### PR TITLE
ATDM:  Turn Anasazi on for EMPIRE

### DIFF
--- a/cmake/std/atdm/apps/empire/EMPIRETrilinosPackagesList.cmake
+++ b/cmake/std/atdm/apps/empire/EMPIRETrilinosPackagesList.cmake
@@ -5,4 +5,5 @@ SET(EMPIRE_Trilinos_Packages
   SEACASNemspread
   SEACASNemslice
   SEACASAprepro
+  Anasazi
   )


### PR DESCRIPTION
## Motivation
EMPIRE needs to turn Anasazi on in order to solve eigen systems to obtain TE and TM modes on surfaces.

## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
Testing manually now.