### PR TITLE
Tempus: Remove ParameterList from TimeStepControlStrategies

### DIFF
--- a/packages/piro/src/Piro_TempusSolver_Def.hpp
+++ b/packages/piro/src/Piro_TempusSolver_Def.hpp
@@ -174,18 +174,15 @@ void Piro::TempusSolver<Scalar>::initialize(
       timeStepControlPL->set<Scalar>("Maximum Time Step", dt_max); 
       timeStepControlPL->set<int>("Initial Time Index", 0); 
       timeStepControlPL->set<int>("Final Time Index", 1.0e6);
-      timeStepControlPL->set<std::string>("Integrator Step Type", "Variable"); 
       RCP<Teuchos::ParameterList> timeStepControlStrategyPL = sublist(timeStepControlPL, "Time Step Control Strategy"); 
-      timeStepControlStrategyPL->set<std::string>("Time Step Control Strategy List", "basic_vs"); 
-      RCP<Teuchos::ParameterList> basic_vs_PL = sublist(timeStepControlStrategyPL, "basic_vs"); 
-      basic_vs_PL->set<std::string>("Name", "Basic VS"); 
-      basic_vs_PL->set<Scalar>("Reduction Factor", reduc_factor); 
-      basic_vs_PL->set<Scalar>("Amplification Factor", ampl_factor); 
+      timeStepControlStrategyPL->set<std::string>("Strategy Type", "Basic VS"); 
+      timeStepControlStrategyPL->set<Scalar>("Reduction Factor", reduc_factor); 
+      timeStepControlStrategyPL->set<Scalar>("Amplification Factor", ampl_factor); 
       //The following options are such that dt is reduced if solve fails,
       //and amplified if solve is successful, to be consistent with what is done in Albany
       //for quasistatics, and for Schwarz. 
-      basic_vs_PL->set<Scalar>("Minimum Value Monitoring Function", 1.0e20); 
-      basic_vs_PL->set<Scalar>("Maximum Value Monitoring Function", 1.0e20); 
+      timeStepControlStrategyPL->set<Scalar>("Minimum Value Monitoring Function", 1.0e20); 
+      timeStepControlStrategyPL->set<Scalar>("Maximum Value Monitoring Function", 1.0e20); 
     }
     else { 
       *out_ << "\n    Using Tempus 'Time Step Control'.\n";

--- a/packages/piro/test/_input_Tempus_BackwardEuler_SinCos.xml
+++ b/packages/piro/test/_input_Tempus_BackwardEuler_SinCos.xml
@@ -31,7 +31,6 @@
         <Parameter name="Maximum Time Step"      type="double" value="0.1"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
-        <Parameter name="Integrator Step Type"  type="string" value="Constant"/>
         <Parameter name="Output Time List"       type="string" value=""/>
         <Parameter name="Output Index List"      type="string" value=""/>
         <Parameter name="Output Time Interval"   type="double" value="10.0"/>

--- a/packages/rol/example/tempus/example_01.xml
+++ b/packages/rol/example/tempus/example_01.xml
@@ -21,7 +21,6 @@
         <Parameter name="Maximum Time Step"      type="double" value="0.1"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
-        <Parameter name="Integrator Step Type"   type="string" value="Constant"/>
         <Parameter name="Output Time List"       type="string" value=""/>
         <Parameter name="Output Index List"      type="string" value=""/>
         <Parameter name="Output Time Interval"   type="double" value="10.0"/>

--- a/packages/rol/example/tempus/example_parabolic.xml
+++ b/packages/rol/example/tempus/example_parabolic.xml
@@ -53,7 +53,6 @@
         <Parameter name="Maximum Time Step"      type="double" value="0.1"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
-        <Parameter name="Integrator Step Type"  type="string" value="Constant"/>
         <Parameter name="Output Time List"       type="string" value=""/>
         <Parameter name="Output Index List"      type="string" value=""/>
         <Parameter name="Output Time Interval"   type="double" value="10.0"/>

--- a/packages/rol/example/tempus/example_sincos.xml
+++ b/packages/rol/example/tempus/example_sincos.xml
@@ -40,7 +40,6 @@
         <Parameter name="Maximum Time Step"      type="double" value="0.1"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
-        <Parameter name="Integrator Step Type"  type="string" value="Constant"/>
         <Parameter name="Output Time List"       type="string" value=""/>
         <Parameter name="Output Index List"      type="string" value=""/>
         <Parameter name="Output Time Interval"   type="double" value="10.0"/>

--- a/packages/tempus/src/Tempus_IntegratorAdjointSensitivity.cpp
+++ b/packages/tempus/src/Tempus_IntegratorAdjointSensitivity.cpp
@@ -16,13 +16,13 @@ namespace Tempus {
 
   TEMPUS_INSTANTIATE_TEMPLATE_CLASS(IntegratorAdjointSensitivity)
 
-  // non-member ctor
+  // Nonmember ctor
   template Teuchos::RCP<IntegratorAdjointSensitivity<double> >
   integratorAdjointSensitivity(
     Teuchos::RCP<Teuchos::ParameterList>        parameterList,
     const Teuchos::RCP<Thyra::ModelEvaluator<double> >& model);
 
-  // non-member ctor
+  // Nonmember ctor
   template Teuchos::RCP<IntegratorAdjointSensitivity<double> >
   integratorAdjointSensitivity();
 

--- a/packages/tempus/src/Tempus_IntegratorAdjointSensitivity_decl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorAdjointSensitivity_decl.hpp
@@ -188,14 +188,14 @@ protected:
   Teuchos::RCP<Thyra::MultiVectorBase<Scalar> > dgdp_;
 };
 
-/// Non-member constructor
+/// Nonmember constructor
 template<class Scalar>
 Teuchos::RCP<IntegratorAdjointSensitivity<Scalar> >
 integratorAdjointSensitivity(
   Teuchos::RCP<Teuchos::ParameterList>                pList,
   const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model);
 
-/// Non-member constructor
+/// Nonmember constructor
 template<class Scalar>
 Teuchos::RCP<IntegratorAdjointSensitivity<Scalar> >
 integratorAdjointSensitivity();

--- a/packages/tempus/src/Tempus_IntegratorAdjointSensitivity_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorAdjointSensitivity_impl.hpp
@@ -546,7 +546,7 @@ buildSolutionHistory(
   }
 }
 
