### PR TITLE
Add flags left behind in GCC 4.8.4 when moving to C++14

### DIFF
--- a/cmake/std/PullRequestLinuxGCC8.3.0TestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxGCC8.3.0TestingSettings.cmake
@@ -13,9 +13,13 @@ set (CMAKE_CXX_STANDARD "14" CACHE STRING "Set C++ standard to C++14")
 # Use the below option only when submitting to the dashboard
 #set (CTEST_USE_LAUNCHERS ON CACHE BOOL "Set by default for PR testing")
 
+set (Trilinos_ENABLE_OpenMP ON CACHE BOOL "Set by default for PR testing")
 set (MPI_EXEC_PRE_NUMPROCS_FLAGS "--bind-to;none" CACHE STRING "Set by default for PR testing")
 # NOTE: The above is a workaround for the problem of having threads on MPI
 # ranks bind to the same cores (see #2422).
+
+set(Tpetra_INST_SERIAL ON CACHE BOOL "Set by default for PR testing")
+# note: mortar uses serial mode no matter what so we need to instantiate this to get it's examples to work
 
 set (Trilinos_ENABLE_COMPLEX_DOUBLE ON CACHE BOOL "Set by default for PR testing to exercise complex doubles case")
 
@@ -23,6 +27,9 @@ set (CMAKE_CXX_EXTENSIONS OFF CACHE BOOL "Kokkos turns off CXX extensions")
 
 # Disable just one Teko sub-unit test that fails with openmpi 1.10 (#2712)
 set (Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D ON CACHE BOOL "Temporarily disabled in PR testing")
+
+# this build is different from the others in using static libraries
+set (BUILD_SHARED_LIBS OFF CACHE BOOL "Off by default for PR testing in GCC 4.8.4")
 
 include("${CMAKE_CURRENT_LIST_DIR}/PullRequestLinuxCommonTestingSettings.cmake")
 


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/framework 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
GCC 4.8.4 had flags set for:

- OpenMP = ON
- Tpetra INTA Serial = ON
- Build Share Libs = OFF

Since GCC 4.8.4 was removed as the PR testing scheme changed to support C++14, these flags will be placed in the GCC 8.3.0 PR build.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->
Related to #6968

<!--- 
## Stakeholder Feedback

If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
This has been tested by building this branch with the GCC 8.3.0 PR build manually.
[CDash](https://testing.sandia.gov/cdash/index.php?project=Trilinos&display=project&filtercount=2&showfilters=1&filtercombine=and&field1=buildname&compare1=63&value1=PR-lostflags-test-Trilinos_pullrequest_gcc_8.3.0-2722&field2=buildstamp&compare2=63&value2=Experimental)
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->