### PR TITLE
weaver: update cmake used in atdm/contributed env script

### DIFF
--- a/cmake/std/atdm/contributed/weaver/environment.sh
+++ b/cmake/std/atdm/contributed/weaver/environment.sh
@@ -182,7 +182,7 @@ module load ninja/1.7.2
 # CMake
 #module swap cmake/3.6.2 cmake/3.12.3
 module unload cmake/3.6.2
-module load cmake/3.12.3
+module load cmake/3.19.3
 
 # HWLOC
 


### PR DESCRIPTION
Update contributed weaver script's cmake for nightly testing with kokkos and kokkos-kernels