### PR TITLE
Issue 8429

### DIFF
--- a/cmake/std/sems/PullRequestClang10.0.0TestingEnv.sh
+++ b/cmake/std/sems/PullRequestClang10.0.0TestingEnv.sh
@@ -9,13 +9,13 @@
 # $ module purge
 # or Trilinos/cmake/unload_sems_dev_env.sh
 
+module purge
+
 source /projects/sems/modulefiles/utils/sems-modules-init.sh
 
-module load sems-git/2.10.1
 module load sems-gcc/5.3.0
 module load sems-clang/10.0.0
 module load sems-openmpi/1.10.1
-module load sems-python/2.7.9
 module load sems-boost/1.69.0/base
 module load sems-zlib/1.2.8/base
 module load sems-hdf5/1.10.6/parallel
@@ -23,8 +23,14 @@ module load sems-netcdf/4.7.3/parallel
 module load sems-parmetis/4.0.3/parallel
 module load sems-scotch/6.0.3/nopthread_64bit_parallel
 module load sems-superlu/4.3/base
+
 module load sems-cmake/3.17.1
 module load sems-ninja_fortran/1.10.0
+
+module load sems-git/2.10.1
+
+module unload sems-python
+module load sems-python/3.5.2
 
 # add the OpenMP environment variable we need
 export OMP_NUM_THREADS=2

--- a/cmake/std/sems/PullRequestClang7.0.1TestingEnv.sh
+++ b/cmake/std/sems/PullRequestClang7.0.1TestingEnv.sh
@@ -9,13 +9,14 @@
 # $ module purge
 # or Trilinos/cmake/unload_sems_dev_env.sh
 
+module purge
+
 source /projects/sems/modulefiles/utils/sems-modules-init.sh
 
 module load sems-git/2.10.1
 module load sems-gcc/5.3.0
 module load sems-clang/7.0.1
 module load sems-openmpi/1.10.1
-module load sems-python/2.7.9
 module load sems-boost/1.63.0/base
 module load sems-zlib/1.2.8/base
 module load sems-hdf5/1.10.6/parallel
@@ -23,7 +24,6 @@ module load sems-netcdf/4.7.3/parallel
 module load sems-parmetis/4.0.3/parallel
 module load sems-scotch/6.0.3/nopthread_64bit_parallel
 module load sems-superlu/4.3/base
-module load sems-cmake/3.12.2
 
 # Load the SEMS CMake Module
 # - One of the SEMS modules will load CMake 3.4.x also,
@@ -40,6 +40,9 @@ module load sems-cmake/3.12.2
 module load atdm-env
 #module load atdm-cmake/3.10.1
 module load atdm-ninja_fortran/1.7.2
+
+module unload sems-python
+module load sems-python/3.5.2
 
 # add the OpenMP environment variable we need
 export OMP_NUM_THREADS=2

--- a/cmake/std/sems/PullRequestClang9.0.0TestingEnv.sh
+++ b/cmake/std/sems/PullRequestClang9.0.0TestingEnv.sh
@@ -9,13 +9,14 @@
 # $ module purge
 # or Trilinos/cmake/unload_sems_dev_env.sh
 
+module purge
+
 source /projects/sems/modulefiles/utils/sems-modules-init.sh
 
 module load sems-git/2.10.1
 module load sems-gcc/5.3.0
 module load sems-clang/9.0.0
 module load sems-openmpi/1.10.1
-module load sems-python/2.7.9
 module load sems-boost/1.63.0/base
 module load sems-zlib/1.2.8/base
 module load sems-hdf5/1.10.6/parallel
@@ -23,13 +24,12 @@ module load sems-netcdf/4.7.3/parallel
 module load sems-parmetis/4.0.3/parallel
 module load sems-scotch/6.0.3/nopthread_64bit_parallel
 module load sems-superlu/4.3/base
-module load sems-cmake/3.12.2
 
 # Load the SEMS CMake Module
 # - One of the SEMS modules will load CMake 3.4.x also,
 #   so this will pull in the SEMS cmake 3.10.3 version
 #   for Trilinos compatibility.
-module load sems-cmake/3.12.2
+module load sems-cmake/3.10.3
 
 # Using CMake and Ninja modules from the ATDM project space.
 # SEMS does not yet supply a recent enough version of CMake
@@ -40,6 +40,10 @@ module load sems-cmake/3.12.2
 module load atdm-env
 #module load atdm-cmake/3.10.1
 module load atdm-ninja_fortran/1.7.2
