### PR TITLE
MueLu: only loop interface rows in MakeQuasiRegionMatrices

### DIFF
--- a/packages/muelu/research/regionMG/src/SetupRegionMatrix_def.hpp
+++ b/packages/muelu/research/regionMG/src/SetupRegionMatrix_def.hpp
@@ -168,18 +168,20 @@ void MakeQuasiregionMatrices(const RCP<Xpetra::CrsMatrixWrap<Scalar, LocalOrdina
   RCP<CrsMatrixWrap> quasiRegionCrsWrap = Teuchos::rcp_dynamic_cast<CrsMatrixWrap>(quasiRegionMats);
   RCP<CrsMatrix> quasiRegionCrs = quasiRegionCrsWrap->getCrsMatrix();
 
-  Array<LO> tmp(regionMatVecLIDs());
-  std::sort(tmp.begin(), tmp.end());
-  auto vecEnd = std::unique(tmp.begin(), tmp.end());
-  auto vecStart = tmp.begin();
+  // Grab first and last element of sorted interface LIDs
+  Array<LO> interfaceLIDs(regionMatVecLIDs());
+  std::sort(interfaceLIDs.begin(), interfaceLIDs.end());
+  auto vecEnd = std::unique(interfaceLIDs.begin(), interfaceLIDs.end());
+  auto vecStart = interfaceLIDs.begin();
 
   GO rowGID;
   LocalOrdinal col;
   GlobalOrdinal colGID;
   std::size_t sizeOfCommonRegions;
+  std::size_t numEntries = 0;
   for(auto row = vecStart; row < vecEnd; ++row) {
     rowGID = rowMap->getGlobalElement(*row);
-    std::size_t numEntries = quasiRegionMats->getNumEntriesInLocalRow(*row); // number of entries in this row
+    numEntries = quasiRegionMats->getNumEntriesInLocalRow(*row); // number of entries in this row
     Array<SC> values(numEntries); // non-zeros in this row
     Array<LO> colInds(numEntries); // local column indices
     quasiRegionMats->getLocalRowCopy(*row, colInds, values, numEntries);

--- a/packages/muelu/research/regionMG/src/SetupRegionUtilities.hpp
+++ b/packages/muelu/research/regionMG/src/SetupRegionUtilities.hpp
@@ -1078,7 +1078,7 @@ void createRegionData(const int numDimensions,
   }
 
   // Have all the GIDs and LIDs we stort them in place with std::sort()
-  // Subsequently we bring unique values to the begining of the array with
+  // Subsequently we bring unique values to the beginning of the array with
   // std::unique() and delete the duplicates with erase.
   std::sort(interfaceLIDsData.begin(), interfaceLIDsData.end());
   interfaceLIDsData.erase(std::unique(interfaceLIDsData.begin(), interfaceLIDsData.end()),

--- a/packages/muelu/research/regionMG/src/SetupRegionUtilities.hpp
+++ b/packages/muelu/research/regionMG/src/SetupRegionUtilities.hpp
@@ -1078,8 +1078,8 @@ void createRegionData(const int numDimensions,
   }
 
   // Have all the GIDs and LIDs we stort them in place with std::sort()
-  // Subsequently we bring unique values to the begin of the array with
-  // std::unique() and delente the duplicates with erase.
+  // Subsequently we bring unique values to the begining of the array with
+  // std::unique() and delete the duplicates with erase.
   std::sort(interfaceLIDsData.begin(), interfaceLIDsData.end());
   interfaceLIDsData.erase(std::unique(interfaceLIDsData.begin(), interfaceLIDsData.end()),
                           interfaceLIDsData.end());

--- a/packages/muelu/research/regionMG/test/structured/Driver_Structured_Regions.cpp
+++ b/packages/muelu/research/regionMG/test/structured/Driver_Structured_Regions.cpp
@@ -580,10 +580,12 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
   tmLocal = Teuchos::null;
   tmLocal = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("Driver: 3.4 - Build QuasiRegion Matrix")));
 
+  std::cout << "About to create quasi region matrix" << std::endl;
   RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > quasiRegionMats;
   MakeQuasiregionMatrices(Teuchos::rcp_dynamic_cast<CrsMatrixWrap>(A),
                           regionsPerGIDWithGhosts, rowMap, colMap, rowImport,
-                          quasiRegionMats);
+                          quasiRegionMats, regionMatVecLIDs);
+  std::cout << "Done creating quasi region matrix" << std::endl;
 
   comm->barrier();
   tmLocal = Teuchos::null;

--- a/packages/muelu/research/regionMG/test/structured/compare_residual_history.py
+++ b/packages/muelu/research/regionMG/test/structured/compare_residual_history.py
@@ -1,6 +1,22 @@
 import os
 import sys
 
