### PR TITLE
Update Trilinos to C++14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,13 +78,27 @@ set(ENV{CMAKE_IS_IN_CONFIGURE_MODE} 1)
 
 INCLUDE(${CMAKE_CURRENT_LIST_DIR}/cmake/tribits/TriBITS.cmake)
 
-
 # Make Trilinos create <Package>Config.cmake files by default
 SET(${PROJECT_NAME}_ENABLE_INSTALL_CMAKE_CONFIG_FILES_DEFAULT ON)
 # Make Trilinos set up CPack support by default
 SET(${PROJECT_NAME}_ENABLE_CPACK_PACKAGING_DEFAULT ON)
 # Don't allow disabled subpackages to be excluded from tarball
 SET(${PROJECT_NAME}_EXCLUDE_DISABLED_SUBPACKAGES_FROM_DISTRIBUTION_DEFAULT FALSE)
+
+# Set up C++ language standard selection (rest is handled by TriBITS)
+SET(${PROJECT_NAME}_CMAKE_CXX_STANDARD_DEFAULT 14)
+SET(${PROJECT_NAME}_CMAKE_CXX_STANDARDS_ALLOWED "(14|17|20)")
+ADVANCED_SET(CMAKE_CXX_STANDARD ${${PROJECT_NAME}_CMAKE_CXX_STANDARD_DEFAULT}
+  CACHE STRING
+  "C++ standard number with values ${${PROJECT_NAME}_CMAKE_CXX_STANDARDS_ALLOWED} (default ${${PROJECT_NAME}_CMAKE_CXX_STANDARD_DEFAULT})")
+IF (NOT CMAKE_CXX_STANDARD MATCHES "^${${PROJECT_NAME}_CMAKE_CXX_STANDARDS_ALLOWED}$")
+  MESSAGE(FATAL_ERROR
+    "CMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD} is not in the allowed set "
+    "${${PROJECT_NAME}_CMAKE_CXX_STANDARDS_ALLOWED}")
+ENDIF ()
+# ToDo: We may want to warn about using a non-default version of C++ but
+# really Trilinos should support bulding with every newer C++ standard so we
+# should just be doing that instead.
 
 # Do all of the processing for this Tribits project
 TRIBITS_PROJECT()

--- a/cmake/std/PullRequestLinuxClang10.0.0TestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxClang10.0.0TestingSettings.cmake
@@ -6,8 +6,6 @@
 
 # Usage: cmake -C PullRequestLinuxClang10.0.0TestingSettings.cmake
 
-set (CMAKE_CXX_STANDARD "14" CACHE STRING "Set C++ standard to C++14")
-
 # Misc options typically added by CI testing mode in TriBITS
 
 # Use the below option only when submitting to the dashboard

--- a/cmake/std/PullRequestLinuxClang7.0.1TestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxClang7.0.1TestingSettings.cmake
@@ -6,8 +6,6 @@
 
 # Usage: cmake -C PullRequestLinuxClang7.0.1TestingSettings.cmake
 
-set (CMAKE_CXX_STANDARD "14" CACHE STRING "Set C++ standard to C++14")
-
 # Misc options typically added by CI testing mode in TriBITS
 
 # Use the below option only when submitting to the dashboard

--- a/cmake/std/PullRequestLinuxClang9.0.0TestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxClang9.0.0TestingSettings.cmake
@@ -6,8 +6,6 @@
 
 # Usage: cmake -C PullRequestLinuxClang9.0.0TestingSettings.cmake
 
-set (CMAKE_CXX_STANDARD "14" CACHE STRING "Set C++ standard to C++14")
-
 # Misc options typically added by CI testing mode in TriBITS
 
 # Use the below option only when submitting to the dashboard

--- a/cmake/std/PullRequestLinuxCuda9.2TestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxCuda9.2TestingSettings.cmake
@@ -6,8 +6,6 @@
 
 # Usage: cmake -C PullRequestLinuxCUDA9.2TestingSettings.cmake
 
