### PR TITLE
Intrepid2: modifications for CUDA 10.1.243 opt build

### DIFF
--- a/packages/intrepid2/src/Cell/Intrepid2_CellGeometry.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellGeometry.hpp
@@ -128,10 +128,12 @@ namespace Intrepid2
        \param [out] jacobianData - a container, allocated by allocateJacobianData(), into which the evaluated Jacobians will be placed.
        \param [in] points - if a valid points container, specifies the points at which the Jacobian will be evaluated.  (Invalid containers are acceptable for affine CellGeometry.)
        \param [in] pointsPerCell - the number of points at which the Jacobian will be evaluated in each cell.  If points is a valid container, pointsPerCell must match its first dimension.
+       \param [in] refData - the return from getJacobianRefData(); may be an empty container, depending on details of CellGeometry (e.g. if it is affine)
        \param [in] startCell - the first cell ordinal for which the Jacobian will be evaluated (used to define worksets smaller than the whole CellGeometry).
        \param [in] endCell - the first cell ordinal for which the Jacobian will not be evaluated (used to define worksets smaller than the whole CellGeometry); use -1 to indicate that all cells from startCell on should be evaluated.
     */
-    void setJacobianDataPrivate(Data<PointScalar,ExecSpaceType> &jacobianData, const TensorPoints<PointScalar,ExecSpaceType> &points, const int &pointsPerCell, const int startCell, const int endCell) const;
+    void setJacobianDataPrivate(Data<PointScalar,ExecSpaceType> &jacobianData, const TensorPoints<PointScalar,ExecSpaceType> &points, const int &pointsPerCell,
+                                const Data<PointScalar,ExecSpaceType> &refData, const int startCell, const int endCell) const;
   protected:
     HypercubeNodeOrdering nodeOrdering_;
     CellGeometryType    cellGeometryType_;
@@ -318,21 +320,31 @@ namespace Intrepid2
     */
     Data<PointScalar,ExecSpaceType> allocateJacobianData(const int &numPoints, const int startCell=0, const int endCell=-1) const;
     
-    /** \brief Compute Jacobian values for the reference-to-physical transformation, and place them in the provided container.
-       \param [out] jacobianData - a container, allocated by allocateJacobianData(), into which the evaluated Jacobians will be placed.
+    /** \brief Computes reference-space data for the specified points, to be used in setJacobian().
        \param [in] points - the points at which the Jacobian will be evaluated.
-       \param [in] startCell - the first cell ordinal for which the Jacobian will be evaluated (used to define worksets smaller than the whole CellGeometry).
-       \param [in] endCell - the first cell ordinal for which the Jacobian will not be evaluated (used to define worksets smaller than the whole CellGeometry); use -1 to indicate that all cells from startCell on should be evaluated.
+       \return a Data object with any reference-space data required.  This may be empty, if no reference-space data is required in setJacobian().
     */
-    void setJacobian(Data<PointScalar,ExecSpaceType> &jacobianData, const TensorPoints<PointScalar,ExecSpaceType> &points, const int startCell=0, const int endCell=-1) const;
+    Data<PointScalar,ExecSpaceType> getJacobianRefData(const TensorPoints<PointScalar,ExecSpaceType> &points) const;
     
     /** \brief Compute Jacobian values for the reference-to-physical transformation, and place them in the provided container.
        \param [out] jacobianData - a container, allocated by allocateJacobianData(), into which the evaluated Jacobians will be placed.
        \param [in] points - the points at which the Jacobian will be evaluated.
+       \param [in] refData - the return from getJacobianRefData(); may be an empty container, depending on details of CellGeometry (e.g. if it is affine)
        \param [in] startCell - the first cell ordinal for which the Jacobian will be evaluated (used to define worksets smaller than the whole CellGeometry).
        \param [in] endCell - the first cell ordinal for which the Jacobian will not be evaluated (used to define worksets smaller than the whole CellGeometry); use -1 to indicate that all cells from startCell on should be evaluated.
     */
