### PR TITLE
MueLu: regionMG remove multiple regions per proc std::vector

### DIFF
--- a/packages/muelu/research/regionMG/src/SetupRegionHierarchy_def.hpp
+++ b/packages/muelu/research/regionMG/src/SetupRegionHierarchy_def.hpp
@@ -117,7 +117,6 @@ void createContinuousCoarseLevelMaps(const RCP<const Xpetra::Map<LocalOrdinal, G
 } // createContinuousCoarseLevelMaps
 
 
-
 /* Reconstruct coarse-level maps (assuming fully structured grids)
  *
  * We know the regional map on the coarse levels since they are just the
@@ -135,13 +134,13 @@ void createContinuousCoarseLevelMaps(const RCP<const Xpetra::Map<LocalOrdinal, G
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void MakeCoarseLevelMaps(const int maxRegPerGID,
                          Teuchos::ArrayView<LocalOrdinal>  compositeToRegionLIDsFinest,
-                         Array<std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > >& regProlong,
-                         Array<std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > >& regRowMaps,
-                         Array<std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > >& regColMaps,
-                         Array<std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > >& quasiRegRowMaps,
-                         Array<std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > >& quasiRegColMaps,
+                         Array<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regProlong,
+                         Array<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& regRowMaps,
+                         Array<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& regColMaps,
+                         Array<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& quasiRegRowMaps,
+                         Array<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& quasiRegColMaps,
                          Array<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& compRowMaps,
-                         Array<std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > >& regRowImporters,
+                         Array<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > >& regRowImporters,
                          Array<Teuchos::RCP<Xpetra::MultiVector<GlobalOrdinal, LocalOrdinal, GlobalOrdinal, Node> > >& interfaceGIDs,
                          Array<Teuchos::RCP<Xpetra::MultiVector<LocalOrdinal, LocalOrdinal, GlobalOrdinal, Node> > >& regionsPerGIDWithGhosts,
                          Array<Teuchos::ArrayRCP<LocalOrdinal> >& regionMatVecLIDs,
@@ -156,18 +155,18 @@ void MakeCoarseLevelMaps(const int maxRegPerGID,
 
   // RCP<Teuchos::FancyOStream> fancy = Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
   // Teuchos::FancyOStream& out = *fancy;
-  const int myRank = regProlong[1][0]->getRowMap()->getComm()->getRank();
+  const int myRank = regProlong[1]->getRowMap()->getComm()->getRank();
 
   Teuchos::Array<LO> coarseCompositeToRegionLIDs;
   Teuchos::ArrayView<LO> compositeToRegionLIDs = compositeToRegionLIDsFinest;
   for(int currentLevel = 1; currentLevel < numLevels; ++currentLevel) {
 
     // Extracting some basic information about local mesh in composite/region format
-    const size_t numFineRegionNodes    = regProlong[currentLevel][0]->getNodeNumRows();
+    const size_t numFineRegionNodes    = regProlong[currentLevel]->getNodeNumRows();
     const size_t numFineCompositeNodes = compositeToRegionLIDs.size();
     const size_t numFineDuplicateNodes = numFineRegionNodes - numFineCompositeNodes;
 
-    const size_t numCoarseRegionNodes  = regProlong[currentLevel][0]->getColMap()->getNodeNumElements();
+    const size_t numCoarseRegionNodes  = regProlong[currentLevel]->getColMap()->getNodeNumElements();
 
     // Find the regionLIDs associated with local duplicated nodes
     // This will allow us to later loop only on duplicated nodes
@@ -184,17 +183,17 @@ void MakeCoarseLevelMaps(const int maxRegPerGID,
 
     // We gather the coarse GIDs associated with each fine point in the local composite mesh part.
     RCP<Xpetra::Vector<MT,LO,GO,NO> > coarseCompositeGIDs
-      = Xpetra::VectorFactory<MT,LO,GO,NO>::Build(regRowImporters[currentLevel - 1][0]->getSourceMap(), false);
+      = Xpetra::VectorFactory<MT,LO,GO,NO>::Build(regRowImporters[currentLevel - 1]->getSourceMap(), false);
     Teuchos::ArrayRCP<MT> coarseCompositeGIDsData = coarseCompositeGIDs->getDataNonConst(0);
 
     for(size_t compositeNodeIdx = 0; compositeNodeIdx < numFineCompositeNodes; ++compositeNodeIdx) {
       ArrayView<const LO> coarseRegionLID; // Should contain a single value
       ArrayView<const SC> dummyData; // Should contain a single value
-      regProlong[currentLevel][0]->getLocalRowView(compositeToRegionLIDs[compositeNodeIdx],
+      regProlong[currentLevel]->getLocalRowView(compositeToRegionLIDs[compositeNodeIdx],
                                                    coarseRegionLID,
                                                    dummyData);
       if(coarseRegionLID.size() == 1) {
-        coarseCompositeGIDsData[compositeNodeIdx] = regProlong[currentLevel][0]->getColMap()->getGlobalElement(coarseRegionLID[0]);
+        coarseCompositeGIDsData[compositeNodeIdx] = regProlong[currentLevel]->getColMap()->getGlobalElement(coarseRegionLID[0]);
       } else {
         coarseCompositeGIDsData[compositeNodeIdx] = -1;
       }
@@ -202,8 +201,8 @@ void MakeCoarseLevelMaps(const int maxRegPerGID,
 
     // We communicate the above GIDs to their duplicate so that we can replace GIDs of the region
     // column map and form the quasiRegion column map.
-    Array<RCP<Xpetra::Vector<MT, LO, GO, NO> > > coarseQuasiregionGIDs(1);
-    Array<RCP<Xpetra::Vector<MT, LO, GO, NO> > > coarseRegionGIDs(1);
+    RCP<Xpetra::Vector<MT, LO, GO, NO> > coarseQuasiregionGIDs;
+    RCP<Xpetra::Vector<MT, LO, GO, NO> > coarseRegionGIDs;
     compositeToRegional(coarseCompositeGIDs,
                         coarseQuasiregionGIDs,
                         coarseRegionGIDs,
@@ -211,11 +210,11 @@ void MakeCoarseLevelMaps(const int maxRegPerGID,
                         regRowImporters[currentLevel - 1]);
 
     regionsPerGIDWithGhosts[currentLevel] =
-      Xpetra::MultiVectorFactory<LO, LO, GO, NO>::Build(regRowMaps[currentLevel][0],
+      Xpetra::MultiVectorFactory<LO, LO, GO, NO>::Build(regRowMaps[currentLevel],
                                                         maxRegPerGID,
                                                         false);
     interfaceGIDs[currentLevel] =
-      Xpetra::MultiVectorFactory<GO, LO, GO, NO>::Build(regRowMaps[currentLevel][0],
+      Xpetra::MultiVectorFactory<GO, LO, GO, NO>::Build(regRowMaps[currentLevel],
                                                         maxRegPerGID,
                                                         false);
     Array<ArrayRCP<const LO> > regionsPerGIDWithGhostsFine(maxRegPerGID);
@@ -235,7 +234,7 @@ void MakeCoarseLevelMaps(const int maxRegPerGID,
     for(size_t fineIdx = 0; fineIdx < numFineRegionNodes; ++fineIdx) {
       ArrayView<const LO> coarseRegionLID; // Should contain a single value
       ArrayView<const SC> dummyData;       // Should contain a single value
-      regProlong[currentLevel][0]->getLocalRowView(fineIdx,
+      regProlong[currentLevel]->getLocalRowView(fineIdx,
                                                    coarseRegionLID,
                                                    dummyData);
       const LO coarseIdx = coarseRegionLID[0];
@@ -260,7 +259,7 @@ void MakeCoarseLevelMaps(const int maxRegPerGID,
         for(LO idx = 0; idx < countFinePIDs; ++idx) {
           regionsPerGIDWithGhostsCoarse[idx][coarseIdx] = regionsPerGIDWithGhostsFine[idx][fineIdx];
           if(regionsPerGIDWithGhostsCoarse[idx][coarseIdx] == myRank) {
-            interfaceGIDsCoarse[idx][coarseIdx] = regRowMaps[currentLevel][0]->getGlobalElement(coarseIdx);
+            interfaceGIDsCoarse[idx][coarseIdx] = regRowMaps[currentLevel]->getGlobalElement(coarseIdx);
           }
         }
       }
@@ -271,17 +270,17 @@ void MakeCoarseLevelMaps(const int maxRegPerGID,
     for(size_t duplicateIdx = 0; duplicateIdx < numFineDuplicateNodes; ++duplicateIdx) {
       ArrayView<const LO> coarseRegionLID; // Should contain a single value
       ArrayView<const SC> dummyData; // Should contain a single value
-      regProlong[currentLevel][0]->getLocalRowView(fineDuplicateLIDs[duplicateIdx],
+      regProlong[currentLevel]->getLocalRowView(fineDuplicateLIDs[duplicateIdx],
                                                    coarseRegionLID,
                                                    dummyData);
-      fineRegionDuplicateCoarseLIDs[duplicateIdx] = regProlong[currentLevel][0]->getColMap()->getGlobalElement(coarseRegionLID[0]);
-      fineRegionDuplicateCoarseGIDs[duplicateIdx] = (coarseQuasiregionGIDs[0]->getDataNonConst(0))[fineDuplicateLIDs[duplicateIdx]];
+      fineRegionDuplicateCoarseLIDs[duplicateIdx] = regProlong[currentLevel]->getColMap()->getGlobalElement(coarseRegionLID[0]);
+      fineRegionDuplicateCoarseGIDs[duplicateIdx] = (coarseQuasiregionGIDs->getDataNonConst(0))[fineDuplicateLIDs[duplicateIdx]];
     }
 
     // Create the coarseQuasiregRowMap, it will be based on the coarseRegRowMap
     LO countCoarseComposites = 0;
     coarseCompositeToRegionLIDs.resize(numCoarseRegionNodes);
-    Array<GO> coarseQuasiregRowMapData = regProlong[currentLevel][0]->getColMap()->getNodeElementList();
+    Array<GO> coarseQuasiregRowMapData = regProlong[currentLevel]->getColMap()->getNodeElementList();
     Array<GO> coarseCompRowMapData(numCoarseRegionNodes, -1);
     for(size_t regionIdx = 0; regionIdx < numCoarseRegionNodes; ++regionIdx) {
       const GO initialValue = coarseQuasiregRowMapData[regionIdx];
@@ -302,20 +301,20 @@ void MakeCoarseLevelMaps(const int maxRegPerGID,
     coarseCompositeToRegionLIDs.resize(countCoarseComposites);
 
     // We are now ready to fill up the outputs
-    regRowMaps[currentLevel][0] = Teuchos::rcp_const_cast<Map>(regProlong[currentLevel][0]->getColMap());
-    regColMaps[currentLevel][0] = Teuchos::rcp_const_cast<Map>(regProlong[currentLevel][0]->getColMap());
-    quasiRegRowMaps[currentLevel][0] = MapFactory::Build(regProlong[currentLevel][0]->getColMap()->lib(),
+    regRowMaps[currentLevel] = Teuchos::rcp_const_cast<Map>(regProlong[currentLevel]->getColMap());
+    regColMaps[currentLevel] = Teuchos::rcp_const_cast<Map>(regProlong[currentLevel]->getColMap());
+    quasiRegRowMaps[currentLevel] = MapFactory::Build(regProlong[currentLevel]->getColMap()->lib(),
                                                          GO_INV,
                                                          coarseQuasiregRowMapData(),
-                                                         regProlong[currentLevel][0]->getColMap()->getIndexBase(),
-                                                         regProlong[currentLevel][0]->getColMap()->getComm());
-    quasiRegColMaps[currentLevel][0] = quasiRegRowMaps[currentLevel][0];
-    compRowMaps[currentLevel] = MapFactory::Build(regProlong[currentLevel][0]->getColMap()->lib(),
+                                                         regProlong[currentLevel]->getColMap()->getIndexBase(),
+                                                         regProlong[currentLevel]->getColMap()->getComm());
+    quasiRegColMaps[currentLevel] = quasiRegRowMaps[currentLevel];
+    compRowMaps[currentLevel] = MapFactory::Build(regProlong[currentLevel]->getColMap()->lib(),
                                                   GO_INV,
                                                   coarseCompRowMapData(),
-                                                  regProlong[currentLevel][0]->getColMap()->getIndexBase(),
-                                                  regProlong[currentLevel][0]->getColMap()->getComm());
-    regRowImporters[currentLevel][0] = ImportFactory::Build(compRowMaps[currentLevel], quasiRegRowMaps[currentLevel][0]);
+                                                  regProlong[currentLevel]->getColMap()->getIndexBase(),
+                                                  regProlong[currentLevel]->getColMap()->getComm());
+    regRowImporters[currentLevel] = ImportFactory::Build(compRowMaps[currentLevel], quasiRegRowMaps[currentLevel]);
 
     // Now generate matvec data
     SetupMatVec(interfaceGIDs[currentLevel], regionsPerGIDWithGhosts[currentLevel],
@@ -330,13 +329,12 @@ void MakeCoarseLevelMaps(const int maxRegPerGID,
 
 // Form the composite coarse level operator
 template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-void MakeCoarseCompositeOperator(const int maxRegPerProc,
-                                 RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> >& compRowMap,
-                                 std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& quasiRegRowMap,
-                                 std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& quasiRegColMap,
-                                 std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > >& regRowImporter,
-                                 std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regMatrix,
-                                 Array<RCP<Xpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::coordinateType, LocalOrdinal, GlobalOrdinal, Node> > >& regCoarseCoordinates,
+void MakeCoarseCompositeOperator(RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> >& compRowMap,
+                                 RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> >& quasiRegRowMap,
+                                 RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> >& quasiRegColMap,
+                                 RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> >& regRowImporter,
+                                 RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> >& regMatrix,
+                                 RCP<Xpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::coordinateType, LocalOrdinal, GlobalOrdinal, Node> >& regCoarseCoordinates,
                                  RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> >& coarseCompOp,
                                  RCP<Xpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::coordinateType, LocalOrdinal, GlobalOrdinal, Node> >& compCoarseCoordinates,
                                  const bool makeCompCoords)
@@ -345,31 +343,26 @@ void MakeCoarseCompositeOperator(const int maxRegPerProc,
   using CoordType = typename Teuchos::ScalarTraits<Scalar>::coordinateType;
   coarseCompOp = MatrixFactory::Build(compRowMap,
                                        // This estimate is very conservative and probably costs us lots of memory...
-                                      8*regMatrix[0]->getCrsGraph()->getNodeMaxNumRowEntries());
+                                      8*regMatrix->getCrsGraph()->getNodeMaxNumRowEntries());
   regionalToComposite(regMatrix,
                       quasiRegRowMap, quasiRegColMap,
                       regRowImporter, Xpetra::ADD,
                       coarseCompOp);
 
-  const int dofsPerNode = regMatrix[0]->GetFixedBlockSize();
+  const int dofsPerNode = regMatrix->GetFixedBlockSize();
   coarseCompOp->SetFixedBlockSize(dofsPerNode);
   coarseCompOp->setObjectLabel("coarse composite operator");
 
   // Create coarse composite coordinates for repartitioning
   if(makeCompCoords) {
-    for(int regIdx = 0; regIdx < maxRegPerProc; ++regIdx) {
-      const int check       = regMatrix[regIdx]->getRowMap()->getNodeNumElements()
-        % regCoarseCoordinates[regIdx]->getMap()->getNodeNumElements();
-      TEUCHOS_ASSERT(check == 0);
-    }
+    const int check       = regMatrix->getRowMap()->getNodeNumElements() % regCoarseCoordinates->getMap()->getNodeNumElements();
+    TEUCHOS_ASSERT(check == 0);
 
     RCP<Map> compCoordMap;
-    std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > regCoordImporter(maxRegPerProc);
+    RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > regCoordImporter;
     if(dofsPerNode == 1) {
       compCoordMap = compRowMap;
-      for(int regionIdx = 0; regionIdx < maxRegPerProc; ++regionIdx) {
-        regCoordImporter[regionIdx] = regRowImporter[regionIdx];
-      }
+      regCoordImporter = regRowImporter;
     } else {
       using size_type = typename Teuchos::Array<GlobalOrdinal>::size_type;
       Array<GlobalOrdinal> compCoordMapData(compRowMap->getNodeNumElements() / dofsPerNode);
@@ -383,37 +376,32 @@ void MakeCoarseCompositeOperator(const int maxRegPerProc,
                                        compRowMap->getIndexBase(),
                                        compRowMap->getComm());
 
-      std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > quasiRegCoordMap(maxRegPerProc);
-      for(int regionIdx = 0; regionIdx < maxRegPerProc; ++regionIdx) {
-        Array<GlobalOrdinal> quasiRegCoordMapData(quasiRegRowMap[regionIdx]->getNodeNumElements() / dofsPerNode);
-        ArrayView<const GlobalOrdinal> quasiRegRowMapData = quasiRegRowMap[regionIdx]->getNodeElementList();
+      RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > quasiRegCoordMap;
+        Array<GlobalOrdinal> quasiRegCoordMapData(quasiRegRowMap->getNodeNumElements() / dofsPerNode);
+        ArrayView<const GlobalOrdinal> quasiRegRowMapData = quasiRegRowMap->getNodeElementList();
         for(size_type nodeIdx = 0; nodeIdx < quasiRegCoordMapData.size(); ++nodeIdx) {
           quasiRegCoordMapData[nodeIdx] = quasiRegRowMapData[nodeIdx*dofsPerNode] / dofsPerNode;
         }
-        quasiRegCoordMap[regionIdx] = MapFactory::Build(quasiRegRowMap[regionIdx]->lib(),
-                                                        quasiRegRowMap[regionIdx]->getGlobalNumElements() / dofsPerNode,
-                                                        quasiRegCoordMapData(),
-                                                        quasiRegRowMap[regionIdx]->getIndexBase(),
-                                                        quasiRegRowMap[regionIdx]->getComm());
-        regCoordImporter[regionIdx] = ImportFactory::Build(compCoordMap, quasiRegCoordMap[regionIdx]);
-      }
+        quasiRegCoordMap = MapFactory::Build(quasiRegRowMap->lib(),
+                                             quasiRegRowMap->getGlobalNumElements() / dofsPerNode,
+                                             quasiRegCoordMapData(),
+                                             quasiRegRowMap->getIndexBase(),
+                                             quasiRegRowMap->getComm());
+        regCoordImporter = ImportFactory::Build(compCoordMap, quasiRegCoordMap);
     }
     compCoarseCoordinates = Xpetra::MultiVectorFactory<CoordType, LocalOrdinal, GlobalOrdinal, Node>
-      ::Build(compCoordMap, regCoarseCoordinates[0]->getNumVectors());
+      ::Build(compCoordMap, regCoarseCoordinates->getNumVectors());
     TEUCHOS_ASSERT(Teuchos::nonnull(compCoarseCoordinates));
 
     // The following looks like regionalToComposite for Vector
     // but it is a bit different since we do not want to add
     // entries in the coordinate MultiVector as we would for
     // a solution or residual vector.
-    RCP<Xpetra::MultiVector<CoordType, LocalOrdinal, GlobalOrdinal, Node>>
-      quasiRegCoarseCoordinates;
-    for(int grpIdx = 0; grpIdx < maxRegPerProc; ++grpIdx) {
-      quasiRegCoarseCoordinates = regCoarseCoordinates[grpIdx];
-      TEUCHOS_ASSERT(Teuchos::nonnull(quasiRegCoarseCoordinates));
-      quasiRegCoarseCoordinates->replaceMap(regCoordImporter[grpIdx]->getTargetMap());
-      compCoarseCoordinates->doExport(*quasiRegCoarseCoordinates, *(regCoordImporter[grpIdx]), Xpetra::INSERT);
-    }
+    RCP<Xpetra::MultiVector<CoordType, LocalOrdinal, GlobalOrdinal, Node>> quasiRegCoarseCoordinates;
+    quasiRegCoarseCoordinates = regCoarseCoordinates;
+    TEUCHOS_ASSERT(Teuchos::nonnull(quasiRegCoarseCoordinates));
+    quasiRegCoarseCoordinates->replaceMap(regCoordImporter->getTargetMap());
+    compCoarseCoordinates->doExport(*quasiRegCoarseCoordinates, *(regCoordImporter), Xpetra::INSERT);
   }
 } // MakeCoarseCompositeOperator
 
@@ -466,8 +454,7 @@ MakeCompositeDirectSolver(RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal
  */
 #if defined(HAVE_MUELU_ZOLTAN2) && defined(HAVE_MPI)
 template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-void RebalanceCoarseCompositeOperator(const int maxRegPerProc,
-              const int rebalanceNumPartitions,
+void RebalanceCoarseCompositeOperator(const int rebalanceNumPartitions,
               RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> >& coarseCompOp,
               RCP<Xpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::coordinateType, LocalOrdinal, GlobalOrdinal, Node> >& compCoarseCoordinates,
               RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> >& rebalancedCompOp,
@@ -478,7 +465,7 @@ void RebalanceCoarseCompositeOperator(const int maxRegPerProc,
   using CoordType = typename Teuchos::ScalarTraits<Scalar>::coordinateType;
   using Teuchos::TimeMonitor;
 
-  RCP<TimeMonitor> tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("ReblanceCoarseCompositeOperator: ")));
+  RCP<TimeMonitor> tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("RebalanceCoarseCompositeOperator: ")));
 
   RCP<Teuchos::FancyOStream> fos = Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
   fos->setOutputToRootOnly(0);
