### PR TITLE
Fix to NOX/LOCA

### DIFF
--- a/packages/nox/src-loca/src-tpetra/LOCA_BorderedSolver_TpetraHouseholder.cpp
+++ b/packages/nox/src-loca/src-tpetra/LOCA_BorderedSolver_TpetraHouseholder.cpp
@@ -271,7 +271,7 @@ setMatrixBlocks(const Teuchos::RCP<const LOCA::BorderedSolver::AbstractOperator>
 
     // Get linear system, and jacobian
     //ROGER linSys = grp->getLinearSystem();
-    using ttlop = ::Thyra::TpetraLinearOp<NOX::Scalar,NOX::LocalOrdinal,NOX::GlobalOrdinal>;
+    using ttlop = ::Thyra::TpetraLinearOp<NOX::Scalar,NOX::LocalOrdinal,NOX::GlobalOrdinal,NOX::NodeType>;
     auto constTpetraOperator = Teuchos::rcp_dynamic_cast<const ttlop>(grp->getJacobianOperator(),true);
     tpetraOp = Teuchos::rcp_const_cast<ttlop>(constTpetraOperator)->getTpetraOperator();
   }


### PR DESCRIPTION
NOX:NodeType not specified in type being cast to.
Fixes inability to compile using clang. 

NOX:NodeType not being specified was producing a cast-to type with Kokkos::Serial, while specifying it produces a cast-to type with Kokkos::Threads.

@trilinos/nox 