### PR TITLE
Tpetra: readPerProcessBinary: Do not read any nonzeros if nnz=0

### DIFF
--- a/packages/tpetra/core/inout/MatrixMarket_TpetraNew.hpp
+++ b/packages/tpetra/core/inout/MatrixMarket_TpetraNew.hpp
@@ -824,12 +824,14 @@ readPerProcessBinary(
   // S. Acer: With large graphs, we can't afford std::map
   buffer = new unsigned int[nNz*2];
 
-  size_t ret = fread(buffer, sizeof(unsigned int), 2*nNz, fp);
-  if (ret == 0) {
-    std::cout << "Unexpected end of matrix file: " << rankFileName << std::endl;
-    std::cout.flush();
-    delete [] buffer;
-    exit(-1);
+  if(nNz > 0) {
+    size_t ret = fread(buffer, sizeof(unsigned int), 2*nNz, fp);
+    if (ret == 0) {
+      std::cout << "Unexpected end of matrix file: " << rankFileName << std::endl;
+      std::cout.flush();
+      delete [] buffer;
+      exit(-1);
+    }
   }
   if (fp != NULL) fclose(fp);
 


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
This PR fixes the error reported by @kddevin in the following tests:
        157 - TpetraCore_MatrixMarket_Tpetra_CrsMatrix_Dist_BinaryPerProcess_simple_MPI_6 (Failed)
        158 - TpetraCore_MatrixMarket_Tpetra_CrsMatrix_Dist_BinaryPerProcess_simple_MPI_10 (Failed)

The issue arises when `fread` tries to read `0` entries from the binary file. 

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
All of the BinaryPerProcess tests are passing:
```
      Start 22: TpetraCore_MatrixMarket_Tpetra_CrsMatrix_Dist_BinaryPerProcess_simple_MPI_1
22/41 Test #22: TpetraCore_MatrixMarket_Tpetra_CrsMatrix_Dist_BinaryPerProcess_simple_MPI_1 ....   Passed    0.68 sec
      Start 23: TpetraCore_MatrixMarket_Tpetra_CrsMatrix_Dist_BinaryPerProcess_simple_MPI_3
23/41 Test #23: TpetraCore_MatrixMarket_Tpetra_CrsMatrix_Dist_BinaryPerProcess_simple_MPI_3 ....   Passed    0.77 sec
      Start 24: TpetraCore_MatrixMarket_Tpetra_CrsMatrix_Dist_BinaryPerProcess_simple_MPI_4
24/41 Test #24: TpetraCore_MatrixMarket_Tpetra_CrsMatrix_Dist_BinaryPerProcess_simple_MPI_4 ....   Passed    0.73 sec
      Start 25: TpetraCore_MatrixMarket_Tpetra_CrsMatrix_Dist_BinaryPerProcess_simple_MPI_6
25/41 Test #25: TpetraCore_MatrixMarket_Tpetra_CrsMatrix_Dist_BinaryPerProcess_simple_MPI_6 ....   Passed    0.95 sec
      Start 26: TpetraCore_MatrixMarket_Tpetra_CrsMatrix_Dist_BinaryPerProcess_simple_MPI_10
26/41 Test #26: TpetraCore_MatrixMarket_Tpetra_CrsMatrix_Dist_BinaryPerProcess_simple_MPI_10 ...   Passed    0.96 sec
      Start 27: TpetraCore_MatrixMarket_Tpetra_CrsMatrix_Dist_BinaryPerProcess_rmat_MPI_1
27/41 Test #27: TpetraCore_MatrixMarket_Tpetra_CrsMatrix_Dist_BinaryPerProcess_rmat_MPI_1 ......   Passed    0.79 sec
      Start 28: TpetraCore_MatrixMarket_Tpetra_CrsMatrix_Dist_BinaryPerProcess_rmat_MPI_3
28/41 Test #28: TpetraCore_MatrixMarket_Tpetra_CrsMatrix_Dist_BinaryPerProcess_rmat_MPI_3 ......   Passed    0.94 sec
      Start 29: TpetraCore_MatrixMarket_Tpetra_CrsMatrix_Dist_BinaryPerProcess_rmat_MPI_4
29/41 Test #29: TpetraCore_MatrixMarket_Tpetra_CrsMatrix_Dist_BinaryPerProcess_rmat_MPI_4 ......   Passed    0.88 sec
      Start 30: TpetraCore_MatrixMarket_Tpetra_CrsMatrix_Dist_BinaryPerProcess_rmat_MPI_6
30/41 Test #30: TpetraCore_MatrixMarket_Tpetra_CrsMatrix_Dist_BinaryPerProcess_rmat_MPI_6 ......   Passed    1.31 sec
      Start 31: TpetraCore_MatrixMarket_Tpetra_CrsMatrix_Dist_BinaryPerProcess_rmat_MPI_10
31/41 Test #31: TpetraCore_MatrixMarket_Tpetra_CrsMatrix_Dist_BinaryPerProcess_rmat_MPI_10 .....   Passed    1.28 sec

```
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->