@@ -696,15 +683,15 @@ MakeCompositeAMGHierarchy(RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal
   return compOpHiearchy;
 } // MakeCompositeAMGHierarchy
 
+
   // Make interface scaling factors recursively
 template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-void MakeInterfaceScalingFactors(const int maxRegPerProc,
-                                 const int numLevels,
+void MakeInterfaceScalingFactors(const int numLevels,
                                  Array<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& compRowMaps,
-                                 Array<Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > >& regInterfaceScalings,
-                                 Array<std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > >& regRowMaps,
-                                 Array<std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > >& regRowImporters,
-                                 Array<std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > >& quasiRegRowMaps)
+                                 Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regInterfaceScalings,
+                                 Array<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& regRowMaps,
+                                 Array<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > >& regRowImporters,
+                                 Array<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& quasiRegRowMaps)
 {
 #include "Xpetra_UseShortNames.hpp"
   // std::cout << compRowMaps[0]->getComm()->getRank() << " | Computing interface scaling factors ..." << std::endl;
@@ -715,10 +702,8 @@ void MakeInterfaceScalingFactors(const int maxRegPerProc,
 
   for (int l = 0; l < numLevels; l++) {
     // initialize region vector with all ones.
-    for (int j = 0; j < maxRegPerProc; j++) {
-      regInterfaceScalings[l][j] = VectorFactory::Build(regRowMaps[l][j]);
-      regInterfaceScalings[l][j]->putScalar(SC_ONE);
-    }
+    regInterfaceScalings[l] = VectorFactory::Build(regRowMaps[l]);
+    regInterfaceScalings[l]->putScalar(SC_ONE);
 
     // transform to composite layout while adding interface values via the Export() combine mode
     RCP<Vector> compInterfaceScalingSum = VectorFactory::Build(compRowMaps[l], true);
@@ -727,7 +712,7 @@ void MakeInterfaceScalingFactors(const int maxRegPerProc,
     /* transform composite layout back to regional layout. Now, GIDs associated
      * with region interface should carry a scaling factor (!= 1).
      */
-    Array<RCP<Vector> > quasiRegInterfaceScaling(maxRegPerProc); // Is that vector really needed?
+    RCP<Vector> quasiRegInterfaceScaling; // Is that vector really needed?
     compositeToRegional(compInterfaceScalingSum, quasiRegInterfaceScaling,
                         regInterfaceScalings[l],
                         regRowMaps[l], regRowImporters[l]);
@@ -736,31 +721,30 @@ void MakeInterfaceScalingFactors(const int maxRegPerProc,
 
 
 template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-void createRegionHierarchy(const int maxRegPerProc,
-                           const int numDimensions,
-                           const Array<Array<int> > lNodesPerDim,
-                           const Array<std::string> aggregationRegionType,
+void createRegionHierarchy(const int numDimensions,
+                           const Array<int> lNodesPerDim,
+                           const std::string aggregationRegionType,
                            RCP<Teuchos::ParameterList>& interfaceParams,
                            const std::string xmlFileName,
-                           Array<RCP<Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& nullspace,
-                           Array<RCP<Xpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::coordinateType, LocalOrdinal, GlobalOrdinal, Node> > >& coordinates,
-                           std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regionGrpMats,
+                           RCP<Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> >& nullspace,
+                           RCP<Xpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::coordinateType, LocalOrdinal, GlobalOrdinal, Node> >& coordinates,
+                           RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> >& regionGrpMats,
                            const RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > mapComp,
-                           const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > rowMapPerGrp,
-                           const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > colMapPerGrp,
-                           const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > revisedRowMapPerGrp,
-                           const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > revisedColMapPerGrp,
-                           const std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > rowImportPerGrp,
+                           const RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > rowMapPerGrp,
+                           const RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > colMapPerGrp,
+                           const RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > revisedRowMapPerGrp,
+                           const RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > revisedColMapPerGrp,
+                           const RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > rowImportPerGrp,
                            Array<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& compRowMaps,
                            Array<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& compColMaps,
-                           Array<std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > >& regRowMaps,
-                           Array<std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > >& regColMaps,
-                           Array<std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > >& quasiRegRowMaps,
-                           Array<std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > >& quasiRegColMaps,
-                           Array<std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > >& regMatrices,
-                           Array<std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > >& regProlong,
-                           Array<std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > >& regRowImporters,
-                           Array<Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > >& regInterfaceScalings,
+                           Array<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& regRowMaps,
+                           Array<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& regColMaps,
+                           Array<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& quasiRegRowMaps,
+                           Array<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& quasiRegColMaps,
+                           Array<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regMatrices,
+                           Array<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regProlong,
+                           Array<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > >& regRowImporters,
+                           Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regInterfaceScalings,
                            Array<Teuchos::RCP<Xpetra::MultiVector<GlobalOrdinal, LocalOrdinal, GlobalOrdinal, Node> > >& interfaceGIDs,
                            Array<Teuchos::RCP<Xpetra::MultiVector<LocalOrdinal, LocalOrdinal, GlobalOrdinal, Node> > >& regionsPerGIDWithGhosts,
                            Array<Teuchos::ArrayRCP<LocalOrdinal> >& regionMatVecLIDs,
@@ -785,41 +769,39 @@ void createRegionHierarchy(const int maxRegPerProc,
   int numLevels = 0;
 
   // A hierarchy for each group
-  std::vector<RCP<Hierarchy> > regGrpHierarchy(maxRegPerProc);
+  RCP<Hierarchy> regGrpHierarchy;
 
   RCP<TimeMonitor> tmLocal = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("createRegionHierarchy: GrpHierarchy")));
-  for (int j = 0; j < maxRegPerProc; j++) {
 
-    /* Set number of nodes per processor per dimension
-     *
-     * We don't use the number of owned nodes provided on input.
-     * Use the region dimensions instead. This is the right thing to do
-     * since duplication of interface nodes has added duplicated nodes to those regions
-     * where inpData_ownedX/inpData_ownedY and inpData_regionX/inpData_regionY have been different on input.
-     */
+  /* Set number of nodes per processor per dimension
+   *
+   * We don't use the number of owned nodes provided on input.
+   * Use the region dimensions instead. This is the right thing to do
+   * since duplication of interface nodes has added duplicated nodes to those regions
+   * where inpData_ownedX/inpData_ownedY and inpData_regionX/inpData_regionY have been different on input.
+   */
 
-    // Read MueLu parameter list form xml file
-    RCP<ParameterList> mueluParams = Teuchos::rcp(new ParameterList());
-    Teuchos::updateParametersFromXmlFileAndBroadcast(xmlFileName, mueluParams.ptr(), *mapComp->getComm());
+  // Read MueLu parameter list form xml file
+  RCP<ParameterList> mueluParams = Teuchos::rcp(new ParameterList());
+  Teuchos::updateParametersFromXmlFileAndBroadcast(xmlFileName, mueluParams.ptr(), *mapComp->getComm());
 
-    // Insert region-specific data into parameter list
-    const std::string userName = "user data";
-    Teuchos::ParameterList& userParamList = mueluParams->sublist(userName);
-    userParamList.set<int>        ("int numDimensions", numDimensions);
-    userParamList.set<Array<LO> > ("Array<LO> lNodesPerDim", lNodesPerDim[j]);
-    userParamList.set<std::string>("string aggregationRegionType", aggregationRegionType[j]);
-    userParamList.set<Array<LO> > ("Array<LO> nodeOnInterface", interfaceParams->get<Array<LO> >("interfaces: interface nodes"));
-    userParamList.set<Array<LO> > ("Array<LO> interfacesDimensions", interfaceParams->get<Array<LO> >("interfaces: nodes per dimensions"));
-    if(Teuchos::nonnull(coordinates[j])) {
-      userParamList.set("Coordinates", coordinates[j]);
-    }
-    if(Teuchos::nonnull(nullspace[j])) {
-      userParamList.set("Nullspace", nullspace[j]);
-    }
-
-    // Setup hierarchy
-    regGrpHierarchy[j] = MueLu::CreateXpetraPreconditioner(regionGrpMats[j], *mueluParams);
+  // Insert region-specific data into parameter list
+  const std::string userName = "user data";
+  Teuchos::ParameterList& userParamList = mueluParams->sublist(userName);
+  userParamList.set<int>        ("int numDimensions", numDimensions);
+  userParamList.set<Array<LO> > ("Array<LO> lNodesPerDim", lNodesPerDim);
+  userParamList.set<std::string>("string aggregationRegionType", aggregationRegionType);
+  userParamList.set<Array<LO> > ("Array<LO> nodeOnInterface", interfaceParams->get<Array<LO> >("interfaces: interface nodes"));
+  userParamList.set<Array<LO> > ("Array<LO> interfacesDimensions", interfaceParams->get<Array<LO> >("interfaces: nodes per dimensions"));
+  if(Teuchos::nonnull(coordinates)) {
+    userParamList.set("Coordinates", coordinates);
   }
+  if(Teuchos::nonnull(nullspace)) {
+    userParamList.set("Nullspace", nullspace);
+  }
+
+  // Setup hierarchy
+  regGrpHierarchy = MueLu::CreateXpetraPreconditioner(regionGrpMats, *mueluParams);
 
   // std::cout << mapComp->getComm()->getRank() << " | Resize containers..." << std::endl;
 
@@ -828,7 +810,7 @@ void createRegionHierarchy(const int maxRegPerProc,
   // resize Arrays and vectors
   {
     // resize level containers
-    numLevels = regGrpHierarchy[0]->GetNumLevels();
+    numLevels = regGrpHierarchy->GetNumLevels();
     compRowMaps.resize(numLevels);
     compColMaps.resize(numLevels);
     regRowMaps.resize(numLevels);
@@ -847,15 +829,6 @@ void createRegionHierarchy(const int maxRegPerProc,
 
     // resize group containers on each level
     for (int l = 0; l < numLevels; ++l) {
-      regRowMaps[l].resize(maxRegPerProc);
-      regColMaps[l].resize(maxRegPerProc);
-      quasiRegRowMaps[l].resize(maxRegPerProc);
-      quasiRegColMaps[l].resize(maxRegPerProc);
-      regMatrices[l].resize(maxRegPerProc);
-      regProlong[l].resize(maxRegPerProc);
-      regRowImporters[l].resize(maxRegPerProc);
-      regInterfaceScalings[l].resize(maxRegPerProc);
-
       // Also doing some initialization in the smootherParams
       if(l > 0) {smootherParams[l] = rcp(new Teuchos::ParameterList(*smootherParams[0]));}
     }
@@ -868,8 +841,8 @@ void createRegionHierarchy(const int maxRegPerProc,
     compRowMaps[0]     = mapComp;
     quasiRegRowMaps[0] = rowMapPerGrp;
     quasiRegColMaps[0] = colMapPerGrp;
-    regRowMaps[0][0]   = revisedRowMapPerGrp[0];
-    regColMaps[0][0]   = revisedColMapPerGrp[0];
+    regRowMaps[0]      = revisedRowMapPerGrp;
+    regColMaps[0]      = revisedColMapPerGrp;
     regRowImporters[0] = rowImportPerGrp;
     regMatrices[0]     = regionGrpMats;
 
@@ -877,9 +850,8 @@ void createRegionHierarchy(const int maxRegPerProc,
      * on the fine level. To have level containers of the same size, let's
      * just put in dummy data
      */
-    std::vector<RCP<Matrix> > fineLevelProlong(maxRegPerProc);
-    for (int j = 0; j < maxRegPerProc; ++j)
-      fineLevelProlong[j] = Teuchos::null;
+    RCP<Matrix> fineLevelProlong;
+    fineLevelProlong = Teuchos::null;
     regProlong[0] = fineLevelProlong;
   }
 
@@ -890,31 +862,29 @@ void createRegionHierarchy(const int maxRegPerProc,
    */
   using real_type = typename Teuchos::ScalarTraits<Scalar>::coordinateType;
   using realvaluedmultivector_type = Xpetra::MultiVector<real_type, LocalOrdinal, GlobalOrdinal, Node>;
-  Array<RCP<realvaluedmultivector_type> > regCoarseCoordinates(maxRegPerProc);
+  RCP<realvaluedmultivector_type> regCoarseCoordinates;
   for (int l = 1; l < numLevels; ++l) { // Note: we start at level 1 (which is the first coarse level)
-    for (int j = 0; j < maxRegPerProc; ++j) {
-      RCP<MueLu::Level> level = regGrpHierarchy[j]->GetLevel(l);
+    RCP<MueLu::Level> level = regGrpHierarchy->GetLevel(l);
 
-      if(keepCoarseCoords && (l == numLevels - 1)) {
-        regCoarseCoordinates[j] = level->Get<RCP<realvaluedmultivector_type> >("Coordinates2", MueLu::NoFactory::get());
-      }
-
-      regProlong[l][j]  = level->Get<RCP<Matrix> >("P", MueLu::NoFactory::get());
-      regMatrices[l][j] = level->Get<RCP<Matrix> >("A", MueLu::NoFactory::get());
-
-      regRowMaps[l][j]  = Teuchos::rcp_const_cast<Xpetra::Map<LO,GO,NO> >(regMatrices[l][j]->getRowMap());
-      regColMaps[l][j]  = Teuchos::rcp_const_cast<Xpetra::Map<LO,GO,NO> >(regMatrices[l][j]->getColMap());
+    if(keepCoarseCoords && (l == numLevels - 1)) {
+      regCoarseCoordinates = level->Get<RCP<realvaluedmultivector_type> >("Coordinates2", MueLu::NoFactory::get());
     }
+
+    regProlong[l]  = level->Get<RCP<Matrix> >("P", MueLu::NoFactory::get());
+    regMatrices[l] = level->Get<RCP<Matrix> >("A", MueLu::NoFactory::get());
+
+    regRowMaps[l]  = Teuchos::rcp_const_cast<Xpetra::Map<LO,GO,NO> >(regMatrices[l]->getRowMap());
+    regColMaps[l]  = Teuchos::rcp_const_cast<Xpetra::Map<LO,GO,NO> >(regMatrices[l]->getColMap());
 
     // Create residual and solution vectors and cache them for vCycle apply
     std::string levelName("level");
     levelName += std::to_string(l);
     ParameterList& levelList = hierarchyData->sublist(levelName, false, "list of data on current level");
-    Teuchos::Array<RCP<Vector> > regRes(maxRegPerProc), regSol(maxRegPerProc);
-    createRegionalVector(regRes, revisedRowMapPerGrp);
-    createRegionalVector(regSol, revisedRowMapPerGrp);
-    levelList.set<Teuchos::Array<RCP<Vector> > >("residual", regRes, "Cached residual vector");
-    levelList.set<Teuchos::Array<RCP<Vector> > >("solution", regSol, "Cached solution vector");
+    RCP<Vector> regRes = VectorFactory::Build(revisedRowMapPerGrp, true);
+    RCP<Vector> regSol = VectorFactory::Build(revisedRowMapPerGrp, true);
+
+    levelList.set<RCP<Vector> >("residual", regRes, "Cached residual vector");
+    levelList.set<RCP<Vector> >("solution", regSol, "Cached solution vector");
   }
 
   // std::cout << mapComp->getComm()->getRank() << " | MakeCoarseLevelMaps ..." << std::endl;
@@ -939,8 +909,7 @@ void createRegionHierarchy(const int maxRegPerProc,
 
   tmLocal = Teuchos::null;
   tmLocal = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("createRegionHierarchy: MakeInterfaceScaling")));
-  MakeInterfaceScalingFactors(maxRegPerProc,
-                              numLevels,
+  MakeInterfaceScalingFactors(numLevels,
                               compRowMaps,
                               regInterfaceScalings,
                               regRowMaps,
@@ -983,8 +952,7 @@ void createRegionHierarchy(const int maxRegPerProc,
 
     RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > coarseCompOp;
     RCP<realvaluedmultivector_type> compCoarseCoordinates;
-    MakeCoarseCompositeOperator(maxRegPerProc,
-                                compRowMaps[numLevels - 1],
+    MakeCoarseCompositeOperator(compRowMaps[numLevels - 1],
                                 quasiRegRowMaps[numLevels - 1],
                                 quasiRegColMaps[numLevels - 1],
                                 regRowImporters[numLevels - 1],
@@ -1015,8 +983,7 @@ void createRegionHierarchy(const int maxRegPerProc,
         RCP<const Import> rebalanceImporter;
 
         const int rebalanceNumPartitions = coarseSolverData->get<int>("coarse rebalance num partitions");
-        RebalanceCoarseCompositeOperator(maxRegPerProc,
-                                    rebalanceNumPartitions,
+        RebalanceCoarseCompositeOperator(rebalanceNumPartitions,
                                     coarseCompOp,
                                     compCoarseCoordinates,
                                     rebalancedCompOp,
@@ -1042,57 +1009,57 @@ void createRegionHierarchy(const int maxRegPerProc,
 } // createRegionHierarchy
 
 
-// Wrapper to be used from the Matlab-based driver
-template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-void createRegionHierarchy(const int maxRegPerProc,
-                           const int numDimensions,
-                           const Array<Array<int> > lNodesPerDim,
-                           const Array<std::string> aggregationRegionType,
-                           const std::string xmlFileName,
-                           Array<RCP<Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& nullspace,
-                           Array<RCP<Xpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::coordinateType, LocalOrdinal, GlobalOrdinal, Node> > >& coordinates,
-                           std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regionGrpMats,
-                           const RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > mapComp,
-                           const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > rowMapPerGrp,
-                           const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > colMapPerGrp,
-                           const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > revisedRowMapPerGrp,
-                           const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > revisedColMapPerGrp,
-                           const std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > rowImportPerGrp,
-                           Array<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& compRowMaps,
-                           Array<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& compColMaps,
-                           Array<std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > >& regRowMaps,
-                           Array<std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > >& regColMaps,
-                           Array<std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > >& quasiRegRowMaps,
-                           Array<std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > >& quasiRegColMaps,
-                           Array<std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > >& regMatrices,
-                           Array<std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > >& regProlong,
-                           Array<std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > >& regRowImporters,
-                           Array<Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > >& regInterfaceScalings,
-                           Array<RCP<Teuchos::ParameterList> >& smootherParams
-                           )
-{
-  // Define dummy values
-  const int maxRegPerGID = 0;
-  ArrayView<LocalOrdinal> compositeToRegionLIDs = {};
-  RCP<ParameterList> coarseSolverParams = rcp(new ParameterList("Coarse solver parameters"));
-  coarseSolverParams->set<bool>("use coarse solver", true);
-  RCP<ParameterList> dummy = Teuchos::parameterList();
-  Array<RCP<Xpetra::MultiVector<GlobalOrdinal, LocalOrdinal, GlobalOrdinal, Node> > > interfaceGIDsPerLevel;
-  Array<RCP<Xpetra::MultiVector<LocalOrdinal, LocalOrdinal, GlobalOrdinal, Node> > > regionsPerGIDWithGhostsPerLevel;
-  Array<ArrayRCP<LocalOrdinal> > regionMatVecLIDsPerLevel;
-  Array<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > regionInterfaceImporterPerLevel;
-
-  // Call the actual routine
-  createRegionHierarchy(maxRegPerProc, numDimensions, lNodesPerDim,
-                        aggregationRegionType, dummy, xmlFileName, nullspace, coordinates,
-                        regionGrpMats, mapComp, rowMapPerGrp, colMapPerGrp, revisedRowMapPerGrp,
-                        revisedColMapPerGrp, rowImportPerGrp, compRowMaps, compColMaps, regRowMaps,
-                        regColMaps, quasiRegRowMaps, quasiRegColMaps, regMatrices, regProlong,
-                        regRowImporters, regInterfaceScalings, interfaceGIDsPerLevel,
-                        regionsPerGIDWithGhostsPerLevel, regionMatVecLIDsPerLevel,
-                        regionInterfaceImporterPerLevel, maxRegPerGID,
-                        compositeToRegionLIDs, coarseSolverParams, smootherParams, dummy, false);
-}
+//// Wrapper to be used from the Matlab-based driver
+//template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+//void createRegionHierarchy(const int maxRegPerProc,
+//                           const int numDimensions,
+//                           const Array<Array<int> > lNodesPerDim,
+//                           const Array<std::string> aggregationRegionType,
+//                           const std::string xmlFileName,
+//                           Array<RCP<Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& nullspace,
+//                           Array<RCP<Xpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::coordinateType, LocalOrdinal, GlobalOrdinal, Node> > >& coordinates,
+//                           std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regionGrpMats,
+//                           const RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > mapComp,
+//                           const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > rowMapPerGrp,
+//                           const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > colMapPerGrp,
+//                           const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > revisedRowMapPerGrp,
+//                           const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > revisedColMapPerGrp,
+//                           const std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > rowImportPerGrp,
+//                           Array<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& compRowMaps,
+//                           Array<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& compColMaps,
+//                           Array<std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > >& regRowMaps,
+//                           Array<std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > >& regColMaps,
+//                           Array<std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > >& quasiRegRowMaps,
+//                           Array<std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > >& quasiRegColMaps,
+//                           Array<std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > >& regMatrices,
+//                           Array<std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > >& regProlong,
+//                           Array<std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > >& regRowImporters,
+//                           Array<Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > >& regInterfaceScalings,
+//                           Array<RCP<Teuchos::ParameterList> >& smootherParams
+//                           )
+//{
+//  // Define dummy values
+//  const int maxRegPerGID = 0;
+//  ArrayView<LocalOrdinal> compositeToRegionLIDs = {};
+//  RCP<ParameterList> coarseSolverParams = rcp(new ParameterList("Coarse solver parameters"));
+//  coarseSolverParams->set<bool>("use coarse solver", true);
+//  RCP<ParameterList> dummy = Teuchos::parameterList();
+//  Array<RCP<Xpetra::MultiVector<GlobalOrdinal, LocalOrdinal, GlobalOrdinal, Node> > > interfaceGIDsPerLevel;
+//  Array<RCP<Xpetra::MultiVector<LocalOrdinal, LocalOrdinal, GlobalOrdinal, Node> > > regionsPerGIDWithGhostsPerLevel;
+//  Array<ArrayRCP<LocalOrdinal> > regionMatVecLIDsPerLevel;
+//  Array<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > regionInterfaceImporterPerLevel;
+//
+//  // Call the actual routine
+//  createRegionHierarchy(maxRegPerProc, numDimensions, lNodesPerDim,
+//                        aggregationRegionType, dummy, xmlFileName, nullspace, coordinates,
+//                        regionGrpMats, mapComp, rowMapPerGrp, colMapPerGrp, revisedRowMapPerGrp,
+//                        revisedColMapPerGrp, rowImportPerGrp, compRowMaps, compColMaps, regRowMaps,
+//                        regColMaps, quasiRegRowMaps, quasiRegColMaps, regMatrices, regProlong,
+//                        regRowImporters, regInterfaceScalings, interfaceGIDsPerLevel,
+//                        regionsPerGIDWithGhostsPerLevel, regionMatVecLIDsPerLevel,
+//                        regionInterfaceImporterPerLevel, maxRegPerGID,
+//                        compositeToRegionLIDs, coarseSolverParams, smootherParams, dummy, false);
+//}
 
 
 //! Recursive V-cycle in region fashion
@@ -1100,15 +1067,15 @@ template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void vCycle(const int l, ///< ID of current level
             const int numLevels, ///< Total number of levels
             const std::string cycleType,
-            Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& fineRegX, ///< solution
-            Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > fineRegB, ///< right hand side
-            Array<std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > > regMatrices, ///< Matrices in region layout
-            Array<std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > > regProlong, ///< Prolongators in region layout
+            RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> >& fineRegX, ///< solution
+            RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > fineRegB, ///< right hand side
+            Array<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regMatrices, ///< Matrices in region layout
+            Array<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regProlong, ///< Prolongators in region layout
             Array<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > compRowMaps, ///< composite maps
-            Array<std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > > quasiRegRowMaps, ///< quasiRegional row maps
-            Array<std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > > regRowMaps, ///< regional row maps
-            Array<std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > > regRowImporters, ///< regional row importers
-            Array<Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > > regInterfaceScalings, ///< regional interface scaling factors
+            Array<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > quasiRegRowMaps, ///< quasiRegional row maps
+            Array<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > regRowMaps, ///< regional row maps
+            Array<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > regRowImporters, ///< regional row importers
+            Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regInterfaceScalings, ///< regional interface scaling factors
             Array<RCP<Teuchos::ParameterList> > smootherParams, ///< region smoother parameter list
             bool& zeroInitGuess,
             RCP<ParameterList> coarseSolverData = Teuchos::null,
@@ -1118,9 +1085,6 @@ void vCycle(const int l, ///< ID of current level
   using Teuchos::TimeMonitor;
   const Scalar SC_ZERO = Teuchos::ScalarTraits<Scalar>::zero();
   const Scalar SC_ONE = Teuchos::ScalarTraits<Scalar>::one();
-
-  // Get max number of regions per process
-  const int maxRegPerProc = fineRegX.size();
 
   int cycleCount = 1;
   if(cycleType == "W" && l > 0) // W cycle and not on finest level
@@ -1150,11 +1114,11 @@ void vCycle(const int l, ///< ID of current level
       tm = Teuchos::null;
       tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("vCycle: 2 - compute residual")));
 
-      Array<RCP<Vector> > regRes(maxRegPerProc);
+      RCP<Vector> regRes;
       if(useCachedVectors) {
-        regRes = levelList.get<Teuchos::Array<RCP<Vector> > >("residual");
+        regRes = levelList.get<RCP<Vector> >("residual");
       } else {
-        createRegionalVector(regRes, regRowMaps[l]);
+        regRes = VectorFactory::Build(regRowMaps[l], true);
       }
       computeResidual(regRes, fineRegX, fineRegB, regMatrices[l], *smootherParams[l]);
 
@@ -1167,23 +1131,21 @@ void vCycle(const int l, ///< ID of current level
       tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("vCycle: 4 - create coarse vectors")));
 
       // Transfer to coarse level
-      Array<RCP<Vector> > coarseRegX(maxRegPerProc);
-      Array<RCP<Vector> > coarseRegB(maxRegPerProc);
+      RCP<Vector> coarseRegX;
+      RCP<Vector> coarseRegB;
 
       {
         // Get pre-communicated communication patterns for the fast MatVec
         const ArrayRCP<LocalOrdinal> regionInterfaceLIDs = smootherParams[l+1]->get<ArrayRCP<LO>>("Fast MatVec: interface LIDs");
         const RCP<Import> regionInterfaceImporter = smootherParams[l+1]->get<RCP<Import>>("Fast MatVec: interface importer");
 
-        for (int j = 0; j < maxRegPerProc; j++) {
-          coarseRegX[j] = VectorFactory::Build(regRowMaps[l+1][j], true);
-          coarseRegB[j] = VectorFactory::Build(regRowMaps[l+1][j], true);
+        coarseRegX = VectorFactory::Build(regRowMaps[l+1], true);
+        coarseRegB = VectorFactory::Build(regRowMaps[l+1], true);
 
-          ApplyMatVec(SC_ONE, regProlong[l+1][j], regRes[j], SC_ZERO, regionInterfaceImporter,
-              regionInterfaceLIDs, coarseRegB[j], Teuchos::TRANS, true);
+        ApplyMatVec(SC_ONE, regProlong[l+1], regRes, SC_ZERO, regionInterfaceImporter,
+            regionInterfaceLIDs, coarseRegB, Teuchos::TRANS, true);
           // TEUCHOS_ASSERT(regProlong[l+1][j]->getRangeMap()->isSameAs(*regRes[j]->getMap()));
           // TEUCHOS_ASSERT(regProlong[l+1][j]->getDomainMap()->isSameAs(*coarseRegB[j]->getMap()));
-        }
       }
 
       tm = Teuchos::null;
@@ -1198,28 +1160,24 @@ void vCycle(const int l, ///< ID of current level
       tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("vCycle: 6 - transfer coarse to fine")));
 
       // Transfer coarse level correction to fine level
-      Array<RCP<Vector> > regCorrection(maxRegPerProc);
+      RCP<Vector> regCorrection;
       {
         // Get pre-communicated communication patterns for the fast MatVec
         const ArrayRCP<LocalOrdinal> regionInterfaceLIDs = smootherParams[l]->get<ArrayRCP<LO>>("Fast MatVec: interface LIDs");
         const RCP<Import> regionInterfaceImporter = smootherParams[l]->get<RCP<Import>>("Fast MatVec: interface importer");
 
-        for (int j = 0; j < maxRegPerProc; j++) {
-          regCorrection[j] = VectorFactory::Build(regRowMaps[l][j], true);
-          ApplyMatVec(SC_ONE, regProlong[l+1][j], coarseRegX[j], SC_ZERO, regionInterfaceImporter,
-              regionInterfaceLIDs, regCorrection[j], Teuchos::NO_TRANS, false);
+        regCorrection = VectorFactory::Build(regRowMaps[l], true);
+        ApplyMatVec(SC_ONE, regProlong[l+1], coarseRegX, SC_ZERO, regionInterfaceImporter,
+            regionInterfaceLIDs, regCorrection, Teuchos::NO_TRANS, false);
           // TEUCHOS_ASSERT(regProlong[l+1][j]->getDomainMap()->isSameAs(*coarseRegX[j]->getMap()));
           // TEUCHOS_ASSERT(regProlong[l+1][j]->getRangeMap()->isSameAs(*regCorrection[j]->getMap()));
-        }
       }
 
       tm = Teuchos::null;
       tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("vCycle: 7 - add coarse grid correction")));
 
       // apply coarse grid correction
-      for (int j = 0; j < maxRegPerProc; j++) {
-        fineRegX[j]->update(SC_ONE, *regCorrection[j], SC_ONE);
-      }
+      fineRegX->update(SC_ONE, *regCorrection, SC_ONE);
       if (coarseZeroInitGuess) zeroInitGuess = true;
 
 //    std::cout << "level: " << l << std::endl;
@@ -1256,11 +1214,9 @@ void vCycle(const int l, ///< ID of current level
       RCP<Vector> compX = VectorFactory::Build(coarseRowMap, true);
       RCP<Vector> compRhs = VectorFactory::Build(coarseRowMap, true);
       {
-        for (int j = 0; j < maxRegPerProc; j++) {
-          RCP<Vector> inverseInterfaceScaling = VectorFactory::Build(regInterfaceScalings[l][j]->getMap());
-          inverseInterfaceScaling->reciprocal(*regInterfaceScalings[l][j]);
-          fineRegB[j]->elementWiseMultiply(SC_ONE, *fineRegB[j], *inverseInterfaceScaling, SC_ZERO);
-        }
+        RCP<Vector> inverseInterfaceScaling = VectorFactory::Build(regInterfaceScalings[l]->getMap());
+        inverseInterfaceScaling->reciprocal(*regInterfaceScalings[l]);
+        fineRegB->elementWiseMultiply(SC_ONE, *fineRegB, *inverseInterfaceScaling, SC_ZERO);
 
         regionalToComposite(fineRegB, compRhs, regRowImporters[l]);
       }
@@ -1350,7 +1306,7 @@ void vCycle(const int l, ///< ID of current level
       }
 
       // Transform back to region format
-      Array<RCP<Vector> > quasiRegX(maxRegPerProc);
+      RCP<Vector> quasiRegX;
       compositeToRegional(compX, quasiRegX, fineRegX,
                           regRowMaps[l],
                           regRowImporters[l]);

--- a/packages/muelu/research/regionMG/src/SetupRegionMatrix_def.hpp
+++ b/packages/muelu/research/regionMG/src/SetupRegionMatrix_def.hpp
@@ -122,283 +122,13 @@ Teuchos::Array<int> findCommonRegions(const GlobalOrdinal nodeA, ///< GID of fir
 }
 
 
-template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node, class widget>
-void MakeGroupRegionRowMaps(const int myRank,
-                            const RCP<Xpetra::CrsMatrixWrap<Scalar, LocalOrdinal, GlobalOrdinal, Node> > AComp,
-                            LocalOrdinal (*LIDregion)(void*, const LocalOrdinal, int),
-                            widget appData,
-                            const std::vector<LocalOrdinal> myRegions,
-                            std::vector<Teuchos::RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& rowMapPerGrp) {
-#include "Xpetra_UseShortNames.hpp"
-  // Make group region row maps
-  // std::cout << myRank << " | Creating region group row maps ..." << std::endl;
-
-  Teuchos::Array<GlobalOrdinal> rowGIDsReg;
-  const Teuchos::ArrayView<const GlobalOrdinal> colGIDsComp = AComp->getColMap()->getNodeElementList();
-
-  for (int k = 0; k < static_cast<int>(myRegions.size()); k++) {
-    rowGIDsReg.resize(0);
-    std::vector<int> tempRegIDs(AComp->getColMap()->getNodeNumElements());
-    for (int i = 0; i < static_cast<int>(AComp->getColMap()->getNodeNumElements()); i++) {
-      tempRegIDs[i] = (*LIDregion)(&appData, i, k);
-    }
-
-    std::vector<int> idx(tempRegIDs.size());
-    std::iota(idx.begin(), idx.end(), 0);
-    std::sort(idx.begin(), idx.end(), [tempRegIDs](int i1,int i2) { return tempRegIDs[i1] < tempRegIDs[i2];});
-
-    for (int i = 0; i < static_cast<int>(AComp->getColMap()->getNodeNumElements()); i++) {
-      if (tempRegIDs[idx[i]] != -1)
-        rowGIDsReg.push_back(colGIDsComp[idx[i]]);
-    }
-    rowMapPerGrp[k] = MapFactory::Build(AComp->getMap()->lib(),
-                                        Teuchos::OrdinalTraits<GlobalOrdinal>::invalid(),
-                                        rowGIDsReg,
-                                        Teuchos::OrdinalTraits<GlobalOrdinal>::zero(),
-                                        AComp->getMap()->getComm());
-  }
-
-  for (int k = static_cast<int>(myRegions.size()); k < appData.maxRegPerProc; k++) {
-    rowMapPerGrp[k] = MapFactory::Build(AComp->getMap()->lib(),
-                                        Teuchos::OrdinalTraits<GlobalOrdinal>::invalid(),
-                                        Teuchos::OrdinalTraits<GlobalOrdinal>::zero(),
-                                        AComp->getMap()->getComm());
-  }
-}
-
-
-template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node, class widget>
-void MakeGroupRegionColumnMaps(const int myRank,
-                               const int whichCase,
-                               const RCP<Xpetra::CrsMatrixWrap<Scalar, LocalOrdinal, GlobalOrdinal, Node> > AComp,
-                               LocalOrdinal (*LIDregion)(void*, const LocalOrdinal, int),
-                               widget appData,
-                               const std::vector<LocalOrdinal> myRegions,
-                               std::vector<Teuchos::RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& rowMapPerGrp,
-                               std::vector<Teuchos::RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& colMapPerGrp) {
-#include "Xpetra_UseShortNames.hpp"
-  // std::cout << myRank << " | Creating region group column maps ..." << std::endl;
-
-  if (whichCase == MultipleRegionsPerProc) {//so maxRegPerProc > 1
-    // clone rowMap
-    for (int j = 0; j < appData.maxRegPerProc; j++) {
-      if (j < static_cast<int>(myRegions.size())) {
-        colMapPerGrp[j] = MapFactory::Build(AComp->getMap()->lib(),
-                                            Teuchos::OrdinalTraits<int>::invalid(),
-                                            rowMapPerGrp[j]->getNodeElementList(),
-                                            Teuchos::OrdinalTraits<int>::zero(),
-                                            AComp->getMap()->getComm());
-      } else {
-        colMapPerGrp[j] = MapFactory::Build(AComp->getMap()->lib(),
-                                            Teuchos::OrdinalTraits<GlobalOrdinal>::invalid(),
-                                            Teuchos::OrdinalTraits<GlobalOrdinal>::zero(),
-                                            AComp->getMap()->getComm());
-      }
-    }
-  } else if (whichCase == RegionsSpanProcs) {//so maxRegPerProc = 1
-    Teuchos::Array<GlobalOrdinal> colIDsReg;
-
-    // copy the rowmap
-    Teuchos::ArrayView<const GlobalOrdinal> rowGIDsReg = rowMapPerGrp[0]->getNodeElementList();
-    for (LocalOrdinal i = 0; i < static_cast<LocalOrdinal>(rowMapPerGrp[0]->getNodeNumElements()); i++) {
-      colIDsReg.push_back(rowGIDsReg[i]);
-    }
-
-    // append additional ghosts who are in my region and
-    // for whom I have a LID
-    LocalOrdinal LID;
-    Teuchos::ArrayView<const GlobalOrdinal> colGIDsComp =  AComp->getColMap()->getNodeElementList();
-    for (std::size_t i = 0; i < AComp->getColMap()->getNodeNumElements(); i++) {
-      LID = LIDregion(&appData, i, 0);
-      if (LID == -1) {
-        for (int j = 0; j < appData.maxRegPerGID; j++) {
-          Teuchos::ArrayRCP<const LocalOrdinal> jthRegions = appData.regionsPerGIDWithGhosts->getData(j);
-          if  (static_cast<int>(jthRegions[i]) == myRegions[0]) {
-            colIDsReg.push_back(colGIDsComp[i]);
-            break;
-          }
-        }
-      }
-    }
-    if (static_cast<int>(myRegions.size()) > 0) {
-      colMapPerGrp[0] = MapFactory::Build(AComp->getMap()->lib(),
-                                          Teuchos::OrdinalTraits<int>::invalid(),
-                                          colIDsReg,
-                                          Teuchos::OrdinalTraits<int>::zero(),
-                                          AComp->getMap()->getComm());
-    } else {
-      colMapPerGrp[0] = MapFactory::Build(AComp->getMap()->lib(),
-                                          Teuchos::OrdinalTraits<GlobalOrdinal>::invalid(),
-                                          Teuchos::OrdinalTraits<GlobalOrdinal>::zero(),
-                                          AComp->getMap()->getComm());
-    }
-  } else {
-    fprintf(stderr,"whichCase not set properly\n");
-    exit(1);
-  }
-} // MakeGroupRegionColumnMaps
-
-template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node, class widget>
-void MakeGroupExtendedMaps(const int myRank,
-                           const int whichCase,
-                           const RCP<Xpetra::CrsMatrixWrap<Scalar, LocalOrdinal, GlobalOrdinal, Node> > AComp,
-                           const RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > mapComp,
-                           LocalOrdinal (*LIDregion)(void*, const LocalOrdinal, int),
-                           widget appData,
-                           const std::vector<LocalOrdinal> myRegions,
-                           std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& rowMapPerGrp,
-                           std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& colMapPerGrp,
-                           std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& revisedRowMapPerGrp,
-                           std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& revisedColMapPerGrp) {
-#include "Xpetra_UseShortNames.hpp"
-  // std::cout << myRank << " | Creating extended group region maps ..." << std::endl;
-
-  const Scalar SC_ONE = Teuchos::ScalarTraits<Scalar>::one();
-
-  LocalOrdinal nLocal = AComp->getRowMap()->getNodeNumElements();
-  LocalOrdinal nExtended = AComp->getColMap()->getNodeNumElements();
-  LocalOrdinal nTotal = 0;
-  Teuchos::reduceAll<LocalOrdinal, LocalOrdinal>(*(AComp->getMap()->getComm()),
-                                                 Teuchos::REDUCE_SUM,
-                                                 nLocal,
-                                                 Teuchos::outArg(nTotal));
-
-  // first step of NewGID calculation just counts the number of NewGIDs
-  // and sets firstNewGID[k] such that it is equal to the number of
-  // NewGIDs that have already been counted in (0:k-1) that myRank
-  // is responsible for.
-
-  RCP<Vector> firstNewGID = VectorFactory::Build(mapComp, true);
-  ArrayRCP<Scalar> firstNewGIDData = firstNewGID->getDataNonConst(0);
-  for (int k = 0; k < nLocal-1; k++) {
-    firstNewGIDData[k + 1] = firstNewGIDData[k] - 1;
-    // firstNewGID->replaceLocalValue(k + 1, (firstNewGID->getData(0))[k]-1);
-    for (int j = 0; j < appData.maxRegPerGID; j++) {
-      Teuchos::ArrayRCP<const LocalOrdinal> jthRegions = appData.regionsPerGIDWithGhosts->getData(j);
-      if (jthRegions[k] != -1) firstNewGIDData[k+1] = SC_ONE;
-      // if (jthRegions[k] != -1) firstNewGID->sumIntoLocalValue(k+1, SC_ONE);
-    }
-  }
-  // So firstNewGID[nLocal-1] is number of NewGIDs up to nLocal-2
-  // To account for newGIDs associated with nLocal-1, we'll just
-  // use an upper bound (to avoid the little loop above).
-  // By adding maxRegPerGID-1 we account for the maximum
-  // number of possible newGIDs due to last composite id
-  GlobalOrdinal upperBndNumNewGIDs = Teuchos::as<GlobalOrdinal>(firstNewGIDData[nLocal-1]) + appData.maxRegPerGID-1;
-  GlobalOrdinal upperBndNumNewGIDsAllProcs;
-  Teuchos::reduceAll<GlobalOrdinal,GlobalOrdinal>(*(AComp->getMap()->getComm()),
-                                                  Teuchos::REDUCE_MAX,
-                                                  upperBndNumNewGIDs,
-                                                  Teuchos::outArg(upperBndNumNewGIDsAllProcs));
-
-  //    std::cout << "upperBndNumNewGIDsAllProcs: " << upperBndNumNewGIDsAllProcs << std::endl;
-
-  // Now that we have an upper bound on the maximum number of
-  // NewGIDs over all procs, we sweep through firstNewGID again
-  // to assign ids to the first NewGID associated with each row of
-  // regionsPerGIDWithGhosts (by adding an offset)
-  for (LocalOrdinal k = 0; k < nLocal; k++) {
-    firstNewGIDData[k] += upperBndNumNewGIDsAllProcs*myRank+nTotal;
-    // firstNewGID->sumIntoLocalValue(k, upperBndNumNewGIDsAllProcs*myRank+nTotal);
-  }
-
-  RCP<Import> Importer = ImportFactory::Build(mapComp, AComp->getColMap());
-  RCP<Vector> firstNewGIDWithGhost = VectorFactory::Build(Importer->getTargetMap()); //AComp->getColMap());
-  firstNewGIDWithGhost->doImport(*firstNewGID, *Importer, Xpetra::INSERT);
-
-  Teuchos::Array<GlobalOrdinal> revisedGIDs;
-
-  for (std::size_t k = 0; k < myRegions.size(); k++) {
-    revisedGIDs.resize(0);
-    int curRegion = myRegions[k];
-    Teuchos::ArrayView<const GlobalOrdinal> colGIDsComp = AComp->getColMap()->getNodeElementList();
-    Teuchos::Array<LocalOrdinal> tempRegIDs(nExtended);
-
-    // must put revisedGIDs in application-provided order by
-    // invoking LIDregion() and sorting
-    for (LocalOrdinal i = 0; i < nExtended; i++) {
-      tempRegIDs[i] = LIDregion(&appData, i, k);
-    }
-    Teuchos::Array<LocalOrdinal> idx(tempRegIDs.size());
-    std::iota(idx.begin(),idx.end(),0);
-    std::sort(idx.begin(),idx.end(),[tempRegIDs](int i1,int i2){return tempRegIDs[i1] < tempRegIDs[i2];});
-
-    // Now sweep through regionsPerGIDWithGhosts looking for those
-    // associated with curRegion and record the revisedGID
-    int j;
-    for (LocalOrdinal i = 0; i < nExtended; i++) {
-
-      if (tempRegIDs[idx[i]] != -1) {// if a valid LID for this region
-        for (j = 0; j < appData.maxRegPerGID; j++) {
-          Teuchos::ArrayRCP<const LocalOrdinal> jthRegions = appData.regionsPerGIDWithGhosts->getData(j);
-          if (jthRegions[idx[i]] == curRegion) break;
-        }
-
-        // (regionsPerGIDWithGhosts)[0] entries keep original GID
-        // while others use firstNewGID to determine NewGID
-
-        if (j == 0) revisedGIDs.push_back(colGIDsComp[idx[i]]);
-        else if (j < appData.maxRegPerGID) {
-          revisedGIDs.push_back((GlobalOrdinal) firstNewGIDWithGhost->getData(0)[idx[i]] + j - 1);
-        }
-
-        // add entry to listDulicatedGIDs
-      }
-    }
-
-    revisedRowMapPerGrp[k] = MapFactory::Build(AComp->getMap()->lib(),
-                                               Teuchos::OrdinalTraits<GlobalOrdinal>::invalid(),
-                                               revisedGIDs,
-                                               Teuchos::OrdinalTraits<GlobalOrdinal>::zero(),
-                                               AComp->getMap()->getComm());
-
-    // now append more stuff to handle ghosts ... needed for
-    // revised version of column map
-
-    for (LocalOrdinal i = 0; i < nExtended; i++) {
-      if (tempRegIDs[i] == -1) {// only in revised col map
-        // note: since sorting not used when making the
-        // original regional colmap, we can't use
-        // it here either ... so no idx[]'s.
-        for (j = 0; j < appData.maxRegPerGID; j++) {
-          Teuchos::ArrayRCP<const LocalOrdinal> jthRegions = appData.regionsPerGIDWithGhosts->getData(j);
-          if  (jthRegions[i] == curRegion) break;
-        }
-        // (*regionsPerGIDWithGhosts)[0] entries keep original GID
-        // while others use firstNewGID to determine NewGID
-
-        if (j == 0) revisedGIDs.push_back(colGIDsComp[i]);
-        else if (j < appData.maxRegPerGID) {
-          revisedGIDs.push_back((int) firstNewGIDWithGhost->getData(0)[i] + j - 1);
-        }
-      }
-    }
-    revisedColMapPerGrp[k] = MapFactory::Build(AComp->getMap()->lib(),
-                                               Teuchos::OrdinalTraits<GlobalOrdinal>::invalid(),
-                                               revisedGIDs,
-                                               Teuchos::OrdinalTraits<GlobalOrdinal>::zero(),
-                                               AComp->getMap()->getComm());
-  }
-  for (std::size_t k = myRegions.size(); k < Teuchos::as<std::size_t>(appData.maxRegPerProc); k++) {
-    revisedRowMapPerGrp[k] = MapFactory::Build(AComp->getMap()->lib(),
-                                               Teuchos::OrdinalTraits<GlobalOrdinal>::invalid(),
-                                               Teuchos::OrdinalTraits<GlobalOrdinal>::zero(),
-                                               AComp->getMap()->getComm());
-    revisedColMapPerGrp[k] = MapFactory::Build(AComp->getMap()->lib(),
-                                               Teuchos::OrdinalTraits<GlobalOrdinal>::invalid(),
-                                               Teuchos::OrdinalTraits<GlobalOrdinal>::zero(),
-                                               AComp->getMap()->getComm());
-  }
-} // MakeGroupExtendedMaps
-
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void MakeQuasiregionMatrices(const RCP<Xpetra::CrsMatrixWrap<Scalar, LocalOrdinal, GlobalOrdinal, Node> > AComp,
-                             const int maxRegPerProc,
                              RCP<Xpetra::MultiVector<LocalOrdinal, LocalOrdinal, GlobalOrdinal, Node> > regionsPerGIDWithGhosts,
-                             std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& rowMapPerGrp,
-                             std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& colMapPerGrp,
-                             std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > >& rowImportPerGrp,
-                             std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& quasiRegionGrpMats) {
+                             RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> >& rowMapPerGrp,
+                             RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> >& colMapPerGrp,
+                             RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> >& rowImportPerGrp,
+                             RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> >& quasiRegionGrpMats) {
 #include "Xpetra_UseShortNames.hpp"
   using Teuchos::RCP;
   using Teuchos::TimeMonitor;
@@ -418,71 +148,69 @@ void MakeQuasiregionMatrices(const RCP<Xpetra::CrsMatrixWrap<Scalar, LocalOrdina
   // Since the stencil size does not grow between composite and region format
   // use AComp->getCrsGraph()->getNodeMaxNumRowEntries() to get an upper
   // bound of the number of nonzeros per row in quasiRegionMat
-  for (int j = 0; j < maxRegPerProc; j++) {
-    RCP<TimeMonitor> tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("MakeQuasiregionMatrices: 1 - Create Matrix")));
+  RCP<TimeMonitor> tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("MakeQuasiregionMatrices: 1 - Create Matrix")));
 
-    quasiRegionGrpMats[j] = MatrixFactory::Build(rowMapPerGrp[j],
-                                                 colMapPerGrp[j],
-                                                 AComp->getCrsGraph()->getNodeMaxNumRowEntries());
+  quasiRegionGrpMats = MatrixFactory::Build(rowMapPerGrp,
+                                               colMapPerGrp,
+                                               AComp->getCrsGraph()->getNodeMaxNumRowEntries());
 
-    tm = Teuchos::null;
-    tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("MakeQuasiregionMatrices: 2 - Import data")));
+  tm = Teuchos::null;
+  tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("MakeQuasiregionMatrices: 2 - Import data")));
 
-    quasiRegionGrpMats[j]->doImport(*AComp,
-                                    *(rowImportPerGrp[j]),
-                                    Xpetra::INSERT);
+  quasiRegionGrpMats->doImport(*AComp,
+                                  *(rowImportPerGrp),
+                                  Xpetra::INSERT);
 
-    tm = Teuchos::null;
-    tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("MakeQuasiregionMatrices: 3 - Scale interface entries")));
+  tm = Teuchos::null;
+  tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("MakeQuasiregionMatrices: 3 - Scale interface entries")));
 
-    RCP<CrsMatrixWrap> quasiRegionCrsWrap = Teuchos::rcp_dynamic_cast<CrsMatrixWrap>(quasiRegionGrpMats[j]);
-    RCP<CrsMatrix> quasiRegionCrs = quasiRegionCrsWrap->getCrsMatrix();
-    const LO numRows = Teuchos::as<LO>(quasiRegionCrs->getNodeNumRows());
+  RCP<CrsMatrixWrap> quasiRegionCrsWrap = Teuchos::rcp_dynamic_cast<CrsMatrixWrap>(quasiRegionGrpMats);
+  RCP<CrsMatrix> quasiRegionCrs = quasiRegionCrsWrap->getCrsMatrix();
+  const LO numRows = Teuchos::as<LO>(quasiRegionCrs->getNodeNumRows());
 
-    for (LO row = 0; row < numRows; ++row) { // loop over local rows of composite matrix
-      GO rowGID = rowMapPerGrp[j]->getGlobalElement(row);
-      std::size_t numEntries = quasiRegionGrpMats[j]->getNumEntriesInLocalRow(row); // number of entries in this row
-      Teuchos::Array<SC> vals(numEntries); // non-zeros in this row
-      Teuchos::Array<LO> inds(numEntries); // local column indices
-      quasiRegionGrpMats[j]->getLocalRowCopy(row, inds, vals, numEntries);
+  for (LO row = 0; row < numRows; ++row) { // loop over local rows of composite matrix
+    GO rowGID = rowMapPerGrp->getGlobalElement(row);
+    std::size_t numEntries = quasiRegionGrpMats->getNumEntriesInLocalRow(row); // number of entries in this row
+    Teuchos::Array<SC> vals(numEntries); // non-zeros in this row
+    Teuchos::Array<LO> inds(numEntries); // local column indices
+    quasiRegionGrpMats->getLocalRowCopy(row, inds, vals, numEntries);
 
-      for (std::size_t c = 0; c < Teuchos::as<std::size_t>(inds.size()); ++c) { // loop over all entries in this row
-        LocalOrdinal col = inds[c];
-        GlobalOrdinal colGID = colMapPerGrp[j]->getGlobalElement(col);
-        Array<int> commonRegions;
-        if (rowGID != colGID) { // Skip the diagonal entry. It will be processed later.
-          // commonRegions = findCommonRegions(rowGID, colGID, *regionsPerGIDWithGhosts);
-          commonRegions = findCommonRegions(rowGID, colGID, regionPerGIDWithGhostsData, regionsPerGIDWithGhosts->getMap());
-        }
-
-        std::size_t sizeOfCommonRegions = commonRegions.size();
-        if (sizeOfCommonRegions > 1) {
-          vals[c] /= Teuchos::as<double>(sizeOfCommonRegions);
-        }
+    for (std::size_t c = 0; c < Teuchos::as<std::size_t>(inds.size()); ++c) { // loop over all entries in this row
+      LocalOrdinal col = inds[c];
+      GlobalOrdinal colGID = colMapPerGrp->getGlobalElement(col);
+      Array<int> commonRegions;
+      if (rowGID != colGID) { // Skip the diagonal entry. It will be processed later.
+        // commonRegions = findCommonRegions(rowGID, colGID, *regionsPerGIDWithGhosts);
+        commonRegions = findCommonRegions(rowGID, colGID, regionPerGIDWithGhostsData, regionsPerGIDWithGhosts->getMap());
       }
 
-      quasiRegionGrpMats[j]->replaceLocalValues(row, inds, vals);
+      std::size_t sizeOfCommonRegions = commonRegions.size();
+      if (sizeOfCommonRegions > 1) {
+        vals[c] /= Teuchos::as<double>(sizeOfCommonRegions);
+      }
     }
 
-    tm = Teuchos::null;
-    tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("MakeQuasiregionMatrices: 4 - fillComplete")));
-
-    quasiRegionGrpMats[j]->fillComplete();
-
-    tm = Teuchos::null;
+    quasiRegionGrpMats->replaceLocalValues(row, inds, vals);
   }
+
+  tm = Teuchos::null;
+  tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("MakeQuasiregionMatrices: 4 - fillComplete")));
+
+  quasiRegionGrpMats->fillComplete();
+
+  tm = Teuchos::null;
 } // MakeQuasiregionMatrices
+
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void MakeRegionMatrices(const RCP<Xpetra::CrsMatrixWrap<Scalar, LocalOrdinal, GlobalOrdinal, Node> > AComp,
                         const RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > mapComp,
-                        std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& rowMapPerGrp,
-                        std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& revisedRowMapPerGrp,
-                        std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& revisedColMapPerGrp,
-                        std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > >& rowImportPerGrp,
-                        const LocalOrdinal maxRegPerProc,
-                        std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& quasiRegionGrpMats,
-                        std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regionGrpMats) {
+                        RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> >& rowMapPerGrp,
+                        RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> >& revisedRowMapPerGrp,
+                        RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> >& revisedColMapPerGrp,
+                        RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> >& rowImportPerGrp,
+                        RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> >& quasiRegionGrpMats,
+                        RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> >& regionGrpMats) {
 #include "Xpetra_UseShortNames.hpp"
   using Teuchos::RCP;
   using Teuchos::TimeMonitor;
@@ -493,14 +221,13 @@ void MakeRegionMatrices(const RCP<Xpetra::CrsMatrixWrap<Scalar, LocalOrdinal, Gl
 
   // Copy data from quasiRegionGrpMats, but into new map layout
   {
-    for (int j = 0; j < maxRegPerProc; j++) {
-      regionGrpMats[j] = rcp(new CrsMatrixWrap(revisedRowMapPerGrp[j], revisedColMapPerGrp[j], 9));
+      regionGrpMats = rcp(new CrsMatrixWrap(revisedRowMapPerGrp, revisedColMapPerGrp, 9));
 
       // Extract current region CrsMatrix
-      RCP<CrsMatrix> regionCrsMat = Teuchos::rcp_dynamic_cast<CrsMatrixWrap>(regionGrpMats[j])->getCrsMatrix();
+      RCP<CrsMatrix> regionCrsMat = Teuchos::rcp_dynamic_cast<CrsMatrixWrap>(regionGrpMats)->getCrsMatrix();
 
       // Extract current quasi-region CrsMatrix
-      RCP<CrsMatrix> quasiRegionCrsMat = Teuchos::rcp_dynamic_cast<CrsMatrixWrap>(quasiRegionGrpMats[j])->getCrsMatrix();
+      RCP<CrsMatrix> quasiRegionCrsMat = Teuchos::rcp_dynamic_cast<CrsMatrixWrap>(quasiRegionGrpMats)->getCrsMatrix();
 
       // Pull out the data from the quasi-region CrsMatrix
       ArrayRCP<const size_t> rowptrQuasiRegion;
@@ -527,15 +254,14 @@ void MakeRegionMatrices(const RCP<Xpetra::CrsMatrixWrap<Scalar, LocalOrdinal, Gl
 
       // Set and fillComplete the region CrsMatrix
       regionCrsMat->setAllValues(rowptrRegion, colindRegion, valuesRegion);
-      regionCrsMat->expertStaticFillComplete(revisedRowMapPerGrp[j], revisedRowMapPerGrp[j]);
-    }
+      regionCrsMat->expertStaticFillComplete(revisedRowMapPerGrp, revisedRowMapPerGrp);
   }
 
   tm = Teuchos::null;
   tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("MakeRegionMatrices: 2 - Enforce nullspace constraint")));
 
   // enforce nullspace constraint
-  Array<RCP<Vector> > regNspViolation(maxRegPerProc);
+  RCP<Vector> regNspViolation;
   {
     // compute violation of nullspace property close to DBCs
     RCP<Vector> nspVec = VectorFactory::Build(mapComp);
@@ -544,9 +270,8 @@ void MakeRegionMatrices(const RCP<Xpetra::CrsMatrixWrap<Scalar, LocalOrdinal, Gl
     AComp->apply(*nspVec, *nspViolation);
 
     // move to regional layout
-    Array<RCP<Vector> > quasiRegNspViolation(maxRegPerProc);
-    createRegionalVector(quasiRegNspViolation, rowMapPerGrp);
-    createRegionalVector(regNspViolation, revisedRowMapPerGrp);
+    RCP<Vector> quasiRegNspViolation = VectorFactory::Build(rowMapPerGrp, true);
+    regNspViolation = VectorFactory::Build(revisedRowMapPerGrp, true);
     compositeToRegional(nspViolation, quasiRegNspViolation, regNspViolation,
                         revisedRowMapPerGrp, rowImportPerGrp);
 
@@ -560,11 +285,8 @@ void MakeRegionMatrices(const RCP<Xpetra::CrsMatrixWrap<Scalar, LocalOrdinal, Gl
      */
     {
       // initialize region vector with all ones.
-      Array<RCP<Vector> > interfaceScaling(maxRegPerProc);
-      for (int j = 0; j < maxRegPerProc; j++) {
-        interfaceScaling[j] = VectorFactory::Build(revisedRowMapPerGrp[j]);
-        interfaceScaling[j]->putScalar(SC_ONE);
-      }
+      RCP<Vector> interfaceScaling = VectorFactory::Build(revisedRowMapPerGrp);
+      interfaceScaling->putScalar(SC_ONE);
 
       // transform to composite layout while adding interface values via the Export() combine mode
       RCP<Vector> compInterfaceScalingSum = VectorFactory::Build(mapComp, true);
@@ -573,48 +295,43 @@ void MakeRegionMatrices(const RCP<Xpetra::CrsMatrixWrap<Scalar, LocalOrdinal, Gl
       /* transform composite layout back to regional layout. Now, GIDs associated
        * with region interface should carry a scaling factor (!= 1).
        */
-      Array<RCP<Vector> > quasiRegInterfaceScaling(maxRegPerProc);
+      RCP<Vector> quasiRegInterfaceScaling;
       compositeToRegional(compInterfaceScalingSum, quasiRegInterfaceScaling,
                           interfaceScaling,
                           revisedRowMapPerGrp, rowImportPerGrp);
 
       // modify its interface entries
-      for (int j = 0; j < maxRegPerProc; j++) {
-        RCP<Vector> inverseInterfaceScaling = VectorFactory::Build(interfaceScaling[j]->getMap(), true);
-        inverseInterfaceScaling->reciprocal(*interfaceScaling[j]);
-        regNspViolation[j]->elementWiseMultiply(SC_ONE, *regNspViolation[j], *inverseInterfaceScaling, SC_ZERO);
-      }
+      RCP<Vector> inverseInterfaceScaling = VectorFactory::Build(interfaceScaling->getMap(), true);
+      inverseInterfaceScaling->reciprocal(*interfaceScaling);
+      regNspViolation->elementWiseMultiply(SC_ONE, *regNspViolation, *inverseInterfaceScaling, SC_ZERO);
     }
   }
 
   tm = Teuchos::null;
   tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("MakeRegionMatrices: 3 - Replace diagonal")));
 
-  Array<RCP<Vector> > regNsp(maxRegPerProc);
-  Array<RCP<Vector> > regCorrection(maxRegPerProc);
-  for (int j = 0; j < maxRegPerProc; j++) {
-    regNsp[j] = VectorFactory::Build(revisedRowMapPerGrp[j]);
-    regNsp[j]->putScalar(SC_ONE);
+  RCP<Vector> regNsp;
+  regNsp = VectorFactory::Build(revisedRowMapPerGrp);
+  regNsp->putScalar(SC_ONE);
 
-    regCorrection[j] = VectorFactory::Build(revisedRowMapPerGrp[j], true);
-    regionGrpMats[j]->apply(*regNsp[j], *regCorrection[j]);
-    regionGrpMats[j]->SetFixedBlockSize(AComp->GetFixedBlockSize());
+  RCP<Vector> regCorrection;
+  regCorrection = VectorFactory::Build(revisedRowMapPerGrp, true);
+  regionGrpMats->apply(*regNsp, *regCorrection);
+  regionGrpMats->SetFixedBlockSize(AComp->GetFixedBlockSize());
 
-  }
 
   RCP<Vector> regDiag = Teuchos::null;
-  for (int j = 0; j < maxRegPerProc; j++) {
-    regDiag = VectorFactory::Build(revisedRowMapPerGrp[j], true);
-    regionGrpMats[j]->getLocalDiagCopy(*regDiag);
-    regDiag->update(-SC_ONE, *regCorrection[j], SC_ONE, *regNspViolation[j], SC_ONE);
+  regDiag = VectorFactory::Build(revisedRowMapPerGrp, true);
+  regionGrpMats->getLocalDiagCopy(*regDiag);
+  regDiag->update(-SC_ONE, *regCorrection, SC_ONE, *regNspViolation, SC_ONE);
 
-    // Extract current region matrix in as CrsMatrix
-    RCP<CrsMatrix> regionCrsMat = Teuchos::rcp_dynamic_cast<CrsMatrixWrap>(regionGrpMats[j])->getCrsMatrix();
-    regionCrsMat->replaceDiag(*regDiag);
-  }
+  // Extract current region matrix in as CrsMatrix
+  RCP<CrsMatrix> regionCrsMat = Teuchos::rcp_dynamic_cast<CrsMatrixWrap>(regionGrpMats)->getCrsMatrix();
+  regionCrsMat->replaceDiag(*regDiag);
 
   tm = Teuchos::null;
 } // MakeRegionMatrices
+
 
 /*! \brief Transform regional matrix to composite layout
  *
@@ -630,10 +347,10 @@ void MakeRegionMatrices(const RCP<Xpetra::CrsMatrixWrap<Scalar, LocalOrdinal, Gl
  *  \return Composite matrix that is fill-completed
  */
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-void regionalToComposite(const std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regMat, ///< Matrix in region layout [in]
-                         const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > rowMapPerGrp, ///< row maps in quasiRegion layout [in]
-                         const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > colMapPerGrp, ///< col maps in quasiRegion layout [in]
-                         const std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > rowImportPerGrp, ///< row importer in region layout [in]
+void regionalToComposite(const RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> >& regMat, ///< Matrix in region layout [in]
+                         const RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > rowMapPerGrp, ///< row maps in quasiRegion layout [in]
+                         const RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > colMapPerGrp, ///< col maps in quasiRegion layout [in]
+                         const RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > rowImportPerGrp, ///< row importer in region layout [in]
                          const Xpetra::CombineMode combineMode, ///< Combine mode for import/export [in]
                          RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> >& compMat ///< Matrix in composite layout [in/out]
                          )
@@ -642,9 +359,6 @@ void regionalToComposite(const std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdin
   using Teuchos::TimeMonitor;
   using Teuchos::rcp;
   using std::size_t;
-
-  // Get max number of regions per proc
-  const int maxRegPerProc = regMat.size();
 
   RCP<TimeMonitor> tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("regionalToComposite: Matrix")));
 
@@ -660,61 +374,55 @@ void regionalToComposite(const std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdin
    */
 
   // Copy data from regMat into quasiRegMat
-  std::vector<RCP<Matrix> > quasiRegMat(maxRegPerProc);
+  RCP<Matrix> quasiRegMat;
   {
-    for (int j = 0; j < maxRegPerProc; j++) {
-      quasiRegMat[j] = rcp(new CrsMatrixWrap(rowMapPerGrp[j],
-                                             colMapPerGrp[j],
-                                             regMat[j]->getCrsGraph()->getNodeMaxNumRowEntries()));
+    quasiRegMat = rcp(new CrsMatrixWrap(rowMapPerGrp,
+                                           colMapPerGrp,
+                                           regMat->getCrsGraph()->getNodeMaxNumRowEntries()));
 
-      // Extract current quasi-region CrsMatrix
-      RCP<CrsMatrix> quasiRegionCrsMat = Teuchos::rcp_dynamic_cast<CrsMatrixWrap>(quasiRegMat[j])->getCrsMatrix();
+    // Extract current quasi-region CrsMatrix
+    RCP<CrsMatrix> quasiRegionCrsMat = Teuchos::rcp_dynamic_cast<CrsMatrixWrap>(quasiRegMat)->getCrsMatrix();
 
-      // Extract current region CrsMatrix
-      RCP<CrsMatrix> regionCrsMat = Teuchos::rcp_dynamic_cast<CrsMatrixWrap>(regMat[j])->getCrsMatrix();
+    // Extract current region CrsMatrix
+    RCP<CrsMatrix> regionCrsMat = Teuchos::rcp_dynamic_cast<CrsMatrixWrap>(regMat)->getCrsMatrix();
 
-      // Pull out the data from the region CrsMatrix
-      Teuchos::ArrayRCP<const size_t> rowptrRegion;
-      Teuchos::ArrayRCP<const LocalOrdinal> colindRegion;
-      Teuchos::ArrayRCP<const Scalar> valuesRegion;
-      regionCrsMat->getAllValues(rowptrRegion, colindRegion, valuesRegion);
+    // Pull out the data from the region CrsMatrix
+    Teuchos::ArrayRCP<const size_t> rowptrRegion;
+    Teuchos::ArrayRCP<const LocalOrdinal> colindRegion;
+    Teuchos::ArrayRCP<const Scalar> valuesRegion;
+    regionCrsMat->getAllValues(rowptrRegion, colindRegion, valuesRegion);
 
-      // Do a deep copy of values
-      // (at least we've been doing deep copies so far, maybe we could do shallow copies to save time?)
-      Teuchos::ArrayRCP<size_t> rowptrQuasiRegion(rowptrRegion.size());
-      Teuchos::ArrayRCP<LocalOrdinal> colindQuasiRegion(colindRegion.size());
-      Teuchos::ArrayRCP<Scalar> valuesQuasiRegion(valuesRegion.size());
+    // Do a deep copy of values
+    // (at least we've been doing deep copies so far, maybe we could do shallow copies to save time?)
+    Teuchos::ArrayRCP<size_t> rowptrQuasiRegion(rowptrRegion.size());
+    Teuchos::ArrayRCP<LocalOrdinal> colindQuasiRegion(colindRegion.size());
+    Teuchos::ArrayRCP<Scalar> valuesQuasiRegion(valuesRegion.size());
 
-      quasiRegionCrsMat->allocateAllValues(valuesQuasiRegion.size(), rowptrQuasiRegion, colindQuasiRegion, valuesQuasiRegion);
+    quasiRegionCrsMat->allocateAllValues(valuesQuasiRegion.size(), rowptrQuasiRegion, colindQuasiRegion, valuesQuasiRegion);
 
-      for(LocalOrdinal idx = 0; idx < static_cast<LocalOrdinal>(rowptrQuasiRegion.size()); ++idx) {
-        rowptrQuasiRegion[idx] = rowptrRegion[idx];
-      }
-
-      for(LocalOrdinal idx = 0; idx < static_cast<LocalOrdinal>(colindQuasiRegion.size()); ++idx) {
-        colindQuasiRegion[idx] = colindRegion[idx];
-        valuesQuasiRegion[idx] = valuesRegion[idx];
-      }
-
-      // Set and fillComplete the quasiRegion CrsMatrix
-      quasiRegionCrsMat->setAllValues(rowptrQuasiRegion, colindQuasiRegion, valuesQuasiRegion);
-      quasiRegionCrsMat->expertStaticFillComplete(rowMapPerGrp[j], rowMapPerGrp[j]);
+    for(LocalOrdinal idx = 0; idx < static_cast<LocalOrdinal>(rowptrQuasiRegion.size()); ++idx) {
+      rowptrQuasiRegion[idx] = rowptrRegion[idx];
     }
+
+    for(LocalOrdinal idx = 0; idx < static_cast<LocalOrdinal>(colindQuasiRegion.size()); ++idx) {
+      colindQuasiRegion[idx] = colindRegion[idx];
+      valuesQuasiRegion[idx] = valuesRegion[idx];
+    }
+
+    // Set and fillComplete the quasiRegion CrsMatrix
+    quasiRegionCrsMat->setAllValues(rowptrQuasiRegion, colindQuasiRegion, valuesQuasiRegion);
+    quasiRegionCrsMat->expertStaticFillComplete(rowMapPerGrp, rowMapPerGrp);
   }
 
   // Export from quasiRegional format to composite layout
-  std::vector<RCP<Matrix> > partialCompMat(maxRegPerProc);
-  for (int j = 0; j < maxRegPerProc; j++) {
-    partialCompMat[j] = MatrixFactory::Build(compMat->getRowMap(),
-                                             8*regMat[0]->getCrsGraph()->getNodeMaxNumRowEntries());
-    partialCompMat[j]->doExport(*(quasiRegMat[j]), *(rowImportPerGrp[j]), Xpetra::INSERT);
-    partialCompMat[j]->fillComplete();
-  }
+  RCP<Matrix> partialCompMat;
+  partialCompMat = MatrixFactory::Build(compMat->getRowMap(),
+                                           8*regMat->getCrsGraph()->getNodeMaxNumRowEntries());
+  partialCompMat->doExport(*(quasiRegMat), *(rowImportPerGrp), Xpetra::INSERT);
+  partialCompMat->fillComplete();
 
   // Add all partialCompMat together
-  for (int j = 0; j < maxRegPerProc; j++) {
-    MatrixMatrix::TwoMatrixAdd(*partialCompMat[j], false, SC_ONE, *compMat, SC_ONE);
-  }
+  MatrixMatrix::TwoMatrixAdd(*partialCompMat, false, SC_ONE, *compMat, SC_ONE);
 
   compMat->fillComplete();
 
@@ -728,8 +436,8 @@ void regionalToComposite(const std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdin
 template <class LocalOrdinal, class GlobalOrdinal, class Node>
 void SetupMatVec(const Teuchos::RCP<Xpetra::MultiVector<GlobalOrdinal, LocalOrdinal, GlobalOrdinal, Node> >& interfaceGIDsMV,
                  const Teuchos::RCP<Xpetra::MultiVector<LocalOrdinal, LocalOrdinal, GlobalOrdinal, Node> >& regionsPerGIDWithGhosts,
-                 const std::vector<Teuchos::RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& regionRowMap,
-                 const std::vector<Teuchos::RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > >& rowImportPerGrp,
+                 const Teuchos::RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> >& regionRowMap,
+                 const Teuchos::RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> >& rowImportPerGrp,
                  Teuchos::ArrayRCP<LocalOrdinal>& regionMatVecLIDs,
                  Teuchos::RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> >& regionInterfaceImporter) {
 #include "Xpetra_UseShortNamesOrdinal.hpp"
@@ -738,12 +446,11 @@ void SetupMatVec(const Teuchos::RCP<Xpetra::MultiVector<GlobalOrdinal, LocalOrdi
   RCP<TimeMonitor> tm;
   tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("SetupMatVec: 1 - sumInterfaceValues")));
 
-  const LO  maxRegPerProc = static_cast<LO>(regionRowMap.size());
   const LO  maxRegPerGID  = static_cast<LO>(regionsPerGIDWithGhosts->getNumVectors());
-  const int myRank        = regionRowMap[0]->getComm()->getRank();
-  interfaceGIDsMV->replaceMap(regionRowMap[0]);
-  Array<RCP<Xpetra::MultiVector<GO, LO, GO, NO> > > interfaceGIDsPerGrp(maxRegPerProc);
-  interfaceGIDsPerGrp[0] = interfaceGIDsMV;
+  const int myRank        = regionRowMap->getComm()->getRank();
+  interfaceGIDsMV->replaceMap(regionRowMap);
+  RCP<Xpetra::MultiVector<GO, LO, GO, NO> > interfaceGIDsPerGrp;
+  interfaceGIDsPerGrp = interfaceGIDsMV;
   sumInterfaceValues(interfaceGIDsPerGrp, regionRowMap, rowImportPerGrp);
 
   tm = Teuchos::null;
@@ -755,7 +462,7 @@ void SetupMatVec(const Teuchos::RCP<Xpetra::MultiVector<GlobalOrdinal, LocalOrdi
   Array<ArrayRCP<const GO> > interfaceGIDsData(maxRegPerGID);
   for(LO regionIdx = 0; regionIdx < maxRegPerGID; ++regionIdx) {
     regionsPerGIDWithGhostsData[regionIdx] = regionsPerGIDWithGhosts->getData(regionIdx);
-    interfaceGIDsData[regionIdx] = interfaceGIDsPerGrp[0]->getData(regionIdx);
+    interfaceGIDsData[regionIdx] = interfaceGIDsPerGrp->getData(regionIdx);
     for(LO idx = 0; idx < static_cast<LO>(regionsPerGIDWithGhostsData[regionIdx].size()); ++idx) {
       if((regionsPerGIDWithGhostsData[regionIdx][idx] != -1)
          && (regionsPerGIDWithGhostsData[regionIdx][idx] != myRank)) {
@@ -769,16 +476,16 @@ void SetupMatVec(const Teuchos::RCP<Xpetra::MultiVector<GlobalOrdinal, LocalOrdi
   // so we can store it and retrieve it easily later on.
   regionMatVecLIDs.deepCopy(regionMatVecLIDstmp());
 
-  RCP<Map> regionInterfaceMap = Xpetra::MapFactory<LO,GO,Node>::Build(regionRowMap[0]->lib(),
+  RCP<Map> regionInterfaceMap = Xpetra::MapFactory<LO,GO,Node>::Build(regionRowMap->lib(),
                                                                       Teuchos::OrdinalTraits<GO>::invalid(),
                                                                       regionMatVecGIDs(),
-                                                                      regionRowMap[0]->getIndexBase(),
-                                                                      regionRowMap[0]->getComm());
+                                                                      regionRowMap->getIndexBase(),
+                                                                      regionRowMap->getComm());
 
   tm = Teuchos::null;
   tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("SetupMatVec: 3 - Build importer")));
 
-  regionInterfaceImporter = ImportFactory::Build(regionRowMap[0], regionInterfaceMap);
+  regionInterfaceImporter = ImportFactory::Build(regionRowMap, regionInterfaceMap);
 
   tm = Teuchos::null;
 } // SetupMatVec
@@ -845,6 +552,7 @@ void ApplyMatVec(const Scalar alpha,
   tm = Teuchos::null;
 } // ApplyMatVec
 
+
 /*! \brief Compute the residual \f$r = b - Ax\f$ with pre-computed communication patterns
  *
  *  The residual is computed based on matrices and vectors in a regional layout.
@@ -853,18 +561,16 @@ void ApplyMatVec(const Scalar alpha,
  */
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void
-computeResidual(Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regRes, ///< residual (to be evaluated)
-                const Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regX, ///< left-hand side (solution)
-                const Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regB, ///< right-hand side (forcing term)
-                const std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regionGrpMats, ///< matrix in region format
+computeResidual(RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> >& regRes, ///< residual (to be evaluated)
+                const RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > regX, ///< left-hand side (solution)
+                const RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > regB, ///< right-hand side (forcing term)
+                const RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > regionGrpMats, ///< matrix in region format
                 const Teuchos::ParameterList& params ///< parameter with fast MatVec parameters and pre-computed communication patterns
     )
 {
 #include "Xpetra_UseShortNames.hpp"
   using TST = Teuchos::ScalarTraits<Scalar>;
   using Teuchos::TimeMonitor;
-
-  TEUCHOS_TEST_FOR_EXCEPT_MSG(regX.size()>1, "Fast MatVec only implemented for one region per group.");
 
   RCP<TimeMonitor> tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("computeResidual: use fast MatVec")));
 
@@ -873,12 +579,12 @@ computeResidual(Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, No
   const RCP<Import> regionInterfaceImporter = params.get<RCP<Import>>("Fast MatVec: interface importer");
 
   // Step 1: Compute region version of y = Ax
-  RCP<Vector> aTimesX = VectorFactory::Build(regionGrpMats[0]->getRangeMap(), true);
-  ApplyMatVec(TST::one(), regionGrpMats[0], regX[0],
+  RCP<Vector> aTimesX = VectorFactory::Build(regionGrpMats->getRangeMap(), true);
+  ApplyMatVec(TST::one(), regionGrpMats, regX,
       TST::zero(), regionInterfaceImporter, regionInterfaceLIDs, aTimesX, Teuchos::NO_TRANS, true);
 
   // Step 2: Compute region version of r = b - y
-  regRes[0]->update(TST::one(), *regB[0], -TST::one(), *aTimesX, TST::zero());
+  regRes->update(TST::one(), *regB, -TST::one(), *aTimesX, TST::zero());
 
   tm = Teuchos::null;
 } // computeResidual

--- a/packages/muelu/research/regionMG/src/SetupRegionUtilities.hpp
+++ b/packages/muelu/research/regionMG/src/SetupRegionUtilities.hpp
@@ -1178,13 +1178,13 @@ refert to interface DOFs, so we can grab them and stick them into the list of \c
 */
 template <class LocalOrdinal, class GlobalOrdinal, class Node>
 void ExtractListOfInterfaceRegionGIDs(
-    std::vector<Teuchos::RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& regionRowMap,
+    Teuchos::RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > & regionRowMap,
     const Teuchos::Array<LocalOrdinal>& interfaceRegionLIDs, Teuchos::Array<GlobalOrdinal>& interfaceRegionGIDs)
 {
   interfaceRegionGIDs.resize(interfaceRegionLIDs.size());
   for(LocalOrdinal interfaceIdx = 0; interfaceIdx < static_cast<LocalOrdinal>(interfaceRegionLIDs.size()); ++interfaceIdx) {
     interfaceRegionGIDs[interfaceIdx] =
-      regionRowMap[0]->getGlobalElement(interfaceRegionLIDs[interfaceIdx]);
+      regionRowMap->getGlobalElement(interfaceRegionLIDs[interfaceIdx]);
   }
 } // ExtractListOfInterfaceRegionGIDs
 

--- a/packages/muelu/research/regionMG/src/SetupRegionVector_def.hpp
+++ b/packages/muelu/research/regionMG/src/SetupRegionVector_def.hpp
@@ -66,23 +66,6 @@ using Teuchos::RCP;
 using Teuchos::ArrayRCP;
 using Teuchos::Array;
 
-//! Create an empty vector in the regional layout
-template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-void createRegionalVector(Teuchos::Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regVecs, ///< regional vector to be filled
-                          const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > revisedRowMapPerGrp ///< regional map
-                          )
-{
-#include "Xpetra_UseShortNames.hpp"
-
-  // Get max number of regions per process
-  const int maxRegPerProc = revisedRowMapPerGrp.size();
-
-  regVecs.resize(maxRegPerProc);
-  for (int j = 0; j < maxRegPerProc; j++)
-    regVecs[j] = VectorFactory::Build(revisedRowMapPerGrp[j], true);
-
-  return;
-} // createRegionalVector
 
 /*! \brief Transform composite vector to regional layout
  *
@@ -92,35 +75,29 @@ void createRegionalVector(Teuchos::Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal
  */
 template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void compositeToRegional(RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > compVec, ///< Vector in composite layout [in]
-                         Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& quasiRegVecs, ///< Vector in quasiRegional layout [in/out]
-                         Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regVecs, ///< Vector in regional layout [in/out]
-                         const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > revisedRowMapPerGrp, ///< revised row maps in region layout [in]
-                         const std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > rowImportPerGrp ///< row importer in region layout [in]
+                         RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> >& quasiRegVecs, ///< Vector in quasiRegional layout [in/out]
+                         RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> >& regVecs, ///< Vector in regional layout [in/out]
+                         const RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > revisedRowMapPerGrp, ///< revised row maps in region layout [in]
+                         const RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > rowImportPerGrp ///< row importer in region layout [in]
                          )
 {
 #include "Xpetra_UseShortNames.hpp"
 
-  // Get max number of regions per proc
-  const int maxRegPerProc = regVecs.size();
-
   // quasiRegional layout
-  for (int grpIdx = 0; grpIdx < maxRegPerProc; ++grpIdx) {
-    // create empty vectors and fill it by extracting data from composite vector
-    quasiRegVecs[grpIdx] = VectorFactory::Build(rowImportPerGrp[grpIdx]->getTargetMap(), true);
-    TEUCHOS_ASSERT(!quasiRegVecs[grpIdx].is_null());
-    quasiRegVecs[grpIdx]->doImport(*compVec, *(rowImportPerGrp[grpIdx]), Xpetra::INSERT);
-  }
+  // create empty vectors and fill it by extracting data from composite vector
+  quasiRegVecs = VectorFactory::Build(rowImportPerGrp->getTargetMap(), true);
+  TEUCHOS_ASSERT(!quasiRegVecs.is_null());
+  quasiRegVecs->doImport(*compVec, *(rowImportPerGrp), Xpetra::INSERT);
 
   // regional layout
-  for (int j = 0; j < maxRegPerProc; j++) {
-    // create regVecs vector (copy from quasiRegVecs and swap the map)
-    regVecs[j] = quasiRegVecs[j]; // assignment operator= does deep copy in Xpetra
-    TEUCHOS_ASSERT(!regVecs[j].is_null());
-    regVecs[j]->replaceMap(revisedRowMapPerGrp[j]);
-  }
+  // create regVecs vector (copy from quasiRegVecs and swap the map)
+  regVecs = quasiRegVecs; // assignment operator= does deep copy in Xpetra
+  TEUCHOS_ASSERT(!regVecs.is_null());
+  regVecs->replaceMap(revisedRowMapPerGrp);
 
   return;
 } // compositeToRegional
+
 
 /*! \brief Transform composite vector to regional layout
  *
@@ -130,35 +107,29 @@ void compositeToRegional(RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal,
  */
 template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void compositeToRegional(RCP<Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > compVec, ///< Vector in composite layout [in]
-                         Array<RCP<Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& quasiRegVecs, ///< Vector in quasiRegional layout [in/out]
-                         Array<RCP<Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regVecs, ///< Vector in regional layout [in/out]
-                         const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > revisedRowMapPerGrp, ///< revised row maps in region layout [in]
-                         const std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > rowImportPerGrp ///< row importer in region layout [in]
+                         RCP<Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> >& quasiRegVecs, ///< Vector in quasiRegional layout [in/out]
+                         RCP<Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> >& regVecs, ///< Vector in regional layout [in/out]
+                         const RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > revisedRowMapPerGrp, ///< revised row maps in region layout [in]
+                         const RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > rowImportPerGrp ///< row importer in region layout [in]
                          )
 {
 #include "Xpetra_UseShortNames.hpp"
 
-  // Get max number of regions per proc
-  const int maxRegPerProc = regVecs.size();
-
   // quasiRegional layout
-  for (int grpIdx = 0; grpIdx < maxRegPerProc; ++grpIdx) {
-    // create empty vectors and fill it by extracting data from composite vector
-    quasiRegVecs[grpIdx] = MultiVectorFactory::Build(rowImportPerGrp[grpIdx]->getTargetMap(), compVec->getNumVectors(), true);
-    TEUCHOS_ASSERT(!quasiRegVecs[grpIdx].is_null());
-    quasiRegVecs[grpIdx]->doImport(*compVec, *(rowImportPerGrp[grpIdx]), Xpetra::INSERT);
-  }
+  // create empty vectors and fill it by extracting data from composite vector
+  quasiRegVecs = MultiVectorFactory::Build(rowImportPerGrp->getTargetMap(), compVec->getNumVectors(), true);
+  TEUCHOS_ASSERT(!quasiRegVecs.is_null());
+  quasiRegVecs->doImport(*compVec, *(rowImportPerGrp), Xpetra::INSERT);
 
   // regional layout
-  for (int j = 0; j < maxRegPerProc; j++) {
-    // create regVecs vector (copy from quasiRegVecs and swap the map)
-    regVecs[j] = quasiRegVecs[j]; // assignment operator= does deep copy in Xpetra
-    TEUCHOS_ASSERT(!regVecs[j].is_null());
-    regVecs[j]->replaceMap(revisedRowMapPerGrp[j]);
-  }
+  // create regVecs vector (copy from quasiRegVecs and swap the map)
+  regVecs = quasiRegVecs; // assignment operator= does deep copy in Xpetra
+  TEUCHOS_ASSERT(!regVecs.is_null());
+  regVecs->replaceMap(revisedRowMapPerGrp);
 
   return;
 } // compositeToRegional
+
 
 /*! \brief Transform regional vector to composite layout
  *
@@ -171,9 +142,9 @@ void compositeToRegional(RCP<Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrd
  *  available CombineMode options in Xpetra/Tpetra, so we use a manual implementation here.
  */
 template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-void regionalToComposite(const Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regVec, ///< Vector in region layout [in]
+void regionalToComposite(const RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> >& regVec, ///< Vector in region layout [in]
                          RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > compVec, ///< Vector in composite layout [in/out]
-                         const std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > rowImportPerGrp ///< row importer in region layout [in]
+                         const RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > rowImportPerGrp ///< row importer in region layout [in]
                          )
 {
   /* Let's fake an ADD combine mode that also adds local values by
@@ -182,9 +153,6 @@ void regionalToComposite(const Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, Gl
    */
 #include "Xpetra_UseShortNames.hpp"
   using Teuchos::TimeMonitor;
-
-  // Get max number of regions per proc
-  const int maxRegPerProc = regVec.size();
 
   RCP<TimeMonitor> tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("regionalToComposite: 1 - compVec setup")));
 
@@ -197,19 +165,18 @@ void regionalToComposite(const Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, Gl
 
   {
     RCP<Vector> quasiRegVec;
-    for(int grpIdx = 0; grpIdx < maxRegPerProc; ++grpIdx) {
       tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("regionalToComposite: 2 - quasiRegVec")));
-      quasiRegVec = regVec[grpIdx];
+      quasiRegVec = regVec;
       TEUCHOS_ASSERT(Teuchos::nonnull(quasiRegVec));
-      quasiRegVec->replaceMap(rowImportPerGrp[grpIdx]->getTargetMap());
+      quasiRegVec->replaceMap(rowImportPerGrp->getTargetMap());
 
       tm = Teuchos::null;
       tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("regionalToComposite: 3 - partialCompVec")));
 
-      RCP<Vector> partialCompVec = VectorFactory::Build(rowImportPerGrp[0]->getSourceMap(), true);
+      RCP<Vector> partialCompVec = VectorFactory::Build(rowImportPerGrp->getSourceMap(), true);
       TEUCHOS_ASSERT(Teuchos::nonnull(partialCompVec));
       TEUCHOS_ASSERT(partialCompVec->getLocalLength() == compVecLocalLength);
-      partialCompVec->doExport(*quasiRegVec, *(rowImportPerGrp[grpIdx]), Xpetra::ADD);
+      partialCompVec->doExport(*quasiRegVec, *(rowImportPerGrp), Xpetra::ADD);
 
       tm = Teuchos::null;
       tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("regionalToComposite: 4 - compVec->sumIntoLocalValue")));
@@ -221,11 +188,11 @@ void regionalToComposite(const Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, Gl
       }
 
       tm = Teuchos::null;
-    }
   }
 
   return;
 } // regionalToComposite
+
 
 /*! \brief Transform regional vector to composite layout
  *
@@ -238,9 +205,9 @@ void regionalToComposite(const Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, Gl
  *  available CombineMode options in Xpetra/Tpetra, so we use a manual implementation here.
  */
 template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-void regionalToComposite(const Array<RCP<Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regVec, ///< Vector in region layout [in]
+void regionalToComposite(const RCP<Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> >& regVec, ///< Vector in region layout [in]
                          RCP<Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > compVec, ///< Vector in composite layout [in/out]
-                         const std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > rowImportPerGrp ///< row importer in region layout [in]
+                         const RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > rowImportPerGrp ///< row importer in region layout [in]
                          )
 {
   /* Let's fake an ADD combine mode that also adds local values by
@@ -249,9 +216,6 @@ void regionalToComposite(const Array<RCP<Xpetra::MultiVector<Scalar, LocalOrdina
    */
 #include "Xpetra_UseShortNames.hpp"
   using Teuchos::TimeMonitor;
-
-  // Get max number of regions per proc
-  const int maxRegPerProc = regVec.size();
 
   RCP<TimeMonitor> tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("regionalToComposite: 1 - compVec setup")));
 
@@ -264,38 +228,37 @@ void regionalToComposite(const Array<RCP<Xpetra::MultiVector<Scalar, LocalOrdina
 
   {
     RCP<MultiVector> quasiRegVec;
-    for(int grpIdx = 0; grpIdx < maxRegPerProc; ++grpIdx) {
-      tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("regionalToComposite: 2 - quasiRegVec")));
-      quasiRegVec = regVec[grpIdx];
-      TEUCHOS_ASSERT(Teuchos::nonnull(quasiRegVec));
-      quasiRegVec->replaceMap(rowImportPerGrp[grpIdx]->getTargetMap());
+    tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("regionalToComposite: 2 - quasiRegVec")));
+    quasiRegVec = regVec;
+    TEUCHOS_ASSERT(Teuchos::nonnull(quasiRegVec));
+    quasiRegVec->replaceMap(rowImportPerGrp->getTargetMap());
 
-      tm = Teuchos::null;
-      tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("regionalToComposite: 3 - partialCompVec")));
+    tm = Teuchos::null;
+    tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("regionalToComposite: 3 - partialCompVec")));
 
-      RCP<MultiVector> partialCompVec
-        = MultiVectorFactory::Build(rowImportPerGrp[0]->getSourceMap(), quasiRegVec->getNumVectors(), true);
-      TEUCHOS_ASSERT(Teuchos::nonnull(partialCompVec));
-      TEUCHOS_ASSERT(partialCompVec->getLocalLength() == compVecLocalLength);
-      partialCompVec->doExport(*quasiRegVec, *(rowImportPerGrp[grpIdx]), Xpetra::ADD);
+    RCP<MultiVector> partialCompVec
+      = MultiVectorFactory::Build(rowImportPerGrp->getSourceMap(), quasiRegVec->getNumVectors(), true);
+    TEUCHOS_ASSERT(Teuchos::nonnull(partialCompVec));
+    TEUCHOS_ASSERT(partialCompVec->getLocalLength() == compVecLocalLength);
+    partialCompVec->doExport(*quasiRegVec, *(rowImportPerGrp), Xpetra::ADD);
 
-      tm = Teuchos::null;
-      tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("regionalToComposite: 4 - compVec->sumIntoLocalValue")));
+    tm = Teuchos::null;
+    tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("regionalToComposite: 4 - compVec->sumIntoLocalValue")));
 
