### PR TITLE
Shylu: use scoped enum to encode NullSpaceType

### DIFF
--- a/packages/shylu/shylu_dd/frosch/src/SchwarzPreconditioners/FROSch_TwoLevelBlockPreconditioner_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SchwarzPreconditioners/FROSch_TwoLevelBlockPreconditioner_def.hpp
@@ -208,16 +208,16 @@ namespace FROSch {
             // Build Null Space
             if (!this->ParameterList_->get("Null Space Type","Stokes").compare("Stokes")) {
                 nullSpaceBasisVec.resize(2);
-                nullSpaceBasisVec[0] = BuildNullSpace<SC,LO,GO,NO>(dimension,LaplaceNullSpace,repeatedMapVec[0],dofsPerNodeVec[0],dofsMapsVec[0]);
-                nullSpaceBasisVec[1] = BuildNullSpace<SC,LO,GO,NO>(dimension,LaplaceNullSpace,repeatedMapVec[1],dofsPerNodeVec[1],dofsMapsVec[1]);
+                nullSpaceBasisVec[0] = BuildNullSpace<SC,LO,GO,NO>(dimension,NullSpaceType::Laplace,repeatedMapVec[0],dofsPerNodeVec[0],dofsMapsVec[0]);
+                nullSpaceBasisVec[1] = BuildNullSpace<SC,LO,GO,NO>(dimension,NullSpaceType::Laplace,repeatedMapVec[1],dofsPerNodeVec[1],dofsMapsVec[1]);
             } if (!this->ParameterList_->get("Null Space Type","Stokes").compare("Linear Elasticity")) {
               nullSpaceBasisVec.resize(repeatedMapVec.size());
               for (int i = 0;i<repeatedMapVec.size();i++) {
-                nullSpaceBasisVec[i] = BuildNullSpace(dimension,LinearElasticityNullSpace,repeatedMapVec[i],dofsPerNodeVec[i],dofsMapsVec[i],nodeListVec[i]);
+                nullSpaceBasisVec[i] = BuildNullSpace(dimension,NullSpaceType::Elasticity,repeatedMapVec[i],dofsPerNodeVec[i],dofsMapsVec[i],nodeListVec[i]);
               }
             }if (!this->ParameterList_->get("Null Space Type","Stokes").compare("Laplace")) {
               nullSpaceBasisVec.resize(1);
-              nullSpaceBasisVec[0] = BuildNullSpace<SC,LO,GO,NO>(dimension,LaplaceNullSpace,repeatedMapVec[0],dofsPerNodeVec[0],dofsMapsVec[0]);
+              nullSpaceBasisVec[0] = BuildNullSpace<SC,LO,GO,NO>(dimension,NullSpaceType::Laplace,repeatedMapVec[0],dofsPerNodeVec[0],dofsMapsVec[0]);
             }else if (!this->ParameterList_->get("Null Space Type","Stokes").compare("Input")) {
                 FROSCH_ASSERT(!nullSpaceBasisVec.is_null(),"Null Space Type is 'Input', but nullSpaceBasis.is_null().");
             } else {
@@ -373,17 +373,17 @@ namespace FROSch {
             // Build Null Space
             if (!this->ParameterList_->get("Null Space Type","Stokes").compare("Stokes")) {
                 nullSpaceBasisVec.resize(2);
-                nullSpaceBasisVec[0] = BuildNullSpace<SC,LO,GO,NO>(dimension,LaplaceNullSpace,repeatedMapVec[0],dofsPerNodeVec[0],dofsMapsVec[0]);
-                nullSpaceBasisVec[1] = BuildNullSpace<SC,LO,GO,NO>(dimension,LaplaceNullSpace,repeatedMapVec[1],dofsPerNodeVec[1],dofsMapsVec[1]);
+                nullSpaceBasisVec[0] = BuildNullSpace<SC,LO,GO,NO>(dimension,NullSpaceType::Laplace,repeatedMapVec[0],dofsPerNodeVec[0],dofsMapsVec[0]);
+                nullSpaceBasisVec[1] = BuildNullSpace<SC,LO,GO,NO>(dimension,NullSpaceType::Laplace,repeatedMapVec[1],dofsPerNodeVec[1],dofsMapsVec[1]);
             } else if (!this->ParameterList_->get("Null Space Type","Stokes").compare("Linear Elasticity")) {
               nullSpaceBasisVec.resize(repeatedMapVec.size());
               for (int i = 0;i<repeatedMapVec.size();i++) {
-                nullSpaceBasisVec[i] = BuildNullSpace(dimension,LinearElasticityNullSpace,repeatedMapVec[i],dofsPerNodeVec[i],dofsMapsVec[i],nodeListVec[i]);
+                nullSpaceBasisVec[i] = BuildNullSpace(dimension,NullSpaceType::Elasticity,repeatedMapVec[i],dofsPerNodeVec[i],dofsMapsVec[i],nodeListVec[i]);
 
               }
             }else if (!this->ParameterList_->get("Null Space Type","Stokes").compare("Laplace")) {
               nullSpaceBasisVec.resize(1);
-              nullSpaceBasisVec[0] = BuildNullSpace<SC,LO,GO,NO>(dimension,LaplaceNullSpace,repeatedMapVec[0],dofsPerNodeVec[0],dofsMapsVec[0]);
+              nullSpaceBasisVec[0] = BuildNullSpace<SC,LO,GO,NO>(dimension,NullSpaceType::Laplace,repeatedMapVec[0],dofsPerNodeVec[0],dofsMapsVec[0]);
             }else if (!this->ParameterList_->get("Null Space Type","Stokes").compare("Input")) {
                 FROSCH_ASSERT(!nullSpaceBasisVec.is_null(),"Null Space Type is 'Input', but nullSpaceBasis.is_null().");
             } else {

--- a/packages/shylu/shylu_dd/frosch/src/SchwarzPreconditioners/FROSch_TwoLevelPreconditioner_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SchwarzPreconditioners/FROSch_TwoLevelPreconditioner_def.hpp
@@ -192,9 +192,9 @@ namespace FROSch {
         if (!this->ParameterList_->get("CoarseOperator Type","IPOUHarmonicCoarseOperator").compare("IPOUHarmonicCoarseOperator")) {
             // Build Null Space
             if (!this->ParameterList_->get("Null Space Type","Laplace").compare("Laplace")) {
-                nullSpaceBasis = BuildNullSpace<SC,LO,GO,NO>(dimension,LaplaceNullSpace,repeatedMap,dofsPerNode,dofsMaps);
+                nullSpaceBasis = BuildNullSpace<SC,LO,GO,NO>(dimension,NullSpaceType::Laplace,repeatedMap,dofsPerNode,dofsMaps);
             } else if (!this->ParameterList_->get("Null Space Type","Laplace").compare("Linear Elasticity")) {
-                nullSpaceBasis = BuildNullSpace(dimension,LinearElasticityNullSpace,repeatedMap,dofsPerNode,dofsMaps,nodeList);
+                nullSpaceBasis = BuildNullSpace(dimension,NullSpaceType::Elasticity,repeatedMap,dofsPerNode,dofsMaps,nodeList);
             } else if (!this->ParameterList_->get("Null Space Type","Laplace").compare("Input")) {
                 FROSCH_ASSERT(!nullSpaceBasis.is_null(),"Null Space Type is 'Input', but nullSpaceBasis.is_null().");
                 ConstXMapPtr nullSpaceBasisMap = nullSpaceBasis->getMap();

--- a/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_Tools_decl.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_Tools_decl.hpp
@@ -81,7 +81,11 @@ namespace FROSch {
 
     enum DofOrdering {NodeWise=0,DimensionWise=1,Custom=2};
 
-    enum NullSpace {LaplaceNullSpace=0,LinearElasticityNullSpace=1};
+    enum class NullSpaceType
+    {
+      Laplace = 0,
+      Elasticity = 1
+    };
 
         enum Verbosity {None=0,All=1};
 
@@ -335,7 +339,7 @@ namespace FROSch {
 
     template <class SC, class LO,class GO,class NO>
     RCP<const MultiVector<SC,LO,GO,NO> > BuildNullSpace(unsigned dimension,
-                                                        unsigned nullSpaceType,
+                                                        const NullSpaceType nullSpaceType,
                                                         RCP<const Map<LO,GO,NO> > repeatedMap,
                                                         unsigned dofsPerNode,
                                                         ArrayRCP<RCP<const Map<LO,GO,NO> > > dofsMaps,

--- a/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_Tools_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_Tools_def.hpp
@@ -1315,7 +1315,7 @@ namespace FROSch {
 
     template <class SC, class LO,class GO,class NO>
     RCP<const MultiVector<SC,LO,GO,NO> > BuildNullSpace(unsigned dimension,
-                                                        unsigned nullSpaceType,
+                                                        const NullSpaceType nullSpaceType,
                                                         RCP<const Map<LO,GO,NO> > repeatedMap,
                                                         unsigned dofsPerNode,
                                                         ArrayRCP<RCP<const Map<LO,GO,NO> > > dofsMaps,
@@ -1328,14 +1328,14 @@ namespace FROSch {
         FROSCH_ASSERT(dofsMaps.size()==dofsPerNode,"dofsMaps.size()!=dofsPerNode.");
 
         RCP<MultiVector<SC,LO,GO,NO> > nullSpaceBasis;
-        if (nullSpaceType==0) { // n-dimensional Laplace
+        if (nullSpaceType == NullSpaceType::Laplace) {
             nullSpaceBasis = MultiVectorFactory<SC,LO,GO,NO>::Build(repeatedMap,dofsPerNode);
             for (unsigned i=0; i<dofsPerNode; i++) {
                 for (unsigned j=0; j<dofsMaps[i]->getNodeNumElements(); j++) {
                     nullSpaceBasis->getDataNonConst(i)[repeatedMap->getLocalElement(dofsMaps[i]->getGlobalElement(j))] = ScalarTraits<SC>::one();
                 }
             }
-        } else if (nullSpaceType==1) { // linear elasticity
+        } else if (nullSpaceType == NullSpaceType::Elasticity) {
             FROSCH_ASSERT(!nodeList.is_null(),"nodeList.is_null()==true. Cannot build the null space for linear elasticity.");
             FROSCH_ASSERT(nodeList->getNumVectors()==dimension,"nodeList->getNumVectors()!=dimension.");
             FROSCH_ASSERT(dofsPerNode==dimension,"dofsPerNode==dimension.");


### PR DESCRIPTION
@trilinos/shylu 
@searhein 

## Motivation

As @searhein and I discovered today, some places don't use the `enum`, but an `int` to encode the type of nullspace. By introduction of an `enum class NullSpaceType`, one is forced to use the scoped `enum` instead of the plain `int`.

This also adapts all calls to `BuildNullSpace()`.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


<!--- 
## Stakeholder Feedback

If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing

All existing tests pass.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->