### PR TITLE
Fix an error introduced in PR 8829

### DIFF
--- a/cmake/std/PullRequestLinuxCuda10.1.243TestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxCuda10.1.243TestingSettings.cmake
@@ -144,7 +144,7 @@ set (SEACASAprepro_aprepro_command_line_vars_test_DISABLE ON CACHE BOOL "Tempora
 set (SEACASAprepro_aprepro_command_line_include_test_DISABLE ON CACHE BOOL "Temporary disable due to jsrun polluting stderr")
 set (SEACASAprepro_aprepro_test_dump_reread_DISABLE ON CACHE BOOL "Temporary disable due to jsrun polluting stderr")
 
- (CMAKE_CXX_STANDARD "14" CACHE STRING "Set C++ standard to C++14")
+set (CMAKE_CXX_STANDARD "14" CACHE STRING "Set C++ standard to C++14")
 # set (CMAKE_CXX_EXTENSIONS OFF CACHE BOOL "Kokkos turns off CXX extensions")
 
 include("${CMAKE_CURRENT_LIST_DIR}/PullRequestLinuxCommonTestingSettings.cmake")


### PR DESCRIPTION
Basically the set command was missed on this line
which leaves cmake very confused.

@trilinos/framework 

## Related Issues

* Follows #8829
* Related to #8797


