### PR TITLE
Panzer fix block dirichlet scatter

### DIFF
--- a/packages/panzer/adapters-stk/example/main_driver/energy-ss-blocked-tp.xml
+++ b/packages/panzer/adapters-stk/example/main_driver/energy-ss-blocked-tp.xml
@@ -75,7 +75,7 @@
             <ParameterList name="EQ 1">
                 <Parameter name="Type" type="string" value="Energy"/> 
                 <Parameter name="Basis Type" type="string" value="HGrad"/> 
-                <Parameter name="Basis Order" type="int" value="1"/>
+                <Parameter name="Basis Order" type="int" value="2"/>
                 <Parameter name="Integration Order" type="int" value="2"/> 
                 <Parameter name="Model ID" type="string" value="fluid model test"/> 
                 <Parameter name="Prefix" type="string" value="TEST_"/>
@@ -168,7 +168,7 @@
 
         <ParameterList>
             <Parameter name="Type" type="string" value="Dirichlet"/> 
-            <Parameter name="Sideset ID" type="string" value="bottom"/> 
+            <Parameter name="Sideset ID" type="string" value="left"/> 
             <Parameter name="Element Block ID" type="string" value="eblock-0_0"/> 
             <Parameter name="Equation Set Name" type="string" value="TEST_TEMPERATURE"/> 
             <Parameter name="Strategy" type="string" value="Constant"/>
@@ -179,7 +179,7 @@
 
         <ParameterList>
             <Parameter name="Type" type="string" value="Dirichlet"/> 
-            <Parameter name="Sideset ID" type="string" value="top"/> 
+            <Parameter name="Sideset ID" type="string" value="right"/> 
             <Parameter name="Element Block ID" type="string" value="eblock-0_0"/> 
             <Parameter name="Equation Set Name" type="string" value="TEST_TEMPERATURE"/> 
             <Parameter name="Strategy" type="string" value="Constant"/>
@@ -191,12 +191,12 @@
     </ParameterList>
 
     <ParameterList name="Output">
-        <Parameter name="File Name" type="string" value="energy-ss-blocked.exo"/>
+        <Parameter name="File Name" type="string" value="energy-ss-blocked-tp.exo"/>
     </ParameterList>
 
     <ParameterList name="Options">
         <Parameter name="Write Volume Assembly Graphs" type="bool" value="false"/>
-        <Parameter name="Volume Assembly Graph Prefix" type="string" value="energy-ss"/> 
+        <Parameter name="Volume Assembly Graph Prefix" type="string" value="energy-ss-blocked-tp"/> 
     </ParameterList>
 
     <ParameterList name="Active Parameters">
@@ -275,7 +275,8 @@
                   </ParameterList>
                 </ParameterList>
                 <ParameterList name="VerboseObject">
-                  <Parameter name="Verbosity Level" type="string" value="extreme"/>
+                  <Parameter name="Verbosity Level" type="string" value="medium"/>
+                  <!--<Parameter name="Verbosity Level" type="string" value="extreme"/>-->
                 </ParameterList>
               </ParameterList>
             </ParameterList>

--- a/packages/panzer/adapters-stk/example/main_driver/energy-ss-blocked-tp.xml
+++ b/packages/panzer/adapters-stk/example/main_driver/energy-ss-blocked-tp.xml
@@ -26,10 +26,16 @@
 
     <ParameterList name="Initial Conditions">
         <ParameterList name="eblock-0_0">
-            <ParameterList name="TEMPERATURE">
+            <ParameterList name="T0_TEMPERATURE">
                 <Parameter name="Value" type="double" value="0.0"/>
             </ParameterList>
-            <ParameterList name="TEST_TEMPERATURE">
+            <ParameterList name="T1_TEMPERATURE">
+                <Parameter name="Value" type="double" value="0.0"/>
+            </ParameterList>
+            <ParameterList name="T2_TEMPERATURE">
+                <Parameter name="Value" type="double" value="0.0"/>
+            </ParameterList>
+            <ParameterList name="T3_TEMPERATURE">
                 <Parameter name="Value" type="double" value="0.0"/>
             </ParameterList>
         </ParameterList>
@@ -55,7 +61,7 @@
     </ParameterList>
 
     <ParameterList name="Assembly">
-        <Parameter name="Field Order" type="string" value="blocked: TEMPERATURE TEST_TEMPERATURE"/>
+        <Parameter name="Field Order" type="string" value="blocked: T0_TEMPERATURE - T1_TEMPERATURE T2_TEMPERATURE - T3_TEMPERATURE"/>
         <Parameter name="Workset Size" type="int" value="1"/>
         <Parameter name="Use Tpetra" type="bool" value="true"/>
     </ParameterList>
