### PR TITLE
Use DeviceType in Basis subclasses, etc.

### DIFF
--- a/packages/intrepid2/src/Cell/Intrepid2_CellGeometry.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellGeometry.hpp
@@ -79,6 +79,7 @@ namespace Intrepid2
   template<class PointScalar, int spaceDim, typename DeviceType = Kokkos::DefaultExecutionSpace::device_type>
   class CellGeometry
   {
+    static_assert(Kokkos::is_device<DeviceType>::value, "Third template argument to CellGeometry must be a Kokkos::Device");
     public:
     /*! Supported types for CellGeometry */
     enum CellGeometryType {

--- a/packages/intrepid2/src/Cell/Intrepid2_CellGeometryDef.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellGeometryDef.hpp
@@ -57,11 +57,11 @@ namespace Intrepid2
   {
     /** \brief Store host-only "members" of CellGeometry using a static map indexed on the CellGeometry pointer.  This allows us to avoid issues related to non-CUDA-aware members with a lambda capture of a CellGeometry object.
      */
-    template<class PointScalar, int spaceDim, typename ExecSpaceType>
+    template<class PointScalar, int spaceDim, typename DeviceType>
     class CellGeometryHostMembers
     {
-      using BasisPtr = Teuchos::RCP<Intrepid2::Basis<ExecSpaceType,PointScalar,PointScalar> >;
-      using CellGeometryType = CellGeometry<PointScalar,spaceDim,ExecSpaceType>;
+      using BasisPtr = Teuchos::RCP<Intrepid2::Basis<DeviceType,PointScalar,PointScalar> >;
+      using CellGeometryType = CellGeometry<PointScalar,spaceDim,DeviceType>;
     public:
       // conceptually, these should be private members, but for the definition of these, we need them to be externally accessible.
       static std::map<const CellGeometryType *, shards::CellTopology> cellTopology_;
@@ -92,14 +92,14 @@ namespace Intrepid2
     };
   
     // member lookup map definitions for CellGeometryHostMembers:
-    template< class PointScalar, int spaceDim, typename ExecSpaceType > typename std::map<const CellGeometry<PointScalar,spaceDim,ExecSpaceType> *, shards::CellTopology> CellGeometryHostMembers< PointScalar,spaceDim,ExecSpaceType>::cellTopology_;
+    template< class PointScalar, int spaceDim, typename DeviceType > typename std::map<const CellGeometry<PointScalar,spaceDim,DeviceType> *, shards::CellTopology> CellGeometryHostMembers< PointScalar,spaceDim,DeviceType>::cellTopology_;
   
-    template< class PointScalar, int spaceDim, typename ExecSpaceType > typename std::map<const CellGeometry<PointScalar,spaceDim,ExecSpaceType> *, Teuchos::RCP<Intrepid2::Basis<ExecSpaceType,PointScalar,PointScalar> >> CellGeometryHostMembers< PointScalar,spaceDim,ExecSpaceType>::basisForNodes_;
+    template< class PointScalar, int spaceDim, typename DeviceType > typename std::map<const CellGeometry<PointScalar,spaceDim,DeviceType> *, Teuchos::RCP<Intrepid2::Basis<DeviceType,PointScalar,PointScalar> >> CellGeometryHostMembers< PointScalar,spaceDim,DeviceType>::basisForNodes_;
   }
 
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
+  template<class PointScalar, int spaceDim, typename DeviceType>
   KOKKOS_INLINE_FUNCTION
-  CellGeometry<PointScalar,spaceDim,ExecSpaceType>::CellGeometry(const CellGeometry<PointScalar,spaceDim,ExecSpaceType> &cellGeometry)
+  CellGeometry<PointScalar,spaceDim,DeviceType>::CellGeometry(const CellGeometry<PointScalar,spaceDim,DeviceType> &cellGeometry)
 :
   nodeOrdering_(cellGeometry.nodeOrdering_),
   cellGeometryType_(cellGeometry.cellGeometryType_),
@@ -119,25 +119,25 @@ namespace Intrepid2
 #ifndef __CUDA_ARCH__
     shards::CellTopology cellTopo = cellGeometry.cellTopology();
     BasisPtr basisForNodes = cellGeometry.basisForNodes();
-    using HostMemberLookup = ::Intrepid2::Impl::CellGeometryHostMembers<PointScalar, spaceDim, ExecSpaceType>;
+    using HostMemberLookup = ::Intrepid2::Impl::CellGeometryHostMembers<PointScalar, spaceDim, DeviceType>;
     HostMemberLookup::constructorCalled(this, cellTopo, basisForNodes);
 #endif
   }
 
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
+  template<class PointScalar, int spaceDim, typename DeviceType>
   KOKKOS_INLINE_FUNCTION
-  CellGeometry<PointScalar,spaceDim,ExecSpaceType>::~CellGeometry()
+  CellGeometry<PointScalar,spaceDim,DeviceType>::~CellGeometry()
   {
     // host-only deregistration with HostMemberLookup:
 #ifndef __CUDA_ARCH__
-    using HostMemberLookup = ::Intrepid2::Impl::CellGeometryHostMembers<PointScalar, spaceDim, ExecSpaceType>;
+    using HostMemberLookup = ::Intrepid2::Impl::CellGeometryHostMembers<PointScalar, spaceDim, DeviceType>;
     HostMemberLookup::destructorCalled(this);
 #endif
   }
 
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
+  template<class PointScalar, int spaceDim, typename DeviceType>
   KOKKOS_INLINE_FUNCTION
-  int CellGeometry<PointScalar,spaceDim,ExecSpaceType>::numCellsPerGridCell(SubdivisionStrategy subdivisionStrategy) const
+  int CellGeometry<PointScalar,spaceDim,DeviceType>::numCellsPerGridCell(SubdivisionStrategy subdivisionStrategy) const
   {
     switch (subdivisionStrategy) {
       case NO_SUBDIVISION:
@@ -155,11 +155,11 @@ namespace Intrepid2
     return -1;
   }
 
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
-  Data<PointScalar,ExecSpaceType>
-  CellGeometry<PointScalar,spaceDim,ExecSpaceType>::allocateJacobianDataPrivate(const TensorPoints<PointScalar,ExecSpaceType> &points, const int &pointsPerCell, const int startCell, const int endCell) const
+  template<class PointScalar, int spaceDim, typename DeviceType>
+  Data<PointScalar,DeviceType>
+  CellGeometry<PointScalar,spaceDim,DeviceType>::allocateJacobianDataPrivate(const TensorPoints<PointScalar,DeviceType> &points, const int &pointsPerCell, const int startCell, const int endCell) const
   {
-    ScalarView<PointScalar,ExecSpaceType> data;
+    ScalarView<PointScalar,DeviceType> data;
     const int rank = 4; // C,P,D,D
     const int CELL_DIM  = 0;
     const int POINT_DIM = 1;
@@ -244,12 +244,12 @@ namespace Intrepid2
       INTREPID2_TEST_FOR_EXCEPTION_DEVICE_SAFE(true, std::invalid_argument, "support for this CellGeometryType is not yet implemented");
     }
     
-    Data<PointScalar,ExecSpaceType> jacobianData(data,rank,extents,variationType,blockPlusDiagonalLastNonDiagonal);
+    Data<PointScalar,DeviceType> jacobianData(data,rank,extents,variationType,blockPlusDiagonalLastNonDiagonal);
     return jacobianData;
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
-  void CellGeometry<PointScalar,spaceDim,ExecSpaceType>::setJacobianDataPrivate(Data<PointScalar,ExecSpaceType> &jacobianData, const TensorPoints<PointScalar,ExecSpaceType> &points, const int &pointsPerCell, const int startCell, const int endCell) const
+  template<class PointScalar, int spaceDim, typename DeviceType>
+  void CellGeometry<PointScalar,spaceDim,DeviceType>::setJacobianDataPrivate(Data<PointScalar,DeviceType> &jacobianData, const TensorPoints<PointScalar,DeviceType> &points, const int &pointsPerCell, const int startCell, const int endCell) const
   {
     const int numCellsWorkset = (endCell == -1) ? (numCells_ - startCell) : (endCell - startCell);
     
@@ -291,6 +291,7 @@ namespace Intrepid2
         const auto domainExtents = domainExtents_;
         const auto gridCellCounts = gridCellCounts_;
         
+        using ExecSpaceType = typename DeviceType::execution_space;
         auto policy = Kokkos::RangePolicy<>(ExecSpaceType(),0,spaceDim);
         Kokkos::parallel_for("fill jacobian", policy, KOKKOS_LAMBDA(const int d1)
         {
@@ -316,6 +317,7 @@ namespace Intrepid2
         auto cellToNodes = cellToNodes_;
         auto nodes       = nodes_;
         
+        using ExecSpaceType = typename DeviceType::execution_space;
         auto policy = Kokkos::MDRangePolicy<ExecSpaceType,Kokkos::Rank<3>>({startCell,0,0},{numCellsWorkset,spaceDim,spaceDim});
         
         Kokkos::parallel_for("compute first-order simplex Jacobians", policy,
@@ -367,6 +369,7 @@ namespace Intrepid2
           int numFields = basisForNodes->getCardinality();
           auto basisGradientsView = getMatchingViewWithLabel(dataView, "CellGeometryProvider: temporary basisGradients", numFields, numPoints, spaceDim);
           
+          using ExecSpaceType = typename DeviceType::execution_space;
           auto policy = Kokkos::MDRangePolicy<ExecSpaceType,Kokkos::Rank<3>>({0,0,0},{numFields,numPoints,spaceDim});
           
           Kokkos::parallel_for("copy basis gradients", policy,
@@ -387,8 +390,8 @@ namespace Intrepid2
   }
 
   // Uniform grid constructor, with optional subdivision into simplices
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
-  CellGeometry<PointScalar,spaceDim,ExecSpaceType>::CellGeometry(const Kokkos::Array<PointScalar,spaceDim> &origin,
+  template<class PointScalar, int spaceDim, typename DeviceType>
+  CellGeometry<PointScalar,spaceDim,DeviceType>::CellGeometry(const Kokkos::Array<PointScalar,spaceDim> &origin,
                                                                  const Kokkos::Array<PointScalar,spaceDim> &domainExtents,
                                                                  const Kokkos::Array<int,spaceDim> &gridCellCounts,
                                                                  SubdivisionStrategy subdivisionStrategy,
@@ -450,7 +453,7 @@ namespace Intrepid2
       }
     }
     
-    using BasisFamily = DerivedNodalBasisFamily<ExecSpaceType,PointScalar,PointScalar>;
+    using BasisFamily = DerivedNodalBasisFamily<DeviceType,PointScalar,PointScalar>;
     const int linearPolyOrder = 1;
     BasisPtr basisForNodes = getBasis<BasisFamily>(cellTopo, FUNCTION_SPACE_HGRAD, linearPolyOrder);
     
@@ -460,25 +463,25 @@ namespace Intrepid2
       // arbitrary-polynomial-order counterparts; the latter do not match the order of the shards::CellTopology nodes.
       if (cellTopo.getKey() == shards::Quadrilateral<>::key)
       {
-        basisForNodes = Teuchos::rcp( new Basis_HGRAD_QUAD_C1_FEM<ExecSpaceType,PointScalar,PointScalar>() );
+        basisForNodes = Teuchos::rcp( new Basis_HGRAD_QUAD_C1_FEM<DeviceType,PointScalar,PointScalar>() );
       }
       else if (cellTopo.getKey() == shards::Hexahedron<>::key)
       {
-        basisForNodes = Teuchos::rcp( new Basis_HGRAD_HEX_C1_FEM<ExecSpaceType,PointScalar,PointScalar>() );
+        basisForNodes = Teuchos::rcp( new Basis_HGRAD_HEX_C1_FEM<DeviceType,PointScalar,PointScalar>() );
       }
     }
     
-    using HostMemberLookup = ::Intrepid2::Impl::CellGeometryHostMembers<PointScalar, spaceDim, ExecSpaceType>;
+    using HostMemberLookup = ::Intrepid2::Impl::CellGeometryHostMembers<PointScalar, spaceDim, DeviceType>;
     HostMemberLookup::constructorCalled(this, cellTopo, basisForNodes);
   }
     
   // Node-based constructor for straight-edged cell geometry.
   // If claimAffine is true, we assume (without checking) that the mapping from reference space is affine.
   // (If claimAffine is false, we check whether the topology is simplicial; if so, we conclude that the mapping must be affine.)
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
-  CellGeometry<PointScalar,spaceDim,ExecSpaceType>::CellGeometry(const shards::CellTopology &cellTopo,
-                                                                 ScalarView<int,ExecSpaceType> cellToNodes,
-                                                                 ScalarView<PointScalar,ExecSpaceType> nodes,
+  template<class PointScalar, int spaceDim, typename DeviceType>
+  CellGeometry<PointScalar,spaceDim,DeviceType>::CellGeometry(const shards::CellTopology &cellTopo,
+                                                                 ScalarView<int,DeviceType> cellToNodes,
+                                                                 ScalarView<PointScalar,DeviceType> nodes,
                                                                  const bool claimAffine,
                                                                  const HypercubeNodeOrdering nodeOrdering)
   :
@@ -502,7 +505,7 @@ namespace Intrepid2
       affine_ = true;
     }
     
-    using BasisFamily = DerivedNodalBasisFamily<ExecSpaceType,PointScalar,PointScalar>;
+    using BasisFamily = DerivedNodalBasisFamily<DeviceType,PointScalar,PointScalar>;
     const int linearPolyOrder = 1;
     BasisPtr basisForNodes = getBasis<BasisFamily>(cellTopo, FUNCTION_SPACE_HGRAD, linearPolyOrder);
     
@@ -512,22 +515,22 @@ namespace Intrepid2
       // arbitrary-polynomial-order counterparts; the latter do not match the order of the shards::CellTopology nodes.
       if (cellTopo.getKey() == shards::Quadrilateral<>::key)
       {
-        basisForNodes = Teuchos::rcp( new Basis_HGRAD_QUAD_C1_FEM<ExecSpaceType,PointScalar,PointScalar>() );
+        basisForNodes = Teuchos::rcp( new Basis_HGRAD_QUAD_C1_FEM<DeviceType,PointScalar,PointScalar>() );
       }
       else if (cellTopo.getKey() == shards::Hexahedron<>::key)
       {
-        basisForNodes = Teuchos::rcp( new Basis_HGRAD_HEX_C1_FEM<ExecSpaceType,PointScalar,PointScalar>() );
+        basisForNodes = Teuchos::rcp( new Basis_HGRAD_HEX_C1_FEM<DeviceType,PointScalar,PointScalar>() );
       }
     }
     
-    using HostMemberLookup = ::Intrepid2::Impl::CellGeometryHostMembers<PointScalar, spaceDim, ExecSpaceType>;
+    using HostMemberLookup = ::Intrepid2::Impl::CellGeometryHostMembers<PointScalar, spaceDim, DeviceType>;
     HostMemberLookup::constructorCalled(this, cellTopo, basisForNodes);
   }
 
   // Constructor for higher-order geometry
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
-  CellGeometry<PointScalar,spaceDim,ExecSpaceType>::CellGeometry(Teuchos::RCP<Intrepid2::Basis<ExecSpaceType,PointScalar,PointScalar> > basisForNodes,
-                                                                 ScalarView<PointScalar,ExecSpaceType> cellNodes)
+  template<class PointScalar, int spaceDim, typename DeviceType>
+  CellGeometry<PointScalar,spaceDim,DeviceType>::CellGeometry(Teuchos::RCP<Intrepid2::Basis<DeviceType,PointScalar,PointScalar> > basisForNodes,
+                                                                 ScalarView<PointScalar,DeviceType> cellNodes)
   :
   nodeOrdering_(HYPERCUBE_NODE_ORDER_TENSOR),
   cellGeometryType_(HIGHER_ORDER),
@@ -550,21 +553,21 @@ namespace Intrepid2
     {
       affine_ = false;
     }
-    using HostMemberLookup = ::Intrepid2::Impl::CellGeometryHostMembers<PointScalar, spaceDim, ExecSpaceType>;
+    using HostMemberLookup = ::Intrepid2::Impl::CellGeometryHostMembers<PointScalar, spaceDim, DeviceType>;
     HostMemberLookup::constructorCalled(this, cellTopo, basisForNodes);
   }
     
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
+  template<class PointScalar, int spaceDim, typename DeviceType>
   KOKKOS_INLINE_FUNCTION
-  bool CellGeometry<PointScalar,spaceDim,ExecSpaceType>::affine() const
+  bool CellGeometry<PointScalar,spaceDim,DeviceType>::affine() const
   {
     return affine_;
   }
     
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
-  TensorData<PointScalar,ExecSpaceType>
-  CellGeometry<PointScalar,spaceDim,ExecSpaceType>::allocateCellMeasure( const Data<PointScalar,ExecSpaceType> & jacobianDet,
-                                                                        const TensorData<PointScalar,ExecSpaceType> & cubatureWeights ) const
+  template<class PointScalar, int spaceDim, typename DeviceType>
+  TensorData<PointScalar,DeviceType>
+  CellGeometry<PointScalar,spaceDim,DeviceType>::allocateCellMeasure( const Data<PointScalar,DeviceType> & jacobianDet,
+                                                                        const TensorData<PointScalar,DeviceType> & cubatureWeights ) const
   {
     // Output possibilities for a cubatureWeights with N components:
     // 1. For AFFINE elements (jacobianDet cell-wise constant), returns a container with N+1 tensorial components; the first component corresponds to cells
@@ -573,7 +576,7 @@ namespace Intrepid2
     INTREPID2_TEST_FOR_EXCEPTION(cubatureWeights.rank() != 1, std::invalid_argument, "cubatureWeights container must have shape (P)");
     
     const int numTensorComponents = affine_ ? cubatureWeights.numTensorComponents() + 1 : 1;
-    std::vector< Data<PointScalar,ExecSpaceType> > tensorComponents(numTensorComponents);
+    std::vector< Data<PointScalar,DeviceType> > tensorComponents(numTensorComponents);
     
     if (affine_)
     {
@@ -582,8 +585,8 @@ namespace Intrepid2
       const int cellDataDim = jacobianDet.getDataExtent(0);
       Kokkos::Array<int,7> cellExtents{cellExtent,1,1,1,1,1,1};
       
-      ScalarView<PointScalar,ExecSpaceType> detDataView ("cell relative volumes", cellDataDim);
-      tensorComponents[0] = Data<PointScalar,ExecSpaceType>(detDataView,1,cellExtents,cellVariationTypes);
+      ScalarView<PointScalar,DeviceType> detDataView ("cell relative volumes", cellDataDim);
+      tensorComponents[0] = Data<PointScalar,DeviceType>(detDataView,1,cellExtents,cellVariationTypes);
       
       for (int cubTensorComponent=0; cubTensorComponent<numTensorComponents-1; cubTensorComponent++)
       {
@@ -591,9 +594,9 @@ namespace Intrepid2
         const auto cubatureExtents        = cubatureComponent.getExtents();
         const auto cubatureVariationTypes = cubatureComponent.getVariationTypes();
         const int numPoints               = cubatureComponent.getDataExtent(0);
-        ScalarView<PointScalar,ExecSpaceType> cubatureWeightView ("cubature component weights", numPoints);
+        ScalarView<PointScalar,DeviceType> cubatureWeightView ("cubature component weights", numPoints);
         const int pointComponentRank = 1;
-        tensorComponents[cubTensorComponent+1] = Data<PointScalar,ExecSpaceType>(cubatureWeightView,pointComponentRank,cubatureExtents,cubatureVariationTypes);
+        tensorComponents[cubTensorComponent+1] = Data<PointScalar,DeviceType>(cubatureWeightView,pointComponentRank,cubatureExtents,cubatureVariationTypes);
       }
     }
     else
@@ -605,26 +608,26 @@ namespace Intrepid2
       const int numPoints = cubatureWeights.extent_int(0);
       Kokkos::Array<int,7> extents{cellExtent,numPoints,1,1,1,1,1};
       
-      ScalarView<PointScalar,ExecSpaceType> cubatureWeightView;
+      ScalarView<PointScalar,DeviceType> cubatureWeightView;
       if (variationTypes[0] != CONSTANT)
       {
-        cubatureWeightView = ScalarView<PointScalar,ExecSpaceType>("cell measure", cellDataDim, numPoints);
+        cubatureWeightView = ScalarView<PointScalar,DeviceType>("cell measure", cellDataDim, numPoints);
       }
       else
       {
-        cubatureWeightView = ScalarView<PointScalar,ExecSpaceType>("cell measure", numPoints);
+        cubatureWeightView = ScalarView<PointScalar,DeviceType>("cell measure", numPoints);
       }
       const int cellMeasureRank = 2;
-      tensorComponents[0] = Data<PointScalar,ExecSpaceType>(cubatureWeightView,cellMeasureRank,extents,variationTypes);
+      tensorComponents[0] = Data<PointScalar,DeviceType>(cubatureWeightView,cellMeasureRank,extents,variationTypes);
     }
     const bool separateFirstComponent = (numTensorComponents > 1);
-    return TensorData<PointScalar,ExecSpaceType>(tensorComponents, separateFirstComponent);
+    return TensorData<PointScalar,DeviceType>(tensorComponents, separateFirstComponent);
   }
     
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
-  void CellGeometry<PointScalar,spaceDim,ExecSpaceType>::computeCellMeasure( TensorData<PointScalar,ExecSpaceType> &cellMeasure,
-                                                                            const Data<PointScalar,ExecSpaceType> & jacobianDet,
-                                                                            const TensorData<PointScalar,ExecSpaceType> & cubatureWeights ) const
+  template<class PointScalar, int spaceDim, typename DeviceType>
+  void CellGeometry<PointScalar,spaceDim,DeviceType>::computeCellMeasure( TensorData<PointScalar,DeviceType> &cellMeasure,
+                                                                            const Data<PointScalar,DeviceType> & jacobianDet,
+                                                                            const TensorData<PointScalar,DeviceType> & cubatureWeights ) const
   {
     // Output possibilities for a cubatureWeights with N components:
     // 1. For AFFINE elements (jacobianDet constant on each cell), returns a container with N+1 tensorial components; the first component corresponds to cells
@@ -652,6 +655,7 @@ namespace Intrepid2
       const bool detCellVaries  = detVaries[0] != CONSTANT;
       const bool detPointVaries = detVaries[1] != CONSTANT;
       
+      using ExecSpaceType = typename DeviceType::execution_space;
       if (detCellVaries && detPointVaries)
       {
         auto cellMeasureData = cellMeasure.getTensorComponent(0).getUnderlyingView2();
@@ -686,24 +690,24 @@ namespace Intrepid2
     }
   }
     
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
-  typename CellGeometry<PointScalar,spaceDim,ExecSpaceType>::BasisPtr
-  CellGeometry<PointScalar,spaceDim,ExecSpaceType>::basisForNodes() const
+  template<class PointScalar, int spaceDim, typename DeviceType>
+  typename CellGeometry<PointScalar,spaceDim,DeviceType>::BasisPtr
+  CellGeometry<PointScalar,spaceDim,DeviceType>::basisForNodes() const
   {
-    using HostMemberLookup = ::Intrepid2::Impl::CellGeometryHostMembers<PointScalar, spaceDim, ExecSpaceType>;
+    using HostMemberLookup = ::Intrepid2::Impl::CellGeometryHostMembers<PointScalar, spaceDim, DeviceType>;
     return HostMemberLookup::getBasis(this);
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
-  const shards::CellTopology & CellGeometry<PointScalar,spaceDim,ExecSpaceType>::cellTopology() const
+  template<class PointScalar, int spaceDim, typename DeviceType>
+  const shards::CellTopology & CellGeometry<PointScalar,spaceDim,DeviceType>::cellTopology() const
   {
-    using HostMemberLookup = ::Intrepid2::Impl::CellGeometryHostMembers<PointScalar, spaceDim, ExecSpaceType>;
+    using HostMemberLookup = ::Intrepid2::Impl::CellGeometryHostMembers<PointScalar, spaceDim, DeviceType>;
     return HostMemberLookup::getCellTopology(this);
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
+  template<class PointScalar, int spaceDim, typename DeviceType>
   KOKKOS_INLINE_FUNCTION
-  DataVariationType CellGeometry<PointScalar,spaceDim,ExecSpaceType>::cellVariationType() const
+  DataVariationType CellGeometry<PointScalar,spaceDim,DeviceType>::cellVariationType() const
   {
     if (cellGeometryType_ == UNIFORM_GRID)
     {
@@ -720,9 +724,9 @@ namespace Intrepid2
     else return GENERAL;
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
+  template<class PointScalar, int spaceDim, typename DeviceType>
   KOKKOS_INLINE_FUNCTION
-  int CellGeometry<PointScalar,spaceDim,ExecSpaceType>::hypercubeComponentNodeNumber(int hypercubeNodeNumber, int d) const
+  int CellGeometry<PointScalar,spaceDim,DeviceType>::hypercubeComponentNodeNumber(int hypercubeNodeNumber, int d) const
   {
     if (nodeOrdering_ == HYPERCUBE_NODE_ORDER_CLASSIC_SHARDS)
     {
@@ -751,17 +755,17 @@ namespace Intrepid2
       return 0;
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
-  void CellGeometry<PointScalar,spaceDim,ExecSpaceType>::initializeOrientations()
+  template<class PointScalar, int spaceDim, typename DeviceType>
+  void CellGeometry<PointScalar,spaceDim,DeviceType>::initializeOrientations()
   {
-    using HostExecSpace = typename Kokkos::Impl::is_space<ExecSpaceType>::host_mirror_space::execution_space ;
+    using HostExecSpace = typename Kokkos::Impl::is_space<DeviceType>::host_mirror_space::execution_space ;
     
     const bool isGridType = (cellGeometryType_ == TENSOR_GRID) || (cellGeometryType_ == UNIFORM_GRID);
     const int numOrientations = isGridType ? numCellsPerGridCell(subdivisionStrategy_) : numCells();
     
     const int nodesPerCell = numNodesPerCell();
     
-    ScalarView<Orientation, ExecSpaceType> orientationsView("orientations", numOrientations);
+    ScalarView<Orientation, DeviceType> orientationsView("orientations", numOrientations);
     auto orientationsHost = Kokkos::create_mirror_view(typename HostExecSpace::memory_space(), orientationsView);
     
     ScalarView<PointScalar, HostExecSpace> cellNodesHost("cellNodesHost",numOrientations,nodesPerCell); // (C,N) -- where C = numOrientations
@@ -796,12 +800,12 @@ namespace Intrepid2
     const int orientationsRank = 1; // shape (C)
     const Kokkos::Array<int,7>               orientationExtents {static_cast<int>(numCells_),1,1,1,1,1,1};
     const Kokkos::Array<DataVariationType,7> orientationVariationTypes { cellVariationType, CONSTANT, CONSTANT, CONSTANT, CONSTANT, CONSTANT, CONSTANT};
-    orientations_ = Data<Orientation,ExecSpaceType>(orientationsView, orientationsRank, orientationExtents, orientationVariationTypes);
+    orientations_ = Data<Orientation,DeviceType>(orientationsView, orientationsRank, orientationExtents, orientationVariationTypes);
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
+  template<class PointScalar, int spaceDim, typename DeviceType>
   KOKKOS_INLINE_FUNCTION
-  size_t CellGeometry<PointScalar,spaceDim,ExecSpaceType>::extent(const int& r) const {
+  size_t CellGeometry<PointScalar,spaceDim,DeviceType>::extent(const int& r) const {
     if (r == 0)
     {
       return numCells_;
@@ -820,33 +824,33 @@ namespace Intrepid2
     }
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
+  template<class PointScalar, int spaceDim, typename DeviceType>
   template <typename iType>
   KOKKOS_INLINE_FUNCTION
   typename std::enable_if<std::is_integral<iType>::value, int>::type
-  CellGeometry<PointScalar,spaceDim,ExecSpaceType>::extent_int(const iType& r) const
+  CellGeometry<PointScalar,spaceDim,DeviceType>::extent_int(const iType& r) const
   {
     return static_cast<int>(extent(r));
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
+  template<class PointScalar, int spaceDim, typename DeviceType>
   KOKKOS_INLINE_FUNCTION
-  typename CellGeometry<PointScalar,spaceDim,ExecSpaceType>::HypercubeNodeOrdering
-  CellGeometry<PointScalar,spaceDim,ExecSpaceType>::nodeOrderingForHypercubes() const
+  typename CellGeometry<PointScalar,spaceDim,DeviceType>::HypercubeNodeOrdering
+  CellGeometry<PointScalar,spaceDim,DeviceType>::nodeOrderingForHypercubes() const
   {
     return nodeOrdering_;
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
+  template<class PointScalar, int spaceDim, typename DeviceType>
   KOKKOS_INLINE_FUNCTION
-  int CellGeometry<PointScalar,spaceDim,ExecSpaceType>::numCells() const
+  int CellGeometry<PointScalar,spaceDim,DeviceType>::numCells() const
   {
     return numCells_;
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
+  template<class PointScalar, int spaceDim, typename DeviceType>
   KOKKOS_INLINE_FUNCTION
-  int CellGeometry<PointScalar,spaceDim,ExecSpaceType>::numCellsInDimension(const int &dim) const
+  int CellGeometry<PointScalar,spaceDim,DeviceType>::numCellsInDimension(const int &dim) const
   {
     if (cellGeometryType_ == UNIFORM_GRID)
     {
@@ -862,23 +866,23 @@ namespace Intrepid2
     }
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
+  template<class PointScalar, int spaceDim, typename DeviceType>
   KOKKOS_INLINE_FUNCTION
-  int CellGeometry<PointScalar,spaceDim,ExecSpaceType>::numNodesPerCell() const
+  int CellGeometry<PointScalar,spaceDim,DeviceType>::numNodesPerCell() const
   {
     return numNodesPerCell_;
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
+  template<class PointScalar, int spaceDim, typename DeviceType>
   KOKKOS_INLINE_FUNCTION
-  Orientation CellGeometry<PointScalar,spaceDim,ExecSpaceType>::getOrientation(int &cellNumber) const
+  Orientation CellGeometry<PointScalar,spaceDim,DeviceType>::getOrientation(int &cellNumber) const
   {
     INTREPID2_TEST_FOR_EXCEPTION_DEVICE_SAFE(!orientations_.isValid(), std::invalid_argument, "orientations_ not initialized; call initializeOrientations() first");
     return orientations_(cellNumber);
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
-  Data<Orientation,ExecSpaceType> CellGeometry<PointScalar,spaceDim,ExecSpaceType>::getOrientations()
+  template<class PointScalar, int spaceDim, typename DeviceType>
+  Data<Orientation,DeviceType> CellGeometry<PointScalar,spaceDim,DeviceType>::getOrientations()
   {
     if (!orientations_.isValid())
     {
@@ -887,9 +891,9 @@ namespace Intrepid2
     return orientations_;
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
+  template<class PointScalar, int spaceDim, typename DeviceType>
   KOKKOS_INLINE_FUNCTION
-  PointScalar CellGeometry<PointScalar,spaceDim,ExecSpaceType>::gridCellCoordinate(const int &gridCellOrdinal, const int &localNodeNumber, const int &dim) const
+  PointScalar CellGeometry<PointScalar,spaceDim,DeviceType>::gridCellCoordinate(const int &gridCellOrdinal, const int &localNodeNumber, const int &dim) const
   {
     const int componentNode = hypercubeComponentNodeNumber(localNodeNumber, dim);
     int cellCountForPriorDimensions = 1;
@@ -920,16 +924,16 @@ namespace Intrepid2
     }
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
+  template<class PointScalar, int spaceDim, typename DeviceType>
   KOKKOS_INLINE_FUNCTION
-  unsigned CellGeometry<PointScalar,spaceDim,ExecSpaceType>::rank() const
+  unsigned CellGeometry<PointScalar,spaceDim,DeviceType>::rank() const
   {
     return 3; // (C,N,D)
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
+  template<class PointScalar, int spaceDim, typename DeviceType>
   KOKKOS_INLINE_FUNCTION
-  int CellGeometry<PointScalar,spaceDim,ExecSpaceType>::gridCellNodeForSubdivisionNode(const int &gridCellOrdinal, const int &subdivisionOrdinal,
+  int CellGeometry<PointScalar,spaceDim,DeviceType>::gridCellNodeForSubdivisionNode(const int &gridCellOrdinal, const int &subdivisionOrdinal,
                                                                                        const int &subdivisionNodeNumber) const
   {
     // TODO: do something to reuse the nodeLookup containers
@@ -1074,9 +1078,9 @@ namespace Intrepid2
     }
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
+  template<class PointScalar, int spaceDim, typename DeviceType>
   KOKKOS_INLINE_FUNCTION
-  PointScalar CellGeometry<PointScalar,spaceDim,ExecSpaceType>::subdivisionCoordinate(const int &gridCellOrdinal, const int &subdivisionOrdinal,
+  PointScalar CellGeometry<PointScalar,spaceDim,DeviceType>::subdivisionCoordinate(const int &gridCellOrdinal, const int &subdivisionOrdinal,
                                                                                       const int &subdivisionNodeNumber, const int &d) const
   {
     int gridCellNode = gridCellNodeForSubdivisionNode(gridCellOrdinal, subdivisionOrdinal, subdivisionNodeNumber);
@@ -1096,10 +1100,10 @@ namespace Intrepid2
     return gridCellCoordinate(gridCellOrdinal, gridCellNode, d);
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
+  template<class PointScalar, int spaceDim, typename DeviceType>
   KOKKOS_INLINE_FUNCTION
   PointScalar
-  CellGeometry<PointScalar,spaceDim,ExecSpaceType>::operator()(const int& cell, const int& node, const int& dim) const {
+  CellGeometry<PointScalar,spaceDim,DeviceType>::operator()(const int& cell, const int& node, const int& dim) const {
     if ((cellGeometryType_ == UNIFORM_GRID) || (cellGeometryType_ == TENSOR_GRID))
     {
       const int numSubdivisions = numCellsPerGridCell(subdivisionStrategy_);
@@ -1137,9 +1141,9 @@ namespace Intrepid2
     }
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
+  template<class PointScalar, int spaceDim, typename DeviceType>
   KOKKOS_INLINE_FUNCTION
-  int CellGeometry<PointScalar,spaceDim,ExecSpaceType>::uniformJacobianModulus() const
+  int CellGeometry<PointScalar,spaceDim,DeviceType>::uniformJacobianModulus() const
   {
     if (cellGeometryType_ == UNIFORM_GRID)
     {
@@ -1151,55 +1155,55 @@ namespace Intrepid2
     }
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
-  Data<PointScalar,ExecSpaceType> CellGeometry<PointScalar,spaceDim,ExecSpaceType>::allocateJacobianData(const TensorPoints<PointScalar,ExecSpaceType> &points, const int startCell, const int endCell) const
+  template<class PointScalar, int spaceDim, typename DeviceType>
+  Data<PointScalar,DeviceType> CellGeometry<PointScalar,spaceDim,DeviceType>::allocateJacobianData(const TensorPoints<PointScalar,DeviceType> &points, const int startCell, const int endCell) const
   {
     const int pointsPerCell = points.extent_int(0);
     return allocateJacobianDataPrivate(points,pointsPerCell,startCell,endCell);
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
-  Data<PointScalar,ExecSpaceType> CellGeometry<PointScalar,spaceDim,ExecSpaceType>::allocateJacobianData(const ScalarView<PointScalar,ExecSpaceType> &points, const int startCell, const int endCell) const
+  template<class PointScalar, int spaceDim, typename DeviceType>
+  Data<PointScalar,DeviceType> CellGeometry<PointScalar,spaceDim,DeviceType>::allocateJacobianData(const ScalarView<PointScalar,DeviceType> &points, const int startCell, const int endCell) const
   {
     // if points is rank 3, it has shape (C,P,D).  If it's rank 2, (P,D).
     const int pointDimension = (points.rank() == 3) ? 1 : 0;
     const int pointsPerCell = points.extent_int(pointDimension);
-    TensorPoints<PointScalar,ExecSpaceType> tensorPoints(points);
+    TensorPoints<PointScalar,DeviceType> tensorPoints(points);
     return allocateJacobianDataPrivate(tensorPoints,pointsPerCell,startCell,endCell);
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
-  Data<PointScalar,ExecSpaceType> CellGeometry<PointScalar,spaceDim,ExecSpaceType>::allocateJacobianData(const int &numPoints, const int startCell, const int endCell) const
+  template<class PointScalar, int spaceDim, typename DeviceType>
+  Data<PointScalar,DeviceType> CellGeometry<PointScalar,spaceDim,DeviceType>::allocateJacobianData(const int &numPoints, const int startCell, const int endCell) const
   {
     INTREPID2_TEST_FOR_EXCEPTION_DEVICE_SAFE(!affine_, std::invalid_argument, "this version of allocateJacobianData() is only supported for affine CellGeometry");
     
-    TensorPoints<PointScalar,ExecSpaceType> emptyPoints;
+    TensorPoints<PointScalar,DeviceType> emptyPoints;
     return allocateJacobianDataPrivate(emptyPoints,numPoints,startCell,endCell);
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
-  void CellGeometry<PointScalar,spaceDim,ExecSpaceType>::setJacobian(Data<PointScalar,ExecSpaceType> &jacobianData, const TensorPoints<PointScalar,ExecSpaceType> &points, const int startCell, const int endCell) const
+  template<class PointScalar, int spaceDim, typename DeviceType>
+  void CellGeometry<PointScalar,spaceDim,DeviceType>::setJacobian(Data<PointScalar,DeviceType> &jacobianData, const TensorPoints<PointScalar,DeviceType> &points, const int startCell, const int endCell) const
   {
     const int pointsPerCell = points.extent_int(0);
     setJacobianDataPrivate(jacobianData,points,pointsPerCell,startCell,endCell);
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
-  void CellGeometry<PointScalar,spaceDim,ExecSpaceType>::setJacobian(Data<PointScalar,ExecSpaceType> &jacobianData, const ScalarView<PointScalar,ExecSpaceType> &points, const int startCell, const int endCell) const
+  template<class PointScalar, int spaceDim, typename DeviceType>
+  void CellGeometry<PointScalar,spaceDim,DeviceType>::setJacobian(Data<PointScalar,DeviceType> &jacobianData, const ScalarView<PointScalar,DeviceType> &points, const int startCell, const int endCell) const
   {
     // if points is rank 3, it has shape (C,P,D).  If it's rank 2, (P,D).
     const int pointDimension = (points.rank() == 3) ? 1 : 0;
     const int pointsPerCell = points.extent_int(pointDimension);
-    TensorPoints<PointScalar,ExecSpaceType> tensorPoints(points);
+    TensorPoints<PointScalar,DeviceType> tensorPoints(points);
     setJacobianDataPrivate(jacobianData,tensorPoints,pointsPerCell,startCell,endCell);
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
-  void CellGeometry<PointScalar,spaceDim,ExecSpaceType>::setJacobian(Data<PointScalar,ExecSpaceType> &jacobianData, const int &numPoints, const int startCell, const int endCell) const
+  template<class PointScalar, int spaceDim, typename DeviceType>
+  void CellGeometry<PointScalar,spaceDim,DeviceType>::setJacobian(Data<PointScalar,DeviceType> &jacobianData, const int &numPoints, const int startCell, const int endCell) const
   {
     INTREPID2_TEST_FOR_EXCEPTION_DEVICE_SAFE(!affine_, std::invalid_argument, "this version of setJacobian() is only supported for affine CellGeometry");
     
-    TensorPoints<PointScalar,ExecSpaceType> emptyPoints;
+    TensorPoints<PointScalar,DeviceType> emptyPoints;
     setJacobianDataPrivate(jacobianData,emptyPoints,numPoints,startCell,endCell);
   }
 } // namespace Intrepid2

--- a/packages/intrepid2/src/Cell/Intrepid2_CellGeometryDef.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellGeometryDef.hpp
@@ -567,7 +567,7 @@ namespace Intrepid2
   template<class PointScalar, int spaceDim, typename DeviceType>
   TensorData<PointScalar,DeviceType>
   CellGeometry<PointScalar,spaceDim,DeviceType>::allocateCellMeasure( const Data<PointScalar,DeviceType> & jacobianDet,
-                                                                        const TensorData<PointScalar,DeviceType> & cubatureWeights ) const
+                                                                      const TensorData<PointScalar,DeviceType> & cubatureWeights ) const
   {
     // Output possibilities for a cubatureWeights with N components:
     // 1. For AFFINE elements (jacobianDet cell-wise constant), returns a container with N+1 tensorial components; the first component corresponds to cells
@@ -626,8 +626,8 @@ namespace Intrepid2
     
   template<class PointScalar, int spaceDim, typename DeviceType>
   void CellGeometry<PointScalar,spaceDim,DeviceType>::computeCellMeasure( TensorData<PointScalar,DeviceType> &cellMeasure,
-                                                                            const Data<PointScalar,DeviceType> & jacobianDet,
-                                                                            const TensorData<PointScalar,DeviceType> & cubatureWeights ) const
+                                                                          const Data<PointScalar,DeviceType> & jacobianDet,
+                                                                          const TensorData<PointScalar,DeviceType> & cubatureWeights ) const
   {
     // Output possibilities for a cubatureWeights with N components:
     // 1. For AFFINE elements (jacobianDet constant on each cell), returns a container with N+1 tensorial components; the first component corresponds to cells

--- a/packages/intrepid2/src/Cell/Intrepid2_CellTools.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellTools.hpp
@@ -104,6 +104,7 @@ namespace Intrepid2 {
 
   template<typename ExecSpaceType>
   class CellTools {
+    using DeviceType = typename ExecSpaceType::device_type;
   public:
 
     /** \brief  Checks if a cell topology has reference cell
@@ -165,28 +166,28 @@ namespace Intrepid2 {
      */
     template<typename outputValueType, 
              typename pointValueType>
-    static Teuchos::RCP<Basis<ExecSpaceType,outputValueType,pointValueType> >
+    static Teuchos::RCP<Basis<DeviceType,outputValueType,pointValueType> >
     createHGradBasis( const shards::CellTopology cellTopo ) {
-      Teuchos::RCP<Basis<ExecSpaceType,outputValueType,pointValueType> > r_val;
+      Teuchos::RCP<Basis<DeviceType,outputValueType,pointValueType> > r_val;
 
       switch (cellTopo.getKey()) {
-      case shards::Line<2>::key:          r_val = Teuchos::rcp(new Basis_HGRAD_LINE_C1_FEM   <ExecSpaceType,outputValueType,pointValueType>()); break;
-      case shards::Triangle<3>::key:      r_val = Teuchos::rcp(new Basis_HGRAD_TRI_C1_FEM    <ExecSpaceType,outputValueType,pointValueType>()); break;
-      case shards::Quadrilateral<4>::key: r_val = Teuchos::rcp(new Basis_HGRAD_QUAD_C1_FEM   <ExecSpaceType,outputValueType,pointValueType>()); break;
-      case shards::Tetrahedron<4>::key:   r_val = Teuchos::rcp(new Basis_HGRAD_TET_C1_FEM    <ExecSpaceType,outputValueType,pointValueType>()); break;
-      case shards::Hexahedron<8>::key:    r_val = Teuchos::rcp(new Basis_HGRAD_HEX_C1_FEM    <ExecSpaceType,outputValueType,pointValueType>()); break;
-      case shards::Wedge<6>::key:         r_val = Teuchos::rcp(new Basis_HGRAD_WEDGE_C1_FEM  <ExecSpaceType,outputValueType,pointValueType>()); break;
-      case shards::Pyramid<5>::key:       r_val = Teuchos::rcp(new Basis_HGRAD_PYR_C1_FEM    <ExecSpaceType,outputValueType,pointValueType>()); break;
+      case shards::Line<2>::key:          r_val = Teuchos::rcp(new Basis_HGRAD_LINE_C1_FEM   <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::Triangle<3>::key:      r_val = Teuchos::rcp(new Basis_HGRAD_TRI_C1_FEM    <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::Quadrilateral<4>::key: r_val = Teuchos::rcp(new Basis_HGRAD_QUAD_C1_FEM   <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::Tetrahedron<4>::key:   r_val = Teuchos::rcp(new Basis_HGRAD_TET_C1_FEM    <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::Hexahedron<8>::key:    r_val = Teuchos::rcp(new Basis_HGRAD_HEX_C1_FEM    <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::Wedge<6>::key:         r_val = Teuchos::rcp(new Basis_HGRAD_WEDGE_C1_FEM  <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::Pyramid<5>::key:       r_val = Teuchos::rcp(new Basis_HGRAD_PYR_C1_FEM    <DeviceType,outputValueType,pointValueType>()); break;
 
-      case shards::Triangle<6>::key:      r_val = Teuchos::rcp(new Basis_HGRAD_TRI_C2_FEM    <ExecSpaceType,outputValueType,pointValueType>()); break;
-      case shards::Quadrilateral<9>::key: r_val = Teuchos::rcp(new Basis_HGRAD_QUAD_C2_FEM   <ExecSpaceType,outputValueType,pointValueType>()); break;
-      case shards::Tetrahedron<10>::key:  r_val = Teuchos::rcp(new Basis_HGRAD_TET_C2_FEM    <ExecSpaceType,outputValueType,pointValueType>()); break;
-      case shards::Tetrahedron<11>::key:  r_val = Teuchos::rcp(new Basis_HGRAD_TET_COMP12_FEM<ExecSpaceType,outputValueType,pointValueType>()); break;
-        //case shards::Hexahedron<20>::key:   r_val = Teuchos::rcp(new Basis_HGRAD_HEX_I2_FEM    <ExecSpaceType,outputValueType,pointValueType>()); break;
-      case shards::Hexahedron<27>::key:   r_val = Teuchos::rcp(new Basis_HGRAD_HEX_C2_FEM    <ExecSpaceType,outputValueType,pointValueType>()); break;
-        //case shards::Wedge<15>::key:        r_val = Teuchos::rcp(new Basis_HGRAD_WEDGE_I2_FEM  <ExecSpaceType,outputValueType,pointValueType>()); break;
-      case shards::Wedge<18>::key:        r_val = Teuchos::rcp(new Basis_HGRAD_WEDGE_C2_FEM  <ExecSpaceType,outputValueType,pointValueType>()); break;
-        //case shards::Pyramid<13>::key:      r_val = Teuchos::rcp(new Basis_HGRAD_PYR_I2_FEM    <ExecSpaceType,outputValueType,pointValueType>()); break;
+      case shards::Triangle<6>::key:      r_val = Teuchos::rcp(new Basis_HGRAD_TRI_C2_FEM    <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::Quadrilateral<9>::key: r_val = Teuchos::rcp(new Basis_HGRAD_QUAD_C2_FEM   <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::Tetrahedron<10>::key:  r_val = Teuchos::rcp(new Basis_HGRAD_TET_C2_FEM    <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::Tetrahedron<11>::key:  r_val = Teuchos::rcp(new Basis_HGRAD_TET_COMP12_FEM<DeviceType,outputValueType,pointValueType>()); break;
+        //case shards::Hexahedron<20>::key:   r_val = Teuchos::rcp(new Basis_HGRAD_HEX_I2_FEM    <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::Hexahedron<27>::key:   r_val = Teuchos::rcp(new Basis_HGRAD_HEX_C2_FEM    <DeviceType,outputValueType,pointValueType>()); break;
+        //case shards::Wedge<15>::key:        r_val = Teuchos::rcp(new Basis_HGRAD_WEDGE_I2_FEM  <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::Wedge<18>::key:        r_val = Teuchos::rcp(new Basis_HGRAD_WEDGE_C2_FEM  <DeviceType,outputValueType,pointValueType>()); break;
+        //case shards::Pyramid<13>::key:      r_val = Teuchos::rcp(new Basis_HGRAD_PYR_I2_FEM    <DeviceType,outputValueType,pointValueType>()); break;
 
       case shards::Quadrilateral<8>::key: 
       case shards::Line<3>::key:
@@ -512,7 +513,7 @@ namespace Intrepid2 {
         \return Data container with shape (C,P)
     */
     template<class PointScalar>
-    static Data<PointScalar> allocateJacobianDet( const Data<PointScalar> & jacobian );
+    static Data<PointScalar,DeviceType> allocateJacobianDet( const Data<PointScalar,DeviceType> & jacobian );
 
     /** \brief  Allocates and returns a Data container suitable for storing inverses corresponding to the Jacobians in the Data container provided
 
@@ -520,7 +521,7 @@ namespace Intrepid2 {
         \return Data container with shape (C,P,D,D)
     */
     template<class PointScalar>
-    static Data<PointScalar,ExecSpaceType> allocateJacobianInv( const Data<PointScalar,ExecSpaceType> & jacobian );
+    static Data<PointScalar,DeviceType> allocateJacobianInv( const Data<PointScalar,DeviceType> & jacobian );
 
     /** \brief  Computes determinants corresponding to the Jacobians in the Data container provided
 
@@ -528,8 +529,8 @@ namespace Intrepid2 {
         \param  jacobian          [in]    - data with shape (C,P,D,D), as returned by CellGeometry::allocateJacobianData()
     */
     template<class PointScalar>
-    static void setJacobianDet( Data<PointScalar,ExecSpaceType> & jacobianDet,
-                               const Data<PointScalar,ExecSpaceType> & jacobian);
+    static void setJacobianDet( Data<PointScalar,DeviceType> & jacobianDet,
+                               const Data<PointScalar,DeviceType> & jacobian);
 
     /** \brief  Computes determinants corresponding to the Jacobians in the Data container provided
 
@@ -537,8 +538,8 @@ namespace Intrepid2 {
         \param  jacobian          [in]    - data with shape (C,P,D,D), as returned by CellGeometry::allocateJacobianData()
     */
     template<class PointScalar>
-    static void setJacobianInv( Data<PointScalar,ExecSpaceType> & jacobianInv,
-                               const Data<PointScalar,ExecSpaceType> & jacobian);
+    static void setJacobianInv(      Data<PointScalar,DeviceType> & jacobianInv,
+                               const Data<PointScalar,DeviceType> & jacobian);
     
     //============================================================================================//
     //                                                                                            //

--- a/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefJacobian.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefJacobian.hpp
@@ -121,7 +121,8 @@ namespace Intrepid2 {
 
   template<typename ExecSpaceType>
   template<class PointScalar>
-  Data<PointScalar> CellTools<ExecSpaceType>::allocateJacobianDet( const Data<PointScalar> & jacobian )
+  Data<PointScalar,typename CellTools<ExecSpaceType>::DeviceType>
+  CellTools<ExecSpaceType>::allocateJacobianDet( const Data<PointScalar,typename CellTools<ExecSpaceType>::DeviceType> & jacobian )
   {
     auto extents           = jacobian.getExtents(); // C,P,D,D, which we reduce to C,P
     auto variationTypes    = jacobian.getVariationTypes();
@@ -137,25 +138,26 @@ namespace Intrepid2 {
     {
       auto data = jacobian.getUnderlyingView4();
       auto detData = getMatchingViewWithLabel(data, "Jacobian det data", data.extent_int(0), data.extent_int(1));
-      return Data<PointScalar,ExecSpaceType>(detData,2,extents,variationTypes);
+      return Data<PointScalar,DeviceType>(detData,2,extents,variationTypes);
     }
     else if (cellVaries || pointVaries)
     {
       auto data = jacobian.getUnderlyingView3();
       auto detData = getMatchingViewWithLabel(data, "Jacobian det data", data.extent_int(0));
-      return Data<PointScalar,ExecSpaceType>(detData,2,extents,variationTypes);
+      return Data<PointScalar,DeviceType>(detData,2,extents,variationTypes);
     }
     else
     {
       auto data = jacobian.getUnderlyingView1();
       auto detData = getMatchingViewWithLabel(data, "Jacobian det data", 1);
-      return Data<PointScalar,ExecSpaceType>(detData,2,extents,variationTypes);
+      return Data<PointScalar,DeviceType>(detData,2,extents,variationTypes);
     }
   }
 
   template<typename ExecSpaceType>
   template<class PointScalar>
-  Data<PointScalar,ExecSpaceType> CellTools<ExecSpaceType>::allocateJacobianInv( const Data<PointScalar,ExecSpaceType> & jacobian )
+  Data<PointScalar,typename CellTools<ExecSpaceType>::DeviceType>
+  CellTools<ExecSpaceType>::allocateJacobianInv( const Data<PointScalar,typename CellTools<ExecSpaceType>::DeviceType> & jacobian )
   {
     auto extents        = jacobian.getExtents(); // C,P,D,D
     auto variationTypes = jacobian.getVariationTypes();
@@ -165,36 +167,37 @@ namespace Intrepid2 {
     {
       auto jacData = jacobian.getUnderlyingView4();
       auto invData = getMatchingViewWithLabel(jacData, "Jacobian inv data",jacData.extent(0),jacData.extent(1),jacData.extent(2),jacData.extent(3));
-      return Data<PointScalar,ExecSpaceType>(invData,4,extents,variationTypes);
+      return Data<PointScalar,DeviceType>(invData,4,extents,variationTypes);
     }
     else if (jacDataRank == 3)
     {
       auto jacData = jacobian.getUnderlyingView3();
       auto invData = getMatchingViewWithLabel(jacData, "Jacobian inv data",jacData.extent(0),jacData.extent(1),jacData.extent(2));
-      return Data<PointScalar,ExecSpaceType>(invData,4,extents,variationTypes);
+      return Data<PointScalar,DeviceType>(invData,4,extents,variationTypes);
     }
     else if (jacDataRank == 2)
     {
       auto jacData = jacobian.getUnderlyingView2();
       auto invData = getMatchingViewWithLabel(jacData, "Jacobian inv data",jacData.extent(0),jacData.extent(1));
-      return Data<PointScalar,ExecSpaceType>(invData,4,extents,variationTypes);
+      return Data<PointScalar,DeviceType>(invData,4,extents,variationTypes);
     }
     else if (jacDataRank == 1)
     {
       auto jacData = jacobian.getUnderlyingView1();
       auto invData = getMatchingViewWithLabel(jacData, "Jacobian inv data",jacData.extent(0));
-      return Data<PointScalar,ExecSpaceType>(invData,4,extents,variationTypes);
+      return Data<PointScalar,DeviceType>(invData,4,extents,variationTypes);
     }
     else
     {
       INTREPID2_TEST_FOR_EXCEPTION_DEVICE_SAFE(true, std::invalid_argument, "allocateJacobianInv requires jacobian to vary in *some* dimension…");
-      return Data<PointScalar,ExecSpaceType>(); // unreachable statement; this line added to avoid compiler warning on CUDA
+      return Data<PointScalar,DeviceType>(); // unreachable statement; this line added to avoid compiler warning on CUDA
     }
   }
 
   template<typename ExecSpaceType>
   template<class PointScalar>
-  void CellTools<ExecSpaceType>::setJacobianDet( Data<PointScalar,ExecSpaceType> &jacobianDet, const Data<PointScalar,ExecSpaceType> & jacobian )
+  void CellTools<ExecSpaceType>::setJacobianDet(      Data<PointScalar,typename CellTools<ExecSpaceType>::DeviceType> &jacobianDet,
+                                                const Data<PointScalar,typename CellTools<ExecSpaceType>::DeviceType> &jacobian )
   {
     auto variationTypes = jacobian.getVariationTypes();
     
@@ -461,7 +464,8 @@ namespace Intrepid2 {
 
   template<typename ExecSpaceType>
   template<class PointScalar>
-  void CellTools<ExecSpaceType>::setJacobianInv( Data<PointScalar,ExecSpaceType> &jacobianInv, const Data<PointScalar,ExecSpaceType> & jacobian )
+  void CellTools<ExecSpaceType>::setJacobianInv(      Data<PointScalar,typename CellTools<ExecSpaceType>::DeviceType> &jacobianInv,
+                                                const Data<PointScalar,typename CellTools<ExecSpaceType>::DeviceType> &jacobian )
   {
     auto variationTypes  = jacobian.getVariationTypes();
     

--- a/packages/intrepid2/src/Cell/Intrepid2_ProjectedGeometry.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_ProjectedGeometry.hpp
@@ -66,6 +66,7 @@ namespace Intrepid2
   template<int spaceDim, typename PointScalar, typename DeviceType>
   class ProjectedGeometry
   {
+    static_assert(Kokkos::is_device<DeviceType>::value, "Third template argument to ProjectedGeometry must be a Kokkos::Device");
   public:
     using ViewType      = ScalarView<      PointScalar, DeviceType>;
     using ConstViewType = ScalarView<const PointScalar, DeviceType>;

--- a/packages/intrepid2/src/Cell/Intrepid2_ProjectedGeometry.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_ProjectedGeometry.hpp
@@ -63,13 +63,13 @@ namespace Intrepid2
 /** \class Intrepid2::ProjectedGeometry
     \brief Allows generation of geometry degrees of freedom based on a provided map from straight-edged mesh domain to curvilinear mesh domain.
 */
-  template<int spaceDim, typename PointScalar, typename ExecSpaceType>
+  template<int spaceDim, typename PointScalar, typename DeviceType>
   class ProjectedGeometry
   {
   public:
-    using ViewType      = ScalarView<      PointScalar, ExecSpaceType>;
-    using ConstViewType = ScalarView<const PointScalar, ExecSpaceType>;
-    using BasisPtr      = Teuchos::RCP< Basis<ExecSpaceType,PointScalar,PointScalar> >;
+    using ViewType      = ScalarView<      PointScalar, DeviceType>;
+    using ConstViewType = ScalarView<const PointScalar, DeviceType>;
+    using BasisPtr      = Teuchos::RCP< Basis<DeviceType,PointScalar,PointScalar> >;
     
     /** \brief Generate geometry degrees of freedom based on a provided map from straight-edged mesh domain to curvilinear mesh domain.
        \param [out] projectedBasisNodes - the projected geometry degrees of freedom
@@ -81,7 +81,7 @@ namespace Intrepid2
      \see Intrepid2_ProjectedGeometryExamples.hpp for sample implementations of exactGeometry and exactGeometryGradient.
     */
     template<class ExactGeometry, class ExactGeometryGradient>
-    static void projectOntoHGRADBasis(ViewType projectedBasisNodes, BasisPtr targetHGradBasis, CellGeometry<PointScalar,spaceDim,ExecSpaceType> flatCellGeometry,
+    static void projectOntoHGRADBasis(ViewType projectedBasisNodes, BasisPtr targetHGradBasis, CellGeometry<PointScalar,spaceDim,DeviceType> flatCellGeometry,
                                       const ExactGeometry &exactGeometry, const ExactGeometryGradient &exactGeometryGradient)
     {
       const ordinal_type numCells = flatCellGeometry.extent_int(0); // (C,N,D)
@@ -92,6 +92,7 @@ namespace Intrepid2
       INTREPID2_TEST_FOR_EXCEPTION(projectedBasisNodes.extent_int(1) != targetHGradBasis->getCardinality(), std::invalid_argument, "projectedBasisNodes must have shape (C,F,D)");
       INTREPID2_TEST_FOR_EXCEPTION(projectedBasisNodes.extent_int(2) != spaceDim, std::invalid_argument, "projectedBasisNodes must have shape (C,F,D)");
       
+      using ExecSpaceType = typename DeviceType::execution_space;
       using ProjectionTools  = Experimental::ProjectionTools<ExecSpaceType>;
       using ProjectionStruct = Experimental::ProjectionStruct<ExecSpaceType,PointScalar>;
       
@@ -166,8 +167,8 @@ namespace Intrepid2
         });
         
         // apply Jacobian
-        Data<PointScalar,ExecSpaceType> gradientData(evaluationGradients);
-        auto transformedGradientData = Data<PointScalar,ExecSpaceType>::allocateMatVecResult(gradPointsJacobians,gradientData);
+        Data<PointScalar,DeviceType> gradientData(evaluationGradients);
+        auto transformedGradientData = Data<PointScalar,DeviceType>::allocateMatVecResult(gradPointsJacobians,gradientData);
         
         transformedGradientData.storeMatVec(gradPointsJacobians,gradientData);
         

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_Basis.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_Basis.hpp
@@ -111,14 +111,18 @@ using BasisPtr = Teuchos::RCP<Basis<DeviceType,OutputType,PointType> >;
       \todo  restore test for inclusion of reference points in their resective reference cells in
              getValues_HGRAD_Args, getValues_CURL_Args, getValues_DIV_Args
   */
-  template<typename DeviceType,
+  template<typename Device,
            typename outputValueType,
            typename pointValueType>
   class Basis {
   public:
+    /**  \brief (Kokkos) Device type for basis.
+     */
+    using DeviceType = Device;
+    
     /**  \brief (Kokkos) Execution space for basis.
      */
-    using ExecutionSpace  = typename DeviceType::execution_space;
+    using ExecutionSpace = typename DeviceType::execution_space;
     
     /**  \brief Output value type for basis; default is double.
      */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasisFamily.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasisFamily.hpp
@@ -82,11 +82,12 @@ namespace Intrepid2
   class DerivedBasisFamily
   {
   public:
+    using DeviceType      = typename LineBasisHGRAD::DeviceType;
     using ExecutionSpace  = typename LineBasisHGRAD::ExecutionSpace;
     using OutputValueType = typename LineBasisHGRAD::OutputValueType;
     using PointValueType  = typename LineBasisHGRAD::PointValueType;
     
-    using Basis    = ::Intrepid2::Basis<ExecutionSpace,OutputValueType,PointValueType>;
+    using Basis    = ::Intrepid2::Basis<DeviceType,OutputValueType,PointValueType>;
     using BasisPtr = Teuchos::RCP<Basis>;
     
     // line bases

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HCURL_HEX.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HCURL_HEX.hpp
@@ -540,11 +540,11 @@ namespace Intrepid2
   
   template<class HGRAD_LINE, class HVOL_LINE>
   class Basis_Derived_HCURL_Family1_Family2_HEX
-  : public Basis_DirectSumBasis <typename HGRAD_LINE::ExecutionSpace, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>
+  : public Basis_DirectSumBasis <typename HGRAD_LINE::DeviceType, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>
   {
     using Family1 = Basis_Derived_HCURL_Family1_HEX<HGRAD_LINE, HVOL_LINE>;
     using Family2 = Basis_Derived_HCURL_Family2_HEX<HGRAD_LINE, HVOL_LINE>;
-    using DirectSumBasis = Basis_DirectSumBasis  <typename HGRAD_LINE::ExecutionSpace, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>;
+    using DirectSumBasis = Basis_DirectSumBasis  <typename HGRAD_LINE::DeviceType, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>;
   public:
     /** \brief  Constructor.
         \param [in] polyOrder_x - the polynomial order in the x dimension.
@@ -560,11 +560,11 @@ namespace Intrepid2
   
   template<class HGRAD_LINE, class HVOL_LINE>
   class Basis_Derived_HCURL_HEX
-  : public Basis_DirectSumBasis <typename HGRAD_LINE::ExecutionSpace, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>
+  : public Basis_DirectSumBasis <typename HGRAD_LINE::DeviceType, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>
   {
     using Family12 = Basis_Derived_HCURL_Family1_Family2_HEX<HGRAD_LINE, HVOL_LINE>;
     using Family3  = Basis_Derived_HCURL_Family3_HEX        <HGRAD_LINE, HVOL_LINE>;
-    using DirectSumBasis = Basis_DirectSumBasis <typename HGRAD_LINE::ExecutionSpace, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>;
+    using DirectSumBasis = Basis_DirectSumBasis <typename HGRAD_LINE::DeviceType, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>;
 
     std::string name_;
     ordinal_type order_x_;
@@ -573,7 +573,7 @@ namespace Intrepid2
     EPointType pointType_;
 
   public:
-
+    using DeviceType      = typename HGRAD_LINE::DeviceType;
     using ExecutionSpace  = typename HGRAD_LINE::ExecutionSpace;
     using OutputValueType = typename HGRAD_LINE::OutputValueType;
     using PointValueType  = typename HGRAD_LINE::PointValueType;
@@ -631,7 +631,7 @@ namespace Intrepid2
         \param [in] subCellOrd - position of the subCell among of the subCells having the same dimension
         \return pointer to the subCell basis of dimension subCellDim and position subCellOrd
      */
-    BasisPtr<ExecutionSpace, OutputValueType, PointValueType>
+    BasisPtr<DeviceType, OutputValueType, PointValueType>
       getSubCellRefBasis(const ordinal_type subCellDim, const ordinal_type subCellOrd) const override{
 
       using LineBasis = HVOL_LINE;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HCURL_QUAD.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HCURL_QUAD.hpp
@@ -66,9 +66,10 @@ namespace Intrepid2
 {
   template<class HGRAD_LINE, class HVOL_LINE>
   class Basis_Derived_HCURL_Family1_QUAD
-  : public Basis_TensorBasis<typename HGRAD_LINE::ExecutionSpace, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>
+  : public Basis_TensorBasis<typename HGRAD_LINE::DeviceType, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>
   {
   public:
+    using DeviceType      = typename HGRAD_LINE::DeviceType;
     using ExecutionSpace  = typename HGRAD_LINE::ExecutionSpace;
     using OutputValueType = typename HGRAD_LINE::OutputValueType;
     using PointValueType  = typename HGRAD_LINE::PointValueType;
@@ -80,7 +81,7 @@ namespace Intrepid2
     using LineGradBasis = HGRAD_LINE;
     using LineHVolBasis = HVOL_LINE;
     
-    using TensorBasis = Basis_TensorBasis<ExecutionSpace, OutputValueType, PointValueType>;
+    using TensorBasis = Basis_TensorBasis<DeviceType, OutputValueType, PointValueType>;
   public:
     /** \brief  Constructor.
         \param [in] polyOrder_x - the polynomial order in the x dimension.
@@ -191,10 +192,11 @@ namespace Intrepid2
 
   template<class HGRAD_LINE, class HVOL_LINE>
   class Basis_Derived_HCURL_Family2_QUAD
-  : public Basis_TensorBasis<typename HGRAD_LINE::ExecutionSpace, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>
+  : public Basis_TensorBasis<typename HGRAD_LINE::DeviceType, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>
   {
 
   public:
+    using DeviceType      = typename HGRAD_LINE::DeviceType;
     using ExecutionSpace  = typename HGRAD_LINE::ExecutionSpace;
     using OutputValueType = typename HGRAD_LINE::OutputValueType;
     using PointValueType  = typename HGRAD_LINE::PointValueType;
@@ -206,7 +208,7 @@ namespace Intrepid2
     using LineGradBasis = HGRAD_LINE;
     using LineHVolBasis = HVOL_LINE;
     
-    using TensorBasis = Basis_TensorBasis<ExecutionSpace, OutputValueType, PointValueType>;
+    using TensorBasis = Basis_TensorBasis<DeviceType, OutputValueType, PointValueType>;
 
     /** \brief  Constructor.
         \param [in] polyOrder_x - the polynomial order in the x dimension.

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HCURL_QUAD.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HCURL_QUAD.hpp
@@ -319,11 +319,11 @@ namespace Intrepid2
   
   template<class HGRAD_LINE, class HVOL_LINE>
   class Basis_Derived_HCURL_QUAD
-  : public Basis_DirectSumBasis <typename HGRAD_LINE::ExecutionSpace, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>
+  : public Basis_DirectSumBasis <typename HGRAD_LINE::DeviceType, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>
   {
     using Family1 = Basis_Derived_HCURL_Family1_QUAD<HGRAD_LINE, HVOL_LINE>;
     using Family2 = Basis_Derived_HCURL_Family2_QUAD<HGRAD_LINE, HVOL_LINE>;
-    using DirectSumBasis = Basis_DirectSumBasis <typename HGRAD_LINE::ExecutionSpace, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>;
+    using DirectSumBasis = Basis_DirectSumBasis <typename HGRAD_LINE::DeviceType, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>;
 
   protected:
     std::string name_;
@@ -332,6 +332,7 @@ namespace Intrepid2
     EPointType pointType_;
 
   public:
+    using DeviceType      = typename HGRAD_LINE::DeviceType;
     using ExecutionSpace  = typename HGRAD_LINE::ExecutionSpace;
     using OutputValueType = typename HGRAD_LINE::OutputValueType;
     using PointValueType  = typename HGRAD_LINE::PointValueType;
@@ -390,7 +391,7 @@ namespace Intrepid2
         \param [in] subCellOrd - position of the subCell among of the subCells having the same dimension
         \return pointer to the subCell basis of dimension subCellDim and position subCellOrd
      */
-    BasisPtr<ExecutionSpace, OutputValueType, PointValueType>
+    BasisPtr<DeviceType, OutputValueType, PointValueType>
       getSubCellRefBasis(const ordinal_type subCellDim, const ordinal_type subCellOrd) const override{
       if(subCellDim == 1) {
         switch(subCellOrd) {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HDIV_HEX.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HDIV_HEX.hpp
@@ -483,11 +483,11 @@ namespace Intrepid2
   // which is to say that we go 3,1,2.
   template<class HGRAD_LINE, class HVOL_LINE>
   class Basis_Derived_HDIV_Family3_Family1_HEX
-  : public Basis_DirectSumBasis <typename HGRAD_LINE::ExecutionSpace, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>
+  : public Basis_DirectSumBasis <typename HGRAD_LINE::DeviceType, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>
   {
     using Family3 = Basis_Derived_HDIV_Family3_HEX<HGRAD_LINE, HVOL_LINE>;
     using Family1 = Basis_Derived_HDIV_Family1_HEX<HGRAD_LINE, HVOL_LINE>;
-    using DirectSumBasis = Basis_DirectSumBasis<typename HGRAD_LINE::ExecutionSpace, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>;
+    using DirectSumBasis = Basis_DirectSumBasis<typename HGRAD_LINE::DeviceType, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>;
   public:
     /** \brief  Constructor.
         \param [in] polyOrder_x - the polynomial order in the x dimension.
@@ -505,11 +505,11 @@ namespace Intrepid2
   
   template<class HGRAD_LINE, class HVOL_LINE>
   class Basis_Derived_HDIV_HEX
-  : public Basis_DirectSumBasis <typename HGRAD_LINE::ExecutionSpace, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>
+  : public Basis_DirectSumBasis <typename HGRAD_LINE::DeviceType, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>
   {
     using Family31 = Basis_Derived_HDIV_Family3_Family1_HEX<HGRAD_LINE, HVOL_LINE>;
     using Family2  = Basis_Derived_HDIV_Family2_HEX        <HGRAD_LINE, HVOL_LINE>;
-    using DirectSumBasis = Basis_DirectSumBasis<typename HGRAD_LINE::ExecutionSpace, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>;
+    using DirectSumBasis = Basis_DirectSumBasis<typename HGRAD_LINE::DeviceType, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>;
 
     std::string name_;
     ordinal_type order_x_;
@@ -518,6 +518,7 @@ namespace Intrepid2
     EPointType pointType_;
 
   public:
+    using DeviceType      = typename HGRAD_LINE::DeviceType;
     using ExecutionSpace  = typename HGRAD_LINE::ExecutionSpace;
     using OutputValueType = typename HGRAD_LINE::OutputValueType;
     using PointValueType  = typename HGRAD_LINE::PointValueType;
@@ -575,7 +576,7 @@ namespace Intrepid2
         \param [in] subCellOrd - position of the subCell among of the subCells having the same dimension
         \return pointer to the subCell basis of dimension subCellDim and position subCellOrd
      */
-    BasisPtr<ExecutionSpace, OutputValueType, PointValueType>
+    BasisPtr<DeviceType, OutputValueType, PointValueType>
       getSubCellRefBasis(const ordinal_type subCellDim, const ordinal_type subCellOrd) const override{
 
       using QuadBasis = Basis_Derived_HVOL_QUAD<HVOL_LINE>;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HDIV_QUAD.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HDIV_QUAD.hpp
@@ -66,9 +66,10 @@ namespace Intrepid2
 {
   template<class HGRAD_LINE, class HVOL_LINE>
   class Basis_Derived_HDIV_Family1_QUAD
-  : public Basis_TensorBasis<typename HGRAD_LINE::ExecutionSpace, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>
+  : public Basis_TensorBasis<typename HGRAD_LINE::DeviceType, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>
   {
   public:
+    using DeviceType      = typename HGRAD_LINE::DeviceType;
     using ExecutionSpace  = typename HGRAD_LINE::ExecutionSpace;
     using OutputValueType = typename HGRAD_LINE::OutputValueType;
     using PointValueType  = typename HGRAD_LINE::PointValueType;
@@ -80,7 +81,7 @@ namespace Intrepid2
     using LineGradBasis = HGRAD_LINE;
     using LineHVolBasis = HVOL_LINE;
     
-    using TensorBasis = Basis_TensorBasis<ExecutionSpace, OutputValueType, PointValueType>;
+    using TensorBasis = Basis_TensorBasis<DeviceType, OutputValueType, PointValueType>;
   public:
     /** \brief  Constructor.
         \param [in] polyOrder_x - the polynomial order in the x dimension.
@@ -204,8 +205,9 @@ namespace Intrepid2
 
   template<class HGRAD_LINE, class HVOL_LINE>
   class Basis_Derived_HDIV_Family2_QUAD
-  : public Basis_TensorBasis<typename HGRAD_LINE::ExecutionSpace, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>
+  : public Basis_TensorBasis<typename HGRAD_LINE::DeviceType, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>
   {
+    using DeviceType      = typename HGRAD_LINE::DeviceType;
     using ExecutionSpace  = typename HGRAD_LINE::ExecutionSpace;
     using OutputValueType = typename HGRAD_LINE::OutputValueType;
     using PointValueType  = typename HGRAD_LINE::PointValueType;
@@ -217,7 +219,7 @@ namespace Intrepid2
     using LineGradBasis = HGRAD_LINE;
     using LineHVolBasis = HVOL_LINE;
     
-    using TensorBasis = Basis_TensorBasis<ExecutionSpace, OutputValueType, PointValueType>;
+    using TensorBasis = Basis_TensorBasis<DeviceType, OutputValueType, PointValueType>;
   public:
     /** \brief  Constructor.
         \param [in] polyOrder_x - the polynomial order in the x dimension.

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HDIV_QUAD.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HDIV_QUAD.hpp
@@ -333,13 +333,14 @@ namespace Intrepid2
   
   template<class HGRAD_LINE, class HVOL_LINE>
   class Basis_Derived_HDIV_QUAD
-  : public Basis_DirectSumBasis <typename HGRAD_LINE::ExecutionSpace, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>
+  : public Basis_DirectSumBasis <typename HGRAD_LINE::DeviceType, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>
   {
     using Family1 = Basis_Derived_HDIV_Family1_QUAD<HGRAD_LINE, HVOL_LINE>;
     using Family2 = Basis_Derived_HDIV_Family2_QUAD<HGRAD_LINE, HVOL_LINE>;
-    using DirectSumBasis = Basis_DirectSumBasis <typename HGRAD_LINE::ExecutionSpace, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>;
+    using DirectSumBasis = Basis_DirectSumBasis <typename HGRAD_LINE::DeviceType, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>;
 
   public:
+    using DeviceType      = typename HGRAD_LINE::DeviceType;
     using ExecutionSpace  = typename HGRAD_LINE::ExecutionSpace;
     using OutputValueType = typename HGRAD_LINE::OutputValueType;
     using PointValueType  = typename HGRAD_LINE::PointValueType;
@@ -403,7 +404,7 @@ namespace Intrepid2
         \param [in] subCellOrd - position of the subCell among of the subCells having the same dimension
         \return pointer to the subCell basis of dimension subCellDim and position subCellOrd
      */
-    BasisPtr<ExecutionSpace, OutputValueType, PointValueType>
+    BasisPtr<DeviceType, OutputValueType, PointValueType>
       getSubCellRefBasis(const ordinal_type subCellDim, const ordinal_type subCellOrd) const override{
       if(subCellDim == 1) {
         switch(subCellOrd) {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HGRAD_HEX.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HGRAD_HEX.hpp
@@ -156,7 +156,7 @@ namespace Intrepid2
       }
     }
 
-    using Basis<ExecutionSpace,OutputValueType,PointValueType>::getValues;
+    using Basis<DeviceType,OutputValueType,PointValueType>::getValues;
     
     /** \brief  multi-component getValues() method (required/called by TensorBasis)
         \param [out] outputValues - the view into which to place the output values
@@ -232,7 +232,7 @@ namespace Intrepid2
         \param [in] subCellOrd - position of the subCell among of the subCells having the same dimension
         \return pointer to the subCell basis of dimension subCellDim and position subCellOrd
      */
-    BasisPtr<ExecutionSpace, OutputValueType, PointValueType>
+    BasisPtr<DeviceType, OutputValueType, PointValueType>
       getSubCellRefBasis(const ordinal_type subCellDim, const ordinal_type subCellOrd) const override{
       if(subCellDim == 1) {
         switch(subCellOrd) {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HGRAD_HEX.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HGRAD_HEX.hpp
@@ -66,9 +66,10 @@ namespace Intrepid2
   // TODO: make this a subclass of TensorBasis3 instead, following what we've done for H(curl) and H(div)
   template<class HGRAD_LINE>
   class Basis_Derived_HGRAD_HEX
-  : public Basis_TensorBasis<typename HGRAD_LINE::ExecutionSpace, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>
+  : public Basis_TensorBasis<typename HGRAD_LINE::DeviceType, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>
   {
   public:
+    using DeviceType      = typename HGRAD_LINE::DeviceType;
     using ExecutionSpace  = typename HGRAD_LINE::ExecutionSpace;
     using OutputValueType = typename HGRAD_LINE::OutputValueType;
     using PointValueType  = typename HGRAD_LINE::PointValueType;
@@ -79,7 +80,7 @@ namespace Intrepid2
     
     using LineBasis = HGRAD_LINE;
     using QuadBasis = Intrepid2::Basis_Derived_HGRAD_QUAD<HGRAD_LINE>;
-    using TensorBasis = Basis_TensorBasis<ExecutionSpace, OutputValueType, PointValueType>;
+    using TensorBasis = Basis_TensorBasis<DeviceType, OutputValueType, PointValueType>;
 
     std::string name_;
     ordinal_type order_x_;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HGRAD_QUAD.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HGRAD_QUAD.hpp
@@ -140,7 +140,7 @@ namespace Intrepid2
       }
     }
     
-    using Basis<ExecutionSpace,OutputValueType,PointValueType>::getValues;
+    using Basis<DeviceType,OutputValueType,PointValueType>::getValues;
 
     /** \brief  multi-component getValues() method (required/called by TensorBasis)
         \param [out] outputValues - the view into which to place the output values
@@ -217,7 +217,7 @@ namespace Intrepid2
           \param [in] subCellOrd - position of the subCell among of the subCells having the same dimension
           \return pointer to the subCell basis of dimension subCellDim and position subCellOrd
        */
-    BasisPtr<ExecutionSpace, OutputValueType, PointValueType>
+    BasisPtr<DeviceType, OutputValueType, PointValueType>
       getSubCellRefBasis(const ordinal_type subCellDim, const ordinal_type subCellOrd) const override{
       if(subCellDim == 1) {
         switch(subCellOrd) {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HGRAD_QUAD.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HGRAD_QUAD.hpp
@@ -57,13 +57,14 @@ namespace Intrepid2
 {
   template<class HGRAD_LINE>
   class Basis_Derived_HGRAD_QUAD
-  : public Basis_TensorBasis<typename HGRAD_LINE::ExecutionSpace, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>
+  : public Basis_TensorBasis<typename HGRAD_LINE::DeviceType, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>
   {
   protected:
     std::string name_;
     ordinal_type order_x_, order_y_;
     EPointType pointType_;
   public:
+    using DeviceType      = typename HGRAD_LINE::DeviceType;
     using ExecutionSpace  = typename HGRAD_LINE::ExecutionSpace;
     using OutputValueType = typename HGRAD_LINE::OutputValueType;
     using PointValueType  = typename HGRAD_LINE::PointValueType;
@@ -73,7 +74,7 @@ namespace Intrepid2
     using ScalarViewType = typename HGRAD_LINE::ScalarViewType;
     
     using LineBasis = HGRAD_LINE;
-    using TensorBasis = Basis_TensorBasis<ExecutionSpace, OutputValueType, PointValueType>;
+    using TensorBasis = Basis_TensorBasis<DeviceType, OutputValueType, PointValueType>;
 
     /** \brief  Constructor.
         \param [in] polyOrder_x - the polynomial order in the x dimension.

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HVOL_HEX.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HVOL_HEX.hpp
@@ -69,12 +69,13 @@ namespace Intrepid2
   template<class HVOL_LINE>
   class Basis_Derived_HVOL_HEX
   :
-  public Basis_TensorBasis<typename HVOL_LINE::ExecutionSpace, typename HVOL_LINE::OutputValueType, typename HVOL_LINE::PointValueType>
+  public Basis_TensorBasis<typename HVOL_LINE::DeviceType, typename HVOL_LINE::OutputValueType, typename HVOL_LINE::PointValueType>
   // TODO: make this a subclass of TensorBasis3 instead, following what we've done for H(curl) and H(div)
   {
     std::string name_;
 
   public:
+    using DeviceType      = typename HVOL_LINE::DeviceType;
     using ExecutionSpace  = typename HVOL_LINE::ExecutionSpace;
     using OutputValueType = typename HVOL_LINE::OutputValueType;
     using PointValueType  = typename HVOL_LINE::PointValueType;
@@ -85,7 +86,7 @@ namespace Intrepid2
     
     using LineBasis = HVOL_LINE;
     using QuadBasis = Intrepid2::Basis_Derived_HVOL_QUAD<HVOL_LINE>;
-    using TensorBasis = Basis_TensorBasis<ExecutionSpace, OutputValueType, PointValueType>;
+    using TensorBasis = Basis_TensorBasis<DeviceType, OutputValueType, PointValueType>;
 
     /** \brief  Constructor.
         \param [in] polyOrder_x - the polynomial order in the x dimension.

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HVOL_QUAD.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HVOL_QUAD.hpp
@@ -71,10 +71,10 @@ namespace Intrepid2
     using LineBasis = HVOL_LINE;
     using TensorBasis = Basis_TensorBasis<typename HVOL_LINE::DeviceType, typename HVOL_LINE::OutputValueType, typename HVOL_LINE::PointValueType>;
   public:
-
-   using ExecutionSpace  = typename HVOL_LINE::ExecutionSpace;
-   using OutputValueType = typename HVOL_LINE::OutputValueType;
-   using PointValueType  = typename HVOL_LINE::PointValueType;
+    using DeviceType      = typename HVOL_LINE::DeviceType;
+    using ExecutionSpace  = typename HVOL_LINE::ExecutionSpace;
+    using OutputValueType = typename HVOL_LINE::OutputValueType;
+    using PointValueType  = typename HVOL_LINE::PointValueType;
 
     using OutputViewType = typename HVOL_LINE::OutputViewType;
     using PointViewType  = typename HVOL_LINE::PointViewType ;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HVOL_QUAD.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HVOL_QUAD.hpp
@@ -64,12 +64,12 @@ namespace Intrepid2
   template<class HVOL_LINE>
   class Basis_Derived_HVOL_QUAD
   :
-  public Basis_TensorBasis<typename HVOL_LINE::ExecutionSpace, typename HVOL_LINE::OutputValueType, typename HVOL_LINE::PointValueType>
+  public Basis_TensorBasis<typename HVOL_LINE::DeviceType, typename HVOL_LINE::OutputValueType, typename HVOL_LINE::PointValueType>
   {
   protected:
     std::string name_;
     using LineBasis = HVOL_LINE;
-    using TensorBasis = Basis_TensorBasis<typename HVOL_LINE::ExecutionSpace, typename HVOL_LINE::OutputValueType, typename HVOL_LINE::PointValueType>;
+    using TensorBasis = Basis_TensorBasis<typename HVOL_LINE::DeviceType, typename HVOL_LINE::OutputValueType, typename HVOL_LINE::PointValueType>;
   public:
 
    using ExecutionSpace  = typename HVOL_LINE::ExecutionSpace;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DirectSumBasis.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DirectSumBasis.hpp
@@ -64,15 +64,16 @@ namespace Intrepid2
    
    The two bases must agree in their BasisType (the return value of getBasisType()).
    */
-  template<typename ExecSpaceType = void,
+  template<typename Device = void,
            typename outputValueType = double,
            typename pointValueType = double>
-  class Basis_DirectSumBasis : public Basis<ExecSpaceType,outputValueType,pointValueType>
+  class Basis_DirectSumBasis : public Basis<Device,outputValueType,pointValueType>
   {
   public:
-    using BasisSuper = ::Intrepid2::Basis<ExecSpaceType,outputValueType,pointValueType>;
+    using BasisSuper = ::Intrepid2::Basis<Device,outputValueType,pointValueType>;
     using BasisPtr   = Teuchos::RCP<BasisSuper>;
     
+    using DeviceType      = typename BasisSuper::DeviceType;
     using ExecutionSpace  = typename BasisSuper::ExecutionSpace;
     using OutputValueType = typename BasisSuper::OutputValueType;
     using PointValueType  = typename BasisSuper::PointValueType;
@@ -208,10 +209,10 @@ namespace Intrepid2
         The default implementation employs a trivial tensor-product structure, for compatibility across all bases.  Subclasses that have tensor-product structure
         should override.  Note that only the basic exact-sequence operators are supported at the moment: VALUE, GRAD, DIV, CURL.
      */
-    virtual BasisValues<OutputValueType,ExecSpaceType> allocateBasisValues( TensorPoints<PointValueType,ExecSpaceType> points, const EOperator operatorType = OPERATOR_VALUE) const override
+    virtual BasisValues<OutputValueType,DeviceType> allocateBasisValues( TensorPoints<PointValueType,DeviceType> points, const EOperator operatorType = OPERATOR_VALUE) const override
     {
-      BasisValues<OutputValueType,ExecSpaceType> basisValues1 = basis1_->allocateBasisValues(points, operatorType);
-      BasisValues<OutputValueType,ExecSpaceType> basisValues2 = basis2_->allocateBasisValues(points, operatorType);
+      BasisValues<OutputValueType,DeviceType> basisValues1 = basis1_->allocateBasisValues(points, operatorType);
+      BasisValues<OutputValueType,DeviceType> basisValues2 = basis2_->allocateBasisValues(points, operatorType);
       
       const int numScalarFamilies1 = basisValues1.numTensorDataFamilies();
       if (numScalarFamilies1 > 0)
@@ -219,7 +220,7 @@ namespace Intrepid2
         // then both basis1 and basis2 should be scalar-valued; check that for basis2:
         const int numScalarFamilies2 = basisValues2.numTensorDataFamilies();
         INTREPID2_TEST_FOR_EXCEPTION(basisValues2.numTensorDataFamilies() <=0, std::invalid_argument, "When basis1 has scalar value, basis2 must also");
-        std::vector< TensorData<OutputValueType,ExecSpaceType> > scalarFamilies(numScalarFamilies1 + numScalarFamilies2);
+        std::vector< TensorData<OutputValueType,DeviceType> > scalarFamilies(numScalarFamilies1 + numScalarFamilies2);
         for (int i=0; i<numScalarFamilies1; i++)
         {
           scalarFamilies[i] = basisValues1.tensorData(i);
@@ -228,7 +229,7 @@ namespace Intrepid2
         {
           scalarFamilies[i+numScalarFamilies1] = basisValues2.tensorData(i);
         }
-        return BasisValues<OutputValueType,ExecSpaceType>(scalarFamilies);
+        return BasisValues<OutputValueType,DeviceType>(scalarFamilies);
       }
       else
       {
@@ -245,7 +246,7 @@ namespace Intrepid2
         const int numFamilies2 = vectorData2.numFamilies();
         
         const int numFamilies = numFamilies1 + numFamilies2;
-        std::vector< std::vector<TensorData<OutputValueType,ExecSpaceType> > > vectorComponents(numFamilies, std::vector<TensorData<OutputValueType,ExecSpaceType> >(numComponents));
+        std::vector< std::vector<TensorData<OutputValueType,DeviceType> > > vectorComponents(numFamilies, std::vector<TensorData<OutputValueType,DeviceType> >(numComponents));
         
         for (int i=0; i<numFamilies1; i++)
         {
@@ -261,8 +262,8 @@ namespace Intrepid2
             vectorComponents[i+numFamilies1][j] = vectorData2.getComponent(i,j);
           }
         }
-        VectorData<OutputValueType,ExecSpaceType> vectorData(vectorComponents);
-        return BasisValues<OutputValueType,ExecSpaceType>(vectorData);
+        VectorData<OutputValueType,DeviceType> vectorData(vectorComponents);
+        return BasisValues<OutputValueType,DeviceType>(vectorData);
       }
     }
     
@@ -338,8 +339,8 @@ namespace Intrepid2
     */
     virtual
     void
-    getValues(       BasisValues<OutputValueType,ExecSpaceType> outputValues,
-               const TensorPoints<PointValueType,ExecSpaceType>  inputPoints,
+    getValues(       BasisValues<OutputValueType,DeviceType> outputValues,
+               const TensorPoints<PointValueType,DeviceType>  inputPoints,
                const EOperator operatorType = OPERATOR_VALUE ) const override
     {
       const int fieldStartOrdinal1 = 0;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_HEX_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_HEX_In_FEM.hpp
@@ -175,26 +175,33 @@ namespace Intrepid2 {
               cardinality 3n (n+1)^2 and spans a INCOMPLETE polynomial space.
 
   */
-  template<typename ExecSpaceType = void,
+  template<typename Device = void,
            typename outputValueType = double,
            typename pointValueType = double>
   class Basis_HCURL_HEX_In_FEM
-    : public Basis<ExecSpaceType,outputValueType,pointValueType> {
+    : public Basis<Device,outputValueType,pointValueType> {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
-    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+    using BasisSuper = Basis<Device,outputValueType,pointValueType>;
+    
+    using OrdinalTypeArray1DHost = typename BasisSuper::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename BasisSuper::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename BasisSuper::OrdinalTypeArray3DHost;
+
+    using DeviceType      = typename BasisSuper::DeviceType;
+    using ExecutionSpace  = typename BasisSuper::ExecutionSpace;
+    using OutputValueType = typename BasisSuper::OutputValueType;
+    using PointValueType  = typename BasisSuper::PointValueType;
+
+    using OutputViewType = typename BasisSuper::OutputViewType;
+    using PointViewType  = typename BasisSuper::PointViewType;
+    using ScalarViewType = typename BasisSuper::ScalarViewType;
+    
+    using BasisSuper::getValues;
 
     /** \brief  Constructor.
      */
     Basis_HCURL_HEX_In_FEM(const ordinal_type order,
                             const EPointType   pointType = POINTTYPE_EQUISPACED);
-
-    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
-    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
-    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
-
-    using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
@@ -210,11 +217,11 @@ namespace Intrepid2 {
 #endif
       constexpr ordinal_type numPtsPerEval = 1;
       Impl::Basis_HCURL_HEX_In_FEM::
-        getValues<ExecSpaceType,numPtsPerEval>( outputValues,
-                                                inputPoints,
-                                                this->vinvLine_,
-                                                this->vinvBubble_,
-                                                operatorType );
+        getValues<ExecutionSpace,numPtsPerEval>( outputValues,
+                                                 inputPoints,
+                                                 this->vinvLine_,
+                                                 this->vinvBubble_,
+                                                 operatorType );
     }
 
     virtual
@@ -272,15 +279,15 @@ namespace Intrepid2 {
         \param [in] subCellOrd - position of the subCell among of the subCells having the same dimension
         \return pointer to the subCell basis of dimension subCellDim and position subCellOrd
      */
-    BasisPtr<ExecSpaceType,outputValueType,pointValueType>
+    BasisPtr<DeviceType,outputValueType,pointValueType>
       getSubCellRefBasis(const ordinal_type subCellDim, const ordinal_type subCellOrd) const override{
       if(subCellDim == 1) {
         return Teuchos::rcp(new
-            Basis_HGRAD_LINE_Cn_FEM<ExecSpaceType,outputValueType,pointValueType>
+            Basis_HGRAD_LINE_Cn_FEM<DeviceType,outputValueType,pointValueType>
             (this->basisDegree_-1, POINTTYPE_GAUSS));
       } else if(subCellDim == 2) {
         return Teuchos::rcp(new
-            Basis_HCURL_QUAD_In_FEM<ExecSpaceType,outputValueType,pointValueType>
+            Basis_HCURL_QUAD_In_FEM<DeviceType,outputValueType,pointValueType>
             (this->basisDegree_, pointType_));
       }
       INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
@@ -289,7 +296,7 @@ namespace Intrepid2 {
   private:
 
     /** \brief inverse of Generalized Vandermonde matrix (isotropic order) */
-    Kokkos::DynRankView<typename ScalarViewType::value_type,ExecSpaceType> vinvLine_, vinvBubble_;
+    Kokkos::DynRankView<typename ScalarViewType::value_type,DeviceType> vinvLine_, vinvBubble_;
 
     /** \brief type of lattice used for creating the DoF coordinates  */
     EPointType pointType_;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_HEX_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_HEX_In_FEMDef.hpp
@@ -349,12 +349,12 @@ namespace Intrepid2 {
       }
       }
     }
-  }
+  } // namespace Impl
 
   // -------------------------------------------------------------------------------------
 
-  template<typename SpT, typename OT, typename PT>
-  Basis_HCURL_HEX_In_FEM<SpT,OT,PT>::
+  template<typename DT, typename OT, typename PT>
+  Basis_HCURL_HEX_In_FEM<DT,OT,PT>::
   Basis_HCURL_HEX_In_FEM( const ordinal_type order,
                           const EPointType   pointType ) {
 
@@ -363,15 +363,15 @@ namespace Intrepid2 {
                                   ">>> ERROR (Basis_HCURL_HEX_In_FEM): pointType must be either equispaced or warpblend.");
 
     // this should be created in host and vinv should be deep copied into device space
-    Basis_HGRAD_LINE_Cn_FEM<SpT,OT,PT> lineBasis( order, pointType );
-    Basis_HGRAD_LINE_Cn_FEM<SpT,OT,PT> bubbleBasis( order - 1, POINTTYPE_GAUSS );
+    Basis_HGRAD_LINE_Cn_FEM<DT,OT,PT> lineBasis( order, pointType );
+    Basis_HGRAD_LINE_Cn_FEM<DT,OT,PT> bubbleBasis( order - 1, POINTTYPE_GAUSS );
 
     const ordinal_type
       cardLine = lineBasis.getCardinality(),
       cardBubble = bubbleBasis.getCardinality();
 
-    this->vinvLine_   = Kokkos::DynRankView<typename ScalarViewType::value_type,SpT>("Hcurl::Hex::In::vinvLine", cardLine, cardLine);
-    this->vinvBubble_ = Kokkos::DynRankView<typename ScalarViewType::value_type,SpT>("Hcurl::Hex::In::vinvBubble", cardBubble, cardBubble);
+    this->vinvLine_   = Kokkos::DynRankView<typename ScalarViewType::value_type,DT>("Hcurl::Hex::In::vinvLine", cardLine, cardLine);
+    this->vinvBubble_ = Kokkos::DynRankView<typename ScalarViewType::value_type,DT>("Hcurl::Hex::In::vinvBubble", cardBubble, cardBubble);
 
     lineBasis.getVandermondeInverse(this->vinvLine_);
     bubbleBasis.getVandermondeInverse(this->vinvBubble_);
@@ -551,14 +551,14 @@ namespace Intrepid2 {
     }
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
       dofCoordsHost("dofCoordsHost", this->basisCardinality_, this->basisCellTopology_.getDimension());
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
       dofCoeffsHost("dofCoeffsHost", this->basisCardinality_, this->basisCellTopology_.getDimension());
 
-    Kokkos::DynRankView<typename ScalarViewType::value_type,SpT>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,DT>
       dofCoordsLine("dofCoordsLine", cardLine, 1),
       dofCoordsBubble("dofCoordsBubble", cardBubble, 1);
 
@@ -610,10 +610,10 @@ namespace Intrepid2 {
       }
     }
 
-    this->dofCoords_ = Kokkos::create_mirror_view(typename SpT::memory_space(), dofCoordsHost);
+    this->dofCoords_ = Kokkos::create_mirror_view(typename DT::memory_space(), dofCoordsHost);
     Kokkos::deep_copy(this->dofCoords_, dofCoordsHost);
 
-    this->dofCoeffs_ = Kokkos::create_mirror_view(typename SpT::memory_space(), dofCoeffsHost);
+    this->dofCoeffs_ = Kokkos::create_mirror_view(typename DT::memory_space(), dofCoeffsHost);
     Kokkos::deep_copy(this->dofCoeffs_, dofCoeffsHost);
   }
 }

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_QUAD_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_QUAD_In_FEM.hpp
@@ -162,26 +162,33 @@ namespace Intrepid2 {
       \brief  Implementation of the default H(curl)-compatible FEM basis on Quadrilateral cell 
   */
 
-  template<typename ExecSpaceType = void,
+  template<typename Device = void,
            typename outputValueType = double,
            typename pointValueType = double>
   class Basis_HCURL_QUAD_In_FEM
-    : public Basis<ExecSpaceType,outputValueType,pointValueType> {
+    : public Basis<Device,outputValueType,pointValueType> {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
-    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+    using BasisSuper = Basis<Device,outputValueType,pointValueType>;
+    
+    using OrdinalTypeArray1DHost = typename BasisSuper::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename BasisSuper::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename BasisSuper::OrdinalTypeArray3DHost;
+
+    using DeviceType      = typename BasisSuper::DeviceType;
+    using ExecutionSpace  = typename BasisSuper::ExecutionSpace;
+    using OutputValueType = typename BasisSuper::OutputValueType;
+    using PointValueType  = typename BasisSuper::PointValueType;
+
+    using OutputViewType = typename BasisSuper::OutputViewType;
+    using PointViewType  = typename BasisSuper::PointViewType;
+    using ScalarViewType = typename BasisSuper::ScalarViewType;
+    
+    using BasisSuper::getValues;
 
     /** \brief  Constructor.
      */
     Basis_HCURL_QUAD_In_FEM(const ordinal_type order,
                             const EPointType   pointType = POINTTYPE_EQUISPACED);
-
-    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
-    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
-    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
-
-    using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
@@ -197,11 +204,11 @@ namespace Intrepid2 {
 #endif
       constexpr ordinal_type numPtsPerEval = Parameters::MaxNumPtsPerBasisEval;
       Impl::Basis_HCURL_QUAD_In_FEM::
-        getValues<ExecSpaceType,numPtsPerEval>( outputValues,
-                                                inputPoints,
-                                                this->vinvLine_,
-                                                this->vinvBubble_,
-                                                operatorType );
+        getValues<ExecutionSpace,numPtsPerEval>( outputValues,
+                                                 inputPoints,
+                                                 this->vinvLine_,
+                                                 this->vinvBubble_,
+                                                 operatorType );
     }
 
     virtual
@@ -259,11 +266,11 @@ namespace Intrepid2 {
         \param [in] subCellOrd - position of the subCell among of the subCells having the same dimension
         \return pointer to the subCell basis of dimension subCellDim and position subCellOrd
      */
-    BasisPtr<ExecSpaceType,outputValueType,pointValueType>
+    BasisPtr<DeviceType,outputValueType,pointValueType>
     getSubCellRefBasis(const ordinal_type subCellDim, const ordinal_type subCellOrd) const override{
       if(subCellDim == 1)
         return Teuchos::rcp( new
-            Basis_HGRAD_LINE_Cn_FEM<ExecSpaceType,outputValueType,pointValueType>
+            Basis_HGRAD_LINE_Cn_FEM<DeviceType,outputValueType,pointValueType>
             ( this->basisDegree_ - 1, POINTTYPE_GAUSS ) );
 
       INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
@@ -272,7 +279,7 @@ namespace Intrepid2 {
   private:
 
     /** \brief inverse of Generalized Vandermonde matrix (isotropic order) */
-    Kokkos::DynRankView<typename ScalarViewType::value_type,ExecSpaceType> vinvLine_, vinvBubble_;
+    Kokkos::DynRankView<typename ScalarViewType::value_type,DeviceType> vinvLine_, vinvBubble_;
   };
   
 }// namespace Intrepid2

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_QUAD_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_QUAD_In_FEMDef.hpp
@@ -194,7 +194,7 @@ namespace Intrepid2 {
       typedef          Kokkos::DynRankView<outputValueValueType,outputValueProperties...>         outputValueViewType;
       typedef          Kokkos::DynRankView<inputPointValueType, inputPointProperties...>          inputPointViewType;
       typedef          Kokkos::DynRankView<vinvValueType,       vinvProperties...>                vinvViewType;
-      typedef typename ExecSpace<typename inputPointViewType::execution_space,SpT>::ExecSpaceType ExecSpaceType;
+      typedef typename ExecSpace<typename inputPointViewType::execution_space, SpT>::ExecSpaceType ExecSpaceType;
 
       // loopSize corresponds to cardinality
       const auto loopSizeTmp1 = (inputPoints.extent(0)/numPtsPerEval);
@@ -240,11 +240,11 @@ namespace Intrepid2 {
       }
       }
     }
-  }
+  } // namespace Impl
   
   // -------------------------------------------------------------------------------------
-  template<typename SpT, typename OT, typename PT>
-  Basis_HCURL_QUAD_In_FEM<SpT,OT,PT>::
+  template<typename DT, typename OT, typename PT>
+  Basis_HCURL_QUAD_In_FEM<DT,OT,PT>::
   Basis_HCURL_QUAD_In_FEM( const ordinal_type order,
                            const EPointType   pointType ) {
 
@@ -253,15 +253,15 @@ namespace Intrepid2 {
                                   ">>> ERROR (Basis_HCURL_QUAD_In_FEM): pointType must be either equispaced or warpblend.");
 
     // this should be in host
-    Basis_HGRAD_LINE_Cn_FEM<SpT,OT,PT> lineBasis( order, pointType );
-    Basis_HGRAD_LINE_Cn_FEM<SpT,OT,PT> bubbleBasis( order - 1, POINTTYPE_GAUSS );
+    Basis_HGRAD_LINE_Cn_FEM<DT,OT,PT> lineBasis( order, pointType );
+    Basis_HGRAD_LINE_Cn_FEM<DT,OT,PT> bubbleBasis( order - 1, POINTTYPE_GAUSS );
 
     const ordinal_type
       cardLine = lineBasis.getCardinality(),
       cardBubble = bubbleBasis.getCardinality();
 
-    this->vinvLine_   = Kokkos::DynRankView<typename ScalarViewType::value_type,SpT>("Hcurl::Quad::In::vinvLine", cardLine, cardLine);
-    this->vinvBubble_ = Kokkos::DynRankView<typename ScalarViewType::value_type,SpT>("Hcurl::Quad::In::vinvBubble", cardBubble, cardBubble);
+    this->vinvLine_   = Kokkos::DynRankView<typename ScalarViewType::value_type,DT>("Hcurl::Quad::In::vinvLine", cardLine, cardLine);
+    this->vinvBubble_ = Kokkos::DynRankView<typename ScalarViewType::value_type,DT>("Hcurl::Quad::In::vinvBubble", cardBubble, cardBubble);
 
     lineBasis.getVandermondeInverse(this->vinvLine_);
     bubbleBasis.getVandermondeInverse(this->vinvBubble_);
@@ -365,14 +365,14 @@ namespace Intrepid2 {
     }
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
       dofCoordsHost("dofCoordsHost", this->basisCardinality_, this->basisCellTopology_.getDimension());
 
     // dofCoeffs on host and create its mirror view to device
-    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
       dofCoeffsHost("dofCoeffsHost", this->basisCardinality_, this->basisCellTopology_.getDimension());
 
-    Kokkos::DynRankView<typename ScalarViewType::value_type,SpT>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,DT>
       dofCoordsLine("dofCoordsLine", cardLine, 1),
       dofCoordsBubble("dofCoordsBubble", cardBubble, 1);
 
@@ -406,10 +406,10 @@ namespace Intrepid2 {
       }
     }
 
-    this->dofCoords_ = Kokkos::create_mirror_view(typename SpT::memory_space(), dofCoordsHost);
+    this->dofCoords_ = Kokkos::create_mirror_view(typename DT::memory_space(), dofCoordsHost);
     Kokkos::deep_copy(this->dofCoords_, dofCoordsHost);
 
-    this->dofCoeffs_ = Kokkos::create_mirror_view(typename SpT::memory_space(), dofCoeffsHost);
+    this->dofCoeffs_ = Kokkos::create_mirror_view(typename DT::memory_space(), dofCoeffsHost);
     Kokkos::deep_copy(this->dofCoeffs_, dofCoeffsHost);
   }
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TET_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TET_In_FEM.hpp
@@ -199,29 +199,33 @@ public:
 };
 }
 
-template<typename ExecSpaceType = void,
+template<typename Device = void,
     typename outputValueType = double,
     typename pointValueType = double>
 class Basis_HCURL_TET_In_FEM
-    : public Basis<ExecSpaceType,outputValueType,pointValueType> {
-    public:
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost OrdinalTypeArray1DHost;
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost OrdinalTypeArray2DHost;
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost OrdinalTypeArray3DHost;
+    : public Basis<Device,outputValueType,pointValueType> {
+  public:
+    using BasisSuper = Basis<Device,outputValueType,pointValueType>;
+    
+    using OrdinalTypeArray1DHost = typename BasisSuper::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename BasisSuper::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename BasisSuper::OrdinalTypeArray3DHost;
 
+    using DeviceType      = typename BasisSuper::DeviceType;
+    using ExecutionSpace  = typename BasisSuper::ExecutionSpace;
+    using OutputValueType = typename BasisSuper::OutputValueType;
+    using PointValueType  = typename BasisSuper::PointValueType;
+
+    using OutputViewType = typename BasisSuper::OutputViewType;
+    using PointViewType  = typename BasisSuper::PointViewType;
+    using ScalarViewType = typename BasisSuper::ScalarViewType;
+    
+    using BasisSuper::getValues;
+    using scalarType = typename BasisSuper::scalarType;
   /** \brief  Constructor.
    */
   Basis_HCURL_TET_In_FEM(const ordinal_type order,
       const EPointType   pointType = POINTTYPE_EQUISPACED);
-
-
-  using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
-  using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
-  using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
-
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarType  scalarType;
-
-  using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
   virtual
   void
@@ -237,10 +241,10 @@ class Basis_HCURL_TET_In_FEM
 #endif
     constexpr ordinal_type numPtsPerEval = Parameters::MaxNumPtsPerBasisEval;
     Impl::Basis_HCURL_TET_In_FEM::
-    getValues<ExecSpaceType,numPtsPerEval>( outputValues,
-        inputPoints,
-        this->coeffs_,
-        operatorType);
+    getValues<ExecutionSpace,numPtsPerEval>( outputValues,
+                                             inputPoints,
+                                             this->coeffs_,
+                                             operatorType );
   }
 
   virtual
@@ -304,15 +308,15 @@ class Basis_HCURL_TET_In_FEM
       \param [in] subCellOrd - position of the subCell among of the subCells having the same dimension
       \return pointer to the subCell basis of dimension subCellDim and position subCellOrd
    */
-  BasisPtr<ExecSpaceType,outputValueType,pointValueType>
+  BasisPtr<DeviceType,outputValueType,pointValueType>
     getSubCellRefBasis(const ordinal_type subCellDim, const ordinal_type subCellOrd) const override{
     if(subCellDim == 1) {
       return Teuchos::rcp(new
-          Basis_HVOL_LINE_Cn_FEM<ExecSpaceType,outputValueType,pointValueType>
+          Basis_HVOL_LINE_Cn_FEM<DeviceType,outputValueType,pointValueType>
           (this->basisDegree_-1, pointType_));
     } else if(subCellDim == 2) {
       return Teuchos::rcp(new
-          Basis_HCURL_TRI_In_FEM<ExecSpaceType,outputValueType,pointValueType>
+          Basis_HCURL_TRI_In_FEM<DeviceType,outputValueType,pointValueType>
           (this->basisDegree_, pointType_));
     }
     INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
@@ -322,7 +326,7 @@ class Basis_HCURL_TET_In_FEM
 
   /** \brief expansion coefficients of the nodal basis in terms of the
         orthgonal one */
-  Kokkos::DynRankView<scalarType,ExecSpaceType> coeffs_;
+  Kokkos::DynRankView<scalarType,DeviceType> coeffs_;
 
   /** \brief type of lattice used for creating the DoF coordinates  */
   EPointType pointType_;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TET_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TET_In_FEMDef.hpp
@@ -244,7 +244,7 @@ Basis_HCURL_TET_In_FEM( const ordinal_type order,
 
   // now I need to integrate { (x,y) \times phi } against the big basis
   // first, get a cubature rule.
-  CubatureDirectTetDefault<Kokkos::HostSpace::execution_space,scalarType,scalarType> myCub( 2 * order );
+  CubatureDirectTetDefault<Kokkos::HostSpace::device_type,scalarType,scalarType> myCub( 2 * order );
   Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace> cubPoints("Hcurl::Tet::In::cubPoints", myCub.getNumPoints() , spaceDim );
   Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace> cubWeights("Hcurl::Tet::In::cubWeights", myCub.getNumPoints() );
   myCub.getCubature( cubPoints , cubWeights );

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_In_FEM.hpp
@@ -189,15 +189,28 @@ public:
 };
 }
 
-template<typename ExecSpaceType = void,
+template<typename Device = void,
     typename outputValueType = double,
     typename pointValueType = double>
 class Basis_HCURL_TRI_In_FEM
-    : public Basis<ExecSpaceType,outputValueType,pointValueType> {
-    public:
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost OrdinalTypeArray1DHost;
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost OrdinalTypeArray2DHost;
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost OrdinalTypeArray3DHost;
+    : public Basis<Device,outputValueType,pointValueType> {
+public:
+  using BasisSuper = Basis<Device,outputValueType,pointValueType>;
+  
+  using OrdinalTypeArray1DHost = typename BasisSuper::OrdinalTypeArray1DHost;
+  using OrdinalTypeArray2DHost = typename BasisSuper::OrdinalTypeArray2DHost;
+  using OrdinalTypeArray3DHost = typename BasisSuper::OrdinalTypeArray3DHost;
+
+  using DeviceType      = typename BasisSuper::DeviceType;
+  using ExecutionSpace  = typename BasisSuper::ExecutionSpace;
+  using OutputValueType = typename BasisSuper::OutputValueType;
+  using PointValueType  = typename BasisSuper::PointValueType;
+
+  using OutputViewType = typename BasisSuper::OutputViewType;
+  using PointViewType  = typename BasisSuper::PointViewType;
+  using ScalarViewType = typename BasisSuper::ScalarViewType;
+  
+  using BasisSuper::getValues;
 
   /** \brief  Constructor.
    */
@@ -205,13 +218,7 @@ class Basis_HCURL_TRI_In_FEM
       const EPointType   pointType = POINTTYPE_EQUISPACED);
 
 
-  using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
-  using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
-  using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
-
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarType  scalarType;
-
-  using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
+  typedef typename BasisSuper::scalarType  scalarType;
 
   virtual
   void
@@ -227,10 +234,10 @@ class Basis_HCURL_TRI_In_FEM
 #endif
     constexpr ordinal_type numPtsPerEval = Parameters::MaxNumPtsPerBasisEval;
     Impl::Basis_HCURL_TRI_In_FEM::
-    getValues<ExecSpaceType,numPtsPerEval>( outputValues,
-        inputPoints,
-        this->coeffs_,
-        operatorType);
+    getValues<ExecutionSpace,numPtsPerEval>( outputValues,
+                                             inputPoints,
+                                             this->coeffs_,
+                                             operatorType);
   }
 
   virtual
@@ -294,11 +301,11 @@ class Basis_HCURL_TRI_In_FEM
       \param [in] subCellOrd - position of the subCell among of the subCells having the same dimension
       \return pointer to the subCell basis of dimension subCellDim and position subCellOrd
    */
-  BasisPtr<ExecSpaceType,outputValueType,pointValueType>
+  BasisPtr<DeviceType,outputValueType,pointValueType>
     getSubCellRefBasis(const ordinal_type subCellDim, const ordinal_type subCellOrd) const override{
     if(subCellDim == 1) {
       return Teuchos::rcp(new
-          Basis_HVOL_LINE_Cn_FEM<ExecSpaceType,outputValueType,pointValueType>
+          Basis_HVOL_LINE_Cn_FEM<DeviceType,outputValueType,pointValueType>
           ( this->basisDegree_ - 1, pointType_) );
     }
     INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
@@ -308,7 +315,7 @@ class Basis_HCURL_TRI_In_FEM
 
   /** \brief expansion coefficients of the nodal basis in terms of the
         orthgonal one */
-  Kokkos::DynRankView<scalarType,ExecSpaceType> coeffs_;
+  Kokkos::DynRankView<scalarType,DeviceType> coeffs_;
 
   /** \brief type of lattice used for creating the DoF coordinates  */
   EPointType pointType_;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_In_FEMDef.hpp
@@ -246,7 +246,7 @@ namespace Intrepid2 {
 
     // now I need to integrate { (x,y) \times phi } against the big basis
     // first, get a cubature rule.
-    CubatureDirectTriDefault<Kokkos::HostSpace::execution_space,scalarType,scalarType> myCub( 2 * order );
+    CubatureDirectTriDefault<typename Kokkos::HostSpace::device_type,scalarType,scalarType> myCub( 2 * order );
     Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace> cubPoints("Hcurl::Tri::In::cubPoints", myCub.getNumPoints() , spaceDim );
     Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace> cubWeights("Hcurl::Tri::In::cubWeights", myCub.getNumPoints() );
     myCub.getCubature( cubPoints , cubWeights );

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_In_FEMDef.hpp
@@ -181,11 +181,11 @@ namespace Intrepid2 {
       }
       }
     }
-  }
+  } // namespace Impl
 
   // -------------------------------------------------------------------------------------
-  template<typename SpT, typename OT, typename PT>
-  Basis_HCURL_TRI_In_FEM<SpT,OT,PT>::
+  template<typename DT, typename OT, typename PT>
+  Basis_HCURL_TRI_In_FEM<DT,OT,PT>::
   Basis_HCURL_TRI_In_FEM( const ordinal_type order,
                           const EPointType   pointType ) {
 
@@ -213,13 +213,13 @@ namespace Intrepid2 {
     ordinal_type tags[maxCard][tagSize];
 
     // points are computed in the host and will be copied
-    Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
       dofCoords("Hcurl::Tri::In::dofCoords", card, spaceDim);
 
-    Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
       coeffs("Hcurl::Tri::In::coeffs", cardVecPn, card);
 
-    Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
       dofCoeffs("Hcurl::Tri::In::dofCoeffs", card, spaceDim);
 
     // first, need to project the basis for RT space onto the
@@ -227,7 +227,7 @@ namespace Intrepid2 {
     // get coefficients of PkHx
 
     const ordinal_type lwork = card*card;
-    Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
       V1("Hcurl::Tri::In::V1", cardVecPn, card);
 
     // basis for the space is
@@ -247,12 +247,12 @@ namespace Intrepid2 {
     // now I need to integrate { (x,y) \times phi } against the big basis
     // first, get a cubature rule.
     CubatureDirectTriDefault<Kokkos::HostSpace::execution_space,scalarType,scalarType> myCub( 2 * order );
-    Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace> cubPoints("Hcurl::Tri::In::cubPoints", myCub.getNumPoints() , spaceDim );
-    Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace> cubWeights("Hcurl::Tri::In::cubWeights", myCub.getNumPoints() );
+    Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace> cubPoints("Hcurl::Tri::In::cubPoints", myCub.getNumPoints() , spaceDim );
+    Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace> cubWeights("Hcurl::Tri::In::cubWeights", myCub.getNumPoints() );
     myCub.getCubature( cubPoints , cubWeights );
 
     // tabulate the scalar orthonormal basis at cubature points
-    Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace> phisAtCubPoints("Hcurl::Tri::In::phisAtCubPoints", cardPn , myCub.getNumPoints() );
+    Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace> phisAtCubPoints("Hcurl::Tri::In::phisAtCubPoints", cardPn , myCub.getNumPoints() );
     Impl::Basis_HGRAD_TRI_Cn_FEM_ORTH::getValues<Kokkos::HostSpace::execution_space,Parameters::MaxNumPtsPerBasisEval>(phisAtCubPoints, cubPoints, order, OPERATOR_VALUE);
 
     // now do the integration
@@ -272,7 +272,7 @@ namespace Intrepid2 {
     }
 
     // next, apply the RT nodes (rows) to the basis for (P_n)^2 (columns)
-    Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
       V2("Hcurl::Tri::In::V2", card ,cardVecPn);
 
     const ordinal_type numEdges = this->basisCellTopology_.getEdgeCount();
@@ -285,7 +285,7 @@ namespace Intrepid2 {
 
     // first numEdges * degree nodes are tangents at each edge
     // get the points on the line
-    Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace> linePts("Hcurl::Tri::In::linePts", numPtsPerEdge , 1 );
+    Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace> linePts("Hcurl::Tri::In::linePts", numPtsPerEdge , 1 );
 
     // construct lattice
     const ordinal_type offset = 1;
@@ -295,9 +295,9 @@ namespace Intrepid2 {
                             pointType );
 
     // holds the image of the line points
-    Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace> edgePts("Hcurl::Tri::In::edgePts", numPtsPerEdge , spaceDim );
-    Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace> phisAtEdgePoints("Hcurl::Tri::In::phisAtEdgePoints", cardPn , numPtsPerEdge );
-    Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace> edgeTan("Hcurl::Tri::In::edgeTan", spaceDim );
+    Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace> edgePts("Hcurl::Tri::In::edgePts", numPtsPerEdge , spaceDim );
+    Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace> phisAtEdgePoints("Hcurl::Tri::In::phisAtEdgePoints", cardPn , numPtsPerEdge );
+    Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace> edgeTan("Hcurl::Tri::In::edgeTan", spaceDim );
 
     // these are tangents scaled by the appropriate edge lengths.
     for (ordinal_type edge=0;edge<numEdges;edge++) {  // loop over edges
@@ -351,7 +351,7 @@ namespace Intrepid2 {
                                                                    1 );
 
     if (numPtsPerCell > 0) {
-      Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace>
+      Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
         internalPoints( "Hcurl::Tri::In::internalPoints", numPtsPerCell , spaceDim );
       PointTools::getLattice( internalPoints ,
                               this->basisCellTopology_ ,
@@ -359,7 +359,7 @@ namespace Intrepid2 {
                               1 ,
                               pointType );
 
-      Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace>
+      Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
         phisAtInternalPoints("Hcurl::Tri::In::phisAtInternalPoints", cardPn , numPtsPerCell );
       Impl::Basis_HGRAD_TRI_Cn_FEM_ORTH::getValues<Kokkos::HostSpace::execution_space,Parameters::MaxNumPtsPerBasisEval>( phisAtInternalPoints , internalPoints , order, OPERATOR_VALUE );
 
@@ -437,13 +437,13 @@ namespace Intrepid2 {
         coeffs(i,j) = s;
       }
 
-    this->coeffs_ = Kokkos::create_mirror_view(typename SpT::memory_space(), coeffs);
+    this->coeffs_ = Kokkos::create_mirror_view(typename DT::memory_space(), coeffs);
     Kokkos::deep_copy(this->coeffs_ , coeffs);
 
-    this->dofCoords_ = Kokkos::create_mirror_view(typename SpT::memory_space(), dofCoords);
+    this->dofCoords_ = Kokkos::create_mirror_view(typename DT::memory_space(), dofCoords);
     Kokkos::deep_copy(this->dofCoords_, dofCoords);
 
-    this->dofCoeffs_ = Kokkos::create_mirror_view(typename SpT::memory_space(), dofCoeffs);
+    this->dofCoeffs_ = Kokkos::create_mirror_view(typename DT::memory_space(), dofCoeffs);
     Kokkos::deep_copy(this->dofCoeffs_, dofCoeffs);
 
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_HEX_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_HEX_In_FEM.hpp
@@ -164,26 +164,33 @@ namespace Intrepid2 {
               cardinality 3(n+1)n^2 and spans a INCOMPLETE polynomial space.
 
   */
-  template<typename ExecSpaceType = void,
+  template<typename Device = void,
            typename outputValueType = double,
            typename pointValueType = double>
   class Basis_HDIV_HEX_In_FEM
-    : public Basis<ExecSpaceType,outputValueType,pointValueType> {
+    : public Basis<Device,outputValueType,pointValueType> {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
-    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+    using BasisSuper = Basis<Device,outputValueType,pointValueType>;
+    
+    using OrdinalTypeArray1DHost = typename BasisSuper::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename BasisSuper::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename BasisSuper::OrdinalTypeArray3DHost;
+
+    using DeviceType      = typename BasisSuper::DeviceType;
+    using ExecutionSpace  = typename BasisSuper::ExecutionSpace;
+    using OutputValueType = typename BasisSuper::OutputValueType;
+    using PointValueType  = typename BasisSuper::PointValueType;
+
+    using OutputViewType = typename BasisSuper::OutputViewType;
+    using PointViewType  = typename BasisSuper::PointViewType;
+    using ScalarViewType = typename BasisSuper::ScalarViewType;
+    
+    using BasisSuper::getValues;
 
     /** \brief  Constructor.
      */
     Basis_HDIV_HEX_In_FEM(const ordinal_type order,
                           const EPointType   pointType = POINTTYPE_EQUISPACED);
-
-    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
-    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
-    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
-
-    using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
@@ -199,11 +206,11 @@ namespace Intrepid2 {
 #endif
       constexpr ordinal_type numPtsPerEval = 1;
       Impl::Basis_HDIV_HEX_In_FEM::
-        getValues<ExecSpaceType,numPtsPerEval>( outputValues,
-                                                inputPoints,
-                                                this->vinvLine_,
-                                                this->vinvBubble_,
-                                                operatorType );
+        getValues<ExecutionSpace,numPtsPerEval>( outputValues,
+                                                 inputPoints,
+                                                 this->vinvLine_,
+                                                 this->vinvBubble_,
+                                                 operatorType );
     }
 
     virtual
@@ -262,12 +269,12 @@ namespace Intrepid2 {
         \param [in] subCellOrd - position of the subCell among of the subCells having the same dimension
         \return pointer to the subCell basis of dimension subCellDim and position subCellOrd
      */
-    BasisPtr<ExecSpaceType,outputValueType,pointValueType>
+    BasisPtr<DeviceType,outputValueType,pointValueType>
       getSubCellRefBasis(const ordinal_type subCellDim, const ordinal_type subCellOrd) const override{
 
       if(subCellDim == 2) {
         return Teuchos::rcp(new
-            Basis_HGRAD_QUAD_Cn_FEM<ExecSpaceType,outputValueType,pointValueType>
+            Basis_HGRAD_QUAD_Cn_FEM<DeviceType,outputValueType,pointValueType>
             (this->basisDegree_-1,POINTTYPE_GAUSS));
       }
       INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
@@ -276,7 +283,7 @@ namespace Intrepid2 {
   private:
 
     /** \brief inverse of Generalized Vandermonde matrix (isotropic order) */
-    Kokkos::DynRankView<typename ScalarViewType::value_type,ExecSpaceType> vinvLine_, vinvBubble_;
+    Kokkos::DynRankView<typename ScalarViewType::value_type,DeviceType> vinvLine_, vinvBubble_;
   };
 
 }// namespace Intrepid2

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_HEX_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_HEX_In_FEMDef.hpp
@@ -315,12 +315,12 @@ namespace Intrepid2 {
       }
       }
     }
-  }
+  } // namespace Impl
 
   // -------------------------------------------------------------------------------------
 
-  template<typename SpT, typename OT, typename PT>
-  Basis_HDIV_HEX_In_FEM<SpT,OT,PT>::
+  template<typename DT, typename OT, typename PT>
+  Basis_HDIV_HEX_In_FEM<DT,OT,PT>::
   Basis_HDIV_HEX_In_FEM( const ordinal_type order,
                          const EPointType   pointType ) {
 
@@ -329,15 +329,15 @@ namespace Intrepid2 {
                                   ">>> ERROR (Basis_HDIV_HEX_In_FEM): pointType must be either equispaced or warpblend.");
 
     // this should be created in host and vinv should be deep copied into device space
-    Basis_HGRAD_LINE_Cn_FEM<SpT,OT,PT> lineBasis( order, pointType );
-    Basis_HGRAD_LINE_Cn_FEM<SpT,OT,PT> bubbleBasis( order - 1, POINTTYPE_GAUSS );
+    Basis_HGRAD_LINE_Cn_FEM<DT,OT,PT> lineBasis( order, pointType );
+    Basis_HGRAD_LINE_Cn_FEM<DT,OT,PT> bubbleBasis( order - 1, POINTTYPE_GAUSS );
 
     const ordinal_type
       cardLine = lineBasis.getCardinality(),
       cardBubble = bubbleBasis.getCardinality();
 
-    this->vinvLine_   = Kokkos::DynRankView<typename ScalarViewType::value_type,SpT>("Hcurl::Hex::In::vinvLine", cardLine, cardLine);
-    this->vinvBubble_ = Kokkos::DynRankView<typename ScalarViewType::value_type,SpT>("Hcurl::Hex::In::vinvBubble", cardBubble, cardBubble);
+    this->vinvLine_   = Kokkos::DynRankView<typename ScalarViewType::value_type,DT>("Hcurl::Hex::In::vinvLine", cardLine, cardLine);
+    this->vinvBubble_ = Kokkos::DynRankView<typename ScalarViewType::value_type,DT>("Hcurl::Hex::In::vinvBubble", cardBubble, cardBubble);
 
     lineBasis.getVandermondeInverse(this->vinvLine_);
     bubbleBasis.getVandermondeInverse(this->vinvBubble_);
@@ -474,14 +474,14 @@ namespace Intrepid2 {
     }
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
       dofCoordsHost("dofCoordsHost", this->basisCardinality_, this->basisCellTopology_.getDimension());
 
     // dofCoeffs on host and create its mirror view to device
-    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
       dofCoeffsHost("dofCoeffsHost", this->basisCardinality_, this->basisCellTopology_.getDimension());
 
-    Kokkos::DynRankView<typename ScalarViewType::value_type,SpT>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,DT>
       dofCoordsLine("dofCoordsLine", cardLine, 1),
       dofCoordsBubble("dofCoordsBubble", cardBubble, 1);
 
@@ -533,10 +533,10 @@ namespace Intrepid2 {
       }
     }
 
-    this->dofCoords_ = Kokkos::create_mirror_view(typename SpT::memory_space(), dofCoordsHost);
+    this->dofCoords_ = Kokkos::create_mirror_view(typename DT::memory_space(), dofCoordsHost);
     Kokkos::deep_copy(this->dofCoords_, dofCoordsHost);
 
-    this->dofCoeffs_ = Kokkos::create_mirror_view(typename SpT::memory_space(), dofCoeffsHost);
+    this->dofCoeffs_ = Kokkos::create_mirror_view(typename DT::memory_space(), dofCoeffsHost);
     Kokkos::deep_copy(this->dofCoeffs_, dofCoeffsHost);
   }
 }

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_QUAD_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_QUAD_In_FEM.hpp
@@ -161,26 +161,33 @@ namespace Intrepid2 {
       \brief  Implementation of the default H(div)-compatible FEM basis on Quadrilateral cell    
   */
   
-  template<typename ExecSpaceType = void,
+  template<typename Device = void,
            typename outputValueType = double,
            typename pointValueType = double>
   class Basis_HDIV_QUAD_In_FEM
-    : public Basis<ExecSpaceType,outputValueType,pointValueType> {
+    : public Basis<Device,outputValueType,pointValueType> {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
-    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+    using BasisSuper = Basis<Device,outputValueType,pointValueType>;
+    
+    using OrdinalTypeArray1DHost = typename BasisSuper::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename BasisSuper::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename BasisSuper::OrdinalTypeArray3DHost;
+
+    using DeviceType      = typename BasisSuper::DeviceType;
+    using ExecutionSpace  = typename BasisSuper::ExecutionSpace;
+    using OutputValueType = typename BasisSuper::OutputValueType;
+    using PointValueType  = typename BasisSuper::PointValueType;
+
+    using OutputViewType = typename BasisSuper::OutputViewType;
+    using PointViewType  = typename BasisSuper::PointViewType;
+    using ScalarViewType = typename BasisSuper::ScalarViewType;
+    
+    using BasisSuper::getValues;
 
     /** \brief  Constructor.
      */
     Basis_HDIV_QUAD_In_FEM(const ordinal_type order,
                             const EPointType   pointType = POINTTYPE_EQUISPACED);
-
-    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
-    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
-    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
-
-    using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
@@ -196,11 +203,11 @@ namespace Intrepid2 {
 #endif
       constexpr ordinal_type numPtsPerEval = Parameters::MaxNumPtsPerBasisEval;
       Impl::Basis_HDIV_QUAD_In_FEM::
-        getValues<ExecSpaceType,numPtsPerEval>( outputValues,
-                                                inputPoints,
-                                                this->vinvLine_,
-                                                this->vinvBubble_,
-                                                operatorType );
+        getValues<ExecutionSpace,numPtsPerEval>( outputValues,
+                                                 inputPoints,
+                                                 this->vinvLine_,
+                                                 this->vinvBubble_,
+                                                 operatorType );
     }
     virtual
     void
@@ -257,11 +264,11 @@ namespace Intrepid2 {
         \param [in] subCellOrd - position of the subCell among of the subCells having the same dimension
         \return pointer to the subCell basis of dimension subCellDim and position subCellOrd
      */
-    BasisPtr<ExecSpaceType,outputValueType,pointValueType>
+    BasisPtr<DeviceType,outputValueType,pointValueType>
     getSubCellRefBasis(const ordinal_type subCellDim, const ordinal_type subCellOrd) const override{
       if(subCellDim == 1)
         return Teuchos::rcp( new
-            Basis_HGRAD_LINE_Cn_FEM<ExecSpaceType,outputValueType,pointValueType>
+            Basis_HGRAD_LINE_Cn_FEM<DeviceType,outputValueType,pointValueType>
             ( this->basisDegree_ - 1, POINTTYPE_GAUSS ) );
 
       INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
@@ -270,7 +277,7 @@ namespace Intrepid2 {
   private:
 
     /** \brief inverse of Generalized Vandermonde matrix (isotropic order) */
-    Kokkos::DynRankView<typename ScalarViewType::value_type,ExecSpaceType> vinvLine_, vinvBubble_;
+    Kokkos::DynRankView<typename ScalarViewType::value_type,DeviceType> vinvLine_, vinvBubble_;
   };
 
 }// namespace Intrepid2

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_QUAD_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_QUAD_In_FEMDef.hpp
@@ -242,8 +242,8 @@ namespace Intrepid2 {
   }
 
   // -------------------------------------------------------------------------------------
-  template<typename SpT, typename OT, typename PT>
-  Basis_HDIV_QUAD_In_FEM<SpT,OT,PT>::
+  template<typename DT, typename OT, typename PT>
+  Basis_HDIV_QUAD_In_FEM<DT,OT,PT>::
   Basis_HDIV_QUAD_In_FEM( const ordinal_type order,
                            const EPointType   pointType ) {
 
@@ -252,15 +252,15 @@ namespace Intrepid2 {
                                   ">>> ERROR (Basis_HDIV_QUAD_In_FEM): pointType must be either equispaced or warpblend.");
 
     // this should be in host
-    Basis_HGRAD_LINE_Cn_FEM<SpT,OT,PT> lineBasis( order, pointType );
-    Basis_HGRAD_LINE_Cn_FEM<SpT,OT,PT> bubbleBasis( order - 1, POINTTYPE_GAUSS );
+    Basis_HGRAD_LINE_Cn_FEM<DT,OT,PT> lineBasis( order, pointType );
+    Basis_HGRAD_LINE_Cn_FEM<DT,OT,PT> bubbleBasis( order - 1, POINTTYPE_GAUSS );
 
     const ordinal_type
       cardLine = lineBasis.getCardinality(),
       cardBubble = bubbleBasis.getCardinality();
 
-    this->vinvLine_   = Kokkos::DynRankView<typename ScalarViewType::value_type,SpT>("Hdiv::Quad::In::vinvLine", cardLine, cardLine);
-    this->vinvBubble_ = Kokkos::DynRankView<typename ScalarViewType::value_type,SpT>("Hdiv::Quad::In::vinvBubble", cardBubble, cardBubble);
+    this->vinvLine_   = Kokkos::DynRankView<typename ScalarViewType::value_type,DT>("Hdiv::Quad::In::vinvLine", cardLine, cardLine);
+    this->vinvBubble_ = Kokkos::DynRankView<typename ScalarViewType::value_type,DT>("Hdiv::Quad::In::vinvBubble", cardBubble, cardBubble);
 
     lineBasis.getVandermondeInverse(this->vinvLine_);
     bubbleBasis.getVandermondeInverse(this->vinvBubble_);
@@ -364,14 +364,14 @@ namespace Intrepid2 {
     }
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
       dofCoordsHost("dofCoordsHost", this->basisCardinality_, this->basisCellTopology_.getDimension());
 
     // dofCoeffs on host and create its mirror view to device
-    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
       dofCoeffsHost("dofCoeffsHost", this->basisCardinality_, this->basisCellTopology_.getDimension());
 
-    Kokkos::DynRankView<typename ScalarViewType::value_type,SpT>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,DT>
       dofCoordsLine("dofCoordsLine", cardLine, 1),
       dofCoordsBubble("dofCoordsBubble", cardBubble, 1);
 
@@ -405,10 +405,10 @@ namespace Intrepid2 {
       }
     }
 
-    this->dofCoords_ = Kokkos::create_mirror_view(typename SpT::memory_space(), dofCoordsHost);
+    this->dofCoords_ = Kokkos::create_mirror_view(typename DT::memory_space(), dofCoordsHost);
     Kokkos::deep_copy(this->dofCoords_, dofCoordsHost);
 
-    this->dofCoeffs_ = Kokkos::create_mirror_view(typename SpT::memory_space(), dofCoeffsHost);
+    this->dofCoeffs_ = Kokkos::create_mirror_view(typename DT::memory_space(), dofCoeffsHost);
     Kokkos::deep_copy(this->dofCoeffs_, dofCoeffsHost);
   }
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TET_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TET_In_FEM.hpp
@@ -193,29 +193,34 @@ public:
 };
 }
 
-template<typename ExecSpaceType = void,
+template<typename Device = void,
     typename outputValueType = double,
     typename pointValueType = double>
 class Basis_HDIV_TET_In_FEM
-    : public Basis<ExecSpaceType,outputValueType,pointValueType> {
-    public:
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost OrdinalTypeArray1DHost;
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost OrdinalTypeArray2DHost;
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost OrdinalTypeArray3DHost;
+    : public Basis<Device,outputValueType,pointValueType> {
+public:
+  using BasisSuper = Basis<Device,outputValueType,pointValueType>;
+  
+  using OrdinalTypeArray1DHost = typename BasisSuper::OrdinalTypeArray1DHost;
+  using OrdinalTypeArray2DHost = typename BasisSuper::OrdinalTypeArray2DHost;
+  using OrdinalTypeArray3DHost = typename BasisSuper::OrdinalTypeArray3DHost;
+
+  using DeviceType      = typename BasisSuper::DeviceType;
+  using ExecutionSpace  = typename BasisSuper::ExecutionSpace;
+  using OutputValueType = typename BasisSuper::OutputValueType;
+  using PointValueType  = typename BasisSuper::PointValueType;
+
+  using OutputViewType = typename BasisSuper::OutputViewType;
+  using PointViewType  = typename BasisSuper::PointViewType;
+  using ScalarViewType = typename BasisSuper::ScalarViewType;
+  
+  using BasisSuper::getValues;
+  using scalarType = typename BasisSuper::scalarType;
 
   /** \brief  Constructor.
    */
   Basis_HDIV_TET_In_FEM(const ordinal_type order,
       const EPointType   pointType = POINTTYPE_EQUISPACED);
-
-
-  using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
-  using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
-  using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
-
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarType  scalarType;
-
-  using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
   virtual
   void
@@ -229,12 +234,12 @@ class Basis_HDIV_TET_In_FEM
         this->getBaseCellTopology(),
         this->getCardinality() );
 #endif
-constexpr ordinal_type numPtsPerEval = Parameters::MaxNumPtsPerBasisEval;
-Impl::Basis_HDIV_TET_In_FEM::
-getValues<ExecSpaceType,numPtsPerEval>( outputValues,
-    inputPoints,
-    this->coeffs_,
-    operatorType);
+    constexpr ordinal_type numPtsPerEval = Parameters::MaxNumPtsPerBasisEval;
+    Impl::Basis_HDIV_TET_In_FEM::
+    getValues<ExecutionSpace,numPtsPerEval>( outputValues,
+                                             inputPoints,
+                                             this->coeffs_,
+                                             operatorType);
   }
 
   virtual
@@ -298,12 +303,12 @@ getValues<ExecSpaceType,numPtsPerEval>( outputValues,
       \param [in] subCellOrd - position of the subCell among of the subCells having the same dimension
       \return pointer to the subCell basis of dimension subCellDim and position subCellOrd
    */
-  BasisPtr<ExecSpaceType,outputValueType,pointValueType>
+  BasisPtr<DeviceType,outputValueType,pointValueType>
     getSubCellRefBasis(const ordinal_type subCellDim, const ordinal_type subCellOrd) const override{
 
     if(subCellDim == 2) {
       return Teuchos::rcp(new
-          Basis_HVOL_TRI_Cn_FEM<ExecSpaceType,outputValueType,pointValueType>
+          Basis_HVOL_TRI_Cn_FEM<DeviceType,outputValueType,pointValueType>
           (this->basisDegree_-1, pointType_));
     }
     INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
@@ -313,7 +318,7 @@ getValues<ExecSpaceType,numPtsPerEval>( outputValues,
 
   /** \brief expansion coefficients of the nodal basis in terms of the
         orthgonal one */
-  Kokkos::DynRankView<scalarType,ExecSpaceType> coeffs_;
+  Kokkos::DynRankView<scalarType,DeviceType> coeffs_;
 
   /** \brief type of lattice used for creating the DoF coordinates  */
   EPointType pointType_;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TET_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TET_In_FEMDef.hpp
@@ -248,7 +248,7 @@ Basis_HDIV_TET_In_FEM( const ordinal_type order,
 
   // now I need to integrate { (x,y,z) phi } against the big basis
   // first, get a cubature rule.
-  CubatureDirectTetDefault<Kokkos::HostSpace::execution_space,scalarType,scalarType> myCub( 2 * order );
+  CubatureDirectTetDefault<Kokkos::HostSpace::device_type,scalarType,scalarType> myCub( 2 * order );
   Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace> cubPoints("Hdiv::Tet::In::cubPoints", myCub.getNumPoints() , spaceDim );
   Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace> cubWeights("Hdiv::Tet::In::cubWeights", myCub.getNumPoints() );
   myCub.getCubature( cubPoints , cubWeights );

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TET_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TET_In_FEMDef.hpp
@@ -184,8 +184,8 @@ getValues( /* */ Kokkos::DynRankView<outputValueValueType,outputValueProperties.
 }
 
 // -------------------------------------------------------------------------------------
-template<typename SpT, typename OT, typename PT>
-Basis_HDIV_TET_In_FEM<SpT,OT,PT>::
+template<typename DT, typename OT, typename PT>
+Basis_HDIV_TET_In_FEM<DT,OT,PT>::
 Basis_HDIV_TET_In_FEM( const ordinal_type order,
     const EPointType   pointType ) {
 
@@ -214,13 +214,13 @@ Basis_HDIV_TET_In_FEM( const ordinal_type order,
   ordinal_type tags[maxCard][tagSize];
 
   // points are computed in the host and will be copied
-  Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace>
+  Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
   dofCoords("Hdiv::Tet::In::dofCoords", card, spaceDim);
 
-  Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace>
+  Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
   dofCoeffs("Hdiv::Tet::In::dofCoeffs", card, spaceDim);
 
-  Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace>
+  Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
   coeffs("Hdiv::Tet::In::coeffs", cardVecPn, card);
 
   // first, need to project the basis for RT space onto the
@@ -228,7 +228,7 @@ Basis_HDIV_TET_In_FEM( const ordinal_type order,
   // get coefficients of PkHx
 
   const ordinal_type lwork = card*card;
-  Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace>
+  Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
   V1("Hdiv::Tet::In::V1", cardVecPn, card);
 
   // basis for the space is
@@ -249,12 +249,12 @@ Basis_HDIV_TET_In_FEM( const ordinal_type order,
   // now I need to integrate { (x,y,z) phi } against the big basis
   // first, get a cubature rule.
   CubatureDirectTetDefault<Kokkos::HostSpace::execution_space,scalarType,scalarType> myCub( 2 * order );
-  Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace> cubPoints("Hdiv::Tet::In::cubPoints", myCub.getNumPoints() , spaceDim );
-  Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace> cubWeights("Hdiv::Tet::In::cubWeights", myCub.getNumPoints() );
+  Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace> cubPoints("Hdiv::Tet::In::cubPoints", myCub.getNumPoints() , spaceDim );
+  Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace> cubWeights("Hdiv::Tet::In::cubWeights", myCub.getNumPoints() );
   myCub.getCubature( cubPoints , cubWeights );
 
   // tabulate the scalar orthonormal basis at cubature points
-  Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace> phisAtCubPoints("Hdiv::Tet::In::phisAtCubPoints", cardPn , myCub.getNumPoints() );
+  Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace> phisAtCubPoints("Hdiv::Tet::In::phisAtCubPoints", cardPn , myCub.getNumPoints() );
   Impl::Basis_HGRAD_TET_Cn_FEM_ORTH::getValues<Kokkos::HostSpace::execution_space,Parameters::MaxNumPtsPerBasisEval>(phisAtCubPoints, cubPoints, order, OPERATOR_VALUE);
 
   // now do the integration
@@ -272,7 +272,7 @@ Basis_HDIV_TET_In_FEM( const ordinal_type order,
   }
 
   // next, apply the RT nodes (rows) to the basis for (P_n)^3 (columns)
-  Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace>
+  Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
   V2("Hdiv::Tet::In::V2", card ,cardVecPn);
 
   const ordinal_type numFaces = this->basisCellTopology_.getFaceCount();
@@ -284,7 +284,7 @@ Basis_HDIV_TET_In_FEM( const ordinal_type order,
       1 );
 
   // get the points on the tetrahedron face
-  Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace> triPts("Hdiv::Tet::In::triPts", numPtsPerFace , 2 );
+  Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace> triPts("Hdiv::Tet::In::triPts", numPtsPerFace , 2 );
 
   // construct lattice
   const ordinal_type offset = 1;
@@ -295,9 +295,9 @@ Basis_HDIV_TET_In_FEM( const ordinal_type order,
       pointType );
 
   // holds the image of the tet points
-  Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace> facePts("Hdiv::Tet::In::facePts", numPtsPerFace , spaceDim );
-  Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace> phisAtFacePoints("Hdiv::Tet::In::phisAtFacePoints", cardPn , numPtsPerFace );
-  Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace> faceNormal("Hcurl::Tet::In::faceNormal", spaceDim );
+  Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace> facePts("Hdiv::Tet::In::facePts", numPtsPerFace , spaceDim );
+  Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace> phisAtFacePoints("Hdiv::Tet::In::phisAtFacePoints", cardPn , numPtsPerFace );
+  Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace> faceNormal("Hcurl::Tet::In::faceNormal", spaceDim );
 
   // loop over faces
   for (ordinal_type face=0;face<numFaces;face++) {  // loop over faces
@@ -351,7 +351,7 @@ Basis_HDIV_TET_In_FEM( const ordinal_type order,
       1 );
 
   if (numPtsPerCell > 0) {
-    Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
     internalPoints( "Hdiv::Tet::In::internalPoints", numPtsPerCell , spaceDim );
     PointTools::getLattice( internalPoints ,
         this->basisCellTopology_ ,
@@ -359,7 +359,7 @@ Basis_HDIV_TET_In_FEM( const ordinal_type order,
         1 ,
         pointType );
 
-    Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
     phisAtInternalPoints("Hdiv::Tet::In::phisAtInternalPoints", cardPn , numPtsPerCell );
     Impl::Basis_HGRAD_TET_Cn_FEM_ORTH::getValues<Kokkos::HostSpace::execution_space,Parameters::MaxNumPtsPerBasisEval>( phisAtInternalPoints , internalPoints , order, OPERATOR_VALUE );
 
@@ -436,13 +436,13 @@ Basis_HDIV_TET_In_FEM( const ordinal_type order,
       coeffs(i,j) = s;
     }
 
-  this->coeffs_ = Kokkos::create_mirror_view(typename SpT::memory_space(), coeffs);
+  this->coeffs_ = Kokkos::create_mirror_view(typename DT::memory_space(), coeffs);
   Kokkos::deep_copy(this->coeffs_ , coeffs);
 
-  this->dofCoords_ = Kokkos::create_mirror_view(typename SpT::memory_space(), dofCoords);
+  this->dofCoords_ = Kokkos::create_mirror_view(typename DT::memory_space(), dofCoords);
   Kokkos::deep_copy(this->dofCoords_, dofCoords);
 
-  this->dofCoeffs_ = Kokkos::create_mirror_view(typename SpT::memory_space(), dofCoeffs);
+  this->dofCoeffs_ = Kokkos::create_mirror_view(typename DT::memory_space(), dofCoeffs);
   Kokkos::deep_copy(this->dofCoeffs_, dofCoeffs);
 
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TRI_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TRI_In_FEM.hpp
@@ -197,28 +197,35 @@ public:
 };
 }
 
-template<typename ExecSpaceType = void,
+template<typename Device = void,
     typename outputValueType = double,
     typename pointValueType = double>
 class Basis_HDIV_TRI_In_FEM
-    : public Basis<ExecSpaceType,outputValueType,pointValueType> {
-    public:
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost OrdinalTypeArray1DHost;
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost OrdinalTypeArray2DHost;
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost OrdinalTypeArray3DHost;
+    : public Basis<Device,outputValueType,pointValueType> {
+public:
+  using BasisSuper = Basis<Device,outputValueType,pointValueType>;
+  
+  using OrdinalTypeArray1DHost = typename BasisSuper::OrdinalTypeArray1DHost;
+  using OrdinalTypeArray2DHost = typename BasisSuper::OrdinalTypeArray2DHost;
+  using OrdinalTypeArray3DHost = typename BasisSuper::OrdinalTypeArray3DHost;
+
+  using DeviceType      = typename BasisSuper::DeviceType;
+  using ExecutionSpace  = typename BasisSuper::ExecutionSpace;
+  using OutputValueType = typename BasisSuper::OutputValueType;
+  using PointValueType  = typename BasisSuper::PointValueType;
+
+  using OutputViewType = typename BasisSuper::OutputViewType;
+  using PointViewType  = typename BasisSuper::PointViewType;
+  using ScalarViewType = typename BasisSuper::ScalarViewType;
+  
+  using BasisSuper::getValues;
 
   /** \brief  Constructor.
    */
   Basis_HDIV_TRI_In_FEM(const ordinal_type order,
       const EPointType   pointType = POINTTYPE_EQUISPACED);
 
-  using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
-  using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
-  using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
-
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarType  scalarType;
-
-  using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
+  typedef typename BasisSuper::scalarType  scalarType;
 
   virtual
   void
@@ -234,10 +241,10 @@ class Basis_HDIV_TRI_In_FEM
 #endif
     constexpr ordinal_type numPtsPerEval = Parameters::MaxNumPtsPerBasisEval;
     Impl::Basis_HDIV_TRI_In_FEM::
-    getValues<ExecSpaceType,numPtsPerEval>( outputValues,
-        inputPoints,
-        this->coeffs_,
-        operatorType);
+    getValues<ExecutionSpace,numPtsPerEval>( outputValues,
+                                             inputPoints,
+                                             this->coeffs_,
+                                             operatorType);
   }
 
   virtual
@@ -301,11 +308,11 @@ class Basis_HDIV_TRI_In_FEM
       \param [in] subCellOrd - position of the subCell among of the subCells having the same dimension
       \return pointer to the subCell basis of dimension subCellDim and position subCellOrd
    */
-  BasisPtr<ExecSpaceType,outputValueType,pointValueType>
+  BasisPtr<DeviceType,outputValueType,pointValueType>
     getSubCellRefBasis(const ordinal_type subCellDim, const ordinal_type subCellOrd) const override{
     if(subCellDim == 1) {
       return Teuchos::rcp(new
-                  Basis_HVOL_LINE_Cn_FEM<ExecSpaceType,outputValueType,pointValueType>
+                  Basis_HVOL_LINE_Cn_FEM<DeviceType,outputValueType,pointValueType>
                   (this->basisDegree_-1, pointType_));
     }
     INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
@@ -315,7 +322,7 @@ class Basis_HDIV_TRI_In_FEM
 
   /** \brief expansion coefficients of the nodal basis in terms of the
         orthgonal one */
-  Kokkos::DynRankView<scalarType,ExecSpaceType> coeffs_;
+  Kokkos::DynRankView<scalarType,DeviceType> coeffs_;
 
   /** \brief type of lattice used for creating the DoF coordinates  */
   EPointType pointType_;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TRI_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TRI_In_FEMDef.hpp
@@ -245,7 +245,7 @@ Basis_HDIV_TRI_In_FEM( const ordinal_type order,
 
   // now I need to integrate { (x,y) phi } against the big basis
   // first, get a cubature rule.
-  CubatureDirectTriDefault<Kokkos::HostSpace::execution_space,scalarType,scalarType> myCub( 2 * order );
+  CubatureDirectTriDefault<Kokkos::HostSpace::device_type,scalarType,scalarType> myCub( 2 * order );
   Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace> cubPoints("Hdiv::Tri::In::cubPoints", myCub.getNumPoints() , spaceDim );
   Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace> cubWeights("Hdiv::Tri::In::cubWeights", myCub.getNumPoints() );
   myCub.getCubature( cubPoints , cubWeights );

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TRI_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TRI_In_FEMDef.hpp
@@ -180,11 +180,11 @@ getValues( /* */ Kokkos::DynRankView<outputValueValueType,outputValueProperties.
   }
   }
 }
-}
+} // namespace Impl
 
 // -------------------------------------------------------------------------------------
-template<typename SpT, typename OT, typename PT>
-Basis_HDIV_TRI_In_FEM<SpT,OT,PT>::
+template<typename DT, typename OT, typename PT>
+Basis_HDIV_TRI_In_FEM<DT,OT,PT>::
 Basis_HDIV_TRI_In_FEM( const ordinal_type order,
     const EPointType   pointType ) {
   INTREPID2_TEST_FOR_EXCEPTION(order > Parameters::MaxOrder, std::invalid_argument, "Unsupported polynomial order");
@@ -213,13 +213,13 @@ Basis_HDIV_TRI_In_FEM( const ordinal_type order,
   ordinal_type tags[maxCard][tagSize];
 
   // points are computed in the host and will be copied
-  Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace>
+  Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
   dofCoords("Hdiv::Tri::In::dofCoords", card, spaceDim);
 
-  Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace>
+  Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
   dofCoeffs("Hdiv::Tri::In::dofCoeffs", card, spaceDim);
 
-  Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace>
+  Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
   coeffs("Hdiv::Tri::In::coeffs", cardVecPn, card);
 
   // first, need to project the basis for RT space onto the
@@ -227,7 +227,7 @@ Basis_HDIV_TRI_In_FEM( const ordinal_type order,
   // get coefficients of PkHx
 
   const ordinal_type lwork = card*card;
-  Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace>
+  Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
   V1("Hdiv::Tri::In::V1", cardVecPn, card);
 
   // basis for the space is
@@ -246,12 +246,12 @@ Basis_HDIV_TRI_In_FEM( const ordinal_type order,
   // now I need to integrate { (x,y) phi } against the big basis
   // first, get a cubature rule.
   CubatureDirectTriDefault<Kokkos::HostSpace::execution_space,scalarType,scalarType> myCub( 2 * order );
-  Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace> cubPoints("Hdiv::Tri::In::cubPoints", myCub.getNumPoints() , spaceDim );
-  Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace> cubWeights("Hdiv::Tri::In::cubWeights", myCub.getNumPoints() );
+  Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace> cubPoints("Hdiv::Tri::In::cubPoints", myCub.getNumPoints() , spaceDim );
+  Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace> cubWeights("Hdiv::Tri::In::cubWeights", myCub.getNumPoints() );
   myCub.getCubature( cubPoints , cubWeights );
 
   // tabulate the scalar orthonormal basis at cubature points
-  Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace> phisAtCubPoints("Hdiv::Tri::In::phisAtCubPoints", cardPn , myCub.getNumPoints() );
+  Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace> phisAtCubPoints("Hdiv::Tri::In::phisAtCubPoints", cardPn , myCub.getNumPoints() );
   Impl::Basis_HGRAD_TRI_Cn_FEM_ORTH::getValues<Kokkos::HostSpace::execution_space,Parameters::MaxNumPtsPerBasisEval>(phisAtCubPoints, cubPoints, order, OPERATOR_VALUE);
 
   // now do the integration
@@ -269,7 +269,7 @@ Basis_HDIV_TRI_In_FEM( const ordinal_type order,
   }
 
   // next, apply the RT nodes (rows) to the basis for (P_n)^2 (columns)
-  Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace>
+  Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
   V2("Hdiv::Tri::In::V2", card ,cardVecPn);
 
   const ordinal_type numEdges = this->basisCellTopology_.getEdgeCount();
@@ -282,7 +282,7 @@ Basis_HDIV_TRI_In_FEM( const ordinal_type order,
 
   // first numEdges * degree nodes are normals at each edge
   // get the points on the line
-  Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace> linePts("Hdiv::Tri::In::linePts", numPtsPerEdge , 1 );
+  Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace> linePts("Hdiv::Tri::In::linePts", numPtsPerEdge , 1 );
 
   // construct lattice
   const ordinal_type offset = 1;
@@ -292,9 +292,9 @@ Basis_HDIV_TRI_In_FEM( const ordinal_type order,
       pointType );
 
   // holds the image of the line points
-  Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace> edgePts("Hdiv::Tri::In::edgePts", numPtsPerEdge , spaceDim );
-  Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace> phisAtEdgePoints("Hdiv::Tri::In::phisAtEdgePoints", cardPn , numPtsPerEdge );
-  Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace> edgeNormal("Hcurl::Tri::In::edgeNormal", spaceDim );
+  Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace> edgePts("Hdiv::Tri::In::edgePts", numPtsPerEdge , spaceDim );
+  Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace> phisAtEdgePoints("Hdiv::Tri::In::phisAtEdgePoints", cardPn , numPtsPerEdge );
+  Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace> edgeNormal("Hcurl::Tri::In::edgeNormal", spaceDim );
 
   // these are normal scaled by the appropriate edge lengths.
   for (ordinal_type edge=0;edge<numEdges;edge++) {  // loop over edges
@@ -350,7 +350,7 @@ Basis_HDIV_TRI_In_FEM( const ordinal_type order,
       1 );
 
   if (numPtsPerCell > 0) {
-    Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
     internalPoints( "Hdiv::Tri::In::internalPoints", numPtsPerCell , spaceDim );
     PointTools::getLattice( internalPoints ,
         this->basisCellTopology_ ,
@@ -358,7 +358,7 @@ Basis_HDIV_TRI_In_FEM( const ordinal_type order,
         1 ,
         pointType );
 
-    Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
     phisAtInternalPoints("Hdiv::Tri::In::phisAtInternalPoints", cardPn , numPtsPerCell );
     Impl::Basis_HGRAD_TRI_Cn_FEM_ORTH::getValues<Kokkos::HostSpace::execution_space,Parameters::MaxNumPtsPerBasisEval>( phisAtInternalPoints , internalPoints , order, OPERATOR_VALUE );
 
@@ -435,13 +435,13 @@ Basis_HDIV_TRI_In_FEM( const ordinal_type order,
       coeffs(i,j) = s;
     }
 
-  this->coeffs_ = Kokkos::create_mirror_view(typename SpT::memory_space(), coeffs);
+  this->coeffs_ = Kokkos::create_mirror_view(typename DT::memory_space(), coeffs);
   Kokkos::deep_copy(this->coeffs_ , coeffs);
 
-  this->dofCoords_ = Kokkos::create_mirror_view(typename SpT::memory_space(), dofCoords);
+  this->dofCoords_ = Kokkos::create_mirror_view(typename DT::memory_space(), dofCoords);
   Kokkos::deep_copy(this->dofCoords_, dofCoords);
 
-  this->dofCoeffs_ = Kokkos::create_mirror_view(typename SpT::memory_space(), dofCoeffs);
+  this->dofCoeffs_ = Kokkos::create_mirror_view(typename DT::memory_space(), dofCoeffs);
   Kokkos::deep_copy(this->dofCoeffs_, dofCoeffs);
 
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C1_FEM.hpp
@@ -166,24 +166,31 @@ namespace Intrepid2 {
     };
   }
 
-  template<typename DeviceType = void,
+  template<typename Device = void,
            typename outputValueType = double,
            typename pointValueType = double>
-  class Basis_HGRAD_HEX_C1_FEM : public Basis<DeviceType,outputValueType,pointValueType> {
+  class Basis_HGRAD_HEX_C1_FEM : public Basis<Device,outputValueType,pointValueType> {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
-    using OrdinalTypeArray3DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+    using BasisSuper = Basis<Device,outputValueType,pointValueType>;
+    
+    using OrdinalTypeArray1DHost = typename BasisSuper::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename BasisSuper::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename BasisSuper::OrdinalTypeArray3DHost;
+
+    using DeviceType      = typename BasisSuper::DeviceType;
+    using ExecutionSpace  = typename BasisSuper::ExecutionSpace;
+    using OutputValueType = typename BasisSuper::OutputValueType;
+    using PointValueType  = typename BasisSuper::PointValueType;
+
+    using OutputViewType = typename BasisSuper::OutputViewType;
+    using PointViewType  = typename BasisSuper::PointViewType;
+    using ScalarViewType = typename BasisSuper::ScalarViewType;
+    
+    using BasisSuper::getValues;
 
     /** \brief  Constructor.
      */
     Basis_HGRAD_HEX_C1_FEM();
-
-    using OutputViewType = typename Basis<DeviceType,outputValueType,pointValueType>::OutputViewType;
-    using PointViewType  = typename Basis<DeviceType,outputValueType,pointValueType>::PointViewType;
-    using ScalarViewType = typename Basis<DeviceType,outputValueType,pointValueType>::ScalarViewType;
-
-    using Basis<DeviceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
@@ -199,9 +206,9 @@ namespace Intrepid2 {
                                       this->getCardinality() );
 #endif
       Impl::Basis_HGRAD_HEX_C1_FEM::
-        getValues<DeviceType>( outputValues,
-                                  inputPoints,
-                                  operatorType );
+        getValues<ExecutionSpace>( outputValues,
+                                   inputPoints,
+                                   operatorType );
     }
 
     virtual

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C1_FEMDef.hpp
@@ -305,7 +305,7 @@ namespace Intrepid2 {
       }
     }
 
-    template<typename DT,
+    template<typename SpT,
              typename outputValueValueType, class ...outputValueProperties,
              typename inputPointValueType,  class ...inputPointProperties>
     void
@@ -315,7 +315,7 @@ namespace Intrepid2 {
                const EOperator operatorType ) {
       typedef          Kokkos::DynRankView<outputValueValueType,outputValueProperties...>         outputValueViewType;
       typedef          Kokkos::DynRankView<inputPointValueType, inputPointProperties...>          inputPointViewType;
-      typedef typename ExecSpace<typename inputPointViewType::execution_space,typename DT::execution_space>::ExecSpaceType ExecSpaceType;
+      typedef typename ExecSpace<typename inputPointViewType::execution_space,SpT>::ExecSpaceType ExecSpaceType;
 
       // Number of evaluation points = dim 0 of inputPoints
       const auto loopSize = inputPoints.extent(0);
@@ -373,7 +373,7 @@ namespace Intrepid2 {
       }
       }
     }
-  }
+  } // namespace Impl
 
   // -------------------------------------------------------------------------------------
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C2_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C2_FEM.hpp
@@ -216,24 +216,31 @@ namespace Intrepid2 {
     };
   }
       
-  template<typename ExecSpaceType = void,
+  template<typename Device = void,
            typename outputValueType = double,
            typename pointValueType = double>
-  class Basis_HGRAD_HEX_C2_FEM : public Basis<ExecSpaceType,outputValueType,pointValueType> {
+  class Basis_HGRAD_HEX_C2_FEM : public Basis<Device,outputValueType,pointValueType> {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
-    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+    using BasisSuper = Basis<Device,outputValueType,pointValueType>;
+    
+    using OrdinalTypeArray1DHost = typename BasisSuper::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename BasisSuper::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename BasisSuper::OrdinalTypeArray3DHost;
+
+    using DeviceType      = typename BasisSuper::DeviceType;
+    using ExecutionSpace  = typename BasisSuper::ExecutionSpace;
+    using OutputValueType = typename BasisSuper::OutputValueType;
+    using PointValueType  = typename BasisSuper::PointValueType;
+
+    using OutputViewType = typename BasisSuper::OutputViewType;
+    using PointViewType  = typename BasisSuper::PointViewType;
+    using ScalarViewType = typename BasisSuper::ScalarViewType;
+    
+    using BasisSuper::getValues;
 
     /** \brief  Constructor.
      */
     Basis_HGRAD_HEX_C2_FEM();
-
-    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
-    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
-    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
-
-    using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
@@ -249,9 +256,9 @@ namespace Intrepid2 {
                                       this->getCardinality() );
 #endif
       Impl::Basis_HGRAD_HEX_C2_FEM::
-        getValues<ExecSpaceType>( outputValues,
-                                  inputPoints,
-                                  operatorType );
+        getValues<ExecutionSpace>( outputValues,
+                                   inputPoints,
+                                   operatorType );
     }
 
     virtual

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C2_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C2_FEMDef.hpp
@@ -1020,8 +1020,8 @@ namespace Intrepid2 {
 
   // -------------------------------------------------------------------------------------
 
-  template<typename SpT, typename OT, typename PT>
-  Basis_HGRAD_HEX_C2_FEM<SpT,OT,PT>::
+  template<typename DT, typename OT, typename PT>
+  Basis_HGRAD_HEX_C2_FEM<DT,OT,PT>::
   Basis_HGRAD_HEX_C2_FEM() {
     this -> basisCardinality_  = 27;
     this -> basisDegree_       = 2;
@@ -1082,7 +1082,7 @@ namespace Intrepid2 {
                               posDfOrd);
     }
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
       dofCoords("dofCoordsHost", this->basisCardinality_,this->basisCellTopology_.getDimension());
 
     dofCoords(0,0) = -1.0;   dofCoords(0,1) = -1.0; dofCoords(0,2) = -1.0;
@@ -1116,7 +1116,7 @@ namespace Intrepid2 {
     dofCoords(25,0) =  0.0;   dofCoords(25,1) = -1.0; dofCoords(25,2) =  0.0;
     dofCoords(26,0) =  0.0;   dofCoords(26,1) =  1.0; dofCoords(26,2) =  0.0;
 
-    this->dofCoords_ = Kokkos::create_mirror_view(typename SpT::memory_space(), dofCoords);
+    this->dofCoords_ = Kokkos::create_mirror_view(typename DT::memory_space(), dofCoords);
     Kokkos::deep_copy(this->dofCoords_, dofCoords);
 
   }

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_Cn_FEM.hpp
@@ -161,23 +161,32 @@ namespace Intrepid2 {
       \endverbatim      
   */
 
-  template<typename ExecSpaceType = void,
+  template<typename Device = void,
            typename outputValueType = double,
            typename pointValueType = double>
   class Basis_HGRAD_HEX_Cn_FEM
-    : public Basis<ExecSpaceType,outputValueType,pointValueType> {
+    : public Basis<Device,outputValueType,pointValueType> {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
-    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+    using BasisSuper = Basis<Device,outputValueType,pointValueType>;
+    
+    using OrdinalTypeArray1DHost = typename BasisSuper::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename BasisSuper::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename BasisSuper::OrdinalTypeArray3DHost;
 
-    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
-    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
-    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    using DeviceType      = typename BasisSuper::DeviceType;
+    using ExecutionSpace  = typename BasisSuper::ExecutionSpace;
+    using OutputValueType = typename BasisSuper::OutputValueType;
+    using PointValueType  = typename BasisSuper::PointValueType;
+
+    using OutputViewType = typename BasisSuper::OutputViewType;
+    using PointViewType  = typename BasisSuper::PointViewType;
+    using ScalarViewType = typename BasisSuper::ScalarViewType;
+    
+    using BasisSuper::getValues;
 
   private:
     /** \brief inverse of Generalized Vandermonde matrix (isotropic order) */
-    Kokkos::DynRankView<typename ScalarViewType::value_type,ExecSpaceType> vinv_;
+    Kokkos::DynRankView<typename ScalarViewType::value_type,DeviceType> vinv_;
 
     /** \brief type of lattice used for creating the DoF coordinates  */
     EPointType pointType_;
@@ -188,8 +197,6 @@ namespace Intrepid2 {
      */
     Basis_HGRAD_HEX_Cn_FEM(const ordinal_type order,
                             const EPointType   pointType = POINTTYPE_EQUISPACED);
-
-    using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
@@ -205,10 +212,10 @@ namespace Intrepid2 {
 #endif
       constexpr ordinal_type numPtsPerEval = Parameters::MaxNumPtsPerBasisEval;
       Impl::Basis_HGRAD_HEX_Cn_FEM::
-        getValues<ExecSpaceType,numPtsPerEval>( outputValues,
-                                                inputPoints,
-                                                this->vinv_,
-                                                operatorType );
+        getValues<ExecutionSpace,numPtsPerEval>( outputValues,
+                                                 inputPoints,
+                                                 this->vinv_,
+                                                 operatorType );
     }
 
 
@@ -255,7 +262,7 @@ namespace Intrepid2 {
       return (this->basisDegree_ > 2);
     }
 
-    Kokkos::DynRankView<typename ScalarViewType::const_value_type,ExecSpaceType>
+    Kokkos::DynRankView<typename ScalarViewType::const_value_type,DeviceType>
     getVandermondeInverse() {
       return vinv_;
     }
@@ -273,15 +280,15 @@ namespace Intrepid2 {
         \param [in] subCellOrd - position of the subCell among of the subCells having the same dimension
         \return pointer to the subCell basis of dimension subCellDim and position subCellOrd
      */
-    BasisPtr<ExecSpaceType,outputValueType,pointValueType>
+    BasisPtr<DeviceType,outputValueType,pointValueType>
       getSubCellRefBasis(const ordinal_type subCellDim, const ordinal_type subCellOrd) const override{
       if(subCellDim == 1) {
         return Teuchos::rcp(new
-            Basis_HGRAD_LINE_Cn_FEM<ExecSpaceType,outputValueType,pointValueType>
+            Basis_HGRAD_LINE_Cn_FEM<DeviceType,outputValueType,pointValueType>
             (this->basisDegree_, pointType_));
       } else if(subCellDim == 2) {
         return Teuchos::rcp(new
-            Basis_HGRAD_QUAD_Cn_FEM<ExecSpaceType,outputValueType,pointValueType>
+            Basis_HGRAD_QUAD_Cn_FEM<DeviceType,outputValueType,pointValueType>
             (this->basisDegree_, pointType_));
       }
       INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_Cn_FEMDef.hpp
@@ -260,19 +260,19 @@ namespace Intrepid2 {
       }
       }
     }
-  }
+  } // namespace Impl
 
   // -------------------------------------------------------------------------------------
-  template<typename SpT, typename OT, typename PT>
-  Basis_HGRAD_HEX_Cn_FEM<SpT,OT,PT>::
+  template<typename DT, typename OT, typename PT>
+  Basis_HGRAD_HEX_Cn_FEM<DT,OT,PT>::
   Basis_HGRAD_HEX_Cn_FEM( const ordinal_type order,
                           const EPointType   pointType ) {
 
     // this should be in host
-    Basis_HGRAD_LINE_Cn_FEM<SpT,OT,PT> lineBasis( order, pointType );
+    Basis_HGRAD_LINE_Cn_FEM<DT,OT,PT> lineBasis( order, pointType );
     const auto cardLine = lineBasis.getCardinality();
 
-    this->vinv_ = Kokkos::DynRankView<typename ScalarViewType::value_type,SpT>("Hgrad::HEX::Cn::vinv", cardLine, cardLine);
+    this->vinv_ = Kokkos::DynRankView<typename ScalarViewType::value_type,DT>("Hgrad::HEX::Cn::vinv", cardLine, cardLine);
     lineBasis.getVandermondeInverse(this->vinv_);
     
     this->basisCardinality_  = cardLine*cardLine*cardLine;
@@ -384,10 +384,10 @@ namespace Intrepid2 {
     }
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
       dofCoordsHost("dofCoordsHost", this->basisCardinality_, this->basisCellTopology_.getDimension());
 
-    Kokkos::DynRankView<typename ScalarViewType::value_type,SpT>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,DT>
       dofCoordsLine("dofCoordsLine", cardLine, 1);
 
     lineBasis.getDofCoords(dofCoordsLine);
@@ -406,7 +406,7 @@ namespace Intrepid2 {
       }
     }
 
-    this->dofCoords_ = Kokkos::create_mirror_view(typename SpT::memory_space(), dofCoordsHost);
+    this->dofCoords_ = Kokkos::create_mirror_view(typename DT::memory_space(), dofCoordsHost);
     Kokkos::deep_copy(this->dofCoords_, dofCoordsHost);
   }
   

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_C1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_C1_FEM.hpp
@@ -149,25 +149,32 @@ namespace Intrepid2 {
     };
   }
 
-  template<typename DeviceType = void,
+  template<typename Device = void,
            typename outputValueType = double,
            typename pointValueType = double>
   class Basis_HGRAD_LINE_C1_FEM
-    : public Basis<DeviceType,outputValueType,pointValueType> {
+    : public Basis<Device,outputValueType,pointValueType> {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
-    using OrdinalTypeArray3DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+    using BasisSuper = Basis<Device,outputValueType,pointValueType>;
+    
+    using OrdinalTypeArray1DHost = typename BasisSuper::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename BasisSuper::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename BasisSuper::OrdinalTypeArray3DHost;
+
+    using DeviceType      = typename BasisSuper::DeviceType;
+    using ExecutionSpace  = typename BasisSuper::ExecutionSpace;
+    using OutputValueType = typename BasisSuper::OutputValueType;
+    using PointValueType  = typename BasisSuper::PointValueType;
+
+    using OutputViewType = typename BasisSuper::OutputViewType;
+    using PointViewType  = typename BasisSuper::PointViewType;
+    using ScalarViewType = typename BasisSuper::ScalarViewType;
+    
+    using BasisSuper::getValues;
 
     /** \brief  Constructor.
      */
     Basis_HGRAD_LINE_C1_FEM();
-
-    using OutputViewType = typename Basis<DeviceType,outputValueType,pointValueType>::OutputViewType;
-    using PointViewType  = typename Basis<DeviceType,outputValueType,pointValueType>::PointViewType;
-    using ScalarViewType = typename Basis<DeviceType,outputValueType,pointValueType>::ScalarViewType;
-
-    using Basis<DeviceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
@@ -183,9 +190,9 @@ namespace Intrepid2 {
                                       this->getCardinality() );
 #endif
       Impl::Basis_HGRAD_LINE_C1_FEM::
-        getValues<DeviceType>( outputValues,
-                                  inputPoints,
-                                  operatorType );
+        getValues<ExecutionSpace>( outputValues,
+                                   inputPoints,
+                                   operatorType );
     }
 
     virtual

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_C1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_C1_FEMDef.hpp
@@ -95,7 +95,7 @@ namespace Intrepid2 {
       }
     }
 
-    template<typename DT,
+    template<typename SpT,
              typename outputValueValueType, class ...outputValueProperties,
              typename inputPointValueType,  class ...inputPointProperties>
     void
@@ -105,7 +105,7 @@ namespace Intrepid2 {
                const EOperator operatorType ) {
       typedef          Kokkos::DynRankView<outputValueValueType,outputValueProperties...>         outputValueViewType;
       typedef          Kokkos::DynRankView<inputPointValueType, inputPointProperties...>          inputPointViewType;
-      typedef typename ExecSpace<typename inputPointViewType::execution_space,typename DT::execution_space>::ExecSpaceType ExecSpaceType;
+      typedef typename ExecSpace<typename inputPointViewType::execution_space,SpT>::ExecSpaceType ExecSpaceType;
 
       // Number of evaluation points = dim 0 of inputPoints
       const auto loopSize = inputPoints.extent(0);
@@ -148,7 +148,7 @@ namespace Intrepid2 {
 
 
 
-  }
+  } // namespace Impl
 
   // -------------------------------------------------------------------------------------
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEM.hpp
@@ -169,33 +169,39 @@ namespace Intrepid2 {
     };
   }
   
-  template<typename ExecSpaceType = void,
+  template<typename Device = void,
            typename outputValueType = double,
            typename pointValueType = double>
   class Basis_HGRAD_LINE_Cn_FEM
-    : public Basis<ExecSpaceType,outputValueType,pointValueType> {
+    : public Basis<Device,outputValueType,pointValueType> {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
-    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+    using BasisSuper = Basis<Device,outputValueType,pointValueType>;
+    
+    using OrdinalTypeArray1DHost = typename BasisSuper::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename BasisSuper::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename BasisSuper::OrdinalTypeArray3DHost;
 
-    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
-    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
-    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    using DeviceType      = typename BasisSuper::DeviceType;
+    using ExecutionSpace  = typename BasisSuper::ExecutionSpace;
+    using OutputValueType = typename BasisSuper::OutputValueType;
+    using PointValueType  = typename BasisSuper::PointValueType;
 
+    using OutputViewType = typename BasisSuper::OutputViewType;
+    using PointViewType  = typename BasisSuper::PointViewType;
+    using ScalarViewType = typename BasisSuper::ScalarViewType;
+    
+    using BasisSuper::getValues;
   private:
 
     /** \brief inverse of Generalized Vandermonde matrix, whose columns store the expansion
         coefficients of the nodal basis in terms of phis_ */
-    Kokkos::DynRankView<typename ScalarViewType::value_type,ExecSpaceType> vinv_;
+    Kokkos::DynRankView<typename ScalarViewType::value_type,DeviceType> vinv_;
 
   public:
     /** \brief  Constructor.
      */
     Basis_HGRAD_LINE_Cn_FEM(const ordinal_type order,
                             const EPointType   pointType = POINTTYPE_EQUISPACED);  
-
-    using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
@@ -211,10 +217,10 @@ namespace Intrepid2 {
 #endif
       constexpr ordinal_type numPtsPerEval = 1;
       Impl::Basis_HGRAD_LINE_Cn_FEM::
-        getValues<ExecSpaceType,numPtsPerEval>( outputValues,
-                                                inputPoints,
-                                                this->vinv_,
-                                                operatorType );
+        getValues<ExecutionSpace,numPtsPerEval>( outputValues,
+                                                 inputPoints,
+                                                 this->vinv_,
+                                                 operatorType );
     }
 
     virtual
@@ -260,7 +266,7 @@ namespace Intrepid2 {
       Kokkos::deep_copy(vinv, this->vinv_);      
     }
 
-    Kokkos::DynRankView<typename ScalarViewType::const_value_type,ExecSpaceType>
+    Kokkos::DynRankView<typename ScalarViewType::const_value_type,DeviceType>
     getVandermondeInverse() const {
       return vinv_;
     }

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEMDef.hpp
@@ -192,8 +192,8 @@ namespace Intrepid2 {
   }
 
   // -------------------------------------------------------------------------------------
-  template<typename SpT, typename OT, typename PT>
-  Basis_HGRAD_LINE_Cn_FEM<SpT,OT,PT>::
+  template<typename DT, typename OT, typename PT>
+  Basis_HGRAD_LINE_Cn_FEM<DT,OT,PT>::
   Basis_HGRAD_LINE_Cn_FEM( const ordinal_type order,
                            const EPointType   pointType ) {
     this->basisCardinality_  = order+1;
@@ -206,7 +206,7 @@ namespace Intrepid2 {
     const ordinal_type card = this->basisCardinality_;
     
     // points are computed in the host and will be copied 
-    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
       dofCoords("Hgrad::Line::Cn::dofCoords", card, 1);
 
     //Default is Equispaced
@@ -255,7 +255,7 @@ namespace Intrepid2 {
     }
     }
 
-    this->dofCoords_ = Kokkos::create_mirror_view(typename SpT::memory_space(), dofCoords);
+    this->dofCoords_ = Kokkos::create_mirror_view(typename DT::memory_space(), dofCoords);
     Kokkos::deep_copy(this->dofCoords_, dofCoords);
     
     // form Vandermonde matrix; actually, this is the transpose of the VDM,
@@ -294,14 +294,14 @@ namespace Intrepid2 {
                                   ">>> ERROR: (Intrepid2::Basis_HGRAD_LINE_Cn_FEM) lapack.GETRI returns nonzero info." );
     
     // create host mirror 
-    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
       vinv("Hgrad::Line::Cn::vinv", card, card);
 
     for (ordinal_type i=0;i<card;++i) 
       for (ordinal_type j=0;j<card;++j) 
         vinv(i,j) = vmat(j,i);
 
-    this->vinv_ = Kokkos::create_mirror_view(typename SpT::memory_space(), vinv);
+    this->vinv_ = Kokkos::create_mirror_view(typename DT::memory_space(), vinv);
     Kokkos::deep_copy(this->vinv_ , vinv);
 
     // initialize tags

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_PYR_C1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_PYR_C1_FEM.hpp
@@ -158,24 +158,31 @@ namespace Intrepid2 {
 
     };
   }
-  template<typename DeviceType = void,
+  template<typename Device = void,
            typename outputValueType = double,
            typename pointValueType = double>
-  class Basis_HGRAD_PYR_C1_FEM : public Basis<DeviceType,outputValueType,pointValueType> {
+  class Basis_HGRAD_PYR_C1_FEM : public Basis<Device,outputValueType,pointValueType> {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
-    using OrdinalTypeArray3DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+    using BasisSuper = Basis<Device,outputValueType,pointValueType>;
+    
+    using OrdinalTypeArray1DHost = typename BasisSuper::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename BasisSuper::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename BasisSuper::OrdinalTypeArray3DHost;
+
+    using DeviceType      = typename BasisSuper::DeviceType;
+    using ExecutionSpace  = typename BasisSuper::ExecutionSpace;
+    using OutputValueType = typename BasisSuper::OutputValueType;
+    using PointValueType  = typename BasisSuper::PointValueType;
+
+    using OutputViewType = typename BasisSuper::OutputViewType;
+    using PointViewType  = typename BasisSuper::PointViewType;
+    using ScalarViewType = typename BasisSuper::ScalarViewType;
+    
+    using BasisSuper::getValues;
 
     /** \brief  Constructor.
      */
     Basis_HGRAD_PYR_C1_FEM();
-
-    using OutputViewType = typename Basis<DeviceType,outputValueType,pointValueType>::OutputViewType;
-    using PointViewType  = typename Basis<DeviceType,outputValueType,pointValueType>::PointViewType;
-    using ScalarViewType = typename Basis<DeviceType,outputValueType,pointValueType>::ScalarViewType;
-
-    using Basis<DeviceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
@@ -191,9 +198,9 @@ namespace Intrepid2 {
                                       this->getCardinality() );
 #endif
       Impl::Basis_HGRAD_PYR_C1_FEM::
-        getValues<DeviceType>( outputValues,
-                                  inputPoints,
-                                  operatorType );
+        getValues<ExecutionSpace>( outputValues,
+                                   inputPoints,
+                                   operatorType );
     }
 
     virtual

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_PYR_C1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_PYR_C1_FEMDef.hpp
@@ -178,7 +178,7 @@ namespace Intrepid2 {
       }
     }
 
-    template<typename DT,
+    template<typename SpT,
              typename outputValueValueType, class ...outputValueProperties,
              typename inputPointValueType,  class ...inputPointProperties>
     void
@@ -188,7 +188,7 @@ namespace Intrepid2 {
                const EOperator operatorType )  {
       typedef          Kokkos::DynRankView<outputValueValueType,outputValueProperties...>         outputValueViewType;
       typedef          Kokkos::DynRankView<inputPointValueType, inputPointProperties...>          inputPointViewType;
-      typedef typename ExecSpace<typename inputPointViewType::execution_space,typename DT::execution_space>::ExecSpaceType ExecSpaceType;
+      typedef typename ExecSpace<typename inputPointViewType::execution_space,SpT>::ExecSpaceType ExecSpaceType;
 
       // Number of evaluation points = dim 0 of inputPoints
       const auto loopSize = inputPoints.extent(0);

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_C1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_C1_FEM.hpp
@@ -197,9 +197,9 @@ namespace Intrepid2 {
                                       this->getCardinality() );
 #endif
       Impl::Basis_HGRAD_QUAD_C1_FEM::
-        getValues<ExecutionSpace>( outputValues,
-                                   inputPoints,
-                                   operatorType );
+        getValues<DeviceType>( outputValues,
+                               inputPoints,
+                               operatorType );
     }
 
     virtual

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_C1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_C1_FEM.hpp
@@ -157,24 +157,31 @@ namespace Intrepid2 {
     };
   }
 
-  template<typename DeviceType = void,
+  template<typename Device = void,
            typename outputValueType = double,
            typename pointValueType = double>
-  class Basis_HGRAD_QUAD_C1_FEM : public Basis<DeviceType,outputValueType,pointValueType> {
+  class Basis_HGRAD_QUAD_C1_FEM : public Basis<Device,outputValueType,pointValueType> {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
-    using OrdinalTypeArray3DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+    using BasisSuper = Basis<Device,outputValueType,pointValueType>;
+    
+    using OrdinalTypeArray1DHost = typename BasisSuper::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename BasisSuper::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename BasisSuper::OrdinalTypeArray3DHost;
+
+    using DeviceType      = typename BasisSuper::DeviceType;
+    using ExecutionSpace  = typename BasisSuper::ExecutionSpace;
+    using OutputValueType = typename BasisSuper::OutputValueType;
+    using PointValueType  = typename BasisSuper::PointValueType;
+
+    using OutputViewType = typename BasisSuper::OutputViewType;
+    using PointViewType  = typename BasisSuper::PointViewType;
+    using ScalarViewType = typename BasisSuper::ScalarViewType;
+    
+    using BasisSuper::getValues;
 
     /** \brief Constructor.
      */
     Basis_HGRAD_QUAD_C1_FEM();
-
-    using OutputViewType = typename Basis<DeviceType,outputValueType,pointValueType>::OutputViewType;
-    using PointViewType  = typename Basis<DeviceType,outputValueType,pointValueType>::PointViewType;
-    using ScalarViewType = typename Basis<DeviceType,outputValueType,pointValueType>::ScalarViewType;
-
-    using Basis<DeviceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
@@ -190,9 +197,9 @@ namespace Intrepid2 {
                                       this->getCardinality() );
 #endif
       Impl::Basis_HGRAD_QUAD_C1_FEM::
-        getValues<DeviceType>( outputValues,
-                                  inputPoints,
-                                  operatorType );
+        getValues<ExecutionSpace>( outputValues,
+                                   inputPoints,
+                                   operatorType );
     }
 
     virtual

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_C1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_C1_FEMDef.hpp
@@ -151,7 +151,7 @@ namespace Intrepid2 {
       }
     }
 
-    template<typename SpT,
+    template<typename DT,
              typename outputValueValueType, class ...outputValueProperties,
              typename inputPointValueType,  class ...inputPointProperties>
     void
@@ -161,7 +161,7 @@ namespace Intrepid2 {
                const EOperator operatorType )  {
       typedef          Kokkos::DynRankView<outputValueValueType,outputValueProperties...>         outputValueViewType;
       typedef          Kokkos::DynRankView<inputPointValueType, inputPointProperties...>          inputPointViewType;
-      typedef typename ExecSpace<typename inputPointViewType::execution_space,SpT>::ExecSpaceType ExecSpaceType;
+      typedef typename ExecSpace<typename inputPointViewType::execution_space,typename DT::execution_space>::ExecSpaceType ExecSpaceType;
 
       // Number of evaluation points = dim 0 of inputPoints
       const auto loopSize = inputPoints.extent(0);

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_C1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_C1_FEMDef.hpp
@@ -151,7 +151,7 @@ namespace Intrepid2 {
       }
     }
 
-    template<typename DT,
+    template<typename SpT,
              typename outputValueValueType, class ...outputValueProperties,
              typename inputPointValueType,  class ...inputPointProperties>
     void
@@ -161,7 +161,7 @@ namespace Intrepid2 {
                const EOperator operatorType )  {
       typedef          Kokkos::DynRankView<outputValueValueType,outputValueProperties...>         outputValueViewType;
       typedef          Kokkos::DynRankView<inputPointValueType, inputPointProperties...>          inputPointViewType;
-      typedef typename ExecSpace<typename inputPointViewType::execution_space,typename DT::execution_space>::ExecSpaceType ExecSpaceType;
+      typedef typename ExecSpace<typename inputPointViewType::execution_space,SpT>::ExecSpaceType ExecSpaceType;
 
       // Number of evaluation points = dim 0 of inputPoints
       const auto loopSize = inputPoints.extent(0);

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_C2_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_C2_FEM.hpp
@@ -173,24 +173,31 @@ namespace Intrepid2 {
     };
   }
 
-  template<typename ExecSpaceType = void,
+  template<typename Device = void,
            typename outputValueType = double,
            typename pointValueType = double>
-  class Basis_HGRAD_QUAD_C2_FEM : public Basis<ExecSpaceType,outputValueType,pointValueType> {
+  class Basis_HGRAD_QUAD_C2_FEM : public Basis<Device,outputValueType,pointValueType> {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
-    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+    using BasisSuper = Basis<Device,outputValueType,pointValueType>;
+    
+    using OrdinalTypeArray1DHost = typename BasisSuper::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename BasisSuper::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename BasisSuper::OrdinalTypeArray3DHost;
+
+    using DeviceType      = typename BasisSuper::DeviceType;
+    using ExecutionSpace  = typename BasisSuper::ExecutionSpace;
+    using OutputValueType = typename BasisSuper::OutputValueType;
+    using PointValueType  = typename BasisSuper::PointValueType;
+
+    using OutputViewType = typename BasisSuper::OutputViewType;
+    using PointViewType  = typename BasisSuper::PointViewType;
+    using ScalarViewType = typename BasisSuper::ScalarViewType;
 
     /** \brief Constructor.
      */
     Basis_HGRAD_QUAD_C2_FEM();
 
-    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
-    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
-    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
-
-    using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
+    using BasisSuper::getValues;
 
     virtual
     void
@@ -206,7 +213,7 @@ namespace Intrepid2 {
                                       this->getCardinality() );
 #endif
       Impl::Basis_HGRAD_QUAD_C2_FEM::
-        getValues<ExecSpaceType>( outputValues,
+        getValues<ExecutionSpace>( outputValues,
                                   inputPoints,
                                   operatorType );
     }

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_C2_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_C2_FEMDef.hpp
@@ -400,8 +400,8 @@ namespace Intrepid2 {
   // -------------------------------------------------------------------------------------
 
 
-  template<typename SpT, typename OT, typename PT>
-  Basis_HGRAD_QUAD_C2_FEM<SpT,OT,PT>::
+  template<typename DT, typename OT, typename PT>
+  Basis_HGRAD_QUAD_C2_FEM<DT,OT,PT>::
   Basis_HGRAD_QUAD_C2_FEM() {
     this->basisCardinality_  = 9;
     this->basisDegree_       = 2;    
@@ -445,7 +445,7 @@ namespace Intrepid2 {
     }
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
       dofCoords("dofCoordsHost", this->basisCardinality_,this->basisCellTopology_.getDimension());
     
     dofCoords(0,0) = -1.0;   dofCoords(0,1) = -1.0;
@@ -460,7 +460,7 @@ namespace Intrepid2 {
   
     dofCoords(8,0) =  0.0;   dofCoords(8,1) =  0.0;
 
-    this->dofCoords_ = Kokkos::create_mirror_view(typename SpT::memory_space(), dofCoords);
+    this->dofCoords_ = Kokkos::create_mirror_view(typename DT::memory_space(), dofCoords);
     Kokkos::deep_copy(this->dofCoords_, dofCoords);   
   }
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_Cn_FEM.hpp
@@ -160,23 +160,32 @@ namespace Intrepid2 {
               Implements Lagrangian basis of degree n on the reference Quadrilateral cell using
               a tensor product of points
   */
-  template<typename ExecSpaceType = void,
+  template<typename Device = void,
            typename outputValueType = double,
            typename pointValueType = double>
   class Basis_HGRAD_QUAD_Cn_FEM
-    : public Basis<ExecSpaceType,outputValueType,pointValueType> {
+    : public Basis<Device,outputValueType,pointValueType> {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
-    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+    using BasisSuper = Basis<Device,outputValueType,pointValueType>;
+    
+    using OrdinalTypeArray1DHost = typename BasisSuper::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename BasisSuper::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename BasisSuper::OrdinalTypeArray3DHost;
 
-    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
-    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
-    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    using DeviceType      = typename BasisSuper::DeviceType;
+    using ExecutionSpace  = typename BasisSuper::ExecutionSpace;
+    using OutputValueType = typename BasisSuper::OutputValueType;
+    using PointValueType  = typename BasisSuper::PointValueType;
+
+    using OutputViewType = typename BasisSuper::OutputViewType;
+    using PointViewType  = typename BasisSuper::PointViewType;
+    using ScalarViewType = typename BasisSuper::ScalarViewType;
+    
+    using BasisSuper::getValues;
 
   private:
     /** \brief inverse of Generalized Vandermonde matrix (isotropic order) */
-    Kokkos::DynRankView<typename ScalarViewType::value_type,ExecSpaceType> vinv_;
+    Kokkos::DynRankView<typename ScalarViewType::value_type,DeviceType> vinv_;
 
     /** \brief type of lattice used for creating the DoF coordinates  */
     EPointType pointType_;
@@ -186,8 +195,6 @@ namespace Intrepid2 {
      */
     Basis_HGRAD_QUAD_Cn_FEM(const ordinal_type order,
                             const EPointType   pointType = POINTTYPE_EQUISPACED);
-
-    using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
@@ -203,10 +210,10 @@ namespace Intrepid2 {
 #endif
       constexpr ordinal_type numPtsPerEval = Parameters::MaxNumPtsPerBasisEval;
       Impl::Basis_HGRAD_QUAD_Cn_FEM::
-        getValues<ExecSpaceType,numPtsPerEval>( outputValues,
-                                                inputPoints,
-                                                this->vinv_,
-                                                operatorType);
+        getValues<ExecutionSpace,numPtsPerEval>( outputValues,
+                                                 inputPoints,
+                                                 this->vinv_,
+                                                 operatorType);
     }
 
     virtual
@@ -252,7 +259,7 @@ namespace Intrepid2 {
       return (this->basisDegree_ > 2);
     }
 
-    Kokkos::DynRankView<typename ScalarViewType::const_value_type,ExecSpaceType>
+    Kokkos::DynRankView<typename ScalarViewType::const_value_type,DeviceType>
     getVandermondeInverse() const {
       return vinv_;
     }
@@ -270,11 +277,11 @@ namespace Intrepid2 {
         \param [in] subCellOrd - position of the subCell among of the subCells having the same dimension
         \return pointer to the subCell basis of dimension subCellDim and position subCellOrd
      */
-    BasisPtr<ExecSpaceType,outputValueType,pointValueType>
+    BasisPtr<DeviceType,outputValueType,pointValueType>
       getSubCellRefBasis(const ordinal_type subCellDim, const ordinal_type subCellOrd) const override{
       if(subCellDim == 1) {
         return Teuchos::rcp(new
-            Basis_HGRAD_LINE_Cn_FEM<ExecSpaceType,outputValueType,pointValueType>
+            Basis_HGRAD_LINE_Cn_FEM<DeviceType,outputValueType,pointValueType>
             (this->basisDegree_,pointType_));
       }
       INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_Cn_FEMDef.hpp
@@ -273,8 +273,8 @@ namespace Intrepid2 {
   }
 
   // -------------------------------------------------------------------------------------
-  template<typename SpT, typename OT, typename PT>
-  Basis_HGRAD_QUAD_Cn_FEM<SpT,OT,PT>::
+  template<typename DT, typename OT, typename PT>
+  Basis_HGRAD_QUAD_Cn_FEM<DT,OT,PT>::
   Basis_HGRAD_QUAD_Cn_FEM( const ordinal_type order,
                            const EPointType   pointType ) {
     // INTREPID2_TEST_FOR_EXCEPTION( !(pointType == POINTTYPE_EQUISPACED ||
@@ -282,10 +282,10 @@ namespace Intrepid2 {
     //                               ">>> ERROR (Basis_HGRAD_QUAD_Cn_FEM): pointType must be either equispaced or warpblend." );
 
     // this should be in host
-    Basis_HGRAD_LINE_Cn_FEM<SpT,OT,PT> lineBasis( order, pointType );
+    Basis_HGRAD_LINE_Cn_FEM<DT,OT,PT> lineBasis( order, pointType );
     const auto cardLine = lineBasis.getCardinality();
     
-    this->vinv_ = Kokkos::DynRankView<typename ScalarViewType::value_type,SpT>("Hgrad::Quad::Cn::vinv", cardLine, cardLine);         
+    this->vinv_ = Kokkos::DynRankView<typename ScalarViewType::value_type,DT>("Hgrad::Quad::Cn::vinv", cardLine, cardLine);
     lineBasis.getVandermondeInverse(this->vinv_);
 
     this->basisCardinality_  = cardLine*cardLine;
@@ -363,10 +363,10 @@ namespace Intrepid2 {
     }
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
       dofCoordsHost("dofCoordsHost", this->basisCardinality_, this->basisCellTopology_.getDimension());
 
-    Kokkos::DynRankView<typename ScalarViewType::value_type,SpT>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,DT>
       dofCoordsLine("dofCoordsLine", cardLine, 1);
 
     lineBasis.getDofCoords(dofCoordsLine);
@@ -382,7 +382,7 @@ namespace Intrepid2 {
       }
     }
 
-    this->dofCoords_ = Kokkos::create_mirror_view(typename SpT::memory_space(), dofCoordsHost);
+    this->dofCoords_ = Kokkos::create_mirror_view(typename DT::memory_space(), dofCoordsHost);
     Kokkos::deep_copy(this->dofCoords_, dofCoordsHost);
   }
   

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_C1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_C1_FEM.hpp
@@ -154,24 +154,31 @@ namespace Intrepid2 {
     };
   }
 
-  template<typename DeviceType = void,
+  template<typename Device = void,
            typename outputValueType = double,
            typename pointValueType = double>
-  class Basis_HGRAD_TET_C1_FEM : public Basis<DeviceType,outputValueType,pointValueType> {
+  class Basis_HGRAD_TET_C1_FEM : public Basis<Device,outputValueType,pointValueType> {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
-    using OrdinalTypeArray3DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+    using BasisSuper = Basis<Device,outputValueType,pointValueType>;
+    
+    using OrdinalTypeArray1DHost = typename BasisSuper::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename BasisSuper::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename BasisSuper::OrdinalTypeArray3DHost;
+
+    using DeviceType      = typename BasisSuper::DeviceType;
+    using ExecutionSpace  = typename BasisSuper::ExecutionSpace;
+    using OutputValueType = typename BasisSuper::OutputValueType;
+    using PointValueType  = typename BasisSuper::PointValueType;
+
+    using OutputViewType = typename BasisSuper::OutputViewType;
+    using PointViewType  = typename BasisSuper::PointViewType;
+    using ScalarViewType = typename BasisSuper::ScalarViewType;
+    
+    using BasisSuper::getValues;
 
     /** \brief  Constructor.
      */
     Basis_HGRAD_TET_C1_FEM();
-
-    using OutputViewType = typename Basis<DeviceType,outputValueType,pointValueType>::OutputViewType;
-    using PointViewType  = typename Basis<DeviceType,outputValueType,pointValueType>::PointViewType;
-    using ScalarViewType = typename Basis<DeviceType,outputValueType,pointValueType>::ScalarViewType;
-
-    using Basis<DeviceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
@@ -187,9 +194,9 @@ namespace Intrepid2 {
                                       this->getCardinality() );
 #endif
       Impl::Basis_HGRAD_TET_C1_FEM::
-        getValues<DeviceType>( outputValues,
-                                  inputPoints,
-                                  operatorType );
+        getValues<ExecutionSpace>( outputValues,
+                                   inputPoints,
+                                   operatorType );
     }
 
     virtual

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_C1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_C1_FEMDef.hpp
@@ -113,7 +113,7 @@ namespace Intrepid2 {
       }
     }
 
-    template<typename DT,
+    template<typename SpT,
              typename outputValueValueType, class ...outputValueProperties,
              typename inputPointValueType,  class ...inputPointProperties>
     void
@@ -123,7 +123,7 @@ namespace Intrepid2 {
                const EOperator operatorType )  {
       typedef          Kokkos::DynRankView<outputValueValueType,outputValueProperties...>         outputValueViewType;
       typedef          Kokkos::DynRankView<inputPointValueType, inputPointProperties...>          inputPointViewType;
-      typedef typename ExecSpace<typename inputPointViewType::execution_space,typename DT::execution_space>::ExecSpaceType ExecSpaceType;
+      typedef typename ExecSpace<typename inputPointViewType::execution_space,SpT>::ExecSpaceType ExecSpaceType;
 
       // Number of evaluation points = dim 0 of inputPoints
       const auto loopSize = inputPoints.extent(0);

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_C2_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_C2_FEM.hpp
@@ -172,24 +172,31 @@ namespace Intrepid2 {
     };
   }
 
-  template<typename ExecSpaceType = void,
+  template<typename Device = void,
            typename outputValueType = double,
            typename pointValueType = double>
-  class Basis_HGRAD_TET_C2_FEM : public Basis<ExecSpaceType,outputValueType,pointValueType> {
+  class Basis_HGRAD_TET_C2_FEM : public Basis<Device,outputValueType,pointValueType> {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
-    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+    using BasisSuper = Basis<Device,outputValueType,pointValueType>;
+    
+    using OrdinalTypeArray1DHost = typename BasisSuper::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename BasisSuper::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename BasisSuper::OrdinalTypeArray3DHost;
 
+    using DeviceType      = typename BasisSuper::DeviceType;
+    using ExecutionSpace  = typename BasisSuper::ExecutionSpace;
+    using OutputValueType = typename BasisSuper::OutputValueType;
+    using PointValueType  = typename BasisSuper::PointValueType;
+
+    using OutputViewType = typename BasisSuper::OutputViewType;
+    using PointViewType  = typename BasisSuper::PointViewType;
+    using ScalarViewType = typename BasisSuper::ScalarViewType;
+
+    using BasisSuper::getValues;
+    
     /** \brief  Constructor.
      */
     Basis_HGRAD_TET_C2_FEM();
-
-    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
-    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
-    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
-
-    using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
@@ -205,9 +212,9 @@ namespace Intrepid2 {
                                       this->getCardinality() );
 #endif
       Impl::Basis_HGRAD_TET_C2_FEM::
-        getValues<ExecSpaceType>( outputValues,
-                                  inputPoints,
-                                  operatorType );
+        getValues<ExecutionSpace>( outputValues,
+                                   inputPoints,
+                                   operatorType );
     }
 
     virtual

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_C2_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_C2_FEMDef.hpp
@@ -224,7 +224,7 @@ namespace Intrepid2 {
       }
     }
 
-    template<typename SpT, 
+    template<typename SpT,
              typename outputValueValueType, class ...outputValueProperties,
              typename inputPointValueType,  class ...inputPointProperties>
     void
@@ -289,8 +289,8 @@ namespace Intrepid2 {
   }
   // -------------------------------------------------------------------------------------
 
-  template<typename SpT, typename OT, typename PT>
-  Basis_HGRAD_TET_C2_FEM<SpT,OT,PT>::
+  template<typename DT, typename OT, typename PT>
+  Basis_HGRAD_TET_C2_FEM<DT,OT,PT>::
   Basis_HGRAD_TET_C2_FEM() {
     this->basisCardinality_  = 10;
     this->basisDegree_       = 2;    
@@ -335,7 +335,7 @@ namespace Intrepid2 {
     }
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
       dofCoords("dofCoordsHost", this->basisCardinality_,this->basisCellTopology_.getDimension());
 
     dofCoords(0,0) = 0.0;   dofCoords(0,1) = 0.0; dofCoords(0,2) = 0.0;
@@ -350,7 +350,7 @@ namespace Intrepid2 {
     dofCoords(8,0) = 0.5;   dofCoords(8,1) = 0.0; dofCoords(8,2) = 0.5;
     dofCoords(9,0) = 0.0;   dofCoords(9,1) = 0.5; dofCoords(9,2) = 0.5;
 
-    this->dofCoords_ = Kokkos::create_mirror_view(typename SpT::memory_space(), dofCoords);
+    this->dofCoords_ = Kokkos::create_mirror_view(typename DT::memory_space(), dofCoords);
     Kokkos::deep_copy(this->dofCoords_, dofCoords);
   }
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_COMP12_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_COMP12_FEM.hpp
@@ -181,24 +181,31 @@ namespace Intrepid2 {
     };
   }
 
-  template<typename ExecSpaceType = void,
+  template<typename Device = void,
            typename outputValueType = double,
            typename pointValueType = double>
-  class Basis_HGRAD_TET_COMP12_FEM : public Basis<ExecSpaceType,outputValueType,pointValueType> {
+  class Basis_HGRAD_TET_COMP12_FEM : public Basis<Device,outputValueType,pointValueType> {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
-    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+    using BasisSuper = Basis<Device,outputValueType,pointValueType>;
+    
+    using OrdinalTypeArray1DHost = typename BasisSuper::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename BasisSuper::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename BasisSuper::OrdinalTypeArray3DHost;
+
+    using DeviceType      = typename BasisSuper::DeviceType;
+    using ExecutionSpace  = typename BasisSuper::ExecutionSpace;
+    using OutputValueType = typename BasisSuper::OutputValueType;
+    using PointValueType  = typename BasisSuper::PointValueType;
+
+    using OutputViewType = typename BasisSuper::OutputViewType;
+    using PointViewType  = typename BasisSuper::PointViewType;
+    using ScalarViewType = typename BasisSuper::ScalarViewType;
+    
+    using BasisSuper::getValues;
 
     /** \brief  Constructor.
      */
     Basis_HGRAD_TET_COMP12_FEM();
-    
-    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
-    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
-    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
-
-    using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     /** \brief  FEM basis evaluation on a <strong>reference Tetrahedron</strong> cell. 
     
@@ -225,9 +232,9 @@ namespace Intrepid2 {
                                       this->getCardinality() );
 #endif
       Impl::Basis_HGRAD_TET_COMP12_FEM::
-        getValues<ExecSpaceType>( outputValues,
-                                  inputPoints,
-                                  operatorType );
+        getValues<ExecutionSpace>( outputValues,
+                                   inputPoints,
+                                   operatorType );
     }
 
     /** \brief  Returns spatial locations (coordinates) of degrees of freedom on a

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_COMP12_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_COMP12_FEMDef.hpp
@@ -316,7 +316,7 @@ namespace Intrepid2 {
       }
     }
 
-    template<typename SpT, 
+    template<typename SpT,
              typename outputValueValueType, class ...outputValueProperties,
              typename inputPointValueType,  class ...inputPointProperties>
     void
@@ -378,8 +378,8 @@ namespace Intrepid2 {
   }
 
   // -------------------------------------------------------------------------------------
-  template<typename SpT, typename OT, typename PT>
-  Basis_HGRAD_TET_COMP12_FEM<SpT,OT,PT>::
+  template<typename DT, typename OT, typename PT>
+  Basis_HGRAD_TET_COMP12_FEM<DT,OT,PT>::
   Basis_HGRAD_TET_COMP12_FEM() {
     this->basisCardinality_  = 10;
     this->basisDegree_       = 1;
@@ -422,7 +422,7 @@ namespace Intrepid2 {
     }
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
       dofCoords("dofCoordsHost", this->basisCardinality_, this->basisCellTopology_.getDimension());
 
     dofCoords(0,0) = 0.0;   dofCoords(0,1) = 0.0; dofCoords(0,2) = 0.0;
@@ -436,7 +436,7 @@ namespace Intrepid2 {
     dofCoords(8,0) = 0.5;   dofCoords(8,1) = 0.0; dofCoords(8,2) = 0.5;
     dofCoords(9,0) = 0.0;   dofCoords(9,1) = 0.5; dofCoords(9,2) = 0.5;
 
-    this->dofCoords_ = Kokkos::create_mirror_view(typename SpT::memory_space(), dofCoords);
+    this->dofCoords_ = Kokkos::create_mirror_view(typename DT::memory_space(), dofCoords);
     Kokkos::deep_copy(this->dofCoords_, dofCoords);
   }
 }

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEM.hpp
@@ -181,27 +181,35 @@ namespace Intrepid2 {
     };
   }
 
-  template<typename ExecSpaceType = void,
+  template<typename Device = void,
            typename outputValueType = double,
            typename pointValueType = double>
   class Basis_HGRAD_TET_Cn_FEM
-    : public Basis<ExecSpaceType,outputValueType,pointValueType> {
+    : public Basis<Device,outputValueType,pointValueType> {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
-    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+    using BasisSuper = Basis<Device,outputValueType,pointValueType>;
+    
+    using OrdinalTypeArray1DHost = typename BasisSuper::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename BasisSuper::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename BasisSuper::OrdinalTypeArray3DHost;
 
-    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
-    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
-    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    using DeviceType      = typename BasisSuper::DeviceType;
+    using ExecutionSpace  = typename BasisSuper::ExecutionSpace;
+    using OutputValueType = typename BasisSuper::OutputValueType;
+    using PointValueType  = typename BasisSuper::PointValueType;
 
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarType  scalarType;
+    using OutputViewType = typename BasisSuper::OutputViewType;
+    using PointViewType  = typename BasisSuper::PointViewType;
+    using ScalarViewType = typename BasisSuper::ScalarViewType;
+    
+    using BasisSuper::getValues;
+    using scalarType = typename BasisSuper::scalarType;
 
   private:
 
     /** \brief inverse of Generalized Vandermonde matrix, whose columns store the expansion
         coefficients of the nodal basis in terms of phis_ */
-    Kokkos::DynRankView<scalarType,ExecSpaceType> vinv_;
+    Kokkos::DynRankView<scalarType,DeviceType> vinv_;
 
     /** \brief type of lattice used for creating the DoF coordinates  */
     EPointType pointType_;
@@ -212,10 +220,6 @@ namespace Intrepid2 {
      */
     Basis_HGRAD_TET_Cn_FEM(const ordinal_type order,
                            const EPointType   pointType = POINTTYPE_EQUISPACED);
-
-
-
-    using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
@@ -231,10 +235,10 @@ namespace Intrepid2 {
 #endif
       constexpr ordinal_type numPtsPerEval = Parameters::MaxNumPtsPerBasisEval;
       Impl::Basis_HGRAD_TET_Cn_FEM::
-        getValues<ExecSpaceType,numPtsPerEval>( outputValues,
-                                                inputPoints,
-                                                this->vinv_,
-                                                operatorType);
+        getValues<ExecutionSpace,numPtsPerEval>( outputValues,
+                                                 inputPoints,
+                                                 this->vinv_,
+                                                 operatorType);
     }
 
     virtual
@@ -287,7 +291,7 @@ namespace Intrepid2 {
       return (this->basisDegree_ > 2);
     }
 
-    Kokkos::DynRankView<typename ScalarViewType::const_value_type,ExecSpaceType>
+    Kokkos::DynRankView<typename ScalarViewType::const_value_type,DeviceType>
     getVandermondeInverse() const {
       return vinv_;
     }
@@ -313,15 +317,15 @@ namespace Intrepid2 {
         \param [in] subCellOrd - position of the subCell among of the subCells having the same dimension
         \return pointer to the subCell basis of dimension subCellDim and position subCellOrd
      */
-    BasisPtr<ExecSpaceType,outputValueType,pointValueType>
+    BasisPtr<DeviceType,outputValueType,pointValueType>
     getSubCellRefBasis(const ordinal_type subCellDim, const ordinal_type subCellOrd) const override{
       if(subCellDim == 1) {
         return Teuchos::rcp(new
-            Basis_HGRAD_LINE_Cn_FEM<ExecSpaceType,outputValueType,pointValueType>
+            Basis_HGRAD_LINE_Cn_FEM<DeviceType,outputValueType,pointValueType>
             (this->basisDegree_, pointType_));
       } else if(subCellDim == 2) {
         return Teuchos::rcp(new
-            Basis_HGRAD_TRI_Cn_FEM<ExecSpaceType,outputValueType,pointValueType>
+            Basis_HGRAD_TRI_Cn_FEM<DeviceType,outputValueType,pointValueType>
             (this->basisDegree_, pointType_));
       }
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEMDef.hpp
@@ -218,11 +218,11 @@ getValues(       Kokkos::DynRankView<outputValueValueType,outputValueProperties.
   }
   }
 }
-}
+} // namespace Impl
 
 // -------------------------------------------------------------------------------------
-template<typename SpT, typename OT, typename PT>
-Basis_HGRAD_TET_Cn_FEM<SpT,OT,PT>::
+template<typename DT, typename OT, typename PT>
+Basis_HGRAD_TET_Cn_FEM<DT,OT,PT>::
 Basis_HGRAD_TET_Cn_FEM( const ordinal_type order,
     const EPointType   pointType ) {
   constexpr ordinal_type spaceDim = 3;
@@ -238,7 +238,7 @@ Basis_HGRAD_TET_Cn_FEM( const ordinal_type order,
   const ordinal_type card = this->basisCardinality_;
 
   // points are computed in the host and will be copied
-  Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace>
+  Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
   dofCoords("Hgrad::Tet::Cn::dofCoords", card, spaceDim);
 
   // Basis-dependent initializations
@@ -270,9 +270,9 @@ Basis_HGRAD_TET_Cn_FEM( const ordinal_type order,
       order ,
       1 );
 
-  Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace> vertexes("Hcurl::Tet::In::vertexes", numVertexes , spaceDim );
-  Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace> linePts("Hcurl::Tet::In::linePts", numPtsPerEdge , 1 );
-  Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace> triPts("Hcurl::Tet::In::triPts", numPtsPerFace , 2 );
+  Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace> vertexes("Hcurl::Tet::In::vertexes", numVertexes , spaceDim );
+  Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace> linePts("Hcurl::Tet::In::linePts", numPtsPerEdge , 1 );
+  Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace> triPts("Hcurl::Tet::In::triPts", numPtsPerFace , 2 );
 
   // construct lattice
   const ordinal_type offset = 1;
@@ -294,8 +294,8 @@ Basis_HGRAD_TET_Cn_FEM( const ordinal_type order,
       this->pointType_ );
 
   // holds the image of the line points
-  Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace> edgePts("Hcurl::Tet::In::edgePts", numPtsPerEdge , spaceDim );
-  Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace> facePts("Hcurl::Tet::In::facePts", numPtsPerFace , spaceDim );
+  Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace> edgePts("Hcurl::Tet::In::edgePts", numPtsPerEdge , spaceDim );
+  Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace> facePts("Hcurl::Tet::In::facePts", numPtsPerFace , spaceDim );
 
   for (ordinal_type i=0;i<numVertexes;i++) {
     auto i_card=i;
@@ -362,7 +362,7 @@ Basis_HGRAD_TET_Cn_FEM( const ordinal_type order,
 
   // internal dof, if needed
   if (numPtsPerCell > 0) {
-    Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
     cellPoints( "Hcurl::Tet::In::cellPoints", numPtsPerCell , spaceDim );
     PointTools::getLattice( cellPoints ,
         this->basisCellTopology_ ,
@@ -386,7 +386,7 @@ Basis_HGRAD_TET_Cn_FEM( const ordinal_type order,
     }
   }
 
-  this->dofCoords_ = Kokkos::create_mirror_view(typename SpT::memory_space(), dofCoords);
+  this->dofCoords_ = Kokkos::create_mirror_view(typename DT::memory_space(), dofCoords);
   Kokkos::deep_copy(this->dofCoords_, dofCoords);
 
   // form Vandermonde matrix.  Actually, this is the transpose of the VDM,
@@ -422,14 +422,14 @@ Basis_HGRAD_TET_Cn_FEM( const ordinal_type order,
       ">>> ERROR: (Intrepid2::Basis_HGRAD_TET_Cn_FEM) lapack.GETRI returns nonzero info." );
 
   // create host mirror
-  Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace>
+  Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
   vinv("Hgrad::Line::Cn::vinv", card, card);
 
   for (ordinal_type i=0;i<card;++i)
     for (ordinal_type j=0;j<card;++j)
       vinv(i,j) = vmat(j,i);
 
-  this->vinv_ = Kokkos::create_mirror_view(typename SpT::memory_space(), vinv);
+  this->vinv_ = Kokkos::create_mirror_view(typename DT::memory_space(), vinv);
   Kokkos::deep_copy(this->vinv_ , vinv);
 
   // initialize tags

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_C1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_C1_FEM.hpp
@@ -152,24 +152,31 @@ namespace Intrepid2 {
     };
   }
 
-  template<typename DeviceType = void,
+  template<typename Device = void,
            typename outputValueType = double,
            typename pointValueType = double>
-  class Basis_HGRAD_TRI_C1_FEM: public Basis<DeviceType,outputValueType,pointValueType> {
+  class Basis_HGRAD_TRI_C1_FEM: public Basis<Device,outputValueType,pointValueType> {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
-    using OrdinalTypeArray3DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+    using BasisSuper = Basis<Device,outputValueType,pointValueType>;
+    
+    using OrdinalTypeArray1DHost = typename BasisSuper::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename BasisSuper::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename BasisSuper::OrdinalTypeArray3DHost;
+
+    using DeviceType      = typename BasisSuper::DeviceType;
+    using ExecutionSpace  = typename BasisSuper::ExecutionSpace;
+    using OutputValueType = typename BasisSuper::OutputValueType;
+    using PointValueType  = typename BasisSuper::PointValueType;
+
+    using OutputViewType = typename BasisSuper::OutputViewType;
+    using PointViewType  = typename BasisSuper::PointViewType;
+    using ScalarViewType = typename BasisSuper::ScalarViewType;
+    
+    using BasisSuper::getValues;
 
     /** \brief  Constructor.
      */
     Basis_HGRAD_TRI_C1_FEM();
-
-    using OutputViewType = typename Basis<DeviceType,outputValueType,pointValueType>::OutputViewType;
-    using PointViewType  = typename Basis<DeviceType,outputValueType,pointValueType>::PointViewType;
-    using ScalarViewType = typename Basis<DeviceType,outputValueType,pointValueType>::ScalarViewType;
-
-    using Basis<DeviceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
@@ -185,9 +192,9 @@ namespace Intrepid2 {
                                       this->getCardinality() );
 #endif
       Impl::Basis_HGRAD_TRI_C1_FEM::
-        getValues<DeviceType>( outputValues,
-                                  inputPoints,
-                                  operatorType );
+        getValues<ExecutionSpace>( outputValues,
+                                   inputPoints,
+                                   operatorType );
     }
 
     virtual

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_C1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_C1_FEMDef.hpp
@@ -118,7 +118,7 @@ namespace Intrepid2 {
     }
 
 
-    template<typename DT,
+    template<typename SpT,
              typename outputValueValueType, class ...outputValueProperties,
              typename inputPointValueType,  class ...inputPointProperties>
     void
@@ -128,7 +128,7 @@ namespace Intrepid2 {
                const EOperator operatorType )  {
       typedef          Kokkos::DynRankView<outputValueValueType,outputValueProperties...>         outputValueViewType;
       typedef          Kokkos::DynRankView<inputPointValueType, inputPointProperties...>          inputPointViewType;
-      typedef typename ExecSpace<typename inputPointViewType::execution_space,typename DT::execution_space>::ExecSpaceType ExecSpaceType;
+      typedef typename ExecSpace<typename inputPointViewType::execution_space,SpT>::ExecSpaceType ExecSpaceType;
 
       // Number of evaluation points = dim 0 of inputPoints
       const auto loopSize = inputPoints.extent(0);

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_C2_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_C2_FEM.hpp
@@ -162,24 +162,30 @@ namespace Intrepid2 {
     };
   }
 
-  template<typename ExecSpaceType = void,
+  template<typename Device = void,
            typename outputValueType = double,
            typename pointValueType = double>
-  class Basis_HGRAD_TRI_C2_FEM: public Basis<ExecSpaceType,outputValueType,pointValueType> {
+  class Basis_HGRAD_TRI_C2_FEM: public Basis<Device,outputValueType,pointValueType> {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
-    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+    using BasisSuper = Basis<Device,outputValueType,pointValueType>;
+    
+    using OrdinalTypeArray1DHost = typename BasisSuper::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename BasisSuper::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename BasisSuper::OrdinalTypeArray3DHost;
 
     /** \brief  Constructor.
      */
     Basis_HGRAD_TRI_C2_FEM();
+    
+    using ExecutionSpace  = typename BasisSuper::ExecutionSpace;
+    using OutputValueType = typename BasisSuper::OutputValueType;
+    using PointValueType  = typename BasisSuper::PointValueType;
 
-    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
-    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
-    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    using OutputViewType = typename BasisSuper::OutputViewType;
+    using PointViewType  = typename BasisSuper::PointViewType;
+    using ScalarViewType = typename BasisSuper::ScalarViewType;
 
-    using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
+    using BasisSuper::getValues;
 
     virtual
     void
@@ -195,7 +201,7 @@ namespace Intrepid2 {
                                       this->getCardinality() );
 #endif
       Impl::Basis_HGRAD_TRI_C2_FEM::
-        getValues<ExecSpaceType>( outputValues,
+        getValues<ExecutionSpace>( outputValues,
                                   inputPoints,
                                   operatorType );
     }

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_C2_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_C2_FEMDef.hpp
@@ -172,7 +172,7 @@ namespace Intrepid2 {
       }
     }
 
-    template<typename SpT,
+    template<typename DT,
              typename outputValueValueType, class ...outputValueProperties,
              typename inputPointValueType,  class ...inputPointProperties>
     void
@@ -182,7 +182,7 @@ namespace Intrepid2 {
                const EOperator operatorType ) {
       typedef          Kokkos::DynRankView<outputValueValueType,outputValueProperties...>         outputValueViewType;
       typedef          Kokkos::DynRankView<inputPointValueType, inputPointProperties...>          inputPointViewType;
-      typedef typename ExecSpace<typename inputPointViewType::execution_space,SpT>::ExecSpaceType ExecSpaceType;
+      typedef typename ExecSpace<typename inputPointViewType::execution_space,DT>::ExecSpaceType ExecSpaceType;
 
       // Number of evaluation points = dim 0 of inputPoints
       const auto loopSize = inputPoints.extent(0);
@@ -239,8 +239,8 @@ namespace Intrepid2 {
   // -------------------------------------------------------------------------------------
 
 
-  template< typename SpT, typename OT, typename PT>
-  Basis_HGRAD_TRI_C2_FEM<SpT,OT,PT>::
+  template< typename DT, typename OT, typename PT>
+  Basis_HGRAD_TRI_C2_FEM<DT,OT,PT>::
   Basis_HGRAD_TRI_C2_FEM() {
     this->basisCardinality_  = 6;
     this->basisDegree_       = 2;
@@ -280,7 +280,7 @@ namespace Intrepid2 {
     }
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
       dofCoords("dofCoordsHost", this->basisCardinality_,this->basisCellTopology_.getDimension());
 
     dofCoords(0,0) =  0.0;   dofCoords(0,1) =  0.0;
@@ -290,7 +290,7 @@ namespace Intrepid2 {
     dofCoords(4,0) =  0.5;   dofCoords(4,1) =  0.5;
     dofCoords(5,0) =  0.0;   dofCoords(5,1) =  0.5;
 
-    this->dofCoords_ = Kokkos::create_mirror_view(typename SpT::memory_space(), dofCoords);
+    this->dofCoords_ = Kokkos::create_mirror_view(typename DT::memory_space(), dofCoords);
     Kokkos::deep_copy(this->dofCoords_, dofCoords);
   }
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEM.hpp
@@ -177,27 +177,36 @@ namespace Intrepid2 {
     };
   }
 
-  template<typename ExecSpaceType = void,
+  template<typename Device = void,
            typename outputValueType = double,
            typename pointValueType = double>
   class Basis_HGRAD_TRI_Cn_FEM
-    : public Basis<ExecSpaceType,outputValueType,pointValueType> {
+    : public Basis<Device,outputValueType,pointValueType> {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
-    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+    using BasisSuper = Basis<Device,outputValueType,pointValueType>;
+    
+    using OrdinalTypeArray1DHost = typename BasisSuper::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename BasisSuper::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename BasisSuper::OrdinalTypeArray3DHost;
 
-    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
-    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
-    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    using DeviceType      = typename BasisSuper::DeviceType;
+    using ExecutionSpace  = typename BasisSuper::ExecutionSpace;
+    using OutputValueType = typename BasisSuper::OutputValueType;
+    using PointValueType  = typename BasisSuper::PointValueType;
 
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarType  scalarType;
+    using OutputViewType = typename BasisSuper::OutputViewType;
+    using PointViewType  = typename BasisSuper::PointViewType;
+    using ScalarViewType = typename BasisSuper::ScalarViewType;
+    
+    using BasisSuper::getValues;
+
+    typedef typename BasisSuper::scalarType  scalarType;
 
   private:
 
     /** \brief inverse of Generalized Vandermonde matrix, whose columns store the expansion
         coefficients of the nodal basis in terms of phis_ */
-    Kokkos::DynRankView<scalarType,ExecSpaceType> vinv_;
+    Kokkos::DynRankView<scalarType,DeviceType> vinv_;
 
     /** \brief type of lattice used for creating the DoF coordinates  */
     EPointType pointType_;
@@ -207,8 +216,6 @@ namespace Intrepid2 {
      */
     Basis_HGRAD_TRI_Cn_FEM(const ordinal_type order,
                            const EPointType   pointType = POINTTYPE_EQUISPACED);
-
-    using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
@@ -224,10 +231,10 @@ namespace Intrepid2 {
 #endif
       constexpr ordinal_type numPtsPerEval = Parameters::MaxNumPtsPerBasisEval;
       Impl::Basis_HGRAD_TRI_Cn_FEM::
-        getValues<ExecSpaceType,numPtsPerEval>( outputValues,
-                                                inputPoints,
-                                                this->vinv_,
-                                                operatorType);
+        getValues<ExecutionSpace,numPtsPerEval>( outputValues,
+                                                 inputPoints,
+                                                 this->vinv_,
+                                                 operatorType);
     }
 
     virtual
@@ -280,7 +287,7 @@ namespace Intrepid2 {
       Kokkos::deep_copy(vinv, this->vinv_);
     }
 
-    Kokkos::DynRankView<typename ScalarViewType::const_value_type,ExecSpaceType>
+    Kokkos::DynRankView<typename ScalarViewType::const_value_type,DeviceType>
     getVandermondeInverse() const {
       return vinv_;
     }
@@ -306,11 +313,11 @@ namespace Intrepid2 {
         \param [in] subCellOrd - position of the subCell among of the subCells having the same dimension
         \return pointer to the subCell basis of dimension subCellDim and position subCellOrd
      */
-    BasisPtr<ExecSpaceType,outputValueType,pointValueType>
+    BasisPtr<DeviceType,outputValueType,pointValueType>
       getSubCellRefBasis(const ordinal_type subCellDim, const ordinal_type subCellOrd) const override{
       if(subCellDim == 1) {
         return Teuchos::rcp(new
-            Basis_HGRAD_LINE_Cn_FEM<ExecSpaceType,outputValueType,pointValueType>
+            Basis_HGRAD_LINE_Cn_FEM<DeviceType,outputValueType,pointValueType>
             (this->basisDegree_, pointType_));
       }
       INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEMDef.hpp
@@ -244,11 +244,11 @@ getValues(       Kokkos::DynRankView<outputValueValueType,outputValueProperties.
   }
   }
 }
-}
+} // namespace Impl
 
 // -------------------------------------------------------------------------------------
-template<typename SpT, typename OT, typename PT>
-Basis_HGRAD_TRI_Cn_FEM<SpT,OT,PT>::
+template<typename DT, typename OT, typename PT>
+Basis_HGRAD_TRI_Cn_FEM<DT,OT,PT>::
 Basis_HGRAD_TRI_Cn_FEM( const ordinal_type order,
     const EPointType   pointType ) {
   constexpr ordinal_type spaceDim = 2;
@@ -264,7 +264,7 @@ Basis_HGRAD_TRI_Cn_FEM( const ordinal_type order,
   const ordinal_type card = this->basisCardinality_;
 
   // points are computed in the host and will be copied
-  Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace>
+  Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
   dofCoords("Hgrad::Tri::Cn::dofCoords", card, spaceDim);
 
   // construct lattice
@@ -274,7 +274,7 @@ Basis_HGRAD_TRI_Cn_FEM( const ordinal_type order,
       order, offset,
       pointType_ );
 
-  this->dofCoords_ = Kokkos::create_mirror_view(typename SpT::memory_space(), dofCoords);
+  this->dofCoords_ = Kokkos::create_mirror_view(typename DT::memory_space(), dofCoords);
   Kokkos::deep_copy(this->dofCoords_, dofCoords);
 
   // form Vandermonde matrix.  Actually, this is the transpose of the VDM,
@@ -310,14 +310,14 @@ Basis_HGRAD_TRI_Cn_FEM( const ordinal_type order,
       ">>> ERROR: (Intrepid2::Basis_HGRAD_TRI_Cn_FEM) lapack.GETRI returns nonzero info." );
 
   // create host mirror
-  Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace>
+  Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
   vinv("Hgrad::Line::Cn::vinv", card, card);
 
   for (ordinal_type i=0;i<card;++i)
     for (ordinal_type j=0;j<card;++j)
       vinv(i,j) = vmat(j,i);
 
-  this->vinv_ = Kokkos::create_mirror_view(typename SpT::memory_space(), vinv);
+  this->vinv_ = Kokkos::create_mirror_view(typename DT::memory_space(), vinv);
   Kokkos::deep_copy(this->vinv_ , vinv);
 
   // initialize tags

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_WEDGE_C1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_WEDGE_C1_FEM.hpp
@@ -159,24 +159,31 @@ namespace Intrepid2 {
 
     };
   }
-  template<typename DeviceType = void,
+  template<typename Device = void,
            typename outputValueType = double,
            typename pointValueType = double>
-  class Basis_HGRAD_WEDGE_C1_FEM : public Basis<DeviceType,outputValueType,pointValueType> {
+  class Basis_HGRAD_WEDGE_C1_FEM : public Basis<Device,outputValueType,pointValueType> {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
-    using OrdinalTypeArray3DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+    using BasisSuper = Basis<Device,outputValueType,pointValueType>;
+    
+    using OrdinalTypeArray1DHost = typename BasisSuper::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename BasisSuper::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename BasisSuper::OrdinalTypeArray3DHost;
+
+    using DeviceType      = typename BasisSuper::DeviceType;
+    using ExecutionSpace  = typename BasisSuper::ExecutionSpace;
+    using OutputValueType = typename BasisSuper::OutputValueType;
+    using PointValueType  = typename BasisSuper::PointValueType;
+
+    using OutputViewType = typename BasisSuper::OutputViewType;
+    using PointViewType  = typename BasisSuper::PointViewType;
+    using ScalarViewType = typename BasisSuper::ScalarViewType;
+    
+    using BasisSuper::getValues;
 
     /** \brief  Constructor.
      */
     Basis_HGRAD_WEDGE_C1_FEM();
-
-    using OutputViewType = typename Basis<DeviceType,outputValueType,pointValueType>::OutputViewType;
-    using PointViewType  = typename Basis<DeviceType,outputValueType,pointValueType>::PointViewType;
-    using ScalarViewType = typename Basis<DeviceType,outputValueType,pointValueType>::ScalarViewType;
-
-    using Basis<DeviceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
@@ -192,9 +199,9 @@ namespace Intrepid2 {
                                       this->getCardinality() );
 #endif
       Impl::Basis_HGRAD_WEDGE_C1_FEM::
-        getValues<DeviceType>( outputValues,
-                                  inputPoints,
-                                  operatorType );
+        getValues<ExecutionSpace>( outputValues,
+                                   inputPoints,
+                                   operatorType );
     }
 
     virtual

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_WEDGE_C1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_WEDGE_C1_FEMDef.hpp
@@ -153,7 +153,7 @@ namespace Intrepid2 {
       }
     }
 
-    template<typename DT,
+    template<typename SpT,
              typename outputValueValueType, class ...outputValueProperties,
              typename inputPointValueType,  class ...inputPointProperties>
     void
@@ -163,7 +163,7 @@ namespace Intrepid2 {
                const EOperator operatorType )  {
       typedef          Kokkos::DynRankView<outputValueValueType,outputValueProperties...>         outputValueViewType;
       typedef          Kokkos::DynRankView<inputPointValueType, inputPointProperties...>          inputPointViewType;
-      typedef typename ExecSpace<typename inputPointViewType::execution_space,typename DT::execution_space>::ExecSpaceType ExecSpaceType;
+      typedef typename ExecSpace<typename inputPointViewType::execution_space,SpT>::ExecSpaceType ExecSpaceType;
 
       // Number of evaluation points = dim 0 of inputPoints
       const auto loopSize = inputPoints.extent(0);

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_WEDGE_C2_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_WEDGE_C2_FEM.hpp
@@ -193,23 +193,31 @@ namespace Intrepid2 {
     };
   }
 
-  template<typename ExecSpaceType = void,
+  template<typename Device = void,
            typename outputValueType = double,
            typename pointValueType = double>
-  class Basis_HGRAD_WEDGE_C2_FEM : public Basis<ExecSpaceType,outputValueType,pointValueType> {
+  class Basis_HGRAD_WEDGE_C2_FEM : public Basis<Device,outputValueType,pointValueType> {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
-    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+    using BasisSuper = Basis<Device,outputValueType,pointValueType>;
+    
+    using OrdinalTypeArray1DHost = typename BasisSuper::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename BasisSuper::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename BasisSuper::OrdinalTypeArray3DHost;
+
+    using DeviceType      = typename BasisSuper::DeviceType;
+    using ExecutionSpace  = typename BasisSuper::ExecutionSpace;
+    using OutputValueType = typename BasisSuper::OutputValueType;
+    using PointValueType  = typename BasisSuper::PointValueType;
+
+    using OutputViewType = typename BasisSuper::OutputViewType;
+    using PointViewType  = typename BasisSuper::PointViewType;
+    using ScalarViewType = typename BasisSuper::ScalarViewType;
+    
+    using BasisSuper::getValues;
+    
     /** \brief  Constructor.
      */
     Basis_HGRAD_WEDGE_C2_FEM();
-
-    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
-    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
-    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
-
-    using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
@@ -225,9 +233,9 @@ namespace Intrepid2 {
                                       this->getCardinality() );
 #endif
       Impl::Basis_HGRAD_WEDGE_C2_FEM::
-        getValues<ExecSpaceType>( outputValues,
-                                  inputPoints,
-                                  operatorType );
+        getValues<ExecutionSpace>( outputValues,
+                                   inputPoints,
+                                   operatorType );
     }
 
     virtual

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_WEDGE_C2_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_WEDGE_C2_FEMDef.hpp
@@ -660,8 +660,8 @@ namespace Intrepid2 {
   }
   // -------------------------------------------------------------------------------------
 
-  template<typename SpT, typename OT, typename PT>
-  Basis_HGRAD_WEDGE_C2_FEM<SpT,OT,PT>::
+  template<typename DT, typename OT, typename PT>
+  Basis_HGRAD_WEDGE_C2_FEM<DT,OT,PT>::
   Basis_HGRAD_WEDGE_C2_FEM() {
     this->basisCardinality_  = 18;
     this->basisDegree_       = 2;
@@ -716,7 +716,7 @@ namespace Intrepid2 {
     }
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
       dofCoords("dofCoordsHost", this->basisCardinality_,this->basisCellTopology_.getDimension());
 
     dofCoords(0,0) =  0.0;  dofCoords(0,1) =  0.0;  dofCoords(0,2) = -1.0;
@@ -740,7 +740,7 @@ namespace Intrepid2 {
     dofCoords(16,0)=  0.5;  dofCoords(16,1)=  0.5;  dofCoords(16,2)=  0.0;
     dofCoords(17,0)=  0.0;  dofCoords(17,1)=  0.5;  dofCoords(17,2)=  0.0;
 
-    this->dofCoords_ = Kokkos::create_mirror_view(typename SpT::memory_space(), dofCoords);
+    this->dofCoords_ = Kokkos::create_mirror_view(typename DT::memory_space(), dofCoords);
     Kokkos::deep_copy(this->dofCoords_, dofCoords);
   }
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_HEX_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_HEX_Cn_FEM.hpp
@@ -164,26 +164,33 @@ namespace Intrepid2 {
       \endverbatim      
   */
 
-  template<typename ExecSpaceType = void,
+  template<typename Device = void,
            typename outputValueType = double,
            typename pointValueType = double>
   class Basis_HVOL_HEX_Cn_FEM
-    : public Basis<ExecSpaceType,outputValueType,pointValueType> {
+    : public Basis<Device,outputValueType,pointValueType> {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
-    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+    using BasisSuper = Basis<Device,outputValueType,pointValueType>;
+    
+    using OrdinalTypeArray1DHost = typename BasisSuper::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename BasisSuper::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename BasisSuper::OrdinalTypeArray3DHost;
+
+    using DeviceType      = typename BasisSuper::DeviceType;
+    using ExecutionSpace  = typename BasisSuper::ExecutionSpace;
+    using OutputValueType = typename BasisSuper::OutputValueType;
+    using PointValueType  = typename BasisSuper::PointValueType;
+
+    using OutputViewType = typename BasisSuper::OutputViewType;
+    using PointViewType  = typename BasisSuper::PointViewType;
+    using ScalarViewType = typename BasisSuper::ScalarViewType;
+    
+    using BasisSuper::getValues;
 
     /** \brief  Constructor.
      */
     Basis_HVOL_HEX_Cn_FEM(const ordinal_type order,
                             const EPointType   pointType = POINTTYPE_EQUISPACED);
-
-    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
-    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
-    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
-
-    using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
@@ -199,7 +206,7 @@ namespace Intrepid2 {
 #endif
       constexpr ordinal_type numPtsPerEval = Parameters::MaxNumPtsPerBasisEval;
       Impl::Basis_HVOL_HEX_Cn_FEM::
-        getValues<ExecSpaceType,numPtsPerEval>( outputValues,
+        getValues<ExecutionSpace,numPtsPerEval>( outputValues,
                                                 inputPoints,
                                                 this->vinv_,
                                                 operatorType );
@@ -252,7 +259,7 @@ namespace Intrepid2 {
   private:
 
     /** \brief inverse of Generalized Vandermonde matrix (isotropic order) */
-    Kokkos::DynRankView<typename ScalarViewType::value_type,ExecSpaceType> vinv_;
+    Kokkos::DynRankView<typename ScalarViewType::value_type,DeviceType> vinv_;
   };
 
 }// namespace Intrepid2

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_HEX_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_HEX_Cn_FEMDef.hpp
@@ -253,19 +253,19 @@ namespace Intrepid2 {
       }
       }
     }
-  }
+  } // namespace Impl
 
   // -------------------------------------------------------------------------------------
-  template<typename SpT, typename OT, typename PT>
-  Basis_HVOL_HEX_Cn_FEM<SpT,OT,PT>::
+  template<typename DT, typename OT, typename PT>
+  Basis_HVOL_HEX_Cn_FEM<DT,OT,PT>::
   Basis_HVOL_HEX_Cn_FEM( const ordinal_type order,
                           const EPointType   pointType ) {
 
     // this should be in host
-    Basis_HVOL_LINE_Cn_FEM<SpT,OT,PT> lineBasis( order, pointType );
+    Basis_HVOL_LINE_Cn_FEM<DT,OT,PT> lineBasis( order, pointType );
     const auto cardLine = lineBasis.getCardinality();
 
-    this->vinv_ = Kokkos::DynRankView<typename ScalarViewType::value_type,SpT>("HVOL::HEX::Cn::vinv", cardLine, cardLine);
+    this->vinv_ = Kokkos::DynRankView<typename ScalarViewType::value_type,DT>("HVOL::HEX::Cn::vinv", cardLine, cardLine);
     lineBasis.getVandermondeInverse(this->vinv_);
     
     this->basisCardinality_  = cardLine*cardLine*cardLine;
@@ -321,10 +321,10 @@ namespace Intrepid2 {
     }
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
       dofCoordsHost("dofCoordsHost", this->basisCardinality_, this->basisCellTopology_.getDimension());
 
-    Kokkos::DynRankView<typename ScalarViewType::value_type,SpT>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,DT>
       dofCoordsLine("dofCoordsLine", cardLine, 1);
 
     lineBasis.getDofCoords(dofCoordsLine);
@@ -344,7 +344,7 @@ namespace Intrepid2 {
 
     }
 
-    this->dofCoords_ = Kokkos::create_mirror_view(typename SpT::memory_space(), dofCoordsHost);
+    this->dofCoords_ = Kokkos::create_mirror_view(typename DT::memory_space(), dofCoordsHost);
     Kokkos::deep_copy(this->dofCoords_, dofCoordsHost);
   }
   

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_LINE_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_LINE_Cn_FEM.hpp
@@ -171,26 +171,33 @@ namespace Intrepid2 {
     };
   }
   
-  template<typename ExecSpaceType = void,
+  template<typename Device = void,
            typename outputValueType = double,
            typename pointValueType = double>
   class Basis_HVOL_LINE_Cn_FEM
-    : public Basis<ExecSpaceType,outputValueType,pointValueType> {
+    : public Basis<Device,outputValueType,pointValueType> {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
-    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+    using BasisSuper = Basis<Device,outputValueType,pointValueType>;
+    
+    using OrdinalTypeArray1DHost = typename BasisSuper::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename BasisSuper::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename BasisSuper::OrdinalTypeArray3DHost;
+
+    using DeviceType      = typename BasisSuper::DeviceType;
+    using ExecutionSpace  = typename BasisSuper::ExecutionSpace;
+    using OutputValueType = typename BasisSuper::OutputValueType;
+    using PointValueType  = typename BasisSuper::PointValueType;
+
+    using OutputViewType = typename BasisSuper::OutputViewType;
+    using PointViewType  = typename BasisSuper::PointViewType;
+    using ScalarViewType = typename BasisSuper::ScalarViewType;
+    
+    using BasisSuper::getValues;
 
     /** \brief  Constructor.
      */
     Basis_HVOL_LINE_Cn_FEM(const ordinal_type order,
                             const EPointType   pointType = POINTTYPE_EQUISPACED);  
-
-    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
-    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
-    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
-
-    using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
@@ -206,10 +213,10 @@ namespace Intrepid2 {
 #endif
       constexpr ordinal_type numPtsPerEval = 1;
       Impl::Basis_HVOL_LINE_Cn_FEM::
-        getValues<ExecSpaceType,numPtsPerEval>( outputValues,
-                                                inputPoints,
-                                                this->vinv_,
-                                                operatorType );
+        getValues<ExecutionSpace,numPtsPerEval>( outputValues,
+                                                 inputPoints,
+                                                 this->vinv_,
+                                                 operatorType );
     }
 
     virtual
@@ -259,7 +266,7 @@ namespace Intrepid2 {
 
     /** \brief inverse of Generalized Vandermonde matrix, whose columns store the expansion
                coefficients of the nodal basis in terms of phis_ */
-    Kokkos::DynRankView<typename ScalarViewType::value_type,ExecSpaceType> vinv_;
+    Kokkos::DynRankView<typename ScalarViewType::value_type,DeviceType> vinv_;
   };
 
 }// namespace Intrepid2

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_LINE_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_LINE_Cn_FEMDef.hpp
@@ -192,10 +192,10 @@ namespace Intrepid2 {
 
   // -------------------------------------------------------------------------------------
 
-  template<typename SpT, typename OT, typename PT>
-  Basis_HVOL_LINE_Cn_FEM<SpT,OT,PT>::
+  template<typename DT, typename OT, typename PT>
+  Basis_HVOL_LINE_Cn_FEM<DT,OT,PT>::
   Basis_HVOL_LINE_Cn_FEM( const ordinal_type order,
-                           const EPointType   pointType ) {
+                          const EPointType   pointType ) {
     this->basisCardinality_  = order+1;
     this->basisDegree_       = order;
     this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Line<2> >() );
@@ -206,7 +206,7 @@ namespace Intrepid2 {
     const ordinal_type card = this->basisCardinality_;
     
     // points are computed in the host and will be copied 
-    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
       dofCoords("HVOL::Line::Cn::dofCoords", card, 1);
 
     //Default is Equispaced
@@ -252,7 +252,7 @@ namespace Intrepid2 {
     }
     }
 
-    this->dofCoords_ = Kokkos::create_mirror_view(typename SpT::memory_space(), dofCoords);
+    this->dofCoords_ = Kokkos::create_mirror_view(typename DT::memory_space(), dofCoords);
     Kokkos::deep_copy(this->dofCoords_, dofCoords);
     
     // form Vandermonde matrix; actually, this is the transpose of the VDM,
@@ -291,14 +291,14 @@ namespace Intrepid2 {
                                   ">>> ERROR: (Intrepid2::Basis_HVOL_LINE_Cn_FEM) lapack.GETRI returns nonzero info." );
     
     // create host mirror 
-    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
       vinv("HVOL::Line::Cn::vinv", card, card);
 
     for (ordinal_type i=0;i<card;++i) 
       for (ordinal_type j=0;j<card;++j) 
         vinv(i,j) = vmat(j,i);
 
-    this->vinv_ = Kokkos::create_mirror_view(typename SpT::memory_space(), vinv);
+    this->vinv_ = Kokkos::create_mirror_view(typename DT::memory_space(), vinv);
     Kokkos::deep_copy(this->vinv_ , vinv);
 
     // initialize tags

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_QUAD_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_QUAD_Cn_FEM.hpp
@@ -159,26 +159,33 @@ namespace Intrepid2 {
               a tensor product of points.
               The degrees of freedom are point evaluation at points in the interior of the Quadrilateral.
   */
-  template<typename ExecSpaceType = void,
+  template<typename Device = void,
            typename outputValueType = double,
            typename pointValueType = double>
   class Basis_HVOL_QUAD_Cn_FEM
-    : public Basis<ExecSpaceType,outputValueType,pointValueType> {
+    : public Basis<Device,outputValueType,pointValueType> {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
-    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+    using BasisSuper = Basis<Device,outputValueType,pointValueType>;
+    
+    using OrdinalTypeArray1DHost = typename BasisSuper::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename BasisSuper::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename BasisSuper::OrdinalTypeArray3DHost;
+
+    using DeviceType      = typename BasisSuper::DeviceType;
+    using ExecutionSpace  = typename BasisSuper::ExecutionSpace;
+    using OutputValueType = typename BasisSuper::OutputValueType;
+    using PointValueType  = typename BasisSuper::PointValueType;
+
+    using OutputViewType = typename BasisSuper::OutputViewType;
+    using PointViewType  = typename BasisSuper::PointViewType;
+    using ScalarViewType = typename BasisSuper::ScalarViewType;
+    
+    using BasisSuper::getValues;
 
     /** \brief  Constructor.
      */
     Basis_HVOL_QUAD_Cn_FEM(const ordinal_type order,
                             const EPointType   pointType = POINTTYPE_EQUISPACED);
-
-    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
-    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
-    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
-
-    using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
@@ -194,10 +201,10 @@ namespace Intrepid2 {
 #endif
       constexpr ordinal_type numPtsPerEval = Parameters::MaxNumPtsPerBasisEval;
       Impl::Basis_HVOL_QUAD_Cn_FEM::
-        getValues<ExecSpaceType,numPtsPerEval>( outputValues,
-                                                inputPoints,
-                                                this->vinv_,
-                                                operatorType );
+        getValues<ExecutionSpace,numPtsPerEval>( outputValues,
+                                                 inputPoints,
+                                                 this->vinv_,
+                                                 operatorType );
     }
 
     virtual
@@ -246,7 +253,7 @@ namespace Intrepid2 {
   private:
 
     /** \brief inverse of Generalized Vandermonde matrix (isotropic order) */
-    Kokkos::DynRankView<typename ScalarViewType::value_type,ExecSpaceType> vinv_;
+    Kokkos::DynRankView<typename ScalarViewType::value_type,DeviceType> vinv_;
   };
 
 }// namespace Intrepid2

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_QUAD_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_QUAD_Cn_FEMDef.hpp
@@ -226,8 +226,8 @@ namespace Intrepid2 {
   }
 
   // -------------------------------------------------------------------------------------
-  template<typename SpT, typename OT, typename PT>
-  Basis_HVOL_QUAD_Cn_FEM<SpT,OT,PT>::
+  template<typename DT, typename OT, typename PT>
+  Basis_HVOL_QUAD_Cn_FEM<DT,OT,PT>::
   Basis_HVOL_QUAD_Cn_FEM( const ordinal_type order,
                            const EPointType   pointType ) {
     // INTREPID2_TEST_FOR_EXCEPTION( !(pointType == POINTTYPE_EQUISPACED ||
@@ -235,10 +235,10 @@ namespace Intrepid2 {
     //                               ">>> ERROR (Basis_HVOL_QUAD_Cn_FEM): pointType must be either equispaced or warpblend." );
 
     // this should be in host
-    Basis_HVOL_LINE_Cn_FEM<SpT,OT,PT> lineBasis( order, pointType );
+    Basis_HVOL_LINE_Cn_FEM<DT,OT,PT> lineBasis( order, pointType );
     const auto cardLine = lineBasis.getCardinality();
     
-    this->vinv_ = Kokkos::DynRankView<typename ScalarViewType::value_type,SpT>("HVOL::Quad::Cn::vinv", cardLine, cardLine);
+    this->vinv_ = Kokkos::DynRankView<typename ScalarViewType::value_type,DT>("HVOL::Quad::Cn::vinv", cardLine, cardLine);
     lineBasis.getVandermondeInverse(this->vinv_);
 
     this->basisCardinality_  = cardLine*cardLine;
@@ -291,10 +291,10 @@ namespace Intrepid2 {
     }
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
       dofCoordsHost("dofCoordsHost", this->basisCardinality_, this->basisCellTopology_.getDimension());
 
-    Kokkos::DynRankView<typename ScalarViewType::value_type,SpT>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,DT>
       dofCoordsLine("dofCoordsLine", cardLine, 1);
 
     lineBasis.getDofCoords(dofCoordsLine);
@@ -310,7 +310,7 @@ namespace Intrepid2 {
       }
     }
 
-    this->dofCoords_ = Kokkos::create_mirror_view(typename SpT::memory_space(), dofCoordsHost);
+    this->dofCoords_ = Kokkos::create_mirror_view(typename DT::memory_space(), dofCoordsHost);
     Kokkos::deep_copy(this->dofCoords_, dofCoordsHost);
   }
   

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TET_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TET_Cn_FEM.hpp
@@ -183,29 +183,34 @@ namespace Intrepid2 {
     };
   }
   
-    template<typename ExecSpaceType = void,
+    template<typename Device = void,
            typename outputValueType = double,
            typename pointValueType = double>
   class Basis_HVOL_TET_Cn_FEM
-    : public Basis<ExecSpaceType,outputValueType,pointValueType> {
+    : public Basis<Device,outputValueType,pointValueType> {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
-    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+    using BasisSuper = Basis<Device,outputValueType,pointValueType>;
+    
+    using OrdinalTypeArray1DHost = typename BasisSuper::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename BasisSuper::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename BasisSuper::OrdinalTypeArray3DHost;
 
+    using DeviceType      = typename BasisSuper::DeviceType;
+    using ExecutionSpace  = typename BasisSuper::ExecutionSpace;
+    using OutputValueType = typename BasisSuper::OutputValueType;
+    using PointValueType  = typename BasisSuper::PointValueType;
+
+    using OutputViewType = typename BasisSuper::OutputViewType;
+    using PointViewType  = typename BasisSuper::PointViewType;
+    using ScalarViewType = typename BasisSuper::ScalarViewType;
+    
+    using BasisSuper::getValues;
+    using scalarType = typename BasisSuper::scalarType;
+      
     /** \brief  Constructor.
      */
     Basis_HVOL_TET_Cn_FEM(const ordinal_type order,
                            const EPointType   pointType = POINTTYPE_EQUISPACED);
-
-
-    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
-    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
-    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
-
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarType  scalarType;
-
-    using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
@@ -221,10 +226,10 @@ namespace Intrepid2 {
 #endif
       constexpr ordinal_type numPtsPerEval = Parameters::MaxNumPtsPerBasisEval;
       Impl::Basis_HVOL_TET_Cn_FEM::
-        getValues<ExecSpaceType,numPtsPerEval>( outputValues,
-                                                inputPoints,
-                                                this->vinv_,
-                                                operatorType);
+        getValues<ExecutionSpace,numPtsPerEval>( outputValues,
+                                                 inputPoints,
+                                                 this->vinv_,
+                                                 operatorType);
     }
 
     virtual
@@ -280,7 +285,7 @@ namespace Intrepid2 {
 
     /** \brief inverse of Generalized Vandermonde matrix, whose columns store the expansion
         coefficients of the nodal basis in terms of phis_ */
-    Kokkos::DynRankView<scalarType,ExecSpaceType> vinv_;
+    Kokkos::DynRankView<scalarType,DeviceType> vinv_;
 
   };
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TET_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TET_Cn_FEMDef.hpp
@@ -223,11 +223,11 @@ namespace Intrepid2 {
       }
       }
     }
-  }
+  } // namespace Impl
   
   // -------------------------------------------------------------------------------------
-  template<typename SpT, typename OT, typename PT>
-  Basis_HVOL_TET_Cn_FEM<SpT,OT,PT>::
+  template<typename DT, typename OT, typename PT>
+  Basis_HVOL_TET_Cn_FEM<DT,OT,PT>::
   Basis_HVOL_TET_Cn_FEM( const ordinal_type order,
                           const EPointType   pointType ) {
     constexpr ordinal_type spaceDim = 3;
@@ -242,7 +242,7 @@ namespace Intrepid2 {
     const ordinal_type card = this->basisCardinality_;
 
     // points are computed in the host and will be copied
-    Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
       dofCoords("HVOL::Tet::Cn::dofCoords", card, spaceDim);
     
     // construct lattice (only internal nodes for HVOL element)
@@ -252,7 +252,7 @@ namespace Intrepid2 {
                             order+spaceDim+offset, offset,
                             pointType );
     
-    this->dofCoords_ = Kokkos::create_mirror_view(typename SpT::memory_space(), dofCoords);
+    this->dofCoords_ = Kokkos::create_mirror_view(typename DT::memory_space(), dofCoords);
     Kokkos::deep_copy(this->dofCoords_, dofCoords);
 
     // form Vandermonde matrix.  Actually, this is the transpose of the VDM,
@@ -288,14 +288,14 @@ namespace Intrepid2 {
                                   ">>> ERROR: (Intrepid2::Basis_HVOL_TET_Cn_FEM) lapack.GETRI returns nonzero info." );
 
     // create host mirror
-    Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
       vinv("HVOL::Line::Cn::vinv", card, card);
 
     for (ordinal_type i=0;i<card;++i)
       for (ordinal_type j=0;j<card;++j)
         vinv(i,j) = vmat(j,i);
 
-    this->vinv_ = Kokkos::create_mirror_view(typename SpT::memory_space(), vinv);
+    this->vinv_ = Kokkos::create_mirror_view(typename DT::memory_space(), vinv);
     Kokkos::deep_copy(this->vinv_ , vinv);
 
     // initialize tags

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TRI_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TRI_Cn_FEM.hpp
@@ -178,29 +178,36 @@ namespace Intrepid2 {
     };
   }
 
-  template<typename ExecSpaceType = void,
+  template<typename Device = void,
            typename outputValueType = double,
            typename pointValueType = double>
   class Basis_HVOL_TRI_Cn_FEM
-    : public Basis<ExecSpaceType,outputValueType,pointValueType> {
+    : public Basis<Device,outputValueType,pointValueType> {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
-    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+    using BasisSuper = Basis<Device,outputValueType,pointValueType>;
+    
+    using OrdinalTypeArray1DHost = typename BasisSuper::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename BasisSuper::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename BasisSuper::OrdinalTypeArray3DHost;
+
+    using DeviceType      = typename BasisSuper::DeviceType;
+    using ExecutionSpace  = typename BasisSuper::ExecutionSpace;
+    using OutputValueType = typename BasisSuper::OutputValueType;
+    using PointValueType  = typename BasisSuper::PointValueType;
+
+    using OutputViewType = typename BasisSuper::OutputViewType;
+    using PointViewType  = typename BasisSuper::PointViewType;
+    using ScalarViewType = typename BasisSuper::ScalarViewType;
+    
+    using BasisSuper::getValues;
 
     /** \brief  Constructor.
      */
     Basis_HVOL_TRI_Cn_FEM(const ordinal_type order,
-                           const EPointType   pointType = POINTTYPE_EQUISPACED);
+                          const EPointType   pointType = POINTTYPE_EQUISPACED);
 
 
-    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
-    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
-    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
-
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarType  scalarType;
-
-    using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
+    typedef typename BasisSuper::scalarType  scalarType;
 
     virtual
     void
@@ -216,10 +223,10 @@ namespace Intrepid2 {
 #endif
       constexpr ordinal_type numPtsPerEval = Parameters::MaxNumPtsPerBasisEval;
       Impl::Basis_HVOL_TRI_Cn_FEM::
-        getValues<ExecSpaceType,numPtsPerEval>( outputValues,
-                                                inputPoints,
-                                                this->vinv_,
-                                                operatorType);
+        getValues<ExecutionSpace,numPtsPerEval>( outputValues,
+                                                 inputPoints,
+                                                 this->vinv_,
+                                                 operatorType);
     }
 
     virtual
@@ -275,7 +282,7 @@ namespace Intrepid2 {
 
     /** \brief inverse of Generalized Vandermonde matrix, whose columns store the expansion
         coefficients of the nodal basis in terms of phis_ */
-    Kokkos::DynRankView<scalarType,ExecSpaceType> vinv_;
+    Kokkos::DynRankView<scalarType,DeviceType> vinv_;
 
   };
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TRI_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TRI_Cn_FEMDef.hpp
@@ -219,8 +219,8 @@ getValues(       Kokkos::DynRankView<outputValueValueType,outputValueProperties.
 }
 
 // -------------------------------------------------------------------------------------
-template<typename SpT, typename OT, typename PT>
-Basis_HVOL_TRI_Cn_FEM<SpT,OT,PT>::
+template<typename DT, typename OT, typename PT>
+Basis_HVOL_TRI_Cn_FEM<DT,OT,PT>::
 Basis_HVOL_TRI_Cn_FEM( const ordinal_type order,
     const EPointType   pointType ) {
 
@@ -236,7 +236,7 @@ Basis_HVOL_TRI_Cn_FEM( const ordinal_type order,
   const ordinal_type card = this->basisCardinality_;
 
   // points are computed in the host and will be copied
-  Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace>
+  Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
   dofCoords("HVOL::Tri::Cn::dofCoords", card, spaceDim);
 
   // construct lattice (only internal nodes for HVOL element)
@@ -246,7 +246,7 @@ Basis_HVOL_TRI_Cn_FEM( const ordinal_type order,
       order+spaceDim+offset, offset,
       pointType );
 
-  this->dofCoords_ = Kokkos::create_mirror_view(typename SpT::memory_space(), dofCoords);
+  this->dofCoords_ = Kokkos::create_mirror_view(typename DT::memory_space(), dofCoords);
   Kokkos::deep_copy(this->dofCoords_, dofCoords);
 
   // form Vandermonde matrix.  Actually, this is the transpose of the VDM,
@@ -282,14 +282,14 @@ Basis_HVOL_TRI_Cn_FEM( const ordinal_type order,
       ">>> ERROR: (Intrepid2::Basis_HVOL_TRI_Cn_FEM) lapack.GETRI returns nonzero info." );
 
   // create host mirror
-  Kokkos::DynRankView<scalarType,typename SpT::array_layout,Kokkos::HostSpace>
+  Kokkos::DynRankView<scalarType,typename ExecutionSpace::array_layout,Kokkos::HostSpace>
   vinv("HVOL::Line::Cn::vinv", card, card);
 
   for (ordinal_type i=0;i<card;++i)
     for (ordinal_type j=0;j<card;++j)
       vinv(i,j) = vmat(j,i);
 
-  this->vinv_ = Kokkos::create_mirror_view(typename SpT::memory_space(), vinv);
+  this->vinv_ = Kokkos::create_mirror_view(typename DT::memory_space(), vinv);
   Kokkos::deep_copy(this->vinv_ , vinv);
 
   // initialize tags

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HierarchicalBasisFamily.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HierarchicalBasisFamily.hpp
@@ -60,16 +60,16 @@ namespace Intrepid2 {
   
 
 //Dummy basis to be temporarily used for Hierarchical bases that have not been implemented yet
-  template<typename ExecutionSpace, typename OutputScalar, typename PointScalar>
+  template<typename DeviceType, typename OutputScalar, typename PointScalar>
   class dummyBasis
-  : public Basis<ExecutionSpace,OutputScalar,PointScalar> {
+  : public Basis<DeviceType,OutputScalar,PointScalar> {
   public:
     dummyBasis(int /*order*/, EPointType /*pointType*/= POINTTYPE_DEFAULT) {};
   };
 
 // the following defines a family of hierarchical basis functions that matches the unpermuted ESEAS basis functions
 // each basis member is associated with appropriate subcell topologies, making this suitable for continuous Galerkin finite elements.
-  template<typename ExecutionSpace=Kokkos::DefaultExecutionSpace,
+  template<typename DeviceType = typename Kokkos::DefaultExecutionSpace::device_type,
            typename OutputScalar = double,
            typename PointScalar  = double,
            bool defineVertexFunctions = true>
@@ -77,24 +77,24 @@ namespace Intrepid2 {
   {
   public:
     // we will fill these in as we implement them
-    using HGRAD = IntegratedLegendreBasis_HGRAD_TRI<ExecutionSpace,OutputScalar,PointScalar,defineVertexFunctions>;
-    using HCURL = dummyBasis<ExecutionSpace,OutputScalar,PointScalar>;
-    using HDIV  = dummyBasis<ExecutionSpace,OutputScalar,PointScalar>;
-    using HVOL  = dummyBasis<ExecutionSpace,OutputScalar,PointScalar>;
+    using HGRAD = IntegratedLegendreBasis_HGRAD_TRI<DeviceType,OutputScalar,PointScalar,defineVertexFunctions>;
+    using HCURL = dummyBasis<DeviceType,OutputScalar,PointScalar>;
+    using HDIV  = dummyBasis<DeviceType,OutputScalar,PointScalar>;
+    using HVOL  = dummyBasis<DeviceType,OutputScalar,PointScalar>;
   };
   
-  template<typename ExecutionSpace=Kokkos::DefaultExecutionSpace,
-  typename OutputScalar = double,
-  typename PointScalar  = double,
-  bool defineVertexFunctions = true>
+  template<typename DeviceType = typename Kokkos::DefaultExecutionSpace::device_type,
+           typename OutputScalar = double,
+           typename PointScalar  = double,
+           bool defineVertexFunctions = true>
   class HierarchicalTetrahedronBasisFamily
   {
   public:
     // we will fill these in as we implement them
-    using HGRAD = IntegratedLegendreBasis_HGRAD_TET<ExecutionSpace,OutputScalar,PointScalar,defineVertexFunctions>;
-    using HCURL = dummyBasis<ExecutionSpace,OutputScalar,PointScalar>;
-    using HDIV  = dummyBasis<ExecutionSpace,OutputScalar,PointScalar>;
-    using HVOL  = dummyBasis<ExecutionSpace,OutputScalar,PointScalar>;
+    using HGRAD = IntegratedLegendreBasis_HGRAD_TET<DeviceType,OutputScalar,PointScalar,defineVertexFunctions>;
+    using HCURL = dummyBasis<DeviceType,OutputScalar,PointScalar>;
+    using HDIV  = dummyBasis<DeviceType,OutputScalar,PointScalar>;
+    using HVOL  = dummyBasis<DeviceType,OutputScalar,PointScalar>;
   };
   
   /** \class Intrepid2::HierarchicalBasisFamily
@@ -117,13 +117,13 @@ namespace Intrepid2 {
    We have offline tests that verify agreement between our implementation and ESEAS.  We hope to add these to the
    Trilinos continuous integration tests in the future.
   */
-  template<typename ExecutionSpace=Kokkos::DefaultExecutionSpace,
+  template<typename DeviceType = typename Kokkos::DefaultExecutionSpace::device_type,
            typename OutputScalar = double,
            typename PointScalar  = double>
-  using HierarchicalBasisFamily = DerivedBasisFamily< IntegratedLegendreBasis_HGRAD_LINE<ExecutionSpace,OutputScalar,PointScalar,true>,
-                                                      LegendreBasis_HVOL_LINE<ExecutionSpace,OutputScalar,PointScalar>,
-                                                      HierarchicalTriangleBasisFamily<ExecutionSpace,OutputScalar,PointScalar>,
-                                                      HierarchicalTetrahedronBasisFamily<ExecutionSpace,OutputScalar,PointScalar>
+  using HierarchicalBasisFamily = DerivedBasisFamily< IntegratedLegendreBasis_HGRAD_LINE<DeviceType,OutputScalar,PointScalar,true>,
+                                                      LegendreBasis_HVOL_LINE<DeviceType,OutputScalar,PointScalar>,
+                                                      HierarchicalTriangleBasisFamily<DeviceType,OutputScalar,PointScalar>,
+                                                      HierarchicalTetrahedronBasisFamily<DeviceType,OutputScalar,PointScalar>
                                                       >;
   
   /** \class Intrepid2::HierarchicalBasisFamily
@@ -134,13 +134,13 @@ namespace Intrepid2 {
    The suitability of this family for DG contexts is primarily due to the fact that the H(grad) basis has a constant member.  Note also that in this family,
    all members are associated with the cell interior; there are no basis functions associated with subcell topologies.
   */
-  template<typename ExecutionSpace=Kokkos::DefaultExecutionSpace,
+  template<typename DeviceType = typename Kokkos::DefaultExecutionSpace::device_type,
            typename OutputScalar = double,
            typename PointScalar  = double>
-  using DGHierarchicalBasisFamily = DerivedBasisFamily< IntegratedLegendreBasis_HGRAD_LINE<ExecutionSpace,OutputScalar,PointScalar,false>,
-                                                        LegendreBasis_HVOL_LINE<ExecutionSpace,OutputScalar,PointScalar>,
-                                                        HierarchicalTriangleBasisFamily<ExecutionSpace,OutputScalar,PointScalar,false>,
-                                                        HierarchicalTetrahedronBasisFamily<ExecutionSpace,OutputScalar,PointScalar,false>
+  using DGHierarchicalBasisFamily = DerivedBasisFamily< IntegratedLegendreBasis_HGRAD_LINE<DeviceType,OutputScalar,PointScalar,false>,
+                                                        LegendreBasis_HVOL_LINE<DeviceType,OutputScalar,PointScalar>,
+                                                        HierarchicalTriangleBasisFamily<DeviceType,OutputScalar,PointScalar,false>,
+                                                        HierarchicalTetrahedronBasisFamily<DeviceType,OutputScalar,PointScalar,false>
                                                       >;
   
 }

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_IntegratedLegendreBasis_HGRAD_LINE.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_IntegratedLegendreBasis_HGRAD_LINE.hpp
@@ -227,21 +227,25 @@ namespace Intrepid2
                is true, then the first basis function will instead be 1.0-x, and the basis will be suitable for
                continuous discretizations.
   */
-  template<typename ExecutionSpace=Kokkos::DefaultExecutionSpace,
+  template<typename DeviceType = typename Kokkos::DefaultExecutionSpace::device_type,
            typename OutputScalar = double,
            typename PointScalar  = double,
            bool defineVertexFunctions = true,            // if defineVertexFunctions is true, first and second basis functions are x and 1-x.  Otherwise, they are 1 and x.
            bool useMinusOneToOneReferenceElement = true> // if useMinusOneToOneReferenceElement is true, basis is define on [-1,1].  Otherwise, [0,1].
   class IntegratedLegendreBasis_HGRAD_LINE
-  : public Basis<ExecutionSpace,OutputScalar,PointScalar>
+  : public Basis<DeviceType,OutputScalar,PointScalar>
   {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<ExecutionSpace,OutputScalar,PointScalar>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<ExecutionSpace,OutputScalar,PointScalar>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray1DHost = typename Basis<DeviceType,OutputScalar,PointScalar>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<DeviceType,OutputScalar,PointScalar>::OrdinalTypeArray2DHost;
     
-    using OutputViewType = typename Basis<ExecutionSpace,OutputScalar,PointScalar>::OutputViewType;
-    using PointViewType  = typename Basis<ExecutionSpace,OutputScalar,PointScalar>::PointViewType ;
-    using ScalarViewType = typename Basis<ExecutionSpace,OutputScalar,PointScalar>::ScalarViewType;
+    using ExecutionSpace = typename Basis<DeviceType,OutputScalar,PointScalar>::ExecutionSpace;
+    using OutputValueType = typename Basis<DeviceType,OutputScalar,PointScalar>::OutputValueType;
+    using PointValueType = typename Basis<DeviceType,OutputScalar,PointScalar>::PointValueType;
+    
+    using OutputViewType = typename Basis<DeviceType,OutputScalar,PointScalar>::OutputViewType;
+    using PointViewType  = typename Basis<DeviceType,OutputScalar,PointScalar>::PointViewType ;
+    using ScalarViewType = typename Basis<DeviceType,OutputScalar,PointScalar>::ScalarViewType;
   protected:
     int polyOrder_; // the maximum order of the polynomial
     bool defineVertexFunctions_; // if true, first and second basis functions are x and 1-x.  Otherwise, they are 1 and x.
@@ -357,7 +361,7 @@ namespace Intrepid2
     // since the getValues() below only overrides the FEM variant, we specify that
     // we use the base class's getValues(), which implements the FVD variant by throwing an exception.
     // (It's an error to use the FVD variant on this basis.)
-    using Basis<ExecutionSpace,OutputScalar,PointScalar>::getValues;
+    using Basis<DeviceType,OutputScalar,PointScalar>::getValues;
     
     /** \brief  Evaluation of a FEM basis on a <strong>reference cell</strong>.
 
@@ -382,6 +386,7 @@ namespace Intrepid2
     {
       auto numPoints = inputPoints.extent_int(0);
       
+      using ExecutionSpace = typename DeviceType::execution_space;
       using FunctorType = Hierarchical_HGRAD_LINE_Functor<ExecutionSpace, OutputScalar, PointScalar, OutputViewType, PointViewType>;
       
       FunctorType functor(operatorType, outputValues, inputPoints, polyOrder_, defineVertexFunctions);

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_IntegratedLegendreBasis_HGRAD_TET.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_IntegratedLegendreBasis_HGRAD_TET.hpp
@@ -602,20 +602,28 @@ namespace Intrepid2
                is true, then the first basis function will instead be 1.0-x-y, and the basis will be suitable for
                continuous discretizations.
   */
-  template<typename ExecutionSpace=Kokkos::DefaultExecutionSpace,
+  template<typename Device = typename Kokkos::DefaultExecutionSpace::device_type,
            typename OutputScalar = double,
            typename PointScalar  = double,
            bool defineVertexFunctions = true>  // if defineVertexFunctions is true, first four basis functions are 1-x-y-z, x, y, and z.  Otherwise, they are 1, x, y, and z.
   class IntegratedLegendreBasis_HGRAD_TET
-  : public Basis<ExecutionSpace,OutputScalar,PointScalar>
+  : public Basis<Device,OutputScalar,PointScalar>
   {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<ExecutionSpace,OutputScalar,PointScalar>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<ExecutionSpace,OutputScalar,PointScalar>::OrdinalTypeArray2DHost;
+    using BasisSuper = Basis<Device,OutputScalar,PointScalar>;
     
-    using OutputViewType = typename Basis<ExecutionSpace,OutputScalar,PointScalar>::OutputViewType;
-    using PointViewType  = typename Basis<ExecutionSpace,OutputScalar,PointScalar>::PointViewType;
-    using ScalarViewType = typename Basis<ExecutionSpace,OutputScalar,PointScalar>::ScalarViewType;
+    using OrdinalTypeArray1DHost = typename BasisSuper::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename BasisSuper::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename BasisSuper::OrdinalTypeArray3DHost;
+
+    using DeviceType      = typename BasisSuper::DeviceType;
+    using ExecutionSpace  = typename BasisSuper::ExecutionSpace;
+    using OutputValueType = typename BasisSuper::OutputValueType;
+    using PointValueType  = typename BasisSuper::PointValueType;
+
+    using OutputViewType = typename BasisSuper::OutputViewType;
+    using PointViewType  = typename BasisSuper::PointViewType;
+    using ScalarViewType = typename BasisSuper::ScalarViewType;
   protected:
     int polyOrder_; // the maximum order of the polynomial
   public:
@@ -819,7 +827,7 @@ namespace Intrepid2
     // since the getValues() below only overrides the FEM variant, we specify that
     // we use the base class's getValues(), which implements the FVD variant by throwing an exception.
     // (It's an error to use the FVD variant on this basis.)
-    using Basis<ExecutionSpace,OutputScalar,PointScalar>::getValues;
+    using Basis<DeviceType,OutputScalar,PointScalar>::getValues;
     
     /** \brief  Evaluation of a FEM basis on a <strong>reference cell</strong>.
 
@@ -865,15 +873,15 @@ namespace Intrepid2
         \param [in] subCellOrd - position of the subCell among of the subCells having the same dimension
         \return pointer to the subCell basis of dimension subCellDim and position subCellOrd
      */
-    BasisPtr<ExecutionSpace,OutputScalar,PointScalar>
+    BasisPtr<DeviceType,OutputScalar,PointScalar>
     getSubCellRefBasis(const ordinal_type subCellDim, const ordinal_type subCellOrd) const override{
       if(subCellDim == 1) {
         return Teuchos::rcp(new
-            IntegratedLegendreBasis_HGRAD_LINE<ExecutionSpace,OutputScalar,PointScalar>
+            IntegratedLegendreBasis_HGRAD_LINE<DeviceType,OutputScalar,PointScalar>
             (this->basisDegree_));
       } else if(subCellDim == 2) {
         return Teuchos::rcp(new
-            IntegratedLegendreBasis_HGRAD_TRI<ExecutionSpace,OutputScalar,PointScalar>
+            IntegratedLegendreBasis_HGRAD_TRI<DeviceType,OutputScalar,PointScalar>
             (this->basisDegree_));
       }
       INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_IntegratedLegendreBasis_HGRAD_TRI.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_IntegratedLegendreBasis_HGRAD_TRI.hpp
@@ -357,20 +357,28 @@ namespace Intrepid2
                is true, then the first basis function will instead be 1.0-x-y, and the basis will be suitable for
                continuous discretizations.
   */
-  template<typename ExecutionSpace=Kokkos::DefaultExecutionSpace,
+  template<typename Device=typename Kokkos::DefaultExecutionSpace::device_type,
            typename OutputScalar = double,
            typename PointScalar  = double,
            bool defineVertexFunctions = true>            // if defineVertexFunctions is true, first three basis functions are 1-x-y, x, and y.  Otherwise, they are 1, x, and y.
   class IntegratedLegendreBasis_HGRAD_TRI
-  : public Basis<ExecutionSpace,OutputScalar,PointScalar>
+  : public Basis<Device,OutputScalar,PointScalar>
   {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<ExecutionSpace,OutputScalar,PointScalar>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<ExecutionSpace,OutputScalar,PointScalar>::OrdinalTypeArray2DHost;
+    using BasisSuper = Basis<Device,OutputScalar,PointScalar>;
     
-    using OutputViewType = typename Basis<ExecutionSpace,OutputScalar,PointScalar>::OutputViewType;
-    using PointViewType  = typename Basis<ExecutionSpace,OutputScalar,PointScalar>::PointViewType;
-    using ScalarViewType = typename Basis<ExecutionSpace,OutputScalar,PointScalar>::ScalarViewType;
+    using OrdinalTypeArray1DHost = typename BasisSuper::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename BasisSuper::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename BasisSuper::OrdinalTypeArray3DHost;
+
+    using DeviceType      = typename BasisSuper::DeviceType;
+    using ExecutionSpace  = typename BasisSuper::ExecutionSpace;
+    using OutputValueType = typename BasisSuper::OutputValueType;
+    using PointValueType  = typename BasisSuper::PointValueType;
+
+    using OutputViewType = typename BasisSuper::OutputViewType;
+    using PointViewType  = typename BasisSuper::PointViewType;
+    using ScalarViewType = typename BasisSuper::ScalarViewType;
   protected:
     int polyOrder_; // the maximum order of the polynomial
   public:
@@ -532,7 +540,7 @@ namespace Intrepid2
     // since the getValues() below only overrides the FEM variant, we specify that
     // we use the base class's getValues(), which implements the FVD variant by throwing an exception.
     // (It's an error to use the FVD variant on this basis.)
-    using Basis<ExecutionSpace,OutputScalar,PointScalar>::getValues;
+    using Basis<DeviceType,OutputScalar,PointScalar>::getValues;
     
     /** \brief  Evaluation of a FEM basis on a <strong>reference cell</strong>.
 
@@ -578,11 +586,11 @@ namespace Intrepid2
         \param [in] subCellOrd - position of the subCell among of the subCells having the same dimension
         \return pointer to the subCell basis of dimension subCellDim and position subCellOrd
      */
-    BasisPtr<ExecutionSpace,OutputScalar,PointScalar>
+    BasisPtr<DeviceType,OutputScalar,PointScalar>
       getSubCellRefBasis(const ordinal_type subCellDim, const ordinal_type subCellOrd) const override{
       if(subCellDim == 1) {
         return Teuchos::rcp(new
-            IntegratedLegendreBasis_HGRAD_LINE<ExecutionSpace,OutputScalar,PointScalar>
+            IntegratedLegendreBasis_HGRAD_LINE<DeviceType,OutputScalar,PointScalar>
                     (this->basisDegree_));
       }
       INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_LegendreBasis_HVOL_LINE.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_LegendreBasis_HVOL_LINE.hpp
@@ -177,19 +177,19 @@ namespace Intrepid2
                Computers & Mathematics with Applications, Volume 70, Issue 4, 2015, Pages 353-458, ISSN 0898-1221.
                https://doi.org/10.1016/j.camwa.2015.04.027.
   */
-  template<typename ExecutionSpace=Kokkos::DefaultExecutionSpace,
+  template<typename DeviceType = typename Kokkos::DefaultExecutionSpace::device_type,
            typename OutputScalar = double,
            typename PointScalar  = double>
   class LegendreBasis_HVOL_LINE
-  : public Basis<ExecutionSpace,OutputScalar,PointScalar>
+  : public Basis<DeviceType,OutputScalar,PointScalar>
   {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<ExecutionSpace,OutputScalar,PointScalar>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<ExecutionSpace,OutputScalar,PointScalar>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray1DHost = typename Basis<DeviceType,OutputScalar,PointScalar>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<DeviceType,OutputScalar,PointScalar>::OrdinalTypeArray2DHost;
     
-    typedef typename Basis<ExecutionSpace,OutputScalar,PointScalar>::OutputViewType OutputViewType;
-    typedef typename Basis<ExecutionSpace,OutputScalar,PointScalar>::PointViewType  PointViewType;
-    typedef typename Basis<ExecutionSpace,OutputScalar,PointScalar>::ScalarViewType ScalarViewType;
+    typedef typename Basis<DeviceType,OutputScalar,PointScalar>::OutputViewType OutputViewType;
+    typedef typename Basis<DeviceType,OutputScalar,PointScalar>::PointViewType  PointViewType;
+    typedef typename Basis<DeviceType,OutputScalar,PointScalar>::ScalarViewType ScalarViewType;
   protected:
     int polyOrder_; // the maximum order of the polynomial
   public:
@@ -257,7 +257,7 @@ namespace Intrepid2
     // since the getValues() below only overrides the FEM variant, we specify that
     // we use the base class's getValues(), which implements the FVD variant by throwing an exception.
     // (It's an error to use the FVD variant on this basis.)
-    using Basis<ExecutionSpace,OutputScalar,PointScalar>::getValues;
+    using Basis<DeviceType,OutputScalar,PointScalar>::getValues;
     
     /** \brief  Returns basis name
      
@@ -292,6 +292,7 @@ namespace Intrepid2
     {
       auto numPoints = inputPoints.extent_int(0);
       
+      using ExecutionSpace = typename DeviceType::execution_space;
       using FunctorType = Hierarchical_HVOL_LINE_Functor<ExecutionSpace, OutputScalar, PointScalar, OutputViewType, PointViewType>;
       
       FunctorType functor(outputValues, inputPoints, polyOrder_, operatorType);

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_NodalBasisFamily.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_NodalBasisFamily.hpp
@@ -77,31 +77,31 @@
 namespace Intrepid2 {
 
   // the following defines a family of nodal basis functions for the reference Triangle
-  template<typename ExecutionSpace=Kokkos::DefaultExecutionSpace,
+  template<typename DeviceType=typename Kokkos::DefaultExecutionSpace::device_type,
            typename OutputScalar = double,
            typename PointScalar  = double,
            bool defineVertexFunctions = true>
   class NodalTriangleBasisFamily
   {
   public:
-    using HGRAD = Basis_HGRAD_TRI_Cn_FEM<ExecutionSpace,OutputScalar,PointScalar>;
-    using HCURL = Basis_HCURL_TRI_In_FEM<ExecutionSpace,OutputScalar,PointScalar>;
-    using HDIV  = Basis_HDIV_TRI_In_FEM<ExecutionSpace,OutputScalar,PointScalar>;
-    using HVOL  = Basis_HVOL_TRI_Cn_FEM<ExecutionSpace,OutputScalar,PointScalar>;
+    using HGRAD = Basis_HGRAD_TRI_Cn_FEM<DeviceType,OutputScalar,PointScalar>;
+    using HCURL = Basis_HCURL_TRI_In_FEM<DeviceType,OutputScalar,PointScalar>;
+    using HDIV  = Basis_HDIV_TRI_In_FEM <DeviceType,OutputScalar,PointScalar>;
+    using HVOL  = Basis_HVOL_TRI_Cn_FEM <DeviceType,OutputScalar,PointScalar>;
   };
 
   // the following defines a family of nodal basis functions for the reference Tetrahedron
-  template<typename ExecutionSpace=Kokkos::DefaultExecutionSpace,
-  typename OutputScalar = double,
-  typename PointScalar  = double,
-  bool defineVertexFunctions = true>
+  template<typename DeviceType=typename Kokkos::DefaultExecutionSpace::device_type,
+           typename OutputScalar = double,
+           typename PointScalar  = double,
+           bool defineVertexFunctions = true>
   class NodalTetrahedronBasisFamily
   {
   public:
-    using HGRAD = Basis_HGRAD_TET_Cn_FEM<ExecutionSpace,OutputScalar,PointScalar>;
-    using HCURL = Basis_HCURL_TET_In_FEM<ExecutionSpace,OutputScalar,PointScalar>;
-    using HDIV  = Basis_HDIV_TET_In_FEM<ExecutionSpace,OutputScalar,PointScalar>;
-    using HVOL  = Basis_HVOL_TET_Cn_FEM<ExecutionSpace,OutputScalar,PointScalar>;
+    using HGRAD = Basis_HGRAD_TET_Cn_FEM<DeviceType,OutputScalar,PointScalar>;
+    using HCURL = Basis_HCURL_TET_In_FEM<DeviceType,OutputScalar,PointScalar>;
+    using HDIV  = Basis_HDIV_TET_In_FEM <DeviceType,OutputScalar,PointScalar>;
+    using HVOL  = Basis_HVOL_TET_Cn_FEM <DeviceType,OutputScalar,PointScalar>;
   };
 
 
@@ -116,59 +116,59 @@ namespace Intrepid2 {
    
    At present, only hypercube topologies (line, quadrilateral, hexahedron) are supported, but other topologies will be supported in the future.
   */
-  template<typename ExecutionSpace=Kokkos::DefaultExecutionSpace,
+  template<typename DeviceType = typename Kokkos::DefaultExecutionSpace::device_type,
            typename OutputScalar = double,
            typename PointScalar  = double>
-  using DerivedNodalBasisFamily = DerivedBasisFamily< Basis_HGRAD_LINE_Cn_FEM<ExecutionSpace,OutputScalar,PointScalar>,
-                                                      Basis_HVOL_LINE_Cn_FEM<ExecutionSpace,OutputScalar,PointScalar>,
-                                                      NodalTriangleBasisFamily<ExecutionSpace,OutputScalar,PointScalar>,
-                                                      NodalTetrahedronBasisFamily<ExecutionSpace,OutputScalar,PointScalar> >;
+  using DerivedNodalBasisFamily = DerivedBasisFamily< Basis_HGRAD_LINE_Cn_FEM<DeviceType,OutputScalar,PointScalar>,
+                                                      Basis_HVOL_LINE_Cn_FEM<DeviceType,OutputScalar,PointScalar>,
+                                                      NodalTriangleBasisFamily<DeviceType,OutputScalar,PointScalar>,
+                                                      NodalTetrahedronBasisFamily<DeviceType,OutputScalar,PointScalar> >;
   
   /** \class Intrepid2::NodalBasisFamily
       \brief A family of nodal basis functions representing the higher-order Lagrangian basis family that Intrepid2 has historically supported.
    
    This family is defined with reference to the higher-order implementations (the "Cn" and "In" bases).
   */
-  template<typename ExecSpace=Kokkos::DefaultExecutionSpace,
+  template<typename DeviceType = typename Kokkos::DefaultExecutionSpace::device_type,
            typename OutputScalar = double,
            typename PointScalar  = double>
   class NodalBasisFamily
   {
   public:
-    using ExecutionSpace  = ExecSpace;
+    using ExecutionSpace  = typename DeviceType::execution_space;
     using OutputValueType = OutputScalar;
     using PointValueType  = PointScalar;
     
-    using BasisType = Basis<ExecSpace,OutputScalar,PointScalar>;
+    using BasisType = Basis<DeviceType,OutputScalar,PointScalar>;
     using BasisPtr  = Teuchos::RCP<BasisType>;
     
     // line bases
-    using HGRAD_LINE = Basis_HGRAD_LINE_Cn_FEM<ExecutionSpace,OutputValueType,PointValueType>;
-    using HVOL_LINE  = Basis_HVOL_LINE_Cn_FEM<ExecutionSpace,OutputValueType,PointValueType>;
+    using HGRAD_LINE = Basis_HGRAD_LINE_Cn_FEM<DeviceType,OutputValueType,PointValueType>;
+    using HVOL_LINE  = Basis_HVOL_LINE_Cn_FEM<DeviceType,OutputValueType,PointValueType>;
     
     // quadrilateral bases
-    using HGRAD_QUAD = Basis_HGRAD_QUAD_Cn_FEM<ExecutionSpace,OutputValueType,PointValueType>;
-    using HCURL_QUAD = Basis_HCURL_QUAD_In_FEM<ExecutionSpace,OutputValueType,PointValueType>;
-    using HDIV_QUAD  = Basis_HDIV_QUAD_In_FEM<ExecutionSpace,OutputValueType,PointValueType>;
-    using HVOL_QUAD  = Basis_HVOL_QUAD_Cn_FEM<ExecutionSpace,OutputValueType,PointValueType>;
+    using HGRAD_QUAD = Basis_HGRAD_QUAD_Cn_FEM<DeviceType,OutputValueType,PointValueType>;
+    using HCURL_QUAD = Basis_HCURL_QUAD_In_FEM<DeviceType,OutputValueType,PointValueType>;
+    using HDIV_QUAD  = Basis_HDIV_QUAD_In_FEM<DeviceType,OutputValueType,PointValueType>;
+    using HVOL_QUAD  = Basis_HVOL_QUAD_Cn_FEM<DeviceType,OutputValueType,PointValueType>;
     
     // triangle bases
-    using HGRAD_TRI = Basis_HGRAD_TRI_Cn_FEM<ExecutionSpace,OutputValueType,PointValueType>;
-    using HCURL_TRI = Basis_HCURL_TRI_In_FEM<ExecutionSpace,OutputValueType,PointValueType>;
-    using HDIV_TRI  = Basis_HDIV_TRI_In_FEM<ExecutionSpace,OutputValueType,PointValueType>;
-    using HVOL_TRI  = Basis_HVOL_TRI_Cn_FEM<ExecutionSpace,OutputValueType,PointValueType>;
+    using HGRAD_TRI = Basis_HGRAD_TRI_Cn_FEM<DeviceType,OutputValueType,PointValueType>;
+    using HCURL_TRI = Basis_HCURL_TRI_In_FEM<DeviceType,OutputValueType,PointValueType>;
+    using HDIV_TRI  = Basis_HDIV_TRI_In_FEM<DeviceType,OutputValueType,PointValueType>;
+    using HVOL_TRI  = Basis_HVOL_TRI_Cn_FEM<DeviceType,OutputValueType,PointValueType>;
     
     // hexahedron bases
-    using HGRAD_HEX = Basis_HGRAD_HEX_Cn_FEM<ExecutionSpace,OutputValueType,PointValueType>;
-    using HCURL_HEX = Basis_HCURL_HEX_In_FEM<ExecutionSpace,OutputValueType,PointValueType>;
-    using HDIV_HEX  = Basis_HDIV_HEX_In_FEM<ExecutionSpace,OutputValueType,PointValueType>;
-    using HVOL_HEX  = Basis_HVOL_HEX_Cn_FEM<ExecutionSpace,OutputValueType,PointValueType>;
+    using HGRAD_HEX = Basis_HGRAD_HEX_Cn_FEM<DeviceType,OutputValueType,PointValueType>;
+    using HCURL_HEX = Basis_HCURL_HEX_In_FEM<DeviceType,OutputValueType,PointValueType>;
+    using HDIV_HEX  = Basis_HDIV_HEX_In_FEM<DeviceType,OutputValueType,PointValueType>;
+    using HVOL_HEX  = Basis_HVOL_HEX_Cn_FEM<DeviceType,OutputValueType,PointValueType>;
     
     // tetrahedron bases
-    using HGRAD_TET = Basis_HGRAD_TET_Cn_FEM<ExecutionSpace,OutputValueType,PointValueType>;
-    using HCURL_TET = Basis_HCURL_TET_In_FEM<ExecutionSpace,OutputValueType,PointValueType>;
-    using HDIV_TET  = Basis_HDIV_TET_In_FEM<ExecutionSpace,OutputValueType,PointValueType>;
-    using HVOL_TET  = Basis_HVOL_TET_Cn_FEM<ExecutionSpace,OutputValueType,PointValueType>;
+    using HGRAD_TET = Basis_HGRAD_TET_Cn_FEM<DeviceType,OutputValueType,PointValueType>;
+    using HCURL_TET = Basis_HCURL_TET_In_FEM<DeviceType,OutputValueType,PointValueType>;
+    using HDIV_TET  = Basis_HDIV_TET_In_FEM<DeviceType,OutputValueType,PointValueType>;
+    using HVOL_TET  = Basis_HVOL_TET_Cn_FEM<DeviceType,OutputValueType,PointValueType>;
     
   };
 }

--- a/packages/intrepid2/src/Discretization/FunctionSpaceTools/Intrepid2_FunctionSpaceTools.hpp
+++ b/packages/intrepid2/src/Discretization/FunctionSpaceTools/Intrepid2_FunctionSpaceTools.hpp
@@ -80,6 +80,7 @@ namespace Intrepid2 {
   */
   template<typename ExecSpaceType = void>
   class FunctionSpaceTools {
+    using DeviceType = typename ExecSpaceType::device_type;
   public:
     /** \brief Transformation of a gradient field in the H-grad space, defined at points on a
           reference cell, stored in the user-provided container <var><b>inputVals</b></var>
@@ -125,9 +126,9 @@ namespace Intrepid2 {
      \return TransformedVectorData object defined on (C,F,P,D) indices; transformation is computed on access.
       */
     template<class Scalar>
-    static TransformedVectorData<Scalar,ExecSpaceType> getHGRADtransformGRAD(const Data<Scalar,ExecSpaceType> &jacobianInverse, const VectorData<Scalar,ExecSpaceType> &refBasisGradValues)
+    static TransformedVectorData<Scalar,DeviceType> getHGRADtransformGRAD(const Data<Scalar,DeviceType> &jacobianInverse, const VectorData<Scalar,DeviceType> &refBasisGradValues)
     {
-      return TransformedVectorData<Scalar,ExecSpaceType>(jacobianInverse,refBasisGradValues);
+      return TransformedVectorData<Scalar,DeviceType>(jacobianInverse,refBasisGradValues);
     }
     
     /** \brief Transformation of a (scalar) value field in the H-grad space, defined at points on a

--- a/packages/intrepid2/src/Discretization/Integration/Intrepid2_Cubature.hpp
+++ b/packages/intrepid2/src/Discretization/Integration/Intrepid2_Cubature.hpp
@@ -128,10 +128,10 @@ namespace Intrepid2 {
     using weightViewType = Kokkos::DynRankView<weightValueType,Kokkos::LayoutStride,DeviceType>;
 
     /// KK: the following needs to be updated with device type after nate's tensor work is updated.
-    using PointViewTypeAllocatable  = Kokkos::DynRankView<pointValueType,ExecSpaceType>;  // uses default layout; allows us to allocate (in contrast to LayoutStride)
-    using WeightViewTypeAllocatable = Kokkos::DynRankView<weightValueType,ExecSpaceType>; // uses default layout; allows us to allocate (in contrast to LayoutStride)
-    using TensorPointDataType       = TensorPoints<pointValueType,ExecSpaceType>;
-    using TensorWeightDataType      = TensorData<weightValueType,ExecSpaceType>;
+    using PointViewTypeAllocatable  = Kokkos::DynRankView<pointValueType,DeviceType>;  // uses default layout; allows us to allocate (in contrast to LayoutStride)
+    using WeightViewTypeAllocatable = Kokkos::DynRankView<weightValueType,DeviceType>; // uses default layout; allows us to allocate (in contrast to LayoutStride)
+    using TensorPointDataType       = TensorPoints<pointValueType,DeviceType>;
+    using TensorWeightDataType      = TensorData<weightValueType,DeviceType>;
     
     /** \brief Returns a points container appropriate for passing to getCubature().
 
@@ -154,7 +154,7 @@ namespace Intrepid2 {
     {
       // default implementation has trivial tensor structure
       /// KK: this also needs to be updated with nate's tensor
-      using WeightDataType = Data<weightValueType,ExecSpaceType>;
+      using WeightDataType = Data<weightValueType,DeviceType>;
       WeightViewTypeAllocatable allWeightData("cubature weights",this->getNumPoints());
       Kokkos::Array< WeightDataType, 1> cubatureWeightComponents;
       cubatureWeightComponents[0] = WeightDataType(allWeightData);

--- a/packages/intrepid2/src/Discretization/Integration/Intrepid2_Cubature.hpp
+++ b/packages/intrepid2/src/Discretization/Integration/Intrepid2_Cubature.hpp
@@ -123,9 +123,9 @@ namespace Intrepid2 {
            typename weightValueType = double>
   class Cubature {
   public:
-    using ExecSpaceType = typename DeviceType::execution_space;
-    using PointViewType             = Kokkos::DynRankView<pointValueType,Kokkos::LayoutStride,DeviceType>;
-    using weightViewType            = Kokkos::DynRankView<weightValueType,Kokkos::LayoutStride,DeviceType>;
+    using ExecSpaceType  = typename DeviceType::execution_space;
+    using PointViewType  = Kokkos::DynRankView<pointValueType,Kokkos::LayoutStride,DeviceType>;
+    using weightViewType = Kokkos::DynRankView<weightValueType,Kokkos::LayoutStride,DeviceType>;
 
     /// KK: the following needs to be updated with device type after nate's tensor work is updated.
     using PointViewTypeAllocatable  = Kokkos::DynRankView<pointValueType,ExecSpaceType>;  // uses default layout; allows us to allocate (in contrast to LayoutStride)

--- a/packages/intrepid2/src/Discretization/Integration/Intrepid2_CubatureTensor.hpp
+++ b/packages/intrepid2/src/Discretization/Integration/Intrepid2_CubatureTensor.hpp
@@ -124,8 +124,7 @@ namespace Intrepid2 {
     */
     virtual TensorWeightDataType allocateCubatureWeights() const override
     {
-      /// KK: this needs to be updated with nate tensor work      
-      using WeightDataType = Data<weightValueType,typename DeviceType::execution_space>;
+      using WeightDataType = Data<weightValueType,DeviceType>;
       
       std::vector< WeightDataType > cubatureWeightComponents(numCubatures_);
       for (ordinal_type i=0;i<numCubatures_;++i)

--- a/packages/intrepid2/src/Discretization/Integration/Intrepid2_IntegrationTools.hpp
+++ b/packages/intrepid2/src/Discretization/Integration/Intrepid2_IntegrationTools.hpp
@@ -76,6 +76,7 @@ namespace Intrepid2 {
   */
   template<typename DeviceType>
   class IntegrationTools {
+    static_assert(Kokkos::is_device<DeviceType>::value, "Template argument to IntegrationTools must be a Kokkos::Device");
   public:
     /** \brief   Allocates storage for the contraction of \a <b>vectorDataLeft</b> and \a <b>vectorDataRight</b> containers on
                  point and space dimensions, weighting each point according to <b>cellMeasures</b>.

--- a/packages/intrepid2/src/Discretization/Integration/Intrepid2_IntegrationTools.hpp
+++ b/packages/intrepid2/src/Discretization/Integration/Intrepid2_IntegrationTools.hpp
@@ -74,7 +74,7 @@ namespace Intrepid2 {
   /** \class Intrepid2::IntegrationTools
       \brief Provides support for structure-aware integration.
   */
-  template<typename ExecSpaceType = void>
+  template<typename DeviceType>
   class IntegrationTools {
   public:
     /** \brief   Allocates storage for the contraction of \a <b>vectorDataLeft</b> and \a <b>vectorDataRight</b> containers on
@@ -88,9 +88,9 @@ namespace Intrepid2 {
         \return <b>integrals</b>, a container with nominal shape (C,F,F), suitable for passing as the first argument to the integrate() variant that takes an Intrepid2::Data object as its first, <b>integrals</b>, argument.
     */
     template<class Scalar>
-    static Data<Scalar,ExecSpaceType> allocateIntegralData(const TransformedVectorData<Scalar,ExecSpaceType> vectorDataLeft,
-                                                           const TensorData<Scalar,ExecSpaceType> cellMeasures,
-                                                           const TransformedVectorData<Scalar,ExecSpaceType> vectorDataRight);
+    static Data<Scalar,DeviceType> allocateIntegralData(const TransformedVectorData<Scalar,DeviceType> vectorDataLeft,
+                                                        const TensorData<Scalar,DeviceType> cellMeasures,
+                                                        const TransformedVectorData<Scalar,DeviceType> vectorDataRight);
     
     /** \brief   Contracts \a <b>vectorDataLeft</b> and \a <b>vectorDataRight</b> containers on
         point and space dimensions, weighting each point according to <b>cellMeasures</b>,
@@ -104,9 +104,9 @@ namespace Intrepid2 {
         \param  approxFlops               [in] - if not NULL, the double pointed to will be set with an estimated number of floating point operations.  Intended for performance assessment purposes.
     */
     template<class Scalar>
-    static void integrate(Data<Scalar,ExecSpaceType> integrals, const TransformedVectorData<Scalar,ExecSpaceType> &vectorDataLeft,
-                          const TensorData<Scalar,ExecSpaceType> &cellMeasures,
-                          const TransformedVectorData<Scalar,ExecSpaceType> &vectorDataRight, const bool sumInto = false,
+    static void integrate(Data<Scalar,DeviceType> integrals, const TransformedVectorData<Scalar,DeviceType> &vectorDataLeft,
+                          const TensorData<Scalar,DeviceType> &cellMeasures,
+                          const TransformedVectorData<Scalar,DeviceType> &vectorDataRight, const bool sumInto = false,
                           double* approximateFlops = NULL);
   }; // end IntegrationTools class
 

--- a/packages/intrepid2/src/Discretization/Integration/Intrepid2_IntegrationToolsDef.hpp
+++ b/packages/intrepid2/src/Discretization/Integration/Intrepid2_IntegrationToolsDef.hpp
@@ -61,18 +61,19 @@ namespace Intrepid2 {
     /**
       \brief Implementation of a general sum factorization algorithm, abstracted from the algorithm described by Mora and Demkowicz, for integration.  Uses hierarchical parallelism.
      */
-    template<class Scalar, class ExecSpaceType, int integralViewRank>
+    template<class Scalar, class DeviceType, int integralViewRank>
     class F_Integrate
     {
+      using ExecSpaceType = typename DeviceType::execution_space;
       using TeamPolicy = Kokkos::TeamPolicy<ExecSpaceType>;
       using TeamMember = typename TeamPolicy::member_type;
       
-      using IntegralViewType = Kokkos::View<typename RankExpander<Scalar, integralViewRank>::value_type, ExecSpaceType>;
+      using IntegralViewType = Kokkos::View<typename RankExpander<Scalar, integralViewRank>::value_type, DeviceType>;
       IntegralViewType integralView_;
-      TensorData<Scalar,ExecSpaceType> leftComponent_;
-      Data<Scalar,ExecSpaceType> composedTransform_;
-      TensorData<Scalar,ExecSpaceType> rightComponent_;
-      TensorData<Scalar,ExecSpaceType> cellMeasures_;
+      TensorData<Scalar,DeviceType> leftComponent_;
+      Data<Scalar,DeviceType> composedTransform_;
+      TensorData<Scalar,DeviceType> rightComponent_;
+      TensorData<Scalar,DeviceType> cellMeasures_;
       int a_offset_;
       int b_offset_;
       int leftComponentSpan_;   //  leftComponentSpan tracks the dimensions spanned by the left component
@@ -99,11 +100,11 @@ namespace Intrepid2 {
       int maxFieldsRight_;
       int maxPointCount_;
     public:
-      F_Integrate(Data<Scalar,ExecSpaceType> integralData,
-                  TensorData<Scalar,ExecSpaceType> leftComponent,
-                  Data<Scalar,ExecSpaceType> composedTransform,
-                  TensorData<Scalar,ExecSpaceType> rightComponent,
-                  TensorData<Scalar,ExecSpaceType> cellMeasures,
+      F_Integrate(Data<Scalar,DeviceType> integralData,
+                  TensorData<Scalar,DeviceType> leftComponent,
+                  Data<Scalar,DeviceType> composedTransform,
+                  TensorData<Scalar,DeviceType> rightComponent,
+                  TensorData<Scalar,DeviceType> cellMeasures,
                   int a_offset,
                   int b_offset,
                   int leftFieldOrdinalOffset,
@@ -313,28 +314,28 @@ namespace Intrepid2 {
         const int numThreads      = teamMember.team_size(); // num threads
         const int scratchViewSize = offsetsForComponentOrdinal_[0]; // per thread
         
-        Kokkos::View<Scalar*, ExecSpaceType, Kokkos::MemoryUnmanaged> scratchView; // for caching partial integration values
-        Kokkos::View<Scalar*, ExecSpaceType, Kokkos::MemoryUnmanaged> pointWeights; // indexed by (expanded) point; stores M_ab * cell measure
-        Kokkos::View<Scalar**, ExecSpaceType, Kokkos::MemoryUnmanaged> leftFields_x, leftFields_y, leftFields_z, rightFields_x, rightFields_y, rightFields_z; // cache the field values for faster access
+        Kokkos::View<Scalar*, DeviceType, Kokkos::MemoryUnmanaged> scratchView; // for caching partial integration values
+        Kokkos::View<Scalar*, DeviceType, Kokkos::MemoryUnmanaged> pointWeights; // indexed by (expanded) point; stores M_ab * cell measure
+        Kokkos::View<Scalar**, DeviceType, Kokkos::MemoryUnmanaged> leftFields_x, leftFields_y, leftFields_z, rightFields_x, rightFields_y, rightFields_z; // cache the field values for faster access
         if (fad_size_output_ > 0) {
-          scratchView = Kokkos::View<Scalar*,   ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(),    scratchViewSize * numThreads,      fad_size_output_);
-          pointWeights   = Kokkos::View<Scalar*, ExecSpaceType, Kokkos::MemoryUnmanaged>  (teamMember.team_shmem(), composedTransform_.extent_int(1),  fad_size_output_);
-          leftFields_x  = Kokkos::View<Scalar**, ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(),  leftFieldBounds[0], pointBounds[0], fad_size_output_);
-          rightFields_x = Kokkos::View<Scalar**, ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), rightFieldBounds[0], pointBounds[0], fad_size_output_);
-          leftFields_y  = Kokkos::View<Scalar**, ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(),  leftFieldBounds[1], pointBounds[1], fad_size_output_);
-          rightFields_y = Kokkos::View<Scalar**, ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), rightFieldBounds[1], pointBounds[1], fad_size_output_);
-          leftFields_z  = Kokkos::View<Scalar**, ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(),  leftFieldBounds[2], pointBounds[2], fad_size_output_);
-          rightFields_z = Kokkos::View<Scalar**, ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), rightFieldBounds[2], pointBounds[2], fad_size_output_);
+          scratchView = Kokkos::View<Scalar*,    DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(),   scratchViewSize * numThreads,      fad_size_output_);
+          pointWeights   = Kokkos::View<Scalar*, DeviceType, Kokkos::MemoryUnmanaged>  (teamMember.team_shmem(), composedTransform_.extent_int(1),  fad_size_output_);
+          leftFields_x  = Kokkos::View<Scalar**, DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(),  leftFieldBounds[0], pointBounds[0], fad_size_output_);
+          rightFields_x = Kokkos::View<Scalar**, DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), rightFieldBounds[0], pointBounds[0], fad_size_output_);
+          leftFields_y  = Kokkos::View<Scalar**, DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(),  leftFieldBounds[1], pointBounds[1], fad_size_output_);
+          rightFields_y = Kokkos::View<Scalar**, DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), rightFieldBounds[1], pointBounds[1], fad_size_output_);
+          leftFields_z  = Kokkos::View<Scalar**, DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(),  leftFieldBounds[2], pointBounds[2], fad_size_output_);
+          rightFields_z = Kokkos::View<Scalar**, DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), rightFieldBounds[2], pointBounds[2], fad_size_output_);
         }
         else {
-          scratchView = Kokkos::View<Scalar*,   ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(),    scratchViewSize * numThreads);
-          pointWeights   = Kokkos::View<Scalar*, ExecSpaceType, Kokkos::MemoryUnmanaged>  (teamMember.team_shmem(), composedTransform_.extent_int(1));
-          leftFields_x  = Kokkos::View<Scalar**, ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(),  leftFieldBounds[0], pointBounds[0]);
-          rightFields_x = Kokkos::View<Scalar**, ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), rightFieldBounds[0], pointBounds[0]);
-          leftFields_y  = Kokkos::View<Scalar**, ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(),  leftFieldBounds[1], pointBounds[1]);
-          rightFields_y = Kokkos::View<Scalar**, ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), rightFieldBounds[1], pointBounds[1]);
-          leftFields_z  = Kokkos::View<Scalar**, ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(),  leftFieldBounds[2], pointBounds[2]);
-          rightFields_z = Kokkos::View<Scalar**, ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), rightFieldBounds[2], pointBounds[2]);
+          scratchView = Kokkos::View<Scalar*,    DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(),   scratchViewSize * numThreads);
+          pointWeights   = Kokkos::View<Scalar*, DeviceType, Kokkos::MemoryUnmanaged>  (teamMember.team_shmem(), composedTransform_.extent_int(1));
+          leftFields_x  = Kokkos::View<Scalar**, DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(),  leftFieldBounds[0], pointBounds[0]);
+          rightFields_x = Kokkos::View<Scalar**, DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), rightFieldBounds[0], pointBounds[0]);
+          leftFields_y  = Kokkos::View<Scalar**, DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(),  leftFieldBounds[1], pointBounds[1]);
+          rightFields_y = Kokkos::View<Scalar**, DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), rightFieldBounds[1], pointBounds[1]);
+          leftFields_z  = Kokkos::View<Scalar**, DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(),  leftFieldBounds[2], pointBounds[2]);
+          rightFields_z = Kokkos::View<Scalar**, DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), rightFieldBounds[2], pointBounds[2]);
         }
         
 //        int approximateFlopCount = 0;
@@ -349,18 +350,18 @@ namespace Intrepid2 {
           {
             const int b = b_offset_ + b_component;
             
-            const Data<Scalar,ExecSpaceType> &  leftFinalComponent =  leftComponent_.getTensorComponent(R);
-            const Data<Scalar,ExecSpaceType> & rightFinalComponent = rightComponent_.getTensorComponent(R);
+            const Data<Scalar,DeviceType> &  leftFinalComponent =  leftComponent_.getTensorComponent(R);
+            const Data<Scalar,DeviceType> & rightFinalComponent = rightComponent_.getTensorComponent(R);
             
             const int numLeftFieldsFinal  =  leftFinalComponent.extent_int(0); // shape (F,P[,D])
             const int numRightFieldsFinal = rightFinalComponent.extent_int(0); // shape (F,P[,D])
             
-            const Data<Scalar,ExecSpaceType> &  leftTensorComponent_x =  leftComponent_.getTensorComponent(0);
-            const Data<Scalar,ExecSpaceType> & rightTensorComponent_x = rightComponent_.getTensorComponent(0);
-            const Data<Scalar,ExecSpaceType> &  leftTensorComponent_y =  leftComponent_.getTensorComponent(1);
-            const Data<Scalar,ExecSpaceType> & rightTensorComponent_y = rightComponent_.getTensorComponent(1);
-            const Data<Scalar,ExecSpaceType> &  leftTensorComponent_z =  leftComponent_.getTensorComponent(2);
-            const Data<Scalar,ExecSpaceType> & rightTensorComponent_z = rightComponent_.getTensorComponent(2);
+            const Data<Scalar,DeviceType> &  leftTensorComponent_x =  leftComponent_.getTensorComponent(0);
+            const Data<Scalar,DeviceType> & rightTensorComponent_x = rightComponent_.getTensorComponent(0);
+            const Data<Scalar,DeviceType> &  leftTensorComponent_y =  leftComponent_.getTensorComponent(1);
+            const Data<Scalar,DeviceType> & rightTensorComponent_y = rightComponent_.getTensorComponent(1);
+            const Data<Scalar,DeviceType> &  leftTensorComponent_z =  leftComponent_.getTensorComponent(2);
+            const Data<Scalar,DeviceType> & rightTensorComponent_z = rightComponent_.getTensorComponent(2);
             
             const int maxFields = (maxFieldsLeft_ > maxFieldsRight_) ? maxFieldsLeft_ : maxFieldsRight_;
             Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember,0,maxFields * maxPointCount_), [&] (const int& fieldOrdinalPointOrdinal) {
@@ -593,20 +594,20 @@ namespace Intrepid2 {
         const int cellDataOrdinal = teamMember.league_rank();
         const int numThreads      = teamMember.team_size(); // num threads
         const int scratchViewSize = offsetsForComponentOrdinal_[0]; // per thread
-        Kokkos::View<Scalar*, ExecSpaceType, Kokkos::MemoryUnmanaged> scratchView; // for caching partial integration values
-        Kokkos::View<Scalar*, ExecSpaceType, Kokkos::MemoryUnmanaged> pointWeights; // indexed by (expanded) point; stores M_ab * cell measure
-        Kokkos::View<Scalar***, ExecSpaceType, Kokkos::MemoryUnmanaged> leftFields, rightFields; // cache the field values for faster access
+        Kokkos::View<Scalar*, DeviceType, Kokkos::MemoryUnmanaged> scratchView; // for caching partial integration values
+        Kokkos::View<Scalar*, DeviceType, Kokkos::MemoryUnmanaged> pointWeights; // indexed by (expanded) point; stores M_ab * cell measure
+        Kokkos::View<Scalar***, DeviceType, Kokkos::MemoryUnmanaged> leftFields, rightFields; // cache the field values for faster access
         if (fad_size_output_ > 0) {
-          scratchView = Kokkos::View<Scalar*,   ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), scratchViewSize * numThreads,     fad_size_output_);
-          pointWeights   = Kokkos::View<Scalar*, ExecSpaceType, Kokkos::MemoryUnmanaged>  (teamMember.team_shmem(), composedTransform_.extent_int(1), fad_size_output_);
-          leftFields  = Kokkos::View<Scalar***, ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), numTensorComponents, maxFieldsLeft_,  maxPointCount_, fad_size_output_);
-          rightFields = Kokkos::View<Scalar***, ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), numTensorComponents, maxFieldsRight_, maxPointCount_, fad_size_output_);
+          scratchView = Kokkos::View<Scalar*,    DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), scratchViewSize * numThreads,     fad_size_output_);
+          pointWeights   = Kokkos::View<Scalar*, DeviceType, Kokkos::MemoryUnmanaged>  (teamMember.team_shmem(), composedTransform_.extent_int(1), fad_size_output_);
+          leftFields  = Kokkos::View<Scalar***,  DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), numTensorComponents, maxFieldsLeft_,  maxPointCount_, fad_size_output_);
+          rightFields = Kokkos::View<Scalar***,  DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), numTensorComponents, maxFieldsRight_, maxPointCount_, fad_size_output_);
         }
         else {
-          scratchView = Kokkos::View<Scalar*, ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), scratchViewSize*numThreads);
-          pointWeights   = Kokkos::View<Scalar*, ExecSpaceType, Kokkos::MemoryUnmanaged>  (teamMember.team_shmem(), composedTransform_.extent_int(1));
-          leftFields  = Kokkos::View<Scalar***, ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), numTensorComponents, maxFieldsLeft_,  maxPointCount_);
-          rightFields = Kokkos::View<Scalar***, ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), numTensorComponents, maxFieldsRight_, maxPointCount_);
+          scratchView = Kokkos::View<Scalar*,    DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), scratchViewSize*numThreads);
+          pointWeights   = Kokkos::View<Scalar*, DeviceType, Kokkos::MemoryUnmanaged>  (teamMember.team_shmem(), composedTransform_.extent_int(1));
+          leftFields  = Kokkos::View<Scalar***,  DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), numTensorComponents, maxFieldsLeft_,  maxPointCount_);
+          rightFields = Kokkos::View<Scalar***,  DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), numTensorComponents, maxFieldsRight_, maxPointCount_);
         }
         
 //        int approximateFlopCount = 0;
@@ -621,15 +622,15 @@ namespace Intrepid2 {
           {
             const int b = b_offset_ + b_component;
             
-            const Data<Scalar,ExecSpaceType> &  leftFinalComponent =  leftComponent_.getTensorComponent(R);
-            const Data<Scalar,ExecSpaceType> & rightFinalComponent = rightComponent_.getTensorComponent(R);
+            const Data<Scalar,DeviceType> &  leftFinalComponent =  leftComponent_.getTensorComponent(R);
+            const Data<Scalar,DeviceType> & rightFinalComponent = rightComponent_.getTensorComponent(R);
             
             const int numLeftFieldsFinal  =  leftFinalComponent.extent_int(0); // shape (F,P[,D])
             const int numRightFieldsFinal = rightFinalComponent.extent_int(0); // shape (F,P[,D])
             
             Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember,0,numTensorComponents), [&] (const int& r) {
-              const Data<Scalar,ExecSpaceType> &  leftTensorComponent =  leftComponent_.getTensorComponent(r);
-              const Data<Scalar,ExecSpaceType> & rightTensorComponent = rightComponent_.getTensorComponent(r);
+              const Data<Scalar,DeviceType> &  leftTensorComponent =  leftComponent_.getTensorComponent(r);
+              const Data<Scalar,DeviceType> & rightTensorComponent = rightComponent_.getTensorComponent(r);
               const int  leftFieldCount =  leftTensorComponent.extent_int(0);
               const int      pointCount =  leftTensorComponent.extent_int(1);
               const int        leftRank =  leftTensorComponent.rank();
@@ -883,8 +884,8 @@ namespace Intrepid2 {
         {
           for (int b_component=0; b_component < rightComponentSpan_; b_component++)
           {
-            const Data<Scalar,ExecSpaceType> &  leftFinalComponent =  leftComponent_.getTensorComponent(R);
-            const Data<Scalar,ExecSpaceType> & rightFinalComponent = rightComponent_.getTensorComponent(R);
+            const Data<Scalar,DeviceType> &  leftFinalComponent =  leftComponent_.getTensorComponent(R);
+            const Data<Scalar,DeviceType> & rightFinalComponent = rightComponent_.getTensorComponent(R);
             
             const int numLeftFieldsFinal  =  leftFinalComponent.extent_int(0); // shape (F,P[,D])
             const int numRightFieldsFinal = rightFinalComponent.extent_int(0); // shape (F,P[,D])
@@ -962,17 +963,17 @@ namespace Intrepid2 {
         
         if (fad_size_output_ > 0)
         {
-          shmem_size += Kokkos::View<Scalar*, ExecSpaceType, Kokkos::MemoryUnmanaged>::shmem_size(offsetsForComponentOrdinal_[0] * team_size, fad_size_output_);
-          shmem_size += Kokkos::View<Scalar*, ExecSpaceType, Kokkos::MemoryUnmanaged>::shmem_size(composedTransform_.extent_int(1),           fad_size_output_);
-          shmem_size += Kokkos::View<Scalar***, ExecSpaceType, Kokkos::MemoryUnmanaged>::shmem_size(numTensorComponents_, maxFieldsLeft_,  maxPointCount_, fad_size_output_);
-          shmem_size += Kokkos::View<Scalar***, ExecSpaceType, Kokkos::MemoryUnmanaged>::shmem_size(numTensorComponents_, maxFieldsRight_, maxPointCount_, fad_size_output_);
+          shmem_size += Kokkos::View<Scalar*, DeviceType, Kokkos::MemoryUnmanaged>::shmem_size(offsetsForComponentOrdinal_[0] * team_size, fad_size_output_);
+          shmem_size += Kokkos::View<Scalar*, DeviceType, Kokkos::MemoryUnmanaged>::shmem_size(composedTransform_.extent_int(1),           fad_size_output_);
+          shmem_size += Kokkos::View<Scalar***, DeviceType, Kokkos::MemoryUnmanaged>::shmem_size(numTensorComponents_, maxFieldsLeft_,  maxPointCount_, fad_size_output_);
+          shmem_size += Kokkos::View<Scalar***, DeviceType, Kokkos::MemoryUnmanaged>::shmem_size(numTensorComponents_, maxFieldsRight_, maxPointCount_, fad_size_output_);
         }
         else
         {
-          shmem_size += Kokkos::View<Scalar*, ExecSpaceType>::shmem_size(offsetsForComponentOrdinal_[0] * team_size);
-          shmem_size += Kokkos::View<Scalar*, ExecSpaceType, Kokkos::MemoryUnmanaged>::shmem_size(composedTransform_.extent_int(1));
-          shmem_size += Kokkos::View<Scalar***, ExecSpaceType, Kokkos::MemoryUnmanaged>::shmem_size(numTensorComponents_, maxFieldsLeft_,  maxPointCount_);
-          shmem_size += Kokkos::View<Scalar***, ExecSpaceType, Kokkos::MemoryUnmanaged>::shmem_size(numTensorComponents_, maxFieldsRight_, maxPointCount_);
+          shmem_size += Kokkos::View<Scalar*, DeviceType>::shmem_size(offsetsForComponentOrdinal_[0] * team_size);
+          shmem_size += Kokkos::View<Scalar*, DeviceType, Kokkos::MemoryUnmanaged>::shmem_size(composedTransform_.extent_int(1));
+          shmem_size += Kokkos::View<Scalar***, DeviceType, Kokkos::MemoryUnmanaged>::shmem_size(numTensorComponents_, maxFieldsLeft_,  maxPointCount_);
+          shmem_size += Kokkos::View<Scalar***, DeviceType, Kokkos::MemoryUnmanaged>::shmem_size(numTensorComponents_, maxFieldsRight_, maxPointCount_);
         }
         
         return shmem_size;
@@ -988,18 +989,19 @@ namespace Intrepid2 {
      requires a cache of size (p_x+1)*(p_y+1).  So long as one is not over-integrating by too much, these sizes are about the same.  The real advantage of our approach here is (we expect)
      that it improves data locality.
        */
-      template<class Scalar, class ExecSpaceType, int integralViewRank>
+      template<class Scalar, class DeviceType, int integralViewRank>
       class F_IntegratePointValueCache
       {
+      using ExecSpaceType = typename DeviceType::execution_space;
       using TeamPolicy = Kokkos::TeamPolicy<ExecSpaceType>;
       using TeamMember = typename TeamPolicy::member_type;
 
-      using IntegralViewType = Kokkos::View<typename RankExpander<Scalar, integralViewRank>::value_type, ExecSpaceType>;
+      using IntegralViewType = Kokkos::View<typename RankExpander<Scalar, integralViewRank>::value_type, DeviceType>;
       IntegralViewType integralView_;
-      TensorData<Scalar,ExecSpaceType> leftComponent_;
-      Data<Scalar,ExecSpaceType> composedTransform_;
-      TensorData<Scalar,ExecSpaceType> rightComponent_;
-      TensorData<Scalar,ExecSpaceType> cellMeasures_;
+      TensorData<Scalar,DeviceType> leftComponent_;
+      Data<Scalar,DeviceType> composedTransform_;
+      TensorData<Scalar,DeviceType> rightComponent_;
+      TensorData<Scalar,DeviceType> cellMeasures_;
       int a_offset_;
       int b_offset_;
       int leftComponentSpan_;   //  leftComponentSpan tracks the dimensions spanned by the left component
@@ -1020,11 +1022,11 @@ namespace Intrepid2 {
       int maxFieldsRight_;
       int maxPointCount_;
     public:
-      F_IntegratePointValueCache(Data<Scalar,ExecSpaceType> integralData,
-                                 TensorData<Scalar,ExecSpaceType> leftComponent,
-                                 Data<Scalar,ExecSpaceType> composedTransform,
-                                 TensorData<Scalar,ExecSpaceType> rightComponent,
-                                 TensorData<Scalar,ExecSpaceType> cellMeasures,
+      F_IntegratePointValueCache(Data<Scalar,DeviceType> integralData,
+                                 TensorData<Scalar,DeviceType> leftComponent,
+                                 Data<Scalar,DeviceType> composedTransform,
+                                 TensorData<Scalar,DeviceType> rightComponent,
+                                 TensorData<Scalar,DeviceType> cellMeasures,
                                  int a_offset,
                                  int b_offset,
                                  int leftFieldOrdinalOffset,
@@ -1208,39 +1210,39 @@ namespace Intrepid2 {
         
         const int numThreads       = teamMember.team_size(); // num threads
         const int GyEntryCount     = pointBounds_z; // for each thread: store one Gy value per z coordinate
-        Kokkos::View<Scalar*, ExecSpaceType, Kokkos::MemoryUnmanaged> GxIntegrals; // for caching Gx values: we integrate out the first component dimension for each coordinate in the remaining dimensios
-        Kokkos::View<Scalar*, ExecSpaceType, Kokkos::MemoryUnmanaged> GyIntegrals; // for caching Gy values (each thread gets a stack, of the same height as tensorComponents - 1)
-        Kokkos::View<Scalar*, ExecSpaceType, Kokkos::MemoryUnmanaged> GzIntegral;  // for one Gz value that we sum into before summing into the destination matrix
-        Kokkos::View<Scalar*, ExecSpaceType, Kokkos::MemoryUnmanaged> pointWeights; // indexed by (expanded) point; stores M_ab * cell measure; shared by team
+        Kokkos::View<Scalar*, DeviceType, Kokkos::MemoryUnmanaged> GxIntegrals; // for caching Gx values: we integrate out the first component dimension for each coordinate in the remaining dimensios
+        Kokkos::View<Scalar*, DeviceType, Kokkos::MemoryUnmanaged> GyIntegrals; // for caching Gy values (each thread gets a stack, of the same height as tensorComponents - 1)
+        Kokkos::View<Scalar*, DeviceType, Kokkos::MemoryUnmanaged> GzIntegral;  // for one Gz value that we sum into before summing into the destination matrix
+        Kokkos::View<Scalar*, DeviceType, Kokkos::MemoryUnmanaged> pointWeights; // indexed by (expanded) point; stores M_ab * cell measure; shared by team
         
-        Kokkos::View<Scalar**, ExecSpaceType, Kokkos::MemoryUnmanaged> leftFields_x, rightFields_x;
-        Kokkos::View<Scalar**, ExecSpaceType, Kokkos::MemoryUnmanaged> leftFields_y, rightFields_y;
-        Kokkos::View<Scalar**, ExecSpaceType, Kokkos::MemoryUnmanaged> leftFields_z, rightFields_z;
+        Kokkos::View<Scalar**, DeviceType, Kokkos::MemoryUnmanaged> leftFields_x, rightFields_x;
+        Kokkos::View<Scalar**, DeviceType, Kokkos::MemoryUnmanaged> leftFields_y, rightFields_y;
+        Kokkos::View<Scalar**, DeviceType, Kokkos::MemoryUnmanaged> leftFields_z, rightFields_z;
         if (fad_size_output_ > 0) {
-          GxIntegrals   = Kokkos::View<Scalar*,   ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(),  pointsInNonzeroComponentDimensions, fad_size_output_);
-          GyIntegrals   = Kokkos::View<Scalar*,   ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(),  GyEntryCount * numThreads,          fad_size_output_);
-          GzIntegral    = Kokkos::View<Scalar*,   ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(),  numThreads,                         fad_size_output_);
-          pointWeights  = Kokkos::View<Scalar*, ExecSpaceType, Kokkos::MemoryUnmanaged>  (teamMember.team_shmem(),  composedTransform_.extent_int(1),   fad_size_output_);
+          GxIntegrals   = Kokkos::View<Scalar*, DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(),   pointsInNonzeroComponentDimensions, fad_size_output_);
+          GyIntegrals   = Kokkos::View<Scalar*, DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(),   GyEntryCount * numThreads,          fad_size_output_);
+          GzIntegral    = Kokkos::View<Scalar*, DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(),   numThreads,                         fad_size_output_);
+          pointWeights  = Kokkos::View<Scalar*, DeviceType, Kokkos::MemoryUnmanaged>  (teamMember.team_shmem(), composedTransform_.extent_int(1),   fad_size_output_);
           
-          leftFields_x  = Kokkos::View<Scalar**, ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(),  leftFieldBounds_x, pointBounds_x, fad_size_output_);
-          rightFields_x = Kokkos::View<Scalar**, ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), rightFieldBounds_x, pointBounds_x, fad_size_output_);
-          leftFields_y  = Kokkos::View<Scalar**, ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(),  leftFieldBounds_y, pointBounds_y, fad_size_output_);
-          rightFields_y = Kokkos::View<Scalar**, ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), rightFieldBounds_y, pointBounds_y, fad_size_output_);
-          leftFields_z  = Kokkos::View<Scalar**, ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(),  leftFieldBounds_z, pointBounds_z, fad_size_output_);
-          rightFields_z = Kokkos::View<Scalar**, ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), rightFieldBounds_z, pointBounds_z, fad_size_output_);
+          leftFields_x  = Kokkos::View<Scalar**, DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(),  leftFieldBounds_x, pointBounds_x, fad_size_output_);
+          rightFields_x = Kokkos::View<Scalar**, DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), rightFieldBounds_x, pointBounds_x, fad_size_output_);
+          leftFields_y  = Kokkos::View<Scalar**, DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(),  leftFieldBounds_y, pointBounds_y, fad_size_output_);
+          rightFields_y = Kokkos::View<Scalar**, DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), rightFieldBounds_y, pointBounds_y, fad_size_output_);
+          leftFields_z  = Kokkos::View<Scalar**, DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(),  leftFieldBounds_z, pointBounds_z, fad_size_output_);
+          rightFields_z = Kokkos::View<Scalar**, DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), rightFieldBounds_z, pointBounds_z, fad_size_output_);
         }
         else {
-          GxIntegrals   = Kokkos::View<Scalar*,   ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(),  pointsInNonzeroComponentDimensions);
-          GyIntegrals   = Kokkos::View<Scalar*,   ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(),  GyEntryCount * numThreads);
-          GzIntegral    = Kokkos::View<Scalar*,   ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(),  numThreads);
-          pointWeights  = Kokkos::View<Scalar*, ExecSpaceType, Kokkos::MemoryUnmanaged>  (teamMember.team_shmem(),  composedTransform_.extent_int(1));
+          GxIntegrals   = Kokkos::View<Scalar*, DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(),      pointsInNonzeroComponentDimensions);
+          GyIntegrals   = Kokkos::View<Scalar*, DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(),      GyEntryCount * numThreads);
+          GzIntegral    = Kokkos::View<Scalar*, DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(),      numThreads);
+          pointWeights  = Kokkos::View<Scalar*, DeviceType, Kokkos::MemoryUnmanaged>  (teamMember.team_shmem(), composedTransform_.extent_int(1));
         
-          leftFields_x  = Kokkos::View<Scalar**, ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(),  leftFieldBounds_x, pointBounds_x);
-          rightFields_x = Kokkos::View<Scalar**, ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), rightFieldBounds_x, pointBounds_x);
-          leftFields_y  = Kokkos::View<Scalar**, ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(),  leftFieldBounds_y, pointBounds_y);
-          rightFields_y = Kokkos::View<Scalar**, ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), rightFieldBounds_y, pointBounds_y);
-          leftFields_z  = Kokkos::View<Scalar**, ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(),  leftFieldBounds_z, pointBounds_z);
-          rightFields_z = Kokkos::View<Scalar**, ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), rightFieldBounds_z, pointBounds_z);
+          leftFields_x  = Kokkos::View<Scalar**, DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(),  leftFieldBounds_x, pointBounds_x);
+          rightFields_x = Kokkos::View<Scalar**, DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), rightFieldBounds_x, pointBounds_x);
+          leftFields_y  = Kokkos::View<Scalar**, DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(),  leftFieldBounds_y, pointBounds_y);
+          rightFields_y = Kokkos::View<Scalar**, DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), rightFieldBounds_y, pointBounds_y);
+          leftFields_z  = Kokkos::View<Scalar**, DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(),  leftFieldBounds_z, pointBounds_z);
+          rightFields_z = Kokkos::View<Scalar**, DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), rightFieldBounds_z, pointBounds_z);
         }
 
 //        int approximateFlopCount = 0;
@@ -1258,12 +1260,12 @@ namespace Intrepid2 {
           {
             const int b = b_offset_ + b_component;
 
-            const Data<Scalar,ExecSpaceType> &  leftTensorComponent_x =  leftComponent_.getTensorComponent(0);
-            const Data<Scalar,ExecSpaceType> & rightTensorComponent_x = rightComponent_.getTensorComponent(0);
-            const Data<Scalar,ExecSpaceType> &  leftTensorComponent_y =  leftComponent_.getTensorComponent(1);
-            const Data<Scalar,ExecSpaceType> & rightTensorComponent_y = rightComponent_.getTensorComponent(1);
-            const Data<Scalar,ExecSpaceType> &  leftTensorComponent_z =  leftComponent_.getTensorComponent(2);
-            const Data<Scalar,ExecSpaceType> & rightTensorComponent_z = rightComponent_.getTensorComponent(2);
+            const Data<Scalar,DeviceType> &  leftTensorComponent_x =  leftComponent_.getTensorComponent(0);
+            const Data<Scalar,DeviceType> & rightTensorComponent_x = rightComponent_.getTensorComponent(0);
+            const Data<Scalar,DeviceType> &  leftTensorComponent_y =  leftComponent_.getTensorComponent(1);
+            const Data<Scalar,DeviceType> & rightTensorComponent_y = rightComponent_.getTensorComponent(1);
+            const Data<Scalar,DeviceType> &  leftTensorComponent_z =  leftComponent_.getTensorComponent(2);
+            const Data<Scalar,DeviceType> & rightTensorComponent_z = rightComponent_.getTensorComponent(2);
             
             const int maxFields = (maxFieldsLeft_ > maxFieldsRight_) ? maxFieldsLeft_ : maxFieldsRight_;
             Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember,0,maxFields), [&] (const int& fieldOrdinal) {
@@ -1443,23 +1445,23 @@ namespace Intrepid2 {
 //        const int cellDataOrdinal  = teamMember.league_rank();
 //        const int numThreads       = teamMember.team_size(); // num threads
 //        const int G_k_StackHeight = numTensorComponents - 1; // per thread
-//        Kokkos::View<Scalar*, ExecSpaceType, Kokkos::MemoryUnmanaged> G_0_IntegralsView; // for caching G0 values: we integrate out the first component dimension for each coordinate in the remaining dimensios
-//        Kokkos::View<Scalar*, ExecSpaceType, Kokkos::MemoryUnmanaged> G_k_StackView; // for caching G_k values (each thread gets a stack, of the same height as tensorComponents - 1)
-//        Kokkos::View<Scalar*, ExecSpaceType, Kokkos::MemoryUnmanaged> pointWeights; // indexed by (expanded) point; stores M_ab * cell measure; shared by team
-//        Kokkos::View<Scalar*, ExecSpaceType, Kokkos::MemoryUnmanaged> leftFields, rightFields; // cache the field values at each level for faster access
+//        Kokkos::View<Scalar*, DeviceType, Kokkos::MemoryUnmanaged> G_0_IntegralsView; // for caching G0 values: we integrate out the first component dimension for each coordinate in the remaining dimensios
+//        Kokkos::View<Scalar*, DeviceType, Kokkos::MemoryUnmanaged> G_k_StackView; // for caching G_k values (each thread gets a stack, of the same height as tensorComponents - 1)
+//        Kokkos::View<Scalar*, DeviceType, Kokkos::MemoryUnmanaged> pointWeights; // indexed by (expanded) point; stores M_ab * cell measure; shared by team
+//        Kokkos::View<Scalar*, DeviceType, Kokkos::MemoryUnmanaged> leftFields, rightFields; // cache the field values at each level for faster access
 //        if (fad_size_output_ > 0) {
-//          G_k_StackView     = Kokkos::View<Scalar*,   ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), G_k_StackHeight * numThreads,       fad_size_output_);
-//          G_0_IntegralsView = Kokkos::View<Scalar*,   ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), pointsInNonzeroComponentDimensions, fad_size_output_);
-//          pointWeights   = Kokkos::View<Scalar*, ExecSpaceType, Kokkos::MemoryUnmanaged>  (teamMember.team_shmem(), composedTransform_.extent_int(1), fad_size_output_);
-//          leftFields     = Kokkos::View<Scalar**, ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), maxPointCount_, fad_size_output_);
-//          rightFields    = Kokkos::View<Scalar**, ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), maxPointCount_, fad_size_output_);
+//          G_k_StackView     = Kokkos::View<Scalar*,   DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), G_k_StackHeight * numThreads,       fad_size_output_);
+//          G_0_IntegralsView = Kokkos::View<Scalar*,   DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), pointsInNonzeroComponentDimensions, fad_size_output_);
+//          pointWeights   = Kokkos::View<Scalar*, DeviceType, Kokkos::MemoryUnmanaged>  (teamMember.team_shmem(), composedTransform_.extent_int(1), fad_size_output_);
+//          leftFields     = Kokkos::View<Scalar**, DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), maxPointCount_, fad_size_output_);
+//          rightFields    = Kokkos::View<Scalar**, DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), maxPointCount_, fad_size_output_);
 //        }
 //        else {
-//          G_k_StackView     = Kokkos::View<Scalar*,   ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), G_k_StackHeight * numThreads);
-//          G_0_IntegralsView = Kokkos::View<Scalar*,   ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), pointsInNonzeroComponentDimensions);
-//          pointWeights   = Kokkos::View<Scalar*, ExecSpaceType, Kokkos::MemoryUnmanaged>  (teamMember.team_shmem(), composedTransform_.extent_int(1));
-//          leftFields     = Kokkos::View<Scalar**, ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), maxPointCount_);
-//          rightFields    = Kokkos::View<Scalar**, ExecSpaceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), maxPointCount_);
+//          G_k_StackView     = Kokkos::View<Scalar*,   DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), G_k_StackHeight * numThreads);
+//          G_0_IntegralsView = Kokkos::View<Scalar*,   DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), pointsInNonzeroComponentDimensions);
+//          pointWeights   = Kokkos::View<Scalar*, DeviceType, Kokkos::MemoryUnmanaged>  (teamMember.team_shmem(), composedTransform_.extent_int(1));
+//          leftFields     = Kokkos::View<Scalar**, DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), maxPointCount_);
+//          rightFields    = Kokkos::View<Scalar**, DeviceType, Kokkos::MemoryUnmanaged>(teamMember.team_shmem(), maxPointCount_);
 //        }
 //
 ////        int approximateFlopCount = 0;
@@ -1479,8 +1481,8 @@ namespace Intrepid2 {
 //          {
 //            const int b = b_offset_ + b_component;
 //
-//            const Data<Scalar,ExecSpaceType> &  leftFirstComponent =  leftComponent_.getTensorComponent(0);
-//            const Data<Scalar,ExecSpaceType> & rightFirstComponent = rightComponent_.getTensorComponent(0);
+//            const Data<Scalar,DeviceType> &  leftFirstComponent =  leftComponent_.getTensorComponent(0);
+//            const Data<Scalar,DeviceType> & rightFirstComponent = rightComponent_.getTensorComponent(0);
 //
 //            const int numLeftFieldsFirst  =  leftFirstComponent.extent_int(0); // shape (F,P[,D])
 //            const int numRightFieldsFirst = rightFirstComponent.extent_int(0); // shape (F,P[,D])
@@ -1753,43 +1755,43 @@ namespace Intrepid2 {
         
         if (fad_size_output_ > 0)
         {
-          shmem_size += Kokkos::View<Scalar*,   ExecSpaceType, Kokkos::MemoryUnmanaged>::shmem_size(pointsInNonzeroComponentDimensions, fad_size_output_); // GxIntegrals: entries with x integrated away
-          shmem_size += Kokkos::View<Scalar*,   ExecSpaceType, Kokkos::MemoryUnmanaged>::shmem_size(GyEntryCount * numThreads,          fad_size_output_); // GyIntegrals: entries with x,y integrated away
-          shmem_size += Kokkos::View<Scalar*,   ExecSpaceType, Kokkos::MemoryUnmanaged>::shmem_size(           1 * numThreads,          fad_size_output_); // GzIntegral:  entry   with x,y,z integrated away
-          shmem_size += Kokkos::View<Scalar*, ExecSpaceType, Kokkos::MemoryUnmanaged>::shmem_size  (composedTransform_.extent_int(1), fad_size_output_); // pointWeights
+          shmem_size += Kokkos::View<Scalar*, DeviceType, Kokkos::MemoryUnmanaged>::shmem_size(pointsInNonzeroComponentDimensions, fad_size_output_); // GxIntegrals: entries with x integrated away
+          shmem_size += Kokkos::View<Scalar*, DeviceType, Kokkos::MemoryUnmanaged>::shmem_size(GyEntryCount * numThreads,          fad_size_output_); // GyIntegrals: entries with x,y integrated away
+          shmem_size += Kokkos::View<Scalar*, DeviceType, Kokkos::MemoryUnmanaged>::shmem_size(           1 * numThreads,          fad_size_output_); // GzIntegral:  entry   with x,y,z integrated away
+          shmem_size += Kokkos::View<Scalar*, DeviceType, Kokkos::MemoryUnmanaged>::shmem_size  (composedTransform_.extent_int(1), fad_size_output_); // pointWeights
           
-          shmem_size += Kokkos::View<Scalar**, ExecSpaceType, Kokkos::MemoryUnmanaged>::shmem_size(  leftFieldBounds_[0], pointBounds_[0], fad_size_output_); // leftFields_x
-          shmem_size += Kokkos::View<Scalar**, ExecSpaceType, Kokkos::MemoryUnmanaged>::shmem_size( rightFieldBounds_[0], pointBounds_[0], fad_size_output_); // rightFields_x
-          shmem_size += Kokkos::View<Scalar**, ExecSpaceType, Kokkos::MemoryUnmanaged>::shmem_size(  leftFieldBounds_[1], pointBounds_[1], fad_size_output_); // leftFields_y
-          shmem_size += Kokkos::View<Scalar**, ExecSpaceType, Kokkos::MemoryUnmanaged>::shmem_size( rightFieldBounds_[1], pointBounds_[1], fad_size_output_); // rightFields_y
-          shmem_size += Kokkos::View<Scalar**, ExecSpaceType, Kokkos::MemoryUnmanaged>::shmem_size(  leftFieldBounds_[2], pointBounds_[2], fad_size_output_); // leftFields_z
-          shmem_size += Kokkos::View<Scalar**, ExecSpaceType, Kokkos::MemoryUnmanaged>::shmem_size( rightFieldBounds_[2], pointBounds_[2], fad_size_output_); // rightFields_z
+          shmem_size += Kokkos::View<Scalar**, DeviceType, Kokkos::MemoryUnmanaged>::shmem_size(  leftFieldBounds_[0], pointBounds_[0], fad_size_output_); // leftFields_x
+          shmem_size += Kokkos::View<Scalar**, DeviceType, Kokkos::MemoryUnmanaged>::shmem_size( rightFieldBounds_[0], pointBounds_[0], fad_size_output_); // rightFields_x
+          shmem_size += Kokkos::View<Scalar**, DeviceType, Kokkos::MemoryUnmanaged>::shmem_size(  leftFieldBounds_[1], pointBounds_[1], fad_size_output_); // leftFields_y
+          shmem_size += Kokkos::View<Scalar**, DeviceType, Kokkos::MemoryUnmanaged>::shmem_size( rightFieldBounds_[1], pointBounds_[1], fad_size_output_); // rightFields_y
+          shmem_size += Kokkos::View<Scalar**, DeviceType, Kokkos::MemoryUnmanaged>::shmem_size(  leftFieldBounds_[2], pointBounds_[2], fad_size_output_); // leftFields_z
+          shmem_size += Kokkos::View<Scalar**, DeviceType, Kokkos::MemoryUnmanaged>::shmem_size( rightFieldBounds_[2], pointBounds_[2], fad_size_output_); // rightFields_z
         }
         else
         {
-          shmem_size += Kokkos::View<Scalar*,   ExecSpaceType, Kokkos::MemoryUnmanaged>::shmem_size(pointsInNonzeroComponentDimensions);  // GxIntegrals: entries with x integrated away
-          shmem_size += Kokkos::View<Scalar*,   ExecSpaceType, Kokkos::MemoryUnmanaged>::shmem_size(GyEntryCount * numThreads);           // GyIntegrals: entries with x,y integrated away
-          shmem_size += Kokkos::View<Scalar*,   ExecSpaceType, Kokkos::MemoryUnmanaged>::shmem_size( 1 * numThreads);                     // GzIntegral:  entry   with x,y,z integrated away
-          shmem_size += Kokkos::View<Scalar*, ExecSpaceType, Kokkos::MemoryUnmanaged>::shmem_size  (composedTransform_.extent_int(1)); // pointWeights
+          shmem_size += Kokkos::View<Scalar*, DeviceType, Kokkos::MemoryUnmanaged>::shmem_size(pointsInNonzeroComponentDimensions);  // GxIntegrals: entries with x integrated away
+          shmem_size += Kokkos::View<Scalar*, DeviceType, Kokkos::MemoryUnmanaged>::shmem_size(GyEntryCount * numThreads);           // GyIntegrals: entries with x,y integrated away
+          shmem_size += Kokkos::View<Scalar*, DeviceType, Kokkos::MemoryUnmanaged>::shmem_size( 1 * numThreads);                     // GzIntegral:  entry   with x,y,z integrated away
+          shmem_size += Kokkos::View<Scalar*, DeviceType, Kokkos::MemoryUnmanaged>::shmem_size  (composedTransform_.extent_int(1)); // pointWeights
           
-          shmem_size += Kokkos::View<Scalar**, ExecSpaceType, Kokkos::MemoryUnmanaged>::shmem_size(  leftFieldBounds_[0], pointBounds_[0]); // leftFields_x
-          shmem_size += Kokkos::View<Scalar**, ExecSpaceType, Kokkos::MemoryUnmanaged>::shmem_size( rightFieldBounds_[0], pointBounds_[0]); // rightFields_x
-          shmem_size += Kokkos::View<Scalar**, ExecSpaceType, Kokkos::MemoryUnmanaged>::shmem_size(  leftFieldBounds_[1], pointBounds_[1]); // leftFields_y
-          shmem_size += Kokkos::View<Scalar**, ExecSpaceType, Kokkos::MemoryUnmanaged>::shmem_size( rightFieldBounds_[1], pointBounds_[1]); // rightFields_y
-          shmem_size += Kokkos::View<Scalar**, ExecSpaceType, Kokkos::MemoryUnmanaged>::shmem_size(  leftFieldBounds_[2], pointBounds_[2]); // leftFields_z
-          shmem_size += Kokkos::View<Scalar**, ExecSpaceType, Kokkos::MemoryUnmanaged>::shmem_size( rightFieldBounds_[2], pointBounds_[2]); // rightFields_z
+          shmem_size += Kokkos::View<Scalar**, DeviceType, Kokkos::MemoryUnmanaged>::shmem_size(  leftFieldBounds_[0], pointBounds_[0]); // leftFields_x
+          shmem_size += Kokkos::View<Scalar**, DeviceType, Kokkos::MemoryUnmanaged>::shmem_size( rightFieldBounds_[0], pointBounds_[0]); // rightFields_x
+          shmem_size += Kokkos::View<Scalar**, DeviceType, Kokkos::MemoryUnmanaged>::shmem_size(  leftFieldBounds_[1], pointBounds_[1]); // leftFields_y
+          shmem_size += Kokkos::View<Scalar**, DeviceType, Kokkos::MemoryUnmanaged>::shmem_size( rightFieldBounds_[1], pointBounds_[1]); // rightFields_y
+          shmem_size += Kokkos::View<Scalar**, DeviceType, Kokkos::MemoryUnmanaged>::shmem_size(  leftFieldBounds_[2], pointBounds_[2]); // leftFields_z
+          shmem_size += Kokkos::View<Scalar**, DeviceType, Kokkos::MemoryUnmanaged>::shmem_size( rightFieldBounds_[2], pointBounds_[2]); // rightFields_z
         }
 
         return shmem_size;
       }
     };
-  }
+  } // namespace Impl
 
-template<typename ExecSpaceType>
+template<typename DeviceType>
 template<class Scalar>
-Data<Scalar,ExecSpaceType> IntegrationTools<ExecSpaceType>::allocateIntegralData(const TransformedVectorData<Scalar,ExecSpaceType> vectorDataLeft,
-                                                                                 const TensorData<Scalar,ExecSpaceType> cellMeasures,
-                                                                                 const TransformedVectorData<Scalar,ExecSpaceType> vectorDataRight)
+Data<Scalar,DeviceType> IntegrationTools<DeviceType>::allocateIntegralData(const TransformedVectorData<Scalar,DeviceType> vectorDataLeft,
+                                                                                 const TensorData<Scalar,DeviceType> cellMeasures,
+                                                                                 const TransformedVectorData<Scalar,DeviceType> vectorDataRight)
 {
   // allocates a (C,F,F) container for storing integral data
   
@@ -1817,24 +1819,24 @@ Data<Scalar,ExecSpaceType> IntegrationTools<ExecSpaceType>::allocateIntegralData
   
   if (cellVariationType != CONSTANT)
   {
-    Kokkos::View<Scalar***,ExecSpaceType> data("Intrepid2 integral data",cellDataExtent,numFieldsLeft,numFieldsRight);
-    return Data<Scalar,ExecSpaceType>(data, extents, variationTypes);
+    Kokkos::View<Scalar***,DeviceType> data("Intrepid2 integral data",cellDataExtent,numFieldsLeft,numFieldsRight);
+    return Data<Scalar,DeviceType>(data, extents, variationTypes);
   }
   else
   {
-    Kokkos::View<Scalar**,ExecSpaceType> data("Intrepid2 integral data",numFieldsLeft,numFieldsRight);
-    return Data<Scalar,ExecSpaceType>(data, extents, variationTypes);
+    Kokkos::View<Scalar**,DeviceType> data("Intrepid2 integral data",numFieldsLeft,numFieldsRight);
+    return Data<Scalar,DeviceType>(data, extents, variationTypes);
   }
 }
 
 //! Two use cases:
 //! 1. affine tensor-topology mesh: cellMeasures is a simple tensor product in this case.
 //! 2. arbitrary mesh: cellMeasures has trivial tensor product structure (one tensorial component).
-template<typename ExecSpaceType>
+template<typename DeviceType>
 template<class Scalar>
-void IntegrationTools<ExecSpaceType>::integrate(Data<Scalar,ExecSpaceType> integrals, const TransformedVectorData<Scalar,ExecSpaceType> & vectorDataLeft,
-                                                const TensorData<Scalar,ExecSpaceType> & cellMeasures,
-                                                const TransformedVectorData<Scalar,ExecSpaceType> & vectorDataRight, const bool sumInto,
+void IntegrationTools<DeviceType>::integrate(Data<Scalar,DeviceType> integrals, const TransformedVectorData<Scalar,DeviceType> & vectorDataLeft,
+                                                const TensorData<Scalar,DeviceType> & cellMeasures,
+                                                const TransformedVectorData<Scalar,DeviceType> & vectorDataRight, const bool sumInto,
                                                 double* approximateFlops)
 {
   if (approximateFlops != NULL)
@@ -1871,7 +1873,7 @@ void IntegrationTools<ExecSpaceType>::integrate(Data<Scalar,ExecSpaceType> integ
   {
     for (int vectorComponent=0; vectorComponent<numVectorComponentsLeft; vectorComponent++)
     {
-      const TensorData<Scalar,ExecSpaceType> &tensorData = refVectorLeft.getComponent(familyOrdinal,vectorComponent);
+      const TensorData<Scalar,DeviceType> &tensorData = refVectorLeft.getComponent(familyOrdinal,vectorComponent);
       if (tensorData.numTensorComponents() > 0)
       {
         if (numTensorComponentsLeft == -1)
@@ -1928,7 +1930,7 @@ void IntegrationTools<ExecSpaceType>::integrate(Data<Scalar,ExecSpaceType> integ
       pointDimensions[r] = cellMeasures.getTensorComponent(r+1).extent_int(0);
     }
 
-    Kokkos::Array< Kokkos::Array<ScalarView<Scalar,ExecSpaceType>, Parameters::MaxTensorComponents>, Parameters::MaxTensorComponents> componentIntegrals; // these are reference-space integrals; no Jacobians or cell measures applied as yet
+    Kokkos::Array< Kokkos::Array<ScalarView<Scalar,DeviceType>, Parameters::MaxTensorComponents>, Parameters::MaxTensorComponents> componentIntegrals; // these are reference-space integrals; no Jacobians or cell measures applied as yet
     
     for (int r=0; r<numPointTensorComponents; r++)
     {
@@ -1948,12 +1950,12 @@ void IntegrationTools<ExecSpaceType>::integrate(Data<Scalar,ExecSpaceType> integ
          while the axial components refer to distinct scalar functions, so their numbering in the data container is cumulative.
         */
         
-        const Data<Scalar,ExecSpaceType> &  leftComponent = vectorDataLeft.vectorData().getComponent(d).getTensorComponent(r);
-        const Data<Scalar,ExecSpaceType> & rightComponent = vectorDataRight.vectorData().getComponent(d).getTensorComponent(r);
+        const Data<Scalar,DeviceType> &  leftComponent = vectorDataLeft.vectorData().getComponent(d).getTensorComponent(r);
+        const Data<Scalar,DeviceType> & rightComponent = vectorDataRight.vectorData().getComponent(d).getTensorComponent(r);
         
         // It may be worth considering the possibility that some of these components point to the same data -- if so, we could possibly get better data locality by making the corresponding componentIntegral entries point to the same location as well.  (And we could avoid some computations here.)
         
-        const Data<Scalar,ExecSpaceType> & quadratureWeights = cellMeasures.getTensorComponent(r+1);
+        const Data<Scalar,DeviceType> & quadratureWeights = cellMeasures.getTensorComponent(r+1);
         
         int leftComponentCount  =  leftComponent.extent_int(0);
         int rightComponentCount = rightComponent.extent_int(0);
@@ -1962,11 +1964,11 @@ void IntegrationTools<ExecSpaceType>::integrate(Data<Scalar,ExecSpaceType> integ
         if (allocateFadStorage)
         {
           auto fad_size_output = dimension_scalar(integrals.getUnderlyingView());
-          componentIntegrals[r][d] = ScalarView<Scalar,ExecSpaceType>("componentIntegrals for tensor component " + std::to_string(r) + ", in dimension " + std::to_string(d), leftComponentCount, rightComponentCount, fad_size_output);
+          componentIntegrals[r][d] = ScalarView<Scalar,DeviceType>("componentIntegrals for tensor component " + std::to_string(r) + ", in dimension " + std::to_string(d), leftComponentCount, rightComponentCount, fad_size_output);
         }
         else
         {
-          componentIntegrals[r][d] = ScalarView<Scalar,ExecSpaceType>("componentIntegrals for tensor component " + std::to_string(r) + ", in dimension " + std::to_string(d), leftComponentCount, rightComponentCount);
+          componentIntegrals[r][d] = ScalarView<Scalar,DeviceType>("componentIntegrals for tensor component " + std::to_string(r) + ", in dimension " + std::to_string(d), leftComponentCount, rightComponentCount);
         }
         
         Kokkos::deep_copy(componentIntegrals[r][d], 0.0); // initialize
@@ -1983,6 +1985,7 @@ void IntegrationTools<ExecSpaceType>::integrate(Data<Scalar,ExecSpaceType> integ
 //        INTREPID2_TEST_FOR_EXCEPTION(( leftComponentRank == 3) && ( leftComponent.extent_int(2) > 1), std::invalid_argument, "spaceDim > 1 not yet supported by this integrate() use case.");
 //        INTREPID2_TEST_FOR_EXCEPTION((rightComponentRank == 3) && (rightComponent.extent_int(2) > 1), std::invalid_argument, "spaceDim > 1 not yet supported by this integrate() use case.");
         
+        using ExecSpaceType = typename DeviceType::execution_space;
         auto policy = Kokkos::MDRangePolicy<ExecSpaceType,Kokkos::Rank<2>>({0,0},{leftComponentCount,rightComponentCount});
         
         for (int a=0; a<leftComponentDimSpan; a++)
@@ -2006,11 +2009,12 @@ void IntegrationTools<ExecSpaceType>::integrate(Data<Scalar,ExecSpaceType> integ
         }
       }
     }
+    using ExecSpaceType = typename DeviceType::execution_space;
     ExecSpaceType().fence(); // ensure that kernels launched above have completed before the kernels below launch.
 
     // only one of these will be a valid container:
-    Kokkos::View<Scalar**,  ExecSpaceType> integralView2;
-    Kokkos::View<Scalar***, ExecSpaceType> integralView3;
+    Kokkos::View<Scalar**,  DeviceType> integralView2;
+    Kokkos::View<Scalar***, DeviceType> integralView3;
     if (integralViewRank == 3)
     {
       integralView3 = integrals.getUnderlyingView3();
@@ -2078,6 +2082,7 @@ void IntegrationTools<ExecSpaceType>::integrate(Data<Scalar,ExecSpaceType> integ
             const int d_start = a_offset;
             const int d_end   = d_start + leftDimSpan;
             
+            using ExecSpaceType = typename DeviceType::execution_space;
             if (haveLaunchedContributionToLeftFamily && haveLaunchedContributionToRightFamily)
             {
               // accumulation to the same block in integrals container; fence to ensure that that has completed before the next kernel is launched
@@ -2150,13 +2155,13 @@ void IntegrationTools<ExecSpaceType>::integrate(Data<Scalar,ExecSpaceType> integ
   else // general case (not axis-aligned + affine tensor-product structure)
   {
     // prepare composed transformation matrices
-    const Data<Scalar,ExecSpaceType> & leftTransform  = vectorDataLeft.transform();
-    const Data<Scalar,ExecSpaceType> & rightTransform = vectorDataRight.transform();
+    const Data<Scalar,DeviceType> & leftTransform  = vectorDataLeft.transform();
+    const Data<Scalar,DeviceType> & rightTransform = vectorDataRight.transform();
     const bool transposeLeft  = true;
     const bool transposeRight = false;
 //    auto timer = Teuchos::TimeMonitor::getNewTimer("mat-mat");
 //    timer->start();
-    Data<Scalar,ExecSpaceType> composedTransform = leftTransform.allocateMatMatResult(transposeLeft, leftTransform, transposeRight, rightTransform);
+    Data<Scalar,DeviceType> composedTransform = leftTransform.allocateMatMatResult(transposeLeft, leftTransform, transposeRight, rightTransform);
     composedTransform.storeMatMat(transposeLeft, leftTransform, transposeRight, rightTransform);
 //    timer->stop();
 //    std::cout << "Completed mat-mat in " << timer->totalElapsedTime() << " seconds.\n";
@@ -2182,7 +2187,7 @@ void IntegrationTools<ExecSpaceType>::integrate(Data<Scalar,ExecSpaceType> integ
       bool haveLaunchedContributionToCurrentFamilyLeft = false; // helps to track whether we need a Kokkos::fence before launching a kernel.
       for (int leftComponentOrdinal=0; leftComponentOrdinal<leftComponentCount; leftComponentOrdinal++)
       {
-        const TensorData<Scalar,ExecSpaceType> & leftComponent = vectorDataLeft.vectorData().getComponent(leftFamilyOrdinal, leftComponentOrdinal);
+        const TensorData<Scalar,DeviceType> & leftComponent = vectorDataLeft.vectorData().getComponent(leftFamilyOrdinal, leftComponentOrdinal);
         if (!leftComponent.isValid())
         {
            // represents zero
@@ -2199,7 +2204,7 @@ void IntegrationTools<ExecSpaceType>::integrate(Data<Scalar,ExecSpaceType> integ
           int b_offset = 0;
           for (int rightComponentOrdinal=0; rightComponentOrdinal<rightComponentCount; rightComponentOrdinal++)
           {
-            const TensorData<Scalar,ExecSpaceType> & rightComponent = vectorDataRight.vectorData().getComponent(rightFamilyOrdinal, rightComponentOrdinal);
+            const TensorData<Scalar,DeviceType> & rightComponent = vectorDataRight.vectorData().getComponent(rightFamilyOrdinal, rightComponentOrdinal);
             if (!rightComponent.isValid())
             {
                // represents zero
@@ -2210,6 +2215,7 @@ void IntegrationTools<ExecSpaceType>::integrate(Data<Scalar,ExecSpaceType> integ
             INTREPID2_TEST_FOR_EXCEPTION_DEVICE_SAFE(leftComponent.numTensorComponents() != rightComponent.numTensorComponents(), std::invalid_argument, "left TensorData and right TensorData have different number of tensor components.  This is not supported.");
             
             const int vectorSize = getVectorSizeForHierarchicalParallelism<Scalar>();
+            using ExecSpaceType = typename DeviceType::execution_space;
             Kokkos::TeamPolicy<ExecSpaceType> policy = Kokkos::TeamPolicy<ExecSpaceType>(cellDataExtent,Kokkos::AUTO(),vectorSize);
             
             // TODO: expose the options for forceNonSpecialized and usePointCacheForRank3Tensor through an IntegrationAlgorithm enumeration.
@@ -2235,7 +2241,7 @@ void IntegrationTools<ExecSpaceType>::integrate(Data<Scalar,ExecSpaceType> integ
             {
               if (usePointCacheForRank3Tensor && (leftComponent.numTensorComponents() == 3))
               {
-                auto functor = Impl::F_IntegratePointValueCache<Scalar, ExecSpaceType, 2>(integrals, leftComponent, composedTransform, rightComponent, cellMeasures, a_offset, b_offset, leftFieldOrdinalOffset, rightFieldOrdinalOffset);
+                auto functor = Impl::F_IntegratePointValueCache<Scalar, DeviceType, 2>(integrals, leftComponent, composedTransform, rightComponent, cellMeasures, a_offset, b_offset, leftFieldOrdinalOffset, rightFieldOrdinalOffset);
                 
                 const int maxTeamSize = policy.team_size_max(functor,Kokkos::ParallelForTag());
                 const int teamSize    = functor.teamSize(maxTeamSize);
@@ -2251,7 +2257,7 @@ void IntegrationTools<ExecSpaceType>::integrate(Data<Scalar,ExecSpaceType> integ
               }
               else
               {
-                auto functor = Impl::F_Integrate<Scalar, ExecSpaceType, 2>(integrals, leftComponent, composedTransform, rightComponent, cellMeasures, a_offset, b_offset, leftFieldOrdinalOffset, rightFieldOrdinalOffset, forceNonSpecialized);
+                auto functor = Impl::F_Integrate<Scalar, DeviceType, 2>(integrals, leftComponent, composedTransform, rightComponent, cellMeasures, a_offset, b_offset, leftFieldOrdinalOffset, rightFieldOrdinalOffset, forceNonSpecialized);
                 
                 const int maxTeamSize = policy.team_size_max(functor,Kokkos::ParallelForTag());
                 const int teamSize    = functor.teamSize(maxTeamSize);
@@ -2270,7 +2276,7 @@ void IntegrationTools<ExecSpaceType>::integrate(Data<Scalar,ExecSpaceType> integ
             {
               if (usePointCacheForRank3Tensor && (leftComponent.numTensorComponents() == 3))
               {
-                auto functor = Impl::F_IntegratePointValueCache<Scalar, ExecSpaceType, 3>(integrals, leftComponent, composedTransform, rightComponent, cellMeasures, a_offset, b_offset, leftFieldOrdinalOffset, rightFieldOrdinalOffset);
+                auto functor = Impl::F_IntegratePointValueCache<Scalar, DeviceType, 3>(integrals, leftComponent, composedTransform, rightComponent, cellMeasures, a_offset, b_offset, leftFieldOrdinalOffset, rightFieldOrdinalOffset);
                 
                 const int maxTeamSize = policy.team_size_max(functor,Kokkos::ParallelForTag());
                 const int teamSize    = functor.teamSize(maxTeamSize);
@@ -2286,7 +2292,7 @@ void IntegrationTools<ExecSpaceType>::integrate(Data<Scalar,ExecSpaceType> integ
               }
               else
               {
-                auto functor = Impl::F_Integrate<Scalar, ExecSpaceType, 3>(integrals, leftComponent, composedTransform, rightComponent, cellMeasures, a_offset, b_offset, leftFieldOrdinalOffset, rightFieldOrdinalOffset, forceNonSpecialized);
+                auto functor = Impl::F_Integrate<Scalar, DeviceType, 3>(integrals, leftComponent, composedTransform, rightComponent, cellMeasures, a_offset, b_offset, leftFieldOrdinalOffset, rightFieldOrdinalOffset, forceNonSpecialized);
                 
                 const int maxTeamSize = policy.team_size_max(functor,Kokkos::ParallelForTag());
                 const int teamSize    = functor.teamSize(maxTeamSize);
@@ -2314,6 +2320,7 @@ void IntegrationTools<ExecSpaceType>::integrate(Data<Scalar,ExecSpaceType> integ
 //  {
 //    std::cout << "Approximate flop count (new): " << *approximateFlops << std::endl;
 //  }
+  using ExecSpaceType = typename DeviceType::execution_space;
   ExecSpaceType().fence(); // make sure we've finished writing to integrals container before exiting…
 }
 

--- a/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefCoeffMatrix_HCURL.hpp
+++ b/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefCoeffMatrix_HCURL.hpp
@@ -183,6 +183,7 @@ getCoeffMatrix_HCURL(OutputViewType &output,
 #endif
 
   using ScalarType = typename cellBasisType::scalarType;
+  using DeviceType = typename cellBasisType::DeviceType;
   using ExecutionSpace = typename cellBasisType::ExecutionSpace;
   using HostExecutionSpace =
       typename Kokkos::Impl::is_space<ExecutionSpace>::host_mirror_space::execution_space;
@@ -212,15 +213,15 @@ getCoeffMatrix_HCURL(OutputViewType &output,
   // Tangents t_j
   ScalarViewType subcellTangents("subcellTangents", numSubcellBasis, subcellDim);
   auto degree = subcellBasis.getDegree();
-  BasisPtr<ExecutionSpace, ScalarType, ScalarType> basisPtr;
+  BasisPtr<DeviceType, ScalarType, ScalarType> basisPtr;
   if(subcellBaseKey == shards::Line<>::key) {
-    basisPtr = Teuchos::rcp(new Intrepid2::Basis_HVOL_LINE_Cn_FEM<ExecutionSpace, ScalarType, ScalarType>(degree));
+    basisPtr = Teuchos::rcp(new Intrepid2::Basis_HVOL_LINE_Cn_FEM<DeviceType, ScalarType, ScalarType>(degree));
     basisPtr->getDofCoeffs(Kokkos::subview(subcellTangents, Kokkos::ALL(),0));
   } else if (subcellBaseKey == shards::Triangle<>::key) {
-    basisPtr = Teuchos::rcp(new Intrepid2::Basis_HCURL_TRI_In_FEM<ExecutionSpace, ScalarType, ScalarType>(degree));
+    basisPtr = Teuchos::rcp(new Intrepid2::Basis_HCURL_TRI_In_FEM<DeviceType, ScalarType, ScalarType>(degree));
     basisPtr->getDofCoeffs(subcellTangents);
   } else if (subcellBaseKey == shards::Quadrilateral<>::key) {
-    basisPtr =  Teuchos::rcp(new Intrepid2::Basis_HCURL_QUAD_In_FEM<ExecutionSpace, ScalarType, ScalarType>(degree));
+    basisPtr =  Teuchos::rcp(new Intrepid2::Basis_HCURL_QUAD_In_FEM<DeviceType, ScalarType, ScalarType>(degree));
     basisPtr->getDofCoeffs(subcellTangents);
   }
 

--- a/packages/intrepid2/src/Projection/Intrepid2_ProjectionStruct.hpp
+++ b/packages/intrepid2/src/Projection/Intrepid2_ProjectionStruct.hpp
@@ -91,6 +91,7 @@ public:
 
   typedef Kokkos::pair<ordinal_type,ordinal_type> range_type;
   typedef typename Kokkos::Impl::is_space<SpT>::host_mirror_space::execution_space host_space_type;
+  using HostDeviceType = typename host_space_type::device_type;
   typedef Kokkos::DynRankView<ValueType,host_space_type> view_type;
   typedef Kokkos::View<range_type**,host_space_type> range_tag;
   static constexpr int numberSubCellDims = 4; //{0 for vertex, 1 for edges, 2 for faces, 3 for volumes}

--- a/packages/intrepid2/src/Projection/Intrepid2_ProjectionStructDef.hpp
+++ b/packages/intrepid2/src/Projection/Intrepid2_ProjectionStructDef.hpp
@@ -131,7 +131,7 @@ void ProjectionStruct<SpT,ValueType>::createL2ProjectionStruct(const BasisPtrTyp
   for(ordinal_type ie=0; ie<numEdges; ++ie) {
     ordinal_type cub_degree = 2*edgeBasisCubDegree;
     subCellTopologyKey(edgeDim,ie) = cellBasis->getBaseCellTopology().getKey(edgeDim, ie);
-    auto edgeBasisCub = cub_factory.create<host_space_type, ValueType, ValueType>(cellBasis->getBaseCellTopology().getKey(edgeDim, ie), cub_degree);
+    auto edgeBasisCub = cub_factory.create<HostDeviceType, ValueType, ValueType>(cellBasis->getBaseCellTopology().getKey(edgeDim, ie), cub_degree);
     basisPointsRange(edgeDim,ie) = range_type(numBasisEvalPoints, numBasisEvalPoints+edgeBasisCub->getNumPoints());
     numBasisEvalPoints +=  edgeBasisCub->getNumPoints();
     maxNumBasisEvalPoints = std::max(maxNumBasisEvalPoints, edgeBasisCub->getNumPoints());
@@ -140,7 +140,7 @@ void ProjectionStruct<SpT,ValueType>::createL2ProjectionStruct(const BasisPtrTyp
     edgeBasisCub->getCubature(basisCubPoints[edgeDim][ie], basisCubWeights[edgeDim][ie]);
 
     cub_degree = edgeBasisCubDegree + targetCubDegree;
-    auto edgeTargetCub = cub_factory.create<host_space_type, ValueType, ValueType>(cellBasis->getBaseCellTopology().getKey(edgeDim, ie), cub_degree);
+    auto edgeTargetCub = cub_factory.create<HostDeviceType, ValueType, ValueType>(cellBasis->getBaseCellTopology().getKey(edgeDim, ie), cub_degree);
     targetPointsRange(edgeDim,ie) = range_type(numTargetEvalPoints, numTargetEvalPoints+edgeTargetCub->getNumPoints());
     numTargetEvalPoints +=  edgeTargetCub->getNumPoints();
     maxNumTargetEvalPoints = std::max(maxNumTargetEvalPoints, edgeTargetCub->getNumPoints());
@@ -152,7 +152,7 @@ void ProjectionStruct<SpT,ValueType>::createL2ProjectionStruct(const BasisPtrTyp
   for(ordinal_type iface=0; iface<numFaces; ++iface) {
     ordinal_type cub_degree = 2*faceBasisCubDegree;
     subCellTopologyKey(faceDim,iface) = cellBasis->getBaseCellTopology().getKey(faceDim, iface);
-    auto faceBasisCub = cub_factory.create<host_space_type, ValueType, ValueType>(subCellTopologyKey(faceDim,iface), cub_degree);
+    auto faceBasisCub = cub_factory.create<HostDeviceType, ValueType, ValueType>(subCellTopologyKey(faceDim,iface), cub_degree);
     basisPointsRange(faceDim,iface) = range_type(numBasisEvalPoints, numBasisEvalPoints+faceBasisCub->getNumPoints());
     numBasisEvalPoints +=  faceBasisCub->getNumPoints();
     maxNumBasisEvalPoints = std::max(maxNumBasisEvalPoints, faceBasisCub->getNumPoints());
@@ -161,7 +161,7 @@ void ProjectionStruct<SpT,ValueType>::createL2ProjectionStruct(const BasisPtrTyp
     faceBasisCub->getCubature(basisCubPoints[faceDim][iface], basisCubWeights[faceDim][iface]);
 
     cub_degree = faceBasisCubDegree + targetCubDegree;
-    auto faceTargetCub = cub_factory.create<host_space_type, ValueType, ValueType>(subCellTopologyKey(faceDim,iface), cub_degree);
+    auto faceTargetCub = cub_factory.create<HostDeviceType, ValueType, ValueType>(subCellTopologyKey(faceDim,iface), cub_degree);
     targetPointsRange(faceDim,iface) = range_type(numTargetEvalPoints, numTargetEvalPoints+faceTargetCub->getNumPoints());
     numTargetEvalPoints +=  faceTargetCub->getNumPoints();
     maxNumTargetEvalPoints = std::max(maxNumTargetEvalPoints, faceTargetCub->getNumPoints());
@@ -172,7 +172,7 @@ void ProjectionStruct<SpT,ValueType>::createL2ProjectionStruct(const BasisPtrTyp
   subCellTopologyKey(dim,0) = cellBasis->getBaseCellTopology().getBaseKey();
   if(hasCellDofs) {
     ordinal_type cub_degree = 2*basisCubDegree;
-    auto elemBasisCub = cub_factory.create<host_space_type, ValueType, ValueType>(subCellTopologyKey(dim,0), cub_degree);
+    auto elemBasisCub = cub_factory.create<HostDeviceType, ValueType, ValueType>(subCellTopologyKey(dim,0), cub_degree);
     basisPointsRange(dim,0) = range_type(numBasisEvalPoints, numBasisEvalPoints+elemBasisCub->getNumPoints());
     numBasisEvalPoints +=  elemBasisCub->getNumPoints();
     maxNumBasisEvalPoints = std::max(maxNumBasisEvalPoints, elemBasisCub->getNumPoints());
@@ -181,7 +181,7 @@ void ProjectionStruct<SpT,ValueType>::createL2ProjectionStruct(const BasisPtrTyp
     elemBasisCub->getCubature(basisCubPoints[dim][0], basisCubWeights[dim][0]);
 
     cub_degree = basisCubDegree + targetCubDegree;
-    auto elemTargetCub = cub_factory.create<host_space_type, ValueType, ValueType>(subCellTopologyKey(dim,0), cub_degree);
+    auto elemTargetCub = cub_factory.create<HostDeviceType, ValueType, ValueType>(subCellTopologyKey(dim,0), cub_degree);
     targetPointsRange(dim,0) = range_type(numTargetEvalPoints, numTargetEvalPoints+elemTargetCub->getNumPoints());
     numTargetEvalPoints +=  elemTargetCub->getNumPoints();
     maxNumTargetEvalPoints = std::max(maxNumTargetEvalPoints, elemTargetCub->getNumPoints());
@@ -248,7 +248,7 @@ void ProjectionStruct<SpT,ValueType>::createHGradProjectionStruct(const BasisPtr
   for(ordinal_type ie=0; ie<numEdges; ++ie) {
     ordinal_type cub_degree = 2*edgeBasisCubDegree;
     subCellTopologyKey(edgeDim,ie) = cellBasis->getBaseCellTopology().getKey(edgeDim, ie);
-    auto edgeBasisCub = cub_factory.create<host_space_type, ValueType, ValueType>(cellBasis->getBaseCellTopology().getKey(edgeDim, ie), cub_degree);
+    auto edgeBasisCub = cub_factory.create<HostDeviceType, ValueType, ValueType>(cellBasis->getBaseCellTopology().getKey(edgeDim, ie), cub_degree);
     basisDerivPointsRange(edgeDim,ie) = range_type(numBasisDerivEvalPoints, numBasisDerivEvalPoints+edgeBasisCub->getNumPoints());
     numBasisDerivEvalPoints +=  edgeBasisCub->getNumPoints();
     maxNumBasisDerivEvalPoints = std::max(maxNumBasisDerivEvalPoints, edgeBasisCub->getNumPoints());
@@ -257,7 +257,7 @@ void ProjectionStruct<SpT,ValueType>::createHGradProjectionStruct(const BasisPtr
     edgeBasisCub->getCubature(basisDerivCubPoints[edgeDim][ie], basisDerivCubWeights[edgeDim][ie]);
 
     cub_degree = edgeBasisCubDegree + targetGradCubDegree;
-    auto edgeTargetCub = cub_factory.create<host_space_type, ValueType, ValueType>(cellBasis->getBaseCellTopology().getKey(edgeDim, ie), cub_degree);
+    auto edgeTargetCub = cub_factory.create<HostDeviceType, ValueType, ValueType>(cellBasis->getBaseCellTopology().getKey(edgeDim, ie), cub_degree);
     targetDerivPointsRange(edgeDim,ie) = range_type(numTargetDerivEvalPoints, numTargetDerivEvalPoints+edgeTargetCub->getNumPoints());
     numTargetDerivEvalPoints +=  edgeTargetCub->getNumPoints();
     maxNumTargetDerivEvalPoints = std::max(maxNumTargetDerivEvalPoints, edgeTargetCub->getNumPoints());
@@ -269,7 +269,7 @@ void ProjectionStruct<SpT,ValueType>::createHGradProjectionStruct(const BasisPtr
   for(ordinal_type iface=0; iface<numFaces; ++iface) {
     ordinal_type cub_degree = 2*faceBasisCubDegree;
     subCellTopologyKey(faceDim,iface) = cellBasis->getBaseCellTopology().getKey(faceDim, iface);
-    auto faceBasisGradCub = cub_factory.create<host_space_type, ValueType, ValueType>(subCellTopologyKey(faceDim,iface), cub_degree);
+    auto faceBasisGradCub = cub_factory.create<HostDeviceType, ValueType, ValueType>(subCellTopologyKey(faceDim,iface), cub_degree);
     basisDerivPointsRange(faceDim,iface) = range_type(numBasisDerivEvalPoints, numBasisDerivEvalPoints+faceBasisGradCub->getNumPoints());
     numBasisDerivEvalPoints +=  faceBasisGradCub->getNumPoints();
     maxNumBasisDerivEvalPoints = std::max(maxNumBasisDerivEvalPoints, faceBasisGradCub->getNumPoints());
@@ -278,7 +278,7 @@ void ProjectionStruct<SpT,ValueType>::createHGradProjectionStruct(const BasisPtr
     faceBasisGradCub->getCubature(basisDerivCubPoints[faceDim][iface], basisDerivCubWeights[faceDim][iface]);
 
     cub_degree = faceBasisCubDegree + targetGradCubDegree;
-    auto faceTargetDerivCub = cub_factory.create<host_space_type, ValueType, ValueType>(subCellTopologyKey(faceDim,iface), cub_degree);
+    auto faceTargetDerivCub = cub_factory.create<HostDeviceType, ValueType, ValueType>(subCellTopologyKey(faceDim,iface), cub_degree);
     targetDerivPointsRange(faceDim,iface) = range_type(numTargetDerivEvalPoints, numTargetDerivEvalPoints+faceTargetDerivCub->getNumPoints());
     numTargetDerivEvalPoints +=  faceTargetDerivCub->getNumPoints();
     maxNumTargetDerivEvalPoints = std::max(maxNumTargetDerivEvalPoints, faceTargetDerivCub->getNumPoints());
@@ -289,7 +289,7 @@ void ProjectionStruct<SpT,ValueType>::createHGradProjectionStruct(const BasisPtr
   subCellTopologyKey(dim,0) = cellBasis->getBaseCellTopology().getBaseKey();
   if(hasCellDofs) {
     ordinal_type cub_degree = 2*basisCubDegree;
-    auto elemBasisGradCub = cub_factory.create<host_space_type, ValueType, ValueType>(subCellTopologyKey(dim,0), cub_degree);
+    auto elemBasisGradCub = cub_factory.create<HostDeviceType, ValueType, ValueType>(subCellTopologyKey(dim,0), cub_degree);
     basisDerivPointsRange(dim,0) = range_type(numBasisDerivEvalPoints, numBasisDerivEvalPoints+elemBasisGradCub->getNumPoints());
     numBasisDerivEvalPoints +=  elemBasisGradCub->getNumPoints();
     maxNumBasisDerivEvalPoints = std::max(maxNumBasisDerivEvalPoints, elemBasisGradCub->getNumPoints());
@@ -298,7 +298,7 @@ void ProjectionStruct<SpT,ValueType>::createHGradProjectionStruct(const BasisPtr
     elemBasisGradCub->getCubature(basisDerivCubPoints[dim][0], basisDerivCubWeights[dim][0]);
 
     cub_degree = basisCubDegree + targetGradCubDegree;
-    auto elemTargetGradCub = cub_factory.create<host_space_type, ValueType, ValueType>(subCellTopologyKey(dim,0), cub_degree);
+    auto elemTargetGradCub = cub_factory.create<HostDeviceType, ValueType, ValueType>(subCellTopologyKey(dim,0), cub_degree);
     targetDerivPointsRange(dim,0) = range_type(numTargetDerivEvalPoints, numTargetDerivEvalPoints+elemTargetGradCub->getNumPoints());
     numTargetDerivEvalPoints +=  elemTargetGradCub->getNumPoints();
     maxNumTargetDerivEvalPoints = std::max(maxNumTargetDerivEvalPoints, elemTargetGradCub->getNumPoints());
@@ -343,7 +343,7 @@ void ProjectionStruct<SpT,ValueType>::createHCurlProjectionStruct(const BasisPtr
   for(ordinal_type ie=0; ie<numEdges; ++ie) {
     ordinal_type cub_degree = 2*edgeBasisCubDegree;
     subCellTopologyKey(edgeDim,ie) = cellBasis->getBaseCellTopology().getKey(edgeDim, ie);
-    auto edgeBasisCub = cub_factory.create<host_space_type, ValueType, ValueType>(subCellTopologyKey(edgeDim,ie), cub_degree);
+    auto edgeBasisCub = cub_factory.create<HostDeviceType, ValueType, ValueType>(subCellTopologyKey(edgeDim,ie), cub_degree);
     basisPointsRange(edgeDim,ie) = range_type(numBasisEvalPoints, numBasisEvalPoints+edgeBasisCub->getNumPoints());
     numBasisEvalPoints +=  edgeBasisCub->getNumPoints();
     maxNumBasisEvalPoints = std::max(maxNumBasisEvalPoints, edgeBasisCub->getNumPoints());
@@ -352,7 +352,7 @@ void ProjectionStruct<SpT,ValueType>::createHCurlProjectionStruct(const BasisPtr
     edgeBasisCub->getCubature(basisCubPoints[edgeDim][ie], basisCubWeights[edgeDim][ie]);
 
     cub_degree = edgeBasisCubDegree + targetCubDegree;
-    auto edgeTargetCub = cub_factory.create<host_space_type, ValueType, ValueType>(subCellTopologyKey(edgeDim,ie), cub_degree);
+    auto edgeTargetCub = cub_factory.create<HostDeviceType, ValueType, ValueType>(subCellTopologyKey(edgeDim,ie), cub_degree);
     targetPointsRange(edgeDim,ie) = range_type(numTargetEvalPoints, numTargetEvalPoints+edgeTargetCub->getNumPoints());
     numTargetEvalPoints +=  edgeTargetCub->getNumPoints();
     maxNumTargetEvalPoints = std::max(maxNumTargetEvalPoints, edgeTargetCub->getNumPoints());
@@ -364,7 +364,7 @@ void ProjectionStruct<SpT,ValueType>::createHCurlProjectionStruct(const BasisPtr
   for(ordinal_type iface=0; iface<numFaces; ++iface) {
     ordinal_type cub_degree = 2*faceBasisCubDegree;
     subCellTopologyKey(faceDim,iface) = cellBasis->getBaseCellTopology().getKey(faceDim, iface);
-    auto faceBasisCub = cub_factory.create<host_space_type, ValueType, ValueType>(subCellTopologyKey(faceDim,iface), cub_degree);
+    auto faceBasisCub = cub_factory.create<HostDeviceType, ValueType, ValueType>(subCellTopologyKey(faceDim,iface), cub_degree);
     basisPointsRange(faceDim,iface) = range_type(numBasisEvalPoints, numBasisEvalPoints+faceBasisCub->getNumPoints());
     numBasisEvalPoints +=  faceBasisCub->getNumPoints();
     maxNumBasisEvalPoints = std::max(maxNumBasisEvalPoints, faceBasisCub->getNumPoints());
@@ -372,7 +372,7 @@ void ProjectionStruct<SpT,ValueType>::createHCurlProjectionStruct(const BasisPtr
     basisCubWeights[faceDim][iface] = view_type("basisCubWeights",faceBasisCub->getNumPoints());
     faceBasisCub->getCubature(basisCubPoints[faceDim][iface], basisCubWeights[faceDim][iface]);
 
-    auto faceBasisDerivCub = cub_factory.create<host_space_type, ValueType, ValueType>(subCellTopologyKey(faceDim,iface), cub_degree);
+    auto faceBasisDerivCub = cub_factory.create<HostDeviceType, ValueType, ValueType>(subCellTopologyKey(faceDim,iface), cub_degree);
     basisDerivPointsRange(faceDim,iface) = range_type(numBasisDerivEvalPoints, numBasisDerivEvalPoints+faceBasisCub->getNumPoints());
     numBasisDerivEvalPoints +=  faceBasisCub->getNumPoints();
     maxNumBasisDerivEvalPoints = std::max(maxNumBasisDerivEvalPoints, faceBasisCub->getNumPoints());
@@ -381,7 +381,7 @@ void ProjectionStruct<SpT,ValueType>::createHCurlProjectionStruct(const BasisPtr
     faceBasisCub->getCubature(basisDerivCubPoints[faceDim][iface], basisDerivCubWeights[faceDim][iface]);
 
     cub_degree = faceBasisCubDegree + targetCubDegree;
-    auto faceTargetCub = cub_factory.create<host_space_type, ValueType, ValueType>(subCellTopologyKey(faceDim,iface), cub_degree);
+    auto faceTargetCub = cub_factory.create<HostDeviceType, ValueType, ValueType>(subCellTopologyKey(faceDim,iface), cub_degree);
     targetPointsRange(faceDim,iface) = range_type(numTargetEvalPoints, numTargetEvalPoints+faceTargetCub->getNumPoints());
     numTargetEvalPoints +=  faceTargetCub->getNumPoints();
     maxNumTargetEvalPoints = std::max(maxNumTargetEvalPoints, faceTargetCub->getNumPoints());
@@ -390,7 +390,7 @@ void ProjectionStruct<SpT,ValueType>::createHCurlProjectionStruct(const BasisPtr
     faceTargetCub->getCubature(targetCubPoints[faceDim][iface], targetCubWeights[faceDim][iface]);
 
     cub_degree = faceBasisCubDegree + targetCurlCubDegre;
-    auto faceTargetDerivCub = cub_factory.create<host_space_type, ValueType, ValueType>(subCellTopologyKey(faceDim,iface), cub_degree);
+    auto faceTargetDerivCub = cub_factory.create<HostDeviceType, ValueType, ValueType>(subCellTopologyKey(faceDim,iface), cub_degree);
     targetDerivPointsRange(faceDim,iface) = range_type(numTargetDerivEvalPoints, numTargetDerivEvalPoints+faceTargetDerivCub->getNumPoints());
     numTargetDerivEvalPoints +=  faceTargetDerivCub->getNumPoints();
     maxNumTargetDerivEvalPoints = std::max(maxNumTargetDerivEvalPoints, faceTargetDerivCub->getNumPoints());
@@ -402,7 +402,7 @@ void ProjectionStruct<SpT,ValueType>::createHCurlProjectionStruct(const BasisPtr
   subCellTopologyKey(dim,0) = cellBasis->getBaseCellTopology().getBaseKey();
   if(hasCellDofs) {
     ordinal_type cub_degree = 2*basisCubDegree;
-    auto elemBasisCub = cub_factory.create<host_space_type, ValueType, ValueType>(subCellTopologyKey(dim,0), cub_degree);
+    auto elemBasisCub = cub_factory.create<HostDeviceType, ValueType, ValueType>(subCellTopologyKey(dim,0), cub_degree);
     basisPointsRange(dim,0) = range_type(numBasisEvalPoints, numBasisEvalPoints+elemBasisCub->getNumPoints());
     numBasisEvalPoints +=  elemBasisCub->getNumPoints();
     maxNumBasisEvalPoints = std::max(maxNumBasisEvalPoints, elemBasisCub->getNumPoints());
@@ -418,7 +418,7 @@ void ProjectionStruct<SpT,ValueType>::createHCurlProjectionStruct(const BasisPtr
     elemBasisCub->getCubature(basisDerivCubPoints[dim][0], basisDerivCubWeights[dim][0]);
 
     cub_degree = basisCubDegree + targetCubDegree;
-    auto elemTargetCub = cub_factory.create<host_space_type, ValueType, ValueType>(subCellTopologyKey(dim,0), cub_degree);
+    auto elemTargetCub = cub_factory.create<HostDeviceType, ValueType, ValueType>(subCellTopologyKey(dim,0), cub_degree);
     targetPointsRange(dim,0) = range_type(numTargetEvalPoints, numTargetEvalPoints+elemTargetCub->getNumPoints());
     numTargetEvalPoints +=  elemTargetCub->getNumPoints();
     maxNumTargetEvalPoints = std::max(maxNumTargetEvalPoints, elemTargetCub->getNumPoints());
@@ -427,7 +427,7 @@ void ProjectionStruct<SpT,ValueType>::createHCurlProjectionStruct(const BasisPtr
     elemTargetCub->getCubature(targetCubPoints[dim][0], targetCubWeights[dim][0]);
 
     cub_degree = basisCubDegree + targetCurlCubDegre;
-    auto elemTargetCurlCub = cub_factory.create<host_space_type, ValueType, ValueType>(subCellTopologyKey(dim,0), cub_degree);
+    auto elemTargetCurlCub = cub_factory.create<HostDeviceType, ValueType, ValueType>(subCellTopologyKey(dim,0), cub_degree);
     targetDerivPointsRange(dim,0) = range_type(numTargetDerivEvalPoints, numTargetDerivEvalPoints+elemTargetCurlCub->getNumPoints());
     numTargetDerivEvalPoints +=  elemTargetCurlCub->getNumPoints();
     maxNumTargetDerivEvalPoints = std::max(maxNumTargetDerivEvalPoints, elemTargetCurlCub->getNumPoints());
@@ -468,15 +468,15 @@ void ProjectionStruct<SpT,ValueType>::createHDivProjectionStruct(const BasisPtrT
   targetDerivPointsRange = range_tag("targetDerivPointsRange", numberSubCellDims,maxSubCellsCount);
   subCellTopologyKey = key_tag("subCellTopologyKey",numberSubCellDims,maxSubCellsCount);
 
-  Basis<host_space_type,ValueType,ValueType> *hcurlBasis = NULL;
+  Basis<HostDeviceType,ValueType,ValueType> *hcurlBasis = NULL;
   if(cellTopo.getKey() == shards::getCellTopologyData<shards::Hexahedron<8> >()->key)
-    hcurlBasis = new Basis_HCURL_HEX_In_FEM<host_space_type,ValueType,ValueType>(cellBasis->getDegree());
+    hcurlBasis = new Basis_HCURL_HEX_In_FEM<HostDeviceType,ValueType,ValueType>(cellBasis->getDegree());
   else if(cellTopo.getKey() == shards::getCellTopologyData<shards::Tetrahedron<4> >()->key)
-    hcurlBasis = new Basis_HCURL_TET_In_FEM<host_space_type,ValueType,ValueType>(cellBasis->getDegree());
+    hcurlBasis = new Basis_HCURL_TET_In_FEM<HostDeviceType,ValueType,ValueType>(cellBasis->getDegree());
   else if(cellTopo.getKey() == shards::getCellTopologyData<shards::Quadrilateral<4> >()->key)
-    hcurlBasis = new Basis_HGRAD_QUAD_Cn_FEM<host_space_type,ValueType,ValueType>(cellBasis->getDegree());
+    hcurlBasis = new Basis_HGRAD_QUAD_Cn_FEM<HostDeviceType,ValueType,ValueType>(cellBasis->getDegree());
   else if(cellTopo.getKey() == shards::getCellTopologyData<shards::Triangle<3> >()->key)
-    hcurlBasis = new Basis_HGRAD_TRI_Cn_FEM<host_space_type,ValueType,ValueType>(cellBasis->getDegree());
+    hcurlBasis = new Basis_HGRAD_TRI_Cn_FEM<HostDeviceType,ValueType,ValueType>(cellBasis->getDegree());
   else  {
     std::stringstream ss;
     ss << ">>> ERROR (Intrepid2::ProjectionTools::createHDivProjectionStruct): "
@@ -492,7 +492,7 @@ void ProjectionStruct<SpT,ValueType>::createHDivProjectionStruct(const BasisPtrT
   for(ordinal_type is=0; is<numSides; ++is) {
     ordinal_type cub_degree = 2*sideBasisCubDegree;
     subCellTopologyKey(sideDim,is) = cellBasis->getBaseCellTopology().getKey(sideDim, is);
-    auto sideBasisCub = cub_factory.create<host_space_type, ValueType, ValueType>(subCellTopologyKey(sideDim,is), cub_degree);
+    auto sideBasisCub = cub_factory.create<HostDeviceType, ValueType, ValueType>(subCellTopologyKey(sideDim,is), cub_degree);
     basisPointsRange(sideDim,is) = range_type(numBasisEvalPoints, numBasisEvalPoints+sideBasisCub->getNumPoints());
     numBasisEvalPoints +=  sideBasisCub->getNumPoints();
     basisCubPoints[sideDim][is] = view_type("basisCubPoints",sideBasisCub->getNumPoints(),sideDim);
@@ -501,7 +501,7 @@ void ProjectionStruct<SpT,ValueType>::createHDivProjectionStruct(const BasisPtrT
     maxNumBasisEvalPoints = std::max(maxNumBasisEvalPoints, sideBasisCub->getNumPoints());
 
     cub_degree = sideBasisCubDegree + targetCubDegree;
-    auto sideTargetCub = cub_factory.create<host_space_type, ValueType, ValueType>(subCellTopologyKey(sideDim,is), cub_degree);
+    auto sideTargetCub = cub_factory.create<HostDeviceType, ValueType, ValueType>(subCellTopologyKey(sideDim,is), cub_degree);
     targetPointsRange(sideDim,is) = range_type(numTargetEvalPoints, numTargetEvalPoints+sideTargetCub->getNumPoints());
     numTargetEvalPoints +=  sideTargetCub->getNumPoints();
     targetCubPoints[sideDim][is] = view_type("targetCubPoints",sideTargetCub->getNumPoints(),sideDim);
@@ -513,7 +513,7 @@ void ProjectionStruct<SpT,ValueType>::createHDivProjectionStruct(const BasisPtrT
   subCellTopologyKey(dim,0) = cellBasis->getBaseCellTopology().getBaseKey();
   if(hasCellDofs) {
     ordinal_type cub_degree = 2*basisCubDegree - 1;
-    auto elemBasisDivCub = cub_factory.create<host_space_type, ValueType, ValueType>(subCellTopologyKey(dim,0), cub_degree);
+    auto elemBasisDivCub = cub_factory.create<HostDeviceType, ValueType, ValueType>(subCellTopologyKey(dim,0), cub_degree);
     basisDerivPointsRange(dim,0) = range_type(numBasisDerivEvalPoints, numBasisDerivEvalPoints+elemBasisDivCub->getNumPoints());
     numBasisDerivEvalPoints +=  elemBasisDivCub->getNumPoints();
     basisDerivCubPoints[dim][0] = view_type("basisDerivCubPoints",elemBasisDivCub->getNumPoints(),dim);
@@ -522,7 +522,7 @@ void ProjectionStruct<SpT,ValueType>::createHDivProjectionStruct(const BasisPtrT
     maxNumBasisDerivEvalPoints = std::max(maxNumBasisDerivEvalPoints, elemBasisDivCub->getNumPoints());
 
     cub_degree = basisCubDegree - 1 + targetDivCubDegre;
-    auto elemTargetDivCub = cub_factory.create<host_space_type, ValueType, ValueType>(subCellTopologyKey(dim,0), cub_degree);
+    auto elemTargetDivCub = cub_factory.create<HostDeviceType, ValueType, ValueType>(subCellTopologyKey(dim,0), cub_degree);
     targetDerivPointsRange(dim,0) = range_type(numTargetDerivEvalPoints, numTargetDerivEvalPoints+elemTargetDivCub->getNumPoints());
     numTargetDerivEvalPoints +=  elemTargetDivCub->getNumPoints();
     targetDerivCubPoints[dim][0] = view_type("targetDerivCubPoints",elemTargetDivCub->getNumPoints(),dim);
@@ -533,7 +533,7 @@ void ProjectionStruct<SpT,ValueType>::createHDivProjectionStruct(const BasisPtrT
     if(haveHCurlConstraint)
     {
       cub_degree = 2*basisCubDegree;
-      auto elemBasisCub = cub_factory.create<host_space_type, ValueType, ValueType>(subCellTopologyKey(dim,0), cub_degree);
+      auto elemBasisCub = cub_factory.create<HostDeviceType, ValueType, ValueType>(subCellTopologyKey(dim,0), cub_degree);
       basisPointsRange(dim,0) = range_type(numBasisEvalPoints, numBasisEvalPoints + elemBasisCub->getNumPoints());
       numBasisEvalPoints +=  elemBasisCub->getNumPoints();
       basisCubPoints[dim][0] = view_type("basisCubPoints",elemBasisCub->getNumPoints(),dim);
@@ -542,7 +542,7 @@ void ProjectionStruct<SpT,ValueType>::createHDivProjectionStruct(const BasisPtrT
       maxNumBasisEvalPoints = std::max(maxNumBasisEvalPoints, elemBasisCub->getNumPoints());
 
       cub_degree = basisCubDegree + targetCubDegree;
-      auto elemTargetCub = cub_factory.create<host_space_type, ValueType, ValueType>(subCellTopologyKey(dim,0), cub_degree);
+      auto elemTargetCub = cub_factory.create<HostDeviceType, ValueType, ValueType>(subCellTopologyKey(dim,0), cub_degree);
       targetPointsRange(dim,0) = range_type(numTargetEvalPoints, numTargetEvalPoints + elemTargetCub->getNumPoints());
       numTargetEvalPoints +=  elemTargetCub->getNumPoints();
       targetCubPoints[dim][0] = view_type("targetCubPoints",elemTargetCub->getNumPoints(),dim);
@@ -577,7 +577,7 @@ void ProjectionStruct<SpT,ValueType>::createHVolProjectionStruct(const BasisPtrT
   maxNumBasisEvalPoints = 0; maxNumTargetEvalPoints =0;
 
   ordinal_type cub_degree = 2*basisCubDegree;
-  auto elemBasisCub = cub_factory.create<host_space_type, ValueType, ValueType>(cellTopo.getBaseKey(), cub_degree);
+  auto elemBasisCub = cub_factory.create<HostDeviceType, ValueType, ValueType>(cellTopo.getBaseKey(), cub_degree);
   basisPointsRange(dim,0) = range_type(0, elemBasisCub->getNumPoints());
   numBasisEvalPoints +=  elemBasisCub->getNumPoints();
   maxNumBasisEvalPoints = elemBasisCub->getNumPoints();
@@ -586,7 +586,7 @@ void ProjectionStruct<SpT,ValueType>::createHVolProjectionStruct(const BasisPtrT
   elemBasisCub->getCubature(basisCubPoints[dim][0], basisCubWeights[dim][0]);
 
   cub_degree = basisCubDegree + targetCubDegree;
-  auto elemTargetCub = cub_factory.create<host_space_type, ValueType, ValueType>(cellTopo.getBaseKey(), cub_degree);
+  auto elemTargetCub = cub_factory.create<HostDeviceType, ValueType, ValueType>(cellTopo.getBaseKey(), cub_degree);
   targetPointsRange(dim,0) = range_type(0, elemTargetCub->getNumPoints());
   numTargetEvalPoints +=  elemTargetCub->getNumPoints();
   maxNumTargetEvalPoints = elemTargetCub->getNumPoints();

--- a/packages/intrepid2/src/Shared/Intrepid2_CellGeometryTestUtils.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_CellGeometryTestUtils.hpp
@@ -66,6 +66,7 @@ namespace Intrepid2
   CellGeometry<PointScalar, spaceDim, DeviceType> getNodalCellGeometry(CellGeometry<PointScalar, spaceDim, DeviceType> &anyCellGeometry,
                                                                        const bool &copyAffineness)
   {
+    static_assert(Kokkos::is_device<DeviceType>::value, "Third template argument to getNodalCellGeometry() must be a Kokkos::Device");
     // copy the nodes from CellGeometry into a raw View
     const int numCells = anyCellGeometry.extent_int(0);
     const int numNodes = anyCellGeometry.extent_int(1);
@@ -110,6 +111,8 @@ namespace Intrepid2
   inline CellGeometry<PointScalar,spaceDim,DeviceType> uniformCartesianMesh(const Kokkos::Array<PointScalar,spaceDim> &domainExtents,
                                                                             const Kokkos::Array<int,spaceDim> &gridCellCounts)
   {
+    static_assert(Kokkos::is_device<DeviceType>::value, "Third template argument to uniformCartesianMesh() must be a Kokkos::Device");
+    
     Kokkos::Array<PointScalar,spaceDim> origin;
     for (int d=0; d<spaceDim; d++)
     {
@@ -131,6 +134,7 @@ namespace Intrepid2
   template<class PointScalar, int spaceDim, typename DeviceType = Kokkos::DefaultExecutionSpace::device_type>
   inline CellGeometry<PointScalar,spaceDim,DeviceType> uniformCartesianMesh(const PointScalar &domainExtent, const int &meshWidth)
   {
+    static_assert(Kokkos::is_device<DeviceType>::value, "Third template argument to uniformCartesianMesh() must be a Kokkos::Device");
     Kokkos::Array<PointScalar,spaceDim> origin;
     Kokkos::Array<PointScalar,spaceDim> domainExtents;
     Kokkos::Array<int,spaceDim> gridCellCounts;

--- a/packages/intrepid2/src/Shared/Intrepid2_CellGeometryTestUtils.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_CellGeometryTestUtils.hpp
@@ -61,21 +61,22 @@ namespace Intrepid2
    \param [in] copyAffineness - if true, the resulting geometry will be marked as affine if the original geometry was, allowing reduce storage of Jacobians, etc.
    \return a representation of the same geometry, defined using cell-to-nodes and node-to-coordinates containers.
 */
-  template< typename PointScalar, int spaceDim, typename ExecutionSpace >
+  template< typename PointScalar, int spaceDim, typename DeviceType >
   inline
-  CellGeometry<PointScalar, spaceDim, ExecutionSpace> getNodalCellGeometry(CellGeometry<PointScalar, spaceDim, ExecutionSpace> &anyCellGeometry,
-                                                                           const bool &copyAffineness)
+  CellGeometry<PointScalar, spaceDim, DeviceType> getNodalCellGeometry(CellGeometry<PointScalar, spaceDim, DeviceType> &anyCellGeometry,
+                                                                       const bool &copyAffineness)
   {
     // copy the nodes from CellGeometry into a raw View
     const int numCells = anyCellGeometry.extent_int(0);
     const int numNodes = anyCellGeometry.extent_int(1);
     
-    using PointScalarView = ScalarView<PointScalar, ExecutionSpace >;
-    using intView         = ScalarView<        int, ExecutionSpace >;
+    using PointScalarView = ScalarView<PointScalar, DeviceType >;
+    using intView         = ScalarView<        int, DeviceType >;
     
     auto cellToNodes      = intView             ("cell to nodes", numCells, numNodes);    // this will be a one-to-one mapping
     PointScalarView nodes = getView<PointScalar>("nodes", numCells * numNodes, spaceDim); // we store redundant copies of vertices for each cell
 
+    using ExecutionSpace = typename DeviceType::execution_space;
     auto policy = Kokkos::MDRangePolicy<ExecutionSpace,Kokkos::Rank<2>>({0,0},{numCells,numNodes});
     
     // "workset"
@@ -95,7 +96,7 @@ namespace Intrepid2
     const auto nodeOrdering = anyCellGeometry.nodeOrderingForHypercubes();
     
     const auto cellTopology = anyCellGeometry.cellTopology();
-    CellGeometry<PointScalar, spaceDim, ExecutionSpace> nodalCellGeometry(cellTopology,cellToNodes,nodes,claimAffine,nodeOrdering);
+    CellGeometry<PointScalar, spaceDim, DeviceType> nodalCellGeometry(cellTopology,cellToNodes,nodes,claimAffine,nodeOrdering);
     
     return nodalCellGeometry;
   }
@@ -105,9 +106,9 @@ namespace Intrepid2
    \param [in] gridCellCounts - array specifying the number of cells in each coordinate dimension.
    \return a uniform Cartesion mesh, with origin at 0, with the specified domain extents and grid cell counts.
 */
-  template<class PointScalar, int spaceDim, typename ExecSpaceType = Kokkos::DefaultExecutionSpace>
-  inline CellGeometry<PointScalar,spaceDim,ExecSpaceType> uniformCartesianMesh(const Kokkos::Array<PointScalar,spaceDim> &domainExtents,
-                                                                               const Kokkos::Array<int,spaceDim> &gridCellCounts)
+  template<class PointScalar, int spaceDim, typename DeviceType = Kokkos::DefaultExecutionSpace::device_type>
+  inline CellGeometry<PointScalar,spaceDim,DeviceType> uniformCartesianMesh(const Kokkos::Array<PointScalar,spaceDim> &domainExtents,
+                                                                            const Kokkos::Array<int,spaceDim> &gridCellCounts)
   {
     Kokkos::Array<PointScalar,spaceDim> origin;
     for (int d=0; d<spaceDim; d++)
@@ -115,7 +116,7 @@ namespace Intrepid2
       origin[d] = 0.0;
     }
     
-    using CellGeometry = ::Intrepid2::CellGeometry<PointScalar, spaceDim, ExecSpaceType>;
+    using CellGeometry = ::Intrepid2::CellGeometry<PointScalar, spaceDim, DeviceType>;
     const auto NO_SUBDIVISION = CellGeometry::NO_SUBDIVISION;
     const auto HYPERCUBE_NODE_ORDER_CLASSIC_SHARDS = CellGeometry::HYPERCUBE_NODE_ORDER_CLASSIC_SHARDS;
     
@@ -127,8 +128,8 @@ namespace Intrepid2
    \param [in] gridCellCounts - the number of cells in each coordinate dimension.
    \return a uniform Cartesion mesh, with origin at 0, with the specified domain extent and grid cell counts.
 */
-  template<class PointScalar, int spaceDim, typename ExecSpaceType = Kokkos::DefaultExecutionSpace>
-  inline CellGeometry<PointScalar,spaceDim,ExecSpaceType> uniformCartesianMesh(const PointScalar &domainExtent, const int &meshWidth)
+  template<class PointScalar, int spaceDim, typename DeviceType = Kokkos::DefaultExecutionSpace::device_type>
+  inline CellGeometry<PointScalar,spaceDim,DeviceType> uniformCartesianMesh(const PointScalar &domainExtent, const int &meshWidth)
   {
     Kokkos::Array<PointScalar,spaceDim> origin;
     Kokkos::Array<PointScalar,spaceDim> domainExtents;
@@ -140,7 +141,7 @@ namespace Intrepid2
       gridCellCounts[d] = meshWidth;
     }
     
-    using CellGeometry = ::Intrepid2::CellGeometry<PointScalar, spaceDim, ExecSpaceType>;
+    using CellGeometry = ::Intrepid2::CellGeometry<PointScalar, spaceDim, DeviceType>;
     const auto NO_SUBDIVISION = CellGeometry::NO_SUBDIVISION;
     const auto HYPERCUBE_NODE_ORDER_CLASSIC_SHARDS = CellGeometry::HYPERCUBE_NODE_ORDER_CLASSIC_SHARDS;
     

--- a/packages/intrepid2/src/Shared/Intrepid2_Data.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_Data.hpp
@@ -170,6 +170,8 @@ namespace Intrepid2 {
   */
   template<class DataScalar,typename DeviceType = typename Kokkos::DefaultExecutionSpace::device_type>
   class Data {
+    // TODO: re-enable this assert once all Basis subclasses have been converted to use DeviceType
+//    static_assert(Kokkos::is_device<DeviceType>::value, "Second template argument to Data must be a Kokkos::Device");
   public:
     using value_type      = DataScalar;
     using execution_space = typename DeviceType::execution_space;

--- a/packages/intrepid2/src/Shared/Intrepid2_Data.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_Data.hpp
@@ -168,20 +168,20 @@ namespace Intrepid2 {
      - BLOCK_PLUS_DIAGONAL: the data varies in this notional dimension and one other, corresponding to a square matrix that has some (possibly trivial) full block, with diagonal entries in the remaining dimensions.  The underlying View will have one dimension corresponding to the two notional dimensions, with extent corresponding to the number of nonzeros in the matrix.
      
   */
-  template<class DataScalar,typename ExecSpaceType = Kokkos::DefaultExecutionSpace>
+  template<class DataScalar,typename DeviceType = typename Kokkos::DefaultExecutionSpace::device_type>
   class Data {
   public:
     using value_type      = DataScalar;
-    using execution_space = ExecSpaceType;
+    using execution_space = typename DeviceType::execution_space;
   private:
     ordinal_type dataRank_;
-    Kokkos::View<DataScalar*,       ExecSpaceType> data1_;  // the rank 1 data that is explicitly stored
-    Kokkos::View<DataScalar**,      ExecSpaceType> data2_;  // the rank 2 data that is explicitly stored
-    Kokkos::View<DataScalar***,     ExecSpaceType> data3_;  // the rank 3 data that is explicitly stored
-    Kokkos::View<DataScalar****,    ExecSpaceType> data4_;  // the rank 4 data that is explicitly stored
-    Kokkos::View<DataScalar*****,   ExecSpaceType> data5_;  // the rank 5 data that is explicitly stored
-    Kokkos::View<DataScalar******,  ExecSpaceType> data6_;  // the rank 6 data that is explicitly stored
-    Kokkos::View<DataScalar*******, ExecSpaceType> data7_;  // the rank 7 data that is explicitly stored
+    Kokkos::View<DataScalar*,       DeviceType> data1_;  // the rank 1 data that is explicitly stored
+    Kokkos::View<DataScalar**,      DeviceType> data2_;  // the rank 2 data that is explicitly stored
+    Kokkos::View<DataScalar***,     DeviceType> data3_;  // the rank 3 data that is explicitly stored
+    Kokkos::View<DataScalar****,    DeviceType> data4_;  // the rank 4 data that is explicitly stored
+    Kokkos::View<DataScalar*****,   DeviceType> data5_;  // the rank 5 data that is explicitly stored
+    Kokkos::View<DataScalar******,  DeviceType> data6_;  // the rank 6 data that is explicitly stored
+    Kokkos::View<DataScalar*******, DeviceType> data7_;  // the rank 7 data that is explicitly stored
     Kokkos::Array<int,7> extents_;                     // logical extents in each dimension
     Kokkos::Array<DataVariationType,7> variationType_; // for each dimension, whether the data varies in that dimension
     Kokkos::Array<int,7> variationModulus_;            // for each dimension, a value by which indices should be modulused (only used when variationType_ is MODULAR)
@@ -194,12 +194,12 @@ namespace Intrepid2 {
     
     ordinal_type rank_;
     
-    using reference_type       = typename ScalarView<DataScalar,ExecSpaceType>::reference_type;
-    using const_reference_type = typename ScalarView<const DataScalar,ExecSpaceType>::reference_type;
+    using reference_type       = typename ScalarView<DataScalar,DeviceType>::reference_type;
+    using const_reference_type = typename ScalarView<const DataScalar,DeviceType>::reference_type;
     // we use reference_type as the return for operator() for performance reasons, especially significant when using Sacado types
     using return_type = const_reference_type;
     
-    ScalarView<DataScalar,ExecSpaceType> zeroView_; // one-entry (zero); used to allow getEntry() to return 0 for off-diagonal entries in BLOCK_PLUS_DIAGONAL
+    ScalarView<DataScalar,DeviceType> zeroView_; // one-entry (zero); used to allow getEntry() to return 0 for off-diagonal entries in BLOCK_PLUS_DIAGONAL
     
     //! Returns the number of non-diagonal entries based on the last non-diagonal.  Only applicable for BLOCK_PLUS_DIAGONAL DataVariationType.
     KOKKOS_INLINE_FUNCTION
@@ -249,7 +249,7 @@ namespace Intrepid2 {
       }
       
       // by default, this should initialize with zero -- no need to deep_copy a 0 into it
-      zeroView_ = ScalarView<DataScalar,ExecSpaceType>("zero",1);
+      zeroView_ = ScalarView<DataScalar,DeviceType>("zero",1);
       
       numActiveDims_ = 0;
       int blockPlusDiagonalCount = 0;
@@ -449,6 +449,7 @@ namespace Intrepid2 {
     static void copyContainer(ToContainer to, FromContainer from)
     {
 //      std::cout << "Entered copyContainer().\n";
+      using ExecSpaceType = typename DeviceType::execution_space;
       auto policy = Kokkos::MDRangePolicy<ExecSpaceType,Kokkos::Rank<6>>({0,0,0,0,0,0},{from.extent_int(0),from.extent_int(1),from.extent_int(2), from.extent_int(3), from.extent_int(4), from.extent_int(5)});
       
       Kokkos::parallel_for("copyContainer", policy,
@@ -461,18 +462,18 @@ namespace Intrepid2 {
     }
     
     //! allocate an underlying View that matches the provided DynRankView in dimensions, and copy.  Called by constructors that accept a DynRankView as argument.
-    void allocateAndCopyFromDynRankView(ScalarView<DataScalar,ExecSpaceType> data)
+    void allocateAndCopyFromDynRankView(ScalarView<DataScalar,DeviceType> data)
     {
 //      std::cout << "Entered allocateAndCopyFromDynRankView().\n";
       switch (dataRank_)
       {
-        case 1: data1_ = Kokkos::View<DataScalar*,       ExecSpaceType>("Intrepid2 Data", data.extent_int(0)); break;
-        case 2: data2_ = Kokkos::View<DataScalar**,      ExecSpaceType>("Intrepid2 Data", data.extent_int(0), data.extent_int(1)); break;
-        case 3: data3_ = Kokkos::View<DataScalar***,     ExecSpaceType>("Intrepid2 Data", data.extent_int(0), data.extent_int(1), data.extent_int(2)); break;
-        case 4: data4_ = Kokkos::View<DataScalar****,    ExecSpaceType>("Intrepid2 Data", data.extent_int(0), data.extent_int(1), data.extent_int(2), data.extent_int(3)); break;
-        case 5: data5_ = Kokkos::View<DataScalar*****,   ExecSpaceType>("Intrepid2 Data", data.extent_int(0), data.extent_int(1), data.extent_int(2), data.extent_int(3), data.extent_int(4)); break;
-        case 6: data6_ = Kokkos::View<DataScalar******,  ExecSpaceType>("Intrepid2 Data", data.extent_int(0), data.extent_int(1), data.extent_int(2), data.extent_int(3), data.extent_int(4), data.extent_int(5)); break;
-        case 7: data7_ = Kokkos::View<DataScalar*******, ExecSpaceType>("Intrepid2 Data", data.extent_int(0), data.extent_int(1), data.extent_int(2), data.extent_int(3), data.extent_int(4), data.extent_int(5), data.extent_int(6)); break;
+        case 1: data1_ = Kokkos::View<DataScalar*,       DeviceType>("Intrepid2 Data", data.extent_int(0)); break;
+        case 2: data2_ = Kokkos::View<DataScalar**,      DeviceType>("Intrepid2 Data", data.extent_int(0), data.extent_int(1)); break;
+        case 3: data3_ = Kokkos::View<DataScalar***,     DeviceType>("Intrepid2 Data", data.extent_int(0), data.extent_int(1), data.extent_int(2)); break;
+        case 4: data4_ = Kokkos::View<DataScalar****,    DeviceType>("Intrepid2 Data", data.extent_int(0), data.extent_int(1), data.extent_int(2), data.extent_int(3)); break;
+        case 5: data5_ = Kokkos::View<DataScalar*****,   DeviceType>("Intrepid2 Data", data.extent_int(0), data.extent_int(1), data.extent_int(2), data.extent_int(3), data.extent_int(4)); break;
+        case 6: data6_ = Kokkos::View<DataScalar******,  DeviceType>("Intrepid2 Data", data.extent_int(0), data.extent_int(1), data.extent_int(2), data.extent_int(3), data.extent_int(4), data.extent_int(5)); break;
+        case 7: data7_ = Kokkos::View<DataScalar*******, DeviceType>("Intrepid2 Data", data.extent_int(0), data.extent_int(1), data.extent_int(2), data.extent_int(3), data.extent_int(4), data.extent_int(5), data.extent_int(6)); break;
         default: INTREPID2_TEST_FOR_EXCEPTION(true, std::invalid_argument, "Invalid data rank");
       }
       
@@ -490,7 +491,7 @@ namespace Intrepid2 {
     }
     
     //! DynRankView constructor.  Will copy to a View of appropriate rank.
-    Data(const ScalarView<DataScalar,ExecSpaceType> &data, int rank, Kokkos::Array<int,7> extents, Kokkos::Array<DataVariationType,7> variationType, const int blockPlusDiagonalLastNonDiagonal = -1)
+    Data(const ScalarView<DataScalar,DeviceType> &data, int rank, Kokkos::Array<int,7> extents, Kokkos::Array<DataVariationType,7> variationType, const int blockPlusDiagonalLastNonDiagonal = -1)
     :
     dataRank_(data.rank()), extents_(extents), variationType_(variationType), blockPlusDiagonalLastNonDiagonal_(blockPlusDiagonalLastNonDiagonal), rank_(rank)
     {
@@ -498,9 +499,9 @@ namespace Intrepid2 {
       setActiveDims();
     }
     
-    //! copy-like constructor for differing execution spaces.  This does a deep_copy of the underlying view.
-    template<typename OtherExecSpaceType, class = typename std::enable_if<!std::is_same<ExecSpaceType, OtherExecSpaceType>::value>::type>
-    Data(const Data<DataScalar,OtherExecSpaceType> &data)
+    //! copy-like constructor for differing memory spaces.  This does a deep_copy of the underlying view.
+    template<typename OtherDeviceType, class = typename std::enable_if<!std::is_same<typename DeviceType::memory_space, typename OtherDeviceType::memory_space>::value>::type>
+    Data(const Data<DataScalar,OtherDeviceType> &data)
     :
     dataRank_(data.getUnderlyingViewRank()), extents_(data.getExtents()), variationType_(data.getVariationTypes()), blockPlusDiagonalLastNonDiagonal_(data.blockPlusDiagonalLastNonDiagonal()), rank_(data.rank())
     {
@@ -510,20 +511,20 @@ namespace Intrepid2 {
         const auto view = data.getUnderlyingView();
         switch (dataRank_)
         {
-          case 1: data1_ = Kokkos::View<DataScalar*,       ExecSpaceType>("Intrepid2 Data", view.extent_int(0)); break;
-          case 2: data2_ = Kokkos::View<DataScalar**,      ExecSpaceType>("Intrepid2 Data", view.extent_int(0), view.extent_int(1)); break;
-          case 3: data3_ = Kokkos::View<DataScalar***,     ExecSpaceType>("Intrepid2 Data", view.extent_int(0), view.extent_int(1), view.extent_int(2)); break;
-          case 4: data4_ = Kokkos::View<DataScalar****,    ExecSpaceType>("Intrepid2 Data", view.extent_int(0), view.extent_int(1), view.extent_int(2), view.extent_int(3)); break;
-          case 5: data5_ = Kokkos::View<DataScalar*****,   ExecSpaceType>("Intrepid2 Data", view.extent_int(0), view.extent_int(1), view.extent_int(2), view.extent_int(3), view.extent_int(4)); break;
-          case 6: data6_ = Kokkos::View<DataScalar******,  ExecSpaceType>("Intrepid2 Data", view.extent_int(0), view.extent_int(1), view.extent_int(2), view.extent_int(3), view.extent_int(4), view.extent_int(5)); break;
-          case 7: data7_ = Kokkos::View<DataScalar*******, ExecSpaceType>("Intrepid2 Data", view.extent_int(0), view.extent_int(1), view.extent_int(2), view.extent_int(3), view.extent_int(4), view.extent_int(5), view.extent_int(6)); break;
+          case 1: data1_ = Kokkos::View<DataScalar*,       DeviceType>("Intrepid2 Data", view.extent_int(0)); break;
+          case 2: data2_ = Kokkos::View<DataScalar**,      DeviceType>("Intrepid2 Data", view.extent_int(0), view.extent_int(1)); break;
+          case 3: data3_ = Kokkos::View<DataScalar***,     DeviceType>("Intrepid2 Data", view.extent_int(0), view.extent_int(1), view.extent_int(2)); break;
+          case 4: data4_ = Kokkos::View<DataScalar****,    DeviceType>("Intrepid2 Data", view.extent_int(0), view.extent_int(1), view.extent_int(2), view.extent_int(3)); break;
+          case 5: data5_ = Kokkos::View<DataScalar*****,   DeviceType>("Intrepid2 Data", view.extent_int(0), view.extent_int(1), view.extent_int(2), view.extent_int(3), view.extent_int(4)); break;
+          case 6: data6_ = Kokkos::View<DataScalar******,  DeviceType>("Intrepid2 Data", view.extent_int(0), view.extent_int(1), view.extent_int(2), view.extent_int(3), view.extent_int(4), view.extent_int(5)); break;
+          case 7: data7_ = Kokkos::View<DataScalar*******, DeviceType>("Intrepid2 Data", view.extent_int(0), view.extent_int(1), view.extent_int(2), view.extent_int(3), view.extent_int(4), view.extent_int(5), view.extent_int(6)); break;
           default: INTREPID2_TEST_FOR_EXCEPTION(true, std::invalid_argument, "Invalid data rank");
         }
         
         // copy
         // (Note: Kokkos::deep_copy() will not generally work if the layouts are different; that's why we do a manual copy here once we have the data on the host):
         // first, mirror and copy dataView; then copy to the appropriate data_ member
-        using MemorySpace = typename ExecSpaceType::memory_space;
+        using MemorySpace = typename DeviceType::memory_space;
         switch (dataRank_)
         {
           case 1: {auto dataViewMirror = Kokkos::create_mirror_view_and_copy(MemorySpace(), data.getUnderlyingView1()); copyContainer(data1_, dataViewMirror);} break;
@@ -540,7 +541,7 @@ namespace Intrepid2 {
     }
     
     //! copy constructor modeled after the copy-like constructor above.  Not as efficient as the implicit copy constructor, so this should only be uncommented to emulate the copy-like constructor above in situations where host and device space are the same, and the copy-like constructor does not exist, or to provide a debugging breakpoint to assess when copies are being constructed.
-//    Data(const Data<DataScalar,ExecSpaceType> &data)
+//    Data(const Data<DataScalar,DeviceType> &data)
 //    :
 //    dataRank_(data.getUnderlyingViewRank()), extents_(data.getExtents()), variationType_(data.getVariationTypes()), blockPlusDiagonalLastNonDiagonal_(data.blockPlusDiagonalLastNonDiagonal()), rank_(data.rank())
 //    {
@@ -550,20 +551,20 @@ namespace Intrepid2 {
 //        const auto view = data.getUnderlyingView();
 //        switch (dataRank_)
 //        {
-//          case 1: data1_ = Kokkos::View<DataScalar*,       ExecSpaceType>("Intrepid2 Data - explicit copy constructor(for debugging)", view.extent_int(0)); break;
-//          case 2: data2_ = Kokkos::View<DataScalar**,      ExecSpaceType>("Intrepid2 Data - explicit copy constructor(for debugging)", view.extent_int(0), view.extent_int(1)); break;
-//          case 3: data3_ = Kokkos::View<DataScalar***,     ExecSpaceType>("Intrepid2 Data - explicit copy constructor(for debugging)", view.extent_int(0), view.extent_int(1), view.extent_int(2)); break;
-//          case 4: data4_ = Kokkos::View<DataScalar****,    ExecSpaceType>("Intrepid2 Data - explicit copy constructor(for debugging)", view.extent_int(0), view.extent_int(1), view.extent_int(2), view.extent_int(3)); break;
-//          case 5: data5_ = Kokkos::View<DataScalar*****,   ExecSpaceType>("Intrepid2 Data - explicit copy constructor(for debugging)", view.extent_int(0), view.extent_int(1), view.extent_int(2), view.extent_int(3), view.extent_int(4)); break;
-//          case 6: data6_ = Kokkos::View<DataScalar******,  ExecSpaceType>("Intrepid2 Data - explicit copy constructor(for debugging)", view.extent_int(0), view.extent_int(1), view.extent_int(2), view.extent_int(3), view.extent_int(4), view.extent_int(5)); break;
-//          case 7: data7_ = Kokkos::View<DataScalar*******, ExecSpaceType>("Intrepid2 Data - explicit copy constructor(for debugging)", view.extent_int(0), view.extent_int(1), view.extent_int(2), view.extent_int(3), view.extent_int(4), view.extent_int(5), view.extent_int(6)); break;
+//          case 1: data1_ = Kokkos::View<DataScalar*,       DeviceType>("Intrepid2 Data - explicit copy constructor(for debugging)", view.extent_int(0)); break;
+//          case 2: data2_ = Kokkos::View<DataScalar**,      DeviceType>("Intrepid2 Data - explicit copy constructor(for debugging)", view.extent_int(0), view.extent_int(1)); break;
+//          case 3: data3_ = Kokkos::View<DataScalar***,     DeviceType>("Intrepid2 Data - explicit copy constructor(for debugging)", view.extent_int(0), view.extent_int(1), view.extent_int(2)); break;
+//          case 4: data4_ = Kokkos::View<DataScalar****,    DeviceType>("Intrepid2 Data - explicit copy constructor(for debugging)", view.extent_int(0), view.extent_int(1), view.extent_int(2), view.extent_int(3)); break;
+//          case 5: data5_ = Kokkos::View<DataScalar*****,   DeviceType>("Intrepid2 Data - explicit copy constructor(for debugging)", view.extent_int(0), view.extent_int(1), view.extent_int(2), view.extent_int(3), view.extent_int(4)); break;
+//          case 6: data6_ = Kokkos::View<DataScalar******,  DeviceType>("Intrepid2 Data - explicit copy constructor(for debugging)", view.extent_int(0), view.extent_int(1), view.extent_int(2), view.extent_int(3), view.extent_int(4), view.extent_int(5)); break;
+//          case 7: data7_ = Kokkos::View<DataScalar*******, DeviceType>("Intrepid2 Data - explicit copy constructor(for debugging)", view.extent_int(0), view.extent_int(1), view.extent_int(2), view.extent_int(3), view.extent_int(4), view.extent_int(5), view.extent_int(6)); break;
 //          default: INTREPID2_TEST_FOR_EXCEPTION(true, std::invalid_argument, "Invalid data rank");
 //        }
 //
 //        // copy
 //        // (Note: Kokkos::deep_copy() will not generally work if the layouts are different; that's why we do a manual copy here once we have the data on the host):
 //        // first, mirror and copy dataView; then copy to the appropriate data_ member
-//        using MemorySpace = typename ExecSpaceType::memory_space;
+//        using MemorySpace = typename DeviceType::memory_space;
 //        switch (dataRank_)
 //        {
 //          case 1: {auto dataViewMirror = Kokkos::create_mirror_view_and_copy(MemorySpace(), data.getUnderlyingView1()); copyContainer(data1_, dataViewMirror);} break;
@@ -581,7 +582,7 @@ namespace Intrepid2 {
 //    }
     
     //! constructor for fully varying data container, no expressed redundancy/repetition.  Copies the data to a new Kokkos::View of matching rank.
-    Data(ScalarView<DataScalar,ExecSpaceType> data)
+    Data(ScalarView<DataScalar,DeviceType> data)
     :
     Data(data,
          data.rank(),
@@ -591,7 +592,7 @@ namespace Intrepid2 {
     
     //! Constructor that accepts a DynRankView as an argument.  The data belonging to the DynRankView will be copied into a new View of matching dimensions.
     template<size_t rank, class ...DynRankViewProperties>
-    Data(const Kokkos::DynRankView<DataScalar,ExecSpaceType, DynRankViewProperties...> &data, Kokkos::Array<int,rank> extents, Kokkos::Array<DataVariationType,rank> variationType, const int blockPlusDiagonalLastNonDiagonal = -1)
+    Data(const Kokkos::DynRankView<DataScalar,DeviceType, DynRankViewProperties...> &data, Kokkos::Array<int,rank> extents, Kokkos::Array<DataVariationType,rank> variationType, const int blockPlusDiagonalLastNonDiagonal = -1)
     :
     dataRank_(data.rank()), extents_({1,1,1,1,1,1,1}), variationType_({CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT}), blockPlusDiagonalLastNonDiagonal_(blockPlusDiagonalLastNonDiagonal), rank_(rank)
     {
@@ -606,7 +607,7 @@ namespace Intrepid2 {
     }
         
     template<size_t rank, class ...ViewProperties>
-    Data(Kokkos::View<DataScalar*,ExecSpaceType, ViewProperties...> data, Kokkos::Array<int,rank> extents, Kokkos::Array<DataVariationType,rank> variationType, const int blockPlusDiagonalLastNonDiagonal = -1)
+    Data(Kokkos::View<DataScalar*,DeviceType, ViewProperties...> data, Kokkos::Array<int,rank> extents, Kokkos::Array<DataVariationType,rank> variationType, const int blockPlusDiagonalLastNonDiagonal = -1)
     :
     dataRank_(data.rank), extents_({1,1,1,1,1,1,1}), variationType_({CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT}), blockPlusDiagonalLastNonDiagonal_(blockPlusDiagonalLastNonDiagonal), rank_(rank)
     {
@@ -620,7 +621,7 @@ namespace Intrepid2 {
     }
     
     template<size_t rank, class ...ViewProperties>
-    Data(Kokkos::View<DataScalar**,ExecSpaceType, ViewProperties...> data, Kokkos::Array<int,rank> extents, Kokkos::Array<DataVariationType,rank> variationType, const int blockPlusDiagonalLastNonDiagonal = -1)
+    Data(Kokkos::View<DataScalar**,DeviceType, ViewProperties...> data, Kokkos::Array<int,rank> extents, Kokkos::Array<DataVariationType,rank> variationType, const int blockPlusDiagonalLastNonDiagonal = -1)
     :
     dataRank_(data.rank), extents_({1,1,1,1,1,1,1}), variationType_({CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT}), blockPlusDiagonalLastNonDiagonal_(blockPlusDiagonalLastNonDiagonal), rank_(rank)
     {
@@ -634,7 +635,7 @@ namespace Intrepid2 {
     }
     
     template<size_t rank, class ...ViewProperties>
-    Data(Kokkos::View<DataScalar***,ExecSpaceType, ViewProperties...> data, Kokkos::Array<int,rank> extents, Kokkos::Array<DataVariationType,rank> variationType, const int blockPlusDiagonalLastNonDiagonal = -1)
+    Data(Kokkos::View<DataScalar***,DeviceType, ViewProperties...> data, Kokkos::Array<int,rank> extents, Kokkos::Array<DataVariationType,rank> variationType, const int blockPlusDiagonalLastNonDiagonal = -1)
     :
     dataRank_(data.rank), extents_({1,1,1,1,1,1,1}), variationType_({CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT}), blockPlusDiagonalLastNonDiagonal_(blockPlusDiagonalLastNonDiagonal), rank_(rank)
     {
@@ -648,7 +649,7 @@ namespace Intrepid2 {
     }
     
     template<size_t rank, class ...ViewProperties>
-    Data(Kokkos::View<DataScalar****,ExecSpaceType, ViewProperties...> data, Kokkos::Array<int,rank> extents, Kokkos::Array<DataVariationType,rank> variationType, const int blockPlusDiagonalLastNonDiagonal = -1)
+    Data(Kokkos::View<DataScalar****,DeviceType, ViewProperties...> data, Kokkos::Array<int,rank> extents, Kokkos::Array<DataVariationType,rank> variationType, const int blockPlusDiagonalLastNonDiagonal = -1)
     :
     dataRank_(data.rank), extents_({1,1,1,1,1,1,1}), variationType_({CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT}), blockPlusDiagonalLastNonDiagonal_(blockPlusDiagonalLastNonDiagonal), rank_(rank)
     {
@@ -662,7 +663,7 @@ namespace Intrepid2 {
     }
     
     template<size_t rank, class ...ViewProperties>
-    Data(Kokkos::View<DataScalar*****,ExecSpaceType, ViewProperties...> data, Kokkos::Array<int,rank> extents, Kokkos::Array<DataVariationType,rank> variationType, const int blockPlusDiagonalLastNonDiagonal = -1)
+    Data(Kokkos::View<DataScalar*****,DeviceType, ViewProperties...> data, Kokkos::Array<int,rank> extents, Kokkos::Array<DataVariationType,rank> variationType, const int blockPlusDiagonalLastNonDiagonal = -1)
     :
     dataRank_(data.rank), extents_({1,1,1,1,1,1,1}), variationType_({CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT}), blockPlusDiagonalLastNonDiagonal_(blockPlusDiagonalLastNonDiagonal), rank_(rank)
     {
@@ -676,7 +677,7 @@ namespace Intrepid2 {
     }
     
     template<size_t rank, class ...ViewProperties>
-    Data(Kokkos::View<DataScalar******,ExecSpaceType, ViewProperties...> data, Kokkos::Array<int,rank> extents, Kokkos::Array<DataVariationType,rank> variationType, const int blockPlusDiagonalLastNonDiagonal = -1)
+    Data(Kokkos::View<DataScalar******,DeviceType, ViewProperties...> data, Kokkos::Array<int,rank> extents, Kokkos::Array<DataVariationType,rank> variationType, const int blockPlusDiagonalLastNonDiagonal = -1)
     :
     dataRank_(data.rank), extents_({1,1,1,1,1,1,1}), variationType_({CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT}), blockPlusDiagonalLastNonDiagonal_(blockPlusDiagonalLastNonDiagonal), rank_(rank)
     {
@@ -690,7 +691,7 @@ namespace Intrepid2 {
     }
     
     template<size_t rank, class ...ViewProperties>
-    Data(Kokkos::View<DataScalar*******,ExecSpaceType, ViewProperties...> data, Kokkos::Array<int,rank> extents, Kokkos::Array<DataVariationType,rank> variationType, const int blockPlusDiagonalLastNonDiagonal = -1)
+    Data(Kokkos::View<DataScalar*******,DeviceType, ViewProperties...> data, Kokkos::Array<int,rank> extents, Kokkos::Array<DataVariationType,rank> variationType, const int blockPlusDiagonalLastNonDiagonal = -1)
     :
     dataRank_(data.rank), extents_({1,1,1,1,1,1,1}), variationType_({CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT}), blockPlusDiagonalLastNonDiagonal_(blockPlusDiagonalLastNonDiagonal), rank_(rank)
     {
@@ -709,7 +710,7 @@ namespace Intrepid2 {
     :
     dataRank_(1), extents_({1,1,1,1,1,1,1}), variationType_({CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT}), blockPlusDiagonalLastNonDiagonal_(-1), rank_(rank)
     {
-      data1_ = Kokkos::View<DataScalar*,ExecSpaceType>("Constant Data",1);
+      data1_ = Kokkos::View<DataScalar*,DeviceType>("Constant Data",1);
       Kokkos::deep_copy(data1_, constantValue);
       for (unsigned d=0; d<rank; d++)
       {
@@ -771,7 +772,7 @@ namespace Intrepid2 {
     //! Returns the underlying view.  Throws an exception if the underlying view is not rank 1.
     template<int rank>
     KOKKOS_INLINE_FUNCTION
-    enable_if_t<rank==1, const Kokkos::View<typename RankExpander<DataScalar, rank>::value_type, ExecSpaceType> &>
+    enable_if_t<rank==1, const Kokkos::View<typename RankExpander<DataScalar, rank>::value_type, DeviceType> &>
     getUnderlyingView() const
     {
       #ifdef HAVE_INTREPID2_DEBUG
@@ -783,7 +784,7 @@ namespace Intrepid2 {
     //! Returns the underlying view.  Throws an exception if the underlying view is not rank 2.
     template<int rank>
     KOKKOS_INLINE_FUNCTION
-    enable_if_t<rank==2, const Kokkos::View<typename RankExpander<DataScalar, rank>::value_type, ExecSpaceType> &>
+    enable_if_t<rank==2, const Kokkos::View<typename RankExpander<DataScalar, rank>::value_type, DeviceType> &>
     getUnderlyingView() const
     {
       #ifdef HAVE_INTREPID2_DEBUG
@@ -795,7 +796,7 @@ namespace Intrepid2 {
     //! Returns the underlying view.  Throws an exception if the underlying view is not rank 3.
     template<int rank>
     KOKKOS_INLINE_FUNCTION
-    enable_if_t<rank==3, const Kokkos::View<typename RankExpander<DataScalar, rank>::value_type, ExecSpaceType> &>
+    enable_if_t<rank==3, const Kokkos::View<typename RankExpander<DataScalar, rank>::value_type, DeviceType> &>
     getUnderlyingView() const
     {
       #ifdef HAVE_INTREPID2_DEBUG
@@ -807,7 +808,7 @@ namespace Intrepid2 {
     //! Returns the underlying view.  Throws an exception if the underlying view is not rank 4.
     template<int rank>
     KOKKOS_INLINE_FUNCTION
-    enable_if_t<rank==4, const Kokkos::View<typename RankExpander<DataScalar, rank>::value_type, ExecSpaceType> &>
+    enable_if_t<rank==4, const Kokkos::View<typename RankExpander<DataScalar, rank>::value_type, DeviceType> &>
     getUnderlyingView() const
     {
       #ifdef HAVE_INTREPID2_DEBUG
@@ -819,7 +820,7 @@ namespace Intrepid2 {
     //! Returns the underlying view.  Throws an exception if the underlying view is not rank 5.
     template<int rank>
     KOKKOS_INLINE_FUNCTION
-    enable_if_t<rank==5, const Kokkos::View<typename RankExpander<DataScalar, rank>::value_type, ExecSpaceType> &>
+    enable_if_t<rank==5, const Kokkos::View<typename RankExpander<DataScalar, rank>::value_type, DeviceType> &>
     getUnderlyingView() const
     {
       #ifdef HAVE_INTREPID2_DEBUG
@@ -831,7 +832,7 @@ namespace Intrepid2 {
     //! Returns the underlying view.  Throws an exception if the underlying view is not rank 6.
     template<int rank>
     KOKKOS_INLINE_FUNCTION
-    enable_if_t<rank==6, const Kokkos::View<typename RankExpander<DataScalar, rank>::value_type, ExecSpaceType> &>
+    enable_if_t<rank==6, const Kokkos::View<typename RankExpander<DataScalar, rank>::value_type, DeviceType> &>
     getUnderlyingView() const
     {
       #ifdef HAVE_INTREPID2_DEBUG
@@ -843,7 +844,7 @@ namespace Intrepid2 {
     //! Returns the underlying view.  Throws an exception if the underlying view is not rank 7.
     template<int rank>
     KOKKOS_INLINE_FUNCTION
-    enable_if_t<rank==7, const Kokkos::View<typename RankExpander<DataScalar, rank>::value_type, ExecSpaceType> &>
+    enable_if_t<rank==7, const Kokkos::View<typename RankExpander<DataScalar, rank>::value_type, DeviceType> &>
     getUnderlyingView() const
     {
       #ifdef HAVE_INTREPID2_DEBUG
@@ -854,104 +855,104 @@ namespace Intrepid2 {
     
     //! returns the View that stores the unique data.  For rank-1 underlying containers.
     KOKKOS_INLINE_FUNCTION
-    const Kokkos::View<DataScalar*, ExecSpaceType> & getUnderlyingView1() const
+    const Kokkos::View<DataScalar*, DeviceType> & getUnderlyingView1() const
     {
       return getUnderlyingView<1>();
     }
     
     //! returns the View that stores the unique data.  For rank-2 underlying containers.
     KOKKOS_INLINE_FUNCTION
-    const Kokkos::View<DataScalar**, ExecSpaceType> & getUnderlyingView2() const
+    const Kokkos::View<DataScalar**, DeviceType> & getUnderlyingView2() const
     {
       return getUnderlyingView<2>();
     }
     
     //! returns the View that stores the unique data.  For rank-3 underlying containers.
     KOKKOS_INLINE_FUNCTION
-    const Kokkos::View<DataScalar***, ExecSpaceType> & getUnderlyingView3() const
+    const Kokkos::View<DataScalar***, DeviceType> & getUnderlyingView3() const
     {
       return getUnderlyingView<3>();
     }
     
     //! returns the View that stores the unique data.  For rank-4 underlying containers.
     KOKKOS_INLINE_FUNCTION
-    const Kokkos::View<DataScalar****, ExecSpaceType> & getUnderlyingView4() const
+    const Kokkos::View<DataScalar****, DeviceType> & getUnderlyingView4() const
     {
       return getUnderlyingView<4>();
     }
     
     //! returns the View that stores the unique data.  For rank-5 underlying containers.
     KOKKOS_INLINE_FUNCTION
-    const Kokkos::View<DataScalar*****, ExecSpaceType> & getUnderlyingView5() const
+    const Kokkos::View<DataScalar*****, DeviceType> & getUnderlyingView5() const
     {
       return getUnderlyingView<5>();
     }
     
     //! returns the View that stores the unique data.  For rank-6 underlying containers.
     KOKKOS_INLINE_FUNCTION
-    const Kokkos::View<DataScalar******, ExecSpaceType> & getUnderlyingView6() const
+    const Kokkos::View<DataScalar******, DeviceType> & getUnderlyingView6() const
     {
       return getUnderlyingView<6>();
     }
     
     //! returns the View that stores the unique data.  For rank-7 underlying containers.
     KOKKOS_INLINE_FUNCTION
-    const Kokkos::View<DataScalar*******, ExecSpaceType> & getUnderlyingView7() const
+    const Kokkos::View<DataScalar*******, DeviceType> & getUnderlyingView7() const
     {
       return getUnderlyingView<7>();
     }
     
     //! sets the View that stores the unique data.  For rank-1 underlying containers.
     KOKKOS_INLINE_FUNCTION
-    void setUnderlyingView1(Kokkos::View<DataScalar*, ExecSpaceType> & view) const
+    void setUnderlyingView1(Kokkos::View<DataScalar*, DeviceType> & view) const
     {
       data1_ = view;
     }
     
     //! sets the View that stores the unique data.  For rank-2 underlying containers.
     KOKKOS_INLINE_FUNCTION
-    void setUnderlyingView2(Kokkos::View<DataScalar**, ExecSpaceType> & view) const
+    void setUnderlyingView2(Kokkos::View<DataScalar**, DeviceType> & view) const
     {
       data2_ = view;
     }
     
     //! sets the View that stores the unique data.  For rank-3 underlying containers.
     KOKKOS_INLINE_FUNCTION
-    void setUnderlyingView3(Kokkos::View<DataScalar***, ExecSpaceType> & view) const
+    void setUnderlyingView3(Kokkos::View<DataScalar***, DeviceType> & view) const
     {
       data3_ = view;
     }
     
     //! sets the View that stores the unique data.  For rank-4 underlying containers.
     KOKKOS_INLINE_FUNCTION
-    void setUnderlyingView4(Kokkos::View<DataScalar****, ExecSpaceType> & view) const
+    void setUnderlyingView4(Kokkos::View<DataScalar****, DeviceType> & view) const
     {
       data4_ = view;
     }
     
     //! sets the View that stores the unique data.  For rank-5 underlying containers.
     KOKKOS_INLINE_FUNCTION
-    void setUnderlyingView5(Kokkos::View<DataScalar*****, ExecSpaceType> & view) const
+    void setUnderlyingView5(Kokkos::View<DataScalar*****, DeviceType> & view) const
     {
       data5_ = view;
     }
     
     //! sets the View that stores the unique data.  For rank-6 underlying containers.
     KOKKOS_INLINE_FUNCTION
-    void setUnderlyingView6(Kokkos::View<DataScalar******, ExecSpaceType> & view) const
+    void setUnderlyingView6(Kokkos::View<DataScalar******, DeviceType> & view) const
     {
       data6_ = view;
     }
     
     //! sets the View that stores the unique data.  For rank-7 underlying containers.
     KOKKOS_INLINE_FUNCTION
-    void setUnderlyingView7(Kokkos::View<DataScalar*******, ExecSpaceType> & view) const
+    void setUnderlyingView7(Kokkos::View<DataScalar*******, DeviceType> & view) const
     {
       data7_ = view;
     }
     
     //! Returns a DynRankView constructed atop the same underlying data as the fixed-rank Kokkos::View used internally.
-    ScalarView<DataScalar,ExecSpaceType> getUnderlyingView() const
+    ScalarView<DataScalar,DeviceType> getUnderlyingView() const
     {
       switch (dataRank_)
       {
@@ -986,7 +987,7 @@ namespace Intrepid2 {
     }
     
     //! Returns a DynRankView that matches the underlying Kokkos::View object in value_type, layout, and dimension.
-    ScalarView<DataScalar,ExecSpaceType> allocateDynRankViewMatchingUnderlying() const
+    ScalarView<DataScalar,DeviceType> allocateDynRankViewMatchingUnderlying() const
     {
       switch (dataRank_)
       {
@@ -1003,7 +1004,7 @@ namespace Intrepid2 {
     
     //! Returns a DynRankView that matches the underlying Kokkos::View object value_type and layout, but with the specified dimensions.
     template<class ... DimArgs>
-    ScalarView<DataScalar,ExecSpaceType> allocateDynRankViewMatchingUnderlying(DimArgs... dims) const
+    ScalarView<DataScalar,DeviceType> allocateDynRankViewMatchingUnderlying(DimArgs... dims) const
     {
       switch (dataRank_)
       {
@@ -1035,7 +1036,7 @@ namespace Intrepid2 {
     }
     
     //! Copies from the provided DynRankView into the underlying Kokkos::View container storing the unique data.
-    void copyDataFromDynRankViewMatchingUnderlying(const ScalarView<DataScalar,ExecSpaceType> &dynRankView) const
+    void copyDataFromDynRankViewMatchingUnderlying(const ScalarView<DataScalar,DeviceType> &dynRankView) const
     {
 //      std::cout << "Entered copyDataFromDynRankViewMatchingUnderlying().\n";
       switch (dataRank_)
@@ -1332,7 +1333,7 @@ namespace Intrepid2 {
     //! \param transposeA                                          [in] - if true, A will be transposed prior to being multiplied by B (or B's transpose).
     //! \param B_MatData                                            [in] - nominally (...,D3,D4)-dimensioned container, where D3,D4 correspond to matrix dimensions.
     //! \param transposeB                                          [in] - if true, B will be transposed prior to the multiplication by A (or A's transpose).
-    static Data<DataScalar,ExecSpaceType> allocateMatMatResult( const bool transposeA, const Data<DataScalar,ExecSpaceType> &A_MatData, const bool transposeB, const Data<DataScalar,ExecSpaceType> &B_MatData )
+    static Data<DataScalar,DeviceType> allocateMatMatResult( const bool transposeA, const Data<DataScalar,DeviceType> &A_MatData, const bool transposeB, const Data<DataScalar,DeviceType> &B_MatData )
     {
       // we treat last two nominal dimensions of matData as the matrix; last dimension of vecData as the vector
       INTREPID2_TEST_FOR_EXCEPTION_DEVICE_SAFE(A_MatData.rank() != B_MatData.rank(), std::invalid_argument, "AmatData and BmatData have incompatible ranks");
@@ -1468,7 +1469,7 @@ namespace Intrepid2 {
         resultExtents[i]        = 1;
       }
       
-      ScalarView<DataScalar,ExecSpaceType> data;
+      ScalarView<DataScalar,DeviceType> data;
       if (resultNumActiveDims == 1)
       {
         auto viewToMatch = A_MatData.getUnderlyingView1(); // new view will match this one in layout and fad dimension, if any
@@ -1509,12 +1510,12 @@ namespace Intrepid2 {
                                         resultDataDims[3], resultDataDims[4], resultDataDims[5], resultDataDims[6]);
       }
       
-      return Data<DataScalar,ExecSpaceType>(data,resultRank,resultExtents,resultVariationTypes,resultBlockPlusDiagonalLastNonDiagonal);
+      return Data<DataScalar,DeviceType>(data,resultRank,resultExtents,resultVariationTypes,resultBlockPlusDiagonalLastNonDiagonal);
     }
     
     //! Constructs a container suitable for storing the result of a matrix-vector multiply corresponding to the two provided containers.
     //! \see storeMatVec()
-    static Data<DataScalar,ExecSpaceType> allocateMatVecResult( const Data<DataScalar,ExecSpaceType> &matData, const Data<DataScalar,ExecSpaceType> &vecData )
+    static Data<DataScalar,DeviceType> allocateMatVecResult( const Data<DataScalar,DeviceType> &matData, const Data<DataScalar,DeviceType> &vecData )
     {
       // we treat last two nominal dimensions of matData as the matrix; last dimension of vecData as the vector
       INTREPID2_TEST_FOR_EXCEPTION_DEVICE_SAFE(matData.rank() != vecData.rank() + 1, std::invalid_argument, "matData and vecData have incompatible ranks");
@@ -1601,7 +1602,7 @@ namespace Intrepid2 {
         resultExtents[i]        = 1;
       }
       
-      ScalarView<DataScalar,ExecSpaceType> data;
+      ScalarView<DataScalar,DeviceType> data;
       if (resultNumActiveDims == 1)
       {
         data = matData.allocateDynRankViewMatchingUnderlying(resultDataDims[0]);
@@ -1635,11 +1636,11 @@ namespace Intrepid2 {
                                                              resultDataDims[3], resultDataDims[4], resultDataDims[5], resultDataDims[6]);
       }
       
-      return Data<DataScalar,ExecSpaceType>(data,resultRank,resultExtents,resultVariationTypes);
+      return Data<DataScalar,DeviceType>(data,resultRank,resultExtents,resultVariationTypes);
     }
     
     //! Places the result of a matrix-vector multiply corresponding to the two provided containers into this Data container.  This Data container should have been constructed by a call to allocateMatVecResult(), or should match such a container in underlying data extent and variation types.
-    void storeMatVec( const Data<DataScalar,ExecSpaceType> &matData, const Data<DataScalar,ExecSpaceType> &vecData )
+    void storeMatVec( const Data<DataScalar,DeviceType> &matData, const Data<DataScalar,DeviceType> &vecData )
     {
       // TODO: add a compile-time (SFINAE-type) guard against DataScalar types that do not support arithmetic operations.  (We support Orientation as a DataScalar type; it might suffice just to compare DataScalar to Orientation, and eliminate this method for that case.)
       // TODO: check for invalidly shaped containers.
@@ -1648,9 +1649,10 @@ namespace Intrepid2 {
       const int matCols = matData.extent_int(matData.rank() - 1);
       
       // shallow copy of this to avoid implicit references to this in call to getWritableEntry() below
-      Data<DataScalar,ExecSpaceType> thisData = *this;
+      Data<DataScalar,DeviceType> thisData = *this;
       
       // note the use of getDataExtent() below: we only range over the possibly-distinct entries
+      using ExecSpaceType = typename DeviceType::execution_space;
       if (rank_ == 3)
       {
         // typical case for e.g. gradient data: (C,P,D)
@@ -1706,7 +1708,7 @@ namespace Intrepid2 {
     //! \param transposeA                                          [in] - if true, A will be transposed prior to being multiplied by B (or B's transpose).
     //! \param B_MatData                                            [in] - nominally (...,D3,D4)-dimensioned container, where D3,D4 correspond to matrix dimensions.
     //! \param transposeB                                          [in] - if true, B will be transposed prior to the multiplication by A (or A's transpose).
-    void storeMatMat( const bool transposeA, const Data<DataScalar,ExecSpaceType> &A_MatData, const bool transposeB, const Data<DataScalar,ExecSpaceType> &B_MatData )
+    void storeMatMat( const bool transposeA, const Data<DataScalar,DeviceType> &A_MatData, const bool transposeB, const Data<DataScalar,DeviceType> &B_MatData )
     {
       // TODO: add a compile-time (SFINAE-type) guard against DataScalar types that do not support arithmetic operations.  (We support Orientation as a DataScalar type; it might suffice just to compare DataScalar to Orientation, and eliminate this method for that case.)
       // TODO: check for invalidly shaped containers.
@@ -1732,10 +1734,11 @@ namespace Intrepid2 {
 #endif
       
       // shallow copy of this to avoid implicit references to this in call to getWritableEntry() below
-      Data<DataScalar,ExecSpaceType> thisData = *this;
+      Data<DataScalar,DeviceType> thisData = *this;
       
       const int diagonalStart = (variationType_[D1_DIM] == BLOCK_PLUS_DIAGONAL) ? blockPlusDiagonalLastNonDiagonal_ + 1 : leftRows;
       // note the use of getDataExtent() below: we only range over the possibly-distinct entries
+      using ExecSpaceType = typename DeviceType::execution_space;
       if (rank_ == 3)
       {
         // (C,D,D), say

--- a/packages/intrepid2/src/Shared/Intrepid2_ScalarView.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_ScalarView.hpp
@@ -13,9 +13,9 @@
 
 namespace Intrepid2
 {
-  //! Intrepid2::ScalarView template requires execution space argument, in contrast to Kokkos::DynRankView, which defaults to the default execution space.  (We allow users to set the execution space for many of our classes; by using this template we can avoid accidentally using the default in members of those classes.
-  template<typename Scalar, typename ExecSpaceType>
-  using ScalarView = Kokkos::DynRankView<Scalar, ExecSpaceType>;
+  //! Intrepid2::ScalarView template requires execution space or device type argument, in contrast to Kokkos::DynRankView, which defaults to the default execution space.  (We allow users to set the execution space for many of our classes; by using this template we can avoid accidentally using the default in members of those classes.
+  template<typename Scalar, typename ExecSpaceOrDeviceType>
+  using ScalarView = Kokkos::DynRankView<Scalar, ExecSpaceOrDeviceType>;
 } // end namespace Intrepid2
 
 #endif /* Intrepid2_ScalarView_h */

--- a/packages/intrepid2/src/Shared/Intrepid2_TensorData.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_TensorData.hpp
@@ -62,6 +62,8 @@ namespace Intrepid2
   */
   template<class Scalar, typename DeviceType = typename Kokkos::DefaultExecutionSpace::device_type>
   class TensorData {
+    // TODO: re-enable this assert once all Basis subclasses have been converted to use DeviceType
+//    static_assert(Kokkos::is_device<DeviceType>::value, "Second template argument to TensorData must be a Kokkos::Device");
   protected:
     Kokkos::Array< Data<Scalar,DeviceType>, Parameters::MaxTensorComponents> tensorComponents_;
     Kokkos::Array<ordinal_type, 7> extents_;

--- a/packages/intrepid2/src/Shared/Intrepid2_TensorData.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_TensorData.hpp
@@ -60,10 +60,10 @@ namespace Intrepid2
   /** \class Intrepid2::TensorData
       \brief View-like interface to tensor data; tensor components are stored separately and multiplied together at access time.
   */
-  template<class Scalar, typename ExecSpaceType = Kokkos::DefaultExecutionSpace>
+  template<class Scalar, typename DeviceType = typename Kokkos::DefaultExecutionSpace::device_type>
   class TensorData {
   protected:
-    Kokkos::Array< Data<Scalar,ExecSpaceType>, Parameters::MaxTensorComponents> tensorComponents_;
+    Kokkos::Array< Data<Scalar,DeviceType>, Parameters::MaxTensorComponents> tensorComponents_;
     Kokkos::Array<ordinal_type, 7> extents_;
     Kokkos::Array<Kokkos::Array<ordinal_type, Parameters::MaxTensorComponents>, 7> entryModulus_;
     ordinal_type rank_;
@@ -122,7 +122,7 @@ namespace Intrepid2
     When <var>separateFirstComponent</var> is true, all components are required to have rank 1, and TensorData has rank 2, with the first argument reserved for the first component.  The second argument is indexed precisely as described above, omitting the first component.
     */
     template<size_t numTensorComponents>
-    TensorData(Kokkos::Array< Data<Scalar,ExecSpaceType>, numTensorComponents> tensorComponents, bool separateFirstComponent = false)
+    TensorData(Kokkos::Array< Data<Scalar,DeviceType>, numTensorComponents> tensorComponents, bool separateFirstComponent = false)
     :
     separateFirstComponent_(separateFirstComponent),
     numTensorComponents_(numTensorComponents)
@@ -144,7 +144,7 @@ namespace Intrepid2
      
     When <var>separateFirstComponent</var> is true, all components are required to have rank 1, and TensorData has rank 2, with the first argument reserved for the first component.  The second argument is indexed precisely as described above, omitting the first component.
     */
-    TensorData(std::vector< Data<Scalar,ExecSpaceType> > tensorComponents, bool separateFirstComponent = false)
+    TensorData(std::vector< Data<Scalar,DeviceType> > tensorComponents, bool separateFirstComponent = false)
     :
     separateFirstComponent_(separateFirstComponent),
     numTensorComponents_(tensorComponents.size())
@@ -163,9 +163,9 @@ namespace Intrepid2
      
       Simple constructor for trivial tensor-product structure.  The TensorData object will have precisely the same nominal data layout as the provided <var>tensorComponent</var>.
     */
-    TensorData(Data<Scalar,ExecSpaceType> tensorComponent)
+    TensorData(Data<Scalar,DeviceType> tensorComponent)
     :
-    TensorData(Kokkos::Array< Data<Scalar,ExecSpaceType>, 1>({tensorComponent}), false)
+    TensorData(Kokkos::Array< Data<Scalar,DeviceType>, 1>({tensorComponent}), false)
     {}
     
     /**
@@ -180,18 +180,18 @@ namespace Intrepid2
     {}
     
     /**
-     \brief Copy-like constructor for differing execution spaces.  This performs a deep copy of the underlying data.
+     \brief Copy-like constructor for differing memory spaces.  This performs a deep copy of the underlying data.
     */
-    template<typename OtherExecSpaceType, class = typename std::enable_if<!std::is_same<ExecSpaceType, OtherExecSpaceType>::value>::type>
-    TensorData(const TensorData<Scalar,OtherExecSpaceType> &tensorData)
+    template<typename OtherDeviceType, class = typename std::enable_if<!std::is_same<typename DeviceType::memory_space, typename OtherDeviceType::memory_space>::value>::type>
+    TensorData(const TensorData<Scalar,OtherDeviceType> &tensorData)
     {
       if (tensorData.isValid())
       {
         numTensorComponents_ = tensorData.numTensorComponents();
         for (ordinal_type r=0; r<numTensorComponents_; r++)
         {
-          Data<Scalar,OtherExecSpaceType> otherTensorComponent = tensorData.getTensorComponent(r);
-          tensorComponents_[r] = Data<Scalar,ExecSpaceType>(otherTensorComponent);
+          Data<Scalar,OtherDeviceType> otherTensorComponent = tensorData.getTensorComponent(r);
+          tensorComponents_[r] = Data<Scalar,DeviceType>(otherTensorComponent);
         }
         initialize();
       }
@@ -208,7 +208,7 @@ namespace Intrepid2
      \return the requested tensor component.
     */
     KOKKOS_INLINE_FUNCTION
-    const Data<Scalar,ExecSpaceType> & getTensorComponent(const ordinal_type &r) const
+    const Data<Scalar,DeviceType> & getTensorComponent(const ordinal_type &r) const
     {
       return tensorComponents_[r];
     }

--- a/packages/intrepid2/src/Shared/Intrepid2_TensorPoints.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_TensorPoints.hpp
@@ -58,6 +58,8 @@ namespace Intrepid2 {
 */
   template<class PointScalar, typename Device = Kokkos::DefaultExecutionSpace::device_type>
   class TensorPoints {
+    // TODO: re-enable this assert once all Basis subclasses have been converted to use DeviceType
+//    static_assert(Kokkos::is_device<Device>::value, "Second template argument to TensorPoints must be a Kokkos::Device");
   public:
     using DeviceType = Device;
   protected:

--- a/packages/intrepid2/src/Shared/Intrepid2_TensorPoints.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_TensorPoints.hpp
@@ -56,10 +56,12 @@ namespace Intrepid2 {
 /** \class Intrepid2::TensorPoints
     \brief View-like interface to tensor points; point components are stored separately; the appropriate coordinate is determined from the composite point index and requested dimension at access time.
 */
-  template<class PointScalar, typename ExecSpaceType = Kokkos::DefaultExecutionSpace>
+  template<class PointScalar, typename Device = Kokkos::DefaultExecutionSpace::device_type>
   class TensorPoints {
+  public:
+    using DeviceType = Device;
   protected:
-    Kokkos::Array< ScalarView<PointScalar,ExecSpaceType>, Parameters::MaxTensorComponents> pointTensorComponents_; // each component has dimensions (P,D)
+    Kokkos::Array< ScalarView<PointScalar,DeviceType>, Parameters::MaxTensorComponents> pointTensorComponents_; // each component has dimensions (P,D)
     ordinal_type numTensorComponents_;
     ordinal_type totalPointCount_;
     ordinal_type totalDimension_;
@@ -69,7 +71,7 @@ namespace Intrepid2 {
     Kokkos::Array<ordinal_type, Parameters::MaxTensorComponents> pointDivisor_;
     
     bool isValid_;
-    using reference_type = typename ScalarView<PointScalar,ExecSpaceType>::reference_type;
+    using reference_type = typename ScalarView<PointScalar,DeviceType>::reference_type;
     
     /**
      \brief Initialize members based on constructor parameters.
@@ -114,7 +116,7 @@ namespace Intrepid2 {
      TensorPoints has shape (P,D), where P is the product of the first dimensions of the component points, and D is the sum of the second dimensions.
     */
     template<size_t numTensorComponents>
-    TensorPoints(Kokkos::Array< ScalarView<PointScalar,ExecSpaceType>, numTensorComponents> pointTensorComponents)
+    TensorPoints(Kokkos::Array< ScalarView<PointScalar,DeviceType>, numTensorComponents> pointTensorComponents)
     :
     numTensorComponents_(numTensorComponents),
     isValid_(true)
@@ -133,7 +135,7 @@ namespace Intrepid2 {
      
      TensorPoints has shape (P,D), where P is the product of the first dimensions of the component points, and D is the sum of the second dimensions.
     */
-    TensorPoints(std::vector< ScalarView<PointScalar,ExecSpaceType>> pointTensorComponents)
+    TensorPoints(std::vector< ScalarView<PointScalar,DeviceType>> pointTensorComponents)
     :
     numTensorComponents_(pointTensorComponents.size()),
     isValid_(true)
@@ -152,7 +154,7 @@ namespace Intrepid2 {
      
      TensorPoints has the same shape (P,D) as the input points.
     */
-    TensorPoints(ScalarView<PointScalar,ExecSpaceType> points)
+    TensorPoints(ScalarView<PointScalar,DeviceType> points)
     :
     numTensorComponents_(1),
     isValid_(true)
@@ -167,10 +169,11 @@ namespace Intrepid2 {
      \param [in] fromPoints - the container to copy from.
     */
     template<class OtherPointsContainer>
-    void copyPointsContainer(ScalarView<PointScalar,ExecSpaceType> toPoints, OtherPointsContainer fromPoints)
+    void copyPointsContainer(ScalarView<PointScalar,DeviceType> toPoints, OtherPointsContainer fromPoints)
     {
       const int numPoints = fromPoints.extent_int(0);
       const int numDims   = fromPoints.extent_int(1);
+      using ExecSpaceType = typename DeviceType::execution_space;
       auto policy = Kokkos::MDRangePolicy<ExecSpaceType,Kokkos::Rank<2>>({0,0},{numPoints,numDims});
       Kokkos::parallel_for("copy points", policy,
       KOKKOS_LAMBDA (const int &i0, const int &i1) {
@@ -178,9 +181,9 @@ namespace Intrepid2 {
       });
     }
     
-    //! copy-like constructor for differing execution spaces.  This does a deep_copy of the underlying view.
-    template<typename OtherExecSpaceType, class = typename std::enable_if<!std::is_same<ExecSpaceType, OtherExecSpaceType>::value>::type>
-    TensorPoints(const TensorPoints<PointScalar,OtherExecSpaceType> &tensorPoints)
+    //! copy-like constructor for differing memory spaces.  This does a deep_copy of the underlying view.
+    template<typename OtherDeviceType, class = typename std::enable_if<!std::is_same<typename DeviceType::memory_space, typename OtherDeviceType::memory_space>::value>::type>
+    TensorPoints(const TensorPoints<PointScalar,OtherDeviceType> &tensorPoints)
     :
     numTensorComponents_(tensorPoints.numTensorComponents()),
     isValid_(tensorPoints.isValid())
@@ -189,12 +192,12 @@ namespace Intrepid2 {
       {
         for (ordinal_type r=0; r<numTensorComponents_; r++)
         {
-          ScalarView<PointScalar,OtherExecSpaceType> otherPointComponent = tensorPoints.getTensorComponent(r);
+          ScalarView<PointScalar,OtherDeviceType> otherPointComponent = tensorPoints.getTensorComponent(r);
           const int numPoints = otherPointComponent.extent_int(0);
           const int numDims   = otherPointComponent.extent_int(1);
-          pointTensorComponents_[r] = ScalarView<PointScalar,ExecSpaceType>("Intrepid2 point component", numPoints, numDims);
+          pointTensorComponents_[r] = ScalarView<PointScalar,DeviceType>("Intrepid2 point component", numPoints, numDims);
           
-          using MemorySpace = typename ExecSpaceType::memory_space;
+          using MemorySpace = typename DeviceType::memory_space;
           auto pointComponentMirror = Kokkos::create_mirror_view_and_copy(MemorySpace(), otherPointComponent);
           
           copyPointsContainer(pointTensorComponents_[r], pointComponentMirror);
@@ -294,12 +297,13 @@ namespace Intrepid2 {
     }
     
     //! This method is for compatibility with existing methods that take raw point views.  Note that in general it is probably better for performance to make the existing methods accept a TensorPoints object, since that can dramatically reduce memory footprint, and avoids an allocation here.
-    ScalarView<PointScalar,ExecSpaceType> allocateAndFillExpandedRawPointView() const
+    ScalarView<PointScalar,DeviceType> allocateAndFillExpandedRawPointView() const
     {
       const int numPoints = this->extent_int(0);
       const int spaceDim  = this->extent_int(1);
-      ScalarView<PointScalar,ExecSpaceType> expandedRawPoints("expanded raw points from TensorPoints", numPoints, spaceDim);
-      TensorPoints<PointScalar,ExecSpaceType> tensorPoints(*this); // (shallow) copy for lambda capture
+      ScalarView<PointScalar,DeviceType> expandedRawPoints("expanded raw points from TensorPoints", numPoints, spaceDim);
+      TensorPoints<PointScalar,DeviceType> tensorPoints(*this); // (shallow) copy for lambda capture
+      using ExecSpaceType = typename DeviceType::execution_space;
       Kokkos::parallel_for(
         Kokkos::MDRangePolicy<ExecSpaceType,Kokkos::Rank<2>>({0,0},{numPoints,spaceDim}),
         KOKKOS_LAMBDA (const int &pointOrdinal, const int &d) {
@@ -314,7 +318,7 @@ namespace Intrepid2 {
      \return the requested tensor component.
     */
     KOKKOS_INLINE_FUNCTION
-    ScalarView<PointScalar,ExecSpaceType> getTensorComponent(const ordinal_type &r) const
+    ScalarView<PointScalar,DeviceType> getTensorComponent(const ordinal_type &r) const
     {
       return pointTensorComponents_[r];
     }
@@ -343,7 +347,7 @@ namespace Intrepid2 {
     // NOTE: the extractTensorPoints() code commented out below appears not to work.  We don't have tests against it, though.
     // TODO: either delete this, or re-enable, add tests, and fix.
 //    template<class ViewType>
-//    static TensorPoints<PointScalar,ExecSpaceType> extractTensorPoints( ViewType expandedPoints, const std::vector<ordinal_type> &dimensionExtents )
+//    static TensorPoints<PointScalar,DeviceType> extractTensorPoints( ViewType expandedPoints, const std::vector<ordinal_type> &dimensionExtents )
 //    {
 //      const ordinal_type numComponents = dimensionExtents.size();
 //      const ordinal_type numPoints     = expandedPoints.extent_int(0);
@@ -357,7 +361,7 @@ namespace Intrepid2 {
 //      ordinal_type dimOffset = 0;
 //      ordinal_type tensorPointStride = 1; // increases with componentOrdinal
 //
-//      TensorPoints<PointScalar,ExecSpaceType> invalidTensorData; // will be returned if extraction does not succeed.
+//      TensorPoints<PointScalar,DeviceType> invalidTensorData; // will be returned if extraction does not succeed.
 //
 //      for (ordinal_type componentOrdinal=0; componentOrdinal<numComponents; componentOrdinal++)
 //      {
@@ -419,13 +423,13 @@ namespace Intrepid2 {
 //        tensorPointStride *= componentPointCounts[componentOrdinal];
 //      }
 //
-//      std::vector< ScalarView<PointScalar,ExecSpaceType> > componentPoints(numComponents);
+//      std::vector< ScalarView<PointScalar,DeviceType> > componentPoints(numComponents);
 //      std::vector< ScalarView<PointScalar,Kokkos::HostSpace> > componentPointsHost(numComponents);
 //      for (ordinal_type componentOrdinal=0; componentOrdinal<numComponents; componentOrdinal++)
 //      {
 //        const ordinal_type numPointsForComponent = componentPointCounts[componentOrdinal];
 //        const ordinal_type dimForComponent       = dimensionExtents[componentOrdinal];
-//        componentPoints[componentOrdinal] = ScalarView<PointScalar,ExecSpaceType>("extracted tensor components", numPointsForComponent, dimForComponent);
+//        componentPoints[componentOrdinal] = ScalarView<PointScalar,DeviceType>("extracted tensor components", numPointsForComponent, dimForComponent);
 //        componentPointsHost[componentOrdinal] = Kokkos::create_mirror(componentPoints[componentOrdinal]);
 //      }
 //
@@ -471,7 +475,7 @@ namespace Intrepid2 {
 //        return invalidTensorData;
 //      }
 //
-//      return TensorPoints<PointScalar,ExecSpaceType>(componentPoints);
+//      return TensorPoints<PointScalar,DeviceType>(componentPoints);
 //    }
   };
 

--- a/packages/intrepid2/src/Shared/Intrepid2_TestUtils.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_TestUtils.hpp
@@ -102,10 +102,10 @@ namespace Intrepid2
 
   // we use DynRankView for both input points and values
   template<typename ScalarType>
-  using ViewType = Kokkos::DynRankView<ScalarType,Kokkos::DefaultExecutionSpace>;
+  using ViewType = Kokkos::DynRankView<ScalarType,typename Kokkos::DefaultExecutionSpace::device_type>;
 
   template<typename ScalarType>
-  using FixedRankViewType = Kokkos::View<ScalarType,Kokkos::DefaultExecutionSpace>;
+  using FixedRankViewType = Kokkos::View<ScalarType,typename Kokkos::DefaultExecutionSpace::device_type>;
 
   template<typename ScalarType>
   KOKKOS_INLINE_FUNCTION bool valuesAreSmall(const ScalarType &a, const ScalarType &b, const double &epsilon)
@@ -159,7 +159,7 @@ namespace Intrepid2
   }
 
   template<class BasisFamily>
-  inline Teuchos::RCP< Intrepid2::Basis<Kokkos::DefaultExecutionSpace,double,double> > getBasisUsingFamily(shards::CellTopology cellTopo, Intrepid2::EFunctionSpace fs,
+  inline Teuchos::RCP< Intrepid2::Basis<typename Kokkos::DefaultExecutionSpace::device_type,double,double> > getBasisUsingFamily(shards::CellTopology cellTopo, Intrepid2::EFunctionSpace fs,
                                                                                                            int polyOrder_x, int polyOrder_y=-1, int polyOrder_z = -1)
   {
     using BasisPtr = typename BasisFamily::BasisPtr;
@@ -198,17 +198,17 @@ namespace Intrepid2
   }
 
   template<bool defineVertexFunctions>
-  inline Teuchos::RCP< Intrepid2::Basis<Kokkos::DefaultExecutionSpace,double,double> > getHierarchicalBasis(shards::CellTopology cellTopo, Intrepid2::EFunctionSpace fs,
-                                                                                                            int polyOrder_x, int polyOrder_y=-1, int polyOrder_z = -1)
+  inline Teuchos::RCP< Intrepid2::Basis<typename Kokkos::DefaultExecutionSpace::device_type,double,double> > getHierarchicalBasis(shards::CellTopology cellTopo, Intrepid2::EFunctionSpace fs,
+                                                                                                                                  int polyOrder_x, int polyOrder_y=-1, int polyOrder_z = -1)
   {
-    using ExecSpace = Kokkos::DefaultExecutionSpace;
+    using DeviceType = typename Kokkos::DefaultExecutionSpace::device_type;
     using Scalar = double;
     using namespace Intrepid2;
     
-    using LineBasisGrad = Intrepid2::IntegratedLegendreBasis_HGRAD_LINE<ExecSpace, Scalar, Scalar, defineVertexFunctions, true>;
-    using LineBasisVol  = Intrepid2::LegendreBasis_HVOL_LINE< ExecSpace, Scalar, Scalar>;
-    using TriangleBasisFamily = Intrepid2::HierarchicalTriangleBasisFamily<ExecSpace, Scalar, Scalar, defineVertexFunctions>;
-    using TetrahedronBasisFamily = Intrepid2::HierarchicalTetrahedronBasisFamily<ExecSpace, Scalar, Scalar, defineVertexFunctions>;
+    using LineBasisGrad = Intrepid2::IntegratedLegendreBasis_HGRAD_LINE<DeviceType, Scalar, Scalar, defineVertexFunctions, true>;
+    using LineBasisVol  = Intrepid2::LegendreBasis_HVOL_LINE< DeviceType, Scalar, Scalar>;
+    using TriangleBasisFamily = Intrepid2::HierarchicalTriangleBasisFamily<DeviceType, Scalar, Scalar, defineVertexFunctions>;
+    using TetrahedronBasisFamily = Intrepid2::HierarchicalTetrahedronBasisFamily<DeviceType, Scalar, Scalar, defineVertexFunctions>;
     
     using BasisFamily = DerivedBasisFamily<LineBasisGrad, LineBasisVol, TriangleBasisFamily, TetrahedronBasisFamily>;
     

--- a/packages/intrepid2/src/Shared/Intrepid2_TransformedVectorData.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_TransformedVectorData.hpp
@@ -60,22 +60,23 @@ namespace Intrepid2 {
  
  TransformedVectorData provides a View-like interface of rank 4, with shape (C,F,P,D).  When the corresponding accessor is used, the transformed value is determined from corresponding reference space values and the transformation.
 */
-  template<class Scalar, typename ExecSpaceType = Kokkos::DefaultExecutionSpace>
+  template<class Scalar, typename DeviceType = typename Kokkos::DefaultExecutionSpace::device_type>
   class TransformedVectorData
   {
+    static_assert(Kokkos::is_device<DeviceType>::value, "Second template argument to TransformedVectorData must be a Kokkos::Device");
   public:
-    using Transform = Data<Scalar,ExecSpaceType>;
+    using Transform = Data<Scalar,DeviceType>;
     
-    Data<Scalar,ExecSpaceType> transform_; // (C,P,D,D) jacobian or jacobian inverse; can also be unset for identity transform
+    Data<Scalar,DeviceType> transform_; // (C,P,D,D) jacobian or jacobian inverse; can also be unset for identity transform
     
-    VectorData<Scalar, ExecSpaceType> vectorData_; // notionally (F,P,D) container
+    VectorData<Scalar, DeviceType> vectorData_; // notionally (F,P,D) container
     
     /**
      \brief Standard constructor.
      \param [in] transform - the transformation matrix, with nominal shape (C,P,D,D)
      \param [in] vectorData - the reference-space data to be transformed, with nominal shape (F,P,D)
     */
-    TransformedVectorData(const Data<Scalar,ExecSpaceType> &transform, const VectorData<Scalar,ExecSpaceType> &vectorData)
+    TransformedVectorData(const Data<Scalar,DeviceType> &transform, const VectorData<Scalar,DeviceType> &vectorData)
     :
     transform_(transform), vectorData_(vectorData)
     {
@@ -87,14 +88,14 @@ namespace Intrepid2 {
      \brief Constructor for the case of an identity transform.
      \param [in] vectorData - the reference-space data, with nominal shape (F,P,D)
     */
-    TransformedVectorData(const VectorData<Scalar, ExecSpaceType> &vectorData)
+    TransformedVectorData(const VectorData<Scalar, DeviceType> &vectorData)
     :
     vectorData_(vectorData)
     {}
     
     //! copy-like constructor for differing execution spaces.  This does a deep_copy of underlying views.
-    template<typename OtherExecSpaceType, class = typename std::enable_if<!std::is_same<ExecSpaceType, OtherExecSpaceType>::value>::type>
-    TransformedVectorData(const TransformedVectorData<Scalar,OtherExecSpaceType> &transformedVectorData)
+    template<typename OtherDeviceType, class = typename std::enable_if<!std::is_same<typename DeviceType::memory_space, typename OtherDeviceType::memory_space>::value>::type>
+    TransformedVectorData(const TransformedVectorData<Scalar,OtherDeviceType> &transformedVectorData)
     :
     transform_(transformedVectorData.transform()),
     vectorData_(transformedVectorData.vectorData())
@@ -188,13 +189,13 @@ namespace Intrepid2 {
     }
     
     //! Returns the transform matrix.  An invalid/empty container indicates the identity transform.
-    const Data<Scalar,ExecSpaceType> & transform() const
+    const Data<Scalar,DeviceType> & transform() const
     {
       return transform_;
     }
     
     //! Returns the reference-space vector data.
-    const VectorData<Scalar,ExecSpaceType> & vectorData() const
+    const VectorData<Scalar,DeviceType> & vectorData() const
     {
       return vectorData_;
     }

--- a/packages/intrepid2/src/Shared/Intrepid2_VectorData.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_VectorData.hpp
@@ -61,11 +61,13 @@ namespace Intrepid2 {
  
  Typically, HDIV and HCURL bases have multiple families corresponding to the nonzero structure of the vector components.  VectorData therefore supports multiple families.  (Gradients of H^1 are expressed as a single family.)
 */
-  template<class Scalar, typename ExecSpaceType = Kokkos::DefaultExecutionSpace>
+  template<class Scalar, typename DeviceType = typename Kokkos::DefaultExecutionSpace::device_type>
   class VectorData
   {
+    // TODO: re-enable this assert once all Basis subclasses have been converted to use DeviceType
+//    static_assert(Kokkos::is_device<DeviceType>::value, "Second template argument to VectorData must be a Kokkos::Device");
   public:
-    using VectorArray = Kokkos::Array< TensorData<Scalar,ExecSpaceType>, Parameters::MaxTensorComponents>; // for axis-aligned case, these correspond entry-wise to the axis with which the vector values align
+    using VectorArray = Kokkos::Array< TensorData<Scalar,DeviceType>, Parameters::MaxTensorComponents>; // for axis-aligned case, these correspond entry-wise to the axis with which the vector values align
     using FamilyVectorArray = Kokkos::Array< VectorArray, Parameters::MaxTensorComponents>;
 
     FamilyVectorArray vectorComponents_; // outer: family ordinal; inner: component/spatial dimension ordinal
@@ -176,7 +178,7 @@ namespace Intrepid2 {
      Outer dimension: number of families; inner dimension: number of components in each vector.  Use empty/invalid TensorData objects to indicate zeroes.  Each family, and each vector component dimension, must have at least one valid entry, and the number of points in each valid entry must agree with each other.  The field count within components of a family must also agree; across families these may differ.  Vector components are allowed to span multiple spatial dimensions, but when they do, any valid TensorData object in that vector position must agree in the dimension across families.
     */
     template<size_t numFamilies, size_t numComponents>
-    VectorData(Kokkos::Array< Kokkos::Array<TensorData<Scalar,ExecSpaceType>, numComponents>, numFamilies> vectorComponents)
+    VectorData(Kokkos::Array< Kokkos::Array<TensorData<Scalar,DeviceType>, numComponents>, numFamilies> vectorComponents)
     :
     numFamilies_(numFamilies),
     numComponents_(numComponents)
@@ -199,7 +201,7 @@ namespace Intrepid2 {
      
      Outer dimension: number of families; inner dimension: number of components in each vector.  Use empty/invalid TensorData objects to indicate zeroes.  Each family, and each vector component dimension, must have at least one valid entry, and the number of points in each valid entry must agree with each other.  The field count within components of a family must also agree; across families these may differ.  Vector components are allowed to span multiple spatial dimensions, but when they do, any valid TensorData object in that vector position must agree in the dimension across families.
     */
-    VectorData(const std::vector< std::vector<TensorData<Scalar,ExecSpaceType> > > &vectorComponents)
+    VectorData(const std::vector< std::vector<TensorData<Scalar,DeviceType> > > &vectorComponents)
     {
       numFamilies_ = vectorComponents.size();
       INTREPID2_TEST_FOR_EXCEPTION(numFamilies_ <= 0, std::invalid_argument, "numFamilies must be at least 1");
@@ -229,7 +231,7 @@ namespace Intrepid2 {
      For the gradient use case, VectorData will have a single family.  For the HDIV and HCURL use cases, will have the same number of families as there are components in the vectorComponents argument; each family will consist of vectors that have one entry filled, the others zeroes; this is what we mean by "axial components."
     */
     template<size_t numComponents>
-    VectorData(Kokkos::Array< TensorData<Scalar,ExecSpaceType>, numComponents> vectorComponents, bool axialComponents)
+    VectorData(Kokkos::Array< TensorData<Scalar,DeviceType>, numComponents> vectorComponents, bool axialComponents)
     {
       if (axialComponents)
       {
@@ -259,7 +261,7 @@ namespace Intrepid2 {
      
      For the gradient use case, VectorData will have a single family.  For the HDIV and HCURL use cases, will have the same number of families as there are components in the vectorComponents argument; each family will consist of vectors that have one entry filled, the others zeroes; this is what we mean by "axial components."
     */
-    VectorData(std::vector< TensorData<Scalar,ExecSpaceType> > vectorComponents, bool axialComponents)
+    VectorData(std::vector< TensorData<Scalar,DeviceType> > vectorComponents, bool axialComponents)
     : numComponents_(vectorComponents.size())
     {
       if (axialComponents)
@@ -282,8 +284,8 @@ namespace Intrepid2 {
     }
     
     //! copy-like constructor for differing execution spaces.  This does a deep copy of underlying views.
-    template<typename OtherExecSpaceType, class = typename std::enable_if<!std::is_same<ExecSpaceType, OtherExecSpaceType>::value>::type>
-    VectorData(const VectorData<Scalar,OtherExecSpaceType> &vectorData)
+    template<typename OtherDeviceType, class = typename std::enable_if<!std::is_same<typename DeviceType::memory_space, typename OtherDeviceType::memory_space>::value>::type>
+    VectorData(const VectorData<Scalar,OtherDeviceType> &vectorData)
     :
     numFamilies_(vectorData.numFamilies()),
     numComponents_(vectorData.numComponents())
@@ -302,15 +304,15 @@ namespace Intrepid2 {
     }
     
     //! Simple 1-argument constructor for the case of trivial tensor product structure.  The argument should have shape (F,P,D) where D has extent equal to the spatial dimension.
-    VectorData(TensorData<Scalar,ExecSpaceType> data)
+    VectorData(TensorData<Scalar,DeviceType> data)
     :
-    VectorData(Kokkos::Array< TensorData<Scalar,ExecSpaceType>, 1>(data), true)
+    VectorData(Kokkos::Array< TensorData<Scalar,DeviceType>, 1>(data), true)
     {}
     
     //! Simple 1-argument constructor for the case of trivial tensor product structure.  The argument should have shape (F,P,D) where D has extent equal to the spatial dimension.
-    VectorData(Data<Scalar,ExecSpaceType> data)
+    VectorData(Data<Scalar,DeviceType> data)
     :
-    VectorData(Kokkos::Array< TensorData<Scalar,ExecSpaceType>, 1>({TensorData<Scalar,ExecSpaceType>(data)}), true)
+    VectorData(Kokkos::Array< TensorData<Scalar,DeviceType>, 1>({TensorData<Scalar,DeviceType>(data)}), true)
     {}
     
     //! default constructor; results in an invalid container.
@@ -418,7 +420,7 @@ namespace Intrepid2 {
      \param [in] componentOrdinal - the vector component ordinal.
     */
     KOKKOS_INLINE_FUNCTION
-    const TensorData<Scalar,ExecSpaceType> & getComponent(const int &componentOrdinal) const
+    const TensorData<Scalar,DeviceType> & getComponent(const int &componentOrdinal) const
     {
       if (axialComponents_)
       {
@@ -442,7 +444,7 @@ namespace Intrepid2 {
      \param [in] componentOrdinal - the vector component ordinal.
     */
     KOKKOS_INLINE_FUNCTION
-    const TensorData<Scalar,ExecSpaceType> & getComponent(const int &familyOrdinal, const int &componentOrdinal) const
+    const TensorData<Scalar,DeviceType> & getComponent(const int &familyOrdinal, const int &componentOrdinal) const
     {
       INTREPID2_TEST_FOR_EXCEPTION_DEVICE_SAFE(familyOrdinal < 0, std::invalid_argument, "familyOrdinal must be non-negative");
       INTREPID2_TEST_FOR_EXCEPTION_DEVICE_SAFE(static_cast<unsigned>(familyOrdinal) >= numFamilies_, std::invalid_argument, "familyOrdinal out of bounds");

--- a/packages/intrepid2/unit-test/MonolithicExecutable/AnalyticPolynomialsMatchTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/AnalyticPolynomialsMatchTests.cpp
@@ -231,13 +231,13 @@ namespace
     }
   }
   
-  template<typename ExecutionSpace=Kokkos::DefaultExecutionSpace,
+  template<typename DeviceType = typename Kokkos::DefaultExecutionSpace::device_type,
            typename OutputScalar = double,
            typename PointScalar  = double>
   void testHierarchicalHGRAD_LINE_MatchesAnalyticValues(Intrepid2::EOperator op, const double tol, Teuchos::FancyOStream &out, bool &success)
   {
     using namespace Intrepid2;
-    using BasisFamily = HierarchicalBasisFamily<ExecutionSpace,OutputScalar,PointScalar>;
+    using BasisFamily = HierarchicalBasisFamily<DeviceType,OutputScalar,PointScalar>;
     
     const int polyOrder = 4;
     auto hgradBasis = getLineBasis<BasisFamily>(FUNCTION_SPACE_HGRAD, polyOrder);
@@ -951,25 +951,25 @@ namespace
   TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL( AnalyticPolynomialsMatch, Hierarchical_HGRAD_LINE, OutputScalar, PointScalar )
   {
     const double tol = TEST_TOLERANCE_TIGHT;
-    using ExecSpace = Kokkos::DefaultExecutionSpace;
+    using DeviceType = typename Kokkos::DefaultExecutionSpace::device_type;
     
     std::vector<Intrepid2::EOperator> operators = {{OPERATOR_VALUE, OPERATOR_GRAD, OPERATOR_D1, OPERATOR_D2, OPERATOR_D3, OPERATOR_D4, OPERATOR_D5, OPERATOR_D6, OPERATOR_D7, OPERATOR_D8, OPERATOR_D9, OPERATOR_D10}};
     for (auto op : operators)
     {
-      testHierarchicalHGRAD_LINE_MatchesAnalyticValues<ExecSpace,OutputScalar,PointScalar>(op, tol, out, success);
+      testHierarchicalHGRAD_LINE_MatchesAnalyticValues<DeviceType,OutputScalar,PointScalar>(op, tol, out, success);
     }
   }
   
   TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL( AnalyticPolynomialsMatch, Hierarchical_HGRAD_TRI, OutputScalar, PointScalar )
   {
     const double tol = TEST_TOLERANCE_TIGHT;
-    using ExecSpace = Kokkos::DefaultExecutionSpace;
+    using DeviceType = typename Kokkos::DefaultExecutionSpace::device_type;
     
 //    std::vector<Intrepid2::EOperator> operators = {{OPERATOR_VALUE, OPERATOR_GRAD, OPERATOR_D1, OPERATOR_D2, OPERATOR_D3, OPERATOR_D4, OPERATOR_D5, OPERATOR_D6, OPERATOR_D7, OPERATOR_D8, OPERATOR_D9, OPERATOR_D10}};
     std::vector<Intrepid2::EOperator> operators = {OPERATOR_VALUE};
     for (auto op : operators)
     {
-      testHierarchicalHGRAD_TRIANGLE_MatchesAnalyticValues<ExecSpace,OutputScalar,PointScalar>(op, tol, out, success);
+      testHierarchicalHGRAD_TRIANGLE_MatchesAnalyticValues<DeviceType,OutputScalar,PointScalar>(op, tol, out, success);
     }
   }
   
@@ -978,8 +978,8 @@ namespace
     const int maxPolyOrder = 10;
     const double tol = TEST_TOLERANCE_TIGHT;
     
-    using ExecSpace = Kokkos::DefaultExecutionSpace;
-    using HierarchicalBasisFamily = HierarchicalBasisFamily<ExecSpace,OutputScalar,PointScalar>;
+    using DeviceType = typename Kokkos::DefaultExecutionSpace::device_type;
+    using HierarchicalBasisFamily = HierarchicalBasisFamily<DeviceType,OutputScalar,PointScalar>;
     
     for (int derivativeOrder=1; derivativeOrder<=5; derivativeOrder++)
     {
@@ -992,9 +992,9 @@ namespace
   {
     // the following should match in H(grad) and H(vol), but are not expected to match in H(curl) and H(div)
     // (the latter differ in that Standard uses another H(grad) instance to represent the L^2 component of H(curl) and H(div), while Derived uses H(vol))
-    using ExecSpace = Kokkos::DefaultExecutionSpace;
-    using DerivedNodalBasisFamily  = Intrepid2::DerivedNodalBasisFamily<ExecSpace,OutputScalar,PointScalar>;
-    using StandardNodalBasisFamily = Intrepid2::NodalBasisFamily       <ExecSpace,OutputScalar,PointScalar>;
+    using DeviceType = typename Kokkos::DefaultExecutionSpace::device_type;
+    using DerivedNodalBasisFamily  = Intrepid2::DerivedNodalBasisFamily<DeviceType,OutputScalar,PointScalar>;
+    using StandardNodalBasisFamily = Intrepid2::NodalBasisFamily       <DeviceType,OutputScalar,PointScalar>;
     
     const double tol = TEST_TOLERANCE_TIGHT;
     

--- a/packages/intrepid2/unit-test/MonolithicExecutable/BasisEquivalenceTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/BasisEquivalenceTests.cpp
@@ -447,8 +447,9 @@ namespace
   
   TEUCHOS_UNIT_TEST( BasisEquivalence, LineNodalCnVersusNodalC1_HGRAD )
   {
-    using CnBasis = Intrepid2::Basis_HGRAD_LINE_Cn_FEM<Kokkos::DefaultExecutionSpace>;
-    using C1Basis = Intrepid2::Basis_HGRAD_LINE_C1_FEM<Kokkos::DefaultExecutionSpace>;
+    using DeviceType = typename Kokkos::DefaultExecutionSpace::device_type;
+    using CnBasis = Intrepid2::Basis_HGRAD_LINE_Cn_FEM<DeviceType>;
+    using C1Basis = Intrepid2::Basis_HGRAD_LINE_C1_FEM<DeviceType>;
     
     std::vector<EOperator> opsToTest {OPERATOR_GRAD, OPERATOR_D1, OPERATOR_D2, OPERATOR_D3, OPERATOR_D4, OPERATOR_D5};
     
@@ -562,9 +563,10 @@ namespace
 
   TEUCHOS_UNIT_TEST( BasisEquivalence, HexahedronNodalCnVersusNodalC1_HGRAD )
   {
-    using CnBasis = Intrepid2::Basis_HGRAD_HEX_Cn_FEM<Kokkos::DefaultExecutionSpace>;
-    using C1Basis = Intrepid2::Basis_HGRAD_HEX_C1_FEM<Kokkos::DefaultExecutionSpace>;
-
+    using DeviceType = typename Kokkos::DefaultExecutionSpace::device_type;
+    using CnBasis = Intrepid2::Basis_HGRAD_HEX_Cn_FEM<DeviceType>;
+    using C1Basis = Intrepid2::Basis_HGRAD_HEX_C1_FEM<DeviceType>;
+    
     // these tolerances are selected such that we have a little leeway for architectural differences
     // (It is true, though, that we incur a fair amount of floating point error for higher order bases in higher dimensions)
     const double relTol=1e-13; // ____ is sharp on development setup for polyOrder=1; relaxing for potential architectural differences
@@ -579,8 +581,9 @@ namespace
   
   TEUCHOS_UNIT_TEST( BasisEquivalence, HexahedronNodalCnVersusNodalC2_HGRAD )
   {
-    using CnBasis = Intrepid2::Basis_HGRAD_HEX_Cn_FEM<Kokkos::DefaultExecutionSpace>;
-    using C2Basis = Intrepid2::Basis_HGRAD_HEX_C2_FEM<Kokkos::DefaultExecutionSpace>;
+    using DeviceType = typename Kokkos::DefaultExecutionSpace::device_type;
+    using CnBasis = Intrepid2::Basis_HGRAD_HEX_Cn_FEM<DeviceType>;
+    using C2Basis = Intrepid2::Basis_HGRAD_HEX_C2_FEM<DeviceType>;
 
     // these tolerances are selected such that we have a little leeway for architectural differences
     // (It is true, though, that we incur a fair amount of floating point error for higher order bases in higher dimensions)
@@ -598,8 +601,9 @@ namespace
   
   TEUCHOS_UNIT_TEST( BasisEquivalence, TetrahedronNodalCnVersusNodalC2_HGRAD )
   {
-    using CnBasis = Intrepid2::Basis_HGRAD_TET_Cn_FEM<Kokkos::DefaultExecutionSpace>;
-    using C2Basis = Intrepid2::Basis_HGRAD_TET_C2_FEM<Kokkos::DefaultExecutionSpace>;
+    using DeviceType = typename Kokkos::DefaultExecutionSpace::device_type;
+    using CnBasis = Intrepid2::Basis_HGRAD_TET_Cn_FEM<DeviceType>;
+    using C2Basis = Intrepid2::Basis_HGRAD_TET_C2_FEM<DeviceType>;
     
     // OPERATOR_D2 and above are not supported by either the nodal or the hierarchical basis at present...
     std::vector<EOperator> opsToTest {OPERATOR_GRAD, OPERATOR_D1};

--- a/packages/intrepid2/unit-test/MonolithicExecutable/BasisEquivalenceTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/BasisEquivalenceTests.cpp
@@ -235,13 +235,13 @@ namespace
     
     // get quadrature points for integrating up to 2*polyOrder
     const int quadratureDegree = 2*basis1.getDegree();
-    using ExecutionSpace = typename Basis1::ExecutionSpace;
+    using DeviceType = typename Basis1::DeviceType;
     using PointScalar = typename Basis1::PointValueType;
     using WeightScalar = typename Basis1::OutputValueType;
     using Scalar = WeightScalar;
     DefaultCubatureFactory cub_factory;
     auto cellTopoKey = basis1.getBaseCellTopology().getKey();
-    auto quadrature = cub_factory.create<ExecutionSpace, PointScalar, WeightScalar>(cellTopoKey, quadratureDegree);
+    auto quadrature = cub_factory.create<DeviceType, PointScalar, WeightScalar>(cellTopoKey, quadratureDegree);
     ordinal_type numRefPoints = quadrature->getNumPoints();
     const int spaceDim = basis1.getBaseCellTopology().getDimension();
     ViewType<PointScalar> points = ViewType<PointScalar>("quadrature points 1D ref cell", numRefPoints, spaceDim);

--- a/packages/intrepid2/unit-test/MonolithicExecutable/BasisValuesTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/BasisValuesTests.cpp
@@ -79,11 +79,12 @@ namespace
     // get quadrature points for integrating up to polyOrder
     const int quadratureDegree = 2*basis.getDegree();
     using ExecutionSpace = typename Basis::ExecutionSpace;
+    using DeviceType     = typename Basis::DeviceType;
     using PointScalar = typename Basis::PointValueType;
     using WeightScalar = typename Basis::OutputValueType;
     DefaultCubatureFactory cub_factory;
     auto cellTopoKey = basis.getBaseCellTopology().getKey();
-    auto quadrature = cub_factory.create<ExecutionSpace, PointScalar, WeightScalar>(cellTopoKey, quadratureDegree);
+    auto quadrature = cub_factory.create<DeviceType, PointScalar, WeightScalar>(cellTopoKey, quadratureDegree);
     ordinal_type numRefPoints = quadrature->getNumPoints();
     const int spaceDim = basis.getBaseCellTopology().getDimension();
     ViewType<PointScalar> points = ViewType<PointScalar>("quadrature points ref cell", numRefPoints, spaceDim);
@@ -93,7 +94,7 @@ namespace
     TensorPoints<PointScalar> tensorPoints;
     TensorData<WeightScalar>  tensorWeights;
     
-    using CubatureTensorType = CubatureTensor<ExecutionSpace,PointScalar,WeightScalar>;
+    using CubatureTensorType = CubatureTensor<DeviceType,PointScalar,WeightScalar>;
     CubatureTensorType* tensorQuadrature = dynamic_cast<CubatureTensorType*>(quadrature.get());
 
     if (tensorQuadrature)

--- a/packages/intrepid2/unit-test/MonolithicExecutable/CubatureTensorTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/CubatureTensorTests.cpp
@@ -64,22 +64,23 @@ namespace
   void testTensorPointCubature(const shards::CellTopology &cellTopo, const int &quadratureDegree,
                                const double &relTol, const double &absTol, Teuchos::FancyOStream &out, bool &success)
   {
-    using ExecutionSpace = Kokkos::DefaultExecutionSpace;
+    using DeviceType = typename Kokkos::DefaultExecutionSpace::device_type;
+    
     using PointScalar = double;
     using WeightScalar = double;
     DefaultCubatureFactory cub_factory;
     auto cellTopoKey = cellTopo.getKey();
-    auto quadrature = cub_factory.create<ExecutionSpace, PointScalar, WeightScalar>(cellTopoKey, quadratureDegree);
+    auto quadrature = cub_factory.create<DeviceType, PointScalar, WeightScalar>(cellTopoKey, quadratureDegree);
     ordinal_type numRefPoints = quadrature->getNumPoints();
     const int spaceDim = cellTopo.getDimension();
     ViewType<PointScalar> points = ViewType<PointScalar>("quadrature points ref cell", numRefPoints, spaceDim);
     ViewType<WeightScalar> weights = ViewType<WeightScalar>("quadrature weights ref cell", numRefPoints);
     quadrature->getCubature(points, weights);
     
-    TensorPoints<PointScalar> tensorPoints;
-    TensorData<WeightScalar>  tensorWeights;
+    TensorPoints<PointScalar,DeviceType> tensorPoints;
+    TensorData<WeightScalar,DeviceType>  tensorWeights;
     
-    using CubatureTensorType = CubatureTensor<ExecutionSpace,PointScalar,WeightScalar>;
+    using CubatureTensorType = CubatureTensor<DeviceType,PointScalar,WeightScalar>;
     CubatureTensorType* tensorQuadrature = dynamic_cast<CubatureTensorType*>(quadrature.get());
 
     if (tensorQuadrature)
@@ -91,10 +92,10 @@ namespace
     else
     {
       std::vector<ViewType<PointScalar>> pointComponents {points};
-      tensorPoints = TensorPoints<PointScalar>(pointComponents);
+      tensorPoints = TensorPoints<PointScalar,DeviceType>(pointComponents);
       Data<WeightScalar> weightData(weights);
-      std::vector<Data<WeightScalar>> weightComponents {weightData};
-      tensorWeights = TensorData<WeightScalar>(weightComponents);
+      std::vector<Data<WeightScalar,DeviceType>> weightComponents {weightData};
+      tensorWeights = TensorData<WeightScalar,DeviceType>(weightComponents);
     }
     
     printView(points, out, "Points being tested");

--- a/packages/intrepid2/unit-test/MonolithicExecutable/StructuredIntegrationTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/StructuredIntegrationTests.cpp
@@ -193,8 +193,7 @@ ScalarView<Scalar,DeviceType> performStandardQuadratureHypercube(int meshWidth, 
   // local stiffness matrix:
   ScalarView<Scalar,DeviceType> cellStiffness("cell stiffness matrices",numCells,numFields,numFields);
   
-  using Kokkos::DefaultExecutionSpace;
-  auto cubature = Intrepid2::DefaultCubatureFactory::create<DefaultExecutionSpace>(cellTopo,polyOrder*2);
+  auto cubature = Intrepid2::DefaultCubatureFactory::create<DeviceType>(cellTopo,polyOrder*2);
   int numPoints = cubature->getNumPoints();
   ScalarView<PointScalar,DeviceType> cubaturePoints("cubature points",numPoints,spaceDim);
   ScalarView<double,DeviceType> cubatureWeights("cubature weights", numPoints);

--- a/packages/intrepid2/unit-test/MonolithicExecutable/StructuredIntegrationTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/StructuredIntegrationTests.cpp
@@ -81,9 +81,9 @@ namespace
 
 //! version of integrate that performs a standard integration for affine meshes; does not take advantage of the tensor product structure at all
 //! this version can be used to verify correctness of other versions
-template<class Scalar, typename ExecSpaceType>
-void integrate_baseline_serial_host(Data<Scalar,ExecSpaceType> integrals, const TransformedVectorData<Scalar,ExecSpaceType> vectorDataLeft,
-                                    const TensorData<Scalar,ExecSpaceType> cellMeasures, const TransformedVectorData<Scalar,ExecSpaceType> vectorDataRight)
+template<class Scalar, typename DeviceType>
+void integrate_baseline_serial_host(Data<Scalar,DeviceType> integrals, const TransformedVectorData<Scalar,DeviceType> vectorDataLeft,
+                                    const TensorData<Scalar,DeviceType> cellMeasures, const TransformedVectorData<Scalar,DeviceType> vectorDataRight)
 {
   const int cellDataExtent = integrals.getDataExtent(0);
   const int numFieldsLeft  = vectorDataLeft.numFields();
@@ -162,8 +162,8 @@ void integrate_baseline_serial_host(Data<Scalar,ExecSpaceType> integrals, const 
 }
 
 //! version that uses the classic Intrepid2 paths
-template<class Scalar, class PointScalar, int spaceDim, typename ExecSpaceType = Kokkos::DefaultExecutionSpace>
-ScalarView<Scalar,ExecSpaceType> performStandardQuadratureHypercube(int meshWidth, int polyOrder, int worksetSize)
+template<class Scalar, class PointScalar, int spaceDim, typename DeviceType = Kokkos::DefaultExecutionSpace::device_type>
+ScalarView<Scalar,DeviceType> performStandardQuadratureHypercube(int meshWidth, int polyOrder, int worksetSize)
 {
   using CellTools = Intrepid2::CellTools<Kokkos::DefaultExecutionSpace>;
   using FunctionSpaceTools = Intrepid2::FunctionSpaceTools<Kokkos::DefaultExecutionSpace>;
@@ -191,30 +191,30 @@ ScalarView<Scalar,ExecSpaceType> performStandardQuadratureHypercube(int meshWidt
   if (worksetSize > numCells) worksetSize = numCells;
   
   // local stiffness matrix:
-  ScalarView<Scalar,ExecSpaceType> cellStiffness("cell stiffness matrices",numCells,numFields,numFields);
+  ScalarView<Scalar,DeviceType> cellStiffness("cell stiffness matrices",numCells,numFields,numFields);
   
   using Kokkos::DefaultExecutionSpace;
   auto cubature = Intrepid2::DefaultCubatureFactory::create<DefaultExecutionSpace>(cellTopo,polyOrder*2);
   int numPoints = cubature->getNumPoints();
-  ScalarView<PointScalar,ExecSpaceType> cubaturePoints("cubature points",numPoints,spaceDim);
-  ScalarView<double,ExecSpaceType> cubatureWeights("cubature weights", numPoints);
+  ScalarView<PointScalar,DeviceType> cubaturePoints("cubature points",numPoints,spaceDim);
+  ScalarView<double,DeviceType> cubatureWeights("cubature weights", numPoints);
   
   cubature->getCubature(cubaturePoints, cubatureWeights);
   
   // Allocate some intermediate containers
-  ScalarView<Scalar,ExecSpaceType> basisValues    ("basis values", numFields, numPoints );
-  ScalarView<Scalar,ExecSpaceType> basisGradValues("basis grad values", numFields, numPoints, spaceDim);
+  ScalarView<Scalar,DeviceType> basisValues    ("basis values", numFields, numPoints );
+  ScalarView<Scalar,DeviceType> basisGradValues("basis grad values", numFields, numPoints, spaceDim);
 
-  ScalarView<Scalar,ExecSpaceType> transformedGradValues("transformed grad values", worksetSize, numFields, numPoints, spaceDim);
-  ScalarView<Scalar,ExecSpaceType> transformedWeightedGradValues("transformed weighted grad values", worksetSize, numFields, numPoints, spaceDim);
+  ScalarView<Scalar,DeviceType> transformedGradValues("transformed grad values", worksetSize, numFields, numPoints, spaceDim);
+  ScalarView<Scalar,DeviceType> transformedWeightedGradValues("transformed weighted grad values", worksetSize, numFields, numPoints, spaceDim);
   
   basis->getValues(basisValues,     cubaturePoints, Intrepid2::OPERATOR_VALUE );
   basis->getValues(basisGradValues, cubaturePoints, Intrepid2::OPERATOR_GRAD  );
   
-  CellGeometry<PointScalar,spaceDim,ExecSpaceType> cellNodes = uniformCartesianMesh<PointScalar,spaceDim,ExecSpaceType>(1.0, meshWidth);
+  CellGeometry<PointScalar,spaceDim,DeviceType> cellNodes = uniformCartesianMesh<PointScalar,spaceDim,DeviceType>(1.0, meshWidth);
   
   const int numNodesPerCell = cellNodes.numNodesPerCell();
-  ScalarView<PointScalar,ExecSpaceType> expandedCellNodes("expanded cell nodes",numCells,numNodesPerCell,spaceDim);
+  ScalarView<PointScalar,DeviceType> expandedCellNodes("expanded cell nodes",numCells,numNodesPerCell,spaceDim);
   for (int cellOrdinal=0; cellOrdinal<numCells; cellOrdinal++)
   {
     for (int nodeOrdinal=0; nodeOrdinal<numNodesPerCell; nodeOrdinal++)
@@ -228,10 +228,10 @@ ScalarView<Scalar,ExecSpaceType> performStandardQuadratureHypercube(int meshWidt
   
   // goal here is to do a weighted Poisson; i.e. (f grad u, grad v) on each cell
 
-  ScalarView<Scalar,ExecSpaceType> cellMeasures("cell measures", worksetSize, numPoints);
-  ScalarView<Scalar,ExecSpaceType> jacobianDeterminant("jacobian determinant", worksetSize, numPoints);
-  ScalarView<Scalar,ExecSpaceType> jacobian("jacobian", worksetSize, numPoints, spaceDim, spaceDim);
-  ScalarView<Scalar,ExecSpaceType> jacobianInverse("jacobian inverse", worksetSize, numPoints, spaceDim, spaceDim);
+  ScalarView<Scalar,DeviceType> cellMeasures("cell measures", worksetSize, numPoints);
+  ScalarView<Scalar,DeviceType> jacobianDeterminant("jacobian determinant", worksetSize, numPoints);
+  ScalarView<Scalar,DeviceType> jacobian("jacobian", worksetSize, numPoints, spaceDim, spaceDim);
+  ScalarView<Scalar,DeviceType> jacobianInverse("jacobian inverse", worksetSize, numPoints, spaceDim, spaceDim);
 
   int cellOffset = 0;
   while (cellOffset < numCells)
@@ -265,15 +265,15 @@ ScalarView<Scalar,ExecSpaceType> performStandardQuadratureHypercube(int meshWidt
   return cellStiffness;
 }
 
-  template<class Scalar, typename ExecSpaceType>
-  void testIntegrateMatchesBaseline(const TransformedVectorData<Scalar,ExecSpaceType> vectorDataLeft,
-                                    const TensorData<Scalar,ExecSpaceType> cellMeasures, const TransformedVectorData<Scalar,ExecSpaceType> vectorDataRight,
+  template<class Scalar, typename DeviceType>
+  void testIntegrateMatchesBaseline(const TransformedVectorData<Scalar,DeviceType> vectorDataLeft,
+                                    const TensorData<Scalar,DeviceType> cellMeasures, const TransformedVectorData<Scalar,DeviceType> vectorDataRight,
                                     Teuchos::FancyOStream &out, bool &success)
   {
     const double relTol = 1e-12;
     const double absTol = 1e-12;
     
-    using IntegrationTools = Intrepid2::IntegrationTools<ExecSpaceType>;
+    using IntegrationTools = Intrepid2::IntegrationTools<DeviceType>;
     
     auto integralsBaseline  = IntegrationTools::allocateIntegralData(vectorDataLeft, cellMeasures, vectorDataRight);
     auto integralsIntegrate = IntegrationTools::allocateIntegralData(vectorDataLeft, cellMeasures, vectorDataRight);
@@ -319,8 +319,10 @@ ScalarView<Scalar,ExecSpaceType> performStandardQuadratureHypercube(int meshWidt
     const double absTol = 1e-12;
     
     using namespace std;
-    using FunctionSpaceTools = Intrepid2::FunctionSpaceTools<Kokkos::DefaultExecutionSpace>;
-    using IntegrationTools   = Intrepid2::IntegrationTools<Kokkos::DefaultExecutionSpace>;
+    using DeviceType = typename Kokkos::DefaultExecutionSpace::device_type;
+    using ExecutionSpace = typename DeviceType::execution_space;
+    using FunctionSpaceTools = Intrepid2::FunctionSpaceTools<ExecutionSpace>;
+    using IntegrationTools   = Intrepid2::IntegrationTools<DeviceType>;
     // dimensions of the returned view are (C,F,F)
     auto fs = Intrepid2::FUNCTION_SPACE_HGRAD;
     
@@ -338,11 +340,9 @@ ScalarView<Scalar,ExecSpaceType> performStandardQuadratureHypercube(int meshWidt
     int numCells = numHypercubes;
     
     if (worksetSize > numCells) worksetSize = numCells;
-    
-    using ExecSpaceType = Kokkos::DefaultExecutionSpace;
-    
+        
     // local stiffness matrix:
-    ScalarView<Scalar,ExecSpaceType> cellStiffness("cell stiffness matrices",numCells,numFields,numFields);
+    ScalarView<Scalar,DeviceType> cellStiffness("cell stiffness matrices",numCells,numFields,numFields);
     
     shards::CellTopology lineTopo = shards::getCellTopologyData< shards::Line<> >();
     shards::CellTopology cellTopo;
@@ -350,16 +350,16 @@ ScalarView<Scalar,ExecSpaceType> performStandardQuadratureHypercube(int meshWidt
     else if (spaceDim == 2) cellTopo = shards::getCellTopologyData< shards::Quadrilateral<> >();
     else if (spaceDim == 3) cellTopo = shards::getCellTopologyData< shards::Hexahedron<>    >();
     
-    auto lineCubature = Intrepid2::DefaultCubatureFactory::create<ExecSpaceType>(lineTopo,polyOrder*2);
+    auto lineCubature = Intrepid2::DefaultCubatureFactory::create<DeviceType>(lineTopo,polyOrder*2);
     int numPoints_1D = lineCubature->getNumPoints();
-    ScalarView<PointScalar,ExecSpaceType> lineCubaturePoints("line cubature points",numPoints_1D,1);
-    ScalarView<double,ExecSpaceType> lineCubatureWeights("line cubature weights", numPoints_1D);
+    ScalarView<PointScalar,DeviceType> lineCubaturePoints("line cubature points",numPoints_1D,1);
+    ScalarView<double,DeviceType> lineCubatureWeights("line cubature weights", numPoints_1D);
     
     lineCubature->getCubature(lineCubaturePoints, lineCubatureWeights);
     
     // Allocate some intermediate containers
-    ScalarView<Scalar,ExecSpaceType> lineBasisValues    ("line basis values",      numFields_1D, numPoints_1D   );
-    ScalarView<Scalar,ExecSpaceType> lineBasisGradValues("line basis grad values", numFields_1D, numPoints_1D, 1);
+    ScalarView<Scalar,DeviceType> lineBasisValues    ("line basis values",      numFields_1D, numPoints_1D   );
+    ScalarView<Scalar,DeviceType> lineBasisGradValues("line basis grad values", numFields_1D, numPoints_1D, 1);
     
     // for now, we use 1D values to build up the 2D or 3D gradients
     // eventually, TensorBasis should offer a getValues() variant that returns tensor basis data
@@ -369,21 +369,21 @@ ScalarView<Scalar,ExecSpaceType> performStandardQuadratureHypercube(int meshWidt
     // drop the trivial space dimension in line gradient values:
     Kokkos::resize(lineBasisGradValues, numFields_1D, numPoints_1D);
       
-    Kokkos::Array<TensorData<Scalar,ExecSpaceType>, spaceDim> vectorComponents;
+    Kokkos::Array<TensorData<Scalar,DeviceType>, spaceDim> vectorComponents;
     
     for (int d=0; d<spaceDim; d++)
     {
-      Kokkos::Array<Data<Scalar,ExecSpaceType>, spaceDim> gradComponent_d;
+      Kokkos::Array<Data<Scalar,DeviceType>, spaceDim> gradComponent_d;
       for (int d2=0; d2<spaceDim; d2++)
       {
-        if (d2 == d) gradComponent_d[d2] = Data<Scalar,ExecSpaceType>(lineBasisGradValues);
-        else         gradComponent_d[d2] = Data<Scalar,ExecSpaceType>(lineBasisValues);
+        if (d2 == d) gradComponent_d[d2] = Data<Scalar,DeviceType>(lineBasisGradValues);
+        else         gradComponent_d[d2] = Data<Scalar,DeviceType>(lineBasisValues);
       }
-      vectorComponents[d] = TensorData<Scalar,ExecSpaceType>(gradComponent_d);
+      vectorComponents[d] = TensorData<Scalar,DeviceType>(gradComponent_d);
     }
-    VectorData<Scalar,ExecSpaceType> gradientValues(vectorComponents, false); // false: not axis-aligned
+    VectorData<Scalar,DeviceType> gradientValues(vectorComponents, false); // false: not axis-aligned
     
-    CellGeometry<PointScalar,spaceDim,ExecSpaceType> cellNodes = uniformCartesianMesh<PointScalar,spaceDim,ExecSpaceType>(1.0, meshWidth);
+    CellGeometry<PointScalar,spaceDim,DeviceType> cellNodes = uniformCartesianMesh<PointScalar,spaceDim,DeviceType>(1.0, meshWidth);
     
     if (useAffinePath)
     {
@@ -393,13 +393,13 @@ ScalarView<Scalar,ExecSpaceType> performStandardQuadratureHypercube(int meshWidt
     {
       // make a "generic" copy of cellNodes, one that uses the (C,N), (N,D) node specification.  This will not know that the geometry is affine, grid-aligned, or uniform.
       const bool copyAffineness = false; // want to go through the non-affine geometry path
-      CellGeometry<PointScalar,spaceDim,ExecSpaceType> nodalCellGeometry = getNodalCellGeometry(cellNodes, copyAffineness);
+      CellGeometry<PointScalar,spaceDim,DeviceType> nodalCellGeometry = getNodalCellGeometry(cellNodes, copyAffineness);
       
       cellNodes = nodalCellGeometry;
       out << "Testing non-affine path.\n";
     }
     
-    auto cubature = Intrepid2::DefaultCubatureFactory::create<ExecSpaceType>(cellTopo,polyOrder*2);
+    auto cubature = Intrepid2::DefaultCubatureFactory::create<DeviceType>(cellTopo,polyOrder*2);
     auto tensorCubatureWeights = cubature->allocateCubatureWeights();
     auto tensorCubaturePoints  = cubature->allocateCubaturePoints();
     
@@ -413,18 +413,18 @@ ScalarView<Scalar,ExecSpaceType> performStandardQuadratureHypercube(int meshWidt
       pointsPerCell *= numPoints_1D;
     }
     
-    Data<PointScalar,ExecSpaceType> jacobian = cellNodes.allocateJacobianData(tensorCubaturePoints);
-    Data<PointScalar,ExecSpaceType> jacobianDet = CellTools<ExecSpaceType>::allocateJacobianDet(jacobian);
-    Data<PointScalar,ExecSpaceType> jacobianInv = CellTools<ExecSpaceType>::allocateJacobianInv(jacobian);
+    Data<PointScalar,DeviceType> jacobian = cellNodes.allocateJacobianData(tensorCubaturePoints);
+    Data<PointScalar,DeviceType> jacobianDet = CellTools<ExecutionSpace>::allocateJacobianDet(jacobian);
+    Data<PointScalar,DeviceType> jacobianInv = CellTools<ExecutionSpace>::allocateJacobianInv(jacobian);
     cellNodes.setJacobian(jacobian, tensorCubaturePoints);
-    CellTools<ExecSpaceType>::setJacobianDet(jacobianDet, jacobian);
-    CellTools<ExecSpaceType>::setJacobianInv(jacobianInv, jacobian);
+    CellTools<ExecutionSpace>::setJacobianDet(jacobianDet, jacobian);
+    CellTools<ExecutionSpace>::setJacobianInv(jacobianInv, jacobian);
     
     // lazily-evaluated transformed gradient values:
     auto transformedGradientValues = FunctionSpaceTools::getHGRADtransformGRAD(jacobianInv, gradientValues);
-    auto standardIntegrals = performStandardQuadratureHypercube<Scalar,PointScalar,spaceDim,ExecSpaceType>(meshWidth, polyOrder, worksetSize);
+    auto standardIntegrals = performStandardQuadratureHypercube<Scalar,PointScalar,spaceDim,DeviceType>(meshWidth, polyOrder, worksetSize);
     
-    TensorData<PointScalar,ExecSpaceType> cellMeasures = cellNodes.allocateCellMeasure(jacobianDet, tensorCubatureWeights);
+    TensorData<PointScalar,DeviceType> cellMeasures = cellNodes.allocateCellMeasure(jacobianDet, tensorCubatureWeights);
     if (!cellNodes.affine())
     {
       // if cellNodes is not (known to be) affine, then cellMeasures should not have a separate first component (indicating the cell dimension is separated, thanks to point-invariant cell Jacobian determinant)
@@ -650,7 +650,7 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureUniformMesh_3D_p2_GeneralPat
 TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_AxisAlignedPath_Case1 )
 {
   using DataScalar  = double;
-  using ExecSpaceType = Kokkos::DefaultExecutionSpace;
+  using DeviceType = typename Kokkos::DefaultExecutionSpace::device_type;
   
   const int spaceDim = 2;
   
@@ -659,8 +659,8 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_AxisAlignedPath_Ca
   const int numPoints = numComponentPoints * numComponentPoints;
   const int numFields = 1;
   
-  Data<DataScalar,ExecSpaceType> unitData(1.0, Kokkos::Array<int,2>{numFields,numComponentPoints});
-  TensorData<DataScalar,ExecSpaceType> unitTensorData(std::vector< Data<DataScalar,ExecSpaceType> >{unitData,unitData});
+  Data<DataScalar,DeviceType> unitData(1.0, Kokkos::Array<int,2>{numFields,numComponentPoints});
+  TensorData<DataScalar,DeviceType> unitTensorData(std::vector< Data<DataScalar,DeviceType> >{unitData,unitData});
   
   auto identityMatrixView = getFixedRankView<DataScalar>("identity matrix", spaceDim);
   Kokkos::deep_copy(identityMatrixView, 1.0);
@@ -669,23 +669,23 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_AxisAlignedPath_Ca
   Kokkos::Array<DataVariationType,4> transformationVariationType {CONSTANT, CONSTANT, BLOCK_PLUS_DIAGONAL, BLOCK_PLUS_DIAGONAL};
   
   const int blockPlusDiagonalLastNonDiagonal = -1; // no non-diagonals; -1 is the default value, but I prefer to be explicit
-  Data<DataScalar,ExecSpaceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType, blockPlusDiagonalLastNonDiagonal);
+  Data<DataScalar,DeviceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType, blockPlusDiagonalLastNonDiagonal);
   
   const int numFamilies = 2;
-  Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > firstFamily  {unitTensorData,TensorData<DataScalar,ExecSpaceType>()};
-  Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > secondFamily {TensorData<DataScalar,ExecSpaceType>(),unitTensorData};
-  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim>, numFamilies> vectorComponents {firstFamily, secondFamily};
+  Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > firstFamily  {unitTensorData,TensorData<DataScalar,DeviceType>()};
+  Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > secondFamily {TensorData<DataScalar,DeviceType>(),unitTensorData};
+  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim>, numFamilies> vectorComponents {firstFamily, secondFamily};
   
-  VectorData<DataScalar,ExecSpaceType> unitVectorData(vectorComponents);
+  VectorData<DataScalar,DeviceType> unitVectorData(vectorComponents);
   
-  TransformedVectorData<DataScalar,ExecSpaceType> transformedUnitVectorData(explicitIdentityMatrix,unitVectorData);
+  TransformedVectorData<DataScalar,DeviceType> transformedUnitVectorData(explicitIdentityMatrix,unitVectorData);
   
-  Data<DataScalar,ExecSpaceType> constantCellMeasuresCellComponent(1.0, Kokkos::Array<int,1>{numCells});
-  Data<DataScalar,ExecSpaceType> constantCellMeasuresPointComponent(1.0, Kokkos::Array<int,1>{numComponentPoints});
-  std::vector< Data<DataScalar,ExecSpaceType> > cellMeasuresComponents { constantCellMeasuresCellComponent, constantCellMeasuresPointComponent, constantCellMeasuresPointComponent};
+  Data<DataScalar,DeviceType> constantCellMeasuresCellComponent(1.0, Kokkos::Array<int,1>{numCells});
+  Data<DataScalar,DeviceType> constantCellMeasuresPointComponent(1.0, Kokkos::Array<int,1>{numComponentPoints});
+  std::vector< Data<DataScalar,DeviceType> > cellMeasuresComponents { constantCellMeasuresCellComponent, constantCellMeasuresPointComponent, constantCellMeasuresPointComponent};
   
   const bool separateFirstComponent = true; // so that constantCellMeasures advertises shape (C,P), instead of folding cell dimension into the point tensor product...
-  TensorData<DataScalar,ExecSpaceType> constantCellMeasures(cellMeasuresComponents, separateFirstComponent);
+  TensorData<DataScalar,DeviceType> constantCellMeasures(cellMeasuresComponents, separateFirstComponent);
   
   testIntegrateMatchesBaseline(transformedUnitVectorData, constantCellMeasures, transformedUnitVectorData, out, success);
 }
@@ -693,8 +693,8 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_AxisAlignedPath_Ca
 // #pragma mark StructuredIntegration: QuadratureSynthetic_GeneralPath_Case1
 TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case1 )
 {
-  using DataScalar  = double;
-  using ExecSpaceType = Kokkos::DefaultExecutionSpace;
+  using DataScalar = double;
+  using DeviceType = typename Kokkos::DefaultExecutionSpace::device_type;
   
   const int spaceDim = 2;
   
@@ -702,8 +702,8 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case1 
   const int numPoints = 1;
   const int numFields = 1;
   
-  Data<DataScalar,ExecSpaceType> unitData(1.0, Kokkos::Array<int,2>{numFields,numPoints});
-  TensorData<DataScalar,ExecSpaceType> unitTensorData(std::vector< Data<DataScalar,ExecSpaceType> >{unitData,unitData});
+  Data<DataScalar,DeviceType> unitData(1.0, Kokkos::Array<int,2>{numFields,numPoints});
+  TensorData<DataScalar,DeviceType> unitTensorData(std::vector< Data<DataScalar,DeviceType> >{unitData,unitData});
   
   auto identityMatrixView = getFixedRankView<DataScalar>("identity matrix", spaceDim, spaceDim);
   auto identityMatrixViewHost = getHostCopy(identityMatrixView);
@@ -720,19 +720,19 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case1 
   Kokkos::Array<int,4> transformationExtents {numCells, numPoints, spaceDim, spaceDim};
   Kokkos::Array<DataVariationType,4> transformationVariationType {CONSTANT, CONSTANT, GENERAL, GENERAL};
   
-  Data<DataScalar,ExecSpaceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType);
+  Data<DataScalar,DeviceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType);
   
   const int numFamilies = 2;
-  Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > firstFamily  {unitTensorData,TensorData<DataScalar,ExecSpaceType>()};
-  Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > secondFamily {TensorData<DataScalar,ExecSpaceType>(),unitTensorData};
-  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim>, numFamilies> vectorComponents {firstFamily, secondFamily};
+  Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > firstFamily  {unitTensorData,TensorData<DataScalar,DeviceType>()};
+  Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > secondFamily {TensorData<DataScalar,DeviceType>(),unitTensorData};
+  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim>, numFamilies> vectorComponents {firstFamily, secondFamily};
   
-  VectorData<DataScalar,ExecSpaceType> unitVectorData(vectorComponents);
+  VectorData<DataScalar,DeviceType> unitVectorData(vectorComponents);
   
-  TransformedVectorData<DataScalar,ExecSpaceType> transformedUnitVectorData(explicitIdentityMatrix,unitVectorData);
+  TransformedVectorData<DataScalar,DeviceType> transformedUnitVectorData(explicitIdentityMatrix,unitVectorData);
   
-  Data<DataScalar,ExecSpaceType> constantCellMeasuresData(1.0, Kokkos::Array<int,2>{numCells,numPoints});
-  TensorData<DataScalar,ExecSpaceType> constantCellMeasures(constantCellMeasuresData);
+  Data<DataScalar,DeviceType> constantCellMeasuresData(1.0, Kokkos::Array<int,2>{numCells,numPoints});
+  TensorData<DataScalar,DeviceType> constantCellMeasures(constantCellMeasuresData);
   
   testIntegrateMatchesBaseline(transformedUnitVectorData, constantCellMeasures, transformedUnitVectorData, out, success);
 }
@@ -741,7 +741,7 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case1 
 TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case2 )
 {
   using DataScalar  = double;
-  using ExecSpaceType = Kokkos::DefaultExecutionSpace;
+  using DeviceType = typename Kokkos::DefaultExecutionSpace::device_type;
   
   const int spaceDim = 2;
   
@@ -763,10 +763,10 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case2 
   const int fieldComponentDataRank = 2;
   Kokkos::Array<int,fieldComponentDataRank> fieldComponentExtents {numComponentFields,numComponentPoints};
   Kokkos::Array<DataVariationType,fieldComponentDataRank> fieldComponentVariationTypes {GENERAL,CONSTANT};
-  Data<DataScalar,ExecSpaceType> fieldComponentData1(fieldComponentDataView1,fieldComponentExtents,fieldComponentVariationTypes);
-  Data<DataScalar,ExecSpaceType> fieldComponentData2(fieldComponentDataView2,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData1(fieldComponentDataView1,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData2(fieldComponentDataView2,fieldComponentExtents,fieldComponentVariationTypes);
   
-  TensorData<DataScalar,ExecSpaceType> tensorData(std::vector< Data<DataScalar,ExecSpaceType> >{fieldComponentData1,fieldComponentData2});
+  TensorData<DataScalar,DeviceType> tensorData(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData1,fieldComponentData2});
   
   auto identityMatrixView = getFixedRankView<DataScalar>("identity matrix", spaceDim, spaceDim);
   auto identityMatrixViewHost = getHostCopy(identityMatrixView);
@@ -784,18 +784,18 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case2 
   Kokkos::Array<int,4> transformationExtents {numCells, numPoints, spaceDim, spaceDim};
   Kokkos::Array<DataVariationType,4> transformationVariationType {CONSTANT, CONSTANT, GENERAL, GENERAL};
   
-  Data<DataScalar,ExecSpaceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType);
+  Data<DataScalar,DeviceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType);
   
   const int numFamilies = 1;
-  Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim> family  {TensorData<DataScalar,ExecSpaceType>(), tensorData};
-  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim>, numFamilies> vectorComponents {family};
+  Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim> family  {TensorData<DataScalar,DeviceType>(), tensorData};
+  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim>, numFamilies> vectorComponents {family};
   
-  VectorData<DataScalar,ExecSpaceType> vectorData(vectorComponents);
+  VectorData<DataScalar,DeviceType> vectorData(vectorComponents);
   
-  TransformedVectorData<DataScalar,ExecSpaceType> transformedVectorData(explicitIdentityMatrix,vectorData);
+  TransformedVectorData<DataScalar,DeviceType> transformedVectorData(explicitIdentityMatrix,vectorData);
   
-  Data<DataScalar,ExecSpaceType> constantCellMeasuresData(1.0, Kokkos::Array<int,2>{numCells,numPoints});
-  TensorData<DataScalar,ExecSpaceType> constantCellMeasures(constantCellMeasuresData);
+  Data<DataScalar,DeviceType> constantCellMeasuresData(1.0, Kokkos::Array<int,2>{numCells,numPoints});
+  TensorData<DataScalar,DeviceType> constantCellMeasures(constantCellMeasuresData);
   
 //  printFunctor2(  fieldComponentData1, std::cout, "fieldComponentData1"); // (F,P)
 //  printFunctor2(  fieldComponentData2, std::cout, "fieldComponentData2"); // (F,P)
@@ -817,7 +817,7 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case2 
 TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case3 )
 {
   using DataScalar  = double;
-  using ExecSpaceType = Kokkos::DefaultExecutionSpace;
+  using DeviceType = typename Kokkos::DefaultExecutionSpace::device_type;
   
   const int spaceDim = 2;
   
@@ -845,10 +845,10 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case3 
   const int fieldComponentDataRank = 2;
   Kokkos::Array<int,fieldComponentDataRank> fieldComponentExtents {numFields,numComponentPoints};
   Kokkos::Array<DataVariationType,fieldComponentDataRank> fieldComponentVariationTypes {GENERAL,GENERAL};
-  Data<DataScalar,ExecSpaceType> fieldComponentData1(fieldComponentDataView1,fieldComponentExtents,fieldComponentVariationTypes);
-  Data<DataScalar,ExecSpaceType> fieldComponentData2(fieldComponentDataView2,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData1(fieldComponentDataView1,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData2(fieldComponentDataView2,fieldComponentExtents,fieldComponentVariationTypes);
     
-  TensorData<DataScalar,ExecSpaceType> tensorData(std::vector< Data<DataScalar,ExecSpaceType> >{fieldComponentData1,fieldComponentData2});
+  TensorData<DataScalar,DeviceType> tensorData(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData1,fieldComponentData2});
   
   auto identityMatrixView = getFixedRankView<DataScalar>("identity matrix", spaceDim, spaceDim);
   auto identityMatrixViewHost = getHostCopy(identityMatrixView);
@@ -866,19 +866,19 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case3 
   Kokkos::Array<int,4> transformationExtents {numCells, numPoints, spaceDim, spaceDim};
   Kokkos::Array<DataVariationType,4> transformationVariationType {CONSTANT, CONSTANT, GENERAL, GENERAL};
   
-  Data<DataScalar,ExecSpaceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType);
+  Data<DataScalar,DeviceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType);
   
   const int numFamilies = 2;
-  Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > firstFamily  {tensorData,TensorData<DataScalar,ExecSpaceType>()};
-  Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > secondFamily {TensorData<DataScalar,ExecSpaceType>(),tensorData};
-  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim>, numFamilies> vectorComponents {firstFamily, secondFamily};
+  Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > firstFamily  {tensorData,TensorData<DataScalar,DeviceType>()};
+  Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > secondFamily {TensorData<DataScalar,DeviceType>(),tensorData};
+  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim>, numFamilies> vectorComponents {firstFamily, secondFamily};
   
-  VectorData<DataScalar,ExecSpaceType> vectorData(vectorComponents);
+  VectorData<DataScalar,DeviceType> vectorData(vectorComponents);
   
-  TransformedVectorData<DataScalar,ExecSpaceType> transformedUnitVectorData(explicitIdentityMatrix,vectorData);
+  TransformedVectorData<DataScalar,DeviceType> transformedUnitVectorData(explicitIdentityMatrix,vectorData);
   
-  Data<DataScalar,ExecSpaceType> constantCellMeasuresData(1.0, Kokkos::Array<int,2>{numCells,numPoints});
-  TensorData<DataScalar,ExecSpaceType> constantCellMeasures(constantCellMeasuresData);
+  Data<DataScalar,DeviceType> constantCellMeasuresData(1.0, Kokkos::Array<int,2>{numCells,numPoints});
+  TensorData<DataScalar,DeviceType> constantCellMeasures(constantCellMeasuresData);
   
   testIntegrateMatchesBaseline(transformedUnitVectorData, constantCellMeasures, transformedUnitVectorData, out, success);
 }
@@ -887,7 +887,7 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case3 
 TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case4 )
 {
   using DataScalar  = double;
-  using ExecSpaceType = Kokkos::DefaultExecutionSpace;
+  using DeviceType = typename Kokkos::DefaultExecutionSpace::device_type;
   
   const int spaceDim = 2;
   
@@ -912,11 +912,11 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case4 
   const int fieldComponentDataRank = 2;
   Kokkos::Array<int,fieldComponentDataRank> fieldComponentExtents {numFields1,numComponentPoints};
   Kokkos::Array<DataVariationType,fieldComponentDataRank> fieldComponentVariationTypes {GENERAL,GENERAL};
-  Data<DataScalar,ExecSpaceType> fieldComponentData1(fieldComponentDataView1,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData1(fieldComponentDataView1,fieldComponentExtents,fieldComponentVariationTypes);
   fieldComponentExtents[0] = numFields2;
-  Data<DataScalar,ExecSpaceType> fieldComponentData2(fieldComponentDataView2,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData2(fieldComponentDataView2,fieldComponentExtents,fieldComponentVariationTypes);
     
-  TensorData<DataScalar,ExecSpaceType> nonzeroTensorData(std::vector< Data<DataScalar,ExecSpaceType> >{fieldComponentData1,fieldComponentData2});
+  TensorData<DataScalar,DeviceType> nonzeroTensorData(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData1,fieldComponentData2});
   
   auto identityMatrixView = getFixedRankView<DataScalar>("identity matrix", spaceDim, spaceDim);
   auto identityMatrixViewHost = getHostCopy(identityMatrixView);
@@ -934,22 +934,22 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case4 
   Kokkos::Array<int,4> transformationExtents {numCells, numPoints, spaceDim, spaceDim};
   Kokkos::Array<DataVariationType,4> transformationVariationType {CONSTANT, CONSTANT, GENERAL, GENERAL};
   
-  Data<DataScalar,ExecSpaceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType);
+  Data<DataScalar,DeviceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType);
   
   const int numFamilies = 2;
-  Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > firstFamily  {nonzeroTensorData,TensorData<DataScalar,ExecSpaceType>()};
-  Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > secondFamily {TensorData<DataScalar,ExecSpaceType>(),nonzeroTensorData};
-  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim>, numFamilies> vectorComponents {firstFamily, secondFamily};
+  Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > firstFamily  {nonzeroTensorData,TensorData<DataScalar,DeviceType>()};
+  Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > secondFamily {TensorData<DataScalar,DeviceType>(),nonzeroTensorData};
+  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim>, numFamilies> vectorComponents {firstFamily, secondFamily};
   
-  VectorData<DataScalar,ExecSpaceType> vectorData(vectorComponents);
+  VectorData<DataScalar,DeviceType> vectorData(vectorComponents);
   
   TEST_EQUALITY(numFieldsPerFamily, vectorData.numFieldsInFamily(0));
   TEST_EQUALITY(numFieldsPerFamily, vectorData.numFieldsInFamily(1));
   
-  TransformedVectorData<DataScalar,ExecSpaceType> transformedUnitVectorData(explicitIdentityMatrix,vectorData);
+  TransformedVectorData<DataScalar,DeviceType> transformedUnitVectorData(explicitIdentityMatrix,vectorData);
   
-  Data<DataScalar,ExecSpaceType> constantCellMeasuresData(1.0, Kokkos::Array<int,2>{numCells,numPoints});
-  TensorData<DataScalar,ExecSpaceType> constantCellMeasures(constantCellMeasuresData);
+  Data<DataScalar,DeviceType> constantCellMeasuresData(1.0, Kokkos::Array<int,2>{numCells,numPoints});
+  TensorData<DataScalar,DeviceType> constantCellMeasures(constantCellMeasuresData);
   
   testIntegrateMatchesBaseline(transformedUnitVectorData, constantCellMeasures, transformedUnitVectorData, out, success);
 }
@@ -958,7 +958,7 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case4 
 TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case5 )
 {
   using DataScalar  = double;
-  using ExecSpaceType = Kokkos::DefaultExecutionSpace;
+  using DeviceType = typename Kokkos::DefaultExecutionSpace::device_type;
   
   const int spaceDim = 2;
   
@@ -986,12 +986,12 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case5 
   const int fieldComponentDataRank = 2;
   Kokkos::Array<int,fieldComponentDataRank> fieldComponentExtents {numFields1,numComponentPoints};
   Kokkos::Array<DataVariationType,fieldComponentDataRank> fieldComponentVariationTypes {GENERAL,GENERAL};
-  Data<DataScalar,ExecSpaceType> fieldComponentData1(fieldComponentDataView1,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData1(fieldComponentDataView1,fieldComponentExtents,fieldComponentVariationTypes);
   fieldComponentExtents[0] = numFields2;
-  Data<DataScalar,ExecSpaceType> fieldComponentData2(fieldComponentDataView2,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData2(fieldComponentDataView2,fieldComponentExtents,fieldComponentVariationTypes);
     
-  TensorData<DataScalar,ExecSpaceType>  tensorDataLeft(std::vector< Data<DataScalar,ExecSpaceType> >{fieldComponentData1,fieldComponentData2});
-  TensorData<DataScalar,ExecSpaceType> tensorDataRight(std::vector< Data<DataScalar,ExecSpaceType> >{fieldComponentData2,fieldComponentData2});
+  TensorData<DataScalar,DeviceType>  tensorDataLeft(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData1,fieldComponentData2});
+  TensorData<DataScalar,DeviceType> tensorDataRight(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData2,fieldComponentData2});
   
   auto identityMatrixView = getFixedRankView<DataScalar>("identity matrix", spaceDim, spaceDim);
   auto identityMatrixViewHost = getHostCopy(identityMatrixView);
@@ -1009,30 +1009,30 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case5 
   Kokkos::Array<int,4> transformationExtents {numCells, numPoints, spaceDim, spaceDim};
   Kokkos::Array<DataVariationType,4> transformationVariationType {CONSTANT, CONSTANT, GENERAL, GENERAL};
   
-  Data<DataScalar,ExecSpaceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType);
+  Data<DataScalar,DeviceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType);
   
   const int numFamilies = 2;
-  Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > firstFamilyLeft  {tensorDataLeft,TensorData<DataScalar,ExecSpaceType>()};
-  Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > secondFamilyLeft {TensorData<DataScalar,ExecSpaceType>(),tensorDataLeft};
-  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim>, numFamilies> vectorComponentsLeft {firstFamilyLeft, secondFamilyLeft};
+  Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > firstFamilyLeft  {tensorDataLeft,TensorData<DataScalar,DeviceType>()};
+  Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > secondFamilyLeft {TensorData<DataScalar,DeviceType>(),tensorDataLeft};
+  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim>, numFamilies> vectorComponentsLeft {firstFamilyLeft, secondFamilyLeft};
   
-  VectorData<DataScalar,ExecSpaceType> vectorDataLeft(vectorComponentsLeft);
+  VectorData<DataScalar,DeviceType> vectorDataLeft(vectorComponentsLeft);
   TEST_EQUALITY(numFieldsPerFamilyLeft, vectorDataLeft.numFieldsInFamily(0));
   TEST_EQUALITY(numFieldsPerFamilyLeft, vectorDataLeft.numFieldsInFamily(1));
   
-  Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > firstFamilyRight  {tensorDataRight,TensorData<DataScalar,ExecSpaceType>()};
-  Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > secondFamilyRight {TensorData<DataScalar,ExecSpaceType>(),tensorDataRight};
-  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim>, numFamilies> vectorComponentsRight {firstFamilyRight, secondFamilyRight};
+  Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > firstFamilyRight  {tensorDataRight,TensorData<DataScalar,DeviceType>()};
+  Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > secondFamilyRight {TensorData<DataScalar,DeviceType>(),tensorDataRight};
+  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim>, numFamilies> vectorComponentsRight {firstFamilyRight, secondFamilyRight};
   
-  VectorData<DataScalar,ExecSpaceType> vectorDataRight(vectorComponentsRight);
+  VectorData<DataScalar,DeviceType> vectorDataRight(vectorComponentsRight);
   TEST_EQUALITY(numFieldsPerFamilyRight, vectorDataRight.numFieldsInFamily(0));
   TEST_EQUALITY(numFieldsPerFamilyRight, vectorDataRight.numFieldsInFamily(1));
   
-  TransformedVectorData<DataScalar,ExecSpaceType>  transformedUnitVectorDataLeft(explicitIdentityMatrix,vectorDataLeft);
-  TransformedVectorData<DataScalar,ExecSpaceType> transformedUnitVectorDataRight(explicitIdentityMatrix,vectorDataRight);
+  TransformedVectorData<DataScalar,DeviceType>  transformedUnitVectorDataLeft(explicitIdentityMatrix,vectorDataLeft);
+  TransformedVectorData<DataScalar,DeviceType> transformedUnitVectorDataRight(explicitIdentityMatrix,vectorDataRight);
   
-  Data<DataScalar,ExecSpaceType> constantCellMeasuresData(1.0, Kokkos::Array<int,2>{numCells,numPoints});
-  TensorData<DataScalar,ExecSpaceType> constantCellMeasures(constantCellMeasuresData);
+  Data<DataScalar,DeviceType> constantCellMeasuresData(1.0, Kokkos::Array<int,2>{numCells,numPoints});
+  TensorData<DataScalar,DeviceType> constantCellMeasures(constantCellMeasuresData);
   
   testIntegrateMatchesBaseline(transformedUnitVectorDataLeft, constantCellMeasures, transformedUnitVectorDataRight, out, success);
 }
@@ -1041,7 +1041,7 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case5 
 TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_AxisAlignedPath_Case6_3D )
 {
   using DataScalar  = double;
-  using ExecSpaceType = Kokkos::DefaultExecutionSpace;
+  using DeviceType = typename Kokkos::DefaultExecutionSpace::device_type;
   
   const int spaceDim = 3;
   
@@ -1077,14 +1077,14 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_AxisAlignedPath_Ca
   const int fieldComponentDataRank = 2;
   Kokkos::Array<int,fieldComponentDataRank> fieldComponentExtents {numFields1,numComponentPoints};
   Kokkos::Array<DataVariationType,fieldComponentDataRank> fieldComponentVariationTypes {GENERAL,GENERAL};
-  Data<DataScalar,ExecSpaceType> fieldComponentData1(fieldComponentDataView1,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData1(fieldComponentDataView1,fieldComponentExtents,fieldComponentVariationTypes);
   fieldComponentExtents[0] = numFields2;
-  Data<DataScalar,ExecSpaceType> fieldComponentData2(fieldComponentDataView2,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData2(fieldComponentDataView2,fieldComponentExtents,fieldComponentVariationTypes);
   fieldComponentExtents[0] = numFields3;
-  Data<DataScalar,ExecSpaceType> fieldComponentData3(fieldComponentDataView3,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData3(fieldComponentDataView3,fieldComponentExtents,fieldComponentVariationTypes);
   
-   TensorData<DataScalar,ExecSpaceType>  tensorDataLeft(std::vector< Data<DataScalar,ExecSpaceType> >{fieldComponentData1,fieldComponentData2,fieldComponentData3});
-   TensorData<DataScalar,ExecSpaceType> tensorDataRight(std::vector< Data<DataScalar,ExecSpaceType> >{fieldComponentData1,fieldComponentData3,fieldComponentData2});
+   TensorData<DataScalar,DeviceType>  tensorDataLeft(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData1,fieldComponentData2,fieldComponentData3});
+   TensorData<DataScalar,DeviceType> tensorDataRight(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData1,fieldComponentData3,fieldComponentData2});
    
    const int numPoints = numComponentPoints * numComponentPoints * numComponentPoints;
    
@@ -1095,33 +1095,33 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_AxisAlignedPath_Ca
    Kokkos::Array<DataVariationType,4> transformationVariationType {CONSTANT, CONSTANT, BLOCK_PLUS_DIAGONAL, BLOCK_PLUS_DIAGONAL};
    
    const int blockPlusDiagonalLastNonDiagonal = -1; // no non-diagonals; -1 is the default value, but I prefer to be explicit
-   Data<DataScalar,ExecSpaceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType, blockPlusDiagonalLastNonDiagonal);
+   Data<DataScalar,DeviceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType, blockPlusDiagonalLastNonDiagonal);
   
   // confirm that the matrix is diagonal (this is required to follow the axis-aligned path):
   TEST_EQUALITY(true, explicitIdentityMatrix.isDiagonal());
 
   const int numFamilies = 1;
-  Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > firstFamilyLeft  {tensorDataLeft,tensorDataLeft,tensorDataLeft};
-  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim>, numFamilies> vectorComponentsLeft {firstFamilyLeft};
+  Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > firstFamilyLeft  {tensorDataLeft,tensorDataLeft,tensorDataLeft};
+  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim>, numFamilies> vectorComponentsLeft {firstFamilyLeft};
   
-  VectorData<DataScalar,ExecSpaceType> vectorDataLeft(vectorComponentsLeft);
+  VectorData<DataScalar,DeviceType> vectorDataLeft(vectorComponentsLeft);
   TEST_EQUALITY(numFieldsPerFamilyLeft, vectorDataLeft.numFieldsInFamily(0));
   
-  Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > firstFamilyRight  {tensorDataRight,tensorDataRight,tensorDataRight};
-  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim>, numFamilies> vectorComponentsRight {firstFamilyRight};
+  Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > firstFamilyRight  {tensorDataRight,tensorDataRight,tensorDataRight};
+  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim>, numFamilies> vectorComponentsRight {firstFamilyRight};
    
-   VectorData<DataScalar,ExecSpaceType> vectorDataRight(vectorComponentsRight);
+   VectorData<DataScalar,DeviceType> vectorDataRight(vectorComponentsRight);
    TEST_EQUALITY(numFieldsPerFamilyRight, vectorDataRight.numFieldsInFamily(0));
    
-   TransformedVectorData<DataScalar,ExecSpaceType>  transformedUnitVectorDataLeft(explicitIdentityMatrix,vectorDataLeft);
-   TransformedVectorData<DataScalar,ExecSpaceType> transformedUnitVectorDataRight(explicitIdentityMatrix,vectorDataRight);
+   TransformedVectorData<DataScalar,DeviceType>  transformedUnitVectorDataLeft(explicitIdentityMatrix,vectorDataLeft);
+   TransformedVectorData<DataScalar,DeviceType> transformedUnitVectorDataRight(explicitIdentityMatrix,vectorDataRight);
    
-   Data<DataScalar,ExecSpaceType>  constantCellMeasuresCellComponent(1.0, Kokkos::Array<int,1>{numCells});
-   Data<DataScalar,ExecSpaceType> constantCellMeasuresPointComponent(1.0, Kokkos::Array<int,1>{numComponentPoints});
-   std::vector< Data<DataScalar,ExecSpaceType> > cellMeasuresComponents { constantCellMeasuresCellComponent, constantCellMeasuresPointComponent, constantCellMeasuresPointComponent, constantCellMeasuresPointComponent};
+   Data<DataScalar,DeviceType>  constantCellMeasuresCellComponent(1.0, Kokkos::Array<int,1>{numCells});
+   Data<DataScalar,DeviceType> constantCellMeasuresPointComponent(1.0, Kokkos::Array<int,1>{numComponentPoints});
+   std::vector< Data<DataScalar,DeviceType> > cellMeasuresComponents { constantCellMeasuresCellComponent, constantCellMeasuresPointComponent, constantCellMeasuresPointComponent, constantCellMeasuresPointComponent};
    
    const bool separateFirstComponent = true; // so that constantCellMeasures advertises shape (C,P), instead of folding cell dimension into the point tensor product...
-   TensorData<DataScalar,ExecSpaceType> constantCellMeasures(cellMeasuresComponents, separateFirstComponent);
+   TensorData<DataScalar,DeviceType> constantCellMeasures(cellMeasuresComponents, separateFirstComponent);
    
    testIntegrateMatchesBaseline(transformedUnitVectorDataLeft, constantCellMeasures, transformedUnitVectorDataRight, out, success);
 }
@@ -1130,7 +1130,7 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_AxisAlignedPath_Ca
 TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case6_3D )
 {
   using DataScalar  = double;
-  using ExecSpaceType = Kokkos::DefaultExecutionSpace;
+  using DeviceType = typename Kokkos::DefaultExecutionSpace::device_type;
   
   const int spaceDim = 3;
   
@@ -1166,14 +1166,14 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case6_
   const int fieldComponentDataRank = 2;
   Kokkos::Array<int,fieldComponentDataRank> fieldComponentExtents {numFields1,numComponentPoints};
   Kokkos::Array<DataVariationType,fieldComponentDataRank> fieldComponentVariationTypes {GENERAL,GENERAL};
-  Data<DataScalar,ExecSpaceType> fieldComponentData1(fieldComponentDataView1,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData1(fieldComponentDataView1,fieldComponentExtents,fieldComponentVariationTypes);
   fieldComponentExtents[0] = numFields2;
-  Data<DataScalar,ExecSpaceType> fieldComponentData2(fieldComponentDataView2,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData2(fieldComponentDataView2,fieldComponentExtents,fieldComponentVariationTypes);
   fieldComponentExtents[0] = numFields3;
-  Data<DataScalar,ExecSpaceType> fieldComponentData3(fieldComponentDataView3,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData3(fieldComponentDataView3,fieldComponentExtents,fieldComponentVariationTypes);
   
-   TensorData<DataScalar,ExecSpaceType>  tensorDataLeft(std::vector< Data<DataScalar,ExecSpaceType> >{fieldComponentData1,fieldComponentData2,fieldComponentData3});
-   TensorData<DataScalar,ExecSpaceType> tensorDataRight(std::vector< Data<DataScalar,ExecSpaceType> >{fieldComponentData1,fieldComponentData3,fieldComponentData2});
+   TensorData<DataScalar,DeviceType>  tensorDataLeft(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData1,fieldComponentData2,fieldComponentData3});
+   TensorData<DataScalar,DeviceType> tensorDataRight(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData1,fieldComponentData3,fieldComponentData2});
    
    auto identityMatrixView = getFixedRankView<DataScalar>("identity matrix", spaceDim, spaceDim);
    auto identityMatrixViewHost = getHostCopy(identityMatrixView);
@@ -1191,44 +1191,44 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case6_
    Kokkos::Array<int,4> transformationExtents {numCells, numPoints, spaceDim, spaceDim};
    Kokkos::Array<DataVariationType,4> transformationVariationType {CONSTANT, CONSTANT, GENERAL, GENERAL};
    
-   Data<DataScalar,ExecSpaceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType);
+   Data<DataScalar,DeviceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType);
    
 //   const int numFamilies = 3;
-//   Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > firstFamilyLeft  {tensorDataLeft,TensorData<DataScalar,ExecSpaceType>(),TensorData<DataScalar,ExecSpaceType>()};
-//   Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > secondFamilyLeft {TensorData<DataScalar,ExecSpaceType>(),tensorDataLeft,TensorData<DataScalar,ExecSpaceType>()};
-//   Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > thirdFamilyLeft  {TensorData<DataScalar,ExecSpaceType>(),TensorData<DataScalar,ExecSpaceType>(),tensorDataLeft};
-//   Kokkos::Array< Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim>, numFamilies> vectorComponentsLeft {firstFamilyLeft, secondFamilyLeft, thirdFamilyLeft};
+//   Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > firstFamilyLeft  {tensorDataLeft,TensorData<DataScalar,DeviceType>(),TensorData<DataScalar,DeviceType>()};
+//   Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > secondFamilyLeft {TensorData<DataScalar,DeviceType>(),tensorDataLeft,TensorData<DataScalar,DeviceType>()};
+//   Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > thirdFamilyLeft  {TensorData<DataScalar,DeviceType>(),TensorData<DataScalar,DeviceType>(),tensorDataLeft};
+//   Kokkos::Array< Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim>, numFamilies> vectorComponentsLeft {firstFamilyLeft, secondFamilyLeft, thirdFamilyLeft};
 //
-//   VectorData<DataScalar,ExecSpaceType> vectorDataLeft(vectorComponentsLeft);
+//   VectorData<DataScalar,DeviceType> vectorDataLeft(vectorComponentsLeft);
 //   TEST_EQUALITY(numFieldsPerFamilyLeft, vectorDataLeft.numFieldsInFamily(0));
 //   TEST_EQUALITY(numFieldsPerFamilyLeft, vectorDataLeft.numFieldsInFamily(1));
 //
-//   Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > firstFamilyRight  {tensorDataRight,TensorData<DataScalar,ExecSpaceType>(),TensorData<DataScalar,ExecSpaceType>()};
-//   Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > secondFamilyRight {TensorData<DataScalar,ExecSpaceType>(),tensorDataRight,TensorData<DataScalar,ExecSpaceType>()};
-//   Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > thirdFamilyRight  {TensorData<DataScalar,ExecSpaceType>(),TensorData<DataScalar,ExecSpaceType>(),tensorDataRight};
-//   Kokkos::Array< Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim>, numFamilies> vectorComponentsRight {firstFamilyRight, secondFamilyRight, thirdFamilyRight};
-//  VectorData<DataScalar,ExecSpaceType> vectorDataRight(vectorComponentsRight);
+//   Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > firstFamilyRight  {tensorDataRight,TensorData<DataScalar,DeviceType>(),TensorData<DataScalar,DeviceType>()};
+//   Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > secondFamilyRight {TensorData<DataScalar,DeviceType>(),tensorDataRight,TensorData<DataScalar,DeviceType>()};
+//   Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > thirdFamilyRight  {TensorData<DataScalar,DeviceType>(),TensorData<DataScalar,DeviceType>(),tensorDataRight};
+//   Kokkos::Array< Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim>, numFamilies> vectorComponentsRight {firstFamilyRight, secondFamilyRight, thirdFamilyRight};
+//  VectorData<DataScalar,DeviceType> vectorDataRight(vectorComponentsRight);
 //  TEST_EQUALITY(numFieldsPerFamilyRight, vectorDataRight.numFieldsInFamily(0));
 //  TEST_EQUALITY(numFieldsPerFamilyRight, vectorDataRight.numFieldsInFamily(1));
   
   const int numFamilies = 1;
-  Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > firstFamilyLeft  {tensorDataLeft,TensorData<DataScalar,ExecSpaceType>(),TensorData<DataScalar,ExecSpaceType>()};
-  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim>, numFamilies> vectorComponentsLeft {firstFamilyLeft};
+  Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > firstFamilyLeft  {tensorDataLeft,TensorData<DataScalar,DeviceType>(),TensorData<DataScalar,DeviceType>()};
+  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim>, numFamilies> vectorComponentsLeft {firstFamilyLeft};
   
-  VectorData<DataScalar,ExecSpaceType> vectorDataLeft(vectorComponentsLeft);
+  VectorData<DataScalar,DeviceType> vectorDataLeft(vectorComponentsLeft);
   TEST_EQUALITY(numFieldsPerFamilyLeft, vectorDataLeft.numFieldsInFamily(0));
   
-  Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > firstFamilyRight  {tensorDataRight,TensorData<DataScalar,ExecSpaceType>(),TensorData<DataScalar,ExecSpaceType>()};
-  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim>, numFamilies> vectorComponentsRight {firstFamilyRight};
+  Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > firstFamilyRight  {tensorDataRight,TensorData<DataScalar,DeviceType>(),TensorData<DataScalar,DeviceType>()};
+  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim>, numFamilies> vectorComponentsRight {firstFamilyRight};
    
-   VectorData<DataScalar,ExecSpaceType> vectorDataRight(vectorComponentsRight);
+   VectorData<DataScalar,DeviceType> vectorDataRight(vectorComponentsRight);
    TEST_EQUALITY(numFieldsPerFamilyRight, vectorDataRight.numFieldsInFamily(0));
    
-   TransformedVectorData<DataScalar,ExecSpaceType>  transformedUnitVectorDataLeft(explicitIdentityMatrix,vectorDataLeft);
-   TransformedVectorData<DataScalar,ExecSpaceType> transformedUnitVectorDataRight(explicitIdentityMatrix,vectorDataRight);
+   TransformedVectorData<DataScalar,DeviceType>  transformedUnitVectorDataLeft(explicitIdentityMatrix,vectorDataLeft);
+   TransformedVectorData<DataScalar,DeviceType> transformedUnitVectorDataRight(explicitIdentityMatrix,vectorDataRight);
    
-   Data<DataScalar,ExecSpaceType> constantCellMeasuresData(1.0, Kokkos::Array<int,2>{numCells,numPoints});
-   TensorData<DataScalar,ExecSpaceType> constantCellMeasures(constantCellMeasuresData);
+   Data<DataScalar,DeviceType> constantCellMeasuresData(1.0, Kokkos::Array<int,2>{numCells,numPoints});
+   TensorData<DataScalar,DeviceType> constantCellMeasures(constantCellMeasuresData);
    
    testIntegrateMatchesBaseline(transformedUnitVectorDataLeft, constantCellMeasures, transformedUnitVectorDataRight, out, success);
 }
@@ -1239,7 +1239,7 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case7_
   // super-simple case for 3D: symmetric data, 1 point, 1 field.
   
   using DataScalar  = double;
-  using ExecSpaceType = Kokkos::DefaultExecutionSpace;
+  using DeviceType = typename Kokkos::DefaultExecutionSpace::device_type;
   
   const int spaceDim = 3;
   
@@ -1271,14 +1271,14 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case7_
   const int fieldComponentDataRank = 2;
   Kokkos::Array<int,fieldComponentDataRank> fieldComponentExtents {numFields1,numComponentPoints};
   Kokkos::Array<DataVariationType,fieldComponentDataRank> fieldComponentVariationTypes {GENERAL,GENERAL};
-  Data<DataScalar,ExecSpaceType> fieldComponentData1(fieldComponentDataView1,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData1(fieldComponentDataView1,fieldComponentExtents,fieldComponentVariationTypes);
   fieldComponentExtents[0] = numFields2;
-  Data<DataScalar,ExecSpaceType> fieldComponentData2(fieldComponentDataView2,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData2(fieldComponentDataView2,fieldComponentExtents,fieldComponentVariationTypes);
   fieldComponentExtents[0] = numFields3;
-  Data<DataScalar,ExecSpaceType> fieldComponentData3(fieldComponentDataView3,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData3(fieldComponentDataView3,fieldComponentExtents,fieldComponentVariationTypes);
   
-   TensorData<DataScalar,ExecSpaceType>  tensorDataLeft(std::vector< Data<DataScalar,ExecSpaceType> >{fieldComponentData1,fieldComponentData2,fieldComponentData3});
-   TensorData<DataScalar,ExecSpaceType> tensorDataRight(std::vector< Data<DataScalar,ExecSpaceType> >{fieldComponentData1,fieldComponentData3,fieldComponentData2});
+   TensorData<DataScalar,DeviceType>  tensorDataLeft(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData1,fieldComponentData2,fieldComponentData3});
+   TensorData<DataScalar,DeviceType> tensorDataRight(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData1,fieldComponentData3,fieldComponentData2});
    
    auto identityMatrixView = getFixedRankView<DataScalar>("identity matrix", spaceDim, spaceDim);
    auto identityMatrixViewHost = getHostCopy(identityMatrixView);
@@ -1296,26 +1296,26 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case7_
    Kokkos::Array<int,4> transformationExtents {numCells, numPoints, spaceDim, spaceDim};
    Kokkos::Array<DataVariationType,4> transformationVariationType {CONSTANT, CONSTANT, GENERAL, GENERAL};
    
-   Data<DataScalar,ExecSpaceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType);
+   Data<DataScalar,DeviceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType);
      
    const int numFamilies = 1;
-   Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > firstFamilyLeft  {tensorDataLeft,TensorData<DataScalar,ExecSpaceType>(),TensorData<DataScalar,ExecSpaceType>()};
-   Kokkos::Array< Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim>, numFamilies> vectorComponentsLeft {firstFamilyLeft};
+   Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > firstFamilyLeft  {tensorDataLeft,TensorData<DataScalar,DeviceType>(),TensorData<DataScalar,DeviceType>()};
+   Kokkos::Array< Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim>, numFamilies> vectorComponentsLeft {firstFamilyLeft};
   
-   VectorData<DataScalar,ExecSpaceType> vectorDataLeft(vectorComponentsLeft);
+   VectorData<DataScalar,DeviceType> vectorDataLeft(vectorComponentsLeft);
    TEST_EQUALITY(numFieldsPerFamilyLeft, vectorDataLeft.numFieldsInFamily(0));
   
-   Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > firstFamilyRight  {tensorDataRight,TensorData<DataScalar,ExecSpaceType>(),TensorData<DataScalar,ExecSpaceType>()};
-   Kokkos::Array< Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim>, numFamilies> vectorComponentsRight {firstFamilyRight};
+   Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > firstFamilyRight  {tensorDataRight,TensorData<DataScalar,DeviceType>(),TensorData<DataScalar,DeviceType>()};
+   Kokkos::Array< Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim>, numFamilies> vectorComponentsRight {firstFamilyRight};
    
-   VectorData<DataScalar,ExecSpaceType> vectorDataRight(vectorComponentsRight);
+   VectorData<DataScalar,DeviceType> vectorDataRight(vectorComponentsRight);
    TEST_EQUALITY(numFieldsPerFamilyRight, vectorDataRight.numFieldsInFamily(0));
    
-   TransformedVectorData<DataScalar,ExecSpaceType>  transformedUnitVectorDataLeft(explicitIdentityMatrix,vectorDataLeft);
-   TransformedVectorData<DataScalar,ExecSpaceType> transformedUnitVectorDataRight(explicitIdentityMatrix,vectorDataRight);
+   TransformedVectorData<DataScalar,DeviceType>  transformedUnitVectorDataLeft(explicitIdentityMatrix,vectorDataLeft);
+   TransformedVectorData<DataScalar,DeviceType> transformedUnitVectorDataRight(explicitIdentityMatrix,vectorDataRight);
    
-   Data<DataScalar,ExecSpaceType> constantCellMeasuresData(1.0, Kokkos::Array<int,2>{numCells,numPoints});
-   TensorData<DataScalar,ExecSpaceType> constantCellMeasures(constantCellMeasuresData);
+   Data<DataScalar,DeviceType> constantCellMeasuresData(1.0, Kokkos::Array<int,2>{numCells,numPoints});
+   TensorData<DataScalar,DeviceType> constantCellMeasures(constantCellMeasuresData);
    
    testIntegrateMatchesBaseline(transformedUnitVectorDataLeft, constantCellMeasures, transformedUnitVectorDataRight, out, success);
 }
@@ -1325,7 +1325,7 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case8_
 {
   // like case 7, but multi-family
   using DataScalar  = double;
-  using ExecSpaceType = Kokkos::DefaultExecutionSpace;
+  using DeviceType = typename Kokkos::DefaultExecutionSpace::device_type;
   
   const int spaceDim = 3;
   
@@ -1357,14 +1357,14 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case8_
   const int fieldComponentDataRank = 2;
   Kokkos::Array<int,fieldComponentDataRank> fieldComponentExtents {numFields1,numComponentPoints};
   Kokkos::Array<DataVariationType,fieldComponentDataRank> fieldComponentVariationTypes {GENERAL,GENERAL};
-  Data<DataScalar,ExecSpaceType> fieldComponentData1(fieldComponentDataView1,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData1(fieldComponentDataView1,fieldComponentExtents,fieldComponentVariationTypes);
   fieldComponentExtents[0] = numFields2;
-  Data<DataScalar,ExecSpaceType> fieldComponentData2(fieldComponentDataView2,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData2(fieldComponentDataView2,fieldComponentExtents,fieldComponentVariationTypes);
   fieldComponentExtents[0] = numFields3;
-  Data<DataScalar,ExecSpaceType> fieldComponentData3(fieldComponentDataView3,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData3(fieldComponentDataView3,fieldComponentExtents,fieldComponentVariationTypes);
   
-   TensorData<DataScalar,ExecSpaceType>  tensorDataLeft(std::vector< Data<DataScalar,ExecSpaceType> >{fieldComponentData1,fieldComponentData2,fieldComponentData3});
-   TensorData<DataScalar,ExecSpaceType> tensorDataRight(std::vector< Data<DataScalar,ExecSpaceType> >{fieldComponentData1,fieldComponentData3,fieldComponentData2});
+   TensorData<DataScalar,DeviceType>  tensorDataLeft(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData1,fieldComponentData2,fieldComponentData3});
+   TensorData<DataScalar,DeviceType> tensorDataRight(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData1,fieldComponentData3,fieldComponentData2});
    
    auto identityMatrixView = getFixedRankView<DataScalar>("identity matrix", spaceDim, spaceDim);
    auto identityMatrixViewHost = getHostCopy(identityMatrixView);
@@ -1382,31 +1382,31 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case8_
    Kokkos::Array<int,4> transformationExtents {numCells, numPoints, spaceDim, spaceDim};
    Kokkos::Array<DataVariationType,4> transformationVariationType {CONSTANT, CONSTANT, GENERAL, GENERAL};
    
-   Data<DataScalar,ExecSpaceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType);
+   Data<DataScalar,DeviceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType);
    
    const int numFamilies = 3;
-   Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > firstFamilyLeft  {tensorDataLeft,TensorData<DataScalar,ExecSpaceType>(),TensorData<DataScalar,ExecSpaceType>()};
-   Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > secondFamilyLeft {TensorData<DataScalar,ExecSpaceType>(),tensorDataLeft,TensorData<DataScalar,ExecSpaceType>()};
-   Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > thirdFamilyLeft  {TensorData<DataScalar,ExecSpaceType>(),TensorData<DataScalar,ExecSpaceType>(),tensorDataLeft};
-   Kokkos::Array< Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim>, numFamilies> vectorComponentsLeft {firstFamilyLeft, secondFamilyLeft, thirdFamilyLeft};
+   Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > firstFamilyLeft  {tensorDataLeft,TensorData<DataScalar,DeviceType>(),TensorData<DataScalar,DeviceType>()};
+   Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > secondFamilyLeft {TensorData<DataScalar,DeviceType>(),tensorDataLeft,TensorData<DataScalar,DeviceType>()};
+   Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > thirdFamilyLeft  {TensorData<DataScalar,DeviceType>(),TensorData<DataScalar,DeviceType>(),tensorDataLeft};
+   Kokkos::Array< Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim>, numFamilies> vectorComponentsLeft {firstFamilyLeft, secondFamilyLeft, thirdFamilyLeft};
 
-   VectorData<DataScalar,ExecSpaceType> vectorDataLeft(vectorComponentsLeft);
+   VectorData<DataScalar,DeviceType> vectorDataLeft(vectorComponentsLeft);
    TEST_EQUALITY(numFieldsPerFamilyLeft, vectorDataLeft.numFieldsInFamily(0));
    TEST_EQUALITY(numFieldsPerFamilyLeft, vectorDataLeft.numFieldsInFamily(1));
 
-   Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > firstFamilyRight  {tensorDataRight,TensorData<DataScalar,ExecSpaceType>(),TensorData<DataScalar,ExecSpaceType>()};
-   Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > secondFamilyRight {TensorData<DataScalar,ExecSpaceType>(),tensorDataRight,TensorData<DataScalar,ExecSpaceType>()};
-   Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > thirdFamilyRight  {TensorData<DataScalar,ExecSpaceType>(),TensorData<DataScalar,ExecSpaceType>(),tensorDataRight};
-   Kokkos::Array< Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim>, numFamilies> vectorComponentsRight {firstFamilyRight, secondFamilyRight, thirdFamilyRight};
-   VectorData<DataScalar,ExecSpaceType> vectorDataRight(vectorComponentsRight);
+   Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > firstFamilyRight  {tensorDataRight,TensorData<DataScalar,DeviceType>(),TensorData<DataScalar,DeviceType>()};
+   Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > secondFamilyRight {TensorData<DataScalar,DeviceType>(),tensorDataRight,TensorData<DataScalar,DeviceType>()};
+   Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > thirdFamilyRight  {TensorData<DataScalar,DeviceType>(),TensorData<DataScalar,DeviceType>(),tensorDataRight};
+   Kokkos::Array< Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim>, numFamilies> vectorComponentsRight {firstFamilyRight, secondFamilyRight, thirdFamilyRight};
+   VectorData<DataScalar,DeviceType> vectorDataRight(vectorComponentsRight);
    TEST_EQUALITY(numFieldsPerFamilyRight, vectorDataRight.numFieldsInFamily(0));
    TEST_EQUALITY(numFieldsPerFamilyRight, vectorDataRight.numFieldsInFamily(1));
   
-   TransformedVectorData<DataScalar,ExecSpaceType>  transformedUnitVectorDataLeft(explicitIdentityMatrix,vectorDataLeft);
-   TransformedVectorData<DataScalar,ExecSpaceType> transformedUnitVectorDataRight(explicitIdentityMatrix,vectorDataRight);
+   TransformedVectorData<DataScalar,DeviceType>  transformedUnitVectorDataLeft(explicitIdentityMatrix,vectorDataLeft);
+   TransformedVectorData<DataScalar,DeviceType> transformedUnitVectorDataRight(explicitIdentityMatrix,vectorDataRight);
    
-   Data<DataScalar,ExecSpaceType> constantCellMeasuresData(1.0, Kokkos::Array<int,2>{numCells,numPoints});
-   TensorData<DataScalar,ExecSpaceType> constantCellMeasures(constantCellMeasuresData);
+   Data<DataScalar,DeviceType> constantCellMeasuresData(1.0, Kokkos::Array<int,2>{numCells,numPoints});
+   TensorData<DataScalar,DeviceType> constantCellMeasures(constantCellMeasuresData);
    
    testIntegrateMatchesBaseline(transformedUnitVectorDataLeft, constantCellMeasures, transformedUnitVectorDataRight, out, success);
 }
@@ -1415,7 +1415,7 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case8_
 TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case9_3D )
 {
   using DataScalar  = double;
-  using ExecSpaceType = Kokkos::DefaultExecutionSpace;
+  using DeviceType = typename Kokkos::DefaultExecutionSpace::device_type;
   
   const int spaceDim = 3;
   
@@ -1445,16 +1445,16 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case9_
   const int fieldComponentDataRank = 2;
   Kokkos::Array<int,fieldComponentDataRank> fieldComponentExtents {numFields1,numComponentPoints};
   Kokkos::Array<DataVariationType,fieldComponentDataRank> fieldComponentVariationTypes {GENERAL,GENERAL};
-  Data<DataScalar,ExecSpaceType> fieldComponentData1(fieldComponentDataView1,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData1(fieldComponentDataView1,fieldComponentExtents,fieldComponentVariationTypes);
   fieldComponentExtents[0] = numFields2;
-  Data<DataScalar,ExecSpaceType> fieldComponentData2(fieldComponentDataView2,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData2(fieldComponentDataView2,fieldComponentExtents,fieldComponentVariationTypes);
   
-  TensorData<DataScalar,ExecSpaceType>  tensorDataLeft1(std::vector< Data<DataScalar,ExecSpaceType> >{fieldComponentData2,fieldComponentData1,fieldComponentData1});
-  TensorData<DataScalar,ExecSpaceType>  tensorDataLeft2(std::vector< Data<DataScalar,ExecSpaceType> >{fieldComponentData1,fieldComponentData2,fieldComponentData1});
-  TensorData<DataScalar,ExecSpaceType>  tensorDataLeft3(std::vector< Data<DataScalar,ExecSpaceType> >{fieldComponentData1,fieldComponentData1,fieldComponentData2});
-  TensorData<DataScalar,ExecSpaceType> tensorDataRight1 = tensorDataLeft1;
-  TensorData<DataScalar,ExecSpaceType> tensorDataRight2 = tensorDataLeft2;
-  TensorData<DataScalar,ExecSpaceType> tensorDataRight3 = tensorDataLeft3;
+  TensorData<DataScalar,DeviceType>  tensorDataLeft1(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData2,fieldComponentData1,fieldComponentData1});
+  TensorData<DataScalar,DeviceType>  tensorDataLeft2(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData1,fieldComponentData2,fieldComponentData1});
+  TensorData<DataScalar,DeviceType>  tensorDataLeft3(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData1,fieldComponentData1,fieldComponentData2});
+  TensorData<DataScalar,DeviceType> tensorDataRight1 = tensorDataLeft1;
+  TensorData<DataScalar,DeviceType> tensorDataRight2 = tensorDataLeft2;
+  TensorData<DataScalar,DeviceType> tensorDataRight3 = tensorDataLeft3;
    
   const int numPoints = numComponentPoints * numComponentPoints * numComponentPoints;
   auto identityMatrixView = getFixedRankView<DataScalar>("identity matrix", numPoints, spaceDim, spaceDim);
@@ -1476,25 +1476,25 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case9_
   Kokkos::Array<int,4> transformationExtents {numCells, numPoints, spaceDim, spaceDim};
   Kokkos::Array<DataVariationType,4> transformationVariationType {CONSTANT, GENERAL, GENERAL, GENERAL};
   
-  Data<DataScalar,ExecSpaceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType);
+  Data<DataScalar,DeviceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType);
   
   const int numFamilies = 1;
-  Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > firstFamilyLeft  {tensorDataLeft1,tensorDataLeft2,tensorDataLeft3};
-  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim>, numFamilies> vectorComponentsLeft {firstFamilyLeft};
+  Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > firstFamilyLeft  {tensorDataLeft1,tensorDataLeft2,tensorDataLeft3};
+  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim>, numFamilies> vectorComponentsLeft {firstFamilyLeft};
 
-  VectorData<DataScalar,ExecSpaceType> vectorDataLeft(vectorComponentsLeft);
+  VectorData<DataScalar,DeviceType> vectorDataLeft(vectorComponentsLeft);
   TEST_EQUALITY(numFieldsPerFamilyLeft, vectorDataLeft.numFieldsInFamily(0));
 
-  Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > firstFamilyRight  {tensorDataRight1,tensorDataRight2,tensorDataRight3};
-  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim>, numFamilies> vectorComponentsRight {firstFamilyRight};
-  VectorData<DataScalar,ExecSpaceType> vectorDataRight(vectorComponentsRight);
+  Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > firstFamilyRight  {tensorDataRight1,tensorDataRight2,tensorDataRight3};
+  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim>, numFamilies> vectorComponentsRight {firstFamilyRight};
+  VectorData<DataScalar,DeviceType> vectorDataRight(vectorComponentsRight);
   TEST_EQUALITY(numFieldsPerFamilyRight, vectorDataRight.numFieldsInFamily(0));
   
-  TransformedVectorData<DataScalar,ExecSpaceType>  transformedUnitVectorDataLeft(explicitIdentityMatrix,vectorDataLeft);
-  TransformedVectorData<DataScalar,ExecSpaceType> transformedUnitVectorDataRight(explicitIdentityMatrix,vectorDataRight);
+  TransformedVectorData<DataScalar,DeviceType>  transformedUnitVectorDataLeft(explicitIdentityMatrix,vectorDataLeft);
+  TransformedVectorData<DataScalar,DeviceType> transformedUnitVectorDataRight(explicitIdentityMatrix,vectorDataRight);
   
-  Data<DataScalar,ExecSpaceType> constantCellMeasuresData(1.0, Kokkos::Array<int,2>{numCells,numPoints});
-  TensorData<DataScalar,ExecSpaceType> constantCellMeasures(constantCellMeasuresData);
+  Data<DataScalar,DeviceType> constantCellMeasuresData(1.0, Kokkos::Array<int,2>{numCells,numPoints});
+  TensorData<DataScalar,DeviceType> constantCellMeasures(constantCellMeasuresData);
   
   testIntegrateMatchesBaseline(transformedUnitVectorDataLeft, constantCellMeasures, transformedUnitVectorDataRight, out, success);
 }
@@ -1504,7 +1504,7 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case10
 {
   // test with variable quadrature weights
   using DataScalar  = double;
-  using ExecSpaceType = Kokkos::DefaultExecutionSpace;
+  using DeviceType = typename Kokkos::DefaultExecutionSpace::device_type;
   
   const int spaceDim = 3;
   
@@ -1532,16 +1532,16 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case10
   const int fieldComponentDataRank = 2;
   Kokkos::Array<int,fieldComponentDataRank> fieldComponentExtents {numFields1,numComponentPoints};
   Kokkos::Array<DataVariationType,fieldComponentDataRank> fieldComponentVariationTypes {GENERAL,GENERAL};
-  Data<DataScalar,ExecSpaceType> fieldComponentData1(fieldComponentDataView1,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData1(fieldComponentDataView1,fieldComponentExtents,fieldComponentVariationTypes);
   fieldComponentExtents[0] = numFields2;
-  Data<DataScalar,ExecSpaceType> fieldComponentData2(fieldComponentDataView2,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData2(fieldComponentDataView2,fieldComponentExtents,fieldComponentVariationTypes);
   
-  TensorData<DataScalar,ExecSpaceType>  tensorDataLeft1(std::vector< Data<DataScalar,ExecSpaceType> >{fieldComponentData2,fieldComponentData1,fieldComponentData1});
-  TensorData<DataScalar,ExecSpaceType>  tensorDataLeft2(std::vector< Data<DataScalar,ExecSpaceType> >{fieldComponentData1,fieldComponentData2,fieldComponentData1});
-  TensorData<DataScalar,ExecSpaceType>  tensorDataLeft3(std::vector< Data<DataScalar,ExecSpaceType> >{fieldComponentData1,fieldComponentData1,fieldComponentData2});
-  TensorData<DataScalar,ExecSpaceType> tensorDataRight1 = tensorDataLeft1;
-  TensorData<DataScalar,ExecSpaceType> tensorDataRight2 = tensorDataLeft2;
-  TensorData<DataScalar,ExecSpaceType> tensorDataRight3 = tensorDataLeft3;
+  TensorData<DataScalar,DeviceType>  tensorDataLeft1(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData2,fieldComponentData1,fieldComponentData1});
+  TensorData<DataScalar,DeviceType>  tensorDataLeft2(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData1,fieldComponentData2,fieldComponentData1});
+  TensorData<DataScalar,DeviceType>  tensorDataLeft3(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData1,fieldComponentData1,fieldComponentData2});
+  TensorData<DataScalar,DeviceType> tensorDataRight1 = tensorDataLeft1;
+  TensorData<DataScalar,DeviceType> tensorDataRight2 = tensorDataLeft2;
+  TensorData<DataScalar,DeviceType> tensorDataRight3 = tensorDataLeft3;
    
   auto identityMatrixView = getFixedRankView<DataScalar>("identity matrix", spaceDim, spaceDim);
   auto identityMatrixViewHost = getHostCopy(identityMatrixView);
@@ -1559,22 +1559,22 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case10
   Kokkos::Array<int,4> transformationExtents {numCells, numPoints, spaceDim, spaceDim};
   Kokkos::Array<DataVariationType,4> transformationVariationType {CONSTANT, CONSTANT, GENERAL, GENERAL};
   
-  Data<DataScalar,ExecSpaceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType);
+  Data<DataScalar,DeviceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType);
   
   const int numFamilies = 1;
-  Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > firstFamilyLeft  {tensorDataLeft1,tensorDataLeft2,tensorDataLeft3};
-  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim>, numFamilies> vectorComponentsLeft {firstFamilyLeft};
+  Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > firstFamilyLeft  {tensorDataLeft1,tensorDataLeft2,tensorDataLeft3};
+  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim>, numFamilies> vectorComponentsLeft {firstFamilyLeft};
 
-  VectorData<DataScalar,ExecSpaceType> vectorDataLeft(vectorComponentsLeft);
+  VectorData<DataScalar,DeviceType> vectorDataLeft(vectorComponentsLeft);
   TEST_EQUALITY(numFieldsPerFamilyLeft, vectorDataLeft.numFieldsInFamily(0));
 
-  Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > firstFamilyRight  {tensorDataRight1,tensorDataRight2,tensorDataRight3};
-  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim>, numFamilies> vectorComponentsRight {firstFamilyRight};
-  VectorData<DataScalar,ExecSpaceType> vectorDataRight(vectorComponentsRight);
+  Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > firstFamilyRight  {tensorDataRight1,tensorDataRight2,tensorDataRight3};
+  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim>, numFamilies> vectorComponentsRight {firstFamilyRight};
+  VectorData<DataScalar,DeviceType> vectorDataRight(vectorComponentsRight);
   TEST_EQUALITY(numFieldsPerFamilyRight, vectorDataRight.numFieldsInFamily(0));
   
-  TransformedVectorData<DataScalar,ExecSpaceType>  transformedUnitVectorDataLeft(explicitIdentityMatrix,vectorDataLeft);
-  TransformedVectorData<DataScalar,ExecSpaceType> transformedUnitVectorDataRight(explicitIdentityMatrix,vectorDataRight);
+  TransformedVectorData<DataScalar,DeviceType>  transformedUnitVectorDataLeft(explicitIdentityMatrix,vectorDataLeft);
+  TransformedVectorData<DataScalar,DeviceType> transformedUnitVectorDataRight(explicitIdentityMatrix,vectorDataRight);
   
   auto cellMeasures = getFixedRankView<DataScalar>("cellMeasures", numCells, numPoints);
   
@@ -1589,8 +1589,8 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case10
   }
   Kokkos::deep_copy(cellMeasures, cellMeasuresHost);
   
-  Data<DataScalar,ExecSpaceType> cellMeasuresData(cellMeasures, Kokkos::Array<int,2>{numCells,numPoints}, Kokkos::Array<DataVariationType,2>{GENERAL,GENERAL});
-  TensorData<DataScalar,ExecSpaceType> cellMeasuresTensorData(cellMeasuresData);
+  Data<DataScalar,DeviceType> cellMeasuresData(cellMeasures, Kokkos::Array<int,2>{numCells,numPoints}, Kokkos::Array<DataVariationType,2>{GENERAL,GENERAL});
+  TensorData<DataScalar,DeviceType> cellMeasuresTensorData(cellMeasuresData);
   
   testIntegrateMatchesBaseline(transformedUnitVectorDataLeft, cellMeasuresTensorData, transformedUnitVectorDataRight, out, success);
 }

--- a/packages/intrepid2/unit-test/MonolithicExecutable/SubBasisInclusionTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/SubBasisInclusionTests.cpp
@@ -62,11 +62,13 @@ namespace
   bool testSubBasis(shards::CellTopology cellTopo, Intrepid2::EFunctionSpace fs, const double tol, Teuchos::FancyOStream &out, bool &success,
                     int polyOrder_x, int polyOrder_y=-1, int polyOrder_z = -1, bool defineVertexFunctions = true)
   {
-    using ExecSpace = Kokkos::DefaultExecutionSpace;
+    using DeviceType = typename Kokkos::DefaultExecutionSpace::device_type;
     using OutputScalar = double;
     using PointScalar  = double;
     using namespace Intrepid2;
-    using Basis = Basis<ExecSpace,OutputScalar,PointScalar>;
+    using Basis = Basis<DeviceType,OutputScalar,PointScalar>;
+    
+    static_assert(!Kokkos::is_execution_space<DeviceType>::value, "Kokkos default Device is also an execution space.  Can't use this static_assert in Basis!");
     
     auto vectorsMatch = [](std::vector<int> lhs,std::vector<int> rhs)
     {

--- a/packages/intrepid2/unit-test/MonolithicExecutable/TransformedVectorDataTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/TransformedVectorDataTests.cpp
@@ -178,7 +178,7 @@ namespace
     ScalarView<Scalar,DeviceType> transformedWeightedGradValues("transformed weighted grad values", numCells, numFields, numPoints, spaceDim);
     
     using Kokkos::DefaultExecutionSpace;
-    auto cubature = Intrepid2::DefaultCubatureFactory::create<DefaultExecutionSpace>(cellTopo,polyOrder*2);
+    auto cubature = Intrepid2::DefaultCubatureFactory::create<DeviceType>(cellTopo,polyOrder*2);
     TEST_EQUALITY( numPoints, cubature->getNumPoints());
     ScalarView<PointScalar,DeviceType> cubaturePoints("cubature points",numPoints,spaceDim);
     ScalarView<double,DeviceType> cubatureWeights("cubature weights", numPoints);

--- a/packages/intrepid2/unit-test/MonolithicExecutable/VectorDataTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/VectorDataTests.cpp
@@ -99,17 +99,17 @@ namespace
     else if (spaceDim == 2) cellTopo = shards::getCellTopologyData< shards::Quadrilateral<> >();
     else if (spaceDim == 3) cellTopo = shards::getCellTopologyData< shards::Hexahedron<>    >();
     
-    using ExecSpaceType = Kokkos::DefaultExecutionSpace;
-    auto lineCubature = Intrepid2::DefaultCubatureFactory::create<ExecSpaceType>(lineTopo,polyOrder*2);
+    using DeviceType = typename Kokkos::DefaultExecutionSpace::device_type;
+    auto lineCubature = Intrepid2::DefaultCubatureFactory::create<DeviceType>(lineTopo,polyOrder*2);
     int numPoints_1D = lineCubature->getNumPoints();
-    ScalarView<PointScalar,ExecSpaceType> lineCubaturePoints("line cubature points",numPoints_1D,1);
-    ScalarView<double,ExecSpaceType> lineCubatureWeights("line cubature weights", numPoints_1D);
+    ScalarView<PointScalar,DeviceType> lineCubaturePoints("line cubature points",numPoints_1D,1);
+    ScalarView<double,DeviceType> lineCubatureWeights("line cubature weights", numPoints_1D);
     
     lineCubature->getCubature(lineCubaturePoints, lineCubatureWeights);
     
     // Allocate some intermediate containers
-    ScalarView<Scalar,ExecSpaceType> lineBasisValues    ("line basis values",      numFields_1D, numPoints_1D   );
-    ScalarView<Scalar,ExecSpaceType> lineBasisGradValues("line basis grad values", numFields_1D, numPoints_1D, 1);
+    ScalarView<Scalar,DeviceType> lineBasisValues    ("line basis values",      numFields_1D, numPoints_1D   );
+    ScalarView<Scalar,DeviceType> lineBasisGradValues("line basis grad values", numFields_1D, numPoints_1D, 1);
     
     // for now, we use 1D values to build up the 2D or 3D gradients
     // eventually, TensorBasis should offer a getValues() variant that returns tensor basis data
@@ -119,23 +119,23 @@ namespace
     // drop the trivial space dimension in line gradient values:
     Kokkos::resize(lineBasisGradValues, numFields_1D, numPoints_1D);
       
-    Kokkos::Array<TensorData<Scalar,ExecSpaceType>, spaceDim> vectorComponents;
+    Kokkos::Array<TensorData<Scalar,DeviceType>, spaceDim> vectorComponents;
     
     for (int d=0; d<spaceDim; d++)
     {
-      Kokkos::Array<Data<Scalar,ExecSpaceType>, spaceDim> gradComponent_d;
+      Kokkos::Array<Data<Scalar,DeviceType>, spaceDim> gradComponent_d;
       // gradComponent_d stores vector component d of the gradient, expressed as the product of values corresponding to each coordinate dimension
       // The gradient operator is (dx,dy,dz) in 3D; that is, the derivative taken is in the coordinate dimension that matches d.
       // Therefore, the operator leaves the tensorial components in dimension d2≠d unaffected, and results in a 1D "gradient" being taken in the dimension for which d2=d.
       // Hence, the assignment below.
       for (int d2=0; d2<spaceDim; d2++)
       {
-        if (d2 == d) gradComponent_d[d2] = Data<Scalar,ExecSpaceType>(lineBasisGradValues);
-        else         gradComponent_d[d2] = Data<Scalar,ExecSpaceType>(lineBasisValues);
+        if (d2 == d) gradComponent_d[d2] = Data<Scalar,DeviceType>(lineBasisGradValues);
+        else         gradComponent_d[d2] = Data<Scalar,DeviceType>(lineBasisValues);
       }
-      vectorComponents[d] = TensorData<Scalar,ExecSpaceType>(gradComponent_d);
+      vectorComponents[d] = TensorData<Scalar,DeviceType>(gradComponent_d);
     }
-    VectorData<Scalar,ExecSpaceType> gradientValues(vectorComponents, false); // false: not axis-aligned
+    VectorData<Scalar,DeviceType> gradientValues(vectorComponents, false); // false: not axis-aligned
     
     int numPoints = 1;
     for (int d=0; d<spaceDim; d++)
@@ -146,14 +146,14 @@ namespace
     auto basis = Intrepid2::getBasis< Intrepid2::NodalBasisFamily<> >(cellTopo, fs, polyOrder);
     
     // Allocate some intermediate containers
-    ScalarView<Scalar,ExecSpaceType> basisValues    ("basis values", numFields, numPoints );
-    ScalarView<Scalar,ExecSpaceType> basisGradValues("basis grad values", numFields, numPoints, spaceDim);
+    ScalarView<Scalar,DeviceType> basisValues    ("basis values", numFields, numPoints );
+    ScalarView<Scalar,DeviceType> basisGradValues("basis grad values", numFields, numPoints, spaceDim);
 
     using Kokkos::DefaultExecutionSpace;
-    auto cubature = Intrepid2::DefaultCubatureFactory::create<DefaultExecutionSpace>(cellTopo,polyOrder*2);
+    auto cubature = Intrepid2::DefaultCubatureFactory::create<DeviceType>(cellTopo,polyOrder*2);
     TEST_EQUALITY( numPoints, cubature->getNumPoints());
-    ScalarView<PointScalar,ExecSpaceType> cubaturePoints("cubature points",numPoints,spaceDim);
-    ScalarView<double,ExecSpaceType> cubatureWeights("cubature weights", numPoints);
+    ScalarView<PointScalar,DeviceType> cubaturePoints("cubature points",numPoints,spaceDim);
+    ScalarView<double,DeviceType> cubatureWeights("cubature weights", numPoints);
     
     cubature->getCubature(cubaturePoints, cubatureWeights);
     
@@ -184,7 +184,7 @@ namespace
   TEUCHOS_UNIT_TEST( VectorData, ZeroFirstComponent )
   {
     using Scalar  = double;
-    using ExecSpaceType = Kokkos::DefaultExecutionSpace;
+    using DeviceType = typename Kokkos::DefaultExecutionSpace::device_type;
     
     const int spaceDim = 2;
     
@@ -193,7 +193,7 @@ namespace
     const int numFields          = numComponentFields * numComponentFields;
     const int numPoints          = numComponentPoints * numComponentPoints;
     
-    ScalarView<Scalar,ExecSpaceType> fieldComponentDataView = getView<Scalar>("field component data", numComponentFields);
+    ScalarView<Scalar,DeviceType> fieldComponentDataView = getView<Scalar>("field component data", numComponentFields);
     auto fieldComponentDataViewHost = Kokkos::create_mirror_view(fieldComponentDataView);
     fieldComponentDataViewHost(0) = 1.0;
     
@@ -202,15 +202,15 @@ namespace
     const int fieldComponentDataRank = 2;
     Kokkos::Array<int,fieldComponentDataRank> fieldComponentExtents {numComponentFields,numComponentPoints};
     Kokkos::Array<DataVariationType,fieldComponentDataRank> fieldComponentVariationTypes {GENERAL,CONSTANT};
-    Data<Scalar,ExecSpaceType> fieldComponentData(fieldComponentDataView,fieldComponentExtents,fieldComponentVariationTypes);
+    Data<Scalar,DeviceType> fieldComponentData(fieldComponentDataView,fieldComponentExtents,fieldComponentVariationTypes);
     
-    TensorData<Scalar,ExecSpaceType> nonzeroTensorData(std::vector< Data<Scalar,ExecSpaceType> >{fieldComponentData,fieldComponentData});
+    TensorData<Scalar,DeviceType> nonzeroTensorData(std::vector< Data<Scalar,DeviceType> >{fieldComponentData,fieldComponentData});
     
     const int numFamilies = 1;
-    Kokkos::Array<TensorData<Scalar,ExecSpaceType>, spaceDim > family {TensorData<Scalar,ExecSpaceType>(), nonzeroTensorData}; // empty first component
-    Kokkos::Array< Kokkos::Array<TensorData<Scalar,ExecSpaceType>, spaceDim>, numFamilies> vectorComponents {family};
+    Kokkos::Array<TensorData<Scalar,DeviceType>, spaceDim > family {TensorData<Scalar,DeviceType>(), nonzeroTensorData}; // empty first component
+    Kokkos::Array< Kokkos::Array<TensorData<Scalar,DeviceType>, spaceDim>, numFamilies> vectorComponents {family};
     
-    VectorData<Scalar,ExecSpaceType> vectorData(vectorComponents);
+    VectorData<Scalar,DeviceType> vectorData(vectorComponents);
     
     TEST_EQUALITY(numFields, vectorData.extent_int(0)); // (F,P,D)
     TEST_EQUALITY(numPoints, vectorData.extent_int(1)); // (F,P,D)


### PR DESCRIPTION
As part of the work described in #8310, this PR replaces uses of ExecutionSpace template arguments with Device arguments, in the new structured integration support classes:
- BasisValues
- CellGeometry
- Data
- IntegrationTools
- ProjectedGeometry
- TransformedVectorData
- VectorData

In addition, it performs the same conversion for a bunch of Basis subclasses:
    - HGRAD C2 - hex, quad, tet, tri, wedge
    - HGRAD Cn - hex, quad, tet, tri, line
    - HCURL In - hex, quad, tet, tri
    - HDIV In - hex, quad, tet, tri
    - HVOL Cn - line, hex, quad, tet, tri

It also includes a commented-out static_assert in the base Basis class that asserts that the template argument is a Kokkos::Device.  This can be used during development to find places where the conversion has not been made.
@trilinos/intrepid2

## Testing
The changed code does get exercised in many ways by the tests.  However, this PR does *not* include any new CUDA-specific tests against UVM-independence, as described in #8310.