### PR TITLE
Xpetra: cleanup and add tests

### DIFF
--- a/packages/xpetra/src/BlockedCrsMatrix/Xpetra_MapExtractorFactory.hpp
+++ b/packages/xpetra/src/BlockedCrsMatrix/Xpetra_MapExtractorFactory.hpp
@@ -68,7 +68,7 @@ namespace Xpetra {
 
   public:
     /*!
-      @brief Build MapExtrasctor from a given set of partial maps.
+      @brief Build MapExtractor from a given set of partial maps.
 
       The Maps indirectly specify the linear algebra library to use (Tpetra or Epetra).
     */
@@ -81,7 +81,7 @@ namespace Xpetra {
     }
 
     /*!
-      @brief Build MapExtrasctor from a given BlockedMap.
+      @brief Build MapExtractor from a given BlockedMap.
 
       The Maps indirectly specify the linear algebra library to use (Tpetra or Epetra).
     */

--- a/packages/xpetra/src/Utils/Xpetra_MapUtils.hpp
+++ b/packages/xpetra/src/Utils/Xpetra_MapUtils.hpp
@@ -78,35 +78,36 @@ public:
 
   /*! @brief Helper function to concatenate several maps
 
-    @param  subMaps    vector of maps which are concatenated
+    @param  subMaps    vector of maps to be concatenated
     @return            concatenated map
 
     The routine builds a global map by concatenating all provided maps in the ordering defined by the vector.
     The GIDs are just appended in the same ordering as in the subMaps. No reordering or sorting is performed.
-    This routine is supposed to generate the full map in an Xpetra::MapExtractor for a block operator. Note, it
-    should not be used for strided maps since the GIDs are not reordered.
+    This routine is supposed to generate the full map in an Xpetra::MapExtractor for a block operator.
+
+    \warning Do not use for strided maps since the GIDs are not reordered.
 
     Example: subMap[0] = { 0, 1, 3, 4 };
              subMap[1] = { 2, 5 };
              concatenated map = { 0, 1, 3, 4, 2 ,5 };
     */
-  static Teuchos::RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > concatenateMaps(const std::vector<Teuchos::RCP<const Xpetra::Map<LocalOrdinal,GlobalOrdinal,Node> > > & subMaps) {
-
+  static Teuchos::RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> >
+  concatenateMaps(const std::vector<Teuchos::RCP<const Xpetra::Map<LocalOrdinal,GlobalOrdinal,Node> > > & subMaps)
+  {
     // ToDo Resolve header issues to allow for using this routing in Xpetra::BlockedMap.
 
-    // merge submaps to global map
+    // Append list of GIDs of individual maps in to one large list
     std::vector<GlobalOrdinal> gids;
-    for(size_t tt = 0; tt<subMaps.size(); ++tt) {
-      Teuchos::RCP<const Xpetra::Map<LocalOrdinal,GlobalOrdinal,Node> > subMap = subMaps[tt];
-      Teuchos::ArrayView< const GlobalOrdinal > subMapGids = subMap->getNodeElementList();
+    for (const auto& map : subMaps) {
+      Teuchos::ArrayView<const GlobalOrdinal> subMapGids = map->getNodeElementList();
       gids.insert(gids.end(), subMapGids.begin(), subMapGids.end());
     }
 
+    // Create the concatenated map object
     const GlobalOrdinal INVALID = Teuchos::OrdinalTraits<Xpetra::global_size_t>::invalid();
-    //std::sort(gids.begin(), gids.end());
-    //gids.erase(std::unique(gids.begin(), gids.end()), gids.end());
     Teuchos::ArrayView<GlobalOrdinal> gidsView(&gids[0], gids.size());
-    Teuchos::RCP<Xpetra::Map<LocalOrdinal,GlobalOrdinal,Node> > fullMap = Xpetra::MapFactory<LocalOrdinal,GlobalOrdinal,Node>::Build(subMaps[0]->lib(), INVALID, gidsView, subMaps[0]->getIndexBase(), subMaps[0]->getComm());
+    Teuchos::RCP<const Map> fullMap = MapFactory::Build(subMaps[0]->lib(), INVALID, gidsView, subMaps[0]->getIndexBase(), subMaps[0]->getComm());
+
     return fullMap;
   }
 
@@ -125,16 +126,16 @@ public:
              result = { 0, 1, 2, 3, 4 }; on proc 0
              result = { 3, 4, 5, 6, 7 }; on proc 1
     */
-  static Teuchos::RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > 
+  static Teuchos::RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> >
   shrinkMapGIDs(const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node>& input,
                 const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node>& nonOvlInput)
   {
-    TEUCHOS_TEST_FOR_EXCEPTION(nonOvlInput.getNodeNumElements() > input.getNodeNumElements(), 
-                               Xpetra::Exceptions::Incompatible, 
+    TEUCHOS_TEST_FOR_EXCEPTION(nonOvlInput.getNodeNumElements() > input.getNodeNumElements(),
+                               Xpetra::Exceptions::Incompatible,
                                "Xpetra::MatrixUtils::shrinkMapGIDs: the non-overlapping map must not have more local ids than the overlapping map.")
 
-    TEUCHOS_TEST_FOR_EXCEPTION(nonOvlInput.getMaxAllGlobalIndex() != input.getMaxAllGlobalIndex(), 
-            Xpetra::Exceptions::Incompatible, 
+    TEUCHOS_TEST_FOR_EXCEPTION(nonOvlInput.getMaxAllGlobalIndex() != input.getMaxAllGlobalIndex(),
+            Xpetra::Exceptions::Incompatible,
             "Xpetra::MatrixUtils::shrinkMapGIDs: the maximum GIDs of the overlapping and non-overlapping maps must be the same.")
 
     RCP< const Teuchos::Comm<int> > comm = input.getComm();
@@ -153,7 +154,7 @@ public:
 
     // we use nonOvlInput to assign the globally unique shrinked GIDs and communicate them to input.
     std::map<const GlobalOrdinal, GlobalOrdinal> origGID2newGID;
-    for(size_t i = 0; i < nonOvlInput.getNodeNumElements(); i++) 
+    for(size_t i = 0; i < nonOvlInput.getNodeNumElements(); i++)
     {
       origGID2newGID[nonOvlInput.getGlobalElement(i)] = Teuchos::as<GlobalOrdinal>(i) + Teuchos::as<GlobalOrdinal>(gidOffset);
     }

--- a/packages/xpetra/sup/Utils/Xpetra_MatrixMatrix.hpp
+++ b/packages/xpetra/sup/Utils/Xpetra_MatrixMatrix.hpp
@@ -630,7 +630,7 @@ Note: this class is not in the Xpetra_UseShortNames.hpp
 
       @return sum in B.
 
-      Note that B does not have to be fill-completed.
+      \note Matrix B must not be fill-completed.
       */
     static void TwoMatrixAdd(const Matrix& A, bool transposeA, SC alpha, Matrix& B, SC beta) {
       if (!(A.getRowMap()->isSameAs(*(B.getRowMap()))))

--- a/packages/xpetra/test/Map/CMakeLists.txt
+++ b/packages/xpetra/test/Map/CMakeLists.txt
@@ -28,6 +28,15 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   )
 
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  MapUtils_UnitTests
+  SOURCES
+    MapUtils_UnitTests
+    ../Xpetra_UnitTests
+  COMM serial mpi
+  STANDARD_PASS_OUTPUT
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
   StridedMap_UnitTests
   SOURCES
     StridedMap_UnitTests

--- a/packages/xpetra/test/Map/MapUtils_UnitTests.cpp
+++ b/packages/xpetra/test/Map/MapUtils_UnitTests.cpp
@@ -1,0 +1,195 @@
+// @HEADER
+//
+// ***********************************************************************
+//
+//             Xpetra: A linear algebra interface package
+//                  Copyright 2012 Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact
+//                    Jonathan Hu       (jhu@sandia.gov)
+//                    Andrey Prokopenko (aprokop@sandia.gov)
+//                    Ray Tuminaro      (rstumin@sandia.gov)
+//
+// ***********************************************************************
+//
+// @HEADER
+#include <Teuchos_UnitTestHarness.hpp>
+#include <Teuchos_Array.hpp>
+#include <Teuchos_Tuple.hpp>
+#include <Teuchos_CommHelpers.hpp>
+
+#include <Teuchos_Array.hpp>
+#include <Teuchos_as.hpp>
+
+#include "Xpetra_ConfigDefs.hpp"
+#include "Xpetra_DefaultPlatform.hpp"
+
+#include "Xpetra_Exceptions.hpp"
+#include "Xpetra_Map.hpp"
+#include "Xpetra_MapFactory.hpp"
+#include "Xpetra_MapUtils.hpp"
+#include "Xpetra_StridedMap.hpp"
+#include "Xpetra_StridedMapFactory.hpp"
+
+#ifdef HAVE_XPETRA_TPETRA
+#include "Xpetra_TpetraMap.hpp"
+#include "Tpetra_Details_Behavior.hpp"
+#endif
+
+#ifdef HAVE_XPETRA_EPETRA
+#include "Xpetra_EpetraMap.hpp"
+#endif
+
+// FINISH: add testing of operator==, operator!=, operator=, copy construct
+// put these into test_same_as and test_is_compatible
+
+namespace {
+
+  bool testMpi = true;
+
+  Teuchos::RCP<const Teuchos::Comm<int> > getDefaultComm()
+  {
+    if (testMpi) {
+      return Xpetra::DefaultPlatform::getDefaultPlatform().getComm();
+    }
+    return Teuchos::rcp(new Teuchos::SerialComm<int>());
+  }
+
+  //
+  // UNIT TESTS
+  //
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( MapUtils, ConcatenateTwoMaps_ObtainMergedMap, M, LO, GO, N )
+  {
+    using Teuchos::Array;
+    using Teuchos::ArrayView;
+    using Teuchos::RCP;
+
+    using Map = Xpetra::Map<LO,GO,N>;
+    using MapFactory = Xpetra::MapFactory<LO,GO,N>;
+    using MapUtils = Xpetra::MapUtils<LO,GO,N>;
+
+    // create a comm
+    Teuchos::RCP<const Teuchos::Comm<int> > comm = getDefaultComm();
+    M testMap(1, 0, comm);
+    Xpetra::UnderlyingLib lib = testMap.lib();
+
+    const GO GO_zero = Teuchos::OrdinalTraits<GO>::zero();
+
+    const LO numLocalElementsPerMap = 3;
+    const Xpetra::global_size_t numGlobalElementsPerMap =
+        Teuchos::as<Xpetra::global_size_t>(comm->getSize() * numLocalElementsPerMap);
+
+    Array<GO> gidsForMapOne;
+    Array<GO> gidsForMapTwo;
+    for (LO i = 0; i < numLocalElementsPerMap; ++i) {
+      gidsForMapOne.push_back(Teuchos::as<GO>(comm->getRank() * numLocalElementsPerMap + i));
+      gidsForMapTwo.push_back(Teuchos::as<GO>((comm->getSize() + comm->getRank() * numLocalElementsPerMap) + i));
+    }
+
+    RCP<const Map> mapOne = MapFactory::Build(lib, numGlobalElementsPerMap, gidsForMapOne(), GO_zero, comm);
+    RCP<const Map> mapTwo = MapFactory::Build(lib, numGlobalElementsPerMap, gidsForMapTwo(), GO_zero, comm);
+
+    TEST_ASSERT(Teuchos::nonnull(mapOne));
+    TEST_ASSERT(Teuchos::nonnull(mapTwo));
+
+    std::vector<RCP<const Map>> maps;
+    maps.push_back(mapOne);
+    maps.push_back(mapTwo);
+
+    RCP<const Map> fullMap = MapUtils::concatenateMaps(maps);
+
+    TEST_ASSERT(Teuchos::nonnull(fullMap));
+    TEST_EQUALITY_CONST(fullMap->getNodeNumElements(), static_cast<size_t>(2 * numLocalElementsPerMap));
+    TEST_EQUALITY_CONST(fullMap->getGlobalNumElements(), 2 * numGlobalElementsPerMap);
+
+    // Manually merge both lists of GIDs and check with GIDs in full map
+    {
+      Array<GO> expectedListOfGids;
+      for (const auto& gid : gidsForMapOne) expectedListOfGids.push_back(gid);
+      for (const auto& gid : gidsForMapTwo) expectedListOfGids.push_back(gid);
+
+      ArrayView<const GO> gidsInFullMap = fullMap->getNodeElementList();
+
+      TEST_COMPARE_ARRAYS(gidsInFullMap(), expectedListOfGids());
+    }
+  }
+
+  //
+  // INSTANTIATIONS
+  //
+#ifdef HAVE_XPETRA_TPETRA
+
+  #define XPETRA_TPETRA_TYPES( LO, GO, N) \
+    typedef typename Xpetra::TpetraMap<LO,GO,N> M##LO##GO##N;
+
+#endif
+
+#ifdef HAVE_XPETRA_EPETRA
+
+  #define XPETRA_EPETRA_TYPES( LO, GO, N) \
+    typedef typename Xpetra::EpetraMapT<GO,N> M##LO##GO##N;
+
+#endif
+
+// List of tests (which run both on Epetra and Tpetra)
+#define XP_MAP_INSTANT(LO,GO,N) \
+    TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( MapUtils, ConcatenateTwoMaps_ObtainMergedMap, M##LO##GO##N, LO, GO, N)
+
+#if defined(HAVE_XPETRA_TPETRA)
+
+#include <TpetraCore_config.h>
+#include <TpetraCore_ETIHelperMacros.h>
+
+TPETRA_ETI_MANGLING_TYPEDEFS()
+// no ordinal types as scalar for testing as some tests use ScalarTraits::eps...
+TPETRA_INSTANTIATE_LGN ( XPETRA_TPETRA_TYPES )
+TPETRA_INSTANTIATE_LGN ( XP_MAP_INSTANT )
+
+#endif
+
+#if defined(HAVE_XPETRA_EPETRA)
+
+#include "Xpetra_Map.hpp" // defines EpetraNode
+typedef Xpetra::EpetraNode EpetraNode;
+#ifndef XPETRA_EPETRA_NO_32BIT_GLOBAL_INDICES
+XPETRA_EPETRA_TYPES(int,int,EpetraNode)
+XP_MAP_INSTANT(int,int,EpetraNode)
+#endif
+#ifndef XPETRA_EPETRA_NO_64BIT_GLOBAL_INDICES
+typedef long long LongLong;
+XPETRA_EPETRA_TYPES(int,LongLong,EpetraNode)
+XP_MAP_INSTANT(int,LongLong,EpetraNode)
+#endif
+#endif
+
+}

--- a/packages/xpetra/test/Matrix/Matrix_UnitTests.cpp
+++ b/packages/xpetra/test/Matrix/Matrix_UnitTests.cpp
@@ -97,70 +97,68 @@ namespace {
   ////
   TEUCHOS_UNIT_TEST_TEMPLATE_6_DECL( Matrix, ViewSwitching, M, MA, Scalar, LO, GO, Node )
   {
-#ifdef HAVE_XPETRA_TPETRA
     typedef Xpetra::CrsMatrixWrap<Scalar, LO, GO, Node> CrsMatrixWrap;
     Teuchos::RCP<const Teuchos::Comm<int> > comm = getDefaultComm();
 
+    M testMap(1,0,comm);
+    Xpetra::UnderlyingLib lib = testMap.lib();
+
     const size_t numLocal = 10;
     const size_t INVALID = Teuchos::OrdinalTraits<size_t>::invalid(); // TODO: global_size_t instead of size_t
-    //Teuchos::RCP<const Xpetra::Map<LO,GO,Node> > map = Xpetra::useTpetra::createContigMapWithNode<LO,GO,Node>(INVALID,numLocal,comm);
     Teuchos::RCP<const Xpetra::Map<LO,GO,Node> > map =
-        Xpetra::MapFactory<LO,GO,Node>::createContigMapWithNode (Xpetra::UseTpetra,INVALID,numLocal,comm);
-     {
-       Xpetra::TpetraCrsMatrix<Scalar, LO, GO, Node> t =  Xpetra::TpetraCrsMatrix<Scalar,LO,GO,Node>(map, numLocal);
+        Xpetra::MapFactory<LO,GO,Node>::createContigMapWithNode (lib, INVALID, numLocal, comm);
+    {
+      // Test of constructor
+      CrsMatrixWrap op(map,1);
+      TEST_EQUALITY_CONST(op.GetCurrentViewLabel(), op.GetDefaultViewLabel());
+      TEST_EQUALITY_CONST(op.GetCurrentViewLabel(), op.SwitchToView(op.GetCurrentViewLabel()));
 
-       // Test of constructor
-       CrsMatrixWrap op(map,1);
-       TEST_EQUALITY_CONST(op.GetCurrentViewLabel(), op.GetDefaultViewLabel());
-       TEST_EQUALITY_CONST(op.GetCurrentViewLabel(), op.SwitchToView(op.GetCurrentViewLabel()));
+      // Test of CreateView
+      TEST_THROW(op.CreateView(op.GetDefaultViewLabel(),op.getRowMap(),op.getColMap()), Xpetra::Exceptions::RuntimeError); // a
+      op.CreateView("newView",op.getRowMap(),op.getColMap());                                                              // b
+      TEST_THROW(op.CreateView("newView",op.getRowMap(),op.getColMap()), Xpetra::Exceptions::RuntimeError);                // c
 
-       // Test of CreateView
-       TEST_THROW(op.CreateView(op.GetDefaultViewLabel(),op.getRowMap(),op.getColMap()), Xpetra::Exceptions::RuntimeError); // a
-       op.CreateView("newView",op.getRowMap(),op.getColMap());                                                              // b
-       TEST_THROW(op.CreateView("newView",op.getRowMap(),op.getColMap()), Xpetra::Exceptions::RuntimeError);                // c
+      // Test of SwitchToView
+      // a
+      viewLabel_t viewLabel    = op.GetCurrentViewLabel();
+      viewLabel_t oldViewLabel = op.SwitchToView("newView");
+      TEST_EQUALITY_CONST(viewLabel, oldViewLabel);
+      TEST_EQUALITY_CONST(op.GetCurrentViewLabel(), "newView");
+      // b
+      TEST_THROW(op.SwitchToView("notAView"), Xpetra::Exceptions::RuntimeError);
 
-       // Test of SwitchToView
-       // a
-       viewLabel_t viewLabel    = op.GetCurrentViewLabel();
-       viewLabel_t oldViewLabel = op.SwitchToView("newView");
-       TEST_EQUALITY_CONST(viewLabel, oldViewLabel);
-       TEST_EQUALITY_CONST(op.GetCurrentViewLabel(), "newView");
-       // b
-       TEST_THROW(op.SwitchToView("notAView"), Xpetra::Exceptions::RuntimeError);
+      // Test of SwitchToDefaultView()
+      // a
+      viewLabel    = op.GetCurrentViewLabel();
+      oldViewLabel = op.SwitchToDefaultView();
+      TEST_EQUALITY_CONST(viewLabel, oldViewLabel);
+      TEST_EQUALITY_CONST(op.GetCurrentViewLabel(), op.GetDefaultViewLabel());
 
-       // Test of SwitchToDefaultView()
-       // a
-       viewLabel    = op.GetCurrentViewLabel();
-       oldViewLabel = op.SwitchToDefaultView();
-       TEST_EQUALITY_CONST(viewLabel, oldViewLabel);
-       TEST_EQUALITY_CONST(op.GetCurrentViewLabel(), op.GetDefaultViewLabel());
+      // Test of RemoveView()
+      TEST_THROW(op.RemoveView(op.GetDefaultViewLabel()), Xpetra::Exceptions::RuntimeError); // a
+      TEST_THROW(op.RemoveView("notAView"), Xpetra::Exceptions::RuntimeError);               // b
+      op.RemoveView("newView");                                                               // c
+      TEST_THROW(op.RemoveView("newView"), Xpetra::Exceptions::RuntimeError);
 
-       // Test of RemoveView()
-       TEST_THROW(op.RemoveView(op.GetDefaultViewLabel()), Xpetra::Exceptions::RuntimeError); // a
-       TEST_THROW(op.RemoveView("notAView"), Xpetra::Exceptions::RuntimeError);               // b
-       op.RemoveView("newView");                                                               // c
-       TEST_THROW(op.RemoveView("newView"), Xpetra::Exceptions::RuntimeError);
-
-       op.fillComplete();
-     }
-#endif
+      op.fillComplete();
+    }
   }
 
   ////
-  TEUCHOS_UNIT_TEST_TEMPLATE_6_DECL( Matrix, StridedMaps_Tpetra, M, MA, Scalar, LO, GO, Node )
+  TEUCHOS_UNIT_TEST_TEMPLATE_6_DECL( Matrix, StridedMaps, M, MA, Scalar, LO, GO, Node )
   {
+    typedef Xpetra::CrsMatrixWrap<Scalar, LO, GO, Node> CrsMatrixWrap;
+
     Teuchos::RCP<const Teuchos::Comm<int> > comm = getDefaultComm();
     const size_t numLocal = 10;
     const size_t INVALID = Teuchos::OrdinalTraits<size_t>::invalid(); // TODO: global_size_t instead of size_t
 
+    M testMap(1,0,comm);
+    Xpetra::UnderlyingLib lib = testMap.lib();
 
-#ifdef HAVE_XPETRA_TPETRA
-    typedef Xpetra::CrsMatrixWrap<Scalar, LO, GO, Node> CrsMatrixWrap;
     Teuchos::RCP<const Xpetra::Map<LO,GO,Node> > map =
-        Xpetra::MapFactory<LO,GO,Node>::createContigMapWithNode (Xpetra::UseTpetra,INVALID,numLocal,comm);
+        Xpetra::MapFactory<LO,GO,Node>::createContigMapWithNode (lib, INVALID, numLocal, comm);
      {
-       Xpetra::TpetraCrsMatrix<Scalar, LO, GO, Node> t =  Xpetra::TpetraCrsMatrix<Scalar,LO,GO,Node>(map, numLocal);
-
        // Test of constructor
        CrsMatrixWrap op(map,1);
        op.fillComplete();
@@ -174,39 +172,7 @@ namespace {
        int blkSize = op.GetFixedBlockSize();
        TEST_EQUALITY_CONST(blkSize, 2);
      }
-#endif
   }
-
-  ////
-  TEUCHOS_UNIT_TEST_TEMPLATE_6_DECL( Matrix, StridedMaps_Epetra, M, MA, Scalar, LO, GO, Node )
-  {
-#ifdef HAVE_XPETRA_EPETRA
-    Teuchos::RCP<const Teuchos::Comm<int> > comm = getDefaultComm();
-    const size_t numLocal = 10;
-    const size_t INVALID = Teuchos::OrdinalTraits<size_t>::invalid();
-
-    typedef Xpetra::CrsMatrixWrap<double, int, GO, Xpetra::EpetraNode> EpCrsMatrix;
-
-    Teuchos::RCP<const Xpetra::Map<int,GO,Node> > epmap = Xpetra::MapFactory<int,GO,Node>::createContigMap(Xpetra::UseEpetra, INVALID, numLocal, comm);
-     {
-       Xpetra::EpetraCrsMatrixT<GO,Node> t =  Xpetra::EpetraCrsMatrixT<GO,Node>(epmap, numLocal);
-
-       // Test of constructor
-       EpCrsMatrix op(epmap,1);
-       op.fillComplete();
-
-       TEST_EQUALITY_CONST(op.GetCurrentViewLabel(), op.GetDefaultViewLabel());
-       TEST_EQUALITY_CONST(op.GetCurrentViewLabel(), op.SwitchToView(op.GetCurrentViewLabel()));
-
-       op.SetFixedBlockSize(2);
-       TEST_EQUALITY(op.IsView("stridedMaps"),true);
-       TEST_EQUALITY(op.IsView("StridedMaps"),false);
-       int blkSize = op.GetFixedBlockSize();
-       TEST_EQUALITY_CONST(blkSize, 2);
-     }
-#endif
-  }
-
 
   ////
   TEUCHOS_UNIT_TEST_TEMPLATE_6_DECL( Matrix, BuildCopy_StridedMaps_Tpetra, M, MA, Scalar, LO, GO, Node )
@@ -228,7 +194,7 @@ namespace {
        s->SetFixedBlockSize(2);
 
        Teuchos::RCP<Xpetra::Matrix<Scalar, LO, GO, Node> > t = Xpetra::MatrixFactory2<Scalar,LO,GO,Node>::BuildCopy(s);
-       
+
        int blkSize = t->GetFixedBlockSize();
        TEST_EQUALITY_CONST(blkSize, 2);
      }
@@ -252,13 +218,13 @@ namespace {
     using MV  = Xpetra::MultiVector<Scalar,LO,GO,Node>;
     typedef Xpetra::CrsMatrixWrap<Scalar, LO, GO, Node> CrsMatrixWrap;
     RCP<const Xpetra::Map<LO,GO,Node> > map =
-      Xpetra::MapFactory<LO,GO,Node>::createContigMapWithNode (Xpetra::UseTpetra,INVALID,numLocal,comm);   
+      Xpetra::MapFactory<LO,GO,Node>::createContigMapWithNode (Xpetra::UseTpetra,INVALID,numLocal,comm);
      {
        // create the identity matrix, via three arrays constructor
        ArrayRCP<size_t> rowptr(numLocal+1);
        ArrayRCP<LO>     colind(numLocal); // one unknown per row
        ArrayRCP<Scalar> values(numLocal); // one unknown per row
-       
+
        for(size_t i=0; i<numLocal; i++){
          rowptr[i] = i;
          colind[i] = Teuchos::as<LO>(i);
@@ -270,18 +236,18 @@ namespace {
        TEST_NOTHROW( eye2->expertStaticFillComplete(map,map) );
 
        RCP<const Xpetra::Matrix<Scalar, LO, GO, Node> > eye2x(new CrsMatrixWrap(eye2));
-       
+
        // Just extract & scale; don't test correctness (Tpetra does this)
-       RCP<const MV> diag5c = Xpetra::MultiVectorFactory<Scalar,LO,GO,Node>::Build(map,5);  
+       RCP<const MV> diag5c = Xpetra::MultiVectorFactory<Scalar,LO,GO,Node>::Build(map,5);
        RCP<MV> diag5 = rcp_const_cast<MV>(diag5c);
        diag5->putScalar(SC_one);
 
        Xpetra::MatrixUtils<Scalar, LO, GO, Node>::extractBlockDiagonal(*eye2x,*diag5);
 
        RCP<MV> toScale5 = Xpetra::MultiVectorFactory<Scalar,LO,GO,Node>::Build(map,2); toScale5->putScalar(SC_one);
-       
+
        Xpetra::MatrixUtils<Scalar, LO, GO, Node>::inverseScaleBlockDiagonal(*diag5c,false,*toScale5);
-      
+
 
      }
 #endif
@@ -309,22 +275,19 @@ namespace {
 
 // List of tests which run only with Tpetra
 #define XP_TPETRA_MATRIX_INSTANT(S,LO,GO,N) \
-    TEUCHOS_UNIT_TEST_TEMPLATE_6_INSTANT( Matrix, StridedMaps_Tpetra,  M##LO##GO##N , MA##S##LO##GO##N, S, LO, GO, N ) \
-    TEUCHOS_UNIT_TEST_TEMPLATE_6_INSTANT( Matrix, BuildCopy_StridedMaps_Tpetra,  M##LO##GO##N , MA##S##LO##GO##N, S, LO, GO, N ) \
-    TEUCHOS_UNIT_TEST_TEMPLATE_6_INSTANT( Matrix, ViewSwitching, M##LO##GO##N , MA##S##LO##GO##N , S, LO, GO, N ) 
+    TEUCHOS_UNIT_TEST_TEMPLATE_6_INSTANT( Matrix, BuildCopy_StridedMaps_Tpetra,  M##LO##GO##N , MA##S##LO##GO##N, S, LO, GO, N )
 
 // Tpetra, but no complex
 #define XP_TPETRA_MATRIX_INSTANT_NO_COMPLEX(S,LO,GO,N) \
     TEUCHOS_UNIT_TEST_TEMPLATE_6_INSTANT( Matrix, BlockDiagonalUtils_Tpetra, M##LO##GO##N , MA##S##LO##GO##N , S, LO, GO, N )
 
-// List of tests which run only with Epetra
-#define XP_EPETRA_MATRIX_INSTANT(S,LO,GO,N) \
-    TEUCHOS_UNIT_TEST_TEMPLATE_6_INSTANT( Matrix, StridedMaps_Epetra, M##LO##GO##N , MA##S##LO##GO##N, S, LO, GO, N )
+// // List of tests which run only with Epetra
+// #define XP_EPETRA_MATRIX_INSTANT(S,LO,GO,N)
 
 // list of all tests which run both with Epetra and Tpetra
-//#define XP_MATRIX_INSTANT(S,LO,GO,N)
-
-
+#define XP_MATRIX_INSTANT(S,LO,GO,N) \
+    TEUCHOS_UNIT_TEST_TEMPLATE_6_INSTANT( Matrix, StridedMaps,  M##LO##GO##N , MA##S##LO##GO##N, S, LO, GO, N ) \
+    TEUCHOS_UNIT_TEST_TEMPLATE_6_INSTANT( Matrix, ViewSwitching, M##LO##GO##N , MA##S##LO##GO##N , S, LO, GO, N )
 
 
 #if defined(HAVE_XPETRA_TPETRA)
@@ -334,7 +297,7 @@ namespace {
 
 TPETRA_ETI_MANGLING_TYPEDEFS()
 TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR ( XPETRA_TPETRA_TYPES )
-//TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR ( XP_MATRIX_INSTANT )
+TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR ( XP_MATRIX_INSTANT )
 TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR ( XP_TPETRA_MATRIX_INSTANT )
 
 #if !defined(HAVE_TPETRA_INST_COMPLEX_DOUBLE) && !defined(HAVE_TPETRA_INST_COMPLEX_FLOAT)
@@ -350,14 +313,14 @@ TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR ( XP_TPETRA_MATRIX_INSTANT_NO_COMPLEX 
 typedef Xpetra::EpetraNode EpetraNode;
 #ifndef XPETRA_EPETRA_NO_32BIT_GLOBAL_INDICES
 XPETRA_EPETRA_TYPES(double,int,int,EpetraNode)
-//XP_MATRIX_INSTANT(double,int,int,EpetraNode)
-XP_EPETRA_MATRIX_INSTANT(double,int,int,EpetraNode)
+XP_MATRIX_INSTANT(double,int,int,EpetraNode)
+// XP_EPETRA_MATRIX_INSTANT(double,int,int,EpetraNode)
 #endif
 #ifndef XPETRA_EPETRA_NO_64BIT_GLOBAL_INDICES
 typedef long long LongLong;
 XPETRA_EPETRA_TYPES(double,int,LongLong,EpetraNode)
-//XP_MATRIX_INSTANT(double,int,LongLong,EpetraNode)
-XP_EPETRA_MATRIX_INSTANT(double,int,LongLong,EpetraNode)
+XP_MATRIX_INSTANT(double,int,LongLong,EpetraNode)
+// XP_EPETRA_MATRIX_INSTANT(double,int,LongLong,EpetraNode)
 #endif
 
 #endif

--- a/packages/xpetra/test/MatrixMatrix/MatrixMatrix_UnitTests.cpp
+++ b/packages/xpetra/test/MatrixMatrix/MatrixMatrix_UnitTests.cpp
@@ -463,6 +463,130 @@ namespace {
 #endif
   }
 
+  TEUCHOS_UNIT_TEST_TEMPLATE_6_DECL( MatrixMatrix, AddTwoNonTransposedMatrices, M, MA, Scalar, LO, GO, Node )
+  {
+    using Teuchos::rcp_dynamic_cast;
+    using Teuchos::ArrayView;
+    using Teuchos::ArrayRCP;
+
+    using CrsMatrix = Xpetra::CrsMatrix<Scalar,LO,GO,Node>;
+    using CrsMatrixFactory = Xpetra::CrsMatrixFactory<Scalar,LO,GO,Node>;
+    using CrsMatrixWrap = Xpetra::CrsMatrixWrap<Scalar,LO,GO,Node>;
+    using Map = Xpetra::Map<LO,GO,Node>;
+    using MapFactory = Xpetra::MapFactory<LO,GO,Node>;
+    using Matrix = Xpetra::Matrix<Scalar,LO,GO,Node>;
+    using MatrixMatrix = Xpetra::MatrixMatrix<Scalar,LO,GO,Node>;
+
+    // Get basi data for map constructions
+    RCP<const Comm<int> > comm = getDefaultComm();
+    M testMap(1,0,comm);
+    Xpetra::UnderlyingLib lib = testMap.lib();
+
+    const Scalar SC_one = Teuchos::ScalarTraits<Scalar>::one();
+    const Scalar SC_two = static_cast<Scalar>(2) * Teuchos::ScalarTraits<Scalar>::one();
+    const Scalar SC_four = static_cast<Scalar>(4) * Teuchos::ScalarTraits<Scalar>::one();
+
+    // define a map
+    const LO nLocalEle = 15;
+    const Xpetra::global_size_t nGlobalEle = static_cast<Xpetra::global_size_t>(nLocalEle * comm->getSize());
+    RCP<const Map> map = MapFactory::Build(lib, nGlobalEle, nLocalEle, 0, comm);
+
+    TEST_ASSERT(!map.is_null());
+
+    Array<size_t> numEntriesPerRow(nLocalEle, 3);
+    numEntriesPerRow[0] = 2;
+    numEntriesPerRow[nLocalEle - 1] = 2;
+    size_t localNumEntries = Teuchos::ScalarTraits<LO>::zero();
+    for (const auto& numEntries : numEntriesPerRow)
+      localNumEntries += numEntries;
+    const Xpetra::global_size_t globalNumEntries = static_cast<Xpetra::global_size_t>(localNumEntries * comm->getSize());
+
+    RCP<CrsMatrix> crsMatrixOne = CrsMatrixFactory::Build(map, map, 3);
+    RCP<Matrix> matrixOne = rcp(new CrsMatrixWrap(crsMatrixOne));
+
+    TEST_ASSERT(!matrixOne.is_null());
+    TEST_EQUALITY_CONST(matrixOne->getNodeNumRows(), nLocalEle);
+    TEST_EQUALITY_CONST(matrixOne->getGlobalNumRows(), nGlobalEle);
+
+    for (LO lRow = 0; lRow < nLocalEle; ++lRow)
+    {
+      Array<LO> lCols;
+      Array<Scalar> vals;
+      if (lRow == 0)
+      {
+        lCols.push_back(0);
+        lCols.push_back(1);
+
+        vals.push_back(SC_one);
+        vals.push_back(-SC_one);
+      }
+      else if (lRow == nLocalEle - 1)
+      {
+        lCols.push_back(nLocalEle - 2);
+        lCols.push_back(nLocalEle - 1);
+
+        vals.push_back(-SC_one);
+        vals.push_back(SC_one);
+      }
+      else
+      {
+        lCols.push_back(lRow - 1);
+        lCols.push_back(lRow);
+        lCols.push_back(lRow + 1);
+
+        vals.push_back(-SC_one);
+        vals.push_back(SC_two);
+        vals.push_back(-SC_one);
+      }
+      matrixOne->insertLocalValues(lRow, lCols(), vals());
+    }
+    matrixOne->fillComplete();
+
+    TEST_ASSERT(matrixOne->isFillComplete());
+    TEST_EQUALITY_CONST(matrixOne->getNodeNumEntries(), localNumEntries);
+    TEST_EQUALITY_CONST(matrixOne->getGlobalNumEntries(), globalNumEntries);
+
+    // Test TwoMatrixAdd, that puts result into a third matrix
+    {
+      RCP<const Matrix> matrixTwo = rcp(new CrsMatrixWrap(rcp_dynamic_cast<CrsMatrixWrap>(matrixOne, true)->getCrsMatrix()));
+
+      TEST_ASSERT(!matrixTwo.is_null());
+      TEST_ASSERT(matrixTwo->isFillComplete());
+
+      RCP<Matrix> matrixAfterSummation = rcp(new CrsMatrixWrap(matrixOne->getCrsGraph()));
+
+      TEST_ASSERT(!matrixAfterSummation.is_null());
+
+      MatrixMatrix::TwoMatrixAdd(*matrixOne, false, 1.0, *matrixTwo, false, 1.0, matrixAfterSummation, out);
+
+      // We've added two identical matrices. Hence, entries need to be doubled values.
+      const LO lNumRows = static_cast<LO>(matrixAfterSummation->getNodeNumRows());
+      for (LO lRow = 0; lRow < lNumRows; ++lRow)
+      {
+        ArrayView<const LO> lCols;
+        ArrayView<const Scalar> vals;
+        matrixAfterSummation->getLocalRowView(lRow, lCols, vals);
+
+        if (lRow == 0)
+        {
+          TEST_EQUALITY_CONST(vals[0], SC_two);
+          TEST_EQUALITY_CONST(vals[1], -SC_two);
+        }
+        else if (lRow == lNumRows - 1)
+        {
+          TEST_EQUALITY_CONST(vals[0], -SC_two);
+          TEST_EQUALITY_CONST(vals[1], SC_two);
+        }
+        else
+        {
+          TEST_EQUALITY_CONST(vals[0], -SC_two);
+          TEST_EQUALITY_CONST(vals[1], SC_four);
+          TEST_EQUALITY_CONST(vals[2], -SC_two);
+        }
+      }
+    }
+  }
+
   //
   // INSTANTIATIONS
   //
@@ -481,6 +605,10 @@ namespace {
     typedef typename Xpetra::EpetraCrsMatrixT<GO,N> MA##S##LO##GO##N;
 
 #endif
+
+  // List of tests (which run both on Epetra and Tpetra)
+#define XP_MATRIX_INSTANT(S,LO,GO,N) \
+    TEUCHOS_UNIT_TEST_TEMPLATE_6_INSTANT( MatrixMatrix, AddTwoNonTransposedMatrices, M##LO##GO##N , MA##S##LO##GO##N, S, LO, GO, N )
 
   // List of tests which run only with Tpetra
 #define XP_TPETRA_MATRIX_INSTANT(S,LO,GO,N) \
@@ -502,6 +630,7 @@ namespace {
 TPETRA_ETI_MANGLING_TYPEDEFS()
 TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR ( XPETRA_TPETRA_TYPES )
 TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR ( XP_TPETRA_MATRIX_INSTANT )
+TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR ( XP_MATRIX_INSTANT )
 
 #endif
 
@@ -513,11 +642,13 @@ typedef Xpetra::EpetraNode EpetraNode;
 #ifndef XPETRA_EPETRA_NO_32BIT_GLOBAL_INDICES
 XPETRA_EPETRA_TYPES(double,int,int,EpetraNode)
 XP_EPETRA_MATRIX_INSTANT(double,int,int,EpetraNode)
+XP_MATRIX_INSTANT(double,int,int,EpetraNode)
 #endif
 #ifndef XPETRA_EPETRA_NO_64BIT_GLOBAL_INDICES
 typedef long long LongLong;
 XPETRA_EPETRA_TYPES(double,int,LongLong,EpetraNode)
 XP_EPETRA64_MATRIX_INSTANT(double,int,LongLong,EpetraNode)
+XP_MATRIX_INSTANT(double,int,LongLong,EpetraNode)
 #endif
 
 #endif


### PR DESCRIPTION
@trilinos/xpetra

## Motivation

- some cleanups
- add unit tests from `Map`, `MapUtils`, `MatrixMatrix`, and `MatrixUtils`utilities. This PR adds test helpers to create saddle-point tests.

## Related Issues

* Part of #8586 

## Stakeholder Feedback

Required for AMG preconditioning of saddle-point systems arising from mortar discretizations of contact mechanic problems

## Testing

Test for existing code have been added. Newly added code is covered with unit tests.

## Additional Information

Creating as Draft first, until all PRs related to #8586 are in place.