@@ -70,15 +76,31 @@
                 <Parameter name="Basis Order" type="int" value="1"/> 
                 <Parameter name="Integration Order" type="int" value="2"/> 
                 <Parameter name="Model ID" type="string" value="fluid model"/> 
-                <Parameter name="Prefix" type="string" value=""/>
+                <Parameter name="Prefix" type="string" value="T0_"/>
             </ParameterList>
             <ParameterList name="EQ 1">
                 <Parameter name="Type" type="string" value="Energy"/> 
                 <Parameter name="Basis Type" type="string" value="HGrad"/> 
+                <Parameter name="Basis Order" type="int" value="1"/>
+                <Parameter name="Integration Order" type="int" value="2"/> 
+                <Parameter name="Model ID" type="string" value="fluid model 1"/> 
+                <Parameter name="Prefix" type="string" value="T1_"/>
+            </ParameterList>
+            <ParameterList name="EQ 2">
+                <Parameter name="Type" type="string" value="Energy"/> 
+                <Parameter name="Basis Type" type="string" value="HGrad"/> 
+                <Parameter name="Basis Order" type="int" value="1"/>
+                <Parameter name="Integration Order" type="int" value="2"/> 
+                <Parameter name="Model ID" type="string" value="fluid model 2"/> 
+                <Parameter name="Prefix" type="string" value="T2_"/>
+            </ParameterList>
+            <ParameterList name="EQ 3">
+                <Parameter name="Type" type="string" value="Energy"/> 
+                <Parameter name="Basis Type" type="string" value="HGrad"/> 
                 <Parameter name="Basis Order" type="int" value="2"/>
                 <Parameter name="Integration Order" type="int" value="2"/> 
-                <Parameter name="Model ID" type="string" value="fluid model test"/> 
-                <Parameter name="Prefix" type="string" value="TEST_"/>
+                <Parameter name="Model ID" type="string" value="fluid model 3"/> 
+                <Parameter name="Prefix" type="string" value="T3_"/>
             </ParameterList>
 
         </ParameterList>
@@ -92,7 +114,7 @@
             <ParameterList name="Volume Integral">
             </ParameterList>
 
-            <ParameterList name="SOURCE_TEMPERATURE">
+            <ParameterList name="SOURCE_T0_TEMPERATURE">
                 <Parameter name="Value" type="double" value="1.0"/>
             </ParameterList>
             <ParameterList name="Heat Capacity">
@@ -101,27 +123,55 @@
             <ParameterList name="Thermal Conductivity">
                 <Parameter name="Value" type="double" value="1.0"/>
             </ParameterList>
-            <ParameterList name="DENSITY">
+            <ParameterList name="T0_DENSITY">
                 <Parameter name="Value" type="double" value="1.0"/>
             </ParameterList>
-            <ParameterList name="HEAT_CAPACITY">
+            <ParameterList name="T0_HEAT_CAPACITY">
                 <Parameter name="Value" type="double" value="1.0"/>
             </ParameterList>
             <ParameterList name="Global Statistics">
-                <Parameter name="Value" type="string" value="TEMPERATURE,DENSITY"/>
+                <Parameter name="Value" type="string" value="T0_TEMPERATURE,T0_DENSITY"/>
             </ParameterList>
 
         </ParameterList>
 
-        <ParameterList name="fluid model test">
+        <ParameterList name="fluid model 1">
 
-            <ParameterList name="SOURCE_TEST_TEMPERATURE">
+            <ParameterList name="SOURCE_T1_TEMPERATURE">
                 <Parameter name="Value" type="double" value="1.0"/>
             </ParameterList>
-            <ParameterList name="TEST_DENSITY">
+            <ParameterList name="T1_DENSITY">
                 <Parameter name="Value" type="double" value="1.0"/>
             </ParameterList>
