### PR TITLE
ATDM:  Update CMake on Chama to 3.19.1

### DIFF
--- a/cmake/std/atdm/common/toss3/environment_tlcc2.sh
+++ b/cmake/std/atdm/common/toss3/environment_tlcc2.sh
@@ -24,7 +24,7 @@ module purge &> /dev/null
 module purge
 . /projects/sems/modulefiles/utils/sems-modules-init.sh
 module load sems-env
-module load cmake/3.12.2
+module load sems-cmake/3.19.1
 module load sems-ninja_fortran/1.8.2
 
 if [ "$ATDM_CONFIG_NODE_TYPE" == "OPENMP" ] ; then


### PR DESCRIPTION
## Motivation
EMPIRE ran into a problem deploying on Chama, and the culprit looks like
it's using an older CMake version.  When the environment for Chama was
created, 3.12 was the best available, but now we can update to 3.19, so
we'll go ahead and do that.

## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
Testing now.