### PR TITLE
Framework: Setting CMake specification to 3.10.3 for PR builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,3 +105,5 @@ ENDIF()
 IF(${PROJECT_NAME}_ENABLE_YouCompleteMe)
   INCLUDE(CodeCompletion)
 ENDIF()
+
+# a simple text change to trigger testing. DO NOT MERGE!

--- a/cmake/std/pr_config/pullrequest.ini
+++ b/cmake/std/pr_config/pullrequest.ini
@@ -244,7 +244,7 @@ module-load sems-hdf5: 1.10.6/base
 module-load sems-netcdf: 4.7.3/base
 module-load sems-metis: 5.1.0/base
 module-load sems-superlu: 4.3/base
-module-load sems-cmake: 3.12.2
+module-load sems-cmake: 3.10.3
 use ATDM-ENV:
 module-load atdm-ninja_fortran: 1.7.2
 setenv OMP_NUM_THREADS: 2
@@ -260,10 +260,10 @@ use SEMS-DEFAULT:
 use ATDM-DEFAULT:
 module-remove sems-boost:
 module-load sems-boost: 1.66.0/base
-module-remove sems-cmake:
 # The GCC 3.8.2 build appears to have an issue that fails with cmake/3.10.3
-# - Trying 3.12.2 and if that fails we'll try 3.17.1
-module-load sems-cmake: 3.12.2
+# - It works with 3.12.2 though.
+#module-remove sems-cmake:
+#module-load sems-cmake: 3.12.2
 
 
 
@@ -326,7 +326,8 @@ module-load sems-netcdf: 4.7.3/parallel
 module-load sems-parmetis: 4.0.3/parallel
 module-load sems-scotch: 6.0.3/nopthread_64bit_parallel
 module-load sems-superlu: 4.3/base
-module-load sems-cmake: 3.17.1
+#module-load sems-cmake: 3.17.1
+module-load sems-cmake: 3.10.3
 module-load sems-ninja_fortran: 1.10.0
 setenv OMP_NUM_THREADS: 2
 
@@ -350,24 +351,6 @@ unsetenv PATH_TMP:
 use Trilinos_pullrequest_gcc_8.3.0:
 
 
-# TODO: Remove this whole section once we've removed
-#       Python2 test execution
-#[Trilinos_pullrequest_python_2]
-#use SEMS-ENV:
-#use ATDM-ENV:
-#module-load sems-gcc: 7.2.0
-#use ATDM-DEFAULT:
-#module-load sems-git: 2.10.1
-#module-load sems-cmake: 3.10.3
-#module-unload sems-python:
-#setenv PYTHONPATH: /projects/sierra/linux_rh7/install/Python/extras/lib/python2.7/site-packages
-#setenv MANPATH:    /projects/sierra/linux_rh7/install/Python/2.7.15/share/man
-#setenv PATH_TMP:   /projects/sierra/linux_rh7/install/Python/extras/bin:${PATH}
-#setenv PATH:       /projects/sierra/linux_rh7/install/Python/2.7.15/share/bin:${PATH_TMP}
-#unsetenv PATH_TMP:
-
-
-
 [Trilinos_pullrequest_python_3]
 use SEMS-ENV:
 use ATDM-ENV:
@@ -376,15 +359,5 @@ use ATDM-DEFAULT:
 module-load sems-git: 2.10.1
 module-load sems-cmake: 3.10.3
 use SIERRA-PYTHON-3.6.3:
-##module-unload sems-python:
-###setenv PYTHONPATH: "/projects/sierra/linux_rh7/install/Python/extras/lib/python/3.6/site-packages"
-##setenv MANPATH:    "/projects/sierra/linux_rh7/install/Python/3.6.3/share/man"
-##setenv PATH_TMP:   "/projects/sierra/linux_rh7/install/Python/extras/bin:${PATH}"
-##setenv PATH:       "/projects/sierra/linux_rh7/install/Python/3.6.3/share/bin:${PATH_TMP}"
-##unsetenv PATH_TMP:
-#module-remove sems-python:
-#module-load sems-python: 3.5.2
-#setenv PYTHONPATH: "${SEMS_PYTHON_LIBRARY_PATH}/python3.5/site-packages"
-#setenv MANPATH:    "${SEMS_PYTHON_LIBRARY_PATH}/../share/man"
 
 

--- a/packages/panzer/core/src/Panzer_Version.hpp
+++ b/packages/panzer/core/src/Panzer_Version.hpp
@@ -52,3 +52,4 @@ namespace panzer {
 
 }
 #endif
+

--- a/packages/tempus/src/Tempus_Version.cpp
+++ b/packages/tempus/src/Tempus_Version.cpp
@@ -9,9 +9,10 @@
 #include "Tempus_Version.hpp"
 
 namespace Tempus {
-  
-  std::string version() { 
-    return("Tempus Version: development"); 
+
+  std::string version() {
+    return("Tempus Version: development");
   }
 
 }
+


### PR DESCRIPTION
@trilinos/framework 

## Motivation
We have some PR builds that seem to fail if we use CMake 3.10.x, which violates the assertion in the top-level CMakeLists.txt file that the minimum required CMake is a 3.10.x variant.

The intent of this PR is to set the specifications in our builds to use CMake 3.10.3 (SEMS) and to trigger some builds so that we can see the errors and discuss them in issue #8387 

## Related Issues
* Part of #8387 

## Additional Information
This PR shouldn't be merged, once I get a test set I'll close it out and we can link to it from the issue as needed.