-            <ParameterList name="TEST_HEAT_CAPACITY">
+            <ParameterList name="T1_HEAT_CAPACITY">
+                <Parameter name="Value" type="double" value="1.0"/>
+            </ParameterList>
+
+        </ParameterList>
+
+        <ParameterList name="fluid model 2">
+
+            <ParameterList name="SOURCE_T2_TEMPERATURE">
+                <Parameter name="Value" type="double" value="1.0"/>
+            </ParameterList>
+            <ParameterList name="T2_DENSITY">
+                <Parameter name="Value" type="double" value="1.0"/>
+            </ParameterList>
+            <ParameterList name="T2_HEAT_CAPACITY">
+                <Parameter name="Value" type="double" value="1.0"/>
+            </ParameterList>
+
+        </ParameterList>
+
+        <ParameterList name="fluid model 3">
+
+            <ParameterList name="SOURCE_T3_TEMPERATURE">
+                <Parameter name="Value" type="double" value="1.0"/>
+            </ParameterList>
+            <ParameterList name="T3_DENSITY">
+                <Parameter name="Value" type="double" value="1.0"/>
+            </ParameterList>
+            <ParameterList name="T3_HEAT_CAPACITY">
                 <Parameter name="Value" type="double" value="1.0"/>
             </ParameterList>
 
@@ -146,9 +196,9 @@
 
         <ParameterList>
             <Parameter name="Type" type="string" value="Dirichlet"/> 
-            <Parameter name="Sideset ID" type="string" value="left"/> 
+            <Parameter name="Sideset ID" type="string" value="top"/> 
             <Parameter name="Element Block ID" type="string" value="eblock-0_0"/> 
-            <Parameter name="Equation Set Name" type="string" value="TEMPERATURE"/> 
+            <Parameter name="Equation Set Name" type="string" value="T0_TEMPERATURE"/> 
             <Parameter name="Strategy" type="string" value="Constant"/>
             <ParameterList name="Data">
                 <Parameter name="Value" type="double" value="0.0"/>
@@ -157,9 +207,9 @@
 
         <ParameterList>
             <Parameter name="Type" type="string" value="Dirichlet"/> 
-            <Parameter name="Sideset ID" type="string" value="right"/> 
+            <Parameter name="Sideset ID" type="string" value="bottom"/> 
             <Parameter name="Element Block ID" type="string" value="eblock-0_0"/> 
-            <Parameter name="Equation Set Name" type="string" value="TEMPERATURE"/> 
+            <Parameter name="Equation Set Name" type="string" value="T0_TEMPERATURE"/> 
             <Parameter name="Strategy" type="string" value="Constant"/>
             <ParameterList name="Data">
                 <Parameter name="Value" type="double" value="1.0"/>
@@ -168,9 +218,9 @@
 
         <ParameterList>
             <Parameter name="Type" type="string" value="Dirichlet"/> 
-            <Parameter name="Sideset ID" type="string" value="left"/> 
+            <Parameter name="Sideset ID" type="string" value="top"/> 
             <Parameter name="Element Block ID" type="string" value="eblock-0_0"/> 
-            <Parameter name="Equation Set Name" type="string" value="TEST_TEMPERATURE"/> 
+            <Parameter name="Equation Set Name" type="string" value="T1_TEMPERATURE"/> 
             <Parameter name="Strategy" type="string" value="Constant"/>
             <ParameterList name="Data">
                 <Parameter name="Value" type="double" value="0.0"/>
@@ -179,9 +229,53 @@
 
         <ParameterList>
             <Parameter name="Type" type="string" value="Dirichlet"/> 
-            <Parameter name="Sideset ID" type="string" value="right"/> 
+            <Parameter name="Sideset ID" type="string" value="bottom"/> 
             <Parameter name="Element Block ID" type="string" value="eblock-0_0"/> 
