### PR TITLE
Sacado:  Add atomic implementations for +,-,*,/,max,min

### DIFF
--- a/packages/sacado/src/CMakeLists.txt
+++ b/packages/sacado/src/CMakeLists.txt
@@ -40,6 +40,7 @@ SET(HEADERS ${HEADERS}
   new_design/Sacado_Fad_Exp_SFad.hpp
   new_design/Sacado_Fad_Exp_ViewFad.hpp
   new_design/Sacado_Fad_Exp_DVFad.hpp
+  new_design/Sacado_Fad_Exp_Atomic.hpp
   )
 
 # FAD

--- a/packages/sacado/src/Sacado.hpp
+++ b/packages/sacado/src/Sacado.hpp
@@ -83,6 +83,7 @@
 #include "Sacado_Fad_Exp_SFad.hpp"
 #include "Sacado_Fad_Exp_SLFad.hpp"
 #include "Sacado_Fad_Exp_ViewFad.hpp"
+#include "Sacado_Fad_Exp_Atomic.hpp"
 #endif
 #include "Sacado_Fad_DFad.hpp"
 #include "Sacado_Fad_SFad.hpp"

--- a/packages/sacado/src/new_design/Sacado_Fad_Exp_Atomic.hpp
+++ b/packages/sacado/src/new_design/Sacado_Fad_Exp_Atomic.hpp
@@ -1,0 +1,470 @@
+// @HEADER
+// ***********************************************************************
+//
+//                           Sacado Package
+//                 Copyright (2006) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// This library is free software; you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as
+// published by the Free Software Foundation; either version 2.1 of the
+// License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+// USA
+// Questions? Contact David M. Gay (dmgay@sandia.gov) or Eric T. Phipps
+// (etphipp@sandia.gov).
+//
+// ***********************************************************************
+// @HEADER
+
+#ifndef SACADO_FAD_EXP_ATOMIC_HPP
+#define SACADO_FAD_EXP_ATOMIC_HPP
+
+#include "Sacado_ConfigDefs.h"
+#if defined(HAVE_SACADO_KOKKOSCORE)
+
+#include "Sacado_Fad_Exp_ViewFad.hpp"
+#include "Kokkos_Atomic.hpp"
+#include "impl/Kokkos_Error.hpp"
+
+namespace Sacado {
+
+  namespace Fad {
+  namespace Exp {
+
+    // Overload of Kokkos::atomic_add for ViewFad types.
+    template <typename ValT, unsigned sl, unsigned ss, typename U, typename T>
+    SACADO_INLINE_FUNCTION
+    void atomic_add(ViewFadPtr<ValT,sl,ss,U> dst, const Expr<T>& xx) {
+      using Kokkos::atomic_add;
+
+      const typename Expr<T>::derived_type& x = xx.derived();
+
+      const int xsz = x.size();
+      const int sz = dst->size();
+
+      // We currently cannot handle resizing since that would need to be
+      // done atomically.
+      if (xsz > sz)
+        Kokkos::abort(
+          "Sacado error: Fad resize within atomic_add() not supported!");
+
+      if (xsz != sz && sz > 0 && xsz > 0)
+        Kokkos::abort(
+          "Sacado error: Fad assignment of incompatiable sizes!");
+
+
+      if (sz > 0 && xsz > 0) {
+        SACADO_FAD_DERIV_LOOP(i,sz)
+          atomic_add(&(dst->fastAccessDx(i)), x.fastAccessDx(i));
+      }
+      SACADO_FAD_THREAD_SINGLE
+        atomic_add(&(dst->val()), x.val());
+    }
+
+    namespace Impl {
+      // Our implementation of Kokkos::atomic_oper_fetch() and
+      // Kokkos::atomic_fetch_oper() for Sacado types
+      template <typename Oper, typename DestPtrT, typename ValT, typename T>
+      SACADO_INLINE_FUNCTION
+      typename Sacado::BaseExprType< Expr<T> >::type
+      atomic_oper_fetch_impl(const Oper& op, DestPtrT dest, ValT* dest_val,
+                             const Expr<T>& x)
+      {
+        typedef typename Sacado::BaseExprType< Expr<T> >::type return_type;
+        const typename Expr<T>::derived_type& val = x.derived();
+
+#ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
+        while (!Kokkos::Impl::lock_address_host_space((void*)dest_val))
+          ;
+        Kokkos::memory_fence();
+        return_type return_val = op.apply(*dest, val);
+        *dest                  = return_val;
+        Kokkos::memory_fence();
+        Kokkos::Impl::unlock_address_host_space((void*)dest_val);
+        return return_val;
+#elif defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_CUDA) && !defined(SACADO_VIEW_CUDA_HIERARCHICAL) && !defined(SACADO_VIEW_CUDA_HIERARCHICAL_DFAD)
+        return_type return_val;
+        // This is a way to (hopefully) avoid dead lock in a warp
+        int done                 = 0;
+#ifdef KOKKOS_IMPL_CUDA_SYNCWARP_NEEDS_MASK
+        unsigned int mask        = KOKKOS_IMPL_CUDA_ACTIVEMASK;
+        unsigned int active      = KOKKOS_IMPL_CUDA_BALLOT_MASK(mask, 1);
+#else
+        unsigned int active = KOKKOS_IMPL_CUDA_BALLOT(1);
+#endif
+        unsigned int done_active = 0;
+        while (active != done_active) {
+          if (!done) {
+            if (Kokkos::Impl::lock_address_cuda_space((void*)dest_val)) {
+              Kokkos::memory_fence();
+              return_val = op.apply(*dest, val);
+              *dest      = return_val;
+              Kokkos::memory_fence();
+              Kokkos::Impl::unlock_address_cuda_space((void*)dest_val);
+              done = 1;
+            }
+          }
+#ifdef KOKKOS_IMPL_CUDA_SYNCWARP_NEEDS_MASK
+          done_active = KOKKOS_IMPL_CUDA_BALLOT_MASK(mask, done);
+#else
+          done_active = KOKKOS_IMPL_CUDA_BALLOT(done);
+#endif
+        }
+        return return_val;
+#elif defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_CUDA) && (defined(SACADO_VIEW_CUDA_HIERARCHICAL) || defined(SACADO_VIEW_CUDA_HIERARCHICAL_DFAD))
+        int go = 1;
+        while (go) {
+          if (threadIdx.x == 0)
+            go = !Kokkos::Impl::lock_address_cuda_space((void*)dest_val);
+          go = Kokkos::shfl(go, 0, blockDim.x);
+        }
+        Kokkos::memory_fence();
+        return_type return_val = op.apply(*dest, val);
+        *dest                  = return_val;
+        //*dest = op.apply(*dest, val);
+        Kokkos::memory_fence();
+        if (threadIdx.x == 0)
+          Kokkos::Impl::unlock_address_cuda_space((void*)dest_val);
+        return return_val;
+#elif defined(__HIP_DEVICE_COMPILE__)
+        // FIXME_HIP
+        Kokkos::abort("atomic_oper_fetch not implemented for large types.");
+        return_type return_val;
+        int done                 = 0;
+        unsigned int active      = __ballot(1);
+        unsigned int done_active = 0;
+        while (active != done_active) {
+          if (!done) {
+            // if (Kokkos::Impl::lock_address_hip_space((void*)dest_val))
+            {
+              return_val = op.apply(*dest, val);
+            *dest      = return_val;
+            // Kokkos::Impl::unlock_address_hip_space((void*)dest_val);
+            done = 1;
+            }
+          }
+          done_active = __ballot(done);
+        }
+        return return_val;
+#endif
+      }
+
+      template <typename Oper, typename DestPtrT, typename ValT, typename T>
+      SACADO_INLINE_FUNCTION
+      typename Sacado::BaseExprType< Expr<T> >::type
+      atomic_fetch_oper_impl(const Oper& op, DestPtrT dest, ValT* dest_val,
+                             const Expr<T>& x)
+      {
+        typedef typename Sacado::BaseExprType< Expr<T> >::type return_type;
+        const typename Expr<T>::derived_type& val = x.derived();
+
+#ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
+        while (!Kokkos::Impl::lock_address_host_space((void*)dest_val))
+          ;
+        Kokkos::memory_fence();
+        return_type return_val = *dest;
+        *dest                  = op.apply(return_val, val);
+        Kokkos::memory_fence();
+        Kokkos::Impl::unlock_address_host_space((void*)dest_val);
+        return return_val;
+#elif defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_CUDA) && !defined(SACADO_VIEW_CUDA_HIERARCHICAL) && !defined(SACADO_VIEW_CUDA_HIERARCHICAL_DFAD)
+        return_type return_val;
+        // This is a way to (hopefully) avoid dead lock in a warp
+        int done                 = 0;
+#ifdef KOKKOS_IMPL_CUDA_SYNCWARP_NEEDS_MASK
+        unsigned int mask        = KOKKOS_IMPL_CUDA_ACTIVEMASK;
+        unsigned int active      = KOKKOS_IMPL_CUDA_BALLOT_MASK(mask, 1);
+#else
+        unsigned int active = KOKKOS_IMPL_CUDA_BALLOT(1);
+#endif
+        unsigned int done_active = 0;
+        while (active != done_active) {
+          if (!done) {
+            if (Kokkos::Impl::lock_address_cuda_space((void*)dest_val)) {
+              Kokkos::memory_fence();
+              return_val = *dest;
+              *dest      = op.apply(return_val, val);
+              Kokkos::memory_fence();
+              Kokkos::Impl::unlock_address_cuda_space((void*)dest_val);
+              done = 1;
+            }
+          }
+#ifdef KOKKOS_IMPL_CUDA_SYNCWARP_NEEDS_MASK
+          done_active = KOKKOS_IMPL_CUDA_BALLOT_MASK(mask, done);
+#else
+          done_active = KOKKOS_IMPL_CUDA_BALLOT(done);
+#endif
+        }
+        return return_val;
+#elif defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_CUDA) && (defined(SACADO_VIEW_CUDA_HIERARCHICAL) || defined(SACADO_VIEW_CUDA_HIERARCHICAL_DFAD))
+        int go = 1;
+        while (go) {
+          if (threadIdx.x == 0)
+            go = !Kokkos::Impl::lock_address_cuda_space((void*)dest_val);
+          go = Kokkos::shfl(go, 0, blockDim.x);
+        }
+        Kokkos::memory_fence();
+        return_type return_val = *dest;
+        *dest                  = op.apply(return_val, val);
+        //*dest = op.apply(*dest, val);
+        Kokkos::memory_fence();
+        if (threadIdx.x == 0)
+          Kokkos::Impl::unlock_address_cuda_space((void*)dest_val);
+        return return_val;
+#elif defined(__HIP_DEVICE_COMPILE__)
+        // FIXME_HIP
+        Kokkos::abort("atomic_oper_fetch not implemented for large types.");
+        return_type return_val;
+        int done                 = 0;
+        unsigned int active      = __ballot(1);
+        unsigned int done_active = 0;
+        while (active != done_active) {
+          if (!done) {
+            // if (Kokkos::Impl::lock_address_hip_space((void*)dest_val))
+            {
+              return_val = *dest;
+              *dest      = op.apply(return_val, val);
+            // Kokkos::Impl::unlock_address_hip_space((void*)dest_val);
+            done = 1;
+            }
+          }
+          done_active = __ballot(done);
+        }
+        return return_val;
+#endif
+      }
+
+      // Overloads of Kokkos::atomic_oper_fetch/Kokkos::atomic_fetch_oper
+      // for Sacado types
+      template <typename Oper, typename S>
+      SACADO_INLINE_FUNCTION GeneralFad<S>
+      atomic_oper_fetch(const Oper& op, GeneralFad<S>* dest,
+                        const GeneralFad<S>& val)
+      {
+        return Impl::atomic_oper_fetch_impl(op, dest, &(dest->val()), val);
+      }
+      template <typename Oper, typename ValT, unsigned sl, unsigned ss,
+                typename U, typename T>
+      SACADO_INLINE_FUNCTION U
+      atomic_oper_fetch(const Oper& op, ViewFadPtr<ValT,sl,ss,U> dest,
+                        const Expr<T>& val)
+      {
+        return Impl::atomic_oper_fetch_impl(op, dest, &dest.val(), val);
+      }
+
+      template <typename Oper, typename S>
+      SACADO_INLINE_FUNCTION GeneralFad<S>
+      atomic_fetch_oper(const Oper& op, GeneralFad<S>* dest,
+                        const GeneralFad<S>& val)
+      {
+        return Impl::atomic_fetch_oper_impl(op, dest, &(dest->val()), val);
+      }
+      template <typename Oper, typename ValT, unsigned sl, unsigned ss,
+                typename U, typename T>
+      SACADO_INLINE_FUNCTION U
+      atomic_fetch_oper(const Oper& op, ViewFadPtr<ValT,sl,ss,U> dest,
+                        const Expr<T>& val)
+      {
+        return Impl::atomic_fetch_oper_impl(op, dest, &dest.val(), val);
+      }
+
+      // Our definition of the various Oper classes to be more type-flexible
+      struct MaxOper {
+        template <class Scalar1, class Scalar2>
+        KOKKOS_FORCEINLINE_FUNCTION
+        static auto apply(const Scalar1& val1, const Scalar2& val2)
+          -> decltype(max(val1,val2))
+        {
+          return max(val1,val2);
+        }
+      };
+      struct MinOper {
+        template <class Scalar1, class Scalar2>
+        KOKKOS_FORCEINLINE_FUNCTION
+        static auto apply(const Scalar1& val1, const Scalar2& val2)
+          -> decltype(min(val1,val2))
+        {
+          return min(val1,val2);
+        }
+      };
+      struct AddOper {
+        template <class Scalar1, class Scalar2>
+        KOKKOS_FORCEINLINE_FUNCTION
+        static auto apply(const Scalar1& val1, const Scalar2& val2)
+          -> decltype(val1+val2)
+        {
+          return val1 + val2;
+        }
+      };
+      struct SubOper {
+        template <class Scalar1, class Scalar2>
+        KOKKOS_FORCEINLINE_FUNCTION
+        static auto apply(const Scalar1& val1, const Scalar2& val2)
+          -> decltype(val1-val2)
+        {
+          return val1 - val2;
+        }
+      };
+      struct MulOper {
+        template <class Scalar1, class Scalar2>
+        KOKKOS_FORCEINLINE_FUNCTION
+        static auto apply(const Scalar1& val1, const Scalar2& val2)
+          -> decltype(val1*val2)
+        {
+          return val1 * val2;
+        }
+      };
+      struct DivOper {
+        template <class Scalar1, class Scalar2>
+        KOKKOS_FORCEINLINE_FUNCTION
+        static auto apply(const Scalar1& val1, const Scalar2& val2)
+          -> decltype(val1/val2)
+        {
+          return val1 / val2;
+        }
+      };
+
+    } // Impl
+
+    // Overload of Kokkos::atomic_*_fetch() and Kokkos::atomic_fetch_*()
+    // for Sacado types
+    template <typename S>
+    SACADO_INLINE_FUNCTION GeneralFad<S>
+    atomic_max_fetch(GeneralFad<S>* dest, const GeneralFad<S>& val) {
+      return Impl::atomic_oper_fetch(Impl::MaxOper(), dest, val);
+    }
+    template <typename ValT, unsigned sl, unsigned ss, typename U, typename T>
+    SACADO_INLINE_FUNCTION U
+    atomic_max_fetch(ViewFadPtr<ValT,sl,ss,U> dest, const Expr<T>& val) {
+      return Impl::atomic_oper_fetch(Impl::MaxOper(), dest, val);
+    }
+    template <typename S>
+    SACADO_INLINE_FUNCTION GeneralFad<S>
+    atomic_min_fetch(GeneralFad<S>* dest, const GeneralFad<S>& val) {
+      return Impl::atomic_oper_fetch(Impl::MinOper(), dest, val);
+    }
+    template <typename ValT, unsigned sl, unsigned ss, typename U, typename T>
+    SACADO_INLINE_FUNCTION U
+    atomic_min_fetch(ViewFadPtr<ValT,sl,ss,U> dest, const Expr<T>& val) {
+      return Impl::atomic_oper_fetch(Impl::MinOper(), dest, val);
+    }
+    template <typename S>
+    SACADO_INLINE_FUNCTION GeneralFad<S>
+    atomic_add_fetch(GeneralFad<S>* dest, const GeneralFad<S>& val) {
+      return Impl::atomic_oper_fetch(Impl::AddOper(), dest, val);
+    }
+    template <typename ValT, unsigned sl, unsigned ss, typename U, typename T>
+    SACADO_INLINE_FUNCTION U
+    atomic_add_fetch(ViewFadPtr<ValT,sl,ss,U> dest, const Expr<T>& val) {
+      return Impl::atomic_oper_fetch(Impl::AddOper(), dest, val);
+    }
+    template <typename S>
+    SACADO_INLINE_FUNCTION GeneralFad<S>
+    atomic_sub_fetch(GeneralFad<S>* dest, const GeneralFad<S>& val) {
+      return Impl::atomic_oper_fetch(Impl::SubOper(), dest, val);
+    }
+    template <typename ValT, unsigned sl, unsigned ss, typename U, typename T>
+    SACADO_INLINE_FUNCTION U
+    atomic_sub_fetch(ViewFadPtr<ValT,sl,ss,U> dest, const Expr<T>& val) {
+      return Impl::atomic_oper_fetch(Impl::SubOper(), dest, val);
+    }
+    template <typename S>
+    SACADO_INLINE_FUNCTION GeneralFad<S>
+    atomic_mul_fetch(GeneralFad<S>* dest, const GeneralFad<S>& val) {
+      return atomic_oper_fetch(Impl::MulOper(), dest, val);
+    }
+    template <typename ValT, unsigned sl, unsigned ss, typename U, typename T>
+    SACADO_INLINE_FUNCTION U
+    atomic_mul_fetch(ViewFadPtr<ValT,sl,ss,U> dest, const Expr<T>& val) {
+      return Impl::atomic_oper_fetch(Impl::MulOper(), dest, val);
+    }
+    template <typename S>
+    SACADO_INLINE_FUNCTION GeneralFad<S>
+    atomic_div_fetch(GeneralFad<S>* dest, const GeneralFad<S>& val) {
+      return Impl::atomic_oper_fetch(Impl::DivOper(), dest, val);
+    }
+    template <typename ValT, unsigned sl, unsigned ss, typename U, typename T>
+    SACADO_INLINE_FUNCTION U
+    atomic_div_fetch(ViewFadPtr<ValT,sl,ss,U> dest, const Expr<T>& val) {
+      return Impl::atomic_oper_fetch(Impl::DivOper(), dest, val);
+    }
+
+    template <typename S>
+    SACADO_INLINE_FUNCTION GeneralFad<S>
+    atomic_fetch_max(GeneralFad<S>* dest, const GeneralFad<S>& val) {
+      return Impl::atomic_fetch_oper(Impl::MaxOper(), dest, val);
+    }
+    template <typename ValT, unsigned sl, unsigned ss, typename U, typename T>
+    SACADO_INLINE_FUNCTION U
+    atomic_fetch_max(ViewFadPtr<ValT,sl,ss,U> dest, const Expr<T>& val) {
+      return Impl::atomic_fetch_oper(Impl::MaxOper(), dest, val);
+    }
+    template <typename S>
+    SACADO_INLINE_FUNCTION GeneralFad<S>
+    atomic_fetch_min(GeneralFad<S>* dest, const GeneralFad<S>& val) {
+      return Impl::atomic_fetch_oper(Impl::MinOper(), dest, val);
+    }
+    template <typename ValT, unsigned sl, unsigned ss, typename U, typename T>
+    SACADO_INLINE_FUNCTION U
+    atomic_fetch_min(ViewFadPtr<ValT,sl,ss,U> dest, const Expr<T>& val) {
+      return Impl::atomic_fetch_oper(Impl::MinOper(), dest, val);
+    }
+    template <typename S>
+    SACADO_INLINE_FUNCTION GeneralFad<S>
+    atomic_fetch_add(GeneralFad<S>* dest, const GeneralFad<S>& val) {
+      return Impl::atomic_fetch_oper(Impl::AddOper(), dest, val);
+    }
+    template <typename ValT, unsigned sl, unsigned ss, typename U, typename T>
+    SACADO_INLINE_FUNCTION U
+    atomic_fetch_add(ViewFadPtr<ValT,sl,ss,U> dest, const Expr<T>& val) {
+      return Impl::atomic_fetch_oper(Impl::AddOper(), dest, val);
+    }
+    template <typename S>
+    SACADO_INLINE_FUNCTION GeneralFad<S>
+    atomic_fetch_sub(GeneralFad<S>* dest, const GeneralFad<S>& val) {
+      return Impl::atomic_fetch_oper(Impl::SubOper(), dest, val);
+    }
+    template <typename ValT, unsigned sl, unsigned ss, typename U, typename T>
+    SACADO_INLINE_FUNCTION U
+    atomic_fetch_sub(ViewFadPtr<ValT,sl,ss,U> dest, const Expr<T>& val) {
+      return Impl::atomic_fetch_oper(Impl::SubOper(), dest, val);
+    }
+    template <typename S>
+    SACADO_INLINE_FUNCTION GeneralFad<S>
+    atomic_fetch_mul(GeneralFad<S>* dest, const GeneralFad<S>& val) {
+      return Impl::atomic_fetch_oper(Impl::MulOper(), dest, val);
+    }
+    template <typename ValT, unsigned sl, unsigned ss, typename U, typename T>
+    SACADO_INLINE_FUNCTION U
+    atomic_fetch_mul(ViewFadPtr<ValT,sl,ss,U> dest, const Expr<T>& val) {
+      return Impl::atomic_fetch_oper(Impl::MulOper(), dest, val);
+    }
+    template <typename S>
+    SACADO_INLINE_FUNCTION GeneralFad<S>
+    atomic_fetch_div(GeneralFad<S>* dest, const GeneralFad<S>& val) {
+      return Impl::atomic_fetch_oper(Impl::DivOper(), dest, val);
+    }
+    template <typename ValT, unsigned sl, unsigned ss, typename U, typename T>
+    SACADO_INLINE_FUNCTION U
+    atomic_fetch_div(ViewFadPtr<ValT,sl,ss,U> dest, const Expr<T>& val) {
+      return Impl::atomic_fetch_oper(Impl::DivOper(), dest, val);
+    }
+
+  } // namespace Exp
+  } // namespace Fad
+
+} // namespace Sacado
+
+#endif // HAVE_SACADO_KOKKOSCORE
+#endif // SACADO_FAD_EXP_VIEWFAD_HPP

