### PR TITLE
TrilinosCouplings: Start a MueLu region multigrid driver

### DIFF
--- a/packages/trilinoscouplings/cmake/Dependencies.cmake
+++ b/packages/trilinoscouplings/cmake/Dependencies.cmake
@@ -1,7 +1,7 @@
 SET(LIB_REQUIRED_DEP_PACKAGES)
 SET(LIB_OPTIONAL_DEP_PACKAGES Amesos AztecOO Belos EpetraExt Ifpack Isorropia ML MueLu NOX Stokhos Zoltan)
 SET(TEST_REQUIRED_DEP_PACKAGES)
-SET(TEST_OPTIONAL_DEP_PACKAGES Amesos AvatarT AztecOO Epetra EpetraExt Ifpack Ifpack2 Intrepid Intrepid2 Isorropia KokkosContainers KokkosCore KokkosKernels ML MueLu MueLu Pamgen SEACASExodus SEACASNemesis Sacado STKIO STKMesh Stokhos Stratimikos Teko TeuchosKokkosComm TeuchosKokkosCompat Tpetra TriKota Zoltan)
+SET(TEST_OPTIONAL_DEP_PACKAGES Amesos AvatarT AztecOO Epetra EpetraExt Ifpack Ifpack2 Intrepid Intrepid2 Isorropia KokkosContainers KokkosCore KokkosKernels ML MueLu MueLu Pamgen Panzer Percept SEACASExodus SEACASNemesis Sacado STKIO STKMesh Stokhos Stratimikos Teko TeuchosKokkosComm TeuchosKokkosCompat Tpetra TriKota Zoltan)
 SET(LIB_REQUIRED_DEP_TPLS)
 SET(LIB_OPTIONAL_DEP_TPLS)
 SET(TEST_REQUIRED_DEP_TPLS)

--- a/packages/trilinoscouplings/examples/scaling/CMakeLists.txt
+++ b/packages/trilinoscouplings/examples/scaling/CMakeLists.txt
@@ -565,6 +565,7 @@ IF(${PACKAGE_NAME}_ENABLE_Belos AND
 
   TRIBITS_COPY_FILES_TO_BINARY_DIR(TestCopyMueLuRegionFiles
     SOURCE_FILES muelu_region_poisson_input.xml
+                 muelu_region_poisson_input_coarse.xml
                  unit_cube_10int_hex.exo
     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}
     DEST_DIR ${CMAKE_CURRENT_BINARY_DIR}

--- a/packages/trilinoscouplings/examples/scaling/CMakeLists.txt
+++ b/packages/trilinoscouplings/examples/scaling/CMakeLists.txt
@@ -548,14 +548,15 @@ ENDIF()
 
 # GBH Oct6 2020: No need to check  Xpetra_ENABLE_Experimental
 # since it is a required flag for MueLu_ENABLE_Experimental
-IF(${PACKAGE_NAME}_ENABLE_Belos AND 
-   ${PACKAGE_NAME}_ENABLE_Intrepid AND 
-   ${PACKAGE_NAME}_ENABLE_MueLu AND 
-   MueLu_ENABLE_Experimental AND 
-   MueLu_ENABLE_Kokkos_Refactor AND 
-   ${PACKAGE_NAME}_ENABLE_Pamgen AND 
-   ${PACKAGE_NAME}_ENABLE_STKIO AND 
-   ${PACKAGE_NAME}_ENABLE_STKMesh AND 
+IF(${PACKAGE_NAME}_ENABLE_Belos AND
+   ${PACKAGE_NAME}_ENABLE_Intrepid AND
+   ${PACKAGE_NAME}_ENABLE_MueLu AND
+   MueLu_ENABLE_Experimental AND
+   MueLu_ENABLE_Kokkos_Refactor AND
+   ${PACKAGE_NAME}_ENABLE_Pamgen AND
+   ${PACKAGE_NAME}_ENABLE_Percept AND
+   ${PACKAGE_NAME}_ENABLE_STKIO AND
+   ${PACKAGE_NAME}_ENABLE_STKMesh AND
    ${PACKAGE_NAME}_ENABLE_Tpetra)
   TRIBITS_ADD_EXECUTABLE(
     MueLu_Region_Poisson

--- a/packages/trilinoscouplings/examples/scaling/CMakeLists.txt
+++ b/packages/trilinoscouplings/examples/scaling/CMakeLists.txt
@@ -544,3 +544,30 @@ IF (${PACKAGE_NAME}_ENABLE_Pamgen AND
 
 
 ENDIF()
+
+
+# GBH Oct6 2020: No need to check  Xpetra_ENABLE_Experimental
+# since it is a required flag for MueLu_ENABLE_Experimental
+IF(${PACKAGE_NAME}_ENABLE_Belos AND 
+   ${PACKAGE_NAME}_ENABLE_Intrepid AND 
+   ${PACKAGE_NAME}_ENABLE_MueLu AND 
+   MueLu_ENABLE_Experimental AND 
+   MueLu_ENABLE_Kokkos_Refactor AND 
+   ${PACKAGE_NAME}_ENABLE_Pamgen AND 
+   ${PACKAGE_NAME}_ENABLE_STKIO AND 
+   ${PACKAGE_NAME}_ENABLE_STKMesh AND 
+   ${PACKAGE_NAME}_ENABLE_Tpetra)
+  TRIBITS_ADD_EXECUTABLE(
+    MueLu_Region_Poisson
+    SOURCES muelu_region_poisson.cpp
+    COMM serial mpi
+    )
+
+  TRIBITS_COPY_FILES_TO_BINARY_DIR(TestCopyMueLuRegionFiles
+    SOURCE_FILES muelu_region_poisson_input.xml
+                 unit_cube_10int_hex.exo
+    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}
+    DEST_DIR ${CMAKE_CURRENT_BINARY_DIR}
+    )
+
+ENDIF()

--- a/packages/trilinoscouplings/examples/scaling/CMakeLists.txt
+++ b/packages/trilinoscouplings/examples/scaling/CMakeLists.txt
@@ -567,6 +567,7 @@ IF(${PACKAGE_NAME}_ENABLE_Belos AND
   TRIBITS_COPY_FILES_TO_BINARY_DIR(TestCopyMueLuRegionFiles
     SOURCE_FILES muelu_region_poisson_input.xml
                  muelu_region_poisson_input_coarse.xml
+                 muelu_region_poisson_1.gen
                  unit_cube_10int_hex.exo
     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}
     DEST_DIR ${CMAKE_CURRENT_BINARY_DIR}

--- a/packages/trilinoscouplings/examples/scaling/muelu_region_poisson.cpp
+++ b/packages/trilinoscouplings/examples/scaling/muelu_region_poisson.cpp
@@ -74,6 +74,95 @@
 #include "Tpetra_Import.hpp"
 #include "MatrixMarket_Tpetra.hpp"
 
+/////////////////////////////////////////////////////////////////////////
+// Headers copied from MueLu driver
+#include <cstdio>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <unistd.h>
+
+// Teuchos
+#include <Teuchos_XMLParameterListHelpers.hpp>
+#include <Teuchos_YamlParameterListHelpers.hpp>
+#include <Teuchos_StandardCatchMacros.hpp>
+
+// Xpetra
+#include <Xpetra_MultiVectorFactory.hpp>
+#include <Xpetra_ImportFactory.hpp>
+#include <Xpetra_Operator.hpp>
+#include <Xpetra_Map.hpp>
+#include <Xpetra_MultiVector.hpp>
+#include <Xpetra_IO.hpp>
+
+// Galeri
+#include <Galeri_XpetraParameters.hpp>
+#include <Galeri_XpetraProblemFactory.hpp>
+#include <Galeri_XpetraUtils.hpp>
+#include <Galeri_XpetraMaps.hpp>
+
+// MueLu
+#include <MueLu.hpp>
+
+#include <MueLu_BaseClass.hpp>
+#ifdef HAVE_MUELU_EXPLICIT_INSTANTIATION
+#include <MueLu_ExplicitInstantiation.hpp>
+#endif
+#include <MueLu_Level.hpp>
+#include <MueLu_MutuallyExclusiveTime.hpp>
+#include <MueLu_ParameterListInterpreter.hpp>
+#include <MueLu_Utilities.hpp>
+
+// Belos
+#ifdef HAVE_MUELU_BELOS
+#include <BelosConfigDefs.hpp>
+#include <BelosBiCGStabSolMgr.hpp>
+#include <BelosBlockCGSolMgr.hpp>
+#include <BelosBlockGmresSolMgr.hpp>
+#include <BelosLinearProblem.hpp>
+#include <BelosPseudoBlockCGSolMgr.hpp>
+#include <BelosXpetraAdapter.hpp>     // => This header defines Belos::XpetraOp
+#include <BelosMueLuAdapter.hpp>      // => This header defines Belos::MueLuOp
+#ifdef HAVE_MUELU_TPETRA
+#include <BelosTpetraAdapter.hpp>    // => This header defines Belos::TpetraOp
+#endif
+#endif
+
+
+#ifdef HAVE_MUELU_CUDA
+#include "cuda_profiler_api.h"
+#endif
+
+// MueLu and Xpetra Tpetra stack
+#ifdef HAVE_MUELU_TPETRA
+#include <MueLu_TpetraOperator.hpp>
+#include <MueLu_CreateTpetraPreconditioner.hpp>
+#include <Xpetra_TpetraOperator.hpp>
+#include "Xpetra_TpetraMultiVector.hpp"
+#include <KokkosBlas1_abs.hpp>
+#include <Tpetra_leftAndOrRightScaleCrsMatrix.hpp>
+#include <Tpetra_computeRowAndColumnOneNorms.hpp>
+#endif
+
+// Xpetra Epetra stack
+#ifdef HAVE_MUELU_EPETRA
+#include "Xpetra_EpetraMultiVector.hpp"
+#endif
+
+#include <MueLu_CreateXpetraPreconditioner.hpp>
+
+#if defined(HAVE_MUELU_TPETRA) && defined(HAVE_MUELU_AMESOS2)
+#include <Amesos2_config.h>
+#include <Amesos2.hpp>
+#endif
+
+// Region MG headers
+#include "SetupRegionUtilities.hpp"
+#include "SetupRegionVector_def.hpp"
+#include "SetupRegionMatrix_def.hpp"
+#include "SetupRegionHierarchy_def.hpp"
+/////////////////////////////////////////////////////////////////////////
+
 // Include factories for boundary conditions and other Panzer setup
 // Most of which is taken from PoissonExample in Panzer_STK
 #include "muelu_region_poisson.hpp"
@@ -100,7 +189,7 @@ int main(int argc, char *argv[]) {
     // Setup output stream, MPI, and grab info
     Teuchos::RCP<Teuchos::FancyOStream> out = Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
 
-    // GH: comb back through everything and make sure I'm using my MPI comms properly when necessary
+    // TODO: comb back through everything and make sure I'm using MPI comms properly when necessary
     Teuchos::GlobalMPISession mpiSession(&argc, &argv,0);
     Teuchos::RCP<const Teuchos::MpiComm<int> > comm = Teuchos::rcp(new Teuchos::MpiComm<int>(MPI_COMM_WORLD));
 
@@ -210,20 +299,25 @@ int main(int argc, char *argv[]) {
     // setup the physics block
     Teuchos::RCP<Example::EquationSetFactory> eqset_factory = Teuchos::rcp(new Example::EquationSetFactory);
     Example::BCStrategyFactory bc_factory;
-    const std::size_t workset_size = 10;
+    const std::size_t workset_size = 10; // TODO: this may be much larger in practice. experiment with it.
     const int discretization_order = 1;
 
+    // grab the number and names of mesh blocks
+    std::vector<std::string> eBlocks;
+    mesh->getElementBlockNames(eBlocks);
+    std::vector<bool> unstructured_eBlocks(eBlocks.size(), false);
+    // TODO: set unstructured blocks based on some sort of input information
+
+    // grab the number and names of sidesets
+    std::vector<std::string> sidesets;
+    mesh->getSidesetNames(sidesets);
+
+    // create a physics blocks parameter list
     Teuchos::RCP<Teuchos::ParameterList> ipb = Teuchos::parameterList("Physics Blocks");
     std::vector<panzer::BC> bcs;
     std::vector<Teuchos::RCP<panzer::PhysicsBlock> > physicsBlocks;
 
-    std::vector<std::string> eBlocks;
-    mesh->getElementBlockNames(eBlocks);
-
-    std::vector<std::string> sidesets;
-    mesh->getSidesetNames(sidesets);
-
-    // set physics and boundary conditions
+    // set physics and boundary conditions on each block
     {
       bool build_transient_support = false;
 
@@ -235,8 +329,8 @@ int main(int argc, char *argv[]) {
       p.set("Basis Order",discretization_order);
       p.set("Integration Order",integration_order);
 
-      // GH: double-check. this assumes we impose Dirichlet BCs on all boundaries of all physics blocks
-      // which may potentially assign Dirichlet BCs to internal block boundaries, which is undesirable
+      // TODO: double-check. this assumes we impose Dirichlet BCs on all boundaries of all physics blocks
+      // It may potentially assign Dirichlet BCs to internal block boundaries, which is undesirable
       for(size_t i=0; i<eBlocks.size(); ++i)
       {
         for(size_t j=0; j<sidesets.size(); ++j)
@@ -248,7 +342,7 @@ int main(int argc, char *argv[]) {
           std::string dof_name = "TEMPERATURE";
           std::string strategy = "Constant";
           double value = 0.0;
-          Teuchos::ParameterList p;
+	  //          Teuchos::ParameterList p; // TODO: why is this here?
           p.set("Value",value);
           panzer::BC bc(bc_id, bctype, sideset_id, element_block_id, dof_name,
                         strategy, p);
@@ -414,13 +508,7 @@ int main(int argc, char *argv[]) {
                   std::cout << "Stk Node = " << node << std::endl;
 
 
-                //std::cout << "node " << node << std::endl;
-                //        double *f_data = refinedMesh->field_data(field, node, null_u);
-                //        for (int i_stride=0; i_stride < refinedMesh->get_spatial_dim(); i_stride++)
-                //        {
-                //        std::cout << f_data[i_stride] << " ";
-                //      }
-                //          std::cout << std::endl;
+
               }
             }
             else
@@ -443,7 +531,7 @@ int main(int argc, char *argv[]) {
     panzer_stk::workset_utils::getIdsAndVertices(*mesh,eBlocks[0],localIds,vertices);
     //mesh->getElementVertices(elements,0,vertices);
 
-    if(dump_element_vertices)
+    if(dump_element_vertices && myRank == 0)
     {
       for(unsigned int ielem=0; ielem<vertices.extent(0); ++ielem)
         for(unsigned int ivert=0; ivert<vertices.extent(1); ++ivert)
@@ -457,13 +545,16 @@ int main(int argc, char *argv[]) {
 
 
 
-    if(print_debug_info)
+    if(print_debug_info && myRank == 0)
     {
       for(unsigned int i=0; i<child_element_gids.size(); ++i)
       {
         std::cout << "child= " << child_element_gids[i] << " parent= " << child_element_region_gids[i] << std::endl;
       }
     }
+
+    if(myRank == 0)
+      perceptrenumbertest(mesh_refinements);
 
     // next we need to get the LIDs
 
@@ -486,7 +577,7 @@ int main(int argc, char *argv[]) {
 
       errorResponseLibrary->addResponse("L2 Error",eBlocks,builder);
 
-      // GH: comment out H1 errors for now while I work on other aspects
+      // TODO: uncomment the H1 errors once things look correct in the L2 norm
       /*
       builder.comm = MPI_COMM_WORLD;
       builder.cubatureDegree = integration_order;
@@ -515,7 +606,7 @@ int main(int argc, char *argv[]) {
       closure_models.sublist("solid").sublist("TEMPERATURE_L2_ERROR").set<std::string>("Field A","TEMPERATURE");
       closure_models.sublist("solid").sublist("TEMPERATURE_L2_ERROR").set<std::string>("Field B","TEMPERATURE_EXACT");
 
-      // GH: comment out H1 errors for now while I work on other aspects
+      // TODO: uncomment the H1 errors once things look correct in the L2 norm
       /*
       closure_models.sublist("solid").sublist("TEMPERATURE_H1_ERROR").set<std::string>("Type","H1 ERROR_CALC");
       closure_models.sublist("solid").sublist("TEMPERATURE_H1_ERROR").set<std::string>("Field A","TEMPERATURE");
@@ -530,13 +621,11 @@ int main(int argc, char *argv[]) {
     // setup field manager builder
     /////////////////////////////////////////////////////////////
 
-    Teuchos::RCP<panzer::FieldManagerBuilder> fmb
-    = Teuchos::rcp(new panzer::FieldManagerBuilder);
+    Teuchos::RCP<panzer::FieldManagerBuilder> fmb = Teuchos::rcp(new panzer::FieldManagerBuilder);
     fmb->setWorksetContainer(wkstContainer);
     fmb->setupVolumeFieldManagers(physicsBlocks,cm_factory,closure_models,*linObjFactory,user_data);
     fmb->setupBCFieldManagers(bcs,physicsBlocks,*eqset_factory,cm_factory,bc_factory,closure_models,
                               *linObjFactory,user_data);
-
     fmb->writeVolumeGraphvizDependencyFiles("Poisson", physicsBlocks);
 
 
@@ -580,6 +669,781 @@ int main(int argc, char *argv[]) {
     // evaluate physics: This does both the Jacobian and residual at once
     ae_tm.getAsObject<panzer::Traits::Jacobian>()->evaluate(input);
 
+
+
+    /**********************************************************************************/
+    /************************************ REGION DRIVER *******************************/
+    /**********************************************************************************/
+    {
+#include <MueLu_UseShortNames.hpp>
+      using Teuchos::RCP;
+      using Teuchos::rcp;
+      using Teuchos::ArrayRCP;
+      using Teuchos::TimeMonitor;
+      using Teuchos::ParameterList;
+
+      // =========================================================================
+      // MPI initialization using Teuchos
+      // =========================================================================
+      RCP<const Teuchos::Comm<int> > comm = Teuchos::DefaultComm<int>::getComm();
+      // const int numRanks = comm->getSize();
+      const int myRank   = comm->getRank();
+
+      // =========================================================================
+      // Convenient definitions
+      // =========================================================================
+      using STS = Teuchos::ScalarTraits<SC>;
+      SC zero = STS::zero(), one = STS::one();
+      using magnitude_type = typename Teuchos::ScalarTraits<Scalar>::magnitudeType;
+      using real_type = typename STS::coordinateType;
+      using RealValuedMultiVector = Xpetra::MultiVector<real_type,LO,GO,NO>;
+
+      // =========================================================================
+      // Parameters initialization
+      // =========================================================================
+      GO nx = 10, ny = 10, nz = 10;
+      Galeri::Xpetra::Parameters<GO> galeriParameters(clp, nx, ny, nz, "Laplace2D"); // manage parameters of the test case
+      Xpetra::Parameters             xpetraParameters(clp);                          // manage parameters of Xpetra
+
+      std::string xmlFileName           = "";                  clp.setOption("xml",                   &xmlFileName,           "read parameters from an xml file");
+      std::string yamlFileName          = "";                  clp.setOption("yaml",                  &yamlFileName,          "read parameters from a yaml file");
+      std::string convergenceLog        = "residual_norm.txt"; clp.setOption("convergence-log",       &convergenceLog,        "file in which the convergence history of the linear solver is stored");
+      int         maxIts                = 200;                 clp.setOption("its",                   &maxIts,                "maximum number of solver iterations");
+      std::string smootherType          = "Jacobi";            clp.setOption("smootherType",          &smootherType,          "smoother to be used: (None | Jacobi | Gauss | Chebyshev)");
+      int         smootherIts           = 2;                   clp.setOption("smootherIts",           &smootherIts,           "number of smoother iterations");
+      double      smootherDamp          = 0.67;                clp.setOption("smootherDamp",          &smootherDamp,          "damping parameter for the level smoother");
+      double      smootherChebyEigRatio = 2.0;                 clp.setOption("smootherChebyEigRatio", &smootherChebyEigRatio, "eigenvalue ratio max/min used to approximate the smallest eigenvalue for Chebyshev relaxation");
+      double      smootherChebyBoostFactor = 1.1;              clp.setOption("smootherChebyBoostFactor", &smootherChebyBoostFactor, "boost factor for Chebyshev smoother");
+      double      tol                   = 1e-12;               clp.setOption("tol",                   &tol,                   "solver convergence tolerance");
+      bool        scaleResidualHist     = true;                clp.setOption("scale", "noscale",      &scaleResidualHist,     "scaled Krylov residual history");
+      bool        serialRandom          = false;               clp.setOption("use-serial-random", "no-use-serial-random", &serialRandom, "generate the random vector serially and then broadcast it");
+      bool        keepCoarseCoords      = false;               clp.setOption("keep-coarse-coords", "no-keep-coarse-coords", &keepCoarseCoords, "keep coordinates on coarsest level of region hierarchy");
+      bool        coarseSolverRebalance = false;               clp.setOption("rebalance-coarse", "no-rebalance-coarse", &coarseSolverRebalance, "rebalance before AMG coarse grid solve");
+      int         rebalanceNumPartitions = -1;                   clp.setOption("numPartitions",         &rebalanceNumPartitions, "number of partitions for rebalancing the coarse grid AMG solve");
+      std::string coarseSolverType      = "direct";            clp.setOption("coarseSolverType",      &coarseSolverType,      "Type of solver for (composite) coarse level operator (smoother | direct | amg)");
+      std::string unstructured          = "{}";                clp.setOption("unstructured",          &unstructured,          "List of ranks to be treated as unstructured, e.g. {0, 2, 5}");
+      std::string coarseAmgXmlFile      = "";                  clp.setOption("coarseAmgXml",          &coarseAmgXmlFile,      "Read parameters for AMG as coarse level solve from this xml file.");
+      std::string coarseSmootherXMLFile = "";                  clp.setOption("coarseSmootherXML",     &coarseSmootherXMLFile, "File containing the parameters to use with the coarse level smoother.");
+#ifdef HAVE_MUELU_TPETRA
+      std::string equilibrate = "no" ;                         clp.setOption("equilibrate",           &equilibrate,           "equilibrate the system (no | diag | 1-norm)");
+#endif
+#ifdef HAVE_MUELU_CUDA
+      bool profileSetup = false;                               clp.setOption("cuda-profile-setup", "no-cuda-profile-setup", &profileSetup, "enable CUDA profiling for setup");
+      bool profileSolve = false;                               clp.setOption("cuda-profile-solve", "no-cuda-profile-solve", &profileSolve, "enable CUDA profiling for solve");
+#endif
+      int  cacheSize = 0;                                      clp.setOption("cachesize",               &cacheSize,           "cache size (in KB)");
+      bool useStackedTimer   = false;                          clp.setOption("stacked-timer","no-stacked-timer", &useStackedTimer, "use stacked timer");
+      bool showTimerSummary = true;                            clp.setOption("show-timer-summary", "no-show-timer-summary", &showTimerSummary, "Switch on/off the timer summary at the end of the run.");
+      std::string cycleType = "V";                             clp.setOption("cycleType", &cycleType, "{Multigrid cycle type. Possible values: V, W.");
+
+      clp.recogniseAllOptions(true);
+      switch (clp.parse(argc, argv)) {
+        case Teuchos::CommandLineProcessor::PARSE_HELP_PRINTED:        return EXIT_SUCCESS;
+        case Teuchos::CommandLineProcessor::PARSE_ERROR:
+        case Teuchos::CommandLineProcessor::PARSE_UNRECOGNIZED_OPTION: return EXIT_FAILURE;
+        case Teuchos::CommandLineProcessor::PARSE_SUCCESSFUL:          break;
+      }
+
+      TEUCHOS_TEST_FOR_EXCEPTION(xmlFileName != "" && yamlFileName != "", std::runtime_error,
+                                 "Cannot provide both xml and yaml input files");
+
+      // Instead of checking each time for rank, create a rank 0 stream
+      RCP<Teuchos::FancyOStream> fancy = Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
+      Teuchos::FancyOStream& out = *fancy;
+      out.setOutputToRootOnly(0);
+
+      ParameterList paramList;
+      auto inst = xpetraParameters.GetInstantiation();
+
+      if (yamlFileName != "") {
+        Teuchos::updateParametersFromYamlFileAndBroadcast(yamlFileName, Teuchos::Ptr<ParameterList>(&paramList), *comm);
+      } else {
+        if (inst == Xpetra::COMPLEX_INT_INT)
+          xmlFileName = (xmlFileName != "" ? xmlFileName : "structured_1dof-complex.xml");
+        else
+          xmlFileName = (xmlFileName != "" ? xmlFileName : "structured_1dof.xml");
+        Teuchos::updateParametersFromXmlFileAndBroadcast(xmlFileName, Teuchos::Ptr<ParameterList>(&paramList), *comm);
+      }
+
+      Array<RCP<Teuchos::ParameterList> > smootherParams(1); //TODO: this is good, resized to numlevel
+      smootherParams[0] = rcp(new Teuchos::ParameterList());
+      smootherParams[0]->set("smoother: type",    smootherType);
+      smootherParams[0]->set("smoother: sweeps",  smootherIts);
+      smootherParams[0]->set("smoother: damping", smootherDamp);
+      smootherParams[0]->set("smoother: Chebyshev eigRatio", smootherChebyEigRatio);
+      smootherParams[0]->set("smoother: Chebyshev boost factor", smootherChebyBoostFactor);
+
+      bool useUnstructured = false;
+      Array<LO> unstructuredRanks = Teuchos::fromStringToArray<LO>(unstructured);
+      for(int idx = 0; idx < unstructuredRanks.size(); ++idx) {
+        if(unstructuredRanks[idx] == myRank) {useUnstructured = true;}
+      }
+
+      // Retrieve matrix parameters (they may have been changed on the command line)
+      // [for instance, if we changed matrix type from 2D to 3D we need to update nz]
+      ParameterList galeriList = galeriParameters.GetParameterList();
+
+      // =========================================================================
+      // Problem construction
+      // =========================================================================
+      std::ostringstream galeriStream;
+#ifdef HAVE_MUELU_OPENMP
+      std::string node_name = Node::name();
+      if(!comm->getRank() && !node_name.compare("OpenMP/Wrapper"))
+        galeriStream<<"OpenMP Max Threads = "<<omp_get_max_threads()<<std::endl;
+#endif
+
+
+      comm->barrier();
+      Teuchos::RCP<Teuchos::StackedTimer> stacked_timer;
+      if(useStackedTimer)
+        stacked_timer = rcp(new Teuchos::StackedTimer("MueLu_Driver"));
+      Teuchos::TimeMonitor::setStackedTimer(stacked_timer);
+      RCP<TimeMonitor> globalTimeMonitor = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("Driver: S - Global Time")));
+      RCP<TimeMonitor> tm                = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("Driver: 1 - Build Composite Matrix")));
+
+
+      RCP<Matrix> A;
+      RCP<Map>    nodeMap, dofMap;
+      RCP<Vector> X, B;
+      RCP<MultiVector>           nullspace;
+      RCP<RealValuedMultiVector> coordinates;
+
+      galeriStream << "========================================================\n" << xpetraParameters << galeriParameters;
+
+      // Galeri will attempt to create a square-as-possible distribution of subdomains di, e.g.,
+      //                                 d1  d2  d3
+      //                                 d4  d5  d6
+      //                                 d7  d8  d9
+      //                                 d10 d11 d12
+      // A perfect distribution is only possible when the #processors is a perfect square.
+      // This *will* result in "strip" distribution if the #processors is a prime number or if the factors are very different in
+      // size. For example, np=14 will give a 7-by-2 distribution.
+      // If you don't want Galeri to do this, specify mx or my on the galeriList.
+      std::string matrixType = galeriParameters.GetMatrixType();
+      int numDimensions  = 0;
+      int numDofsPerNode = 0;
+      Teuchos::Array<GO> procsPerDim(3);
+      Teuchos::Array<GO> gNodesPerDim(3);
+      Teuchos::Array<LO> lNodesPerDim(3);
+
+      // Create map and coordinates
+      // In the future, we hope to be able to first create a Galeri problem, and then request map and coordinates from it
+      // At the moment, however, things are fragile as we hope that the Problem uses same map and coordinates inside
+      if (matrixType == "Laplace1D") {
+        numDimensions = 1;
+        nodeMap = Galeri::Xpetra::CreateMap<LO, GO, Node>(xpetraParameters.GetLib(), "Cartesian1D", comm, galeriList);
+        coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<double,LO,GO,Map,RealValuedMultiVector>("1D", nodeMap, galeriList);
+
+      } else if (matrixType == "Laplace2D" || matrixType == "Star2D" ||
+          matrixType == "BigStar2D" || matrixType == "Elasticity2D") {
+        numDimensions = 2;
+        nodeMap = Galeri::Xpetra::CreateMap<LO, GO, Node>(xpetraParameters.GetLib(), "Cartesian2D", comm, galeriList);
+        coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<double,LO,GO,Map,RealValuedMultiVector>("2D", nodeMap, galeriList);
+
+      } else if (matrixType == "Laplace3D" || matrixType == "Brick3D" || matrixType == "Elasticity3D") {
+        numDimensions = 3;
+        nodeMap = Galeri::Xpetra::CreateMap<LO, GO, Node>(xpetraParameters.GetLib(), "Cartesian3D", comm, galeriList);
+        coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<double,LO,GO,Map,RealValuedMultiVector>("3D", nodeMap, galeriList);
+      }
+
+      // Expand map to do multiple DOF per node for block problems
+      if (matrixType == "Elasticity2D") {
+        numDofsPerNode = 2;
+      } else if (matrixType == "Elasticity3D") {
+        numDofsPerNode = 3;
+      } else {
+        numDofsPerNode = 1;
+      }
+      dofMap = Xpetra::MapFactory<LO,GO,Node>::Build(nodeMap, numDofsPerNode);
+
+      galeriStream << "Processor subdomains in x direction: " << galeriList.get<GO>("mx") << std::endl
+          << "Processor subdomains in y direction: " << galeriList.get<GO>("my") << std::endl
+          << "Processor subdomains in z direction: " << galeriList.get<GO>("mz") << std::endl
+          << "========================================================" << std::endl;
+
+      if (matrixType == "Elasticity2D" || matrixType == "Elasticity3D") {
+        // Our default test case for elasticity: all boundaries of a square/cube have Neumann b.c. except left which has Dirichlet
+        galeriList.set("right boundary" , "Neumann");
+        galeriList.set("bottom boundary", "Neumann");
+        galeriList.set("top boundary"   , "Neumann");
+        galeriList.set("front boundary" , "Neumann");
+        galeriList.set("back boundary"  , "Neumann");
+      }
+
+      RCP<Galeri::Xpetra::Problem<Map,CrsMatrixWrap,MultiVector> > Pr =
+          Galeri::Xpetra::BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>(galeriParameters.GetMatrixType(), dofMap, galeriList);
+      A = Pr->BuildMatrix();
+
+      A->SetFixedBlockSize(numDofsPerNode);
+
+      nullspace = Pr->BuildNullspace();
+
+      X = VectorFactory::Build(dofMap);
+      B = VectorFactory::Build(dofMap);
+
+      if(serialRandom) {
+        //Build the seed on rank zero and broadcast it.
+        size_t localNumElements = 0;
+        if(comm->getRank() == 0) {
+          localNumElements = static_cast<size_t>(dofMap->getGlobalNumElements());
+        }
+        RCP<Map> serialMap = MapFactory::Build(dofMap->lib(),
+                                               dofMap->getGlobalNumElements(),
+                                               localNumElements,
+                                               0,
+                                               comm);
+        RCP<Vector> Xserial = VectorFactory::Build(serialMap);
+        Xserial->setSeed(251743369);
+        Xserial->randomize();
+        RCP<Import> randomnessImporter = ImportFactory::Build(serialMap, dofMap);
+        X->doImport(*Xserial, *randomnessImporter, Xpetra::INSERT);
+      } else {
+        // we set seed for reproducibility
+        Utilities::SetRandomSeed(*comm);
+        X->randomize();
+      }
+      A->apply(*X, *B, Teuchos::NO_TRANS, one, zero);
+
+      Teuchos::Array<typename STS::magnitudeType> norms(1);
+      B->norm2(norms);
+      B->scale(one/norms[0]);
+      galeriStream << "Galeri complete.\n========================================================" << std::endl;
+
+#ifdef MATLAB_COMPARE
+      Xpetra::IO<Scalar,LocalOrdinal,GlobalOrdinal,Node>::Write("Ax.mm",*B);
+      Xpetra::IO<Scalar,LocalOrdinal,GlobalOrdinal,Node>::Write("A.mm",*A);
+      B->putScalar(zero);
+      Xpetra::IO<Scalar,LocalOrdinal,GlobalOrdinal,Node>::Write("rhs.mm",*B);
+      Xpetra::IO<Scalar,LocalOrdinal,GlobalOrdinal,Node>::Write("x.mm",*X);
+#endif
+      out << galeriStream.str();
+
+      comm->barrier();
+      tm = Teuchos::null;
+
+      tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("Driver: 2 - Compute region data")));
+
+      // Set aggregation type for each region
+      std::string aggregationRegionType;
+      RCP<ParameterList> interfaceParams = rcp(new ParameterList());
+      if(useUnstructured) {
+        aggregationRegionType = "uncoupled";
+      } else {
+        aggregationRegionType = "structured";
+      }
+
+      // Loading geometric info from galeri
+      if(numDimensions == 1) {
+        gNodesPerDim[0] = galeriList.get<GO>("nx");
+        gNodesPerDim[1] = 1;
+        gNodesPerDim[2] = 1;
+
+        lNodesPerDim[0] = galeriList.get<LO>("lnx");
+        lNodesPerDim[1] = 1;
+        lNodesPerDim[2] = 1;
+
+        procsPerDim[0] = galeriList.get<GO>("mx");
+        procsPerDim[1] = 1;
+        procsPerDim[2] = 1;
+      } else if(numDimensions == 2) {
+        gNodesPerDim[0] = galeriList.get<GO>("nx");
+        gNodesPerDim[1] = galeriList.get<GO>("ny");
+        gNodesPerDim[2] = 1;
+
+        lNodesPerDim[0] = galeriList.get<LO>("lnx");
+        lNodesPerDim[1] = galeriList.get<LO>("lny");
+        lNodesPerDim[2] = 1;
+
+        procsPerDim[0] = galeriList.get<GO>("mx");
+        procsPerDim[1] = galeriList.get<GO>("my");
+        procsPerDim[2] = 1;
+      } else if(numDimensions == 3) {
+        gNodesPerDim[0] = galeriList.get<GO>("nx");
+        gNodesPerDim[1] = galeriList.get<GO>("ny");
+        gNodesPerDim[2] = galeriList.get<GO>("nz");
+
+        lNodesPerDim[0] = galeriList.get<LO>("lnx");
+        lNodesPerDim[1] = galeriList.get<LO>("lny");
+        lNodesPerDim[2] = galeriList.get<LO>("lnz");
+
+        procsPerDim[0] = galeriList.get<GO>("mx");
+        procsPerDim[1] = galeriList.get<GO>("my");
+        procsPerDim[2] = galeriList.get<GO>("mz");
+      }
+
+      const LO numLocalCompositeNodes = lNodesPerDim[0]*lNodesPerDim[1]*lNodesPerDim[2];
+
+      // Rule for boundary duplication
+      // For any two ranks that share an interface:
+      // the lowest rank owns the interface and the highest rank gets extra nodes
+
+      // 1D example of the relation between Composite, Quasi Region, and Region formats
+      //
+      // Composite:
+      // Rank 0   Rank 1
+      // [0 1 2]  [3 4]
+      //
+      // Quasi Region:
+      // Rank 0   Rank 1
+      // [0 1 2]  [2 3 4]
+      //
+      // Region:
+      // Rank 0   Rank 1
+      // [0 1 2]  [5 3 4]
+
+      // First we count how many nodes the region needs to send and receive
+      // and allocate arrays accordingly
+      Array<int> boundaryConditions;
+      int maxRegPerGID = 0;
+      int numInterfaces = 0;
+      LO numLocalRegionNodes = 0;
+      Array<GO>  sendGIDs;
+      Array<int> sendPIDs;
+      Array<LO>  rNodesPerDim(3);
+      Array<LO>  compositeToRegionLIDs(nodeMap->getNodeNumElements()*numDofsPerNode);
+      Array<GO>  quasiRegionGIDs;
+      Array<GO>  quasiRegionCoordGIDs;
+      Array<GO>  interfaceGIDs;
+      Array<LO>  interfaceLIDsData;
+
+      createRegionData(numDimensions, useUnstructured, numDofsPerNode,
+                       gNodesPerDim(), lNodesPerDim(), procsPerDim(), nodeMap, dofMap,
+                       maxRegPerGID, numLocalRegionNodes, boundaryConditions,
+                       sendGIDs, sendPIDs, numInterfaces, rNodesPerDim,
+                       quasiRegionGIDs, quasiRegionCoordGIDs, compositeToRegionLIDs,
+                       interfaceGIDs, interfaceLIDsData);
+
+      const LO numSend = static_cast<LO>(sendGIDs.size());
+
+      // std::cout << "p=" << myRank << " | numSend=" << numSend << std::endl;
+      // << ", numReceive=" << numReceive << std::endl;
+      // std::cout << "p=" << myRank << " | receiveGIDs: " << receiveGIDs << std::endl;
+      // std::cout << "p=" << myRank << " | receivePIDs: " << receivePIDs << std::endl;
+      // std::cout << "p=" << myRank << " | sendGIDs: " << sendGIDs << std::endl;
+      // std::cout << "p=" << myRank << " | sendPIDs: " << sendPIDs << std::endl;
+
+      // Second we actually fill the send and receive arrays with appropriate data
+      // which will allow us to compute the region and composite maps.
+      // Now we can construct a list of GIDs that corresponds to rowMap
+      Array<LO>  interfacesDimensions, interfacesLIDs;
+      if(useUnstructured) {
+        findInterface(numDimensions, rNodesPerDim, boundaryConditions,
+                      interfacesDimensions, interfacesLIDs);
+
+        // std::cout << "p=" << myRank << " | numLocalRegionNodes=" << numLocalRegionNodes
+        //           << ", rNodesPerDim: " << rNodesPerDim << std::endl;
+        // std::cout << "p=" << myRank << " | boundaryConditions: " << boundaryConditions << std::endl
+        //           << "p=" << myRank << " | rNodesPerDim: " << rNodesPerDim << std::endl
+        //           << "p=" << myRank << " | interfacesDimensions: " << interfacesDimensions << std::endl
+        //           << "p=" << myRank << " | interfacesLIDs: " << interfacesLIDs << std::endl;
+      }
+
+      interfaceParams->set<Array<LO> >("interfaces: nodes per dimensions", interfacesDimensions); // nodesPerDimensions);
+      interfaceParams->set<Array<LO> >("interfaces: interface nodes",      interfacesLIDs); // interfaceLIDs);
+
+      // std::cout << "p=" << myRank << " | compositeToRegionLIDs: " << compositeToRegionLIDs << std::endl;
+      // std::cout << "p=" << myRank << " | quasiRegionGIDs: " << quasiRegionGIDs << std::endl;
+      // std::cout << "p=" << myRank << " | interfaceGIDs: " << interfaceGIDs << std::endl;
+      // std::cout << "p=" << myRank << " | interfaceLIDsData: " << interfaceLIDsData << std::endl;
+      // std::cout << "p=" << myRank << " | interfaceLIDs: " << interfaceLIDs << std::endl;
+      // std::cout << "p=" << myRank << " | quasiRegionCoordGIDs: " << quasiRegionCoordGIDs() << std::endl;
+
+      // In our very particular case we know that a node is at most shared by 4 (8) regions in 2D (3D) problems.
+      // Other geometries will certainly have different constrains and a parallel reduction using MAX
+      // would be appropriate.
+
+      comm->barrier();
+      tm = Teuchos::null;
+
+      tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("Driver: 3 - Build Region Matrix")));
+
+      RCP<TimeMonitor> tmLocal = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("Driver: 3.1 - Build Region Maps")));
+
+      Teuchos::RCP<const Xpetra::Map<LO,GO,NO> > rowMap, colMap;
+      Teuchos::RCP<const Xpetra::Map<LO,GO,NO> > revisedRowMap, revisedColMap;
+      rowMap = Xpetra::MapFactory<LO,GO,Node>::Build(dofMap->lib(),
+                                                     Teuchos::OrdinalTraits<GO>::invalid(),
+                                                     quasiRegionGIDs(),
+                                                     dofMap->getIndexBase(),
+                                                     dofMap->getComm());
+      colMap = rowMap;
+      revisedRowMap = Xpetra::MapFactory<LO,GO,Node>::Build(dofMap->lib(),
+                                                            Teuchos::OrdinalTraits<GO>::invalid(),
+                                                            numLocalRegionNodes*numDofsPerNode,
+                                                            dofMap->getIndexBase(),
+                                                            dofMap->getComm());
+      revisedColMap = revisedRowMap;
+
+      // Build objects needed to construct the region coordinates
+      Teuchos::RCP<Xpetra::Map<LO,GO,NO> > quasiRegCoordMap = Xpetra::MapFactory<LO,GO,Node>::
+          Build(nodeMap->lib(),
+                Teuchos::OrdinalTraits<GO>::invalid(),
+                quasiRegionCoordGIDs(),
+                nodeMap->getIndexBase(),
+                nodeMap->getComm());
+      Teuchos::RCP<Xpetra::Map<LO,GO,NO> > regCoordMap = Xpetra::MapFactory<LO,GO,Node>::
+          Build(nodeMap->lib(),
+                Teuchos::OrdinalTraits<GO>::invalid(),
+                numLocalRegionNodes,
+                nodeMap->getIndexBase(),
+                nodeMap->getComm());
+
+      comm->barrier();
+      tmLocal = Teuchos::null;
+      tmLocal = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("Driver: 3.2 - Build Region Importers")));
+
+      // Setup importers
+      RCP<Import> rowImport;
+      RCP<Import> colImport;
+      rowImport = ImportFactory::Build(dofMap, rowMap);
+      colImport = ImportFactory::Build(dofMap, colMap);
+      RCP<Import> coordImporter = ImportFactory::Build(nodeMap, quasiRegCoordMap);
+
+      comm->barrier();
+      tmLocal = Teuchos::null;
+      tmLocal = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("Driver: 3.3 - Import ghost GIDs")));
+
+      Array<GO>  interfaceCompositeGIDs, interfaceRegionGIDs;
+      ExtractListOfInterfaceRegionGIDs(revisedRowMap, interfaceLIDsData, interfaceRegionGIDs);
+
+      RCP<Xpetra::MultiVector<LO, LO, GO, NO> > regionsPerGIDWithGhosts;
+      RCP<Xpetra::MultiVector<GO, LO, GO, NO> > interfaceGIDsMV;
+      MakeRegionPerGIDWithGhosts(nodeMap, revisedRowMap, rowImport,
+                                 maxRegPerGID, numDofsPerNode,
+                                 lNodesPerDim, sendGIDs, sendPIDs, interfaceLIDsData,
+                                 regionsPerGIDWithGhosts, interfaceGIDsMV);
+
+      Teuchos::ArrayRCP<LO> regionMatVecLIDs;
+      RCP<Import> regionInterfaceImporter;
+      SetupMatVec(interfaceGIDsMV, regionsPerGIDWithGhosts, revisedRowMap, rowImport,
+                  regionMatVecLIDs, regionInterfaceImporter);
+
+      comm->barrier();
+      tmLocal = Teuchos::null;
+      tmLocal = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("Driver: 3.4 - Build QuasiRegion Matrix")));
+
+      std::cout << "About to create quasi region matrix" << std::endl;
+      RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > quasiRegionMats;
+      MakeQuasiregionMatrices(Teuchos::rcp_dynamic_cast<CrsMatrixWrap>(A),
+                              regionsPerGIDWithGhosts, rowMap, colMap, rowImport,
+                              quasiRegionMats, regionMatVecLIDs);
+      std::cout << "Done creating quasi region matrix" << std::endl;
+
+      comm->barrier();
+      tmLocal = Teuchos::null;
+      tmLocal = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("Driver: 3.5 - Build Region Matrix")));
+
+      RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > regionMats;
+      MakeRegionMatrices(Teuchos::rcp_dynamic_cast<CrsMatrixWrap>(A), A->getRowMap(), rowMap,
+                         revisedRowMap, revisedColMap,
+                         rowImport, quasiRegionMats, regionMats);
+
+      // We don't need the composite operator on the fine level anymore. Free it!
+      A = Teuchos::null;
+
+      comm->barrier();
+      tmLocal = Teuchos::null;
+
+      comm->barrier();
+      tm = Teuchos::null;
+
+      tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("Driver: 4 - Build Region Hierarchy")));
+
+      // Setting up parameters before hierarchy construction
+      // These need to stay in the driver as they would be provide by an app
+      Array<int> regionNodesPerDim;
+      RCP<MultiVector> regionNullspace;
+      RCP<RealValuedMultiVector> regionCoordinates;
+
+      // Set mesh structure data
+      regionNodesPerDim = rNodesPerDim;
+
+      // create nullspace vector
+      regionNullspace = MultiVectorFactory::Build(rowMap, nullspace->getNumVectors());
+      regionNullspace->doImport(*nullspace, *rowImport, Xpetra::INSERT);
+      regionNullspace->replaceMap(revisedRowMap);
+
+      // create region coordinates vector
+      regionCoordinates = Xpetra::MultiVectorFactory<real_type,LO,GO,NO>::Build(quasiRegCoordMap,
+                                                                                coordinates->getNumVectors());
+      regionCoordinates->doImport(*coordinates, *coordImporter, Xpetra::INSERT);
+      regionCoordinates->replaceMap(regCoordMap);
+
+      using Tpetra_CrsMatrix = Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>;
+      using Tpetra_MultiVector = Tpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>;
+
+      /* Stuff for multi-level algorithm
+       *
+       * To allow for multi-level schemes with more than two levels, we need to store
+       * maps, matrices, vectors, and stuff like that on each level. Since we call the
+       * multi-level scheme recursively, this should be reflected in the design of
+       * variables.
+       *
+       * We use MueLu::Hierarchy and MueLu:Level to store each quantity on each level.
+       */
+      RCP<ParameterList> coarseSolverData = rcp(new ParameterList());
+      coarseSolverData->set<std::string>("coarse solver type", coarseSolverType);
+      coarseSolverData->set<bool>("coarse solver rebalance", coarseSolverRebalance);
+      coarseSolverData->set<int>("coarse rebalance num partitions", rebalanceNumPartitions);
+      coarseSolverData->set<std::string>("amg xml file", coarseAmgXmlFile);
+      coarseSolverData->set<std::string>("smoother xml file", coarseSmootherXMLFile);
+      RCP<ParameterList> hierarchyData = rcp(new ParameterList());
+
+
+      // Create MueLu Hierarchy Initially...
+      // Read MueLu parameter list form xml file
+      RCP<ParameterList> mueluParams = Teuchos::rcp(new ParameterList());
+      Teuchos::updateParametersFromXmlFileAndBroadcast(xmlFileName, mueluParams.ptr(), *dofMap->getComm());
+
+      // Insert region-specific data into parameter list
+      const std::string userName = "user data";
+      Teuchos::ParameterList& userParamList = mueluParams->sublist(userName);
+      userParamList.set<int>        ("int numDimensions", numDimensions);
+      userParamList.set<Array<LO> > ("Array<LO> lNodesPerDim", regionNodesPerDim);
+      userParamList.set<std::string>("string aggregationRegionType", aggregationRegionType);
+      userParamList.set<Array<LO> > ("Array<LO> nodeOnInterface", interfaceParams->get<Array<LO> >("interfaces: interface nodes"));
+      userParamList.set<Array<LO> > ("Array<LO> interfacesDimensions", interfaceParams->get<Array<LO> >("interfaces: nodes per dimensions"));
+      if(Teuchos::nonnull(regionCoordinates)) {
+        userParamList.set("Coordinates", regionCoordinates);
+      }
+      if(Teuchos::nonnull(regionNullspace)) {
+        userParamList.set("Nullspace", regionNullspace);
+      }
+
+      tmLocal = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("CreateXpetraPreconditioner: Hierarchy")));
+
+      // Create multigrid hierarchy part 1
+      RCP<Hierarchy> regHierarchy  = MueLu::CreateXpetraPreconditioner(regionMats, *mueluParams);
+
+      {
+        RCP<MueLu::Level> level = regHierarchy->GetLevel(0);
+        level->Set<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > >("rowImport",rowImport);
+        level->Set<ArrayView<LocalOrdinal> > ("compositeToRegionLIDs", compositeToRegionLIDs() );
+        level->Set<RCP<Xpetra::MultiVector<GlobalOrdinal, LocalOrdinal, GlobalOrdinal, Node> > >("interfaceGIDs", interfaceGIDsMV);
+        level->Set<RCP<Xpetra::MultiVector<LocalOrdinal, LocalOrdinal, GlobalOrdinal, Node> > >("regionsPerGIDWithGhosts", regionsPerGIDWithGhosts);
+        level->Set<Teuchos::ArrayRCP<LocalOrdinal> >("regionMatVecLIDs", regionMatVecLIDs);
+        level->Set<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > >("regionInterfaceImporter", regionInterfaceImporter);
+        level->print( std::cout, MueLu::Extreme );
+      }
+
+      tmLocal = Teuchos::null;
+
+
+      // Create multigrid hierarchy part 2
+      createRegionHierarchy(numDimensions,
+                            regionNodesPerDim,
+                            aggregationRegionType,
+                            interfaceParams,
+                            maxRegPerGID,
+                            coarseSolverData,
+                            smootherParams,
+                            hierarchyData,
+                            regHierarchy,
+                            keepCoarseCoords);
+
+      hierarchyData->print();
+
+
+
+      comm->barrier();
+      tm = Teuchos::null;
+
+      // Extract the number of levels from the prolongator data structure
+      const int numLevels = regHierarchy->GetNumLevels();
+
+      // Set data for fast MatVec
+      for(LO levelIdx = 0; levelIdx < numLevels; ++levelIdx) {
+        RCP<MueLu::Level> level = regHierarchy->GetLevel(levelIdx);
+        RCP<Xpetra::Import<LO, GO, NO> > regionInterfaceImport = level->Get<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > >("regionInterfaceImporter");
+        Teuchos::ArrayRCP<LO>            regionMatVecLIDs1     = level->Get<Teuchos::ArrayRCP<LO> >("regionMatVecLIDs");
+        smootherParams[levelIdx]->set("Fast MatVec: interface LIDs",
+                                      regionMatVecLIDs1);
+        smootherParams[levelIdx]->set("Fast MatVec: interface importer",
+                                      regionInterfaceImport);
+      }
+
+      // RCP<Teuchos::FancyOStream> fancy2 = Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
+      // Teuchos::FancyOStream& out2 = *fancy2;
+      // for(LO levelIdx = 0; levelIdx < numLevels; ++levelIdx) {
+      //   out2 << "p=" << myRank << " | regionMatVecLIDs on level " << levelIdx << std::endl;
+      //   regionMatVecLIDsPerLevel[levelIdx]->describe(out2, Teuchos::VERB_EXTREME);
+      // }
+
+      tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("Driver: 5 - Solve with V-cycle")));
+
+      {
+        //    std::cout << myRank << " | Running V-cycle ..." << std::endl;
+
+        TEUCHOS_TEST_FOR_EXCEPT_MSG(!(numLevels>0), "We require numLevel > 0. Probably, numLevel has not been set, yet.");
+
+        /* We first use the non-level container variables to setup the fine grid problem.
+         * This is ok since the initial setup just mimics the application and the outer
+         * Krylov method.
+         *
+         * We switch to using the level container variables as soon as we enter the
+         * recursive part of the algorithm.
+         */
+
+        // Composite residual vector
+        RCP<Vector> compRes = VectorFactory::Build(dofMap, true);
+
+        // transform composite vectors to regional layout
+        Teuchos::RCP<Vector> quasiRegX;
+        Teuchos::RCP<Vector> regX;
+        compositeToRegional(X, quasiRegX, regX,
+                            revisedRowMap, rowImport);
+
+        RCP<Vector> quasiRegB;
+        RCP<Vector> regB;
+        compositeToRegional(B, quasiRegB, regB,
+                            revisedRowMap, rowImport);
+#ifdef DUMP_LOCALX_AND_A
+        FILE *fp;
+        char str[80];
+        sprintf(str,"theMatrix.%d",myRank);
+        fp = fopen(str,"w");
+        fprintf(fp, "%%%%MatrixMarket matrix coordinate real general\n");
+        LO numNzs = 0;
+        for (size_t kkk = 0; kkk < regionMats->getNodeNumRows(); kkk++) {
+          ArrayView<const LO> AAcols;
+          ArrayView<const SC> AAvals;
+          regionMats->getLocalRowView(kkk, AAcols, AAvals);
+          const int *Acols    = AAcols.getRawPtr();
+          const SC  *Avals = AAvals.getRawPtr();
+          numNzs += AAvals.size();
+        }
+        fprintf(fp, "%d %d %d\n",regionMats->getNodeNumRows(),regionMats->getNodeNumRows(),numNzs);
+
+        for (size_t kkk = 0; kkk < regionMats->getNodeNumRows(); kkk++) {
+          ArrayView<const LO> AAcols;
+          ArrayView<const SC> AAvals;
+          regionMats->getLocalRowView(kkk, AAcols, AAvals);
+          const int *Acols    = AAcols.getRawPtr();
+          const SC  *Avals = AAvals.getRawPtr();
+          LO RowLeng = AAvals.size();
+          for (LO kk = 0; kk < RowLeng; kk++) {
+            fprintf(fp, "%d %d %22.16e\n",kkk+1,Acols[kk]+1,Avals[kk]);
+          }
+        }
+        fclose(fp);
+        sprintf(str,"theX.%d",myRank);
+        fp = fopen(str,"w");
+        ArrayRCP<SC> lX= regX->getDataNonConst(0);
+        for (size_t kkk = 0; kkk < regionMats->getNodeNumRows(); kkk++) fprintf(fp, "%22.16e\n",lX[kkk]);
+        fclose(fp);
+#endif
+
+        RCP<Vector> regRes;
+        regRes = VectorFactory::Build(revisedRowMap, true);
+
+        /////////////////////////////////////////////////////////////////////////
+        // SWITCH TO RECURSIVE STYLE --> USE LEVEL CONTAINER VARIABLES
+        /////////////////////////////////////////////////////////////////////////
+
+        // Prepare output of residual norm to file
+        RCP<std::ofstream> log;
+        if (myRank == 0)
+        {
+          log = rcp(new std::ofstream(convergenceLog.c_str()));
+          (*log) << "# num procs = " << dofMap->getComm()->getSize() << "\n"
+              << "# iteration | res-norm (scaled=" << scaleResidualHist << ")\n"
+              << "#\n";
+          *log << std::setprecision(16) << std::scientific;
+        }
+
+        // Print type of residual norm to the screen
+        if (scaleResidualHist)
+          out << "Using scaled residual norm." << std::endl;
+        else
+          out << "Using unscaled residual norm." << std::endl;
+
+
+        // Richardson iterations
+        magnitude_type normResIni = Teuchos::ScalarTraits<magnitude_type>::zero();
+        const int old_precision = std::cout.precision();
+        std::cout << std::setprecision(8) << std::scientific;
+        int cycle = 0;
+
+        Teuchos::RCP<Vector> regCorrect;
+        regCorrect = VectorFactory::Build(revisedRowMap, true);
+        for (cycle = 0; cycle < maxIts; ++cycle)
+        {
+          const Scalar SC_ZERO = Teuchos::ScalarTraits<SC>::zero();
+          regCorrect->putScalar(SC_ZERO);
+          // Get Stuff out of Hierarchy
+          RCP<MueLu::Level> level = regHierarchy->GetLevel(0);
+          RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal> > regInterfaceScalings = level->Get<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal> > >("regInterfaceScalings");
+          // check for convergence
+          {
+            ////////////////////////////////////////////////////////////////////////
+            // SWITCH BACK TO NON-LEVEL VARIABLES
+            ////////////////////////////////////////////////////////////////////////
+            computeResidual(regRes, regX, regB, regionMats, *smootherParams[0]);
+            scaleInterfaceDOFs(regRes, regInterfaceScalings, true);
+
+            compRes = VectorFactory::Build(dofMap, true);
+            regionalToComposite(regRes, compRes, rowImport);
+
+            typename Teuchos::ScalarTraits<Scalar>::magnitudeType normRes = compRes->norm2();
+            if(cycle == 0) { normResIni = normRes; }
+
+            if (scaleResidualHist)
+              normRes /= normResIni;
+
+            // Output current residual norm to screen (on proc 0 only)
+            out << cycle << "\t" << normRes << std::endl;
+            if (myRank == 0)
+              (*log) << cycle << "\t" << normRes << "\n";
+
+            if (normRes < tol)
+              break;
+          }
+
+          /////////////////////////////////////////////////////////////////////////
+          // SWITCH TO RECURSIVE STYLE --> USE LEVEL CONTAINER VARIABLES
+          /////////////////////////////////////////////////////////////////////////
+
+          bool zeroInitGuess = true;
+          scaleInterfaceDOFs(regRes, regInterfaceScalings, false);
+          vCycle(0, numLevels, cycleType, regHierarchy,
+                 regCorrect, regRes,
+                 smootherParams, zeroInitGuess, coarseSolverData, hierarchyData);
+
+          regX->update(one, *regCorrect, one);
+        }
+        out << "Number of iterations performed for this solve: " << cycle << std::endl;
+
+        std::cout << std::setprecision(old_precision);
+        std::cout.unsetf(std::ios::fixed | std::ios::scientific);
+      }
+
+      comm->barrier();
+      tm = Teuchos::null;
+      globalTimeMonitor = Teuchos::null;
+
+      if (showTimerSummary)
+      {
+        RCP<ParameterList> reportParams = rcp(new ParameterList);
+        const std::string filter = "";
+        if (useStackedTimer) {
+          Teuchos::StackedTimer::OutputOptions options;
+          options.output_fraction = options.output_histogram = options.output_minmax = true;
+          stacked_timer->report(out, comm, options);
+        } else {
+          std::ios_base::fmtflags ff(out.flags());
+          TimeMonitor::report(comm.ptr(), out, filter, reportParams);
+          out << std::setiosflags(ff);
+        }
+      }
+
+      TimeMonitor::clearCounters();
+
+      return EXIT_SUCCESS;
+    }
+    /**********************************************************************************/
+    /*********************************** END REGION DRIVER*****************************/
+    /**********************************************************************************/
 
     // solve the linear system
     /////////////////////////////////////////////////////////////