-      for(LO vecIdx = 0; vecIdx < static_cast<LO>(partialCompVec->getNumVectors()); ++vecIdx) {
-        ArrayRCP<const SC> partialCompVecData = partialCompVec->getData(vecIdx);
-        ArrayRCP<SC>       compVecData        = compVec->getDataNonConst(vecIdx);
-        for(size_t entryIdx = 0; entryIdx < compVecLocalLength; ++entryIdx) {
-          compVecData[entryIdx] += partialCompVecData[entryIdx];
-        }
+    for(LO vecIdx = 0; vecIdx < static_cast<LO>(partialCompVec->getNumVectors()); ++vecIdx) {
+      ArrayRCP<const SC> partialCompVecData = partialCompVec->getData(vecIdx);
+      ArrayRCP<SC>       compVecData        = compVec->getDataNonConst(vecIdx);
+      for(size_t entryIdx = 0; entryIdx < compVecLocalLength; ++entryIdx) {
+        compVecData[entryIdx] += partialCompVecData[entryIdx];
       }
-
-      tm = Teuchos::null;
     }
+
+    tm = Teuchos::null;
   }
 
   return;
 } // regionalToComposite
+
 
 /*! \brief Sum region interface values
  *
@@ -305,19 +268,16 @@ void regionalToComposite(const Array<RCP<Xpetra::MultiVector<Scalar, LocalOrdina
  *  composite layout takes care of the summation of interface values.
  */
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-void sumInterfaceValues(Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regVec,
-                        const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > revisedRowMapPerGrp,///< revised row maps in region layout [in]
-                        const std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > rowImportPerGrp ///< row importer in region layout [in])
+void sumInterfaceValues(RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> >& regVec,
+                        const RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> >  revisedRowMapPerGrp,///< revised row maps in region layout [in]
+                        const RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> >  rowImportPerGrp ///< row importer in region layout [in])
                         )
 {
 #include "Xpetra_UseShortNames.hpp"
   using Teuchos::TimeMonitor;
 
-  // Get max number of regions per proc
-  const int maxRegPerProc = regVec.size();
-
   // Composite map is the same in every group, so just take the first one.
-  const RCP<const Map> compMap = rowImportPerGrp[0]->getSourceMap();
+  const RCP<const Map> compMap = rowImportPerGrp->getSourceMap();
 
   RCP<Vector> compVec = VectorFactory::Build(compMap, true);
   TEUCHOS_ASSERT(!compVec.is_null());
@@ -328,7 +288,7 @@ void sumInterfaceValues(Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrd
   tm = Teuchos::null;
   tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("sumInterfaceValues: 2 - compositeToRegional")));
 
-  Array<Teuchos::RCP<Vector> > quasiRegVec(maxRegPerProc);
+  Teuchos::RCP<Vector> quasiRegVec;
   compositeToRegional(compVec, quasiRegVec, regVec,
                       revisedRowMapPerGrp, rowImportPerGrp);
 
@@ -336,6 +296,7 @@ void sumInterfaceValues(Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrd
 
   return;
 } // sumInterfaceValues
+
 
 /*! \brief Sum region interface values
  *
@@ -345,21 +306,18 @@ void sumInterfaceValues(Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrd
  *  composite layout takes care of the summation of interface values.
  */
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-void sumInterfaceValues(Array<RCP<Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regVec,
-                        const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > revisedRowMapPerGrp,///< revised row maps in region layout [in]
-                        const std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > rowImportPerGrp ///< row importer in region layout [in])
+void sumInterfaceValues(RCP<Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> >& regVec,
+                        const RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > revisedRowMapPerGrp,///< revised row maps in region layout [in]
+                        const RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > rowImportPerGrp ///< row importer in region layout [in])
                         )
 {
 #include "Xpetra_UseShortNames.hpp"
   using Teuchos::TimeMonitor;
 
-  // Get max number of regions per proc
-  const int maxRegPerProc = regVec.size();
-
   // Composite map is the same in every group, so just take the first one.
-  const RCP<const Map> compMap = rowImportPerGrp[0]->getSourceMap();
+  const RCP<const Map> compMap = rowImportPerGrp->getSourceMap();
 
-  RCP<MultiVector> compVec = MultiVectorFactory::Build(compMap, regVec[0]->getNumVectors(), true);
+  RCP<MultiVector> compVec = MultiVectorFactory::Build(compMap, regVec->getNumVectors(), true);
   TEUCHOS_ASSERT(!compVec.is_null());
 
   RCP<TimeMonitor> tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("sumInterfaceValues: 1 - regionalToComposite")));
@@ -368,7 +326,7 @@ void sumInterfaceValues(Array<RCP<Xpetra::MultiVector<Scalar, LocalOrdinal, Glob
   tm = Teuchos::null;
   tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("sumInterfaceValues: 2 - compositeToRegional")));
 
