### PR TITLE
sems-rhel7 env:  Add clang-10.0.0

### DIFF
--- a/cmake/std/atdm/sems-rhel7/all_supported_builds.sh
+++ b/cmake/std/atdm/sems-rhel7/all_supported_builds.sh
@@ -3,8 +3,8 @@
 export ATDM_CONFIG_CTEST_S_BUILD_NAME_PREFIX=Trilinos-atdm-
 
 export ATDM_CONFIG_ALL_SUPPORTED_BUILDS=(
-  sems-rhel7-clang-7.0.1-openmp-shared-release
-  sems-rhel7-clang-7.0.1-openmp-shared-release-debug
+  sems-rhel7-clang-10.0.0-openmp-shared-release
+  sems-rhel7-clang-10.0.0-openmp-shared-release-debug
   sems-rhel7-cuda-9.2-Volta70-complex-shared-release-debug
   sems-rhel7-gnu-7.2.0-openmp-complex-shared-release-debug
   sems-rhel7-intel-18.0.5-openmp-complex-shared-release-debug

--- a/cmake/std/atdm/sems-rhel7/environment.sh
+++ b/cmake/std/atdm/sems-rhel7/environment.sh
@@ -13,14 +13,18 @@
 if [ "$ATDM_CONFIG_COMPILER" == "DEFAULT" ] ; then
   export ATDM_CONFIG_COMPILER=GNU-7.2.0
 elif [[ "$ATDM_CONFIG_COMPILER" == "CLANG"* ]]; then
-  if [[ "$ATDM_CONFIG_COMPILER" == "CLANG" ]] ; then
+  if [[ "$ATDM_CONFIG_COMPILER" == "CLANG" || \
+        "$ATDM_CONFIG_COMPILER" == "CLANG-10.0.0" ]] ; then
+    export ATDM_CONFIG_COMPILER=CLANG-10.0.0
+  elif [[ "$ATDM_CONFIG_COMPILER" == "CLANG-7.0.1" ]] ; then
     export ATDM_CONFIG_COMPILER=CLANG-7.0.1
-  elif [[ "$ATDM_CONFIG_COMPILER" != "CLANG-7.0.1" ]] ; then
+  else
     echo
     echo "***"
     echo "*** ERROR: CLANG COMPILER=$ATDM_CONFIG_COMPILER is not supported!"
     echo "*** Only CLANG compilers supported on this system are:"
-    echo "***   clang (defaults to clang-7.0.1)"
+    echo "***   clang (defaults to clang-10.0.0)"
+    echo "***   clang-10.0.0"
     echo "***   clang-7.0.1"
     echo "***"
     return
@@ -144,7 +148,14 @@ else
   export OMP_NUM_THREADS=1
 fi
 
-if [[ "$ATDM_CONFIG_COMPILER" == "CLANG-7.0.1" ]] ; then
+if [[ "$ATDM_CONFIG_COMPILER" == "CLANG-10.0.0" ]] ; then
+  module load sems-clang/10.0.0
+  export OMPI_CXX=`which clang++`
+  export OMPI_CC=`which clang`
+  export OMPI_FC=`which gfortran`
+  export ATDM_CONFIG_LAPACK_LIBS="/usr/lib64/liblapack.so.3"
+  export ATDM_CONFIG_BLAS_LIBS="/usr/lib64/libblas.so.3"
+elif [[ "$ATDM_CONFIG_COMPILER" == "CLANG-7.0.1" ]] ; then
   module load sems-clang/7.0.1
   export OMPI_CXX=`which clang++`
   export OMPI_CC=`which clang`

--- a/cmake/std/atdm/utils/set_build_options.sh
+++ b/cmake/std/atdm/utils/set_build_options.sh
@@ -142,6 +142,8 @@ elif atdm_match_buildname_keyword clang-5.0.1; then
   export ATDM_CONFIG_COMPILER=CLANG-5.0.1
 elif atdm_match_buildname_keyword clang-7.0.1; then
   export ATDM_CONFIG_COMPILER=CLANG-7.0.1
+elif atdm_match_buildname_keyword clang-10.0.0; then
+  export ATDM_CONFIG_COMPILER=CLANG-10.0.0
 elif atdm_match_buildname_keyword clang; then
   export ATDM_CONFIG_COMPILER=CLANG
 else


### PR DESCRIPTION
## Motivation
From @rppawlo:
> Trilinos is looking to retire the clang 7 PR build. We are already running clang 10 in PR testing. I notice that the empire testing is using clang 7. Can Trilinos drop clang 7 testing? Should we wait until empire upgrades? What kind of schedule would that look like?

This PR updates the default clang in the `sems-rhel7` environment from `7.0.1` to `10.0.0`.

## Testing
Trying this out on an ascic machine, it seems to work just fine.

## Potential Concerns
* @e10harvey, I don't know if `sems-rhel7/all_supported_builds.sh` should be updated as well&mdash;I'm not sure what that file is used for.  If you want me to update it, let me know.
* Additionally, I wasn't sure if we should update the `cee-rhel7` environment as well, as the initial request was just for the sake of EMPIRE.  If you want me to update that env at the same time, let me know.
* BTW, I don't know how this might affect any of the ATDM nightly builds.