### PR TITLE
Framework: Add GitHub Actions script to close stale issues and PR's

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,9 +4,6 @@
 #
 name: "Close stale issues"
 on:
-  # For debugging: toggle action by starring/unstarring the repo
-  watch:
-    types: [started]
   # Regular scheduling, run daily at 6AM Mountain time (12:00pm UTC)
   # - Note: Mountain Standard Time (MST) is 7 hours behind UTC during the winter.
   # Cron strings: MIN HR DOM MON DOW

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,69 @@
+#
+# This workflow will process issues and PR's to determine if they are stale and/or need to be
+# removed.
+#
+name: "Close stale issues"
+on:
+  # For debugging: toggle action by starring/unstarring the repo
+  watch:
+    types: [started]
+  # Regular scheduling, run daily at 6AM Mountain time (12:00pm UTC)
+  # - Note: Mountain Standard Time (MST) is 7 hours behind UTC during the winter.
+  # Cron strings: MIN HR DOM MON DOW
+  schedule:
+  - cron: "0 12 * * *"
+
+
+# See https://github.com/actions/stale/blob/master/action.yml for information on actions
+# that GitHub knows for stale issues.
+
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v3.0.14
+      with:
+        debug-only: true
+        ascending: true
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        days-before-stale: 365
+        days-before-close: 30
+        stale-issue-label: 'MARKED_FOR_CLOSURE'
+        stale-pr-label: 'MARKED_FOR_CLOSURE'
+        close-pr-label: 'CLOSED_DUE_TO_INACTIVITY'
+        exempt-issue-labels: 'DO_NOT_AUTOCLOSE'
+        # We specifically DO NOT exempt PR's from autoclosing.
+        #exempt-pr-labels: ''
+        remove-stale-when-updated: true
+        operations-per-run: 30
+        stale-issue-message: >
+          This issue has had no activity for **365** days and is marked for
+          closure. It will be closed after an additional **30** days of inactivity.
+
+          If you would like to keep this issue open please add a comment and remove
+          the `MARKED_FOR_CLOSURE` label.
+
+          If this issue should be kept open even with no activity beyond the time
+          limits you can add the label `DO_NOT_AUTOCLOSE`.
+
+        close-issue-message: >
+          This issue was closed due to inactivity for **395** days.
+
+        stale-pr-message: >
+          This Pull Request has been *marked for closure* due to inactivity.
+
+          Because of the changing nature of the Trilinos source due to active
+          development, a pull request with _no_ activity for **365** days is
+          considered to be abandoned and will be automatically closed after **30**
+          additional days of inactivity from when it was marked inactive.
+
+          If this should be kept open, please post a comment and remove the
+          label `MARKED_FOR_CLOSURE` to reset the inactivity timer.
+
+        close-pr-message: >
+          This Pull Request has been automatically closed due to **395** days of inactivity.
+
+
+
+


### PR DESCRIPTION
@trilinos/framework 

## Motivation
See #8306 for more information about this work.

This PR pulls in the initial github runner script that will mark issues and PR's as stale after 365 days of inactivity and then close them after another 30 days from being marked for closure.

## Testing
I've been testing this out in a test repository at https://github.com/william76/workflowTest/


## Additional Information
This is in **debug mode** (`debug-only: true`) currently so it should not actually affect any issues or PR's. We should get this in place so we can watch what it does in our repository before we enable it.
