### PR TITLE
Add single-reduce MGS & CGS2 options into GmresSingleReduce

### DIFF
--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_Gmres.hpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_Gmres.hpp
@@ -312,7 +312,7 @@ public:
     this->input_.maxOrthoSteps = maxOrthoSteps;
   }
 
-private:
+protected:
   //! Create Belos::OrthoManager instance.
   void
   setOrthogonalizer (const std::string& ortho)
@@ -339,19 +339,21 @@ private:
     }
   }
 
+private:
   int
   projectAndNormalize (const int n,
-                       const SolverInput<SC>& /* input */,
+                       const SolverInput<SC>& input,
                        MV& Q,
                        dense_matrix_type& H,
                        dense_matrix_type& /* WORK */)
   {
-    return this->projectAndNormalizeBelosOrthoManager (n, Q, H);
+    return this->projectAndNormalizeBelosOrthoManager (n, Q, H, input);
   }
 
   // ! Apply the orthogonalization using Belos' OrthoManager
   int
-  projectAndNormalizeBelosOrthoManager (int n, MV &Q, dense_matrix_type &H)
+  projectAndNormalizeBelosOrthoManager (int n, MV &Q, dense_matrix_type &H,
+                                        const SolverInput<SC>& input)
   {
     using Teuchos::RCP;
     using Teuchos::rcp;
@@ -369,7 +371,7 @@ private:
     auto r_new = rcp (new dense_matrix_type (Teuchos::View, H, 1, 1, n+1, n));
 
     if (ortho_.get () == nullptr) {
-      setOrthogonalizer (this->input_.orthoType);
+      setOrthogonalizer (input.orthoType);
     }
     TEUCHOS_TEST_FOR_EXCEPTION
       (ortho_.get () == nullptr, std::logic_error, "Gmres: Failed to create "

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_Gmres.hpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_Gmres.hpp
@@ -543,7 +543,7 @@ protected:
     std::vector<real_type> cs (restart);
     std::vector<SC> sn (restart);
 
-    #define HAVE_TPETRA_DEBUG
+    //#define HAVE_TPETRA_DEBUG
     #ifdef HAVE_TPETRA_DEBUG
     dense_matrix_type H2 (restart+1, restart,   true);
     dense_matrix_type H3 (restart+1, restart,   true);

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresSingleReduce.hpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresSingleReduce.hpp
@@ -643,6 +643,9 @@ private:
                                                  b_norm, input);
           }
           else {
+            if (outPtr != nullptr) {
+              *outPtr << " > warning: H(" << check+1 << ", " << check << ") = zero" << endl;
+            }
             H(check+1, check) = zero;
             metric = STM::zero ();
           }
