### PR TITLE
Panzer STK: Add functionality and tests for querying the underlying PerceptMesh

### DIFF
--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_ExodusReaderFactory.hpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_ExodusReaderFactory.hpp
@@ -142,6 +142,12 @@ private:
   //! Did the user request mesh scaling
   bool userMeshScaling_;
 
+  //! Did the user request to keep the Percept data
+  bool keepPerceptData_;
+
+  //! Did the user request to keep the Percept parent element data
+  bool keepPerceptParentElements_;
+
   //! If requested, scale the input mesh by this factor
   double meshScaleFactor_;
 

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.cpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.cpp
@@ -1986,12 +1986,10 @@ void STK_Interface::refineMesh(const int numberOfLevels, const bool deleteParent
   refinedMesh_->setCoordinatesField();
 
   percept::UniformRefiner breaker(*refinedMesh_,*breakPattern_);
+  breaker.setRemoveOldElements(deleteParentElements);
 
   for (int i=0; i < numberOfLevels; ++i)
     breaker.doBreak();
-
-  if (deleteParentElements)
-    breaker.deleteParentElements();
 
 #else
   TEUCHOS_TEST_FOR_EXCEPTION(true,std::logic_error,

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.hpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.hpp
@@ -591,6 +591,12 @@ public:
    Teuchos::RCP<stk::mesh::BulkData> getBulkData() const { return bulkData_; }
    Teuchos::RCP<stk::mesh::MetaData> getMetaData() const { return metaData_; }
 
+#ifdef PANZER_HAVE_PERCEPT
+  //! Get the uniformly refined PerceptMesh object. 
+  Teuchos::RCP<percept::PerceptMesh> getRefinedMesh() const
+  { TEUCHOS_ASSERT(Teuchos::nonnull(refinedMesh_)); return refinedMesh_; }
+#endif
+
    bool isWritable() const;
 
    bool isModifiable() const


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/panzer 
@rppawlo 

## Motivation
Querying mesh family tree information from the underlying uniformly refined PerceptMesh object will allow for more advanced solving and preconditioning strategies, such as the region multigrid approach.
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Testing
It builds and 125/125 tests pass on my workstation.
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

## Additional Information
Ideally the `keepPerceptData` test would also check that the "Keep Percept Parent Elements" flag is working properly. Currently the lines (L358 and L382 in tPamgenMeshFactory.cpp) are commented out because I wasn't able to find a nice and simple command to do so. Perhaps @bricar could provide a suggestion?