### PR TITLE
Teuchos ParameterList: Add option to toggle printing of default values

### DIFF
--- a/packages/teuchos/parameterlist/src/Teuchos_ParameterList.cpp
+++ b/packages/teuchos/parameterlist/src/Teuchos_ParameterList.cpp
@@ -345,10 +345,11 @@ void ParameterList::print() const
 
 std::ostream& ParameterList::print(std::ostream& os, const PrintOptions &printOptions ) const
 {
-  const int   indent    = printOptions.indent();
-  const bool  showTypes = printOptions.showTypes();
-  const bool  showFlags = printOptions.showFlags();
-  const bool  showDoc   = printOptions.showDoc();
+  const int   indent      = printOptions.indent();
+  const bool  showTypes   = printOptions.showTypes();
+  const bool  showFlags   = printOptions.showFlags();
+  const bool  showDoc     = printOptions.showDoc();
+  const bool  showDefault = printOptions.showDefault();
   const std::string linePrefix(indent,' ');
   RCP<FancyOStream>
     out = getFancyOStream(rcp(&os,false));
@@ -365,6 +366,8 @@ std::ostream& ParameterList::print(std::ostream& os, const PrintOptions &printOp
       RCP<const ParameterEntryValidator>
         validator = entry_i.validator();
       if(entry_i.isList())
+        continue;
+      if(!showDefault && entry_i.isDefault())
         continue;
       *out << name_i;
       const std::string &docString = entry_i.docString();
@@ -399,9 +402,9 @@ std::ostream& ParameterList::print(std::ostream& os, const PrintOptions &printOp
 }
 
 
-std::ostream& ParameterList::print(std::ostream& os, int indent, bool showTypes, bool showFlags) const
+std::ostream& ParameterList::print(std::ostream& os, int indent, bool showTypes, bool showFlags, bool showDefault) const
 {
-  return this->print(os,PrintOptions().indent(indent).showTypes(showTypes).showFlags(showFlags));
+  return this->print(os,PrintOptions().indent(indent).showTypes(showTypes).showFlags(showFlags).showDefault(showDefault));
 }
 
 

--- a/packages/teuchos/parameterlist/src/Teuchos_ParameterList.hpp
+++ b/packages/teuchos/parameterlist/src/Teuchos_ParameterList.hpp
@@ -149,22 +149,25 @@ public:
   /** \brief Utility class for setting and passing in print options. */
   class PrintOptions {
   public:
-    PrintOptions() : indent_(0), showTypes_(false), showFlags_(false), showDoc_(false) {}
-    PrintOptions& indent(int _indent)        { indent_ = _indent; return *this; }
-    PrintOptions& showTypes(bool _showTypes) { showTypes_ = _showTypes; return *this; }
-    PrintOptions& showFlags(bool _showFlags) { showFlags_ = _showFlags; return *this; }
-    PrintOptions& showDoc(bool _showDoc)     { showDoc_ = _showDoc; return *this; }
-    PrintOptions& incrIndent(int indents)    { indent_ += indents; return *this; }
+    PrintOptions() : indent_(0), showTypes_(false), showFlags_(false), showDoc_(false), showDefault_(true) {}
+    PrintOptions& indent(int _indent)            { indent_ = _indent; return *this; }
+    PrintOptions& showTypes(bool _showTypes)     { showTypes_ = _showTypes; return *this; }
+    PrintOptions& showFlags(bool _showFlags)     { showFlags_ = _showFlags; return *this; }
+    PrintOptions& showDoc(bool _showDoc)         { showDoc_ = _showDoc; return *this; }
+    PrintOptions& showDefault(bool _showDefault) { showDefault_ = _showDefault; return *this; }
+    PrintOptions& incrIndent(int indents)        { indent_ += indents; return *this; }
     int indent() const { return indent_; }
     bool showTypes() const { return showTypes_; }
     bool showFlags() const { return showFlags_; }
     bool showDoc() const { return showDoc_; }
+    bool showDefault() const { return showDefault_; }
     PrintOptions copy() const { return PrintOptions(*this); }
   private:
     int    indent_;
     bool   showTypes_;
     bool   showFlags_;
     bool   showDoc_;
+    bool   showDefault_;
   };
 
   //@}
@@ -595,7 +598,7 @@ public:
 
   /*! \brief Printing method for parameter lists.  Indenting is used to indicate
     parameter list hierarchies. */
-  std::ostream& print(std::ostream& os, int indent = 0, bool showTypes = false, bool showFlags = true ) const;
+  std::ostream& print(std::ostream& os, int indent = 0, bool showTypes = false, bool showFlags = true, bool showDefault = true ) const;
   
   //! Print out unused parameters in the ParameterList.
   void unused(std::ostream& os) const;

--- a/packages/teuchos/parameterlist/test/ParameterList/ParameterList_UnitTests.cpp
+++ b/packages/teuchos/parameterlist/test/ParameterList/ParameterList_UnitTests.cpp
@@ -1096,6 +1096,39 @@ TEUCHOS_UNIT_TEST( ParameterList, attachValidatorRecursively ) {
 // TODO: test printing of modifiers
 // valid_pl.print(std::cout, ParameterList::PrintOptions().showDoc(true).indent(2).showTypes(true));
 
+TEUCHOS_UNIT_TEST( ParameterList, print ) {
+  ParameterList valid_pl("valid_pl");
+  valid_pl.set("a", 0.);
+
+  {
+    ParameterList pl("pl");
+    pl.set("a", 1.);
+    pl.validateParametersAndSetDefaults(valid_pl);
+    ParameterList::PrintOptions printOptions;
+    printOptions.showDefault(false);
+    std::ostringstream ss;
+    pl.print(ss, printOptions);
+    std::cout << ss.str();
+    TEST_ASSERT(ss.str().size() > 0);
+  }
+
+  {
+    ParameterList pl("pl");
+    pl.validateParametersAndSetDefaults(valid_pl);
+    ParameterList::PrintOptions printOptions;
+    std::ostringstream ss;
+    pl.print(ss, printOptions);
+    std::cout << ss.str();
+    TEST_ASSERT(ss.str().size() > 0);
+
+    ss.str("");
+    printOptions.showDefault(false);
+    pl.print(ss, printOptions);
+    std::cout << ss.str();
+    TEST_ASSERT(ss.str().size() == 0);
+  }
+}
+
 } // namespace Teuchos
 
 


### PR DESCRIPTION
@trilinos/teuchos 

## Motivation
Add a flag to `ParamterList::PrintOptions` that toggles the printing of default options.
The default behavior has not changed: defaults are printed.