### PR TITLE
zoltan: 1400 download page is being retired

### DIFF
--- a/packages/zoltan/doc/Zoltan_html/Zoltan.html
+++ b/packages/zoltan/doc/Zoltan_html/Zoltan.html
@@ -200,7 +200,7 @@ and Presentations</a></font></b></td>
 <td VALIGN=TOP WIDTH="150"><!----------- 5th little turquoise bevel button ------------>
 <table BORDER=0 CELLSPACING=0 CELLPADDING=0 WIDTH="150" BGCOLOR="#00CCFF" >
 <tr ALIGN=CENTER VALIGN=CENTER>
-<td COLSPAN="2"><b><font face="Verdana, Arial, Helvetica"><a href="http://cs.sandia.gov/~web1400/1400_download.html">Download
+<td COLSPAN="2"><b><font face="Verdana, Arial, Helvetica"><a href="https://github.com/sandialabs/Zoltan">Download
 Zoltan</a></font></b></td>
 </tr>
 </table>
@@ -739,7 +739,7 @@ of new functionality and more.
 <li>
 <a href="ug_html/ug_backward.html">Backward Compatibility</a>
 <li>
-<a href="http://cs.sandia.gov/~web1400/1400_download.html">Download Now!</a>
+<a href="https://github.com/sandialabs/Zoltan">Download Now!</a>
 </ul>
 
 

--- a/packages/zoltan/doc/Zoltan_html/Zoltan_FAQ.html
+++ b/packages/zoltan/doc/Zoltan_html/Zoltan_FAQ.html
@@ -217,7 +217,7 @@ and Presentations</a></font></b></td>
 <td VALIGN=TOP WIDTH="150"><!----------- 5th little turquoise bevel button ------------>
 <table BORDER=0 CELLSPACING=0 CELLPADDING=0 WIDTH="150" BGCOLOR="#00CCFF" >
 <tr ALIGN=CENTER VALIGN=CENTER>
-<td COLSPAN="2"><b><font face="Verdana, Arial, Helvetica"><a href="http://cs.sandia.gov/~web1400/1400_download.html">Download
+<td COLSPAN="2"><b><font face="Verdana, Arial, Helvetica"><a href="https://github.com/sandialabs/Zoltan">Download
 Zoltan</a></font></b></td>
 </tr>
 </table>

--- a/packages/zoltan/doc/Zoltan_html/Zoltan_bugreport.html
+++ b/packages/zoltan/doc/Zoltan_html/Zoltan_bugreport.html
@@ -218,7 +218,7 @@ and Presentations</a></font></b></td>
 <td VALIGN=TOP WIDTH="150"><!----------- 5th little turquoise bevel button ------------>
 <table BORDER=0 CELLSPACING=0 CELLPADDING=0 WIDTH="150" BGCOLOR="#00CCFF" >
 <tr ALIGN=CENTER VALIGN=CENTER>
-<td COLSPAN="2"><b><font face="Verdana, Arial, Helvetica"><a href="http://cs.sandia.gov/~web1400/1400_download.html">Download
+<td COLSPAN="2"><b><font face="Verdana, Arial, Helvetica"><a href="https://github.com/sandialabs/Zoltan">Download
 Zoltan</a></font></b></td>
 </tr>
 </table>

--- a/packages/zoltan/doc/Zoltan_html/Zoltan_cite.html
+++ b/packages/zoltan/doc/Zoltan_html/Zoltan_cite.html
@@ -218,7 +218,7 @@ and Presentations</a></font></b></td>
 <td VALIGN=TOP WIDTH="150"><!----------- 5th little turquoise bevel button ------------>
 <table BORDER=0 CELLSPACING=0 CELLPADDING=0 WIDTH="150" BGCOLOR="#00CCFF" >
 <tr ALIGN=CENTER VALIGN=CENTER>
-<td COLSPAN="2"><b><font face="Verdana, Arial, Helvetica"><a href="http://cs.sandia.gov/~web1400/1400_download.html">Download
+<td COLSPAN="2"><b><font face="Verdana, Arial, Helvetica"><a href="https://github.com/sandialabs/Zoltan">Download
 Zoltan</a></font></b></td>
 </tr>
 </table>

