### PR TITLE
Shylu: re-enable tests w/ MueLu as inexact subdomain solver

### DIFF
--- a/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_SubdomainSolver_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_SubdomainSolver_def.hpp
@@ -147,7 +147,7 @@ namespace FROSch {
                 }
             }
             MueLuHierarchy_ = MueLuFactory_->CreateHierarchy(); // Das vor den if block
-            MueLuHierarchy_->GetLevel(0)->Set("A",K_); // Das in den if block
+            MueLuHierarchy_->GetLevel(0)->Set("A", Teuchos::rcp_const_cast<XMatrix>(K_)); // Das in den if block
             MueLuHierarchy_->GetLevel(0)->Set("Nullspace", nullspace);
 #else
             ThrowErrorMissingPackage("FROSch::SubdomainSolver", "MueLu");

--- a/packages/shylu/shylu_dd/frosch/test/Thyra_Xpetra_Laplace/CMakeLists.txt
+++ b/packages/shylu/shylu_dd/frosch/test/Thyra_Xpetra_Laplace/CMakeLists.txt
@@ -244,15 +244,15 @@ COMM mpi
 NUM_MPI_PROCS 4
 )
 
-#IF(ShyLU_DDFROSch_ENABLE_MueLu)
-#  TRIBITS_ADD_TEST(
-#  thyra_xpetra_laplace
-#  NAME test_thyra_xpetra_laplace_TLP_GDSW_MUELU_DIM2_DPN2_ORD1_EPETRA
-#  ARGS "--M=3 --DIM=2 --O=1 --NB=1 --DPN=2 --ORD=1 --PLIST=ParameterLists/ParameterList_TwoLevelPreconditioner_GDSW_muelu.xml --USEEPETRA"
-#  COMM mpi
-#  NUM_MPI_PROCS 4
-#  )
-#ENDIF() # IF(ShyLU_DDFROSch_ENABLE_MueLu)
+IF(ShyLU_DDFROSch_ENABLE_MueLu)
+  TRIBITS_ADD_TEST(
+  thyra_xpetra_laplace
+  NAME test_thyra_xpetra_laplace_TLP_GDSW_MUELU_DIM2_DPN2_ORD1_EPETRA
+  ARGS "--M=3 --DIM=2 --O=1 --NB=1 --DPN=2 --ORD=1 --PLIST=ParameterLists/ParameterList_TwoLevelPreconditioner_GDSW_muelu.xml --USEEPETRA"
+  COMM mpi
+  NUM_MPI_PROCS 4
+  )
+ENDIF() # IF(ShyLU_DDFROSch_ENABLE_MueLu)
 
 TRIBITS_ADD_TEST(
 thyra_xpetra_laplace
@@ -305,15 +305,15 @@ COMM mpi
 NUM_MPI_PROCS 4
 )
 
-#IF(ShyLU_DDFROSch_ENABLE_MueLu)
-#  TRIBITS_ADD_TEST(
-#  thyra_xpetra_laplace
-#  NAME test_thyra_xpetra_laplace_TLP_GDSW_MUELU_DIM2_DPN2_ORD1_TPETRA
-#  ARGS "--M=3 --DIM=2 --O=1 --NB=1 --DPN=2 --ORD=1 --PLIST=ParameterLists/ParameterList_TwoLevelPreconditioner_GDSW_muelu.xml --USETPETRA"
-#  COMM mpi
-#  NUM_MPI_PROCS 4
-#  )
-#ENDIF() # IF(ShyLU_DDFROSch_ENABLE_MueLu)
+IF(ShyLU_DDFROSch_ENABLE_MueLu)
+  TRIBITS_ADD_TEST(
+  thyra_xpetra_laplace
+  NAME test_thyra_xpetra_laplace_TLP_GDSW_MUELU_DIM2_DPN2_ORD1_TPETRA
+  ARGS "--M=3 --DIM=2 --O=1 --NB=1 --DPN=2 --ORD=1 --PLIST=ParameterLists/ParameterList_TwoLevelPreconditioner_GDSW_muelu.xml --USETPETRA"
+  COMM mpi
+  NUM_MPI_PROCS 4
+  )
+ENDIF() # IF(ShyLU_DDFROSch_ENABLE_MueLu)
 
 TRIBITS_ADD_TEST(
 thyra_xpetra_laplace


### PR DESCRIPTION
@trilinos/shylu 
@searhein 

## Motivation

To cover the use of MueLu as inexact subdomain solver, two tests are re-activated. They solve a Laplace problem with FROSch, while using a MueLu hierarchy as subdomain solver.

As reported in #6390, MueLu does not accept `const` operators as input to the hierarchy construction. Hence, let's do a
`Teuchos::rcp_const_cast()` to get rid of the const qualifier prior to handing the matrix to MueLu.

## Related Issues

* Closes #8762 
* Related to #6390 

## Stakeholder Feedback

@searhein and I are looking into the use of MueLu as inexact subdomain solver within FROSch.

## Testing

Two tests have been reactivated.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->