### PR TITLE
Ifpack2: fix timers

### DIFF
--- a/packages/ifpack2/src/Ifpack2_AdditiveSchwarz_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_AdditiveSchwarz_def.hpp
@@ -367,6 +367,7 @@ apply (const Tpetra::MultiVector<scalar_type,local_ordinal_type,global_ordinal_t
   if (timer.is_null ()) {
     timer = TimeMonitor::getNewCounter (timerName);
   }
+  double startTime = timer->wallTime();
 
   { // Start timing here.
     TimeMonitor timeMon (*timer);
@@ -617,9 +618,7 @@ apply (const Tpetra::MultiVector<scalar_type,local_ordinal_type,global_ordinal_t
 
   ++NumApply_;
 
-  // timer->totalElapsedTime() returns the total time over all timer
-  // calls.  Thus, we use = instead of +=.
-  ApplyTime_ = timer->totalElapsedTime ();
+  ApplyTime_ += (timer->wallTime() - startTime);
 }
 
 template<class MatrixType,class LocalInverseType>
@@ -935,6 +934,7 @@ void AdditiveSchwarz<MatrixType,LocalInverseType>::initialize ()
   if (timer.is_null ()) {
     timer = TimeMonitor::getNewCounter (timerName);
   }
+  double startTime = timer->wallTime();
 
   { // Start timing here.
     TimeMonitor timeMon (*timer);
@@ -992,9 +992,7 @@ void AdditiveSchwarz<MatrixType,LocalInverseType>::initialize ()
   IsInitialized_ = true;
   ++NumInitialize_;
 
-  // timer->totalElapsedTime() returns the total time over all timer
-  // calls.  Thus, we use = instead of +=.
-  InitializeTime_ = timer->totalElapsedTime ();
+  InitializeTime_ += (timer->wallTime() - startTime);
 }
 
 
@@ -1036,6 +1034,7 @@ void AdditiveSchwarz<MatrixType,LocalInverseType>::compute ()
   if (timer.is_null ()) {
     timer = TimeMonitor::getNewCounter (timerName);
   }
+  double startTime = timer->wallTime();
 
   { // Start timing here.
     TimeMonitor timeMon (*timer);
@@ -1047,9 +1046,7 @@ void AdditiveSchwarz<MatrixType,LocalInverseType>::compute ()
   IsComputed_ = true;
   ++NumCompute_;
 
-  // timer->totalElapsedTime() returns the total time over all timer
-  // calls.  Thus, we use = instead of +=.
-  ComputeTime_ = timer->totalElapsedTime ();
+  ComputeTime_ += (timer->wallTime() - startTime);
 }
 
 //==============================================================================

--- a/packages/ifpack2/src/Ifpack2_BlockRelaxation_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockRelaxation_def.hpp
@@ -487,6 +487,8 @@ apply (const Tpetra::MultiVector<typename MatrixType::scalar_type,
     timer = Teuchos::TimeMonitor::getNewCounter (timerName);
   }
 
+  double startTime = timer->wallTime();
+
   {
     Teuchos::TimeMonitor timeMon (*timer);
 
@@ -534,7 +536,7 @@ apply (const Tpetra::MultiVector<typename MatrixType::scalar_type,
     }
   }
 
-  ApplyTime_ += timer->totalElapsedTime();
+  ApplyTime_ += (timer->wallTime() - startTime);
   ++NumApply_;
 }
 
@@ -570,6 +572,7 @@ initialize ()
 
   Teuchos::RCP<Teuchos::Time> timer =
     Teuchos::TimeMonitor::getNewCounter ("Ifpack2::BlockRelaxation::initialize");
+  double startTime = timer->wallTime();
 
   { // Timing of initialize starts here
     Teuchos::TimeMonitor timeMon (*timer);
@@ -661,7 +664,7 @@ initialize ()
     }
   } // timing of initialize stops here
 
-  InitializeTime_ += timer->totalElapsedTime ();
+  InitializeTime_ += (timer->wallTime() - startTime);
   ++NumInitialize_;
   IsInitialized_ = true;
 }
@@ -686,6 +689,8 @@ compute ()
   Teuchos::RCP<Teuchos::Time> timer =
     Teuchos::TimeMonitor::getNewCounter ("Ifpack2::BlockRelaxation::compute");
 
+  double startTime = timer->wallTime();
+
   {
     Teuchos::TimeMonitor timeMon (*timer);
 
@@ -695,7 +700,7 @@ compute ()
     Container_->compute();   // compute each block matrix
   }
 
