### PR TITLE
intrepid2: fix clang warning autological overlap compare.

### DIFF
--- a/packages/intrepid2/src/Discretization/Integration/Intrepid2_CubatureTensorDef.hpp
+++ b/packages/intrepid2/src/Discretization/Integration/Intrepid2_CubatureTensorDef.hpp
@@ -133,7 +133,7 @@ namespace Intrepid2 {
         break;
       }
       default: {
-        INTREPID2_TEST_FOR_EXCEPTION( this->numCubatures_ != 2 || this->numCubatures_ != 3, std::runtime_error,
+        INTREPID2_TEST_FOR_EXCEPTION( !(this->numCubatures_ == 2 || this->numCubatures_ == 3), std::runtime_error,
                                       ">>> ERROR (CubatureTensor::getCubature): CubatureTensor supports only 2 or 3 component direct cubatures.");
       }
       }


### PR DESCRIPTION
@trilinos/Intrepid2
@mperego @kyungjoo-kim 

## Motivation
* closes #8614

## Testing
Triggered by exception handling...