### PR TITLE
Turn CUDA Launch Blocking OFF

### DIFF
--- a/cmake/std/PullRequestLinuxCuda10.1.105TestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxCuda10.1.105TestingSettings.cmake
@@ -132,5 +132,9 @@ set (EpetraExt_inout_test_MPI_4_DISABLE ON CACHE BOOL "Temporary disable for CUD
 set (Teko_testdriver_MPI_4_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
 set (Zoltan2_fix4785_MPI_4_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
 set (Intrepid2_unit-test_Discretization_Basis_HierarchicalBases_Hierarchical_Basis_Tests_MPI_1_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
+# Disabled for Launch Blocking: 0
+set (Teko_testdriver_tpetra_MPI_1_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
+set (Teko_testdriver_tpetra_MPI_4_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
+
 
 include("${CMAKE_CURRENT_LIST_DIR}/PullRequestLinuxCommonTestingSettings.cmake")

--- a/cmake/std/pr_config/pullrequest.ini
+++ b/cmake/std/pr_config/pullrequest.ini
@@ -359,7 +359,7 @@ module-swap openblas/0.3.4/gcc/7.4.0: netlib/3.8.0/gcc/7.2.0
 setenv OMPI_CXX: ${WORKSPACE}/Trilinos/packages/kokkos/bin/nvcc_wrapper
 setenv OMPI_CC: ${CC}
 setenv OMPI_FC: ${FC}
-setenv CUDA_LAUNCH_BLOCKING: 1
+setenv CUDA_LAUNCH_BLOCKING: 0
 setenv CUDA_MANAGED_FORCE_DEVICE_ALLOC: 1
 setenv PATH_TMP: /ascldap/users/rabartl/install/white-ride/ninja-1.8.2/bin:${PATH}
 setenv PATH:     /ascldap/users/rabartl/install/white-ride/cmake-3.11.2/bin:${PATH_TMP}


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/framework 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Environment change to `setenv CUDA_LAUNCH_BLOCKING: 0`
This change does cause two @trilinos/teko tests to fail, so those have been turned off until they can be adjusted.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->
Issue #8396

<!--- 
## Stakeholder Feedback

If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
These changes have been run with the Jenkins job, successful with the two tests turned off.
[CDash Results](https://testing.sandia.gov/cdash/index.php?project=Trilinos&display=project&filtercount=3&showfilters=1&filtercombine=and&field1=buildname&compare1=63&value1=cuda_10.1.105&field2=buildname&compare2=63&value2=launchblocking&field3=buildstamp&compare3=63&value3=Experimental)
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->