--- a/packages/zoltan/doc/Zoltan_html/Zoltan_phil.html
+++ b/packages/zoltan/doc/Zoltan_html/Zoltan_phil.html
@@ -218,7 +218,7 @@ and Presentations</a></font></b></td>
 <td VALIGN=TOP WIDTH="150"><!----------- 5th little turquoise bevel button ------------>
 <table BORDER=0 CELLSPACING=0 CELLPADDING=0 WIDTH="150" BGCOLOR="#00CCFF" >
 <tr ALIGN=CENTER VALIGN=CENTER>
-<td COLSPAN="2"><b><font face="Verdana, Arial, Helvetica"><a href="http://cs.sandia.gov/~web1400/1400_download.html">Download
+<td COLSPAN="2"><b><font face="Verdana, Arial, Helvetica"><a href="https://github.com/sandialabs/Zoltan">Download
 Zoltan</a></font></b></td>
 </tr>
 </table>

--- a/packages/zoltan/doc/Zoltan_html/Zoltan_pubs.html
+++ b/packages/zoltan/doc/Zoltan_html/Zoltan_pubs.html
@@ -218,7 +218,7 @@ and Presentations</a></font></b></td>
 <td VALIGN=TOP WIDTH="150"><!----------- 5th little turquoise bevel button ------------>
 <table BORDER=0 CELLSPACING=0 CELLPADDING=0 WIDTH="150" BGCOLOR="#00CCFF" >
 <tr ALIGN=CENTER VALIGN=CENTER>
-<td COLSPAN="2"><b><font face="Verdana, Arial, Helvetica"><a href="http://cs.sandia.gov/~web1400/1400_download.html">Download
+<td COLSPAN="2"><b><font face="Verdana, Arial, Helvetica"><a href="https://github.com/sandialabs/Zoltan">Download
 Zoltan</a></font></b></td>
 </tr>
 </table>

--- a/packages/zoltan/doc/Zoltan_html/dev_html/dev.html
+++ b/packages/zoltan/doc/Zoltan_html/dev_html/dev.html
@@ -218,7 +218,7 @@ and Presentations</a></font></b></td>
 <td VALIGN=TOP WIDTH="150"><!----------- 5th little turquoise bevel button ------------>
 <table BORDER=0 CELLSPACING=0 CELLPADDING=0 WIDTH="150" BGCOLOR="#00CCFF" >
 <tr ALIGN=CENTER VALIGN=CENTER>
-<td COLSPAN="2"><b><font face="Verdana, Arial, Helvetica"><a href="http://cs.sandia.gov/~web1400/1400_download.html">Download
+<td COLSPAN="2"><b><font face="Verdana, Arial, Helvetica"><a href="https://github.com/sandialabs/Zoltan">Download
 Zoltan</a></font></b></td>
 </tr>
 </table>

--- a/packages/zoltan/doc/Zoltan_html/ug_html/ug.html
+++ b/packages/zoltan/doc/Zoltan_html/ug_html/ug.html
@@ -219,7 +219,7 @@ and Presentations</a></font></b></td>
 <td VALIGN=TOP WIDTH="150"><!----------- 5th little turquoise bevel button ------------>
 <table BORDER=0 CELLSPACING=0 CELLPADDING=0 WIDTH="150" BGCOLOR="#00CCFF" >
 <tr ALIGN=CENTER VALIGN=CENTER>
-<td COLSPAN="2"><b><font face="Verdana, Arial, Helvetica"><a href="http://cs.sandia.gov/~web1400/1400_download.html">Download
+<td COLSPAN="2"><b><font face="Verdana, Arial, Helvetica"><a href="https://github.com/sandialabs/Zoltan">Download
 Zoltan</a></font></b></td>
 </tr>
 </table>


### PR DESCRIPTION
The classic 1400 download page is being retired.  The Zoltan stand-alone downloads have moved to SNL's github space.
This PR updates the links on Zoltan's webpages.
@trilinos/zoltan 