--- a/packages/sacado/src/new_design/Sacado_Fad_Exp_MathFunctions.hpp
+++ b/packages/sacado/src/new_design/Sacado_Fad_Exp_MathFunctions.hpp
@@ -142,16 +142,101 @@ namespace Sacado {
     template <typename S>
     SACADO_INLINE_FUNCTION
     void atomic_add(GeneralFad<S>* dst, const GeneralFad<S>& x);
-
     template <typename ValT, unsigned sl, unsigned ss, typename U, typename T>
     SACADO_INLINE_FUNCTION
     void atomic_add(ViewFadPtr<ValT,sl,ss,U> dst, const Expr<T>& x);
+
+    template <typename S>
+    SACADO_INLINE_FUNCTION GeneralFad<S>
+    atomic_max_fetch(GeneralFad<S>* dest, const GeneralFad<S>& val);
+    template <typename ValT, unsigned sl, unsigned ss, typename U, typename T>
+    SACADO_INLINE_FUNCTION U
+    atomic_max_fetch(ViewFadPtr<ValT,sl,ss,U> dest, const Expr<T>& val);
+    template <typename S>
+    SACADO_INLINE_FUNCTION GeneralFad<S>
+    atomic_min_fetch(GeneralFad<S>* dest, const GeneralFad<S>& val);
+    template <typename ValT, unsigned sl, unsigned ss, typename U, typename T>
+    SACADO_INLINE_FUNCTION U
+    atomic_min_fetch(ViewFadPtr<ValT,sl,ss,U> dest, const Expr<T>& val);
+    template <typename S>
+    SACADO_INLINE_FUNCTION GeneralFad<S>
+    atomic_add_fetch(GeneralFad<S>* dst, const GeneralFad<S>& x);
+    template <typename ValT, unsigned sl, unsigned ss, typename U, typename T>
+    SACADO_INLINE_FUNCTION U
+    atomic_add_fetch(ViewFadPtr<ValT,sl,ss,U> dst, const Expr<T>& x);
+    template <typename S>
+    SACADO_INLINE_FUNCTION GeneralFad<S>
+    atomic_sub_fetch(GeneralFad<S>* dest, const GeneralFad<S>& val);
+    template <typename ValT, unsigned sl, unsigned ss, typename U, typename T>
+    SACADO_INLINE_FUNCTION U
+    atomic_sub_fetch(ViewFadPtr<ValT,sl,ss,U> dest, const Expr<T>& val);
+    template <typename S>
+    SACADO_INLINE_FUNCTION GeneralFad<S>
+    atomic_mul_fetch(GeneralFad<S>* dest, const GeneralFad<S>& val);
+    template <typename ValT, unsigned sl, unsigned ss, typename U, typename T>
+    SACADO_INLINE_FUNCTION U
+    atomic_mul_fetch(ViewFadPtr<ValT,sl,ss,U> dest, const Expr<T>& val);
+    template <typename S>
+    SACADO_INLINE_FUNCTION GeneralFad<S>
+    atomic_div_fetch(GeneralFad<S>* dest, const GeneralFad<S>& val);
+    template <typename ValT, unsigned sl, unsigned ss, typename U, typename T>
+    SACADO_INLINE_FUNCTION U
+    atomic_div_fetch(ViewFadPtr<ValT,sl,ss,U> dest, const Expr<T>& val);
+
+    template <typename S>
+    SACADO_INLINE_FUNCTION GeneralFad<S>
+    atomic_fetch_max(GeneralFad<S>* dest, const GeneralFad<S>& val);
+    template <typename ValT, unsigned sl, unsigned ss, typename U, typename T>
+    SACADO_INLINE_FUNCTION U
+    atomic_fetch_max(ViewFadPtr<ValT,sl,ss,U> dest, const Expr<T>& val);
+    template <typename S>
+    SACADO_INLINE_FUNCTION GeneralFad<S>
+    atomic_fetch_min(GeneralFad<S>* dest, const GeneralFad<S>& val);
+    template <typename ValT, unsigned sl, unsigned ss, typename U, typename T>
+    SACADO_INLINE_FUNCTION U
+    atomic_fetch_min(ViewFadPtr<ValT,sl,ss,U> dest, const Expr<T>& val);
+    template <typename S>
+    SACADO_INLINE_FUNCTION GeneralFad<S>
+    atomic_fetch_add(GeneralFad<S>* dst, const GeneralFad<S>& x);
+    template <typename ValT, unsigned sl, unsigned ss, typename U, typename T>
+    SACADO_INLINE_FUNCTION U
+    atomic_fetch_add(ViewFadPtr<ValT,sl,ss,U> dst, const Expr<T>& x);
+    template <typename S>
+    SACADO_INLINE_FUNCTION GeneralFad<S>
+    atomic_fetch_sub(GeneralFad<S>* dest, const GeneralFad<S>& val);
+    template <typename ValT, unsigned sl, unsigned ss, typename U, typename T>
+    SACADO_INLINE_FUNCTION U
+    atomic_fetch_sub(ViewFadPtr<ValT,sl,ss,U> dest, const Expr<T>& val);
+    template <typename S>
+    SACADO_INLINE_FUNCTION GeneralFad<S>
+    atomic_fetch_mul(GeneralFad<S>* dest, const GeneralFad<S>& val);
+    template <typename ValT, unsigned sl, unsigned ss, typename U, typename T>
+    SACADO_INLINE_FUNCTION U
+    atomic_fetch_mul(ViewFadPtr<ValT,sl,ss,U> dest, const Expr<T>& val);
+    template <typename S>
+    SACADO_INLINE_FUNCTION GeneralFad<S>
+    atomic_fetch_div(GeneralFad<S>* dest, const GeneralFad<S>& val);
+    template <typename ValT, unsigned sl, unsigned ss, typename U, typename T>
+    SACADO_INLINE_FUNCTION U
+    atomic_fetch_div(ViewFadPtr<ValT,sl,ss,U> dest, const Expr<T>& val);
   }
   }
 }
 
 namespace Kokkos {
   using Sacado::Fad::Exp::atomic_add;
+  using Sacado::Fad::Exp::atomic_max_fetch;
+  using Sacado::Fad::Exp::atomic_min_fetch;
+  using Sacado::Fad::Exp::atomic_add_fetch;
+  using Sacado::Fad::Exp::atomic_sub_fetch;
+  using Sacado::Fad::Exp::atomic_mul_fetch;
+  using Sacado::Fad::Exp::atomic_div_fetch;
+  using Sacado::Fad::Exp::atomic_fetch_max;
+  using Sacado::Fad::Exp::atomic_fetch_min;
+  using Sacado::Fad::Exp::atomic_fetch_add;
+  using Sacado::Fad::Exp::atomic_fetch_sub;
+  using Sacado::Fad::Exp::atomic_fetch_mul;
+  using Sacado::Fad::Exp::atomic_fetch_div;
 }
 
 #endif

