### PR TITLE
tpetra:  removed use of device_type in BlockView test

### DIFF
--- a/packages/tpetra/core/test/Block/BlockView.cpp
+++ b/packages/tpetra/core/test/Block/BlockView.cpp
@@ -43,7 +43,6 @@
 
 #include "Tpetra_TestingUtilities.hpp"
 #include "Tpetra_BlockView.hpp"
-#include "Tpetra_Vector.hpp"
 #include "Teuchos_Array.hpp"
 #include "Teuchos_BLAS.hpp"
 #include "Teuchos_LAPACK.hpp"
@@ -111,11 +110,10 @@ namespace {
   {
     using Teuchos::Array;
     typedef typename Kokkos::Details::ArithTraits<ST>::val_type IST;
-    typedef typename Tpetra::Vector<ST, LO>::device_type device_type;
     typedef Teuchos::LAPACK<LO, ST> lapack_type;
-    typedef Kokkos::View<IST**, Kokkos::LayoutLeft, device_type> block_type;
-    typedef Kokkos::View<LO*, device_type> int_vec_type;
-    typedef Kokkos::View<IST*, device_type> scalar_vec_type;
+    typedef Kokkos::View<IST**, Kokkos::LayoutLeft, Kokkos::HostSpace> block_type;
+    typedef Kokkos::View<LO*, Kokkos::HostSpace> int_vec_type;
+    typedef Kokkos::View<IST*, Kokkos::HostSpace> scalar_vec_type;
 
     const auto tol = 10.0 * Kokkos::Details::ArithTraits<IST>::eps ();
 
@@ -209,11 +207,10 @@ namespace {
   {
     using Teuchos::Array;
     typedef typename Kokkos::Details::ArithTraits<ST>::val_type IST;
-    typedef typename Tpetra::Vector<ST, LO>::device_type device_type;
     typedef Teuchos::LAPACK<LO, ST> lapack_type;
-    typedef Kokkos::View<IST**, Kokkos::LayoutLeft, device_type> block_type;
-    typedef Kokkos::View<LO*, device_type> int_vec_type;
-    typedef Kokkos::View<IST*, device_type> scalar_vec_type;
+    typedef Kokkos::View<IST**, Kokkos::LayoutLeft, Kokkos::HostSpace> block_type;
+    typedef Kokkos::View<LO*, Kokkos::HostSpace> int_vec_type;
+    typedef Kokkos::View<IST*, Kokkos::HostSpace> scalar_vec_type;
 
     const auto tol = 10.0 * Kokkos::Details::ArithTraits<IST>::eps ();
 


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

The BlockView.cpp test exercises LAPACK functions provided by Tpetra (GETF2, GETRS, etc.).

It had used Kokkos::Views declared using the device_type, but in truth, the tests run on host.  The device_type declaration was misleading (fake news) and didn't work without UVM.

This PR changes the view declarations to use HostSpace memory.

This test probably *should* exercise the Tpetra LAPACK implementations on device, since the intent of the functions likely is to be applied with parallelism over many small blocks.  Such an extension would be a nice addition to this test, but it is not provided in this PR.   This PR checks only the correctness of the functions for a single block.

Fixed while working on #8591 

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
CEE-LAN GPU machine, CUDA build, with and without UVM

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->