-    void setJacobian(Data<PointScalar,ExecSpaceType> &jacobianData, const ScalarView<PointScalar,ExecSpaceType> &points, const int startCell=0, const int endCell=-1) const;
+    void setJacobian(Data<PointScalar,ExecSpaceType> &jacobianData, const TensorPoints<PointScalar,ExecSpaceType> &points, const Data<PointScalar,ExecSpaceType> &refData,
+                     const int startCell=0, const int endCell=-1) const;
+    
+    /** \brief Compute Jacobian values for the reference-to-physical transformation, and place them in the provided container.
+       \param [out] jacobianData - a container, allocated by allocateJacobianData(), into which the evaluated Jacobians will be placed.
+       \param [in] points - the points at which the Jacobian will be evaluated.
+       \param [in] refData - the return from getJacobianRefData(); may be an empty container, depending on details of CellGeometry (e.g. if it is affine)
+       \param [in] startCell - the first cell ordinal for which the Jacobian will be evaluated (used to define worksets smaller than the whole CellGeometry).
+       \param [in] endCell - the first cell ordinal for which the Jacobian will not be evaluated (used to define worksets smaller than the whole CellGeometry); use -1 to indicate that all cells from startCell on should be evaluated.
+    */
+    void setJacobian(Data<PointScalar,ExecSpaceType> &jacobianData, const ScalarView<PointScalar,ExecSpaceType> &points, const Data<PointScalar,ExecSpaceType> &refData,
+                     const int startCell=0, const int endCell=-1) const;
     
     /** \brief Compute Jacobian values for the reference-to-physical transformation, and place them in the provided container (variant for affine geometry).
        \param [out] jacobianData - a container, allocated by allocateJacobianData(), into which the evaluated Jacobians will be placed.

--- a/packages/intrepid2/src/Cell/Intrepid2_ProjectedGeometry.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_ProjectedGeometry.hpp
@@ -125,6 +125,8 @@ namespace Intrepid2
         CellTools::mapToPhysicalFrame(evaluationGradPoints, evaluationGradPointsRefSpace, flatCellGeometry, hgradLinearBasisForFlatGeometry);
       }
       
+      auto refData = flatCellGeometry.getJacobianRefData(evaluationGradPoints);
+      
       // evaluate, transform, and project in each component
       auto policy = Kokkos::MDRangePolicy<ExecSpaceType,Kokkos::Rank<2>>({0,0},  {numCells,numPoints});
       auto gradPolicy  = Kokkos::MDRangePolicy<ExecSpaceType,Kokkos::Rank<3>>({0,0,0},{numCells,numGradPoints,spaceDim});
@@ -153,7 +155,7 @@ namespace Intrepid2
         // HGRADtransformGRAD  is multiplication by inverse of Jacobian, so here we want to multiply by Jacobian
         
         auto gradPointsJacobians = flatCellGeometry.allocateJacobianData(evaluationGradPoints);
-        flatCellGeometry.setJacobian(gradPointsJacobians,evaluationGradPoints);
+        flatCellGeometry.setJacobian(gradPointsJacobians,evaluationGradPoints,refData);
         
         Kokkos::parallel_for("evaluate geometry gradients for projection", gradPolicy,
         KOKKOS_LAMBDA (const int &cellOrdinal, const int &pointOrdinal, const int &d2) {

--- a/packages/intrepid2/src/Shared/Intrepid2_Data.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_Data.hpp
@@ -1306,7 +1306,7 @@ namespace Intrepid2 {
     KOKKOS_INLINE_FUNCTION constexpr
     typename std::enable_if<std::is_integral<iType>::value, size_t>::type
     extent(const iType& r) const {
-      return extents_(r);
+      return extents_[r];
     }
     
     //! returns true for containers that have two dimensions marked as BLOCK_PLUS_DIAGONAL for which the non-diagonal block is empty or size 1.

--- a/packages/intrepid2/unit-test/MonolithicExecutable/CellGeometryTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/CellGeometryTests.cpp
@@ -123,7 +123,8 @@ namespace
     }
     
     Data<PointScalar,ExecutionSpace> jacobians = cellGeometry.allocateJacobianData(tensorPoints);
-    cellGeometry.setJacobian(jacobians, tensorPoints);
+    auto refData = cellGeometry.getJacobianRefData(tensorPoints);
+    cellGeometry.setJacobian(jacobians, tensorPoints, refData);
     
     printFunctor4(jacobians, out, "jacobians from CellGeometry");
     testFloatingEquality4(expectedJacobians, jacobians, relTol, absTol, out, success, "expected Jacobians", "actual Jacobians from CellGeometry");
@@ -200,7 +201,9 @@ namespace
     jacobian = nonAffineCellGeometry.allocateJacobianData(cubaturePoints);
     jacobianDet = CellTools::allocateJacobianDet(jacobian);
     jacobianInv = CellTools::allocateJacobianInv(jacobian);
-    nonAffineCellGeometry.setJacobian(jacobian, cubaturePoints);
+    
+    auto refData = nonAffineCellGeometry.getJacobianRefData(cubaturePoints);
+    nonAffineCellGeometry.setJacobian(jacobian, cubaturePoints, refData);
     CellTools::setJacobianDet(jacobianDet, jacobian);
     CellTools::setJacobianInv(jacobianInv, jacobian);
     

--- a/packages/intrepid2/unit-test/MonolithicExecutable/ProjectedGeometryTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/ProjectedGeometryTests.cpp
@@ -123,7 +123,8 @@ namespace
       TEST_EQUALITY(numCells,  jacobianDet.extent_int(0));
       TEST_EQUALITY(numPoints, jacobianDet.extent_int(1));
       
-      projectedGeometry.setJacobian(jacobian, cubaturePoints);
+      auto refData = projectedGeometry.getJacobianRefData(cubaturePoints);
+      projectedGeometry.setJacobian(jacobian, cubaturePoints, refData);
       CellTools<ExecutionSpace>::setJacobianDet(jacobianDet, jacobian);
       
       auto cellMeasure = projectedGeometry.allocateCellMeasure(jacobianDet, cubatureWeights);

--- a/packages/intrepid2/unit-test/MonolithicExecutable/StructuredIntegrationTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/StructuredIntegrationTests.cpp
@@ -416,7 +416,9 @@ ScalarView<Scalar,ExecSpaceType> performStandardQuadratureHypercube(int meshWidt
     Data<PointScalar,ExecSpaceType> jacobian = cellNodes.allocateJacobianData(tensorCubaturePoints);
     Data<PointScalar,ExecSpaceType> jacobianDet = CellTools<ExecSpaceType>::allocateJacobianDet(jacobian);
     Data<PointScalar,ExecSpaceType> jacobianInv = CellTools<ExecSpaceType>::allocateJacobianInv(jacobian);
-    cellNodes.setJacobian(jacobian, tensorCubaturePoints);
+    
+    auto refData = cellNodes.getJacobianRefData(tensorCubaturePoints);
+    cellNodes.setJacobian(jacobian, tensorCubaturePoints, refData);
     CellTools<ExecSpaceType>::setJacobianDet(jacobianDet, jacobian);
     CellTools<ExecSpaceType>::setJacobianInv(jacobianInv, jacobian);
     

--- a/packages/intrepid2/unit-test/performance/StructuredIntegration/StructuredIntegrationPerformance.cpp
+++ b/packages/intrepid2/unit-test/performance/StructuredIntegration/StructuredIntegrationPerformance.cpp
@@ -410,6 +410,8 @@ void performStructuredQuadratureHypercubeGRADGRAD(CellGeometry<PointScalar, spac
   jacobianCellMeasureFlopCount += numCells * flopsPerJacobianDetPerCell; // determinant
   jacobianCellMeasureFlopCount += numCells * numPoints; // cell measure: (C,P) gets weighted with cubature weights of shape (P)
   
+  auto refData = geometry.getJacobianRefData(tensorCubaturePoints);
+  
   initialSetupTimer->stop();
   while (cellOffset < numCells)
   {
@@ -430,7 +432,7 @@ void performStructuredQuadratureHypercubeGRADGRAD(CellGeometry<PointScalar, spac
       cellMeasures.setFirstComponentExtentInDimension0(numCellsInWorkset);
     }
     
-    geometry.setJacobian(jacobian, tensorCubaturePoints, startCell, endCell);
+    geometry.setJacobian(jacobian, tensorCubaturePoints, refData, startCell, endCell);
     CellTools<ExecSpaceType>::setJacobianDet(jacobianDet, jacobian);
     CellTools<ExecSpaceType>::setJacobianInv(jacobianInv, jacobian);
     


### PR DESCRIPTION
## Motivation

#8801 notes a test failure in Intrepid2 when built for CUDA 10.1.243 opt.  This appears to be a compiler bug related to a couple lambda functions.  (Among other evidence, the error does not present in a debug build.)  This PR's main motivation is to rewrite to avoid that apparent compiler bug.

To that end, we have two changes to CellGeometry: 
1. Modified CellGeometry `setJacobian()` implementations to allow reuse of reference-space basis gradients.  This is a change that I wanted to make anyway; it allows more efficient Jacobian computations when using the same reference-space points across multiple worksets.
2. Modified one lambda within `computeCellMeasure()`, making it use a one-dimensional range rather than a 2D MDRangePolicy.  This was purely for the purpose of working around the compiler issue.

Additionally, the rewrite exposed a syntax error in the `Data::extent()` implementation; this is now fixed.

With these changes, all Intrepid2 tests pass with the PR build for CUDA 10.1.243 opt.

@trilinos/intrepid2

## Related Issues
* Closes #8801

## Testing
This code is indeed tested; fixing the tests is the motivation for the PR.