### PR TITLE
Tempus: Remove Doxygen dependence on algpseudocode.

### DIFF
--- a/packages/tempus/doc/Doxyfile
+++ b/packages/tempus/doc/Doxyfile
@@ -851,7 +851,7 @@ ALPHABETICAL_INDEX     = YES
 # the COLS_IN_ALPHA_INDEX tag can be used to specify the number of columns
 # in which this list will be split (can be a number in the range [1..20])
 
-COLS_IN_ALPHA_INDEX    = 3
+#COLS_IN_ALPHA_INDEX    = 3
 
 # In case all classes in a project start with a common prefix, all
 # classes will be put under the same header in the alphabetical index.
@@ -1323,8 +1323,7 @@ PAPER_TYPE             = letter
 # The EXTRA_PACKAGES tag can be to specify one or more names of LaTeX
 # packages that should be included in the LaTeX output.
 
-EXTRA_PACKAGES         = {algorithm} \
-                         {algpseudocode}
+EXTRA_PACKAGES         = 
 
 # The LATEX_HEADER tag can be used to specify a personal LaTeX header for
 # the generated latex document. The header should contain everything until

--- a/packages/tempus/src/Tempus_StepperBDF2AppAction.hpp
+++ b/packages/tempus/src/Tempus_StepperBDF2AppAction.hpp
@@ -23,27 +23,12 @@ template<class Scalar> class StepperBDF2;
  *  This class provides a means to apply various actions with the BDF2 time step.
  *  The data available to this class is solution variables (through
  *  SolutionHistory), and stepper data (through the Stepper).  It allows
- *  the application to just observe this data (i.e., use but not change the
- *  data) to change any of it (USER BEWARE!).
+ *  the application to just observe this data, i.e., use but not change
+ *  any of it (USER BEWARE!).
  *
- *  Below is the BDF2 algorithm and includes the locations where the
- *  application can take actions (in italicized).
- *
- *  \f{algorithm}{
- *  \renewcommand{\thealgorithm}{}
- *  \caption{BDF2 with the locations of the application actions indicated.  Note
- *  that the following algorithm in only applied after the first two steps (where
- *  the appAction for the start-up stepper is used)}
- *  \begin{algorithmic}[1]
- *    \State {\it appAction.execute(solutionHistory, stepper, BEGIN\_STEP)}
- *    \State Set old values of $x_{n}$, $x_{n-1}$ to the new values of $x_{n-1}$, $x_{n-2}$ respectively.
- *    \State {\it appAction.execute(solutionHistory, stepper, BEFORE\_SOLVE)}
- *    \State Solve $F( (3 x_{n} - 4 x _{n-1} + x_{n-2})/(3\Delta t),x_{n},t_{n}) for $x_n$
- *    \State {\it appAction.execute(solutionHistory, stepper, AFTER\_SOLVE)}
- *    \State $\dot{x}_{n} \leftarrow (3 x_{n} - 4 x_{n-1} + x_{n-2})/(3\Delta t)$
- *    \State {\it appAction.execute(solutionHistory, stepper, END\_STEP)}
- *  \end{algorithmic}
- *  \f}
+ *  The locations for these AppAction calls
+ *  (StepperBDF2AppAction::ACTION_LOCATION) are shown in the
+ *  algorithm documentation of the StepperBDF2.
  */
 template<class Scalar>
 class StepperBDF2AppAction