-/// Non-member constructor
+/// Nonmember constructor
 template<class Scalar>
 Teuchos::RCP<IntegratorAdjointSensitivity<Scalar> >
 integratorAdjointSensitivity(
@@ -558,7 +558,7 @@ integratorAdjointSensitivity(
   return(integrator);
 }
 
-/// Non-member constructor
+/// Nonmember constructor
 template<class Scalar>
 Teuchos::RCP<IntegratorAdjointSensitivity<Scalar> >
 integratorAdjointSensitivity()

--- a/packages/tempus/src/Tempus_IntegratorBasic.cpp
+++ b/packages/tempus/src/Tempus_IntegratorBasic.cpp
@@ -16,20 +16,20 @@ namespace Tempus {
 
   TEMPUS_INSTANTIATE_TEMPLATE_CLASS(IntegratorBasic)
 
-  // non-member ctor
+  // Nonmember ctor
   template Teuchos::RCP<IntegratorBasic<double> > integratorBasic(
     Teuchos::RCP<Teuchos::ParameterList>        parameterList,
     const Teuchos::RCP<Thyra::ModelEvaluator<double> >& model);
 
-  // non-member ctor
+  // Nonmember ctor
   template Teuchos::RCP<IntegratorBasic<double> > integratorBasic(
     const Teuchos::RCP<Thyra::ModelEvaluator<double> >& model,
     std::string stepperType);
 
-  // non-member ctor
+  // Nonmember ctor
   template Teuchos::RCP<IntegratorBasic<double> > integratorBasic();
 
-  // non-member ctor
+  // Nonmember ctor
   template Teuchos::RCP<IntegratorBasic<double> > integratorBasic(
     Teuchos::RCP<Teuchos::ParameterList>                     pList,
     std::vector<Teuchos::RCP<const Thyra::ModelEvaluator<double> > > models);

--- a/packages/tempus/src/Tempus_IntegratorBasic_decl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorBasic_decl.hpp
@@ -217,23 +217,23 @@ protected:
   bool isInitialized_;
 };
 
-/// Non-member constructor
+/// Nonmember constructor
 template<class Scalar>
 Teuchos::RCP<IntegratorBasic<Scalar> > integratorBasic(
   Teuchos::RCP<Teuchos::ParameterList>                pList,
   const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model);
 
-/// Non-member constructor
+/// Nonmember constructor
 template<class Scalar>
 Teuchos::RCP<IntegratorBasic<Scalar> > integratorBasic(
   const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model,
   std::string stepperType);
 
-/// Non-member constructor
+/// Nonmember constructor
 template<class Scalar>
 Teuchos::RCP<IntegratorBasic<Scalar> > integratorBasic();
 
-/// Non-member constructor
+/// Nonmember constructor
 template<class Scalar>
 Teuchos::RCP<IntegratorBasic<Scalar> > integratorBasic(
   Teuchos::RCP<Teuchos::ParameterList>                pList,

--- a/packages/tempus/src/Tempus_IntegratorBasic_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorBasic_impl.hpp
@@ -258,7 +258,6 @@ void IntegratorBasic<Scalar>::setTimeStepControl(
     // Make integratorPL_ consistent with new TimeStepControl.
     timeStepControl_ = tsc;
     RCP<const ParameterList> tscPL = timeStepControl_->getValidParameters();
-    integratorPL_->set("Time Step Control", tscPL->name());
     integratorPL_->set(tscPL->name(), *tscPL);
   }
 
@@ -410,7 +409,7 @@ bool IntegratorBasic<Scalar>::advanceTime()
       startTimeStep();
       integratorObserver_->observeStartTimeStep(*this);
 
-      timeStepControl_->getNextTimeStep(solutionHistory_, integratorStatus_);
+      timeStepControl_->setNextTimeStep(solutionHistory_, integratorStatus_);
       integratorObserver_->observeNextTimeStep(*this);
 
       if (integratorStatus_ == Status::FAILED) break;
@@ -669,7 +668,7 @@ IntegratorBasic<Scalar>::unsetParameterList()
   return(temp_param_list);
 }
 
-/// Non-member constructor
+/// Nonmember constructor
 template<class Scalar>
 Teuchos::RCP<IntegratorBasic<Scalar> > integratorBasic(
   Teuchos::RCP<Teuchos::ParameterList>                     pList,
@@ -680,7 +679,7 @@ Teuchos::RCP<IntegratorBasic<Scalar> > integratorBasic(
   return(integrator);
 }
 
-/// Non-member constructor
+/// Nonmember constructor
 template<class Scalar>
 Teuchos::RCP<IntegratorBasic<Scalar> > integratorBasic(
   const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >&      model,
@@ -691,7 +690,7 @@ Teuchos::RCP<IntegratorBasic<Scalar> > integratorBasic(
   return(integrator);
 }
 
-/// Non-member constructor
+/// Nonmember constructor
 template<class Scalar>
 Teuchos::RCP<IntegratorBasic<Scalar> > integratorBasic()
 {
@@ -700,7 +699,7 @@ Teuchos::RCP<IntegratorBasic<Scalar> > integratorBasic()
   return(integrator);
 }
 
-/// Non-member constructor
+/// Nonmember constructor
 template<class Scalar>
 Teuchos::RCP<IntegratorBasic<Scalar> > integratorBasic(
   Teuchos::RCP<Teuchos::ParameterList>                     pList,

--- a/packages/tempus/src/Tempus_IntegratorForwardSensitivity.cpp
+++ b/packages/tempus/src/Tempus_IntegratorForwardSensitivity.cpp
@@ -16,19 +16,19 @@ namespace Tempus {
 
   TEMPUS_INSTANTIATE_TEMPLATE_CLASS(IntegratorForwardSensitivity)
 
-  // non-member ctor
+  // Nonmember ctor
   template Teuchos::RCP<IntegratorForwardSensitivity<double> >
   integratorForwardSensitivity(
     Teuchos::RCP<Teuchos::ParameterList>        parameterList,
     const Teuchos::RCP<Thyra::ModelEvaluator<double> >& model);
 
-  // non-member ctor
+  // Nonmember ctor
   template Teuchos::RCP<IntegratorForwardSensitivity<double> >
   integratorForwardSensitivity(
     const Teuchos::RCP<Thyra::ModelEvaluator<double> >& model,
     std::string stepperType);
 
-  // non-member ctor
+  // Nonmember ctor
   template Teuchos::RCP<IntegratorForwardSensitivity<double> >
   integratorForwardSensitivity();
 

--- a/packages/tempus/src/Tempus_IntegratorForwardSensitivity_decl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorForwardSensitivity_decl.hpp
@@ -243,21 +243,21 @@ protected:
   bool use_combined_method_;
 };
 
-/// Non-member constructor
+/// Nonmember constructor
 template<class Scalar>
 Teuchos::RCP<IntegratorForwardSensitivity<Scalar> >
 integratorForwardSensitivity(
   Teuchos::RCP<Teuchos::ParameterList>                pList,
   const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model);
 
-/// Non-member constructor
+/// Nonmember constructor
 template<class Scalar>
 Teuchos::RCP<IntegratorForwardSensitivity<Scalar> >
 integratorForwardSensitivity(
   const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model,
   std::string stepperType);
 
-/// Non-member constructor
+/// Nonmember constructor
 template<class Scalar>
 Teuchos::RCP<IntegratorForwardSensitivity<Scalar> >
 integratorForwardSensitivity();

--- a/packages/tempus/src/Tempus_IntegratorForwardSensitivity_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorForwardSensitivity_impl.hpp
@@ -324,7 +324,7 @@ createSensitivityModelAndStepper(
   }
 }
 
-/// Non-member constructor
+/// Nonmember constructor
 template<class Scalar>
 Teuchos::RCP<IntegratorForwardSensitivity<Scalar> >
 integratorForwardSensitivity(
@@ -336,7 +336,7 @@ integratorForwardSensitivity(
   return(integrator);
 }
 
-/// Non-member constructor
+/// Nonmember constructor
 template<class Scalar>
 Teuchos::RCP<IntegratorForwardSensitivity<Scalar> >
 integratorForwardSensitivity(
@@ -348,7 +348,7 @@ integratorForwardSensitivity(
   return(integrator);
 }
 
-/// Non-member constructor
+/// Nonmember constructor
 template<class Scalar>
 Teuchos::RCP<IntegratorForwardSensitivity<Scalar> >
 integratorForwardSensitivity()

--- a/packages/tempus/src/Tempus_IntegratorPseudoTransientAdjointSensitivity.cpp
+++ b/packages/tempus/src/Tempus_IntegratorPseudoTransientAdjointSensitivity.cpp
@@ -16,19 +16,19 @@ namespace Tempus {
 
   TEMPUS_INSTANTIATE_TEMPLATE_CLASS(IntegratorPseudoTransientAdjointSensitivity)
 
-  // non-member ctor
+  // Nonmember ctor
   template Teuchos::RCP<IntegratorPseudoTransientAdjointSensitivity<double> >
   integratorPseudoTransientAdjointSensitivity(
     Teuchos::RCP<Teuchos::ParameterList>        parameterList,
     const Teuchos::RCP<Thyra::ModelEvaluator<double> >& model);
 
-  // non-member ctor
+  // Nonmember ctor
   template Teuchos::RCP<IntegratorPseudoTransientAdjointSensitivity<double> >
   integratorPseudoTransientAdjointSensitivity(
     const Teuchos::RCP<Thyra::ModelEvaluator<double> >& model,
     std::string stepperType);
 
-  // non-member ctor
+  // Nonmember ctor
   template Teuchos::RCP<IntegratorPseudoTransientAdjointSensitivity<double> >
   integratorPseudoTransientAdjointSensitivity();
 

--- a/packages/tempus/src/Tempus_IntegratorPseudoTransientAdjointSensitivity_decl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorPseudoTransientAdjointSensitivity_decl.hpp
@@ -175,21 +175,21 @@ protected:
   Teuchos::RCP<DMVPV> dgdp_;
 };
 
-/// Non-member constructor
+/// Nonmember constructor
 template<class Scalar>
 Teuchos::RCP<Tempus::IntegratorPseudoTransientAdjointSensitivity<Scalar> >
 integratorPseudoTransientAdjointSensitivity(
   Teuchos::RCP<Teuchos::ParameterList>                pList,
   const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model);
 
-/// Non-member constructor
+/// Nonmember constructor
 template<class Scalar>
 Teuchos::RCP<Tempus::IntegratorPseudoTransientAdjointSensitivity<Scalar> >
 integratorPseudoTransientAdjointSensitivity(
   const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model,
   std::string stepperType);
 
-/// Non-member constructor
+/// Nonmember constructor
 template<class Scalar>
 Teuchos::RCP<Tempus::IntegratorPseudoTransientAdjointSensitivity<Scalar> >
 integratorPseudoTransientAdjointSensitivity();

--- a/packages/tempus/src/Tempus_IntegratorPseudoTransientAdjointSensitivity_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorPseudoTransientAdjointSensitivity_impl.hpp
@@ -455,7 +455,7 @@ buildSolutionHistory()
   }
 }
 
-/// Non-member constructor
+/// Nonmember constructor
 template<class Scalar>
 Teuchos::RCP<IntegratorPseudoTransientAdjointSensitivity<Scalar> >
 integratorPseudoTransientAdjointSensitivity(
@@ -467,7 +467,7 @@ integratorPseudoTransientAdjointSensitivity(
   return(integrator);
 }
 
-/// Non-member constructor
+/// Nonmember constructor
 template<class Scalar>
 Teuchos::RCP<IntegratorPseudoTransientAdjointSensitivity<Scalar> >
 integratorPseudoTransientAdjointSensitivity(
@@ -479,7 +479,7 @@ integratorPseudoTransientAdjointSensitivity(
   return(integrator);
 }
 
-/// Non-member constructor
+/// Nonmember constructor
 template<class Scalar>
 Teuchos::RCP<IntegratorPseudoTransientAdjointSensitivity<Scalar> >
 integratorPseudoTransientAdjointSensitivity()

--- a/packages/tempus/src/Tempus_IntegratorPseudoTransientForwardSensitivity.cpp
+++ b/packages/tempus/src/Tempus_IntegratorPseudoTransientForwardSensitivity.cpp
@@ -16,19 +16,19 @@ namespace Tempus {
 
   TEMPUS_INSTANTIATE_TEMPLATE_CLASS(IntegratorPseudoTransientForwardSensitivity)
 
-  // non-member ctor
+  // Nonmember ctor
   template Teuchos::RCP<IntegratorPseudoTransientForwardSensitivity<double> >
   integratorPseudoTransientForwardSensitivity(
     Teuchos::RCP<Teuchos::ParameterList>        parameterList,
     const Teuchos::RCP<Thyra::ModelEvaluator<double> >& model);
 
-  // non-member ctor
+  // Nonmember ctor
   template Teuchos::RCP<IntegratorPseudoTransientForwardSensitivity<double> >
   integratorPseudoTransientForwardSensitivity(
     const Teuchos::RCP<Thyra::ModelEvaluator<double> >& model,
     std::string stepperType);
 
-  // non-member ctor
+  // Nonmember ctor
   template Teuchos::RCP<IntegratorPseudoTransientForwardSensitivity<double> >
   integratorPseudoTransientForwardSensitivity();
 

--- a/packages/tempus/src/Tempus_IntegratorPseudoTransientForwardSensitivity_decl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorPseudoTransientForwardSensitivity_decl.hpp
@@ -188,21 +188,21 @@ protected:
   bool force_W_update_;
 };
 
-/// Non-member constructor
+/// Nonmember constructor
 template<class Scalar>
 Teuchos::RCP<Tempus::IntegratorPseudoTransientForwardSensitivity<Scalar> >
 integratorPseudoTransientForwardSensitivity(
   Teuchos::RCP<Teuchos::ParameterList>                pList,
   const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model);
 
-/// Non-member constructor
+/// Nonmember constructor
 template<class Scalar>
 Teuchos::RCP<Tempus::IntegratorPseudoTransientForwardSensitivity<Scalar> >
 integratorPseudoTransientForwardSensitivity(
   const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model,
   std::string stepperType);
 
-/// Non-member constructor
+/// Nonmember constructor
 template<class Scalar>
 Teuchos::RCP<Tempus::IntegratorPseudoTransientForwardSensitivity<Scalar> >
 integratorPseudoTransientForwardSensitivity();

--- a/packages/tempus/src/Tempus_IntegratorPseudoTransientForwardSensitivity_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorPseudoTransientForwardSensitivity_impl.hpp
@@ -544,7 +544,7 @@ buildSolutionHistory()
   }
 }
 
-/// Non-member constructor
+/// Nonmember constructor
 template<class Scalar>
 Teuchos::RCP<Tempus::IntegratorPseudoTransientForwardSensitivity<Scalar> >
 integratorPseudoTransientForwardSensitivity(
@@ -556,7 +556,7 @@ integratorPseudoTransientForwardSensitivity(
   return(integrator);
 }
 
-/// Non-member constructor
+/// Nonmember constructor
 template<class Scalar>
 Teuchos::RCP<Tempus::IntegratorPseudoTransientForwardSensitivity<Scalar> >
 integratorPseudoTransientForwardSensitivity(
@@ -568,7 +568,7 @@ integratorPseudoTransientForwardSensitivity(
   return(integrator);
 }
 
-/// Non-member constructor
+/// Nonmember constructor
 template<class Scalar>
 Teuchos::RCP<Tempus::IntegratorPseudoTransientForwardSensitivity<Scalar> >
 integratorPseudoTransientForwardSensitivity()

--- a/packages/tempus/src/Tempus_Interpolator.hpp
+++ b/packages/tempus/src/Tempus_Interpolator.hpp
@@ -65,7 +65,7 @@ public:
 
 };
 
-/// Non-member constructor
+/// Nonmember constructor
 template<class Scalar>
 void interpolate(const Interpolator<Scalar>& interpolator,
                  const Scalar& t,
@@ -74,7 +74,7 @@ void interpolate(const Interpolator<Scalar>& interpolator,
   interpolator.interpolate(t, state_out);
 }
 
-/// Non-member constructor
+/// Nonmember constructor
 template<class Scalar>
 void interpolate(Interpolator<Scalar>& interpolator,
                  const Teuchos::RCP<const std::vector<Teuchos::RCP<SolutionState<Scalar> > > >&  nodes,

--- a/packages/tempus/src/Tempus_InterpolatorLagrange_decl.hpp
+++ b/packages/tempus/src/Tempus_InterpolatorLagrange_decl.hpp
@@ -69,7 +69,7 @@ private:
 
 };
 
-// non-member constructor
+// Nonmember constructor
 template<class Scalar>
 Teuchos::RCP<InterpolatorLagrange<Scalar> > lagrangeInterpolator()
 {

--- a/packages/tempus/src/Tempus_StepperBDF2_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperBDF2_decl.hpp
@@ -75,91 +75,91 @@ class StepperBDF2 : virtual public Tempus::StepperImplicit<Scalar>
 {
 public:
 
-    /** \brief Default constructor.
-     *
-     *  - Requires the following calls before takeStep():
-     *    setModel() and initialize().
-     */
-    StepperBDF2();
+  /** \brief Default constructor.
+   *
+   *  - Requires the following calls before takeStep():
+   *    setModel() and initialize().
+   */
+  StepperBDF2();
 
-    StepperBDF2(
-      const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel,
-      const Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> >& solver,
-      const Teuchos::RCP<Stepper<Scalar> >& startUpStepper,
-      bool useFSAL,
-      std::string ICConsistency,
-      bool ICConsistencyCheck,
-      bool zeroInitialGuess,
-      const Teuchos::RCP<StepperBDF2AppAction<Scalar> >& stepperBDF2AppAction);
+  StepperBDF2(
+    const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel,
+    const Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> >& solver,
+    const Teuchos::RCP<Stepper<Scalar> >& startUpStepper,
+    bool useFSAL,
+    std::string ICConsistency,
+    bool ICConsistencyCheck,
+    bool zeroInitialGuess,
+    const Teuchos::RCP<StepperBDF2AppAction<Scalar> >& stepperBDF2AppAction);
 
-    /// \name Basic stepper methods
-    //@{
-    virtual void setModel(
-      const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel);
+  /// \name Basic stepper methods
+  //@{
+  virtual void setModel(
+    const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel);
 
-    virtual void setAppAction(
-      Teuchos::RCP<StepperBDF2AppAction<Scalar> > appAction);
+  virtual void setAppAction(
+    Teuchos::RCP<StepperBDF2AppAction<Scalar> > appAction);
 
-    virtual Teuchos::RCP<StepperBDF2AppAction<Scalar> > getAppAction() const
-    { return stepperBDF2AppAction_; }
+  virtual Teuchos::RCP<StepperBDF2AppAction<Scalar> > getAppAction() const
+  { return stepperBDF2AppAction_; }
 
-    /// Set the stepper to use in first step
-    void setStartUpStepper(std::string startupStepperType);
-    void setStartUpStepper(Teuchos::RCP<Stepper<Scalar> > startupStepper);
+  /// Set the stepper to use in first step
+  void setStartUpStepper(std::string startupStepperType);
+  void setStartUpStepper(Teuchos::RCP<Stepper<Scalar> > startupStepper);
 
-    /// Initialize during construction and after changing input parameters.
-    virtual void initialize();
+  /// Initialize during construction and after changing input parameters.
+  virtual void initialize();
 
-    /// Set the initial conditions and make them consistent.
-    virtual void setInitialConditions (
-      const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory);
+  /// Set the initial conditions and make them consistent.
+  virtual void setInitialConditions (
+    const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory);
 
-    /// Take the specified timestep, dt, and return true if successful.
-    virtual void takeStep(
-      const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory);
+  /// Take the specified timestep, dt, and return true if successful.
+  virtual void takeStep(
+    const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory);
 
-    /// Get a default (initial) StepperState
-    virtual Teuchos::RCP<Tempus::StepperState<Scalar> > getDefaultStepperState();
-    virtual Scalar getOrder() const {return order_;}
-    virtual Scalar getOrderMin() const {return 1.0;}
-    virtual Scalar getOrderMax() const {return 2.0;}
+  /// Get a default (initial) StepperState
+  virtual Teuchos::RCP<Tempus::StepperState<Scalar> > getDefaultStepperState();
+  virtual Scalar getOrder() const {return order_;}
+  virtual Scalar getOrderMin() const {return 1.0;}
+  virtual Scalar getOrderMax() const {return 2.0;}
 
-    virtual bool isExplicit()         const {return false;}
-    virtual bool isImplicit()         const {return true;}
-    virtual bool isExplicitImplicit() const
-    {return isExplicit() and isImplicit();}
-    virtual bool isOneStepMethod()   const {return false;}
-    virtual bool isMultiStepMethod() const {return !isOneStepMethod();}
-    virtual OrderODE getOrderODE()   const {return FIRST_ORDER_ODE;}
-    //@}
+  virtual bool isExplicit()         const {return false;}
+  virtual bool isImplicit()         const {return true;}
+  virtual bool isExplicitImplicit() const
+  {return isExplicit() and isImplicit();}
+  virtual bool isOneStepMethod()   const {return false;}
+  virtual bool isMultiStepMethod() const {return !isOneStepMethod();}
+  virtual OrderODE getOrderODE()   const {return FIRST_ORDER_ODE;}
+  //@}
 
-    /// Return alpha = d(xDot)/dx.
-    virtual Scalar getAlpha(const Scalar dt) const {return getAlpha(dt,dt);}
-    virtual Scalar getAlpha(const Scalar dt, const Scalar dtOld) const
-    { return (Scalar(2.0)*dt + dtOld)/(dt*(dt + dtOld)); }
-    /// Return beta  = d(x)/dx.
-    virtual Scalar getBeta (const Scalar   ) const { return Scalar(1.0); }
+  /// Return alpha = d(xDot)/dx.
+  virtual Scalar getAlpha(const Scalar dt) const {return getAlpha(dt,dt);}
+  virtual Scalar getAlpha(const Scalar dt, const Scalar dtOld) const
+  { return (Scalar(2.0)*dt + dtOld)/(dt*(dt + dtOld)); }
+  /// Return beta  = d(x)/dx.
+  virtual Scalar getBeta (const Scalar   ) const { return Scalar(1.0); }
 
-    /// Compute the first time step given the supplied startup stepper
-    virtual void computeStartUp(
-      const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory);
+  /// Compute the first time step given the supplied startup stepper
+  virtual void computeStartUp(
+    const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory);
 
-    Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
+  Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
 
-    /// \name Overridden from Teuchos::Describable
-    //@{
-    virtual void describe(Teuchos::FancyOStream        & out,
-                          const Teuchos::EVerbosityLevel verbLevel) const;
-    //@}
+  /// \name Overridden from Teuchos::Describable
+  //@{
+  virtual void describe(Teuchos::FancyOStream        & out,
+                        const Teuchos::EVerbosityLevel verbLevel) const;
+  //@}
 
-    virtual bool isValidSetup(Teuchos::FancyOStream & out) const;
+  virtual bool isValidSetup(Teuchos::FancyOStream & out) const;
 
-  private:
+private:
 
-    Teuchos::RCP<Stepper<Scalar> >              startUpStepper_;
-    Teuchos::RCP<StepperBDF2AppAction<Scalar> > stepperBDF2AppAction_;
-    Scalar                                      order_ = Scalar(2.0);
-  };
+  Teuchos::RCP<Stepper<Scalar> >              startUpStepper_;
+  Teuchos::RCP<StepperBDF2AppAction<Scalar> > stepperBDF2AppAction_;
+  Scalar                                      order_ = Scalar(2.0);
+};
 
 /** \brief Time-derivative interface for BDF2.
  *

--- a/packages/tempus/src/Tempus_StepperDIRK_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperDIRK_decl.hpp
@@ -194,8 +194,8 @@ public:
     virtual std::string getDescription() const = 0;
   //@}
 
-  std::vector<Teuchos::RCP<Thyra::VectorBase<Scalar> > >& getStageXDot() {return stageXDot_;};
-  Teuchos::RCP<Thyra::VectorBase<Scalar> >& getXTilde() {return xTilde_;};
+  std::vector<Teuchos::RCP<Thyra::VectorBase<Scalar> > >& getStageXDot() {return stageXDot_;}
+  Teuchos::RCP<Thyra::VectorBase<Scalar> >& getXTilde() {return xTilde_;}
 
   /// Return alpha = d(xDot)/dx.
   virtual Scalar getAlpha(const Scalar dt) const

--- a/packages/tempus/src/Tempus_StepperExplicit_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperExplicit_decl.hpp
@@ -108,7 +108,8 @@ protected:
   Thyra::ModelEvaluatorBase::InArgs<Scalar>          inArgs_;
   Thyra::ModelEvaluatorBase::OutArgs<Scalar>         outArgs_;
 
- };
+};
+
 
 } // namespace Tempus
 #endif // Tempus_StepperExplicit_decl_hpp

--- a/packages/tempus/src/Tempus_StepperIMEX_RK_Partition_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperIMEX_RK_Partition_decl.hpp
@@ -403,9 +403,9 @@ public:
     virtual OrderODE getOrderODE()   const {return FIRST_ORDER_ODE;}
   //@}
 
-  std::vector<Teuchos::RCP<Thyra::VectorBase<Scalar> > >& getStageF() {return stageF_;};
-  std::vector<Teuchos::RCP<Thyra::VectorBase<Scalar> > >& getStageGx() {return stageGx_;};
-  Teuchos::RCP<Thyra::VectorBase<Scalar> >& getXTilde() {return xTilde_;};
+  std::vector<Teuchos::RCP<Thyra::VectorBase<Scalar> > >& getStageF() {return stageF_;}
+  std::vector<Teuchos::RCP<Thyra::VectorBase<Scalar> > >& getStageGx() {return stageGx_;}
+  Teuchos::RCP<Thyra::VectorBase<Scalar> >& getXTilde() {return xTilde_;}
 
   /// Return alpha = d(xDot)/dx.
   virtual Scalar getAlpha(const Scalar dt) const

--- a/packages/tempus/src/Tempus_StepperIMEX_RK_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperIMEX_RK_decl.hpp
@@ -372,9 +372,9 @@ public:
     virtual OrderODE getOrderODE()   const {return FIRST_ORDER_ODE;}
   //@}
 
-  std::vector<Teuchos::RCP<Thyra::VectorBase<Scalar> > >& getStageF() {return stageF_;};
-  std::vector<Teuchos::RCP<Thyra::VectorBase<Scalar> > >& getStageG() {return stageG_;};
-  Teuchos::RCP<Thyra::VectorBase<Scalar> >& getXTilde() {return xTilde_;};
+  std::vector<Teuchos::RCP<Thyra::VectorBase<Scalar> > >& getStageF() {return stageF_;}
+  std::vector<Teuchos::RCP<Thyra::VectorBase<Scalar> > >& getStageG() {return stageG_;}
+  Teuchos::RCP<Thyra::VectorBase<Scalar> >& getXTilde() {return xTilde_;}
 
   /// Return alpha = d(xDot)/dx.
   virtual Scalar getAlpha(const Scalar dt) const

--- a/packages/tempus/src/Tempus_StepperSubcycling_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperSubcycling_decl.hpp
@@ -123,7 +123,6 @@ public:
     virtual void setSubcyclingMinTimeStep(Scalar MinTimeStep);
     virtual void setSubcyclingInitTimeStep(Scalar InitTimeStep);
     virtual void setSubcyclingMaxTimeStep(Scalar MaxTimeStep);
-    virtual void setSubcyclingStepType(std::string StepType);
     virtual void setSubcyclingMaxFailures(int MaxFailures);
     virtual void setSubcyclingMaxConsecFailures(int MaxConsecFailures);
     virtual void setSubcyclingScreenOutputIndexInterval(int i);

--- a/packages/tempus/src/Tempus_StepperSubcycling_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperSubcycling_impl.hpp
@@ -135,25 +135,6 @@ void StepperSubcycling<Scalar>::setSubcyclingMaxTimeStep(Scalar MaxTimeStep)
 
 
 template<class Scalar>
-void StepperSubcycling<Scalar>::setSubcyclingStepType(std::string stepType)
-{
-  scIntegrator_->getNonConstTimeStepControl()->setStepType(stepType);
-
-  auto tsc = scIntegrator_->getNonConstTimeStepControl();
-  auto tscStrategy = tsc->getTimeStepControlStrategy();
-
-  Teuchos::RCP<TimeStepControlStrategy<Scalar> > strategy =
-    Teuchos::rcp(new TimeStepControlStrategyConstant<Scalar>());
-  if (stepType == "Variable")
-    strategy = Teuchos::rcp(new TimeStepControlStrategyBasicVS<Scalar>());
-
-  tsc->setTimeStepControlStrategy(strategy);
-
-  this->isInitialized_ = false;
-}
-
-
-template<class Scalar>
 void StepperSubcycling<Scalar>::setSubcyclingMaxFailures(int MaxFailures)
 {
   scIntegrator_->getNonConstTimeStepControl()->setMaxFailures(MaxFailures);

--- a/packages/tempus/src/Tempus_TimeStepControl.cpp
+++ b/packages/tempus/src/Tempus_TimeStepControl.cpp
@@ -19,7 +19,8 @@ namespace Tempus {
   // Nonmember constructor from ParameterList.
   template Teuchos::RCP<TimeStepControl<double> >
   createTimeStepControl(
-    Teuchos::RCP<Teuchos::ParameterList> const& pList);
+    Teuchos::RCP<Teuchos::ParameterList> const& pList,
+    bool runInitialize);
 
 }
 

--- a/packages/tempus/src/Tempus_TimeStepControlStrategy.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategy.hpp
@@ -12,6 +12,7 @@
 // Teuchos
 #include "Teuchos_ParameterListAcceptorDefaultBase.hpp"
 
+//#include "Tempus_Types.hpp"
 #include "Tempus_SolutionHistory.hpp"
 
 
@@ -19,52 +20,80 @@ namespace Tempus {
 
 template<class Scalar> class TimeStepControl;
 
-/** \brief StepControlStrategy class for TimeStepControl
+/** \brief TimeStepControlStrategy class for TimeStepControl
  *
- *  This strategy is the default base class, which provides a no-op strategy.
+ *  This is the base class for TimeStepControlStrategies.
+ *  The primary function required from derived classes is setNextTimeStep(),
+ *  which will
+ *   - determine the next step from information in the TimeStepControl
+ *     and SolutionHistory (i.e., SolutionStates)
+ *   - set the next time step on the workingState in the SolutionHistory
+ *  If a valid timestep can not be determined the Status is set to FAILED.
  */
 template<class Scalar>
 class TimeStepControlStrategy
   : virtual public Teuchos::Describable,
-    virtual public Teuchos::ParameterListAcceptor
+    virtual public Teuchos::VerboseObject<Tempus::TimeStepControlStrategy<Scalar> >
 {
 public:
 
   /// Constructor
-  TimeStepControlStrategy(){}
+  TimeStepControlStrategy()
+   : strategyType_("Base Strategy"), stepType_("Constant"),
+     name_("Base Strategy"), isInitialized_(false)
+  {}
 
   /// Destructor
   virtual ~TimeStepControlStrategy(){}
 
-  /// Determine the time step size.
+#ifndef TEMPUS_HIDE_DEPRECATED_CODE
+  /// Deprecated get the time step size.
   virtual void getNextTimeStep(
-    const TimeStepControl<Scalar> /* tsc */,
+    const TimeStepControl<Scalar> tsc,
+    Teuchos::RCP<SolutionHistory<Scalar> > sh,
+    Status & integratorStatus)
+  {
+    this->setNextTimeStep(tsc, sh, integratorStatus);
+  }
+#endif
+
+  /// Set the time step size.
+  virtual void setNextTimeStep(
+    const TimeStepControl<Scalar> & /* tsc */,
     Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
-    Status & /* integratorStatus */){}
+    Status & /* integratorStatus */) {}
 
-  /// \name Overridden from Teuchos::Describable
-  //@{
-    std::string description() const override
-    { return "Tempus::TimeStepControlStrategy"; }
-
-    void describe(Teuchos::FancyOStream          &out,
-                  const Teuchos::EVerbosityLevel verbLevel) const override
-    {
-      Teuchos::OSTab ostab(out,2,"describe");
-      out << description() << std::endl;
+  virtual void initialize() const { isInitialized_ = true; }
+  virtual bool isInitialized() { return isInitialized_; }
+  virtual void checkInitialized()
+  {
+    if ( !isInitialized_ ) {
+      this->describe( *(this->getOStream()), Teuchos::VERB_MEDIUM);
+      TEUCHOS_TEST_FOR_EXCEPTION( !isInitialized_, std::logic_error,
+        "Error - " << this->description() << " is not initialized!");
     }
-  //@}
+  }
 
-  /// \name Overridden from Teuchos::ParameterListAcceptor
-  //@{
-    void setParameterList(const Teuchos::RCP<Teuchos::ParameterList> & /* pl */) override {}
-    Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const override
-      { return  Teuchos::null;}
-    Teuchos::RCP<Teuchos::ParameterList> getNonconstParameterList() override
-      { return  Teuchos::null;}
-    Teuchos::RCP<Teuchos::ParameterList> unsetParameterList() override
-      { return  Teuchos::null;}
-  //@}
+  virtual void setName(std::string s) { name_ = s; }
+
+  virtual std::string getStrategyType() const { return strategyType_; }
+  virtual std::string getStepType() const { return stepType_; }
+  virtual std::string getName() const { return name_; }
+
+  /// Return ParameterList with current values.
+  virtual Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const
+  { return Teuchos::parameterList(); }
+
+protected:
+
+  virtual void setStrategyType(std::string s) { strategyType_ = s; }
+  virtual void setStepType(std::string s) { stepType_ = s; }
+
+  std::string  strategyType_;   ///< Strategy type
+  std::string  stepType_;       ///< Step Type - "Constant" or "Variable"
+  std::string  name_;           ///< Name of strategy.
+  mutable bool isInitialized_;  ///< Bool if strategy is initialized.
+
 };
 
 

--- a/packages/tempus/src/Tempus_TimeStepControlStrategyBasicVS.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategyBasicVS.hpp
@@ -106,43 +106,45 @@ class TimeStepControlStrategyBasicVS
 {
 public:
 
-  /// Constructor
-  TimeStepControlStrategyBasicVS(
-    Teuchos::RCP<Teuchos::ParameterList> pList = Teuchos::null){
-     this->setParameterList(pList);
+  /// Default Constructor
+  TimeStepControlStrategyBasicVS()
+    : rho_(1.75), sigma_(0.5), minEta_(0.0), maxEta_(1.0e+16)
+  {
+    this->setStrategyType("Basic VS");
+    this->setStepType("Variable");
+    this->setName("Basic VS");
+    this->initialize();
+  }
+
+  /// Full Constructor
+  TimeStepControlStrategyBasicVS(Scalar rho, Scalar sigma, Scalar minEta,
+    Scalar maxEta, std::string name = "Basic VS")
+    : rho_(rho), sigma_(sigma), minEta_(minEta), maxEta_(maxEta)
+  {
+    this->setStrategyType("Basic VS");
+    this->setStepType("Variable");
+    this->setName(name);
+    this->initialize();
   }
 
   /// Destructor
   virtual ~TimeStepControlStrategyBasicVS(){}
 
-  /** \brief Determine the time step size.*/
-  virtual void getNextTimeStep(
-    const TimeStepControl<Scalar> tsc,
+  /** \brief Set the time step size.*/
+  virtual void setNextTimeStep(
+    const TimeStepControl<Scalar> & tsc,
     Teuchos::RCP<SolutionHistory<Scalar> > solutionHistory,
     Status & /* integratorStatus */) override
   {
     using Teuchos::RCP;
+
+    this->checkInitialized();
+
     RCP<SolutionState<Scalar> > workingState=solutionHistory->getWorkingState();
     const Scalar errorAbs = workingState->getErrorAbs();
     const Scalar errorRel = workingState->getErrorRel();
     const int iStep = workingState->getIndex();
-    Scalar dt = workingState->getTimeStep();
-    bool printDtChanges = tsc.getPrintDtChanges();
-
-    RCP<Teuchos::FancyOStream> out = tsc.getOStream();
-    Teuchos::OSTab ostab(out,0,"getNextTimeStep");
-
-    auto changeDT = [] (int istep, Scalar dt_old, Scalar dt_new,
-                        std::string reason)
-    {
-      std::stringstream message;
-      message << std::scientific
-                       <<std::setw(6)<<std::setprecision(3)<<istep
-        << " *  (dt = "<<std::setw(9)<<std::setprecision(3)<<dt_old
-        <<   ", new = "<<std::setw(9)<<std::setprecision(3)<<dt_new
-        << ")  " << reason << std::endl;
-      return message.str();
-    };
+    Scalar dt       = workingState->getTimeStep();
 
     Scalar rho   = getAmplFactor();
     Scalar sigma = getReductFactor();
@@ -151,34 +153,34 @@ public:
 
     // General rule: only increase/decrease dt once for any given reason.
     if (workingState->getSolutionStatus() == Status::FAILED) {
-      if (printDtChanges) *out << changeDT(iStep, dt, dt*sigma,
-        "Stepper failure - Decreasing dt.");
+      tsc.printDtChanges(iStep, dt, dt*sigma,
+                          "Stepper failure - Decreasing dt.");
       dt *= sigma;
     }
     else { //Stepper passed
       if (eta < getMinEta()) { // increase dt
-        if (printDtChanges) *out << changeDT(iStep, dt, dt*rho,
+        tsc.printDtChanges(iStep, dt, dt*rho,
           "Change too small ("
           + std::to_string(eta) + " < " + std::to_string(getMinEta())
           + ").  Increasing dt.");
         dt *= rho;
       }
       else if (eta > getMaxEta()) { // reduce dt
-        if (printDtChanges) *out << changeDT(iStep, dt, dt*sigma,
+        tsc.printDtChanges(iStep, dt, dt*sigma,
           "Change too large ("
           + std::to_string(eta) + " > " + std::to_string(getMaxEta())
           + ").  Decreasing dt.");
         dt *= sigma;
       }
       else if (errorAbs > tsc.getMaxAbsError()) { // reduce dt
-        if (printDtChanges) *out << changeDT(iStep, dt, dt*sigma,
+        tsc.printDtChanges(iStep, dt, dt*sigma,
           "Absolute error is too large ("
           + std::to_string(errorAbs)+" > "+std::to_string(tsc.getMaxAbsError())
           + ").  Decreasing dt.");
         dt *= sigma;
       }
       else if (errorRel > tsc.getMaxRelError()) { // reduce dt
-        if (printDtChanges) *out << changeDT(iStep, dt, dt*sigma,
+        tsc.printDtChanges(iStep, dt, dt*sigma,
           "Relative error is too large ("
           + std::to_string(errorRel)+" > "+std::to_string(tsc.getMaxRelError())
           + ").  Decreasing dt.");
@@ -187,17 +189,18 @@ public:
     }
 
     if (dt < tsc.getMinTimeStep()) { // decreased below minimum dt
-      if (printDtChanges) *out << changeDT(iStep, dt, tsc.getMinTimeStep(),
+      tsc.printDtChanges(iStep, dt, tsc.getMinTimeStep(),
         "dt is too small.  Resetting to minimum dt.");
       dt = tsc.getMinTimeStep();
     }
     if (dt > tsc.getMaxTimeStep()) { // increased above maximum dt
-      if (printDtChanges) *out << changeDT(iStep, dt, tsc.getMaxTimeStep(),
+      tsc.printDtChanges(iStep, dt, tsc.getMaxTimeStep(),
         "dt is too large.  Resetting to maximum dt.");
       dt = tsc.getMaxTimeStep();
     }
 
     workingState->setTimeStep(dt);
+    workingState->setTime(solutionHistory->getCurrentState()->getTime() + dt);
     workingState->setComputeNorms(true);
   }
 
@@ -211,6 +214,7 @@ public:
     {
       Teuchos::OSTab ostab(out,2,"describe");
       out << description() << "::describe:" << std::endl
+          << "StrategyType                      = " << this->getStrategyType()<< std::endl
           << "Amplification Factor              = " << getAmplFactor()   << std::endl
           << "Reduction Factor                  = " << getReductFactor() << std::endl
           << "Minimum Value Monitoring Function = " << getMinEta()       << std::endl
@@ -218,87 +222,98 @@ public:
     }
   //@}
 
-  /// \name Overridden from Teuchos::ParameterListAcceptor
-  //@{
-    void setParameterList(
-      const Teuchos::RCP<Teuchos::ParameterList> & pList) override
-    {
-      if (pList == Teuchos::null) {
-        // Create default parameters if null, otherwise keep current parameters.
-        if (tscsPL_ == Teuchos::null) {
-           tscsPL_ = Teuchos::parameterList("TimeStepControlStrategyBasicVS");
-           *tscsPL_= *(this->getValidParameters());
-        }
-      } else {
-         tscsPL_ = pList;
-      }
-      tscsPL_->validateParametersAndSetDefaults(*this->getValidParameters());
+  /// Return ParameterList with current values.
+  virtual Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const override
+  {
+     Teuchos::RCP<Teuchos::ParameterList> pl =
+       Teuchos::parameterList("Time Step Control Strategy");
 
-      TEUCHOS_TEST_FOR_EXCEPTION(getAmplFactor() <= 1.0, std::out_of_range,
+     pl->set<std::string>("Strategy Type", this->getStrategyType(), "Basic VS");
+     pl->set<double>("Amplification Factor", getAmplFactor(), "Amplification factor");
+     pl->set<double>("Reduction Factor"    , getReductFactor() , "Reduction factor");
+     pl->set<double>("Minimum Value Monitoring Function", getMinEta(), "Min value eta");
+     pl->set<double>("Maximum Value Monitoring Function", getMaxEta(), "Max value eta");
+     return pl;
+  }
+
+
+  virtual void initialize() const override
+  {
+    TEUCHOS_TEST_FOR_EXCEPTION(getAmplFactor() <= 1.0, std::out_of_range,
       "Error - Invalid value of Amplification Factor = " << getAmplFactor()
       << "!  \n" << "Amplification Factor must be > 1.0.\n");
 
-      TEUCHOS_TEST_FOR_EXCEPTION(getReductFactor() >= 1.0, std::out_of_range,
+    TEUCHOS_TEST_FOR_EXCEPTION(getReductFactor() >= 1.0, std::out_of_range,
       "Error - Invalid value of Reduction Factor = " << getReductFactor()
       << "!  \n" << "Reduction Factor must be < 1.0.\n");
 
-      TEUCHOS_TEST_FOR_EXCEPTION(getMinEta() > getMaxEta(), std::out_of_range,
+    TEUCHOS_TEST_FOR_EXCEPTION(getMinEta() > getMaxEta(), std::out_of_range,
       "Error - Invalid values of 'Minimum Value Monitoring Function' = "
       << getMinEta() << "\n and 'Maximum Value Monitoring Function' = "
       << getMaxEta() <<"! \n Mininum Value cannot be > Maximum Value! \n");
 
-    }
+    this->isInitialized_ = true;   // Only place where this is set to true!
+  }
 
-    Teuchos::RCP<const Teuchos::ParameterList>
-    getValidParameters() const override {
-       Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
 
-       // From (Denner, 2014), amplification factor can be at most 1.91 for
-       // stability.
-       pl->set<double>("Amplification Factor", 1.75, "Amplification factor");
-       pl->set<double>("Reduction Factor"    , 0.5 , "Reduction factor");
-       // From (Denner, 2014), it seems a reasonable choice for eta_min is
-       // 0.1*eta_max.  Numerical tests confirm this.
-       pl->set<double>("Minimum Value Monitoring Function", 0.0    , "Min value eta");
-       pl->set<double>("Maximum Value Monitoring Function", 1.0e-16, "Max value eta");
-       pl->set<std::string>("Name", "Basic VS");
-       return pl;
-    }
+  virtual Scalar getAmplFactor() const { return rho_; }
+  virtual Scalar getReductFactor() const { return sigma_;}
+  virtual Scalar getMinEta() const { return minEta_; }
+  virtual Scalar getMaxEta() const { return maxEta_; }
 
-    Teuchos::RCP<Teuchos::ParameterList> getNonconstParameterList() override {
-       return tscsPL_;
-    }
+  virtual void setAmplFactor(Scalar rho) { rho_ = rho; this->isInitialized_ = false; }
+  virtual void setReductFactor(Scalar sigma) { sigma_ = sigma; this->isInitialized_ = false; }
+  virtual void setMinEta(Scalar minEta) { minEta_ = minEta; this->isInitialized_ = false; }
+  virtual void setMaxEta(Scalar maxEta) { maxEta_ = maxEta; this->isInitialized_ = false; }
 
-    Teuchos::RCP<Teuchos::ParameterList> unsetParameterList() override {
-       Teuchos::RCP<Teuchos::ParameterList> temp_plist = tscsPL_;
-       tscsPL_ = Teuchos::null;
-       return(temp_plist);
-    }
-  //@}
-
-  virtual Scalar getAmplFactor() const
-    { return tscsPL_->get<double>("Amplification Factor"); }
-  virtual Scalar getReductFactor() const
-    { return tscsPL_->get<double>("Reduction Factor");}
-  virtual Scalar getMinEta() const
-    { return tscsPL_->get<double>("Minimum Value Monitoring Function"); }
-  virtual Scalar getMaxEta() const
-    { return tscsPL_->get<double>("Maximum Value Monitoring Function"); }
-
-  virtual void setAmplFactor(Scalar rho)
-    { tscsPL_->set<double>("Amplification Factor", rho); }
-  virtual void setReductFactor(Scalar sigma)
-    { tscsPL_->set<double>("Reduction Factor", sigma); }
-  virtual void setMinEta(Scalar minEta)
-    { tscsPL_->set<double>("Minimum Value Monitoring Function", minEta); }
-  virtual void setMaxEta(Scalar maxEta)
-    { tscsPL_->set<double>("Maximum Value Monitoring Function", maxEta); }
 
 private:
 
-  Teuchos::RCP<Teuchos::ParameterList> tscsPL_;
+  Scalar rho_;      ///< Amplification Factor
+  Scalar sigma_;    ///< Reduction Factor
+  Scalar minEta_;   ///< Minimum Value Monitoring Function
+  Scalar maxEta_;   ///< Maximum Value Monitoring Function
 
 };
+
+
+/// Nonmember constructor.
+template <class Scalar>
+Teuchos::RCP<TimeStepControlStrategyBasicVS<Scalar> >
+createTimeStepControlStrategyBasicVS(
+  const Teuchos::RCP<Teuchos::ParameterList> & pList,
+  std::string name = "Basic VS")
+{
+  auto tscs = Teuchos::rcp(new TimeStepControlStrategyBasicVS<Scalar>());
+  if (pList == Teuchos::null) return tscs;
+
+  TEUCHOS_TEST_FOR_EXCEPTION(
+    pList->get<std::string>("Strategy Type", "Basic VS") != "Basic VS",
+    std::logic_error,
+    "Error - Strategy Type != 'Basic VS'.  (='"
+    +pList->get<std::string>("Strategy Type")+"')\n");
+
+  pList->validateParametersAndSetDefaults(*tscs->getValidParameters(), 0);
+
+  tscs->setAmplFactor(  pList->get<double>("Amplification Factor"));
+  tscs->setReductFactor(pList->get<double>("Reduction Factor"));
+  tscs->setMinEta(pList->get<double>("Minimum Value Monitoring Function"));
+  tscs->setMaxEta(pList->get<double>("Maximum Value Monitoring Function"));
+
+  tscs->setName(name);
+  tscs->initialize();
+
+  return tscs;
+}
+
+
+/// Nonmember function to return ParameterList with default values.
+template<class Scalar>
+Teuchos::RCP<Teuchos::ParameterList> getTimeStepControlStrategyBasicVS_PL()
+{
+  auto t = rcp(new Tempus::TimeStepControlStrategyBasicVS<Scalar>());
+  return Teuchos::rcp_const_cast<Teuchos::ParameterList> (t->getValidParameters());
+}
 
 
 } // namespace Tempus

--- a/packages/tempus/src/Tempus_TimeStepControlStrategyComposite.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategyComposite.hpp
@@ -10,6 +10,9 @@
 #define Tempus_TimeStepControlStrategyComposite_hpp
 
 #include "Tempus_TimeStepControlStrategy.hpp"
+#include "Tempus_TimeStepControlStrategyConstant.hpp"
+#include "Tempus_TimeStepControlStrategyBasicVS.hpp"
+#include "Tempus_TimeStepControlStrategyIntegralController.hpp"
 #include "Tempus_SolutionHistory.hpp"
 
 
@@ -17,7 +20,7 @@ namespace Tempus {
 
 template<class Scalar> class TimeStepControl;
 
-/** \brief TimeStepControlStrategyComposite loops over a vector of TimeStepControlStrategy.
+/** \brief TimeStepControlStrategyComposite loops over a vector of TimeStepControlStrategies.
  *
  *
  * Essentially, this is an <b>and</b> case if each strategies do a `min`
@@ -32,25 +35,34 @@ template<class Scalar> class TimeStepControl;
  *   - TimeStepControlStrategyBasicVS
  *   - TimeStepControlStrategyIntegralController
  *
- * <b>Note:<b> The ordering in the TimeStepControlStrategyComposite list is very important.
- * The final TimeStepControlStrategy from the composite could negate all previous step size updates.
+ * <b>Note:</b> The ordering in the TimeStepControlStrategyComposite
+ * list is very important.  The final TimeStepControlStrategy from
+ * the composite could negate all previous step size updates.
  */
 template<class Scalar>
-class TimeStepControlStrategyComposite : virtual public TimeStepControlStrategy<Scalar>
+class TimeStepControlStrategyComposite
+  : virtual public TimeStepControlStrategy<Scalar>
 {
 public:
 
   /// Constructor
-  TimeStepControlStrategyComposite(){}
+  TimeStepControlStrategyComposite()
+  {
+    this->setStrategyType("Composite");
+    this->setStepType("Variable");
+    this->isInitialized_ = false;
+  }
 
   /// Destructor
   virtual ~TimeStepControlStrategyComposite(){}
 
   /** \brief Determine the time step size.*/
-  virtual void getNextTimeStep(const TimeStepControl<Scalar> tsc, Teuchos::RCP<SolutionHistory<Scalar> > sh ,
-        Status & integratorStatus) override {
-     for(auto& s : strategies_)
-        s->getNextTimeStep(tsc, sh, integratorStatus);
+  virtual void setNextTimeStep(const TimeStepControl<Scalar> & tsc,
+                               Teuchos::RCP<SolutionHistory<Scalar> > sh,
+                               Status & integratorStatus) override
+  {
+    for(auto& s : strategies_)
+      s->setNextTimeStep(tsc, sh, integratorStatus);
   }
 
   /// \name Overridden from Teuchos::Describable
@@ -62,26 +74,207 @@ public:
                   const Teuchos::EVerbosityLevel verbLevel) const override
     {
       Teuchos::OSTab ostab(out,2,"describe");
-      out << description() << "::describe:" << std::endl;
+      out << description() << "::describe:" << std::endl
+          << "Strategy Type = " << this->getStrategyType()<< std::endl
+          << "Step Type     = " << this->getStepType()<< std::endl;
+
+      std::stringstream sList;
+      for(std::size_t i = 0; i < strategies_.size(); ++i) {
+        sList << strategies_[i]->getStrategyType();
+        if (i < strategies_.size()-1) sList << ", ";
+      }
+      out << "Strategy List = " << sList.str() << std::endl;
+
       for(auto& s : strategies_)
         s->describe(out, verbLevel);
     }
   //@}
 
   /** \brief Append strategy to the composite list.*/
-  void addStrategy(const Teuchos::RCP<TimeStepControlStrategy<Scalar> > &strategy){
-     if (Teuchos::nonnull(strategy))
-        strategies_.push_back(strategy);
+  void addStrategy(
+    const Teuchos::RCP<TimeStepControlStrategy<Scalar> > &strategy)
+  {
+    if (Teuchos::nonnull(strategy)) {
+      if (this->size() == 0) this->setStepType(strategy->getStepType());
+
+      TEUCHOS_TEST_FOR_EXCEPTION(this->getStepType() != strategy->getStepType(),
+        std::logic_error,
+        "Error - Cannot mix 'Constant' and 'Variable' step types.\n"
+        "strategies in composite!  Need at least one.\n");
+
+      strategies_.push_back(strategy);
+    }
   }
 
+  /** \brief Size of composite list.*/
+  virtual int size() const { return strategies_.size(); }
+
+  /** \brief Return composite list.*/
+  virtual std::vector<Teuchos::RCP<TimeStepControlStrategy<Scalar>>>
+  getStrategies() const { return strategies_; }
+
   /** \brief Clear the composite list.*/
-  void clearStrategies(){
-     strategies_.clear();
+  void clearStrategies() { strategies_.clear(); }
+
+  virtual void initialize() const override
+  {
+    TEUCHOS_TEST_FOR_EXCEPTION( strategies_.size() == 0, std::logic_error,
+      "Error - No strategies in composite!  Need at least one.\n");
+
+    for(auto& s : strategies_)
+      s->initialize();
+
+    auto strategy0 = strategies_[0];
+    for (auto& s : strategies_) {
+      TEUCHOS_TEST_FOR_EXCEPTION(s->isInitialized() == false, std::logic_error,
+        "Error - Composite strategy, "<< s->getName() <<" is not initialized!\n");
+
+      if (strategy0->getStepType() != s->getStepType()) {
+        std::ostringstream msg;
+        msg << "Error - All the Strategy Step Types must match.\n";
+        for(std::size_t i = 0; i < strategies_.size(); ++i) {
+          msg << "  Strategy[" << i << "] = "
+              << strategies_[i]->getStepType()
+              << "  (" << strategies_[i]->getName() << ")\n";
+        }
+        TEUCHOS_TEST_FOR_EXCEPTION( true, std::logic_error, msg.str());
+      }
+    }
+
+    this->isInitialized_ = true;   // Only place where this is set to true!
+  }
+
+  /// Return ParameterList with current values.
+  virtual Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const override
+  {
+    Teuchos::RCP<Teuchos::ParameterList> pl =
+      Teuchos::parameterList("Time Step Control Strategy");
+
+    pl->set<std::string>("Strategy Type", this->getStrategyType(), "Composite");
+
+    std::stringstream sList;
+    for(std::size_t i = 0; i < strategies_.size(); ++i) {
+      sList << strategies_[i]->getStrategyType();
+      if (i < strategies_.size()-1) sList << ", ";
+    }
+    pl->set<std::string>("Strategy List", sList.str());
+
+    for(auto& s : strategies_)
+      pl->set(s->getName(), *s->getValidParameters());
+
+    return pl;
   }
 
 private:
+
   std::vector<Teuchos::RCP<TimeStepControlStrategy<Scalar > > > strategies_;
 
 };
+
+
+// Nonmember constructor - ParameterList
+// ------------------------------------------------------------------------
+template <class Scalar>
+Teuchos::RCP<TimeStepControlStrategyComposite<Scalar> >
+createTimeStepControlStrategyComposite(
+  Teuchos::RCP<Teuchos::ParameterList> const& pList,
+  std::string name = "Composite")
+{
+  using Teuchos::RCP;
+  using Teuchos::ParameterList;
+
+  std::vector<std::string> tscsList;
+
+  TEUCHOS_TEST_FOR_EXCEPTION(
+    pList->get<std::string>("Strategy Type", "Composite") !=
+      "Composite", std::logic_error,
+    "Error - Strategy Type != 'Composite'.  (='"
+    +pList->get<std::string>("Strategy Type")+"')\n");
+
+  // string tokenizer
+  tscsList.clear();
+  std::string str = pList->get<std::string>("Strategy List");
+  std::string delimiters(",");
+  const char* WhiteSpace = " \t\v\r\n";
+  // Skip delimiters at the beginning
+  std::string::size_type lastPos = str.find_first_not_of(delimiters, 0);
+  // Find the first delimiter
+  std::string::size_type pos     = str.find_first_of(delimiters, lastPos);
+  while ((pos != std::string::npos) || (lastPos != std::string::npos)) {
+    // Found a token, add it to the vector
+    std::string token = str.substr(lastPos,pos-lastPos);
+
+    std::size_t start = token.find_first_not_of(WhiteSpace);
+    std::size_t end = token.find_last_not_of(WhiteSpace);
+    token = (start == end ? std::string() : token.substr(start, end-start+1));
+
+    tscsList.push_back(token);
+    if(pos==std::string::npos) break;
+
+    lastPos = str.find_first_not_of(delimiters, pos); // Skip delimiters
+    pos = str.find_first_of(delimiters, lastPos);     // Find next delimiter
+  }
+
+  auto tscsc = Teuchos::rcp(new TimeStepControlStrategyComposite<Scalar>());
+
+  // For each sublist name tokenized, add the TSCS
+  for ( auto tscsName: tscsList) {
+    RCP<ParameterList> pl =
+      Teuchos::rcp(new ParameterList(pList->sublist(tscsName)));
+
+    auto strategyType = pl->get<std::string>("Strategy Type", "Unknown");
+    if (strategyType == "Constant") {
+      tscsc->addStrategy(
+        createTimeStepControlStrategyConstant<Scalar>(pl, tscsName));
+    } else if (strategyType == "Basic VS") {
+      tscsc->addStrategy(
+        createTimeStepControlStrategyBasicVS<Scalar>(pl, tscsName));
+    } else if (strategyType == "Integral Controller") {
+      tscsc->addStrategy(
+        createTimeStepControlStrategyIntegralController<Scalar>(pl, tscsName));
+    } else if (strategyType == "Composite") {
+      tscsc->addStrategy(
+        createTimeStepControlStrategyComposite<Scalar>(pl, tscsName));
+    } else {
+      RCP<Teuchos::FancyOStream> out =
+        Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
+      Teuchos::OSTab ostab(out,1, "createTimeStepControlStrategyComposite()");
+      *out << "Warning -- Unknown strategy type!\n"
+           << "'Strategy Type' = '" << strategyType << "'\n"
+           << "Should call addStrategy() with this\n"
+           << "(app-specific?) strategy, and initialize().\n" << std::endl;
+    }
+
+  }
+
+  tscsc->setName(name);
+
+  if (tscsc->size() == 0) {
+    RCP<Teuchos::FancyOStream> out =
+      Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
+    Teuchos::OSTab ostab(out,1, "createTimeStepControlStrategyComposite()");
+    *out << "Warning -- Did not find a Tempus strategy to create!\n"
+         << "Should call addStrategy() with (app-specific?) strategy(ies),\n"
+         << "and initialize().\n" << std::endl;
+  } else {
+    tscsc->initialize();
+  }
+
+  return tscsc;
+
+}
+
+
+/// Nonmember function to return ParameterList with default values.
+template<class Scalar>
+Teuchos::RCP<Teuchos::ParameterList> getTimeStepControlStrategyCompositePL()
+{
+  auto t = rcp(new Tempus::TimeStepControlStrategyComposite<Scalar>());
+  auto tscs = rcp(new Tempus::TimeStepControlStrategyConstant<double>());
+  t->addStrategy(tscs);
+  return Teuchos::rcp_const_cast<Teuchos::ParameterList> (t->getValidParameters());
+}
+
+
 } // namespace Tempus
 #endif // Tempus_TimeStepControlStrategy_hpp

--- a/packages/tempus/src/Tempus_TimeStepControlStrategyConstant.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategyConstant.hpp
@@ -27,58 +27,92 @@ class TimeStepControlStrategyConstant
 {
 public:
 
-  /// Constructor
-  TimeStepControlStrategyConstant(){}
+  /// Default Constructor
+  TimeStepControlStrategyConstant()
+    : constantTimeStep_(0.0)
+  {
+    this->setStrategyType("Constant");
+    this->setStepType("Constant");
+    this->setName("Constant");
+    this->initialize();
+  }
+
+  /// Full Constructor
+  TimeStepControlStrategyConstant(Scalar constantTimeStep,
+    std::string name = "Constant")
+    : constantTimeStep_(constantTimeStep)
+  {
+    this->setStrategyType("Constant");
+    this->setStepType("Constant");
+    this->setName(name);
+    this->initialize();
+  }
 
   /// Destructor
   virtual ~TimeStepControlStrategyConstant(){}
 
   /** \brief Determine the time step size.*/
-  virtual void getNextTimeStep(const TimeStepControl<Scalar> tsc,
+  virtual void setNextTimeStep(const TimeStepControl<Scalar> & tsc,
     Teuchos::RCP<SolutionHistory<Scalar> > solutionHistory,
     Status & integratorStatus) override
   {
-     using Teuchos::RCP;
-     RCP<SolutionState<Scalar> >workingState=solutionHistory->getWorkingState();
-     const Scalar errorAbs = workingState->getErrorAbs();
-     const Scalar errorRel = workingState->getErrorRel();
-     Scalar dt = workingState->getTimeStep();
+    using Teuchos::RCP;
 
-     dt = tsc.getInitTimeStep();
+    this->checkInitialized();
 
-     RCP<Teuchos::FancyOStream> out = tsc.getOStream();
-     Teuchos::OSTab ostab(out,1,"getNextTimeStep");
+    RCP<SolutionState<Scalar> >workingState=solutionHistory->getWorkingState();
+    const Scalar errorAbs = workingState->getErrorAbs();
+    const Scalar errorRel = workingState->getErrorRel();
+    Scalar dt = workingState->getTimeStep();
 
-     // Stepper failure
-     if (workingState->getSolutionStatus() == Status::FAILED) {
-       *out << "Failure - Stepper failed and can not change time step size!\n"
-            << "    Time step type == CONSTANT_STEP_SIZE\n" << std::endl;
-       integratorStatus = FAILED;
-       return;
-     }
+    RCP<Teuchos::FancyOStream> out = tsc.getOStream();
+    Teuchos::OSTab ostab(out,1,"setNextTimeStep");
 
-     // Absolute error failure
-     if (errorAbs > tsc.getMaxAbsError()) {
-       *out << "Failure - Absolute error failed and can not change time step!\n"
-            << "  Time step type == CONSTANT_STEP_SIZE\n"
-            << "  (errorAbs ="<<errorAbs<<") > (errorMaxAbs ="
-            << tsc.getMaxAbsError() << ")" << std::endl;
-       integratorStatus = FAILED;
-       return;
-     }
 
-     // Relative error failure
-     if (errorRel > tsc.getMaxRelError()) {
-       *out << "Failure - Relative error failed and can not change time step!\n"
-          << "  Time step type == CONSTANT_STEP_SIZE\n"
-          << "  (errorRel ="<<errorRel<<") > (errorMaxRel ="
-          << tsc.getMaxRelError() << ")" << std::endl;
-       integratorStatus = FAILED;
-       return;
-     }
+    // Check constant time step
+    if ( dt != tsc.getInitTimeStep() ) {
+      tsc.printDtChanges(workingState->getIndex(), dt, tsc.getInitTimeStep(),
+                         "Resetting constant dt.");
+      dt = tsc.getInitTimeStep();
+    }
 
-     // update dt
-     workingState->setTimeStep(dt);
+    // Stepper failure
+    if (workingState->getSolutionStatus() == Status::FAILED) {
+      *out << "Failure - Stepper failed and can not change time step size!\n"
+           << "    Time step type == CONSTANT_STEP_SIZE\n" << std::endl;
+      integratorStatus = FAILED;
+      return;
+    }
+
+    // Absolute error failure
+    if (errorAbs > tsc.getMaxAbsError()) {
+      *out << "Failure - Absolute error failed and can not change time step!\n"
+           << "  Time step type == CONSTANT_STEP_SIZE\n"
+           << "  (errorAbs ="<<errorAbs<<") > (errorMaxAbs ="
+           << tsc.getMaxAbsError() << ")" << std::endl;
+      integratorStatus = FAILED;
+      return;
+    }
+
+    // Relative error failure
+    if (errorRel > tsc.getMaxRelError()) {
+      *out << "Failure - Relative error failed and can not change time step!\n"
+         << "  Time step type == CONSTANT_STEP_SIZE\n"
+         << "  (errorRel ="<<errorRel<<") > (errorMaxRel ="
+         << tsc.getMaxRelError() << ")" << std::endl;
+      integratorStatus = FAILED;
+      return;
+    }
+
+    // update dt
+    workingState->setTimeStep(dt);
+
+    // Set time from initial time, dt, and index to avoid numerical roundoff.
+    const Scalar initTime = tsc.getInitTime();
+    const int initIndex   = tsc.getInitIndex();
+    const int index       = workingState->getIndex();
+    const Scalar time     = (index-initIndex)*dt + initTime;
+    workingState->setTime(time);
   }
 
 
@@ -91,11 +125,78 @@ public:
                   const Teuchos::EVerbosityLevel verbLevel) const override
     {
       Teuchos::OSTab ostab(out,2,"describe");
-      out << description() << std::endl;
+      out << description() << std::endl
+          << "Strategy Type = " << this->getStrategyType() << std::endl
+          << "Step Type     = " << this->getStepType() << std::endl
+          << "Time Step     = " << getConstantTimeStep() << std::endl;
     }
   //@}
 
+  /// Return ParameterList with current values.
+  virtual Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const override
+  {
+    Teuchos::RCP<Teuchos::ParameterList> pl =
+      Teuchos::parameterList("Time Step Control Strategy");
+
+    pl->set<std::string>("Strategy Type", this->getStrategyType(), "Constant");
+    pl->set<double>("Time Step", getConstantTimeStep());
+
+    return pl;
+  }
+
+
+  virtual void initialize() const override
+  {
+    this->isInitialized_ = true;   // Only place where this is set to true!
+  }
+
+  virtual Scalar getConstantTimeStep() const { return constantTimeStep_; }
+
+  virtual void setConstantTimeStep(Scalar dt)
+  { constantTimeStep_ = dt; this->isInitialized_ = false; }
+
+
+private:
+
+  Scalar constantTimeStep_;   ///< Constant time step size.
+
 };
+
+
+/// Nonmember constructor.
+template <class Scalar>
+Teuchos::RCP<TimeStepControlStrategyConstant<Scalar> >
+createTimeStepControlStrategyConstant(
+  const Teuchos::RCP<Teuchos::ParameterList> & pList,
+  std::string name = "Constant")
+{
+  auto tscs = Teuchos::rcp(new TimeStepControlStrategyConstant<Scalar>());
+  if (pList == Teuchos::null) return tscs;
+
+  TEUCHOS_TEST_FOR_EXCEPTION(
+    pList->get<std::string>("Strategy Type", "Constant") != "Constant",
+    std::logic_error,
+    "Error - Strategy Type != 'Constant'.  (='"
+    +pList->get<std::string>("Strategy Type")+"')\n");
+
+  pList->validateParametersAndSetDefaults(*tscs->getValidParameters(), 0);
+
+  tscs->setConstantTimeStep(pList->get<double>("Time Step"));
+
+  tscs->setName(name);
+  tscs->initialize();
+
+  return tscs;
+}
+
+
+/// Nonmember function to return ParameterList with default values.
+template<class Scalar>
+Teuchos::RCP<Teuchos::ParameterList> getTimeStepControlStrategyConstantPL()
+{
+  auto t = rcp(new Tempus::TimeStepControlStrategyConstant<Scalar>());
+  return Teuchos::rcp_const_cast<Teuchos::ParameterList> (t->getValidParameters());
+}
 
 
 } // namespace Tempus

--- a/packages/tempus/src/Tempus_TimeStepControlStrategyIntegralController.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategyIntegralController.hpp
@@ -30,22 +30,27 @@ namespace Tempus {
  * PID = Proportional-Integral-Derivative Controller
  * \f[
  *      (\Delta t)_{n+1} =
- *      (\Delta t)_n \left( \epsilon_n ^{-k_1 / p} \epsilon_{n-1}^{k_2 / p} \epsilon_{n-2}^{-k_3 / p} \right)
+ *      (\Delta t)_n \left( \epsilon_n ^{-k_I / p}
+ *           \epsilon_{n-1}^{k_P / p} \epsilon_{n-2}^{-k_D / p} \right)
  * \f]
  *
  * PI = Proportional-Integral Controller
  * \f[
  *      (\Delta t)_{n+1} =
- *      (\Delta t)_n \left( \epsilon_n ^{-k_1 / p} \epsilon_{n-1}^{k_2 / p} \right)
+ *      (\Delta t)_n \left( \epsilon_n ^{-k_I / p}
+ *           \epsilon_{n-1}^{k_P / p} \right)
  * \f]
  *
  * I = Integral Controller
  * \f[
  *      (\Delta t)_{n+1} =
- *      (\Delta t)_n \left( \epsilon_n ^{-k_1 / p} \right)
+ *      (\Delta t)_n \left( \epsilon_n ^{-k_I / p} \right)
  * \f]
  *
- * where \f$\epsilon_n \f$ is the error at time step \f$n\f$.
+ * where \f$\epsilon_n \f$ is the error at time step \f$n\f$
+ * and \f$p\f$ is the order of the embedded solution, which
+ * is assumed to be the low order solution (i.e., the time
+ * step order minus one).
  *
  * Appropriate for Explicit Methods
  */
@@ -55,91 +60,115 @@ class TimeStepControlStrategyIntegralController
 {
 public:
 
-  /// Constructor
-  TimeStepControlStrategyIntegralController(Teuchos::RCP<Teuchos::ParameterList> pList = Teuchos::null){
-     this->setParameterList(pList);
+  /// Default Constructor
+  TimeStepControlStrategyIntegralController()
+    : controller_("PID"), KI_(0.58), KP_(0.21), KD_(0.10),
+      safetyFactor_(0.90), safetyFactorAfterReject_(0.9),
+      facMax_(5.0), facMin_(0.5)
+  {
+    errN_ = Scalar(1.0);
+    errNm1_ = Scalar(1.0);
+    errNm2_ = Scalar(1.0);
+    facMaxINPUT_ = facMax_;
+
+    this->setStrategyType("Integral Controller");
+    this->setStepType("Variable");
+    this->setName("Integral Controller");
+    this->initialize();
   }
+
+  /// Full Constructor
+  TimeStepControlStrategyIntegralController( std::string controller,
+    Scalar KI, Scalar KP, Scalar KD,
+    Scalar safetyFactor, Scalar safetyFactorAfterReject,
+    Scalar facMax, Scalar facMin, std::string name = "Integral Controller")
+    : controller_(controller), KI_(KI), KP_(KP), KD_(KD),
+      safetyFactor_(safetyFactor),
+      safetyFactorAfterReject_(safetyFactorAfterReject),
+      facMax_(facMax), facMin_(facMin)
+  {
+    errN_ = Scalar(1.0);
+    errNm1_ = Scalar(1.0);
+    errNm2_ = Scalar(1.0);
+    facMaxINPUT_ = facMax_;
+
+    this->setStrategyType("Integral Controller");
+    this->setStepType("Variable");
+    this->setName(name);
+    this->initialize();
+  }
+
 
   /// Destructor
   virtual ~TimeStepControlStrategyIntegralController(){}
 
-  /** \brief Determine the time step size.*/
-  virtual void getNextTimeStep(const TimeStepControl<Scalar> tsc,
+  /** \brief Set the time step size.*/
+  virtual void setNextTimeStep(const TimeStepControl<Scalar> & tsc,
     Teuchos::RCP<SolutionHistory<Scalar> > solutionHistory,
     Status & /* integratorStatus */) override
   {
+    using Teuchos::RCP;
 
-     // Take first step with initial time step provided
-     if (!firstSuccessfulStep_){
-        firstSuccessfulStep_ = true;
-        return;
-     }
+    this->checkInitialized();
 
-     Teuchos::RCP<SolutionState<Scalar> > workingState=solutionHistory->getWorkingState();
-     const Scalar errorRel = workingState->getErrorRel();
-     Scalar beta = 1.0;
+    // Take first step with initial time step provided
+    if (!firstSuccessfulStep_){
+      firstSuccessfulStep_ = true;
+      return;
+    }
 
-     // assumes the embedded solution is the low order solution
-     int order = workingState->getOrder() - 1;
-     Scalar dt = workingState->getTimeStep();
-     //bool printDtChanges = tsc.getPrintDtChanges();
+    RCP<SolutionState<Scalar> > workingState=solutionHistory->getWorkingState();
+    const Scalar errorRel = workingState->getErrorRel();
+    Scalar beta = 1.0;
 
-     Teuchos::RCP<Teuchos::FancyOStream> out = tsc.getOStream();
-     Teuchos::OSTab ostab(out,1,"getNextTimeStep");
+    // assumes the embedded solution is the low order solution
+    int order = workingState->getOrder() - 1;
+    Scalar dt = workingState->getTimeStep();
 
-     // For now, only time step is changed (not order)
-     /*
-     auto changeOrder = [] (int order_old, int order_new, std::string reason) {
-        std::stringstream message;
-        message << "     (order = " << std::setw(2) << order_old
-           <<       ", new = " << std::setw(2) << order_new
-           << ")  " << reason << std::endl;
-        return message.str();
-     };
-     */
+    // update errors
+    errNm2_ = errNm1_;
+    errNm1_ = errN_;
+    errN_ = errorRel;
 
-     // update errors
-     errNm2_ = errNm1_;
-     errNm1_ = errN_;
-     errN_ = errorRel;
+    Scalar k1 = Teuchos::as<Scalar>(-KI_ / order);
+    Scalar k2 = Teuchos::as<Scalar>( KP_ / order);
+    Scalar k3 = Teuchos::as<Scalar>(-KD_ / order);
 
-     Scalar k1 = Teuchos::as<Scalar>(-k1_ / order);
-     Scalar k2 = Teuchos::as<Scalar>(k2_ / order);
-     Scalar k3 = Teuchos::as<Scalar>(-k3_ / order);
+    k1 = std::pow(errN_, k1);
+    k2 = std::pow(errNm1_, k2);
+    k3 = std::pow(errNm2_, k3);
 
-     k1 = std::pow(errN_, k1);
-     k2 = std::pow(errNm1_, k2);
-     k3 = std::pow(errNm2_, k3);
+    if (controller_ == "I")
+       beta = safetyFactor_*k1;
+    else if (controller_ == "PI")
+       beta = safetyFactor_ *k1*k2;
+    else // (controller_ == "PID")
+       beta = safetyFactor_*k1*k2*k3;
 
-     if (controller_ == "I")
-        beta = safetyFactor_*k1;
-     else if (controller_ == "PI")
-        beta = safetyFactor_ *k1*k2;
-     else // (controller_ == "PID")
-        beta = safetyFactor_*k1*k2*k3;
+    beta = std::max(facMin_, beta);
+    beta = std::min(facMax_, beta);
 
-     beta = std::max(facMin_, beta);
-     beta = std::min(facMax_, beta);
+    // new (optimal) suggested time step
+    dt = beta * dt;
 
-     // new (optimal) suggested time step
-     dt = beta * dt;
+    if (workingState->getSolutionStatus() == Status::PASSED or
+        workingState->getSolutionStatus() == Status::WORKING) {
+      if(lastStepRejected_){
+         dt = std::min(dt, workingState->getTimeStep());
+      } else {
+         facMax_ = facMaxINPUT_;
+      }
+      lastStepRejected_ = false;
+    } else {
+      facMax_ = safetyFactorAfterReject_;
+      lastStepRejected_ = true;
+    }
 
-     if (workingState->getSolutionStatus() == Status::PASSED or
-         workingState->getSolutionStatus() == Status::WORKING) {
-        if(lastStepRejected_){
-           dt = std::min(dt, workingState->getTimeStep());
-        } else {
-           facMax_ = tscsPL_->get<Scalar>("Maximum Safety Factor");
-        }
-        lastStepRejected_ = false;
-     } else {
-        facMax_ = tscsPL_->get<Scalar>("Safety Factor After Step Rejection");
-        lastStepRejected_ = true;
-     }
-
-     // update dt
-     workingState->setTimeStep(dt);
+    // update dt
+    workingState->setTimeStep(dt);
+    workingState->setTime(solutionHistory->getCurrentState()->getTime() + dt);
   }
+
 
   /// \name Overridden from Teuchos::Describable
   //@{
@@ -151,113 +180,150 @@ public:
     {
       Teuchos::OSTab ostab(out,2,"describe");
       out << description() << "::describe:" << std::endl
-          << "Name                               = " << tscsPL_->get<std::string>("Name") << std::endl
-          << "Controller Type                    = " << controller_   << std::endl
-          << "KI                                 = " << k1_           << std::endl
-          << "KP                                 = " << k2_           << std::endl
-          << "KD                                 = " << k3_           << std::endl
-          << "errN_                              = " << errN_         << std::endl
-          << "errNm1_                            = " << errNm1_       << std::endl
-          << "errNm2_                            = " << errNm2_       << std::endl
-          << "Safety Factor                      = " << safetyFactor_ << std::endl
-          << "Maximum Safety Factor              = " << facMax_       << std::endl
-          << "Minimum Safety Factor              = " << facMin_       << std::endl
-          << "Safety Factor After Step Rejection = " << tscsPL_->get<Scalar>("Safety Factor After Step Rejection")       << std::endl;
+          << "Strategy Type                      = " << this->getStrategyType() << std::endl
+          << "Step Type                          = " << this->getStepType()     << std::endl
+          << "Controller Type                    = " << getController()         << std::endl
+          << "KI                                 = " << getKI()                 << std::endl
+          << "KP                                 = " << getKP()                 << std::endl
+          << "KD                                 = " << getKD()                 << std::endl
+          << "errN_                              = " << errN_                   << std::endl
+          << "errNm1_                            = " << errNm1_                 << std::endl
+          << "errNm2_                            = " << errNm2_                 << std::endl
+          << "Safety Factor                      = " << getSafetyFactor()       << std::endl
+          << "Safety Factor After Step Rejection = " << getSafetyFactorAfterReject() << std::endl
+          << "Maximum Safety Factor (INPUT)      = " << facMaxINPUT_            << std::endl
+          << "Maximum Safety Factor              = " << getFacMax()             << std::endl
+          << "Minimum Safety Factor              = " << getFacMin()             << std::endl;
     }
   //@}
 
-  /// \name Overridden from Teuchos::ParameterListAcceptor
-  //@{
-  void setParameterList(
-    const Teuchos::RCP<Teuchos::ParameterList> & pList) override
+  /// Return ParameterList with current values.
+  virtual Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const override
   {
+    Teuchos::RCP<Teuchos::ParameterList> pl =
+      Teuchos::parameterList("Time Step Control Strategy");
 
-     if (pList == Teuchos::null) {
-        // Create default parameters if null, otherwise keep current parameters.
-        if (tscsPL_ == Teuchos::null) {
-           tscsPL_ = Teuchos::parameterList("TimeStepControlStrategyIntegralController");
-           *tscsPL_= *(this->getValidParameters());
-        }
-     } else {
-        tscsPL_ = pList;
-     }
-     tscsPL_->validateParametersAndSetDefaults(*this->getValidParameters());
-
-     errN_ = Scalar(1.0);
-     errNm1_ = Scalar(1.0);
-     errNm2_ = Scalar(1.0);
-     k1_ = tscsPL_->get<Scalar>("KI");
-     k2_ = tscsPL_->get<Scalar>("KP");
-     k3_ = tscsPL_->get<Scalar>("KD");
-     safetyFactor_ = tscsPL_->get<Scalar>("Safety Factor");
-     facMax_ = tscsPL_->get<Scalar>("Maximum Safety Factor");
-     facMin_ = tscsPL_->get<Scalar>("Minimum Safety Factor");
-     controller_ = tscsPL_->get<std::string>("Controller Type");
-
-     TEUCHOS_TEST_FOR_EXCEPTION(safetyFactor_ <= 0.0, std::out_of_range,
-     "Error - Invalid value of Safety Factory= " << safetyFactor_ << "!  \n"
-     << "Safety Factor must be > 0.0.\n");
-
-     TEUCHOS_TEST_FOR_EXCEPTION(facMax_ <= 0.0, std::out_of_range,
-     "Error - Invalid value of Maximum Safety Factory= " << facMax_ << "!  \n"
-     << "Maximum Safety Factor must be > 0.0.\n");
-
-     TEUCHOS_TEST_FOR_EXCEPTION(facMax_<= 0.0, std::out_of_range,
-     "Error - Invalid value of Minimum Safety Factory= " << facMin_ << "!  \n"
-     << "Minimum Safety Factor must be > 0.0.\n");
-
-     TEUCHOS_TEST_FOR_EXCEPTION(((controller_ != "I") and
-                                 (controller_ != "PI") and
-                                 (controller_ != "PID")), std::invalid_argument,
-     "Error - Invalid choice of Controller Type = " << controller_ << "!  \n"
-     << "Valid Choice are ['I', 'PI', 'PID'].\n");
-
+    pl->set<std::string>("Strategy Type", this->getStrategyType(), "Integral Controller");
+    pl->set<std::string>("Controller Type", getController(),
+                         "Proportional-Integral-Derivative");
+    pl->set<Scalar>("KI" , getKI(), "Integral gain");
+    pl->set<Scalar>("KP" , getKP(), "Proportional gain");
+    pl->set<Scalar>("KD" , getKD(), "Derivative gain");
+    pl->set<Scalar>("Safety Factor" , getSafetyFactor(), "Safety Factor");
+    pl->set<Scalar>("Safety Factor After Step Rejection",
+                    getSafetyFactorAfterReject(),
+                    "Safety Factor Following Step Rejection");
+    pl->set<Scalar>("Maximum Safety Factor" , getFacMax(), "Maximum Safety Factor");
+    pl->set<Scalar>("Minimum Safety Factor" , getFacMin(), "Minimum Safety Factor");
+    return pl;
   }
 
-  Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const override
+
+  virtual void initialize() const override
   {
-     Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
+    TEUCHOS_TEST_FOR_EXCEPTION(safetyFactor_ <= 0.0, std::out_of_range,
+    "Error - Invalid value of Safety Factory= " << safetyFactor_ << "!  \n"
+    << "Safety Factor must be > 0.0.\n");
 
-     pl->set<std::string>("Name","Integral Controller","Integral Controller");
-     pl->set<std::string>("Controller Type","PID",
-                          "Proportional-Integral-Derivative");
-     pl->set<Scalar>("KI" , 0.58, "Integral gain");
-     pl->set<Scalar>("KP" , 0.21, "Proportional gain");
-     pl->set<Scalar>("KD" , 0.10, "Derivative gain");
-     pl->set<Scalar>("Safety Factor" , 0.90, "Safety Factor");
-     pl->set<Scalar>("Maximum Safety Factor" , 5.0, "Maximum Safety Factor");
-     pl->set<Scalar>("Minimum Safety Factor" , 0.5, "Minimum Safety Factor");
-     pl->set<Scalar>("Safety Factor After Step Rejection" , 0.9,
-                     "Safety Factor Following Step Rejection");
-     return pl;
+    TEUCHOS_TEST_FOR_EXCEPTION(facMax_ <= 0.0, std::out_of_range,
+    "Error - Invalid value of Maximum Safety Factory= " << facMax_ << "!  \n"
+    << "Maximum Safety Factor must be > 0.0.\n");
+
+    TEUCHOS_TEST_FOR_EXCEPTION(facMax_<= 0.0, std::out_of_range,
+    "Error - Invalid value of Minimum Safety Factory= " << facMin_ << "!  \n"
+    << "Minimum Safety Factor must be > 0.0.\n");
+
+    TEUCHOS_TEST_FOR_EXCEPTION(((controller_ != "I") and
+                                (controller_ != "PI") and
+                                (controller_ != "PID")), std::invalid_argument,
+    "Error - Invalid choice of Controller Type = " << controller_ << "!  \n"
+    << "Valid Choice are ['I', 'PI', 'PID'].\n");
+
+    this->isInitialized_ = true;   // Only place where this is set to true!
   }
 
-  Teuchos::RCP<Teuchos::ParameterList> getNonconstParameterList() override {
-     return tscsPL_;
-  }
 
-  Teuchos::RCP<Teuchos::ParameterList> unsetParameterList() override {
-     Teuchos::RCP<Teuchos::ParameterList> temp_plist = tscsPL_;
-     tscsPL_ = Teuchos::null;
-     return(temp_plist);
-  }
-  //@}
+  virtual std::string getController() const { return controller_; }
+  virtual Scalar getKI() const { return KI_; }
+  virtual Scalar getKP() const { return KP_; }
+  virtual Scalar getKD() const { return KD_; }
+  virtual Scalar getSafetyFactor() const { return safetyFactor_; }
+  virtual Scalar getSafetyFactorAfterReject() const { return safetyFactorAfterReject_; }
+  virtual Scalar getFacMax() const { return facMax_; }
+  virtual Scalar getFacMin() const { return facMin_; }
+
+  virtual void setController(std::string c) { controller_ = c; this->isInitialized_ = false; }
+  virtual void setKI(Scalar k) { KI_ = k; this->isInitialized_ = false; }
+  virtual void setKP(Scalar k) { KP_ = k; this->isInitialized_ = false; }
+  virtual void setKD(Scalar k) { KD_ = k; this->isInitialized_ = false; }
+  virtual void setSafetyFactor(Scalar f) { safetyFactor_ = f; this->isInitialized_ = false; }
+  virtual void setSafetyFactorAfterReject(Scalar f) { safetyFactorAfterReject_ = f; this->isInitialized_ = false; }
+  virtual void setFacMax(Scalar f) { facMax_ = f; facMaxINPUT_ = f; this->isInitialized_ = false; }
+  virtual void setFacMin(Scalar f) { facMin_ = f; this->isInitialized_ = false; }
 
 private:
-    Teuchos::RCP<Teuchos::ParameterList> tscsPL_;
-    Scalar k1_;
-    Scalar k2_;
-    Scalar k3_;
-    Scalar errN_;
-    Scalar errNm1_;
-    Scalar errNm2_;
-    Scalar safetyFactor_;
-    Scalar facMax_;
-    Scalar facMin_;
-    bool firstSuccessfulStep_ = false;
-    bool lastStepRejected_ = false;
-    std::string controller_;
+
+  std::string controller_;          ///< Control type ['I', 'PI', 'PID']
+  Scalar KI_;                       ///< Integral gain
+  Scalar KP_;                       ///< Proportional gain
+  Scalar KD_;                       ///< Derivative gain
+  Scalar errN_;
+  Scalar errNm1_;
+  Scalar errNm2_;
+  Scalar safetyFactor_;             ///< Safety Factor
+  Scalar safetyFactorAfterReject_;  ///< Safety Factor Following Step Rejection
+  Scalar facMaxINPUT_;              ///< Maximum Safety Factor from input
+  Scalar facMax_;                   ///< Maximum Safety Factor
+  Scalar facMin_;                   ///< Minimum Safety Factor
+  bool firstSuccessfulStep_ = false;
+  bool lastStepRejected_ = false;
 
 };
+
+
+// Nonmember constructor.
+template <class Scalar>
+Teuchos::RCP<TimeStepControlStrategyIntegralController<Scalar> >
+createTimeStepControlStrategyIntegralController(
+  const Teuchos::RCP<Teuchos::ParameterList> pList,
+  std::string name = "Integral Controller")
+{
+  using Teuchos::rcp;
+  auto tscs = rcp(new TimeStepControlStrategyIntegralController<Scalar>());
+  if (pList == Teuchos::null) return tscs;
+
+  TEUCHOS_TEST_FOR_EXCEPTION(
+    pList->get<std::string>("Strategy Type", "Integral Controller") !=
+      "Integral Controller", std::logic_error,
+    "Error - Strategy Type != 'Integral Controller'.  (='"
+    +pList->get<std::string>("Strategy Type")+"')\n");
+
+  pList->validateParametersAndSetDefaults(*tscs->getValidParameters());
+
+  tscs->setController  (pList->get<std::string>("Controller Type"));
+  tscs->setKI          (pList->get<Scalar>("KI"));
+  tscs->setKP          (pList->get<Scalar>("KP"));
+  tscs->setKD          (pList->get<Scalar>("KD"));
+  tscs->setSafetyFactor(pList->get<Scalar>("Safety Factor"));
+  tscs->setSafetyFactorAfterReject(pList->get<Scalar>("Safety Factor After Step Rejection"));
+  tscs->setFacMax      (pList->get<Scalar>("Maximum Safety Factor"));
+  tscs->setFacMin      (pList->get<Scalar>("Minimum Safety Factor"));
+
+  tscs->setName(name);
+  tscs->initialize();
+
+  return tscs;
+}
+
+
+/// Nonmember function to return ParameterList with default values.
+template<class Scalar>
+Teuchos::RCP<Teuchos::ParameterList> getTimeStepControlStrategyIntegralControllerPL()
+{
+  auto t = rcp(new Tempus::TimeStepControlStrategyIntegralController<Scalar>());
+  return Teuchos::rcp_const_cast<Teuchos::ParameterList> (t->getValidParameters());
+}
+
+
 } // namespace Tempus
 #endif // Tempus_TimeStepControlStrategy_IntegralController_hpp

--- a/packages/tempus/src/Tempus_TimeStepControl_decl.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControl_decl.hpp
@@ -205,9 +205,11 @@ protected:
 
 
 /// Nonmember constructor from ParameterList.
+// ------------------------------------------------------------------------
 template<class Scalar>
 Teuchos::RCP<TimeStepControl<Scalar> > createTimeStepControl(
-  Teuchos::RCP<Teuchos::ParameterList> const& pList);
+  Teuchos::RCP<Teuchos::ParameterList> const& pList,
+  bool runInitialize = true);
 
 /// Nonmember function to return ParameterList with default values.
 template<class Scalar>
@@ -216,7 +218,6 @@ Teuchos::RCP<Teuchos::ParameterList> getTimeStepControlPL()
   auto tsc = rcp(new Tempus::TimeStepControl<Scalar>());
   return Teuchos::rcp_const_cast<Teuchos::ParameterList> (tsc->getValidParameters());
 }
-
 
 
 } // namespace Tempus

--- a/packages/tempus/src/Tempus_TimeStepControl_decl.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControl_decl.hpp
@@ -16,7 +16,7 @@
 // Tempus
 #include "Tempus_config.hpp"
 #include "Tempus_SolutionHistory.hpp"
-#include "Tempus_TimeStepControlStrategyComposite.hpp"
+#include "Tempus_TimeStepControlStrategyBasicVS.hpp"
 #include "Tempus_Stepper.hpp"
 
 #include <iostream>
@@ -41,7 +41,7 @@ namespace Tempus {
  *
  *  Using TimeStepControlStrategy allows applications to define their
  *  very own strategy used to determine the next time step size
- *  (`getNextTimeStep()`).  Applications can define multiple strategies
+ *  (`setNextTimeStep()`).  Applications can define multiple strategies
  *  and add it to a vector of strategies TimeStepControlStrategyComposite
  *  using setTimeStepControlStrategy().  TimeStepControlStrategyComposite
  *  iterates over the list of strategies to determine the "optimal"
@@ -69,7 +69,6 @@ public:
     int                 finalIndex,
     Scalar              maxAbsError,
     Scalar              maxRelError,
-    std::string         stepType,
     int                 maxFailures,
     int                 maxConsecFailures,
     int                 numTimeSteps,
@@ -79,15 +78,23 @@ public:
     std::vector<Scalar> outputTimes,
     int                 outputIndexInterval,
     Scalar              outputTimeInterval,
-    Teuchos::RCP<TimeStepControlStrategyComposite<Scalar>> stepControlStrategy);
+    Teuchos::RCP<TimeStepControlStrategy<Scalar>> stepControlStrategy);
 
   /// Destructor
   virtual ~TimeStepControl() {}
 
-  virtual void initialize();
+#ifndef TEMPUS_HIDE_DEPRECATED_CODE
+  /// Deprecated get the time step size.
+  virtual void getNextTimeStep(
+    const Teuchos::RCP<SolutionHistory<Scalar> > & sh,
+    Status & integratorStatus)
+  {
+    this->setNextTimeStep(sh, integratorStatus);
+  };
+#endif
 
   /** \brief Determine the time step size.*/
-  virtual void getNextTimeStep(
+  virtual void setNextTimeStep(
     const Teuchos::RCP<SolutionHistory<Scalar> > & solutionHistory,
     Status & integratorStatus);
 
@@ -97,11 +104,8 @@ public:
   /** \brief Check if time step index is within minimum and maximum index. */
   virtual bool indexInRange(const int iStep) const;
 
-  /** \brief Set the TimeStepControlStrategy. */
-  virtual void setTimeStepControlStrategy(
-        Teuchos::RCP<TimeStepControlStrategy<Scalar> > tscs = Teuchos::null);
-
-  Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
+  /// Return ParameterList with current values.
+  virtual Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
 
   /// \name Overridden from Teuchos::Describable
   //@{
@@ -112,6 +116,7 @@ public:
 
   /// \name Get accessors
   //@{
+    virtual std::string getStepType() const { return stepControlStrategy_->getStepType(); }
     virtual Scalar getInitTime() const { return initTime_; }
     virtual Scalar getFinalTime() const { return finalTime_; }
     virtual Scalar getMinTimeStep() const { return minTimeStep_; }
@@ -121,12 +126,6 @@ public:
     virtual int getFinalIndex() const { return finalIndex_; }
     virtual Scalar getMaxAbsError() const { return maxAbsError_; }
     virtual Scalar getMaxRelError() const { return maxRelError_; }
-#ifndef TEMPUS_HIDE_DEPRECATED_CODE
-    virtual int getMinOrder() const { return -1; }
-    virtual int getInitOrder() const { return -1; }
-    virtual int getMaxOrder() const { return -1; }
-#endif
-    virtual std::string getStepType() const { return stepType_; }
     virtual bool getOutputExactly() const { return outputExactly_; }
     virtual std::vector<int> getOutputIndices() const { return outputIndices_; }
     virtual std::vector<Scalar> getOutputTimes() const { return outputTimes_; }
@@ -141,7 +140,7 @@ public:
     virtual Scalar getOutputTimeInterval() const { return outputTimeInterval_;}
   //@}
 
-  /// \name Set accesors
+  /// \name Set accessors
   //@{
     virtual void setInitTime(Scalar t) { initTime_ = t; isInitialized_ = false; }
     virtual void setFinalTime(Scalar t) { finalTime_ = t; isInitialized_ = false; }
@@ -152,12 +151,6 @@ public:
     virtual void setFinalIndex(int i) { finalIndex_ = i; isInitialized_ = false; }
     virtual void setMaxAbsError(Scalar e) { maxAbsError_ = e; isInitialized_ = false; }
     virtual void setMaxRelError(Scalar e) { maxRelError_ = e; isInitialized_ = false; }
-#ifndef TEMPUS_HIDE_DEPRECATED_CODE
-    virtual void setMinOrder(int)  { isInitialized_ = false; }
-    virtual void setInitOrder(int) { isInitialized_ = false; }
-    virtual void setMaxOrder(int)  { isInitialized_ = false; }
-#endif
-    virtual void setStepType(std::string s) { stepType_ = s; isInitialized_ = false; }
     virtual void setMaxFailures(int i) { maxFailures_ = i; isInitialized_ = false; }
     virtual void setMaxConsecFailures(int i) { maxConsecFailures_ = i; isInitialized_ = false; }
     virtual void setPrintDtChanges(bool b) { printDtChanges_ = b; isInitialized_ = false; }
@@ -168,27 +161,34 @@ public:
     virtual void setOutputTimes(std::vector<Scalar> v) { outputTimes_ = v; isInitialized_ = false; }
     virtual void setOutputIndexInterval(int i) { outputIndexInterval_ = i; isInitialized_ = false; }
     virtual void setOutputTimeInterval(Scalar t) { outputTimeInterval_ = t; isInitialized_ = false; }
+
+    virtual void setTimeStepControlStrategy(
+      Teuchos::RCP<TimeStepControlStrategy<Scalar> > tscs = Teuchos::null);
   //@}
 
+  virtual void printDtChanges(int istep, Scalar dt_old, Scalar dt_new,
+                              std::string reason) const;
+
+  virtual void initialize() const;
+  virtual bool isInitialized() { return isInitialized_; }
   virtual void checkInitialized();
 
 protected:
 
-  bool        isInitialized_;     ///< Bool if TimeStepControl is initialized.
-  Scalar      initTime_;          ///< Initial Time
-  Scalar      finalTime_;         ///< Final Time
-  Scalar      minTimeStep_;       ///< Minimum Time Step
-  Scalar      initTimeStep_;      ///< Initial Time Step
-  Scalar      maxTimeStep_;       ///< Maximum Time Step
-  int         initIndex_;         ///< Initial Time Index
-  int         finalIndex_;        ///< Final Time Index
-  Scalar      maxAbsError_;       ///< Maximum Absolute Error
-  Scalar      maxRelError_;       ///< Maximum Relative Error
-  std::string stepType_;          ///< Integrator Step Type
-  int         maxFailures_;       ///< Maximum Number of Stepper Failures
-  int         maxConsecFailures_; ///< Maximum Number of Consecutive Stepper Failures
-  int         numTimeSteps_;      ///< Number of time steps for Constant time step
-  bool        printDtChanges_;    ///< Print timestep size when it changes
+  mutable bool isInitialized_;     ///< Bool if TimeStepControl is initialized.
+  Scalar       initTime_;          ///< Initial Time
+  Scalar       finalTime_;         ///< Final Time
+  Scalar       minTimeStep_;       ///< Minimum Time Step
+  Scalar       initTimeStep_;      ///< Initial Time Step
+  Scalar       maxTimeStep_;       ///< Maximum Time Step
+  int          initIndex_;         ///< Initial Time Index
+  int          finalIndex_;        ///< Final Time Index
+  Scalar       maxAbsError_;       ///< Maximum Absolute Error
+  Scalar       maxRelError_;       ///< Maximum Relative Error
+  int          maxFailures_;       ///< Maximum Number of Stepper Failures
+  int          maxConsecFailures_; ///< Maximum Number of Consecutive Stepper Failures
+  int          numTimeSteps_;      ///< Number of time steps for Constant time step
+  bool         printDtChanges_;    ///< Print timestep size when it changes
 
   bool                outputExactly_;  ///< Output Exactly On Output Times
   std::vector<int>    outputIndices_;  ///< Vector of output indices
@@ -208,6 +208,16 @@ protected:
 template<class Scalar>
 Teuchos::RCP<TimeStepControl<Scalar> > createTimeStepControl(
   Teuchos::RCP<Teuchos::ParameterList> const& pList);
+
+/// Nonmember function to return ParameterList with default values.
+template<class Scalar>
+Teuchos::RCP<Teuchos::ParameterList> getTimeStepControlPL()
+{
+  auto tsc = rcp(new Tempus::TimeStepControl<Scalar>());
+  return Teuchos::rcp_const_cast<Teuchos::ParameterList> (tsc->getValidParameters());
+}
+
+
 
 } // namespace Tempus
 

--- a/packages/tempus/src/Tempus_TimeStepControl_impl.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControl_impl.hpp
@@ -595,7 +595,7 @@ TimeStepControl<Scalar>::getValidParameters() const
 // ------------------------------------------------------------------------
 template <class Scalar>
 Teuchos::RCP<TimeStepControl<Scalar> > createTimeStepControl(
-  Teuchos::RCP<Teuchos::ParameterList> const& pList)
+  Teuchos::RCP<Teuchos::ParameterList> const& pList, bool runInitialize)
 {
   using Teuchos::RCP;
   using Teuchos::ParameterList;
@@ -709,7 +709,7 @@ Teuchos::RCP<TimeStepControl<Scalar> > createTimeStepControl(
     }
   }
 
-  tsc->initialize();
+  if (runInitialize) tsc->initialize();
   return tsc;
 }
 

--- a/packages/tempus/src/Tempus_TimeStepControl_impl.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControl_impl.hpp
@@ -38,7 +38,6 @@ TimeStepControl<Scalar>::TimeStepControl()
     finalIndex_         (1000000),
     maxAbsError_        (1.0e-08),
     maxRelError_        (1.0e-08),
-    stepType_           ("Variable"),
     maxFailures_        (10),
     maxConsecFailures_  (5),
     numTimeSteps_       (-1),
@@ -67,7 +66,6 @@ TimeStepControl<Scalar>::TimeStepControl(
   int                 finalIndex,
   Scalar              maxAbsError,
   Scalar              maxRelError,
-  std::string         stepType,
   int                 maxFailures,
   int                 maxConsecFailures,
   int                 numTimeSteps,
@@ -77,8 +75,8 @@ TimeStepControl<Scalar>::TimeStepControl(
   std::vector<Scalar> outputTimes,
   int                 outputIndexInterval,
   Scalar              outputTimeInterval,
-  Teuchos::RCP<TimeStepControlStrategyComposite<Scalar>> stepControlStrategy)
-  : isInitialized_      (false),
+  Teuchos::RCP<TimeStepControlStrategy<Scalar>> stepControlStrategy)
+  : isInitialized_      (false              ),
     initTime_           (initTime           ),
     finalTime_          (finalTime          ),
     minTimeStep_        (minTimeStep        ),
@@ -88,7 +86,6 @@ TimeStepControl<Scalar>::TimeStepControl(
     finalIndex_         (finalIndex         ),
     maxAbsError_        (maxAbsError        ),
     maxRelError_        (maxRelError        ),
-    stepType_           (stepType           ),
     maxFailures_        (maxFailures        ),
     maxConsecFailures_  (maxConsecFailures  ),
     numTimeSteps_       (numTimeSteps       ),
@@ -102,21 +99,14 @@ TimeStepControl<Scalar>::TimeStepControl(
     dtAfterOutput_      (0.0                ),
     stepControlStrategy_(stepControlStrategy)
 {
+  setNumTimeSteps(getNumTimeSteps());
   this->initialize();
 }
 
 
 template<class Scalar>
-void TimeStepControl<Scalar>::initialize()
+void TimeStepControl<Scalar>::initialize() const
 {
-  // Override parameters
-  if (getStepType() == "Constant") {
-    setMinTimeStep( getInitTimeStep() );
-    setMaxTimeStep( getInitTimeStep() );
-  }
-  setNumTimeSteps(getNumTimeSteps());
-
-
   TEUCHOS_TEST_FOR_EXCEPTION(
     (getInitTime() > getFinalTime() ), std::logic_error,
     "Error - Inconsistent time range.\n"
@@ -167,12 +157,37 @@ void TimeStepControl<Scalar>::initialize()
   TEUCHOS_TEST_FOR_EXCEPTION(
     (getStepType() != "Constant" and getStepType() != "Variable"),
     std::out_of_range,
-      "Error - 'Integrator Step Type' does not equal none of these:\n"
+      "Error - 'Step Type' does not equal one of these:\n"
     << "  'Constant' - Integrator will take constant time step sizes.\n"
     << "  'Variable' - Integrator will allow changes to the time step size.\n"
-    << "  stepType = " << getStepType()  << "\n");
+    << "  stepType = " << getStepType() << "\n");
+
+  TEUCHOS_TEST_FOR_EXCEPTION(
+    (stepControlStrategy_ == Teuchos::null), std::logic_error,
+    "Error - Strategy is unset!\n");
+
+  stepControlStrategy_->initialize();
 
   isInitialized_ = true;   // Only place where this is set to true!
+}
+
+
+template<class Scalar>
+void TimeStepControl<Scalar>::
+printDtChanges(int istep, Scalar dt_old, Scalar dt_new, std::string reason) const
+{
+  if (!getPrintDtChanges()) return;
+
+  Teuchos::RCP<Teuchos::FancyOStream> out = this->getOStream();
+  Teuchos::OSTab ostab(out,0,"printDtChanges");
+
+  std::stringstream message;
+  message << std::scientific
+                   <<std::setw(6)<<std::setprecision(3)<<istep
+    << " *  (dt = "<<std::setw(9)<<std::setprecision(3)<<dt_old
+    <<   ", new = "<<std::setw(9)<<std::setprecision(3)<<dt_new
+    << ")  " << reason << std::endl;
+  *out << message.str();
 }
 
 
@@ -188,7 +203,7 @@ void TimeStepControl<Scalar>::checkInitialized()
 
 
 template<class Scalar>
-void TimeStepControl<Scalar>::getNextTimeStep(
+void TimeStepControl<Scalar>::setNextTimeStep(
   const Teuchos::RCP<SolutionHistory<Scalar> > & solutionHistory,
   Status & integratorStatus)
 {
@@ -196,83 +211,72 @@ void TimeStepControl<Scalar>::getNextTimeStep(
 
   checkInitialized();
 
-  TEMPUS_FUNC_TIME_MONITOR("Tempus::TimeStepControl::getNextTimeStep()");
+  TEMPUS_FUNC_TIME_MONITOR("Tempus::TimeStepControl::setNextTimeStep()");
   {
-    RCP<Teuchos::FancyOStream> out = this->getOStream();
-    Teuchos::OSTab ostab(out,0,"getNextTimeStep");
-
-    // Lambda function to report changes to dt.
-    auto changeDT = [] (int istep, Scalar dt_old, Scalar dt_new,
-                        std::string reason)
-    {
-      std::stringstream message;
-      message << std::scientific
-                       <<std::setw(6)<<std::setprecision(3)<<istep
-        << " *  (dt = "<<std::setw(9)<<std::setprecision(3)<<dt_old
-        <<   ", new = "<<std::setw(9)<<std::setprecision(3)<<dt_new
-        << ")  " << reason << std::endl;
-      return message.str();
-    };
-
     RCP<SolutionState<Scalar> > workingState=solutionHistory->getWorkingState();
     const Scalar lastTime = solutionHistory->getCurrentState()->getTime();
     const int iStep = workingState->getIndex();
-    Scalar dt = workingState->getTimeStep();
+    Scalar dt   = workingState->getTimeStep();
+    Scalar time = workingState->getTime();
     bool output = false;
 
     RCP<StepperState<Scalar> > stepperState = workingState->getStepperState();
 
+    // If last time step was adjusted for output, reinstate previous dt.
     if (getStepType() == "Variable") {
-      // If last time step was adjusted for output, reinstate previous dt.
       if (outputAdjustedDt_ == true) {
-        if (printDtChanges_) *out << changeDT(iStep, dt, dtAfterOutput_,
-          "Reset dt after output.");
+        printDtChanges(iStep, dt, dtAfterOutput_, "Reset dt after output.");
         dt = dtAfterOutput_;
+        time = lastTime + dt;
         outputAdjustedDt_ = false;
         dtAfterOutput_ = 0.0;
       }
 
       if (dt <= 0.0) {
-        if (printDtChanges_) *out << changeDT(iStep, dt, getInitTimeStep(),
-          "Reset dt to initial dt.");
+        printDtChanges(iStep, dt, getInitTimeStep(), "Reset dt to initial dt.");
         dt = getInitTimeStep();
+        time = lastTime + dt;
       }
 
       if (dt < getMinTimeStep()) {
-        if (printDtChanges_) *out << changeDT(iStep, dt, getMinTimeStep(),
-          "Reset dt to minimum dt.");
+        printDtChanges(iStep, dt, getMinTimeStep(), "Reset dt to minimum dt.");
         dt = getMinTimeStep();
+        time = lastTime + dt;
       }
     }
 
-    // update dt for the step control strategy to be informed
+    // Update dt for the step control strategy to be informed
     workingState->setTimeStep(dt);
+    workingState->setTime(time);
 
-    // call the step control strategy (to update dt if needed)
-    stepControlStrategy_->getNextTimeStep(*this, solutionHistory,
-                                         integratorStatus);
+    // Call the step control strategy (to update dt if needed)
+    stepControlStrategy_->setNextTimeStep(*this, solutionHistory,
+                                          integratorStatus);
 
-    // get the dt (probably have changed by stepControlStrategy_)
+    // Get the dt (probably have changed by stepControlStrategy_)
     dt = workingState->getTimeStep();
+    time = workingState->getTime();
 
     if (getStepType() == "Variable") {
       if (dt < getMinTimeStep()) { // decreased below minimum dt
-        if (printDtChanges_) *out << changeDT(iStep, dt, getMinTimeStep(),
+        printDtChanges(iStep, dt, getMinTimeStep(),
           "dt is too small.  Resetting to minimum dt.");
         dt = getMinTimeStep();
+        time = lastTime + dt;
       }
       if (dt > getMaxTimeStep()) { // increased above maximum dt
-        if (printDtChanges_) *out << changeDT(iStep, dt, getMaxTimeStep(),
+        printDtChanges(iStep, dt, getMaxTimeStep(),
           "dt is too large.  Resetting to maximum dt.");
         dt = getMaxTimeStep();
+        time = lastTime + dt;
       }
     }
 
 
     // Check if we need to output this step index
     std::vector<int>::const_iterator it =
-      std::find(outputIndices_.begin(), outputIndices_.end(), iStep);
-    if (it != outputIndices_.end()) output = true;
+      std::find(getOutputIndices().begin(), getOutputIndices().end(), iStep);
+    if (it != getOutputIndices().end()) output = true;
 
     const int iInterval = getOutputIndexInterval();
     if ( (iStep - getInitIndex()) % iInterval == 0) output = true;
@@ -309,19 +313,9 @@ void TimeStepControl<Scalar>::getNextTimeStep(
       const bool outputExactly = getOutputExactly();
       if (getStepType() == "Variable" && outputExactly == true) {
         // Adjust time step to hit output times.
-        if (std::abs((lastTime+dt-oTime)/(lastTime+dt)) < reltol) {
+        if ( time > oTime ) {
           output = true;
-          if (printDtChanges_) *out << changeDT(iStep, dt, oTime - lastTime,
-            "Adjusting dt for numerical roundoff to hit the next output time.");
-          // Next output time IS VERY near next time (<reltol away from it),
-          // e.g., adjust for numerical roundoff.
-          outputAdjustedDt_ = true;
-          dtAfterOutput_ = dt;
-          dt = oTime - lastTime;
-        } else if (lastTime*(1.0+reltol) < oTime &&
-                   oTime < (lastTime+dt-getMinTimeStep())*(1.0+reltol)) {
-          output = true;
-          if (printDtChanges_) *out << changeDT(iStep, dt, oTime - lastTime,
+          printDtChanges(iStep, dt, oTime - lastTime,
             "Adjusting dt to hit the next output time.");
           // Next output time is not near next time
           // (>getMinTimeStep() away from it).
@@ -329,14 +323,26 @@ void TimeStepControl<Scalar>::getNextTimeStep(
           outputAdjustedDt_ = true;
           dtAfterOutput_ = dt;
           dt = oTime - lastTime;
-        } else {
-          if (printDtChanges_) *out << changeDT(iStep, dt, (oTime - lastTime)/2.0,
+          time = lastTime + dt;
+        } else if (std::fabs((time-oTime)/(time)) < reltol) {
+          output = true;
+          printDtChanges(iStep, dt, oTime - lastTime,
+            "Adjusting dt for numerical roundoff to hit the next output time.");
+          // Next output time IS VERY near next time (<reltol away from it),
+          // e.g., adjust for numerical roundoff.
+          outputAdjustedDt_ = true;
+          dtAfterOutput_ = dt;
+          dt = oTime - lastTime;
+          time = lastTime + dt;
+        } else  if (std::fabs((time + getMinTimeStep() - oTime)/oTime) < reltol ) {
+          printDtChanges(iStep, dt, (oTime - lastTime)/2.0,
             "The next output time is within the minimum dt of the next time. "
             "Adjusting dt to take two steps.");
           // Next output time IS near next time
           // (<getMinTimeStep() away from it).
           // Take two time steps to get to next output time.
           dt = (oTime - lastTime)/2.0;
+          time = lastTime + dt;
         }
       } else {
         // Stepping over output time and want this time step for output,
@@ -348,11 +354,14 @@ void TimeStepControl<Scalar>::getNextTimeStep(
 
     // Adjust time step to hit final time or correct for small
     // numerical differences.
-    if ((lastTime + dt > getFinalTime() ) ||
-        (std::abs((lastTime+dt-getFinalTime())/(lastTime+dt)) < reltol)) {
-      if (printDtChanges_) *out << changeDT(iStep, dt, getFinalTime() - lastTime,
-        "Adjusting dt to hit final time.");
-      dt = getFinalTime() - lastTime;
+    if (getStepType() == "Variable") {
+      if ((lastTime + dt > getFinalTime() ) ||
+          (std::fabs((lastTime+dt-getFinalTime())/(lastTime+dt)) < reltol)) {
+        printDtChanges(iStep, dt, getFinalTime() - lastTime,
+          "Adjusting dt to hit final time.");
+        dt = getFinalTime() - lastTime;
+        time = lastTime + dt;
+      }
     }
 
     // Check for negative time step.
@@ -367,31 +376,44 @@ void TimeStepControl<Scalar>::getNextTimeStep(
       << getFinalTime() << "]\n"
       "    T + dt = " << lastTime <<" + "<< dt <<" = " << lastTime + dt <<"\n");
 
-    TEUCHOS_TEST_FOR_EXCEPTION(
-      (lastTime + dt > getFinalTime()), std::out_of_range,
-      "Error - Time step move time OUT OF time range.\n"
-      "    [timeMin, timeMax] = [" << getInitTime() << ", "
-      << getFinalTime() << "]\n"
-      "    T + dt = " << lastTime <<" + "<< dt <<" = " << lastTime + dt <<"\n");
+    if (getStepType() == "Variable") {
+      TEUCHOS_TEST_FOR_EXCEPTION(
+        (lastTime + dt > getFinalTime()), std::out_of_range,
+        "Error - Time step move time OUT OF time range.\n"
+        "    [timeMin, timeMax] = [" << getInitTime() << ", "
+        << getFinalTime() << "]\n"
+        "    T + dt = " << lastTime <<" + "<< dt <<" = " << lastTime + dt <<"\n");
+    }
 
     workingState->setTimeStep(dt);
-    workingState->setTime(lastTime + dt);
+    workingState->setTime(time);
     workingState->setOutput(output);
   }
   return;
 }
 
 
-/// Test if time is within range: include timeMin and exclude timeMax.
+/// Test if time is within range: include initTime and exclude finalTime.
 template<class Scalar>
-bool TimeStepControl<Scalar>::timeInRange(const Scalar time) const{
-  const Scalar relTol = 1.0e-14;
-  bool tir = (getInitTime()*(1.0-relTol) <= time and
-              time < getFinalTime()*(1.0-relTol));
-  return tir;
+bool TimeStepControl<Scalar>::timeInRange(const Scalar time) const
+{
+  // Get absolute tolerance 1.0e-(i+14), i.e., 14 digits of accuracy.
+  const int relTol = 14;
+  const int i =
+    (getInitTime() == 0) ? 0 : 1 + (int)std::floor(std::log10(std::fabs(getInitTime()) ) );
+  const Scalar absTolInit = std::pow(10, i-relTol);
+  const int j =
+    (getFinalTime() == 0) ? 0 : 1 + (int)std::floor(std::log10(std::fabs(getFinalTime()) ) );
+  const Scalar absTolFinal = std::pow(10, j-relTol);
+
+  const bool test1 = getInitTime() - absTolInit <= time;
+  const bool test2 = time < getFinalTime() - absTolFinal;
+
+  return (test1 and test2);
 }
 
 
+/// Test if index is within range: include initIndex and exclude finalIndex.
 template<class Scalar>
 bool TimeStepControl<Scalar>::indexInRange(const int iStep) const{
   bool iir = (getInitIndex() <= iStep and iStep < getFinalIndex());
@@ -402,6 +424,9 @@ bool TimeStepControl<Scalar>::indexInRange(const int iStep) const{
 template<class Scalar>
 void TimeStepControl<Scalar>::setNumTimeSteps(int numTimeSteps)
 {
+  TEUCHOS_TEST_FOR_EXCEPTION( getStepType() != "Constant", std::out_of_range,
+      "Error - Can only use setNumTimeSteps() when 'Step Type' == 'Constant'.\n");
+
   if (numTimeSteps >= 0) {
     numTimeSteps_ = numTimeSteps;
     setFinalIndex(getInitIndex() + numTimeSteps_);
@@ -413,15 +438,14 @@ void TimeStepControl<Scalar>::setNumTimeSteps(int numTimeSteps)
     setInitTimeStep(initTimeStep);
     setMinTimeStep (initTimeStep);
     setMaxTimeStep (initTimeStep);
-    setStepType("Constant");
 
     Teuchos::RCP<Teuchos::FancyOStream> out = this->getOStream();
     Teuchos::OSTab ostab(out,1,"setNumTimeSteps");
-    *out << "Warning - Setting 'Number of Time Steps' = " << getNumTimeSteps()
+    *out << "Warning - setNumTimeSteps() Setting 'Number of Time Steps' = " << getNumTimeSteps()
          << "  Set the following parameters: \n"
          << "  'Final Time Index'     = " << getFinalIndex() << "\n"
          << "  'Initial Time Step'    = " << getInitTimeStep() << "\n"
-         << "  'Integrator Step Type' = " << getStepType() << std::endl;
+         << "  'Step Type'            = " << getStepType() << std::endl;
 
     isInitialized_ = false;
   }
@@ -458,27 +482,27 @@ void TimeStepControl<Scalar>::describe(
     }
 
     out << description() << "::describe:" << std::endl
-        << "initTime           = " << initTime_            << std::endl
-        << "finalTime          = " << finalTime_           << std::endl
-        << "minTimeStep        = " << minTimeStep_         << std::endl
-        << "initTimeStep       = " << initTimeStep_        << std::endl
-        << "maxTimeStep        = " << maxTimeStep_         << std::endl
-        << "initIndex          = " << initIndex_           << std::endl
-        << "finalIndex         = " << finalIndex_          << std::endl
-        << "maxAbsError        = " << maxAbsError_         << std::endl
-        << "maxRelError        = " << maxRelError_         << std::endl
-        << "stepType           = " << stepType_            << std::endl
-        << "maxFailures        = " << maxFailures_         << std::endl
-        << "maxConsecFailures  = " << maxConsecFailures_   << std::endl
-        << "numTimeSteps       = " << numTimeSteps_        << std::endl
-        << "printDtChanges     = " << printDtChanges_      << std::endl
-        << "outputExactly      = " << outputExactly_       << std::endl
-        << "outputIndices      = " << listIdx.str()        << std::endl
-        << "outputTimes        = " << listTimes.str()      << std::endl
-        << "outputIndexInterval= " << outputIndexInterval_ << std::endl
-        << "outputTimeInterval = " << outputTimeInterval_  << std::endl
-        << "outputAdjustedDt   = " << outputAdjustedDt_    << std::endl
-        << "dtAfterOutput      = " << dtAfterOutput_       << std::endl
+        << "stepType           = " << getStepType()            << std::endl
+        << "initTime           = " << getInitTime()            << std::endl
+        << "finalTime          = " << getFinalTime()           << std::endl
+        << "minTimeStep        = " << getMinTimeStep()         << std::endl
+        << "initTimeStep       = " << getInitTimeStep()        << std::endl
+        << "maxTimeStep        = " << getMaxTimeStep()         << std::endl
+        << "initIndex          = " << getInitIndex()           << std::endl
+        << "finalIndex         = " << getFinalIndex()          << std::endl
+        << "maxAbsError        = " << getMaxAbsError()         << std::endl
+        << "maxRelError        = " << getMaxRelError()         << std::endl
+        << "maxFailures        = " << getMaxFailures()         << std::endl
+        << "maxConsecFailures  = " << getMaxConsecFailures()   << std::endl
+        << "numTimeSteps       = " << getNumTimeSteps()        << std::endl
+        << "printDtChanges     = " << getPrintDtChanges()      << std::endl
+        << "outputExactly      = " << getOutputExactly()       << std::endl
+        << "outputIndices      = " << listIdx.str()            << std::endl
+        << "outputTimes        = " << listTimes.str()          << std::endl
+        << "outputIndexInterval= " << getOutputIndexInterval() << std::endl
+        << "outputTimeInterval = " << getOutputTimeInterval()  << std::endl
+        << "outputAdjustedDt   = " << outputAdjustedDt_        << std::endl
+        << "dtAfterOutput      = " << dtAfterOutput_           << std::endl
         << "stepControlSrategy = " << std::endl;
         stepControlStrategy_->describe(out, verbLevel);
   }
@@ -489,14 +513,14 @@ template<class Scalar>
 void TimeStepControl<Scalar>::setTimeStepControlStrategy(
   Teuchos::RCP<TimeStepControlStrategy<Scalar> > tscs)
 {
+  using Teuchos::rcp;
+
   if ( tscs != Teuchos::null ) {
     stepControlStrategy_ = tscs;
-    //stepControlStrategy_->addStrategy(tscs);
   } else {
-    stepControlStrategy_ = Teuchos::rcp(new TimeStepControlStrategyConstant<Scalar>());
-    //stepControlStrategy_ = Teuchos::rcp(new TimeStepControlStrategy<Scalar>());
+    stepControlStrategy_ =
+      rcp(new TimeStepControlStrategyConstant<Scalar>(getInitTimeStep()));
   }
-
   isInitialized_ = false;
 }
 
@@ -505,7 +529,7 @@ template<class Scalar>
 Teuchos::RCP<const Teuchos::ParameterList>
 TimeStepControl<Scalar>::getValidParameters() const
 {
-  Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
+  Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList("Time Step Control");
 
   pl->set<double>("Initial Time"          , getInitTime()    , "Initial time");
   pl->set<double>("Final Time"            , getFinalTime()   , "Final time");
@@ -519,16 +543,9 @@ TimeStepControl<Scalar>::getValidParameters() const
     "on the fly given the size of the time domain.  Overides and resets\n"
     "  'Final Time Index'     = 'Initial Time Index' + 'Number of Time Steps'\n"
     "  'Initial Time Step'    = "
-    "('Final Time' - 'Initial Time')/'Number of Time Steps'\n"
-    "  'Integrator Step Type' = 'Constant'\n");
+    "('Final Time' - 'Initial Time')/'Number of Time Steps'\n");
   pl->set<double>("Maximum Absolute Error", getMaxAbsError() , "Maximum absolute error");
   pl->set<double>("Maximum Relative Error", getMaxRelError() , "Maximum relative error");
-
-  pl->set<std::string>("Integrator Step Type", getStepType(),
-    "'Integrator Step Type' indicates whether the Integrator will allow "
-    "the time step to be modified.\n"
-    "  'Constant' - Integrator will take constant time step sizes.\n"
-    "  'Variable' - Integrator will allow changes to the time step size.\n");
 
   pl->set<bool>  ("Print Time Step Changes", getPrintDtChanges(),
     "Print timestep size when it changes");
@@ -568,9 +585,7 @@ TimeStepControl<Scalar>::getValidParameters() const
   pl->set<int>   ("Maximum Number of Consecutive Stepper Failures", getMaxConsecFailures(),
     "Maximum number of consecutive Stepper failures");
 
-  Teuchos::RCP<Teuchos::ParameterList> tscsPL = Teuchos::parameterList("Time Step Control Strategy");
-  tscsPL->set<std::string>("Time Step Control Strategy List","");
-  pl->set("Time Step Control Strategy", *tscsPL);
+  pl->set("Time Step Control Strategy", *stepControlStrategy_->getValidParameters());
 
   return pl;
 }
@@ -599,7 +614,6 @@ Teuchos::RCP<TimeStepControl<Scalar> > createTimeStepControl(
   tsc->setFinalIndex(       pList->get<int>   ("Final Time Index"));
   tsc->setMaxAbsError(      pList->get<double>("Maximum Absolute Error"));
   tsc->setMaxRelError(      pList->get<double>("Maximum Relative Error"));
-  tsc->setStepType(         pList->get<std::string>("Integrator Step Type"));
   tsc->setMaxFailures(      pList->get<int>   ("Maximum Number of Stepper Failures"));
   tsc->setMaxConsecFailures(pList->get<int>   ("Maximum Number of Consecutive Stepper Failures"));
   tsc->setPrintDtChanges(   pList->get<bool>  ("Print Time Step Changes"));
@@ -624,18 +638,12 @@ Teuchos::RCP<TimeStepControl<Scalar> > createTimeStepControl(
       pos = str.find_first_of(delimiters, lastPos);
     }
 
-    int outputIndexInterval = pList->get<int>("Output Index Interval");
-    tsc->setOutputIndexInterval(outputIndexInterval);
-    Scalar output_i = tsc->getInitIndex();
-    while (output_i <= tsc->getFinalIndex()) {
-      outputIndices.push_back(output_i);
-      output_i += outputIndexInterval;
-    }
-
     // order output indices
     std::sort(outputIndices.begin(),outputIndices.end());
     tsc->setOutputIndices(outputIndices);
   }
+
+  tsc->setOutputIndexInterval(pList->get<int>("Output Index Interval"));
 
   // Parse output times
   {
@@ -660,68 +668,48 @@ Teuchos::RCP<TimeStepControl<Scalar> > createTimeStepControl(
     // order output times
     std::sort(outputTimes.begin(),outputTimes.end());
     outputTimes.erase(std::unique(outputTimes.begin(),
-                                   outputTimes.end()   ),
-                                   outputTimes.end()     );
+                                  outputTimes.end()   ),
+                                  outputTimes.end()     );
     tsc->setOutputTimes(outputTimes);
   }
 
   tsc->setOutputTimeInterval(pList->get<double>("Output Time Interval"));
 
-  // set the time step control strategy
-  auto stepControlStrategy =
-    Teuchos::rcp(new TimeStepControlStrategyComposite<Scalar>());
 
-  if (tsc->getStepType() == "Constant") {
-     stepControlStrategy->addStrategy(
-       Teuchos::rcp(new TimeStepControlStrategyConstant<Scalar>()));
-  } else if (tsc->getStepType() == "Variable") {
-     // add TSCS from "Time Step Control Strategy List"
+  if ( !pList->isParameter("Time Step Control Strategy") ) {
 
-     RCP<ParameterList> tscsPL =
-       Teuchos::sublist(pList, "Time Step Control Strategy", true);
-     // Construct from TSCS sublist
-     std::vector<std::string> tscsLists;
+    tsc->setTimeStepControlStrategy();  // i.e, set default Constant timestep strategy.
 
-     // string tokenizer
-     tscsLists.clear();
-     std::string str = tscsPL->get<std::string>("Time Step Control Strategy List");
-     std::string delimiters(",");
-     // Skip delimiters at the beginning
-     std::string::size_type lastPos = str.find_first_not_of(delimiters, 0);
-     // Find the first delimiter
-     std::string::size_type pos     = str.find_first_of(delimiters, lastPos);
-     while ((pos != std::string::npos) || (lastPos != std::string::npos)) {
-        // Found a token, add it to the vector
-        std::string token = str.substr(lastPos,pos-lastPos);
-        tscsLists.push_back(token);
-        if(pos==std::string::npos) break;
+  } else {
 
-        lastPos = str.find_first_not_of(delimiters, pos); // Skip delimiters
-        pos = str.find_first_of(delimiters, lastPos);     // Find next delimiter
-     }
+    RCP<ParameterList> tscsPL =
+      Teuchos::sublist(pList, "Time Step Control Strategy", true);
 
-     // For each sublist name tokenized, add the TSCS
-     for( auto el: tscsLists){
-
-        RCP<ParameterList> pl =
-           Teuchos::rcp(new ParameterList(tscsPL->sublist(el)));
-
-        RCP<TimeStepControlStrategy<Scalar>> ts;
-
-        // construct appropriate TSCS
-        if(pl->get<std::string>("Name") == "Integral Controller")
-           ts = Teuchos::rcp(new TimeStepControlStrategyIntegralController<Scalar>(pl));
-        else if(pl->get<std::string>("Name") == "Basic VS")
-           ts = Teuchos::rcp(new TimeStepControlStrategyBasicVS<Scalar>(pl));
-
-        stepControlStrategy->addStrategy(ts);
-     }
+    auto strategyType = tscsPL->get<std::string>("Strategy Type");
+    if (strategyType == "Constant") {
+      tsc->setTimeStepControlStrategy(
+        createTimeStepControlStrategyConstant<Scalar>(tscsPL));
+    } else if (strategyType == "Basic VS") {
+      tsc->setTimeStepControlStrategy(
+        createTimeStepControlStrategyBasicVS<Scalar>(tscsPL));
+    } else if (strategyType == "Integral Controller") {
+      tsc->setTimeStepControlStrategy(
+        createTimeStepControlStrategyIntegralController<Scalar>(tscsPL));
+    } else if (strategyType == "Composite") {
+      tsc->setTimeStepControlStrategy(
+        createTimeStepControlStrategyComposite<Scalar>(tscsPL));
+    } else {
+      RCP<Teuchos::FancyOStream> out =
+        Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
+      Teuchos::OSTab ostab(out,1, "createTimeStepControl()");
+      *out << "Warning -- Did not find a Tempus strategy to create!\n"
+           << "'Strategy Type' = '" << strategyType << "'\n"
+           << "Should call setTimeStepControlStrategy() with this\n"
+           << "(app-specific?) strategy, and initialize().\n" << std::endl;
+    }
   }
 
-  tsc->setTimeStepControlStrategy(stepControlStrategy);
-
   tsc->initialize();
-
   return tsc;
 }
 

--- a/packages/tempus/src/Tempus_WrapperModelEvaluatorBasic_decl.hpp
+++ b/packages/tempus/src/Tempus_WrapperModelEvaluatorBasic_decl.hpp
@@ -89,7 +89,7 @@ public:
       { return appModel_->get_f_space(); }
 
     Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> > get_p_space(int p) const
-      { return appModel_->get_p_space(p); };
+      { return appModel_->get_p_space(p); }
 
     Teuchos::RCP<const Teuchos::Array<std::string> > get_p_names(int p) const
       { return appModel_->get_p_names(p); }

--- a/packages/tempus/src/Tempus_WrapperModelEvaluatorSecondOrder_decl.hpp
+++ b/packages/tempus/src/Tempus_WrapperModelEvaluatorSecondOrder_decl.hpp
@@ -122,7 +122,7 @@ public:
       *out_ << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
 #endif
       return appModel_->get_p_space(p);
-    };
+    }
 
     Teuchos::RCP<const Teuchos::Array<std::string> > get_p_names(int p) const
     {
@@ -186,7 +186,7 @@ public:
               const Thyra::ModelEvaluatorBase::OutArgs<Scalar> &outArgs) const;
   //@}
 
-    enum SCHEME_TYPE {NEWMARK_IMPLICIT_AFORM, NEWMARK_IMPLICIT_DFORM};
+  enum SCHEME_TYPE {NEWMARK_IMPLICIT_AFORM, NEWMARK_IMPLICIT_DFORM};
 
 private:
 

--- a/packages/tempus/test/BDF2/Tempus_BDF2Test.cpp
+++ b/packages/tempus/test/BDF2/Tempus_BDF2Test.cpp
@@ -133,7 +133,6 @@ TEUCHOS_UNIT_TEST(BDF2, ConstructingFromDefaults)
     auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
     ParameterList tscPL = pl->sublist("Default Integrator")
                              .sublist("Time Step Control");
-    timeStepControl->setStepType (tscPL.get<std::string>("Integrator Step Type"));
     timeStepControl->setInitIndex(tscPL.get<int>   ("Initial Time Index"));
     timeStepControl->setInitTime (tscPL.get<double>("Initial Time"));
     timeStepControl->setFinalTime(tscPL.get<double>("Final Time"));
@@ -378,7 +377,6 @@ TEUCHOS_UNIT_TEST(BDF2, SinCosAdapt)
     pl->sublist("Default Integrator")
        .sublist("Time Step Control")
        .sublist("Time Step Control Strategy")
-       .sublist("basic_vs")
        .set("Minimum Value Monitoring Function", dt*0.99);
     integrator = Tempus::integratorBasic<double>(pl, model);
 
@@ -466,8 +464,8 @@ TEUCHOS_UNIT_TEST(BDF2, SinCosAdapt)
                     solutions,    xErrorNorm,    xSlope,
                     solutionsDot, xDotErrorNorm, xDotSlope);
 
-    TEST_FLOATING_EQUALITY( xSlope,               1.96126, 0.01 );
-    TEST_FLOATING_EQUALITY( xDotSlope,            1.96126, 0.01 );
+    TEST_FLOATING_EQUALITY( xSlope,                 1.932, 0.01 );
+    TEST_FLOATING_EQUALITY( xDotSlope,              1.932, 0.01 );
     TEST_FLOATING_EQUALITY( xErrorNorm[0],    0.000192591, 1.0e-4 );
     TEST_FLOATING_EQUALITY( xDotErrorNorm[0], 0.000192591, 1.0e-4 );
   }

--- a/packages/tempus/test/BDF2/Tempus_BDF2_CDR.xml
+++ b/packages/tempus/test/BDF2/Tempus_BDF2_CDR.xml
@@ -29,7 +29,6 @@
         <Parameter name="Maximum Time Step"      type="double" value="0.1"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
-        <Parameter name="Integrator Step Type"  type="string" value="Constant"/>
         <Parameter name="Output Time List"       type="string" value=""/>
         <Parameter name="Output Index List"      type="string" value=""/>
         <Parameter name="Output Time Interval"   type="double" value="10.0"/>

--- a/packages/tempus/test/BDF2/Tempus_BDF2_SinCos.xml
+++ b/packages/tempus/test/BDF2/Tempus_BDF2_SinCos.xml
@@ -33,7 +33,6 @@
         <Parameter name="Maximum Time Step"      type="double" value="0.1"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
-        <Parameter name="Integrator Step Type"  type="string" value="Constant"/>
         <Parameter name="Output Time List"       type="string" value="0.31"/>
         <Parameter name="Output Index List"      type="string" value=""/>
         <Parameter name="Output Time Interval"   type="double" value="10.0"/>

--- a/packages/tempus/test/BDF2/Tempus_BDF2_SinCos_AdaptDt.xml
+++ b/packages/tempus/test/BDF2/Tempus_BDF2_SinCos_AdaptDt.xml
@@ -38,16 +38,12 @@
         <Parameter name="Output Index Interval"  type="int"    value="1000"/>
         <Parameter name="Maximum Number of Stepper Failures" type="int" value="10"/>
         <Parameter name="Maximum Number of Consecutive Stepper Failures" type="int" value="5"/>
-        <Parameter name="Integrator Step Type"  type="string" value="Variable"/>
         <ParameterList name="Time Step Control Strategy">
-            <Parameter name="Time Step Control Strategy List" type="string" value="basic_vs"/>
-            <ParameterList name="basic_vs">
-                <Parameter name="Name" type="string" value="Basic VS"/>
-                <Parameter name="Reduction Factor" type="double" value="0.5"/>
-                <Parameter name="Amplification Factor" type="double" value="1.5"/>
-                <Parameter name="Minimum Value Monitoring Function" type="double" value="1.0e-1"/>
-                <Parameter name="Maximum Value Monitoring Function" type="double" value="1.0e-0"/>
-            </ParameterList>
+            <Parameter name="Strategy Type" type="string" value="Basic VS"/>
+            <Parameter name="Reduction Factor" type="double" value="0.5"/>
+            <Parameter name="Amplification Factor" type="double" value="1.5"/>
+            <Parameter name="Minimum Value Monitoring Function" type="double" value="1.0e-1"/>
+            <Parameter name="Maximum Value Monitoring Function" type="double" value="1.0e-0"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>

--- a/packages/tempus/test/BDF2/Tempus_BDF2_SinCos_SA.xml
+++ b/packages/tempus/test/BDF2/Tempus_BDF2_SinCos_SA.xml
@@ -32,7 +32,6 @@
         <Parameter name="Maximum Time Step"      type="double" value="0.1"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
-        <Parameter name="Integrator Step Type"  type="string" value="Constant"/>
         <Parameter name="Output Time List"       type="string" value=""/>
         <Parameter name="Output Index List"      type="string" value=""/>
         <Parameter name="Output Time Interval"   type="double" value="10.0"/>

--- a/packages/tempus/test/BDF2/Tempus_BDF2_SteadyQuadratic.xml
+++ b/packages/tempus/test/BDF2/Tempus_BDF2_SteadyQuadratic.xml
@@ -24,7 +24,6 @@
         <Parameter name="Maximum Time Step"      type="double" value="1.0"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
-        <Parameter name="Integrator Step Type"  type="string" value="Constant"/>
         <Parameter name="Output Time List"       type="string" value=""/>
         <Parameter name="Output Index List"      type="string" value=""/>
         <Parameter name="Output Time Interval"   type="double" value="10.0"/>

--- a/packages/tempus/test/BDF2/Tempus_BDF2_VanDerPol.xml
+++ b/packages/tempus/test/BDF2/Tempus_BDF2_VanDerPol.xml
@@ -36,16 +36,12 @@
         <Parameter name="Output Index Interval"  type="int"    value="100000"/>
         <Parameter name="Maximum Number of Stepper Failures" type="int" value="10"/>
         <Parameter name="Maximum Number of Consecutive Stepper Failures" type="int" value="5"/>
-        <Parameter name="Integrator Step Type"  type="string" value="Variable"/>
         <ParameterList name="Time Step Control Strategy">
-            <Parameter name="Time Step Control Strategy List"  type="string" value="basic_vs"/>
-            <ParameterList name="basic_vs">
-                <Parameter name="Name" type="string" value="Basic VS"/>
-                <Parameter name="Reduction Factor" type="double" value="0.5"/>
-                <Parameter name="Amplification Factor" type="double" value="1.75"/>
-                <Parameter name="Minimum Value Monitoring Function" type="double" value="5.0e-3"/>
-                <Parameter name="Maximum Value Monitoring Function" type="double" value="1.0e-1"/>
-            </ParameterList>
+            <Parameter name="Strategy Type" type="string" value="Basic VS"/>
+            <Parameter name="Reduction Factor" type="double" value="0.5"/>
+            <Parameter name="Amplification Factor" type="double" value="1.75"/>
+            <Parameter name="Minimum Value Monitoring Function" type="double" value="5.0e-3"/>
+            <Parameter name="Maximum Value Monitoring Function" type="double" value="1.0e-1"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>

--- a/packages/tempus/test/BackwardEuler/Tempus_BackwardEulerTest.cpp
+++ b/packages/tempus/test/BackwardEuler/Tempus_BackwardEulerTest.cpp
@@ -136,7 +136,6 @@ TEUCHOS_UNIT_TEST(BackwardEuler, ConstructingFromDefaults)
     auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
     ParameterList tscPL = pl->sublist("Default Integrator")
                              .sublist("Time Step Control");
-    timeStepControl->setStepType (tscPL.get<std::string>("Integrator Step Type"));
     timeStepControl->setInitIndex(tscPL.get<int>   ("Initial Time Index"));
     timeStepControl->setInitTime (tscPL.get<double>("Initial Time"));
     timeStepControl->setFinalTime(tscPL.get<double>("Final Time"));

--- a/packages/tempus/test/BackwardEuler/Tempus_BackwardEuler_CDR.xml
+++ b/packages/tempus/test/BackwardEuler/Tempus_BackwardEuler_CDR.xml
@@ -28,7 +28,6 @@
         <Parameter name="Maximum Time Step"      type="double" value="0.1"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
-        <Parameter name="Integrator Step Type"  type="string" value="Constant"/>
         <Parameter name="Output Time List"       type="string" value=""/>
         <Parameter name="Output Index List"      type="string" value=""/>
         <Parameter name="Output Time Interval"   type="double" value="10.0"/>

--- a/packages/tempus/test/BackwardEuler/Tempus_BackwardEuler_SinCos.xml
+++ b/packages/tempus/test/BackwardEuler/Tempus_BackwardEuler_SinCos.xml
@@ -31,7 +31,6 @@
         <Parameter name="Maximum Time Step"      type="double" value="0.1"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
-        <Parameter name="Integrator Step Type"  type="string" value="Constant"/>
         <Parameter name="Output Time List"       type="string" value=""/>
         <Parameter name="Output Index List"      type="string" value=""/>
         <Parameter name="Output Time Interval"   type="double" value="10.0"/>

--- a/packages/tempus/test/BackwardEuler/Tempus_BackwardEuler_SteadyQuadratic.xml
+++ b/packages/tempus/test/BackwardEuler/Tempus_BackwardEuler_SteadyQuadratic.xml
@@ -24,7 +24,6 @@
         <Parameter name="Maximum Time Step"      type="double" value="1.0"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
-        <Parameter name="Integrator Step Type"  type="string" value="Constant"/>
         <Parameter name="Output Time List"       type="string" value=""/>
         <Parameter name="Output Index List"      type="string" value=""/>
         <Parameter name="Output Time Interval"   type="double" value="10.0"/>

--- a/packages/tempus/test/BackwardEuler/Tempus_BackwardEuler_VanDerPol.xml
+++ b/packages/tempus/test/BackwardEuler/Tempus_BackwardEuler_VanDerPol.xml
@@ -35,16 +35,12 @@
         <Parameter name="Output Index Interval"  type="int"    value="100000"/>
         <Parameter name="Maximum Number of Stepper Failures" type="int" value="10"/>
         <Parameter name="Maximum Number of Consecutive Stepper Failures" type="int" value="5"/>
-        <Parameter name="Integrator Step Type"  type="string" value="Variable"/>
         <ParameterList name="Time Step Control Strategy">
-            <Parameter name="Time Step Control Strategy List"  type="string" value="basic_vs"/>
-            <ParameterList name="basic_vs">
-                <Parameter name="Name" type="string" value="Basic VS"/>
-                <Parameter name="Reduction Factor" type="double" value="0.5"/>
-                <Parameter name="Amplification Factor" type="double" value="1.75"/>
-                <Parameter name="Minimum Value Monitoring Function" type="double" value="0.0"/>
-                <Parameter name="Maximum Value Monitoring Function" type="double" value="1.0e+10"/>
-            </ParameterList>
+            <Parameter name="Strategy Type" type="string" value="Basic VS"/>
+            <Parameter name="Reduction Factor" type="double" value="0.5"/>
+            <Parameter name="Amplification Factor" type="double" value="1.75"/>
+            <Parameter name="Minimum Value Monitoring Function" type="double" value="0.0"/>
+            <Parameter name="Maximum Value Monitoring Function" type="double" value="1.0e+10"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>

--- a/packages/tempus/test/DIRK/Tempus_DIRKTest.cpp
+++ b/packages/tempus/test/DIRK/Tempus_DIRKTest.cpp
@@ -212,7 +212,6 @@ TEUCHOS_UNIT_TEST(DIRK, ConstructingFromDefaults)
     auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
     ParameterList tscPL = pl->sublist("Default Integrator")
                              .sublist("Time Step Control");
-    timeStepControl->setStepType (tscPL.get<std::string>("Integrator Step Type"));
     timeStepControl->setInitIndex(tscPL.get<int>   ("Initial Time Index"));
     timeStepControl->setInitTime (tscPL.get<double>("Initial Time"));
     timeStepControl->setFinalTime(tscPL.get<double>("Final Time"));
@@ -307,7 +306,6 @@ TEUCHOS_UNIT_TEST(DIRK, useFSAL_false)
 
     // Setup TimeStepControl ------------------------------------
     auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
-    timeStepControl->setStepType ("Constant");
     timeStepControl->setInitTime (0.0);
     timeStepControl->setFinalTime(1.0);
     timeStepControl->setInitTimeStep(dt);
@@ -356,8 +354,8 @@ TEUCHOS_UNIT_TEST(DIRK, useFSAL_false)
     Thyra::V_StVpStV(xdiff.ptr(), 1.0, *x_exact, -1.0, *(x));
 
     // Check the order and intercept
-     std::cout << "  Stepper = " << stepper->description()
-               << "\n            with " << "useFSAL=false" << std::endl;
+    std::cout << "  Stepper = " << stepper->description()
+              << "\n            with " << "useFSAL=false" << std::endl;
     std::cout << "  =========================" << std::endl;
     std::cout << "  Exact solution   : " << get_ele(*(x_exact), 0) << "   "
                                          << get_ele(*(x_exact), 1) << std::endl;

--- a/packages/tempus/test/DIRK/Tempus_DIRK_SinCos.xml
+++ b/packages/tempus/test/DIRK/Tempus_DIRK_SinCos.xml
@@ -31,7 +31,6 @@
         <Parameter name="Maximum Time Step"      type="double" value="0.1"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
-        <Parameter name="Integrator Step Type"  type="string" value="Constant"/>
         <Parameter name="Output Time List"       type="string" value=""/>
         <Parameter name="Output Index List"      type="string" value=""/>
         <Parameter name="Output Time Interval"   type="double" value="10.0"/>

--- a/packages/tempus/test/DIRK/Tempus_DIRK_SteadyQuadratic.xml
+++ b/packages/tempus/test/DIRK/Tempus_DIRK_SteadyQuadratic.xml
@@ -24,7 +24,6 @@
         <Parameter name="Maximum Time Step"      type="double" value="1.0"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
-        <Parameter name="Integrator Step Type"  type="string" value="Constant"/>
         <Parameter name="Output Time List"       type="string" value=""/>
         <Parameter name="Output Index List"      type="string" value=""/>
         <Parameter name="Output Time Interval"   type="double" value="10.0"/>

--- a/packages/tempus/test/DIRK/Tempus_DIRK_VanDerPol.xml
+++ b/packages/tempus/test/DIRK/Tempus_DIRK_VanDerPol.xml
@@ -43,16 +43,12 @@
         <Parameter name="Output Index Interval"  type="int"    value="100000"/>
         <Parameter name="Maximum Number of Stepper Failures" type="int" value="10"/>
         <Parameter name="Maximum Number of Consecutive Stepper Failures" type="int" value="5"/>
-        <Parameter name="Integrator Step Type"  type="string" value="Variable"/>
         <ParameterList name="Time Step Control Strategy">
-            <Parameter name="Time Step Control Strategy List"  type="string" value="basic_vs"/>
-            <ParameterList name="basic_vs">
-                <Parameter name="Name" type="string" value="Basic VS"/>
-                <Parameter name="Reduction Factor" type="double" value="0.5"/>
-                <Parameter name="Amplification Factor" type="double" value="1.75"/>
-                <Parameter name="Minimum Value Monitoring Function" type="double" value="1.0e-6"/>
-                <Parameter name="Maximum Value Monitoring Function" type="double" value="5.0e-1"/>
-            </ParameterList>
+            <Parameter name="Strategy Type" type="string" value="Basic VS"/>
+            <Parameter name="Reduction Factor" type="double" value="0.5"/>
+            <Parameter name="Amplification Factor" type="double" value="1.75"/>
+            <Parameter name="Minimum Value Monitoring Function" type="double" value="1.0e-6"/>
+            <Parameter name="Maximum Value Monitoring Function" type="double" value="5.0e-1"/>
         </ParameterList>
       </ParameterList>
   </ParameterList>
@@ -69,7 +65,6 @@
       <ParameterList name="Time Step Control">
           <Parameter name="Initial Time"           type="double" value="0.0"/>
           <Parameter name="Final Time"             type="double" value="2.0"/>
-          <Parameter name="Integrator Step Type"  type="string" value="Constant"/>
           <Parameter name="Number of Time Steps" type="int" value="100"/>
       </ParameterList>
   </ParameterList>
@@ -92,14 +87,17 @@
           <Parameter name="Maximum Absolute Error" type="double" value="1.0e-3"/>
           <Parameter name="Maximum Relative Error" type="double" value="1.0e-3"/>
           <Parameter name="Output Index Interval"  type="int"    value="1"/>
-          <Parameter name="Integrator Step Type"  type="string" value="Variable"/>
           <Parameter name="Maximum Number of Stepper Failures" type="int" value="12"/>
           <Parameter name="Maximum Number of Consecutive Stepper Failures" type="int" value="3"/>
           <ParameterList name="Time Step Control Strategy">
-              <Parameter name="Time Step Control Strategy List" type="string" value="pid"/>
-              <ParameterList name="pid">
-                  <Parameter name="Name" type="string" value="Integral Controller"/>
-              </ParameterList>
+              <Parameter name="Strategy Type"   type="string" value="Integral Controller"/>
+              <Parameter name="Controller Type" type="string" value="PID"/>
+              <Parameter name="KI"              type="double" value="0.58"/>
+              <Parameter name="KP"              type="double" value="0.21"/>
+              <Parameter name="KD"              type="double" value="0.10"/>
+              <Parameter name="Safety Factor"   type="double" value="0.90"/>
+              <Parameter name="Maximum Safety Factor" type="double" value="5.0"/>
+              <Parameter name="Minimum Safety Factor" type="double" value="0.5"/>
           </ParameterList>
       </ParameterList>
   </ParameterList>

--- a/packages/tempus/test/ExplicitRK/Tempus_ExplicitRKTest.cpp
+++ b/packages/tempus/test/ExplicitRK/Tempus_ExplicitRKTest.cpp
@@ -167,7 +167,6 @@ TEUCHOS_UNIT_TEST(ExplicitRK, ConstructingFromDefaults)
     auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
     ParameterList tscPL = pl->sublist("Demo Integrator")
                              .sublist("Time Step Control");
-    timeStepControl->setStepType (tscPL.get<std::string>("Integrator Step Type"));
     timeStepControl->setInitIndex(tscPL.get<int>   ("Initial Time Index"));
     timeStepControl->setInitTime (tscPL.get<double>("Initial Time"));
     timeStepControl->setFinalTime(tscPL.get<double>("Final Time"));
@@ -262,7 +261,6 @@ TEUCHOS_UNIT_TEST(ExplicitRK, useFSAL_false)
 
     // Setup TimeStepControl ------------------------------------
     auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
-    timeStepControl->setStepType ("Constant");
     timeStepControl->setInitTime (0.0);
     timeStepControl->setFinalTime(1.0);
     timeStepControl->setInitTimeStep(dt);
@@ -311,8 +309,8 @@ TEUCHOS_UNIT_TEST(ExplicitRK, useFSAL_false)
     Thyra::V_StVpStV(xdiff.ptr(), 1.0, *x_exact, -1.0, *(x));
 
     // Check the order and intercept
-     std::cout << "  Stepper = " << stepper->description()
-               << "\n            with " << "useFSAL=false" << std::endl;
+    std::cout << "  Stepper = " << stepper->description()
+              << "\n            with " << "useFSAL=false" << std::endl;
     std::cout << "  =========================" << std::endl;
     std::cout << "  Exact solution   : " << get_ele(*(x_exact), 0) << "   "
                                          << get_ele(*(x_exact), 1) << std::endl;
@@ -656,7 +654,6 @@ TEUCHOS_UNIT_TEST(ExplicitRK, stage_number)
   auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
   ParameterList tscPL = pl->sublist("Demo Integrator")
                            .sublist("Time Step Control");
-  timeStepControl->setStepType (tscPL.get<std::string>("Integrator Step Type"));
   timeStepControl->setInitIndex(tscPL.get<int>   ("Initial Time Index"));
   timeStepControl->setInitTime (tscPL.get<double>("Initial Time"));
   timeStepControl->setFinalTime(tscPL.get<double>("Final Time"));

--- a/packages/tempus/test/ExplicitRK/Tempus_ExplicitRK_SinCos.xml
+++ b/packages/tempus/test/ExplicitRK/Tempus_ExplicitRK_SinCos.xml
@@ -31,7 +31,6 @@
         <Parameter name="Maximum Time Step"      type="double" value="0.1"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
-        <Parameter name="Integrator Step Type"  type="string" value="Constant"/>
         <Parameter name="Output Time List"       type="string" value=""/>
         <Parameter name="Output Index List"      type="string" value=""/>
         <Parameter name="Output Time Interval"   type="double" value="10.0"/>

--- a/packages/tempus/test/ExplicitRK/Tempus_ExplicitRK_SteadyQuadratic.xml
+++ b/packages/tempus/test/ExplicitRK/Tempus_ExplicitRK_SteadyQuadratic.xml
@@ -24,7 +24,6 @@
         <Parameter name="Maximum Time Step"      type="double" value="1.0"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
-        <Parameter name="Integrator Step Type"  type="string" value="Constant"/>
         <Parameter name="Output Time List"       type="string" value=""/>
         <Parameter name="Output Index List"      type="string" value=""/>
         <Parameter name="Output Time Interval"   type="double" value="10.0"/>

--- a/packages/tempus/test/ExplicitRK/Tempus_ExplicitRK_VanDerPol.xml
+++ b/packages/tempus/test/ExplicitRK/Tempus_ExplicitRK_VanDerPol.xml
@@ -24,7 +24,6 @@
                 <Parameter name="Final Time"             type="double" value="2.0"/>
                 <!--<Parameter name="Initial Time Step"      type="double" value="0.0001"/>-->
                 <!--<Parameter name="Initial Time Index"     type="int"    value="0"/>-->
-                <Parameter name="Integrator Step Type"  type="string" value="Constant"/>
                 <Parameter name="Number of Time Steps" type="int" value="100"/>
             </ParameterList>
         </ParameterList>
@@ -42,7 +41,6 @@
             <ParameterList name="Time Step Control">
                 <Parameter name="Initial Time"           type="double" value="0.0"/>
                 <Parameter name="Final Time"             type="double" value="2.0"/>
-                <Parameter name="Integrator Step Type"  type="string" value="Constant"/>
                 <Parameter name="Number of Time Steps" type="int" value="100"/>
             </ParameterList>
         </ParameterList>
@@ -59,7 +57,6 @@
             <ParameterList name="Time Step Control">
                 <Parameter name="Initial Time"           type="double" value="0.0"/>
                 <Parameter name="Final Time"             type="double" value="2.0"/>
-                <Parameter name="Integrator Step Type"  type="string" value="Constant"/>
                 <Parameter name="Number of Time Steps" type="int" value="100"/>
             </ParameterList>
         </ParameterList>
@@ -82,14 +79,10 @@
                 <Parameter name="Maximum Absolute Error" type="double" value="1.0e-3"/>
                 <Parameter name="Maximum Relative Error" type="double" value="1.0e-3"/>
                 <Parameter name="Output Index Interval"  type="int"    value="1"/>
-                <Parameter name="Integrator Step Type"  type="string" value="Variable"/>
                 <Parameter name="Maximum Number of Stepper Failures" type="int" value="12"/>
                 <Parameter name="Maximum Number of Consecutive Stepper Failures" type="int" value="5"/>
                 <ParameterList name="Time Step Control Strategy">
-                    <Parameter name="Time Step Control Strategy List" type="string" value="pid"/>
-                    <ParameterList name="pid">
-                        <Parameter name="Name" type="string" value="Integral Controller"/>
-                    </ParameterList>
+                    <Parameter name="Strategy Type" type="string" value="Integral Controller"/>
                 </ParameterList>
             </ParameterList>
          </ParameterList>
@@ -112,16 +105,12 @@
                 <Parameter name="Maximum Absolute Error" type="double" value="1.0e-3"/>
                 <Parameter name="Maximum Relative Error" type="double" value="1.0e-3"/>
                 <Parameter name="Output Index Interval"  type="int"    value="1"/>
-                <Parameter name="Integrator Step Type"   type="string" value="Variable"/>
                 <Parameter name="Output Exactly On Output Times"  type="bool" value="false"/>
                 <Parameter name="Output Time List"       type="string" value="0.12"/>
                 <Parameter name="Maximum Number of Stepper Failures" type="int" value="12"/>
                 <Parameter name="Maximum Number of Consecutive Stepper Failures" type="int" value="5"/>
                 <ParameterList name="Time Step Control Strategy">
-                    <Parameter name="Time Step Control Strategy List" type="string" value="pid"/>
-                    <ParameterList name="pid">
-                        <Parameter name="Name" type="string" value="Integral Controller"/>
-                    </ParameterList>
+                    <Parameter name="Strategy Type" type="string" value="Integral Controller"/>
                 </ParameterList>
             </ParameterList>
         </ParameterList>

--- a/packages/tempus/test/ForwardEuler/Tempus_ForwardEulerTest.cpp
+++ b/packages/tempus/test/ForwardEuler/Tempus_ForwardEulerTest.cpp
@@ -131,7 +131,6 @@ TEUCHOS_UNIT_TEST(ForwardEuler, ConstructingFromDefaults)
     auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
     ParameterList tscPL = pl->sublist("Demo Integrator")
                              .sublist("Time Step Control");
-    timeStepControl->setStepType (tscPL.get<std::string>("Integrator Step Type"));
     timeStepControl->setInitIndex(tscPL.get<int>   ("Initial Time Index"));
     timeStepControl->setInitTime (tscPL.get<double>("Initial Time"));
     timeStepControl->setFinalTime(tscPL.get<double>("Final Time"));
@@ -437,10 +436,6 @@ TEUCHOS_UNIT_TEST(ForwardEuler, NumberTimeSteps)
     const int numTimeSteps = pl->sublist("Demo Integrator")
                                 .sublist("Time Step Control")
                                 .get<int>("Number of Time Steps");
-    const std::string integratorStepperType =
-      pl->sublist("Demo Integrator")
-         .sublist("Time Step Control")
-         .get<std::string>("Integrator Step Type");
 
     RCP<Tempus::IntegratorBasic<double> > integrator =
       Tempus::integratorBasic<double>(pl, model);
@@ -476,20 +471,16 @@ TEUCHOS_UNIT_TEST(ForwardEuler, Variable_TimeSteps)
 
   pl->sublist("Demo Integrator")
      .sublist("Time Step Control")
-     .sublist("Time Step Control Strategy")
-     .sublist("basic_vs").set("Reduction Factor", 0.9);
+     .sublist("Time Step Control Strategy").set("Reduction Factor", 0.9);
   pl->sublist("Demo Integrator")
      .sublist("Time Step Control")
-     .sublist("Time Step Control Strategy")
-     .sublist("basic_vs").set("Amplification Factor", 1.15);
+     .sublist("Time Step Control Strategy").set("Amplification Factor", 1.15);
   pl->sublist("Demo Integrator")
      .sublist("Time Step Control")
-     .sublist("Time Step Control Strategy")
-     .sublist("basic_vs").set("Minimum Value Monitoring Function", 0.05);
+     .sublist("Time Step Control Strategy").set("Minimum Value Monitoring Function", 0.05);
   pl->sublist("Demo Integrator")
      .sublist("Time Step Control")
-     .sublist("Time Step Control Strategy")
-     .sublist("basic_vs").set("Maximum Value Monitoring Function", 0.1);
+     .sublist("Time Step Control Strategy").set("Maximum Value Monitoring Function", 0.1);
 
   pl->sublist("Demo Integrator")
      .sublist("Solution History").set("Storage Type", "Static");

--- a/packages/tempus/test/ForwardEuler/Tempus_ForwardEuler_NumberOfTimeSteps.xml
+++ b/packages/tempus/test/ForwardEuler/Tempus_ForwardEuler_NumberOfTimeSteps.xml
@@ -24,7 +24,6 @@
         <Parameter name="Final Time"             type="double" value="3.0"/>
         <Parameter name="Number of Time Steps"   type="int"    value="5"/>
         <Parameter name="Initial Time Step"      type="double" value="0"/>
-        <Parameter name="Integrator Step Type"  type="string" value="Constant"/>
       </ParameterList>
     </ParameterList>
 

--- a/packages/tempus/test/ForwardEuler/Tempus_ForwardEuler_SinCos.xml
+++ b/packages/tempus/test/ForwardEuler/Tempus_ForwardEuler_SinCos.xml
@@ -31,13 +31,16 @@
         <Parameter name="Maximum Time Step"      type="double" value="0.1"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
-        <Parameter name="Integrator Step Type"  type="string" value="Constant"/>
         <Parameter name="Output Time List"       type="string" value=""/>
         <Parameter name="Output Index List"      type="string" value=""/>
         <Parameter name="Output Time Interval"   type="double" value="10.0"/>
         <Parameter name="Output Index Interval"  type="int"    value="1000"/>
         <Parameter name="Maximum Number of Stepper Failures" type="int" value="10"/>
         <Parameter name="Maximum Number of Consecutive Stepper Failures" type="int" value="5"/>
+        <ParameterList name="Time Step Control Strategy">
+           <Parameter name="Strategy Type" type="string" value="Constant Time Step"/>
+           <Parameter name="Time Step Size" type="double" value="1.0"/>
+        </ParameterList>
       </ParameterList>
     </ParameterList>
 

--- a/packages/tempus/test/ForwardEuler/Tempus_ForwardEuler_VanDerPol.xml
+++ b/packages/tempus/test/ForwardEuler/Tempus_ForwardEuler_VanDerPol.xml
@@ -35,16 +35,12 @@
         <Parameter name="Output Index Interval"  type="int"    value="100000"/>
         <Parameter name="Maximum Number of Stepper Failures" type="int" value="10"/>
         <Parameter name="Maximum Number of Consecutive Stepper Failures" type="int" value="5"/>
-        <Parameter name="Integrator Step Type"  type="string" value="Variable"/>
         <ParameterList name="Time Step Control Strategy">
-            <Parameter name="Time Step Control Strategy List"  type="string" value="basic_vs"/>
-            <ParameterList name="basic_vs">
-                <Parameter name="Name" type="string" value="Basic VS"/>
-                <Parameter name="Reduction Factor" type="double" value="0.5"/>
-                <Parameter name="Amplification Factor" type="double" value="1.75"/>
-                <Parameter name="Minimum Value Monitoring Function" type="double" value="1.0e-6"/>
-                <Parameter name="Maximum Value Monitoring Function" type="double" value="5.0e-1"/>
-            </ParameterList>
+            <Parameter name="Strategy Type" type="string" value="Basic VS"/>
+            <Parameter name="Reduction Factor" type="double" value="0.5"/>
+            <Parameter name="Amplification Factor" type="double" value="1.75"/>
+            <Parameter name="Minimum Value Monitoring Function" type="double" value="1.0e-6"/>
+            <Parameter name="Maximum Value Monitoring Function" type="double" value="5.0e-1"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>

--- a/packages/tempus/test/HHTAlpha/Tempus_HHTAlphaTest.cpp
+++ b/packages/tempus/test/HHTAlpha/Tempus_HHTAlphaTest.cpp
@@ -138,7 +138,6 @@ TEUCHOS_UNIT_TEST(HHTAlpha, ConstructingFromDefaults)
   auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
   ParameterList tscPL = pl->sublist("Default Integrator")
                            .sublist("Time Step Control");
-  timeStepControl->setStepType (tscPL.get<std::string>("Integrator Step Type"));
   timeStepControl->setInitIndex(tscPL.get<int>   ("Initial Time Index"));
   timeStepControl->setInitTime (tscPL.get<double>("Initial Time"));
   timeStepControl->setFinalTime(tscPL.get<double>("Final Time"));

--- a/packages/tempus/test/HHTAlpha/Tempus_HHTAlpha_BallParabolic.xml
+++ b/packages/tempus/test/HHTAlpha/Tempus_HHTAlpha_BallParabolic.xml
@@ -25,7 +25,6 @@
         <Parameter name="Initial Time Step"      type="double" value="0.2"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
-        <Parameter name="Integrator Step Type"  type="string" value="Constant"/>
         <Parameter name="Output Time List"       type="string" value=""/>
         <Parameter name="Output Index List"      type="string" value=""/>
         <Parameter name="Output Time Interval"   type="double" value="1.0"/>

--- a/packages/tempus/test/HHTAlpha/Tempus_HHTAlpha_SinCos_ExplicitCD.xml
+++ b/packages/tempus/test/HHTAlpha/Tempus_HHTAlpha_SinCos_ExplicitCD.xml
@@ -28,7 +28,6 @@
         <Parameter name="Initial Time Step"      type="double" value="0.05"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
-        <Parameter name="Integrator Step Type"  type="string" value="Constant"/>
         <Parameter name="Output Time List"       type="string" value=""/>
         <Parameter name="Output Index List"      type="string" value=""/>
         <Parameter name="Output Time Interval"   type="double" value="1.0"/>

--- a/packages/tempus/test/HHTAlpha/Tempus_HHTAlpha_SinCos_FirstOrder.xml
+++ b/packages/tempus/test/HHTAlpha/Tempus_HHTAlpha_SinCos_FirstOrder.xml
@@ -28,7 +28,6 @@
         <Parameter name="Initial Time Step"      type="double" value="0.05"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
-        <Parameter name="Integrator Step Type"  type="string" value="Constant"/>
         <Parameter name="Output Time List"       type="string" value=""/>
         <Parameter name="Output Index List"      type="string" value=""/>
         <Parameter name="Output Time Interval"   type="double" value="1.0"/>

--- a/packages/tempus/test/HHTAlpha/Tempus_HHTAlpha_SinCos_SecondOrder.xml
+++ b/packages/tempus/test/HHTAlpha/Tempus_HHTAlpha_SinCos_SecondOrder.xml
@@ -28,7 +28,6 @@
         <Parameter name="Initial Time Step"      type="double" value="0.05"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
-        <Parameter name="Integrator Step Type"  type="string" value="Constant"/>
         <Parameter name="Output Time List"       type="string" value=""/>
         <Parameter name="Output Index List"      type="string" value=""/>
         <Parameter name="Output Time Interval"   type="double" value="1.0"/>

--- a/packages/tempus/test/IMEX_RK/Tempus_IMEX_RKTest.cpp
+++ b/packages/tempus/test/IMEX_RK/Tempus_IMEX_RKTest.cpp
@@ -69,7 +69,6 @@ TEUCHOS_UNIT_TEST(IMEX_RK, ConstructingFromDefaults)
   auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
   ParameterList tscPL = pl->sublist("Default Integrator")
                            .sublist("Time Step Control");
-  timeStepControl->setStepType (tscPL.get<std::string>("Integrator Step Type"));
   timeStepControl->setInitIndex(tscPL.get<int>   ("Initial Time Index"));
   timeStepControl->setInitTime (tscPL.get<double>("Initial Time"));
   timeStepControl->setFinalTime(tscPL.get<double>("Final Time"));

--- a/packages/tempus/test/IMEX_RK/Tempus_IMEX_RK_FSA.hpp
+++ b/packages/tempus/test/IMEX_RK/Tempus_IMEX_RK_FSA.hpp
@@ -156,8 +156,6 @@ void test_vdp_fsa(const bool use_combined_method,
       pl->sublist("Default Integrator")
          .sublist("Time Step Control").set("Initial Time Step", dt);
       pl->sublist("Default Integrator")
-         .sublist("Time Step Control").set("Integrator Step Type", "Constant");
-      pl->sublist("Default Integrator")
          .sublist("Time Step Control").remove("Time Step Control Strategy");
       RCP<Tempus::IntegratorForwardSensitivity<double> > integrator =
         Tempus::integratorForwardSensitivity<double>(pl, model);

--- a/packages/tempus/test/IMEX_RK/Tempus_IMEX_RK_VanDerPol.xml
+++ b/packages/tempus/test/IMEX_RK/Tempus_IMEX_RK_VanDerPol.xml
@@ -35,16 +35,12 @@
         <Parameter name="Output Index Interval"  type="int"    value="100000"/>
         <Parameter name="Maximum Number of Stepper Failures" type="int" value="10"/>
         <Parameter name="Maximum Number of Consecutive Stepper Failures" type="int" value="5"/>
-        <Parameter name="Integrator Step Type"  type="string" value="Variable"/>
         <ParameterList name="Time Step Control Strategy">
-            <Parameter name="Time Step Control Strategy List"  type="string" value="basic_vs"/>
-            <ParameterList name="basic_vs">
-                <Parameter name="Name" type="string" value="Basic VS"/>
-                <Parameter name="Reduction Factor" type="double" value="0.5"/>
-                <Parameter name="Amplification Factor" type="double" value="1.75"/>
-                <Parameter name="Minimum Value Monitoring Function" type="double" value="1.0e-6"/>
-                <Parameter name="Maximum Value Monitoring Function" type="double" value="5.0e0"/>
-            </ParameterList>
+            <Parameter name="Strategy Type" type="string" value="Basic VS"/>
+            <Parameter name="Reduction Factor" type="double" value="0.5"/>
+            <Parameter name="Amplification Factor" type="double" value="1.75"/>
+            <Parameter name="Minimum Value Monitoring Function" type="double" value="1.0e-6"/>
+            <Parameter name="Maximum Value Monitoring Function" type="double" value="5.0e0"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>

--- a/packages/tempus/test/IMEX_RK_Partitioned/Tempus_IMEX_RK_PartitionedTest.cpp
+++ b/packages/tempus/test/IMEX_RK_Partitioned/Tempus_IMEX_RK_PartitionedTest.cpp
@@ -74,7 +74,6 @@ TEUCHOS_UNIT_TEST(IMEX_RK_Partitioned, ConstructingFromDefaults)
   auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
   ParameterList tscPL = pl->sublist("Default Integrator")
                            .sublist("Time Step Control");
-  timeStepControl->setStepType (tscPL.get<std::string>("Integrator Step Type"));
   timeStepControl->setInitIndex(tscPL.get<int>   ("Initial Time Index"));
   timeStepControl->setInitTime (tscPL.get<double>("Initial Time"));
   timeStepControl->setFinalTime(tscPL.get<double>("Final Time"));

--- a/packages/tempus/test/IMEX_RK_Partitioned/Tempus_IMEX_RK_Partitioned_FSA.hpp
+++ b/packages/tempus/test/IMEX_RK_Partitioned/Tempus_IMEX_RK_Partitioned_FSA.hpp
@@ -200,8 +200,6 @@ void test_vdp_fsa(const std::string& method_name,
       pl->sublist("Default Integrator")
          .sublist("Time Step Control").set("Initial Time Step", dt);
       pl->sublist("Default Integrator")
-         .sublist("Time Step Control").set("Integrator Step Type", "Constant");
-      pl->sublist("Default Integrator")
          .sublist("Time Step Control").remove("Time Step Control Strategy");
       RCP<Tempus::IntegratorForwardSensitivity<double> > integrator =
         Tempus::integratorForwardSensitivity<double>(pl, model);

--- a/packages/tempus/test/IMEX_RK_Partitioned/Tempus_IMEX_RK_VanDerPol.xml
+++ b/packages/tempus/test/IMEX_RK_Partitioned/Tempus_IMEX_RK_VanDerPol.xml
@@ -35,16 +35,12 @@
         <Parameter name="Output Index Interval"  type="int"    value="100000"/>
         <Parameter name="Maximum Number of Stepper Failures" type="int" value="10"/>
         <Parameter name="Maximum Number of Consecutive Stepper Failures" type="int" value="5"/>
-        <Parameter name="Integrator Step Type"  type="string" value="Variable"/>
         <ParameterList name="Time Step Control Strategy">
-            <Parameter name="Time Step Control Strategy List"  type="string" value="basic_vs"/>
-            <ParameterList name="basic_vs">
-                <Parameter name="Name" type="string" value="Basic VS"/>
-                <Parameter name="Reduction Factor" type="double" value="0.5"/>
-                <Parameter name="Amplification Factor" type="double" value="1.75"/>
-                <Parameter name="Minimum Value Monitoring Function" type="double" value="1.0e-6"/>
-                <Parameter name="Maximum Value Monitoring Function" type="double" value="5.0e0"/>
-            </ParameterList>
+            <Parameter name="Strategy Type" type="string" value="Basic VS"/>
+            <Parameter name="Reduction Factor" type="double" value="0.5"/>
+            <Parameter name="Amplification Factor" type="double" value="1.75"/>
+            <Parameter name="Minimum Value Monitoring Function" type="double" value="1.0e-6"/>
+            <Parameter name="Maximum Value Monitoring Function" type="double" value="5.0e0"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>

--- a/packages/tempus/test/Integrator/Tempus_IntegratorBasic_ref.xml
+++ b/packages/tempus/test/Integrator/Tempus_IntegratorBasic_ref.xml
@@ -21,7 +21,6 @@
       <Parameter docString="" id="25" isDefault="true" isUsed="true" name="Number of Time Steps" type="int" value="-1"/>
       <Parameter docString="" id="13" isDefault="true" isUsed="true" name="Maximum Absolute Error" type="double" value="1.00000000000000002e-08"/>
       <Parameter docString="" id="14" isDefault="true" isUsed="true" name="Maximum Relative Error" type="double" value="1.00000000000000002e-08"/>
-      <Parameter docString="" id="18" isDefault="true" isUsed="true" name="Integrator Step Type" type="string" value="Variable"/>
       <Parameter docString="" id="38" isDefault="true" isUsed="true" name="Print Time Step Changes" type="bool" value="true"/>
       <Parameter docString="" id="37" isDefault="true" isUsed="true" name="Output Exactly On Output Times" type="bool" value="true"/>
       <Parameter docString="" id="22" isDefault="true" isUsed="true" name="Output Index Interval" type="int" value="1000000"/>
@@ -31,7 +30,8 @@
       <Parameter docString="" id="23" isDefault="true" isUsed="true" name="Maximum Number of Stepper Failures" type="int" value="10"/>
       <Parameter docString="" id="24" isDefault="true" isUsed="true" name="Maximum Number of Consecutive Stepper Failures" type="int" value="5"/>
       <ParameterList id="32" name="Time Step Control Strategy">
-          <Parameter docString="" id="33" isDefault="true" isUsed="true" name="Time Step Control Strategy List" type="string" value=""/>
+          <Parameter docString="" id="39" isDefault="true" isUsed="true" name="Strategy Type" type="string" value="Constant"/>
+          <Parameter docString="" id="33" isDefault="true" isUsed="true" name="Time Step" type="double" value="1.0"/>
       </ParameterList>
     </ParameterList>
     <Parameter docString="" id="27" isDefault="true" isUsed="true" name="Screen Output Index List" type="string" value=""/>

--- a/packages/tempus/test/Integrator/Tempus_IntegratorBasic_ref2.xml
+++ b/packages/tempus/test/Integrator/Tempus_IntegratorBasic_ref2.xml
@@ -23,7 +23,6 @@
       <Parameter docString="" id="27" isDefault="true" isUsed="true" name="Number of Time Steps" type="int" value="-1"/>
       <Parameter docString="" id="15" isDefault="true" isUsed="true" name="Maximum Absolute Error" type="double" value="1.00000000000000002e-08"/>
       <Parameter docString="" id="16" isDefault="true" isUsed="true" name="Maximum Relative Error" type="double" value="1.00000000000000002e-08"/>
-      <Parameter docString="" id="20" isDefault="true" isUsed="true" name="Integrator Step Type" type="string" value="Variable"/>
       <Parameter docString="" id="38" isDefault="true" isUsed="true" name="Print Time Step Changes" type="bool" value="true"/>
       <Parameter docString="" id="37" isDefault="true" isUsed="true" name="Output Exactly On Output Times" type="bool" value="true"/>
       <Parameter docString="" id="24" isDefault="true" isUsed="true" name="Output Index Interval" type="int" value="1000000"/>
@@ -33,7 +32,8 @@
       <Parameter docString="" id="25" isDefault="true" isUsed="true" name="Maximum Number of Stepper Failures" type="int" value="10"/>
       <Parameter docString="" id="26" isDefault="true" isUsed="true" name="Maximum Number of Consecutive Stepper Failures" type="int" value="5"/>
       <ParameterList id="32" name="Time Step Control Strategy">
-          <Parameter docString="" id="33" isDefault="true" isUsed="true" name="Time Step Control Strategy List" type="string" value=""/>
+          <Parameter docString="" id="20" isDefault="true" isUsed="true" name="Strategy Type" type="string" value="Constant"/>
+          <Parameter docString="" id="33" isDefault="true" isUsed="true" name="Time Step" type="double" value="1.0"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>

--- a/packages/tempus/test/Leapfrog/Tempus_LeapfrogTest.cpp
+++ b/packages/tempus/test/Leapfrog/Tempus_LeapfrogTest.cpp
@@ -79,7 +79,6 @@ TEUCHOS_UNIT_TEST(Leapfrog, ConstructingFromDefaults)
     auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
     ParameterList tscPL = pl->sublist("Default Integrator")
                              .sublist("Time Step Control");
-    timeStepControl->setStepType (tscPL.get<std::string>("Integrator Step Type"));
     timeStepControl->setInitIndex(tscPL.get<int>   ("Initial Time Index"));
     timeStepControl->setInitTime (tscPL.get<double>("Initial Time"));
     timeStepControl->setFinalTime(tscPL.get<double>("Final Time"));

--- a/packages/tempus/test/Leapfrog/Tempus_Leapfrog_SinCos.xml
+++ b/packages/tempus/test/Leapfrog/Tempus_Leapfrog_SinCos.xml
@@ -25,7 +25,6 @@
         <Parameter name="Initial Time Step"      type="double" value="0.1"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
-        <Parameter name="Integrator Step Type"  type="string" value="Constant"/>
         <Parameter name="Output Time List"       type="string" value=""/>
         <Parameter name="Output Index List"      type="string" value=""/>
         <Parameter name="Output Time Interval"   type="double" value="1.0"/>

--- a/packages/tempus/test/Newmark/Tempus_NewmarkExplicitAForm_BallParabolic.xml
+++ b/packages/tempus/test/Newmark/Tempus_NewmarkExplicitAForm_BallParabolic.xml
@@ -25,7 +25,6 @@
         <Parameter name="Initial Time Step"      type="double" value="0.2"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
-        <Parameter name="Integrator Step Type"  type="string" value="Constant"/>
         <Parameter name="Output Time List"       type="string" value=""/>
         <Parameter name="Output Index List"      type="string" value=""/>
         <Parameter name="Output Time Interval"   type="double" value="1.0"/>

--- a/packages/tempus/test/Newmark/Tempus_NewmarkExplicitAForm_HarmonicOscillator_Damped.xml
+++ b/packages/tempus/test/Newmark/Tempus_NewmarkExplicitAForm_HarmonicOscillator_Damped.xml
@@ -25,7 +25,6 @@
         <Parameter name="Initial Time Step"      type="double" value="1.0"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
-        <Parameter name="Integrator Step Type"  type="string" value="Constant"/>
         <Parameter name="Output Time List"       type="string" value=""/>
         <Parameter name="Output Index List"      type="string" value=""/>
         <Parameter name="Output Time Interval"   type="double" value="1.0"/>

--- a/packages/tempus/test/Newmark/Tempus_NewmarkExplicitAForm_SinCos.xml
+++ b/packages/tempus/test/Newmark/Tempus_NewmarkExplicitAForm_SinCos.xml
@@ -25,7 +25,6 @@
         <Parameter name="Initial Time Step"      type="double" value="0.1"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
-        <Parameter name="Integrator Step Type"  type="string" value="Constant"/>
         <Parameter name="Output Time List"       type="string" value=""/>
         <Parameter name="Output Index List"      type="string" value=""/>
         <Parameter name="Output Time Interval"   type="double" value="1.0"/>

--- a/packages/tempus/test/Newmark/Tempus_NewmarkImplicitAForm_HarmonicOscillator_Damped_FirstOrder.xml
+++ b/packages/tempus/test/Newmark/Tempus_NewmarkImplicitAForm_HarmonicOscillator_Damped_FirstOrder.xml
@@ -25,7 +25,6 @@
         <Parameter name="Initial Time Step"      type="double" value="0.125"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
-        <Parameter name="Integrator Step Type"  type="string" value="Constant"/>
         <Parameter name="Output Time List"       type="string" value=""/>
         <Parameter name="Output Index List"      type="string" value=""/>
         <Parameter name="Output Time Interval"   type="double" value="1.0"/>

--- a/packages/tempus/test/Newmark/Tempus_NewmarkImplicitAForm_HarmonicOscillator_Damped_SecondOrder.xml
+++ b/packages/tempus/test/Newmark/Tempus_NewmarkImplicitAForm_HarmonicOscillator_Damped_SecondOrder.xml
@@ -25,7 +25,6 @@
         <Parameter name="Initial Time Step"      type="double" value="1.0"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
-        <Parameter name="Integrator Step Type"  type="string" value="Constant"/>
         <Parameter name="Output Time List"       type="string" value=""/>
         <Parameter name="Output Index List"      type="string" value=""/>
         <Parameter name="Output Time Interval"   type="double" value="1.0"/>

--- a/packages/tempus/test/Newmark/Tempus_NewmarkImplicitDForm_HarmonicOscillator_Damped_SecondOrder.xml
+++ b/packages/tempus/test/Newmark/Tempus_NewmarkImplicitDForm_HarmonicOscillator_Damped_SecondOrder.xml
@@ -25,7 +25,6 @@
         <Parameter name="Initial Time Step"      type="double" value="1.0"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
-        <Parameter name="Integrator Step Type"  type="string" value="Constant"/>
         <Parameter name="Output Time List"       type="string" value=""/>
         <Parameter name="Output Index List"      type="string" value=""/>
         <Parameter name="Output Time Interval"   type="double" value="1.0"/>

--- a/packages/tempus/test/Newmark/Tempus_NewmarkTest.cpp
+++ b/packages/tempus/test/Newmark/Tempus_NewmarkTest.cpp
@@ -400,7 +400,6 @@ TEUCHOS_UNIT_TEST(NewmarkImplicitAForm, ConstructingFromDefaults)
       Teuchos::rcp(new Tempus::TimeStepControl<double>());
     ParameterList tscPL = pl->sublist("Default Integrator")
                              .sublist("Time Step Control");
-    timeStepControl->setStepType (tscPL.get<std::string>("Integrator Step Type"));
     timeStepControl->setInitIndex(tscPL.get<int>   ("Initial Time Index"));
     timeStepControl->setInitTime (tscPL.get<double>("Initial Time"));
     timeStepControl->setFinalTime(tscPL.get<double>("Final Time"));
@@ -501,7 +500,6 @@ TEUCHOS_UNIT_TEST(NewmarkImplicitDForm, Constructing_From_Defaults)
     Teuchos::rcp(new Tempus::TimeStepControl<double>());
   ParameterList tscPL = pl->sublist("Default Integrator")
                            .sublist("Time Step Control");
-  timeStepControl->setStepType (tscPL.get<std::string>("Integrator Step Type"));
   timeStepControl->setInitIndex(tscPL.get<int>   ("Initial Time Index"));
   timeStepControl->setInitTime (tscPL.get<double>("Initial Time"));
   timeStepControl->setFinalTime(tscPL.get<double>("Final Time"));

--- a/packages/tempus/test/OperatorSplit/Tempus_OperatorSplitTest.cpp
+++ b/packages/tempus/test/OperatorSplit/Tempus_OperatorSplitTest.cpp
@@ -79,7 +79,6 @@ TEUCHOS_UNIT_TEST(OperatorSplit, ConstructingFromDefaults)
   auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
   ParameterList tscPL = pl->sublist("Demo Integrator")
                            .sublist("Time Step Control");
-  timeStepControl->setStepType (tscPL.get<std::string>("Integrator Step Type"));
   timeStepControl->setInitIndex(tscPL.get<int>   ("Initial Time Index"));
   timeStepControl->setInitTime (tscPL.get<double>("Initial Time"));
   timeStepControl->setFinalTime(tscPL.get<double>("Final Time"));

--- a/packages/tempus/test/OperatorSplit/Tempus_OperatorSplit_VanDerPol.xml
+++ b/packages/tempus/test/OperatorSplit/Tempus_OperatorSplit_VanDerPol.xml
@@ -35,16 +35,12 @@
         <Parameter name="Output Index Interval"  type="int"    value="100000"/>
         <Parameter name="Maximum Number of Stepper Failures" type="int" value="10"/>
         <Parameter name="Maximum Number of Consecutive Stepper Failures" type="int" value="5"/>
-        <Parameter name="Integrator Step Type"  type="string" value="Variable"/>
         <ParameterList name="Time Step Control Strategy">
-            <Parameter name="Time Step Control Strategy List"  type="string" value="basic_vs"/>
-            <ParameterList name="basic_vs">
-                <Parameter name="Name" type="string" value="Basic VS"/>
-                <Parameter name="Reduction Factor" type="double" value="0.5"/>
-                <Parameter name="Amplification Factor" type="double" value="1.75"/>
-                <Parameter name="Minimum Value Monitoring Function" type="double" value="1.0e-6"/>
-                <Parameter name="Maximum Value Monitoring Function" type="double" value="5.0e0"/>
-            </ParameterList>
+            <Parameter name="Strategy Type" type="string" value="Basic VS"/>
+            <Parameter name="Reduction Factor" type="double" value="0.5"/>
+            <Parameter name="Amplification Factor" type="double" value="1.75"/>
+            <Parameter name="Minimum Value Monitoring Function" type="double" value="1.0e-6"/>
+            <Parameter name="Maximum Value Monitoring Function" type="double" value="5.0e0"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>

--- a/packages/tempus/test/PhysicsState/Tempus_PhysicsState_SinCos.xml
+++ b/packages/tempus/test/PhysicsState/Tempus_PhysicsState_SinCos.xml
@@ -31,7 +31,6 @@
         <Parameter name="Maximum Time Step"      type="double" value="0.1"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
-        <Parameter name="Integrator Step Type"  type="string" value="Constant"/>
         <Parameter name="Output Time List"       type="string" value=""/>
         <Parameter name="Output Index List"      type="string" value=""/>
         <Parameter name="Output Time Interval"   type="double" value="10.0"/>

--- a/packages/tempus/test/Subcycling/Tempus_Subcycling_SinCos.xml
+++ b/packages/tempus/test/Subcycling/Tempus_Subcycling_SinCos.xml
@@ -31,7 +31,6 @@
         <Parameter name="Maximum Time Step"      type="double" value="0.1"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
-        <Parameter name="Integrator Step Type"  type="string" value="Constant"/>
         <Parameter name="Output Time List"       type="string" value=""/>
         <Parameter name="Output Index List"      type="string" value=""/>
         <Parameter name="Output Time Interval"   type="double" value="10.0"/>

--- a/packages/tempus/test/Trapezoidal/Tempus_TrapezoidalTest.cpp
+++ b/packages/tempus/test/Trapezoidal/Tempus_TrapezoidalTest.cpp
@@ -146,7 +146,6 @@ TEUCHOS_UNIT_TEST(Trapezoidal, ConstructingFromDefaults)
     auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
     ParameterList tscPL = pl->sublist("Default Integrator")
                              .sublist("Time Step Control");
-    timeStepControl->setStepType (tscPL.get<std::string>("Integrator Step Type"));
     timeStepControl->setInitIndex(tscPL.get<int>   ("Initial Time Index"));
     timeStepControl->setInitTime (tscPL.get<double>("Initial Time"));
     timeStepControl->setFinalTime(tscPL.get<double>("Final Time"));

--- a/packages/tempus/test/Trapezoidal/Tempus_Trapezoidal_SinCos.xml
+++ b/packages/tempus/test/Trapezoidal/Tempus_Trapezoidal_SinCos.xml
@@ -31,7 +31,6 @@
         <Parameter name="Maximum Time Step"      type="double" value="0.1"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
-        <Parameter name="Integrator Step Type"  type="string" value="Constant"/>
         <Parameter name="Output Time List"       type="string" value=""/>
         <Parameter name="Output Index List"      type="string" value=""/>
         <Parameter name="Output Time Interval"   type="double" value="10.0"/>

--- a/packages/tempus/test/Trapezoidal/Tempus_Trapezoidal_VanDerPol.xml
+++ b/packages/tempus/test/Trapezoidal/Tempus_Trapezoidal_VanDerPol.xml
@@ -35,16 +35,12 @@
         <Parameter name="Output Index Interval"  type="int"    value="100000"/>
         <Parameter name="Maximum Number of Stepper Failures" type="int" value="10"/>
         <Parameter name="Maximum Number of Consecutive Stepper Failures" type="int" value="5"/>
-        <Parameter name="Integrator Step Type"  type="string" value="Variable"/>
         <ParameterList name="Time Step Control Strategy">
-            <Parameter name="Time Step Control Strategy List"  type="string" value="basic_vs"/>
-            <ParameterList name="basic_vs">
-                <Parameter name="Name" type="string" value="Basic VS"/>
-                <Parameter name="Reduction Factor" type="double" value="0.5"/>
-                <Parameter name="Amplification Factor" type="double" value="1.75"/>
-                <Parameter name="Minimum Value Monitoring Function" type="double" value="5.0e-2"/>
-                <Parameter name="Maximum Value Monitoring Function" type="double" value="5.0e-1"/>
-            </ParameterList>
+            <Parameter name="Strategy Type" type="string" value="Basic VS"/>
+            <Parameter name="Reduction Factor" type="double" value="0.5"/>
+            <Parameter name="Amplification Factor" type="double" value="1.75"/>
+            <Parameter name="Minimum Value Monitoring Function" type="double" value="5.0e-2"/>
+            <Parameter name="Maximum Value Monitoring Function" type="double" value="5.0e-1"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>

--- a/packages/tempus/unit_test/CMakeLists.txt
+++ b/packages/tempus/unit_test/CMakeLists.txt
@@ -9,6 +9,34 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   )
 
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_TimeStepControlStrategyConstant
+  SOURCES Tempus_UnitTest_TimeStepControlStrategyConstant.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_TimeStepControlStrategyBasicVS
+  SOURCES Tempus_UnitTest_TimeStepControlStrategyBasicVS.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_TimeStepControlStrategyIntegralController
+  SOURCES Tempus_UnitTest_TimeStepControlStrategyIntegralController.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_TimeStepControlStrategyComposite
+  SOURCES Tempus_UnitTest_TimeStepControlStrategyComposite.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
   UnitTest_BDF2 
   SOURCES Tempus_UnitTest_BDF2.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
   TESTONLYLIBS tempus_test_models

--- a/packages/tempus/unit_test/Tempus_NewmarkExplicitAForm_HarmonicOscillator_Damped.xml
+++ b/packages/tempus/unit_test/Tempus_NewmarkExplicitAForm_HarmonicOscillator_Damped.xml
@@ -25,7 +25,6 @@
         <Parameter name="Initial Time Step"      type="double" value="1.0"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
-        <Parameter name="Integrator Step Type"  type="string" value="Constant"/>
         <Parameter name="Output Time List"       type="string" value=""/>
         <Parameter name="Output Index List"      type="string" value=""/>
         <Parameter name="Output Time Interval"   type="double" value="1.0"/>

--- a/packages/tempus/unit_test/Tempus_NewmarkImplicitAForm_HarmonicOscillator_Damped_SecondOrder.xml
+++ b/packages/tempus/unit_test/Tempus_NewmarkImplicitAForm_HarmonicOscillator_Damped_SecondOrder.xml
@@ -25,7 +25,6 @@
         <Parameter name="Initial Time Step"      type="double" value="1.0"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
-        <Parameter name="Integrator Step Type"  type="string" value="Constant"/>
         <Parameter name="Output Time List"       type="string" value=""/>
         <Parameter name="Output Index List"      type="string" value=""/>
         <Parameter name="Output Time Interval"   type="double" value="1.0"/>

--- a/packages/tempus/unit_test/Tempus_UnitTest_BDF2.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_BDF2.cpp
@@ -194,7 +194,6 @@ public:
 
   // Setup TimeStepControl ------------------------------------
   auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
-  timeStepControl->setStepType ("Constant");
   timeStepControl->setInitIndex(0);
   timeStepControl->setInitTime (0.0);
   timeStepControl->setFinalTime(2.0);
@@ -323,7 +322,6 @@ TEUCHOS_UNIT_TEST(BDF2, AppAction_Observer)
 
   // Setup TimeStepControl ------------------------------------
   auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
-  timeStepControl->setStepType ("Constant");
   timeStepControl->setInitIndex(0);
   timeStepControl->setInitTime (0.0);
   timeStepControl->setFinalTime(2.0);
@@ -448,7 +446,6 @@ TEUCHOS_UNIT_TEST(BDF2, AppAction_ModifierX)
 
   // Setup TimeStepControl ------------------------------------
   auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
-  timeStepControl->setStepType ("Constant");
   timeStepControl->setInitIndex(0);
   timeStepControl->setInitTime (0.0);
   timeStepControl->setFinalTime(2.0);

--- a/packages/tempus/unit_test/Tempus_UnitTest_NewmarkImplicitAForm.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_NewmarkImplicitAForm.cpp
@@ -271,7 +271,6 @@ TEUCHOS_UNIT_TEST(NewmarkImplicitAForm, AppAction_Modifier)
     Teuchos::rcp(new Tempus::TimeStepControl<double>());
   ParameterList tscPL = pl->sublist("Default Integrator")
                            .sublist("Time Step Control");
-  timeStepControl->setStepType (tscPL.get<std::string>("Integrator Step Type"));
   timeStepControl->setInitIndex(tscPL.get<int>   ("Initial Time Index"));
   timeStepControl->setInitTime (tscPL.get<double>("Initial Time"));
   timeStepControl->setFinalTime(dt);
@@ -365,7 +364,6 @@ TEUCHOS_UNIT_TEST(NewmarkImplicitAForm, AppAction_ModifierX)
     Teuchos::rcp(new Tempus::TimeStepControl<double>());
   ParameterList tscPL = pl->sublist("Default Integrator")
                            .sublist("Time Step Control");
-  timeStepControl->setStepType (tscPL.get<std::string>("Integrator Step Type"));
   timeStepControl->setInitIndex(tscPL.get<int>   ("Initial Time Index"));
   timeStepControl->setInitTime (tscPL.get<double>("Initial Time"));
   timeStepControl->setFinalTime(dt);

--- a/packages/tempus/unit_test/Tempus_UnitTest_NewmarkImplicitDForm.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_NewmarkImplicitDForm.cpp
@@ -270,7 +270,6 @@ TEUCHOS_UNIT_TEST(NewmarkImplicitDForm, AppAction_Modifier)
     Teuchos::rcp(new Tempus::TimeStepControl<double>());
   ParameterList tscPL = pl->sublist("Default Integrator")
                            .sublist("Time Step Control");
-  timeStepControl->setStepType (tscPL.get<std::string>("Integrator Step Type"));
   timeStepControl->setInitIndex(tscPL.get<int>   ("Initial Time Index"));
   timeStepControl->setInitTime (tscPL.get<double>("Initial Time"));
   timeStepControl->setFinalTime(dt);
@@ -363,7 +362,6 @@ TEUCHOS_UNIT_TEST(NewmarkImplicitDForm, AppAction_ModifierX)
     Teuchos::rcp(new Tempus::TimeStepControl<double>());
   ParameterList tscPL = pl->sublist("Default Integrator")
                            .sublist("Time Step Control");
-  timeStepControl->setStepType (tscPL.get<std::string>("Integrator Step Type"));
   timeStepControl->setInitIndex(tscPL.get<int>   ("Initial Time Index"));
   timeStepControl->setInitTime (tscPL.get<double>("Initial Time"));
   timeStepControl->setFinalTime(dt);

--- a/packages/tempus/unit_test/Tempus_UnitTest_Subcycling.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_Subcycling.cpp
@@ -194,7 +194,6 @@ TEUCHOS_UNIT_TEST(Subcycling, AppAction_Modifier)
   stepper->setSubcyclingMinTimeStep      (15);
   stepper->setSubcyclingInitTimeStep     (15.0);
   stepper->setSubcyclingMaxTimeStep      (15.0);
-  stepper->setSubcyclingStepType         ("Constant");
   stepper->setSubcyclingMaxFailures      (10);
   stepper->setSubcyclingMaxConsecFailures(5);
   stepper->setSubcyclingScreenOutputIndexInterval(1);
@@ -203,7 +202,6 @@ TEUCHOS_UNIT_TEST(Subcycling, AppAction_Modifier)
 
   // Setup TimeStepControl ------------------------------------
   auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
-  timeStepControl->setStepType ("Constant");
   timeStepControl->setInitIndex(0);
   timeStepControl->setInitTime (0.0);
   timeStepControl->setFinalTime(1.0);
@@ -316,7 +314,6 @@ TEUCHOS_UNIT_TEST(Subcycling, AppAction_Observer)
   stepper->setSubcyclingMinTimeStep      (15);
   stepper->setSubcyclingInitTimeStep     (15.0);
   stepper->setSubcyclingMaxTimeStep      (15.0);
-  stepper->setSubcyclingStepType         ("Constant");
   stepper->setSubcyclingMaxFailures      (10);
   stepper->setSubcyclingMaxConsecFailures(5);
   stepper->setSubcyclingScreenOutputIndexInterval(1);
@@ -325,7 +322,6 @@ TEUCHOS_UNIT_TEST(Subcycling, AppAction_Observer)
 
   // Setup TimeStepControl ------------------------------------
   auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
-  timeStepControl->setStepType ("Constant");
   timeStepControl->setInitIndex(0);
   timeStepControl->setInitTime (0.0);
   timeStepControl->setFinalTime(1.0);
@@ -437,7 +433,6 @@ TEUCHOS_UNIT_TEST(Subcycling, AppAction_ModifierX)
   stepper->setSubcyclingMinTimeStep      (15);
   stepper->setSubcyclingInitTimeStep     (15.0);
   stepper->setSubcyclingMaxTimeStep      (15.0);
-  stepper->setSubcyclingStepType         ("Constant");
   stepper->setSubcyclingMaxFailures      (10);
   stepper->setSubcyclingMaxConsecFailures(5);
   stepper->setSubcyclingScreenOutputIndexInterval(1);
@@ -446,7 +441,6 @@ TEUCHOS_UNIT_TEST(Subcycling, AppAction_ModifierX)
 
   // Setup TimeStepControl ------------------------------------
   auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
-  timeStepControl->setStepType ("Constant");
   timeStepControl->setInitIndex(0);
   timeStepControl->setInitTime (0.0);
   timeStepControl->setFinalTime(1.0);

--- a/packages/tempus/unit_test/Tempus_UnitTest_TimeStepControl.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_TimeStepControl.cpp
@@ -14,7 +14,12 @@
 #include "Thyra_VectorStdOps.hpp"
 
 #include "Tempus_TimeStepControl.hpp"
+#include "Tempus_TimeStepControlStrategyConstant.hpp"
+#include "Tempus_TimeStepControlStrategyBasicVS.hpp"
+#include "Tempus_TimeStepControlStrategyIntegralController.hpp"
+#include "Tempus_TimeStepControlStrategyComposite.hpp"
 
+#include "../TestModels/SinCosModel.hpp"
 #include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
 
 #include <fstream>
@@ -33,15 +38,216 @@ using Teuchos::getParametersFromXmlFile;
 
 // ************************************************************
 // ************************************************************
+TEUCHOS_UNIT_TEST(TimeStepControl, Default_Construction)
+{
+  auto tsc = rcp(new Tempus::TimeStepControl<double>());
+  TEUCHOS_TEST_FOR_EXCEPT(!tsc->isInitialized());
+
+  // Test the get functions (i.e., defaults).
+  TEST_COMPARE          ( tsc->getStepType()           , ==, "Constant"      );
+  TEST_FLOATING_EQUALITY( tsc->getInitTime()               , 0.0    , 1.0e-14);
+  TEST_FLOATING_EQUALITY( tsc->getFinalTime()              , 1.0e+99, 1.0e-14);
+  TEST_FLOATING_EQUALITY( tsc->getMinTimeStep()            , 0.0    , 1.0e-14);
+  TEST_FLOATING_EQUALITY( tsc->getInitTimeStep()           , 1.0    , 1.0e-14);
+  TEST_FLOATING_EQUALITY( tsc->getMaxTimeStep()            , 1.0e+99, 1.0e-14);
+  TEST_COMPARE          ( tsc->getInitIndex()          , ==, 0               );
+  TEST_COMPARE          ( tsc->getFinalIndex()         , ==, 1000000         );
+  TEST_FLOATING_EQUALITY( tsc->getMaxAbsError()            , 1.0e-08, 1.0e-14);
+  TEST_FLOATING_EQUALITY( tsc->getMaxRelError()            , 1.0e-08, 1.0e-14);
+  TEST_COMPARE          ( tsc->getMaxFailures()        , ==, 10              );
+  TEST_COMPARE          ( tsc->getMaxConsecFailures()  , ==, 5               );
+  TEST_COMPARE          ( tsc->getNumTimeSteps()       , ==, -1              );
+  TEST_COMPARE          ( tsc->getPrintDtChanges()     , ==, true            );
+  TEST_COMPARE          ( tsc->getOutputExactly()      , ==, true            );
+  TEST_COMPARE          ( tsc->getOutputIndexInterval(), ==, 1000000         );
+  TEST_FLOATING_EQUALITY( tsc->getOutputTimeInterval()     , 1.0e+99, 1.0e-14);
+
+  // Test the set functions.
+  tsc->setInitTime(1.0);          tsc->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!tsc->isInitialized());
+  tsc->setFinalTime(100.0);       tsc->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!tsc->isInitialized());
+  tsc->setMinTimeStep(0.01);      tsc->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!tsc->isInitialized());
+  tsc->setInitTimeStep(0.02);     tsc->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!tsc->isInitialized());
+  tsc->setMaxTimeStep(0.05);      tsc->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!tsc->isInitialized());
+  tsc->setInitIndex(-100);        tsc->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!tsc->isInitialized());
+  tsc->setFinalIndex(100);        tsc->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!tsc->isInitialized());
+  tsc->setMaxAbsError(1.0e-06);   tsc->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!tsc->isInitialized());
+  tsc->setMaxRelError(1.0e-06);   tsc->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!tsc->isInitialized());
+  tsc->setMaxFailures(8);         tsc->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!tsc->isInitialized());
+  tsc->setMaxConsecFailures(4);   tsc->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!tsc->isInitialized());
+  tsc->setNumTimeSteps(-1);       tsc->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!tsc->isInitialized());
+  tsc->setPrintDtChanges(false);  tsc->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!tsc->isInitialized());
+  tsc->setOutputExactly(false);   tsc->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!tsc->isInitialized());
+  tsc->setOutputIndexInterval(9); tsc->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!tsc->isInitialized());
+  tsc->setOutputTimeInterval(0.1);tsc->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!tsc->isInitialized());
+
+  TEST_COMPARE          ( tsc->getStepType()           , ==, "Constant"      );
+  TEST_FLOATING_EQUALITY( tsc->getInitTime()               , 1.0    , 1.0e-14);
+  TEST_FLOATING_EQUALITY( tsc->getFinalTime()              , 100.0  , 1.0e-14);
+  TEST_FLOATING_EQUALITY( tsc->getMinTimeStep()            , 0.01   , 1.0e-14);
+  TEST_FLOATING_EQUALITY( tsc->getInitTimeStep()           , 0.02   , 1.0e-14);
+  TEST_FLOATING_EQUALITY( tsc->getMaxTimeStep()            , 0.05   , 1.0e-14);
+  TEST_COMPARE          ( tsc->getInitIndex()          , ==, -100            );
+  TEST_COMPARE          ( tsc->getFinalIndex()         , ==, 100             );
+  TEST_FLOATING_EQUALITY( tsc->getMaxAbsError()            , 1.0e-06, 1.0e-14);
+  TEST_FLOATING_EQUALITY( tsc->getMaxRelError()            , 1.0e-06, 1.0e-14);
+  TEST_COMPARE          ( tsc->getMaxFailures()        , ==, 8               );
+  TEST_COMPARE          ( tsc->getMaxConsecFailures()  , ==, 4               );
+  TEST_COMPARE          ( tsc->getNumTimeSteps()       , ==, -1              );
+  TEST_COMPARE          ( tsc->getPrintDtChanges()     , ==, false           );
+  TEST_COMPARE          ( tsc->getOutputExactly()      , ==, false           );
+  TEST_COMPARE          ( tsc->getOutputIndexInterval(), ==, 9               );
+  TEST_FLOATING_EQUALITY( tsc->getOutputTimeInterval()     , 0.1    , 1.0e-14);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeStepControl, Full_Construction)
+{
+  std::vector<int>    outputIndices;
+  outputIndices.push_back(7);
+  outputIndices.push_back(11);
+  outputIndices.push_back(13);
+
+  std::vector<double> outputTimes;
+  outputTimes.push_back(0.3);
+  outputTimes.push_back(0.7);
+  outputTimes.push_back(1.3);
+  outputTimes.push_back(1.7);
+
+  auto tscsc =
+    rcp(new Tempus::TimeStepControlStrategyConstant<double>());
+
+  auto tsc = rcp(new Tempus::TimeStepControl<double>(
+    1.0, 100.0, 0.01, 0.02, 0.05, -100,
+    100, 1.0e-06, 1.0e-06, 8, 4, -1, false, false,
+    outputIndices, outputTimes, 9, 0.011, tscsc));
+
+  TEUCHOS_TEST_FOR_EXCEPT(!tsc->isInitialized());
+
+  TEST_COMPARE          ( tsc->getStepType()           , ==, "Constant"      );
+  TEST_FLOATING_EQUALITY( tsc->getInitTime()               , 1.0    , 1.0e-14);
+  TEST_FLOATING_EQUALITY( tsc->getFinalTime()              , 100.0  , 1.0e-14);
+  TEST_FLOATING_EQUALITY( tsc->getMinTimeStep()            , 0.01   , 1.0e-14);
+  TEST_FLOATING_EQUALITY( tsc->getInitTimeStep()           , 0.02   , 1.0e-14);
+  TEST_FLOATING_EQUALITY( tsc->getMaxTimeStep()            , 0.05   , 1.0e-14);
+  TEST_COMPARE          ( tsc->getInitIndex()          , ==, -100            );
+  TEST_COMPARE          ( tsc->getFinalIndex()         , ==, 100             );
+  TEST_FLOATING_EQUALITY( tsc->getMaxAbsError()            , 1.0e-06, 1.0e-14);
+  TEST_FLOATING_EQUALITY( tsc->getMaxRelError()            , 1.0e-06, 1.0e-14);
+  TEST_COMPARE          ( tsc->getMaxFailures()        , ==, 8               );
+  TEST_COMPARE          ( tsc->getMaxConsecFailures()  , ==, 4               );
+  TEST_COMPARE          ( tsc->getNumTimeSteps()       , ==, -1              );
+  TEST_COMPARE          ( tsc->getPrintDtChanges()     , ==, false           );
+  TEST_COMPARE          ( tsc->getOutputExactly()      , ==, false           );
+  TEST_COMPARE          ( tsc->getOutputIndexInterval(), ==, 9               );
+  TEST_FLOATING_EQUALITY( tsc->getOutputTimeInterval()     , 0.011  , 1.0e-14);
+
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeStepControl, Create_Construction)
+{
+  Teuchos::RCP<Teuchos::ParameterList> pl =
+    Tempus::getTimeStepControlPL<double>();
+
+  pl->set<double>     ("Initial Time"          , 1.0);
+  pl->set<double>     ("Final Time"            , 100.0);
+  pl->set<double>     ("Minimum Time Step"     , 0.01);
+  pl->set<double>     ("Initial Time Step"     , 0.02);
+  pl->set<double>     ("Maximum Time Step"     , 0.05);
+  pl->set<int>        ("Initial Time Index"    , -100);
+  pl->set<int>        ("Final Time Index"      , 100);
+  pl->set<double>     ("Maximum Absolute Error", 1.0e-06);
+  pl->set<double>     ("Maximum Relative Error", 1.0e-06);
+  pl->set<int>        ("Maximum Number of Stepper Failures",              8);
+  pl->set<int>        ("Maximum Number of Consecutive Stepper Failures",  4);
+  pl->set<int>        ("Number of Time Steps"  , -1);
+  pl->set<bool>       ("Print Time Step Changes",false);
+  pl->set<bool>       ("Output Exactly On Output Times", false);
+  pl->set<std::string>("Output Index List"     , "7, 11, 13"     );
+  pl->set<std::string>("Output Time List"      , "0.3, 0.7, 1.3, 1.7");
+  pl->set<int>        ("Output Index Interval" , 9);
+  pl->set<double>     ("Output Time Interval"  , 0.011);
+
+  auto tscs = rcp(new Tempus::TimeStepControlStrategyConstant<double>());
+  auto tscsPL = tscs->getValidParameters();
+  pl->set("Time Step Control Strategy", *tscsPL);
+  //std::cout << "  pl = " << *pl << std::endl;
+
+  auto tsc = Tempus::createTimeStepControl<double>(pl);
+  TEUCHOS_TEST_FOR_EXCEPT(!tsc->isInitialized());
+
+  //Teuchos::RCP<Teuchos::FancyOStream> my_out =
+  //  Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
+  //tsc->describe(*my_out, Teuchos::VERB_EXTREME);
+
+  TEST_COMPARE          ( tsc->getStepType()           , ==, "Constant"      );
+  TEST_FLOATING_EQUALITY( tsc->getInitTime()               , 1.0    , 1.0e-14);
+  TEST_FLOATING_EQUALITY( tsc->getFinalTime()              , 100.0  , 1.0e-14);
+  TEST_FLOATING_EQUALITY( tsc->getMinTimeStep()            , 0.01   , 1.0e-14);
+  TEST_FLOATING_EQUALITY( tsc->getInitTimeStep()           , 0.02   , 1.0e-14);
+  TEST_FLOATING_EQUALITY( tsc->getMaxTimeStep()            , 0.05   , 1.0e-14);
+  TEST_COMPARE          ( tsc->getInitIndex()          , ==, -100            );
+  TEST_COMPARE          ( tsc->getFinalIndex()         , ==, 100             );
+  TEST_FLOATING_EQUALITY( tsc->getMaxAbsError()            , 1.0e-06, 1.0e-14);
+  TEST_FLOATING_EQUALITY( tsc->getMaxRelError()            , 1.0e-06, 1.0e-14);
+  TEST_COMPARE          ( tsc->getMaxFailures()        , ==, 8               );
+  TEST_COMPARE          ( tsc->getMaxConsecFailures()  , ==, 4               );
+  TEST_COMPARE          ( tsc->getNumTimeSteps()       , ==, -1              );
+  TEST_COMPARE          ( tsc->getPrintDtChanges()     , ==, false           );
+  TEST_COMPARE          ( tsc->getOutputExactly()      , ==, false           );
+  TEST_COMPARE          ( tsc->getOutputIndices()[0]   , ==, 7               );
+  TEST_COMPARE          ( tsc->getOutputIndices()[1]   , ==, 11              );
+  TEST_COMPARE          ( tsc->getOutputIndices()[2]   , ==, 13              );
+  TEST_FLOATING_EQUALITY( tsc->getOutputTimes()[0]         , 0.3    , 1.0e-14);
+  TEST_FLOATING_EQUALITY( tsc->getOutputTimes()[1]         , 0.7    , 1.0e-14);
+  TEST_FLOATING_EQUALITY( tsc->getOutputTimes()[2]         , 1.3    , 1.0e-14);
+  TEST_FLOATING_EQUALITY( tsc->getOutputTimes()[3]         , 1.7    , 1.0e-14);
+  TEST_COMPARE          ( tsc->getOutputIndexInterval(), ==, 9               );
+  TEST_FLOATING_EQUALITY( tsc->getOutputTimeInterval()     , 0.011  , 1.0e-14);
+
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeStepControl, Accessors)
+{
+  auto tsc = rcp(new Tempus::TimeStepControl<double>());
+  int    iSet = 17;
+  double dSet = 0.989;
+
+  tsc->setInitTime(dSet); TEST_COMPARE( tsc->getInitTime(), ==, dSet);
+  tsc->setFinalTime(dSet); TEST_COMPARE( tsc->getFinalTime(), ==, dSet);
+  tsc->setMinTimeStep(dSet); TEST_COMPARE( tsc->getMinTimeStep(), ==, dSet);
+  tsc->setInitTimeStep(dSet); TEST_COMPARE( tsc->getInitTimeStep(), ==, dSet);
+  tsc->setMaxTimeStep(dSet); TEST_COMPARE( tsc->getMaxTimeStep(), ==, dSet);
+  tsc->setInitIndex(iSet); TEST_COMPARE( tsc->getInitIndex(), ==, iSet);
+  tsc->setFinalIndex(iSet); TEST_COMPARE( tsc->getFinalIndex(), ==, iSet);
+  tsc->setMaxAbsError(dSet); TEST_COMPARE( tsc->getMaxAbsError(), ==, dSet);
+  tsc->setMaxRelError(dSet); TEST_COMPARE( tsc->getMaxRelError(), ==, dSet);
+  tsc->setOutputExactly(false); TEST_COMPARE( tsc->getOutputExactly(), ==, false);
+  tsc->setOutputExactly(true); TEST_COMPARE( tsc->getOutputExactly(), ==, true);
+
+  std::vector<int> iVSet{ 0, 1, 1, 2, 3, 5, 8, 13, 21, 34 };
+  tsc->setOutputIndices(iVSet); TEUCHOS_TEST_FOR_EXCEPT(tsc->getOutputIndices() != iVSet);
+
+
+  tsc->setOutputIndexInterval(iSet); TEST_COMPARE( tsc->getOutputIndexInterval(), ==, iSet);
+  tsc->setOutputTimeInterval(dSet); TEST_COMPARE( tsc->getOutputTimeInterval(), ==, dSet);
+}
+
+
+// ************************************************************
+// ************************************************************
 TEUCHOS_UNIT_TEST(TimeStepControl, setOutputTimes)
 {
   auto tsc = rcp(new Tempus::TimeStepControl<double>());
 
-  //auto tscPL = tsc->getParameterList();
-  //std::cout << "tscPL = \n" << *tscPL << std::endl;
-
   std::vector<double> times_in;
-  //std::cout << "Test 1" << std::endl;
   times_in.push_back(0.0000000000000000e-11);
   times_in.push_back(0.1001384570000000e-11);
   times_in.push_back(0.2002769140000000e-11);
@@ -64,14 +270,13 @@ TEUCHOS_UNIT_TEST(TimeStepControl, setOutputTimes)
     //std::cout << std::setw(25) << std::setprecision(16) << times_in[i] << ","
     //          << std::setw(25) << std::setprecision(16) << times_out[i]
     //          << std::endl;
-    maxDiff = std::max(std::abs(times_in[i] - times_out[i]), maxDiff);
+    maxDiff = std::max(std::fabs(times_in[i] - times_out[i]), maxDiff);
   }
   //std::cout << "  maxDiff = " << maxDiff << std::endl;
 
   TEST_COMPARE(maxDiff, <, 1.0e-25);
 
 
-  //std::cout << "Test 2" << std::endl;
   times_in.clear();
   times_in.push_back(0.00000000000000000000000000000000);
   times_in.push_back(0.00000000000100138457000000009381);
@@ -95,20 +300,18 @@ TEUCHOS_UNIT_TEST(TimeStepControl, setOutputTimes)
     //std::cout << std::setw(30) << std::setprecision(20) << times_in[i] << ","
     //          << std::setw(30) << std::setprecision(20) << times_out[i]
     //          << std::endl;
-    maxDiff = std::max(std::abs(times_in[i] - times_out[i]), maxDiff);
+    maxDiff = std::max(std::fabs(times_in[i] - times_out[i]), maxDiff);
   }
   //std::cout << "  maxDiff = " << maxDiff << std::endl;
 
   TEST_COMPARE(maxDiff, <, 1.0e-25);
-
-  //tscPL = tsc->getParameterList();
-  //std::cout << "tscPL = \n" << *tscPL << std::endl;
 }
 
 
 // ************************************************************
 // ************************************************************
-TEUCHOS_UNIT_TEST(TimeStepControl, getOutputIndicesandIntervals){
+TEUCHOS_UNIT_TEST(TimeStepControl, getOutputIndicesandIntervals)
+{
   auto tsc = rcp(new Tempus::TimeStepControl<double>());
   int setOutputTimeIndex = 17;
   double setOutputTimeInterval = 1.101001000100001e-7;
@@ -120,6 +323,511 @@ TEUCHOS_UNIT_TEST(TimeStepControl, getOutputIndicesandIntervals){
   double getOutputTimeInterval = tsc->getOutputTimeInterval();
   TEST_COMPARE(getOutputTimeInterval, ==, setOutputTimeInterval);
   TEST_COMPARE(getOutputTimeIndex, ==, setOutputTimeIndex);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeStepControl, timeInRange)
+{
+  auto tsc = rcp(new Tempus::TimeStepControl<double>());
+  TEUCHOS_TEST_FOR_EXCEPT(!tsc->isInitialized());
+
+  // Testing lambda function
+  auto testTimeInRange = [=] (double initTime, double finalTime)
+  {
+    tsc->setInitTime (initTime);
+    tsc->setFinalTime(finalTime);
+    tsc->initialize();
+    TEUCHOS_TEST_FOR_EXCEPT(!tsc->isInitialized());
+
+    const int i = (initTime == 0) ? 0 : 1 + (int)std::floor(std::log10(std::fabs(initTime) ) );
+    const double absTolInit10 = std::pow(10, i-10);
+    const double absTolInit15 = std::pow(10, i-15);
+    const int j = (finalTime == 0) ? 0 : 1 + (int)std::floor(std::log10(std::fabs(finalTime) ) );
+    const double absTolFinal10 = std::pow(10, j-10);
+    const double absTolFinal15 = std::pow(10, j-15);
+
+
+    // Classic unit testing of critical values.
+    if ( initTime == 0.0 ) {
+      TEUCHOS_TEST_FOR_EXCEPT( tsc->timeInRange( initTime - 0.1));
+    } else {
+      TEUCHOS_TEST_FOR_EXCEPT( tsc->timeInRange( initTime - 0.1*std::fabs(initTime)));
+    }
+    TEUCHOS_TEST_FOR_EXCEPT( tsc->timeInRange( initTime - absTolInit10));
+    TEUCHOS_TEST_FOR_EXCEPT(!tsc->timeInRange( initTime - absTolInit15));
+    TEUCHOS_TEST_FOR_EXCEPT(!tsc->timeInRange( initTime          ));
+    TEUCHOS_TEST_FOR_EXCEPT(!tsc->timeInRange( initTime + absTolInit15));
+    TEUCHOS_TEST_FOR_EXCEPT(!tsc->timeInRange( initTime + absTolInit10));
+    TEUCHOS_TEST_FOR_EXCEPT(!tsc->timeInRange( initTime + 0.3*(std::fabs(finalTime-initTime))));
+    TEUCHOS_TEST_FOR_EXCEPT(!tsc->timeInRange(finalTime - absTolFinal10));
+    TEUCHOS_TEST_FOR_EXCEPT( tsc->timeInRange(finalTime - absTolFinal15));
+    TEUCHOS_TEST_FOR_EXCEPT( tsc->timeInRange(finalTime          ));
+    TEUCHOS_TEST_FOR_EXCEPT( tsc->timeInRange(finalTime + absTolFinal15));
+    TEUCHOS_TEST_FOR_EXCEPT( tsc->timeInRange(finalTime + absTolFinal10));
+    if ( finalTime == 0.0 ) {
+      TEUCHOS_TEST_FOR_EXCEPT( tsc->timeInRange(finalTime + 0.1));
+    } else {
+      TEUCHOS_TEST_FOR_EXCEPT( tsc->timeInRange(finalTime + 0.1*std::fabs(finalTime)));
+    }
+  };
+
+  // Test with initTime = 0.0
+  testTimeInRange (0.0, 1.0);
+
+  // Test with finalTime = 0.0
+  testTimeInRange (-1.0, 0.0);
+
+  // Test large and small times
+  testTimeInRange ( 9.9e-20, 3.3e+20);
+  testTimeInRange (-1.9e+20, 2.3e-20);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeStepControl, indexInRange)
+{
+  auto tsc = rcp(new Tempus::TimeStepControl<double>());
+  TEUCHOS_TEST_FOR_EXCEPT(!tsc->isInitialized());
+
+  // Testing lambda function
+  auto testIndexInRange = [=] (double initIndex, double finalIndex)
+  {
+    tsc->setInitIndex (initIndex);
+    tsc->setFinalIndex(finalIndex);
+    tsc->initialize();
+    TEUCHOS_TEST_FOR_EXCEPT(!tsc->isInitialized());
+
+    // Classic unit testing of critical values.
+    TEUCHOS_TEST_FOR_EXCEPT( tsc->indexInRange( initIndex - 7));
+    TEUCHOS_TEST_FOR_EXCEPT( tsc->indexInRange( initIndex - 1));
+    TEUCHOS_TEST_FOR_EXCEPT(!tsc->indexInRange( initIndex          ));
+    TEUCHOS_TEST_FOR_EXCEPT(!tsc->indexInRange( initIndex + 1));
+    TEUCHOS_TEST_FOR_EXCEPT(!tsc->indexInRange( initIndex + (int)0.3*(std::fabs(finalIndex-initIndex))));
+    TEUCHOS_TEST_FOR_EXCEPT(!tsc->indexInRange(finalIndex - 1));
+    TEUCHOS_TEST_FOR_EXCEPT( tsc->indexInRange(finalIndex          ));
+    TEUCHOS_TEST_FOR_EXCEPT( tsc->indexInRange(finalIndex + 1));
+    TEUCHOS_TEST_FOR_EXCEPT( tsc->indexInRange(finalIndex + 7));
+  };
+
+  // Test with initIndex = 0.0
+  testIndexInRange (0, 10);
+
+  // Test with finalIndex = 0.0
+  testIndexInRange (-10, 0);
+
+  // Test large and small indices
+  testIndexInRange (-190000, 20);
+  testIndexInRange (-19, 200000);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeStepControl, getValidParameters)
+{
+  std::vector<int>    outputIndices;
+  outputIndices.push_back(7);
+  outputIndices.push_back(11);
+  outputIndices.push_back(13);
+
+  std::vector<double> outputTimes;
+  outputTimes.push_back(0.3);
+  outputTimes.push_back(0.7);
+  outputTimes.push_back(1.3);
+  outputTimes.push_back(1.7);
+
+  auto tscsc =
+    rcp(new Tempus::TimeStepControlStrategyConstant<double>());
+
+  auto tsc = rcp(new Tempus::TimeStepControl<double>(
+    1.0, 100.0, 0.01, 0.02, 0.05, -100,
+    100, 1.0e-06, 1.0e-06, 8, 4, -1, false, false,
+    outputIndices, outputTimes, 9, 0.011, tscsc));
+  TEUCHOS_TEST_FOR_EXCEPT(!tsc->isInitialized());
+
+  auto pl = tsc->getValidParameters();
+
+  TEST_FLOATING_EQUALITY( pl->get<double>("Initial Time")                      , 1.0    , 1.0e-14);
+  TEST_FLOATING_EQUALITY( pl->get<double>("Final Time")                        , 100.0  , 1.0e-14);
+  TEST_FLOATING_EQUALITY( pl->get<double>("Minimum Time Step")                 , 0.01   , 1.0e-14);
+  TEST_FLOATING_EQUALITY( pl->get<double>("Initial Time Step")                 , 0.02   , 1.0e-14);
+  TEST_FLOATING_EQUALITY( pl->get<double>("Maximum Time Step")                 , 0.05   , 1.0e-14);
+  TEST_COMPARE          ( pl->get<int>   ("Initial Time Index")            , ==, -100            );
+  TEST_COMPARE          ( pl->get<int>   ("Final Time Index")              , ==, 100             );
+  TEST_FLOATING_EQUALITY( pl->get<double>("Maximum Absolute Error")            , 1.0e-06, 1.0e-14);
+  TEST_FLOATING_EQUALITY( pl->get<double>("Maximum Relative Error")            , 1.0e-06, 1.0e-14);
+  TEST_COMPARE          ( pl->get<int>   ("Maximum Number of Stepper Failures")            , ==, 8);
+  TEST_COMPARE          ( pl->get<int>   ("Maximum Number of Consecutive Stepper Failures"), ==, 4);
+  TEST_COMPARE          ( pl->get<int>   ("Number of Time Steps")          , ==, -1              );
+  TEST_COMPARE          ( pl->get<bool>  ("Print Time Step Changes")       , ==, false           );
+  TEST_COMPARE          ( pl->get<bool>  ("Output Exactly On Output Times"), ==, false           );
+  TEST_COMPARE          ( pl->get<std::string>("Output Index List")        , ==, "7, 11, 13"     );
+  TEST_COMPARE          ( pl->get<std::string>("Output Time List")         , ==, "0.3, 0.7, 1.3, 1.7");
+  TEST_COMPARE          ( pl->get<int>   ("Output Index Interval")         , ==, 9               );
+  TEST_FLOATING_EQUALITY( pl->get<double>("Output Time Interval")              , 0.011  , 1.0e-14);
+
+  { // Ensure that parameters are "used", excluding sublists.
+    std::ostringstream unusedParameters;
+    pl->unused(unusedParameters);
+    TEST_COMPARE ( unusedParameters.str(), ==,
+      "WARNING: Parameter \"Time Step Control Strategy\"    [unused] is unused\n");
+  }
+
+  std::cout << "\n pl = \n" << *pl << std::endl;
+
+  auto tscs_PL = pl->sublist("Time Step Control Strategy");
+  TEST_COMPARE          ( tscs_PL.get<std::string>("Strategy Type")  , ==, "Constant");
+  TEST_FLOATING_EQUALITY( tscs_PL.get<double>("Time Step"), 0.0, 1.0e-14);
+
+  { // Ensure that parameters are "used", excluding sublists.
+    std::ostringstream unusedParameters;
+    tscs_PL.unused(unusedParameters);
+    TEST_COMPARE ( unusedParameters.str(), ==, "");
+  }
+
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeStepControl, setNumTimeSteps)
+{
+  auto tsc = rcp(new Tempus::TimeStepControl<double>());
+  TEUCHOS_TEST_FOR_EXCEPT(!tsc->isInitialized());
+
+  tsc->setInitTime(0.0);
+  tsc->setFinalTime(100.0);
+  tsc->setMinTimeStep(0.01);
+  tsc->setInitTimeStep(0.02);
+  tsc->setMaxTimeStep(0.05);
+  tsc->setNumTimeSteps(-1);
+  tsc->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!tsc->isInitialized());
+
+  TEST_FLOATING_EQUALITY( tsc->getInitTime()    , 0.0  , 1.0e-14);
+  TEST_FLOATING_EQUALITY( tsc->getFinalTime()   , 100.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY( tsc->getMinTimeStep() , 0.01 , 1.0e-14);
+  TEST_FLOATING_EQUALITY( tsc->getInitTimeStep(), 0.02 , 1.0e-14);
+  TEST_FLOATING_EQUALITY( tsc->getMaxTimeStep() , 0.05 , 1.0e-14);
+  TEST_COMPARE          ( tsc->getNumTimeSteps(), ==, -1        );
+
+  tsc->setNumTimeSteps(100);
+  tsc->initialize();
+
+  TEST_FLOATING_EQUALITY( tsc->getInitTime()    , 0.0  , 1.0e-14);
+  TEST_FLOATING_EQUALITY( tsc->getFinalTime()   , 100.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY( tsc->getMinTimeStep() , 1.0  , 1.0e-14);
+  TEST_FLOATING_EQUALITY( tsc->getInitTimeStep(), 1.0  , 1.0e-14);
+  TEST_FLOATING_EQUALITY( tsc->getMaxTimeStep() , 1.0  , 1.0e-14);
+  TEST_COMPARE          ( tsc->getNumTimeSteps(), ==, 100       );
+
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeStepControl, SetDtAfterOutput_Variable)
+{
+  // Setup the SolutionHistory --------------------------------
+  auto model   = rcp(new Tempus_Test::SinCosModel<double>());
+  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =model->getNominalValues();
+  auto icSolution = rcp_const_cast<Thyra::VectorBase<double> >(inArgsIC.get_x());
+  auto icState = Tempus::createSolutionStateX<double>(icSolution);
+  auto solutionHistory = rcp(new Tempus::SolutionHistory<double>());
+  solutionHistory->addState(icState);
+  double dt = 0.9;
+  solutionHistory->getCurrentState()->setTimeStep(dt);
+
+  // Setup the TimeStepControl --------------------------------
+  auto tsc = rcp(new Tempus::TimeStepControl<double>());
+  std::vector<double> outputTimes;
+  double outputTime = 0.8;
+  outputTimes.push_back(outputTime);
+  tsc->setOutputTimes(outputTimes);
+  tsc->setOutputExactly(true);
+  auto tscs = rcp(new Tempus::TimeStepControlStrategyBasicVS<double>());
+  tsc->setTimeStepControlStrategy(tscs);
+  tsc->setMinTimeStep (dt/2.0);
+  tsc->setInitTimeStep(dt);
+  tsc->setMaxTimeStep (2.0*dt);
+  tsc->setPrintDtChanges(true);
+  tsc->initialize();
+  TEST_COMPARE(tsc->getOutputExactly(), ==, true);
+  Tempus::Status status = Tempus::Status::WORKING;
+
+  // ** First Timestep ** //
+  // Set dt to hit outputTime.
+  solutionHistory->initWorkingState();
+  auto currentState = solutionHistory->getCurrentState();
+  auto workingState = solutionHistory->getWorkingState();
+
+  tsc->setNextTimeStep(solutionHistory, status);
+
+  TEST_FLOATING_EQUALITY( workingState->getTimeStep(), outputTime, 1.0e-14);
+  TEST_FLOATING_EQUALITY( workingState->getTime(), outputTime, 1.0e-14);
+  TEST_COMPARE(workingState->getOutput(), ==, true);
+
+  // ** Successful timestep !! ** //
+  workingState->setSolutionStatus(Tempus::Status::PASSED);
+
+  solutionHistory->promoteWorkingState();
+
+  // ** Second Timestep ** //
+  // Set dt to timestep before output.
+  solutionHistory->initWorkingState();
+  currentState = solutionHistory->getCurrentState();
+  workingState = solutionHistory->getWorkingState();
+
+  tsc->setNextTimeStep(solutionHistory, status);
+
+  TEST_FLOATING_EQUALITY( workingState->getTimeStep(), dt, 1.0e-14);
+  TEST_FLOATING_EQUALITY(
+    currentState->getTime() + workingState->getTimeStep(),
+    workingState->getTime(), 1.0e-14);
+
+  TEST_COMPARE(workingState->getOutput(), ==, false);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeStepControl, SetDtAfterOutput_Constant)
+{
+  // Setup the SolutionHistory --------------------------------
+  auto model   = rcp(new Tempus_Test::SinCosModel<double>());
+  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =model->getNominalValues();
+  auto icSolution =rcp_const_cast<Thyra::VectorBase<double> >(inArgsIC.get_x());
+  auto icState = Tempus::createSolutionStateX<double>(icSolution);
+  auto solutionHistory = rcp(new Tempus::SolutionHistory<double>());
+  solutionHistory->addState(icState);
+  double dt = 0.9;
+  solutionHistory->getCurrentState()->setTimeStep(dt);
+
+  // Setup the TimeStepControl --------------------------------
+  auto tsc = rcp(new Tempus::TimeStepControl<double>());
+  std::vector<double> outputTimes;
+  double outputTime = 0.8;
+  outputTimes.push_back(outputTime);
+  tsc->setOutputTimes(outputTimes);
+  tsc->setOutputExactly(true);
+  tsc->setMinTimeStep (dt/2.0);
+  tsc->setInitTimeStep(dt);
+  tsc->setMaxTimeStep (2.0*dt);
+  tsc->setOutputExactly(false);
+  tsc->initialize();
+  TEST_COMPARE(tsc->getOutputExactly(), ==, false);
+  Tempus::Status status = Tempus::Status::WORKING;
+
+  // Set dt to hit outputTime for first timestep.
+  solutionHistory->initWorkingState();
+  auto currentState = solutionHistory->getCurrentState();
+  auto workingState = solutionHistory->getWorkingState();
+
+  tsc->setNextTimeStep(solutionHistory, status);
+  double timeN   = workingState->getTime();
+  TEST_COMPARE(timeN, ==, dt);
+  //TEST_COMPARE( std::fabs(timeN-dt)/dt, <, 1.0e-15);
+  TEST_COMPARE(workingState->getOutput(), ==, true);
+
+  // ** Successful timestep !! ** //
+  workingState->setSolutionStatus(Tempus::Status::PASSED);
+
+  solutionHistory->promoteWorkingState();
+
+  // Set dt to timestep before output for second timestep.
+  solutionHistory->initWorkingState();
+  // Set local RCPs for WS and CS after initialize.
+  currentState = solutionHistory->getCurrentState();
+  workingState = solutionHistory->getWorkingState();
+
+  tsc->setNextTimeStep(solutionHistory, status);
+  timeN   = workingState->getTime();
+  TEST_COMPARE( (timeN), ==, 2*dt);
+
+  double dtN = workingState->getTimeStep();
+  TEST_COMPARE( dt, ==, dtN);
+
+  TEST_COMPARE(workingState->getOutput(), ==, false);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeStepControl, ConstantTimeStep_Roundoff)
+{
+  // Setup the SolutionHistory --------------------------------
+  auto model   = rcp(new Tempus_Test::SinCosModel<double>());
+  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =model->getNominalValues();
+  auto icSolution =rcp_const_cast<Thyra::VectorBase<double> >(inArgsIC.get_x());
+  auto icState = Tempus::createSolutionStateX<double>(icSolution);
+  auto solutionHistory = rcp(new Tempus::SolutionHistory<double>());
+  solutionHistory->addState(icState);
+  double dt = 1.0e-04;
+  solutionHistory->getCurrentState()->setTimeStep(dt);
+
+  // Setup the TimeStepControl --------------------------------
+  auto tsc = rcp(new Tempus::TimeStepControl<double>());
+  std::vector<double> outputTimes;
+  double outputTime = 0.8;
+  outputTimes.push_back(outputTime);
+  tsc->setOutputTimes(outputTimes);
+  tsc->setOutputExactly(true);
+  tsc->setTimeStepControlStrategy();
+  tsc->setInitTimeStep(dt);
+  tsc->initialize();
+  Tempus::Status status = Tempus::Status::WORKING;
+
+
+  // Take 10000 timesteps.
+  for (int i=0; i < 10000; ++i) {
+    solutionHistory->initWorkingState();
+    tsc->setNextTimeStep(solutionHistory, status);
+
+    // ** Successful timestep !! ** //
+    solutionHistory->getWorkingState()->setSolutionStatus(Tempus::Status::PASSED);
+
+    solutionHistory->promoteWorkingState();
+  }
+
+  auto currentState = solutionHistory->getCurrentState();
+  double time = currentState->getTime();
+  TEST_COMPARE( std::fabs(time-1.0), <, 1.0e-15);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeStepControl, Setting_Strategies_PLs)
+{
+
+  { // Test without "Time Step Control Strategy"
+    auto pl = Tempus::getTimeStepControlPL<double>();
+    pl->remove("Time Step Control Strategy");
+
+    auto tsc = Tempus::createTimeStepControl<double>(pl);
+    TEUCHOS_TEST_FOR_EXCEPT(!tsc->isInitialized());
+
+    // Default strategy is "Constant"
+    TEUCHOS_TEST_FOR_EXCEPT(!(tsc->getStepType() == "Constant"));
+    TEUCHOS_TEST_FOR_EXCEPT(!(tsc->getTimeStepControlStrategy()->getStrategyType() == "Constant"));
+  }
+
+  { // Test with "Basic VS" strategy
+    auto pl = Tempus::getTimeStepControlPL<double>();
+    pl->remove("Time Step Control Strategy");
+    pl->set("Time Step Control Strategy",
+      *(Tempus::getTimeStepControlStrategyBasicVS_PL<double>()));
+
+    auto tsc = Tempus::createTimeStepControl<double>(pl);
+    TEUCHOS_TEST_FOR_EXCEPT(!tsc->isInitialized());
+
+    // Strategy should be "Basic VS"
+    TEUCHOS_TEST_FOR_EXCEPT(!(tsc->getStepType() == "Variable"));
+    TEUCHOS_TEST_FOR_EXCEPT(!(tsc->getTimeStepControlStrategy()->getStrategyType() == "Basic VS"));
+  }
+
+  { // Test with "Integral Controller" strategy
+    auto pl = Tempus::getTimeStepControlPL<double>();
+    pl->remove("Time Step Control Strategy");
+    pl->set("Time Step Control Strategy",
+      *(Tempus::getTimeStepControlStrategyIntegralControllerPL<double>()));
+
+    auto tsc = Tempus::createTimeStepControl<double>(pl);
+    TEUCHOS_TEST_FOR_EXCEPT(!tsc->isInitialized());
+
+    // Strategy should be "Integral Controller"
+    TEUCHOS_TEST_FOR_EXCEPT(!(tsc->getStepType() == "Variable"));
+    TEUCHOS_TEST_FOR_EXCEPT(!(tsc->getTimeStepControlStrategy()->getStrategyType() == "Integral Controller"));
+  }
+
+  { // Test with "Composite" strategy
+    auto pl = Tempus::getTimeStepControlPL<double>();
+    pl->remove("Time Step Control Strategy");
+    pl->set("Time Step Control Strategy",
+      *(Tempus::getTimeStepControlStrategyCompositePL<double>()));
+
+    auto tsc = Tempus::createTimeStepControl<double>(pl);
+    TEUCHOS_TEST_FOR_EXCEPT(!tsc->isInitialized());
+
+    // Strategy should be "Composite"
+    TEUCHOS_TEST_FOR_EXCEPT(!(tsc->getStepType() == "Constant"));
+    TEUCHOS_TEST_FOR_EXCEPT(!(tsc->getTimeStepControlStrategy()->getStrategyType() == "Composite"));
+  }
+
+  { // Test with a non-Tempus strategy
+    auto pl = Tempus::getTimeStepControlPL<double>();
+    pl->remove("Time Step Control Strategy");
+
+    auto nonTempusStrategyPL =
+      Teuchos::parameterList("Time Step Control Strategy");
+    nonTempusStrategyPL->set<std::string>("Strategy Type", "Application Strategy");
+    nonTempusStrategyPL->set<double>("Secret Sauce", 1.2345);
+
+    pl->set("Time Step Control Strategy", *nonTempusStrategyPL);
+
+    auto tsc = Tempus::createTimeStepControl<double>(pl);
+    TEUCHOS_TEST_FOR_EXCEPT(!tsc->isInitialized());
+
+    // Without finding a Tempus Strategy, the strategy should be the default strategy "Constant"
+    TEUCHOS_TEST_FOR_EXCEPT(!(tsc->getStepType() == "Constant"));
+    TEUCHOS_TEST_FOR_EXCEPT(!(tsc->getTimeStepControlStrategy()->getStrategyType() == "Constant"));
+  }
+
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeStepControl, Cast_Composite)
+{
+  // Setup Composite for this test.
+  auto temp = rcp(new Tempus::TimeStepControlStrategyComposite<double>());
+  auto tscsBasicVS = rcp(new Tempus::TimeStepControlStrategyBasicVS<double>());
+  temp->addStrategy(tscsBasicVS);
+  auto tscsIntCtrl = rcp(new Tempus::TimeStepControlStrategyIntegralController<double>());
+  temp->addStrategy(tscsIntCtrl);
+  temp->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!temp->isInitialized());
+
+  auto tsc = rcp(new Tempus::TimeStepControl<double>());
+  tsc->setTimeStepControlStrategy(temp);
+  tsc->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!tsc->isInitialized());
+
+  Teuchos::RCP<Tempus::TimeStepControlStrategy<double>> strategy =
+    tsc->getTimeStepControlStrategy();
+
+  // Test that we can cast this to a TimeStepControlStrategyComposite.
+  auto tscsc = rcp_dynamic_cast<Tempus::TimeStepControlStrategyComposite<double> >(strategy);
+
+  TEST_COMPARE(tscsc->size(), ==, 2);
+
+  std::vector<Teuchos::RCP<Tempus::TimeStepControlStrategy<double>>>
+    strategies = tscsc->getStrategies();
+
+  auto strategyBasicVS = Teuchos::rcp_dynamic_cast<Tempus::TimeStepControlStrategyBasicVS<double> > (strategies[0]);
+
+  TEUCHOS_TEST_FOR_EXCEPT(strategyBasicVS->getStepType() != "Variable");
+  TEUCHOS_TEST_FOR_EXCEPT(strategyBasicVS->getAmplFactor() != 1.75);
+  TEUCHOS_TEST_FOR_EXCEPT(strategyBasicVS->getReductFactor() != 0.5);
+  TEUCHOS_TEST_FOR_EXCEPT(strategyBasicVS->getMinEta() != 0.0);
+  TEUCHOS_TEST_FOR_EXCEPT(strategyBasicVS->getMaxEta() != 1.0e+16);
+
+  auto strategyIC = Teuchos::rcp_dynamic_cast<Tempus::TimeStepControlStrategyIntegralController<double> > (strategies[1]);
+
+  TEUCHOS_TEST_FOR_EXCEPT(strategyIC->getStepType() != "Variable");
+  TEUCHOS_TEST_FOR_EXCEPT(strategyIC->getController() != "PID");
+  TEUCHOS_TEST_FOR_EXCEPT(strategyIC->getKI() != 0.58);
+  TEUCHOS_TEST_FOR_EXCEPT(strategyIC->getKP() != 0.21);
+  TEUCHOS_TEST_FOR_EXCEPT(strategyIC->getKD() != 0.10);
+  TEUCHOS_TEST_FOR_EXCEPT(strategyIC->getSafetyFactor() != 0.90);
+  TEUCHOS_TEST_FOR_EXCEPT(strategyIC->getSafetyFactorAfterReject() != 0.90);
+  TEUCHOS_TEST_FOR_EXCEPT(strategyIC->getFacMax() != 5.0);
+  TEUCHOS_TEST_FOR_EXCEPT(strategyIC->getFacMin() != 0.5);
+
 }
 
 

--- a/packages/tempus/unit_test/Tempus_UnitTest_TimeStepControl.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_TimeStepControl.cpp
@@ -707,7 +707,9 @@ TEUCHOS_UNIT_TEST(TimeStepControl, Setting_Strategies_PLs)
     auto pl = Tempus::getTimeStepControlPL<double>();
     pl->remove("Time Step Control Strategy");
 
-    auto tsc = Tempus::createTimeStepControl<double>(pl);
+    auto tsc = Tempus::createTimeStepControl<double>(pl,false);
+    TEUCHOS_TEST_FOR_EXCEPT(tsc->isInitialized());
+    tsc->initialize();
     TEUCHOS_TEST_FOR_EXCEPT(!tsc->isInitialized());
 
     // Default strategy is "Constant"

--- a/packages/tempus/unit_test/Tempus_UnitTest_TimeStepControlStrategyBasicVS.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_TimeStepControlStrategyBasicVS.cpp
@@ -1,0 +1,226 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Thyra_VectorStdOps.hpp"
+
+#include "Tempus_StepperFactory.hpp"
+#include "Tempus_TimeStepControl.hpp"
+#include "Tempus_TimeStepControlStrategyBasicVS.hpp"
+
+#include "../TestModels/SinCosModel.hpp"
+#include "../TestModels/DahlquistTestModel.hpp"
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::ParameterList;
+using Teuchos::sublist;
+using Teuchos::getParametersFromXmlFile;
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeStepControlStrategyBasicVS, Default_Construction)
+{
+  auto tscs = rcp(new Tempus::TimeStepControlStrategyBasicVS<double>());
+  TEUCHOS_TEST_FOR_EXCEPT(!tscs->isInitialized());
+
+  // Test the get functions (i.e., defaults).
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getStrategyType() != "Basic VS");
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getStepType() != "Variable");
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getAmplFactor() != 1.75);
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getReductFactor() != 0.5);
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getMinEta() != 0.0);
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getMaxEta() != 1.0e+16);
+
+  // Test the set functions.
+  tscs->setAmplFactor(1.33);    tscs->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!tscs->isInitialized());
+  tscs->setReductFactor(0.75);  tscs->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!tscs->isInitialized());
+  tscs->setMinEta(0.01);        tscs->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!tscs->isInitialized());
+  tscs->setMaxEta(0.05);        tscs->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!tscs->isInitialized());
+
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getAmplFactor() != 1.33);
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getReductFactor() != 0.75);
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getMinEta() != 0.01);
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getMaxEta() != 0.05);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeStepControlStrategyBasicVS, Full_Construction)
+{
+  auto tscs = rcp(new Tempus::TimeStepControlStrategyBasicVS<double>(
+    1.33, 0.75, 0.01, 0.05));
+  TEUCHOS_TEST_FOR_EXCEPT(!tscs->isInitialized());
+
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getStrategyType() != "Basic VS");
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getStepType() != "Variable");
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getAmplFactor() != 1.33);
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getReductFactor() != 0.75);
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getMinEta() != 0.01);
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getMaxEta() != 0.05);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeStepControlStrategyBasicVS, Create_Construction)
+{
+  auto pl = Tempus::getTimeStepControlStrategyBasicVS_PL<double>();
+
+  pl->set<double>("Amplification Factor", 1.33);
+  pl->set<double>("Reduction Factor"    , 0.75);
+  pl->set<double>("Minimum Value Monitoring Function", 0.01);
+  pl->set<double>("Maximum Value Monitoring Function", 0.05);
+
+  auto tscs = Tempus::createTimeStepControlStrategyBasicVS<double>(pl);
+
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getStrategyType() != "Basic VS");
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getStepType() != "Variable");
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getAmplFactor() != 1.33);
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getReductFactor() != 0.75);
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getMinEta() != 0.01);
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getMaxEta() != 0.05);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeStepControlStrategyBasicVS, setNextTimeStep)
+{
+  auto tscs = rcp(new Tempus::TimeStepControlStrategyBasicVS<double>());
+  tscs->setAmplFactor(1.1);
+  tscs->setReductFactor(0.5);
+  tscs->setMinEta(0.01);
+  tscs->setMaxEta(0.05);
+  tscs->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!tscs->isInitialized());
+
+  // Setup the TimeStepControl --------------------------------
+  auto tsc = rcp(new Tempus::TimeStepControl<double>());
+  tsc->setTimeStepControlStrategy(tscs);
+  tsc->setInitTime(0.0);
+  tsc->setFinalTime(10.0);
+  tsc->setMinTimeStep (0.01);
+  tsc->setInitTimeStep(0.1);
+  tsc->setMaxTimeStep (1.0);
+  tsc->setFinalIndex(100);
+  tsc->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!tsc->isInitialized());
+  Tempus::Status status = Tempus::Status::WORKING;
+
+  // Setup the SolutionHistory --------------------------------
+  auto model = rcp(new Tempus_Test::DahlquistTestModel<double>());
+  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =model->getNominalValues();
+  auto icSolution = rcp_const_cast<Thyra::VectorBase<double> >(inArgsIC.get_x());
+  auto icState = Tempus::createSolutionStateX<double>(icSolution);
+  auto solutionHistory = rcp(new Tempus::SolutionHistory<double>());
+
+  // Test Reducing timestep
+  {
+    solutionHistory->addState(icState);
+    solutionHistory->getCurrentState()->setTimeStep(0.5);
+    solutionHistory->getCurrentState()->setTime(0.0);
+    solutionHistory->getCurrentState()->setIndex(0);
+
+    // Set up solution history with two time steps.
+    for (int i = 0; i < 2; i++) {
+      solutionHistory->initWorkingState();
+
+      tsc->setNextTimeStep(solutionHistory, status);
+
+      { // Mock takeStep
+        auto currentState = solutionHistory->getCurrentState();
+        auto workingState = solutionHistory->getWorkingState();
+        auto xN   = workingState->getX();
+        Thyra::Vp_S(xN.ptr(), 1.0);
+        workingState->setSolutionStatus(Tempus::Status::PASSED);
+        workingState->computeNorms(currentState);
+      }
+
+      solutionHistory->promoteWorkingState();
+      //auto x = solutionHistory->getCurrentState()->getX();
+      //std::cout << "  x = " << get_ele(*(x), 0) << std::endl;
+    }
+
+    auto currentState = solutionHistory->getCurrentState();
+    TEST_FLOATING_EQUALITY( currentState->getTimeStep(), 0.25, 1.0e-14);
+    TEST_FLOATING_EQUALITY( currentState->getTime(), 0.75, 1.0e-14);
+  }
+
+  // Test increasing timestep
+  {
+    solutionHistory->clear();
+    solutionHistory->addState(icState);
+    solutionHistory->getCurrentState()->setTimeStep(0.5);
+    solutionHistory->getCurrentState()->setTime(0.0);
+    solutionHistory->getCurrentState()->setIndex(0);
+
+    // Set up solution history with two time steps.
+    for (int i = 0; i < 2; i++) {
+      solutionHistory->initWorkingState();
+
+      tsc->setNextTimeStep(solutionHistory, status);
+
+      { // Mock takeStep
+        auto currentState = solutionHistory->getCurrentState();
+        auto workingState = solutionHistory->getWorkingState();
+        auto xN   = workingState->getX();
+        Thyra::Vp_S(xN.ptr(), 0.0);
+        workingState->setSolutionStatus(Tempus::Status::PASSED);
+        workingState->computeNorms(currentState);
+      }
+
+      solutionHistory->promoteWorkingState();
+      //auto x = solutionHistory->getCurrentState()->getX();
+      //std::cout << "  x = " << get_ele(*(x), 0) << std::endl;
+    }
+
+    auto currentState = solutionHistory->getCurrentState();
+    TEST_FLOATING_EQUALITY( currentState->getTimeStep(), 0.55, 1.0e-14);
+    TEST_FLOATING_EQUALITY( currentState->getTime(), 1.05, 1.0e-14);
+  }
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeStepControlStrategyBasicVS, getValidParameters)
+{
+  auto tscs = rcp(new Tempus::TimeStepControlStrategyBasicVS<double>());
+
+  auto pl = tscs->getValidParameters();
+
+  TEST_COMPARE          ( pl->get<std::string>("Strategy Type"), ==,"Basic VS");
+  TEST_FLOATING_EQUALITY( pl->get<double>("Amplification Factor"), 1.75, 1.0e-14);
+  TEST_FLOATING_EQUALITY( pl->get<double>("Reduction Factor"), 0.5, 1.0e-14);
+  TEST_FLOATING_EQUALITY( pl->get<double>("Minimum Value Monitoring Function"), 0.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY( pl->get<double>("Maximum Value Monitoring Function"), 1.0e+16, 1.0e-14);
+
+  { // Ensure that parameters are "used", excluding sublists.
+    std::ostringstream unusedParameters;
+    pl->unused(unusedParameters);
+    TEST_COMPARE ( unusedParameters.str(), ==, "");
+  }
+}
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_TimeStepControlStrategyComposite.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_TimeStepControlStrategyComposite.cpp
@@ -1,0 +1,288 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Thyra_VectorStdOps.hpp"
+
+#include "Tempus_StepperFactory.hpp"
+#include "Tempus_TimeStepControl.hpp"
+#include "Tempus_TimeStepControlStrategyBasicVS.hpp"
+#include "Tempus_TimeStepControlStrategyConstant.hpp"
+#include "Tempus_TimeStepControlStrategyIntegralController.hpp"
+#include "Tempus_TimeStepControlStrategyComposite.hpp"
+
+#include "../TestModels/SinCosModel.hpp"
+#include "../TestModels/DahlquistTestModel.hpp"
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::ParameterList;
+using Teuchos::sublist;
+using Teuchos::getParametersFromXmlFile;
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeStepControlStrategyComposite, Default_Construction_1)
+{
+  auto tscsc = rcp(new Tempus::TimeStepControlStrategyComposite<double>());
+  TEUCHOS_TEST_FOR_EXCEPT(tscsc->isInitialized()); // Should NOT be initialized.
+
+  auto tscsConstant = rcp(new Tempus::TimeStepControlStrategyConstant<double>());
+  tscsc->addStrategy(tscsConstant);
+  tscsc->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!tscsc->isInitialized());
+
+  TEST_COMPARE(tscsc->size(), ==, 1);
+
+  std::vector<Teuchos::RCP<Tempus::TimeStepControlStrategy<double>>>
+    strategies = tscsc->getStrategies();
+
+  auto strategyConstant = rcp_dynamic_cast<Tempus::TimeStepControlStrategyConstant<double> > (strategies[0]);
+
+  TEUCHOS_TEST_FOR_EXCEPT(strategyConstant->getStepType() != "Constant");
+  TEUCHOS_TEST_FOR_EXCEPT(strategyConstant->getConstantTimeStep() != 0.0);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeStepControlStrategyComposite, Default_Construction_2)
+{
+  auto tscsc = rcp(new Tempus::TimeStepControlStrategyComposite<double>());
+  TEUCHOS_TEST_FOR_EXCEPT(tscsc->isInitialized()); // Should NOT be initialized.
+
+  auto tscsBasicVS = rcp(new Tempus::TimeStepControlStrategyBasicVS<double>());
+  tscsc->addStrategy(tscsBasicVS);
+  auto tscsIntCtrl = rcp(new Tempus::TimeStepControlStrategyIntegralController<double>());
+  tscsc->addStrategy(tscsIntCtrl);
+  tscsc->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!tscsc->isInitialized());
+
+  TEST_COMPARE(tscsc->size(), ==, 2);
+
+  std::vector<Teuchos::RCP<Tempus::TimeStepControlStrategy<double>>>
+    strategies = tscsc->getStrategies();
+
+  auto strategyBasicVS = rcp_dynamic_cast<Tempus::TimeStepControlStrategyBasicVS<double> > (strategies[0]);
+  TEUCHOS_TEST_FOR_EXCEPT(strategyBasicVS->getStrategyType() != "Basic VS");
+
+  auto strategyIntCtrl = rcp_dynamic_cast<Tempus::TimeStepControlStrategyIntegralController<double> > (strategies[1]);
+  TEUCHOS_TEST_FOR_EXCEPT(strategyIntCtrl->getStrategyType() != "Integral Controller");
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeStepControlStrategyComposite, Create_Construction)
+{
+  // Construct ParmeterList for testing.
+  auto tscsc_temp = rcp(new Tempus::TimeStepControlStrategyComposite<double>());
+  auto tscs_BasicVS =
+    rcp(new Tempus::TimeStepControlStrategyBasicVS<double>());
+  auto tscs_IC =
+    rcp(new Tempus::TimeStepControlStrategyIntegralController<double>());
+
+  tscsc_temp->addStrategy(tscs_BasicVS);
+  tscsc_temp->addStrategy(tscs_IC);
+  tscsc_temp->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!tscsc_temp->isInitialized());
+
+  auto pl = rcp_const_cast<Teuchos::ParameterList>(tscsc_temp->getValidParameters());
+
+  auto tscsc = Tempus::createTimeStepControlStrategyComposite<double>(pl);
+
+  TEST_COMPARE(tscsc->size(), ==, 2);
+
+  std::vector<Teuchos::RCP<Tempus::TimeStepControlStrategy<double>>>
+    strategies = tscsc->getStrategies();
+
+  auto strategyBasicVS = Teuchos::rcp_dynamic_cast<Tempus::TimeStepControlStrategyBasicVS<double> > (strategies[0]);
+
+  TEUCHOS_TEST_FOR_EXCEPT(strategyBasicVS->getStepType() != "Variable");
+  TEUCHOS_TEST_FOR_EXCEPT(strategyBasicVS->getAmplFactor() != 1.75);
+  TEUCHOS_TEST_FOR_EXCEPT(strategyBasicVS->getReductFactor() != 0.5);
+  TEUCHOS_TEST_FOR_EXCEPT(strategyBasicVS->getMinEta() != 0.0);
+  TEUCHOS_TEST_FOR_EXCEPT(strategyBasicVS->getMaxEta() != 1.0e+16);
+
+  auto strategyIC = Teuchos::rcp_dynamic_cast<Tempus::TimeStepControlStrategyIntegralController<double> > (strategies[1]);
+
+  TEUCHOS_TEST_FOR_EXCEPT(strategyIC->getStepType() != "Variable");
+  TEUCHOS_TEST_FOR_EXCEPT(strategyIC->getController() != "PID");
+  TEUCHOS_TEST_FOR_EXCEPT(strategyIC->getKI() != 0.58);
+  TEUCHOS_TEST_FOR_EXCEPT(strategyIC->getKP() != 0.21);
+  TEUCHOS_TEST_FOR_EXCEPT(strategyIC->getKD() != 0.10);
+  TEUCHOS_TEST_FOR_EXCEPT(strategyIC->getSafetyFactor() != 0.90);
+  TEUCHOS_TEST_FOR_EXCEPT(strategyIC->getSafetyFactorAfterReject() != 0.90);
+  TEUCHOS_TEST_FOR_EXCEPT(strategyIC->getFacMax() != 5.0);
+  TEUCHOS_TEST_FOR_EXCEPT(strategyIC->getFacMin() != 0.5);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeStepControlStrategyComposite, getValidParameters)
+{
+  // Construct ParmeterList for testing.
+  auto tscsc_temp = rcp(new Tempus::TimeStepControlStrategyComposite<double>());
+  auto tscs_BasicVS = rcp(new Tempus::TimeStepControlStrategyBasicVS<double>());
+  auto tscs_IC = rcp(new Tempus::TimeStepControlStrategyIntegralController<double>());
+
+  tscsc_temp->addStrategy(tscs_BasicVS);
+  tscsc_temp->addStrategy(tscs_IC);
+  tscsc_temp->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!tscsc_temp->isInitialized());
+
+  auto pl = tscsc_temp->getValidParameters();
+
+  TEST_COMPARE          ( pl->get<std::string>("Strategy Type"), ==, "Composite");
+  TEST_COMPARE          ( pl->get<std::string>("Strategy List"), ==, "Basic VS, Integral Controller");
+  TEST_COMPARE          ( pl->isSublist("Basic VS")            , ==, true);
+  TEST_COMPARE          ( pl->isSublist("Integral Controller") , ==, true);
+
+  { // Ensure that parameters are "used", excluding sublists.
+    std::ostringstream unusedParameters;
+    pl->unused(unusedParameters);
+    TEST_COMPARE ( unusedParameters.str(), ==,
+      "WARNING: Parameter \"Basic VS\"    [unused] is unused\n"
+      "WARNING: Parameter \"Integral Controller\"    [unused] is unused\n");
+  }
+
+  auto BasicVS_PL = pl->sublist("Basic VS");
+  TEST_COMPARE          ( BasicVS_PL.get<std::string>("Strategy Type")  , ==, "Basic VS");
+  TEST_FLOATING_EQUALITY( BasicVS_PL.get<double>("Amplification Factor"), 1.75, 1.0e-14);
+  TEST_FLOATING_EQUALITY( BasicVS_PL.get<double>("Reduction Factor")    , 0.5 , 1.0e-14);
+  TEST_FLOATING_EQUALITY( BasicVS_PL.get<double>("Minimum Value Monitoring Function"), 0.0    , 1.0e-14);
+  TEST_FLOATING_EQUALITY( BasicVS_PL.get<double>("Maximum Value Monitoring Function"), 1.0e+16, 1.0e-14);
+
+  { // Ensure that parameters are "used", excluding sublists.
+    std::ostringstream unusedParameters;
+    BasicVS_PL.unused(unusedParameters);
+    TEST_COMPARE ( unusedParameters.str(), ==, "");
+  }
+
+  auto IntCtrl_PL = pl->sublist("Integral Controller");
+  TEST_COMPARE          ( IntCtrl_PL.get<std::string>("Strategy Type")  , ==, "Integral Controller");
+  TEST_COMPARE          ( IntCtrl_PL.get<std::string>("Controller Type")  , ==, "PID");
+  TEST_FLOATING_EQUALITY( IntCtrl_PL.get<double>("KI"), 0.58, 1.0e-14);
+  TEST_FLOATING_EQUALITY( IntCtrl_PL.get<double>("KP"), 0.21, 1.0e-14);
+  TEST_FLOATING_EQUALITY( IntCtrl_PL.get<double>("KD"), 0.1 , 1.0e-14);
+  TEST_FLOATING_EQUALITY( IntCtrl_PL.get<double>("Safety Factor"), 0.9 , 1.0e-14);
+  TEST_FLOATING_EQUALITY( IntCtrl_PL.get<double>("Safety Factor After Step Rejection"), 0.9 , 1.0e-14);
+  TEST_FLOATING_EQUALITY( IntCtrl_PL.get<double>("Maximum Safety Factor"), 5.0 , 1.0e-14);
+  TEST_FLOATING_EQUALITY( IntCtrl_PL.get<double>("Minimum Safety Factor"), 0.5 , 1.0e-14);
+
+  { // Ensure that parameters are "used", excluding sublists.
+    std::ostringstream unusedParameters;
+    IntCtrl_PL.unused(unusedParameters);
+    TEST_COMPARE ( unusedParameters.str(), ==, "");
+  }
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeStepControlStrategyComposite, Setting_Strategies_PLs)
+{
+
+  { // Test with default ParameterList
+    auto pl = Tempus::getTimeStepControlStrategyCompositePL<double>();
+
+    auto tscsc = Tempus::createTimeStepControlStrategyComposite<double>(pl);
+    TEUCHOS_TEST_FOR_EXCEPT(!tscsc->isInitialized());
+
+    std::vector<Teuchos::RCP<Tempus::TimeStepControlStrategy<double>>>
+      strategies = tscsc->getStrategies();
+
+    // Default strategy is "Constant"
+    TEUCHOS_TEST_FOR_EXCEPT(!(tscsc->getStepType() == "Constant"));
+    TEUCHOS_TEST_FOR_EXCEPT(!(tscsc->getStrategyType() == "Composite"));
+    TEUCHOS_TEST_FOR_EXCEPT(!(tscsc->getStrategies().size() == 1));
+    TEUCHOS_TEST_FOR_EXCEPT(!(strategies[0]->getStepType() == "Constant"));
+    TEUCHOS_TEST_FOR_EXCEPT(!(strategies[0]->getStrategyType() == "Constant"));
+  }
+
+  { // Test with empty "Strategy List"
+    auto pl = Tempus::getTimeStepControlStrategyCompositePL<double>();
+    pl->set("Strategy List", "");
+    pl->remove("Constant");
+
+    auto tscsc = Tempus::createTimeStepControlStrategyComposite<double>(pl);
+    TEUCHOS_TEST_FOR_EXCEPT(tscsc->isInitialized());  // Should NOT be initialized!
+
+    // Default strategy is "Variable"
+    TEUCHOS_TEST_FOR_EXCEPT(!(tscsc->getStepType() == "Variable"));
+    TEUCHOS_TEST_FOR_EXCEPT(!(tscsc->getStrategyType() == "Composite"));
+    TEUCHOS_TEST_FOR_EXCEPT(!(tscsc->getStrategies().size() == 0));
+  }
+
+  { // Test with non-Tempus strategy
+    auto pl = Tempus::getTimeStepControlStrategyCompositePL<double>();
+    pl->remove("Constant");
+    pl->set("Strategy List", "Application Strategy");
+
+    auto nonTempusStrategyPL =
+      Teuchos::parameterList("Application Strategy");
+    nonTempusStrategyPL->set<std::string>("Strategy Type", "Application Strategy");
+    nonTempusStrategyPL->set<double>("Secret Sauce", 1.2345);
+    pl->set("Application Strategy", *nonTempusStrategyPL);
+
+    auto tscsc = Tempus::createTimeStepControlStrategyComposite<double>(pl);
+    TEUCHOS_TEST_FOR_EXCEPT(tscsc->isInitialized());  // Should NOT be initialized!
+
+    // Default strategy is "Variable"
+    TEUCHOS_TEST_FOR_EXCEPT(!(tscsc->getStepType() == "Variable"));
+    TEUCHOS_TEST_FOR_EXCEPT(!(tscsc->getStrategyType() == "Composite"));
+    TEUCHOS_TEST_FOR_EXCEPT(!(tscsc->getStrategies().size() == 0));
+  }
+
+  { // Test with two Tempus strategies and a non-Tempus strategy
+
+    // Setup ParameterList for this test.
+    auto temp = rcp(new Tempus::TimeStepControlStrategyComposite<double>());
+    auto tscsBasicVS = rcp(new Tempus::TimeStepControlStrategyBasicVS<double>());
+    temp->addStrategy(tscsBasicVS);
+    auto tscsIntCtrl = rcp(new Tempus::TimeStepControlStrategyIntegralController<double>());
+    temp->addStrategy(tscsIntCtrl);
+    temp->initialize();
+
+    auto pl = rcp_const_cast<Teuchos::ParameterList>(temp->getValidParameters());
+    auto sList = pl->get<std::string>("Strategy List");
+    pl->set("Strategy List", sList+", Application Strategy");
+
+    auto nonTempusStrategyPL =
+      Teuchos::parameterList("Application Strategy");
+    nonTempusStrategyPL->set<std::string>("Strategy Type", "Application Strategy");
+    nonTempusStrategyPL->set<double>("Secret Sauce", 1.2345);
+    pl->set("Application Strategy", *nonTempusStrategyPL);
+
+    auto tscsc = Tempus::createTimeStepControlStrategyComposite<double>(pl);
+    TEUCHOS_TEST_FOR_EXCEPT(!tscsc->isInitialized());
+
+    // Default strategy is "Constant"
+    TEUCHOS_TEST_FOR_EXCEPT(!(tscsc->getStepType() == "Variable"));
+    TEUCHOS_TEST_FOR_EXCEPT(!(tscsc->getStrategyType() == "Composite"));
+    TEUCHOS_TEST_FOR_EXCEPT(!(tscsc->getStrategies().size() == 2));
+  }
+
+}
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_TimeStepControlStrategyConstant.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_TimeStepControlStrategyConstant.cpp
@@ -1,0 +1,157 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Thyra_VectorStdOps.hpp"
+
+#include "Tempus_StepperFactory.hpp"
+#include "Tempus_TimeStepControl.hpp"
+#include "Tempus_TimeStepControlStrategyConstant.hpp"
+#include "Tempus_TimeStepControlStrategyBasicVS.hpp"
+
+#include "../TestModels/SinCosModel.hpp"
+#include "../TestModels/DahlquistTestModel.hpp"
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::ParameterList;
+using Teuchos::sublist;
+using Teuchos::getParametersFromXmlFile;
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeStepControlStrategyConstant, Default_Construction)
+{
+  auto tscs = rcp(new Tempus::TimeStepControlStrategyConstant<double>());
+  TEUCHOS_TEST_FOR_EXCEPT(!tscs->isInitialized());
+
+  // Test the get functions (i.e., defaults).
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getStrategyType() != "Constant");
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getStepType() != "Constant");
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getName() != "Constant");
+  TEST_FLOATING_EQUALITY (tscs->getConstantTimeStep(), 0.0, 1.0e-14);
+
+  // Test the set functions.
+  tscs->setConstantTimeStep(0.989);  tscs->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!tscs->isInitialized());
+
+  TEST_FLOATING_EQUALITY (tscs->getConstantTimeStep(), 0.989, 1.0e-14);
+
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeStepControlStrategyConstant, Full_Construction)
+{
+  auto tscs = rcp(new Tempus::TimeStepControlStrategyConstant<double>(
+    0.123, "Full_Construction_Test"));
+  TEUCHOS_TEST_FOR_EXCEPT(!tscs->isInitialized());
+
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getStrategyType() != "Constant");
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getStepType() != "Constant");
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getName() != "Full_Construction_Test");
+  TEST_FLOATING_EQUALITY (tscs->getConstantTimeStep(), 0.123, 1.0e-14);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeStepControlStrategyConstant, Create_Construction)
+{
+  auto pl = Tempus::getTimeStepControlStrategyConstantPL<double>();
+
+  // Set strategy parameters.
+  pl->set<double>("Time Step", 0.02);
+
+  auto tscsc = Tempus::createTimeStepControlStrategyConstant<double>(pl);
+  TEUCHOS_TEST_FOR_EXCEPT(!tscsc->isInitialized());
+
+  TEST_FLOATING_EQUALITY (tscsc->getConstantTimeStep(), 0.02, 1.0e-14);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeStepControlStrategyConstant, setNextTimeStep)
+{
+  auto tscs = rcp(new Tempus::TimeStepControlStrategyConstant<double>());
+  TEUCHOS_TEST_FOR_EXCEPT(!tscs->isInitialized());
+
+  double initTime  = 1.0;
+  int    initIndex = -100;
+
+  // Setup the SolutionHistory --------------------------------
+  auto model   = rcp(new Tempus_Test::SinCosModel<double>());
+  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =model->getNominalValues();
+  auto icSolution = rcp_const_cast<Thyra::VectorBase<double> >(inArgsIC.get_x());
+  auto icState = Tempus::createSolutionStateX<double>(icSolution);
+  auto solutionHistory = rcp(new Tempus::SolutionHistory<double>());
+  solutionHistory->addState(icState);
+  solutionHistory->getCurrentState()->setTimeStep(0.9);
+  solutionHistory->getCurrentState()->setTime(initTime);
+  solutionHistory->getCurrentState()->setIndex(initIndex);
+
+  // Setup the TimeStepControl --------------------------------
+  auto tsc = rcp(new Tempus::TimeStepControl<double>());
+  tsc->setTimeStepControlStrategy(tscs);
+  tsc->setInitTime(initTime);
+  tsc->setFinalTime(100.0);
+  tsc->setMinTimeStep(0.01);
+  tsc->setInitTimeStep(0.02);
+  tsc->setMaxTimeStep(0.05);
+  tsc->setInitIndex(initIndex);
+  tsc->setFinalIndex(100);
+  tsc->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!tsc->isInitialized());
+  Tempus::Status status = Tempus::Status::WORKING;
+
+  // ** Mock Timestep ** //
+  solutionHistory->initWorkingState();
+
+  tsc->setNextTimeStep(solutionHistory, status);
+  // ** Mock Timestep ** //
+
+  auto workingState = solutionHistory->getWorkingState();
+  TEST_FLOATING_EQUALITY( workingState->getTimeStep(), 0.02, 1.0e-14);
+  TEST_FLOATING_EQUALITY( workingState->getTime(), 1.02, 1.0e-14);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeStepControlStrategyConstant, getValidParameters)
+{
+  auto tscsc = rcp(new Tempus::TimeStepControlStrategyConstant<double>());
+
+  auto pl = tscsc->getValidParameters();
+
+  TEST_COMPARE          ( pl->get<std::string>("Strategy Type"), ==,"Constant");
+  TEST_FLOATING_EQUALITY( pl->get<double>("Time Step"), 0.0, 1.0e-14);
+
+  { // Ensure that parameters are "used", excluding sublists.
+    std::ostringstream unusedParameters;
+    pl->unused(unusedParameters);
+    TEST_COMPARE ( unusedParameters.str(), ==, "");
+  }
+}
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_TimeStepControlStrategyIntegralController.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_TimeStepControlStrategyIntegralController.cpp
@@ -1,0 +1,274 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Thyra_VectorStdOps.hpp"
+
+#include "Tempus_StepperFactory.hpp"
+#include "Tempus_TimeStepControl.hpp"
+#include "Tempus_TimeStepControlStrategyIntegralController.hpp"
+
+#include "../TestModels/SinCosModel.hpp"
+#include "../TestModels/DahlquistTestModel.hpp"
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::ParameterList;
+using Teuchos::sublist;
+using Teuchos::getParametersFromXmlFile;
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeStepControlStrategyIntegralController, Default_Construction)
+{
+  auto tscs = rcp(new Tempus::TimeStepControlStrategyIntegralController<double>());
+  TEUCHOS_TEST_FOR_EXCEPT(!tscs->isInitialized());
+
+  // Test the get functions (i.e., defaults).
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getStepType() != "Variable");
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getController() != "PID");
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getKI() != 0.58);
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getKP() != 0.21);
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getKD() != 0.10);
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getSafetyFactor() != 0.90);
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getSafetyFactorAfterReject() != 0.90);
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getFacMax() != 5.0);
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getFacMin() != 0.5);
+
+  // Test the set functions.
+  tscs->setController("I");     tscs->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!tscs->isInitialized());
+  tscs->setKI(0.6);             tscs->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!tscs->isInitialized());
+  tscs->setKP(0.0);             tscs->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!tscs->isInitialized());
+  tscs->setKD(0.0);             tscs->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!tscs->isInitialized());
+  tscs->setSafetyFactor(0.8);   tscs->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!tscs->isInitialized());
+  tscs->setSafetyFactorAfterReject(0.8);   tscs->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!tscs->isInitialized());
+  tscs->setFacMax(4.0);         tscs->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!tscs->isInitialized());
+  tscs->setFacMin(0.4);         tscs->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!tscs->isInitialized());
+
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getStepType() != "Variable");
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getController() != "I");
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getKI() != 0.6);
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getKP() != 0.0);
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getKD() != 0.0);
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getSafetyFactor() != 0.8);
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getSafetyFactorAfterReject() != 0.8);
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getFacMax() != 4.0);
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getFacMin() != 0.4);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeStepControlStrategyIntegralController, Full_Construction)
+{
+  auto tscs = rcp(new Tempus::TimeStepControlStrategyIntegralController<double>(
+    "I", 0.6, 0.0, 0.0, 0.8, 0.8, 4.0, 0.4));
+  TEUCHOS_TEST_FOR_EXCEPT(!tscs->isInitialized());
+
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getStepType() != "Variable");
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getController() != "I");
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getKI() != 0.6);
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getKP() != 0.0);
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getKD() != 0.0);
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getSafetyFactor() != 0.8);
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getSafetyFactorAfterReject() != 0.8);
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getFacMax() != 4.0);
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getFacMin() != 0.4);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeStepControlStrategyIntegralController, Create_Construction)
+{
+  auto pl = Tempus::getTimeStepControlStrategyIntegralControllerPL<double>();
+
+  pl->set<std::string>("Controller Type", "I");
+  pl->set<double>("KI", 0.6);
+  pl->set<double>("KP", 0.0);
+  pl->set<double>("KD", 0.0);
+  pl->set<double>("Safety Factor", 0.8);
+  pl->set<double>("Safety Factor After Step Rejection", 0.8);
+  pl->set<double>("Maximum Safety Factor", 4.0);
+  pl->set<double>("Minimum Safety Factor", 0.4);
+
+  auto tscs = Tempus::createTimeStepControlStrategyIntegralController<double>(pl);
+
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getStepType() != "Variable");
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getController() != "I");
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getKI() != 0.6);
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getKP() != 0.0);
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getKD() != 0.0);
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getSafetyFactor() != 0.8);
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getSafetyFactorAfterReject() != 0.8);
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getFacMax() != 4.0);
+  TEUCHOS_TEST_FOR_EXCEPT(tscs->getFacMin() != 0.4);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeStepControlStrategyIntegralController, setNextTimeStep)
+{
+  double KI = 0.5;
+  double KP = 0.25;
+  double KD = 0.15;
+  double safetyFactor = 0.9;
+  double safetyFactorAfterReject = 0.9;
+  double facMax = 5.0;
+  double facMin = 0.5;
+
+  auto tscs =
+    rcp(new Tempus::TimeStepControlStrategyIntegralController<double>(
+      "PID", KI, KP, KD, safetyFactor, safetyFactorAfterReject,
+      facMax, facMin));
+
+  // Setup the TimeStepControl --------------------------------
+  auto tsc = rcp(new Tempus::TimeStepControl<double>());
+  tsc->setTimeStepControlStrategy(tscs);
+  tsc->setInitTime(0.0);
+  tsc->setFinalTime(10.0);
+  tsc->setMinTimeStep (0.01);
+  tsc->setInitTimeStep(1.0);
+  tsc->setMaxTimeStep (10.0);
+  tsc->setFinalIndex(100);
+  tsc->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!tsc->isInitialized());
+  Tempus::Status status = Tempus::Status::WORKING;
+
+  // Setup the SolutionHistory --------------------------------
+  auto model = rcp(new Tempus_Test::DahlquistTestModel<double>());
+  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =model->getNominalValues();
+  auto icSolution = rcp_const_cast<Thyra::VectorBase<double> >(inArgsIC.get_x());
+  auto icState = Tempus::createSolutionStateX<double>(icSolution);
+  auto solutionHistory = rcp(new Tempus::SolutionHistory<double>());
+
+  double order = 2.0;
+  solutionHistory->addState(icState);
+  solutionHistory->getCurrentState()->setTimeStep(1.0);
+  solutionHistory->getCurrentState()->setTime(0.0);
+  solutionHistory->getCurrentState()->setIndex(0);
+  solutionHistory->getCurrentState()->setOrder(order);
+
+  // Mock Integrator
+
+  // -- First Time Step
+  solutionHistory->initWorkingState();
+  auto currentState = solutionHistory->getCurrentState();
+  auto workingState = solutionHistory->getWorkingState();
+
+  tsc->setNextTimeStep(solutionHistory, status);
+
+  // First time step should cause no change to dt because
+  // internal relative errors = 1.
+  TEST_FLOATING_EQUALITY(workingState->getTimeStep(), 1.0, 1.0e-14);
+
+  // Mock takeStep
+  double errN = 0.1;
+  workingState->setErrorRel(errN);
+  workingState->setSolutionStatus(Tempus::Status::PASSED);
+
+
+
+  // -- Second Time Step
+  solutionHistory->initWorkingState();
+  currentState = solutionHistory->getCurrentState();
+  workingState = solutionHistory->getWorkingState();
+  double dt = workingState->getTimeStep();
+
+  tsc->setNextTimeStep(solutionHistory, status);
+
+  double p    = order - 1.0;
+  double dtNew = dt*safetyFactor*std::pow(errN, -KI/p);
+  TEST_FLOATING_EQUALITY(workingState->getTimeStep(), dtNew, 1.0e-14);
+
+  // Mock takeStep
+  errN = 0.2;
+  double errNm1 = 0.1;
+  workingState->setErrorRel(errN);
+  workingState->setSolutionStatus(Tempus::Status::PASSED);
+
+
+
+  // -- Third Time Step
+  solutionHistory->initWorkingState();
+  currentState = solutionHistory->getCurrentState();
+  workingState = solutionHistory->getWorkingState();
+  dt = workingState->getTimeStep();
+
+  tsc->setNextTimeStep(solutionHistory, status);
+
+  dtNew = dt*safetyFactor*std::pow(errN,   -KI/p)
+                         *std::pow(errNm1,  KP/p);
+  TEST_FLOATING_EQUALITY(workingState->getTimeStep(), dtNew, 1.0e-14);
+
+  // Mock takeStep
+  errN = 0.3;
+  errNm1 = 0.2;
+  double errNm2 = 0.1;
+  workingState->setErrorRel(errN);
+  workingState->setSolutionStatus(Tempus::Status::PASSED);
+
+
+
+  // -- Fourth Time Step
+  solutionHistory->initWorkingState();
+  currentState = solutionHistory->getCurrentState();
+  workingState = solutionHistory->getWorkingState();
+  dt = workingState->getTimeStep();
+
+  tsc->setNextTimeStep(solutionHistory, status);
+
+  dtNew = dt*safetyFactor*std::pow(errN,   -KI/p)
+                         *std::pow(errNm1,  KP/p)
+                         *std::pow(errNm2, -KD/p);
+  TEST_FLOATING_EQUALITY(workingState->getTimeStep(), dtNew, 1.0e-14);
+
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeStepControlStrategyIntegralController, getValidParameters)
+{
+  auto tscs = rcp(new Tempus::TimeStepControlStrategyIntegralController<double>());
+
+  auto pl = tscs->getValidParameters();
+
+  TEST_COMPARE          ( pl->get<std::string>("Strategy Type"), ==,"Integral Controller");
+  TEST_COMPARE          ( pl->get<std::string>("Controller Type"), ==,"PID");
+  TEST_FLOATING_EQUALITY( pl->get<double>("KI"), 0.58, 1.0e-14);
+  TEST_FLOATING_EQUALITY( pl->get<double>("KP"), 0.21, 1.0e-14);
+  TEST_FLOATING_EQUALITY( pl->get<double>("KD"), 0.10, 1.0e-14);
+  TEST_FLOATING_EQUALITY( pl->get<double>("Safety Factor"), 0.9, 1.0e-14);
+  TEST_FLOATING_EQUALITY( pl->get<double>("Safety Factor After Step Rejection"), 0.9, 1.0e-14);
+  TEST_FLOATING_EQUALITY( pl->get<double>("Maximum Safety Factor"), 5.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY( pl->get<double>("Minimum Safety Factor"), 0.5, 1.0e-14);
+
+  { // Ensure that parameters are "used", excluding sublists.
+    std::ostringstream unusedParameters;
+    pl->unused(unusedParameters);
+    TEST_COMPARE ( unusedParameters.str(), ==, "");
+  }
+}
+
+
+} // namespace Tempus_Test


