### PR TITLE
Teko: fix tests for CUDA_LAUNCH_BLOCKING=OFF

### DIFF
--- a/packages/thyra/adapters/tpetra/src/Thyra_TpetraLinearOp_def.hpp
+++ b/packages/thyra/adapters/tpetra/src/Thyra_TpetraLinearOp_def.hpp
@@ -296,7 +296,7 @@ void TpetraLinearOp<Scalar,LocalOrdinal,GlobalOrdinal,Node>::applyImpl(
   // Apply the operator
 
   tpetraOperator_->apply(*tX, *tY, tTransp, alpha, beta);
-
+  Kokkos::fence();
 }
 
 // Protected member functions overridden from ScaledLinearOpBase
@@ -330,6 +330,7 @@ scaleLeftImpl(const VectorBase<Scalar> &row_scaling_in)
     Teuchos::rcp_dynamic_cast<Tpetra::RowMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> >(tpetraOperator_.getNonconstObj(),true);
 
   rowMatrix->leftScale(*row_scaling);
+  Kokkos::fence();
 }
 
 
@@ -347,6 +348,7 @@ scaleRightImpl(const VectorBase<Scalar> &col_scaling_in)
     Teuchos::rcp_dynamic_cast<Tpetra::RowMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> >(tpetraOperator_.getNonconstObj(),true);
 
   rowMatrix->rightScale(*col_scaling);
+  Kokkos::fence();
 }
 
 // Protected member functions overridden from RowStatLinearOpBase
@@ -442,6 +444,7 @@ void TpetraLinearOp<Scalar,LocalOrdinal,GlobalOrdinal,Node>::getRowStatImpl(
     TEUCHOS_TEST_FOR_EXCEPTION(true,std::runtime_error,
                                "Error - Thyra::TpetraLinearOp::getRowStatImpl() - Column sum support not implemented!");
   }
+  Kokkos::fence();
 }
 
 


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Two Teko tests are failing with CUDA_LAUNCH_BLOCKING=OFF. This fixes the tests by adding required fences in the Thyra/Tpetra adapters.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->
Closes #8497 

## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Tests are covered by:
- Teko_testdriver_tpetra_MPI_1
- Teko_testdriver_tpetra_MPI_4

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->