### PR TITLE
Tempus: Remove ParameterList from TimeStepControl

### DIFF
--- a/packages/piro/test/_input_Tempus_BackwardEuler_SinCos.xml
+++ b/packages/piro/test/_input_Tempus_BackwardEuler_SinCos.xml
@@ -29,9 +29,6 @@
         <Parameter name="Minimum Time Step"      type="double" value="0.00001"/>
         <Parameter name="Initial Time Step"      type="double" value="0.1"/>
         <Parameter name="Maximum Time Step"      type="double" value="0.1"/>
-        <Parameter name="Minimum Order"          type="int"    value="1"/>
-        <Parameter name="Initial Order"          type="int"    value="1"/>
-        <Parameter name="Maximum Order"          type="int"    value="1"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
         <Parameter name="Integrator Step Type"  type="string" value="Constant"/>

--- a/packages/rol/example/tempus/example_01.xml
+++ b/packages/rol/example/tempus/example_01.xml
@@ -19,9 +19,6 @@
         <Parameter name="Minimum Time Step"      type="double" value="0.0001"/>
         <Parameter name="Initial Time Step"      type="double" value="0.1"/>
         <Parameter name="Maximum Time Step"      type="double" value="0.1"/>
-        <Parameter name="Minimum Order"          type="int"    value="1"/>
-        <Parameter name="Initial Order"          type="int"    value="1"/>
-        <Parameter name="Maximum Order"          type="int"    value="1"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
         <Parameter name="Integrator Step Type"   type="string" value="Constant"/>

--- a/packages/rol/example/tempus/example_parabolic.xml
+++ b/packages/rol/example/tempus/example_parabolic.xml
@@ -51,9 +51,6 @@
         <Parameter name="Initial Time Step"      type="double" value="0.01"/>
         <Parameter name="Minimum Time Step"      type="double" value="0.00001"/>
         <Parameter name="Maximum Time Step"      type="double" value="0.1"/>
-        <Parameter name="Minimum Order"          type="int"    value="1"/>
-        <Parameter name="Initial Order"          type="int"    value="1"/>
-        <Parameter name="Maximum Order"          type="int"    value="1"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
         <Parameter name="Integrator Step Type"  type="string" value="Constant"/>

--- a/packages/rol/example/tempus/example_sincos.xml
+++ b/packages/rol/example/tempus/example_sincos.xml
@@ -38,9 +38,6 @@
         <Parameter name="Initial Time Step"      type="double" value="0.0125"/>
         <Parameter name="Minimum Time Step"      type="double" value="0.00001"/>
         <Parameter name="Maximum Time Step"      type="double" value="0.1"/>
-        <Parameter name="Minimum Order"          type="int"    value="1"/>
-        <Parameter name="Initial Order"          type="int"    value="1"/>
-        <Parameter name="Maximum Order"          type="int"    value="1"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
         <Parameter name="Integrator Step Type"  type="string" value="Constant"/>

--- a/packages/tempus/src/Tempus_StepperFactory_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperFactory_impl.hpp
@@ -1616,7 +1616,6 @@ setStepperSolverValues(
   auto subPL = sublist(defaultSolverPL, "NOX");
   solver->setParameterList(subPL);
   if (stepperPL != Teuchos::null) {
-    std::cout << "stepperPL = \n" << *stepperPL << "\n" << std::endl;
     std::string solverName = stepperPL->get<std::string>("Solver Name");
     if ( stepperPL->isSublist(solverName) ) {
       auto solverPL = Teuchos::parameterList();

--- a/packages/tempus/src/Tempus_StepperSubcycling_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperSubcycling_impl.hpp
@@ -36,12 +36,9 @@ StepperSubcycling<Scalar>::StepperSubcycling()
 
   this->setAppAction(Teuchos::null);
   scIntegrator_ = Teuchos::rcp(new IntegratorBasic<Scalar>());
-  scIntegrator_->setTimeStepControl();
 
   scIntegrator_->setObserver(
     Teuchos::rcp(new IntegratorObserverNoOp<Scalar>()));
-
-  this->setSubcyclingPrintDtChanges(false);
 
   RCP<ParameterList> tempusPL = scIntegrator_->getTempusParameterList();
 
@@ -74,6 +71,10 @@ StepperSubcycling<Scalar>::StepperSubcycling()
              .sublist("Time Step Control")
                  .set("Initial Time Step", std::numeric_limits<Scalar>::max());
   }
+
+  scIntegrator_->setTimeStepControl();
+  this->setSubcyclingPrintDtChanges(false);
+
 }
 
 
@@ -140,14 +141,13 @@ void StepperSubcycling<Scalar>::setSubcyclingStepType(std::string stepType)
 
   auto tsc = scIntegrator_->getNonConstTimeStepControl();
   auto tscStrategy = tsc->getTimeStepControlStrategy();
-  tscStrategy->clearObservers();
 
   Teuchos::RCP<TimeStepControlStrategy<Scalar> > strategy =
     Teuchos::rcp(new TimeStepControlStrategyConstant<Scalar>());
   if (stepType == "Variable")
     strategy = Teuchos::rcp(new TimeStepControlStrategyBasicVS<Scalar>());
 
-  tscStrategy->addStrategy(strategy);
+  tsc->setTimeStepControlStrategy(strategy);
 
   this->isInitialized_ = false;
 }
@@ -193,7 +193,6 @@ void StepperSubcycling<Scalar>::
 setSubcyclingTimeStepControlStrategy(
   Teuchos::RCP<TimeStepControlStrategy<Scalar> > tscs)
 {
-  scIntegrator_->getNonConstTimeStepControl()->getTimeStepControlStrategy()->clearObservers();
   scIntegrator_->getNonConstTimeStepControl()->setTimeStepControlStrategy(tscs);
   this->isInitialized_ = false;
 }

--- a/packages/tempus/src/Tempus_TimeStepControl.cpp
+++ b/packages/tempus/src/Tempus_TimeStepControl.cpp
@@ -13,7 +13,14 @@
 #include "Tempus_TimeStepControl_impl.hpp"
 
 namespace Tempus {
+
   TEMPUS_INSTANTIATE_TEMPLATE_CLASS(TimeStepControl)
+
+  // Nonmember constructor from ParameterList.
+  template Teuchos::RCP<TimeStepControl<double> >
+  createTimeStepControl(
+    Teuchos::RCP<Teuchos::ParameterList> const& pList);
+
 }
 
 #endif

--- a/packages/tempus/src/Tempus_TimeStepControlStrategy.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategy.hpp
@@ -21,10 +21,12 @@ template<class Scalar> class TimeStepControl;
 
 /** \brief StepControlStrategy class for TimeStepControl
  *
+ *  This strategy is the default base class, which provides a no-op strategy.
  */
 template<class Scalar>
 class TimeStepControlStrategy
-  : virtual public Teuchos::ParameterListAcceptor
+  : virtual public Teuchos::Describable,
+    virtual public Teuchos::ParameterListAcceptor
 {
 public:
 
@@ -40,16 +42,31 @@ public:
     Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
     Status & /* integratorStatus */){}
 
+  /// \name Overridden from Teuchos::Describable
+  //@{
+    std::string description() const override
+    { return "Tempus::TimeStepControlStrategy"; }
+
+    void describe(Teuchos::FancyOStream          &out,
+                  const Teuchos::EVerbosityLevel verbLevel) const override
+    {
+      Teuchos::OSTab ostab(out,2,"describe");
+      out << description() << std::endl;
+    }
+  //@}
+
   /// \name Overridden from Teuchos::ParameterListAcceptor
   //@{
-    void setParameterList(const Teuchos::RCP<Teuchos::ParameterList> & /* pl */){}
-    Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const
+    void setParameterList(const Teuchos::RCP<Teuchos::ParameterList> & /* pl */) override {}
+    Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const override
       { return  Teuchos::null;}
-    Teuchos::RCP<Teuchos::ParameterList> getNonconstParameterList()
+    Teuchos::RCP<Teuchos::ParameterList> getNonconstParameterList() override
       { return  Teuchos::null;}
-    Teuchos::RCP<Teuchos::ParameterList> unsetParameterList()
+    Teuchos::RCP<Teuchos::ParameterList> unsetParameterList() override
       { return  Teuchos::null;}
   //@}
 };
+
+
 } // namespace Tempus
 #endif // Tempus_TimeStepControlStrategy_hpp

--- a/packages/tempus/src/Tempus_TimeStepControlStrategyComposite.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategyComposite.hpp
@@ -53,6 +53,21 @@ public:
         s->getNextTimeStep(tsc, sh, integratorStatus);
   }
 
+  /// \name Overridden from Teuchos::Describable
+  //@{
+    std::string description() const override
+    { return "Tempus::TimeStepControlComposite"; }
+
+    void describe(Teuchos::FancyOStream          &out,
+                  const Teuchos::EVerbosityLevel verbLevel) const override
+    {
+      Teuchos::OSTab ostab(out,2,"describe");
+      out << description() << "::describe:" << std::endl;
+      for(auto& s : strategies_)
+        s->describe(out, verbLevel);
+    }
+  //@}
+
   /** \brief Append strategy to the composite list.*/
   void addStrategy(const Teuchos::RCP<TimeStepControlStrategy<Scalar> > &strategy){
      if (Teuchos::nonnull(strategy))

--- a/packages/tempus/src/Tempus_TimeStepControlStrategyComposite.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategyComposite.hpp
@@ -75,7 +75,7 @@ public:
   }
 
   /** \brief Clear the composite list.*/
-  void clearObservers(){
+  void clearStrategies(){
      strategies_.clear();
   }
 

--- a/packages/tempus/src/Tempus_TimeStepControlStrategyIntegralController.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategyIntegralController.hpp
@@ -141,6 +141,31 @@ public:
      workingState->setTimeStep(dt);
   }
 
+  /// \name Overridden from Teuchos::Describable
+  //@{
+    std::string description() const override
+    { return "Tempus::TimeStepControlStrategyIntegralController"; }
+
+    void describe(Teuchos::FancyOStream          &out,
+                  const Teuchos::EVerbosityLevel verbLevel) const override
+    {
+      Teuchos::OSTab ostab(out,2,"describe");
+      out << description() << "::describe:" << std::endl
+          << "Name                               = " << tscsPL_->get<std::string>("Name") << std::endl
+          << "Controller Type                    = " << controller_   << std::endl
+          << "KI                                 = " << k1_           << std::endl
+          << "KP                                 = " << k2_           << std::endl
+          << "KD                                 = " << k3_           << std::endl
+          << "errN_                              = " << errN_         << std::endl
+          << "errNm1_                            = " << errNm1_       << std::endl
+          << "errNm2_                            = " << errNm2_       << std::endl
+          << "Safety Factor                      = " << safetyFactor_ << std::endl
+          << "Maximum Safety Factor              = " << facMax_       << std::endl
+          << "Minimum Safety Factor              = " << facMin_       << std::endl
+          << "Safety Factor After Step Rejection = " << tscsPL_->get<Scalar>("Safety Factor After Step Rejection")       << std::endl;
+    }
+  //@}
+
   /// \name Overridden from Teuchos::ParameterListAcceptor
   //@{
   void setParameterList(

--- a/packages/tempus/src/Tempus_TimeStepControlStrategyPID.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategyPID.hpp
@@ -124,10 +124,33 @@ public:
      workingState->setTimeStep(dt);
   }
 
+  /// \name Overridden from Teuchos::Describable
+  //@{
+    std::string description() const override
+    { return "Tempus::TimeStepControlStrategyPID"; }
+
+    void describe(Teuchos::FancyOStream          &out,
+                  const Teuchos::EVerbosityLevel verbLevel) const override
+    {
+      Teuchos::OSTab ostab(out,2,"describe");
+      out << description() << "::describe:" << std::endl
+          << "Name                               = " << tscsPL_->get<std::string>("Name") << std::endl
+          << "K1                                 = " << k1_           << std::endl
+          << "K2                                 = " << k2_           << std::endl
+          << "K3                                 = " << k3_           << std::endl
+          << "errN_                              = " << errN_         << std::endl
+          << "errNm1_                            = " << errNm1_       << std::endl
+          << "errNm2_                            = " << errNm2_       << std::endl
+          << "Safety Factor                      = " << safetyFactor_ << std::endl
+          << "Maximum Safety Factor              = " << facMax_       << std::endl
+          << "Minimum Safety Factor              = " << facMin_       << std::endl;
+    }
+  //@}
+
   /// \name Overridden from Teuchos::ParameterListAcceptor
   //@{
