### PR TITLE
Framework: Update CMake minimum requirement to 3.17.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@
 
 # To be safe, define your minimum CMake version.  This may be newer than the
 # min required by TriBITS.
-CMAKE_MINIMUM_REQUIRED(VERSION 3.10.0 FATAL_ERROR)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.17.0 FATAL_ERROR)
 
 # Must set the project name as a variable at very beginning before including anything else
 # We set the project name in a separate file so CTest scripts can use it.


### PR DESCRIPTION
@trilinos/framework 

## Motivation
Updates the minimum CMake requirement for Trilinos to 3.17.0

- Part of #8401 
- Part of #8520
- Depends on #8521 



