### PR TITLE
Intrepid2: resolve warnings under CUDA.

### DIFF
--- a/packages/intrepid2/src/Cell/Intrepid2_CellGeometry.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellGeometry.hpp
@@ -137,7 +137,6 @@ namespace Intrepid2
     CellGeometryType    cellGeometryType_;
     SubdivisionStrategy subdivisionStrategy_ = NO_SUBDIVISION;
     bool affine_; // if true, each cell has constant Jacobian across the cell
-    shards::CellTopology cellTopo_;
     Data<Orientation, ExecSpaceType> orientations_; // for grid types, this could have either a single entry or one matching numCellsPerGridCell().  For other types, it has as many entries as there are cells.
     
     // uniform grid data -- used for UNIFORM_GRID type
@@ -153,7 +152,6 @@ namespace Intrepid2
     ScalarView<int,ExecSpaceType>         cellToNodes_; // (C,N) -- N is the number of nodes per cell; values are global node ordinals
     ScalarView<PointScalar,ExecSpaceType> nodes_;       // (GN,D) or (C,N,D) -- GN is the number of global nodes; (C,N,D) used only if cellToNodes_ is empty.
     using BasisPtr = Teuchos::RCP< Basis<ExecSpaceType,PointScalar,PointScalar> >;
-    BasisPtr basisForNodes_; // basis used to define the cellToNodes_ map.
     
     unsigned numCells_        = 0;
     unsigned numNodesPerCell_ = 0;
@@ -191,6 +189,15 @@ namespace Intrepid2
     CellGeometry(Teuchos::RCP<Intrepid2::Basis<ExecSpaceType,PointScalar,PointScalar> > basisForNodes,
                  ScalarView<PointScalar,ExecSpaceType> cellNodes);
     
+    /** \brief  Copy constructor.
+        \param [in] cellGeometry - the object being copied.
+     */
+    KOKKOS_INLINE_FUNCTION CellGeometry(const CellGeometry &cellGeometry);
+    
+    /** \brief  Destructor.
+    */
+    KOKKOS_INLINE_FUNCTION ~CellGeometry();
+    
     //! Returns true if Jacobian is constant within each cell
     KOKKOS_INLINE_FUNCTION
     bool affine() const;
@@ -213,7 +220,7 @@ namespace Intrepid2
     BasisPtr basisForNodes() const;
     
     //! The shards CellTopology for each cell within the CellGeometry object.  Note that this is always a lowest-order CellTopology, even for higher-order curvilinear geometry.  Higher-order geometry for CellGeometry is expressed in terms of the basis returned by basisForNodes().
-    shards::CellTopology cellTopology() const;
+    const shards::CellTopology & cellTopology() const;
     
     //! Indicates the type of geometric variation from one cell to the next.  If all cells are known to have the same geometry, returns CONSTANT.
     //! Returns CONSTANT for uniform grids with no subdivisions, MODULAR for uniform grids with subdivisions, GENERAL for all others.

