### PR TITLE
MueLu: Add option to read coordinate map to Driver

### DIFF
--- a/packages/muelu/example/basic/Simple.cpp
+++ b/packages/muelu/example/basic/Simple.cpp
@@ -123,6 +123,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
   std::string matrixFile;                             clp.setOption("matrix",                &matrixFile,        "matrix data file");
   std::string rhsFile;                                clp.setOption("rhs",                   &rhsFile,           "rhs data file");
   std::string coordFile;                              clp.setOption("coords",                &coordFile,         "coordinates data file");
+  std::string coordMapFile;                           clp.setOption("coordsmap",             &coordMapFile,      "coordinates map data file");
   std::string nullFile;                               clp.setOption("nullspace",             &nullFile,          "nullspace data file");
   std::string materialFile;                           clp.setOption("material",              &materialFile,      "material data file");    
   int         maxIts            = 200;                clp.setOption("its",                   &maxIts,            "maximum number of solver iterations");
@@ -184,7 +185,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
   RCP<MultiVector> X, B;
 
   // Load the matrix off disk (or generate it via Galeri)
-  MatrixLoad<SC,LO,GO,NO>(comm,lib,binaryFormat,matrixFile,rhsFile,rowMapFile,colMapFile,domainMapFile,rangeMapFile,coordFile,nullFile,materialFile,map,A,coordinates,nullspace,material,X,B,numVectors,galeriParameters,xpetraParameters,galeriStream);
+  MatrixLoad<SC,LO,GO,NO>(comm,lib,binaryFormat,matrixFile,rhsFile,rowMapFile,colMapFile,domainMapFile,rangeMapFile,coordFile,coordMapFile,nullFile,materialFile,map,A,coordinates,nullspace,material,X,B,numVectors,galeriParameters,xpetraParameters,galeriStream);
   comm->barrier();
   tm = Teuchos::null;
   out << galeriStream.str();

