### PR TITLE
ATDM rhel7 cmake 3.19

### DIFF
--- a/cmake/std/atdm/cee-rhel7/environment.sh
+++ b/cmake/std/atdm/cee-rhel7/environment.sh
@@ -193,7 +193,7 @@ fi
 
 # Use updated Ninja and CMake
 module load sems-env
-module load sems-cmake/3.12.2
+module load sems-cmake/3.17.1
 module load sems-ninja_fortran/1.8.2
 
 export ATDM_CONFIG_USE_HWLOC=OFF

--- a/cmake/std/atdm/cee-rhel7/environment.sh
+++ b/cmake/std/atdm/cee-rhel7/environment.sh
@@ -193,7 +193,7 @@ fi
 
 # Use updated Ninja and CMake
 module load sems-env
-module load sems-cmake/3.17.1
+module load sems-cmake/3.19.1
 module load sems-ninja_fortran/1.8.2
 
 export ATDM_CONFIG_USE_HWLOC=OFF


### PR DESCRIPTION
@trilinos/framework 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

Trilinos now requires CMake 3.17 or greater

Part of #8675 

This updates the rhel7 cee environment to use a supported version of CMake.