### PR TITLE
MueLu: Mixed precision RefMaxwell

### DIFF
--- a/packages/muelu/adapters/stratimikos/Thyra_MueLuRefMaxwellPreconditionerFactory_decl.hpp
+++ b/packages/muelu/adapters/stratimikos/Thyra_MueLuRefMaxwellPreconditionerFactory_decl.hpp
@@ -75,17 +75,12 @@
 #include <Xpetra_Matrix.hpp>
 #include <Xpetra_ThyraUtils.hpp>
 
-#include <MueLu_Hierarchy.hpp>
-#include <MueLu_HierarchyManager.hpp>
-#include <MueLu_HierarchyUtils.hpp>
-#include <MueLu_Utilities.hpp>
-#include <MueLu_ParameterListInterpreter.hpp>
-#include <MueLu_MLParameterListInterpreter.hpp>
-#include <MueLu_MasterList.hpp>
 #include <MueLu_XpetraOperator_decl.hpp> // todo fix me
 #include <MueLu_RefMaxwell.hpp>
 #ifdef HAVE_MUELU_TPETRA
 #include <MueLu_TpetraOperator.hpp>
+#include <Xpetra_TpetraOperator.hpp>
+#include <Xpetra_TpetraHalfPrecisionOperator.hpp>
 #endif
 #ifdef HAVE_MUELU_EPETRA
 #include <MueLu_EpetraOperator.hpp>
@@ -96,8 +91,12 @@
 
 #include "Kokkos_DefaultNode.hpp"
 
