### PR TITLE
Implement getHostBasis() in newer Basis subclasses

### DIFF
--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_Basis.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_Basis.hpp
@@ -75,6 +75,11 @@ class Basis;
 template <typename DeviceType = void, typename OutputType = double, typename PointType = double>
 using BasisPtr = Teuchos::RCP<Basis<DeviceType,OutputType,PointType> >;
 
+/** \brief Pointer to a Basis whose device type is on the host (Kokkos::HostSpace::device_type), allowing host access to input and output views, and ensuring host execution of basis evaluation.
+ */
+template <typename OutputType = double, typename PointType = double>
+using HostBasisPtr = BasisPtr<typename Kokkos::HostSpace::device_type, OutputType, PointType>;
+
   /** \class  Intrepid2::Basis
       \brief  An abstract base class that defines interface for concrete basis implementations for
               Finite Element (FEM) and Finite Volume/Finite Difference (FVD) discrete spaces.
@@ -902,7 +907,7 @@ using BasisPtr = Teuchos::RCP<Basis<DeviceType,OutputType,PointType> >;
     
        \return Pointer to the new Basis object.
     */
-    virtual BasisPtr<typename Kokkos::HostSpace::device_type, OutputValueType, PointValueType>
+    virtual HostBasisPtr<OutputValueType, PointValueType>
     getHostBasis() const {
       INTREPID2_TEST_FOR_EXCEPTION( true, std::logic_error,
                                     ">>> ERROR (Basis::getHostBasis): this method is not supported or should be overridden accordingly by derived classes.");

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_Basis.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_Basis.hpp
@@ -898,10 +898,10 @@ using BasisPtr = Teuchos::RCP<Basis<DeviceType,OutputType,PointType> >;
                                     ">>> ERROR (Basis::getSubCellRefBasis): this method is not supported or should be overridden accordingly by derived classes.");
     }
 
