### PR TITLE
MueLu: Fix missing parameters in ML2MueLuParameterTranslator

### DIFF
--- a/packages/muelu/doc/UsersGuide/masterList.xml
+++ b/packages/muelu/doc/UsersGuide/masterList.xml
@@ -134,6 +134,7 @@
      <parameter>
        <name>hierarchy label</name>
        <type>string</type>
+       <name-ML>ML label</name-ML>
        <default>""</default>
        <description>Label for the hierarchy. Is applied to timer labels.</description>
        <visible>true</visible>
@@ -1103,7 +1104,7 @@
       <name>sa: enforce constraints</name>
       <type>bool</type>
       <default>false</default>
-      <description>Insure that all interpolation entries are between 0 and 1 while trying to maintain the same rowsum as obtained by sa. 
+      <description>Insure that all interpolation entries are between 0 and 1 while trying to maintain the same rowsum as obtained by sa.
 Only used when tentative: calculate qr is set to false.</description>
       <visible>false</visible>
       <name-ML>not supported by ML</name-ML>

--- a/packages/muelu/doc/UsersGuide/paramlist_hidden.tex
+++ b/packages/muelu/doc/UsersGuide/paramlist_hidden.tex
@@ -241,7 +241,7 @@
         
 \cbb{sa: use rowsumabs diagonal scaling}{bool}{false}{Use the row sums of the absolute values of the matrix as the diagonal wherever inverse(D) is required.}
         
-\cbb{sa: enforce constraints}{bool}{false}{Insure that all interpolation entries are between 0 and 1 while trying to maintain the same rowsum as obtained by sa. 
+\cbb{sa: enforce constraints}{bool}{false}{Insure that all interpolation entries are between 0 and 1 while trying to maintain the same rowsum as obtained by sa.
 Only used when tentative: calculate qr is set to false.}
         
 \cbb{sa: max eigenvalue}{double}{-1.0}{If not -1, use this value for lambdaMax(Dinv A) in prolongator smoothing instead of calculating it.}

--- a/packages/muelu/src/Interface/MueLu_ML2MueLuParameterTranslator.cpp
+++ b/packages/muelu/src/Interface/MueLu_ML2MueLuParameterTranslator.cpp
@@ -152,6 +152,7 @@ namespace MueLu {
 
       if ( paramList.isParameter("smoother: sweeps") ) { mueluss << "<Parameter name=\"relaxation: sweeps\" type=\"int\" value=\"" << paramList.get<int>("smoother: sweeps") << "\"/>" << std::endl; adaptingParamList.remove("smoother: sweeps",false); }
       if ( paramList.isParameter("smoother: damping factor") ) { mueluss << "<Parameter name=\"relaxation: damping factor\" type=\"double\" value=\"" << paramList.get<double>("smoother: damping factor") << "\"/>" << std::endl; adaptingParamList.remove("smoother: damping factor",false); }
+      if ( paramList.isParameter("smoother: use l1 Gauss-Seidel") ) { mueluss << "<Parameter name=\"relaxation: use l1\" type=\"bool\" value=\"" << paramList.get<bool>("smoother: use l1 Gauss-Seidel") << "\"/>" << std::endl; adaptingParamList.remove("smoother: use l1 Gauss-Seidel",false); }
     }
 
     // Chebyshev

--- a/packages/muelu/src/MueCentral/MueLu_MasterList.cpp
+++ b/packages/muelu/src/MueCentral/MueLu_MasterList.cpp
@@ -561,7 +561,7 @@ namespace MueLu {
       
          ("parameterlist: syntax","parameterlist: syntax")
       
-         ("hierarchy label","hierarchy label")
+         ("ML label","hierarchy label")
       
          ("matvec params","matvec params")
       


### PR DESCRIPTION
@trilinos/muelu 

## Motivation
`smoother: use l1 Gauss-Seidel` and `ML label` were not translated.