### PR TITLE
Change Trilinos/TriBITS default of ETI to ON (#8130)

### DIFF
--- a/cmake/tribits/ReleaseNotes.txt
+++ b/cmake/tribits/ReleaseNotes.txt
@@ -2,6 +2,16 @@
 Release Notes for TriBITS
 ----------------------------------------
 
+2020/11/12:
+
+*) MAJOR: The default for `<Project>_ENABLE_EXPLICIT_INSTANTIATION` (ETI) was
+ changed from `OFF` to `ON`.  This was turned on in practice for almost all
+ users of Trilinos so while this change technically breaks backward
+ compatibility of TriBITS, in practice, this will likely not impact any
+ important customers.  (And new customers of Trilinos and related TriBITS
+ projects will enjoy the benefits of ETI by default.  See
+ trilinos/Trilinos#8130.)
+
 2020/10/08:
 
 *) MAJOR: Tests defined with `TRIBITS_ADD_TEST()` and
@@ -9,8 +19,8 @@ Release Notes for TriBITS
  for non-MPI TPL_ENABLE_MPI=OFF configurations.  Before, the test would get
  added and basically ignore the value of `NUM_MPI_PROCS`.  This change
  together with the change to move to using `add_test(NAME <name> COMMAND
- <command>)` mostly restores backward compatbility for projects using TriBITS.
- For more details, see trilinos/Trilinos#8110.
+ <command>)` mostly restores backward compatibility for projects using
+ TriBITS.  For more details, see trilinos/Trilinos#8110.
 
 2020/09/28:
 
@@ -51,12 +61,12 @@ Release Notes for TriBITS
 
 2017/09/25:
 
-(*) MINOR: TriBITS CTest Driver: Added cache and enve vars
+(*) MINOR: TriBITS CTest Driver: Added cache and env vars
     CTEST_SUBMIT_RETRY_COUNT and CTEST_SUBMIT_RETRY_DELAY to allow the number
-    of ctest_submit() submit attemtps to retry and how how log to pause
+    of ctest_submit() submit attempts to retry and how how log to pause
     between retries.  Before, these were hard-coded to 25 and 120
     respectively, which means that something like a MySQL insertion error
-    could consume as much as 50 minutes befor moving on!  The new defalts are
+    could consume as much as 50 minutes before moving on!  The new defaults are
     set at 5 retries with a 3 sec delay (which appear to be the CTest
     defaults).
 
@@ -70,7 +80,7 @@ Release Notes for TriBITS
 
 2017/09/05:
 
-(*) MINOR: TriBITS Core: Unparsed and otherwise ignored arguments are now
+(*) MINOR: TriBITS Core: Un-parsed and otherwise ignored arguments are now
     flagged (see developers guide documentation for
     ${PROJECT_NAME}_CHECK_FOR_UNPARSED_ARGUMENTS).  The default value is
     'WARNING' which results in simply printing a warning but allow configure
@@ -159,7 +169,7 @@ Release Notes for TriBITS
 2016/01/22:
 
 (*) MINOR: TriBITS Core: Change test category WEEKLY to HEAVY and depreciate
-    WEEKLY.  You can stil use WEEKLY but it will result in a lot of warnings.
+    WEEKLY.  You can still use WEEKLY but it will result in a lot of warnings.
 
 2015/12/03:
 
@@ -193,7 +203,7 @@ Release Notes for TriBITS
     TRIBITS_TDD_USE_SYSTEM_CTEST so that if equal to 1, then the TriBITS
     Dashboard Driver (TDD) system will use the CTest (and CMake) in the env
     will be used instead of being downloaded using download-cmake.py.  This
-    not only speeds up the auotmated builds, but it also ensures that the
+    not only speeds up the automated builds, but it also ensures that the
     automated testing uses exactly the install of CMake/CTest that is used by
     the developers on the system.  Also, it has been found that
     download-cmake.py will download and install a 32bit version even on 64bit
@@ -204,9 +214,9 @@ Trilinos 11.7:
 
 (*) MINOR: TriBITS Core: Switched from the terms Primary Stable (PS) and
     Secondary Stable (SS) code to Primary Tested (PT) and Secondary Tested
-    (ST) according to the plan in the TriBITS Lifecycle model.  Using 'PS' and
+    (ST) according to the plan in the TriBITS Life-cycle model.  Using 'PS' and
     'SS' is still allowed but is deprecated.  This also included deprecating
-    the varible <Project>_ENABLE_SECONDARY_STABLE_CODE and replacing it with
+    the variable <Project>_ENABLE_SECONDARY_STABLE_CODE and replacing it with
     <Project>_ENABLE_SECONDARY_TEST_CODE.  Again, backward compatibility is
     preserved.  Also, the checkin-test.py arg --ss-extra-builds is deprecated
     and replaced with --st-extra-builds.
@@ -216,7 +226,7 @@ Trilinos 11.6:
 --------------
 
 (*) MAJOR: TriBITS Core: Changed behavior of <Project>_ENABLE_<PACKAGE>=ON to
-    enable all subpackages for that package including in propogating forward
+    enable all subpackages for that package including in propagating forward
     dependencies.  See updated <Project>BuildQuickRef.* document.
 
 
@@ -230,7 +240,7 @@ Trilinos 11.3:
 (*) MINOR: TriBITS Core: Fixed the generation of headers for explicit
     instantation system for subpackages: Now subpackages that use the macro
     TRIBITS_CREATE_CLIENT_TEMPLATE_HEADERS() to generate XXX.hpp header files
-    with or without expliict instantation will key off of the parent package's
+    with or without explicit instantation will key off of the parent package's
     explicit instantation setting.  In addition, packages that use the macro
     TRIBITS_CREATE_CLIENT_TEMPLATE_HEADERS() will also need to add a call to
     TRIBITS_ADD_EXPLICIT_INSTANTIATION_OPTION() in their top-level

--- a/cmake/tribits/core/package_arch/TribitsGlobalMacros.cmake
+++ b/cmake/tribits/core/package_arch/TribitsGlobalMacros.cmake
@@ -482,7 +482,7 @@ MACRO(TRIBITS_DEFINE_GLOBAL_OPTIONS_AND_DEFINE_EXTRA_REPOS)
     "Print out when all of the various files get processed."
     )
 
-  ADVANCED_SET(${PROJECT_NAME}_ENABLE_EXPLICIT_INSTANTIATION OFF
+  ADVANCED_SET(${PROJECT_NAME}_ENABLE_EXPLICIT_INSTANTIATION ON
     CACHE BOOL
     "Enable explicit template instantiation in all packages that support it"
     )

--- a/cmake/tribits/doc/build_ref/TribitsBuildReferenceBody.rst
+++ b/cmake/tribits/doc/build_ref/TribitsBuildReferenceBody.rst
@@ -309,6 +309,7 @@ c) Using the QT CMake configuration GUI:
   create a fragment file and just load it by setting
   `<Project>_CONFIGURE_OPTIONS_FILE`_ (see above) in the GUI.
 
+
 Selecting the list of packages to enable
 ----------------------------------------
 
@@ -352,10 +353,11 @@ for ``<Project>_SE_PACKAGES`` using, for example::
 
   ./do-configure 2>&1 | grep "<Project>_SE_PACKAGES: "
 
-.. _<Project>_DUMP_PACKAGE_DEPENDENCIES:
 
 Print package dependencies
 ++++++++++++++++++++++++++
+
+.. _<Project>_DUMP_PACKAGE_DEPENDENCIES:
 
 The set of package dependencies can be printed in the ``cmake`` STDOUT by
 setting the configure option::
@@ -570,6 +572,7 @@ expensive configure time checks and to preserve other cache variables that you
 have set and don't want to loose.  For example, one would want to do this to
 avoid compiler and TPL checks.
 
+
 Selecting compiler and linker options
 -------------------------------------
 
@@ -693,10 +696,11 @@ these flags are not set.  These flags get set internally into the variables
 variable level) but the user can append flags that override these as described
 below.
 
-.. _CMAKE_BUILD_TYPE:
 
 Configuring to build with default debug or release compiler flags
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. _CMAKE_BUILD_TYPE:
 
 To build a debug version, pass into 'cmake'::
 
@@ -715,6 +719,7 @@ to what is in ``CMAKE_<LANG>_FLAGS_RELEASE``.
 The default build type is typically ``CMAKE_BUILD_TYPE=RELEASE`` unless ``-D
 USE_XSDK_DEFAULTS=TRUE`` is set in which case the default build type is
 ``CMAKE_BUILD_TYPE=DEBUG`` as per the xSDK configure standard.
+
 
 Adding arbitrary compiler flags but keeping default build-type flags
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -782,6 +787,7 @@ manually set ``CMAKE_<LANG>_FLAGS_<CMAKE_BUILD_TYPE>`` directly!  To
 override those options, see
 ``CMAKE_<LANG>_FLAGS_<CMAKE_BUILD_TYPE>_OVERRIDE`` below.
 
+
 Overriding CMAKE_BUILD_TYPE debug/release compiler options
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -808,6 +814,7 @@ NOTES: The TriBITS CMake cache variable
 internally by CMake and the new varaible is needed to make the override
 explicit.
 
+
 Appending arbitrary libraries and link flags every executable
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -831,10 +838,11 @@ instead.  The TriBITS variable ``<Project>_EXTRA_LINK_FLAGS`` is badly named
 in this respect but the name remains due to backward compatibility
 requirements.
 
-.. _<TRIBITS_PACKAGE>_DISABLE_STRONG_WARNINGS:
 
 Turning off strong warnings for individual packages
 +++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. _<TRIBITS_PACKAGE>_DISABLE_STRONG_WARNINGS:
 
 To turn off strong warnings (for all languages) for a given TriBITS package,
 set::
@@ -849,6 +857,7 @@ Note that strong warnings are only enabled by default in development mode
 (``<Project>_ENABLE_DEVELOPMENT_MODE==ON``) but not release mode
 (``<Project>_ENABLE_DEVELOPMENT_MODE==ON``).  A release of <Project> should
 therefore not have strong warning options enabled.
+
 
 Overriding all (strong warnings and debug/release) compiler options
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -874,6 +883,7 @@ NOTE: By setting ``CMAKE_BUILD_TYPE=NONE``, then ``CMAKE_<LANG>_FLAGS_NONE``
 will be empty and therefore the options set in ``CMAKE_<LANG>_FLAGS`` will
 be all that is passed in.
 
+
 Enable and disable shadowing warnings for all <Project> packages
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -891,6 +901,7 @@ NOTE: The default value is empty '' which lets each <Project> package
 decide for itself if shadowing warnings will be turned on or off for that
 package.
 
+
 Removing warnings as errors for CLEANED packages
 ++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -899,6 +910,7 @@ applied to compile CLEANED packages (like the Trilinos package Teuchos), set
 the following when configuring::
 
   -D <Project>_WARNINGS_AS_ERRORS_FLAGS=""
+
 
 Adding debug symbols to the build
 +++++++++++++++++++++++++++++++++
@@ -909,6 +921,7 @@ To get the compiler to add debug symbols to the build, configure with::
 
 This will add ``-g`` on most compilers.  NOTE: One does **not** generally
 need to create a fully debug build to get debug symbols on most compilers.
+
 
 Enabling support for Ninja
 --------------------------
@@ -978,30 +991,30 @@ NOTE: These options are ignored when using Makefiles or other CMake
 generators.  They only work for the Ninja generator.
 
 
-Enabling explicit template instantiation for C++
-------------------------------------------------
+Disabling explicit template instantiation for C++
+-------------------------------------------------
 
-To enable explicit template instantiation for C++ code for packages that
-support it, configure with::
+By default, support for optional explicit template instantiation (ETI) for C++
+code is enabled.  To disable support for optional ETI, configure with::
 
-  -D <Project>_ENABLE_EXPLICIT_INSTANTIATION=ON
+  -D <Project>_ENABLE_EXPLICIT_INSTANTIATION=OFF
 
 When ``OFF``, all packages that have templated C++ code will use implicit
-template instantiation.
+template instantiation (unless they have hard-coded usage of ETI).
 
-Explicit template instantiation can be enabled (``ON``) or disabled (``OFF``)
-for individual packages with::
-
+ETI can be enabled (``ON``) or disabled (``OFF``) for individual packages
+with::
 
   -D <TRIBITS_PACKAGE>_ENABLE_EXPLICIT_INSTANTIATION=[ON|OFF]
 
 The default value for ``<TRIBITS_PACKAGE>_ENABLE_EXPLICIT_INSTANTIATION`` is
 set by ``<Project>_ENABLE_EXPLICIT_INSTANTIATION``.
 
-For packages that support it, explicit template instantation can massively
-reduce the compile times for the C++ code involved.  To see what packages
-support explicit instantation just search the CMakeCache.txt file for
-variables with ``ENABLE_EXPLICIT_INSTANTIATION`` in the name.
+For packages that support it, explicit template instantiation can massively
+reduce the compile times for the C++ code involved and can even avoid compiler
+crashes in some cases.  To see what packages support explicit template
+instantiation, just search the CMakeCache.txt file for variables with
+``ENABLE_EXPLICIT_INSTANTIATION`` in the name.
 
 
 Disabling the Fortran compiler and all Fortran code
@@ -1264,6 +1277,7 @@ c) **Setting up to run MPI programs:**
   ``MPI_EXEC_POST_NUMPROCS_FLAGS`` must be quoted and separated by ``';'`` as
   these variables are interpreted as CMake arrays.
 
+
 Configuring for OpenMP support
 ------------------------------
 
@@ -1285,10 +1299,11 @@ the ``FIND_PACKAGE(OpenMP)`` command will fail.  Setting the variable
 ``-DOpenMP_<LANG>_FLAGS_OVERRIDE= " "`` is the only way to enable OpenMP but
 skip adding the OpenMP flags provided by ``FIND_PACKAGE(OpenMP)``.
 
-.. _BUILD_SHARED_LIBS:
 
 Building shared libraries
 -------------------------
+
+.. _BUILD_SHARED_LIBS:
 
 To configure to build shared libraries, set::
 
@@ -1313,6 +1328,7 @@ environment variables.  However, this can be disabled by setting::
   -D CMAKE_SKIP_BUILD_RPATH=TRUE
 
 but it is hard to find a use case where that would be useful.
+
 
 Building static libraries and executables
 -----------------------------------------
@@ -2097,11 +2113,10 @@ and therefore will only work on many (but perhaps not all) Linux/Unix/Mac
 systems and not native Windows systems.
 
 
-.. _DART_TESTING_TIMEOUT:
-
-
 Setting test timeouts at configure time
 +++++++++++++++++++++++++++++++++++++++
+
+.. _DART_TESTING_TIMEOUT:
 
 A maximum default time limit (timeout) for all the tests can be set at
 configure time using the cache variable::
@@ -2145,11 +2160,11 @@ NOTES:
 * To set or override the default global test timeout limit at runtime, see
   `Overriding test timeouts`_.
 
-.. _<Project>_SCALE_TEST_TIMEOUT:
-
 
 Scaling test timeouts at configure time
 +++++++++++++++++++++++++++++++++++++++
+
+.. _<Project>_SCALE_TEST_TIMEOUT:
 
 The global default test timeout `DART_TESTING_TIMEOUT`_ as well as all of the
 timeouts for the individual tests that have their own timeout set (through the
@@ -2428,6 +2443,7 @@ NOTE: The set of extra repositories listed in the file
 ``<Project>_PRE_REPOSITORIES`` if PRE extra repos are listed and/or
 ``<Project>_EXTRA_REPOSITORIES`` if POST extra repos are listed.
 
+
 Selecting a different source location for a package
 ---------------------------------------------------
 
@@ -2525,6 +2541,7 @@ NOTES:
   really only be turned on for large projects (where the extra overhead is
   small) or for smaller projects for extra informational purposes.
 
+
 Generating export files
 -----------------------
 
@@ -2561,10 +2578,11 @@ NOTES:
 * One would only want to limit the export files generated for very large
   projects where the cost my be high for doing so.
 
-.. _<Project>_GENERATE_REPO_VERSION_FILE:
 
 Generating a project repo version file
 --------------------------------------
+
+.. _<Project>_GENERATE_REPO_VERSION_FILE:
 
 When working with local git repos for the project sources, one can generate a
 ``<Project>RepoVersion.txt`` file which lists all of the repos and their
@@ -2580,10 +2598,11 @@ NOTE: If the base ``.git/`` directory is missing, then no
 ``<Project>RepoVersion.txt`` file will get generated and a ``NOTE`` message is
 printed to cmake STDOUT.
 
-.. _<Project>_GENERATE_VERSION_DATE_FILES:
 
 Generating git version date files
 ---------------------------------
+
+.. _<Project>_GENERATE_VERSION_DATE_FILES:
 
 When working with local git repos for the project sources, one can generate
 the files ``VersionDate.cmake`` and ``<Project>_version_date.h`` in the build
@@ -2721,6 +2740,7 @@ Windows, XCode on Macs, and Eclipse project files but using those build
 systems are not documented here (consult standard CMake and concrete build
 tool documentation).
 
+
 Building all targets
 --------------------
 
@@ -2771,7 +2791,6 @@ Building all of the libraries for a package
 To build only the libraries for given TriBITS package, use::
 
   $ make <TRIBITS_PACKAGE>_libs
-
 
 
 Building all of the libraries for all enabled packages
@@ -3897,3 +3916,5 @@ original configure state.  Even with the all-at-once mode, if one kills the
 with an invalid configuration of the project.  In these cases, one may need to
 configure from scratch to get back to the original state before calling ``make
 dashboard``.
+
+..  LocalWords:  templated instantiation Makefiles CMake

--- a/cmake/tribits/doc/developers_guide/TribitsDevelopersGuide.rst
+++ b/cmake/tribits/doc/developers_guide/TribitsDevelopersGuide.rst
@@ -6616,8 +6616,8 @@ One can also change what compilers are written into the generated
 ``<Project>Config.cmake`` and ``<Package>Config.cmake`` files for the build
 and the install trees.  By default, the compilers pointed to in these
 ``Config.cmake`` files will be ``CMAKE_<LANG>_COMPILER`` where ``<LANG>`` =
-``CXX``, ``C``, and ``Fortran``, but one can change this by setting any of the
-following::
+``CXX``, ``C``, and ``Fortran``.  But one can change this by setting any of
+the following::
 
   SET(CMAKE_CXX_COMPILER_FOR_CONFIG_FILE_BUILD_DIR <path>)
   SET(CMAKE_C_COMPILER_FOR_CONFIG_FILE_BUILD_DIR <path>)


### PR DESCRIPTION
This brings in an updated TriBITS snapshot primarily for updating the ETI default from OFF to ON.  (See https://github.com/TriBITSPub/TriBITS/pull/336).

This also brings up TriBITS updates for:

* TriBITS PR https://github.com/TriBITSPub/TriBITS/pull/324 (trilinos/Trilinos#7642)
* TriBITS commit TriBITSPub/TriBITS@8d696d0

## How was this tested?

I passed the TriBITS test suite as recorded in TriBITSPub/TriBITS@5e674ad.  Otherwise, this is one-line changes to TriBITS functionality (i.e. ETI default from 'OFF' to 'ON').  But since all of the Trilinos PRs and all of the ATDM Trilinos builds and every customer I know about all explicitly enabled ETI, this will not likely impact any important builds of Trilinos.  (This really just makes Trilinos easier to build for new Trilinos users.)