-            <Parameter name="Equation Set Name" type="string" value="TEST_TEMPERATURE"/> 
+            <Parameter name="Equation Set Name" type="string" value="T1_TEMPERATURE"/> 
+            <Parameter name="Strategy" type="string" value="Constant"/>
+            <ParameterList name="Data">
+                <Parameter name="Value" type="double" value="1.0"/>
+            </ParameterList>
+        </ParameterList>
+
+        <ParameterList>
+            <Parameter name="Type" type="string" value="Dirichlet"/> 
+            <Parameter name="Sideset ID" type="string" value="top"/> 
+            <Parameter name="Element Block ID" type="string" value="eblock-0_0"/> 
+            <Parameter name="Equation Set Name" type="string" value="T2_TEMPERATURE"/> 
+            <Parameter name="Strategy" type="string" value="Constant"/>
+            <ParameterList name="Data">
+                <Parameter name="Value" type="double" value="0.0"/>
+            </ParameterList>
+        </ParameterList>
+
+        <ParameterList>
+            <Parameter name="Type" type="string" value="Dirichlet"/> 
+            <Parameter name="Sideset ID" type="string" value="bottom"/> 
+            <Parameter name="Element Block ID" type="string" value="eblock-0_0"/> 
+            <Parameter name="Equation Set Name" type="string" value="T2_TEMPERATURE"/> 
+            <Parameter name="Strategy" type="string" value="Constant"/>
+            <ParameterList name="Data">
+                <Parameter name="Value" type="double" value="1.0"/>
+            </ParameterList>
+        </ParameterList>
+
+        <ParameterList>
+            <Parameter name="Type" type="string" value="Dirichlet"/> 
+            <Parameter name="Sideset ID" type="string" value="top"/> 
+            <Parameter name="Element Block ID" type="string" value="eblock-0_0"/> 
+            <Parameter name="Equation Set Name" type="string" value="T3_TEMPERATURE"/> 
+            <Parameter name="Strategy" type="string" value="Constant"/>
+            <ParameterList name="Data">
+                <Parameter name="Value" type="double" value="0.0"/>
+            </ParameterList>
+        </ParameterList>
+
+        <ParameterList>
+            <Parameter name="Type" type="string" value="Dirichlet"/> 
+            <Parameter name="Sideset ID" type="string" value="bottom"/> 
+            <Parameter name="Element Block ID" type="string" value="eblock-0_0"/> 
+            <Parameter name="Equation Set Name" type="string" value="T3_TEMPERATURE"/> 
             <Parameter name="Strategy" type="string" value="Constant"/>
             <ParameterList name="Data">
                 <Parameter name="Value" type="double" value="1.0"/>

--- a/packages/panzer/adapters-stk/example/main_driver/energy-ss-tp.xml
+++ b/packages/panzer/adapters-stk/example/main_driver/energy-ss-tp.xml
@@ -120,7 +120,7 @@
 
         <ParameterList>
             <Parameter name="Type" type="string" value="Dirichlet"/> 
-            <Parameter name="Sideset ID" type="string" value="left"/> 
+            <Parameter name="Sideset ID" type="string" value="top"/> 
             <Parameter name="Element Block ID" type="string" value="eblock-0_0"/> 
             <Parameter name="Equation Set Name" type="string" value="TEMPERATURE"/> 
             <Parameter name="Strategy" type="string" value="Constant"/>
@@ -131,7 +131,7 @@
 
         <ParameterList>
             <Parameter name="Type" type="string" value="Dirichlet"/> 
-            <Parameter name="Sideset ID" type="string" value="right"/> 
+            <Parameter name="Sideset ID" type="string" value="bottom"/> 
             <Parameter name="Element Block ID" type="string" value="eblock-0_0"/> 
             <Parameter name="Equation Set Name" type="string" value="TEMPERATURE"/> 
             <Parameter name="Strategy" type="string" value="Constant"/>

--- a/packages/panzer/disc-fe/src/Panzer_ModelEvaluator.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_ModelEvaluator.hpp
@@ -709,6 +709,8 @@ private: // data members
   bool build_volume_field_managers_;
   bool build_bc_field_managers_;
   std::vector<bool> active_evaluation_types_;
+
+  mutable unsigned long long write_matrix_count_;
 };
 
 // Inline definition of the add response (its template on the builder type)

--- a/packages/panzer/disc-fe/src/Panzer_ModelEvaluator_impl.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_ModelEvaluator_impl.hpp
@@ -73,6 +73,11 @@
 #include "Thyra_MultiVectorStdOps.hpp"
 #include "Thyra_VectorStdOps.hpp"
 
+// For writing out residuals/Jacobians
+#include "Thyra_ProductVectorBase.hpp"
+#include "Thyra_BlockedLinearOpBase.hpp"
+#include "Thyra_TpetraVector.hpp"
+#include "Thyra_TpetraLinearOp.hpp"
 #include "Tpetra_CrsMatrix.hpp"
 
 // Constructors/Initializers/Accessors