+
+module unload sems-python
+module load sems-python/3.5.2
+
 
 # add the OpenMP environment variable we need
 export OMP_NUM_THREADS=2

--- a/cmake/std/sems/PullRequestGCC4.8.4TestingEnv.sh
+++ b/cmake/std/sems/PullRequestGCC4.8.4TestingEnv.sh
@@ -8,12 +8,12 @@
 # $ module purge
 # or Trilinos/cmake/unload_sems_dev_env.sh
  
+module purge
+
 source /projects/sems/modulefiles/utils/sems-modules-init.sh
 
 module load sems-gcc/4.8.4
 module load sems-openmpi/1.10.1
-module load sems-python/2.7.9
-module load sems-git/2.10.1
 module load sems-boost/1.63.0/base
 module load sems-zlib/1.2.8/base
 module load sems-hdf5/1.10.6/parallel
@@ -28,6 +28,11 @@ module load sems-superlu/4.3/base
 #   for Trilinos compatibility.
 module load sems-cmake/3.10.3
 module load sems-ninja_fortran/1.8.2
+
+module load sems-git/2.10.1
+
+module unload sems-python
+module load sems-python/3.5.2
 
 # add the OpenMP environment variable we need
 export OMP_NUM_THREADS=2

--- a/cmake/std/sems/PullRequestGCC4.9.3TestingEnv.sh
+++ b/cmake/std/sems/PullRequestGCC4.9.3TestingEnv.sh
@@ -4,12 +4,12 @@
 
 # usage: $ source PullRequestGCC4.9.3TestingEnv.sh
 
+module purge
+
 source /projects/sems/modulefiles/utils/sems-modules-init.sh
 
 module load sems-gcc/4.9.3
 module load sems-openmpi/1.10.1
-module load sems-python/2.7.9
-module load sems-git/2.10.1
 module load sems-boost/1.63.0/base
 module load sems-zlib/1.2.8/base
 module load sems-hdf5/1.10.6/parallel
@@ -17,8 +17,14 @@ module load sems-netcdf/4.7.3/parallel
 module load sems-parmetis/4.0.3/parallel
 module load sems-scotch/6.0.3/nopthread_64bit_parallel
 module load sems-superlu/4.3/base
+
 module load sems-cmake/3.12.2
 module load sems-ninja_fortran/1.8.2
+
+module load sems-git/2.10.1
+
+module unload sems-python
+module load sems-python/3.5.2
 
 # add the OpenMP environment variable we need
 export OMP_NUM_THREADS=2

--- a/cmake/std/sems/PullRequestGCC4.9.3TestingEnvSERIAL.sh
+++ b/cmake/std/sems/PullRequestGCC4.9.3TestingEnvSERIAL.sh
@@ -4,11 +4,11 @@
 
 # usage: $ source PullRequestGCC4.9.3TestingEnv.sh
 
+module purge
+
 source /projects/sems/modulefiles/utils/sems-modules-init.sh
 
 module load sems-gcc/4.9.3
-module load sems-python/2.7.9
-module load sems-git/2.10.1
 module load sems-boost/1.63.0/base
 module load sems-zlib/1.2.8/base
 module load sems-hdf5/1.10.6/base
@@ -16,8 +16,15 @@ module load sems-netcdf/4.7.3/base
 module load sems-metis/5.1.0/base
 # module load sems-scotch/6.0.3/nopthread_64bit_parallel
 module load sems-superlu/4.3/base
+
 module load sems-cmake/3.12.2
 module load sems-ninja_fortran/1.8.2
+
+module load sems-git/2.10.1
+
+module unload sems-python
+module load sems-python/3.5.2
+
 
 # add the OpenMP environment variable we need
 export OMP_NUM_THREADS=2

--- a/cmake/std/sems/PullRequestGCC7.2.0SerialTestingEnv.sh
+++ b/cmake/std/sems/PullRequestGCC7.2.0SerialTestingEnv.sh
@@ -4,19 +4,26 @@
 
 # usage: $ source PullRequestGCC7.2.0TestingEnv.sh
 
+module purge
+
 source /projects/sems/modulefiles/utils/sems-modules-init.sh
 
 module load sems-gcc/7.2.0