--- a/packages/trilinoscouplings/examples/scaling/muelu_region_poisson.cpp
+++ b/packages/trilinoscouplings/examples/scaling/muelu_region_poisson.cpp
@@ -1,0 +1,628 @@
+// Standard headers
+#include <cstdio>
+#include <iomanip>
+#include <unistd.h>
+
+// TrilinosCouplings headers
+#include "TrilinosCouplings_config.h"
+
+// Teuchos headers
+#include "Teuchos_CommandLineProcessor.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_DefaultComm.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+
+// Belos headers
+#include "BelosConfigDefs.hpp"
+#include "BelosLinearProblem.hpp"
+#include "BelosPseudoBlockGmresSolMgr.hpp"
+#include "BelosTpetraAdapter.hpp"
+
+// MueLu headers
+#include "MueLu.hpp"
+#include "MueLu_BaseClass.hpp"
+#include "MueLu_Level.hpp"
+#include "MueLu_MutuallyExclusiveTime.hpp"
+#include "MueLu_ParameterListInterpreter.hpp"
+#include "MueLu_TpetraOperator.hpp"
+#include "MueLu_Utilities.hpp"
+
+// Region MG headers
+#include "SetupRegionUtilities.hpp"
+#include "SetupRegionVector_def.hpp"
+#include "SetupRegionMatrix_def.hpp"
+#include "SetupRegionHierarchy_def.hpp"
+
+// Shards headers
+#include "Shards_CellTopology.hpp"
+
+// Panzer headers
+#include "Panzer_AssemblyEngine.hpp"
+#include "Panzer_AssemblyEngine_InArgs.hpp"
+#include "Panzer_AssemblyEngine_TemplateManager.hpp"
+#include "Panzer_AssemblyEngine_TemplateBuilder.hpp"
+#include "Panzer_BlockedTpetraLinearObjFactory.hpp"
+#include "Panzer_CheckBCConsistency.hpp"
+#include "Panzer_DOFManagerFactory.hpp"
+#include "Panzer_FieldManagerBuilder.hpp"
+#include "Panzer_GlobalData.hpp"
+#include "Panzer_LinearObjFactory.hpp"
+#include "Panzer_ResponseEvaluatorFactory_Functional.hpp"
+#include "Panzer_ResponseLibrary.hpp"
+#include "Panzer_Response_Functional.hpp"
+#include "Panzer_STK_Interface.hpp"
+#include "Panzer_STK_MeshFactory.hpp"
+#include "Panzer_STK_SetupUtilities.hpp"
+#include "Panzer_STK_ExodusReaderFactory.hpp"
+#include "Panzer_STK_WorksetFactory.hpp"
+#include "Panzer_STKConnManager.hpp"
+#include "Panzer_STK_Version.hpp"
+#include "Panzer_STK_SetupUtilities.hpp"
+#include "Panzer_STK_Utilities.hpp"
+#include "Panzer_TpetraLinearObjContainer.hpp"
+
+// Percept headers
+#include "percept/PerceptMesh.hpp"
+
+// Tpetra headers
+#include "Tpetra_Core.hpp"
+#include "Tpetra_Map.hpp"
+#include "Tpetra_FECrsMatrix.hpp"
+#include "Tpetra_Import.hpp"
+#include "MatrixMarket_Tpetra.hpp"
+
+// Include factories for boundary conditions and other Panzer setup
+// Most of which is taken from PoissonExample in Panzer_STK
+#include "muelu_region_poisson.hpp"
+
+
+int main(int argc, char *argv[]) {
+
+  using ST = double;
+  using LO = panzer::LocalOrdinal;
+  using GO = panzer::GlobalOrdinal;
+  using NT = panzer::TpetraNodeType;
+  using OP = Tpetra::Operator<ST,LO,GO,NT>;
+  using MV = Tpetra::MultiVector<ST,LO,GO,NT>; 
+
+  Kokkos::initialize(argc,argv);
+  { // Kokkos scope
+
+  /**********************************************************************************/
+  /************************************** SETUP *************************************/
+  /**********************************************************************************/
+
+  // Setup output stream, MPI, and grab info
+  Teuchos::RCP<Teuchos::FancyOStream> out = Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
+
+  Teuchos::GlobalMPISession mpiSession(&argc, &argv,0);
+  Teuchos::RCP<const Teuchos::MpiComm<int> > comm = Teuchos::rcp(new Teuchos::MpiComm<int>(MPI_COMM_WORLD));
+
+  const int numRanks = comm->getSize();
+  const int myRank = comm->getRank();
+
+  if (myRank == 0) {
+    *out << "Running MueLu region driver on " << numRanks << " ranks... \n";
+  }
+
+  // Parse command line arguments
+  Teuchos::CommandLineProcessor clp(false);
+  std::string exodusFileName        = "";                  clp.setOption("exodus-mesh",           &exodusFileName,          "Exodus hex mesh filename");
+  std::string pamgenFileName        = "cylinder.rtp";      clp.setOption("pamgen-mesh",           &pamgenFileName,          "Pamgen hex mesh filename");
+  std::string xmlFileName           = "";                  clp.setOption("xml",                   &xmlFileName,             "MueLu parameters file");
+  int mesh_refinements              = 1;                   clp.setOption("mesh-refinements",      &mesh_refinements,        "Uniform mesh refinements");
+
+  bool print_percept_mesh           = false;                clp.setOption("print-percept-mesh", "no-print-percept-mesh", &print_percept_mesh, "Calls perceptMesh's print_info routine");
+  bool delete_parent_elements       = false;                clp.setOption("delete-parent-elements", "keep-parent-elements", &delete_parent_elements,"Save the parent elements in the perceptMesh");
+  bool useStackedTimer              = false;                clp.setOption("stacked-timer","no-stacked-timer", &useStackedTimer, "use stacked timer");
+  bool showTimerSummary             = false;                clp.setOption("show-timer-summary", "no-show-timer-summary", &showTimerSummary, "Switch on/off the timer summary at the end of the run.");
+
+  /* GH: come back to these later
+  bool optPrintLocalStats           = false;               clp.setOption("localstats", "nolocalstats", &optPrintLocalStats, "print per-process statistics");
+  std::string convergenceLog        = "residual_norm.txt"; clp.setOption("convergence-log",       &convergenceLog,        "file in which the convergence history of the linear solver is stored");
+  int         maxIts                = 200;                 clp.setOption("its",                   &maxIts,                "maximum number of solver iterations");
+  std::string smootherType          = "Jacobi";            clp.setOption("smootherType",          &smootherType,          "smoother to be used: (None | Jacobi | Gauss | Chebyshev)");
+  int         smootherIts           = 2;                   clp.setOption("smootherIts",           &smootherIts,           "number of smoother iterations");
+  double      smootherDamp          = 0.67;                clp.setOption("smootherDamp",          &smootherDamp,          "damping parameter for the level smoother");
+  double      smootherChebyEigRatio = 2.0;                 clp.setOption("smootherChebyEigRatio", &smootherChebyEigRatio, "eigenvalue ratio max/min used to approximate the smallest eigenvalue for Chebyshev relaxation");
+  double      smootherChebyBoostFactor = 1.1;              clp.setOption("smootherChebyBoostFactor", &smootherChebyBoostFactor, "boost factor for Chebyshev smoother");
+  double      tol                   = 1e-12;               clp.setOption("tol",                   &tol,                   "solver convergence tolerance");
+  bool        scaleResidualHist     = true;                clp.setOption("scale", "noscale",      &scaleResidualHist,     "scaled Krylov residual history");
+  bool        serialRandom          = false;               clp.setOption("use-serial-random", "no-use-serial-random", &serialRandom, "generate the random vector serially and then broadcast it");
+  bool        keepCoarseCoords      = false;               clp.setOption("keep-coarse-coords", "no-keep-coarse-coords", &keepCoarseCoords, "keep coordinates on coarsest level of region hierarchy");
+  bool        coarseSolverRebalance = false;               clp.setOption("rebalance-coarse", "no-rebalance-coarse", &coarseSolverRebalance, "rebalance before AMG coarse grid solve");
+  int         rebalanceNumPartitions = 1;                  clp.setOption("numPartitions",         &rebalanceNumPartitions, "number of partitions for rebalancing the coarse grid AMG solve");
+  std::string coarseSolverType      = "direct";            clp.setOption("coarseSolverType",      &coarseSolverType,      "Type of solver for (composite) coarse level operator (smoother | direct | amg)");
+  std::string unstructured          = "{}";                clp.setOption("unstructured",          &unstructured,          "List of ranks to be treated as unstructured, e.g. {0, 2, 5}");
+  std::string coarseAmgXmlFile      = "";                  clp.setOption("coarseAmgXml",          &coarseAmgXmlFile,      "Read parameters for AMG as coarse level solve from this xml file.");
+  std::string coarseSmootherXMLFile = "";                  clp.setOption("coarseSmootherXML",     &coarseSmootherXMLFile, "File containing the parameters to use with the coarse level smoother.");
+  std::string equilibrate           = "no" ;               clp.setOption("equilibrate",           &equilibrate,           "equilibrate the system (no | diag | 1-norm)");
+  int  cacheSize                    = 0;                   clp.setOption("cachesize",               &cacheSize,           "cache size (in KB)");
+  std::string cycleType             = "V";                 clp.setOption("cycleType", &cycleType, "{Multigrid cycle type. Possible values: V, W.");
+  */
+  
+  clp.recogniseAllOptions(true);
+  switch (clp.parse(argc, argv)) {
+  case Teuchos::CommandLineProcessor::PARSE_HELP_PRINTED:        return EXIT_SUCCESS;
+  case Teuchos::CommandLineProcessor::PARSE_ERROR:
+  case Teuchos::CommandLineProcessor::PARSE_UNRECOGNIZED_OPTION: return EXIT_FAILURE;
+  case Teuchos::CommandLineProcessor::PARSE_SUCCESSFUL:          break;
+  }
+  
+
+
+  // get xml file from command line if provided, otherwise use default
+  std::string  xmlSolverInFileName(xmlFileName);
+
+  // Read xml file into parameter list
+  Teuchos::ParameterList inputSolverList;
+
+  if(xmlSolverInFileName.length()) {
+    if (myRank == 0)
+      *out << "\nReading parameter list from the XML file \""<<xmlSolverInFileName<<"\" ...\n" << std::endl;
+    Teuchos::updateParametersFromXmlFile (xmlSolverInFileName, Teuchos::ptr(&inputSolverList));
+  }
+  else if (myRank == 0)
+    *out << "Using default solver values ..." << std::endl;
+
+
+  /**********************************************************************************/
+  /************************************* MESH ***************************************/
+  /**********************************************************************************/
+  
+  //Teuchos::RCP<Teuchos::Time> meshTimer = Teuchos::TimeMonitor::getNewCounter("Step 1: Mesh generation");
+  Teuchos::RCP<Teuchos::StackedTimer> stacked_timer;
+  if(useStackedTimer)
+    stacked_timer = rcp(new Teuchos::StackedTimer("MueLu_Driver"));
+  Teuchos::TimeMonitor::setStackedTimer(stacked_timer);
+  RCP<Teuchos::TimeMonitor> globalTimeMonitor = rcp(new Teuchos::TimeMonitor(*Teuchos::TimeMonitor::getNewTimer("Driver: S - Global Time")));
+  RCP<Teuchos::TimeMonitor> tm                = rcp(new Teuchos::TimeMonitor(*Teuchos::TimeMonitor::getNewTimer("Driver: 1 - Build Mesh and Assign Physics")));  
+
+  Teuchos::RCP<panzer_stk::STK_MeshFactory> mesh_factory;
+  Teuchos::RCP<Teuchos::ParameterList> mesh_pl = Teuchos::rcp(new Teuchos::ParameterList);
+  std::string celltype = "Hex";  
+  
+  if(exodusFileName.length())
+  {
+    // set the filename and type
+    mesh_factory = Teuchos::rcp(new panzer_stk::STK_ExodusReaderFactory);
+    mesh_pl->set("File Name",exodusFileName);
+    mesh_pl->set("File Type","Exodus");
+    mesh_pl->set("Levels of Uniform Refinement",mesh_refinements); // this may impose 2^(level) coarsening
+    mesh_pl->set("Keep Percept Data",true); // this is necessary to gather mesh hierarchy information
+    mesh_pl->set("Keep Percept Parent Elements",!delete_parent_elements); // this is necessary to gather mesh hierarchy information
+
+    // check if the user provided conflicting mesh arguments
+    if(pamgenFileName.length())
+      *out << "Warning: using --exodus-mesh despite --pamgen-mesh being provided as well" << std::endl;
+  }
+  else if(pamgenFileName.length())
+  {
+    // set the filename and type
+    mesh_factory = Teuchos::rcp(new panzer_stk::STK_ExodusReaderFactory);
+    mesh_pl->set("File Name",pamgenFileName);
+    mesh_pl->set("File Type","Pamgen");
+    mesh_pl->set("Levels of Uniform Refinement",mesh_refinements); // this may impose 2^(level) coarsening
+    mesh_pl->set("Keep Percept Data",true); // this is necessary to gather mesh hierarchy information
+    mesh_pl->set("Keep Percept Parent Elements",!delete_parent_elements); // this is necessary to gather mesh hierarchy information
+  }
+  else
+    throw std::runtime_error("no mesh file name found!");
+
+  // set the parameters
+  mesh_factory->setParameterList(mesh_pl);
+  
+  // build the mesh
+  Teuchos::RCP<panzer_stk::STK_Interface> mesh;
+  mesh = mesh_factory->buildUncommitedMesh(MPI_COMM_WORLD);
+
+  // setup the physics block
+  Teuchos::RCP<Example::EquationSetFactory> eqset_factory = Teuchos::rcp(new Example::EquationSetFactory);
+  Example::BCStrategyFactory bc_factory;
+  const std::size_t workset_size = 10;
+  const int discretization_order = 1;
+  
+  Teuchos::RCP<Teuchos::ParameterList> ipb = Teuchos::parameterList("Physics Blocks");
+  std::vector<panzer::BC> bcs;
+  std::vector<Teuchos::RCP<panzer::PhysicsBlock> > physicsBlocks;
+
+  std::vector<std::string> eBlocks;
+  mesh->getElementBlockNames(eBlocks);
+
+  std::vector<std::string> sidesets;
+  mesh->getSidesetNames(sidesets);
+
+  // set physics and boundary conditions
+  {
+    bool build_transient_support = false;
+
+    const int integration_order = 10;
+    Teuchos::ParameterList& p = ipb->sublist("Poisson Physics");
+    p.set("Type","Poisson");
+    p.set("Model ID","solid");
+    p.set("Basis Type","HGrad");
+    p.set("Basis Order",discretization_order);
+    p.set("Integration Order",integration_order);
+
+    // GH: double-check. this assumes we impose Dirichlet BCs on all boundaries of all physics blocks
+    // which may potentially assign Dirichlet BCs to internal block boundaries, which is undesirable  
+    for(size_t i=0; i<eBlocks.size(); ++i)
+    {
+      for(size_t j=0; j<sidesets.size(); ++j)
+      {
+        std::size_t bc_id = i;    
+        panzer::BCType bctype = panzer::BCT_Dirichlet;
+        std::string sideset_id = sidesets[j];
+        std::string element_block_id = eBlocks[i];
+        std::string dof_name = "TEMPERATURE";
+        std::string strategy = "Constant";
+        double value = 0.0;
+        Teuchos::ParameterList p;
+        p.set("Value",value);
+        panzer::BC bc(bc_id, bctype, sideset_id, element_block_id, dof_name, 
+                      strategy, p);
+        bcs.push_back(bc);
+      }    
+    const panzer::CellData volume_cell_data(workset_size, mesh->getCellTopology(eBlocks[i]));
+
+    // GobalData sets ostream and parameter interface to physics
+    Teuchos::RCP<panzer::GlobalData> gd = panzer::createGlobalData();
+
+    // Can be overridden by the equation set
+    int default_integration_order = 1;
+    
+    // the physics block nows how to build and register evaluator with the field manager
+    Teuchos::RCP<panzer::PhysicsBlock> pb 
+      = Teuchos::rcp(new panzer::PhysicsBlock(ipb,
+                                              eBlocks[i], 
+                                              default_integration_order,
+                                              volume_cell_data,
+                                              eqset_factory,
+                                              gd,
+                                              build_transient_support));
+
+    // we can have more than one physics block, one per element block
+    physicsBlocks.push_back(pb);
+    }
+    panzer::checkBCConsistency(eBlocks,sidesets,bcs);
+  }
+
+
+  // finish building mesh, set required field variables and mesh bulk data
+  ////////////////////////////////////////////////////////////////////////
+
+  for(size_t i=0; i<physicsBlocks.size(); ++i)
+  {
+    Teuchos::RCP<panzer::PhysicsBlock> pb = physicsBlocks[i]; // we are assuming only one physics block
+
+    const std::vector<panzer::StrPureBasisPair> & blockFields = pb->getProvidedDOFs();
+
+    // insert all fields into a set
+    std::set<panzer::StrPureBasisPair,panzer::StrPureBasisComp> fieldNames;
+    fieldNames.insert(blockFields.begin(),blockFields.end());
+
+    // add basis to DOF manager: block specific
+    std::set<panzer::StrPureBasisPair,panzer::StrPureBasisComp>::const_iterator fieldItr;
+    for (fieldItr=fieldNames.begin();fieldItr!=fieldNames.end();++fieldItr)
+       mesh->addSolutionField(fieldItr->first,pb->elementBlockID());
+  }
+  mesh_factory->completeMeshConstruction(*mesh,MPI_COMM_WORLD); // this is where the mesh refinements are applied
+
+  // GH: query the Pamgen mesh info here; this is where we will construct a region hierarchy
+  Teuchos::RCP<percept::PerceptMesh> refinedMesh = mesh->getRefinedMesh();
+  if(print_percept_mesh)
+    refinedMesh->print_info(*out,"",1,true);
+
+  // check if the parent information is stored
+  std::vector<stk::mesh::EntityRank> ranks_to_be_deleted;
+  //ranks_to_be_deleted.push_back(stk::topology::ELEMENT_RANK); // GH: we only care about elements for now
+  ranks_to_be_deleted.push_back(refinedMesh->side_rank());
+  if (refinedMesh->get_spatial_dim() == 3)
+    ranks_to_be_deleted.push_back(refinedMesh->edge_rank());
+
+  for (unsigned irank=0; irank < ranks_to_be_deleted.size()-1; irank++) // don't look for children of nodes
+    {
+      const stk::mesh::BucketVector & buckets = refinedMesh->get_bulk_data()->buckets( ranks_to_be_deleted[irank] );
+      int npar=0;
+      int nchild=0;
+      for ( stk::mesh::BucketVector::const_iterator k = buckets.begin() ; k != buckets.end() ; ++k )
+	{
+	  stk::mesh::Bucket & bucket = **k ;
+
+	  //std::cout << "New bucket" << std::endl;
+
+	  const unsigned num_elements_in_bucket = bucket.size();
+	  for (unsigned iElement = 0; iElement < num_elements_in_bucket; iElement++)
+	    {
+	      stk::mesh::Entity element = bucket[iElement];
+	      //	      std::cout << element << std::endl;
+	      if (!refinedMesh->isParentElement(element, false))
+		{
+		  ++nchild;
+		  refinedMesh->printParent(element,true);
+		  //		  stk::mesh::Entity parent = refinedMesh->printParent(element,true);
+		  //		  stk::mesh::Entity parent = 
+
+    		  //std::cout << "Child index " << iElement << std::endl;
+		}
+	      else
+		{
+		  ++npar;
+		  //std::cout << "Parent index " << iElement << std::endl;
+		  //parents.insert(element);
+		}
+	    }
+	}
+      //std::cout << "Children on topology rank " << irank << ": " << nchild << std::endl;
+      //std::cout << "Parents on topology rank " << irank << ": " << npar << std::endl;
+    }
+  
+
+  // build DOF Manager and linear object factory
+  /////////////////////////////////////////////////////////////
+
+  tm = Teuchos::null;
+  tm = rcp(new Teuchos::TimeMonitor(*Teuchos::TimeMonitor::getNewTimer("Driver: 2 - Build DOF Manager and Worksets")));
+  // build the connection manager 
+  const Teuchos::RCP<panzer::ConnManager> conn_manager 
+    = Teuchos::rcp(new panzer_stk::STKConnManager(mesh));
+
+  panzer::DOFManagerFactory globalIndexerFactory;
+  Teuchos::RCP<panzer::GlobalIndexer> dofManager 
+    = globalIndexerFactory.buildGlobalIndexer(Teuchos::opaqueWrapper(MPI_COMM_WORLD),physicsBlocks,conn_manager);
+
+  // construct some linear algebra object, build object to pass to evaluators
+  Teuchos::RCP<panzer::LinearObjFactory<panzer::Traits> > linObjFactory
+    = Teuchos::rcp(new panzer::TpetraLinearObjFactory<panzer::Traits,ST,LO,GO>(comm.getConst(),dofManager));
+
+  /*
+  ArrayRCP<GO> dofs_to_region;
+  // Construct the DofToRegion map based on the Percept mesh and the DOF manager
+  {
+    std::vector<GO> gids;
+    dofManager->getElementGIDs((LO) 0, gids);
+    std::cout << "Element 0 GIDs: " << gids((int) 0); 
+    for(GO i=1; i<gids.size(); ++i)
+    {
+      std::cout << ", " << gids(static_cast<LO>(i));
+    }
+    std::cout << std::endl;
+  }
+  */
+
+  // build worksets
+  ////////////////////////////////////////////////////////
+
+  Teuchos::RCP<panzer_stk::WorksetFactory> wkstFactory
+    = Teuchos::rcp(new panzer_stk::WorksetFactory(mesh)); // build STK workset factory
+  Teuchos::RCP<panzer::WorksetContainer> wkstContainer     // attach it to a workset container (uses lazy evaluation)
+    = Teuchos::rcp(new panzer::WorksetContainer);
+  wkstContainer->setFactory(wkstFactory);
+  for(size_t i=0;i<physicsBlocks.size();i++) 
+    wkstContainer->setNeeds(physicsBlocks[i]->elementBlockID(),physicsBlocks[i]->getWorksetNeeds());
+  wkstContainer->setWorksetSize(workset_size);
+  wkstContainer->setGlobalIndexer(dofManager);
+
+
+  // Setup response library for checking the error in this manufactered solution
+  ////////////////////////////////////////////////////////////////////////
+
+  Teuchos::RCP<panzer::ResponseLibrary<panzer::Traits> > errorResponseLibrary
+    = Teuchos::rcp(new panzer::ResponseLibrary<panzer::Traits>(wkstContainer,dofManager,linObjFactory));
+
+  {
+    const int integration_order = 10;
+    
+    panzer::FunctionalResponse_Builder<int,int> builder;
+    builder.comm = MPI_COMM_WORLD;
+    builder.cubatureDegree = integration_order;
+    builder.requiresCellIntegral = true;
+    builder.quadPointField = "TEMPERATURE_L2_ERROR";
+
+    errorResponseLibrary->addResponse("L2 Error",eBlocks,builder);
+
+    /*    builder.comm = MPI_COMM_WORLD;
+    builder.cubatureDegree = integration_order;
+    builder.requiresCellIntegral = true;
+    builder.quadPointField = "TEMPERATURE_H1_ERROR";
+
+    errorResponseLibrary->addResponse("H1 Error",eBlocks,builder);
+    */
+  }
+
+
+  // setup closure model
+  /////////////////////////////////////////////////////////////
+ 
+  // Add in the application specific closure model factory
+  panzer::ClosureModelFactory_TemplateManager<panzer::Traits> cm_factory; 
+  Example::ClosureModelFactory_TemplateBuilder cm_builder;
+  cm_factory.buildObjects(cm_builder);
+
+  Teuchos::ParameterList closure_models("Closure Models");
+  {
+    closure_models.sublist("solid").sublist("SOURCE_TEMPERATURE").set<std::string>("Type","SIMPLE SOURCE"); // a constant source
+    // SOURCE_TEMPERATURE field is required by the PoissonEquationSet
+    // required for error calculation
+    closure_models.sublist("solid").sublist("TEMPERATURE_L2_ERROR").set<std::string>("Type","L2 ERROR_CALC");
+    closure_models.sublist("solid").sublist("TEMPERATURE_L2_ERROR").set<std::string>("Field A","TEMPERATURE");
+    closure_models.sublist("solid").sublist("TEMPERATURE_L2_ERROR").set<std::string>("Field B","TEMPERATURE_EXACT");
+
+    /*
+    closure_models.sublist("solid").sublist("TEMPERATURE_H1_ERROR").set<std::string>("Type","H1 ERROR_CALC");
+    closure_models.sublist("solid").sublist("TEMPERATURE_H1_ERROR").set<std::string>("Field A","TEMPERATURE");
+    closure_models.sublist("solid").sublist("TEMPERATURE_H1_ERROR").set<std::string>("Field B","TEMPERATURE_EXACT");
+    */
+    closure_models.sublist("solid").sublist("TEMPERATURE_EXACT").set<std::string>("Type","TEMPERATURE_EXACT");
+  }
+
+  Teuchos::ParameterList user_data("User Data"); // user data can be empty here
+
+
+  // setup field manager builder
+  /////////////////////////////////////////////////////////////
+
+  Teuchos::RCP<panzer::FieldManagerBuilder> fmb 
+    = Teuchos::rcp(new panzer::FieldManagerBuilder);
+  fmb->setWorksetContainer(wkstContainer);
+  fmb->setupVolumeFieldManagers(physicsBlocks,cm_factory,closure_models,*linObjFactory,user_data);
+  fmb->setupBCFieldManagers(bcs,physicsBlocks,*eqset_factory,cm_factory,bc_factory,closure_models,
+                            *linObjFactory,user_data);
+
+  fmb->writeVolumeGraphvizDependencyFiles("Poisson", physicsBlocks);
+
+
+  // setup assembly engine
+  /////////////////////////////////////////////////////////////
+
+  panzer::AssemblyEngine_TemplateManager<panzer::Traits> ae_tm;
+  panzer::AssemblyEngine_TemplateBuilder builder(fmb,linObjFactory);
+  ae_tm.buildObjects(builder);
+
+
+  // Finalize construcition of STK writer response library
+  /////////////////////////////////////////////////////////////
+  {
+    user_data.set<int>("Workset Size",workset_size);
+    errorResponseLibrary->buildResponseEvaluators(physicsBlocks,
+                                                  cm_factory,
+                                                  closure_models,
+                                                  user_data);
+  }
+
+
+  // assemble linear system
+  /////////////////////////////////////////////////////////////
+
+  Teuchos::RCP<panzer::LinearObjContainer> ghostCont = linObjFactory->buildGhostedLinearObjContainer();
+  Teuchos::RCP<panzer::LinearObjContainer> container = linObjFactory->buildLinearObjContainer();
+  linObjFactory->initializeGhostedContainer(panzer::LinearObjContainer::X |
+                                            panzer::LinearObjContainer::F |
+                                            panzer::LinearObjContainer::Mat,*ghostCont);
+  linObjFactory->initializeContainer(panzer::LinearObjContainer::X |
+                                     panzer::LinearObjContainer::F |
+                                     panzer::LinearObjContainer::Mat,*container);
+  ghostCont->initialize();
+  container->initialize();
+
+  panzer::AssemblyEngineInArgs input(ghostCont,container);
+  input.alpha = 0;
+  input.beta = 1;
+
+  // evaluate physics: This does both the Jacobian and residual at once
+  ae_tm.getAsObject<panzer::Traits::Jacobian>()->evaluate(input);
+
+
+  // solve linear system
+  /////////////////////////////////////////////////////////////
+
+
+  // GH: convert this to our MueLu region solver
+  // convert generic linear object container to tpetra container
+  Teuchos::RCP<panzer::TpetraLinearObjContainer<ST,LO,GO> > tp_container
+    = Teuchos::rcp_dynamic_cast<panzer::TpetraLinearObjContainer<ST,LO,GO> >(container);
+
+  // Setup the linear solve: notice A is used directly 
+  Belos::LinearProblem<ST,MV,OP> problem(tp_container->get_A(), tp_container->get_x(), tp_container->get_f());
+
+  problem.setProblem();
+
+  Teuchos::RCP<Teuchos::ParameterList> pl_belos = Teuchos::rcp(new Teuchos::ParameterList());
+  pl_belos->set("Maximum Iterations", 1000);
+  pl_belos->set("Convergence Tolerance", 1e-9);
+
+  // build the solver  
+  Belos::PseudoBlockGmresSolMgr<ST,MV,OP> solver(Teuchos::rcpFromRef(problem), pl_belos);
+
+  // solve the linear system
+  solver.solve();
+
+  // scale by -1 since we solved a residual correction
+  tp_container->get_x()->scale(-1.0);
+  std::cout << "Solution local length: " << tp_container->get_x()->getLocalLength() << std::endl;
+  std::cout << "Solution norm: " << tp_container->get_x()->norm2() << std::endl;
+  
+  // output data (optional)
+  /////////////////////////////////////////////////////////////
+
+  // write out solution to matrix
+  {
+    // redistribute solution vector to ghosted vector
+    linObjFactory->globalToGhostContainer(*container,*ghostCont, panzer::TpetraLinearObjContainer<ST,LO,GO>::X 
+					                       | panzer::TpetraLinearObjContainer<ST,LO,GO>::DxDt); 
+
+    // get X Tpetra_Vector from ghosted container
+    //Teuchos::RCP<panzer::TpetraLinearObjContainer<ST,LO,GO> > tp_ghostCont = Teuchos::rcp_dynamic_cast<panzer::TpetraLinearObjContainer<ST,LO,GO> >(ghostCont);
+    //panzer_stk::write_solution_data(*dofManager,*mesh,*tp_ghostCont->get_x());
+
+    // Due to multiple instances of this test being run at the same
+    // time (one for each celltype and each order), we need to
+    // differentiate output to prevent race conditions on output
+    // file. Multiple runs for different mesh refinement levels for
+    // the same celltype/order are ok as they are staged one after
+    // another in the ADD_ADVANCED_TEST cmake macro.
+    std::ostringstream filename;
+    filename << "output_" << celltype << "_p" << discretization_order << ".exo";
+    mesh->writeToExodus(filename.str());
+  }
+
+  // compute error norm
+  /////////////////////////////////////////////////////////////
+
+  if(true)
+  {
+    panzer::AssemblyEngineInArgs respInput(ghostCont,container);
+    respInput.alpha = 0;
+    respInput.beta = 1;
+
+    Teuchos::RCP<panzer::ResponseBase> l2_resp = errorResponseLibrary->getResponse<panzer::Traits::Residual>("L2 Error");
+    Teuchos::RCP<panzer::Response_Functional<panzer::Traits::Residual> > l2_resp_func 
+      = Teuchos::rcp_dynamic_cast<panzer::Response_Functional<panzer::Traits::Residual> >(l2_resp);
+    Teuchos::RCP<Thyra::VectorBase<double> > l2_respVec = Thyra::createMember(l2_resp_func->getVectorSpace());
+    l2_resp_func->setVector(l2_respVec);
+
+    /*
+    Teuchos::RCP<panzer::ResponseBase> h1_resp = errorResponseLibrary->getResponse<panzer::Traits::Residual>("H1 Error");
+    Teuchos::RCP<panzer::Response_Functional<panzer::Traits::Residual> > h1_resp_func 
+      = Teuchos::rcp_dynamic_cast<panzer::Response_Functional<panzer::Traits::Residual> >(h1_resp);
+    Teuchos::RCP<Thyra::VectorBase<double> > h1_respVec = Thyra::createMember(h1_resp_func->getVectorSpace());
+    h1_resp_func->setVector(h1_respVec);
+    */
+
+    errorResponseLibrary->addResponsesToInArgs<panzer::Traits::Residual>(respInput);
+    errorResponseLibrary->evaluate<panzer::Traits::Residual>(respInput);
+
+    if(myRank == 0)
+    {
+      *out << "This is the Basis Order" << std::endl;
+      *out << "Basis Order = " << discretization_order << std::endl;
+      *out << "This is the L2 Error" << std::endl;
+      *out << "L2 Error = " << sqrt(l2_resp_func->value) << std::endl;
+      //*out << "This is the H1 Error" << std::endl;
+      //*out << "H1 Error = " << sqrt(h1_resp_func->value) << std::endl;
+    }
+  }
+
+  tm = Teuchos::null;
+  globalTimeMonitor = Teuchos::null;
+
+  if (showTimerSummary)
+  {
+    RCP<ParameterList> reportParams = rcp(new ParameterList);
+    const std::string filter = "";
+    if (useStackedTimer) {
+      Teuchos::StackedTimer::OutputOptions options;
+      options.output_fraction = options.output_histogram = options.output_minmax = true;
+      stacked_timer->report(*out, comm, options);
+    } else {
+      std::ios_base::fmtflags ff(out->flags());
+      Teuchos::TimeMonitor::report(comm.ptr(), *out, filter, reportParams);
+      *out << std::setiosflags(ff);
+    }
+  }
+
+  } // Kokkos scope
+  Kokkos::finalize();
+
+  return 0;
+} // main

