### PR TITLE
tpetra:  removed Doxygen comments with incorrect advice on including _decl files

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -42,11 +42,6 @@
 
 /// \file Tpetra_CrsGraph_decl.hpp
 /// \brief Declaration of the Tpetra::CrsGraph class
-///
-/// If you want to use Tpetra::CrsGraph, include "Tpetra_CrsGraph.hpp"
-/// (a file which CMake generates and installs for you).  If you only
-/// want the declaration of Tpetra::CrsGraph, include this file
-/// (Tpetra_CrsGraph_decl.hpp).
 
 #include "Tpetra_CrsGraph_fwd.hpp"
 #include "Tpetra_CrsMatrix_fwd.hpp"

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -42,11 +42,6 @@
 
 /// \file Tpetra_CrsGraph_def.hpp
 /// \brief Definition of the Tpetra::CrsGraph class
-///
-/// If you want to use Tpetra::CrsGraph, include "Tpetra_CrsGraph.hpp"
-/// (a file which CMake generates and installs for you).  If you only
-/// want the declaration of Tpetra::CrsGraph, include
-/// "Tpetra_CrsGraph_decl.hpp".
 
 #include "Tpetra_Details_Behavior.hpp"
 #include "Tpetra_Details_computeOffsets.hpp"

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -42,11 +42,6 @@
 
 /// \file Tpetra_CrsMatrix_decl.hpp
 /// \brief Declaration of the Tpetra::CrsMatrix class
-///
-/// If you want to use Tpetra::CrsMatrix, include
-/// "Tpetra_CrsMatrix.hpp" (a file which CMake generates and installs
-/// for you).  If you only want the declaration of Tpetra::CrsMatrix,
-/// include this file (Tpetra_CrsMatrix_decl.hpp).
 
 #include "Tpetra_CrsMatrix_fwd.hpp"
 #include "Tpetra_LocalCrsMatrixOperator_fwd.hpp"

--- a/packages/tpetra/core/src/Tpetra_DistObject_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_DistObject_decl.hpp
@@ -42,11 +42,6 @@
 
 /// \file Tpetra_DistObject_decl.hpp
 /// \brief Declaration of the Tpetra::DistObject class
-///
-/// If you want to use Tpetra::DistObject, include
-/// "Tpetra_DistObject.hpp" (a file which CMake generates and installs
-/// for you).  If you only want the declaration of Tpetra::DistObject,
-/// include this file (Tpetra_DistObject_decl.hpp).
 
 #include "Tpetra_Map.hpp"
 #include "Tpetra_Import.hpp"

--- a/packages/tpetra/core/src/Tpetra_FECrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_FECrsGraph_decl.hpp
@@ -44,11 +44,6 @@
 
 /// \file Tpetra_FECrsGraph_decl.hpp
 /// \brief Declaration of the Tpetra::FECrsGraph class
-///
-/// If you want to use Tpetra::FECrsGraph, include "Tpetra_FECrsGraph.hpp"
-/// (a file which CMake generates and installs for you).  If you only
-/// want the declaration of Tpetra::FECrsGraph, include this file
-/// (Tpetra_FECrsGraph_decl.hpp).
 
 #include "Tpetra_FECrsGraph_fwd.hpp"
 #include "Tpetra_CrsGraph_decl.hpp"

--- a/packages/tpetra/core/src/Tpetra_FECrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_FECrsMatrix_decl.hpp
@@ -44,11 +44,6 @@
 
 /// \file Tpetra_FECrsMatrix_decl.hpp
 /// \brief Declaration of the Tpetra::FECrsMatrix class
-///
-/// If you want to use Tpetra::FECrsMatrix, include
-/// "Tpetra_FECrsMatrix.hpp" (a file which CMake generates and installs
-/// for you).  If you only want the declaration of Tpetra::FECrsMatrix,
-/// include this file (Tpetra_FECrsMatrix_decl.hpp).
 
 #include "Tpetra_CrsMatrix_decl.hpp"
 #include "Tpetra_FECrsGraph.hpp"