-    /** \brief creates and returns a basis object allocated on host.
-     
-        \return pointer to a basis allocated on host.
-     */
+    /** \brief Creates and returns a Basis object whose DeviceType template argument is Kokkos::HostSpace::device_type, but is otherwise identical to this.
+    
+       \return Pointer to the new Basis object.
+    */
     virtual BasisPtr<typename Kokkos::HostSpace::device_type, OutputValueType, PointValueType>
     getHostBasis() const {
       INTREPID2_TEST_FOR_EXCEPTION( true, std::logic_error,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasisFamily.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasisFamily.hpp
@@ -86,7 +86,7 @@ namespace Intrepid2
     using OutputValueType = typename LineBasisHGRAD::OutputValueType;
     using PointValueType  = typename LineBasisHGRAD::PointValueType;
     
-    using Basis    = ::Intrepid2::Basis<ExecutionSpace,OutputValueType,PointValueType>;
+    using Basis    = typename LineBasisHGRAD::BasisBase;
     using BasisPtr = Teuchos::RCP<Basis>;
     
     // line bases

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HCURL_HEX.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HCURL_HEX.hpp
@@ -540,11 +540,11 @@ namespace Intrepid2
   
   template<class HGRAD_LINE, class HVOL_LINE>
   class Basis_Derived_HCURL_Family1_Family2_HEX
-  : public Basis_DirectSumBasis <typename HGRAD_LINE::ExecutionSpace, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>
+  : public Basis_DirectSumBasis <typename HGRAD_LINE::BasisBase>
   {
     using Family1 = Basis_Derived_HCURL_Family1_HEX<HGRAD_LINE, HVOL_LINE>;
     using Family2 = Basis_Derived_HCURL_Family2_HEX<HGRAD_LINE, HVOL_LINE>;
-    using DirectSumBasis = Basis_DirectSumBasis  <typename HGRAD_LINE::ExecutionSpace, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>;
+    using DirectSumBasis = Basis_DirectSumBasis  <typename HGRAD_LINE::BasisBase>;
   public:
     /** \brief  Constructor.
         \param [in] polyOrder_x - the polynomial order in the x dimension.
@@ -560,11 +560,11 @@ namespace Intrepid2
   
   template<class HGRAD_LINE, class HVOL_LINE>
   class Basis_Derived_HCURL_HEX
-  : public Basis_DirectSumBasis <typename HGRAD_LINE::ExecutionSpace, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>
+  : public Basis_DirectSumBasis <typename HGRAD_LINE::BasisBase>
   {
     using Family12 = Basis_Derived_HCURL_Family1_Family2_HEX<HGRAD_LINE, HVOL_LINE>;
     using Family3  = Basis_Derived_HCURL_Family3_HEX        <HGRAD_LINE, HVOL_LINE>;
-    using DirectSumBasis = Basis_DirectSumBasis <typename HGRAD_LINE::ExecutionSpace, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>;
+    using DirectSumBasis = Basis_DirectSumBasis <typename HGRAD_LINE::BasisBase>;
 
     std::string name_;
     ordinal_type order_x_;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HCURL_HEX.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HCURL_HEX.hpp
@@ -67,9 +67,7 @@ namespace Intrepid2
 {
   template<class HGRAD_LINE, class HVOL_LINE>
   class Basis_Derived_HCURL_Family1_HEX
-  : public Basis_TensorBasis3<HVOL_LINE,
-                              HGRAD_LINE,
-                              HGRAD_LINE>
+  : public Basis_TensorBasis3<typename HGRAD_LINE::BasisBase>
   {
   public:
     using OutputViewType = typename HGRAD_LINE::OutputViewType;
@@ -79,7 +77,7 @@ namespace Intrepid2
     using LineGradBasis = HGRAD_LINE;
     using LineVolBasis  = HVOL_LINE;
     
-    using TensorBasis3 = Basis_TensorBasis3<LineVolBasis, LineGradBasis, LineGradBasis>;
+    using TensorBasis3 = Basis_TensorBasis3<typename HGRAD_LINE::BasisBase>;
   public:
     /** \brief  Constructor.
         \param [in] polyOrder_x - the polynomial order in the x dimension.
@@ -224,9 +222,7 @@ namespace Intrepid2
 
   template<class HGRAD_LINE, class HVOL_LINE>
   class Basis_Derived_HCURL_Family2_HEX
-  : public Basis_TensorBasis3<HGRAD_LINE,
-                              HVOL_LINE,
-                              HGRAD_LINE>
+  : public Basis_TensorBasis3<typename HGRAD_LINE::BasisBase>
   {
   public:
     using OutputViewType = typename HGRAD_LINE::OutputViewType;
@@ -236,7 +232,7 @@ namespace Intrepid2
     using LineGradBasis = HGRAD_LINE;
     using LineVolBasis  = HVOL_LINE;
     
-    using TensorBasis3 = Basis_TensorBasis3<LineGradBasis, LineVolBasis, LineGradBasis>;
+    using TensorBasis3 = Basis_TensorBasis3<typename HGRAD_LINE::BasisBase>;
   public:
     /** \brief  Constructor.
         \param [in] polyOrder_x - the polynomial order in the x dimension.
@@ -388,9 +384,7 @@ namespace Intrepid2
   
   template<class HGRAD_LINE, class HVOL_LINE>
   class Basis_Derived_HCURL_Family3_HEX
-  : public Basis_TensorBasis3<HGRAD_LINE,
-                              HGRAD_LINE,
-                              HVOL_LINE>
+  : public Basis_TensorBasis3<typename HGRAD_LINE::BasisBase>
   {
     using OutputViewType = typename HGRAD_LINE::OutputViewType;
     using PointViewType  = typename HGRAD_LINE::PointViewType ;
@@ -399,7 +393,7 @@ namespace Intrepid2
     using LineGradBasis = HGRAD_LINE;
     using LineVolBasis  = HVOL_LINE;
     
-    using TensorBasis3 = Basis_TensorBasis3<LineGradBasis, LineGradBasis, LineVolBasis>;
+    using TensorBasis3 = Basis_TensorBasis3<typename HGRAD_LINE::BasisBase>;
   public:
     /** \brief  Constructor.
         \param [in] polyOrder_x - the polynomial order in the x dimension.
@@ -577,6 +571,8 @@ namespace Intrepid2
     using ExecutionSpace  = typename HGRAD_LINE::ExecutionSpace;
     using OutputValueType = typename HGRAD_LINE::OutputValueType;
     using PointValueType  = typename HGRAD_LINE::PointValueType;
+    
+    using BasisBase = typename HGRAD_LINE::BasisBase;
 
     /** \brief  Constructor.
         \param [in] polyOrder_x - the polynomial order in the x dimension.
@@ -631,7 +627,7 @@ namespace Intrepid2
         \param [in] subCellOrd - position of the subCell among of the subCells having the same dimension
         \return pointer to the subCell basis of dimension subCellDim and position subCellOrd
      */
-    BasisPtr<ExecutionSpace, OutputValueType, PointValueType>
+    Teuchos::RCP<BasisBase>
       getSubCellRefBasis(const ordinal_type subCellDim, const ordinal_type subCellOrd) const override{
 
       using LineBasis = HVOL_LINE;
@@ -674,7 +670,18 @@ namespace Intrepid2
 
       INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
     }
-
+    /** \brief Creates and returns a Basis object whose DeviceType template argument is Kokkos::HostSpace::device_type, but is otherwise identical to this.
+     
+        \return Pointer to the new Basis object.
+     */
+    virtual HostBasisPtr<OutputValueType, PointValueType>
+    getHostBasis() const override {
+      using HostBasis  = Basis_Derived_HCURL_HEX<typename HGRAD_LINE::HostBasis, typename HVOL_LINE::HostBasis>;
+      
+      auto hostBasis = Teuchos::rcp(new HostBasis(order_x_, order_y_, order_z_, pointType_));
+      
+      return hostBasis;
+    }
   };
 } // end namespace Intrepid2
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HCURL_QUAD.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HCURL_QUAD.hpp
@@ -66,7 +66,7 @@ namespace Intrepid2
 {
   template<class HGRAD_LINE, class HVOL_LINE>
   class Basis_Derived_HCURL_Family1_QUAD
-  : public Basis_TensorBasis<typename HGRAD_LINE::ExecutionSpace, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>
+  : public Basis_TensorBasis<typename HGRAD_LINE::BasisBase>
   {
   public:
     using ExecutionSpace  = typename HGRAD_LINE::ExecutionSpace;
@@ -77,10 +77,12 @@ namespace Intrepid2
     using PointViewType  = typename HGRAD_LINE::PointViewType ;
     using ScalarViewType = typename HGRAD_LINE::ScalarViewType;
     
+    using BasisBase = typename HGRAD_LINE::BasisBase;
+    
     using LineGradBasis = HGRAD_LINE;
     using LineHVolBasis = HVOL_LINE;
     
-    using TensorBasis = Basis_TensorBasis<ExecutionSpace, OutputValueType, PointValueType>;
+    using TensorBasis = Basis_TensorBasis<BasisBase>;
   public:
     /** \brief  Constructor.
         \param [in] polyOrder_x - the polynomial order in the x dimension.
@@ -191,7 +193,7 @@ namespace Intrepid2
 
   template<class HGRAD_LINE, class HVOL_LINE>
   class Basis_Derived_HCURL_Family2_QUAD
-  : public Basis_TensorBasis<typename HGRAD_LINE::ExecutionSpace, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>
+  : public Basis_TensorBasis<typename HGRAD_LINE::BasisBase>
   {
 
   public:
@@ -206,7 +208,9 @@ namespace Intrepid2
     using LineGradBasis = HGRAD_LINE;
     using LineHVolBasis = HVOL_LINE;
     
-    using TensorBasis = Basis_TensorBasis<ExecutionSpace, OutputValueType, PointValueType>;
+    using BasisBase = typename HGRAD_LINE::BasisBase;
+    
+    using TensorBasis = Basis_TensorBasis<BasisBase>;
 
     /** \brief  Constructor.
         \param [in] polyOrder_x - the polynomial order in the x dimension.

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HCURL_QUAD.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HCURL_QUAD.hpp
@@ -321,11 +321,11 @@ namespace Intrepid2
   
   template<class HGRAD_LINE, class HVOL_LINE>
   class Basis_Derived_HCURL_QUAD
-  : public Basis_DirectSumBasis <typename HGRAD_LINE::ExecutionSpace, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>
+  : public Basis_DirectSumBasis <typename HGRAD_LINE::BasisBase>
   {
     using Family1 = Basis_Derived_HCURL_Family1_QUAD<HGRAD_LINE, HVOL_LINE>;
     using Family2 = Basis_Derived_HCURL_Family2_QUAD<HGRAD_LINE, HVOL_LINE>;
-    using DirectSumBasis = Basis_DirectSumBasis <typename HGRAD_LINE::ExecutionSpace, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>;
+    using DirectSumBasis = Basis_DirectSumBasis <typename HGRAD_LINE::BasisBase>;
 
   protected:
     std::string name_;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HCURL_QUAD.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HCURL_QUAD.hpp
@@ -326,6 +326,8 @@ namespace Intrepid2
     using Family1 = Basis_Derived_HCURL_Family1_QUAD<HGRAD_LINE, HVOL_LINE>;
     using Family2 = Basis_Derived_HCURL_Family2_QUAD<HGRAD_LINE, HVOL_LINE>;
     using DirectSumBasis = Basis_DirectSumBasis <typename HGRAD_LINE::BasisBase>;
+    
+    using BasisBase = typename HGRAD_LINE::BasisBase;
 
   protected:
     std::string name_;
@@ -392,7 +394,7 @@ namespace Intrepid2
         \param [in] subCellOrd - position of the subCell among of the subCells having the same dimension
         \return pointer to the subCell basis of dimension subCellDim and position subCellOrd
      */
-    BasisPtr<ExecutionSpace, OutputValueType, PointValueType>
+    Teuchos::RCP<BasisBase>
       getSubCellRefBasis(const ordinal_type subCellDim, const ordinal_type subCellOrd) const override{
       if(subCellDim == 1) {
         switch(subCellOrd) {
@@ -408,6 +410,18 @@ namespace Intrepid2
       INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
     }
 
+    /** \brief Creates and returns a Basis object whose DeviceType template argument is Kokkos::HostSpace::device_type, but is otherwise identical to this.
+     
+        \return Pointer to the new Basis object.
+     */
+    virtual HostBasisPtr<OutputValueType, PointValueType>
+    getHostBasis() const override {
+      using HostBasis  = Basis_Derived_HCURL_QUAD<typename HGRAD_LINE::HostBasis, typename HVOL_LINE::HostBasis>;
+      
+      auto hostBasis = Teuchos::rcp(new HostBasis(order_x_, order_y_, pointType_));
+      
+      return hostBasis;
+    }
   };
 } // end namespace Intrepid2
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HDIV_HEX.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HDIV_HEX.hpp
@@ -483,11 +483,11 @@ namespace Intrepid2
   // which is to say that we go 3,1,2.
   template<class HGRAD_LINE, class HVOL_LINE>
   class Basis_Derived_HDIV_Family3_Family1_HEX
-  : public Basis_DirectSumBasis <typename HGRAD_LINE::ExecutionSpace, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>
+  : public Basis_DirectSumBasis <typename HGRAD_LINE::BasisBase>
   {
     using Family3 = Basis_Derived_HDIV_Family3_HEX<HGRAD_LINE, HVOL_LINE>;
     using Family1 = Basis_Derived_HDIV_Family1_HEX<HGRAD_LINE, HVOL_LINE>;
-    using DirectSumBasis = Basis_DirectSumBasis<typename HGRAD_LINE::ExecutionSpace, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>;
+    using DirectSumBasis = Basis_DirectSumBasis<typename HGRAD_LINE::BasisBase>;
   public:
     /** \brief  Constructor.
         \param [in] polyOrder_x - the polynomial order in the x dimension.
@@ -505,11 +505,11 @@ namespace Intrepid2
   
   template<class HGRAD_LINE, class HVOL_LINE>
   class Basis_Derived_HDIV_HEX
-  : public Basis_DirectSumBasis <typename HGRAD_LINE::ExecutionSpace, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>
+  : public Basis_DirectSumBasis <typename HGRAD_LINE::BasisBase>
   {
     using Family31 = Basis_Derived_HDIV_Family3_Family1_HEX<HGRAD_LINE, HVOL_LINE>;
     using Family2  = Basis_Derived_HDIV_Family2_HEX        <HGRAD_LINE, HVOL_LINE>;
-    using DirectSumBasis = Basis_DirectSumBasis<typename HGRAD_LINE::ExecutionSpace, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>;
+    using DirectSumBasis = Basis_DirectSumBasis<typename HGRAD_LINE::BasisBase>;
 
     std::string name_;
     ordinal_type order_x_;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HDIV_HEX.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HDIV_HEX.hpp
@@ -71,7 +71,7 @@ namespace Intrepid2
   template<class HGRAD_LINE, class HVOL_LINE>
   class Basis_Derived_HDIV_Family1_HEX
   :
-  public Basis_TensorBasis3<HGRAD_LINE, HVOL_LINE, HVOL_LINE>
+  public Basis_TensorBasis3<typename HGRAD_LINE::BasisBase>
   {
   public:
     using OutputViewType = typename HGRAD_LINE::OutputViewType;
@@ -81,7 +81,7 @@ namespace Intrepid2
     using LineGradBasis = HGRAD_LINE;
     using LineHVolBasis = HVOL_LINE;
     
-    using TensorBasis3 = Basis_TensorBasis3<LineGradBasis, LineHVolBasis, LineHVolBasis>;
+    using TensorBasis3 = Basis_TensorBasis3<typename HGRAD_LINE::BasisBase>;
   public:
     /** \brief  Constructor.
         \param [in] polyOrder_x - the polynomial order in the x dimension.
@@ -205,7 +205,7 @@ namespace Intrepid2
   template<class HGRAD_LINE, class HVOL_LINE>
   class Basis_Derived_HDIV_Family2_HEX
   :
-  public Basis_TensorBasis3<HVOL_LINE, HGRAD_LINE, HVOL_LINE>
+  public Basis_TensorBasis3<typename HGRAD_LINE::BasisBase>
   {
   public:
     using OutputViewType = typename HGRAD_LINE::OutputViewType;
@@ -215,7 +215,7 @@ namespace Intrepid2
     using LineGradBasis = HGRAD_LINE;
     using LineHVolBasis = HVOL_LINE;
     
-    using TensorBasis3 = Basis_TensorBasis3<LineHVolBasis, LineGradBasis, LineHVolBasis>;
+    using TensorBasis3 = Basis_TensorBasis3<typename HGRAD_LINE::BasisBase>;
   public:
     /** \brief  Constructor.
         \param [in] polyOrder_x - the polynomial order in the x dimension.
@@ -344,7 +344,7 @@ namespace Intrepid2
   
   template<class HGRAD_LINE, class HVOL_LINE>
   class Basis_Derived_HDIV_Family3_HEX
-  : public Basis_TensorBasis3<HVOL_LINE, HVOL_LINE, HGRAD_LINE>
+  : public Basis_TensorBasis3<typename HGRAD_LINE::BasisBase>
   {
   public:
     using OutputViewType = typename HGRAD_LINE::OutputViewType;
@@ -354,7 +354,7 @@ namespace Intrepid2
     using LineGradBasis = HGRAD_LINE;
     using LineHVolBasis = HVOL_LINE;
     
-    using TensorBasis3 = Basis_TensorBasis3<LineHVolBasis, LineHVolBasis, LineGradBasis>;
+    using TensorBasis3 = Basis_TensorBasis3<typename HGRAD_LINE::BasisBase>;
   public:
     /** \brief  Constructor.
         \param [in] polyOrder_x - the polynomial order in the x dimension.
@@ -521,6 +521,8 @@ namespace Intrepid2
     using ExecutionSpace  = typename HGRAD_LINE::ExecutionSpace;
     using OutputValueType = typename HGRAD_LINE::OutputValueType;
     using PointValueType  = typename HGRAD_LINE::PointValueType;
+    
+    using BasisBase = typename HGRAD_LINE::BasisBase;
 
     /** \brief  Constructor.
         \param [in] polyOrder_x - the polynomial order in the x dimension.
@@ -575,8 +577,8 @@ namespace Intrepid2
         \param [in] subCellOrd - position of the subCell among of the subCells having the same dimension
         \return pointer to the subCell basis of dimension subCellDim and position subCellOrd
      */
-    BasisPtr<ExecutionSpace, OutputValueType, PointValueType>
-      getSubCellRefBasis(const ordinal_type subCellDim, const ordinal_type subCellOrd) const override{
+    Teuchos::RCP<BasisBase>
+      getSubCellRefBasis(const ordinal_type subCellDim, const ordinal_type subCellOrd) const override {
 
       using QuadBasis = Basis_Derived_HVOL_QUAD<HVOL_LINE>;
 
@@ -599,7 +601,19 @@ namespace Intrepid2
 
       INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
     }
-
+    
+    /** \brief Creates and returns a Basis object whose DeviceType template argument is Kokkos::HostSpace::device_type, but is otherwise identical to this.
+     
+        \return Pointer to the new Basis object.
+     */
+    virtual HostBasisPtr<OutputValueType, PointValueType>
+    getHostBasis() const override {
+      using HostBasis  = Basis_Derived_HDIV_HEX<typename HGRAD_LINE::HostBasis, typename HVOL_LINE::HostBasis>;
+      
+      auto hostBasis = Teuchos::rcp(new HostBasis(order_x_, order_y_, order_z_, pointType_));
+      
+      return hostBasis;
+    }
   };
 } // end namespace Intrepid2
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HDIV_QUAD.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HDIV_QUAD.hpp
@@ -335,11 +335,11 @@ namespace Intrepid2
   
   template<class HGRAD_LINE, class HVOL_LINE>
   class Basis_Derived_HDIV_QUAD
-  : public Basis_DirectSumBasis <typename HGRAD_LINE::ExecutionSpace, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>
+  : public Basis_DirectSumBasis <typename HGRAD_LINE::BasisBase>
   {
     using Family1 = Basis_Derived_HDIV_Family1_QUAD<HGRAD_LINE, HVOL_LINE>;
     using Family2 = Basis_Derived_HDIV_Family2_QUAD<HGRAD_LINE, HVOL_LINE>;
-    using DirectSumBasis = Basis_DirectSumBasis <typename HGRAD_LINE::ExecutionSpace, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>;
+    using DirectSumBasis = Basis_DirectSumBasis <typename HGRAD_LINE::BasisBase>;
 
   public:
     using ExecutionSpace  = typename HGRAD_LINE::ExecutionSpace;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HDIV_QUAD.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HDIV_QUAD.hpp
@@ -66,7 +66,7 @@ namespace Intrepid2
 {
   template<class HGRAD_LINE, class HVOL_LINE>
   class Basis_Derived_HDIV_Family1_QUAD
-  : public Basis_TensorBasis<typename HGRAD_LINE::ExecutionSpace, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>
+  : public Basis_TensorBasis<typename HGRAD_LINE::BasisBase>
   {
   public:
     using ExecutionSpace  = typename HGRAD_LINE::ExecutionSpace;
@@ -80,7 +80,9 @@ namespace Intrepid2
     using LineGradBasis = HGRAD_LINE;
     using LineHVolBasis = HVOL_LINE;
     
-    using TensorBasis = Basis_TensorBasis<ExecutionSpace, OutputValueType, PointValueType>;
+    using BasisBase = typename HGRAD_LINE::BasisBase;
+    
+    using TensorBasis = Basis_TensorBasis<BasisBase>;
   public:
     /** \brief  Constructor.
         \param [in] polyOrder_x - the polynomial order in the x dimension.
@@ -204,7 +206,7 @@ namespace Intrepid2
 
   template<class HGRAD_LINE, class HVOL_LINE>
   class Basis_Derived_HDIV_Family2_QUAD
-  : public Basis_TensorBasis<typename HGRAD_LINE::ExecutionSpace, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>
+  : public Basis_TensorBasis<typename HGRAD_LINE::BasisBase>
   {
     using ExecutionSpace  = typename HGRAD_LINE::ExecutionSpace;
     using OutputValueType = typename HGRAD_LINE::OutputValueType;
@@ -217,7 +219,9 @@ namespace Intrepid2
     using LineGradBasis = HGRAD_LINE;
     using LineHVolBasis = HVOL_LINE;
     
-    using TensorBasis = Basis_TensorBasis<ExecutionSpace, OutputValueType, PointValueType>;
+    using BasisBase = typename HGRAD_LINE::BasisBase;
+    
+    using TensorBasis = Basis_TensorBasis<BasisBase>;
   public:
     /** \brief  Constructor.
         \param [in] polyOrder_x - the polynomial order in the x dimension.

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HDIV_QUAD.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HDIV_QUAD.hpp
@@ -345,6 +345,8 @@ namespace Intrepid2
     using ExecutionSpace  = typename HGRAD_LINE::ExecutionSpace;
     using OutputValueType = typename HGRAD_LINE::OutputValueType;
     using PointValueType  = typename HGRAD_LINE::PointValueType;
+    
+    using BasisBase = typename HGRAD_LINE::BasisBase;
 
   protected:
     std::string name_;
@@ -405,7 +407,7 @@ namespace Intrepid2
         \param [in] subCellOrd - position of the subCell among of the subCells having the same dimension
         \return pointer to the subCell basis of dimension subCellDim and position subCellOrd
      */
-    BasisPtr<ExecutionSpace, OutputValueType, PointValueType>
+    Teuchos::RCP<BasisBase>
       getSubCellRefBasis(const ordinal_type subCellDim, const ordinal_type subCellOrd) const override{
       if(subCellDim == 1) {
         switch(subCellOrd) {
@@ -419,6 +421,19 @@ namespace Intrepid2
       }
 
       INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
+    }
+    
+    /** \brief Creates and returns a Basis object whose DeviceType template argument is Kokkos::HostSpace::device_type, but is otherwise identical to this.
+     
+        \return Pointer to the new Basis object.
+     */
+    virtual HostBasisPtr<OutputValueType, PointValueType>
+    getHostBasis() const override {
+      using HostBasis  = Basis_Derived_HDIV_QUAD<typename HGRAD_LINE::HostBasis, typename HVOL_LINE::HostBasis>;
+      
+      auto hostBasis = Teuchos::rcp(new HostBasis(order_x_, order_y_, pointType_));
+      
+      return hostBasis;
     }
   };
 } // end namespace Intrepid2

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HGRAD_HEX.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HGRAD_HEX.hpp
@@ -66,7 +66,7 @@ namespace Intrepid2
   // TODO: make this a subclass of TensorBasis3 instead, following what we've done for H(curl) and H(div)
   template<class HGRAD_LINE>
   class Basis_Derived_HGRAD_HEX
-  : public Basis_TensorBasis<typename HGRAD_LINE::ExecutionSpace, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>
+  : public Basis_TensorBasis<typename HGRAD_LINE::BasisBase>
   {
   public:
     using ExecutionSpace  = typename HGRAD_LINE::ExecutionSpace;
@@ -79,7 +79,8 @@ namespace Intrepid2
     
     using LineBasis = HGRAD_LINE;
     using QuadBasis = Intrepid2::Basis_Derived_HGRAD_QUAD<HGRAD_LINE>;
-    using TensorBasis = Basis_TensorBasis<ExecutionSpace, OutputValueType, PointValueType>;
+    using BasisBase = typename HGRAD_LINE::BasisBase;
+    using TensorBasis = Basis_TensorBasis<BasisBase>;
 
     std::string name_;
     ordinal_type order_x_;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HGRAD_HEX.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HGRAD_HEX.hpp
@@ -156,7 +156,7 @@ namespace Intrepid2
       }
     }
 
-    using Basis<ExecutionSpace,OutputValueType,PointValueType>::getValues;
+    using BasisBase::getValues;
     
     /** \brief  multi-component getValues() method (required/called by TensorBasis)
         \param [out] outputValues - the view into which to place the output values
@@ -232,7 +232,7 @@ namespace Intrepid2
         \param [in] subCellOrd - position of the subCell among of the subCells having the same dimension
         \return pointer to the subCell basis of dimension subCellDim and position subCellOrd
      */
-    BasisPtr<ExecutionSpace, OutputValueType, PointValueType>
+    Teuchos::RCP<BasisBase>
       getSubCellRefBasis(const ordinal_type subCellDim, const ordinal_type subCellOrd) const override{
       if(subCellDim == 1) {
         switch(subCellOrd) {
@@ -270,6 +270,19 @@ namespace Intrepid2
       }
 
       INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
+    }
+    
+    /** \brief Creates and returns a Basis object whose DeviceType template argument is Kokkos::HostSpace::device_type, but is otherwise identical to this.
+     
+        \return Pointer to the new Basis object.
+     */
+    virtual HostBasisPtr<OutputValueType, PointValueType>
+    getHostBasis() const override {
+      using HostBasis  = Basis_Derived_HGRAD_HEX<typename HGRAD_LINE::HostBasis>;
+      
+      auto hostBasis = Teuchos::rcp(new HostBasis(order_x_, order_y_, order_z_, pointType_));
+      
+      return hostBasis;
     }
   };
 } // end namespace Intrepid2

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HGRAD_QUAD.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HGRAD_QUAD.hpp
@@ -140,7 +140,7 @@ namespace Intrepid2
       }
     }
     
-    using Basis<ExecutionSpace,OutputValueType,PointValueType>::getValues;
+    using BasisBase::getValues;
 
     /** \brief  multi-component getValues() method (required/called by TensorBasis)
         \param [out] outputValues - the view into which to place the output values
@@ -217,7 +217,7 @@ namespace Intrepid2
           \param [in] subCellOrd - position of the subCell among of the subCells having the same dimension
           \return pointer to the subCell basis of dimension subCellDim and position subCellOrd
        */
-    BasisPtr<ExecutionSpace, OutputValueType, PointValueType>
+    Teuchos::RCP<BasisBase>
       getSubCellRefBasis(const ordinal_type subCellDim, const ordinal_type subCellOrd) const override{
       if(subCellDim == 1) {
         switch(subCellOrd) {
@@ -231,6 +231,19 @@ namespace Intrepid2
       }
 
       INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
+    }
+    
+    /** \brief Creates and returns a Basis object whose DeviceType template argument is Kokkos::HostSpace::device_type, but is otherwise identical to this.
+     
+        \return Pointer to the new Basis object.
+     */
+    virtual HostBasisPtr<OutputValueType, PointValueType>
+    getHostBasis() const override {
+      using HostBasis  = Basis_Derived_HGRAD_QUAD<typename HGRAD_LINE::HostBasis>;
+      
+      auto hostBasis = Teuchos::rcp(new HostBasis(order_x_, order_y_, pointType_));
+      
+      return hostBasis;
     }
   };
 } // end namespace Intrepid2

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HGRAD_QUAD.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HGRAD_QUAD.hpp
@@ -57,7 +57,7 @@ namespace Intrepid2
 {
   template<class HGRAD_LINE>
   class Basis_Derived_HGRAD_QUAD
-  : public Basis_TensorBasis<typename HGRAD_LINE::ExecutionSpace, typename HGRAD_LINE::OutputValueType, typename HGRAD_LINE::PointValueType>
+  : public Basis_TensorBasis<typename HGRAD_LINE::BasisBase>
   {
   protected:
     std::string name_;
@@ -72,8 +72,9 @@ namespace Intrepid2
     using PointViewType  = typename HGRAD_LINE::PointViewType ;
     using ScalarViewType = typename HGRAD_LINE::ScalarViewType;
     
+    using BasisBase = typename HGRAD_LINE::BasisBase;
     using LineBasis = HGRAD_LINE;
-    using TensorBasis = Basis_TensorBasis<ExecutionSpace, OutputValueType, PointValueType>;
+    using TensorBasis = Basis_TensorBasis<BasisBase>;
 
     /** \brief  Constructor.
         \param [in] polyOrder_x - the polynomial order in the x dimension.

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HVOL_HEX.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HVOL_HEX.hpp
@@ -73,7 +73,8 @@ namespace Intrepid2
   // TODO: make this a subclass of TensorBasis3 instead, following what we've done for H(curl) and H(div)
   {
     std::string name_;
-
+    ordinal_type polyOrder_x_, polyOrder_y_, polyOrder_z_;
+    EPointType pointType_;
   public:
     using ExecutionSpace  = typename HVOL_LINE::ExecutionSpace;
     using OutputValueType = typename HVOL_LINE::OutputValueType;
@@ -98,7 +99,11 @@ namespace Intrepid2
     Basis_Derived_HVOL_HEX(int polyOrder_x, int polyOrder_y, int polyOrder_z, const EPointType pointType=POINTTYPE_DEFAULT)
     :
     TensorBasis(Teuchos::rcp(new QuadBasis(polyOrder_x,polyOrder_y,pointType)),
-                Teuchos::rcp(new LineBasis(polyOrder_z,pointType)))
+                Teuchos::rcp(new LineBasis(polyOrder_z,pointType))),
+    polyOrder_x_(polyOrder_x),
+    polyOrder_y_(polyOrder_y),
+    polyOrder_z_(polyOrder_z),
+    pointType_(pointType)
     {
       this->functionSpace_ = FUNCTION_SPACE_HVOL;
 
@@ -170,6 +175,16 @@ namespace Intrepid2
       {
         INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"operator not yet supported");
       }
+    }
+    
+    /** \brief Creates and returns a Basis object whose DeviceType template argument is Kokkos::HostSpace::device_type, but is otherwise identical to this.
+     
+        \return Pointer to the new Basis object.
+     */
+    virtual BasisPtr<typename Kokkos::HostSpace::device_type, typename BasisBase::OutputValueType, typename BasisBase::PointValueType>
+    getHostBasis() const override {
+      using HostBasisType  = Basis_Derived_HVOL_HEX<typename HVOL_LINE::HostBasis>;
+      return Teuchos::rcp( new HostBasisType(polyOrder_x_, polyOrder_y_, polyOrder_z_, pointType_) );
     }
   };
 } // end namespace Intrepid2

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HVOL_HEX.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HVOL_HEX.hpp
@@ -69,7 +69,7 @@ namespace Intrepid2
   template<class HVOL_LINE>
   class Basis_Derived_HVOL_HEX
   :
