### PR TITLE
Intrepid2 - add host basis function interface

### DIFF
--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_Basis.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_Basis.hpp
@@ -898,11 +898,14 @@ using BasisPtr = Teuchos::RCP<Basis<DeviceType,OutputType,PointType> >;
                                     ">>> ERROR (Basis::getSubCellRefBasis): this method is not supported or should be overridden accordingly by derived classes.");
     }
 
-    /// create a basis object living on host
+    /** \brief creates and returns a basis object living host.
+     
+        \return pointer to a basis living host.
+     */
     virtual BasisPtr<typename Kokkos::HostSpace::device_type, OutputValueType, PointValueType>
     getHostBasis() const {
       INTREPID2_TEST_FOR_EXCEPTION( true, std::logic_error,
-                                    ">>> ERROR (Basis::getSubCellRefBasis): this method is not supported or should be overridden accordingly by derived classes.");
+                                    ">>> ERROR (Basis::getHostBasis): this method is not supported or should be overridden accordingly by derived classes.");
     }
 
   }; // class Basis

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_Basis.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_Basis.hpp
@@ -898,6 +898,13 @@ using BasisPtr = Teuchos::RCP<Basis<DeviceType,OutputType,PointType> >;
                                     ">>> ERROR (Basis::getSubCellRefBasis): this method is not supported or should be overridden accordingly by derived classes.");
     }
 
+    /// create a basis object living on host
+    virtual BasisPtr<typename Kokkos::HostSpace::device_type, OutputValueType, PointValueType>
+    getHostBasis() const {
+      INTREPID2_TEST_FOR_EXCEPTION( true, std::logic_error,
+                                    ">>> ERROR (Basis::getSubCellRefBasis): this method is not supported or should be overridden accordingly by derived classes.");
+    }
+
   }; // class Basis
 
   //--------------------------------------------------------------------------------------------//

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_Basis.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_Basis.hpp
@@ -898,9 +898,9 @@ using BasisPtr = Teuchos::RCP<Basis<DeviceType,OutputType,PointType> >;
                                     ">>> ERROR (Basis::getSubCellRefBasis): this method is not supported or should be overridden accordingly by derived classes.");
     }
 
-    /** \brief creates and returns a basis object living host.
+    /** \brief creates and returns a basis object allocated on host.
      
-        \return pointer to a basis living host.
+        \return pointer to a basis allocated on host.
      */
     virtual BasisPtr<typename Kokkos::HostSpace::device_type, OutputValueType, PointValueType>
     getHostBasis() const {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_HEX_I1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_HEX_I1_FEM.hpp
@@ -288,6 +288,11 @@ namespace Intrepid2 {
       INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
     }
 
+    BasisPtr<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>
+    getHostBasis() const override{
+      return Teuchos::rcp(new Basis_HCURL_HEX_I1_FEM<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>());
+    }
+
   };
 }// namespace Intrepid2
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_HEX_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_HEX_In_FEM.hpp
@@ -286,6 +286,11 @@ namespace Intrepid2 {
       INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
     }
 
+    BasisPtr<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>
+    getHostBasis() const override{
+      return Teuchos::rcp(new Basis_HCURL_HEX_In_FEM<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>(this->basisDegree_, pointType_));
+    }
+
   private:
 
     /** \brief inverse of Generalized Vandermonde matrix (isotropic order) */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_QUAD_I1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_QUAD_I1_FEM.hpp
@@ -275,6 +275,11 @@ namespace Intrepid2 {
       INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
     }
 
+    BasisPtr<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>
+    getHostBasis() const override{
+      return Teuchos::rcp(new Basis_HCURL_QUAD_I1_FEM<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>());
+    }
+
   };
 }// namespace Intrepid2
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_QUAD_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_QUAD_In_FEM.hpp
@@ -269,10 +269,16 @@ namespace Intrepid2 {
       INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
     }
 
+    BasisPtr<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>
+    getHostBasis() const override{
+      return Teuchos::rcp(new Basis_HCURL_QUAD_In_FEM<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>(this->basisDegree_, pointType_));
+    }
+
   private:
 
     /** \brief inverse of Generalized Vandermonde matrix (isotropic order) */
     Kokkos::DynRankView<typename ScalarViewType::value_type,DeviceType> vinvLine_, vinvBubble_;
+    EPointType pointType_;
   };
   
 }// namespace Intrepid2

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_QUAD_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_QUAD_In_FEMDef.hpp
@@ -272,6 +272,7 @@ namespace Intrepid2 {
     this->basisType_         = BASIS_FEM_LAGRANGIAN;
     this->basisCoordinates_  = COORDINATES_CARTESIAN;
     this->functionSpace_     = FUNCTION_SPACE_HCURL;
+    pointType_ = pointType;
 
     // initialize tags
     {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TET_I1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TET_I1_FEM.hpp
@@ -281,6 +281,12 @@ namespace Intrepid2 {
       INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
     }
 
+    BasisPtr<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>
+    getHostBasis() const override{
+      return Teuchos::rcp(new Basis_HCURL_TET_I1_FEM<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>());
+    }                                                                                                                                                                                                                                         
+    
+
   };
 }// namespace Intrepid2
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TET_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TET_In_FEM.hpp
@@ -318,6 +318,11 @@ class Basis_HCURL_TET_In_FEM
     INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
   }
 