-  ComputeTime_ += timer->totalElapsedTime();
+  ComputeTime_ += (timer->wallTime() - startTime);
   ++NumCompute_;
   IsComputed_ = true;
 }

--- a/packages/ifpack2/src/Ifpack2_Chebyshev_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Chebyshev_def.hpp
@@ -240,6 +240,8 @@ apply (const Tpetra::MultiVector<scalar_type, local_ordinal_type, global_ordinal
     timer = Teuchos::TimeMonitor::getNewCounter (timerName);
   }
 
+  double startTime = timer->wallTime();
+
   // Start timing here.
   {
     Teuchos::TimeMonitor timeMon (*timer);
@@ -258,10 +260,7 @@ apply (const Tpetra::MultiVector<scalar_type, local_ordinal_type, global_ordinal
     applyImpl (X, Y, mode, alpha, beta);
   }
   ++NumApply_;
-
-  // timer->totalElapsedTime() returns the total time over all timer
-  // calls.  Thus, we use = instead of +=.
-  ApplyTime_ = timer->totalElapsedTime ();
+  ApplyTime_ += (timer->wallTime() - startTime);
 }
 
 
@@ -310,6 +309,8 @@ void Chebyshev<MatrixType>::compute ()
     timer = Teuchos::TimeMonitor::getNewCounter (timerName);
   }
 
+  double startTime = timer->wallTime();
+
   // Start timing here.
   {
     Teuchos::TimeMonitor timeMon (*timer);
@@ -322,9 +323,7 @@ void Chebyshev<MatrixType>::compute ()
   IsComputed_ = true;
   ++NumCompute_;
 
-  // timer->totalElapsedTime() returns the total time over all timer
-  // calls.  Thus, we use = instead of +=.
-  ComputeTime_ = timer->totalElapsedTime ();
+  ComputeTime_ += (timer->wallTime() - startTime);
 }
 
 

--- a/packages/ifpack2/src/Ifpack2_Details_Amesos2Wrapper_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Amesos2Wrapper_def.hpp
@@ -289,6 +289,8 @@ void Amesos2Wrapper<MatrixType>::initialize ()
     timer = TimeMonitor::getNewCounter (timerName);
   }
 
+  double startTime = timer->wallTime();
+
   { // Start timing here.
     TimeMonitor timeMon (*timer);
 
@@ -372,9 +374,7 @@ void Amesos2Wrapper<MatrixType>::initialize ()
   IsInitialized_ = true;
   ++NumInitialize_;
 
-  // timer->totalElapsedTime() returns the total time over all timer
-  // calls.  Thus, we use = instead of +=.
-  InitializeTime_ = timer->totalElapsedTime ();
+  InitializeTime_ += (timer->wallTime() - startTime);
 }
 
 template<class MatrixType>
@@ -395,6 +395,8 @@ void Amesos2Wrapper<MatrixType>::compute ()
     timer = TimeMonitor::getNewCounter (timerName);
   }
 
+  double startTime = timer->wallTime();
+
   { // Start timing here.
     TimeMonitor timeMon (*timer);
     solver_->numeric ();
@@ -403,9 +405,7 @@ void Amesos2Wrapper<MatrixType>::compute ()
   IsComputed_ = true;
   ++NumCompute_;
 
-  // timer->totalElapsedTime() returns the total time over all timer
-  // calls.  Thus, we use = instead of +=.
-  ComputeTime_ = timer->totalElapsedTime ();
+  ComputeTime_ += (timer->wallTime() - startTime);
 }
 
 
@@ -432,6 +432,8 @@ apply (const Tpetra::MultiVector<scalar_type, local_ordinal_type, global_ordinal
   if (timer.is_null ()) {
     timer = TimeMonitor::getNewCounter (timerName);
   }
+
+  double startTime = timer->wallTime();
 
   { // Start timing here.
     TimeMonitor timeMon (*timer);
@@ -506,9 +508,7 @@ apply (const Tpetra::MultiVector<scalar_type, local_ordinal_type, global_ordinal
 
   ++NumApply_;
 
-  // timer->totalElapsedTime() returns the total time over all timer
-  // calls.  Thus, we use = instead of +=.
-  ApplyTime_ = timer->totalElapsedTime ();
+  ApplyTime_ += (timer->wallTime() - startTime);
 }
 
 

--- a/packages/ifpack2/src/Ifpack2_Details_DenseSolver_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_DenseSolver_def.hpp
@@ -225,6 +225,8 @@ void DenseSolver<MatrixType, false>::initialize ()
     timer = TimeMonitor::getNewCounter (timerName);
   }
 
+  double startTime = timer->wallTime();
+
   { // Begin timing here.
     Teuchos::TimeMonitor timeMon (*timer);
 
@@ -268,9 +270,7 @@ void DenseSolver<MatrixType, false>::initialize ()
     ++numInitialize_;
   }
 
-  // timer->totalElapsedTime() returns the total time over all timer
-  // calls.  Thus, we use = instead of +=.
-  initializeTime_ = timer->totalElapsedTime ();
+  initializeTime_ += (timer->wallTime() - startTime);
 }
 
 
