### PR TITLE
Turn Teko tests back on.

### DIFF
--- a/cmake/std/PullRequestLinuxCuda10.1.105TestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxCuda10.1.105TestingSettings.cmake
@@ -87,8 +87,7 @@ set (Trilinos_ENABLE_ShyLU_NodeTacho OFF CACHE BOOL
 # Force some tests to run in serial in this PR build (usually to resolve random timeouts that can occur under contention)
 set (Intrepid2_unit-test_Discretization_Basis_HierarchicalBases_Hierarchical_Basis_Tests_MPI_1_SET_RUN_SERIAL ON CACHE BOOL "Run serial for CUDA PR testing")
 
-# Temporary options to clean up build
-set (Teko_ModALPreconditioner_MPI_1_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
+# Options used to clean up build
 set (MueLu_ParameterListInterpreterTpetra_MPI_1_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
 set (MueLu_ParameterListInterpreterTpetraHeavy_MPI_1_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
 set (STKUnit_tests_stk_ngp_test_utest_MPI_4_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
@@ -132,9 +131,6 @@ set (EpetraExt_inout_test_MPI_4_DISABLE ON CACHE BOOL "Temporary disable for CUD
 set (Teko_testdriver_MPI_4_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
 set (Zoltan2_fix4785_MPI_4_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
 set (Intrepid2_unit-test_Discretization_Basis_HierarchicalBases_Hierarchical_Basis_Tests_MPI_1_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
-# Disabled for Launch Blocking: 0
-set (Teko_testdriver_tpetra_MPI_1_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
-set (Teko_testdriver_tpetra_MPI_4_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
 
 
 include("${CMAKE_CURRENT_LIST_DIR}/PullRequestLinuxCommonTestingSettings.cmake")


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/framework 
@trilinos/teko 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
This will turn 3 Teko tests on for the CUDA 10.1.105 build.

- `ModALPreconditioner_MPI_1`
- `testdriver_tpetra_MPI_1`
- `testdriver_tpetra_MPI_4`

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->
Closes #8497

<!--- 
## Stakeholder Feedback
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
I manually ran a build with 4 tests turned on. These 3 now finish successfully.
[CDash](https://testing.sandia.gov/cdash/index.php?project=Trilinos&display=project&filtercount=3&showfilters=1&filtercombine=and&field1=site&compare1=61&value1=ride17&field2=buildname&compare2=61&value2=PR-teko_tests_ON-test-Trilinos_pullrequest_cuda_10.1.105-67&field3=buildstamp&compare3=61&value3=20201221-1656-Experimental)
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->