### PR TITLE
Fixing issue seen in #8705.

### DIFF
--- a/cmake/std/sems/PullRequestCuda10.1.105uvmTestingEnv.sh
+++ b/cmake/std/sems/PullRequestCuda10.1.105uvmTestingEnv.sh
@@ -17,4 +17,5 @@ export CUDA_MANAGED_FORCE_DEVICE_ALLOC=1
 
 # Use manually installed cmake and ninja to try to avoid module loading
 # problems (see TRIL-208)
-export PATH=/ascldap/users/rabartl/install/white-ride/cmake-3.11.2/bin:/ascldap/users/rabartl/install/white-ride/ninja-1.8.2/bin:$PATH
+export PATH=/home/atdm-devops-admin/tools/ride/cmake-3.17.2/bin/:/ascldap/users/rabartl/install/white-ride/ninja-1.8.2/bin:$PATH
+#export PATH=/ascldap/users/rabartl/install/white-ride/cmake-3.11.2/bin:/ascldap/users/rabartl/install/white-ride/ninja-1.8.2/bin:$PATH


### PR DESCRIPTION
Moving to new CMake version for UVM dev->master build

As seen in the dev->master testing results for #8705, the uvm free dev->master build is using an old version of CMake no longer supported. This PR upgrades to the same version used for the UVM enabled variant of the build.