@@ -289,6 +289,8 @@ void DenseSolver<MatrixType, false>::compute ()
   if (timer.is_null ()) {
     timer = Teuchos::TimeMonitor::getNewCounter (timerName);
   }
+
+  double startTime = timer->wallTime();
 
   // Begin timing here.
   {
@@ -313,9 +315,7 @@ void DenseSolver<MatrixType, false>::compute ()
     isComputed_ = true;
     ++numCompute_;
   }
-  // timer->totalElapsedTime() returns the total time over all timer
-  // calls.  Thus, we use = instead of +=.
-  computeTime_ = timer->totalElapsedTime ();
+  computeTime_ += (timer->wallTime() - startTime);
 }
 
 template<class MatrixType>
@@ -436,6 +436,8 @@ apply (const Tpetra::MultiVector<scalar_type,local_ordinal_type,global_ordinal_t
     timer = Teuchos::TimeMonitor::getNewCounter (timerName);
   }
 
+  double startTime = timer->wallTime();
+
   // Begin timing here.
   {
     Teuchos::TimeMonitor timeMon (*timer);
@@ -482,9 +484,7 @@ apply (const Tpetra::MultiVector<scalar_type,local_ordinal_type,global_ordinal_t
     ++numApply_; // We've successfully finished the work of apply().
   }
 
-  // timer->totalElapsedTime() returns the total time over all timer
-  // calls.  Thus, we use = instead of +=.
-  applyTime_ = timer->totalElapsedTime ();
+  applyTime_ += (timer->wallTime() - startTime);
 }
 
 

--- a/packages/ifpack2/src/Ifpack2_Details_TriDiSolver_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_TriDiSolver_def.hpp
@@ -227,6 +227,8 @@ void TriDiSolver<MatrixType, false>::initialize ()
     timer = TimeMonitor::getNewCounter (timerName);
   }
 
+  double startTime = timer->wallTime();
+
   { // Begin timing here.
     Teuchos::TimeMonitor timeMon (*timer);
 
@@ -270,9 +272,7 @@ void TriDiSolver<MatrixType, false>::initialize ()
     ++numInitialize_;
   }
 
-  // timer->totalElapsedTime() returns the total time over all timer
-  // calls.  Thus, we use = instead of +=.
-  initializeTime_ = timer->totalElapsedTime ();
+  initializeTime_ += (timer->wallTime() - startTime);
 }
 
 
@@ -291,6 +291,8 @@ void TriDiSolver<MatrixType, false>::compute ()
   if (timer.is_null ()) {
     timer = Teuchos::TimeMonitor::getNewCounter (timerName);
   }
+
+  double startTime = timer->wallTime();
 
   // Begin timing here.
   {
@@ -316,9 +318,7 @@ void TriDiSolver<MatrixType, false>::compute ()
     isComputed_ = true;
     ++numCompute_;
   }
-  // timer->totalElapsedTime() returns the total time over all timer
-  // calls.  Thus, we use = instead of +=.
-  computeTime_ = timer->totalElapsedTime ();
+  computeTime_ += (timer->wallTime() - startTime);
 }
 
 template<class MatrixType>
@@ -445,6 +445,8 @@ apply (const Tpetra::MultiVector<scalar_type,local_ordinal_type,global_ordinal_t
     timer = Teuchos::TimeMonitor::getNewCounter (timerName);
   }
 
+  double startTime = timer->wallTime();
+
   // Begin timing here.
   {
     Teuchos::TimeMonitor timeMon (*timer);
@@ -491,9 +493,7 @@ apply (const Tpetra::MultiVector<scalar_type,local_ordinal_type,global_ordinal_t
     ++numApply_; // We've successfully finished the work of apply().
   }
 
-  // timer->totalElapsedTime() returns the total time over all timer
-  // calls.  Thus, we use = instead of +=.
-  applyTime_ = timer->totalElapsedTime ();
+  applyTime_ += (timer->wallTime() - startTime);
 }
 
 

