### PR TITLE
Tpetra: Fix modify/sync issues in MultiVector and unit tests

### DIFF
--- a/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
@@ -842,7 +842,7 @@ namespace Tpetra {
     void
     replaceGlobalValue (const GlobalOrdinal gblRow,
                         const size_t col,
-                        const impl_scalar_type& value) const;
+                        const impl_scalar_type& value);
 
     /// \brief Like the above replaceGlobalValue, but only enabled if
     ///   T differs from impl_scalar_type.
@@ -880,7 +880,7 @@ namespace Tpetra {
     typename std::enable_if<! std::is_same<T, impl_scalar_type>::value && std::is_convertible<T, impl_scalar_type>::value, void>::type
     replaceGlobalValue (GlobalOrdinal globalRow,
                         size_t col,
-                        const T& value) const
+                        const T& value)
     {
       replaceGlobalValue (globalRow, col, static_cast<impl_scalar_type> (value));
     }
@@ -912,7 +912,7 @@ namespace Tpetra {
     sumIntoGlobalValue (const GlobalOrdinal gblRow,
                         const size_t col,
                         const impl_scalar_type& value,
-                        const bool atomic = useAtomicUpdatesByDefault) const;
+                        const bool atomic = useAtomicUpdatesByDefault);
 
     /// \brief Like the above sumIntoGlobalValue, but only enabled if
     ///   T differs from impl_scalar_type.
@@ -946,7 +946,7 @@ namespace Tpetra {
     sumIntoGlobalValue (const GlobalOrdinal gblRow,
                         const size_t col,
                         const T& val,
-                        const bool atomic = useAtomicUpdatesByDefault) const
+                        const bool atomic = useAtomicUpdatesByDefault)
     {
       sumIntoGlobalValue (gblRow, col, static_cast<impl_scalar_type> (val), atomic);
     }
@@ -982,7 +982,7 @@ namespace Tpetra {
     void
     replaceLocalValue (const LocalOrdinal lclRow,
                        const size_t col,
-                       const impl_scalar_type& value) const;
+                       const impl_scalar_type& value);
 
     /// \brief Like the above replaceLocalValue, but only enabled if
     ///   T differs from impl_scalar_type.
@@ -1020,7 +1020,7 @@ namespace Tpetra {
     typename std::enable_if<! std::is_same<T, impl_scalar_type>::value && std::is_convertible<T, impl_scalar_type>::value, void>::type
     replaceLocalValue (const LocalOrdinal lclRow,
                        const size_t col,
-                       const T& val) const
+                       const T& val)
     {
       replaceLocalValue (lclRow, col, static_cast<impl_scalar_type> (val));
     }
@@ -1052,7 +1052,7 @@ namespace Tpetra {
     sumIntoLocalValue (const LocalOrdinal lclRow,
                        const size_t col,
                        const impl_scalar_type& val,
-                       const bool atomic = useAtomicUpdatesByDefault) const;
+                       const bool atomic = useAtomicUpdatesByDefault);
 
     /// \brief Like the above sumIntoLocalValue, but only enabled if
     ///   T differs from impl_scalar_type.
@@ -1084,7 +1084,7 @@ namespace Tpetra {
     sumIntoLocalValue (const LocalOrdinal lclRow,
                        const size_t col,
                        const T& val,
-                       const bool atomic = useAtomicUpdatesByDefault) const
+                       const bool atomic = useAtomicUpdatesByDefault)
     {
       sumIntoLocalValue (lclRow, col, static_cast<impl_scalar_type> (val), atomic);
     }

