### PR TITLE
Tempus: Remove ParameterList from SolutionHistory

### DIFF
--- a/packages/tempus/src/Tempus_IntegratorAdjointSensitivity_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorAdjointSensitivity_impl.hpp
@@ -488,7 +488,7 @@ buildSolutionHistory(
   RCP<ParameterList> shPL =
     Teuchos::sublist(state_integrator_->getIntegratorParameterList(),
                      "Solution History", true);
-  solutionHistory_ = rcp(new SolutionHistory<Scalar>(shPL));
+  solutionHistory_ = createSolutionHistoryPL<Scalar>(shPL);
 
   RCP<const VectorSpaceBase<Scalar> > x_space = model_->get_x_space();
   RCP<const VectorSpaceBase<Scalar> > adjoint_space =

--- a/packages/tempus/src/Tempus_IntegratorBasic_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorBasic_impl.hpp
@@ -122,7 +122,7 @@ initializeSolutionHistory(Teuchos::RCP<SolutionState<Scalar> > state)
   // Construct from Integrator ParameterList
   RCP<ParameterList> shPL =
     Teuchos::sublist(integratorPL_, "Solution History", true);
-  solutionHistory_ = rcp(new SolutionHistory<Scalar>(shPL));
+  solutionHistory_ = createSolutionHistoryPL<Scalar>(shPL);
 
   if (state == Teuchos::null) {
     // Construct default IC from the application model
@@ -163,7 +163,7 @@ initializeSolutionHistory(Scalar t0,
   // Construct from Integrator ParameterList
   RCP<ParameterList> shPL =
     Teuchos::sublist(integratorPL_, "Solution History", true);
-  solutionHistory_ = rcp(new SolutionHistory<Scalar>(shPL));
+  solutionHistory_ = createSolutionHistoryPL<Scalar>(shPL);
 
   // Create and set xdot and xdotdot.
   RCP<Thyra::VectorBase<Scalar> > xdot    = x0->clone_v();
@@ -213,11 +213,6 @@ void IntegratorBasic<Scalar>::setSolutionHistory(
          "Error - setSolutionHistory requires at least one SolutionState.\n"
       << "        Supplied SolutionHistory has only " << sh->getNumStates()
       << " SolutionStates.\n");
-
-    // Make integratorPL_ consistent with new SolutionHistory.
-    RCP<ParameterList> shPL = sh->getNonconstParameterList();
-    integratorPL_->set("Solution History", shPL->name());
-    integratorPL_->set(shPL->name(), *shPL);
 
     solutionHistory_ = sh;
   }

--- a/packages/tempus/src/Tempus_IntegratorPseudoTransientAdjointSensitivity_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorPseudoTransientAdjointSensitivity_impl.hpp
@@ -361,7 +361,7 @@ buildSolutionHistory()
   RCP<ParameterList> shPL =
     Teuchos::sublist(state_integrator_->getIntegratorParameterList(),
                      "Solution History", true);
-  solutionHistory_ = rcp(new SolutionHistory<Scalar>(shPL));
+  solutionHistory_ = createSolutionHistoryPL<Scalar>(shPL);
 
   RCP<const VectorSpaceBase<Scalar> > x_space =
     model_->get_x_space();
@@ -450,7 +450,7 @@ buildSolutionHistory()
     prod_state->setX(x_b);
     prod_state->setXDot(x_dot_b);
     prod_state->setXDotDot(x_dot_dot_b);
-    solutionHistory_->addState(prod_state);
+    solutionHistory_->addState(prod_state, false);
   }
 }
 

--- a/packages/tempus/src/Tempus_IntegratorPseudoTransientForwardSensitivity_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorPseudoTransientForwardSensitivity_impl.hpp
@@ -442,7 +442,7 @@ buildSolutionHistory()
   RCP<ParameterList> shPL =
     Teuchos::sublist(state_integrator_->getIntegratorParameterList(),
                      "Solution History", true);
-  solutionHistory_ = rcp(new SolutionHistory<Scalar>(shPL));
+  solutionHistory_ = createSolutionHistoryPL<Scalar>(shPL);
 
   const int num_param =
     rcp_dynamic_cast<const DMVPV>(sens_integrator_->getX())->getMultiVector()->domain()->dim();
@@ -541,7 +541,7 @@ buildSolutionHistory()
     prod_state->setX(x);
     prod_state->setXDot(x_dot);
     prod_state->setXDotDot(x_dot_dot);
-    solutionHistory_->addState(prod_state);
+    solutionHistory_->addState(prod_state, false);
   }
 }
 

--- a/packages/tempus/src/Tempus_SolutionHistory_decl.hpp
+++ b/packages/tempus/src/Tempus_SolutionHistory_decl.hpp
@@ -246,10 +246,16 @@ public:
     /// Get the maximum storage of this history
     int getStorageLimit() const {return storageLimit_;}
 
+    /// Set the storage type via enum.
     void setStorageType(StorageType st);
+
+    /// Get the enum storage type.
     StorageType getStorageType() const {return storageType_;}
 
+    /// Set the storage type via string.
     void setStorageTypeString(std::string st);
+
+    /// Set the string storage type.
     std::string getStorageTypeString() const;
 
     /// Return the current minimum time of the SolutionStates
@@ -283,8 +289,11 @@ public:
     Teuchos::RCP<SolutionState<Scalar> > getStateTimeIndex(int index, bool warn = true) const;
   //@}
 
-    Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
-    Teuchos::RCP<Teuchos::ParameterList> getNonconstParameterList();
+  /// Return a valid ParameterList with current settings.
+  Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
+
+  /// Return a valid non-const ParameterList with current settings.
+  Teuchos::RCP<Teuchos::ParameterList> getNonconstParameterList();
 
   /// \name Overridden from Teuchos::Describable
   //@{
@@ -303,11 +312,19 @@ public:
     Teuchos::RCP<Interpolator<Scalar> > unSetInterpolator();
   //@}
 
+  /// Print information on States in the SolutionHistory.
   void printHistory(std::string verb="low") const;
 
+  /** \brief Initialize SolutionHistory
+   *
+   *  This function will check if all member data is initialized
+   *  and is consistent.  This function does not make member data
+   *  consistent, but just checks it.  This ensures it is inexpensive.
+   */
   void initialize() const;
+
+  /// Return if SolutionHistory is initialized.
   bool isInitialized() { return isInitialized_; }
