### PR TITLE
Tpetra: fix warning about unused local typedef

### DIFF
--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -2101,7 +2101,6 @@ namespace Tpetra {
   dot (const MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& A,
        const Teuchos::ArrayView<dot_type>& dots) const
   {
-    typedef Tpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> MV;
     const char tfecfFuncName[] = "dot: ";
     ::Tpetra::Details::ProfilingRegion region ("Tpetra::MV::dot (Teuchos::ArrayView)");
 


### PR DESCRIPTION
@trilinos/tpetra 

## Motivation

Fix a compiler warning about an unused local `typedef` of `MultiVector`

<!--- 

## Stakeholder Feedback
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing

Build and existing tests pass locally. No new tests necessary, as no functionality has been added.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->