### PR TITLE
ROL: Fix rol reduced constraint simopt

### DIFF
--- a/packages/rol/src/function/simopt/ROL_Reduced_Constraint_SimOpt.hpp
+++ b/packages/rol/src/function/simopt/ROL_Reduced_Constraint_SimOpt.hpp
@@ -146,7 +146,7 @@ private:
   void solve_adjoint_sensitivity(const Vector<Real> &w, const Vector<Real> &v, const Vector<Real> &z, Real &tol) {
     // Evaluate full hessVec in the direction (s,v)
     conVal_->applyAdjointHessian_11(*dualstate_,w,*state_sens_,*state_,z,tol);
-    conVal_->applyAdjointHessian_12(*dualstate1_,w,v,*state_,z,tol);
+    conVal_->applyAdjointHessian_21(*dualstate1_,w,v,*state_,z,tol);
     dualstate_->plus(*dualstate1_);
     // Apply adjoint Hessian of constraint
     conRed_->applyAdjointHessian_11(*dualstate1_,*adjoint_,*state_sens_,*state_,z,tol);
@@ -311,7 +311,7 @@ public:
       solve_adjoint_sensitivity(w,v,z,tol);
       // Build hessVec
       conRed_->applyAdjointJacobian_2(ahwv,*adjoint_sens_,*state_,z,tol);
-      conVal_->applyAdjointHessian_21(*dualcontrol_,w,*state_sens_,*state_,z,tol);
+      conVal_->applyAdjointHessian_12(*dualcontrol_,w,*state_sens_,*state_,z,tol);
       ahwv.plus(*dualcontrol_);
       conVal_->applyAdjointHessian_22(*dualcontrol_,w,v,*state_,z,tol);
       ahwv.plus(*dualcontrol_);


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->

@trilinos/rol


## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Constraints use adjointHessian products, and therefore, the use of applyAdjointHessian_12 and applyAdjointHessian_21 were switched out within the ROL_Reduced_Constraint_SimOpt class.

This error must be due to copying from ROL_Reduced_Objective_SimOpt, where Objective_SimOpt::hessVec_12 and hessVec_21 are the non-transposed versions.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
N/A

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->