### PR TITLE
Tempus output to root only

### DIFF
--- a/packages/tempus/src/Tempus_IntegratorAdjointSensitivity_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorAdjointSensitivity_impl.hpp
@@ -377,6 +377,7 @@ describe(
   const Teuchos::EVerbosityLevel verbLevel) const
 {
   out << description() << "::describe" << std::endl;
+  out.setOutputToRootOnly(0);
   state_integrator_->describe(out, verbLevel);
   adjoint_integrator_->describe(out, verbLevel);
 }

--- a/packages/tempus/src/Tempus_IntegratorAdjointSensitivity_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorAdjointSensitivity_impl.hpp
@@ -376,8 +376,10 @@ describe(
   Teuchos::FancyOStream          &out,
   const Teuchos::EVerbosityLevel verbLevel) const
 {
-  out << description() << "::describe" << std::endl;
-  out.setOutputToRootOnly(0);
+
+  auto l_out = Teuchos::fancyOStream( out.getOStream() );
+  l_out->setOutputToRootOnly(0);
+  *l_out << description() << "::describe" << std::endl;
   state_integrator_->describe(out, verbLevel);
   adjoint_integrator_->describe(out, verbLevel);
 }

--- a/packages/tempus/src/Tempus_IntegratorBasic_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorBasic_impl.hpp
@@ -327,23 +327,24 @@ std::string IntegratorBasic<Scalar>::description() const
 
 template<class Scalar>
 void IntegratorBasic<Scalar>::describe(
-  Teuchos::FancyOStream          &out,
+  Teuchos::FancyOStream          &in_out,
   const Teuchos::EVerbosityLevel verbLevel) const
 {
-  out.setOutputToRootOnly(0);
-  out << description() << "::describe" << std::endl;
-  out << "solutionHistory= " << solutionHistory_->description()<<std::endl;
-  out << "timeStepControl= " << timeStepControl_->description()<<std::endl;
-  out << "stepper        = " << stepper_        ->description()<<std::endl;
+  auto out = Teuchos::fancyOStream( in_out.getOStream() );
+  out->setOutputToRootOnly(0);
+  *out << description() << "::describe" << std::endl;
+  *out << "solutionHistory= " << solutionHistory_->description()<<std::endl;
+  *out << "timeStepControl= " << timeStepControl_->description()<<std::endl;
+  *out << "stepper        = " << stepper_        ->description()<<std::endl;
 
   if (Teuchos::as<int>(verbLevel) >=
               Teuchos::as<int>(Teuchos::VERB_HIGH)) {
-    out << "solutionHistory= " << std::endl;
-    solutionHistory_->describe(out,verbLevel);
-    out << "timeStepControl= " << std::endl;
-    timeStepControl_->describe(out,verbLevel);
-    out << "stepper        = " << std::endl;
-    stepper_        ->describe(out,verbLevel);
+    *out << "solutionHistory= " << std::endl;
+    solutionHistory_->describe(in_out,verbLevel);
+    *out << "timeStepControl= " << std::endl;
+    timeStepControl_->describe(in_out,verbLevel);
+    *out << "stepper        = " << std::endl;
+    stepper_        ->describe(in_out,verbLevel);
   }
 }
 

--- a/packages/tempus/src/Tempus_IntegratorBasic_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorBasic_impl.hpp
@@ -308,6 +308,7 @@ void IntegratorBasic<Scalar>::initialize()
   if (Teuchos::as<int>(this->getVerbLevel()) >=
       Teuchos::as<int>(Teuchos::VERB_HIGH)) {
     Teuchos::RCP<Teuchos::FancyOStream> out = this->getOStream();
+    out->setOutputToRootOnly(0);
     Teuchos::OSTab ostab(out,1,"IntegratorBasic::IntegratorBasic");
     *out << this->description() << std::endl;
   }