-  Array<Teuchos::RCP<MultiVector> > quasiRegVec(maxRegPerProc);
+  Teuchos::RCP<MultiVector> quasiRegVec;
   compositeToRegional(compVec, quasiRegVec, regVec,
                       revisedRowMapPerGrp, rowImportPerGrp);
 
@@ -387,8 +345,8 @@ void sumInterfaceValues(Array<RCP<Xpetra::MultiVector<Scalar, LocalOrdinal, Glob
  * This can be achieved by setting \c inverseScaling to \c true.
  */
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-void scaleInterfaceDOFs(Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regVec, ///< Vector to be scaled
-                        const Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& scalingFactors, ///< Vector with scaling factors
+void scaleInterfaceDOFs(RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> >& regVec, ///< Vector to be scaled
+                        const RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> >& scalingFactors, ///< Vector with scaling factors
                         bool inverseScaling ///< Divide by scaling factors (yes/no?)
                         )
 {
@@ -398,19 +356,16 @@ void scaleInterfaceDOFs(Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrd
   const Scalar zero = Teuchos::ScalarTraits<Scalar>::zero();
   const Scalar one = Teuchos::ScalarTraits<Scalar>::one();
 
-  for (int j = 0; j < regVec.size(); j++)
+  if (inverseScaling)
   {
-    if (inverseScaling)
-    {
-      RCP<Vector> inverseScalingFactors = VectorFactory::Build(scalingFactors[j]->getMap());
-      inverseScalingFactors->reciprocal(*scalingFactors[j]);
-      regVec[j]->elementWiseMultiply(one, *regVec[j], *inverseScalingFactors, zero);
-    }
-    else
-    {
-      regVec[j]->elementWiseMultiply(one, *regVec[j], *scalingFactors[j], zero);
-    }
+    RCP<Vector> inverseScalingFactors = VectorFactory::Build(scalingFactors->getMap());
+    inverseScalingFactors->reciprocal(*scalingFactors);
+    regVec->elementWiseMultiply(one, *regVec, *inverseScalingFactors, zero);
   }
-}
+  else
+  {
+    regVec->elementWiseMultiply(one, *regVec, *scalingFactors, zero);
+  }
+}// scaleInterfaceDOFs
 
 #endif // MUELU_SETUPREGIONVECTOR_DEF_HPP

--- a/packages/muelu/research/regionMG/test/structured/Driver_Structured_Regions.cpp
+++ b/packages/muelu/research/regionMG/test/structured/Driver_Structured_Regions.cpp
@@ -222,7 +222,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
     Teuchos::updateParametersFromXmlFileAndBroadcast(xmlFileName, Teuchos::Ptr<ParameterList>(&paramList), *comm);
   }
 
-  Array<RCP<Teuchos::ParameterList> > smootherParams(1);
+  Array<RCP<Teuchos::ParameterList> > smootherParams(1); //TODO: this is good, resized to numlevel
   smootherParams[0] = rcp(new Teuchos::ParameterList());
   smootherParams[0]->set("smoother: type",    smootherType);
   smootherParams[0]->set("smoother: sweeps",  smootherIts);
@@ -382,12 +382,12 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
   tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("Driver: 2 - Compute region data")));
 
   // Set aggregation type for each region
