### PR TITLE
Panzer: Improve the performance of the the CubeHexMeshFactory

### DIFF
--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.cpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.cpp
@@ -528,6 +528,13 @@ void STK_Interface::addEntityToEdgeBlock(stk::mesh::Entity entity,stk::mesh::Par
 
    bulkData_->change_entity_parts(entity,edgeblockV);
 }
+void STK_Interface::addEntitiesToEdgeBlock(std::vector<stk::mesh::Entity> entities,stk::mesh::Part * edgeblock)
+{
+   std::vector<stk::mesh::Part*> edgeblockV;
+   edgeblockV.push_back(edgeblock);
+
+   bulkData_->change_entity_parts(entities,edgeblockV);
+}
 
 void STK_Interface::addEntityToFaceBlock(stk::mesh::Entity entity,stk::mesh::Part * faceblock)
 {
@@ -535,6 +542,13 @@ void STK_Interface::addEntityToFaceBlock(stk::mesh::Entity entity,stk::mesh::Par
    faceblockV.push_back(faceblock);
 
    bulkData_->change_entity_parts(entity,faceblockV);
+}
+void STK_Interface::addEntitiesToFaceBlock(std::vector<stk::mesh::Entity> entities,stk::mesh::Part * faceblock)
+{
+   std::vector<stk::mesh::Part*> faceblockV;
+   faceblockV.push_back(faceblock);
+
+   bulkData_->change_entity_parts(entities,faceblockV);
 }
 
 void STK_Interface::addElement(const Teuchos::RCP<ElementDescriptor> & ed,stk::mesh::Part * block)

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.hpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.hpp
@@ -238,10 +238,16 @@ public:
    /** Adds an entity to a specified edge block.
      */
    void addEntityToEdgeBlock(stk::mesh::Entity entity,stk::mesh::Part * edgeblock);
+   /** Adds a vector of entities to a specified edge block.
+     */
+   void addEntitiesToEdgeBlock(std::vector<stk::mesh::Entity> entities,stk::mesh::Part * edgeblock);
 
    /** Adds an entity to a specified face block.
      */
    void addEntityToFaceBlock(stk::mesh::Entity entity,stk::mesh::Part * faceblock);
+   /** Adds a vector of entities to a specified face block.
+     */
+   void addEntitiesToFaceBlock(std::vector<stk::mesh::Entity> entities,stk::mesh::Part * faceblock);
 
    // Methods to interrogate the mesh topology and structure
    //////////////////////////////////////////

--- a/packages/panzer/adapters-stk/test/stk_interface_test/tCubeHexMeshFactory.cpp
+++ b/packages/panzer/adapters-stk/test/stk_interface_test/tCubeHexMeshFactory.cpp
@@ -145,6 +145,43 @@ TEUCHOS_UNIT_TEST(tCubeHexMeshFactory, element_counts)
    TEST_EQUALITY(mesh->getEntityCounts(mesh->getElementRank()),4*2*5);
    TEST_EQUALITY(mesh->getEntityCounts(mesh->getSideRank()),2*4*(5+1)+2*5*(4+1)+4*5*(2+1));
    TEST_EQUALITY(mesh->getEntityCounts(mesh->getEdgeRank()),2*(4+1)*(5+1)+4*(2+1)*(5+1)+5*(2+1)*(4+1));
+   TEST_EQUALITY(mesh->getEntityCounts(mesh->getFaceRank()),2*4*(5+1)+2*5*(4+1)+4*5*(2+1));
+   TEST_EQUALITY(mesh->getEntityCounts(mesh->getNodeRank()),(4+1)*(2+1)*(5+1));
+}
+
+TEUCHOS_UNIT_TEST(tCubeHexMeshFactory, disable_subcells)
+{
+   using Teuchos::RCP;
+   using Teuchos::rcp;
+   using Teuchos::rcpFromRef;
+
+   RCP<Teuchos::ParameterList> pl = rcp(new Teuchos::ParameterList);
+   pl->set("X Blocks",1);
+   pl->set("Y Blocks",1);
+   pl->set("Z Blocks",1);
+   pl->set("X Elements",2);
+   pl->set("Y Elements",4);
+   pl->set("Z Elements",5);
+   pl->set("Build Subcells",false);
+   
+   CubeHexMeshFactory factory; 
+   factory.setParameterList(pl);
+   RCP<STK_Interface> mesh = factory.buildMesh(MPI_COMM_WORLD);
+   TEST_ASSERT(mesh!=Teuchos::null);
+ 
+   if(mesh->isWritable())
+      mesh->writeToExodus("CubeHex_disable_subcells.exo");
+
+   // minimal requirements
+   TEST_ASSERT(not mesh->isModifiable());
+
+   TEST_EQUALITY(mesh->getDimension(),3);
+   TEST_EQUALITY(mesh->getNumElementBlocks(),1);
+   TEST_EQUALITY(mesh->getNumSidesets(),6);
+   TEST_EQUALITY(mesh->getEntityCounts(mesh->getElementRank()),4*2*5);
+   TEST_EQUALITY(mesh->getEntityCounts(mesh->getSideRank()),2*4*2 + 2*5*2 + 4*5*2);
+   TEST_EQUALITY(mesh->getEntityCounts(mesh->getEdgeRank()),0);
+   TEST_EQUALITY(mesh->getEntityCounts(mesh->getFaceRank()),2*4*2 + 2*5*2 + 4*5*2);
    TEST_EQUALITY(mesh->getEntityCounts(mesh->getNodeRank()),(4+1)*(2+1)*(5+1));
 }
 


### PR DESCRIPTION
@trilinos/panzer 

This PR improves the performance of CubeHexMeshFactory in two ways.  First, it replaces multiple calls to addEntityToEdgeBlock() 
with a single call to addEntitiesToEdgeBlock() that adds a vector of entities all at once.  The same is done for addEntityToFaceBlock().  Second, it groups multiple mesh modifications into a single block with only one call to beginModification() and endModification().

This could impact subclasses of CubeHexMeshFactory that call addSideSets(), addNodeSets(), addEdgeBlocks() and addFaceBlocks().  These methods now expect that beginModification() has been called externally prior to entry.  They also expect that endModification() will be called externally after exit.

This PR also adds a disable_subcells test to tCubeHexMeshFactory.  This test checks the "Build Subcells: false" case.


## Related Issues

* Closes #8635 

