### PR TITLE
MueLu: Reduce the size of an elasticity test to speedup the testsuite

### DIFF
--- a/packages/muelu/research/regionMG/test/structured/CMakeLists.txt
+++ b/packages/muelu/research/regionMG/test/structured/CMakeLists.txt
@@ -220,7 +220,7 @@ IF (${PACKAGE_NAME}_ENABLE_Tpetra AND ${PACKAGE_NAME}_ENABLE_Amesos2)
   TRIBITS_ADD_TEST(
     StructuredRegionDriver
     NAME "Structured_Region_Linear_R_Elasticity3D_Tpetra"
-    ARGS "--linAlgebra=Tpetra --xml=structured_linear_R_3dof.xml --matrixType=Elasticity3D --nx=19 --ny=19 --nz=19 --smootherIts=2 --convergence-log=Elasticity3D_linear_R_4.log"
+    ARGS "--linAlgebra=Tpetra --xml=structured_linear_R_3dof.xml --matrixType=Elasticity3D --nx=19 --ny=19 --nz=10 --smootherIts=2 --convergence-log=Elasticity3D_linear_R_4.log"
     COMM mpi
     NUM_MPI_PROCS 4
     )


### PR DESCRIPTION
@trilinos/muelu 
@pohm01 

## Motivation
This cuts the time down for `MueLu_Structured_Region_Linear_R_Elasticity3D_Tpetra_MPI_4` in a debug build from 48 seconds to 15 seconds.

## Related Issues
* Part of #8374 

## Testing
I ran `ctest -R "Structured_Region_Linear_R_Elasticity3D_Tpetra"` to confirm that it speeds this test up.