### PR DESCRIPTION
Remove ParameterList from internals of TimeStepControlStrategies:
 - TimeStepControlStrategyBasicVS
 - TimeStepControlStrategyComposite
 - TimeStepControlStrategyConstant
 - TimeStepControlStrategyIntegralController

 * Move ParameterList constructor to a non-member function,
   createTimeStepControlStrategy*().
 * Created a default constructor and a full member data
   constructor.
 * Made initialize() check member data settings to ensure
   they are valid, and set isInitialized_.
 * Added setNextTimeStep() as the replacement for getNextTimeStep(),
   which better indicates what the function does.  getNextTimeStep()
   is still avaiable but just calls setNextTimeStep().
 * Made Strategies more consistent.
 * Added a step type to strategies to ensure it match the TimeStepControl.
 * Added initialization checks to the strategies.
 * Ensure each strategy updates the time step AND the time.
   - TimeStepControlStrategyConstant now sets the time from
     the dt and time step index to avoid numerical round-off.
 * Added to the documentation to TimeStepControlStrategyIntegralController.
 * Added unit tests for TimeStepControl and Strategies.


@trilinos/tempus 

## Motivation
Removing ParamerLists from the internals of the TimeStepControl objects simplifies the code and clarifies the data transparency. 

* Closes #8372 

## Testing
Added multiple unit tests covering TimeStepControl and TimeStepControlStrategies.
