### PR TITLE
MueLu: fix region unit tests

### DIFF
--- a/packages/muelu/test/unit_tests/RegionMatrix.cpp
+++ b/packages/muelu/test/unit_tests/RegionMatrix.cpp
@@ -422,7 +422,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, CompositeToRegionMatrix, Scalar,
                      rowMap, colMap, revisedRowMap, revisedColMap,
                      rowImport, colImport, regionMats,
                      regionMatVecLIDs, regionInterfaceImporter);
-  RCP<Matrix> regionMat = regionMats;
 
   // Extract the local data from the region matrix
   using local_matrix_type = typename Matrix::local_matrix_type;
@@ -430,7 +429,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, CompositeToRegionMatrix, Scalar,
   using entries_type      = typename local_graph_type::entries_type;
   using values_type       = typename local_matrix_type::values_type;
 
-  local_matrix_type myLocalA  = regionMat->getLocalMatrix();  // Local matrix
+  local_matrix_type myLocalA  = regionMats->getLocalMatrix();  // Local matrix
   entries_type      myEntries = myLocalA.graph.entries;       // view of local column indices
   values_type       myValues  = myLocalA.values;              // view of local values
 
@@ -441,11 +440,11 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, CompositeToRegionMatrix, Scalar,
 
   // Now do a bunch of checks regarding the values stored in region A
   if(numRanks == 1) {
-    TEST_EQUALITY(regionMat->getGlobalNumRows(),     25);
-    TEST_EQUALITY(regionMat->getGlobalNumCols(),     25);
-    TEST_EQUALITY(regionMat->getNodeNumRows(),       25);
-    TEST_EQUALITY(regionMat->getGlobalNumEntries(), 105);
-    TEST_EQUALITY(regionMat->getNodeNumEntries(),   105);
+    TEST_EQUALITY(regionMats->getGlobalNumRows(),     25);
+    TEST_EQUALITY(regionMats->getGlobalNumCols(),     25);
+    TEST_EQUALITY(regionMats->getNodeNumRows(),       25);
+    TEST_EQUALITY(regionMats->getGlobalNumEntries(), 105);
+    TEST_EQUALITY(regionMats->getNodeNumEntries(),   105);
 
     // In the serial case we can just compare to the values in A
     entries_type refEntries = A->getLocalMatrix().graph.entries;
@@ -463,11 +462,11 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, CompositeToRegionMatrix, Scalar,
     }
   } else if(numRanks == 4) {
     // All ranks will have the same number of rows/cols/entries
-    TEST_EQUALITY(regionMat->getGlobalNumRows(),     36);
-    TEST_EQUALITY(regionMat->getGlobalNumCols(),     36);
-    TEST_EQUALITY(regionMat->getNodeNumRows(),        9);
-    TEST_EQUALITY(regionMat->getGlobalNumEntries(), 132);
-    TEST_EQUALITY(regionMat->getNodeNumEntries(),    33);
+    TEST_EQUALITY(regionMats->getGlobalNumRows(),     36);
+    TEST_EQUALITY(regionMats->getGlobalNumCols(),     36);
+    TEST_EQUALITY(regionMats->getNodeNumRows(),        9);
+    TEST_EQUALITY(regionMats->getGlobalNumEntries(), 132);
+    TEST_EQUALITY(regionMats->getNodeNumEntries(),    33);
 
     ArrayRCP<LO> refEntries;
     ArrayRCP<SC> refValues;
@@ -712,8 +711,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, FastMatVec, Scalar, LocalOrdinal
                      rowImport, colImport, regionMats,
                      regionMatVecLIDs, regionInterfaceImporter);
 
-  RCP<Matrix> regionMat = regionMats;
-
   // Create initial vectors in composite format and apply composite A.
   // This will give a reference to compare with.
   RCP<Vector> X = VectorFactory::Build(dofMap);
@@ -733,7 +730,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, FastMatVec, Scalar, LocalOrdinal
   RCP<Vector> regB = Teuchos::null;
   compositeToRegional(X, quasiRegX, regX, revisedRowMap, rowImport);
   regB = VectorFactory::Build(revisedRowMap, true);
-  regionMat->apply(*regX, *regB, Teuchos::NO_TRANS, TST::one(), TST::zero());
+  regionMats->apply(*regX, *regB, Teuchos::NO_TRANS, TST::one(), TST::zero());
   sumInterfaceValues(regB, revisedRowMap, rowImport);
 
   // Now create a refRegB vector using B as a starting point
@@ -758,7 +755,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, FastMatVec, Scalar, LocalOrdinal
 
   RCP<Vector> regC = Teuchos::null;
   regC = VectorFactory::Build(revisedRowMap, true);
-  ApplyMatVec(TST::one(), regionMat, regX, TST::zero(),
+  ApplyMatVec(TST::one(), regionMats, regX, TST::zero(),
               regionInterfaceImporter, regionMatVecLIDs,
               regC, Teuchos::NO_TRANS, true);
 
@@ -813,8 +810,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, FastMatVec3D, Scalar, LocalOrdin
                 A, regionMats, revisedRowMap, rowImport,
                 regionMatVecLIDs, regionInterfaceImporter);
 
-  RCP<Matrix> regionMat = regionMats;
-
   // Create initial vectors in composite format and apply composite A.
   // This will give a reference to compare with.
   RCP<Vector> X = VectorFactory::Build(A->getRowMap());
@@ -835,7 +830,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, FastMatVec3D, Scalar, LocalOrdin
   compositeToRegional(X, quasiRegX, regX,
                       revisedRowMap, rowImport);
   regB = VectorFactory::Build(revisedRowMap, true);
-  regionMat->apply(*regX, *regB, Teuchos::NO_TRANS, TST::one(), TST::zero());
+  regionMats->apply(*regX, *regB, Teuchos::NO_TRANS, TST::one(), TST::zero());
   sumInterfaceValues(regB, revisedRowMap, rowImport);
 
   // Now create a refRegB vector using B as a starting point
@@ -860,7 +855,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, FastMatVec3D, Scalar, LocalOrdin
 
   RCP<Vector> regC = Teuchos::null;
   regC = VectorFactory::Build(revisedRowMap, true);
-  ApplyMatVec(TST::one(), regionMat, regX, TST::zero(),
+  ApplyMatVec(TST::one(), regionMats, regX, TST::zero(),
               regionInterfaceImporter, regionMatVecLIDs,
               regC, Teuchos::NO_TRANS, true);
 
@@ -911,8 +906,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, FastMatVec2D_Elasticity, Scalar,
                 A, regionMats, revisedRowMap, rowImport,
                 regionMatVecLIDs, regionInterfaceImporter);
 
-  RCP<Matrix> regionMat = regionMats;
-
   // Create initial vectors in composite format and apply composite A.
   // This will give a reference to compare with.
   RCP<Vector> X = VectorFactory::Build(A->getRowMap());
@@ -932,7 +925,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, FastMatVec2D_Elasticity, Scalar,
   RCP<Vector> regB = Teuchos::null;
   compositeToRegional(X, quasiRegX, regX, revisedRowMap, rowImport);
   regB = VectorFactory::Build(revisedRowMap, true);
-  regionMat->apply(*regX, *regB, Teuchos::NO_TRANS, TST::one(), TST::zero());
+  regionMats->apply(*regX, *regB, Teuchos::NO_TRANS, TST::one(), TST::zero());
   sumInterfaceValues(regB, revisedRowMap, rowImport);
 
   // Now create a refRegB vector using B as a starting point
@@ -957,7 +950,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, FastMatVec2D_Elasticity, Scalar,
 
   RCP<Vector> regC = Teuchos::null;
   regC = VectorFactory::Build(revisedRowMap, true);
-  ApplyMatVec(TST::one(), regionMat, regX, TST::zero(),
+  ApplyMatVec(TST::one(), regionMats, regX, TST::zero(),
               regionInterfaceImporter, regionMatVecLIDs,
               regC, Teuchos::NO_TRANS, true);
 
@@ -1008,8 +1001,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, FastMatVec3D_Elasticity, Scalar,
                 A, regionMats, revisedRowMap, rowImport,
                 regionMatVecLIDs, regionInterfaceImporter);
 
-  RCP<Matrix> regionMat = regionMats;
-
   // Create initial vectors in composite format and apply composite A.
   // This will give a reference to compare with.
   RCP<Vector> X = VectorFactory::Build(A->getRowMap());
@@ -1029,7 +1020,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, FastMatVec3D_Elasticity, Scalar,
   RCP<Vector> regB = Teuchos::null;
   compositeToRegional(X, quasiRegX, regX, revisedRowMap, rowImport);
   regB = VectorFactory::Build(revisedRowMap, true);
-  regionMat->apply(*regX, *regB, Teuchos::NO_TRANS, TST::one(), TST::zero());
+  regionMats->apply(*regX, *regB, Teuchos::NO_TRANS, TST::one(), TST::zero());
   sumInterfaceValues(regB, revisedRowMap, rowImport);
 
   // Now create a refRegB vector using B as a starting point
@@ -1054,7 +1045,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, FastMatVec3D_Elasticity, Scalar,
 
   RCP<Vector> regC = Teuchos::null;
   regC = VectorFactory::Build(revisedRowMap, true);