-module load sems-python/2.7.9
-module load sems-git/2.10.1
 module load sems-boost/1.63.0/base
 module load sems-zlib/1.2.8/base
 module load sems-hdf5/1.10.6/base
 module load sems-netcdf/4.7.3/base
 module load sems-metis/5.1.0/base
 module load sems-superlu/4.3/base
+
 module load sems-cmake/3.12.2
 module load sems-ninja_fortran/1.8.2
+
+# Boost loads sems-python/2.7.x as a side effect.
+module unload sems-python
+module load sems-python/3.5.2
+
+module load sems-git/2.10.1
 
 # add the OpenMP environment variable we need
 export OMP_NUM_THREADS=2

--- a/cmake/std/sems/PullRequestGCC7.2.0TestingEnv.sh
+++ b/cmake/std/sems/PullRequestGCC7.2.0TestingEnv.sh
@@ -4,12 +4,12 @@
 
 # usage: $ source PullRequestGCC7.2.0TestingEnv.sh
 
+module purge
+
 source /projects/sems/modulefiles/utils/sems-modules-init.sh
 
 module load sems-gcc/7.2.0
 module load sems-openmpi/1.10.1
-module load sems-python/2.7.9
-module load sems-git/2.10.1
 module load sems-boost/1.63.0/base
 module load sems-zlib/1.2.8/base
 module load sems-hdf5/1.10.6/parallel
@@ -17,8 +17,16 @@ module load sems-netcdf/4.7.3/parallel
 module load sems-parmetis/4.0.3/parallel
 module load sems-scotch/6.0.3/nopthread_64bit_parallel
 module load sems-superlu/4.3/base
-module load sems-cmake/3.12.2
+
+module load sems-cmake/3.10.3
 module load sems-ninja_fortran/1.8.2
+
+module load sems-git/2.10.1
+
+# Note: sems-boost also loads sems-python/2.7.x, we need to
+#       unload it here.
+module unload sems-python
+module load sems-python/3.5.2
 
 # add the OpenMP environment variable we need
 export OMP_NUM_THREADS=2

--- a/cmake/std/sems/PullRequestGCC8.3.0TestingEnv.sh
+++ b/cmake/std/sems/PullRequestGCC8.3.0TestingEnv.sh
@@ -4,12 +4,12 @@
 
 # usage: $ source PullRequestGCC8.3.0TestingEnv.sh
 
+module purge
+
 source /projects/sems/modulefiles/utils/sems-modules-init.sh
 
 module load sems-gcc/8.3.0
 module load sems-openmpi/1.10.1
-module load sems-python/2.7.9
-module load sems-git/2.10.1
 module load sems-boost/1.66.0/base
 module load sems-zlib/1.2.8/base
 module load sems-hdf5/1.10.6/parallel
@@ -17,8 +17,17 @@ module load sems-netcdf/4.7.3/parallel
 module load sems-parmetis/4.0.3/parallel
 module load sems-scotch/6.0.3/nopthread_64bit_parallel
 module load sems-superlu/4.3/base
+
 module load sems-cmake/3.17.1
 module load sems-ninja_fortran/1.10.0
 
+module load sems-git/2.10.1
+
+module unload sems-python
+module load sems-python/3.5.2
+
+
 # add the OpenMP environment variable we need
 export OMP_NUM_THREADS=2
+
+

--- a/cmake/std/sems/PullRequestIntel17.0.1TestingEnv.sh
+++ b/cmake/std/sems/PullRequestIntel17.0.1TestingEnv.sh
@@ -7,6 +7,8 @@
 # After the environment is no longer needed, it can be purged using
 # $ module purge
 # or Trilinos/cmake/unload_sems_dev_env.sh
+
+module purge
  
 source /projects/sems/modulefiles/utils/sems-modules-init.sh
 
@@ -14,8 +16,6 @@ export SEMS_FORCE_LOCAL_COMPILER_VERSION=4.9.3
 module load sems-gcc/5.3.0
 module load sems-intel/17.0.1
 module load sems-mpich/3.2
-module load sems-python/2.7.9
-module load sems-git/2.10.1
 module load sems-boost/1.63.0/base
 module load sems-zlib/1.2.8/base
 module load sems-hdf5/1.10.6/parallel
@@ -23,8 +23,14 @@ module load sems-netcdf/4.7.3/parallel
 module load sems-parmetis/4.0.3/parallel
 module load sems-scotch/6.0.3/nopthread_64bit_parallel
 module load sems-superlu/4.3/base
