### PR TITLE
Framework: Issue 8669 - Fix CMake 3.17 bug with Intel 19 compiler

### DIFF
--- a/cmake/std/pr_config/pullrequest.ini
+++ b/cmake/std/pr_config/pullrequest.ini
@@ -290,7 +290,7 @@ module-load sems-mpich: 3.2
 use SEMS-DEFAULT:
 module-remove sems-openmpi:
 use ATDM-DEFAULT:
-# setenv LDFLAGS: -lifcore
+setenv LDFLAGS: -lifcore
 
 
 


### PR DESCRIPTION
@trilinos/framework 

## Motivation
We missed setting `LDFLAGS=-lifcore` envvar in the push that fixed the trivial compilation of a fortran program with the intel compiler and cmake 3.17.x ... issue we had last week. 

Since the intel 19 compiler is only tested in the dev->master builds this got missed on our earlier PR.

## Related Issues
* Closes #8669
* Relates to #8664

FYI @prwolfe @jwillenbring @ZUUL42 @e10harvey 
