### PR TITLE
Teuchos TimeMonitor: Print more info on overlapping timers

### DIFF
--- a/packages/teuchos/comm/src/Teuchos_TimeMonitor.cpp
+++ b/packages/teuchos/comm/src/Teuchos_TimeMonitor.cpp
@@ -273,7 +273,7 @@ namespace Teuchos {
         if (nonnull(stackedTimer_))
           stackedTimer_->stop(counter().name(),false);
       }
-      catch (std::runtime_error&) {
+      catch (std::runtime_error& e) {
         std::ostringstream warning;
         warning <<
           "\n*********************************************************************\n"
@@ -290,7 +290,7 @@ namespace Teuchos {
           "MM = Teuchos::null;\n"
           "MM = rcp(new TimeMonitor(*(TimeMonitor::getNewTimer(\"SecondJunk\"))));\n"
           "*********************************************************************\n";
-        std::cout << warning.str() << std::endl;
+        std::cout << warning.str() << std::endl << e.what() << std::endl;
         Teuchos::TimeMonitor::setStackedTimer(Teuchos::null);
       }
 #endif


### PR DESCRIPTION
@trilinos/teuchos 

## Motivation
Print the exception message coming out of the stacked timers, since it says which two timers are overlapping. This makes debugging a bit easier.