### PR TITLE
ATDM: Fix ats2 and cee-rhel7 drivers

### DIFF
--- a/cmake/ctest/drivers/atdm/ats2/local-driver.sh
+++ b/cmake/ctest/drivers/atdm/ats2/local-driver.sh
@@ -23,7 +23,11 @@ if atdm_match_buildname_keyword xl ; then
   fi
   # Only enable the SPARC packages by default
   export ATDM_CONFIG_CONFIGURE_OPTIONS_FILES=cmake/std/atdm/ATDMDevEnv.cmake,cmake/std/atdm/apps/sparc/SPARCTrilinosPackagesEnables.cmake
-  export Trilinos_PACKAGE_ENABLES_FILE=$WORKSPACE/Trilinos/cmake/std/atdm/apps/sparc/SPARCTrilinosPackagesEnables.cmake
+
+  # Ensure that we don't set both Trilinos_PACKAGES and Trilinos_PACKAGE_ENABLES_FILE
+  if [ -z $Trilinos_PACKAGES ]; then
+      export Trilinos_PACKAGE_ENABLES_FILE=$WORKSPACE/Trilinos/cmake/std/atdm/apps/sparc/SPARCMiniTrilinosPackagesEnables.cmake
+  fi
 fi
 
 # Allow default setting for TPETRA_ASSUME_CUDA_AWARE_MPI=0 in trilinos_jsrun

--- a/cmake/ctest/drivers/atdm/cee-rhel7/local-driver.sh
+++ b/cmake/ctest/drivers/atdm/cee-rhel7/local-driver.sh
@@ -12,14 +12,17 @@ if [[ "${Trilinos_ENABLE_BUILD_STATS}" == "" ]] && \
 fi
 echo "Trilinos_ENABLE_BUILD_STATS='${Trilinos_ENABLE_BUILD_STATS}'"
 
-# Make adjustments for mini build of Trilinos for SPARC
-if atdm_match_buildname_keyword mini ; then
-  echo "This is a mini build of Trilinos for SPARC!"
-  export ATDM_CONFIG_CONFIGURE_OPTIONS_FILES=cmake/std/atdm/apps/sparc/SPARCMiniTrilinosPackagesEnables.cmake,cmake/std/atdm/ATDMDevEnv.cmake
-  export Trilinos_PACKAGE_ENABLES_FILE=$WORKSPACE/Trilinos/cmake/std/atdm/apps/sparc/SPARCMiniTrilinosPackagesEnables.cmake
-  # NOTE: Above, we list SPARCMiniTrilinosPackagesEnables.cmake before
-  # ATDMDevEnv.cmake so that defaults for cache vars are set there before they
-  # get set in ATDMDevEnv.cmake.
+# Ensure that we don't set both Trilinos_PACKAGES and Trilinos_PACKAGE_ENABLES_FILE
+if [ -z $Trilinos_PACKAGES ]; then
+  # Make adjustments for mini build of Trilinos for SPARC
+  if atdm_match_buildname_keyword mini ; then
+    echo "This is a mini build of Trilinos for SPARC!"
+    export ATDM_CONFIG_CONFIGURE_OPTIONS_FILES=cmake/std/atdm/apps/sparc/SPARCMiniTrilinosPackagesEnables.cmake,cmake/std/atdm/ATDMDevEnv.cmake
+    export Trilinos_PACKAGE_ENABLES_FILE=$WORKSPACE/Trilinos/cmake/std/atdm/apps/sparc/SPARCMiniTrilinosPackagesEnables.cmake
+    # NOTE: Above, we list SPARCMiniTrilinosPackagesEnables.cmake before
+    # ATDMDevEnv.cmake so that defaults for cache vars are set there before they
+    # get set in ATDMDevEnv.cmake.
+  fi
 fi
 
 set -x


### PR DESCRIPTION
When running `env Trilinos_PACKAGES=Kokkos,Teuchos,TrilinosATDMConfigTests ATDM_CTEST_S_DEFAULT_ENV=cee-rhel7-default ./ctest-s-local-test-driver.sh` the mini builds produce:
```
CMake Error at /path/to/TribitsCTestDriverCore.cmake:1723 (MESSAGE):
  ERROR: Both Trilinos_PACKAGES and Trilinos_PACKAGE_ENABLES_FILE cannot be
  non-empty! Set one or the other to select the set of packages to be
  processed/tested.
```

Paul and I saw this while working on the ats2 xl build.

## cee-rhel7 test
https://testing-dev.sandia.gov/cdash/index.php?project=Trilinos&parentid=6129661&filtercount=1&showfilters=1&field1=groupname&compare1=63&value1=Experimental&filtercombine=and

## ats2 test
https://testing-dev.sandia.gov/cdash/index.php?project=Trilinos&parentid=6129666&filtercount=1&showfilters=1&field1=groupname&compare1=63&value1=Experimental&filtercombine=and
