### PR TITLE
Windows: remove obsolete winmath.h

### DIFF
--- a/packages/intrepid/src/Shared/Intrepid_BurkardtRulesDef.hpp
+++ b/packages/intrepid/src/Shared/Intrepid_BurkardtRulesDef.hpp
@@ -48,10 +48,6 @@
     \author Created by D. Kouri and D. Ridzal.
  */
 
-#ifdef _MSC_VER
-#include "winmath.h"
-#endif
-
 //# include <cstdlib>
 //# include <iomanip>
 //# include <iostream>

--- a/packages/intrepid/src/Shared/Intrepid_PointToolsDef.hpp
+++ b/packages/intrepid/src/Shared/Intrepid_PointToolsDef.hpp
@@ -45,10 +45,6 @@
     \brief  Definition file for utilities for barycentric coordinates and lattices
     \author Created by R. Kirby
 */
-#ifdef _MSC_VER
-#include "winmath.h"
-#endif
-
 
 namespace Intrepid {
 

--- a/packages/intrepid/src/Shared/Intrepid_PolylibDef.hpp
+++ b/packages/intrepid/src/Shared/Intrepid_PolylibDef.hpp
@@ -91,10 +91,6 @@
     \author Created by Spencer Sherwin, Aeronautics, Imperial College London,
             modified and redistributed by D. Ridzal.
 */
-#ifdef _MSC_VER
-#include "winmath.h"
-#endif
-
 
 namespace Intrepid {
 

--- a/packages/intrepid2/src/Shared/Intrepid2_PointToolsDef.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_PointToolsDef.hpp
@@ -48,10 +48,6 @@
 #ifndef __INTREPID2_POINTTOOLS_DEF_HPP__
 #define __INTREPID2_POINTTOOLS_DEF_HPP__
 
-#ifdef _MSC_VER
-#include "winmath.h"
-#endif
-
 
 namespace Intrepid2 {
 

--- a/packages/rythmos/test/ConvergenceTest/Rythmos_ConvergenceTestHelpers.cpp
+++ b/packages/rythmos/test/ConvergenceTest/Rythmos_ConvergenceTestHelpers.cpp
@@ -28,10 +28,6 @@
 
 #include "Rythmos_ConvergenceTestHelpers.hpp"
 #include "Thyra_VectorStdOps.hpp"
-#ifdef _MSC_VER
-#include "winmath.h"
-#endif
-
 namespace Rythmos {
 
 

--- a/packages/sacado/test/tradoptest/tradoptest_47.cpp
+++ b/packages/sacado/test/tradoptest/tradoptest_47.cpp
@@ -9,10 +9,6 @@
 
 
 #include "Sacado_trad.hpp"
-#ifdef _MSC_VER
-#include "winmath.h"
-#endif
-
 #include <cstdio>
 
 using std::printf;


### PR DESCRIPTION
This TriBITS-distributed file seems to have been necessary at some point in the distant past for successful Windows builds, but it now causes build errors:
```
    D:\nfr\scale\TriBITS\tribits\win_interface\include\winmath.h(155): error: function "tgammal" has alread

      inline long double tgammal(long double z){
```

Without the winmath includes, Intrepid successfully builds on VS2015 (with an older Trilinos version) and VS2017.

@bartlettroscoe 

## Motivation

Building on Windows with newer versions of Visual Studio.
