### PR TITLE
This will resolve #8756  by changing CXX_FLAGS

### DIFF
--- a/cmake/std/atdm/ats2/environment.sh
+++ b/cmake/std/atdm/ats2/environment.sh
@@ -105,7 +105,11 @@ elif [[ "$ATDM_CONFIG_COMPILER" == *"XL"* ]]; then
   # Don't use ninja as the fortran compiler test is broken.
   export ATDM_CONFIG_USE_NINJA=OFF
 
-  export ATDM_CONFIG_CXX_FLAGS="-ccbin xlc++ -qxflag=disable__cplusplusOverride"
+  if [[ "CUDA" == "$ATDM_CONFIG_NODE_TYPE" ]]; then
+    export ATDM_CONFIG_CXX_FLAGS="-ccbin xlc++ -qxflag=disable__cplusplusOverride"
+  else
+    export ATDM_CONFIG_CXX_FLAGS="-qxflag=disable__cplusplusOverride"
+  fi
 
   # set the gcc compiler XL  will use for backend to one that handles c++14
   export XLC_USR_CONFIG=/opt/ibm/xlC/16.1.1/etc/xlc.cfg.rhel.7.6.gcc.7.3.1.cuda.10.1.243


### PR DESCRIPTION
Basically the added c++14 flags for xl (-qxflag=disable__cplusplusOverride)
and the nvcc_wrapper flag needed to allow that (-ccbin xlc++)
need to be split.


@trilinos/framework 

## Motivation
See issue #8756 

## Related Issues

* Closes #8756 

## Testing
This was tested by hand agains the Trilinos-atdm-ats2-cuda-10.1.243-xl-2020.03.18_spmpi-rolling_static_opt and Trilinos-atdm-ats2-xl-2020.03.18_spmpi-rolling_serial_static_opt builds by hand using the process outlined at https://github.com/trilinos/Trilinos/blob/develop/cmake/std/atdm/README.md

