### PR TITLE
Piro: add HessianScaledThyraVector to ROL adapters and use it in Piro_PerformAnalysis

### DIFF
--- a/packages/piro/test/CMakeLists.txt
+++ b/packages/piro/test/CMakeLists.txt
@@ -116,6 +116,8 @@ IF (Piro_ENABLE_NOX)
       Main_AnalysisDriver_Tpetra.cpp
       MockModelEval_A_Tpetra.cpp
       MockModelEval_A_Tpetra.hpp
+      MockModelEval_B_Tpetra.cpp
+      MockModelEval_B_Tpetra.hpp
     NUM_MPI_PROCS 1-4
     ARGS -v
     PASS_REGULAR_EXPRESSION "TEST PASSED"

--- a/packages/piro/test/Main_AnalysisDriver_Tpetra.cpp
+++ b/packages/piro/test/Main_AnalysisDriver_Tpetra.cpp
@@ -44,6 +44,7 @@
 #include <string>
 
 #include "MockModelEval_A_Tpetra.hpp"
+#include "MockModelEval_B_Tpetra.hpp"
 //#include "ObserveSolution_Epetra.hpp"
 
 #include "Piro_SolverFactory.hpp"
@@ -122,61 +123,77 @@ int main(int argc, char *argv[]) {
 
     try {
 
-      // Create (1) a Model Evaluator and (2) a ParameterList
-      const RCP<Thyra::ModelEvaluator<double>> Model = rcp(new MockModelEval_A_Tpetra(appComm));
+      std::vector<std::string> mockModels = {"MockModelEval_A_Tpetra", "MockModelEval_B_Tpetra"};
+      for (auto mockModel : mockModels) {
 
-      // BEGIN Builder
-      const RCP<Teuchos::ParameterList> appParams = rcp(new Teuchos::ParameterList("Application Parameters"));
-      Teuchos::updateParametersFromXmlFile(inputFile, Teuchos::ptr(appParams.get()));
+        // Create (1) a Model Evaluator and (2) a ParameterList
+        RCP<Thyra::ModelEvaluator<double>> Model;
+        if (mockModel=="MockModelEval_A_Tpetra")
+          Model = rcp(new MockModelEval_A_Tpetra(appComm));
+        if (mockModel=="MockModelEval_B_Tpetra")
+          Model = rcp(new MockModelEval_B_Tpetra(appComm));
 
-      const RCP<Teuchos::ParameterList>  piroParams = Teuchos::sublist(appParams,"Piro");
-      Teuchos::ParameterList& analysisParams = piroParams->sublist("Analysis");
+        // BEGIN Builder
+        const RCP<Teuchos::ParameterList> appParams = rcp(new Teuchos::ParameterList("Application Parameters"));
+        Teuchos::updateParametersFromXmlFile(inputFile, Teuchos::ptr(appParams.get()));
 
-
-      Stratimikos::DefaultLinearSolverBuilder linearSolverBuilder;
-
-#ifdef HAVE_PIRO_IFPACK2
-      typedef Thyra::PreconditionerFactoryBase<double>              Base;
-      typedef Thyra::Ifpack2PreconditionerFactory<Tpetra_CrsMatrix> Impl;
-      linearSolverBuilder.setPreconditioningStrategyFactory(
-          Teuchos::abstractFactoryStd<Base, Impl>(), "Ifpack2");
-#endif
-
-#ifdef HAVE_PIRO_MUELU
-      using local_ordinal_type = Tpetra::Map<>::local_ordinal_type;
-      using global_ordinal_type = Tpetra::Map<>::global_ordinal_type;
-      Stratimikos::enableMueLu<local_ordinal_type, global_ordinal_type>(linearSolverBuilder);
-#endif
-
-      const Teuchos::RCP<Teuchos::ParameterList> stratList = Piro::extractStratimikosParams(piroParams);
-      linearSolverBuilder.setParameterList(stratList);
+        const RCP<Teuchos::ParameterList>  piroParams = Teuchos::sublist(appParams,"Piro");
+        Teuchos::ParameterList& analysisParams = piroParams->sublist("Analysis");
 
 
-      const RCP<Thyra::LinearOpWithSolveFactoryBase<double>> lowsFactory =
-          createLinearSolveStrategy(linearSolverBuilder);
+        Stratimikos::DefaultLinearSolverBuilder linearSolverBuilder;
 
-      RCP<Thyra::ModelEvaluator<double>> ModelWithSolve = rcp(new Thyra::DefaultModelEvaluatorWithSolveFactory<double>(
-          Model, lowsFactory));
+  #ifdef HAVE_PIRO_IFPACK2
+        typedef Thyra::PreconditionerFactoryBase<double>              Base;
+        typedef Thyra::Ifpack2PreconditionerFactory<Tpetra_CrsMatrix> Impl;
+        linearSolverBuilder.setPreconditioningStrategyFactory(
+            Teuchos::abstractFactoryStd<Base, Impl>(), "Ifpack2");
+  #endif
 
-      const RCP<Thyra::ModelEvaluatorDefaultBase<double>> piro = solverFactory.createSolver(piroParams, ModelWithSolve);
+  #ifdef HAVE_PIRO_MUELU
+        using local_ordinal_type = Tpetra::Map<>::local_ordinal_type;
+        using global_ordinal_type = Tpetra::Map<>::global_ordinal_type;
+        Stratimikos::enableMueLu<local_ordinal_type, global_ordinal_type>(linearSolverBuilder);
+  #endif
 
-      // Call the analysis routine
-      RCP<Thyra::VectorBase<double>> p;
-      status = Piro::PerformAnalysis(*piro, analysisParams, p);
+        const Teuchos::RCP<Teuchos::ParameterList> stratList = Piro::extractStratimikosParams(piroParams);
+        linearSolverBuilder.setParameterList(stratList);
 
-      if (Teuchos::nonnull(p)) { //p might be null if the package ROL is not enabled
-        Thyra::DetachedVectorView<double> p_view(p);
-        double p_exact[2] = {1,3};
-        double tol = 1e-5;
 
-        double l2_diff = std::sqrt(std::pow(p_view(0)-p_exact[0],2) + std::pow(p_view(1)-p_exact[1],2));
-        if(l2_diff > tol) {
-          status+=100;
-          if (Proc==0) {
-            std::cout << "\nPiro_AnalysisDrvier:  Optimum parameter values are: {"
-                <<  p_exact[0] << ", " << p_exact[1] << "}, but computed values are: {"
-                <<  p_view(0) << ", " << p_view(1) << "}." <<
-                "\n                      Difference in l2 norm: " << l2_diff << " > tol: " << tol <<   std::endl;
+        const RCP<Thyra::LinearOpWithSolveFactoryBase<double>> lowsFactory =
+            createLinearSolveStrategy(linearSolverBuilder);
+
+        RCP<Thyra::ModelEvaluator<double>> ModelWithSolve = rcp(new Thyra::DefaultModelEvaluatorWithSolveFactory<double>(
+            Model, lowsFactory));
+
+        const RCP<Thyra::ModelEvaluatorDefaultBase<double>> piro = solverFactory.createSolver(piroParams, ModelWithSolve);
+
+        // Call the analysis routine
+        RCP<Thyra::VectorBase<double>> p;
+        status = Piro::PerformAnalysis(*piro, analysisParams, p);
+
+        if (Teuchos::nonnull(p)) { //p might be null if the package ROL is not enabled
+          Thyra::DetachedVectorView<double> p_view(p);
+          double p_exact[2];
+          if (mockModel=="MockModelEval_A_Tpetra") {
+            p_exact[0] = 1;
+            p_exact[1] = 3;
+          }
+          if (mockModel=="MockModelEval_B_Tpetra") {
+            p_exact[0] = 6;
+            p_exact[1] = 4;
+          }
+          double tol = 1e-5;
+
+          double l2_diff = std::sqrt(std::pow(p_view(0)-p_exact[0],2) + std::pow(p_view(1)-p_exact[1],2));
+          if(l2_diff > tol) {
+            status+=100;
+            if (Proc==0) {
+              std::cout << "\nPiro_AnalysisDrvier:  Optimum parameter values are: {"
+                  <<  p_exact[0] << ", " << p_exact[1] << "}, but computed values are: {"
+                  <<  p_view(0) << ", " << p_view(1) << "}." <<
+                  "\n                      Difference in l2 norm: " << l2_diff << " > tol: " << tol <<   std::endl;
+            }
           }
         }
       }

--- a/packages/piro/test/MockModelEval_A_Tpetra.cpp
+++ b/packages/piro/test/MockModelEval_A_Tpetra.cpp
@@ -88,12 +88,26 @@ MockModelEval_A_Tpetra::MockModelEval_A_Tpetra(const Teuchos::RCP<const Teuchos:
 
     //set up jacobian graph
     crs_graph = rcp(new Tpetra_CrsGraph(x_map, vecLength));
-    std::vector<typename Tpetra_CrsGraph::global_ordinal_type> indices(vecLength);
-    for (int i=0; i<vecLength; i++) indices[i]=i;
-    const int nodeNumElements = x_map->getNodeNumElements();
-    for (int i=0; i<nodeNumElements; i++)
-      crs_graph->insertGlobalIndices(x_map->getGlobalElement(i), vecLength, &indices[0]);
+    {
+      std::vector<typename Tpetra_CrsGraph::global_ordinal_type> indices(vecLength);
+      for (int i=0; i<vecLength; i++) indices[i]=i;
+      const int nodeNumElements = x_map->getNodeNumElements();
+      for (int i=0; i<nodeNumElements; i++)
+        crs_graph->insertGlobalIndices(x_map->getGlobalElement(i), vecLength, &indices[0]);
+    }
     crs_graph->fillComplete();
+
+    //set up hessian graph
+    hess_crs_graph = rcp(new Tpetra_CrsGraph(p_map, numParameters));
+    if (comm->getRank() == 0)
+    {
+      std::vector<typename Tpetra_CrsGraph::global_ordinal_type> indices(numParameters);
+      for (int i=0; i<numParameters; i++) indices[i]=i;
+      const int nodeNumElements = p_map->getNodeNumElements();
+      for (int i=0; i<nodeNumElements; i++)
+        hess_crs_graph->insertGlobalIndices(p_map->getGlobalElement(i), numParameters, &indices[0]);
+    }
+    hess_crs_graph->fillComplete();
 
     // Setup nominal values, lower and upper bounds
     nominalValues = this->createInArgsImpl();
@@ -196,6 +210,14 @@ MockModelEval_A_Tpetra::get_W_factory() const
   return Teuchos::null;
 }
 
+Teuchos::RCP<Thyra::LinearOpBase<double>>
+MockModelEval_A_Tpetra::create_hess_g_pp( int j, int l1, int l2 ) const
+{
+  const Teuchos::RCP<Tpetra_Operator> H =
+      Teuchos::rcp(new Tpetra_CrsMatrix(hess_crs_graph));
+  return Thyra::createLinearOp(H);
+}
+
 Thyra::ModelEvaluatorBase::InArgs<double>
 MockModelEval_A_Tpetra::getNominalValues() const
 {
@@ -281,6 +303,7 @@ void MockModelEval_A_Tpetra::evalModelImpl(
 
   int vecLength = x_in->getGlobalLength();
   int myVecLength = x_in->getLocalLength();
+  int myParametersLength = p_map->getNodeNumElements();
 
   // Parse OutArgs
 
@@ -439,6 +462,27 @@ void MockModelEval_A_Tpetra::evalModelImpl(
     }
     if(!Teuchos::nonnull(x_dot_in))
       W_out_crs->fillComplete();
+  }
+
+  const Teuchos::RCP<Tpetra_Operator> H_pp_out =
+      Teuchos::nonnull(outArgs.get_hess_g_pp(0,0,0)) ?
+          ConverterT::getTpetraOperator(outArgs.get_hess_g_pp(0,0,0)) :
+          Teuchos::null;
+
+  if (H_pp_out != Teuchos::null) {
+    Teuchos::RCP<Tpetra_CrsMatrix> H_pp_out_crs =
+      Teuchos::rcp_dynamic_cast<Tpetra_CrsMatrix>(H_pp_out, true);
+    H_pp_out_crs->resumeFill();
+    H_pp_out_crs->setAllToScalar(0.0);
+
+    if (comm->getRank() == 0) {
+      std::vector<double> vals = {2, 1};
+      std::vector<typename Tpetra_CrsGraph::global_ordinal_type> indices = {0, 1};
+      H_pp_out_crs->replaceGlobalValues(0, 2, &vals[0], &indices[0]);
+      vals[0] = 1;
+      H_pp_out_crs->replaceGlobalValues(1, 2, &vals[0], &indices[0]);
+    }
+    H_pp_out_crs->fillComplete();
   }
 
   if (Teuchos::nonnull(dfdp_out)) {

--- a/packages/piro/test/MockModelEval_A_Tpetra.hpp
+++ b/packages/piro/test/MockModelEval_A_Tpetra.hpp
@@ -114,6 +114,10 @@ class MockModelEval_A_Tpetra
   get_W_factory() const;
 
   /** \brief . */
+  Teuchos::RCP<Thyra::LinearOpBase<double>>
+  create_hess_g_pp( int j, int l1, int l2 ) const;
+
+  /** \brief . */
   Thyra::ModelEvaluatorBase::InArgs<double>
   createInArgs() const;
 
@@ -166,6 +170,7 @@ class MockModelEval_A_Tpetra
   Teuchos::RCP<const Tpetra_Map> p_map;
   Teuchos::RCP<const Tpetra_Map> g_map;
   Teuchos::RCP<Tpetra_CrsGraph> crs_graph;
+  Teuchos::RCP<Tpetra_CrsGraph> hess_crs_graph;
   Teuchos::RCP<const Teuchos::Comm<int> > comm;
 
   Teuchos::RCP<Tpetra_Vector> p_vec;

--- a/packages/piro/test/MockModelEval_B_Tpetra.cpp
+++ b/packages/piro/test/MockModelEval_B_Tpetra.cpp
@@ -40,14 +40,14 @@
 // ************************************************************************
 // @HEADER
 
-#include "MockModelEval_A_Tpetra.hpp"
+#include "MockModelEval_B_Tpetra.hpp"
 
 #include <iostream>
 
 using Teuchos::RCP;
 using Teuchos::rcp;
 
-MockModelEval_A_Tpetra::MockModelEval_A_Tpetra(const Teuchos::RCP<const Teuchos::Comm<int> >  appComm)
+MockModelEval_B_Tpetra::MockModelEval_B_Tpetra(const Teuchos::RCP<const Teuchos::Comm<int> >  appComm)
 {
     comm = appComm;
 
@@ -122,12 +122,12 @@ MockModelEval_A_Tpetra::MockModelEval_A_Tpetra(const Teuchos::RCP<const Teuchos:
     upperBounds.set_p(0, Thyra::createVector(p_up, p_space));
 }
 
-MockModelEval_A_Tpetra::~MockModelEval_A_Tpetra()
+MockModelEval_B_Tpetra::~MockModelEval_B_Tpetra()
 {
 }
 
 Teuchos::RCP<const Thyra::VectorSpaceBase<double>>
-MockModelEval_A_Tpetra::get_x_space() const
+MockModelEval_B_Tpetra::get_x_space() const
 {
   Teuchos::RCP<const Thyra::VectorSpaceBase<double>> x_space =
       Thyra::createVectorSpace<double>(x_map);
@@ -135,7 +135,7 @@ MockModelEval_A_Tpetra::get_x_space() const
 }
 
 Teuchos::RCP<const Thyra::VectorSpaceBase<double>>
-MockModelEval_A_Tpetra::get_f_space() const
+MockModelEval_B_Tpetra::get_f_space() const
 {
   Teuchos::RCP<const Thyra::VectorSpaceBase<double>> f_space =
       Thyra::createVectorSpace<double>(x_map);
@@ -143,7 +143,7 @@ MockModelEval_A_Tpetra::get_f_space() const
 }
 
 Teuchos::RCP<const Thyra::VectorSpaceBase<double>>
-MockModelEval_A_Tpetra::get_p_space(int l) const
+MockModelEval_B_Tpetra::get_p_space(int l) const
 {
   TEUCHOS_TEST_FOR_EXCEPTION(l != 0, std::logic_error,
                      std::endl <<
@@ -156,11 +156,11 @@ MockModelEval_A_Tpetra::get_p_space(int l) const
 }
 
 Teuchos::RCP<const Thyra::VectorSpaceBase<double>>
-MockModelEval_A_Tpetra::get_g_space(int l) const
+MockModelEval_B_Tpetra::get_g_space(int l) const
 {
   TEUCHOS_TEST_FOR_EXCEPTION(l != 0, std::logic_error,
                      std::endl <<
-                     "Error!  MockModelEval_A_Tpetra::get_g_map() only " <<
+                     "Error!  MockModelEval_B_Tpetra::get_g_map() only " <<
                      " supports 1 parameter vector.  Supplied index l = " <<
                      l << std::endl);
   Teuchos::RCP<const Thyra::VectorSpaceBase<double>> g_space =
@@ -168,7 +168,7 @@ MockModelEval_A_Tpetra::get_g_space(int l) const
   return g_space;
 }
 
-RCP<const  Teuchos::Array<std::string> > MockModelEval_A_Tpetra::get_p_names(int l) const
+RCP<const  Teuchos::Array<std::string> > MockModelEval_B_Tpetra::get_p_names(int l) const
 {
   TEUCHOS_TEST_FOR_EXCEPTION(l != 0, std::logic_error,
                      std::endl <<
@@ -190,7 +190,7 @@ RCP<const  Teuchos::Array<std::string> > MockModelEval_A_Tpetra::get_p_names(int
 
 
 Teuchos::RCP<Thyra::LinearOpBase<double>>
-MockModelEval_A_Tpetra::create_W_op() const
+MockModelEval_B_Tpetra::create_W_op() const
 {
   const Teuchos::RCP<Tpetra_Operator> W =
       Teuchos::rcp(new Tpetra_CrsMatrix(crs_graph));
@@ -199,19 +199,19 @@ MockModelEval_A_Tpetra::create_W_op() const
 
 //! Create preconditioner operator
 Teuchos::RCP<Thyra::PreconditionerBase<double>>
-MockModelEval_A_Tpetra::create_W_prec() const
+MockModelEval_B_Tpetra::create_W_prec() const
 {
   return Teuchos::null;
 }
 
 Teuchos::RCP<const Thyra::LinearOpWithSolveFactoryBase<double>>
-MockModelEval_A_Tpetra::get_W_factory() const
+MockModelEval_B_Tpetra::get_W_factory() const
 {
   return Teuchos::null;
 }
 
 Teuchos::RCP<Thyra::LinearOpBase<double>>
-MockModelEval_A_Tpetra::create_hess_g_pp( int j, int l1, int l2 ) const
+MockModelEval_B_Tpetra::create_hess_g_pp( int j, int l1, int l2 ) const
 {
   const Teuchos::RCP<Tpetra_Operator> H =
       Teuchos::rcp(new Tpetra_CrsMatrix(hess_crs_graph));
@@ -219,39 +219,39 @@ MockModelEval_A_Tpetra::create_hess_g_pp( int j, int l1, int l2 ) const
 }
 
 Thyra::ModelEvaluatorBase::InArgs<double>
-MockModelEval_A_Tpetra::getNominalValues() const
+MockModelEval_B_Tpetra::getNominalValues() const
 {
   return nominalValues;
 }
 
 Thyra::ModelEvaluatorBase::InArgs<double>
-MockModelEval_A_Tpetra::getLowerBounds() const
+MockModelEval_B_Tpetra::getLowerBounds() const
 {
   return lowerBounds;
 }
 
 Thyra::ModelEvaluatorBase::InArgs<double>
-MockModelEval_A_Tpetra::getUpperBounds() const
+MockModelEval_B_Tpetra::getUpperBounds() const
 {
   return upperBounds;
 }
 
 
 Thyra::ModelEvaluatorBase::InArgs<double>
-MockModelEval_A_Tpetra::createInArgs() const
+MockModelEval_B_Tpetra::createInArgs() const
 {
   return this->createInArgsImpl();
 }
 
 void
-MockModelEval_A_Tpetra::reportFinalPoint(
+MockModelEval_B_Tpetra::reportFinalPoint(
     const Thyra::ModelEvaluatorBase::InArgs<double>& /* finalPoint */,
     const bool /* wasSolved */) {
   // Do nothing  
 }
 
 Thyra::ModelEvaluatorBase::OutArgs<double>
-MockModelEval_A_Tpetra::createOutArgsImpl() const
+MockModelEval_B_Tpetra::createOutArgsImpl() const
 {
   Thyra::ModelEvaluatorBase::OutArgsSetup<double> result;
   result.setModelEvalDescription(this->description());
@@ -278,7 +278,7 @@ MockModelEval_A_Tpetra::createOutArgsImpl() const
   return result;
 }
 
-void MockModelEval_A_Tpetra::evalModelImpl(
+void MockModelEval_B_Tpetra::evalModelImpl(
     const Thyra::ModelEvaluatorBase::InArgs<double>&  inArgs,
     const Thyra::ModelEvaluatorBase::OutArgs<double>& outArgs) const
 {
@@ -287,21 +287,17 @@ void MockModelEval_A_Tpetra::evalModelImpl(
 
   const Teuchos::RCP<const Tpetra_Vector> x_in =
       ConverterT::getConstTpetraVector(inArgs.get_x());
-  if (!Teuchos::nonnull(x_in)) std::cerr << "ERROR: MockModelEval_A_Tpetra requires x as inargs\n";
+  if (!Teuchos::nonnull(x_in)) std::cerr << "ERROR: MockModelEval_B_Tpetra requires x as inargs\n";
 
   const Teuchos::RCP<const Tpetra_Vector> x_dot_in =
       Teuchos::nonnull(inArgs.get_x_dot()) ?
           ConverterT::getConstTpetraVector(inArgs.get_x_dot()) :
           Teuchos::null;
 
-
   const Teuchos::RCP<const Thyra::VectorBase<double>> p_in = inArgs.get_p(0);
   if (Teuchos::nonnull(p_in))
     p_vec->assign(*ConverterT::getConstTpetraVector(p_in));
 
-
-
-  int vecLength = x_in->getGlobalLength();
   int myVecLength = x_in->getLocalLength();
 
   // Parse OutArgs
@@ -416,27 +412,11 @@ void MockModelEval_A_Tpetra::evalModelImpl(
   auto x = x_in->getData();
   auto p = p_vec->getData();
 
-  double x0;
-  for (int i=0; i<myVecLength; i++) {
-    if( x_in->getMap()->getGlobalElement(i) == 0) {
-      x0 = x[i];
-      TEUCHOS_ASSERT(comm->getRank() == 0);
-    }
-  }
-  comm->broadcast(0, sizeof(double), (char*)(&x0));
-
   if (f_out != Teuchos::null) {
     f_out->putScalar(0.0);
     auto f_out_data = f_out->getDataNonConst();
-    for (int i=0; i<myVecLength; i++) {
-      int gid = x_in->getMap()->getGlobalElement(i);
-
-      if (gid==0) { // f_0 = (x_0)^3 - p_0
-        f_out_data[i] = x[i] * x[i] * x[i] -  p[0];
-      }
-      else // f_i = x_i * (1 + x_0 - p_0^(1/3)) - (i+p_1) - 0.5*(x_0 - p_0),  (for i != 0)
-        f_out_data[i] = x[i] - (gid + p[1]) - 0.5*(x0 - p[0]) + x[i] * (x0 - std::cbrt(p[0]));
-    }
+    for (int i=0; i<myVecLength; i++)
+      f_out_data[i] = x[i];
   }
   if (W_out != Teuchos::null) {
     Teuchos::RCP<Tpetra_CrsMatrix> W_out_crs =
@@ -444,21 +424,9 @@ void MockModelEval_A_Tpetra::evalModelImpl(
     W_out_crs->resumeFill();
     W_out_crs->setAllToScalar(0.0);
 
-    double diag=0, extra_diag=0;
-    for (int i=0; i<myVecLength; i++) {
-      auto gid = x_in->getMap()->getGlobalElement(i);
-      if(gid==0) {
-        diag = 3.0 * x0 * x0;
-        W_out_crs->replaceLocalValues(i, 1, &diag, &i);
-      }
-      else {
-        diag = 1.0 + x0 - std::cbrt(p[0]);
-        W_out_crs->replaceLocalValues(i, 1, &diag, &i);
-        decltype(gid) col = 0;
-        extra_diag = -0.5 + x[i];
-        W_out_crs->replaceGlobalValues(gid, 1, &extra_diag, &col);
-      }
-    }
+    double diag=1.0;
+    for (int i=0; i<myVecLength; i++)
+      W_out_crs->replaceLocalValues(i, 1, &diag, &i);
     if(!Teuchos::nonnull(x_dot_in))
       W_out_crs->fillComplete();
   }
@@ -467,6 +435,15 @@ void MockModelEval_A_Tpetra::evalModelImpl(
       Teuchos::nonnull(outArgs.get_hess_g_pp(0,0,0)) ?
           ConverterT::getTpetraOperator(outArgs.get_hess_g_pp(0,0,0)) :
           Teuchos::null;
+
+  // Response: g = 0.5*(p0-6)^2 + 0.5*c*(p1-4)^2 + 0.5*(p0+p1-10)^2
+  // min g(x(p), p) s.t. f(x, p) = 0 reached for p0 = 6, p1 = 4
+
+  double term1, term2, term3, c;
+  term1 = p[0]-6;
+  term2 = p[1]-4;
+  term3 = p[0]+p[1]-10;
+  c = 5;
 
   if (H_pp_out != Teuchos::null) {
     Teuchos::RCP<Tpetra_CrsMatrix> H_pp_out_crs =
@@ -479,6 +456,7 @@ void MockModelEval_A_Tpetra::evalModelImpl(
       std::vector<typename Tpetra_CrsGraph::global_ordinal_type> indices = {0, 1};
       H_pp_out_crs->replaceGlobalValues(0, 2, &vals[0], &indices[0]);
       vals[0] = 1;
+      vals[1] = 1+c;
       H_pp_out_crs->replaceGlobalValues(1, 2, &vals[0], &indices[0]);
     }
     H_pp_out_crs->fillComplete();
@@ -488,132 +466,56 @@ void MockModelEval_A_Tpetra::evalModelImpl(
     dfdp_out->putScalar(0.0);
     auto dfdp_out_data_0 = dfdp_out->getVectorNonConst(0)->getDataNonConst();
     auto dfdp_out_data_1 = dfdp_out->getVectorNonConst(1)->getDataNonConst();
-    for (int i=0; i<myVecLength; i++) {
-      const int gid = x_in->getMap()->getGlobalElement(i);
-      if  (gid==0) {
-        dfdp_out_data_0[i] = -1.0;
-      }
-      else {
-        dfdp_out_data_0[i] = 0.5 - x[i] / (3.0 * std::cbrt(p[0]*p[0]));
-        dfdp_out_data_1[i] = -1.0;
-      }
-    }
+    for (int i=0; i<myVecLength; i++)
+      dfdp_out_data_1[i] = 0.0;
   }
 
-  // Response: g = 0.5*(Sum(x)-Sum(p)-12)^2 + 0.5*(p0-1)^2
-  // min g(x(p), p) s.t. f(x, p) = 0 reached for p_0 = 1, p_1 = 3
-
-  double term1, term2;
-  term1 = x_in->meanValue();
-  term1 =  vecLength * term1 - (p[0] + p[1]) - 12.0;
-  term2 = p[0] - 1.0;
-
   if (Teuchos::nonnull(g_out)) {
-    g_out->getDataNonConst()[0] = 0.5*term1*term1 + 0.5*term2*term2;
+    g_out->getDataNonConst()[0] = 0.5*term1*term1 + 0.5*c*term2*term2 + 0.5*term3*term3;
   }
 
   if (dgdx_out != Teuchos::null) {
-    dgdx_out->putScalar(term1);
-    auto dgdx = dgdx_out->getVector(0)->getData();
+    dgdx_out->putScalar(0);
   }
   if (dgdp_out != Teuchos::null) {
     dgdp_out->putScalar(0.0);
-    dgdp_out->getVectorNonConst(0)->getDataNonConst()[0] = -term1 + term2;
-    dgdp_out->getVectorNonConst(0)->getDataNonConst()[1] = -term1;
+    dgdp_out->getVectorNonConst(0)->getDataNonConst()[0] = term1+term3;
+    dgdp_out->getVectorNonConst(0)->getDataNonConst()[1] = c*term2+term3;
   }
 
   if (Teuchos::nonnull(f_hess_xx_v_out)) {
-    TEUCHOS_ASSERT(Teuchos::nonnull(x_direction));
-
-    double x_direction_0;
-    for (int i=0; i<myVecLength; i++) {
-      if( x_in->getMap()->getGlobalElement(i) == 0) {
-        x_direction_0 = x_direction->getVector(0)->getData()[i];
-        TEUCHOS_ASSERT(comm->getRank() == 0);
-      }
-    }
-
-    double temp= lag_multiplier_f_in->dot(*x_direction->getVector(0));
-    comm->broadcast(0, sizeof(double), (char*)(&x_direction_0));
-
     f_hess_xx_v_out->getVectorNonConst(0)->putScalar(0);
-    for (int i=0; i<myVecLength; i++) {
-      if (x_in->getMap()->getGlobalElement(i)==0){
-        f_hess_xx_v_out->getVectorNonConst(0)->getDataNonConst()[i] =
-            (6.0* x[i] - 1.0) *lag_multiplier_f_in->getData()[i] * x_direction->getVector(0)->getData()[i]  + temp;
-      }
-      else {
-        f_hess_xx_v_out->getVectorNonConst(0)->getDataNonConst()[i] = x_direction_0 * lag_multiplier_f_in->getData()[i];
-      }
-    }
   }
 
   if (Teuchos::nonnull(f_hess_xp_v_out)) {
-    TEUCHOS_ASSERT(Teuchos::nonnull(p_direction));
     f_hess_xp_v_out->getVectorNonConst(0)->putScalar(0);
-    for (int i=0; i<myVecLength; i++) {
-      if (x_in->getMap()->getGlobalElement(i)!=0){
-        f_hess_xp_v_out->getVectorNonConst(0)->getDataNonConst()[i] =
-            - p_direction->getVector(0)->getData()[0]*lag_multiplier_f_in->getData()[i]/(3.0* std::cbrt(p[0]*p[0]));
-      }
-    }
   }
 
   if (Teuchos::nonnull(f_hess_px_v_out)) {
-    TEUCHOS_ASSERT(Teuchos::nonnull(x_direction));
     f_hess_px_v_out->getVectorNonConst(0)->putScalar(0);
-    Tpetra_Vector temp_vec(lag_multiplier_f_in->getMap());
-    for (int i=0; i<myVecLength; i++) {
-      if (x_in->getMap()->getGlobalElement(i)==0)
-        temp_vec.getDataNonConst()[i] = 0;
-      else
-        temp_vec.getDataNonConst()[i] = lag_multiplier_f_in->getData()[i];
-    }
-    double temp= temp_vec.dot(*x_direction->getVector(0));
-    f_hess_px_v_out->getVectorNonConst(0)->getDataNonConst()[0] = -temp/(3.0* std::cbrt(p[0]*p[0]));
   }
 
   if (Teuchos::nonnull(f_hess_pp_v_out)) {
-    TEUCHOS_ASSERT(Teuchos::nonnull(p_direction));
     f_hess_pp_v_out->getVectorNonConst(0)->putScalar(0);
-    Tpetra_Vector temp_vec(lag_multiplier_f_in->getMap());
-    for (int i=0; i<myVecLength; i++) {
-      if (x_in->getMap()->getGlobalElement(i)==0)
-        temp_vec.getDataNonConst()[i] = 0;
-      else
-        temp_vec.getDataNonConst()[i] = lag_multiplier_f_in->getData()[i];
-    }
-    double temp = temp_vec.dot(*x_in);
-    f_hess_pp_v_out->getVectorNonConst(0)->getDataNonConst()[0] = 2.0*p_direction->getVector(0)->getData()[0]*temp/(9.0* std::cbrt(std::pow(p[0],5)));
   }
 
-  double mult = Teuchos::nonnull(lag_multiplier_g_in) ? lag_multiplier_g_in->getData()[0] : 1.0;
   if (Teuchos::nonnull(g_hess_xx_v_out)) {
-    TEUCHOS_ASSERT(Teuchos::nonnull(x_direction));
-    term1 = x_direction->getVector(0)->meanValue() * vecLength;
-    for (int j=0; j<myVecLength; j++)
-      g_hess_xx_v_out->getVectorNonConst(0)->getDataNonConst()[j] = mult*term1;
+    g_hess_xx_v_out->getVectorNonConst(0)->putScalar(0);
   }
 
   if (Teuchos::nonnull(g_hess_xp_v_out)) {
-    TEUCHOS_ASSERT(Teuchos::nonnull(p_direction));
-    const auto direction_p = p_direction->getVector(0)->getData();
-    for (int j=0; j<myVecLength; j++)
-      g_hess_xp_v_out->getVectorNonConst(0)->getDataNonConst()[j] = - mult*(direction_p[0]+direction_p[1]);
+    g_hess_xp_v_out->getVectorNonConst(0)->putScalar(0);
   }
 
   if (Teuchos::nonnull(g_hess_px_v_out)) {
-    TEUCHOS_ASSERT(Teuchos::nonnull(x_direction));
-    term1 = x_direction->getVector(0)->meanValue() * vecLength;
-    g_hess_px_v_out->getVectorNonConst(0)->getDataNonConst()[0] = - mult*term1;
-    g_hess_px_v_out->getVectorNonConst(0)->getDataNonConst()[1] = - mult*term1;
+    g_hess_px_v_out->getVectorNonConst(0)->putScalar(0);
   }
 
   if (Teuchos::nonnull(g_hess_pp_v_out)) {
     TEUCHOS_ASSERT(Teuchos::nonnull(p_direction));
     const auto direction_p = p_direction->getVector(0)->getData();
-    g_hess_pp_v_out->getVectorNonConst(0)->getDataNonConst()[0] = mult*(2.0*direction_p[0]+direction_p[1]);
-    g_hess_pp_v_out->getVectorNonConst(0)->getDataNonConst()[1] = mult*(direction_p[0]+direction_p[1]);
+    g_hess_pp_v_out->getVectorNonConst(0)->getDataNonConst()[0] = 2*direction_p[0]+direction_p[1];
+    g_hess_pp_v_out->getVectorNonConst(0)->getDataNonConst()[1] = direction_p[0]+(c+1)*direction_p[1];
   }
 
   // Modify for time dependent (implicit time integration or eigensolves)
@@ -649,7 +551,7 @@ void MockModelEval_A_Tpetra::evalModelImpl(
 }
 
 Thyra::ModelEvaluatorBase::InArgs<double>
-MockModelEval_A_Tpetra::createInArgsImpl() const
+MockModelEval_B_Tpetra::createInArgsImpl() const
 {
   Thyra::ModelEvaluatorBase::InArgsSetup<double> result;
   result.setModelEvalDescription(this->description());

--- a/packages/piro/test/MockModelEval_B_Tpetra.hpp
+++ b/packages/piro/test/MockModelEval_B_Tpetra.hpp
@@ -1,0 +1,186 @@
+// @HEADER
+// ************************************************************************
+//
+//        Piro: Strategy package for embedded analysis capabilitites
+//                  Copyright (2010) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Andy Salinger (agsalin@sandia.gov), Sandia
+// National Laboratories.
+//
+// ************************************************************************
+// @HEADER
+
+#ifndef MOCKMODELEVAL_B_TPETRA_H
+#define MOCKMODELEVAL_B_TPETRA_H
+
+#include "Teuchos_Assert.hpp"
+#include "Teuchos_RCP.hpp"
+#include "Thyra_ModelEvaluatorDefaultBase.hpp"
+#include "Tpetra_MultiVector.hpp"
+#include "Tpetra_CrsMatrix.hpp"
+#include "Thyra_TpetraThyraWrappers.hpp"
+
+
+using LO = Tpetra::Map<>::local_ordinal_type;
+using GO = Tpetra::Map<>::global_ordinal_type;
+typedef Tpetra::Map<LO,GO>  Tpetra_Map;
+typedef Tpetra::Vector<double,LO,GO>  Tpetra_Vector;
+typedef Tpetra::MultiVector<double,LO,GO>  Tpetra_MultiVector;
+typedef Tpetra::Operator<double,LO,GO>  Tpetra_Operator;
+typedef Tpetra::CrsGraph<LO,GO>  Tpetra_CrsGraph;
+typedef Tpetra::CrsMatrix<double,LO,GO>  Tpetra_CrsMatrix;
+typedef Thyra::TpetraOperatorVectorExtraction<
+    double, LO, GO> ConverterT;
+
+/** \brief Concrete Tpetra-based Model Evaluator
+ *
+ * Concrete model evaluator for the solution of the following PDE-Constrained problem:
+ *
+ * find (p_0,p_1) that minimizes
+ * g = 0.5*(p0-6)^2 + 0.5*c*(p1-4)^2 + 0.5*(p0+p1-10)^2
+ * subject to:
+ * f_i = x_i = 0
+ *
+ * solution is p = (6,4).
+ */
+
+class MockModelEval_B_Tpetra
+    : public Thyra::ModelEvaluatorDefaultBase<double>
+{
+  public:
+
+  /** \name Constructors/initializers */
+  //@{
+
+  /** \brief Takes the number of elements in the discretization . */
+  MockModelEval_B_Tpetra(const Teuchos::RCP<const Teuchos::Comm<int> >  appComm);
+
+  //@}
+
+  ~MockModelEval_B_Tpetra();
+
+
+  /** \name Overridden from EpetraExt::ModelEvaluator . */
+  //@{
+
+  /** \brief . */
+  Thyra::ModelEvaluatorBase::InArgs<double> getNominalValues() const;
+  /** \brief . */
+  Thyra::ModelEvaluatorBase::InArgs<double> getLowerBounds() const;
+  /** \brief . */
+  Thyra::ModelEvaluatorBase::InArgs<double> getUpperBounds() const;
+
+  /** \brief . */
+  Teuchos::RCP<Thyra::LinearOpBase<double>>
+  create_W_op() const;
+
+  /** \brief . */
+  Teuchos::RCP<Thyra::PreconditionerBase<double>>
+  create_W_prec() const;
+
+  /** \brief . */
+  Teuchos::RCP<const Thyra::LinearOpWithSolveFactoryBase<double>>
+  get_W_factory() const;
+
+  /** \brief . */
+  Teuchos::RCP<Thyra::LinearOpBase<double>>
+  create_hess_g_pp( int j, int l1, int l2 ) const;
+
+  /** \brief . */
+  Thyra::ModelEvaluatorBase::InArgs<double>
+  createInArgs() const;
+
+  /** \brief . */
+  void
+  reportFinalPoint(
+      const Thyra::ModelEvaluatorBase::InArgs<double>& finalPoint,
+      const bool wasSolved);
+
+  /** \brief . */
+  Teuchos::RCP<const Thyra::VectorSpaceBase<double>>  get_x_space() const;
+  /** \brief . */
+  Teuchos::RCP<const Thyra::VectorSpaceBase<double>>  get_f_space() const;
+  /** \brief . */
+  Teuchos::RCP<const Thyra::VectorSpaceBase<double>> get_p_space(int l) const;
+  /** \brief . */
+  Teuchos::RCP<const Thyra::VectorSpaceBase<double>> get_g_space(int j) const;
+  /** \brief . */
+  Teuchos::RCP<const Teuchos::Array<std::string> > get_p_names(int l) const;
+  /** \brief . */
+  Teuchos::ArrayView<const std::string> get_g_names(int j) const {
+    TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error, "not implemented");
+  }
+  //@}
+
+  protected:
+
+  //@{
+
+  /** \brief . */
+  Thyra::ModelEvaluatorBase::OutArgs<double>
+  createOutArgsImpl() const;
+
+  /** \brief . */
+  void
+  evalModelImpl(
+      const Thyra::ModelEvaluatorBase::InArgs<double>& inArgs,
+      const Thyra::ModelEvaluatorBase::OutArgs<double>& outArgs) const;
+  //@}
+
+
+  private:
+
+  /** \brief . */
+  Thyra::ModelEvaluatorBase::InArgs<double>
+  createInArgsImpl() const;
+
+   //These are set in the constructor and used in evalModel
+  Teuchos::RCP<const Tpetra_Map> x_map;
+  Teuchos::RCP<const Tpetra_Map> p_map;
+  Teuchos::RCP<const Tpetra_Map> g_map;
+  Teuchos::RCP<Tpetra_CrsGraph> crs_graph;
+  Teuchos::RCP<Tpetra_CrsGraph> hess_crs_graph;
+  Teuchos::RCP<const Teuchos::Comm<int> > comm;
+
+  Teuchos::RCP<Tpetra_Vector> p_vec;
+  Teuchos::RCP<Tpetra_Vector> x_vec;
+  Teuchos::RCP<Tpetra_Vector> x_dot_vec;
+
+   //! Cached nominal values and lower/upper bounds
+   Thyra::ModelEvaluatorBase::InArgs<double> nominalValues;
+   Thyra::ModelEvaluatorBase::InArgs<double> lowerBounds;
+   Thyra::ModelEvaluatorBase::InArgs<double> upperBounds;
+
+};
+
+#endif // SIMPLE_MODELEVAL_H

--- a/packages/piro/test/_input_Analysis_ROL_Tpetra.xml
+++ b/packages/piro/test/_input_Analysis_ROL_Tpetra.xml
@@ -294,6 +294,21 @@
             <Parameter name="Step Tolerance" type="double" value="1.e-14" />
             <Parameter name="Iteration Limit" type="int" value="1000" />
           </ParameterList>
+
+          <!-- =========== SIMOPT SOLVER PARAMETER SUBLIST =========== -->
+          <ParameterList name="SimOpt">
+            <ParameterList name="Solve">
+              <Parameter name="Absolute Residual Tolerance" type="double" value="1.0e-5" />
+              <Parameter name="Relative Residual Tolerance" type="double" value="1.0e+0" />
+              <Parameter name="Iteration Limit" type="int" value="20" />
+              <Parameter name="Sufficient Decrease Tolerance" type="double" value="1.e-4" />
+              <Parameter name="Step Tolerance" type="double" value="1.e-8" />
+              <Parameter name="Backtracking Factor" type="double" value="0.5" />
+              <Parameter name="Output Iteration History" type="bool" value="true" />
+              <Parameter name="Zero Initial Guess" type="bool" value="false" />
+              <Parameter name="Solver Type" type="int" value="0" />
+            </ParameterList>
+          </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>

--- a/packages/piro/test/_input_Analysis_ROL_Tpetra.xml
+++ b/packages/piro/test/_input_Analysis_ROL_Tpetra.xml
@@ -181,6 +181,7 @@
 
         <Parameter name="Step Method" type="string" value="Line Search" />
         <Parameter name="Full Space" type="bool" value="false" />
+        <Parameter name="Hessian Dot Product" type="bool" value="true" />
         <Parameter name="Use NOX Solver" type="bool" value="false" />
 
         <!-- =========== BEGIN ROL INPUT PARAMETER SUBLIST =========== -->

--- a/packages/rol/adapters/thyra/src/function/ROL_ThyraProductME_Objective_SimOpt.hpp
+++ b/packages/rol/adapters/thyra/src/function/ROL_ThyraProductME_Objective_SimOpt.hpp
@@ -45,6 +45,7 @@
 #define ROL_THYRAPRODUCTME_OBJECTIVE_SIMOPT
 
 #include "Thyra_ProductVectorBase.hpp"
+#include "Thyra_PhysicallyBlockedLinearOpBase.hpp"
 #include "ROL_StdVector.hpp"
 #include "ROL_Objective_SimOpt.hpp"
 #include "ROL_Types.hpp"
@@ -259,6 +260,53 @@ public:
     computeGradient2 = false;
   }
 
+  void hessian_22(const Teuchos::RCP<Thyra::PhysicallyBlockedLinearOpBase<Real>> H,
+                  const Vector<Real> &u,
+                  const Vector<Real> &z) {
+    if(verbosityLevel >= Teuchos::VERB_MEDIUM)
+      *out << "ROL::ThyraProductME_Objective_SimOpt::hessian_22" << std::endl;
+
+    Thyra::ModelEvaluatorBase::OutArgs<Real> outArgs = thyra_model.createOutArgs();
+    bool supports_deriv = true;
+    for(std::size_t i=0; i<p_indices.size(); ++i)
+      supports_deriv = supports_deriv &&  outArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_hess_g_pp, g_index, p_indices[i], p_indices[i]);
+
+    if(supports_deriv) { //use derivatives computed by model evaluator
+      const ThyraVector<Real>  & thyra_p = dynamic_cast<const ThyraVector<Real>&>(z);
+      Ptr<Vector<Real>> unew = u.clone();
+      unew->set(u);
+      const ThyraVector<Real>  & thyra_x = dynamic_cast<const ThyraVector<Real>&>(*unew);
+
+      Teuchos::RCP<const  Thyra::ProductVectorBase<Real> > thyra_prodvec_p = Teuchos::rcp_dynamic_cast<const Thyra::ProductVectorBase<Real>>(thyra_p.getVector());
+
+      Thyra::ModelEvaluatorBase::InArgs<Real> inArgs = thyra_model.createInArgs();
+
+      H->beginBlockFill(p_indices.size(), p_indices.size());
+
+      for(std::size_t i=0; i<p_indices.size(); ++i) {
+        inArgs.set_p(p_indices[i], thyra_prodvec_p->getVectorBlock(i));
+      }
+      inArgs.set_x(thyra_x.getVector());
+
+      Teuchos::RCP< Thyra::VectorBase<Real> > multiplier_g = Thyra::createMember<Real>(thyra_model.get_g_multiplier_space(g_index));
+      Thyra::put_scalar(1.0, multiplier_g.ptr());
+      inArgs.set_g_multiplier(g_index, multiplier_g);
+
+      Thyra::ModelEvaluatorBase::OutArgs<Real> outArgs = thyra_model.createOutArgs();
+
+      for(std::size_t i=0; i<p_indices.size(); ++i) {
+        bool supports_deriv = outArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_hess_g_pp, g_index, p_indices[i], p_indices[i]);
+        ROL_TEST_FOR_EXCEPTION( !supports_deriv, std::logic_error, "ROL::ThyraProductME_Objective_SimOpt: H_pp is not supported");
+
+        Teuchos::RCP<Thyra::LinearOpBase<Real>> hess_g_pp = thyra_model.create_hess_g_pp(g_index, p_indices[i], p_indices[i]);
+        outArgs.set_hess_g_pp(g_index, p_indices[i], p_indices[i], hess_g_pp);
+        H->setBlock(p_indices[i], p_indices[i], hess_g_pp);
+      }
+      H->endBlockFill();
+
+      thyra_model.evalModel(inArgs, outArgs);
+    }
+  }
 
   void hessVec_11( Vector<Real> &hv, const Vector<Real> &v,
       const Vector<Real> &u,  const Vector<Real> &z, Real &/*tol*/ ) {

--- a/packages/rol/adapters/thyra/src/vector/ROL_HessianScaledThyraVector.hpp
+++ b/packages/rol/adapters/thyra/src/vector/ROL_HessianScaledThyraVector.hpp
@@ -1,0 +1,194 @@
+// @HEADER
+// ************************************************************************
+//
+//               Rapid Optimization Library (ROL) Package
+//                 Copyright (2014) Sandia Corporation
+//
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact lead developers:
+//              Drew Kouri   (dpkouri@sandia.gov) and
+//              Denis Ridzal (dridzal@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+
+#ifndef ROL_HESSIANSCALEDTHYRAVECTOR_HPP
+#define ROL_HESSIANSCALEDTHYRAVECTOR_HPP
+
+/** \class ROL::HessianScaledThyraVector
+    \brief Implements the ROL::Vector interface for a Thyra::Vector
+           with Hessian dot function.
+*/
+
+#include "ROL_ThyraVector.hpp"
+#include "Teko_BlockLowerTriInverseOp.hpp"
+#include "Teko_BlockUpperTriInverseOp.hpp"
+#include "Teko_SolveInverseFactory.hpp"
+
+namespace ROL {
+
+template <class Real>
+class PrimalHessianScaledThyraVector;
+
+template <class Real>
+class DualHessianScaledThyraVector;
+
+template <class Real>
+class PrimalHessianScaledThyraVector : public ThyraVector<Real> {
+   private:
+    const Teuchos::RCP<const Thyra::LinearOpBase<Real> > hessian_;
+    const Teuchos::RCP<const Thyra::LinearOpBase<Real> > invHessian_;
+
+    mutable Teuchos::RCP<DualHessianScaledThyraVector<Real> > dual_vec_;
+    mutable bool isDualInitialized_;
+
+    void applyScaling(const Teuchos::RCP<Thyra::VectorBase<Real> > &out,
+                      const Teuchos::RCP<const Thyra::VectorBase<Real> > &in) const {
+        Thyra::apply(*hessian_, Thyra::NOTRANS, *in, out.ptr(), (Real)1, (Real)0);
+    }
+
+   public:
+    virtual ~PrimalHessianScaledThyraVector() {}
+
+    PrimalHessianScaledThyraVector(const Teuchos::RCP<Thyra::VectorBase<Real> > &thyra_vec,
+                                   const Teuchos::RCP<const Thyra::LinearOpBase<Real> > hessian,
+                                   const Teuchos::RCP<const Thyra::LinearOpBase<Real> > invHessian)
+        : ThyraVector<Real>(thyra_vec),
+          hessian_(hessian),
+          invHessian_(invHessian),
+          isDualInitialized_(false) {}
+
+    PrimalHessianScaledThyraVector(const Teuchos::RCP<Thyra::VectorBase<Real> > &thyra_vec,
+                                   const Teko::BlockedLinearOp hessian,
+                                   const Teko::BlockedLinearOp invHessian)
+        : ThyraVector<Real>(thyra_vec),
+          hessian_(Teko::toLinearOp(hessian)),
+          invHessian_(Teko::toLinearOp(invHessian)),
+          isDualInitialized_(false) {}
+
+    Real dot(const Vector<Real> &x) const {
+        Teuchos::RCP<const Thyra::VectorBase<Real> > ex = dynamic_cast<const ThyraVector<Real> &>(x).getVector();
+
+        // compute a scaled version of the "this" vector
+        Teuchos::RCP<const Thyra::VectorBase<Real> > vec = ThyraVector<Real>::getVector();
+        Teuchos::RCP<Thyra::VectorBase<Real> > scaled_vec = vec->clone_v();
+        applyScaling(scaled_vec, vec);
+
+        // compute this vector but scaled
+        return ::Thyra::dot<Real>(*scaled_vec, *ex);
+    }
+
+    Teuchos::RCP<Vector<Real> > clone() const {
+        Teuchos::RCP<const Thyra::VectorBase<Real> > vec = ThyraVector<Real>::getVector();
+        return Teuchos::rcp(new PrimalHessianScaledThyraVector<Real>(vec->clone_v(), hessian_, invHessian_));
+    }
+
+    const Vector<Real> &dual() const {
+        if (!isDualInitialized_) {
+            // Create new memory for dual vector
+            Teuchos::RCP<const Thyra::VectorBase<Real> > vec = ThyraVector<Real>::getVector();
+            dual_vec_ = Teuchos::rcp(new DualHessianScaledThyraVector<Real>(vec->clone_v(), hessian_, invHessian_));
+            isDualInitialized_ = true;
+        }
+        // Scale this with scaling_vec_ and place in dual vector
+        applyScaling(dual_vec_->getVector(), ThyraVector<Real>::getVector());
+        return *dual_vec_;
+    }
+
+};  // class PrimalHessianScaledThyraVector
+
+template <class Real>
+class DualHessianScaledThyraVector : public ThyraVector<Real> {
+   private:
+    const Teuchos::RCP<const Thyra::LinearOpBase<Real> > hessian_;
+    const Teuchos::RCP<const Thyra::LinearOpBase<Real> > invHessian_;
+    mutable Teuchos::RCP<PrimalHessianScaledThyraVector<Real> > primal_vec_;
+    mutable bool isDualInitialized_;
+
+    void applyScaling(const Teuchos::RCP<Thyra::VectorBase<Real> > &out,
+                      const Teuchos::RCP<const Thyra::VectorBase<Real> > &in) const {
+        Thyra::apply(*invHessian_, Thyra::NOTRANS, *in, out.ptr(), (Real)1, (Real)0);
+    }
+
+   public:
+    virtual ~DualHessianScaledThyraVector() {}
+
+    DualHessianScaledThyraVector(const Teuchos::RCP<Thyra::VectorBase<Real> > &thyra_vec,
+                                 const Teuchos::RCP<const Thyra::LinearOpBase<Real> > hessian,
+                                 const Teuchos::RCP<const Thyra::LinearOpBase<Real> > invHessian)
+        : ThyraVector<Real>(thyra_vec),
+          hessian_(hessian),
+          invHessian_(invHessian),
+          isDualInitialized_(false) {}
+
+    DualHessianScaledThyraVector(const Teuchos::RCP<Thyra::VectorBase<Real> > &thyra_vec,
+                                 const Teko::BlockedLinearOp hessian,
+                                 const Teko::BlockedLinearOp invHessian)
+        : ThyraVector<Real>(thyra_vec),
+          hessian_(Teko::toLinearOp(hessian)),
+          invHessian_(Teko::toLinearOp(invHessian)),
+          isDualInitialized_(false) {}
+
+    Real dot(const Vector<Real> &x) const {
+        Teuchos::RCP<const Thyra::VectorBase<Real> > ex = dynamic_cast<const ThyraVector<Real> &>(x).getVector();
+
+        // compute a scaled version of the "this" vector
+        Teuchos::RCP<const Thyra::VectorBase<Real> > vec = ThyraVector<Real>::getVector();
+        Teuchos::RCP<Thyra::VectorBase<Real> > scaled_vec = vec->clone_v();
+        applyScaling(scaled_vec, vec);
+
+        // compute this vector but scaled
+        return ::Thyra::dot<Real>(*scaled_vec, *ex);
+    }
+
+    Teuchos::RCP<Vector<Real> > clone() const {
+        Teuchos::RCP<const Thyra::VectorBase<Real> > vec = ThyraVector<Real>::getVector();
+        return Teuchos::rcp(new DualHessianScaledThyraVector<Real>(vec->clone_v(), hessian_, invHessian_));
+    }
+
+    const Vector<Real> &dual() const {
+        if (!isDualInitialized_) {
+            // Create new memory for dual vector
+            Teuchos::RCP<const Thyra::VectorBase<Real> > vec = ThyraVector<Real>::getVector();
+            primal_vec_ = Teuchos::rcp(new PrimalHessianScaledThyraVector<Real>(vec->clone_v(), hessian_, invHessian_));
+            isDualInitialized_ = true;
+        }
+        // Scale this with scaling_vec_ and place in dual vector
+        applyScaling(primal_vec_->getVector(), ThyraVector<Real>::getVector());
+        return *primal_vec_;
+    }
+
+};  // class DualHessianScaledThyraVector
+
+}  // namespace ROL
+
+#endif

--- a/packages/rol/adapters/thyra/src/vector/ROL_HessianScaledThyraVector.hpp
+++ b/packages/rol/adapters/thyra/src/vector/ROL_HessianScaledThyraVector.hpp
@@ -73,7 +73,10 @@ class PrimalHessianScaledThyraVector : public ThyraVector<Real> {
 
     void applyScaling(const Teuchos::RCP<Thyra::VectorBase<Real> > &out,
                       const Teuchos::RCP<const Thyra::VectorBase<Real> > &in) const {
-        Thyra::apply(*hessian_, Thyra::NOTRANS, *in, out.ptr(), (Real)1, (Real)0);
+        if(Teuchos::is_null(hessian_))
+            Thyra::copy(*in, out.ptr());
+        else
+            Thyra::apply(*hessian_, Thyra::NOTRANS, *in, out.ptr(), (Real)1, (Real)0);
     }
 
    public:
@@ -136,7 +139,10 @@ class DualHessianScaledThyraVector : public ThyraVector<Real> {
 
     void applyScaling(const Teuchos::RCP<Thyra::VectorBase<Real> > &out,
                       const Teuchos::RCP<const Thyra::VectorBase<Real> > &in) const {
-        Thyra::apply(*invHessian_, Thyra::NOTRANS, *in, out.ptr(), (Real)1, (Real)0);
+        if(Teuchos::is_null(invHessian_))
+            Thyra::copy(*in, out.ptr());
+        else
+            Thyra::apply(*invHessian_, Thyra::NOTRANS, *in, out.ptr(), (Real)1, (Real)0);
     }
 
    public:

--- a/packages/thyra/core/src/support/nonlinear/model_evaluator/client_support/Thyra_ModelEvaluatorDelegatorBase.hpp
+++ b/packages/thyra/core/src/support/nonlinear/model_evaluator/client_support/Thyra_ModelEvaluatorDelegatorBase.hpp
@@ -163,6 +163,8 @@ public:
   /** \brief . */
   RCP<const LinearOpWithSolveFactoryBase<Scalar> > get_W_factory() const;
   /** \brief . */
+  RCP<LinearOpBase<Scalar> > create_hess_g_pp( int j, int l1, int l2 ) const;
+  /** \brief . */
   ModelEvaluatorBase::InArgs<Scalar> createInArgs() const;
   /** \brief . */
   void reportFinalPoint(
@@ -515,6 +517,14 @@ RCP<const LinearOpWithSolveFactoryBase<Scalar> >
 ModelEvaluatorDelegatorBase<Scalar>::get_W_factory() const
 {
   return getUnderlyingModel()->get_W_factory();
+}
+
+
+template<class Scalar>
+RCP<LinearOpBase<Scalar> >
+ModelEvaluatorDelegatorBase<Scalar>::create_hess_g_pp( int j, int l1, int l2 ) const
+{
+  return getUnderlyingModel()->create_hess_g_pp(j, l1, l2);
 }
 
 


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@mperego
@trilinos/rol 
@bartlettroscoe 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

This PR adds the capability to use a dot product which uses the Hessian w.r.t a parameter while using ROL with Thyra vectors.

The modifications included in this PR are:
- Thyra:
  - `packages/thyra/core/src/support/nonlinear/model_evaluator/client_support/Thyra_ModelEvaluatorDelegatorBase.hpp` has been modified to enable to call the member function `create_hess_g_pp` of the underlying model.
- ROL:
  - `packages/rol/adapters/thyra/src/vector/ROL_HessianScaledThyraVector.hpp` has been added. This header defines the Thyra vector which the dot product is scaled by the Hessian.
  - `packages/rol/adapters/thyra/src/function/ROL_ThyraProductME_Objective_SimOpt.hpp` has been updated to add the capability to evaluate the Hessian w.r.t a parameter.
- Piro:
  - `packages/piro/src/Piro_PerformAnalysis.cpp` has been updated to add the option to use the Hessian dot product (this option is disabled by default).
  - `packages/piro/test/*` the test `packages/piro/test/Main_AnalysisDriver_Tpetra.cpp` has been updated to test the new option. A second mock model has been added; this mock model, while using the Hessian dot product, converges in 1 iteration as theoretically expected.

Edit:
An extra option has been added to remove the mean of the right-hand side before applying the inverse of the Hessian.
This is useful to apply pseudo-inverse of the Hessian matrix for cases where its kernel is <img src="https://render.githubusercontent.com/render/math?math=\left\{0%2B c\,\boldsymbol{1}\right\}">  where <img src="https://render.githubusercontent.com/render/math?math=\boldsymbol{1}"> is the vector which all entries are 1.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
The new capability is tested in `packages/piro/test/Main_AnalysisDriver_Tpetra.cpp` 
The previous and updated tests passed on Blake.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->