+#include <list>
 
 namespace Thyra {
+
+  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+  bool replaceWithXpetra(ParameterList& paramList, std::string parameterName);
 
   /** @brief Concrete preconditioner factory subclass for Thyra based on MueLu.
       @ingroup MueLuAdapters
@@ -208,8 +207,6 @@ namespace Thyra {
       if (Xpetra::ThyraUtils<Scalar,LocalOrdinal,GlobalOrdinal,Node>::isEpetra(fwdOp)) return true;
 #endif
 
-      if (Xpetra::ThyraUtils<Scalar,LocalOrdinal,GlobalOrdinal,Node>::isBlockedOperator(fwdOp)) return true;
-
       return false;
     }
 
@@ -226,21 +223,25 @@ namespace Thyra {
       using Teuchos::rcp_dynamic_cast;
 
       // we are using typedefs here, since we are using objects from different packages (Xpetra, Thyra,...)
-      typedef Xpetra::Map<LocalOrdinal,GlobalOrdinal,Node>                     XpMap;
       typedef Xpetra::Operator<Scalar, LocalOrdinal, GlobalOrdinal, Node>      XpOp;
       typedef Xpetra::ThyraUtils<Scalar,LocalOrdinal,GlobalOrdinal,Node>       XpThyUtils;
-      typedef Xpetra::CrsMatrixWrap<Scalar,LocalOrdinal,GlobalOrdinal,Node>    XpCrsMatWrap;
       typedef Xpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>        XpCrsMat;
-      typedef Xpetra::BlockedCrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> XpBlockedCrsMat;
       typedef Xpetra::Matrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>           XpMat;
-      typedef Xpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>      XpMultVec;
-      typedef Xpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::magnitudeType,LocalOrdinal,GlobalOrdinal,Node>      XpMultVecDouble;
       typedef Thyra::LinearOpBase<Scalar>                                      ThyLinOpBase;
-      typedef Thyra::DiagonalLinearOpBase<Scalar>                              ThyDiagLinOpBase;
       typedef Thyra::XpetraLinearOp<Scalar, LocalOrdinal, GlobalOrdinal, Node> ThyXpOp;
-#if defined(HAVE_MUELU_EPETRA)
-      typedef Xpetra::EpetraCrsMatrixT<GlobalOrdinal,Node>                  XpEpCrsMat;
+#if defined(HAVE_MUELU_TPETRA) && defined(HAVE_TPETRA_INST_DOUBLE) && defined(HAVE_TPETRA_INST_FLOAT)
+      typedef Xpetra::TpetraHalfPrecisionOperator<Scalar,LocalOrdinal,GlobalOrdinal,Node> XpHalfPrecOp;
+      typedef Xpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>           XpMV;
+      typedef typename XpHalfPrecOp::HalfScalar                                     HalfScalar;
+      typedef Xpetra::Operator<HalfScalar,LocalOrdinal,GlobalOrdinal,Node>          XpHalfOp;
+      typedef typename Teuchos::ScalarTraits<Scalar>::magnitudeType                 Magnitude;
+      typedef typename Teuchos::ScalarTraits<Magnitude>::halfPrecision              HalfMagnitude;
+      typedef Xpetra::MultiVector<HalfScalar,LocalOrdinal,GlobalOrdinal,Node>       XphMV;
+      typedef Xpetra::MultiVector<Magnitude,LocalOrdinal,GlobalOrdinal,Node >       XpmMV;
+      typedef Xpetra::MultiVector<HalfMagnitude,LocalOrdinal,GlobalOrdinal,Node >   XphmMV;
+      typedef Xpetra::Matrix<HalfScalar,LocalOrdinal,GlobalOrdinal,Node>            XphMat;
 #endif
+      Teuchos::TimeMonitor tM(*Teuchos::TimeMonitor::getNewTimer(std::string("ThyraMueLuRefMaxwell::initializePrec")));
 
       // Check precondition
       TEUCHOS_ASSERT(Teuchos::nonnull(fwdOpSrc));
@@ -257,53 +258,17 @@ namespace Thyra {
       // Check whether it is Epetra/Tpetra
       bool bIsEpetra  = XpThyUtils::isEpetra(fwdOp);
       bool bIsTpetra  = XpThyUtils::isTpetra(fwdOp);
-      bool bIsBlocked = XpThyUtils::isBlockedOperator(fwdOp);
       TEUCHOS_TEST_FOR_EXCEPT((bIsEpetra == true  && bIsTpetra == true));
-      TEUCHOS_TEST_FOR_EXCEPT((bIsEpetra == bIsTpetra) && bIsBlocked == false);
-      TEUCHOS_TEST_FOR_EXCEPT((bIsEpetra != bIsTpetra) && bIsBlocked == true);
 
-      RCP<XpMat> A = Teuchos::null;
-      if(bIsBlocked) {
-        Teuchos::RCP<const Thyra::BlockedLinearOpBase<Scalar> > ThyBlockedOp =
-            Teuchos::rcp_dynamic_cast<const Thyra::BlockedLinearOpBase<Scalar> >(fwdOp);
-        TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(ThyBlockedOp));
+      RCP<const XpCrsMat > xpetraFwdCrsMat = XpThyUtils::toXpetra(fwdOp);
+      TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(xpetraFwdCrsMat));
 
-        TEUCHOS_TEST_FOR_EXCEPT(ThyBlockedOp->blockExists(0,0)==false);
+      // MueLu needs a non-const object as input
+      RCP<XpCrsMat> xpetraFwdCrsMatNonConst = Teuchos::rcp_const_cast<XpCrsMat>(xpetraFwdCrsMat);
+      TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(xpetraFwdCrsMatNonConst));
 
-        Teuchos::RCP<const LinearOpBase<Scalar> > b00 = ThyBlockedOp->getBlock(0,0);
-        TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(b00));
-
-        RCP<const XpCrsMat > xpetraFwdCrsMat00 = XpThyUtils::toXpetra(b00);
-        TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(xpetraFwdCrsMat00));
-
-        // MueLu needs a non-const object as input
-        RCP<XpCrsMat> xpetraFwdCrsMatNonConst00 = Teuchos::rcp_const_cast<XpCrsMat>(xpetraFwdCrsMat00);
-        TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(xpetraFwdCrsMatNonConst00));
-
-        // wrap the forward operator as an Xpetra::Matrix that MueLu can work with
-        RCP<XpMat> A00 = rcp(new Xpetra::CrsMatrixWrap<Scalar,LocalOrdinal,GlobalOrdinal,Node>(xpetraFwdCrsMatNonConst00));
-        TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(A00));
-
-        RCP<const XpMap> rowmap00 = A00->getRowMap();
-        RCP< const Teuchos::Comm< int > > comm = rowmap00->getComm();
-
-        // create a Xpetra::BlockedCrsMatrix which derives from Xpetra::Matrix that MueLu can work with
-        RCP<XpBlockedCrsMat> bMat = Teuchos::rcp(new XpBlockedCrsMat(ThyBlockedOp, comm));
-        TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(bMat));
-
-        // save blocked matrix
-        A = bMat;
-      } else {
-        RCP<const XpCrsMat > xpetraFwdCrsMat = XpThyUtils::toXpetra(fwdOp);
-        TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(xpetraFwdCrsMat));
-
-        // MueLu needs a non-const object as input
-        RCP<XpCrsMat> xpetraFwdCrsMatNonConst = Teuchos::rcp_const_cast<XpCrsMat>(xpetraFwdCrsMat);
-        TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(xpetraFwdCrsMatNonConst));
-
-        // wrap the forward operator as an Xpetra::Matrix that MueLu can work with
-        A = rcp(new Xpetra::CrsMatrixWrap<Scalar,LocalOrdinal,GlobalOrdinal,Node>(xpetraFwdCrsMatNonConst));
-      }
+      // wrap the forward operator as an Xpetra::Matrix that MueLu can work with
+      RCP<XpMat> A = rcp(new Xpetra::CrsMatrixWrap<Scalar,LocalOrdinal,GlobalOrdinal,Node>(xpetraFwdCrsMatNonConst));
       TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(A));
 
       // Retrieve concrete preconditioner object
@@ -314,303 +279,86 @@ namespace Thyra {
       RCP<ThyLinOpBase> thyra_precOp = Teuchos::null;
       thyra_precOp = rcp_dynamic_cast<Thyra::LinearOpBase<Scalar> >(defaultPrec->getNonconstUnspecifiedPrecOp(), true);
 
-      // Variable for RefMaxwell preconditioner: either build a new one or reuse the existing preconditioner
-      RCP<MueLu::RefMaxwell<Scalar,LocalOrdinal,GlobalOrdinal,Node> > preconditioner = Teuchos::null;
-
       // make a decision whether to (re)build the multigrid preconditioner or reuse the old one
       // rebuild preconditioner if startingOver == true
       // reuse preconditioner if startingOver == false
       const bool startingOver = (thyra_precOp.is_null() || !paramList.isParameter("refmaxwell: enable reuse") || !paramList.get<bool>("refmaxwell: enable reuse"));
+      const bool useHalfPrecision = paramList.get<bool>("refmaxwell: half precision", false) && bIsTpetra;
 
+      RCP<XpOp> xpPrecOp;
       if (startingOver == true) {
-        // extract coordinates from parameter list
-        Teuchos::RCP<XpMultVecDouble> coordinates = Teuchos::null;
-        coordinates = MueLu::Utilities<Scalar,LocalOrdinal,GlobalOrdinal,Node>::ExtractCoordinatesFromParameterList(paramList);
-        paramList.set<RCP<XpMultVecDouble> >("Coordinates", coordinates);
 
-        // TODO check for Xpetra or Thyra vectors?
-#ifdef HAVE_MUELU_TPETRA
-        if (bIsTpetra) {
-#if ((defined(EPETRA_HAVE_OMP) && (defined(HAVE_TPETRA_INST_OPENMP) && defined(HAVE_TPETRA_INST_INT_INT))) || \
-    (!defined(EPETRA_HAVE_OMP) && (defined(HAVE_TPETRA_INST_SERIAL) && defined(HAVE_TPETRA_INST_INT_INT))))
-          typedef Tpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>      tV;
-          typedef Tpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> tMV;
-          typedef Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>      TpCrsMat;
-          if (paramList.isType<Teuchos::RCP<tMV> >("Nullspace")) {
-            RCP<tMV> tpetra_nullspace = paramList.get<RCP<tMV> >("Nullspace");
-            paramList.remove("Nullspace");
-            RCP<XpMultVec> nullspace = MueLu::TpetraMultiVector_To_XpetraMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>(tpetra_nullspace);
-            paramList.set<RCP<XpMultVec> >("Nullspace", nullspace);
-            TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(nullspace));
-          }
+        // Convert to Xpetra
+        std::list<std::string> convertXpetra = {"Coordinates", "Nullspace", "M1", "Ms", "D0", "M0inv"};
+        for (auto it = convertXpetra.begin(); it != convertXpetra.end(); ++it)
+          replaceWithXpetra<Scalar,LocalOrdinal,GlobalOrdinal,Node>(paramList,*it);
 
-          if (paramList.isParameter("M1")) {           
-            if (paramList.isType<Teuchos::RCP<TpCrsMat> >("M1")) {
-              RCP<TpCrsMat> tM1 = paramList.get<RCP<TpCrsMat> >("M1");
-              paramList.remove("M1");
-              RCP<XpCrsMat> xM1 = rcp_dynamic_cast<XpCrsMat>(tM1, true);
-              paramList.set<RCP<XpCrsMat> >("M1", xM1);
-            } else if (paramList.isType<Teuchos::RCP<const ThyLinOpBase> >("M1")) {
-              RCP<const ThyLinOpBase> thyM1 = paramList.get<RCP<const ThyLinOpBase> >("M1");
-              paramList.remove("M1");
-              RCP<const XpCrsMat> crsM1 = XpThyUtils::toXpetra(thyM1);
-              TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(crsM1));
-              // MueLu needs a non-const object as input
-              RCP<XpCrsMat> crsM1NonConst = Teuchos::rcp_const_cast<XpCrsMat>(crsM1);
-              TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(crsM1NonConst));
-              // wrap as an Xpetra::Matrix that MueLu can work with
-              RCP<XpMat> M1 = rcp(new Xpetra::CrsMatrixWrap<Scalar,LocalOrdinal,GlobalOrdinal,Node>(crsM1NonConst));
-              paramList.set<RCP<XpMat> >("M1", M1);
-            } else if (paramList.isType<Teuchos::RCP<XpMat> >("M1")) {
-              // do nothing
-            } else
-              TEUCHOS_TEST_FOR_EXCEPTION(true, MueLu::Exceptions::RuntimeError, "Parameter M1 has wrong type.");
-          } else
-            TEUCHOS_TEST_FOR_EXCEPTION(true, MueLu::Exceptions::RuntimeError, "Need to specify matrix M1.");
-
-          if (paramList.isParameter("Ms")) {
-            if (paramList.isType<Teuchos::RCP<TpCrsMat> >("Ms")) {
-              RCP<TpCrsMat> tMs = paramList.get<RCP<TpCrsMat> >("Ms");
-              paramList.remove("Ms");
-              RCP<XpCrsMat> xMs = rcp_dynamic_cast<XpCrsMat>(tMs, true);
-              paramList.set<RCP<XpCrsMat> >("Ms", xMs);
-            } else if (paramList.isType<Teuchos::RCP<const ThyLinOpBase> >("Ms")) {
-              RCP<const ThyLinOpBase> thyMs = paramList.get<RCP<const ThyLinOpBase> >("Ms");
-              paramList.remove("Ms");
-              RCP<const XpCrsMat> crsMs = XpThyUtils::toXpetra(thyMs);
-              TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(crsMs));
-              // MueLu needs a non-const object as input
-              RCP<XpCrsMat> crsMsNonConst = Teuchos::rcp_const_cast<XpCrsMat>(crsMs);
-              TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(crsMsNonConst));
-              // wrap as an Xpetra::Matrix that MueLu can work with
-              RCP<XpMat> Ms = rcp(new Xpetra::CrsMatrixWrap<Scalar,LocalOrdinal,GlobalOrdinal,Node>(crsMsNonConst));
-              paramList.set<RCP<XpMat> >("Ms", Ms);
-            } else if (paramList.isType<Teuchos::RCP<XpMat> >("Ms")) {
-              // do nothing
-            } else
-              TEUCHOS_TEST_FOR_EXCEPTION(true, MueLu::Exceptions::RuntimeError, "Parameter Ms has wrong type.");
-          }
-
-          if (paramList.isParameter("D0")) {
-            if(paramList.isType<Teuchos::RCP<TpCrsMat> >("D0")) {
-              RCP<TpCrsMat> tD0 = paramList.get<RCP<TpCrsMat> >("D0");
-              paramList.remove("D0");
-              RCP<XpCrsMat> xD0 = rcp_dynamic_cast<XpCrsMat>(tD0, true);
-              paramList.set<RCP<XpCrsMat> >("D0", xD0);
-            } else if (paramList.isType<Teuchos::RCP<const ThyLinOpBase> >("D0")) {
-              RCP<const ThyLinOpBase> thyD0 = paramList.get<RCP<const ThyLinOpBase> >("D0");
-              paramList.remove("D0");
-              RCP<const XpCrsMat> crsD0 = XpThyUtils::toXpetra(thyD0);
-              TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(crsD0));
-              // MueLu needs a non-const object as input
-              RCP<XpCrsMat> crsD0NonConst = Teuchos::rcp_const_cast<XpCrsMat>(crsD0);
-              TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(crsD0NonConst));
-              // wrap as an Xpetra::Matrix that MueLu can work with
-              RCP<XpMat> D0 = rcp(new Xpetra::CrsMatrixWrap<Scalar,LocalOrdinal,GlobalOrdinal,Node>(crsD0NonConst));
-              paramList.set<RCP<XpMat> >("D0", D0);
-            } else if (paramList.isType<Teuchos::RCP<XpMat> >("D0")) {
-              // do nothing
-            } else
-              TEUCHOS_TEST_FOR_EXCEPTION(true, MueLu::Exceptions::RuntimeError, "Parameter D0 has wrong type.");
-          } else
-            TEUCHOS_TEST_FOR_EXCEPTION(true, MueLu::Exceptions::RuntimeError, "Need to specify matrix D0.");
-
-          if (paramList.isParameter("M0inv")) {
-            if (paramList.isType<Teuchos::RCP<TpCrsMat> >("M0inv")) {
-              RCP<TpCrsMat> tM0inv = paramList.get<RCP<TpCrsMat> >("M0inv");
-              paramList.remove("M0inv");
-              RCP<XpCrsMat> xM0inv = rcp_dynamic_cast<XpCrsMat>(tM0inv, true);
-              paramList.set<RCP<XpCrsMat> >("M0inv", xM0inv);
-            } else if (paramList.isType<Teuchos::RCP<const ThyDiagLinOpBase> >("M0inv")) {
-              RCP<const ThyDiagLinOpBase> thyM0inv = paramList.get<RCP<const ThyDiagLinOpBase> >("M0inv");
-              paramList.remove("M0inv");
-              RCP<const Thyra::VectorBase<Scalar> > diag = thyM0inv->getDiag();
-              RCP<const Thyra::TpetraVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> > ttDiag = rcp_dynamic_cast<const Thyra::TpetraVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> >(diag);
-              RCP<const tV> tDiag = Thyra::TpetraOperatorVectorExtraction<Scalar,LocalOrdinal,GlobalOrdinal,Node>::getConstTpetraVector(diag);
-              RCP<XpMat> M0inv = Xpetra::MatrixFactory<Scalar,LocalOrdinal,GlobalOrdinal,Node>::Build(Xpetra::toXpetra(tDiag));
-              paramList.set<RCP<XpMat> >("M0inv", M0inv);
-            } else if (paramList.isType<Teuchos::RCP<const ThyLinOpBase> >("M0inv")) {
-              RCP<const ThyLinOpBase> thyM0inv = paramList.get<RCP<const ThyLinOpBase> >("M0inv");
-              paramList.remove("M0inv");
-              RCP<const XpCrsMat> crsM0inv = XpThyUtils::toXpetra(thyM0inv);
-              TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(crsM0inv));
-              // MueLu needs a non-const object as input
-              RCP<XpCrsMat> crsM0invNonConst = Teuchos::rcp_const_cast<XpCrsMat>(crsM0inv);
-              TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(crsM0invNonConst));
-              // wrap as an Xpetra::Matrix that MueLu can work with
-              RCP<XpMat> M0inv = rcp(new Xpetra::CrsMatrixWrap<Scalar,LocalOrdinal,GlobalOrdinal,Node>(crsM0invNonConst));
-              paramList.set<RCP<XpMat> >("M0inv", M0inv);
-            } else if (paramList.isType<Teuchos::RCP<XpMat> >("M0inv")) {
-              // do nothing
-            } else
-              TEUCHOS_TEST_FOR_EXCEPTION(true, MueLu::Exceptions::RuntimeError, "Parameter M0inv has wrong type.");
-          } else
-            TEUCHOS_TEST_FOR_EXCEPTION(true, MueLu::Exceptions::RuntimeError, "Need to specify matrix M0inv.");
-#else
-          TEUCHOS_TEST_FOR_EXCEPTION(true, MueLu::Exceptions::RuntimeError,
-                                     "Thyra::MueLuRefMaxwellPreconditionerFactory: Tpetra does not support GO=int and or EpetraNode.");
-#endif
-        }
-#endif
-#ifdef HAVE_MUELU_EPETRA
-        if (bIsEpetra) {
-          if (paramList.isType<RCP<Epetra_MultiVector> >("Nullspace")) {
-            RCP<Epetra_MultiVector> epetra_nullspace = Teuchos::null;
-            epetra_nullspace = paramList.get<RCP<Epetra_MultiVector> >("Nullspace");
-            paramList.remove("Nullspace");
-            RCP<Xpetra::EpetraMultiVectorT<int,Node> > xpEpNullspace = Teuchos::rcp(new Xpetra::EpetraMultiVectorT<int,Node>(epetra_nullspace));
-            RCP<Xpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::magnitudeType,int,int,Node> > xpEpNullspaceMult = rcp_dynamic_cast<Xpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::magnitudeType,int,int,Node> >(xpEpNullspace, true);
-            RCP<XpMultVec> nullspace = rcp_dynamic_cast<XpMultVec>(xpEpNullspaceMult, true);
-            paramList.set<RCP<XpMultVec> >("Nullspace", nullspace);
-          }
-
-          if (paramList.isParameter("M1")) {
-            if (paramList.isType<Teuchos::RCP<Epetra_CrsMatrix> >("M1")) {
-              RCP<Epetra_CrsMatrix> eM1 = paramList.get<RCP<Epetra_CrsMatrix> >("M1");
-              paramList.remove("M1");
-              RCP<XpEpCrsMat> xeM1 = Teuchos::rcp(new XpEpCrsMat(eM1));
-              RCP<XpCrsMat> xCrsM1 = rcp_dynamic_cast<XpCrsMat>(xeM1, true);
-              RCP<XpCrsMatWrap> xwM1 = Teuchos::rcp(new XpCrsMatWrap(xCrsM1));
-              RCP<XpMat> xM1 = rcp_dynamic_cast<XpMat>(xwM1);
-              paramList.set<RCP<XpMat> >("M1", xM1);
-            }
-            else if (paramList.isType<Teuchos::RCP<const ThyLinOpBase> >("M1")) {
-              RCP<const ThyLinOpBase> thyM1 = paramList.get<RCP<const ThyLinOpBase> >("M1");
-              paramList.remove("M1");
-              RCP<const XpCrsMat> crsM1 = XpThyUtils::toXpetra(thyM1);
-              TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(crsM1));
-              // MueLu needs a non-const object as input
-              RCP<XpCrsMat> crsM1NonConst = Teuchos::rcp_const_cast<XpCrsMat>(crsM1);
-              TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(crsM1NonConst));
-              // wrap as an Xpetra::Matrix that MueLu can work with
-              RCP<XpMat> M1 = rcp(new Xpetra::CrsMatrixWrap<Scalar,LocalOrdinal,GlobalOrdinal,Node>(crsM1NonConst));
-              paramList.set<RCP<XpMat> >("M1", M1);
-            } else if (paramList.isType<Teuchos::RCP<XpMat> >("M1")) {
-              // do nothing
-            } else
-              TEUCHOS_TEST_FOR_EXCEPTION(true, MueLu::Exceptions::RuntimeError, "Parameter M1 has wrong type.");
-          } else
-            TEUCHOS_TEST_FOR_EXCEPTION(true, MueLu::Exceptions::RuntimeError, "Need to specify matrix M1.");
-
-          if (paramList.isParameter("Ms")) {
-            if (paramList.isType<Teuchos::RCP<Epetra_CrsMatrix> >("Ms")) {
-              RCP<Epetra_CrsMatrix> eMs = paramList.get<RCP<Epetra_CrsMatrix> >("Ms");
-              paramList.remove("Ms");
-              RCP<XpEpCrsMat> xeMs = Teuchos::rcp(new XpEpCrsMat(eMs));
-              RCP<XpCrsMat> xCrsMs = rcp_dynamic_cast<XpCrsMat>(xeMs, true);
-              RCP<XpCrsMatWrap> xwMs = Teuchos::rcp(new XpCrsMatWrap(xCrsMs));
-              RCP<XpMat> xMs = rcp_dynamic_cast<XpMat>(xwMs);
-              paramList.set<RCP<XpMat> >("Ms", xMs);
-            }
-            else if (paramList.isType<Teuchos::RCP<const ThyLinOpBase> >("Ms")) {
-              RCP<const ThyLinOpBase> thyMs = paramList.get<RCP<const ThyLinOpBase> >("Ms");
-              paramList.remove("Ms");
-              RCP<const XpCrsMat> crsMs = XpThyUtils::toXpetra(thyMs);
-              TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(crsMs));
-              // MueLu needs a non-const object as input
-              RCP<XpCrsMat> crsMsNonConst = Teuchos::rcp_const_cast<XpCrsMat>(crsMs);
-              TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(crsMsNonConst));
-              // wrap as an Xpetra::Matrix that MueLu can work with
-              RCP<XpMat> Ms = rcp(new Xpetra::CrsMatrixWrap<Scalar,LocalOrdinal,GlobalOrdinal,Node>(crsMsNonConst));
-              paramList.set<RCP<XpMat> >("Ms", Ms);
-            } else if (paramList.isType<Teuchos::RCP<XpMat> >("Ms")) {
-              // do nothing
-            } else
-              TEUCHOS_TEST_FOR_EXCEPTION(true, MueLu::Exceptions::RuntimeError, "Parameter Ms has wrong type.");
-          }
-
-          if (paramList.isParameter("D0")) {
-            if (paramList.isType<Teuchos::RCP<Epetra_CrsMatrix> >("D0")) {
-              RCP<Epetra_CrsMatrix> eD0 = paramList.get<RCP<Epetra_CrsMatrix> >("D0");
-              paramList.remove("D0");
-              RCP<XpEpCrsMat> xeD0 = Teuchos::rcp(new XpEpCrsMat(eD0));
-              RCP<XpCrsMat> xCrsD0 = rcp_dynamic_cast<XpCrsMat>(xeD0, true);
-              RCP<XpCrsMatWrap> xwD0 = Teuchos::rcp(new XpCrsMatWrap(xCrsD0));
-              RCP<XpMat> xD0 = rcp_dynamic_cast<XpMat>(xwD0);
-              paramList.set<RCP<XpMat> >("D0", xD0);
-            }
-            else if (paramList.isType<Teuchos::RCP<const ThyLinOpBase> >("D0")) {
-              RCP<const ThyLinOpBase> thyD0 = paramList.get<RCP<const ThyLinOpBase> >("D0");
-              paramList.remove("D0");
-              RCP<const XpCrsMat> crsD0 = XpThyUtils::toXpetra(thyD0);
-              TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(crsD0));
-              // MueLu needs a non-const object as input
-              RCP<XpCrsMat> crsD0NonConst = Teuchos::rcp_const_cast<XpCrsMat>(crsD0);
-              TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(crsD0NonConst));
-              // wrap as an Xpetra::Matrix that MueLu can work with
-              RCP<XpMat> D0 = rcp(new Xpetra::CrsMatrixWrap<Scalar,LocalOrdinal,GlobalOrdinal,Node>(crsD0NonConst));
-              paramList.set<RCP<XpMat> >("D0", D0);
-            } else if (paramList.isType<Teuchos::RCP<XpMat> >("D0")) {
-              // do nothing
-            } else
-              TEUCHOS_TEST_FOR_EXCEPTION(true, MueLu::Exceptions::RuntimeError, "Parameter D0 has wrong type.");
-          } else
-            TEUCHOS_TEST_FOR_EXCEPTION(true, MueLu::Exceptions::RuntimeError, "Need to specify matrix D0.");
-
-          if (paramList.isParameter("M0inv")) {
-            if (paramList.isType<Teuchos::RCP<Epetra_CrsMatrix> >("M0inv")) {
-              RCP<Epetra_CrsMatrix> eM0inv = paramList.get<RCP<Epetra_CrsMatrix> >("M0inv");
-              paramList.remove("M0inv");
-              RCP<XpEpCrsMat> xeM0inv = Teuchos::rcp(new XpEpCrsMat(eM0inv));
-              RCP<XpCrsMat> xCrsM0inv = rcp_dynamic_cast<XpCrsMat>(xeM0inv, true);
-              RCP<XpCrsMatWrap> xwM0inv = Teuchos::rcp(new XpCrsMatWrap(xCrsM0inv));
-              RCP<XpMat> xM0inv = rcp_dynamic_cast<XpMat>(xwM0inv);
-              paramList.set<RCP<XpMat> >("M0inv", xM0inv);
-            }
-            else if (paramList.isType<Teuchos::RCP<const ThyDiagLinOpBase> >("M0inv")) {
-              RCP<const ThyDiagLinOpBase> thyM0inv = paramList.get<RCP<const ThyDiagLinOpBase> >("M0inv");
-              paramList.remove("M0inv");
-
-              RCP<const Teuchos::Comm<int> > comm = A->getDomainMap()->getComm();
-              RCP<const Epetra_Map> map = Thyra::get_Epetra_Map(*(thyM0inv->range()), Xpetra::toEpetra(comm));
-              // RCP<XpMap> map = XpThyUtils::toXpetra(thyM0inv->range(), comm);
-              RCP<const Thyra::VectorBase<double> > diag = thyM0inv->getDiag();
-              RCP<const Epetra_Vector> eDiag = Thyra::get_Epetra_Vector(*map, diag);
-              RCP<Epetra_Vector> nceDiag = Teuchos::rcp_const_cast<Epetra_Vector>(eDiag);
-              RCP<Xpetra::EpetraVectorT<int,Node> > xpEpDiag = Teuchos::rcp(new Xpetra::EpetraVectorT<int,Node>(nceDiag));
-              RCP<const Xpetra::Vector<typename Teuchos::ScalarTraits<Scalar>::magnitudeType,int,int,Node> > xpDiag = rcp_dynamic_cast<const Xpetra::Vector<typename Teuchos::ScalarTraits<Scalar>::magnitudeType,int,int,Node> >(xpEpDiag, true);
-              RCP<XpMat> M0inv = Xpetra::MatrixFactory<double,int,int,Node>::Build(xpDiag);
-              paramList.set<RCP<XpMat> >("M0inv", M0inv);
-            } else if (paramList.isType<Teuchos::RCP<const ThyLinOpBase> >("M0inv")) {
-              RCP<const ThyLinOpBase> thyM0inv = paramList.get<RCP<const ThyLinOpBase> >("M0inv");
-              paramList.remove("M0inv");
-              RCP<const XpCrsMat> crsM0inv = XpThyUtils::toXpetra(thyM0inv);
-              TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(crsM0inv));
-              // MueLu needs a non-const object as input
-              RCP<XpCrsMat> crsM0invNonConst = Teuchos::rcp_const_cast<XpCrsMat>(crsM0inv);
-              TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(crsM0invNonConst));
-              // wrap as an Xpetra::Matrix that MueLu can work with
-              RCP<XpMat> M0inv = rcp(new Xpetra::CrsMatrixWrap<Scalar,LocalOrdinal,GlobalOrdinal,Node>(crsM0invNonConst));
-              paramList.set<RCP<XpMat> >("M0inv", M0inv);
-            } else if (paramList.isType<Teuchos::RCP<XpMat> >("M0inv")) {
-              // do nothing
-            } else
-              TEUCHOS_TEST_FOR_EXCEPTION(true, MueLu::Exceptions::RuntimeError, "Parameter M0inv has wrong type.");
-          } else
-            TEUCHOS_TEST_FOR_EXCEPTION(true, MueLu::Exceptions::RuntimeError, "Need to specify matrix M0inv.");
-        }
-#endif
-        // build a new MueLu RefMaxwell preconditioner
         paramList.set<bool>("refmaxwell: use as preconditioner", true);
-        preconditioner = rcp(new MueLu::RefMaxwell<Scalar,LocalOrdinal,GlobalOrdinal,Node>(A, paramList, true));
+        if (useHalfPrecision) {
+#if defined(HAVE_MUELU_TPETRA) && defined(HAVE_TPETRA_INST_DOUBLE) && defined(HAVE_TPETRA_INST_FLOAT)
 
+          // convert to half precision
+          RCP<XphMat> halfA = Xpetra::convertToHalfPrecision(A);
+          if (paramList.isType<RCP<XpmMV> >("Coordinates")) {
+            RCP<XpmMV> coords = paramList.get<RCP<XpmMV> >("Coordinates");
+            paramList.remove("Coordinates");
+            RCP<XphmMV> halfCoords = Xpetra::convertToHalfPrecision(coords);
+            paramList.set("Coordinates",halfCoords);
+          }
+          if (paramList.isType<RCP<XpMV> >("Nullspace")) {
+            RCP<XpMV> nullspace = paramList.get<RCP<XpMV> >("Nullspace");
+            paramList.remove("Nullspace");
+            RCP<XphMV> halfNullspace = Xpetra::convertToHalfPrecision(nullspace);
+            paramList.set("Nullspace",halfNullspace);
+          }
+          std::list<std::string> convertMat = {"M1", "Ms", "D0", "M0inv"};
+          for (auto it = convertMat.begin(); it != convertMat.end(); ++it) {
+            if (paramList.isType<RCP<XpMat> >(*it)) {
+              RCP<XpMat> M = paramList.get<RCP<XpMat> >(*it);
+              paramList.remove(*it);
+              RCP<XphMat> halfM = Xpetra::convertToHalfPrecision(M);
+              paramList.set(*it,halfM);
+            }
+          }
+
+          // build a new half-precision MueLu RefMaxwell preconditioner
+          RCP<MueLu::RefMaxwell<HalfScalar,LocalOrdinal,GlobalOrdinal,Node> > halfPrec = rcp(new MueLu::RefMaxwell<HalfScalar,LocalOrdinal,GlobalOrdinal,Node>(halfA, paramList, true));
+          xpPrecOp = rcp(new XpHalfPrecOp(halfPrec));
+#else
+          TEUCHOS_TEST_FOR_EXCEPT(true);
+#endif
+        } else
+        {
+          // build a new MueLu RefMaxwell preconditioner
+          RCP<MueLu::RefMaxwell<Scalar,LocalOrdinal,GlobalOrdinal,Node> > preconditioner = rcp(new MueLu::RefMaxwell<Scalar,LocalOrdinal,GlobalOrdinal,Node>(A, paramList, true));
+          xpPrecOp = rcp_dynamic_cast<XpOp>(preconditioner);
+        }
       } else {
         // reuse old MueLu preconditioner stored in MueLu Xpetra operator and put in new matrix
 
         RCP<ThyXpOp> thyXpOp = rcp_dynamic_cast<ThyXpOp>(thyra_precOp, true);
         RCP<XpOp>    xpOp    = thyXpOp->getXpetraOperator();
-        preconditioner = rcp_dynamic_cast<MueLu::RefMaxwell<Scalar,LocalOrdinal,GlobalOrdinal,Node>>(xpOp, true);
-        preconditioner->resetMatrix(A);
+#if defined(HAVE_MUELU_TPETRA) && defined(HAVE_TPETRA_INST_DOUBLE) && defined(HAVE_TPETRA_INST_FLOAT)
+        RCP<XpHalfPrecOp> xpHalfPrecOp = rcp_dynamic_cast<XpHalfPrecOp>(xpOp);
+        if (!xpHalfPrecOp.is_null()) {
+          RCP<MueLu::RefMaxwell<HalfScalar,LocalOrdinal,GlobalOrdinal,Node> > preconditioner = rcp_dynamic_cast<MueLu::RefMaxwell<HalfScalar,LocalOrdinal,GlobalOrdinal,Node>>(xpHalfPrecOp->GetHalfPrecisionOperator(), true);
+          RCP<XphMat> halfA = Xpetra::convertToHalfPrecision(A);
+          preconditioner->resetMatrix(halfA);
+          xpPrecOp = rcp_dynamic_cast<XpOp>(preconditioner);
+        } else
+#endif
+        {
+          RCP<MueLu::RefMaxwell<Scalar,LocalOrdinal,GlobalOrdinal,Node> > preconditioner = rcp_dynamic_cast<MueLu::RefMaxwell<Scalar,LocalOrdinal,GlobalOrdinal,Node>>(xpOp, true);
+          preconditioner->resetMatrix(A);
+          xpPrecOp = rcp_dynamic_cast<XpOp>(preconditioner);
+        }
       }
 
       // wrap preconditioner in thyraPrecOp
-      RCP<ThyLinOpBase > thyraPrecOp = Teuchos::null;
-      RCP<const VectorSpaceBase<Scalar> > thyraRangeSpace  = Xpetra::ThyraUtils<Scalar,LocalOrdinal,GlobalOrdinal,Node>::toThyra(preconditioner->getRangeMap());
-      RCP<const VectorSpaceBase<Scalar> > thyraDomainSpace = Xpetra::ThyraUtils<Scalar,LocalOrdinal,GlobalOrdinal,Node>::toThyra(preconditioner->getDomainMap());
+      RCP<const VectorSpaceBase<Scalar> > thyraRangeSpace  = Xpetra::ThyraUtils<Scalar,LocalOrdinal,GlobalOrdinal,Node>::toThyra(xpPrecOp->getRangeMap());
+      RCP<const VectorSpaceBase<Scalar> > thyraDomainSpace = Xpetra::ThyraUtils<Scalar,LocalOrdinal,GlobalOrdinal,Node>::toThyra(xpPrecOp->getDomainMap());
 
-      RCP<XpOp> xpOp = Teuchos::rcp_dynamic_cast<XpOp>(preconditioner);
-      thyraPrecOp = Thyra::xpetraLinearOp<Scalar, LocalOrdinal, GlobalOrdinal, Node>(thyraRangeSpace, thyraDomainSpace,xpOp);
-
+      RCP<ThyLinOpBase > thyraPrecOp = Thyra::xpetraLinearOp<Scalar, LocalOrdinal, GlobalOrdinal, Node>(thyraRangeSpace, thyraDomainSpace, xpPrecOp);
       TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(thyraPrecOp));
 
       defaultPrec->initializeUnspecified(thyraPrecOp);

--- a/packages/muelu/adapters/stratimikos/Thyra_MueLuRefMaxwellPreconditionerFactory_def.hpp
+++ b/packages/muelu/adapters/stratimikos/Thyra_MueLuRefMaxwellPreconditionerFactory_def.hpp
@@ -47,6 +47,7 @@
 #define THYRA_MUELU_REFMAXWELL_PRECONDITIONER_FACTORY_DEF_HPP
 
 #include "Thyra_MueLuRefMaxwellPreconditionerFactory_decl.hpp"
+#include <list>
 
 #if defined(HAVE_MUELU_STRATIMIKOS) && defined(HAVE_MUELU_THYRA)
 
@@ -55,6 +56,174 @@ namespace Thyra {
   using Teuchos::RCP;
   using Teuchos::rcp;
   using Teuchos::ParameterList;
+  using Teuchos::rcp_dynamic_cast;
+  using Teuchos::rcp_const_cast;
+
+  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+  bool replaceWithXpetra(ParameterList& paramList, std::string parameterName) {
+    typedef typename Teuchos::ScalarTraits<Scalar>::magnitudeType            Magnitude;
+    typedef Xpetra::Operator<Scalar, LocalOrdinal, GlobalOrdinal, Node>      XpOp;
+    typedef Xpetra::ThyraUtils<Scalar,LocalOrdinal,GlobalOrdinal,Node>       XpThyUtils;
+    typedef Xpetra::CrsMatrixWrap<Scalar,LocalOrdinal,GlobalOrdinal,Node>    XpCrsMatWrap;
+    typedef Xpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>        XpCrsMat;
+    typedef Xpetra::Matrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>           XpMat;
+    typedef Xpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>      XpMultVec;
+    typedef Xpetra::MultiVector<Magnitude,LocalOrdinal,GlobalOrdinal,Node>   XpMagMultVec;
+    typedef Xpetra::Vector<Scalar,LocalOrdinal,GlobalOrdinal,Node>           XpVec;
+
+    typedef Thyra::LinearOpBase<Scalar>                                      ThyLinOpBase;
+    typedef Thyra::DiagonalLinearOpBase<Scalar>                              ThyDiagLinOpBase;
+    typedef Thyra::XpetraLinearOp<Scalar, LocalOrdinal, GlobalOrdinal, Node> ThyXpOp;
+    typedef Thyra::SpmdVectorSpaceBase<Scalar>                               ThyVSBase;
+
+#ifdef HAVE_MUELU_TPETRA
+    typedef Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>         TpCrsMat;
+    typedef Tpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>         tV;
+    typedef Thyra::TpetraVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>       thyTpV;
+    typedef Tpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>    tMV;
+    typedef Tpetra::MultiVector<Magnitude, LocalOrdinal, GlobalOrdinal, Node> tMagMV;
+# if defined(HAVE_TPETRA_INST_DOUBLE) && defined(HAVE_TPETRA_INST_FLOAT)
+    typedef typename Teuchos::ScalarTraits<Magnitude>::halfPrecision          HalfMagnitude;
+    typedef Tpetra::MultiVector<HalfMagnitude, LocalOrdinal, GlobalOrdinal, Node> tHalfMagMV;
+# endif
+#endif
+#if defined(HAVE_MUELU_EPETRA)
+    typedef Xpetra::EpetraCrsMatrixT<GlobalOrdinal,Node>                  XpEpCrsMat;
+#endif
+
+    if (paramList.isParameter(parameterName)) {
+      if (paramList.isType<RCP<XpMat> >(parameterName))
+        return true;
+      else if (paramList.isType<RCP<const XpMat> >(parameterName)) {
+        RCP<const XpMat> constM = paramList.get<RCP<const XpMat> >(parameterName);
+        paramList.remove(parameterName);
+        RCP<XpMat> M = rcp_const_cast<XpMat>(constM);
+        paramList.set<RCP<XpMat> >(parameterName, M);
+        return true;
+      }
+      else if (paramList.isType<RCP<XpMultVec> >(parameterName))
+        return true;
+      else if (paramList.isType<RCP<const XpMultVec> >(parameterName)) {
+        RCP<const XpMultVec> constX = paramList.get<RCP<const XpMultVec> >(parameterName);
+        paramList.remove(parameterName);
+        RCP<XpMultVec> X = rcp_const_cast<XpMultVec>(constX);
+        paramList.set<RCP<XpMultVec> >(parameterName, X);
+        return true;
+      }
+      else if (paramList.isType<RCP<XpMagMultVec> >(parameterName))
+        return true;
+      else if (paramList.isType<RCP<const XpMagMultVec> >(parameterName)) {
+        RCP<const XpMagMultVec> constX = paramList.get<RCP<const XpMagMultVec> >(parameterName);
+        paramList.remove(parameterName);
+        RCP<XpMagMultVec> X = rcp_const_cast<XpMagMultVec>(constX);
+        paramList.set<RCP<XpMagMultVec> >(parameterName, X);
+        return true;
+      }
+#ifdef HAVE_MUELU_TPETRA
+      else if (paramList.isType<RCP<TpCrsMat> >(parameterName)) {
+        RCP<TpCrsMat> tM = paramList.get<RCP<TpCrsMat> >(parameterName);
+        paramList.remove(parameterName);
+        RCP<XpCrsMat> xM = rcp_dynamic_cast<XpCrsMat>(tM, true);
+        paramList.set<RCP<XpCrsMat> >(parameterName, xM);
+        return true;
+      } else if (paramList.isType<RCP<tMV> >(parameterName)) {
+        RCP<tMV> tpetra_X = paramList.get<RCP<tMV> >(parameterName);
+        paramList.remove(parameterName);
+        RCP<XpMultVec> X = MueLu::TpetraMultiVector_To_XpetraMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>(tpetra_X);
+        paramList.set<RCP<XpMultVec> >(parameterName, X);
+        TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(X));
+        return true;
+      } else if (paramList.isType<RCP<tMagMV> >(parameterName)) {
+        RCP<tMagMV> tpetra_X = paramList.get<RCP<tMagMV> >(parameterName);
+        paramList.remove(parameterName);
+        RCP<XpMagMultVec> X = MueLu::TpetraMultiVector_To_XpetraMultiVector<Magnitude,LocalOrdinal,GlobalOrdinal,Node>(tpetra_X);
+        paramList.set<RCP<XpMagMultVec> >(parameterName, X);
+        TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(X));
+        return true;
+      }
+# if defined(HAVE_TPETRA_INST_DOUBLE) && defined(HAVE_TPETRA_INST_FLOAT)
+      else if (paramList.isType<RCP<tHalfMagMV> >(parameterName)) {
+        RCP<tHalfMagMV> tpetra_hX = paramList.get<RCP<tHalfMagMV> >(parameterName);
+        paramList.remove(parameterName);
+        RCP<tMagMV> tpetra_X = rcp(new tMagMV(tpetra_hX->getMap(),tpetra_hX->getNumVectors()));
+        Tpetra::deep_copy(*tpetra_X,*tpetra_hX);
+        RCP<XpMagMultVec> X = MueLu::TpetraMultiVector_To_XpetraMultiVector<Magnitude,LocalOrdinal,GlobalOrdinal,Node>(tpetra_X);
+        paramList.set<RCP<XpMagMultVec> >(parameterName, X);
+        TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(X));
+        return true;
+      }
+# endif
+#endif
+#ifdef HAVE_MUELU_EPETRA
+      else if (paramList.isType<RCP<Epetra_CrsMatrix> >(parameterName)) {
+        RCP<Epetra_CrsMatrix> eM = paramList.get<RCP<Epetra_CrsMatrix> >(parameterName);
+        paramList.remove(parameterName);
+        RCP<XpEpCrsMat> xeM = rcp(new XpEpCrsMat(eM));
+        RCP<XpCrsMat> xCrsM = rcp_dynamic_cast<XpCrsMat>(xeM, true);
+        RCP<XpCrsMatWrap> xwM = rcp(new XpCrsMatWrap(xCrsM));
+        RCP<XpMat> xM = rcp_dynamic_cast<XpMat>(xwM);
+        paramList.set<RCP<XpMat> >(parameterName, xM);
+        return true;
+      } else if (paramList.isType<RCP<Epetra_MultiVector> >(parameterName)) {
+        RCP<Epetra_MultiVector> epetra_X = Teuchos::null;
+        epetra_X = paramList.get<RCP<Epetra_MultiVector> >(parameterName);
+        paramList.remove(parameterName);
+        RCP<Xpetra::EpetraMultiVectorT<int,Node> > xpEpX = rcp(new Xpetra::EpetraMultiVectorT<int,Node>(epetra_X));
+        RCP<Xpetra::MultiVector<Scalar,int,int,Node> > xpEpXMult = rcp_dynamic_cast<Xpetra::MultiVector<Scalar,int,int,Node> >(xpEpX, true);
+        RCP<XpMultVec> X = rcp_dynamic_cast<XpMultVec>(xpEpXMult, true);
+        paramList.set<RCP<XpMultVec> >(parameterName, X);
+        return true;
+      }
+#endif
+      else if (paramList.isType<RCP<const ThyLinOpBase> >(parameterName)) {
+        RCP<const ThyLinOpBase> thyM = paramList.get<RCP<const ThyLinOpBase> >(parameterName);
+        paramList.remove(parameterName);
+        RCP<const XpCrsMat> crsM = XpThyUtils::toXpetra(thyM);
+        TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(crsM));
+        // MueLu needs a non-const object as input
+        RCP<XpCrsMat> crsMNonConst = rcp_const_cast<XpCrsMat>(crsM);
+        TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(crsMNonConst));
+        // wrap as an Xpetra::Matrix that MueLu can work with
+        RCP<XpMat> M = rcp(new Xpetra::CrsMatrixWrap<Scalar,LocalOrdinal,GlobalOrdinal,Node>(crsMNonConst));
+        paramList.set<RCP<XpMat> >(parameterName, M);
+        return true;
+      } else if (paramList.isType<RCP<const ThyDiagLinOpBase> >(parameterName)) {
+        RCP<const ThyDiagLinOpBase> thyM = paramList.get<RCP<const ThyDiagLinOpBase> >(parameterName);
+        paramList.remove(parameterName);
+        RCP<const Thyra::VectorBase<Scalar> > diag = thyM->getDiag();
+
+        RCP<const XpVec> xpDiag;
+#ifdef HAVE_MUELU_TPETRA
+        if (!rcp_dynamic_cast<const thyTpV>(diag).is_null()) {
+          RCP<const tV> tDiag = Thyra::TpetraOperatorVectorExtraction<Scalar,LocalOrdinal,GlobalOrdinal,Node>::getConstTpetraVector(diag);
+          if (!tDiag.is_null())
+            xpDiag = Xpetra::toXpetra(tDiag);
+        }
+#endif
+#ifdef HAVE_MUELU_EPETRA
+        if (xpDiag.is_null()) {
+          RCP<const Epetra_Comm> comm = Thyra::get_Epetra_Comm(*rcp_dynamic_cast<const ThyVSBase>(thyM->range())->getComm());
+          RCP<const Epetra_Map> map = Thyra::get_Epetra_Map(*(thyM->range()), comm);
+          if (!map.is_null()) {
+            RCP<const Epetra_Vector> eDiag = Thyra::get_Epetra_Vector(*map, diag);
+            RCP<Epetra_Vector> nceDiag = rcp_const_cast<Epetra_Vector>(eDiag);
+            RCP<Xpetra::EpetraVectorT<int,Node> > xpEpDiag = rcp(new Xpetra::EpetraVectorT<int,Node>(nceDiag));
+            xpDiag = rcp_dynamic_cast<XpVec>(xpEpDiag, true);
+          }
+        }
+#endif
+        TEUCHOS_ASSERT(!xpDiag.is_null());
+        RCP<XpMat> M = Xpetra::MatrixFactory<Scalar,LocalOrdinal,GlobalOrdinal,Node>::Build(xpDiag);
+        paramList.set<RCP<XpMat> >(parameterName, M);
+        return true;
+      }
+      else {
+        TEUCHOS_TEST_FOR_EXCEPTION(true, MueLu::Exceptions::RuntimeError, "Parameter M1 has wrong type.");
+        return false;
+      }
+    } else
+      return false;
+  }
 
 
   // Constructors/initializers/accessors
@@ -74,8 +243,6 @@ namespace Thyra {
     if (Xpetra::ThyraUtils<Scalar,LocalOrdinal,GlobalOrdinal,Node>::isTpetra(fwdOp)) return true;
 #endif
 
-    if (Xpetra::ThyraUtils<Scalar,LocalOrdinal,GlobalOrdinal,Node>::isBlockedOperator(fwdOp)) return true;
-
     return false;
   }
 
@@ -88,20 +255,26 @@ namespace Thyra {
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void MueLuRefMaxwellPreconditionerFactory<Scalar,LocalOrdinal,GlobalOrdinal,Node>::
   initializePrec(const RCP<const LinearOpSourceBase<Scalar> >& fwdOpSrc, PreconditionerBase<Scalar>* prec, const ESupportSolveUse supportSolveUse) const {
-    using Teuchos::rcp_dynamic_cast;
 
     // we are using typedefs here, since we are using objects from different packages (Xpetra, Thyra,...)
-    typedef Xpetra::Map<LocalOrdinal,GlobalOrdinal,Node>                     XpMap;
     typedef Xpetra::Operator<Scalar, LocalOrdinal, GlobalOrdinal, Node>      XpOp;
     typedef Xpetra::ThyraUtils<Scalar,LocalOrdinal,GlobalOrdinal,Node>       XpThyUtils;
     typedef Xpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>        XpCrsMat;
-    typedef Xpetra::BlockedCrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> XpBlockedCrsMat;
     typedef Xpetra::Matrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>           XpMat;
-    typedef Xpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>      XpMultVec;
-    typedef Xpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::magnitudeType,LocalOrdinal,GlobalOrdinal,Node>      XpMultVecDouble;
     typedef Thyra::LinearOpBase<Scalar>                                      ThyLinOpBase;
-    typedef Thyra::DiagonalLinearOpBase<Scalar>                              ThyDiagLinOpBase;
     typedef Thyra::XpetraLinearOp<Scalar, LocalOrdinal, GlobalOrdinal, Node> ThyXpOp;
+#if defined(HAVE_MUELU_TPETRA) && defined(HAVE_TPETRA_INST_DOUBLE) && defined(HAVE_TPETRA_INST_FLOAT)
+    typedef Xpetra::TpetraHalfPrecisionOperator<Scalar,LocalOrdinal,GlobalOrdinal,Node> XpHalfPrecOp;
+    typedef Xpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>           XpMV;
+    typedef typename XpHalfPrecOp::HalfScalar                                     HalfScalar;
+    typedef Xpetra::Operator<HalfScalar,LocalOrdinal,GlobalOrdinal,Node>          XpHalfOp;
+    typedef typename Teuchos::ScalarTraits<Scalar>::magnitudeType                 Magnitude;
+    typedef typename Teuchos::ScalarTraits<Magnitude>::halfPrecision              HalfMagnitude;
+    typedef Xpetra::MultiVector<HalfScalar,LocalOrdinal,GlobalOrdinal,Node>       XphMV;
+    typedef Xpetra::MultiVector<Magnitude,LocalOrdinal,GlobalOrdinal,Node >       XpmMV;
+    typedef Xpetra::MultiVector<HalfMagnitude,LocalOrdinal,GlobalOrdinal,Node >   XphmMV;
+    typedef Xpetra::Matrix<HalfScalar,LocalOrdinal,GlobalOrdinal,Node>            XphMat;
+#endif
     Teuchos::TimeMonitor tM(*Teuchos::TimeMonitor::getNewTimer(std::string("ThyraMueLuRefMaxwell::initializePrec")));
 
     // Check precondition
@@ -119,53 +292,17 @@ namespace Thyra {
     // Check whether it is Epetra/Tpetra
     bool bIsEpetra  = XpThyUtils::isEpetra(fwdOp);
     bool bIsTpetra  = XpThyUtils::isTpetra(fwdOp);
-    bool bIsBlocked = XpThyUtils::isBlockedOperator(fwdOp);
     TEUCHOS_TEST_FOR_EXCEPT((bIsEpetra == true  && bIsTpetra == true));
-    TEUCHOS_TEST_FOR_EXCEPT((bIsEpetra == bIsTpetra) && bIsBlocked == false);
-    TEUCHOS_TEST_FOR_EXCEPT((bIsEpetra != bIsTpetra) && bIsBlocked == true);
 
-    RCP<XpMat> A = Teuchos::null;
-    if(bIsBlocked) {
-      Teuchos::RCP<const Thyra::BlockedLinearOpBase<Scalar> > ThyBlockedOp =
-          Teuchos::rcp_dynamic_cast<const Thyra::BlockedLinearOpBase<Scalar> >(fwdOp);
-      TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(ThyBlockedOp));
+    RCP<const XpCrsMat > xpetraFwdCrsMat = XpThyUtils::toXpetra(fwdOp);
+    TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(xpetraFwdCrsMat));
 
-      TEUCHOS_TEST_FOR_EXCEPT(ThyBlockedOp->blockExists(0,0)==false);
+    // MueLu needs a non-const object as input
+    RCP<XpCrsMat> xpetraFwdCrsMatNonConst = Teuchos::rcp_const_cast<XpCrsMat>(xpetraFwdCrsMat);
+    TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(xpetraFwdCrsMatNonConst));
 
-      Teuchos::RCP<const LinearOpBase<Scalar> > b00 = ThyBlockedOp->getBlock(0,0);
-      TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(b00));
-
-      RCP<const XpCrsMat > xpetraFwdCrsMat00 = XpThyUtils::toXpetra(b00);
-      TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(xpetraFwdCrsMat00));
-
-      // MueLu needs a non-const object as input
-      RCP<XpCrsMat> xpetraFwdCrsMatNonConst00 = Teuchos::rcp_const_cast<XpCrsMat>(xpetraFwdCrsMat00);
-      TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(xpetraFwdCrsMatNonConst00));
-
-      // wrap the forward operator as an Xpetra::Matrix that MueLu can work with
-      RCP<XpMat> A00 = rcp(new Xpetra::CrsMatrixWrap<Scalar,LocalOrdinal,GlobalOrdinal,Node>(xpetraFwdCrsMatNonConst00));
-      TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(A00));
-
-      RCP<const XpMap> rowmap00 = A00->getRowMap();
-      RCP< const Teuchos::Comm< int > > comm = rowmap00->getComm();
-
-      // create a Xpetra::BlockedCrsMatrix which derives from Xpetra::Matrix that MueLu can work with
-      RCP<XpBlockedCrsMat> bMat = Teuchos::rcp(new XpBlockedCrsMat(ThyBlockedOp, comm));
-      TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(bMat));
-
-      // save blocked matrix
-      A = bMat;
-    } else {
-      RCP<const XpCrsMat > xpetraFwdCrsMat = XpThyUtils::toXpetra(fwdOp);
-      TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(xpetraFwdCrsMat));
-
-      // MueLu needs a non-const object as input
-      RCP<XpCrsMat> xpetraFwdCrsMatNonConst = Teuchos::rcp_const_cast<XpCrsMat>(xpetraFwdCrsMat);
-      TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(xpetraFwdCrsMatNonConst));
-
-      // wrap the forward operator as an Xpetra::Matrix that MueLu can work with
-      A = rcp(new Xpetra::CrsMatrixWrap<Scalar,LocalOrdinal,GlobalOrdinal,Node>(xpetraFwdCrsMatNonConst));
-    }
+    // wrap the forward operator as an Xpetra::Matrix that MueLu can work with
+    RCP<XpMat> A = rcp(new Xpetra::CrsMatrixWrap<Scalar,LocalOrdinal,GlobalOrdinal,Node>(xpetraFwdCrsMatNonConst));
     TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(A));
 
     // Retrieve concrete preconditioner object
@@ -176,177 +313,86 @@ namespace Thyra {
     RCP<ThyLinOpBase> thyra_precOp = Teuchos::null;
     thyra_precOp = rcp_dynamic_cast<Thyra::LinearOpBase<Scalar> >(defaultPrec->getNonconstUnspecifiedPrecOp(), true);
 
-    // Variable for RefMaxwell preconditioner: either build a new one or reuse the existing preconditioner
-    RCP<MueLu::RefMaxwell<Scalar,LocalOrdinal,GlobalOrdinal,Node> > preconditioner = Teuchos::null;
-
     // make a decision whether to (re)build the multigrid preconditioner or reuse the old one
     // rebuild preconditioner if startingOver == true
     // reuse preconditioner if startingOver == false
     const bool startingOver = (thyra_precOp.is_null() || !paramList.isParameter("refmaxwell: enable reuse") || !paramList.get<bool>("refmaxwell: enable reuse"));
+    const bool useHalfPrecision = paramList.get<bool>("refmaxwell: half precision", false) && bIsTpetra;
 
+    RCP<XpOp> xpPrecOp;
     if (startingOver == true) {
-      // extract coordinates from parameter list
-      Teuchos::RCP<XpMultVecDouble> coordinates = Teuchos::null;
-      {
-        Teuchos::TimeMonitor tM_coords(*Teuchos::TimeMonitor::getNewTimer(std::string("ThyraMueLuRefMaxwell::initializePrec get coords")));
-        coordinates = MueLu::Utilities<Scalar,LocalOrdinal,GlobalOrdinal,Node>::ExtractCoordinatesFromParameterList(paramList);
-        paramList.set<RCP<XpMultVecDouble> >("Coordinates", coordinates);
-      }
 
-      // TODO check for Xpetra or Thyra vectors?
-#ifdef HAVE_MUELU_TPETRA
-      if (bIsTpetra) {
-        typedef Tpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>      tV;
-        typedef Tpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> tMV;
-        typedef Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>      TpCrsMat;
-        Teuchos::TimeMonitor tMwrap(*Teuchos::TimeMonitor::getNewTimer(std::string("ThyraMueLuRefMaxwell::initializePrec wrap objects")));
-        if (paramList.isType<Teuchos::RCP<tMV> >("Nullspace")) {
-          Teuchos::TimeMonitor tM_nullspace(*Teuchos::TimeMonitor::getNewTimer(std::string("ThyraMueLuRefMaxwell::initializePrec wrap nullspace")));
-          RCP<tMV> tpetra_nullspace = paramList.get<RCP<tMV> >("Nullspace");
+      // Convert to Xpetra
+      std::list<std::string> convertXpetra = {"Coordinates", "Nullspace", "M1", "Ms", "D0", "M0inv"};
+      for (auto it = convertXpetra.begin(); it != convertXpetra.end(); ++it)
+        replaceWithXpetra<Scalar,LocalOrdinal,GlobalOrdinal,Node>(paramList,*it);
+
+      paramList.set<bool>("refmaxwell: use as preconditioner", true);
+      if (useHalfPrecision) {
+#if defined(HAVE_MUELU_TPETRA) && defined(HAVE_TPETRA_INST_DOUBLE) && defined(HAVE_TPETRA_INST_FLOAT)
+
+        // convert to half precision
+        RCP<XphMat> halfA = Xpetra::convertToHalfPrecision(A);
+        if (paramList.isType<RCP<XpmMV> >("Coordinates")) {
+          RCP<XpmMV> coords = paramList.get<RCP<XpmMV> >("Coordinates");
+          paramList.remove("Coordinates");
+          RCP<XphmMV> halfCoords = Xpetra::convertToHalfPrecision(coords);
+          paramList.set("Coordinates",halfCoords);
+        }
+        if (paramList.isType<RCP<XpMV> >("Nullspace")) {
+          RCP<XpMV> nullspace = paramList.get<RCP<XpMV> >("Nullspace");
           paramList.remove("Nullspace");
-          RCP<XpMultVec> nullspace = MueLu::TpetraMultiVector_To_XpetraMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>(tpetra_nullspace);
-          paramList.set<RCP<XpMultVec> >("Nullspace", nullspace);
-          TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(nullspace));
+          RCP<XphMV> halfNullspace = Xpetra::convertToHalfPrecision(nullspace);
+          paramList.set("Nullspace",halfNullspace);
+        }
+        std::list<std::string> convertMat = {"M1", "Ms", "D0", "M0inv"};
+        for (auto it = convertMat.begin(); it != convertMat.end(); ++it) {
+          if (paramList.isType<RCP<XpMat> >(*it)) {
+            RCP<XpMat> M = paramList.get<RCP<XpMat> >(*it);
+            paramList.remove(*it);
+            RCP<XphMat> halfM = Xpetra::convertToHalfPrecision(M);
+            paramList.set(*it,halfM);
+          }
         }
 
-        if (paramList.isParameter("M1")) {
-          if (paramList.isType<Teuchos::RCP<TpCrsMat> >("M1")) {
-            Teuchos::TimeMonitor tM_M1(*Teuchos::TimeMonitor::getNewTimer(std::string("ThyraMueLuRefMaxwell::initializePrec wrap M1")));
-            RCP<TpCrsMat> tM1 = paramList.get<RCP<TpCrsMat> >("M1");
-            paramList.remove("M1");
-            RCP<XpCrsMat> xM1 = rcp_dynamic_cast<XpCrsMat>(tM1, true);
-            paramList.set<RCP<XpCrsMat> >("M1", xM1);
-          } else if (paramList.isType<Teuchos::RCP<const ThyLinOpBase> >("M1")) {
-            Teuchos::TimeMonitor tM_M1(*Teuchos::TimeMonitor::getNewTimer(std::string("ThyraMueLuRefMaxwell::initializePrec wrap M1")));
-            RCP<const ThyLinOpBase> thyM1 = paramList.get<RCP<const ThyLinOpBase> >("M1");
-            paramList.remove("M1");
-            RCP<const XpCrsMat> crsM1 = XpThyUtils::toXpetra(thyM1);
-            TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(crsM1));
-            // MueLu needs a non-const object as input
-            RCP<XpCrsMat> crsM1NonConst = Teuchos::rcp_const_cast<XpCrsMat>(crsM1);
-            TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(crsM1NonConst));
-            // wrap as an Xpetra::Matrix that MueLu can work with
-            RCP<XpMat> M1 = rcp(new Xpetra::CrsMatrixWrap<Scalar,LocalOrdinal,GlobalOrdinal,Node>(crsM1NonConst));
-            paramList.set<RCP<XpMat> >("M1", M1);
-          } else if (paramList.isType<Teuchos::RCP<XpMat> >("M1")) {
-            // do nothing
-          } else
-            TEUCHOS_TEST_FOR_EXCEPTION(true, MueLu::Exceptions::RuntimeError, "Parameter M1 has wrong type.");
-        } else
-          TEUCHOS_TEST_FOR_EXCEPTION(true, MueLu::Exceptions::RuntimeError, "Need to specify matrix M1.");
-
-        if (paramList.isParameter("Ms")) {
-          if (paramList.isType<Teuchos::RCP<TpCrsMat> >("Ms")) {
-            Teuchos::TimeMonitor tM_Ms(*Teuchos::TimeMonitor::getNewTimer(std::string("ThyraMueLuRefMaxwell::initializePrec wrap Ms")));
-            RCP<TpCrsMat> tMs = paramList.get<RCP<TpCrsMat> >("Ms");
-            paramList.remove("Ms");
-            RCP<XpCrsMat> xMs = rcp_dynamic_cast<XpCrsMat>(tMs, true);
-            paramList.set<RCP<XpCrsMat> >("Ms", xMs);
-          } else if (paramList.isType<Teuchos::RCP<const ThyLinOpBase> >("Ms")) {
-            Teuchos::TimeMonitor tM_Ms(*Teuchos::TimeMonitor::getNewTimer(std::string("ThyraMueLuRefMaxwell::initializePrec wrap Ms")));
-            RCP<const ThyLinOpBase> thyMs = paramList.get<RCP<const ThyLinOpBase> >("Ms");
-            paramList.remove("Ms");
-            RCP<const XpCrsMat> crsMs = XpThyUtils::toXpetra(thyMs);
-            TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(crsMs));
-            // MueLu needs a non-const object as input
-            RCP<XpCrsMat> crsMsNonConst = Teuchos::rcp_const_cast<XpCrsMat>(crsMs);
-            TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(crsMsNonConst));
-            // wrap as an Xpetra::Matrix that MueLu can work with
-            RCP<XpMat> Ms = rcp(new Xpetra::CrsMatrixWrap<Scalar,LocalOrdinal,GlobalOrdinal,Node>(crsMsNonConst));
-            paramList.set<RCP<XpMat> >("Ms", Ms);
-          } else if (paramList.isType<Teuchos::RCP<XpMat> >("Ms")) {
-            // do nothing
-          } else
-            TEUCHOS_TEST_FOR_EXCEPTION(true, MueLu::Exceptions::RuntimeError, "Parameter Ms has wrong type.");
-        }
-
-        if (paramList.isParameter("D0")) {
-          if (paramList.isType<Teuchos::RCP<TpCrsMat> >("D0")) {
-            Teuchos::TimeMonitor tM_D0(*Teuchos::TimeMonitor::getNewTimer(std::string("ThyraMueLuRefMaxwell::initializePrec wrap D0")));
-            RCP<TpCrsMat> tD0 = paramList.get<RCP<TpCrsMat> >("D0");
-            paramList.remove("D0");
-            RCP<XpCrsMat> xD0 = rcp_dynamic_cast<XpCrsMat>(tD0, true);
-            paramList.set<RCP<XpCrsMat> >("D0", xD0);
-          } else if (paramList.isType<Teuchos::RCP<const ThyLinOpBase> >("D0")) {
-            Teuchos::TimeMonitor tM_D0(*Teuchos::TimeMonitor::getNewTimer(std::string("ThyraMueLuRefMaxwell::initializePrec wrap D0")));
-            RCP<const ThyLinOpBase> thyD0 = paramList.get<RCP<const ThyLinOpBase> >("D0");
-            paramList.remove("D0");
-            RCP<const XpCrsMat> crsD0 = XpThyUtils::toXpetra(thyD0);
-            TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(crsD0));
-            // MueLu needs a non-const object as input
-            RCP<XpCrsMat> crsD0NonConst = Teuchos::rcp_const_cast<XpCrsMat>(crsD0);
-            TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(crsD0NonConst));
-            // wrap as an Xpetra::Matrix that MueLu can work with
-            RCP<XpMat> D0 = rcp(new Xpetra::CrsMatrixWrap<Scalar,LocalOrdinal,GlobalOrdinal,Node>(crsD0NonConst));
-            paramList.set<RCP<XpMat> >("D0", D0);
-          } else if (paramList.isType<Teuchos::RCP<XpMat> >("D0")) {
-            // do nothing
-          } else
-            TEUCHOS_TEST_FOR_EXCEPTION(true, MueLu::Exceptions::RuntimeError, "Parameter D0 has wrong type.");
-        } else
-          TEUCHOS_TEST_FOR_EXCEPTION(true, MueLu::Exceptions::RuntimeError, "Need to specify matrix D0.");
-
-        if (paramList.isParameter("M0inv")) {
-          if (paramList.isType<Teuchos::RCP<TpCrsMat> >("M0inv")) {
-            Teuchos::TimeMonitor tM_M0inv(*Teuchos::TimeMonitor::getNewTimer(std::string("ThyraMueLuRefMaxwell::initializePrec wrap M0inv")));
-            RCP<TpCrsMat> tM0inv = paramList.get<RCP<TpCrsMat> >("M0inv");
-            paramList.remove("M0inv");
-            RCP<XpCrsMat> xM0inv = rcp_dynamic_cast<XpCrsMat>(tM0inv, true);
-            paramList.set<RCP<XpCrsMat> >("M0inv", xM0inv);
-          } else if (paramList.isType<Teuchos::RCP<const ThyDiagLinOpBase> >("M0inv")) {
-            Teuchos::TimeMonitor tM_M0inv(*Teuchos::TimeMonitor::getNewTimer(std::string("ThyraMueLuRefMaxwell::initializePrec wrap M0inv")));
-            RCP<const ThyDiagLinOpBase> thyM0inv = paramList.get<RCP<const ThyDiagLinOpBase> >("M0inv");
-            paramList.remove("M0inv");
-            RCP<const Thyra::VectorBase<Scalar> > diag = thyM0inv->getDiag();
-            RCP<const tV> tDiag = Thyra::TpetraOperatorVectorExtraction<Scalar,LocalOrdinal,GlobalOrdinal,Node>::getConstTpetraVector(diag);
-            RCP<XpMat> M0inv = Xpetra::MatrixFactory<Scalar,LocalOrdinal,GlobalOrdinal,Node>::Build(Xpetra::toXpetra(tDiag));
-            paramList.set<RCP<XpMat> >("M0inv", M0inv);
-          } else if (paramList.isType<Teuchos::RCP<const ThyLinOpBase> >("M0inv")) {
-            Teuchos::TimeMonitor tM_M0inv(*Teuchos::TimeMonitor::getNewTimer(std::string("ThyraMueLuRefMaxwell::initializePrec wrap M0inv")));
-            RCP<const ThyLinOpBase> thyM0inv = paramList.get<RCP<const ThyLinOpBase> >("M0inv");
-            paramList.remove("M0inv");
-            RCP<const XpCrsMat> crsM0inv = XpThyUtils::toXpetra(thyM0inv);
-            TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(crsM0inv));
-            // MueLu needs a non-const object as input
-            RCP<XpCrsMat> crsM0invNonConst = Teuchos::rcp_const_cast<XpCrsMat>(crsM0inv);
-            TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(crsM0invNonConst));
-            // wrap as an Xpetra::Matrix that MueLu can work with
-            RCP<XpMat> M0inv = rcp(new Xpetra::CrsMatrixWrap<Scalar,LocalOrdinal,GlobalOrdinal,Node>(crsM0invNonConst));
-            paramList.set<RCP<XpMat> >("M0inv", M0inv);
-          } else if (paramList.isType<Teuchos::RCP<XpMat> >("M0inv")) {
-            // do nothing
-          } else
-            TEUCHOS_TEST_FOR_EXCEPTION(true, MueLu::Exceptions::RuntimeError, "Parameter M0inv has wrong type.");
-        } else
-          TEUCHOS_TEST_FOR_EXCEPTION(true, MueLu::Exceptions::RuntimeError, "Need to specify matrix M0inv.");
-        
-      }
+        // build a new half-precision MueLu RefMaxwell preconditioner
+        RCP<MueLu::RefMaxwell<HalfScalar,LocalOrdinal,GlobalOrdinal,Node> > halfPrec = rcp(new MueLu::RefMaxwell<HalfScalar,LocalOrdinal,GlobalOrdinal,Node>(halfA, paramList, true));
+        xpPrecOp = rcp(new XpHalfPrecOp(halfPrec));
+#else
+        TEUCHOS_TEST_FOR_EXCEPT(true);
 #endif
-
-      {
-        // build a new MueLu RefMaxwell preconditioner
-        Teuchos::TimeMonitor tMbuild(*Teuchos::TimeMonitor::getNewTimer(std::string("ThyraMueLuRefMaxwell::initializePrec build prec")));
-        paramList.set<bool>("refmaxwell: use as preconditioner", true);
-        preconditioner = rcp(new MueLu::RefMaxwell<Scalar,LocalOrdinal,GlobalOrdinal,Node>(A, paramList, true));
-      }
-
+      } else
+        {
+          // build a new MueLu RefMaxwell preconditioner
+          RCP<MueLu::RefMaxwell<Scalar,LocalOrdinal,GlobalOrdinal,Node> > preconditioner = rcp(new MueLu::RefMaxwell<Scalar,LocalOrdinal,GlobalOrdinal,Node>(A, paramList, true));
+          xpPrecOp = rcp_dynamic_cast<XpOp>(preconditioner);
+        }
     } else {
       // reuse old MueLu preconditioner stored in MueLu Xpetra operator and put in new matrix
 
       RCP<ThyXpOp> thyXpOp = rcp_dynamic_cast<ThyXpOp>(thyra_precOp, true);
       RCP<XpOp>    xpOp    = thyXpOp->getXpetraOperator();
-      preconditioner = rcp_dynamic_cast<MueLu::RefMaxwell<Scalar,LocalOrdinal,GlobalOrdinal,Node>>(xpOp, true);
-      preconditioner->resetMatrix(A);
+#if defined(HAVE_MUELU_TPETRA) && defined(HAVE_TPETRA_INST_DOUBLE) && defined(HAVE_TPETRA_INST_FLOAT)
+      RCP<XpHalfPrecOp> xpHalfPrecOp = rcp_dynamic_cast<XpHalfPrecOp>(xpOp);
+      if (!xpHalfPrecOp.is_null()) {
+        RCP<MueLu::RefMaxwell<HalfScalar,LocalOrdinal,GlobalOrdinal,Node> > preconditioner = rcp_dynamic_cast<MueLu::RefMaxwell<HalfScalar,LocalOrdinal,GlobalOrdinal,Node>>(xpHalfPrecOp->GetHalfPrecisionOperator(), true);
+        RCP<XphMat> halfA = Xpetra::convertToHalfPrecision(A);
+        preconditioner->resetMatrix(halfA);
+        xpPrecOp = rcp_dynamic_cast<XpOp>(preconditioner);
+      } else
+#endif
+        {
+          RCP<MueLu::RefMaxwell<Scalar,LocalOrdinal,GlobalOrdinal,Node> > preconditioner = rcp_dynamic_cast<MueLu::RefMaxwell<Scalar,LocalOrdinal,GlobalOrdinal,Node>>(xpOp, true);
+          preconditioner->resetMatrix(A);
+          xpPrecOp = rcp_dynamic_cast<XpOp>(preconditioner);
+        }
     }
 
     // wrap preconditioner in thyraPrecOp
-    RCP<ThyLinOpBase > thyraPrecOp = Teuchos::null;
-    RCP<const VectorSpaceBase<Scalar> > thyraRangeSpace  = Xpetra::ThyraUtils<Scalar,LocalOrdinal,GlobalOrdinal,Node>::toThyra(preconditioner->getRangeMap());
-    RCP<const VectorSpaceBase<Scalar> > thyraDomainSpace = Xpetra::ThyraUtils<Scalar,LocalOrdinal,GlobalOrdinal,Node>::toThyra(preconditioner->getDomainMap());
+    RCP<const VectorSpaceBase<Scalar> > thyraRangeSpace  = Xpetra::ThyraUtils<Scalar,LocalOrdinal,GlobalOrdinal,Node>::toThyra(xpPrecOp->getRangeMap());
+    RCP<const VectorSpaceBase<Scalar> > thyraDomainSpace = Xpetra::ThyraUtils<Scalar,LocalOrdinal,GlobalOrdinal,Node>::toThyra(xpPrecOp->getDomainMap());
 
-    RCP<XpOp> xpOp = Teuchos::rcp_dynamic_cast<XpOp>(preconditioner);
-    thyraPrecOp = Thyra::xpetraLinearOp<Scalar, LocalOrdinal, GlobalOrdinal, Node>(thyraRangeSpace, thyraDomainSpace,xpOp);
-
+    RCP<ThyLinOpBase > thyraPrecOp = Thyra::xpetraLinearOp<Scalar, LocalOrdinal, GlobalOrdinal, Node>(thyraRangeSpace, thyraDomainSpace, xpPrecOp);
     TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(thyraPrecOp));
 
     defaultPrec->initializeUnspecified(thyraPrecOp);

--- a/packages/muelu/src/Misc/MueLu_RAPFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_RAPFactory_def.hpp
@@ -223,7 +223,11 @@ namespace MueLu {
         bool checkAc             = pL.get<bool>("CheckMainDiagonal")|| pL.get<bool>("rap: fix zero diagonals"); ;
         if (checkAc || repairZeroDiagonals) {
           using magnitudeType = typename Teuchos::ScalarTraits<Scalar>::magnitudeType;
-          magnitudeType threshold = pL.get<magnitudeType>("rap: fix zero diagonals threshold");
+          magnitudeType threshold;
+          if (pL.isType<magnitudeType>("rap: fix zero diagonals threshold"))
+            threshold = pL.get<magnitudeType>("rap: fix zero diagonals threshold");
+          else
+            threshold = Teuchos::as<magnitudeType>(pL.get<double>("rap: fix zero diagonals threshold"));
           Scalar replacement = Teuchos::as<Scalar>(pL.get<double>("rap: fix zero diagonals replacement"));
           Xpetra::MatrixUtils<SC,LO,GO,NO>::CheckRepairMainDiagonal(Ac, repairZeroDiagonals, GetOStream(Warnings1), threshold, replacement);
         }
@@ -296,7 +300,11 @@ namespace MueLu {
         bool checkAc             = pL.get<bool>("CheckMainDiagonal")|| pL.get<bool>("rap: fix zero diagonals"); ;
         if (checkAc || repairZeroDiagonals) {
           using magnitudeType = typename Teuchos::ScalarTraits<Scalar>::magnitudeType;
-          magnitudeType threshold = pL.get<magnitudeType>("rap: fix zero diagonals threshold");
+          magnitudeType threshold;
+          if (pL.isType<magnitudeType>("rap: fix zero diagonals threshold"))
+            threshold = pL.get<magnitudeType>("rap: fix zero diagonals threshold");
+          else
+            threshold = Teuchos::as<magnitudeType>(pL.get<double>("rap: fix zero diagonals threshold"));
           Scalar replacement = Teuchos::as<Scalar>(pL.get<double>("rap: fix zero diagonals replacement"));
           Xpetra::MatrixUtils<SC,LO,GO,NO>::CheckRepairMainDiagonal(Ac, repairZeroDiagonals, GetOStream(Warnings1), threshold, replacement);
         }

--- a/packages/muelu/src/Smoothers/MueLu_Ifpack2Smoother_def.hpp
+++ b/packages/muelu/src/Smoothers/MueLu_Ifpack2Smoother_def.hpp
@@ -730,9 +730,14 @@ namespace MueLu {
     // option is supported by current ifpack2 preconditioner
     Teuchos::ParameterList paramList;
     bool supportInitialGuess = false;
+    const Teuchos::ParameterList params = this->GetParameterList();
     if (type_ == "CHEBYSHEV") {
-      paramList.set("chebyshev: zero starting solution", InitialGuessIsZero);
-      SetPrecParameters(paramList);
+      const std::string paramName = "chebyshev: zero starting solution";
+      if (!params.isType<bool>(paramName) ||
+          (params.get<bool>(paramName) != InitialGuessIsZero)) {
+        paramList.set(paramName, InitialGuessIsZero);
+        SetPrecParameters(paramList);
+      }
       supportInitialGuess = true;
 
     } else if (type_ == "RELAXATION"       ||
@@ -750,13 +755,21 @@ namespace MueLu {
                type_ == "TRIDIAGONAL_RELAXATION" ||
                type_ == "TRIDIAGONAL RELAXATION" ||
                type_ == "TRIDIAGONALRELAXATION") {
-      paramList.set("relaxation: zero starting solution", InitialGuessIsZero);
-      SetPrecParameters(paramList);
+      const std::string paramName = "relaxation: zero starting solution";
+      if (!params.isType<bool>(paramName) ||
+          (params.get<bool>(paramName) != InitialGuessIsZero)) {
+        paramList.set(paramName, InitialGuessIsZero);
+        SetPrecParameters(paramList);
+      }
       supportInitialGuess = true;
 
     } else if (type_ == "KRYLOV") {
-      paramList.set("krylov: zero starting solution", InitialGuessIsZero);
-      SetPrecParameters(paramList);
+      const std::string paramName = "krylov: zero starting solution";
+      if (!params.isType<bool>(paramName) ||
+          (params.get<bool>(paramName) != InitialGuessIsZero)) {
+        paramList.set(paramName, InitialGuessIsZero);
+        SetPrecParameters(paramList);
+      }
       supportInitialGuess = true;
 
     } else if (type_ == "SCHWARZ") {

--- a/packages/panzer/mini-em/src/solvers/MiniEM_FullMaxwellPreconditionerFactory.cpp
+++ b/packages/panzer/mini-em/src/solvers/MiniEM_FullMaxwellPreconditionerFactory.cpp
@@ -400,9 +400,9 @@ void FullMaxwellPreconditionerFactory::initializeFromParameterList(const Teuchos
                           Q_B_prec_pl.get<std::string>("Prec Type"),
                           Q_B_prec_pl.sublist("Prec Types"));
 
-   if (S_E_prec_type_ == "MueLuRefMaxwell-Tpetra" || S_E_prec_type_ == "MueLuRefMaxwell" || S_E_prec_type_ == "ML") { // RefMaxwell based solve
+   dt = params.get<double>("dt");
 
-     dt = params.get<double>("dt");
+   if (S_E_prec_type_ == "MueLuRefMaxwell-Tpetra" || S_E_prec_type_ == "MueLuRefMaxwell" || S_E_prec_type_ == "ML") { // RefMaxwell based solve
 
      // S_E solve
      Teuchos::ParameterList ml_pl = pl.sublist("S_E Solve");

--- a/packages/xpetra/src/Headers/Xpetra_UseShortNamesScalar.hpp
+++ b/packages/xpetra/src/Headers/Xpetra_UseShortNamesScalar.hpp
@@ -97,6 +97,10 @@ typedef Xpetra::Operator<Scalar, LocalOrdinal, GlobalOrdinal, Node> Operator;
 typedef Xpetra::TpetraOperator<Scalar, LocalOrdinal, GlobalOrdinal, Node> TpetraOperator;
 #endif
 
+#ifdef XPETRA_TPETRAHALFPRECISIONOPERATOR_SHORT
+typedef Xpetra::TpetraHalfPrecisionOperator<Scalar, LocalOrdinal, GlobalOrdinal, Node> TpetraHalfPrecisionOperator;
+#endif
+
 #ifdef XPETRA_BLOCKEDCRSMATRIX_SHORT
 typedef Xpetra::BlockedCrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> BlockedCrsMatrix;
 #endif

--- a/packages/xpetra/src/Operator/Xpetra_EpetraOperator.hpp
+++ b/packages/xpetra/src/Operator/Xpetra_EpetraOperator.hpp
@@ -171,7 +171,7 @@ namespace Xpetra {
     //! The Tpetra::Operator which this class wraps.
     RCP< Epetra_Operator> op_;
 
-  }; // TpetraOperator class
+  }; // EpetraOperator class
 
 
 } // Xpetra namespace

--- a/packages/xpetra/src/Operator/Xpetra_TpetraHalfPrecisionOperator.hpp
+++ b/packages/xpetra/src/Operator/Xpetra_TpetraHalfPrecisionOperator.hpp
@@ -1,0 +1,179 @@
+// @HEADER
+//
+// ***********************************************************************
+//
+//        MueLu: A package for multigrid based preconditioning
+//                  Copyright 2012 Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact
+//                    Jonathan Hu       (jhu@sandia.gov)
+//                    Andrey Prokopenko (aprokop@sandia.gov)
+//                    Ray Tuminaro      (rstumin@sandia.gov)
+//
+// ***********************************************************************
+//
+// @HEADER
+#ifndef XPETRA_TPETRAHALFPRECISIONOPEARTOR_HPP
+#define XPETRA_TPETRAHALFPRECISIONOPEARTOR_HPP
+
+#include "Xpetra_ConfigDefs.hpp"
+
+#include <Teuchos_ScalarTraits.hpp>
+
+#include <Xpetra_TpetraOperator.hpp>
+#include <Xpetra_MultiVector.hpp>
+#include <Xpetra_MultiVectorFactory.hpp>
+
+namespace Xpetra {
+
+  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+  RCP<Xpetra::Matrix<typename Teuchos::ScalarTraits<Scalar>::halfPrecision, LocalOrdinal, GlobalOrdinal, Node> >
+  convertToHalfPrecision(RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> >& A) {
+    typedef typename Teuchos::ScalarTraits<Scalar>::halfPrecision                                 HalfScalar;
+    typedef typename Xpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>::local_matrix_type LM;
+    typedef Xpetra::Matrix<HalfScalar,LocalOrdinal,GlobalOrdinal,Node>                            MatrixHalf;
+    typedef Xpetra::CrsMatrix<HalfScalar,LocalOrdinal,GlobalOrdinal,Node>                         CrsHalf;
+    typedef Xpetra::TpetraCrsMatrix<HalfScalar,LocalOrdinal,GlobalOrdinal,Node>                   tCrsHalf;
+    typedef typename CrsHalf::local_matrix_type                                                    LMhalf;
+
+    LM lclA = A->getLocalMatrix();
+    LMhalf newLclA = LMhalf("new A", lclA.graph);
+    Kokkos::deep_copy(newLclA.values, lclA.values);
+    RCP<CrsHalf> newCrsA = Teuchos::rcp(new tCrsHalf(newLclA, A->getRowMap(), A->getColMap(), A->getDomainMap(), A->getRangeMap()));
+    RCP<MatrixHalf> newA = Teuchos::rcp(new Xpetra::CrsMatrixWrap<HalfScalar,LocalOrdinal,GlobalOrdinal,Node>(newCrsA));
+    newA->setObjectLabel(A->getObjectLabel());
+    return newA;
+  }
+
+  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+  RCP<Xpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::halfPrecision, LocalOrdinal, GlobalOrdinal, Node> >
+  convertToHalfPrecision(RCP<Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> >& X) {
+    typedef Xpetra::TpetraMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>    tMV;
+    typedef typename Teuchos::ScalarTraits<Scalar>::halfPrecision                HalfScalar;
+    typedef Xpetra::MultiVector<HalfScalar,LocalOrdinal,GlobalOrdinal,Node>       MVHalf;
+    typedef Xpetra::TpetraMultiVector<HalfScalar,LocalOrdinal,GlobalOrdinal,Node> tMVHalf;
+
+    RCP<MVHalf> newX = Xpetra::MultiVectorFactory<HalfScalar,LocalOrdinal,GlobalOrdinal,Node>::Build(X->getMap(),
+                                                                                                     X->getNumVectors());
+    Tpetra::deep_copy(*Teuchos::rcp_dynamic_cast<tMVHalf>(newX)->getTpetra_MultiVector(),
+                      *Teuchos::rcp_dynamic_cast<tMV>(X)->getTpetra_MultiVector());
+    return newX;
+  }
+
+/*!  @brief Wraps an existing halfer precision Xpetra::Operator as a Xpetra::Operator.
+*/
+  template <class Scalar,
+            class LocalOrdinal,
+            class GlobalOrdinal,
+            class Node = KokkosClassic::DefaultNode::DefaultNodeType>
+  class TpetraHalfPrecisionOperator : public Xpetra::Operator<Scalar,LocalOrdinal,GlobalOrdinal,Node> {
+  public:
+    typedef typename Teuchos::ScalarTraits<Scalar>::halfPrecision HalfScalar;
+
+    //! @name Constructor/Destructor
+    //@{
+
+    //! Constructor
+    TpetraHalfPrecisionOperator(const RCP<Xpetra::Operator<HalfScalar, LocalOrdinal, GlobalOrdinal, Node> >& op) : Op_(op) {
+      Allocate(1);
+    }
+
+    void Allocate(int numVecs) {
+      X_ = Xpetra::MultiVectorFactory<HalfScalar,LocalOrdinal,GlobalOrdinal,Node>::Build(Op_->getDomainMap(),numVecs);
+      Y_ = Xpetra::MultiVectorFactory<HalfScalar,LocalOrdinal,GlobalOrdinal,Node>::Build(Op_->getRangeMap(),numVecs);
+    }
+
+    //! Destructor.
+    virtual ~TpetraHalfPrecisionOperator() { }
+
+    //@}
+
+    //! Returns the Tpetra::Map object associated with the domain of this TpetraOperator.
+    Teuchos::RCP<const Xpetra::Map<LocalOrdinal,GlobalOrdinal,Node> > getDomainMap() const {
+      return Op_->getDomainMap();
+    }
+
+    //! Returns the Tpetra::Map object associated with the range of this TpetraOperator.
+    Teuchos::RCP<const Xpetra::Map<LocalOrdinal,GlobalOrdinal,Node> > getRangeMap() const {
+      return Op_->getRangeMap();
+    }
+
+    //! Returns in Y the result of a Xpetra::TpetraOperator applied to a Xpetra::MultiVector X.
+    /*!
+      \param[in]  X - Xpetra::MultiVector of dimension NumVectors to multiply with matrix.
+      \param[out] Y - Xpetra::MultiVector of dimension NumVectors containing result.
+    */
+    void apply(const Xpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>& X,
+               Xpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>& Y,
+               Teuchos::ETransp mode = Teuchos::NO_TRANS,
+               Scalar alpha = Teuchos::ScalarTraits<Scalar>::one(),
+               Scalar beta = Teuchos::ScalarTraits<Scalar>::one()) const{
+      typedef Xpetra::TpetraMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>     tMV;
+      typedef Xpetra::TpetraMultiVector<HalfScalar,LocalOrdinal,GlobalOrdinal,Node> tMVHalf;
+      Tpetra::deep_copy(*Teuchos::rcp_dynamic_cast<tMVHalf>(X_)->getTpetra_MultiVector(),
+                        toTpetra(X));
+      Op_->apply(*X_, *Y_, mode, Teuchos::as<HalfScalar>(alpha), Teuchos::as<HalfScalar>(beta));
+      Tpetra::deep_copy(toTpetra(Y),
+                        *Teuchos::rcp_dynamic_cast<tMVHalf>(Y_)->getTpetra_MultiVector());
+    }
+
+    //! Indicates whether this TpetraOperator supports applying the adjoint TpetraOperator.
+    bool hasTransposeApply() const { return false; }
+
+    //! Compute a residual R = B - (*this) * X
+    void residual(const Xpetra::MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & X,
+                  const Xpetra::MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & B,
+                  Xpetra::MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & R) const {
+      using STS = Teuchos::ScalarTraits<Scalar>;
+      R.update(STS::one(),B,STS::zero());
+      this->apply (X, R, Teuchos::NO_TRANS, -STS::one(), STS::one());
+    }
+
+    //! @name Xpetra specific
+    //@{
+
+    //! Direct access to the underlying TpetraOperator.
+    RCP<Xpetra::Operator<HalfScalar, LocalOrdinal, GlobalOrdinal, Node> > GetHalfPrecisionOperator() const { return Op_; }
+
+    void SetHalfPrecisionOperator(const RCP<Xpetra::Operator<HalfScalar, LocalOrdinal, GlobalOrdinal, Node> >& op) { Op_ = op; };
+
+    //@}
+
+  private:
+    RCP<Xpetra::Operator<HalfScalar, LocalOrdinal, GlobalOrdinal, Node> > Op_;
+    RCP<Xpetra::MultiVector<HalfScalar, LocalOrdinal, GlobalOrdinal, Node> > X_, Y_;
+  };
+
+} // namespace
+
+#endif // XPETRA_TPETRAHALFPRECISIONOPEARTOR_HPP

