### PR TITLE
Switch to SSH github authentication for inner Trilinos repo to fix 'sems-rhel7' builds (ATDV-416)

### DIFF
--- a/cmake/ctest/drivers/atdm/sems-rhel7/local-driver.sh
+++ b/cmake/ctest/drivers/atdm/sems-rhel7/local-driver.sh
@@ -6,4 +6,8 @@ if [[ "${Trilinos_ENABLE_BUILD_STATS}" == "" ]] ; then
   export Trilinos_ENABLE_BUILD_STATS=ON
 fi
 
+if [[ "${Trilinos_REPOSITORY_LOCATION}" == "" ]] ; then
+  export Trilinos_REPOSITORY_LOCATION=git@github.com:trilinos/Trilinos.git
+fi
+
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ctest-s-driver.sh


### PR DESCRIPTION
This fixes the inner git fetch errors reported in [ATDV-416](https://sems-atlassian-srn.sandia.gov/browse/ATDV-416).

This fixes the ATDM Trilinos 'sems-rhel7' builds which have been offline for weeks.

## How was this tested?

I verified this manually by running:

* https://jenkins-srn.sandia.gov/view/Trilinos%20ATDM/job/Trilinos-atdm-sems-rhel7-clang-7.0.1-openmp-shared-release-debug/1/console

and by locally running:

```
$ cd /scratch/rabartl/Trilinos.base/BUILDS/ATDM/SEMS-RHEL7/CTEST_S/

$ ./ctest-s-local-test-driver.sh sems-rhel7-clang-7.0.1-openmp-shared-release  # Killed it after a few seconds!

$ grep Trilinos_REPOSITORY_LOCATION Trilinos-atdm-sems-rhel7-clang-7.0.1-openmp-shared-release/smart-jenkins-driver.out
-- ENV_Trilinos_REPOSITORY_LOCATION='git@github.com:trilinos/Trilinos.git'
-- Trilinos_REPOSITORY_LOCATION='git@github.com:trilinos/Trilinos.git'
```