@@ -725,6 +728,10 @@ private:
         // Otherwise continue the inner-iteration.
         if (iter >= restart || H(iter,iter-1) == zero) { // done with restart cycyle, or probably lost ortho
           // Initialize starting vector for restart
+          if (outPtr != nullptr && H(iter,iter-1) == zero) {
+            *outPtr << " > restarting with explicit residual vector"
+                    << " since H(" << iter << ", " << iter-1 << ") = zero" << endl;
+          }
           iter = 0;
           P = * (Q.getVectorNonConst (0));
           if (input.precoSide == "left") {

--- a/packages/belos/tpetra/test/Native/CMakeLists.txt
+++ b/packages/belos/tpetra/test/Native/CMakeLists.txt
@@ -92,7 +92,31 @@ TRIBITS_ADD_TEST(
 TRIBITS_ADD_TEST(
   Tpetra_Native_solvers_nonsymm_matrix
   NAME Tpetra_Native_GMRES_SINGLE_REDUCE_nonsymm_matrix
-  ARGS "--solver=\"TPETRA GMRES SINGLE REDUCE\" --restartLength=10"
+  ARGS "--solver=\"TPETRA GMRES SINGLE REDUCE\" --restartLength=10 --noRitzValues"
+  COMM serial mpi
+  STANDARD_PASS_OUTPUT
+  )
+
+TRIBITS_ADD_TEST(
+  Tpetra_Native_solvers_nonsymm_matrix
+  NAME Tpetra_Native_GMRES_SINGLE_REDUCE_nonsymm_matrix_cgs
+  ARGS "--solver=\"TPETRA GMRES SINGLE REDUCE\" --restartLength=10 --ortho=CGS --noRitzValues"
+  COMM serial mpi
+  STANDARD_PASS_OUTPUT
+  )
+
+TRIBITS_ADD_TEST(
+  Tpetra_Native_solvers_nonsymm_matrix
+  NAME Tpetra_Native_GMRES_SINGLE_REDUCE_nonsymm_matrix_cgs2
+  ARGS "--solver=\"TPETRA GMRES SINGLE REDUCE\" --restartLength=10 --ortho=CGS2 --noRitzValues"
+  COMM serial mpi
+  STANDARD_PASS_OUTPUT
+  )
+
+TRIBITS_ADD_TEST(
+  Tpetra_Native_solvers_nonsymm_matrix
+  NAME Tpetra_Native_GMRES_SINGLE_REDUCE_nonsymm_matrix_mgs
+  ARGS "--solver=\"TPETRA GMRES SINGLE REDUCE\" --restartLength=10 --ortho=MGS --noRitzValues"
   COMM serial mpi
   STANDARD_PASS_OUTPUT
   )

--- a/packages/belos/tpetra/test/Native/CMakeLists.txt
+++ b/packages/belos/tpetra/test/Native/CMakeLists.txt
@@ -99,6 +99,14 @@ TRIBITS_ADD_TEST(
 
 TRIBITS_ADD_TEST(
   Tpetra_Native_solvers_nonsymm_matrix
+  NAME Tpetra_Native_GMRES_SINGLE_REDUCE_nonsymm_matrix_cgs_newton
+  ARGS "--solver=\"TPETRA GMRES SINGLE REDUCE\" --restartLength=10 --ortho=CGS"
+  COMM serial mpi
+  STANDARD_PASS_OUTPUT
+  )
+
+TRIBITS_ADD_TEST(
+  Tpetra_Native_solvers_nonsymm_matrix
   NAME Tpetra_Native_GMRES_SINGLE_REDUCE_nonsymm_matrix_cgs
   ARGS "--solver=\"TPETRA GMRES SINGLE REDUCE\" --restartLength=10 --ortho=CGS --noRitzValues"
   COMM serial mpi

--- a/packages/belos/tpetra/test/Native/nonsymm_matrix.cpp
+++ b/packages/belos/tpetra/test/Native/nonsymm_matrix.cpp
@@ -21,6 +21,7 @@ struct CommandLineOptions {
   int maxAllowedNumIters {30};
   int maxNumIters {100};
   int restartLength {30};
+  std::string orthoType {"ICGS"};
   int stepSize {1};
   bool useCholQR {false};
   bool useCholQR2 {false};
@@ -53,6 +54,8 @@ TEUCHOS_STATIC_SETUP()
                  "Maximum number of iterations per restart cycle.  "
                  "This corresponds to the standard Belos parameter "
                  "\"Num Blocks\".");
+  clp.setOption ("ortho", &commandLineOptions.orthoType,
+                 "Name of the orthogonalization procedure");
   clp.setOption ("stepSize", &commandLineOptions.stepSize,
                  "Step size; only applies to algorithms that take it.");
   clp.setOption ("useCholQR", "noCholQR", &commandLineOptions.useCholQR,
@@ -232,11 +235,14 @@ testSolver (Teuchos::FancyOStream& out,
   params->set ("Verbosity", verbose ? 1 : 0);
   params->set ("Maximum Iterations", commandLineOptions.maxNumIters);
   params->set ("Num Blocks", commandLineOptions.restartLength);
+  params->set ("Orthogonalization", commandLineOptions.orthoType);
   if (solverName == "TPETRA GMRES S-STEP") {
     params->set ("Step Size", commandLineOptions.stepSize);
-    params->set ("Compute Ritz Values", commandLineOptions.computeRitzValues);
     params->set ("CholeskyQR",  commandLineOptions.useCholQR);
     params->set ("CholeskyQR2", commandLineOptions.useCholQR2);
+  }
+  if (solverName == "TPETRA GMRES S-STEP" || solverName == "TPETRA GMRES SINGLE REDUCE") {
+    params->set ("Compute Ritz Values", commandLineOptions.computeRitzValues);
   }
   try {
     solver->setParameters (params);


### PR DESCRIPTION

@trilinos/belos 

## Motivation
This PR adds the single-reduce MGS & CGS2 options into GmresSingleReduce under Belos "Native Tpetra" solvers

## Related Issues

## Stakeholder Feedback

## Testing
Added new options into ctest under belos/tpetra/Native, and ran ctest on blake