-set (CMAKE_CXX_STANDARD "14" CACHE STRING "Set C++ standard to C++14")
-
 # Misc options typically added by CI testing mode in TriBITS
 
 # Use the below option only when submitting to the dashboard

--- a/cmake/std/PullRequestLinuxGCC7.2.0DebugTestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxGCC7.2.0DebugTestingSettings.cmake
@@ -6,8 +6,6 @@
 
 # Usage: cmake -C PullRequestLinuxGCC7.2.0DebugTestingSettings.cmake
 
-set (CMAKE_CXX_STANDARD "14" CACHE STRING "Set C++ standard to C++14")
-
 # Misc options typically added by CI testing mode in TriBITS
 
 # Use the below option only when submitting to the dashboard

--- a/cmake/std/PullRequestLinuxGCC7.2.0SerialTestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxGCC7.2.0SerialTestingSettings.cmake
@@ -6,8 +6,6 @@
 
 # Usage: cmake -C PullRequestLinuxGCC7.2.0TestingSettings.cmake
 
-set (CMAKE_CXX_STANDARD "14" CACHE STRING "Set C++ standard to C++14")
-
 # Misc options typically added by CI testing mode in TriBITS
 
 # Use the below option only when submitting to the dashboard

--- a/cmake/std/PullRequestLinuxGCC7.2.0TestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxGCC7.2.0TestingSettings.cmake
@@ -6,8 +6,6 @@
 
 # Usage: cmake -C PullRequestLinuxGCC7.2.0TestingSettings.cmake
 
-set (CMAKE_CXX_STANDARD "14" CACHE STRING "Set C++ standard to C++14")
-
 # Misc options typically added by CI testing mode in TriBITS
 
 # Use the below option only when submitting to the dashboard

--- a/cmake/std/PullRequestLinuxGCC8.3.0TestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxGCC8.3.0TestingSettings.cmake
@@ -6,8 +6,6 @@
 
 # Usage: cmake -C PullRequestLinuxGCC8.3.0TestingSettings.cmake
 
-set (CMAKE_CXX_STANDARD "14" CACHE STRING "Set C++ standard to C++14")
-
 # Misc options typically added by CI testing mode in TriBITS
 
 # Use the below option only when submitting to the dashboard

--- a/cmake/std/PullRequestLinuxIntelTestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxIntelTestingSettings.cmake
@@ -6,7 +6,6 @@
 
 # Usage: cmake -C PullRequestLinuxIntelTestingSettings.cmake
 