-  Array<std::string> aggregationRegionType(1);
+  std::string aggregationRegionType;
   RCP<ParameterList> interfaceParams = rcp(new ParameterList());
   if(useUnstructured) {
-    aggregationRegionType[0] = "uncoupled";
+    aggregationRegionType = "uncoupled";
   } else {
-    aggregationRegionType[0] = "structured";
+    aggregationRegionType = "structured";
   }
 
   // Loading geometric info from galeri
@@ -539,21 +539,20 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
 
   RCP<TimeMonitor> tmLocal = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("Driver: 3.1 - Build Region Maps")));
 
-  const int maxRegPerProc = 1;
-  std::vector<Teuchos::RCP<Xpetra::Map<LO,GO,NO> > > rowMapPerGrp(maxRegPerProc), colMapPerGrp(maxRegPerProc);
-  std::vector<Teuchos::RCP<Xpetra::Map<LO,GO,NO> > > revisedRowMapPerGrp(maxRegPerProc), revisedColMapPerGrp(maxRegPerProc);
-  rowMapPerGrp[0] = Xpetra::MapFactory<LO,GO,Node>::Build(dofMap->lib(),
+  Teuchos::RCP<Xpetra::Map<LO,GO,NO> > rowMapPerGrp, colMapPerGrp;
+  Teuchos::RCP<Xpetra::Map<LO,GO,NO> > revisedRowMapPerGrp, revisedColMapPerGrp;
+  rowMapPerGrp = Xpetra::MapFactory<LO,GO,Node>::Build(dofMap->lib(),
                                                           Teuchos::OrdinalTraits<GO>::invalid(),
                                                           quasiRegionGIDs(),
                                                           dofMap->getIndexBase(),
                                                           dofMap->getComm());
-  colMapPerGrp[0] = rowMapPerGrp[0];
-  revisedRowMapPerGrp[0] = Xpetra::MapFactory<LO,GO,Node>::Build(dofMap->lib(),
+  colMapPerGrp = rowMapPerGrp;
+  revisedRowMapPerGrp = Xpetra::MapFactory<LO,GO,Node>::Build(dofMap->lib(),
                                                                  Teuchos::OrdinalTraits<GO>::invalid(),
                                                                  numLocalRegionNodes*numDofsPerNode,
                                                                  dofMap->getIndexBase(),
                                                                  dofMap->getComm());
-  revisedColMapPerGrp[0] = revisedRowMapPerGrp[0];
+  revisedColMapPerGrp = revisedRowMapPerGrp;
 
   // Build objects needed to construct the region coordinates
   Teuchos::RCP<Xpetra::Map<LO,GO,NO> > quasiRegCoordMap = Xpetra::MapFactory<LO,GO,Node>::
@@ -574,10 +573,10 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
   tmLocal = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("Driver: 3.2 - Build Region Importers")));
 
   // Setup importers
