### PR TITLE
Sacado:  Fix two errors when configured without Kokkos or Teuchos.

### DIFF
--- a/packages/sacado/src/Sacado_DynamicArrayTraits.hpp
+++ b/packages/sacado/src/Sacado_DynamicArrayTraits.hpp
@@ -224,8 +224,8 @@ namespace Sacado {
 #if defined(HAVE_SACADO_KOKKOSCORE)
         if (m == 0)
           Kokkos::abort("Allocation failed.");
-      }
 #endif
+      }
 #endif
       return m;
     }

--- a/packages/sacado/test/GTestSuite/CMakeLists.txt
+++ b/packages/sacado/test/GTestSuite/CMakeLists.txt
@@ -30,17 +30,22 @@ SET(${PACKAGE_NAME}_TESTSUITE_SOURCES ${${PACKAGE_NAME}_TESTSUITE_SOURCES}
   TraitsTests.hpp
   TraitsTests.cpp
   LogicalSparseUnitTests.cpp
-  FadBLASUnitTests.hpp
-  RealDFadBLASUnitTests.cpp
-  RealDVFadBLASUnitTests.cpp
-  ComplexDFadBLASUnitTests.cpp
-  ComplexDVFadBLASUnitTests.cpp
-  RealDFadLAPACKUnitTests.cpp
   TayUnitTests.hpp
   TayUnitTests.cpp
   GTestUtils.hpp
   GTestSuite.cpp
   )
+
+IF (Sacado_ENABLE_TeuchosNumerics)
+  SET(${PACKAGE_NAME}_TESTSUITE_SOURCES ${${PACKAGE_NAME}_TESTSUITE_SOURCES}
+     FadBLASUnitTests.hpp
+     RealDFadBLASUnitTests.cpp
+     RealDVFadBLASUnitTests.cpp
+     ComplexDFadBLASUnitTests.cpp
+     ComplexDVFadBLASUnitTests.cpp
+     RealDFadLAPACKUnitTests.cpp
+     )
+ENDIF()
 
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   GTestSuite


### PR DESCRIPTION
Fixes build errors when compiled with Kokkos or Teuchos disabled