### PR TITLE
Zoltan2 Fixed case of Teuchos parameter

### DIFF
--- a/packages/zoltan2/core/src/TpetraCrsColorer/Zoltan2_TpetraCrsColorer_Zoltan.hpp
+++ b/packages/zoltan2/core/src/TpetraCrsColorer/Zoltan2_TpetraCrsColorer_Zoltan.hpp
@@ -199,7 +199,7 @@ ZoltanCrsColorer<CrsMatrixType>::computeColoring(
                                                                       : true));
 
   // User request to use Zoltan's TRANSPOSE symmetrization, if needed
-  const bool symmetrize = coloring_params.get<bool>("Symmetrize", false);
+  const bool symmetrize = coloring_params.get<bool>("symmetrize", false);
 
   // Get MPI communicator, and throw an exception if our comm isn't MPI
   Teuchos::RCP<const Teuchos::Comm<int>> comm = 


### PR DESCRIPTION
@trilinos/zoltan2 
Fixed case of parameter.

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Sigh.  Teuchos parameters are still case sensitive, after all these years.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of   #8356 #8411 
* Composed of 


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Tested on mac with clang
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->