--- a/packages/sacado/src/new_design/Sacado_Fad_Exp_ViewFad.hpp
+++ b/packages/sacado/src/new_design/Sacado_Fad_Exp_ViewFad.hpp
@@ -63,40 +63,8 @@ namespace Sacado {
 
       // Add overload of dereference operator
       SACADO_INLINE_FUNCTION
-      view_fad_type& operator*() { *this; }
+      view_fad_type& operator*() { return *this; }
     };
-
-#if defined(HAVE_SACADO_KOKKOSCORE)
-    // Overload of Kokkos::atomic_add for ViewFad types.
-    template <typename ValT, unsigned sl, unsigned ss, typename U, typename T>
-    SACADO_INLINE_FUNCTION
-    void atomic_add(ViewFadPtr<ValT,sl,ss,U> dst, const Expr<T>& xx) {
-      using Kokkos::atomic_add;
-
-      const typename Expr<T>::derived_type& x = xx.derived();
-
-      const int xsz = x.size();
-      const int sz = dst->size();
-
-      // We currently cannot handle resizing since that would need to be
-      // done atomically.
-      if (xsz > sz)
-        Kokkos::abort(
-          "Sacado error: Fad resize within atomic_add() not supported!");
-
-      if (xsz != sz && sz > 0 && xsz > 0)
-        Kokkos::abort(
-          "Sacado error: Fad assignment of incompatiable sizes!");
-
-
-      if (sz > 0 && xsz > 0) {
-        SACADO_FAD_DERIV_LOOP(i,sz)
-          atomic_add(&(dst->fastAccessDx(i)), x.fastAccessDx(i));
-      }
-      SACADO_FAD_THREAD_SINGLE
-        atomic_add(&(dst->val()), x.val());
-    }
-#endif
 
   } // namespace Exp
   } // namespace Fad

--- a/packages/sacado/test/UnitTests/CMakeLists.txt
+++ b/packages/sacado/test/UnitTests/CMakeLists.txt
@@ -111,6 +111,24 @@ IF (Sacado_ENABLE_TeuchosCore)
         STANDARD_PASS_OUTPUT
         NUM_MPI_PROCS 1
         )
+
+      TRIBITS_ADD_EXECUTABLE_AND_TEST(
+        FadKokkosAtomicTests_Serial
+        SOURCES Fad_KokkosAtomicTests.hpp
+                Fad_KokkosAtomicTests_Serial.cpp
+        COMM serial mpi
+        STANDARD_PASS_OUTPUT
+        NUM_MPI_PROCS 1
+        )
+
+      TRIBITS_ADD_EXECUTABLE_AND_TEST(
+        FadKokkosAtomicTests_NoViewSpec_Serial
+        SOURCES Fad_KokkosAtomicTests.hpp
+                Fad_KokkosAtomicTests_NoViewSpec_Serial.cpp
+        COMM serial mpi
+        STANDARD_PASS_OUTPUT
+        NUM_MPI_PROCS 1
+        )
     ENDIF ()
 
     IF (Kokkos_ENABLE_PTHREAD)
@@ -153,6 +171,26 @@ IF (Sacado_ENABLE_TeuchosCore)
         NUM_MPI_PROCS 1
         RUN_SERIAL
         )
+
+      TRIBITS_ADD_EXECUTABLE_AND_TEST(
+        FadKokkosAtomicTests_Threads
+        SOURCES Fad_KokkosAtomicTests.hpp
+                Fad_KokkosAtomicTests_Threads.cpp
+        COMM serial mpi
+        STANDARD_PASS_OUTPUT
+        NUM_MPI_PROCS 1
+        RUN_SERIAL
+        )
+
+      TRIBITS_ADD_EXECUTABLE_AND_TEST(
+        FadKokkosAtomicTests_NoViewSpec_Threads
+        SOURCES Fad_KokkosAtomicTests.hpp
+                Fad_KokkosAtomicTests_NoViewSpec_Threads.cpp
+        COMM serial mpi
+        STANDARD_PASS_OUTPUT
+        NUM_MPI_PROCS 1
+        RUN_SERIAL
+        )
     ENDIF()
 
     IF (Kokkos_ENABLE_OPENMP)
@@ -190,6 +228,26 @@ IF (Sacado_ENABLE_TeuchosCore)
         FadFadKokkosTests_OpenMP
         SOURCES Fad_Fad_KokkosTests.hpp
                 Fad_Fad_KokkosTests_OpenMP.cpp