+
 module load sems-cmake/3.12.2
 module load sems-ninja_fortran/1.8.2
+
+module load sems-git/2.10.1
+
+module unload sems-python
+module load sems-python/3.5.2
 
 # add the OpenMP environment variable we need
 export OMP_NUM_THREADS=2

--- a/cmake/std/sems/PullRequestIntel19.0.5TestingEnv.sh
+++ b/cmake/std/sems/PullRequestIntel19.0.5TestingEnv.sh
@@ -8,14 +8,14 @@
 # $ module purge
 # or Trilinos/cmake/unload_sems_dev_env.sh
 
+module purge
+
 source /projects/sems/modulefiles/utils/sems-modules-init.sh
 
 export SEMS_FORCE_LOCAL_COMPILER_VERSION=4.9.3
 module load sems-gcc/6.1.0
 module load sems-intel/19.0.5
 module load sems-mpich/3.2
-module load sems-python/2.7.9
-module load sems-git/2.10.1
 module load sems-boost/1.63.0/base
 module load sems-zlib/1.2.8/base
 module load sems-hdf5/1.10.6/parallel
@@ -23,8 +23,14 @@ module load sems-netcdf/4.7.3/parallel
 module load sems-parmetis/4.0.3/parallel
 module load sems-scotch/6.0.3/nopthread_64bit_parallel
 module load sems-superlu/4.3/base
+
 module load sems-cmake/3.12.2
 module load sems-ninja_fortran/1.8.2
+
+module load sems-git/2.10.1
+
+module unload sems-python
+module load sems-python/3.5.2
 
 # add the OpenMP environment variable we need
 export OMP_NUM_THREADS=2

--- a/packages/ifpack2/src/Ifpack2_Details_Chebyshev_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Chebyshev_def.hpp
@@ -654,7 +654,7 @@ setParameters (Teuchos::ParameterList& plist)
   minDiagVal_ = minDiagVal;
   numIters_ = numIters;
   eigMaxIters_ = eigMaxIters;
-  eigNormalizationFreq_ = eigNormalizationFreq_;
+  eigNormalizationFreq_ = eigNormalizationFreq;
   zeroStartingSolution_ = zeroStartingSolution;
   assumeMatrixUnchanged_ = assumeMatrixUnchanged;
   textbookAlgorithm_ = textbookAlgorithm;


### PR DESCRIPTION
@trilinos/framework 
@bartlettroscoe 

## Motivation
With the updates to the PR drivers, the scripts to [reproduce PR errors][1] have become outdated. Especially where Python has been concerned. The main problem it appears from #8429 is that these scripts encounter a problem trying to load the right version of Python which conflicts with the work we put in to remove the use of Python 2.x from our PR scripts.

One problem is that loading the SEMS boost module also loads the `sems-python/2.7.x` module as a side-effect, so when we tried to load a Python 3.x module we got conflicts. 

I went in and modified the non CUDA scripts to perform a `module purge` in the beginning as well as a `module unload sems-python` before we load`sems-python/3.5.2`.  


## Related Issues
* Related to #8429 

## Testing
Ran tests on a RHEL COE system using a simple script:
```bash
#!/usr/bin/env bash

TRILINOS_DIR=${HOME:?}/dev/trilinos-dev/source/Trilinos

build_name="Trilinos_pullrequest_gcc_8.3.0"
env_file="PullRequestGCC8.3.0TestingEnv.sh"
cmake_file="PullRequestLinuxGCC8.3.0TestingSettings.cmake"

echo ""
echo "$ source ${TRILINOS_DIR}/cmake/std/sems/${env_file}"
echo ""
source ${TRILINOS_DIR}/cmake/std/sems/${env_file}

module list

rm -rf build-${build_name}
mkdir build-${build_name}
cd build-${build_name}

cmake_opts=(
    -C ${TRILINOS_DIR}/cmake/std/${cmake_file}
    -DTrilinos_ENABLE_Teuchos=ON
    ${TRILINOS_DIR}/.
    )

cmake ${cmake_opts[@]}

make -j 20
```
for these builds:
- [x] `Trilinos_pullrequest_gcc_8.3.0`
- [x] `Trilinos_pullrequest_clang_10.0.0`

They are still running but I'll go ahead and get this PR in so we can get a review from @bartlettroscoe and iterate over the fix.

[1]: https://github.com/trilinos/Trilinos/wiki/Reproducing-PR-Testing-Errors
