### PR TITLE
Correct setenv left in bash scripts

### DIFF
--- a/cmake/std/sems/PullRequestIntel17.0.1TestingEnv.sh
+++ b/cmake/std/sems/PullRequestIntel17.0.1TestingEnv.sh
@@ -36,4 +36,4 @@ module load sems-python/3.5.2
 export OMP_NUM_THREADS=2
 
 # required for cmake > 3.10 during configure compiler testing.
-setenv LDFLAGS=-lifcore
+export LDFLAGS=-lifcore

--- a/cmake/std/sems/PullRequestIntel19.0.5TestingEnv.sh
+++ b/cmake/std/sems/PullRequestIntel19.0.5TestingEnv.sh
@@ -36,4 +36,4 @@ module load sems-python/3.5.2
 export OMP_NUM_THREADS=2
 
 # required for cmake > 3.10 during configure compiler testing.
-setenv LDFLAGS=-lifcore
+export LDFLAGS=-lifcore


### PR DESCRIPTION
These were copied from the ini file without interpretation
which of course is incorrect.

@trilinos/framework 

## Motivation
Fails in Production - reported by Ross.

