### PR TITLE
Ifpack2: Fix bugs in RILUK that not clearing old matrix values in reuse case and seg fault with empty matrix

### DIFF
--- a/packages/kokkos-kernels/src/sparse/impl/KokkosSparse_spiluk_symbolic_impl.hpp
+++ b/packages/kokkos-kernels/src/sparse/impl/KokkosSparse_spiluk_symbolic_impl.hpp
@@ -97,8 +97,10 @@ void level_sched ( IlukHandle& thandle,
     level_ptr(level_list(i)-1) += 1;
   }
 
-  for ( size_type i = nlevels-1; i > 0; --i ) {
-    level_ptr(i) = level_ptr(i-1);
+  if (nlevels>0) {//note: to avoid wrapping around to the max of size_t when nlevels = 0.
+    for ( size_type i = nlevels-1; i > 0; --i ) {
+      level_ptr(i) = level_ptr(i-1);
+    }
   }
 
   level_ptr(0) = 0;


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/ifpack2

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
This PR is to fix two bugs reported by @vbrunini: (i) the RILUK preconditioner not taking the new matrix values when preconditioner->compute() is called in the reuse case; (ii) seg fault when dealing with empty matrix

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Tests were performed on ```white``` with CTest. The two changes were confirmed fixing the bugs by @vbrunini .

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->