-  std::vector<RCP<Import> > rowImportPerGrp(maxRegPerProc);
-  std::vector<RCP<Import> > colImportPerGrp(maxRegPerProc);
-  rowImportPerGrp[0] = ImportFactory::Build(dofMap, rowMapPerGrp[0]);
-  colImportPerGrp[0] = ImportFactory::Build(dofMap, colMapPerGrp[0]);
+  RCP<Import> rowImportPerGrp;
+  RCP<Import> colImportPerGrp;
+  rowImportPerGrp = ImportFactory::Build(dofMap, rowMapPerGrp);
+  colImportPerGrp = ImportFactory::Build(dofMap, colMapPerGrp);
   RCP<Import> coordImporter = ImportFactory::Build(nodeMap, quasiRegCoordMap);
 
   comm->barrier();
@@ -589,7 +588,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
 
   RCP<Xpetra::MultiVector<LO, LO, GO, NO> > regionsPerGIDWithGhosts;
   RCP<Xpetra::MultiVector<GO, LO, GO, NO> > interfaceGIDsMV;
-  MakeRegionPerGIDWithGhosts(nodeMap, revisedRowMapPerGrp[0], rowImportPerGrp[0],
+  MakeRegionPerGIDWithGhosts(nodeMap, revisedRowMapPerGrp, rowImportPerGrp,
                              maxRegPerGID, numDofsPerNode,
                              lNodesPerDim, sendGIDs, sendPIDs, interfaceLIDsData,
                              regionsPerGIDWithGhosts, interfaceGIDsMV);
@@ -603,8 +602,8 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
   tmLocal = Teuchos::null;
   tmLocal = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("Driver: 3.4 - Build QuasiRegion Matrix")));
 