-  public Basis_TensorBasis<typename HVOL_LINE::ExecutionSpace, typename HVOL_LINE::OutputValueType, typename HVOL_LINE::PointValueType>
+  public Basis_TensorBasis<typename HVOL_LINE::BasisBase>
   // TODO: make this a subclass of TensorBasis3 instead, following what we've done for H(curl) and H(div)
   {
     std::string name_;
@@ -83,9 +83,11 @@ namespace Intrepid2
     using PointViewType  = typename HVOL_LINE::PointViewType ;
     using ScalarViewType = typename HVOL_LINE::ScalarViewType;
     
+    using BasisBase = typename HVOL_LINE::BasisBase;
+    
     using LineBasis = HVOL_LINE;
     using QuadBasis = Intrepid2::Basis_Derived_HVOL_QUAD<HVOL_LINE>;
-    using TensorBasis = Basis_TensorBasis<ExecutionSpace, OutputValueType, PointValueType>;
+    using TensorBasis = Basis_TensorBasis<BasisBase>;
 
     /** \brief  Constructor.
         \param [in] polyOrder_x - the polynomial order in the x dimension.

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HVOL_QUAD.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HVOL_QUAD.hpp
@@ -70,11 +70,13 @@ namespace Intrepid2
     std::string name_;
     using LineBasis = HVOL_LINE;
     using TensorBasis = Basis_TensorBasis<typename HVOL_LINE::BasisBase>;
+    
+    ordinal_type polyOrder_x_, polyOrder_y_;
+    EPointType pointType_;
   public:
-
-   using ExecutionSpace  = typename HVOL_LINE::ExecutionSpace;
-   using OutputValueType = typename HVOL_LINE::OutputValueType;
-   using PointValueType  = typename HVOL_LINE::PointValueType;
+    using ExecutionSpace  = typename HVOL_LINE::ExecutionSpace;
+    using OutputValueType = typename HVOL_LINE::OutputValueType;
+    using PointValueType  = typename HVOL_LINE::PointValueType;
 
     using OutputViewType = typename HVOL_LINE::OutputViewType;
     using PointViewType  = typename HVOL_LINE::PointViewType ;
@@ -90,7 +92,10 @@ namespace Intrepid2
     Basis_Derived_HVOL_QUAD(int polyOrder_x, int polyOrder_y, const EPointType pointType=POINTTYPE_DEFAULT)
     :
     TensorBasis(Teuchos::rcp( new LineBasis(polyOrder_x, pointType)),
-                Teuchos::rcp( new LineBasis(polyOrder_y, pointType)))
+                Teuchos::rcp( new LineBasis(polyOrder_y, pointType))),
+    polyOrder_x_(polyOrder_x),
+    polyOrder_y_(polyOrder_y),
+    pointType_(pointType)
     {
       this->functionSpace_ = FUNCTION_SPACE_HVOL;
 
@@ -162,6 +167,16 @@ namespace Intrepid2
       {
         INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"operator not yet supported");
       }
+    }
+    
+    /** \brief Creates and returns a Basis object whose DeviceType template argument is Kokkos::HostSpace::device_type, but is otherwise identical to this.
+     
+        \return Pointer to the new Basis object.
+     */
+    virtual BasisPtr<typename Kokkos::HostSpace::device_type, typename BasisBase::OutputValueType, typename BasisBase::PointValueType>
+    getHostBasis() const override {
+      using HostBasisType  = Basis_Derived_HVOL_QUAD<typename HVOL_LINE::HostBasis>;
+      return Teuchos::rcp( new HostBasisType(polyOrder_x_, polyOrder_y_, pointType_) );
     }
   };
 } // end namespace Intrepid2

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HVOL_QUAD.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HVOL_QUAD.hpp
@@ -64,12 +64,12 @@ namespace Intrepid2
   template<class HVOL_LINE>
   class Basis_Derived_HVOL_QUAD
   :
