### PR TITLE
Tpetra: make access tags public

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Access.hpp
+++ b/packages/tpetra/core/src/Tpetra_Access.hpp
@@ -1,0 +1,59 @@
+// @HEADER
+// ***********************************************************************
+//
+//          Tpetra: Templated Linear Algebra Services Package
+//                 Copyright (2008) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+
+#ifndef TPETRA_ACCESS_HPP
+#define TPETRA_ACCESS_HPP
+
+namespace Tpetra
+{
+namespace Access
+{
+  //Tag indicating intent to read up-to-date data, but not modify.
+  struct ReadOnly {};
+  //Tag indicating intent to completely overwrite existing data.
+  struct WriteOnly {};
+  //Tag indicating intent to both read up-to-date data and modify it.
+  struct ReadWrite {};
+}
+}
+
+#endif
+

--- a/packages/tpetra/core/src/Tpetra_withLocalAccess.hpp
+++ b/packages/tpetra/core/src/Tpetra_withLocalAccess.hpp
@@ -43,6 +43,7 @@
 #define TPETRA_WITHLOCALACCESS_HPP
 
 #include "TpetraCore_config.h"
+#include "Tpetra_Access.hpp"
 #include <functional>
 #include <type_traits>
 
@@ -57,39 +58,10 @@ namespace Tpetra {
   ////////////////////////////////////////////////////////////
 
   namespace Details {
-    /// \brief Enum for declaring access intent.
-    ///
-    /// This is not for users; it's an implementation detail of
-    /// functions readOnly, writeOnly, and readWrite (see below).
-    enum class EAccess {
-      ReadOnly,
-      WriteOnly,
-      ReadWrite
-    };
-
-    /// \brief Tag class for declaring access intent.
-    ///
-    /// This is a class, not an enum, so that LocalAccess (see below)
-    /// can have a parameter pack.  You can't mix class types and
-    /// constexpr values in a parameter pack.  Compare to
-    /// Kokkos::MemoryTraits or Kokkos::Schedule.
-    template<const EAccess accessMode>
-    class Access {
-      /// \brief Type alias to help identifying the tag class.
-      ///
-      /// We follow Kokkos in identifying a tag class by checking
-      /// whether a type alias inside it has the same type as the tag
-      /// class itself.
-      using access_mode = Access<accessMode>;
-    };
-
     template<class T> struct is_access_mode : public std::false_type {};
-    template<EAccess am>
-    struct is_access_mode<Access<am>> : public std::true_type {};
-
-    using read_only = Access<EAccess::ReadOnly>;
-    using write_only = Access<EAccess::WriteOnly>;
-    using read_write = Access<EAccess::ReadWrite>;
+    template<> struct is_access_mode<Access::ReadOnly> : public std::true_type {};
+    template<> struct is_access_mode<Access::ReadWrite> : public std::true_type {};
+    template<> struct is_access_mode<Access::WriteOnly> : public std::true_type {};
 
     /// \brief Given a global object, get its default memory space
     ///   (both the type and the default instance thereof).
@@ -257,7 +229,7 @@ namespace Tpetra {
   template<class GlobalObjectType>
   Details::LocalAccess<
     GlobalObjectType,
-    Details::read_only>
+    Access::ReadOnly>
   readOnly (GlobalObjectType&);
 
   /// \brief Declare that you want to access the given global object's
@@ -266,7 +238,7 @@ namespace Tpetra {
   template<class GlobalObjectType>
   Details::LocalAccess<
     GlobalObjectType,
-    Details::read_only>
+    Access::ReadOnly>
   readOnly (const GlobalObjectType&);
 
   /// \brief Declare that you want to access the given global object's
@@ -274,7 +246,7 @@ namespace Tpetra {
   template<class GlobalObjectType>
   Details::LocalAccess<
     GlobalObjectType,
-    Details::write_only>
+    Access::WriteOnly>
   writeOnly (GlobalObjectType&);
 
   /// \brief Declare that you want to access the given global object's
@@ -282,7 +254,7 @@ namespace Tpetra {
   template<class GlobalObjectType>
   Details::LocalAccess<
     GlobalObjectType,
-    Details::read_write>
+    Access::ReadWrite>
   readWrite (GlobalObjectType&);
 
   ////////////////////////////////////////////////////////////
@@ -681,7 +653,7 @@ namespace Tpetra {
   template<class GlobalObjectType>
   Details::LocalAccess<
     GlobalObjectType,
-    Details::read_only>
+    Access::ReadOnly>
   readOnly (GlobalObjectType& G)
   {
     return {G};
@@ -690,7 +662,7 @@ namespace Tpetra {
   template<class GlobalObjectType>
   Details::LocalAccess<
     GlobalObjectType,
-    Details::read_only>
+    Access::ReadOnly>
   readOnly (const GlobalObjectType& G)
   {
     GlobalObjectType& G_nc = const_cast<GlobalObjectType&> (G);
@@ -700,7 +672,7 @@ namespace Tpetra {
   template<class GlobalObjectType>
   Details::LocalAccess<
     GlobalObjectType,
-    Details::write_only>
+    Access::WriteOnly>
   writeOnly (GlobalObjectType& G)
   {
     return {G};
@@ -709,7 +681,7 @@ namespace Tpetra {
   template<class GlobalObjectType>
   Details::LocalAccess<
     GlobalObjectType,
-    Details::read_write>
+    Access::ReadWrite>
   readWrite (GlobalObjectType& G)
   {
     return {G};

--- a/packages/tpetra/core/src/Tpetra_withLocalAccess_MultiVector.hpp
+++ b/packages/tpetra/core/src/Tpetra_withLocalAccess_MultiVector.hpp
@@ -169,7 +169,7 @@ namespace Tpetra {
         else {
           using access_mode = typename local_access_type::access_mode;
           constexpr bool is_write_only =
-            std::is_same<access_mode, write_only>::value;
+            std::is_same<access_mode, Access::WriteOnly>::value;
           if (is_write_only) {
             LA.G_.clear_sync_state();
           }
@@ -208,7 +208,7 @@ namespace Tpetra {
           }
 
           constexpr bool is_read_only =
-            std::is_same<access_mode, read_only>::value;
+            std::is_same<access_mode, Access::ReadOnly>::value;
           if (! is_read_only) {
             LA.G_.template modify<execution_space>();
           }
@@ -246,14 +246,14 @@ namespace Tpetra {
     static_assert(
       Kokkos::is_view<
         GetMasterLocalObject<
-          LocalAccess<Tpetra::MultiVector<>, read_only>
+          LocalAccess<Tpetra::MultiVector<>, Access::ReadOnly>
         >::master_local_view_type
       >::value, "Missing GetMasterLocalObject specialization");
 
     static_assert(
       Kokkos::is_view<
         GetMasterLocalObject<
-          LocalAccess<Tpetra::MultiVector<>, Kokkos::HostSpace, read_only>
+          LocalAccess<Tpetra::MultiVector<>, Kokkos::HostSpace, Access::ReadOnly>
         >::master_local_view_type
       >::value, "Missing GetMasterLocalObject specialization");
 
@@ -335,7 +335,7 @@ namespace Tpetra {
         else {
           using access_mode = typename local_access_type::access_mode;
           constexpr bool is_write_only =
-            std::is_same<access_mode, write_only>::value;
+            std::is_same<access_mode, Access::WriteOnly>::value;
           if (is_write_only) {
             LA.G_.clear_sync_state();
           }
@@ -345,7 +345,7 @@ namespace Tpetra {
           }
 
           constexpr bool is_read_only =
-            std::is_same<access_mode, read_only>::value;
+            std::is_same<access_mode, Access::ReadOnly>::value;
           if (! is_read_only) {
             LA.G_.template modify<execution_space>();
           }
@@ -386,14 +386,14 @@ namespace Tpetra {
     static_assert(
       Kokkos::is_view<
         GetMasterLocalObject<
-          LocalAccess<Tpetra::Vector<>, read_only>
+          LocalAccess<Tpetra::Vector<>, Access::ReadOnly>
         >::master_local_view_type
       >::value, "Missing GetMasterLocalObject specialization");
 
     static_assert(
       Kokkos::is_view<
         GetMasterLocalObject<
-          LocalAccess<Tpetra::Vector<>, Kokkos::HostSpace, read_only>
+          LocalAccess<Tpetra::Vector<>, Kokkos::HostSpace, Access::ReadOnly>
         >::master_local_view_type
       >::value, "Missing GetMasterLocalObject specialization");
 
@@ -429,7 +429,7 @@ namespace Tpetra {
       // MV::impl_scalar_type**, where
       // MV = Tpetra::MultiVector<SC, LO, GO, NT>.
       using output_data_type = typename std::conditional<
-        std::is_same<access_mode, read_only>::value,
+        std::is_same<access_mode, Access::ReadOnly>::value,
         typename master_local_view_type::const_data_type,
         typename master_local_view_type::non_const_data_type>::type;
 
@@ -484,7 +484,7 @@ namespace Tpetra {
       // input_view_type::non_const_data_type is V::impl_scalar_type*,
       // where V = Tpetra::Vector<SC, LO, GO, NT>.
       using output_data_type = typename std::conditional<
-        std::is_same<access_mode, read_only>::value,
+        std::is_same<access_mode, Access::ReadOnly>::value,
         typename master_local_view_type::const_data_type,
         typename master_local_view_type::non_const_data_type>::type;
 

--- a/packages/tpetra/core/test/MultiVector/WithLocalAccess.cpp
+++ b/packages/tpetra/core/test/MultiVector/WithLocalAccess.cpp
@@ -114,7 +114,7 @@ namespace { // (anonymous)
       {
         using local_access_type =
           LocalAccess<multivec_type, dev_mem_space,
-                      Tpetra::Details::read_only>;
+                      Tpetra::Access::ReadOnly>;
 
         using mv_mlo = GetMasterLocalObject<local_access_type>::
           master_local_object_type;
@@ -291,7 +291,7 @@ namespace { // (anonymous)
 
       using local_access_type = decltype (lclAccess);
       static_assert(std::is_same<local_access_type::access_mode,
-        Tpetra::Details::write_only>::value, "Incorrect AccessMode");
+        Tpetra::Access::WriteOnly>::value, "Incorrect AccessMode");
       static_assert
         (std::is_same<local_access_type::global_object_type, vec_type>::value,
          "Incorrect global_object_type");

--- a/packages/tpetra/core/test/Utils/withLocalAccess_generic.cpp
+++ b/packages/tpetra/core/test/Utils/withLocalAccess_generic.cpp
@@ -92,7 +92,7 @@ template<class AccessMode>
 struct StubGlobalObjectLocalObjectImpl {};
 
 template<>
-struct StubGlobalObjectLocalObjectImpl<Access<EAccess::ReadOnly> >
+struct StubGlobalObjectLocalObjectImpl<Access::ReadOnly>
 {
   // In practice, prefer things that behave like std::unique_ptr,
   // since you don't actually need to share state.
@@ -117,7 +117,7 @@ struct StubGlobalObjectLocalObjectImpl<Access<EAccess::ReadOnly> >
 
 // Example of the "copy-back" model.
 template<>
-struct StubGlobalObjectLocalObjectImpl<Access<EAccess::WriteOnly> >
+struct StubGlobalObjectLocalObjectImpl<Access::WriteOnly>
 {
 private:
   struct Deleter {
@@ -160,7 +160,7 @@ public:
 };
 
 template<>
-struct StubGlobalObjectLocalObjectImpl<Access<EAccess::ReadWrite> >
+struct StubGlobalObjectLocalObjectImpl<Access::ReadWrite>
 {
   // In practice, prefer things that behave like std::unique_ptr,
   // since you don't actually need to share state.


### PR DESCRIPTION
Make WithLocalAccess use these tags instead of internal Details:: ones:

```
#include "Tpetra_Access.hpp"
...
do_thing(Tpetra::Access::ReadOnly());
do_thing(Tpetra::Access::ReadWrite());
do_thing(Tpetra::Access::WriteOnly());
```

These will also be used for the new MultiVector view access interface.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
Tested through withLocalAccess multivector tests.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->