### PR TITLE
Intrepid2: Added CMake flag to run the "MonolithicExecutable" Intrepid2 tests in serial (as opposed to MPI), to avoid some timeouts that can occur on some CUDA platforms.

### DIFF
--- a/cmake/std/PullRequestLinuxCuda9.2TestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxCuda9.2TestingSettings.cmake
@@ -85,7 +85,7 @@ set (Trilinos_ENABLE_ShyLU_NodeTacho OFF CACHE BOOL
   "Can't test Tacho with CUDA without RDC" FORCE)
 
 # Force some tests to run in serial in this PR build (usually to resolve random timeouts that can occur under contention)
-set (Intrepid2_unit-test_Discretization_Basis_HierarchicalBases_Hierarchical_Basis_Tests_MPI_1_SET_RUN_SERIAL ON CACHE BOOL "Run serial for CUDA PR testing")
+set (Intrepid2_unit-test_MonolithicExecutable_Intrepid2_Tests_MPI_1_SET_RUN_SERIAL ON CACHE BOOL "Run serial for CUDA PR testing")
 
 # Temporary options to clean up build
 set (Teko_ModALPreconditioner_MPI_1_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")

--- a/cmake/std/atdm/ATDMDisables.cmake
+++ b/cmake/std/atdm/ATDMDisables.cmake
@@ -323,4 +323,7 @@ IF (ATDM_NODE_TYPE STREQUAL "CUDA")
   ATDM_SET_ENABLE(KokkosCore_UnitTest_CudaInterOpStreams_MPI_1_SET_RUN_SERIAL ON)
   # See #8543.
   ATDM_SET_ENABLE(KokkosCore_UnitTest_CudaInterOpInit_MPI_1_SET_RUN_SERIAL ON)
+
+  # See #8516.
+  ATDM_SET_ENABLE(Intrepid2_unit-test_MonolithicExecutable_Intrepid2_Tests_MPI_1_SET_RUN_SERIAL ON)
 ENDIF()


### PR DESCRIPTION
Intrepid2: Added CMake flag to run the "MonolithicExecutable" Intrepid2 tests in serial (as opposed to MPI), to avoid some timeouts that can occur on some CUDA platforms.

@trilinos/intrepid2 

## Motivation
As discussed in #8516, the new `Intrepid2_unit-test_MonolithicExecutable_Intrepid2_Tests_MPI_1`, which encompasses many unit tests, can time out on some CUDA test platforms.  This PR adds a flag to run this test in serial (as opposed to having multiple tests running simultaneously) to ensure that this test is not competing with others for CUDA resources.

## Testing
N/A.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->