### PR TITLE
Framework: Preparation for CMake minimum required version update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,8 @@
 
 # To be safe, define your minimum CMake version.  This may be newer than the
 # min required by TriBITS.
-CMAKE_MINIMUM_REQUIRED(VERSION 3.17.0 FATAL_ERROR)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.10.0 FATAL_ERROR)
+#CMAKE_MINIMUM_REQUIRED(VERSION 3.17.0 FATAL_ERROR)
 
 # Must set the project name as a variable at very beginning before including anything else
 # We set the project name in a separate file so CTest scripts can use it.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@
 
 # To be safe, define your minimum CMake version.  This may be newer than the
 # min required by TriBITS.
-CMAKE_MINIMUM_REQUIRED(VERSION 3.10.0 FATAL_ERROR)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.17.0 FATAL_ERROR)
 
 # Must set the project name as a variable at very beginning before including anything else
 # We set the project name in a separate file so CTest scripts can use it.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@
 
 # To be safe, define your minimum CMake version.  This may be newer than the
 # min required by TriBITS.
-CMAKE_MINIMUM_REQUIRED(VERSION 3.17.0 FATAL_ERROR)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.10.0 FATAL_ERROR)
 
 # Must set the project name as a variable at very beginning before including anything else
 # We set the project name in a separate file so CTest scripts can use it.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,8 +59,7 @@
 
 # To be safe, define your minimum CMake version.  This may be newer than the
 # min required by TriBITS.
-CMAKE_MINIMUM_REQUIRED(VERSION 3.10.0 FATAL_ERROR)
-#CMAKE_MINIMUM_REQUIRED(VERSION 3.17.0 FATAL_ERROR)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.17.0 FATAL_ERROR)
 
 # Must set the project name as a variable at very beginning before including anything else
 # We set the project name in a separate file so CTest scripts can use it.

