### PR TITLE
Added viable overload '=' for Zoltan2_AlgMultiJagged

### DIFF
--- a/packages/zoltan2/core/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
+++ b/packages/zoltan2/core/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
@@ -3541,6 +3541,11 @@ struct Zoltan2_MJArrayType {
 
   KOKKOS_INLINE_FUNCTION
   Zoltan2_MJArrayType(scalar_t * pSetPtr) : ptr(pSetPtr) {};
+
+  Zoltan2_MJArrayType<scalar_t>& operator=(const volatile Zoltan2_MJArrayType<scalar_t>& zmj) {
+      ptr = zmj.ptr;
+      return *this;
+  }
 };
 
 #ifndef KOKKOS_ENABLE_CUDA


### PR DESCRIPTION
Added assignment operator to Zoltan2_MJArrayType to fix error compiling with Clang on mac.

Error this fixes below:

```
=====================
/Users/pakuber/Compadre/trilinos/packages/kokkos/core/src/Threads/Kokkos_ThreadsTeam.hpp:312:25: error: no viable
      overloaded '='
    reducer.reference() = *((type volatile const*)local_value);
    ~~~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/pakuber/Compadre/trilinos/packages/kokkos/core/src/Threads/Kokkos_ThreadsTeam.hpp:975:26: note: in
      instantiation of function template specialization
      'Kokkos::Impl::ThreadsExecTeamMember::team_reduce<Zoltan2::ArrayCombinationReducer<Kokkos::TeamPolicy<Kokkos::Threads>,
      double, int> >' requested here
  loop_boundaries.thread.team_reduce(reducer, value);
                         ^
/Users/pakuber/Compadre/trilinos/packages/zoltan2/core/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp:3793:13: note: 
      in instantiation of function template specialization 'Kokkos::parallel_reduce<int, (lambda at
      /Users/pakuber/Compadre/trilinos/packages/zoltan2/core/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp:3795:7),
      Zoltan2::ArrayCombinationReducer<Kokkos::TeamPolicy<Kokkos::Threads>, double, int> >' requested here
    Kokkos::parallel_reduce(
            ^
/Users/pakuber/Compadre/trilinos/packages/kokkos/core/src/Threads/Kokkos_Threads_Parallel.hpp:738:7: note: in
      instantiation of member function 'Zoltan2::ReduceWeightsFunctor<Kokkos::TeamPolicy<Kokkos::Threads>, double,
      int, int, Kokkos::Device<Kokkos::Threads, Kokkos::HostSpace>, double>::operator()' requested here
      functor(member, update);
      ^
/Users/pakuber/Compadre/trilinos/packages/kokkos/core/src/Threads/Kokkos_Threads_Parallel.hpp:756:30: note: in
      instantiation of function template specialization
      'Kokkos::Impl::ParallelReduce<Zoltan2::ReduceWeightsFunctor<Kokkos::TeamPolicy<Kokkos::Threads>, double, int,
      int, Kokkos::Device<Kokkos::Threads, Kokkos::HostSpace>, double>, Kokkos::TeamPolicy<Kokkos::Threads>,
      Kokkos::InvalidType, Kokkos::Threads>::exec_team<void>' requested here
    ParallelReduce::template exec_team<WorkTag>(
                             ^
/Users/pakuber/Compadre/trilinos/packages/kokkos/core/src/Threads/Kokkos_Threads_Parallel.hpp:781:43: note: in
      instantiation of member function
      'Kokkos::Impl::ParallelReduce<Zoltan2::ReduceWeightsFunctor<Kokkos::TeamPolicy<Kokkos::Threads>, double, int,
      int, Kokkos::Device<Kokkos::Threads, Kokkos::HostSpace>, double>, Kokkos::TeamPolicy<Kokkos::Threads>,
      Kokkos::InvalidType, Kokkos::Threads>::exec' requested here
      ThreadsExec::start(&ParallelReduce::exec, this);
                                          ^
/Users/pakuber/Compadre/trilinos/packages/kokkos/core/src/Kokkos_Parallel_Reduce.hpp:877:13: note: (skipping 4
      contexts in backtrace; use -ftemplate-backtrace-limit=0 to see all)
    closure.execute();
            ^
/Users/pakuber/Compadre/trilinos/packages/zoltan2/core/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp:8060:15: note: 
      in instantiation of member function 'Zoltan2::AlgMJ<double, int, long long, int,
      Kokkos::Compat::KokkosDeviceWrapperNode<Kokkos::Threads, Kokkos::HostSpace> >::mj_1D_part' requested here
        this->mj_1D_part(
              ^
/Users/pakuber/Compadre/trilinos/packages/zoltan2/core/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp:9022:28: note: 
      in instantiation of member function 'Zoltan2::AlgMJ<double, int, long long, int,
      Kokkos::Compat::KokkosDeviceWrapperNode<Kokkos::Threads, Kokkos::HostSpace> >::multi_jagged_part' requested
      here
      this->mj_partitioner.multi_jagged_part(
                           ^
/Users/pakuber/Compadre/trilinos/packages/zoltan2/core/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp:8571:3: note: 
      in instantiation of member function
      'Zoltan2::Zoltan2_AlgMJ<Zoltan2::XpetraMultiVectorAdapter<Xpetra::MultiVector<double, int, long long,
      Kokkos::Compat::KokkosDeviceWrapperNode<Kokkos::Threads, Kokkos::HostSpace> > > >::partition' requested here
  Zoltan2_AlgMJ(const RCP<const Environment> &env,
  ^
/Users/pakuber/Compadre/trilinos/packages/zoltan2/core/src/problems/Zoltan2_PartitioningProblem.hpp:550:34: note: 
      in instantiation of member function
      'Zoltan2::Zoltan2_AlgMJ<Zoltan2::XpetraMultiVectorAdapter<Xpetra::MultiVector<double, int, long long,
      Kokkos::Compat::KokkosDeviceWrapperNode<Kokkos::Threads, Kokkos::HostSpace> > > >::Zoltan2_AlgMJ' requested
      here
      this->algorithm_ = rcp(new Zoltan2_AlgMJ<Adapter>(this->envConst_,
                                 ^
/Users/pakuber/Compadre/trilinos/packages/muelu/src/Rebalancing/MueLu_Zoltan2Interface_def.hpp:219:18: note: in
      instantiation of member function
      'Zoltan2::PartitioningProblem<Zoltan2::XpetraMultiVectorAdapter<Xpetra::MultiVector<double, int, long long,
      Kokkos::Compat::KokkosDeviceWrapperNode<Kokkos::Threads, Kokkos::HostSpace> > > >::solve' requested here
        problem->solve();
                 ^
/Users/pakuber/Compadre/trilinos/packages/zoltan2/core/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp:3534:8: note: 
      candidate function (the implicit copy assignment operator) not viable: 1st argument ('const volatile type'
      (aka 'const volatile Zoltan2::Zoltan2_MJArrayType<double>')) would lose volatile qualifier
struct Zoltan2_MJArrayType {
       ^
/Users/pakuber/Compadre/trilinos/packages/zoltan2/core/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp:3534:8: note: 
      candidate function (the implicit move assignment operator) not viable: 1st argument ('const volatile type'
      (aka 'const volatile Zoltan2::Zoltan2_MJArrayType<double>')) would lose const and volatile qualifiers
In file included from /Users/pakuber/Compadre/trilinos/build/packages/muelu/src/Utils/ExplicitInstantiation/MueLu_Zoltan2Interface.cpp:49:
In file included from /Users/pakuber/Compadre/trilinos/packages/muelu/src/Headers/MueLu_ConfigDefs.hpp:54:
In file included from /Users/pakuber/Compadre/trilinos/packages/tpetra/classic/NodeAPI/Kokkos_DefaultNode.hpp:47:
In file included from /Users/pakuber/Compadre/trilinos/packages/tpetra/classic/NodeAPI/KokkosCompat_ClassicNodeAPI_Wrapper.hpp:4:
In file included from /Users/pakuber/Compadre/trilinos/packages/kokkos/core/src/Kokkos_Core.hpp:56:
In file included from /Users/pakuber/Compadre/trilinos/build/packages/kokkos/KokkosCore_Config_DeclareBackend.hpp:47:
In file included from /Users/pakuber/Compadre/trilinos/packages/kokkos/core/src/decl/Kokkos_Declare_THREADS.hpp:49:
In file included from /Users/pakuber/Compadre/trilinos/packages/kokkos/core/src/Kokkos_Threads.hpp:230:
/Users/pakuber/Compadre/trilinos/packages/kokkos/core/src/Threads/Kokkos_ThreadsTeam.hpp:312:25: error: no viable
      overloaded '='
    reducer.reference() = *((type volatile const*)local_value);
    ~~~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/pakuber/Compadre/trilinos/packages/kokkos/core/src/Threads/Kokkos_ThreadsTeam.hpp:975:26: note: in
      instantiation of function template specialization
      'Kokkos::Impl::ThreadsExecTeamMember::team_reduce<Zoltan2::ArrayReducer<Kokkos::TeamPolicy<Kokkos::Threads>,
      int> >' requested here
  loop_boundaries.thread.team_reduce(reducer, value);
                         ^
/Users/pakuber/Compadre/trilinos/packages/zoltan2/core/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp:4576:13: note: 
      in instantiation of function template specialization 'Kokkos::parallel_reduce<int, (lambda at
      /Users/pakuber/Compadre/trilinos/packages/zoltan2/core/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp:4578:7),
      Zoltan2::ArrayReducer<Kokkos::TeamPolicy<Kokkos::Threads>, int> >' requested here
    Kokkos::parallel_reduce(
            ^
/Users/pakuber/Compadre/trilinos/packages/kokkos/core/src/Threads/Kokkos_Threads_Parallel.hpp:738:7: note: in
      instantiation of member function 'Zoltan2::ReduceArrayFunctor<Kokkos::TeamPolicy<Kokkos::Threads>, double,
      int, int, Kokkos::Device<Kokkos::Threads, Kokkos::HostSpace>, int>::operator()' requested here
      functor(member, update);
      ^
/Users/pakuber/Compadre/trilinos/packages/kokkos/core/src/Threads/Kokkos_Threads_Parallel.hpp:756:30: note: in
      instantiation of function template specialization
      'Kokkos::Impl::ParallelReduce<Zoltan2::ReduceArrayFunctor<Kokkos::TeamPolicy<Kokkos::Threads>, double, int,
      int, Kokkos::Device<Kokkos::Threads, Kokkos::HostSpace>, int>, Kokkos::TeamPolicy<Kokkos::Threads>,
      Kokkos::InvalidType, Kokkos::Threads>::exec_team<void>' requested here
    ParallelReduce::template exec_team<WorkTag>(
                             ^
/Users/pakuber/Compadre/trilinos/packages/kokkos/core/src/Threads/Kokkos_Threads_Parallel.hpp:781:43: note: in
      instantiation of member function
      'Kokkos::Impl::ParallelReduce<Zoltan2::ReduceArrayFunctor<Kokkos::TeamPolicy<Kokkos::Threads>, double, int,
      int, Kokkos::Device<Kokkos::Threads, Kokkos::HostSpace>, int>, Kokkos::TeamPolicy<Kokkos::Threads>,
      Kokkos::InvalidType, Kokkos::Threads>::exec' requested here
      ThreadsExec::start(&ParallelReduce::exec, this);
                                          ^
/Users/pakuber/Compadre/trilinos/packages/kokkos/core/src/Kokkos_Parallel_Reduce.hpp:877:13: note: (skipping 3
      contexts in backtrace; use -ftemplate-backtrace-limit=0 to see all)
    closure.execute();
            ^
/Users/pakuber/Compadre/trilinos/packages/zoltan2/core/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp:8157:19: note: 
      in instantiation of member function 'Zoltan2::AlgMJ<double, int, long long, int,
      Kokkos::Compat::KokkosDeviceWrapperNode<Kokkos::Threads, Kokkos::HostSpace> >::mj_create_new_partitions'
      requested here
            this->mj_create_new_partitions(
                  ^
/Users/pakuber/Compadre/trilinos/packages/zoltan2/core/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp:9022:28: note: 
      in instantiation of member function 'Zoltan2::AlgMJ<double, int, long long, int,
      Kokkos::Compat::KokkosDeviceWrapperNode<Kokkos::Threads, Kokkos::HostSpace> >::multi_jagged_part' requested
      here
      this->mj_partitioner.multi_jagged_part(
                           ^
/Users/pakuber/Compadre/trilinos/packages/zoltan2/core/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp:8571:3: note: 
      in instantiation of member function
      'Zoltan2::Zoltan2_AlgMJ<Zoltan2::XpetraMultiVectorAdapter<Xpetra::MultiVector<double, int, long long,
      Kokkos::Compat::KokkosDeviceWrapperNode<Kokkos::Threads, Kokkos::HostSpace> > > >::partition' requested here
  Zoltan2_AlgMJ(const RCP<const Environment> &env,
  ^
/Users/pakuber/Compadre/trilinos/packages/zoltan2/core/src/problems/Zoltan2_PartitioningProblem.hpp:550:34: note: 
      in instantiation of member function
      'Zoltan2::Zoltan2_AlgMJ<Zoltan2::XpetraMultiVectorAdapter<Xpetra::MultiVector<double, int, long long,
      Kokkos::Compat::KokkosDeviceWrapperNode<Kokkos::Threads, Kokkos::HostSpace> > > >::Zoltan2_AlgMJ' requested
      here
      this->algorithm_ = rcp(new Zoltan2_AlgMJ<Adapter>(this->envConst_,
                                 ^
/Users/pakuber/Compadre/trilinos/packages/muelu/src/Rebalancing/MueLu_Zoltan2Interface_def.hpp:219:18: note: in
      instantiation of member function
      'Zoltan2::PartitioningProblem<Zoltan2::XpetraMultiVectorAdapter<Xpetra::MultiVector<double, int, long long,
      Kokkos::Compat::KokkosDeviceWrapperNode<Kokkos::Threads, Kokkos::HostSpace> > > >::solve' requested here
        problem->solve();
                 ^
/Users/pakuber/Compadre/trilinos/packages/zoltan2/core/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp:3534:8: note: 
      candidate function (the implicit copy assignment operator) not viable: 1st argument ('const volatile type'
      (aka 'const volatile Zoltan2::Zoltan2_MJArrayType<int>')) would lose volatile qualifier
struct Zoltan2_MJArrayType {
       ^
/Users/pakuber/Compadre/trilinos/packages/zoltan2/core/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp:3534:8: note: 
      candidate function (the implicit move assignment operator) not viable: 1st argument ('const volatile type'
      (aka 'const volatile Zoltan2::Zoltan2_MJArrayType<int>')) would lose const and volatile qualifiers
2 errors generated.
=====================
```