--- a/packages/ifpack2/src/Ifpack2_Experimental_RBILUK_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Experimental_RBILUK_def.hpp
@@ -234,6 +234,7 @@ void RBILUK<MatrixType>::initialize ()
   blockSize_ = A_block_->getBlockSize();
 
   Teuchos::Time timer ("RBILUK::initialize");
+  double startTime = timer.wallTime();
   { // Start timing
     Teuchos::TimeMonitor timeMon (timer);
 
@@ -266,7 +267,7 @@ void RBILUK<MatrixType>::initialize ()
 
   this->isInitialized_ = true;
   this->numInitialize_ += 1;
-  this->initializeTime_ += timer.totalElapsedTime ();
+  this->initializeTime_ += (timer.wallTime() - startTime);
 }
 
 
@@ -485,6 +486,7 @@ void RBILUK<MatrixType>::compute ()
   D_block_->modify_host ();
 
   Teuchos::Time timer ("RBILUK::compute");
+  double startTime = timer.wallTime();
   { // Start timing
     Teuchos::TimeMonitor timeMon (timer);
     this->isComputed_ = false;
@@ -772,7 +774,7 @@ void RBILUK<MatrixType>::compute ()
 
   this->isComputed_ = true;
   this->numCompute_ += 1;
-  this->computeTime_ += timer.totalElapsedTime ();
+  this->computeTime_ += (timer.wallTime() - startTime);
 }
 
 
@@ -823,6 +825,7 @@ apply (const Tpetra::MultiVector<scalar_type,local_ordinal_type,global_ordinal_t
   const scalar_type zero = STM::zero ();
 
   Teuchos::Time timer ("RBILUK::apply");
+  double startTime = timer.wallTime();
   { // Start timing
     Teuchos::TimeMonitor timeMon (timer);
     if (alpha == one && beta == zero) {
@@ -925,7 +928,7 @@ apply (const Tpetra::MultiVector<scalar_type,local_ordinal_type,global_ordinal_t
   } // Stop timing
 
   this->numApply_ += 1;
-  this->applyTime_ = timer.totalElapsedTime ();
+  this->applyTime_ += (timer.wallTime() - startTime);
 }
 
 

--- a/packages/ifpack2/src/Ifpack2_Hiptmair_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Hiptmair_def.hpp
@@ -224,6 +224,7 @@ void Hiptmair<MatrixType>::initialize ()
   IsComputed_ = false;
 
   Teuchos::Time timer ("initialize");
+  double startTime = timer.wallTime();
   { // The body of code to time
     Teuchos::TimeMonitor timeMon (timer);
 
@@ -240,7 +241,7 @@ void Hiptmair<MatrixType>::initialize ()
   }
   IsInitialized_ = true;
   ++NumInitialize_;
-  InitializeTime_ += timer.totalElapsedTime ();
+  InitializeTime_ += (timer.wallTime() - startTime);
 }
 
 
@@ -258,6 +259,7 @@ void Hiptmair<MatrixType>::compute ()
   }
 
   Teuchos::Time timer ("compute");
+  double startTime = timer.wallTime();
   { // The body of code to time
     Teuchos::TimeMonitor timeMon (timer);
     ifpack2_prec1_->compute();
@@ -265,7 +267,7 @@ void Hiptmair<MatrixType>::compute ()
   }
   IsComputed_ = true;
   ++NumCompute_;
-  ComputeTime_ += timer.totalElapsedTime ();
+  ComputeTime_ += (timer.wallTime() - startTime);
 }
 
 
@@ -309,6 +311,7 @@ apply (const Tpetra::MultiVector<typename MatrixType::scalar_type,
     "Ifpack2::Hiptmair::apply: mode != Teuchos::NO_TRANS has not been implemented.");
 
   Teuchos::Time timer ("apply");
+  double startTime = timer.wallTime();
   { // The body of code to time
     Teuchos::TimeMonitor timeMon (timer);
 
@@ -336,7 +339,7 @@ apply (const Tpetra::MultiVector<typename MatrixType::scalar_type,
 
   }
   ++NumApply_;
-  ApplyTime_ += timer.totalElapsedTime ();
+  ApplyTime_ += (timer.wallTime() - startTime);
 }
 
 template <class MatrixType>