--- a/packages/tempus/src/Tempus_StepperBDF2ModifierBase.hpp
+++ b/packages/tempus/src/Tempus_StepperBDF2ModifierBase.hpp
@@ -28,21 +28,9 @@ namespace Tempus {
  *  Thus the user should be careful when accessing data through classes
  *  derived from the default modifier (i.e., USER BEWARE!!).
  *
- *  \f{algorithm}{
- *  \renewcommand{\thealgorithm}{}
- *  \caption{BDF2 with the locations of the modifier modifications indicated.  Note
- *  that the following algorithm in only applied after the first two steps (where
- *  the appAction for the start-up stepper is used)}
- *  \begin{algorithmic}[1]
- *    \State {\it modifier.modify(solutionHistory, stepper, BEGIN\_STEP)}
- *    \State Set old values of $x_{n}$, $x_{n-1}$ to the new values of $x_{n-1}$, $x_{n-2}$ respectively.
- *    \State {\it modifier.modify(solutionHistory, stepper, BEFORE\_SOLVE)}
- *    \State Solve $F( (3 x_{n} - 4 x _{n-1} + x_{n-2})/(3\Delta t),x_{n},t_{n}) for $x_n$
- *    \State {\it modifier.modify(solutionHistory, stepper, AFTER\_SOLVE)}
- *    \State $\dot{x}_{n} \leftarrow (3 x_{n} - 4 x_{n-1} + x_{n-2})/(3\Delta t)$
- *    \State {\it modifier.modify(solutionHistory, stepper, END\_STEP)}
- *  \end{algorithmic}
- *  \f}
+ *  The locations for these AppAction calls
+ *  (StepperBDF2AppAction::ACTION_LOCATION) are shown in the
+ *  algorithm documentation of the StepperBDF2.
  */
 template<class Scalar>
 class StepperBDF2ModifierBase

--- a/packages/tempus/src/Tempus_StepperBDF2ModifierXBase.hpp
+++ b/packages/tempus/src/Tempus_StepperBDF2ModifierXBase.hpp
@@ -28,22 +28,10 @@ namespace Tempus {
  *  affecting the Stepper correctness, performance, accuracy and stability
  *  (i.e., USER BEWARE!!).
  *
- *  Below is the BDF2 algorithm with the locations of the ModifierX calls
- *  italicized.
- *
- *  \f{algorithm}{
- *  \renewcommand{\thealgorithm}{}
- *  \caption{BDF2 with the locations of the application actions indicated}
- *  \begin{algorithmic}[1]
- *    \State {\it modifierX.execute(solutionHistory, stepper, BEGIN\_STEP)}                                                         
- *    \State Set old values of $x_{n}$, $x_{n-1}$ to the new values of $x_{n-1}$, $x_{n-2}$ respectively.                                             
- *    \State {\it modifierX.execute(solutionHistory, stepper, BEFORE\_SOLVE)}                                              
- *    \State Solve $F( (3 x_{n} - 4 x _{n-1} + x_{n-2})/(3\Delta t),x_{n},t_{n}) for $x_n$                                                            
- *    \State {\it modifierX.execute(solutionHistory, stepper, AFTER\_SOLVE)}                                                                          
- *    \State $\dot{x}_{n} \leftarrow (3 x_{n} - 4 x_{n-1} + x_{n-2})/(3\Delta t)$                                                                     
- *    \State {\it modifierX.execute(solutionHistory, stepper, END\_STEP)}             
- *  \end{algorithmic}
- *  \f}
+ *  The locations of the StepperBDF2ModifierXBase::MODIFIER_TYPE
+ *  which correspond to the AppAction calls
+ *  (StepperBDF2AppAction::ACTION_LOCATION) are shown in the
+ *  algorithm documentation of the StepperBDF2.
  */
 
 template<class Scalar>

--- a/packages/tempus/src/Tempus_StepperBDF2ObserverBase.hpp
+++ b/packages/tempus/src/Tempus_StepperBDF2ObserverBase.hpp
@@ -27,25 +27,10 @@ namespace Tempus {
  *  wishes to modify the solution and/or stepper data during the
  *  Stepper::takeStep, they should use the Modifier class (with care!).
  *
- *  Below is the BDF2 algorithm with the locations of the observe calls
- *  italicized.
- *
- *  \f{algorithm}{                                                                               
- *  \renewcommand{\thealgorithm}{}                                                               
- *  \caption{BDF2 with the locations of the oberserver observations  indicated.   Note                             
- *  that the following algorithm in only applied after the first two steps (where                                    
- *  the appAction for the start-up stepper is used)}                                                                 
- *  \begin{algorithmic}[1]                                                                                           
- *    \State {\it observer.observe(solutionHistory, stepper, BEGIN\_STEP)}                                          
- *    \State Set old values of $x_{n}$, $x_{n-1}$ to the new values of $x_{n-1}$, $x_{n-2}$ respectively.            
- *    \State {\it oberserver.observe(solutionHistory, stepper, BEFORE\_SOLVE)}                                       
- *    \State Solve $F( (3 x_{n} - 4 x _{n-1} + x_{n-2})/(3\Delta t),x_{n},t_{n}) for $x_n$                           
- *    \State {\it observer.observe(solutionHistory, stepper, AFTER\_SOLVE)}                                         
- *    \State $\dot{x}_{n} \leftarrow (3 x_{n} - 4 x_{n-1} + x_{n-2})/(3\Delta t)$                                    
- *    \State {\it observer.observe(solutionHistory, stepper, END\_STEP)}                                            
- *  \end{algorithmic}   
- * \f}
- */ 
+ *  The locations for these AppAction calls
+ *  (StepperBDF2AppAction::ACTION_LOCATION) are shown in the
+ *  algorithm documentation of the StepperBDF2.
+ */
 template<class Scalar>
 class StepperBDF2ObserverBase
   : virtual public Tempus::StepperBDF2AppAction<Scalar>

--- a/packages/tempus/src/Tempus_StepperBDF2_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperBDF2_decl.hpp
@@ -24,23 +24,47 @@ namespace Tempus {
  *  for a variable time-step, \f$\Delta t\f$.  It is a 2-step method.
  *
  *  <b> Algorithm </b>
- *   - For \f$n=0\f$, set the initial condition, \f$x_0\f$.
- *   - For \f$n=1\f$, use a one-step startup stepper, e.g., Backward Euler
- *     or RK4.  The default startup stepper is 'IRK 1 Stage Theta Method'
- *     which second order.
- *   - For \f$n>1\f$, solve for \f$x_n\f$ via
- *       \f$ f\left(x_n, \dot{x}_n, t_n\right) = 0\f$
- *  where \f$
- *    \dot{x}_{n} = \frac{2\tau_n + \tau_{n-1}}{\tau_n + \tau_{n-1}}
+ *  The single-timestep algorithm for BDF2 is
+ *
+ *  \f{center}{
+ *    \parbox{5in}{
+ *    \rule{5in}{0.4pt} \\
+ *    {\bf Algorithm} BDF2 \\
+ *    \rule{5in}{0.4pt} \vspace{-15pt}
+ *    \begin{enumerate}
+ *      \setlength{\itemsep}{0pt} \setlength{\parskip}{0pt} \setlength{\parsep}{0pt}
+ *      \item {\bf if ( "Startup", i.e., number of states $<$ 3) then}
+ *      \item \quad {\bf Take timestep with startup Stepper.}
+ *      \item \quad {\bf return}
+ *      \item {\bf endif}
+ *      \item {\it appAction.execute(solutionHistory, stepper, BEGIN\_STEP)}
+ *      \item {\bf Get old states $x_{n-1}$ and $x_{n-2}$.}
+ *      \item {\bf Set ODE parameters.}
+ *      \item \quad {\bf Time derivative: }
+ *            $\dot{x}_{n} = \frac{2\tau_n + \tau_{n-1}}{\tau_n + \tau_{n-1}}
  *                  \left[ \frac{x_n-x_{n-1}}{\tau_n}\right]
  *                -  \frac{\tau_n}{\tau_n + \tau_{n-1}}
- *                   \left[ \frac{x_{n-1}-x_{n-2}}{\tau_{n-1}}\right], \f$
- *  and \f$\Delta t_n = \tau_n = t_n - t_{n-1}\f$.
- *   - \f$\dot{x}_n \leftarrow
- *    \dot{x}_{n} = \frac{2\tau_n + \tau_{n-1}}{\tau_n + \tau_{n-1}}
+ *                   \left[ \frac{x_{n-1}-x_{n-2}}{\tau_{n-1}}\right]$
+ *      \item \quad {\bf Alpha: $\alpha = \frac{2\tau_n + \tau_{n-1}}{(\tau_n + \tau_{n-1})\tau_n}$}
+ *      \item \quad {\bf Beta: $\beta = 1$}
+ *      \item {\it appAction.execute(solutionHistory, stepper, BEFORE\_SOLVE)}
+ *      \item {\bf Solve $\mathcal{F}(\dot{x}_n,x_n,t_n) = 0$ for $x_n$.}
+ *      \item {\it appAction.execute(solutionHistory, stepper, AFTER\_SOLVE)}
+ *      \item {\bf Update} $\dot{x}_{n} = \frac{2\tau_n + \tau_{n-1}}{\tau_n + \tau_{n-1}}
  *                  \left[ \frac{x_n-x_{n-1}}{\tau_n}\right]
  *                -  \frac{\tau_n}{\tau_n + \tau_{n-1}}
- *                   \left[ \frac{x_{n-1}-x_{n-2}}{\tau_{n-1}}\right], \f$
+ *                   \left[ \frac{x_{n-1}-x_{n-2}}{\tau_{n-1}}\right]$
+ *      \item {\it appAction.execute(solutionHistory, stepper, END\_STEP)}
+ *    \end{enumerate}
+ *    \vspace{-10pt} \rule{5in}{0.4pt}
+ *    }
+ *  \f}
+ *
+ *  The startup stepper allows BDF2 to use user-specified Stepper for the
+ *  first timestep in order to populate the SolutionHistory with past states.
+ *  A one-step startup stepper is perfect for this situation, e.g., Backward
+ *  Euler or RK4.  The default startup stepper is 'IRK 1 Stage Theta Method',
+ *  which is second order accurate and allows an overall second-order solution.
  *
  *  The First-Same-As-Last (FSAL) principle is not needed for BDF2.
  *  The default is to set useFSAL=false, however useFSAL=true will also work

--- a/packages/tempus/src/Tempus_StepperBackwardEulerAppAction.hpp
+++ b/packages/tempus/src/Tempus_StepperBackwardEulerAppAction.hpp
@@ -23,25 +23,12 @@ template<class Scalar> class StepperBackwardEuler;
  *  This class provides a means to apply various actions with the BackwardEuler time step.
  *  The data available to this class is solution variables (through
  *  SolutionHistory), and stepper data (through the Stepper).  It allows
- *  the application to just observe this data (i.e., use but not change the
- *  data) to change any of it (USER BEWARE!).
+ *  the application to just observe this data, i.e., use but not change
+ *  any of it (USER BEWARE!).
  *
- *  Below is the BackwardEuler algorithm and includes the locations where the
- *  application can take actions (in italicized).
- *
- *  \f{algorithm}{
- *  \renewcommand{\thealgorithm}{}
- *  \caption{Backward Euler with application-action locations indicated.}
- *  \begin{algorithmic}[1]
- *    \State {\it appAction.execute(solutionHistory, stepper, BEGIN\_STEP)}
- *    \State Compute the predictor (e.g., apply stepper to $x_n$).
- *    \State {\it appAction.execute(solutionHistory, stepper, BEFORE\_SOLVE)}
- *    \State Solve $\mathcal{F}_n(\dot{x}=(x_n-x_{n-1})/\Delta t_n, x_n, t_n)=0$ for $x_n$
- *    \State {\it appAction.execute(solutionHistory, stepper, AFTER\_SOLVE)}
- *    \State $\dot{x}_n \leftarrow (x_n-x_{n-1})/\Delta t_n$
- *    \State {\it appAction.execute(solutionHistory, stepper, END\_STEP)}
- *  \end{algorithmic}
- *  \f}
+ *  The locations for these AppAction calls
+ *  (StepperBackwardEulerAppAction::ACTION_LOCATION) are shown in the
+ *  algorithm documentation of the StepperBackwardEuler.
  */
 template<class Scalar>
 class StepperBackwardEulerAppAction

--- a/packages/tempus/src/Tempus_StepperBackwardEulerModifierBase.hpp
+++ b/packages/tempus/src/Tempus_StepperBackwardEulerModifierBase.hpp
@@ -29,22 +29,9 @@ namespace Tempus {
  *  Thus the user should be careful when accessing data through classes
  *  derived from the default modifier (i.e., USER BEWARE!!).
  *
- *  Below is the BackwardEuler algorithm with the locations of the modify calls
- *  italicized.
- *
- *  \f{algorithm}{
- *  \renewcommand{\thealgorithm}{}
- *  \caption{Backward Euler with modify calls indicated.}
- *  \begin{algorithmic}[1]
- *    \State \quad {\it modifier.modify(solutionHistory, stepper, BEGIN\_STEP)}
- *    \State Compute the predictor (e.g., apply stepper to $x_n$).
- *    \State \quad {\it modifier.modify(solutionHistory, stepper, BEFORE\_SOLVE)}
- *    \State Solve $\mathcal{F}_n(\dot{x}=(x_n-x_{n-1})/\Delta t_n, x_n, t_n)=0$ for $x_n$
- *    \State \quad {\it modifier.modify(solutionHistory, stepper, AFTER\_SOLVE)}
- *    \State $\dot{x}_n \leftarrow (x_n-x_{n-1})/\Delta t_n$
- *    \State \quad {\it modifier.modify(solutionHistory, stepper, END\_STEP)}
- *  \end{algorithmic}
- *  \f}
+ *  The locations for these AppAction calls
+ *  (StepperBackwardEulerAppAction::ACTION_LOCATION) are shown in the
+ *  algorithm documentation of the StepperBackwardEuler.
  */
 template<class Scalar>
 class StepperBackwardEulerModifierBase

--- a/packages/tempus/src/Tempus_StepperBackwardEulerModifierXBase.hpp
+++ b/packages/tempus/src/Tempus_StepperBackwardEulerModifierXBase.hpp
@@ -28,22 +28,10 @@ namespace Tempus {
  *  affecting the Stepper correctness, performance, accuracy and stability
  *  (i.e., USER BEWARE!!).
  *
- *  Below is the BackwardEuler algorithm with the locations of the ModifierX calls
- *  italicized.
- *
- *  \f{algorithm}{
- *  \renewcommand{\thealgorithm}{}
- *  \caption{Backward Euler with modify calls indicated.}
- *  \begin{algorithmic}[1]
- *    \State \quad {\it modifierX.modify(x, time, dt, X\_BEGIN\_STEP)}
- *    \State Compute the predictor (e.g., apply stepper to $x_n$).
- *    \State \quad {\it modifierX.modify(x, time, dt, X\_BEFORE\_SOLVE)}
- *    \State Solve $\mathcal{F}_n(\dot{x}=(x_n-x_{n-1})/\Delta t_n, x_n, t_n)=0$ for $x_n$
- *    \State \quad {\it modifierX.modify(x, time, dt, X\_AFTER\_SOLVE)}
- *    \State $\dot{x}_n \leftarrow (x_n-x_{n-1})/\Delta t_n$
- *    \State \quad {\it modifierX.modify(x, time, dt, XDOT\_END\_STEP)}
- *  \end{algorithmic}
- *  \f}
+ *  The locations of the StepperBackwardEulerModifierXBase::MODIFIER_TYPE
+ *  which correspond to the AppAction calls
+ *  (StepperBackwardEulerAppAction::ACTION_LOCATION) are shown in the
+ *  algorithm documentation of the StepperBackwardEuler.
  */
 template<class Scalar>
 class StepperBackwardEulerModifierXBase

--- a/packages/tempus/src/Tempus_StepperBackwardEulerObserverBase.hpp
+++ b/packages/tempus/src/Tempus_StepperBackwardEulerObserverBase.hpp
@@ -27,22 +27,9 @@ namespace Tempus {
  *  wishes to modify the solution and/or stepper data during the
  *  Stepper::takeStep, they should use the Modifier class (with care!).
  *
- *  Below is the BackwardEuler algorithm with the locations of the observe calls
- *  italicized.
- *
- *  \f{algorithm}{
- *  \renewcommand{\thealgorithm}{}
- *  \caption{DIRK Backward Euler with observe calls indicated.}
- *  \begin{algorithmic}[1]
- *    \State \quad {\it observer.observe(solutionHistory, stepper, BEGIN\_STEP)}
- *    \State Compute the predictor (e.g., apply stepper to $x_n$).
- *    \State \quad {\it observer.observe(solutionHistory, stepper, BEFORE\_SOLVE)}
- *    \State Solve $\mathcal{F}_n(\dot{x}=(x_n-x_{n-1})/\Delta t_n, x_n, t_n)=0$ for $x_n$
- *    \State \quad {\it observer.observe(solutionHistory, stepper, AFTER\_SOLVE)}
- *    \State $\dot{x}_n \leftarrow (x_n-x_{n-1})/\Delta t_n$
- *    \State \quad {\it observer.observe(solutionHistory, stepper, END\_STEP)}
- *  \end{algorithmic}
- *  \f}
+ *  The locations for these AppAction calls
+ *  (StepperBackwardEulerAppAction::ACTION_LOCATION) are shown in the
+ *  algorithm documentation of the StepperBackwardEuler.
  */
 template<class Scalar>
 class StepperBackwardEulerObserverBase

--- a/packages/tempus/src/Tempus_StepperBackwardEuler_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperBackwardEuler_decl.hpp
@@ -27,18 +27,23 @@ namespace Tempus {
  *  <b> Algorithm </b>
  *  The single-timestep algorithm for Backward Euler is
  *
- *  \f{algorithm}{
- *  \renewcommand{\thealgorithm}{}
- *  \caption{Backward Euler}
- *  \begin{algorithmic}[1]
- *    \State {\it appAction.execute(solutionHistory, stepper, BEGIN\_STEP)}
- *    \State Compute the predictor (e.g., apply stepper to $x_n$).
- *    \State {\it appAction.execute(solutionHistory, stepper, BEFORE\_SOLVE)}
- *    \State Solve $\mathcal{F}_n(\dot{x}=(x_n-x_{n-1})/\Delta t_n, x_n, t_n)=0$ for $x_n$
- *    \State {\it appAction.execute(solutionHistory, stepper, AFTER\_SOLVE)}
- *    \State $\dot{x}_n \leftarrow (x_n-x_{n-1})/\Delta t_n$
- *    \State {\it appAction.execute(solutionHistory, stepper, END\_STEP)}
- *  \end{algorithmic}
+ *  \f{center}{
+ *    \parbox{5in}{
+ *    \rule{5in}{0.4pt} \\
+ *    {\bf Algorithm} Backward Euler \\
+ *    \rule{5in}{0.4pt} \vspace{-15pt}
+ *    \begin{enumerate}
+ *      \setlength{\itemsep}{0pt} \setlength{\parskip}{0pt} \setlength{\parsep}{0pt}
+ *      \item {\it appAction.execute(solutionHistory, stepper, BEGIN\_STEP)}
+ *      \item {\bf Compute the predictor} (e.g., apply stepper to $x_n$).
+ *      \item {\it appAction.execute(solutionHistory, stepper, BEGIN\_SOLVE)}
+ *      \item {\bf Solve $\mathcal{F}_n(\dot{x}=(x_n-x_{n-1})/\Delta t_n, x_n, t_n)=0$ for $x_n$}
+ *      \item {\it appAction.execute(solutionHistory, stepper, AFTER\_SOLVE)}
+ *      \item $\dot{x}_n \leftarrow (x_n-x_{n-1})/\Delta t_n$
+ *      \item {\it appAction.execute(solutionHistory, stepper, END\_STEP)}
+ *    \end{enumerate}
+ *    \vspace{-10pt} \rule{5in}{0.4pt}
+ *    }
  *  \f}
  *
  *  The First-Same-As-Last (FSAL) principle is not needed with Backward Euler.

--- a/packages/tempus/src/Tempus_StepperDIRK_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperDIRK_decl.hpp
@@ -62,54 +62,62 @@ namespace Tempus {
  *  <b> Algorithm </b>
  *  The single-timestep algorithm for DIRK is
  *
- *  \f{algorithm}{
- *  \renewcommand{\thealgorithm}{}
- *  \caption{DIRK with the application-action locations indicated.}
- *  \begin{algorithmic}[1]
- *    \If {``Reset initial guess.''}
- *      \State $X \leftarrow x_{n-1}$
- *        \Comment{Reset initial guess to last timestep.}
- *    \EndIf
- *    \State {\it appAction.execute(solutionHistory, stepper, BEGIN\_STEP)}
- *    \For {$i = 0 \ldots s-1$}
- *      \State $\tilde{X} \leftarrow
- *                      x_{n-1} +\Delta t \sum_{j=1}^{i-1} a_{ij}\,\dot{X}_{j}$
- *      \State {\it appAction.execute(solutionHistory, stepper, BEGIN\_STAGE)}
- *      \If { $a_{k,i} = 0 \;\forall k = (i+1,\ldots, s-1)$, $b(i) = 0$, $b^\ast(i) = 0$}
- *        \State $\dot{X}_i \leftarrow 0$
- *          \Comment{Not needed for later calculations.}
- *      \ElsIf {$a_{ii} = 0$}             \Comment{Explicit stage.}
- *        \If {$i=0$ and ``Use FSAL'' and (previous step not failed)}
- *          \State $\dot{X}_0 \leftarrow \dot{X}_{s-1}$
- *            \Comment{Use $\dot{X}_{s-1}$ from $n-1$ time step.}
- *        \Else
- *          \State $\dot{X}_i \leftarrow \bar{f}(\tilde{X},t_{n-1}+c_i\Delta t)$
- *        \EndIf
- *      \Else                          \Comment{Implicit stage.}
- *        \State {\it appAction.execute(solutionHistory, stepper, BEFORE\_SOLVE)}
- *        \If {``Zero initial guess.''}
- *          \State $X \leftarrow 0$
- *            \Comment{Else use previous stage value as initial guess.}
- *        \EndIf
- *        \State Solve $\mathcal{F}_i(
- *                      \dot{X}_i = \frac{X - \tilde{X}}{a_{ii} \Delta t},
- *                      X, t_{n-1}+c_{i}\Delta t) = 0$ for $X$
- *        \State {\it appAction.execute(solutionHistory, stepper, AFTER\_SOLVE)}
- *        \State $\dot{X}_i \leftarrow \frac{X - \tilde{X}}{a_{ii} \Delta t}$
- *      \EndIf
- *      \State {\it appAction.execute(solutionHistory, stepper, BEFORE\_EXPLICIT\_EVAL)}
- *      \State {\it appAction.execute(solutionHistory, stepper, END\_STAGE)}
- *    \EndFor
- *    \State $x_n \leftarrow x_{n-1} + \Delta t\,\sum_{i=0}^{s-1}b_i\,\dot{X}_i$
- *    \If {``Embedded''}  \Comment{Compute the local truncation error estimate.}
- *      \State $\mathbf{e} \leftarrow
- *                         \sum_{i=0}^{s-1} (b_i-b^\ast_i)\Delta t\,\dot{X}_i$
- *      \State $\tilde{\mathbf{e}} \leftarrow
- *             \mathbf{e}/(a_{tol} + \max(\|x_n\|, \|x_{n-1}\|)r_{tol})$
- *      \State $e_n \leftarrow \|\tilde{\mathbf{e}}\|_\infty$
- *    \EndIf
- *    \State {\it appAction.execute(solutionHistory, stepper, END\_STEP)}
- *  \end{algorithmic}
+ *  \f{center}{
+ *    \parbox{6in}{
+ *    \rule{6in}{0.4pt} \\
+ *    {\bf Algorithm} DIRK \\
+ *    \rule{6in}{0.4pt} \vspace{-15pt}
+ *    \begin{enumerate}
+ *      \setlength{\itemsep}{0pt} \setlength{\parskip}{0pt} \setlength{\parsep}{0pt}
+ *      \item {\bf if ("Reset Initial guess.") then}
+ *      \item \quad $X \leftarrow x_{n-1}$
+ *                  \hfill {\it * Reset initial guess to last timestep.}
+ *      \item {\bf endif}
+ *      \item {\it appAction.execute(solutionHistory, stepper, BEGIN\_STEP)}
+ *      \item {\bf for {$i = 0 \ldots s-1$}}
+ *      \item \quad $\tilde{X} \leftarrow
+ *                     x_{n-1} +\Delta t \sum_{j=1}^{i-1} a_{ij}\,\dot{X}_{j}$
+ *      \item \quad {\it appAction.execute(solutionHistory, stepper, BEGIN\_STAGE)}
+ *      \item \quad {\bf if ( $a_{k,i} = 0 \;\forall k = (i+1,\ldots, s-1)$, $b(i) = 0$, $b^\ast(i) = 0$) then}
+ *      \item \qquad  $\dot{X}_i \leftarrow 0$
+ *                    \hfill {\it * Not needed for later calculations.}
+ *      \item \quad {\bf else if ($a_{ii} = 0$) then}
+ *                  \hfill {\it * Explicit stage.}
+ *      \item \qquad  {\bf if ($i=0$ and ``Use FSAL'' and (previous step not failed))}
+ *      \item \qquad \quad  $\dot{X}_0 \leftarrow \dot{X}_{s-1}$
+ *                          \hfill {\it * Use $\dot{X}_{s-1}$ from $n-1$ time step.}
+ *      \item \qquad {\bf else}
+ *      \item \qquad \quad  $\dot{X}_i \leftarrow \bar{f}(\tilde{X},t_{n-1}+c_i\Delta t)$
+ *      \item \qquad {\bf endif}
+ *      \item \quad {\bf else}
+ *                  \hfill {\it * Implicit stage.}
+ *      \item \qquad  {\it appAction.execute(solutionHistory, stepper, BEFORE\_SOLVE)}
+ *      \item \qquad  {\bf if (``Zero initial guess.'')}
+ *      \item \qquad \quad  $X \leftarrow 0$
+ *                          \hfill {\it * Else use previous stage value as initial guess.}
+ *      \item \qquad {\bf endif}
+ *      \item \qquad {\bf Solve $\mathcal{F}_i(
+ *                                \dot{X}_i = \frac{X - \tilde{X}}{a_{ii} \Delta t},
+ *                                X, t_{n-1}+c_{i}\Delta t) = 0$ for $X$}
+ *      \item \qquad  {\it appAction.execute(solutionHistory, stepper, AFTER\_SOLVE)}
+ *      \item \qquad  $\dot{X}_i \leftarrow \frac{X - \tilde{X}}{a_{ii} \Delta t}$
+ *      \item \quad  {\bf endif}
+ *      \item \quad  {\it appAction.execute(solutionHistory, stepper, BEFORE\_EXPLICIT\_EVAL)}
+ *      \item \quad  {\it appAction.execute(solutionHistory, stepper, END\_STAGE)}
+ *      \item {\bf end for}
+ *      \item $x_n \leftarrow x_{n-1} + \Delta t\,\sum_{i=0}^{s-1}b_i\,\dot{X}_i$
+ *      \item {\bf if (``Embedded'') then}
+ *            \hfill {\it * Compute the local truncation error estimate.}
+ *      \item \quad  $\mathbf{e} \leftarrow
+ *                               \sum_{i=0}^{s-1} (b_i-b^\ast_i)\Delta t\,\dot{X}_i$
+ *      \item \quad  $\tilde{\mathbf{e}} \leftarrow
+ *                     \mathbf{e}/(a_{tol} + \max(\|x_n\|, \|x_{n-1}\|)r_{tol})$
+ *      \item \quad  $e_n \leftarrow \|\tilde{\mathbf{e}}\|_\infty$
+ *      \item {\bf endif}
+ *      \item {\it appAction.execute(solutionHistory, stepper, END\_STEP)}
+ *    \end{enumerate}
+ *    \vspace{-10pt} \rule{6in}{0.4pt}
+ *    }
  *  \f}
  *
  *  The First-Same-As-Last (FSAL) principle is not needed with DIRK, but
@@ -126,7 +134,7 @@ namespace Tempus {
  *  and \f$ \beta \equiv \frac{\partial x_n}{\partial x_n} = 1\f$. For the stage
  *  solutions, we have
  *  \f[
- *    \mathcal{F}_i = \dot{X}_{i} - \bar{f}(X_{i},t_{n-1}+c_{i}\Delta t) =0.
+ *    \mathcal{F}_i = \dot{X}_{i} - \bar{f}(X_{i},t_{n-1}+c_{i}\Delta t) = 0
  *  \f]
  *  where \f$\mathcal{F}_n \rightarrow \mathcal{F}_i\f$,
  *  \f$x_n \rightarrow X_{i}\f$, and

--- a/packages/tempus/src/Tempus_StepperExplicitRK_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperExplicitRK_decl.hpp
@@ -51,32 +51,37 @@ namespace Tempus {
  *  <b> Algorithm </b>
  *  The single-timestep algorithm for Explicit RK is
  *
- *  \f{algorithm}{
- *  \renewcommand{\thealgorithm}{}
- *  \caption{Explicit RK with the application-action locations indicated.}
- *  \begin{algorithmic}[1]
- *    \State $X \leftarrow x_{n-1}$ \Comment Set initial guess to last timestep.
- *    \State {\it appAction.execute(solutionHistory, stepper, BEGIN\_STEP)}
- *    \For {$i = 0 \ldots s-1$}
- *      \State $X \leftarrow x_{n-1}
- *                + \Delta t\,\sum_{j=1}^{i-1} a_{ij}\,\dot{X}_j$
- *      \State {\it appAction.execute(solutionHistory, stepper, BEGIN\_STAGE)}
- *      \State {\it appAction.execute(solutionHistory, stepper, BEFORE\_SOLVE)}
- *      \State {\it appAction.execute(solutionHistory, stepper, AFTER\_SOLVE)}
- *      \State {\it appAction.execute(solutionHistory, stepper, BEFORE\_EXPLICIT\_EVAL)}
- *      \If { i==0 and useFSAL and (previous step not failed) }
- *        \State tmp = $\dot{X}_0$
- *        \State $\dot{X}_0 = \dot{X}_s$
- *        \State $\dot{X}_s$ = tmp
- *        \State {\bf continue}
- *      \Else
- *        \State $\dot{X}_i \leftarrow \bar{f}(X_i,t_{n-1}+c_i\Delta t)$
- *      \EndIf
- *      \State {\it appAction.execute(solutionHistory, stepper, END\_STAGE)}
- *    \EndFor
- *    \State $x_n \leftarrow x_{n-1} + \Delta t\,\sum_{i=1}^{s}b_i\,\dot{X}_i$
- *    \State {\it appAction.execute(solutionHistory, stepper, END\_STEP)}
- *  \end{algorithmic}
+ *  \f{center}{
+ *    \parbox{5in}{
+ *    \rule{5in}{0.4pt} \\
+ *    {\bf Algorithm} Explicit RK \\
+ *    \rule{5in}{0.4pt} \vspace{-15pt}
+ *    \begin{enumerate}
+ *      \setlength{\itemsep}{0pt} \setlength{\parskip}{0pt} \setlength{\parsep}{0pt}
+ *      \item $X \leftarrow x_{n-1}$
+ *      \item {\it appAction.execute(solutionHistory, stepper, BEGIN\_STEP)}
+ *      \item {\bf for {$i = 0 \ldots s-1$}}
+ *      \item \quad $X \leftarrow x_{n-1}
+ *                    + \Delta t\,\sum_{j=1}^{i-1} a_{ij}\,\dot{X}_j$
+ *      \item \quad {\it appAction.execute(solutionHistory, stepper, BEGIN\_STAGE)}
+ *      \item \quad {\it appAction.execute(solutionHistory, stepper, BEFORE\_SOLVE)}
+ *      \item \quad {\it appAction.execute(solutionHistory, stepper, AFTER\_SOLVE)}
+ *      \item \quad {\it appAction.execute(solutionHistory, stepper, BEFORE\_EXPLICIT\_EVAL)}
+ *      \item \quad {\bf if (i=0 and useFSAL and (previous step not failed)) then}
+ *      \item \qquad  tmp = $\dot{X}_0$
+ *      \item \qquad  $\dot{X}_0 = \dot{X}_s$
+ *      \item \qquad  $\dot{X}_s$ = tmp
+ *      \item \qquad  {\bf continue}
+ *      \item \quad {\bf else}
+ *      \item \qquad  $\dot{X}_i \leftarrow \bar{f}(X_i,t_{n-1}+c_i\Delta t)$
+ *      \item \quad {\bf endif}
+ *      \item \quad {\it appAction.execute(solutionHistory, stepper, END\_STAGE)}
+ *      \item {\bf end for}
+ *      \item $x_n \leftarrow x_{n-1} + \Delta t\,\sum_{i=1}^{s}b_i\,\dot{X}_i$
+ *      \item {\it appAction.execute(solutionHistory, stepper, END\_STEP)}
+ *    \end{enumerate}
+ *    \vspace{-10pt} \rule{5in}{0.4pt}
+ *    }
  *  \f}
  *
  *   For Explicit RK, FSAL requires \f$c_1 = 0\f$, \f$c_s = 1\f$, and

--- a/packages/tempus/src/Tempus_StepperForwardEulerAppAction.hpp
+++ b/packages/tempus/src/Tempus_StepperForwardEulerAppAction.hpp
@@ -23,24 +23,12 @@ template<class Scalar> class StepperForwardEuler;
  *  This class provides a means to apply various actions with the ForwardEuler time step.
  *  The data available to this class is solution variables (through
  *  SolutionHistory), and stepper data (through the Stepper).  It allows
- *  the application to just observe this data (i.e., use but not change the
- *  data) to change any of it (USER BEWARE!).
+ *  the application to just observe this data, i.e., use but not change
+ *  any of it (USER BEWARE!).
  *
- *  Below is the ForwardEuler algorithm and includes the locations where the
- *  application can take actions (in italicized).
- *
- *  \f{algorithm}{
- *  \renewcommand{\thealgorithm}{}
- *  \caption{Forward Euler with the locations of the application actions indicated.}
- *  \begin{algorithmic}[1]
- *    \State Start with $x_n$, $\Delta t_n$
- *    \State {\it appAction.execute(solutionHistory, stepper, BEGIN\_STEP)}
- *    \State Form $f(x_{n},t_{n})$
- *    \State {\it appAction.execute(solutionHistory, stepper, BEFORE\_EXPLICIT\_EVAL)}
- *    \State Form $x_n \leftarrow x_{n} + \Delta t_n f(x_{n},t_n)$
- *    \State {\it appAction.execute(solutionHistory, stepper, END\_STEP)}
- *  \end{algorithmic}
- *  \f}
+ *  The locations for these AppAction calls
+ *  (StepperForwardEulerAppAction::ACTION_LOCATION) are shown in the
+ *  algorithm documentation of the StepperForwardEuler.
  */
 template<class Scalar>
 class StepperForwardEulerAppAction

--- a/packages/tempus/src/Tempus_StepperForwardEulerModifierBase.hpp
+++ b/packages/tempus/src/Tempus_StepperForwardEulerModifierBase.hpp
@@ -27,21 +27,11 @@ namespace Tempus {
  *  affecting the Stepper correctness, performance, accuracy and stability.
  *  Thus the user should be careful when accessing data through classes
  *  derived from the default modifier (i.e., USER BEWARE!!).
- * 
- *  \f{algorithm}{                                                                             
- *  \renewcommand{\thealgorithm}{}                                                             
- *  \caption{Forward Euler with the locations of the application actions indicated.}           
- *  \begin{algorithmic}[1]                                                                     
- *    \State Start with $x_n$, $\Delta t_n$                                                             
- *    \State {\it appAction.execute(solutionHistory, stepper, BEGIN\_STEP)}                             
- *    \State Form $f(x_{n},t_{n})$                                                                      
- *    \State {\it appAction.execute(solutionHistory, stepper, BEFORE\_EXPLICIT\_EVAL)}                  
- *    \State Form $x_n \leftarrow x_{n} + \Delta t_n f(x_{n},t_n)$                                      
- *    \State {\it appAction.execute(solutionHistory, stepper, END\_STEP)} 
- *  \end{algorithmic}                                                                         
- *  \f}                                                                                       
+ *
+ *  The locations for these AppAction calls
+ *  (StepperForwardEulerAppAction::ACTION_LOCATION) are shown in the
+ *  algorithm documentation of the StepperForwardEuler.
  */
-
 template<class Scalar>
 class StepperForwardEulerModifierBase
   : virtual public Tempus::StepperForwardEulerAppAction<Scalar>

--- a/packages/tempus/src/Tempus_StepperForwardEulerModifierXBase.hpp
+++ b/packages/tempus/src/Tempus_StepperForwardEulerModifierXBase.hpp
@@ -28,21 +28,10 @@ namespace Tempus {
  *  affecting the Stepper correctness, performance, accuracy and stability
  *  (i.e., USER BEWARE!!).
  *
- *  Below is the ForwardEuler algorithm with the locations of the ModifierX calls
- *  italicized.
- *
- *  \f{algorithm}{
- *  \renewcommand{\thealgorithm}{}
- *  \caption{Forward Euler with the locations of the application actions indicated}
- *  \begin{algorithmic}[1]
- *    \State Start with $x_n$, $\Delta t_n$
- *    \State {\it appAction.execute(solutionHistory, stepper, BEGIN\_STEP)}
- *    \State Form $f(x_{n},t_{n})$
- *    \State {\it appAction.execute(solutionHistory, stepper, BEFORE\_EXPLICIT\_EVAL)}
- *    \State Form $x_n \leftarrow x_{n} + \Delta t_n f(x_{n},t_n)$
- *    \State {\it appAction.execute(solutionHistory, stepper, END\_STEP)}
- *  \end{algorithmic}
- *  \f}
+ *  The locations of the StepperForwardEulerModifierXBase::MODIFIER_TYPE
+ *  which correspond to the AppAction calls
+ *  (StepperForwardEulerAppAction::ACTION_LOCATION) are shown in the
+ *  algorithm documentation of the StepperForwardEuler.
  */
 
 template<class Scalar>

--- a/packages/tempus/src/Tempus_StepperForwardEulerObserverBase.hpp
+++ b/packages/tempus/src/Tempus_StepperForwardEulerObserverBase.hpp
@@ -27,21 +27,9 @@ namespace Tempus {
  *  wishes to modify the solution and/or stepper data during the
  *  Stepper::takeStep, they should use the Modifier class (with care!).
  *
- *  Below is the ForwardEuler algorithm with the locations of the observe calls
- *  italicized.
- *
- *  \f{algorithm}{                                                                               
- *  \renewcommand{\thealgorithm}{}                                                               
- *  \caption{Forward Euler with the locations of the application actions indicated.}             
- *  \begin{algorithmic}[1]                                                                       
- *    \State Start with $x_n$, $\Delta t_n$                                                             
- *    \State {\it appAction.execute(solutionHistory, stepper, BEGIN\_STEP)}                             
- *    \State Form $f(x_{n},t_{n})$                                                                      
- *    \State {\it appAction.execute(solutionHistory, stepper, BEFORE\_EXPLICIT\_EVAL)}                  
- *    \State Form $x_n \leftarrow x_{n} + \Delta t_n f(x_{n},t_n)$                                      
- *    \State {\it appAction.execute(solutionHistory, stepper, END\_STEP)}    
- *  \end{algorithmic}                                                                            
- *  \f}                                                                                          
+ *  The locations for these AppAction calls
+ *  (StepperForwardEulerAppAction::ACTION_LOCATION) are shown in the
+ *  algorithm documentation of the StepperForwardEuler.
  */
 template<class Scalar>
 class StepperForwardEulerObserverBase

--- a/packages/tempus/src/Tempus_StepperForwardEuler_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperForwardEuler_decl.hpp
@@ -33,23 +33,30 @@ namespace Tempus {
  *
  *  <b> Algorithm </b>
  *  The single-timestep algorithm for Forward Euler is
- *  \f{algorithm}{
- *  \renewcommand{\thealgorithm}{}
- *  \caption{Forward Euler}
- *  \begin{algorithmic}[1]
- *    \State {\it appAction.execute(solutionHistory, stepper, BEGIN\_STEP)}
- *    \If { Not ``Use FSAL'' or (previous step failed)}
- *      \State {\it appAction.execute(solutionHistory, stepper, BEFORE\_EXPLICIT\_EVAL)}
- *      \State $\dot{x}_{n-1} \leftarrow \bar{f}(x_{n-1},t_{n-1})$
- *    \EndIf
- *    \State $x_{n} \leftarrow x_{n-1} + \Delta t\, \dot{x}_{n-1}$
- *        \Comment{Forward Euler update.}
- *    \If { ``Use FSAL'' }
- *      \State {\it appAction.execute(solutionHistory, stepper, BEFORE\_EXPLICIT\_EVAL)}
- *      \State $\dot{x}_n \leftarrow \bar{f}(x_{n},t_{n})$
- *    \EndIf
- *    \State {\it appAction.execute(solutionHistory, stepper, END\_STEP)}
- *  \end{algorithmic}
+ *
+ *  \f{center}
+ *    \parbox{5in}{
+ *    \rule{5in}{0.4pt} \\
+ *    {\bf Algorithm} Forward Euler \\
+ *    \rule{5in}{0.4pt} \vspace{-15pt}
+ *    \begin{enumerate}
+ *      \setlength{\itemsep}{0pt} \setlength{\parskip}{0pt} \setlength{\parsep}{0pt}
+ *      \item {\it appAction.execute(solutionHistory, stepper, BEGIN\_STEP)}
+ *      \item {\bf if (Not ``Use FSAL'' or (previous step failed)) then}
+ *      \item \quad  {\it appAction.execute(solutionHistory, stepper, BEFORE\_EXPLICIT\_EVAL)}
+ *      \item \quad  $\dot{x}_{n-1} \leftarrow \bar{f}(x_{n-1},t_{n-1})$
+ *      \item {\bf endif}
+ *      \item $x_{n} \leftarrow x_{n-1} + \Delta t\, \dot{x}_{n-1}$
+ *            \hfill {\it * Forward Euler update.}
+ *      \item {\it appAction.execute(solutionHistory, stepper, END\_STEP)}
+ *      \item {\bf if (``Use FSAL'') then}
+ *      \item \quad  {\it appAction.execute(solutionHistory, stepper, BEFORE\_EXPLICIT\_EVAL)}
+ *      \item \quad  $\dot{x}_n \leftarrow \bar{f}(x_{n},t_{n})$
+ *      \item {\bf endif}
+ *      \item {\it appAction.execute(solutionHistory, stepper, END\_STEP)}
+ *    \end{enumerate}
+ *    \vspace{-10pt} \rule{5in}{0.4pt}
+ *    }
  *  \f}
  *
  *  Note that with useFSAL=false \f$x_n\f$ and \f$\dot{x}_{n-1}\f$ are not

--- a/packages/tempus/src/Tempus_StepperHHTAlphaAppAction.hpp
+++ b/packages/tempus/src/Tempus_StepperHHTAlphaAppAction.hpp
@@ -23,24 +23,8 @@ template<class Scalar> class StepperHHTAlpha;
  *  This class provides a means to apply various actions with the HHT Alpha time step.
  *  The data available to this class is solution variables (through
  *  SolutionHistory), and stepper data (through the Stepper).  It allows
- *  the application to just observe this data (i.e., use but not change the
- *  data) to change any of it (USER BEWARE!).
- *
- *  Below is the HHT Alpha algorithm and includes the locations where the
- *  application can take actions (in italicized).
- *
- *  \f{algorithm}{
- *  \renewcommand{\thealgorithm}{}
- *  \caption{HHT Alpha with application-action locations indicated.}
- *  \begin{algorithmic}[1]
- *    \State {\it appAction.execute(solutionHistory, stepper, BEGIN\_STEP)}
- *    \State Compute the predictor (e.g., apply stepper to $x_n$).
- *    \State {\it appAction.execute(solutionHistory, stepper, BEFORE\_SOLVE)}
- *    \State Solve for $x_{n+1}$ using the HHT one-step update.                                                                                        *    \State {\it appAction.execute(solutionHistory, stepper, AFTER\_SOLVE)}
- *    \State Update $\dot x_{n+1}$.
- *    \State {\it appAction.execute(solutionHistory, stepper, END\_STEP)}
- *  \end{algorithmic}
- *  \f}
+ *  the application to just observe this data, i.e., use but not change
+ *  any of it (USER BEWARE!).
  */
 template<class Scalar>
 class StepperHHTAlphaAppAction

--- a/packages/tempus/src/Tempus_StepperHHTAlphaModifierBase.hpp
+++ b/packages/tempus/src/Tempus_StepperHHTAlphaModifierBase.hpp
@@ -28,23 +28,6 @@ namespace Tempus {
  *  affecting the Stepper correctness, performance, accuracy and stability.
  *  Thus the user should be careful when accessing data through classes
  *  derived from the default modifier (i.e., USER BEWARE!!).
- *
- *  Below is the HHTAlpha algorithm with the locations of the modify calls
- *  italicized.
- *
- *  \f{algorithm}{
- *  \renewcommand{\thealgorithm}{}
- *  \caption{HHTAlpha stepper with modify calls indicated.}
- *  \begin{algorithmic}[1]
- *    \State \quad {\it modifier.modify(solutionHistory, stepper, BEGIN\_STEP)}
- *    \State Compute the predictor (e.g., apply stepper to $x_n$).
- *    \State \quad {\it modifier.modify(solutionHistory, stepper, BEFORE\_SOLVE)}
- *    \State Solve for $x_{n+1}$ using the HHT one-step update.                                                                                       
- *    \State \quad {\it modifier.modify(solutionHistory, stepper, AFTER\_SOLVE)}
- *    \State Update $\dot x_{n+1}$.           
- *    \State \quad {\it modifier.modify(solutionHistory, stepper, END\_STEP)}
- *  \end{algorithmic}
- *  \f}
  */
 template<class Scalar>
 class StepperHHTAlphaModifierBase

--- a/packages/tempus/src/Tempus_StepperHHTAlphaModifierXBase.hpp
+++ b/packages/tempus/src/Tempus_StepperHHTAlphaModifierXBase.hpp
@@ -27,23 +27,6 @@ namespace Tempus {
  *  It is expected that the user knows what changes are allowable without
  *  affecting the Stepper correctness, performance, accuracy and stability
  *  (i.e., USER BEWARE!!).
- *
- *  Below is the HHTAlpha algorithm with the locations of the ModifierX calls
- *  italicized.
- *
- *  \f{algorithm}{
- *  \renewcommand{\thealgorithm}{}
- *  \caption{HHTAlpha algorithm with modify calls indicated.}
- *  \begin{algorithmic}[1]
- *    \State \quad {\it modifierX.modify(x, time, dt, X\_BEGIN\_STEP)}
- *    \State Compute the predictor (e.g., apply stepper to $x_n$).
- *    \State \quad {\it modifierX.modify(x, time, dt, X\_BEFORE\_SOLVE)}
- *    \State Solve for $x_{n+1}$ using the HHT one-step update.       
- *    \State \quad {\it modifierX.modify(x, time, dt, X\_AFTER\_SOLVE)}                                                           
- *    \State Update $\dot x_{n+1}$.   
- *    \State \quad {\it modifierX.modify(x, time, dt, X\_END\_STEP)}
- *  \end{algorithmic}
- *  \f}
  */
 template<class Scalar>
 class StepperHHTAlphaModifierXBase

--- a/packages/tempus/src/Tempus_StepperHHTAlphaObserverBase.hpp
+++ b/packages/tempus/src/Tempus_StepperHHTAlphaObserverBase.hpp
@@ -26,23 +26,6 @@ namespace Tempus {
  *  expected that users will NOT modify any of that data.  If the user
  *  wishes to modify the solution and/or stepper data during the
  *  Stepper::takeStep, they should use the Modifier class (with care!).
- *
- *  Below is the HHTAlpha algorithm with the locations of the observe calls
- *  italicized.
- *
- *  \f{algorithm}{
- *  \renewcommand{\thealgorithm}{}
- *  \caption{HHTAlpha with observe calls indicated.}
- *  \begin{algorithmic}[1]
- *    \State \quad {\it observer.observe(solutionHistory, stepper, BEGIN\_STEP)}
- *    \State Compute the predictor (e.g., apply stepper to $x_n$).
- *    \State \quad {\it observer.observe(solutionHistory, stepper, BEFORE\_SOLVE)}
- *    \State Solve for $x_{n+1}$ using the HHT one-step update.
- *    \State \quad {\it observer.observe(solutionHistory, stepper, AFTER\_SOLVE)}
- *    \State Update $\dot x_{n+1}$.
- *    \State \quad {\it observer.observe(solutionHistory, stepper, END\_STEP)}
- *  \end{algorithmic}
- *  \f}
  */
 template<class Scalar>
 class StepperHHTAlphaObserverBase

--- a/packages/tempus/src/Tempus_StepperIMEX_RK_Partition_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperIMEX_RK_Partition_decl.hpp
@@ -210,51 +210,58 @@ namespace Tempus {
  *  but again note that the explicit term, \f$f^x(X_i,Y_i,t_i)\f$,
  *  is evaluated at the implicit stage time, \f$t_i\f$.
  *
- *  <b> Partitioned IMEX-RK Algorithm </b>
+ *  <b> Algorithm </b>
  *  The single-timestep algorithm for the partitioned IMEX-RK is
- *  \f{algorithm}{
- *  \renewcommand{\thealgorithm}{}
- *  \caption{IMEX RK with the application-action locations indicated.}
- *  \begin{algorithmic}[1]
- *    \State $Z \leftarrow z_{n-1}$ (Recall $Z_i = \{Y_i,X_i\}^T$)
- *    \State {\it appAction.execute(solutionHistory, stepper, BEGIN\_STEP)}
- *      \Comment Set initial guess to last timestep.
- *    \For {$i = 0 \ldots s-1$}
- *      \State $Y_i = y_{n-1} -\Delta t \sum_{j=1}^{i-1} \hat{a}_{ij}\;f^y_j$
- *      \State $\tilde{X} \leftarrow x_{n-1} - \Delta t\,\sum_{j=1}^{i-1} \left[
- *                 \hat{a}_{ij}\, f^x_j + a_{ij}\, g^x_j \right]$
- *      \State {\it appAction.execute(solutionHistory, stepper, BEGIN\_STAGE)}
- *      \State \Comment Implicit Tableau
- *      \If {$a_{ii} = 0$}
- *        \State $X_i   \leftarrow \tilde{X}$
- *        \If {$a_{k,i} = 0 \;\forall k = (i+1,\ldots, s-1)$, $b(i) = 0$, $b^\ast(i) = 0$}
- *          \State $g^x_i \leftarrow 0$ \Comment{Not needed for later calculations.}
- *        \Else
- *          \State $g^x_i \leftarrow g^x(X_i,Y_i,t_i)$
- *        \EndIf
- *      \Else
- *        \State {\it appAction.execute(solutionHistory, stepper, BEFORE\_SOLVE)}
- *        \If {``Zero initial guess.''}
- *          \State $X \leftarrow 0$
- *            \Comment{Else use previous stage value as initial guess.}
- *        \EndIf
- *        \State Solve $\mathcal{G}^x\left(\tilde{\dot{X}}
- *            = \frac{X-\tilde{X}}{a_{ii} \Delta t},X,Y,t_i\right) = 0$
- *              for $X$ where $Y$ are known parameters
- *        \State {\it appAction.execute(solutionHistory, stepper, AFTER\_SOLVE)}
- *        \State $\tilde{\dot{X}} \leftarrow \frac{X - \tilde{X}}{a_{ii} \Delta t}$
- *        \State $g_i \leftarrow - \tilde{\dot{X}}$
- *      \EndIf
- *      \State \Comment Explicit Tableau
- *      \State {\it appAction.execute(solutionHistory, stepper, BEFORE\_EXPLICIT\_EVAL)}
- *      \State $f_i \leftarrow M(X,\hat{t}_i)^{-1}\, F(X,\hat{t}_i)$
- *      \State $\dot{Z} \leftarrow - g(Z_i,t_i) - f(Z_i,t_i)$ [Optionally]
- *      \State {\it appAction.execute(solutionHistory, stepper, END\_STAGE)}
- *    \EndFor
- *    \State $z_n = z_{n-1} - \Delta t\,\sum_{i=1}^{s}\hat{b}_i\, f_i$
- *    \State $x_n \mathrel{+{=}} - \Delta t\,\sum_{i=1}^{s} b_i\, g^x_i$
- *    \State {\it appAction.execute(solutionHistory, stepper, END\_STEP)}
- *  \end{algorithmic}
+ *
+ *  \f{center}{
+ *    \parbox{5in}{
+ *    \rule{5in}{0.4pt} \\
+ *    {\bf Algorithm} Partitioned IMEX-RK \\
+ *    \rule{5in}{0.4pt} \vspace{-15pt}
+ *    \begin{enumerate}
+ *      \setlength{\itemsep}{0pt} \setlength{\parskip}{0pt} \setlength{\parsep}{0pt}
+ *      \item $Z \leftarrow z_{n-1}$
+ *            \hfill {\it * Recall $Z_i = \{Y_i,X_i\}^T$}
+ *      \item {\it appAction.execute(solutionHistory, stepper, BEGIN\_STEP)}
+ *      \item {\bf for ($i = 0 \ldots s-1$)}
+ *      \item \quad  $Y_i = y_{n-1} -\Delta t \sum_{j=1}^{i-1} \hat{a}_{ij}\;f^y_j$
+ *      \item \quad  $\tilde{X} \leftarrow x_{n-1} - \Delta t\,\sum_{j=1}^{i-1} \left[
+ *                                       \hat{a}_{ij}\, f^x_j + a_{ij}\, g^x_j \right]$
+ *      \item \quad  {\it appAction.execute(solutionHistory, stepper, BEGIN\_STAGE)}
+ *      \item \quad  \hfill {\bf Implicit Tableau}
+ *      \item \quad  {\bf if ($a_{ii} = 0$) then}
+ *      \item \qquad    $X_i   \leftarrow \tilde{X}$
+ *      \item \qquad    {\bf if ($a_{k,i} = 0 \;\forall k = (i+1,\ldots, s-1)$, $b(i) = 0$, $b^\ast(i) = 0$) then}
+ *      \item \qquad \quad  $g^x_i \leftarrow 0$
+ *                          \hfill {\it * Not needed for later calculations.}
+ *      \item \qquad    {\bf else}
+ *      \item \qquad \quad  $g^x_i \leftarrow g^x(X_i,Y_i,t_i)$
+ *      \item \qquad    {\bf endif}
+ *      \item \quad  {\bf else}
+ *      \item \qquad  {\it appAction.execute(solutionHistory, stepper, BEFORE\_SOLVE)}
+ *      \item \qquad  {\bf if (``Zero initial guess.'') then}
+ *      \item \qquad \quad   $X \leftarrow 0$
+ *                           \hfill {\it * Else use previous stage value as initial guess.}
+ *      \item \qquad  {\bf endif}
+ *      \item \qquad  {\bf Solve $\mathcal{G}^x\left(\tilde{\dot{X}}
+ *                          = \frac{X-\tilde{X}}{a_{ii} \Delta t},X,Y,t_i\right) = 0$
+ *                            for $X$ where $Y$ is known.}
+ *      \item \qquad   {\it appAction.execute(solutionHistory, stepper, AFTER\_SOLVE)}
+ *      \item \qquad   $\tilde{\dot{X}} \leftarrow \frac{X - \tilde{X}}{a_{ii} \Delta t}$
+ *      \item \qquad   $g_i \leftarrow - \tilde{\dot{X}}$
+ *      \item \quad  {\bf endif}
+ *      \item \quad  \hfill {\bf Explicit Tableau}
+ *      \item \quad  {\it appAction.execute(solutionHistory, stepper, BEFORE\_EXPLICIT\_EVAL)}
+ *      \item \quad  $f_i \leftarrow M(X,\hat{t}_i)^{-1}\, F(X,\hat{t}_i)$
+ *      \item \quad  $\dot{Z} \leftarrow - g(Z_i,t_i) - f(Z_i,t_i)$ [Optionally]
+ *      \item \quad  {\it appAction.execute(solutionHistory, stepper, END\_STAGE)}
+ *      \item {\bf end for}
+ *      \item $z_n = z_{n-1} - \Delta t\,\sum_{i=1}^{s}\hat{b}_i\, f_i$
+ *      \item $x_n \mathrel{+{=}} - \Delta t\,\sum_{i=1}^{s} b_i\, g^x_i$
+ *      \item {\it appAction.execute(solutionHistory, stepper, END\_STEP)}
+ *    \end{enumerate}
+ *    \vspace{-10pt} \rule{5in}{0.4pt}
+ *    }
  *  \f}
  *
  *  The following table contains the pre-coded IMEX-RK tableaus.

--- a/packages/tempus/src/Tempus_StepperIMEX_RK_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperIMEX_RK_decl.hpp
@@ -148,46 +148,53 @@ namespace Tempus {
  *
  *  The single-timestep algorithm for IMEX-RK is
  *
- *  \f{algorithm}{
- *  \renewcommand{\thealgorithm}{}
- *  \caption{IMEX RK with the application-action locations indicated.}
- *  \begin{algorithmic}[1]
- *    \State $X \leftarrow x_{n-1}$ \Comment Set initial guess to last timestep.
- *    \State {\it appAction.execute(solutionHistory, stepper, BEGIN\_STEP)}
- *    \For {$i = 0 \ldots s-1$}
- *      \State $\tilde{X} \leftarrow x_{n-1} - \Delta t\,\sum_{j=1}^{i-1} \left(
- *            \hat{a}_{ij}\, f_j + a_{ij}\, g_j \right)$
- *      \State {\it appAction.execute(solutionHistory, stepper, BEGIN\_STAGE)}
- *      \State \Comment Implicit Tableau
- *      \If {$a_{ii} = 0$}
- *        \State $X \leftarrow \tilde{X}$
- *        \If {$a_{k,i} = 0 \;\forall k = (i+1,\ldots, s-1)$, $b(i) = 0$, $b^\ast(i) = 0$}
- *          \State $g_i \leftarrow 0$ \Comment{Not needed for later calculations.}
- *        \Else
- *          \State $g_i \leftarrow M(X, t_i)^{-1}\, G(X, t_i)$
- *        \EndIf
- *      \Else
- *        \State {\it appAction.execute(solutionHistory, stepper, BEFORE\_SOLVE)}
- *        \If {``Zero initial guess.''}
- *          \State $X \leftarrow 0$
- *            \Comment{Else use previous stage value as initial guess.}
- *        \EndIf
- *        \State Solve $\mathcal{G}\left(\tilde{\dot{X}}
- *            = \frac{X-\tilde{X}}{a_{ii} \Delta t},X,t_i\right) = 0$ for $X$
- *        \State {\it appAction.execute(solutionHistory, stepper, AFTER\_SOLVE)}
- *        \State $\tilde{\dot{X}} \leftarrow \frac{X - \tilde{X}}{a_{ii} \Delta t}$
- *        \State $g_i \leftarrow - \tilde{\dot{X}}$
- *      \EndIf
- *      \State \Comment Explicit Tableau
- *      \State {\it appAction.execute(solutionHistory, stepper, BEFORE\_EXPLICIT\_EVAL)}
- *      \State $f_i \leftarrow M(X,\hat{t}_i)^{-1}\, F(X,\hat{t}_i)$
- *      \State $\dot{X} \leftarrow - g_i - f_i$ [Optionally]
- *      \State {\it appAction.execute(solutionHistory, stepper, END\_STAGE)}
- *    \EndFor
- *    \State $x_n \leftarrow x_{n-1} - \Delta t\,\sum_{i=1}^{s}\hat{b}_i\,f_i
- *                                   - \Delta t\,\sum_{i=1}^{s}     b_i \,g_i$
- *    \State {\it appAction.execute(solutionHistory, stepper, END\_STEP)}
- *  \end{algorithmic}
+ *  \f{center}{
+ *    \parbox{5in}{
+ *    \rule{5in}{0.4pt} \\
+ *    {\bf Algorithm} IMEX-RK \\
+ *    \rule{5in}{0.4pt} \vspace{-15pt}
+ *    \begin{enumerate}
+ *      \setlength{\itemsep}{0pt} \setlength{\parskip}{0pt} \setlength{\parsep}{0pt}
+ *      \item $X \leftarrow x_{n-1}$
+ *               \hfill {\it * Reset initial guess to last timestep.}
+ *      \item {\it appAction.execute(solutionHistory, stepper, BEGIN\_STEP)}
+ *      \item {\bf for {$i = 0 \ldots s-1$}}
+ *      \item \quad  $\tilde{X} \leftarrow x_{n-1} - \Delta t\,\sum_{j=1}^{i-1} \left(
+ *                                           \hat{a}_{ij}\, f_j + a_{ij}\, g_j \right)$
+ *      \item \quad  {\it appAction.execute(solutionHistory, stepper, BEGIN\_STAGE)}
+ *      \item \quad  \hfill {\bf Implicit Tableau}
+ *      \item \quad  {\bf if ($a_{ii} = 0$) then}
+ *      \item \qquad   $X \leftarrow \tilde{X}$
+ *      \item \qquad  {\bf if ($a_{k,i} = 0 \;\forall k = (i+1,\ldots, s-1)$, $b(i) = 0$, $b^\ast(i) = 0$) then}
+ *      \item \qquad \quad  $g_i \leftarrow 0$
+ *                          \hfill {\it * Not needed for later calculations.}
+ *      \item \qquad  {\bf else}
+ *      \item \qquad \quad  $g_i \leftarrow M(X, t_i)^{-1}\, G(X, t_i)$
+ *      \item \qquad  {\bf endif}
+ *      \item \quad  {\bf else}
+ *      \item \qquad  {\it appAction.execute(solutionHistory, stepper, BEFORE\_SOLVE)}
+ *      \item \qquad  {\bf if (``Zero initial guess.'') then}
+ *      \item \qquad \quad  $X \leftarrow 0$
+ *                          \hfill {\it * Else use previous stage value as initial guess.}
+ *      \item \qquad  {\bf endif}
+ *      \item \qquad  {\bf Solve $\mathcal{G}\left(\tilde{\dot{X}}
+ *                    = \frac{X-\tilde{X}}{a_{ii} \Delta t},X,t_i\right) = 0$ for $X$}
+ *      \item \qquad  {\it appAction.execute(solutionHistory, stepper, AFTER\_SOLVE)}
+ *      \item \qquad  $\tilde{\dot{X}} \leftarrow \frac{X - \tilde{X}}{a_{ii} \Delta t}$
+ *      \item \qquad  $g_i \leftarrow - \tilde{\dot{X}}$
+ *      \item \quad  {\bf endif}
+ *      \item \quad  \hfill {\bf Explicit Tableau}
+ *      \item \quad  {\it appAction.execute(solutionHistory, stepper, BEFORE\_EXPLICIT\_EVAL)}
+ *      \item \quad  $f_i \leftarrow M(X,\hat{t}_i)^{-1}\, F(X,\hat{t}_i)$
+ *      \item \quad  $\dot{X} \leftarrow - g_i - f_i$ [Optionally]
+ *      \item \quad  {\it appAction.execute(solutionHistory, stepper, END\_STAGE)}
+ *      \item {\bf end for}
+ *      \item $x_n \leftarrow x_{n-1} - \Delta t\,\sum_{i=1}^{s}\hat{b}_i\,f_i
+ *                                    - \Delta t\,\sum_{i=1}^{s}     b_i \,g_i$
+ *      \item {\it appAction.execute(solutionHistory, stepper, END\_STEP)}
+ *    \end{enumerate}
+ *    \vspace{-10pt} \rule{5in}{0.4pt}
+ *    }
  *  \f}
  *
  *  The following table contains the pre-coded IMEX-RK tableaus.

--- a/packages/tempus/src/Tempus_StepperLeapfrogAppAction.hpp
+++ b/packages/tempus/src/Tempus_StepperLeapfrogAppAction.hpp
@@ -23,27 +23,12 @@ template<class Scalar> class StepperLeapfrog;
  *  This class provides a means to apply various actions with the Leapfrog time step.
  *  The data available to this class is solution variables (through
  *  SolutionHistory), and stepper data (through the Stepper).  It allows
- *  the application to just observe this data (i.e., use but not change the
- *  data) to change any of it (USER BEWARE!).
+ *  the application to just observe this data, i.e., use but not change
+ *  any of it (USER BEWARE!).
  *
- *  Below is the Leapfrog algorithm and includes the locations where the
- *  application can take actions (in italicized).
- *
- *  \f{algorithm}{
- *  \renewcommand{\thealgorithm}{}
- *  \caption{Leapfrog with the locations of the application actions indicated.}
- *  \begin{algorithmic}[1]
- *    \State \quad {\it appAction.execute(solutionHistory, stepper, BEGIN\_STEP)}
- *    \State Compute $\dot{x}_{n+1/2} = \dot{x}_n + 0.5\Delta t \ddot{x}_n$
- *    \State \quad {\it appAction.execute(solutionHistory, stepper, BEFORE\_X\_UPDATE)}
- *    \State Compute $x_{n+1} = x_n + \Delta t \dot{x}_{n+1/2}$
- *    \State \quad {\it appAction.execute(solutionHistory, stepper, BEFORE\_EXPLICIT\_EVAL)}
- *    \State Evaluate $\ddot{x}_{n+1} = f(x_{n+1},t_{n+1})$
- *    \State \quad {\it appAction.execute(solutionHistory, stepper, BEFORE\_XDOT\_UPDATE)}
- *    \State Compute half-step sync $\dot{x}_{n+1} = \dot{x}_{n+1/2} + 0.5 \Delta t \ddot{x}_{n+1}$ or full step
-$\dot{x}_{n+3/2} = \dot{x}_{n+1/2} + \Delta t \ddot{x}_{n+1}$
- *  \end{algorithmic}
- *  \f}
+ *  The locations for these AppAction calls
+ *  (StepperLeapfrogAppAction::ACTION_LOCATION) are shown in the
+ *  algorithm documentation of the StepperLeapfrog.
  */
 template<class Scalar>
 class StepperLeapfrogAppAction
@@ -52,12 +37,11 @@ public:
 
   /// Indicates the location of application action (see algorithm).
   enum ACTION_LOCATION {
-    BEGIN_STEP,     ///< At the beginning of the step.
-    BEFORE_XDOT_UPDATE_INITIALIZE, // Before updating xDot while initializing xDotDot
-    BEFORE_X_UPDATE, //  Before updating x
-    BEFORE_EXPLICIT_EVAL,   /// Before the explicit ME evaluation.
-    BEFORE_XDOT_UPDATE, /// Before updating xDot
-    END_STEP        ///< At the end of the step.
+    BEGIN_STEP,             ///< At the beginning of the step.
+    BEFORE_X_UPDATE,        ///< Before updating x
+    BEFORE_EXPLICIT_EVAL,   ///< Before the explicit ME evaluation.
+    BEFORE_XDOT_UPDATE,     ///< Before updating xDot
+    END_STEP                ///< At the end of the step.
   };
 
   /// Constructor

--- a/packages/tempus/src/Tempus_StepperLeapfrogModifierBase.hpp
+++ b/packages/tempus/src/Tempus_StepperLeapfrogModifierBase.hpp
@@ -27,14 +27,10 @@ namespace Tempus {
  *  affecting the Stepper correctness, performance, accuracy and stability.
  *  Thus the user should be careful when accessing data through classes
  *  derived from the default modifier (i.e., USER BEWARE!!).
- * 
- *  \f{algorithm}{                                                                             
- *  \renewcommand{\thealgorithm}{}                                                             
- *  \caption{Leapfrog with the locations of the application actions indicated.}           
- *  \begin{algorithmic}[1]                                                                     
- *    TODO
- *  \end{algorithmic}                                                                         
- *  \f}                                                                                       
+ *
+ *  The locations for these AppAction calls
+ *  (StepperLeapfrogAppAction::ACTION_LOCATION) are shown in the
+ *  algorithm documentation of the StepperLeapfrog.
  */
 
 template<class Scalar>

--- a/packages/tempus/src/Tempus_StepperLeapfrogModifierDefault.hpp
+++ b/packages/tempus/src/Tempus_StepperLeapfrogModifierDefault.hpp
@@ -41,7 +41,6 @@ public:
   {
     switch(actLoc) {
       case StepperLeapfrogAppAction<Scalar>::BEGIN_STEP:
-      case StepperLeapfrogAppAction<Scalar>::BEFORE_XDOT_UPDATE_INITIALIZE:
       case StepperLeapfrogAppAction<Scalar>::BEFORE_X_UPDATE:
       case StepperLeapfrogAppAction<Scalar>::BEFORE_EXPLICIT_EVAL:
       case StepperLeapfrogAppAction<Scalar>::BEFORE_XDOT_UPDATE:

--- a/packages/tempus/src/Tempus_StepperLeapfrogModifierXBase.hpp
+++ b/packages/tempus/src/Tempus_StepperLeapfrogModifierXBase.hpp
@@ -28,24 +28,10 @@ namespace Tempus {
  *  affecting the Stepper correctness, performance, accuracy and stability
  *  (i.e., USER BEWARE!!).
  *
- *  Below is the Leapfrog algorithm with the locations of the ModifierX calls
- *  italicized.
- *
- *  \f{algorithm}{
- *  \renewcommand{\thealgorithm}{}
- *  \caption{Leapfrog with the locations of the application actions indicated}
- *  \begin{algorithmic}[1]
- *    \State \quad {\it appAction.execute(solutionHistory, stepper, X\_BEGIN\_STEP)}                            
- *    \State Compute $\dot{x}_{n+1/2} = \dot{x}_n + 0.5\Delta t \ddot{x}_n$                                      
- *    \State \quad {\it appAction.execute(solutionHistory, stepper, X\_BEFORE\_X\_UPDATE)}                      
- *    \State Compute $x_{n+1} = x_n + \Delta t \dot{x}_{n+1/2}$                                                  
- *    \State \quad {\it appAction.execute(solutionHistory, stepper, X\_BEFORE\_EXPLICIT\_EVAL)}                
- *    \State Evaluate $\ddot{x}_{n+1} = f(x_{n+1},t_{n+1})$                                                      
- *    \State \quad {\it appAction.execute(solutionHistory, stepper, X\_BEFORE\_XDOT\_UPDATE)}          
- *    \State Compute half-step sync $\dot{x}_{n+1} = \dot{x}_{n+1/2} + 0.5 \Delta t \ddot{x}_{n+1}$ or full step 
-$\dot{x}_{n+3/2} = \dot{x}_{n+1/2} + \Delta t \ddot{x}_{n+1}$     
- *  \end{algorithmic}
- *  \f}
+ *  The locations of the StepperLeapfrogModifierXBase::MODIFIER_TYPE
+ *  which correspond to the AppAction calls
+ *  (StepperLeapfrogAppAction::ACTION_LOCATION) are shown in the
+ *  algorithm documentation of the StepperLeapfrog.
  */
 
 template<class Scalar>
@@ -87,12 +73,6 @@ private:
         x = workingState->getX();
         break;
       }
-      case StepperLeapfrogAppAction<Scalar>::BEFORE_XDOT_UPDATE_INITIALIZE:
-      {
-        modType = X_BEFORE_XDOT_UPDATE_INITIALIZE;
-        x = workingState->getX();
-        break;
-      }
       case StepperLeapfrogAppAction<Scalar>::BEFORE_X_UPDATE:
       {
         modType = X_BEFORE_X_UPDATE;
@@ -114,7 +94,7 @@ private:
       case StepperLeapfrogAppAction<Scalar>::END_STEP:
       {
         modType = X_END_STEP;
-        x = stepper->getStepperX();
+        x = workingState->getX();
         break;
       }
       default:
@@ -129,12 +109,11 @@ public:
 
   /// Indicates the location of application action (see algorithm).
   enum MODIFIER_TYPE {
-    X_BEGIN_STEP,     ///< Modify \f$x\f$ at the beginning of the step.
-    X_BEFORE_XDOT_UPDATE_INITIALIZE,     ///< Modify \f$x\f$ before updating xDot while initializing xDotDot
-    X_BEFORE_X_UPDATE,     ///< Modify \f$x\f$ before updating x   
-    X_BEFORE_EXPLICIT_EVAL,   ///< Modify \f$x\f$ before the explicit ME evaluation
-    X_BEFORE_XDOT_UPDATE, //Modify \f$x\f$ Before updating xDot 
-    X_END_STEP     ///< Modify \f$\dot{x}\f$ at the end of the step.
+    X_BEGIN_STEP,           ///< Modify \f$x\f$ at the beginning of the step.
+    X_BEFORE_X_UPDATE,      ///< Modify \f$x\f$ before updating x
+    X_BEFORE_EXPLICIT_EVAL, ///< Modify \f$x\f$ before the explicit ME evaluation
+    X_BEFORE_XDOT_UPDATE,   ///< Modify \f$x\f$ Before updating xDot
+    X_END_STEP              ///< Modify \f$\dot{x}\f$ at the end of the step.
   };
 
   /// Modify solution based on the MODIFIER_TYPE.

--- a/packages/tempus/src/Tempus_StepperLeapfrogModifierXDefault.hpp
+++ b/packages/tempus/src/Tempus_StepperLeapfrogModifierXDefault.hpp
@@ -41,7 +41,6 @@ public:
   {
     switch(modType) {
       case StepperLeapfrogModifierXBase<Scalar>::X_BEGIN_STEP:
-      case StepperLeapfrogModifierXBase<Scalar>::X_BEFORE_XDOT_UPDATE_INITIALIZE:
       case StepperLeapfrogModifierXBase<Scalar>::X_BEFORE_X_UPDATE:
       case StepperLeapfrogModifierXBase<Scalar>::X_BEFORE_EXPLICIT_EVAL:
       case StepperLeapfrogModifierXBase<Scalar>::X_BEFORE_XDOT_UPDATE:

--- a/packages/tempus/src/Tempus_StepperLeapfrogObserverBase.hpp
+++ b/packages/tempus/src/Tempus_StepperLeapfrogObserverBase.hpp
@@ -27,23 +27,9 @@ namespace Tempus {
  *  wishes to modify the solution and/or stepper data during the
  *  Stepper::takeStep, they should use the Modifier class (with care!).
  *
- *  Below is the Leapfrog algorithm with the locations of the observe calls
- *  italicized.
- *
- *  \f{algorithm}{                                                                               
- *  \renewcommand{\thealgorithm}{}                                                               
- *  \caption{Leapfrog with the locations of the application actions indicated.}             
- *  \begin{algorithmic}[1]
- *    \State \quad {\it observer.observe(solutionHistory, stepper, BEGIN\_STEP)}
- *    \State Compute $\dot{x}_{n+1/2} = \dot{x}_n + 0.5\Delta t \ddot{x}_n$
- *    \State \quad {\it observer.observe(solutionHistory, stepper, BEFORE\_X\_UPDATE)}
- *    \State Compute $x_{n+1} = x_n + \Delta t \dot{x}_{n+1/2}$
- *    \State \quad {\it observer.observe(solutionHistory, stepper, BEFORE\_EXPLICIT\_EVAL)}
- *    \State Evaluate $\ddot{x}_{n+1} = f(x_{n+1},t_{n+1})$
- *    \State \quad {\it observer.observe(solutionHistory, stepper, BEFORE\_XDOT\_UPDATE)}
- *    \State Compute half-step sync $\dot{x}_{n+1} = \dot{x}_{n+1/2} + 0.5 \Delta t \ddot{x}_{n+1}$ or full step $\dot{x}_{n+3/2} = \dot{x}_{n+1/2} + \Delta t \ddot{x}_{n+1}$
- *  \end{algorithmic}                                                                            
- *  \f}                                                                                          
+ *  The locations for these AppAction calls
+ *  (StepperLeapfrogAppAction::ACTION_LOCATION) are shown in the
+ *  algorithm documentation of the StepperLeapfrog.
  */
 template<class Scalar>
 class StepperLeapfrogObserverBase

--- a/packages/tempus/src/Tempus_StepperLeapfrogObserverDefault.hpp
+++ b/packages/tempus/src/Tempus_StepperLeapfrogObserverDefault.hpp
@@ -41,7 +41,6 @@ public:
   {
     switch(actLoc) {
       case StepperLeapfrogAppAction<Scalar>::BEGIN_STEP:
-      case StepperLeapfrogAppAction<Scalar>::BEFORE_XDOT_UPDATE_INITIALIZE:
       case StepperLeapfrogAppAction<Scalar>::BEFORE_X_UPDATE:
       case StepperLeapfrogAppAction<Scalar>::BEFORE_EXPLICIT_EVAL:
       case StepperLeapfrogAppAction<Scalar>::BEFORE_XDOT_UPDATE:

--- a/packages/tempus/src/Tempus_StepperLeapfrog_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperLeapfrog_decl.hpp
@@ -51,22 +51,41 @@ namespace Tempus {
  *  \f}
  *
  *  <b> Algorithm </b>
+ *  The single-timestep algorithm for Leapfrog is
  *
- *  Beginning with \f$(x_n,\dot{x}_{n+1/2})\f$ or \f$(x_n,\dot{x}_{n})\f$
- *  and/or ending with \f$(x_{n+1},\dot{x}_{n+3/2})\f$ or
- *  \f$(x_{n+1},\dot{x}_{n+1})\f$, the algorithm for Leapfrog is
- *   - if "startup"
- *     - \f$ \ddot{x}_{n} \leftarrow f(x_{n},t_{n}) \f$
- *     - \f$ \dot{x}_{n+1/2} \leftarrow
- *           \dot{x}_{n} + \frac{1}{2} \Delta t\, \ddot{x}_{n} \f$
- *   - \f$x_{n+1} \leftarrow x_{n} + \Delta t\, \dot{x}_{n+1/2} \f$
- *   - \f$\ddot{x}_{n+1} \leftarrow f(x_{n+1},t_{n+1}) \f$
- *   - if "ending"
- *     - \f$ \dot{x}_{n+1} \leftarrow
- *           \dot{x}_{n+1/2} +\frac{1}{2} \Delta t\, \ddot{x}_{n+1} \f$
- *   - else
- *     - \f$ \dot{x}_{n+3/2} \leftarrow
- *           \dot{x}_{n+1/2} + \Delta t\, \ddot{x}_{n+1} \f$
+ *  \f{center}{
+ *    \parbox{5in}{
+ *    \rule{5in}{0.4pt} \\
+ *    {\bf Algorithm} Leapfrog \\
+ *    \rule{5in}{0.4pt} \vspace{-15pt}
+ *    \begin{enumerate}
+ *      \setlength{\itemsep}{0pt} \setlength{\parskip}{0pt} \setlength{\parsep}{0pt}
+ *      \item {\it appAction.execute(solutionHistory, stepper, BEGIN\_STEP)}
+ *      \item {\bf if (``Startup") then}
+ *            \hfill {\it * Take half-step startup.}
+ *      \item \quad  $\dot{x}_{n+1/2} = \dot{x}_n + \frac{1}{2}\Delta t \ddot{x}_n$
+ *      \item {\bf endif}
+ *      \item {\it appAction.execute(solutionHistory, stepper, BEFORE\_X\_UPDATE)}
+ *      \item $x_{n+1} = x_n + \Delta t \dot{x}_{n+1/2}$
+ *      \item {\it appAction.execute(solutionHistory, stepper, BEFORE\_EXPLICIT\_EVAL)}
+ *      \item $\ddot{x}_{n+1} = f(x_{n+1},t_{n+1})$
+ *      \item {\it appAction.execute(solutionHistory, stepper, BEFORE\_XDOT\_UPDATE)}
+ *      \item {\bf if (``Ending") then}
+ *            \hfill {\it * Take half-step to get solution at the same time level.}
+ *      \item \quad $\dot{x}_{n+1} \leftarrow
+ *                   \dot{x}_{n+1/2} +\frac{1}{2} \Delta t\, \ddot{x}_{n+1}$
+ *      \item {\bf else}
+ *      \item \quad  $\dot{x}_{n+3/2} \leftarrow
+ *                    \dot{x}_{n+1/2} + \Delta t\, \ddot{x}_{n+1}$
+ *      \item {\bf endif}
+ *      \item {\it appAction.execute(solutionHistory, stepper, END\_STEP)}
+ *    \end{enumerate}
+ *    \vspace{-10pt} \rule{5in}{0.4pt}
+ *    }
+ *  \f}
+ *  where one can begin with \f$(x_n,\dot{x}_{n+1/2})\f$ or \f$(x_n,\dot{x}_{n})\f$
+ *  and/or end with \f$(x_{n+1},\dot{x}_{n+3/2})\f$ or
+ *  \f$(x_{n+1},\dot{x}_{n+1})\f$.
  *
  *  The First-Same-As-Last (FSAL) principle is not used with Leapfrog
  *  because of the algorithm's prescribed order of solution update.

--- a/packages/tempus/src/Tempus_StepperLeapfrog_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperLeapfrog_impl.hpp
@@ -117,11 +117,12 @@ void StepperLeapfrog<Scalar>::takeStep(
 
     RCP<StepperLeapfrog<Scalar> > thisStepper = Teuchos::rcpFromRef(*this);
 
+    stepperLFAppAction_->execute(solutionHistory, thisStepper,
+      StepperLeapfrogAppAction<Scalar>::ACTION_LOCATION::BEGIN_STEP);
+
     // Perform half-step startup if working state is synced
     // (i.e., xDot and x are at the same time level).
     if (workingState->getIsSynced() == true) {
-      stepperLFAppAction_->execute(solutionHistory, thisStepper,
-        StepperLeapfrogAppAction<Scalar>::ACTION_LOCATION::BEGIN_STEP);
       // Half-step startup: xDot_{n+1/2} = xDot_n + 0.5*dt*xDotDot_n
       Thyra::V_VpStV(Teuchos::outArg(*(workingState->getXDot())),
         *(currentState->getXDot()),0.5*dt,*(currentState->getXDotDot()));
@@ -157,6 +158,9 @@ void StepperLeapfrog<Scalar>::takeStep(
     workingState->setSolutionStatus(Status::PASSED);
     workingState->setOrder(this->getOrder());
     workingState->computeNorms(currentState);
+
+    stepperLFAppAction_->execute(solutionHistory, thisStepper,
+      StepperLeapfrogAppAction<Scalar>::ACTION_LOCATION::END_STEP);
   }
   return;
 }

--- a/packages/tempus/src/Tempus_StepperNewmarkExplicitAFormAppAction.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkExplicitAFormAppAction.hpp
@@ -23,25 +23,12 @@ template<class Scalar> class StepperNewmarkExplicitAForm;
  *  This class provides a means to apply various actions with the NewmarkExplicitAForm time step.
  *  The data available to this class is solution variables (through
  *  SolutionHistory), and stepper data (through the Stepper).  It allows
- *  the application to just observe this data (i.e., use but not change the
- *  data) to change any of it (USER BEWARE!).
+ *  the application to just observe this data, i.e., use but not change
+ *  any of it (USER BEWARE!).
  *
- *  Below is the NewmarkExplicitAForm algorithm and includes the locations where the
- *  application can take actions (in italicized).
- *
- *  \f{algorithm}{
- *  \renewcommand{\thealgorithm}{}
- *  \caption{Newmark Explicit-A with application-action locations indicated.}
- *  \begin{algorithmic}[1]
- *    \State {\it appAction.execute(solutionHistory, stepper, BEGIN\_STEP)}
- *    \State Compute displacement and velocity predictors
- *    \State {\it appAction.execute(solutionHistory, stepper, BEFORE\_EXPLICIT\_EVAL)}
- *    \State Form $\ddot{x}_n \leftarrow x_{n} + \Delta t_n f(x_{n},t_n)$
- *    \State {\it appAction.execute(solutionHistory, stepper, AFTER\_EXPLICIT\_EVAL)}
- *    \State Correct velocity
- *    \State {\it appAction.execute(solutionHistory, stepper, END\_STEP)}
- *  \end{algorithmic}
- *  \f}
+ *  The locations for these AppAction calls
+ *  (StepperNewmarkExplicitAFormAppAction::ACTION_LOCATION) are shown in the
+ *  algorithm documentation of the StepperNewmarkExplicitAForm.
  */
 template<class Scalar>
 class StepperNewmarkExplicitAFormAppAction

--- a/packages/tempus/src/Tempus_StepperNewmarkExplicitAFormModifierBase.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkExplicitAFormModifierBase.hpp
@@ -29,22 +29,9 @@ namespace Tempus {
  *  Thus the user should be careful when accessing data through classes
  *  derived from the default modifier (i.e., USER BEWARE!!).
  *
- *  Below is the NewmarkExplicitAForm algorithm with the locations of the modify calls
- *  italicized.
- *
- *  \f{algorithm}{
- *  \renewcommand{\thealgorithm}{}
- *  \caption{Newmark Explicit-A with modify calls indicated.}
- *  \begin{algorithmic}[1]
- *    \State \quad {\it modifier.modify(solutionHistory, stepper, BEGIN\_STEP)}
- *    \State Compute the predictor (e.g., apply stepper to $x_n$).
- *    \State \quad {\it modifier.modify(solutionHistory, stepper, BEFORE\_SOLVE)}
- *    \State Solve $\mathcal{F}_n(\dot{x}=(x_n-x_{n-1})/\Delta t_n, x_n, t_n)=0$ for $x_n$
- *    \State \quad {\it modifier.modify(solutionHistory, stepper, AFTER\_SOLVE)}
- *    \State $\dot{x}_n \leftarrow (x_n-x_{n-1})/\Delta t_n$
- *    \State \quad {\it modifier.modify(solutionHistory, stepper, END\_STEP)}
- *  \end{algorithmic}
- *  \f}
+ *  The locations for these AppAction calls
+ *  (StepperNewmarkExplicitAFormAppAction::ACTION_LOCATION) are shown in the
+ *  algorithm documentation of the StepperNewmarkExplicitAForm.
  */
 template<class Scalar>
 class StepperNewmarkExplicitAFormModifierBase

--- a/packages/tempus/src/Tempus_StepperNewmarkExplicitAFormModifierXBase.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkExplicitAFormModifierXBase.hpp
@@ -28,22 +28,10 @@ namespace Tempus {
  *  affecting the Stepper correctness, performance, accuracy and stability
  *  (i.e., USER BEWARE!!).
  *
- *  Below is the NewmarkExplicitAForm algorithm with the locations of the ModifierX calls
- *  italicized.
- *
- *  \f{algorithm}{
- *  \renewcommand{\thealgorithm}{}
- *  \caption{Newmark Explicit-A with modify calls indicated.}
- *  \begin{algorithmic}[1]
- *    \State {\it appAction.execute(solutionHistory, stepper, X\_BEGIN\_STEP)}
- *    \State Compute displacement and velocity predictors 
- *    \State {\it appAction.execute(solutionHistory, stepper, X\_BEFORE\_EXPLICIT\_EVAL)}
- *    \State Form $\ddot{x}_n \leftarrow x_{n} + \Delta t_n f(x_{n},t_n)$
- *    \State {\it appAction.execute(solutionHistory, stepper, X\_AFTER\_EXPLICIT\_EVAL)}
- *    \State Correct velocity 
- *    \State {\it appAction.execute(solutionHistory, stepper, X\_END\_STEP)}
- *  \end{algorithmic}
- *  \f}
+ *  The locations of the StepperNewmarkExplicitAFormModifierXBase::MODIFIER_TYPE
+ *  which correspond to the AppAction calls
+ *  (StepperNewmarkExplicitAFormAppAction::ACTION_LOCATION) are shown in the
+ *  algorithm documentation of the StepperNewmarkExplicitAForm.
  */
 template<class Scalar>
 class StepperNewmarkExplicitAFormModifierXBase

--- a/packages/tempus/src/Tempus_StepperNewmarkExplicitAForm_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkExplicitAForm_decl.hpp
@@ -36,34 +36,39 @@ namespace Tempus {
  *  where \f$\mathbf{v} = \dot{\mathbf{x}}\f$ and \f$\mathbf{d} = \mathbf{x}\f$.
  *
  *  <b> Algorithm </b>
- *  The algorithm for the Newmark explicit A-form is
-
- *  \f{algorithm}{
- *  \renewcommand{\thealgorithm}{}
- *  \caption{Forward Euler}
- *  \begin{algorithmic}[1]
- *    \State {\it appAction.execute(solutionHistory, stepper, BEGIN\_STEP)}
- *    \If { Not ``Use FSAL'' or (previous step failed)}
- *      \State {\it appAction.execute(solutionHistory, stepper, BEFORE\_EXPLICIT\_EVAL)}
- *      \State $\mathbf{a}^{n-1} =
- *          \bar{\mathbf{f}}(\mathbf{d}^{n-1}, \mathbf{v}^{n-1}, t^{n-1})$
- *    \EndIf
- *    \State $\mathbf{d}^{\ast} = \mathbf{d}^{n-1} + \Delta t \mathbf{v}^{n-1}
- *                            + \Delta t^2 \mathbf{a}^{n-1} / 2$
- *    \State $\mathbf{v}^{\ast} =
- *        \mathbf{v}^{n-1} + \Delta t (1-\gamma) \mathbf{a}^{n-1}$
- *    \State $\mathbf{a}^{\ast} =
- *        \bar{\mathbf{f}}(\mathbf{d}^{\ast}, \mathbf{v}^{\ast}, t^{n-1})$
- *    \State $\mathbf{d}^n = \mathbf{d}^{\ast}$
- *    \State $\mathbf{v}^n =
- *        \mathbf{v}^{\ast} + \Delta t \gamma \mathbf{a}^{\ast}$
- *    \If { ``Use FSAL'' }
- *      \State {\it appAction.execute(solutionHistory, stepper, BEFORE\_EXPLICIT\_EVAL)}
- *      \State $\mathbf{a}^n =
- *          \bar{\mathbf{f}}(\mathbf{d}^n, \mathbf{v}^n, t^n)$
- *    \EndIf
- *    \State {\it appAction.execute(solutionHistory, stepper, END\_STEP)}
- *  \end{algorithmic}
+ *  The algorithm for the Newmark Explicit A-form is
+ *
+ *  \f{center}{
+ *    \parbox{5in}{
+ *    \rule{5in}{0.4pt} \\
+ *    {\bf Algorithm} Newmark Explicit A-form \\
+ *    \rule{5in}{0.4pt} \vspace{-15pt}
+ *    \begin{enumerate}
+ *      \setlength{\itemsep}{0pt} \setlength{\parskip}{0pt} \setlength{\parsep}{0pt}
+ *      \item {\it appAction.execute(solutionHistory, stepper, BEGIN\_STEP)}
+ *      \item {\bf if (Not ``Use FSAL'' or (previous step failed)) then}
+ *      \item \quad  {\it appAction.execute(solutionHistory, stepper, BEFORE\_EXPLICIT\_EVAL)}
+ *      \item \quad  $\mathbf{a}^{n-1} =
+ *                   \bar{\mathbf{f}}(\mathbf{d}^{n-1}, \mathbf{v}^{n-1}, t^{n-1})$
+ *      \item {\bf endif}
+ *      \item $\mathbf{d}^{\ast} = \mathbf{d}^{n-1} + \Delta t \mathbf{v}^{n-1}
+ *                               + \Delta t^2 \mathbf{a}^{n-1} / 2$
+ *      \item $\mathbf{v}^{\ast} =
+ *            \mathbf{v}^{n-1} + \Delta t (1-\gamma) \mathbf{a}^{n-1}$
+ *      \item $\mathbf{a}^{\ast} =
+ *            \bar{\mathbf{f}}(\mathbf{d}^{\ast}, \mathbf{v}^{\ast}, t^{n-1})$
+ *      \item $\mathbf{d}^n = \mathbf{d}^{\ast}$
+ *      \item $\mathbf{v}^n =
+ *            \mathbf{v}^{\ast} + \Delta t \gamma \mathbf{a}^{\ast}$
+ *      \item {\bf if (``Use FSAL'') then}
+ *      \item \quad  {\it appAction.execute(solutionHistory, stepper, BEFORE\_EXPLICIT\_EVAL)}
+ *      \item \quad  $\mathbf{a}^n =
+ *                   \bar{\mathbf{f}}(\mathbf{d}^n, \mathbf{v}^n, t^n)$
+ *      \item {\bf endif}
+ *      \item {\it appAction.execute(solutionHistory, stepper, END\_STEP)}
+ *    \end{enumerate}
+ *    \vspace{-10pt} \rule{5in}{0.4pt}
+ *    }
  *  \f}
  *
  *  Note that with useFSAL=false \f$x_n\f$ and \f$\dot{x}_{n-1}\f$ are not

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitAFormAppAction.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitAFormAppAction.hpp
@@ -23,25 +23,12 @@ template<class Scalar> class StepperNewmarkImplicitAForm;
  *  This class provides a means to apply various actions with the NewmarkImplicitAForm time step.
  *  The data available to this class is solution variables (through
  *  SolutionHistory), and stepper data (through the Stepper).  It allows
- *  the application to just observe this data (i.e., use but not change the
- *  data) to change any of it (USER BEWARE!).
+ *  the application to just observe this data, i.e., use but not change
+ *  any of it (USER BEWARE!).
  *
- *  Below is the NewmarkImplicitAForm algorithm and includes the locations where the
- *  application can take actions (in italicized).
- *
- *  \f{algorithm}{
- *  \renewcommand{\thealgorithm}{}
- *  \caption{Newmark Implicit-A with application-action locations indicated.}
- *  \begin{algorithmic}[1]
- *    \State {\it appAction.execute(solutionHistory, stepper, BEGIN\_STEP)}
- *    \State Compute the predictor (e.g., apply stepper to $x_n$).
- *    \State {\it appAction.execute(solutionHistory, stepper, BEFORE\_SOLVE)}
- *    \State Solve $\mathcal{F}_n(\dot{x}=(x_n-x_{n-1})/\Delta t_n, x_n, t_n)=0$ for $x_n$
- *    \State {\it appAction.execute(solutionHistory, stepper, AFTER\_SOLVE)}
- *    \State $\dot{x}_n \leftarrow (x_n-x_{n-1})/\Delta t_n$
- *    \State {\it appAction.execute(solutionHistory, stepper, END\_STEP)}
- *  \end{algorithmic}
- *  \f}
+ *  The locations for these AppAction calls
+ *  (StepperNewmarkImplicitAFormAppAction::ACTION_LOCATION) are shown in the
+ *  algorithm documentation of the StepperNewmarkImplicitAForm.
  */
 template<class Scalar>
 class StepperNewmarkImplicitAFormAppAction

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitAFormModifierBase.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitAFormModifierBase.hpp
@@ -29,22 +29,9 @@ namespace Tempus {
  *  Thus the user should be careful when accessing data through classes
  *  derived from the default modifier (i.e., USER BEWARE!!).
  *
- *  Below is the NewmarkImplicitAForm algorithm with the locations of the modify calls
- *  italicized.
- *
- *  \f{algorithm}{
- *  \renewcommand{\thealgorithm}{}
- *  \caption{Newmark Implicit-A with modify calls indicated.}
- *  \begin{algorithmic}[1]
- *    \State \quad {\it modifier.modify(solutionHistory, stepper, BEGIN\_STEP)}
- *    \State Compute the predictor (e.g., apply stepper to $x_n$).
- *    \State \quad {\it modifier.modify(solutionHistory, stepper, BEFORE\_SOLVE)}
- *    \State Solve $\mathcal{F}_n(\dot{x}=(x_n-x_{n-1})/\Delta t_n, x_n, t_n)=0$ for $x_n$
- *    \State \quad {\it modifier.modify(solutionHistory, stepper, AFTER\_SOLVE)}
- *    \State $\dot{x}_n \leftarrow (x_n-x_{n-1})/\Delta t_n$
- *    \State \quad {\it modifier.modify(solutionHistory, stepper, END\_STEP)}
- *  \end{algorithmic}
- *  \f}
+ *  The locations for these AppAction calls
+ *  (StepperNewmarkImplicitAFormAppAction::ACTION_LOCATION) are shown in the
+ *  algorithm documentation of the StepperNewmarkImplicitAForm.
  */
 template<class Scalar>
 class StepperNewmarkImplicitAFormModifierBase

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitAFormModifierXBase.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitAFormModifierXBase.hpp
@@ -28,22 +28,10 @@ namespace Tempus {
  *  affecting the Stepper correctness, performance, accuracy and stability
  *  (i.e., USER BEWARE!!).
  *
- *  Below is the NewmarkImplicitAForm algorithm with the locations of the ModifierX calls
- *  italicized.
- *
- *  \f{algorithm}{
- *  \renewcommand{\thealgorithm}{}
- *  \caption{Newmark Implicit-A with modify calls indicated.}
- *  \begin{algorithmic}[1]
- *    \State \quad {\it modifierX.modify(x, time, dt, X\_BEGIN\_STEP)}
- *    \State Compute the predictor (e.g., apply stepper to $x_n$).
- *    \State \quad {\it modifierX.modify(x, time, dt, X\_BEFORE\_SOLVE)}
- *    \State Solve $\mathcal{F}_n(\dot{x}=(x_n-x_{n-1})/\Delta t_n, x_n, t_n)=0$ for $x_n$
- *    \State \quad {\it modifierX.modify(x, time, dt, X\_AFTER\_SOLVE)}
- *    \State $\dot{x}_n \leftarrow (x_n-x_{n-1})/\Delta t_n$
- *    \State \quad {\it modifierX.modify(x, time, dt, X\_END\_STEP)}
- *  \end{algorithmic}
- *  \f}
+ *  The locations of the StepperNewmarkImplicitAFormModifierXBase::MODIFIER_TYPE
+ *  which correspond to the AppAction calls
+ *  (StepperNewmarkImplicitAFormAppAction::ACTION_LOCATION) are shown in the
+ *  algorithm documentation of the StepperNewmarkImplicitAForm.
  */
 template<class Scalar>
 class StepperNewmarkImplicitAFormModifierXBase

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitAForm_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitAForm_decl.hpp
@@ -56,15 +56,32 @@ namespace Tempus {
  *  <b> Algorithm </b>
  *  The algorithm for the Newmark implicit A-form with predictors and
  *  correctors is
- *   - \f$\mathbf{d}^{\ast} = \mathbf{d}^{n-1} + \Delta t \mathbf{v}^{n-1}
- *                            + \Delta t^2 (1-2 \beta) \mathbf{a}^{n-1} / 2\f$
- *   - \f$\mathbf{v}^{\ast} =
- *        \mathbf{v}^{n-1} + \Delta t (1-\gamma) \mathbf{a}^{n-1}\f$
- *   - Solve
- *        \f$\mathbf{f}(\mathbf{d}^n, \mathbf{v}^n, \mathbf{a}^n, t^n) = 0\f$
- *     for \f$\mathbf{a}^n\f$ where
- *     - \f$\mathbf{d}^n = \mathbf{d}^{\ast} + \beta \Delta t^2 \mathbf{a}^n\f$
- *     - \f$\mathbf{v}^n = \mathbf{v}^{\ast} + \gamma \Delta t \mathbf{a}^n\f$
+ *
+ *  \f{center}{
+ *    \parbox{5in}{
+ *    \rule{5in}{0.4pt} \\
+ *    {\bf Algorithm} Newmark Implicit A-form \\
+ *    \rule{5in}{0.4pt} \vspace{-15pt}
+ *    \begin{enumerate}
+ *      \setlength{\itemsep}{0pt} \setlength{\parskip}{0pt} \setlength{\parsep}{0pt}
+ *      \item {\it appAction.execute(solutionHistory, stepper, BEGIN\_STEP)}
+ *      \item $\mathbf{d}^{\ast} = \mathbf{d}^{n-1} + \Delta t \mathbf{v}^{n-1}
+ *                               + \Delta t^2 (1-2 \beta) \mathbf{a}^{n-1} / 2$
+ *      \item $\mathbf{v}^{\ast} = \mathbf{v}^{n-1} + \Delta t (1-\gamma) \mathbf{a}^{n-1}$
+ *      \item {\it appAction.execute(solutionHistory, stepper, BEFORE\_SOLVE)}
+ *      \item {\bf Solve
+ *            $\mathbf{f}(\mathbf{d}^n, \mathbf{v}^n, \mathbf{a}^n, t^n) = 0$
+ *            for $\mathbf{a}^n$ where} \\
+ *            $\mathbf{d}^n = \mathbf{d}^{\ast} + \beta \Delta t^2 \mathbf{a}^n$ \\
+ *            $\mathbf{v}^n = \mathbf{v}^{\ast} + \gamma \Delta t \mathbf{a}^n$
+ *      \item {\it appAction.execute(solutionHistory, stepper, AFTER\_SOLVE)}
+ *      \item $\mathbf{d}^n = \mathbf{d}^{\ast} + \beta \Delta t^2 \mathbf{a}^n$
+ *      \item $\mathbf{v}^n = \mathbf{v}^{\ast} + \gamma \Delta t \mathbf{a}^n$
+ *      \item {\it appAction.execute(solutionHistory, stepper, END\_STEP)}
+ *    \end{enumerate}
+ *    \vspace{-10pt} \rule{5in}{0.4pt}
+ *    }
+ *  \f}
  *
  *  The First-Same-As-Last (FSAL) principle is not needed with Newmark
  *  Implicit A-Form.  The default is to set useFSAL=false, however

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitAForm_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitAForm_impl.hpp
@@ -442,7 +442,7 @@ void StepperNewmarkImplicitAForm<Scalar>::takeStep(
 
     auto thisStepper = Teuchos::rcpFromRef(*this);
     stepperNewmarkImpAppAction_->execute(solutionHistory, thisStepper,
-        StepperNewmarkImplicitAFormAppAction<Scalar>::ACTION_LOCATION::BEGIN_STEP);
+      StepperNewmarkImplicitAFormAppAction<Scalar>::ACTION_LOCATION::BEGIN_STEP);
 
     RCP<SolutionState<Scalar> > workingState=solutionHistory->getWorkingState();
     RCP<SolutionState<Scalar> > currentState=solutionHistory->getCurrentState();
@@ -474,13 +474,13 @@ void StepperNewmarkImplicitAForm<Scalar>::takeStep(
     wrapperModel->initializeNewmark(v_new,d_new,dt,t,beta_,gamma_);
 
     stepperNewmarkImpAppAction_->execute(solutionHistory, thisStepper,
-        StepperNewmarkImplicitAFormAppAction<Scalar>::ACTION_LOCATION::BEFORE_SOLVE);
+      StepperNewmarkImplicitAFormAppAction<Scalar>::ACTION_LOCATION::BEFORE_SOLVE);
 
     // Solve nonlinear system with a_new as initial guess
     const Thyra::SolveStatus<Scalar> sStatus = this->solveImplicitODE(a_new);
 
     stepperNewmarkImpAppAction_->execute(solutionHistory, thisStepper,
-        StepperNewmarkImplicitAFormAppAction<Scalar>::ACTION_LOCATION::AFTER_SOLVE);
+      StepperNewmarkImplicitAFormAppAction<Scalar>::ACTION_LOCATION::AFTER_SOLVE);
 
     // Correct velocity, displacement.
     correctVelocity(*v_new, *v_new, *a_new, dt);
@@ -491,7 +491,7 @@ void StepperNewmarkImplicitAForm<Scalar>::takeStep(
     workingState->computeNorms(currentState);
 
     stepperNewmarkImpAppAction_->execute(solutionHistory, thisStepper,
-        StepperNewmarkImplicitAFormAppAction<Scalar>::ACTION_LOCATION::END_STEP);
+      StepperNewmarkImplicitAFormAppAction<Scalar>::ACTION_LOCATION::END_STEP);
   }
   return;
 }

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitDFormAppAction.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitDFormAppAction.hpp
@@ -23,25 +23,12 @@ template<class Scalar> class StepperNewmarkImplicitDForm;
  *  This class provides a means to apply various actions with the NewmarkImplicitDForm time step.
  *  The data available to this class is solution variables (through
  *  SolutionHistory), and stepper data (through the Stepper).  It allows
- *  the application to just observe this data (i.e., use but not change the
- *  data) to change any of it (USER BEWARE!).
+ *  the application to just observe this data, i.e., use but not change
+ *  any of it (USER BEWARE!).
  *
- *  Below is the NewmarkImplicitDForm algorithm and includes the locations where the
- *  application can take actions (in italicized).
- *
- *  \f{algorithm}{
- *  \renewcommand{\thealgorithm}{}
- *  \caption{Newmark Implicit-D with application-action locations indicated.}
- *  \begin{algorithmic}[1]
- *    \State {\it appAction.execute(solutionHistory, stepper, BEGIN\_STEP)}
- *    \State Compute the predictor (e.g., apply stepper to $x_n$).
- *    \State {\it appAction.execute(solutionHistory, stepper, BEFORE\_SOLVE)}
- *    \State Solve $\mathcal{F}_n(\dot{x}=(x_n-x_{n-1})/\Delta t_n, x_n, t_n)=0$ for $x_n$
- *    \State {\it appAction.execute(solutionHistory, stepper, AFTER\_SOLVE)}
- *    \State $\dot{x}_n \leftarrow (x_n-x_{n-1})/\Delta t_n$
- *    \State {\it appAction.execute(solutionHistory, stepper, END\_STEP)}
- *  \end{algorithmic}
- *  \f}
+ *  The locations for these AppAction calls
+ *  (StepperNewmarkImplicitDFormAppAction::ACTION_LOCATION) are shown in the
+ *  algorithm documentation of the StepperNewmarkImplicitDForm.
  */
 template<class Scalar>
 class StepperNewmarkImplicitDFormAppAction

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitDFormModifierBase.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitDFormModifierBase.hpp
@@ -29,22 +29,9 @@ namespace Tempus {
  *  Thus the user should be careful when accessing data through classes
  *  derived from the default modifier (i.e., USER BEWARE!!).
  *
- *  Below is the NewmarkImplicitDForm algorithm with the locations of the modify calls
- *  italicized.
- *
- *  \f{algorithm}{
- *  \renewcommand{\thealgorithm}{}
- *  \caption{Newmark Implicit-A with modify calls indicated.}
- *  \begin{algorithmic}[1]
- *    \State \quad {\it modifier.modify(solutionHistory, stepper, BEGIN\_STEP)}
- *    \State Compute the predictor (e.g., apply stepper to $x_n$).
- *    \State \quad {\it modifier.modify(solutionHistory, stepper, BEFORE\_SOLVE)}
- *    \State Solve $\mathcal{F}_n(\dot{x}=(x_n-x_{n-1})/\Delta t_n, x_n, t_n)=0$ for $x_n$
- *    \State \quad {\it modifier.modify(solutionHistory, stepper, AFTER\_SOLVE)}
- *    \State $\dot{x}_n \leftarrow (x_n-x_{n-1})/\Delta t_n$
- *    \State \quad {\it modifier.modify(solutionHistory, stepper, END\_STEP)}
- *  \end{algorithmic}
- *  \f}
+ *  The locations for these AppAction calls
+ *  (StepperNewmarkImplicitDFormAppAction::ACTION_LOCATION) are shown in the
+ *  algorithm documentation of the StepperNewmarkImplicitDForm.
  */
 template<class Scalar>
 class StepperNewmarkImplicitDFormModifierBase

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitDFormModifierXBase.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitDFormModifierXBase.hpp
@@ -28,22 +28,10 @@ namespace Tempus {
  *  affecting the Stepper correctness, performance, accuracy and stability
  *  (i.e., USER BEWARE!!).
  *
- *  Below is the NewmarkImplicitDForm algorithm with the locations of the ModifierX calls
- *  italicized.
- *
- *  \f{algorithm}{
- *  \renewcommand{\thealgorithm}{}
- *  \caption{Newmark Implicit-A with modify calls indicated.}
- *  \begin{algorithmic}[1]
- *    \State \quad {\it modifierX.modify(x, time, dt, X\_BEGIN\_STEP)}
- *    \State Compute the predictor (e.g., apply stepper to $x_n$).
- *    \State \quad {\it modifierX.modify(x, time, dt, X\_BEFORE\_SOLVE)}
- *    \State Solve $\mathcal{F}_n(\dot{x}=(x_n-x_{n-1})/\Delta t_n, x_n, t_n)=0$ for $x_n$
- *    \State \quad {\it modifierX.modify(x, time, dt, X\_AFTER\_SOLVE)}
- *    \State $\dot{x}_n \leftarrow (x_n-x_{n-1})/\Delta t_n$
- *    \State \quad {\it modifierX.modify(x, time, dt, X\_END\_STEP)}
- *  \end{algorithmic}
- *  \f}
+ *  The locations of the StepperNewmarkImplicitDFormModifierXBase::MODIFIER_TYPE
+ *  which correspond to the AppAction calls
+ *  (StepperNewmarkImplicitDFormAppAction::ACTION_LOCATION) are shown in the
+ *  algorithm documentation of the StepperNewmarkImplicitDForm.
  */
 template<class Scalar>
 class StepperNewmarkImplicitDFormModifierXBase

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitDForm_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitDForm_decl.hpp
@@ -35,6 +35,36 @@ namespace Tempus {
  *  Beta scheme can be found
  *  <a href="http://opensees.berkeley.edu/wiki/index.php/Newmark_Method">here</a>.
  *
+ *  <b> Algorithm </b>
+ *  The algorithm for the Newmark implicit D-form with predictors and
+ *  correctors is
+ *
+ *  \f{center}{
+ *    \parbox{5in}{
+ *    \rule{5in}{0.4pt} \\
+ *    {\bf Algorithm} Newmark Implicit D-form \\
+ *    \rule{5in}{0.4pt} \vspace{-15pt}
+ *    \begin{enumerate}
+ *      \setlength{\itemsep}{0pt} \setlength{\parskip}{0pt} \setlength{\parsep}{0pt}
+ *      \item {\it appAction.execute(solutionHistory, stepper, BEGIN\_STEP)}
+ *      \item $\mathbf{d}^{\ast} = \mathbf{d}^{n-1} + \Delta t \mathbf{v}^{n-1}
+ *                               + \Delta t^2 (1-2 \beta) \mathbf{a}^{n-1} / 2$
+ *      \item $\mathbf{v}^{\ast} = \mathbf{v}^{n-1} + \Delta t (1-\gamma) \mathbf{a}^{n-1}$
+ *      \item {\it appAction.execute(solutionHistory, stepper, BEFORE\_SOLVE)}
+ *      \item {\bf Solve
+ *            $\mathbf{f}(\mathbf{d}^n, \mathbf{v}^n, \mathbf{a}^n, t^n) = 0$
+ *            for $\mathbf{d}^n$ where} \\
+ *            $\mathbf{a}^n = (\mathbf{d}^n - \mathbf{d}^{\ast})/(\beta \Delta t^2)$ \\
+ *            $\mathbf{v}^n = \mathbf{v}^{\ast} + \gamma \Delta t \mathbf{a}^n$
+ *      \item {\it appAction.execute(solutionHistory, stepper, AFTER\_SOLVE)}
+ *      \item $\mathbf{a}^n = (\mathbf{d}^n - \mathbf{d}^{\ast})/(\beta \Delta t^2)$
+ *      \item $\mathbf{v}^n = \mathbf{v}^{\ast} + \gamma \Delta t \mathbf{a}^n$
+ *      \item {\it appAction.execute(solutionHistory, stepper, END\_STEP)}
+ *    \end{enumerate}
+ *    \vspace{-10pt} \rule{5in}{0.4pt}
+ *    }
+ *  \f}
+ *
  *  The First-Same-As-Last (FSAL) principle is not used with the
  *  Newmark implicit D-Form method.  The default is to set useFSAL=false,
  *  however useFSAL=true will also work but have no affect (i.e., no-op).

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitDForm_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitDForm_impl.hpp
@@ -188,8 +188,8 @@ StepperNewmarkImplicitDForm<Scalar>::StepperNewmarkImplicitDForm()
 
 template<class Scalar>
 StepperNewmarkImplicitDForm<Scalar>::StepperNewmarkImplicitDForm(
-    const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar>>& appModel,
-    const Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> >& solver,
+    const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > & appModel,
+    const Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> >  & solver,
     bool useFSAL,
     std::string ICConsistency,
     bool ICConsistencyCheck,
@@ -278,7 +278,7 @@ StepperNewmarkImplicitDForm<Scalar>::takeStep(
 
     auto thisStepper = Teuchos::rcpFromRef(*this);
     stepperNewmarkImpAppAction_->execute(solutionHistory, thisStepper,
-        StepperNewmarkImplicitDFormAppAction<Scalar>::ACTION_LOCATION::BEGIN_STEP);
+      StepperNewmarkImplicitDFormAppAction<Scalar>::ACTION_LOCATION::BEGIN_STEP);
 
     RCP<SolutionState<Scalar>> workingState =solutionHistory->getWorkingState();
     RCP<SolutionState<Scalar>> currentState =solutionHistory->getCurrentState();
@@ -375,7 +375,7 @@ StepperNewmarkImplicitDForm<Scalar>::takeStep(
     }
 
     stepperNewmarkImpAppAction_->execute(solutionHistory, thisStepper,
-        StepperNewmarkImplicitDFormAppAction<Scalar>::ACTION_LOCATION::BEFORE_SOLVE);
+      StepperNewmarkImplicitDFormAppAction<Scalar>::ACTION_LOCATION::BEFORE_SOLVE);
 
 
     //Set d_pred as initial guess for NOX solver, and solve nonlinear system.
@@ -385,7 +385,7 @@ StepperNewmarkImplicitDForm<Scalar>::takeStep(
     workingState->setSolutionStatus(sStatus);  // Converged --> pass.
 
     stepperNewmarkImpAppAction_->execute(solutionHistory, thisStepper,
-        StepperNewmarkImplicitDFormAppAction<Scalar>::ACTION_LOCATION::AFTER_SOLVE);
+      StepperNewmarkImplicitDFormAppAction<Scalar>::ACTION_LOCATION::AFTER_SOLVE);
 
     //solveImplicitODE will return converged solution in initial_guess
     //vector.  Copy it here to d_new, to define the new displacement.
@@ -422,7 +422,7 @@ StepperNewmarkImplicitDForm<Scalar>::takeStep(
     workingState->computeNorms(currentState);
 
     stepperNewmarkImpAppAction_->execute(solutionHistory, thisStepper,
-        StepperNewmarkImplicitDFormAppAction<Scalar>::ACTION_LOCATION::END_STEP);
+      StepperNewmarkImplicitDFormAppAction<Scalar>::ACTION_LOCATION::END_STEP);
   }
   return;
 }

--- a/packages/tempus/src/Tempus_StepperOperatorSplitAppAction.hpp
+++ b/packages/tempus/src/Tempus_StepperOperatorSplitAppAction.hpp
@@ -20,12 +20,15 @@ template<class Scalar> class StepperOperatorSplit;
 
 /** \brief StepperOperatorSplitAppAction class for StepperOperatorSplit.
  *
- * This is a means for application developers to perform tasks
- * during the time steps, e.g.,
- *   - Compute specific quantities
- *   - Output information
- *   - "Massage" the working solution state
- *   - ...
+ *  This class provides a means to apply various actions with the OperatorSplit time step.
+ *  The data available to this class is solution variables (through
+ *  SolutionHistory), and stepper data (through the Stepper).  It allows
+ *  the application to just observe this data, i.e., use but not change
+ *  any of it (USER BEWARE!).
+ *
+ *  The locations for these AppAction calls
+ *  (StepperOperatorSplitAppAction::ACTION_LOCATION) are shown in the
+ *  algorithm documentation of the StepperOperatorSplit.
  *
  * <b>Design Considerations</b>
  *   - StepperOperatorSplitAppAction is not stateless!  Developers may touch the

--- a/packages/tempus/src/Tempus_StepperOperatorSplitModifierBase.hpp
+++ b/packages/tempus/src/Tempus_StepperOperatorSplitModifierBase.hpp
@@ -28,6 +28,9 @@ namespace Tempus {
  *  Thus the user should be careful when accessing data through classes
  *  derived from the default modifier (i.e., USER BEWARE!!).
  *
+ *  The locations for these AppAction calls
+ *  (StepperOperatorSplitAppAction::ACTION_LOCATION) are shown in the
+ *  algorithm documentation of the StepperOperatorSplit.
  */
   template<class Scalar>
 class StepperOperatorSplitModifierBase

--- a/packages/tempus/src/Tempus_StepperOperatorSplitModifierXBase.hpp
+++ b/packages/tempus/src/Tempus_StepperOperatorSplitModifierXBase.hpp
@@ -28,6 +28,10 @@ namespace Tempus {
  *  affecting the Stepper correctness, performance, accuracy and stability
  *  (i.e., USER BEWARE!!).
  *
+ *  The locations of the StepperOperatorSplitModifierXBase::MODIFIER_TYPE
+ *  which correspond to the AppAction calls
+ *  (StepperOperatorSplitAppAction::ACTION_LOCATION) are shown in the
+ *  algorithm documentation of the StepperOperatorSplit.
  */
 
 template<class Scalar>

--- a/packages/tempus/src/Tempus_StepperOperatorSplitObserverBase.hpp
+++ b/packages/tempus/src/Tempus_StepperOperatorSplitObserverBase.hpp
@@ -26,7 +26,10 @@ namespace Tempus {
  *  expected that users will NOT modify any of that data.  If the user
  *  wishes to modify the solution and/or stepper data during the
  *  Stepper::takeStep, they should use the Modifier class (with care!).
- *                                                                                           
+ *
+ *  The locations for these AppAction calls
+ *  (StepperOperatorSplitAppAction::ACTION_LOCATION) are shown in the
+ *  algorithm documentation of the StepperBackwardEuler.
  */
 template<class Scalar>
 class StepperOperatorSplitObserverBase

--- a/packages/tempus/src/Tempus_StepperOperatorSplit_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperOperatorSplit_decl.hpp
@@ -30,6 +30,33 @@ namespace Tempus {
  *  Operator Split is only defined for one-step methods, so multi-step
  *  methods (e.g., BDF) should not be used with StepperOperatorSplit.
  *
+ *  <b> Algorithm </b>
+ *  The algorithm for operator-split stepper is
+ *
+ *  \f{center}{
+ *    \parbox{5in}{
+ *    \rule{5in}{0.4pt} \\
+ *    {\bf Algorithm} Operator Split \\
+ *    \rule{5in}{0.4pt} \vspace{-15pt}
+ *    \begin{enumerate}
+ *      \setlength{\itemsep}{0pt} \setlength{\parskip}{0pt} \setlength{\parsep}{0pt}
+ *      \item {\it appAction.execute(solutionHistory, stepper, BEGIN\_STEP)}
+ *      \item $x^\ast = x^n$
+ *            \hfill {\it * Initialize operator-split solution.}
+ *      \item {\bf for (each subStepper)}
+ *      \item \quad  {\it appAction.execute(solutionHistory, stepper, BEFORE\_STEPPER)}
+ *      \item \quad  {\bf subStepper take time step.}
+ *                   \hfill {\it * Evolve solution, $x^\ast \rightarrow x^{\ast\ast}$.}
+ *      \item \quad  {\it appAction.execute(solutionHistory, stepper, AFTER\_STEPPER)}
+ *      \item \quad  {\bf if (subStep failed) then break.}
+ *      \item \quad  {\bf Promote solution, $ x^\ast \leftarrow x^{\ast\ast}$}
+ *      \item {\bf end for}
+ *      \item {\it appAction.execute(solutionHistory, stepper, END\_STEP)}
+ *    \end{enumerate}
+ *    \vspace{-10pt} \rule{5in}{0.4pt}
+ *    }
+ *  \f}
+ *
  *  Note that steppers in general can not use FSAL (useFSAL=true) with
  *  operator splitting as \f$\dot{x}_{n-1}\f$ will usually be modified
  *  by other operators.

--- a/packages/tempus/src/Tempus_StepperRKAppAction.hpp
+++ b/packages/tempus/src/Tempus_StepperRKAppAction.hpp
@@ -24,11 +24,10 @@ template<class Scalar> class StepperRKBase;
  *  RK time step.  The data available to this class is solution
  *  variables (through SolutionHistory), and stepper data (through
  *  the Stepper).  It allows the application to just observe this
- *  data (i.e., use but not change the data) to change any of it
- *  (USER BEWARE!).
+ *  data, i.e., use but not change any of it (USER BEWARE!).
  *
- *  The locations of the RK AppActions (ACTION_LOCATION) in takeStep
- *  are documented in each of the RK Algorithm sections:
+ *  The locations of the RK AppActions (StepperRKAppAction::ACTION_LOCATION)
+ *  in takeStep are documented in each of the RK Algorithm sections:
  *  StepperExplicitRK, StepperDIRK and StepperIMEX_RK.
  */
 template<class Scalar>

--- a/packages/tempus/src/Tempus_StepperRKModifierBase.hpp
+++ b/packages/tempus/src/Tempus_StepperRKModifierBase.hpp
@@ -32,22 +32,9 @@ template<class Scalar> class StepperRKBase;
  *  Thus the user should be careful when accessing data through classes
  *  derived from the default modifier (i.e., USER BEWARE!!).
  *
- *  Below is the RK algorithm with the locations of the modify calls
- *  italicized.
- *
- *  \f{algorithm}{
- *  \renewcommand{\thealgorithm}{}
- *  \caption{Backward Euler with modify calls indicated.}
- *  \begin{algorithmic}[1]
- *    \State \quad {\it modifier.modify(solutionHistory, stepper, BEGIN\_STEP)}
- *    \State Compute the predictor (e.g., apply stepper to $x_n$).
- *    \State \quad {\it modifier.modify(solutionHistory, stepper, BEFORE\_SOLVE)}
- *    \State Solve $\mathcal{F}_n(\dot{x}=(x_n-x_{n-1})/\Delta t_n, x_n, t_n)=0$ for $x_n$
- *    \State \quad {\it modifier.modify(solutionHistory, stepper, AFTER\_SOLVE)}
- *    \State $\dot{x}_n \leftarrow (x_n-x_{n-1})/\Delta t_n$
- *    \State \quad {\it modifier.modify(solutionHistory, stepper, END\_STEP)}
- *  \end{algorithmic}
- *  \f}
+ *  The locations of the RK AppActions (StepperRKAppAction::ACTION_LOCATION)
+ *  in takeStep are documented in each of the RK Algorithm sections:
+ *  StepperExplicitRK, StepperDIRK and StepperIMEX_RK.
  */
 template<class Scalar>
 class StepperRKModifierBase

--- a/packages/tempus/src/Tempus_StepperRKModifierXBase.hpp
+++ b/packages/tempus/src/Tempus_StepperRKModifierXBase.hpp
@@ -29,22 +29,11 @@ namespace Tempus {
  *  affecting the Stepper correctness, performance, accuracy and stability
  *  (i.e., USER BEWARE!!).
  *
- *  Below is the RK algorithm with the locations of the ModifierX calls
- *  italicized.
- *
- *  \f{algorithm}{
- *  \renewcommand{\thealgorithm}{}
- *  \caption{Backward Euler with modify calls indicated.}
- *  \begin{algorithmic}[1]
- *    \State \quad {\it modifierX.modify(x, time, dt, X\_BEGIN\_STEP)}
- *    \State Compute the predictor (e.g., apply stepper to $x_n$).
- *    \State \quad {\it modifierX.modify(x, time, dt, X\_BEFORE\_SOLVE)}
- *    \State Solve $\mathcal{F}_n(\dot{x}=(x_n-x_{n-1})/\Delta t_n, x_n, t_n)=0$ for $x_n$
- *    \State \quad {\it modifierX.modify(x, time, dt, X\_AFTER\_SOLVE)}
- *    \State $\dot{x}_n \leftarrow (x_n-x_{n-1})/\Delta t_n$
- *    \State \quad {\it modifierX.modify(x, time, dt, XDOT\_END\_STEP)}
- *  \end{algorithmic}
- *  \f}
+ *  The locations of the StepperRKModifierXBase::MODIFIER_TYPE
+ *  which correspond to the RK AppActions
+ *  (StepperRKAppAction::ACTION_LOCATION)
+ *  in takeStep are documented in each of the RK Algorithm sections:
+ *  StepperExplicitRK, StepperDIRK and StepperIMEX_RK.
  */
 template<class Scalar>
 class StepperRKModifierXBase

--- a/packages/tempus/src/Tempus_StepperRKObserverBase.hpp
+++ b/packages/tempus/src/Tempus_StepperRKObserverBase.hpp
@@ -27,22 +27,9 @@ namespace Tempus {
  *  wishes to modify the solution and/or stepper data during the
  *  Stepper::takeStep, they should use the Modifier class (with care!).
  *
- *  Below is the RK algorithm with the locations of the observe calls
- *  italicized.
- *
- *  \f{algorithm}{
- *  \renewcommand{\thealgorithm}{}
- *  \caption{DIRK Backward Euler with observe calls indicated.}
- *  \begin{algorithmic}[1]
- *    \State \quad {\it observer.observe(solutionHistory, stepper, BEGIN\_STEP)}
- *    \State Compute the predictor (e.g., apply stepper to $x_n$).
- *    \State \quad {\it observer.observe(solutionHistory, stepper, BEFORE\_SOLVE)}
- *    \State Solve $\mathcal{F}_n(\dot{x}=(x_n-x_{n-1})/\Delta t_n, x_n, t_n)=0$ for $x_n$
- *    \State \quad {\it observer.observe(solutionHistory, stepper, AFTER\_SOLVE)}
- *    \State $\dot{x}_n \leftarrow (x_n-x_{n-1})/\Delta t_n$
- *    \State \quad {\it observer.observe(solutionHistory, stepper, END\_STEP)}
- *  \end{algorithmic}
- *  \f}
+ *  The locations of the RK AppActions (StepperRKAppAction::ACTION_LOCATION)
+ *  in takeStep are documented in each of the RK Algorithm sections:
+ *  StepperExplicitRK, StepperDIRK and StepperIMEX_RK.
  */
 template<class Scalar>
 class StepperRKObserverBase

--- a/packages/tempus/src/Tempus_StepperSubcyclingAppAction.hpp
+++ b/packages/tempus/src/Tempus_StepperSubcyclingAppAction.hpp
@@ -23,21 +23,12 @@ template<class Scalar> class StepperSubcycling;
  *  This class provides a means to apply various actions with the Subcycling
  *  time step.  The data available to this class is solution variables (through
  *  SolutionHistory), and stepper data (through the Stepper).  It allows
- *  the application to just observe this data (i.e., use but not change the
- *  data) to change any of it (USER BEWARE!).
+ *  the application to just observe this data, i.e., use but not change
+ *  any of it (USER BEWARE!).
  *
- *  Below is the Subcycling algorithm and includes the locations where the
- *  application can take actions (in italicized).
- *
- *  \f{algorithm}{
- *  \renewcommand{\thealgorithm}{}
- *  \caption{Subcyling with the locations of the application actions indicated.}
- *  \begin{algorithmic}[1]
- *    \State {\it appAction.execute(solutionHistory, stepper, BEGIN\_STEP)}
- *    \State Compute $x_{n}$ from $x_{n-1}$, applying appActions from sub-steppers
- *    \State {\it appAction.execute(solutionHistory, stepper, END\_STEP)}
- *  \end{algorithmic}
- *  \f}
+ *  The locations for these AppAction calls
+ *  (StepperSubcyclingAppAction::ACTION_LOCATION) are shown in the
+ *  algorithm documentation of the StepperSubcycling.
  */
 template<class Scalar>
 class StepperSubcyclingAppAction

--- a/packages/tempus/src/Tempus_StepperSubcyclingModifierBase.hpp
+++ b/packages/tempus/src/Tempus_StepperSubcyclingModifierBase.hpp
@@ -27,16 +27,10 @@ namespace Tempus {
  *  affecting the Stepper correctness, performance, accuracy and stability.
  *  Thus the user should be careful when accessing data through classes
  *  derived from the default modifier (i.e., USER BEWARE!!).
- * 
- *  \f{algorithm}{                                                                             
- *  \renewcommand{\thealgorithm}{}                                                             
- *  \caption{Subcycling with the locations of the application actions indicated.}           
- *  \begin{algorithmic}[1]                                                                     
- *    \State {\it appAction.execute(solutionHistory, stepper, BEGIN\_STEP)}                    
- *    \State Compute $x_{n}$ from $x_{n-1}$, applying appActions from sub-steppers                       
- *    \State {\it appAction.execute(solutionHistory, stepper, END\_STEP)} 
- *  \end{algorithmic}                                                                         
- *  \f}                                                                                       
+ *
+ *  The locations for these AppAction calls
+ *  (StepperSubcyclingAppAction::ACTION_LOCATION) are shown in the
+ *  algorithm documentation of the StepperSubcycling.
  */
 
 template<class Scalar>

--- a/packages/tempus/src/Tempus_StepperSubcyclingModifierXBase.hpp
+++ b/packages/tempus/src/Tempus_StepperSubcyclingModifierXBase.hpp
@@ -28,16 +28,10 @@ namespace Tempus {
  *  affecting the Stepper correctness, performance, accuracy and stability
  *  (i.e., USER BEWARE!!).
  *
- *  Below is the Subcycling algorithm with the locations of the ModifierX calls
- *  italicized.
- *
- *  \f{algorithm}{
- *  \renewcommand{\thealgorithm}{}
- *  \caption{Subcycling with the locations of the application actions indicated}
- *  \begin{algorithmic}[1]
- *    \State ToDO
- *  \end{algorithmic}
- *  \f}
+ *  The locations of the StepperSubcyclingModifierXBase::MODIFIER_TYPE
+ *  which correspond to the AppAction calls
+ *  (StepperSubcyclingAppAction::ACTION_LOCATION) are shown in the
+ *  algorithm documentation of the StepperSubcycling.
  */
 
 template<class Scalar>

--- a/packages/tempus/src/Tempus_StepperSubcyclingObserverBase.hpp
+++ b/packages/tempus/src/Tempus_StepperSubcyclingObserverBase.hpp
@@ -27,18 +27,9 @@ namespace Tempus {
  *  wishes to modify the solution and/or stepper data during the
  *  Stepper::takeStep, they should use the Modifier class (with care!).
  *
- *  Below is the Subcycling algorithm with the locations of the observe calls
- *  italicized.
- *
- *  \f{algorithm}{                                                                               
- *  \renewcommand{\thealgorithm}{}                                                               
- *  \caption{Subcycling with the locations of the application actions indicated.}             
- *  \begin{algorithmic}[1]                                                                       
- *    \State {\it appAction.execute(solutionHistory, stepper, BEGIN\_STEP)}                      
- *    \State Compute $x_{n}$ from $x_{n-1}$, applying appActions from sub-steppers                       
- *    \State {\it appAction.execute(solutionHistory, stepper, END\_STEP)}  
- *  \end{algorithmic}                                                                            
- *  \f}                                                                                          
+ *  The locations for these AppAction calls
+ *  (StepperSubcyclingAppAction::ACTION_LOCATION) are shown in the
+ *  algorithm documentation of the StepperSubcycling.
  */
 template<class Scalar>
 class StepperSubcyclingObserverBase

--- a/packages/tempus/src/Tempus_StepperSubcycling_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperSubcycling_decl.hpp
@@ -31,6 +31,24 @@ namespace Tempus {
  *   - No restart capability within subcycling, but still have restart
  *     capability from the full timestep.
  *   - Do not need to keep a solution history of the subcycling.
+ *
+ *  <b> Algorithm </b>
+ *  The algorithm for Subcycling stepper is
+ *
+ *  \f{center}{
+ *    \parbox{5in}{
+ *    \rule{5in}{0.4pt} \\
+ *    {\bf Algorithm} Subcycling \\
+ *    \rule{5in}{0.4pt} \vspace{-15pt}
+ *    \begin{enumerate}
+ *      \setlength{\itemsep}{0pt} \setlength{\parskip}{0pt} \setlength{\parsep}{0pt}
+ *      \item {\it appAction.execute(solutionHistory, stepper, BEGIN\_STEP)}
+ *      \item {\bf Advance solution, $x_{n}$ from $x_{n-1}$, by cycling substeppers.}
+ *      \item {\it appAction.execute(solutionHistory, stepper, END\_STEP)}
+ *    \end{enumerate}
+ *    \vspace{-10pt} \rule{5in}{0.4pt}
+ *    }
+ *  \f}
  */
 template<class Scalar>
 class StepperSubcycling : virtual public Tempus::Stepper<Scalar>

--- a/packages/tempus/src/Tempus_StepperTrapezoidalAppAction.hpp
+++ b/packages/tempus/src/Tempus_StepperTrapezoidalAppAction.hpp
@@ -19,29 +19,16 @@ namespace Tempus {
 template<class Scalar> class StepperTrapezoidal;
 
 /** \brief Application Action for StepperTrapezoidal.
-*
-*  This class provides a means to apply various actions with the Trapezoidal time step.
-*  The data available to this class is solution variables (through
-*  SolutionHistory), and stepper data (through the Stepper).  It allows
-*  the application to just observe this data (i.e., use but not change the
-*  data) to change any of it (USER BEWARE!).
-*
-*  Below is the Trapezoidal algorithm and includes the locations where the
-*  application can take actions (in italicized).
-*
-*  \f{algorithm}{
-*  \renewcommand{\thealgorithm}{}
-*  \caption{Trapezoidal stepper with application-action locations indicated.}
-*  \begin{algorithmic}[1]
-*    \State {\it appAction.execute(solutionHistory, stepper, BEGIN\_STEP)}
-*    \State Compute $y \leftarrow x_{n-1} + \frac{\Delta t_{n-1}}{2}f(x_{n-1},t_{n-1})$
-*    \State {\it appAction.execute(solutionHistory, stepper, BEFORE\_SOLVE)}
-*    \State Solve $x - y - \frac{\Delta t_{n-1}}{2}f(x,t_{n}) = 0$ for $x$
-*    \State {\it appAction.execute(solutionHistory, stepper, AFTER\_SOLVE)}
-*    \State $x_n \leftarrow x$ and $\dot x_n \leftarrow f(x,t_n)$
-*    \State {\it appAction.execute(solutionHistory, stepper, END\_STEP)}
-*  \end{algorithmic}
-*  \f}
+ *
+ *  This class provides a means to apply various actions with the Trapezoidal time step.
+ *  The data available to this class is solution variables (through
+ *  SolutionHistory), and stepper data (through the Stepper).  It allows
+ *  the application to just observe this data, i.e., use but not change
+ *  any of it (USER BEWARE!).
+ *
+ *  The locations for these AppAction calls
+ *  (StepperTrapezoidalAppAction::ACTION_LOCATION) are shown in the
+ *  algorithm documentation of the StepperTrapezoidal.
 */
 template<class Scalar>
 class StepperTrapezoidalAppAction

--- a/packages/tempus/src/Tempus_StepperTrapezoidalModifierBase.hpp
+++ b/packages/tempus/src/Tempus_StepperTrapezoidalModifierBase.hpp
@@ -16,32 +16,22 @@
 namespace Tempus {
 
 /** \brief Base modifier for StepperTrapezoidal.
-*
-*  This class provides a means to modify values (e.g., solution variables
-*  through SolutionHistory, and stepper member data through the Stepper),
-*  and can be very powerful and easy to make changes to the stepper and
-*  the solution.
-*
-*  Users deriving from this class can access a lot of data, and it is
-*  expected that those users know what changes are allowable without
-*  affecting the Stepper correctness, performance, accuracy and stability.
-*  Thus the user should be careful when accessing data through classes
-*  derived from the default modifier (i.e., USER BEWARE!!).
-* 
-*  \f{algorithm}{                                                             
-*  \renewcommand{\thealgorithm}{}                                                          
-*  \caption{Trapezoidal stepper with modfiy call locations indicated.}                    
-*  \begin{algorithmic}[1]                                                                
-*    \State {\it modifier.modify(solutionHistory, stepper, BEGIN\_STEP)}                 
-*    \State Compute $y \leftarrow x_{n-1} + \frac{\Delta t_{n-1}}{2}f(x_{n-1},t_{n-1})$    
-*    \State {\it modifier.modify(solutionHistory, stepper, BEFORE\_SOLVE)}                
-*    \State Solve $x - y - \frac{\Delta t_{n-1}}{2}f(x,t_{n}) = 0$ for $x$    
-*    \State {\it modifier.modify(solutionHistory, stepper, AFTER\_SOLVE)}                
-*    \State $x_n \leftarrow x$ and $\dot x_n \leftarrow f(x,t_n)$                      
-*    \State {\it modifier.modify(solutionHistory, stepper, END\_STEP)}           
-*  \end{algorithmic}                                                                 
-*  \f}                 
-*/
+ *
+ *  This class provides a means to modify values (e.g., solution variables
+ *  through SolutionHistory, and stepper member data through the Stepper),
+ *  and can be very powerful and easy to make changes to the stepper and
+ *  the solution.
+ *
+ *  Users deriving from this class can access a lot of data, and it is
+ *  expected that those users know what changes are allowable without
+ *  affecting the Stepper correctness, performance, accuracy and stability.
+ *  Thus the user should be careful when accessing data through classes
+ *  derived from the default modifier (i.e., USER BEWARE!!).
+ *
+ *  The locations for these AppAction calls
+ *  (StepperTrapezoidalAppAction::ACTION_LOCATION) are shown in the
+ *  algorithm documentation of the StepperTrapezoidal.
+ */
 
 template<class Scalar>
 class StepperTrapezoidalModifierBase

--- a/packages/tempus/src/Tempus_StepperTrapezoidalModifierXBase.hpp
+++ b/packages/tempus/src/Tempus_StepperTrapezoidalModifierXBase.hpp
@@ -17,34 +17,22 @@
 namespace Tempus {
 
 /** \brief Base ModifierX for StepperTrapezoidal.
-*
-*  This class provides a means to modify just the solution values
-*  (i.e., \f$x\f$ and \f$dot{x}\f$), and nothing else, but time and
-*  timestep are also provided.
-*
-*  Users deriving from this class can access and change the solution
-*  during the timestep (e.g., limiting the solution for monoticity).
-*  It is expected that the user knows what changes are allowable without
-*  affecting the Stepper correctness, performance, accuracy and stability
-*  (i.e., USER BEWARE!!).
-*
-*  Below is the Trapezoidal algorithm with the locations of the ModifierX calls
-*  italicized.
-*
-*  \f{algorithm}{                                                                                           
-*  \renewcommand{\thealgorithm}{}                                                                              
-*  \caption{Trapezoidal stepper with modfiyX call locations indicated.}                                        
-*  \begin{algorithmic}[1]                                                                                      
-*    \State {\it modifierX.modify(x, time, dt, X\_BEGIN\_STEP)}                                       
-*    \State Compute $y \leftarrow x_{n-1} + \frac{\Delta t_{n-1}}{2}f(x_{n-1},t_{n-1})$                        
-*    \State {\it modifierX.modify(x, time, dt, X\_BEFORE\_SOLVE)}                                     
-*    \State Solve $x - y - \frac{\Delta t_{n-1}}{2}f(x,t_{n}) = 0$ for $x$                    
-*    \State {\it modifierX.modify(x, time, dt,X\_AFTER\_SOLVE)}                                      
-*    \State $x_n \leftarrow x$ and $\dot x_n \leftarrow f(x,t_n)$                                              
-*    \State {\it modifierX.modify(x, time, dt, XDOT\_END\_STEP)}                                        
-*  \end{algorithmic}                                                                                           
-*  \f}  
-*/
+ *
+ *  This class provides a means to modify just the solution values
+ *  (i.e., \f$x\f$ and \f$dot{x}\f$), and nothing else, but time and
+ *  timestep are also provided.
+ *
+ *  Users deriving from this class can access and change the solution
+ *  during the timestep (e.g., limiting the solution for monoticity).
+ *  It is expected that the user knows what changes are allowable without
+ *  affecting the Stepper correctness, performance, accuracy and stability
+ *  (i.e., USER BEWARE!!).
+ *
+ *  The locations of the StepperTrapezoidalModifierXBase::MODIFIER_TYPE
+ *  which correspond to the AppAction calls
+ *  (StepperTrapezoidalAppAction::ACTION_LOCATION) are shown in the
+ *  algorithm documentation of the StepperTrapezoidal.
+ */
 template<class Scalar>
 class StepperTrapezoidalModifierXBase
   : virtual public Tempus::StepperTrapezoidalAppAction<Scalar>

--- a/packages/tempus/src/Tempus_StepperTrapezoidalObserverBase.hpp
+++ b/packages/tempus/src/Tempus_StepperTrapezoidalObserverBase.hpp
@@ -17,33 +17,20 @@
 namespace Tempus {
 
 /** \brief Base observer for StepperTrapezoidal.
-*
-*  This class provides a means to observe values (e.g., solution variables
-*  through SolutionHistory, and stepper member data through the Stepper),
-*  and cannot modify them.
-*
-*  Users deriving from this class can observer a lot of data, and it is
-*  expected that users will NOT modify any of that data.  If the user
-*  wishes to modify the solution and/or stepper data during the
-*  Stepper::takeStep, they should use the Modifier class (with care!).
-*
-*  Below is the Trapezoidal algorithm with the locations of the observe calls
-*  italicized.
-*
-*  \f{algorithm}{                                                                                                   
-*  \renewcommand{\thealgorithm}{}                                                                                   
-*  \caption{Trapezoidal stepper with observe call locations indicated.}                                       
-*  \begin{algorithmic}[1]                                                                                       
-*    \State {\it observer.observe(solutionHistory, stepper, BEGIN\_STEP)}                                          
-*    \State Compute $y \leftarrow x_{n-1} + \frac{\Delta t_{n-1}}{2}f(x_{n-1},t_{n-1})$                           
-*    \State {\it observer.observe(solutionHistory, stepper, BEFORE\_SOLVE)}                                   
-*    \State Solve $x - y - \frac{\Delta t_{n-1}}{2}f(x,t_{n}) = 0$ for $x$                    
-*    \State {\it observer.observe(solutionHistory, stepper, AFTER\_SOLVE)}                                    
-*    \State $x_n \leftarrow x$ and $\dot x_n \leftarrow f(x,t_n)$                                               
-*    \State {\it observer.observe(solutionHistory, stepper, END\_STEP)}                                       
-*  \end{algorithmic}                                                                                          
-*  \f}       
-*/
+ *
+ *  This class provides a means to observe values (e.g., solution variables
+ *  through SolutionHistory, and stepper member data through the Stepper),
+ *  and cannot modify them.
+ *
+ *  Users deriving from this class can observer a lot of data, and it is
+ *  expected that users will NOT modify any of that data.  If the user
+ *  wishes to modify the solution and/or stepper data during the
+ *  Stepper::takeStep, they should use the Modifier class (with care!).
+ *
+ *  The locations for these AppAction calls
+ *  (StepperTrapezoidalAppAction::ACTION_LOCATION) are shown in the
+ *  algorithm documentation of the StepperTrapezoidal.
+ */
 template<class Scalar>
 class StepperTrapezoidalObserverBase
   : virtual public Tempus::StepperTrapezoidalAppAction<Scalar>

--- a/packages/tempus/src/Tempus_StepperTrapezoidal_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperTrapezoidal_decl.hpp
@@ -25,19 +25,29 @@ namespace Tempus {
  *  solver (e.g., a non-linear solver, like NOX).
  *
  *  <b> Algorithm </b>
- *  The single-timestep algorithm for Forward Euler is
- *  \f{algorithm}{
- *  \renewcommand{\thealgorithm}{}
- *  \caption{Forward Euler}
- *  \begin{algorithmic}[1]
- *    \State {\it appAction.execute(solutionHistory, stepper, BEGIN\_STEP)}
- *    \State {Get $\dot{x}$ from SolutionHistory or from Stepper}
- *    \State {\it appAction.execute(solutionHistory, stepper, BEFORE\_SOLVE)}
- *    \State $\mathcal{F}_n(\dot{x}=(x_n-x_{n-1})/(\Delta t_n/2) - \dot{x}_{n-1}, x_n, t_n)=0\f$ for \f$x_n$
- *    \State {\it appAction.execute(solutionHistory, stepper, AFTER\_SOLVE)}
- *    \State $\dot{x}_n \leftarrow (x_n-x_{n-1})/(\Delta t_n/2) - \dot{x}_{n-1}$
- *    \State {\it appAction.execute(solutionHistory, stepper, END\_STEP)}
- *  \end{algorithmic}
+ *  The single-timestep algorithm for Trapezoidal is
+ *
+ *  \f{center}{
+ *    \parbox{5in}{
+ *    \rule{5in}{0.4pt} \\
+ *    {\bf Algorithm} Trapezoidal \\
+ *    \rule{5in}{0.4pt} \vspace{-15pt}
+ *    \begin{enumerate}
+ *      \setlength{\itemsep}{0pt} \setlength{\parskip}{0pt} \setlength{\parsep}{0pt}
+ *      \item {\it appAction.execute(solutionHistory, stepper, BEGIN\_STEP)}
+ *      \item {\bf Set ODE parameters.}
+ *      \item \quad {\bf Time derivative: }
+ *                  $\dot{x}_{n} = \frac{(x_{n} - x_{n-1})}{(\Delta t_n/2)} - \dot{x}_{n-1}.$
+ *      \item \quad {\bf Alpha: $\alpha = \frac{2}{\Delta t_n}$}
+ *      \item \quad {\bf Beta: $\beta = 1$}
+ *      \item {\it appAction.execute(solutionHistory, stepper, BEFORE\_SOLVE)}
+ *      \item {\bf Solve $\mathcal{F}_n(\dot{x}=(x_n-x_{n-1})/(\Delta t_n/2) - \dot{x}_{n-1}, x_n, t_n)=0$ for $x_n$}
+ *      \item {\it appAction.execute(solutionHistory, stepper, AFTER\_SOLVE)}
+ *      \item $\dot{x}_n \leftarrow (x_n-x_{n-1})/(\Delta t_n/2) - \dot{x}_{n-1}$
+ *      \item {\it appAction.execute(solutionHistory, stepper, END\_STEP)}
+ *    \end{enumerate}
+ *    \vspace{-10pt} \rule{5in}{0.4pt}
+ *    }
  *  \f}
  *
  *  The First-Same-As-Last (FSAL) principle is required for the Trapezoidal

--- a/packages/tempus/unit_test/Tempus_UnitTest_BDF2.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_BDF2.cpp
@@ -82,7 +82,7 @@ namespace Tempus_Unit_Test {
     stepper->setZeroInitialGuess(zeroInitialGuess);      stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
 
     stepper = rcp(new Tempus::StepperBDF2<double>(model, solver, startUpStepper, useFSAL,
-						    ICConsistency, ICConsistencyCheck, zeroInitialGuess,modifier));
+              ICConsistency, ICConsistencyCheck, zeroInitialGuess,modifier));
     TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
     // Test stepper properties.
     TEUCHOS_ASSERT(stepper->getOrder() == 2);
@@ -118,8 +118,8 @@ public:
 
   /// Modify BDF2 Stepper at end of takeStep.
   virtual void modify(Teuchos::RCP<Tempus::SolutionHistory<double> > sh,
-		      Teuchos::RCP<Tempus::StepperBDF2<double> > stepper,
-		      const typename Tempus::StepperBDF2AppAction<double>::ACTION_LOCATION actLoc)
+    Teuchos::RCP<Tempus::StepperBDF2<double> > stepper,
+    const typename Tempus::StepperBDF2AppAction<double>::ACTION_LOCATION actLoc)
   {
     switch(actLoc) {
     case StepperBDF2AppAction<double>::BEGIN_STEP:
@@ -145,8 +145,8 @@ public:
     case StepperBDF2AppAction<double>::END_STEP:
       {
         testEND_STEP = true;
-	auto x  = sh->getWorkingState()->getX();
-	testWorkingValue = get_ele(*(x), 0);
+        auto x  = sh->getWorkingState()->getX();
+        testWorkingValue = get_ele(*(x), 0);
         break;
       }
     default:
@@ -246,8 +246,8 @@ public:
 
   /// Modify BDF2 Stepper at end of takeStep.
   virtual void modify(Teuchos::RCP<Tempus::SolutionHistory<double> > sh,
-		      Teuchos::RCP<Tempus::StepperBDF2<double> > stepper,
-		      const typename Tempus::StepperBDF2AppAction<double>::ACTION_LOCATION actLoc)
+    Teuchos::RCP<Tempus::StepperBDF2<double> > stepper,
+    const typename Tempus::StepperBDF2AppAction<double>::ACTION_LOCATION actLoc)
   {
     switch(actLoc) {
     case StepperBDF2AppAction<double>::BEGIN_STEP:
@@ -260,7 +260,7 @@ public:
     case StepperBDF2AppAction<double>::BEFORE_SOLVE:
       {
         testBEFORE_SOLVE = true;
-	testType = stepper->getStepperType();
+        testType = stepper->getStepperType();
         break;
       }
     case StepperBDF2AppAction<double>::AFTER_SOLVE:
@@ -373,9 +373,9 @@ public:
 
   /// Modify BDF2 Stepper at end of takeStep.
   virtual void modify(
-		      Teuchos::RCP<Thyra::VectorBase<double> > x,
-		      const double time, const double dt,
-		      const typename Tempus::StepperBDF2ModifierXBase<double>::MODIFIER_TYPE modType)
+    Teuchos::RCP<Thyra::VectorBase<double> > x,
+    const double time, const double dt,
+    const typename Tempus::StepperBDF2ModifierXBase<double>::MODIFIER_TYPE modType)
   {
     switch(modType) {
     case StepperBDF2ModifierXBase<double>::X_BEGIN_STEP:

--- a/packages/tempus/unit_test/Tempus_UnitTest_ForwardEuler.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_ForwardEuler.cpp
@@ -110,14 +110,14 @@ public:
 
   /// Observe ForwardEuler Stepper at end of takeStep.
   virtual void modify(
-		      Teuchos::RCP<Tempus::SolutionHistory<double> > sh,
-		      Teuchos::RCP<Tempus::StepperForwardEuler<double> > stepper,
-		      const typename Tempus::StepperForwardEulerAppAction<double>::ACTION_LOCATION actLoc)
+    Teuchos::RCP<Tempus::SolutionHistory<double> > sh,
+    Teuchos::RCP<Tempus::StepperForwardEuler<double> > stepper,
+    const typename Tempus::StepperForwardEulerAppAction<double>::ACTION_LOCATION actLoc)
   {
     switch(actLoc) {
     case StepperForwardEulerAppAction<double>::BEGIN_STEP:
       {
-	testBEGIN_STEP = true;
+        testBEGIN_STEP = true;
         auto x = sh->getCurrentState()->getX();
         testCurrentValue = get_ele(*(x), 0);
         break;
@@ -140,7 +140,7 @@ public:
       }
     default:
       TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error,
-				 "Error - unknown action location.\n");
+        "Error - unknown action location.\n");
     }
   }
   bool testBEGIN_STEP;
@@ -223,9 +223,9 @@ public:
 
   /// Observe ForwardEuler Stepper at end of takeStep.
   virtual void observe(
-		       Teuchos::RCP<const Tempus::SolutionHistory<double> > sh,
-		       Teuchos::RCP<const Tempus::StepperForwardEuler<double> > stepper,
-		       const typename Tempus::StepperForwardEulerAppAction<double>::ACTION_LOCATION actLoc)
+    Teuchos::RCP<const Tempus::SolutionHistory<double> > sh,
+    Teuchos::RCP<const Tempus::StepperForwardEuler<double> > stepper,
+    const typename Tempus::StepperForwardEulerAppAction<double>::ACTION_LOCATION actLoc)
   {
     switch(actLoc) {
     case StepperForwardEulerAppAction<double>::BEGIN_STEP:
@@ -251,7 +251,7 @@ public:
       }
     default:
       TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error,
-				 "Error - unknown action location.\n");
+        "Error - unknown action location.\n");
     }
   }
 
@@ -334,9 +334,9 @@ public:
 
   /// Observe BackwardEuler Stepper at end of takeStep.
   virtual void modify(
-		      Teuchos::RCP<Thyra::VectorBase<double> > x,
-		      const double time, const double dt,
-		      const typename Tempus::StepperForwardEulerModifierXBase<double>::MODIFIER_TYPE modType)
+    Teuchos::RCP<Thyra::VectorBase<double> > x,
+    const double time, const double dt,
+    const typename Tempus::StepperForwardEulerModifierXBase<double>::MODIFIER_TYPE modType)
   {
     switch(modType) {
     case StepperForwardEulerModifierXBase<double>::X_BEGIN_STEP:
@@ -360,7 +360,7 @@ public:
       }
     default:
       TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error,
-				 "Error - unknown action location.\n");
+        "Error - unknown action location.\n");
     }
   }
   bool testX_BEGIN_STEP;

--- a/packages/tempus/unit_test/Tempus_UnitTest_HHTAlpha.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_HHTAlpha.cpp
@@ -164,7 +164,7 @@ public:
       }
     default:
       TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error,
-				 "Error - unknown action location.\n");
+        "Error - unknown action location.\n");
     }
   }
   bool testBEGIN_STEP;
@@ -267,7 +267,7 @@ public:
     }
     default:
       TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error,
-				 "Error - unknown action location.\n");
+        "Error - unknown action location.\n");
     }
   }
 
@@ -369,7 +369,7 @@ public:
     }
     default:
     TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error,
-			       "Error - unknown action location.\n");
+      "Error - unknown action location.\n");
     }
   }
 

--- a/packages/tempus/unit_test/Tempus_UnitTest_Leapfrog.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_Leapfrog.cpp
@@ -95,8 +95,10 @@ public:
 
   /// Constructor
   StepperLeapfrogModifierTest()
-    : testBEGIN_STEP(false), testBEFORE_X_UPDATE(false),testBEFORE_EXPLICIT_EVAL(false),
-      testBEFORE_XDOT_UPDATE(false), testCurrentValue(-0.99), testWorkingValue(-0.99),
+    : testBEGIN_STEP(false), testBEFORE_X_UPDATE(false),
+      testBEFORE_EXPLICIT_EVAL(false), testBEFORE_XDOT_UPDATE(false),
+      testEND_STEP(false),
+      testCurrentValue(-0.99), testWorkingValue(-0.99),
       testDt(-1.5), testType("")
   {}
 
@@ -138,6 +140,11 @@ public:
         testWorkingValue = get_ele(*(x), 0);
         break;
       }
+    case StepperLeapfrogAppAction<double>::END_STEP:
+      {
+        testEND_STEP = true;
+        break;
+      }
     default:
       TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error,
                                  "Error - unknown action location.\n");
@@ -147,6 +154,7 @@ public:
   bool testBEFORE_X_UPDATE;
   bool testBEFORE_EXPLICIT_EVAL;
   bool testBEFORE_XDOT_UPDATE;
+  bool testEND_STEP;
   double testCurrentValue;
   double testWorkingValue;
   double testDt;
@@ -199,6 +207,7 @@ TEUCHOS_UNIT_TEST(Leapfrog, AppAction_Modifier)
   TEST_COMPARE(modifier->testBEFORE_EXPLICIT_EVAL, ==, true);
   TEST_COMPARE(modifier->testBEFORE_X_UPDATE, ==, true);
   TEST_COMPARE(modifier->testBEFORE_XDOT_UPDATE, ==, true);
+  TEST_COMPARE(modifier->testEND_STEP, ==, true);
 
   auto x = solutionHistory->getCurrentState()->getX();
   TEST_FLOATING_EQUALITY(modifier->testCurrentValue, get_ele(*(x), 0), 1.0e-15);
@@ -220,6 +229,7 @@ public:
   StepperLeapfrogModifierXTest()
     : testX_BEGIN_STEP(false), testX_BEFORE_EXPLICIT_EVAL(false),
       testX_BEFORE_X_UPDATE(false), testX_BEFORE_XDOT_UPDATE(false),
+      testX_END_STEP(false),
       testX(0.0), testDt(-1.25), testTime(-1.25),testType("")
   {}
 
@@ -254,7 +264,12 @@ public:
     case StepperLeapfrogModifierXBase<double>::X_BEFORE_XDOT_UPDATE:
       {
         testX_BEFORE_XDOT_UPDATE = true;
-	testType = "Leapfrog - ModifierX";
+        testType = "Leapfrog - ModifierX";
+        break;
+      }
+    case StepperLeapfrogModifierXBase<double>::X_END_STEP:
+      {
+        testX_END_STEP = true;
         break;
       }
     default:
@@ -266,6 +281,7 @@ public:
   bool testX_BEFORE_EXPLICIT_EVAL;
   bool testX_BEFORE_X_UPDATE;
   bool testX_BEFORE_XDOT_UPDATE;
+  bool testX_END_STEP;
   double testX;
   double testDt;
   double testTime;
@@ -318,6 +334,7 @@ TEUCHOS_UNIT_TEST(LeapFrog, AppAction_ModifierX)
   TEST_COMPARE(modifierX->testX_BEFORE_EXPLICIT_EVAL, ==, true);
   TEST_COMPARE(modifierX->testX_BEFORE_XDOT_UPDATE, ==, true);
   TEST_COMPARE(modifierX->testX_BEFORE_X_UPDATE, ==, true);
+  TEST_COMPARE(modifierX->testX_END_STEP, ==, true);
 
   auto x = solutionHistory->getCurrentState()->getX();
   TEST_FLOATING_EQUALITY(modifierX->testX, get_ele(*(x), 0), 1.0e-15);
@@ -339,6 +356,7 @@ public:
   StepperLeapfrogObserverTest()
     : testBEGIN_STEP(false), testBEFORE_EXPLICIT_EVAL(false),
       testBEFORE_X_UPDATE(false), testBEFORE_XDOT_UPDATE(false),
+      testEND_STEP(false),
       testCurrentValue(-0.99), testWorkingValue(-0.99),
       testDt(-1.5), testType("")
   {}
@@ -347,9 +365,9 @@ public:
 
   /// Observe Leapfrog Stepper at action location.
   virtual void observe(
-		       Teuchos::RCP<const Tempus::SolutionHistory<double> > sh,
-		       Teuchos::RCP<const Tempus::StepperLeapfrog<double> > stepper,
-		       const typename Tempus::StepperLeapfrogAppAction<double>::ACTION_LOCATION actLoc)
+    Teuchos::RCP<const Tempus::SolutionHistory<double> > sh,
+    Teuchos::RCP<const Tempus::StepperLeapfrog<double> > stepper,
+    const typename Tempus::StepperLeapfrogAppAction<double>::ACTION_LOCATION actLoc)
   {
     switch(actLoc) {
     case StepperLeapfrogAppAction<double>::BEGIN_STEP:
@@ -378,15 +396,21 @@ public:
         testWorkingValue = get_ele(*(x), 0);
         break;
       }
+    case StepperLeapfrogAppAction<double>::END_STEP:
+      {
+        testEND_STEP = true;
+        break;
+      }
     default:
       TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error,
-				 "Error - unknown action location.\n");
+        "Error - unknown action location.\n");
     }
   }
   bool testBEGIN_STEP;
   bool testBEFORE_EXPLICIT_EVAL;
   bool testBEFORE_X_UPDATE;
   bool testBEFORE_XDOT_UPDATE;
+  bool testEND_STEP;
   double testCurrentValue;
   double testWorkingValue;
   double testDt;
@@ -437,6 +461,12 @@ TEUCHOS_UNIT_TEST(Leapfrog, AppAction_Observer)
   stepper->takeStep(solutionHistory);
 
   // Testing that values can be observed through the observer.
+  TEST_COMPARE(observer->testBEGIN_STEP, ==, true);
+  TEST_COMPARE(observer->testBEFORE_EXPLICIT_EVAL, ==, true);
+  TEST_COMPARE(observer->testBEFORE_X_UPDATE, ==, true);
+  TEST_COMPARE(observer->testBEFORE_XDOT_UPDATE, ==, true);
+  TEST_COMPARE(observer->testEND_STEP, ==, true);
+
   auto x = solutionHistory->getCurrentState()->getX();
   TEST_FLOATING_EQUALITY(observer->testCurrentValue, get_ele(*(x), 0), 1.0e-15);
   x = solutionHistory->getWorkingState()->getX();

--- a/packages/tempus/unit_test/Tempus_UnitTest_OperatorSplit.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_OperatorSplit.cpp
@@ -186,7 +186,7 @@ public:
       }
       default:
         TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error,
-	"Error - unknown action location.\n");
+          "Error - unknown action location.\n");
     }
   }
 
@@ -311,7 +311,7 @@ public:
       }
     default:
       TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error,
-				 "Error - unknown action location.\n");
+        "Error - unknown action location.\n");
     }
   }
 
@@ -433,7 +433,7 @@ public:
       }
     default:
       TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error,
-				 "Error - unknown action location.\n");
+        "Error - unknown action location.\n");
     }
   }
 

--- a/packages/tempus/unit_test/Tempus_UnitTest_Trapezoidal.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_Trapezoidal.cpp
@@ -111,9 +111,9 @@ public:
 
   /// Modify Trapezoidal Stepper at action location.
   virtual void modify(
-		      Teuchos::RCP<Tempus::SolutionHistory<double> > sh,
-		      Teuchos::RCP<Tempus::StepperTrapezoidal<double> > stepper,
-		      const typename Tempus::StepperTrapezoidalAppAction<double>::ACTION_LOCATION actLoc)
+    Teuchos::RCP<Tempus::SolutionHistory<double> > sh,
+    Teuchos::RCP<Tempus::StepperTrapezoidal<double> > stepper,
+    const typename Tempus::StepperTrapezoidalAppAction<double>::ACTION_LOCATION actLoc)
   {
     switch(actLoc) {
     case StepperTrapezoidalAppAction<double>::BEGIN_STEP:
@@ -146,7 +146,7 @@ public:
       }
     default:
       TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error,
-				 "Error - unknown action location.\n");
+        "Error - unknown action location.\n");
     }
   }
 
@@ -351,7 +351,7 @@ public:
     }
     default:
       TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error,
-				 "Error - unknown action location.\n");
+        "Error - unknown action location.\n");
     }
   }
   bool testX_BEGIN_STEP;


### PR DESCRIPTION
Need to remove our doxygen dependency on algpseudocode and algorithm
as not all systems have it installed, and therefore the doxygen
documentation was not available.  Just used simple latex functionality
to reproduce the pseudo-algorithms.

 * Cleaned up documentation between Steppers and AppActions.
   - AppActions (Modifier, ModifierX and Observer) reference Stepper's
     pseudo-code.
 * Fix bugs int Leapfrog AppAction
   - Removed BEFORE_XDOT_UPDATE_INITIALIZE as it was not being used).
   - Added END_STEP.
 * Fixed some bugs in the doxygen
   - Miss use of algpseudocode.
   - doxygen confused ">>" used in templating (cahnged to "> >".
 * Removed tabs.

@trilinos/tempus 

* Closes #8844 