-  std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > quasiRegionGrpMats(1);
-  MakeQuasiregionMatrices(Teuchos::rcp_dynamic_cast<CrsMatrixWrap>(A), maxRegPerProc,
+  RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > quasiRegionGrpMats;
+  MakeQuasiregionMatrices(Teuchos::rcp_dynamic_cast<CrsMatrixWrap>(A),
                           regionsPerGIDWithGhosts, rowMapPerGrp, colMapPerGrp, rowImportPerGrp,
                           quasiRegionGrpMats);
 
@@ -612,10 +611,10 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
   tmLocal = Teuchos::null;
   tmLocal = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("Driver: 3.5 - Build Region Matrix")));
 
-  std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regionGrpMats(1);
+  RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > regionGrpMats;
   MakeRegionMatrices(Teuchos::rcp_dynamic_cast<CrsMatrixWrap>(A), A->getRowMap(), rowMapPerGrp,
                      revisedRowMapPerGrp, revisedColMapPerGrp,
-                     rowImportPerGrp, maxRegPerProc, quasiRegionGrpMats, regionGrpMats);
+                     rowImportPerGrp, quasiRegionGrpMats, regionGrpMats);
 
   // We don't need the composite operator on the fine level anymore. Free it!
   A = Teuchos::null;
@@ -630,23 +629,23 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
 
   // Setting up parameters before hierarchy construction
   // These need to stay in the driver as they would be provide by an app
