### PR TITLE
MueLu: Add research/regionMG/src to include directories if ENABLE_Experimental

### DIFF
--- a/packages/muelu/src/CMakeLists.txt
+++ b/packages/muelu/src/CMakeLists.txt
@@ -68,6 +68,9 @@ ENDIF()
 IF (${PACKAGE_NAME}_ENABLE_Intrepid2)
   INCLUDE_DIRECTORIES(${DIR}/Transfers/PCoarsen)
 ENDIF()
+IF (${PACKAGE_NAME}_ENABLE_Experimental)
+  INCLUDE_DIRECTORIES(${DIR}/../research/regionMG/src)
+ENDIF()
 
 # Function to generate ETI (explicit template instantiation) files
 # from a template and list of class names


### PR DESCRIPTION
@trilinos/muelu

## Motivation
#8155 didn't actually make the regionMG header files accessible to the rest of MueLu or to outside packages, although I thought it did. This PR might be a silly way to do things since I sometimes don't fully understand what CMake is doing, but it adds the regionMG headers in the CMakeLists file in `muelu/src` if `${PACKAGE_NAME}_ENABLE_Experimental`, and I believe my testing is sufficient to say it works.

Of course, there is no need to have the headers accessible to other MueLu functionality, since we wouldn't base production code on experimental research code, but it allows for the headers to be accessed within TrilinosCouplings, which is what I care about for the region multigrid & panzer code.

## Testing
I don't think this affects anything. Everything builds fine in debug mode, and I'm running the testsuite now. The autotester will probably not pick this up since it's experimental.

Edit: All tests passed on my experimental debug build.