### PR TITLE
cmake/std/atdm: Disable Kokkos timing based test

### DIFF
--- a/cmake/std/atdm/ATDMDisables.cmake
+++ b/cmake/std/atdm/ATDMDisables.cmake
@@ -250,6 +250,9 @@ ATDM_SET_ENABLE(Piro_AnalysisDriverTpetra_MPI_4_DISABLE ON)
 ATDM_SET_ENABLE(ROL_adapters_tpetra_test_vector_SimulatedVectorTpetraBatchManagerInterface_EXE_DISABLE ON)
 ATDM_SET_ENABLE(ROL_adapters_tpetra_test_vector_SimulatedVectorTpetraBatchManagerInterface_MPI_4_DISABLE ON)
 
+# Disable Kokkos timing based test. See #8545.
+ATDM_SET_ENABLE(KokkosCore_UnitTest_CudaTimingBased_MPI_1_DISABLE ON)
+
 IF (ATDM_NODE_TYPE STREQUAL "OPENMP")
 
   # Disable ctest DISABLED test (otherwise, this shows up on CDash as "NotRun")


### PR DESCRIPTION
Addresses #8545