### PR TITLE
teuchos:  fix tests to pass without CUDA UVM  #8633

### DIFF
--- a/cmake/std/PullRequestLinuxCuda10.1.105uvmTestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxCuda10.1.105uvmTestingSettings.cmake
@@ -1013,10 +1013,6 @@ set (Adelus_vector_random_MPI_4_DISABLE ON CACHE BOOL "Turn off tests for UVM bu
 set (ThyraTpetraAdapters_Simple2DTpetraModelEvaluatorUnitTests_MPI_1_DISABLE ON CACHE BOOL "Turn off tests for UVM build")
 set (ThyraTpetraAdapters_TpetraThyraWrappersUnitTests_serial_MPI_1_DISABLE ON CACHE BOOL "Turn off tests for UVM build")
 set (ThyraTpetraAdapters_TpetraThyraWrappersUnitTests_MPI_4_DISABLE ON CACHE BOOL "Turn off tests for UVM build")
-# Teuchos UVM = OFF tests
-set (TeuchosComm_stacked_timer_MPI_2_DISABLE ON CACHE BOOL "Turn off tests for UVM build")
-set (TeuchosComm_stacked_timer4_MPI_4_DISABLE ON CACHE BOOL "Turn off tests for UVM build")
-set (TeuchosKokkosCompat_linkTest_MPI_1_DISABLE ON CACHE BOOL "Turn off tests for UVM build")
 # Piro UVM = OFF tests
 set (Piro_AnalysisDriverTpetra_MPI_4_DISABLE ON CACHE BOOL "Turn off tests for UVM build")
 set (Piro_ThyraSolverTpetra_MPI_4_DISABLE ON CACHE BOOL "Turn off tests for UVM build")

--- a/packages/teuchos/kokkoscompat/test/linkTest.cpp
+++ b/packages/teuchos/kokkoscompat/test/linkTest.cpp
@@ -130,10 +130,10 @@ TEUCHOS_UNIT_TEST( LinkTeuchosAndKokkos, ArrayViewOfView ) {
   Kokkos::deep_copy (y_host, y);
 
   Teuchos::ArrayView<double> y_view (y_host.data (), y_host.extent (0));
-  TEST_EQUALITY_CONST( size_t (y_view.size ()), size_t (y.extent (0)) );
+  TEST_EQUALITY_CONST( size_t (y_view.size ()), size_t (y_host.extent (0)) );
   if (success) {
-    for (size_type k = 0; k < size_type (y.extent (0)); ++k) {
-      TEST_EQUALITY( y_view[k], y[k] );
+    for (size_type k = 0; k < size_type (y_host.extent (0)); ++k) {
+      TEST_EQUALITY( y_view[k], y_host[k] );
     }
   }
 }


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/teuchos
 
## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
This PR fixes Teuchos tests that failed when UVM is disabled.
It re-enables Teuchos tests that had been disabled.

I did not see failures in the Teuchos_stackedTimer tests, so I re-enabled them as well.
If they fail in the dev->master test, please mention me and I'll take a second look at them.


## Related Issues
* Related to  #8633



## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Tested on cee-lan GPU machine with sierra-devel/nvidia module and 
```
-D Kokkos_ENABLE_CUDA_UVM=OFF
-D Tpetra_ENABLE_CUDA_UVM=OFF
```
All Teuchos tests passed.


<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->