### PR TITLE
Framework: Reduce rate limit for stale job actionscript

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -34,7 +34,7 @@ jobs:
         # We specifically DO NOT exempt PR's from autoclosing.
         #exempt-pr-labels: ''
         remove-stale-when-updated: true
-        operations-per-run: 100
+        operations-per-run: 50
         stale-issue-message: >
           This issue has had no activity for **365** days and is marked for
           closure. It will be closed after an additional **30** days of inactivity.


### PR DESCRIPTION
@trilinos/framework 

## Motivation
Reduced the rate limiter for the issue/pr auto closer from 100 to 50 to reduce the # of hits it makes against the Github access rate.  @allevin noted to us that Trilinos was hitting the rate limit today, so in case our action script is the culprit, I'll cut its rate in half.

The script runs at 12:00 AM UTC which is around 5 or 6 AM mountain time, depending on whether or not we're in DST. I think right now it's running at 5am our time so if this is the culprit, we would see the rate limit happening sometime within an hour of this script running until Github clears the count.