### PR TITLE
Added code which rounds down the vector length

### DIFF
--- a/packages/panzer/disc-fe/src/Panzer_HierarchicParallelism.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_HierarchicParallelism.cpp
@@ -77,9 +77,16 @@ namespace panzer {
   }
   void HP::overrideSizes(const int& in_team_size,
 			 const int& in_vector_size,
-			 const int& in_fad_vector_size)
+			 const int& in_fad_vector_size,
+                         const bool force_override)
   {
     use_auto_team_size_ = false;
+    if ( force_override ) {
+      team_size_=in_team_size;
+      vector_size_=in_vector_size;
+      fad_vector_size_=in_fad_vector_size;
+      return;
+    }
 
     Kokkos::TeamPolicy<PHX::Device> policy(1, Kokkos::AUTO);
     auto blank_functor = KOKKOS_LAMBDA ( const Kokkos::TeamPolicy<PHX::exec_space>::member_type) {};

--- a/packages/panzer/disc-fe/src/Panzer_HierarchicParallelism.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_HierarchicParallelism.cpp
@@ -82,7 +82,7 @@ namespace panzer {
     use_auto_team_size_ = false;
 
     Kokkos::TeamPolicy<PHX::Device> policy(1, Kokkos::AUTO);
-    auto blank_functor = [] ( const Kokkos::TeamPolicy<PHX::exec_space>::member_type) {};
+    auto blank_functor = KOKKOS_LAMBDA ( const Kokkos::TeamPolicy<PHX::exec_space>::member_type) {};
 
     int team_size_max = std::min(in_team_size, policy.team_size_max(blank_functor, Kokkos::ParallelForTag()));
     team_size_=roundDownToPowerOfTwo(team_size_max);

--- a/packages/panzer/disc-fe/src/Panzer_HierarchicParallelism.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_HierarchicParallelism.cpp
@@ -65,14 +65,31 @@ namespace panzer {
     return hp;
   }
 
+  namespace {
+    int roundDownToPowerOfTwo(int in) {
+      int out=1;
+      while (in > 1) {
+        out *= 2;
+        in /= 2;
+      }
+      return out;
+    }
+  }
   void HP::overrideSizes(const int& in_team_size,
 			 const int& in_vector_size,
 			 const int& in_fad_vector_size)
   {
     use_auto_team_size_ = false;
-    team_size_ = in_team_size;
-    vector_size_ = in_vector_size;
-    fad_vector_size_ = in_fad_vector_size;
+
+    Kokkos::TeamPolicy<PHX::Device> policy(1, Kokkos::AUTO);
+    auto blank_functor = [] ( const Kokkos::TeamPolicy<PHX::exec_space>::member_type) {};
+
+    int team_size_max = std::min(in_team_size, policy.team_size_max(blank_functor, Kokkos::ParallelForTag()));
+    team_size_=roundDownToPowerOfTwo(team_size_max);
+
+    int vec_size_max = policy.vector_length_max();
+    vector_size_ = roundDownToPowerOfTwo(std::min(vec_size_max, in_vector_size));
+    fad_vector_size_ = roundDownToPowerOfTwo(std::min(vec_size_max, in_fad_vector_size));
   }
 
   void HP::setUseSharedMemory(const bool& in_use_shared_memory,

--- a/packages/panzer/disc-fe/src/Panzer_HierarchicParallelism.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_HierarchicParallelism.hpp
@@ -63,7 +63,14 @@ namespace panzer {
     /// Return singleton instance of this class.
     static HP& inst();
 
-    /// Allows the user to override default sizes.
+    /** Allows the user to override the Kokkos default team and vector
+        sizes for kernel dispatch. The values will be capped by
+        hardware limits and rounded down to the nearest power of two.
+
+        @param team_size Team size requested for hierarchic kernel
+        @param vector_size Vector size requested for hierarchic kernel for non-FAD scalar types
+        @param fad_vector_size Vector size requested for hierarchic kernel for FAD scalar types
+    */
     void overrideSizes(const int& team_size,
 		       const int& vector_size,
 		       const int& fad_vector_size);

--- a/packages/panzer/disc-fe/src/Panzer_HierarchicParallelism.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_HierarchicParallelism.hpp
@@ -67,13 +67,18 @@ namespace panzer {
         sizes for kernel dispatch. The values will be capped by
         hardware limits and rounded down to the nearest power of two.
 
+        The final variable will force the values input to be set explicity and
+        not round down to the nearest power of two or hardware maximum.
+
         @param team_size Team size requested for hierarchic kernel
         @param vector_size Vector size requested for hierarchic kernel for non-FAD scalar types
         @param fad_vector_size Vector size requested for hierarchic kernel for FAD scalar types
+        @param force_override_safety Ignore the power of two and other checks
     */
     void overrideSizes(const int& team_size,
 		       const int& vector_size,
-		       const int& fad_vector_size);
+		       const int& fad_vector_size, 
+                       const bool force_override_safety=false);
 
     /** \brief Returns the vector size. Specialized for AD scalar types.
 


### PR DESCRIPTION
@rppawlo this is so you can use team and vector size of 123, 321 and it will round down and limit by max values.