### PR TITLE
Intrepid2 develop

### DIFF
--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C2_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C2_FEM.hpp
@@ -157,7 +157,7 @@ namespace Intrepid2 {
         
       };
       
-      template<typename ExecSpaceType, 
+      template<typename DeviceType, 
                typename outputValueValueType, class ...outputValueProperties,
                typename inputPointValueType,  class ...inputPointProperties>
       static void
@@ -216,24 +216,24 @@ namespace Intrepid2 {
     };
   }
       
-  template<typename ExecSpaceType = void,
+  template<typename DeviceType = void,
            typename outputValueType = double,
            typename pointValueType = double>
-  class Basis_HGRAD_HEX_C2_FEM : public Basis<ExecSpaceType,outputValueType,pointValueType> {
+  class Basis_HGRAD_HEX_C2_FEM : public Basis<DeviceType,outputValueType,pointValueType> {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
-    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+    using OrdinalTypeArray1DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
 
     /** \brief  Constructor.
      */
     Basis_HGRAD_HEX_C2_FEM();
 
-    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
-    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
-    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    using OutputViewType = typename Basis<DeviceType,outputValueType,pointValueType>::OutputViewType;
+    using PointViewType  = typename Basis<DeviceType,outputValueType,pointValueType>::PointViewType;
+    using ScalarViewType = typename Basis<DeviceType,outputValueType,pointValueType>::ScalarViewType;
 
-    using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
+    using Basis<DeviceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
@@ -249,7 +249,7 @@ namespace Intrepid2 {
                                       this->getCardinality() );
 #endif
       Impl::Basis_HGRAD_HEX_C2_FEM::
-        getValues<ExecSpaceType>( outputValues,
+        getValues<DeviceType>( outputValues,
                                   inputPoints,
                                   operatorType );
     }

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C2_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C2_FEMDef.hpp
@@ -941,7 +941,7 @@ namespace Intrepid2 {
       }
     }
 
-    template<typename SpT, 
+    template<typename DT, 
              typename outputValueValueType, class ...outputValueProperties,
              typename inputPointValueType,  class ...inputPointProperties>
     void
@@ -951,7 +951,7 @@ namespace Intrepid2 {
                const EOperator operatorType ) {
       typedef          Kokkos::DynRankView<outputValueValueType,outputValueProperties...>         outputValueViewType;
       typedef          Kokkos::DynRankView<inputPointValueType, inputPointProperties...>          inputPointViewType;
-      typedef typename ExecSpace<typename inputPointViewType::execution_space,SpT>::ExecSpaceType ExecSpaceType;
+      typedef typename ExecSpace<typename inputPointViewType::execution_space,typename DT::execution_space>::ExecSpaceType ExecSpaceType;
 
       // Number of evaluation points = dim 0 of inputPoints
       const auto loopSize = inputPoints.extent(0);
@@ -1020,8 +1020,8 @@ namespace Intrepid2 {
 
   // -------------------------------------------------------------------------------------
 
-  template<typename SpT, typename OT, typename PT>
-  Basis_HGRAD_HEX_C2_FEM<SpT,OT,PT>::
+  template<typename DT, typename OT, typename PT>
+  Basis_HGRAD_HEX_C2_FEM<DT,OT,PT>::
   Basis_HGRAD_HEX_C2_FEM() {
     this -> basisCardinality_  = 27;
     this -> basisDegree_       = 2;
@@ -1082,7 +1082,7 @@ namespace Intrepid2 {
                               posDfOrd);
     }
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename DT::execution_space::array_layout,Kokkos::HostSpace>
       dofCoords("dofCoordsHost", this->basisCardinality_,this->basisCellTopology_.getDimension());
 
     dofCoords(0,0) = -1.0;   dofCoords(0,1) = -1.0; dofCoords(0,2) = -1.0;
@@ -1116,7 +1116,7 @@ namespace Intrepid2 {
     dofCoords(25,0) =  0.0;   dofCoords(25,1) = -1.0; dofCoords(25,2) =  0.0;
     dofCoords(26,0) =  0.0;   dofCoords(26,1) =  1.0; dofCoords(26,2) =  0.0;
 
-    this->dofCoords_ = Kokkos::create_mirror_view(typename SpT::memory_space(), dofCoords);
+    this->dofCoords_ = Kokkos::create_mirror_view(typename DT::memory_space(), dofCoords);
     Kokkos::deep_copy(this->dofCoords_, dofCoords);
 
   }

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_C2_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_C2_FEM.hpp
@@ -112,7 +112,7 @@ namespace Intrepid2 {
 
       };
 
-      template<typename ExecSpaceType,
+      template<typename DeviceType,
                typename outputValueValueType, class ...outputValueProperties,
                typename inputPointValueType,  class ...inputPointProperties>
       static void
@@ -173,24 +173,24 @@ namespace Intrepid2 {
     };
   }
 
-  template<typename ExecSpaceType = void,
+  template<typename DeviceType = void,
            typename outputValueType = double,
            typename pointValueType = double>
-  class Basis_HGRAD_QUAD_C2_FEM : public Basis<ExecSpaceType,outputValueType,pointValueType> {
+  class Basis_HGRAD_QUAD_C2_FEM : public Basis<DeviceType,outputValueType,pointValueType> {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
-    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+    using OrdinalTypeArray1DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
 
     /** \brief Constructor.
      */
     Basis_HGRAD_QUAD_C2_FEM();
 
-    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
-    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
-    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    using OutputViewType = typename Basis<DeviceType,outputValueType,pointValueType>::OutputViewType;
+    using PointViewType  = typename Basis<DeviceType,outputValueType,pointValueType>::PointViewType;
+    using ScalarViewType = typename Basis<DeviceType,outputValueType,pointValueType>::ScalarViewType;
 
-    using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
+    using Basis<DeviceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
@@ -206,7 +206,7 @@ namespace Intrepid2 {
                                       this->getCardinality() );
 #endif
       Impl::Basis_HGRAD_QUAD_C2_FEM::
-        getValues<ExecSpaceType>( outputValues,
+        getValues<DeviceType>( outputValues,
                                   inputPoints,
                                   operatorType );
     }

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_C2_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_C2_FEMDef.hpp
@@ -320,7 +320,7 @@ namespace Intrepid2 {
     }
   }
 
-  template<typename SpT, 
+  template<typename DT, 
   typename outputValueValueType, class ...outputValueProperties,
            typename inputPointValueType,  class ...inputPointProperties>
   void 
@@ -330,7 +330,7 @@ namespace Intrepid2 {
              const EOperator operatorType ) {
     typedef          Kokkos::DynRankView<outputValueValueType,outputValueProperties...>         outputValueViewType;
     typedef          Kokkos::DynRankView<inputPointValueType, inputPointProperties...>          inputPointViewType;
-    typedef typename ExecSpace<typename inputPointViewType::execution_space,SpT>::ExecSpaceType ExecSpaceType;
+    typedef typename ExecSpace<typename inputPointViewType::execution_space,typename DT::execution_space>::ExecSpaceType ExecSpaceType;
 
     // Number of evaluation points = dim 0 of inputPoints
     const auto loopSize = inputPoints.extent(0);
@@ -400,8 +400,8 @@ namespace Intrepid2 {
   // -------------------------------------------------------------------------------------
 
 
-  template<typename SpT, typename OT, typename PT>
-  Basis_HGRAD_QUAD_C2_FEM<SpT,OT,PT>::
+  template<typename DT, typename OT, typename PT>
+  Basis_HGRAD_QUAD_C2_FEM<DT,OT,PT>::
   Basis_HGRAD_QUAD_C2_FEM() {
     this->basisCardinality_  = 9;
     this->basisDegree_       = 2;    
@@ -445,7 +445,7 @@ namespace Intrepid2 {
     }
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename DT::execution_space::array_layout,Kokkos::HostSpace>
       dofCoords("dofCoordsHost", this->basisCardinality_,this->basisCellTopology_.getDimension());
     
     dofCoords(0,0) = -1.0;   dofCoords(0,1) = -1.0;
@@ -460,7 +460,7 @@ namespace Intrepid2 {
   
     dofCoords(8,0) =  0.0;   dofCoords(8,1) =  0.0;
 
-    this->dofCoords_ = Kokkos::create_mirror_view(typename SpT::memory_space(), dofCoords);
+    this->dofCoords_ = Kokkos::create_mirror_view(typename DT::memory_space(), dofCoords);
     Kokkos::deep_copy(this->dofCoords_, dofCoords);   
   }
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_C2_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_C2_FEM.hpp
@@ -119,7 +119,7 @@ namespace Intrepid2 {
 
       };
 
-      template<typename ExecSpaceType,
+      template<typename DeviceType,
                typename outputValueValueType, class ...outputValueProperties,
                typename inputPointValueType,  class ...inputPointProperties>
       static void
@@ -172,24 +172,24 @@ namespace Intrepid2 {
     };
   }
 
-  template<typename ExecSpaceType = void,
+  template<typename DeviceType = void,
            typename outputValueType = double,
            typename pointValueType = double>
-  class Basis_HGRAD_TET_C2_FEM : public Basis<ExecSpaceType,outputValueType,pointValueType> {
+  class Basis_HGRAD_TET_C2_FEM : public Basis<DeviceType,outputValueType,pointValueType> {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
-    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+    using OrdinalTypeArray1DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
 
     /** \brief  Constructor.
      */
     Basis_HGRAD_TET_C2_FEM();
 
-    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
-    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
-    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    using OutputViewType = typename Basis<DeviceType,outputValueType,pointValueType>::OutputViewType;
+    using PointViewType  = typename Basis<DeviceType,outputValueType,pointValueType>::PointViewType;
+    using ScalarViewType = typename Basis<DeviceType,outputValueType,pointValueType>::ScalarViewType;
 
-    using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
+    using Basis<DeviceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
@@ -205,7 +205,7 @@ namespace Intrepid2 {
                                       this->getCardinality() );
 #endif
       Impl::Basis_HGRAD_TET_C2_FEM::
-        getValues<ExecSpaceType>( outputValues,
+        getValues<DeviceType>( outputValues,
                                   inputPoints,
                                   operatorType );
     }

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_C2_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_C2_FEMDef.hpp
@@ -224,7 +224,7 @@ namespace Intrepid2 {
       }
     }
 
-    template<typename SpT, 
+    template<typename DT, 
              typename outputValueValueType, class ...outputValueProperties,
              typename inputPointValueType,  class ...inputPointProperties>
     void
@@ -234,7 +234,7 @@ namespace Intrepid2 {
                const EOperator operatorType )  {
       typedef          Kokkos::DynRankView<outputValueValueType,outputValueProperties...>         outputValueViewType;
       typedef          Kokkos::DynRankView<inputPointValueType, inputPointProperties...>          inputPointViewType;
-      typedef typename ExecSpace<typename inputPointViewType::execution_space,SpT>::ExecSpaceType ExecSpaceType;
+      typedef typename ExecSpace<typename inputPointViewType::execution_space,typename DT::execution_space>::ExecSpaceType ExecSpaceType;
 
       // Number of evaluation points = dim 0 of inputPoints
       const auto loopSize = inputPoints.extent(0);
@@ -289,8 +289,8 @@ namespace Intrepid2 {
   }
   // -------------------------------------------------------------------------------------
 
-  template<typename SpT, typename OT, typename PT>
-  Basis_HGRAD_TET_C2_FEM<SpT,OT,PT>::
+  template<typename DT, typename OT, typename PT>
+  Basis_HGRAD_TET_C2_FEM<DT,OT,PT>::
   Basis_HGRAD_TET_C2_FEM() {
     this->basisCardinality_  = 10;
     this->basisDegree_       = 2;    
@@ -335,7 +335,7 @@ namespace Intrepid2 {
     }
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename DT::execution_space::array_layout,Kokkos::HostSpace>
       dofCoords("dofCoordsHost", this->basisCardinality_,this->basisCellTopology_.getDimension());
 
     dofCoords(0,0) = 0.0;   dofCoords(0,1) = 0.0; dofCoords(0,2) = 0.0;
@@ -350,7 +350,7 @@ namespace Intrepid2 {
     dofCoords(8,0) = 0.5;   dofCoords(8,1) = 0.0; dofCoords(8,2) = 0.5;
     dofCoords(9,0) = 0.0;   dofCoords(9,1) = 0.5; dofCoords(9,2) = 0.5;
 
-    this->dofCoords_ = Kokkos::create_mirror_view(typename SpT::memory_space(), dofCoords);
+    this->dofCoords_ = Kokkos::create_mirror_view(typename DT::memory_space(), dofCoords);
     Kokkos::deep_copy(this->dofCoords_, dofCoords);
   }
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_C2_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_C2_FEM.hpp
@@ -105,7 +105,7 @@ namespace Intrepid2 {
 
       };
 
-      template<typename ExecSpaceType,
+      template<typename DeviceType,
                typename outputValueValueType, class ...outputValueProperties,
                typename inputPointValueType,  class ...inputPointProperties>
       static void
@@ -162,24 +162,24 @@ namespace Intrepid2 {
     };
   }
 
-  template<typename ExecSpaceType = void,
+  template<typename DeviceType = void,
            typename outputValueType = double,
            typename pointValueType = double>
-  class Basis_HGRAD_TRI_C2_FEM: public Basis<ExecSpaceType,outputValueType,pointValueType> {
+  class Basis_HGRAD_TRI_C2_FEM: public Basis<DeviceType,outputValueType,pointValueType> {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
-    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+    using OrdinalTypeArray1DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
 
     /** \brief  Constructor.
      */
     Basis_HGRAD_TRI_C2_FEM();
 
-    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
-    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
-    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    using OutputViewType = typename Basis<DeviceType,outputValueType,pointValueType>::OutputViewType;
+    using PointViewType  = typename Basis<DeviceType,outputValueType,pointValueType>::PointViewType;
+    using ScalarViewType = typename Basis<DeviceType,outputValueType,pointValueType>::ScalarViewType;
 
-    using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
+    using Basis<DeviceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
@@ -195,7 +195,7 @@ namespace Intrepid2 {
                                       this->getCardinality() );
 #endif
       Impl::Basis_HGRAD_TRI_C2_FEM::
-        getValues<ExecSpaceType>( outputValues,
+        getValues<DeviceType>( outputValues,
                                   inputPoints,
                                   operatorType );
     }

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_C2_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_C2_FEMDef.hpp
@@ -172,7 +172,7 @@ namespace Intrepid2 {
       }
     }
 
-    template<typename SpT,
+    template<typename DT,
              typename outputValueValueType, class ...outputValueProperties,
              typename inputPointValueType,  class ...inputPointProperties>
     void
@@ -182,7 +182,7 @@ namespace Intrepid2 {
                const EOperator operatorType ) {
       typedef          Kokkos::DynRankView<outputValueValueType,outputValueProperties...>         outputValueViewType;
       typedef          Kokkos::DynRankView<inputPointValueType, inputPointProperties...>          inputPointViewType;
-      typedef typename ExecSpace<typename inputPointViewType::execution_space,SpT>::ExecSpaceType ExecSpaceType;
+      typedef typename ExecSpace<typename inputPointViewType::execution_space,typename DT::execution_space>::ExecSpaceType ExecSpaceType;
 
       // Number of evaluation points = dim 0 of inputPoints
       const auto loopSize = inputPoints.extent(0);
@@ -239,8 +239,8 @@ namespace Intrepid2 {
   // -------------------------------------------------------------------------------------
 
 
-  template< typename SpT, typename OT, typename PT>
-  Basis_HGRAD_TRI_C2_FEM<SpT,OT,PT>::
+  template< typename DT, typename OT, typename PT>
+  Basis_HGRAD_TRI_C2_FEM<DT,OT,PT>::
   Basis_HGRAD_TRI_C2_FEM() {
     this->basisCardinality_  = 6;
     this->basisDegree_       = 2;
@@ -280,7 +280,7 @@ namespace Intrepid2 {
     }
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename DT::execution_space::array_layout,Kokkos::HostSpace>
       dofCoords("dofCoordsHost", this->basisCardinality_,this->basisCellTopology_.getDimension());
 
     dofCoords(0,0) =  0.0;   dofCoords(0,1) =  0.0;
@@ -290,7 +290,7 @@ namespace Intrepid2 {
     dofCoords(4,0) =  0.5;   dofCoords(4,1) =  0.5;
     dofCoords(5,0) =  0.0;   dofCoords(5,1) =  0.5;
 
-    this->dofCoords_ = Kokkos::create_mirror_view(typename SpT::memory_space(), dofCoords);
+    this->dofCoords_ = Kokkos::create_mirror_view(typename DT::memory_space(), dofCoords);
     Kokkos::deep_copy(this->dofCoords_, dofCoords);
   }
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_WEDGE_C2_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_WEDGE_C2_FEM.hpp
@@ -139,7 +139,7 @@ namespace Intrepid2 {
 
       };
 
-      template<typename ExecSpaceType,
+      template<typename DeviceType,
                typename outputValueValueType, class ...outputValueProperties,
                typename inputPointValueType,  class ...inputPointProperties>
       static void
@@ -193,23 +193,23 @@ namespace Intrepid2 {
     };
   }
 
-  template<typename ExecSpaceType = void,
+  template<typename DeviceType = void,
            typename outputValueType = double,
            typename pointValueType = double>
-  class Basis_HGRAD_WEDGE_C2_FEM : public Basis<ExecSpaceType,outputValueType,pointValueType> {
+  class Basis_HGRAD_WEDGE_C2_FEM : public Basis<DeviceType,outputValueType,pointValueType> {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
-    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+    using OrdinalTypeArray1DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
     /** \brief  Constructor.
      */
     Basis_HGRAD_WEDGE_C2_FEM();
 
-    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
-    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
-    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    using OutputViewType = typename Basis<DeviceType,outputValueType,pointValueType>::OutputViewType;
+    using PointViewType  = typename Basis<DeviceType,outputValueType,pointValueType>::PointViewType;
+    using ScalarViewType = typename Basis<DeviceType,outputValueType,pointValueType>::ScalarViewType;
 
-    using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
+    using Basis<DeviceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
@@ -225,7 +225,7 @@ namespace Intrepid2 {
                                       this->getCardinality() );
 #endif
       Impl::Basis_HGRAD_WEDGE_C2_FEM::
-        getValues<ExecSpaceType>( outputValues,
+        getValues<DeviceType>( outputValues,
                                   inputPoints,
                                   operatorType );
     }

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_WEDGE_C2_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_WEDGE_C2_FEMDef.hpp
@@ -587,7 +587,7 @@ namespace Intrepid2 {
     }
 
 
-    template<typename SpT,
+    template<typename DT,
              typename outputValueValueType, class ...outputValueProperties,
              typename inputPointValueType,  class ...inputPointProperties>
     void
@@ -597,7 +597,7 @@ namespace Intrepid2 {
                const EOperator operatorType ) {
       typedef          Kokkos::DynRankView<outputValueValueType,outputValueProperties...>         outputValueViewType;
       typedef          Kokkos::DynRankView<inputPointValueType, inputPointProperties...>          inputPointViewType;
-      typedef typename ExecSpace<typename inputPointViewType::execution_space,SpT>::ExecSpaceType ExecSpaceType;
+      typedef typename ExecSpace<typename inputPointViewType::execution_space,typename DT::execution_space>::ExecSpaceType ExecSpaceType;
 
       // Number of evaluation points = dim 0 of inputPoints
       const auto loopSize = inputPoints.extent(0);
@@ -660,8 +660,8 @@ namespace Intrepid2 {
   }
   // -------------------------------------------------------------------------------------
 
-  template<typename SpT, typename OT, typename PT>
-  Basis_HGRAD_WEDGE_C2_FEM<SpT,OT,PT>::
+  template<typename DT, typename OT, typename PT>
+  Basis_HGRAD_WEDGE_C2_FEM<DT,OT,PT>::
   Basis_HGRAD_WEDGE_C2_FEM() {
     this->basisCardinality_  = 18;
     this->basisDegree_       = 2;
@@ -716,7 +716,7 @@ namespace Intrepid2 {
     }
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename DT::execution_space::array_layout,Kokkos::HostSpace>
       dofCoords("dofCoordsHost", this->basisCardinality_,this->basisCellTopology_.getDimension());
 
     dofCoords(0,0) =  0.0;  dofCoords(0,1) =  0.0;  dofCoords(0,2) = -1.0;
@@ -740,7 +740,7 @@ namespace Intrepid2 {
     dofCoords(16,0)=  0.5;  dofCoords(16,1)=  0.5;  dofCoords(16,2)=  0.0;
     dofCoords(17,0)=  0.0;  dofCoords(17,1)=  0.5;  dofCoords(17,2)=  0.0;
 
-    this->dofCoords_ = Kokkos::create_mirror_view(typename SpT::memory_space(), dofCoords);
+    this->dofCoords_ = Kokkos::create_mirror_view(typename DT::memory_space(), dofCoords);
     Kokkos::deep_copy(this->dofCoords_, dofCoords);
   }
 

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_HEX_C2_FEM/Cuda/test_01.cpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_HEX_C2_FEM/Cuda/test_01.cpp
@@ -54,7 +54,7 @@ int main(int argc, char *argv[]) {
   const bool verbose = (argc-1) > 0;
   Kokkos::initialize();
 
-  const int r_val = Intrepid2::Test::HGRAD_HEX_C2_FEM_Test01<double,Kokkos::Cuda>(verbose);
+  const int r_val = Intrepid2::Test::HGRAD_HEX_C2_FEM_Test01<double,Kokkos::Device<Kokkos::Cuda,Kokkos::CudaSpace> >(verbose);
 
   Kokkos::finalize();
   return r_val;

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_HEX_C2_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_HEX_C2_FEM/test_01.hpp
@@ -72,7 +72,7 @@ namespace Intrepid2 {
     }
 
 
-    template<typename ValueType, typename DeviceSpaceType>
+    template<typename ValueType, typename DeviceType>
     int HGRAD_HEX_C2_FEM_Test01(const bool verbose) {
 
       Teuchos::RCP<std::ostream> outStream;
@@ -86,6 +86,7 @@ namespace Intrepid2 {
       Teuchos::oblackholestream oldFormatState;
       oldFormatState.copyfmt(std::cout);
 
+      using DeviceSpaceType = typename DeviceType::execution_space;
       typedef typename
         Kokkos::Impl::is_space<DeviceSpaceType>::host_mirror_space::execution_space HostSpaceType ;
 
@@ -111,7 +112,7 @@ namespace Intrepid2 {
         << "===============================================================================\n";
 
 
-      typedef Kokkos::DynRankView<ValueType,DeviceSpaceType> DynRankView;
+      typedef Kokkos::DynRankView<ValueType,DeviceType> DynRankView;
       typedef Kokkos::DynRankView<ValueType,HostSpaceType>   DynRankViewHost;
 #define ConstructWithLabel(obj, ...) obj(#obj, __VA_ARGS__)
 
@@ -121,7 +122,7 @@ namespace Intrepid2 {
       // for virtual function, value and point types are declared in the class
       typedef ValueType outputValueType;
       typedef ValueType pointValueType;
-      Basis_HGRAD_HEX_C2_FEM<DeviceSpaceType,outputValueType,pointValueType> hexBasis;
+      Basis_HGRAD_HEX_C2_FEM<DeviceType,outputValueType,pointValueType> hexBasis;
       //typedef typename decltype(hexBasis)::OutputViewType OutputViewType;
       //typedef typename decltype(hexBasis)::PointViewType  PointViewType;
 
@@ -470,7 +471,7 @@ namespace Intrepid2 {
         hexNodesHost(25,0) =  0.0;   hexNodesHost(25,1) = -1.0;  hexNodesHost(25,2) =  0.0;
         hexNodesHost(26,0) =  0.0;   hexNodesHost(26,1) =  1.0;  hexNodesHost(26,2) =  0.0;
 
-        auto hexNodes = Kokkos::create_mirror_view(typename DeviceSpaceType::memory_space(), hexNodesHost);
+        auto hexNodes = Kokkos::create_mirror_view(typename DeviceType::memory_space(), hexNodesHost);
         Kokkos::deep_copy(hexNodes, hexNodesHost);
 
         // Dimensions for the output arrays:

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_QUAD_C2_FEM/Cuda/test_01.cpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_QUAD_C2_FEM/Cuda/test_01.cpp
@@ -54,7 +54,7 @@ int main(int argc, char *argv[]) {
   const bool verbose = (argc-1) > 0;
   Kokkos::initialize();
 
-  const int r_val = Intrepid2::Test::HGRAD_QUAD_C2_FEM_Test01<double,Kokkos::Cuda>(verbose);
+  const int r_val = Intrepid2::Test::HGRAD_QUAD_C2_FEM_Test01<double,Kokkos::Device<Kokkos::Cuda,Kokkos::CudaSpace> >(verbose);
 
   Kokkos::finalize();
   return r_val;

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_QUAD_C2_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_QUAD_C2_FEM/test_01.hpp
@@ -72,7 +72,7 @@ namespace Intrepid2 {
       *outStream << "-------------------------------------------------------------------------------" << "\n\n"; \
     }
     
-    template<typename ValueType, typename DeviceSpaceType>
+    template<typename ValueType, typename DeviceType>
     int HGRAD_QUAD_C2_FEM_Test01(const bool verbose) {
       
       Teuchos::RCP<std::ostream> outStream;
@@ -86,6 +86,7 @@ namespace Intrepid2 {
       Teuchos::oblackholestream oldFormatState;
       oldFormatState.copyfmt(std::cout);
       
+      using DeviceSpaceType = typename DeviceType::execution_space;
       typedef typename
         Kokkos::Impl::is_space<DeviceSpaceType>::host_mirror_space::execution_space HostSpaceType ;
       
@@ -109,7 +110,7 @@ namespace Intrepid2 {
         << "|                                                                             |\n" 
         << "===============================================================================\n";
 
-      typedef Kokkos::DynRankView<ValueType,DeviceSpaceType> DynRankView;
+      typedef Kokkos::DynRankView<ValueType,DeviceType> DynRankView;
       typedef Kokkos::DynRankView<ValueType,HostSpaceType>   DynRankViewHost;
 #define ConstructWithLabel(obj, ...) obj(#obj, __VA_ARGS__)
 
@@ -119,7 +120,7 @@ namespace Intrepid2 {
       // for virtual function, value and point types are declared in the class
       typedef ValueType outputValueType;
       typedef ValueType pointValueType;
-      Basis_HGRAD_QUAD_C2_FEM<DeviceSpaceType,outputValueType,pointValueType> quadBasis;
+      Basis_HGRAD_QUAD_C2_FEM<DeviceType,outputValueType,pointValueType> quadBasis;
       //typedef typename decltype(quadBasis)::OutputViewType OutputViewType;
       //typedef typename decltype(quadBasis)::PointViewType  PointViewType;
 
@@ -512,7 +513,7 @@ namespace Intrepid2 {
         quadNodesHost(8,0) =  0.0;  quadNodesHost(8,1) =  0.0;
         quadNodesHost(9,0) =1./3.;  quadNodesHost(9,1) =-3./5.;
 
-        auto quadNodes = Kokkos::create_mirror_view(typename DeviceSpaceType::memory_space(), quadNodesHost);
+        auto quadNodes = Kokkos::create_mirror_view(typename DeviceType::memory_space(), quadNodesHost);
         Kokkos::deep_copy(quadNodes, quadNodesHost);
 
         // Dimensions for the output arrays:
@@ -761,7 +762,7 @@ namespace Intrepid2 {
         << "===============================================================================\n";
 
       try{
-        Basis_HGRAD_QUAD_C2_FEM<DeviceSpaceType> quadBasis;
+        Basis_HGRAD_QUAD_C2_FEM<DeviceType> quadBasis;
         const ordinal_type numFields = quadBasis.getCardinality();
         const ordinal_type spaceDim  = quadBasis.getBaseCellTopology().getDimension();
 

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TET_C2_FEM/Cuda/test_01.cpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TET_C2_FEM/Cuda/test_01.cpp
@@ -54,7 +54,7 @@ int main(int argc, char *argv[]) {
   const bool verbose = (argc-1) > 0;
   Kokkos::initialize();
 
-  const int r_val = Intrepid2::Test::HGRAD_TET_C2_FEM_Test01<double,Kokkos::Cuda>(verbose);
+  const int r_val = Intrepid2::Test::HGRAD_TET_C2_FEM_Test01<double,Kokkos::Device<Kokkos::Cuda,Kokkos::CudaSpace> >(verbose);
 
   Kokkos::finalize();
   return r_val;

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TET_C2_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TET_C2_FEM/test_01.hpp
@@ -72,7 +72,7 @@ namespace Test {
       *outStream << "-------------------------------------------------------------------------------" << "\n\n"; \
     }
 
-  template<typename ValueType, typename DeviceSpaceType>
+  template<typename ValueType, typename DeviceType>
   int HGRAD_TET_C2_FEM_Test01(const bool verbose) {
 
     Teuchos::RCP<std::ostream> outStream;
@@ -86,6 +86,7 @@ namespace Test {
     Teuchos::oblackholestream oldFormatState;
     oldFormatState.copyfmt(std::cout);
 
+    using DeviceSpaceType = typename DeviceType::execution_space;
     typedef typename
       Kokkos::Impl::is_space<DeviceSpaceType>::host_mirror_space::execution_space HostSpaceType ;
 
@@ -111,7 +112,7 @@ namespace Test {
     << "|                                                                             |\n"
     << "===============================================================================\n";
 
-    typedef Kokkos::DynRankView<ValueType,DeviceSpaceType> DynRankView;
+    typedef Kokkos::DynRankView<ValueType,DeviceType> DynRankView;
     typedef Kokkos::DynRankView<ValueType,HostSpaceType>   DynRankViewHost;
 #define ConstructWithLabel(obj, ...) obj(#obj, __VA_ARGS__)
 
@@ -121,7 +122,7 @@ namespace Test {
     // for virtual function, value and point types are declared in the class
     typedef ValueType outputValueType;
     typedef ValueType pointValueType;
-    Basis_HGRAD_TET_C2_FEM<DeviceSpaceType,outputValueType,pointValueType> tetBasis;
+    Basis_HGRAD_TET_C2_FEM<DeviceType,outputValueType,pointValueType> tetBasis;
 
   *outStream
     << "\n"
@@ -400,7 +401,7 @@ namespace Test {
     tetNodesHost(8,0) =  0.5;  tetNodesHost(8,1) =  0.0;  tetNodesHost(8,2) =  0.5;  
     tetNodesHost(9,0) =  0.0;  tetNodesHost(9,1) =  0.5;  tetNodesHost(9,2) =  0.5;  
 
-    auto tetNodes = Kokkos::create_mirror_view(typename DeviceSpaceType::memory_space(), tetNodesHost);
+    auto tetNodes = Kokkos::create_mirror_view(typename DeviceType::memory_space(), tetNodesHost);
     Kokkos::deep_copy(tetNodes, tetNodesHost);
         
     // Dimensions for the output arrays:

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TRI_C2_FEM/Cuda/test_01.cpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TRI_C2_FEM/Cuda/test_01.cpp
@@ -54,7 +54,7 @@ int main(int argc, char *argv[]) {
   const bool verbose = (argc-1) > 0;
   Kokkos::initialize();
 
-  const int r_val = Intrepid2::Test::HGRAD_TRI_C2_FEM_Test01<double,Kokkos::Cuda>(verbose);
+  const int r_val = Intrepid2::Test::HGRAD_TRI_C2_FEM_Test01<double,Kokkos::Device<Kokkos::Cuda,Kokkos::CudaSpace> >(verbose);
 
   Kokkos::finalize();
   return r_val;

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TRI_C2_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TRI_C2_FEM/test_01.hpp
@@ -73,7 +73,7 @@ namespace Intrepid2 {
     }
 
 
-    template<typename ValueType, typename DeviceSpaceType>
+    template<typename ValueType, typename DeviceType>
     int HGRAD_TRI_C2_FEM_Test01(const bool verbose) {
 
       Teuchos::RCP<std::ostream> outStream;
@@ -87,6 +87,7 @@ namespace Intrepid2 {
       Teuchos::oblackholestream oldFormatState;
       oldFormatState.copyfmt(std::cout);
 
+      using DeviceSpaceType = typename DeviceType::execution_space;
       typedef typename
         Kokkos::Impl::is_space<DeviceSpaceType>::host_mirror_space::execution_space HostSpaceType ;
 
@@ -112,7 +113,7 @@ namespace Intrepid2 {
         << "|                                                                             |\n" 
         << "===============================================================================\n";
 
-      typedef Kokkos::DynRankView<ValueType,DeviceSpaceType> DynRankView;
+      typedef Kokkos::DynRankView<ValueType,DeviceType> DynRankView;
       typedef Kokkos::DynRankView<ValueType,HostSpaceType>   DynRankViewHost;
 #define ConstructWithLabel(obj, ...) obj(#obj, __VA_ARGS__)
 
@@ -122,7 +123,7 @@ namespace Intrepid2 {
       // for virtual function, value and point types are declared in the class
       typedef ValueType outputValueType;
       typedef ValueType pointValueType;
-      Basis_HGRAD_TRI_C2_FEM<DeviceSpaceType,outputValueType,pointValueType> triBasis;
+      Basis_HGRAD_TRI_C2_FEM<DeviceType,outputValueType,pointValueType> triBasis;
       //typedef typename decltype(triBasis)::OutputViewType OutputViewType;
       //typedef typename decltype(triBasis)::PointViewType  PointViewType;
 
@@ -337,7 +338,7 @@ namespace Intrepid2 {
         triNodesHost(5,0) =  0.0;     triNodesHost(5,1) =  0.5;
         triNodesHost(6,0) =  0.1732;  triNodesHost(6,1) = 0.6714;
 
-        auto triNodes = Kokkos::create_mirror_view(typename DeviceSpaceType::memory_space(), triNodesHost);
+        auto triNodes = Kokkos::create_mirror_view(typename DeviceType::memory_space(), triNodesHost);
         Kokkos::deep_copy(triNodes,triNodesHost);
 
         // Dimensions for the output arrays:

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_WEDGE_C2_FEM/Cuda/test_01.cpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_WEDGE_C2_FEM/Cuda/test_01.cpp
@@ -54,7 +54,7 @@ int main(int argc, char *argv[]) {
   const bool verbose = (argc-1) > 0;
   Kokkos::initialize();
 
-  const int r_val = Intrepid2::Test::HGRAD_WEDGE_C2_FEM_Test01<double,Kokkos::Cuda>(verbose);
+  const int r_val = Intrepid2::Test::HGRAD_WEDGE_C2_FEM_Test01<double,Kokkos::Device<Kokkos::Cuda,Kokkos::CudaSpace> >(verbose);
 
   Kokkos::finalize();
   return r_val;

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_WEDGE_C2_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_WEDGE_C2_FEM/test_01.hpp
@@ -71,7 +71,7 @@ namespace Intrepid2 {
       *outStream << "-------------------------------------------------------------------------------" << "\n\n"; \
     }
     
-    template<typename ValueType, typename DeviceSpaceType>
+    template<typename ValueType, typename DeviceType>
     int HGRAD_WEDGE_C2_FEM_Test01(const bool verbose) {
       
       Teuchos::RCP<std::ostream> outStream;
@@ -85,6 +85,7 @@ namespace Intrepid2 {
       Teuchos::oblackholestream oldFormatState;
       oldFormatState.copyfmt(std::cout);
 
+      using DeviceSpaceType = typename DeviceType::execution_space;
       typedef typename
         Kokkos::Impl::is_space<DeviceSpaceType>::host_mirror_space::execution_space HostSpaceType ;
 
@@ -109,7 +110,7 @@ namespace Intrepid2 {
         << "|                                                                             |\n"
         << "===============================================================================\n";
 
-      typedef Kokkos::DynRankView<ValueType,DeviceSpaceType> DynRankView;
+      typedef Kokkos::DynRankView<ValueType,DeviceType> DynRankView;
       typedef Kokkos::DynRankView<ValueType,HostSpaceType>   DynRankViewHost;
 #define ConstructWithLabel(obj, ...) obj(#obj, __VA_ARGS__)
 
@@ -119,7 +120,7 @@ namespace Intrepid2 {
       // for virtual function, value and point types are declared in the class
       typedef ValueType outputValueType;
       typedef ValueType pointValueType;
-      Basis_HGRAD_WEDGE_C2_FEM<DeviceSpaceType,outputValueType,pointValueType> wedgeBasis;
+      Basis_HGRAD_WEDGE_C2_FEM<DeviceType,outputValueType,pointValueType> wedgeBasis;
 
       *outStream
         << "\n"
@@ -404,7 +405,7 @@ namespace Intrepid2 {
         wedgeNodesHost(16,0)=  0.5;  wedgeNodesHost(16,1)=  0.5;  wedgeNodesHost(16,2)=  0.0;  
         wedgeNodesHost(17,0)=  0.0;  wedgeNodesHost(17,1)=  0.5;  wedgeNodesHost(17,2)=  0.0;  
         
-        auto wedgeNodes = Kokkos::create_mirror_view(typename DeviceSpaceType::memory_space(), wedgeNodesHost);
+        auto wedgeNodes = Kokkos::create_mirror_view(typename DeviceType::memory_space(), wedgeNodesHost);
         Kokkos::deep_copy(wedgeNodes, wedgeNodesHost);
 
         // Dimensions for the output arrays:


### PR DESCRIPTION
## Motivation

UVM removal on HGRAD C2 basis functions

## Related Issues

#8310 

## Testing

Intrepid2 unit tests are passed on Weaver with ``Kokkos::Device<Kokkos::Cuda,Kokkos::CudaSpace>``
