### PR TITLE
Panzer STK: Add functionality to delete parent elements after they are queried

### DIFF
--- a/packages/panzer/adapters-stk/example/PoissonInterfaceExample/main.cpp
+++ b/packages/panzer/adapters-stk/example/PoissonInterfaceExample/main.cpp
@@ -455,8 +455,13 @@ int main (int argc, char* argv[])
 
     // Construct mesh.
     Teuchos::RCP<panzer_stk::STK_MeshFactory> mesh_factory;
+    RCP<Teuchos::ParameterList> pl = rcp(new Teuchos::ParameterList);
     if ( ! po.mesh_filename.empty()) {
       mesh_factory = Teuchos::rcp(new panzer_stk::STK_ExodusReaderFactory(po.mesh_filename));
+      pl->set("File Name", po.mesh_filename);
+      pl->set("Keep Percept Data", true);
+      pl->set("Keep Percept Parent Elements", true);
+      pl->set("Levels of Uniform Refinement", 1);
     } else {
       if (po.is3d)
         mesh_factory = Teuchos::rcp(new panzer_stk::CubeHexMeshFactory);
@@ -466,7 +471,6 @@ int main (int argc, char* argv[])
 
     if (po.mesh_filename.empty()) {
       // set mesh factory parameters
-      RCP<Teuchos::ParameterList> pl = rcp(new Teuchos::ParameterList);
       pl->set("X Blocks",2);
       pl->set("Y Blocks",1);
       if (po.is3d) pl->set("Z Blocks",1);
@@ -485,8 +489,8 @@ int main (int argc, char* argv[])
           pl->set("Y Procs", nyp);
         }
       }
-      mesh_factory->setParameterList(pl);
     }
+    mesh_factory->setParameterList(pl);
 
     RCP<panzer_stk::STK_Interface> mesh = mesh_factory->buildUncommitedMesh(MPI_COMM_WORLD);
     if (po.generate_mesh_only) {

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_ExodusReaderFactory.cpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_ExodusReaderFactory.cpp
@@ -257,6 +257,9 @@ void STK_ExodusReaderFactory::completeMeshConstruction(STK_Interface & mesh,stk:
    }
    mesh.endModification();
 
+   if(keepPerceptData_)
+     mesh.deleteParentElements();
+
    if (userMeshScaling_) {
      stk::mesh::Field<double,stk::mesh::Cartesian>* coord_field =
        metaData.get_field<stk::mesh::Field<double, stk::mesh::Cartesian> >(stk::topology::NODE_RANK, "coordinates");

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.cpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.cpp
@@ -2040,5 +2040,18 @@ void STK_Interface::refineMesh(const int numberOfLevels, const bool deleteParent
 #endif
 }
 
+void STK_Interface::deleteParentElements() {
+#ifdef PANZER_HAVE_PERCEPT
+  TEUCHOS_ASSERT(nonnull(refinedMesh_));
+  TEUCHOS_ASSERT(nonnull(breakPattern_));
+  
+  percept::UniformRefiner breaker(*refinedMesh_,*breakPattern_);
+  breaker.deleteParentElements();
+
+#else
+  TEUCHOS_TEST_FOR_EXCEPTION(true,std::logic_error,
+                             "ERROR: This requires the Percept package to be enabled in Trilinos!");
+#endif
+}
 
 } // end namespace panzer_stk

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.hpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.hpp
@@ -1223,6 +1223,10 @@ public:
    */
   void refineMesh(const int numberOfLevels, const bool deleteParentElements);
 
+  /** Delete the parent elements if there are any in the mesh.
+    */
+  void deleteParentElements();
+
 public: // static operations
    static const std::string coordsString;
    static const std::string nodesString;


### PR DESCRIPTION
@rppawlo I'm interested in some brief feedback. As discussed in #8475, I took the route of implementing a function in `STK_Interface` that allows for deleting parent elements; however, I think there's an issue. In its current form, this correctly deletes parent elements, but any calls to any Panzer functionality immediately after mesh generation and deleting parent elements causes a segfault. My best guess is that the `mesh.buildSubcells();` or `mesh.buildLocalElementIDs();` commands (and their subcommands) on line 231 of ExodusReaderFactory are creating references to the parent objects that I'm deleting. Should I go into these calls and try combining some selectors with no-parent selectors, or do you think there's an easier way?

@trilinos/panzer

## Related Issues
* Related to #8475, #8365

## Testing
Test `PanzerAdaptersSTK_tPamgenMeshFactory_MPI_1` currently fails. This is partially insurance to make sure this change doesn't get merged yet because it will cause segfaults. I will make sure to address tests once I have everything polished.

## To-Do
This is for myself, but I don't want to forget to add appropriate warnings about using this functionality.