### PR TITLE
Tpetra:  remove UVM dependence from test

### DIFF
--- a/packages/tpetra/core/test/HashTable/FixedHashTableTest.cpp
+++ b/packages/tpetra/core/test/HashTable/FixedHashTableTest.cpp
@@ -176,32 +176,30 @@ namespace { // (anonymous)
          << numKeys << " != vals.extent(0) = " << vals.extent (0)
          << ".");
 
-      auto keys_h = Kokkos::create_mirror_view (keys);
-      Kokkos::deep_copy (keys_h, keys);
-      auto vals_h = Kokkos::create_mirror_view (vals);
-      Kokkos::deep_copy (vals_h, vals);
       size_type badCount = 0;
-      for (size_type i = 0; i < keys.size (); ++i) {
-        const KeyType key = keys_h(i);
-        const ValueType expectedVal = vals_h(i);
-        const ValueType actualVal = table.get (key);
-        bool curBad = false;
-
-        if (actualVal == Teuchos::OrdinalTraits<ValueType>::invalid ()) {
-          curBad = true;
-          out << "get(key=" << key << ") = invalid, should have been "
-              << expectedVal << endl;
-        }
-        else if (testValues && actualVal != expectedVal) {
-          curBad = true;
-          out << "get(key=" << key << ") = " << actualVal
-              << ", should have been " << expectedVal << endl;
-        }
-
-        if (curBad) {
-          ++badCount;
-        }
-      }
+      Kokkos::parallel_reduce("testKeys",
+        Kokkos::RangePolicy<typename DeviceType::execution_space>(0, numKeys),
+        KOKKOS_LAMBDA(const size_t &i, size_type &myBadCount) {
+          const KeyType key = keys(i);
+          const ValueType expectedVal = vals(i);
+          const ValueType actualVal = table.get (key);
+          bool curBad = false;
+  
+          if (actualVal == Tpetra::Details::OrdinalTraits<ValueType>::invalid ()) {
+            curBad = true;
+            printf("get(key=%lld) = invalid, should have been %d\n",
+                    key, expectedVal);
+          }
+          else if (testValues && actualVal != expectedVal) {
+            curBad = true;
+            printf("get(key=%lld) = %d, should have been %d\n",
+                    key, actualVal, expectedVal);
+          }
+  
+          if (curBad) {
+            ++myBadCount;
+          }
+        }, badCount);
 
       if (badCount == 0) {
         out << "PASSED" << endl;
@@ -239,8 +237,6 @@ namespace { // (anonymous)
     const size_type numKeys = 0;
     Kokkos::View<KeyType*, Kokkos::LayoutLeft, DeviceType> keys ("keys", numKeys);
     auto keys_h = Kokkos::create_mirror_view (keys);
-    Kokkos::deep_copy (keys, keys_h);
-    out << "Finished deep_copy(keys, keys_h)" << endl;
 
     // Pick something other than 0, just to make sure that it works.
     const ValueType startingValue = 1;
@@ -248,40 +244,41 @@ namespace { // (anonymous)
     Teuchos::ArrayView<const KeyType> keys_av = Kokkos::Compat::getArrayView (keys_h);
     out << "Create table" << endl;
 
-    using table_ptr_type = std::unique_ptr<table_type>; // macros may not like colons etc.
-    table_ptr_type table;
-    TEST_NOTHROW( table = table_ptr_type (new table_type (keys_av, startingValue)) );
-    if (table.get () == nullptr) {
-      out << "table is null!  Its constructor must have thrown.  "
-        "No sense in continuing." << endl;
-      return; // above constructor must have thrown
+    Teuchos::RCP<table_type> table;
+    TEST_NOTHROW( table = Teuchos::rcp (new table_type (keys_av, startingValue)) );
+    if (table.is_null ()) {
+      return; // stop the test now to prevent dereferencing null
     }
 
     bool duplicateKeys = false;
     TEST_NOTHROW( duplicateKeys = table->hasDuplicateKeys () );
     if (! success) {
-      out << "table->hasDuplicateKeys() raised an exception; no sense in "
+      out << "table.hasDuplicateKeys() raised an exception; no sense in "
         "continuing." << endl;
       return;
     }
     TEST_EQUALITY_CONST( duplicateKeys, false );
 
-    KeyType key = 0;
-    ValueType val = 0;
-    TEST_NOTHROW( val = table->get (key) );
-    TEST_EQUALITY( val, Teuchos::OrdinalTraits<ValueType>::invalid () );
+    const size_type numTestKeys = 4;
+    Kokkos::View<KeyType*, Kokkos::LayoutLeft, DeviceType> testKeys ("testKeys", numTestKeys);
+    auto testKeys_h = Kokkos::create_mirror_view (testKeys);
+    testKeys_h(0) = static_cast<KeyType> (0);
+    testKeys_h(1) = static_cast<KeyType> (1);
+    testKeys_h(2) = static_cast<KeyType> (-1);
+    testKeys_h(3) = static_cast<KeyType> (42);
+    Kokkos::deep_copy (testKeys, testKeys_h);
 
-    key = 1;
-    TEST_NOTHROW( val = table->get (key) );
-    TEST_EQUALITY( val, Teuchos::OrdinalTraits<ValueType>::invalid () );
+    size_type badCount = 0;
+    table_type tt = *table;
+    Kokkos::parallel_reduce("testEmpty",
+      Kokkos::RangePolicy<typename DeviceType::execution_space>(0, numTestKeys),
+      KOKKOS_LAMBDA(const size_t &i, size_type &myBadCount) {
+        if (tt.get(testKeys(i)) != Tpetra::Details::OrdinalTraits<ValueType>::invalid()) {
+          myBadCount++;
+        }
+      }, badCount);
 
-    key = -1;
-    TEST_NOTHROW( val = table->get (key) );
-    TEST_EQUALITY( val, Teuchos::OrdinalTraits<ValueType>::invalid () );
-
-    key = 42;
-    TEST_NOTHROW( val = table->get (key) );
-    TEST_EQUALITY( val, Teuchos::OrdinalTraits<ValueType>::invalid () );
+    TEST_EQUALITY( badCount, 0);
   }
 
   // Test contiguous keys, with the constructor that takes a
@@ -933,20 +930,11 @@ namespace { // (anonymous)
 
 #ifdef KOKKOS_ENABLE_CUDA
     {
-      // mfh 14 Jan 2016: Only exercise CudaUVMSpace, not CudaSpace,
-      // because Tpetra (and FixedHashTable in particular) assume UVM.
-      // Testing CudaSpace here results in the following exception:
-      //
-      // p=0: *** Caught standard std::exception of type 'std::runtime_error' :
-      //
-      // Kokkos::CudaSpace::access_error attempt to execute Cuda
-      //   function from non-Cuda space
-      // Traceback functionality not available
-      if (! std::is_same<typename DeviceType::memory_space, Kokkos::CudaUVMSpace>::value) {
-        out << "Testing copy constructor to CudaUVMSpace" << endl;
-        TestCopyCtor<KeyType, ValueType, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaUVMSpace>,
+      if (! std::is_same<typename DeviceType::memory_space, Kokkos::CudaSpace>::value) {
+        out << "Testing copy constructor to CudaSpace" << endl;
+        TestCopyCtor<KeyType, ValueType, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>,
           DeviceType>::test (out, success, *table, keys, vals,
-                             "Kokkos::Device<Kokkos::Cuda, Kokkos::CudaUVMSpace>",
+                             "Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>",
                              typeid(DeviceType).name ());
         testedAtLeastOnce = true;
       }
@@ -1082,20 +1070,11 @@ namespace { // (anonymous)
 
 #ifdef KOKKOS_ENABLE_CUDA
     {
-      // mfh 14 Jan 2016: Only exercise CudaUVMSpace, not CudaSpace,
-      // because Tpetra (and FixedHashTable in particular) assume UVM.
-      // Testing CudaSpace here results in the following exception:
-      //
-      // p=0: *** Caught standard std::exception of type 'std::runtime_error' :
-      //
-      // Kokkos::CudaSpace::access_error attempt to execute Cuda
-      //   function from non-Cuda space
-      // Traceback functionality not available
-      if (! std::is_same<typename DeviceType::memory_space, Kokkos::CudaUVMSpace>::value) {
-        out << "Testing copy constructor to CudaUVMSpace" << endl;
-        TestCopyCtor<KeyType, ValueType, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaUVMSpace>,
+      if (! std::is_same<typename DeviceType::memory_space, Kokkos::CudaSpace>::value) {
+        out << "Testing copy constructor to CudaSpace" << endl;
+        TestCopyCtor<KeyType, ValueType, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>,
           DeviceType>::test (out, success, *table, keys, vals,
-                             "Kokkos::Device<Kokkos::Cuda, Kokkos::CudaUVMSpace>",
+                             "Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>",
                              typeid(DeviceType).name (), testValues);
         testedAtLeastOnce = true;
       }
@@ -1181,24 +1160,16 @@ namespace { // (anonymous)
 #endif // KOKKOS_ENABLE_THREADS
 
 
-// NOTE (mfh 12 Jan 2016) Both Tpetra and the above test assume UVM.
-// Thus, it is both incorrect and unnecessary to use them with
-// Kokkos::CudaSpace as the memory space.  The right memory space is
-// CudaUVMSpace.  As a result, using CudaSpace raises an exception (as
-// it should) when Kokkos' bounds checking option is enabled:
-// "Kokkos::CudaSpace::access_error attempt to execute Cuda function
-// from non-Cuda space".
-
 #ifdef KOKKOS_ENABLE_CUDA
-  typedef Kokkos::Device<Kokkos::Cuda, Kokkos::CudaUVMSpace> cuda_uvm_device_type;
+  typedef Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace> cuda_device_type;
 
-#define UNIT_TEST_GROUP_CUDA_UVM( LO, GO ) \
-  UNIT_TEST_GROUP_3( LO, GO, cuda_uvm_device_type )
+#define UNIT_TEST_GROUP_CUDA( LO, GO ) \
+  UNIT_TEST_GROUP_3( LO, GO, cuda_device_type )
 
-  TPETRA_INSTANTIATE_LG( UNIT_TEST_GROUP_CUDA_UVM )
+  TPETRA_INSTANTIATE_LG( UNIT_TEST_GROUP_CUDA )
 
 #else
-#  define UNIT_TEST_GROUP_CUDA_UVM( LO, GO )
+#  define UNIT_TEST_GROUP_CUDA( LO, GO )
 #endif // KOKKOS_ENABLE_CUDA
 
 } // namespace (anonymous)

--- a/packages/tpetra/core/test/HashTable/computeOffsetsFromCounts.cpp
+++ b/packages/tpetra/core/test/HashTable/computeOffsetsFromCounts.cpp
@@ -84,67 +84,13 @@ namespace { // (anonymous)
 
   using std::endl;
 
-
-  template<class ExecutionSpace>
-  struct ExecSpaceName {
-    static const char* name ();
-  };
-
-  template<class MemorySpace>
-  struct MemorySpaceName {
-    static const char* name ();
-  };
-
-  template<>
-  struct MemorySpaceName<Kokkos::HostSpace> {
-    static const char* name () { return "HostSpace"; }
-  };
-
-#ifdef KOKKOS_ENABLE_SERIAL
-  template<>
-  struct ExecSpaceName<Kokkos::Serial> {
-    static const char* name () { return "Serial"; }
-  };
-#endif // KOKKOS_ENABLE_SERIAL
-
-#ifdef KOKKOS_ENABLE_THREADS
-  template<>
-  struct ExecSpaceName<Kokkos::Threads> {
-    static const char* name () { return "Threads"; }
-  };
-#endif // KOKKOS_ENABLE_THREADS
-
-#ifdef KOKKOS_ENABLE_OPENMP
-  template<>
-  struct ExecSpaceName<Kokkos::OpenMP> {
-    static const char* name () { return "OpenMP"; }
-  };
-#endif // KOKKOS_ENABLE_OPENMP
-
-#ifdef KOKKOS_ENABLE_CUDA
-  template<>
-  struct ExecSpaceName<Kokkos::Cuda> {
-    static const char* name () { return "Cuda"; }
-  };
-
-  template<>
-  struct MemorySpaceName<Kokkos::CudaSpace> {
-    static const char* name () { return "CudaSpace"; }
-  };
-
-  template<>
-  struct MemorySpaceName<Kokkos::CudaUVMSpace> {
-    static const char* name () { return "CudaUVMSpace"; }
-  };
-#endif // KOKKOS_ENABLE_CUDA
-
   template<class DeviceType>
   std::string deviceName ()
   {
     return std::string ("Kokkos::Device<") +
-      ExecSpaceName<typename DeviceType::execution_space>::name () +
+      DeviceType::execution_space::name() +
       std::string (", ") +
-      MemorySpaceName<typename DeviceType::memory_space>::name () +
+      DeviceType::memory_space::name() +
       std::string (" >");
   }
 


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
When UVM dependence is removed, one cannot call function FixedHashTable.get(key) from host for FixedHashTables that are build on device.  This PR replaces the host accesses with device accesses.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->
#8209 

## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Tested on cee-lan gpus without UVM.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->