### PR TITLE
Intrepid: fix bug in face tag initialization for high-order H(div) Triangle elements.

### DIFF
--- a/packages/intrepid/src/Discretization/Basis/Intrepid_HDIV_TRI_In_FEMDef.hpp
+++ b/packages/intrepid/src/Discretization/Basis/Intrepid_HDIV_TRI_In_FEMDef.hpp
@@ -259,7 +259,7 @@ namespace Intrepid {
     // the rest of the dofs are internal
     const int numFaceDof = (degree-1)*degree;
     int faceDofCur = 0;
-    for (int i=3*degree;i<degree*(degree+1);i++) {
+    for (int i=3*degree;i<3*degree+numFaceDof;i++) {
       tag_cur[0] = 2;  tag_cur[1] = 0;  tag_cur[2] = faceDofCur;  tag_cur[3] = numFaceDof;
       tag_cur += tagSize;
       faceDofCur++;


### PR DESCRIPTION
Note: this regards Intrepid, *not* Intrepid2.  Since there is no intrepid team as such, sending to intrepid2.

Fixes a bug in face tag initialization for high-order H(div) Triangle elements; some face tag entries were left uninitialized.  This was exhibiting as a hang during tag initialization for a Camellia user, when attempting to use a degree-3 H(div) triangle basis.

@trilinos/intrepid2