### PR TITLE
Framework: Bugfix for cycle detection PR configurations

### DIFF
--- a/cmake/std/pr_config/pullrequest.ini
+++ b/cmake/std/pr_config/pullrequest.ini
@@ -154,9 +154,12 @@ setenv PATH:       "/projects/sierra/linux_rh7/install/Python/3.6.3/share/bin:${
 unsetenv PATH_TMP:
 
 
+[MODULE-PURGE]
+module-purge:
+
 
 [SEMS-ENV]
-module-purge:
+use MODULE-PURGE:
 module-use: /projects/sems/modulefiles/projects
 module-load sems-env:
 

--- a/cmake/std/trilinosprhelpers/setenvironment/SetEnvironment.py
+++ b/cmake/std/trilinosprhelpers/setenvironment/SetEnvironment.py
@@ -162,6 +162,9 @@ class SetEnvironment(object):
             IndexError: Invalid number of parameters for 'module' command
         """
         status = 0
+
+        self.actions["module-op"]
+
         print("Module Operations")
         print("+---------------+")
         for m in self.actions["module-op"]:
@@ -206,9 +209,10 @@ class SetEnvironment(object):
             k = envvar['key']
             v = envvar['value']
             print("[envvar] export {}={}".format(k,v))
-            v = self._expand_envvars_in_string(v)
-            os.environ[k] = v
-            print("[envvar] export {}={} (actual)".format(k,v))
+            v2 = self._expand_envvars_in_string(v)
+            os.environ[k] = v2
+            if v != v2:
+                print("[envvar] export {}={} (expanded)".format(k,v2))
         for k in self.actions["unsetenv"]:
             del os.environ[k]
             print("[envvar] unset {}".format(k))
@@ -288,6 +292,8 @@ class SetEnvironment(object):
         Raises:
             IndexError: Invalid number of parameters for 'module' command
         """
+        self.actions["module-op"]
+
         print("")
         print("Module Operations")
         print("+---------------+")
@@ -360,7 +366,12 @@ class SetEnvironment(object):
                          "module-list": {}     # Keys = modules already set to 'load'
                         }
 
+        print("Processing Configuration .ini")
+        print("+---------------------------+")
+
         self.actions = self._load_configuration_r(self.profile, actions=self.actions)
+
+        print("")
 
         return self.actions
 
@@ -403,15 +414,11 @@ class SetEnvironment(object):
         if processed_secs is None:
             processed_secs = {}
 
-        # Exit if we've already processed this section (recursion breaker)
-        if config_section in processed_secs.keys():
-            print("WARNING: Cyclic dependencies encountered when loading {} ... {}".format(self.profile, config_section))
-            return actions
-
+        print("Section: {}".format(config_section))
         processed_secs[config_section] = True
 
         for op2,value in sec.items():
-            #print("> k=`{}` v=`{}`".format(k,v))
+            #print(": op2=`{}` value=`{}`".format(op2,value))
             value  = str(value.strip('"'))
             oplist = op2.split()
             op1    = str(oplist[0])
@@ -421,7 +428,14 @@ class SetEnvironment(object):
 
             if "use" == op1:
                 new_profile = op2
-                self._load_configuration_r(new_profile, actions, processed_secs)
+
+                # Cycle breaking -- only process new section IF it's not in the list of already
+                # processed sections.
+                if new_profile not in processed_secs.keys():
+                    self._load_configuration_r(new_profile, actions, processed_secs)
+                else:
+                    print("WARNING: Detected a cycle in the section dependencies: " +
+                          "cannot load [{}] from [{}].".format(new_profile, config_section))
 
             elif "module-purge" == op1:
                 actions["module-op"].append(["purge", ''])
@@ -458,10 +472,15 @@ class SetEnvironment(object):
                 actions["module-op"].append(["swap", op2, value])
 
             elif "setenv" == op1:
+                # TODO: Should we force envvars to upper case?
                 actions["setenv"].append( {'key': op2.upper(), 'value': value} )
 
             elif "unsetenv" == op1:
+                # TODO: Should we force envvars to upper case?
                 actions["unsetenv"].append(op2.upper())
+
+        # remove the current section from the 'processed_secs' list.
+        del processed_secs[config_section]
 
         return actions
 