-  void setParameterList(const Teuchos::RCP<Teuchos::ParameterList> & pList){
-
+  void setParameterList(const Teuchos::RCP<Teuchos::ParameterList> & pList) override
+  {
      if (pList == Teuchos::null) {
         // Create default parameters if null, otherwise keep current parameters.
         if (tscsPL_ == Teuchos::null) {
@@ -163,7 +186,7 @@ public:
 
   }
 
-  Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const {
+  Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const override {
      Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
 
      pl->set<std::string>("Name","PID");
@@ -176,11 +199,11 @@ public:
      return pl;
   }
 
-  Teuchos::RCP<Teuchos::ParameterList> getNonconstParameterList() {
+  Teuchos::RCP<Teuchos::ParameterList> getNonconstParameterList() override {
      return tscsPL_;
   }
 
-  Teuchos::RCP<Teuchos::ParameterList> unsetParameterList() {
+  Teuchos::RCP<Teuchos::ParameterList> unsetParameterList() override {
      Teuchos::RCP<Teuchos::ParameterList> temp_plist = tscsPL_;
      tscsPL_ = Teuchos::null;
      return(temp_plist);

--- a/packages/tempus/src/Tempus_TimeStepControl_decl.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControl_decl.hpp
@@ -17,6 +17,7 @@
 #include "Tempus_config.hpp"
 #include "Tempus_SolutionHistory.hpp"
 #include "Tempus_TimeStepControlStrategyComposite.hpp"
+#include "Tempus_Stepper.hpp"
 
 #include <iostream>
 #include <iterator>
@@ -32,36 +33,58 @@ namespace Tempus {
  *   - Maximum and minimum time index
  *   - Maximum and minimum time step size
  *   - Maximum and minimum error
- *   - Maximum and minimum order
  *   - Startup considerations (e.g., ramping)
  *   - Solution and/or diagnostic output
  *  Additional step control can be added through the step control observer,
  *  or inheriting from this class.
  *   - Stability limits (e.g., CFL number)
  *
- * Using TimeStepControlStrategy allows applications to define
- * their very own  strategy used to determine the next time step size (`getNextTimeStep()`). 
- * Applications can define multiple strategies and add it to a vector of strategies TimeStepControlStrategyComposite  using setTimeStepControlStrategy().
- * TimeStepControlStrategyComposite iterates over the list of strategies to determine
- * the "optimal" next time step size.
+ *  Using TimeStepControlStrategy allows applications to define their
+ *  very own strategy used to determine the next time step size
+ *  (`getNextTimeStep()`).  Applications can define multiple strategies
+ *  and add it to a vector of strategies TimeStepControlStrategyComposite
+ *  using setTimeStepControlStrategy().  TimeStepControlStrategyComposite
+ *  iterates over the list of strategies to determine the "optimal"
+ *  next time step size.
  *
  */
 template<class Scalar>
 class TimeStepControl
   : virtual public Teuchos::Describable,
-    virtual public Teuchos::ParameterListAcceptor,
     virtual public Teuchos::VerboseObject<Tempus::TimeStepControl<Scalar> >
 {
 public:
 
+  /// Default Constructor
+  TimeStepControl();
+
   /// Constructor
-  TimeStepControl(Teuchos::RCP<Teuchos::ParameterList> pList = Teuchos::null);
+  TimeStepControl(
+    Scalar              initTime,
+    Scalar              finalTime,
+    Scalar              minTimeStep,
+    Scalar              initTimeStep,
+    Scalar              maxTimeStep,
+    int                 initIndex,
+    int                 finalIndex,
+    Scalar              maxAbsError,
+    Scalar              maxRelError,
+    std::string         stepType,
+    int                 maxFailures,
+    int                 maxConsecFailures,
+    int                 numTimeSteps,
+    bool                printDtChanges,
+    bool                outputExactly,
+    std::vector<int>    outputIndices,
+    std::vector<Scalar> outputTimes,
+    int                 outputIndexInterval,
+    Scalar              outputTimeInterval,
+    Teuchos::RCP<TimeStepControlStrategyComposite<Scalar>> stepControlStrategy);
 
   /// Destructor
   virtual ~TimeStepControl() {}
 
-  virtual void initialize(Teuchos::RCP<Teuchos::ParameterList> pList =
-    Teuchos::null) { this->setParameterList(pList); }
+  virtual void initialize();
 
   /** \brief Determine the time step size.*/
   virtual void getNextTimeStep(
@@ -78,13 +101,7 @@ public:
   virtual void setTimeStepControlStrategy(
         Teuchos::RCP<TimeStepControlStrategy<Scalar> > tscs = Teuchos::null);
 
-  /// \name Overridden from Teuchos::ParameterListAccepto{}
-  //@{
-    void setParameterList(const Teuchos::RCP<Teuchos::ParameterList> & pl);
-    Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
-    Teuchos::RCP<Teuchos::ParameterList> getNonconstParameterList();
-    Teuchos::RCP<Teuchos::ParameterList> unsetParameterList();
-  //@}
+  Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
 
   /// \name Overridden from Teuchos::Describable
   //@{
@@ -93,139 +110,105 @@ public:
                   const Teuchos::EVerbosityLevel verbLevel) const;
   //@}
 
-  /// \name Get ParameterList values
+  /// \name Get accessors
   //@{
-    virtual Scalar getInitTime() const
-      { return tscPL_->get<double>("Initial Time"); }
-    virtual Scalar getFinalTime() const
-      { return tscPL_->get<double>("Final Time"); }
-    virtual Scalar getMinTimeStep() const
-      { return tscPL_->get<double>("Minimum Time Step"); }
-    virtual Scalar getInitTimeStep() const
-      { return tscPL_->get<double>("Initial Time Step"); }
-    virtual Scalar getMaxTimeStep() const
-      { return tscPL_->get<double>("Maximum Time Step"); }
-    virtual int getInitIndex() const
-      { return tscPL_->get<int>   ("Initial Time Index"); }
-    virtual int getFinalIndex() const
-      { return tscPL_->get<int>   ("Final Time Index"); }
-    virtual Scalar getMaxAbsError() const
-      { return tscPL_->get<double>("Maximum Absolute Error"); }
-    virtual Scalar getMaxRelError() const
-      { return tscPL_->get<double>("Maximum Relative Error"); }
-    virtual int getMinOrder() const
-      { return tscPL_->get<int>   ("Minimum Order"); }
-    virtual int getInitOrder() const
-      { return tscPL_->get<int>   ("Initial Order"); }
-    virtual int getMaxOrder() const
-      { return tscPL_->get<int>   ("Maximum Order"); }
-    virtual std::string getStepType() const
-      { return tscPL_->get<std::string>("Integrator Step Type"); }
-    virtual bool getOutputExactly() const
-      { return tscPL_->get<bool>("Output Exactly On Output Times"); }
-    virtual std::vector<int> getOutputIndices() const
-      { return outputIndices_; }
-    virtual std::vector<Scalar> getOutputTimes() const
-      { return outputTimes_; }
-    virtual int getMaxFailures() const
-      { return tscPL_->get<int>("Maximum Number of Stepper Failures"); }
-    virtual int getMaxConsecFailures() const
-      { return tscPL_->
-               get<int>("Maximum Number of Consecutive Stepper Failures"); }
-    virtual int getNumTimeSteps() const
-      { return tscPL_->get<int>("Number of Time Steps"); }
-    virtual Teuchos::RCP<TimeStepControlStrategyComposite<Scalar>>
+    virtual Scalar getInitTime() const { return initTime_; }
+    virtual Scalar getFinalTime() const { return finalTime_; }
+    virtual Scalar getMinTimeStep() const { return minTimeStep_; }
+    virtual Scalar getInitTimeStep() const { return initTimeStep_; }
+    virtual Scalar getMaxTimeStep() const { return maxTimeStep_; }
+    virtual int getInitIndex() const { return initIndex_; }
+    virtual int getFinalIndex() const { return finalIndex_; }
+    virtual Scalar getMaxAbsError() const { return maxAbsError_; }
+    virtual Scalar getMaxRelError() const { return maxRelError_; }
+#ifndef TEMPUS_HIDE_DEPRECATED_CODE
+    virtual int getMinOrder() const { return -1; }
+    virtual int getInitOrder() const { return -1; }
+    virtual int getMaxOrder() const { return -1; }
+#endif
+    virtual std::string getStepType() const { return stepType_; }
+    virtual bool getOutputExactly() const { return outputExactly_; }
+    virtual std::vector<int> getOutputIndices() const { return outputIndices_; }
+    virtual std::vector<Scalar> getOutputTimes() const { return outputTimes_; }
+    virtual int getMaxFailures() const { return maxFailures_; }
+    virtual int getMaxConsecFailures() const { return maxConsecFailures_; }
+    virtual bool getPrintDtChanges() const { return printDtChanges_; }
+    virtual int getNumTimeSteps() const { return numTimeSteps_; }
+
+    virtual Teuchos::RCP<TimeStepControlStrategy<Scalar>>
        getTimeStepControlStrategy() const { return stepControlStrategy_;}
-    virtual int getOutputIndexInterval()
-      { return outputIndexInterval_;}
-    virtual double getOutputTimeInterval()
-      { return outputTimeInterval_;}
+    virtual int getOutputIndexInterval() const { return outputIndexInterval_;}
+    virtual Scalar getOutputTimeInterval() const { return outputTimeInterval_;}
   //@}
 
-  /// \name Set ParameterList values
+  /// \name Set accesors
   //@{
-    virtual void setInitTime(Scalar InitTime)
-      { tscPL_->set<double>("Initial Time"             , InitTime    ); }
-    virtual void setFinalTime(Scalar FinalTime)
-      { tscPL_->set<double>("Final Time"               , FinalTime   ); }
-    virtual void setMinTimeStep(Scalar MinTimeStep)
-      { tscPL_->set<double>("Minimum Time Step"        , MinTimeStep ); }
-    virtual void setInitTimeStep(Scalar InitTimeStep)
-      { tscPL_->set<double>("Initial Time Step"        , InitTimeStep); }
-    virtual void setMaxTimeStep(Scalar MaxTimeStep)
-      { tscPL_->set<double>("Maximum Time Step"        , MaxTimeStep ); }
-    virtual void setInitIndex(int InitIndex)
-      { tscPL_->set<int>   ("Initial Time Index"       , InitIndex   ); }
-    virtual void setFinalIndex(int FinalIndex)
-      { tscPL_->set<int>   ("Final Time Index"         , FinalIndex  ); }
-    virtual void setMaxAbsError(Scalar MaxAbsError)
-      { tscPL_->set<double>("Maximum Absolute Error"   , MaxAbsError ); }
-    virtual void setMaxRelError(Scalar MaxRelError)
-      { tscPL_->set<double>("Maximum Relative Error"   , MaxRelError ); }
-    virtual void setMinOrder(int MinOrder)
-     { tscPL_->set<int>   ("Minimum Order"             , MinOrder    ); }
-    virtual void setInitOrder(int InitOrder)
-      { tscPL_->set<int>   ("Initial Order"            , InitOrder   ); }
-    virtual void setMaxOrder(int MaxOrder)
-      { tscPL_->set<int>   ("Maximum Order"            , MaxOrder    ); }
-    virtual void setStepType(std::string StepType)
-      { tscPL_->set<std::string>("Integrator Step Type", StepType    ); }
-    virtual void setOutputExactly(bool OutputExactly)
-      { tscPL_->get<bool>("Output Exactly On Output Times", OutputExactly); }
-    virtual void setOutputIndices(std::vector<int> OutputIndices)
-      { outputIndices_ = OutputIndices;
-        std::ostringstream ss;
-        std::copy(OutputIndices.begin(), OutputIndices.end()-1,
-                  std::ostream_iterator<int>(ss, ","));
-        ss << OutputIndices.back();
-        tscPL_->set<std::string>("Output Index List", ss.str());
-      }
-    virtual void setOutputTimes(std::vector<Scalar> OutputTimes)
-      {
-        outputTimes_ = OutputTimes;
-        std::ostringstream ss;
-        ss << std::setprecision(16);
-        if (!outputTimes_.empty()) {
-          for (size_t i=0; i < outputTimes_.size()-1; ++i)
-            ss << outputTimes_[i] << ",";
-          ss << outputTimes_[outputTimes_.size()-1];
-        }
-        tscPL_->set<std::string>("Output Time List", ss.str());
-      }
-    virtual void setMaxFailures(int MaxFailures)
-      { tscPL_->set<int>("Maximum Number of Stepper Failures", MaxFailures); }
-    virtual void setMaxConsecFailures(int MaxConsecFailures)
-      { tscPL_->set<int>
-        ("Maximum Number of Consecutive Stepper Failures", MaxConsecFailures); }
+    virtual void setInitTime(Scalar t) { initTime_ = t; isInitialized_ = false; }
+    virtual void setFinalTime(Scalar t) { finalTime_ = t; isInitialized_ = false; }
+    virtual void setMinTimeStep(Scalar t) { minTimeStep_ = t; isInitialized_ = false; }
+    virtual void setInitTimeStep(Scalar t) { initTimeStep_ = t; isInitialized_ = false; }
+    virtual void setMaxTimeStep(Scalar t) { maxTimeStep_ = t; isInitialized_ = false; }
+    virtual void setInitIndex(int i) { initIndex_ = i; isInitialized_ = false; }
+    virtual void setFinalIndex(int i) { finalIndex_ = i; isInitialized_ = false; }
+    virtual void setMaxAbsError(Scalar e) { maxAbsError_ = e; isInitialized_ = false; }
+    virtual void setMaxRelError(Scalar e) { maxRelError_ = e; isInitialized_ = false; }
+#ifndef TEMPUS_HIDE_DEPRECATED_CODE
+    virtual void setMinOrder(int)  { isInitialized_ = false; }
+    virtual void setInitOrder(int) { isInitialized_ = false; }
+    virtual void setMaxOrder(int)  { isInitialized_ = false; }
+#endif
+    virtual void setStepType(std::string s) { stepType_ = s; isInitialized_ = false; }
+    virtual void setMaxFailures(int i) { maxFailures_ = i; isInitialized_ = false; }
+    virtual void setMaxConsecFailures(int i) { maxConsecFailures_ = i; isInitialized_ = false; }
+    virtual void setPrintDtChanges(bool b) { printDtChanges_ = b; isInitialized_ = false; }
     virtual void setNumTimeSteps(int numTimeSteps);
-    virtual void setOutputIndexInterval(int OutputIndexInterval)
-      { tscPL_->set<int>("Output Index Interval",OutputIndexInterval);
-        outputIndexInterval_ = OutputIndexInterval; }
-    virtual void setOutputTimeInterval(double OutputTimeInterval)
-      { tscPL_->set<double>("Output Time Interval",OutputTimeInterval);
-        outputTimeInterval_ = OutputTimeInterval; }
-    virtual void setPrintDtChanges(bool printDtChanges)
-      { printDtChanges_ = printDtChanges; }
-    virtual bool getPrintDtChanges() const { return printDtChanges_; }
+
+    virtual void setOutputExactly(bool b) { outputExactly_ = b; isInitialized_ = false; }
+    virtual void setOutputIndices(std::vector<int> v) { outputIndices_ = v; isInitialized_ = false; }
+    virtual void setOutputTimes(std::vector<Scalar> v) { outputTimes_ = v; isInitialized_ = false; }
+    virtual void setOutputIndexInterval(int i) { outputIndexInterval_ = i; isInitialized_ = false; }
+    virtual void setOutputTimeInterval(Scalar t) { outputTimeInterval_ = t; isInitialized_ = false; }
   //@}
+
+  virtual void checkInitialized();
 
 protected:
 
-  Teuchos::RCP<Teuchos::ParameterList> tscPL_;
+  bool        isInitialized_;     ///< Bool if TimeStepControl is initialized.
+  Scalar      initTime_;          ///< Initial Time
+  Scalar      finalTime_;         ///< Final Time
+  Scalar      minTimeStep_;       ///< Minimum Time Step
+  Scalar      initTimeStep_;      ///< Initial Time Step
+  Scalar      maxTimeStep_;       ///< Maximum Time Step
+  int         initIndex_;         ///< Initial Time Index
+  int         finalIndex_;        ///< Final Time Index
+  Scalar      maxAbsError_;       ///< Maximum Absolute Error
+  Scalar      maxRelError_;       ///< Maximum Relative Error
+  std::string stepType_;          ///< Integrator Step Type
+  int         maxFailures_;       ///< Maximum Number of Stepper Failures
+  int         maxConsecFailures_; ///< Maximum Number of Consecutive Stepper Failures
+  int         numTimeSteps_;      ///< Number of time steps for Constant time step
+  bool        printDtChanges_;    ///< Print timestep size when it changes
 
-  std::vector<int>    outputIndices_;  ///< Vector of output indices.
-  std::vector<Scalar> outputTimes_;    ///< Vector of output times.
+  bool                outputExactly_;  ///< Output Exactly On Output Times
+  std::vector<int>    outputIndices_;  ///< Vector of output indices
+  std::vector<Scalar> outputTimes_;    ///< Vector of output times
   int outputIndexInterval_;
-  double outputTimeInterval_;
+  Scalar outputTimeInterval_;
 
   bool outputAdjustedDt_; ///< Flag indicating that dt was adjusted for output.
   Scalar dtAfterOutput_;  ///< dt to reinstate after output step.
 
-  Teuchos::RCP<TimeStepControlStrategyComposite<Scalar>> stepControlStrategy_;
-
-  bool printDtChanges_;
+  Teuchos::RCP<TimeStepControlStrategy<Scalar>> stepControlStrategy_;
 
 };
+
+
+/// Nonmember constructor from ParameterList.
+template<class Scalar>
+Teuchos::RCP<TimeStepControl<Scalar> > createTimeStepControl(
+  Teuchos::RCP<Teuchos::ParameterList> const& pList);
+
 } // namespace Tempus
 
 #endif // Tempus_TimeStepControl_decl_hpp

--- a/packages/tempus/src/Tempus_TimeStepControl_impl.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControl_impl.hpp
@@ -27,15 +27,163 @@
 namespace Tempus {
 
 template<class Scalar>
-TimeStepControl<Scalar>::TimeStepControl(
-  Teuchos::RCP<Teuchos::ParameterList> pList)
-  : tscPL_(pList),
+TimeStepControl<Scalar>::TimeStepControl()
+  : isInitialized_      (false),
+    initTime_           (0.0),
+    finalTime_          (1.0e+99),
+    minTimeStep_        (0.0),
+    initTimeStep_       (1.0),
+    maxTimeStep_        (1.0e+99),
+    initIndex_          (0),
+    finalIndex_         (1000000),
+    maxAbsError_        (1.0e-08),
+    maxRelError_        (1.0e-08),
+    stepType_           ("Variable"),
+    maxFailures_        (10),
+    maxConsecFailures_  (5),
+    numTimeSteps_       (-1),
+    printDtChanges_     (true),
+    outputExactly_      (true),
+    //outputIndices_      (),
+    //outputTimes_        (),
+    outputIndexInterval_(1000000),
+    outputTimeInterval_ (1.0e+99),
     outputAdjustedDt_(false),
-    dtAfterOutput_(0.0),
-    stepControlStrategy_(Teuchos::null),
-    printDtChanges_(true)
+    dtAfterOutput_(0.0)
 {
-  this->initialize(pList);
+  setTimeStepControlStrategy();
+  this->initialize();
+}
+
+
+template<class Scalar>
+TimeStepControl<Scalar>::TimeStepControl(
+  Scalar              initTime,
+  Scalar              finalTime,
+  Scalar              minTimeStep,
+  Scalar              initTimeStep,
+  Scalar              maxTimeStep,
+  int                 initIndex,
+  int                 finalIndex,
+  Scalar              maxAbsError,
+  Scalar              maxRelError,
+  std::string         stepType,
+  int                 maxFailures,
+  int                 maxConsecFailures,
+  int                 numTimeSteps,
+  bool                printDtChanges,
+  bool                outputExactly,
+  std::vector<int>    outputIndices,
+  std::vector<Scalar> outputTimes,
+  int                 outputIndexInterval,
+  Scalar              outputTimeInterval,
+  Teuchos::RCP<TimeStepControlStrategyComposite<Scalar>> stepControlStrategy)
+  : isInitialized_      (false),
+    initTime_           (initTime           ),
+    finalTime_          (finalTime          ),
+    minTimeStep_        (minTimeStep        ),
+    initTimeStep_       (initTimeStep       ),
+    maxTimeStep_        (maxTimeStep        ),
+    initIndex_          (initIndex          ),
+    finalIndex_         (finalIndex         ),
+    maxAbsError_        (maxAbsError        ),
+    maxRelError_        (maxRelError        ),
+    stepType_           (stepType           ),
+    maxFailures_        (maxFailures        ),
+    maxConsecFailures_  (maxConsecFailures  ),
+    numTimeSteps_       (numTimeSteps       ),
+    printDtChanges_     (printDtChanges     ),
+    outputExactly_      (outputExactly      ),
+    outputIndices_      (outputIndices      ),
+    outputTimes_        (outputTimes        ),
+    outputIndexInterval_(outputIndexInterval),
+    outputTimeInterval_ (outputTimeInterval ),
+    outputAdjustedDt_   (false              ),
+    dtAfterOutput_      (0.0                ),
+    stepControlStrategy_(stepControlStrategy)
+{
+  this->initialize();
+}
+
+
+template<class Scalar>
+void TimeStepControl<Scalar>::initialize()
+{
+  // Override parameters
+  if (getStepType() == "Constant") {
+    setMinTimeStep( getInitTimeStep() );
+    setMaxTimeStep( getInitTimeStep() );
+  }
+  setNumTimeSteps(getNumTimeSteps());
+
+
+  TEUCHOS_TEST_FOR_EXCEPTION(
+    (getInitTime() > getFinalTime() ), std::logic_error,
+    "Error - Inconsistent time range.\n"
+    "    (timeMin = "<<getInitTime()<<") > (timeMax = "<<getFinalTime()<<")\n");
+
+  TEUCHOS_TEST_FOR_EXCEPTION(
+    (getMinTimeStep() < Teuchos::ScalarTraits<Scalar>::zero() ),
+    std::logic_error,
+    "Error - Negative minimum time step.  dtMin = "<<getMinTimeStep()<<")\n");
+  TEUCHOS_TEST_FOR_EXCEPTION(
+    (getMaxTimeStep() < Teuchos::ScalarTraits<Scalar>::zero() ),
+    std::logic_error,
+    "Error - Negative maximum time step.  dtMax = "<<getMaxTimeStep()<<")\n");
+  TEUCHOS_TEST_FOR_EXCEPTION(
+    (getMinTimeStep() > getMaxTimeStep() ), std::logic_error,
+    "Error - Inconsistent time step range.\n"
+    "  (dtMin = "<<getMinTimeStep()<<") > (dtMax = "<<getMaxTimeStep()<<")\n");
+  TEUCHOS_TEST_FOR_EXCEPTION(
+    (getInitTimeStep() < Teuchos::ScalarTraits<Scalar>::zero() ),
+    std::logic_error,
+    "Error - Negative initial time step.  dtInit = "<<getInitTimeStep()<<")\n");
+  TEUCHOS_TEST_FOR_EXCEPTION(
+    (getInitTimeStep() < getMinTimeStep() ||
+     getInitTimeStep() > getMaxTimeStep() ),
+    std::out_of_range,
+    "Error - Initial time step is out of range.\n"
+    << "    [dtMin, dtMax] = [" << getMinTimeStep() << ", "
+                                << getMaxTimeStep() << "]\n"
+    << "    dtInit = " << getInitTimeStep() << "\n");
+
+  TEUCHOS_TEST_FOR_EXCEPTION(
+    (getInitIndex() > getFinalIndex() ), std::logic_error,
+    "Error - Inconsistent time index range.\n"
+    "  (iStepMin = "<<getInitIndex()<<") > (iStepMax = "
+    <<getFinalIndex()<<")\n");
+
+  TEUCHOS_TEST_FOR_EXCEPTION(
+    (getMaxAbsError() < Teuchos::ScalarTraits<Scalar>::zero() ),
+    std::logic_error,
+    "Error - Negative maximum time step.  errorMaxAbs = "
+    <<getMaxAbsError()<<")\n");
+  TEUCHOS_TEST_FOR_EXCEPTION(
+    (getMaxRelError() < Teuchos::ScalarTraits<Scalar>::zero() ),
+    std::logic_error,
+    "Error - Negative maximum time step.  errorMaxRel = "
+    <<getMaxRelError()<<")\n");
+
+  TEUCHOS_TEST_FOR_EXCEPTION(
+    (getStepType() != "Constant" and getStepType() != "Variable"),
+    std::out_of_range,
+      "Error - 'Integrator Step Type' does not equal none of these:\n"
+    << "  'Constant' - Integrator will take constant time step sizes.\n"
+    << "  'Variable' - Integrator will allow changes to the time step size.\n"
+    << "  stepType = " << getStepType()  << "\n");
+
+  isInitialized_ = true;   // Only place where this is set to true!
+}
+
+
+template<class Scalar>
+void TimeStepControl<Scalar>::checkInitialized()
+{
+  if ( !isInitialized_ ) {
+    this->describe( *(this->getOStream()), Teuchos::VERB_MEDIUM);
+    TEUCHOS_TEST_FOR_EXCEPTION( !isInitialized_, std::logic_error,
+      "Error - " << this->description() << " is not initialized!");
+  }
 }
 
 
@@ -45,6 +193,8 @@ void TimeStepControl<Scalar>::getNextTimeStep(
   Status & integratorStatus)
 {
   using Teuchos::RCP;
+
+  checkInitialized();
 
   TEMPUS_FUNC_TIME_MONITOR("Tempus::TimeStepControl::getNextTimeStep()");
   {
@@ -67,7 +217,6 @@ void TimeStepControl<Scalar>::getNextTimeStep(
     RCP<SolutionState<Scalar> > workingState=solutionHistory->getWorkingState();
     const Scalar lastTime = solutionHistory->getCurrentState()->getTime();
     const int iStep = workingState->getIndex();
-    int order = workingState->getOrder();
     Scalar dt = workingState->getTimeStep();
     bool output = false;
 
@@ -99,12 +248,11 @@ void TimeStepControl<Scalar>::getNextTimeStep(
     // update dt for the step control strategy to be informed
     workingState->setTimeStep(dt);
 
-    // call the step control strategy (to update order/dt if needed)
+    // call the step control strategy (to update dt if needed)
     stepControlStrategy_->getNextTimeStep(*this, solutionHistory,
                                          integratorStatus);
 
-    // get the order and dt (probably have changed by stepControlStrategy_)
-    order = workingState->getOrder();
+    // get the dt (probably have changed by stepControlStrategy_)
     dt = workingState->getTimeStep();
 
     if (getStepType() == "Variable") {
@@ -126,7 +274,7 @@ void TimeStepControl<Scalar>::getNextTimeStep(
       std::find(outputIndices_.begin(), outputIndices_.end(), iStep);
     if (it != outputIndices_.end()) output = true;
 
-    const int iInterval = tscPL_->get<int>("Output Index Interval");
+    const int iInterval = getOutputIndexInterval();
     if ( (iStep - getInitIndex()) % iInterval == 0) output = true;
 
     // Check if we need to output in the next timestep based on
@@ -145,7 +293,7 @@ void TimeStepControl<Scalar>::getNextTimeStep(
         break;
       }
     }
-    const Scalar tInterval = tscPL_->get<double>("Output Time Interval");
+    const Scalar tInterval = getOutputTimeInterval();
     Scalar oTime2 =  ceil((lastTime-getInitTime())/tInterval)*tInterval
                    + getInitTime();
     if (lastTime < oTime2 && oTime2 <= endTime) {
@@ -158,8 +306,7 @@ void TimeStepControl<Scalar>::getNextTimeStep(
     }
 
     if (checkOutput == true) {
-      const bool outputExactly =
-        tscPL_->get<bool>("Output Exactly On Output Times");
+      const bool outputExactly = getOutputExactly();
       if (getStepType() == "Variable" && outputExactly == true) {
         // Adjust time step to hit output times.
         if (std::abs((lastTime+dt-oTime)/(lastTime+dt)) < reltol) {
@@ -227,7 +374,6 @@ void TimeStepControl<Scalar>::getNextTimeStep(
       << getFinalTime() << "]\n"
       "    T + dt = " << lastTime <<" + "<< dt <<" = " << lastTime + dt <<"\n");
 
-    workingState->setOrder(order);
     workingState->setTimeStep(dt);
     workingState->setTime(lastTime + dt);
     workingState->setOutput(output);
@@ -257,25 +403,27 @@ template<class Scalar>
 void TimeStepControl<Scalar>::setNumTimeSteps(int numTimeSteps)
 {
   if (numTimeSteps >= 0) {
-    tscPL_->set<int>        ("Number of Time Steps", numTimeSteps);
-    const int initIndex = getInitIndex();
-    tscPL_->set<int>        ("Final Time Index", initIndex + numTimeSteps);
-    const double initTime = tscPL_->get<double>("Initial Time");
-    const double finalTime = tscPL_->get<double>("Final Time");
-    double initTimeStep = (finalTime - initTime)/numTimeSteps;
-    if (numTimeSteps == 0) initTimeStep = Scalar(0.0);
-    tscPL_->set<double>     ("Initial Time Step", initTimeStep);
-    tscPL_->set<double>     ("Minimum Time Step", initTimeStep);
-    tscPL_->set<double>     ("Maximum Time Step", initTimeStep);
-    tscPL_->set<std::string>("Integrator Step Type", "Constant");
+    numTimeSteps_ = numTimeSteps;
+    setFinalIndex(getInitIndex() + numTimeSteps_);
+    Scalar initTimeStep;
+    if (numTimeSteps_ == 0)
+      initTimeStep = Scalar(0.0);
+    else
+      initTimeStep = (getFinalTime() - getInitTime())/numTimeSteps_;
+    setInitTimeStep(initTimeStep);
+    setMinTimeStep (initTimeStep);
+    setMaxTimeStep (initTimeStep);
+    setStepType("Constant");
 
     Teuchos::RCP<Teuchos::FancyOStream> out = this->getOStream();
     Teuchos::OSTab ostab(out,1,"setNumTimeSteps");
-    *out << "Warning - Found 'Number of Time Steps' = " << getNumTimeSteps()
+    *out << "Warning - Setting 'Number of Time Steps' = " << getNumTimeSteps()
          << "  Set the following parameters: \n"
          << "  'Final Time Index'     = " << getFinalIndex() << "\n"
          << "  'Initial Time Step'    = " << getInitTimeStep() << "\n"
          << "  'Integrator Step Type' = " << getStepType() << std::endl;
+
+    isInitialized_ = false;
   }
 }
 
@@ -294,237 +442,62 @@ void TimeStepControl<Scalar>::describe(
    const Teuchos::EVerbosityLevel      verbLevel) const
 {
   if (verbLevel == Teuchos::VERB_EXTREME) {
+
+    std::vector<int> idx = getOutputIndices();
+    std::ostringstream listIdx;
+    if (!idx.empty()) {
+      for(std::size_t i = 0; i < idx.size()-1; ++i) listIdx << idx[i] << ", ";
+      listIdx << idx[idx.size()-1];
+    }
+
+    std::vector<Scalar> times = getOutputTimes();
+    std::ostringstream listTimes;
+    if (!times.empty()) {
+      for(std::size_t i = 0; i < times.size()-1; ++i) listTimes << times[i] << ", ";
+      listTimes << times[times.size()-1];
+    }
+
     out << description() << "::describe:" << std::endl
-        << "pList        = " << tscPL_    << std::endl;
+        << "initTime           = " << initTime_            << std::endl
+        << "finalTime          = " << finalTime_           << std::endl
+        << "minTimeStep        = " << minTimeStep_         << std::endl
+        << "initTimeStep       = " << initTimeStep_        << std::endl
+        << "maxTimeStep        = " << maxTimeStep_         << std::endl
+        << "initIndex          = " << initIndex_           << std::endl
+        << "finalIndex         = " << finalIndex_          << std::endl
+        << "maxAbsError        = " << maxAbsError_         << std::endl
+        << "maxRelError        = " << maxRelError_         << std::endl
+        << "stepType           = " << stepType_            << std::endl
+        << "maxFailures        = " << maxFailures_         << std::endl
+        << "maxConsecFailures  = " << maxConsecFailures_   << std::endl
+        << "numTimeSteps       = " << numTimeSteps_        << std::endl
+        << "printDtChanges     = " << printDtChanges_      << std::endl
+        << "outputExactly      = " << outputExactly_       << std::endl
+        << "outputIndices      = " << listIdx.str()        << std::endl
+        << "outputTimes        = " << listTimes.str()      << std::endl
+        << "outputIndexInterval= " << outputIndexInterval_ << std::endl
+        << "outputTimeInterval = " << outputTimeInterval_  << std::endl
+        << "outputAdjustedDt   = " << outputAdjustedDt_    << std::endl
+        << "dtAfterOutput      = " << dtAfterOutput_       << std::endl
+        << "stepControlSrategy = " << std::endl;
+        stepControlStrategy_->describe(out, verbLevel);
   }
 }
 
-
-template <class Scalar>
-void TimeStepControl<Scalar>::setParameterList(
-  Teuchos::RCP<Teuchos::ParameterList> const& pList)
-{
-  if (pList == Teuchos::null) {
-    // Create default parameters if null, otherwise keep current parameters.
-    if (tscPL_ == Teuchos::null) {
-      tscPL_ = Teuchos::parameterList("TimeStepControl");
-      *tscPL_ = *(this->getValidParameters());
-    }
-  } else {
-    tscPL_ = pList;
-  }
-  tscPL_->validateParametersAndSetDefaults(*this->getValidParameters(), 0);
-
-  // Override parameters
-  if (getStepType() == "Constant") {
-    const double initTimeStep = tscPL_->get<double>("Initial Time Step");
-    tscPL_->set<double>     ("Minimum Time Step", initTimeStep);
-    tscPL_->set<double>     ("Maximum Time Step", initTimeStep);
-  }
-  setNumTimeSteps(getNumTimeSteps());
-
-  // set the time step control strategy
-  setTimeStepControlStrategy();
-
-  TEUCHOS_TEST_FOR_EXCEPTION(
-    (getInitTime() > getFinalTime() ), std::logic_error,
-    "Error - Inconsistent time range.\n"
-    "    (timeMin = "<<getInitTime()<<") > (timeMax = "<<getFinalTime()<<")\n");
-
-  TEUCHOS_TEST_FOR_EXCEPTION(
-    (getMinTimeStep() < Teuchos::ScalarTraits<Scalar>::zero() ),
-    std::logic_error,
-    "Error - Negative minimum time step.  dtMin = "<<getMinTimeStep()<<")\n");
-  TEUCHOS_TEST_FOR_EXCEPTION(
-    (getMaxTimeStep() < Teuchos::ScalarTraits<Scalar>::zero() ),
-    std::logic_error,
-    "Error - Negative maximum time step.  dtMax = "<<getMaxTimeStep()<<")\n");
-  TEUCHOS_TEST_FOR_EXCEPTION(
-    (getMinTimeStep() > getMaxTimeStep() ), std::logic_error,
-    "Error - Inconsistent time step range.\n"
-    "  (dtMin = "<<getMinTimeStep()<<") > (dtMax = "<<getMaxTimeStep()<<")\n");
-  TEUCHOS_TEST_FOR_EXCEPTION(
-    (getInitTimeStep() < Teuchos::ScalarTraits<Scalar>::zero() ),
-    std::logic_error,
-    "Error - Negative initial time step.  dtInit = "<<getInitTimeStep()<<")\n");
-  TEUCHOS_TEST_FOR_EXCEPTION(
-    (getInitTimeStep() < getMinTimeStep() ||
-     getInitTimeStep() > getMaxTimeStep() ),
-    std::out_of_range,
-    "Error - Initial time step is out of range.\n"
-    << "    [dtMin, dtMax] = [" << getMinTimeStep() << ", "
-                                << getMaxTimeStep() << "]\n"
-    << "    dtInit = " << getInitTimeStep() << "\n");
-
-  TEUCHOS_TEST_FOR_EXCEPTION(
-    (getInitIndex() > getFinalIndex() ), std::logic_error,
-    "Error - Inconsistent time index range.\n"
-    "  (iStepMin = "<<getInitIndex()<<") > (iStepMax = "
-    <<getFinalIndex()<<")\n");
-
-  TEUCHOS_TEST_FOR_EXCEPTION(
-    (getMaxAbsError() < Teuchos::ScalarTraits<Scalar>::zero() ),
-    std::logic_error,
-    "Error - Negative maximum time step.  errorMaxAbs = "
-    <<getMaxAbsError()<<")\n");
-  TEUCHOS_TEST_FOR_EXCEPTION(
-    (getMaxRelError() < Teuchos::ScalarTraits<Scalar>::zero() ),
-    std::logic_error,
-    "Error - Negative maximum time step.  errorMaxRel = "
-    <<getMaxRelError()<<")\n");
-
-  TEUCHOS_TEST_FOR_EXCEPTION(
-    (getMinOrder() < Teuchos::ScalarTraits<Scalar>::zero() ),
-    std::logic_error,
-    "Error - Negative minimum order.  orderMin = "<<getMinOrder()<<")\n");
-  TEUCHOS_TEST_FOR_EXCEPTION(
-    (getMaxOrder() < Teuchos::ScalarTraits<Scalar>::zero() ), std::logic_error,
-    "Error - Negative maximum order.  orderMax = "<<getMaxOrder()<<")\n");
-  TEUCHOS_TEST_FOR_EXCEPTION(
-    (getMinOrder() > getMaxOrder() ), std::logic_error,
-    "Error - Inconsistent order range.\n"
-    "    (orderMin = "<<getMinOrder()<<") > (orderMax = "
-    <<getMaxOrder()<<")\n");
-  TEUCHOS_TEST_FOR_EXCEPTION(
-    (getInitOrder() < getMinOrder() || getInitOrder() > getMaxOrder()),
-    std::out_of_range,
-    "Error - Initial order is out of range.\n"
-    << "    [orderMin, orderMax] = [" << getMinOrder() << ", "
-                                      << getMaxOrder() << "]\n"
-    << "    order = " << getInitOrder()  << "\n");
-
-  TEUCHOS_TEST_FOR_EXCEPTION(
-    (getStepType() != "Constant" and getStepType() != "Variable"),
-    std::out_of_range,
-      "Error - 'Integrator Step Type' does not equal none of these:\n"
-    << "  'Constant' - Integrator will take constant time step sizes.\n"
-    << "  'Variable' - Integrator will allow changes to the time step size.\n"
-    << "  stepType = " << getStepType()  << "\n");
-
-
-  // Parse output times
-  {
-    outputTimes_.clear();
-    std::string str = tscPL_->get<std::string>("Output Time List");
-    std::string delimiters(",");
-    // Skip delimiters at the beginning
-    std::string::size_type lastPos = str.find_first_not_of(delimiters, 0);
-    // Find the first delimiter
-    std::string::size_type pos     = str.find_first_of(delimiters, lastPos);
-    while ((pos != std::string::npos) || (lastPos != std::string::npos)) {
-      // Found a token, add it to the vector
-      std::string token = str.substr(lastPos,pos-lastPos);
-      outputTimes_.push_back(Scalar(std::stod(token)));
-      if(pos==std::string::npos) break;
-
-      lastPos = str.find_first_not_of(delimiters, pos); // Skip delimiters
-      pos = str.find_first_of(delimiters, lastPos);     // Find next delimiter
-    }
-
-    // order output times
-    std::sort(outputTimes_.begin(),outputTimes_.end());
-    outputTimes_.erase(std::unique(outputTimes_.begin(),
-                                   outputTimes_.end()   ),
-                                   outputTimes_.end()     );
-  }
-
-  // Parse output indices
-  {
-    outputIndices_.clear();
-    std::string str = tscPL_->get<std::string>("Output Index List");
-    std::string delimiters(",");
-    std::string::size_type lastPos = str.find_first_not_of(delimiters, 0);
-    std::string::size_type pos     = str.find_first_of(delimiters, lastPos);
-    while ((pos != std::string::npos) || (lastPos != std::string::npos)) {
-      std::string token = str.substr(lastPos,pos-lastPos);
-      outputIndices_.push_back(int(std::stoi(token)));
-      if(pos==std::string::npos) break;
-
-      lastPos = str.find_first_not_of(delimiters, pos);
-      pos = str.find_first_of(delimiters, lastPos);
-    }
-
-    Scalar outputIndexInterval = tscPL_->get<int>("Output Index Interval");
-    Scalar output_i = getInitIndex();
-    while (output_i <= getFinalIndex()) {
-      outputIndices_.push_back(output_i);
-      output_i += outputIndexInterval;
-    }
-
-    // order output indices
-    std::sort(outputIndices_.begin(),outputIndices_.end());
-  }
-
-  return;
-}
 
 template<class Scalar>
 void TimeStepControl<Scalar>::setTimeStepControlStrategy(
   Teuchos::RCP<TimeStepControlStrategy<Scalar> > tscs)
 {
-   using Teuchos::RCP;
-   using Teuchos::ParameterList;
+  if ( tscs != Teuchos::null ) {
+    stepControlStrategy_ = tscs;
+    //stepControlStrategy_->addStrategy(tscs);
+  } else {
+    stepControlStrategy_ = Teuchos::rcp(new TimeStepControlStrategyConstant<Scalar>());
+    //stepControlStrategy_ = Teuchos::rcp(new TimeStepControlStrategy<Scalar>());
+  }
 
-   if (stepControlStrategy_ == Teuchos::null){
-      stepControlStrategy_ =
-         Teuchos::rcp(new TimeStepControlStrategyComposite<Scalar>());
-   }
-
-   if (tscs == Teuchos::null) {
-      // Create stepControlStrategy_ if null, otherwise keep current parameters.
-
-      if (getStepType() == "Constant"){
-         stepControlStrategy_->addStrategy(
-               Teuchos::rcp(new TimeStepControlStrategyConstant<Scalar>()));
-      } else if (getStepType() == "Variable") {
-         // add TSCS from "Time Step Control Strategy List"
-
-         RCP<ParameterList> tscsPL =
-            Teuchos::sublist(tscPL_,"Time Step Control Strategy",true);
-         // Construct from TSCS sublist
-         std::vector<std::string> tscsLists;
-
-         // string tokenizer
-         tscsLists.clear();
-         std::string str = tscsPL->get<std::string>("Time Step Control Strategy List");
-         std::string delimiters(",");
-         // Skip delimiters at the beginning
-         std::string::size_type lastPos = str.find_first_not_of(delimiters, 0);
-         // Find the first delimiter
-         std::string::size_type pos     = str.find_first_of(delimiters, lastPos);
-         while ((pos != std::string::npos) || (lastPos != std::string::npos)) {
-            // Found a token, add it to the vector
-            std::string token = str.substr(lastPos,pos-lastPos);
-            tscsLists.push_back(token);
-            if(pos==std::string::npos) break;
-
-            lastPos = str.find_first_not_of(delimiters, pos); // Skip delimiters
-            pos = str.find_first_of(delimiters, lastPos);     // Find next delimiter
-         }
-
-         // For each sublist name tokenized, add the TSCS
-         for( auto el: tscsLists){
-
-            RCP<Teuchos::ParameterList> pl =
-               Teuchos::rcp(new ParameterList(tscsPL->sublist(el)));
-
-            RCP<TimeStepControlStrategy<Scalar>> ts;
-
-            // construct appropriate TSCS
-            if(pl->get<std::string>("Name") == "Integral Controller")
-               ts = Teuchos::rcp(new TimeStepControlStrategyIntegralController<Scalar>(pl));
-            else if(pl->get<std::string>("Name") == "Basic VS")
-               ts = Teuchos::rcp(new TimeStepControlStrategyBasicVS<Scalar>(pl));
-
-            stepControlStrategy_->addStrategy(ts);
-         }
-      }
-
-   } else {
-      // just add the new tscs to the vector of strategies
-      stepControlStrategy_->addStrategy(tscs);
-   }
-
+  isInitialized_ = false;
 }
 
 
@@ -534,79 +507,222 @@ TimeStepControl<Scalar>::getValidParameters() const
 {
   Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
 
-  const double stdMax = double(1.0e+99);
-  pl->set<double>("Initial Time"         , 0.0    , "Initial time");
-  pl->set<double>("Final Time"           , stdMax , "Final time");
-  pl->set<int>   ("Initial Time Index"   , 0      , "Initial time index");
-  pl->set<int>   ("Final Time Index"     , 1000000, "Final time index");
-  pl->set<double>("Minimum Time Step"    , 0.0    , "Minimum time step size");
-  pl->set<double>("Initial Time Step"    , 1.0    , "Initial time step size");
-  pl->set<double>("Maximum Time Step"    , stdMax , "Maximum time step size");
-  pl->set<int>   ("Minimum Order", 0,
-    "Minimum time-integration order.  If set to zero (default), the\n"
-    "Stepper minimum order is used.");
-  pl->set<int>   ("Initial Order", 0,
-    "Initial time-integration order.  If set to zero (default), the\n"
-    "Stepper minimum order is used.");
-  pl->set<int>   ("Maximum Order", 0,
-    "Maximum time-integration order.  If set to zero (default), the\n"
-    "Stepper maximum order is used.");
-  pl->set<double>("Maximum Absolute Error", 1.0e-08, "Maximum absolute error");
-  pl->set<double>("Maximum Relative Error", 1.0e-08, "Maximum relative error");
-
-  pl->set<std::string>("Integrator Step Type", "Variable",
-    "'Integrator Step Type' indicates whether the Integrator will allow "
-    "the time step to be modified.\n"
-    "  'Constant' - Integrator will take constant time step sizes.\n"
-    "  'Variable' - Integrator will allow changes to the time step size.\n");
-
-  pl->set<bool>("Output Exactly On Output Times", true,
-    "This determines if the timestep size will be adjusted to exactly land\n"
-    "on the output times for 'Variable' timestepping (default=true).\n"
-    "When set to 'false' or for 'Constant' time stepping, the timestep\n"
-    "following the output time will be flagged for output.\n");
-
-  pl->set<std::string>("Output Time List", "",
-    "Comma deliminated list of output times");
-  pl->set<std::string>("Output Index List","",
-    "Comma deliminated list of output indices");
-  pl->set<double>("Output Time Interval", stdMax, "Output time interval");
-  pl->set<int>   ("Output Index Interval", 1000000, "Output index interval");
-
-  pl->set<int>   ("Maximum Number of Stepper Failures", 10,
-    "Maximum number of Stepper failures");
-  pl->set<int>   ("Maximum Number of Consecutive Stepper Failures", 5,
-    "Maximum number of consecutive Stepper failures");
-  pl->set<int>   ("Number of Time Steps", -1,
+  pl->set<double>("Initial Time"          , getInitTime()    , "Initial time");
+  pl->set<double>("Final Time"            , getFinalTime()   , "Final time");
+  pl->set<double>("Minimum Time Step"     , getMinTimeStep() , "Minimum time step size");
+  pl->set<double>("Initial Time Step"     , getInitTimeStep(), "Initial time step size");
+  pl->set<double>("Maximum Time Step"     , getMaxTimeStep() , "Maximum time step size");
+  pl->set<int>   ("Initial Time Index"    , getInitIndex()   , "Initial time index");
+  pl->set<int>   ("Final Time Index"      , getFinalIndex()  , "Final time index");
+  pl->set<int>   ("Number of Time Steps", getNumTimeSteps(),
     "The number of constant time steps.  The actual step size gets computed\n"
     "on the fly given the size of the time domain.  Overides and resets\n"
     "  'Final Time Index'     = 'Initial Time Index' + 'Number of Time Steps'\n"
     "  'Initial Time Step'    = "
     "('Final Time' - 'Initial Time')/'Number of Time Steps'\n"
     "  'Integrator Step Type' = 'Constant'\n");
+  pl->set<double>("Maximum Absolute Error", getMaxAbsError() , "Maximum absolute error");
+  pl->set<double>("Maximum Relative Error", getMaxRelError() , "Maximum relative error");
 
-   Teuchos::RCP<Teuchos::ParameterList> tscsPL = Teuchos::parameterList("Time Step Control Strategy");
-   tscsPL->set<std::string>("Time Step Control Strategy List","");
-   pl->set("Time Step Control Strategy", *tscsPL);
+  pl->set<std::string>("Integrator Step Type", getStepType(),
+    "'Integrator Step Type' indicates whether the Integrator will allow "
+    "the time step to be modified.\n"
+    "  'Constant' - Integrator will take constant time step sizes.\n"
+    "  'Variable' - Integrator will allow changes to the time step size.\n");
+
+  pl->set<bool>  ("Print Time Step Changes", getPrintDtChanges(),
+    "Print timestep size when it changes");
+
+  pl->set<bool>("Output Exactly On Output Times", getOutputExactly(),
+    "This determines if the timestep size will be adjusted to exactly land\n"
+    "on the output times for 'Variable' timestepping (default=true).\n"
+    "When set to 'false' or for 'Constant' time stepping, the timestep\n"
+    "following the output time will be flagged for output.\n");
+
+  pl->set<int>   ("Output Index Interval", getOutputIndexInterval(), "Output index interval");
+  pl->set<double>("Output Time Interval", getOutputTimeInterval(), "Output time interval");
+
+  {
+    std::vector<int> idx = getOutputIndices();
+    std::ostringstream list;
+    if (!idx.empty()) {
+      for(std::size_t i = 0; i < idx.size()-1; ++i) list << idx[i] << ", ";
+      list << idx[idx.size()-1];
+    }
+    pl->set<std::string>("Output Index List", list.str(),
+      "Comma deliminated list of output indices");
+  }
+  {
+    std::vector<Scalar> times = getOutputTimes();
+    std::ostringstream list;
+    if (!times.empty()) {
+      for(std::size_t i = 0; i < times.size()-1; ++i) list << times[i] << ", ";
+      list << times[times.size()-1];
+    }
+    pl->set<std::string>("Output Time List", list.str(),
+      "Comma deliminated list of output times");
+  }
+
+  pl->set<int>   ("Maximum Number of Stepper Failures", getMaxFailures(),
+    "Maximum number of Stepper failures");
+  pl->set<int>   ("Maximum Number of Consecutive Stepper Failures", getMaxConsecFailures(),
+    "Maximum number of consecutive Stepper failures");
+
+  Teuchos::RCP<Teuchos::ParameterList> tscsPL = Teuchos::parameterList("Time Step Control Strategy");
+  tscsPL->set<std::string>("Time Step Control Strategy List","");
+  pl->set("Time Step Control Strategy", *tscsPL);
+
   return pl;
 }
 
 
+// Nonmember constructor - ParameterList
+// ------------------------------------------------------------------------
 template <class Scalar>
-Teuchos::RCP<Teuchos::ParameterList>
-TimeStepControl<Scalar>::getNonconstParameterList()
+Teuchos::RCP<TimeStepControl<Scalar> > createTimeStepControl(
+  Teuchos::RCP<Teuchos::ParameterList> const& pList)
 {
-  return(tscPL_);
-}
+  using Teuchos::RCP;
+  using Teuchos::ParameterList;
 
+  auto tsc = Teuchos::rcp(new TimeStepControl<Scalar>());
+  if (pList == Teuchos::null) return tsc;
 
-template <class Scalar>
-Teuchos::RCP<Teuchos::ParameterList>
-TimeStepControl<Scalar>::unsetParameterList()
-{
-  Teuchos::RCP<Teuchos::ParameterList> temp_plist = tscPL_;
-  tscPL_ = Teuchos::null;
-  return(temp_plist);
+  pList->validateParametersAndSetDefaults(*tsc->getValidParameters(), 0);
+
+  tsc->setInitTime(         pList->get<double>("Initial Time"));
+  tsc->setFinalTime(        pList->get<double>("Final Time"));
+  tsc->setMinTimeStep(      pList->get<double>("Minimum Time Step"));
+  tsc->setInitTimeStep(     pList->get<double>("Initial Time Step"));
+  tsc->setMaxTimeStep(      pList->get<double>("Maximum Time Step"));
+  tsc->setInitIndex(        pList->get<int>   ("Initial Time Index"));
+  tsc->setFinalIndex(       pList->get<int>   ("Final Time Index"));
+  tsc->setMaxAbsError(      pList->get<double>("Maximum Absolute Error"));
+  tsc->setMaxRelError(      pList->get<double>("Maximum Relative Error"));
+  tsc->setStepType(         pList->get<std::string>("Integrator Step Type"));
+  tsc->setMaxFailures(      pList->get<int>   ("Maximum Number of Stepper Failures"));
+  tsc->setMaxConsecFailures(pList->get<int>   ("Maximum Number of Consecutive Stepper Failures"));
+  tsc->setPrintDtChanges(   pList->get<bool>  ("Print Time Step Changes"));
+  tsc->setNumTimeSteps(     pList->get<int>   ("Number of Time Steps"));
+
+  tsc->setOutputExactly(    pList->get<bool>  ("Output Exactly On Output Times"));
+
+  // Parse output indices
+  {
+    std::vector<int> outputIndices;
+    outputIndices.clear();
+    std::string str = pList->get<std::string>("Output Index List");
+    std::string delimiters(",");
+    std::string::size_type lastPos = str.find_first_not_of(delimiters, 0);
+    std::string::size_type pos     = str.find_first_of(delimiters, lastPos);
+    while ((pos != std::string::npos) || (lastPos != std::string::npos)) {
+      std::string token = str.substr(lastPos,pos-lastPos);
+      outputIndices.push_back(int(std::stoi(token)));
+      if(pos==std::string::npos) break;
+
+      lastPos = str.find_first_not_of(delimiters, pos);
+      pos = str.find_first_of(delimiters, lastPos);
+    }
+
+    int outputIndexInterval = pList->get<int>("Output Index Interval");
+    tsc->setOutputIndexInterval(outputIndexInterval);
+    Scalar output_i = tsc->getInitIndex();
+    while (output_i <= tsc->getFinalIndex()) {
+      outputIndices.push_back(output_i);
+      output_i += outputIndexInterval;
+    }
+
+    // order output indices
+    std::sort(outputIndices.begin(),outputIndices.end());
+    tsc->setOutputIndices(outputIndices);
+  }
+
+  // Parse output times
+  {
+    std::vector<Scalar> outputTimes;
+    outputTimes.clear();
+    std::string str = pList->get<std::string>("Output Time List");
+    std::string delimiters(",");
+    // Skip delimiters at the beginning
+    std::string::size_type lastPos = str.find_first_not_of(delimiters, 0);
+    // Find the first delimiter
+    std::string::size_type pos     = str.find_first_of(delimiters, lastPos);
+    while ((pos != std::string::npos) || (lastPos != std::string::npos)) {
+      // Found a token, add it to the vector
+      std::string token = str.substr(lastPos,pos-lastPos);
+      outputTimes.push_back(Scalar(std::stod(token)));
+      if(pos==std::string::npos) break;
+
+      lastPos = str.find_first_not_of(delimiters, pos); // Skip delimiters
+      pos = str.find_first_of(delimiters, lastPos);     // Find next delimiter
+    }
+
+    // order output times
+    std::sort(outputTimes.begin(),outputTimes.end());
+    outputTimes.erase(std::unique(outputTimes.begin(),
+                                   outputTimes.end()   ),
+                                   outputTimes.end()     );
+    tsc->setOutputTimes(outputTimes);
+  }
+
+  tsc->setOutputTimeInterval(pList->get<double>("Output Time Interval"));
+
+  // set the time step control strategy
+  auto stepControlStrategy =
+    Teuchos::rcp(new TimeStepControlStrategyComposite<Scalar>());
+
+  if (tsc->getStepType() == "Constant") {
+     stepControlStrategy->addStrategy(
+       Teuchos::rcp(new TimeStepControlStrategyConstant<Scalar>()));
+  } else if (tsc->getStepType() == "Variable") {
+     // add TSCS from "Time Step Control Strategy List"
+
+     RCP<ParameterList> tscsPL =
+       Teuchos::sublist(pList, "Time Step Control Strategy", true);
+     // Construct from TSCS sublist
+     std::vector<std::string> tscsLists;
+
+     // string tokenizer
+     tscsLists.clear();
+     std::string str = tscsPL->get<std::string>("Time Step Control Strategy List");
+     std::string delimiters(",");
+     // Skip delimiters at the beginning
+     std::string::size_type lastPos = str.find_first_not_of(delimiters, 0);
+     // Find the first delimiter
+     std::string::size_type pos     = str.find_first_of(delimiters, lastPos);
+     while ((pos != std::string::npos) || (lastPos != std::string::npos)) {
+        // Found a token, add it to the vector
+        std::string token = str.substr(lastPos,pos-lastPos);
+        tscsLists.push_back(token);
+        if(pos==std::string::npos) break;
+
+        lastPos = str.find_first_not_of(delimiters, pos); // Skip delimiters
+        pos = str.find_first_of(delimiters, lastPos);     // Find next delimiter
+     }
+
+     // For each sublist name tokenized, add the TSCS
+     for( auto el: tscsLists){
+
+        RCP<ParameterList> pl =
+           Teuchos::rcp(new ParameterList(tscsPL->sublist(el)));
+
+        RCP<TimeStepControlStrategy<Scalar>> ts;
+
+        // construct appropriate TSCS
+        if(pl->get<std::string>("Name") == "Integral Controller")
+           ts = Teuchos::rcp(new TimeStepControlStrategyIntegralController<Scalar>(pl));
+        else if(pl->get<std::string>("Name") == "Basic VS")
+           ts = Teuchos::rcp(new TimeStepControlStrategyBasicVS<Scalar>(pl));
+
+        stepControlStrategy->addStrategy(ts);
+     }
+  }
+
+  tsc->setTimeStepControlStrategy(stepControlStrategy);
+
+  tsc->initialize();
+
+  return tsc;
 }
 
 

--- a/packages/tempus/test/BDF2/Tempus_BDF2_CDR.xml
+++ b/packages/tempus/test/BDF2/Tempus_BDF2_CDR.xml
@@ -27,9 +27,6 @@
         <Parameter name="Minimum Time Step"      type="double" value="0.00001"/>
         <Parameter name="Initial Time Step"      type="double" value="0.1"/>
         <Parameter name="Maximum Time Step"      type="double" value="0.1"/>
-        <Parameter name="Minimum Order"          type="int"    value="1"/>
-        <Parameter name="Initial Order"          type="int"    value="1"/>
-        <Parameter name="Maximum Order"          type="int"    value="2"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
         <Parameter name="Integrator Step Type"  type="string" value="Constant"/>

--- a/packages/tempus/test/BDF2/Tempus_BDF2_SinCos.xml
+++ b/packages/tempus/test/BDF2/Tempus_BDF2_SinCos.xml
@@ -31,9 +31,6 @@
         <Parameter name="Minimum Time Step"      type="double" value="0.00001"/>
         <Parameter name="Initial Time Step"      type="double" value="0.0125"/>
         <Parameter name="Maximum Time Step"      type="double" value="0.1"/>
-        <Parameter name="Minimum Order"          type="int"    value="1"/>
-        <Parameter name="Initial Order"          type="int"    value="1"/>
-        <Parameter name="Maximum Order"          type="int"    value="2"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
         <Parameter name="Integrator Step Type"  type="string" value="Constant"/>

--- a/packages/tempus/test/BDF2/Tempus_BDF2_SinCos_AdaptDt.xml
+++ b/packages/tempus/test/BDF2/Tempus_BDF2_SinCos_AdaptDt.xml
@@ -30,9 +30,6 @@
         <Parameter name="Minimum Time Step"      type="double" value="0.00001"/>
         <Parameter name="Initial Time Step"      type="double" value="0.025"/>
         <Parameter name="Maximum Time Step"      type="double" value="0.025"/>
-        <Parameter name="Minimum Order"          type="int"    value="1"/>
-        <Parameter name="Initial Order"          type="int"    value="1"/>
-        <Parameter name="Maximum Order"          type="int"    value="2"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
         <Parameter name="Output Time List"       type="string" value="0.31"/>

--- a/packages/tempus/test/BDF2/Tempus_BDF2_SinCos_SA.xml
+++ b/packages/tempus/test/BDF2/Tempus_BDF2_SinCos_SA.xml
@@ -30,9 +30,6 @@
         <Parameter name="Minimum Time Step"      type="double" value="0.00001"/>
         <Parameter name="Initial Time Step"      type="double" value="0.1"/>
         <Parameter name="Maximum Time Step"      type="double" value="0.1"/>
-        <Parameter name="Minimum Order"          type="int"    value="1"/>
-        <Parameter name="Initial Order"          type="int"    value="1"/>
-        <Parameter name="Maximum Order"          type="int"    value="2"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
         <Parameter name="Integrator Step Type"  type="string" value="Constant"/>

--- a/packages/tempus/test/BDF2/Tempus_BDF2_SteadyQuadratic.xml
+++ b/packages/tempus/test/BDF2/Tempus_BDF2_SteadyQuadratic.xml
@@ -22,9 +22,6 @@
         <Parameter name="Minimum Time Step"      type="double" value="0.00001"/>
         <Parameter name="Initial Time Step"      type="double" value="1.0"/>
         <Parameter name="Maximum Time Step"      type="double" value="1.0"/>
-        <Parameter name="Minimum Order"          type="int"    value="1"/>
-        <Parameter name="Initial Order"          type="int"    value="1"/>
-        <Parameter name="Maximum Order"          type="int"    value="2"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
         <Parameter name="Integrator Step Type"  type="string" value="Constant"/>

--- a/packages/tempus/test/BDF2/Tempus_BDF2_VanDerPol.xml
+++ b/packages/tempus/test/BDF2/Tempus_BDF2_VanDerPol.xml
@@ -28,9 +28,6 @@
         <Parameter name="Minimum Time Step"      type="double" value="0.00001"/>
         <Parameter name="Initial Time Step"      type="double" value="0.00625"/>
         <Parameter name="Maximum Time Step"      type="double" value="0.1"/>
-        <Parameter name="Minimum Order"          type="int"    value="1"/>
-        <Parameter name="Initial Order"          type="int"    value="1"/>
-        <Parameter name="Maximum Order"          type="int"    value="2"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
         <Parameter name="Output Time List"       type="string" value=""/>

--- a/packages/tempus/test/BackwardEuler/Tempus_BackwardEuler_CDR.xml
+++ b/packages/tempus/test/BackwardEuler/Tempus_BackwardEuler_CDR.xml
@@ -26,9 +26,6 @@
         <Parameter name="Minimum Time Step"      type="double" value="0.00001"/>
         <Parameter name="Initial Time Step"      type="double" value="0.1"/>
         <Parameter name="Maximum Time Step"      type="double" value="0.1"/>
-        <Parameter name="Minimum Order"          type="int"    value="1"/>
-        <Parameter name="Initial Order"          type="int"    value="1"/>
-        <Parameter name="Maximum Order"          type="int"    value="1"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
         <Parameter name="Integrator Step Type"  type="string" value="Constant"/>

--- a/packages/tempus/test/BackwardEuler/Tempus_BackwardEuler_SinCos.xml
+++ b/packages/tempus/test/BackwardEuler/Tempus_BackwardEuler_SinCos.xml
@@ -29,9 +29,6 @@
         <Parameter name="Minimum Time Step"      type="double" value="0.00001"/>
         <Parameter name="Initial Time Step"      type="double" value="0.1"/>
         <Parameter name="Maximum Time Step"      type="double" value="0.1"/>
-        <Parameter name="Minimum Order"          type="int"    value="1"/>
-        <Parameter name="Initial Order"          type="int"    value="1"/>
-        <Parameter name="Maximum Order"          type="int"    value="1"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
         <Parameter name="Integrator Step Type"  type="string" value="Constant"/>

--- a/packages/tempus/test/BackwardEuler/Tempus_BackwardEuler_SteadyQuadratic.xml
+++ b/packages/tempus/test/BackwardEuler/Tempus_BackwardEuler_SteadyQuadratic.xml
@@ -22,9 +22,6 @@
         <Parameter name="Minimum Time Step"      type="double" value="0.00001"/>
         <Parameter name="Initial Time Step"      type="double" value="1.0"/>
         <Parameter name="Maximum Time Step"      type="double" value="1.0"/>
-        <Parameter name="Minimum Order"          type="int"    value="1"/>
-        <Parameter name="Initial Order"          type="int"    value="1"/>
-        <Parameter name="Maximum Order"          type="int"    value="1"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
         <Parameter name="Integrator Step Type"  type="string" value="Constant"/>

--- a/packages/tempus/test/BackwardEuler/Tempus_BackwardEuler_VanDerPol.xml
+++ b/packages/tempus/test/BackwardEuler/Tempus_BackwardEuler_VanDerPol.xml
@@ -27,9 +27,6 @@
         <Parameter name="Minimum Time Step"      type="double" value="1.0e-08"/>
         <Parameter name="Initial Time Step"      type="double" value="0.1"/>
         <Parameter name="Maximum Time Step"      type="double" value="0.1"/>
-        <Parameter name="Minimum Order"          type="int"    value="1"/>
-        <Parameter name="Initial Order"          type="int"    value="1"/>
-        <Parameter name="Maximum Order"          type="int"    value="1"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
         <Parameter name="Output Time List"       type="string" value=""/>

--- a/packages/tempus/test/DIRK/Tempus_DIRK_SinCos.xml
+++ b/packages/tempus/test/DIRK/Tempus_DIRK_SinCos.xml
@@ -29,9 +29,6 @@
         <Parameter name="Minimum Time Step"      type="double" value="0.00001"/>
         <Parameter name="Initial Time Step"      type="double" value="0.1"/>
         <Parameter name="Maximum Time Step"      type="double" value="0.1"/>
-        <Parameter name="Minimum Order"          type="int"    value="0"/>
-        <Parameter name="Initial Order"          type="int"    value="0"/>
-        <Parameter name="Maximum Order"          type="int"    value="0"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
         <Parameter name="Integrator Step Type"  type="string" value="Constant"/>

--- a/packages/tempus/test/DIRK/Tempus_DIRK_SteadyQuadratic.xml
+++ b/packages/tempus/test/DIRK/Tempus_DIRK_SteadyQuadratic.xml
@@ -22,9 +22,6 @@
         <Parameter name="Minimum Time Step"      type="double" value="0.00001"/>
         <Parameter name="Initial Time Step"      type="double" value="1.0"/>
         <Parameter name="Maximum Time Step"      type="double" value="1.0"/>
-        <Parameter name="Minimum Order"          type="int"    value="1"/>
-        <Parameter name="Initial Order"          type="int"    value="1"/>
-        <Parameter name="Maximum Order"          type="int"    value="10"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
         <Parameter name="Integrator Step Type"  type="string" value="Constant"/>

--- a/packages/tempus/test/DIRK/Tempus_DIRK_VanDerPol.xml
+++ b/packages/tempus/test/DIRK/Tempus_DIRK_VanDerPol.xml
@@ -35,9 +35,6 @@
         <Parameter name="Minimum Time Step"      type="double" value="0.00001"/>
         <Parameter name="Initial Time Step"      type="double" value="0.1"/>
         <Parameter name="Maximum Time Step"      type="double" value="1.0"/>
-        <Parameter name="Minimum Order"          type="int"    value="0"/>
-        <Parameter name="Initial Order"          type="int"    value="0"/>
-        <Parameter name="Maximum Order"          type="int"    value="0"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
         <Parameter name="Output Time List"       type="string" value=""/>

--- a/packages/tempus/test/ExplicitRK/Tempus_ExplicitRK_SinCos.xml
+++ b/packages/tempus/test/ExplicitRK/Tempus_ExplicitRK_SinCos.xml
@@ -29,9 +29,6 @@
         <Parameter name="Minimum Time Step"      type="double" value="0.00001"/>
         <Parameter name="Initial Time Step"      type="double" value="0.1"/>
         <Parameter name="Maximum Time Step"      type="double" value="0.1"/>
-        <Parameter name="Minimum Order"          type="int"    value="0"/>
-        <Parameter name="Initial Order"          type="int"    value="0"/>
-        <Parameter name="Maximum Order"          type="int"    value="0"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
         <Parameter name="Integrator Step Type"  type="string" value="Constant"/>

--- a/packages/tempus/test/ExplicitRK/Tempus_ExplicitRK_SteadyQuadratic.xml
+++ b/packages/tempus/test/ExplicitRK/Tempus_ExplicitRK_SteadyQuadratic.xml
@@ -22,9 +22,6 @@
         <Parameter name="Minimum Time Step"      type="double" value="0.00001"/>
         <Parameter name="Initial Time Step"      type="double" value="1.0"/>
         <Parameter name="Maximum Time Step"      type="double" value="1.0"/>
-        <Parameter name="Minimum Order"          type="int"    value="1"/>
-        <Parameter name="Initial Order"          type="int"    value="1"/>
-        <Parameter name="Maximum Order"          type="int"    value="10"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
         <Parameter name="Integrator Step Type"  type="string" value="Constant"/>

--- a/packages/tempus/test/ForwardEuler/Tempus_ForwardEuler_SinCos.xml
+++ b/packages/tempus/test/ForwardEuler/Tempus_ForwardEuler_SinCos.xml
@@ -29,9 +29,6 @@
         <Parameter name="Minimum Time Step"      type="double" value="0.00001"/>
         <Parameter name="Initial Time Step"      type="double" value="0.1"/>
         <Parameter name="Maximum Time Step"      type="double" value="0.1"/>
-        <Parameter name="Minimum Order"          type="int"    value="1"/>
-        <Parameter name="Initial Order"          type="int"    value="1"/>
-        <Parameter name="Maximum Order"          type="int"    value="1"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
         <Parameter name="Integrator Step Type"  type="string" value="Constant"/>

--- a/packages/tempus/test/ForwardEuler/Tempus_ForwardEuler_VanDerPol.xml
+++ b/packages/tempus/test/ForwardEuler/Tempus_ForwardEuler_VanDerPol.xml
@@ -27,9 +27,6 @@
         <Parameter name="Minimum Time Step"      type="double" value="0.00001"/>
         <Parameter name="Initial Time Step"      type="double" value="0.1"/>
         <Parameter name="Maximum Time Step"      type="double" value="0.1"/>
-        <Parameter name="Minimum Order"          type="int"    value="1"/>
-        <Parameter name="Initial Order"          type="int"    value="1"/>
-        <Parameter name="Maximum Order"          type="int"    value="1"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
         <Parameter name="Output Time List"       type="string" value=""/>

--- a/packages/tempus/test/IMEX_RK/Tempus_IMEX_RK_VanDerPol.xml
+++ b/packages/tempus/test/IMEX_RK/Tempus_IMEX_RK_VanDerPol.xml
@@ -27,9 +27,6 @@
         <Parameter name="Minimum Time Step"      type="double" value="0.00001"/>
         <Parameter name="Initial Time Step"      type="double" value="0.1"/>
         <Parameter name="Maximum Time Step"      type="double" value="1.0"/>
-        <Parameter name="Minimum Order"          type="int"    value="0"/>
-        <Parameter name="Initial Order"          type="int"    value="0"/>
-        <Parameter name="Maximum Order"          type="int"    value="0"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
         <Parameter name="Output Time List"       type="string" value=""/>

--- a/packages/tempus/test/IMEX_RK_Partitioned/Tempus_IMEX_RK_VanDerPol.xml
+++ b/packages/tempus/test/IMEX_RK_Partitioned/Tempus_IMEX_RK_VanDerPol.xml
@@ -27,9 +27,6 @@
         <Parameter name="Minimum Time Step"      type="double" value="0.00001"/>
         <Parameter name="Initial Time Step"      type="double" value="0.1"/>
         <Parameter name="Maximum Time Step"      type="double" value="1.0"/>
-        <Parameter name="Minimum Order"          type="int"    value="0"/>
-        <Parameter name="Initial Order"          type="int"    value="0"/>
-        <Parameter name="Maximum Order"          type="int"    value="0"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
         <Parameter name="Output Time List"       type="string" value=""/>

--- a/packages/tempus/test/Integrator/Tempus_IntegratorBasic_ref.xml
+++ b/packages/tempus/test/Integrator/Tempus_IntegratorBasic_ref.xml
@@ -13,25 +13,23 @@
     <ParameterList id="26" name="Time Step Control">
       <Parameter docString="" id="6" isDefault="true" isUsed="true" name="Initial Time" type="double" value="0.00000000000000000e+00"/>
       <Parameter docString="" id="7" isDefault="true" isUsed="true" name="Final Time" type="double" value="1.0e+99"/>
-      <Parameter docString="" id="8" isDefault="true" isUsed="true" name="Initial Time Index" type="int" value="0"/>
-      <Parameter docString="" id="9" isDefault="true" isUsed="true" name="Final Time Index" type="int" value="1000000"/>
       <Parameter docString="" id="10" isDefault="true" isUsed="true" name="Minimum Time Step" type="double" value="0.0"/>
       <Parameter docString="" id="11" isDefault="true" isUsed="true" name="Initial Time Step" type="double" value="1.0"/>
       <Parameter docString="" id="12" isDefault="true" isUsed="true" name="Maximum Time Step" type="double" value="1.0e+99"/>
-      <Parameter docString="" id="15" isDefault="true" isUsed="true" name="Minimum Order" type="int" value="1"/>
-      <Parameter docString="" id="16" isDefault="true" isUsed="true" name="Initial Order" type="int" value="1"/>
-      <Parameter docString="" id="17" isDefault="true" isUsed="true" name="Maximum Order" type="int" value="1"/>
+      <Parameter docString="" id="8" isDefault="true" isUsed="true" name="Initial Time Index" type="int" value="0"/>
+      <Parameter docString="" id="9" isDefault="true" isUsed="true" name="Final Time Index" type="int" value="1000000"/>
+      <Parameter docString="" id="25" isDefault="true" isUsed="true" name="Number of Time Steps" type="int" value="-1"/>
       <Parameter docString="" id="13" isDefault="true" isUsed="true" name="Maximum Absolute Error" type="double" value="1.00000000000000002e-08"/>
       <Parameter docString="" id="14" isDefault="true" isUsed="true" name="Maximum Relative Error" type="double" value="1.00000000000000002e-08"/>
       <Parameter docString="" id="18" isDefault="true" isUsed="true" name="Integrator Step Type" type="string" value="Variable"/>
+      <Parameter docString="" id="38" isDefault="true" isUsed="true" name="Print Time Step Changes" type="bool" value="true"/>
       <Parameter docString="" id="37" isDefault="true" isUsed="true" name="Output Exactly On Output Times" type="bool" value="true"/>
-      <Parameter docString="" id="19" isDefault="true" isUsed="true" name="Output Time List" type="string" value=""/>
-      <Parameter docString="" id="20" isDefault="true" isUsed="true" name="Output Index List" type="string" value=""/>
-      <Parameter docString="" id="21" isDefault="true" isUsed="true" name="Output Time Interval" type="double" value="1.0e+99"/>
       <Parameter docString="" id="22" isDefault="true" isUsed="true" name="Output Index Interval" type="int" value="1000000"/>
+      <Parameter docString="" id="21" isDefault="true" isUsed="true" name="Output Time Interval" type="double" value="1.0e+99"/>
+      <Parameter docString="" id="20" isDefault="true" isUsed="true" name="Output Index List" type="string" value=""/>
+      <Parameter docString="" id="19" isDefault="true" isUsed="true" name="Output Time List" type="string" value=""/>
       <Parameter docString="" id="23" isDefault="true" isUsed="true" name="Maximum Number of Stepper Failures" type="int" value="10"/>
       <Parameter docString="" id="24" isDefault="true" isUsed="true" name="Maximum Number of Consecutive Stepper Failures" type="int" value="5"/>
-      <Parameter docString="" id="25" isDefault="true" isUsed="true" name="Number of Time Steps" type="int" value="-1"/>
       <ParameterList id="32" name="Time Step Control Strategy">
           <Parameter docString="" id="33" isDefault="true" isUsed="true" name="Time Step Control Strategy List" type="string" value=""/>
       </ParameterList>

--- a/packages/tempus/test/Integrator/Tempus_IntegratorBasic_ref2.xml
+++ b/packages/tempus/test/Integrator/Tempus_IntegratorBasic_ref2.xml
@@ -15,25 +15,23 @@
     <ParameterList id="31" name="Time Step Control">
       <Parameter docString="" id="8" isDefault="true" isUsed="true" name="Initial Time" type="double" value="0.00000000000000000e+00"/>
       <Parameter docString="" id="9" isDefault="true" isUsed="true" name="Final Time" type="double" value="1.0e+99"/>
-      <Parameter docString="" id="10" isDefault="true" isUsed="true" name="Initial Time Index" type="int" value="0"/>
-      <Parameter docString="" id="11" isDefault="true" isUsed="true" name="Final Time Index" type="int" value="1000000"/>
       <Parameter docString="" id="12" isDefault="true" isUsed="true" name="Minimum Time Step" type="double" value="0.0"/>
       <Parameter docString="" id="13" isDefault="true" isUsed="true" name="Initial Time Step" type="double" value="1.0"/>
       <Parameter docString="" id="14" isDefault="true" isUsed="true" name="Maximum Time Step" type="double" value="1.0e+99"/>
-      <Parameter docString="" id="17" isDefault="true" isUsed="true" name="Minimum Order" type="int" value="1"/>
-      <Parameter docString="" id="18" isDefault="true" isUsed="true" name="Initial Order" type="int" value="1"/>
-      <Parameter docString="" id="19" isDefault="true" isUsed="true" name="Maximum Order" type="int" value="1"/>
+      <Parameter docString="" id="10" isDefault="true" isUsed="true" name="Initial Time Index" type="int" value="0"/>
+      <Parameter docString="" id="11" isDefault="true" isUsed="true" name="Final Time Index" type="int" value="1000000"/>
+      <Parameter docString="" id="27" isDefault="true" isUsed="true" name="Number of Time Steps" type="int" value="-1"/>
       <Parameter docString="" id="15" isDefault="true" isUsed="true" name="Maximum Absolute Error" type="double" value="1.00000000000000002e-08"/>
       <Parameter docString="" id="16" isDefault="true" isUsed="true" name="Maximum Relative Error" type="double" value="1.00000000000000002e-08"/>
       <Parameter docString="" id="20" isDefault="true" isUsed="true" name="Integrator Step Type" type="string" value="Variable"/>
+      <Parameter docString="" id="38" isDefault="true" isUsed="true" name="Print Time Step Changes" type="bool" value="true"/>
       <Parameter docString="" id="37" isDefault="true" isUsed="true" name="Output Exactly On Output Times" type="bool" value="true"/>
-      <Parameter docString="" id="21" isDefault="true" isUsed="true" name="Output Time List" type="string" value=""/>
-      <Parameter docString="" id="22" isDefault="true" isUsed="true" name="Output Index List" type="string" value=""/>
-      <Parameter docString="" id="23" isDefault="true" isUsed="true" name="Output Time Interval" type="double" value="1.0e+99"/>
       <Parameter docString="" id="24" isDefault="true" isUsed="true" name="Output Index Interval" type="int" value="1000000"/>
+      <Parameter docString="" id="23" isDefault="true" isUsed="true" name="Output Time Interval" type="double" value="1.0e+99"/>
+      <Parameter docString="" id="22" isDefault="true" isUsed="true" name="Output Index List" type="string" value=""/>
+      <Parameter docString="" id="21" isDefault="true" isUsed="true" name="Output Time List" type="string" value=""/>
       <Parameter docString="" id="25" isDefault="true" isUsed="true" name="Maximum Number of Stepper Failures" type="int" value="10"/>
       <Parameter docString="" id="26" isDefault="true" isUsed="true" name="Maximum Number of Consecutive Stepper Failures" type="int" value="5"/>
-      <Parameter docString="" id="27" isDefault="true" isUsed="true" name="Number of Time Steps" type="int" value="-1"/>
       <ParameterList id="32" name="Time Step Control Strategy">
           <Parameter docString="" id="33" isDefault="true" isUsed="true" name="Time Step Control Strategy List" type="string" value=""/>
       </ParameterList>

--- a/packages/tempus/test/OperatorSplit/Tempus_OperatorSplit_VanDerPol.xml
+++ b/packages/tempus/test/OperatorSplit/Tempus_OperatorSplit_VanDerPol.xml
@@ -27,9 +27,6 @@
         <Parameter name="Minimum Time Step"      type="double" value="0.00001"/>
         <Parameter name="Initial Time Step"      type="double" value="0.1"/>
         <Parameter name="Maximum Time Step"      type="double" value="0.1"/>
-        <Parameter name="Minimum Order"          type="int"    value="1"/>
-        <Parameter name="Initial Order"          type="int"    value="1"/>
-        <Parameter name="Maximum Order"          type="int"    value="1"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
         <Parameter name="Output Time List"       type="string" value=""/>

--- a/packages/tempus/test/PhysicsState/Tempus_PhysicsState_SinCos.xml
+++ b/packages/tempus/test/PhysicsState/Tempus_PhysicsState_SinCos.xml
@@ -29,9 +29,6 @@
         <Parameter name="Minimum Time Step"      type="double" value="0.00001"/>
         <Parameter name="Initial Time Step"      type="double" value="0.1"/>
         <Parameter name="Maximum Time Step"      type="double" value="0.1"/>
-        <Parameter name="Minimum Order"          type="int"    value="1"/>
-        <Parameter name="Initial Order"          type="int"    value="1"/>
-        <Parameter name="Maximum Order"          type="int"    value="1"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
         <Parameter name="Integrator Step Type"  type="string" value="Constant"/>

--- a/packages/tempus/test/Subcycling/Tempus_Subcycling_SinCos.xml
+++ b/packages/tempus/test/Subcycling/Tempus_Subcycling_SinCos.xml
@@ -29,9 +29,6 @@
         <Parameter name="Minimum Time Step"      type="double" value="0.00001"/>
         <Parameter name="Initial Time Step"      type="double" value="0.1"/>
         <Parameter name="Maximum Time Step"      type="double" value="0.1"/>
-        <Parameter name="Minimum Order"          type="int"    value="1"/>
-        <Parameter name="Initial Order"          type="int"    value="1"/>
-        <Parameter name="Maximum Order"          type="int"    value="1"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
         <Parameter name="Integrator Step Type"  type="string" value="Constant"/>

--- a/packages/tempus/test/Trapezoidal/Tempus_Trapezoidal_SinCos.xml
+++ b/packages/tempus/test/Trapezoidal/Tempus_Trapezoidal_SinCos.xml
@@ -29,9 +29,6 @@
         <Parameter name="Minimum Time Step"      type="double" value="0.00001"/>
         <Parameter name="Initial Time Step"      type="double" value="0.1"/>
         <Parameter name="Maximum Time Step"      type="double" value="0.1"/>
-        <Parameter name="Minimum Order"          type="int"    value="1"/>
-        <Parameter name="Initial Order"          type="int"    value="1"/>
-        <Parameter name="Maximum Order"          type="int"    value="1"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
         <Parameter name="Integrator Step Type"  type="string" value="Constant"/>

--- a/packages/tempus/test/Trapezoidal/Tempus_Trapezoidal_VanDerPol.xml
+++ b/packages/tempus/test/Trapezoidal/Tempus_Trapezoidal_VanDerPol.xml
@@ -27,9 +27,6 @@
         <Parameter name="Minimum Time Step"      type="double" value="0.00001"/>
         <Parameter name="Initial Time Step"      type="double" value="0.1"/>
         <Parameter name="Maximum Time Step"      type="double" value="0.1"/>
-        <Parameter name="Minimum Order"          type="int"    value="1"/>
-        <Parameter name="Initial Order"          type="int"    value="1"/>
-        <Parameter name="Maximum Order"          type="int"    value="1"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
         <Parameter name="Output Time List"       type="string" value=""/>

--- a/packages/tempus/unit_test/Tempus_UnitTest_ERK_ForwardEuler.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_ERK_ForwardEuler.cpp
@@ -96,7 +96,7 @@ TEUCHOS_UNIT_TEST(ERK_ForwardEuler, FSAL)
   auto workingState   = solutionHistory->getWorkingState();
   const double x_1    = get_ele(*(workingState->getX()), 0);
   const double xDot_1 = get_ele(*(workingState->getXDot()), 0);
-  std::cout << "xDot_1 = " << xDot_1 << std::endl;
+  //std::cout << "xDot_1 = " << xDot_1 << std::endl;
   TEST_ASSERT(std::abs(x_1   ) < relTol);
   TEST_ASSERT(std::abs(xDot_1) < relTol);
   TEST_FLOATING_EQUALITY(workingState->getTime(), 1.0, relTol);

--- a/packages/tempus/unit_test/Tempus_UnitTest_Subcycling.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_Subcycling.cpp
@@ -113,6 +113,7 @@ TEUCHOS_UNIT_TEST(Subcycling, MaxTimeStepDoesNotChangeDuring_takeStep)
   solutionHistory->initWorkingState();
 
   // Test
+  stepper->setSubcyclingInitTimeStep(0.25);
   stepper->setSubcyclingMaxTimeStep(0.5);
   double maxTimeStep_Set = stepper->getSubcyclingMaxTimeStep();
   stepper->takeStep(solutionHistory);


### PR DESCRIPTION
Remove all the internal uses of ParameterList from TimeStepControl.
This means moving the variables in the TimeStepControl ParameterList
to member data.  TimeStepControl will not longer inherit from
Teuchos::ParameterListAcceptor.  However TimeStepcontrol can still
be built from a ParameterList, and will still provide a valid
ParameterList.

 * Removed all internal usage of ParameterLists, except for
   getValidParameter().
 * Created two contructors: a default and a full argument list.
   The default constructor sets all the member data to their default values.
   The argument-list constructor sets all the member data to the
   arugment list values.
 * Removed contructor that takes a ParameterList, but there is now
   a non-member function, createTimeStepControl(), that will create
   a TimeStepControl from a Parameterlist.
 * The TimeStepControl::initialize() just checks if member data is
   "correct".  If so, it sets an isInitialized_ flag, which is checked
   during timesteps.  Any changes to the member data resets isInitialized_
   to false, and requires another initialize() call.
 * The TimeStepControlStrategy, stepControlStrategy_, is not longer a
   TimeStepControlStrategyComposite but just a TimeStepControlStrategy.
   This greatly simplifies the logic.  A TimeStepControlStrategyComposite
   can still be passed on the TimeStepControl from the application.
 * TimeStepControlStrategies now also inherit from Teuchos::Describable
   so that debug information can printed.
 * Since there are no plans to handle variable order time stepping,
   removed the concept of order control from TimeStepControl, but
   left the interfaces as deprecated code.


@trilinos/tempus 

## Motivation
Improve data flow transparency.


* Closes #8246 

## Stakeholder Feedback
Prompted by EMPIRE development.

## Testing
Pass all current tests.