-  Array<Array<int> > regionNodesPerDim(maxRegPerProc);
-  Array<RCP<MultiVector> > regionNullspace(maxRegPerProc);
-  Array<RCP<RealValuedMultiVector> > regionCoordinates(maxRegPerProc);
+  Array<int> regionNodesPerDim;
+  RCP<MultiVector> regionNullspace;
+  RCP<RealValuedMultiVector> regionCoordinates;
 
   // Set mesh structure data
-  regionNodesPerDim[0] = rNodesPerDim;
+  regionNodesPerDim = rNodesPerDim;
 
   // create nullspace vector
-  regionNullspace[0] = MultiVectorFactory::Build(rowMapPerGrp[0], nullspace->getNumVectors());
-  regionNullspace[0]->doImport(*nullspace, *rowImportPerGrp[0], Xpetra::INSERT);
-  regionNullspace[0]->replaceMap(revisedRowMapPerGrp[0]);
+  regionNullspace = MultiVectorFactory::Build(rowMapPerGrp, nullspace->getNumVectors());
+  regionNullspace->doImport(*nullspace, *rowImportPerGrp, Xpetra::INSERT);
+  regionNullspace->replaceMap(revisedRowMapPerGrp);
 
   // create region coordinates vector
-  regionCoordinates[0] = Xpetra::MultiVectorFactory<real_type,LO,GO,NO>::Build(quasiRegCoordMap,
+  regionCoordinates = Xpetra::MultiVectorFactory<real_type,LO,GO,NO>::Build(quasiRegCoordMap,
                                                                                coordinates->getNumVectors());
-  regionCoordinates[0]->doImport(*coordinates, *coordImporter, Xpetra::INSERT);
-  regionCoordinates[0]->replaceMap(regCoordMap);
+  regionCoordinates->doImport(*coordinates, *coordImporter, Xpetra::INSERT);
+  regionCoordinates->replaceMap(regCoordMap);
 
   using Tpetra_CrsMatrix = Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>;
   using Tpetra_MultiVector = Tpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>;
@@ -662,14 +661,15 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
    */
   Array<RCP<Xpetra::Map<LO,GO,NO> > > compRowMaps; // composite row maps on each level
   Array<RCP<Xpetra::Map<LO,GO,NO> > > compColMaps; // composite columns maps on each level
-  Array<std::vector<RCP<Xpetra::Map<LO,GO,NO> > > > regRowMaps; // regional row maps on each level
-  Array<std::vector<RCP<Xpetra::Map<LO,GO,NO> > > > regColMaps; // regional column maps on each level
-  Array<std::vector<RCP<Xpetra::Map<LO,GO,NO> > > > quasiRegRowMaps; // quasiRegional row maps on each level
-  Array<std::vector<RCP<Xpetra::Map<LO,GO,NO> > > > quasiRegColMaps; // quasiRegional column maps on each level
-  Array<std::vector<RCP<Matrix> > > regMatrices; // regional matrices on each level
-  Array<std::vector<RCP<Matrix> > > regProlong; // regional prolongators on each level
-  Array<std::vector<RCP<Import> > > regRowImporters; // regional row importers on each level
-  Array<Array<RCP<Vector> > > regInterfaceScalings; // regional interface scaling factors on each level
+  Array<RCP<Xpetra::Map<LO,GO,NO> > > regRowMaps; // regional row maps on each level
+  Array<RCP<Xpetra::Map<LO,GO,NO> > > regColMaps; // regional column maps on each level
+  Array<RCP<Xpetra::Map<LO,GO,NO> > > quasiRegRowMaps; // quasiRegional row maps on each level
+  Array<RCP<Xpetra::Map<LO,GO,NO> > > quasiRegColMaps; // quasiRegional column maps on each level
+  Array<RCP<Matrix> > regMatrices; // regional matrices on each level
+  Array<RCP<Matrix> > regProlong; // regional prolongators on each level
+  Array<RCP<Import> > regRowImporters; // regional row importers on each level
+
+  Array<RCP<Vector> > regInterfaceScalings; // regional interface scaling factors on each level
   Array<RCP<Xpetra::MultiVector<GO, LO, GO, Node> > > interfaceGIDsPerLevel(1);
   Array<RCP<Xpetra::MultiVector<LO, LO, GO, Node> > > regionsPerGIDWithGhostsPerLevel(1);
   interfaceGIDsPerLevel[0] = interfaceGIDsMV;
@@ -688,8 +688,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
 
 
   // Create multigrid hierarchy
-  createRegionHierarchy(maxRegPerProc,
-                        numDimensions,
+  createRegionHierarchy(numDimensions,
                         regionNodesPerDim,
                         aggregationRegionType,
                         interfaceParams,
@@ -768,13 +767,13 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
     RCP<Vector> compRes = VectorFactory::Build(dofMap, true);
 
     // transform composite vectors to regional layout
-    Array<Teuchos::RCP<Vector> > quasiRegX(maxRegPerProc);
-    Array<Teuchos::RCP<Vector> > regX(maxRegPerProc);
+    Teuchos::RCP<Vector> quasiRegX;
+    Teuchos::RCP<Vector> regX;
     compositeToRegional(X, quasiRegX, regX,
                         revisedRowMapPerGrp, rowImportPerGrp);
 
-    Array<RCP<Vector> > quasiRegB(maxRegPerProc);
-    Array<RCP<Vector> > regB(maxRegPerProc);
+    RCP<Vector> quasiRegB;
+    RCP<Vector> regB;
     compositeToRegional(B, quasiRegB, regB,
                         revisedRowMapPerGrp, rowImportPerGrp);
 #ifdef DUMP_LOCALX_AND_A
@@ -784,20 +783,20 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
     fp = fopen(str,"w");
     fprintf(fp, "%%%%MatrixMarket matrix coordinate real general\n");
     LO numNzs = 0;
-    for (size_t kkk = 0; kkk < regionGrpMats[0]->getNodeNumRows(); kkk++) {
+    for (size_t kkk = 0; kkk < regionGrpMats->getNodeNumRows(); kkk++) {
       ArrayView<const LO> AAcols;
       ArrayView<const SC> AAvals;
-      regionGrpMats[0]->getLocalRowView(kkk, AAcols, AAvals);
+      regionGrpMats->getLocalRowView(kkk, AAcols, AAvals);
       const int *Acols    = AAcols.getRawPtr();
       const SC  *Avals = AAvals.getRawPtr();
       numNzs += AAvals.size();
     }
-    fprintf(fp, "%d %d %d\n",regionGrpMats[0]->getNodeNumRows(),regionGrpMats[0]->getNodeNumRows(),numNzs);
+    fprintf(fp, "%d %d %d\n",regionGrpMats->getNodeNumRows(),regionGrpMats->getNodeNumRows(),numNzs);
 
-    for (size_t kkk = 0; kkk < regionGrpMats[0]->getNodeNumRows(); kkk++) {
+    for (size_t kkk = 0; kkk < regionGrpMats->getNodeNumRows(); kkk++) {
       ArrayView<const LO> AAcols;
       ArrayView<const SC> AAvals;
-      regionGrpMats[0]->getLocalRowView(kkk, AAcols, AAvals);
+      regionGrpMats->getLocalRowView(kkk, AAcols, AAvals);
       const int *Acols    = AAcols.getRawPtr();
       const SC  *Avals = AAvals.getRawPtr();
       LO RowLeng = AAvals.size();
@@ -808,15 +807,13 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
     fclose(fp);
     sprintf(str,"theX.%d",myRank);
     fp = fopen(str,"w");
-    ArrayRCP<SC> lX= regX[0]->getDataNonConst(0);
-    for (size_t kkk = 0; kkk < regionGrpMats[0]->getNodeNumRows(); kkk++) fprintf(fp, "%22.16e\n",lX[kkk]);
+    ArrayRCP<SC> lX= regX->getDataNonConst(0);
+    for (size_t kkk = 0; kkk < regionGrpMats->getNodeNumRows(); kkk++) fprintf(fp, "%22.16e\n",lX[kkk]);
     fclose(fp);
 #endif
 
-    Array<RCP<Vector> > regRes(maxRegPerProc);
-    for (int j = 0; j < maxRegPerProc; j++) { // step 1
-      regRes[j] = VectorFactory::Build(revisedRowMapPerGrp[j], true);
-    }
+    RCP<Vector> regRes;
+    regRes = VectorFactory::Build(revisedRowMapPerGrp, true);
 
     /////////////////////////////////////////////////////////////////////////
     // SWITCH TO RECURSIVE STYLE --> USE LEVEL CONTAINER VARIABLES
@@ -846,14 +843,12 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
     std::cout << std::setprecision(8) << std::scientific;
     int cycle = 0;
 
-    Array<Teuchos::RCP<Vector> > regCorrect(maxRegPerProc);
-    for (int j = 0; j < maxRegPerProc; j++) {
-      regCorrect[j] = VectorFactory::Build(revisedRowMapPerGrp[j], true);
-    }
+    Teuchos::RCP<Vector> regCorrect;
+    regCorrect = VectorFactory::Build(revisedRowMapPerGrp, true);
     for (cycle = 0; cycle < maxIts; ++cycle)
     {
       const Scalar SC_ZERO = Teuchos::ScalarTraits<SC>::zero();
-      regCorrect[0]->putScalar(SC_ZERO);
+      regCorrect->putScalar(SC_ZERO);
       // check for convergence
       {
         ////////////////////////////////////////////////////////////////////////
@@ -891,7 +886,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
                regProlong, compRowMaps, quasiRegRowMaps, regRowMaps, regRowImporters,
                regInterfaceScalings, smootherParams, zeroInitGuess, coarseSolverData, hierarchyData);
 
-        regX[0]->update(one, *regCorrect[0], one);
+        regX->update(one, *regCorrect, one);
     }
     out << "Number of iterations performed for this solve: " << cycle << std::endl;
 


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/muelu 

## Motivation
Removes the old std:vectors used to handle multiple regions per rank, since multiple regions per rank is not currently supported and will not be done using these vectors in the future.


<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Testing
regionMG tests pass and have the same result as before.


<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->