### PR TITLE
Disable Kokkos unit test Random_XorShift64 and Random_XorShift1024

### DIFF
--- a/cmake/std/PullRequestLinuxCommonTestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxCommonTestingSettings.cmake
@@ -63,6 +63,10 @@ set (PanzerAdaptersSTK_PoissonInterfaceExample_2d_diffsideids_MPI_1_DISABLE ON C
 # Disable long-failing Anazazi test until it can be fixed (#3585)
 set (Anasazi_Epetra_OrthoManagerGenTester_0_MPI_4_DISABLE ON CACHE BOOL "Set by default for PR testing")
 
+# Disable Random_XorShift64 and Random_XorShift1024 due to random failures. See #3282.
+set (KokkosAlgorithms_UnitTest_MPI_1_EXTRA_ARGS
+  "--gtest_filter=-*Random_XorShift64:-*Random_XorShift1024" CACHE STRING "Set by default for PR testing")
+
 # Options from SEMSDevEnv.cmake
 
 SET(CMAKE_C_COMPILER "$ENV{MPICC}" CACHE FILEPATH "Set by default for PR testing")

--- a/cmake/std/atdm/ATDMDisables.cmake
+++ b/cmake/std/atdm/ATDMDisables.cmake
@@ -255,7 +255,7 @@ ATDM_SET_ENABLE(KokkosCore_UnitTest_CudaTimingBased_MPI_1_DISABLE ON)
 
 # Disable serial.Random_XorShift64 due to random failures. See #3282.
 ATDM_SET_CACHE(KokkosAlgorithms_UnitTest_MPI_1_EXTRA_ARGS
-  "--gtest_filter=-*Random_XorShift64" CACHE STRING)
+  "--gtest_filter=-*Random_XorShift64:-*Random_XorShift1024" CACHE STRING)
 
 IF (ATDM_NODE_TYPE STREQUAL "OPENMP")
 

--- a/cmake/std/atdm/ATDMDisables.cmake
+++ b/cmake/std/atdm/ATDMDisables.cmake
@@ -253,6 +253,10 @@ ATDM_SET_ENABLE(ROL_adapters_tpetra_test_vector_SimulatedVectorTpetraBatchManage
 # Disable Kokkos timing based test. See #8545.
 ATDM_SET_ENABLE(KokkosCore_UnitTest_CudaTimingBased_MPI_1_DISABLE ON)
 
+# Disable serial.Random_XorShift64 due to random failures. See #3282.
+ATDM_SET_CACHE(KokkosAlgorithms_UnitTest_MPI_1_EXTRA_ARGS
+  "--gtest_filter=-*Random_XorShift64" CACHE STRING)
+
 IF (ATDM_NODE_TYPE STREQUAL "OPENMP")
 
   # Disable ctest DISABLED test (otherwise, this shows up on CDash as "NotRun")


### PR DESCRIPTION
Related to #3282 

## How was this tested?
On a cee-rhel7 machine via:
```
nohup env Trilinos_PACKAGES=Kokkos ATDM_CTEST_S_DEFAULT_ENV=cee-rhel7-default ./ctest-s-local-test-driver.sh cee-rhel7_cuda-10.1.243_gnu-7.2.0_openmpi-4.0.3_shared_dbg &> ctest-s-local-test-driver.out &
```
Evidence of the disable for `Random_XorShift64` is shown in [this](https://testing-dev.sandia.gov/cdash/queryTests.php?project=Trilinos&date=2021-02-11&filtercount=4&showfilters=1&filtercombine=and&field1=groupname&compare1=61&value1=Experimental&field2=buildname&compare2=65&value2=Trilinos-atdm-cee-rhel7_cuda-10.1.243_gnu-7.2.0_openmpi-4.0.3_shared_dbg&field3=testname&compare3=63&value3=KokkosAlgorithms_UnitTest_MPI_1&field4=testoutput&compare4=95&value4=Random_XorShift) query by clicking "Show Matching Output".