### PR TITLE
ATDM/cee-rhel7: Update LDFLAGS export

### DIFF
--- a/cmake/std/atdm/cee-rhel7/environment.sh
+++ b/cmake/std/atdm/cee-rhel7/environment.sh
@@ -114,6 +114,8 @@ elif [ "$ATDM_CONFIG_COMPILER" == "INTEL-19.0.3_INTELMPI-2018.4" ]; then
   export ATDM_CONFIG_OPENMP_FORTRAN_FLAGS=-fopenmp
   export ATDM_CONFIG_OPENMP_FORTRAN_LIB_NAMES=gomp
   export ATDM_CONFIG_OPENMP_GOMP_LIBRARY=-lgomp
+  # Point CMake 3.19 compiler checks to missing symbols
+  export LDFLAGS="$LDFLAGS -lifcore"
 
 elif [ "$ATDM_CONFIG_COMPILER" == "INTEL-19.0.3_MPICH2-3.2" ]; then
   atdm_config_load_sparc_dev_module sparc-dev/intel-19.0.3_mpich2-3.2
@@ -136,6 +138,8 @@ elif [ "$ATDM_CONFIG_COMPILER" == "INTEL-19.0.3_MPICH2-3.2" ]; then
   export ATDM_CONFIG_OPENMP_FORTRAN_FLAGS=-fopenmp
   export ATDM_CONFIG_OPENMP_FORTRAN_LIB_NAMES=gomp
   export ATDM_CONFIG_OPENMP_GOMP_LIBRARY=-lgomp
+  # Point CMake 3.19 compiler checks to missing symbols
+  export LDFLAGS="$LDFLAGS -lifcore"
 
 elif [ "$ATDM_CONFIG_COMPILER" == "CUDA-10.1.243_GNU-7.2.0_OPENMPI-4.0.3" ]; then
   # ninja is running into issues with response files when building shared libraries with CUDA.
@@ -261,9 +265,6 @@ if [[ "${ATDM_CONFIG_SUPERLUDIST_INCLUDE_DIRS}" == "" ]] ; then
   export ATDM_CONFIG_SUPERLUDIST_INCLUDE_DIRS=${SUPERLUDIST_ROOT}/include
   export ATDM_CONFIG_SUPERLUDIST_LIBS=${SUPERLUDIST_ROOT}/lib64/libsuperlu_dist.a
 fi
-
-# Point CMake 3.19 compiler checks to missing symbols
-export LDFLAGS="$LDFLAGS -lifcore"
 
 # Finished!
 export ATDM_CONFIG_COMPLETED_ENV_SETUP=TRUE


### PR DESCRIPTION
Related to #8675 and caused by #8685.

## Cee-rhel7 testing in progress
https://testing-dev.sandia.gov/cdash/index.php?project=Trilinos&date=2021-02-04&filtercount=2&showfilters=1&filtercombine=and&field1=buildname&compare1=63&value1=cee-rhel7&field2=groupname&compare2=63&value2=Experimental

The reason Sems-rhel7 builds were run in #8685 was due to running:
`nohup env Trilinos_PACKAGES=Kokkos,Teuchos,TrilinosATDMConfigTests ./ctest-s-local-test-driver.sh all`

instead of:
`nohup env Trilinos_PACKAGES=Kokkos,Teuchos,TrilinosATDMConfigTests ATDM_CTEST_S_DEFAULT_ENV=cee-rhel7-default ./ctest-s-local-test-driver.sh all`