### PR TITLE
zoltan2:  fix edge cnt overflow in GraphModel

### DIFF
--- a/packages/zoltan2/core/src/models/Zoltan2_GraphModel.hpp
+++ b/packages/zoltan2/core/src/models/Zoltan2_GraphModel.hpp
@@ -640,7 +640,7 @@ void GraphModel<Adapter>::shared_constructor(
 
     // Loop over edges; keep only those that are local (i.e., on-rank)
     eOffsets_[0] = 0;
-    lno_t ecnt = 0;
+    offset_t ecnt = 0;
     for (size_t i = 0; i < nLocalVertices_; i++) {
       vGids_[i] = gno_t(i);
       for (offset_t j = adapterEOffsets[i]; j < adapterEOffsets[i+1]; j++) {
@@ -765,7 +765,7 @@ void GraphModel<Adapter>::shared_constructor(
     }
 
     // Renumber and/or filter the edges and vertices
-    lno_t ecnt = 0;
+    offset_t ecnt = 0;
     int me = comm_->getRank();
     for (size_t i = 0; i < nLocalVertices_; i++) {
 


### PR DESCRIPTION
@ibogle detected an overflow in the edge counter in GraphModel.
ecnt type should be offset_t instead of lno_t.

@trilinos/zoltan2 


## Motivation

We want to work with large irregular graphs.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Tested on cee-lan

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->