### PR TITLE
.github/workflows: Automate Build Triage management

### DIFF
--- a/.github/workflows/assigned-issues-in-progress.yml
+++ b/.github/workflows/assigned-issues-in-progress.yml
@@ -1,0 +1,15 @@
+name: Move assigned issues into In Progress
+
+on:
+  issues:
+    types: [assigned]
+
+jobs:
+  automate-project-columns:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: alex-page/github-project-automation-plus@v0.3.0
+        with:
+          project: Build Triage
+          column: In Progress
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Automate moving cards to the In Progress column of the Build Triage project when an issue is assigned to an entity.