### PR TITLE
Tpetra: add error check to enforce assumption about maps

### DIFF
--- a/packages/tpetra/core/inout/Tpetra_DistributionLowerTriangularBlock.hpp
+++ b/packages/tpetra/core/inout/Tpetra_DistributionLowerTriangularBlock.hpp
@@ -504,7 +504,7 @@ public:
     // to be the same.  Check it here.
     TEUCHOS_TEST_FOR_EXCEPTION(
       !lowerTriangularMatrix->getRangeMap()->isSameAs(
-                                        lowerTriangularMatrix->getDomainMap()), 
+                             *lowerTriangularMatrix->getDomainMap()), 
        std::logic_error,
        "The Domain and Range maps of the LowerTriangularBlock matrix "
        "must be the same");

--- a/packages/tpetra/core/inout/Tpetra_DistributionLowerTriangularBlock.hpp
+++ b/packages/tpetra/core/inout/Tpetra_DistributionLowerTriangularBlock.hpp
@@ -500,6 +500,15 @@ public:
   : lowerTriangularMatrix(lowerTriangularMatrix_),
     permMatrix(dist.getPermutationMatrix())
   {
+    // LowerTriangularBlockOperator requires the range map and domain map 
+    // to be the same.  Check it here.
+    TEUCHOS_TEST_FOR_EXCEPTION(
+      !lowerTriangularMatrix->getRangeMap()->isSameAs(
+                                        lowerTriangularMatrix->getDomainMap()), 
+       std::logic_error,
+       "The Domain and Range maps of the LowerTriangularBlock matrix "
+       "must be the same");
+    
     // Extract diagonals
 
     vector_t diagByRowMap(lowerTriangularMatrix->getRowMap());


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The LowerTriangularBlockOperator assumes that the matrix's Range and Domain map are the same.
This PR adds an error check to the operator's constructor to enforce the assumption.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
@seheracer @ndellingwood 
## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Tested on mac with clang
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->