-  void checkInitialized();
 
 
 protected:

--- a/packages/tempus/src/Tempus_SolutionState_impl.hpp
+++ b/packages/tempus/src/Tempus_SolutionState_impl.hpp
@@ -408,6 +408,13 @@ void SolutionState<Scalar>::describe(
    Teuchos::FancyOStream               &out,
    const Teuchos::EVerbosityLevel      verbLevel) const
 {
+  if (verbLevel == Teuchos::VERB_MEDIUM) {
+    out << "(index =" <<std::setw(6)<< this->getIndex()
+        << "; time =" <<std::setw(10)<<std::setprecision(3)<<this->getTime()
+        << "; dt   =" <<std::setw(10)<<std::setprecision(3)<<this->getTimeStep()
+        << ")" << std::endl;
+  }
+
   if (verbLevel == Teuchos::VERB_EXTREME) {
     out << description() << "::describe:" << std::endl
         << "metaData = " << std::endl;

--- a/packages/tempus/src/Tempus_StepperStaggeredForwardSensitivity_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperStaggeredForwardSensitivity_impl.hpp
@@ -153,7 +153,7 @@ takeStep(
     state_state->setX(x);
     state_state->setXDot(xdot);
     state_state->setXDotDot(xdotdot);
-    stateSolutionHistory_ = rcp(new SolutionHistory<Scalar>(shPL));
+    stateSolutionHistory_ = createSolutionHistoryPL<Scalar>(shPL);
     stateSolutionHistory_->addState(state_state);
 
     const int num_param = X->getMultiVector()->domain()->dim()-1;
@@ -181,7 +181,7 @@ takeStep(
     sens_state->setX(dxdp_vec);
     sens_state->setXDot(dxdotdp_vec);
     sens_state->setXDotDot(dxdotdotdp_vec);
-    sensSolutionHistory_ = rcp(new SolutionHistory<Scalar>(shPL));
+    sensSolutionHistory_ = createSolutionHistoryPL<Scalar>(shPL);
     sensSolutionHistory_->addState(sens_state);
   }
 

--- a/packages/tempus/test/Integrator/Tempus_IntegratorBasic_ref.xml
+++ b/packages/tempus/test/Integrator/Tempus_IntegratorBasic_ref.xml
@@ -8,6 +8,7 @@
       <Parameter docString="" id="4" isDefault="true" isUsed="true" name="Storage Limit" type="int" value="2"/>
       <ParameterList name="Interpolator">
         <Parameter name="Interpolator Type" type="string" value="Lagrange"/>
+        <Parameter name="Order" type="int" value="0"/>
       </ParameterList>
     </ParameterList>
     <ParameterList id="26" name="Time Step Control">

--- a/packages/tempus/test/Integrator/Tempus_IntegratorBasic_ref2.xml
+++ b/packages/tempus/test/Integrator/Tempus_IntegratorBasic_ref2.xml
@@ -10,6 +10,7 @@
       <Parameter docString="" id="6" isDefault="true" isUsed="true" name="Storage Limit" type="int" value="2"/>
       <ParameterList name="Interpolator">
         <Parameter name="Interpolator Type" type="string" value="Lagrange"/>
+        <Parameter name="Order" type="int" value="0"/>
       </ParameterList>
     </ParameterList>
     <ParameterList id="31" name="Time Step Control">

--- a/packages/tempus/unit_test/CMakeLists.txt
+++ b/packages/tempus/unit_test/CMakeLists.txt
@@ -2,6 +2,13 @@ INCLUDE_DIRECTORIES(REQUIRED_DURING_INSTALLATION_TESTING
                     ${CMAKE_CURRENT_SOURCE_DIR})
 
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_SolutionHistory
+  SOURCES Tempus_UnitTest_SolutionHistory.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
   UnitTest_TimeStepControl
   SOURCES Tempus_UnitTest_TimeStepControl.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
   TESTONLYLIBS tempus_test_models

--- a/packages/tempus/unit_test/Tempus_UnitTest_SolutionHistory.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_SolutionHistory.cpp
@@ -1,0 +1,742 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Thyra_VectorStdOps.hpp"
+
+#include "Tempus_SolutionHistory.hpp"
+#include "Tempus_InterpolatorFactory.hpp"
+
+#include "../TestModels/SinCosModel.hpp"
+#include "../TestModels/DahlquistTestModel.hpp"
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::ParameterList;
+using Teuchos::sublist;
+using Teuchos::getParametersFromXmlFile;
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(SolutionHistory, Default_Construction)
+{
+  auto sh = rcp(new Tempus::SolutionHistory<double>());
+  TEUCHOS_TEST_FOR_EXCEPT(sh->isInitialized());  // Should NOT be initialized
+                                                 // as no State is set.
+
+  auto model = rcp(new Tempus_Test::SinCosModel<double>());
+  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =model->getNominalValues();
+  auto icSolution = rcp_const_cast<Thyra::VectorBase<double> >(inArgsIC.get_x());
+  auto icState = Tempus::createSolutionStateX<double>(icSolution);
+  sh->addState(icState);
+  sh->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!sh->isInitialized());
+
+  // Test the get functions (i.e., defaults).
+  TEST_COMPARE ( sh->getNumStates(), ==, 1);
+  TEST_COMPARE ( sh->getInterpolator()->order(), ==, 0);
+  TEST_COMPARE ( sh->getStorageType(), ==, Tempus::STORAGE_TYPE_UNDO);
+  TEST_COMPARE ( sh->getStorageLimit(), ==, 2);
+
+  // Test the set functions.
+  sh->setName ("Testing");                                              TEUCHOS_TEST_FOR_EXCEPT(!sh->isInitialized());
+  sh->setStorageType (Tempus::STORAGE_TYPE_STATIC);  sh->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!sh->isInitialized());
+  sh->setStorageTypeString ("Static");               sh->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!sh->isInitialized());
+  sh->setStorageLimit(99);                           sh->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!sh->isInitialized());
+
+  TEST_COMPARE( sh->getName        ()     , ==, "Testing");
+  TEST_COMPARE( sh->getStorageType ()     , ==, Tempus::STORAGE_TYPE_STATIC);
+  TEST_COMPARE( sh->getStorageTypeString(), ==, "Static");
+  TEST_COMPARE( sh->getStorageLimit()     , ==, 99);
+
+  TEST_FLOATING_EQUALITY( sh->minTime(), 0.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY( sh->maxTime(), 0.0, 1.0e-14);
+
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(SolutionHistory, Full_Construction)
+{
+  std::string name = "Unit Test";
+
+  auto history = rcp(new std::vector<RCP<Tempus::SolutionState<double> > >);;
+  auto model = rcp(new Tempus_Test::SinCosModel<double>());
+  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =model->getNominalValues();
+  auto icSolution = rcp_const_cast<Thyra::VectorBase<double> >(inArgsIC.get_x());
+  Teuchos::RCP<Tempus::SolutionState<double> >
+    icState = Tempus::createSolutionStateX<double>(icSolution);
+  history->push_back(icState);
+
+  auto interpolator = Tempus::InterpolatorFactory<double>::createInterpolator();
+
+  Tempus::StorageType storageType = Tempus::STORAGE_TYPE_STATIC;
+  int storageLimit = 99;
+
+  auto sh = rcp(new Tempus::SolutionHistory<double>(
+    name, history, interpolator, storageType, storageLimit));
+  TEUCHOS_TEST_FOR_EXCEPT(!sh->isInitialized());
+
+  TEST_COMPARE ( sh->getNumStates(), ==, 1);
+  TEST_COMPARE ( sh->getInterpolator()->order(), ==, 0);
+  TEST_COMPARE ( sh->getStorageType(), ==, Tempus::STORAGE_TYPE_STATIC);
+  TEST_COMPARE ( sh->getStorageLimit(), ==, 99);
+
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(SolutionHistory, Create_Construction)
+{
+  auto sh_temp = rcp(new Tempus::SolutionHistory<double>());
+  RCP<ParameterList> pl = sh_temp->getNonconstParameterList();
+
+  pl->setName("Unit Test");
+  pl->set<std::string>("Storage Type", "Static"     );
+  pl->set<int>        ("Storage Limit", 99);
+
+  pl->sublist("Interpolator").set("Interpolator Type", "Lagrange");
+  pl->sublist("Interpolator").set("Order", 1);
+
+  auto sh = Tempus::createSolutionHistoryPL<double>(pl);
+  TEUCHOS_TEST_FOR_EXCEPT(sh->isInitialized());  // Should NOT be initialized
+                                                 // as no State is set.
+
+  TEST_COMPARE ( sh->getNumStates(), ==, 0);
+  TEST_COMPARE ( sh->getInterpolator()->order(), ==, 1);
+  TEST_COMPARE ( sh->getStorageType(), ==, Tempus::STORAGE_TYPE_STATIC);
+  TEST_COMPARE ( sh->getStorageLimit(), ==, 99);
+
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(SolutionHistory, addState_With_Keep_Newest)
+{
+  // Setup SolutionHistory for testing.
+  auto sh = rcp(new Tempus::SolutionHistory<double>());
+  TEUCHOS_TEST_FOR_EXCEPT(sh->isInitialized());  // Should NOT be initialized
+                                                 // as no State is set.
+
+  auto model = rcp(new Tempus_Test::DahlquistTestModel<double>(-1.0, false));
+  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =model->getNominalValues();
+  auto icSoln = rcp_const_cast<Thyra::VectorBase<double> >(inArgsIC.get_x());
+  auto state0 = Tempus::createSolutionStateX<double>(icSoln);
+  state0->setTime (0.0);
+  state0->setIndex(0);
+
+  sh->setStorageTypeString ("Keep Newest");
+  sh->addState(state0);
+  sh->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!sh->isInitialized());
+
+  TEST_COMPARE          ( sh->getNumStates(), ==, 1);
+  TEST_FLOATING_EQUALITY( sh->getCurrentTime(), 0.0, 1.0e-14);
+  TEST_COMPARE          ( sh->getCurrentIndex(), ==, 0);
+  TEST_FLOATING_EQUALITY( sh->minTime(), 0.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY( sh->maxTime(), 0.0, 1.0e-14);
+
+  TEUCHOS_ASSERT(sh->getCurrentState     ()         != Teuchos::null);
+  TEUCHOS_ASSERT(sh->getStateTimeIndexN  (false)    != Teuchos::null);
+  TEUCHOS_ASSERT(sh->getStateTimeIndexNM1(false)    == Teuchos::null);
+  TEUCHOS_ASSERT(sh->getStateTimeIndexNM2(false)    == Teuchos::null);
+  TEUCHOS_ASSERT(sh->getStateTimeIndex   (0, false) != Teuchos::null);
+
+  TEST_COMPARE( sh->getStateTimeIndexN  ()->getIndex(), ==, 0);
+  TEST_FLOATING_EQUALITY( sh->getStateTimeIndexN  ()->getTime(), 0.0, 1.0e-14);
+
+  // ---------------------------------------------------------------------------
+
+  // Second State -- should replace first state.
+  auto state1 = Tempus::createSolutionStateX<double>(icSoln);
+  state1->setTime (1.0);
+  state1->setIndex(1);
+  sh->addState(state1);
+
+  TEST_COMPARE          ( sh->getNumStates(), ==, 1);          // Only 1 state!
+  TEST_FLOATING_EQUALITY( sh->getCurrentTime(), 1.0, 1.0e-14);
+  TEST_COMPARE          ( sh->getCurrentIndex(), ==, 1);
+  TEST_FLOATING_EQUALITY( sh->minTime(), 1.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY( sh->maxTime(), 1.0, 1.0e-14);
+
+  TEUCHOS_ASSERT(sh->getCurrentState     ()         != Teuchos::null);
+  TEUCHOS_ASSERT(sh->getStateTimeIndexN  (false)    != Teuchos::null);
+  TEUCHOS_ASSERT(sh->getStateTimeIndexNM1(false)    == Teuchos::null);
+  TEUCHOS_ASSERT(sh->getStateTimeIndexNM2(false)    == Teuchos::null);
+  TEUCHOS_ASSERT(sh->getStateTimeIndex   (0, false) == Teuchos::null);
+  TEUCHOS_ASSERT(sh->getStateTimeIndex   (1, false) != Teuchos::null);
+
+  TEST_COMPARE( sh->getStateTimeIndexN  ()->getIndex(), ==, 1);
+  TEST_FLOATING_EQUALITY( sh->getStateTimeIndexN  ()->getTime(), 1.0, 1.0e-14);
+
+  // ---------------------------------------------------------------------------
+
+  // Third State -- old state should not be added.
+  auto state2 = Tempus::createSolutionStateX<double>(icSoln);
+  state2->setTime (-1.0);
+  state2->setIndex(-1);
+  sh->addState(state2);
+
+  // Still second state.
+  TEST_COMPARE          ( sh->getNumStates(), ==, 1);          // Only 1 state!
+  TEST_FLOATING_EQUALITY( sh->getCurrentTime(), 1.0, 1.0e-14);
+  TEST_COMPARE          ( sh->getCurrentIndex(), ==, 1);
+  TEST_FLOATING_EQUALITY( sh->minTime(), 1.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY( sh->maxTime(), 1.0, 1.0e-14);
+
+  TEUCHOS_ASSERT(sh->getCurrentState     ()         != Teuchos::null);
+  TEUCHOS_ASSERT(sh->getStateTimeIndexN  (false)    != Teuchos::null);
+  TEUCHOS_ASSERT(sh->getStateTimeIndexNM1(false)    == Teuchos::null);
+  TEUCHOS_ASSERT(sh->getStateTimeIndexNM2(false)    == Teuchos::null);
+  TEUCHOS_ASSERT(sh->getStateTimeIndex   (0, false) == Teuchos::null);
+  TEUCHOS_ASSERT(sh->getStateTimeIndex   (1, false) != Teuchos::null);
+
+  TEST_COMPARE( sh->getStateTimeIndexN  ()->getIndex(), ==, 1);
+  TEST_FLOATING_EQUALITY( sh->getStateTimeIndexN  ()->getTime(), 1.0, 1.0e-14);
+
+  // ---------------------------------------------------------------------------
+
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(SolutionHistory, addState_With_Undo)
+{
+  // Setup SolutionHistory for testing.
+  auto sh = rcp(new Tempus::SolutionHistory<double>());
+  TEUCHOS_TEST_FOR_EXCEPT(sh->isInitialized());  // Should NOT be initialized
+                                                 // as no State is set.
+
+  auto model = rcp(new Tempus_Test::DahlquistTestModel<double>(-1.0, false));
+  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =model->getNominalValues();
+  auto icSoln = rcp_const_cast<Thyra::VectorBase<double> >(inArgsIC.get_x());
+  auto state0 = Tempus::createSolutionStateX<double>(icSoln);
+  state0->setTime (0.0);
+  state0->setIndex(0);
+  sh->addState(state0);
+  sh->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!sh->isInitialized());
+
+  TEST_COMPARE          ( sh->getNumStates(), ==, 1);
+  TEST_FLOATING_EQUALITY( sh->getCurrentTime(), 0.0, 1.0e-14);
+  TEST_COMPARE          ( sh->getCurrentIndex(), ==, 0);
+  TEST_FLOATING_EQUALITY( sh->minTime(), 0.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY( sh->maxTime(), 0.0, 1.0e-14);
+
+  TEUCHOS_ASSERT(sh->getCurrentState     ()         != Teuchos::null);
+  TEUCHOS_ASSERT(sh->getStateTimeIndexN  (false)    != Teuchos::null);
+  TEUCHOS_ASSERT(sh->getStateTimeIndexNM1(false)    == Teuchos::null);
+  TEUCHOS_ASSERT(sh->getStateTimeIndexNM2(false)    == Teuchos::null);
+  TEUCHOS_ASSERT(sh->getStateTimeIndex   (0, false) != Teuchos::null);
+
+  TEST_COMPARE( sh->getStateTimeIndexN  ()->getIndex(), ==, 0);
+  TEST_FLOATING_EQUALITY( sh->getStateTimeIndexN  ()->getTime(), 0.0, 1.0e-14);
+
+  // ---------------------------------------------------------------------------
+
+  // Second State
+  auto state1 = Tempus::createSolutionStateX<double>(icSoln);
+  state1->setTime (1.0);
+  state1->setIndex(1);
+  sh->addState(state1);
+
+  TEST_COMPARE          ( sh->getNumStates(), ==, 2);
+  TEST_FLOATING_EQUALITY( sh->getCurrentTime(), 1.0, 1.0e-14);
+  TEST_COMPARE          ( sh->getCurrentIndex(), ==, 1);
+  TEST_FLOATING_EQUALITY( sh->minTime(), 0.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY( sh->maxTime(), 1.0, 1.0e-14);
+
+  TEUCHOS_ASSERT(sh->getCurrentState     ()         != Teuchos::null);
+  TEUCHOS_ASSERT(sh->getStateTimeIndexN  (false)    != Teuchos::null);
+  TEUCHOS_ASSERT(sh->getStateTimeIndexNM1(false)    != Teuchos::null);
+  TEUCHOS_ASSERT(sh->getStateTimeIndexNM2(false)    == Teuchos::null);
+  TEUCHOS_ASSERT(sh->getStateTimeIndex   (0, false) != Teuchos::null);
+  TEUCHOS_ASSERT(sh->getStateTimeIndex   (1, false) != Teuchos::null);
+
+  TEST_COMPARE( sh->getStateTimeIndexN  ()->getIndex(), ==, 1);
+  TEST_COMPARE( sh->getStateTimeIndexNM1()->getIndex(), ==, 0);
+  TEST_FLOATING_EQUALITY( sh->getStateTimeIndexN  ()->getTime(), 1.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY( sh->getStateTimeIndexNM1()->getTime(), 0.0, 1.0e-14);
+
+  // ---------------------------------------------------------------------------
+
+  // Third State -- should be added and first state dropped.
+  auto state2 = Tempus::createSolutionStateX<double>(icSoln);
+  state2->setTime (2.0);
+  state2->setIndex(2);
+  sh->addState(state2);
+
+  TEST_COMPARE          ( sh->getNumStates(), ==, 2);          // Only 2 states!
+  TEST_FLOATING_EQUALITY( sh->getCurrentTime(), 2.0, 1.0e-14);
+  TEST_COMPARE          ( sh->getCurrentIndex(), ==, 2);
+  TEST_FLOATING_EQUALITY( sh->minTime(), 1.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY( sh->maxTime(), 2.0, 1.0e-14);
+
+  TEUCHOS_ASSERT(sh->getCurrentState     ()         != Teuchos::null);
+  TEUCHOS_ASSERT(sh->getStateTimeIndexN  (false)    != Teuchos::null);
+  TEUCHOS_ASSERT(sh->getStateTimeIndexNM1(false)    != Teuchos::null);
+  TEUCHOS_ASSERT(sh->getStateTimeIndexNM2(false)    == Teuchos::null);
+  TEUCHOS_ASSERT(sh->getStateTimeIndex   (1, false) != Teuchos::null);
+  TEUCHOS_ASSERT(sh->getStateTimeIndex   (2, false) != Teuchos::null);
+
+  TEST_COMPARE( sh->getStateTimeIndexN  ()->getIndex(), ==, 2);
+  TEST_COMPARE( sh->getStateTimeIndexNM1()->getIndex(), ==, 1);
+  TEST_FLOATING_EQUALITY( sh->getStateTimeIndexN  ()->getTime(), 2.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY( sh->getStateTimeIndexNM1()->getTime(), 1.0, 1.0e-14);
+
+  // ---------------------------------------------------------------------------
+
+  // Fourth State -- old state should not be added.
+  sh->addState(state0);
+
+  // Still third and second states.
+  TEST_COMPARE          ( sh->getNumStates(), ==, 2);          // Only 2 states!
+  TEST_FLOATING_EQUALITY( sh->getCurrentTime(), 2.0, 1.0e-14);
+  TEST_COMPARE          ( sh->getCurrentIndex(), ==, 2);
+  TEST_FLOATING_EQUALITY( sh->minTime(), 1.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY( sh->maxTime(), 2.0, 1.0e-14);
+
+  TEUCHOS_ASSERT(sh->getCurrentState     ()         != Teuchos::null);
+  TEUCHOS_ASSERT(sh->getStateTimeIndexN  (false)    != Teuchos::null);
+  TEUCHOS_ASSERT(sh->getStateTimeIndexNM1(false)    != Teuchos::null);
+  TEUCHOS_ASSERT(sh->getStateTimeIndexNM2(false)    == Teuchos::null);
+  TEUCHOS_ASSERT(sh->getStateTimeIndex   (1, false) != Teuchos::null);
+  TEUCHOS_ASSERT(sh->getStateTimeIndex   (2, false) != Teuchos::null);
+
+  TEST_COMPARE( sh->getStateTimeIndexN  ()->getIndex(), ==, 2);
+  TEST_COMPARE( sh->getStateTimeIndexNM1()->getIndex(), ==, 1);
+  TEST_FLOATING_EQUALITY( sh->getStateTimeIndexN  ()->getTime(), 2.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY( sh->getStateTimeIndexNM1()->getTime(), 1.0, 1.0e-14);
+
+  // ---------------------------------------------------------------------------
+
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(SolutionHistory, addState_With_Static)
+{
+  // Setup SolutionHistory for testing.
+  auto sh = rcp(new Tempus::SolutionHistory<double>());
+  TEUCHOS_TEST_FOR_EXCEPT(sh->isInitialized());  // Should NOT be initialized
+                                                 // as no State is set.
+  sh->setStorageTypeString ("Static");
+  sh->setStorageLimit(7);
+
+  auto model = rcp(new Tempus_Test::DahlquistTestModel<double>(-1.0, false));
+  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =model->getNominalValues();
+
+  // Sequential insertion.
+  // ---------------------------------------------------------------------------
+  for (size_t i=0; i < 13; ++i) {
+    auto icSoln = rcp_const_cast<Thyra::VectorBase<double> >(inArgsIC.get_x());
+    auto stateI = Tempus::createSolutionStateX<double>(icSoln);
+    stateI->setTime    (i*0.9);
+    stateI->setTimeStep(0.9);
+    stateI->setIndex(i);
+    sh->addState(stateI);
+  }
+  sh->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!sh->isInitialized());
+
+  sh->describe(out, Teuchos::VERB_MEDIUM);
+
+  TEST_COMPARE          ( sh->getNumStates(), ==, 7);
+  TEST_FLOATING_EQUALITY( sh->getCurrentTime(), 10.8, 1.0e-14);
+  TEST_COMPARE          ( sh->getCurrentIndex(), ==, 12);
+  TEST_FLOATING_EQUALITY( sh->minTime(), 5.4, 1.0e-14);
+  TEST_FLOATING_EQUALITY( sh->maxTime(), 10.8, 1.0e-14);
+
+  TEUCHOS_ASSERT(sh->getCurrentState     () != Teuchos::null);
+  TEUCHOS_ASSERT(sh->getStateTimeIndexN  () != Teuchos::null);
+  TEUCHOS_ASSERT(sh->getStateTimeIndexNM1() != Teuchos::null);
+  TEUCHOS_ASSERT(sh->getStateTimeIndexNM2() != Teuchos::null);
+  TEUCHOS_ASSERT(sh->getStateTimeIndex   (7)!= Teuchos::null);
+
+  TEST_COMPARE( sh->getStateTimeIndexN  ()->getIndex(), ==, 12);
+  TEST_FLOATING_EQUALITY( sh->getStateTimeIndexN  ()->getTime(), 10.8, 1.0e-14);
+
+  TEST_COMPARE( sh->getStateTimeIndexNM1()->getIndex(), ==, 11);
+  TEST_FLOATING_EQUALITY( sh->getStateTimeIndexNM1()->getTime(),  9.9, 1.0e-14);
+
+  TEST_COMPARE( sh->getStateTimeIndexNM2()->getIndex(), ==, 10);
+  TEST_FLOATING_EQUALITY( sh->getStateTimeIndexNM2()->getTime(),  9.0, 1.0e-14);
+
+  TEST_COMPARE( sh->getStateTimeIndex  (7)->getIndex(), ==,  7);
+  TEST_FLOATING_EQUALITY( sh->getStateTimeIndex  (7)->getTime(),  6.3, 1.0e-14);
+
+  // ---------------------------------------------------------------------------
+
+  // "Random" insertion.
+  // ---------------------------------------------------------------------------
+  sh->clear();
+  for (size_t i=0; i < 3; ++i) {
+    auto icSoln = rcp_const_cast<Thyra::VectorBase<double> >(inArgsIC.get_x());
+    auto stateI = Tempus::createSolutionStateX<double>(icSoln);
+    stateI->setTime    (2*i*0.9+6.3);
+    stateI->setTimeStep(0.9);
+    stateI->setIndex(2*i+7);
+    sh->addState(stateI);
+  }
+  for (size_t i=0; i < 4; ++i) {
+    auto icSoln = rcp_const_cast<Thyra::VectorBase<double> >(inArgsIC.get_x());
+    auto stateI = Tempus::createSolutionStateX<double>(icSoln);
+    stateI->setTime    (2*i*0.9+5.4);
+    stateI->setTimeStep(0.9);
+    stateI->setIndex(2*i+6);
+    sh->addState(stateI);
+  }
+  sh->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!sh->isInitialized());
+
+  sh->describe(out, Teuchos::VERB_MEDIUM);
+
+  TEST_COMPARE          ( sh->getNumStates(), ==, 7);
+  TEST_FLOATING_EQUALITY( sh->getCurrentTime(), 10.8, 1.0e-14);
+  TEST_COMPARE          ( sh->getCurrentIndex(), ==, 12);
+  TEST_FLOATING_EQUALITY( sh->minTime(), 5.4, 1.0e-14);
+  TEST_FLOATING_EQUALITY( sh->maxTime(), 10.8, 1.0e-14);
+
+  TEUCHOS_ASSERT(sh->getCurrentState     () != Teuchos::null);
+  TEUCHOS_ASSERT(sh->getStateTimeIndexN  () != Teuchos::null);
+  TEUCHOS_ASSERT(sh->getStateTimeIndexNM1() != Teuchos::null);
+  TEUCHOS_ASSERT(sh->getStateTimeIndexNM2() != Teuchos::null);
+  TEUCHOS_ASSERT(sh->getStateTimeIndex   (7)!= Teuchos::null);
+
+  TEST_COMPARE( sh->getStateTimeIndexN  ()->getIndex(), ==, 12);
+  TEST_FLOATING_EQUALITY( sh->getStateTimeIndexN  ()->getTime(), 10.8, 1.0e-14);
+
+  TEST_COMPARE( sh->getStateTimeIndexNM1()->getIndex(), ==, 11);
+  TEST_FLOATING_EQUALITY( sh->getStateTimeIndexNM1()->getTime(),  9.9, 1.0e-14);
+
+  TEST_COMPARE( sh->getStateTimeIndexNM2()->getIndex(), ==, 10);
+  TEST_FLOATING_EQUALITY( sh->getStateTimeIndexNM2()->getTime(),  9.0, 1.0e-14);
+
+  TEST_COMPARE( sh->getStateTimeIndex  (7)->getIndex(), ==,  7);
+  TEST_FLOATING_EQUALITY( sh->getStateTimeIndex  (7)->getTime(),  6.3, 1.0e-14);
+
+  // ---------------------------------------------------------------------------
+
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(SolutionHistory, removeState)
+{
+  // Setup SolutionHistory for testing.
+  auto sh = rcp(new Tempus::SolutionHistory<double>());
+  TEUCHOS_TEST_FOR_EXCEPT(sh->isInitialized());  // Should NOT be initialized
+                                                 // as no State is set.
+  sh->setStorageTypeString ("Static");
+  sh->setStorageLimit(7);
+
+  auto model = rcp(new Tempus_Test::DahlquistTestModel<double>(-1.0, false));
+  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =model->getNominalValues();
+
+  // ---------------------------------------------------------------------------
+  for (size_t i=0; i < 13; ++i) {
+    auto icSoln = rcp_const_cast<Thyra::VectorBase<double> >(inArgsIC.get_x());
+    auto stateI = Tempus::createSolutionStateX<double>(icSoln);
+    stateI->setTime    (i*0.9);
+    stateI->setTimeStep(0.9);
+    stateI->setIndex(i);
+    sh->addState(stateI);
+  }
+  sh->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!sh->isInitialized());
+
+  sh->describe(out, Teuchos::VERB_MEDIUM);
+
+  sh->removeState(sh->getStateTimeIndex(6));
+  sh->removeState( 7.2);
+  sh->removeState(sh->getStateTimeIndex(10));
+  sh->removeState(10.8);
+
+  sh->describe(out, Teuchos::VERB_MEDIUM);
+
+  TEST_COMPARE          ( sh->getNumStates(), ==, 3);
+  TEST_FLOATING_EQUALITY( sh->getCurrentTime(),  9.9, 1.0e-14);
+  TEST_COMPARE          ( sh->getCurrentIndex(), ==, 11);
+  TEST_FLOATING_EQUALITY( sh->minTime(), 6.3, 1.0e-14);
+  TEST_FLOATING_EQUALITY( sh->maxTime(), 9.9, 1.0e-14);
+
+  TEUCHOS_ASSERT(sh->getCurrentState     () != Teuchos::null);
+  TEUCHOS_ASSERT(sh->getStateTimeIndexN  () != Teuchos::null);
+  TEUCHOS_ASSERT(sh->getStateTimeIndexNM1() == Teuchos::null);
+  TEUCHOS_ASSERT(sh->getStateTimeIndexNM2() != Teuchos::null);
+  TEUCHOS_ASSERT(sh->getStateTimeIndex   (7)!= Teuchos::null);
+
+  TEST_COMPARE( sh->getStateTimeIndexN  ()->getIndex(), ==, 11);
+  TEST_FLOATING_EQUALITY( sh->getStateTimeIndexN  ()->getTime(), 9.9, 1.0e-14);
+
+  TEST_COMPARE( sh->getStateTimeIndexNM2()->getIndex(), ==,  9);
+  TEST_FLOATING_EQUALITY( sh->getStateTimeIndexNM2()->getTime(), 8.1, 1.0e-14);
+
+  // ---------------------------------------------------------------------------
+
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(SolutionHistory, initWorkingState_Passing)
+{
+  // Setup SolutionHistory for testing.
+  auto sh = rcp(new Tempus::SolutionHistory<double>());
+  TEUCHOS_TEST_FOR_EXCEPT(sh->isInitialized());  // Should NOT be initialized
+                                                 // as no State is set.
+
+  auto model = rcp(new Tempus_Test::DahlquistTestModel<double>(-1.0, false));
+  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =model->getNominalValues();
+  auto icSoln = rcp_const_cast<Thyra::VectorBase<double> >(inArgsIC.get_x());
+  auto state0 = Tempus::createSolutionStateX<double>(icSoln);
+  state0->setTime (0.0);
+  state0->setTimeStep(1.0);
+  state0->setIndex(0);
+  sh->addState(state0);
+  sh->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!sh->isInitialized());
+
+  // State before initializing workingState
+  // with sh->getWorkingState() == Teuchos::null, i.e., workingState
+  // was promoted from last time step or initial condition.
+  TEST_COMPARE          ( sh->getNumStates(), ==, 1);
+  TEUCHOS_ASSERT(sh->getCurrentState() != Teuchos::null);
+  TEUCHOS_ASSERT(sh->getCurrentState() == sh->getStateTimeIndexN());
+  TEUCHOS_ASSERT(sh->getWorkingState() == Teuchos::null);
+
+  sh->initWorkingState();
+
+  // State after initializing workingState.
+  TEST_COMPARE          ( sh->getNumStates(), ==, 2);
+  TEST_FLOATING_EQUALITY( sh->getCurrentTime(), 0.0, 1.0e-14);
+  TEST_COMPARE          ( sh->getCurrentIndex(), ==, 0);
+  TEST_FLOATING_EQUALITY( sh->minTime(), 0.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY( sh->maxTime(), 1.0, 1.0e-14);
+
+  TEUCHOS_ASSERT(sh->getCurrentState() != Teuchos::null);
+  TEUCHOS_ASSERT(sh->getCurrentState() == sh->getStateTimeIndexNM1());
+  TEUCHOS_ASSERT(sh->getWorkingState() != Teuchos::null);
+  TEUCHOS_ASSERT(sh->getWorkingState() == sh->getStateTimeIndexN());
+
+  TEST_COMPARE          ( sh->getCurrentState()->getIndex(), ==, 0);
+  TEST_FLOATING_EQUALITY( sh->getCurrentState()->getTime(), 0.0, 1.0e-14);
+
+  TEST_COMPARE          ( sh->getWorkingState()->getIndex(), ==, 1);
+  TEST_FLOATING_EQUALITY( sh->getWorkingState()->getTime(), 1.0, 1.0e-14);
+
+  // ---------------------------------------------------------------------------
+
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(SolutionHistory, initWorkingState_Failing)
+{
+  // Setup SolutionHistory for testing.
+  auto sh = rcp(new Tempus::SolutionHistory<double>());
+  TEUCHOS_TEST_FOR_EXCEPT(sh->isInitialized());  // Should NOT be initialized
+                                                 // as no State is set.
+
+  auto model = rcp(new Tempus_Test::DahlquistTestModel<double>(-1.0, false));
+  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =model->getNominalValues();
+  auto icSoln = rcp_const_cast<Thyra::VectorBase<double> >(inArgsIC.get_x());
+  auto state0 = Tempus::createSolutionStateX<double>(icSoln);
+  state0->setTime (0.0);
+  state0->setTimeStep(1.0);
+  state0->setIndex(0);
+  sh->addState(state0);
+  sh->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!sh->isInitialized());
+
+  auto state1 = Tempus::createSolutionStateX<double>(icSoln);
+  state1->setTime (1.0);
+  state1->setTimeStep(1.0);
+  state1->setIndex(1);
+  sh->addWorkingState(state1);
+  sh->getWorkingState()->setSolutionStatus(Tempus::Status::FAILED);
+
+  // State before initializing workingState
+  // with sh->getWorkingState() != Teuchos::null, i.e., workingState
+  // was NOT promoted from last time step or initial condition.
+  TEST_COMPARE          ( sh->getNumStates(), ==, 2);
+  TEST_FLOATING_EQUALITY( sh->getCurrentTime(), 0.0, 1.0e-14);
+  TEST_COMPARE          ( sh->getCurrentIndex(), ==, 0);
+  TEST_FLOATING_EQUALITY( sh->minTime(), 0.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY( sh->maxTime(), 1.0, 1.0e-14);
+
+  TEUCHOS_ASSERT(sh->getCurrentState() != Teuchos::null);
+  TEUCHOS_ASSERT(sh->getCurrentState() == sh->getStateTimeIndexNM1());
+  TEUCHOS_ASSERT(sh->getWorkingState() != Teuchos::null);
+  TEUCHOS_ASSERT(sh->getWorkingState() == sh->getStateTimeIndexN());
+
+  TEST_COMPARE          ( sh->getCurrentState()->getIndex(), ==, 0);
+  TEST_FLOATING_EQUALITY( sh->getCurrentState()->getTime(), 0.0, 1.0e-14);
+
+  TEST_COMPARE          ( sh->getWorkingState()->getIndex(), ==, 1);
+  TEST_FLOATING_EQUALITY( sh->getWorkingState()->getTime(), 1.0, 1.0e-14);
+
+  sh->initWorkingState();
+
+  // State after initializing workingState.
+  // Should be unchanged as we are trying to redo FAILing time step.
+  TEST_COMPARE          ( sh->getNumStates(), ==, 2);
+  TEST_FLOATING_EQUALITY( sh->getCurrentTime(), 0.0, 1.0e-14);
+  TEST_COMPARE          ( sh->getCurrentIndex(), ==, 0);
+  TEST_FLOATING_EQUALITY( sh->minTime(), 0.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY( sh->maxTime(), 1.0, 1.0e-14);
+
+  TEUCHOS_ASSERT(sh->getCurrentState() != Teuchos::null);
+  TEUCHOS_ASSERT(sh->getCurrentState() == sh->getStateTimeIndexNM1());
+  TEUCHOS_ASSERT(sh->getWorkingState() != Teuchos::null);
+  TEUCHOS_ASSERT(sh->getWorkingState() == sh->getStateTimeIndexN());
+
+  TEST_COMPARE          ( sh->getCurrentState()->getIndex(), ==, 0);
+  TEST_FLOATING_EQUALITY( sh->getCurrentState()->getTime(), 0.0, 1.0e-14);
+
+  TEST_COMPARE          ( sh->getWorkingState()->getIndex(), ==, 1);
+  TEST_FLOATING_EQUALITY( sh->getWorkingState()->getTime(), 1.0, 1.0e-14);
+
+  // ---------------------------------------------------------------------------
+
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(SolutionHistory, promoteWorkingState_Passing)
+{
+  // Setup SolutionHistory for testing.
+  auto sh = rcp(new Tempus::SolutionHistory<double>());
+  TEUCHOS_TEST_FOR_EXCEPT(sh->isInitialized());  // Should NOT be initialized
+                                                 // as no State is set.
+
+  auto model = rcp(new Tempus_Test::DahlquistTestModel<double>(-1.0, false));
+  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =model->getNominalValues();
+  auto icSoln = rcp_const_cast<Thyra::VectorBase<double> >(inArgsIC.get_x());
+  auto state0 = Tempus::createSolutionStateX<double>(icSoln);
+  state0->setTime (0.0);
+  state0->setTimeStep(1.0);
+  state0->setIndex(0);
+  sh->addState(state0);
+  sh->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!sh->isInitialized());
+  sh->initWorkingState();
+  sh->getWorkingState()->setSolutionStatus(Tempus::Status::PASSED);
+
+  // State before promoting workingState.
+  // with workingState PASSing.
+  TEST_COMPARE          ( sh->getNumStates(), ==, 2);
+  TEUCHOS_ASSERT(sh->getCurrentState() != Teuchos::null);
+  TEUCHOS_ASSERT(sh->getCurrentState() == sh->getStateTimeIndexNM1());
+  TEUCHOS_ASSERT(sh->getWorkingState() != Teuchos::null);
+  TEUCHOS_ASSERT(sh->getWorkingState() == sh->getStateTimeIndexN());
+
+  TEST_COMPARE          ( sh->getCurrentState()->getIndex(), ==, 0);
+  TEST_FLOATING_EQUALITY( sh->getCurrentState()->getTime(), 0.0, 1.0e-14);
+
+  TEST_COMPARE          ( sh->getWorkingState()->getIndex(), ==, 1);
+  TEST_FLOATING_EQUALITY( sh->getWorkingState()->getTime(), 1.0, 1.0e-14);
+
+  sh->promoteWorkingState();
+
+  // State after promoting workingState.
+  TEST_COMPARE          ( sh->getNumStates(), ==, 2);
+  TEUCHOS_ASSERT(sh->getCurrentState() != Teuchos::null);
+  TEUCHOS_ASSERT(sh->getCurrentState() == sh->getStateTimeIndexN());
+  TEUCHOS_ASSERT(sh->getWorkingState() == Teuchos::null);
+
+  // Current state is now at t=1.0!
+  TEST_COMPARE          ( sh->getCurrentState()->getIndex(), ==, 1);
+  TEST_FLOATING_EQUALITY( sh->getCurrentState()->getTime(), 1.0, 1.0e-14);
+
+  // ---------------------------------------------------------------------------
+
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(SolutionHistory, promoteWorkingState_Failing)
+{
+  // Setup SolutionHistory for testing.
+  auto sh = rcp(new Tempus::SolutionHistory<double>());
+  TEUCHOS_TEST_FOR_EXCEPT(sh->isInitialized());  // Should NOT be initialized
+                                                 // as no State is set.
+
+  auto model = rcp(new Tempus_Test::DahlquistTestModel<double>(-1.0, false));
+  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =model->getNominalValues();
+  auto icSoln = rcp_const_cast<Thyra::VectorBase<double> >(inArgsIC.get_x());
+  auto state0 = Tempus::createSolutionStateX<double>(icSoln);
+  state0->setTime (0.0);
+  state0->setTimeStep(1.0);
+  state0->setIndex(0);
+  sh->addState(state0);
+  sh->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!sh->isInitialized());
+  sh->initWorkingState();
+  sh->getWorkingState()->setSolutionStatus(Tempus::Status::FAILED);
+
+  // State before promoting workingState.
+  // with workingState FAILing.
+  TEST_COMPARE          ( sh->getNumStates(), ==, 2);
+  TEUCHOS_ASSERT(sh->getCurrentState() != Teuchos::null);
+  TEUCHOS_ASSERT(sh->getCurrentState() == sh->getStateTimeIndexNM1());
+  TEUCHOS_ASSERT(sh->getWorkingState() != Teuchos::null);
+  TEUCHOS_ASSERT(sh->getWorkingState() == sh->getStateTimeIndexN());
+
+  TEST_COMPARE          ( sh->getCurrentState()->getIndex(), ==, 0);
+  TEST_FLOATING_EQUALITY( sh->getCurrentState()->getTime(), 0.0, 1.0e-14);
+
+  TEST_COMPARE          ( sh->getWorkingState()->getIndex(), ==, 1);
+  TEST_FLOATING_EQUALITY( sh->getWorkingState()->getTime(), 1.0, 1.0e-14);
+
+  sh->promoteWorkingState();
+
+  // State after promoting workingState.
+  // Should be unchanged as we are trying to redo FAILing time step.
+  TEST_COMPARE          ( sh->getNumStates(), ==, 2);
+  TEUCHOS_ASSERT(sh->getCurrentState() != Teuchos::null);
+  TEUCHOS_ASSERT(sh->getCurrentState() == sh->getStateTimeIndexNM1());
+  TEUCHOS_ASSERT(sh->getWorkingState() != Teuchos::null);
+  TEUCHOS_ASSERT(sh->getWorkingState() == sh->getStateTimeIndexN());
+
+  // Current state is still at t=0.0!
+  TEST_COMPARE          ( sh->getCurrentState()->getIndex(), ==, 0);
+  TEST_FLOATING_EQUALITY( sh->getCurrentState()->getTime(), 0.0, 1.0e-14);
+
+  // Working state is still at t=1.0!
+  TEST_COMPARE          ( sh->getWorkingState()->getIndex(), ==, 1);
+  TEST_FLOATING_EQUALITY( sh->getWorkingState()->getTime(), 1.0, 1.0e-14);
+
+  // ---------------------------------------------------------------------------
+
+}
+
+
+} // namespace Tempus_Test


### PR DESCRIPTION
 * SolutionHistory is no longer inherits from ParameterListAcceptor.
 * Moved SolutionHistory constructor with ParameterList to a
   nonmember constructor, createSolutionHistoryPL(pl).
 * Added function to set the history, setHistory().
 * Simplified the internal management of "Storage Type".
   - Can set with enum StorageType or a string.
   - Removed ParameterList validator for enum storageType.
 * Added methods to initialize SolutionHistory similar to
   other Tempus objects.
 * Added checks to addState to ensure new state's index does not
   match an index already in the SolutionHistory. This can
   be turned off.
 * Fixed bug in addWorkingState, where state was added to
   history (chronologically) and then the TIME was changed.
 * Added unit tests.

@trilinos/tempus 

