### PR TITLE
Patch in KokkosKernels #872

### DIFF
--- a/packages/kokkos-kernels/test_common/Test_Common_Sorting.hpp
+++ b/packages/kokkos-kernels/test_common/Test_Common_Sorting.hpp
@@ -544,7 +544,7 @@ void testBitonicSortLexicographic()
 }
 
 template<typename exec_space>
-void testSortCRS(default_lno_t numRows, default_size_type nnz, bool doValues)
+void testSortCRS(default_lno_t numRows, default_lno_t numCols, default_size_type nnz, bool doValues)
 {
   using scalar_t = default_scalar;
   using lno_t = default_lno_t;
@@ -559,7 +559,7 @@ void testSortCRS(default_lno_t numRows, default_size_type nnz, bool doValues)
   //IMPORTANT: kk_generate_sparse_matrix does not sort the rows, if it did this
   //wouldn't test anything
   crsMat_t A = KokkosKernels::Impl::kk_generate_sparse_matrix<crsMat_t>
-    (numRows, numRows, nnz, 2, numRows / 2);
+    (numRows, numCols, nnz, 2, numCols / 2);
   auto rowmap = A.graph.row_map;
   auto entries = A.graph.entries;
   auto values = A.values;
@@ -774,15 +774,20 @@ TEST_F( TestCategory, common_device_bitonic) {
 }
 
 TEST_F( TestCategory, common_sort_crsgraph) {
-  testSortCRS<TestExecSpace>(10, 20, false);
-  testSortCRS<TestExecSpace>(100, 2000, false);
-  testSortCRS<TestExecSpace>(1000, 30000, false);
+  testSortCRS<TestExecSpace>(10, 10, 20, false);
+  testSortCRS<TestExecSpace>(100, 100, 2000, false);
+  testSortCRS<TestExecSpace>(1000, 1000, 30000, false);
 }
 
 TEST_F( TestCategory, common_sort_crsmatrix) {
-  testSortCRS<TestExecSpace>(10, 20, true);
-  testSortCRS<TestExecSpace>(100, 2000, true);
-  testSortCRS<TestExecSpace>(1000, 30000, true);
+  testSortCRS<TestExecSpace>(10, 10, 20, true);
+  testSortCRS<TestExecSpace>(100, 100, 2000, true);
+  testSortCRS<TestExecSpace>(1000, 1000, 30000, true);
+}
+
+TEST_F( TestCategory, common_sort_crs_longrows) {
+  testSortCRS<TestExecSpace>(1, 50000, 10000, false);
+  testSortCRS<TestExecSpace>(1, 50000, 10000, true);
 }
 
 TEST_F( TestCategory, common_sort_merge_crsmatrix) {


### PR DESCRIPTION
(fix #8727, TeamPolicy team size too large in sort_crs_*)
Adds the KokkosKernels unit test that replicated this issue.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/kokkos-kernels 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Fixes bug in sort_crs_matrix/sort_crs_graph for an input graph with a high average degree. It was constructing a TeamPolicy with the desired number of threads per team, just to ask Kokkos for the recommended team size. Instead, this policy should just use 1 thread per team.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:
-->

## Related Issues

* Closes #8727 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of https://github.com/kokkos/kokkos-kernels/pull/872


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
This bug was affecting Exawind.
## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
This PR includes a unit test in KokkosKernels which calls sort_crs_graph and sort_crs_matrix with a matrix with very long rows, which replicated the bug before the fix was applied.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->