### PR TITLE
MiniTensor: Fix inconsistent KOKKOS_INLINE_FUNCTION markings

### DIFF
--- a/packages/minitensor/src/MiniTensor_Geometry.t.h
+++ b/packages/minitensor/src/MiniTensor_Geometry.t.h
@@ -402,7 +402,6 @@ in_hexahedron(
 // \return index to closest point
 //
 template<typename T, Index N>
-KOKKOS_INLINE_FUNCTION
 typename std::vector<Vector<T, N>>::size_type
 closest_point(Vector<T, N> const & p, std::vector<Vector<T, N>> const & n)
 {

--- a/packages/minitensor/src/MiniTensor_Mechanics.t.h
+++ b/packages/minitensor/src/MiniTensor_Mechanics.t.h
@@ -613,7 +613,6 @@ check_strict_ellipticity(Tensor4<T, N> const & A)
 // Assume A has major and minor symmetries.
 //
 template<typename T, Index N>
-KOKKOS_INLINE_FUNCTION
 std::pair<bool, Vector<T, N>>
 check_strong_ellipticity(Tensor4<T, N> const & A)
 {


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/MiniTensor
@lxmota 

## Motivation
Fix warnings coming from KOKKOS_INLINE_FUNCTION markings on functions that use C++ STL constructs.

## Related Issues
* Closes #8650

## Testing
N/A