--- a/packages/muelu/example/basic/Stratimikos.cpp
+++ b/packages/muelu/example/basic/Stratimikos.cpp
@@ -150,6 +150,7 @@ int MainWrappers<double,LocalOrdinal,GlobalOrdinal,Node>::main_(Teuchos::Command
     std::string matrixFile;                             clp.setOption("matrix",                &matrixFile,        "matrix data file");
     std::string rhsFile;                                clp.setOption("rhs",                   &rhsFile,           "rhs data file");
     std::string coordFile;                              clp.setOption("coords",                &coordFile,         "coordinates data file");
+    std::string coordMapFile;                           clp.setOption("coordsmap",             &coordMapFile,      "coordinates map data file");
     std::string nullFile;                               clp.setOption("nullspace",             &nullFile,          "nullspace data file");
     std::string materialFile;                           clp.setOption("material",              &materialFile,      "material data file");
     int         numVectors        = 1;                  clp.setOption("multivector",           &numVectors,        "number of rhs to solve simultaneously");
@@ -192,7 +193,7 @@ int MainWrappers<double,LocalOrdinal,GlobalOrdinal,Node>::main_(Teuchos::Command
     RCP<MultiVector>           X, B;
 
     std::ostringstream galeriStream;
-    MatrixLoad<SC,LocalOrdinal,GlobalOrdinal,Node>(comm,lib,binaryFormat,matrixFile,rhsFile,rowMapFile,colMapFile,domainMapFile,rangeMapFile,coordFile,nullFile,materialFile,map,A,coordinates,nullspace,material,X,B,numVectors,matrixParameters,xpetraParameters,galeriStream);
+    MatrixLoad<SC,LocalOrdinal,GlobalOrdinal,Node>(comm,lib,binaryFormat,matrixFile,rhsFile,rowMapFile,colMapFile,domainMapFile,rangeMapFile,coordFile,coordMapFile,nullFile,materialFile,map,A,coordinates,nullspace,material,X,B,numVectors,matrixParameters,xpetraParameters,galeriStream);
     out << galeriStream.str();
 
     //

--- a/packages/muelu/test/scaling/Driver.cpp
+++ b/packages/muelu/test/scaling/Driver.cpp
@@ -231,6 +231,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
   std::string matrixFile;                             clp.setOption("matrix",                &matrixFile,        "matrix data file");
   std::string rhsFile;                                clp.setOption("rhs",                   &rhsFile,           "rhs data file");
   std::string coordFile;                              clp.setOption("coords",                &coordFile,         "coordinates data file");
+  std::string coordMapFile;                           clp.setOption("coordsmap",             &coordMapFile,      "coordinates map data file");
   std::string nullFile;                               clp.setOption("nullspace",             &nullFile,          "nullspace data file");
   std::string materialFile;                           clp.setOption("material",              &materialFile,      "material data file");
   int         numRebuilds       = 0;                  clp.setOption("rebuild",               &numRebuilds,       "#times to rebuild hierarchy");
@@ -355,7 +356,7 @@ MueLu::MueLu_AMGX_initialize_plugins();
   RCP<MultiVector> X, B;
 
   // Load the matrix off disk (or generate it via Galeri)
-  MatrixLoad<SC,LO,GO,NO>(comm,lib,binaryFormat,matrixFile,rhsFile,rowMapFile,colMapFile,domainMapFile,rangeMapFile,coordFile,nullFile,materialFile,map,A,coordinates,nullspace,material,X,B,numVectors,galeriParameters,xpetraParameters,galeriStream);
+  MatrixLoad<SC,LO,GO,NO>(comm,lib,binaryFormat,matrixFile,rhsFile,rowMapFile,colMapFile,domainMapFile,rangeMapFile,coordFile,coordMapFile,nullFile,materialFile,map,A,coordinates,nullspace,material,X,B,numVectors,galeriParameters,xpetraParameters,galeriStream);
   comm->barrier();
   tm = Teuchos::null;
 

--- a/packages/muelu/test/scaling/MatrixLoad.hpp
+++ b/packages/muelu/test/scaling/MatrixLoad.hpp
@@ -77,7 +77,8 @@ void MatrixLoad(Teuchos::RCP<const Teuchos::Comm<int> > &comm,  Xpetra::Underlyi
                 const std::string & colMapFile,
                 const std::string & domainMapFile,
                 const std::string & rangeMapFile,
-                const std::string & coordFile, const std::string &nullFile, const std::string &materialFile,
+                const std::string & coordFile,
+                const std::string & coordMapFile, const std::string &nullFile, const std::string &materialFile,
                 Teuchos::RCP<const Xpetra::Map<LocalOrdinal,GlobalOrdinal,Node> >          & map,
                 Teuchos::RCP<Xpetra::Matrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> >      & A,
                 Teuchos::RCP<Xpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::magnitudeType,LocalOrdinal,GlobalOrdinal,Node> > & coordinates,
@@ -189,9 +190,12 @@ void MatrixLoad(Teuchos::RCP<const Teuchos::Comm<int> > &comm,  Xpetra::Underlyi
     comm->barrier();
 
     if (!coordFile.empty()) {
-      // NOTE: currently we only allow reading scalar matrices, thus coordinate
-      // map is same as matrix map
-      coordinates = Xpetra::IO<typename Teuchos::ScalarTraits<Scalar>::magnitudeType,LO,GO,Node>::ReadMultiVector(coordFile, map);
+      RCP<const Map> coordMap;
+      if (!coordMapFile.empty())
+        coordMap = Xpetra::IO<SC,LO,GO,Node>::ReadMap(coordMapFile, lib, comm);
+      else
+        coordMap = map;
+      coordinates = Xpetra::IO<typename Teuchos::ScalarTraits<Scalar>::magnitudeType,LO,GO,Node>::ReadMultiVector(coordFile, coordMap);
     }
 
     if (!nullFile.empty())

--- a/packages/muelu/test/scaling/MatvecKernelDriver.cpp
+++ b/packages/muelu/test/scaling/MatvecKernelDriver.cpp
@@ -525,7 +525,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
     clp.setOption("report_error_norms", "noreport_error_norms", &report_error_norms,   "Report L2 norms for the solution");
 
     std::ostringstream galeriStream;
-    std::string rhsFile,coordFile,nullFile, materialFile; //unused
+    std::string rhsFile,coordFile,coordMapFile,nullFile, materialFile; //unused
     typedef typename Teuchos::ScalarTraits<SC>::magnitudeType real_type;
     typedef Xpetra::MultiVector<real_type,LO,GO,NO> RealValuedMultiVector;
     RCP<RealValuedMultiVector> coordinates;
@@ -544,7 +544,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
       TEUCHOS_TEST_FOR_EXCEPTION(true,std::runtime_error,"The Kokkos-Kernels matvec kernel cannot be run with more than one rank.");
 
     // Load the matrix off disk (or generate it via Galeri), assuming only one right hand side is loaded.
-    MatrixLoad<SC,LO,GO,NO>(comm, lib, binaryFormat, matrixFile, rhsFile, rowMapFile, colMapFile, domainMapFile, rangeMapFile, coordFile, nullFile, materialFile, map, A, coordinates, nullspace, material, x, b, 1, galeriParameters, xpetraParameters, galeriStream);
+    MatrixLoad<SC,LO,GO,NO>(comm, lib, binaryFormat, matrixFile, rhsFile, rowMapFile, colMapFile, domainMapFile, rangeMapFile, coordFile, coordMapFile, nullFile, materialFile, map, A, coordinates, nullspace, material, x, b, 1, galeriParameters, xpetraParameters, galeriStream);
 
     #ifndef HAVE_MUELU_MKL
     if (do_mkl) {

--- a/packages/muelu/test/scaling/SpMVPerformance.cpp
+++ b/packages/muelu/test/scaling/SpMVPerformance.cpp
@@ -194,7 +194,7 @@ public:
     MatrixLoad<Scalar, LocalOrdinal, GlobalOrdinal, Node>(
         comm, system.lib,
         binaryFormat, matrixFile, rhsFile, rowMapFile, colMapFile,
-        domainMapFile, rangeMapFile, coordFile, nullFile, materialFile,
+        domainMapFile, rangeMapFile, coordFile, coordMapFile, nullFile, materialFile,
         map, system.A,
         coordinates, nullspace, material,
         system.X, system.B, system.numVectors,
@@ -216,6 +216,7 @@ private:
   std::string domainMapFile = "";
   std::string rangeMapFile = "";
   std::string coordFile = "";
+  std::string coordMapFile = "";
   std::string nullFile = "";
   std::string materialFile = "";
 


### PR DESCRIPTION
@trilinos/muelu 

## Motivation
This is useful when the coordinate map doesn't match the rowmap of the matrix, as is the case for "number of equations" > 1.