+        COMM serial mpi
+        STANDARD_PASS_OUTPUT
+        NUM_MPI_PROCS 1
+        RUN_SERIAL
+        )
+
+      TRIBITS_ADD_EXECUTABLE_AND_TEST(
+        FadKokkosAtomicTests_OpenMP
+        SOURCES Fad_KokkosAtomicTests.hpp
+                Fad_KokkosAtomicTests_OpenMP.cpp
+        COMM serial mpi
+        STANDARD_PASS_OUTPUT
+        NUM_MPI_PROCS 1
+        RUN_SERIAL
+        )
+
+      TRIBITS_ADD_EXECUTABLE_AND_TEST(
+        FadKokkosAtomicTests_NoViewSpec_OpenMP
+        SOURCES Fad_KokkosAtomicTests.hpp
+                Fad_KokkosAtomicTests_NoViewSpec_OpenMP.cpp
         COMM serial mpi
         STANDARD_PASS_OUTPUT
         NUM_MPI_PROCS 1
@@ -262,6 +320,56 @@ IF (Sacado_ENABLE_TeuchosCore)
         FadFadKokkosTests_Cuda
         SOURCES Fad_Fad_KokkosTests.hpp
                 Fad_Fad_KokkosTests_Cuda.cpp
+        COMM serial mpi
+        STANDARD_PASS_OUTPUT
+        NUM_MPI_PROCS 1
+        RUN_SERIAL
+        )
+
+      TRIBITS_ADD_EXECUTABLE_AND_TEST(
+        FadKokkosAtomicTests_Cuda
+        SOURCES Fad_KokkosAtomicTests.hpp
+                Fad_KokkosAtomicTests_Cuda.cpp
+        COMM serial mpi
+        STANDARD_PASS_OUTPUT
+        NUM_MPI_PROCS 1
+        RUN_SERIAL
+        )
+
+      TRIBITS_ADD_EXECUTABLE_AND_TEST(
+        FadKokkosAtomicTests_NoViewSpec_Cuda
+        SOURCES Fad_KokkosAtomicTests.hpp
+                Fad_KokkosAtomicTests_NoViewSpec_Cuda.cpp
+        COMM serial mpi
+        STANDARD_PASS_OUTPUT
+        NUM_MPI_PROCS 1
+        RUN_SERIAL
+        )
+
+      TRIBITS_ADD_EXECUTABLE_AND_TEST(
+        FadKokkosAtomicTests_Cuda_Hierarchical
+        SOURCES Fad_KokkosAtomicTests.hpp
+                Fad_KokkosAtomicTests_Cuda_Hierarchical.cpp
+        COMM serial mpi
+        STANDARD_PASS_OUTPUT
+        NUM_MPI_PROCS 1
+        RUN_SERIAL
+        )
+
+      TRIBITS_ADD_EXECUTABLE_AND_TEST(
+        FadKokkosAtomicTests_Cuda_Hierarchical_SFad
+        SOURCES Fad_KokkosAtomicTests.hpp
+                Fad_KokkosAtomicTests_Cuda_Hierarchical_SFad.cpp
+        COMM serial mpi
+        STANDARD_PASS_OUTPUT
+        NUM_MPI_PROCS 1
+        RUN_SERIAL
+        )
+
+      TRIBITS_ADD_EXECUTABLE_AND_TEST(
+        FadKokkosAtomicTests_Cuda_Hierarchical_DFad
+        SOURCES Fad_KokkosAtomicTests.hpp
+                Fad_KokkosAtomicTests_Cuda_Hierarchical_DFad.cpp
         COMM serial mpi
         STANDARD_PASS_OUTPUT
         NUM_MPI_PROCS 1

--- a/packages/sacado/test/UnitTests/Fad_KokkosAtomicTests.hpp
+++ b/packages/sacado/test/UnitTests/Fad_KokkosAtomicTests.hpp
@@ -1,0 +1,425 @@
+// @HEADER
+// ***********************************************************************
+//
+//                           Sacado Package
+//                 Copyright (2006) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// This library is free software; you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as
+// published by the Free Software Foundation; either version 2.1 of the
+// License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+// USA
+// Questions? Contact David M. Gay (dmgay@sandia.gov) or Eric T. Phipps
+// (etphipp@sandia.gov).
+//
+// ***********************************************************************
+// @HEADER
+#include "Teuchos_TestingHelpers.hpp"
+
+#include "Sacado.hpp"
+
+template <typename T>
+struct is_dfad {
+  static const bool value = false;
+};
+
+template <typename T>
+struct is_dfad< Sacado::Fad::Exp::DFad<T> > {
+  static const bool value = true;
+};
+
+template <typename FadType1, typename FadType2>
+bool checkFads(const FadType1& x, const FadType2& x2,
+               Teuchos::FancyOStream& out, double tol = 1.0e-15)
+{
+  bool success = true;
+
+  // Check sizes match
+  TEUCHOS_TEST_EQUALITY(x.size(), x2.size(), out, success);
+
+  // Check values match
+  TEUCHOS_TEST_FLOATING_EQUALITY(x.val(), x2.val(), tol, out, success);
+
+  // Check derivatives match
+  for (int i=0; i<x.size(); ++i)
+    TEUCHOS_TEST_FLOATING_EQUALITY(x.dx(i), x2.dx(i), tol, out, success);
+
+  return success;
+}
+
+template <typename fadtype, typename ordinal>
+inline
+fadtype generate_fad( const ordinal num_rows,
+                      const ordinal num_cols,
+                      const ordinal fad_size,
+                      const ordinal row,
+                      const ordinal col )
+{
+  typedef typename fadtype::value_type scalar;
+  fadtype x(fad_size, scalar(0.0));
+
+  const scalar x_row = 100.0 + scalar(num_rows) / scalar(row+1);
+  const scalar x_col =  10.0 + scalar(num_cols) / scalar(col+1);
+  x.val() = x_row + x_col;
+  for (ordinal i=0; i<fad_size; ++i) {
+    const scalar x_fad = 1.0 + scalar(fad_size) / scalar(i+1);
+    x.fastAccessDx(i) = x_row + x_col + x_fad;
+  }
+  return x;
+}
+
+#ifndef GLOBAL_FAD_SIZE
+#define GLOBAL_FAD_SIZE 5
+#endif
+const int global_num_rows = 11;
+const int global_num_cols = 7;
+const int global_fad_size = GLOBAL_FAD_SIZE;
+
+struct AddTag {
+  static double init() { return 0.0; }
+  template <typename T1, typename T2>
+  static auto apply(const T1& a, const T2& b) -> decltype(a+b)
+  {
+    return a+b;
+  }
+};
+struct SubTag {
+  static double init() { return 0.0; }
+  template <typename T1, typename T2>
+  static auto apply(const T1& a, const T2& b) -> decltype(a-b)
+  {
+    return a-b;
+  }
+};
+struct MulTag {
+  static double init() { return 1.0; }
+  template <typename T1, typename T2>
+  static auto apply(const T1& a, const T2& b) -> decltype(a*b)
+  {
+    return a*b;
+  }
+};
+struct DivTag {
+  static double init() { return 1.0; }
+  template <typename T1, typename T2>
+  static auto apply(const T1& a, const T2& b) -> decltype(a/b)
+  {
+    return a/b;
+  }
+};
+struct MaxTag {
+  static double init() { return 1.0; }
+  template <typename T1, typename T2>
+  static auto apply(const T1& a, const T2& b) -> decltype(max(a,b))
+  {
+    return max(a,b);
+  }
+};
+struct MinTag {
+  static double init() { return 1.0; }
+  template <typename T1, typename T2>
+  static auto apply(const T1& a, const T2& b) -> decltype(min(a,b))
+  {
+    return min(a,b);
+  }
+};
+
+// Kernel to test atomic_add
+template <typename ViewType, typename ScalarViewType, bool OperFetch>
+struct AtomicKernel {
+  typedef typename ViewType::execution_space execution_space;
+  typedef typename ViewType::size_type size_type;
+  typedef typename Kokkos::TeamPolicy< execution_space>::member_type team_handle;
+  typedef typename Kokkos::ThreadLocalScalarType<ViewType>::type local_scalar_type;
+  static const size_type stride = Kokkos::ViewScalarStride<ViewType>::stride;
+
+  const ViewType m_v;
+  const ScalarViewType m_s;
+
+  AtomicKernel(const ViewType& v, const ScalarViewType& s) :
+    m_v(v), m_s(s) {};
+
+  KOKKOS_INLINE_FUNCTION
+  void operator() (AddTag tag, const size_type i) const {
+    local_scalar_type x = m_v(i);
+    if (OperFetch)
+      Kokkos::atomic_add_fetch(&(m_s()), x);
+    else
+      Kokkos::atomic_fetch_add(&(m_s()), x);
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator() (SubTag tag, const size_type i) const {
+    local_scalar_type x = m_v(i);
+    if (OperFetch)
+      Kokkos::atomic_sub_fetch(&(m_s()), x);
+    else
+      Kokkos::atomic_fetch_sub(&(m_s()), x);
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator() (MulTag tag, const size_type i) const {
+    local_scalar_type x = m_v(i);
+    if (OperFetch)
+      Kokkos::atomic_mul_fetch(&(m_s()), x);
+    else
+      Kokkos::atomic_fetch_mul(&(m_s()), x);
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator() (DivTag tag, const size_type i) const {
+    local_scalar_type x = m_v(i);
+    if (OperFetch)
+      Kokkos::atomic_div_fetch(&(m_s()), x);
+    else
+      Kokkos::atomic_fetch_div(&(m_s()), x);
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator() (MaxTag tag, const size_type i) const {
+    local_scalar_type x = m_v(i);
+    if (OperFetch)
+      Kokkos::atomic_max_fetch(&(m_s()), x);
+    else
+      Kokkos::atomic_fetch_max(&(m_s()), x);
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator() (MinTag tag, const size_type i) const {
+    local_scalar_type x = m_v(i);
+    if (OperFetch)
+      Kokkos::atomic_min_fetch(&(m_s()), x);
+    else
+      Kokkos::atomic_fetch_min(&(m_s()), x);
+  }
+
+  template <typename Tag>
+  KOKKOS_INLINE_FUNCTION
+  void operator()( Tag tag, const team_handle& team ) const
+  {
+    const size_type i = team.league_rank()*team.team_size() + team.team_rank();
+    if (i < m_v.extent(0))
+      (*this)(tag, i);
+  }
+
+  // Kernel launch
+  template <typename Tag>
+  static void apply(Tag tag, const ViewType& v, const ScalarViewType& s) {
+    const size_type nrow = v.extent(0);
+
+#if defined (KOKKOS_ENABLE_CUDA) && defined (SACADO_VIEW_CUDA_HIERARCHICAL)
+    const bool use_team =
+      std::is_same<execution_space, Kokkos::Cuda>::value &&
+      Kokkos::is_view_fad_contiguous<ViewType>::value &&
+      ( stride > 1 );
+#elif defined (KOKKOS_ENABLE_CUDA) && defined (SACADO_VIEW_CUDA_HIERARCHICAL_DFAD)
+    const bool use_team =
+      std::is_same<execution_space, Kokkos::Cuda>::value &&
+      Kokkos::is_view_fad_contiguous<ViewType>::value &&
+      is_dfad<typename ViewType::non_const_value_type>::value;
+#else
+    const bool use_team = false;
+#endif
+
+    if (use_team) {
+      const size_type team_size = 256 / stride;
+      Kokkos::TeamPolicy<execution_space, Tag> policy(
+        (nrow+team_size-1)/team_size, team_size, stride );
+      Kokkos::parallel_for( policy, AtomicKernel(v,s) );
+    }
+    else {
+      Kokkos::RangePolicy<execution_space, Tag> policy( 0, nrow );
+      Kokkos::parallel_for( policy, AtomicKernel(v,s) );
+    }
+  }
+};
+
+template <typename FadType, typename Layout, typename Device, bool OperFetch,
+          typename TagType>
+bool testAtomic(const TagType& tag, Teuchos::FancyOStream& out)
+{
+  typedef Kokkos::View<FadType*,Layout,Device> ViewType;
+  typedef Kokkos::View<FadType,Layout,Device> ScalarViewType;
+  typedef typename ViewType::size_type size_type;
+  typedef typename ViewType::HostMirror host_view_type;
+  typedef typename ScalarViewType::HostMirror host_scalar_view_type;
+
+  const size_type num_rows = global_num_rows;
+  const size_type fad_size = global_fad_size;
+
+  // Create and fill view
+  ViewType v;
+#if defined (SACADO_DISABLE_FAD_VIEW_SPEC)
+  v = ViewType ("view", num_rows);
+#else
+  v = ViewType ("view", num_rows, fad_size+1);
+#endif
+  host_view_type h_v = Kokkos::create_mirror_view(v);
+  for (size_type i=0; i<num_rows; ++i)
+    h_v(i) =
+      generate_fad<FadType>(num_rows, size_type(1), fad_size, i, size_type(0));
+  Kokkos::deep_copy(v, h_v);
+
+  // Create scalar view
+  ScalarViewType s;
+  FadType s0 = FadType(fad_size,tag.init());
+#if defined (SACADO_DISABLE_FAD_VIEW_SPEC)
+  s = ScalarViewType ("scalar view");
+#else
+  s = ScalarViewType ("scalar view", fad_size+1);
+#endif
+  Kokkos::deep_copy( s, s0 );
+
+  // Call atomic_add kernel, which adds up entries in v
+  AtomicKernel<ViewType,ScalarViewType,OperFetch>::apply( tag, v, s );
+
+  // Copy to host
+  host_scalar_view_type hs = Kokkos::create_mirror_view(s);
+  Kokkos::deep_copy(hs, s);
+
+  // Compute correct result
+  FadType b = s0;
+  for (size_type i=0; i<num_rows; ++i)
+    b = tag.apply(b, h_v(i));
+
+  // Check
+  bool success = checkFads(b, hs(), out);
+
+  return success;
+}
+
+// Test atomic_oper_fetch form
+
+TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
+  Kokkos_View_Fad, AtomicAddFetch, FadType, Layout, Device )
+{
+  success = testAtomic<FadType, Layout, Device, true>(AddTag(), out);
+}
+
+TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
+  Kokkos_View_Fad, AtomicSubFetch, FadType, Layout, Device )
+{
+  success = testAtomic<FadType, Layout, Device, true>(SubTag(), out);
+}
+
+TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
+  Kokkos_View_Fad, AtomicMulFetch, FadType, Layout, Device )
+{
+  success = testAtomic<FadType, Layout, Device, true>(MulTag(), out);
+}
+
+TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
+  Kokkos_View_Fad, AtomicDivFetch, FadType, Layout, Device )
+{
+  success = testAtomic<FadType, Layout, Device, true>(DivTag(), out);
+}
+
+TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
+  Kokkos_View_Fad, AtomicMaxFetch, FadType, Layout, Device )
+{
+  success = testAtomic<FadType, Layout, Device, true>(MaxTag(), out);
+}
+
+TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
+  Kokkos_View_Fad, AtomicMinFetch, FadType, Layout, Device )
+{
+  success = testAtomic<FadType, Layout, Device, true>(MinTag(), out);
+}
+
+// Test atomic_fetch_oper form
+
+TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
+  Kokkos_View_Fad, AtomicFetchAdd, FadType, Layout, Device )
+{
+  success = testAtomic<FadType, Layout, Device, false>(AddTag(), out);
+}
+
+TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
+  Kokkos_View_Fad, AtomicFetchSub, FadType, Layout, Device )
+{
+  success = testAtomic<FadType, Layout, Device, false>(SubTag(), out);
+}
+
+TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
+  Kokkos_View_Fad, AtomicFetchMul, FadType, Layout, Device )
+{
+  success = testAtomic<FadType, Layout, Device, false>(MulTag(), out);
+}
+
+TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
+  Kokkos_View_Fad, AtomicFetchDiv, FadType, Layout, Device )
+{
+  success = testAtomic<FadType, Layout, Device, false>(DivTag(), out);
+}
+
+TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
+  Kokkos_View_Fad, AtomicFetchMax, FadType, Layout, Device )
+{
+  success = testAtomic<FadType, Layout, Device, false>(MaxTag(), out);
+}
+
+TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
+  Kokkos_View_Fad, AtomicFetchMin, FadType, Layout, Device )
+{
+  success = testAtomic<FadType, Layout, Device, false>(MinTag(), out);
+}
+
+#define VIEW_FAD_TESTS_FLD( F, L, D ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Kokkos_View_Fad, AtomicAddFetch, F, L, D ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Kokkos_View_Fad, AtomicSubFetch, F, L, D ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Kokkos_View_Fad, AtomicMulFetch, F, L, D ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Kokkos_View_Fad, AtomicDivFetch, F, L, D ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Kokkos_View_Fad, AtomicMaxFetch, F, L, D ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Kokkos_View_Fad, AtomicMinFetch, F, L, D ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Kokkos_View_Fad, AtomicFetchAdd, F, L, D ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Kokkos_View_Fad, AtomicFetchSub, F, L, D ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Kokkos_View_Fad, AtomicFetchMul, F, L, D ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Kokkos_View_Fad, AtomicFetchDiv, F, L, D ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Kokkos_View_Fad, AtomicFetchMax, F, L, D ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Kokkos_View_Fad, AtomicFetchMin, F, L, D )
+
+using Kokkos::LayoutLeft;
+using Kokkos::LayoutRight;
+typedef Kokkos::LayoutContiguous<Kokkos::LayoutLeft> LeftContiguous;
+typedef Kokkos::LayoutContiguous<Kokkos::LayoutRight> RightContiguous;
+
+#define VIEW_FAD_TESTS_FD( F, D )                                       \
+  VIEW_FAD_TESTS_FLD( F, LayoutLeft, D )                                \
+  VIEW_FAD_TESTS_FLD( F, LayoutRight, D )                               \
+  VIEW_FAD_TESTS_FLD( F, LeftContiguous, D )                            \
+  VIEW_FAD_TESTS_FLD( F, RightContiguous, D )
+
+// Full set of atomics only implemented for new design
+#if SACADO_ENABLE_NEW_DESIGN
+typedef Sacado::Fad::Exp::DFad<double> DFadType;
+typedef Sacado::Fad::Exp::SLFad<double,2*global_fad_size> SLFadType;
+typedef Sacado::Fad::Exp::SFad<double,global_fad_size> SFadType;
+
+#if SACADO_TEST_DFAD
+#define VIEW_FAD_TESTS_D( D )                            \
+  VIEW_FAD_TESTS_FD( SFadType, D )                       \
+  VIEW_FAD_TESTS_FD( SLFadType, D )                      \
+  VIEW_FAD_TESTS_FD( DFadType, D )
+#else
+#define VIEW_FAD_TESTS_D( D )                            \
+  VIEW_FAD_TESTS_FD( SFadType, D )                       \
+  VIEW_FAD_TESTS_FD( SLFadType, D )
+#endif
+
+#else
+
+#define VIEW_FAD_TESTS_D( D ) /* */
+
+#endif