--- a/packages/ifpack2/src/Ifpack2_Hypre_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Hypre_def.hpp
@@ -476,7 +476,7 @@ void Hypre<MatrixType>::initialize(){
   if (timer.is_null ()) timer = Teuchos::TimeMonitor::getNewCounter (timerName);
 
   if(IsInitialized_) return;  
-
+  double startTime = timer->wallTime();
   {
     Teuchos::TimeMonitor timeMon (*timer);
     
@@ -519,7 +519,7 @@ void Hypre<MatrixType>::initialize(){
     IsInitialized_=true;
     NumInitialize_++;
   }
-  InitializeTime_ = timer->totalElapsedTime ();
+  InitializeTime_ += (timer->wallTime() - startTime);
 } //Initialize()
 
 //==============================================================================
@@ -836,7 +836,7 @@ void Hypre<MatrixType>::compute(){
   const std::string timerName ("Ifpack2::Hypre::compute");
   Teuchos::RCP<Teuchos::Time> timer = Teuchos::TimeMonitor::lookupCounter (timerName);
   if (timer.is_null ()) timer = Teuchos::TimeMonitor::getNewCounter (timerName);
-
+  double startTime = timer->wallTime();
   // Start timing here.
   {
     Teuchos::TimeMonitor timeMon (*timer);
@@ -856,9 +856,7 @@ void Hypre<MatrixType>::compute(){
     NumCompute_++;
   }
   
-  // timer->totalElapsedTime() returns the total time over all timer
-  // calls.  Thus, we use = instead of +=.
-  ComputeTime_ = timer->totalElapsedTime ();
+  ComputeTime_ += (timer->wallTime() - startTime);
 } //Compute()
 
 //==============================================================================
@@ -882,7 +880,7 @@ void Hypre<MatrixType>::apply (const Tpetra::MultiVector<scalar_type,local_ordin
   const std::string timerName ("Ifpack2::Hypre::apply");
   Teuchos::RCP<Teuchos::Time> timer = Teuchos::TimeMonitor::lookupCounter (timerName);
   if (timer.is_null ()) timer = Teuchos::TimeMonitor::getNewCounter (timerName);
-
+  double startTime = timer->wallTime();
   // Start timing here.
   {
     Teuchos::TimeMonitor timeMon (*timer);
@@ -941,9 +939,7 @@ void Hypre<MatrixType>::apply (const Tpetra::MultiVector<scalar_type,local_ordin
     }
     NumApply_++;
   }
-  // timer->totalElapsedTime() returns the total time over all timer
-  // calls.  Thus, we use = instead of +=.
-  ApplyTime_ = timer->totalElapsedTime ();
+  ApplyTime_ += (timer->wallTime() - startTime);
 } //apply()
 
 

--- a/packages/ifpack2/src/Ifpack2_ILUT_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_ILUT_def.hpp
@@ -360,6 +360,7 @@ template<class MatrixType>
 void ILUT<MatrixType>::initialize ()
 {
   Teuchos::Time timer ("ILUT::initialize");
+  double startTime = timer.wallTime();
   {
     Teuchos::TimeMonitor timeMon (timer);
 
@@ -381,7 +382,7 @@ void ILUT<MatrixType>::initialize ()
     IsInitialized_ = true;
     ++NumInitialize_;
   }
-  InitializeTime_ += timer.totalElapsedTime ();
+  InitializeTime_ += (timer.wallTime() - startTime);
 }
 
 
@@ -432,6 +433,7 @@ void ILUT<MatrixType>::compute ()
   }
 
   Teuchos::Time timer ("ILUT::compute");
+  double startTime = timer.wallTime();
   { // Timer scope for timing compute()
     Teuchos::TimeMonitor timeMon (timer, true);
     const scalar_type zero = STS::zero ();
@@ -744,7 +746,7 @@ void ILUT<MatrixType>::compute ()
     U_solver_->initialize ();
     U_solver_->compute ();
   }
-  ComputeTime_ += timer.totalElapsedTime ();
+  ComputeTime_ += (timer.wallTime() - startTime);
   IsComputed_ = true;
   ++NumCompute_;
 }