--- a/packages/trilinoscouplings/examples/scaling/muelu_region_poisson.cpp
+++ b/packages/trilinoscouplings/examples/scaling/muelu_region_poisson.cpp
@@ -21,6 +21,7 @@
 // MueLu headers
 #include "MueLu.hpp"
 #include "MueLu_BaseClass.hpp"
+#include "MueLu_CreateTpetraPreconditioner.hpp"
 #include "MueLu_Level.hpp"
 #include "MueLu_MutuallyExclusiveTime.hpp"
 #include "MueLu_ParameterListInterpreter.hpp"
@@ -62,7 +63,9 @@
 #include "Panzer_TpetraLinearObjContainer.hpp"
 
 // Percept headers
-#include "percept/PerceptMesh.hpp"
+#include <percept/PerceptMesh.hpp>
+#include <adapt/UniformRefinerPattern.hpp>
+#include <adapt/UniformRefiner.hpp>
 
 // Tpetra headers
 #include "Tpetra_Core.hpp"
@@ -88,538 +91,583 @@ int main(int argc, char *argv[]) {
   Kokkos::initialize(argc,argv);
   { // Kokkos scope
 
-  /**********************************************************************************/
-  /************************************** SETUP *************************************/
-  /**********************************************************************************/
 
-  // Setup output stream, MPI, and grab info
-  Teuchos::RCP<Teuchos::FancyOStream> out = Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
-
-  Teuchos::GlobalMPISession mpiSession(&argc, &argv,0);
-  Teuchos::RCP<const Teuchos::MpiComm<int> > comm = Teuchos::rcp(new Teuchos::MpiComm<int>(MPI_COMM_WORLD));
-
-  const int numRanks = comm->getSize();
-  const int myRank = comm->getRank();
-
-  if (myRank == 0) {
-    *out << "Running MueLu region driver on " << numRanks << " ranks... \n";
-  }
-
-  // Parse command line arguments
-  Teuchos::CommandLineProcessor clp(false);
-  std::string exodusFileName        = "";                  clp.setOption("exodus-mesh",           &exodusFileName,          "Exodus hex mesh filename");
-  std::string pamgenFileName        = "cylinder.rtp";      clp.setOption("pamgen-mesh",           &pamgenFileName,          "Pamgen hex mesh filename");
-  std::string xmlFileName           = "";                  clp.setOption("xml",                   &xmlFileName,             "MueLu parameters file");
-  int mesh_refinements              = 1;                   clp.setOption("mesh-refinements",      &mesh_refinements,        "Uniform mesh refinements");
-
-  bool print_percept_mesh           = false;                clp.setOption("print-percept-mesh", "no-print-percept-mesh", &print_percept_mesh, "Calls perceptMesh's print_info routine");
-  bool delete_parent_elements       = false;                clp.setOption("delete-parent-elements", "keep-parent-elements", &delete_parent_elements,"Save the parent elements in the perceptMesh");
-  bool useStackedTimer              = false;                clp.setOption("stacked-timer","no-stacked-timer", &useStackedTimer, "use stacked timer");
-  bool showTimerSummary             = false;                clp.setOption("show-timer-summary", "no-show-timer-summary", &showTimerSummary, "Switch on/off the timer summary at the end of the run.");
-
-  /* GH: come back to these later
-  bool optPrintLocalStats           = false;               clp.setOption("localstats", "nolocalstats", &optPrintLocalStats, "print per-process statistics");
-  std::string convergenceLog        = "residual_norm.txt"; clp.setOption("convergence-log",       &convergenceLog,        "file in which the convergence history of the linear solver is stored");
-  int         maxIts                = 200;                 clp.setOption("its",                   &maxIts,                "maximum number of solver iterations");
-  std::string smootherType          = "Jacobi";            clp.setOption("smootherType",          &smootherType,          "smoother to be used: (None | Jacobi | Gauss | Chebyshev)");
-  int         smootherIts           = 2;                   clp.setOption("smootherIts",           &smootherIts,           "number of smoother iterations");
-  double      smootherDamp          = 0.67;                clp.setOption("smootherDamp",          &smootherDamp,          "damping parameter for the level smoother");
-  double      smootherChebyEigRatio = 2.0;                 clp.setOption("smootherChebyEigRatio", &smootherChebyEigRatio, "eigenvalue ratio max/min used to approximate the smallest eigenvalue for Chebyshev relaxation");
-  double      smootherChebyBoostFactor = 1.1;              clp.setOption("smootherChebyBoostFactor", &smootherChebyBoostFactor, "boost factor for Chebyshev smoother");
-  double      tol                   = 1e-12;               clp.setOption("tol",                   &tol,                   "solver convergence tolerance");
-  bool        scaleResidualHist     = true;                clp.setOption("scale", "noscale",      &scaleResidualHist,     "scaled Krylov residual history");
-  bool        serialRandom          = false;               clp.setOption("use-serial-random", "no-use-serial-random", &serialRandom, "generate the random vector serially and then broadcast it");
-  bool        keepCoarseCoords      = false;               clp.setOption("keep-coarse-coords", "no-keep-coarse-coords", &keepCoarseCoords, "keep coordinates on coarsest level of region hierarchy");
-  bool        coarseSolverRebalance = false;               clp.setOption("rebalance-coarse", "no-rebalance-coarse", &coarseSolverRebalance, "rebalance before AMG coarse grid solve");
-  int         rebalanceNumPartitions = 1;                  clp.setOption("numPartitions",         &rebalanceNumPartitions, "number of partitions for rebalancing the coarse grid AMG solve");
-  std::string coarseSolverType      = "direct";            clp.setOption("coarseSolverType",      &coarseSolverType,      "Type of solver for (composite) coarse level operator (smoother | direct | amg)");
-  std::string unstructured          = "{}";                clp.setOption("unstructured",          &unstructured,          "List of ranks to be treated as unstructured, e.g. {0, 2, 5}");
-  std::string coarseAmgXmlFile      = "";                  clp.setOption("coarseAmgXml",          &coarseAmgXmlFile,      "Read parameters for AMG as coarse level solve from this xml file.");
-  std::string coarseSmootherXMLFile = "";                  clp.setOption("coarseSmootherXML",     &coarseSmootherXMLFile, "File containing the parameters to use with the coarse level smoother.");
-  std::string equilibrate           = "no" ;               clp.setOption("equilibrate",           &equilibrate,           "equilibrate the system (no | diag | 1-norm)");
-  int  cacheSize                    = 0;                   clp.setOption("cachesize",               &cacheSize,           "cache size (in KB)");
-  std::string cycleType             = "V";                 clp.setOption("cycleType", &cycleType, "{Multigrid cycle type. Possible values: V, W.");
-  */
-  
-  clp.recogniseAllOptions(true);
-  switch (clp.parse(argc, argv)) {
-  case Teuchos::CommandLineProcessor::PARSE_HELP_PRINTED:        return EXIT_SUCCESS;
-  case Teuchos::CommandLineProcessor::PARSE_ERROR:
-  case Teuchos::CommandLineProcessor::PARSE_UNRECOGNIZED_OPTION: return EXIT_FAILURE;
-  case Teuchos::CommandLineProcessor::PARSE_SUCCESSFUL:          break;
-  }
-  
+    /**********************************************************************************/
+    /************************************** SETUP *************************************/
+    /**********************************************************************************/
 
 
-  // get xml file from command line if provided, otherwise use default
-  std::string  xmlSolverInFileName(xmlFileName);
+    // Setup output stream, MPI, and grab info
+    Teuchos::RCP<Teuchos::FancyOStream> out = Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
 
-  // Read xml file into parameter list
-  Teuchos::ParameterList inputSolverList;
+    // GH: comb back through everything and make sure I'm using my MPI comms properly when necessary
+    Teuchos::GlobalMPISession mpiSession(&argc, &argv,0);
+    Teuchos::RCP<const Teuchos::MpiComm<int> > comm = Teuchos::rcp(new Teuchos::MpiComm<int>(MPI_COMM_WORLD));
 
-  if(xmlSolverInFileName.length()) {
-    if (myRank == 0)
-      *out << "\nReading parameter list from the XML file \""<<xmlSolverInFileName<<"\" ...\n" << std::endl;
-    Teuchos::updateParametersFromXmlFile (xmlSolverInFileName, Teuchos::ptr(&inputSolverList));
-  }
-  else if (myRank == 0)
-    *out << "Using default solver values ..." << std::endl;
+    const int numRanks = comm->getSize();
+    const int myRank = comm->getRank();
+
+    if (myRank == 0) {
+      *out << "Running MueLu region driver on " << numRanks << " ranks... \n";
+    }
+
+    // Parse command line arguments
+    Teuchos::CommandLineProcessor clp(false);
+    std::string exodusFileName        = "";                  clp.setOption("exodus-mesh",           &exodusFileName,          "Exodus hex mesh filename (overrides a pamgen-mesh if both specified)");
+    std::string pamgenFileName        = "cylinder.rtp";      clp.setOption("pamgen-mesh",           &pamgenFileName,          "Pamgen hex mesh filename");
+    std::string xmlFileName           = "";                  clp.setOption("xml",                   &xmlFileName,             "MueLu parameters file");
+    int mesh_refinements              = 1;                   clp.setOption("mesh-refinements",      &mesh_refinements,        "Uniform mesh refinements");
+    bool delete_parent_elements       = false;                clp.setOption("delete-parent-elements", "keep-parent-elements", &delete_parent_elements,"Save the parent elements in the perceptMesh");
+
+    // debug options
+    bool print_percept_mesh           = false;                clp.setOption("print-percept-mesh", "no-print-percept-mesh", &print_percept_mesh, "Calls perceptMesh's print_info routine");
+    bool print_debug_info             = false;                clp.setOption("print-debug-info", "no-print-debug-info", &print_debug_info, "Print more debugging information");
+
+    // timer options
+    bool useStackedTimer              = false;                clp.setOption("stacked-timer","no-stacked-timer", &useStackedTimer, "use stacked timer");
+    bool showTimerSummary             = false;                clp.setOption("show-timer-summary", "no-show-timer-summary", &showTimerSummary, "Switch on/off the timer summary at the end of the run.");
+
+    clp.recogniseAllOptions(true);
+    switch (clp.parse(argc, argv)) {
+      case Teuchos::CommandLineProcessor::PARSE_HELP_PRINTED:        return EXIT_SUCCESS;
+      case Teuchos::CommandLineProcessor::PARSE_ERROR:
+      case Teuchos::CommandLineProcessor::PARSE_UNRECOGNIZED_OPTION: return EXIT_FAILURE;
+      case Teuchos::CommandLineProcessor::PARSE_SUCCESSFUL:          break;
+    }
+    TEUCHOS_ASSERT(mesh_refinements >= 0); // get around the expected 7 arguments error for clp.setOption(...unsigned int...) for now
+
+    // get xml file from command line if provided, otherwise use default
+    std::string  xmlSolverInFileName(xmlFileName);
+
+    // Read xml file into parameter list
+    Teuchos::ParameterList inputSolverList;
+
+    if(xmlSolverInFileName.length()) {
+      if (myRank == 0)
+        *out << "\nReading parameter list from the XML file \""<<xmlSolverInFileName<<"\" ...\n" << std::endl;
+      Teuchos::updateParametersFromXmlFile (xmlSolverInFileName, Teuchos::ptr(&inputSolverList));
+    }
+    else if (myRank == 0)
+      *out << "Using default solver values ..." << std::endl;
 
 
-  /**********************************************************************************/
-  /************************************* MESH ***************************************/
-  /**********************************************************************************/
-  
-  //Teuchos::RCP<Teuchos::Time> meshTimer = Teuchos::TimeMonitor::getNewCounter("Step 1: Mesh generation");
-  Teuchos::RCP<Teuchos::StackedTimer> stacked_timer;
-  if(useStackedTimer)
-    stacked_timer = rcp(new Teuchos::StackedTimer("MueLu_Driver"));
-  Teuchos::TimeMonitor::setStackedTimer(stacked_timer);
-  RCP<Teuchos::TimeMonitor> globalTimeMonitor = rcp(new Teuchos::TimeMonitor(*Teuchos::TimeMonitor::getNewTimer("Driver: S - Global Time")));
-  RCP<Teuchos::TimeMonitor> tm                = rcp(new Teuchos::TimeMonitor(*Teuchos::TimeMonitor::getNewTimer("Driver: 1 - Build Mesh and Assign Physics")));  
+    /**********************************************************************************/
+    /******************************* MESH AND WORKSETS ********************************/
+    /**********************************************************************************/
 
-  Teuchos::RCP<panzer_stk::STK_MeshFactory> mesh_factory;
-  Teuchos::RCP<Teuchos::ParameterList> mesh_pl = Teuchos::rcp(new Teuchos::ParameterList);
-  std::string celltype = "Hex";  
-  
-  if(exodusFileName.length())
-  {
-    // set the filename and type
-    mesh_factory = Teuchos::rcp(new panzer_stk::STK_ExodusReaderFactory);
-    mesh_pl->set("File Name",exodusFileName);
-    mesh_pl->set("File Type","Exodus");
-    mesh_pl->set("Levels of Uniform Refinement",mesh_refinements); // this may impose 2^(level) coarsening
-    mesh_pl->set("Keep Percept Data",true); // this is necessary to gather mesh hierarchy information
-    mesh_pl->set("Keep Percept Parent Elements",!delete_parent_elements); // this is necessary to gather mesh hierarchy information
 
-    // check if the user provided conflicting mesh arguments
-    if(pamgenFileName.length())
-      *out << "Warning: using --exodus-mesh despite --pamgen-mesh being provided as well" << std::endl;
-  }
-  else if(pamgenFileName.length())
-  {
-    // set the filename and type
-    mesh_factory = Teuchos::rcp(new panzer_stk::STK_ExodusReaderFactory);
-    mesh_pl->set("File Name",pamgenFileName);
-    mesh_pl->set("File Type","Pamgen");
-    mesh_pl->set("Levels of Uniform Refinement",mesh_refinements); // this may impose 2^(level) coarsening
-    mesh_pl->set("Keep Percept Data",true); // this is necessary to gather mesh hierarchy information
-    mesh_pl->set("Keep Percept Parent Elements",!delete_parent_elements); // this is necessary to gather mesh hierarchy information
-  }
-  else
-    throw std::runtime_error("no mesh file name found!");
+    Teuchos::RCP<Teuchos::Time> meshTimer = Teuchos::TimeMonitor::getNewCounter("Step 1: Mesh generation");
+    Teuchos::RCP<Teuchos::StackedTimer> stacked_timer;
+    if(useStackedTimer)
+      stacked_timer = rcp(new Teuchos::StackedTimer("MueLu_Driver"));
+    Teuchos::TimeMonitor::setStackedTimer(stacked_timer);
+    RCP<Teuchos::TimeMonitor> globalTimeMonitor = rcp(new Teuchos::TimeMonitor(*Teuchos::TimeMonitor::getNewTimer("Driver: S - Global Time")));
+    RCP<Teuchos::TimeMonitor> tm                = rcp(new Teuchos::TimeMonitor(*Teuchos::TimeMonitor::getNewTimer("Driver: 1 - Build Mesh and Assign Physics")));
 
-  // set the parameters
-  mesh_factory->setParameterList(mesh_pl);
-  
-  // build the mesh
-  Teuchos::RCP<panzer_stk::STK_Interface> mesh;
-  mesh = mesh_factory->buildUncommitedMesh(MPI_COMM_WORLD);
+    Teuchos::RCP<panzer_stk::STK_MeshFactory> mesh_factory;
+    Teuchos::RCP<Teuchos::ParameterList> mesh_pl = Teuchos::rcp(new Teuchos::ParameterList);
+    std::string celltype = "Hex";
 
-  // setup the physics block
-  Teuchos::RCP<Example::EquationSetFactory> eqset_factory = Teuchos::rcp(new Example::EquationSetFactory);
-  Example::BCStrategyFactory bc_factory;
-  const std::size_t workset_size = 10;
-  const int discretization_order = 1;
-  
-  Teuchos::RCP<Teuchos::ParameterList> ipb = Teuchos::parameterList("Physics Blocks");
-  std::vector<panzer::BC> bcs;
-  std::vector<Teuchos::RCP<panzer::PhysicsBlock> > physicsBlocks;
-
-  std::vector<std::string> eBlocks;
-  mesh->getElementBlockNames(eBlocks);
-
-  std::vector<std::string> sidesets;
-  mesh->getSidesetNames(sidesets);
-
-  // set physics and boundary conditions
-  {
-    bool build_transient_support = false;
-
-    const int integration_order = 10;
-    Teuchos::ParameterList& p = ipb->sublist("Poisson Physics");
-    p.set("Type","Poisson");
-    p.set("Model ID","solid");
-    p.set("Basis Type","HGrad");
-    p.set("Basis Order",discretization_order);
-    p.set("Integration Order",integration_order);
-
-    // GH: double-check. this assumes we impose Dirichlet BCs on all boundaries of all physics blocks
-    // which may potentially assign Dirichlet BCs to internal block boundaries, which is undesirable  
-    for(size_t i=0; i<eBlocks.size(); ++i)
+    if(exodusFileName.length())
     {
-      for(size_t j=0; j<sidesets.size(); ++j)
+      // set the filename and type
+      mesh_factory = Teuchos::rcp(new panzer_stk::STK_ExodusReaderFactory);
+      mesh_pl->set("File Name",exodusFileName);
+      mesh_pl->set("File Type","Exodus");
+
+      if(mesh_refinements>0)
       {
-        std::size_t bc_id = i;    
-        panzer::BCType bctype = panzer::BCT_Dirichlet;
-        std::string sideset_id = sidesets[j];
-        std::string element_block_id = eBlocks[i];
-        std::string dof_name = "TEMPERATURE";
-        std::string strategy = "Constant";
-        double value = 0.0;
-        Teuchos::ParameterList p;
-        p.set("Value",value);
-        panzer::BC bc(bc_id, bctype, sideset_id, element_block_id, dof_name, 
-                      strategy, p);
-        bcs.push_back(bc);
-      }    
-    const panzer::CellData volume_cell_data(workset_size, mesh->getCellTopology(eBlocks[i]));
-
-    // GobalData sets ostream and parameter interface to physics
-    Teuchos::RCP<panzer::GlobalData> gd = panzer::createGlobalData();
-
-    // Can be overridden by the equation set
-    int default_integration_order = 1;
-    
-    // the physics block nows how to build and register evaluator with the field manager
-    Teuchos::RCP<panzer::PhysicsBlock> pb 
-      = Teuchos::rcp(new panzer::PhysicsBlock(ipb,
-                                              eBlocks[i], 
-                                              default_integration_order,
-                                              volume_cell_data,
-                                              eqset_factory,
-                                              gd,
-                                              build_transient_support));
-
-    // we can have more than one physics block, one per element block
-    physicsBlocks.push_back(pb);
+        mesh_pl->set("Levels of Uniform Refinement",mesh_refinements); // this multiplies the number of elements by 2^(dimension*level)
+        mesh_pl->set("Keep Percept Data",true); // this is necessary to gather mesh hierarchy information
+        mesh_pl->set("Keep Percept Parent Elements",!delete_parent_elements); // this is necessary to gather mesh hierarchy information
+      }
     }
-    panzer::checkBCConsistency(eBlocks,sidesets,bcs);
-  }
-
-
-  // finish building mesh, set required field variables and mesh bulk data
-  ////////////////////////////////////////////////////////////////////////
-
-  for(size_t i=0; i<physicsBlocks.size(); ++i)
-  {
-    Teuchos::RCP<panzer::PhysicsBlock> pb = physicsBlocks[i]; // we are assuming only one physics block
-
-    const std::vector<panzer::StrPureBasisPair> & blockFields = pb->getProvidedDOFs();
-
-    // insert all fields into a set
-    std::set<panzer::StrPureBasisPair,panzer::StrPureBasisComp> fieldNames;
-    fieldNames.insert(blockFields.begin(),blockFields.end());
-
-    // add basis to DOF manager: block specific
-    std::set<panzer::StrPureBasisPair,panzer::StrPureBasisComp>::const_iterator fieldItr;
-    for (fieldItr=fieldNames.begin();fieldItr!=fieldNames.end();++fieldItr)
-       mesh->addSolutionField(fieldItr->first,pb->elementBlockID());
-  }
-  mesh_factory->completeMeshConstruction(*mesh,MPI_COMM_WORLD); // this is where the mesh refinements are applied
-
-  // GH: query the Pamgen mesh info here; this is where we will construct a region hierarchy
-  Teuchos::RCP<percept::PerceptMesh> refinedMesh = mesh->getRefinedMesh();
-  if(print_percept_mesh)
-    refinedMesh->print_info(*out,"",1,true);
-
-  // check if the parent information is stored
-  std::vector<stk::mesh::EntityRank> ranks_to_be_deleted;
-  //ranks_to_be_deleted.push_back(stk::topology::ELEMENT_RANK); // GH: we only care about elements for now
-  ranks_to_be_deleted.push_back(refinedMesh->side_rank());
-  if (refinedMesh->get_spatial_dim() == 3)
-    ranks_to_be_deleted.push_back(refinedMesh->edge_rank());
-
-  for (unsigned irank=0; irank < ranks_to_be_deleted.size()-1; irank++) // don't look for children of nodes
+    else if(pamgenFileName.length())
     {
-      const stk::mesh::BucketVector & buckets = refinedMesh->get_bulk_data()->buckets( ranks_to_be_deleted[irank] );
-      int npar=0;
-      int nchild=0;
-      for ( stk::mesh::BucketVector::const_iterator k = buckets.begin() ; k != buckets.end() ; ++k )
-	{
-	  stk::mesh::Bucket & bucket = **k ;
+      // set the filename and type
+      mesh_factory = Teuchos::rcp(new panzer_stk::STK_ExodusReaderFactory);
+      mesh_pl->set("File Name",pamgenFileName);
+      mesh_pl->set("File Type","Pamgen");
 
-	  //std::cout << "New bucket" << std::endl;
-
-	  const unsigned num_elements_in_bucket = bucket.size();
-	  for (unsigned iElement = 0; iElement < num_elements_in_bucket; iElement++)
-	    {
-	      stk::mesh::Entity element = bucket[iElement];
-	      //	      std::cout << element << std::endl;
-	      if (!refinedMesh->isParentElement(element, false))
-		{
-		  ++nchild;
-		  refinedMesh->printParent(element,true);
-		  //		  stk::mesh::Entity parent = refinedMesh->printParent(element,true);
-		  //		  stk::mesh::Entity parent = 
-
-    		  //std::cout << "Child index " << iElement << std::endl;
-		}
-	      else
-		{
-		  ++npar;
-		  //std::cout << "Parent index " << iElement << std::endl;
-		  //parents.insert(element);
-		}
-	    }
-	}
-      //std::cout << "Children on topology rank " << irank << ": " << nchild << std::endl;
-      //std::cout << "Parents on topology rank " << irank << ": " << npar << std::endl;
+      if(mesh_refinements>0)
+      {
+        mesh_pl->set("Levels of Uniform Refinement",mesh_refinements); // this multiplies the number of elements by 2^(dimension*level)
+        mesh_pl->set("Keep Percept Data",true); // this is necessary to gather mesh hierarchy information
+        mesh_pl->set("Keep Percept Parent Elements",!delete_parent_elements); // this is necessary to gather mesh hierarchy information
+      }
     }
-  
+    else
+      throw std::runtime_error("no mesh file name found!");
 
-  // build DOF Manager and linear object factory
-  /////////////////////////////////////////////////////////////
+    // set the parameters
+    mesh_factory->setParameterList(mesh_pl);
 
-  tm = Teuchos::null;
-  tm = rcp(new Teuchos::TimeMonitor(*Teuchos::TimeMonitor::getNewTimer("Driver: 2 - Build DOF Manager and Worksets")));
-  // build the connection manager 
-  const Teuchos::RCP<panzer::ConnManager> conn_manager 
+    // build the mesh
+    Teuchos::RCP<panzer_stk::STK_Interface> mesh;
+    mesh = mesh_factory->buildUncommitedMesh(MPI_COMM_WORLD);
+
+    // setup the physics block
+    Teuchos::RCP<Example::EquationSetFactory> eqset_factory = Teuchos::rcp(new Example::EquationSetFactory);
+    Example::BCStrategyFactory bc_factory;
+    const std::size_t workset_size = 10;
+    const int discretization_order = 1;
+
+    Teuchos::RCP<Teuchos::ParameterList> ipb = Teuchos::parameterList("Physics Blocks");
+    std::vector<panzer::BC> bcs;
+    std::vector<Teuchos::RCP<panzer::PhysicsBlock> > physicsBlocks;
+
+    std::vector<std::string> eBlocks;
+    mesh->getElementBlockNames(eBlocks);
+
+    std::vector<std::string> sidesets;
+    mesh->getSidesetNames(sidesets);
+
+    // set physics and boundary conditions
+    {
+      bool build_transient_support = false;
+
+      const int integration_order = 10;
+      Teuchos::ParameterList& p = ipb->sublist("Poisson Physics");
+      p.set("Type","Poisson");
+      p.set("Model ID","solid");
+      p.set("Basis Type","HGrad");
+      p.set("Basis Order",discretization_order);
+      p.set("Integration Order",integration_order);
+
+      // GH: double-check. this assumes we impose Dirichlet BCs on all boundaries of all physics blocks
+      // which may potentially assign Dirichlet BCs to internal block boundaries, which is undesirable
+      for(size_t i=0; i<eBlocks.size(); ++i)
+      {
+        for(size_t j=0; j<sidesets.size(); ++j)
+        {
+          std::size_t bc_id = i;
+          panzer::BCType bctype = panzer::BCT_Dirichlet;
+          std::string sideset_id = sidesets[j];
+          std::string element_block_id = eBlocks[i];
+          std::string dof_name = "TEMPERATURE";
+          std::string strategy = "Constant";
+          double value = 0.0;
+          Teuchos::ParameterList p;
+          p.set("Value",value);
+          panzer::BC bc(bc_id, bctype, sideset_id, element_block_id, dof_name,
+                        strategy, p);
+          bcs.push_back(bc);
+        }
+        const panzer::CellData volume_cell_data(workset_size, mesh->getCellTopology(eBlocks[i]));
+
+        // GobalData sets ostream and parameter interface to physics
+        Teuchos::RCP<panzer::GlobalData> gd = panzer::createGlobalData();
+
+        // Can be overridden by the equation set
+        int default_integration_order = 1;
+
+        // the physics block nows how to build and register evaluator with the field manager
+        Teuchos::RCP<panzer::PhysicsBlock> pb
+        = Teuchos::rcp(new panzer::PhysicsBlock(ipb,
+                                                eBlocks[i],
+                                                default_integration_order,
+                                                volume_cell_data,
+                                                eqset_factory,
+                                                gd,
+                                                build_transient_support));
+
+        // we can have more than one physics block, one per element block
+        physicsBlocks.push_back(pb);
+      }
+      panzer::checkBCConsistency(eBlocks,sidesets,bcs);
+    }
+
+
+    // finish building mesh, set required field variables and mesh bulk data
+    ////////////////////////////////////////////////////////////////////////
+
+    for(size_t i=0; i<physicsBlocks.size(); ++i)
+    {
+      Teuchos::RCP<panzer::PhysicsBlock> pb = physicsBlocks[i]; // we are assuming only one physics block
+
+      const std::vector<panzer::StrPureBasisPair> & blockFields = pb->getProvidedDOFs();
+
+      // insert all fields into a set
+      std::set<panzer::StrPureBasisPair,panzer::StrPureBasisComp> fieldNames;
+      fieldNames.insert(blockFields.begin(),blockFields.end());
+
+      // add basis to DOF manager: block specific
+      std::set<panzer::StrPureBasisPair,panzer::StrPureBasisComp>::const_iterator fieldItr;
+      for (fieldItr=fieldNames.begin();fieldItr!=fieldNames.end();++fieldItr)
+        mesh->addSolutionField(fieldItr->first,pb->elementBlockID());
+    }
+    mesh_factory->completeMeshConstruction(*mesh,MPI_COMM_WORLD); // this is where the mesh refinements are applied
+
+    unsigned int dimension = mesh->getDimension();
+    if(print_debug_info)
+      std::cout << "Using dimension = " << dimension << std::endl;
+
+    // build DOF Manager and linear object factory
+    /////////////////////////////////////////////////////////////
+
+    tm = Teuchos::null;
+    tm = rcp(new Teuchos::TimeMonitor(*Teuchos::TimeMonitor::getNewTimer("Driver: 2 - Build DOF Manager and Worksets")));
+    // build the connection manager
+    const Teuchos::RCP<panzer::ConnManager> conn_manager
     = Teuchos::rcp(new panzer_stk::STKConnManager(mesh));
 
-  panzer::DOFManagerFactory globalIndexerFactory;
-  Teuchos::RCP<panzer::GlobalIndexer> dofManager 
+    panzer::DOFManagerFactory globalIndexerFactory;
+    Teuchos::RCP<panzer::GlobalIndexer> dofManager
     = globalIndexerFactory.buildGlobalIndexer(Teuchos::opaqueWrapper(MPI_COMM_WORLD),physicsBlocks,conn_manager);
 
-  // construct some linear algebra object, build object to pass to evaluators
-  Teuchos::RCP<panzer::LinearObjFactory<panzer::Traits> > linObjFactory
+    // construct some linear algebra object, build object to pass to evaluators
+    Teuchos::RCP<panzer::LinearObjFactory<panzer::Traits> > linObjFactory
     = Teuchos::rcp(new panzer::TpetraLinearObjFactory<panzer::Traits,ST,LO,GO>(comm.getConst(),dofManager));
 
-  /*
-  ArrayRCP<GO> dofs_to_region;
-  // Construct the DofToRegion map based on the Percept mesh and the DOF manager
-  {
-    std::vector<GO> gids;
-    dofManager->getElementGIDs((LO) 0, gids);
-    std::cout << "Element 0 GIDs: " << gids((int) 0); 
-    for(GO i=1; i<gids.size(); ++i)
-    {
-      std::cout << ", " << gids(static_cast<LO>(i));
-    }
-    std::cout << std::endl;
-  }
-  */
+    // build worksets
+    ////////////////////////////////////////////////////////
 
-  // build worksets
-  ////////////////////////////////////////////////////////
-
-  Teuchos::RCP<panzer_stk::WorksetFactory> wkstFactory
+    Teuchos::RCP<panzer_stk::WorksetFactory> wkstFactory
     = Teuchos::rcp(new panzer_stk::WorksetFactory(mesh)); // build STK workset factory
-  Teuchos::RCP<panzer::WorksetContainer> wkstContainer     // attach it to a workset container (uses lazy evaluation)
+    Teuchos::RCP<panzer::WorksetContainer> wkstContainer     // attach it to a workset container (uses lazy evaluation)
     = Teuchos::rcp(new panzer::WorksetContainer);
-  wkstContainer->setFactory(wkstFactory);
-  for(size_t i=0;i<physicsBlocks.size();i++) 
-    wkstContainer->setNeeds(physicsBlocks[i]->elementBlockID(),physicsBlocks[i]->getWorksetNeeds());
-  wkstContainer->setWorksetSize(workset_size);
-  wkstContainer->setGlobalIndexer(dofManager);
+    wkstContainer->setFactory(wkstFactory);
+    for(size_t i=0;i<physicsBlocks.size();i++)
+      wkstContainer->setNeeds(physicsBlocks[i]->elementBlockID(),physicsBlocks[i]->getWorksetNeeds());
+    wkstContainer->setWorksetSize(workset_size);
+    wkstContainer->setGlobalIndexer(dofManager);
 
 
-  // Setup response library for checking the error in this manufactered solution
-  ////////////////////////////////////////////////////////////////////////
+    /**********************************************************************************/
+    /********************************** CONSTRUCT REGIONS *****************************/
+    /**********************************************************************************/
 
-  Teuchos::RCP<panzer::ResponseLibrary<panzer::Traits> > errorResponseLibrary
+    unsigned int children_per_element = 1 << (dimension*mesh_refinements);
+    if(print_debug_info)
+      std::cout << "Number of mesh children = " << children_per_element << std::endl;
+
+    // initialize data here that we will use for the region MG solver
+    std::vector<GO> child_element_gids; // these don't always start at 0, and changes I'm making to Panzer keep changing this, so I'll store them for now
+    std::vector<GO> child_element_region_gids;
+
+    // do not run region MG if we delete parent elements or if we do not refine the mesh regularly
+    if(mesh_refinements>0 && !delete_parent_elements)
+    {
+      // get the Percept mesh from Panzer
+      Teuchos::RCP<percept::PerceptMesh> refinedMesh = mesh->getRefinedMesh();
+      if(print_percept_mesh)
+        refinedMesh->print_info(*out,"",1,true);
+
+      //    Teuchos::RCP<percept::URP_Heterogeneous_3D> breakPattern = Teuchos::rcp(new percept::URP_Heterogeneous_3D(*refinedMesh));
+      //    percept::UniformRefiner breaker(*refinedMesh,*breakPattern);
+      //    breaker.deleteParentElements();
+
+      // ids are linear within stk, but we need an offset because the original mesh info comes first
+      size_t node_id_start = 0;
+      {
+        const stk::mesh::BucketVector & buckets = refinedMesh->get_bulk_data()->buckets(refinedMesh->node_rank());
+        stk::mesh::Bucket & bucket = **buckets.begin() ;
+        node_id_start = refinedMesh->id(bucket[0]);
+        if(print_debug_info)
+          std::cout << "Starting node id = " << node_id_start << std::endl;
+      }
+
+      size_t elem_id_start = 0;
+      {
+        const stk::mesh::BucketVector & buckets = refinedMesh->get_bulk_data()->buckets(refinedMesh->element_rank());
+        stk::mesh::Bucket & bucket = **buckets.begin() ;
+        elem_id_start = refinedMesh->id(bucket[0]);
+        if(print_debug_info)
+          std::cout << "Starting element id = " << elem_id_start << std::endl;
+      }
+
+
+      {
+        const stk::mesh::BucketVector & buckets = refinedMesh->get_bulk_data()->buckets(refinedMesh->element_rank());
+        int npar=0;
+        int nchild=0;
+        for (stk::mesh::BucketVector::const_iterator k = buckets.begin(); k != buckets.end(); ++k)
+        {
+          stk::mesh::Bucket & bucket = **k ;
+          if(print_debug_info)
+            std::cout << "New bucket" << std::endl;
+
+          const unsigned num_elements_in_bucket = bucket.size();
+          for (unsigned iElement = 0; iElement < num_elements_in_bucket; iElement++)
+          {
+            stk::mesh::Entity element = bucket[iElement];
+            if (!refinedMesh->isParentElement(element, false))
+            {
+              ++nchild;
+
+              // this is the important part here. take the id of the element and the id of the element's root
+              child_element_gids.push_back(refinedMesh->id(element));
+              child_element_region_gids.push_back(refinedMesh->id(refinedMesh->rootOfTree(element)));
+
+              if(print_debug_info)
+                std::cout << "Stk Element = " << element << std::endl;
+
+              percept::MyPairIterRelation elem_nodes ( *refinedMesh, element,  stk::topology::NODE_RANK);
+
+              for (unsigned i_node = 0; i_node < elem_nodes.size(); i_node++)
+              {
+                stk::mesh::Entity node = elem_nodes[i_node].entity();
+                if(print_debug_info)
+                  std::cout << "Stk Node = " << node << std::endl;
+
+                //std::cout << "node " << node << std::endl;
+                //        double *f_data = refinedMesh->field_data(field, node, null_u);
+                //        for (int i_stride=0; i_stride < refinedMesh->get_spatial_dim(); i_stride++)
+                //        {
+                //        std::cout << f_data[i_stride] << " ";
+                //      }
+                //          std::cout << std::endl;
+              }
+            }
+            else
+            {
+              std::cout << "parent= " << refinedMesh->id(element) << std::endl;
+            }
+          }
+        }
+      }
+    }
+
+    if(print_debug_info)
+    {
+      for(unsigned int i=0; i<child_element_gids.size(); ++i)
+      {
+        std::cout << "child= " << child_element_gids[i] << " parent= " << child_element_region_gids[i] << std::endl;
+      }
+    }
+
+    // next we need to get the LIDs
+
+    // Setup response library for checking the error in this manufactered solution
+    ////////////////////////////////////////////////////////////////////////
+
+    Teuchos::RCP<panzer::ResponseLibrary<panzer::Traits> > errorResponseLibrary
     = Teuchos::rcp(new panzer::ResponseLibrary<panzer::Traits>(wkstContainer,dofManager,linObjFactory));
 
-  {
-    const int integration_order = 10;
-    
-    panzer::FunctionalResponse_Builder<int,int> builder;
-    builder.comm = MPI_COMM_WORLD;
-    builder.cubatureDegree = integration_order;
-    builder.requiresCellIntegral = true;
-    builder.quadPointField = "TEMPERATURE_L2_ERROR";
-
-    errorResponseLibrary->addResponse("L2 Error",eBlocks,builder);
-
-    /*    builder.comm = MPI_COMM_WORLD;
-    builder.cubatureDegree = integration_order;
-    builder.requiresCellIntegral = true;
-    builder.quadPointField = "TEMPERATURE_H1_ERROR";
-
-    errorResponseLibrary->addResponse("H1 Error",eBlocks,builder);
-    */
-  }
-
-
-  // setup closure model
-  /////////////////////////////////////////////////////////////
- 
-  // Add in the application specific closure model factory
-  panzer::ClosureModelFactory_TemplateManager<panzer::Traits> cm_factory; 
-  Example::ClosureModelFactory_TemplateBuilder cm_builder;
-  cm_factory.buildObjects(cm_builder);
-
-  Teuchos::ParameterList closure_models("Closure Models");
-  {
-    closure_models.sublist("solid").sublist("SOURCE_TEMPERATURE").set<std::string>("Type","SIMPLE SOURCE"); // a constant source
-    // SOURCE_TEMPERATURE field is required by the PoissonEquationSet
-    // required for error calculation
-    closure_models.sublist("solid").sublist("TEMPERATURE_L2_ERROR").set<std::string>("Type","L2 ERROR_CALC");
-    closure_models.sublist("solid").sublist("TEMPERATURE_L2_ERROR").set<std::string>("Field A","TEMPERATURE");
-    closure_models.sublist("solid").sublist("TEMPERATURE_L2_ERROR").set<std::string>("Field B","TEMPERATURE_EXACT");
-
-    /*
-    closure_models.sublist("solid").sublist("TEMPERATURE_H1_ERROR").set<std::string>("Type","H1 ERROR_CALC");
-    closure_models.sublist("solid").sublist("TEMPERATURE_H1_ERROR").set<std::string>("Field A","TEMPERATURE");
-    closure_models.sublist("solid").sublist("TEMPERATURE_H1_ERROR").set<std::string>("Field B","TEMPERATURE_EXACT");
-    */
-    closure_models.sublist("solid").sublist("TEMPERATURE_EXACT").set<std::string>("Type","TEMPERATURE_EXACT");
-  }
-
-  Teuchos::ParameterList user_data("User Data"); // user data can be empty here
-
-
-  // setup field manager builder
-  /////////////////////////////////////////////////////////////
-
-  Teuchos::RCP<panzer::FieldManagerBuilder> fmb 
-    = Teuchos::rcp(new panzer::FieldManagerBuilder);
-  fmb->setWorksetContainer(wkstContainer);
-  fmb->setupVolumeFieldManagers(physicsBlocks,cm_factory,closure_models,*linObjFactory,user_data);
-  fmb->setupBCFieldManagers(bcs,physicsBlocks,*eqset_factory,cm_factory,bc_factory,closure_models,
-                            *linObjFactory,user_data);
-
-  fmb->writeVolumeGraphvizDependencyFiles("Poisson", physicsBlocks);
-
-
-  // setup assembly engine
-  /////////////////////////////////////////////////////////////
-
-  panzer::AssemblyEngine_TemplateManager<panzer::Traits> ae_tm;
-  panzer::AssemblyEngine_TemplateBuilder builder(fmb,linObjFactory);
-  ae_tm.buildObjects(builder);
-
-
-  // Finalize construcition of STK writer response library
-  /////////////////////////////////////////////////////////////
-  {
-    user_data.set<int>("Workset Size",workset_size);
-    errorResponseLibrary->buildResponseEvaluators(physicsBlocks,
-                                                  cm_factory,
-                                                  closure_models,
-                                                  user_data);
-  }
-
-
-  // assemble linear system
-  /////////////////////////////////////////////////////////////
-
-  Teuchos::RCP<panzer::LinearObjContainer> ghostCont = linObjFactory->buildGhostedLinearObjContainer();
-  Teuchos::RCP<panzer::LinearObjContainer> container = linObjFactory->buildLinearObjContainer();
-  linObjFactory->initializeGhostedContainer(panzer::LinearObjContainer::X |
-                                            panzer::LinearObjContainer::F |
-                                            panzer::LinearObjContainer::Mat,*ghostCont);
-  linObjFactory->initializeContainer(panzer::LinearObjContainer::X |
-                                     panzer::LinearObjContainer::F |
-                                     panzer::LinearObjContainer::Mat,*container);
-  ghostCont->initialize();
-  container->initialize();
-
-  panzer::AssemblyEngineInArgs input(ghostCont,container);
-  input.alpha = 0;
-  input.beta = 1;
-
-  // evaluate physics: This does both the Jacobian and residual at once
-  ae_tm.getAsObject<panzer::Traits::Jacobian>()->evaluate(input);
-
-
-  // solve linear system
-  /////////////////////////////////////////////////////////////
-
-
-  // GH: convert this to our MueLu region solver
-  // convert generic linear object container to tpetra container
-  Teuchos::RCP<panzer::TpetraLinearObjContainer<ST,LO,GO> > tp_container
-    = Teuchos::rcp_dynamic_cast<panzer::TpetraLinearObjContainer<ST,LO,GO> >(container);
-
-  // Setup the linear solve: notice A is used directly 
-  Belos::LinearProblem<ST,MV,OP> problem(tp_container->get_A(), tp_container->get_x(), tp_container->get_f());
-
-  problem.setProblem();
-
-  Teuchos::RCP<Teuchos::ParameterList> pl_belos = Teuchos::rcp(new Teuchos::ParameterList());
-  pl_belos->set("Maximum Iterations", 1000);
-  pl_belos->set("Convergence Tolerance", 1e-9);
-
-  // build the solver  
-  Belos::PseudoBlockGmresSolMgr<ST,MV,OP> solver(Teuchos::rcpFromRef(problem), pl_belos);
-
-  // solve the linear system
-  solver.solve();
-
-  // scale by -1 since we solved a residual correction
-  tp_container->get_x()->scale(-1.0);
-  std::cout << "Solution local length: " << tp_container->get_x()->getLocalLength() << std::endl;
-  std::cout << "Solution norm: " << tp_container->get_x()->norm2() << std::endl;
-  
-  // output data (optional)
-  /////////////////////////////////////////////////////////////
-
-  // write out solution to matrix
-  {
-    // redistribute solution vector to ghosted vector
-    linObjFactory->globalToGhostContainer(*container,*ghostCont, panzer::TpetraLinearObjContainer<ST,LO,GO>::X 
-					                       | panzer::TpetraLinearObjContainer<ST,LO,GO>::DxDt); 
-
-    // get X Tpetra_Vector from ghosted container
-    //Teuchos::RCP<panzer::TpetraLinearObjContainer<ST,LO,GO> > tp_ghostCont = Teuchos::rcp_dynamic_cast<panzer::TpetraLinearObjContainer<ST,LO,GO> >(ghostCont);
-    //panzer_stk::write_solution_data(*dofManager,*mesh,*tp_ghostCont->get_x());
-
-    // Due to multiple instances of this test being run at the same
-    // time (one for each celltype and each order), we need to
-    // differentiate output to prevent race conditions on output
-    // file. Multiple runs for different mesh refinement levels for
-    // the same celltype/order are ok as they are staged one after
-    // another in the ADD_ADVANCED_TEST cmake macro.
-    std::ostringstream filename;
-    filename << "output_" << celltype << "_p" << discretization_order << ".exo";
-    mesh->writeToExodus(filename.str());
-  }
-
-  // compute error norm
-  /////////////////////////////////////////////////////////////
-
-  if(true)
-  {
-    panzer::AssemblyEngineInArgs respInput(ghostCont,container);
-    respInput.alpha = 0;
-    respInput.beta = 1;
-
-    Teuchos::RCP<panzer::ResponseBase> l2_resp = errorResponseLibrary->getResponse<panzer::Traits::Residual>("L2 Error");
-    Teuchos::RCP<panzer::Response_Functional<panzer::Traits::Residual> > l2_resp_func 
-      = Teuchos::rcp_dynamic_cast<panzer::Response_Functional<panzer::Traits::Residual> >(l2_resp);
-    Teuchos::RCP<Thyra::VectorBase<double> > l2_respVec = Thyra::createMember(l2_resp_func->getVectorSpace());
-    l2_resp_func->setVector(l2_respVec);
-
-    /*
-    Teuchos::RCP<panzer::ResponseBase> h1_resp = errorResponseLibrary->getResponse<panzer::Traits::Residual>("H1 Error");
-    Teuchos::RCP<panzer::Response_Functional<panzer::Traits::Residual> > h1_resp_func 
-      = Teuchos::rcp_dynamic_cast<panzer::Response_Functional<panzer::Traits::Residual> >(h1_resp);
-    Teuchos::RCP<Thyra::VectorBase<double> > h1_respVec = Thyra::createMember(h1_resp_func->getVectorSpace());
-    h1_resp_func->setVector(h1_respVec);
-    */
-
-    errorResponseLibrary->addResponsesToInArgs<panzer::Traits::Residual>(respInput);
-    errorResponseLibrary->evaluate<panzer::Traits::Residual>(respInput);
-
-    if(myRank == 0)
     {
-      *out << "This is the Basis Order" << std::endl;
-      *out << "Basis Order = " << discretization_order << std::endl;
-      *out << "This is the L2 Error" << std::endl;
-      *out << "L2 Error = " << sqrt(l2_resp_func->value) << std::endl;
-      //*out << "This is the H1 Error" << std::endl;
-      //*out << "H1 Error = " << sqrt(h1_resp_func->value) << std::endl;
-    }
-  }
+      const int integration_order = 10;
 
-  tm = Teuchos::null;
-  globalTimeMonitor = Teuchos::null;
+      panzer::FunctionalResponse_Builder<int,int> builder;
+      builder.comm = MPI_COMM_WORLD;
+      builder.cubatureDegree = integration_order;
+      builder.requiresCellIntegral = true;
+      builder.quadPointField = "TEMPERATURE_L2_ERROR";
 
-  if (showTimerSummary)
-  {
-    RCP<ParameterList> reportParams = rcp(new ParameterList);
-    const std::string filter = "";
-    if (useStackedTimer) {
-      Teuchos::StackedTimer::OutputOptions options;
-      options.output_fraction = options.output_histogram = options.output_minmax = true;
-      stacked_timer->report(*out, comm, options);
-    } else {
-      std::ios_base::fmtflags ff(out->flags());
-      Teuchos::TimeMonitor::report(comm.ptr(), *out, filter, reportParams);
-      *out << std::setiosflags(ff);
+      errorResponseLibrary->addResponse("L2 Error",eBlocks,builder);
+
+      // GH: comment out H1 errors for now while I work on other aspects
+      /*
+      builder.comm = MPI_COMM_WORLD;
+      builder.cubatureDegree = integration_order;
+      builder.requiresCellIntegral = true;
+      builder.quadPointField = "TEMPERATURE_H1_ERROR";
+
+      errorResponseLibrary->addResponse("H1 Error",eBlocks,builder);
+       */
     }
-  }
+
+
+    // setup closure model
+    /////////////////////////////////////////////////////////////
+
+    // Add in the application specific closure model factory
+    panzer::ClosureModelFactory_TemplateManager<panzer::Traits> cm_factory;
+    Example::ClosureModelFactory_TemplateBuilder cm_builder;
+    cm_factory.buildObjects(cm_builder);
+
+    Teuchos::ParameterList closure_models("Closure Models");
+    {
+      closure_models.sublist("solid").sublist("SOURCE_TEMPERATURE").set<std::string>("Type","SIMPLE SOURCE"); // a constant source
+      // SOURCE_TEMPERATURE field is required by the PoissonEquationSet
+      // required for error calculation
+      closure_models.sublist("solid").sublist("TEMPERATURE_L2_ERROR").set<std::string>("Type","L2 ERROR_CALC");
+      closure_models.sublist("solid").sublist("TEMPERATURE_L2_ERROR").set<std::string>("Field A","TEMPERATURE");
+      closure_models.sublist("solid").sublist("TEMPERATURE_L2_ERROR").set<std::string>("Field B","TEMPERATURE_EXACT");
+
+      // GH: comment out H1 errors for now while I work on other aspects
+      /*
+      closure_models.sublist("solid").sublist("TEMPERATURE_H1_ERROR").set<std::string>("Type","H1 ERROR_CALC");
+      closure_models.sublist("solid").sublist("TEMPERATURE_H1_ERROR").set<std::string>("Field A","TEMPERATURE");
+      closure_models.sublist("solid").sublist("TEMPERATURE_H1_ERROR").set<std::string>("Field B","TEMPERATURE_EXACT");
+       */
+      closure_models.sublist("solid").sublist("TEMPERATURE_EXACT").set<std::string>("Type","TEMPERATURE_EXACT");
+    }
+
+    Teuchos::ParameterList user_data("User Data"); // user data can be empty here
+
+
+    // setup field manager builder
+    /////////////////////////////////////////////////////////////
+
+    Teuchos::RCP<panzer::FieldManagerBuilder> fmb
+    = Teuchos::rcp(new panzer::FieldManagerBuilder);
+    fmb->setWorksetContainer(wkstContainer);
+    fmb->setupVolumeFieldManagers(physicsBlocks,cm_factory,closure_models,*linObjFactory,user_data);
+    fmb->setupBCFieldManagers(bcs,physicsBlocks,*eqset_factory,cm_factory,bc_factory,closure_models,
+                              *linObjFactory,user_data);
+
+    fmb->writeVolumeGraphvizDependencyFiles("Poisson", physicsBlocks);
+
+
+    // setup assembly engine
+    /////////////////////////////////////////////////////////////
+
+    panzer::AssemblyEngine_TemplateManager<panzer::Traits> ae_tm;
+    panzer::AssemblyEngine_TemplateBuilder builder(fmb,linObjFactory);
+    ae_tm.buildObjects(builder);
+
+
+    // Finalize construction of STK writer response library
+    /////////////////////////////////////////////////////////////
+    {
+      user_data.set<int>("Workset Size",workset_size);
+      errorResponseLibrary->buildResponseEvaluators(physicsBlocks,
+                                                    cm_factory,
+                                                    closure_models,
+                                                    user_data);
+    }
+
+
+    // assemble linear system
+    /////////////////////////////////////////////////////////////
+
+    Teuchos::RCP<panzer::LinearObjContainer> ghostCont = linObjFactory->buildGhostedLinearObjContainer();
+    Teuchos::RCP<panzer::LinearObjContainer> container = linObjFactory->buildLinearObjContainer();
+    linObjFactory->initializeGhostedContainer(panzer::LinearObjContainer::X |
+                                              panzer::LinearObjContainer::F |
+                                              panzer::LinearObjContainer::Mat,*ghostCont);
+    linObjFactory->initializeContainer(panzer::LinearObjContainer::X |
+                                       panzer::LinearObjContainer::F |
+                                       panzer::LinearObjContainer::Mat,*container);
+    ghostCont->initialize();
+    container->initialize();
+
+    panzer::AssemblyEngineInArgs input(ghostCont,container);
+    input.alpha = 0;
+    input.beta = 1;
+
+    // evaluate physics: This does both the Jacobian and residual at once
+    ae_tm.getAsObject<panzer::Traits::Jacobian>()->evaluate(input);
+
+
+    // solve the linear system
+    /////////////////////////////////////////////////////////////
+
+    // convert generic linear object container to tpetra container
+    Teuchos::RCP<panzer::TpetraLinearObjContainer<ST,LO,GO> > tp_container = Teuchos::rcp_dynamic_cast<panzer::TpetraLinearObjContainer<ST,LO,GO> >(container);
+
+    Teuchos::RCP<MueLu::TpetraOperator<ST,LO,GO,NT> > mueLuPreconditioner;
+
+    if(xmlFileName.size())
+      mueLuPreconditioner = MueLu::CreateTpetraPreconditioner(Teuchos::rcp_dynamic_cast<Tpetra::Operator<ST,LO,GO,NT> >(tp_container->get_A()), xmlFileName);
+    else
+    {
+      Teuchos::ParameterList mueLuParamList;
+      mueLuParamList.set("verbosity", "low");
+      mueLuParamList.set("max levels", 3);
+      mueLuParamList.set("coarse: max size", 10);
+      mueLuParamList.set("multigrid algorithm", "sa");
+      mueLuPreconditioner = MueLu::CreateTpetraPreconditioner(Teuchos::rcp_dynamic_cast<Tpetra::Operator<ST,LO,GO,NT> >(tp_container->get_A()), mueLuParamList);
+    }
+
+    // Setup the linear solve
+    Belos::LinearProblem<ST,MV,OP> problem(tp_container->get_A(), tp_container->get_x(), tp_container->get_f());
+    problem.setLeftPrec(mueLuPreconditioner);
+    problem.setProblem();
+
+    Teuchos::RCP<Teuchos::ParameterList> pl_belos = Teuchos::rcp(new Teuchos::ParameterList());
+    pl_belos->set("Maximum Iterations", 1000);
+    pl_belos->set("Convergence Tolerance", 1e-9);
+
+    // build the solver
+    Belos::PseudoBlockGmresSolMgr<ST,MV,OP> solver(Teuchos::rcpFromRef(problem), pl_belos);
+
+    // solve the linear system
+    solver.solve();
+
+    // scale by -1 since we solved a residual correction
+    tp_container->get_x()->scale(-1.0);
+    std::cout << "Solution local length: " << tp_container->get_x()->getLocalLength() << std::endl;
+    std::cout << "Solution norm: " << tp_container->get_x()->norm2() << std::endl;
+
+    // output data (optional)
+    /////////////////////////////////////////////////////////////
+
+    // write the solution to matrix
+    {
+      // redistribute solution vector to ghosted vector
+      linObjFactory->globalToGhostContainer(*container,*ghostCont, panzer::TpetraLinearObjContainer<ST,LO,GO>::X
+                                            | panzer::TpetraLinearObjContainer<ST,LO,GO>::DxDt);
+
+      // get X Tpetra_Vector from ghosted container
+      //Teuchos::RCP<panzer::TpetraLinearObjContainer<ST,LO,GO> > tp_ghostCont = Teuchos::rcp_dynamic_cast<panzer::TpetraLinearObjContainer<ST,LO,GO> >(ghostCont);
+      //panzer_stk::write_solution_data(*dofManager,*mesh,*tp_ghostCont->get_x());
+
+      // Due to multiple instances of this test being run at the same
+      // time (one for each celltype and each order), we need to
+      // differentiate output to prevent race conditions on output
+      // file. Multiple runs for different mesh refinement levels for
+      // the same celltype/order are ok as they are staged one after
+      // another in the ADD_ADVANCED_TEST cmake macro.
+      std::ostringstream filename;
+      filename << "output_" << celltype << "_p" << discretization_order << ".exo";
+      mesh->writeToExodus(filename.str());
+    }
+
+    // compute the error of the finite element solution
+    /////////////////////////////////////////////////////////////
+
+    if(true)
+    {
+      panzer::AssemblyEngineInArgs respInput(ghostCont,container);
+      respInput.alpha = 0;
+      respInput.beta = 1;
+
+      Teuchos::RCP<panzer::ResponseBase> l2_resp = errorResponseLibrary->getResponse<panzer::Traits::Residual>("L2 Error");
+      Teuchos::RCP<panzer::Response_Functional<panzer::Traits::Residual> > l2_resp_func
+      = Teuchos::rcp_dynamic_cast<panzer::Response_Functional<panzer::Traits::Residual> >(l2_resp);
+      Teuchos::RCP<Thyra::VectorBase<double> > l2_respVec = Thyra::createMember(l2_resp_func->getVectorSpace());
+      l2_resp_func->setVector(l2_respVec);
+
+      /*
+      Teuchos::RCP<panzer::ResponseBase> h1_resp = errorResponseLibrary->getResponse<panzer::Traits::Residual>("H1 Error");
+      Teuchos::RCP<panzer::Response_Functional<panzer::Traits::Residual> > h1_resp_func
+        = Teuchos::rcp_dynamic_cast<panzer::Response_Functional<panzer::Traits::Residual> >(h1_resp);
+      Teuchos::RCP<Thyra::VectorBase<double> > h1_respVec = Thyra::createMember(h1_resp_func->getVectorSpace());
+      h1_resp_func->setVector(h1_respVec);
+       */
+
+      errorResponseLibrary->addResponsesToInArgs<panzer::Traits::Residual>(respInput);
+      errorResponseLibrary->evaluate<panzer::Traits::Residual>(respInput);
+
+      if(myRank == 0)
+      {
+        *out << "This is the Basis Order" << std::endl;
+        *out << "Basis Order = " << discretization_order << std::endl;
+        *out << "This is the L2 Error" << std::endl;
+        *out << "L2 Error = " << sqrt(l2_resp_func->value) << std::endl;
+        //*out << "This is the H1 Error" << std::endl;
+        //*out << "H1 Error = " << sqrt(h1_resp_func->value) << std::endl;
+      }
+    }
+
+    tm = Teuchos::null;
+    globalTimeMonitor = Teuchos::null;
+
+    if (showTimerSummary)
+    {
+      RCP<ParameterList> reportParams = rcp(new ParameterList);
+      const std::string filter = "";
+      if (useStackedTimer) {
+        Teuchos::StackedTimer::OutputOptions options;
+        options.output_fraction = options.output_histogram = options.output_minmax = true;
+        stacked_timer->report(*out, comm, options);
+      } else {
+        std::ios_base::fmtflags ff(out->flags());
+        Teuchos::TimeMonitor::report(comm.ptr(), *out, filter, reportParams);
+        *out << std::setiosflags(ff);
+      }
+    }
 
   } // Kokkos scope
   Kokkos::finalize();