-set (CMAKE_CXX_STANDARD "14" CACHE STRING "Set C++ standard to C++14")
 #Failing tests under C++14
 #Remove line if test has been fixed
 set (Piro_AnalysisDriver_MPI_4_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")

--- a/cmake/std/atdm/common/toss3/environment_tlcc2.sh
+++ b/cmake/std/atdm/common/toss3/environment_tlcc2.sh
@@ -47,7 +47,7 @@ if [ "$ATDM_CONFIG_COMPILER" == "INTEL" ]; then
     module load sems-boost/1.66.0/base
 
     module swap mkl/18.0.0.128 mkl/18.0.5.274
-    module load gcc/4.9.3
+    module load cde/compiler/gcc/7.2.0
     module unload sems-python/2.7.9
     export BOOST_ROOT=$SEMS_BOOST_ROOT
     export HDF5_ROOT=$SEMS_HDF5_ROOT

--- a/doc/build_ref/TrilinosBuildReferenceTemplate.rst
+++ b/doc/build_ref/TrilinosBuildReferenceTemplate.rst
@@ -186,6 +186,33 @@ To see more documentation for each of these options, run a configure with
 (as raw text or using the CMake QT GUI or ``ccmake``).
 
 
+Setting the C++ language standard for Trilinos
+----------------------------------------------
+
+Trilinos currently supports building with the C++14 language standard as
+supported by a wide range of C++ compilers.  In addition, the library targets
+imported from the installed ``<Package>Config.cmake`` files (also pulled in
+through ``TrilinosConfig.cmake``) will automatically require downstream CMake
+projects turn on C++14 or later standard support in the compiler options
+(using the CMake ``INTERFACE_COMPILE_FEATURES`` properties of the Trilinos
+library targets).  Building Trilinos with C++11 or lower C++ language
+standards is not supported.
+
+However, to try building Trilinos with a higher C++ language standard (with a
+supporting compiler), set the CMake cache variable ``CMAKE_CXX_STANDARD`` to
+an appropriate value.  For example, to try building Trilinos with C++17 turned
+on, configure with::
+
+  -D CMAKE_CXX_STANDARD:STRING=17
+
+As mentioned above, that will also result in all downstream C++ software built
+CMake to be built with C++17 compiler options turned on as well.
+
+However, Trilinos is currently only rigorously tested with C++14 compiler
+options so trying to build and use with a higher language standard may not
+give satisfactory results.
+
+
 Addressing problems with large builds of Trilinos
 -------------------------------------------------
 
@@ -244,3 +271,5 @@ to do dependency analysis have been reported to determine if a single target
 needs to be rebuilt).  The solution is to switch from the default ``Unix
 Makefiles`` generator to the ``Ninja`` generator (see `Enabling support for
 Ninja`_).
+
+..  LocalWords:  Trilinos

--- a/doc/build_ref/TrilinosBuildReferenceTemplate.rst
+++ b/doc/build_ref/TrilinosBuildReferenceTemplate.rst
@@ -272,4 +272,155 @@ needs to be rebuilt).  The solution is to switch from the default ``Unix
 Makefiles`` generator to the ``Ninja`` generator (see `Enabling support for
 Ninja`_).
 