-  public Basis_TensorBasis<typename HVOL_LINE::ExecutionSpace, typename HVOL_LINE::OutputValueType, typename HVOL_LINE::PointValueType>
+  public Basis_TensorBasis<typename HVOL_LINE::BasisBase>
   {
   protected:
     std::string name_;
     using LineBasis = HVOL_LINE;
-    using TensorBasis = Basis_TensorBasis<typename HVOL_LINE::ExecutionSpace, typename HVOL_LINE::OutputValueType, typename HVOL_LINE::PointValueType>;
+    using TensorBasis = Basis_TensorBasis<typename HVOL_LINE::BasisBase>;
   public:
 
    using ExecutionSpace  = typename HVOL_LINE::ExecutionSpace;
@@ -80,6 +80,7 @@ namespace Intrepid2
     using PointViewType  = typename HVOL_LINE::PointViewType ;
     using ScalarViewType = typename HVOL_LINE::ScalarViewType;
     
+    using BasisBase = typename HVOL_LINE::BasisBase;
     
     /** \brief  Constructor.
         \param [in] polyOrder_x - the polynomial order in the x dimension.

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DirectSumBasis.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DirectSumBasis.hpp
@@ -64,24 +64,22 @@ namespace Intrepid2
    
    The two bases must agree in their BasisType (the return value of getBasisType()).
    */
-  template<typename ExecSpaceType = void,
-           typename outputValueType = double,
-           typename pointValueType = double>
-  class Basis_DirectSumBasis : public Basis<ExecSpaceType,outputValueType,pointValueType>
+  template<typename BasisBaseClass>
+  class Basis_DirectSumBasis : public BasisBaseClass
   {
   public:
-    using BasisSuper = ::Intrepid2::Basis<ExecSpaceType,outputValueType,pointValueType>;
-    using BasisPtr   = Teuchos::RCP<BasisSuper>;
+    using BasisBase = BasisBaseClass;
+    using BasisPtr  = Teuchos::RCP<BasisBase>;
     
-    using ExecutionSpace  = typename BasisSuper::ExecutionSpace;
-    using OutputValueType = typename BasisSuper::OutputValueType;
-    using PointValueType  = typename BasisSuper::PointValueType;
+    using ExecutionSpace  = typename BasisBase::ExecutionSpace;
+    using OutputValueType = typename BasisBase::OutputValueType;
+    using PointValueType  = typename BasisBase::PointValueType;
     
-    using OrdinalTypeArray1DHost = typename BasisSuper::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename BasisSuper::OrdinalTypeArray2DHost;
-    using OutputViewType         = typename BasisSuper::OutputViewType;
-    using PointViewType          = typename BasisSuper::PointViewType;
-    using ScalarViewType         = typename BasisSuper::ScalarViewType;
+    using OrdinalTypeArray1DHost = typename BasisBase::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename BasisBase::OrdinalTypeArray2DHost;
+    using OutputViewType         = typename BasisBase::OutputViewType;
+    using PointViewType          = typename BasisBase::PointViewType;
+    using ScalarViewType         = typename BasisBase::ScalarViewType;
   protected:
     BasisPtr basis1_;
     BasisPtr basis2_;
@@ -208,10 +206,10 @@ namespace Intrepid2
         The default implementation employs a trivial tensor-product structure, for compatibility across all bases.  Subclasses that have tensor-product structure
         should override.  Note that only the basic exact-sequence operators are supported at the moment: VALUE, GRAD, DIV, CURL.
      */
-    virtual BasisValues<OutputValueType,ExecSpaceType> allocateBasisValues( TensorPoints<PointValueType,ExecSpaceType> points, const EOperator operatorType = OPERATOR_VALUE) const override
+    virtual BasisValues<OutputValueType,ExecutionSpace> allocateBasisValues( TensorPoints<PointValueType,ExecutionSpace> points, const EOperator operatorType = OPERATOR_VALUE) const override
     {
-      BasisValues<OutputValueType,ExecSpaceType> basisValues1 = basis1_->allocateBasisValues(points, operatorType);
-      BasisValues<OutputValueType,ExecSpaceType> basisValues2 = basis2_->allocateBasisValues(points, operatorType);
+      BasisValues<OutputValueType,ExecutionSpace> basisValues1 = basis1_->allocateBasisValues(points, operatorType);
+      BasisValues<OutputValueType,ExecutionSpace> basisValues2 = basis2_->allocateBasisValues(points, operatorType);
       
       const int numScalarFamilies1 = basisValues1.numTensorDataFamilies();
       if (numScalarFamilies1 > 0)
@@ -219,7 +217,7 @@ namespace Intrepid2
         // then both basis1 and basis2 should be scalar-valued; check that for basis2:
         const int numScalarFamilies2 = basisValues2.numTensorDataFamilies();
         INTREPID2_TEST_FOR_EXCEPTION(basisValues2.numTensorDataFamilies() <=0, std::invalid_argument, "When basis1 has scalar value, basis2 must also");
-        std::vector< TensorData<OutputValueType,ExecSpaceType> > scalarFamilies(numScalarFamilies1 + numScalarFamilies2);
+        std::vector< TensorData<OutputValueType,ExecutionSpace> > scalarFamilies(numScalarFamilies1 + numScalarFamilies2);
         for (int i=0; i<numScalarFamilies1; i++)
         {
           scalarFamilies[i] = basisValues1.tensorData(i);
@@ -228,7 +226,7 @@ namespace Intrepid2
         {
           scalarFamilies[i+numScalarFamilies1] = basisValues2.tensorData(i);
         }
-        return BasisValues<OutputValueType,ExecSpaceType>(scalarFamilies);
+        return BasisValues<OutputValueType,ExecutionSpace>(scalarFamilies);
       }
       else
       {
@@ -245,7 +243,7 @@ namespace Intrepid2
         const int numFamilies2 = vectorData2.numFamilies();
         
         const int numFamilies = numFamilies1 + numFamilies2;
-        std::vector< std::vector<TensorData<OutputValueType,ExecSpaceType> > > vectorComponents(numFamilies, std::vector<TensorData<OutputValueType,ExecSpaceType> >(numComponents));
+        std::vector< std::vector<TensorData<OutputValueType,ExecutionSpace> > > vectorComponents(numFamilies, std::vector<TensorData<OutputValueType,ExecutionSpace> >(numComponents));
         
         for (int i=0; i<numFamilies1; i++)
         {
@@ -261,8 +259,8 @@ namespace Intrepid2
             vectorComponents[i+numFamilies1][j] = vectorData2.getComponent(i,j);
           }
         }
-        VectorData<OutputValueType,ExecSpaceType> vectorData(vectorComponents);
-        return BasisValues<OutputValueType,ExecSpaceType>(vectorData);
+        VectorData<OutputValueType,ExecutionSpace> vectorData(vectorComponents);
+        return BasisValues<OutputValueType,ExecutionSpace>(vectorData);
       }
     }
     
@@ -323,7 +321,7 @@ namespace Intrepid2
     // since the getValues() below only overrides the FEM variants, we specify that
     // we use the base class's getValues(), which implements the FVD variant by throwing an exception.
     // (It's an error to use the FVD variant on this basis.)
-    using BasisSuper::getValues;
+    using BasisBase::getValues;
     
     /** \brief  Evaluation of a FEM basis on a <strong>reference cell</strong>, using point and output value containers that allow preservation of tensor-product structure.
 
@@ -338,8 +336,8 @@ namespace Intrepid2
     */
     virtual
     void
-    getValues(       BasisValues<OutputValueType,ExecSpaceType> outputValues,
-               const TensorPoints<PointValueType,ExecSpaceType>  inputPoints,
+    getValues(       BasisValues<OutputValueType,ExecutionSpace> outputValues,
+               const TensorPoints<PointValueType,ExecutionSpace>  inputPoints,
                const EOperator operatorType = OPERATOR_VALUE ) const override
     {
       const int fieldStartOrdinal1 = 0;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_C1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_C1_FEM.hpp
@@ -155,19 +155,21 @@ namespace Intrepid2 {
   class Basis_HGRAD_LINE_C1_FEM
     : public Basis<DeviceType,outputValueType,pointValueType> {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
-    using OrdinalTypeArray3DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
-
+    using BasisBase = Basis<DeviceType,outputValueType,pointValueType>;
+    
+    using OrdinalTypeArray1DHost = typename BasisBase::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename BasisBase::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename BasisBase::OrdinalTypeArray3DHost;
+    
+    using OutputViewType = typename BasisBase::OutputViewType;
+    using PointViewType  = typename BasisBase::PointViewType ;
+    using ScalarViewType = typename BasisBase::ScalarViewType;
+      
     /** \brief  Constructor.
      */
     Basis_HGRAD_LINE_C1_FEM();
 
-    using OutputViewType = typename Basis<DeviceType,outputValueType,pointValueType>::OutputViewType;
-    using PointViewType  = typename Basis<DeviceType,outputValueType,pointValueType>::PointViewType;
-    using ScalarViewType = typename Basis<DeviceType,outputValueType,pointValueType>::ScalarViewType;
-
-    using Basis<DeviceType,outputValueType,pointValueType>::getValues;
+    using BasisBase::getValues;
 
     virtual
     void

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEM.hpp
@@ -175,13 +175,15 @@ namespace Intrepid2 {
   class Basis_HGRAD_LINE_Cn_FEM
     : public Basis<DeviceType,outputValueType,pointValueType> {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
-    using OrdinalTypeArray3DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
-
-    using OutputViewType = typename Basis<DeviceType,outputValueType,pointValueType>::OutputViewType;
-    using PointViewType  = typename Basis<DeviceType,outputValueType,pointValueType>::PointViewType;
-    using ScalarViewType = typename Basis<DeviceType,outputValueType,pointValueType>::ScalarViewType;
+    using BasisBase = Basis<DeviceType,outputValueType,pointValueType>;
+    
+    using OrdinalTypeArray1DHost = typename BasisBase::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename BasisBase::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename BasisBase::OrdinalTypeArray3DHost;
+    
+    using OutputViewType = typename BasisBase::OutputViewType;
+    using PointViewType  = typename BasisBase::PointViewType ;
+    using ScalarViewType = typename BasisBase::ScalarViewType;
 
   private:
 
@@ -195,7 +197,7 @@ namespace Intrepid2 {
     Basis_HGRAD_LINE_Cn_FEM(const ordinal_type order,
                             const EPointType   pointType = POINTTYPE_EQUISPACED);  
 
-    using Basis<DeviceType,outputValueType,pointValueType>::getValues;
+    using BasisBase::getValues;
 
     virtual
     void

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEM.hpp
@@ -176,6 +176,8 @@ namespace Intrepid2 {
     : public Basis<DeviceType,outputValueType,pointValueType> {
   public:
     using BasisBase = Basis<DeviceType,outputValueType,pointValueType>;
+      
+    using HostBasis = Basis_HGRAD_LINE_Cn_FEM<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>;
     
     using OrdinalTypeArray1DHost = typename BasisBase::OrdinalTypeArray1DHost;
     using OrdinalTypeArray2DHost = typename BasisBase::OrdinalTypeArray2DHost;
@@ -190,7 +192,7 @@ namespace Intrepid2 {
     /** \brief inverse of Generalized Vandermonde matrix, whose columns store the expansion
         coefficients of the nodal basis in terms of phis_ */
     Kokkos::DynRankView<typename ScalarViewType::value_type,DeviceType> vinv_;
-
+    EPointType   pointType_;
   public:
     /** \brief  Constructor.
      */
@@ -272,6 +274,16 @@ namespace Intrepid2 {
       return getPnCardinality<1>(this->basisDegree_);
     }
 
+  /** \brief Creates and returns a Basis object whose DeviceType template argument is Kokkos::HostSpace::device_type, but is otherwise identical to this.
+      
+         \return Pointer to the new Basis object.
+      */
+     virtual HostBasisPtr<outputValueType,pointValueType>
+     getHostBasis() const override {
+       auto hostBasis = Teuchos::rcp(new HostBasis(this->basisDegree_, pointType_));
+       
+       return hostBasis;
+     }
   };
 
 }// namespace Intrepid2

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEMDef.hpp
@@ -196,6 +196,7 @@ namespace Intrepid2 {
   Basis_HGRAD_LINE_Cn_FEM<DT,OT,PT>::
   Basis_HGRAD_LINE_Cn_FEM( const ordinal_type order,
                            const EPointType   pointType ) {
+    this->pointType_         = pointType;
     this->basisCardinality_  = order+1;
     this->basisDegree_       = order;
     this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Line<2> >() );

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_LINE_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_LINE_Cn_FEM.hpp
@@ -177,20 +177,22 @@ namespace Intrepid2 {
   class Basis_HVOL_LINE_Cn_FEM
     : public Basis<DeviceType,outputValueType,pointValueType> {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
-    using OrdinalTypeArray3DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+    using BasisBase = Basis<DeviceType,outputValueType,pointValueType>;
+    
+    using OrdinalTypeArray1DHost = typename BasisBase::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename BasisBase::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename BasisBase::OrdinalTypeArray3DHost;
+    
+    using OutputViewType = typename BasisBase::OutputViewType;
+    using PointViewType  = typename BasisBase::PointViewType ;
+    using ScalarViewType = typename BasisBase::ScalarViewType;
 
     /** \brief  Constructor.
      */
     Basis_HVOL_LINE_Cn_FEM(const ordinal_type order,
                             const EPointType   pointType = POINTTYPE_EQUISPACED);  
 
-    using OutputViewType = typename Basis<DeviceType,outputValueType,pointValueType>::OutputViewType;
-    using PointViewType  = typename Basis<DeviceType,outputValueType,pointValueType>::PointViewType;
-    using ScalarViewType = typename Basis<DeviceType,outputValueType,pointValueType>::ScalarViewType;
-
-    using Basis<DeviceType,outputValueType,pointValueType>::getValues;
+    using BasisBase::getValues;
 
     virtual
     void

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_LINE_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_LINE_Cn_FEM.hpp
@@ -178,6 +178,7 @@ namespace Intrepid2 {
     : public Basis<DeviceType,outputValueType,pointValueType> {
   public:
     using BasisBase = Basis<DeviceType,outputValueType,pointValueType>;
+    using HostBasis = Basis_HVOL_LINE_Cn_FEM<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>;
     
     using OrdinalTypeArray1DHost = typename BasisBase::OrdinalTypeArray1DHost;
     using OrdinalTypeArray2DHost = typename BasisBase::OrdinalTypeArray2DHost;
@@ -190,7 +191,7 @@ namespace Intrepid2 {
     /** \brief  Constructor.
      */
     Basis_HVOL_LINE_Cn_FEM(const ordinal_type order,
-                            const EPointType   pointType = POINTTYPE_EQUISPACED);  
+                           const EPointType   pointType = POINTTYPE_EQUISPACED);  
 
     using BasisBase::getValues;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HierarchicalBasisFamily.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HierarchicalBasisFamily.hpp
@@ -69,7 +69,7 @@ namespace Intrepid2 {
 
 // the following defines a family of hierarchical basis functions that matches the unpermuted ESEAS basis functions
 // each basis member is associated with appropriate subcell topologies, making this suitable for continuous Galerkin finite elements.
-  template<typename ExecutionSpace=Kokkos::DefaultExecutionSpace,
+  template<typename DeviceType=typename Kokkos::DefaultExecutionSpace,
            typename OutputScalar = double,
            typename PointScalar  = double,
            bool defineVertexFunctions = true>
@@ -77,24 +77,24 @@ namespace Intrepid2 {
   {
   public:
     // we will fill these in as we implement them
-    using HGRAD = IntegratedLegendreBasis_HGRAD_TRI<ExecutionSpace,OutputScalar,PointScalar,defineVertexFunctions>;
-    using HCURL = dummyBasis<ExecutionSpace,OutputScalar,PointScalar>;
-    using HDIV  = dummyBasis<ExecutionSpace,OutputScalar,PointScalar>;
-    using HVOL  = dummyBasis<ExecutionSpace,OutputScalar,PointScalar>;
+    using HGRAD = IntegratedLegendreBasis_HGRAD_TRI<DeviceType,OutputScalar,PointScalar,defineVertexFunctions>;
+    using HCURL = dummyBasis<DeviceType,OutputScalar,PointScalar>;
+    using HDIV  = dummyBasis<DeviceType,OutputScalar,PointScalar>;
+    using HVOL  = dummyBasis<DeviceType,OutputScalar,PointScalar>;
   };
   
-  template<typename ExecutionSpace=Kokkos::DefaultExecutionSpace,
-  typename OutputScalar = double,
-  typename PointScalar  = double,
-  bool defineVertexFunctions = true>
+  template<typename DeviceType=typename Kokkos::DefaultExecutionSpace,
+           typename OutputScalar = double,
+           typename PointScalar  = double,
+           bool defineVertexFunctions = true>
   class HierarchicalTetrahedronBasisFamily
   {
   public:
     // we will fill these in as we implement them
-    using HGRAD = IntegratedLegendreBasis_HGRAD_TET<ExecutionSpace,OutputScalar,PointScalar,defineVertexFunctions>;
-    using HCURL = dummyBasis<ExecutionSpace,OutputScalar,PointScalar>;
-    using HDIV  = dummyBasis<ExecutionSpace,OutputScalar,PointScalar>;
-    using HVOL  = dummyBasis<ExecutionSpace,OutputScalar,PointScalar>;
+    using HGRAD = IntegratedLegendreBasis_HGRAD_TET<DeviceType,OutputScalar,PointScalar,defineVertexFunctions>;
+    using HCURL = dummyBasis<DeviceType,OutputScalar,PointScalar>;
+    using HDIV  = dummyBasis<DeviceType,OutputScalar,PointScalar>;
+    using HVOL  = dummyBasis<DeviceType,OutputScalar,PointScalar>;
   };
   
   /** \class Intrepid2::HierarchicalBasisFamily
@@ -117,13 +117,13 @@ namespace Intrepid2 {
    We have offline tests that verify agreement between our implementation and ESEAS.  We hope to add these to the
    Trilinos continuous integration tests in the future.
   */
-  template<typename ExecutionSpace=Kokkos::DefaultExecutionSpace,
+  template<typename DeviceType=typename Kokkos::DefaultExecutionSpace,
            typename OutputScalar = double,
            typename PointScalar  = double>
-  using HierarchicalBasisFamily = DerivedBasisFamily< IntegratedLegendreBasis_HGRAD_LINE<ExecutionSpace,OutputScalar,PointScalar,true>,
-                                                      LegendreBasis_HVOL_LINE<ExecutionSpace,OutputScalar,PointScalar>,
-                                                      HierarchicalTriangleBasisFamily<ExecutionSpace,OutputScalar,PointScalar>,
-                                                      HierarchicalTetrahedronBasisFamily<ExecutionSpace,OutputScalar,PointScalar>
+  using HierarchicalBasisFamily = DerivedBasisFamily< IntegratedLegendreBasis_HGRAD_LINE<DeviceType,OutputScalar,PointScalar,true>,
+                                                      LegendreBasis_HVOL_LINE<DeviceType,OutputScalar,PointScalar>,
+                                                      HierarchicalTriangleBasisFamily<DeviceType,OutputScalar,PointScalar>,
+                                                      HierarchicalTetrahedronBasisFamily<DeviceType,OutputScalar,PointScalar>
                                                       >;
   
   /** \class Intrepid2::HierarchicalBasisFamily
@@ -134,13 +134,13 @@ namespace Intrepid2 {
    The suitability of this family for DG contexts is primarily due to the fact that the H(grad) basis has a constant member.  Note also that in this family,
    all members are associated with the cell interior; there are no basis functions associated with subcell topologies.
   */
-  template<typename ExecutionSpace=Kokkos::DefaultExecutionSpace,
+  template<typename DeviceType=typename Kokkos::DefaultExecutionSpace,
            typename OutputScalar = double,
            typename PointScalar  = double>
-  using DGHierarchicalBasisFamily = DerivedBasisFamily< IntegratedLegendreBasis_HGRAD_LINE<ExecutionSpace,OutputScalar,PointScalar,false>,
-                                                        LegendreBasis_HVOL_LINE<ExecutionSpace,OutputScalar,PointScalar>,
-                                                        HierarchicalTriangleBasisFamily<ExecutionSpace,OutputScalar,PointScalar,false>,
-                                                        HierarchicalTetrahedronBasisFamily<ExecutionSpace,OutputScalar,PointScalar,false>
+  using DGHierarchicalBasisFamily = DerivedBasisFamily< IntegratedLegendreBasis_HGRAD_LINE<DeviceType,OutputScalar,PointScalar,false>,
+                                                        LegendreBasis_HVOL_LINE<DeviceType,OutputScalar,PointScalar>,
+                                                        HierarchicalTriangleBasisFamily<DeviceType,OutputScalar,PointScalar,false>,
+                                                        HierarchicalTetrahedronBasisFamily<DeviceType,OutputScalar,PointScalar,false>
                                                       >;
   
 }

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_IntegratedLegendreBasis_HGRAD_LINE.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_IntegratedLegendreBasis_HGRAD_LINE.hpp
@@ -228,7 +228,7 @@ namespace Intrepid2
                is true, then the first basis function will instead be 1.0-x, and the basis will be suitable for
                continuous discretizations.
   */
-  template<typename DeviceType=Kokkos::DefaultExecutionSpace::device_type,
+  template<typename DeviceType=Kokkos::DefaultExecutionSpace,
            typename OutputScalar = double,
            typename PointScalar  = double,
            bool defineVertexFunctions = true,            // if defineVertexFunctions is true, first and second basis functions are x and 1-x.  Otherwise, they are 1 and x.

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_IntegratedLegendreBasis_HGRAD_LINE.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_IntegratedLegendreBasis_HGRAD_LINE.hpp
@@ -64,10 +64,11 @@ namespace Intrepid2
    
    This functor is not intended for use outside of IntegratedLegendreBasis_HGRAD_LINE.
   */
-  template<class ExecutionSpace, class OutputScalar, class PointScalar,
+  template<class DeviceType, class OutputScalar, class PointScalar,
            class OutputFieldType, class InputPointsType>
   struct Hierarchical_HGRAD_LINE_Functor
   {
+    using ExecutionSpace     = typename DeviceType::execution_space;
     using ScratchSpace       = typename ExecutionSpace::scratch_memory_space;
     using OutputScratchView  = Kokkos::View<OutputScalar*,ScratchSpace,Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
     using PointScratchView   = Kokkos::View<PointScalar*, ScratchSpace,Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
@@ -227,24 +228,27 @@ namespace Intrepid2
                is true, then the first basis function will instead be 1.0-x, and the basis will be suitable for
                continuous discretizations.
   */
-  template<typename ExecutionSpace=Kokkos::DefaultExecutionSpace,
+  template<typename DeviceType=Kokkos::DefaultExecutionSpace::device_type,
            typename OutputScalar = double,
            typename PointScalar  = double,
            bool defineVertexFunctions = true,            // if defineVertexFunctions is true, first and second basis functions are x and 1-x.  Otherwise, they are 1 and x.
            bool useMinusOneToOneReferenceElement = true> // if useMinusOneToOneReferenceElement is true, basis is define on [-1,1].  Otherwise, [0,1].
   class IntegratedLegendreBasis_HGRAD_LINE
-  : public Basis<ExecutionSpace,OutputScalar,PointScalar>
+  : public Basis<DeviceType,OutputScalar,PointScalar>
   {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<ExecutionSpace,OutputScalar,PointScalar>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<ExecutionSpace,OutputScalar,PointScalar>::OrdinalTypeArray2DHost;
+    using BasisBase = Basis<DeviceType,OutputScalar,PointScalar>;
     
-    using OutputViewType = typename Basis<ExecutionSpace,OutputScalar,PointScalar>::OutputViewType;
-    using PointViewType  = typename Basis<ExecutionSpace,OutputScalar,PointScalar>::PointViewType ;
-    using ScalarViewType = typename Basis<ExecutionSpace,OutputScalar,PointScalar>::ScalarViewType;
+    using OrdinalTypeArray1DHost = typename BasisBase::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename BasisBase::OrdinalTypeArray2DHost;
+    
+    using OutputViewType = typename BasisBase::OutputViewType;
+    using PointViewType  = typename BasisBase::PointViewType ;
+    using ScalarViewType = typename BasisBase::ScalarViewType;
   protected:
     int polyOrder_; // the maximum order of the polynomial
     bool defineVertexFunctions_; // if true, first and second basis functions are x and 1-x.  Otherwise, they are 1 and x.
+    EPointType pointType_;
   public:
     /** \brief  Constructor.
         \param [in] polyOrder - the polynomial order of the basis.
@@ -258,7 +262,8 @@ namespace Intrepid2
      */
     IntegratedLegendreBasis_HGRAD_LINE(int polyOrder, EPointType pointType=POINTTYPE_DEFAULT)
     :
-    polyOrder_(polyOrder)
+    polyOrder_(polyOrder),
+    pointType_(pointType)
     {
       INTREPID2_TEST_FOR_EXCEPTION(pointType!=POINTTYPE_DEFAULT,std::invalid_argument,"PointType not supported");
 
@@ -357,7 +362,7 @@ namespace Intrepid2
     // since the getValues() below only overrides the FEM variant, we specify that
     // we use the base class's getValues(), which implements the FVD variant by throwing an exception.
     // (It's an error to use the FVD variant on this basis.)
-    using Basis<ExecutionSpace,OutputScalar,PointScalar>::getValues;
+    using BasisBase::getValues;
     
     /** \brief  Evaluation of a FEM basis on a <strong>reference cell</strong>.
 
@@ -382,7 +387,7 @@ namespace Intrepid2
     {
       auto numPoints = inputPoints.extent_int(0);
       
-      using FunctorType = Hierarchical_HGRAD_LINE_Functor<ExecutionSpace, OutputScalar, PointScalar, OutputViewType, PointViewType>;
+      using FunctorType = Hierarchical_HGRAD_LINE_Functor<DeviceType, OutputScalar, PointScalar, OutputViewType, PointViewType>;
       
       FunctorType functor(operatorType, outputValues, inputPoints, polyOrder_, defineVertexFunctions);
       
@@ -391,8 +396,21 @@ namespace Intrepid2
       const int vectorSize = std::max(outputVectorSize,pointVectorSize);
       const int teamSize = 1; // because of the way the basis functions are computed, we don't have a second level of parallelism...
       
+      using ExecutionSpace = typename BasisBase::ExecutionSpace;
+      
       auto policy = Kokkos::TeamPolicy<ExecutionSpace>(numPoints,teamSize,vectorSize);
-      Kokkos::parallel_for( policy , functor, "Hierarchical_HGRAD_LINE_Functor");
+      Kokkos::parallel_for( policy, functor, "Hierarchical_HGRAD_LINE_Functor");
+    }
+    
+    /** \brief Creates and returns a Basis object whose DeviceType template argument is Kokkos::HostSpace::device_type, but is otherwise identical to this.
+     
+        \return Pointer to the new Basis object.
+     */
+    virtual BasisPtr<typename Kokkos::HostSpace::device_type, OutputScalar, PointScalar>
+    getHostBasis() const override {
+      using HostDeviceType = typename Kokkos::HostSpace::device_type;
+      using HostBasisType  = IntegratedLegendreBasis_HGRAD_LINE<HostDeviceType, OutputScalar, PointScalar, defineVertexFunctions, useMinusOneToOneReferenceElement>;
+      return Teuchos::rcp( new HostBasisType(polyOrder_, pointType_) );
     }
   };
 } // end namespace Intrepid2

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_IntegratedLegendreBasis_HGRAD_LINE.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_IntegratedLegendreBasis_HGRAD_LINE.hpp
@@ -238,6 +238,7 @@ namespace Intrepid2
   {
   public:
     using BasisBase = Basis<DeviceType,OutputScalar,PointScalar>;
+    using HostBasis = IntegratedLegendreBasis_HGRAD_LINE<typename Kokkos::HostSpace::device_type,OutputScalar,PointScalar,defineVertexFunctions,useMinusOneToOneReferenceElement>;
     
     using OrdinalTypeArray1DHost = typename BasisBase::OrdinalTypeArray1DHost;
     using OrdinalTypeArray2DHost = typename BasisBase::OrdinalTypeArray2DHost;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_IntegratedLegendreBasis_HGRAD_TET.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_IntegratedLegendreBasis_HGRAD_TET.hpp
@@ -64,10 +64,11 @@ namespace Intrepid2
    
    This functor is not intended for use outside of IntegratedLegendreBasis_HGRAD_TET.
   */
-  template<class ExecutionSpace, class OutputScalar, class PointScalar,
+  template<class DeviceType, class OutputScalar, class PointScalar,
            class OutputFieldType, class InputPointsType>
   struct Hierarchical_HGRAD_TET_Functor
   {
+    using ExecutionSpace     = typename DeviceType::execution_space;
     using ScratchSpace        = typename ExecutionSpace::scratch_memory_space;
     using OutputScratchView   = Kokkos::View<OutputScalar*,ScratchSpace,Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
     using OutputScratchView2D = Kokkos::View<OutputScalar**,ScratchSpace,Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
@@ -602,22 +603,25 @@ namespace Intrepid2
                is true, then the first basis function will instead be 1.0-x-y, and the basis will be suitable for
                continuous discretizations.
   */
-  template<typename ExecutionSpace=Kokkos::DefaultExecutionSpace,
+  template<typename DeviceType=Kokkos::DefaultExecutionSpace::device_type,
            typename OutputScalar = double,
            typename PointScalar  = double,
            bool defineVertexFunctions = true>  // if defineVertexFunctions is true, first four basis functions are 1-x-y-z, x, y, and z.  Otherwise, they are 1, x, y, and z.
   class IntegratedLegendreBasis_HGRAD_TET
-  : public Basis<ExecutionSpace,OutputScalar,PointScalar>
+  : public Basis<DeviceType,OutputScalar,PointScalar>
   {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<ExecutionSpace,OutputScalar,PointScalar>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<ExecutionSpace,OutputScalar,PointScalar>::OrdinalTypeArray2DHost;
+    using BasisBase = Basis<DeviceType,OutputScalar,PointScalar>;
     
-    using OutputViewType = typename Basis<ExecutionSpace,OutputScalar,PointScalar>::OutputViewType;
-    using PointViewType  = typename Basis<ExecutionSpace,OutputScalar,PointScalar>::PointViewType;
-    using ScalarViewType = typename Basis<ExecutionSpace,OutputScalar,PointScalar>::ScalarViewType;
+    using OrdinalTypeArray1DHost = typename BasisBase::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename BasisBase::OrdinalTypeArray2DHost;
+    
+    using OutputViewType = typename BasisBase::OutputViewType;
+    using PointViewType  = typename BasisBase::PointViewType ;
+    using ScalarViewType = typename BasisBase::ScalarViewType;
   protected:
     int polyOrder_; // the maximum order of the polynomial
+    EPointType pointType_;
   public:
     /** \brief  Constructor.
         \param [in] polyOrder - the polynomial order of the basis.
@@ -631,7 +635,8 @@ namespace Intrepid2
      */
     IntegratedLegendreBasis_HGRAD_TET(int polyOrder, const EPointType pointType=POINTTYPE_DEFAULT)
     :
-    polyOrder_(polyOrder)
+    polyOrder_(polyOrder),
+    pointType_(pointType)
     {
       INTREPID2_TEST_FOR_EXCEPTION(pointType!=POINTTYPE_DEFAULT,std::invalid_argument,"PointType not supported");
       this->basisCardinality_  = ((polyOrder+1) * (polyOrder+2) * (polyOrder+3)) / 6;
@@ -819,7 +824,7 @@ namespace Intrepid2
     // since the getValues() below only overrides the FEM variant, we specify that
     // we use the base class's getValues(), which implements the FVD variant by throwing an exception.
     // (It's an error to use the FVD variant on this basis.)
-    using Basis<ExecutionSpace,OutputScalar,PointScalar>::getValues;
+    using BasisBase::getValues;
     
     /** \brief  Evaluation of a FEM basis on a <strong>reference cell</strong>.
 
@@ -844,7 +849,7 @@ namespace Intrepid2
     {
       auto numPoints = inputPoints.extent_int(0);
       
-      using FunctorType = Hierarchical_HGRAD_TET_Functor<ExecutionSpace, OutputScalar, PointScalar, OutputViewType, PointViewType>;
+      using FunctorType = Hierarchical_HGRAD_TET_Functor<DeviceType, OutputScalar, PointScalar, OutputViewType, PointViewType>;
       
       FunctorType functor(operatorType, outputValues, inputPoints, polyOrder_, defineVertexFunctions);
       
@@ -852,6 +857,8 @@ namespace Intrepid2
       const int pointVectorSize  = getVectorSizeForHierarchicalParallelism<PointScalar>();
       const int vectorSize = std::max(outputVectorSize,pointVectorSize);
       const int teamSize = 1; // because of the way the basis functions are computed, we don't have a second level of parallelism...
+      
+      using ExecutionSpace = typename BasisBase::ExecutionSpace;
       
       auto policy = Kokkos::TeamPolicy<ExecutionSpace>(numPoints,teamSize,vectorSize);
       Kokkos::parallel_for( policy , functor, "Hierarchical_HGRAD_TET_Functor");
@@ -865,20 +872,30 @@ namespace Intrepid2
         \param [in] subCellOrd - position of the subCell among of the subCells having the same dimension
         \return pointer to the subCell basis of dimension subCellDim and position subCellOrd
      */
-    BasisPtr<ExecutionSpace,OutputScalar,PointScalar>
+    BasisPtr<DeviceType,OutputScalar,PointScalar>
     getSubCellRefBasis(const ordinal_type subCellDim, const ordinal_type subCellOrd) const override{
       if(subCellDim == 1) {
         return Teuchos::rcp(new
-            IntegratedLegendreBasis_HGRAD_LINE<ExecutionSpace,OutputScalar,PointScalar>
+            IntegratedLegendreBasis_HGRAD_LINE<DeviceType,OutputScalar,PointScalar>
             (this->basisDegree_));
       } else if(subCellDim == 2) {
         return Teuchos::rcp(new
-            IntegratedLegendreBasis_HGRAD_TRI<ExecutionSpace,OutputScalar,PointScalar>
+            IntegratedLegendreBasis_HGRAD_TRI<DeviceType,OutputScalar,PointScalar>
             (this->basisDegree_));
       }
       INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
     }
 
+    /** \brief Creates and returns a Basis object whose DeviceType template argument is Kokkos::HostSpace::device_type, but is otherwise identical to this.
+     
+        \return Pointer to the new Basis object.
+     */
+    virtual BasisPtr<typename Kokkos::HostSpace::device_type, OutputScalar, PointScalar>
+    getHostBasis() const override {
+      using HostDeviceType = typename Kokkos::HostSpace::device_type;
+      using HostBasisType  = IntegratedLegendreBasis_HGRAD_TET<HostDeviceType, OutputScalar, PointScalar, defineVertexFunctions>;
+      return Teuchos::rcp( new HostBasisType(polyOrder_, pointType_) );
+    }
   };
 } // end namespace Intrepid2
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_IntegratedLegendreBasis_HGRAD_TET.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_IntegratedLegendreBasis_HGRAD_TET.hpp
@@ -603,7 +603,7 @@ namespace Intrepid2
                is true, then the first basis function will instead be 1.0-x-y, and the basis will be suitable for
                continuous discretizations.
   */
-  template<typename DeviceType=Kokkos::DefaultExecutionSpace::device_type,
+  template<typename DeviceType=Kokkos::DefaultExecutionSpace,
            typename OutputScalar = double,
            typename PointScalar  = double,
            bool defineVertexFunctions = true>  // if defineVertexFunctions is true, first four basis functions are 1-x-y-z, x, y, and z.  Otherwise, they are 1, x, y, and z.

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_IntegratedLegendreBasis_HGRAD_TRI.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_IntegratedLegendreBasis_HGRAD_TRI.hpp
@@ -64,10 +64,11 @@ namespace Intrepid2
    
    This functor is not intended for use outside of IntegratedLegendreBasis_HGRAD_TRI.
   */
-  template<class ExecutionSpace, class OutputScalar, class PointScalar,
+  template<class DeviceType, class OutputScalar, class PointScalar,
            class OutputFieldType, class InputPointsType>
   struct Hierarchical_HGRAD_TRI_Functor
   {
+    using ExecutionSpace     = typename DeviceType::execution_space;
     using ScratchSpace       = typename ExecutionSpace::scratch_memory_space;
     using OutputScratchView  = Kokkos::View<OutputScalar*,ScratchSpace,Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
     using PointScratchView   = Kokkos::View<PointScalar*, ScratchSpace,Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
@@ -357,22 +358,25 @@ namespace Intrepid2
                is true, then the first basis function will instead be 1.0-x-y, and the basis will be suitable for
                continuous discretizations.
   */
-  template<typename ExecutionSpace=Kokkos::DefaultExecutionSpace,
+  template<typename DeviceType=Kokkos::DefaultExecutionSpace::device_type,
            typename OutputScalar = double,
            typename PointScalar  = double,
            bool defineVertexFunctions = true>            // if defineVertexFunctions is true, first three basis functions are 1-x-y, x, and y.  Otherwise, they are 1, x, and y.
   class IntegratedLegendreBasis_HGRAD_TRI
-  : public Basis<ExecutionSpace,OutputScalar,PointScalar>
+  : public Basis<DeviceType,OutputScalar,PointScalar>
   {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<ExecutionSpace,OutputScalar,PointScalar>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<ExecutionSpace,OutputScalar,PointScalar>::OrdinalTypeArray2DHost;
+    using BasisBase = Basis<DeviceType,OutputScalar,PointScalar>;
     
-    using OutputViewType = typename Basis<ExecutionSpace,OutputScalar,PointScalar>::OutputViewType;
-    using PointViewType  = typename Basis<ExecutionSpace,OutputScalar,PointScalar>::PointViewType;
-    using ScalarViewType = typename Basis<ExecutionSpace,OutputScalar,PointScalar>::ScalarViewType;
+    using OrdinalTypeArray1DHost = typename BasisBase::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename BasisBase::OrdinalTypeArray2DHost;
+    
+    using OutputViewType = typename BasisBase::OutputViewType;
+    using PointViewType  = typename BasisBase::PointViewType ;
+    using ScalarViewType = typename BasisBase::ScalarViewType;
   protected:
     int polyOrder_; // the maximum order of the polynomial
+    EPointType pointType_;
   public:
     /** \brief  Constructor.
         \param [in] polyOrder - the polynomial order of the basis.
@@ -386,7 +390,8 @@ namespace Intrepid2
      */
     IntegratedLegendreBasis_HGRAD_TRI(int polyOrder, const EPointType pointType=POINTTYPE_DEFAULT)
     :
-    polyOrder_(polyOrder)
+    polyOrder_(polyOrder),
+    pointType_(pointType)
     {
       INTREPID2_TEST_FOR_EXCEPTION(pointType!=POINTTYPE_DEFAULT,std::invalid_argument,"PointType not supported");
 
@@ -532,7 +537,7 @@ namespace Intrepid2
     // since the getValues() below only overrides the FEM variant, we specify that
     // we use the base class's getValues(), which implements the FVD variant by throwing an exception.
     // (It's an error to use the FVD variant on this basis.)
-    using Basis<ExecutionSpace,OutputScalar,PointScalar>::getValues;
+    using BasisBase::getValues;
     
     /** \brief  Evaluation of a FEM basis on a <strong>reference cell</strong>.
 
@@ -557,7 +562,7 @@ namespace Intrepid2
     {
       auto numPoints = inputPoints.extent_int(0);
       
-      using FunctorType = Hierarchical_HGRAD_TRI_Functor<ExecutionSpace, OutputScalar, PointScalar, OutputViewType, PointViewType>;
+      using FunctorType = Hierarchical_HGRAD_TRI_Functor<DeviceType, OutputScalar, PointScalar, OutputViewType, PointViewType>;
       
       FunctorType functor(operatorType, outputValues, inputPoints, polyOrder_, defineVertexFunctions);
       
@@ -565,6 +570,8 @@ namespace Intrepid2
       const int pointVectorSize  = getVectorSizeForHierarchicalParallelism<PointScalar>();
       const int vectorSize = std::max(outputVectorSize,pointVectorSize);
       const int teamSize = 1; // because of the way the basis functions are computed, we don't have a second level of parallelism...
+      
+      using ExecutionSpace = typename BasisBase::ExecutionSpace;
       
       auto policy = Kokkos::TeamPolicy<ExecutionSpace>(numPoints,teamSize,vectorSize);
       Kokkos::parallel_for( policy , functor, "Hierarchical_HGRAD_TRI_Functor");
@@ -578,16 +585,26 @@ namespace Intrepid2
         \param [in] subCellOrd - position of the subCell among of the subCells having the same dimension
         \return pointer to the subCell basis of dimension subCellDim and position subCellOrd
      */
-    BasisPtr<ExecutionSpace,OutputScalar,PointScalar>
+    BasisPtr<DeviceType,OutputScalar,PointScalar>
       getSubCellRefBasis(const ordinal_type subCellDim, const ordinal_type subCellOrd) const override{
       if(subCellDim == 1) {
         return Teuchos::rcp(new
-            IntegratedLegendreBasis_HGRAD_LINE<ExecutionSpace,OutputScalar,PointScalar>
+            IntegratedLegendreBasis_HGRAD_LINE<DeviceType,OutputScalar,PointScalar>
                     (this->basisDegree_));
       }
       INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
     }
 
+    /** \brief Creates and returns a Basis object whose DeviceType template argument is Kokkos::HostSpace::device_type, but is otherwise identical to this.
+     
+        \return Pointer to the new Basis object.
+     */
+    virtual BasisPtr<typename Kokkos::HostSpace::device_type, OutputScalar, PointScalar>
+    getHostBasis() const override {
+      using HostDeviceType = typename Kokkos::HostSpace::device_type;
+      using HostBasisType  = IntegratedLegendreBasis_HGRAD_TRI<HostDeviceType, OutputScalar, PointScalar, defineVertexFunctions>;
+      return Teuchos::rcp( new HostBasisType(polyOrder_, pointType_) );
+    }
   };
 } // end namespace Intrepid2
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_IntegratedLegendreBasis_HGRAD_TRI.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_IntegratedLegendreBasis_HGRAD_TRI.hpp
@@ -358,7 +358,7 @@ namespace Intrepid2
                is true, then the first basis function will instead be 1.0-x-y, and the basis will be suitable for
                continuous discretizations.
   */
-  template<typename DeviceType=Kokkos::DefaultExecutionSpace::device_type,
+  template<typename DeviceType=Kokkos::DefaultExecutionSpace,
            typename OutputScalar = double,
            typename PointScalar  = double,
            bool defineVertexFunctions = true>            // if defineVertexFunctions is true, first three basis functions are 1-x-y, x, and y.  Otherwise, they are 1, x, and y.

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_LegendreBasis_HVOL_LINE.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_LegendreBasis_HVOL_LINE.hpp
@@ -69,10 +69,11 @@ namespace Intrepid2
    
    This functor is not intended for use outside of LegendreBasis_HVOL_LINE.
   */
-  template<class ExecutionSpace, class OutputScalar, class PointScalar,
+  template<class DeviceType, class OutputScalar, class PointScalar,
   class OutputFieldType, class InputPointsType>
   struct Hierarchical_HVOL_LINE_Functor
   {
+    using ExecutionSpace     = typename DeviceType::execution_space;
     using ScratchSpace       = typename ExecutionSpace::scratch_memory_space;
     using OutputScratchView  = Kokkos::View<OutputScalar*,ScratchSpace,Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
     using PointScratchView   = Kokkos::View<PointScalar*, ScratchSpace,Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
@@ -177,21 +178,24 @@ namespace Intrepid2
                Computers & Mathematics with Applications, Volume 70, Issue 4, 2015, Pages 353-458, ISSN 0898-1221.
                https://doi.org/10.1016/j.camwa.2015.04.027.
   */
-  template<typename ExecutionSpace=Kokkos::DefaultExecutionSpace,
+  template<typename DeviceType=Kokkos::DefaultExecutionSpace::device_type,
            typename OutputScalar = double,
            typename PointScalar  = double>
   class LegendreBasis_HVOL_LINE
-  : public Basis<ExecutionSpace,OutputScalar,PointScalar>
+  : public Basis<DeviceType,OutputScalar,PointScalar>
   {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<ExecutionSpace,OutputScalar,PointScalar>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<ExecutionSpace,OutputScalar,PointScalar>::OrdinalTypeArray2DHost;
+    using BasisBase = Basis<DeviceType,OutputScalar,PointScalar>;
     
-    typedef typename Basis<ExecutionSpace,OutputScalar,PointScalar>::OutputViewType OutputViewType;
-    typedef typename Basis<ExecutionSpace,OutputScalar,PointScalar>::PointViewType  PointViewType;
-    typedef typename Basis<ExecutionSpace,OutputScalar,PointScalar>::ScalarViewType ScalarViewType;
+    using OrdinalTypeArray1DHost = typename BasisBase::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename BasisBase::OrdinalTypeArray2DHost;
+    
+    using OutputViewType = typename BasisBase::OutputViewType;
+    using PointViewType  = typename BasisBase::PointViewType ;
+    using ScalarViewType = typename BasisBase::ScalarViewType;
   protected:
     int polyOrder_; // the maximum order of the polynomial
+    EPointType pointType_;
   public:
     /** \brief  Constructor.
         \param [in] polyOrder - the polynomial order of the basis.
@@ -203,7 +207,8 @@ namespace Intrepid2
      */
     LegendreBasis_HVOL_LINE(int polyOrder, const EPointType pointType=POINTTYPE_DEFAULT)
     :
-    polyOrder_(polyOrder)
+    polyOrder_(polyOrder),
+    pointType_(pointType)
     {
       INTREPID2_TEST_FOR_EXCEPTION(pointType!=POINTTYPE_DEFAULT,std::invalid_argument,"PointType not supported");
       this->basisCardinality_  = polyOrder+1;
@@ -257,7 +262,7 @@ namespace Intrepid2
     // since the getValues() below only overrides the FEM variant, we specify that
     // we use the base class's getValues(), which implements the FVD variant by throwing an exception.
     // (It's an error to use the FVD variant on this basis.)
-    using Basis<ExecutionSpace,OutputScalar,PointScalar>::getValues;
+    using BasisBase::getValues;
     
     /** \brief  Returns basis name
      
@@ -292,7 +297,7 @@ namespace Intrepid2
     {
       auto numPoints = inputPoints.extent_int(0);
       
-      using FunctorType = Hierarchical_HVOL_LINE_Functor<ExecutionSpace, OutputScalar, PointScalar, OutputViewType, PointViewType>;
+      using FunctorType = Hierarchical_HVOL_LINE_Functor<DeviceType, OutputScalar, PointScalar, OutputViewType, PointViewType>;
       
       FunctorType functor(outputValues, inputPoints, polyOrder_, operatorType);
       
@@ -301,8 +306,21 @@ namespace Intrepid2
       const int vectorSize = std::max(outputVectorSize,pointVectorSize);
       const int teamSize = 1; // because of the way the basis functions are computed, we don't have a second level of parallelism...
       
+      using ExecutionSpace = typename BasisBase::ExecutionSpace;
+      
       auto policy = Kokkos::TeamPolicy<ExecutionSpace>(numPoints,teamSize,vectorSize);
       Kokkos::parallel_for( policy , functor, "Hierarchical_HVOL_LINE_Functor");
+    }
+    
+    /** \brief Creates and returns a Basis object whose DeviceType template argument is Kokkos::HostSpace::device_type, but is otherwise identical to this.
+     
+        \return Pointer to the new Basis object.
+     */
+    virtual BasisPtr<typename Kokkos::HostSpace::device_type, OutputScalar, PointScalar>
+    getHostBasis() const override {
+      using HostDeviceType = typename Kokkos::HostSpace::device_type;
+      using HostBasisType  = LegendreBasis_HVOL_LINE<HostDeviceType, OutputScalar, PointScalar>;
+      return Teuchos::rcp( new HostBasisType(polyOrder_, pointType_) );
     }
   };
 } // end namespace Intrepid2

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_LegendreBasis_HVOL_LINE.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_LegendreBasis_HVOL_LINE.hpp
@@ -186,6 +186,7 @@ namespace Intrepid2
   {
   public:
     using BasisBase = Basis<DeviceType,OutputScalar,PointScalar>;
+    using HostBasis = LegendreBasis_HVOL_LINE<typename Kokkos::HostSpace::device_type,OutputScalar,PointScalar>;
     
     using OrdinalTypeArray1DHost = typename BasisBase::OrdinalTypeArray1DHost;
     using OrdinalTypeArray2DHost = typename BasisBase::OrdinalTypeArray2DHost;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_LegendreBasis_HVOL_LINE.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_LegendreBasis_HVOL_LINE.hpp
@@ -178,7 +178,7 @@ namespace Intrepid2
                Computers & Mathematics with Applications, Volume 70, Issue 4, 2015, Pages 353-458, ISSN 0898-1221.
                https://doi.org/10.1016/j.camwa.2015.04.027.
   */
-  template<typename DeviceType=Kokkos::DefaultExecutionSpace::device_type,
+  template<typename DeviceType=Kokkos::DefaultExecutionSpace,
            typename OutputScalar = double,
            typename PointScalar  = double>
   class LegendreBasis_HVOL_LINE

--- a/packages/intrepid2/src/Shared/Intrepid2_TestUtils.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_TestUtils.hpp
@@ -67,6 +67,13 @@ namespace Intrepid2
   //! Maximum number of derivatives to track for Fad types in tests.
   constexpr int MAX_FAD_DERIVATIVES_FOR_TESTS = 3;
 
+  //! Default Kokkos::Device to use for tests; depends on platform
+#ifdef KOKKOS_ENABLE_CUDA
+  using DefaultTestDeviceType = Kokkos::Device<Kokkos::Cuda,Kokkos::CudaSpace>;
+#else
+  using DefaultTestDeviceType = Kokkos::Device<Kokkos::Serial,Kokkos::HostSpace>;
+#endif
+
   //! Use Teuchos small number determination on host; pass this to Intrepid2::relErr() on device.
   template <class Scalar>
   const typename Teuchos::ScalarTraits<Scalar>::magnitudeType

--- a/packages/intrepid2/src/Shared/Intrepid2_TestUtils.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_TestUtils.hpp
@@ -71,7 +71,7 @@ namespace Intrepid2
 #ifdef KOKKOS_ENABLE_CUDA
   using DefaultTestDeviceType = Kokkos::Device<Kokkos::Cuda,Kokkos::CudaSpace>;
 #else
-  using DefaultTestDeviceType = Kokkos::Device<Kokkos::Serial,Kokkos::HostSpace>;
+  using DefaultTestDeviceType = typename Kokkos::DefaultExecutionSpace::device_type;
 #endif
 
   //! Use Teuchos small number determination on host; pass this to Intrepid2::relErr() on device.

--- a/packages/intrepid2/unit-test/MonolithicExecutable/BasisValuesTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/BasisValuesTests.cpp
@@ -236,23 +236,6 @@ namespace
 
   TEUCHOS_UNIT_TEST( BasisValues, HierarchicalHGRAD_LINE )
   {
-    using Basis = HierarchicalBasisFamily<>::HGRAD_LINE;
-    
-    // for now, the BasisValues path only supports the standard exact-sequence operators
-    std::vector<EOperator> opsToTest {OPERATOR_VALUE, OPERATOR_GRAD};
-    
-    const double relTol=1e-13;
-    const double absTol=1e-13;
-    
-    for (int polyOrder=1; polyOrder<5; polyOrder++)
-    {
-      Basis basis(polyOrder);
-      testGetValuesEquality(basis, opsToTest, relTol, absTol, out, success);
-    }
-  }
-
-  TEUCHOS_UNIT_TEST( BasisValues, HierarchicalHGRAD_LINE_DeviceType )
-  {
     using DeviceType = Intrepid2::DefaultTestDeviceType;
     using Basis = HierarchicalBasisFamily<DeviceType>::HGRAD_LINE;
     
@@ -270,23 +253,6 @@ namespace
   }
 
   TEUCHOS_UNIT_TEST( BasisValues, HierarchicalHGRAD_QUAD )
-  {
-    using Basis = HierarchicalBasisFamily<>::HGRAD_QUAD;
-    
-    // for now, the BasisValues path only supports the standard exact-sequence operators
-    std::vector<EOperator> opsToTest {OPERATOR_VALUE, OPERATOR_GRAD};
-    
-    const double relTol=1e-13;
-    const double absTol=1e-13;
-    
-    for (int polyOrder=1; polyOrder<5; polyOrder++)
-    {
-      Basis basis(polyOrder);
-      testGetValuesEquality(basis, opsToTest, relTol, absTol, out, success);
-    }
-  }
-
-  TEUCHOS_UNIT_TEST( BasisValues, HierarchicalHGRAD_QUAD_DeviceType )
   {
     using DeviceType = Intrepid2::DefaultTestDeviceType;
     using Basis = HierarchicalBasisFamily<DeviceType>::HGRAD_QUAD;
@@ -306,23 +272,6 @@ namespace
 
   TEUCHOS_UNIT_TEST( BasisValues, HierarchicalHGRAD_TRI )
   {
-    using Basis = HierarchicalBasisFamily<>::HGRAD_TRI;
-    
-    // for now, the BasisValues path only supports the standard exact-sequence operators
-    std::vector<EOperator> opsToTest {OPERATOR_VALUE, OPERATOR_GRAD};
-    
-    const double relTol=1e-13;
-    const double absTol=1e-13;
-    
-    for (int polyOrder=1; polyOrder<5; polyOrder++)
-    {
-      Basis basis(polyOrder);
-      testGetValuesEquality(basis, opsToTest, relTol, absTol, out, success);
-    }
-  }
-
-  TEUCHOS_UNIT_TEST( BasisValues, HierarchicalHGRAD_TRI_DeviceType )
-  {
     using DeviceType = Intrepid2::DefaultTestDeviceType;
     using Basis = HierarchicalBasisFamily<DeviceType>::HGRAD_TRI;
     
@@ -340,23 +289,6 @@ namespace
   }
 
   TEUCHOS_UNIT_TEST( BasisValues, HierarchicalHGRAD_HEX )
-  {
-    using Basis = HierarchicalBasisFamily<>::HGRAD_HEX;
-    
-    // for now, the BasisValues path only supports the standard exact-sequence operators
-    std::vector<EOperator> opsToTest {OPERATOR_VALUE, OPERATOR_GRAD};
-    
-    const double relTol=1e-13;
-    const double absTol=1e-13;
-    
-    for (int polyOrder=1; polyOrder<5; polyOrder++)
-    {
-      Basis basis(polyOrder);
-      testGetValuesEquality(basis, opsToTest, relTol, absTol, out, success);
-    }
-  }
-
-  TEUCHOS_UNIT_TEST( BasisValues, HierarchicalHGRAD_HEX_DeviceType )
   {
     using DeviceType = Intrepid2::DefaultTestDeviceType;
     using Basis = HierarchicalBasisFamily<DeviceType>::HGRAD_HEX;
@@ -376,23 +308,6 @@ namespace
 
   TEUCHOS_UNIT_TEST( BasisValues, HierarchicalHGRAD_TET )
   {
-    using Basis = HierarchicalBasisFamily<>::HGRAD_TET;
-    
-    // for now, the BasisValues path only supports the standard exact-sequence operators
-    std::vector<EOperator> opsToTest {OPERATOR_VALUE, OPERATOR_GRAD};
-    
-    const double relTol=1e-13;
-    const double absTol=1e-13;
-    
-    for (int polyOrder=1; polyOrder<5; polyOrder++)
-    {
-      Basis basis(polyOrder);
-      testGetValuesEquality(basis, opsToTest, relTol, absTol, out, success);
-    }
-  }
-
-  TEUCHOS_UNIT_TEST( BasisValues, HierarchicalHGRAD_TET_DeviceType )
-  {
     using DeviceType = Intrepid2::DefaultTestDeviceType;
     using Basis = HierarchicalBasisFamily<DeviceType>::HGRAD_TET;
     
@@ -410,23 +325,6 @@ namespace
   }
 
   TEUCHOS_UNIT_TEST( BasisValues, HierarchicalHDIV_QUAD )
-  {
-    using Basis = HierarchicalBasisFamily<>::HDIV_QUAD;
-    
-    // for now, the BasisValues path only supports the standard exact-sequence operators
-    std::vector<EOperator> opsToTest {OPERATOR_VALUE, OPERATOR_DIV};
-    
-    const double relTol=1e-13;
-    const double absTol=1e-13;
-    
-    for (int polyOrder=1; polyOrder<5; polyOrder++)
-    {
-      Basis basis(polyOrder);
-      testGetValuesEquality(basis, opsToTest, relTol, absTol, out, success);
-    }
-  }
-
-  TEUCHOS_UNIT_TEST( BasisValues, HierarchicalHDIV_QUAD_DeviceType )
   {
     using DeviceType = Intrepid2::DefaultTestDeviceType;
     using Basis = HierarchicalBasisFamily<DeviceType>::HDIV_QUAD;
@@ -446,23 +344,6 @@ namespace
 
   TEUCHOS_UNIT_TEST( BasisValues, NodalHDIV_TRI )
   {
-    using Basis = NodalBasisFamily<>::HDIV_TRI; // Hierarchical basis family does not yet support HDIV_TRI
-    
-    // for now, the BasisValues path only supports the standard exact-sequence operators
-    std::vector<EOperator> opsToTest {OPERATOR_VALUE, OPERATOR_DIV};
-    
-    const double relTol=1e-13;
-    const double absTol=1e-13;
-    
-    for (int polyOrder=1; polyOrder<5; polyOrder++)
-    {
-      Basis basis(polyOrder);
-      testGetValuesEquality(basis, opsToTest, relTol, absTol, out, success);
-    }
-  }
-
-  TEUCHOS_UNIT_TEST( BasisValues, NodalHDIV_TRI_DeviceType )
-  {
     using DeviceType = Intrepid2::DefaultTestDeviceType;
     using Basis = NodalBasisFamily<DeviceType>::HDIV_TRI; // Hierarchical basis family does not yet support HDIV_TRI
     
@@ -480,23 +361,6 @@ namespace
   }
 
   TEUCHOS_UNIT_TEST( BasisValues, HierarchicalHDIV_HEX )
-  {
-    using Basis = HierarchicalBasisFamily<>::HDIV_HEX;
-    
-    // for now, the BasisValues path only supports the standard exact-sequence operators
-    std::vector<EOperator> opsToTest {OPERATOR_VALUE, OPERATOR_DIV};
-    
-    const double relTol=1e-13;
-    const double absTol=1e-13;
-    
-    for (int polyOrder=1; polyOrder<5; polyOrder++)
-    {
-      Basis basis(polyOrder);
-      testGetValuesEquality(basis, opsToTest, relTol, absTol, out, success);
-    }
-  }
-
-  TEUCHOS_UNIT_TEST( BasisValues, HierarchicalHDIV_HEX_DeviceType )
   {
     using DeviceType = Intrepid2::DefaultTestDeviceType;
     using Basis = HierarchicalBasisFamily<DeviceType>::HDIV_HEX;
@@ -516,23 +380,6 @@ namespace
 
   TEUCHOS_UNIT_TEST( BasisValues, NodalHDIV_TET )
   {
-    using Basis = NodalBasisFamily<>::HDIV_TET;  // Hierarchical basis family does not yet support HDIV_TET
-    
-    // for now, the BasisValues path only supports the standard exact-sequence operators
-    std::vector<EOperator> opsToTest {OPERATOR_VALUE, OPERATOR_DIV};
-    
-    const double relTol=1e-13;
-    const double absTol=1e-13;
-    
-    for (int polyOrder=1; polyOrder<5; polyOrder++)
-    {
-      Basis basis(polyOrder);
-      testGetValuesEquality(basis, opsToTest, relTol, absTol, out, success);
-    }
-  }
-
-  TEUCHOS_UNIT_TEST( BasisValues, NodalHDIV_TET_DeviceType )
-  {
     using DeviceType = Intrepid2::DefaultTestDeviceType;
     using Basis = NodalBasisFamily<DeviceType>::HDIV_TET;  // Hierarchical basis family does not yet support HDIV_TET
     
@@ -550,23 +397,6 @@ namespace
   }
 
   TEUCHOS_UNIT_TEST( BasisValues, HierarchicalHCURL_QUAD )
-  {
-    using Basis = HierarchicalBasisFamily<>::HCURL_QUAD;
-    
-    // for now, the BasisValues path only supports the standard exact-sequence operators
-    std::vector<EOperator> opsToTest {OPERATOR_VALUE, OPERATOR_CURL};
-    
-    const double relTol=1e-13;
-    const double absTol=1e-13;
-    
-    for (int polyOrder=1; polyOrder<5; polyOrder++)
-    {
-      Basis basis(polyOrder);
-      testGetValuesEquality(basis, opsToTest, relTol, absTol, out, success);
-    }
-  }
-
-  TEUCHOS_UNIT_TEST( BasisValues, HierarchicalHCURL_QUAD_DeviceType )
   {
     using DeviceType = Intrepid2::DefaultTestDeviceType;
     using Basis = HierarchicalBasisFamily<DeviceType>::HCURL_QUAD;
@@ -586,23 +416,6 @@ namespace
 
   TEUCHOS_UNIT_TEST( BasisValues, NodalHCURL_TRI )
   {
-    using Basis = NodalBasisFamily<>::HCURL_TRI;  // Hierarchical basis family does not yet support HCURL_TRI
-    
-    // for now, the BasisValues path only supports the standard exact-sequence operators
-    std::vector<EOperator> opsToTest {OPERATOR_VALUE, OPERATOR_CURL};
-    
-    const double relTol=1e-13;
-    const double absTol=1e-13;
-    
-    for (int polyOrder=1; polyOrder<5; polyOrder++)
-    {
-      Basis basis(polyOrder);
-      testGetValuesEquality(basis, opsToTest, relTol, absTol, out, success);
-    }
-  }
-
-  TEUCHOS_UNIT_TEST( BasisValues, NodalHCURL_TRI_DeviceType )
-  {
     using DeviceType = Intrepid2::DefaultTestDeviceType;
     using Basis = NodalBasisFamily<DeviceType>::HCURL_TRI;  // Hierarchical basis family does not yet support HCURL_TRI
     
@@ -621,23 +434,6 @@ namespace
 
   TEUCHOS_UNIT_TEST( BasisValues, HierarchicalHCURL_HEX )
   {
-    using Basis = HierarchicalBasisFamily<>::HCURL_HEX;
-    
-    // for now, the BasisValues path only supports the standard exact-sequence operators
-    std::vector<EOperator> opsToTest {OPERATOR_VALUE, OPERATOR_CURL};
-    
-    const double relTol=1e-13;
-    const double absTol=1e-13;
-    
-    for (int polyOrder=1; polyOrder<5; polyOrder++)
-    {
-      Basis basis(polyOrder);
-      testGetValuesEquality(basis, opsToTest, relTol, absTol, out, success);
-    }
-  }
-
-  TEUCHOS_UNIT_TEST( BasisValues, HierarchicalHCURL_HEX_DeviceType )
-  {
     using DeviceType = Intrepid2::DefaultTestDeviceType;
     using Basis = HierarchicalBasisFamily<DeviceType>::HCURL_HEX;
     
@@ -654,12 +450,13 @@ namespace
     }
   }
 
-  TEUCHOS_UNIT_TEST( BasisValues, NodalHCURL_TET )
+  TEUCHOS_UNIT_TEST( BasisValues, HierarchicalHVOL_QUAD )
   {
-    using Basis = NodalBasisFamily<>::HCURL_TET;  // Hierarchical basis family does not yet support HCURL_TET
+    using DeviceType = Intrepid2::DefaultTestDeviceType;
+    using Basis = HierarchicalBasisFamily<DeviceType>::HVOL_QUAD;
     
     // for now, the BasisValues path only supports the standard exact-sequence operators
-    std::vector<EOperator> opsToTest {OPERATOR_VALUE, OPERATOR_CURL};
+    std::vector<EOperator> opsToTest {OPERATOR_VALUE};
     
     const double relTol=1e-13;
     const double absTol=1e-13;
@@ -671,7 +468,25 @@ namespace
     }
   }
 
-  TEUCHOS_UNIT_TEST( BasisValues, NodalHCURL_TET_DeviceType )
+  TEUCHOS_UNIT_TEST( BasisValues, HierarchicalHVOL_HEX )
+  {
+    using DeviceType = Intrepid2::DefaultTestDeviceType;
+    using Basis = HierarchicalBasisFamily<DeviceType>::HVOL_HEX;
+    
+    // for now, the BasisValues path only supports the standard exact-sequence operators
+    std::vector<EOperator> opsToTest {OPERATOR_VALUE};
+    
+    const double relTol=1e-13;
+    const double absTol=1e-13;
+    
+    for (int polyOrder=1; polyOrder<5; polyOrder++)
+    {
+      Basis basis(polyOrder);
+      testGetValuesEquality(basis, opsToTest, relTol, absTol, out, success);
+    }
+  }
+
+  TEUCHOS_UNIT_TEST( BasisValues, NodalHCURL_TET )
   {
     using DeviceType = Intrepid2::DefaultTestDeviceType;
     using Basis = NodalBasisFamily<DeviceType>::HCURL_TET;  // Hierarchical basis family does not yet support HCURL_TET
@@ -690,23 +505,6 @@ namespace
   }
 
   TEUCHOS_UNIT_TEST( BasisValues, NodalHGRAD_LINE )
-  {
-    using Basis = NodalBasisFamily<>::HGRAD_LINE;
-    
-    // for now, the BasisValues path only supports the standard exact-sequence operators
-    std::vector<EOperator> opsToTest {OPERATOR_VALUE, OPERATOR_GRAD};
-    
-    const double relTol=1e-13;
-    const double absTol=1e-13;
-    
-    for (int polyOrder=1; polyOrder<5; polyOrder++)
-    {
-      Basis basis(polyOrder);
-      testGetValuesEquality(basis, opsToTest, relTol, absTol, out, success);
-    }
-  }
-
-  TEUCHOS_UNIT_TEST( BasisValues, NodalHGRAD_LINE_DeviceType )
   {
     using DeviceType = Intrepid2::DefaultTestDeviceType;
     using Basis = NodalBasisFamily<DeviceType>::HGRAD_LINE;

--- a/packages/intrepid2/unit-test/MonolithicExecutable/BasisValuesTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/BasisValuesTests.cpp
@@ -251,6 +251,24 @@ namespace
     }
   }
 
+  TEUCHOS_UNIT_TEST( BasisValues, HierarchicalHGRAD_LINE_DeviceType )
+  {
+    using DeviceType = Intrepid2::DefaultTestDeviceType;
+    using Basis = HierarchicalBasisFamily<DeviceType>::HGRAD_LINE;
+    
+    // for now, the BasisValues path only supports the standard exact-sequence operators
+    std::vector<EOperator> opsToTest {OPERATOR_VALUE, OPERATOR_GRAD};
+    
+    const double relTol=1e-13;
+    const double absTol=1e-13;
+    
+    for (int polyOrder=1; polyOrder<5; polyOrder++)
+    {
+      Basis basis(polyOrder);
+      testGetValuesEquality(basis, opsToTest, relTol, absTol, out, success);
+    }
+  }
+
   TEUCHOS_UNIT_TEST( BasisValues, HierarchicalHGRAD_QUAD )
   {
     using Basis = HierarchicalBasisFamily<>::HGRAD_QUAD;

--- a/packages/intrepid2/unit-test/MonolithicExecutable/BasisValuesTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/BasisValuesTests.cpp
@@ -286,9 +286,45 @@ namespace
     }
   }
 
+  TEUCHOS_UNIT_TEST( BasisValues, HierarchicalHGRAD_QUAD_DeviceType )
+  {
+    using DeviceType = Intrepid2::DefaultTestDeviceType;
+    using Basis = HierarchicalBasisFamily<DeviceType>::HGRAD_QUAD;
+    
+    // for now, the BasisValues path only supports the standard exact-sequence operators
+    std::vector<EOperator> opsToTest {OPERATOR_VALUE, OPERATOR_GRAD};
+    
+    const double relTol=1e-13;
+    const double absTol=1e-13;
+    
+    for (int polyOrder=1; polyOrder<5; polyOrder++)
+    {
+      Basis basis(polyOrder);
+      testGetValuesEquality(basis, opsToTest, relTol, absTol, out, success);
+    }
+  }
+
   TEUCHOS_UNIT_TEST( BasisValues, HierarchicalHGRAD_TRI )
   {
     using Basis = HierarchicalBasisFamily<>::HGRAD_TRI;
+    
+    // for now, the BasisValues path only supports the standard exact-sequence operators
+    std::vector<EOperator> opsToTest {OPERATOR_VALUE, OPERATOR_GRAD};
+    
+    const double relTol=1e-13;
+    const double absTol=1e-13;
+    
+    for (int polyOrder=1; polyOrder<5; polyOrder++)
+    {
+      Basis basis(polyOrder);
+      testGetValuesEquality(basis, opsToTest, relTol, absTol, out, success);
+    }
+  }
+
+  TEUCHOS_UNIT_TEST( BasisValues, HierarchicalHGRAD_TRI_DeviceType )
+  {
+    using DeviceType = Intrepid2::DefaultTestDeviceType;
+    using Basis = HierarchicalBasisFamily<DeviceType>::HGRAD_TRI;
     
     // for now, the BasisValues path only supports the standard exact-sequence operators
     std::vector<EOperator> opsToTest {OPERATOR_VALUE, OPERATOR_GRAD};
@@ -320,9 +356,45 @@ namespace
     }
   }
 
+  TEUCHOS_UNIT_TEST( BasisValues, HierarchicalHGRAD_HEX_DeviceType )
+  {
+    using DeviceType = Intrepid2::DefaultTestDeviceType;
+    using Basis = HierarchicalBasisFamily<DeviceType>::HGRAD_HEX;
+    
+    // for now, the BasisValues path only supports the standard exact-sequence operators
+    std::vector<EOperator> opsToTest {OPERATOR_VALUE, OPERATOR_GRAD};
+    
+    const double relTol=1e-13;
+    const double absTol=1e-13;
+    
+    for (int polyOrder=1; polyOrder<5; polyOrder++)
+    {
+      Basis basis(polyOrder);
+      testGetValuesEquality(basis, opsToTest, relTol, absTol, out, success);
+    }
+  }
+
   TEUCHOS_UNIT_TEST( BasisValues, HierarchicalHGRAD_TET )
   {
     using Basis = HierarchicalBasisFamily<>::HGRAD_TET;
+    
+    // for now, the BasisValues path only supports the standard exact-sequence operators
+    std::vector<EOperator> opsToTest {OPERATOR_VALUE, OPERATOR_GRAD};
+    
+    const double relTol=1e-13;
+    const double absTol=1e-13;
+    
+    for (int polyOrder=1; polyOrder<5; polyOrder++)
+    {
+      Basis basis(polyOrder);
+      testGetValuesEquality(basis, opsToTest, relTol, absTol, out, success);
+    }
+  }
+
+  TEUCHOS_UNIT_TEST( BasisValues, HierarchicalHGRAD_TET_DeviceType )
+  {
+    using DeviceType = Intrepid2::DefaultTestDeviceType;
+    using Basis = HierarchicalBasisFamily<DeviceType>::HGRAD_TET;
     
     // for now, the BasisValues path only supports the standard exact-sequence operators
     std::vector<EOperator> opsToTest {OPERATOR_VALUE, OPERATOR_GRAD};
@@ -354,9 +426,45 @@ namespace
     }
   }
 
+  TEUCHOS_UNIT_TEST( BasisValues, HierarchicalHDIV_QUAD_DeviceType )
+  {
+    using DeviceType = Intrepid2::DefaultTestDeviceType;
+    using Basis = HierarchicalBasisFamily<DeviceType>::HDIV_QUAD;
+    
+    // for now, the BasisValues path only supports the standard exact-sequence operators
+    std::vector<EOperator> opsToTest {OPERATOR_VALUE, OPERATOR_DIV};
+    
+    const double relTol=1e-13;
+    const double absTol=1e-13;
+    
+    for (int polyOrder=1; polyOrder<5; polyOrder++)
+    {
+      Basis basis(polyOrder);
+      testGetValuesEquality(basis, opsToTest, relTol, absTol, out, success);
+    }
+  }
+
   TEUCHOS_UNIT_TEST( BasisValues, NodalHDIV_TRI )
   {
     using Basis = NodalBasisFamily<>::HDIV_TRI; // Hierarchical basis family does not yet support HDIV_TRI
+    
+    // for now, the BasisValues path only supports the standard exact-sequence operators
+    std::vector<EOperator> opsToTest {OPERATOR_VALUE, OPERATOR_DIV};
+    
+    const double relTol=1e-13;
+    const double absTol=1e-13;
+    
+    for (int polyOrder=1; polyOrder<5; polyOrder++)
+    {
+      Basis basis(polyOrder);
+      testGetValuesEquality(basis, opsToTest, relTol, absTol, out, success);
+    }
+  }
+
+  TEUCHOS_UNIT_TEST( BasisValues, NodalHDIV_TRI_DeviceType )
+  {
+    using DeviceType = Intrepid2::DefaultTestDeviceType;
+    using Basis = NodalBasisFamily<DeviceType>::HDIV_TRI; // Hierarchical basis family does not yet support HDIV_TRI
     
     // for now, the BasisValues path only supports the standard exact-sequence operators
     std::vector<EOperator> opsToTest {OPERATOR_VALUE, OPERATOR_DIV};
@@ -388,9 +496,45 @@ namespace
     }
   }
 
+  TEUCHOS_UNIT_TEST( BasisValues, HierarchicalHDIV_HEX_DeviceType )
+  {
+    using DeviceType = Intrepid2::DefaultTestDeviceType;
+    using Basis = HierarchicalBasisFamily<DeviceType>::HDIV_HEX;
+    
+    // for now, the BasisValues path only supports the standard exact-sequence operators
+    std::vector<EOperator> opsToTest {OPERATOR_VALUE, OPERATOR_DIV};
+    
+    const double relTol=1e-13;
+    const double absTol=1e-13;
+    
+    for (int polyOrder=1; polyOrder<5; polyOrder++)
+    {
+      Basis basis(polyOrder);
+      testGetValuesEquality(basis, opsToTest, relTol, absTol, out, success);
+    }
+  }
+
   TEUCHOS_UNIT_TEST( BasisValues, NodalHDIV_TET )
   {
     using Basis = NodalBasisFamily<>::HDIV_TET;  // Hierarchical basis family does not yet support HDIV_TET
+    
+    // for now, the BasisValues path only supports the standard exact-sequence operators
+    std::vector<EOperator> opsToTest {OPERATOR_VALUE, OPERATOR_DIV};
+    
+    const double relTol=1e-13;
+    const double absTol=1e-13;
+    
+    for (int polyOrder=1; polyOrder<5; polyOrder++)
+    {
+      Basis basis(polyOrder);
+      testGetValuesEquality(basis, opsToTest, relTol, absTol, out, success);
+    }
+  }
+
+  TEUCHOS_UNIT_TEST( BasisValues, NodalHDIV_TET_DeviceType )
+  {
+    using DeviceType = Intrepid2::DefaultTestDeviceType;
+    using Basis = NodalBasisFamily<DeviceType>::HDIV_TET;  // Hierarchical basis family does not yet support HDIV_TET
     
     // for now, the BasisValues path only supports the standard exact-sequence operators
     std::vector<EOperator> opsToTest {OPERATOR_VALUE, OPERATOR_DIV};
@@ -422,9 +566,45 @@ namespace
     }
   }
 
+  TEUCHOS_UNIT_TEST( BasisValues, HierarchicalHCURL_QUAD_DeviceType )
+  {
+    using DeviceType = Intrepid2::DefaultTestDeviceType;
+    using Basis = HierarchicalBasisFamily<DeviceType>::HCURL_QUAD;
+    
+    // for now, the BasisValues path only supports the standard exact-sequence operators
+    std::vector<EOperator> opsToTest {OPERATOR_VALUE, OPERATOR_CURL};
+    
+    const double relTol=1e-13;
+    const double absTol=1e-13;
+    
+    for (int polyOrder=1; polyOrder<5; polyOrder++)
+    {
+      Basis basis(polyOrder);
+      testGetValuesEquality(basis, opsToTest, relTol, absTol, out, success);
+    }
+  }
+
   TEUCHOS_UNIT_TEST( BasisValues, NodalHCURL_TRI )
   {
     using Basis = NodalBasisFamily<>::HCURL_TRI;  // Hierarchical basis family does not yet support HCURL_TRI
+    
+    // for now, the BasisValues path only supports the standard exact-sequence operators
+    std::vector<EOperator> opsToTest {OPERATOR_VALUE, OPERATOR_CURL};
+    
+    const double relTol=1e-13;
+    const double absTol=1e-13;
+    
+    for (int polyOrder=1; polyOrder<5; polyOrder++)
+    {
+      Basis basis(polyOrder);
+      testGetValuesEquality(basis, opsToTest, relTol, absTol, out, success);
+    }
+  }
+
+  TEUCHOS_UNIT_TEST( BasisValues, NodalHCURL_TRI_DeviceType )
+  {
+    using DeviceType = Intrepid2::DefaultTestDeviceType;
+    using Basis = NodalBasisFamily<DeviceType>::HCURL_TRI;  // Hierarchical basis family does not yet support HCURL_TRI
     
     // for now, the BasisValues path only supports the standard exact-sequence operators
     std::vector<EOperator> opsToTest {OPERATOR_VALUE, OPERATOR_CURL};
@@ -456,6 +636,24 @@ namespace
     }
   }
 
+  TEUCHOS_UNIT_TEST( BasisValues, HierarchicalHCURL_HEX_DeviceType )
+  {
+    using DeviceType = Intrepid2::DefaultTestDeviceType;
+    using Basis = HierarchicalBasisFamily<DeviceType>::HCURL_HEX;
+    
+    // for now, the BasisValues path only supports the standard exact-sequence operators
+    std::vector<EOperator> opsToTest {OPERATOR_VALUE, OPERATOR_CURL};
+    
+    const double relTol=1e-13;
+    const double absTol=1e-13;
+    
+    for (int polyOrder=1; polyOrder<5; polyOrder++)
+    {
+      Basis basis(polyOrder);
+      testGetValuesEquality(basis, opsToTest, relTol, absTol, out, success);
+    }
+  }
+
   TEUCHOS_UNIT_TEST( BasisValues, NodalHCURL_TET )
   {
     using Basis = NodalBasisFamily<>::HCURL_TET;  // Hierarchical basis family does not yet support HCURL_TET
@@ -473,9 +671,45 @@ namespace
     }
   }
 
+  TEUCHOS_UNIT_TEST( BasisValues, NodalHCURL_TET_DeviceType )
+  {
+    using DeviceType = Intrepid2::DefaultTestDeviceType;
+    using Basis = NodalBasisFamily<DeviceType>::HCURL_TET;  // Hierarchical basis family does not yet support HCURL_TET
+    
+    // for now, the BasisValues path only supports the standard exact-sequence operators
+    std::vector<EOperator> opsToTest {OPERATOR_VALUE, OPERATOR_CURL};
+    
+    const double relTol=1e-13;
+    const double absTol=1e-13;
+    
+    for (int polyOrder=1; polyOrder<5; polyOrder++)
+    {
+      Basis basis(polyOrder);
+      testGetValuesEquality(basis, opsToTest, relTol, absTol, out, success);
+    }
+  }
+
   TEUCHOS_UNIT_TEST( BasisValues, NodalHGRAD_LINE )
   {
     using Basis = NodalBasisFamily<>::HGRAD_LINE;
+    
+    // for now, the BasisValues path only supports the standard exact-sequence operators
+    std::vector<EOperator> opsToTest {OPERATOR_VALUE, OPERATOR_GRAD};
+    
+    const double relTol=1e-13;
+    const double absTol=1e-13;
+    
+    for (int polyOrder=1; polyOrder<5; polyOrder++)
+    {
+      Basis basis(polyOrder);
+      testGetValuesEquality(basis, opsToTest, relTol, absTol, out, success);
+    }
+  }
+
+  TEUCHOS_UNIT_TEST( BasisValues, NodalHGRAD_LINE_DeviceType )
+  {
+    using DeviceType = Intrepid2::DefaultTestDeviceType;
+    using Basis = NodalBasisFamily<DeviceType>::HGRAD_LINE;
     
     // for now, the BasisValues path only supports the standard exact-sequence operators
     std::vector<EOperator> opsToTest {OPERATOR_VALUE, OPERATOR_GRAD};


### PR DESCRIPTION
@trilinos/intrepid2 

## Motivation
This is part of #8310.

Intrepid2: added getHostBasis() implementations for several Basis subclasses, along with support for DeviceType template arguments in the same.

Specifically, the following classes now support getHostBasis and DeviceType template arguments:
- DerivedBasis_HCURL_HEX
- DerivedBasis_HCURL_QUAD
- DerivedBasis_HDIV_HEX
- DerivedBasis_HDIV_QUAD
- DerivedBasis_HGRAD_HEX
- DerivedBasis_HGRAD_QUAD
- DerivedBasis_HVOL_HEX
- DerivedBasis_HVOL_QUAD
- HGRAD_LINE_Cn_FEM
- HVOL_LINE_Cn_FEM
- IntegratedLegendreBasis_HGRAD_LINE
- LegendreBasis_HVOL_LINE

Other changes:
- added typedef Intrepid2::DefaultTestDeviceType to TestUtils; this is UVM-free on CUDA, and Kokkos::DefaultExecutionSpace::device_type otherwise.
- Made use of DefaultTestDeviceType as well as getHostBasis in the BasisValues test group (in MonolithicExecutable)
- revised template arguments of Basis_DirectSumBasis, Basis_TensorBasis, andBasis_TensorBasis3; these now depend only on the base Basis class
- added typedef for BasisBase in several Basis subclasses
- added typedef for HostBasis in several Basis subclasses (specifically, those defined on the line which are used in DerivedBasis instantiations)

## Testing
The modified tests within `MonolithicExecutable` exercise getHostBasis() on all modified bases.  These also test the modified bases with the UVM-free DeviceType when run under CUDA.
