### PR TITLE
Panzer: speed up cuda builds of IntegrationValues and PointValues

### DIFF
--- a/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.cpp
@@ -1253,6 +1253,11 @@ evaluateValuesCV(const PHX::MDField<Scalar, Cell, NODE, Dim>& in_node_coordinate
     template class IntegrationValues2<SCALAR>;
 
 INTEGRATION_VALUES2_INSTANTIATION(panzer::Traits::RealType)
-INTEGRATION_VALUES2_INSTANTIATION(panzer::Traits::FadType)
+
+// Disabled FAD support due to long build times on cuda (in debug mode
+// it takes multiple hours on some platforms). If we need
+// sensitivities wrt coordinates, we can reenable.
+
+// INTEGRATION_VALUES2_INSTANTIATION(panzer::Traits::FadType)
 
 }

--- a/packages/panzer/disc-fe/src/Panzer_PointValues2.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_PointValues2.cpp
@@ -68,15 +68,21 @@ template void PointValues2<SCALAR>::copyPointCoords<Kokkos::DynRankView<SCALAR2,
 template void PointValues2<double>::copyPointCoords<Kokkos::DynRankView<double> >(const Kokkos::DynRankView<double> & in_node_coords);
 
 POINT_VALUES_INSTANTIATION(panzer::Traits::RealType)
-POINT_VALUES_INSTANTIATION(panzer::Traits::FadType)
+// Disabled FAD support due to long build times on cuda (in debug mode
+// it takes multiple hours on some platforms). If we need
+// sensitivities wrt coordinates, we can reenable.
+// POINT_VALUES_INSTANTIATION(panzer::Traits::FadType)
 #ifdef Panzer_BUILD_HESSIAN_SUPPORT
 POINT_VALUES_INSTANTIATION(panzer::Traits::HessianType)
 #endif
 
 // This is very complicated for reasons I don't fully understand...
 POINT_VALUES_INSTANTIATION2(panzer::Traits::RealType,panzer::Traits::RealType)
-POINT_VALUES_INSTANTIATION2(panzer::Traits::FadType,panzer::Traits::RealType)
-POINT_VALUES_INSTANTIATION2(panzer::Traits::FadType,panzer::Traits::FadType)
+// Disabled FAD support due to long build times on cuda (in debug mode
+// it takes multiple hours on some platforms). If we need
+// sensitivities wrt coordinates, we can reenable.
+// POINT_VALUES_INSTANTIATION2(panzer::Traits::FadType,panzer::Traits::RealType)
+// POINT_VALUES_INSTANTIATION2(panzer::Traits::FadType,panzer::Traits::FadType)
 #ifdef Panzer_BUILD_HESSIAN_SUPPORT
 POINT_VALUES_INSTANTIATION2(panzer::Traits::HessianType,panzer::Traits::RealType)
 #endif


### PR DESCRIPTION
## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
In debug builds, IntegrationValues2 and PointValues2 object files were taking multiple hours to compile. 

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->
Fixes #7532


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
All regression tests use integration and (optionally) point values. PointValues has its own unit test as well.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->