--- a/packages/xpetra/src/Utils/ClassList/SC-LO-GO-NO.classList
+++ b/packages/xpetra/src/Utils/ClassList/SC-LO-GO-NO.classList
@@ -14,6 +14,7 @@
 #ReorderedBlockedCrsMatrix
 TpetraBlockCrsMatrix
 TpetraCrsMatrix
+TpetraHalfPrecisionOperator
 ##TpetraVbrMatrix
 ##VbrMatrix
 #Vector

--- a/packages/xpetra/src/Utils/ForwardDeclaration/Xpetra_TpetraHalfPrecisionOperator_fwd.hpp
+++ b/packages/xpetra/src/Utils/ForwardDeclaration/Xpetra_TpetraHalfPrecisionOperator_fwd.hpp
@@ -1,0 +1,58 @@
+// @HEADER
+//
+// ***********************************************************************
+//
+//             Xpetra: A linear algebra interface package
+//                  Copyright 2012 Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact
+//                    Jonathan Hu       (jhu@sandia.gov)
+//                    Andrey Prokopenko (aprokop@sandia.gov)
+//                    Ray Tuminaro      (rstumin@sandia.gov)
+//
+// ***********************************************************************
+//
+// @HEADER
+#ifndef XPETRA_TPETRAHALFPRECISIONOPERATOR_FWD_HPP
+#define XPETRA_TPETRAHALFPRECISIONOPERATOR_FWD_HPP
+
+namespace Xpetra {
+  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+  class TpetraHalfPrecisionOperator;
+}
+
+#ifndef XPETRA_TPETRAHALFPRECISIONOPERATOR_SHORT
+#define XPETRA_TPETRAHALFPRECISIONOPERATOR_SHORT
+#endif
+
+#endif // XPETRA_TPETRAHALFPRECISIONOPERATOR_FWD_HPP


### PR DESCRIPTION
@trilinos/muelu @trilinos/xpetra 

## Motivation
- Ifpack2Smoother: Only call `SetPrecParameters` when they actually change
- RAPFactory: Fix repair threshold parameter when Scalar != double
- RefMaxwell: When requested, use average edge length for nullspace normalization
- Xpetra: Add an operator that wraps an operator with ScalarTraits<Scalar>::halfPrecision into a Scalar one.
- Allow running RefMaxwell in half precision through Stratimikos interface

Let's see what the AT thinks of this..