### PR TITLE
Teuchos core: Reorder noreturn and DLL export

### DIFF
--- a/packages/teuchos/core/src/Teuchos_TestForException.hpp
+++ b/packages/teuchos/core/src/Teuchos_TestForException.hpp
@@ -76,7 +76,7 @@ TEUCHOSCORE_LIB_DLL_EXPORT void TestForException_setEnableStacktrace(bool enable
 TEUCHOSCORE_LIB_DLL_EXPORT bool TestForException_getEnableStacktrace();
 
 /** \brief Prints the message to std::cerr and calls std::terminate. */
-TEUCHOSCORE_LIB_DLL_EXPORT [[noreturn]] void TestForTermination_terminate(const std::string &msg);
+[[noreturn]] TEUCHOSCORE_LIB_DLL_EXPORT void TestForTermination_terminate(const std::string &msg);
 
 
 } // namespace Teuchos


### PR DESCRIPTION
Reorder so [[noreturn]] precedes TEUCHOSCORE_LIB_DLL_EXPORT in
exception testers to restore DLL builds on MSVS 2015 and 2019.

Fixes #8818

@trilinos/teuchos
@ibaned 

## Related Issues
* Closes  #8818 

## Testing
Problem manifests on Windows MSVS, DLL builds only, so likely not covered by current PR testing. All other builds enabling Teuchos should hit the edited line of code, though.