@@ -778,6 +780,7 @@ apply (const Tpetra::MultiVector<scalar_type, local_ordinal_type, global_ordinal
   const scalar_type zero = STS::zero ();
 
   Teuchos::Time timer ("ILUT::apply");
+  double startTime = timer.wallTime();
   { // Start timing
     Teuchos::TimeMonitor timeMon (timer, true);
 
@@ -817,7 +820,7 @@ apply (const Tpetra::MultiVector<scalar_type, local_ordinal_type, global_ordinal
   }//end timing
 
   ++NumApply_;
-  ApplyTime_ += timer.totalElapsedTime ();
+  ApplyTime_ += (timer.wallTime() - startTime);
 }
 
 

--- a/packages/ifpack2/src/Ifpack2_RILUK_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_RILUK_def.hpp
@@ -472,6 +472,7 @@ void RILUK<MatrixType>::initialize ()
      "range Maps, if appropriate) before calling this method.");
   
   Teuchos::Time timer ("RILUK::initialize");
+  double startTime = timer.wallTime();
   { // Start timing
     Teuchos::TimeMonitor timeMon (timer);
 
@@ -560,7 +561,7 @@ void RILUK<MatrixType>::initialize ()
 
   isInitialized_ = true;
   ++numInitialize_;
-  initializeTime_ += timer.totalElapsedTime ();
+  initializeTime_ += (timer.wallTime() - startTime);
 }
 
 template<class MatrixType>
@@ -747,6 +748,7 @@ void RILUK<MatrixType>::compute ()
 
   // Start timing
   Teuchos::TimeMonitor timeMon (timer);
+  double startTime = timer.wallTime();
 
   isComputed_ = false;
 
@@ -937,7 +939,7 @@ void RILUK<MatrixType>::compute ()
 
   isComputed_ = true;
   ++numCompute_;
-  computeTime_ += timer.totalElapsedTime ();
+  computeTime_ += (timer.wallTime() - startTime);
 }
 
 
@@ -992,6 +994,7 @@ apply (const Tpetra::MultiVector<scalar_type,local_ordinal_type,global_ordinal_t
   const scalar_type zero = STS::zero ();
 
   Teuchos::Time timer ("RILUK::apply");
+  double startTime = timer.wallTime();
   { // Start timing
     Teuchos::TimeMonitor timeMon (timer);
     if (alpha == one && beta == zero) {
@@ -1057,7 +1060,7 @@ apply (const Tpetra::MultiVector<scalar_type,local_ordinal_type,global_ordinal_t
 #endif // HAVE_IFPACK2_DEBUG
 
   ++numApply_;
-  applyTime_ = timer.totalElapsedTime ();
+  applyTime_ += (timer.wallTime() - startTime);
 }
 
 

--- a/packages/ifpack2/src/Ifpack2_Relaxation_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Relaxation_def.hpp
@@ -544,6 +544,7 @@ apply (const Tpetra::MultiVector<scalar_type, local_ordinal_type, global_ordinal
     timer = Teuchos::TimeMonitor::getNewCounter (timerName);
   }
 
+  double startTime = timer->wallTime();
   {
     Teuchos::TimeMonitor timeMon (*timer);
     // Special case: alpha == 0.
@@ -605,7 +606,7 @@ apply (const Tpetra::MultiVector<scalar_type, local_ordinal_type, global_ordinal
       }
     }
   }
-  ApplyTime_ += timer->totalElapsedTime ();
+  ApplyTime_ += (timer->wallTime() - startTime);
   ++NumApply_;
 }
 
@@ -645,6 +646,8 @@ void Relaxation<MatrixType>::initialize ()
 
   Teuchos::RCP<Teuchos::Time> timer =
     Teuchos::TimeMonitor::getNewCounter (methodName);
+
+  double startTime = timer->wallTime();
 
   { // Timing of initialize starts here
     Teuchos::TimeMonitor timeMon (*timer);
@@ -724,7 +727,7 @@ void Relaxation<MatrixType>::initialize ()
     }
   } // timing of initialize stops here
 
-  InitializeTime_ += timer->totalElapsedTime ();
+  InitializeTime_ += (timer->wallTime() - startTime);
   ++NumInitialize_;
   isInitialized_ = true;
 }
@@ -810,6 +813,7 @@ void Relaxation<MatrixType>::computeBlockCrs ()
   if (timer.is_null ()) {
     timer = Teuchos::TimeMonitor::getNewCounter (timerName);
   }
+  double startTime = timer->wallTime();
   {
     Teuchos::TimeMonitor timeMon (*timer);
 
@@ -928,7 +932,7 @@ void Relaxation<MatrixType>::computeBlockCrs ()
 #endif // HAVE_IFPACK2_DEBUG
   } // end TimeMonitor scope
 
