### PR TITLE
Tpetra:  Add missing syncs/modifies in BlockMultiVector unit tests

### DIFF
--- a/packages/tpetra/core/test/Block/BlockMultiVector.cpp
+++ b/packages/tpetra/core/test/Block/BlockMultiVector.cpp
@@ -429,16 +429,6 @@ namespace {
     TEST_ASSERT( X_overlap.data () != NULL );
     TEST_EQUALITY_CONST( static_cast<size_t> (X_overlap.extent (0)), static_cast<size_t> (blockSize) );
 
-    // {
-    //   std::ostringstream os;
-    //   os << "Proc " << myRank
-    //      << ": X_overlap.data() = " << X_overlap.data ()
-    //      << ", X_overlap.getBlockSize() = " << X_overlap.getBlockSize ()
-    //      << ", meshMap.getMinGlobalIndex() = " << meshMap.getMinGlobalIndex ()
-    //      << std::endl;
-    //   std::cerr << os.str ();
-    // }
-
     {
       const int lclOk = (X_overlap.data () != NULL &&
                          static_cast<size_t> (X_overlap.extent (0)) == static_cast<size_t> (blockSize)) ? 1 : 0;
@@ -454,9 +444,9 @@ namespace {
     }
 
     { // BlockMultiVector relies on the point multivector infrastructure
-      const auto pointMehsMap = BMV::makePointMap(meshMap, blockSize);
+      const auto pointMeshMap = BMV::makePointMap(meshMap, blockSize);
       const auto pointOverlappingMeshMap = BMV::makePointMap(overlappingMeshMap, blockSize);
-      import_type pointImport (rcpFromRef (pointMehsMap), rcpFromRef (pointOverlappingMeshMap));
+      import_type pointImport (rcpFromRef (pointMeshMap), rcpFromRef (pointOverlappingMeshMap));
       Y.getMultiVectorView().doImport (X.getMultiVectorView(), pointImport, Tpetra::REPLACE);
     }
 

--- a/packages/tpetra/core/test/Block/BlockMultiVector.cpp
+++ b/packages/tpetra/core/test/Block/BlockMultiVector.cpp
@@ -415,6 +415,8 @@ namespace {
 
     BMV X (meshMap, blockSize, numVecs);
     BMV Y (overlappingMeshMap, blockSize, numVecs);
+    X.sync_host();
+    Y.sync_host();
 
     //
     // Fill X with meaningful things to test Import with REPLACE combine mode.
@@ -442,6 +444,7 @@ namespace {
     for (LO i = 0; i < blockSize; ++i) {
       X_overlap(i) = static_cast<Scalar> (i+1);
     }
+    X.modify_host();
 
     { // BlockMultiVector relies on the point multivector infrastructure
       const auto pointMeshMap = BMV::makePointMap(meshMap, blockSize);

--- a/packages/tpetra/core/test/Block/BlockMultiVector.cpp
+++ b/packages/tpetra/core/test/Block/BlockMultiVector.cpp
@@ -263,6 +263,7 @@ namespace {
     //RCP<const map_type> mapPtr = Teuchos::rcpFromRef (map); // nonowning RCP
 
     BMV X (meshMap, blockSize, numVecs);
+    X.sync_host();
 
     typedef typename BMV::mv_type mv_type;
     mv_type X_mv = X.getMultiVectorView ();
@@ -305,6 +306,7 @@ namespace {
       X_5_1(i) = static_cast<Scalar> (i + 1); // all are nonzero
     }
     TEST_ASSERT( ! equal (X_5_1, zeroLittleVector) && ! equal (zeroLittleVector, X_5_1) );
+    X.modify_host();
 
     // Make sure that getLocalBlock() returns a read-and-write view,
     // not a deep copy.  Do this by calling getLocalBlock(5,1) again,


### PR DESCRIPTION
@trilinos/tpetra 

## Motivation
These tests operate on primarily on host, but without explicit sync/modify calls, data added on host using non-const Views handed out from the BlockMultivector was being overwritten.  Also, in the Import test, without X being marked modify_host after modifications were made to a host view of X's data, the correct data was not brought over to Y.

## Related Issues

* Related to #8209

## Testing
Now passing in a non-UVM build on an x86/V100 platform (ascicgpu).