### PR TITLE
WIP: ETI on as default

### DIFF
--- a/cmake/tribits/core/package_arch/TribitsGlobalMacros.cmake
+++ b/cmake/tribits/core/package_arch/TribitsGlobalMacros.cmake
@@ -482,7 +482,7 @@ MACRO(TRIBITS_DEFINE_GLOBAL_OPTIONS_AND_DEFINE_EXTRA_REPOS)
     "Print out when all of the various files get processed."
     )
 
-  ADVANCED_SET(${PROJECT_NAME}_ENABLE_EXPLICIT_INSTANTIATION OFF
+  ADVANCED_SET(${PROJECT_NAME}_ENABLE_EXPLICIT_INSTANTIATION ON
     CACHE BOOL
     "Enable explicit template instantiation in all packages that support it"
     )


### PR DESCRIPTION
@trilinos/framework 

## Motivation
This will change the default for ETI from OFF to ON. I realize this is also changing the default in tributes, which may not be wanted, so I am asking @bartlettroscoe to weigh in on that.

## Testing
This has been used extensively in PR testing for some months. The specific change was tested using gcc 8.3.0 directly.

