### PR TITLE
Sacado:  A few fixes for converting SPARC to use the Sacado View spec.

### DIFF
--- a/packages/sacado/src/KokkosExp_View_Fad.hpp
+++ b/packages/sacado/src/KokkosExp_View_Fad.hpp
@@ -521,29 +521,30 @@ create_mirror( const Kokkos::View<T,P...> & src
              )
 {
   typedef View<T,P...>                   src_type ;
+  typedef typename src_type::array_type  src_array_type ;
   typedef typename src_type::HostMirror  dst_type ;
 
   Kokkos::LayoutStride layout ;
 
-  layout.dimension[0] = src.extent(0);
-  layout.dimension[1] = src.extent(1);
-  layout.dimension[2] = src.extent(2);
-  layout.dimension[3] = src.extent(3);
-  layout.dimension[4] = src.extent(4);
-  layout.dimension[5] = src.extent(5);
-  layout.dimension[6] = src.extent(6);
-  layout.dimension[7] = src.extent(7);
+  // Use dimensions/strides from array_type to get hidden dim/stride
+  src_array_type src_array = src;
+  layout.dimension[0] = src_array.extent(0);
+  layout.dimension[1] = src_array.extent(1);
+  layout.dimension[2] = src_array.extent(2);
+  layout.dimension[3] = src_array.extent(3);
+  layout.dimension[4] = src_array.extent(4);
+  layout.dimension[5] = src_array.extent(5);
+  layout.dimension[6] = src_array.extent(6);
+  layout.dimension[7] = src_array.extent(7);
 
-  layout.stride[0] = src.stride_0();
-  layout.stride[1] = src.stride_1();
-  layout.stride[2] = src.stride_2();
-  layout.stride[3] = src.stride_3();
-  layout.stride[4] = src.stride_4();
-  layout.stride[5] = src.stride_5();
-  layout.stride[6] = src.stride_6();
-  layout.stride[7] = src.stride_7();
-
-  layout.dimension[src_type::rank] = Kokkos::dimension_scalar(src);
+  layout.stride[0] = src_array.stride_0();
+  layout.stride[1] = src_array.stride_1();
+  layout.stride[2] = src_array.stride_2();
+  layout.stride[3] = src_array.stride_3();
+  layout.stride[4] = src_array.stride_4();
+  layout.stride[5] = src_array.stride_5();
+  layout.stride[6] = src_array.stride_6();
+  layout.stride[7] = src_array.stride_7();
 
   return dst_type(std::string(src.label()).append("_mirror"), layout);
 }
@@ -1505,10 +1506,10 @@ public:
         "View assignment must have compatible layout" );
 
       static_assert(
-        std::is_same< typename DstTraits::scalar_array_type
-                    , typename SrcTraits::scalar_array_type >::value ||
-        std::is_same< typename DstTraits::scalar_array_type
-                    , typename SrcTraits::const_scalar_array_type >::value ,
+        std::is_same< typename DstTraits::value_type
+                    , typename SrcTraits::value_type >::value ||
+        std::is_same< typename DstTraits::value_type
+                    , typename SrcTraits::const_value_type >::value ,
         "View assignment must have same value type or const = non-const" );
 
       static_assert(

--- a/packages/sacado/src/KokkosExp_View_Fad_Contiguous.hpp
+++ b/packages/sacado/src/KokkosExp_View_Fad_Contiguous.hpp
@@ -1206,10 +1206,10 @@ public:
         "View assignment must have compatible layout" );
 
       static_assert(
-        std::is_same< typename DstTraits::scalar_array_type
-                    , typename SrcTraits::scalar_array_type >::value ||
-        std::is_same< typename DstTraits::scalar_array_type
-                    , typename SrcTraits::const_scalar_array_type >::value ,
+        std::is_same< typename DstTraits::value_type
+                    , typename SrcTraits::value_type >::value ||
+        std::is_same< typename DstTraits::value_type
+                    , typename SrcTraits::const_value_type >::value ,
         "View assignment must have same value type or const = non-const" );
 
       static_assert(

--- a/packages/sacado/src/new_design/Sacado_Fad_Exp_StaticFixedStorage.hpp
+++ b/packages/sacado/src/new_design/Sacado_Fad_Exp_StaticFixedStorage.hpp
@@ -239,11 +239,11 @@ namespace Sacado {
 
     protected:
 
-      //! Value
-      T val_;
-
       //! Derivative array
       T dx_[Num];
+
+      //! Value
+      T val_;
 
     }; // class StaticFixedStorage
 


### PR DESCRIPTION
* Allow assignments of the form `View<Fad**> = View<Fad*[n]>`
* Fix `create_mirror()` for `LayoutStride`
* Order value after derivative array in new design SFad (as it was in
  the old design) to be consistent with ordering in `View<Fad*>` and allow
  reinterpret cast of `View<SFad<double,N>*>::data()` to `SFad<double,N>*`.