### PR TITLE
MueLu: option to print level data info

### DIFF
--- a/packages/muelu/src/Interface/MueLu_HierarchyManager.hpp
+++ b/packages/muelu/src/Interface/MueLu_HierarchyManager.hpp
@@ -243,6 +243,7 @@ namespace MueLu {
                          LvlMngr(levelID-1, lastLevelID),
                          LvlMngr(levelID,   lastLevelID),
                          LvlMngr(levelID+1, lastLevelID));
+        H.GetLevel(levelID)->print(H.GetOStream(Developer), verbosity_);
 
         isLastLevel = r || (levelID == lastLevelID);
         levelID++;

--- a/packages/muelu/src/MueCentral/MueLu_VerbosityLevel.cpp
+++ b/packages/muelu/src/MueCentral/MueLu_VerbosityLevel.cpp
@@ -107,6 +107,7 @@ namespace MueLu {
     verbMap["timings1"]       = Timings1;
     verbMap["timingsByLevel"] = TimingsByLevel;
     verbMap["external"]       = External;
+    verbMap["developer"]      = Developer;
     verbMap["debug"]          = Debug;
     verbMap["test"]           = Test;
 

--- a/packages/muelu/src/MueCentral/MueLu_VerbosityLevel.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_VerbosityLevel.hpp
@@ -78,7 +78,7 @@ namespace MueLu {
       External        = 0x01000000, //!< Print external lib objects
       Debug           = 0x02000000, //!< Print additional debugging information
 
-      Developer       = 0x03000000, //!< Print information primarily of interest to developers
+      Developer       = 0x04000000, //!< Print information primarily of interest to developers
 
       Test0           = 0x10000000, //!< Print skeleton for the run, i.e. factory calls and used parameters
 

--- a/packages/muelu/src/MueCentral/MueLu_VerbosityLevel.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_VerbosityLevel.hpp
@@ -78,6 +78,8 @@ namespace MueLu {
       External        = 0x01000000, //!< Print external lib objects
       Debug           = 0x02000000, //!< Print additional debugging information
 
+      Developer       = 0x03000000, //!< Print information primarily of interest to developers
+
       Test0           = 0x10000000, //!< Print skeleton for the run, i.e. factory calls and used parameters
 
       // Predefined combinations of MsgType
@@ -95,9 +97,9 @@ namespace MueLu {
       Medium  = Errors | Warnings0 | Runtime0 | Parameters0 | Statistics0 | Statistics1 | Timings0,
       High    = Errors | Warnings  | Runtime  | Parameters  | Statistics0 | Statistics1  | Timings,
 #ifdef HAVE_MUELU_DEBUG
-      Extreme = Errors | Warnings  | Runtime  | Parameters  | Statistics  | Timings | External | Debug,
+      Extreme = Errors | Warnings  | Runtime  | Parameters  | Statistics  | Timings | External | Developer | Debug,
 #else
-      Extreme = Errors | Warnings  | Runtime  | Parameters  | Statistics  | Timings | External,
+      Extreme = Errors | Warnings  | Runtime  | Parameters  | Statistics  | Timings | External | Developer,
 #endif
       Default = High, // This is the default of print() methods. For VerboseObject, another default is set by VerboseObject::globalVerbLevel_ // TODO: move it to the VerboseObject class
 


### PR DESCRIPTION
Print individual levels with data pointers during setup.  This is useful for developers.
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/muelu 

## Motivation
useful for MueLu developers
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
N/A
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

## Additional Information
Adds a new verbosity level, `developer`.  This is also part of the `extreme` verbosity level.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trilinos/trilinos/8330)
<!-- Reviewable:end -->
