### PR TITLE
Intrepid2: fix namespaces in orientation tools

### DIFF
--- a/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefCoeffMatrix_HCURL.hpp
+++ b/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefCoeffMatrix_HCURL.hpp
@@ -263,8 +263,8 @@ getCoeffMatrix_HCURL(OutputViewType &output,
   // Basis evaluation on the reference points
   //
 
-  typename CellTools<ExecutionSpace>::subcellParamViewType subcellParam;
-  CellTools<ExecutionSpace>::getSubcellParametrization(subcellParam, subcellDim, cellTopo);
+  typename Intrepid2::CellTools<ExecutionSpace>::subcellParamViewType subcellParam;
+  Intrepid2::CellTools<ExecutionSpace>::getSubcellParametrization(subcellParam, subcellDim, cellTopo);
 
   // refPtsCell = F_s (\eta_o (refPtsSubcell))
   PointViewType refPtsCell("refPtsCell", ndofSubcell, cellDim);

--- a/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefCoeffMatrix_HDIV.hpp
+++ b/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefCoeffMatrix_HDIV.hpp
@@ -222,8 +222,8 @@ getCoeffMatrix_HDIV(OutputViewType &output,
   PointTools::getLattice(refPtsSubcell, subcellTopo, latticeDegree, 1);//, POINTTYPE_WARPBLEND);
 
   // evaluate values on the modified cell
-  typename CellTools<ExecutionSpace>::subcellParamViewType subcellParam;
-  CellTools<ExecutionSpace>::getSubcellParametrization(subcellParam, subcellDim, cellTopo);
+  typename Intrepid2::CellTools<ExecutionSpace>::subcellParamViewType subcellParam;
+  Intrepid2::CellTools<ExecutionSpace>::getSubcellParametrization(subcellParam, subcellDim, cellTopo);
 
   // refPtsCell = F_s (\eta_o (refPtsSubcell))
   PointViewType refPtsCell("refPtsCell", ndofSubcell, cellDim);

--- a/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefCoeffMatrix_HGRAD.hpp
+++ b/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefCoeffMatrix_HGRAD.hpp
@@ -174,8 +174,8 @@ getCoeffMatrix_HGRAD(OutputViewType &output,
   PointTools::getLattice(refPtsSubcell, subcellTopo, subcellBasis.getDegree(), 1, POINTTYPE_WARPBLEND);
 
   // map the points into the parent, cell accounting for orientation
-  typename CellTools<ExecutionSpace>::subcellParamViewType subcellParam;
-  CellTools<ExecutionSpace>::getSubcellParametrization(subcellParam, subcellDim, cellTopo);
+  typename Intrepid2::CellTools<ExecutionSpace>::subcellParamViewType subcellParam;
+  Intrepid2::CellTools<ExecutionSpace>::getSubcellParametrization(subcellParam, subcellDim, cellTopo);
   PointViewType refPtsCell("refPtsCell", ndofSubcell, cellDim);
   // refPtsCell = F_s (\eta_o (refPtsSubcell))
   mapSubcellCoordsToRefCell(refPtsCell,refPtsSubcell, subcellParam, subcellBaseKey, subcellId, subcellOrt);


### PR DESCRIPTION
## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Tried to pull these files into empire, but had compile failures. Unit tests probably are declaring "using namespace Intrepid2" to work around this.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->