--- a/packages/tpetra/core/src/Tpetra_FEMultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_FEMultiVector_decl.hpp
@@ -44,12 +44,6 @@
 
 /// \file Tpetra_FEMultiVector_decl.hpp
 /// \brief Declaration of the Tpetra::MultiVector class
-///
-/// If you want to use Tpetra::FEMultiVector, include "Tpetra_FEMultiVector.hpp"
-/// (a file which CMake generates and installs for you).  If you only want
-/// the declaration of Tpetra::FEMultiVector, include this file
-/// (Tpetra_FEMultiVector_decl.hpp).
-///
 
 #include "Tpetra_FEMultiVector_fwd.hpp"
 #include "Tpetra_MultiVector_decl.hpp"

--- a/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
@@ -44,12 +44,6 @@
 
 /// \file Tpetra_MultiVector_decl.hpp
 /// \brief Declaration of the Tpetra::MultiVector class
-///
-/// If you want to use Tpetra::MultiVector, include
-/// "Tpetra_MultiVector.hpp" (a file which CMake generates and
-/// installs for you).  If you only want the declaration of
-/// Tpetra::MultiVector, include this file
-/// (Tpetra_MultiVector_decl.hpp).
 
 #include "Tpetra_MultiVector_fwd.hpp"
 #include "Tpetra_Vector_fwd.hpp"

--- a/packages/tpetra/core/src/Tpetra_Vector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Vector_decl.hpp
@@ -44,11 +44,6 @@
 
 /// \file Tpetra_Vector_decl.hpp
 /// \brief Declaration of the Tpetra::Vector class
-///
-/// If you want to use Tpetra::Vector, include "Tpetra_Vector.hpp" (a
-/// file which CMake generates and installs for you).  If you only
-/// want the declaration of Tpetra::Vector, include this file
-/// (Tpetra_Vector_decl.hpp).
 
 #include "Tpetra_ConfigDefs.hpp"
 #include "Tpetra_Vector_fwd.hpp"

--- a/packages/tpetra/core/src/Tpetra_Vector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Vector_def.hpp
@@ -44,11 +44,6 @@
 
 /// \file Tpetra_Vector_def.hpp
 /// \brief Definition of the Tpetra::Vector class
-///
-/// If you want to use Tpetra::Vector, include "Tpetra_Vector.hpp" (a
-/// file which CMake generates and installs for you).  If you only
-/// want the declaration of Tpetra::Vector, include
-/// "Tpetra_Vector_decl.hpp".
 
 #include "Tpetra_MultiVector.hpp"
 #include "Tpetra_Details_gathervPrint.hpp"

--- a/packages/tpetra/core/src/Tpetra_replaceDiagonalCrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_replaceDiagonalCrsMatrix_decl.hpp
@@ -43,7 +43,7 @@
 #define TPETRA_REPLACEDIAGONALCRSMATRIX_DECL_HPP
 
 /// \file Tpetra_replaceDiagonalCrsMatrix_decl.hpp
-/// \brief Declaration of Tpetra::repalceDiagonalCrsMatrix
+/// \brief Declaration of Tpetra::replaceDiagonalCrsMatrix
 
 #include "Tpetra_CrsMatrix_fwd.hpp"
 #include "Tpetra_Vector_fwd.hpp"


### PR DESCRIPTION


<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Users of Tpetra should include Tpetra_ClassName.hpp.

If users are using ETI builds and need to instantiate a non-ETI template type, they should also include Tpetra_ClassName_def.hpp.

These comments recommend include Tpetra_ClassName_decl.hpp; that advice is wrong and can lead to errors.  Just ask @tasmith4, @shardest, @crdohrm , @kddevin.

@mmwolf  found this bad documentation; I am removing it.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
N/A -- changes to comments only

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->