### PR TITLE
First set of changes to facilitate adoption of ATDM Trilinos configuration into SPARC TPL installer (ATDV-408)

### DIFF
--- a/cmake/std/atdm/apps/sparc/SPARCMiniTrilinosPackagesList.cmake
+++ b/cmake/std/atdm/apps/sparc/SPARCMiniTrilinosPackagesList.cmake
@@ -8,4 +8,7 @@ SET(SPARC_MiniTrilinos_Package_Disables
 SET(SPARC_MiniTrilinos_TPL_Disables
   METIS
   ParMETIS
+  SuperLUDist
+  Boost
+  BoostLib
   )

--- a/cmake/std/atdm/cee-rhel6/environment.sh
+++ b/cmake/std/atdm/cee-rhel6/environment.sh
@@ -48,7 +48,11 @@ fi
 export ATDM_CONFIG_BUILD_COUNT=$ATDM_CONFIG_MAX_NUM_CORES_TO_USE
 # NOTE: Use as many build processes and there are cores by default.
 
-module purge
+if [[ "${ATDM_CONFIG_DONT_LOAD_SPARC_MODULES_PLEASE}" != "1" ]] ; then
+  module purge
+else
+  echo "NOTE: ATDM_CONFIG_DONT_LOAD_SPARC_MODULES_PLEASE=1 is set so using pre-loaded sparc-dev module!"
+fi
 
 # Warning options requested by Gemma team (which should hopefully also take
 # care of warnings required by the other ATDM APPs as well).  See #3178 and
@@ -62,7 +66,9 @@ if [[ "${ATDM_CONFIG_ENABLE_STRONG_WARNINGS}" == "" ]] ; then
 fi
 
 if  [[ "$ATDM_CONFIG_COMPILER" == "CLANG-9.0.1_OPENMPI-4.0.3" ]]; then
-  module load sparc-dev/clang-9.0.1_openmpi-4.0.3
+  if [[ "${ATDM_CONFIG_DONT_LOAD_SPARC_MODULES_PLEASE}" != "1" ]] ; then
+    module load sparc-dev/clang-9.0.1_openmpi-4.0.3
+  fi
   export OMPI_CXX=`which clang++`
   export OMPI_CC=`which clang`
   export OMPI_FC=`which gfortran`
@@ -75,7 +81,9 @@ if  [[ "$ATDM_CONFIG_COMPILER" == "CLANG-9.0.1_OPENMPI-4.0.3" ]]; then
   export ATDM_CONFIG_MKL_ROOT=${CBLAS_ROOT}
 
 elif [[ "$ATDM_CONFIG_COMPILER" == "GNU-7.2.0_OPENMPI-4.0.3" ]] ; then
-  module load sparc-dev/gcc-7.2.0_openmpi-4.0.3
+  if [[ "${ATDM_CONFIG_DONT_LOAD_SPARC_MODULES_PLEASE}" != "1" ]] ; then
+    module load sparc-dev/gcc-7.2.0_openmpi-4.0.3
+  fi
   unset OMP_NUM_THREADS  # SPARC module sets these and we must unset!
   unset OMP_PROC_BIND
   unset OMP_PLACES
@@ -94,7 +102,9 @@ elif [[ "$ATDM_CONFIG_COMPILER" == "GNU-7.2.0_OPENMPI-4.0.3" ]] ; then
   export ATDM_CONFIG_MPI_PRE_FLAGS="--bind-to;none"
 
 elif [ "$ATDM_CONFIG_COMPILER" == "INTEL-19.0.3_INTELMPI-2018.4" ]; then
-  module load sparc-dev/intel-19.0.3_intelmpi-2018.4
+  if [[ "${ATDM_CONFIG_DONT_LOAD_SPARC_MODULES_PLEASE}" != "1" ]] ; then
+    module load sparc-dev/intel-19.0.3_intelmpi-2018.4
+  fi
   export OMPI_CXX=`which icpc`
   export OMPI_CC=`which icc`
   export OMPI_FC=`which ifort`
@@ -112,7 +122,9 @@ elif [ "$ATDM_CONFIG_COMPILER" == "INTEL-19.0.3_INTELMPI-2018.4" ]; then
   export ATDM_CONFIG_OPENMP_GOMP_LIBRARY=-lgomp
 
 elif [ "$ATDM_CONFIG_COMPILER" == "INTEL-19.0.3_MPICH2-3.2" ]; then
-  module load sparc-dev/intel-19.0.3_mpich2-3.2
+  if [[ "${ATDM_CONFIG_DONT_LOAD_SPARC_MODULES_PLEASE}" != "1" ]] ; then
+    module load sparc-dev/intel-19.0.3_mpich2-3.2
+  fi
   export OMP_NUM_THREADS=3 # Because Si H. requested this
   export OMP_PROC_BIND=false
   unset OMP_PLACES
@@ -139,7 +151,9 @@ elif [ "$ATDM_CONFIG_COMPILER" == "CUDA-10.1.243_GCC-7.2.0_OPENMPI-4.0.3" ]; the
   # Using the Unix Makefiles cmake generator works.
   export ATDM_CONFIG_USE_NINJA=OFF
 
-  module load sparc-dev/cuda-10.1.243_gcc-7.2.0_openmpi-4.0.3
+  if [[ "${ATDM_CONFIG_DONT_LOAD_SPARC_MODULES_PLEASE}" != "1" ]] ; then
+    module load sparc-dev/cuda-10.1.243_gcc-7.2.0_openmpi-4.0.3
+  fi
 
   # OpenMPI Settings
   export OMPI_CXX=${ATDM_CONFIG_NVCC_WRAPPER}

--- a/cmake/std/atdm/cee-rhel6/environment.sh
+++ b/cmake/std/atdm/cee-rhel6/environment.sh
@@ -66,9 +66,7 @@ if [[ "${ATDM_CONFIG_ENABLE_STRONG_WARNINGS}" == "" ]] ; then
 fi
 
 if  [[ "$ATDM_CONFIG_COMPILER" == "CLANG-9.0.1_OPENMPI-4.0.3" ]]; then
-  if [[ "${ATDM_CONFIG_DONT_LOAD_SPARC_MODULES_PLEASE}" != "1" ]] ; then
-    module load sparc-dev/clang-9.0.1_openmpi-4.0.3
-  fi
+  atdm_config_load_sparc_dev_module sparc-dev/clang-9.0.1_openmpi-4.0.3
   export OMPI_CXX=`which clang++`
   export OMPI_CC=`which clang`
   export OMPI_FC=`which gfortran`
@@ -81,9 +79,7 @@ if  [[ "$ATDM_CONFIG_COMPILER" == "CLANG-9.0.1_OPENMPI-4.0.3" ]]; then
   export ATDM_CONFIG_MKL_ROOT=${CBLAS_ROOT}
 
 elif [[ "$ATDM_CONFIG_COMPILER" == "GNU-7.2.0_OPENMPI-4.0.3" ]] ; then
-  if [[ "${ATDM_CONFIG_DONT_LOAD_SPARC_MODULES_PLEASE}" != "1" ]] ; then
-    module load sparc-dev/gcc-7.2.0_openmpi-4.0.3
-  fi
+  atdm_config_load_sparc_dev_module sparc-dev/gcc-7.2.0_openmpi-4.0.3
   unset OMP_NUM_THREADS  # SPARC module sets these and we must unset!
   unset OMP_PROC_BIND
   unset OMP_PLACES
@@ -102,9 +98,7 @@ elif [[ "$ATDM_CONFIG_COMPILER" == "GNU-7.2.0_OPENMPI-4.0.3" ]] ; then
   export ATDM_CONFIG_MPI_PRE_FLAGS="--bind-to;none"
 
 elif [ "$ATDM_CONFIG_COMPILER" == "INTEL-19.0.3_INTELMPI-2018.4" ]; then
-  if [[ "${ATDM_CONFIG_DONT_LOAD_SPARC_MODULES_PLEASE}" != "1" ]] ; then
-    module load sparc-dev/intel-19.0.3_intelmpi-2018.4
-  fi
+  atdm_config_load_sparc_dev_module sparc-dev/intel-19.0.3_intelmpi-2018.4
   export OMPI_CXX=`which icpc`
   export OMPI_CC=`which icc`
   export OMPI_FC=`which ifort`
@@ -122,9 +116,7 @@ elif [ "$ATDM_CONFIG_COMPILER" == "INTEL-19.0.3_INTELMPI-2018.4" ]; then
   export ATDM_CONFIG_OPENMP_GOMP_LIBRARY=-lgomp
 
 elif [ "$ATDM_CONFIG_COMPILER" == "INTEL-19.0.3_MPICH2-3.2" ]; then
-  if [[ "${ATDM_CONFIG_DONT_LOAD_SPARC_MODULES_PLEASE}" != "1" ]] ; then
-    module load sparc-dev/intel-19.0.3_mpich2-3.2
-  fi
+  atdm_config_load_sparc_dev_module sparc-dev/intel-19.0.3_mpich2-3.2
   export OMP_NUM_THREADS=3 # Because Si H. requested this
   export OMP_PROC_BIND=false
   unset OMP_PLACES
@@ -151,9 +143,7 @@ elif [ "$ATDM_CONFIG_COMPILER" == "CUDA-10.1.243_GCC-7.2.0_OPENMPI-4.0.3" ]; the
   # Using the Unix Makefiles cmake generator works.
   export ATDM_CONFIG_USE_NINJA=OFF
 
-  if [[ "${ATDM_CONFIG_DONT_LOAD_SPARC_MODULES_PLEASE}" != "1" ]] ; then
-    module load sparc-dev/cuda-10.1.243_gcc-7.2.0_openmpi-4.0.3
-  fi
+  atdm_config_load_sparc_dev_module sparc-dev/cuda-10.1.243_gcc-7.2.0_openmpi-4.0.3
 
   # OpenMPI Settings
   export OMPI_CXX=${ATDM_CONFIG_NVCC_WRAPPER}

--- a/cmake/std/atdm/utils/atdm_config_helper_funcs.sh
+++ b/cmake/std/atdm/utils/atdm_config_helper_funcs.sh
@@ -63,6 +63,48 @@ function get_sparc_dev_module_name() {
 }
 
 
+# Get the full name of the currently loaded sparc-dev module
+function get_loaded_sparc_dev_module_name() {
+  module list -t 2>&1 | grep sparc-dev
+}
+
+
+# Load the given sparc-dev module or assert that it is already set
+function atdm_config_load_sparc_dev_module () {
+  sparc_dev_mod_name_in=$1 ; shift
+  if [[ "${ATDM_CONFIG_DONT_LOAD_SPARC_MODULES_PLEASE}" == "1" ]] ; then
+    loaded_sparc_dev_mod=$(get_loaded_sparc_dev_module_name)
+    if [[ "${loaded_sparc_dev_mod}" == "" ]] ; then
+      echo
+      echo "***"
+      echo "*** ERROR: ATDM_CONFIG_DONT_LOAD_SPARC_MODULES_PLEASE=1 but no sparc-dev"
+      echo "*** module is currently loaded!"
+      echo "***"
+      echo
+      return
+    elif [[ "${loaded_sparc_dev_mod}" != "${sparc_dev_mod_name_in}" ]] ; then
+      echo
+      echo "***"
+      echo "*** ERROR: ATDM_CONFIG_DONT_LOAD_SPARC_MODULES_PLEASE=1 but loaded module:"
+      echo "***"
+      echo "***   ${loaded_sparc_dev_mod}"
+      echo "***"
+      echo "*** does not equal requested module:"
+      echo "***"
+      echo "***   ${sparc_dev_mod_name_in}"
+      echo "***"
+      echo "*** !"
+      echo "***"
+      echo
+     return
+    fi
+    # If we get here, the desired sparc-dev module is already loaded!
+  else
+    module load ${sparc_dev_mod_name_in}
+  fi
+}
+
+
 # Remove the substrings from the environment variable.
 #
 # Usage:

--- a/cmake/std/atdm/utils/atdm_config_helper_funcs.sh
+++ b/cmake/std/atdm/utils/atdm_config_helper_funcs.sh
@@ -73,7 +73,7 @@ function get_loaded_sparc_dev_module_name() {
 function atdm_config_load_sparc_dev_module () {
   sparc_dev_mod_name_in=$1 ; shift
   if [[ "${ATDM_CONFIG_DONT_LOAD_SPARC_MODULES_PLEASE}" == "1" ]] ; then
-    loaded_sparc_dev_mod=$(get_loaded_sparc_dev_module_name)
+    loaded_sparc_dev_mod=${SPARC_MODULE}
     if [[ "${loaded_sparc_dev_mod}" == "" ]] ; then
       echo
       echo "***"
@@ -94,6 +94,8 @@ function atdm_config_load_sparc_dev_module () {
       echo "***   ${sparc_dev_mod_name_in}"
       echo "***"
       echo "*** !"
+      echo "***"
+      echo "*** Please 'unset ATDM_CONFIG_DONT_LOAD_SPARC_MODULES_PLEASE' and try again."
       echo "***"
       echo
      return


### PR DESCRIPTION
This is a first set of changes to the ATDM Trilinos configuration to support having the SPARC TPL installer.

The commits and the changes should be self explanatory.

The controlling story for this in [ATDV-408](https://sems-atlassian-srn.sandia.gov/browse/ATDV-408).

More PRs after this one will be created to finish out  ADV-408.

## How was this tested?

This was tested locally on the CEE RHEL7 machine 'ceerws1113' with a branch of the SPARC TPL installer and testing against SPARC locally.  For details, see  [ATDV-408](https://sems-atlassian-srn.sandia.gov/browse/ATDV-408).

ToDo: I will merge this branch into 'atdm-nightly-manual-updates' so that this will run in the ATDM Trilinos builds posting to CDash.
