### PR TITLE
Zoltan2:  fix map used for transpose_graph in TpetraCrsColorer

### DIFF
--- a/packages/zoltan2/core/src/TpetraCrsColorer/Zoltan2_TpetraCrsColorerUtils.hpp
+++ b/packages/zoltan2/core/src/TpetraCrsColorer/Zoltan2_TpetraCrsColorerUtils.hpp
@@ -129,9 +129,20 @@ compute_transpose_graph(const Tpetra::CrsGraph<LO, GO, NO> &graph)
 
   // Build (possibly overlapped) transpose graph using original graph's
   // column map as the new row map, and vice versa
+  //
+  // Normally, for a transpose graph, we'd use
+  //     original matrix's RangeMap as the DomainMap, and
+  //     original matrix's DomainMap as the RangeMap.
+  // Moreover, we're not doing SpMV with the transpose graph, so
+  // you might think we wouldn't care about RangeMap and DomainMap.
+  // But we DO care, because exportAndFillCompleteCrsGraph uses the
+  // shared (overlapped) transpose matrix's RangeMap as the RowMap of the
+  // transpose matrix, while the Zoltan callbacks are assuming the
+  // transpose matrix's RowMap is the same as the original matrix's.
+  // So we'll use the original matrix's RowMap as the RangeMap.
   RCP<graph_t> trans_graph_shared = rcp(new graph_t(
                   local_trans_graph, graph.getColMap(), graph.getRowMap(),
-                  graph.getRangeMap(), graph.getDomainMap()));
+                  graph.getRangeMap(), graph.getRowMap()));
 
   RCP<graph_t> trans_graph;
 

--- a/packages/zoltan2/core/src/TpetraCrsColorer/Zoltan2_TpetraCrsColorer_Zoltan.hpp
+++ b/packages/zoltan2/core/src/TpetraCrsColorer/Zoltan2_TpetraCrsColorer_Zoltan.hpp
@@ -199,7 +199,7 @@ ZoltanCrsColorer<CrsMatrixType>::computeColoring(
                                                                       : true));
 
   // User request to use Zoltan's TRANSPOSE symmetrization, if needed
-  const bool symmetrize = coloring_params.get<bool>("Symmetrize", false);
+  const bool symmetrize = coloring_params.get<bool>("symmetrize", false);
 
   // Get MPI communicator, and throw an exception if our comm isn't MPI
   Teuchos::RCP<const Teuchos::Comm<int>> comm = 

--- a/packages/zoltan2/test/core/TpetraCrsColorer/TpetraCrsColorer.cpp
+++ b/packages/zoltan2/test/core/TpetraCrsColorer/TpetraCrsColorer.cpp
@@ -90,13 +90,6 @@ public:
     JCyclic = rcp(new matrix_t(JBlock->getLocalMatrix(),
                                JBlock->getRowMap(), JBlock->getColMap(),
                                vMapCyclic, wMapCyclic));
-
-//    Teuchos::FancyOStream foo(Teuchos::rcp(&std::cout,false));
-//    std::cout << "JBlock: " << std::endl;
-//    JBlock->describe(foo, Teuchos::VERB_EXTREME);
-
-//    std::cout << "JCyclic: " << std::endl;
-//    JCyclic->describe(foo, Teuchos::VERB_EXTREME);
   }
 
   ////////////////////////////////////////////////////////////////
@@ -110,7 +103,7 @@ public:
     ok = buildAndCheckSeedMatrix(testname, params, true);
 
     // test with cyclic maps
-    // ok &= buildAndCheckSeedMatrix(testname, params, false);
+    ok &= buildAndCheckSeedMatrix(testname, params, false);
 
     return ok;
   }


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/zoltan2 
#8356 #8411 #8416 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The TpetraCrsColorer should work with Domain and Range maps that are not the default Trilinos contiguous map.
This PR re-enables the tests that use cyclic Domain and Range maps.

This PR changes the Range map used by the transpose_graph when bipartite symmetrization is used.
Normally, for a transpose graph, we'd use
-  original matrix's RangeMap as the DomainMap, and
-  original matrix's DomainMap as the RangeMap.

Moreover, we're not doing SpMV with the transpose graph, so
you might think we wouldn't care about RangeMap and DomainMap.
But we DO care, because exportAndFillCompleteCrsGraph uses the
shared (overlapped) transpose matrix's RangeMap as the RowMap of the
transpose matrix, while the Zoltan callbacks are assuming the
transpose matrix's RowMap is the same as the original matrix's.
So this PR uses the original matrix's RowMap as the RangeMap.

Teuchos parameter 
-  symmetrize = true tells the Zoltan colorer to use Zoltan's TRANSPOSE symmetrization and distance-2 coloring; 
-  symmetrize = false tells Zoltan to use bipartite symmetrization and partial-distance-2 coloring.  

RIght now, the default is symmetrize=true.   Let me know if you want me to change the default, or eliminate this parameter all together.

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of  #8356 #8411 #8416 
* Composed of 



## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Tested on Mac with clang.
Re-enabled test cases using cyclic maps for Range and Domain maps.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->