### PR TITLE
Tpetra:  add getEntriesOnHost

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_getEntryOnHost.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_getEntryOnHost.hpp
@@ -67,6 +67,19 @@ getEntryOnHost (const ViewType& x,
   return val;
 }
 
+template<class ViewType,
+         class IndexType>
+typename ViewType::HostMirror::const_type
+getEntriesOnHost (const ViewType& x,
+                  const IndexType ind,
+                  const int count)
+{
+  static_assert (ViewType::Rank == 1, "x must be a rank-1 Kokkos::View.");
+  // Get a 1-D subview of the entry of the array, and copy to host.
+  auto subview = Kokkos::subview(x, Kokkos::make_pair(ind, ind + count));
+  return Kokkos::create_mirror_view_and_copy(typename ViewType::HostMirror::memory_space(), subview);
+}
+
 } // namespace Details
 } // namespace Tpetra
 


### PR DESCRIPTION
@trilinos/tpetra 

## Motivation
Similar to existing `getEntryOnHost`, but allows us to bring up more than one value at a time for efficiency in cases when we know for sure we need multiple consecutive values from a device view.

## Testing
Added two new unit tests for the new function `getEntriesOnHost`.  Also refactored the existing test for `getEntryOnHost` for clarity.