### PR TITLE
amesos2: guard include file based on slu_dist version

### DIFF
--- a/packages/amesos2/src/Amesos2_Superludist_TypeMap.hpp
+++ b/packages/amesos2/src/Amesos2_Superludist_TypeMap.hpp
@@ -74,7 +74,10 @@ namespace SLUD {
 
 extern "C" {
 
+#if SUPERLU_DIST_MAJOR_VERSION > 4
+// SuperLU_Dist before major version 5 does not contain the config file
 #include "superlu_dist_config.h" // provides define for size 32 or 64 int_t
+#endif
 
   /// use the same function with name space in the macro
 #define USER_FREE(addr) SLUD::superlu_free_dist(addr)


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/amesos2

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Fixes compiler errors on systems using superlu_dist tpl major version 4

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Confirmed this resolves compilation errors on weaver testbed with devpacks loading superlu_dist v. 4.3

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->