--- a/cmake/std/trilinosprhelpers/setenvironment/unittests/setenvironment_config.ini
+++ b/cmake/std/trilinosprhelpers/setenvironment/unittests/setenvironment_config.ini
@@ -91,7 +91,6 @@ module-load sems-env:
 
 
 [SEMS-DEFAULT]
-use SEMS-ENV:
 module-load sems-boost    : 1.63.0/base
 module-load sems-cmake    : 3.10.3
 module-load sems-python   : 3.5.2
@@ -124,14 +123,17 @@ use TEST_PROFILE_001:
 module-unload sems-python:
 
 
-[TEST_PROFILE_005]:
+[TEST_PROFILE_005]
 use TEST_PROFILE_001:
 setenv TEST_ENVVAR_002  :  TEST_ENVVAR_002_VALUE/${TEST_ENVVAR_001}
 
 
-[TEST_PROFILE_006]:
+[TEST_PROFILE_006]
 use TEST_PROFILE_001:
 module-swap sems-python/3.5.2: sems-python/3.8.0
+
+[TEST_MODULE_FAIL]
+module-load kzzzzzt: 16.16.16
 
 
 [GCC_1.0]
@@ -152,3 +154,50 @@ module-unload gcc:
 
 [Module_Purge]:
 module-purge:
+
+
+#
+# Sections to test cycle breaking
+# - Test by trying to process Sec_D, we should get blocked
+#   when Sec_A tries to load Sec_C
+# - Final result should have envvar Sec_C == '99'
+[Sec_A]:
+setenv Sec_A: 1
+setenv Sec_C: 99
+use Sec_C:
+
+[Sec_B]:
+setenv Sec_B: 1
+use Sec_A:
+
+[Sec_C]:
+setenv Sec_C: 1
+use Sec_B:
+
+[Sec_D]:
+setenv Sec_D: 1
+use Sec_C:
+
+
+#
+# Cycle breaking 2
+# - Invoke by loading Sec_D2
+# - The second `use Sec_A2` should be ok
+# - The final result should have envvar Sec_A2 == 1
+#
+[Sec_A2]:
+setenv Sec_A2: 1
+
+[Sec_B2]:
+setenv Sec_B2: 1
+use Sec_A2:
+
+[Sec_C2]:
+setenv Sec_C2: 1
+use Sec_B2:
+
+[Sec_D2]:
+setenv Sec_D2: 1
+use Sec_C2:
+setenv Sec_A2: 99
+use Sec_A2:


### PR DESCRIPTION
@trilinos/framework 

## Motivation
The cycle-detection logic in the PR driver `setenvironment` module had a minor bug that resulted in an overly aggressive 'cycle prevention' mode.

For example, section dependencies like this would be blocked:
```
A -> B -> C -> B
```

but we also blocked this:
```
A -> B -> C
A -> B
```

This fixes the issue by popping off the sections from the 'seen list' as we pop out of scope during the recursive module that scans through the configurations.

This generally didn't affect any of our configurations but I could see a scenerio where we do something like this:

```ini
[MODULE-MANUAL-CONFIG]
setenv ENVVAR1: foo
setenv ENVVAR2: bar
setenv ENVVAR3: baz

[SEMS-DEFAULT]
use MODULE-MANUAL-CONFIG:

[SOME_BUILD_CONFIG]
use SEMS-DEFAULT:
use MODULE-MANUAL-CONFIG:
```

Generally, I think we can avoid stuff like this by the order in which things are done -- but as configurations get more complicated we probably wouldn't want to avoid having the explicit call to MODULE-MANUAL-CONFIG in the `SOME_BUILD_CONFIG` section be ignored because it had already been seen in the default config -- especially if there is some module that has a side effect which might smash something.

Provenance
------------
This came out from some of the Python work... for various reasons we need to use the sierra python compiler for our cloud nodes due to some errors we had with the SEMS Python 3.5.x compiler in the PR environment. Internally, the sems-boost module also loads a sems-python 2.x which we need to fix.

It's easily fixable by just setting our Sierra Python envvars after we load sems-boost... but it's good to make sure the cycle detection routine works properly to eliminate future gotchas.

FYI @jmgate @prwolfe 

