### PR TITLE
Intrepid2: Allow CubatureTensor in more dimensions

### DIFF
--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_BasisValues.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_BasisValues.hpp
@@ -100,6 +100,13 @@ namespace Intrepid2
     vectorData_(vectorData)
     {}
     
+    //! Default constructor.
+    BasisValues()
+    :
+    numTensorDataFamilies_(0)
+    {}
+    
+    
     //! copy-like constructor for differing execution spaces.  This does a deep copy of underlying views.
     template<typename OtherExecSpaceType, class = typename std::enable_if<!std::is_same<ExecSpaceType, OtherExecSpaceType>::value>::type>
     BasisValues(const BasisValues<Scalar,OtherExecSpaceType> &basisValues)
@@ -285,9 +292,13 @@ namespace Intrepid2
         {
           return vectorData_.extent_int(i);
         }
-        else
+        else if (tensorDataFamilies_[0].isValid())
         {
           return tensorDataFamilies_[0].extent_int(i);
+        }
+        else
+        {
+          return 0;
         }
       }
     }
@@ -306,9 +317,13 @@ namespace Intrepid2
       {
         return vectorData_.rank();
       }
-      else
+      else if (tensorDataFamilies_[0].isValid())
       {
         return tensorDataFamilies_[0].rank();
+      }
+      else
+      {
+        return 0;
       }
     }
   };

--- a/packages/intrepid2/src/Discretization/Integration/Intrepid2_CubatureTensor.hpp
+++ b/packages/intrepid2/src/Discretization/Integration/Intrepid2_CubatureTensor.hpp
@@ -141,7 +141,7 @@ namespace Intrepid2 {
     virtual
     void
     getCubature( const TensorPointDataType & tensorCubPoints,
-                       const TensorWeightDataType & tensorCubWeights) const override {
+                 const TensorWeightDataType & tensorCubWeights) const override {
       for (ordinal_type i=0;i<numCubatures_;++i)
       {
         cubatures_[i].getCubature(tensorCubPoints.getTensorComponent(i), tensorCubWeights.getTensorComponent(i).getUnderlyingView());
@@ -242,6 +242,20 @@ namespace Intrepid2 {
       cubatures_[2] = cubature2;
     }
 
+    /** \brief Constructor for extending an existing CubatureTensor object with an additional direct cubature rule.
+
+        \param cubatureTensor    [in] - Existing CubatureTensor object.
+        \param cubatureExtension [in] - The direct cubature rule to use to extend in the new dimension.
+    */
+    template<typename DirectCubature>
+    CubatureTensor( const CubatureTensor cubatureTensor,
+                    const DirectCubature cubatureExtension )
+      : numCubatures_(cubatureTensor.getNumCubatures()+1),
+        dimension_(cubatureTensor.getDimension()+cubatureExtension.getDimension()) {
+      for (ordinal_type i=0;i<cubatureTensor.getNumCubatures();++i)
+        cubatures_[i] = cubatureTensor.cubatures_[i];
+      cubatures_[cubatureTensor.getNumCubatures()] = cubatureExtension;
+    }
   };
 
 

--- a/packages/intrepid2/unit-test/MonolithicExecutable/BasisValuesTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/BasisValuesTests.cpp
@@ -185,6 +185,20 @@ namespace
     }
   }
 
+  TEUCHOS_UNIT_TEST( BasisValues, DefaultConstructor )
+  {
+    // test of default-constructed basis values object.
+    BasisValues<double> emptyBasisValues;
+    TEST_EQUALITY(0, emptyBasisValues.rank());
+    for (int d=0; d<8; d++)
+    {
+      TEST_EQUALITY(0, emptyBasisValues.extent(d));
+      TEST_EQUALITY(0, emptyBasisValues.extent_int(d));
+    }
+    TEST_EQUALITY(0, emptyBasisValues.numFamilies());
+  }
+
+
   TEUCHOS_UNIT_TEST( BasisValues, HierarchicalHGRAD_LINE )
   {
     using Basis = HierarchicalBasisFamily<>::HGRAD_LINE;


### PR DESCRIPTION
@trilinos/intrepid2 

## Motivation
By adding a constructor that allows a tensorial extension of an existing CubatureTensor object, we allow the use of CubatureTensor in dimensions beyond 3.  This has applications for space-time finite elements, as well as for Boltzmann models (which may be up to 6D).

Additionally, this PR includes a default constructor for BasisValues, which was missing.

## Testing
Both CubatureTensor and BasisValues are tested by existing unit tests, as well as one new one that explicitly tests the new default constructor for BasisValues.