+def check_residual(goldResidual, testResidual, maxDiff, relDiff=1e-7, precisionThreshold=1e-7):
+    res=False
+    if(abs(goldResidual) < precisionThreshold):
+        print("Using absolute error")
+        # Check residual using absolute error
+        # as values are to small to check reliably
+        # with relative error due to machine precision
+        if(abs(goldResidual - testResidual) < maxDiff):
+            res=True
+    else:
+        print("Using relative error")
+        if(abs(goldResidual - testResidual) / abs(goldResidual) < relDiff):
+            res=True
+
+    return res
+
 numIterPassed = False
 goldConvergenceHistoryPassed = True
 
@@ -39,7 +55,7 @@ if numIterPassed:
         goldResidual = float((goldConvergenceHistory[iteration].split())[1])
         testResidual = float((testLogConvergenceHistory[iteration].split())[1])
 
-        if abs(goldResidual-testResidual) < maxDiff:
+        if check_residual(goldResidual, testResidual, maxDiff):
             print(('Residual in iteration {}: OK').format(str(iteration)))
         else:
             print(('Residual in iteration {}: WRONG -- deviation from value in gold file.').format(str(iteration)))
@@ -47,7 +63,7 @@ if numIterPassed:
             break
 
 # Print final result to be processed by Tribits
-if numIterPassed and goldConvergenceHistory:
+if numIterPassed and goldConvergenceHistoryPassed:
     print('End Result: TEST PASSED')
 else:
     print('End Result: TEST FAILED')

--- a/packages/muelu/research/regionMG/test/structured/compare_residual_history.py
+++ b/packages/muelu/research/regionMG/test/structured/compare_residual_history.py
@@ -6,7 +6,7 @@ goldConvergenceHistoryPassed = True
 
 goldFileName =  sys.argv[1]
 testLogFileName =  sys.argv[2]
-maxDiff = sys.argv[3]
+maxDiff = float(sys.argv[3])
 
 ## Read gold file and extract pure convergence history
 goldFile = open(goldFileName, 'rt')
@@ -25,20 +25,20 @@ for line in testLogFileContent:
     if not line.startswith('#'):
         testLogConvergenceHistory.append(line)
 testLogFile.close()
-    
+
 # Check for same number of iterations
 if len(goldConvergenceHistory) == len(testLogConvergenceHistory):
     print('Number of iterations: OK')
     numIterPassed = True
 else:
     print('Number of iterations: WRONG -- deviation from value in gold file.')
-    
+
 # Check residual in each iteration
 if numIterPassed:
     for iteration in range(len(goldConvergenceHistory)):
         goldResidual = float((goldConvergenceHistory[iteration].split())[1])
         testResidual = float((testLogConvergenceHistory[iteration].split())[1])
-        
+
         if abs(goldResidual-testResidual) < maxDiff:
             print(('Residual in iteration {}: OK').format(str(iteration)))
         else:

--- a/packages/muelu/test/unit_tests/RegionMatrix.cpp
+++ b/packages/muelu/test/unit_tests/RegionMatrix.cpp
@@ -168,7 +168,7 @@ void createRegionMatrix(const Teuchos::ParameterList galeriList,
   RCP<Matrix> quasiRegionGrpMats = Teuchos::null;
   MakeQuasiregionMatrices(Teuchos::rcp_dynamic_cast<CrsMatrixWrap>(A),
                           regionsPerGIDWithGhosts, rowMap, colMap, rowImport,
-                          quasiRegionGrpMats);
+                          quasiRegionGrpMats, regionMatVecLIDs);
 
   MakeRegionMatrices(Teuchos::rcp_dynamic_cast<CrsMatrixWrap>(A), A->getRowMap(), rowMap,
                      revisedRowMap, revisedColMap,

--- a/packages/muelu/test/unit_tests/RegionRFactory.cpp
+++ b/packages/muelu/test/unit_tests/RegionRFactory.cpp
@@ -170,7 +170,7 @@ void createRegionMatrix(const Teuchos::ParameterList galeriList,
   RCP<Matrix> quasiRegionGrpMats = Teuchos::null;
   MakeQuasiregionMatrices(Teuchos::rcp_dynamic_cast<CrsMatrixWrap>(A),
                           regionsPerGIDWithGhosts, rowMap, colMap, rowImport,
-                          quasiRegionGrpMats);
+                          quasiRegionGrpMats, regionMatVecLIDs);
 
   MakeRegionMatrices(Teuchos::rcp_dynamic_cast<CrsMatrixWrap>(A), A->getRowMap(), rowMap,
                      revisedRowMap, revisedColMap,


### PR DESCRIPTION
Calling functions such as getLocalRowCopy() and replaceLocalValues()
are very slow for some reason. Rewritting loops over the matrix
rows without using these yields large code speed ups.

@trilinos/muelu 

## Motivation
The change in implementation yields a two order of magnitude speed up.
This allows unit-tests and at scale runs to improve dramatically in run time
as the driver runtime is dominated by matrix scaling at the moment.

## Related Issues

* Closes 8374
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 


## Stakeholder Feedback
People running the unit-tests are very happy with reduced runtime.

## Testing
This has been tested locally on my workstation.