@@ -104,6 +109,7 @@ ModelEvaluator(const Teuchos::RCP<panzer::FieldManagerBuilder>& fmb,
   , build_volume_field_managers_(true)
   , build_bc_field_managers_(true)
   , active_evaluation_types_(Sacado::mpl::size<panzer::Traits::EvalTypes>::value, true)
+  , write_matrix_count_(0)
 {
   using Teuchos::RCP;
   using Teuchos::rcp;
@@ -159,6 +165,7 @@ ModelEvaluator(const Teuchos::RCP<const panzer::LinearObjFactory<panzer::Traits>
   , build_volume_field_managers_(true)
   , build_bc_field_managers_(true)
   , active_evaluation_types_(Sacado::mpl::size<panzer::Traits::EvalTypes>::value, true)
+  , write_matrix_count_(0)
 {
   using Teuchos::RCP;
   using Teuchos::rcp_dynamic_cast;
@@ -1629,6 +1636,48 @@ evalModelImpl_basic(const Thyra::ModelEvaluatorBase::InArgs<Scalar> &inArgs,
 
   // reset parameters back to nominal values
   resetParameters();
+
+  const bool writeToFile = false;
+  if (writeToFile && nonnull(W_out)) {
+    const auto check_blocked = Teuchos::rcp_dynamic_cast<::Thyra::BlockedLinearOpBase<double> >(W_out,false);
+    if (check_blocked) {
+      const int numBlocks = check_blocked->productDomain()->numBlocks();
+      const int rangeBlocks = check_blocked->productRange()->numBlocks();
+      TEUCHOS_ASSERT(numBlocks == rangeBlocks); // not true for optimization
+      for (int row=0; row < numBlocks; ++row) {
+        for (int col=0; col < numBlocks; ++col) {
+          using LO = panzer::LocalOrdinal;
+          using GO = panzer::GlobalOrdinal;
+          using NodeT = panzer::TpetraNodeType;
+          const auto thyraTpetraOperator = Teuchos::rcp_dynamic_cast<::Thyra::TpetraLinearOp<double,LO,GO,NodeT>>(check_blocked->getNonconstBlock(row,col),true);
+          const auto tpetraCrsMatrix = Teuchos::rcp_dynamic_cast<Tpetra::CrsMatrix<double,LO,GO,NodeT>>(thyraTpetraOperator->getTpetraOperator(),true);      
+          tpetraCrsMatrix->print(std::cout);
+          std::stringstream ss;
+          ss << "W_out_" << write_matrix_count_ << ".rank_" << tpetraCrsMatrix->getMap()->getComm()->getRank() << ".block_" << row << "_" << col << ".txt";
+          std::fstream fs(ss.str().c_str(),std::fstream::out|std::fstream::trunc);
+          Teuchos::FancyOStream fos(Teuchos::rcpFromRef(fs));
+          tpetraCrsMatrix->describe(fos,Teuchos::VERB_EXTREME);
+          fs.close();
+        }
+      }
+    }
+    else {
+      using LO = panzer::LocalOrdinal;
+      using GO = panzer::GlobalOrdinal;
+      using NodeT = panzer::TpetraNodeType;
+      const auto thyraTpetraOperator = Teuchos::rcp_dynamic_cast<::Thyra::TpetraLinearOp<double,LO,GO,NodeT>>(W_out,true);
+      const auto tpetraCrsMatrix = Teuchos::rcp_dynamic_cast<Tpetra::CrsMatrix<double,LO,GO,NodeT>>(thyraTpetraOperator->getTpetraOperator(),true);      
+      tpetraCrsMatrix->print(std::cout);
+      std::stringstream ss;
+      ss << "W_out_" << write_matrix_count_ << ".rank_" << tpetraCrsMatrix->getMap()->getComm()->getRank() << ".txt";
+      std::fstream fs(ss.str().c_str(),std::fstream::out|std::fstream::trunc);
+      Teuchos::FancyOStream fos(Teuchos::rcpFromRef(fs));
+      tpetraCrsMatrix->describe(fos,Teuchos::VERB_EXTREME);
+      fs.close();
+    }
+    ++write_matrix_count_;
+  }
+
 }
 
 template <typename Scalar>

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterDirichletResidual_BlockedTpetra_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterDirichletResidual_BlockedTpetra_impl.hpp
@@ -585,7 +585,8 @@ evaluateFields(typename TRAITS::EvalData workset)
       typename Sacado::ScalarType<ScalarT>::type vals[maxDerivativeArraySize_];
 
       for(int basis=0; basis < static_cast<int>(fieldOffsets.size()); ++basis) {
-        const int rowLID = worksetLIDs(cell,fieldOffsets(basis));
+        const int block_row_offset = blockOffsets(blockRowIndex);
+        const int rowLID = worksetLIDs(cell,block_row_offset+fieldOffsets(basis));
 
         if (rowLID < 0) // not on this processor!
           continue;


### PR DESCRIPTION
## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Drekar users reported exception throw with a certain blocked dirichlet scatter use case. 

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
Fixed the issue.

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
The test energy-ss-blocked-tp.xml has been modified to cover this use case.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->