### PR TITLE
Framework: Fix PyTest regex checker

### DIFF
--- a/cmake/std/common.bash
+++ b/cmake/std/common.bash
@@ -170,26 +170,26 @@ function get_md5sum() {
 #
 # Get pip
 # - @param1 python_exe - the python executable to install PIP for
-function get_pip() {
-    local python_exe=${1:?}
-
-    echo -e "--- get_pip():"
-    echo -e "--- Python: ${python_exe:?}"
-
-    # fetch get-pip.py
-    echo -e "--- curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py"
-    curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-
-    get_pip_args=(
-        --user
-        --proxy="http://user:nopass@wwwproxy.sandia.gov:80"
-        --no-setuptools
-        --no-wheel
-    )
-    echo -e ""
-    echo -e "--- ${python_exe:?} ./get-pip.py ${get_pip_args[@]}"
-    ${python_exe:?} ./get-pip.py ${get_pip_args[@]}
-}
+#function get_pip() {
+#    local python_exe=${1:?}
+#
+#    echo -e "--- get_pip():"
+#    echo -e "--- Python: ${python_exe:?}"
+#
+#    # fetch get-pip.py
+#    echo -e "--- curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py"
+#    curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+#
+#    get_pip_args=(
+#        --user
+#        --proxy="http://user:nopass@wwwproxy.sandia.gov:80"
+#        --no-setuptools
+#        --no-wheel
+#    )
+#    echo -e ""
+#    echo -e "--- ${python_exe:?} ./get-pip.py ${get_pip_args[@]}"
+#    ${python_exe:?} ./get-pip.py ${get_pip_args[@]}
+#}
 
 
 

--- a/cmake/std/pr_python_test_driver.sh
+++ b/cmake/std/pr_python_test_driver.sh
@@ -35,8 +35,8 @@ get_python_packages ${pip_exe:?}
 
 message_std "" ""
 print_banner "E X E C U T E   T E S T S"
-message_std "--- " "${python_exe:?} -m pytest --cov=trilinosprhelpers --cov-report term-missing"
-${python_exe:?} -m pytest --cov=trilinosprhelpers --cov-report term-missing
+message_std "--- " "${python_exe:?} -m pytest --cov=trilinosprhelpers --cov-report term-missing --color=no"
+${python_exe:?} -m pytest --cov=trilinosprhelpers --cov-report term-missing --color=no
 err=$?
 message_std "" ""
 message_std "--- " "STATUS: ${err:?}"

--- a/cmake/std/pr_python_test_driver.sh
+++ b/cmake/std/pr_python_test_driver.sh
@@ -28,7 +28,9 @@ pip_exe=${2:?}
 message_std "--- " "python: ${python_exe:?}"
 message_std "--- " "pip   : ${pip_exe:?}"
 
-get_pip ${python_exe:?}
+# Remove get_pip usage -- we only really needed this for python2 since
+# the SEMS python3 distros come with pip3 installed.
+# get_pip ${python_exe:?}
 get_python_packages ${pip_exe:?}
 
 message_std "" ""

--- a/commonTools/framework/CMakeLists.txt
+++ b/commonTools/framework/CMakeLists.txt
@@ -4,7 +4,7 @@ TRIBITS_PACKAGE(TrilinosFrameworkTests)
 TRIBITS_ADD_ADVANCED_TEST( ProjectCiFileChangeLogic_UnitTests
   OVERALL_WORKING_DIRECTORY TEST_NAME
   OVERALL_NUM_MPI_PROCS 1
-  TEST_0 CMND ${PYTHON_EXECUTABLE} 
+  TEST_0 CMND ${PYTHON_EXECUTABLE}
     ARGS ${CMAKE_CURRENT_SOURCE_DIR}/ProjectCiFileChangeLogic_UnitTests.py -v
     PASS_REGULAR_EXPRESSION "OK"
     ALWAYS_FAIL_ON_NONZERO_RETURN
@@ -25,7 +25,7 @@ TRIBITS_ADD_ADVANCED_TEST( clean_all_jobs_UnitTests
   OVERALL_WORKING_DIRECTORY TEST_NAME
   OVERALL_NUM_MPI_PROCS 1
   EXCLUDE_IF_NOT_TRUE TFW_Python_Testing
-  TEST_0 CMND ${PYTHON_EXECUTABLE} 
+  TEST_0 CMND ${PYTHON_EXECUTABLE}
     ARGS ${CMAKE_CURRENT_SOURCE_DIR}/clean_workspace/unittests/test_clean_all_jobs.py -v
     PASS_REGULAR_EXPRESSION "OK"
   )
@@ -35,7 +35,7 @@ TRIBITS_ADD_ADVANCED_TEST( clean_sentinel_UnitTests
   OVERALL_WORKING_DIRECTORY TEST_NAME
   OVERALL_NUM_MPI_PROCS 1
   EXCLUDE_IF_NOT_TRUE TFW_Python_Testing
-  TEST_0 CMND ${PYTHON_EXECUTABLE} 
+  TEST_0 CMND ${PYTHON_EXECUTABLE}
     ARGS ${CMAKE_CURRENT_SOURCE_DIR}/clean_workspace/unittests/test_clean_sentinel.py -v
     PASS_REGULAR_EXPRESSION "OK"
   )
@@ -45,7 +45,7 @@ TRIBITS_ADD_ADVANCED_TEST( clean_workspace_UnitTests
   OVERALL_WORKING_DIRECTORY TEST_NAME
   OVERALL_NUM_MPI_PROCS 1
   EXCLUDE_IF_NOT_TRUE TFW_Python_Testing
-  TEST_0 CMND ${PYTHON_EXECUTABLE} 
+  TEST_0 CMND ${PYTHON_EXECUTABLE}
     ARGS ${CMAKE_CURRENT_SOURCE_DIR}/clean_workspace/unittests/test_clean_workspace.py -v
     PASS_REGULAR_EXPRESSION "OK"
   )
@@ -55,10 +55,11 @@ TRIBITS_ADD_ADVANCED_TEST( PullRequestLinuxDriverMerge_UnitTests
   OVERALL_WORKING_DIRECTORY TEST_NAME
   OVERALL_NUM_MPI_PROCS 1
   EXCLUDE_IF_NOT_TRUE TFW_Python_Testing
-  TEST_0 CMND ${PYTHON_EXECUTABLE} 
+  TEST_0 CMND ${PYTHON_EXECUTABLE}
     ARGS ${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/std/unittests/TestPullRequestLinuxDriverMerge.py -v
     PASS_REGULAR_EXPRESSION "OK"
   )
+
 
 
 # Run the discoverable unit tests under the cmake/std directory tree
@@ -66,14 +67,19 @@ TRIBITS_ADD_ADVANCED_TEST( PullRequestLinuxDriverTest_UnitTests
     OVERALL_WORKING_DIRECTORY TEST_NAME
     OVERALL_NUM_MPI_PROCS 1
     EXCLUDE_IF_NOT_TRUE TFW_Python_Testing
-    TEST_0 CMND bash 
+    TEST_0 CMND bash
         ARGS pr_python_test_driver.sh ${PYTHON_EXECUTABLE} ${PYTHON_PIP_EXECUTABLE}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/std
         SKIP_CLEAN_WORKING_DIRECTORY
-        # FAIL_REGULAR_EXPRESSION "FAILED"
-        PASS_REGULAR_EXPRESSION " passed in"
+        PASS_REGULAR_EXPRESSION "^=+ [0-9]+ passed in"
         #ALWAYS_FAIL_ON_NONZERO_RETURN
 )
+# Note: pytest output looks like this:
+# Passing tests:
+# ========...======= 36 passed in 0.79s ====...======
+# Failing tests:
+# ========...======= 1 failed, 35 passed in 0.80s ======...=======
+
 
 
 FUNCTION(create_get_changed_trilinos_packages_test  TEST_POSTFIX
@@ -93,7 +99,7 @@ FUNCTION(create_get_changed_trilinos_packages_test  TEST_POSTFIX
   SET(GIT_MOCKPROGRAM_TXT_FILE
     "${CMAKE_CURRENT_BINARY_DIR}/${FULL_TEST_NAME}_git_mockprogram.txt")
 
-  # We need to write the expected input and the output for 
+  # We need to write the expected input and the output for
   FILE(WRITE "${GIT_MOCKPROGRAM_TXT_FILE}"
 "MOCK_PROGRAM_INPUT: diff --name-only sha1-from..sha1-to
 MOCK_PROGRAM_RETURN: 0
@@ -111,7 +117,7 @@ MOCK_PROGRAM_OUTPUT: ${FILES_CHANGED}
     TEST_0
       MESSAGE "Copy the mockprogram.py inout file each time since it gets modifed!"
       CMND "${CMAKE_COMMAND}"
-        ARGS -E copy "${GIT_MOCKPROGRAM_TXT_FILE}" mockprogram_inout.txt 
+        ARGS -E copy "${GIT_MOCKPROGRAM_TXT_FILE}" mockprogram_inout.txt
 
     TEST_1
       MESSAGE "Run get-changed-trilinos-packages.sh with mock git"

--- a/commonTools/framework/CMakeLists.txt
+++ b/commonTools/framework/CMakeLists.txt
@@ -71,7 +71,7 @@ TRIBITS_ADD_ADVANCED_TEST( PullRequestLinuxDriverTest_UnitTests
         ARGS pr_python_test_driver.sh ${PYTHON_EXECUTABLE} ${PYTHON_PIP_EXECUTABLE}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/std
         SKIP_CLEAN_WORKING_DIRECTORY
-        PASS_REGULAR_EXPRESSION "^=+ [0-9]+ passed in"
+        PASS_REGULAR_EXPRESSION "=+ [0-9]+ passed in"
         #ALWAYS_FAIL_ON_NONZERO_RETURN
 )
 # Note: pytest output looks like this:


### PR DESCRIPTION
The pytest checker when we do the python tests returns a summary
line that is formatted like this:

All tests passed:
```
============================================= 36 passed in 0.79s =============================================
```

Some test(s) failed:
```
======================================== 1 failed, 35 passed in 0.80s ========================================
```

A regular expression that can match a testing scenerio where there are
zero failures might look like this:
`^=+ [0-9]+ passed in`

This can be tested at: https://regexr.com/

Get Pip Removed
-----------------
I also removed the `get_pip` bash function since it's not needed anymore since we removed Python2 based testing for the PR driver. The `get_pip` stuff isn't needed since we don't test Python2 anymore and our Python3 comes with pip3 already built. We don't need to go get it anymore. :)


@trilinos/framework 

## Related Issues

* Related to #8633

## Testing
Tested this out at regexr.com -- will see what happens in the PR testing under CMake. The regex works, but not all apps use the same regex rules.
