### PR TITLE
Tpetra:  enable ReplaceDiagonal to work for CrsMatrix with overlapped row map

### DIFF
--- a/packages/tpetra/core/src/Tpetra_replaceDiagonalCrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_replaceDiagonalCrsMatrix_decl.hpp
@@ -64,7 +64,8 @@ namespace Tpetra {
 ///   for requirements.
 ///
 /// \param[in/out] matrix Tpetra::CrsMatrix to be modified
-/// \paran[in] newDiag Tpetra::Vector with new values for the diagonal
+/// \param[in] newDiag Tpetra::Vector with new values for the diagonal; must have same Tpetra::Map as matrix's rowMap
+///
 ///
 /// \return Local number of successfully replaced diagonal entries
 template<class SC, class LO, class GO, class NT>

--- a/packages/tpetra/core/src/Tpetra_replaceDiagonalCrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_replaceDiagonalCrsMatrix_def.hpp
@@ -117,16 +117,18 @@ replaceDiagonalCrsMatrix (CrsMatrix<SC, LO, GO, NT>& matrix,
     const SC vals[] = {static_cast<SC>(newDiagData[lclRowInd])};
     const LO cols[] = {lclColInd};
 
-    // Do the actual replacement of the diagonal element
-    numReplacedEntriesPerRow = matrix.replaceLocalValues(lclRowInd, oneLO, vals, cols);
+    // Do the actual replacement of the diagonal element, if on this proc
+    numReplacedEntriesPerRow = matrix.replaceLocalValues(lclRowInd, oneLO,
+                                                         vals, cols);
 
-    // Check for success of replacement
+    // Check for success of replacement. 
+    // numReplacedEntriesPerRow is one if the diagonal was replaced.
+    // numReplacedEntriesPerRow is zero if the diagonal is not on 
+    // this processor.  For example, in a 2D matrix distribution, gblInd may
+    // be in both the row and column map, but the diagonal may not be on 
+    // this processor.
     if (numReplacedEntriesPerRow == oneLO) {
       ++numReplacedDiagEntries;
-    } else {
-      TEUCHOS_TEST_FOR_EXCEPTION(true, std::runtime_error,
-        "Number of replaced entries in this row is not equal to one.  "
-        "It has to be exactly one, since we want to replace the diagonal element.");
     }
   }
 

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_ReplaceDiagonal.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_ReplaceDiagonal.cpp
@@ -81,10 +81,10 @@ namespace { // (anonymous)
     int gblSuccess = 0;
 
     RCP<const Comm<int> > comm = Tpetra::getDefaultComm ();
-    const size_t numImages = comm->getSize();
-    const size_t myImageID = comm->getRank();
+    const size_t numProc = comm->getSize();
+    const size_t myProc = comm->getRank();
 
-    if (myImageID == 0) {
+    if (myProc == 0) {
       cerr << "Tpetra replaceDiagonal test" << endl
            << "Create Map and matrix" << endl;
     }
@@ -100,12 +100,12 @@ namespace { // (anonymous)
 
     Teuchos::Array<Scalar> vals = {{SC_ONE, rankAsScalar + SC_ONE, SC_ONE}};
     for(size_t lclRowIdx = 0; lclRowIdx < 2; ++lclRowIdx) {
-      const GO gblRowIdx = Teuchos::as<GO>(2*myImageID + lclRowIdx);
+      const GO gblRowIdx = Teuchos::as<GO>(2*myProc + lclRowIdx);
       Teuchos::Array<GO> cols = {{gblRowIdx - GO_ONE, gblRowIdx, gblRowIdx + GO_ONE}};
 
-      if((myImageID == 0) && (lclRowIdx == 0)) { // First row of the matrix
+      if((myProc == 0) && (lclRowIdx == 0)) { // First row of the matrix
         matrix->insertGlobalValues(gblRowIdx, cols(1, 2), vals(1, 2));
-      } else if((myImageID == numImages - 1) && (lclRowIdx == 1)) { // Last row of the matrix
+      } else if((myProc == numProc - 1) && (lclRowIdx == 1)) { // Last row of the matrix
         matrix->insertGlobalValues(gblRowIdx, cols(0, 2), vals(0, 2));
       } else {
         matrix->insertGlobalValues(gblRowIdx, cols(), vals());
@@ -124,7 +124,7 @@ namespace { // (anonymous)
       TEST_EQUALITY_CONST( gblSuccess, 1 );
     }
 
-    if (myImageID == 0) {
+    if (myProc == 0) {
       cerr << "The matrix is now a FEM-type tri-diagonal mass matrix. "
            << "Let's replace all diagonal entries by the global ID of the owning proc." << endl;
     }
@@ -137,7 +137,7 @@ namespace { // (anonymous)
        * 3. Replace the diagonal
        * 4. Test for
        *    - successful replacement of diagonal values
-       *    - unchanged off-diagonal values (not implemented yet)
+       *    - unchanged off-diagonal values
        */
 
       // Create vector with new diagonal values
@@ -178,6 +178,28 @@ namespace { // (anonymous)
         for (size_t i = 0; i < diagCopyData.size(); ++i) {
           TEST_EQUALITY_CONST(diagCopyData(i,0), rankAsImplScalarType);
 	}
+
+        /* Test that no other matrix values were changed
+         */
+        
+        for (size_t i = 0; i < matrix->getRowMap()->getNodeNumElements(); i++) {
+          Teuchos::ArrayView<const LO> lcols;
+          Teuchos::ArrayView<const Scalar> lvals;
+          matrix->getLocalRowView(static_cast<LO>(i), lcols, lvals);
+          GO gI = matrix->getRowMap()->getGlobalElement(i);
+          auto j = lcols.size();
+          for (j = 0; j < lcols.size(); j++) {
+            GO gJ = matrix->getColMap()->getGlobalElement(lcols[j]);
+            if (gI == gJ) {
+              // Diagonal entry; value should be row GO
+              TEST_EQUALITY_CONST(lvals[j], rankAsImplScalarType);
+            }
+            else {
+              // Nondiagonal entry; value should be SC_MONE
+              TEST_EQUALITY_CONST(lvals[j], SC_ONE);
+            }
+          }
+        }
       }
     }
 
@@ -190,7 +212,215 @@ namespace { // (anonymous)
       TEST_EQUALITY_CONST( gblSuccess, 1 );
     }
 
-    if (myImageID == 0) {
+    if (myProc == 0) {
+      cerr << "All done!  Test " << (gblSuccess ? "succeeded" : "FAILED") << "."
+           << endl;
+    }
+  }
+
+  // Unit test of replacing the diagonal of a Tpetra::CrsMatrix with 
+  // overlapped row map
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( CrsMatrix, ReplaceDiagonalOverlapRowMap, Scalar, LO, GO, Node )
+  {
+    using Teuchos::Comm;
+    using Teuchos::outArg;
+    using Teuchos::RCP;
+    using Teuchos::rcp;
+    using Teuchos::REDUCE_MIN;
+    using Teuchos::REDUCE_SUM;
+    using Teuchos::reduceAll;
+    using std::cerr;
+    using std::endl;
+    using std::size_t;
+    typedef Tpetra::Map<LO, GO, Node> map_type;
+    typedef Tpetra::CrsMatrix<Scalar, LO, GO, Node> crs_matrix_type;
+    typedef Tpetra::Vector<Scalar, LO, GO, Node> vec_type;
+    typedef Teuchos::ScalarTraits<Scalar> STS;
+    const Scalar SC_MONE = -STS::one();
+    int lclSuccess = 0;
+    int gblSuccess = 0;
+
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm ();
+    const int nProc = comm->getSize();
+    const int myProc = comm->getRank();
+
+    if (myProc == 0) {
+      cerr << "Tpetra replaceDiagonalOverlapRowMap test" << endl
+           << "Create Map and matrix" << endl;
+    }
+    
+    RCP<crs_matrix_type> matrix;
+    LO nMyDiags = 0;
+    { // Create a tri-diagonal matrix with a 2D blockwise parallel distribution
+
+      // create 2D processor layout
+      int nProcRow = std::sqrt(nProc);
+      int nProcCol = nProc / nProcRow;
+      while (nProcRow * nProcCol != nProc) {
+        nProcRow--;
+        nProcCol = nProc / nProcRow;
+      }
+      if (myProc == 0) {
+        cerr << "Tpetra replaceDiagonalOverlapRowMap test" << endl
+             << "Processor layout:  " << nProcRow << " x " << nProcCol << endl;
+      }
+      int myProcRow = myProc % nProcRow;
+      int myProcCol = myProc / nProcRow;
+  
+      // create a Map with overlapped entries 
+      const int nRowPerProc = 10;
+      const int nRows = nRowPerProc * nProcRow;
+      const int nCols = nRows; // square matrix
+      GO myFirstRow = myProcRow * nRowPerProc;
+      GO myLastRow = myFirstRow + nRowPerProc - 1;
+      GO myFirstCol = myProcCol * (nCols / nProcCol);
+      GO myLastCol = (myProc < nProc-1 ? (myProcCol+1) * (nCols / nProcCol) 
+                                       : nRows-1);
+ 
+      const int maxNZPerRow = 3;
+      Teuchos::Array<GO> myRows(nRowPerProc);
+      Teuchos::Array<int> nNZPerRow(nRowPerProc, 0);
+      Teuchos::Array<GO> myJ(nRowPerProc * maxNZPerRow);
+
+      // Build tridiagonal matrix using 2D processor layout
+      for (int i = 0; i < nRows; i++) {
+        if (i >= myFirstRow && i <= myLastRow) {
+          // Diagonal entry
+          if (i >= myFirstCol && i <= myLastCol) {
+            nNZPerRow[i-myFirstRow]++;
+            myJ.push_back(i);
+            nMyDiags++;
+          }
+          // i+1 entry
+          if (i+1 < nRows && i+1 >= myFirstCol && i+1 <= myLastCol) {
+            nNZPerRow[i-myFirstRow]++;
+            myJ.push_back(i+1);
+          }
+          // i-1 entry
+          if (i-1 >= 0 && i-1 >= myFirstCol && i-1 <= myLastCol) {
+            nNZPerRow[i-myFirstRow]++;
+            myJ.push_back(i-1);
+          }
+          if (nNZPerRow[i-myFirstRow]) myRows.push_back(i);
+        }
+      }
+    
+      Tpetra::global_size_t dummy = 
+              Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid();
+      RCP<const map_type> map = rcp(new map_type(dummy, myRows(), 0, comm));
+
+      matrix = rcp (new crs_matrix_type (map, 3));
+
+      int curJ = 0;
+      Teuchos::Array<Scalar> vals(maxNZPerRow, SC_MONE);
+      for (int i = 0; i < nRowPerProc; i++) {
+        int nnz = nNZPerRow[i];
+        if (nnz > 0) 
+          matrix->insertGlobalValues(i+myFirstRow, myJ(curJ,nnz), vals(0,nnz));
+        curJ += nnz;
+      }
+
+      matrix->fillComplete();
+      TEST_ASSERT(matrix->isFillComplete());
+    }
+
+    // Make sure that all processes got this far.
+    {
+      lclSuccess = success ? 1 : 0;
+      gblSuccess = 0;
+      reduceAll<int, int> (*comm, REDUCE_MIN, lclSuccess, outArg (gblSuccess));
+      success = success && (gblSuccess == 1);
+      TEST_EQUALITY_CONST( gblSuccess, 1 );
+    }
+
+    if (myProc == 0) {
+      cerr << "The matrix is now a FEM-type tri-diagonal mass matrix. "
+           << "Replace diagonal entries by the global ID of row." << endl;
+    }
+    comm->barrier ();
+    {
+      /* Replace the diagonal of the matrix by the row's GNO
+       *
+       * 2. Create vector with new diagonal values using row map
+       * 3. Replace the diagonal
+       * 4. Test for
+       *    - successful replacement of diagonal values
+       *    - unchanged off-diagonal values 
+       */
+
+      // Create vector with new diagonal values (row GO)
+      RCP<vec_type> newDiag = rcp(new vec_type(matrix->getRowMap()));
+      auto newDiagData = newDiag->getLocalViewHost();
+      for (size_t i = 0; i < newDiag->getLocalLength(); i++) 
+        newDiagData(i,0) = newDiag->getMap()->getGlobalElement(i);
+
+      // Replace the diagonal
+      LO numReplacedDiagEntries = 
+         ::Tpetra::replaceDiagonalCrsMatrix<Scalar,LO,GO,Node>(*matrix,*newDiag);
+
+      // Tests
+      {
+        /* Test whether number of replaced diagonal entries is correct. */
+        TEST_EQUALITY_CONST(numReplacedDiagEntries, nMyDiags);
+
+        /* Test for successful replacement
+         *
+         * 1. Extract diagonal copy
+         * 2. Test if diagonal element matches rank ID that we intended to set
+         */
+
+        vec_type diagCopy (matrix->getRowMap());
+        matrix->getLocalDiagCopy(diagCopy);
+	diagCopy.sync_host();
+	auto diagCopyData = diagCopy.getLocalViewHost();
+
+	using impl_scalar_type = typename vec_type::impl_scalar_type;
+	// If Scalar is std::complex<T>, impl_scalar_type is
+	// Kokkos::complex<T>.  Otherwise, Scalar and impl_scalar_type
+	// are the same.
+        for (size_t i = 0; i < diagCopy.getLocalLength(); ++i) {
+	  const impl_scalar_type expected = 
+  	    static_cast<impl_scalar_type> 
+                       (diagCopy.getMap()->getGlobalElement(i));
+          TEST_EQUALITY_CONST(diagCopyData(i,0), expected);
+	}
+   
+        /* Test that no other matrix values were changed
+         */
+        
+        for (size_t i = 0; i < matrix->getRowMap()->getNodeNumElements(); i++) {
+          Teuchos::ArrayView<const LO> lcols;
+          Teuchos::ArrayView<const Scalar> lvals;
+          matrix->getLocalRowView(static_cast<LO>(i), lcols, lvals);
+          GO gI = matrix->getRowMap()->getGlobalElement(i);
+          auto j = lcols.size();
+          for (j = 0; j < lcols.size(); j++) {
+            GO gJ = matrix->getColMap()->getGlobalElement(lcols[j]);
+            if (gI == gJ) {
+              // Diagonal entry; value should be row GO
+	      const impl_scalar_type expected = 
+    	            static_cast<impl_scalar_type> (gI);
+              TEST_EQUALITY_CONST(lvals[j], expected);
+            }
+            else {
+              // Nondiagonal entry; value should be SC_MONE
+              TEST_EQUALITY_CONST(lvals[j], SC_MONE);
+            }
+          }
+        }
+      }
+    }
+
+    // Make sure that all processes got this far.
+    {
+      lclSuccess = success ? 1 : 0;
+      gblSuccess = 0;
+      reduceAll<int, int> (*comm, REDUCE_MIN, lclSuccess, outArg (gblSuccess));
+      success = success && (gblSuccess == 1);
+      TEST_EQUALITY_CONST( gblSuccess, 1 );
+    }
+
+    if (myProc == 0) {
       cerr << "All done!  Test " << (gblSuccess ? "succeeded" : "FAILED") << "."
            << endl;
     }
@@ -201,7 +431,8 @@ namespace { // (anonymous)
   //
 
 #define UNIT_TEST_GROUP( SCALAR, LO, GO, NODE ) \
-  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( CrsMatrix, ReplaceDiagonal, SCALAR, LO, GO, NODE )
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( CrsMatrix, ReplaceDiagonal, SCALAR, LO, GO, NODE ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( CrsMatrix, ReplaceDiagonalOverlapRowMap, SCALAR, LO, GO, NODE )
 
   TPETRA_ETI_MANGLING_TYPEDEFS()
 


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

Tpetra's code to replace diagonal values assumed 1D row-wise distribution of the matrix.  It was incorrect when other distributions were used.   These changes fix replaceDiagonalCrsMatrix to remove the assumption of 1D row-wise matrix distribution.

These changes are needed to use Tpetra in Grafiki. Power-law matrices (e.g., social networks) perform better using 2D matrix distributions than 1D (row-wise) distributions.


## Related Issues

* Closes 
* Blocks  #8472 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

@ndellingwood @seheracer 
Needed by #8472 

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Added new test ReplaceDiagonalOverlapRowMap added to CrsMatrix_ReplaceDiagonal.cpp that creates 2D block-wise distribution of tridiagonal matrix and replace diagonal values with row's globalID.
Also implemented check in old ReplaceDiagonal test to ensure that non-diagonal matrix entries were not changed.

Tested on mac with 1,2,3,4,...,9,12,16 processors.


<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->