+  BasisPtr<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>
+  getHostBasis() const override{
+    return Teuchos::rcp(new Basis_HCURL_TET_In_FEM<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>(this->basisDegree_, pointType_));
+  }  
+
     private:
 
   /** \brief expansion coefficients of the nodal basis in terms of the

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_I1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_I1_FEM.hpp
@@ -279,6 +279,10 @@ namespace Intrepid2 {
       INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
     }
 
+    BasisPtr<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>
+    getHostBasis() const override{
+      return Teuchos::rcp(new Basis_HCURL_TRI_I1_FEM<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>());
+    }
   };
 
 }// namespace Intrepid2

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_In_FEM.hpp
@@ -304,6 +304,10 @@ class Basis_HCURL_TRI_In_FEM
     INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
   }
 
+  BasisPtr<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>
+  getHostBasis() const override{
+    return Teuchos::rcp(new Basis_HCURL_TRI_In_FEM<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>(this->basisDegree_, pointType_));
+  }
     private:
 
   /** \brief expansion coefficients of the nodal basis in terms of the

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_WEDGE_I1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_WEDGE_I1_FEM.hpp
@@ -291,6 +291,10 @@ namespace Intrepid2 {
       INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
     }
 
+    BasisPtr<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>
+    getHostBasis() const override{
+      return Teuchos::rcp(new Basis_HCURL_WEDGE_I1_FEM<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>());
+    }
   };
 }// namespace Intrepid2
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_HEX_I1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_HEX_I1_FEM.hpp
@@ -287,7 +287,10 @@ namespace Intrepid2 {
       }
       INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
     }
-
+    BasisPtr<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>
+    getHostBasis() const override{
+      return Teuchos::rcp(new Basis_HDIV_HEX_I1_FEM<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>());
+    }
   };
 
 }// namespace Intrepid2

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_HEX_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_HEX_In_FEM.hpp
@@ -273,10 +273,15 @@ namespace Intrepid2 {
       INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
     }
 
+    BasisPtr<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>
+    getHostBasis() const override{
+      return Teuchos::rcp(new Basis_HDIV_HEX_In_FEM<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>(this->basisDegree_, pointType_));
+    }
   private:
 
     /** \brief inverse of Generalized Vandermonde matrix (isotropic order) */
     Kokkos::DynRankView<typename ScalarViewType::value_type,DeviceType> vinvLine_, vinvBubble_;
+    EPointType pointType_;
   };
 
 }// namespace Intrepid2

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_HEX_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_HEX_In_FEMDef.hpp
@@ -348,6 +348,7 @@ namespace Intrepid2 {
     this->basisType_         = BASIS_FEM_LAGRANGIAN;
     this->basisCoordinates_  = COORDINATES_CARTESIAN;
     this->functionSpace_     = FUNCTION_SPACE_HDIV;
+    pointType_ = pointType;
 
     // initialize tags
     {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_QUAD_I1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_QUAD_I1_FEM.hpp
@@ -276,6 +276,10 @@ namespace Intrepid2 {
       INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
     }
 
+    BasisPtr<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>
+    getHostBasis() const override{
+      return Teuchos::rcp(new Basis_HDIV_QUAD_I1_FEM<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>());
+    }
   };
 
 }// namespace Intrepid2

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_QUAD_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_QUAD_In_FEM.hpp
@@ -267,10 +267,16 @@ namespace Intrepid2 {
       INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
     }
 
+    BasisPtr<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>
+    getHostBasis() const override{
+      return Teuchos::rcp(new Basis_HDIV_QUAD_In_FEM<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>(this->basisDegree_, pointType_));
+    }
   private:
 
     /** \brief inverse of Generalized Vandermonde matrix (isotropic order) */
     Kokkos::DynRankView<typename ScalarViewType::value_type,DeviceType> vinvLine_, vinvBubble_;
+    EPointType pointType_;
+
   };
 
 }// namespace Intrepid2

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_QUAD_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_QUAD_In_FEMDef.hpp
@@ -271,6 +271,7 @@ namespace Intrepid2 {
     this->basisType_         = BASIS_FEM_LAGRANGIAN;
     this->basisCoordinates_  = COORDINATES_CARTESIAN;
     this->functionSpace_     = FUNCTION_SPACE_HDIV;
+    pointType_ = pointType;
 
     // initialize tags
     {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TET_I1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TET_I1_FEM.hpp
@@ -275,6 +275,10 @@ namespace Intrepid2 {
       INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
     }
 
+    BasisPtr<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>
+    getHostBasis() const override{
+      return Teuchos::rcp(new Basis_HDIV_TET_I1_FEM<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>());
+    }
   };
 
 }// namespace Intrepid2

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TET_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TET_In_FEM.hpp
@@ -309,6 +309,10 @@ getValues<DeviceType,numPtsPerEval>( outputValues,
     INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
   }
 