-..  LocalWords:  Trilinos
+
+Enabling and viewing build statistics
+-------------------------------------
+
+The Trilinos project has portable built-in support for generating and
+reporting build statistics such the high-watermark for RAM, the wall clock
+time, and many other statistics used to build each and every object file,
+library, and executable target.  To enable support for this, configure with::
+
+  -D Trilinos_ENABLE_BUILD_STATS=ON \
+
+This will do the following:
+
+* Generate compiler wrappers ``build_stats_<lang>_wrapper.sh`` for C, C++, and
+  Fortran in the build tree that will compute statics as a byproduct for every
+  usage of each compiler.  (The compiler wrappers create a file
+  ``<output-file>.timing`` for every generated object, library and executable
+  ``<output-file>`` file.)
+
+* Define a build target called ``generate-build-stats`` that when run will
+  gather up all of the generated build statistics into a single CSV file
+  ``build_stats.csv`` in the base build directory.  (This target also runs at
+  the end of the ``ALL`` target so a raw ``make`` will automatically create an
+  up-to-date ``build_stats.csv`` file.)
+
+* Enable the package ``TrilinosBuildStats`` (and when
+  ``-DTrilinos_ENABLE_TESTS=ON`` or ``-DTrilinosBuildStats_ENABLE_TESTS=ON``
+  are also set) will define the test ``TrilinosBuildStats_Results`` to
+  summarize and report the build statistics.  When run, this test calls the
+  tool ``summarize_build_stats.py`` in to report summary build stats to STDOUT
+  the test and will also upload the file ``build_stats.csv`` to CDash as using
+  the CTest property ``ATTACHED_FILES`` when submitting test results to CDash.
+
+* Set up to install the generated build-stats compiler wrappers and a helper
+  script ``gather_build_stats.sh`` into the ``<prefix>/bin`` directory as part
+  of the default ``install`` target.  (This allows customers to also use these
+  compiler wrappers to generate and gather up build stats for their own
+  project as well that depends on Trilinos.)
+
+The default for the cache variable ``Trilinos_ENABLE_BUILD_STATS`` is
+determined as follows:
+
+* If the variable ``Trilinos_ENABLE_BUILD_STATS`` is set in the environment
+  (e.g. with ``export Trilinos_ENABLE_BUILD_STATS=ON``), then it will be used
+  as the default value.
+
+* Else if the CMake variable ``Trilinos_ENABLE_BUILD_STATS_DEFAULT`` is set in
+  a ``*.cmake`` file included using
+  ``-DTrilinos_CONFIGURE_OPTIONS_FILE=<config_file>.cmake``, then it will be
+  used as the default value.
+
+* Else, the default value is set to ``OFF``.
+
+When the test ``TrilinosBuildStats_Results`` is run, it produces summary
+statistics to STDOUT like shown below::
+
+  Full Project: sum(max_resident_size_size_mb) = ??? (??? entries)
+  Full Project: max(max_resident_size_size_mb) = ??? (<file-name>)
+  Full Project: max(elapsed_real_time_sec) = ??? (<file-name>)
+  Full Project: sum(elapsed_real_time_sec) = ??? (??? entries)
+  Full Project: sum(file_size_mb) = ??? (??? entries)
+  Full Project: max(file_size_mb) = ??? (<file-name>)
+
+  <package1>: sum(max_resident_size_mb) = ??? (??? entries)
+  <package1>: max(max_resident_size_mb) = ??? (<file-name>)
+  <package1>: max(elapsed_real_time_sec) = ??? (<file-name>)
+  <package1>: sum(elapsed_real_time_sec) = ??? (??? entries)
+  <package1>: sum(file_size_mb) = ??? (??? entries)
+  <package1>: max(file_size_mb) = ??? (<file-name>)
+
+  ...
+
+  <packagen>: sum(max_resident_size_mb) = ??? (??? entries)
+  <packagen>: max(max_resident_size_mb) = ??? (<file-name>)
+  <packagen>: max(elapsed_real_time_sec) = ??? (<file-name>)
+  <packagen>: sum(elapsed_real_time_sec) = ??? (??? entries)
+  <packagen>: sum(file_size_mb) = ??? (??? entries)
+  <packagen>: max(file_size_mb) = ??? (<file-name>)
+
+where:
+
+* ``max_resident_size_size_mb`` is the high watermark for RAM usage to build a
+  given target measured in MB.
+* ``elapsed_real_time_sec`` is the wall clock time used to build a given
+  target measured in seconds.
+* ``file_size_mb`` is the produced file size of a given build target
+  (i.e. object file, library, or executable) measured in MB.
+* ``Full Project`` are the stats for all of the enabled Trilinos packages.
+* ``<packagei>`` are the build stats for the ``<packagei>`` subdirectory under
+  the base directories ``commonTools`` and ``packages``.  (These map to Trilinos
+  packages is most cases.)
+
+This output format makes it easy to query and view these statistics directly
+on CDash using the "Test Output" filter on the ``cdash/queryTests.php`` page.
+(This allows viewing and comparing these statistics across many different
+compilers, platforms, and build configurations and even across the same builds
+over days, weeks, and months.)
+
+The generated ``build_stats.csv`` file contains many other types of useful
+build stats as well but the above three are some of the more impact-full build
+statistics.
+
+To avoid situations where a full rebuild does not occur (e.g. any build target
+fails) and an old obsolete ``build_stats.csv`` file is hanging around, one can
+cause that file to get deleted on every (re)configure by setting::
+
+  -D Trilinos_REMOVE_BUILD_STATS_ON_CONFIGURE=ON
+
+This will remove the file ``build_stats.csv`` very early in the configure
+process and therefore will usually remove the file even of later configure
+operations fail.
+
+Finally, to make rebuilds more robust and to restrict build stats to only new
+targets getting (re)built after an initial configure, configure with::
+
+  -D Trilinos_REMOVE_BUILD_STATS_TIMING_FILES_ON_FRESH_CONFIGURE=ON
+
+The will remove **all** of the ``*.timing`` files under the base build
+directory during a fresh configure (i.e. where the ``CMakeCache.txt`` file
+does not exist).  But this will not remove ``*.timing`` files on reconfigures
+(i..e where a ``CMakeCache.txt`` file is preserved).  Timing stats for targets
+that are already built and don't need to be rebuilt after the last fresh
+configure will not get reported.  (But this can be useful for CI builds where
+one only wants to see build stats for the files updated in the last PR
+iteration.  Also, this will avoid problems with corrupted `<target>.timing`
+files that may already exist in the base repo.)
+
+NOTES:
+
+* The installed ``TrilinosConfig.cmake`` and ``<Package>Config.cmake`` files
+  list the original underlying C, C++, and Fortran compilers, **not** the
+  build stats compiler wrappers.
+
+* If a customer wants to use the build stats compiler wrappers, then they can
+  just directly set ``CMAKE_<LANG>_COMPILER`` to the path of the installed
+  compiler wrappers ``<prefix>/bin/build_stats_<lang>_wrapper.sh`` for each
+  language ``<lang>`` = C, CXX, and Fortran and also add
+  ``set(ENV{CMAKE_IS_IN_CONFIGURE_MODE} 1)`` to the beginning of their
+  project's top-level ``CMakeLists.txt`` file.
+
+* The ``generate-build-stats`` target has dependencies on every object,
+  library, and executable build target in the project so it will always only
+  run after all of those targets are up to date.
+
+* The file ``build_stats.csv`` can be downloaded off of CDash from the
+  ``TrilinosBuildStats_Results`` test results summary page.  (The file is
+  downloaded as a compressed ``build_stats.csv.tgz`` file which will then need
+  to be uncompressed using ``tar -xzvf build_stats.csv.tgz`` before being
+  viewed.)
+
+* Any ``build_stats.csv`` file can be viewed and queried by uploading it to
+  the site ``https://jjellio.github.io/build_stats/index.html``.


