### PR TITLE
MueLu: Fix BGS and Blocked Jacobi logic when InitialGuessIsZero

### DIFF
--- a/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_BlockedGaussSeidelSmoother_def.hpp
+++ b/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_BlockedGaussSeidelSmoother_def.hpp
@@ -303,12 +303,9 @@ namespace MueLu {
     Scalar omega = pL.get<Scalar>("Damping factor");
 
 
-    // Clear solution from previos V cycle if still stored
-    Scalar normX = rcpX->getVector(0)->norm2();
-    if(InitialGuessIsZero==true && normX > 0){
+    // Clear solution from previos V cycles in case it is still stored
+    if( InitialGuessIsZero==true )
       rcpX->putScalar(Teuchos::ScalarTraits<Scalar>::zero());
-      // Is there a better way to do this?
-    }
 
 
     // outer Richardson loop

--- a/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_BlockedGaussSeidelSmoother_def.hpp
+++ b/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_BlockedGaussSeidelSmoother_def.hpp
@@ -302,6 +302,15 @@ namespace MueLu {
     LocalOrdinal nSweeps = pL.get<LocalOrdinal>("Sweeps");
     Scalar omega = pL.get<Scalar>("Damping factor");
 
+
+    // Clear solution from previos V cycle if still stored
+    Scalar normX = rcpX->getVector(0)->norm2();
+    if(InitialGuessIsZero==true && normX > 0){
+      rcpX->putScalar(Teuchos::ScalarTraits<Scalar>::zero());
+      // Is there a better way to do this?
+    }
+
+
     // outer Richardson loop
     for (LocalOrdinal run = 0; run < nSweeps; ++run) {
       // one BGS sweep
@@ -313,7 +322,6 @@ namespace MueLu {
         residual->update(1.0,*rcpB,0.0); // r = B
         if(InitialGuessIsZero == false || i > 0 || run > 0)
           bA->bgs_apply(*rcpX, *residual, i, Teuchos::NO_TRANS, -1.0, 1.0);
-          //A_->apply(*rcpX, *residual, Teuchos::NO_TRANS, -1.0, 1.0);
 
         // extract corresponding subvectors from X and residual
         bool bRangeThyraMode =  rangeMapExtractor_->getThyraMode();
@@ -328,8 +336,6 @@ namespace MueLu {
         // update vector
         Xi->update(omega,*tXi,1.0);  // X_{i+1} = X_i + omega \Delta X_i
 
-        // update corresponding part of rhs and lhs
-        domainMapExtractor_->InsertVector(Xi, i, rcpX, bDomainThyraMode); // TODO wrong! fix me
       }
     }
 

--- a/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_BlockedJacobiSmoother_def.hpp
+++ b/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_BlockedJacobiSmoother_def.hpp
@@ -295,14 +295,12 @@ namespace MueLu {
 
     // outer Richardson loop
     for (LocalOrdinal run = 0; run < nSweeps; ++run) {
+      residual->update(1.0,*rcpB,0.0); // r = B
+      if(InitialGuessIsZero == false || run > 0){
+        bA->apply(*rcpX, *residual, Teuchos::NO_TRANS, -1.0, 1.0);
+      }
       // one sweep of Jacobi: loop over all block rows
       for(size_t i = 0; i<Inverse_.size(); i++) {
-
-        // calculate block residual r = B-A*X
-        // note: A_ is the full blocked operator
-        residual->update(1.0,*rcpB,0.0); // r = B
-        if(InitialGuessIsZero == false || i > 0 || run > 0)
-          bA->bgs_apply(*rcpX, *residual, i, Teuchos::NO_TRANS, -1.0, 1.0);
 
         // extract corresponding subvectors from X and residual
         bool bRangeThyraMode =  rangeMapExtractor_->getThyraMode();
@@ -315,7 +313,11 @@ namespace MueLu {
         Inverse_.at(i)->Apply(*tXi, *ri, false);
 
         // update vector
-        Xi->update(omega,*tXi,1.0); // X_{i+1} = X_i + omega \Delta X_i
+        if( InitialGuessIsZero && run == 0 ){
+          Xi->update(omega,*tXi,0.0); // X_{i+1} = X_i + omega \Delta X_i
+        } else {
+          Xi->update(omega,*tXi,1.0); // X_{i+1} = X_i + omega \Delta X_i
+        }
 
       }
     }

--- a/packages/muelu/test/unit_tests/Smoothers/BlockedSmoother.cpp
+++ b/packages/muelu/test/unit_tests/Smoothers/BlockedSmoother.cpp
@@ -378,12 +378,12 @@ namespace MueLuTests {
       TEUCHOS_TEST_COMPARE(residualNorm1[0], <, 5e-15, out, success);
       TEUCHOS_TEST_COMPARE(finalNorms[0] - Teuchos::ScalarTraits<Scalar>::magnitude(Teuchos::ScalarTraits<Scalar>::one()), <, 5e-15, out, success);
 
-      out << "solve with random initial guess" << std::endl;
+      out << "solve with zero initial guess, and unreliable nonzeroed vector X" << std::endl;
       X->randomize();
       X->norm2(initialNorms);
       out << "  ||X_initial|| = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) << initialNorms[0] << std::endl;
 
-      jacSmoother->Apply(*X, *RHS, false); //nonzero initial guess
+      jacSmoother->Apply(*X, *RHS, true); //zero initial guess with nonzero X
 
       X->norm2(finalNorms);
       Teuchos::Array<magnitude_type> residualNorm2 = Utilities::ResidualNorm(*A, *X, *RHS);
@@ -393,8 +393,24 @@ namespace MueLuTests {
       TEUCHOS_TEST_COMPARE(residualNorm2[0], <, 5e-15, out, success);
       TEUCHOS_TEST_COMPARE(finalNorms[0] - Teuchos::ScalarTraits<Scalar>::magnitude(Teuchos::ScalarTraits<Scalar>::one()), <, 5e-15, out, success);
 
+      out << "solve with random initial guess" << std::endl;
+      X->randomize();
+      X->norm2(initialNorms);
+      out << "  ||X_initial|| = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) << initialNorms[0] << std::endl;
+
+      jacSmoother->Apply(*X, *RHS, false); //nonzero initial guess
+
+      X->norm2(finalNorms);
+      Teuchos::Array<magnitude_type> residualNorm3 = Utilities::ResidualNorm(*A, *X, *RHS);
+      out << "  ||Residual_final|| = " << std::setiosflags(std::ios::fixed) << std::setprecision(20) << residualNorm3[0] << std::endl;
+      out << "  ||X_final|| = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) << finalNorms[0] << std::endl;
+
+      TEUCHOS_TEST_COMPARE(residualNorm3[0], <, 5e-15, out, success);
+      TEUCHOS_TEST_COMPARE(finalNorms[0] - Teuchos::ScalarTraits<Scalar>::magnitude(Teuchos::ScalarTraits<Scalar>::one()), <, 5e-15, out, success);
+
       if (comm->getSize() == 1) {
-        TEST_EQUALITY(residualNorm1[0] != residualNorm2[0], true);
+        TEST_EQUALITY(residualNorm1[0] == residualNorm2[0], true);
+        TEST_EQUALITY(residualNorm1[0] != residualNorm3[0], true);
       } else {
         out << "Pass/Fail is only checked in serial." << std::endl;
       }
@@ -504,12 +520,12 @@ namespace MueLuTests {
       TEUCHOS_TEST_COMPARE(residualNorm1[0], <, 5e-15, out, success);
       TEUCHOS_TEST_COMPARE(finalNorms[0] - Teuchos::ScalarTraits<Scalar>::magnitude(Teuchos::ScalarTraits<Scalar>::one()), <, 5e-15, out, success);
 
-      out << "solve with random initial guess" << std::endl;
+      out << "solve with zero initial guess, and unreliable nonzeroed vector X" << std::endl;
       X->randomize();
       X->norm2(initialNorms);
       out << "  ||X_initial|| = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) << initialNorms[0] << std::endl;
 
-      bgsSmoother->Apply(*X, *RHS, false); //nonzero initial guess
+      bgsSmoother->Apply(*X, *RHS, true);  //zero initial guess with nonzero X
 
       X->norm2(finalNorms);
       Teuchos::Array<magnitude_type> residualNorm2 = Utilities::ResidualNorm(*A, *X, *RHS);
@@ -519,8 +535,24 @@ namespace MueLuTests {
       TEUCHOS_TEST_COMPARE(residualNorm2[0], <, 5e-15, out, success);
       TEUCHOS_TEST_COMPARE(finalNorms[0] - Teuchos::ScalarTraits<Scalar>::magnitude(Teuchos::ScalarTraits<Scalar>::one()), <, 5e-15, out, success);
 
+      out << "solve with random initial guess" << std::endl;
+      X->randomize();
+      X->norm2(initialNorms);
+      out << "  ||X_initial|| = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) << initialNorms[0] << std::endl;
+
+      bgsSmoother->Apply(*X, *RHS, false); //nonzero initial guess
+
+      X->norm2(finalNorms);
+      Teuchos::Array<magnitude_type> residualNorm3 = Utilities::ResidualNorm(*A, *X, *RHS);
+      out << "  ||Residual_final|| = " << std::setiosflags(std::ios::fixed) << std::setprecision(20) << residualNorm3[0] << std::endl;
+      out << "  ||X_final|| = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) << finalNorms[0] << std::endl;
+
+      TEUCHOS_TEST_COMPARE(residualNorm3[0], <, 5e-15, out, success);
+      TEUCHOS_TEST_COMPARE(finalNorms[0] - Teuchos::ScalarTraits<Scalar>::magnitude(Teuchos::ScalarTraits<Scalar>::one()), <, 5e-15, out, success);
+
       if (comm->getSize() == 1) {
-        TEST_EQUALITY(residualNorm1[0] != residualNorm2[0], true);
+        TEST_EQUALITY(residualNorm1[0] == residualNorm2[0], true);
+        TEST_EQUALITY(residualNorm1[0] != residualNorm3[0], true);
       } else {
         out << "Pass/Fail is only checked in serial." << std::endl;
       }


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/muelu 

## Motivation
The logic with `InitialGuessIsZero` int BlockedGaussSeidel and BlockedJacobi smoothers resulted in the use of a solution from the previous V-cycle as an initial guess instead of an actual zero initial guess.

This also fixes a bug where BlockedJacobi would update the residual after each block, resulting in a Gauss-Seidel-like method.
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->



## Related Issues
Appears to resolve convergence issues discussed in:
rppawlo/DrekarBase#505


## Testing 
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->