--- a/packages/intrepid2/src/Shared/Intrepid2_Data.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_Data.hpp
@@ -53,8 +53,7 @@ namespace Intrepid2 {
   {
     const int myNominalExtent    = myData.nominalExtent;
 #ifdef HAVE_INTREPID2_DEBUG
-    const int otherNominalExtent = otherData.nominalExtent;
-    INTREPID2_TEST_FOR_EXCEPTION_DEVICE_SAFE(myNominalExtent != otherNominalExtent, std::invalid_argument, "both Data objects must match in their nominal extent in the specified dimension");
+    INTREPID2_TEST_FOR_EXCEPTION_DEVICE_SAFE(myNominalExtent != otherData.nominalExtent, std::invalid_argument, "both Data objects must match in their nominal extent in the specified dimension");
 #endif
     const DataVariationType & myVariation    = myData.variationType;
     const DataVariationType & otherVariation = otherData.variationType;
@@ -246,7 +245,7 @@ namespace Intrepid2 {
       // check that rank is compatible with the claimed extents:
       for (int d=rank_; d<7; d++)
       {
-        INTREPID2_TEST_FOR_EXCEPTION_DEVICE_SAFE(extents_[d] > 1, std::invalid_argument, "Nominal extents may not be > 1 in dimensions beyond the rank of the container");
+        INTREPID2_TEST_FOR_EXCEPTION(extents_[d] > 1, std::invalid_argument, "Nominal extents may not be > 1 in dimensions beyond the rank of the container");
       }
       
       // by default, this should initialize with zero -- no need to deep_copy a 0 into it
@@ -279,7 +278,7 @@ namespace Intrepid2 {
             const int logicalExtent = extents_[i];
             const int modulus = dataExtent;
             
-            INTREPID2_TEST_FOR_EXCEPTION_DEVICE_SAFE( dataExtent * (logicalExtent / dataExtent) != logicalExtent, std::invalid_argument, "data extent must evenly divide logical extent");
+            INTREPID2_TEST_FOR_EXCEPTION( dataExtent * (logicalExtent / dataExtent) != logicalExtent, std::invalid_argument, "data extent must evenly divide logical extent");
             
             variationModulus_[i] = modulus;
           }
@@ -303,17 +302,17 @@ namespace Intrepid2 {
 #ifdef HAVE_INTREPID2_DEBUG
             const int numDiagonalEntries    = logicalExtent - (blockPlusDiagonalLastNonDiagonal_ + 1);
             const int expectedDataExtent = numNondiagonalEntries + numDiagonalEntries;
-            INTREPID2_TEST_FOR_EXCEPTION_DEVICE_SAFE(dataExtent != expectedDataExtent, std::invalid_argument, ("BLOCK_PLUS_DIAGONAL data extent of " + std::to_string(dataExtent) + " does not match expected based on blockPlusDiagonalLastNonDiagonal setting of " + std::to_string(blockPlusDiagonalLastNonDiagonal_)).c_str());
+            INTREPID2_TEST_FOR_EXCEPTION(dataExtent != expectedDataExtent, std::invalid_argument, ("BLOCK_PLUS_DIAGONAL data extent of " + std::to_string(dataExtent) + " does not match expected based on blockPlusDiagonalLastNonDiagonal setting of " + std::to_string(blockPlusDiagonalLastNonDiagonal_)).c_str());
 #endif
             
             activeDims_[numActiveDims_] = i;
             numActiveDims_++;
           }
           variationModulus_[i] = getUnderlyingViewExtent(numActiveDims_);
-          INTREPID2_TEST_FOR_EXCEPTION_DEVICE_SAFE(variationType_[i+1] != BLOCK_PLUS_DIAGONAL, std::invalid_argument, "BLOCK_PLUS_DIAGONAL ranks must be contiguous");
+          INTREPID2_TEST_FOR_EXCEPTION(variationType_[i+1] != BLOCK_PLUS_DIAGONAL, std::invalid_argument, "BLOCK_PLUS_DIAGONAL ranks must be contiguous");
           i++; // skip over the next BLOCK_PLUS_DIAGONAL
           variationModulus_[i] = 1; // trivial modulus (should not ever be used)
-          INTREPID2_TEST_FOR_EXCEPTION_DEVICE_SAFE(blockPlusDiagonalCount > 1, std::invalid_argument, "BLOCK_PLUS_DIAGONAL can only apply to two ranks");
+          INTREPID2_TEST_FOR_EXCEPTION(blockPlusDiagonalCount > 1, std::invalid_argument, "BLOCK_PLUS_DIAGONAL can only apply to two ranks");
         }
         else // CONSTANT
         {
@@ -338,7 +337,7 @@ namespace Intrepid2 {
       }
       for (int d=0; d<7; d++)
       {
-        INTREPID2_TEST_FOR_EXCEPTION_DEVICE_SAFE(variationModulus_[d] == 0, std::logic_error, "variationModulus should not ever be 0");
+        INTREPID2_TEST_FOR_EXCEPTION(variationModulus_[d] == 0, std::logic_error, "variationModulus should not ever be 0");
       }
     }
     


### PR DESCRIPTION
Intrepid2: resolve warnings under CUDA.

As part of the warning resolution, fixed some issues with the safety of using CellGeometry objects on device under CUDA.

@trilinos/intrepid2 

## Motivation
Some warnings issued during CUDA debug builds (see #8554) indicated that lambda captures, etc. of CellGeometry as implemented could lead to indeterminate behavior on device, due to host code being called during construction and destruction of the device copy of the objects.  This PR resolves that by isolating the host-only "members" of CellGeometry in a separate, static class.

## Testing
Tested by the CellGeometry group of unit tests in Intrepid2, among other unit tests.