### PR TITLE
ATDM: Upgrade to CMake 3.17+ and fix intel compiler checks 

### DIFF
--- a/cmake/std/atdm/cee-rhel7/environment.sh
+++ b/cmake/std/atdm/cee-rhel7/environment.sh
@@ -262,5 +262,8 @@ if [[ "${ATDM_CONFIG_SUPERLUDIST_INCLUDE_DIRS}" == "" ]] ; then
   export ATDM_CONFIG_SUPERLUDIST_LIBS=${SUPERLUDIST_ROOT}/lib64/libsuperlu_dist.a
 fi
 
+# Point CMake 3.19 compiler checks to missing symbols
+export LDFLAGS="$LDFLAGS -lifcore"
+
 # Finished!
 export ATDM_CONFIG_COMPLETED_ENV_SETUP=TRUE

--- a/cmake/std/atdm/cts1empire/environment_new.sh
+++ b/cmake/std/atdm/cts1empire/environment_new.sh
@@ -32,7 +32,7 @@ else
 fi
 
 sparc_tpl_base=${ATDM_CONFIG_SPARC_TPL_BASE}
-module load cmake/3.12.2
+module load sparc-cmake/3.18.1
 
 if [ "$ATDM_CONFIG_COMPILER" == "INTEL-18.0.2_OPENMPI-4.0.1" ]; then
     module load intel/18.0.2.199
@@ -94,5 +94,8 @@ export F90=mpif90
 
 # Define function atdm_run_script_on_compute_node
 source $ATDM_SCRIPT_DIR/common/define_run_on_slurm_compute_node_func.sh
+
+# Point CMake 3.18 compiler checks to missing symbols
+export LDFLAGS="$LDFLAGS -lifcore"
 
 export ATDM_CONFIG_COMPLETED_ENV_SETUP=TRUE

--- a/cmake/std/atdm/cts1empire/environment_new.sh
+++ b/cmake/std/atdm/cts1empire/environment_new.sh
@@ -23,6 +23,7 @@ module purge
 module load sems-env
 module load sems-ninja_fortran/1.8.2
 module load sems-git/2.10.1
+module load sems-cmake/3.19.1
 
 if [ "$ATDM_CONFIG_NODE_TYPE" == "OPENMP" ] ; then
   export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=8
@@ -32,7 +33,6 @@ else
 fi
 
 sparc_tpl_base=${ATDM_CONFIG_SPARC_TPL_BASE}
-module load sparc-cmake/3.18.1
 
 if [ "$ATDM_CONFIG_COMPILER" == "INTEL-18.0.2_OPENMPI-4.0.1" ]; then
     module load intel/18.0.2.199

--- a/cmake/std/atdm/van1-tx2/environment.sh
+++ b/cmake/std/atdm/van1-tx2/environment.sh
@@ -168,9 +168,6 @@ export ATMD_CONFIG_MPI_USE_COMPILER_WRAPPERS=ON
 
 export ATDM_CONFIG_WCID_ACCOUNT_DEFAULT=fy150090
 
-# Point CMake 3.17 compiler checks to missing symbols
-export LDFLAGS="$LDFLAGS -lifcore"
-
 #
 # Done
 #

--- a/cmake/std/atdm/van1-tx2/environment.sh
+++ b/cmake/std/atdm/van1-tx2/environment.sh
@@ -115,7 +115,7 @@ fi
 
 # Common modules for all builds
 module load ninja
-module load cmake/3.12.2
+module load cmake/3.17.1
 
 export ATDM_CONFIG_USE_HWLOC=OFF
 export HWLOC_LIBS=
@@ -167,6 +167,9 @@ export ATDM_CONFIG_MPI_EXEC="mpirun"
 export ATMD_CONFIG_MPI_USE_COMPILER_WRAPPERS=ON
 
 export ATDM_CONFIG_WCID_ACCOUNT_DEFAULT=fy150090
+
+# Point CMake 3.17 compiler checks to missing symbols
+export LDFLAGS="$LDFLAGS -lifcore"
 
 #
 # Done


### PR DESCRIPTION
Related to #8675.

## Sems-rhel7 testing in progress:
https://testing-dev.sandia.gov/cdash/index.php?project=Trilinos&date=2021-02-03&filtercount=2&showfilters=1&filtercombine=and&field1=buildname&compare1=63&value1=sems-rhel7&field2=groupname&compare2=63&value2=Experimental

## cts1empire testing in progress:
https://testing-dev.sandia.gov/cdash/index.php?project=Trilinos&date=2021-02-03&filtercount=2&showfilters=1&filtercombine=and&field1=buildname&compare1=63&value1=cts1empire&field2=groupname&compare2=63&value2=Experimental

## van1-tx2 testing in progress:
https://testing-dev.sandia.gov/cdash/index.php?project=Trilinos&date=2021-02-03&filtercount=2&showfilters=1&filtercombine=and&field1=buildname&compare1=63&value1=van1-tx2&field2=groupname&compare2=63&value2=Experimental