--- a/cmake/std/PullRequestLinuxIntel17.0.1TestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxIntel17.0.1TestingSettings.cmake
@@ -76,7 +76,7 @@ set (Trilinos_ENABLE_STKBalance OFF CACHE BOOL "Hard disabled since Tpetra_INST_
 #STK-TODO: try to remember to come back and remove this when stk-balance
 #is able to tolerate int as a global-index.
 
-set(CMAKE_CXX_FLAGS "-Wall -Warray-bounds -Wchar-subscripts -Wcomment -Wenum-compare -Wformat -Wuninitialized -Wmaybe-uninitialized -Wmain -Wnarrowing -Wnonnull -Wparentheses -Wpointer-sign -Wreorder -Wreturn-type -Wsign-compare -Wsequence-point -Wtrigraphs -Wunused-function -Wunused-but-set-variable -Wunused-variable -Wwrite-strings" CACHE STRING "Warning settings")
+# set(CMAKE_CXX_FLAGS "-Wall -Warray-bounds -Wchar-subscripts -Wcomment -Wenum-compare -Wformat -Wuninitialized -Wmaybe-uninitialized -Wmain -Wnarrowing -Wnonnull -Wparentheses -Wpointer-sign -Wreorder -Wreturn-type -Wsign-compare -Wsequence-point -Wtrigraphs -Wunused-function -Wunused-but-set-variable -Wunused-variable -Wwrite-strings" CACHE STRING "Warning settings")
 
 #set (Anasazi_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as errors setting")
 #set (Belos_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as errors setting")

--- a/cmake/std/PullRequestLinuxIntel17.0.1TestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxIntel17.0.1TestingSettings.cmake
@@ -76,7 +76,9 @@ set (Trilinos_ENABLE_STKBalance OFF CACHE BOOL "Hard disabled since Tpetra_INST_
 #STK-TODO: try to remember to come back and remove this when stk-balance
 #is able to tolerate int as a global-index.
 
-# set(CMAKE_CXX_FLAGS "-Wall -Warray-bounds -Wchar-subscripts -Wcomment -Wenum-compare -Wformat -Wuninitialized -Wmaybe-uninitialized -Wmain -Wnarrowing -Wnonnull -Wparentheses -Wpointer-sign -Wreorder -Wreturn-type -Wsign-compare -Wsequence-point -Wtrigraphs -Wunused-function -Wunused-but-set-variable -Wunused-variable -Wwrite-strings" CACHE STRING "Warning settings")
+set(CMAKE_CXX_FLAGS "-Wall -Warray-bounds -Wchar-subscripts -Wcomment -Wenum-compare -Wformat -Wuninitialized -Wmaybe-uninitialized -Wmain -Wnarrowing -Wnonnull -Wparentheses -Wpointer-sign -Wreorder -Wreturn-type -Wsign-compare -Wsequence-point -Wtrigraphs -Wunused-function -Wunused-but-set-variable -Wunused-variable -Wwrite-strings" CACHE STRING "Warning settings")
+
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lifcore" CACHE STRING "updated by Pull Request")
 
 #set (Anasazi_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as errors setting")
 #set (Belos_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as errors setting")

--- a/cmake/std/PullRequestLinuxIntel19.0.5TestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxIntel19.0.5TestingSettings.cmake
@@ -92,6 +92,10 @@ set (TPL_Netcdf_LIBRARIES "-L${Netcdf_LIBRARY_DIRS}/lib;${Netcdf_LIBRARY_DIRS}/l
 
 set(CMAKE_CXX_FLAGS "-fPIC -Wall -Warray-bounds -Wchar-subscripts -Wcomment -Wenum-compare -Wformat -Wuninitialized -Wmaybe-uninitialized -Wmain -Wnarrowing -Wnonnull -Wparentheses -Wpointer-sign -Wreorder -Wreturn-type -Wsign-compare -Wsequence-point -Wtrigraphs -Wunused-function -Wunused-but-set-variable -Wunused-variable -Wwrite-strings" CACHE STRING "enable relocatable code, turn on WError settings")
 
+# -lifcore might be needed for CMake > 3.10.x builds. We failed on the Intel 17.x build with CMake 3.17 and
+# greater.
+# set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lifcore" CACHE STRING "updated by Pull Request")
+
 #set (Anasazi_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as errors setting")
 #set (Belos_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as errors setting")
 #set (Domi_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as errors setting")

--- a/cmake/std/pr_config/pullrequest.ini
+++ b/cmake/std/pr_config/pullrequest.ini
@@ -284,6 +284,7 @@ module-remove sems-openmpi:
 #module-load   sems-cmake: 3.19.1
 #module-load sems-cmake: 3.10.3
 use ATDM-DEFAULT:
+# setenv LDFLAGS: -lifcore
 
 
 

--- a/cmake/std/pr_config/pullrequest.ini
+++ b/cmake/std/pr_config/pullrequest.ini
@@ -86,7 +86,7 @@ Trilinos_pullrequest_clang_10.0.0:     PullRequestLinuxClang10.0.0TestingSetting
 
 # CUDA Testing
 Trilinos_pullrequest_cuda_9.2:         PullRequestLinuxCuda9.2TestingSettings.cmake
-Trilinos_pullrequest_cuda_10.1.105:         PullRequestLinuxCuda10.1.105TestingSettings.cmake
+Trilinos_pullrequest_cuda_10.1.105:    PullRequestLinuxCuda10.1.105TestingSettings.cmake
 
 
 # GCC Builds
@@ -337,13 +337,14 @@ setenv OMP_NUM_THREADS: 2
 module-load git: 2.10.1
 module-load devpack: 20180521/openmpi/2.1.2/gcc/7.2.0/cuda/9.2.88
 module-swap openblas/0.2.20/gcc/7.2.0: netlib/3.8.0/gcc/7.2.0
+module-unload cmake
 setenv OMPI_CXX: ${WORKSPACE}/Trilinos/packages/kokkos/bin/nvcc_wrapper
 setenv OMPI_CC: ${CC}
 setenv OMPI_FC: ${FC}
 setenv CUDA_LAUNCH_BLOCKING: 1
 setenv CUDA_MANAGED_FORCE_DEVICE_ALLOC: 1
 setenv PATH_TMP: /ascldap/users/rabartl/install/white-ride/ninja-1.8.2/bin:${PATH}
-setenv PATH:     /ascldap/users/rabartl/install/white-ride/cmake-3.11.2/bin:${PATH_TMP}
+setenv PATH:     /home/atdm-devops-admin/tools/ride/cmake-3.17.2/bin:${PATH_TMP}
 unsetenv PATH_TMP:
 
 
@@ -352,13 +353,14 @@ unsetenv PATH_TMP:
 module-load git: 2.10.1
 module-load devpack: 20190404/openmpi/4.0.1/gcc/7.2.0/cuda/10.1.105
 module-swap openblas/0.3.4/gcc/7.4.0: netlib/3.8.0/gcc/7.2.0
+module-unload cmake
 setenv OMPI_CXX: ${WORKSPACE}/Trilinos/packages/kokkos/bin/nvcc_wrapper
 setenv OMPI_CC: ${CC}
 setenv OMPI_FC: ${FC}
 setenv CUDA_LAUNCH_BLOCKING: 0
 setenv CUDA_MANAGED_FORCE_DEVICE_ALLOC: 1
 setenv PATH_TMP: /ascldap/users/rabartl/install/white-ride/ninja-1.8.2/bin:${PATH}
-setenv PATH:     /ascldap/users/rabartl/install/white-ride/cmake-3.11.2/bin:${PATH_TMP}
+setenv PATH:     /home/atdm-devops-admin/tools/ride/cmake-3.17.2/bin:${PATH_TMP}
 unsetenv PATH_TMP:
 
 

--- a/cmake/std/pr_config/pullrequest.ini
+++ b/cmake/std/pr_config/pullrequest.ini
@@ -280,9 +280,9 @@ module-remove sems-openmpi:
 # Note: sems-cmake/3.17.1 might be problematic for intel 17.0.1
 #       CMake fails compiler test of trivial program.
 #       So, let's try SEMS CMake 3.19.1.
-#module-remove sems-cmake:
+module-remove sems-cmake:
 #module-load   sems-cmake: 3.19.1
-#module-load sems-cmake: 3.10.3
+module-load sems-cmake: 3.10.3
 use ATDM-DEFAULT:
 
 

--- a/cmake/std/pr_config/pullrequest.ini
+++ b/cmake/std/pr_config/pullrequest.ini
@@ -281,7 +281,8 @@ module-remove sems-openmpi:
 #       CMake fails compiler test of trivial program.
 #       So, let's try SEMS CMake 3.19.1.
 module-remove sems-cmake:
-module-load   sems-cmake: 3.19.1
+#module-load   sems-cmake: 3.19.1
+module-load sems-cmake: 3.10.3
 use ATDM-DEFAULT:
 
 

--- a/cmake/std/pr_config/pullrequest.ini
+++ b/cmake/std/pr_config/pullrequest.ini
@@ -277,7 +277,7 @@ module-load sems-mpich: 3.2
 use SEMS-DEFAULT:
 module-remove sems-openmpi:
 use ATDM-DEFAULT:
-# setenv LDFLAGS: -lifcore
+setenv LDFLAGS: -lifcore
 
 
 

--- a/cmake/std/pr_config/pullrequest.ini
+++ b/cmake/std/pr_config/pullrequest.ini
@@ -276,6 +276,12 @@ module-load sems-intel: 17.0.1
 module-load sems-mpich: 3.2
 use SEMS-DEFAULT:
 module-remove sems-openmpi:
+
+# Note: sems-cmake/3.17.1 might be problematic for intel 17.0.1
+#       CMake fails compiler test of trivial program.
+#       So, let's try SEMS CMake 3.19.1.
+module-remove sems-cmake:
+module-load   sems-cmake: 3.19.1
 use ATDM-DEFAULT:
 
 

--- a/cmake/std/pr_config/pullrequest.ini
+++ b/cmake/std/pr_config/pullrequest.ini
@@ -177,7 +177,7 @@ module-load sems-parmetis : 4.0.3/parallel
 module-load sems-scotch   : 6.0.3/nopthread_64bit_parallel
 module-load sems-superlu  : 4.3/base
 module-load sems-git      : 2.10.1
-module-load sems-cmake    : 3.10.3
+module-load sems-cmake    : 3.17.1
 #module-load sems-python: 3.5.2
 use SIERRA-PYTHON-3.6.3:
 setenv OMP_NUM_THREADS    : 2
@@ -249,7 +249,7 @@ module-load sems-hdf5: 1.10.6/base
 module-load sems-netcdf: 4.7.3/base
 module-load sems-metis: 5.1.0/base
 module-load sems-superlu: 4.3/base
-module-load sems-cmake: 3.12.2
+module-load sems-cmake: 3.17.1
 use ATDM-ENV:
 module-load atdm-ninja_fortran: 1.7.2
 setenv OMP_NUM_THREADS: 2
@@ -265,10 +265,6 @@ use SEMS-DEFAULT:
 use ATDM-DEFAULT:
 module-remove sems-boost:
 module-load sems-boost: 1.66.0/base
-module-remove sems-cmake:
-# The GCC 3.8.2 build appears to have an issue that fails with cmake/3.10.3
-# - Trying 3.12.2 and if that fails we'll try 3.17.1
-module-load sems-cmake: 3.12.2
 
 
 
@@ -371,23 +367,6 @@ unsetenv PATH_TMP:
 use Trilinos_pullrequest_gcc_8.3.0:
 
 
-# TODO: Remove this whole section once we've removed
-#       Python2 test execution
-#[Trilinos_pullrequest_python_2]
-#use SEMS-ENV:
-#use ATDM-ENV:
-#module-load sems-gcc: 7.2.0
-#use ATDM-DEFAULT:
-#module-load sems-git: 2.10.1
-#module-load sems-cmake: 3.10.3
-#module-unload sems-python:
-#setenv PYTHONPATH: /projects/sierra/linux_rh7/install/Python/extras/lib/python2.7/site-packages
-#setenv MANPATH:    /projects/sierra/linux_rh7/install/Python/2.7.15/share/man
-#setenv PATH_TMP:   /projects/sierra/linux_rh7/install/Python/extras/bin:${PATH}
-#setenv PATH:       /projects/sierra/linux_rh7/install/Python/2.7.15/share/bin:${PATH_TMP}
-#unsetenv PATH_TMP:
-
-
 
 [Trilinos_pullrequest_python_3]
 use SEMS-ENV:
@@ -395,15 +374,7 @@ use ATDM-ENV:
 module-load sems-gcc: 7.2.0
 use ATDM-DEFAULT:
 module-load sems-git: 2.10.1
-module-load sems-cmake: 3.10.3
+module-load sems-cmake: 3.17.1
 use SIERRA-PYTHON-3.6.3:
-##module-unload sems-python:
-###setenv PYTHONPATH: "/projects/sierra/linux_rh7/install/Python/extras/lib/python/3.6/site-packages"
-##setenv MANPATH:    "/projects/sierra/linux_rh7/install/Python/3.6.3/share/man"
-##setenv PATH_TMP:   "/projects/sierra/linux_rh7/install/Python/extras/bin:${PATH}"
-##setenv PATH:       "/projects/sierra/linux_rh7/install/Python/3.6.3/share/bin:${PATH_TMP}"
-##unsetenv PATH_TMP:
-#module-remove sems-python:
-#module-load sems-python: 3.5.2
-#setenv PYTHONPATH: "${SEMS_PYTHON_LIBRARY_PATH}/python3.5/site-packages"
-#setenv MANPATH:    "${SEMS_PYTHON_LIBRARY_PATH}/../share/man"
+
+

--- a/cmake/std/pr_config/pullrequest.ini
+++ b/cmake/std/pr_config/pullrequest.ini
@@ -337,7 +337,7 @@ setenv OMP_NUM_THREADS: 2
 module-load git: 2.10.1
 module-load devpack: 20180521/openmpi/2.1.2/gcc/7.2.0/cuda/9.2.88
 module-swap openblas/0.2.20/gcc/7.2.0: netlib/3.8.0/gcc/7.2.0
-module-unload cmake
+module-unload cmake:
 setenv OMPI_CXX: ${WORKSPACE}/Trilinos/packages/kokkos/bin/nvcc_wrapper
 setenv OMPI_CC: ${CC}
 setenv OMPI_FC: ${FC}
@@ -353,7 +353,7 @@ unsetenv PATH_TMP:
 module-load git: 2.10.1
 module-load devpack: 20190404/openmpi/4.0.1/gcc/7.2.0/cuda/10.1.105
 module-swap openblas/0.3.4/gcc/7.4.0: netlib/3.8.0/gcc/7.2.0
-module-unload cmake
+module-unload cmake:
 setenv OMPI_CXX: ${WORKSPACE}/Trilinos/packages/kokkos/bin/nvcc_wrapper
 setenv OMPI_CC: ${CC}
 setenv OMPI_FC: ${FC}

--- a/cmake/std/pr_config/pullrequest.ini
+++ b/cmake/std/pr_config/pullrequest.ini
@@ -276,13 +276,6 @@ module-load sems-intel: 17.0.1
 module-load sems-mpich: 3.2
 use SEMS-DEFAULT:
 module-remove sems-openmpi:
-
-# Note: sems-cmake/3.17.1 might be problematic for intel 17.0.1
-#       CMake fails compiler test of trivial program.
-#       So, let's try SEMS CMake 3.19.1.
-#module-remove sems-cmake:
-#module-load   sems-cmake: 3.19.1
-#module-load sems-cmake: 3.10.3
 use ATDM-DEFAULT:
 # setenv LDFLAGS: -lifcore
 
@@ -297,6 +290,7 @@ module-load sems-mpich: 3.2
 use SEMS-DEFAULT:
 module-remove sems-openmpi:
 use ATDM-DEFAULT:
+# setenv LDFLAGS: -lifcore
 
 
 

--- a/cmake/std/pr_config/pullrequest.ini
+++ b/cmake/std/pr_config/pullrequest.ini
@@ -280,9 +280,9 @@ module-remove sems-openmpi:
 # Note: sems-cmake/3.17.1 might be problematic for intel 17.0.1
 #       CMake fails compiler test of trivial program.
 #       So, let's try SEMS CMake 3.19.1.
-module-remove sems-cmake:
+#module-remove sems-cmake:
 #module-load   sems-cmake: 3.19.1
-module-load sems-cmake: 3.10.3
+#module-load sems-cmake: 3.10.3
 use ATDM-DEFAULT:
 
 

--- a/cmake/std/pr_config/pullrequest.ini
+++ b/cmake/std/pr_config/pullrequest.ini
@@ -318,7 +318,6 @@ module-load sems-git: 2.10.1
 module-load sems-gcc: 5.3.0
 module-load sems-clang: 10.0.0
 module-load sems-openmpi: 1.10.1
-#module-load sems-python: 3.5.2
 use SIERRA-PYTHON-3.6.3:
 module-load sems-boost: 1.69.0/base
 module-load sems-zlib: 1.2.8/base

--- a/cmake/std/sems/PullRequestClang7.0.1TestingEnv.sh
+++ b/cmake/std/sems/PullRequestClang7.0.1TestingEnv.sh
@@ -29,7 +29,7 @@ module load sems-superlu/4.3/base
 # - One of the SEMS modules will load CMake 3.4.x also,
 #   so this will pull in the SEMS cmake 3.10.3 version
 #   for Trilinos compatibility.
-module load sems-cmake/3.12.2
+module load sems-cmake/3.17.1
 
 # Using CMake and Ninja modules from the ATDM project space.
 # SEMS does not yet supply a recent enough version of CMake

--- a/cmake/std/sems/PullRequestClang9.0.0TestingEnv.sh
+++ b/cmake/std/sems/PullRequestClang9.0.0TestingEnv.sh
@@ -29,7 +29,7 @@ module load sems-superlu/4.3/base
 # - One of the SEMS modules will load CMake 3.4.x also,
 #   so this will pull in the SEMS cmake 3.10.3 version
 #   for Trilinos compatibility.
-module load sems-cmake/3.10.3
+module load sems-cmake/3.17.1
 
 # Using CMake and Ninja modules from the ATDM project space.
 # SEMS does not yet supply a recent enough version of CMake

--- a/cmake/std/sems/PullRequestCuda10.1.105TestingEnv.sh
+++ b/cmake/std/sems/PullRequestCuda10.1.105TestingEnv.sh
@@ -17,4 +17,5 @@ export CUDA_MANAGED_FORCE_DEVICE_ALLOC=1
 
 # Use manually installed cmake and ninja to try to avoid module loading
 # problems (see TRIL-208)
-export PATH=/ascldap/users/rabartl/install/white-ride/cmake-3.11.2/bin:/ascldap/users/rabartl/install/white-ride/ninja-1.8.2/bin:$PATH
+export PATH=/home/atdm-devops-admin/tools/ride/cmake-3.17.2/bin/:/ascldap/users/rabartl/install/white-ride/ninja-1.8.2/bin:$PATH
+#export PATH=/ascldap/users/rabartl/install/white-ride/cmake-3.11.2/bin:/ascldap/users/rabartl/install/white-ride/ninja-1.8.2/bin:$PATH

--- a/cmake/std/sems/PullRequestCuda9.2TestingEnv.sh
+++ b/cmake/std/sems/PullRequestCuda9.2TestingEnv.sh
@@ -17,4 +17,5 @@ export CUDA_MANAGED_FORCE_DEVICE_ALLOC=1
 
 # Use manually installed cmake and ninja to try to avoid module loading
 # problems (see TRIL-208)
-export PATH=/ascldap/users/rabartl/install/white-ride/cmake-3.11.2/bin:/ascldap/users/rabartl/install/white-ride/ninja-1.8.2/bin:$PATH
+export PATH=/home/atdm-devops-admin/tools/ride/cmake-3.17.2/bin/:/ascldap/users/rabartl/install/white-ride/ninja-1.8.2/bin:$PATH
+# export PATH=/ascldap/users/rabartl/install/white-ride/cmake-3.11.2/bin:/ascldap/users/rabartl/install/white-ride/ninja-1.8.2/bin:$PATH

--- a/cmake/std/sems/PullRequestGCC4.8.4TestingEnv.sh
+++ b/cmake/std/sems/PullRequestGCC4.8.4TestingEnv.sh
@@ -7,7 +7,7 @@
 # After the environment is no longer needed, it can be purged using
 # $ module purge
 # or Trilinos/cmake/unload_sems_dev_env.sh
- 
+
 module purge
 
 source /projects/sems/modulefiles/utils/sems-modules-init.sh
@@ -26,7 +26,7 @@ module load sems-superlu/4.3/base
 # - One of the SEMS modules will load CMake 3.4.x also,
 #   so this will pull in the SEMS cmake 3.10.3 version
 #   for Trilinos compatibility.
-module load sems-cmake/3.10.3
+module load sems-cmake/3.17.1
 module load sems-ninja_fortran/1.8.2
 
 module load sems-git/2.10.1

--- a/cmake/std/sems/PullRequestGCC4.9.3TestingEnv.sh
+++ b/cmake/std/sems/PullRequestGCC4.9.3TestingEnv.sh
@@ -18,7 +18,7 @@ module load sems-parmetis/4.0.3/parallel
 module load sems-scotch/6.0.3/nopthread_64bit_parallel
 module load sems-superlu/4.3/base
 
-module load sems-cmake/3.12.2
+module load sems-cmake/3.17.1
 module load sems-ninja_fortran/1.8.2
 
 module load sems-git/2.10.1

--- a/cmake/std/sems/PullRequestGCC4.9.3TestingEnvSERIAL.sh
+++ b/cmake/std/sems/PullRequestGCC4.9.3TestingEnvSERIAL.sh
@@ -17,7 +17,7 @@ module load sems-metis/5.1.0/base
 # module load sems-scotch/6.0.3/nopthread_64bit_parallel
 module load sems-superlu/4.3/base
 
-module load sems-cmake/3.12.2
+module load sems-cmake/3.17.1
 module load sems-ninja_fortran/1.8.2
 
 module load sems-git/2.10.1

--- a/cmake/std/sems/PullRequestGCC7.2.0SerialTestingEnv.sh
+++ b/cmake/std/sems/PullRequestGCC7.2.0SerialTestingEnv.sh
@@ -16,7 +16,7 @@ module load sems-netcdf/4.7.3/base
 module load sems-metis/5.1.0/base
 module load sems-superlu/4.3/base
 
-module load sems-cmake/3.12.2
+module load sems-cmake/3.17.1
 module load sems-ninja_fortran/1.8.2
 
 # Boost loads sems-python/2.7.x as a side effect.

--- a/cmake/std/sems/PullRequestGCC7.2.0TestingEnv.sh
+++ b/cmake/std/sems/PullRequestGCC7.2.0TestingEnv.sh
@@ -18,7 +18,7 @@ module load sems-parmetis/4.0.3/parallel
 module load sems-scotch/6.0.3/nopthread_64bit_parallel
 module load sems-superlu/4.3/base
 
-module load sems-cmake/3.10.3
+module load sems-cmake/3.17.1
 module load sems-ninja_fortran/1.8.2
 
 module load sems-git/2.10.1

--- a/cmake/std/sems/PullRequestIntel17.0.1TestingEnv.sh
+++ b/cmake/std/sems/PullRequestIntel17.0.1TestingEnv.sh
@@ -9,7 +9,7 @@
 # or Trilinos/cmake/unload_sems_dev_env.sh
 
 module purge
- 
+
 source /projects/sems/modulefiles/utils/sems-modules-init.sh
 
 export SEMS_FORCE_LOCAL_COMPILER_VERSION=4.9.3
@@ -24,7 +24,7 @@ module load sems-parmetis/4.0.3/parallel
 module load sems-scotch/6.0.3/nopthread_64bit_parallel
 module load sems-superlu/4.3/base
 
-module load sems-cmake/3.12.2
+module load sems-cmake/3.17.1
 module load sems-ninja_fortran/1.8.2
 
 module load sems-git/2.10.1

--- a/cmake/std/sems/PullRequestIntel19.0.5TestingEnv.sh
+++ b/cmake/std/sems/PullRequestIntel19.0.5TestingEnv.sh
@@ -24,7 +24,7 @@ module load sems-parmetis/4.0.3/parallel
 module load sems-scotch/6.0.3/nopthread_64bit_parallel
 module load sems-superlu/4.3/base
 
-module load sems-cmake/3.12.2
+module load sems-cmake/3.17.1
 module load sems-ninja_fortran/1.8.2
 
 module load sems-git/2.10.1

--- a/cmake/std/sems/PullRequestPython2TestingEnv.sh
+++ b/cmake/std/sems/PullRequestPython2TestingEnv.sh
@@ -7,7 +7,7 @@
 # After the environment is no longer needed, it can be purged using
 # $ module purge
 # or Trilinos/cmake/unload_sems_dev_env.sh
- 
+
 source /projects/sems/modulefiles/utils/sems-modules-init.sh
 
 module load sems-gcc/4.8.4
@@ -25,7 +25,7 @@ module load sems-superlu/4.3/base
 # - One of the SEMS modules will load CMake 3.4.x also,
 #   so this will pull in the SEMS cmake 3.10.3 version
 #   for Trilinos compatibility.
-module load sems-cmake/3.10.3
+module load sems-cmake/3.17.1
 module load sems-ninja_fortran/1.8.2
 
 # we will have implicitly gotten the sems python from
@@ -37,4 +37,4 @@ export PATH=/projects/sierra/linux_rh7/install/Python/2.7.15/bin:${PATH}
 PATH=/projects/sierra/linux_rh7/install/Python/extras/bin:${PATH}
 export PYTHONPATH=/projects/sierra/linux_rh7/install/Python/extras/lib/python2.7/site-packages:${PYTHONPATH}
 export MANPATH=/projects/sierra/linux_rh7/install/Python/2.7.15/share/man:${MANPATH}
-unset PYTHONHOME 
+unset PYTHONHOME

--- a/cmake/std/sems/PullRequestPython3TestingEnv.sh
+++ b/cmake/std/sems/PullRequestPython3TestingEnv.sh
@@ -21,7 +21,7 @@ module load sems-superlu/4.3/base
 # - One of the SEMS modules will load CMake 3.4.x also,
 #   so this will pull in the SEMS cmake 3.10.3 version
 #   for Trilinos compatibility.
-module load sems-cmake/3.10.3
+module load sems-cmake/3.17.1
 
 # Using CMake and Ninja modules from the ATDM project space.
 # SEMS does not yet supply a recent enough version of CMake
@@ -41,5 +41,5 @@ export PATH=/projects/sierra/linux_rh7/install/Python/3.6.3/bin:${PATH}
 PATH=/projects/sierra/linux_rh7/install/Python/extras/bin:${PATH}
 export PYTHONPATH=/projects/sierra/linux_rh7/install/Python/extras/lib/python3.6/site-packages:${PYTHONPATH}
 export MANPATH=/projects/sierra/linux_rh7/install/Python/3.6.3/share/man:${MANPATH}
-unset PYTHONHOME 
+unset PYTHONHOME
 

--- a/cmake/std/sems/get_default_modules.sh
+++ b/cmake/std/sems/get_default_modules.sh
@@ -11,15 +11,15 @@ fi
 
 sems_mpi_and_version_default=sems-openmpi/1.10.1
 sems_python_and_version_default=sems-python/2.7.9
-sems_cmake_and_version_default=sems-cmake/3.12.2
+sems_cmake_and_version_default=sems-cmake/3.17.1
 sems_ninja_and_version_default=sems-ninja_fortran/1.8.2
 sems_git_and_version_default=sems-git/2.10.1
 sems_boost_and_version_default=sems-boost/1.63.0/base
-sems_zlib_and_version_default=sems-zlib/1.2.8/base 
-sems_hdf5_and_version_default=sems-hdf5/1.10.6/parallel 
+sems_zlib_and_version_default=sems-zlib/1.2.8/base
+sems_hdf5_and_version_default=sems-hdf5/1.10.6/parallel
 sems_netcdf_and_version_default=sems-netcdf/4.7.3/parallel
-sems_parmetis_and_version_default=sems-parmetis/4.0.3/parallel 
-sems_scotch_and_version_default=sems-scotch/6.0.3/nopthread_64bit_parallel   
+sems_parmetis_and_version_default=sems-parmetis/4.0.3/parallel
+sems_scotch_and_version_default=sems-scotch/6.0.3/nopthread_64bit_parallel
 sems_superlu_and_version_default=sems-superlu/4.3/base
 
 # NOTE: The above defaults are what are used for the standard CI dev env so


### PR DESCRIPTION
@trilinos/framework
This is a Work in Progress.

## Motivation
This is part of Issue #8520 to prepare the way for upgrading the minimum CMake required version to 17.0.0
* Part of #8520

## Testing
The PR updates will be tested through the usual PR driver.

The updates to the manual replication scripts will need to be tested manually.

This is due by January 29th, 2021.

## Requirements

### Update and Test PR Replication Scripts
These will need to be manually tested on an appropriate system.  See [Reproducing PR Testing Errors][1] for detailed instructions.
- [x] PullRequestClang10.0.0TestingEnv.sh
- ~~PullRequestClang7.0.1TestingEnv.sh~~
- ~~PullRequestClang9.0.0TestingEnv.sh~~
- [x] PullRequestCuda10.1.105TestingEnv.sh
- [x] PullRequestCuda9.2TestingEnv.sh
-  ~~PullRequestGCC4.8.4TestingEnv.sh~~
- ~~PullRequestGCC4.9.3TestingEnv.sh~~
- ~~PullRequestGCC4.9.3TestingEnvSERIAL.sh~~
- ~~PullRequestGCC7.2.0SerialTestingEnv.sh~~
- [x] PullRequestGCC7.2.0TestingEnv.sh
- [x] PullRequestGCC8.3.0TestingEnv.sh
- [x] PullRequestIntel17.0.1TestingEnv.sh
- [x] PullRequestIntel19.0.5TestingEnv.sh
- ~~PullRequestPython3TestingEnv.sh~~

Update: marked out .sh files that we don't use anymore for PR's.

[1]: https://github.com/trilinos/Trilinos/wiki/Reproducing-PR-Testing-Errors
