### PR TITLE
Panzer: fix race condition with launch blocking off in GED accessor.

### DIFF
--- a/packages/panzer/disc-fe/src/Panzer_TpetraVector_ReadOnly_GlobalEvaluationData_impl.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_TpetraVector_ReadOnly_GlobalEvaluationData_impl.hpp
@@ -121,6 +121,7 @@ globalToGhost(int /* mem */)
 
   // Do the global distribution.
   ghostedVector_->doImport(*ownedVector_, *importer_, Tpetra::INSERT);
+  PHX::ExecSpace().fence();
 }
 
 template <typename ScalarT,typename LocalOrdinalT,typename GlobalOrdinalT,typename NodeT>
@@ -132,6 +133,7 @@ initializeData()
                               "TpetraVector_ReadOnly_GED has not been initialized, cannot call \"initializeData\"!");
 
    ghostedVector_->putScalar(0.0);
+   PHX::ExecSpace().fence();
 
    typedef typename VectorType::dual_view_type::t_dev::memory_space DMS;
    auto values_2d = ghostedVector_->template getLocalView<DMS>();


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->


## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The empire sync with Trilinos failed with launch blocking off due to a single panzer test for the GED accessor. Turned out to be a race condition that needed fencing.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
Fixes EMPIRE Trilinos update.

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Covered by the test: ```PanzerDiscFE_LinearObjFactory_Tests_MPI_2```

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->