--- a/packages/sacado/test/UnitTests/Fad_KokkosAtomicTests_Cuda.cpp
+++ b/packages/sacado/test/UnitTests/Fad_KokkosAtomicTests_Cuda.cpp
@@ -30,29 +30,18 @@
 #include "Teuchos_UnitTestRepository.hpp"
 #include "Teuchos_GlobalMPISession.hpp"
 
-// Re-test cuda with hierarchical cuda parallelism turned on (experimental)
-#define SACADO_VIEW_CUDA_HIERARCHICAL_DFAD 1
-#define SACADO_KOKKOS_USE_MEMORY_POOL 1
+#include "Kokkos_Macros.hpp"
 
-#include "Fad_KokkosTests.hpp"
-
-typedef Kokkos::LayoutContiguous<Kokkos::LayoutLeft,32> LeftContiguous32;
-typedef Kokkos::LayoutContiguous<Kokkos::LayoutRight,32> RightContiguous32;
-#undef VIEW_FAD_TESTS_FDC
-#define VIEW_FAD_TESTS_FDC( F, D )                                      \
-  VIEW_FAD_TESTS_FLD( F, LeftContiguous32, D )                          \
-  VIEW_FAD_TESTS_FLD( F, RightContiguous32, D )
-
-#undef VIEW_FAD_TESTS_SFDC
-#define VIEW_FAD_TESTS_SFDC( F, D )                                     \
-  VIEW_FAD_TESTS_SFLD( F, LeftContiguous32, D )                         \
-  VIEW_FAD_TESTS_SFLD( F, RightContiguous32, D )
-
-// Instantiate tests for Cuda device
 #if defined(KOKKOS_ENABLE_CUDA_UVM)
-using Kokkos::Cuda;
-VIEW_FAD_TESTS_FDC(  DFadType , Cuda )
+#define SACADO_TEST_DFAD 1
+#else
+#define SACADO_TEST_DFAD 0
 #endif
