### PR TITLE
Add environment variable for intel configure with intel 19

### DIFF
--- a/cmake/std/PullRequestLinuxIntel19.0.5TestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxIntel19.0.5TestingSettings.cmake
@@ -92,9 +92,8 @@ set (TPL_Netcdf_LIBRARIES "-L${Netcdf_LIBRARY_DIRS}/lib;${Netcdf_LIBRARY_DIRS}/l
 
 set(CMAKE_CXX_FLAGS "-fPIC -Wall -Warray-bounds -Wchar-subscripts -Wcomment -Wenum-compare -Wformat -Wuninitialized -Wmaybe-uninitialized -Wmain -Wnarrowing -Wnonnull -Wparentheses -Wpointer-sign -Wreorder -Wreturn-type -Wsign-compare -Wsequence-point -Wtrigraphs -Wunused-function -Wunused-but-set-variable -Wunused-variable -Wwrite-strings" CACHE STRING "enable relocatable code, turn on WError settings")
 
-# -lifcore might be needed for CMake > 3.10.x builds. We failed on the Intel 17.x build with CMake 3.17 and
-# greater.
-# set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lifcore" CACHE STRING "updated by Pull Request")
+# -lifcore is needed for CMake > 3.10.x builds.
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lifcore" CACHE STRING "updated by Pull Request")
 
 #set (Anasazi_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as errors setting")
 #set (Belos_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as errors setting")

--- a/cmake/std/pr_config/pullrequest.ini
+++ b/cmake/std/pr_config/pullrequest.ini
@@ -290,7 +290,7 @@ module-load sems-mpich: 3.2
 use SEMS-DEFAULT:
 module-remove sems-openmpi:
 use ATDM-DEFAULT:
-# setenv LDFLAGS: -lifcore
+setenv LDFLAGS: -lifcore
 
 
 

--- a/cmake/std/sems/PullRequestIntel17.0.1TestingEnv.sh
+++ b/cmake/std/sems/PullRequestIntel17.0.1TestingEnv.sh
@@ -35,3 +35,5 @@ module load sems-python/3.5.2
 # add the OpenMP environment variable we need
 export OMP_NUM_THREADS=2
 
+# required for cmake > 3.10 during configure compiler testing.
+setenv LDFLAGS=-lifcore

--- a/cmake/std/sems/PullRequestIntel19.0.5TestingEnv.sh
+++ b/cmake/std/sems/PullRequestIntel19.0.5TestingEnv.sh
@@ -34,3 +34,6 @@ module load sems-python/3.5.2
 
 # add the OpenMP environment variable we need
 export OMP_NUM_THREADS=2
+
+# required for cmake > 3.10 during configure compiler testing.
+setenv LDFLAGS=-lifcore


### PR DESCRIPTION
A previous PR had set this up for intel 17 and
subsequent testing showed a problem with intel 19
as well. This also adds the environment variables
to the evn.sh scripts for reproducing builds.

@trilinos/framework 

# Motivation
This is blocking develop->master promotions and will be needed in general.
