### PR TITLE
Tpetra:  store permutation matrix (rather than its transpose) for LowerTriangularBlock distribution

### DIFF
--- a/packages/tpetra/core/inout/Tpetra_DistributionLowerTriangularBlock.hpp
+++ b/packages/tpetra/core/inout/Tpetra_DistributionLowerTriangularBlock.hpp
@@ -427,7 +427,7 @@ private:
   // in decreasing sort order of number of nonzeros per row in full matrix
   bool sortByDegree;
 
-  // Permutation matrix built only when sortByDegree = true;
+  // Column permutation matrix built only when sortByDegree = true;
   Teuchos::RCP<matrix_t> permMatrix;
 
   // Flag whether redistribution has occurred yet
@@ -510,20 +510,20 @@ public:
       lowerTriangularMatrix->apply(x, y, Teuchos::TRANS, alpha, ONE);
 
       // Subtract out duplicate diagonal terms
-      y.elementWiseMultiply(-ONE, *diag, x, ONE);
+      y.elementWiseMultiply(-alpha, *diag, x, ONE);
     }
     else {
 
-      // With sorting, the LowerTriangularBlock distribution stores (P A P)
+      // With sorting, the LowerTriangularBlock distribution stores (P^T A P)
       // in the CrsMatrix, for permutation matrix P. 
       // Thus, apply must compute
-      // y = P^T (beta (P y) + alpha (P A P) (P^T x))
+      // y = P (beta (P^T y) + alpha (P^T A P) (P^T x))
 
       vector_t xtmp(x.getMap(), x.getNumVectors());
       vector_t ytmp(y.getMap(), y.getNumVectors());
 
       permMatrix->apply(x, xtmp, Teuchos::TRANS);
-      permMatrix->apply(y, ytmp, Teuchos::NO_TRANS);
+      if (beta != ZERO) permMatrix->apply(y, ytmp, Teuchos::TRANS);
 
       // Multiply lower triangular
       lowerTriangularMatrix->apply(xtmp, ytmp, Teuchos::NO_TRANS, alpha, beta);
@@ -532,9 +532,9 @@ public:
       lowerTriangularMatrix->apply(xtmp, ytmp, Teuchos::TRANS, alpha, ONE);
 
       // Subtract out duplicate diagonal terms
-      ytmp.elementWiseMultiply(-ONE, *diag, xtmp, ONE);
+      ytmp.elementWiseMultiply(-alpha, *diag, xtmp, ONE);
 
-      permMatrix->apply(ytmp, y, Teuchos::TRANS);
+      permMatrix->apply(ytmp, y, Teuchos::NO_TRANS);
     }
   }
 


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->


## Motivation
@trilinos/tpetra 
The sorted LowerTriangularBlock distribution stores a column permutation matrix that is used to correctly apply the matrix in the LowerTriangularBlockOperator.  This PR corrects use of the permutation matrix in the LowerTriangularBlockOperator.  It also corrects the operation y = by + aAx in LowerTriangualBlockOperator; scalar a was previously handled incorrectly.
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
@ndellingwood 

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Passes the sorted LowerTriangularBlock tests in Tpetra/core/test/inout on mac.
These tests exercise the distribution and the operator.
Tests are enhanced to check that result of apply is correctly permuted for sorted LowerTriangularBlock.
Also, tests are enhanced to use apply y = by + aAx (rather than just y = Ax).


<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->