### PR TITLE
MueLu: updating trappist nightly clang build

### DIFF
--- a/cmake/ctest/drivers/trappist/cron_driver.sh
+++ b/cmake/ctest/drivers/trappist/cron_driver.sh
@@ -65,7 +65,7 @@ module unload sems-cmake/3.17.1
 # ===========================================================================
 export CTEST_CONFIGURATION="clang"
 module load sems-cmake/3.17.1
-module load sems-clang/3.9.0
+module load sems-clang/10.0.0
 module load sems-openmpi/1.10.1
 module load sems-superlu/4.3/base
 
@@ -85,7 +85,7 @@ $SCRIPT_DIR/../cron_driver.py
 
 module unload sems-superlu/4.3/base
 module unload sems-openmpi/1.10.1
-module unload sems-clang/3.9.0
+module unload sems-clang/10.0.0
 module unload sems-cmake/3.17.1
 # ===========================================================================
 


### PR DESCRIPTION
trappist was using the archaic clang 3.9.0, it will now jump
into the present with a new clang 10.0.0 until even higher
versions are needed for OpenMP Target and other NGP stuff
comes along.

@trilinos/muelu 

## Motivation
trappist was using the archaic clang 3.9.0 which no longer supported by Trilinos (guessing 3.9.0 does not implement c++14 fully).
It will now jump into the present with a new clang 10.0.0 until even higher versions are needed for OpenMP Target and other NGP stuff comes along.


## Stakeholder Feedback
The MueLu team is happy to see this build not failing at configure time anymore!