-  ComputeTime_ += timer->totalElapsedTime ();
+  ComputeTime_ += (timer->wallTime() - startTime);
   ++NumCompute_;
   IsComputed_ = true;
 }
@@ -985,6 +989,7 @@ void Relaxation<MatrixType>::compute ()
 
   Teuchos::RCP<Teuchos::Time> timer =
     Teuchos::TimeMonitor::getNewCounter (methodName);
+  double startTime = timer->wallTime();
 
   { // Timing of compute starts here.
     Teuchos::TimeMonitor timeMon (*timer);
@@ -1344,7 +1349,7 @@ void Relaxation<MatrixType>::compute ()
     }
   } // end TimeMonitor scope
 
-  ComputeTime_ += timer->totalElapsedTime ();
+  ComputeTime_ += (timer->wallTime() - startTime);
   ++NumCompute_;
   IsComputed_ = true;
 }

--- a/packages/ifpack2/src/supportgraph/Ifpack2_SupportGraph_def.hpp
+++ b/packages/ifpack2/src/supportgraph/Ifpack2_SupportGraph_def.hpp
@@ -516,7 +516,7 @@ void SupportGraph<MatrixType>::initialize ()
   if (timer.is_null()) {
     timer = TimeMonitor::getNewCounter(timerName);
   }
-
+  double startTime = timer->wallTime();
   { // Start timing here.
     TimeMonitor timeMon (*timer);
 
@@ -543,9 +543,7 @@ void SupportGraph<MatrixType>::initialize ()
     ++NumInitialize_;
   } // Stop timing here.
 
-  // timer->totalElapsedTime() returns the total time over all timer
-  // calls.  Thus, we use = instead of +=.
-  InitializeTime_ = timer->totalElapsedTime();
+  InitializeTime_ += (timer->wallTime() - startTime);
 }
 
 
