### PR TITLE
Framework: Set issue autocloser to weekends

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,7 +8,8 @@ on:
   # - Note: Mountain Standard Time (MST) is 7 hours behind UTC during the winter.
   # Cron strings: MIN HR DOM MON DOW
   schedule:
-  - cron: "0 12 * * *"
+  - cron: "0 12 * * 0,3,6"
+  #- cron: "0 12 * * *"
 
 
 # See https://github.com/actions/stale/blob/master/action.yml for information on actions


### PR DESCRIPTION
Changing the CRON for the issue autocloser to `0 12 * * 0,6` which will make it run around 5 or 6am mountain time (depending on daylight savings) on Saturday and Sunday only.

@trilinos/framework 

## Motivation
Reduces the frequency the autocloser runs, from once daily to just once on Saturday, Sunday, and Wednesday.

## Related Issues
* Closes #8509 