### PR DESCRIPTION
This updates Trilinos to require C++14 by default.   See updated documentation for details.

Closes #6260.

## How was this tested?

I tested this locally manually with several different use cases:

* Default configure (don't set `CMAKE_CXX_STANDARD`) => Produces `CMAKE_CXX_STANDARD:STRING=14` in the `CMakeCache.txt` file and produces the compiler flag `-std=c++14` with GCC 7.2.0.
* Set `-D CMAKE_CXX_STANDARD=11` => Errors out right away with the error message `CMAKE_CXX_STANDARD=11 is not in the allowed set (14|17|20)`
* Set `-D CMAKE_CXX_STANDARD=14` => Configures the same as default configure
* Set `-D CMAKE_CXX_STANDARD=17` => Results in compiler flag `-std=c++1z` with GCC 7.2.0 (which is the same thing as  `-std=c++17` according to GCC documentation).

## Checklist

* [X] Merge this branch to the 'atdm-nighlty-manual-updates' branch and push to get this tested with the ATDM Trilinos builds.
* [X] Revert the merge of the merge commit to the 'atdm-nighlty-manual-updates' branch and push.
* [ ] Reproduce and fix the build failures in the 'tlcc2' and 'ats2' builds shown [below](https://github.com/trilinos/Trilinos/pull/8317#issuecomment-723138268).
* [ ] Revert the revert commit e2ebb2f9addd969af3cfe2823776d66efa4da169 on the 'atdm-nightly-manual-updates' branch to get this tested again in the ATDM Trilinos builds.
* [ ] After getting back passing results from the ATDM Trilinos builds (except for perhaps a few new test failures), merge this branch to the 'develop' branch.
* [ ] Create new ATDM Trilinos GitHub issues for any new failures caused by this change. 