-  ApplyMatVec(TST::one(), regionMat, regX, TST::zero(),
+  ApplyMatVec(TST::one(), regionMats, regX, TST::zero(),
               regionInterfaceImporter, regionMatVecLIDs,
               regC, Teuchos::NO_TRANS, true);
 
@@ -1130,7 +1121,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, Laplace2D, Scalar, LocalOrdinal,
   test_matrix(A, regionMats,
               rowMap, colMap, revisedRowMap, rowImport,
               out, success);
-  RCP<Matrix> regionMat = regionMats;
 
   // Extract the local data from the region matrix
   using local_matrix_type = typename Matrix::local_matrix_type;
@@ -1138,7 +1128,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, Laplace2D, Scalar, LocalOrdinal,
   using entries_type      = typename local_graph_type::entries_type;
   using values_type       = typename local_matrix_type::values_type;
 
-  local_matrix_type myLocalA  = regionMat->getLocalMatrix();  // Local matrix
+  local_matrix_type myLocalA  = regionMats->getLocalMatrix();  // Local matrix
   entries_type      myEntries = myLocalA.graph.entries;       // view of local column indices
   values_type       myValues  = myLocalA.values;              // view of local values
 
@@ -1150,11 +1140,11 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, Laplace2D, Scalar, LocalOrdinal,
   const int numRanks = comm->getSize();
   const int myRank   = comm->getRank();
   if(numRanks == 1) {
-    TEST_EQUALITY(regionMat->getGlobalNumRows(),    30);
-    TEST_EQUALITY(regionMat->getGlobalNumCols(),    30);
-    TEST_EQUALITY(regionMat->getNodeNumRows(),      30);
-    TEST_EQUALITY(regionMat->getGlobalNumEntries(), 128);
-    TEST_EQUALITY(regionMat->getNodeNumEntries(),   128);
+    TEST_EQUALITY(regionMats->getGlobalNumRows(),    30);
+    TEST_EQUALITY(regionMats->getGlobalNumCols(),    30);
+    TEST_EQUALITY(regionMats->getNodeNumRows(),      30);
+    TEST_EQUALITY(regionMats->getGlobalNumEntries(), 128);
+    TEST_EQUALITY(regionMats->getNodeNumEntries(),   128);
 
     // In the serial case we can just compare to the values in A
     entries_type refEntries = A->getLocalMatrix().graph.entries;
@@ -1172,14 +1162,14 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, Laplace2D, Scalar, LocalOrdinal,
     }
   } else if(numRanks == 4) {
     // All ranks will have the same number of rows/cols/entries
-    TEST_EQUALITY(regionMat->getGlobalNumRows(),    42);
-    TEST_EQUALITY(regionMat->getGlobalNumCols(),    42);
-    TEST_EQUALITY(regionMat->getGlobalNumEntries(), 158);
+    TEST_EQUALITY(regionMats->getGlobalNumRows(),    42);
+    TEST_EQUALITY(regionMats->getGlobalNumCols(),    42);
+    TEST_EQUALITY(regionMats->getGlobalNumEntries(), 158);
 
     ArrayRCP<SC> refValues;
     if(myRank == 0) {
-      TEST_EQUALITY(regionMat->getNodeNumRows(),      9);
-      TEST_EQUALITY(regionMat->getNodeNumEntries(),   33);
+      TEST_EQUALITY(regionMats->getNodeNumRows(),      9);
+      TEST_EQUALITY(regionMats->getNodeNumEntries(),   33);
       refValues.deepCopy(ArrayView<const SC>({4.0, -1.0, -1.0,
               -1.0, 4.0, -1.0, -1.0,
               -1.0, 2.0, -0.5,
@@ -1191,8 +1181,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, Laplace2D, Scalar, LocalOrdinal,
               -0.5, -0.5, 1.0}));
 
     } else if(myRank == 1) {
-      TEST_EQUALITY(regionMat->getNodeNumRows(),      12);
-      TEST_EQUALITY(regionMat->getNodeNumEntries(),   46);
+      TEST_EQUALITY(regionMats->getNodeNumRows(),      12);
+      TEST_EQUALITY(regionMats->getNodeNumEntries(),   46);
       refValues.deepCopy(ArrayView<const SC>({2.0, -1.0, -0.5,
               -1.0, 4.0, -1.0, -1.0,
               -1.0, 4.0, -1.0, -1.0,
@@ -1207,8 +1197,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, Laplace2D, Scalar, LocalOrdinal,
               -1.0, -0.5, 2.0}));
 
     } else if(myRank == 2) {
-      TEST_EQUALITY(regionMat->getNodeNumRows(),      9);
-      TEST_EQUALITY(regionMat->getNodeNumEntries(),   33);
+      TEST_EQUALITY(regionMats->getNodeNumRows(),      9);
+      TEST_EQUALITY(regionMats->getNodeNumEntries(),   33);
       refValues.deepCopy(ArrayView<const SC>({2.0, -0.5, -1.0,
               -0.5, 2.0, -0.5, -1.0,
               -0.5, 1.0, -0.5,
@@ -1220,8 +1210,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, Laplace2D, Scalar, LocalOrdinal,
               -0.5, -1.0, 2.0}));
 
     } else if(myRank == 3) {
-      TEST_EQUALITY(regionMat->getNodeNumRows(),      12);
-      TEST_EQUALITY(regionMat->getNodeNumEntries(),   46);
+      TEST_EQUALITY(regionMats->getNodeNumRows(),      12);
+      TEST_EQUALITY(regionMats->getNodeNumEntries(),   46);
       refValues.deepCopy(ArrayView<const SC>({1.0, -0.5, -0.5,
               -0.5, 2.0, -0.5, -1.0,
               -0.5, 2.0, -0.5, -1.0,
@@ -1309,7 +1299,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, Laplace3D, Scalar, LocalOrdinal,
   test_matrix(A, regionMats,
               rowMap, colMap, revisedRowMap, rowImport,
               out, success);
-  RCP<Matrix> regionMat = regionMats;
 
   // Extract the local data from the region matrix
   using local_matrix_type = typename Matrix::local_matrix_type;
@@ -1317,7 +1306,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, Laplace3D, Scalar, LocalOrdinal,
   using entries_type      = typename local_graph_type::entries_type;
   using values_type       = typename local_matrix_type::values_type;
 
-  local_matrix_type myLocalA  = regionMat->getLocalMatrix();  // Local matrix
+  local_matrix_type myLocalA  = regionMats->getLocalMatrix();  // Local matrix
   entries_type      myEntries = myLocalA.graph.entries;       // view of local column indices
   values_type       myValues  = myLocalA.values;              // view of local values
 
@@ -1329,11 +1318,11 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, Laplace3D, Scalar, LocalOrdinal,
   const int numRanks = comm->getSize();
   const int myRank   = comm->getRank();
   if((numRanks == 1) && (myRank == 0)) {
-    TEST_EQUALITY(regionMat->getGlobalNumRows(),    120);
-    TEST_EQUALITY(regionMat->getGlobalNumCols(),    120);
-    TEST_EQUALITY(regionMat->getNodeNumRows(),      120);
-    TEST_EQUALITY(regionMat->getGlobalNumEntries(), 692);
-    TEST_EQUALITY(regionMat->getNodeNumEntries(),   692);
+    TEST_EQUALITY(regionMats->getGlobalNumRows(),    120);
+    TEST_EQUALITY(regionMats->getGlobalNumCols(),    120);
+    TEST_EQUALITY(regionMats->getNodeNumRows(),      120);
+    TEST_EQUALITY(regionMats->getGlobalNumEntries(), 692);
+    TEST_EQUALITY(regionMats->getNodeNumEntries(),   692);
 
     // In the serial case we can just compare to the values in A
     entries_type refEntries = A->getLocalMatrix().graph.entries;
@@ -1351,14 +1340,14 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, Laplace3D, Scalar, LocalOrdinal,
     }
   } else if(numRanks == 4) {
     // All ranks will have the same number of rows/cols/entries
-    TEST_EQUALITY(regionMat->getGlobalNumRows(),    168);
-    TEST_EQUALITY(regionMat->getGlobalNumCols(),    168);
-    TEST_EQUALITY(regionMat->getGlobalNumEntries(), 884);
+    TEST_EQUALITY(regionMats->getGlobalNumRows(),    168);
+    TEST_EQUALITY(regionMats->getGlobalNumCols(),    168);
+    TEST_EQUALITY(regionMats->getGlobalNumEntries(), 884);
 
     ArrayRCP<SC> refValues;
     if(myRank == 0) {
-      TEST_EQUALITY(regionMat->getNodeNumRows(),     36);
-      TEST_EQUALITY(regionMat->getNodeNumEntries(), 186);
+      TEST_EQUALITY(regionMats->getNodeNumRows(),     36);
+      TEST_EQUALITY(regionMats->getNodeNumEntries(), 186);
       refValues.deepCopy(ArrayView<const SC>({6.0, -1.0, -1.0, -1.0,
               -1.0, 6.0, -1.0, -1.0, -1.0,
               -1.0, 3.0, -0.5, -0.5,
@@ -1404,8 +1393,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, Laplace3D, Scalar, LocalOrdinal,
       }
 
     } else if(myRank == 1) {
-      TEST_EQUALITY(regionMat->getNodeNumRows(),     48);
-      TEST_EQUALITY(regionMat->getNodeNumEntries(), 256);
+      TEST_EQUALITY(regionMats->getNodeNumRows(),     48);
+      TEST_EQUALITY(regionMats->getNodeNumEntries(), 256);
       refValues.deepCopy(ArrayView<const SC>({3.0, -1.0, -0.5, -0.5,
               -1.0, 6.0, -1.0, -1.0, -1.0,
               -1.0, 6.0, -1.0, -1.0, -1.0,
@@ -1463,8 +1452,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, Laplace3D, Scalar, LocalOrdinal,
       }
 
     } else if(myRank == 2) {
-      TEST_EQUALITY(regionMat->getNodeNumRows(),     36);
-      TEST_EQUALITY(regionMat->getNodeNumEntries(), 186);
+      TEST_EQUALITY(regionMats->getNodeNumRows(),     36);
+      TEST_EQUALITY(regionMats->getNodeNumEntries(), 186);
       refValues.deepCopy(ArrayView<const SC>({3.0, -0.5, -1.0, -0.5,
               -0.5, 2.5, -0.5, -1.0, -0.5,
               -0.5, 1.25, -0.5, -0.25,
@@ -1510,8 +1499,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, Laplace3D, Scalar, LocalOrdinal,
       }
 
     } else if(myRank == 3) {
-      TEST_EQUALITY(regionMat->getNodeNumRows(),     48);
-      TEST_EQUALITY(regionMat->getNodeNumEntries(), 256);
+      TEST_EQUALITY(regionMats->getNodeNumRows(),     48);
+      TEST_EQUALITY(regionMats->getNodeNumEntries(), 256);
       refValues.deepCopy(ArrayView<const SC>({1.25, -0.5, -0.5, -0.25,
               -0.5, 2.5, -0.5, -1.0, -0.5,
               -0.5, 2.5, -0.5, -1.0, -0.5,

--- a/packages/muelu/test/unit_tests/RegionMatrix.cpp
+++ b/packages/muelu/test/unit_tests/RegionMatrix.cpp
@@ -62,17 +62,16 @@ namespace MueLuTests {
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void createRegionMatrix(const Teuchos::ParameterList galeriList,
                         const int numDofsPerNode,
-                        const int maxRegPerProc,
                         const RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > nodeMap,
                         const RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > dofMap,
                         const RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > A,
-                        std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& rowMapPerGrp,
-                        std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& colMapPerGrp,
-                        std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& revisedRowMapPerGrp,
-                        std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& revisedColMapPerGrp,
-                        std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > >& rowImportPerGrp,
-                        std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > >& colImportPerGrp,
-                        std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regionGrpMats,
+                        RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> >& rowMap,
+                        RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> >& colMap,
+                        RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> >& revisedRowMap,
+                        RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> >& revisedColMap,
+                        RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> >& rowImport,
+                        RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> >& colImport,
+                        RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> >& regionMats,
                         Teuchos::ArrayRCP<LocalOrdinal>&  regionMatVecLIDs,
                         Teuchos::RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> >& regionInterfaceImporter) {
 #include <MueLu_UseShortNames.hpp>
@@ -137,61 +136,60 @@ void createRegionMatrix(const Teuchos::ParameterList galeriList,
   // std::cout << "p=" << myRank << " | interfaceCompositeGIDs" << interfaceCompositeGIDs << std::endl;
   // std::cout << "p=" << myRank << " | interfaceRegionLIDs" << interfaceRegionLIDs() << std::endl;
 
-  rowMapPerGrp[0] = Xpetra::MapFactory<LO,GO,Node>::Build(A->getRowMap()->lib(),
-                                                          Teuchos::OrdinalTraits<GO>::invalid(),
-                                                          quasiRegionGIDs(),
-                                                          A->getRowMap()->getIndexBase(),
-                                                          A->getRowMap()->getComm());
-  colMapPerGrp[0] = rowMapPerGrp[0];
+  rowMap = Xpetra::MapFactory<LO,GO,Node>::Build(A->getRowMap()->lib(),
+      Teuchos::OrdinalTraits<GO>::invalid(),
+      quasiRegionGIDs(),
+      A->getRowMap()->getIndexBase(),
+      A->getRowMap()->getComm());
+  colMap = rowMap;
 
-  revisedRowMapPerGrp[0] = Xpetra::MapFactory<LO,GO,Node>::Build(A->getRowMap()->lib(),
-                                                                 Teuchos::OrdinalTraits<GO>::invalid(),
-                                                                 quasiRegionGIDs.size(),
-                                                                 A->getRowMap()->getIndexBase(),
-                                                                 A->getRowMap()->getComm());
-  revisedColMapPerGrp[0] = revisedRowMapPerGrp[0];
+  revisedRowMap = Xpetra::MapFactory<LO,GO,Node>::Build(A->getRowMap()->lib(),
+      Teuchos::OrdinalTraits<GO>::invalid(),
+      quasiRegionGIDs.size(),
+      A->getRowMap()->getIndexBase(),
+      A->getRowMap()->getComm());
+  revisedColMap = revisedRowMap;
 
-  ExtractListOfInterfaceRegionGIDs(revisedRowMapPerGrp, interfaceRegionLIDs, interfaceRegionGIDs);
+  ExtractListOfInterfaceRegionGIDs(revisedRowMap, interfaceRegionLIDs, interfaceRegionGIDs);
 
-  rowImportPerGrp[0] = ImportFactory::Build(dofMap, rowMapPerGrp[0]);
-  colImportPerGrp[0] = ImportFactory::Build(dofMap, colMapPerGrp[0]);
+  rowImport = ImportFactory::Build(dofMap, rowMap);
+  colImport = ImportFactory::Build(dofMap, colMap);
 
   RCP<Xpetra::MultiVector<LO, LO, GO, NO> > regionsPerGIDWithGhosts;
   RCP<Xpetra::MultiVector<GO, LO, GO, NO> > interfaceGIDsMV;
-  MakeRegionPerGIDWithGhosts(nodeMap, revisedRowMapPerGrp[0], rowImportPerGrp[0],
+  MakeRegionPerGIDWithGhosts(nodeMap, revisedRowMap, rowImport,
                              maxRegPerGID, numDofsPerNode,
                              lNodesPerDir, sendGIDs, sendPIDs, interfaceRegionLIDs,
                              regionsPerGIDWithGhosts, interfaceGIDsMV);
 
-  SetupMatVec(interfaceGIDsMV, regionsPerGIDWithGhosts, revisedRowMapPerGrp, rowImportPerGrp,
+  SetupMatVec(interfaceGIDsMV, regionsPerGIDWithGhosts, revisedRowMap, rowImport,
               regionMatVecLIDs, regionInterfaceImporter);
 
-  std::vector<RCP<Matrix> > quasiRegionGrpMats(maxRegPerProc);
-  MakeQuasiregionMatrices(Teuchos::rcp_dynamic_cast<CrsMatrixWrap>(A), maxRegPerProc,
-                          regionsPerGIDWithGhosts, rowMapPerGrp, colMapPerGrp, rowImportPerGrp,
+  RCP<Matrix> quasiRegionGrpMats = Teuchos::null;
+  MakeQuasiregionMatrices(Teuchos::rcp_dynamic_cast<CrsMatrixWrap>(A),
+                          regionsPerGIDWithGhosts, rowMap, colMap, rowImport,
                           quasiRegionGrpMats);
 
-  MakeRegionMatrices(Teuchos::rcp_dynamic_cast<CrsMatrixWrap>(A), A->getRowMap(), rowMapPerGrp,
-                     revisedRowMapPerGrp, revisedColMapPerGrp,
-                     rowImportPerGrp, maxRegPerProc, quasiRegionGrpMats, regionGrpMats);
+  MakeRegionMatrices(Teuchos::rcp_dynamic_cast<CrsMatrixWrap>(A), A->getRowMap(), rowMap,
+                     revisedRowMap, revisedColMap,
+                     rowImport, quasiRegionGrpMats, regionMats);
 
 } // createRegionMatrix
 
 // Helper function that creates almost all the data needed to generate a unit-test
-// maxRegPerProc [in]: maximum number of regions assigned to any processor
 // numDofsPerNode [in]: number of degrees of freedom per grid point
 // galeriParameters [in]: parameters passed to galeri to generate the composite problem
 // comm [in]: the MPI communicator used with distributed objects
 // A [out]: composite matrix
-// regionGrpMats [out]: the region matrix
+// regionMats [out]: the region matrix
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-void createProblem(const int maxRegPerProc, const LocalOrdinal numDofsPerNode,
+void createProblem(const LocalOrdinal numDofsPerNode,
                    Galeri::Xpetra::Parameters<GlobalOrdinal>& galeriParameters,
                    RCP<const Teuchos::Comm<int> > comm,
                    RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> >& A,
-                   std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regionGrpMats,
-                   std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& revisedRowMapPerGrp,
-                   std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > >& rowImportPerGrp,
+                   RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> >& regionMats,
+                   RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> >& revisedRowMap,
+                   RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> >& rowImport,
                    Teuchos::ArrayRCP<LocalOrdinal>& regionMatVecLIDs,
                    RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> >& regionInterfaceImporter) {
 #include <MueLu_UseShortNames.hpp>
@@ -230,12 +228,13 @@ void createProblem(const int maxRegPerProc, const LocalOrdinal numDofsPerNode,
   RCP<RealValuedMultiVector> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<double,LO,GO,Map,RealValuedMultiVector>(coordinatesType, nodeMap, galeriList);
 
   // create the region maps, importer and operator from composite counter parts
-  std::vector<RCP<Map> >    rowMapPerGrp(maxRegPerProc), colMapPerGrp(maxRegPerProc);
-  std::vector<RCP<Map> >    revisedColMapPerGrp(maxRegPerProc);
-  std::vector<RCP<Import> > colImportPerGrp(maxRegPerProc);
-  createRegionMatrix(galeriList, numDofsPerNode, maxRegPerProc, nodeMap, dofMap, A,
-                     rowMapPerGrp, colMapPerGrp, revisedRowMapPerGrp, revisedColMapPerGrp,
-                     rowImportPerGrp, colImportPerGrp, regionGrpMats,
+  RCP<Map> rowMap = Teuchos::null;
+  RCP<Map> colMap = Teuchos::null;
+  RCP<Map> revisedColMap = Teuchos::null;
+  RCP<Import> colImport = Teuchos::null;
+  createRegionMatrix(galeriList, numDofsPerNode, nodeMap, dofMap, A,
+                     rowMap, colMap, revisedRowMap, revisedColMap,
+                     rowImport, colImport, regionMats,
                      regionMatVecLIDs, regionInterfaceImporter);
 
   // Debug output
@@ -252,13 +251,12 @@ void createProblem(const int maxRegPerProc, const LocalOrdinal numDofsPerNode,
 // yields the same vector. It also verifies that regionalToComposite(regA) returns
 // the same matrix as composite A. It is a convenience function to perform common tests.
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-void test_matrix(const int maxRegPerProc,
-                 RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > A,
-                 std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regionGrpMats,
-                 std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > rowMapPerGrp,
-                 std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > colMapPerGrp,
-                 std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > revisedRowMapPerGrp,
-                 std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > rowImportPerGrp,
+void test_matrix(RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > A,
+                 RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > regionMats,
+                 RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > rowMap,
+                 RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > colMap,
+                 RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > revisedRowMap,
+                 RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > rowImport,
                  Teuchos::FancyOStream& out,
                  bool& success) {
 #include <MueLu_UseShortNames.hpp>
@@ -284,20 +282,22 @@ void test_matrix(const int maxRegPerProc,
   A->apply(*X, *B, Teuchos::NO_TRANS, TST::one(), TST::zero());
 
   // Now build the region X vector
-  Array<RCP<Vector> > quasiRegX(maxRegPerProc), quasiRegB(maxRegPerProc);
-  Array<RCP<Vector> > regX(maxRegPerProc), regB(maxRegPerProc);
+  RCP<Vector> quasiRegX = Teuchos::null;
+  RCP<Vector> quasiRegB = Teuchos::null;
+  RCP<Vector> regX = Teuchos::null;
+  RCP<Vector> regB = Teuchos::null;
   compositeToRegional(X, quasiRegX, regX,
-                      revisedRowMapPerGrp, rowImportPerGrp);
-  regB[0] = VectorFactory::Build(revisedRowMapPerGrp[0], true);
+                      revisedRowMap, rowImport);
+  regB = VectorFactory::Build(revisedRowMap, true);
 
   // Perform regional MatVec
-  regionGrpMats[0]->apply(*regX[0], *regB[0], Teuchos::NO_TRANS, TST::one(), TST::zero());
+  regionMats->apply(*regX, *regB, Teuchos::NO_TRANS, TST::one(), TST::zero());
 
   // Bring the result of the region MatVec
   // to composite format so it can be compared
   // with the original composite B vector.
   RCP<Vector> compB = VectorFactory::Build(A->getRowMap());
-  regionalToComposite(regB, compB, rowImportPerGrp);
+  regionalToComposite(regB, compB, rowImport);
 
   // Extract the data from B and compB to compare it
   ArrayRCP<const SC> dataB     = B->getData(0);
@@ -317,9 +317,9 @@ void test_matrix(const int maxRegPerProc,
   /************************************/
   RCP<Matrix> compositeMatrix = MatrixFactory::Build(A->getRowMap(), 10);
   // Transform region A into composite A.
-  regionalToComposite(regionGrpMats,
-                      rowMapPerGrp, colMapPerGrp,
-                      rowImportPerGrp, Xpetra::INSERT,
+  regionalToComposite(regionMats,
+                      rowMap, colMap,
+                      rowImport, Xpetra::INSERT,
                       compositeMatrix);
 
   // Extract the local data from the original and final matrices to compare them
@@ -408,19 +408,21 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, CompositeToRegionMatrix, Scalar,
   RCP<MultiVector> nullspace = Pr->BuildNullspace();
   RCP<RealValuedMultiVector> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<double,LO,GO,Map,RealValuedMultiVector>("2D", nodeMap, galeriList);
 
-  // Create the region version of A called regionGrpMats
-  const int maxRegPerProc = 1;
-  std::vector<RCP<Map> >    rowMapPerGrp(maxRegPerProc), colMapPerGrp(maxRegPerProc);
-  std::vector<RCP<Map> >    revisedRowMapPerGrp(maxRegPerProc), revisedColMapPerGrp(maxRegPerProc);
-  std::vector<RCP<Import> > rowImportPerGrp(maxRegPerProc), colImportPerGrp(maxRegPerProc);
-  std::vector<RCP<Matrix> > regionGrpMats(maxRegPerProc);
+  // Create the region version of A called regionMats
+  RCP<Map> rowMap = Teuchos::null;
+  RCP<Map> colMap = Teuchos::null;
+  RCP<Map> revisedRowMap = Teuchos::null;
+  RCP<Map> revisedColMap = Teuchos::null;
+  RCP<Import> rowImport = Teuchos::null;
+  RCP<Import> colImport = Teuchos::null;
+  RCP<Matrix> regionMats = Teuchos::null;
   Teuchos::ArrayRCP<LO> regionMatVecLIDs;
   RCP<Import> regionInterfaceImporter;
-  createRegionMatrix(galeriList, numDofsPerNode, maxRegPerProc, nodeMap, dofMap, A,
-                     rowMapPerGrp, colMapPerGrp, revisedRowMapPerGrp, revisedColMapPerGrp,
-                     rowImportPerGrp, colImportPerGrp, regionGrpMats,
+  createRegionMatrix(galeriList, numDofsPerNode, nodeMap, dofMap, A,
+                     rowMap, colMap, revisedRowMap, revisedColMap,
+                     rowImport, colImport, regionMats,
                      regionMatVecLIDs, regionInterfaceImporter);
-  RCP<Matrix> regionMat = regionGrpMats[0];
+  RCP<Matrix> regionMat = regionMats;
 
   // Extract the local data from the region matrix
   using local_matrix_type = typename Matrix::local_matrix_type;
@@ -586,24 +588,26 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, RegionToCompositeMatrix, Scalar,
   RCP<RealValuedMultiVector> coordinates = Galeri::Xpetra::Utils::
     CreateCartesianCoordinates<double,LO,GO,Map,RealValuedMultiVector>("2D", nodeMap, galeriList);
 
-  // From the original composite matrix A, build the region equivalent: regionGrpMats
-  const int maxRegPerProc = 1;
-  std::vector<RCP<Map> >    rowMapPerGrp(maxRegPerProc), colMapPerGrp(maxRegPerProc);
-  std::vector<RCP<Map> >    revisedRowMapPerGrp(maxRegPerProc), revisedColMapPerGrp(maxRegPerProc);
-  std::vector<RCP<Import> > rowImportPerGrp(maxRegPerProc), colImportPerGrp(maxRegPerProc);
-  std::vector<RCP<Matrix> > regionGrpMats(maxRegPerProc);
+  // From the original composite matrix A, build the region equivalent: regionMats
+  RCP<Map> rowMap = Teuchos::null;
+  RCP<Map> colMap = Teuchos::null;
+  RCP<Map> revisedRowMap = Teuchos::null;
+  RCP<Map> revisedColMap = Teuchos::null;
+  RCP<Import> rowImport = Teuchos::null;
+  RCP<Import> colImport = Teuchos::null;
+  RCP<Matrix> regionMats = Teuchos::null;
   Teuchos::ArrayRCP<LO> regionMatVecLIDs;
   RCP<Import> regionInterfaceImporter;
-  createRegionMatrix(galeriList, numDofsPerNode, maxRegPerProc, nodeMap, dofMap, A,
-                     rowMapPerGrp, colMapPerGrp, revisedRowMapPerGrp, revisedColMapPerGrp,
-                     rowImportPerGrp, colImportPerGrp, regionGrpMats,
+  createRegionMatrix(galeriList, numDofsPerNode, nodeMap, dofMap, A,
+                     rowMap, colMap, revisedRowMap, revisedColMap,
+                     rowImport, colImport, regionMats,
                      regionMatVecLIDs, regionInterfaceImporter);
 
-  // Finally do the revert operation: start with regionGrpMats and bring it to composite format
+  // Finally do the revert operation: start with regionMats and bring it to composite format
   RCP<Matrix> compositeMatrix = MatrixFactory::Build(dofMap, 10);
-  regionalToComposite(regionGrpMats,
-                      rowMapPerGrp, colMapPerGrp,
-                      rowImportPerGrp, Xpetra::INSERT,
+  regionalToComposite(regionMats,
+                      rowMap, colMap,
+                      rowImport, Xpetra::INSERT,
                       compositeMatrix);
 
   // Now simply check that the original matrix A is identical to compositeMatrix.
@@ -694,19 +698,21 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, FastMatVec, Scalar, LocalOrdinal
   RCP<RealValuedMultiVector> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<double,LO,GO,Map,RealValuedMultiVector>("2D", nodeMap, galeriList);
 
   // create the region maps, importer and operator from composite counter parts
-  const int maxRegPerProc = 1;
-  std::vector<RCP<Map> >    rowMapPerGrp(maxRegPerProc), colMapPerGrp(maxRegPerProc);
-  std::vector<RCP<Map> >    revisedRowMapPerGrp(maxRegPerProc), revisedColMapPerGrp(maxRegPerProc);
-  std::vector<RCP<Import> > rowImportPerGrp(maxRegPerProc), colImportPerGrp(maxRegPerProc);
-  std::vector<RCP<Matrix> > regionGrpMats(maxRegPerProc);
+  RCP<Map> rowMap = Teuchos::null;
+  RCP<Map> colMap = Teuchos::null;
+  RCP<Map> revisedRowMap = Teuchos::null;
+  RCP<Map> revisedColMap = Teuchos::null;
+  RCP<Import> rowImport = Teuchos::null;
+  RCP<Import> colImport = Teuchos::null;
+  RCP<Matrix> regionMats = Teuchos::null;
   Teuchos::ArrayRCP<LO> regionMatVecLIDs;
   RCP<Import> regionInterfaceImporter;
-  createRegionMatrix(galeriList, numDofsPerNode, maxRegPerProc, nodeMap, dofMap, A,
-                     rowMapPerGrp, colMapPerGrp, revisedRowMapPerGrp, revisedColMapPerGrp,
-                     rowImportPerGrp, colImportPerGrp, regionGrpMats,
+  createRegionMatrix(galeriList, numDofsPerNode, nodeMap, dofMap, A,
+                     rowMap, colMap, revisedRowMap, revisedColMap,
+                     rowImport, colImport, regionMats,
                      regionMatVecLIDs, regionInterfaceImporter);
 
-  RCP<Matrix> regionMat = regionGrpMats[0];
+  RCP<Matrix> regionMat = regionMats;
 
   // Create initial vectors in composite format and apply composite A.
   // This will give a reference to compare with.
@@ -721,26 +727,24 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, FastMatVec, Scalar, LocalOrdinal
   A->apply(*X, *B, Teuchos::NO_TRANS, TST::one(), TST::zero());
 
   // Create the region vectors and apply region A
-  Array<RCP<Vector> > quasiRegX(maxRegPerProc);
-  Array<RCP<Vector> > quasiRegB(maxRegPerProc);
-  Array<RCP<Vector> > regX(maxRegPerProc);
-  Array<RCP<Vector> > regB(maxRegPerProc);
-  compositeToRegional(X, quasiRegX, regX,
-                      revisedRowMapPerGrp, rowImportPerGrp);
-  regB[0] = VectorFactory::Build(revisedRowMapPerGrp[0], true);
-  regionMat->apply(*regX[0], *regB[0], Teuchos::NO_TRANS, TST::one(), TST::zero());
-  sumInterfaceValues(regB, revisedRowMapPerGrp, rowImportPerGrp);
+  RCP<Vector> quasiRegX = Teuchos::null;
+  RCP<Vector> quasiRegB = Teuchos::null;
+  RCP<Vector> regX = Teuchos::null;
+  RCP<Vector> regB = Teuchos::null;
+  compositeToRegional(X, quasiRegX, regX, revisedRowMap, rowImport);
+  regB = VectorFactory::Build(revisedRowMap, true);
+  regionMat->apply(*regX, *regB, Teuchos::NO_TRANS, TST::one(), TST::zero());
+  sumInterfaceValues(regB, revisedRowMap, rowImport);
 
   // Now create a refRegB vector using B as a starting point
   // and compare the result to regB
-  Array<RCP<Vector> > refRegB(maxRegPerProc);
-  compositeToRegional(B, quasiRegB, refRegB,
-                      revisedRowMapPerGrp, rowImportPerGrp);
+  RCP<Vector> refRegB = Teuchos::null;
+  compositeToRegional(B, quasiRegB, refRegB, revisedRowMap, rowImport);
 
   // Extract the data from B and compB to compare it
-  ArrayRCP<const SC> dataRegB    = regB[0]->getData(0);
-  ArrayRCP<const SC> dataRefRegB = refRegB[0]->getData(0);
-  for(size_t idx = 0; idx < refRegB[0]->getLocalLength(); ++idx) {
+  ArrayRCP<const SC> dataRegB    = regB->getData(0);
+  ArrayRCP<const SC> dataRefRegB = refRegB->getData(0);
+  for(size_t idx = 0; idx < refRegB->getLocalLength(); ++idx) {
     TEST_FLOATING_EQUALITY(TST::magnitude(dataRegB[idx]),
                            TST::magnitude(dataRefRegB[idx]),
                            100*TMT::eps());
@@ -750,16 +754,16 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, FastMatVec, Scalar, LocalOrdinal
   // to transform data from region to composite and back
   // it should perform faster and allow for easy customization
   // of the local MatVec
-  RCP<Map> regionMap = revisedRowMapPerGrp[0];
+  RCP<Map> regionMap = revisedRowMap;
 
-  Array<RCP<Vector> > regC(maxRegPerProc);
-  regC[0] = VectorFactory::Build(revisedRowMapPerGrp[0], true);
-  ApplyMatVec(TST::one(), regionMat, regX[0], TST::zero(),
+  RCP<Vector> regC = Teuchos::null;
+  regC = VectorFactory::Build(revisedRowMap, true);
+  ApplyMatVec(TST::one(), regionMat, regX, TST::zero(),
               regionInterfaceImporter, regionMatVecLIDs,
-              regC[0], Teuchos::NO_TRANS, true);
+              regC, Teuchos::NO_TRANS, true);
 
-  ArrayRCP<const SC> dataRegC = regC[0]->getData(0);
-  for(size_t idx = 0; idx < refRegB[0]->getLocalLength(); ++idx) {
+  ArrayRCP<const SC> dataRegC = regC->getData(0);
+  for(size_t idx = 0; idx < refRegB->getLocalLength(); ++idx) {
     TEST_FLOATING_EQUALITY(TST::magnitude(dataRegC[idx]),
                            TST::magnitude(dataRefRegB[idx]),
                            100*TMT::eps());
@@ -796,21 +800,20 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, FastMatVec3D, Scalar, LocalOrdin
   Teuchos::ParameterList galeriList = galeriParameters.GetParameterList();
   std::string   matrixType = galeriParameters.GetMatrixType();
   const LO numDofsPerNode = 1;
-  const int maxRegPerProc = 1;
 
   // create the region maps, importer and operator from composite counter parts
-  std::vector<RCP<Matrix> > regionGrpMats(maxRegPerProc);
+  RCP<Matrix> regionMats = Teuchos::null;
   RCP<Matrix> A;
-  std::vector<RCP<Map> > revisedRowMapPerGrp(maxRegPerProc);
-  std::vector<RCP<Import> > rowImportPerGrp(maxRegPerProc);
+  RCP<Map> revisedRowMap = Teuchos::null;
+  RCP<Import> rowImport = Teuchos::null;
   Teuchos::ArrayRCP<LocalOrdinal> regionMatVecLIDs;
   RCP<Import> regionInterfaceImporter;
 
-  createProblem(maxRegPerProc, numDofsPerNode, galeriParameters, comm,
-                A, regionGrpMats, revisedRowMapPerGrp, rowImportPerGrp,
+  createProblem(numDofsPerNode, galeriParameters, comm,
+                A, regionMats, revisedRowMap, rowImport,
                 regionMatVecLIDs, regionInterfaceImporter);
 
-  RCP<Matrix> regionMat = regionGrpMats[0];
+  RCP<Matrix> regionMat = regionMats;
 
   // Create initial vectors in composite format and apply composite A.
   // This will give a reference to compare with.
@@ -825,26 +828,25 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, FastMatVec3D, Scalar, LocalOrdin
   A->apply(*X, *B, Teuchos::NO_TRANS, TST::one(), TST::zero());
 
   // Create the region vectors and apply region A
-  Array<RCP<Vector> > quasiRegX(maxRegPerProc);
-  Array<RCP<Vector> > quasiRegB(maxRegPerProc);
-  Array<RCP<Vector> > regX(maxRegPerProc);
-  Array<RCP<Vector> > regB(maxRegPerProc);
+  RCP<Vector> quasiRegX = Teuchos::null;
+  RCP<Vector> quasiRegB = Teuchos::null;
+  RCP<Vector> regX = Teuchos::null;
+  RCP<Vector> regB = Teuchos::null;
   compositeToRegional(X, quasiRegX, regX,
-                      revisedRowMapPerGrp, rowImportPerGrp);
-  regB[0] = VectorFactory::Build(revisedRowMapPerGrp[0], true);
-  regionMat->apply(*regX[0], *regB[0], Teuchos::NO_TRANS, TST::one(), TST::zero());
-  sumInterfaceValues(regB, revisedRowMapPerGrp, rowImportPerGrp);
+                      revisedRowMap, rowImport);
+  regB = VectorFactory::Build(revisedRowMap, true);
+  regionMat->apply(*regX, *regB, Teuchos::NO_TRANS, TST::one(), TST::zero());
+  sumInterfaceValues(regB, revisedRowMap, rowImport);
 
   // Now create a refRegB vector using B as a starting point
   // and compare the result to regB
-  Array<RCP<Vector> > refRegB(maxRegPerProc);
-  compositeToRegional(B, quasiRegB, refRegB,
-                      revisedRowMapPerGrp, rowImportPerGrp);
+  RCP<Vector> refRegB = Teuchos::null;
+  compositeToRegional(B, quasiRegB, refRegB, revisedRowMap, rowImport);
 
   // Extract the data from B and compB to compare it
-  ArrayRCP<const SC> dataRegB    = regB[0]->getData(0);
-  ArrayRCP<const SC> dataRefRegB = refRegB[0]->getData(0);
-  for(size_t idx = 0; idx < refRegB[0]->getLocalLength(); ++idx) {
+  ArrayRCP<const SC> dataRegB    = regB->getData(0);
+  ArrayRCP<const SC> dataRefRegB = refRegB->getData(0);
+  for(size_t idx = 0; idx < refRegB->getLocalLength(); ++idx) {
     TEST_FLOATING_EQUALITY(TST::magnitude(dataRegB[idx]),
                            TST::magnitude(dataRefRegB[idx]),
                            100*TMT::eps());
@@ -854,16 +856,16 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, FastMatVec3D, Scalar, LocalOrdin
   // to transform data from region to composite and back
   // it should perform faster and allow for easy customization
   // of the local MatVec
-  RCP<Map> regionMap = revisedRowMapPerGrp[0];
+  RCP<Map> regionMap = revisedRowMap;
 
-  Array<RCP<Vector> > regC(maxRegPerProc);
-  regC[0] = VectorFactory::Build(revisedRowMapPerGrp[0], true);
-  ApplyMatVec(TST::one(), regionMat, regX[0], TST::zero(),
+  RCP<Vector> regC = Teuchos::null;
+  regC = VectorFactory::Build(revisedRowMap, true);
+  ApplyMatVec(TST::one(), regionMat, regX, TST::zero(),
               regionInterfaceImporter, regionMatVecLIDs,
-              regC[0], Teuchos::NO_TRANS, true);
+              regC, Teuchos::NO_TRANS, true);
 
-  ArrayRCP<const SC> dataRegC = regC[0]->getData(0);
-  for(size_t idx = 0; idx < refRegB[0]->getLocalLength(); ++idx) {
+  ArrayRCP<const SC> dataRegC = regC->getData(0);
+  for(size_t idx = 0; idx < refRegB->getLocalLength(); ++idx) {
     TEST_FLOATING_EQUALITY(TST::magnitude(dataRegC[idx]),
                            TST::magnitude(dataRefRegB[idx]),
                            100*TMT::eps());
@@ -894,23 +896,22 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, FastMatVec2D_Elasticity, Scalar,
   // Get MPI parameter
   RCP<const Teuchos::Comm<int> > comm = TestHelpers::Parameters::getDefaultComm();
 
-  const int maxRegPerProc = 1;
   const LO numDofsPerNode = 2;
   GO nx = 7, ny = 7, nz = 1;
   Teuchos::CommandLineProcessor &clp = Teuchos::UnitTestRepository::getCLP();
   Galeri::Xpetra::Parameters<GO> galeriParameters(clp, nx, ny, nz, "Elasticity2D");
-  std::vector<RCP<Matrix> > regionGrpMats(maxRegPerProc);
+  RCP<Matrix> regionMats = Teuchos::null;
   RCP<Matrix> A;
-  std::vector<RCP<Map> > revisedRowMapPerGrp(maxRegPerProc);
-  std::vector<RCP<Import> > rowImportPerGrp(maxRegPerProc);
+  RCP<Map> revisedRowMap = Teuchos::null;
+  RCP<Import> rowImport = Teuchos::null;
   Teuchos::ArrayRCP<LocalOrdinal> regionMatVecLIDs;
   RCP<Import> regionInterfaceImporter;
 
-  createProblem(maxRegPerProc, numDofsPerNode, galeriParameters, comm,
-                A, regionGrpMats, revisedRowMapPerGrp, rowImportPerGrp,
+  createProblem(numDofsPerNode, galeriParameters, comm,
+                A, regionMats, revisedRowMap, rowImport,
                 regionMatVecLIDs, regionInterfaceImporter);
 
-  RCP<Matrix> regionMat = regionGrpMats[0];
+  RCP<Matrix> regionMat = regionMats;
 
   // Create initial vectors in composite format and apply composite A.
   // This will give a reference to compare with.
@@ -925,26 +926,24 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, FastMatVec2D_Elasticity, Scalar,
   A->apply(*X, *B, Teuchos::NO_TRANS, TST::one(), TST::zero());
 
   // Create the region vectors and apply region A
-  Array<RCP<Vector> > quasiRegX(maxRegPerProc);
-  Array<RCP<Vector> > quasiRegB(maxRegPerProc);
-  Array<RCP<Vector> > regX(maxRegPerProc);
-  Array<RCP<Vector> > regB(maxRegPerProc);
-  compositeToRegional(X, quasiRegX, regX,
-                      revisedRowMapPerGrp, rowImportPerGrp);
-  regB[0] = VectorFactory::Build(revisedRowMapPerGrp[0], true);
-  regionMat->apply(*regX[0], *regB[0], Teuchos::NO_TRANS, TST::one(), TST::zero());
-  sumInterfaceValues(regB, revisedRowMapPerGrp, rowImportPerGrp);
+  RCP<Vector> quasiRegX = Teuchos::null;
+  RCP<Vector> quasiRegB = Teuchos::null;
+  RCP<Vector> regX = Teuchos::null;
+  RCP<Vector> regB = Teuchos::null;
+  compositeToRegional(X, quasiRegX, regX, revisedRowMap, rowImport);
+  regB = VectorFactory::Build(revisedRowMap, true);
+  regionMat->apply(*regX, *regB, Teuchos::NO_TRANS, TST::one(), TST::zero());
+  sumInterfaceValues(regB, revisedRowMap, rowImport);
 
   // Now create a refRegB vector using B as a starting point
   // and compare the result to regB
-  Array<RCP<Vector> > refRegB(maxRegPerProc);
-  compositeToRegional(B, quasiRegB, refRegB,
-                      revisedRowMapPerGrp, rowImportPerGrp);
+  RCP<Vector> refRegB = Teuchos::null;
+  compositeToRegional(B, quasiRegB, refRegB, revisedRowMap, rowImport);
 
   // Extract the data from B and compB to compare it
-  ArrayRCP<const SC> dataRegB    = regB[0]->getData(0);
-  ArrayRCP<const SC> dataRefRegB = refRegB[0]->getData(0);
-  for(size_t idx = 0; idx < refRegB[0]->getLocalLength(); ++idx) {
+  ArrayRCP<const SC> dataRegB    = regB->getData(0);
+  ArrayRCP<const SC> dataRefRegB = refRegB->getData(0);
+  for(size_t idx = 0; idx < refRegB->getLocalLength(); ++idx) {
     TEST_FLOATING_EQUALITY(TST::magnitude(dataRegB[idx]),
                            TST::magnitude(dataRefRegB[idx]),
                            100*TMT::eps());
@@ -954,16 +953,16 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, FastMatVec2D_Elasticity, Scalar,
   // to transform data from region to composite and back
   // it should perform faster and allow for easy customization
   // of the local MatVec
-  RCP<Map> regionMap = revisedRowMapPerGrp[0];
+  RCP<Map> regionMap = revisedRowMap;
 
-  Array<RCP<Vector> > regC(maxRegPerProc);
-  regC[0] = VectorFactory::Build(revisedRowMapPerGrp[0], true);
-  ApplyMatVec(TST::one(), regionMat, regX[0], TST::zero(),
+  RCP<Vector> regC = Teuchos::null;
+  regC = VectorFactory::Build(revisedRowMap, true);
+  ApplyMatVec(TST::one(), regionMat, regX, TST::zero(),
               regionInterfaceImporter, regionMatVecLIDs,
-              regC[0], Teuchos::NO_TRANS, true);
+              regC, Teuchos::NO_TRANS, true);
 
-  ArrayRCP<const SC> dataRegC = regC[0]->getData(0);
-  for(size_t idx = 0; idx < refRegB[0]->getLocalLength(); ++idx) {
+  ArrayRCP<const SC> dataRegC = regC->getData(0);
+  for(size_t idx = 0; idx < refRegB->getLocalLength(); ++idx) {
     TEST_FLOATING_EQUALITY(TST::magnitude(dataRegC[idx]),
                            TST::magnitude(dataRefRegB[idx]),
                            100*TMT::eps());
@@ -994,23 +993,22 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, FastMatVec3D_Elasticity, Scalar,
   // Get MPI parameter
   RCP<const Teuchos::Comm<int> > comm = TestHelpers::Parameters::getDefaultComm();
 
-  const int maxRegPerProc = 1;
   const LO numDofsPerNode = 3;
   GO nx = 5, ny = 5, nz = 3;
   Teuchos::CommandLineProcessor &clp = Teuchos::UnitTestRepository::getCLP();
   Galeri::Xpetra::Parameters<GO> galeriParameters(clp, nx, ny, nz, "Elasticity3D");
-  std::vector<RCP<Matrix> > regionGrpMats(maxRegPerProc);
-  RCP<Matrix> A;
-  std::vector<RCP<Map> > revisedRowMapPerGrp(maxRegPerProc);
-  std::vector<RCP<Import> > rowImportPerGrp(maxRegPerProc);
+  RCP<Matrix> regionMats = Teuchos::null;
+  RCP<Matrix> A = Teuchos::null;
+  RCP<Map> revisedRowMap = Teuchos::null;
+  RCP<Import> rowImport = Teuchos::null;
   Teuchos::ArrayRCP<LocalOrdinal> regionMatVecLIDs;
   RCP<Import> regionInterfaceImporter;
 
-  createProblem(maxRegPerProc, numDofsPerNode, galeriParameters, comm,
-                A, regionGrpMats, revisedRowMapPerGrp, rowImportPerGrp,
+  createProblem(numDofsPerNode, galeriParameters, comm,
+                A, regionMats, revisedRowMap, rowImport,
                 regionMatVecLIDs, regionInterfaceImporter);
 
-  RCP<Matrix> regionMat = regionGrpMats[0];
+  RCP<Matrix> regionMat = regionMats;
 
   // Create initial vectors in composite format and apply composite A.
   // This will give a reference to compare with.
@@ -1025,26 +1023,24 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, FastMatVec3D_Elasticity, Scalar,
   A->apply(*X, *B, Teuchos::NO_TRANS, TST::one(), TST::zero());
 
   // Create the region vectors and apply region A
-  Array<RCP<Vector> > quasiRegX(maxRegPerProc);
-  Array<RCP<Vector> > quasiRegB(maxRegPerProc);
-  Array<RCP<Vector> > regX(maxRegPerProc);
-  Array<RCP<Vector> > regB(maxRegPerProc);
-  compositeToRegional(X, quasiRegX, regX,
-                      revisedRowMapPerGrp, rowImportPerGrp);
-  regB[0] = VectorFactory::Build(revisedRowMapPerGrp[0], true);
-  regionMat->apply(*regX[0], *regB[0], Teuchos::NO_TRANS, TST::one(), TST::zero());
-  sumInterfaceValues(regB, revisedRowMapPerGrp, rowImportPerGrp);
+  RCP<Vector> quasiRegX = Teuchos::null;
+  RCP<Vector> quasiRegB = Teuchos::null;
+  RCP<Vector> regX = Teuchos::null;
+  RCP<Vector> regB = Teuchos::null;
+  compositeToRegional(X, quasiRegX, regX, revisedRowMap, rowImport);
+  regB = VectorFactory::Build(revisedRowMap, true);
+  regionMat->apply(*regX, *regB, Teuchos::NO_TRANS, TST::one(), TST::zero());
+  sumInterfaceValues(regB, revisedRowMap, rowImport);
 
   // Now create a refRegB vector using B as a starting point
   // and compare the result to regB
-  Array<RCP<Vector> > refRegB(maxRegPerProc);
-  compositeToRegional(B, quasiRegB, refRegB,
-                      revisedRowMapPerGrp, rowImportPerGrp);
+  RCP<Vector> refRegB = Teuchos::null;
+  compositeToRegional(B, quasiRegB, refRegB, revisedRowMap, rowImport);
 
   // Extract the data from B and compB to compare it
-  ArrayRCP<const SC> dataRegB    = regB[0]->getData(0);
-  ArrayRCP<const SC> dataRefRegB = refRegB[0]->getData(0);
-  for(size_t idx = 0; idx < refRegB[0]->getLocalLength(); ++idx) {
+  ArrayRCP<const SC> dataRegB    = regB->getData(0);
+  ArrayRCP<const SC> dataRefRegB = refRegB->getData(0);
+  for(size_t idx = 0; idx < refRegB->getLocalLength(); ++idx) {
     TEST_FLOATING_EQUALITY(TST::magnitude(dataRegB[idx]),
                            TST::magnitude(dataRefRegB[idx]),
                            100*TMT::eps());
@@ -1054,16 +1050,16 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, FastMatVec3D_Elasticity, Scalar,
   // to transform data from region to composite and back
   // it should perform faster and allow for easy customization
   // of the local MatVec
-  RCP<Map> regionMap = revisedRowMapPerGrp[0];
+  RCP<Map> regionMap = revisedRowMap;
 
-  Array<RCP<Vector> > regC(maxRegPerProc);
-  regC[0] = VectorFactory::Build(revisedRowMapPerGrp[0], true);
-  ApplyMatVec(TST::one(), regionMat, regX[0], TST::zero(),
+  RCP<Vector> regC = Teuchos::null;
+  regC = VectorFactory::Build(revisedRowMap, true);
+  ApplyMatVec(TST::one(), regionMat, regX, TST::zero(),
               regionInterfaceImporter, regionMatVecLIDs,
-              regC[0], Teuchos::NO_TRANS, true);
+              regC, Teuchos::NO_TRANS, true);
 
-  ArrayRCP<const SC> dataRegC = regC[0]->getData(0);
-  for(size_t idx = 0; idx < refRegB[0]->getLocalLength(); ++idx) {
+  ArrayRCP<const SC> dataRegC = regC->getData(0);
+  for(size_t idx = 0; idx < refRegB->getLocalLength(); ++idx) {
     TEST_FLOATING_EQUALITY(TST::magnitude(dataRegC[idx]),
                            TST::magnitude(dataRefRegB[idx]),
                            100*TMT::eps());
@@ -1117,22 +1113,24 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, Laplace2D, Scalar, LocalOrdinal,
   RCP<MultiVector> nullspace = Pr->BuildNullspace();
   RCP<RealValuedMultiVector> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<double,LO,GO,Map,RealValuedMultiVector>("2D", nodeMap, galeriList);
 
-  const int maxRegPerProc = 1;
-  std::vector<RCP<Map> >    rowMapPerGrp(maxRegPerProc), colMapPerGrp(maxRegPerProc);
-  std::vector<RCP<Map> >    revisedRowMapPerGrp(maxRegPerProc), revisedColMapPerGrp(maxRegPerProc);
-  std::vector<RCP<Import> > rowImportPerGrp(maxRegPerProc), colImportPerGrp(maxRegPerProc);
-  std::vector<RCP<Matrix> > regionGrpMats(maxRegPerProc);
+  RCP<Map> rowMap = Teuchos::null;
+  RCP<Map> colMap = Teuchos::null;
+  RCP<Map> revisedRowMap = Teuchos::null;
+  RCP<Map> revisedColMap = Teuchos::null;
+  RCP<Import> rowImport = Teuchos::null;
+  RCP<Import> colImport = Teuchos::null;
+  RCP<Matrix> regionMats = Teuchos::null;
   Teuchos::ArrayRCP<LO> regionMatVecLIDs;
   RCP<Import> regionInterfaceImporter;
-  createRegionMatrix(galeriList, numDofsPerNode, maxRegPerProc, nodeMap, dofMap, A,
-                     rowMapPerGrp, colMapPerGrp, revisedRowMapPerGrp, revisedColMapPerGrp,
-                     rowImportPerGrp, colImportPerGrp, regionGrpMats,
+  createRegionMatrix(galeriList, numDofsPerNode, nodeMap, dofMap, A,
+                     rowMap, colMap, revisedRowMap, revisedColMap,
+                     rowImport, colImport, regionMats,
                      regionMatVecLIDs, regionInterfaceImporter);
 
-  test_matrix(maxRegPerProc, A, regionGrpMats,
-              rowMapPerGrp, colMapPerGrp, revisedRowMapPerGrp, rowImportPerGrp,
+  test_matrix(A, regionMats,
+              rowMap, colMap, revisedRowMap, rowImport,
               out, success);
-  RCP<Matrix> regionMat = regionGrpMats[0];
+  RCP<Matrix> regionMat = regionMats;
 
   // Extract the local data from the region matrix
   using local_matrix_type = typename Matrix::local_matrix_type;
@@ -1294,22 +1292,24 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, Laplace3D, Scalar, LocalOrdinal,
   RCP<MultiVector> nullspace = Pr->BuildNullspace();
   RCP<RealValuedMultiVector> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<double,LO,GO,Map,RealValuedMultiVector>("3D", nodeMap, galeriList);
 
-  const int maxRegPerProc = 1;
-  std::vector<RCP<Map> >    rowMapPerGrp(maxRegPerProc), colMapPerGrp(maxRegPerProc);
-  std::vector<RCP<Map> >    revisedRowMapPerGrp(maxRegPerProc), revisedColMapPerGrp(maxRegPerProc);
-  std::vector<RCP<Import> > rowImportPerGrp(maxRegPerProc), colImportPerGrp(maxRegPerProc);
-  std::vector<RCP<Matrix> > regionGrpMats(maxRegPerProc);
+  RCP<Map> rowMap = Teuchos::null;
+  RCP<Map> colMap = Teuchos::null;
+  RCP<Map> revisedRowMap = Teuchos::null;
+  RCP<Map> revisedColMap = Teuchos::null;
+  RCP<Import> rowImport = Teuchos::null;
+  RCP<Import> colImport = Teuchos::null;
+  RCP<Matrix> regionMats = Teuchos::null;
   Teuchos::ArrayRCP<LO> regionMatVecLIDs;
   RCP<Import> regionInterfaceImporter;
-  createRegionMatrix(galeriList, numDofsPerNode, maxRegPerProc, nodeMap, dofMap, A,
-                     rowMapPerGrp, colMapPerGrp, revisedRowMapPerGrp, revisedColMapPerGrp,
-                     rowImportPerGrp, colImportPerGrp, regionGrpMats,
+  createRegionMatrix(galeriList, numDofsPerNode, nodeMap, dofMap, A,
+                     rowMap, colMap, revisedRowMap, revisedColMap,
+                     rowImport, colImport, regionMats,
                      regionMatVecLIDs, regionInterfaceImporter);
 
-  test_matrix(maxRegPerProc, A, regionGrpMats,
-              rowMapPerGrp, colMapPerGrp, revisedRowMapPerGrp, rowImportPerGrp,
+  test_matrix(A, regionMats,
+              rowMap, colMap, revisedRowMap, rowImport,
               out, success);
-  RCP<Matrix> regionMat = regionGrpMats[0];
+  RCP<Matrix> regionMat = regionMats;
 
   // Extract the local data from the region matrix
   using local_matrix_type = typename Matrix::local_matrix_type;

--- a/packages/muelu/test/unit_tests/RegionRFactory.cpp
+++ b/packages/muelu/test/unit_tests/RegionRFactory.cpp
@@ -340,8 +340,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionRFactory, RegionRFactLaplace3D, Scalar, 
                 revisedRowMap, rowImport,
                 regionMatVecLIDs, regionInterfaceImporter, rNodesPerDim);
 
-  RCP<Matrix> regionMat = regionMats;
-
   // Generate levels for a two level hierarchy
   MueLu::Level fineLevel, coarseLevel;
   test_factory::createTwoLevelHierarchy(fineLevel, coarseLevel);
@@ -350,7 +348,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionRFactory, RegionRFactLaplace3D, Scalar, 
 
   // Set requests and input data on fine level
   fineLevel.Request("A");
-  fineLevel.Set("A", regionMat);
+  fineLevel.Set("A", regionMats);
   fineLevel.Set("numDimensions", numDimensions);
   fineLevel.Set("lNodesPerDim",  rNodesPerDim);
   fineLevel.Set("Nullspace", regionNullspace);
@@ -507,8 +505,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionRFactory, RegionRFactElasticity3D, Scala
                 revisedRowMap, rowImport,
                 regionMatVecLIDs, regionInterfaceImporter, rNodesPerDim);
 
-  RCP<Matrix> regionMat = regionMats;
-
   // Generate levels for a two level hierarchy
   MueLu::Level fineLevel, coarseLevel;
   test_factory::createTwoLevelHierarchy(fineLevel, coarseLevel);
@@ -517,7 +513,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionRFactory, RegionRFactElasticity3D, Scala
 
   // Set requests and input data on fine level
   fineLevel.Request("A");
-  fineLevel.Set("A", regionMat);
+  fineLevel.Set("A", regionMats);
   fineLevel.Set("numDimensions", numDimensions);
   fineLevel.Set("lNodesPerDim",  rNodesPerDim);
   fineLevel.Set("Nullspace", regionNullspace);

--- a/packages/muelu/test/unit_tests/RegionRFactory.cpp
+++ b/packages/muelu/test/unit_tests/RegionRFactory.cpp
@@ -64,17 +64,16 @@ namespace MueLuTests {
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void createRegionMatrix(const Teuchos::ParameterList galeriList,
                         const int numDofsPerNode,
-                        const int maxRegPerProc,
                         const RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > nodeMap,
                         const RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > dofMap,
                         const RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > A,
-                        std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& rowMapPerGrp,
-                        std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& colMapPerGrp,
-                        std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& revisedRowMapPerGrp,
-                        std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& revisedColMapPerGrp,
-                        std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > >& rowImportPerGrp,
-                        std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > >& colImportPerGrp,
-                        std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regionGrpMats,
+                        RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> >& rowMap,
+                        RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> >& colMap,
+                        RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> >& revisedRowMap,
+                        RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> >& revisedColMap,
+                        RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> >& rowImport,
+                        RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> >& colImport,
+                        RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> >& regionMats,
                         Teuchos::ArrayRCP<LocalOrdinal>&  regionMatVecLIDs,
                         Teuchos::Array<GlobalOrdinal>& quasiRegionCoordGIDs,
                         Teuchos::RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> >& regionInterfaceImporter,
@@ -139,64 +138,62 @@ void createRegionMatrix(const Teuchos::ParameterList galeriList,
   // std::cout << "p=" << myRank << " | interfaceCompositeGIDs" << interfaceCompositeGIDs << std::endl;
   // std::cout << "p=" << myRank << " | interfaceRegionLIDs" << interfaceRegionLIDs() << std::endl;
 
-  rowMapPerGrp[0] = Xpetra::MapFactory<LO,GO,Node>::Build(A->getRowMap()->lib(),
-                                                          Teuchos::OrdinalTraits<GO>::invalid(),
-                                                          quasiRegionGIDs(),
-                                                          A->getRowMap()->getIndexBase(),
-                                                          A->getRowMap()->getComm());
-  colMapPerGrp[0] = rowMapPerGrp[0];
+  rowMap = Xpetra::MapFactory<LO,GO,Node>::Build(A->getRowMap()->lib(),
+      Teuchos::OrdinalTraits<GO>::invalid(),
+      quasiRegionGIDs(),
+      A->getRowMap()->getIndexBase(),
+      A->getRowMap()->getComm());
+  colMap= rowMap;
 
-  revisedRowMapPerGrp[0] = Xpetra::MapFactory<LO,GO,Node>::Build(A->getRowMap()->lib(),
-                                                                 Teuchos::OrdinalTraits<GO>::invalid(),
-                                                                 quasiRegionGIDs.size(),
-                                                                 A->getRowMap()->getIndexBase(),
-                                                                 A->getRowMap()->getComm());
-  revisedColMapPerGrp[0] = revisedRowMapPerGrp[0];
+  revisedRowMap = Xpetra::MapFactory<LO,GO,Node>::Build(A->getRowMap()->lib(),
+      Teuchos::OrdinalTraits<GO>::invalid(),
+      quasiRegionGIDs.size(),
+      A->getRowMap()->getIndexBase(),
+      A->getRowMap()->getComm());
+  revisedColMap = revisedRowMap;
 
-  ExtractListOfInterfaceRegionGIDs(revisedRowMapPerGrp, interfaceRegionLIDs, interfaceRegionGIDs);
+  ExtractListOfInterfaceRegionGIDs(revisedRowMap, interfaceRegionLIDs, interfaceRegionGIDs);
 
-  rowImportPerGrp[0] = ImportFactory::Build(dofMap, rowMapPerGrp[0]);
-  colImportPerGrp[0] = ImportFactory::Build(dofMap, colMapPerGrp[0]);
+  rowImport = ImportFactory::Build(dofMap, rowMap);
+  colImport = ImportFactory::Build(dofMap, colMap);
 
   RCP<Xpetra::MultiVector<LO, LO, GO, NO> > regionsPerGIDWithGhosts;
   RCP<Xpetra::MultiVector<GO, LO, GO, NO> > interfaceGIDsMV;
-  MakeRegionPerGIDWithGhosts(nodeMap, revisedRowMapPerGrp[0], rowImportPerGrp[0],
+  MakeRegionPerGIDWithGhosts(nodeMap, revisedRowMap, rowImport,
                              maxRegPerGID, numDofsPerNode,
                              lNodesPerDir, sendGIDs, sendPIDs, interfaceRegionLIDs,
                              regionsPerGIDWithGhosts, interfaceGIDsMV);
 
-  SetupMatVec(interfaceGIDsMV, regionsPerGIDWithGhosts, revisedRowMapPerGrp, rowImportPerGrp,
+  SetupMatVec(interfaceGIDsMV, regionsPerGIDWithGhosts, revisedRowMap, rowImport,
               regionMatVecLIDs, regionInterfaceImporter);
 
-  std::vector<RCP<Matrix> > quasiRegionGrpMats(maxRegPerProc);
-  MakeQuasiregionMatrices(Teuchos::rcp_dynamic_cast<CrsMatrixWrap>(A), maxRegPerProc,
-                          regionsPerGIDWithGhosts, rowMapPerGrp, colMapPerGrp, rowImportPerGrp,
+  RCP<Matrix> quasiRegionGrpMats = Teuchos::null;
+  MakeQuasiregionMatrices(Teuchos::rcp_dynamic_cast<CrsMatrixWrap>(A),
+                          regionsPerGIDWithGhosts, rowMap, colMap, rowImport,
                           quasiRegionGrpMats);
 
-  MakeRegionMatrices(Teuchos::rcp_dynamic_cast<CrsMatrixWrap>(A), A->getRowMap(), rowMapPerGrp,
-                     revisedRowMapPerGrp, revisedColMapPerGrp,
-                     rowImportPerGrp, maxRegPerProc, quasiRegionGrpMats, regionGrpMats);
+  MakeRegionMatrices(Teuchos::rcp_dynamic_cast<CrsMatrixWrap>(A), A->getRowMap(), rowMap,
+                     revisedRowMap, revisedColMap,
+                     rowImport, quasiRegionGrpMats, regionMats);
 
 } // createRegionMatrix
 
 // Helper function that creates almost all the data needed to generate a unit-test
-// maxRegPerProc [in]: maximum number of regions assigned to any processor
 // numDofsPerNode [in]: number of degrees of freedom per grid point
 // galeriParameters [in]: parameters passed to galeri to generate the composite problem
 // comm [in]: the MPI communicator used with distributed objects
 // A [out]: composite matrix
-// regionGrpMats [out]: the region matrix
+// regionMats [out]: the region matrix
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-void createProblem(const int maxRegPerProc, 
-                   const LocalOrdinal numDofsPerNode,
+void createProblem(const LocalOrdinal numDofsPerNode,
                    Galeri::Xpetra::Parameters<GlobalOrdinal>& galeriParameters,
                    RCP<const Teuchos::Comm<int> > comm,
                    RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> >& A,
-                   std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regionGrpMats,
-                   Teuchos::Array<RCP<Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regionNullspace,
-                   Teuchos::Array<RCP<Xpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::coordinateType, LocalOrdinal, GlobalOrdinal, Node> > >& regionCoordinates,
-                   std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& revisedRowMapPerGrp,
-                   std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > >& rowImportPerGrp,
+                   RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> >& regionMats,
+                   RCP<Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> >& regionNullspace,
+                   RCP<Xpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::coordinateType, LocalOrdinal, GlobalOrdinal, Node> >& regionCoordinates,
+                   RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> >& revisedRowMap,
+                   RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> >& rowImport,
                    Teuchos::ArrayRCP<LocalOrdinal>& regionMatVecLIDs,
                    RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> >& regionInterfaceImporter,
                    Teuchos::Array<LocalOrdinal>& rNodesPerDim) {
@@ -233,53 +230,54 @@ void createProblem(const int maxRegPerProc,
 
   // Create auxiliary data for MG
   RCP<MultiVector> nullspace = Pr->BuildNullspace();
-  RCP<RealValuedMultiVector> coordinates = 
+  RCP<RealValuedMultiVector> coordinates =
     Galeri::Xpetra::Utils::CreateCartesianCoordinates<double,LO,GO,Map,RealValuedMultiVector>(coordinatesType, nodeMap, galeriList);
 
   // create the region maps, importer and operator from composite counter parts
-  std::vector<RCP<Map> >    rowMapPerGrp(maxRegPerProc), colMapPerGrp(maxRegPerProc);
-  std::vector<RCP<Map> >    revisedColMapPerGrp(maxRegPerProc);
-  std::vector<RCP<Import> > colImportPerGrp(maxRegPerProc);
+  RCP<Map> rowMap = Teuchos::null;
+  RCP<Map> colMap = Teuchos::null;
+  RCP<Map> revisedColMap = Teuchos::null;
+  RCP<Import> colImport = Teuchos::null;
   Array<GO>  quasiRegionCoordGIDs;
   LO numLocalRegionNodes = 0;
-  createRegionMatrix(galeriList, numDofsPerNode, maxRegPerProc, nodeMap, dofMap, A,
-                     rowMapPerGrp, colMapPerGrp, revisedRowMapPerGrp, revisedColMapPerGrp,
-                     rowImportPerGrp, colImportPerGrp, regionGrpMats,
-                     regionMatVecLIDs, quasiRegionCoordGIDs, regionInterfaceImporter, 
+  createRegionMatrix(galeriList, numDofsPerNode, nodeMap, dofMap, A,
+                     rowMap, colMap, revisedRowMap, revisedColMap,
+                     rowImport, colImport, regionMats,
+                     regionMatVecLIDs, quasiRegionCoordGIDs, regionInterfaceImporter,
                      rNodesPerDim, numLocalRegionNodes);
 
   // Build objects needed to construct the region coordinates
-  std::vector<RCP<Map> > quasiRegCoordMap(maxRegPerProc);
-  std::vector<RCP<Map> > regCoordMap(maxRegPerProc);
-  std::vector<RCP<Import> > coordImporter(maxRegPerProc);
+  RCP<Map> quasiRegCoordMap = Teuchos::null;
+  RCP<Map> regCoordMap = Teuchos::null;
+  RCP<Import> coordImporter = Teuchos::null;
 
-  quasiRegCoordMap[0] = Xpetra::MapFactory<LO,GO,Node>::
+  quasiRegCoordMap = Xpetra::MapFactory<LO,GO,Node>::
     Build(nodeMap->lib(),
           Teuchos::OrdinalTraits<GO>::invalid(),
           quasiRegionCoordGIDs(),
           nodeMap->getIndexBase(),
           nodeMap->getComm());
-  regCoordMap[0] = Xpetra::MapFactory<LO,GO,Node>::
+  regCoordMap = Xpetra::MapFactory<LO,GO,Node>::
     Build(nodeMap->lib(),
           Teuchos::OrdinalTraits<GO>::invalid(),
           numLocalRegionNodes,
           nodeMap->getIndexBase(),
           nodeMap->getComm());
 
-  coordImporter[0] = ImportFactory::Build(nodeMap, quasiRegCoordMap[0]);
+  coordImporter = ImportFactory::Build(nodeMap, quasiRegCoordMap);
 
   // create region coordinates vector
-  regionCoordinates[0] = Xpetra::MultiVectorFactory<real_type,LO,GO,NO>::Build(quasiRegCoordMap[0],
-                                                                               coordinates->getNumVectors());
-  regionCoordinates[0]->doImport(*coordinates, *coordImporter[0], Xpetra::INSERT);
-  regionCoordinates[0]->replaceMap(regCoordMap[0]);
+  regionCoordinates = Xpetra::MultiVectorFactory<real_type,LO,GO,NO>::Build(quasiRegCoordMap,
+      coordinates->getNumVectors());
+  regionCoordinates->doImport(*coordinates, *coordImporter, Xpetra::INSERT);
+  regionCoordinates->replaceMap(regCoordMap);
 
   // Create regional nullspace and coordinates
-  Teuchos::Array<RCP<MultiVector> > quasiRegionNullspace(maxRegPerProc);
-  Teuchos::Array<RCP<RealValuedMultiVector> > quasiRegionCoordinates(maxRegPerProc);
+  RCP<MultiVector> quasiRegionNullspace = Teuchos::null;
+  RCP<RealValuedMultiVector> quasiRegionCoordinates = Teuchos::null;
 
   compositeToRegional(nullspace, quasiRegionNullspace, regionNullspace,
-                      revisedRowMapPerGrp, rowImportPerGrp);
+                      revisedRowMap, rowImport);
   compositeToRegional(coordinates, quasiRegionCoordinates, regionCoordinates,
                       regCoordMap, coordImporter);
 
@@ -322,28 +320,27 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionRFactory, RegionRFactLaplace3D, Scalar, 
   const int myRank   = comm->getRank();
 
   const int numDimensions = 3;
-  const int maxRegPerProc = 1;
   const LO numDofsPerNode = 1;
   GO nx = 7, ny = 7, nz = 4;
   Teuchos::Array<LO> lNodesPerDim({static_cast<LO>(nx), static_cast<LO>(ny), static_cast<LO>(nz)});
   Teuchos::CommandLineProcessor &clp = Teuchos::UnitTestRepository::getCLP();
   Galeri::Xpetra::Parameters<GO> galeriParameters(clp, nx, ny, nz, "Laplace3D");
-  std::vector<RCP<Matrix> > regionGrpMats(maxRegPerProc);
-  Teuchos::Array<RCP<MultiVector> > regionNullspace(maxRegPerProc);
-  Teuchos::Array<RCP<RealValuedMultiVector> > regionCoordinates(maxRegPerProc);
-  RCP<Matrix> A;
-  std::vector<RCP<Map> > revisedRowMapPerGrp(maxRegPerProc);
-  std::vector<RCP<Import> > rowImportPerGrp(maxRegPerProc);
+  RCP<Matrix> regionMats = Teuchos::null;
+  RCP<MultiVector> regionNullspace = Teuchos::null;
+  RCP<RealValuedMultiVector> regionCoordinates = Teuchos::null;
+  RCP<Matrix> A = Teuchos::null;
+  RCP<Map> revisedRowMap = Teuchos::null;
+  RCP<Import> rowImport = Teuchos::null;
   Teuchos::ArrayRCP<LocalOrdinal> regionMatVecLIDs;
-  RCP<Import> regionInterfaceImporter;
+  RCP<Import> regionInterfaceImporter = Teuchos::null;
   Teuchos::Array<LO> rNodesPerDim(3);
 
-  createProblem(maxRegPerProc, numDofsPerNode, galeriParameters, comm,
-                A, regionGrpMats, regionNullspace, regionCoordinates,
-                revisedRowMapPerGrp, rowImportPerGrp,
+  createProblem(numDofsPerNode, galeriParameters, comm,
+                A, regionMats, regionNullspace, regionCoordinates,
+                revisedRowMap, rowImport,
                 regionMatVecLIDs, regionInterfaceImporter, rNodesPerDim);
 
-  RCP<Matrix> regionMat = regionGrpMats[0];
+  RCP<Matrix> regionMat = regionMats;
 
   // Generate levels for a two level hierarchy
   MueLu::Level fineLevel, coarseLevel;
@@ -356,8 +353,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionRFactory, RegionRFactLaplace3D, Scalar, 
   fineLevel.Set("A", regionMat);
   fineLevel.Set("numDimensions", numDimensions);
   fineLevel.Set("lNodesPerDim",  rNodesPerDim);
-  fineLevel.Set("Nullspace", regionNullspace[0]);
-  fineLevel.Set("Coordinates", regionCoordinates[0]);
+  fineLevel.Set("Nullspace", regionNullspace);
+  fineLevel.Set("Coordinates", regionCoordinates);
 
   // Construct the region R factory
   RCP<RegionRFactory> myRFact = rcp(new RegionRFactory);
@@ -490,28 +487,27 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionRFactory, RegionRFactElasticity3D, Scala
   const int myRank   = comm->getRank();
 
   const int numDimensions = 3;
-  const int maxRegPerProc = 1;
   const LO numDofsPerNode = 3;
   GO nx = 7, ny = 7, nz = 4;
   Teuchos::Array<LO> lNodesPerDim({static_cast<LO>(nx), static_cast<LO>(ny), static_cast<LO>(nz)});
   Teuchos::CommandLineProcessor &clp = Teuchos::UnitTestRepository::getCLP();
   Galeri::Xpetra::Parameters<GO> galeriParameters(clp, nx, ny, nz, "Elasticity3D");
-  std::vector<RCP<Matrix> > regionGrpMats(maxRegPerProc);
-  Teuchos::Array<RCP<MultiVector> > regionNullspace(maxRegPerProc);
-  Teuchos::Array<RCP<RealValuedMultiVector> > regionCoordinates(maxRegPerProc);
-  RCP<Matrix> A;
-  std::vector<RCP<Map> > revisedRowMapPerGrp(maxRegPerProc);
-  std::vector<RCP<Import> > rowImportPerGrp(maxRegPerProc);
+  RCP<Matrix> regionMats = Teuchos::null;
+  RCP<MultiVector> regionNullspace = Teuchos::null;
+  RCP<RealValuedMultiVector> regionCoordinates = Teuchos::null;
+  RCP<Matrix> A = Teuchos::null;
+  RCP<Map> revisedRowMap = Teuchos::null;
+  RCP<Import> rowImport = Teuchos::null;
   Teuchos::ArrayRCP<LocalOrdinal> regionMatVecLIDs;
   RCP<Import> regionInterfaceImporter;
   Teuchos::Array<LO> rNodesPerDim(4);
 
-  createProblem(maxRegPerProc, numDofsPerNode, galeriParameters, comm,
-                A, regionGrpMats, regionNullspace, regionCoordinates,
-                revisedRowMapPerGrp, rowImportPerGrp,
+  createProblem(numDofsPerNode, galeriParameters, comm,
+                A, regionMats, regionNullspace, regionCoordinates,
+                revisedRowMap, rowImport,
                 regionMatVecLIDs, regionInterfaceImporter, rNodesPerDim);
 
-  RCP<Matrix> regionMat = regionGrpMats[0];
+  RCP<Matrix> regionMat = regionMats;
 
   // Generate levels for a two level hierarchy
   MueLu::Level fineLevel, coarseLevel;
@@ -524,8 +520,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionRFactory, RegionRFactElasticity3D, Scala
   fineLevel.Set("A", regionMat);
   fineLevel.Set("numDimensions", numDimensions);
   fineLevel.Set("lNodesPerDim",  rNodesPerDim);
-  fineLevel.Set("Nullspace", regionNullspace[0]);
-  fineLevel.Set("Coordinates", regionCoordinates[0]);
+  fineLevel.Set("Nullspace", regionNullspace);
+  fineLevel.Set("Coordinates", regionCoordinates);
 
   // Construct the region R factory
   RCP<RegionRFactory> myRFact = rcp(new RegionRFactory);
@@ -574,10 +570,10 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionRFactory, RegionRFactElasticity3D, Scala
     TEST_EQUALITY(R->getCrsGraph()->getNodeNumCols(),   588);
     TEST_EQUALITY(R->getNodeNumEntries(),              2178);
 
-    Array<LO> rowLength = {{27, 27, 27, 45, 45, 45, 27, 27, 27, 45, 45, 45, 
-                            75, 75, 75, 45, 45, 45, 27, 27, 27, 45, 45, 45, 
-                            27, 27, 27, 27, 27, 27, 45, 45, 45, 27, 27, 27, 
-                            45, 45, 45, 75, 75, 75, 45, 45, 45, 27, 27, 27, 
+    Array<LO> rowLength = {{27, 27, 27, 45, 45, 45, 27, 27, 27, 45, 45, 45,
+                            75, 75, 75, 45, 45, 45, 27, 27, 27, 45, 45, 45,
+                            27, 27, 27, 27, 27, 27, 45, 45, 45, 27, 27, 27,
+                            45, 45, 45, 75, 75, 75, 45, 45, 45, 27, 27, 27,
                             45, 45, 45, 27, 27, 27}};
     ArrayView<const LO> rowEntries;
     ArrayView<const SC> rowValues;

--- a/packages/muelu/test/unit_tests/RegionVector.cpp
+++ b/packages/muelu/test/unit_tests/RegionVector.cpp
@@ -130,27 +130,26 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionVector, RegionCompositeVector, Scalar, L
                    quasiRegionGIDs, quasiRegionCoordGIDs, compositeToRegionLIDs,
                    interfaceGIDs, interfaceLIDsData);
 
-  const int maxRegPerProc = 1;
-  std::vector<RCP<Map> > rowMapPerGrp(maxRegPerProc),        colMapPerGrp(maxRegPerProc);
-  rowMapPerGrp[0] = Xpetra::MapFactory<LO,GO,Node>::Build(A->getRowMap()->lib(),
-                                                          Teuchos::OrdinalTraits<GO>::invalid(),
-                                                          quasiRegionGIDs(),
-                                                          A->getRowMap()->getIndexBase(),
-                                                          A->getRowMap()->getComm());
-  colMapPerGrp[0] = rowMapPerGrp[0];
+  RCP<Map> rowMap = Teuchos::null;
+  RCP<Map> colMap = Teuchos::null;
+  rowMap = Xpetra::MapFactory<LO,GO,Node>::Build(A->getRowMap()->lib(),
+      Teuchos::OrdinalTraits<GO>::invalid(),
+      quasiRegionGIDs(),
+      A->getRowMap()->getIndexBase(),
+      A->getRowMap()->getComm());
+  colMap = rowMap;
 
-  std::vector<RCP<Map> > revisedRowMapPerGrp(maxRegPerProc), revisedColMapPerGrp(maxRegPerProc);
-  revisedRowMapPerGrp[0] = Xpetra::MapFactory<LO,GO,Node>::Build(A->getRowMap()->lib(),
-                                                                 Teuchos::OrdinalTraits<GO>::invalid(),
-                                                                 quasiRegionGIDs.size()*numDofsPerNode,
-                                                                 A->getRowMap()->getIndexBase(),
-                                                                 A->getRowMap()->getComm());
-  revisedColMapPerGrp[0] = revisedRowMapPerGrp[0];
+  RCP<Map> revisedRowMap = Teuchos::null;
+  RCP<Map> revisedColMap = Teuchos::null;
+  revisedRowMap = Xpetra::MapFactory<LO,GO,Node>::Build(A->getRowMap()->lib(),
+      Teuchos::OrdinalTraits<GO>::invalid(),
+      quasiRegionGIDs.size()*numDofsPerNode,
+      A->getRowMap()->getIndexBase(),
+      A->getRowMap()->getComm());
+  revisedColMap = revisedRowMap;
 
-  std::vector<RCP<Import> > rowImportPerGrp(maxRegPerProc);
-  std::vector<RCP<Import> > colImportPerGrp(maxRegPerProc);
-  rowImportPerGrp[0] = ImportFactory::Build(dofMap, rowMapPerGrp[0]);
-  colImportPerGrp[0] = ImportFactory::Build(dofMap, colMapPerGrp[0]);
+  RCP<Import> rowImport = ImportFactory::Build(dofMap, rowMap);
+  // RCP<Import> colImport = ImportFactory::Build(dofMap, colMap);
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   { // test compositeToRegional
@@ -164,16 +163,16 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionVector, RegionCompositeVector, Scalar, L
     }
 
     // Create a region vector
-    Array<RCP<Vector> > regVec(maxRegPerProc);
-    Array<Teuchos::RCP<Vector> > quasiRegVec(maxRegPerProc);
+    RCP<Vector> regVec = Teuchos::null;
+    RCP<Vector> quasiRegVec = Teuchos::null;
 
-    compositeToRegional(compVec, quasiRegVec, regVec, revisedRowMapPerGrp, rowImportPerGrp);
+    compositeToRegional(compVec, quasiRegVec, regVec, revisedRowMap, rowImport);
 
     if(numRanks == 1){
-      TEST_EQUALITY(regVec[0]->getLocalLength(),  25);
-      TEST_EQUALITY(regVec[0]->getGlobalLength(), 25);
-      TEST_EQUALITY(quasiRegVec[0]->getLocalLength(),  25);
-      TEST_EQUALITY(quasiRegVec[0]->getGlobalLength(), 25);
+      TEST_EQUALITY(regVec->getLocalLength(),  25);
+      TEST_EQUALITY(regVec->getGlobalLength(), 25);
+      TEST_EQUALITY(quasiRegVec->getLocalLength(),  25);
+      TEST_EQUALITY(quasiRegVec->getGlobalLength(), 25);
       ArrayRCP<SC> refValues;
       Teuchos::ArrayRCP<const SC> myValues;
       refValues.deepCopy(ArrayView<const SC>({0.0, 1, 2, 3, 4,
@@ -181,24 +180,22 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionVector, RegionCompositeVector, Scalar, L
                                               10, 11, 12, 13, 14,
                                               15, 16, 17, 18, 19,
                                               20, 21, 22, 23, 24}));
-      for (int j = 0; j < maxRegPerProc; j++) {
-        myValues = regVec[j]->getData(0);
-        for(size_t idx = 0; idx < regVec[j]->getLocalLength(); ++idx) {
-          TEST_FLOATING_EQUALITY(myValues[idx], refValues[idx], 100*TMT::eps());
-        }
-        myValues = quasiRegVec[j]->getData(0);
-        for(size_t idx = 0; idx < quasiRegVec[j]->getLocalLength(); ++idx) {
-          TEST_FLOATING_EQUALITY(myValues[idx], refValues[idx], 100*TMT::eps());
-        }
 
+      myValues = regVec->getData(0);
+      for(size_t idx = 0; idx < regVec->getLocalLength(); ++idx) {
+        TEST_FLOATING_EQUALITY(myValues[idx], refValues[idx], 100*TMT::eps());
+      }
+      myValues = quasiRegVec->getData(0);
+      for(size_t idx = 0; idx < quasiRegVec->getLocalLength(); ++idx) {
+        TEST_FLOATING_EQUALITY(myValues[idx], refValues[idx], 100*TMT::eps());
       }
 
     } else if(numRanks == 4) {
       // All ranks will have the same number of rows/cols/entries
-      TEST_EQUALITY(regVec[0]->getLocalLength(),  9);
-      TEST_EQUALITY(regVec[0]->getGlobalLength(), 36);
-      TEST_EQUALITY(quasiRegVec[0]->getLocalLength(),  9);
-      TEST_EQUALITY(quasiRegVec[0]->getGlobalLength(), 36);
+      TEST_EQUALITY(regVec->getLocalLength(),  9);
+      TEST_EQUALITY(regVec->getGlobalLength(), 36);
+      TEST_EQUALITY(quasiRegVec->getLocalLength(),  9);
+      TEST_EQUALITY(quasiRegVec->getGlobalLength(), 36);
 
       ArrayRCP<SC> refValues;
       Teuchos::ArrayRCP<const SC> myValues;
@@ -215,15 +212,13 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionVector, RegionCompositeVector, Scalar, L
         refValues.deepCopy(ArrayView<const SC>({8, 4.1, 5.1, 2.2, 0.3, 1.3, 5.2, 2.3, 3.3}));
       }
       // Loop over region matrix data and compare it to ref data
-      for (int j = 0; j < maxRegPerProc; j++){
-        myValues = regVec[j]->getData(0);
-        for(size_t idx = 0; idx < regVec[j]->getLocalLength(); ++idx) {
-          TEST_FLOATING_EQUALITY(myValues[idx], refValues[idx], 100*TMT::eps());
-        }
-        myValues = quasiRegVec[j]->getData(0);
-        for(size_t idx = 0; idx < quasiRegVec[j]->getLocalLength(); ++idx) {
-          TEST_FLOATING_EQUALITY(myValues[idx], refValues[idx], 100*TMT::eps());
-        }
+      myValues = regVec->getData(0);
+      for(size_t idx = 0; idx < regVec->getLocalLength(); ++idx) {
+        TEST_FLOATING_EQUALITY(myValues[idx], refValues[idx], 100*TMT::eps());
+      }
+      myValues = quasiRegVec->getData(0);
+      for(size_t idx = 0; idx < quasiRegVec->getLocalLength(); ++idx) {
+        TEST_FLOATING_EQUALITY(myValues[idx], refValues[idx], 100*TMT::eps());
       }
     }
 
@@ -231,19 +226,18 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionVector, RegionCompositeVector, Scalar, L
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   {
     // Create a region vector
-    Array<RCP<Vector> > regVec(maxRegPerProc);
-    for (int j = 0; j < maxRegPerProc; j++) {
-      regVec[j] = VectorFactory::Build(revisedRowMapPerGrp[j]);
-      regVec[j]->putScalar( myRank / 10.0 );
-      for (size_t k = 0; k < regVec[j]->getLocalLength(); ++k){
-        regVec[j]->sumIntoLocalValue(k, k);
-      }
+    RCP<Vector> regVec = Teuchos::null;
+    regVec = VectorFactory::Build(revisedRowMap);
+    regVec->putScalar( myRank / 10.0 );
+    for (size_t k = 0; k < regVec->getLocalLength(); ++k){
+      regVec->sumIntoLocalValue(k, k);
     }
+
 
     // Create a composite vector
     RCP<Vector> compVec = VectorFactory::Build(dofMap, true);
 
-    regionalToComposite(regVec, compVec, rowImportPerGrp);
+    regionalToComposite(regVec, compVec, rowImport);
 
     if(numRanks == 1) {
       TEST_EQUALITY(compVec->getLocalLength(),  25);
@@ -303,41 +297,38 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionVector, RegionCompositeVector, Scalar, L
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   {
     // initialize region vector with all ones.
-    Array<RCP<Vector> > interfaceScaling(maxRegPerProc);
-    for (int j = 0; j < maxRegPerProc; j++) {
-      interfaceScaling[j] = VectorFactory::Build(revisedRowMapPerGrp[j]);
-      interfaceScaling[j]->putScalar(1.0);
-    }
+    RCP<Vector> interfaceScaling = Teuchos::null;
+    interfaceScaling = VectorFactory::Build(revisedRowMap);
+    interfaceScaling->putScalar(1.0);
+
 
     // transform to composite layout while adding interface values via the Export() combine mode
     RCP<Vector> compInterfaceScalingSum = VectorFactory::Build(dofMap, true);
-    regionalToComposite(interfaceScaling, compInterfaceScalingSum, rowImportPerGrp);
+    regionalToComposite(interfaceScaling, compInterfaceScalingSum, rowImport);
 
     /* transform composite layout back to regional layout. Now, GIDs associated
      * with region interface should carry a scaling factor (!= 1).
      */
-    Array<RCP<Vector> > regVec(maxRegPerProc);
-    Array<RCP<Vector> > quasiRegInterfaceScaling(maxRegPerProc);
+    RCP<Vector> regVec = Teuchos::null;
+    RCP<Vector> quasiRegInterfaceScaling = Teuchos::null;
     compositeToRegional(compInterfaceScalingSum, quasiRegInterfaceScaling,
-                        interfaceScaling, revisedRowMapPerGrp, rowImportPerGrp);
+                        interfaceScaling, revisedRowMap, rowImport);
 
     if(numRanks == 1) {
-      TEST_EQUALITY(interfaceScaling[0]->getLocalLength(),    25);
-      TEST_EQUALITY(interfaceScaling[0]->getGlobalLength(),   25);
+      TEST_EQUALITY(interfaceScaling->getLocalLength(),    25);
+      TEST_EQUALITY(interfaceScaling->getGlobalLength(),   25);
 
       // No scaling on one rank, so all values are 1.0
       Teuchos::ArrayRCP<const SC> myScaling;
-      for (int j = 0; j < maxRegPerProc; j++){
-        myScaling = interfaceScaling[j]->getData(0);
-        for(size_t idx = 0; idx < interfaceScaling[j]->getLocalLength(); ++idx) {
-          TEST_FLOATING_EQUALITY(myScaling[idx], TST::one(), 100*TMT::eps());
-        }
+      myScaling = interfaceScaling->getData(0);
+      for(size_t idx = 0; idx < interfaceScaling->getLocalLength(); ++idx) {
+        TEST_FLOATING_EQUALITY(myScaling[idx], TST::one(), 100*TMT::eps());
       }
 
     } else if(numRanks == 4) {
       // All ranks will have the same number of rows/cols/entries
-      TEST_EQUALITY(interfaceScaling[0]->getLocalLength(),    9);
-      TEST_EQUALITY(interfaceScaling[0]->getGlobalLength(),    36);
+      TEST_EQUALITY(interfaceScaling->getLocalLength(),    9);
+      TEST_EQUALITY(interfaceScaling->getGlobalLength(),    36);
 
       ArrayRCP<SC> refValues;
       Teuchos::ArrayRCP<const SC> myScaling;
@@ -354,12 +345,11 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionVector, RegionCompositeVector, Scalar, L
         refValues.deepCopy(ArrayView<const SC>({4, 2, 2, 2, 1, 1, 2, 1, 1}));
       }
       // Loop over region vector data and compare it to reference data
-      for (int j = 0; j < maxRegPerProc; j++){
-        myScaling = interfaceScaling[j]->getData(0);
-        for(size_t idx = 0; idx < interfaceScaling[j]->getLocalLength(); ++idx) {
-          TEST_FLOATING_EQUALITY(myScaling[idx], refValues[idx], 100*TMT::eps());
-        }
+      myScaling = interfaceScaling->getData(0);
+      for(size_t idx = 0; idx < interfaceScaling->getLocalLength(); ++idx) {
+        TEST_FLOATING_EQUALITY(myScaling[idx], refValues[idx], 100*TMT::eps());
       }
+
     }
 
   }


### PR DESCRIPTION
@trilinos/muelu 

## Motivation

Fix compilation and test execution for `-D MueLu_ENABLE_Experimental:BOOL=ON`.

In particular, the region unit tests needed to be adapted to the removal of the `std::vector` clutter stemming from the abandoned "group" concept (c.f. PR #8319).

## Related Issues

* Follows PR #8319

## Stakeholder Feedback

Related to an ASCR project by @rstumin, @lucbv 

## Testing

Region unit tests are building and passing again.