+  BasisPtr<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>
+  getHostBasis() const override{
+    return Teuchos::rcp(new Basis_HDIV_TET_In_FEM<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>(this->basisDegree_, pointType_));
+  }
     private:
 
   /** \brief expansion coefficients of the nodal basis in terms of the

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TRI_I1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TRI_I1_FEM.hpp
@@ -272,6 +272,10 @@ namespace Intrepid2 {
       INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
     }
 
+    BasisPtr<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>
+    getHostBasis() const override{
+      return Teuchos::rcp(new Basis_HDIV_TRI_I1_FEM<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>());
+    }
   };
 
 }// namespace Intrepid2

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TRI_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TRI_In_FEM.hpp
@@ -311,6 +311,10 @@ class Basis_HDIV_TRI_In_FEM
     INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
   }
 
+  BasisPtr<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>
+  getHostBasis() const override{
+    return Teuchos::rcp(new Basis_HDIV_TRI_In_FEM<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>(this->basisDegree_, pointType_));
+  }
     private:
 
   /** \brief expansion coefficients of the nodal basis in terms of the

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_WEDGE_I1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_WEDGE_I1_FEM.hpp
@@ -262,6 +262,11 @@ namespace Intrepid2 {
       INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
     }
 
+
+    BasisPtr<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>
+    getHostBasis() const override{
+      return Teuchos::rcp(new Basis_HDIV_WEDGE_I1_FEM<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>());
+    }
   };
 }// namespace Intrepid2
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C1_FEM.hpp
@@ -261,6 +261,10 @@ namespace Intrepid2 {
       INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
     }
 
+    BasisPtr<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>
+    getHostBasis() const override{
+      return Teuchos::rcp(new Basis_HGRAD_HEX_C1_FEM<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>());
+    }
   };
 }// namespace Intrepid2
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_Cn_FEM.hpp
@@ -287,6 +287,10 @@ namespace Intrepid2 {
       INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
     }
 
+    BasisPtr<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>
+    getHostBasis() const override{
+      return Teuchos::rcp(new Basis_HGRAD_HEX_Cn_FEM<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>(this->basisDegree_, pointType_));
+    }
   };
 
 }// namespace Intrepid2

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_C1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_C1_FEM.hpp
@@ -249,6 +249,10 @@ namespace Intrepid2 {
       INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
     }
 
+    BasisPtr<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>
+    getHostBasis() const override {
+      return Teuchos::rcp(new Basis_HGRAD_QUAD_C1_FEM<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>());
+    }  
   };
 }// namespace Intrepid2
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_Cn_FEM.hpp
@@ -280,6 +280,10 @@ namespace Intrepid2 {
       INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
     }
 
+    BasisPtr<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>
+    getHostBasis() const override{
+      return Teuchos::rcp(new Basis_HGRAD_QUAD_Cn_FEM<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>(this->basisDegree_, pointType_));
+    }  
   };
 
 }// namespace Intrepid2

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_C1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_C1_FEM.hpp
@@ -249,6 +249,10 @@ namespace Intrepid2 {
       INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
     }
 
+    BasisPtr<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>
+    getHostBasis() const override{
+      return Teuchos::rcp(new Basis_HGRAD_TET_C1_FEM<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>());
+    }
   };
 }// namespace Intrepid2
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEM.hpp
@@ -288,6 +288,7 @@ namespace Intrepid2 {
     }
 
     Kokkos::DynRankView<typename ScalarViewType::const_value_type,Devicetype>
+
     getVandermondeInverse() const {
       return vinv_;
     }
@@ -328,6 +329,10 @@ namespace Intrepid2 {
       INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
     }
 
+    BasisPtr<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>
+    getHostBasis() const override{
+      return Teuchos::rcp(new Basis_HGRAD_TET_Cn_FEM<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>(this->basisDegree_, pointType_));
+    }
   };
 
 }// namespace Intrepid2

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_C1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_C1_FEM.hpp
@@ -244,6 +244,10 @@ namespace Intrepid2 {
       INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
     }
 
+    BasisPtr<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>
+    getHostBasis() const override{
+      return Teuchos::rcp(new Basis_HGRAD_TRI_C1_FEM<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>());
+    }  
   };
 
 }// namespace Intrepid2

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEM.hpp
@@ -316,6 +316,10 @@ namespace Intrepid2 {
       INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
     }
 
+    BasisPtr<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>
+    getHostBasis() const override{
+      return Teuchos::rcp(new Basis_HGRAD_TRI_Cn_FEM<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>(this->basisDegree_, pointType_));
+    }
   };
 
 }// namespace Intrepid2


### PR DESCRIPTION

## Motivation

Add host basis function interface. This is required for orientation tools. I also expect that this can be useful for other purpose as well. 

## Related Issues

#8310 
#8772 - This PR is closed as it depends on the get host basis interface of all.

## Testing

tested on weaver.
