### PR TITLE
Framework: Expand the envvars that get fully printed out in PR's

### DIFF
--- a/cmake/std/trilinosprhelpers/TrilinosPRConfigurationBase.py
+++ b/cmake/std/trilinosprhelpers/TrilinosPRConfigurationBase.py
@@ -587,7 +587,13 @@ class TrilinosPRConfigurationBase(object):
             "PROXY",
             "PATH",
             "OMP_",
-            "WORKSPACE"
+            "WORKSPACE",
+            "CC",
+            "CXX",
+            "F77",
+            "F90",
+            "FC",
+            "MODULESHOME"
             ]
         print("")
         tr_config.pretty_print_envvars(envvar_filter=envvars_to_print)


### PR DESCRIPTION
@trilinos/framework

## Motivation
The autotester driver does some filtering on whether or not it prints out the _value_ of an envvar in the logs because some envvars have a lot of content that's not relevant. Generally it prints out the envvar names, but not the value unless we include a partial string match to the envvar name in `TrilinosPRConfigurationBase.py`.

We missed adding envvars such as `CXX`, `CC`, `FC`, etc. to the list of envvars we should fully print out in the logs.

This PR addresses this by adding the flags `CC`, `CXX`, `F77`, `F90`, `FC`, `MODULESHOME` so that their values will be printed out to the console during a PR run in the future.

- Related to #8401
- Related to #8520
- Related to #8521