@@ -329,6 +330,7 @@ void IntegratorBasic<Scalar>::describe(
   Teuchos::FancyOStream          &out,
   const Teuchos::EVerbosityLevel verbLevel) const
 {
+  out.setOutputToRootOnly(0);
   out << description() << "::describe" << std::endl;
   out << "solutionHistory= " << solutionHistory_->description()<<std::endl;
   out << "timeStepControl= " << timeStepControl_->description()<<std::endl;
@@ -360,6 +362,7 @@ template <class Scalar>
 void IntegratorBasic<Scalar>::startIntegrator()
 {
   Teuchos::RCP<Teuchos::FancyOStream> out = this->getOStream();
+  out->setOutputToRootOnly(0);
   if (isInitialized_ == false) {
     Teuchos::OSTab ostab(out,1,"StartIntegrator");
     *out << "Failure - IntegratorBasic is not initialized." << std::endl;
@@ -466,6 +469,7 @@ void IntegratorBasic<Scalar>::checkTimeStep()
   // Too many TimeStep failures, Integrator fails.
   if (ws->getNFailures() >= timeStepControl_->getMaxFailures()) {
     RCP<Teuchos::FancyOStream> out = this->getOStream();
+    out->setOutputToRootOnly(0);
     Teuchos::OSTab ostab(out,2,"checkTimeStep");
     *out << "Failure - Stepper has failed more than the maximum allowed.\n"
          << "  (nFailures = "<<ws->getNFailures()<< ") >= (nFailuresMax = "
@@ -476,6 +480,7 @@ void IntegratorBasic<Scalar>::checkTimeStep()
   if (ws->getNConsecutiveFailures()
       >= timeStepControl_->getMaxConsecFailures()){
     RCP<Teuchos::FancyOStream> out = this->getOStream();
+    out->setOutputToRootOnly(0);
     Teuchos::OSTab ostab(out,1,"checkTimeStep");
     *out << "Failure - Stepper has failed more than the maximum "
          << "consecutive allowed.\n"
@@ -498,6 +503,7 @@ void IntegratorBasic<Scalar>::checkTimeStep()
      )
   {
     RCP<Teuchos::FancyOStream> out = this->getOStream();
+    out->setOutputToRootOnly(0);
     Teuchos::OSTab ostab(out,0,"checkTimeStep");
     *out <<std::scientific
       <<std::setw( 6)<<std::setprecision(3)<<ws->getIndex()

--- a/packages/tempus/src/Tempus_IntegratorForwardSensitivity_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorForwardSensitivity_impl.hpp
@@ -248,7 +248,7 @@ describe(
   auto out = Teuchos::fancyOStream( in_out.getOStream() );
   out->setOutputToRootOnly(0);
   *out << description() << "::describe" << std::endl;
-  integrator_->describe(out, verbLevel);
+  integrator_->describe(in_out, verbLevel);
 }
 
 template<class Scalar>

--- a/packages/tempus/src/Tempus_IntegratorForwardSensitivity_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorForwardSensitivity_impl.hpp
@@ -242,11 +242,12 @@ template<class Scalar>
 void
 IntegratorForwardSensitivity<Scalar>::
 describe(
-  Teuchos::FancyOStream          &out,
+  Teuchos::FancyOStream          &in_out,
   const Teuchos::EVerbosityLevel verbLevel) const
 {
-  out.setOutputToRootOnly(0);
-  out << description() << "::describe" << std::endl;
+  auto out = Teuchos::fancyOStream( in_out.getOStream() );
+  out->setOutputToRootOnly(0);
+  *out << description() << "::describe" << std::endl;
   integrator_->describe(out, verbLevel);
 }
 

--- a/packages/tempus/src/Tempus_IntegratorForwardSensitivity_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorForwardSensitivity_impl.hpp
@@ -245,6 +245,7 @@ describe(
   Teuchos::FancyOStream          &out,
   const Teuchos::EVerbosityLevel verbLevel) const
 {
+  out.setOutputToRootOnly(0);
   out << description() << "::describe" << std::endl;
   integrator_->describe(out, verbLevel);
 }

--- a/packages/tempus/src/Tempus_IntegratorObserverBasic_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorObserverBasic_impl.hpp
@@ -106,6 +106,7 @@ observeEndIntegrator(const Integrator<Scalar>& integrator){
   std::time_t end = std::time(nullptr);
   const Scalar runtime = integrator.getIntegratorTimer()->totalElapsedTime();
   const Teuchos::RCP<Teuchos::FancyOStream> out = integrator.getOStream();
+  out->setOutputToRootOnly(0);
   Teuchos::OSTab ostab(out,0,"ScreenOutput");
   *out << "============================================================================\n"
        << "  Total runtime = " << runtime << " sec = "

--- a/packages/tempus/src/Tempus_IntegratorObserverBasic_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorObserverBasic_impl.hpp
@@ -25,6 +25,7 @@ observeStartIntegrator(const Integrator<Scalar>& integrator){
 
   std::time_t begin = std::time(nullptr);
   const Teuchos::RCP<Teuchos::FancyOStream> out = integrator.getOStream();
+  out->setOutputToRootOnly(0);
   Teuchos::OSTab ostab(out,0,"ScreenOutput");
   *out << "\nTempus - IntegratorBasic\n"
        << std::asctime(std::localtime(&begin)) << "\n"
@@ -74,6 +75,7 @@ observeEndTimeStep(const Integrator<Scalar>& integrator){
      integrator.getStepperTimer()->reset();
 
      const Teuchos::RCP<Teuchos::FancyOStream> out = integrator.getOStream();
+     out->setOutputToRootOnly(0);
      Teuchos::OSTab ostab(out,0,"ScreenOutput");
      *out<<std::scientific
         <<std::setw( 6)<<std::setprecision(3)<<cs->getIndex()

--- a/packages/tempus/src/Tempus_IntegratorObserverSubcycling_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorObserverSubcycling_impl.hpp
@@ -24,6 +24,7 @@ void IntegratorObserverSubcycling<Scalar>::
 observeStartIntegrator(const Integrator<Scalar>& integrator){
 
   const Teuchos::RCP<Teuchos::FancyOStream> out = integrator.getOStream();
+  out->setOutputToRootOnly(0);
   Teuchos::OSTab ostab(out,0,"ScreenOutput");
   *out << "\n    Begin Subcycling -------------------------------------------------------\n";
     // << "  Step       Time         dt  Abs Error  Rel Error  Order  nFail  dCompTime"
@@ -66,6 +67,7 @@ observeEndTimeStep(const Integrator<Scalar>& integrator){
      integrator.getStepperTimer()->reset();
 
      const Teuchos::RCP<Teuchos::FancyOStream> out = integrator.getOStream();
+     out->setOutputToRootOnly(0);
      Teuchos::OSTab ostab(out,0,"ScreenOutput");
      *out<<std::scientific
         <<std::setw( 6)<<std::setprecision(3)<<cs->getIndex()
@@ -86,6 +88,7 @@ void IntegratorObserverSubcycling<Scalar>::
 observeEndIntegrator(const Integrator<Scalar>& integrator){
 
   const Teuchos::RCP<Teuchos::FancyOStream> out = integrator.getOStream();
+  out->setOutputToRootOnly(0);
   Teuchos::OSTab ostab(out,0,"ScreenOutput");
   *out << "    End Subcycling ---------------------------------------------------------\n\n";
 }

--- a/packages/tempus/src/Tempus_IntegratorPseudoTransientAdjointSensitivity_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorPseudoTransientAdjointSensitivity_impl.hpp
@@ -271,12 +271,13 @@ template<class Scalar>
 void
 IntegratorPseudoTransientAdjointSensitivity<Scalar>::
 describe(
-  Teuchos::FancyOStream          &out,
+  Teuchos::FancyOStream          &in_out,
   const Teuchos::EVerbosityLevel verbLevel) const
 {
-  out << description() << "::describe" << std::endl;
-  state_integrator_->describe(out, verbLevel);
-  sens_integrator_->describe(out, verbLevel);
+  auto out = Teuchos::fancyOStream( in_out.getOStream() );
+  *out << description() << "::describe" << std::endl;
+  state_integrator_->describe(*out, verbLevel);
+  sens_integrator_->describe(*out, verbLevel);
 }
 
 template<class Scalar>

--- a/packages/tempus/src/Tempus_IntegratorPseudoTransientForwardSensitivity_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorPseudoTransientForwardSensitivity_impl.hpp
@@ -343,12 +343,14 @@ template<class Scalar>
 void
 IntegratorPseudoTransientForwardSensitivity<Scalar>::
 describe(
-  Teuchos::FancyOStream          &out,
+  Teuchos::FancyOStream          &in_out,
   const Teuchos::EVerbosityLevel verbLevel) const
 {
-  out << description() << "::describe" << std::endl;
-  state_integrator_->describe(out, verbLevel);
-  sens_integrator_->describe(out, verbLevel);
+  auto out = Teuchos::fancyOStream( in_out.getOStream() );
+  out->setOutputToRootOnly(0);
+  *out << description() << "::describe" << std::endl;
+  state_integrator_->describe(in_out, verbLevel);
+  sens_integrator_->describe(in_out, verbLevel);
 }
 
 template<class Scalar>

--- a/packages/tempus/src/Tempus_PhysicsState_impl.hpp
+++ b/packages/tempus/src/Tempus_PhysicsState_impl.hpp
@@ -60,10 +60,12 @@ std::string PhysicsState<Scalar>::description() const
 
 template<class Scalar>
 void PhysicsState<Scalar>::describe(
-  Teuchos::FancyOStream        & out,
+  Teuchos::FancyOStream        & in_out,
   const Teuchos::EVerbosityLevel /* verbLevel */) const
 {
-  out << description() << "::describe" << std::endl
+  auto out = Teuchos::fancyOStream( in_out.getOStream() );
+  out->setOutputToRootOnly(0);
+  *out << description() << "::describe" << std::endl
       << "  physicsName   = " << physicsName_ << std::endl;
 }
 

--- a/packages/tempus/src/Tempus_SolutionStateMetaData_impl.hpp
+++ b/packages/tempus/src/Tempus_SolutionStateMetaData_impl.hpp
@@ -182,6 +182,7 @@ void SolutionStateMetaData<Scalar>::describe(
    const Teuchos::EVerbosityLevel      verbLevel) const
 {
   if (verbLevel == Teuchos::VERB_EXTREME) {
+    out.setOutputToRootOnly(0);
     out << description() << "::describe:" << std::endl
         << "time           = " << time_ << std::endl
         << "iStep          = " << iStep_ << std::endl

--- a/packages/tempus/src/Tempus_SolutionStateMetaData_impl.hpp
+++ b/packages/tempus/src/Tempus_SolutionStateMetaData_impl.hpp
@@ -182,29 +182,30 @@ void SolutionStateMetaData<Scalar>::describe(
    const Teuchos::EVerbosityLevel      verbLevel) const
 {
   if (verbLevel == Teuchos::VERB_EXTREME) {
-    out.setOutputToRootOnly(0);
-    out << description() << "::describe:" << std::endl
-        << "time           = " << time_ << std::endl
-        << "iStep          = " << iStep_ << std::endl
-        << "dt             = " << dt_ << std::endl
-        << "errorAbs       = " << errorAbs_ << std::endl
-        << "errorRel       = " << errorRel_ << std::endl
-        << "order          = " << order_ << std::endl
-        << "nFailures      = " << nFailures_ << std::endl
-        << "nRunningFailures = " << nRunningFailures_<< std::endl
-        << "nConsecutiveFailures = " << nConsecutiveFailures_ << std::endl
-        << "tolRel         = " << tolRel_ << std::endl
-        << "tolAbs         = " << tolAbs_ << std::endl
-        << "xNormL2        = " << xNormL2_ << std::endl
-        << "dxNormL2Rel    = " << dxNormL2Rel_ << std::endl
-        << "dxNormL2Abs    = " << dxNormL2Abs_ << std::endl
-        << "computeNorms   = " << computeNorms_ << std::endl
-        << "solutionStatus = " << toString(solutionStatus_) << std::endl
-        << "output         = " << output_ << std::endl
-        << "outputScreen   = " << outputScreen_ << std::endl
-        << "isSynced       = " << isSynced_ << std::endl
-        << "isInterpolated = " << isInterpolated_ << std::endl
-        << "accuracy       = " << accuracy_ << std::endl;
+    auto l_out = Teuchos::fancyOStream( out.getOStream() );
+    l_out->setOutputToRootOnly(0);
+    *l_out << description() << "::describe:" << std::endl
+           << "time           = " << time_ << std::endl
+           << "iStep          = " << iStep_ << std::endl
+           << "dt             = " << dt_ << std::endl
+           << "errorAbs       = " << errorAbs_ << std::endl
+           << "errorRel       = " << errorRel_ << std::endl
+           << "order          = " << order_ << std::endl
+           << "nFailures      = " << nFailures_ << std::endl
+           << "nRunningFailures = " << nRunningFailures_<< std::endl
+           << "nConsecutiveFailures = " << nConsecutiveFailures_ << std::endl
+           << "tolRel         = " << tolRel_ << std::endl
+           << "tolAbs         = " << tolAbs_ << std::endl
+           << "xNormL2        = " << xNormL2_ << std::endl
+           << "dxNormL2Rel    = " << dxNormL2Rel_ << std::endl
+           << "dxNormL2Abs    = " << dxNormL2Abs_ << std::endl
+           << "computeNorms   = " << computeNorms_ << std::endl
+           << "solutionStatus = " << toString(solutionStatus_) << std::endl
+           << "output         = " << output_ << std::endl
+           << "outputScreen   = " << outputScreen_ << std::endl
+           << "isSynced       = " << isSynced_ << std::endl
+           << "isInterpolated = " << isInterpolated_ << std::endl
+           << "accuracy       = " << accuracy_ << std::endl;
   }
 }
 

--- a/packages/tempus/src/Tempus_SolutionState_impl.hpp
+++ b/packages/tempus/src/Tempus_SolutionState_impl.hpp
@@ -408,6 +408,13 @@ void SolutionState<Scalar>::describe(
    Teuchos::FancyOStream               &out,
    const Teuchos::EVerbosityLevel      verbLevel) const
 {
+  if (verbLevel == Teuchos::VERB_MEDIUM) {
+    out << "(index =" <<std::setw(6)<< this->getIndex()
+        << "; time =" <<std::setw(10)<<std::setprecision(3)<<this->getTime()
+        << "; dt   =" <<std::setw(10)<<std::setprecision(3)<<this->getTimeStep()
+        << ")" << std::endl;
+  }
+
   if (verbLevel == Teuchos::VERB_EXTREME) {
     out << description() << "::describe:" << std::endl
         << "metaData = " << std::endl;

--- a/packages/tempus/src/Tempus_StepperBDF2_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperBDF2_impl.hpp
@@ -238,7 +238,7 @@ template<class Scalar>
 void StepperBDF2<Scalar>::computeStartUp(
   const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory)
 {
-  Teuchos::RCP<Teuchos::FancyOStream> out = this->getOStream();
+  auto out = Teuchos::fancyOStream( this->getOStream() );
   out->setOutputToRootOnly(0);
   Teuchos::OSTab ostab(out,1,"StepperBDF2::computeStartUp()");
   *out << "Warning -- Taking a startup step for BDF2 using '"
@@ -272,25 +272,26 @@ void StepperBDF2<Scalar>::describe(
   Teuchos::FancyOStream               &out,
   const Teuchos::EVerbosityLevel      verbLevel ) const
 {
-  out.setOutputToRootOnly(0);
-  out << std::endl;
+  auto l_out = Teuchos::fancyOStream( out.getOStream() );
+  l_out->setOutputToRootOnly(0);
+  *l_out << std::endl;
   Stepper<Scalar>::describe(out, verbLevel);
   StepperImplicit<Scalar>::describe(out, verbLevel);
 
-  out << "--- StepperBDF2 ---\n";
+  *l_out << "--- StepperBDF2 ---\n";
   if (startUpStepper_ != Teuchos::null) {
-    out << "  startup stepper type             = "
-        << startUpStepper_->description() << std::endl;
+    *l_out << "  startup stepper type             = "
+           << startUpStepper_->description() << std::endl;
   }
-  out << "  startUpStepper_                  = "
-      << startUpStepper_ << std::endl;
-  out << "  startUpStepper_->isInitialized() = "
-      << Teuchos::toString(startUpStepper_->isInitialized()) << std::endl;
-  out << "  stepperBDF2AppAction_            = "
-      << stepperBDF2AppAction_ << std::endl;
-  out << "----------------------------" << std::endl;
-  out << "  order_                           = " << order_ << std::endl;
-  out << "-------------------" << std::endl;
+  *l_out << "  startUpStepper_                  = "
+         << startUpStepper_ << std::endl;
+  *l_out << "  startUpStepper_->isInitialized() = "
+         << Teuchos::toString(startUpStepper_->isInitialized()) << std::endl;
+  *l_out << "  stepperBDF2AppAction_            = "
+         << stepperBDF2AppAction_ << std::endl;
+  *l_out << "----------------------------" << std::endl;
+  *l_out << "  order_                           = " << order_ << std::endl;
+  *l_out << "-------------------" << std::endl;
 }
 
 
@@ -298,18 +299,19 @@ template<class Scalar>
 bool StepperBDF2<Scalar>::isValidSetup(Teuchos::FancyOStream & out) const
 {
   bool isValidSetup = true;
-  out.setOutputToRootOnly(0);
+  auto l_out = Teuchos::fancyOStream( out.getOStream() );
+  l_out->setOutputToRootOnly(0);
 
   if ( !Stepper<Scalar>::isValidSetup(out) ) isValidSetup = false;
   if ( !StepperImplicit<Scalar>::isValidSetup(out) ) isValidSetup = false;
 
   if ( !this->startUpStepper_->isInitialized() ) {
     isValidSetup = false;
-    out << "The startup stepper is not initialized!\n";
+    *l_out << "The startup stepper is not initialized!\n";
   }
   if (stepperBDF2AppAction_ == Teuchos::null) {
     isValidSetup = false;
-    out << "The BDF2 AppAction is not set!\n";
+    *l_out << "The BDF2 AppAction is not set!\n";
   }
   return isValidSetup;
 }

--- a/packages/tempus/src/Tempus_StepperBDF2_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperBDF2_impl.hpp
@@ -239,6 +239,7 @@ void StepperBDF2<Scalar>::computeStartUp(
   const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory)
 {
   Teuchos::RCP<Teuchos::FancyOStream> out = this->getOStream();
+  out->setOutputToRootOnly(0);
   Teuchos::OSTab ostab(out,1,"StepperBDF2::computeStartUp()");
   *out << "Warning -- Taking a startup step for BDF2 using '"
        << startUpStepper_->getStepperType()<<"'!" << std::endl;
@@ -271,6 +272,7 @@ void StepperBDF2<Scalar>::describe(
   Teuchos::FancyOStream               &out,
   const Teuchos::EVerbosityLevel      verbLevel ) const
 {
+  out.setOutputToRootOnly(0);
   out << std::endl;
   Stepper<Scalar>::describe(out, verbLevel);
   StepperImplicit<Scalar>::describe(out, verbLevel);
@@ -296,6 +298,7 @@ template<class Scalar>
 bool StepperBDF2<Scalar>::isValidSetup(Teuchos::FancyOStream & out) const
 {
   bool isValidSetup = true;
+  out.setOutputToRootOnly(0);
 
   if ( !Stepper<Scalar>::isValidSetup(out) ) isValidSetup = false;
   if ( !StepperImplicit<Scalar>::isValidSetup(out) ) isValidSetup = false;

--- a/packages/tempus/src/Tempus_StepperHHTAlpha_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperHHTAlpha_impl.hpp
@@ -486,6 +486,7 @@ void StepperHHTAlpha<Scalar>::describe(
    Teuchos::FancyOStream               &out,
    const Teuchos::EVerbosityLevel      verbLevel) const
 {
+
 #ifdef VERBOSE_DEBUG_OUTPUT
   *out_ << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
 #endif
@@ -494,13 +495,15 @@ void StepperHHTAlpha<Scalar>::describe(
   Stepper<Scalar>::describe(out, verbLevel);
   StepperImplicit<Scalar>::describe(out, verbLevel);
 
-  out << "--- StepperHHTAlpha ---\n";
-  out << "  schemeName_ = " << schemeName_ << std::endl;
-  out << "  beta_       = " << beta_       << std::endl;
-  out << "  gamma_      = " << gamma_      << std::endl;
-  out << "  alpha_f_    = " << alpha_f_    << std::endl;
-  out << "  alpha_m_    = " << alpha_m_    << std::endl;
-  out << "-----------------------" << std::endl;
+  auto l_out = Teuchos::fancyOStream( out.getOStream() );
+  l_out->setOutputToRootOnly(0);
+  *l_out << "--- StepperHHTAlpha ---\n";
+  *l_out << "  schemeName_ = " << schemeName_ << std::endl;
+  *l_out << "  beta_       = " << beta_       << std::endl;
+  *l_out << "  gamma_      = " << gamma_      << std::endl;
+  *l_out << "  alpha_f_    = " << alpha_f_    << std::endl;
+  *l_out << "  alpha_m_    = " << alpha_m_    << std::endl;
+  *l_out << "-----------------------" << std::endl;
 }
 
 

--- a/packages/tempus/src/Tempus_StepperHHTAlpha_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperHHTAlpha_impl.hpp
@@ -126,6 +126,7 @@ template<class Scalar>
 void StepperHHTAlpha<Scalar>::setBeta(Scalar beta)
 {
   if (schemeName_ != "Newmark Beta User Defined") {
+    out_->setOutputToRootOnly(0);
     *out_ << "\nWARNING: schemeName != 'Newmark Beta User Defined' (= '"
           << schemeName_ << "').\n"
           << " Leaving as beta = " << beta_ << "!\n";
@@ -135,6 +136,7 @@ void StepperHHTAlpha<Scalar>::setBeta(Scalar beta)
   beta_ = beta;
 
   if (beta_ == 0.0) {
+    out_->setOutputToRootOnly(0);
     *out_ << "\nWARNING: Running (implicit implementation of) Newmark "
           << "Implicit a-Form Stepper with Beta = 0.0, which \n"
           << "specifies an explicit scheme.  Mass lumping is not possible, "
@@ -158,6 +160,7 @@ template<class Scalar>
 void StepperHHTAlpha<Scalar>::setGamma(Scalar gamma)
 {
   if (schemeName_ != "Newmark Beta User Defined") {
+    out_->setOutputToRootOnly(0);
     *out_ << "\nWARNING: schemeName != 'Newmark Beta User Defined' (= '"
           << schemeName_ << "').\n"
           << " Leaving as gamma = " << gamma_ << "!\n";

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitAForm_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitAForm_impl.hpp
@@ -263,6 +263,7 @@ void StepperNewmarkImplicitAForm<Scalar>::setInitialConditions(
 
   if (numStates > 1) {
     RCP<Teuchos::FancyOStream> out = this->getOStream();
+    out->setOutputToRootOnly(0);
     Teuchos::OSTab ostab(out,1,"StepperNewmarkImplicitAForm::setInitialConditions()");
     *out << "Warning -- SolutionHistory has more than one state!\n"
          << "Setting the initial conditions on the currentState.\n"<<std::endl;
@@ -305,6 +306,7 @@ void StepperNewmarkImplicitAForm<Scalar>::setInitialConditions(
   if (icConsistency == "None") {
     if (initialState->getXDotDot() == Teuchos::null) {
       RCP<Teuchos::FancyOStream> out = this->getOStream();
+      out->setOutputToRootOnly(0);
       Teuchos::OSTab ostab(out,1,
         "StepperNewmarkImplicitAForm::setInitialConditions()");
       *out << "Warning -- Requested IC consistency of 'None' but\n"
@@ -397,6 +399,7 @@ void StepperNewmarkImplicitAForm<Scalar>::setInitialConditions(
 
     if (reldiff > eps) {
       RCP<Teuchos::FancyOStream> out = this->getOStream();
+      out->setOutputToRootOnly(0);
       Teuchos::OSTab ostab(out,1,
         "StepperNewmarkImplicitAForm::setInitialConditions()");
       *out << "Warning -- Failed consistency check but continuing!\n"
@@ -410,6 +413,7 @@ void StepperNewmarkImplicitAForm<Scalar>::setInitialConditions(
 
   if (!(this->getUseFSAL())) {
     RCP<Teuchos::FancyOStream> out = this->getOStream();
+    out->setOutputToRootOnly(0);
     Teuchos::OSTab ostab(out,1,
       "StepperNewmarkImplicitAForm::setInitialConditions()");
     *out << "\nWarning -- The First-Same-As-Last (FSAL) principle is "
@@ -523,6 +527,7 @@ void StepperNewmarkImplicitAForm<Scalar>::describe(
   Teuchos::FancyOStream               &out,
   const Teuchos::EVerbosityLevel      verbLevel) const
 {
+  out.setOutputToRootOnly(0);
 #ifdef VERBOSE_DEBUG_OUTPUT
   *out_ << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
 #endif
@@ -543,6 +548,7 @@ template<class Scalar>
 bool StepperNewmarkImplicitAForm<Scalar>::isValidSetup(Teuchos::FancyOStream & out) const
 {
   bool isValidSetup = true;
+  out.setOutputToRootOnly(0);
 
   if ( !Stepper<Scalar>::isValidSetup(out) ) isValidSetup = false;
 

--- a/packages/tempus/src/Tempus_Stepper_impl.hpp
+++ b/packages/tempus/src/Tempus_Stepper_impl.hpp
@@ -151,6 +151,7 @@ template<class Scalar>
 void Stepper<Scalar>::initialize()
 {
   Teuchos::RCP<Teuchos::FancyOStream> out = this->getOStream();
+  out->setOutputToRootOnly(0);
 
   bool isValidSetup = this->isValidSetup(*out);
 
@@ -177,6 +178,7 @@ void Stepper<Scalar>::setUseFSALTrueOnly(bool a)
 {
   if (a == false) {
     Teuchos::RCP<Teuchos::FancyOStream> out = this->getOStream();
+    out->setOutputToRootOnly(0);
     Teuchos::OSTab ostab(out,1,"Stepper::setUseFSALTrueOnly()");
     *out << "Warning -- useFSAL for '" << this->getStepperType() << "'\n"
          << "can only be set to true.  Leaving set to true." << std::endl;
@@ -190,6 +192,7 @@ void Stepper<Scalar>::setUseFSALFalseOnly(bool a)
 {
   if (a == true) {
     Teuchos::RCP<Teuchos::FancyOStream> out = this->getOStream();
+    out->setOutputToRootOnly(0);
     Teuchos::OSTab ostab(out,1,"Stepper::setUseFSALFalseOnly()");
     *out << "Warning -- useFSAL for '" << this->getStepperType() << "'\n"
          << "can only be set to false.  Leaving set to false." << std::endl;
@@ -252,6 +255,7 @@ template<class Scalar>
 void Stepper<Scalar>::describe(Teuchos::FancyOStream        & out,
                                const Teuchos::EVerbosityLevel verbLevel) const
 {
+  out.setOutputToRootOnly(0);
   out << "--- Stepper ---\n"
       << "  isInitialized_      = " << Teuchos::toString(isInitialized_) << std::endl
       << "  stepperType_        = " << stepperType_ << std::endl
@@ -273,6 +277,7 @@ bool Stepper<Scalar>::isValidSetup(
   if ( !(ICConsistency_ == "None" || ICConsistency_ == "Zero" ||
          ICConsistency_ == "App"  || ICConsistency_ == "Consistent") ) {
     isValidSetup = false;
+    out.setOutputToRootOnly(0);
     out << "The IC consistency does not have a valid value!\n"
         << "('None', 'Zero', 'App' or 'Consistent')\n"
         << "  ICConsistency  = " << ICConsistency_ << "\n";

--- a/packages/tempus/src/Tempus_Stepper_impl.hpp
+++ b/packages/tempus/src/Tempus_Stepper_impl.hpp
@@ -252,35 +252,37 @@ Stepper<Scalar>::getStepperXDotDot(Teuchos::RCP<SolutionState<Scalar> > state)
 
 
 template<class Scalar>
-void Stepper<Scalar>::describe(Teuchos::FancyOStream        & out,
+void Stepper<Scalar>::describe(Teuchos::FancyOStream        & in_out,
                                const Teuchos::EVerbosityLevel verbLevel) const
 {
-  out.setOutputToRootOnly(0);
-  out << "--- Stepper ---\n"
-      << "  isInitialized_      = " << Teuchos::toString(isInitialized_) << std::endl
-      << "  stepperType_        = " << stepperType_ << std::endl
-      << "  useFSAL_            = " << Teuchos::toString(useFSAL_) << std::endl
-      << "  ICConsistency_      = " << ICConsistency_ << std::endl
-      << "  ICConsistencyCheck_ = " << Teuchos::toString(ICConsistencyCheck_) << std::endl
-      << "  stepperX_           = " << stepperX_ << std::endl
-      << "  stepperXDot_        = " << stepperXDot_ << std::endl
-      << "  stepperXDotDot_     = " << stepperXDotDot_ << std::endl;
+  auto out = Teuchos::fancyOStream( in_out.getOStream() );
+  out->setOutputToRootOnly(0);
+  *out << "--- Stepper ---\n"
+       << "  isInitialized_      = " << Teuchos::toString(isInitialized_) << std::endl
+       << "  stepperType_        = " << stepperType_ << std::endl
+       << "  useFSAL_            = " << Teuchos::toString(useFSAL_) << std::endl
+       << "  ICConsistency_      = " << ICConsistency_ << std::endl
+       << "  ICConsistencyCheck_ = " << Teuchos::toString(ICConsistencyCheck_) << std::endl
+       << "  stepperX_           = " << stepperX_ << std::endl
+       << "  stepperXDot_        = " << stepperXDot_ << std::endl
+       << "  stepperXDotDot_     = " << stepperXDotDot_ << std::endl;
 }
 
 
 template<class Scalar>
 bool Stepper<Scalar>::isValidSetup(
-  Teuchos::FancyOStream & out) const
+  Teuchos::FancyOStream & in_out) const
 {
   bool isValidSetup = true;
 
   if ( !(ICConsistency_ == "None" || ICConsistency_ == "Zero" ||
          ICConsistency_ == "App"  || ICConsistency_ == "Consistent") ) {
     isValidSetup = false;
-    out.setOutputToRootOnly(0);
-    out << "The IC consistency does not have a valid value!\n"
-        << "('None', 'Zero', 'App' or 'Consistent')\n"
-        << "  ICConsistency  = " << ICConsistency_ << "\n";
+    auto out = Teuchos::fancyOStream( in_out.getOStream() );
+    out->setOutputToRootOnly(0);
+    *out << "The IC consistency does not have a valid value!\n"
+         << "('None', 'Zero', 'App' or 'Consistent')\n"
+         << "  ICConsistency  = " << ICConsistency_ << "\n";
   }
 
   return isValidSetup;

--- a/packages/tempus/src/Tempus_TimeStepControlStrategyComposite.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategyComposite.hpp
@@ -72,6 +72,7 @@ public:
     void describe(Teuchos::FancyOStream          &out,
                   const Teuchos::EVerbosityLevel verbLevel) const override
     {
+      out.setOutputToRootOnly(0);
       Teuchos::OSTab ostab(out,2,"describe");
       out << description() << "::describe:" << std::endl
           << "Strategy Type = " << this->getStrategyType()<< std::endl
@@ -237,6 +238,7 @@ createTimeStepControlStrategyComposite(
     } else {
       RCP<Teuchos::FancyOStream> out =
         Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
+      out->setOutputToRootOnly(0);
       Teuchos::OSTab ostab(out,1, "createTimeStepControlStrategyComposite()");
       *out << "Warning -- Unknown strategy type!\n"
            << "'Strategy Type' = '" << strategyType << "'\n"
@@ -251,6 +253,7 @@ createTimeStepControlStrategyComposite(
   if (tscsc->size() == 0) {
     RCP<Teuchos::FancyOStream> out =
       Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
+    out->setOutputToRootOnly(0);
     Teuchos::OSTab ostab(out,1, "createTimeStepControlStrategyComposite()");
     *out << "Warning -- Did not find a Tempus strategy to create!\n"
          << "Should call addStrategy() with (app-specific?) strategy(ies),\n"

--- a/packages/tempus/src/Tempus_TimeStepControlStrategyComposite.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategyComposite.hpp
@@ -69,24 +69,25 @@ public:
     std::string description() const override
     { return "Tempus::TimeStepControlComposite"; }
 
-    void describe(Teuchos::FancyOStream          &out,
+    void describe(Teuchos::FancyOStream          &in_out,
                   const Teuchos::EVerbosityLevel verbLevel) const override
     {
-      out.setOutputToRootOnly(0);
-      Teuchos::OSTab ostab(out,2,"describe");
-      out << description() << "::describe:" << std::endl
-          << "Strategy Type = " << this->getStrategyType()<< std::endl
-          << "Step Type     = " << this->getStepType()<< std::endl;
+      auto out = Teuchos::fancyOStream( in_out.getOStream() );
+      out->setOutputToRootOnly(0);
+      Teuchos::OSTab ostab(*out,2,"describe");
+      *out << description() << "::describe:" << std::endl
+           << "Strategy Type = " << this->getStrategyType()<< std::endl
+           << "Step Type     = " << this->getStepType()<< std::endl;
 
       std::stringstream sList;
       for(std::size_t i = 0; i < strategies_.size(); ++i) {
         sList << strategies_[i]->getStrategyType();
         if (i < strategies_.size()-1) sList << ", ";
       }
-      out << "Strategy List = " << sList.str() << std::endl;
+      *out << "Strategy List = " << sList.str() << std::endl;
 
       for(auto& s : strategies_)
-        s->describe(out, verbLevel);
+        s->describe(*out, verbLevel);
     }
   //@}
 

--- a/packages/tempus/src/Tempus_TimeStepControl_impl.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControl_impl.hpp
@@ -476,31 +476,32 @@ void TimeStepControl<Scalar>::describe(
       listTimes << times[times.size()-1];
     }
 
-    out.setOutputToRootOnly(0);
-    out << description() << "::describe:" << std::endl
-        << "stepType           = " << getStepType()            << std::endl
-        << "initTime           = " << getInitTime()            << std::endl
-        << "finalTime          = " << getFinalTime()           << std::endl
-        << "minTimeStep        = " << getMinTimeStep()         << std::endl
-        << "initTimeStep       = " << getInitTimeStep()        << std::endl
-        << "maxTimeStep        = " << getMaxTimeStep()         << std::endl
-        << "initIndex          = " << getInitIndex()           << std::endl
-        << "finalIndex         = " << getFinalIndex()          << std::endl
-        << "maxAbsError        = " << getMaxAbsError()         << std::endl
-        << "maxRelError        = " << getMaxRelError()         << std::endl
-        << "maxFailures        = " << getMaxFailures()         << std::endl
-        << "maxConsecFailures  = " << getMaxConsecFailures()   << std::endl
-        << "numTimeSteps       = " << getNumTimeSteps()        << std::endl
-        << "printDtChanges     = " << getPrintDtChanges()      << std::endl
-        << "outputExactly      = " << getOutputExactly()       << std::endl
-        << "outputIndices      = " << listIdx.str()            << std::endl
-        << "outputTimes        = " << listTimes.str()          << std::endl
-        << "outputIndexInterval= " << getOutputIndexInterval() << std::endl
-        << "outputTimeInterval = " << getOutputTimeInterval()  << std::endl
-        << "outputAdjustedDt   = " << outputAdjustedDt_        << std::endl
-        << "dtAfterOutput      = " << dtAfterOutput_           << std::endl
-        << "stepControlSrategy = " << std::endl;
-        stepControlStrategy_->describe(out, verbLevel);
+    auto l_out = Teuchos::fancyOStream( out.getOStream() );
+    l_out->setOutputToRootOnly(0);
+    *l_out << description() << "::describe:" << std::endl
+           << "stepType           = " << getStepType()            << std::endl
+           << "initTime           = " << getInitTime()            << std::endl
+           << "finalTime          = " << getFinalTime()           << std::endl
+           << "minTimeStep        = " << getMinTimeStep()         << std::endl
+           << "initTimeStep       = " << getInitTimeStep()        << std::endl
+           << "maxTimeStep        = " << getMaxTimeStep()         << std::endl
+           << "initIndex          = " << getInitIndex()           << std::endl
+           << "finalIndex         = " << getFinalIndex()          << std::endl
+           << "maxAbsError        = " << getMaxAbsError()         << std::endl
+           << "maxRelError        = " << getMaxRelError()         << std::endl
+           << "maxFailures        = " << getMaxFailures()         << std::endl
+           << "maxConsecFailures  = " << getMaxConsecFailures()   << std::endl
+           << "numTimeSteps       = " << getNumTimeSteps()        << std::endl
+           << "printDtChanges     = " << getPrintDtChanges()      << std::endl
+           << "outputExactly      = " << getOutputExactly()       << std::endl
+           << "outputIndices      = " << listIdx.str()            << std::endl
+           << "outputTimes        = " << listTimes.str()          << std::endl
+           << "outputIndexInterval= " << getOutputIndexInterval() << std::endl
+           << "outputTimeInterval = " << getOutputTimeInterval()  << std::endl
+           << "outputAdjustedDt   = " << outputAdjustedDt_        << std::endl
+           << "dtAfterOutput      = " << dtAfterOutput_           << std::endl
+           << "stepControlSrategy = " << std::endl;
+           stepControlStrategy_->describe(out, verbLevel);
   }
 }
 

--- a/packages/tempus/src/Tempus_TimeStepControl_impl.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControl_impl.hpp
@@ -172,6 +172,7 @@ printDtChanges(int istep, Scalar dt_old, Scalar dt_new, std::string reason) cons
   if (!getPrintDtChanges()) return;
 
   Teuchos::RCP<Teuchos::FancyOStream> out = this->getOStream();
+  out->setOutputToRootOnly(0);
   Teuchos::OSTab ostab(out,0,"printDtChanges");
 
   std::stringstream message;
@@ -433,6 +434,7 @@ void TimeStepControl<Scalar>::setNumTimeSteps(int numTimeSteps)
     setMaxTimeStep (initTimeStep);
 
     Teuchos::RCP<Teuchos::FancyOStream> out = this->getOStream();
+    out->setOutputToRootOnly(0);
     Teuchos::OSTab ostab(out,1,"setNumTimeSteps");
     *out << "Warning - setNumTimeSteps() Setting 'Number of Time Steps' = " << getNumTimeSteps()
          << "  Set the following parameters: \n"
@@ -474,6 +476,7 @@ void TimeStepControl<Scalar>::describe(
       listTimes << times[times.size()-1];
     }
 
+    out.setOutputToRootOnly(0);
     out << description() << "::describe:" << std::endl
         << "stepType           = " << getStepType()            << std::endl
         << "initTime           = " << getInitTime()            << std::endl
@@ -694,6 +697,7 @@ Teuchos::RCP<TimeStepControl<Scalar> > createTimeStepControl(
     } else {
       RCP<Teuchos::FancyOStream> out =
         Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
+      out->setOutputToRootOnly(0);
       Teuchos::OSTab ostab(out,1, "createTimeStepControl()");
       *out << "Warning -- Did not find a Tempus strategy to create!\n"
            << "'Strategy Type' = '" << strategyType << "'\n"

--- a/packages/tempus/src/Tempus_WrapperModelEvaluatorPairPartIMEX_Basic_impl.hpp
+++ b/packages/tempus/src/Tempus_WrapperModelEvaluatorPairPartIMEX_Basic_impl.hpp
@@ -317,6 +317,7 @@ setParameterIndex(int parameterIndex)
   if (implicitModel_->Np() == 0) {
     if (parameterIndex >= 0) {
       Teuchos::RCP<Teuchos::FancyOStream> out = this->getOStream();
+      out->setOutputToRootOnly(0);
       Teuchos::OSTab ostab(out,1,
         "WrapperModelEvaluatorPairPartIMEX_Basic::setParameterIndex()");
       *out << "Warning -- \n"
@@ -326,6 +327,7 @@ setParameterIndex(int parameterIndex)
     }
     if (parameterIndex_ >= 0) {
       Teuchos::RCP<Teuchos::FancyOStream> out = this->getOStream();
+      out->setOutputToRootOnly(0);
       Teuchos::OSTab ostab(out,1,
         "WrapperModelEvaluatorPairPartIMEX_Basic::setParameterIndex()");
       *out << "Warning -- \n"


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tempus 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

When in parallel, the warnings are printed by each rank. On small number processor count, this is not an issue. However, on large number of processor counts, this fills up the log file ( space issue ) and burdens the user.

So to fix it, define the output stream to be a Teuchos fanceOSstream and set output to root only to true.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->