### PR TITLE
Issue 8675 updating ATDM toss3 build to use CMake 3.19

### DIFF
--- a/cmake/std/atdm/common/toss3/environment_new.sh
+++ b/cmake/std/atdm/common/toss3/environment_new.sh
@@ -24,7 +24,7 @@ module load sems-env
 module load sems-git/2.10.1
 
 # Common paths and modules for both intel-1{8,9}
-module load cmake/3.12.2
+module load sems-cmake/3.19.1
 
 module load sparc-dev/intel-19.0.4_openmpi-4.0.3
 


### PR DESCRIPTION
Trilinos now requires CMake 3.17 or greater

Part of #8675

This updates the toss3 environment to use a supported version of CMake. I based the version used on another environment file for this platform.