@@ -570,7 +568,7 @@ void SupportGraph<MatrixType>::compute () {
   if (timer.is_null()) {
     timer = TimeMonitor::getNewCounter(timerName);
   }
-
+  double startTime = timer->wallTime();
   { // Start timing here.
     Teuchos::TimeMonitor timeMon (*timer);
     solver_->numericFactorization();
@@ -578,9 +576,7 @@ void SupportGraph<MatrixType>::compute () {
     ++NumCompute_;
   } // Stop timing here.
 
-  // timer->totalElapsedTime() returns the total time over all timer
-  // calls.  Thus, we use = instead of +=.
-  ComputeTime_ = timer->totalElapsedTime();
+  ComputeTime_ += (timer->wallTime() - startTime);
 }
 
 
@@ -622,7 +618,7 @@ apply (const Tpetra::MultiVector<scalar_type,
   if (timer.is_null()) {
     timer = TimeMonitor::getNewCounter(timerName);
   }
-
+  double startTime = timer->wallTime();
   { // Start timing here.
     Teuchos::TimeMonitor timeMon (*timer);
 
@@ -668,9 +664,7 @@ apply (const Tpetra::MultiVector<scalar_type,
 
   ++NumApply_;
 
-  // timer->totalElapsedTime() returns the total time over all timer
-  // calls.  Thus, we use = instead of +=.
-  ApplyTime_ = timer->totalElapsedTime();
+  ApplyTime_ += (timer->wallTime() - startTime);
 }
 
 


### PR DESCRIPTION
- Don't do e.g. "ApplyTime_ += timer->totalElapsedTime()" since this
  will re-count time from all previous applies.
- Replace totalElapsedTime() with a wallTime() interval for this
  instead, since if two preconditioner objects A and B are used in
  the same StackedTimer scope, B's times will include A's
  times.

Here's an example output from before these changes, showing both issues. I looped over a setup+solve 3 times in the Ifpack2+Belos driver:
```
Every proc reading parameters from xml_file: test_MTGS_calore1_mm.xml
Matrix Market file for sparse matrix A: /ascldap/users/bmkelle/MatrixCollection/bodyy5.mtx
Configuring, initializing, and computing Ifpack2 preconditioner
 Time Init: 0.0451295
 Finished computing Ifpack2 preconditioner
  Time (s): 0.00254004
Converged in 196 iterations.
Preconditioner attributes:
 "Ifpack2::Relaxation":
  MatrixType: "Tpetra::RowMatrix<double, int, long long, Kokkos::Compat::KokkosDeviceWrapperNode<Kokkos::Serial, Kokkos::HostSpace> >"
  Label: Ifpack2::Relaxation
  Initialized: true
  Computed: true
  Parameters: 
...
  Call counts and total times (in seconds): 
   initialize: 
    Call count: 1
    Total time: 0.0445694
   compute: 
    Call count: 1
    Total time: 0.00245176
   apply: 
    Call count: 197
    Total time: 45.5491             <---------- this time is obviously too high, the whole solve < 2 seconds
2-Norm of 0th residual vec: 0
Achieved tolerance: 9.90648e-09
Matrix Market file for sparse matrix A: /ascldap/users/bmkelle/MatrixCollection/bodyy5.mtx
Configuring, initializing, and computing Ifpack2 preconditioner
 Time Init: 0.0410482
 Finished computing Ifpack2 preconditioner
  Time (s): 0.00175627
Converged in 197 iterations.
Preconditioner attributes:
 "Ifpack2::Relaxation":
  MatrixType: "Tpetra::RowMatrix<double, int, long long, Kokkos::Compat::KokkosDeviceWrapperNode<Kokkos::Serial, Kokkos::HostSpace> >"
  Label: Ifpack2::Relaxation
  Initialized: true
  Computed: true
  Parameters: 
...
  Call counts and total times (in seconds): 
   initialize: 
    Call count: 1
    Total time: 0.0856112    <----- this is twice the initialize time from the 1st run, because it's including that timer
   compute: 
    Call count: 1
    Total time: 0.00420082
   apply: 
    Call count: 198
    Total time: 137.697
2-Norm of 0th residual vec: 0
Achieved tolerance: 9.36909e-09
Matrix Market file for sparse matrix A: /ascldap/users/bmkelle/MatrixCollection/bodyy5.mtx
Configuring, initializing, and computing Ifpack2 preconditioner
 Time Init: 0.0410016
 Finished computing Ifpack2 preconditioner
  Time (s): 0.00189405
Converged in 198 iterations.
Preconditioner attributes:
 "Ifpack2::Relaxation":
  MatrixType: "Tpetra::RowMatrix<double, int, long long, Kokkos::Compat::KokkosDeviceWrapperNode<Kokkos::Serial, Kokkos::HostSpace> >"
  Label: Ifpack2::Relaxation
  Initialized: true
  Computed: true
  Parameters: 
...
  Call counts and total times (in seconds): 
   initialize: 
    Call count: 1
    Total time: 0.126603 <------ and this is 3x the first (correct) init time
   compute: 
    Call count: 1
    Total time: 0.00608721
   apply: 
    Call count: 199
    Total time: 231.351
2-Norm of 0th residual vec: 0
Achieved tolerance: 9.94677e-09
proc 0 total program time: 7.25437
End Result: TEST PASSED
```

Here is what StackedTimer shows (this always had the correct call counts and total times). With this PR, the times reported by the Preconditioner above are consistent with the StackedTimer.
```
Ifpack2+Belos: total: 7.30449 [1]
|   init: 0.126711 [3]
|   |   Ifpack2::Relaxation::initialize: 0.126314 [3]
|   |   Remainder: 0.000397178
|   precond: 0.0060841 [3]
|   |   Ifpack2::Relaxation::compute: 0.00603574 [3]
|   |   Remainder: 4.836e-05
|   Belos: Operation Op*x: 0.0138657 [6]
|   Belos: Operation Prec*x: 0.00765458 [3]
|   |   Ifpack2::Relaxation::apply: 0.00762528 [3]
|   |   Remainder: 2.93e-05
|   Belos: BlockGmresSolMgr total solve time: 6.6073 [3]
|   |   Belos: ICGS[2]: Orthogonalization: 3.72666 [594]
|   |   |   Belos: ICGS[2]: Ortho (Norm): 0.0673645 [594]
|   |   |   Belos: ICGS[2]: Ortho (Inner Product): 2.20892 [1182]
|   |   |   Belos: ICGS[2]: Ortho (Update): 1.38941 [1182]
|   |   |   Remainder: 0.0609764
|   |   Belos: Operation Op*x: 1.38112 [610]
|   |   Belos: Operation Prec*x: 1.39858 [591]
|   |   |   Ifpack2::Relaxation::apply: 1.395 [591]
|   |   |   Remainder: 0.00357807
|   |   Remainder: 0.100944
|   Remainder: 0.542874
```
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/ifpack2 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Makes all Ifpack2::Preconditioner compute InitTime_, ComputeTime_, ApplyTime_ correctly.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
Did the setup+solve 3 times to demonstrate the incorrect reported times, and that this fixed it.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->