### PR TITLE
Xpetra: remove obsolete CMake commands

### DIFF
--- a/packages/xpetra/CMakeLists.txt
+++ b/packages/xpetra/CMakeLists.txt
@@ -210,10 +210,6 @@ TRIBITS_ADD_TEST_DIRECTORIES(test)
 
 TRIBITS_EXCLUDE_AUTOTOOLS_FILES()
 
-TRIBITS_EXCLUDE_FILES(
-  test/BlockedCrsOperator
-  )
-
 #
 # D) Do standard postprocessing
 #


### PR DESCRIPTION
@trilinos/xpetra 

## Motivation

We don't have to exclude the directory `src/test/BlockedCrsOperator`, since it does not exist.

## Stakeholder Feedback

n/a.

## Testing

Build and existing tests pass.