--- a/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
@@ -823,8 +823,9 @@ namespace Tpetra {
     /// must access the device View directly by calling
     /// getLocalView().  Please see modify(), sync(), and the
     /// discussion of DualView semantics elsewhere in the
-    /// documentation.  You are responsible for calling modify() and
-    /// sync(), if needed; this method doesn't do that.
+    /// documentation.
+    /// This method calls sync_host() before modifying
+    /// host data, and modify_host() afterwards.
     ///
     /// This method does not have an "atomic" option like
     /// sumIntoGlobalValue.  This is deliberate.  Replacement is not
@@ -859,9 +860,9 @@ namespace Tpetra {
     /// and you want to modify the non-host version of the data, you
     /// must access the device View directly by calling getLocalView().
     /// Please see modify(), sync(), and the discussion of DualView
-    /// semantics elsewhere in the documentation.  You are responsible
-    /// for calling modify() and sync(), if needed; this method
-    /// doesn't do that.
+    /// semantics elsewhere in the documentation.
+    /// This method calls sync_host() before modifying
+    /// host data, and modify_host() afterwards.
     ///
     /// This method does not have an "atomic" option like
     /// sumIntoGlobalValue.  This is deliberate.  Replacement is not
@@ -897,8 +898,9 @@ namespace Tpetra {
     /// must access the device View directly by calling
     /// getLocalView().  Please see modify(), sync(), and the
     /// discussion of DualView semantics elsewhere in the
-    /// documentation.  You are responsible for calling modify() and
-    /// sync(), if needed; this method doesn't do that.
+    /// documentation.
+    /// This method calls sync_host() before modifying
+    /// host data, and modify_host() afterwards.
     ///
     /// \param gblRow [in] Global row index of the entry to modify.
     ///   This <i>must</i> be a valid global row index on the calling
@@ -930,8 +932,9 @@ namespace Tpetra {
     /// must access the device View directly by calling
     /// getLocalView().  Please see modify(), sync(), and the
     /// discussion of DualView semantics elsewhere in the
-    /// documentation.  You are responsible for calling modify() and
-    /// sync(), if needed; this method doesn't do that.
+    /// documentation.
+    /// This method calls sync_host() before modifying
+    /// host data, and modify_host() afterwards.
     ///
     /// \param gblRow [in] Global row index of the entry to modify.
     ///   This <i>must</i> be a valid global row index on the calling
@@ -963,8 +966,9 @@ namespace Tpetra {
     /// must access the device View directly by calling
     /// getLocalView().  Please see modify(), sync(), and the
     /// discussion of DualView semantics elsewhere in the
-    /// documentation.  You are responsible for calling modify() and
-    /// sync(), if needed; this method doesn't do that.
+    /// documentation.
+    /// This method calls sync_host() before modifying
+    /// host data, and modify_host() afterwards.
     ///
     /// This method does not have an "atomic" option like
     /// sumIntoLocalValue.  This is deliberate.  Replacement is not
@@ -1000,8 +1004,9 @@ namespace Tpetra {
     /// must access the device View directly by calling
     /// getLocalView().  Please see modify(), sync(), and the
     /// discussion of DualView semantics elsewhere in the
-    /// documentation.  You are responsible for calling modify() and
-    /// sync(), if needed; this method doesn't do that.
+    /// documentation.
+    /// This method calls sync_host() before modifying
+    /// host data, and modify_host() afterwards.
     ///
     /// This method does not have an "atomic" option like
     /// sumIntoLocalValue.  This is deliberate.  Replacement is not
@@ -1037,8 +1042,9 @@ namespace Tpetra {
     /// must access the device View directly by calling
     /// getLocalView().  Please see modify(), sync(), and the
     /// discussion of DualView semantics elsewhere in the
-    /// documentation.  You are responsible for calling modify() and
-    /// sync(), if needed; this method doesn't do that.
+    /// documentation.
+    /// This method calls sync_host() before modifying
+    /// host data, and modify_host() afterwards.
     ///
     /// \param lclRow [in] Local row index of the entry to modify.
     ///   Must be a valid local index in this MultiVector's Map on the
@@ -1070,8 +1076,9 @@ namespace Tpetra {
     /// must access the device View directly by calling
     /// getLocalView().  Please see modify(), sync(), and the
     /// discussion of DualView semantics elsewhere in the
-    /// documentation.  You are responsible for calling modify() and
-    /// sync(), if needed; this method doesn't do that.
+    /// documentation.
+    /// This method calls sync_host() before modifying
+    /// host data, and modify_host() afterwards.
     ///
     /// \param lclRow [in] Local row index of the entry to modify.
     /// \param col [in] Column index of the entry to modify.

--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -4159,8 +4159,11 @@ namespace Tpetra {
         << " of the multivector is invalid.");
     }
 
+    this->sync_host();
+
     const size_t colInd = isConstantStride () ? col : whichVectors_[col];
     view_.h_view (lclRow, colInd) = ScalarValue;
+    this->modify_host();
   }
 
 
@@ -4189,6 +4192,8 @@ namespace Tpetra {
         << " of the multivector is invalid.");
     }
 
+    this->sync_host();
+
     const size_t colInd = isConstantStride () ? col : whichVectors_[col];
     if (atomic) {
       Kokkos::atomic_add (& (view_.h_view(lclRow, colInd)), value);
@@ -4196,6 +4201,7 @@ namespace Tpetra {
     else {
       view_.h_view (lclRow, colInd) += value;
     }
+    this->modify_host();
   }
 
 

--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -4140,24 +4140,25 @@ namespace Tpetra {
   MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   replaceLocalValue (const LocalOrdinal lclRow,
                      const size_t col,
-                     const impl_scalar_type& ScalarValue) const
+                     const impl_scalar_type& ScalarValue)
   {
-#ifdef HAVE_TPETRA_DEBUG
-    const LocalOrdinal minLocalIndex = this->getMap()->getMinLocalIndex();
-    const LocalOrdinal maxLocalIndex = this->getMap()->getMaxLocalIndex();
-    TEUCHOS_TEST_FOR_EXCEPTION(
-      lclRow < minLocalIndex || lclRow > maxLocalIndex,
-      std::runtime_error,
-      "Tpetra::MultiVector::replaceLocalValue: row index " << lclRow
-      << " is invalid.  The range of valid row indices on this process "
-      << this->getMap()->getComm()->getRank() << " is [" << minLocalIndex
-      << ", " << maxLocalIndex << "].");
-    TEUCHOS_TEST_FOR_EXCEPTION(
-      vectorIndexOutOfRange(col),
-      std::runtime_error,
-      "Tpetra::MultiVector::replaceLocalValue: vector index " << col
-      << " of the multivector is invalid.");
-#endif
+    if (::Tpetra::Details::Behavior::debug()) {
+      const LocalOrdinal minLocalIndex = this->getMap()->getMinLocalIndex();
+      const LocalOrdinal maxLocalIndex = this->getMap()->getMaxLocalIndex();
+      TEUCHOS_TEST_FOR_EXCEPTION(
+        lclRow < minLocalIndex || lclRow > maxLocalIndex,
+        std::runtime_error,
+        "Tpetra::MultiVector::replaceLocalValue: row index " << lclRow
+        << " is invalid.  The range of valid row indices on this process "
+        << this->getMap()->getComm()->getRank() << " is [" << minLocalIndex
+        << ", " << maxLocalIndex << "].");
+      TEUCHOS_TEST_FOR_EXCEPTION(
+        vectorIndexOutOfRange(col),
+        std::runtime_error,
+        "Tpetra::MultiVector::replaceLocalValue: vector index " << col
+        << " of the multivector is invalid.");
+    }
+
     const size_t colInd = isConstantStride () ? col : whichVectors_[col];
     view_.h_view (lclRow, colInd) = ScalarValue;
   }
@@ -4169,24 +4170,25 @@ namespace Tpetra {
   sumIntoLocalValue (const LocalOrdinal lclRow,
                      const size_t col,
                      const impl_scalar_type& value,
-                     const bool atomic) const
+                     const bool atomic)
   {
-#ifdef HAVE_TPETRA_DEBUG
-    const LocalOrdinal minLocalIndex = this->getMap()->getMinLocalIndex();
-    const LocalOrdinal maxLocalIndex = this->getMap()->getMaxLocalIndex();
-    TEUCHOS_TEST_FOR_EXCEPTION(
-      lclRow < minLocalIndex || lclRow > maxLocalIndex,
-      std::runtime_error,
-      "Tpetra::MultiVector::sumIntoLocalValue: row index " << lclRow
-      << " is invalid.  The range of valid row indices on this process "
-      << this->getMap()->getComm()->getRank() << " is [" << minLocalIndex
-      << ", " << maxLocalIndex << "].");
-    TEUCHOS_TEST_FOR_EXCEPTION(
-      vectorIndexOutOfRange(col),
-      std::runtime_error,
-      "Tpetra::MultiVector::sumIntoLocalValue: vector index " << col
-      << " of the multivector is invalid.");
-#endif
+    if (::Tpetra::Details::Behavior::debug()) {
+      const LocalOrdinal minLocalIndex = this->getMap()->getMinLocalIndex();
+      const LocalOrdinal maxLocalIndex = this->getMap()->getMaxLocalIndex();
+      TEUCHOS_TEST_FOR_EXCEPTION(
+        lclRow < minLocalIndex || lclRow > maxLocalIndex,
+        std::runtime_error,
+        "Tpetra::MultiVector::sumIntoLocalValue: row index " << lclRow
+        << " is invalid.  The range of valid row indices on this process "
+        << this->getMap()->getComm()->getRank() << " is [" << minLocalIndex
+        << ", " << maxLocalIndex << "].");
+      TEUCHOS_TEST_FOR_EXCEPTION(
+        vectorIndexOutOfRange(col),
+        std::runtime_error,
+        "Tpetra::MultiVector::sumIntoLocalValue: vector index " << col
+        << " of the multivector is invalid.");
+    }
+
     const size_t colInd = isConstantStride () ? col : whichVectors_[col];
     if (atomic) {
       Kokkos::atomic_add (& (view_.h_view(lclRow, colInd)), value);
@@ -4202,22 +4204,24 @@ namespace Tpetra {
   MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   replaceGlobalValue (const GlobalOrdinal gblRow,
                       const size_t col,
-                      const impl_scalar_type& ScalarValue) const
+                      const impl_scalar_type& ScalarValue)
   {
     // mfh 23 Nov 2015: Use map_ and not getMap(), because the latter
     // touches the RCP's reference count, which isn't thread safe.
     const LocalOrdinal lclRow = this->map_->getLocalElement (gblRow);
-#ifdef HAVE_TPETRA_DEBUG
-    const char tfecfFuncName[] = "replaceGlobalValue: ";
-    TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-      (lclRow == Teuchos::OrdinalTraits<LocalOrdinal>::invalid (),
-       std::runtime_error,
-       "Global row index " << gblRow << " is not present on this process "
-       << this->getMap ()->getComm ()->getRank () << ".");
-    TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-      (this->vectorIndexOutOfRange (col), std::runtime_error,
-       "Vector index " << col << " of the MultiVector is invalid.");
-#endif // HAVE_TPETRA_DEBUG
+
+    if (::Tpetra::Details::Behavior::debug()) {
+      const char tfecfFuncName[] = "replaceGlobalValue: ";
+      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+        (lclRow == Teuchos::OrdinalTraits<LocalOrdinal>::invalid (),
+         std::runtime_error,
+         "Global row index " << gblRow << " is not present on this process "
+         << this->getMap ()->getComm ()->getRank () << ".");
+      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+        (this->vectorIndexOutOfRange (col), std::runtime_error,
+         "Vector index " << col << " of the MultiVector is invalid.");
+    }
+
     this->replaceLocalValue (lclRow, col, ScalarValue);
   }
 
@@ -4227,24 +4231,26 @@ namespace Tpetra {
   sumIntoGlobalValue (const GlobalOrdinal globalRow,
                       const size_t col,
                       const impl_scalar_type& value,
-                      const bool atomic) const
+                      const bool atomic)
   {
     // mfh 23 Nov 2015: Use map_ and not getMap(), because the latter
     // touches the RCP's reference count, which isn't thread safe.
     const LocalOrdinal lclRow = this->map_->getLocalElement (globalRow);
-#ifdef HAVE_TEUCHOS_DEBUG
-    TEUCHOS_TEST_FOR_EXCEPTION(
-      lclRow == Teuchos::OrdinalTraits<LocalOrdinal>::invalid (),
-      std::runtime_error,
-      "Tpetra::MultiVector::sumIntoGlobalValue: Global row index " << globalRow
-      << " is not present on this process "
-      << this->getMap ()->getComm ()->getRank () << ".");
-    TEUCHOS_TEST_FOR_EXCEPTION(
-      vectorIndexOutOfRange(col),
-      std::runtime_error,
-      "Tpetra::MultiVector::sumIntoGlobalValue: Vector index " << col
-      << " of the multivector is invalid.");
-#endif
+
+    if (::Tpetra::Details::Behavior::debug()) {
+      TEUCHOS_TEST_FOR_EXCEPTION(
+          lclRow == Teuchos::OrdinalTraits<LocalOrdinal>::invalid (),
+          std::runtime_error,
+          "Tpetra::MultiVector::sumIntoGlobalValue: Global row index " << globalRow
+          << " is not present on this process "
+          << this->getMap ()->getComm ()->getRank () << ".");
+      TEUCHOS_TEST_FOR_EXCEPTION(
+          vectorIndexOutOfRange(col),
+          std::runtime_error,
+          "Tpetra::MultiVector::sumIntoGlobalValue: Vector index " << col
+          << " of the multivector is invalid.");
+    }
+
     this->sumIntoLocalValue (lclRow, col, value, atomic);
   }
 

--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -2044,7 +2044,7 @@ namespace Tpetra {
   namespace { // (anonymous)
     template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
     typename MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::dot_type
-    multiVectorSingleColumnDot (MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& x,
+    multiVectorSingleColumnDot (const MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& x,
                                 const MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& y)
     {
       using ::Tpetra::Details::ProfilingRegion;
@@ -2070,14 +2070,9 @@ namespace Tpetra {
         dot_type gblDot = Kokkos::ArithTraits<dot_type>::zero ();
 
         // All non-unary kernels are executed on the device as per Tpetra policy.  Sync to device if needed.
-        if (x.need_sync_device ()) {
-          x.sync_device ();
-        }
-        if (y.need_sync_device ()) {
-          const_cast<MV&>(y).sync_device ();
-        }
+        const_cast<MV&>(x).sync_device ();
+        const_cast<MV&>(y).sync_device ();
 
-        x.modify_device ();
         auto x_2d = x.getLocalViewDevice ();
         auto x_1d = Kokkos::subview (x_2d, rowRng, 0);
         auto y_2d = y.getLocalViewDevice ();
@@ -2139,7 +2134,7 @@ namespace Tpetra {
        numDots << " != this->getNumVectors() = " << numVecs << ".");
 
     if (numVecs == 1 && this->isConstantStride () && A.isConstantStride ()) {
-      const dot_type gblDot = multiVectorSingleColumnDot (const_cast<MV&> (*this), A);
+      const dot_type gblDot = multiVectorSingleColumnDot (*this, A);
       dots[0] = gblDot;
     }
     else {

--- a/packages/tpetra/core/src/Tpetra_Vector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Vector_decl.hpp
@@ -262,7 +262,7 @@ public:
   //! Replace current value at the specified location with specified value.
   /** \pre \c globalRow must be a valid global element on this node, according to the row map.
    */
-  void replaceGlobalValue (const GlobalOrdinal globalRow, const Scalar& value) const;
+  void replaceGlobalValue (const GlobalOrdinal globalRow, const Scalar& value);
 
   /// \brief Add value to existing value, using global (row) index.
   ///
@@ -286,12 +286,12 @@ public:
   void
   sumIntoGlobalValue (const GlobalOrdinal globalRow,
                       const Scalar& value,
-                      const bool atomic = base_type::useAtomicUpdatesByDefault) const;
+                      const bool atomic = base_type::useAtomicUpdatesByDefault);
 
   //! Replace current value at the specified location with specified values.
   /** \pre \c localRow must be a valid local element on this node, according to the row map.
    */
-  void replaceLocalValue (const LocalOrdinal myRow, const Scalar& value) const;
+  void replaceLocalValue (const LocalOrdinal myRow, const Scalar& value);
 
   /// \brief Add \c value to existing value, using local (row) index.
   ///
@@ -313,7 +313,7 @@ public:
   void
   sumIntoLocalValue (const LocalOrdinal myRow,
                      const Scalar& value,
-                     const bool atomic = base_type::useAtomicUpdatesByDefault) const;
+                     const bool atomic = base_type::useAtomicUpdatesByDefault);
 
   //@}
 

--- a/packages/tpetra/core/src/Tpetra_Vector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Vector_def.hpp
@@ -118,7 +118,7 @@ namespace Tpetra {
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void
   Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-  replaceGlobalValue (const GlobalOrdinal globalRow, const Scalar& value) const {
+  replaceGlobalValue (const GlobalOrdinal globalRow, const Scalar& value) {
     this->base_type::replaceGlobalValue (globalRow, 0, value);
   }
 
@@ -127,7 +127,7 @@ namespace Tpetra {
   Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   sumIntoGlobalValue (const GlobalOrdinal globalRow,
                       const Scalar& value,
-                      const bool atomic) const
+                      const bool atomic)
   {
     this->base_type::sumIntoGlobalValue (globalRow, 0, value, atomic);
   }
@@ -135,7 +135,7 @@ namespace Tpetra {
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void
   Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-  replaceLocalValue (const LocalOrdinal myRow, const Scalar& value) const {
+  replaceLocalValue (const LocalOrdinal myRow, const Scalar& value) {
     this->base_type::replaceLocalValue (myRow, 0, value);
   }
 
@@ -144,7 +144,7 @@ namespace Tpetra {
   Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   sumIntoLocalValue (const LocalOrdinal globalRow,
                      const Scalar& value,
-                     const bool atomic) const
+                     const bool atomic)
   {
     this->base_type::sumIntoLocalValue (globalRow, 0, value, atomic);
   }

--- a/packages/tpetra/core/test/MultiVector/MultiVector_UnitTests.cpp
+++ b/packages/tpetra/core/test/MultiVector/MultiVector_UnitTests.cpp
@@ -2705,6 +2705,8 @@ namespace {
   ////
   TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( MultiVector, ScaleAndAssign, LO , GO , Scalar , Node )
   {
+    std::cerr << std::endl;
+
     typedef typename ScalarTraits<Scalar>::magnitudeType Mag;
     typedef Tpetra::MultiVector<Scalar,LO,GO,Node> MV;
     typedef Tpetra::Vector<Scalar,LO,GO,Node>       V;
@@ -2735,12 +2737,13 @@ namespace {
     // Also, ensure that other vectors aren't changed
 
     out << "Create A, and fill with random numbers" << endl;
-    MV A (map, numVectors, false);
-    A.randomize ();
+    MV A(map, numVectors, false);
+    A.randomize();
+    A.sync_host();
 
     out << "Stash away norms of columns of A" << endl;
     Array<Mag> Anrms(numVectors);
-    A.norm1 (Anrms ());
+    A.norm1(Anrms());
 
     out << "Test B := A*2, using different methods" << endl;
     // set B = A * 2, using different techniques
@@ -2769,8 +2772,8 @@ namespace {
             std::ostringstream os;
             os << ">>> Proc " << comm->getSize ();
             os << ": A.modified_host: " << (A.need_sync_device ()?1:0);
-            os  << ", A.modified_device: " << (A.need_sync_host ()?1:0);
-            os << ": B.modified_host: " << (B.need_sync_device ()?1:0);
+            os << ", A.modified_device: " << (A.need_sync_host ()?1:0);
+            os << ", B.modified_host: " << (B.need_sync_device ()?1:0);
             os << ", B.modified_device: " << (B.need_sync_host ()?1:0);
             os << std::endl;
             std::cerr << os.str ();

--- a/packages/tpetra/core/test/MultiVector/MultiVector_UnitTests.cpp
+++ b/packages/tpetra/core/test/MultiVector/MultiVector_UnitTests.cpp
@@ -1749,7 +1749,7 @@ namespace {
     mvec2.norm1(norms2());
     std::fill(ans.begin(), ans.end(), M0);
     TEST_COMPARE_FLOATING_ARRAYS(norms1,ans,M0);
-    TEST_COMPARE_FLOATING_ARRAYS(norms1,ans,M0);
+    TEST_COMPARE_FLOATING_ARRAYS(norms2,ans,M0);
     // replace local entries s.t.
     // mvec1 = [1 1]  and  mvec2 = [0 0]
     //         [0 0]               [1 1]


### PR DESCRIPTION
* Change behavior of replaceLocalValue/sumIntoLocalValue to call modify_host and sync_host internally, which feels safer for users.
* Remove a modify_device call inside multiVectorSingleColumnDot (since a dot product shouldn't change the values of the input vectors).
* Also fixes some const inconsistencies and updates some debug ifdefs to use the Behavior class instead.

@trilinos/tpetra 

## Related Issues

* Closes #8361 
* Related to #8209 

## Testing
MultiVector unit tests now passing in a non-UVM build on ascicgpu24.