+#include "Fad_KokkosAtomicTests.hpp"
+
+// Instantiate tests for Cuda device.  We can only test DFad is UVM is enabled.
+using Kokkos::Cuda;
+VIEW_FAD_TESTS_D( Cuda )
 
 int main( int argc, char* argv[] ) {
   Teuchos::GlobalMPISession mpiSession(&argc, &argv);
@@ -63,20 +52,7 @@ int main( int argc, char* argv[] ) {
   Kokkos::initialize( init_args );
   Kokkos::print_configuration(std::cout);
 
-#if defined(SACADO_KOKKOS_USE_MEMORY_POOL)
-  Sacado::createGlobalMemoryPool(
-    Kokkos::Cuda(),
-    2*32*global_fad_size*global_num_rows*global_num_cols*sizeof(double),
-    global_fad_size*sizeof(double),
-    4*global_fad_size*sizeof(double),
-    128*global_fad_size*sizeof(double));
-#endif
-
   int res = Teuchos::UnitTestRepository::runUnitTestsFromMain(argc, argv);
-
-#if defined(SACADO_KOKKOS_USE_MEMORY_POOL)
-  Sacado::destroyGlobalMemoryPool(Kokkos::Cuda());
-#endif
 
   // Finalize Cuda
   Kokkos::finalize();

--- a/packages/sacado/test/UnitTests/Fad_KokkosAtomicTests_Cuda_Hierarchical.cpp
+++ b/packages/sacado/test/UnitTests/Fad_KokkosAtomicTests_Cuda_Hierarchical.cpp
@@ -31,28 +31,29 @@
 #include "Teuchos_GlobalMPISession.hpp"
 
 // Re-test cuda with hierarchical cuda parallelism turned on (experimental)
-#define SACADO_VIEW_CUDA_HIERARCHICAL_DFAD 1
+#define SACADO_VIEW_CUDA_HIERARCHICAL 1
+#define SACADO_VIEW_CUDA_HIERARCHICAL_DFAD_STRIDED 1
 #define SACADO_KOKKOS_USE_MEMORY_POOL 1
 
-#include "Fad_KokkosTests.hpp"
+#include "Kokkos_Macros.hpp"
+
+#if defined(KOKKOS_ENABLE_CUDA_UVM)
+#define SACADO_TEST_DFAD 1
+#else
+#define SACADO_TEST_DFAD 0
+#endif
+#include "Fad_KokkosAtomicTests.hpp"
 
 typedef Kokkos::LayoutContiguous<Kokkos::LayoutLeft,32> LeftContiguous32;
 typedef Kokkos::LayoutContiguous<Kokkos::LayoutRight,32> RightContiguous32;
-#undef VIEW_FAD_TESTS_FDC
-#define VIEW_FAD_TESTS_FDC( F, D )                                      \
+#undef VIEW_FAD_TESTS_FD
+#define VIEW_FAD_TESTS_FD( F, D )                                       \
   VIEW_FAD_TESTS_FLD( F, LeftContiguous32, D )                          \
   VIEW_FAD_TESTS_FLD( F, RightContiguous32, D )
 
-#undef VIEW_FAD_TESTS_SFDC
-#define VIEW_FAD_TESTS_SFDC( F, D )                                     \
-  VIEW_FAD_TESTS_SFLD( F, LeftContiguous32, D )                         \
-  VIEW_FAD_TESTS_SFLD( F, RightContiguous32, D )
-
 // Instantiate tests for Cuda device
-#if defined(KOKKOS_ENABLE_CUDA_UVM)
 using Kokkos::Cuda;
-VIEW_FAD_TESTS_FDC(  DFadType , Cuda )
-#endif
+VIEW_FAD_TESTS_D( Cuda )
 
 int main( int argc, char* argv[] ) {
   Teuchos::GlobalMPISession mpiSession(&argc, &argv);
@@ -69,7 +70,8 @@ int main( int argc, char* argv[] ) {
     2*32*global_fad_size*global_num_rows*global_num_cols*sizeof(double),
     global_fad_size*sizeof(double),
     4*global_fad_size*sizeof(double),
-    128*global_fad_size*sizeof(double));
+    128*global_fad_size*sizeof(double)
+    );
 #endif
 
   int res = Teuchos::UnitTestRepository::runUnitTestsFromMain(argc, argv);

--- a/packages/sacado/test/UnitTests/Fad_KokkosAtomicTests_Cuda_Hierarchical_DFad.cpp
+++ b/packages/sacado/test/UnitTests/Fad_KokkosAtomicTests_Cuda_Hierarchical_DFad.cpp
@@ -34,24 +34,19 @@
 #define SACADO_VIEW_CUDA_HIERARCHICAL_DFAD 1
 #define SACADO_KOKKOS_USE_MEMORY_POOL 1
 
-#include "Fad_KokkosTests.hpp"
+#include "Fad_KokkosAtomicTests.hpp"
 
 typedef Kokkos::LayoutContiguous<Kokkos::LayoutLeft,32> LeftContiguous32;
 typedef Kokkos::LayoutContiguous<Kokkos::LayoutRight,32> RightContiguous32;
-#undef VIEW_FAD_TESTS_FDC
-#define VIEW_FAD_TESTS_FDC( F, D )                                      \
+#undef VIEW_FAD_TESTS_FD
+#define VIEW_FAD_TESTS_FD( F, D )                                       \
   VIEW_FAD_TESTS_FLD( F, LeftContiguous32, D )                          \
   VIEW_FAD_TESTS_FLD( F, RightContiguous32, D )
 
-#undef VIEW_FAD_TESTS_SFDC
-#define VIEW_FAD_TESTS_SFDC( F, D )                                     \
-  VIEW_FAD_TESTS_SFLD( F, LeftContiguous32, D )                         \
-  VIEW_FAD_TESTS_SFLD( F, RightContiguous32, D )
-
 // Instantiate tests for Cuda device
-#if defined(KOKKOS_ENABLE_CUDA_UVM)
+#if defined(KOKKOS_ENABLE_CUDA_UVM) && SACADO_ENABLE_NEW_DESIGN
 using Kokkos::Cuda;
-VIEW_FAD_TESTS_FDC(  DFadType , Cuda )
+VIEW_FAD_TESTS_FD(  DFadType , Cuda )
 #endif
 
 int main( int argc, char* argv[] ) {

--- a/packages/sacado/test/UnitTests/Fad_KokkosAtomicTests_Cuda_Hierarchical_SFad.cpp
+++ b/packages/sacado/test/UnitTests/Fad_KokkosAtomicTests_Cuda_Hierarchical_SFad.cpp
@@ -31,27 +31,23 @@
 #include "Teuchos_GlobalMPISession.hpp"
 
 // Re-test cuda with hierarchical cuda parallelism turned on (experimental)
-#define SACADO_VIEW_CUDA_HIERARCHICAL_DFAD 1
-#define SACADO_KOKKOS_USE_MEMORY_POOL 1
+#define SACADO_VIEW_CUDA_HIERARCHICAL 1
 
-#include "Fad_KokkosTests.hpp"
+#define GLOBAL_FAD_SIZE 64
+
+#include "Fad_KokkosAtomicTests.hpp"
 
 typedef Kokkos::LayoutContiguous<Kokkos::LayoutLeft,32> LeftContiguous32;
 typedef Kokkos::LayoutContiguous<Kokkos::LayoutRight,32> RightContiguous32;
-#undef VIEW_FAD_TESTS_FDC
-#define VIEW_FAD_TESTS_FDC( F, D )                                      \
+#undef VIEW_FAD_TESTS_FD
+#define VIEW_FAD_TESTS_FD( F, D )                                       \
   VIEW_FAD_TESTS_FLD( F, LeftContiguous32, D )                          \
   VIEW_FAD_TESTS_FLD( F, RightContiguous32, D )
 
-#undef VIEW_FAD_TESTS_SFDC
-#define VIEW_FAD_TESTS_SFDC( F, D )                                     \
-  VIEW_FAD_TESTS_SFLD( F, LeftContiguous32, D )                         \
-  VIEW_FAD_TESTS_SFLD( F, RightContiguous32, D )
-
 // Instantiate tests for Cuda device
-#if defined(KOKKOS_ENABLE_CUDA_UVM)
+#if SACADO_ENABLE_NEW_DESIGN
 using Kokkos::Cuda;
-VIEW_FAD_TESTS_FDC(  DFadType , Cuda )
+VIEW_FAD_TESTS_FD( SFadType , Cuda )
 #endif
 
 int main( int argc, char* argv[] ) {
@@ -63,20 +59,7 @@ int main( int argc, char* argv[] ) {
   Kokkos::initialize( init_args );
   Kokkos::print_configuration(std::cout);
 
-#if defined(SACADO_KOKKOS_USE_MEMORY_POOL)
-  Sacado::createGlobalMemoryPool(
-    Kokkos::Cuda(),
-    2*32*global_fad_size*global_num_rows*global_num_cols*sizeof(double),
-    global_fad_size*sizeof(double),
-    4*global_fad_size*sizeof(double),
-    128*global_fad_size*sizeof(double));
-#endif
-
   int res = Teuchos::UnitTestRepository::runUnitTestsFromMain(argc, argv);
-
-#if defined(SACADO_KOKKOS_USE_MEMORY_POOL)
-  Sacado::destroyGlobalMemoryPool(Kokkos::Cuda());
-#endif
 
   // Finalize Cuda
   Kokkos::finalize();

--- a/packages/sacado/test/UnitTests/Fad_KokkosAtomicTests_NoViewSpec_Cuda.cpp
+++ b/packages/sacado/test/UnitTests/Fad_KokkosAtomicTests_NoViewSpec_Cuda.cpp
@@ -30,29 +30,19 @@
 #include "Teuchos_UnitTestRepository.hpp"
 #include "Teuchos_GlobalMPISession.hpp"
 
-// Re-test cuda with hierarchical cuda parallelism turned on (experimental)
-#define SACADO_VIEW_CUDA_HIERARCHICAL_DFAD 1
-#define SACADO_KOKKOS_USE_MEMORY_POOL 1
+#include "Kokkos_Macros.hpp"
 
-#include "Fad_KokkosTests.hpp"
+// Disable view specializations (changes atomic argument from ViewFadPtr to
+// Fad*)
+#define SACADO_DISABLE_FAD_VIEW_SPEC
 
-typedef Kokkos::LayoutContiguous<Kokkos::LayoutLeft,32> LeftContiguous32;
-typedef Kokkos::LayoutContiguous<Kokkos::LayoutRight,32> RightContiguous32;
-#undef VIEW_FAD_TESTS_FDC
-#define VIEW_FAD_TESTS_FDC( F, D )                                      \
-  VIEW_FAD_TESTS_FLD( F, LeftContiguous32, D )                          \
-  VIEW_FAD_TESTS_FLD( F, RightContiguous32, D )
+// DFad requires the View specialization, so don't test DFad
+#define SACADO_TEST_DFAD 0
+#include "Fad_KokkosAtomicTests.hpp"
 
-#undef VIEW_FAD_TESTS_SFDC
-#define VIEW_FAD_TESTS_SFDC( F, D )                                     \
-  VIEW_FAD_TESTS_SFLD( F, LeftContiguous32, D )                         \
-  VIEW_FAD_TESTS_SFLD( F, RightContiguous32, D )
-
-// Instantiate tests for Cuda device
-#if defined(KOKKOS_ENABLE_CUDA_UVM)
+// Instantiate tests for Cuda device.  We can only test DFad is UVM is enabled.
 using Kokkos::Cuda;
-VIEW_FAD_TESTS_FDC(  DFadType , Cuda )
-#endif
+VIEW_FAD_TESTS_D( Cuda )
 
 int main( int argc, char* argv[] ) {
   Teuchos::GlobalMPISession mpiSession(&argc, &argv);
@@ -63,20 +53,7 @@ int main( int argc, char* argv[] ) {
   Kokkos::initialize( init_args );
   Kokkos::print_configuration(std::cout);
 
-#if defined(SACADO_KOKKOS_USE_MEMORY_POOL)
-  Sacado::createGlobalMemoryPool(
-    Kokkos::Cuda(),
-    2*32*global_fad_size*global_num_rows*global_num_cols*sizeof(double),
-    global_fad_size*sizeof(double),
-    4*global_fad_size*sizeof(double),
-    128*global_fad_size*sizeof(double));
-#endif
-
   int res = Teuchos::UnitTestRepository::runUnitTestsFromMain(argc, argv);
-
-#if defined(SACADO_KOKKOS_USE_MEMORY_POOL)
-  Sacado::destroyGlobalMemoryPool(Kokkos::Cuda());
-#endif
 
   // Finalize Cuda
   Kokkos::finalize();

--- a/packages/sacado/test/UnitTests/Fad_KokkosAtomicTests_NoViewSpec_OpenMP.cpp
+++ b/packages/sacado/test/UnitTests/Fad_KokkosAtomicTests_NoViewSpec_OpenMP.cpp
@@ -30,55 +30,28 @@
 #include "Teuchos_UnitTestRepository.hpp"
 #include "Teuchos_GlobalMPISession.hpp"
 
-// Re-test cuda with hierarchical cuda parallelism turned on (experimental)
-#define SACADO_VIEW_CUDA_HIERARCHICAL_DFAD 1
-#define SACADO_KOKKOS_USE_MEMORY_POOL 1
+// Disable view specializations (changes atomic argument from ViewFadPtr to
+// Fad*)
+#define SACADO_DISABLE_FAD_VIEW_SPEC
 
-#include "Fad_KokkosTests.hpp"
+#define SACADO_TEST_DFAD 1
+#include "Fad_KokkosAtomicTests.hpp"
 
-typedef Kokkos::LayoutContiguous<Kokkos::LayoutLeft,32> LeftContiguous32;
-typedef Kokkos::LayoutContiguous<Kokkos::LayoutRight,32> RightContiguous32;
-#undef VIEW_FAD_TESTS_FDC
-#define VIEW_FAD_TESTS_FDC( F, D )                                      \
-  VIEW_FAD_TESTS_FLD( F, LeftContiguous32, D )                          \
-  VIEW_FAD_TESTS_FLD( F, RightContiguous32, D )
+// Instantiate tests for OpenMP device
 
-#undef VIEW_FAD_TESTS_SFDC
-#define VIEW_FAD_TESTS_SFDC( F, D )                                     \
-  VIEW_FAD_TESTS_SFLD( F, LeftContiguous32, D )                         \
-  VIEW_FAD_TESTS_SFLD( F, RightContiguous32, D )
-
-// Instantiate tests for Cuda device
-#if defined(KOKKOS_ENABLE_CUDA_UVM)
-using Kokkos::Cuda;
-VIEW_FAD_TESTS_FDC(  DFadType , Cuda )
-#endif
+using Kokkos::OpenMP;
+VIEW_FAD_TESTS_D( OpenMP )
 
 int main( int argc, char* argv[] ) {
   Teuchos::GlobalMPISession mpiSession(&argc, &argv);
 
-  // Initialize Cuda
-  Kokkos::InitArguments init_args;
-  init_args.device_id = 0;
-  Kokkos::initialize( init_args );
+  // Initialize OpenMP
+  Kokkos::initialize();
   Kokkos::print_configuration(std::cout);
-
-#if defined(SACADO_KOKKOS_USE_MEMORY_POOL)
-  Sacado::createGlobalMemoryPool(
-    Kokkos::Cuda(),
-    2*32*global_fad_size*global_num_rows*global_num_cols*sizeof(double),
-    global_fad_size*sizeof(double),
-    4*global_fad_size*sizeof(double),
-    128*global_fad_size*sizeof(double));
-#endif
 
   int res = Teuchos::UnitTestRepository::runUnitTestsFromMain(argc, argv);
 
-#if defined(SACADO_KOKKOS_USE_MEMORY_POOL)
-  Sacado::destroyGlobalMemoryPool(Kokkos::Cuda());
-#endif
-
-  // Finalize Cuda
+  // Finalize OpenMP
   Kokkos::finalize();
 
   return res;

--- a/packages/sacado/test/UnitTests/Fad_KokkosAtomicTests_NoViewSpec_Serial.cpp
+++ b/packages/sacado/test/UnitTests/Fad_KokkosAtomicTests_NoViewSpec_Serial.cpp
@@ -30,55 +30,25 @@
 #include "Teuchos_UnitTestRepository.hpp"
 #include "Teuchos_GlobalMPISession.hpp"
 
-// Re-test cuda with hierarchical cuda parallelism turned on (experimental)
-#define SACADO_VIEW_CUDA_HIERARCHICAL_DFAD 1
-#define SACADO_KOKKOS_USE_MEMORY_POOL 1
+// Disable view specializations (changes atomic argument from ViewFadPtr to
+// Fad*)
+#define SACADO_DISABLE_FAD_VIEW_SPEC
 
-#include "Fad_KokkosTests.hpp"
+#define SACADO_TEST_DFAD 1
+#include "Fad_KokkosAtomicTests.hpp"
 
-typedef Kokkos::LayoutContiguous<Kokkos::LayoutLeft,32> LeftContiguous32;
-typedef Kokkos::LayoutContiguous<Kokkos::LayoutRight,32> RightContiguous32;
-#undef VIEW_FAD_TESTS_FDC
-#define VIEW_FAD_TESTS_FDC( F, D )                                      \
-  VIEW_FAD_TESTS_FLD( F, LeftContiguous32, D )                          \
-  VIEW_FAD_TESTS_FLD( F, RightContiguous32, D )
-
-#undef VIEW_FAD_TESTS_SFDC
-#define VIEW_FAD_TESTS_SFDC( F, D )                                     \
-  VIEW_FAD_TESTS_SFLD( F, LeftContiguous32, D )                         \
-  VIEW_FAD_TESTS_SFLD( F, RightContiguous32, D )
-
-// Instantiate tests for Cuda device
-#if defined(KOKKOS_ENABLE_CUDA_UVM)
-using Kokkos::Cuda;
-VIEW_FAD_TESTS_FDC(  DFadType , Cuda )
-#endif
+// Instantiate tests for Serial device
+using Kokkos::Serial;
+VIEW_FAD_TESTS_D( Serial )
 
 int main( int argc, char* argv[] ) {
   Teuchos::GlobalMPISession mpiSession(&argc, &argv);
 
-  // Initialize Cuda
-  Kokkos::InitArguments init_args;
-  init_args.device_id = 0;
-  Kokkos::initialize( init_args );
-  Kokkos::print_configuration(std::cout);
-
-#if defined(SACADO_KOKKOS_USE_MEMORY_POOL)
-  Sacado::createGlobalMemoryPool(
-    Kokkos::Cuda(),
-    2*32*global_fad_size*global_num_rows*global_num_cols*sizeof(double),
-    global_fad_size*sizeof(double),
-    4*global_fad_size*sizeof(double),
-    128*global_fad_size*sizeof(double));
-#endif
+  // Initialize serial
+  Kokkos::initialize(argc,argv);
 
   int res = Teuchos::UnitTestRepository::runUnitTestsFromMain(argc, argv);
 
-#if defined(SACADO_KOKKOS_USE_MEMORY_POOL)
-  Sacado::destroyGlobalMemoryPool(Kokkos::Cuda());
-#endif
-
-  // Finalize Cuda
   Kokkos::finalize();
 
   return res;

--- a/packages/sacado/test/UnitTests/Fad_KokkosAtomicTests_NoViewSpec_Threads.cpp
+++ b/packages/sacado/test/UnitTests/Fad_KokkosAtomicTests_NoViewSpec_Threads.cpp
@@ -30,55 +30,27 @@
 #include "Teuchos_UnitTestRepository.hpp"
 #include "Teuchos_GlobalMPISession.hpp"
 
-// Re-test cuda with hierarchical cuda parallelism turned on (experimental)
-#define SACADO_VIEW_CUDA_HIERARCHICAL_DFAD 1
-#define SACADO_KOKKOS_USE_MEMORY_POOL 1
+// Disable view specializations (changes atomic argument from ViewFadPtr to
+// Fad*)
+#define SACADO_DISABLE_FAD_VIEW_SPEC
 
-#include "Fad_KokkosTests.hpp"
+#define SACADO_TEST_DFAD 1
+#include "Fad_KokkosAtomicTests.hpp"
 
-typedef Kokkos::LayoutContiguous<Kokkos::LayoutLeft,32> LeftContiguous32;
-typedef Kokkos::LayoutContiguous<Kokkos::LayoutRight,32> RightContiguous32;
-#undef VIEW_FAD_TESTS_FDC
-#define VIEW_FAD_TESTS_FDC( F, D )                                      \
-  VIEW_FAD_TESTS_FLD( F, LeftContiguous32, D )                          \
-  VIEW_FAD_TESTS_FLD( F, RightContiguous32, D )
-
-#undef VIEW_FAD_TESTS_SFDC
-#define VIEW_FAD_TESTS_SFDC( F, D )                                     \
-  VIEW_FAD_TESTS_SFLD( F, LeftContiguous32, D )                         \
-  VIEW_FAD_TESTS_SFLD( F, RightContiguous32, D )
-
-// Instantiate tests for Cuda device
-#if defined(KOKKOS_ENABLE_CUDA_UVM)
-using Kokkos::Cuda;
-VIEW_FAD_TESTS_FDC(  DFadType , Cuda )
-#endif
+// Instantiate tests for Threads device
+using Kokkos::Threads;
+VIEW_FAD_TESTS_D( Threads )
 
 int main( int argc, char* argv[] ) {
   Teuchos::GlobalMPISession mpiSession(&argc, &argv);
 
-  // Initialize Cuda
-  Kokkos::InitArguments init_args;
-  init_args.device_id = 0;
-  Kokkos::initialize( init_args );
+  // Initialize threads
+  Kokkos::initialize();
   Kokkos::print_configuration(std::cout);
-
-#if defined(SACADO_KOKKOS_USE_MEMORY_POOL)
-  Sacado::createGlobalMemoryPool(
-    Kokkos::Cuda(),
-    2*32*global_fad_size*global_num_rows*global_num_cols*sizeof(double),
-    global_fad_size*sizeof(double),
-    4*global_fad_size*sizeof(double),
-    128*global_fad_size*sizeof(double));
-#endif
 
   int res = Teuchos::UnitTestRepository::runUnitTestsFromMain(argc, argv);
 
-#if defined(SACADO_KOKKOS_USE_MEMORY_POOL)
-  Sacado::destroyGlobalMemoryPool(Kokkos::Cuda());
-#endif
-
-  // Finalize Cuda
+  // Finalize threads
   Kokkos::finalize();
 
   return res;

--- a/packages/sacado/test/UnitTests/Fad_KokkosAtomicTests_OpenMP.cpp
+++ b/packages/sacado/test/UnitTests/Fad_KokkosAtomicTests_OpenMP.cpp
@@ -30,55 +30,24 @@
 #include "Teuchos_UnitTestRepository.hpp"
 #include "Teuchos_GlobalMPISession.hpp"
 
-// Re-test cuda with hierarchical cuda parallelism turned on (experimental)
-#define SACADO_VIEW_CUDA_HIERARCHICAL_DFAD 1
-#define SACADO_KOKKOS_USE_MEMORY_POOL 1
+#define SACADO_TEST_DFAD 1
+#include "Fad_KokkosAtomicTests.hpp"
 
-#include "Fad_KokkosTests.hpp"
+// Instantiate tests for OpenMP device
 
-typedef Kokkos::LayoutContiguous<Kokkos::LayoutLeft,32> LeftContiguous32;
-typedef Kokkos::LayoutContiguous<Kokkos::LayoutRight,32> RightContiguous32;
-#undef VIEW_FAD_TESTS_FDC
-#define VIEW_FAD_TESTS_FDC( F, D )                                      \
-  VIEW_FAD_TESTS_FLD( F, LeftContiguous32, D )                          \
-  VIEW_FAD_TESTS_FLD( F, RightContiguous32, D )
-
-#undef VIEW_FAD_TESTS_SFDC
-#define VIEW_FAD_TESTS_SFDC( F, D )                                     \
-  VIEW_FAD_TESTS_SFLD( F, LeftContiguous32, D )                         \
-  VIEW_FAD_TESTS_SFLD( F, RightContiguous32, D )
-
-// Instantiate tests for Cuda device
-#if defined(KOKKOS_ENABLE_CUDA_UVM)
-using Kokkos::Cuda;
-VIEW_FAD_TESTS_FDC(  DFadType , Cuda )
-#endif
+using Kokkos::OpenMP;
+VIEW_FAD_TESTS_D( OpenMP )
 
 int main( int argc, char* argv[] ) {
   Teuchos::GlobalMPISession mpiSession(&argc, &argv);
 
-  // Initialize Cuda
-  Kokkos::InitArguments init_args;
-  init_args.device_id = 0;
-  Kokkos::initialize( init_args );
+  // Initialize OpenMP
+  Kokkos::initialize();
   Kokkos::print_configuration(std::cout);
-
-#if defined(SACADO_KOKKOS_USE_MEMORY_POOL)
-  Sacado::createGlobalMemoryPool(
-    Kokkos::Cuda(),
-    2*32*global_fad_size*global_num_rows*global_num_cols*sizeof(double),
-    global_fad_size*sizeof(double),
-    4*global_fad_size*sizeof(double),
-    128*global_fad_size*sizeof(double));
-#endif
 
   int res = Teuchos::UnitTestRepository::runUnitTestsFromMain(argc, argv);
 
-#if defined(SACADO_KOKKOS_USE_MEMORY_POOL)
-  Sacado::destroyGlobalMemoryPool(Kokkos::Cuda());
-#endif
-
-  // Finalize Cuda
+  // Finalize OpenMP
   Kokkos::finalize();
 
   return res;

--- a/packages/sacado/test/UnitTests/Fad_KokkosAtomicTests_Serial.cpp
+++ b/packages/sacado/test/UnitTests/Fad_KokkosAtomicTests_Serial.cpp
@@ -30,55 +30,21 @@
 #include "Teuchos_UnitTestRepository.hpp"
 #include "Teuchos_GlobalMPISession.hpp"
 
-// Re-test cuda with hierarchical cuda parallelism turned on (experimental)
-#define SACADO_VIEW_CUDA_HIERARCHICAL_DFAD 1
-#define SACADO_KOKKOS_USE_MEMORY_POOL 1
+#define SACADO_TEST_DFAD 1
+#include "Fad_KokkosAtomicTests.hpp"
 
-#include "Fad_KokkosTests.hpp"
-
-typedef Kokkos::LayoutContiguous<Kokkos::LayoutLeft,32> LeftContiguous32;
-typedef Kokkos::LayoutContiguous<Kokkos::LayoutRight,32> RightContiguous32;
-#undef VIEW_FAD_TESTS_FDC
-#define VIEW_FAD_TESTS_FDC( F, D )                                      \
-  VIEW_FAD_TESTS_FLD( F, LeftContiguous32, D )                          \
-  VIEW_FAD_TESTS_FLD( F, RightContiguous32, D )
-
-#undef VIEW_FAD_TESTS_SFDC
-#define VIEW_FAD_TESTS_SFDC( F, D )                                     \
-  VIEW_FAD_TESTS_SFLD( F, LeftContiguous32, D )                         \
-  VIEW_FAD_TESTS_SFLD( F, RightContiguous32, D )
-
-// Instantiate tests for Cuda device
-#if defined(KOKKOS_ENABLE_CUDA_UVM)
-using Kokkos::Cuda;
-VIEW_FAD_TESTS_FDC(  DFadType , Cuda )
-#endif
+// Instantiate tests for Serial device
+using Kokkos::Serial;
+VIEW_FAD_TESTS_D( Serial )
 
 int main( int argc, char* argv[] ) {
   Teuchos::GlobalMPISession mpiSession(&argc, &argv);
 
-  // Initialize Cuda
-  Kokkos::InitArguments init_args;
-  init_args.device_id = 0;
-  Kokkos::initialize( init_args );
-  Kokkos::print_configuration(std::cout);
-
-#if defined(SACADO_KOKKOS_USE_MEMORY_POOL)
-  Sacado::createGlobalMemoryPool(
-    Kokkos::Cuda(),
-    2*32*global_fad_size*global_num_rows*global_num_cols*sizeof(double),
-    global_fad_size*sizeof(double),
-    4*global_fad_size*sizeof(double),
-    128*global_fad_size*sizeof(double));
-#endif
+  // Initialize serial
+  Kokkos::initialize(argc,argv);
 
   int res = Teuchos::UnitTestRepository::runUnitTestsFromMain(argc, argv);
 
-#if defined(SACADO_KOKKOS_USE_MEMORY_POOL)
-  Sacado::destroyGlobalMemoryPool(Kokkos::Cuda());
-#endif
-
-  // Finalize Cuda
   Kokkos::finalize();
 
   return res;

--- a/packages/sacado/test/UnitTests/Fad_KokkosAtomicTests_Threads.cpp
+++ b/packages/sacado/test/UnitTests/Fad_KokkosAtomicTests_Threads.cpp
@@ -30,55 +30,23 @@
 #include "Teuchos_UnitTestRepository.hpp"
 #include "Teuchos_GlobalMPISession.hpp"
 
-// Re-test cuda with hierarchical cuda parallelism turned on (experimental)
-#define SACADO_VIEW_CUDA_HIERARCHICAL_DFAD 1
-#define SACADO_KOKKOS_USE_MEMORY_POOL 1
+#define SACADO_TEST_DFAD 1
+#include "Fad_KokkosAtomicTests.hpp"
 
-#include "Fad_KokkosTests.hpp"
-
-typedef Kokkos::LayoutContiguous<Kokkos::LayoutLeft,32> LeftContiguous32;
-typedef Kokkos::LayoutContiguous<Kokkos::LayoutRight,32> RightContiguous32;
-#undef VIEW_FAD_TESTS_FDC
-#define VIEW_FAD_TESTS_FDC( F, D )                                      \
-  VIEW_FAD_TESTS_FLD( F, LeftContiguous32, D )                          \
-  VIEW_FAD_TESTS_FLD( F, RightContiguous32, D )
-
-#undef VIEW_FAD_TESTS_SFDC
-#define VIEW_FAD_TESTS_SFDC( F, D )                                     \
-  VIEW_FAD_TESTS_SFLD( F, LeftContiguous32, D )                         \
-  VIEW_FAD_TESTS_SFLD( F, RightContiguous32, D )
-
-// Instantiate tests for Cuda device
-#if defined(KOKKOS_ENABLE_CUDA_UVM)
-using Kokkos::Cuda;
-VIEW_FAD_TESTS_FDC(  DFadType , Cuda )
-#endif
+// Instantiate tests for Threads device
+using Kokkos::Threads;
+VIEW_FAD_TESTS_D( Threads )
 
 int main( int argc, char* argv[] ) {
   Teuchos::GlobalMPISession mpiSession(&argc, &argv);
 
-  // Initialize Cuda
-  Kokkos::InitArguments init_args;
-  init_args.device_id = 0;
-  Kokkos::initialize( init_args );
+  // Initialize threads
+  Kokkos::initialize();
   Kokkos::print_configuration(std::cout);
-
-#if defined(SACADO_KOKKOS_USE_MEMORY_POOL)
-  Sacado::createGlobalMemoryPool(
-    Kokkos::Cuda(),
-    2*32*global_fad_size*global_num_rows*global_num_cols*sizeof(double),
-    global_fad_size*sizeof(double),
-    4*global_fad_size*sizeof(double),
-    128*global_fad_size*sizeof(double));
-#endif
 
   int res = Teuchos::UnitTestRepository::runUnitTestsFromMain(argc, argv);
 
-#if defined(SACADO_KOKKOS_USE_MEMORY_POOL)
-  Sacado::destroyGlobalMemoryPool(Kokkos::Cuda());
-#endif
-
-  // Finalize Cuda
+  // Finalize threads
   Kokkos::finalize();
 
   return res;

--- a/packages/sacado/test/UnitTests/Fad_KokkosTests_Cuda.cpp
+++ b/packages/sacado/test/UnitTests/Fad_KokkosTests_Cuda.cpp
@@ -30,16 +30,16 @@
 #include "Teuchos_UnitTestRepository.hpp"
 #include "Teuchos_GlobalMPISession.hpp"
 
-#include "Fad_KokkosTests.hpp"
+#include "Kokkos_Macros.hpp"
 
-#include "Kokkos_Core.hpp"
-
-// Instantiate tests for Cuda device.  We can only test DFad is UVM is enabled.
 #if defined(KOKKOS_ENABLE_CUDA_UVM)
 #define SACADO_TEST_DFAD 1
 #else
 #define SACADO_TEST_DFAD 0
 #endif
+#include "Fad_KokkosTests.hpp"
+
+// Instantiate tests for Cuda device.  We can only test DFad is UVM is enabled.
 using Kokkos::Cuda;
 VIEW_FAD_TESTS_D( Cuda )
 

--- a/packages/sacado/test/UnitTests/Fad_KokkosTests_Cuda_Hierarchical.cpp
+++ b/packages/sacado/test/UnitTests/Fad_KokkosTests_Cuda_Hierarchical.cpp
@@ -35,8 +35,14 @@
 #define SACADO_VIEW_CUDA_HIERARCHICAL_DFAD_STRIDED 1
 #define SACADO_KOKKOS_USE_MEMORY_POOL 1
 
+#include "Kokkos_Macros.hpp"
+
+#if defined(KOKKOS_ENABLE_CUDA_UVM)
+#define SACADO_TEST_DFAD 1
+#else
+#define SACADO_TEST_DFAD 0
+#endif
 #include "Fad_KokkosTests.hpp"
-#include "Kokkos_Core.hpp"
 
 typedef Kokkos::LayoutContiguous<Kokkos::LayoutLeft,32> LeftContiguous32;
 typedef Kokkos::LayoutContiguous<Kokkos::LayoutRight,32> RightContiguous32;
@@ -51,11 +57,6 @@ typedef Kokkos::LayoutContiguous<Kokkos::LayoutRight,32> RightContiguous32;
   VIEW_FAD_TESTS_SFLD( F, RightContiguous32, D )
 
 // Instantiate tests for Cuda device
-#if defined(KOKKOS_ENABLE_CUDA_UVM)
-#define SACADO_TEST_DFAD 1
-#else
-#define SACADO_TEST_DFAD 0
-#endif
 using Kokkos::Cuda;
 VIEW_FAD_TESTS_D( Cuda )
 

--- a/packages/sacado/test/UnitTests/Fad_KokkosTests_Cuda_Hierarchical_SFad.cpp
+++ b/packages/sacado/test/UnitTests/Fad_KokkosTests_Cuda_Hierarchical_SFad.cpp
@@ -36,7 +36,6 @@
 #define GLOBAL_FAD_SIZE 64
 
 #include "Fad_KokkosTests.hpp"
-#include "Kokkos_Core.hpp"
 
 typedef Kokkos::LayoutContiguous<Kokkos::LayoutLeft,32> LeftContiguous32;
 typedef Kokkos::LayoutContiguous<Kokkos::LayoutRight,32> RightContiguous32;

--- a/packages/sacado/test/UnitTests/Fad_KokkosTests_NoViewSpec_Cuda.cpp
+++ b/packages/sacado/test/UnitTests/Fad_KokkosTests_NoViewSpec_Cuda.cpp
@@ -33,16 +33,16 @@
 // Disable view specializations
 #define SACADO_DISABLE_FAD_VIEW_SPEC
 
-#include "Fad_KokkosTests.hpp"
+#include "Kokkos_Macros.hpp"
 
-#include "Kokkos_Core.hpp"
-
-// Instantiate tests for Cuda device
 #if defined(KOKKOS_ENABLE_CUDA_UVM)
 #define SACADO_TEST_DFAD 1
 #else
 #define SACADO_TEST_DFAD 0
 #endif
+#include "Fad_KokkosTests.hpp"
+
+// Instantiate tests for Cuda device
 using Kokkos::Cuda;
 VIEW_FAD_TESTS_D( Cuda )
 

--- a/packages/sacado/test/UnitTests/Fad_KokkosTests_NoViewSpec_OpenMP.cpp
+++ b/packages/sacado/test/UnitTests/Fad_KokkosTests_NoViewSpec_OpenMP.cpp
@@ -33,12 +33,10 @@
 // Disable view specializations
 #define SACADO_DISABLE_FAD_VIEW_SPEC
 
+#define SACADO_TEST_DFAD 1
 #include "Fad_KokkosTests.hpp"
 
-#include "Kokkos_Core.hpp"
-
 // Instantiate tests for OpenMP device
-#define SACADO_TEST_DFAD 1
 using Kokkos::OpenMP;
 VIEW_FAD_TESTS_D( OpenMP )
 

--- a/packages/sacado/test/UnitTests/Fad_KokkosTests_NoViewSpec_Serial.cpp
+++ b/packages/sacado/test/UnitTests/Fad_KokkosTests_NoViewSpec_Serial.cpp
@@ -33,12 +33,10 @@
 // Disable view specializations
 #define SACADO_DISABLE_FAD_VIEW_SPEC
 
+#define SACADO_TEST_DFAD 1
 #include "Fad_KokkosTests.hpp"
 
-#include "Kokkos_Core.hpp"
-
 // Instantiate tests for Serial device
-#define SACADO_TEST_DFAD 1
 using Kokkos::Serial;
 VIEW_FAD_TESTS_D( Serial )
 

--- a/packages/sacado/test/UnitTests/Fad_KokkosTests_NoViewSpec_Threads.cpp
+++ b/packages/sacado/test/UnitTests/Fad_KokkosTests_NoViewSpec_Threads.cpp
@@ -33,12 +33,10 @@
 // Disable view specializations
 #define SACADO_DISABLE_FAD_VIEW_SPEC
 
+#define SACADO_TEST_DFAD 1
 #include "Fad_KokkosTests.hpp"
 
-#include "Kokkos_Core.hpp"
-
 // Instantiate tests for Threads device
-#define SACADO_TEST_DFAD 1
 using Kokkos::Threads;
 VIEW_FAD_TESTS_D( Threads )
 

--- a/packages/sacado/test/UnitTests/Fad_KokkosTests_OpenMP.cpp
+++ b/packages/sacado/test/UnitTests/Fad_KokkosTests_OpenMP.cpp
@@ -30,12 +30,10 @@
 #include "Teuchos_UnitTestRepository.hpp"
 #include "Teuchos_GlobalMPISession.hpp"
 
+#define SACADO_TEST_DFAD 1
 #include "Fad_KokkosTests.hpp"
 
-#include "Kokkos_Core.hpp"
-
 // Instantiate tests for OpenMP device
-#define SACADO_TEST_DFAD 1
 using Kokkos::OpenMP;
 VIEW_FAD_TESTS_D( OpenMP )
 

--- a/packages/sacado/test/UnitTests/Fad_KokkosTests_Serial.cpp
+++ b/packages/sacado/test/UnitTests/Fad_KokkosTests_Serial.cpp
@@ -30,12 +30,10 @@
 #include "Teuchos_UnitTestRepository.hpp"
 #include "Teuchos_GlobalMPISession.hpp"
 
+#define SACADO_TEST_DFAD 1
 #include "Fad_KokkosTests.hpp"
 
-#include "Kokkos_Core.hpp"
-
 // Instantiate tests for Serial device
-#define SACADO_TEST_DFAD 1
 using Kokkos::Serial;
 VIEW_FAD_TESTS_D( Serial )
 

--- a/packages/sacado/test/UnitTests/Fad_KokkosTests_Threads.cpp
+++ b/packages/sacado/test/UnitTests/Fad_KokkosTests_Threads.cpp
@@ -30,12 +30,10 @@
 #include "Teuchos_UnitTestRepository.hpp"
 #include "Teuchos_GlobalMPISession.hpp"
 
+#define SACADO_TEST_DFAD 1
 #include "Fad_KokkosTests.hpp"
 
-#include "Kokkos_Core.hpp"
-
 // Instantiate tests for Threads device
-#define SACADO_TEST_DFAD 1
 using Kokkos::Threads;
 VIEW_FAD_TESTS_D( Threads )
 


### PR DESCRIPTION
This adds atomic implementations (for the new design) for more functions
of the form Kokkos::atomic_oper_fetch/Kokkos::atomic_fetch_oper where
oper is in {add, sub, mul, div, min, max}.  Since no architecture
supports atomic operations on objects as large as a typical AD type,
this duplicates the Kokkos implementation for arbitrarily large types,
which really uses locks instead of atomics (the default Kokkos
implementation doesn't work directly because the types of the two
arguments are often different).

@jewatkins 