--- a/packages/trilinoscouplings/examples/scaling/muelu_region_poisson.cpp
+++ b/packages/trilinoscouplings/examples/scaling/muelu_region_poisson.cpp
@@ -218,7 +218,6 @@ int main(int argc, char *argv[]) {
     bool profileSetup = false;                               clp.setOption("cuda-profile-setup", "no-cuda-profile-setup", &profileSetup, "enable CUDA profiling for setup");
     bool profileSolve = false;                               clp.setOption("cuda-profile-solve", "no-cuda-profile-solve", &profileSolve, "enable CUDA profiling for solve");
 #endif
-
     // debug options
     bool print_percept_mesh           = false;               clp.setOption("print-percept-mesh", "no-print-percept-mesh", &print_percept_mesh, "Calls perceptMesh's print_info routine");
     bool print_debug_info             = false;               clp.setOption("print-debug-info", "no-print-debug-info", &print_debug_info, "Print more debugging information");
@@ -238,8 +237,7 @@ int main(int argc, char *argv[]) {
     case Teuchos::CommandLineProcessor::PARSE_SUCCESSFUL:          break;
     }
 
-    TEUCHOS_TEST_FOR_EXCEPTION(xmlFileName != "" && yamlFileName != "", std::runtime_error,
-                               "Cannot provide both xml and yaml input files");
+    TEUCHOS_TEST_FOR_EXCEPTION(xmlFileName != "" && yamlFileName != "", std::runtime_error, "Cannot provide both xml and yaml input files");
 
     // get xml file from command line if provided, otherwise use default
     std::string  xmlSolverInFileName(xmlFileName);
@@ -248,8 +246,8 @@ int main(int argc, char *argv[]) {
     Teuchos::ParameterList inputSolverList;
 
     if(xmlSolverInFileName.length()) {
-        out << "\nReading parameter list from the XML file \""<<xmlSolverInFileName<<"\" ...\n" << std::endl;
-      Teuchos::updateParametersFromXmlFile (xmlSolverInFileName, Teuchos::ptr(&inputSolverList));
+      out << "\nReading parameter list from the XML file \"" << xmlSolverInFileName << "\" ...\n" << std::endl;
+      Teuchos::updateParametersFromXmlFile(xmlSolverInFileName, Teuchos::ptr(&inputSolverList));
     }
     else {
       out << "Using default solver values ..." << std::endl;

--- a/packages/trilinoscouplings/examples/scaling/muelu_region_poisson.cpp
+++ b/packages/trilinoscouplings/examples/scaling/muelu_region_poisson.cpp
@@ -578,7 +578,7 @@ int main(int argc, char *argv[]) {
           const unsigned int i_elem = region_cells_per_dim*region_cells_per_dim*k + region_cells_per_dim*j + i;
 
           // the bottom-left corner of a cell is always inside the region when following lexicographic ordering
-          quasiRegionGIDs[i_node] = LIDs(i_elem,0);
+          quasiRegionGIDs[i_node] = LIDs(region_cells_lexicographic_order[i_elem],0);
           x_coords[i_node] = vertices(i_elem,0,0);
           y_coords[i_node] = vertices(i_elem,0,1);
           z_coords[i_node] = vertices(i_elem,0,2);
@@ -586,30 +586,30 @@ int main(int argc, char *argv[]) {
           // if we're on the +z side of a region
           if(k==region_cells_per_dim-1)
           {
-            quasiRegionGIDs[i_node+plane_offset] = LIDs(i_elem,4);
+            quasiRegionGIDs[i_node+plane_offset] = LIDs(region_cells_lexicographic_order[i_elem],4);
             x_coords[i_node+plane_offset] = vertices(i_elem,4,0);
             y_coords[i_node+plane_offset] = vertices(i_elem,4,1);
             z_coords[i_node+plane_offset] = vertices(i_elem,4,2);
             // if we're on a +yz edge
             if(j==region_cells_per_dim-1)
             {
-              quasiRegionGIDs[i_node+plane_offset+line_offset] = LIDs(i_elem,6);
-              x_coords[i_node+plane_offset+line_offset] = vertices(i_elem,6,0);
-              y_coords[i_node+plane_offset+line_offset] = vertices(i_elem,6,1);
-              z_coords[i_node+plane_offset+line_offset] = vertices(i_elem,6,2);
+              quasiRegionGIDs[i_node+plane_offset+line_offset] = LIDs(region_cells_lexicographic_order[i_elem],7);
+              x_coords[i_node+plane_offset+line_offset] = vertices(i_elem,7,0);
+              y_coords[i_node+plane_offset+line_offset] = vertices(i_elem,7,1);
+              z_coords[i_node+plane_offset+line_offset] = vertices(i_elem,7,2);
               // if we're on an +xyz corner
               if(i==region_cells_per_dim-1)
               {
-                quasiRegionGIDs[i_node+plane_offset+line_offset+1] = LIDs(i_elem,7);
-                x_coords[i_node+plane_offset+line_offset+1] = vertices(i_elem,7,0);
-                y_coords[i_node+plane_offset+line_offset+1] = vertices(i_elem,7,1);
-                z_coords[i_node+plane_offset+line_offset+1] = vertices(i_elem,7,2);
+                quasiRegionGIDs[i_node+plane_offset+line_offset+1] = LIDs(region_cells_lexicographic_order[i_elem],6);
+                x_coords[i_node+plane_offset+line_offset+1] = vertices(i_elem,6,0);
+                y_coords[i_node+plane_offset+line_offset+1] = vertices(i_elem,6,1);
+                z_coords[i_node+plane_offset+line_offset+1] = vertices(i_elem,6,2);
               }
             }
-            // if we're on the +xz edge (and not +xyz corner)
-            if(i==region_cells_per_dim-1 && j!=region_cells_per_dim-1)
+            // if we're on the +xz edge
+            if(i==region_cells_per_dim-1)
             {
-              quasiRegionGIDs[i_node+plane_offset+1] = LIDs(i_elem,5);
+              quasiRegionGIDs[i_node+plane_offset+1] = LIDs(region_cells_lexicographic_order[i_elem],5);
               x_coords[i_node+plane_offset+1] = vertices(i_elem,5,0);
               y_coords[i_node+plane_offset+1] = vertices(i_elem,5,1);
               z_coords[i_node+plane_offset+1] = vertices(i_elem,5,2);
@@ -618,14 +618,14 @@ int main(int argc, char *argv[]) {
           // if we're on the +y side of a region
           if(j==region_cells_per_dim-1)
           {
-            quasiRegionGIDs[i_node+line_offset] = LIDs(i_elem,3);
+            quasiRegionGIDs[i_node+line_offset] = LIDs(region_cells_lexicographic_order[i_elem],3);
             x_coords[i_node+line_offset] = vertices(i_elem,3,0);
             y_coords[i_node+line_offset] = vertices(i_elem,3,1);
             z_coords[i_node+line_offset] = vertices(i_elem,3,2);
             // if we're on a +xy edge
             if(i==region_cells_per_dim-1)
             {
-              quasiRegionGIDs[i_node+line_offset+1] = LIDs(i_elem,2);
+              quasiRegionGIDs[i_node+line_offset+1] = LIDs(region_cells_lexicographic_order[i_elem],2);
               x_coords[i_node+line_offset+1] = vertices(i_elem,2,0);
               y_coords[i_node+line_offset+1] = vertices(i_elem,2,1);
               z_coords[i_node+line_offset+1] = vertices(i_elem,2,2);
@@ -634,7 +634,7 @@ int main(int argc, char *argv[]) {
           // if we're on the +x side of a region
           if(i==region_cells_per_dim-1)
           {
-            quasiRegionGIDs[i_node+1] = LIDs(i_elem,1);
+            quasiRegionGIDs[i_node+1] = LIDs(region_cells_lexicographic_order[i_elem],1);
             x_coords[i_node+1] = vertices(i_elem,1,0);
             y_coords[i_node+1] = vertices(i_elem,1,1);
             z_coords[i_node+1] = vertices(i_elem,1,2);
@@ -646,6 +646,8 @@ int main(int argc, char *argv[]) {
     DUMPSTDVECTOR(x_coords, std::cout)
     DUMPSTDVECTOR(y_coords, std::cout)
     DUMPSTDVECTOR(z_coords, std::cout)
+    PRINT_VIEW2(LIDs)
+    DUMPSTDVECTOR(quasiRegionGIDs, std::cout)
     
 
 //     // if we use Percept, this is the strategy to follow.

--- a/packages/trilinoscouplings/examples/scaling/muelu_region_poisson.cpp
+++ b/packages/trilinoscouplings/examples/scaling/muelu_region_poisson.cpp
@@ -147,8 +147,10 @@ int main(int argc, char *argv[]) {
 
 #include <MueLu_UseShortNames.hpp>
 
-  Kokkos::initialize(argc,argv);
-  { // Kokkos scope
+  Teuchos::GlobalMPISession mpiSession(&argc, &argv);
+  Kokkos::initialize (argc, argv);
+  Tpetra::initialize (&argc, &argv);
+  { // Parallel initialization scope
 
 
     ////////////////////////////////////////////////////////////////////////////////////
@@ -167,8 +169,6 @@ int main(int argc, char *argv[]) {
     Teuchos::RCP<Teuchos::FancyOStream> fancydebug = Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
     Teuchos::FancyOStream& debug = *fancydebug; // use on all ranks
 
-    // TODO: comb back through everything and make sure I'm using MPI comms properly when necessary
-    Teuchos::GlobalMPISession mpiSession(&argc, &argv,0);
     Teuchos::RCP<const Teuchos::Comm<int> > comm = Teuchos::DefaultComm<int>::getComm();
 
     const int numRanks = comm->getSize();
@@ -970,14 +970,10 @@ int main(int argc, char *argv[]) {
         if(unstructuredRanks[idx] == myRank) {useUnstructured = true;}
       }
       
-      // Retrieve matrix parameters (they may have been changed on the command line)
-      // [for instance, if we changed matrix type from 2D to 3D we need to update nz]
-      //ParameterList galeriList = galeriParameters.GetParameterList();
 
       // =========================================================================
       // Problem construction
       // =========================================================================
-      //std::ostringstream galeriStream;
 #ifdef HAVE_MUELU_OPENMP
       //std::string node_name = Node::name();
       //if(!comm->getRank() && !node_name.compare("OpenMP/Wrapper"))
@@ -1619,8 +1615,11 @@ int main(int argc, char *argv[]) {
       }
     }
 
-  } // Kokkos scope
+  } // Parallel initialization scope
+  Tpetra::finalize();
   Kokkos::finalize();
+
+  // TODO: Does this need to be scoped again for MPI? Double-check based on review
 
   return 0;
 } // main

--- a/packages/trilinoscouplings/examples/scaling/muelu_region_poisson.cpp
+++ b/packages/trilinoscouplings/examples/scaling/muelu_region_poisson.cpp
@@ -5,6 +5,11 @@
 #include <sstream>
 #include <unistd.h>
 
+// Kokkos headers have to go first
+#include "Kokkos_View.hpp"
+#include "Kokkos_DynRankView_Fad.hpp"
+#include "KokkosCompat_ClassicNodeAPI_Wrapper.hpp"
+
 // TrilinosCouplings headers
 #include "TrilinosCouplings_config.h"
 
@@ -67,9 +72,21 @@
 #include "SetupRegionVector_def.hpp"
 #include "SetupRegionMatrix_def.hpp"
 #include "SetupRegionHierarchy_def.hpp"
+#include "SolveRegionHierarchy_def.hpp"
 
 // Shards headers
 #include "Shards_CellTopology.hpp"
+
+// Tpetra headers
+#include "Tpetra_Core.hpp"
+#include "Tpetra_Map.hpp"
+#include "Tpetra_FECrsMatrix.hpp"
+#include "Tpetra_Import.hpp"
+#include "MatrixMarket_Tpetra.hpp"
+
+// Include factories for boundary conditions and other Panzer setup
+// Most of which is taken from PoissonExample in Panzer_STK
+#include "muelu_region_poisson.hpp"
 
 // Panzer headers
 #include "Panzer_AssemblyEngine.hpp"
@@ -101,17 +118,6 @@
 #include <percept/PerceptMesh.hpp>
 #include <adapt/UniformRefinerPattern.hpp>
 #include <adapt/UniformRefiner.hpp>
-
-// Tpetra headers
-#include "Tpetra_Core.hpp"
-#include "Tpetra_Map.hpp"
-#include "Tpetra_FECrsMatrix.hpp"
-#include "Tpetra_Import.hpp"
-#include "MatrixMarket_Tpetra.hpp"
-
-// Include factories for boundary conditions and other Panzer setup
-// Most of which is taken from PoissonExample in Panzer_STK
-#include "muelu_region_poisson.hpp"
 
 
 // need this for debugging purposes... technically any class that has a size()
@@ -932,8 +938,6 @@ int main(int argc, char *argv[]) {
       using Teuchos::TimeMonitor;
       using Teuchos::ParameterList;
 
-      using RealValuedMultiVector = Xpetra::MultiVector<real_type,LO,GO,NO>;
-
       // =========================================================================
       // Convenient definitions
       // =========================================================================
@@ -941,6 +945,7 @@ int main(int argc, char *argv[]) {
       SC zero = STS::zero(), one = STS::one();
       using magnitude_type = typename Teuchos::ScalarTraits<Scalar>::magnitudeType;
       using real_type = typename STS::coordinateType;
+      using RealValuedMultiVector = Xpetra::MultiVector<real_type,LO,GO,NO>;
 
 
       ParameterList paramList;

--- a/packages/trilinoscouplings/examples/scaling/muelu_region_poisson.hpp
+++ b/packages/trilinoscouplings/examples/scaling/muelu_region_poisson.hpp
@@ -1,0 +1,859 @@
+// @HEADER
+// ***********************************************************************
+//
+//           Panzer: A partial differential equation assembly
+//       engine for strongly coupled complex multiphysics systems
+//                 Copyright (2011) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Graham B. Harper (gbharpe@sandia.gov)
+// ***********************************************************************
+// @HEADER
+
+#ifndef __muelu_region_poisson_hpp__
+#define __muelu_region_poisson_hpp__
+
+// Standard headers
+#include <cmath>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <typeinfo>
+#include <vector>
+
+// Teuchos headers
+#include "Teuchos_Assert.hpp"
+#include "Teuchos_ParameterEntry.hpp"
+#include "Teuchos_ParameterList.hpp"
+#include "Teuchos_RCP.hpp"
+#include "Teuchos_StandardParameterEntryValidators.hpp"
+#include "Teuchos_TypeNameTraits.hpp"
+
+// Panzer headers
+#include "PanzerAdaptersSTK_config.hpp"
+#include "Panzer_BasisIRLayout.hpp"
+#include "Panzer_BCStrategy_Dirichlet_DefaultImpl.hpp"
+#include "Panzer_BCStrategy_Factory.hpp"
+#include "Panzer_BCStrategy_Factory_Defines.hpp"
+#include "Panzer_BCStrategy_TemplateManager.hpp"
+#include "Panzer_CellData.hpp"
+#include "Panzer_ClosureModel_Factory.hpp"
+#include "Panzer_Constant.hpp"
+#include "Panzer_Dimension.hpp"
+#include "Panzer_DotProduct.hpp"
+#include "Panzer_EquationSet_DefaultImpl.hpp"
+#include "Panzer_EquationSet_Factory.hpp"
+#include "Panzer_EquationSet_Factory_Defines.hpp"
+#include "Panzer_Evaluator_WithBaseImpl.hpp"
+#include "Panzer_FieldLibrary.hpp"
+#include "Panzer_IntegrationRule.hpp"
+#include "Panzer_Integrator_BasisTimesScalar.hpp"
+#include "Panzer_Integrator_GradBasisDotVector.hpp"
+#include "Panzer_Integrator_Scalar.hpp"
+#include "Panzer_Traits.hpp"
+#include "Panzer_PhysicsBlock.hpp"
+#include "Panzer_Product.hpp"
+#include "Panzer_PureBasis.hpp"
+#include "Panzer_ScalarToVector.hpp"
+#include "Panzer_Sum.hpp"
+#include "Panzer_Workset.hpp"
+#include "Panzer_Workset_Utilities.hpp"
+
+// Phalanx headers
+#include "Phalanx_config.hpp"
+#include "Phalanx_DataLayout.hpp"
+#include "Phalanx_DataLayout_MDALayout.hpp"
+#include "Phalanx_Evaluator_Derived.hpp"
+#include "Phalanx_Evaluator_WithBaseImpl.hpp"
+#include "Phalanx_FieldManager.hpp"
+#include "Phalanx_FieldTag_Tag.hpp"
+#include "Phalanx_MDField.hpp"
+
+// Sacado headers
+#include "Sacado_mpl_apply.hpp"
+
+namespace panzer {
+  class InputEquationSet;
+}
+
+namespace Example {
+  
+  // ******************************************************* //
+  // ******************** BC STRATEGIES ******************** //
+  // ******************************************************* //
+  template <typename EvalT>
+  class BCStrategy_Dirichlet_Constant : public panzer::BCStrategy_Dirichlet_DefaultImpl<EvalT> {
+  public:    
+    
+    BCStrategy_Dirichlet_Constant(const panzer::BC& bc, const Teuchos::RCP<panzer::GlobalData>& global_data);
+    
+    void setup(const panzer::PhysicsBlock& side_pb,
+	       const Teuchos::ParameterList& user_data);
+    
+    void buildAndRegisterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
+				    const panzer::PhysicsBlock& pb,
+				    const panzer::ClosureModelFactory_TemplateManager<panzer::Traits>& factory,
+				    const Teuchos::ParameterList& models,
+				    const Teuchos::ParameterList& user_data) const;
+
+    std::string residual_name;
+    Teuchos::RCP<panzer::PureBasis> basis;
+  };
+
+  // ***********************************************************************
+  template <typename EvalT>
+  BCStrategy_Dirichlet_Constant<EvalT>::
+  BCStrategy_Dirichlet_Constant(const panzer::BC& bc, const Teuchos::RCP<panzer::GlobalData>& global_data) :
+    panzer::BCStrategy_Dirichlet_DefaultImpl<EvalT>(bc,global_data)
+  {
+    TEUCHOS_ASSERT(this->m_bc.strategy() == "Constant");
+  }
+
+  // ***********************************************************************
+  template <typename EvalT>
+  void BCStrategy_Dirichlet_Constant<EvalT>::
+  setup(const panzer::PhysicsBlock& side_pb,
+	const Teuchos::ParameterList& /* user_data */)
+  {
+    using Teuchos::RCP;
+    using std::vector;
+    using std::string;
+    using std::pair;
+
+    // need the dof value to form the residual
+    this->required_dof_names.push_back(this->m_bc.equationSetName());
+
+    // unique residual name
+    this->residual_name = "Residual_" + this->m_bc.identifier();
+
+    // map residual to dof 
+    this->residual_to_dof_names_map[residual_name] = this->m_bc.equationSetName();
+
+    // map residual to target field
+    this->residual_to_target_field_map[residual_name] = "Constant_" + this->m_bc.equationSetName();
+
+    // find the basis for this dof 
+    const vector<pair<string,RCP<panzer::PureBasis> > >& dofs = side_pb.getProvidedDOFs();
+
+    for (vector<pair<string,RCP<panzer::PureBasis> > >::const_iterator dof_it = 
+	   dofs.begin(); dof_it != dofs.end(); ++dof_it) {
+      if (dof_it->first == this->m_bc.equationSetName())
+	this->basis = dof_it->second;
+    }
+
+    TEUCHOS_TEST_FOR_EXCEPTION(Teuchos::is_null(this->basis), std::runtime_error,
+			       "Error the name \"" << this->m_bc.equationSetName()
+			       << "\" is not a valid DOF for the boundary condition:\n"
+			       << this->m_bc << "\n");
+
+  }
+
+  // ***********************************************************************
+  template <typename EvalT>
+  void BCStrategy_Dirichlet_Constant<EvalT>::
+  buildAndRegisterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
+			     const panzer::PhysicsBlock& /* pb */,
+			     const panzer::ClosureModelFactory_TemplateManager<panzer::Traits>& /* factory */,
+			     const Teuchos::ParameterList& /* models */,
+			     const Teuchos::ParameterList& /* user_data */) const
+  {
+    using Teuchos::ParameterList;
+    using Teuchos::RCP;
+    using Teuchos::rcp;
+
+    // provide a constant target value to map into residual
+    {
+      ParameterList p("BC Constant Dirichlet");
+      p.set("Name", "Constant_" + this->m_bc.equationSetName());
+      p.set("Data Layout", basis->functional);
+      p.set("Value", this->m_bc.params()->template get<double>("Value"));
+    
+      RCP< PHX::Evaluator<panzer::Traits> > op = 
+	rcp(new panzer::Constant<EvalT,panzer::Traits>(p));
+    
+      this->template registerEvaluator<EvalT>(fm, op);
+    }
+
+  }
+
+  PANZER_DECLARE_BCSTRATEGY_TEMPLATE_BUILDER(BCStrategy_Dirichlet_Constant,
+					     BCStrategy_Dirichlet_Constant)
+
+  struct BCStrategyFactory : public panzer::BCStrategyFactory {
+
+    Teuchos::RCP<panzer::BCStrategy_TemplateManager<panzer::Traits> >
+    buildBCStrategy(const panzer::BC& bc,const Teuchos::RCP<panzer::GlobalData>& global_data) const
+    {
+
+      Teuchos::RCP<panzer::BCStrategy_TemplateManager<panzer::Traits> > bcs_tm = 
+	Teuchos::rcp(new panzer::BCStrategy_TemplateManager<panzer::Traits>);
+      
+      bool found = false;
+
+      PANZER_BUILD_BCSTRATEGY_OBJECTS("Constant",
+				      BCStrategy_Dirichlet_Constant)
+
+	TEUCHOS_TEST_FOR_EXCEPTION(!found, std::logic_error, 
+				   "Error - the BC Strategy called \"" << bc.strategy() <<
+				    "\" is not a valid identifier in the BCStrategyFactory.  Either add a "
+                         "valid implementation to your factory or fix your input file.  The "
+				   "relevant boundary condition is:\n\n" << bc << std::endl);
+      
+      return bcs_tm;
+    }
+
+  };
+
+  // ******************************************************* //
+  // ******************** MODEL FACTORY ******************** //
+  // ******************************************************* //
+  template<typename EvalT>
+  class ModelFactory : public panzer::ClosureModelFactory<EvalT> {
+
+  public:
+
+    Teuchos::RCP< std::vector< Teuchos::RCP<PHX::Evaluator<panzer::Traits> > > >
+    buildClosureModels(const std::string& model_id,
+		       const Teuchos::ParameterList& models,
+		       const panzer::FieldLayoutLibrary& fl,
+		       const Teuchos::RCP<panzer::IntegrationRule>& ir,
+		       const Teuchos::ParameterList& default_params,
+		       const Teuchos::ParameterList& user_data,
+		       const Teuchos::RCP<panzer::GlobalData>& global_data,
+		       PHX::FieldManager<panzer::Traits>& fm) const;
+
+  };
+
+  using panzer::Cell;
+  using panzer::Point;
+  using panzer::Dim;
+
+  /** A source for the curl Laplacian that results in the solution
+   */
+  template<typename EvalT, typename Traits>
+  class SimpleSource : public panzer::EvaluatorWithBaseImpl<Traits>,
+		       public PHX::EvaluatorDerived<EvalT, Traits>  {
+
+  public:
+    SimpleSource(const std::string & name,
+		 const panzer::IntegrationRule & ir);
+                                                                        
+    void postRegistrationSetup(typename Traits::SetupData d,           
+                               PHX::FieldManager<Traits>& fm);        
+                                                                     
+    void evaluateFields(typename Traits::EvalData d);               
+
+
+  private:
+    typedef typename EvalT::ScalarT ScalarT;
+
+    // Simulation source
+    PHX::MDField<ScalarT,Cell,Point> source;
+    int ir_degree, ir_index;
+  };
+
+  //**********************************************************************
+  template <typename EvalT,typename Traits>
+  SimpleSource<EvalT,Traits>::SimpleSource(const std::string & name,
+					   const panzer::IntegrationRule & ir)
+  {
+    using Teuchos::RCP;
+
+    Teuchos::RCP<PHX::DataLayout> data_layout = ir.dl_scalar;
+    ir_degree = ir.cubature_degree;
+
+    source = PHX::MDField<ScalarT,Cell,Point>(name, data_layout);
+
+    this->addEvaluatedField(source);
+  
+    std::string n = "Simple Source";
+    this->setName(n);
+  }
+
+  //**********************************************************************
+  template <typename EvalT,typename Traits>
+  void SimpleSource<EvalT,Traits>::postRegistrationSetup(typename Traits::SetupData sd,           
+							 PHX::FieldManager<Traits>& /* fm */)
+  {
+    ir_index = panzer::getIntegrationRuleIndex(ir_degree,(*sd.worksets_)[0], this->wda);
+  }
+
+  //**********************************************************************
+  template <typename EvalT,typename Traits>
+  void SimpleSource<EvalT,Traits>::evaluateFields(typename Traits::EvalData workset)
+  { 
+    using panzer::index_t;
+    for (index_t cell = 0; cell < workset.num_cells; ++cell) {
+      for (int point = 0; point < source.extent_int(1); ++point) {
+	const double& x = workset.int_rules[ir_index]->ip_coordinates(cell,point,0);
+	const double& y = workset.int_rules[ir_index]->ip_coordinates(cell,point,1);
+
+	source(cell,point) = 8.0*M_PI*M_PI*std::sin(2.0*M_PI*x)*std::sin(2.0*M_PI*y);
+      }
+    }
+  }
+
+  //**********************************************************************
+
+  /** The analytic solution to the mixed poisson equation for the sine source.
+   */
+  template<typename EvalT, typename Traits>
+  class SimpleSolution : public panzer::EvaluatorWithBaseImpl<Traits>,
+			 public PHX::EvaluatorDerived<EvalT, Traits>  {
+
+  public:
+    SimpleSolution(const std::string & name,
+		   const panzer::IntegrationRule & ir);
+                                                                        
+    void postRegistrationSetup(typename Traits::SetupData d,           
+                               PHX::FieldManager<Traits>& fm);        
+                                                                     
+    void evaluateFields(typename Traits::EvalData d);               
+
+
+  private:
+    typedef typename EvalT::ScalarT ScalarT;
+
+    // Simulation solution
+    PHX::MDField<ScalarT,Cell,Point> solution;
+    PHX::MDField<ScalarT,Cell,Point,Dim> solution_grad;
+    int ir_degree, ir_index;
+  };
+
+  //**********************************************************************
+  template <typename EvalT,typename Traits>
+  SimpleSolution<EvalT,Traits>::SimpleSolution(const std::string & name,
+					       const panzer::IntegrationRule & ir)
+  {
+    using Teuchos::RCP;
+
+    Teuchos::RCP<PHX::DataLayout> data_layout_scalar = ir.dl_scalar;
+    Teuchos::RCP<PHX::DataLayout> data_layout_vector = ir.dl_vector;
+    ir_degree = ir.cubature_degree;
+
+    solution = PHX::MDField<ScalarT,Cell,Point>(name, data_layout_scalar);
+    solution_grad = PHX::MDField<ScalarT,Cell,Point,Dim>("GRAD_"+name, data_layout_vector);
+
+    this->addEvaluatedField(solution);
+    this->addEvaluatedField(solution_grad);
+  
+    std::string n = "Simple Solution";
+    this->setName(n);
+  }
+
+  //**********************************************************************
+  template <typename EvalT,typename Traits>
+  void SimpleSolution<EvalT,Traits>::postRegistrationSetup(typename Traits::SetupData sd,           
+							   PHX::FieldManager<Traits>& /* fm */)
+  {
+    ir_index = panzer::getIntegrationRuleIndex(ir_degree,(*sd.worksets_)[0], this->wda);
+  }
+
+  //**********************************************************************
+  template <typename EvalT,typename Traits>
+  void SimpleSolution<EvalT,Traits>::evaluateFields(typename Traits::EvalData workset)
+  { 
+    using panzer::index_t;
+    for (index_t cell = 0; cell < workset.num_cells; ++cell) {
+      for (int point = 0; point < solution.extent_int(1); ++point) {
+
+	const double & x = this->wda(workset).int_rules[ir_index]->ip_coordinates(cell,point,0);
+	const double & y = this->wda(workset).int_rules[ir_index]->ip_coordinates(cell,point,1);
+
+	solution(cell,point) = std::sin(2*M_PI*x)*std::sin(2*M_PI*y);
+	solution_grad(cell,point,0) = 2.0*M_PI*std::cos(2*M_PI*x)*std::sin(2*M_PI*y);
+	solution_grad(cell,point,1) = 2.0*M_PI*std::sin(2*M_PI*x)*std::cos(2*M_PI*y);
+      }
+    }
+  }
+
+  //**********************************************************************
+
+
+  // ********************************************************************
+  // ********************************************************************
+  template<typename EvalT>
+  Teuchos::RCP< std::vector< Teuchos::RCP<PHX::Evaluator<panzer::Traits> > > >
+  ModelFactory<EvalT>::
+  buildClosureModels(const std::string& model_id,
+		     const Teuchos::ParameterList& models, 
+		     const panzer::FieldLayoutLibrary& fl,
+		     const Teuchos::RCP<panzer::IntegrationRule>& ir,
+		     const Teuchos::ParameterList& /* default_params */,
+		     const Teuchos::ParameterList& /* user_data */,
+		     const Teuchos::RCP<panzer::GlobalData>& /* global_data */,
+		     PHX::FieldManager<panzer::Traits>& /* fm */) const
+  {
+    using std::string;
+    using std::vector;
+    using Teuchos::RCP;
+    using Teuchos::rcp;
+    using Teuchos::ParameterList;
+    using PHX::Evaluator;
+
+    RCP< vector< RCP<Evaluator<panzer::Traits> > > > evaluators = 
+      rcp(new vector< RCP<Evaluator<panzer::Traits> > > );
+
+    if (!models.isSublist(model_id)) {
+      models.print(std::cout);
+      std::stringstream msg;
+      msg << "Falied to find requested model, \"" << model_id 
+	  << "\", for equation set:\n" << std::endl;
+      TEUCHOS_TEST_FOR_EXCEPTION(!models.isSublist(model_id), std::logic_error, msg.str());
+    }
+
+    std::vector<Teuchos::RCP<const panzer::PureBasis> > bases;
+    fl.uniqueBases(bases);
+
+    const ParameterList& my_models = models.sublist(model_id);
+
+    for (ParameterList::ConstIterator model_it = my_models.begin(); 
+	 model_it != my_models.end(); ++model_it) {
+    
+      bool found = false;
+    
+      const std::string key = model_it->first;
+      ParameterList input;
+      const Teuchos::ParameterEntry& entry = model_it->second;
+      const ParameterList& plist = Teuchos::getValue<Teuchos::ParameterList>(entry);
+
+      if (plist.isType<double>("Value")) {
+	{ // at IP
+	  input.set("Name", key);
+	  input.set("Value", plist.get<double>("Value"));
+	  input.set("Data Layout", ir->dl_scalar);
+	  RCP< Evaluator<panzer::Traits> > e = 
+	    rcp(new panzer::Constant<EvalT,panzer::Traits>(input));
+	  evaluators->push_back(e);
+	}
+      
+	for (std::vector<Teuchos::RCP<const panzer::PureBasis> >::const_iterator basis_itr = bases.begin();
+	     basis_itr != bases.end(); ++basis_itr) { // at BASIS
+	  input.set("Name", key);
+	  input.set("Value", plist.get<double>("Value"));
+	  Teuchos::RCP<const panzer::BasisIRLayout> basis = basisIRLayout(*basis_itr,*ir);
+	  input.set("Data Layout", basis->functional);
+	  RCP< Evaluator<panzer::Traits> > e = 
+	    rcp(new panzer::Constant<EvalT,panzer::Traits>(input));
+	  evaluators->push_back(e);
+	}
+	found = true;
+      }
+
+      if (plist.isType<std::string>("Type")) {
+	std::string type = plist.get<std::string>("Type");
+	if(type=="SIMPLE SOURCE") {
+	  RCP< Evaluator<panzer::Traits> > e = 
+	    rcp(new Example::SimpleSource<EvalT,panzer::Traits>(key,*ir));
+	  evaluators->push_back(e);
+
+	  found = true;
+	}
+	else if(type=="TEMPERATURE_EXACT") {
+	  RCP< Evaluator<panzer::Traits> > e = 
+	    rcp(new Example::SimpleSolution<EvalT,panzer::Traits>(key,*ir));
+	  evaluators->push_back(e);
+
+	  found = true;
+	}
+	else if(type=="L2 ERROR_CALC") {
+	  {
+	    std::vector<std::string> values(2);
+	    values[0] = plist.get<std::string>("Field A");
+	    values[1] = plist.get<std::string>("Field B");
+  
+	    std::vector<double> scalars(2); 
+	    scalars[0] = 1.0; 
+	    scalars[1] = -1.0;
+  
+	    Teuchos::ParameterList p;
+	    p.set("Sum Name",key+"_DIFF"); // Name of sum
+	    p.set<RCP<std::vector<std::string> > >("Values Names",Teuchos::rcpFromRef(values));
+	    p.set<RCP<const std::vector<double> > >("Scalars",Teuchos::rcpFromRef(scalars));
+	    p.set("Data Layout",ir->dl_scalar);
+  
+	    RCP< Evaluator<panzer::Traits> > e = 
+	      rcp(new panzer::Sum<EvalT,panzer::Traits>(p));
+  
+	    evaluators->push_back(e);
+	  }
+
+	  {
+	    Teuchos::RCP<const panzer::PointRule> pr = ir;
+	    std::vector<std::string> values(2);
+	    values[0] = key+"_DIFF";
+	    values[1] = key+"_DIFF";
+  
+	    Teuchos::ParameterList p;
+	    p.set("Product Name",key);
+	    p.set("Values Names",Teuchos::rcpFromRef(values));
+	    p.set("Data Layout",ir->dl_scalar);
+  
+	    RCP< Evaluator<panzer::Traits> > e = 
+	      rcp(new panzer::Product<EvalT,panzer::Traits>(p));
+  
+	    evaluators->push_back(e);
+	  }
+
+	  found = true;
+	}
+	else if(type=="H1 ERROR_CALC") {
+	  // Compute L2 contribution
+	  {
+	    std::vector<std::string> values(2);
+	    values[0] = plist.get<std::string>("Field A");
+	    values[1] = plist.get<std::string>("Field B");
+  
+	    std::vector<double> scalars(2); 
+	    scalars[0] = 1.0; 
+	    scalars[1] = -1.0;
+  
+	    Teuchos::ParameterList p;
+	    p.set("Sum Name",key+"_H1_L2DIFF"); // Name of sum
+	    p.set<RCP<std::vector<std::string> > >("Values Names",Teuchos::rcpFromRef(values));
+	    p.set<RCP<const std::vector<double> > >("Scalars",Teuchos::rcpFromRef(scalars));
+	    p.set("Data Layout",ir->dl_scalar);
+  
+	    RCP< Evaluator<panzer::Traits> > e = 
+	      rcp(new panzer::Sum<EvalT,panzer::Traits>(p));
+  
+	    evaluators->push_back(e);
+	  }
+
+	  {
+	    std::vector<std::string> values(2);
+	    values[0] = "GRAD_"+plist.get<std::string>("Field A");
+	    values[1] = "GRAD_"+plist.get<std::string>("Field B");
+  
+	    std::vector<double> scalars(2); 
+	    scalars[0] = 1.0; 
+	    scalars[1] = -1.0;
+  
+	    Teuchos::ParameterList p;
+	    p.set("Sum Name","GRAD_"+key+"_DIFF"); // Name of sum
+	    p.set<RCP<std::vector<std::string> > >("Values Names",Teuchos::rcpFromRef(values));
+	    p.set<RCP<const std::vector<double> > >("Scalars",Teuchos::rcpFromRef(scalars));
+	    p.set("Data Layout",ir->dl_vector);
+  
+	    RCP< Evaluator<panzer::Traits> > e = 
+	      rcp(new panzer::Sum<EvalT,panzer::Traits>(p));
+  
+	    evaluators->push_back(e);
+	  }
+
+	  {
+	    Teuchos::RCP<const panzer::PointRule> pr = ir;
+	    std::vector<std::string> values(2);
+	    values[0] = "GRAD_"+key+"_DIFF";
+	    values[1] = "GRAD_"+key+"_DIFF";
+  
+	    Teuchos::ParameterList p;
+	    p.set("Product Name",key+"_H1Semi");
+	    p.set("Values Names",Teuchos::rcpFromRef(values));
+	    p.set("Data Layout",ir->dl_vector);
+  
+	    RCP< Evaluator<panzer::Traits> > e = 
+	      panzer::buildEvaluator_DotProduct<EvalT,panzer::Traits>(key,*ir,values[0],values[1]);
+  
+	    evaluators->push_back(e);
+	  }
+
+	  {
+	    Teuchos::RCP<const panzer::PointRule> pr = ir;
+	    std::vector<std::string> values(2);
+	    values[0] = key+"_H1_L2DIFF";
+	    values[1] = key+"_H1_L2DIFF";
+  
+	    Teuchos::ParameterList p;
+	    p.set("Product Name",key+"_L2");
+	    p.set("Values Names",Teuchos::rcpFromRef(values));
+	    p.set("Data Layout",ir->dl_scalar);
+  
+	    RCP< Evaluator<panzer::Traits> > e = 
+	      rcp(new panzer::Product<EvalT,panzer::Traits>(p));
+  
+	    evaluators->push_back(e);
+	  }
+
+	  {
+	    std::vector<std::string> values(2);
+	    values[0] = key+"_L2";
+	    values[1] = key+"_H1Semi";
+  
+	    Teuchos::ParameterList p;
+	    p.set("Sum Name",key); // Name of sum
+	    p.set<RCP<std::vector<std::string> > >("Values Names",Teuchos::rcpFromRef(values));
+	    p.set("Data Layout",ir->dl_scalar);
+  
+	    RCP< Evaluator<panzer::Traits> > e = 
+	      rcp(new panzer::Sum<EvalT,panzer::Traits>(p));
+  
+	    evaluators->push_back(e);
+	  }
+
+	  found = true;
+	}
+      }
+
+      if (!found) {
+	std::stringstream msg;
+	msg << "ClosureModelFactory failed to build evaluator for key \"" << key 
+	    << "\"\nin model \"" << model_id 
+	    << "\".  Please correct the type or add support to the \nfactory." <<std::endl;
+	TEUCHOS_TEST_FOR_EXCEPTION(!found, std::logic_error, msg.str());
+      }
+
+    }
+
+    return evaluators;
+  }
+
+  class ClosureModelFactory_TemplateBuilder {
+  public:
+      
+     template <typename EvalT>
+     Teuchos::RCP<panzer::ClosureModelFactoryBase> build() const 
+     {
+        return Teuchos::rcp( static_cast<panzer::ClosureModelFactoryBase*>(new Example::ModelFactory<EvalT>) );
+     }
+      
+  };
+  
+  /** The equation set serves two roles. The first is to let the panzer library
+   * know which fields this equation set defines and their names. It registers
+   * the evaluators required for a particular equation set. The level of the
+   * granularity is largely up to a user. For instance this could be the momentum
+   * or continuity equation in Navier-Stokes, or it could simply be the Navier-Stokes
+   * equations. 
+   *
+   * Generally, this inherits from the panzer::EquationSet_DefaultImpl which takes
+   * care of adding the gather (extract basis coefficients from solution vector) and 
+   * scatter (using element matrices and vectors distribute and sum their values
+   * to a global linear system) evaluators. These use data members that must be set by
+   * the user.
+   */
+  template <typename EvalT>
+  class PoissonEquationSet : public panzer::EquationSet_DefaultImpl<EvalT> {
+  public:    
+
+    /** In the constructor you set all the fields provided by this
+     * equation set. 
+     */
+    PoissonEquationSet(const Teuchos::RCP<Teuchos::ParameterList>& params,
+		       const int& default_integration_order,
+		       const panzer::CellData& cell_data,
+		       const Teuchos::RCP<panzer::GlobalData>& global_data,
+		       const bool build_transient_support);
+    
+    /** The specific evaluators are registered with the field manager argument.
+     */
+    void buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
+					       const panzer::FieldLibrary& field_library,
+					       const Teuchos::ParameterList& user_data) const;
+
+  };
+
+  // ***********************************************************************
+  template <typename EvalT>
+  PoissonEquationSet<EvalT>::
+  PoissonEquationSet(const Teuchos::RCP<Teuchos::ParameterList>& params,
+		     const int& default_integration_order,
+		     const panzer::CellData& cell_data,
+		     const Teuchos::RCP<panzer::GlobalData>& global_data,
+		     const bool build_transient_support) :
+    panzer::EquationSet_DefaultImpl<EvalT>(params, default_integration_order, cell_data, global_data, build_transient_support )
+  {
+    // ********************
+    // Validate and parse parameter list
+    // ********************
+    {    
+      Teuchos::ParameterList valid_parameters;
+      this->setDefaultValidParameters(valid_parameters);
+    
+      valid_parameters.set("Model ID","","Closure model id associated with this equaiton set");
+      valid_parameters.set("Basis Type","HGrad","Type of Basis to use");
+      valid_parameters.set("Basis Order",1,"Order of the basis");
+      valid_parameters.set("Integration Order",-1,"Order of the integration rule");
+    
+      params->validateParametersAndSetDefaults(valid_parameters);
+    }
+  
+    std::string basis_type = params->get<std::string>("Basis Type");
+    int basis_order = params->get<int>("Basis Order");
+    int integration_order = params->get<int>("Integration Order");
+    std::string model_id = params->get<std::string>("Model ID");
+
+    // ********************
+    // Panzer uses strings to match fields. In this section we define the
+    // name of the fields provided by this equation set. This is a bit strange
+    // in that this is not the fields necessarily required by this equation set.
+    // For instance for the momentum equations in Navier-Stokes only the velocity
+    // fields are added, the pressure field is added by continuity.
+    //
+    // In this case "TEMPERATURE" is the lone field.  We also name the gradient
+    // for this field. These names automatically generate evaluators for "TEMPERATURE"
+    // and "GRAD_TEMPERATURE" gathering the basis coefficients of "TEMPERATURE" and
+    // the values of the TEMPERATURE and GRAD_TEMPERATURE fields at quadrature points.
+    //
+    // After all the equation set evaluators are added to a given field manager, the
+    // panzer code adds in appropriate scatter evaluators to distribute the
+    // entries into the residual and the Jacobian operator. These operators will be
+    // "required" by the field manager and will serve as roots of evaluation tree.
+    // The leaves of this tree will include the gather evaluators whose job it is to
+    // gather the solution from a vector.
+    // ********************
+
+    // ********************
+    // Assemble DOF names and Residual names
+    // ********************
+
+    this->addDOF("TEMPERATURE",basis_type,basis_order,integration_order);
+    this->addDOFGrad("TEMPERATURE");
+    if (this->buildTransientSupport())
+      this->addDOFTimeDerivative("TEMPERATURE");
+
+    // ********************
+    // Build Basis Functions and Integration Rules
+    // ********************
+   
+    this->addClosureModel(model_id);
+
+    this->setupDOFs();
+  }
+
+  // ***********************************************************************
+  template <typename EvalT>
+  void PoissonEquationSet<EvalT>::
+  buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
+					const panzer::FieldLibrary& /* fl */,
+					const Teuchos::ParameterList& /* user_data */) const
+  {
+    using panzer::BasisIRLayout;
+    using panzer::EvaluatorStyle;
+    using panzer::IntegrationRule;
+    using panzer::Integrator_BasisTimesScalar;
+    using panzer::Integrator_GradBasisDotVector;
+    using panzer::Traits;
+    using PHX::Evaluator;
+    using std::string;
+    using Teuchos::ParameterList;
+    using Teuchos::RCP;
+    using Teuchos::rcp;
+  
+    RCP<IntegrationRule> ir = this->getIntRuleForDOF("TEMPERATURE");
+    RCP<BasisIRLayout> basis = this->getBasisIRLayoutForDOF("TEMPERATURE"); 
+
+    // ********************
+    // Energy Equation
+    // ********************
+
+    // Transient Operator: Assembles \int \dot{T} v
+    if (this->buildTransientSupport())
+      {
+	string resName("RESIDUAL_TEMPERATURE"), valName("DXDT_TEMPERATURE");
+	double multiplier(1);
+	RCP<Evaluator<Traits>> op = rcp(new
+					Integrator_BasisTimesScalar<EvalT, Traits>(EvaluatorStyle::CONTRIBUTES,
+										   resName, valName, *basis, *ir, multiplier));
+	this->template registerEvaluator<EvalT>(fm, op);
+      }
+
+    // Diffusion Operator: Assembles \int \nabla T \cdot \nabla v
+    {
+      double thermal_conductivity = 1.0;
+
+      ParameterList p("Diffusion Residual");
+      p.set("Residual Name", "RESIDUAL_TEMPERATURE");
+      p.set("Flux Name", "GRAD_TEMPERATURE"); // this field is constructed by the panzer library
+      p.set("Basis", basis);
+      p.set("IR", ir);
+      p.set("Multiplier", thermal_conductivity);
+    
+      RCP<Evaluator<Traits>> op = rcp(new
+				      Integrator_GradBasisDotVector<EvalT, Traits>(p));
+
+      this->template registerEvaluator<EvalT>(fm, op);
+    }
+  
+    // Source Operator
+    {   
+      string resName("RESIDUAL_TEMPERATURE"),
+	valName("SOURCE_TEMPERATURE");
+      double multiplier(-1);
+      RCP<Evaluator<Traits>> op = rcp(new
+				      Integrator_BasisTimesScalar<EvalT, Traits>(EvaluatorStyle::CONTRIBUTES,
+										 resName, valName, *basis, *ir, multiplier));
+      this->template registerEvaluator<EvalT>(fm, op);
+    }
+  }
+
+  // ***********************************************************************
+
+  // A macro that defines a class to make construction of the equation sets easier
+  //   - The equation set is constructed over a list of automatic differention types
+  PANZER_DECLARE_EQSET_TEMPLATE_BUILDER(PoissonEquationSet, PoissonEquationSet)
+
+  // A user written factory that creates each equation set.  The key member here
+  // is buildEquationSet
+  class EquationSetFactory : public panzer::EquationSetFactory {
+  public:
+
+    Teuchos::RCP<panzer::EquationSet_TemplateManager<panzer::Traits> >
+    buildEquationSet(const Teuchos::RCP<Teuchos::ParameterList>& params,
+		     const int& default_integration_order,
+		     const panzer::CellData& cell_data,
+		     const Teuchos::RCP<panzer::GlobalData>& global_data,
+		     const bool build_transient_support) const
+    {
+      Teuchos::RCP<panzer::EquationSet_TemplateManager<panzer::Traits> > eq_set= 
+	Teuchos::rcp(new panzer::EquationSet_TemplateManager<panzer::Traits>);
+         
+      bool found = false; // this is used by PANZER_BUILD_EQSET_OBJECTS
+         
+      // macro checks if(ies.name=="Poisson") then an EquationSet_Energy object is constructed
+      PANZER_BUILD_EQSET_OBJECTS("Poisson", PoissonEquationSet)
+         
+	// make sure your equation set has been found
+	if(!found) {
+	  std::string msg = "Error - the \"Equation Set\" called \"" + params->get<std::string>("Type") +
+	    "\" is not a valid equation set identifier. Please supply the correct factory.\n";
+	  TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error, msg);
+	}
+         
+      return eq_set;
+    }
+    
+  };
+
+}
+
+#endif

--- a/packages/trilinoscouplings/examples/scaling/muelu_region_poisson.hpp
+++ b/packages/trilinoscouplings/examples/scaling/muelu_region_poisson.hpp
@@ -138,7 +138,7 @@ void perceptrenumbertest(const unsigned int num_levels_refinement)
   // scope in case I decide to copypasta
   {
     // initialize to 0
-    unsigned int outputorder[cells_per_dim][cells_per_dim][cells_per_dim];
+    unsigned int outputorder[cells_per_dim][cells_per_dim][cells_per_dim]; // TODO: dirty VLA usage
     for(unsigned int i=0; i<cells_per_dim; ++i)
       for(unsigned int j=0; j<cells_per_dim; ++j)
         for(unsigned int k=0; k<cells_per_dim; ++k)
@@ -197,13 +197,13 @@ namespace Example {
     BCStrategy_Dirichlet_Constant(const panzer::BC& bc, const Teuchos::RCP<panzer::GlobalData>& global_data);
     
     void setup(const panzer::PhysicsBlock& side_pb,
-	       const Teuchos::ParameterList& user_data);
+               const Teuchos::ParameterList& user_data);
     
     void buildAndRegisterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
-				    const panzer::PhysicsBlock& pb,
-				    const panzer::ClosureModelFactory_TemplateManager<panzer::Traits>& factory,
-				    const Teuchos::ParameterList& models,
-				    const Teuchos::ParameterList& user_data) const;
+                                    const panzer::PhysicsBlock& pb,
+                                    const panzer::ClosureModelFactory_TemplateManager<panzer::Traits>& factory,
+                                    const Teuchos::ParameterList& models,
+                                    const Teuchos::ParameterList& user_data) const;
 
     std::string residual_name;
     Teuchos::RCP<panzer::PureBasis> basis;
@@ -213,7 +213,7 @@ namespace Example {
   template <typename EvalT>
   BCStrategy_Dirichlet_Constant<EvalT>::
   BCStrategy_Dirichlet_Constant(const panzer::BC& bc, const Teuchos::RCP<panzer::GlobalData>& global_data) :
-    panzer::BCStrategy_Dirichlet_DefaultImpl<EvalT>(bc,global_data)
+  panzer::BCStrategy_Dirichlet_DefaultImpl<EvalT>(bc,global_data)
   {
     TEUCHOS_ASSERT(this->m_bc.strategy() == "Constant");
   }
@@ -222,7 +222,7 @@ namespace Example {
   template <typename EvalT>
   void BCStrategy_Dirichlet_Constant<EvalT>::
   setup(const panzer::PhysicsBlock& side_pb,
-	const Teuchos::ParameterList& /* user_data */)
+        const Teuchos::ParameterList& /* user_data */)
   {
     using Teuchos::RCP;
     using std::vector;
@@ -245,15 +245,15 @@ namespace Example {
     const vector<pair<string,RCP<panzer::PureBasis> > >& dofs = side_pb.getProvidedDOFs();
 
     for (vector<pair<string,RCP<panzer::PureBasis> > >::const_iterator dof_it = 
-	   dofs.begin(); dof_it != dofs.end(); ++dof_it) {
+        dofs.begin(); dof_it != dofs.end(); ++dof_it) {
       if (dof_it->first == this->m_bc.equationSetName())
-	this->basis = dof_it->second;
+        this->basis = dof_it->second;
     }
 
     TEUCHOS_TEST_FOR_EXCEPTION(Teuchos::is_null(this->basis), std::runtime_error,
-			       "Error the name \"" << this->m_bc.equationSetName()
-			       << "\" is not a valid DOF for the boundary condition:\n"
-			       << this->m_bc << "\n");
+                               "Error the name \"" << this->m_bc.equationSetName()
+                               << "\" is not a valid DOF for the boundary condition:\n"
+                               << this->m_bc << "\n");
 
   }
 
@@ -261,10 +261,10 @@ namespace Example {
   template <typename EvalT>
   void BCStrategy_Dirichlet_Constant<EvalT>::
   buildAndRegisterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
-			     const panzer::PhysicsBlock& /* pb */,
-			     const panzer::ClosureModelFactory_TemplateManager<panzer::Traits>& /* factory */,
-			     const Teuchos::ParameterList& /* models */,
-			     const Teuchos::ParameterList& /* user_data */) const
+                             const panzer::PhysicsBlock& /* pb */,
+                             const panzer::ClosureModelFactory_TemplateManager<panzer::Traits>& /* factory */,
+                             const Teuchos::ParameterList& /* models */,
+                             const Teuchos::ParameterList& /* user_data */) const
   {
     using Teuchos::ParameterList;
     using Teuchos::RCP;
@@ -276,17 +276,17 @@ namespace Example {
       p.set("Name", "Constant_" + this->m_bc.equationSetName());
       p.set("Data Layout", basis->functional);
       p.set("Value", this->m_bc.params()->template get<double>("Value"));
-    
+
       RCP< PHX::Evaluator<panzer::Traits> > op = 
-	rcp(new panzer::Constant<EvalT,panzer::Traits>(p));
-    
+          rcp(new panzer::Constant<EvalT,panzer::Traits>(p));
+
       this->template registerEvaluator<EvalT>(fm, op);
     }
 
   }
 
   PANZER_DECLARE_BCSTRATEGY_TEMPLATE_BUILDER(BCStrategy_Dirichlet_Constant,
-					     BCStrategy_Dirichlet_Constant)
+                                             BCStrategy_Dirichlet_Constant)
 
   struct BCStrategyFactory : public panzer::BCStrategyFactory {
 
@@ -295,18 +295,18 @@ namespace Example {
     {
 
       Teuchos::RCP<panzer::BCStrategy_TemplateManager<panzer::Traits> > bcs_tm = 
-	Teuchos::rcp(new panzer::BCStrategy_TemplateManager<panzer::Traits>);
+          Teuchos::rcp(new panzer::BCStrategy_TemplateManager<panzer::Traits>);
       
       bool found = false;
 
       PANZER_BUILD_BCSTRATEGY_OBJECTS("Constant",
-				      BCStrategy_Dirichlet_Constant)
+                                      BCStrategy_Dirichlet_Constant)
 
-	TEUCHOS_TEST_FOR_EXCEPTION(!found, std::logic_error, 
-				   "Error - the BC Strategy called \"" << bc.strategy() <<
-				    "\" is not a valid identifier in the BCStrategyFactory.  Either add a "
-                         "valid implementation to your factory or fix your input file.  The "
-				   "relevant boundary condition is:\n\n" << bc << std::endl);
+      TEUCHOS_TEST_FOR_EXCEPTION(!found, std::logic_error,
+                                 "Error - the BC Strategy called \"" << bc.strategy() <<
+                                 "\" is not a valid identifier in the BCStrategyFactory.  Either add a "
+                                 "valid implementation to your factory or fix your input file.  The "
+                                 "relevant boundary condition is:\n\n" << bc << std::endl);
       
       return bcs_tm;
     }
@@ -323,13 +323,13 @@ namespace Example {
 
     Teuchos::RCP< std::vector< Teuchos::RCP<PHX::Evaluator<panzer::Traits> > > >
     buildClosureModels(const std::string& model_id,
-		       const Teuchos::ParameterList& models,
-		       const panzer::FieldLayoutLibrary& fl,
-		       const Teuchos::RCP<panzer::IntegrationRule>& ir,
-		       const Teuchos::ParameterList& default_params,
-		       const Teuchos::ParameterList& user_data,
-		       const Teuchos::RCP<panzer::GlobalData>& global_data,
-		       PHX::FieldManager<panzer::Traits>& fm) const;
+                       const Teuchos::ParameterList& models,
+                       const panzer::FieldLayoutLibrary& fl,
+                       const Teuchos::RCP<panzer::IntegrationRule>& ir,
+                       const Teuchos::ParameterList& default_params,
+                       const Teuchos::ParameterList& user_data,
+                       const Teuchos::RCP<panzer::GlobalData>& global_data,
+                       PHX::FieldManager<panzer::Traits>& fm) const;
 
   };
 
@@ -341,15 +341,15 @@ namespace Example {
    */
   template<typename EvalT, typename Traits>
   class SimpleSource : public panzer::EvaluatorWithBaseImpl<Traits>,
-		       public PHX::EvaluatorDerived<EvalT, Traits>  {
+  public PHX::EvaluatorDerived<EvalT, Traits>  {
 
   public:
     SimpleSource(const std::string & name,
-		 const panzer::IntegrationRule & ir);
-                                                                        
+                 const panzer::IntegrationRule & ir);
+
     void postRegistrationSetup(typename Traits::SetupData d,           
                                PHX::FieldManager<Traits>& fm);        
-                                                                     
+
     void evaluateFields(typename Traits::EvalData d);               
 
 
@@ -364,7 +364,7 @@ namespace Example {
   //**********************************************************************
   template <typename EvalT,typename Traits>
   SimpleSource<EvalT,Traits>::SimpleSource(const std::string & name,
-					   const panzer::IntegrationRule & ir)
+                                           const panzer::IntegrationRule & ir)
   {
     using Teuchos::RCP;
 
@@ -374,7 +374,7 @@ namespace Example {
     source = PHX::MDField<ScalarT,Cell,Point>(name, data_layout);
 
     this->addEvaluatedField(source);
-  
+
     std::string n = "Simple Source";
     this->setName(n);
   }
@@ -382,7 +382,7 @@ namespace Example {
   //**********************************************************************
   template <typename EvalT,typename Traits>
   void SimpleSource<EvalT,Traits>::postRegistrationSetup(typename Traits::SetupData sd,           
-							 PHX::FieldManager<Traits>& /* fm */)
+                                                         PHX::FieldManager<Traits>& /* fm */)
   {
     ir_index = panzer::getIntegrationRuleIndex(ir_degree,(*sd.worksets_)[0], this->wda);
   }
@@ -394,10 +394,10 @@ namespace Example {
     using panzer::index_t;
     for (index_t cell = 0; cell < workset.num_cells; ++cell) {
       for (int point = 0; point < source.extent_int(1); ++point) {
-	const double& x = workset.int_rules[ir_index]->ip_coordinates(cell,point,0);
-	const double& y = workset.int_rules[ir_index]->ip_coordinates(cell,point,1);
+        const double& x = workset.int_rules[ir_index]->ip_coordinates(cell,point,0);
+        const double& y = workset.int_rules[ir_index]->ip_coordinates(cell,point,1);
 
-	source(cell,point) = 8.0*M_PI*M_PI*std::sin(2.0*M_PI*x)*std::sin(2.0*M_PI*y);
+        source(cell,point) = 8.0*M_PI*M_PI*std::sin(2.0*M_PI*x)*std::sin(2.0*M_PI*y);
       }
     }
   }
@@ -408,15 +408,15 @@ namespace Example {
    */
   template<typename EvalT, typename Traits>
   class SimpleSolution : public panzer::EvaluatorWithBaseImpl<Traits>,
-			 public PHX::EvaluatorDerived<EvalT, Traits>  {
+  public PHX::EvaluatorDerived<EvalT, Traits>  {
 
   public:
     SimpleSolution(const std::string & name,
-		   const panzer::IntegrationRule & ir);
-                                                                        
+                   const panzer::IntegrationRule & ir);
+
     void postRegistrationSetup(typename Traits::SetupData d,           
                                PHX::FieldManager<Traits>& fm);        
-                                                                     
+
     void evaluateFields(typename Traits::EvalData d);               
 
 
@@ -432,7 +432,7 @@ namespace Example {
   //**********************************************************************
   template <typename EvalT,typename Traits>
   SimpleSolution<EvalT,Traits>::SimpleSolution(const std::string & name,
-					       const panzer::IntegrationRule & ir)
+                                               const panzer::IntegrationRule & ir)
   {
     using Teuchos::RCP;
 
@@ -445,7 +445,7 @@ namespace Example {
 
     this->addEvaluatedField(solution);
     this->addEvaluatedField(solution_grad);
-  
+
     std::string n = "Simple Solution";
     this->setName(n);
   }
@@ -453,7 +453,7 @@ namespace Example {
   //**********************************************************************
   template <typename EvalT,typename Traits>
   void SimpleSolution<EvalT,Traits>::postRegistrationSetup(typename Traits::SetupData sd,           
-							   PHX::FieldManager<Traits>& /* fm */)
+                                                           PHX::FieldManager<Traits>& /* fm */)
   {
     ir_index = panzer::getIntegrationRuleIndex(ir_degree,(*sd.worksets_)[0], this->wda);
   }
@@ -466,12 +466,12 @@ namespace Example {
     for (index_t cell = 0; cell < workset.num_cells; ++cell) {
       for (int point = 0; point < solution.extent_int(1); ++point) {
 
-	const double & x = this->wda(workset).int_rules[ir_index]->ip_coordinates(cell,point,0);
-	const double & y = this->wda(workset).int_rules[ir_index]->ip_coordinates(cell,point,1);
+        const double & x = this->wda(workset).int_rules[ir_index]->ip_coordinates(cell,point,0);
+        const double & y = this->wda(workset).int_rules[ir_index]->ip_coordinates(cell,point,1);
 
-	solution(cell,point) = std::sin(2*M_PI*x)*std::sin(2*M_PI*y);
-	solution_grad(cell,point,0) = 2.0*M_PI*std::cos(2*M_PI*x)*std::sin(2*M_PI*y);
-	solution_grad(cell,point,1) = 2.0*M_PI*std::sin(2*M_PI*x)*std::cos(2*M_PI*y);
+        solution(cell,point) = std::sin(2*M_PI*x)*std::sin(2*M_PI*y);
+        solution_grad(cell,point,0) = 2.0*M_PI*std::cos(2*M_PI*x)*std::sin(2*M_PI*y);
+        solution_grad(cell,point,1) = 2.0*M_PI*std::sin(2*M_PI*x)*std::cos(2*M_PI*y);
       }
     }
   }
@@ -485,13 +485,13 @@ namespace Example {
   Teuchos::RCP< std::vector< Teuchos::RCP<PHX::Evaluator<panzer::Traits> > > >
   ModelFactory<EvalT>::
   buildClosureModels(const std::string& model_id,
-		     const Teuchos::ParameterList& models, 
-		     const panzer::FieldLayoutLibrary& fl,
-		     const Teuchos::RCP<panzer::IntegrationRule>& ir,
-		     const Teuchos::ParameterList& /* default_params */,
-		     const Teuchos::ParameterList& /* user_data */,
-		     const Teuchos::RCP<panzer::GlobalData>& /* global_data */,
-		     PHX::FieldManager<panzer::Traits>& /* fm */) const
+                     const Teuchos::ParameterList& models,
+                     const panzer::FieldLayoutLibrary& fl,
+                     const Teuchos::RCP<panzer::IntegrationRule>& ir,
+                     const Teuchos::ParameterList& /* default_params */,
+                     const Teuchos::ParameterList& /* user_data */,
+                     const Teuchos::RCP<panzer::GlobalData>& /* global_data */,
+                     PHX::FieldManager<panzer::Traits>& /* fm */) const
   {
     using std::string;
     using std::vector;
@@ -501,13 +501,13 @@ namespace Example {
     using PHX::Evaluator;
 
     RCP< vector< RCP<Evaluator<panzer::Traits> > > > evaluators = 
-      rcp(new vector< RCP<Evaluator<panzer::Traits> > > );
+        rcp(new vector< RCP<Evaluator<panzer::Traits> > > );
 
     if (!models.isSublist(model_id)) {
       models.print(std::cout);
       std::stringstream msg;
       msg << "Falied to find requested model, \"" << model_id 
-	  << "\", for equation set:\n" << std::endl;
+          << "\", for equation set:\n" << std::endl;
       TEUCHOS_TEST_FOR_EXCEPTION(!models.isSublist(model_id), std::logic_error, msg.str());
     }
 
@@ -517,199 +517,199 @@ namespace Example {
     const ParameterList& my_models = models.sublist(model_id);
 
     for (ParameterList::ConstIterator model_it = my_models.begin(); 
-	 model_it != my_models.end(); ++model_it) {
-    
+        model_it != my_models.end(); ++model_it) {
+
       bool found = false;
-    
+
       const std::string key = model_it->first;
       ParameterList input;
       const Teuchos::ParameterEntry& entry = model_it->second;
       const ParameterList& plist = Teuchos::getValue<Teuchos::ParameterList>(entry);
 
       if (plist.isType<double>("Value")) {
-	{ // at IP
-	  input.set("Name", key);
-	  input.set("Value", plist.get<double>("Value"));
-	  input.set("Data Layout", ir->dl_scalar);
-	  RCP< Evaluator<panzer::Traits> > e = 
-	    rcp(new panzer::Constant<EvalT,panzer::Traits>(input));
-	  evaluators->push_back(e);
-	}
-      
-	for (std::vector<Teuchos::RCP<const panzer::PureBasis> >::const_iterator basis_itr = bases.begin();
-	     basis_itr != bases.end(); ++basis_itr) { // at BASIS
-	  input.set("Name", key);
-	  input.set("Value", plist.get<double>("Value"));
-	  Teuchos::RCP<const panzer::BasisIRLayout> basis = basisIRLayout(*basis_itr,*ir);
-	  input.set("Data Layout", basis->functional);
-	  RCP< Evaluator<panzer::Traits> > e = 
-	    rcp(new panzer::Constant<EvalT,panzer::Traits>(input));
-	  evaluators->push_back(e);
-	}
-	found = true;
+        { // at IP
+          input.set("Name", key);
+          input.set("Value", plist.get<double>("Value"));
+          input.set("Data Layout", ir->dl_scalar);
+          RCP< Evaluator<panzer::Traits> > e =
+              rcp(new panzer::Constant<EvalT,panzer::Traits>(input));
+          evaluators->push_back(e);
+        }
+
+        for (std::vector<Teuchos::RCP<const panzer::PureBasis> >::const_iterator basis_itr = bases.begin();
+            basis_itr != bases.end(); ++basis_itr) { // at BASIS
+          input.set("Name", key);
+          input.set("Value", plist.get<double>("Value"));
+          Teuchos::RCP<const panzer::BasisIRLayout> basis = basisIRLayout(*basis_itr,*ir);
+          input.set("Data Layout", basis->functional);
+          RCP< Evaluator<panzer::Traits> > e =
+              rcp(new panzer::Constant<EvalT,panzer::Traits>(input));
+          evaluators->push_back(e);
+        }
+        found = true;
       }
-
+      
       if (plist.isType<std::string>("Type")) {
-	std::string type = plist.get<std::string>("Type");
-	if(type=="SIMPLE SOURCE") {
-	  RCP< Evaluator<panzer::Traits> > e = 
-	    rcp(new Example::SimpleSource<EvalT,panzer::Traits>(key,*ir));
-	  evaluators->push_back(e);
+        std::string type = plist.get<std::string>("Type");
+        if(type=="SIMPLE SOURCE") {
+          RCP< Evaluator<panzer::Traits> > e =
+              rcp(new Example::SimpleSource<EvalT,panzer::Traits>(key,*ir));
+          evaluators->push_back(e);
 
-	  found = true;
-	}
-	else if(type=="TEMPERATURE_EXACT") {
-	  RCP< Evaluator<panzer::Traits> > e = 
-	    rcp(new Example::SimpleSolution<EvalT,panzer::Traits>(key,*ir));
-	  evaluators->push_back(e);
+          found = true;
+        }
+        else if(type=="TEMPERATURE_EXACT") {
+          RCP< Evaluator<panzer::Traits> > e =
+              rcp(new Example::SimpleSolution<EvalT,panzer::Traits>(key,*ir));
+          evaluators->push_back(e);
 
-	  found = true;
-	}
-	else if(type=="L2 ERROR_CALC") {
-	  {
-	    std::vector<std::string> values(2);
-	    values[0] = plist.get<std::string>("Field A");
-	    values[1] = plist.get<std::string>("Field B");
-  
-	    std::vector<double> scalars(2); 
-	    scalars[0] = 1.0; 
-	    scalars[1] = -1.0;
-  
-	    Teuchos::ParameterList p;
-	    p.set("Sum Name",key+"_DIFF"); // Name of sum
-	    p.set<RCP<std::vector<std::string> > >("Values Names",Teuchos::rcpFromRef(values));
-	    p.set<RCP<const std::vector<double> > >("Scalars",Teuchos::rcpFromRef(scalars));
-	    p.set("Data Layout",ir->dl_scalar);
-  
-	    RCP< Evaluator<panzer::Traits> > e = 
-	      rcp(new panzer::Sum<EvalT,panzer::Traits>(p));
-  
-	    evaluators->push_back(e);
-	  }
+          found = true;
+        }
+        else if(type=="L2 ERROR_CALC") {
+          {
+            std::vector<std::string> values(2);
+            values[0] = plist.get<std::string>("Field A");
+            values[1] = plist.get<std::string>("Field B");
 
-	  {
-	    Teuchos::RCP<const panzer::PointRule> pr = ir;
-	    std::vector<std::string> values(2);
-	    values[0] = key+"_DIFF";
-	    values[1] = key+"_DIFF";
-  
-	    Teuchos::ParameterList p;
-	    p.set("Product Name",key);
-	    p.set("Values Names",Teuchos::rcpFromRef(values));
-	    p.set("Data Layout",ir->dl_scalar);
-  
-	    RCP< Evaluator<panzer::Traits> > e = 
-	      rcp(new panzer::Product<EvalT,panzer::Traits>(p));
-  
-	    evaluators->push_back(e);
-	  }
+            std::vector<double> scalars(2);
+            scalars[0] = 1.0;
+            scalars[1] = -1.0;
 
-	  found = true;
-	}
-	else if(type=="H1 ERROR_CALC") {
-	  // Compute L2 contribution
-	  {
-	    std::vector<std::string> values(2);
-	    values[0] = plist.get<std::string>("Field A");
-	    values[1] = plist.get<std::string>("Field B");
-  
-	    std::vector<double> scalars(2); 
-	    scalars[0] = 1.0; 
-	    scalars[1] = -1.0;
-  
-	    Teuchos::ParameterList p;
-	    p.set("Sum Name",key+"_H1_L2DIFF"); // Name of sum
-	    p.set<RCP<std::vector<std::string> > >("Values Names",Teuchos::rcpFromRef(values));
-	    p.set<RCP<const std::vector<double> > >("Scalars",Teuchos::rcpFromRef(scalars));
-	    p.set("Data Layout",ir->dl_scalar);
-  
-	    RCP< Evaluator<panzer::Traits> > e = 
-	      rcp(new panzer::Sum<EvalT,panzer::Traits>(p));
-  
-	    evaluators->push_back(e);
-	  }
+            Teuchos::ParameterList p;
+            p.set("Sum Name",key+"_DIFF"); // Name of sum
+            p.set<RCP<std::vector<std::string> > >("Values Names",Teuchos::rcpFromRef(values));
+            p.set<RCP<const std::vector<double> > >("Scalars",Teuchos::rcpFromRef(scalars));
+            p.set("Data Layout",ir->dl_scalar);
 
-	  {
-	    std::vector<std::string> values(2);
-	    values[0] = "GRAD_"+plist.get<std::string>("Field A");
-	    values[1] = "GRAD_"+plist.get<std::string>("Field B");
-  
-	    std::vector<double> scalars(2); 
-	    scalars[0] = 1.0; 
-	    scalars[1] = -1.0;
-  
-	    Teuchos::ParameterList p;
-	    p.set("Sum Name","GRAD_"+key+"_DIFF"); // Name of sum
-	    p.set<RCP<std::vector<std::string> > >("Values Names",Teuchos::rcpFromRef(values));
-	    p.set<RCP<const std::vector<double> > >("Scalars",Teuchos::rcpFromRef(scalars));
-	    p.set("Data Layout",ir->dl_vector);
-  
-	    RCP< Evaluator<panzer::Traits> > e = 
-	      rcp(new panzer::Sum<EvalT,panzer::Traits>(p));
-  
-	    evaluators->push_back(e);
-	  }
+            RCP< Evaluator<panzer::Traits> > e =
+                rcp(new panzer::Sum<EvalT,panzer::Traits>(p));
 
-	  {
-	    Teuchos::RCP<const panzer::PointRule> pr = ir;
-	    std::vector<std::string> values(2);
-	    values[0] = "GRAD_"+key+"_DIFF";
-	    values[1] = "GRAD_"+key+"_DIFF";
-  
-	    Teuchos::ParameterList p;
-	    p.set("Product Name",key+"_H1Semi");
-	    p.set("Values Names",Teuchos::rcpFromRef(values));
-	    p.set("Data Layout",ir->dl_vector);
-  
-	    RCP< Evaluator<panzer::Traits> > e = 
-	      panzer::buildEvaluator_DotProduct<EvalT,panzer::Traits>(key,*ir,values[0],values[1]);
-  
-	    evaluators->push_back(e);
-	  }
+            evaluators->push_back(e);
+          }
 
-	  {
-	    Teuchos::RCP<const panzer::PointRule> pr = ir;
-	    std::vector<std::string> values(2);
-	    values[0] = key+"_H1_L2DIFF";
-	    values[1] = key+"_H1_L2DIFF";
-  
-	    Teuchos::ParameterList p;
-	    p.set("Product Name",key+"_L2");
-	    p.set("Values Names",Teuchos::rcpFromRef(values));
-	    p.set("Data Layout",ir->dl_scalar);
-  
-	    RCP< Evaluator<panzer::Traits> > e = 
-	      rcp(new panzer::Product<EvalT,panzer::Traits>(p));
-  
-	    evaluators->push_back(e);
-	  }
+          {
+            Teuchos::RCP<const panzer::PointRule> pr = ir;
+            std::vector<std::string> values(2);
+            values[0] = key+"_DIFF";
+            values[1] = key+"_DIFF";
 
-	  {
-	    std::vector<std::string> values(2);
-	    values[0] = key+"_L2";
-	    values[1] = key+"_H1Semi";
-  
-	    Teuchos::ParameterList p;
-	    p.set("Sum Name",key); // Name of sum
-	    p.set<RCP<std::vector<std::string> > >("Values Names",Teuchos::rcpFromRef(values));
-	    p.set("Data Layout",ir->dl_scalar);
-  
-	    RCP< Evaluator<panzer::Traits> > e = 
-	      rcp(new panzer::Sum<EvalT,panzer::Traits>(p));
-  
-	    evaluators->push_back(e);
-	  }
+            Teuchos::ParameterList p;
+            p.set("Product Name",key);
+            p.set("Values Names",Teuchos::rcpFromRef(values));
+            p.set("Data Layout",ir->dl_scalar);
 
-	  found = true;
-	}
+            RCP< Evaluator<panzer::Traits> > e =
+                rcp(new panzer::Product<EvalT,panzer::Traits>(p));
+
+            evaluators->push_back(e);
+          }
+
+          found = true;
+        }
+        else if(type=="H1 ERROR_CALC") {
+          // Compute L2 contribution
+          {
+            std::vector<std::string> values(2);
+            values[0] = plist.get<std::string>("Field A");
+            values[1] = plist.get<std::string>("Field B");
+
+            std::vector<double> scalars(2);
+            scalars[0] = 1.0;
+            scalars[1] = -1.0;
+
+            Teuchos::ParameterList p;
+            p.set("Sum Name",key+"_H1_L2DIFF"); // Name of sum
+            p.set<RCP<std::vector<std::string> > >("Values Names",Teuchos::rcpFromRef(values));
+            p.set<RCP<const std::vector<double> > >("Scalars",Teuchos::rcpFromRef(scalars));
+            p.set("Data Layout",ir->dl_scalar);
+
+            RCP< Evaluator<panzer::Traits> > e =
+                rcp(new panzer::Sum<EvalT,panzer::Traits>(p));
+
+            evaluators->push_back(e);
+          }
+
+          {
+            std::vector<std::string> values(2);
+            values[0] = "GRAD_"+plist.get<std::string>("Field A");
+            values[1] = "GRAD_"+plist.get<std::string>("Field B");
+
+            std::vector<double> scalars(2);
+            scalars[0] = 1.0;
+            scalars[1] = -1.0;
+
+            Teuchos::ParameterList p;
+            p.set("Sum Name","GRAD_"+key+"_DIFF"); // Name of sum
+            p.set<RCP<std::vector<std::string> > >("Values Names",Teuchos::rcpFromRef(values));
+            p.set<RCP<const std::vector<double> > >("Scalars",Teuchos::rcpFromRef(scalars));
+            p.set("Data Layout",ir->dl_vector);
+
+            RCP< Evaluator<panzer::Traits> > e =
+                rcp(new panzer::Sum<EvalT,panzer::Traits>(p));
+
+            evaluators->push_back(e);
+          }
+
+          {
+            Teuchos::RCP<const panzer::PointRule> pr = ir;
+            std::vector<std::string> values(2);
+            values[0] = "GRAD_"+key+"_DIFF";
+            values[1] = "GRAD_"+key+"_DIFF";
+
+            Teuchos::ParameterList p;
+            p.set("Product Name",key+"_H1Semi");
+            p.set("Values Names",Teuchos::rcpFromRef(values));
+            p.set("Data Layout",ir->dl_vector);
+
+            RCP< Evaluator<panzer::Traits> > e =
+                panzer::buildEvaluator_DotProduct<EvalT,panzer::Traits>(key,*ir,values[0],values[1]);
+
+            evaluators->push_back(e);
+          }
+
+          {
+            Teuchos::RCP<const panzer::PointRule> pr = ir;
+            std::vector<std::string> values(2);
+            values[0] = key+"_H1_L2DIFF";
+            values[1] = key+"_H1_L2DIFF";
+
+            Teuchos::ParameterList p;
+            p.set("Product Name",key+"_L2");
+            p.set("Values Names",Teuchos::rcpFromRef(values));
+            p.set("Data Layout",ir->dl_scalar);
+
+            RCP< Evaluator<panzer::Traits> > e =
+                rcp(new panzer::Product<EvalT,panzer::Traits>(p));
+
+            evaluators->push_back(e);
+          }
+
+          {
+            std::vector<std::string> values(2);
+            values[0] = key+"_L2";
+            values[1] = key+"_H1Semi";
+
+            Teuchos::ParameterList p;
+            p.set("Sum Name",key); // Name of sum
+            p.set<RCP<std::vector<std::string> > >("Values Names",Teuchos::rcpFromRef(values));
+            p.set("Data Layout",ir->dl_scalar);
+
+            RCP< Evaluator<panzer::Traits> > e =
+                rcp(new panzer::Sum<EvalT,panzer::Traits>(p));
+
+            evaluators->push_back(e);
+          }
+
+          found = true;
+        }
       }
 
       if (!found) {
-	std::stringstream msg;
-	msg << "ClosureModelFactory failed to build evaluator for key \"" << key 
-	    << "\"\nin model \"" << model_id 
-	    << "\".  Please correct the type or add support to the \nfactory." <<std::endl;
-	TEUCHOS_TEST_FOR_EXCEPTION(!found, std::logic_error, msg.str());
+        std::stringstream msg;
+        msg << "ClosureModelFactory failed to build evaluator for key \"" << key
+            << "\"\nin model \"" << model_id
+            << "\".  Please correct the type or add support to the \nfactory." <<std::endl;
+        TEUCHOS_TEST_FOR_EXCEPTION(!found, std::logic_error, msg.str());
       }
 
     }
@@ -719,13 +719,13 @@ namespace Example {
 
   class ClosureModelFactory_TemplateBuilder {
   public:
-      
-     template <typename EvalT>
-     Teuchos::RCP<panzer::ClosureModelFactoryBase> build() const 
-     {
-        return Teuchos::rcp( static_cast<panzer::ClosureModelFactoryBase*>(new Example::ModelFactory<EvalT>) );
-     }
-      
+
+    template <typename EvalT>
+    Teuchos::RCP<panzer::ClosureModelFactoryBase> build() const
+    {
+      return Teuchos::rcp( static_cast<panzer::ClosureModelFactoryBase*>(new Example::ModelFactory<EvalT>) );
+    }
+
   };
   
   /** The equation set serves two roles. The first is to let the panzer library
@@ -749,16 +749,16 @@ namespace Example {
      * equation set. 
      */
     PoissonEquationSet(const Teuchos::RCP<Teuchos::ParameterList>& params,
-		       const int& default_integration_order,
-		       const panzer::CellData& cell_data,
-		       const Teuchos::RCP<panzer::GlobalData>& global_data,
-		       const bool build_transient_support);
+                       const int& default_integration_order,
+                       const panzer::CellData& cell_data,
+                       const Teuchos::RCP<panzer::GlobalData>& global_data,
+                       const bool build_transient_support);
     
     /** The specific evaluators are registered with the field manager argument.
      */
     void buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
-					       const panzer::FieldLibrary& field_library,
-					       const Teuchos::ParameterList& user_data) const;
+                                               const panzer::FieldLibrary& field_library,
+                                               const Teuchos::ParameterList& user_data) const;
 
   };
 
@@ -766,27 +766,27 @@ namespace Example {
   template <typename EvalT>
   PoissonEquationSet<EvalT>::
   PoissonEquationSet(const Teuchos::RCP<Teuchos::ParameterList>& params,
-		     const int& default_integration_order,
-		     const panzer::CellData& cell_data,
-		     const Teuchos::RCP<panzer::GlobalData>& global_data,
-		     const bool build_transient_support) :
-    panzer::EquationSet_DefaultImpl<EvalT>(params, default_integration_order, cell_data, global_data, build_transient_support )
-  {
+                     const int& default_integration_order,
+                     const panzer::CellData& cell_data,
+                     const Teuchos::RCP<panzer::GlobalData>& global_data,
+                     const bool build_transient_support) :
+                     panzer::EquationSet_DefaultImpl<EvalT>(params, default_integration_order, cell_data, global_data, build_transient_support )
+                     {
     // ********************
     // Validate and parse parameter list
     // ********************
     {    
       Teuchos::ParameterList valid_parameters;
       this->setDefaultValidParameters(valid_parameters);
-    
+
       valid_parameters.set("Model ID","","Closure model id associated with this equaiton set");
       valid_parameters.set("Basis Type","HGrad","Type of Basis to use");
       valid_parameters.set("Basis Order",1,"Order of the basis");
       valid_parameters.set("Integration Order",-1,"Order of the integration rule");
-    
+
       params->validateParametersAndSetDefaults(valid_parameters);
     }
-  
+
     std::string basis_type = params->get<std::string>("Basis Type");
     int basis_order = params->get<int>("Basis Order");
     int integration_order = params->get<int>("Integration Order");
@@ -824,18 +824,18 @@ namespace Example {
     // ********************
     // Build Basis Functions and Integration Rules
     // ********************
-   
+
     this->addClosureModel(model_id);
 
     this->setupDOFs();
-  }
+                     }
 
   // ***********************************************************************
   template <typename EvalT>
   void PoissonEquationSet<EvalT>::
   buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
-					const panzer::FieldLibrary& /* fl */,
-					const Teuchos::ParameterList& /* user_data */) const
+                                        const panzer::FieldLibrary& /* fl */,
+                                        const Teuchos::ParameterList& /* user_data */) const
   {
     using panzer::BasisIRLayout;
     using panzer::EvaluatorStyle;
@@ -848,7 +848,7 @@ namespace Example {
     using Teuchos::ParameterList;
     using Teuchos::RCP;
     using Teuchos::rcp;
-  
+
     RCP<IntegrationRule> ir = this->getIntRuleForDOF("TEMPERATURE");
     RCP<BasisIRLayout> basis = this->getBasisIRLayoutForDOF("TEMPERATURE"); 
 
@@ -858,14 +858,12 @@ namespace Example {
 
     // Transient Operator: Assembles \int \dot{T} v
     if (this->buildTransientSupport())
-      {
-	string resName("RESIDUAL_TEMPERATURE"), valName("DXDT_TEMPERATURE");
-	double multiplier(1);
-	RCP<Evaluator<Traits>> op = rcp(new
-					Integrator_BasisTimesScalar<EvalT, Traits>(EvaluatorStyle::CONTRIBUTES,
-										   resName, valName, *basis, *ir, multiplier));
-	this->template registerEvaluator<EvalT>(fm, op);
-      }
+    {
+      string resName("RESIDUAL_TEMPERATURE"), valName("DXDT_TEMPERATURE");
+      double multiplier(1);
+      RCP<Evaluator<Traits>> op = rcp(new Integrator_BasisTimesScalar<EvalT, Traits>(EvaluatorStyle::CONTRIBUTES, resName, valName, *basis, *ir, multiplier));
+      this->template registerEvaluator<EvalT>(fm, op);
+    }
 
     // Diffusion Operator: Assembles \int \nabla T \cdot \nabla v
     {
@@ -877,21 +875,17 @@ namespace Example {
       p.set("Basis", basis);
       p.set("IR", ir);
       p.set("Multiplier", thermal_conductivity);
-    
-      RCP<Evaluator<Traits>> op = rcp(new
-				      Integrator_GradBasisDotVector<EvalT, Traits>(p));
+
+      RCP<Evaluator<Traits>> op = rcp(new Integrator_GradBasisDotVector<EvalT, Traits>(p));
 
       this->template registerEvaluator<EvalT>(fm, op);
     }
-  
+
     // Source Operator
     {   
-      string resName("RESIDUAL_TEMPERATURE"),
-	valName("SOURCE_TEMPERATURE");
+      string resName("RESIDUAL_TEMPERATURE"), valName("SOURCE_TEMPERATURE");
       double multiplier(-1);
-      RCP<Evaluator<Traits>> op = rcp(new
-				      Integrator_BasisTimesScalar<EvalT, Traits>(EvaluatorStyle::CONTRIBUTES,
-										 resName, valName, *basis, *ir, multiplier));
+      RCP<Evaluator<Traits>> op = rcp(new Integrator_BasisTimesScalar<EvalT, Traits>(EvaluatorStyle::CONTRIBUTES, resName, valName, *basis, *ir, multiplier));
       this->template registerEvaluator<EvalT>(fm, op);
     }
   }
@@ -909,26 +903,26 @@ namespace Example {
 
     Teuchos::RCP<panzer::EquationSet_TemplateManager<panzer::Traits> >
     buildEquationSet(const Teuchos::RCP<Teuchos::ParameterList>& params,
-		     const int& default_integration_order,
-		     const panzer::CellData& cell_data,
-		     const Teuchos::RCP<panzer::GlobalData>& global_data,
-		     const bool build_transient_support) const
+                     const int& default_integration_order,
+                     const panzer::CellData& cell_data,
+                     const Teuchos::RCP<panzer::GlobalData>& global_data,
+                     const bool build_transient_support) const
     {
-      Teuchos::RCP<panzer::EquationSet_TemplateManager<panzer::Traits> > eq_set= 
-	Teuchos::rcp(new panzer::EquationSet_TemplateManager<panzer::Traits>);
-         
+      Teuchos::RCP<panzer::EquationSet_TemplateManager<panzer::Traits> > eq_set = Teuchos::rcp(new panzer::EquationSet_TemplateManager<panzer::Traits>);
+
       bool found = false; // this is used by PANZER_BUILD_EQSET_OBJECTS
-         
+
       // macro checks if(ies.name=="Poisson") then an EquationSet_Energy object is constructed
       PANZER_BUILD_EQSET_OBJECTS("Poisson", PoissonEquationSet)
-         
-	// make sure your equation set has been found
-	if(!found) {
-	  std::string msg = "Error - the \"Equation Set\" called \"" + params->get<std::string>("Type") +
-	    "\" is not a valid equation set identifier. Please supply the correct factory.\n";
-	  TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error, msg);
-	}
-         
+
+      // make sure your equation set has been found
+      if(!found)
+      {
+        std::string msg = "Error - the \"Equation Set\" called \"" + params->get<std::string>("Type") +
+            "\" is not a valid equation set identifier. Please supply the correct factory.\n";
+        TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error, msg);
+      }
+
       return eq_set;
     }
     

--- a/packages/trilinoscouplings/examples/scaling/muelu_region_poisson.hpp
+++ b/packages/trilinoscouplings/examples/scaling/muelu_region_poisson.hpp
@@ -101,12 +101,12 @@
 // Sacado headers
 #include "Sacado_mpl_apply.hpp"
 
-void perceptrenumbertest()
+void perceptrenumbertest(const unsigned int num_levels_refinement)
 {
   std::cout << "Starting perceptrenumber..." << std::endl;
 
   const unsigned int d = 2; // spatial dimension (only 2 or 3 makes sense)... I only really care about the 2D case since it's where the ccw rotation lies
-  const unsigned int r = 4; // levels of recursion/refinement
+  const unsigned int r = num_levels_refinement; // levels of recursion/refinement
   const unsigned int cells_per_dim = (1 << r); // number of cells per dim is 2^(r-1), i.e. 1<<r
   const unsigned int points_per_dim = cells_per_dim + 1; // number of points per spatial dimension is just 1 higher
   const unsigned int num_cells = (d<3)? cells_per_dim*cells_per_dim : cells_per_dim*cells_per_dim*cells_per_dim; // evil ternary op code

--- a/packages/trilinoscouplings/examples/scaling/muelu_region_poisson.hpp
+++ b/packages/trilinoscouplings/examples/scaling/muelu_region_poisson.hpp
@@ -101,26 +101,36 @@
 // Sacado headers
 #include "Sacado_mpl_apply.hpp"
 
-void perceptrenumbertest(const unsigned int num_levels_refinement)
+// because Percept's breakers order things in a counter-clockwise fashion,
+// this function recreates percept's
+std::vector<unsigned int> perceptrenumbertest(const unsigned int num_levels_refinement)
 {
+
+  std::vector<unsigned int> renumber;
+
+  const bool print_info = true;
+
   std::cout << "Starting perceptrenumber..." << std::endl;
 
-  const unsigned int d = 2; // spatial dimension (only 2 or 3 makes sense)... I only really care about the 2D case since it's where the ccw rotation lies
+  const unsigned int d = 3; // spatial dimension (only 2 or 3 makes sense)... I only really care about the 2D case since it's where the ccw rotation lies
   const unsigned int r = num_levels_refinement; // levels of recursion/refinement
   const unsigned int cells_per_dim = (1 << r); // number of cells per dim is 2^(r-1), i.e. 1<<r
   const unsigned int points_per_dim = cells_per_dim + 1; // number of points per spatial dimension is just 1 higher
-  const unsigned int num_cells = (d<3)? cells_per_dim*cells_per_dim : cells_per_dim*cells_per_dim*cells_per_dim; // evil ternary op code
-  const unsigned int num_points = (d<3)? points_per_dim*points_per_dim : points_per_dim*points_per_dim*points_per_dim; // evil ternary op code
+  const unsigned int num_cells = (d<3)? cells_per_dim*cells_per_dim : cells_per_dim*cells_per_dim*cells_per_dim; // evil ternary op code to avoid using pow
+  const unsigned int num_points = (d<3)? points_per_dim*points_per_dim : points_per_dim*points_per_dim*points_per_dim; // evil ternary op code to avoid using pow
 
-  std::cout << "Parameters: " << std::endl;
-  std::cout << "   Dimension = " << d << std::endl;
-  std::cout << "      Levels = " << r << std::endl;
-  std::cout << "   Cells/dim = " << cells_per_dim << std::endl;
-  std::cout << "       Cells = " << num_cells << std::endl;
-  std::cout << "  Points/dim = " << points_per_dim << std::endl;
-  std::cout << "      Points = " << num_points << std::endl;
-  std::cout << std::endl;
-  std::cout << "Running re-ordering scheme..." << std::endl;
+  if(print_info)
+  {
+    std::cout << "Parameters: " << std::endl;
+    std::cout << "   Dimension = " << d << std::endl;
+    std::cout << "      Levels = " << r << std::endl;
+    std::cout << "   Cells/dim = " << cells_per_dim << std::endl;
+    std::cout << "       Cells = " << num_cells << std::endl;
+    std::cout << "  Points/dim = " << points_per_dim << std::endl;
+    std::cout << "      Points = " << num_points << std::endl;
+    std::cout << std::endl;
+    std::cout << "Running re-ordering scheme..." << std::endl;
+  }
 
   unsigned int percept[2][2][2];
 
@@ -157,27 +167,73 @@ void perceptrenumbertest(const unsigned int num_levels_refinement)
         for(unsigned int k=0; k<cells_per_dim; ++k)
           outputorder[i][j][k] = outputorder[i][j][k] + (1<<(d*(r-1)))*percept[i/(cells_per_dim/2)][j/(cells_per_dim/2)][k/(cells_per_dim/2)];
 
-
-    std::cout << "Outputting Percept's order in 2D... " << std::endl;
-    for(int j=cells_per_dim-1; j>=0; --j)
+    // note: there's a lot of nonsense here to prettily format the output and make sure things look correct
+    if(d==2)
     {
-      std::cout << outputorder[0][j][0];
-      for(unsigned int i=1; i<cells_per_dim; ++i)
+      if(print_info)
       {
-        std::cout << " " << outputorder[i][j][0];
-      }
-      std::cout << std::endl;
-    }
+        std::cout << "Outputting Percept's order in 2D... " << std::endl;
+        for(int j=cells_per_dim-1; j>=0; --j)
+        {
+          std::cout << outputorder[0][j][0];
+          for(unsigned int i=1; i<cells_per_dim; ++i)
+          {
+            std::cout << " " << outputorder[i][j][0];
+          }
+          std::cout << std::endl;
+        }
 
-    std::cout << "Outputting the lexicographic reordering..." << std::endl;
-    for(unsigned int j=0; j<cells_per_dim; ++j)
-      for(unsigned int i=0; i<cells_per_dim; ++i)
-        std::cout << " " << outputorder[i][j][0];
-    std::cout << std::endl;
+        std::cout << "Outputting the lexicographic reordering..." << std::endl;
+        for(unsigned int j=0; j<cells_per_dim; ++j)
+          for(unsigned int i=0; i<cells_per_dim; ++i)
+            std::cout << " " << outputorder[i][j][0];
+        std::cout << std::endl;
+      }
+
+      // fill the renumber lexicographically
+      for(unsigned int j=0; j<cells_per_dim; ++j)
+        for(unsigned int i=0; i<cells_per_dim; ++i)
+          renumber.push_back(outputorder[i][j][0]);
+    }
+    else
+    {
+      if(print_info)
+      {
+        std::cout << "Outputting Percept's order in 3D... " << std::endl;
+        for(int k=cells_per_dim-1; k>=0; --k)
+        {
+          for(int j=cells_per_dim-1; j>=0; --j)
+          {
+            std::cout << outputorder[0][j][k];
+            for(unsigned int i=1; i<cells_per_dim; ++i)
+            {
+              std::cout << " " << outputorder[i][j][k];
+            }
+            std::cout << std::endl;
+          }
+          std::cout << std::endl;
+        }
+
+        std::cout << "Outputting the lexicographic reordering..." << std::endl;
+        for(unsigned int k=0; k<cells_per_dim; ++k)
+          for(unsigned int j=0; j<cells_per_dim; ++j)
+            for(unsigned int i=0; i<cells_per_dim; ++i)
+              std::cout << " " << outputorder[i][j][k];
+        std::cout << std::endl;
+      }
+
+      // fill the renumber lexicographically
+      for(unsigned int k=0; k<cells_per_dim; ++k)
+        for(unsigned int j=0; j<cells_per_dim; ++j)
+          for(unsigned int i=0; i<cells_per_dim; ++i)
+            renumber.push_back(outputorder[i][j][k]);
+    }
   }
 
   std::cout << "Done!" << std::endl;
   std::cout << std::endl;
+
+  return renumber;
 }
 
 

--- a/packages/trilinoscouplings/examples/scaling/muelu_region_poisson.hpp
+++ b/packages/trilinoscouplings/examples/scaling/muelu_region_poisson.hpp
@@ -138,6 +138,7 @@ std::vector<unsigned int> renumberPerceptCellsToLexicographic(const unsigned int
 
   // notice the numbering is ccw in the xy plane
   // assuming the indexing is [x][y][z]... this looks backwards as far as access patterns go
+  //Kokkos::View<unsigned int***,HostSpace> percept(2,2,2);
   percept[0][0][0] = 0;
   percept[1][0][0] = 1;
   percept[1][1][0] = 2;
@@ -430,7 +431,7 @@ namespace Example {
   {
     using Teuchos::RCP;
 
-    Teuchos::RCP<PHX::DataLayout> data_layout = ir.dl_scalar;
+    RCP<PHX::DataLayout> data_layout = ir.dl_scalar;
     ir_degree = ir.cubature_degree;
 
     source = PHX::MDField<ScalarT,Cell,Point>(name, data_layout);
@@ -498,8 +499,8 @@ namespace Example {
   {
     using Teuchos::RCP;
 
-    Teuchos::RCP<PHX::DataLayout> data_layout_scalar = ir.dl_scalar;
-    Teuchos::RCP<PHX::DataLayout> data_layout_vector = ir.dl_vector;
+    RCP<PHX::DataLayout> data_layout_scalar = ir.dl_scalar;
+    RCP<PHX::DataLayout> data_layout_vector = ir.dl_vector;
     ir_degree = ir.cubature_degree;
 
     solution = PHX::MDField<ScalarT,Cell,Point>(name, data_layout_scalar);
@@ -573,7 +574,7 @@ namespace Example {
       TEUCHOS_TEST_FOR_EXCEPTION(!models.isSublist(model_id), std::logic_error, msg.str());
     }
 
-    std::vector<Teuchos::RCP<const panzer::PureBasis> > bases;
+    std::vector<RCP<const panzer::PureBasis> > bases;
     fl.uniqueBases(bases);
 
     const ParameterList& my_models = models.sublist(model_id);
@@ -598,11 +599,11 @@ namespace Example {
           evaluators->push_back(e);
         }
 
-        for (std::vector<Teuchos::RCP<const panzer::PureBasis> >::const_iterator basis_itr = bases.begin();
+        for (std::vector<RCP<const panzer::PureBasis> >::const_iterator basis_itr = bases.begin();
             basis_itr != bases.end(); ++basis_itr) { // at BASIS
           input.set("Name", key);
           input.set("Value", plist.get<double>("Value"));
-          Teuchos::RCP<const panzer::BasisIRLayout> basis = basisIRLayout(*basis_itr,*ir);
+          RCP<const panzer::BasisIRLayout> basis = basisIRLayout(*basis_itr,*ir);
           input.set("Data Layout", basis->functional);
           RCP< Evaluator<panzer::Traits> > e =
               rcp(new panzer::Constant<EvalT,panzer::Traits>(input));
@@ -650,7 +651,7 @@ namespace Example {
           }
 
           {
-            Teuchos::RCP<const panzer::PointRule> pr = ir;
+            RCP<const panzer::PointRule> pr = ir;
             std::vector<std::string> values(2);
             values[0] = key+"_DIFF";
             values[1] = key+"_DIFF";
@@ -713,7 +714,7 @@ namespace Example {
           }
 
           {
-            Teuchos::RCP<const panzer::PointRule> pr = ir;
+            RCP<const panzer::PointRule> pr = ir;
             std::vector<std::string> values(2);
             values[0] = "GRAD_"+key+"_DIFF";
             values[1] = "GRAD_"+key+"_DIFF";
@@ -730,7 +731,7 @@ namespace Example {
           }
 
           {
-            Teuchos::RCP<const panzer::PointRule> pr = ir;
+            RCP<const panzer::PointRule> pr = ir;
             std::vector<std::string> values(2);
             values[0] = key+"_H1_L2DIFF";
             values[1] = key+"_H1_L2DIFF";

--- a/packages/trilinoscouplings/examples/scaling/muelu_region_poisson.hpp
+++ b/packages/trilinoscouplings/examples/scaling/muelu_region_poisson.hpp
@@ -123,28 +123,25 @@
  * it recursively orders counterclockwise on top of each level of refinement.
  * For a more visual description of what's happening, pass print_details=true
  */
-std::vector<unsigned int> renumberPerceptCellsToLexicographic(const unsigned int num_levels_refinement, const bool print_details=false)
+std::vector<size_t> renumberPerceptCellsToLexicographic(const unsigned int num_levels_refinement, const unsigned int dimension, const bool print_details=false)
 {
-  std::vector<unsigned int> renumber; // output array
+  std::vector<size_t> renumber; // output array
 
-  const unsigned int d = 3; // spatial dimension (only 2 or 3 makes sense)...
+  const unsigned int d = dimension; // spatial dimension (only 2 or 3 makes sense)...
   const unsigned int r = num_levels_refinement; // levels of recursion/refinement
   const unsigned int cells_per_dim = (1 << r); // number of cells per dim is 2^(r-1), i.e. 1<<r
-  const unsigned int points_per_dim = cells_per_dim + 1; // number of points per spatial dimension is just 1 higher
-  const unsigned int num_cells = (d<3)? cells_per_dim*cells_per_dim : cells_per_dim*cells_per_dim*cells_per_dim; // evil ternary op code to avoid using pow
-  const unsigned int num_points = (d<3)? points_per_dim*points_per_dim : points_per_dim*points_per_dim*points_per_dim; // evil ternary op code to avoid using pow
 
   // notice the numbering is ccw in the xy plane
   // assuming the indexing is (x,y,z)... this looks backwards as far as access patterns go, but probably not important for performance since this is only called once
   Kokkos::View<unsigned int***,Kokkos::HostSpace> percept_view("Percept ordering",2,2,2);
   percept_view(0,0,0) = 0;
   percept_view(1,0,0) = 1;
-  percept_view(1,1,0) = 2;
   percept_view(0,1,0) = 3;
+  percept_view(1,1,0) = 2;
   percept_view(0,0,1) = 4;
   percept_view(1,0,1) = 5;
-  percept_view(1,1,1) = 6;
   percept_view(0,1,1) = 7;
+  percept_view(1,1,1) = 6;
 
   // scope in case I decide to copypasta
   {

--- a/packages/trilinoscouplings/examples/scaling/muelu_region_poisson.hpp
+++ b/packages/trilinoscouplings/examples/scaling/muelu_region_poisson.hpp
@@ -143,7 +143,6 @@ std::vector<size_t> renumberPerceptCellsToLexicographic(const unsigned int num_l
   percept_view(0,1,1) = 7;
   percept_view(1,1,1) = 6;
 
-  // scope in case I decide to copypasta
   {
     // initialize to 0
     Kokkos::View<unsigned int***,Kokkos::HostSpace> outputorder("Multi-level re-numbering indices",cells_per_dim,cells_per_dim,cells_per_dim);

--- a/packages/trilinoscouplings/examples/scaling/muelu_region_poisson.hpp
+++ b/packages/trilinoscouplings/examples/scaling/muelu_region_poisson.hpp
@@ -134,10 +134,8 @@ std::vector<unsigned int> renumberPerceptCellsToLexicographic(const unsigned int
   const unsigned int num_cells = (d<3)? cells_per_dim*cells_per_dim : cells_per_dim*cells_per_dim*cells_per_dim; // evil ternary op code to avoid using pow
   const unsigned int num_points = (d<3)? points_per_dim*points_per_dim : points_per_dim*points_per_dim*points_per_dim; // evil ternary op code to avoid using pow
 
-  //unsigned int percept[2][2][2];
-
   // notice the numbering is ccw in the xy plane
-  // assuming the indexing is [x][y][z]... this looks backwards as far as access patterns go
+  // assuming the indexing is (x,y,z)... this looks backwards as far as access patterns go, but probably not important for performance since this is only called once
   Kokkos::View<unsigned int***,Kokkos::HostSpace> percept_view("Percept ordering",2,2,2);
   percept_view(0,0,0) = 0;
   percept_view(1,0,0) = 1;
@@ -148,21 +146,8 @@ std::vector<unsigned int> renumberPerceptCellsToLexicographic(const unsigned int
   percept_view(1,1,1) = 6;
   percept_view(0,1,1) = 7;
 
-  // percept[0][0][0] = 0;
-  // percept[1][0][0] = 1;
-  // percept[1][1][0] = 2;
-  // percept[0][1][0] = 3;
-  // percept[0][0][1] = 4;
-  // percept[1][0][1] = 5;
-  // percept[1][1][1] = 6;
-  // percept[0][1][1] = 7;
-
   // scope in case I decide to copypasta
   {
-    // TODO: this uses VLAs on the stack for simplicity, but using a different
-    // data structure on the heap would be safer. we'll return to this if it
-    // severely affects performance, but we'll likely keep num_refinements<=8
-
     // initialize to 0
     Kokkos::View<unsigned int***,Kokkos::HostSpace> outputorder("Multi-level re-numbering indices",cells_per_dim,cells_per_dim,cells_per_dim);
     for(unsigned int i=0; i<cells_per_dim; ++i)

--- a/packages/trilinoscouplings/examples/scaling/muelu_region_poisson_1.gen
+++ b/packages/trilinoscouplings/examples/scaling/muelu_region_poisson_1.gen
@@ -1,0 +1,26 @@
+mesh
+  rectilinear
+    nx 1
+    ny 1
+    nz 1
+    bx 1
+    by 1
+    bz 1
+    gmin = 0.0 0.0 0.0
+    gmax = 1.0 1.0 1.0
+  end
+  set assign
+    sideset,jlo,1
+    sideset,ihi,2
+    sideset,jhi,3
+    sideset,ilo,4
+    sideset,klo,5
+    sideset,khi,6
+    nodeset,jlo,1
+    nodeset,ihi,2
+    nodeset,jhi,3
+    nodeset,ilo,4
+    nodeset,klo,5
+    nodeset,khi,6
+  end
+end

--- a/packages/trilinoscouplings/examples/scaling/muelu_region_poisson_input.xml
+++ b/packages/trilinoscouplings/examples/scaling/muelu_region_poisson_input.xml
@@ -1,0 +1,1 @@
+<!-- GH: Come back and fill this with a region parameter deck for structured_1dof probably  -->

--- a/packages/trilinoscouplings/examples/scaling/muelu_region_poisson_input.xml
+++ b/packages/trilinoscouplings/examples/scaling/muelu_region_poisson_input.xml
@@ -1,1 +1,132 @@
-<!-- GH: Come back and fill this with a region parameter deck for structured_1dof probably  -->
+<ParameterList name="MueLu">
+
+  <!-- Configuration of the Xpetra operator (fine level) -->
+  <ParameterList name="Matrix">
+    <Parameter name="PDE equations"                   type="int" value="1"/> <!-- Number of PDE equations at each grid node.-->
+  </ParameterList>
+
+  <!-- Factory collection -->
+  <ParameterList name="Factories">
+
+    <ParameterList name="myAmalgamationFact">
+      <Parameter name="factory"                             type="string" value="AmalgamationFactory"/>
+    </ParameterList>
+
+    <ParameterList name="myCoalesceDropFact">
+      <Parameter name="factory"                             type="string" value="CoalesceDropFactory"/>
+      <Parameter name="lightweight wrap"                    type="bool"   value="true"/>
+      <Parameter name="aggregation: drop tol"               type="double" value="0.00"/>
+      <Parameter name="UnAmalgamationInfo"                  type="string" value="myAmalgamationFact"/>
+    </ParameterList>
+
+    <ParameterList name="myAggregationFact">
+      <Parameter name="factory"                                   type="string" value="StructuredAggregationFactory"/>
+      <Parameter name="aggregation: coupling"                     type="string" value="uncoupled"/>
+      <Parameter name="aggregation: output type"                  type="string" value="CrsGraph"/>
+      <Parameter name="aggregation: coarsening order"             type="int"    value="0"/>
+      <Parameter name="aggregation: coarsening rate"              type="string" value="{2}"/>
+      <Parameter name="Graph"                                     type="string" value="myCoalesceDropFact"/>
+    </ParameterList>
+
+    <ParameterList name="myCoarseMapFact">
+      <Parameter name="factory"                             type="string" value="CoarseMapFactory"/>
+      <Parameter name="Aggregates"                          type="string" value="myAggregationFact"/>
+    </ParameterList>
+
+    <!-- Note that ParameterLists must be defined prior to being used -->
+    <ParameterList name="myProlongatorFact">
+      <Parameter name="factory"                             type="string" value="GeometricInterpolationPFactory"/>
+      <Parameter name="interp: build coarse coordinates"    type="bool"   value="true"/>
+      <Parameter name="interp: interpolation order"         type="int"    value="0"/>
+      <Parameter name="prolongatorGraph"                    type="string" value="myAggregationFact"/>
+      <Parameter name="coarseCoordinatesFineMap"            type="string" value="myAggregationFact"/>
+      <Parameter name="coarseCoordinatesMap"                type="string" value="myAggregationFact"/>
+    </ParameterList>
+
+    <ParameterList name="myCoordTransferFact">
+      <Parameter name="factory"                             type="string" value="CoordinatesTransferFactory"/>
+      <Parameter name="structured aggregation"              type="bool"   value="true"/>
+      <Parameter name="numDimensions"                       type="string" value="myAggregationFact"/>
+      <Parameter name="lCoarseNodesPerDim"                  type="string" value="myAggregationFact"/>
+    </ParameterList>
+
+    <ParameterList name="myNullspaceFact">
+      <Parameter name="factory"                             type="string" value="NullspaceFactory"/>
+      <Parameter name="Nullspace"                           type="string" value="myProlongatorFact"/>
+    </ParameterList>
+
+    <ParameterList name="myRestrictorFact">
+      <Parameter name="factory"                             type="string" value="TransPFactory"/>
+    </ParameterList>
+
+    <!-- <ParameterList name="myAggExport"> -->
+    <!--   <Parameter name="factory"                             type="string" value="AggregationExportFactory"/> -->
+    <!--   <Parameter name="Aggregates"                          type="string" value="myAggregationFact"/> -->
+    <!--   <Parameter name="aggregation: output filename"        type="string" value="structured_aggs"/> -->
+    <!--   <Parameter name="aggregation: output file: agg style" type="string" value="Jacks"/> -->
+    <!--   <Parameter name="aggregation: output file: agg style" type="string" value="Convex Hulls"/> -->
+    <!-- </ParameterList> -->
+
+    <ParameterList name="myRAPFact">
+      <Parameter name="factory"                             type="string" value="RAPFactory"/>
+      <Parameter name="P"                                   type="string" value="myProlongatorFact"/>
+      <Parameter name="R"                                   type="string" value="myRestrictorFact"/>
+      <ParameterList name="TransferFactories">
+        <Parameter name="CoordinateTransfer"                type="string" value="myCoordTransferFact"/>
+        <!-- <Parameter name="AggregationExportFactory"                type="string" value="myAggExport"/> -->
+      </ParameterList>
+    </ParameterList>
+
+    <ParameterList name="myILU">
+      <Parameter name="factory" type="string" value="TrilinosSmoother"/>
+      <Parameter name="type"  type="string" value="RILUK"/>
+      <ParameterList name="ParameterList">
+        <Parameter name="schwarz: overlap level"           type="int"    value="1"/>
+        <Parameter name="schwarz: combine mode"            type="string" value="Zero"/>
+        <Parameter name="schwarz: use reordering"          type="bool"   value="false"/>
+        <Parameter name="fact: iluk level-of-fill"         type="int"    value="0"/>
+        <Parameter name="fact: absolute threshold"         type="double" value="0."/>
+        <Parameter name="fact: relative threshold"         type="double" value="1."/>
+        <Parameter name="fact: relax value"                type="double" value="0."/>
+      </ParameterList>
+    </ParameterList>
+
+    <ParameterList name="myJacobi">
+      <Parameter name="factory" type="string" value="TrilinosSmoother"/>
+      <Parameter name="type"  type="string" value="RELAXATION"/>
+      <ParameterList name="ParameterList">
+        <Parameter name="relaxation: type"                 type="string"    value="Jacobi"/>
+        <Parameter name="relaxation: sweeps"               type="int"       value="1"/>
+        <Parameter name="relaxation: damping"              type="double"    value="0.666"/>
+      </ParameterList>
+    </ParameterList>
+
+  </ParameterList>
+
+
+  <!-- Definition of the multigrid preconditioner -->
+  <ParameterList name="Hierarchy">
+
+    <Parameter name="max levels"                            type="int"      value="6"/> <!-- Max number of levels -->
+    <Parameter name="cycle type"                            type="string"   value="W"/>
+    <Parameter name="coarse: max size"                      type="int"      value="20"/> <!-- Min number of rows on coarsest level -->
+    <Parameter name="verbosity"                             type="string"   value="High"/>
+
+    <ParameterList name="All">
+      <Parameter name="PreSmoother"                         type="string"   value="NoSmoother"/>
+      <Parameter name="PostSmoother"                        type="string"   value="NoSmoother"/>
+      <Parameter name="Nullspace"                           type="string"   value="myNullspaceFact"/>
+      <Parameter name="Aggregates"                          type="string"   value="myAggregationFact"/>
+      <Parameter name="lCoarseNodesPerDim"                  type="string"   value="myAggregationFact"/>
+      <Parameter name="P"                                   type="string"   value="myProlongatorFact"/>
+      <Parameter name="R"                                   type="string"   value="myRestrictorFact"/>
+      <Parameter name="A"                                   type="string"   value="myRAPFact"/>
+      <!-- <Parameter name="CoarseSolver"                        type="string"   value="DirectSolver"/> -->
+      <Parameter name="CoarseSolver"                        type="string"   value="myILU"/>
+      <Parameter name="Coordinates"                         type="string"   value="myProlongatorFact"/>
+      <Parameter name="lNodesPerDim"                        type="string"   value="myCoordTransferFact"/>
+      <Parameter name="numDimensions"                       type="string"   value="myCoordTransferFact"/>
+    </ParameterList>
+  </ParameterList>
+
+</ParameterList>

--- a/packages/trilinoscouplings/examples/scaling/muelu_region_poisson_input_coarse.xml
+++ b/packages/trilinoscouplings/examples/scaling/muelu_region_poisson_input_coarse.xml
@@ -1,0 +1,78 @@
+<ParameterList name="MueLu">
+  <!-- Factory collection -->
+  <ParameterList name="Factories">
+
+    <ParameterList name="UncoupledAggregationFact">
+      <Parameter name="factory"                             type="string" value="UncoupledAggregationFactory"/>
+      <Parameter name="aggregation: ordering"               type="string" value="natural"/>
+      <Parameter name="aggregation: max selected neighbors" type="int"    value="0"/>
+      <Parameter name="aggregation: min agg size"           type="int"    value="2"/>
+    </ParameterList>
+
+    <ParameterList name="myTentativePFact">
+      <Parameter name="factory"                             type="string" value="TentativePFactory"/>
+      <Parameter name="tentative: build coarse coordinates" type="bool"   value="false"/>
+    </ParameterList>
+
+    <ParameterList name="myProlongatorFact">
+      <Parameter name="factory"                             type="string" value="SaPFactory"/>
+      <Parameter name="P"                                   type="string" value="myTentativePFact"/>
+      <Parameter name="sa: damping factor"                  type="double" value="1.33333333"/>
+    </ParameterList>
+
+    <ParameterList name="myRestrictorFact">
+      <Parameter name="factory"                             type="string" value="TransPFactory"/>
+      <Parameter name="P"                                   type="string" value="myProlongatorFact"/>
+    </ParameterList>
+
+    <ParameterList name="myRAPFact">
+      <Parameter name="factory"                             type="string" value="RAPFactory"/>
+      <Parameter name="P"                                   type="string" value="myProlongatorFact"/>
+      <Parameter name="R"                                   type="string" value="myRestrictorFact"/>
+    </ParameterList>
+
+    <ParameterList name="Chebyshev">
+      <Parameter name="factory"                             type="string"  value="TrilinosSmoother"/>
+      <Parameter name="type"                                type="string"  value="CHEBYSHEV"/>
+
+      <ParameterList name="ParameterList">
+        <Parameter name="chebyshev: degree"                 type="int"     value="3"/>>
+        <!-- 7 in 2D, 20 in 3D -->
+        <Parameter name="chebyshev: ratio eigenvalue"       type="double"  value="20"/>
+        <Parameter name="chebyshev: min eigenvalue"         type="double"  value="1.0"/>
+        <Parameter name="chebyshev: zero starting solution" type="bool"    value="true"/>
+      </ParameterList>
+    </ParameterList>
+
+    <ParameterList name="mySGS">
+      <Parameter name="factory"                             type="string"  value="TrilinosSmoother"/>
+      <Parameter name="type"                                type="string"  value="RELAXATION"/>
+      <ParameterList name="ParameterList">
+        <Parameter name="relaxation: type"                  type="string"  value="Symmetric Gauss-Seidel"/>
+        <Parameter name="relaxation: sweeps"                type="int"     value="1"/>
+      </ParameterList>
+    </ParameterList>
+
+  </ParameterList>
+
+  <!-- Definition of the multigrid preconditioner -->
+  <ParameterList name="Hierarchy">
+
+    <Parameter name="max levels"                            type="int"      value="3"/>
+    <Parameter name="coarse: max size"                      type="int"      value="10"/>
+    <Parameter name="cycle type"                            type="string"   value="V"/>
+    <Parameter name="verbosity"                             type="string"   value="High"/>
+    <Parameter name="use kokkos refactor"                   type="bool"     value="false"/>
+
+    <ParameterList name="All">
+      <Parameter name="Smoother"                            type="string"   value="mySGS"/>
+      <Parameter name="Aggregates"                          type="string"   value="UncoupledAggregationFact"/>
+      <Parameter name="Nullspace"                           type="string"   value="myTentativePFact"/>
+      <Parameter name="P"                                   type="string"   value="myProlongatorFact"/>
+      <Parameter name="R"                                   type="string"   value="myRestrictorFact"/>
+      <Parameter name="CoarseSolver"                        type="string"   value="DirectSolver"/>
+    </ParameterList>
+
+  </ParameterList>
+
+</ParameterList>


### PR DESCRIPTION
@lucbv 

This code is the start of the region driver for TrilinosCouplings. I'll put a checklist below of things I personally want to work on, but I'm also interested in a review.
- [x] Reorganize the header file. Right now, it's a little messy.
- [x] Setup command line argument parsing or an xml file for the MueLu solver
- [x] Region headers still can't be detected by this file for some reason
- [ ] Errors when running it look a little funny, even on a quad mesh. This probably means there's something that needs to be fixed with how the physics on the blocks is set, or it could be as simple as correcting inputs from the Pamgen mesh.
- [x] Add timers so we can analyze scalability results

## Motivation
To implement MueLu's region capabilities in a more general setting that uses meshes and discretizations.

## Testing
This is what I use to test it on my workstation.
[configure-trilinos-trilinoscouplings-region.txt](https://github.com/trilinos/Trilinos/files/5661111/configure-trilinos-trilinoscouplings-region.txt)
