### PR TITLE
Intrepid2: UVM-free MonolothicExecutable Tests

### DIFF
--- a/packages/intrepid2/src/Cell/Intrepid2_CellGeometry.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellGeometry.hpp
@@ -76,7 +76,7 @@ namespace Intrepid2
       
    \note Conceptually, it would make sense to use class inheritance and have different member data for each type of geometry supported.  We instead glom all the options together into one multi-modal class; this is basically to avoid certain difficulties with vtables under CUDA.
    */
-  template<class PointScalar, int spaceDim, typename ExecSpaceType = Kokkos::DefaultExecutionSpace>
+  template<class PointScalar, int spaceDim, typename DeviceType = Kokkos::DefaultExecutionSpace>
   class CellGeometry
   {
     public:
@@ -122,7 +122,7 @@ namespace Intrepid2
        \param [in] endCell - the first cell ordinal for which the Jacobian will not be evaluated (used to define worksets smaller than the whole CellGeometry); use -1 to indicate that all cells from startCell on should be evaluated.
        \return a Data object appropriately sized to accomodate the specified Jacobian values.
     */
-    Data<PointScalar,ExecSpaceType> allocateJacobianDataPrivate(const TensorPoints<PointScalar,ExecSpaceType> &points, const int &pointsPerCell, const int startCell, const int endCell) const;
+    Data<PointScalar,DeviceType> allocateJacobianDataPrivate(const TensorPoints<PointScalar,DeviceType> &points, const int &pointsPerCell, const int startCell, const int endCell) const;
     
     /** \brief  Notionally-private method that provides a common interface for multiple public-facing setJacobianData() methods.  (Marked as public due to compiler constraints.)
        \param [out] jacobianData - a container, allocated by allocateJacobianData(), into which the evaluated Jacobians will be placed.
@@ -132,14 +132,14 @@ namespace Intrepid2
        \param [in] startCell - the first cell ordinal for which the Jacobian will be evaluated (used to define worksets smaller than the whole CellGeometry).
        \param [in] endCell - the first cell ordinal for which the Jacobian will not be evaluated (used to define worksets smaller than the whole CellGeometry); use -1 to indicate that all cells from startCell on should be evaluated.
     */
-    void setJacobianDataPrivate(Data<PointScalar,ExecSpaceType> &jacobianData, const TensorPoints<PointScalar,ExecSpaceType> &points, const int &pointsPerCell,
-                                const Data<PointScalar,ExecSpaceType> &refData, const int startCell, const int endCell) const;
+    void setJacobianDataPrivate(Data<PointScalar,DeviceType> &jacobianData, const TensorPoints<PointScalar,DeviceType> &points, const int &pointsPerCell,
+                                const Data<PointScalar,DeviceType> &refData, const int startCell, const int endCell) const;
   protected:
     HypercubeNodeOrdering nodeOrdering_;
     CellGeometryType    cellGeometryType_;
     SubdivisionStrategy subdivisionStrategy_ = NO_SUBDIVISION;
     bool affine_; // if true, each cell has constant Jacobian across the cell
-    Data<Orientation, ExecSpaceType> orientations_; // for grid types, this could have either a single entry or one matching numCellsPerGridCell().  For other types, it has as many entries as there are cells.
+    Data<Orientation, DeviceType> orientations_; // for grid types, this could have either a single entry or one matching numCellsPerGridCell().  For other types, it has as many entries as there are cells.
     
     // uniform grid data -- used for UNIFORM_GRID type
     Kokkos::Array<PointScalar,spaceDim> origin_;         // point specifying a corner of the mesh
@@ -147,13 +147,13 @@ namespace Intrepid2
     Kokkos::Array<int,spaceDim>         gridCellCounts_; // how many grid cells wide the mesh is in each dimension
     
     // tensor grid data -- only used for TENSOR_GRID type
-    TensorPoints<PointScalar, ExecSpaceType> tensorVertices_;
+    TensorPoints<PointScalar, DeviceType> tensorVertices_;
     
     // arbitrary cell node data, used for both higher-order and first-order
     // (here, nodes are understood as geometry degrees of freedom)
-    ScalarView<int,ExecSpaceType>         cellToNodes_; // (C,N) -- N is the number of nodes per cell; values are global node ordinals
-    ScalarView<PointScalar,ExecSpaceType> nodes_;       // (GN,D) or (C,N,D) -- GN is the number of global nodes; (C,N,D) used only if cellToNodes_ is empty.
-    using BasisPtr = Teuchos::RCP< Basis<ExecSpaceType,PointScalar,PointScalar> >;
+    ScalarView<int,DeviceType>         cellToNodes_; // (C,N) -- N is the number of nodes per cell; values are global node ordinals
+    ScalarView<PointScalar,DeviceType> nodes_;       // (GN,D) or (C,N,D) -- GN is the number of global nodes; (C,N,D) used only if cellToNodes_ is empty.
+    using BasisPtr = Teuchos::RCP< Basis<DeviceType,PointScalar,PointScalar> >;
     
     unsigned numCells_        = 0;
     unsigned numNodesPerCell_ = 0;
@@ -179,8 +179,8 @@ namespace Intrepid2
         \param [in] nodeOrdering - applicable for hypercube cell topologies; specifies whether to use the order used by Shards (and lowest-order Intrepid2 bases), or the one used by higher-order Intrepid2 bases.
     */
     CellGeometry(const shards::CellTopology &cellTopo,
-                 ScalarView<int,ExecSpaceType> cellToNodes,
-                 ScalarView<PointScalar,ExecSpaceType> nodes,
+                 ScalarView<int,DeviceType> cellToNodes,
+                 ScalarView<PointScalar,DeviceType> nodes,
                  const bool claimAffine = false,
                  const HypercubeNodeOrdering nodeOrdering = HYPERCUBE_NODE_ORDER_CLASSIC_SHARDS);
 
@@ -188,8 +188,8 @@ namespace Intrepid2
         \param [in] basisForNodes - the basis in terms of which the reference-to-physical transformation is expressed.
         \param [in] cellNodes - (C,F,D) container specifying the coordinate weight of the node; F is the (local) field ordinal for the basis in terms of which the reference-to-physical transformation is expressed.
      */
-    CellGeometry(Teuchos::RCP<Intrepid2::Basis<ExecSpaceType,PointScalar,PointScalar> > basisForNodes,
-                 ScalarView<PointScalar,ExecSpaceType> cellNodes);
+    CellGeometry(Teuchos::RCP<Intrepid2::Basis<DeviceType,PointScalar,PointScalar> > basisForNodes,
+                 ScalarView<PointScalar,DeviceType> cellNodes);
     
     /** \brief  Copy constructor.
         \param [in] cellGeometry - the object being copied.
@@ -209,14 +209,14 @@ namespace Intrepid2
        \param [in] cubatureWeights - a container approriately sized to store the quadrature weights.
        \return TensorData object sized to accept the result of computeCellMeasure() when called with the provided jacobianDet and cubatureWeights arguments.
     */
-    TensorData<PointScalar,ExecSpaceType> allocateCellMeasure( const Data<PointScalar,ExecSpaceType> & jacobianDet, const TensorData<PointScalar,ExecSpaceType> & cubatureWeights ) const;
+    TensorData<PointScalar,DeviceType> allocateCellMeasure( const Data<PointScalar,DeviceType> & jacobianDet, const TensorData<PointScalar,DeviceType> & cubatureWeights ) const;
     
     /** \brief  Compute cell measures that correspond to provided Jacobian determinants and
        \param [out] cellMeasure - a container, usually provided by allocateCellMeasure(), to store the cell measures.
        \param [in] jacobianDet -  the determinants of the Jacobians of the reference-to-physical mapping.
        \param [in] cubatureWeights - the quadrature weights.
     */
-    void computeCellMeasure( TensorData<PointScalar,ExecSpaceType> &cellMeasure, const Data<PointScalar,ExecSpaceType> & jacobianDet, const TensorData<PointScalar,ExecSpaceType> & cubatureWeights ) const;
+    void computeCellMeasure( TensorData<PointScalar,DeviceType> &cellMeasure, const Data<PointScalar,DeviceType> & jacobianDet, const TensorData<PointScalar,DeviceType> & cubatureWeights ) const;
     
     //! H^1 Basis used in the reference-to-physical transformation.  Linear for straight-edged geometry; higher-order for curvilinear.
     BasisPtr basisForNodes() const;
@@ -267,7 +267,7 @@ namespace Intrepid2
     Orientation getOrientation(int &cellNumber) const;
     
     //! Returns the orientations for all cells.  Calls initializeOrientations() if it has not previously been called.
-    Data<Orientation,ExecSpaceType> getOrientations();
+    Data<Orientation,DeviceType> getOrientations();
     
     //! returns coordinate in dimension dim of the indicated node in the indicated grid cell
     KOKKOS_INLINE_FUNCTION
@@ -302,7 +302,7 @@ namespace Intrepid2
        \param [in] endCell - the first cell ordinal for which the Jacobian will not be evaluated (used to define worksets smaller than the whole CellGeometry); use -1 to indicate that all cells from startCell on should be evaluated.
        \return a Data object appropriately sized to accomodate the specified Jacobian values.
     */
-    Data<PointScalar,ExecSpaceType> allocateJacobianData(const TensorPoints<PointScalar,ExecSpaceType> &points, const int startCell=0, const int endCell=-1) const;
+    Data<PointScalar,DeviceType> allocateJacobianData(const TensorPoints<PointScalar,DeviceType> &points, const int startCell=0, const int endCell=-1) const;
     
     /** \brief  Allocate a container into which Jacobians of the reference-to-physical mapping can be placed.
        \param [in] points - the points at which the Jacobian will be evaluated.
@@ -310,7 +310,7 @@ namespace Intrepid2
        \param [in] endCell - the first cell ordinal for which the Jacobian will not be evaluated (used to define worksets smaller than the whole CellGeometry); use -1 to indicate that all cells from startCell on should be evaluated.
        \return a Data object appropriately sized to accomodate the specified Jacobian values.
     */
-    Data<PointScalar,ExecSpaceType> allocateJacobianData(const ScalarView<PointScalar,ExecSpaceType> &points, const int startCell=0, const int endCell=-1) const;
+    Data<PointScalar,DeviceType> allocateJacobianData(const ScalarView<PointScalar,DeviceType> &points, const int startCell=0, const int endCell=-1) const;
     
     /** \brief  Allocate a container into which Jacobians of the reference-to-physical mapping can be placed (variant for affine geometry).
        \param [in] numPoints - the number of points at which the Jacobian will be defined.
@@ -318,13 +318,13 @@ namespace Intrepid2
        \param [in] endCell - the first cell ordinal for which the Jacobian will not be evaluated (used to define worksets smaller than the whole CellGeometry); use -1 to indicate that all cells from startCell on should be evaluated.
        \return a Data object appropriately sized to accomodate the specified Jacobian values.
     */
-    Data<PointScalar,ExecSpaceType> allocateJacobianData(const int &numPoints, const int startCell=0, const int endCell=-1) const;
+    Data<PointScalar,DeviceType> allocateJacobianData(const int &numPoints, const int startCell=0, const int endCell=-1) const;
     
     /** \brief Computes reference-space data for the specified points, to be used in setJacobian().
        \param [in] points - the points at which the Jacobian will be evaluated.
        \return a Data object with any reference-space data required.  This may be empty, if no reference-space data is required in setJacobian().
     */
-    Data<PointScalar,ExecSpaceType> getJacobianRefData(const TensorPoints<PointScalar,ExecSpaceType> &points) const;
+    Data<PointScalar,DeviceType> getJacobianRefData(const TensorPoints<PointScalar,DeviceType> &points) const;
     
     /** \brief Compute Jacobian values for the reference-to-physical transformation, and place them in the provided container.
        \param [out] jacobianData - a container, allocated by allocateJacobianData(), into which the evaluated Jacobians will be placed.
@@ -333,7 +333,7 @@ namespace Intrepid2
        \param [in] startCell - the first cell ordinal for which the Jacobian will be evaluated (used to define worksets smaller than the whole CellGeometry).
        \param [in] endCell - the first cell ordinal for which the Jacobian will not be evaluated (used to define worksets smaller than the whole CellGeometry); use -1 to indicate that all cells from startCell on should be evaluated.
     */
-    void setJacobian(Data<PointScalar,ExecSpaceType> &jacobianData, const TensorPoints<PointScalar,ExecSpaceType> &points, const Data<PointScalar,ExecSpaceType> &refData,
+    void setJacobian(Data<PointScalar,DeviceType> &jacobianData, const TensorPoints<PointScalar,DeviceType> &points, const Data<PointScalar,DeviceType> &refData,
                      const int startCell=0, const int endCell=-1) const;
     
     /** \brief Compute Jacobian values for the reference-to-physical transformation, and place them in the provided container.
@@ -343,7 +343,7 @@ namespace Intrepid2
        \param [in] startCell - the first cell ordinal for which the Jacobian will be evaluated (used to define worksets smaller than the whole CellGeometry).
        \param [in] endCell - the first cell ordinal for which the Jacobian will not be evaluated (used to define worksets smaller than the whole CellGeometry); use -1 to indicate that all cells from startCell on should be evaluated.
     */
-    void setJacobian(Data<PointScalar,ExecSpaceType> &jacobianData, const ScalarView<PointScalar,ExecSpaceType> &points, const Data<PointScalar,ExecSpaceType> &refData,
+    void setJacobian(Data<PointScalar,DeviceType> &jacobianData, const ScalarView<PointScalar,DeviceType> &points, const Data<PointScalar,DeviceType> &refData,
                      const int startCell=0, const int endCell=-1) const;
     
     /** \brief Compute Jacobian values for the reference-to-physical transformation, and place them in the provided container (variant for affine geometry).
@@ -352,7 +352,7 @@ namespace Intrepid2
        \param [in] startCell - the first cell ordinal for which the Jacobian will be evaluated (used to define worksets smaller than the whole CellGeometry).
        \param [in] endCell - the first cell ordinal for which the Jacobian will not be evaluated (used to define worksets smaller than the whole CellGeometry); use -1 to indicate that all cells from startCell on should be evaluated.
     */
-    void setJacobian(Data<PointScalar,ExecSpaceType> &jacobianData, const int &numPoints, const int startCell=0, const int endCell=-1) const;
+    void setJacobian(Data<PointScalar,DeviceType> &jacobianData, const int &numPoints, const int startCell=0, const int endCell=-1) const;
   };
 } // namespace Intrepid2
 

--- a/packages/intrepid2/src/Cell/Intrepid2_CellGeometryDef.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellGeometryDef.hpp
@@ -778,6 +778,7 @@ namespace Intrepid2
       // TODO: handle the other cases
       INTREPID2_TEST_FOR_EXCEPTION_DEVICE_SAFE(true, std::invalid_argument, "support for this CellGeometryType is not yet implemented");
     }
+    return emptyRefData;
   }
   
   template<class PointScalar, int spaceDim, typename ExecSpaceType>

--- a/packages/intrepid2/src/Cell/Intrepid2_CellGeometryDef.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellGeometryDef.hpp
@@ -57,11 +57,11 @@ namespace Intrepid2
   {
     /** \brief Store host-only "members" of CellGeometry using a static map indexed on the CellGeometry pointer.  This allows us to avoid issues related to non-CUDA-aware members with a lambda capture of a CellGeometry object.
      */
-    template<class PointScalar, int spaceDim, typename ExecSpaceType>
+    template<class PointScalar, int spaceDim, typename DeviceType>
     class CellGeometryHostMembers
     {
-      using BasisPtr = Teuchos::RCP<Intrepid2::Basis<ExecSpaceType,PointScalar,PointScalar> >;
-      using CellGeometryType = CellGeometry<PointScalar,spaceDim,ExecSpaceType>;
+      using BasisPtr = Teuchos::RCP<Intrepid2::Basis<DeviceType,PointScalar,PointScalar> >;
+      using CellGeometryType = CellGeometry<PointScalar,spaceDim,DeviceType>;
     public:
       // conceptually, these should be private members, but for the definition of these, we need them to be externally accessible.
       static std::map<const CellGeometryType *, shards::CellTopology> cellTopology_;
@@ -92,14 +92,14 @@ namespace Intrepid2
     };
   
     // member lookup map definitions for CellGeometryHostMembers:
-    template< class PointScalar, int spaceDim, typename ExecSpaceType > typename std::map<const CellGeometry<PointScalar,spaceDim,ExecSpaceType> *, shards::CellTopology> CellGeometryHostMembers< PointScalar,spaceDim,ExecSpaceType>::cellTopology_;
+    template< class PointScalar, int spaceDim, typename DeviceType > typename std::map<const CellGeometry<PointScalar,spaceDim,DeviceType> *, shards::CellTopology> CellGeometryHostMembers< PointScalar,spaceDim,DeviceType>::cellTopology_;
   
-    template< class PointScalar, int spaceDim, typename ExecSpaceType > typename std::map<const CellGeometry<PointScalar,spaceDim,ExecSpaceType> *, Teuchos::RCP<Intrepid2::Basis<ExecSpaceType,PointScalar,PointScalar> >> CellGeometryHostMembers< PointScalar,spaceDim,ExecSpaceType>::basisForNodes_;
+    template< class PointScalar, int spaceDim, typename DeviceType > typename std::map<const CellGeometry<PointScalar,spaceDim,DeviceType> *, Teuchos::RCP<Intrepid2::Basis<DeviceType,PointScalar,PointScalar> >> CellGeometryHostMembers< PointScalar,spaceDim,DeviceType>::basisForNodes_;
   }
 
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
+  template<class PointScalar, int spaceDim, typename DeviceType>
   KOKKOS_INLINE_FUNCTION
-  CellGeometry<PointScalar,spaceDim,ExecSpaceType>::CellGeometry(const CellGeometry<PointScalar,spaceDim,ExecSpaceType> &cellGeometry)
+  CellGeometry<PointScalar,spaceDim,DeviceType>::CellGeometry(const CellGeometry<PointScalar,spaceDim,DeviceType> &cellGeometry)
 :
   nodeOrdering_(cellGeometry.nodeOrdering_),
   cellGeometryType_(cellGeometry.cellGeometryType_),
@@ -119,25 +119,25 @@ namespace Intrepid2
 #ifndef __CUDA_ARCH__
     shards::CellTopology cellTopo = cellGeometry.cellTopology();
     BasisPtr basisForNodes = cellGeometry.basisForNodes();
-    using HostMemberLookup = ::Intrepid2::Impl::CellGeometryHostMembers<PointScalar, spaceDim, ExecSpaceType>;
+    using HostMemberLookup = ::Intrepid2::Impl::CellGeometryHostMembers<PointScalar, spaceDim, DeviceType>;
     HostMemberLookup::constructorCalled(this, cellTopo, basisForNodes);
 #endif
   }
 
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
+  template<class PointScalar, int spaceDim, typename DeviceType>
   KOKKOS_INLINE_FUNCTION
-  CellGeometry<PointScalar,spaceDim,ExecSpaceType>::~CellGeometry()
+  CellGeometry<PointScalar,spaceDim,DeviceType>::~CellGeometry()
   {
     // host-only deregistration with HostMemberLookup:
 #ifndef __CUDA_ARCH__
-    using HostMemberLookup = ::Intrepid2::Impl::CellGeometryHostMembers<PointScalar, spaceDim, ExecSpaceType>;
+    using HostMemberLookup = ::Intrepid2::Impl::CellGeometryHostMembers<PointScalar, spaceDim, DeviceType>;
     HostMemberLookup::destructorCalled(this);
 #endif
   }
 
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
+  template<class PointScalar, int spaceDim, typename DeviceType>
   KOKKOS_INLINE_FUNCTION
-  int CellGeometry<PointScalar,spaceDim,ExecSpaceType>::numCellsPerGridCell(SubdivisionStrategy subdivisionStrategy) const
+  int CellGeometry<PointScalar,spaceDim,DeviceType>::numCellsPerGridCell(SubdivisionStrategy subdivisionStrategy) const
   {
     switch (subdivisionStrategy) {
       case NO_SUBDIVISION:
@@ -155,11 +155,11 @@ namespace Intrepid2
     return -1;
   }
 
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
-  Data<PointScalar,ExecSpaceType>
-  CellGeometry<PointScalar,spaceDim,ExecSpaceType>::allocateJacobianDataPrivate(const TensorPoints<PointScalar,ExecSpaceType> &points, const int &pointsPerCell, const int startCell, const int endCell) const
+  template<class PointScalar, int spaceDim, typename DeviceType>
+  Data<PointScalar,DeviceType>
+  CellGeometry<PointScalar,spaceDim,DeviceType>::allocateJacobianDataPrivate(const TensorPoints<PointScalar,DeviceType> &points, const int &pointsPerCell, const int startCell, const int endCell) const
   {
-    ScalarView<PointScalar,ExecSpaceType> data;
+    ScalarView<PointScalar,DeviceType> data;
     const int rank = 4; // C,P,D,D
     const int CELL_DIM  = 0;
     const int POINT_DIM = 1;
@@ -244,13 +244,13 @@ namespace Intrepid2
       INTREPID2_TEST_FOR_EXCEPTION_DEVICE_SAFE(true, std::invalid_argument, "support for this CellGeometryType is not yet implemented");
     }
     
-    Data<PointScalar,ExecSpaceType> jacobianData(data,rank,extents,variationType,blockPlusDiagonalLastNonDiagonal);
+    Data<PointScalar,DeviceType> jacobianData(data,rank,extents,variationType,blockPlusDiagonalLastNonDiagonal);
     return jacobianData;
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
-  void CellGeometry<PointScalar,spaceDim,ExecSpaceType>::setJacobianDataPrivate(Data<PointScalar,ExecSpaceType> &jacobianData, const TensorPoints<PointScalar,ExecSpaceType> &points,
-                                                                                const int &pointsPerCell, const Data<PointScalar,ExecSpaceType> &refData,
+  template<class PointScalar, int spaceDim, typename DeviceType>
+  void CellGeometry<PointScalar,spaceDim,DeviceType>::setJacobianDataPrivate(Data<PointScalar,DeviceType> &jacobianData, const TensorPoints<PointScalar,DeviceType> &points,
+                                                                                const int &pointsPerCell, const Data<PointScalar,DeviceType> &refData,
                                                                                 const int startCell, const int endCell) const
   {
     const int numCellsWorkset = (endCell == -1) ? (numCells_ - startCell) : (endCell - startCell);
@@ -293,14 +293,15 @@ namespace Intrepid2
         const auto domainExtents = domainExtents_;
         const auto gridCellCounts = gridCellCounts_;
         
-        auto policy = Kokkos::RangePolicy<>(ExecSpaceType(),0,spaceDim);
+        using ExecutionSpace = typename DeviceType::execution_space;
+        auto policy = Kokkos::RangePolicy<>(ExecutionSpace(),0,spaceDim);
         Kokkos::parallel_for("fill jacobian", policy, KOKKOS_LAMBDA(const int d1)
         {
           // diagonal jacobian
           const double REF_SPACE_EXTENT = 2.0;
           dataView1(d1) = (domainExtents[d1] / REF_SPACE_EXTENT) / gridCellCounts[d1];
         });
-        ExecSpaceType().fence();
+        ExecutionSpace().fence();
       }
     }
     else if (cellGeometryType_ == TENSOR_GRID)
@@ -318,7 +319,8 @@ namespace Intrepid2
         auto cellToNodes = cellToNodes_;
         auto nodes       = nodes_;
         
-        auto policy = Kokkos::MDRangePolicy<ExecSpaceType,Kokkos::Rank<3>>({startCell,0,0},{numCellsWorkset,spaceDim,spaceDim});
+        using ExecutionSpace = typename DeviceType::execution_space;
+        auto policy = Kokkos::MDRangePolicy<ExecutionSpace,Kokkos::Rank<3>>({startCell,0,0},{numCellsWorkset,spaceDim,spaceDim});
         
         Kokkos::parallel_for("compute first-order simplex Jacobians", policy,
         KOKKOS_LAMBDA (const int &cellOrdinal, const int &d1, const int &d2) {
@@ -375,12 +377,12 @@ namespace Intrepid2
   }
 
   // Uniform grid constructor, with optional subdivision into simplices
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
-  CellGeometry<PointScalar,spaceDim,ExecSpaceType>::CellGeometry(const Kokkos::Array<PointScalar,spaceDim> &origin,
-                                                                 const Kokkos::Array<PointScalar,spaceDim> &domainExtents,
-                                                                 const Kokkos::Array<int,spaceDim> &gridCellCounts,
-                                                                 SubdivisionStrategy subdivisionStrategy,
-                                                                 HypercubeNodeOrdering nodeOrdering)
+  template<class PointScalar, int spaceDim, typename DeviceType>
+  CellGeometry<PointScalar,spaceDim,DeviceType>::CellGeometry(const Kokkos::Array<PointScalar,spaceDim> &origin,
+                                                              const Kokkos::Array<PointScalar,spaceDim> &domainExtents,
+                                                              const Kokkos::Array<int,spaceDim> &gridCellCounts,
+                                                              SubdivisionStrategy subdivisionStrategy,
+                                                              HypercubeNodeOrdering nodeOrdering)
   :
   nodeOrdering_(nodeOrdering),
   cellGeometryType_(UNIFORM_GRID),
@@ -438,7 +440,7 @@ namespace Intrepid2
       }
     }
     
-    using BasisFamily = DerivedNodalBasisFamily<ExecSpaceType,PointScalar,PointScalar>;
+    using BasisFamily = DerivedNodalBasisFamily<DeviceType,PointScalar,PointScalar>;
     const int linearPolyOrder = 1;
     BasisPtr basisForNodes = getBasis<BasisFamily>(cellTopo, FUNCTION_SPACE_HGRAD, linearPolyOrder);
     
@@ -448,27 +450,27 @@ namespace Intrepid2
       // arbitrary-polynomial-order counterparts; the latter do not match the order of the shards::CellTopology nodes.
       if (cellTopo.getKey() == shards::Quadrilateral<>::key)
       {
-        basisForNodes = Teuchos::rcp( new Basis_HGRAD_QUAD_C1_FEM<ExecSpaceType,PointScalar,PointScalar>() );
+        basisForNodes = Teuchos::rcp( new Basis_HGRAD_QUAD_C1_FEM<DeviceType,PointScalar,PointScalar>() );
       }
       else if (cellTopo.getKey() == shards::Hexahedron<>::key)
       {
-        basisForNodes = Teuchos::rcp( new Basis_HGRAD_HEX_C1_FEM<ExecSpaceType,PointScalar,PointScalar>() );
+        basisForNodes = Teuchos::rcp( new Basis_HGRAD_HEX_C1_FEM<DeviceType,PointScalar,PointScalar>() );
       }
     }
     
-    using HostMemberLookup = ::Intrepid2::Impl::CellGeometryHostMembers<PointScalar, spaceDim, ExecSpaceType>;
+    using HostMemberLookup = ::Intrepid2::Impl::CellGeometryHostMembers<PointScalar, spaceDim, DeviceType>;
     HostMemberLookup::constructorCalled(this, cellTopo, basisForNodes);
   }
     
   // Node-based constructor for straight-edged cell geometry.
   // If claimAffine is true, we assume (without checking) that the mapping from reference space is affine.
   // (If claimAffine is false, we check whether the topology is simplicial; if so, we conclude that the mapping must be affine.)
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
-  CellGeometry<PointScalar,spaceDim,ExecSpaceType>::CellGeometry(const shards::CellTopology &cellTopo,
-                                                                 ScalarView<int,ExecSpaceType> cellToNodes,
-                                                                 ScalarView<PointScalar,ExecSpaceType> nodes,
-                                                                 const bool claimAffine,
-                                                                 const HypercubeNodeOrdering nodeOrdering)
+  template<class PointScalar, int spaceDim, typename DeviceType>
+  CellGeometry<PointScalar,spaceDim,DeviceType>::CellGeometry(const shards::CellTopology &cellTopo,
+                                                              ScalarView<int,DeviceType> cellToNodes,
+                                                              ScalarView<PointScalar,DeviceType> nodes,
+                                                              const bool claimAffine,
+                                                              const HypercubeNodeOrdering nodeOrdering)
   :
   nodeOrdering_(nodeOrdering),
   cellGeometryType_(FIRST_ORDER),
@@ -490,7 +492,7 @@ namespace Intrepid2
       affine_ = true;
     }
     
-    using BasisFamily = DerivedNodalBasisFamily<ExecSpaceType,PointScalar,PointScalar>;
+    using BasisFamily = DerivedNodalBasisFamily<DeviceType,PointScalar,PointScalar>;
     const int linearPolyOrder = 1;
     BasisPtr basisForNodes = getBasis<BasisFamily>(cellTopo, FUNCTION_SPACE_HGRAD, linearPolyOrder);
     
@@ -500,22 +502,22 @@ namespace Intrepid2
       // arbitrary-polynomial-order counterparts; the latter do not match the order of the shards::CellTopology nodes.
       if (cellTopo.getKey() == shards::Quadrilateral<>::key)
       {
-        basisForNodes = Teuchos::rcp( new Basis_HGRAD_QUAD_C1_FEM<ExecSpaceType,PointScalar,PointScalar>() );
+        basisForNodes = Teuchos::rcp( new Basis_HGRAD_QUAD_C1_FEM<DeviceType,PointScalar,PointScalar>() );
       }
       else if (cellTopo.getKey() == shards::Hexahedron<>::key)
       {
-        basisForNodes = Teuchos::rcp( new Basis_HGRAD_HEX_C1_FEM<ExecSpaceType,PointScalar,PointScalar>() );
+        basisForNodes = Teuchos::rcp( new Basis_HGRAD_HEX_C1_FEM<DeviceType,PointScalar,PointScalar>() );
       }
     }
     
-    using HostMemberLookup = ::Intrepid2::Impl::CellGeometryHostMembers<PointScalar, spaceDim, ExecSpaceType>;
+    using HostMemberLookup = ::Intrepid2::Impl::CellGeometryHostMembers<PointScalar, spaceDim, DeviceType>;
     HostMemberLookup::constructorCalled(this, cellTopo, basisForNodes);
   }
 
   // Constructor for higher-order geometry
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
-  CellGeometry<PointScalar,spaceDim,ExecSpaceType>::CellGeometry(Teuchos::RCP<Intrepid2::Basis<ExecSpaceType,PointScalar,PointScalar> > basisForNodes,
-                                                                 ScalarView<PointScalar,ExecSpaceType> cellNodes)
+  template<class PointScalar, int spaceDim, typename DeviceType>
+  CellGeometry<PointScalar,spaceDim,DeviceType>::CellGeometry(Teuchos::RCP<Intrepid2::Basis<DeviceType,PointScalar,PointScalar> > basisForNodes,
+                                                              ScalarView<PointScalar,DeviceType> cellNodes)
   :
   nodeOrdering_(HYPERCUBE_NODE_ORDER_TENSOR),
   cellGeometryType_(HIGHER_ORDER),
@@ -538,21 +540,21 @@ namespace Intrepid2
     {
       affine_ = false;
     }
-    using HostMemberLookup = ::Intrepid2::Impl::CellGeometryHostMembers<PointScalar, spaceDim, ExecSpaceType>;
+    using HostMemberLookup = ::Intrepid2::Impl::CellGeometryHostMembers<PointScalar, spaceDim, DeviceType>;
     HostMemberLookup::constructorCalled(this, cellTopo, basisForNodes);
   }
     
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
+  template<class PointScalar, int spaceDim, typename DeviceType>
   KOKKOS_INLINE_FUNCTION
-  bool CellGeometry<PointScalar,spaceDim,ExecSpaceType>::affine() const
+  bool CellGeometry<PointScalar,spaceDim,DeviceType>::affine() const
   {
     return affine_;
   }
     
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
-  TensorData<PointScalar,ExecSpaceType>
-  CellGeometry<PointScalar,spaceDim,ExecSpaceType>::allocateCellMeasure( const Data<PointScalar,ExecSpaceType> & jacobianDet,
-                                                                        const TensorData<PointScalar,ExecSpaceType> & cubatureWeights ) const
+  template<class PointScalar, int spaceDim, typename DeviceType>
+  TensorData<PointScalar,DeviceType>
+  CellGeometry<PointScalar,spaceDim,DeviceType>::allocateCellMeasure( const Data<PointScalar,DeviceType> & jacobianDet,
+                                                                      const TensorData<PointScalar,DeviceType> & cubatureWeights ) const
   {
     // Output possibilities for a cubatureWeights with N components:
     // 1. For AFFINE elements (jacobianDet cell-wise constant), returns a container with N+1 tensorial components; the first component corresponds to cells
@@ -561,7 +563,7 @@ namespace Intrepid2
     INTREPID2_TEST_FOR_EXCEPTION(cubatureWeights.rank() != 1, std::invalid_argument, "cubatureWeights container must have shape (P)");
     
     const int numTensorComponents = affine_ ? cubatureWeights.numTensorComponents() + 1 : 1;
-    std::vector< Data<PointScalar,ExecSpaceType> > tensorComponents(numTensorComponents);
+    std::vector< Data<PointScalar,DeviceType> > tensorComponents(numTensorComponents);
     
     if (affine_)
     {
@@ -570,8 +572,8 @@ namespace Intrepid2
       const int cellDataDim = jacobianDet.getDataExtent(0);
       Kokkos::Array<int,7> cellExtents{cellExtent,1,1,1,1,1,1};
       
-      ScalarView<PointScalar,ExecSpaceType> detDataView ("cell relative volumes", cellDataDim);
-      tensorComponents[0] = Data<PointScalar,ExecSpaceType>(detDataView,1,cellExtents,cellVariationTypes);
+      ScalarView<PointScalar,DeviceType> detDataView ("cell relative volumes", cellDataDim);
+      tensorComponents[0] = Data<PointScalar,DeviceType>(detDataView,1,cellExtents,cellVariationTypes);
       
       for (int cubTensorComponent=0; cubTensorComponent<numTensorComponents-1; cubTensorComponent++)
       {
@@ -579,9 +581,9 @@ namespace Intrepid2
         const auto cubatureExtents        = cubatureComponent.getExtents();
         const auto cubatureVariationTypes = cubatureComponent.getVariationTypes();
         const int numPoints               = cubatureComponent.getDataExtent(0);
-        ScalarView<PointScalar,ExecSpaceType> cubatureWeightView ("cubature component weights", numPoints);
+        ScalarView<PointScalar,DeviceType> cubatureWeightView ("cubature component weights", numPoints);
         const int pointComponentRank = 1;
-        tensorComponents[cubTensorComponent+1] = Data<PointScalar,ExecSpaceType>(cubatureWeightView,pointComponentRank,cubatureExtents,cubatureVariationTypes);
+        tensorComponents[cubTensorComponent+1] = Data<PointScalar,DeviceType>(cubatureWeightView,pointComponentRank,cubatureExtents,cubatureVariationTypes);
       }
     }
     else
@@ -593,26 +595,26 @@ namespace Intrepid2
       const int numPoints = cubatureWeights.extent_int(0);
       Kokkos::Array<int,7> extents{cellExtent,numPoints,1,1,1,1,1};
       
-      ScalarView<PointScalar,ExecSpaceType> cubatureWeightView;
+      ScalarView<PointScalar,DeviceType> cubatureWeightView;
       if (variationTypes[0] != CONSTANT)
       {
-        cubatureWeightView = ScalarView<PointScalar,ExecSpaceType>("cell measure", cellDataDim, numPoints);
+        cubatureWeightView = ScalarView<PointScalar,DeviceType>("cell measure", cellDataDim, numPoints);
       }
       else
       {
-        cubatureWeightView = ScalarView<PointScalar,ExecSpaceType>("cell measure", numPoints);
+        cubatureWeightView = ScalarView<PointScalar,DeviceType>("cell measure", numPoints);
       }
       const int cellMeasureRank = 2;
-      tensorComponents[0] = Data<PointScalar,ExecSpaceType>(cubatureWeightView,cellMeasureRank,extents,variationTypes);
+      tensorComponents[0] = Data<PointScalar,DeviceType>(cubatureWeightView,cellMeasureRank,extents,variationTypes);
     }
     const bool separateFirstComponent = (numTensorComponents > 1);
-    return TensorData<PointScalar,ExecSpaceType>(tensorComponents, separateFirstComponent);
+    return TensorData<PointScalar,DeviceType>(tensorComponents, separateFirstComponent);
   }
     
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
-  void CellGeometry<PointScalar,spaceDim,ExecSpaceType>::computeCellMeasure( TensorData<PointScalar,ExecSpaceType> &cellMeasure,
-                                                                            const Data<PointScalar,ExecSpaceType> & jacobianDet,
-                                                                            const TensorData<PointScalar,ExecSpaceType> & cubatureWeights ) const
+  template<class PointScalar, int spaceDim, typename DeviceType>
+  void CellGeometry<PointScalar,spaceDim,DeviceType>::computeCellMeasure( TensorData<PointScalar,DeviceType> &cellMeasure,
+                                                                          const Data<PointScalar,DeviceType> & jacobianDet,
+                                                                          const TensorData<PointScalar,DeviceType> & cubatureWeights ) const
   {
     // Output possibilities for a cubatureWeights with N components:
     // 1. For AFFINE elements (jacobianDet constant on each cell), returns a container with N+1 tensorial components; the first component corresponds to cells
@@ -658,8 +660,9 @@ namespace Intrepid2
       {
         auto cellMeasureData = cellMeasure.getTensorComponent(0).getUnderlyingView2();
         auto detData = jacobianDet.getUnderlyingView1();
+        using ExecutionSpace = typename DeviceType::execution_space;
         Kokkos::parallel_for(
-        Kokkos::MDRangePolicy<ExecSpaceType,Kokkos::Rank<2>>({0,0},{detData.extent_int(0),cubatureWeights.extent_int(0)}),
+        Kokkos::MDRangePolicy<ExecutionSpace,Kokkos::Rank<2>>({0,0},{detData.extent_int(0),cubatureWeights.extent_int(0)}),
         KOKKOS_LAMBDA (int cellOrdinal, int pointOrdinal) {
           cellMeasureData(cellOrdinal,pointOrdinal) = detData(cellOrdinal) * cubatureWeights(pointOrdinal);
         });
@@ -670,7 +673,8 @@ namespace Intrepid2
         // cell measure data has shape (P)
         auto cellMeasureData = cellMeasure.getTensorComponent(0).getUnderlyingView1();
         auto detData = jacobianDet.getUnderlyingView1();
-        Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpaceType>(0,cellMeasureData.extent_int(0)),
+        using ExecutionSpace = typename DeviceType::execution_space;
+        Kokkos::parallel_for(Kokkos::RangePolicy<ExecutionSpace>(0,cellMeasureData.extent_int(0)),
         KOKKOS_LAMBDA (const int &pointOrdinal) {
           cellMeasureData(pointOrdinal) = detData(0) * cubatureWeights(pointOrdinal);
         });
@@ -678,24 +682,24 @@ namespace Intrepid2
     }
   }
     
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
-  typename CellGeometry<PointScalar,spaceDim,ExecSpaceType>::BasisPtr
-  CellGeometry<PointScalar,spaceDim,ExecSpaceType>::basisForNodes() const
+  template<class PointScalar, int spaceDim, typename DeviceType>
+  typename CellGeometry<PointScalar,spaceDim,DeviceType>::BasisPtr
+  CellGeometry<PointScalar,spaceDim,DeviceType>::basisForNodes() const
   {
-    using HostMemberLookup = ::Intrepid2::Impl::CellGeometryHostMembers<PointScalar, spaceDim, ExecSpaceType>;
+    using HostMemberLookup = ::Intrepid2::Impl::CellGeometryHostMembers<PointScalar, spaceDim, DeviceType>;
     return HostMemberLookup::getBasis(this);
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
-  const shards::CellTopology & CellGeometry<PointScalar,spaceDim,ExecSpaceType>::cellTopology() const
+  template<class PointScalar, int spaceDim, typename DeviceType>
+  const shards::CellTopology & CellGeometry<PointScalar,spaceDim,DeviceType>::cellTopology() const
   {
-    using HostMemberLookup = ::Intrepid2::Impl::CellGeometryHostMembers<PointScalar, spaceDim, ExecSpaceType>;
+    using HostMemberLookup = ::Intrepid2::Impl::CellGeometryHostMembers<PointScalar, spaceDim, DeviceType>;
     return HostMemberLookup::getCellTopology(this);
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
+  template<class PointScalar, int spaceDim, typename DeviceType>
   KOKKOS_INLINE_FUNCTION
-  DataVariationType CellGeometry<PointScalar,spaceDim,ExecSpaceType>::cellVariationType() const
+  DataVariationType CellGeometry<PointScalar,spaceDim,DeviceType>::cellVariationType() const
   {
     if (cellGeometryType_ == UNIFORM_GRID)
     {
@@ -712,10 +716,10 @@ namespace Intrepid2
     else return GENERAL;
   }
 
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
-  Data<PointScalar,ExecSpaceType> CellGeometry<PointScalar,spaceDim,ExecSpaceType>::getJacobianRefData(const TensorPoints<PointScalar,ExecSpaceType> &points) const
+  template<class PointScalar, int spaceDim, typename DeviceType>
+  Data<PointScalar,DeviceType> CellGeometry<PointScalar,spaceDim,DeviceType>::getJacobianRefData(const TensorPoints<PointScalar,DeviceType> &points) const
   {
-    Data<PointScalar,ExecSpaceType> emptyRefData;
+    Data<PointScalar,DeviceType> emptyRefData;
     if (cellGeometryType_ == UNIFORM_GRID)
     {
       // no need for basis computations
@@ -760,15 +764,16 @@ namespace Intrepid2
           auto firstPointComponentView = points.getTensorComponent(0); // (P,D0)
           auto basisGradientsView = getMatchingViewWithLabel(firstPointComponentView, "CellGeometryProvider: temporary basisGradients", numFields, numPoints, spaceDim);
           
-          auto policy = Kokkos::MDRangePolicy<ExecSpaceType,Kokkos::Rank<3>>({0,0,0},{numFields,numPoints,spaceDim});
+          using ExecutionSpace = typename DeviceType::execution_space;
+          auto policy = Kokkos::MDRangePolicy<ExecutionSpace,Kokkos::Rank<3>>({0,0,0},{numFields,numPoints,spaceDim});
           
           Kokkos::parallel_for("copy basis gradients", policy,
           KOKKOS_LAMBDA (const int &fieldOrdinal, const int &pointOrdinal, const int &d) {
             basisGradientsView(fieldOrdinal,pointOrdinal,d) = basisGradients(fieldOrdinal,pointOrdinal,d);
           });
-          ExecSpaceType().fence();
+          ExecutionSpace().fence();
           
-          Data<PointScalar,ExecSpaceType> basisRefData(basisGradientsView);
+          Data<PointScalar,DeviceType> basisRefData(basisGradientsView);
           return basisRefData;
         }
       }
@@ -781,9 +786,9 @@ namespace Intrepid2
     return emptyRefData;
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
+  template<class PointScalar, int spaceDim, typename DeviceType>
   KOKKOS_INLINE_FUNCTION
-  int CellGeometry<PointScalar,spaceDim,ExecSpaceType>::hypercubeComponentNodeNumber(int hypercubeNodeNumber, int d) const
+  int CellGeometry<PointScalar,spaceDim,DeviceType>::hypercubeComponentNodeNumber(int hypercubeNodeNumber, int d) const
   {
     if (nodeOrdering_ == HYPERCUBE_NODE_ORDER_CLASSIC_SHARDS)
     {
@@ -812,17 +817,17 @@ namespace Intrepid2
       return 0;
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
-  void CellGeometry<PointScalar,spaceDim,ExecSpaceType>::initializeOrientations()
+  template<class PointScalar, int spaceDim, typename DeviceType>
+  void CellGeometry<PointScalar,spaceDim,DeviceType>::initializeOrientations()
   {
-    using HostExecSpace = typename Kokkos::Impl::is_space<ExecSpaceType>::host_mirror_space::execution_space ;
+    using HostExecSpace = typename Kokkos::Impl::is_space<DeviceType>::host_mirror_space::execution_space ;
     
     const bool isGridType = (cellGeometryType_ == TENSOR_GRID) || (cellGeometryType_ == UNIFORM_GRID);
     const int numOrientations = isGridType ? numCellsPerGridCell(subdivisionStrategy_) : numCells();
     
     const int nodesPerCell = numNodesPerCell();
     
-    ScalarView<Orientation, ExecSpaceType> orientationsView("orientations", numOrientations);
+    ScalarView<Orientation, DeviceType> orientationsView("orientations", numOrientations);
     auto orientationsHost = Kokkos::create_mirror_view(typename HostExecSpace::memory_space(), orientationsView);
     
     ScalarView<PointScalar, HostExecSpace> cellNodesHost("cellNodesHost",numOrientations,nodesPerCell); // (C,N) -- where C = numOrientations
@@ -857,12 +862,12 @@ namespace Intrepid2
     const int orientationsRank = 1; // shape (C)
     const Kokkos::Array<int,7>               orientationExtents {static_cast<int>(numCells_),1,1,1,1,1,1};
     const Kokkos::Array<DataVariationType,7> orientationVariationTypes { cellVariationType, CONSTANT, CONSTANT, CONSTANT, CONSTANT, CONSTANT, CONSTANT};
-    orientations_ = Data<Orientation,ExecSpaceType>(orientationsView, orientationsRank, orientationExtents, orientationVariationTypes);
+    orientations_ = Data<Orientation,DeviceType>(orientationsView, orientationsRank, orientationExtents, orientationVariationTypes);
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
+  template<class PointScalar, int spaceDim, typename DeviceType>
   KOKKOS_INLINE_FUNCTION
-  size_t CellGeometry<PointScalar,spaceDim,ExecSpaceType>::extent(const int& r) const {
+  size_t CellGeometry<PointScalar,spaceDim,DeviceType>::extent(const int& r) const {
     if (r == 0)
     {
       return numCells_;
@@ -881,33 +886,33 @@ namespace Intrepid2
     }
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
+  template<class PointScalar, int spaceDim, typename DeviceType>
   template <typename iType>
   KOKKOS_INLINE_FUNCTION
   typename std::enable_if<std::is_integral<iType>::value, int>::type
-  CellGeometry<PointScalar,spaceDim,ExecSpaceType>::extent_int(const iType& r) const
+  CellGeometry<PointScalar,spaceDim,DeviceType>::extent_int(const iType& r) const
   {
     return static_cast<int>(extent(r));
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
+  template<class PointScalar, int spaceDim, typename DeviceType>
   KOKKOS_INLINE_FUNCTION
-  typename CellGeometry<PointScalar,spaceDim,ExecSpaceType>::HypercubeNodeOrdering
-  CellGeometry<PointScalar,spaceDim,ExecSpaceType>::nodeOrderingForHypercubes() const
+  typename CellGeometry<PointScalar,spaceDim,DeviceType>::HypercubeNodeOrdering
+  CellGeometry<PointScalar,spaceDim,DeviceType>::nodeOrderingForHypercubes() const
   {
     return nodeOrdering_;
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
+  template<class PointScalar, int spaceDim, typename DeviceType>
   KOKKOS_INLINE_FUNCTION
-  int CellGeometry<PointScalar,spaceDim,ExecSpaceType>::numCells() const
+  int CellGeometry<PointScalar,spaceDim,DeviceType>::numCells() const
   {
     return numCells_;
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
+  template<class PointScalar, int spaceDim, typename DeviceType>
   KOKKOS_INLINE_FUNCTION
-  int CellGeometry<PointScalar,spaceDim,ExecSpaceType>::numCellsInDimension(const int &dim) const
+  int CellGeometry<PointScalar,spaceDim,DeviceType>::numCellsInDimension(const int &dim) const
   {
     if (cellGeometryType_ == UNIFORM_GRID)
     {
@@ -923,23 +928,23 @@ namespace Intrepid2
     }
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
+  template<class PointScalar, int spaceDim, typename DeviceType>
   KOKKOS_INLINE_FUNCTION
-  int CellGeometry<PointScalar,spaceDim,ExecSpaceType>::numNodesPerCell() const
+  int CellGeometry<PointScalar,spaceDim,DeviceType>::numNodesPerCell() const
   {
     return numNodesPerCell_;
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
+  template<class PointScalar, int spaceDim, typename DeviceType>
   KOKKOS_INLINE_FUNCTION
-  Orientation CellGeometry<PointScalar,spaceDim,ExecSpaceType>::getOrientation(int &cellNumber) const
+  Orientation CellGeometry<PointScalar,spaceDim,DeviceType>::getOrientation(int &cellNumber) const
   {
     INTREPID2_TEST_FOR_EXCEPTION_DEVICE_SAFE(!orientations_.isValid(), std::invalid_argument, "orientations_ not initialized; call initializeOrientations() first");
     return orientations_(cellNumber);
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
-  Data<Orientation,ExecSpaceType> CellGeometry<PointScalar,spaceDim,ExecSpaceType>::getOrientations()
+  template<class PointScalar, int spaceDim, typename DeviceType>
+  Data<Orientation,DeviceType> CellGeometry<PointScalar,spaceDim,DeviceType>::getOrientations()
   {
     if (!orientations_.isValid())
     {
@@ -948,9 +953,9 @@ namespace Intrepid2
     return orientations_;
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
+  template<class PointScalar, int spaceDim, typename DeviceType>
   KOKKOS_INLINE_FUNCTION
-  PointScalar CellGeometry<PointScalar,spaceDim,ExecSpaceType>::gridCellCoordinate(const int &gridCellOrdinal, const int &localNodeNumber, const int &dim) const
+  PointScalar CellGeometry<PointScalar,spaceDim,DeviceType>::gridCellCoordinate(const int &gridCellOrdinal, const int &localNodeNumber, const int &dim) const
   {
     const int componentNode = hypercubeComponentNodeNumber(localNodeNumber, dim);
     int cellCountForPriorDimensions = 1;
@@ -981,16 +986,16 @@ namespace Intrepid2
     }
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
+  template<class PointScalar, int spaceDim, typename DeviceType>
   KOKKOS_INLINE_FUNCTION
-  unsigned CellGeometry<PointScalar,spaceDim,ExecSpaceType>::rank() const
+  unsigned CellGeometry<PointScalar,spaceDim,DeviceType>::rank() const
   {
     return 3; // (C,N,D)
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
+  template<class PointScalar, int spaceDim, typename DeviceType>
   KOKKOS_INLINE_FUNCTION
-  int CellGeometry<PointScalar,spaceDim,ExecSpaceType>::gridCellNodeForSubdivisionNode(const int &gridCellOrdinal, const int &subdivisionOrdinal,
+  int CellGeometry<PointScalar,spaceDim,DeviceType>::gridCellNodeForSubdivisionNode(const int &gridCellOrdinal, const int &subdivisionOrdinal,
                                                                                        const int &subdivisionNodeNumber) const
   {
     // TODO: do something to reuse the nodeLookup containers
@@ -1135,9 +1140,9 @@ namespace Intrepid2
     }
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
+  template<class PointScalar, int spaceDim, typename DeviceType>
   KOKKOS_INLINE_FUNCTION
-  PointScalar CellGeometry<PointScalar,spaceDim,ExecSpaceType>::subdivisionCoordinate(const int &gridCellOrdinal, const int &subdivisionOrdinal,
+  PointScalar CellGeometry<PointScalar,spaceDim,DeviceType>::subdivisionCoordinate(const int &gridCellOrdinal, const int &subdivisionOrdinal,
                                                                                       const int &subdivisionNodeNumber, const int &d) const
   {
     int gridCellNode = gridCellNodeForSubdivisionNode(gridCellOrdinal, subdivisionOrdinal, subdivisionNodeNumber);
@@ -1157,10 +1162,10 @@ namespace Intrepid2
     return gridCellCoordinate(gridCellOrdinal, gridCellNode, d);
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
+  template<class PointScalar, int spaceDim, typename DeviceType>
   KOKKOS_INLINE_FUNCTION
   PointScalar
-  CellGeometry<PointScalar,spaceDim,ExecSpaceType>::operator()(const int& cell, const int& node, const int& dim) const {
+  CellGeometry<PointScalar,spaceDim,DeviceType>::operator()(const int& cell, const int& node, const int& dim) const {
     if ((cellGeometryType_ == UNIFORM_GRID) || (cellGeometryType_ == TENSOR_GRID))
     {
       const int numSubdivisions = numCellsPerGridCell(subdivisionStrategy_);
@@ -1198,9 +1203,9 @@ namespace Intrepid2
     }
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
+  template<class PointScalar, int spaceDim, typename DeviceType>
   KOKKOS_INLINE_FUNCTION
-  int CellGeometry<PointScalar,spaceDim,ExecSpaceType>::uniformJacobianModulus() const
+  int CellGeometry<PointScalar,spaceDim,DeviceType>::uniformJacobianModulus() const
   {
     if (cellGeometryType_ == UNIFORM_GRID)
     {
@@ -1212,58 +1217,58 @@ namespace Intrepid2
     }
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
-  Data<PointScalar,ExecSpaceType> CellGeometry<PointScalar,spaceDim,ExecSpaceType>::allocateJacobianData(const TensorPoints<PointScalar,ExecSpaceType> &points, const int startCell, const int endCell) const
+  template<class PointScalar, int spaceDim, typename DeviceType>
+  Data<PointScalar,DeviceType> CellGeometry<PointScalar,spaceDim,DeviceType>::allocateJacobianData(const TensorPoints<PointScalar,DeviceType> &points, const int startCell, const int endCell) const
   {
     const int pointsPerCell = points.extent_int(0);
     return allocateJacobianDataPrivate(points,pointsPerCell,startCell,endCell);
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
-  Data<PointScalar,ExecSpaceType> CellGeometry<PointScalar,spaceDim,ExecSpaceType>::allocateJacobianData(const ScalarView<PointScalar,ExecSpaceType> &points, const int startCell, const int endCell) const
+  template<class PointScalar, int spaceDim, typename DeviceType>
+  Data<PointScalar,DeviceType> CellGeometry<PointScalar,spaceDim,DeviceType>::allocateJacobianData(const ScalarView<PointScalar,DeviceType> &points, const int startCell, const int endCell) const
   {
     // if points is rank 3, it has shape (C,P,D).  If it's rank 2, (P,D).
     const int pointDimension = (points.rank() == 3) ? 1 : 0;
     const int pointsPerCell = points.extent_int(pointDimension);
-    TensorPoints<PointScalar,ExecSpaceType> tensorPoints(points);
+    TensorPoints<PointScalar,DeviceType> tensorPoints(points);
     return allocateJacobianDataPrivate(tensorPoints,pointsPerCell,startCell,endCell);
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
-  Data<PointScalar,ExecSpaceType> CellGeometry<PointScalar,spaceDim,ExecSpaceType>::allocateJacobianData(const int &numPoints, const int startCell, const int endCell) const
+  template<class PointScalar, int spaceDim, typename DeviceType>
+  Data<PointScalar,DeviceType> CellGeometry<PointScalar,spaceDim,DeviceType>::allocateJacobianData(const int &numPoints, const int startCell, const int endCell) const
   {
     INTREPID2_TEST_FOR_EXCEPTION_DEVICE_SAFE(!affine_, std::invalid_argument, "this version of allocateJacobianData() is only supported for affine CellGeometry");
     
-    TensorPoints<PointScalar,ExecSpaceType> emptyPoints;
+    TensorPoints<PointScalar,DeviceType> emptyPoints;
     return allocateJacobianDataPrivate(emptyPoints,numPoints,startCell,endCell);
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
-  void CellGeometry<PointScalar,spaceDim,ExecSpaceType>::setJacobian(Data<PointScalar,ExecSpaceType> &jacobianData, const TensorPoints<PointScalar,ExecSpaceType> &points,
-                                                                     const Data<PointScalar,ExecSpaceType> &refData, const int startCell, const int endCell) const
+  template<class PointScalar, int spaceDim, typename DeviceType>
+  void CellGeometry<PointScalar,spaceDim,DeviceType>::setJacobian(Data<PointScalar,DeviceType> &jacobianData, const TensorPoints<PointScalar,DeviceType> &points,
+                                                                  const Data<PointScalar,DeviceType> &refData, const int startCell, const int endCell) const
   {
     const int pointsPerCell = points.extent_int(0);
     setJacobianDataPrivate(jacobianData,points,pointsPerCell,refData,startCell,endCell);
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
-  void CellGeometry<PointScalar,spaceDim,ExecSpaceType>::setJacobian(Data<PointScalar,ExecSpaceType> &jacobianData, const ScalarView<PointScalar,ExecSpaceType> &points,
-                                                                     const Data<PointScalar,ExecSpaceType> &refData, const int startCell, const int endCell) const
+  template<class PointScalar, int spaceDim, typename DeviceType>
+  void CellGeometry<PointScalar,spaceDim,DeviceType>::setJacobian(Data<PointScalar,DeviceType> &jacobianData, const ScalarView<PointScalar,DeviceType> &points,
+                                                                  const Data<PointScalar,DeviceType> &refData, const int startCell, const int endCell) const
   {
     // if points is rank 3, it has shape (C,P,D).  If it's rank 2, (P,D).
     const int pointDimension = (points.rank() == 3) ? 1 : 0;
     const int pointsPerCell = points.extent_int(pointDimension);
-    TensorPoints<PointScalar,ExecSpaceType> tensorPoints(points);
+    TensorPoints<PointScalar,DeviceType> tensorPoints(points);
     setJacobianDataPrivate(jacobianData,tensorPoints,pointsPerCell,refData,startCell,endCell);
   }
   
-  template<class PointScalar, int spaceDim, typename ExecSpaceType>
-  void CellGeometry<PointScalar,spaceDim,ExecSpaceType>::setJacobian(Data<PointScalar,ExecSpaceType> &jacobianData, const int &numPoints, const int startCell, const int endCell) const
+  template<class PointScalar, int spaceDim, typename DeviceType>
+  void CellGeometry<PointScalar,spaceDim,DeviceType>::setJacobian(Data<PointScalar,DeviceType> &jacobianData, const int &numPoints, const int startCell, const int endCell) const
   {
     INTREPID2_TEST_FOR_EXCEPTION_DEVICE_SAFE(!affine_, std::invalid_argument, "this version of setJacobian() is only supported for affine CellGeometry");
     
-    TensorPoints<PointScalar,ExecSpaceType> emptyPoints;
-    Data<PointScalar,ExecSpaceType> emptyRefData;
+    TensorPoints<PointScalar,DeviceType> emptyPoints;
+    Data<PointScalar,DeviceType> emptyRefData;
     setJacobianDataPrivate(jacobianData,emptyPoints,numPoints,emptyRefData,startCell,endCell);
   }
 } // namespace Intrepid2

--- a/packages/intrepid2/src/Cell/Intrepid2_CellTools.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellTools.hpp
@@ -166,28 +166,28 @@ namespace Intrepid2 {
      */
     template<typename outputValueType, 
              typename pointValueType>
-    static Teuchos::RCP<Basis<ExecSpaceType,outputValueType,pointValueType> >
+    static Teuchos::RCP<Basis<DeviceType,outputValueType,pointValueType> >
     createHGradBasis( const shards::CellTopology cellTopo ) {
-      Teuchos::RCP<Basis<ExecSpaceType,outputValueType,pointValueType> > r_val;
+      Teuchos::RCP<Basis<DeviceType,outputValueType,pointValueType> > r_val;
 
       switch (cellTopo.getKey()) {
-      case shards::Line<2>::key:          r_val = Teuchos::rcp(new Basis_HGRAD_LINE_C1_FEM   <ExecSpaceType,outputValueType,pointValueType>()); break;
-      case shards::Triangle<3>::key:      r_val = Teuchos::rcp(new Basis_HGRAD_TRI_C1_FEM    <ExecSpaceType,outputValueType,pointValueType>()); break;
-      case shards::Quadrilateral<4>::key: r_val = Teuchos::rcp(new Basis_HGRAD_QUAD_C1_FEM   <ExecSpaceType,outputValueType,pointValueType>()); break;
-      case shards::Tetrahedron<4>::key:   r_val = Teuchos::rcp(new Basis_HGRAD_TET_C1_FEM    <ExecSpaceType,outputValueType,pointValueType>()); break;
-      case shards::Hexahedron<8>::key:    r_val = Teuchos::rcp(new Basis_HGRAD_HEX_C1_FEM    <ExecSpaceType,outputValueType,pointValueType>()); break;
-      case shards::Wedge<6>::key:         r_val = Teuchos::rcp(new Basis_HGRAD_WEDGE_C1_FEM  <ExecSpaceType,outputValueType,pointValueType>()); break;
-      case shards::Pyramid<5>::key:       r_val = Teuchos::rcp(new Basis_HGRAD_PYR_C1_FEM    <ExecSpaceType,outputValueType,pointValueType>()); break;
+      case shards::Line<2>::key:          r_val = Teuchos::rcp(new Basis_HGRAD_LINE_C1_FEM   <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::Triangle<3>::key:      r_val = Teuchos::rcp(new Basis_HGRAD_TRI_C1_FEM    <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::Quadrilateral<4>::key: r_val = Teuchos::rcp(new Basis_HGRAD_QUAD_C1_FEM   <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::Tetrahedron<4>::key:   r_val = Teuchos::rcp(new Basis_HGRAD_TET_C1_FEM    <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::Hexahedron<8>::key:    r_val = Teuchos::rcp(new Basis_HGRAD_HEX_C1_FEM    <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::Wedge<6>::key:         r_val = Teuchos::rcp(new Basis_HGRAD_WEDGE_C1_FEM  <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::Pyramid<5>::key:       r_val = Teuchos::rcp(new Basis_HGRAD_PYR_C1_FEM    <DeviceType,outputValueType,pointValueType>()); break;
 
-      case shards::Triangle<6>::key:      r_val = Teuchos::rcp(new Basis_HGRAD_TRI_C2_FEM    <ExecSpaceType,outputValueType,pointValueType>()); break;
-      case shards::Quadrilateral<9>::key: r_val = Teuchos::rcp(new Basis_HGRAD_QUAD_C2_FEM   <ExecSpaceType,outputValueType,pointValueType>()); break;
-      case shards::Tetrahedron<10>::key:  r_val = Teuchos::rcp(new Basis_HGRAD_TET_C2_FEM    <ExecSpaceType,outputValueType,pointValueType>()); break;
-      case shards::Tetrahedron<11>::key:  r_val = Teuchos::rcp(new Basis_HGRAD_TET_COMP12_FEM<ExecSpaceType,outputValueType,pointValueType>()); break;
-        //case shards::Hexahedron<20>::key:   r_val = Teuchos::rcp(new Basis_HGRAD_HEX_I2_FEM    <ExecSpaceType,outputValueType,pointValueType>()); break;
-      case shards::Hexahedron<27>::key:   r_val = Teuchos::rcp(new Basis_HGRAD_HEX_C2_FEM    <ExecSpaceType,outputValueType,pointValueType>()); break;
-        //case shards::Wedge<15>::key:        r_val = Teuchos::rcp(new Basis_HGRAD_WEDGE_I2_FEM  <ExecSpaceType,outputValueType,pointValueType>()); break;
-      case shards::Wedge<18>::key:        r_val = Teuchos::rcp(new Basis_HGRAD_WEDGE_C2_FEM  <ExecSpaceType,outputValueType,pointValueType>()); break;
-        //case shards::Pyramid<13>::key:      r_val = Teuchos::rcp(new Basis_HGRAD_PYR_I2_FEM    <ExecSpaceType,outputValueType,pointValueType>()); break;
+      case shards::Triangle<6>::key:      r_val = Teuchos::rcp(new Basis_HGRAD_TRI_C2_FEM    <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::Quadrilateral<9>::key: r_val = Teuchos::rcp(new Basis_HGRAD_QUAD_C2_FEM   <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::Tetrahedron<10>::key:  r_val = Teuchos::rcp(new Basis_HGRAD_TET_C2_FEM    <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::Tetrahedron<11>::key:  r_val = Teuchos::rcp(new Basis_HGRAD_TET_COMP12_FEM<DeviceType,outputValueType,pointValueType>()); break;
+        //case shards::Hexahedron<20>::key:   r_val = Teuchos::rcp(new Basis_HGRAD_HEX_I2_FEM    <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::Hexahedron<27>::key:   r_val = Teuchos::rcp(new Basis_HGRAD_HEX_C2_FEM    <DeviceType,outputValueType,pointValueType>()); break;
+        //case shards::Wedge<15>::key:        r_val = Teuchos::rcp(new Basis_HGRAD_WEDGE_I2_FEM  <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::Wedge<18>::key:        r_val = Teuchos::rcp(new Basis_HGRAD_WEDGE_C2_FEM  <DeviceType,outputValueType,pointValueType>()); break;
+        //case shards::Pyramid<13>::key:      r_val = Teuchos::rcp(new Basis_HGRAD_PYR_I2_FEM    <DeviceType,outputValueType,pointValueType>()); break;
 
       case shards::Quadrilateral<8>::key: 
       case shards::Line<3>::key:

--- a/packages/intrepid2/src/Cell/Intrepid2_CellTools.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellTools.hpp
@@ -102,8 +102,9 @@ namespace Intrepid2 {
   */
 
 
-  template<typename ExecSpaceType>
+  template<typename DeviceType>
   class CellTools {
+    using ExecSpaceType = typename DeviceType::execution_space;
   public:
 
     /** \brief  Checks if a cell topology has reference cell
@@ -512,7 +513,7 @@ namespace Intrepid2 {
         \return Data container with shape (C,P)
     */
     template<class PointScalar>
-    static Data<PointScalar> allocateJacobianDet( const Data<PointScalar> & jacobian );
+    static Data<PointScalar,DeviceType> allocateJacobianDet( const Data<PointScalar,DeviceType> & jacobian );
 
     /** \brief  Allocates and returns a Data container suitable for storing inverses corresponding to the Jacobians in the Data container provided
 
@@ -520,7 +521,7 @@ namespace Intrepid2 {
         \return Data container with shape (C,P,D,D)
     */
     template<class PointScalar>
-    static Data<PointScalar,ExecSpaceType> allocateJacobianInv( const Data<PointScalar,ExecSpaceType> & jacobian );
+    static Data<PointScalar,DeviceType> allocateJacobianInv( const Data<PointScalar,DeviceType> & jacobian );
 
     /** \brief  Computes determinants corresponding to the Jacobians in the Data container provided
 
@@ -528,8 +529,8 @@ namespace Intrepid2 {
         \param  jacobian          [in]    - data with shape (C,P,D,D), as returned by CellGeometry::allocateJacobianData()
     */
     template<class PointScalar>
-    static void setJacobianDet( Data<PointScalar,ExecSpaceType> & jacobianDet,
-                               const Data<PointScalar,ExecSpaceType> & jacobian);
+    static void setJacobianDet( Data<PointScalar,DeviceType> & jacobianDet,
+                               const Data<PointScalar,DeviceType> & jacobian);
 
     /** \brief  Computes determinants corresponding to the Jacobians in the Data container provided
 
@@ -537,8 +538,8 @@ namespace Intrepid2 {
         \param  jacobian          [in]    - data with shape (C,P,D,D), as returned by CellGeometry::allocateJacobianData()
     */
     template<class PointScalar>
-    static void setJacobianInv( Data<PointScalar,ExecSpaceType> & jacobianInv,
-                               const Data<PointScalar,ExecSpaceType> & jacobian);
+    static void setJacobianInv( Data<PointScalar,DeviceType> & jacobianInv,
+                               const Data<PointScalar,DeviceType> & jacobian);
     
     //============================================================================================//
     //                                                                                            //

--- a/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefControlVolume.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefControlVolume.hpp
@@ -421,10 +421,10 @@ namespace Intrepid2 {
     typedef Kokkos::DynRankView<cellCoordValueType,cellCoordProperties...>   cellCoordViewType;
     typedef Kokkos::View<ordinal_type**,Kokkos::LayoutRight,SpT>             mapViewType;
 
-    typedef typename ExecSpace<typename subcvCoordViewType::execution_space,SpT>::ExecSpaceType ExecSpaceType;
+    typedef typename ExecSpace<typename subcvCoordViewType::execution_space,SpT>::ExecSpaceType ExecutionSpace;
 
     const auto loopSize = numCells;
-    Kokkos::RangePolicy<ExecSpaceType,Kokkos::Schedule<Kokkos::Static> > policy(0, loopSize);
+    Kokkos::RangePolicy<ExecutionSpace,Kokkos::Schedule<Kokkos::Static> > policy(0, loopSize);
 
     switch (primaryCell.getKey()) {
     case shards::Triangle<3>::key:

--- a/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefJacobian.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefJacobian.hpp
@@ -165,30 +165,30 @@ namespace Intrepid2 {
     {
       auto jacData = jacobian.getUnderlyingView4();
       auto invData = getMatchingViewWithLabel(jacData, "Jacobian inv data",jacData.extent(0),jacData.extent(1),jacData.extent(2),jacData.extent(3));
-      return Data<PointScalar,ExecSpaceType>(invData,4,extents,variationTypes);
+      return Data<PointScalar,DeviceType>(invData,4,extents,variationTypes);
     }
     else if (jacDataRank == 3)
     {
       auto jacData = jacobian.getUnderlyingView3();
       auto invData = getMatchingViewWithLabel(jacData, "Jacobian inv data",jacData.extent(0),jacData.extent(1),jacData.extent(2));
-      return Data<PointScalar,ExecSpaceType>(invData,4,extents,variationTypes);
+      return Data<PointScalar,DeviceType>(invData,4,extents,variationTypes);
     }
     else if (jacDataRank == 2)
     {
       auto jacData = jacobian.getUnderlyingView2();
       auto invData = getMatchingViewWithLabel(jacData, "Jacobian inv data",jacData.extent(0),jacData.extent(1));
-      return Data<PointScalar,ExecSpaceType>(invData,4,extents,variationTypes);
+      return Data<PointScalar,DeviceType>(invData,4,extents,variationTypes);
     }
     else if (jacDataRank == 1)
     {
       auto jacData = jacobian.getUnderlyingView1();
       auto invData = getMatchingViewWithLabel(jacData, "Jacobian inv data",jacData.extent(0));
-      return Data<PointScalar,ExecSpaceType>(invData,4,extents,variationTypes);
+      return Data<PointScalar,DeviceType>(invData,4,extents,variationTypes);
     }
     else
     {
       INTREPID2_TEST_FOR_EXCEPTION_DEVICE_SAFE(true, std::invalid_argument, "allocateJacobianInv requires jacobian to vary in *some* dimension…");
-      return Data<PointScalar,ExecSpaceType>(); // unreachable statement; this line added to avoid compiler warning on CUDA
+      return Data<PointScalar,DeviceType>(); // unreachable statement; this line added to avoid compiler warning on CUDA
     }
   }
 

--- a/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefJacobian.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefJacobian.hpp
@@ -795,7 +795,6 @@ namespace Intrepid2 {
                const BasisGradientsType gradients, const int startCell, const int endCell)
   {
     using JacobianViewType = Kokkos::DynRankView<jacobianValueType,jacobianProperties...>;
-    using ExecSpaceType    = typename DeviceType::execution_space;
     using FunctorType      = FunctorCellTools::F_setJacobian<JacobianViewType,WorksetType,BasisGradientsType> ;
     
     // resolve the -1 default argument for endCell into the true end cell index

--- a/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefJacobian.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefJacobian.hpp
@@ -119,9 +119,9 @@ namespace Intrepid2 {
     };
   }
 
-  template<typename ExecSpaceType>
+  template<typename DeviceType>
   template<class PointScalar>
-  Data<PointScalar> CellTools<ExecSpaceType>::allocateJacobianDet( const Data<PointScalar> & jacobian )
+  Data<PointScalar,DeviceType> CellTools<DeviceType>::allocateJacobianDet( const Data<PointScalar,DeviceType> & jacobian )
   {
     auto extents           = jacobian.getExtents(); // C,P,D,D, which we reduce to C,P
     auto variationTypes    = jacobian.getVariationTypes();
@@ -137,25 +137,25 @@ namespace Intrepid2 {
     {
       auto data = jacobian.getUnderlyingView4();
       auto detData = getMatchingViewWithLabel(data, "Jacobian det data", data.extent_int(0), data.extent_int(1));
-      return Data<PointScalar,ExecSpaceType>(detData,2,extents,variationTypes);
+      return Data<PointScalar,DeviceType>(detData,2,extents,variationTypes);
     }
     else if (cellVaries || pointVaries)
     {
       auto data = jacobian.getUnderlyingView3();
       auto detData = getMatchingViewWithLabel(data, "Jacobian det data", data.extent_int(0));
-      return Data<PointScalar,ExecSpaceType>(detData,2,extents,variationTypes);
+      return Data<PointScalar,DeviceType>(detData,2,extents,variationTypes);
     }
     else
     {
       auto data = jacobian.getUnderlyingView1();
       auto detData = getMatchingViewWithLabel(data, "Jacobian det data", 1);
-      return Data<PointScalar,ExecSpaceType>(detData,2,extents,variationTypes);
+      return Data<PointScalar,DeviceType>(detData,2,extents,variationTypes);
     }
   }
 
-  template<typename ExecSpaceType>
+  template<typename DeviceType>
   template<class PointScalar>
-  Data<PointScalar,ExecSpaceType> CellTools<ExecSpaceType>::allocateJacobianInv( const Data<PointScalar,ExecSpaceType> & jacobian )
+  Data<PointScalar,DeviceType> CellTools<DeviceType>::allocateJacobianInv( const Data<PointScalar,DeviceType> & jacobian )
   {
     auto extents        = jacobian.getExtents(); // C,P,D,D
     auto variationTypes = jacobian.getVariationTypes();
@@ -192,9 +192,9 @@ namespace Intrepid2 {
     }
   }
 
-  template<typename ExecSpaceType>
+  template<typename DeviceType>
   template<class PointScalar>
-  void CellTools<ExecSpaceType>::setJacobianDet( Data<PointScalar,ExecSpaceType> &jacobianDet, const Data<PointScalar,ExecSpaceType> & jacobian )
+  void CellTools<DeviceType>::setJacobianDet( Data<PointScalar,DeviceType> &jacobianDet, const Data<PointScalar,DeviceType> & jacobian )
   {
     auto variationTypes = jacobian.getVariationTypes();
     
@@ -459,9 +459,9 @@ namespace Intrepid2 {
     }
   }
 
-  template<typename ExecSpaceType>
+  template<typename DeviceType>
   template<class PointScalar>
-  void CellTools<ExecSpaceType>::setJacobianInv( Data<PointScalar,ExecSpaceType> &jacobianInv, const Data<PointScalar,ExecSpaceType> & jacobian )
+  void CellTools<DeviceType>::setJacobianInv( Data<PointScalar,DeviceType> &jacobianInv, const Data<PointScalar,DeviceType> & jacobian )
   {
     auto variationTypes  = jacobian.getVariationTypes();
     
@@ -784,18 +784,18 @@ namespace Intrepid2 {
     }
   }
 
-  template<typename SpT>
+  template<typename DeviceType>
   template<typename jacobianValueType,    class ...jacobianProperties,
            typename BasisGradientsType,
            typename WorksetType>
   void
-  CellTools<SpT>::
+  CellTools<DeviceType>::
   setJacobian(       Kokkos::DynRankView<jacobianValueType,jacobianProperties...> jacobian,
                const WorksetType worksetCell,
                const BasisGradientsType gradients, const int startCell, const int endCell)
   {
     using JacobianViewType = Kokkos::DynRankView<jacobianValueType,jacobianProperties...>;
-    using ExecSpaceType    = typename ExecSpace<typename JacobianViewType::execution_space,SpT>::ExecSpaceType;
+    using ExecSpaceType    = typename DeviceType::execution_space;
     using FunctorType      = FunctorCellTools::F_setJacobian<JacobianViewType,WorksetType,BasisGradientsType> ;
     
     // resolve the -1 default argument for endCell into the true end cell index

--- a/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefRefToPhys.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefRefToPhys.hpp
@@ -174,11 +174,11 @@ namespace Intrepid2 {
     }
     }
     
-    using FunctorType   = FunctorCellTools::F_mapToPhysicalFrame<physPointViewType,WorksetType,valViewType>;
-    using ExecSpaceType = typename Kokkos::DynRankView<physPointValueType,physPointProperties...>::execution_space;
+    using FunctorType    = FunctorCellTools::F_mapToPhysicalFrame<physPointViewType,WorksetType,valViewType>;
+    using ExecutionSpace = typename Kokkos::DynRankView<physPointValueType,physPointProperties...>::execution_space;
 
     const auto loopSize = physPoints.extent(0)*physPoints.extent(1);
-    Kokkos::RangePolicy<ExecSpaceType,Kokkos::Schedule<Kokkos::Static> > policy(0, loopSize);
+    Kokkos::RangePolicy<ExecutionSpace,Kokkos::Schedule<Kokkos::Static> > policy(0, loopSize);
     Kokkos::parallel_for( policy, FunctorType(physPoints, worksetCell, vals) );
   }
 

--- a/packages/intrepid2/src/Cell/Intrepid2_ProjectedGeometry.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_ProjectedGeometry.hpp
@@ -63,13 +63,13 @@ namespace Intrepid2
 /** \class Intrepid2::ProjectedGeometry
     \brief Allows generation of geometry degrees of freedom based on a provided map from straight-edged mesh domain to curvilinear mesh domain.
 */
-  template<int spaceDim, typename PointScalar, typename ExecSpaceType>
+  template<int spaceDim, typename PointScalar, typename DeviceType>
   class ProjectedGeometry
   {
   public:
-    using ViewType      = ScalarView<      PointScalar, ExecSpaceType>;
-    using ConstViewType = ScalarView<const PointScalar, ExecSpaceType>;
-    using BasisPtr      = Teuchos::RCP< Basis<ExecSpaceType,PointScalar,PointScalar> >;
+    using ViewType      = ScalarView<      PointScalar, DeviceType>;
+    using ConstViewType = ScalarView<const PointScalar, DeviceType>;
+    using BasisPtr      = Teuchos::RCP< Basis<DeviceType,PointScalar,PointScalar> >;
     
     /** \brief Generate geometry degrees of freedom based on a provided map from straight-edged mesh domain to curvilinear mesh domain.
        \param [out] projectedBasisNodes - the projected geometry degrees of freedom
@@ -81,7 +81,7 @@ namespace Intrepid2
      \see Intrepid2_ProjectedGeometryExamples.hpp for sample implementations of exactGeometry and exactGeometryGradient.
     */
     template<class ExactGeometry, class ExactGeometryGradient>
-    static void projectOntoHGRADBasis(ViewType projectedBasisNodes, BasisPtr targetHGradBasis, CellGeometry<PointScalar,spaceDim,ExecSpaceType> flatCellGeometry,
+    static void projectOntoHGRADBasis(ViewType projectedBasisNodes, BasisPtr targetHGradBasis, CellGeometry<PointScalar,spaceDim,DeviceType> flatCellGeometry,
                                       const ExactGeometry &exactGeometry, const ExactGeometryGradient &exactGeometryGradient)
     {
       const ordinal_type numCells = flatCellGeometry.extent_int(0); // (C,N,D)
@@ -92,8 +92,9 @@ namespace Intrepid2
       INTREPID2_TEST_FOR_EXCEPTION(projectedBasisNodes.extent_int(1) != targetHGradBasis->getCardinality(), std::invalid_argument, "projectedBasisNodes must have shape (C,F,D)");
       INTREPID2_TEST_FOR_EXCEPTION(projectedBasisNodes.extent_int(2) != spaceDim, std::invalid_argument, "projectedBasisNodes must have shape (C,F,D)");
       
-      using ProjectionTools  = Experimental::ProjectionTools<ExecSpaceType>;
-      using ProjectionStruct = Experimental::ProjectionStruct<ExecSpaceType,PointScalar>;
+      using ExecutionSpace = typename DeviceType::execution_space;
+      using ProjectionTools  = Experimental::ProjectionTools<ExecutionSpace>; // TODO: when ProjectionTools supports it, replace template argument with DeviceType
+      using ProjectionStruct = Experimental::ProjectionStruct<ExecutionSpace,PointScalar>; // TODO: when ProjectionTools supports it, replace template argument with DeviceType
       
       ProjectionStruct projectionStruct;
       ordinal_type targetQuadratureDegree(targetHGradBasis->getDegree()), targetDerivativeQuadratureDegree(targetHGradBasis->getDegree());
@@ -114,7 +115,7 @@ namespace Intrepid2
       ViewType evaluationPoints    ("ProjectedGeometry evaluation points (value)",    numCells, numPoints,     spaceDim);
       ViewType evaluationGradPoints("ProjectedGeometry evaluation points (gradient)", numCells, numGradPoints, spaceDim);
   
-      using CellTools = CellTools<ExecSpaceType>;
+      using CellTools = CellTools<ExecutionSpace>; // TODO: when CellTools fully supports it, switch to DeviceType
       BasisPtr hgradLinearBasisForFlatGeometry = flatCellGeometry.basisForNodes();
       if (numPoints > 0)
       {
@@ -128,8 +129,8 @@ namespace Intrepid2
       auto refData = flatCellGeometry.getJacobianRefData(evaluationGradPoints);
       
       // evaluate, transform, and project in each component
-      auto policy = Kokkos::MDRangePolicy<ExecSpaceType,Kokkos::Rank<2>>({0,0},  {numCells,numPoints});
-      auto gradPolicy  = Kokkos::MDRangePolicy<ExecSpaceType,Kokkos::Rank<3>>({0,0,0},{numCells,numGradPoints,spaceDim});
+      auto policy = Kokkos::MDRangePolicy<ExecutionSpace,Kokkos::Rank<2>>({0,0},  {numCells,numPoints});
+      auto gradPolicy  = Kokkos::MDRangePolicy<ExecutionSpace,Kokkos::Rank<3>>({0,0,0},{numCells,numGradPoints,spaceDim});
       
       ViewType evaluationValues    ("exact geometry values",    numCells, numPoints);
       ViewType evaluationGradients ("exact geometry gradients", numCells, numGradPoints, spaceDim);
@@ -168,8 +169,8 @@ namespace Intrepid2
         });
         
         // apply Jacobian
-        Data<PointScalar,ExecSpaceType> gradientData(evaluationGradients);
-        auto transformedGradientData = Data<PointScalar,ExecSpaceType>::allocateMatVecResult(gradPointsJacobians,gradientData);
+        Data<PointScalar,DeviceType> gradientData(evaluationGradients);
+        auto transformedGradientData = Data<PointScalar,DeviceType>::allocateMatVecResult(gradPointsJacobians,gradientData);
         
         transformedGradientData.storeMatVec(gradPointsJacobians,gradientData);
         

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasisFamily.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasisFamily.hpp
@@ -86,8 +86,9 @@ namespace Intrepid2
     using OutputValueType = typename LineBasisHGRAD::OutputValueType;
     using PointValueType  = typename LineBasisHGRAD::PointValueType;
     
-    using Basis    = typename LineBasisHGRAD::BasisBase;
-    using BasisPtr = Teuchos::RCP<Basis>;
+    using Basis      = typename LineBasisHGRAD::BasisBase;
+    using BasisPtr   = Teuchos::RCP<Basis>;
+    using DeviceType = typename Basis::DeviceType;
     
     // line bases
     using HGRAD_LINE = LineBasisHGRAD;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DirectSumBasis.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DirectSumBasis.hpp
@@ -71,6 +71,7 @@ namespace Intrepid2
     using BasisBase = BasisBaseClass;
     using BasisPtr  = Teuchos::RCP<BasisBase>;
     
+    using DeviceType      = typename BasisBase::DeviceType;
     using ExecutionSpace  = typename BasisBase::ExecutionSpace;
     using OutputValueType = typename BasisBase::OutputValueType;
     using PointValueType  = typename BasisBase::PointValueType;
@@ -206,10 +207,10 @@ namespace Intrepid2
         The default implementation employs a trivial tensor-product structure, for compatibility across all bases.  Subclasses that have tensor-product structure
         should override.  Note that only the basic exact-sequence operators are supported at the moment: VALUE, GRAD, DIV, CURL.
      */
-    virtual BasisValues<OutputValueType,ExecutionSpace> allocateBasisValues( TensorPoints<PointValueType,ExecutionSpace> points, const EOperator operatorType = OPERATOR_VALUE) const override
+    virtual BasisValues<OutputValueType,DeviceType> allocateBasisValues( TensorPoints<PointValueType,DeviceType> points, const EOperator operatorType = OPERATOR_VALUE) const override
     {
-      BasisValues<OutputValueType,ExecutionSpace> basisValues1 = basis1_->allocateBasisValues(points, operatorType);
-      BasisValues<OutputValueType,ExecutionSpace> basisValues2 = basis2_->allocateBasisValues(points, operatorType);
+      BasisValues<OutputValueType,DeviceType> basisValues1 = basis1_->allocateBasisValues(points, operatorType);
+      BasisValues<OutputValueType,DeviceType> basisValues2 = basis2_->allocateBasisValues(points, operatorType);
       
       const int numScalarFamilies1 = basisValues1.numTensorDataFamilies();
       if (numScalarFamilies1 > 0)
@@ -217,7 +218,7 @@ namespace Intrepid2
         // then both basis1 and basis2 should be scalar-valued; check that for basis2:
         const int numScalarFamilies2 = basisValues2.numTensorDataFamilies();
         INTREPID2_TEST_FOR_EXCEPTION(basisValues2.numTensorDataFamilies() <=0, std::invalid_argument, "When basis1 has scalar value, basis2 must also");
-        std::vector< TensorData<OutputValueType,ExecutionSpace> > scalarFamilies(numScalarFamilies1 + numScalarFamilies2);
+        std::vector< TensorData<OutputValueType,DeviceType> > scalarFamilies(numScalarFamilies1 + numScalarFamilies2);
         for (int i=0; i<numScalarFamilies1; i++)
         {
           scalarFamilies[i] = basisValues1.tensorData(i);
@@ -226,7 +227,7 @@ namespace Intrepid2
         {
           scalarFamilies[i+numScalarFamilies1] = basisValues2.tensorData(i);
         }
-        return BasisValues<OutputValueType,ExecutionSpace>(scalarFamilies);
+        return BasisValues<OutputValueType,DeviceType>(scalarFamilies);
       }
       else
       {
@@ -243,7 +244,7 @@ namespace Intrepid2
         const int numFamilies2 = vectorData2.numFamilies();
         
         const int numFamilies = numFamilies1 + numFamilies2;
-        std::vector< std::vector<TensorData<OutputValueType,ExecutionSpace> > > vectorComponents(numFamilies, std::vector<TensorData<OutputValueType,ExecutionSpace> >(numComponents));
+        std::vector< std::vector<TensorData<OutputValueType,DeviceType> > > vectorComponents(numFamilies, std::vector<TensorData<OutputValueType,DeviceType> >(numComponents));
         
         for (int i=0; i<numFamilies1; i++)
         {
@@ -259,8 +260,8 @@ namespace Intrepid2
             vectorComponents[i+numFamilies1][j] = vectorData2.getComponent(i,j);
           }
         }
-        VectorData<OutputValueType,ExecutionSpace> vectorData(vectorComponents);
-        return BasisValues<OutputValueType,ExecutionSpace>(vectorData);
+        VectorData<OutputValueType,DeviceType> vectorData(vectorComponents);
+        return BasisValues<OutputValueType,DeviceType>(vectorData);
       }
     }
     
@@ -336,8 +337,8 @@ namespace Intrepid2
     */
     virtual
     void
-    getValues(       BasisValues<OutputValueType,ExecutionSpace> outputValues,
-               const TensorPoints<PointValueType,ExecutionSpace>  inputPoints,
+    getValues(       BasisValues<OutputValueType,DeviceType> outputValues,
+               const TensorPoints<PointValueType,DeviceType>  inputPoints,
                const EOperator operatorType = OPERATOR_VALUE ) const override
     {
       const int fieldStartOrdinal1 = 0;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_TensorBasis.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_TensorBasis.hpp
@@ -570,7 +570,7 @@ struct OperatorTensorDecomposition
     
     std::string name_; // name of the basis
   public:
-    
+    using DeviceType = typename BasisBase::DeviceType;
     using ExecutionSpace  = typename BasisBase::ExecutionSpace;
     using OutputValueType = typename BasisBase::OutputValueType;
     using PointValueType  = typename BasisBase::PointValueType;
@@ -764,7 +764,7 @@ struct OperatorTensorDecomposition
      
         Note that only the basic exact-sequence operators are supported at the moment: VALUE, GRAD, DIV, CURL.
      */
-    virtual BasisValues<OutputValueType,ExecutionSpace> allocateBasisValues( TensorPoints<PointValueType,ExecutionSpace> points, const EOperator operatorType = OPERATOR_VALUE) const override
+    virtual BasisValues<OutputValueType,DeviceType> allocateBasisValues( TensorPoints<PointValueType,DeviceType> points, const EOperator operatorType = OPERATOR_VALUE) const override
     {
       const bool operatorSupported = (operatorType == OPERATOR_VALUE) || (operatorType == OPERATOR_GRAD) || (operatorType == OPERATOR_CURL) || (operatorType == OPERATOR_DIV);
       INTREPID2_TEST_FOR_EXCEPTION(!operatorSupported, std::invalid_argument, "operator is not supported by allocateBasisValues");
@@ -778,31 +778,31 @@ struct OperatorTensorDecomposition
       if (useVectorData)
       {
         const int numFamilies = 1;
-        std::vector< std::vector<TensorData<OutputValueType,ExecutionSpace> > > vectorComponents(numFamilies, std::vector<TensorData<OutputValueType,ExecutionSpace> >(numVectorComponents));
+        std::vector< std::vector<TensorData<OutputValueType,DeviceType> > > vectorComponents(numFamilies, std::vector<TensorData<OutputValueType,DeviceType> >(numVectorComponents));
         
         const int familyOrdinal = 0;
         for (ordinal_type vectorComponentOrdinal=0; vectorComponentOrdinal<numVectorComponents; vectorComponentOrdinal++)
         {
           if (!opDecomposition.identicallyZeroComponent(vectorComponentOrdinal))
           {
-            std::vector< Data<OutputValueType,ExecutionSpace> > componentData;
+            std::vector< Data<OutputValueType,DeviceType> > componentData;
             for (ordinal_type r=0; r<numBasisComponents; r++)
             {
               const int numComponentPoints = points.componentPointCount(r);
               const EOperator op = opDecomposition.op(vectorComponentOrdinal, r);
               auto componentView = tensorComponents_[r]->allocateOutputView(numComponentPoints, op);
-              componentData.push_back(Data<OutputValueType,ExecutionSpace>(componentView));
+              componentData.push_back(Data<OutputValueType,DeviceType>(componentView));
             }
-            vectorComponents[familyOrdinal][vectorComponentOrdinal] = TensorData<OutputValueType,ExecutionSpace>(componentData);
+            vectorComponents[familyOrdinal][vectorComponentOrdinal] = TensorData<OutputValueType,DeviceType>(componentData);
           }
         }
-        VectorData<OutputValueType,ExecutionSpace> vectorData(vectorComponents);
-        return BasisValues<OutputValueType,ExecutionSpace>(vectorData);
+        VectorData<OutputValueType,DeviceType> vectorData(vectorComponents);
+        return BasisValues<OutputValueType,DeviceType>(vectorData);
       }
       else
       {
         // TensorData: single tensor product
-        std::vector< Data<OutputValueType,ExecutionSpace> > componentData;
+        std::vector< Data<OutputValueType,DeviceType> > componentData;
         
         const ordinal_type vectorComponentOrdinal = 0;
         for (ordinal_type r=0; r<numBasisComponents; r++)
@@ -816,13 +816,13 @@ struct OperatorTensorDecomposition
           //  we want Data to insulate us from that fact)
           const Kokkos::Array<int,7> extents {componentView.extent_int(0), componentView.extent_int(1), 1,1,1,1,1};
           Kokkos::Array<DataVariationType,7> variationType {GENERAL, GENERAL, CONSTANT, CONSTANT, CONSTANT, CONSTANT, CONSTANT };
-          componentData.push_back(Data<OutputValueType,ExecutionSpace>(componentView, rank, extents, variationType));
+          componentData.push_back(Data<OutputValueType,DeviceType>(componentView, rank, extents, variationType));
         }
         
-        TensorData<OutputValueType,ExecutionSpace> tensorData(componentData);
+        TensorData<OutputValueType,DeviceType> tensorData(componentData);
         
-        std::vector< TensorData<OutputValueType,ExecutionSpace> > tensorDataEntries {tensorData};
-        return BasisValues<OutputValueType,ExecutionSpace>(tensorDataEntries);
+        std::vector< TensorData<OutputValueType,DeviceType> > tensorDataEntries {tensorData};
+        return BasisValues<OutputValueType,DeviceType>(tensorDataEntries);
       }
     }
     
@@ -1040,8 +1040,8 @@ struct OperatorTensorDecomposition
     */
     virtual
     void
-    getValues(       BasisValues<OutputValueType,ExecutionSpace> outputValues,
-               const TensorPoints<PointValueType,ExecutionSpace>  inputPoints,
+    getValues(       BasisValues<OutputValueType,DeviceType> outputValues,
+               const TensorPoints<PointValueType,DeviceType>  inputPoints,
                const EOperator operatorType = OPERATOR_VALUE ) const override
     {
       OperatorTensorDecomposition operatorDecomposition = getOperatorDecomposition(operatorType);
@@ -1066,7 +1066,7 @@ struct OperatorTensorDecomposition
             PointViewType  pointView      = inputPoints.getTensorComponent(basisOrdinal);
             
             // Data stores things in fixed-rank Kokkos::View, but Basis requires DynRankView.  We allocate a temporary DynRankView, then copy back to Data.
-            const Data<OutputValueType,ExecutionSpace> & outputData = tensorData.getTensorComponent(basisOrdinal);
+            const Data<OutputValueType,DeviceType> & outputData = tensorData.getTensorComponent(basisOrdinal);
             
             auto basisValueView = outputData.getUnderlyingView();
             tensorComponents_[basisOrdinal]->getValues(basisValueView, pointView, op);

--- a/packages/intrepid2/src/Discretization/Integration/Intrepid2_Cubature.hpp
+++ b/packages/intrepid2/src/Discretization/Integration/Intrepid2_Cubature.hpp
@@ -127,11 +127,10 @@ namespace Intrepid2 {
     using PointViewType             = Kokkos::DynRankView<pointValueType,Kokkos::LayoutStride,DeviceType>;
     using weightViewType            = Kokkos::DynRankView<weightValueType,Kokkos::LayoutStride,DeviceType>;
 
-    /// KK: the following needs to be updated with device type after nate's tensor work is updated.
-    using PointViewTypeAllocatable  = Kokkos::DynRankView<pointValueType,ExecSpaceType>;  // uses default layout; allows us to allocate (in contrast to LayoutStride)
-    using WeightViewTypeAllocatable = Kokkos::DynRankView<weightValueType,ExecSpaceType>; // uses default layout; allows us to allocate (in contrast to LayoutStride)
-    using TensorPointDataType       = TensorPoints<pointValueType,ExecSpaceType>;
-    using TensorWeightDataType      = TensorData<weightValueType,ExecSpaceType>;
+    using PointViewTypeAllocatable  = Kokkos::DynRankView<pointValueType,DeviceType>;  // uses default layout; allows us to allocate (in contrast to LayoutStride)
+    using WeightViewTypeAllocatable = Kokkos::DynRankView<weightValueType,DeviceType>; // uses default layout; allows us to allocate (in contrast to LayoutStride)
+    using TensorPointDataType       = TensorPoints<pointValueType,DeviceType>;
+    using TensorWeightDataType      = TensorData<weightValueType,DeviceType>;
     
     /** \brief Returns a points container appropriate for passing to getCubature().
 
@@ -153,8 +152,7 @@ namespace Intrepid2 {
     virtual TensorWeightDataType allocateCubatureWeights() const
     {
       // default implementation has trivial tensor structure
-      /// KK: this also needs to be updated with nate's tensor
-      using WeightDataType = Data<weightValueType,ExecSpaceType>;
+      using WeightDataType = Data<weightValueType,DeviceType>;
       WeightViewTypeAllocatable allWeightData("cubature weights",this->getNumPoints());
       Kokkos::Array< WeightDataType, 1> cubatureWeightComponents;
       cubatureWeightComponents[0] = WeightDataType(allWeightData);

--- a/packages/intrepid2/src/Discretization/Integration/Intrepid2_CubatureTensor.hpp
+++ b/packages/intrepid2/src/Discretization/Integration/Intrepid2_CubatureTensor.hpp
@@ -124,8 +124,7 @@ namespace Intrepid2 {
     */
     virtual TensorWeightDataType allocateCubatureWeights() const override
     {
-      /// KK: this needs to be updated with nate tensor work      
-      using WeightDataType = Data<weightValueType,typename DeviceType::execution_space>;
+      using WeightDataType = Data<weightValueType,DeviceType>;
       
       std::vector< WeightDataType > cubatureWeightComponents(numCubatures_);
       for (ordinal_type i=0;i<numCubatures_;++i)

--- a/packages/intrepid2/src/Discretization/Integration/Intrepid2_IntegrationTools.hpp
+++ b/packages/intrepid2/src/Discretization/Integration/Intrepid2_IntegrationTools.hpp
@@ -74,7 +74,7 @@ namespace Intrepid2 {
   /** \class Intrepid2::IntegrationTools
       \brief Provides support for structure-aware integration.
   */
-  template<typename ExecSpaceType = void>
+  template<typename DeviceType = void>
   class IntegrationTools {
   public:
     /** \brief   Allocates storage for the contraction of \a <b>vectorDataLeft</b> and \a <b>vectorDataRight</b> containers on
@@ -88,9 +88,9 @@ namespace Intrepid2 {
         \return <b>integrals</b>, a container with nominal shape (C,F,F), suitable for passing as the first argument to the integrate() variant that takes an Intrepid2::Data object as its first, <b>integrals</b>, argument.
     */
     template<class Scalar>
-    static Data<Scalar,ExecSpaceType> allocateIntegralData(const TransformedVectorData<Scalar,ExecSpaceType> vectorDataLeft,
-                                                           const TensorData<Scalar,ExecSpaceType> cellMeasures,
-                                                           const TransformedVectorData<Scalar,ExecSpaceType> vectorDataRight);
+    static Data<Scalar,DeviceType> allocateIntegralData(const TransformedVectorData<Scalar,DeviceType> vectorDataLeft,
+                                                        const TensorData<Scalar,DeviceType> cellMeasures,
+                                                        const TransformedVectorData<Scalar,DeviceType> vectorDataRight);
     
     /** \brief   Contracts \a <b>vectorDataLeft</b> and \a <b>vectorDataRight</b> containers on
         point and space dimensions, weighting each point according to <b>cellMeasures</b>,
@@ -104,9 +104,9 @@ namespace Intrepid2 {
         \param  approxFlops               [in] - if not NULL, the double pointed to will be set with an estimated number of floating point operations.  Intended for performance assessment purposes.
     */
     template<class Scalar>
-    static void integrate(Data<Scalar,ExecSpaceType> integrals, const TransformedVectorData<Scalar,ExecSpaceType> &vectorDataLeft,
-                          const TensorData<Scalar,ExecSpaceType> &cellMeasures,
-                          const TransformedVectorData<Scalar,ExecSpaceType> &vectorDataRight, const bool sumInto = false,
+    static void integrate(Data<Scalar,DeviceType> integrals, const TransformedVectorData<Scalar,DeviceType> &vectorDataLeft,
+                          const TensorData<Scalar,DeviceType> &cellMeasures,
+                          const TransformedVectorData<Scalar,DeviceType> &vectorDataRight, const bool sumInto = false,
                           double* approximateFlops = NULL);
   }; // end IntegrationTools class
 

--- a/packages/intrepid2/src/Shared/Intrepid2_CellGeometryTestUtils.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_CellGeometryTestUtils.hpp
@@ -74,7 +74,7 @@ namespace Intrepid2
     using intView         = ScalarView<        int, DeviceType >;
     
     auto cellToNodes      = intView                          ("cell to nodes", numCells, numNodes);    // this will be a one-to-one mapping
-    PointScalarView nodes = getView2T<PointScalar,DeviceType>("nodes", numCells * numNodes, spaceDim); // we store redundant copies of vertices for each cell
+    PointScalarView nodes = getView<PointScalar,DeviceType>("nodes", numCells * numNodes, spaceDim); // we store redundant copies of vertices for each cell
 
     using ExecutionSpace = typename DeviceType::execution_space;
     auto policy = Kokkos::MDRangePolicy<ExecutionSpace,Kokkos::Rank<2>>({0,0},{numCells,numNodes});

--- a/packages/intrepid2/src/Shared/Intrepid2_CellGeometryTestUtils.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_CellGeometryTestUtils.hpp
@@ -61,21 +61,22 @@ namespace Intrepid2
    \param [in] copyAffineness - if true, the resulting geometry will be marked as affine if the original geometry was, allowing reduce storage of Jacobians, etc.
    \return a representation of the same geometry, defined using cell-to-nodes and node-to-coordinates containers.
 */
-  template< typename PointScalar, int spaceDim, typename ExecutionSpace >
+  template< typename PointScalar, int spaceDim, typename DeviceType >
   inline
-  CellGeometry<PointScalar, spaceDim, ExecutionSpace> getNodalCellGeometry(CellGeometry<PointScalar, spaceDim, ExecutionSpace> &anyCellGeometry,
-                                                                           const bool &copyAffineness)
+  CellGeometry<PointScalar, spaceDim, DeviceType> getNodalCellGeometry(CellGeometry<PointScalar, spaceDim, DeviceType> &anyCellGeometry,
+                                                                       const bool &copyAffineness)
   {
     // copy the nodes from CellGeometry into a raw View
     const int numCells = anyCellGeometry.extent_int(0);
     const int numNodes = anyCellGeometry.extent_int(1);
     
-    using PointScalarView = ScalarView<PointScalar, ExecutionSpace >;
-    using intView         = ScalarView<        int, ExecutionSpace >;
+    using PointScalarView = ScalarView<PointScalar, DeviceType >;
+    using intView         = ScalarView<        int, DeviceType >;
     
-    auto cellToNodes      = intView             ("cell to nodes", numCells, numNodes);    // this will be a one-to-one mapping
-    PointScalarView nodes = getView<PointScalar>("nodes", numCells * numNodes, spaceDim); // we store redundant copies of vertices for each cell
+    auto cellToNodes      = intView                          ("cell to nodes", numCells, numNodes);    // this will be a one-to-one mapping
+    PointScalarView nodes = getView2T<PointScalar,DeviceType>("nodes", numCells * numNodes, spaceDim); // we store redundant copies of vertices for each cell
 
+    using ExecutionSpace = typename DeviceType::execution_space;
     auto policy = Kokkos::MDRangePolicy<ExecutionSpace,Kokkos::Rank<2>>({0,0},{numCells,numNodes});
     
     // "workset"
@@ -95,7 +96,7 @@ namespace Intrepid2
     const auto nodeOrdering = anyCellGeometry.nodeOrderingForHypercubes();
     
     const auto cellTopology = anyCellGeometry.cellTopology();
-    CellGeometry<PointScalar, spaceDim, ExecutionSpace> nodalCellGeometry(cellTopology,cellToNodes,nodes,claimAffine,nodeOrdering);
+    CellGeometry<PointScalar, spaceDim, DeviceType> nodalCellGeometry(cellTopology,cellToNodes,nodes,claimAffine,nodeOrdering);
     
     return nodalCellGeometry;
   }
@@ -105,9 +106,9 @@ namespace Intrepid2
    \param [in] gridCellCounts - array specifying the number of cells in each coordinate dimension.
    \return a uniform Cartesion mesh, with origin at 0, with the specified domain extents and grid cell counts.
 */
-  template<class PointScalar, int spaceDim, typename ExecSpaceType = Kokkos::DefaultExecutionSpace>
-  inline CellGeometry<PointScalar,spaceDim,ExecSpaceType> uniformCartesianMesh(const Kokkos::Array<PointScalar,spaceDim> &domainExtents,
-                                                                               const Kokkos::Array<int,spaceDim> &gridCellCounts)
+  template<class PointScalar, int spaceDim, typename DeviceType = Kokkos::DefaultExecutionSpace>
+  inline CellGeometry<PointScalar,spaceDim,DeviceType> uniformCartesianMesh(const Kokkos::Array<PointScalar,spaceDim> &domainExtents,
+                                                                            const Kokkos::Array<int,spaceDim> &gridCellCounts)
   {
     Kokkos::Array<PointScalar,spaceDim> origin;
     for (int d=0; d<spaceDim; d++)
@@ -115,7 +116,7 @@ namespace Intrepid2
       origin[d] = 0.0;
     }
     
-    using CellGeometry = ::Intrepid2::CellGeometry<PointScalar, spaceDim, ExecSpaceType>;
+    using CellGeometry = ::Intrepid2::CellGeometry<PointScalar, spaceDim, DeviceType>;
     const auto NO_SUBDIVISION = CellGeometry::NO_SUBDIVISION;
     const auto HYPERCUBE_NODE_ORDER_CLASSIC_SHARDS = CellGeometry::HYPERCUBE_NODE_ORDER_CLASSIC_SHARDS;
     
@@ -127,8 +128,8 @@ namespace Intrepid2
    \param [in] gridCellCounts - the number of cells in each coordinate dimension.
    \return a uniform Cartesion mesh, with origin at 0, with the specified domain extent and grid cell counts.
 */
-  template<class PointScalar, int spaceDim, typename ExecSpaceType = Kokkos::DefaultExecutionSpace>
-  inline CellGeometry<PointScalar,spaceDim,ExecSpaceType> uniformCartesianMesh(const PointScalar &domainExtent, const int &meshWidth)
+  template<class PointScalar, int spaceDim, typename DeviceType = Kokkos::DefaultExecutionSpace>
+  inline CellGeometry<PointScalar,spaceDim,DeviceType> uniformCartesianMesh(const PointScalar &domainExtent, const int &meshWidth)
   {
     Kokkos::Array<PointScalar,spaceDim> origin;
     Kokkos::Array<PointScalar,spaceDim> domainExtents;
@@ -140,7 +141,7 @@ namespace Intrepid2
       gridCellCounts[d] = meshWidth;
     }
     
-    using CellGeometry = ::Intrepid2::CellGeometry<PointScalar, spaceDim, ExecSpaceType>;
+    using CellGeometry = ::Intrepid2::CellGeometry<PointScalar, spaceDim, DeviceType>;
     const auto NO_SUBDIVISION = CellGeometry::NO_SUBDIVISION;
     const auto HYPERCUBE_NODE_ORDER_CLASSIC_SHARDS = CellGeometry::HYPERCUBE_NODE_ORDER_CLASSIC_SHARDS;
     

--- a/packages/intrepid2/src/Shared/Intrepid2_Data.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_Data.hpp
@@ -498,6 +498,32 @@ namespace Intrepid2 {
       setActiveDims();
     }
     
+    //! copy-like constructor for differing device type, but same memory space.  This does a shallow copy of the underlying view.
+    template<typename OtherDeviceType, class = typename std::enable_if< std::is_same<typename DeviceType::memory_space, typename OtherDeviceType::memory_space>::value>::type,
+                                       class = typename std::enable_if<!std::is_same<DeviceType,OtherDeviceType>::value>::type>
+    Data(const Data<DataScalar,OtherDeviceType> &data)
+    :
+    dataRank_(data.getUnderlyingViewRank()), extents_(data.getExtents()), variationType_(data.getVariationTypes()), blockPlusDiagonalLastNonDiagonal_(data.blockPlusDiagonalLastNonDiagonal()), rank_(data.rank())
+    {
+//      std::cout << "Entered copy-like Data constructor.\n";
+      if (dataRank_ != 0) // dataRank_ == 0 indicates an invalid Data object (a placeholder, can indicate zero value)
+      {
+        const auto view = data.getUnderlyingView();
+        switch (dataRank_)
+        {
+          case 1: data1_ = data.getUnderlyingView1(); break;
+          case 2: data2_ = data.getUnderlyingView2(); break;
+          case 3: data3_ = data.getUnderlyingView3(); break;
+          case 4: data4_ = data.getUnderlyingView4(); break;
+          case 5: data5_ = data.getUnderlyingView5(); break;
+          case 6: data6_ = data.getUnderlyingView6(); break;
+          case 7: data7_ = data.getUnderlyingView7(); break;
+          default: INTREPID2_TEST_FOR_EXCEPTION(true, std::invalid_argument, "Invalid data rank");
+        }
+      }
+      setActiveDims();
+    }
+    
     //! copy-like constructor for differing execution spaces.  This does a deep_copy of the underlying view.
     template<typename OtherDeviceType, class = typename std::enable_if<!std::is_same<typename DeviceType::memory_space, typename OtherDeviceType::memory_space>::value>::type>
     Data(const Data<DataScalar,OtherDeviceType> &data)

--- a/packages/intrepid2/src/Shared/Intrepid2_Data.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_Data.hpp
@@ -168,20 +168,20 @@ namespace Intrepid2 {
      - BLOCK_PLUS_DIAGONAL: the data varies in this notional dimension and one other, corresponding to a square matrix that has some (possibly trivial) full block, with diagonal entries in the remaining dimensions.  The underlying View will have one dimension corresponding to the two notional dimensions, with extent corresponding to the number of nonzeros in the matrix.
      
   */
-  template<class DataScalar,typename ExecSpaceType = Kokkos::DefaultExecutionSpace>
+  template<class DataScalar,typename DeviceType = Kokkos::DefaultExecutionSpace>
   class Data {
   public:
     using value_type      = DataScalar;
-    using execution_space = ExecSpaceType;
+    using execution_space = typename DeviceType::execution_space;
   private:
     ordinal_type dataRank_;
-    Kokkos::View<DataScalar*,       ExecSpaceType> data1_;  // the rank 1 data that is explicitly stored
-    Kokkos::View<DataScalar**,      ExecSpaceType> data2_;  // the rank 2 data that is explicitly stored
-    Kokkos::View<DataScalar***,     ExecSpaceType> data3_;  // the rank 3 data that is explicitly stored
-    Kokkos::View<DataScalar****,    ExecSpaceType> data4_;  // the rank 4 data that is explicitly stored
-    Kokkos::View<DataScalar*****,   ExecSpaceType> data5_;  // the rank 5 data that is explicitly stored
-    Kokkos::View<DataScalar******,  ExecSpaceType> data6_;  // the rank 6 data that is explicitly stored
-    Kokkos::View<DataScalar*******, ExecSpaceType> data7_;  // the rank 7 data that is explicitly stored
+    Kokkos::View<DataScalar*,       DeviceType> data1_;  // the rank 1 data that is explicitly stored
+    Kokkos::View<DataScalar**,      DeviceType> data2_;  // the rank 2 data that is explicitly stored
+    Kokkos::View<DataScalar***,     DeviceType> data3_;  // the rank 3 data that is explicitly stored
+    Kokkos::View<DataScalar****,    DeviceType> data4_;  // the rank 4 data that is explicitly stored
+    Kokkos::View<DataScalar*****,   DeviceType> data5_;  // the rank 5 data that is explicitly stored
+    Kokkos::View<DataScalar******,  DeviceType> data6_;  // the rank 6 data that is explicitly stored
+    Kokkos::View<DataScalar*******, DeviceType> data7_;  // the rank 7 data that is explicitly stored
     Kokkos::Array<int,7> extents_;                     // logical extents in each dimension
     Kokkos::Array<DataVariationType,7> variationType_; // for each dimension, whether the data varies in that dimension
     Kokkos::Array<int,7> variationModulus_;            // for each dimension, a value by which indices should be modulused (only used when variationType_ is MODULAR)
@@ -194,12 +194,12 @@ namespace Intrepid2 {
     
     ordinal_type rank_;
     
-    using reference_type       = typename ScalarView<DataScalar,ExecSpaceType>::reference_type;
-    using const_reference_type = typename ScalarView<const DataScalar,ExecSpaceType>::reference_type;
+    using reference_type       = typename ScalarView<DataScalar,DeviceType>::reference_type;
+    using const_reference_type = typename ScalarView<const DataScalar,DeviceType>::reference_type;
     // we use reference_type as the return for operator() for performance reasons, especially significant when using Sacado types
     using return_type = const_reference_type;
     
-    ScalarView<DataScalar,ExecSpaceType> zeroView_; // one-entry (zero); used to allow getEntry() to return 0 for off-diagonal entries in BLOCK_PLUS_DIAGONAL
+    ScalarView<DataScalar,DeviceType> zeroView_; // one-entry (zero); used to allow getEntry() to return 0 for off-diagonal entries in BLOCK_PLUS_DIAGONAL
     
     //! Returns the number of non-diagonal entries based on the last non-diagonal.  Only applicable for BLOCK_PLUS_DIAGONAL DataVariationType.
     KOKKOS_INLINE_FUNCTION
@@ -249,7 +249,7 @@ namespace Intrepid2 {
       }
       
       // by default, this should initialize with zero -- no need to deep_copy a 0 into it
-      zeroView_ = ScalarView<DataScalar,ExecSpaceType>("zero",1);
+      zeroView_ = ScalarView<DataScalar,DeviceType>("zero",1);
       
       numActiveDims_ = 0;
       int blockPlusDiagonalCount = 0;
@@ -449,7 +449,7 @@ namespace Intrepid2 {
     static void copyContainer(ToContainer to, FromContainer from)
     {
 //      std::cout << "Entered copyContainer().\n";
-      auto policy = Kokkos::MDRangePolicy<ExecSpaceType,Kokkos::Rank<6>>({0,0,0,0,0,0},{from.extent_int(0),from.extent_int(1),from.extent_int(2), from.extent_int(3), from.extent_int(4), from.extent_int(5)});
+      auto policy = Kokkos::MDRangePolicy<execution_space,Kokkos::Rank<6>>({0,0,0,0,0,0},{from.extent_int(0),from.extent_int(1),from.extent_int(2), from.extent_int(3), from.extent_int(4), from.extent_int(5)});
       
       Kokkos::parallel_for("copyContainer", policy,
       KOKKOS_LAMBDA (const int &i0, const int &i1, const int &i2, const int &i3, const int &i4, const int &i5) {
@@ -461,18 +461,18 @@ namespace Intrepid2 {
     }
     
     //! allocate an underlying View that matches the provided DynRankView in dimensions, and copy.  Called by constructors that accept a DynRankView as argument.
-    void allocateAndCopyFromDynRankView(ScalarView<DataScalar,ExecSpaceType> data)
+    void allocateAndCopyFromDynRankView(ScalarView<DataScalar,DeviceType> data)
     {
 //      std::cout << "Entered allocateAndCopyFromDynRankView().\n";
       switch (dataRank_)
       {
-        case 1: data1_ = Kokkos::View<DataScalar*,       ExecSpaceType>("Intrepid2 Data", data.extent_int(0)); break;
-        case 2: data2_ = Kokkos::View<DataScalar**,      ExecSpaceType>("Intrepid2 Data", data.extent_int(0), data.extent_int(1)); break;
-        case 3: data3_ = Kokkos::View<DataScalar***,     ExecSpaceType>("Intrepid2 Data", data.extent_int(0), data.extent_int(1), data.extent_int(2)); break;
-        case 4: data4_ = Kokkos::View<DataScalar****,    ExecSpaceType>("Intrepid2 Data", data.extent_int(0), data.extent_int(1), data.extent_int(2), data.extent_int(3)); break;
-        case 5: data5_ = Kokkos::View<DataScalar*****,   ExecSpaceType>("Intrepid2 Data", data.extent_int(0), data.extent_int(1), data.extent_int(2), data.extent_int(3), data.extent_int(4)); break;
-        case 6: data6_ = Kokkos::View<DataScalar******,  ExecSpaceType>("Intrepid2 Data", data.extent_int(0), data.extent_int(1), data.extent_int(2), data.extent_int(3), data.extent_int(4), data.extent_int(5)); break;
-        case 7: data7_ = Kokkos::View<DataScalar*******, ExecSpaceType>("Intrepid2 Data", data.extent_int(0), data.extent_int(1), data.extent_int(2), data.extent_int(3), data.extent_int(4), data.extent_int(5), data.extent_int(6)); break;
+        case 1: data1_ = Kokkos::View<DataScalar*,       DeviceType>("Intrepid2 Data", data.extent_int(0)); break;
+        case 2: data2_ = Kokkos::View<DataScalar**,      DeviceType>("Intrepid2 Data", data.extent_int(0), data.extent_int(1)); break;
+        case 3: data3_ = Kokkos::View<DataScalar***,     DeviceType>("Intrepid2 Data", data.extent_int(0), data.extent_int(1), data.extent_int(2)); break;
+        case 4: data4_ = Kokkos::View<DataScalar****,    DeviceType>("Intrepid2 Data", data.extent_int(0), data.extent_int(1), data.extent_int(2), data.extent_int(3)); break;
+        case 5: data5_ = Kokkos::View<DataScalar*****,   DeviceType>("Intrepid2 Data", data.extent_int(0), data.extent_int(1), data.extent_int(2), data.extent_int(3), data.extent_int(4)); break;
+        case 6: data6_ = Kokkos::View<DataScalar******,  DeviceType>("Intrepid2 Data", data.extent_int(0), data.extent_int(1), data.extent_int(2), data.extent_int(3), data.extent_int(4), data.extent_int(5)); break;
+        case 7: data7_ = Kokkos::View<DataScalar*******, DeviceType>("Intrepid2 Data", data.extent_int(0), data.extent_int(1), data.extent_int(2), data.extent_int(3), data.extent_int(4), data.extent_int(5), data.extent_int(6)); break;
         default: INTREPID2_TEST_FOR_EXCEPTION(true, std::invalid_argument, "Invalid data rank");
       }
       
@@ -490,7 +490,7 @@ namespace Intrepid2 {
     }
     
     //! DynRankView constructor.  Will copy to a View of appropriate rank.
-    Data(const ScalarView<DataScalar,ExecSpaceType> &data, int rank, Kokkos::Array<int,7> extents, Kokkos::Array<DataVariationType,7> variationType, const int blockPlusDiagonalLastNonDiagonal = -1)
+    Data(const ScalarView<DataScalar,DeviceType> &data, int rank, Kokkos::Array<int,7> extents, Kokkos::Array<DataVariationType,7> variationType, const int blockPlusDiagonalLastNonDiagonal = -1)
     :
     dataRank_(data.rank()), extents_(extents), variationType_(variationType), blockPlusDiagonalLastNonDiagonal_(blockPlusDiagonalLastNonDiagonal), rank_(rank)
     {
@@ -499,8 +499,8 @@ namespace Intrepid2 {
     }
     
     //! copy-like constructor for differing execution spaces.  This does a deep_copy of the underlying view.
-    template<typename OtherExecSpaceType, class = typename std::enable_if<!std::is_same<ExecSpaceType, OtherExecSpaceType>::value>::type>
-    Data(const Data<DataScalar,OtherExecSpaceType> &data)
+    template<typename OtherDeviceType, class = typename std::enable_if<!std::is_same<typename DeviceType::memory_space, typename OtherDeviceType::memory_space>::value>::type>
+    Data(const Data<DataScalar,OtherDeviceType> &data)
     :
     dataRank_(data.getUnderlyingViewRank()), extents_(data.getExtents()), variationType_(data.getVariationTypes()), blockPlusDiagonalLastNonDiagonal_(data.blockPlusDiagonalLastNonDiagonal()), rank_(data.rank())
     {
@@ -510,20 +510,20 @@ namespace Intrepid2 {
         const auto view = data.getUnderlyingView();
         switch (dataRank_)
         {
-          case 1: data1_ = Kokkos::View<DataScalar*,       ExecSpaceType>("Intrepid2 Data", view.extent_int(0)); break;
-          case 2: data2_ = Kokkos::View<DataScalar**,      ExecSpaceType>("Intrepid2 Data", view.extent_int(0), view.extent_int(1)); break;
-          case 3: data3_ = Kokkos::View<DataScalar***,     ExecSpaceType>("Intrepid2 Data", view.extent_int(0), view.extent_int(1), view.extent_int(2)); break;
-          case 4: data4_ = Kokkos::View<DataScalar****,    ExecSpaceType>("Intrepid2 Data", view.extent_int(0), view.extent_int(1), view.extent_int(2), view.extent_int(3)); break;
-          case 5: data5_ = Kokkos::View<DataScalar*****,   ExecSpaceType>("Intrepid2 Data", view.extent_int(0), view.extent_int(1), view.extent_int(2), view.extent_int(3), view.extent_int(4)); break;
-          case 6: data6_ = Kokkos::View<DataScalar******,  ExecSpaceType>("Intrepid2 Data", view.extent_int(0), view.extent_int(1), view.extent_int(2), view.extent_int(3), view.extent_int(4), view.extent_int(5)); break;
-          case 7: data7_ = Kokkos::View<DataScalar*******, ExecSpaceType>("Intrepid2 Data", view.extent_int(0), view.extent_int(1), view.extent_int(2), view.extent_int(3), view.extent_int(4), view.extent_int(5), view.extent_int(6)); break;
+          case 1: data1_ = Kokkos::View<DataScalar*,       DeviceType>("Intrepid2 Data", view.extent_int(0)); break;
+          case 2: data2_ = Kokkos::View<DataScalar**,      DeviceType>("Intrepid2 Data", view.extent_int(0), view.extent_int(1)); break;
+          case 3: data3_ = Kokkos::View<DataScalar***,     DeviceType>("Intrepid2 Data", view.extent_int(0), view.extent_int(1), view.extent_int(2)); break;
+          case 4: data4_ = Kokkos::View<DataScalar****,    DeviceType>("Intrepid2 Data", view.extent_int(0), view.extent_int(1), view.extent_int(2), view.extent_int(3)); break;
+          case 5: data5_ = Kokkos::View<DataScalar*****,   DeviceType>("Intrepid2 Data", view.extent_int(0), view.extent_int(1), view.extent_int(2), view.extent_int(3), view.extent_int(4)); break;
+          case 6: data6_ = Kokkos::View<DataScalar******,  DeviceType>("Intrepid2 Data", view.extent_int(0), view.extent_int(1), view.extent_int(2), view.extent_int(3), view.extent_int(4), view.extent_int(5)); break;
+          case 7: data7_ = Kokkos::View<DataScalar*******, DeviceType>("Intrepid2 Data", view.extent_int(0), view.extent_int(1), view.extent_int(2), view.extent_int(3), view.extent_int(4), view.extent_int(5), view.extent_int(6)); break;
           default: INTREPID2_TEST_FOR_EXCEPTION(true, std::invalid_argument, "Invalid data rank");
         }
         
         // copy
         // (Note: Kokkos::deep_copy() will not generally work if the layouts are different; that's why we do a manual copy here once we have the data on the host):
         // first, mirror and copy dataView; then copy to the appropriate data_ member
-        using MemorySpace = typename ExecSpaceType::memory_space;
+        using MemorySpace = typename DeviceType::memory_space;
         switch (dataRank_)
         {
           case 1: {auto dataViewMirror = Kokkos::create_mirror_view_and_copy(MemorySpace(), data.getUnderlyingView1()); copyContainer(data1_, dataViewMirror);} break;
@@ -550,20 +550,20 @@ namespace Intrepid2 {
 //        const auto view = data.getUnderlyingView();
 //        switch (dataRank_)
 //        {
-//          case 1: data1_ = Kokkos::View<DataScalar*,       ExecSpaceType>("Intrepid2 Data - explicit copy constructor(for debugging)", view.extent_int(0)); break;
-//          case 2: data2_ = Kokkos::View<DataScalar**,      ExecSpaceType>("Intrepid2 Data - explicit copy constructor(for debugging)", view.extent_int(0), view.extent_int(1)); break;
-//          case 3: data3_ = Kokkos::View<DataScalar***,     ExecSpaceType>("Intrepid2 Data - explicit copy constructor(for debugging)", view.extent_int(0), view.extent_int(1), view.extent_int(2)); break;
-//          case 4: data4_ = Kokkos::View<DataScalar****,    ExecSpaceType>("Intrepid2 Data - explicit copy constructor(for debugging)", view.extent_int(0), view.extent_int(1), view.extent_int(2), view.extent_int(3)); break;
-//          case 5: data5_ = Kokkos::View<DataScalar*****,   ExecSpaceType>("Intrepid2 Data - explicit copy constructor(for debugging)", view.extent_int(0), view.extent_int(1), view.extent_int(2), view.extent_int(3), view.extent_int(4)); break;
-//          case 6: data6_ = Kokkos::View<DataScalar******,  ExecSpaceType>("Intrepid2 Data - explicit copy constructor(for debugging)", view.extent_int(0), view.extent_int(1), view.extent_int(2), view.extent_int(3), view.extent_int(4), view.extent_int(5)); break;
-//          case 7: data7_ = Kokkos::View<DataScalar*******, ExecSpaceType>("Intrepid2 Data - explicit copy constructor(for debugging)", view.extent_int(0), view.extent_int(1), view.extent_int(2), view.extent_int(3), view.extent_int(4), view.extent_int(5), view.extent_int(6)); break;
+//          case 1: data1_ = Kokkos::View<DataScalar*,       DeviceType>("Intrepid2 Data - explicit copy constructor(for debugging)", view.extent_int(0)); break;
+//          case 2: data2_ = Kokkos::View<DataScalar**,      DeviceType>("Intrepid2 Data - explicit copy constructor(for debugging)", view.extent_int(0), view.extent_int(1)); break;
+//          case 3: data3_ = Kokkos::View<DataScalar***,     DeviceType>("Intrepid2 Data - explicit copy constructor(for debugging)", view.extent_int(0), view.extent_int(1), view.extent_int(2)); break;
+//          case 4: data4_ = Kokkos::View<DataScalar****,    DeviceType>("Intrepid2 Data - explicit copy constructor(for debugging)", view.extent_int(0), view.extent_int(1), view.extent_int(2), view.extent_int(3)); break;
+//          case 5: data5_ = Kokkos::View<DataScalar*****,   DeviceType>("Intrepid2 Data - explicit copy constructor(for debugging)", view.extent_int(0), view.extent_int(1), view.extent_int(2), view.extent_int(3), view.extent_int(4)); break;
+//          case 6: data6_ = Kokkos::View<DataScalar******,  DeviceType>("Intrepid2 Data - explicit copy constructor(for debugging)", view.extent_int(0), view.extent_int(1), view.extent_int(2), view.extent_int(3), view.extent_int(4), view.extent_int(5)); break;
+//          case 7: data7_ = Kokkos::View<DataScalar*******, DeviceType>("Intrepid2 Data - explicit copy constructor(for debugging)", view.extent_int(0), view.extent_int(1), view.extent_int(2), view.extent_int(3), view.extent_int(4), view.extent_int(5), view.extent_int(6)); break;
 //          default: INTREPID2_TEST_FOR_EXCEPTION(true, std::invalid_argument, "Invalid data rank");
 //        }
 //
 //        // copy
 //        // (Note: Kokkos::deep_copy() will not generally work if the layouts are different; that's why we do a manual copy here once we have the data on the host):
 //        // first, mirror and copy dataView; then copy to the appropriate data_ member
-//        using MemorySpace = typename ExecSpaceType::memory_space;
+//        using MemorySpace = typename DeviceType::memory_space;
 //        switch (dataRank_)
 //        {
 //          case 1: {auto dataViewMirror = Kokkos::create_mirror_view_and_copy(MemorySpace(), data.getUnderlyingView1()); copyContainer(data1_, dataViewMirror);} break;
@@ -581,7 +581,7 @@ namespace Intrepid2 {
 //    }
     
     //! constructor for fully varying data container, no expressed redundancy/repetition.  Copies the data to a new Kokkos::View of matching rank.
-    Data(ScalarView<DataScalar,ExecSpaceType> data)
+    Data(ScalarView<DataScalar,DeviceType> data)
     :
     Data(data,
          data.rank(),
@@ -591,7 +591,7 @@ namespace Intrepid2 {
     
     //! Constructor that accepts a DynRankView as an argument.  The data belonging to the DynRankView will be copied into a new View of matching dimensions.
     template<size_t rank, class ...DynRankViewProperties>
-    Data(const Kokkos::DynRankView<DataScalar,ExecSpaceType, DynRankViewProperties...> &data, Kokkos::Array<int,rank> extents, Kokkos::Array<DataVariationType,rank> variationType, const int blockPlusDiagonalLastNonDiagonal = -1)
+    Data(const Kokkos::DynRankView<DataScalar,DeviceType, DynRankViewProperties...> &data, Kokkos::Array<int,rank> extents, Kokkos::Array<DataVariationType,rank> variationType, const int blockPlusDiagonalLastNonDiagonal = -1)
     :
     dataRank_(data.rank()), extents_({1,1,1,1,1,1,1}), variationType_({CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT}), blockPlusDiagonalLastNonDiagonal_(blockPlusDiagonalLastNonDiagonal), rank_(rank)
     {
@@ -606,7 +606,7 @@ namespace Intrepid2 {
     }
         
     template<size_t rank, class ...ViewProperties>
-    Data(Kokkos::View<DataScalar*,ExecSpaceType, ViewProperties...> data, Kokkos::Array<int,rank> extents, Kokkos::Array<DataVariationType,rank> variationType, const int blockPlusDiagonalLastNonDiagonal = -1)
+    Data(Kokkos::View<DataScalar*,DeviceType, ViewProperties...> data, Kokkos::Array<int,rank> extents, Kokkos::Array<DataVariationType,rank> variationType, const int blockPlusDiagonalLastNonDiagonal = -1)
     :
     dataRank_(data.rank), extents_({1,1,1,1,1,1,1}), variationType_({CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT}), blockPlusDiagonalLastNonDiagonal_(blockPlusDiagonalLastNonDiagonal), rank_(rank)
     {
@@ -620,7 +620,7 @@ namespace Intrepid2 {
     }
     
     template<size_t rank, class ...ViewProperties>
-    Data(Kokkos::View<DataScalar**,ExecSpaceType, ViewProperties...> data, Kokkos::Array<int,rank> extents, Kokkos::Array<DataVariationType,rank> variationType, const int blockPlusDiagonalLastNonDiagonal = -1)
+    Data(Kokkos::View<DataScalar**,DeviceType, ViewProperties...> data, Kokkos::Array<int,rank> extents, Kokkos::Array<DataVariationType,rank> variationType, const int blockPlusDiagonalLastNonDiagonal = -1)
     :
     dataRank_(data.rank), extents_({1,1,1,1,1,1,1}), variationType_({CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT}), blockPlusDiagonalLastNonDiagonal_(blockPlusDiagonalLastNonDiagonal), rank_(rank)
     {
@@ -634,7 +634,7 @@ namespace Intrepid2 {
     }
     
     template<size_t rank, class ...ViewProperties>
-    Data(Kokkos::View<DataScalar***,ExecSpaceType, ViewProperties...> data, Kokkos::Array<int,rank> extents, Kokkos::Array<DataVariationType,rank> variationType, const int blockPlusDiagonalLastNonDiagonal = -1)
+    Data(Kokkos::View<DataScalar***,DeviceType, ViewProperties...> data, Kokkos::Array<int,rank> extents, Kokkos::Array<DataVariationType,rank> variationType, const int blockPlusDiagonalLastNonDiagonal = -1)
     :
     dataRank_(data.rank), extents_({1,1,1,1,1,1,1}), variationType_({CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT}), blockPlusDiagonalLastNonDiagonal_(blockPlusDiagonalLastNonDiagonal), rank_(rank)
     {
@@ -648,7 +648,7 @@ namespace Intrepid2 {
     }
     
     template<size_t rank, class ...ViewProperties>
-    Data(Kokkos::View<DataScalar****,ExecSpaceType, ViewProperties...> data, Kokkos::Array<int,rank> extents, Kokkos::Array<DataVariationType,rank> variationType, const int blockPlusDiagonalLastNonDiagonal = -1)
+    Data(Kokkos::View<DataScalar****,DeviceType, ViewProperties...> data, Kokkos::Array<int,rank> extents, Kokkos::Array<DataVariationType,rank> variationType, const int blockPlusDiagonalLastNonDiagonal = -1)
     :
     dataRank_(data.rank), extents_({1,1,1,1,1,1,1}), variationType_({CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT}), blockPlusDiagonalLastNonDiagonal_(blockPlusDiagonalLastNonDiagonal), rank_(rank)
     {
@@ -662,7 +662,7 @@ namespace Intrepid2 {
     }
     
     template<size_t rank, class ...ViewProperties>
-    Data(Kokkos::View<DataScalar*****,ExecSpaceType, ViewProperties...> data, Kokkos::Array<int,rank> extents, Kokkos::Array<DataVariationType,rank> variationType, const int blockPlusDiagonalLastNonDiagonal = -1)
+    Data(Kokkos::View<DataScalar*****,DeviceType, ViewProperties...> data, Kokkos::Array<int,rank> extents, Kokkos::Array<DataVariationType,rank> variationType, const int blockPlusDiagonalLastNonDiagonal = -1)
     :
     dataRank_(data.rank), extents_({1,1,1,1,1,1,1}), variationType_({CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT}), blockPlusDiagonalLastNonDiagonal_(blockPlusDiagonalLastNonDiagonal), rank_(rank)
     {
@@ -676,7 +676,7 @@ namespace Intrepid2 {
     }
     
     template<size_t rank, class ...ViewProperties>
-    Data(Kokkos::View<DataScalar******,ExecSpaceType, ViewProperties...> data, Kokkos::Array<int,rank> extents, Kokkos::Array<DataVariationType,rank> variationType, const int blockPlusDiagonalLastNonDiagonal = -1)
+    Data(Kokkos::View<DataScalar******,DeviceType, ViewProperties...> data, Kokkos::Array<int,rank> extents, Kokkos::Array<DataVariationType,rank> variationType, const int blockPlusDiagonalLastNonDiagonal = -1)
     :
     dataRank_(data.rank), extents_({1,1,1,1,1,1,1}), variationType_({CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT}), blockPlusDiagonalLastNonDiagonal_(blockPlusDiagonalLastNonDiagonal), rank_(rank)
     {
@@ -690,7 +690,7 @@ namespace Intrepid2 {
     }
     
     template<size_t rank, class ...ViewProperties>
-    Data(Kokkos::View<DataScalar*******,ExecSpaceType, ViewProperties...> data, Kokkos::Array<int,rank> extents, Kokkos::Array<DataVariationType,rank> variationType, const int blockPlusDiagonalLastNonDiagonal = -1)
+    Data(Kokkos::View<DataScalar*******,DeviceType, ViewProperties...> data, Kokkos::Array<int,rank> extents, Kokkos::Array<DataVariationType,rank> variationType, const int blockPlusDiagonalLastNonDiagonal = -1)
     :
     dataRank_(data.rank), extents_({1,1,1,1,1,1,1}), variationType_({CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT}), blockPlusDiagonalLastNonDiagonal_(blockPlusDiagonalLastNonDiagonal), rank_(rank)
     {
@@ -709,7 +709,7 @@ namespace Intrepid2 {
     :
     dataRank_(1), extents_({1,1,1,1,1,1,1}), variationType_({CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT,CONSTANT}), blockPlusDiagonalLastNonDiagonal_(-1), rank_(rank)
     {
-      data1_ = Kokkos::View<DataScalar*,ExecSpaceType>("Constant Data",1);
+      data1_ = Kokkos::View<DataScalar*,DeviceType>("Constant Data",1);
       Kokkos::deep_copy(data1_, constantValue);
       for (unsigned d=0; d<rank; d++)
       {
@@ -771,7 +771,7 @@ namespace Intrepid2 {
     //! Returns the underlying view.  Throws an exception if the underlying view is not rank 1.
     template<int rank>
     KOKKOS_INLINE_FUNCTION
-    enable_if_t<rank==1, const Kokkos::View<typename RankExpander<DataScalar, rank>::value_type, ExecSpaceType> &>
+    enable_if_t<rank==1, const Kokkos::View<typename RankExpander<DataScalar, rank>::value_type, DeviceType> &>
     getUnderlyingView() const
     {
       #ifdef HAVE_INTREPID2_DEBUG
@@ -783,7 +783,7 @@ namespace Intrepid2 {
     //! Returns the underlying view.  Throws an exception if the underlying view is not rank 2.
     template<int rank>
     KOKKOS_INLINE_FUNCTION
-    enable_if_t<rank==2, const Kokkos::View<typename RankExpander<DataScalar, rank>::value_type, ExecSpaceType> &>
+    enable_if_t<rank==2, const Kokkos::View<typename RankExpander<DataScalar, rank>::value_type, DeviceType> &>
     getUnderlyingView() const
     {
       #ifdef HAVE_INTREPID2_DEBUG
@@ -795,7 +795,7 @@ namespace Intrepid2 {
     //! Returns the underlying view.  Throws an exception if the underlying view is not rank 3.
     template<int rank>
     KOKKOS_INLINE_FUNCTION
-    enable_if_t<rank==3, const Kokkos::View<typename RankExpander<DataScalar, rank>::value_type, ExecSpaceType> &>
+    enable_if_t<rank==3, const Kokkos::View<typename RankExpander<DataScalar, rank>::value_type, DeviceType> &>
     getUnderlyingView() const
     {
       #ifdef HAVE_INTREPID2_DEBUG
@@ -807,7 +807,7 @@ namespace Intrepid2 {
     //! Returns the underlying view.  Throws an exception if the underlying view is not rank 4.
     template<int rank>
     KOKKOS_INLINE_FUNCTION
-    enable_if_t<rank==4, const Kokkos::View<typename RankExpander<DataScalar, rank>::value_type, ExecSpaceType> &>
+    enable_if_t<rank==4, const Kokkos::View<typename RankExpander<DataScalar, rank>::value_type, DeviceType> &>
     getUnderlyingView() const
     {
       #ifdef HAVE_INTREPID2_DEBUG
@@ -819,7 +819,7 @@ namespace Intrepid2 {
     //! Returns the underlying view.  Throws an exception if the underlying view is not rank 5.
     template<int rank>
     KOKKOS_INLINE_FUNCTION
-    enable_if_t<rank==5, const Kokkos::View<typename RankExpander<DataScalar, rank>::value_type, ExecSpaceType> &>
+    enable_if_t<rank==5, const Kokkos::View<typename RankExpander<DataScalar, rank>::value_type, DeviceType> &>
     getUnderlyingView() const
     {
       #ifdef HAVE_INTREPID2_DEBUG
@@ -831,7 +831,7 @@ namespace Intrepid2 {
     //! Returns the underlying view.  Throws an exception if the underlying view is not rank 6.
     template<int rank>
     KOKKOS_INLINE_FUNCTION
-    enable_if_t<rank==6, const Kokkos::View<typename RankExpander<DataScalar, rank>::value_type, ExecSpaceType> &>
+    enable_if_t<rank==6, const Kokkos::View<typename RankExpander<DataScalar, rank>::value_type, DeviceType> &>
     getUnderlyingView() const
     {
       #ifdef HAVE_INTREPID2_DEBUG
@@ -843,7 +843,7 @@ namespace Intrepid2 {
     //! Returns the underlying view.  Throws an exception if the underlying view is not rank 7.
     template<int rank>
     KOKKOS_INLINE_FUNCTION
-    enable_if_t<rank==7, const Kokkos::View<typename RankExpander<DataScalar, rank>::value_type, ExecSpaceType> &>
+    enable_if_t<rank==7, const Kokkos::View<typename RankExpander<DataScalar, rank>::value_type, DeviceType> &>
     getUnderlyingView() const
     {
       #ifdef HAVE_INTREPID2_DEBUG
@@ -854,104 +854,104 @@ namespace Intrepid2 {
     
     //! returns the View that stores the unique data.  For rank-1 underlying containers.
     KOKKOS_INLINE_FUNCTION
-    const Kokkos::View<DataScalar*, ExecSpaceType> & getUnderlyingView1() const
+    const Kokkos::View<DataScalar*, DeviceType> & getUnderlyingView1() const
     {
       return getUnderlyingView<1>();
     }
     
     //! returns the View that stores the unique data.  For rank-2 underlying containers.
     KOKKOS_INLINE_FUNCTION
-    const Kokkos::View<DataScalar**, ExecSpaceType> & getUnderlyingView2() const
+    const Kokkos::View<DataScalar**, DeviceType> & getUnderlyingView2() const
     {
       return getUnderlyingView<2>();
     }
     
     //! returns the View that stores the unique data.  For rank-3 underlying containers.
     KOKKOS_INLINE_FUNCTION
-    const Kokkos::View<DataScalar***, ExecSpaceType> & getUnderlyingView3() const
+    const Kokkos::View<DataScalar***, DeviceType> & getUnderlyingView3() const
     {
       return getUnderlyingView<3>();
     }
     
     //! returns the View that stores the unique data.  For rank-4 underlying containers.
     KOKKOS_INLINE_FUNCTION
-    const Kokkos::View<DataScalar****, ExecSpaceType> & getUnderlyingView4() const
+    const Kokkos::View<DataScalar****, DeviceType> & getUnderlyingView4() const
     {
       return getUnderlyingView<4>();
     }
     
     //! returns the View that stores the unique data.  For rank-5 underlying containers.
     KOKKOS_INLINE_FUNCTION
-    const Kokkos::View<DataScalar*****, ExecSpaceType> & getUnderlyingView5() const
+    const Kokkos::View<DataScalar*****, DeviceType> & getUnderlyingView5() const
     {
       return getUnderlyingView<5>();
     }
     
     //! returns the View that stores the unique data.  For rank-6 underlying containers.
     KOKKOS_INLINE_FUNCTION
-    const Kokkos::View<DataScalar******, ExecSpaceType> & getUnderlyingView6() const
+    const Kokkos::View<DataScalar******, DeviceType> & getUnderlyingView6() const
     {
       return getUnderlyingView<6>();
     }
     
     //! returns the View that stores the unique data.  For rank-7 underlying containers.
     KOKKOS_INLINE_FUNCTION
-    const Kokkos::View<DataScalar*******, ExecSpaceType> & getUnderlyingView7() const
+    const Kokkos::View<DataScalar*******, DeviceType> & getUnderlyingView7() const
     {
       return getUnderlyingView<7>();
     }
     
     //! sets the View that stores the unique data.  For rank-1 underlying containers.
     KOKKOS_INLINE_FUNCTION
-    void setUnderlyingView1(Kokkos::View<DataScalar*, ExecSpaceType> & view) const
+    void setUnderlyingView1(Kokkos::View<DataScalar*, DeviceType> & view) const
     {
       data1_ = view;
     }
     
     //! sets the View that stores the unique data.  For rank-2 underlying containers.
     KOKKOS_INLINE_FUNCTION
-    void setUnderlyingView2(Kokkos::View<DataScalar**, ExecSpaceType> & view) const
+    void setUnderlyingView2(Kokkos::View<DataScalar**, DeviceType> & view) const
     {
       data2_ = view;
     }
     
     //! sets the View that stores the unique data.  For rank-3 underlying containers.
     KOKKOS_INLINE_FUNCTION
-    void setUnderlyingView3(Kokkos::View<DataScalar***, ExecSpaceType> & view) const
+    void setUnderlyingView3(Kokkos::View<DataScalar***, DeviceType> & view) const
     {
       data3_ = view;
     }
     
     //! sets the View that stores the unique data.  For rank-4 underlying containers.
     KOKKOS_INLINE_FUNCTION
-    void setUnderlyingView4(Kokkos::View<DataScalar****, ExecSpaceType> & view) const
+    void setUnderlyingView4(Kokkos::View<DataScalar****, DeviceType> & view) const
     {
       data4_ = view;
     }
     
     //! sets the View that stores the unique data.  For rank-5 underlying containers.
     KOKKOS_INLINE_FUNCTION
-    void setUnderlyingView5(Kokkos::View<DataScalar*****, ExecSpaceType> & view) const
+    void setUnderlyingView5(Kokkos::View<DataScalar*****, DeviceType> & view) const
     {
       data5_ = view;
     }
     
     //! sets the View that stores the unique data.  For rank-6 underlying containers.
     KOKKOS_INLINE_FUNCTION
-    void setUnderlyingView6(Kokkos::View<DataScalar******, ExecSpaceType> & view) const
+    void setUnderlyingView6(Kokkos::View<DataScalar******, DeviceType> & view) const
     {
       data6_ = view;
     }
     
     //! sets the View that stores the unique data.  For rank-7 underlying containers.
     KOKKOS_INLINE_FUNCTION
-    void setUnderlyingView7(Kokkos::View<DataScalar*******, ExecSpaceType> & view) const
+    void setUnderlyingView7(Kokkos::View<DataScalar*******, DeviceType> & view) const
     {
       data7_ = view;
     }
     
     //! Returns a DynRankView constructed atop the same underlying data as the fixed-rank Kokkos::View used internally.
-    ScalarView<DataScalar,ExecSpaceType> getUnderlyingView() const
+    ScalarView<DataScalar,DeviceType> getUnderlyingView() const
     {
       switch (dataRank_)
       {
@@ -986,7 +986,7 @@ namespace Intrepid2 {
     }
     
     //! Returns a DynRankView that matches the underlying Kokkos::View object in value_type, layout, and dimension.
-    ScalarView<DataScalar,ExecSpaceType> allocateDynRankViewMatchingUnderlying() const
+    ScalarView<DataScalar,DeviceType> allocateDynRankViewMatchingUnderlying() const
     {
       switch (dataRank_)
       {
@@ -1003,7 +1003,7 @@ namespace Intrepid2 {
     
     //! Returns a DynRankView that matches the underlying Kokkos::View object value_type and layout, but with the specified dimensions.
     template<class ... DimArgs>
-    ScalarView<DataScalar,ExecSpaceType> allocateDynRankViewMatchingUnderlying(DimArgs... dims) const
+    ScalarView<DataScalar,DeviceType> allocateDynRankViewMatchingUnderlying(DimArgs... dims) const
     {
       switch (dataRank_)
       {
@@ -1035,7 +1035,7 @@ namespace Intrepid2 {
     }
     
     //! Copies from the provided DynRankView into the underlying Kokkos::View container storing the unique data.
-    void copyDataFromDynRankViewMatchingUnderlying(const ScalarView<DataScalar,ExecSpaceType> &dynRankView) const
+    void copyDataFromDynRankViewMatchingUnderlying(const ScalarView<DataScalar,DeviceType> &dynRankView) const
     {
 //      std::cout << "Entered copyDataFromDynRankViewMatchingUnderlying().\n";
       switch (dataRank_)
@@ -1332,7 +1332,7 @@ namespace Intrepid2 {
     //! \param transposeA                                          [in] - if true, A will be transposed prior to being multiplied by B (or B's transpose).
     //! \param B_MatData                                            [in] - nominally (...,D3,D4)-dimensioned container, where D3,D4 correspond to matrix dimensions.
     //! \param transposeB                                          [in] - if true, B will be transposed prior to the multiplication by A (or A's transpose).
-    static Data<DataScalar,ExecSpaceType> allocateMatMatResult( const bool transposeA, const Data<DataScalar,ExecSpaceType> &A_MatData, const bool transposeB, const Data<DataScalar,ExecSpaceType> &B_MatData )
+    static Data<DataScalar,DeviceType> allocateMatMatResult( const bool transposeA, const Data<DataScalar,DeviceType> &A_MatData, const bool transposeB, const Data<DataScalar,DeviceType> &B_MatData )
     {
       // we treat last two nominal dimensions of matData as the matrix; last dimension of vecData as the vector
       INTREPID2_TEST_FOR_EXCEPTION_DEVICE_SAFE(A_MatData.rank() != B_MatData.rank(), std::invalid_argument, "AmatData and BmatData have incompatible ranks");
@@ -1468,7 +1468,7 @@ namespace Intrepid2 {
         resultExtents[i]        = 1;
       }
       
-      ScalarView<DataScalar,ExecSpaceType> data;
+      ScalarView<DataScalar,DeviceType> data;
       if (resultNumActiveDims == 1)
       {
         auto viewToMatch = A_MatData.getUnderlyingView1(); // new view will match this one in layout and fad dimension, if any
@@ -1509,12 +1509,12 @@ namespace Intrepid2 {
                                         resultDataDims[3], resultDataDims[4], resultDataDims[5], resultDataDims[6]);
       }
       
-      return Data<DataScalar,ExecSpaceType>(data,resultRank,resultExtents,resultVariationTypes,resultBlockPlusDiagonalLastNonDiagonal);
+      return Data<DataScalar,DeviceType>(data,resultRank,resultExtents,resultVariationTypes,resultBlockPlusDiagonalLastNonDiagonal);
     }
     
     //! Constructs a container suitable for storing the result of a matrix-vector multiply corresponding to the two provided containers.
     //! \see storeMatVec()
-    static Data<DataScalar,ExecSpaceType> allocateMatVecResult( const Data<DataScalar,ExecSpaceType> &matData, const Data<DataScalar,ExecSpaceType> &vecData )
+    static Data<DataScalar,DeviceType> allocateMatVecResult( const Data<DataScalar,DeviceType> &matData, const Data<DataScalar,DeviceType> &vecData )
     {
       // we treat last two nominal dimensions of matData as the matrix; last dimension of vecData as the vector
       INTREPID2_TEST_FOR_EXCEPTION_DEVICE_SAFE(matData.rank() != vecData.rank() + 1, std::invalid_argument, "matData and vecData have incompatible ranks");
@@ -1601,7 +1601,7 @@ namespace Intrepid2 {
         resultExtents[i]        = 1;
       }
       
-      ScalarView<DataScalar,ExecSpaceType> data;
+      ScalarView<DataScalar,DeviceType> data;
       if (resultNumActiveDims == 1)
       {
         data = matData.allocateDynRankViewMatchingUnderlying(resultDataDims[0]);
@@ -1635,11 +1635,11 @@ namespace Intrepid2 {
                                                              resultDataDims[3], resultDataDims[4], resultDataDims[5], resultDataDims[6]);
       }
       
-      return Data<DataScalar,ExecSpaceType>(data,resultRank,resultExtents,resultVariationTypes);
+      return Data<DataScalar,DeviceType>(data,resultRank,resultExtents,resultVariationTypes);
     }
     
     //! Places the result of a matrix-vector multiply corresponding to the two provided containers into this Data container.  This Data container should have been constructed by a call to allocateMatVecResult(), or should match such a container in underlying data extent and variation types.
-    void storeMatVec( const Data<DataScalar,ExecSpaceType> &matData, const Data<DataScalar,ExecSpaceType> &vecData )
+    void storeMatVec( const Data<DataScalar,DeviceType> &matData, const Data<DataScalar,DeviceType> &vecData )
     {
       // TODO: add a compile-time (SFINAE-type) guard against DataScalar types that do not support arithmetic operations.  (We support Orientation as a DataScalar type; it might suffice just to compare DataScalar to Orientation, and eliminate this method for that case.)
       // TODO: check for invalidly shaped containers.
@@ -1648,13 +1648,14 @@ namespace Intrepid2 {
       const int matCols = matData.extent_int(matData.rank() - 1);
       
       // shallow copy of this to avoid implicit references to this in call to getWritableEntry() below
-      Data<DataScalar,ExecSpaceType> thisData = *this;
+      Data<DataScalar,DeviceType> thisData = *this;
       
+      using ExecutionSpace = typename DeviceType::execution_space;
       // note the use of getDataExtent() below: we only range over the possibly-distinct entries
       if (rank_ == 3)
       {
         // typical case for e.g. gradient data: (C,P,D)
-        auto policy = Kokkos::MDRangePolicy<ExecSpaceType,Kokkos::Rank<3>>({0,0,0},{getDataExtent(0),getDataExtent(1),matRows});
+        auto policy = Kokkos::MDRangePolicy<ExecutionSpace,Kokkos::Rank<3>>({0,0,0},{getDataExtent(0),getDataExtent(1),matRows});
         Kokkos::parallel_for("compute mat-vec", policy,
         KOKKOS_LAMBDA (const int &cellOrdinal, const int &pointOrdinal, const int &i) {
           auto & val_i = thisData.getWritableEntry(cellOrdinal, pointOrdinal, i, 0, 0, 0, 0);
@@ -1668,7 +1669,7 @@ namespace Intrepid2 {
       else if (rank_ == 2)
       {
         //
-        auto policy = Kokkos::MDRangePolicy<ExecSpaceType,Kokkos::Rank<2>>({0,0},{getDataExtent(0),matRows});
+        auto policy = Kokkos::MDRangePolicy<ExecutionSpace,Kokkos::Rank<2>>({0,0},{getDataExtent(0),matRows});
         Kokkos::parallel_for("compute mat-vec", policy,
         KOKKOS_LAMBDA (const int &vectorOrdinal, const int &i) {
           auto & val_i = thisData.getWritableEntry(vectorOrdinal, i, 0, 0, 0, 0, 0);
@@ -1682,7 +1683,7 @@ namespace Intrepid2 {
       else if (rank_ == 1)
       {
         // single-vector case
-        Kokkos::RangePolicy<ExecSpaceType> policy(0,matRows);
+        Kokkos::RangePolicy<ExecutionSpace> policy(0,matRows);
         Kokkos::parallel_for("compute mat-vec", policy,
         KOKKOS_LAMBDA (const int &i) {
           auto & val_i = thisData.getWritableEntry(i, 0, 0, 0, 0, 0, 0);
@@ -1706,7 +1707,7 @@ namespace Intrepid2 {
     //! \param transposeA                                          [in] - if true, A will be transposed prior to being multiplied by B (or B's transpose).
     //! \param B_MatData                                            [in] - nominally (...,D3,D4)-dimensioned container, where D3,D4 correspond to matrix dimensions.
     //! \param transposeB                                          [in] - if true, B will be transposed prior to the multiplication by A (or A's transpose).
-    void storeMatMat( const bool transposeA, const Data<DataScalar,ExecSpaceType> &A_MatData, const bool transposeB, const Data<DataScalar,ExecSpaceType> &B_MatData )
+    void storeMatMat( const bool transposeA, const Data<DataScalar,DeviceType> &A_MatData, const bool transposeB, const Data<DataScalar,DeviceType> &B_MatData )
     {
       // TODO: add a compile-time (SFINAE-type) guard against DataScalar types that do not support arithmetic operations.  (We support Orientation as a DataScalar type; it might suffice just to compare DataScalar to Orientation, and eliminate this method for that case.)
       // TODO: check for invalidly shaped containers.
@@ -1732,14 +1733,16 @@ namespace Intrepid2 {
 #endif
       
       // shallow copy of this to avoid implicit references to this in call to getWritableEntry() below
-      Data<DataScalar,ExecSpaceType> thisData = *this;
+      Data<DataScalar,DeviceType> thisData = *this;
+      
+      using ExecutionSpace = typename DeviceType::execution_space;
       
       const int diagonalStart = (variationType_[D1_DIM] == BLOCK_PLUS_DIAGONAL) ? blockPlusDiagonalLastNonDiagonal_ + 1 : leftRows;
       // note the use of getDataExtent() below: we only range over the possibly-distinct entries
       if (rank_ == 3)
       {
         // (C,D,D), say
-        auto policy = Kokkos::RangePolicy<ExecSpaceType>(0,getDataExtent(0));
+        auto policy = Kokkos::RangePolicy<ExecutionSpace>(0,getDataExtent(0));
         Kokkos::parallel_for("compute mat-mat", policy,
         KOKKOS_LAMBDA (const int &matrixOrdinal) {
           for (int i=0; i<diagonalStart; i++)
@@ -1768,7 +1771,7 @@ namespace Intrepid2 {
       else if (rank_ == 4)
       {
         // (C,P,D,D), perhaps
-        auto policy = Kokkos::MDRangePolicy<ExecSpaceType, Kokkos::Rank<2> >({0,0},{getDataExtent(0),getDataExtent(1)});
+        auto policy = Kokkos::MDRangePolicy<ExecutionSpace, Kokkos::Rank<2> >({0,0},{getDataExtent(0),getDataExtent(1)});
         if (underlyingMatchesNotional_) // receiving data object is completely expanded
         {
           Kokkos::parallel_for("compute mat-mat", policy,

--- a/packages/intrepid2/src/Shared/Intrepid2_TensorData.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_TensorData.hpp
@@ -60,10 +60,10 @@ namespace Intrepid2
   /** \class Intrepid2::TensorData
       \brief View-like interface to tensor data; tensor components are stored separately and multiplied together at access time.
   */
-  template<class Scalar, typename ExecSpaceType = Kokkos::DefaultExecutionSpace>
+  template<class Scalar, typename DeviceType = Kokkos::DefaultExecutionSpace>
   class TensorData {
   protected:
-    Kokkos::Array< Data<Scalar,ExecSpaceType>, Parameters::MaxTensorComponents> tensorComponents_;
+    Kokkos::Array< Data<Scalar,DeviceType>, Parameters::MaxTensorComponents> tensorComponents_;
     Kokkos::Array<ordinal_type, 7> extents_;
     Kokkos::Array<Kokkos::Array<ordinal_type, Parameters::MaxTensorComponents>, 7> entryModulus_;
     ordinal_type rank_;
@@ -122,7 +122,7 @@ namespace Intrepid2
     When <var>separateFirstComponent</var> is true, all components are required to have rank 1, and TensorData has rank 2, with the first argument reserved for the first component.  The second argument is indexed precisely as described above, omitting the first component.
     */
     template<size_t numTensorComponents>
-    TensorData(Kokkos::Array< Data<Scalar,ExecSpaceType>, numTensorComponents> tensorComponents, bool separateFirstComponent = false)
+    TensorData(Kokkos::Array< Data<Scalar,DeviceType>, numTensorComponents> tensorComponents, bool separateFirstComponent = false)
     :
     separateFirstComponent_(separateFirstComponent),
     numTensorComponents_(numTensorComponents)
@@ -144,7 +144,7 @@ namespace Intrepid2
      
     When <var>separateFirstComponent</var> is true, all components are required to have rank 1, and TensorData has rank 2, with the first argument reserved for the first component.  The second argument is indexed precisely as described above, omitting the first component.
     */
-    TensorData(std::vector< Data<Scalar,ExecSpaceType> > tensorComponents, bool separateFirstComponent = false)
+    TensorData(std::vector< Data<Scalar,DeviceType> > tensorComponents, bool separateFirstComponent = false)
     :
     separateFirstComponent_(separateFirstComponent),
     numTensorComponents_(tensorComponents.size())
@@ -163,9 +163,9 @@ namespace Intrepid2
      
       Simple constructor for trivial tensor-product structure.  The TensorData object will have precisely the same nominal data layout as the provided <var>tensorComponent</var>.
     */
-    TensorData(Data<Scalar,ExecSpaceType> tensorComponent)
+    TensorData(Data<Scalar,DeviceType> tensorComponent)
     :
-    TensorData(Kokkos::Array< Data<Scalar,ExecSpaceType>, 1>({tensorComponent}), false)
+    TensorData(Kokkos::Array< Data<Scalar,DeviceType>, 1>({tensorComponent}), false)
     {}
     
     /**
@@ -182,16 +182,16 @@ namespace Intrepid2
     /**
      \brief Copy-like constructor for differing execution spaces.  This performs a deep copy of the underlying data.
     */
-    template<typename OtherExecSpaceType, class = typename std::enable_if<!std::is_same<ExecSpaceType, OtherExecSpaceType>::value>::type>
-    TensorData(const TensorData<Scalar,OtherExecSpaceType> &tensorData)
+    template<typename OtherDeviceType, class = typename std::enable_if<!std::is_same<typename DeviceType::memory_space, typename OtherDeviceType::memory_space>::value>::type>
+    TensorData(const TensorData<Scalar,OtherDeviceType> &tensorData)
     {
       if (tensorData.isValid())
       {
         numTensorComponents_ = tensorData.numTensorComponents();
         for (ordinal_type r=0; r<numTensorComponents_; r++)
         {
-          Data<Scalar,OtherExecSpaceType> otherTensorComponent = tensorData.getTensorComponent(r);
-          tensorComponents_[r] = Data<Scalar,ExecSpaceType>(otherTensorComponent);
+          Data<Scalar,OtherDeviceType> otherTensorComponent = tensorData.getTensorComponent(r);
+          tensorComponents_[r] = Data<Scalar,DeviceType>(otherTensorComponent);
         }
         initialize();
       }
@@ -208,7 +208,7 @@ namespace Intrepid2
      \return the requested tensor component.
     */
     KOKKOS_INLINE_FUNCTION
-    const Data<Scalar,ExecSpaceType> & getTensorComponent(const ordinal_type &r) const
+    const Data<Scalar,DeviceType> & getTensorComponent(const ordinal_type &r) const
     {
       return tensorComponents_[r];
     }

--- a/packages/intrepid2/src/Shared/Intrepid2_TensorData.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_TensorData.hpp
@@ -179,6 +179,28 @@ namespace Intrepid2
     rank_(0)
     {}
     
+    //! copy-like constructor for differing device type, but same memory space.  This does a shallow copy of the underlying view.
+    template<typename OtherDeviceType, class = typename std::enable_if< std::is_same<typename DeviceType::memory_space, typename OtherDeviceType::memory_space>::value>::type,
+                                       class = typename std::enable_if<!std::is_same<DeviceType,OtherDeviceType>::value>::type>
+    TensorData(const TensorData<Scalar,OtherDeviceType> &tensorData)
+    {
+      if (tensorData.isValid())
+      {
+        numTensorComponents_ = tensorData.numTensorComponents();
+        for (ordinal_type r=0; r<numTensorComponents_; r++)
+        {
+          Data<Scalar,OtherDeviceType> otherTensorComponent = tensorData.getTensorComponent(r);
+          tensorComponents_[r] = Data<Scalar,DeviceType>(otherTensorComponent);
+        }
+        initialize();
+      }
+      else
+      {
+        extents_ = Kokkos::Array<ordinal_type,7>{0,0,0,0,0,0,0};
+        rank_    = 0;
+      }
+    }
+    
     /**
      \brief Copy-like constructor for differing execution spaces.  This performs a deep copy of the underlying data.
     */

--- a/packages/intrepid2/src/Shared/Intrepid2_TensorPoints.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_TensorPoints.hpp
@@ -179,7 +179,25 @@ namespace Intrepid2 {
       });
     }
     
-    //! copy-like constructor for differing execution spaces.  This does a deep_copy of the underlying view.
+    //! copy-like constructor for differing device type, but same memory space.  This does a shallow copy of the underlying view.
+    template<typename OtherDeviceType, class = typename std::enable_if< std::is_same<typename DeviceType::memory_space, typename OtherDeviceType::memory_space>::value>::type,
+                                       class = typename std::enable_if<!std::is_same<DeviceType,OtherDeviceType>::value>::type>
+    TensorPoints(const TensorPoints<PointScalar,OtherDeviceType> &tensorPoints)
+    :
+    numTensorComponents_(tensorPoints.numTensorComponents()),
+    isValid_(tensorPoints.isValid())
+    {
+      if (isValid_)
+      {
+        for (ordinal_type r=0; r<numTensorComponents_; r++)
+        {
+          pointTensorComponents_[r] = tensorPoints.getTensorComponent(r);
+        }
+        initialize();
+      }
+    }
+    
+    //! copy-like constructor for differing memory spaces.  This does a deep_copy of the underlying view.
     template<typename OtherDeviceType, class = typename std::enable_if<!std::is_same<typename DeviceType::memory_space, typename OtherDeviceType::memory_space>::value>::type>
     TensorPoints(const TensorPoints<PointScalar,OtherDeviceType> &tensorPoints)
     :

--- a/packages/intrepid2/src/Shared/Intrepid2_TensorPoints.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_TensorPoints.hpp
@@ -56,10 +56,10 @@ namespace Intrepid2 {
 /** \class Intrepid2::TensorPoints
     \brief View-like interface to tensor points; point components are stored separately; the appropriate coordinate is determined from the composite point index and requested dimension at access time.
 */
-  template<class PointScalar, typename ExecSpaceType = Kokkos::DefaultExecutionSpace>
+  template<class PointScalar, typename DeviceType = Kokkos::DefaultExecutionSpace>
   class TensorPoints {
   protected:
-    Kokkos::Array< ScalarView<PointScalar,ExecSpaceType>, Parameters::MaxTensorComponents> pointTensorComponents_; // each component has dimensions (P,D)
+    Kokkos::Array< ScalarView<PointScalar,DeviceType>, Parameters::MaxTensorComponents> pointTensorComponents_; // each component has dimensions (P,D)
     ordinal_type numTensorComponents_;
     ordinal_type totalPointCount_;
     ordinal_type totalDimension_;
@@ -69,7 +69,7 @@ namespace Intrepid2 {
     Kokkos::Array<ordinal_type, Parameters::MaxTensorComponents> pointDivisor_;
     
     bool isValid_;
-    using reference_type = typename ScalarView<PointScalar,ExecSpaceType>::reference_type;
+    using reference_type = typename ScalarView<PointScalar,DeviceType>::reference_type;
     
     /**
      \brief Initialize members based on constructor parameters.
@@ -114,7 +114,7 @@ namespace Intrepid2 {
      TensorPoints has shape (P,D), where P is the product of the first dimensions of the component points, and D is the sum of the second dimensions.
     */
     template<size_t numTensorComponents>
-    TensorPoints(Kokkos::Array< ScalarView<PointScalar,ExecSpaceType>, numTensorComponents> pointTensorComponents)
+    TensorPoints(Kokkos::Array< ScalarView<PointScalar,DeviceType>, numTensorComponents> pointTensorComponents)
     :
     numTensorComponents_(numTensorComponents),
     isValid_(true)
@@ -133,7 +133,7 @@ namespace Intrepid2 {
      
      TensorPoints has shape (P,D), where P is the product of the first dimensions of the component points, and D is the sum of the second dimensions.
     */
-    TensorPoints(std::vector< ScalarView<PointScalar,ExecSpaceType>> pointTensorComponents)
+    TensorPoints(std::vector< ScalarView<PointScalar,DeviceType>> pointTensorComponents)
     :
     numTensorComponents_(pointTensorComponents.size()),
     isValid_(true)
@@ -152,7 +152,7 @@ namespace Intrepid2 {
      
      TensorPoints has the same shape (P,D) as the input points.
     */
-    TensorPoints(ScalarView<PointScalar,ExecSpaceType> points)
+    TensorPoints(ScalarView<PointScalar,DeviceType> points)
     :
     numTensorComponents_(1),
     isValid_(true)
@@ -167,11 +167,12 @@ namespace Intrepid2 {
      \param [in] fromPoints - the container to copy from.
     */
     template<class OtherPointsContainer>
-    void copyPointsContainer(ScalarView<PointScalar,ExecSpaceType> toPoints, OtherPointsContainer fromPoints)
+    void copyPointsContainer(ScalarView<PointScalar,DeviceType> toPoints, OtherPointsContainer fromPoints)
     {
       const int numPoints = fromPoints.extent_int(0);
       const int numDims   = fromPoints.extent_int(1);
-      auto policy = Kokkos::MDRangePolicy<ExecSpaceType,Kokkos::Rank<2>>({0,0},{numPoints,numDims});
+      using ExecutionSpace = typename DeviceType::execution_space;
+      auto policy = Kokkos::MDRangePolicy<ExecutionSpace,Kokkos::Rank<2>>({0,0},{numPoints,numDims});
       Kokkos::parallel_for("copy points", policy,
       KOKKOS_LAMBDA (const int &i0, const int &i1) {
         toPoints(i0,i1) = fromPoints(i0,i1);
@@ -179,8 +180,8 @@ namespace Intrepid2 {
     }
     
     //! copy-like constructor for differing execution spaces.  This does a deep_copy of the underlying view.
-    template<typename OtherExecSpaceType, class = typename std::enable_if<!std::is_same<ExecSpaceType, OtherExecSpaceType>::value>::type>
-    TensorPoints(const TensorPoints<PointScalar,OtherExecSpaceType> &tensorPoints)
+    template<typename OtherDeviceType, class = typename std::enable_if<!std::is_same<typename DeviceType::memory_space, typename OtherDeviceType::memory_space>::value>::type>
+    TensorPoints(const TensorPoints<PointScalar,OtherDeviceType> &tensorPoints)
     :
     numTensorComponents_(tensorPoints.numTensorComponents()),
     isValid_(tensorPoints.isValid())
@@ -189,12 +190,12 @@ namespace Intrepid2 {
       {
         for (ordinal_type r=0; r<numTensorComponents_; r++)
         {
-          ScalarView<PointScalar,OtherExecSpaceType> otherPointComponent = tensorPoints.getTensorComponent(r);
+          ScalarView<PointScalar,OtherDeviceType> otherPointComponent = tensorPoints.getTensorComponent(r);
           const int numPoints = otherPointComponent.extent_int(0);
           const int numDims   = otherPointComponent.extent_int(1);
-          pointTensorComponents_[r] = ScalarView<PointScalar,ExecSpaceType>("Intrepid2 point component", numPoints, numDims);
+          pointTensorComponents_[r] = ScalarView<PointScalar,DeviceType>("Intrepid2 point component", numPoints, numDims);
           
-          using MemorySpace = typename ExecSpaceType::memory_space;
+          using MemorySpace = typename DeviceType::memory_space;
           auto pointComponentMirror = Kokkos::create_mirror_view_and_copy(MemorySpace(), otherPointComponent);
           
           copyPointsContainer(pointTensorComponents_[r], pointComponentMirror);
@@ -294,14 +295,15 @@ namespace Intrepid2 {
     }
     
     //! This method is for compatibility with existing methods that take raw point views.  Note that in general it is probably better for performance to make the existing methods accept a TensorPoints object, since that can dramatically reduce memory footprint, and avoids an allocation here.
-    ScalarView<PointScalar,ExecSpaceType> allocateAndFillExpandedRawPointView() const
+    ScalarView<PointScalar,DeviceType> allocateAndFillExpandedRawPointView() const
     {
       const int numPoints = this->extent_int(0);
       const int spaceDim  = this->extent_int(1);
-      ScalarView<PointScalar,ExecSpaceType> expandedRawPoints("expanded raw points from TensorPoints", numPoints, spaceDim);
-      TensorPoints<PointScalar,ExecSpaceType> tensorPoints(*this); // (shallow) copy for lambda capture
+      ScalarView<PointScalar,DeviceType> expandedRawPoints("expanded raw points from TensorPoints", numPoints, spaceDim);
+      TensorPoints<PointScalar,DeviceType> tensorPoints(*this); // (shallow) copy for lambda capture
+      using ExecutionSpace = typename DeviceType::execution_space;
       Kokkos::parallel_for(
-        Kokkos::MDRangePolicy<ExecSpaceType,Kokkos::Rank<2>>({0,0},{numPoints,spaceDim}),
+        Kokkos::MDRangePolicy<ExecutionSpace,Kokkos::Rank<2>>({0,0},{numPoints,spaceDim}),
         KOKKOS_LAMBDA (const int &pointOrdinal, const int &d) {
           expandedRawPoints(pointOrdinal,d) = tensorPoints(pointOrdinal,d);
       });
@@ -314,7 +316,7 @@ namespace Intrepid2 {
      \return the requested tensor component.
     */
     KOKKOS_INLINE_FUNCTION
-    ScalarView<PointScalar,ExecSpaceType> getTensorComponent(const ordinal_type &r) const
+    ScalarView<PointScalar,DeviceType> getTensorComponent(const ordinal_type &r) const
     {
       return pointTensorComponents_[r];
     }
@@ -343,7 +345,7 @@ namespace Intrepid2 {
     // NOTE: the extractTensorPoints() code commented out below appears not to work.  We don't have tests against it, though.
     // TODO: either delete this, or re-enable, add tests, and fix.
 //    template<class ViewType>
-//    static TensorPoints<PointScalar,ExecSpaceType> extractTensorPoints( ViewType expandedPoints, const std::vector<ordinal_type> &dimensionExtents )
+//    static TensorPoints<PointScalar,DeviceType> extractTensorPoints( ViewType expandedPoints, const std::vector<ordinal_type> &dimensionExtents )
 //    {
 //      const ordinal_type numComponents = dimensionExtents.size();
 //      const ordinal_type numPoints     = expandedPoints.extent_int(0);
@@ -357,7 +359,7 @@ namespace Intrepid2 {
 //      ordinal_type dimOffset = 0;
 //      ordinal_type tensorPointStride = 1; // increases with componentOrdinal
 //
-//      TensorPoints<PointScalar,ExecSpaceType> invalidTensorData; // will be returned if extraction does not succeed.
+//      TensorPoints<PointScalar,DeviceType> invalidTensorData; // will be returned if extraction does not succeed.
 //
 //      for (ordinal_type componentOrdinal=0; componentOrdinal<numComponents; componentOrdinal++)
 //      {
@@ -419,13 +421,13 @@ namespace Intrepid2 {
 //        tensorPointStride *= componentPointCounts[componentOrdinal];
 //      }
 //
-//      std::vector< ScalarView<PointScalar,ExecSpaceType> > componentPoints(numComponents);
+//      std::vector< ScalarView<PointScalar,DeviceType> > componentPoints(numComponents);
 //      std::vector< ScalarView<PointScalar,Kokkos::HostSpace> > componentPointsHost(numComponents);
 //      for (ordinal_type componentOrdinal=0; componentOrdinal<numComponents; componentOrdinal++)
 //      {
 //        const ordinal_type numPointsForComponent = componentPointCounts[componentOrdinal];
 //        const ordinal_type dimForComponent       = dimensionExtents[componentOrdinal];
-//        componentPoints[componentOrdinal] = ScalarView<PointScalar,ExecSpaceType>("extracted tensor components", numPointsForComponent, dimForComponent);
+//        componentPoints[componentOrdinal] = ScalarView<PointScalar,DeviceType>("extracted tensor components", numPointsForComponent, dimForComponent);
 //        componentPointsHost[componentOrdinal] = Kokkos::create_mirror(componentPoints[componentOrdinal]);
 //      }
 //
@@ -471,7 +473,7 @@ namespace Intrepid2 {
 //        return invalidTensorData;
 //      }
 //
-//      return TensorPoints<PointScalar,ExecSpaceType>(componentPoints);
+//      return TensorPoints<PointScalar,DeviceType>(componentPoints);
 //    }
   };
 

--- a/packages/intrepid2/src/Shared/Intrepid2_TestUtils.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_TestUtils.hpp
@@ -115,6 +115,12 @@ namespace Intrepid2
   using FixedRankViewType = Kokkos::View<ScalarType,Kokkos::DefaultExecutionSpace>; // TODO: change to DefaultTestDeviceType, once all Monolithic tests have been changed
 
   template<typename ScalarType>
+  using ViewTypeDefaultTestDT = Kokkos::DynRankView<ScalarType,DefaultTestDeviceType>; // this one is to allow us to switch tests over incrementally; should collapse with ViewType once everything has been switched
+
+  template<typename ScalarType>
+  using FixedRankViewTypeDefaultTestDT = Kokkos::View<ScalarType,DefaultTestDeviceType>; // this one is to allow us to switch tests over incrementally; should collapse with FixedRankViewType once everything has been switched
+
+  template<typename ScalarType>
   KOKKOS_INLINE_FUNCTION bool valuesAreSmall(const ScalarType &a, const ScalarType &b, const double &epsilon)
   {
     using std::abs;
@@ -248,6 +254,37 @@ namespace Intrepid2
     else
     {
       return FixedRankViewType<value_type>(label,dims...,MAX_FAD_DERIVATIVES_FOR_TESTS+1);
+    }
+  }
+
+  // this method is to allow us to switch tests over incrementally; should collapse with getView once everything has been switched
+  template<typename ValueType, class ... DimArgs>
+  inline ViewTypeDefaultTestDT<ValueType> getViewDefaultTestDT(const std::string &label, DimArgs... dims)
+  {
+    const bool allocateFadStorage = !std::is_pod<ValueType>::value;
+    if (!allocateFadStorage)
+    {
+      return ViewTypeDefaultTestDT<ValueType>(label,dims...);
+    }
+    else
+    {
+      return ViewTypeDefaultTestDT<ValueType>(label,dims...,MAX_FAD_DERIVATIVES_FOR_TESTS+1);
+    }
+  }
+
+  // this method is to allow us to switch tests over incrementally; should collapse with ViewType once everything has been switched
+  template<typename ValueType, class ... DimArgs>
+  inline FixedRankViewTypeDefaultTestDT< typename RankExpander<ValueType, sizeof...(DimArgs) >::value_type > getFixedRankViewDefaultTestDT(const std::string &label, DimArgs... dims)
+  {
+    const bool allocateFadStorage = !std::is_pod<ValueType>::value;
+    using value_type = typename RankExpander<ValueType, sizeof...(dims) >::value_type;
+    if (!allocateFadStorage)
+    {
+      return FixedRankViewTypeDefaultTestDT<value_type>(label,dims...);
+    }
+    else
+    {
+      return FixedRankViewTypeDefaultTestDT<value_type>(label,dims...,MAX_FAD_DERIVATIVES_FOR_TESTS+1);
     }
   }
 

--- a/packages/intrepid2/src/Shared/Intrepid2_TestUtils.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_TestUtils.hpp
@@ -109,10 +109,10 @@ namespace Intrepid2
 
   // we use DynRankView for both input points and values
   template<typename ScalarType>
-  using ViewType = Kokkos::DynRankView<ScalarType,Kokkos::DefaultExecutionSpace>;
+  using ViewType = Kokkos::DynRankView<ScalarType,Kokkos::DefaultExecutionSpace>; // TODO: change to DefaultTestDeviceType, once all Monolithic tests have been changed
 
   template<typename ScalarType>
-  using FixedRankViewType = Kokkos::View<ScalarType,Kokkos::DefaultExecutionSpace>;
+  using FixedRankViewType = Kokkos::View<ScalarType,Kokkos::DefaultExecutionSpace>; // TODO: change to DefaultTestDeviceType, once all Monolithic tests have been changed
 
   template<typename ScalarType>
   KOKKOS_INLINE_FUNCTION bool valuesAreSmall(const ScalarType &a, const ScalarType &b, const double &epsilon)
@@ -166,8 +166,8 @@ namespace Intrepid2
   }
 
   template<class BasisFamily>
-  inline Teuchos::RCP< Intrepid2::Basis<Kokkos::DefaultExecutionSpace,double,double> > getBasisUsingFamily(shards::CellTopology cellTopo, Intrepid2::EFunctionSpace fs,
-                                                                                                           int polyOrder_x, int polyOrder_y=-1, int polyOrder_z = -1)
+  inline Teuchos::RCP< Intrepid2::Basis<DefaultTestDeviceType,double,double> > getBasisUsingFamily(shards::CellTopology cellTopo, Intrepid2::EFunctionSpace fs,
+                                                                                                   int polyOrder_x, int polyOrder_y=-1, int polyOrder_z = -1)
   {
     using BasisPtr = typename BasisFamily::BasisPtr;
     
@@ -205,17 +205,17 @@ namespace Intrepid2
   }
 
   template<bool defineVertexFunctions>
-  inline Teuchos::RCP< Intrepid2::Basis<Kokkos::DefaultExecutionSpace,double,double> > getHierarchicalBasis(shards::CellTopology cellTopo, Intrepid2::EFunctionSpace fs,
-                                                                                                            int polyOrder_x, int polyOrder_y=-1, int polyOrder_z = -1)
+  inline Teuchos::RCP< Intrepid2::Basis<DefaultTestDeviceType,double,double> > getHierarchicalBasis(shards::CellTopology cellTopo, Intrepid2::EFunctionSpace fs,
+                                                                                                    int polyOrder_x, int polyOrder_y=-1, int polyOrder_z = -1)
   {
-    using ExecSpace = Kokkos::DefaultExecutionSpace;
+    using DeviceType = DefaultTestDeviceType;
     using Scalar = double;
     using namespace Intrepid2;
     
-    using LineBasisGrad = Intrepid2::IntegratedLegendreBasis_HGRAD_LINE<ExecSpace, Scalar, Scalar, defineVertexFunctions, true>;
-    using LineBasisVol  = Intrepid2::LegendreBasis_HVOL_LINE< ExecSpace, Scalar, Scalar>;
-    using TriangleBasisFamily = Intrepid2::HierarchicalTriangleBasisFamily<ExecSpace, Scalar, Scalar, defineVertexFunctions>;
-    using TetrahedronBasisFamily = Intrepid2::HierarchicalTetrahedronBasisFamily<ExecSpace, Scalar, Scalar, defineVertexFunctions>;
+    using LineBasisGrad = Intrepid2::IntegratedLegendreBasis_HGRAD_LINE<DeviceType, Scalar, Scalar, defineVertexFunctions, true>;
+    using LineBasisVol  = Intrepid2::LegendreBasis_HVOL_LINE< DeviceType, Scalar, Scalar>;
+    using TriangleBasisFamily = Intrepid2::HierarchicalTriangleBasisFamily<DeviceType, Scalar, Scalar, defineVertexFunctions>;
+    using TetrahedronBasisFamily = Intrepid2::HierarchicalTetrahedronBasisFamily<DeviceType, Scalar, Scalar, defineVertexFunctions>;
     
     using BasisFamily = DerivedBasisFamily<LineBasisGrad, LineBasisVol, TriangleBasisFamily, TetrahedronBasisFamily>;
     

--- a/packages/intrepid2/src/Shared/Intrepid2_TestUtils.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_TestUtils.hpp
@@ -107,6 +107,9 @@ namespace Intrepid2
 
   static const double TEST_TOLERANCE_TIGHT = 1.e2 * std::numeric_limits<double>::epsilon();
 
+  template<typename ScalarType, typename DeviceType>
+  using ViewType2T = Kokkos::DynRankView<ScalarType,DeviceType>; // 2-template-argument ViewType; see getView2T().  Probably should consider this a placeholder; eventually, should collapse ViewType2T and ViewType (by requiring all ViewType instantiations to have two argumetns)
+
   // we use DynRankView for both input points and values
   template<typename ScalarType>
   using ViewType = Kokkos::DynRankView<ScalarType,Kokkos::DefaultExecutionSpace>; // TODO: change to DefaultTestDeviceType, once all Monolithic tests have been changed
@@ -239,6 +242,20 @@ namespace Intrepid2
     else
     {
       return ViewType<ValueType>(label,dims...,MAX_FAD_DERIVATIVES_FOR_TESTS+1);
+    }
+  }
+
+  template<typename ValueType, typename DeviceType, class ... DimArgs>
+  inline ViewType2T<ValueType,DeviceType> getView2T(const std::string &label, DimArgs... dims)
+  {
+    const bool allocateFadStorage = !std::is_pod<ValueType>::value;
+    if (!allocateFadStorage)
+    {
+      return ViewType2T<ValueType,DeviceType>(label,dims...);
+    }
+    else
+    {
+      return ViewType2T<ValueType,DeviceType>(label,dims...,MAX_FAD_DERIVATIVES_FOR_TESTS+1);
     }
   }
 

--- a/packages/intrepid2/src/Shared/Intrepid2_TransformedVectorData.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_TransformedVectorData.hpp
@@ -60,22 +60,22 @@ namespace Intrepid2 {
  
  TransformedVectorData provides a View-like interface of rank 4, with shape (C,F,P,D).  When the corresponding accessor is used, the transformed value is determined from corresponding reference space values and the transformation.
 */
-  template<class Scalar, typename ExecSpaceType = Kokkos::DefaultExecutionSpace>
+  template<class Scalar, typename DeviceType = Kokkos::DefaultExecutionSpace>
   class TransformedVectorData
   {
   public:
-    using Transform = Data<Scalar,ExecSpaceType>;
+    using Transform = Data<Scalar,DeviceType>;
     
-    Data<Scalar,ExecSpaceType> transform_; // (C,P,D,D) jacobian or jacobian inverse; can also be unset for identity transform
+    Data<Scalar,DeviceType> transform_; // (C,P,D,D) jacobian or jacobian inverse; can also be unset for identity transform
     
-    VectorData<Scalar, ExecSpaceType> vectorData_; // notionally (F,P,D) container
+    VectorData<Scalar, DeviceType> vectorData_; // notionally (F,P,D) container
     
     /**
      \brief Standard constructor.
      \param [in] transform - the transformation matrix, with nominal shape (C,P,D,D)
      \param [in] vectorData - the reference-space data to be transformed, with nominal shape (F,P,D)
     */
-    TransformedVectorData(const Data<Scalar,ExecSpaceType> &transform, const VectorData<Scalar,ExecSpaceType> &vectorData)
+    TransformedVectorData(const Data<Scalar,DeviceType> &transform, const VectorData<Scalar,DeviceType> &vectorData)
     :
     transform_(transform), vectorData_(vectorData)
     {
@@ -87,14 +87,14 @@ namespace Intrepid2 {
      \brief Constructor for the case of an identity transform.
      \param [in] vectorData - the reference-space data, with nominal shape (F,P,D)
     */
-    TransformedVectorData(const VectorData<Scalar, ExecSpaceType> &vectorData)
+    TransformedVectorData(const VectorData<Scalar, DeviceType> &vectorData)
     :
     vectorData_(vectorData)
     {}
     
-    //! copy-like constructor for differing execution spaces.  This does a deep_copy of underlying views.
-    template<typename OtherExecSpaceType, class = typename std::enable_if<!std::is_same<ExecSpaceType, OtherExecSpaceType>::value>::type>
-    TransformedVectorData(const TransformedVectorData<Scalar,OtherExecSpaceType> &transformedVectorData)
+    //! copy-like constructor for differing device types.  This may do a deep_copy of underlying views, depending on the memory spaces involved.
+    template<typename OtherDeviceType, class = typename std::enable_if<!std::is_same<DeviceType, OtherDeviceType>::value>::type>
+    TransformedVectorData(const TransformedVectorData<Scalar,OtherDeviceType> &transformedVectorData)
     :
     transform_(transformedVectorData.transform()),
     vectorData_(transformedVectorData.vectorData())
@@ -188,13 +188,13 @@ namespace Intrepid2 {
     }
     
     //! Returns the transform matrix.  An invalid/empty container indicates the identity transform.
-    const Data<Scalar,ExecSpaceType> & transform() const
+    const Data<Scalar,DeviceType> & transform() const
     {
       return transform_;
     }
     
     //! Returns the reference-space vector data.
-    const VectorData<Scalar,ExecSpaceType> & vectorData() const
+    const VectorData<Scalar,DeviceType> & vectorData() const
     {
       return vectorData_;
     }

--- a/packages/intrepid2/src/Shared/Intrepid2_VectorData.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_VectorData.hpp
@@ -61,11 +61,11 @@ namespace Intrepid2 {
  
  Typically, HDIV and HCURL bases have multiple families corresponding to the nonzero structure of the vector components.  VectorData therefore supports multiple families.  (Gradients of H^1 are expressed as a single family.)
 */
-  template<class Scalar, typename ExecSpaceType = Kokkos::DefaultExecutionSpace>
+  template<class Scalar, typename DeviceType = Kokkos::DefaultExecutionSpace>
   class VectorData
   {
   public:
-    using VectorArray = Kokkos::Array< TensorData<Scalar,ExecSpaceType>, Parameters::MaxTensorComponents>; // for axis-aligned case, these correspond entry-wise to the axis with which the vector values align
+    using VectorArray = Kokkos::Array< TensorData<Scalar,DeviceType>, Parameters::MaxTensorComponents>; // for axis-aligned case, these correspond entry-wise to the axis with which the vector values align
     using FamilyVectorArray = Kokkos::Array< VectorArray, Parameters::MaxTensorComponents>;
 
     FamilyVectorArray vectorComponents_; // outer: family ordinal; inner: component/spatial dimension ordinal
@@ -176,7 +176,7 @@ namespace Intrepid2 {
      Outer dimension: number of families; inner dimension: number of components in each vector.  Use empty/invalid TensorData objects to indicate zeroes.  Each family, and each vector component dimension, must have at least one valid entry, and the number of points in each valid entry must agree with each other.  The field count within components of a family must also agree; across families these may differ.  Vector components are allowed to span multiple spatial dimensions, but when they do, any valid TensorData object in that vector position must agree in the dimension across families.
     */
     template<size_t numFamilies, size_t numComponents>
-    VectorData(Kokkos::Array< Kokkos::Array<TensorData<Scalar,ExecSpaceType>, numComponents>, numFamilies> vectorComponents)
+    VectorData(Kokkos::Array< Kokkos::Array<TensorData<Scalar,DeviceType>, numComponents>, numFamilies> vectorComponents)
     :
     numFamilies_(numFamilies),
     numComponents_(numComponents)
@@ -199,7 +199,7 @@ namespace Intrepid2 {
      
      Outer dimension: number of families; inner dimension: number of components in each vector.  Use empty/invalid TensorData objects to indicate zeroes.  Each family, and each vector component dimension, must have at least one valid entry, and the number of points in each valid entry must agree with each other.  The field count within components of a family must also agree; across families these may differ.  Vector components are allowed to span multiple spatial dimensions, but when they do, any valid TensorData object in that vector position must agree in the dimension across families.
     */
-    VectorData(const std::vector< std::vector<TensorData<Scalar,ExecSpaceType> > > &vectorComponents)
+    VectorData(const std::vector< std::vector<TensorData<Scalar,DeviceType> > > &vectorComponents)
     {
       numFamilies_ = vectorComponents.size();
       INTREPID2_TEST_FOR_EXCEPTION(numFamilies_ <= 0, std::invalid_argument, "numFamilies must be at least 1");
@@ -229,7 +229,7 @@ namespace Intrepid2 {
      For the gradient use case, VectorData will have a single family.  For the HDIV and HCURL use cases, will have the same number of families as there are components in the vectorComponents argument; each family will consist of vectors that have one entry filled, the others zeroes; this is what we mean by "axial components."
     */
     template<size_t numComponents>
-    VectorData(Kokkos::Array< TensorData<Scalar,ExecSpaceType>, numComponents> vectorComponents, bool axialComponents)
+    VectorData(Kokkos::Array< TensorData<Scalar,DeviceType>, numComponents> vectorComponents, bool axialComponents)
     {
       if (axialComponents)
       {
@@ -259,7 +259,7 @@ namespace Intrepid2 {
      
      For the gradient use case, VectorData will have a single family.  For the HDIV and HCURL use cases, will have the same number of families as there are components in the vectorComponents argument; each family will consist of vectors that have one entry filled, the others zeroes; this is what we mean by "axial components."
     */
-    VectorData(std::vector< TensorData<Scalar,ExecSpaceType> > vectorComponents, bool axialComponents)
+    VectorData(std::vector< TensorData<Scalar,DeviceType> > vectorComponents, bool axialComponents)
     : numComponents_(vectorComponents.size())
     {
       if (axialComponents)
@@ -282,8 +282,8 @@ namespace Intrepid2 {
     }
     
     //! copy-like constructor for differing execution spaces.  This does a deep copy of underlying views.
-    template<typename OtherExecSpaceType, class = typename std::enable_if<!std::is_same<ExecSpaceType, OtherExecSpaceType>::value>::type>
-    VectorData(const VectorData<Scalar,OtherExecSpaceType> &vectorData)
+    template<typename OtherDeviceType, class = typename std::enable_if<!std::is_same<typename DeviceType::memory_space, typename OtherDeviceType::memory_space>::value>::type>
+    VectorData(const VectorData<Scalar,OtherDeviceType> &vectorData)
     :
     numFamilies_(vectorData.numFamilies()),
     numComponents_(vectorData.numComponents())
@@ -302,15 +302,15 @@ namespace Intrepid2 {
     }
     
     //! Simple 1-argument constructor for the case of trivial tensor product structure.  The argument should have shape (F,P,D) where D has extent equal to the spatial dimension.
-    VectorData(TensorData<Scalar,ExecSpaceType> data)
+    VectorData(TensorData<Scalar,DeviceType> data)
     :
-    VectorData(Kokkos::Array< TensorData<Scalar,ExecSpaceType>, 1>(data), true)
+    VectorData(Kokkos::Array< TensorData<Scalar,DeviceType>, 1>(data), true)
     {}
     
     //! Simple 1-argument constructor for the case of trivial tensor product structure.  The argument should have shape (F,P,D) where D has extent equal to the spatial dimension.
-    VectorData(Data<Scalar,ExecSpaceType> data)
+    VectorData(Data<Scalar,DeviceType> data)
     :
-    VectorData(Kokkos::Array< TensorData<Scalar,ExecSpaceType>, 1>({TensorData<Scalar,ExecSpaceType>(data)}), true)
+    VectorData(Kokkos::Array< TensorData<Scalar,DeviceType>, 1>({TensorData<Scalar,DeviceType>(data)}), true)
     {}
     
     //! default constructor; results in an invalid container.
@@ -418,7 +418,7 @@ namespace Intrepid2 {
      \param [in] componentOrdinal - the vector component ordinal.
     */
     KOKKOS_INLINE_FUNCTION
-    const TensorData<Scalar,ExecSpaceType> & getComponent(const int &componentOrdinal) const
+    const TensorData<Scalar,DeviceType> & getComponent(const int &componentOrdinal) const
     {
       if (axialComponents_)
       {
@@ -442,7 +442,7 @@ namespace Intrepid2 {
      \param [in] componentOrdinal - the vector component ordinal.
     */
     KOKKOS_INLINE_FUNCTION
-    const TensorData<Scalar,ExecSpaceType> & getComponent(const int &familyOrdinal, const int &componentOrdinal) const
+    const TensorData<Scalar,DeviceType> & getComponent(const int &familyOrdinal, const int &componentOrdinal) const
     {
       INTREPID2_TEST_FOR_EXCEPTION_DEVICE_SAFE(familyOrdinal < 0, std::invalid_argument, "familyOrdinal must be non-negative");
       INTREPID2_TEST_FOR_EXCEPTION_DEVICE_SAFE(static_cast<unsigned>(familyOrdinal) >= numFamilies_, std::invalid_argument, "familyOrdinal out of bounds");

--- a/packages/intrepid2/src/Shared/Intrepid2_VectorData.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_VectorData.hpp
@@ -281,6 +281,27 @@ namespace Intrepid2 {
       initialize();
     }
     
+    //! copy-like constructor for differing device type, but same memory space.  This does a shallow copy of the underlying view.
+    template<typename OtherDeviceType, class = typename std::enable_if< std::is_same<typename DeviceType::memory_space, typename OtherDeviceType::memory_space>::value>::type,
+                                       class = typename std::enable_if<!std::is_same<DeviceType,OtherDeviceType>::value>::type>
+    VectorData(const VectorData<Scalar,OtherDeviceType> &vectorData)
+    :
+    numFamilies_(vectorData.numFamilies()),
+    numComponents_(vectorData.numComponents())
+    {
+      if (vectorData.isValid())
+      {
+        for (unsigned i=0; i<numFamilies_; i++)
+        {
+          for (unsigned j=0; j<numComponents_; j++)
+          {
+            vectorComponents_[i][j] = vectorData.getComponent(i, j);
+          }
+        }
+        initialize();
+      }
+    }
+    
     //! copy-like constructor for differing execution spaces.  This does a deep copy of underlying views.
     template<typename OtherDeviceType, class = typename std::enable_if<!std::is_same<typename DeviceType::memory_space, typename OtherDeviceType::memory_space>::value>::type>
     VectorData(const VectorData<Scalar,OtherDeviceType> &vectorData)

--- a/packages/intrepid2/unit-test/MonolithicExecutable/AnalyticPolynomialsMatchTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/AnalyticPolynomialsMatchTests.cpp
@@ -788,8 +788,9 @@ namespace
                              Teuchos::FancyOStream &out, bool &success)
   {
     using namespace Intrepid2;
-    using BasisPtr = typename DerivedNodalBasisFamily::BasisPtr;
+    using BasisPtr       = typename DerivedNodalBasisFamily::BasisPtr;
     using ExecutionSpace = typename DerivedNodalBasisFamily::ExecutionSpace;
+    using DeviceType     = typename DerivedNodalBasisFamily::DeviceType;
     using Teuchos::rcp;
     
     BasisPtr derivedBasis, standardBasis;
@@ -830,7 +831,6 @@ namespace
     
     using ValueType    = typename ScalarViewType::value_type;
     using ResultLayout = typename DeduceLayout< ScalarViewType >::result_layout;
-    using DeviceType = typename ScalarViewType::device_type;
     using AllocatableScalarViewType = Kokkos::DynRankView<ValueType, ResultLayout, DeviceType >;
     
     AllocatableScalarViewType dofCoordsStandard ("dofCoordsStandard", standardCardinality, spaceDim);
@@ -872,7 +872,6 @@ namespace
     // copy dofMapToDerived to host view
 //    Kokkos::deep_copy(dofMapToStandardHost, dofMapToStandard);
     
-    using DeviceType   = typename DerivedNodalBasisFamily::DeviceType;
     using PointScalar  = typename DerivedNodalBasisFamily::PointValueType;
     using OutputScalar = typename DerivedNodalBasisFamily::OutputValueType;
     

--- a/packages/intrepid2/unit-test/MonolithicExecutable/AnalyticPolynomialsMatchTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/AnalyticPolynomialsMatchTests.cpp
@@ -231,13 +231,13 @@ namespace
     }
   }
   
-  template<typename ExecutionSpace=Kokkos::DefaultExecutionSpace,
+  template<typename DeviceType,
            typename OutputScalar = double,
            typename PointScalar  = double>
   void testHierarchicalHGRAD_LINE_MatchesAnalyticValues(Intrepid2::EOperator op, const double tol, Teuchos::FancyOStream &out, bool &success)
   {
     using namespace Intrepid2;
-    using BasisFamily = HierarchicalBasisFamily<ExecutionSpace,OutputScalar,PointScalar>;
+    using BasisFamily = HierarchicalBasisFamily<DeviceType,OutputScalar,PointScalar>;
     
     const int polyOrder = 4;
     auto hgradBasis = getLineBasis<BasisFamily>(FUNCTION_SPACE_HGRAD, polyOrder);
@@ -480,13 +480,13 @@ namespace
     }
   }
   
-  template<typename ExecutionSpace=Kokkos::DefaultExecutionSpace,
+  template<typename DeviceType,
            typename OutputScalar = double,
            typename PointScalar  = double>
   void testHierarchicalHGRAD_TRIANGLE_MatchesAnalyticValues(Intrepid2::EOperator op, const double tol, Teuchos::FancyOStream &out, bool &success)
   {
     using namespace Intrepid2;
-    using BasisFamily = HierarchicalBasisFamily<ExecutionSpace,OutputScalar,PointScalar>;
+    using BasisFamily = HierarchicalBasisFamily<DeviceType,OutputScalar,PointScalar>;
     
     const int spaceDim  = 2;
     const int polyOrder = 4;
@@ -951,25 +951,25 @@ namespace
   TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL( AnalyticPolynomialsMatch, Hierarchical_HGRAD_LINE, OutputScalar, PointScalar )
   {
     const double tol = TEST_TOLERANCE_TIGHT;
-    using ExecSpace = Kokkos::DefaultExecutionSpace;
+    using DeviceType = DefaultTestDeviceType;
     
     std::vector<Intrepid2::EOperator> operators = {{OPERATOR_VALUE, OPERATOR_GRAD, OPERATOR_D1, OPERATOR_D2, OPERATOR_D3, OPERATOR_D4, OPERATOR_D5, OPERATOR_D6, OPERATOR_D7, OPERATOR_D8, OPERATOR_D9, OPERATOR_D10}};
     for (auto op : operators)
     {
-      testHierarchicalHGRAD_LINE_MatchesAnalyticValues<ExecSpace,OutputScalar,PointScalar>(op, tol, out, success);
+      testHierarchicalHGRAD_LINE_MatchesAnalyticValues<DeviceType,OutputScalar,PointScalar>(op, tol, out, success);
     }
   }
   
   TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL( AnalyticPolynomialsMatch, Hierarchical_HGRAD_TRI, OutputScalar, PointScalar )
   {
     const double tol = TEST_TOLERANCE_TIGHT;
-    using ExecSpace = Kokkos::DefaultExecutionSpace;
+    using DeviceType = DefaultTestDeviceType;
     
 //    std::vector<Intrepid2::EOperator> operators = {{OPERATOR_VALUE, OPERATOR_GRAD, OPERATOR_D1, OPERATOR_D2, OPERATOR_D3, OPERATOR_D4, OPERATOR_D5, OPERATOR_D6, OPERATOR_D7, OPERATOR_D8, OPERATOR_D9, OPERATOR_D10}};
     std::vector<Intrepid2::EOperator> operators = {OPERATOR_VALUE};
     for (auto op : operators)
     {
-      testHierarchicalHGRAD_TRIANGLE_MatchesAnalyticValues<ExecSpace,OutputScalar,PointScalar>(op, tol, out, success);
+      testHierarchicalHGRAD_TRIANGLE_MatchesAnalyticValues<DeviceType,OutputScalar,PointScalar>(op, tol, out, success);
     }
   }
   
@@ -978,8 +978,8 @@ namespace
     const int maxPolyOrder = 10;
     const double tol = TEST_TOLERANCE_TIGHT;
     
-    using ExecSpace = Kokkos::DefaultExecutionSpace;
-    using HierarchicalBasisFamily = HierarchicalBasisFamily<ExecSpace,OutputScalar,PointScalar>;
+    using DeviceType = DefaultTestDeviceType;
+    using HierarchicalBasisFamily = HierarchicalBasisFamily<DeviceType,OutputScalar,PointScalar>;
     
     for (int derivativeOrder=1; derivativeOrder<=5; derivativeOrder++)
     {
@@ -992,9 +992,9 @@ namespace
   {
     // the following should match in H(grad) and H(vol), but are not expected to match in H(curl) and H(div)
     // (the latter differ in that Standard uses another H(grad) instance to represent the L^2 component of H(curl) and H(div), while Derived uses H(vol))
-    using ExecSpace = Kokkos::DefaultExecutionSpace;
-    using DerivedNodalBasisFamily  = Intrepid2::DerivedNodalBasisFamily<ExecSpace,OutputScalar,PointScalar>;
-    using StandardNodalBasisFamily = Intrepid2::NodalBasisFamily       <ExecSpace,OutputScalar,PointScalar>;
+    using DeviceType = DefaultTestDeviceType;
+    using DerivedNodalBasisFamily  = Intrepid2::DerivedNodalBasisFamily<DeviceType,OutputScalar,PointScalar>;
+    using StandardNodalBasisFamily = Intrepid2::NodalBasisFamily       <DeviceType,OutputScalar,PointScalar>;
     
     const double tol = TEST_TOLERANCE_TIGHT;
     

--- a/packages/intrepid2/unit-test/MonolithicExecutable/AnalyticPolynomialsMatchTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/AnalyticPolynomialsMatchTests.cpp
@@ -68,8 +68,7 @@ namespace
   {
     // ideally, we would have closed-form expressions somewhere in here, as we do for integrated Legendre below
     // for now, though, this is just a thin wrapper around the call to Intrepid2::Polynomials::integratedJacobiValues()
-    using DeviceType = DefaultTestDeviceType;
-    auto values = getView2T<Scalar,DeviceType>("integrated Jacobi values", n+1);
+    auto values = getView2T<Scalar,Kokkos::HostSpace>("integrated Jacobi values", n+1);
     Polynomials::integratedJacobiValues(values, alpha, n, x, t);
     return values(n);
   }

--- a/packages/intrepid2/unit-test/MonolithicExecutable/AnalyticPolynomialsMatchTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/AnalyticPolynomialsMatchTests.cpp
@@ -68,7 +68,8 @@ namespace
   {
     // ideally, we would have closed-form expressions somewhere in here, as we do for integrated Legendre below
     // for now, though, this is just a thin wrapper around the call to Intrepid2::Polynomials::integratedJacobiValues()
-    auto values = getView<Scalar>("integrated Jacobi values", n+1);
+    using DeviceType = DefaultTestDeviceType;
+    auto values = getView2T<Scalar,DeviceType>("integrated Jacobi values", n+1);
     Polynomials::integratedJacobiValues(values, alpha, n, x, t);
     return values(n);
   }

--- a/packages/intrepid2/unit-test/MonolithicExecutable/AnalyticPolynomialsMatchTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/AnalyticPolynomialsMatchTests.cpp
@@ -68,7 +68,7 @@ namespace
   {
     // ideally, we would have closed-form expressions somewhere in here, as we do for integrated Legendre below
     // for now, though, this is just a thin wrapper around the call to Intrepid2::Polynomials::integratedJacobiValues()
-    auto values = getView2T<Scalar,Kokkos::HostSpace>("integrated Jacobi values", n+1);
+    auto values = getView<Scalar,Kokkos::HostSpace>("integrated Jacobi values", n+1);
     Polynomials::integratedJacobiValues(values, alpha, n, x, t);
     return values(n);
   }
@@ -244,16 +244,16 @@ namespace
     
     int numPoints_1D = 5;
     shards::CellTopology lineTopo = shards::CellTopology(shards::getCellTopologyData<shards::Line<> >() );
-    auto inputPointsView = getInputPointsView<PointScalar>(lineTopo, numPoints_1D);
+    auto inputPointsView = getInputPointsView<PointScalar,DeviceType>(lineTopo, numPoints_1D);
     
-    auto hgradOutputView = getOutputView<OutputScalar>(FUNCTION_SPACE_HGRAD, op, hgradBasis->getCardinality(), numPoints_1D, 1);
+    auto hgradOutputView = getOutputView<OutputScalar,DeviceType>(FUNCTION_SPACE_HGRAD, op, hgradBasis->getCardinality(), numPoints_1D, 1);
     
     hgradBasis->getValues(hgradOutputView, inputPointsView, op);
     
     auto hgradOutputViewHost = getHostCopy(hgradOutputView);
     auto inputPointsViewHost = getHostCopy(inputPointsView);
     
-    auto expectedValuesView     = getView<OutputScalar>("expected values", hgradBasis->getCardinality());
+    auto expectedValuesView     = getView<OutputScalar,DeviceType>("expected values", hgradBasis->getCardinality());
     auto expectedValuesViewHost = getHostCopy(expectedValuesView);
     
     for (int pointOrdinal=0; pointOrdinal<numPoints_1D; pointOrdinal++)
@@ -346,7 +346,8 @@ namespace
   void testHierarchicalHVOL_LINE_MatchesAnalyticValues(Intrepid2::EOperator op, const double tol, Teuchos::FancyOStream &out, bool &success)
   {
     using namespace Intrepid2;
-    using BasisFamily  = HierarchicalBasisFamily<>;
+    using DeviceType   = DefaultTestDeviceType;
+    using BasisFamily  = HierarchicalBasisFamily<DeviceType>;
     using PointScalar  = BasisFamily::PointValueType;
     using OutputScalar = BasisFamily::OutputValueType;
     
@@ -355,9 +356,9 @@ namespace
     
     int numPoints_1D = 5;
     shards::CellTopology lineTopo = shards::CellTopology(shards::getCellTopologyData<shards::Line<> >() );
-    auto inputPointsView = getInputPointsView<PointScalar>(lineTopo, numPoints_1D);
+    auto inputPointsView = getInputPointsView<PointScalar,DeviceType>(lineTopo, numPoints_1D);
     
-    auto hvolOutputView = getOutputView<OutputScalar>(FUNCTION_SPACE_HVOL, op, hvolBasis->getCardinality(), numPoints_1D, 1);
+    auto hvolOutputView = getOutputView<OutputScalar,DeviceType>(FUNCTION_SPACE_HVOL, op, hvolBasis->getCardinality(), numPoints_1D, 1);
     
     hvolBasis->getValues(hvolOutputView, inputPointsView, op);
     
@@ -506,20 +507,20 @@ namespace
     
     int numPoints_1D = 5;
     shards::CellTopology triangleTopo = shards::CellTopology(shards::getCellTopologyData<shards::Triangle<> >() );
-    auto inputPointsView = getInputPointsView<PointScalar>(triangleTopo, numPoints_1D);
+    auto inputPointsView = getInputPointsView<PointScalar,DeviceType>(triangleTopo, numPoints_1D);
     
     const int numPoints = inputPointsView.extent_int(0);
         
-    auto hgradOutputView = getOutputView<OutputScalar>(FUNCTION_SPACE_HGRAD, op, hgradBasis->getCardinality(), numPoints, spaceDim);
+    auto hgradOutputView = getOutputView<OutputScalar,DeviceType>(FUNCTION_SPACE_HGRAD, op, hgradBasis->getCardinality(), numPoints, spaceDim);
     hgradBasis->getValues(hgradOutputView, inputPointsView, op);
     
     auto hgradOutputViewHost  = getHostCopy(hgradOutputView);
     auto inputPointsViewHost = getHostCopy(inputPointsView);
     
-    ViewType<OutputScalar> expectedValuesView = getOutputView<OutputScalar>(FUNCTION_SPACE_HGRAD, op, hgradBasis->getCardinality(), numPoints, spaceDim);
+    auto expectedValuesView = getOutputView<OutputScalar,DeviceType>(FUNCTION_SPACE_HGRAD, op, hgradBasis->getCardinality(), numPoints, spaceDim);
     auto expectedValuesViewHost = getHostCopy(expectedValuesView);
     
-    auto legendreValuesAtPoint = getView<OutputScalar>("Legendre values temporary storage", polyOrder+1);
+    auto legendreValuesAtPoint = getView<OutputScalar,DeviceType>("Legendre values temporary storage", polyOrder+1);
     auto legendreValuesAtPointHost = getHostCopy(legendreValuesAtPoint);
     
     for (int pointOrdinal=0; pointOrdinal<numPoints; pointOrdinal++)
@@ -689,6 +690,7 @@ namespace
     using namespace Intrepid2;
     using Teuchos::rcp;
     
+    using DeviceType   = typename LineBasisFamily::DeviceType;
     using PointScalar  = typename LineBasisFamily::PointValueType;
     using OutputScalar = typename LineBasisFamily::OutputValueType;
     
@@ -700,11 +702,11 @@ namespace
     
     int numPoints_1D = 5;
     shards::CellTopology lineTopo = shards::CellTopology(shards::getCellTopologyData<shards::Line<> >() );
-    auto inputPointsView = getInputPointsView<PointScalar>(lineTopo, numPoints_1D);
+    auto inputPointsView = getInputPointsView<PointScalar,DeviceType>(lineTopo, numPoints_1D);
     const int spaceDim = 1;
     
-    auto hgradOutputView = getOutputView<OutputScalar>(FUNCTION_SPACE_HGRAD, opGrad, hgradBasis->getCardinality(), numPoints_1D, spaceDim);
-    auto hvolOutputView  = getOutputView<OutputScalar>(FUNCTION_SPACE_HVOL, opVol, hvolBasis->getCardinality(), numPoints_1D, spaceDim);
+    auto hgradOutputView = getOutputView<OutputScalar,DeviceType>(FUNCTION_SPACE_HGRAD, opGrad, hgradBasis->getCardinality(), numPoints_1D, spaceDim);
+    auto hvolOutputView  = getOutputView<OutputScalar,DeviceType>(FUNCTION_SPACE_HVOL, opVol, hvolBasis->getCardinality(), numPoints_1D, spaceDim);
     
     hgradBasis->getValues(hgradOutputView, inputPointsView, opGrad);
     hvolBasis->getValues(  hvolOutputView, inputPointsView, opVol);
@@ -870,22 +872,23 @@ namespace
     // copy dofMapToDerived to host view
 //    Kokkos::deep_copy(dofMapToStandardHost, dofMapToStandard);
     
+    using DeviceType   = typename DerivedNodalBasisFamily::DeviceType;
     using PointScalar  = typename DerivedNodalBasisFamily::PointValueType;
     using OutputScalar = typename DerivedNodalBasisFamily::OutputValueType;
     
     int numPoints_1D = 5;
-    auto inputPointsView = getInputPointsView<PointScalar>(cellTopo, numPoints_1D);
+    auto inputPointsView = getInputPointsView<PointScalar,DeviceType>(cellTopo, numPoints_1D);
     int numPoints = inputPointsView.extent_int(0);
-    auto standardOutputView = getOutputView<OutputScalar>(fs, op, standardCardinality, numPoints, spaceDim);
-    auto derivedOutputView  = getOutputView<OutputScalar>(fs, op, standardCardinality, numPoints, spaceDim);
+    auto standardOutputView = getOutputView<OutputScalar,DeviceType>(fs, op, standardCardinality, numPoints, spaceDim);
+    auto derivedOutputView  = getOutputView<OutputScalar,DeviceType>(fs, op, standardCardinality, numPoints, spaceDim);
     
     standardBasis->getValues(standardOutputView, inputPointsView, op);
     derivedBasis->getValues(derivedOutputView, inputPointsView, op);
     
     // derived may be in a different order.  Remap so it's in the same order as standard basis
-    auto derivedOutputViewRemapped = getOutputView<OutputScalar>(fs, op, standardCardinality, numPoints, spaceDim);
+    auto derivedOutputViewRemapped = getOutputView<OutputScalar,DeviceType>(fs, op, standardCardinality, numPoints, spaceDim);
     
-    using ViewIteratorScalar    = Intrepid2::ViewIterator<decltype(derivedOutputView), OutputScalar>;
+    using ViewIteratorScalar = Intrepid2::ViewIterator<decltype(derivedOutputView), OutputScalar>;
     const int entryCount = standardOutputView.size();
 
     Kokkos::RangePolicy < ExecutionSpace > policy(0,entryCount);

--- a/packages/intrepid2/unit-test/MonolithicExecutable/BasisEquivalenceTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/BasisEquivalenceTests.cpp
@@ -427,8 +427,8 @@ namespace
   
   TEUCHOS_UNIT_TEST( BasisEquivalence, LineNodalVersusHierarchicalCG_HGRAD )
   {
-    using HierarchicalBasis = HierarchicalBasisFamily<>::HGRAD_LINE;
-    using NodalBasis        = NodalBasisFamily<>::HGRAD_LINE;
+    using HierarchicalBasis = HierarchicalBasisFamily<DefaultTestDeviceType>::HGRAD_LINE;
+    using NodalBasis        = NodalBasisFamily<DefaultTestDeviceType>::HGRAD_LINE;
     
     std::vector<EOperator> opsToTest {OPERATOR_GRAD, OPERATOR_D1, OPERATOR_D2, OPERATOR_D3, OPERATOR_D4, OPERATOR_D5};
     
@@ -447,8 +447,8 @@ namespace
   
   TEUCHOS_UNIT_TEST( BasisEquivalence, LineNodalCnVersusNodalC1_HGRAD )
   {
-    using CnBasis = Intrepid2::Basis_HGRAD_LINE_Cn_FEM<Kokkos::DefaultExecutionSpace>;
-    using C1Basis = Intrepid2::Basis_HGRAD_LINE_C1_FEM<Kokkos::DefaultExecutionSpace>;
+    using CnBasis = Intrepid2::Basis_HGRAD_LINE_Cn_FEM<DefaultTestDeviceType>;
+    using C1Basis = Intrepid2::Basis_HGRAD_LINE_C1_FEM<DefaultTestDeviceType>;
     
     std::vector<EOperator> opsToTest {OPERATOR_GRAD, OPERATOR_D1, OPERATOR_D2, OPERATOR_D3, OPERATOR_D4, OPERATOR_D5};
     
@@ -464,8 +464,8 @@ namespace
   
   TEUCHOS_UNIT_TEST( BasisEquivalence, LineHierarchicalDGVersusHierarchicalCG_HGRAD )
   {
-    using CGBasis = HierarchicalBasisFamily<>::HGRAD_LINE;
-    using DGBasis = DGHierarchicalBasisFamily<>::HGRAD_LINE;
+    using CGBasis = HierarchicalBasisFamily<DefaultTestDeviceType>::HGRAD_LINE;
+    using DGBasis = DGHierarchicalBasisFamily<DefaultTestDeviceType>::HGRAD_LINE;
     
     std::vector<EOperator> opsToTest {OPERATOR_GRAD, OPERATOR_D1, OPERATOR_D2, OPERATOR_D3, OPERATOR_D4, OPERATOR_D5};
     
@@ -484,8 +484,8 @@ namespace
   
   TEUCHOS_UNIT_TEST( BasisEquivalence, QuadrilateralHierarchicalDGVersusHierarchicalCG_HGRAD )
   {
-    using CGBasis = HierarchicalBasisFamily<>::HGRAD_QUAD;
-    using DGBasis = DGHierarchicalBasisFamily<>::HGRAD_QUAD;
+    using CGBasis = HierarchicalBasisFamily<DefaultTestDeviceType>::HGRAD_QUAD;
+    using DGBasis = DGHierarchicalBasisFamily<DefaultTestDeviceType>::HGRAD_QUAD;
     
     std::vector<EOperator> opsToTest {OPERATOR_GRAD, OPERATOR_D1, OPERATOR_D2, OPERATOR_D3, OPERATOR_D4, OPERATOR_D5};
     
@@ -504,8 +504,8 @@ namespace
   
   TEUCHOS_UNIT_TEST( BasisEquivalence, QuadrilateralNodalVersusHierarchicalCG_HGRAD )
   {
-    using HierarchicalBasis = HierarchicalBasisFamily<>::HGRAD_QUAD;
-    using NodalBasis        = NodalBasisFamily<>::HGRAD_QUAD;
+    using HierarchicalBasis = HierarchicalBasisFamily<DefaultTestDeviceType>::HGRAD_QUAD;
+    using NodalBasis        = NodalBasisFamily<DefaultTestDeviceType>::HGRAD_QUAD;
     
     std::vector<EOperator> opsToTest {OPERATOR_GRAD, OPERATOR_D1, OPERATOR_D2, OPERATOR_D3, OPERATOR_D4, OPERATOR_D5};
     
@@ -524,8 +524,8 @@ namespace
   
   TEUCHOS_UNIT_TEST( BasisEquivalence, HexahedronHierarchicalDGVersusHierarchicalCG_HGRAD )
   {
-    using CGBasis = HierarchicalBasisFamily<>::HGRAD_HEX;
-    using DGBasis = DGHierarchicalBasisFamily<>::HGRAD_HEX;
+    using CGBasis = HierarchicalBasisFamily<DefaultTestDeviceType>::HGRAD_HEX;
+    using DGBasis = DGHierarchicalBasisFamily<DefaultTestDeviceType>::HGRAD_HEX;
     
     // these tolerances are selected such that we have a little leeway for architectural differences
     // (It is true, though, that we incur a fair amount of floating point error for higher order bases in higher dimensions)
@@ -543,8 +543,8 @@ namespace
   
   TEUCHOS_UNIT_TEST( BasisEquivalence, HexahedronNodalVersusHierarchicalCG_HGRAD )
   {
-    using HierarchicalBasis = HierarchicalBasisFamily<>::HGRAD_HEX;
-    using NodalBasis        = NodalBasisFamily<>::HGRAD_HEX;
+    using HierarchicalBasis = HierarchicalBasisFamily<DefaultTestDeviceType>::HGRAD_HEX;
+    using NodalBasis        = NodalBasisFamily<DefaultTestDeviceType>::HGRAD_HEX;
     
     // these tolerances are selected such that we have a little leeway for architectural differences
     // (It is true, though, that we incur a fair amount of floating point error for higher order bases in higher dimensions)
@@ -562,8 +562,8 @@ namespace
 
   TEUCHOS_UNIT_TEST( BasisEquivalence, HexahedronNodalCnVersusNodalC1_HGRAD )
   {
-    using CnBasis = Intrepid2::Basis_HGRAD_HEX_Cn_FEM<Kokkos::DefaultExecutionSpace>;
-    using C1Basis = Intrepid2::Basis_HGRAD_HEX_C1_FEM<Kokkos::DefaultExecutionSpace>;
+    using CnBasis = Intrepid2::Basis_HGRAD_HEX_Cn_FEM<DefaultTestDeviceType>;
+    using C1Basis = Intrepid2::Basis_HGRAD_HEX_C1_FEM<DefaultTestDeviceType>;
 
     // these tolerances are selected such that we have a little leeway for architectural differences
     // (It is true, though, that we incur a fair amount of floating point error for higher order bases in higher dimensions)
@@ -579,8 +579,8 @@ namespace
   
   TEUCHOS_UNIT_TEST( BasisEquivalence, HexahedronNodalCnVersusNodalC2_HGRAD )
   {
-    using CnBasis = Intrepid2::Basis_HGRAD_HEX_Cn_FEM<Kokkos::DefaultExecutionSpace>;
-    using C2Basis = Intrepid2::Basis_HGRAD_HEX_C2_FEM<Kokkos::DefaultExecutionSpace>;
+    using CnBasis = Intrepid2::Basis_HGRAD_HEX_Cn_FEM<DefaultTestDeviceType>;
+    using C2Basis = Intrepid2::Basis_HGRAD_HEX_C2_FEM<DefaultTestDeviceType>;
 
     // these tolerances are selected such that we have a little leeway for architectural differences
     // (It is true, though, that we incur a fair amount of floating point error for higher order bases in higher dimensions)
@@ -598,8 +598,8 @@ namespace
   
   TEUCHOS_UNIT_TEST( BasisEquivalence, TetrahedronNodalCnVersusNodalC2_HGRAD )
   {
-    using CnBasis = Intrepid2::Basis_HGRAD_TET_Cn_FEM<Kokkos::DefaultExecutionSpace>;
-    using C2Basis = Intrepid2::Basis_HGRAD_TET_C2_FEM<Kokkos::DefaultExecutionSpace>;
+    using CnBasis = Intrepid2::Basis_HGRAD_TET_Cn_FEM<DefaultTestDeviceType>;
+    using C2Basis = Intrepid2::Basis_HGRAD_TET_C2_FEM<DefaultTestDeviceType>;
     
     // OPERATOR_D2 and above are not supported by either the nodal or the hierarchical basis at present...
     std::vector<EOperator> opsToTest {OPERATOR_GRAD, OPERATOR_D1};
@@ -616,8 +616,8 @@ namespace
   
   TEUCHOS_UNIT_TEST( BasisEquivalence, TetrahedronHierarchicalDGVersusHierarchicalCG_HGRAD )
   {
-    using CGBasis = HierarchicalBasisFamily<>::HGRAD_TET;
-    using DGBasis = DGHierarchicalBasisFamily<>::HGRAD_TET;
+    using CGBasis = HierarchicalBasisFamily<DefaultTestDeviceType>::HGRAD_TET;
+    using DGBasis = DGHierarchicalBasisFamily<DefaultTestDeviceType>::HGRAD_TET;
     
     // these tolerances are selected such that we have a little leeway for architectural differences
     // (It is true, though, that we incur a fair amount of floating point error for higher order bases in higher dimensions)
@@ -635,8 +635,8 @@ namespace
   
   TEUCHOS_UNIT_TEST( BasisEquivalence, TetrahedronNodalVersusHierarchicalCG_HGRAD )
   {
-    using HierarchicalBasis = HierarchicalBasisFamily<>::HGRAD_TET;
-    using NodalBasis        = NodalBasisFamily<>::HGRAD_TET;
+    using HierarchicalBasis = HierarchicalBasisFamily<DefaultTestDeviceType>::HGRAD_TET;
+    using NodalBasis        = NodalBasisFamily<DefaultTestDeviceType>::HGRAD_TET;
     
     // OPERATOR_D2 and above are not supported by either the nodal or the hierarchical basis at present...
     std::vector<EOperator> opsToTest {OPERATOR_GRAD, OPERATOR_D1};
@@ -667,8 +667,8 @@ namespace
   
   TEUCHOS_UNIT_TEST( BasisEquivalence, TriangleNodalVersusHierarchicalCG_HGRAD )
   {
-    using HierarchicalBasis = HierarchicalBasisFamily<>::HGRAD_TRI;
-    using NodalBasis        = NodalBasisFamily<>::HGRAD_TRI;
+    using HierarchicalBasis = HierarchicalBasisFamily<DefaultTestDeviceType>::HGRAD_TRI;
+    using NodalBasis        = NodalBasisFamily<DefaultTestDeviceType>::HGRAD_TRI;
     
     // OPERATOR_D2 and above are not supported by either the nodal or the hierarchical basis at present...
     std::vector<EOperator> opsToTest {OPERATOR_GRAD, OPERATOR_D1};
@@ -688,8 +688,8 @@ namespace
   
   TEUCHOS_UNIT_TEST( BasisEquivalence, TriangleHierarchicalCGVersusHierarchicalDG_HGRAD )
   {
-    using CGBasis =   HierarchicalBasisFamily<>::HGRAD_TRI;
-    using DGBasis = DGHierarchicalBasisFamily<>::HGRAD_TRI;
+    using CGBasis =   HierarchicalBasisFamily<DefaultTestDeviceType>::HGRAD_TRI;
+    using DGBasis = DGHierarchicalBasisFamily<DefaultTestDeviceType>::HGRAD_TRI;
     
     // OPERATOR_D2 and above are not supported by either the nodal or the hierarchical basis at present...
     std::vector<EOperator> opsToTest {OPERATOR_GRAD, OPERATOR_D1};

--- a/packages/intrepid2/unit-test/MonolithicExecutable/BasisOpDecompositionTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/BasisOpDecompositionTests.cpp
@@ -100,7 +100,7 @@ namespace
   
 TEUCHOS_UNIT_TEST( BasisOpDecomposition, HierarchicalHGRAD_QUAD )
 {
-  using Basis = HierarchicalBasisFamily<>::HGRAD_QUAD;
+  using Basis = HierarchicalBasisFamily<DefaultTestDeviceType>::HGRAD_QUAD;
   
   auto GRAD  = OPERATOR_GRAD;
   auto VALUE = OPERATOR_VALUE;
@@ -120,7 +120,7 @@ TEUCHOS_UNIT_TEST( BasisOpDecomposition, HierarchicalHGRAD_QUAD )
 
   TEUCHOS_UNIT_TEST( BasisOpDecomposition, HierarchicalHGRAD_HEX )
   {
-    using Basis = HierarchicalBasisFamily<>::HGRAD_HEX;
+    using Basis = HierarchicalBasisFamily<DefaultTestDeviceType>::HGRAD_HEX;
     
     auto GRAD  = OPERATOR_GRAD;
     auto VALUE = OPERATOR_VALUE;
@@ -141,8 +141,8 @@ TEUCHOS_UNIT_TEST( BasisOpDecomposition, HierarchicalHGRAD_QUAD )
 
   TEUCHOS_UNIT_TEST( BasisOpDecomposition, HierarchicalHDIV_HEX_Family1 )
   {
-    using BasisGRAD = HierarchicalBasisFamily<>::HGRAD_LINE;
-    using BasisVOL  = HierarchicalBasisFamily<>::HVOL_LINE;
+    using BasisGRAD = HierarchicalBasisFamily<DefaultTestDeviceType>::HGRAD_LINE;
+    using BasisVOL  = HierarchicalBasisFamily<DefaultTestDeviceType>::HVOL_LINE;
     
     using Basis = Basis_Derived_HDIV_Family1_HEX<BasisGRAD,BasisVOL>;
     const int familyOrdinal = 0;
@@ -188,8 +188,8 @@ TEUCHOS_UNIT_TEST( BasisOpDecomposition, HierarchicalHGRAD_QUAD )
   TEUCHOS_UNIT_TEST( BasisOpDecomposition, HierarchicalHDIV_HEX_Family2 )
   {
     
-    using BasisGRAD = HierarchicalBasisFamily<>::HGRAD_LINE;
-    using BasisVOL  = HierarchicalBasisFamily<>::HVOL_LINE;
+    using BasisGRAD = HierarchicalBasisFamily<DefaultTestDeviceType>::HGRAD_LINE;
+    using BasisVOL  = HierarchicalBasisFamily<DefaultTestDeviceType>::HVOL_LINE;
     
     using Basis = Basis_Derived_HDIV_Family2_HEX<BasisGRAD,BasisVOL>;
     const int familyOrdinal = 1;
@@ -235,8 +235,8 @@ TEUCHOS_UNIT_TEST( BasisOpDecomposition, HierarchicalHGRAD_QUAD )
   TEUCHOS_UNIT_TEST( BasisOpDecomposition, HierarchicalHDIV_HEX_Family3 )
   {
     
-    using BasisGRAD = HierarchicalBasisFamily<>::HGRAD_LINE;
-    using BasisVOL  = HierarchicalBasisFamily<>::HVOL_LINE;
+    using BasisGRAD = HierarchicalBasisFamily<DefaultTestDeviceType>::HGRAD_LINE;
+    using BasisVOL  = HierarchicalBasisFamily<DefaultTestDeviceType>::HVOL_LINE;
     
     using Basis = Basis_Derived_HDIV_Family3_HEX<BasisGRAD,BasisVOL>;
     const int familyOrdinal = 2;
@@ -281,8 +281,8 @@ TEUCHOS_UNIT_TEST( BasisOpDecomposition, HierarchicalHGRAD_QUAD )
 
   TEUCHOS_UNIT_TEST( BasisOpDecomposition, HierarchicalHCURL_QUAD_Family1 )
   {
-    using BasisGRAD = HierarchicalBasisFamily<>::HGRAD_LINE;
-    using BasisVOL  = HierarchicalBasisFamily<>::HVOL_LINE;
+    using BasisGRAD = HierarchicalBasisFamily<DefaultTestDeviceType>::HGRAD_LINE;
+    using BasisVOL  = HierarchicalBasisFamily<DefaultTestDeviceType>::HVOL_LINE;
     
     using Basis = Basis_Derived_HCURL_Family1_QUAD<BasisGRAD,BasisVOL>;
     const int familyOrdinal = 0;
@@ -327,8 +327,8 @@ TEUCHOS_UNIT_TEST( BasisOpDecomposition, HierarchicalHGRAD_QUAD )
   TEUCHOS_UNIT_TEST( BasisOpDecomposition, HierarchicalHCURL_QUAD_Family2 )
   {
     
-    using BasisGRAD = HierarchicalBasisFamily<>::HGRAD_LINE;
-    using BasisVOL  = HierarchicalBasisFamily<>::HVOL_LINE;
+    using BasisGRAD = HierarchicalBasisFamily<DefaultTestDeviceType>::HGRAD_LINE;
+    using BasisVOL  = HierarchicalBasisFamily<DefaultTestDeviceType>::HVOL_LINE;
     
     using Basis = Basis_Derived_HCURL_Family2_QUAD<BasisGRAD,BasisVOL>;
     const int familyOrdinal = 1;
@@ -373,8 +373,8 @@ TEUCHOS_UNIT_TEST( BasisOpDecomposition, HierarchicalHGRAD_QUAD )
 
   TEUCHOS_UNIT_TEST( BasisOpDecomposition, HierarchicalHCURL_HEX_Family1 )
   {
-    using BasisGRAD = HierarchicalBasisFamily<>::HGRAD_LINE;
-    using BasisVOL  = HierarchicalBasisFamily<>::HVOL_LINE;
+    using BasisGRAD = HierarchicalBasisFamily<DefaultTestDeviceType>::HGRAD_LINE;
+    using BasisVOL  = HierarchicalBasisFamily<DefaultTestDeviceType>::HVOL_LINE;
     
     using Basis = Basis_Derived_HCURL_Family1_HEX<BasisGRAD,BasisVOL>;
     const int familyOrdinal = 0;
@@ -423,8 +423,8 @@ TEUCHOS_UNIT_TEST( BasisOpDecomposition, HierarchicalHGRAD_QUAD )
   TEUCHOS_UNIT_TEST( BasisOpDecomposition, HierarchicalHCURL_HEX_Family2 )
   {
     
-    using BasisGRAD = HierarchicalBasisFamily<>::HGRAD_LINE;
-    using BasisVOL  = HierarchicalBasisFamily<>::HVOL_LINE;
+    using BasisGRAD = HierarchicalBasisFamily<DefaultTestDeviceType>::HGRAD_LINE;
+    using BasisVOL  = HierarchicalBasisFamily<DefaultTestDeviceType>::HVOL_LINE;
     
     using Basis = Basis_Derived_HCURL_Family2_HEX<BasisGRAD,BasisVOL>;
     const int familyOrdinal = 1;
@@ -473,8 +473,8 @@ TEUCHOS_UNIT_TEST( BasisOpDecomposition, HierarchicalHGRAD_QUAD )
   TEUCHOS_UNIT_TEST( BasisOpDecomposition, HierarchicalHCURL_HEX_Family3 )
   {
     
-    using BasisGRAD = HierarchicalBasisFamily<>::HGRAD_LINE;
-    using BasisVOL  = HierarchicalBasisFamily<>::HVOL_LINE;
+    using BasisGRAD = HierarchicalBasisFamily<DefaultTestDeviceType>::HGRAD_LINE;
+    using BasisVOL  = HierarchicalBasisFamily<DefaultTestDeviceType>::HVOL_LINE;
     
     using Basis = Basis_Derived_HCURL_Family3_HEX<BasisGRAD,BasisVOL>;
     const int familyOrdinal = 2;

--- a/packages/intrepid2/unit-test/MonolithicExecutable/BasisValuesTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/BasisValuesTests.cpp
@@ -121,18 +121,7 @@ namespace
       tensorWeights = TensorData<WeightScalar,DeviceType>(weightComponents);
     }
     
-    out << "Points being tested:\n";
-    for (int pointOrdinal=0; pointOrdinal<numRefPoints; pointOrdinal++)
-    {
-      out << pointOrdinal << ": " << "(";
-      for (int d=0; d<spaceDim; d++)
-      {
-        out << points(pointOrdinal,d);
-        if (d < spaceDim-1) out << ",";
-      }
-      out << ")\n";
-    }
-    
+    printFunctor2(points, out, "points being tested");
     printFunctor2(tensorPoints, out, "tensorPoints");
     
     testFloatingEquality2(points,tensorPoints,  relTol, absTol, out, success, "points", "tensorPoints");

--- a/packages/intrepid2/unit-test/MonolithicExecutable/BasisValuesTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/BasisValuesTests.cpp
@@ -114,7 +114,7 @@ namespace
     }
     else
     {
-      std::vector<ViewTypeDefaultTestDT<PointScalar>> pointComponents {points};
+      std::vector<ViewType<PointScalar,DeviceType>> pointComponents {points};
       tensorPoints = TensorPoints<PointScalar,DeviceType>(pointComponents);
       Data<WeightScalar,DeviceType> weightData(weights);
       std::vector<Data<WeightScalar,DeviceType>> weightComponents {weightData};

--- a/packages/intrepid2/unit-test/MonolithicExecutable/BasisValuesTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/BasisValuesTests.cpp
@@ -78,20 +78,23 @@ namespace
   {
     // get quadrature points for integrating up to polyOrder
     const int quadratureDegree = 2*basis.getDegree();
-    using ExecutionSpace = typename Basis::ExecutionSpace;
+    using DeviceType = DefaultTestDeviceType;
     using PointScalar = typename Basis::PointValueType;
     using WeightScalar = typename Basis::OutputValueType;
+    using CubatureType = Cubature<DeviceType,PointScalar,WeightScalar>;
+    using PointView  = typename CubatureType::PointViewTypeAllocatable;
+    using WeightView = typename CubatureType::WeightViewTypeAllocatable;
     DefaultCubatureFactory cub_factory;
     auto cellTopoKey = basis.getBaseCellTopology().getKey();
-    auto quadrature = cub_factory.create<ExecutionSpace, PointScalar, WeightScalar>(cellTopoKey, quadratureDegree);
+    auto quadrature = cub_factory.create<DeviceType, PointScalar, WeightScalar>(cellTopoKey, quadratureDegree);
     ordinal_type numRefPoints = quadrature->getNumPoints();
     const int spaceDim = basis.getBaseCellTopology().getDimension();
-    ViewType<PointScalar> points = ViewType<PointScalar>("quadrature points ref cell", numRefPoints, spaceDim);
-    ViewType<WeightScalar> weights = ViewType<WeightScalar>("quadrature weights ref cell", numRefPoints);
+    PointView points("quadrature points ref cell", numRefPoints, spaceDim);
+    WeightView weights("quadrature weights ref cell", numRefPoints);
     quadrature->getCubature(points, weights);
     
-    TensorPoints<PointScalar> tensorPoints;
-    TensorData<WeightScalar>  tensorWeights;
+    TensorPoints<PointScalar,DeviceType> tensorPoints;
+    TensorData<WeightScalar,DeviceType>  tensorWeights;
     
     using HostPointViewType = Kokkos::DynRankView<PointScalar,Kokkos::HostSpace>;
     using HostWeightViewType = Kokkos::DynRankView<WeightScalar,Kokkos::HostSpace>;
@@ -100,7 +103,7 @@ namespace
     HostWeightViewType hostWeights("quadrature weights ref cell - host", numRefPoints);
     hostQuadrature->getCubature(hostPoints, hostWeights);
     
-    using CubatureTensorType = CubatureTensor<ExecutionSpace,PointScalar,WeightScalar>;
+    using CubatureTensorType = CubatureTensor<DeviceType,PointScalar,WeightScalar>;
     CubatureTensorType* tensorQuadrature = dynamic_cast<CubatureTensorType*>(quadrature.get());
 
     if (tensorQuadrature)
@@ -111,11 +114,11 @@ namespace
     }
     else
     {
-      std::vector<ViewType<PointScalar>> pointComponents {points};
-      tensorPoints = TensorPoints<PointScalar>(pointComponents);
-      Data<WeightScalar> weightData(weights);
-      std::vector<Data<WeightScalar>> weightComponents {weightData};
-      tensorWeights = TensorData<WeightScalar>(weightComponents);
+      std::vector<ViewTypeDefaultTestDT<PointScalar>> pointComponents {points};
+      tensorPoints = TensorPoints<PointScalar,DeviceType>(pointComponents);
+      Data<WeightScalar,DeviceType> weightData(weights);
+      std::vector<Data<WeightScalar,DeviceType>> weightComponents {weightData};
+      tensorWeights = TensorData<WeightScalar,DeviceType>(weightComponents);
     }
     
     out << "Points being tested:\n";
@@ -223,7 +226,7 @@ namespace
   TEUCHOS_UNIT_TEST( BasisValues, DefaultConstructor )
   {
     // test of default-constructed basis values object.
-    BasisValues<double> emptyBasisValues;
+    BasisValues<double,DefaultTestDeviceType> emptyBasisValues;
     TEST_EQUALITY(0, emptyBasisValues.rank());
     for (int d=0; d<8; d++)
     {

--- a/packages/intrepid2/unit-test/MonolithicExecutable/BasisValuesTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/BasisValuesTests.cpp
@@ -124,7 +124,7 @@ namespace
     printFunctor2(points, out, "points being tested");
     printFunctor2(tensorPoints, out, "tensorPoints");
     
-    testFloatingEquality2(points,tensorPoints,  relTol, absTol, out, success, "points", "tensorPoints");
+    testFloatingEquality2(points, tensorPoints, relTol, absTol, out, success, "points", "tensorPoints");
         
     auto hostBasisPtr = basis.getHostBasis();
         

--- a/packages/intrepid2/unit-test/MonolithicExecutable/CellGeometryTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/CellGeometryTests.cpp
@@ -158,17 +158,17 @@ namespace
     
     const int numCells        = cellNodes.numCells();
     const int numNodesPerCell = cellNodes.numNodesPerCell();
-    auto expandedCellNodes    = getView<PointScalar>("expanded cell nodes",numCells,numNodesPerCell,spaceDim);
-    for (int cellOrdinal=0; cellOrdinal<numCells; cellOrdinal++)
+    auto expandedCellNodes    = getView2T<PointScalar,DeviceType>("expanded cell nodes",numCells,numNodesPerCell,spaceDim);
+    using ExecutionSpace = typename DeviceType::execution_space;
+    auto policy = Kokkos::MDRangePolicy<ExecutionSpace,Kokkos::Rank<2>>({0,0},{numCells,numNodesPerCell});
+    Kokkos::parallel_for("fill expanded cell nodes", policy,
+    KOKKOS_LAMBDA (const int &cellOrdinal, const int &nodeOrdinal)
     {
-      for (int nodeOrdinal=0; nodeOrdinal<numNodesPerCell; nodeOrdinal++)
+      for (int d=0; d<spaceDim; d++)
       {
-        for (int d=0; d<spaceDim; d++)
-        {
-          expandedCellNodes(cellOrdinal,nodeOrdinal,d) = cellNodes(cellOrdinal,nodeOrdinal,d);
-        }
+        expandedCellNodes(cellOrdinal,nodeOrdinal,d) = cellNodes(cellOrdinal,nodeOrdinal,d);
       }
-    }
+    });
     
     auto cellMeasures                = getView2T<PointScalar,DeviceType>("cell measures",        numCells, numPoints);
     auto expandedJacobianDeterminant = getView2T<PointScalar,DeviceType>("jacobian determinant", numCells, numPoints);

--- a/packages/intrepid2/unit-test/MonolithicExecutable/CellGeometryTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/CellGeometryTests.cpp
@@ -118,7 +118,7 @@ namespace
     {
       std::vector<ViewType<PointScalar,DeviceType>> pointComponents {points};
       tensorPoints = TensorPoints<PointScalar,DeviceType>(pointComponents);
-      Data<WeightScalar> weightData(weights);
+      Data<WeightScalar,DeviceType> weightData(weights);
       std::vector<Data<WeightScalar,DeviceType>> weightComponents {weightData};
       tensorWeights = TensorData<WeightScalar,DeviceType>(weightComponents);
     }

--- a/packages/intrepid2/unit-test/MonolithicExecutable/CellGeometryTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/CellGeometryTests.cpp
@@ -100,10 +100,10 @@ namespace
     out << std::endl << "basisForNodes: " << basisForNodes->getName() << std::endl;
 
     ScalarView<PointScalar,DeviceType> expectedJacobians("cell Jacobians", numCells, numRefPoints, spaceDim, spaceDim);
-    CellTools<ExecutionSpace>::setJacobian(expectedJacobians, points, cellNodes, basisForNodes); // TODO: when CellTools supports DeviceType, change the template argument here
+    CellTools<DeviceType>::setJacobian(expectedJacobians, points, cellNodes, basisForNodes);
     
-    TensorPoints<PointScalar> tensorPoints;
-    TensorData<WeightScalar>  tensorWeights;
+    TensorPoints<PointScalar,DeviceType> tensorPoints;
+    TensorData<WeightScalar,DeviceType>  tensorWeights;
     
     using CubatureTensorType = CubatureTensor<DeviceType,PointScalar,WeightScalar>;
     CubatureTensorType* tensorQuadrature = dynamic_cast<CubatureTensorType*>(quadrature.get());
@@ -175,7 +175,6 @@ namespace
     auto expandedJacobian            = getView<PointScalar>("jacobian",             numCells, numPoints, spaceDim, spaceDim);
     auto expandedJacobianInverse     = getView<PointScalar>("jacobian inverse",     numCells, numPoints, spaceDim, spaceDim);
     
-    using ExecutionSpace = typename DeviceType::execution_space;
     using CellTools = Intrepid2::CellTools<DeviceType>;
     
     CellTools::setJacobian(expandedJacobian, cubaturePoints, expandedCellNodes, cellTopo);
@@ -219,28 +218,28 @@ namespace
     const int spaceDim = 2;
     
     using PointScalar = double;
-    using ExecutionSpace = Kokkos::DefaultExecutionSpace;
+    using DeviceType = DefaultTestDeviceType;
     
     Kokkos::Array<PointScalar,spaceDim> origin{0,0};
     Kokkos::Array<PointScalar,spaceDim> domainExtents{1,1};
     Kokkos::Array<int,spaceDim> gridCellCounts{2,2};
     
-    using Geometry = CellGeometry<PointScalar, spaceDim, ExecutionSpace>;
+    using Geometry = CellGeometry<PointScalar, spaceDim, DeviceType>;
     Geometry::SubdivisionStrategy   subdivisionStrategy = Geometry::NO_SUBDIVISION;
     Geometry::HypercubeNodeOrdering nodeOrdering        = Geometry::HYPERCUBE_NODE_ORDER_CLASSIC_SHARDS;
     Geometry cellGeometry(origin, domainExtents, gridCellCounts, subdivisionStrategy, nodeOrdering);
     
     const int polyOrder = 3;
     
-    auto cubature = Intrepid2::DefaultCubatureFactory::create<ExecutionSpace>(cellGeometry.cellTopology(),polyOrder*2);
+    auto cubature = Intrepid2::DefaultCubatureFactory::create<DeviceType>(cellGeometry.cellTopology(),polyOrder*2);
     auto tensorCubatureWeights = cubature->allocateCubatureWeights();
     auto tensorCubaturePoints  = cubature->allocateCubaturePoints();
     
     const int numCells  = cellGeometry.numCells();
     const int numPoints = tensorCubaturePoints.extent_int(0);
     
-    Data<PointScalar,ExecutionSpace> jacobian = cellGeometry.allocateJacobianData(tensorCubaturePoints);
-    Data<PointScalar,ExecutionSpace> jacobianDet = CellTools<ExecutionSpace>::allocateJacobianDet(jacobian);
+    Data<PointScalar,DeviceType> jacobian = cellGeometry.allocateJacobianData(tensorCubaturePoints);
+    Data<PointScalar,DeviceType> jacobianDet = CellTools<DeviceType>::allocateJacobianDet(jacobian);
     
     // jacobian should have shape (C,P,D,D)
     TEST_EQUALITY(4,         jacobian.rank());
@@ -256,7 +255,7 @@ namespace
     
     cubature->getCubature(tensorCubaturePoints, tensorCubatureWeights);
     
-    TensorData<PointScalar,ExecutionSpace> cellMeasures = cellGeometry.allocateCellMeasure(jacobianDet, tensorCubatureWeights);
+    TensorData<PointScalar,DeviceType> cellMeasures = cellGeometry.allocateCellMeasure(jacobianDet, tensorCubatureWeights);
     
     // cellMeasures should have shape (C,P)
     TEST_EQUALITY(2,         cellMeasures.rank());
@@ -274,13 +273,13 @@ namespace
     const int spaceDim = 2;
     
     using PointScalar = double;
-    using ExecutionSpace = Kokkos::DefaultExecutionSpace;
+    using DeviceType = DefaultTestDeviceType;
     
     Kokkos::Array<PointScalar,spaceDim> origin{0,0};
     Kokkos::Array<PointScalar,spaceDim> domainExtents{1,1};
     Kokkos::Array<int,spaceDim> gridCellCounts{2,2};
     
-    using Geometry = CellGeometry<PointScalar, spaceDim, ExecutionSpace>;
+    using Geometry = CellGeometry<PointScalar, spaceDim, DeviceType>;
     Geometry::SubdivisionStrategy   subdivisionStrategy = Geometry::NO_SUBDIVISION;
     Geometry::HypercubeNodeOrdering nodeOrdering        = Geometry::HYPERCUBE_NODE_ORDER_CLASSIC_SHARDS;
     Geometry uniformCellGeometry(origin, domainExtents, gridCellCounts, subdivisionStrategy, nodeOrdering);
@@ -290,15 +289,15 @@ namespace
     
     const int polyOrder = 3;
     
-    auto cubature = Intrepid2::DefaultCubatureFactory::create<ExecutionSpace>(cellGeometry.cellTopology(),polyOrder*2);
+    auto cubature = Intrepid2::DefaultCubatureFactory::create<DeviceType>(cellGeometry.cellTopology(),polyOrder*2);
     auto tensorCubatureWeights = cubature->allocateCubatureWeights();
     auto tensorCubaturePoints  = cubature->allocateCubaturePoints();
     
     const int numCells  = cellGeometry.numCells();
     const int numPoints = tensorCubaturePoints.extent_int(0);
     
-    Data<PointScalar,ExecutionSpace> jacobian = cellGeometry.allocateJacobianData(tensorCubaturePoints);
-    Data<PointScalar,ExecutionSpace> jacobianDet = CellTools<ExecutionSpace>::allocateJacobianDet(jacobian);
+    Data<PointScalar,DeviceType> jacobian = cellGeometry.allocateJacobianData(tensorCubaturePoints);
+    Data<PointScalar,DeviceType> jacobianDet = CellTools<DeviceType>::allocateJacobianDet(jacobian);
     
     // jacobian should have shape (C,P,D,D)
     TEST_EQUALITY(4,         jacobian.rank());
@@ -314,7 +313,7 @@ namespace
     
     cubature->getCubature(tensorCubaturePoints, tensorCubatureWeights);
     
-    TensorData<PointScalar,ExecutionSpace> cellMeasures = cellGeometry.allocateCellMeasure(jacobianDet, tensorCubatureWeights);
+    TensorData<PointScalar,DeviceType> cellMeasures = cellGeometry.allocateCellMeasure(jacobianDet, tensorCubatureWeights);
     
     // cellMeasures should have shape (C,P)
     TEST_EQUALITY(2,         cellMeasures.rank());
@@ -333,14 +332,14 @@ namespace
     const double tol=1e-15;
     
     using PointScalar = double;
-    using ExecutionSpace = Kokkos::DefaultExecutionSpace;
+    using DeviceType = DefaultTestDeviceType;
     
     // unit quad should be defined as shards does: counter-clockwise, starting at the origin vertex
     Kokkos::Array<PointScalar,spaceDim> origin{0,0};
     Kokkos::Array<PointScalar,spaceDim> domainExtents{1,1};
     Kokkos::Array<int,spaceDim> gridCellCounts{1,1};
     
-    using Geometry = CellGeometry<PointScalar, spaceDim, ExecutionSpace>;
+    using Geometry = CellGeometry<PointScalar, spaceDim, DeviceType>;
     Geometry::SubdivisionStrategy   subdivisionStrategy = Geometry::NO_SUBDIVISION;
     Geometry::HypercubeNodeOrdering nodeOrdering        = Geometry::HYPERCUBE_NODE_ORDER_CLASSIC_SHARDS;
     Geometry cellGeometry(origin, domainExtents, gridCellCounts, subdivisionStrategy, nodeOrdering);
@@ -380,13 +379,13 @@ namespace
     const double absTol=1e-13;
     
     using PointScalar = double;
-    using ExecutionSpace = Kokkos::DefaultExecutionSpace;
+    using DeviceType = DefaultTestDeviceType;
     
     Kokkos::Array<PointScalar,spaceDim> origin{0,0};
     Kokkos::Array<PointScalar,spaceDim> domainExtents{1,2};
     Kokkos::Array<int,spaceDim> gridCellCounts{4,8};
-    CellGeometry<PointScalar, spaceDim, ExecutionSpace>::SubdivisionStrategy subdivisionStrategy = CellGeometry<PointScalar, spaceDim>::NO_SUBDIVISION;
-    CellGeometry<PointScalar, spaceDim, ExecutionSpace> cellGeometry(origin, domainExtents, gridCellCounts, subdivisionStrategy);
+    CellGeometry<PointScalar, spaceDim, DeviceType>::SubdivisionStrategy subdivisionStrategy = CellGeometry<PointScalar, spaceDim, DeviceType>::NO_SUBDIVISION;
+    CellGeometry<PointScalar, spaceDim, DeviceType> cellGeometry(origin, domainExtents, gridCellCounts, subdivisionStrategy);
     
     testJacobiansAgree(cellGeometry, relTol, absTol, out, success);
   }
@@ -398,13 +397,13 @@ namespace
     const double absTol=1e-13;
     
     using PointScalar = double;
-    using ExecutionSpace = Kokkos::DefaultExecutionSpace;
+    using DeviceType = DefaultTestDeviceType;
     
     Kokkos::Array<PointScalar,spaceDim> origin{0,0,0};
     Kokkos::Array<PointScalar,spaceDim> domainExtents{1,2,3};
     Kokkos::Array<int,spaceDim> gridCellCounts{2,4,8};
-    CellGeometry<PointScalar, spaceDim, ExecutionSpace>::SubdivisionStrategy subdivisionStrategy = CellGeometry<PointScalar, spaceDim>::NO_SUBDIVISION;
-    CellGeometry<PointScalar, spaceDim, ExecutionSpace> cellGeometry(origin, domainExtents, gridCellCounts, subdivisionStrategy);
+    CellGeometry<PointScalar, spaceDim, DeviceType>::SubdivisionStrategy subdivisionStrategy = CellGeometry<PointScalar, spaceDim, DeviceType>::NO_SUBDIVISION;
+    CellGeometry<PointScalar, spaceDim, DeviceType> cellGeometry(origin, domainExtents, gridCellCounts, subdivisionStrategy);
     
     testJacobiansAgree(cellGeometry, relTol, absTol, out, success);
   }
@@ -416,18 +415,18 @@ namespace
     const double absTol=1e-13;
     
     using PointScalar = double;
-    using ExecutionSpace = Kokkos::DefaultExecutionSpace;
+    using DeviceType = DefaultTestDeviceType;
     
     Kokkos::Array<PointScalar,spaceDim> origin{0,0};
     Kokkos::Array<PointScalar,spaceDim> domainExtents{1,2};
     Kokkos::Array<int,spaceDim> gridCellCounts{2,4};
     
-    using CellGeometryType = CellGeometry<PointScalar, spaceDim, ExecutionSpace>;
+    using CellGeometryType = CellGeometry<PointScalar, spaceDim, DeviceType>;
     
     std::vector<CellGeometryType::SubdivisionStrategy> subdivisionStrategies = {CellGeometryType::TWO_TRIANGLES_RIGHT, CellGeometryType::TWO_TRIANGLES_LEFT, CellGeometryType::FOUR_TRIANGLES};
     for (const auto & subdivisionStrategy : subdivisionStrategies)
     {
-      CellGeometry<PointScalar, spaceDim, ExecutionSpace> cellGeometry(origin, domainExtents, gridCellCounts, subdivisionStrategy);
+      CellGeometry<PointScalar, spaceDim, DeviceType> cellGeometry(origin, domainExtents, gridCellCounts, subdivisionStrategy);
       testJacobiansAgree(cellGeometry, relTol, absTol, out, success);
     }
   }
@@ -439,18 +438,18 @@ namespace
     const double absTol=1e-13;
     
     using PointScalar = double;
-    using ExecutionSpace = Kokkos::DefaultExecutionSpace;
+    using DeviceType = DefaultTestDeviceType;
     
     Kokkos::Array<PointScalar,spaceDim> origin{0,0};
     Kokkos::Array<PointScalar,spaceDim> domainExtents{1,2,4};
     Kokkos::Array<int,spaceDim> gridCellCounts{2,4,2};
     
-    using CellGeometryType = CellGeometry<PointScalar, spaceDim, ExecutionSpace>;
+    using CellGeometryType = CellGeometry<PointScalar, spaceDim, DeviceType>;
     
     std::vector<CellGeometryType::SubdivisionStrategy> subdivisionStrategies = {CellGeometryType::FIVE_TETRAHEDRA}; // TODO: add CellGeometryType::SIX_TETRAHEDRA once CellGeometry supports that
     for (const auto & subdivisionStrategy : subdivisionStrategies)
     {
-      CellGeometry<PointScalar, spaceDim, ExecutionSpace> cellGeometry(origin, domainExtents, gridCellCounts, subdivisionStrategy);
+      CellGeometry<PointScalar, spaceDim, DeviceType> cellGeometry(origin, domainExtents, gridCellCounts, subdivisionStrategy);
       testJacobiansAgree(cellGeometry, relTol, absTol, out, success);
     }
   }
@@ -492,13 +491,13 @@ namespace
     const double absTol=1e-13;
     
     using PointScalar = double;
-    using ExecutionSpace = Kokkos::DefaultExecutionSpace;
+    using DeviceType = DefaultTestDeviceType;
     
     Kokkos::Array<PointScalar,spaceDim> origin{0,0};
     Kokkos::Array<PointScalar,spaceDim> domainExtents{1,2};
     Kokkos::Array<int,spaceDim> gridCellCounts{4,8};
-    CellGeometry<PointScalar, spaceDim, ExecutionSpace>::SubdivisionStrategy subdivisionStrategy = CellGeometry<PointScalar, spaceDim>::NO_SUBDIVISION;
-    CellGeometry<PointScalar, spaceDim, ExecutionSpace> uniformGridCellGeometry(origin, domainExtents, gridCellCounts, subdivisionStrategy);
+    CellGeometry<PointScalar, spaceDim, DeviceType>::SubdivisionStrategy subdivisionStrategy = CellGeometry<PointScalar, spaceDim, DeviceType>::NO_SUBDIVISION;
+    CellGeometry<PointScalar, spaceDim, DeviceType> uniformGridCellGeometry(origin, domainExtents, gridCellCounts, subdivisionStrategy);
     
     const std::vector<bool> copyAffineValues {false, true};
     
@@ -519,13 +518,13 @@ namespace
     const double absTol=1e-13;
     
     using PointScalar = double;
-    using ExecutionSpace = Kokkos::DefaultExecutionSpace;
+    using DeviceType = DefaultTestDeviceType;
     
     Kokkos::Array<PointScalar,spaceDim> origin{0,0,0};
     Kokkos::Array<PointScalar,spaceDim> domainExtents{1,2,3};
     Kokkos::Array<int,spaceDim> gridCellCounts{2,4,8};
-    CellGeometry<PointScalar, spaceDim, ExecutionSpace>::SubdivisionStrategy subdivisionStrategy = CellGeometry<PointScalar, spaceDim>::NO_SUBDIVISION;
-    CellGeometry<PointScalar, spaceDim, ExecutionSpace> uniformGridCellGeometry(origin, domainExtents, gridCellCounts, subdivisionStrategy);
+    CellGeometry<PointScalar, spaceDim, DeviceType>::SubdivisionStrategy subdivisionStrategy = CellGeometry<PointScalar, spaceDim, DeviceType>::NO_SUBDIVISION;
+    CellGeometry<PointScalar, spaceDim, DeviceType> uniformGridCellGeometry(origin, domainExtents, gridCellCounts, subdivisionStrategy);
     
     const std::vector<bool> copyAffineValues {false, true};
     
@@ -545,18 +544,18 @@ namespace
     const double absTol=1e-13;
     
     using PointScalar = double;
-    using ExecutionSpace = Kokkos::DefaultExecutionSpace;
+    using DeviceType = DefaultTestDeviceType;
     
     Kokkos::Array<PointScalar,spaceDim> origin{0,0};
     Kokkos::Array<PointScalar,spaceDim> domainExtents{1,2};
     Kokkos::Array<int,spaceDim> gridCellCounts{2,4};
     
-    using CellGeometryType = CellGeometry<PointScalar, spaceDim, ExecutionSpace>;
+    using CellGeometryType = CellGeometry<PointScalar, spaceDim, DeviceType>;
     
     std::vector<CellGeometryType::SubdivisionStrategy> subdivisionStrategies = {CellGeometryType::TWO_TRIANGLES_RIGHT, CellGeometryType::TWO_TRIANGLES_LEFT, CellGeometryType::FOUR_TRIANGLES};
     for (const auto & subdivisionStrategy : subdivisionStrategies)
     {
-      CellGeometry<PointScalar, spaceDim, ExecutionSpace> uniformGridCellGeometry(origin, domainExtents, gridCellCounts, subdivisionStrategy);
+      CellGeometry<PointScalar, spaceDim, DeviceType> uniformGridCellGeometry(origin, domainExtents, gridCellCounts, subdivisionStrategy);
       
       // "affine" and "non-affine" paths for linear triangles should be identical in terms of e.g. the number of Jacobian evaluations (the affine structure is detected rather than enforced because of the claimAffine argument).  We test both possibilities anyway.
       const std::vector<bool> copyAffineValues {false, true};

--- a/packages/intrepid2/unit-test/MonolithicExecutable/CellGeometryTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/CellGeometryTests.cpp
@@ -92,8 +92,8 @@ namespace
     auto quadrature = cub_factory.create<DeviceType, PointScalar, PointScalar>(cellTopoKey, quadratureDegree);
     ordinal_type numRefPoints = quadrature->getNumPoints();
     using WeightScalar = PointScalar;
-    ViewType<PointScalar> points = ViewType<PointScalar>("quadrature points ref cell", numRefPoints, spaceDim);
-    ViewType<WeightScalar> weights = ViewType<WeightScalar>("quadrature weights ref cell", numRefPoints);
+    auto points  = getView<PointScalar,DeviceType>("quadrature points ref cell", numRefPoints, spaceDim);
+    auto weights = getView<WeightScalar,DeviceType>("quadrature weights ref cell", numRefPoints);
     quadrature->getCubature(points, weights);
     
     auto basisForNodes = cellGeometry.basisForNodes();
@@ -116,11 +116,11 @@ namespace
     }
     else
     {
-      std::vector<ViewType<PointScalar>> pointComponents {points};
-      tensorPoints = TensorPoints<PointScalar>(pointComponents);
+      std::vector<ViewType<PointScalar,DeviceType>> pointComponents {points};
+      tensorPoints = TensorPoints<PointScalar,DeviceType>(pointComponents);
       Data<WeightScalar> weightData(weights);
-      std::vector<Data<WeightScalar>> weightComponents {weightData};
-      tensorWeights = TensorData<WeightScalar>(weightComponents);
+      std::vector<Data<WeightScalar,DeviceType>> weightComponents {weightData};
+      tensorWeights = TensorData<WeightScalar,DeviceType>(weightComponents);
     }
     
     Data<PointScalar,DeviceType> jacobians = cellGeometry.allocateJacobianData(tensorPoints);
@@ -158,7 +158,7 @@ namespace
     
     const int numCells        = cellNodes.numCells();
     const int numNodesPerCell = cellNodes.numNodesPerCell();
-    auto expandedCellNodes    = getView2T<PointScalar,DeviceType>("expanded cell nodes",numCells,numNodesPerCell,spaceDim);
+    auto expandedCellNodes    = getView<PointScalar,DeviceType>("expanded cell nodes",numCells,numNodesPerCell,spaceDim);
     using ExecutionSpace = typename DeviceType::execution_space;
     auto policy = Kokkos::MDRangePolicy<ExecutionSpace,Kokkos::Rank<2>>({0,0},{numCells,numNodesPerCell});
     Kokkos::parallel_for("fill expanded cell nodes", policy,
@@ -170,10 +170,10 @@ namespace
       }
     });
     
-    auto cellMeasures                = getView2T<PointScalar,DeviceType>("cell measures",        numCells, numPoints);
-    auto expandedJacobianDeterminant = getView2T<PointScalar,DeviceType>("jacobian determinant", numCells, numPoints);
-    auto expandedJacobian            = getView2T<PointScalar,DeviceType>("jacobian",             numCells, numPoints, spaceDim, spaceDim);
-    auto expandedJacobianInverse     = getView2T<PointScalar,DeviceType>("jacobian inverse",     numCells, numPoints, spaceDim, spaceDim);
+    auto cellMeasures                = getView<PointScalar,DeviceType>("cell measures",        numCells, numPoints);
+    auto expandedJacobianDeterminant = getView<PointScalar,DeviceType>("jacobian determinant", numCells, numPoints);
+    auto expandedJacobian            = getView<PointScalar,DeviceType>("jacobian",             numCells, numPoints, spaceDim, spaceDim);
+    auto expandedJacobianInverse     = getView<PointScalar,DeviceType>("jacobian inverse",     numCells, numPoints, spaceDim, spaceDim);
     
     using CellTools = Intrepid2::CellTools<DeviceType>;
     

--- a/packages/intrepid2/unit-test/MonolithicExecutable/CellGeometryTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/CellGeometryTests.cpp
@@ -170,10 +170,10 @@ namespace
       }
     }
     
-    auto cellMeasures                = getView<PointScalar>("cell measures",        numCells, numPoints);
-    auto expandedJacobianDeterminant = getView<PointScalar>("jacobian determinant", numCells, numPoints);
-    auto expandedJacobian            = getView<PointScalar>("jacobian",             numCells, numPoints, spaceDim, spaceDim);
-    auto expandedJacobianInverse     = getView<PointScalar>("jacobian inverse",     numCells, numPoints, spaceDim, spaceDim);
+    auto cellMeasures                = getView2T<PointScalar,DeviceType>("cell measures",        numCells, numPoints);
+    auto expandedJacobianDeterminant = getView2T<PointScalar,DeviceType>("jacobian determinant", numCells, numPoints);
+    auto expandedJacobian            = getView2T<PointScalar,DeviceType>("jacobian",             numCells, numPoints, spaceDim, spaceDim);
+    auto expandedJacobianInverse     = getView2T<PointScalar,DeviceType>("jacobian inverse",     numCells, numPoints, spaceDim, spaceDim);
     
     using CellTools = Intrepid2::CellTools<DeviceType>;
     

--- a/packages/intrepid2/unit-test/MonolithicExecutable/CubatureTensorTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/CubatureTensorTests.cpp
@@ -64,12 +64,12 @@ namespace
   void testTensorPointCubature(const shards::CellTopology &cellTopo, const int &quadratureDegree,
                                const double &relTol, const double &absTol, Teuchos::FancyOStream &out, bool &success)
   {
-    using ExecutionSpace = Kokkos::DefaultExecutionSpace;
+    using DeviceType = DefaultTestDeviceType;
     using PointScalar = double;
     using WeightScalar = double;
     DefaultCubatureFactory cub_factory;
     auto cellTopoKey = cellTopo.getKey();
-    auto quadrature = cub_factory.create<ExecutionSpace, PointScalar, WeightScalar>(cellTopoKey, quadratureDegree);
+    auto quadrature = cub_factory.create<DeviceType, PointScalar, WeightScalar>(cellTopoKey, quadratureDegree);
     ordinal_type numRefPoints = quadrature->getNumPoints();
     const int spaceDim = cellTopo.getDimension();
     ViewType<PointScalar> points = ViewType<PointScalar>("quadrature points ref cell", numRefPoints, spaceDim);
@@ -79,7 +79,7 @@ namespace
     TensorPoints<PointScalar> tensorPoints;
     TensorData<WeightScalar>  tensorWeights;
     
-    using CubatureTensorType = CubatureTensor<ExecutionSpace,PointScalar,WeightScalar>;
+    using CubatureTensorType = CubatureTensor<DeviceType,PointScalar,WeightScalar>;
     CubatureTensorType* tensorQuadrature = dynamic_cast<CubatureTensorType*>(quadrature.get());
 
     if (tensorQuadrature)

--- a/packages/intrepid2/unit-test/MonolithicExecutable/CubatureTensorTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/CubatureTensorTests.cpp
@@ -67,13 +67,19 @@ namespace
     using DeviceType = DefaultTestDeviceType;
     using PointScalar = double;
     using WeightScalar = double;
+    using CubatureType   = Cubature<DeviceType,PointScalar,WeightScalar>;
+    using PointViewType  = typename CubatureType::PointViewTypeAllocatable;
+    using WeightViewType = typename CubatureType::WeightViewTypeAllocatable;
+    
     DefaultCubatureFactory cub_factory;
     auto cellTopoKey = cellTopo.getKey();
     auto quadrature = cub_factory.create<DeviceType, PointScalar, WeightScalar>(cellTopoKey, quadratureDegree);
     ordinal_type numRefPoints = quadrature->getNumPoints();
     const int spaceDim = cellTopo.getDimension();
-    ViewType<PointScalar> points = ViewType<PointScalar>("quadrature points ref cell", numRefPoints, spaceDim);
-    ViewType<WeightScalar> weights = ViewType<WeightScalar>("quadrature weights ref cell", numRefPoints);
+    
+    PointViewType points("quadrature points ref cell", numRefPoints, spaceDim);
+    WeightViewType weights("quadrature weights ref cell", numRefPoints);
+    
     quadrature->getCubature(points, weights);
     
     TensorPoints<PointScalar> tensorPoints;

--- a/packages/intrepid2/unit-test/MonolithicExecutable/CubatureTensorTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/CubatureTensorTests.cpp
@@ -82,8 +82,8 @@ namespace
     
     quadrature->getCubature(points, weights);
     
-    TensorPoints<PointScalar> tensorPoints;
-    TensorData<WeightScalar>  tensorWeights;
+    TensorPoints<PointScalar,DeviceType> tensorPoints;
+    TensorData<WeightScalar,DeviceType>  tensorWeights;
     
     using CubatureTensorType = CubatureTensor<DeviceType,PointScalar,WeightScalar>;
     CubatureTensorType* tensorQuadrature = dynamic_cast<CubatureTensorType*>(quadrature.get());
@@ -96,11 +96,11 @@ namespace
     }
     else
     {
-      std::vector<ViewType<PointScalar>> pointComponents {points};
-      tensorPoints = TensorPoints<PointScalar>(pointComponents);
-      Data<WeightScalar> weightData(weights);
-      std::vector<Data<WeightScalar>> weightComponents {weightData};
-      tensorWeights = TensorData<WeightScalar>(weightComponents);
+      std::vector<ViewTypeDefaultTestDT<PointScalar>> pointComponents {points};
+      tensorPoints = TensorPoints<PointScalar,DeviceType>(pointComponents);
+      Data<WeightScalar,DeviceType> weightData(weights);
+      std::vector<Data<WeightScalar,DeviceType>> weightComponents {weightData};
+      tensorWeights = TensorData<WeightScalar,DeviceType>(weightComponents);
     }
     
     printView(points, out, "Points being tested");

--- a/packages/intrepid2/unit-test/MonolithicExecutable/CubatureTensorTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/CubatureTensorTests.cpp
@@ -96,7 +96,7 @@ namespace
     }
     else
     {
-      std::vector<ViewTypeDefaultTestDT<PointScalar>> pointComponents {points};
+      std::vector<ViewType<PointScalar,DeviceType>> pointComponents {points};
       tensorPoints = TensorPoints<PointScalar,DeviceType>(pointComponents);
       Data<WeightScalar,DeviceType> weightData(weights);
       std::vector<Data<WeightScalar,DeviceType>> weightComponents {weightData};

--- a/packages/intrepid2/unit-test/MonolithicExecutable/DataTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/DataTests.cpp
@@ -317,7 +317,6 @@ TEUCHOS_UNIT_TEST( Data, MatMatExplicitIdentity_PDD ) // (P,D,D) underlying; not
     Data<Scalar,DefaultTestDeviceType> B(rightMatrixView, rank, extents, variationTypes, rightLastNonDiagonal);
     
     auto expectedResultView = getViewDefaultTestDT<Scalar>("result matrix", cellCount, spaceDim, spaceDim);
-    auto expectedResultViewHost = Kokkos::create_mirror(expectedResultView);
     
     const int cellOrdinal = 0;
     auto policy = Kokkos::MDRangePolicy<typename DefaultTestDeviceType::execution_space,Kokkos::Rank<2>>({0,0},{spaceDim,spaceDim});
@@ -331,11 +330,9 @@ TEUCHOS_UNIT_TEST( Data, MatMatExplicitIdentity_PDD ) // (P,D,D) underlying; not
         Scalar right = transposeB ? B(cellOrdinal,j,k) : B(cellOrdinal,k,j);
         result += left * right;
       }
-      expectedResultViewHost(cellOrdinal, i, j) = result;
+      expectedResultView(cellOrdinal, i, j) = result;
     });
-    
-    Kokkos::deep_copy(expectedResultView, expectedResultViewHost);
-    
+        
     auto actualResultData = Data<Scalar,DefaultTestDeviceType>::allocateMatMatResult(transposeA, A, transposeB, B);
     
     TEST_EQUALITY(       3,  actualResultData.rank());

--- a/packages/intrepid2/unit-test/MonolithicExecutable/DataTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/DataTests.cpp
@@ -82,7 +82,7 @@ namespace
     const int numRows = 3;
     const int numCols = 3;
     const Scalar lastValueToSet = 18;
-    auto zeroView = getView<Scalar>("GetWritableEntry view", numRows, numCols);
+    auto zeroView = getViewDefaultTestDT<Scalar>("GetWritableEntry view", numRows, numCols);
     Kokkos::deep_copy(zeroView,0);
     Data<double,DefaultTestDeviceType> data(zeroView);
     
@@ -93,7 +93,7 @@ namespace
       lastVal = lastValueToSet;
     });
     
-    auto expectedView = getView<Scalar>("GetWritableEntry expected view", numRows, numCols);
+    auto expectedView = getViewDefaultTestDT<Scalar>("GetWritableEntry expected view", numRows, numCols);
     auto expectedViewHost = Kokkos::create_mirror_view(expectedView);
     Kokkos::deep_copy(expectedViewHost,0);
     expectedViewHost(numRows-1,numCols-1) = lastValueToSet;
@@ -112,20 +112,20 @@ namespace
     
     using Scalar = double;
     const int spaceDim = 2;
-    auto matrixView = getView<Scalar>("full matrix", spaceDim, spaceDim);
+    auto matrixView = getViewDefaultTestDT<Scalar>("full matrix", spaceDim, spaceDim);
     auto matrixViewHost = Kokkos::create_mirror(matrixView);
     matrixViewHost(0,0) =  1.0;  matrixViewHost(0,1) =  2.0;
     matrixViewHost(1,0) = -1.0;  matrixViewHost(1,1) =  3.0;
     Kokkos::deep_copy(matrixView, matrixViewHost);
     
-    auto vecView = getView<Scalar>("vector", spaceDim);
+    auto vecView = getViewDefaultTestDT<Scalar>("vector", spaceDim);
     auto vecViewHost = Kokkos::create_mirror(vecView);
     
     vecViewHost(0) = 1.0;
     vecViewHost(1) = 2.0;
     Kokkos::deep_copy(vecView, vecViewHost);
     
-    auto expectedResultView = getView<Scalar>("result vector", spaceDim);
+    auto expectedResultView = getViewDefaultTestDT<Scalar>("result vector", spaceDim);
     auto expectedResultViewHost = Kokkos::create_mirror(expectedResultView);
     
     expectedResultViewHost(0) = matrixViewHost(0,0) * vecViewHost(0) + matrixViewHost(0,1) * vecViewHost(1);
@@ -152,19 +152,19 @@ namespace
     using Scalar = double;
     const int spaceDim = 2;
     const int cellCount = 1;
-    auto leftMatrixView = getView<Scalar>("left matrix", cellCount, spaceDim, spaceDim);
+    auto leftMatrixView = getViewDefaultTestDT<Scalar>("left matrix", cellCount, spaceDim, spaceDim);
     auto leftMatrixViewHost = Kokkos::create_mirror(leftMatrixView);
     leftMatrixViewHost(0,0,0) =  1.0;  leftMatrixViewHost(0,0,1) =  2.0;
     leftMatrixViewHost(0,1,0) = -1.0;  leftMatrixViewHost(0,1,1) =  3.0;
     Kokkos::deep_copy(leftMatrixView, leftMatrixViewHost);
     
-    auto rightMatrixView = getView<Scalar>("right matrix", cellCount, spaceDim, spaceDim);
+    auto rightMatrixView = getViewDefaultTestDT<Scalar>("right matrix", cellCount, spaceDim, spaceDim);
     auto rightMatrixViewHost = Kokkos::create_mirror(rightMatrixView);
     rightMatrixViewHost(0,0,0) =  1.0;  rightMatrixViewHost(0,0,1) =  2.0;
     rightMatrixViewHost(0,1,0) = -1.0;  rightMatrixViewHost(0,1,1) =  3.0;
     Kokkos::deep_copy(rightMatrixView, rightMatrixViewHost);
     
-    auto expectedResultView = getView<Scalar>("result matrix", cellCount, spaceDim, spaceDim);
+    auto expectedResultView = getViewDefaultTestDT<Scalar>("result matrix", cellCount, spaceDim, spaceDim);
     auto expectedResultViewHost = Kokkos::create_mirror(expectedResultView);
     
     const int cellOrdinal = 0;
@@ -285,7 +285,7 @@ TEUCHOS_UNIT_TEST( Data, MatMatExplicitIdentity_PDD ) // (P,D,D) underlying; not
     const int spaceDim = 3;
     const int leftLastNonDiagonal = 1;
     const int cellCount = 1;
-    auto leftMatrixView = getView<Scalar>("left matrix", cellCount, (leftLastNonDiagonal+1) * (leftLastNonDiagonal+1) + (spaceDim - leftLastNonDiagonal - 1));
+    auto leftMatrixView = getViewDefaultTestDT<Scalar>("left matrix", cellCount, (leftLastNonDiagonal+1) * (leftLastNonDiagonal+1) + (spaceDim - leftLastNonDiagonal - 1));
     auto leftMatrixViewHost = Kokkos::create_mirror(leftMatrixView);
     int entryIndex = 0;
     // Block:
@@ -296,7 +296,7 @@ TEUCHOS_UNIT_TEST( Data, MatMatExplicitIdentity_PDD ) // (P,D,D) underlying; not
     Kokkos::deep_copy(leftMatrixView, leftMatrixViewHost);
     
     const int rightLastNonDiagonal = 0;
-    auto rightMatrixView = getView<Scalar>("right matrix", cellCount, (rightLastNonDiagonal+1) * (rightLastNonDiagonal+1) + (spaceDim - rightLastNonDiagonal - 1));
+    auto rightMatrixView = getViewDefaultTestDT<Scalar>("right matrix", cellCount, (rightLastNonDiagonal+1) * (rightLastNonDiagonal+1) + (spaceDim - rightLastNonDiagonal - 1));
     auto rightMatrixViewHost = Kokkos::create_mirror(rightMatrixView);
     entryIndex = 0;
     // Diagonal:
@@ -316,7 +316,7 @@ TEUCHOS_UNIT_TEST( Data, MatMatExplicitIdentity_PDD ) // (P,D,D) underlying; not
     Data<Scalar,DefaultTestDeviceType> A( leftMatrixView, rank, extents, variationTypes, leftLastNonDiagonal);
     Data<Scalar,DefaultTestDeviceType> B(rightMatrixView, rank, extents, variationTypes, rightLastNonDiagonal);
     
-    auto expectedResultView = getView<Scalar>("result matrix", cellCount, spaceDim, spaceDim);
+    auto expectedResultView = getViewDefaultTestDT<Scalar>("result matrix", cellCount, spaceDim, spaceDim);
     auto expectedResultViewHost = Kokkos::create_mirror(expectedResultView);
     
     const int cellOrdinal = 0;

--- a/packages/intrepid2/unit-test/MonolithicExecutable/DataTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/DataTests.cpp
@@ -62,8 +62,9 @@ namespace
  */
   TEUCHOS_UNIT_TEST( Data, EmptyDataMarkedAsInvalid )
   {
+    using DeviceType = DefaultTestDeviceType;
     // check the new default constructor for Data
-    Data<double,DefaultTestDeviceType> emptyData;
+    Data<double,DeviceType> emptyData;
     TEST_EQUALITY(emptyData.isValid(), false); // empty data container should return false from isValid()
   }
 
@@ -73,7 +74,7 @@ namespace
   TEUCHOS_UNIT_TEST( Data, GetWritableEntry )
   {
     using Scalar = double;
-    using ExecSpaceType = Kokkos::DefaultExecutionSpace;
+    using DeviceType = DefaultTestDeviceType;
     
     // no arithmetic, so comparisons should be exact
     double relTol = 0.0;
@@ -82,10 +83,11 @@ namespace
     const int numRows = 3;
     const int numCols = 3;
     const Scalar lastValueToSet = 18;
-    auto zeroView = getViewDefaultTestDT<Scalar>("GetWritableEntry view", numRows, numCols);
+    auto zeroView = getView<Scalar,DeviceType>("GetWritableEntry view", numRows, numCols);
     Kokkos::deep_copy(zeroView,0);
-    Data<double,DefaultTestDeviceType> data(zeroView);
+    Data<double,DeviceType> data(zeroView);
     
+    using ExecSpaceType = typename DeviceType::execution_space;
     Kokkos::RangePolicy<ExecSpaceType> policy(0,1); // trivial policy: 1 entry
     Kokkos::parallel_for("set lastVal", policy,
     KOKKOS_LAMBDA (const int &i) {
@@ -93,7 +95,7 @@ namespace
       lastVal = lastValueToSet;
     });
     
-    auto expectedView = getViewDefaultTestDT<Scalar>("GetWritableEntry expected view", numRows, numCols);
+    auto expectedView = getView<Scalar,DeviceType>("GetWritableEntry expected view", numRows, numCols);
     auto expectedViewHost = Kokkos::create_mirror_view(expectedView);
     Kokkos::deep_copy(expectedViewHost,0);
     expectedViewHost(numRows-1,numCols-1) = lastValueToSet;
@@ -110,22 +112,23 @@ namespace
     double relTol = 1e-13;
     double absTol = 1e-13;
     
+    using DeviceType = DefaultTestDeviceType;
     using Scalar = double;
     const int spaceDim = 2;
-    auto matrixView = getViewDefaultTestDT<Scalar>("full matrix", spaceDim, spaceDim);
+    auto matrixView = getView<Scalar,DeviceType>("full matrix", spaceDim, spaceDim);
     auto matrixViewHost = Kokkos::create_mirror(matrixView);
     matrixViewHost(0,0) =  1.0;  matrixViewHost(0,1) =  2.0;
     matrixViewHost(1,0) = -1.0;  matrixViewHost(1,1) =  3.0;
     Kokkos::deep_copy(matrixView, matrixViewHost);
     
-    auto vecView = getViewDefaultTestDT<Scalar>("vector", spaceDim);
+    auto vecView = getView<Scalar,DeviceType>("vector", spaceDim);
     auto vecViewHost = Kokkos::create_mirror(vecView);
     
     vecViewHost(0) = 1.0;
     vecViewHost(1) = 2.0;
     Kokkos::deep_copy(vecView, vecViewHost);
     
-    auto expectedResultView = getViewDefaultTestDT<Scalar>("result vector", spaceDim);
+    auto expectedResultView = getView<Scalar,DeviceType>("result vector", spaceDim);
     auto expectedResultViewHost = Kokkos::create_mirror(expectedResultView);
     
     expectedResultViewHost(0) = matrixViewHost(0,0) * vecViewHost(0) + matrixViewHost(0,1) * vecViewHost(1);
@@ -133,9 +136,9 @@ namespace
     
     Kokkos::deep_copy(expectedResultView, expectedResultViewHost);
     
-    Data<Scalar,DefaultTestDeviceType> matData(matrixView);
-    Data<Scalar,DefaultTestDeviceType> vecData(vecView);
-    auto actualResultData = Data<Scalar,DefaultTestDeviceType>::allocateMatVecResult(matData, vecData);
+    Data<Scalar,DeviceType> matData(matrixView);
+    Data<Scalar,DeviceType> vecData(vecView);
+    auto actualResultData = Data<Scalar,DeviceType>::allocateMatVecResult(matData, vecData);
     actualResultData.storeMatVec(matData, vecData);
     
     testFloatingEquality1(expectedResultView, actualResultData.getUnderlyingView1(), relTol, absTol, out, success);
@@ -149,22 +152,23 @@ namespace
     double relTol = 1e-13;
     double absTol = 1e-13;
     
+    using DeviceType = DefaultTestDeviceType;
     using Scalar = double;
     const int spaceDim = 2;
     const int cellCount = 1;
-    auto leftMatrixView = getViewDefaultTestDT<Scalar>("left matrix", cellCount, spaceDim, spaceDim);
+    auto leftMatrixView = getView<Scalar,DeviceType>("left matrix", cellCount, spaceDim, spaceDim);
     auto leftMatrixViewHost = Kokkos::create_mirror(leftMatrixView);
     leftMatrixViewHost(0,0,0) =  1.0;  leftMatrixViewHost(0,0,1) =  2.0;
     leftMatrixViewHost(0,1,0) = -1.0;  leftMatrixViewHost(0,1,1) =  3.0;
     Kokkos::deep_copy(leftMatrixView, leftMatrixViewHost);
     
-    auto rightMatrixView = getViewDefaultTestDT<Scalar>("right matrix", cellCount, spaceDim, spaceDim);
+    auto rightMatrixView = getView<Scalar,DeviceType>("right matrix", cellCount, spaceDim, spaceDim);
     auto rightMatrixViewHost = Kokkos::create_mirror(rightMatrixView);
     rightMatrixViewHost(0,0,0) =  1.0;  rightMatrixViewHost(0,0,1) =  2.0;
     rightMatrixViewHost(0,1,0) = -1.0;  rightMatrixViewHost(0,1,1) =  3.0;
     Kokkos::deep_copy(rightMatrixView, rightMatrixViewHost);
     
-    auto expectedResultView = getViewDefaultTestDT<Scalar>("result matrix", cellCount, spaceDim, spaceDim);
+    auto expectedResultView = getView<Scalar,DeviceType>("result matrix", cellCount, spaceDim, spaceDim);
     auto expectedResultViewHost = Kokkos::create_mirror(expectedResultView);
     
     const int cellOrdinal = 0;
@@ -188,9 +192,9 @@ namespace
     const bool transposeA = false;
     const bool transposeB = false;
     
-    Data<Scalar,DefaultTestDeviceType> A_data(leftMatrixView);
-    Data<Scalar,DefaultTestDeviceType> B_data(rightMatrixView);
-    auto actualResultData = Data<Scalar,DefaultTestDeviceType>::allocateMatMatResult(transposeA, A_data, transposeB, B_data);
+    Data<Scalar,DeviceType> A_data(leftMatrixView);
+    Data<Scalar,DeviceType> B_data(rightMatrixView);
+    auto actualResultData = Data<Scalar,DeviceType>::allocateMatMatResult(transposeA, A_data, transposeB, B_data);
     
     TEST_EQUALITY(       3,  actualResultData.rank());
     TEST_EQUALITY(cellCount, actualResultData.extent_int(0));
@@ -210,6 +214,8 @@ namespace
 TEUCHOS_UNIT_TEST( Data, MatMatExplicitIdentity_PDD ) // (P,D,D) underlying; notionally (C,P,D,D)
 {
   // tests that identity * identity = identity
+  using DeviceType = DefaultTestDeviceType;
+  
   double relTol = 1e-13;
   double absTol = 1e-13;
   
@@ -218,7 +224,7 @@ TEUCHOS_UNIT_TEST( Data, MatMatExplicitIdentity_PDD ) // (P,D,D) underlying; not
   const int cellCount = 1;
   const int numPoints = 4;
   
-  auto identityMatrixView = getFixedRankViewDefaultTestDT<Scalar>("identity matrix", numPoints, spaceDim, spaceDim);
+  auto identityMatrixView = getFixedRankView<Scalar>("identity matrix", numPoints, spaceDim, spaceDim);
   auto identityMatrixViewHost = getHostCopy(identityMatrixView);
   
   for (int pointOrdinal=0; pointOrdinal<numPoints; pointOrdinal++)
@@ -236,7 +242,7 @@ TEUCHOS_UNIT_TEST( Data, MatMatExplicitIdentity_PDD ) // (P,D,D) underlying; not
   Kokkos::Array<int,4> transformationExtents {cellCount, numPoints, spaceDim, spaceDim};
   Kokkos::Array<DataVariationType,4> transformationVariationType {CONSTANT, GENERAL, GENERAL, GENERAL};
   
-  Data<Scalar,DefaultTestDeviceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType);
+  Data<Scalar,DeviceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType);
   
   using std::vector;
   using std::pair;
@@ -257,7 +263,7 @@ TEUCHOS_UNIT_TEST( Data, MatMatExplicitIdentity_PDD ) // (P,D,D) underlying; not
     const string transposeBString = transposeB ? "true" : "false";
   
     out << "*** Testing transposeA = " << transposeAString << ", transposeB = " << transposeBString << " ***\n";
-    auto actualResultData = Data<Scalar,DefaultTestDeviceType>::allocateMatMatResult(transposeA, explicitIdentityMatrix, transposeB, explicitIdentityMatrix);
+    auto actualResultData = Data<Scalar,DeviceType>::allocateMatMatResult(transposeA, explicitIdentityMatrix, transposeB, explicitIdentityMatrix);
     
     TEST_EQUALITY(       4,  actualResultData.rank());
     TEST_EQUALITY(cellCount, actualResultData.extent_int(0));
@@ -278,6 +284,8 @@ TEUCHOS_UNIT_TEST( Data, MatMatExplicitIdentity_PDD ) // (P,D,D) underlying; not
 */
   TEUCHOS_UNIT_TEST( Data, MatMatBlockPlusDiagonal )
   {
+    using DeviceType = DefaultTestDeviceType;
+    
     double relTol = 1e-13;
     double absTol = 1e-13;
     
@@ -285,7 +293,7 @@ TEUCHOS_UNIT_TEST( Data, MatMatExplicitIdentity_PDD ) // (P,D,D) underlying; not
     const int spaceDim = 3;
     const int leftLastNonDiagonal = 1;
     const int cellCount = 1;
-    auto leftMatrixView = getViewDefaultTestDT<Scalar>("left matrix", cellCount, (leftLastNonDiagonal+1) * (leftLastNonDiagonal+1) + (spaceDim - leftLastNonDiagonal - 1));
+    auto leftMatrixView = getView<Scalar,DeviceType>("left matrix", cellCount, (leftLastNonDiagonal+1) * (leftLastNonDiagonal+1) + (spaceDim - leftLastNonDiagonal - 1));
     auto leftMatrixViewHost = Kokkos::create_mirror(leftMatrixView);
     int entryIndex = 0;
     // Block:
@@ -296,7 +304,7 @@ TEUCHOS_UNIT_TEST( Data, MatMatExplicitIdentity_PDD ) // (P,D,D) underlying; not
     Kokkos::deep_copy(leftMatrixView, leftMatrixViewHost);
     
     const int rightLastNonDiagonal = 0;
-    auto rightMatrixView = getViewDefaultTestDT<Scalar>("right matrix", cellCount, (rightLastNonDiagonal+1) * (rightLastNonDiagonal+1) + (spaceDim - rightLastNonDiagonal - 1));
+    auto rightMatrixView = getView<Scalar,DeviceType>("right matrix", cellCount, (rightLastNonDiagonal+1) * (rightLastNonDiagonal+1) + (spaceDim - rightLastNonDiagonal - 1));
     auto rightMatrixViewHost = Kokkos::create_mirror(rightMatrixView);
     entryIndex = 0;
     // Diagonal:
@@ -313,13 +321,13 @@ TEUCHOS_UNIT_TEST( Data, MatMatExplicitIdentity_PDD ) // (P,D,D) underlying; not
     Kokkos::Array<int,7> extents {cellCount,spaceDim,spaceDim,0,0,0,0};
     Kokkos::Array<DataVariationType,7> variationTypes {GENERAL,BLOCK_PLUS_DIAGONAL,BLOCK_PLUS_DIAGONAL,CONSTANT,CONSTANT,CONSTANT,CONSTANT};
     
-    Data<Scalar,DefaultTestDeviceType> A( leftMatrixView, rank, extents, variationTypes, leftLastNonDiagonal);
-    Data<Scalar,DefaultTestDeviceType> B(rightMatrixView, rank, extents, variationTypes, rightLastNonDiagonal);
+    Data<Scalar,DeviceType> A( leftMatrixView, rank, extents, variationTypes, leftLastNonDiagonal);
+    Data<Scalar,DeviceType> B(rightMatrixView, rank, extents, variationTypes, rightLastNonDiagonal);
     
-    auto expectedResultView = getViewDefaultTestDT<Scalar>("result matrix", cellCount, spaceDim, spaceDim);
+    auto expectedResultView = getView<Scalar,DeviceType>("result matrix", cellCount, spaceDim, spaceDim);
     
     const int cellOrdinal = 0;
-    auto policy = Kokkos::MDRangePolicy<typename DefaultTestDeviceType::execution_space,Kokkos::Rank<2>>({0,0},{spaceDim,spaceDim});
+    auto policy = Kokkos::MDRangePolicy<typename DeviceType::execution_space,Kokkos::Rank<2>>({0,0},{spaceDim,spaceDim});
     Kokkos::parallel_for("compute first-order simplex Jacobians", policy,
     KOKKOS_LAMBDA(const int &i, const int &j)
     {
@@ -333,7 +341,7 @@ TEUCHOS_UNIT_TEST( Data, MatMatExplicitIdentity_PDD ) // (P,D,D) underlying; not
       expectedResultView(cellOrdinal, i, j) = result;
     });
         
-    auto actualResultData = Data<Scalar,DefaultTestDeviceType>::allocateMatMatResult(transposeA, A, transposeB, B);
+    auto actualResultData = Data<Scalar,DeviceType>::allocateMatMatResult(transposeA, A, transposeB, B);
     
     TEST_EQUALITY(       3,  actualResultData.rank());
     TEST_EQUALITY(cellCount, actualResultData.extent_int(0));

--- a/packages/intrepid2/unit-test/MonolithicExecutable/DirectSumBasisTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/DirectSumBasisTests.cpp
@@ -84,8 +84,8 @@ namespace
     WeightViewType weights("quadrature weights ref cell", numRefPoints);
     quadrature->getCubature(points, weights);
     
-    TensorPoints<PointScalar> tensorPoints;
-    TensorData<WeightScalar>  tensorWeights;
+    TensorPoints<PointScalar,DeviceType> tensorPoints;
+    TensorData<WeightScalar,DeviceType>  tensorWeights;
     
     using CubatureTensorType = CubatureTensor<DeviceType,PointScalar,WeightScalar>;
     CubatureTensorType* tensorQuadrature = dynamic_cast<CubatureTensorType*>(quadrature.get());

--- a/packages/intrepid2/unit-test/MonolithicExecutable/DirectSumBasisTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/DirectSumBasisTests.cpp
@@ -62,29 +62,32 @@ namespace
 // #pragma mark DirectSumBasis group
   TEUCHOS_UNIT_TEST( DirectSumBasis, AllocateBasisValues )
   {
-    using Basis = HierarchicalBasisFamily<>::HDIV_HEX;
+    using Basis = HierarchicalBasisFamily<DefaultTestDeviceType>::HDIV_HEX;
     
     Basis basis(1,1,1);
     
     int quadratureDegree = 1;
-    using ExecutionSpace = Kokkos::DefaultExecutionSpace;
+    using DeviceType = DefaultTestDeviceType;
     using PointScalar = double;
     using WeightScalar = double;
     DefaultCubatureFactory cub_factory;
+    using CubatureType   = Cubature<DeviceType,PointScalar,WeightScalar>;
+    using PointViewType  = typename CubatureType::PointViewTypeAllocatable;
+    using WeightViewType = typename CubatureType::WeightViewTypeAllocatable;
     auto cellTopo = basis.getBaseCellTopology();
     auto cellTopoKey = cellTopo.getKey();
-    auto quadrature = cub_factory.create<ExecutionSpace, PointScalar, WeightScalar>(cellTopoKey, quadratureDegree);
+    auto quadrature = cub_factory.create<DeviceType, PointScalar, WeightScalar>(cellTopoKey, quadratureDegree);
     
     ordinal_type numRefPoints = quadrature->getNumPoints();
     const int spaceDim = cellTopo.getDimension();
-    ViewType<PointScalar> points = ViewType<PointScalar>("quadrature points ref cell", numRefPoints, spaceDim);
-    ViewType<WeightScalar> weights = ViewType<WeightScalar>("quadrature weights ref cell", numRefPoints);
+    PointViewType points("quadrature points ref cell", numRefPoints, spaceDim);
+    WeightViewType weights("quadrature weights ref cell", numRefPoints);
     quadrature->getCubature(points, weights);
     
     TensorPoints<PointScalar> tensorPoints;
     TensorData<WeightScalar>  tensorWeights;
     
-    using CubatureTensorType = CubatureTensor<ExecutionSpace,PointScalar,WeightScalar>;
+    using CubatureTensorType = CubatureTensor<DeviceType,PointScalar,WeightScalar>;
     CubatureTensorType* tensorQuadrature = dynamic_cast<CubatureTensorType*>(quadrature.get());
 
     if (tensorQuadrature)

--- a/packages/intrepid2/unit-test/MonolithicExecutable/HostCopyTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/HostCopyTests.cpp
@@ -72,15 +72,15 @@ namespace
   {
     // first, construct a BasisValues object with scalar tensor data
     
-    using ExecutionSpace = Kokkos::DefaultExecutionSpace;
+    using DeviceType = DefaultTestDeviceType;
     using Scalar = double;
     const double value = 3.0;
-    Data<Scalar,ExecutionSpace> data(value, Kokkos::Array<int,2>{1,1}); // (F,P)
+    Data<Scalar,DeviceType> data(value, Kokkos::Array<int,2>{1,1}); // (F,P)
     
-    std::vector< Data<Scalar,ExecutionSpace> > tensorComponents {data, data};
-    TensorData<Scalar,ExecutionSpace> tensorData(tensorComponents);
+    std::vector< Data<Scalar,DeviceType> > tensorComponents {data, data};
+    TensorData<Scalar,DeviceType> tensorData(tensorComponents);
     
-    BasisValues<Scalar,ExecutionSpace> basisValues(tensorData);
+    BasisValues<Scalar,DeviceType> basisValues(tensorData);
     
     using HostExecSpace = Kokkos::HostSpace::execution_space;
     BasisValues<Scalar,HostExecSpace> basisValuesHost(basisValues);
@@ -88,13 +88,13 @@ namespace
     TEST_EQUALITY(value*value, basisValuesHost(0,0));
     
     // now, construct BasisValues with vector data
-    TensorData<Scalar,ExecutionSpace> emptyTensorData; // represents 0 in the vector
-    std::vector< TensorData<Scalar,ExecutionSpace> > vectorComponents { emptyTensorData, tensorData };
-    std::vector< std::vector< TensorData<Scalar,ExecutionSpace> > > families { vectorComponents };
+    TensorData<Scalar,DeviceType> emptyTensorData; // represents 0 in the vector
+    std::vector< TensorData<Scalar,DeviceType> > vectorComponents { emptyTensorData, tensorData };
+    std::vector< std::vector< TensorData<Scalar,DeviceType> > > families { vectorComponents };
     
-    VectorData<Scalar,ExecutionSpace> vectorData(families);
+    VectorData<Scalar,DeviceType> vectorData(families);
     
-    basisValues      = BasisValues<Scalar,ExecutionSpace>(vectorData);
+    basisValues      = BasisValues<Scalar,DeviceType>(vectorData);
     basisValuesHost  = BasisValues<Scalar,HostExecSpace>(basisValues);
     
     TEST_EQUALITY(0.0,           basisValuesHost(0,0,0) ); // zero first component
@@ -103,10 +103,10 @@ namespace
 
   TEUCHOS_UNIT_TEST(HostCopy, Data)
   {
-    using ExecutionSpace = Kokkos::DefaultExecutionSpace;
+    using DeviceType = DefaultTestDeviceType;
     using Scalar = double;
     const double value = 3.0;
-    Data<Scalar,ExecutionSpace> data(value, Kokkos::Array<int,1>{1});
+    Data<Scalar,DeviceType> data(value, Kokkos::Array<int,1>{1});
     
     using HostExecSpace = Kokkos::HostSpace::execution_space;
     Data<Scalar,HostExecSpace> dataHost(data);
@@ -114,7 +114,7 @@ namespace
     TEST_EQUALITY(value, dataHost(0));
     
     // now, test that the host-copy of an invalid data object is invalid, too
-    data = Data<Scalar,ExecutionSpace>(); // empty/invalid Data
+    data = Data<Scalar,DeviceType>(); // empty/invalid Data
     dataHost = Data<Scalar,HostExecSpace>(data);
 
     TEST_EQUALITY(data.isValid(), dataHost.isValid());
@@ -122,13 +122,13 @@ namespace
 
   TEUCHOS_UNIT_TEST(HostCopy, TensorData)
   {
-    using ExecutionSpace = Kokkos::DefaultExecutionSpace;
+    using DeviceType = DefaultTestDeviceType;
     using Scalar = double;
     const double value = 3.0;
-    Data<Scalar,ExecutionSpace> data(value, Kokkos::Array<int,1>{1});
+    Data<Scalar,DeviceType> data(value, Kokkos::Array<int,1>{1});
     
-    std::vector< Data<Scalar,ExecutionSpace> > tensorComponents {data, data};
-    TensorData<Scalar,ExecutionSpace> tensorData(tensorComponents);
+    std::vector< Data<Scalar,DeviceType> > tensorComponents {data, data};
+    TensorData<Scalar,DeviceType> tensorData(tensorComponents);
     
     using HostExecSpace = Kokkos::HostSpace::execution_space;
     TensorData<Scalar,HostExecSpace> tensorDataHost(tensorData);
@@ -136,7 +136,7 @@ namespace
     TEST_EQUALITY(value*value, tensorDataHost(0));
 
     // now, test that the host-copy of an invalid TensorData object is invalid, too
-    tensorData = TensorData<Scalar,ExecutionSpace>(); // empty/invalid TensorData
+    tensorData = TensorData<Scalar,DeviceType>(); // empty/invalid TensorData
     tensorDataHost = TensorData<Scalar,HostExecSpace>(tensorData);
 
     TEST_EQUALITY(tensorData.isValid(), tensorDataHost.isValid());
@@ -144,25 +144,30 @@ namespace
 
   TEUCHOS_UNIT_TEST(HostCopy, TensorPoints)
   {
-    using ExecutionSpace = Kokkos::DefaultExecutionSpace;
+    using DeviceType = DefaultTestDeviceType;
     using HostExecSpace = Kokkos::HostSpace::execution_space;
     using PointScalar = double;
     using WeightScalar = double;
     DefaultCubatureFactory cub_factory;
+    using CubatureType   = Cubature<DeviceType,PointScalar,WeightScalar>;
+    using PointViewType  = typename CubatureType::PointViewTypeAllocatable;
+    using WeightViewType = typename CubatureType::WeightViewTypeAllocatable;
+    
     shards::CellTopology cellTopo = shards::CellTopology(shards::getCellTopologyData<shards::Quadrilateral<> >());
     auto cellTopoKey = cellTopo.getKey();
     const int quadratureDegree = 3;
-    auto quadrature = cub_factory.create<ExecutionSpace, PointScalar, WeightScalar>(cellTopoKey, quadratureDegree);
+    auto quadrature = cub_factory.create<DeviceType, PointScalar, WeightScalar>(cellTopoKey, quadratureDegree);
     ordinal_type numRefPoints = quadrature->getNumPoints();
     const int spaceDim = cellTopo.getDimension();
     ViewType<PointScalar> points = ViewType<PointScalar>("quadrature points ref cell", numRefPoints, spaceDim);
     ViewType<WeightScalar> weights = ViewType<WeightScalar>("quadrature weights ref cell", numRefPoints);
     quadrature->getCubature(points, weights);
     
-    TensorPoints<PointScalar,ExecutionSpace> tensorPoints;
-    TensorData<WeightScalar,ExecutionSpace>  tensorWeights;
     
-    using CubatureTensorType = CubatureTensor<ExecutionSpace,PointScalar,WeightScalar>;
+    TensorPoints<PointScalar,DeviceType> tensorPoints;
+    TensorData<WeightScalar,DeviceType>  tensorWeights;
+    
+    using CubatureTensorType = CubatureTensor<DeviceType,PointScalar,WeightScalar>;
     CubatureTensorType* tensorQuadrature = dynamic_cast<CubatureTensorType*>(quadrature.get());
 
     TEST_ASSERT(tensorQuadrature != NULL);
@@ -191,20 +196,20 @@ namespace
 
   TEUCHOS_UNIT_TEST(HostCopy, TransformedVectorData)
   {
-    using ExecutionSpace = Kokkos::DefaultExecutionSpace;
+    using DeviceType = DefaultTestDeviceType;
     using Scalar = double;
     const double value = 3.0;
-    Data<Scalar,ExecutionSpace> data(value, Kokkos::Array<int,2>{1,1}); // F,P (but just 1 for each, here)
+    Data<Scalar,DeviceType> data(value, Kokkos::Array<int,2>{1,1}); // F,P (but just 1 for each, here)
     
-    std::vector< Data<Scalar,ExecutionSpace> > tensorComponents {data, data};
-    TensorData<Scalar,ExecutionSpace> tensorData(tensorComponents);
+    std::vector< Data<Scalar,DeviceType> > tensorComponents {data, data};
+    TensorData<Scalar,DeviceType> tensorData(tensorComponents);
 
     // one family with vector entries of form (0, value*value)
-    TensorData<Scalar,ExecutionSpace> emptyTensorData; // represents 0 in the vector
-    std::vector< TensorData<Scalar,ExecutionSpace> > vectorComponents { emptyTensorData, tensorData };
-    std::vector< std::vector< TensorData<Scalar,ExecutionSpace> > > families { vectorComponents };
+    TensorData<Scalar,DeviceType> emptyTensorData; // represents 0 in the vector
+    std::vector< TensorData<Scalar,DeviceType> > vectorComponents { emptyTensorData, tensorData };
+    std::vector< std::vector< TensorData<Scalar,DeviceType> > > families { vectorComponents };
     
-    VectorData<Scalar,ExecutionSpace> vectorData(families);
+    VectorData<Scalar,DeviceType> vectorData(families);
 
     // set up a simple diagonal scaling
     const double scaling = 0.1;
@@ -215,9 +220,9 @@ namespace
     Kokkos::Array<int,7> extents {1,1,spaceDim,spaceDim,1,1,1};
     Kokkos::Array<DataVariationType,7> variationTypes {CONSTANT,CONSTANT,BLOCK_PLUS_DIAGONAL,BLOCK_PLUS_DIAGONAL,CONSTANT,CONSTANT,CONSTANT};
     const int blockPlusDiagonalLastNonDiagonal = -1; // only diagonal
-    Data<Scalar,ExecutionSpace> transform(scalingView,rank,extents,variationTypes,blockPlusDiagonalLastNonDiagonal);
+    Data<Scalar,DeviceType> transform(scalingView,rank,extents,variationTypes,blockPlusDiagonalLastNonDiagonal);
     
-    TransformedVectorData<Scalar,ExecutionSpace> transformedVectorData(transform,vectorData);
+    TransformedVectorData<Scalar,DeviceType> transformedVectorData(transform,vectorData);
     
     using HostExecSpace = Kokkos::HostSpace::execution_space;
     TransformedVectorData<Scalar,HostExecSpace> transformedVectorDataHost(transformedVectorData);
@@ -235,19 +240,19 @@ namespace
 
   TEUCHOS_UNIT_TEST(HostCopy, VectorData)
   {
-    using ExecutionSpace = Kokkos::DefaultExecutionSpace;
+    using DeviceType = DefaultTestDeviceType;
     using Scalar = double;
     const double value = 3.0;
-    Data<Scalar,ExecutionSpace> data(value, Kokkos::Array<int,2>{1,1}); // F,P (but just 1 for each, here)
+    Data<Scalar,DeviceType> data(value, Kokkos::Array<int,2>{1,1}); // F,P (but just 1 for each, here)
     
-    std::vector< Data<Scalar,ExecutionSpace> > tensorComponents {data, data};
-    TensorData<Scalar,ExecutionSpace> tensorData(tensorComponents);
+    std::vector< Data<Scalar,DeviceType> > tensorComponents {data, data};
+    TensorData<Scalar,DeviceType> tensorData(tensorComponents);
     
-    TensorData<Scalar,ExecutionSpace> emptyTensorData; // represents 0 in the vector
-    std::vector< TensorData<Scalar,ExecutionSpace> > vectorComponents { emptyTensorData, tensorData };
-    std::vector< std::vector< TensorData<Scalar,ExecutionSpace> > > families { vectorComponents };
+    TensorData<Scalar,DeviceType> emptyTensorData; // represents 0 in the vector
+    std::vector< TensorData<Scalar,DeviceType> > vectorComponents { emptyTensorData, tensorData };
+    std::vector< std::vector< TensorData<Scalar,DeviceType> > > families { vectorComponents };
     
-    VectorData<Scalar,ExecutionSpace> vectorData(families);
+    VectorData<Scalar,DeviceType> vectorData(families);
     
     using HostExecSpace = Kokkos::HostSpace::execution_space;
     VectorData<Scalar,HostExecSpace> vectorDataHost(vectorData);

--- a/packages/intrepid2/unit-test/MonolithicExecutable/HostCopyTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/HostCopyTests.cpp
@@ -159,10 +159,9 @@ namespace
     auto quadrature = cub_factory.create<DeviceType, PointScalar, WeightScalar>(cellTopoKey, quadratureDegree);
     ordinal_type numRefPoints = quadrature->getNumPoints();
     const int spaceDim = cellTopo.getDimension();
-    ViewType<PointScalar> points = ViewType<PointScalar>("quadrature points ref cell", numRefPoints, spaceDim);
-    ViewType<WeightScalar> weights = ViewType<WeightScalar>("quadrature weights ref cell", numRefPoints);
+    auto points = getView<PointScalar,DeviceType>("quadrature points ref cell", numRefPoints, spaceDim);
+    auto weights = getView<WeightScalar,DeviceType>("quadrature weights ref cell", numRefPoints);
     quadrature->getCubature(points, weights);
-    
     
     TensorPoints<PointScalar,DeviceType> tensorPoints;
     TensorData<WeightScalar,DeviceType>  tensorWeights;
@@ -213,7 +212,7 @@ namespace
 
     // set up a simple diagonal scaling
     const double scaling = 0.1;
-    ViewType<Scalar> scalingView("scaling", 2);
+    ViewType<Scalar,DeviceType> scalingView("scaling", 2);
     Kokkos::deep_copy(scalingView, scaling);
     const int rank = 4; // (C,P,D,D)
     const int spaceDim = 2;

--- a/packages/intrepid2/unit-test/MonolithicExecutable/IntegratedJacobiTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/IntegratedJacobiTests.cpp
@@ -87,15 +87,17 @@ namespace
         {
           integratedJacobiValues(integratedJacobiView, alpha, polyOrder, x, t);
         });
-
+        
         Kokkos::fence();
+        auto integratedJacobiViewHost = getHostCopy(integratedJacobiView);
+        
         for (int i=1; i<=polyOrder; i++)
         {
           if ( abs(integratedJacobiView(i)) > tol)
           {
             success = false;
             out << "for alpha = " << alpha << ", t = " << t << ", integrated Jacobi for polyOrder " << i;
-            out << " at x=0 is not zero (it is " << integratedJacobiView(i) << ")\n";
+            out << " at x=0 is not zero (it is " << integratedJacobiViewHost(i) << ")\n";
           }
         }
       }
@@ -125,13 +127,15 @@ namespace
         });
         
         Kokkos::fence();
+        
+        auto integratedJacobiViewHost = getHostCopy(integratedJacobiView);
         const int i = 2;
-        double diff = integratedJacobiView(i) - expected_value;
+        double diff = integratedJacobiViewHost(i) - expected_value;
         if ( abs(diff) > tol)
         {
           success = false;
           out << "for alpha = " << alpha << ", t = " << t << ", integrated Jacobi for polyOrder " << i;
-          out << " at x=" << x << " is not x^2 - x * t (" << expected_value << "); instead, it is " << integratedJacobiView(i);
+          out << " at x=" << x << " is not x^2 - x * t (" << expected_value << "); instead, it is " << integratedJacobiViewHost(i);
           out << ", a difference of " << abs(diff) << ")\n";
         }
       }

--- a/packages/intrepid2/unit-test/MonolithicExecutable/IntegratedJacobiTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/IntegratedJacobiTests.cpp
@@ -93,7 +93,7 @@ namespace
         
         for (int i=1; i<=polyOrder; i++)
         {
-          if ( abs(integratedJacobiView(i)) > tol)
+          if ( abs(integratedJacobiViewHost(i)) > tol)
           {
             success = false;
             out << "for alpha = " << alpha << ", t = " << t << ", integrated Jacobi for polyOrder " << i;

--- a/packages/intrepid2/unit-test/MonolithicExecutable/IntegratedJacobiTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/IntegratedJacobiTests.cpp
@@ -63,11 +63,14 @@ namespace
   std::vector<double> alpha_values = {{0.0, 0.2, 0.4, 0.6, 0.8, 1.0}};
   std::vector<double> t_values = {{0.0, 0.2, 0.4, 0.6, 0.8, 1.0}};
   std::vector<double> x_values = {{-1.0,-0.5,-1.0/3.0,0.0,1.0/3.0,0.50,1.0}};
+
+  using DeviceType = DefaultTestDeviceType;
+  using ExecutionSpace = typename DeviceType::execution_space;
   
   void testIntegratedJacobiIsZeroAtZero(const int polyOrder, const double tol, Teuchos::FancyOStream &out, bool &success)
   {
     // for all alpha, t, integrated jacobi should evaluate to 0 at 0.
-    Kokkos::View<double*> integratedJacobiView("integrated jacobi values",polyOrder+1);
+    Kokkos::View<double*,DeviceType> integratedJacobiView("integrated jacobi values",polyOrder+1);
     
     using Intrepid2::Polynomials::integratedJacobiValues;
     using Intrepid2::Polynomials::shiftedScaledJacobiValues;
@@ -79,7 +82,8 @@ namespace
       for (auto t : t_values)
       {
         // wrap invocation in parallel_for just to ensure execution on device (for CUDA)
-        Kokkos::parallel_for(1, KOKKOS_LAMBDA(const int dummy_index)
+        auto policy = Kokkos::RangePolicy<>(ExecutionSpace(),0,1);
+        Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const int dummy_index)
         {
           integratedJacobiValues(integratedJacobiView, alpha, polyOrder, x, t);
         });
@@ -102,7 +106,7 @@ namespace
   {
     // for alpha=0, integrated jacobi j=2 should be x^2 - x*t
     const int polyOrder = 2;
-    Kokkos::View<double*> integratedJacobiView("integrated jacobi values",polyOrder+1);
+    Kokkos::View<double*,DeviceType> integratedJacobiView("integrated jacobi values",polyOrder+1);
     
     using Intrepid2::Polynomials::integratedJacobiValues;
     
@@ -114,7 +118,8 @@ namespace
       {
         double expected_value = x * x - x * t;
         // wrap invocation in parallel_for just to ensure execution on device (for CUDA)
-        Kokkos::parallel_for(1, KOKKOS_LAMBDA(const int dummy_index)
+        auto policy = Kokkos::RangePolicy<>(ExecutionSpace(),0,1);
+        Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const int dummy_index)
         {
           integratedJacobiValues(integratedJacobiView, alpha, polyOrder, x, t);
         });
@@ -135,9 +140,9 @@ namespace
   
   void testIntegratedJacobiTwoPathsMatch(const int polyOrder, const double tol, Teuchos::FancyOStream &out, bool &success)
   {
-    Kokkos::View<double*> jacobiView("jacobi values",polyOrder+1);
-    Kokkos::View<double*> integratedJacobiViewSecondPath("integrated jacobi values (second path)",polyOrder+1);
-    Kokkos::View<double*> integratedJacobiView("integrated jacobi values",polyOrder+1);
+    Kokkos::View<double*,DeviceType> jacobiView("jacobi values",polyOrder+1);
+    Kokkos::View<double*,DeviceType> integratedJacobiViewSecondPath("integrated jacobi values (second path)",polyOrder+1);
+    Kokkos::View<double*,DeviceType> integratedJacobiView("integrated jacobi values",polyOrder+1);
 
     for (auto alpha : alpha_values)
     {
@@ -149,7 +154,8 @@ namespace
           using Intrepid2::Polynomials::shiftedScaledJacobiValues;
           
           // wrap invocation in parallel_for just to ensure execution on device (for CUDA)
-          Kokkos::parallel_for(1, KOKKOS_LAMBDA(const int dummy_index)
+          auto policy = Kokkos::RangePolicy<>(ExecutionSpace(),0,1);
+          Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const int dummy_index)
           {
             shiftedScaledJacobiValues(jacobiView, alpha, polyOrder, x, t);
             integratedJacobiValues(integratedJacobiView, alpha, polyOrder, x, t);
@@ -181,9 +187,9 @@ namespace
   
   void testIntegratedJacobi_dtTwoPathsMatch(const int polyOrder, const double tol, Teuchos::FancyOStream &out, bool &success)
   {
-    Kokkos::View<double*> jacobiView("jacobi values",polyOrder+1);
-    Kokkos::View<double*> integratedJacobiView_dt("d/dt(integrated jacobi) values",polyOrder+1);
-    Kokkos::View<double*> secondPathIntegratedJacobiView_dt("d/dt(integrated jacobi) values (second path)",polyOrder+1);
+    Kokkos::View<double*,DeviceType> jacobiView("jacobi values",polyOrder+1);
+    Kokkos::View<double*,DeviceType> integratedJacobiView_dt("d/dt(integrated jacobi) values",polyOrder+1);
+    Kokkos::View<double*,DeviceType> secondPathIntegratedJacobiView_dt("d/dt(integrated jacobi) values (second path)",polyOrder+1);
     
     for (auto alpha : alpha_values)
     {
@@ -195,7 +201,8 @@ namespace
           using Intrepid2::Polynomials::shiftedScaledJacobiValues;
           
           // wrap invocation in parallel_for just to ensure execution on device (for CUDA)
-          Kokkos::parallel_for(1, KOKKOS_LAMBDA(const int dummy_index)
+          auto policy = Kokkos::RangePolicy<>(ExecutionSpace(),0,1);
+          Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const int dummy_index)
           {
             shiftedScaledJacobiValues(jacobiView, alpha, polyOrder, x, t);
             integratedJacobiValues_dt(integratedJacobiView_dt, alpha, polyOrder, x, t);

--- a/packages/intrepid2/unit-test/MonolithicExecutable/IntegratedLegendreTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/IntegratedLegendreTests.cpp
@@ -61,12 +61,15 @@ namespace
   // x and t values used across these tests
   std::vector<double> t_values = {{0.0, 0.2, 0.4, 0.6, 0.8, 1.0}};
   std::vector<double> x_values = {{-1.0,-0.5,-1.0/3.0,0.0,1.0/3.0,0.50,1.0}};
+
+  using DeviceType = DefaultTestDeviceType;
+  using ExecutionSpace = typename DeviceType::execution_space;
   
   void testIntegratedLegendreTwoPathsMatch(const int polyOrder, const double tol, Teuchos::FancyOStream &out, bool &success)
   {
-    Kokkos::View<double*> integrated_legendre_values("integrated legendre values",polyOrder+1);
-    Kokkos::View<double*> shifted_scaled_legendre_values("shifted scaled legendre values",polyOrder+1);
-    Kokkos::View<double*> integrated_legendre_values_second_path("integrated legendre values (second path)",polyOrder+1);
+    Kokkos::View<double*,DeviceType> integrated_legendre_values("integrated legendre values",polyOrder+1);
+    Kokkos::View<double*,DeviceType> shifted_scaled_legendre_values("shifted scaled legendre values",polyOrder+1);
+    Kokkos::View<double*,DeviceType> integrated_legendre_values_second_path("integrated legendre values (second path)",polyOrder+1);
     
     for (auto x : x_values)
     {
@@ -75,8 +78,9 @@ namespace
         using Intrepid2::Polynomials::shiftedScaledIntegratedLegendreValues;
         using Intrepid2::Polynomials::shiftedScaledLegendreValues;
         
-        // wrap polynomial invocations in parallel_for just to ensure execution on device (for CUDA)
-        Kokkos::parallel_for(1, KOKKOS_LAMBDA(const int dummy_index)
+        // wrap invocation in parallel_for just to ensure execution on device (for CUDA)
+        auto policy = Kokkos::RangePolicy<>(ExecutionSpace(),0,1);
+        Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const int dummy_index)
         {
           shiftedScaledIntegratedLegendreValues(integrated_legendre_values, polyOrder, x, t);
           shiftedScaledLegendreValues(shifted_scaled_legendre_values, polyOrder, x, t);
@@ -108,9 +112,9 @@ namespace
   
   void testIntegratedLegendre_dtTwoPathsMatch(const int polyOrder, const double tol, Teuchos::FancyOStream &out, bool &success)
   {
-    Kokkos::View<double*> integrated_legendre_values_dt("d/dt(integrated legendre) values",polyOrder+1);
-    Kokkos::View<double*> shifted_scaled_legendre_values("shifted scaled legendre values",polyOrder+1);
-    Kokkos::View<double*> integrated_legendre_values_dt_second_path("d/dt(integrated legendre) values (second path)",polyOrder+1);
+    Kokkos::View<double*,DeviceType> integrated_legendre_values_dt("d/dt(integrated legendre) values",polyOrder+1);
+    Kokkos::View<double*,DeviceType> shifted_scaled_legendre_values("shifted scaled legendre values",polyOrder+1);
+    Kokkos::View<double*,DeviceType> integrated_legendre_values_dt_second_path("d/dt(integrated legendre) values (second path)",polyOrder+1);
     
     for (auto x : x_values)
     {
@@ -119,8 +123,9 @@ namespace
         using Intrepid2::Polynomials::shiftedScaledIntegratedLegendreValues_dt;
         using Intrepid2::Polynomials::shiftedScaledLegendreValues;
         
-        // wrap polynomial invocations in parallel_for just to ensure execution on device (for CUDA)
-        Kokkos::parallel_for(1, KOKKOS_LAMBDA(const int dummy_index)
+        // wrap invocation in parallel_for just to ensure execution on device (for CUDA)
+        auto policy = Kokkos::RangePolicy<>(ExecutionSpace(),0,1);
+        Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const int dummy_index)
         {
           shiftedScaledIntegratedLegendreValues_dt(integrated_legendre_values_dt, polyOrder, x, t);
           shiftedScaledLegendreValues(shifted_scaled_legendre_values, polyOrder, x, t);
@@ -151,8 +156,8 @@ namespace
   
   void testIntegratedLegendreMatchesFormula(const int polyOrder, const double tol, Teuchos::FancyOStream &out, bool &success)
   {
-    Kokkos::View<double*> integrated_legendre_values("integrated legendre values",polyOrder+1);
-    Kokkos::View<double*> shifted_scaled_legendre_values("shifted scaled legendre values",polyOrder+1);
+    Kokkos::View<double*,DeviceType> integrated_legendre_values("integrated legendre values",polyOrder+1);
+    Kokkos::View<double*,DeviceType> shifted_scaled_legendre_values("shifted scaled legendre values",polyOrder+1);
     
     for (auto x : x_values)
     {
@@ -161,8 +166,9 @@ namespace
         using Intrepid2::Polynomials::shiftedScaledIntegratedLegendreValues;
         using Intrepid2::Polynomials::shiftedScaledLegendreValues;
         
-        // wrap polynomial invocations in parallel_for just to ensure execution on device (for CUDA)
-        Kokkos::parallel_for(1, KOKKOS_LAMBDA(const int dummy_index)
+        // wrap invocation in parallel_for just to ensure execution on device (for CUDA)
+        auto policy = Kokkos::RangePolicy<>(ExecutionSpace(),0,1);
+        Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const int dummy_index)
         {
           shiftedScaledIntegratedLegendreValues(integrated_legendre_values, polyOrder, x, t);
           shiftedScaledLegendreValues(shifted_scaled_legendre_values, polyOrder, x, t);
@@ -216,7 +222,7 @@ namespace
   //{
   //  bool success = true;
   //
-  //  Kokkos::View<double*> integrated_legendre_values("integrated legendre values",polyOrder+1);
+  //  Kokkos::View<double*,DeviceType> integrated_legendre_values("integrated legendre values",polyOrder+1);
   //
   //  using Intrepid2::PolyLib::integratedLegendreValues;
   //  using Intrepid2::PolyLib::shiftedScaledIntegratedLegendreValues;
@@ -224,7 +230,7 @@ namespace
   //
   //  integratedLegendreValues(integrated_legendre_values, polyOrder, x);
   //
-  //  Kokkos::View<double*> shifted_scaled_integrated_legendre_values("shifted scaled integrated legendre values",polyOrder+1);
+  //  Kokkos::View<double*,DeviceType> shifted_scaled_integrated_legendre_values("shifted scaled integrated legendre values",polyOrder+1);
   //  using Intrepid2::PolyLib::shiftedScaledIntegratedLegendreValues;
   //
   //  const double x_scaled = (x + 1.0) / 2.0;

--- a/packages/intrepid2/unit-test/MonolithicExecutable/ProjectedGeometryTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/ProjectedGeometryTests.cpp
@@ -64,12 +64,12 @@ namespace
 {
   using namespace Intrepid2;
 
-  template<typename PointScalar, typename ExecutionSpace>
+  template<typename PointScalar, typename DeviceType>
   void testCircularGeometryProjectionConvergesInP(int meshWidth, Teuchos::FancyOStream &out, bool &success)
   {
     constexpr int spaceDim = 2;
-    using BasisFamily = DerivedNodalBasisFamily<ExecutionSpace,PointScalar,PointScalar>;
-    using ProjectedGeometry = ProjectedGeometry<spaceDim,PointScalar,ExecutionSpace>;
+    using BasisFamily = DerivedNodalBasisFamily<DeviceType,PointScalar,PointScalar>;
+    using ProjectedGeometry = ProjectedGeometry<spaceDim,PointScalar,DeviceType>;
     
     constexpr PointScalar R = 1.0; // unit circle centered at origin
     constexpr PointScalar exactArea = M_PI * R * R;
@@ -89,12 +89,12 @@ namespace
       numCells *= meshWidth;
     }
     
-    CellGeometry<PointScalar, spaceDim> flatCellGeometry(origin,extent,cellCount);
+    CellGeometry<PointScalar, spaceDim, DeviceType> flatCellGeometry(origin,extent,cellCount);
     shards::CellTopology cellTopo = flatCellGeometry.cellTopology();
     
-    auto cubature = Intrepid2::DefaultCubatureFactory::create<ExecutionSpace>(cellTopo,Intrepid2::Parameters::MaxOrder);
+    auto cubature = Intrepid2::DefaultCubatureFactory::create<DeviceType>(cellTopo,Intrepid2::Parameters::MaxOrder);
     auto cubatureWeights = cubature->allocateCubatureWeights();
-    TensorPoints<PointScalar,ExecutionSpace> cubaturePoints  = cubature->allocateCubaturePoints();
+    TensorPoints<PointScalar,DeviceType> cubaturePoints  = cubature->allocateCubaturePoints();
     cubature->getCubature(cubaturePoints, cubatureWeights);
     
     const int numPoints = cubaturePoints.extent_int(0);
@@ -106,14 +106,14 @@ namespace
       
       const int nodesPerCell = basisForNodes->getCardinality();
       
-      ViewType<PointScalar> projectedNodes("projected nodes", numCells, nodesPerCell, spaceDim);
+      ViewType2T<PointScalar,DeviceType> projectedNodes("projected nodes", numCells, nodesPerCell, spaceDim);
       
       ProjectedGeometry::projectOntoHGRADBasis(projectedNodes, basisForNodes, flatCellGeometry, circularGeometry, circularGeometry);
 
-      CellGeometry<PointScalar, spaceDim> projectedGeometry(basisForNodes,projectedNodes);
+      CellGeometry<PointScalar, spaceDim, DeviceType> projectedGeometry(basisForNodes,projectedNodes);
 
       auto jacobian = projectedGeometry.allocateJacobianData(cubaturePoints);
-      auto jacobianDet = CellTools<ExecutionSpace>::allocateJacobianDet(jacobian);
+      auto jacobianDet = CellTools<DeviceType>::allocateJacobianDet(jacobian);
       
       // sanity checks on the allocations:
       TEST_EQUALITY(numCells,  jacobian.extent_int(0));
@@ -125,12 +125,13 @@ namespace
       
       auto refData = projectedGeometry.getJacobianRefData(cubaturePoints);
       projectedGeometry.setJacobian(jacobian, cubaturePoints, refData);
-      CellTools<ExecutionSpace>::setJacobianDet(jacobianDet, jacobian);
+      CellTools<DeviceType>::setJacobianDet(jacobianDet, jacobian);
       
       auto cellMeasure = projectedGeometry.allocateCellMeasure(jacobianDet, cubatureWeights);
       projectedGeometry.computeCellMeasure(cellMeasure, jacobianDet, cubatureWeights);
           
       PointScalar actualArea = 0;
+      using ExecutionSpace = typename DeviceType::execution_space;
       Kokkos::RangePolicy<ExecutionSpace > reducePolicy(0, numCells);
       Kokkos::parallel_reduce( reducePolicy,
       KOKKOS_LAMBDA( const int &cellOrdinal, PointScalar &reducedValue )
@@ -150,7 +151,7 @@ namespace
     }
   }
 
-  template<typename PointScalar, int spaceDim, typename ExecutionSpace>
+  template<typename PointScalar, int spaceDim, typename DeviceType>
   void testLinearGeometryIsExact(int meshWidth, const double &relTol, const double &absTol,
                                  Teuchos::FancyOStream &out, bool &success)
   {
@@ -165,7 +166,7 @@ namespace
       cellCount[d] = meshWidth;
     }
     
-    CellGeometry<PointScalar, spaceDim> flatCellGeometry(origin,extent,cellCount);
+    CellGeometry<PointScalar, spaceDim, DeviceType> flatCellGeometry(origin,extent,cellCount);
     auto linearBasis = flatCellGeometry.basisForNodes();
     
     ProjectedGeometryIdentityMap<PointScalar, spaceDim> exactGeometry;
@@ -179,14 +180,14 @@ namespace
     
     ViewType<PointScalar> projectedNodes("projected nodes", numCells, nodesPerCell, spaceDim);
     
-    using ProjectedGeometry = ProjectedGeometry<spaceDim,PointScalar,ExecutionSpace>;
+    using ProjectedGeometry = ProjectedGeometry<spaceDim,PointScalar,DeviceType>;
     ProjectedGeometry::projectOntoHGRADBasis(projectedNodes, linearBasis, flatCellGeometry, exactGeometry, exactGeometry);
     
     printFunctor3(projectedNodes, out, "projectedNodes");
     testFloatingEquality3(projectedNodes, flatCellGeometry, relTol, absTol, out, success, "projected geometry", "original CellGeometry");
   }
 
-  template<typename PointScalar, int spaceDim, typename ExecutionSpace>
+  template<typename PointScalar, int spaceDim, typename DeviceType>
   void testLinearGeometryIsExact(int meshWidth, int polyOrderForBasis, const double &relTol, const double &absTol,
                                  Teuchos::FancyOStream &out, bool &success)
   {
@@ -203,9 +204,9 @@ namespace
     
     CellGeometry<PointScalar, spaceDim> flatCellGeometry(origin,extent,cellCount);
     
-    using BasisPtr = Teuchos::RCP< Basis<ExecutionSpace,PointScalar,PointScalar> >;
+    using BasisPtr = Teuchos::RCP< Basis<DeviceType,PointScalar,PointScalar> >;
     
-    using BasisFamily = DerivedNodalBasisFamily<ExecutionSpace,PointScalar,PointScalar>;
+    using BasisFamily = DerivedNodalBasisFamily<DeviceType,PointScalar,PointScalar>;
     BasisPtr hgradBasisForProjection = getBasis<BasisFamily>(flatCellGeometry.cellTopology(), FUNCTION_SPACE_HGRAD, polyOrderForBasis);
     
     ProjectedGeometryIdentityMap<PointScalar, spaceDim> exactGeometry;
@@ -218,19 +219,19 @@ namespace
     const int nodesPerCell = hgradBasisForProjection->getCardinality();
     ViewType<PointScalar> projectedNodes("projected nodes", numCells, nodesPerCell, spaceDim);
     
-    using ProjectedGeometry = ProjectedGeometry<spaceDim,PointScalar,ExecutionSpace>;
+    using ProjectedGeometry = ProjectedGeometry<spaceDim,PointScalar,DeviceType>;
     ProjectedGeometry::projectOntoHGRADBasis(projectedNodes, hgradBasisForProjection, flatCellGeometry, exactGeometry, exactGeometry);
     
     auto cellTopo = flatCellGeometry.cellTopology();
     
     // get reference-element points at which we can evaluate the projected basis
     const int numNodesPerFlatCell = flatCellGeometry.numNodesPerCell();
-    ScalarView<PointScalar,ExecutionSpace> refCellNodes("ref cell nodes", numNodesPerFlatCell, spaceDim);
+    ScalarView<PointScalar,DeviceType> refCellNodes("ref cell nodes", numNodesPerFlatCell, spaceDim);
     
     for (int node=0; node<numNodesPerFlatCell; node++)
     {
       auto nodeSubview = Kokkos::subdynrankview(refCellNodes, node, Kokkos::ALL());
-      CellTools<ExecutionSpace>::getReferenceNode(nodeSubview, cellTopo, node);
+      CellTools<DeviceType>::getReferenceNode(nodeSubview, cellTopo, node);
     }
     
     auto hgradValuesAtNodes = hgradBasisForProjection->allocateOutputView(numNodesPerFlatCell);
@@ -238,6 +239,7 @@ namespace
 
     ViewType<PointScalar> evaluatedNodes("projected nodes evaluated on flat cell", numCells, numNodesPerFlatCell, spaceDim);
     
+    using ExecutionSpace = typename DeviceType::execution_space;
     auto policy = Kokkos::MDRangePolicy<ExecutionSpace,Kokkos::Rank<2>>({0,0},{numCells,numNodesPerFlatCell});
     Kokkos::parallel_for("evaluate projected nodes", policy,
     KOKKOS_LAMBDA (const int &cellOrdinal, const int &nodeOrdinalInFlatCell) {
@@ -259,10 +261,10 @@ namespace
     printFunctor3(evaluatedNodes, out, "evaluatedNodes");
     
     // need to use "classic" node ordering for the comparison below because the refCellNodes above use the classic node ordering
-    auto subdivisionStrategy = CellGeometry<PointScalar, spaceDim>::NO_SUBDIVISION;
-    auto nodeOrdering = CellGeometry<PointScalar, spaceDim>::HYPERCUBE_NODE_ORDER_CLASSIC_SHARDS;
+    auto subdivisionStrategy = CellGeometry<PointScalar, spaceDim, DeviceType>::NO_SUBDIVISION;
+    auto nodeOrdering = CellGeometry<PointScalar, spaceDim, DeviceType>::HYPERCUBE_NODE_ORDER_CLASSIC_SHARDS;
     
-    CellGeometry<PointScalar, spaceDim> flatCellGeometryClassic(origin,extent,cellCount, subdivisionStrategy, nodeOrdering);
+    CellGeometry<PointScalar, spaceDim, DeviceType> flatCellGeometryClassic(origin,extent,cellCount, subdivisionStrategy, nodeOrdering);
     
     testFloatingEquality3(evaluatedNodes, flatCellGeometryClassic, relTol, absTol, out, success, "projected geometry", "original CellGeometry");
   }
@@ -270,9 +272,9 @@ namespace
   TEUCHOS_UNIT_TEST( ProjectedGeometry, CircularGeometryConvergesInP_SingleCell )
   {
     using Scalar = double;
-    using ExecSpace = Kokkos::DefaultExecutionSpace;
+    using DeviceType = DefaultTestDeviceType;
     const int meshWidth = 1;
-    testCircularGeometryProjectionConvergesInP<Scalar, ExecSpace>(meshWidth, out, success);
+    testCircularGeometryProjectionConvergesInP<Scalar, DeviceType>(meshWidth, out, success);
   }
 
   TEUCHOS_UNIT_TEST( ProjectedGeometry, CircularGeometryConvergesInP_MultiCell )

--- a/packages/intrepid2/unit-test/MonolithicExecutable/ProjectedGeometryTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/ProjectedGeometryTests.cpp
@@ -106,7 +106,7 @@ namespace
       
       const int nodesPerCell = basisForNodes->getCardinality();
       
-      ViewType2T<PointScalar,DeviceType> projectedNodes("projected nodes", numCells, nodesPerCell, spaceDim);
+      ViewType<PointScalar,DeviceType> projectedNodes("projected nodes", numCells, nodesPerCell, spaceDim);
       
       ProjectedGeometry::projectOntoHGRADBasis(projectedNodes, basisForNodes, flatCellGeometry, circularGeometry, circularGeometry);
 
@@ -178,7 +178,7 @@ namespace
     }
     const int nodesPerCell = linearBasis->getCardinality();
     
-    ViewType<PointScalar> projectedNodes("projected nodes", numCells, nodesPerCell, spaceDim);
+    ViewType<PointScalar,DeviceType> projectedNodes("projected nodes", numCells, nodesPerCell, spaceDim);
     
     using ProjectedGeometry = ProjectedGeometry<spaceDim,PointScalar,DeviceType>;
     ProjectedGeometry::projectOntoHGRADBasis(projectedNodes, linearBasis, flatCellGeometry, exactGeometry, exactGeometry);
@@ -217,7 +217,7 @@ namespace
       numCells *= meshWidth;
     }
     const int nodesPerCell = hgradBasisForProjection->getCardinality();
-    ViewType<PointScalar> projectedNodes("projected nodes", numCells, nodesPerCell, spaceDim);
+    ViewType<PointScalar,DeviceType> projectedNodes("projected nodes", numCells, nodesPerCell, spaceDim);
     
     using ProjectedGeometry = ProjectedGeometry<spaceDim,PointScalar,DeviceType>;
     ProjectedGeometry::projectOntoHGRADBasis(projectedNodes, hgradBasisForProjection, flatCellGeometry, exactGeometry, exactGeometry);
@@ -237,7 +237,7 @@ namespace
     auto hgradValuesAtNodes = hgradBasisForProjection->allocateOutputView(numNodesPerFlatCell);
     hgradBasisForProjection->getValues(hgradValuesAtNodes, refCellNodes, OPERATOR_VALUE);
 
-    ViewType<PointScalar> evaluatedNodes("projected nodes evaluated on flat cell", numCells, numNodesPerFlatCell, spaceDim);
+    ViewType<PointScalar,DeviceType> evaluatedNodes("projected nodes evaluated on flat cell", numCells, numNodesPerFlatCell, spaceDim);
     
     using ExecutionSpace = typename DeviceType::execution_space;
     auto policy = Kokkos::MDRangePolicy<ExecutionSpace,Kokkos::Rank<2>>({0,0},{numCells,numNodesPerFlatCell});

--- a/packages/intrepid2/unit-test/MonolithicExecutable/StructuredIntegrationTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/StructuredIntegrationTests.cpp
@@ -162,7 +162,7 @@ void integrate_baseline_serial_host(Data<Scalar,DeviceType> integrals, const Tra
 }
 
 //! version that uses the classic Intrepid2 paths
-template<class Scalar, class PointScalar, int spaceDim, typename DeviceType = Kokkos::DefaultExecutionSpace>
+template<class Scalar, class PointScalar, int spaceDim, typename DeviceType>
 ScalarView<Scalar,DeviceType> performStandardQuadratureHypercube(int meshWidth, int polyOrder, int worksetSize)
 {
   using ExecutionSpace = typename DeviceType::execution_space;
@@ -194,8 +194,7 @@ ScalarView<Scalar,DeviceType> performStandardQuadratureHypercube(int meshWidth, 
   // local stiffness matrix:
   ScalarView<Scalar,DeviceType> cellStiffness("cell stiffness matrices",numCells,numFields,numFields);
   
-  using Kokkos::DefaultExecutionSpace;
-  auto cubature = Intrepid2::DefaultCubatureFactory::create<DefaultExecutionSpace>(cellTopo,polyOrder*2);
+  auto cubature = Intrepid2::DefaultCubatureFactory::create<DeviceType>(cellTopo,polyOrder*2);
   int numPoints = cubature->getNumPoints();
   ScalarView<PointScalar,DeviceType> cubaturePoints("cubature points",numPoints,spaceDim);
   ScalarView<double,DeviceType> cubatureWeights("cubature weights", numPoints);

--- a/packages/intrepid2/unit-test/MonolithicExecutable/StructuredIntegrationTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/StructuredIntegrationTests.cpp
@@ -166,7 +166,7 @@ template<class Scalar, class PointScalar, int spaceDim, typename DeviceType>
 ScalarView<Scalar,DeviceType> performStandardQuadratureHypercube(int meshWidth, int polyOrder, int worksetSize)
 {
   using ExecutionSpace = typename DeviceType::execution_space;
-  using CellTools = Intrepid2::CellTools<ExecutionSpace>;
+  using CellTools = Intrepid2::CellTools<DeviceType>;
   using FunctionSpaceTools = Intrepid2::FunctionSpaceTools<ExecutionSpace>;
   
   using namespace std;

--- a/packages/intrepid2/unit-test/MonolithicExecutable/StructuredIntegrationTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/StructuredIntegrationTests.cpp
@@ -81,9 +81,9 @@ namespace
 
 //! version of integrate that performs a standard integration for affine meshes; does not take advantage of the tensor product structure at all
 //! this version can be used to verify correctness of other versions
-template<class Scalar, typename ExecSpaceType>
-void integrate_baseline_serial_host(Data<Scalar,ExecSpaceType> integrals, const TransformedVectorData<Scalar,ExecSpaceType> vectorDataLeft,
-                                    const TensorData<Scalar,ExecSpaceType> cellMeasures, const TransformedVectorData<Scalar,ExecSpaceType> vectorDataRight)
+template<class Scalar, typename DeviceType>
+void integrate_baseline_serial_host(Data<Scalar,DeviceType> integrals, const TransformedVectorData<Scalar,DeviceType> vectorDataLeft,
+                                    const TensorData<Scalar,DeviceType> cellMeasures, const TransformedVectorData<Scalar,DeviceType> vectorDataRight)
 {
   const int cellDataExtent = integrals.getDataExtent(0);
   const int numFieldsLeft  = vectorDataLeft.numFields();
@@ -162,11 +162,12 @@ void integrate_baseline_serial_host(Data<Scalar,ExecSpaceType> integrals, const 
 }
 
 //! version that uses the classic Intrepid2 paths
-template<class Scalar, class PointScalar, int spaceDim, typename ExecSpaceType = Kokkos::DefaultExecutionSpace>
-ScalarView<Scalar,ExecSpaceType> performStandardQuadratureHypercube(int meshWidth, int polyOrder, int worksetSize)
+template<class Scalar, class PointScalar, int spaceDim, typename DeviceType = Kokkos::DefaultExecutionSpace>
+ScalarView<Scalar,DeviceType> performStandardQuadratureHypercube(int meshWidth, int polyOrder, int worksetSize)
 {
-  using CellTools = Intrepid2::CellTools<Kokkos::DefaultExecutionSpace>;
-  using FunctionSpaceTools = Intrepid2::FunctionSpaceTools<Kokkos::DefaultExecutionSpace>;
+  using ExecutionSpace = typename DeviceType::execution_space;
+  using CellTools = Intrepid2::CellTools<ExecutionSpace>;
+  using FunctionSpaceTools = Intrepid2::FunctionSpaceTools<ExecutionSpace>;
   
   using namespace std;
   // dimensions of the returned view are (C,F,F)
@@ -191,30 +192,30 @@ ScalarView<Scalar,ExecSpaceType> performStandardQuadratureHypercube(int meshWidt
   if (worksetSize > numCells) worksetSize = numCells;
   
   // local stiffness matrix:
-  ScalarView<Scalar,ExecSpaceType> cellStiffness("cell stiffness matrices",numCells,numFields,numFields);
+  ScalarView<Scalar,DeviceType> cellStiffness("cell stiffness matrices",numCells,numFields,numFields);
   
   using Kokkos::DefaultExecutionSpace;
   auto cubature = Intrepid2::DefaultCubatureFactory::create<DefaultExecutionSpace>(cellTopo,polyOrder*2);
   int numPoints = cubature->getNumPoints();
-  ScalarView<PointScalar,ExecSpaceType> cubaturePoints("cubature points",numPoints,spaceDim);
-  ScalarView<double,ExecSpaceType> cubatureWeights("cubature weights", numPoints);
+  ScalarView<PointScalar,DeviceType> cubaturePoints("cubature points",numPoints,spaceDim);
+  ScalarView<double,DeviceType> cubatureWeights("cubature weights", numPoints);
   
   cubature->getCubature(cubaturePoints, cubatureWeights);
   
   // Allocate some intermediate containers
-  ScalarView<Scalar,ExecSpaceType> basisValues    ("basis values", numFields, numPoints );
-  ScalarView<Scalar,ExecSpaceType> basisGradValues("basis grad values", numFields, numPoints, spaceDim);
+  ScalarView<Scalar,DeviceType> basisValues    ("basis values", numFields, numPoints );
+  ScalarView<Scalar,DeviceType> basisGradValues("basis grad values", numFields, numPoints, spaceDim);
 
-  ScalarView<Scalar,ExecSpaceType> transformedGradValues("transformed grad values", worksetSize, numFields, numPoints, spaceDim);
-  ScalarView<Scalar,ExecSpaceType> transformedWeightedGradValues("transformed weighted grad values", worksetSize, numFields, numPoints, spaceDim);
+  ScalarView<Scalar,DeviceType> transformedGradValues("transformed grad values", worksetSize, numFields, numPoints, spaceDim);
+  ScalarView<Scalar,DeviceType> transformedWeightedGradValues("transformed weighted grad values", worksetSize, numFields, numPoints, spaceDim);
   
   basis->getValues(basisValues,     cubaturePoints, Intrepid2::OPERATOR_VALUE );
   basis->getValues(basisGradValues, cubaturePoints, Intrepid2::OPERATOR_GRAD  );
   
-  CellGeometry<PointScalar,spaceDim,ExecSpaceType> cellNodes = uniformCartesianMesh<PointScalar,spaceDim,ExecSpaceType>(1.0, meshWidth);
+  CellGeometry<PointScalar,spaceDim,DeviceType> cellNodes = uniformCartesianMesh<PointScalar,spaceDim,DeviceType>(1.0, meshWidth);
   
   const int numNodesPerCell = cellNodes.numNodesPerCell();
-  ScalarView<PointScalar,ExecSpaceType> expandedCellNodes("expanded cell nodes",numCells,numNodesPerCell,spaceDim);
+  ScalarView<PointScalar,DeviceType> expandedCellNodes("expanded cell nodes",numCells,numNodesPerCell,spaceDim);
   for (int cellOrdinal=0; cellOrdinal<numCells; cellOrdinal++)
   {
     for (int nodeOrdinal=0; nodeOrdinal<numNodesPerCell; nodeOrdinal++)
@@ -228,10 +229,10 @@ ScalarView<Scalar,ExecSpaceType> performStandardQuadratureHypercube(int meshWidt
   
   // goal here is to do a weighted Poisson; i.e. (f grad u, grad v) on each cell
 
-  ScalarView<Scalar,ExecSpaceType> cellMeasures("cell measures", worksetSize, numPoints);
-  ScalarView<Scalar,ExecSpaceType> jacobianDeterminant("jacobian determinant", worksetSize, numPoints);
-  ScalarView<Scalar,ExecSpaceType> jacobian("jacobian", worksetSize, numPoints, spaceDim, spaceDim);
-  ScalarView<Scalar,ExecSpaceType> jacobianInverse("jacobian inverse", worksetSize, numPoints, spaceDim, spaceDim);
+  ScalarView<Scalar,DeviceType> cellMeasures("cell measures", worksetSize, numPoints);
+  ScalarView<Scalar,DeviceType> jacobianDeterminant("jacobian determinant", worksetSize, numPoints);
+  ScalarView<Scalar,DeviceType> jacobian("jacobian", worksetSize, numPoints, spaceDim, spaceDim);
+  ScalarView<Scalar,DeviceType> jacobianInverse("jacobian inverse", worksetSize, numPoints, spaceDim, spaceDim);
 
   int cellOffset = 0;
   while (cellOffset < numCells)
@@ -265,15 +266,15 @@ ScalarView<Scalar,ExecSpaceType> performStandardQuadratureHypercube(int meshWidt
   return cellStiffness;
 }
 
-  template<class Scalar, typename ExecSpaceType>
-  void testIntegrateMatchesBaseline(const TransformedVectorData<Scalar,ExecSpaceType> vectorDataLeft,
-                                    const TensorData<Scalar,ExecSpaceType> cellMeasures, const TransformedVectorData<Scalar,ExecSpaceType> vectorDataRight,
+  template<class Scalar, typename DeviceType>
+  void testIntegrateMatchesBaseline(const TransformedVectorData<Scalar,DeviceType> vectorDataLeft,
+                                    const TensorData<Scalar,DeviceType> cellMeasures, const TransformedVectorData<Scalar,DeviceType> vectorDataRight,
                                     Teuchos::FancyOStream &out, bool &success)
   {
     const double relTol = 1e-12;
     const double absTol = 1e-12;
     
-    using IntegrationTools = Intrepid2::IntegrationTools<ExecSpaceType>;
+    using IntegrationTools = Intrepid2::IntegrationTools<DeviceType>;
     
     auto integralsBaseline  = IntegrationTools::allocateIntegralData(vectorDataLeft, cellMeasures, vectorDataRight);
     auto integralsIntegrate = IntegrationTools::allocateIntegralData(vectorDataLeft, cellMeasures, vectorDataRight);
@@ -319,12 +320,15 @@ ScalarView<Scalar,ExecSpaceType> performStandardQuadratureHypercube(int meshWidt
     const double absTol = 1e-12;
     
     using namespace std;
-    using FunctionSpaceTools = Intrepid2::FunctionSpaceTools<Kokkos::DefaultExecutionSpace>;
-    using IntegrationTools   = Intrepid2::IntegrationTools<Kokkos::DefaultExecutionSpace>;
+    using DeviceType = DefaultTestDeviceType;
+    using ExecutionSpace = typename DeviceType::execution_space;
+    
+    using FunctionSpaceTools = Intrepid2::FunctionSpaceTools<ExecutionSpace>; // TODO: once FunctionSpaceTools has proper DeviceType support, change the template argument here…
+    using IntegrationTools   = Intrepid2::IntegrationTools<DeviceType>;
     // dimensions of the returned view are (C,F,F)
     auto fs = Intrepid2::FUNCTION_SPACE_HGRAD;
     
-    auto lineBasis = Intrepid2::getLineBasis< Intrepid2::NodalBasisFamily<> >(fs, polyOrder);
+    auto lineBasis = Intrepid2::getLineBasis< Intrepid2::NodalBasisFamily<DeviceType> >(fs, polyOrder);
     
     int numFields_1D = lineBasis->getCardinality();
     
@@ -339,10 +343,8 @@ ScalarView<Scalar,ExecSpaceType> performStandardQuadratureHypercube(int meshWidt
     
     if (worksetSize > numCells) worksetSize = numCells;
     
-    using ExecSpaceType = Kokkos::DefaultExecutionSpace;
-    
     // local stiffness matrix:
-    ScalarView<Scalar,ExecSpaceType> cellStiffness("cell stiffness matrices",numCells,numFields,numFields);
+    ScalarView<Scalar,DeviceType> cellStiffness("cell stiffness matrices",numCells,numFields,numFields);
     
     shards::CellTopology lineTopo = shards::getCellTopologyData< shards::Line<> >();
     shards::CellTopology cellTopo;
@@ -350,16 +352,16 @@ ScalarView<Scalar,ExecSpaceType> performStandardQuadratureHypercube(int meshWidt
     else if (spaceDim == 2) cellTopo = shards::getCellTopologyData< shards::Quadrilateral<> >();
     else if (spaceDim == 3) cellTopo = shards::getCellTopologyData< shards::Hexahedron<>    >();
     
-    auto lineCubature = Intrepid2::DefaultCubatureFactory::create<ExecSpaceType>(lineTopo,polyOrder*2);
+    auto lineCubature = Intrepid2::DefaultCubatureFactory::create<DeviceType>(lineTopo,polyOrder*2);
     int numPoints_1D = lineCubature->getNumPoints();
-    ScalarView<PointScalar,ExecSpaceType> lineCubaturePoints("line cubature points",numPoints_1D,1);
-    ScalarView<double,ExecSpaceType> lineCubatureWeights("line cubature weights", numPoints_1D);
+    ScalarView<PointScalar,DeviceType> lineCubaturePoints("line cubature points",numPoints_1D,1);
+    ScalarView<double,DeviceType> lineCubatureWeights("line cubature weights", numPoints_1D);
     
     lineCubature->getCubature(lineCubaturePoints, lineCubatureWeights);
     
     // Allocate some intermediate containers
-    ScalarView<Scalar,ExecSpaceType> lineBasisValues    ("line basis values",      numFields_1D, numPoints_1D   );
-    ScalarView<Scalar,ExecSpaceType> lineBasisGradValues("line basis grad values", numFields_1D, numPoints_1D, 1);
+    ScalarView<Scalar,DeviceType> lineBasisValues    ("line basis values",      numFields_1D, numPoints_1D   );
+    ScalarView<Scalar,DeviceType> lineBasisGradValues("line basis grad values", numFields_1D, numPoints_1D, 1);
     
     // for now, we use 1D values to build up the 2D or 3D gradients
     // eventually, TensorBasis should offer a getValues() variant that returns tensor basis data
@@ -369,21 +371,21 @@ ScalarView<Scalar,ExecSpaceType> performStandardQuadratureHypercube(int meshWidt
     // drop the trivial space dimension in line gradient values:
     Kokkos::resize(lineBasisGradValues, numFields_1D, numPoints_1D);
       
-    Kokkos::Array<TensorData<Scalar,ExecSpaceType>, spaceDim> vectorComponents;
+    Kokkos::Array<TensorData<Scalar,DeviceType>, spaceDim> vectorComponents;
     
     for (int d=0; d<spaceDim; d++)
     {
-      Kokkos::Array<Data<Scalar,ExecSpaceType>, spaceDim> gradComponent_d;
+      Kokkos::Array<Data<Scalar,DeviceType>, spaceDim> gradComponent_d;
       for (int d2=0; d2<spaceDim; d2++)
       {
-        if (d2 == d) gradComponent_d[d2] = Data<Scalar,ExecSpaceType>(lineBasisGradValues);
-        else         gradComponent_d[d2] = Data<Scalar,ExecSpaceType>(lineBasisValues);
+        if (d2 == d) gradComponent_d[d2] = Data<Scalar,DeviceType>(lineBasisGradValues);
+        else         gradComponent_d[d2] = Data<Scalar,DeviceType>(lineBasisValues);
       }
-      vectorComponents[d] = TensorData<Scalar,ExecSpaceType>(gradComponent_d);
+      vectorComponents[d] = TensorData<Scalar,DeviceType>(gradComponent_d);
     }
-    VectorData<Scalar,ExecSpaceType> gradientValues(vectorComponents, false); // false: not axis-aligned
+    VectorData<Scalar,DeviceType> gradientValues(vectorComponents, false); // false: not axis-aligned
     
-    CellGeometry<PointScalar,spaceDim,ExecSpaceType> cellNodes = uniformCartesianMesh<PointScalar,spaceDim,ExecSpaceType>(1.0, meshWidth);
+    CellGeometry<PointScalar,spaceDim,DeviceType> cellNodes = uniformCartesianMesh<PointScalar,spaceDim,DeviceType>(1.0, meshWidth);
     
     if (useAffinePath)
     {
@@ -393,13 +395,13 @@ ScalarView<Scalar,ExecSpaceType> performStandardQuadratureHypercube(int meshWidt
     {
       // make a "generic" copy of cellNodes, one that uses the (C,N), (N,D) node specification.  This will not know that the geometry is affine, grid-aligned, or uniform.
       const bool copyAffineness = false; // want to go through the non-affine geometry path
-      CellGeometry<PointScalar,spaceDim,ExecSpaceType> nodalCellGeometry = getNodalCellGeometry(cellNodes, copyAffineness);
+      CellGeometry<PointScalar,spaceDim,DeviceType> nodalCellGeometry = getNodalCellGeometry(cellNodes, copyAffineness);
       
       cellNodes = nodalCellGeometry;
       out << "Testing non-affine path.\n";
     }
     
-    auto cubature = Intrepid2::DefaultCubatureFactory::create<ExecSpaceType>(cellTopo,polyOrder*2);
+    auto cubature = Intrepid2::DefaultCubatureFactory::create<DeviceType>(cellTopo,polyOrder*2);
     auto tensorCubatureWeights = cubature->allocateCubatureWeights();
     auto tensorCubaturePoints  = cubature->allocateCubaturePoints();
     
@@ -413,20 +415,21 @@ ScalarView<Scalar,ExecSpaceType> performStandardQuadratureHypercube(int meshWidt
       pointsPerCell *= numPoints_1D;
     }
     
-    Data<PointScalar,ExecSpaceType> jacobian = cellNodes.allocateJacobianData(tensorCubaturePoints);
-    Data<PointScalar,ExecSpaceType> jacobianDet = CellTools<ExecSpaceType>::allocateJacobianDet(jacobian);
-    Data<PointScalar,ExecSpaceType> jacobianInv = CellTools<ExecSpaceType>::allocateJacobianInv(jacobian);
+    Data<PointScalar,DeviceType> jacobian = cellNodes.allocateJacobianData(tensorCubaturePoints);
+    Data<PointScalar,DeviceType> jacobianDet = CellTools<DeviceType>::allocateJacobianDet(jacobian);
+    Data<PointScalar,DeviceType> jacobianInv = CellTools<DeviceType>::allocateJacobianInv(jacobian);
     
     auto refData = cellNodes.getJacobianRefData(tensorCubaturePoints);
     cellNodes.setJacobian(jacobian, tensorCubaturePoints, refData);
-    CellTools<ExecSpaceType>::setJacobianDet(jacobianDet, jacobian);
-    CellTools<ExecSpaceType>::setJacobianInv(jacobianInv, jacobian);
+    CellTools<DeviceType>::setJacobianDet(jacobianDet, jacobian);
+    CellTools<DeviceType>::setJacobianInv(jacobianInv, jacobian);
     
     // lazily-evaluated transformed gradient values:
-    auto transformedGradientValues = FunctionSpaceTools::getHGRADtransformGRAD(jacobianInv, gradientValues);
-    auto standardIntegrals = performStandardQuadratureHypercube<Scalar,PointScalar,spaceDim,ExecSpaceType>(meshWidth, polyOrder, worksetSize);
+    using FunctionSpaceToolsDT = ::Intrepid2::FunctionSpaceTools<DeviceType>; // TODO: once FunctionSpaceTools has proper DeviceType support, change the earlier FunctionSpaceTools typedef, and use it here…
+    auto transformedGradientValues = FunctionSpaceToolsDT::getHGRADtransformGRAD(jacobianInv, gradientValues);
+    auto standardIntegrals = performStandardQuadratureHypercube<Scalar,PointScalar,spaceDim,DeviceType>(meshWidth, polyOrder, worksetSize);
     
-    TensorData<PointScalar,ExecSpaceType> cellMeasures = cellNodes.allocateCellMeasure(jacobianDet, tensorCubatureWeights);
+    TensorData<PointScalar,DeviceType> cellMeasures = cellNodes.allocateCellMeasure(jacobianDet, tensorCubatureWeights);
     if (!cellNodes.affine())
     {
       // if cellNodes is not (known to be) affine, then cellMeasures should not have a separate first component (indicating the cell dimension is separated, thanks to point-invariant cell Jacobian determinant)
@@ -652,7 +655,7 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureUniformMesh_3D_p2_GeneralPat
 TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_AxisAlignedPath_Case1 )
 {
   using DataScalar  = double;
-  using ExecSpaceType = Kokkos::DefaultExecutionSpace;
+  using DeviceType = DefaultTestDeviceType;
   
   const int spaceDim = 2;
   
@@ -661,33 +664,33 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_AxisAlignedPath_Ca
   const int numPoints = numComponentPoints * numComponentPoints;
   const int numFields = 1;
   
-  Data<DataScalar,ExecSpaceType> unitData(1.0, Kokkos::Array<int,2>{numFields,numComponentPoints});
-  TensorData<DataScalar,ExecSpaceType> unitTensorData(std::vector< Data<DataScalar,ExecSpaceType> >{unitData,unitData});
+  Data<DataScalar,DeviceType> unitData(1.0, Kokkos::Array<int,2>{numFields,numComponentPoints});
+  TensorData<DataScalar,DeviceType> unitTensorData(std::vector< Data<DataScalar,DeviceType> >{unitData,unitData});
   
-  auto identityMatrixView = getFixedRankView<DataScalar>("identity matrix", spaceDim);
+  auto identityMatrixView = getFixedRankViewDefaultTestDT<DataScalar>("identity matrix", spaceDim);
   Kokkos::deep_copy(identityMatrixView, 1.0);
   
   Kokkos::Array<int,4> transformationExtents {numCells, numPoints, spaceDim, spaceDim};
   Kokkos::Array<DataVariationType,4> transformationVariationType {CONSTANT, CONSTANT, BLOCK_PLUS_DIAGONAL, BLOCK_PLUS_DIAGONAL};
   
   const int blockPlusDiagonalLastNonDiagonal = -1; // no non-diagonals; -1 is the default value, but I prefer to be explicit
-  Data<DataScalar,ExecSpaceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType, blockPlusDiagonalLastNonDiagonal);
+  Data<DataScalar,DeviceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType, blockPlusDiagonalLastNonDiagonal);
   
   const int numFamilies = 2;
-  Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > firstFamily  {unitTensorData,TensorData<DataScalar,ExecSpaceType>()};
-  Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > secondFamily {TensorData<DataScalar,ExecSpaceType>(),unitTensorData};
-  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim>, numFamilies> vectorComponents {firstFamily, secondFamily};
+  Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > firstFamily  {unitTensorData,TensorData<DataScalar,DeviceType>()};
+  Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > secondFamily {TensorData<DataScalar,DeviceType>(),unitTensorData};
+  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim>, numFamilies> vectorComponents {firstFamily, secondFamily};
   
-  VectorData<DataScalar,ExecSpaceType> unitVectorData(vectorComponents);
+  VectorData<DataScalar,DeviceType> unitVectorData(vectorComponents);
   
-  TransformedVectorData<DataScalar,ExecSpaceType> transformedUnitVectorData(explicitIdentityMatrix,unitVectorData);
+  TransformedVectorData<DataScalar,DeviceType> transformedUnitVectorData(explicitIdentityMatrix,unitVectorData);
   
-  Data<DataScalar,ExecSpaceType> constantCellMeasuresCellComponent(1.0, Kokkos::Array<int,1>{numCells});
-  Data<DataScalar,ExecSpaceType> constantCellMeasuresPointComponent(1.0, Kokkos::Array<int,1>{numComponentPoints});
-  std::vector< Data<DataScalar,ExecSpaceType> > cellMeasuresComponents { constantCellMeasuresCellComponent, constantCellMeasuresPointComponent, constantCellMeasuresPointComponent};
+  Data<DataScalar,DeviceType> constantCellMeasuresCellComponent(1.0, Kokkos::Array<int,1>{numCells});
+  Data<DataScalar,DeviceType> constantCellMeasuresPointComponent(1.0, Kokkos::Array<int,1>{numComponentPoints});
+  std::vector< Data<DataScalar,DeviceType> > cellMeasuresComponents { constantCellMeasuresCellComponent, constantCellMeasuresPointComponent, constantCellMeasuresPointComponent};
   
   const bool separateFirstComponent = true; // so that constantCellMeasures advertises shape (C,P), instead of folding cell dimension into the point tensor product...
-  TensorData<DataScalar,ExecSpaceType> constantCellMeasures(cellMeasuresComponents, separateFirstComponent);
+  TensorData<DataScalar,DeviceType> constantCellMeasures(cellMeasuresComponents, separateFirstComponent);
   
   testIntegrateMatchesBaseline(transformedUnitVectorData, constantCellMeasures, transformedUnitVectorData, out, success);
 }
@@ -696,7 +699,7 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_AxisAlignedPath_Ca
 TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case1 )
 {
   using DataScalar  = double;
-  using ExecSpaceType = Kokkos::DefaultExecutionSpace;
+  using DeviceType = DefaultTestDeviceType;
   
   const int spaceDim = 2;
   
@@ -704,10 +707,10 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case1 
   const int numPoints = 1;
   const int numFields = 1;
   
-  Data<DataScalar,ExecSpaceType> unitData(1.0, Kokkos::Array<int,2>{numFields,numPoints});
-  TensorData<DataScalar,ExecSpaceType> unitTensorData(std::vector< Data<DataScalar,ExecSpaceType> >{unitData,unitData});
+  Data<DataScalar,DeviceType> unitData(1.0, Kokkos::Array<int,2>{numFields,numPoints});
+  TensorData<DataScalar,DeviceType> unitTensorData(std::vector< Data<DataScalar,DeviceType> >{unitData,unitData});
   
-  auto identityMatrixView = getFixedRankView<DataScalar>("identity matrix", spaceDim, spaceDim);
+  auto identityMatrixView = getFixedRankViewDefaultTestDT<DataScalar>("identity matrix", spaceDim, spaceDim);
   auto identityMatrixViewHost = getHostCopy(identityMatrixView);
   
   for (int d1=0; d1<spaceDim; d1++)
@@ -722,19 +725,19 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case1 
   Kokkos::Array<int,4> transformationExtents {numCells, numPoints, spaceDim, spaceDim};
   Kokkos::Array<DataVariationType,4> transformationVariationType {CONSTANT, CONSTANT, GENERAL, GENERAL};
   
-  Data<DataScalar,ExecSpaceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType);
+  Data<DataScalar,DeviceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType);
   
   const int numFamilies = 2;
-  Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > firstFamily  {unitTensorData,TensorData<DataScalar,ExecSpaceType>()};
-  Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > secondFamily {TensorData<DataScalar,ExecSpaceType>(),unitTensorData};
-  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim>, numFamilies> vectorComponents {firstFamily, secondFamily};
+  Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > firstFamily  {unitTensorData,TensorData<DataScalar,DeviceType>()};
+  Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > secondFamily {TensorData<DataScalar,DeviceType>(),unitTensorData};
+  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim>, numFamilies> vectorComponents {firstFamily, secondFamily};
   
-  VectorData<DataScalar,ExecSpaceType> unitVectorData(vectorComponents);
+  VectorData<DataScalar,DeviceType> unitVectorData(vectorComponents);
   
-  TransformedVectorData<DataScalar,ExecSpaceType> transformedUnitVectorData(explicitIdentityMatrix,unitVectorData);
+  TransformedVectorData<DataScalar,DeviceType> transformedUnitVectorData(explicitIdentityMatrix,unitVectorData);
   
-  Data<DataScalar,ExecSpaceType> constantCellMeasuresData(1.0, Kokkos::Array<int,2>{numCells,numPoints});
-  TensorData<DataScalar,ExecSpaceType> constantCellMeasures(constantCellMeasuresData);
+  Data<DataScalar,DeviceType> constantCellMeasuresData(1.0, Kokkos::Array<int,2>{numCells,numPoints});
+  TensorData<DataScalar,DeviceType> constantCellMeasures(constantCellMeasuresData);
   
   testIntegrateMatchesBaseline(transformedUnitVectorData, constantCellMeasures, transformedUnitVectorData, out, success);
 }
@@ -743,7 +746,7 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case1 
 TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case2 )
 {
   using DataScalar  = double;
-  using ExecSpaceType = Kokkos::DefaultExecutionSpace;
+  using DeviceType = DefaultTestDeviceType;
   
   const int spaceDim = 2;
   
@@ -751,11 +754,11 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case2 
   const int numComponentPoints = 1;
   const int numComponentFields = 1;
   
-  auto fieldComponentDataView1 = getFixedRankView<DataScalar>("field component data 1", numComponentFields);
+  auto fieldComponentDataView1 = getFixedRankViewDefaultTestDT<DataScalar>("field component data 1", numComponentFields);
   auto fieldComponentDataViewHost1 = Kokkos::create_mirror_view(fieldComponentDataView1);
   fieldComponentDataViewHost1(0) = 1.0;
   
-  auto fieldComponentDataView2 = getFixedRankView<DataScalar>("field component data 2", numComponentFields);
+  auto fieldComponentDataView2 = getFixedRankViewDefaultTestDT<DataScalar>("field component data 2", numComponentFields);
   auto fieldComponentDataViewHost2 = Kokkos::create_mirror_view(fieldComponentDataView2);
   fieldComponentDataViewHost2(0) = 2.0;
   
@@ -765,12 +768,12 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case2 
   const int fieldComponentDataRank = 2;
   Kokkos::Array<int,fieldComponentDataRank> fieldComponentExtents {numComponentFields,numComponentPoints};
   Kokkos::Array<DataVariationType,fieldComponentDataRank> fieldComponentVariationTypes {GENERAL,CONSTANT};
-  Data<DataScalar,ExecSpaceType> fieldComponentData1(fieldComponentDataView1,fieldComponentExtents,fieldComponentVariationTypes);
-  Data<DataScalar,ExecSpaceType> fieldComponentData2(fieldComponentDataView2,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData1(fieldComponentDataView1,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData2(fieldComponentDataView2,fieldComponentExtents,fieldComponentVariationTypes);
   
-  TensorData<DataScalar,ExecSpaceType> tensorData(std::vector< Data<DataScalar,ExecSpaceType> >{fieldComponentData1,fieldComponentData2});
+  TensorData<DataScalar,DeviceType> tensorData(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData1,fieldComponentData2});
   
-  auto identityMatrixView = getFixedRankView<DataScalar>("identity matrix", spaceDim, spaceDim);
+  auto identityMatrixView = getFixedRankViewDefaultTestDT<DataScalar>("identity matrix", spaceDim, spaceDim);
   auto identityMatrixViewHost = getHostCopy(identityMatrixView);
   
   for (int d1=0; d1<spaceDim; d1++)
@@ -786,18 +789,18 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case2 
   Kokkos::Array<int,4> transformationExtents {numCells, numPoints, spaceDim, spaceDim};
   Kokkos::Array<DataVariationType,4> transformationVariationType {CONSTANT, CONSTANT, GENERAL, GENERAL};
   
-  Data<DataScalar,ExecSpaceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType);
+  Data<DataScalar,DeviceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType);
   
   const int numFamilies = 1;
-  Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim> family  {TensorData<DataScalar,ExecSpaceType>(), tensorData};
-  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim>, numFamilies> vectorComponents {family};
+  Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim> family  {TensorData<DataScalar,DeviceType>(), tensorData};
+  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim>, numFamilies> vectorComponents {family};
   
-  VectorData<DataScalar,ExecSpaceType> vectorData(vectorComponents);
+  VectorData<DataScalar,DeviceType> vectorData(vectorComponents);
   
-  TransformedVectorData<DataScalar,ExecSpaceType> transformedVectorData(explicitIdentityMatrix,vectorData);
+  TransformedVectorData<DataScalar,DeviceType> transformedVectorData(explicitIdentityMatrix,vectorData);
   
-  Data<DataScalar,ExecSpaceType> constantCellMeasuresData(1.0, Kokkos::Array<int,2>{numCells,numPoints});
-  TensorData<DataScalar,ExecSpaceType> constantCellMeasures(constantCellMeasuresData);
+  Data<DataScalar,DeviceType> constantCellMeasuresData(1.0, Kokkos::Array<int,2>{numCells,numPoints});
+  TensorData<DataScalar,DeviceType> constantCellMeasures(constantCellMeasuresData);
   
 //  printFunctor2(  fieldComponentData1, std::cout, "fieldComponentData1"); // (F,P)
 //  printFunctor2(  fieldComponentData2, std::cout, "fieldComponentData2"); // (F,P)
@@ -819,7 +822,7 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case2 
 TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case3 )
 {
   using DataScalar  = double;
-  using ExecSpaceType = Kokkos::DefaultExecutionSpace;
+  using DeviceType = DefaultTestDeviceType;
   
   const int spaceDim = 2;
   
@@ -827,14 +830,14 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case3 
   const int numComponentPoints = 2;
   const int numFields = 2;
   
-  auto fieldComponentDataView1 = getFixedRankView<DataScalar>("field component data 1", numFields,numComponentPoints);
+  auto fieldComponentDataView1 = getFixedRankViewDefaultTestDT<DataScalar>("field component data 1", numFields,numComponentPoints);
   auto fieldComponentDataViewHost1 = Kokkos::create_mirror_view(fieldComponentDataView1);
   fieldComponentDataViewHost1(0,0) = 1.0;
   fieldComponentDataViewHost1(0,1) = 2.0;
   fieldComponentDataViewHost1(1,0) = 3.0;
   fieldComponentDataViewHost1(1,1) = 4.0;
   
-  auto fieldComponentDataView2 = getFixedRankView<DataScalar>("field component data 2", numFields,numComponentPoints);
+  auto fieldComponentDataView2 = getFixedRankViewDefaultTestDT<DataScalar>("field component data 2", numFields,numComponentPoints);
   auto fieldComponentDataViewHost2 = Kokkos::create_mirror_view(fieldComponentDataView2);
   fieldComponentDataViewHost2(0,0) = 1.0/1.0;
   fieldComponentDataViewHost2(0,1) = 1.0/2.0;
@@ -847,12 +850,12 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case3 
   const int fieldComponentDataRank = 2;
   Kokkos::Array<int,fieldComponentDataRank> fieldComponentExtents {numFields,numComponentPoints};
   Kokkos::Array<DataVariationType,fieldComponentDataRank> fieldComponentVariationTypes {GENERAL,GENERAL};
-  Data<DataScalar,ExecSpaceType> fieldComponentData1(fieldComponentDataView1,fieldComponentExtents,fieldComponentVariationTypes);
-  Data<DataScalar,ExecSpaceType> fieldComponentData2(fieldComponentDataView2,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData1(fieldComponentDataView1,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData2(fieldComponentDataView2,fieldComponentExtents,fieldComponentVariationTypes);
     
-  TensorData<DataScalar,ExecSpaceType> tensorData(std::vector< Data<DataScalar,ExecSpaceType> >{fieldComponentData1,fieldComponentData2});
+  TensorData<DataScalar,DeviceType> tensorData(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData1,fieldComponentData2});
   
-  auto identityMatrixView = getFixedRankView<DataScalar>("identity matrix", spaceDim, spaceDim);
+  auto identityMatrixView = getFixedRankViewDefaultTestDT<DataScalar>("identity matrix", spaceDim, spaceDim);
   auto identityMatrixViewHost = getHostCopy(identityMatrixView);
   
   for (int d1=0; d1<spaceDim; d1++)
@@ -868,19 +871,19 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case3 
   Kokkos::Array<int,4> transformationExtents {numCells, numPoints, spaceDim, spaceDim};
   Kokkos::Array<DataVariationType,4> transformationVariationType {CONSTANT, CONSTANT, GENERAL, GENERAL};
   
-  Data<DataScalar,ExecSpaceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType);
+  Data<DataScalar,DeviceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType);
   
   const int numFamilies = 2;
-  Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > firstFamily  {tensorData,TensorData<DataScalar,ExecSpaceType>()};
-  Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > secondFamily {TensorData<DataScalar,ExecSpaceType>(),tensorData};
-  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim>, numFamilies> vectorComponents {firstFamily, secondFamily};
+  Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > firstFamily  {tensorData,TensorData<DataScalar,DeviceType>()};
+  Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > secondFamily {TensorData<DataScalar,DeviceType>(),tensorData};
+  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim>, numFamilies> vectorComponents {firstFamily, secondFamily};
   
-  VectorData<DataScalar,ExecSpaceType> vectorData(vectorComponents);
+  VectorData<DataScalar,DeviceType> vectorData(vectorComponents);
   
-  TransformedVectorData<DataScalar,ExecSpaceType> transformedUnitVectorData(explicitIdentityMatrix,vectorData);
+  TransformedVectorData<DataScalar,DeviceType> transformedUnitVectorData(explicitIdentityMatrix,vectorData);
   
-  Data<DataScalar,ExecSpaceType> constantCellMeasuresData(1.0, Kokkos::Array<int,2>{numCells,numPoints});
-  TensorData<DataScalar,ExecSpaceType> constantCellMeasures(constantCellMeasuresData);
+  Data<DataScalar,DeviceType> constantCellMeasuresData(1.0, Kokkos::Array<int,2>{numCells,numPoints});
+  TensorData<DataScalar,DeviceType> constantCellMeasures(constantCellMeasuresData);
   
   testIntegrateMatchesBaseline(transformedUnitVectorData, constantCellMeasures, transformedUnitVectorData, out, success);
 }
@@ -889,7 +892,7 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case3 
 TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case4 )
 {
   using DataScalar  = double;
-  using ExecSpaceType = Kokkos::DefaultExecutionSpace;
+  using DeviceType = DefaultTestDeviceType;
   
   const int spaceDim = 2;
   
@@ -899,12 +902,12 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case4 
   const int numFields2 = 1;
   const int numFieldsPerFamily = numFields1 * numFields2;
   
-  auto fieldComponentDataView1 = getFixedRankView<DataScalar>("field component data 1", numFields1);
+  auto fieldComponentDataView1 = getFixedRankViewDefaultTestDT<DataScalar>("field component data 1", numFields1);
   auto fieldComponentDataViewHost1 = Kokkos::create_mirror_view(fieldComponentDataView1);
   fieldComponentDataViewHost1(0) = 1.0;
   fieldComponentDataViewHost1(1) = 3.0;
   
-  auto fieldComponentDataView2 = getFixedRankView<DataScalar>("field component data 2", numFields2);
+  auto fieldComponentDataView2 = getFixedRankViewDefaultTestDT<DataScalar>("field component data 2", numFields2);
   auto fieldComponentDataViewHost2 = Kokkos::create_mirror_view(fieldComponentDataView2);
   fieldComponentDataViewHost2(0) = 1.0/2.0;
   
@@ -914,13 +917,13 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case4 
   const int fieldComponentDataRank = 2;
   Kokkos::Array<int,fieldComponentDataRank> fieldComponentExtents {numFields1,numComponentPoints};
   Kokkos::Array<DataVariationType,fieldComponentDataRank> fieldComponentVariationTypes {GENERAL,GENERAL};
-  Data<DataScalar,ExecSpaceType> fieldComponentData1(fieldComponentDataView1,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData1(fieldComponentDataView1,fieldComponentExtents,fieldComponentVariationTypes);
   fieldComponentExtents[0] = numFields2;
-  Data<DataScalar,ExecSpaceType> fieldComponentData2(fieldComponentDataView2,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData2(fieldComponentDataView2,fieldComponentExtents,fieldComponentVariationTypes);
     
-  TensorData<DataScalar,ExecSpaceType> nonzeroTensorData(std::vector< Data<DataScalar,ExecSpaceType> >{fieldComponentData1,fieldComponentData2});
+  TensorData<DataScalar,DeviceType> nonzeroTensorData(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData1,fieldComponentData2});
   
-  auto identityMatrixView = getFixedRankView<DataScalar>("identity matrix", spaceDim, spaceDim);
+  auto identityMatrixView = getFixedRankViewDefaultTestDT<DataScalar>("identity matrix", spaceDim, spaceDim);
   auto identityMatrixViewHost = getHostCopy(identityMatrixView);
   
   for (int d1=0; d1<spaceDim; d1++)
@@ -936,22 +939,22 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case4 
   Kokkos::Array<int,4> transformationExtents {numCells, numPoints, spaceDim, spaceDim};
   Kokkos::Array<DataVariationType,4> transformationVariationType {CONSTANT, CONSTANT, GENERAL, GENERAL};
   
-  Data<DataScalar,ExecSpaceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType);
+  Data<DataScalar,DeviceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType);
   
   const int numFamilies = 2;
-  Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > firstFamily  {nonzeroTensorData,TensorData<DataScalar,ExecSpaceType>()};
-  Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > secondFamily {TensorData<DataScalar,ExecSpaceType>(),nonzeroTensorData};
-  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim>, numFamilies> vectorComponents {firstFamily, secondFamily};
+  Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > firstFamily  {nonzeroTensorData,TensorData<DataScalar,DeviceType>()};
+  Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > secondFamily {TensorData<DataScalar,DeviceType>(),nonzeroTensorData};
+  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim>, numFamilies> vectorComponents {firstFamily, secondFamily};
   
-  VectorData<DataScalar,ExecSpaceType> vectorData(vectorComponents);
+  VectorData<DataScalar,DeviceType> vectorData(vectorComponents);
   
   TEST_EQUALITY(numFieldsPerFamily, vectorData.numFieldsInFamily(0));
   TEST_EQUALITY(numFieldsPerFamily, vectorData.numFieldsInFamily(1));
   
-  TransformedVectorData<DataScalar,ExecSpaceType> transformedUnitVectorData(explicitIdentityMatrix,vectorData);
+  TransformedVectorData<DataScalar,DeviceType> transformedUnitVectorData(explicitIdentityMatrix,vectorData);
   
-  Data<DataScalar,ExecSpaceType> constantCellMeasuresData(1.0, Kokkos::Array<int,2>{numCells,numPoints});
-  TensorData<DataScalar,ExecSpaceType> constantCellMeasures(constantCellMeasuresData);
+  Data<DataScalar,DeviceType> constantCellMeasuresData(1.0, Kokkos::Array<int,2>{numCells,numPoints});
+  TensorData<DataScalar,DeviceType> constantCellMeasures(constantCellMeasuresData);
   
   testIntegrateMatchesBaseline(transformedUnitVectorData, constantCellMeasures, transformedUnitVectorData, out, success);
 }
@@ -960,7 +963,7 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case4 
 TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case5 )
 {
   using DataScalar  = double;
-  using ExecSpaceType = Kokkos::DefaultExecutionSpace;
+  using DeviceType = DefaultTestDeviceType;
   
   const int spaceDim = 2;
   
@@ -971,12 +974,12 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case5 
   const int numFieldsPerFamilyLeft  = numFields1 * numFields2;
   const int numFieldsPerFamilyRight = numFields2 * numFields2;
   
-  auto fieldComponentDataView1 = getFixedRankView<DataScalar>("field component data 1", numFields1);
+  auto fieldComponentDataView1 = getFixedRankViewDefaultTestDT<DataScalar>("field component data 1", numFields1);
   auto fieldComponentDataViewHost1 = Kokkos::create_mirror_view(fieldComponentDataView1);
   fieldComponentDataViewHost1(0) = 1.0;
   fieldComponentDataViewHost1(1) = 3.0;
   
-  auto fieldComponentDataView2 = getFixedRankView<DataScalar>("field component data 2", numFields2);
+  auto fieldComponentDataView2 = getFixedRankViewDefaultTestDT<DataScalar>("field component data 2", numFields2);
   auto fieldComponentDataViewHost2 = Kokkos::create_mirror_view(fieldComponentDataView2);
   fieldComponentDataViewHost2(0) = 1.0/2.0;
   fieldComponentDataViewHost2(1) = 1.0/3.0;
@@ -988,14 +991,14 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case5 
   const int fieldComponentDataRank = 2;
   Kokkos::Array<int,fieldComponentDataRank> fieldComponentExtents {numFields1,numComponentPoints};
   Kokkos::Array<DataVariationType,fieldComponentDataRank> fieldComponentVariationTypes {GENERAL,GENERAL};
-  Data<DataScalar,ExecSpaceType> fieldComponentData1(fieldComponentDataView1,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData1(fieldComponentDataView1,fieldComponentExtents,fieldComponentVariationTypes);
   fieldComponentExtents[0] = numFields2;
-  Data<DataScalar,ExecSpaceType> fieldComponentData2(fieldComponentDataView2,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData2(fieldComponentDataView2,fieldComponentExtents,fieldComponentVariationTypes);
     
-  TensorData<DataScalar,ExecSpaceType>  tensorDataLeft(std::vector< Data<DataScalar,ExecSpaceType> >{fieldComponentData1,fieldComponentData2});
-  TensorData<DataScalar,ExecSpaceType> tensorDataRight(std::vector< Data<DataScalar,ExecSpaceType> >{fieldComponentData2,fieldComponentData2});
+  TensorData<DataScalar,DeviceType>  tensorDataLeft(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData1,fieldComponentData2});
+  TensorData<DataScalar,DeviceType> tensorDataRight(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData2,fieldComponentData2});
   
-  auto identityMatrixView = getFixedRankView<DataScalar>("identity matrix", spaceDim, spaceDim);
+  auto identityMatrixView = getFixedRankViewDefaultTestDT<DataScalar>("identity matrix", spaceDim, spaceDim);
   auto identityMatrixViewHost = getHostCopy(identityMatrixView);
   
   for (int d1=0; d1<spaceDim; d1++)
@@ -1011,30 +1014,30 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case5 
   Kokkos::Array<int,4> transformationExtents {numCells, numPoints, spaceDim, spaceDim};
   Kokkos::Array<DataVariationType,4> transformationVariationType {CONSTANT, CONSTANT, GENERAL, GENERAL};
   
-  Data<DataScalar,ExecSpaceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType);
+  Data<DataScalar,DeviceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType);
   
   const int numFamilies = 2;
-  Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > firstFamilyLeft  {tensorDataLeft,TensorData<DataScalar,ExecSpaceType>()};
-  Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > secondFamilyLeft {TensorData<DataScalar,ExecSpaceType>(),tensorDataLeft};
-  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim>, numFamilies> vectorComponentsLeft {firstFamilyLeft, secondFamilyLeft};
+  Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > firstFamilyLeft  {tensorDataLeft,TensorData<DataScalar,DeviceType>()};
+  Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > secondFamilyLeft {TensorData<DataScalar,DeviceType>(),tensorDataLeft};
+  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim>, numFamilies> vectorComponentsLeft {firstFamilyLeft, secondFamilyLeft};
   
-  VectorData<DataScalar,ExecSpaceType> vectorDataLeft(vectorComponentsLeft);
+  VectorData<DataScalar,DeviceType> vectorDataLeft(vectorComponentsLeft);
   TEST_EQUALITY(numFieldsPerFamilyLeft, vectorDataLeft.numFieldsInFamily(0));
   TEST_EQUALITY(numFieldsPerFamilyLeft, vectorDataLeft.numFieldsInFamily(1));
   
-  Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > firstFamilyRight  {tensorDataRight,TensorData<DataScalar,ExecSpaceType>()};
-  Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > secondFamilyRight {TensorData<DataScalar,ExecSpaceType>(),tensorDataRight};
-  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim>, numFamilies> vectorComponentsRight {firstFamilyRight, secondFamilyRight};
+  Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > firstFamilyRight  {tensorDataRight,TensorData<DataScalar,DeviceType>()};
+  Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > secondFamilyRight {TensorData<DataScalar,DeviceType>(),tensorDataRight};
+  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim>, numFamilies> vectorComponentsRight {firstFamilyRight, secondFamilyRight};
   
-  VectorData<DataScalar,ExecSpaceType> vectorDataRight(vectorComponentsRight);
+  VectorData<DataScalar,DeviceType> vectorDataRight(vectorComponentsRight);
   TEST_EQUALITY(numFieldsPerFamilyRight, vectorDataRight.numFieldsInFamily(0));
   TEST_EQUALITY(numFieldsPerFamilyRight, vectorDataRight.numFieldsInFamily(1));
   
-  TransformedVectorData<DataScalar,ExecSpaceType>  transformedUnitVectorDataLeft(explicitIdentityMatrix,vectorDataLeft);
-  TransformedVectorData<DataScalar,ExecSpaceType> transformedUnitVectorDataRight(explicitIdentityMatrix,vectorDataRight);
+  TransformedVectorData<DataScalar,DeviceType>  transformedUnitVectorDataLeft(explicitIdentityMatrix,vectorDataLeft);
+  TransformedVectorData<DataScalar,DeviceType> transformedUnitVectorDataRight(explicitIdentityMatrix,vectorDataRight);
   
-  Data<DataScalar,ExecSpaceType> constantCellMeasuresData(1.0, Kokkos::Array<int,2>{numCells,numPoints});
-  TensorData<DataScalar,ExecSpaceType> constantCellMeasures(constantCellMeasuresData);
+  Data<DataScalar,DeviceType> constantCellMeasuresData(1.0, Kokkos::Array<int,2>{numCells,numPoints});
+  TensorData<DataScalar,DeviceType> constantCellMeasures(constantCellMeasuresData);
   
   testIntegrateMatchesBaseline(transformedUnitVectorDataLeft, constantCellMeasures, transformedUnitVectorDataRight, out, success);
 }
@@ -1043,7 +1046,7 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case5 
 TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_AxisAlignedPath_Case6_3D )
 {
   using DataScalar  = double;
-  using ExecSpaceType = Kokkos::DefaultExecutionSpace;
+  using DeviceType = DefaultTestDeviceType;
   
   const int spaceDim = 3;
   
@@ -1056,18 +1059,18 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_AxisAlignedPath_Ca
   const int numFieldsPerFamilyLeft  = numFields1 * numFields2 * numFields3;
   const int numFieldsPerFamilyRight = numFields1 * numFields3 * numFields2;
   
-  auto fieldComponentDataView1 = getFixedRankView<DataScalar>("field component data 1", numFields1);
+  auto fieldComponentDataView1 = getFixedRankViewDefaultTestDT<DataScalar>("field component data 1", numFields1);
   auto fieldComponentDataViewHost1 = Kokkos::create_mirror_view(fieldComponentDataView1);
   fieldComponentDataViewHost1(0) = 1.0;
 //  fieldComponentDataViewHost1(1) = 3.0;
   
-  auto fieldComponentDataView2 = getFixedRankView<DataScalar>("field component data 2", numFields2);
+  auto fieldComponentDataView2 = getFixedRankViewDefaultTestDT<DataScalar>("field component data 2", numFields2);
   auto fieldComponentDataViewHost2 = Kokkos::create_mirror_view(fieldComponentDataView2);
   fieldComponentDataViewHost2(0) = 1.0;
   fieldComponentDataViewHost2(1) = 1.0/3.0;
   fieldComponentDataViewHost2(2) = 1.0/4.0;
   
-  auto fieldComponentDataView3 = getFixedRankView<DataScalar>("field component data 3", numFields3);
+  auto fieldComponentDataView3 = getFixedRankViewDefaultTestDT<DataScalar>("field component data 3", numFields3);
   auto fieldComponentDataViewHost3 = Kokkos::create_mirror_view(fieldComponentDataView3);
   fieldComponentDataViewHost3(0) = 1.0;
   fieldComponentDataViewHost3(1) = 0.25;
@@ -1079,51 +1082,51 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_AxisAlignedPath_Ca
   const int fieldComponentDataRank = 2;
   Kokkos::Array<int,fieldComponentDataRank> fieldComponentExtents {numFields1,numComponentPoints};
   Kokkos::Array<DataVariationType,fieldComponentDataRank> fieldComponentVariationTypes {GENERAL,GENERAL};
-  Data<DataScalar,ExecSpaceType> fieldComponentData1(fieldComponentDataView1,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData1(fieldComponentDataView1,fieldComponentExtents,fieldComponentVariationTypes);
   fieldComponentExtents[0] = numFields2;
-  Data<DataScalar,ExecSpaceType> fieldComponentData2(fieldComponentDataView2,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData2(fieldComponentDataView2,fieldComponentExtents,fieldComponentVariationTypes);
   fieldComponentExtents[0] = numFields3;
-  Data<DataScalar,ExecSpaceType> fieldComponentData3(fieldComponentDataView3,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData3(fieldComponentDataView3,fieldComponentExtents,fieldComponentVariationTypes);
   
-   TensorData<DataScalar,ExecSpaceType>  tensorDataLeft(std::vector< Data<DataScalar,ExecSpaceType> >{fieldComponentData1,fieldComponentData2,fieldComponentData3});
-   TensorData<DataScalar,ExecSpaceType> tensorDataRight(std::vector< Data<DataScalar,ExecSpaceType> >{fieldComponentData1,fieldComponentData3,fieldComponentData2});
+   TensorData<DataScalar,DeviceType>  tensorDataLeft(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData1,fieldComponentData2,fieldComponentData3});
+   TensorData<DataScalar,DeviceType> tensorDataRight(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData1,fieldComponentData3,fieldComponentData2});
    
    const int numPoints = numComponentPoints * numComponentPoints * numComponentPoints;
    
-   auto identityMatrixView = getFixedRankView<DataScalar>("identity matrix", spaceDim);
+   auto identityMatrixView = getFixedRankViewDefaultTestDT<DataScalar>("identity matrix", spaceDim);
    Kokkos::deep_copy(identityMatrixView, 1.0);
    
    Kokkos::Array<int,4> transformationExtents {numCells, numPoints, spaceDim, spaceDim};
    Kokkos::Array<DataVariationType,4> transformationVariationType {CONSTANT, CONSTANT, BLOCK_PLUS_DIAGONAL, BLOCK_PLUS_DIAGONAL};
    
    const int blockPlusDiagonalLastNonDiagonal = -1; // no non-diagonals; -1 is the default value, but I prefer to be explicit
-   Data<DataScalar,ExecSpaceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType, blockPlusDiagonalLastNonDiagonal);
+   Data<DataScalar,DeviceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType, blockPlusDiagonalLastNonDiagonal);
   
   // confirm that the matrix is diagonal (this is required to follow the axis-aligned path):
   TEST_EQUALITY(true, explicitIdentityMatrix.isDiagonal());
 
   const int numFamilies = 1;
-  Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > firstFamilyLeft  {tensorDataLeft,tensorDataLeft,tensorDataLeft};
-  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim>, numFamilies> vectorComponentsLeft {firstFamilyLeft};
+  Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > firstFamilyLeft  {tensorDataLeft,tensorDataLeft,tensorDataLeft};
+  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim>, numFamilies> vectorComponentsLeft {firstFamilyLeft};
   
-  VectorData<DataScalar,ExecSpaceType> vectorDataLeft(vectorComponentsLeft);
+  VectorData<DataScalar,DeviceType> vectorDataLeft(vectorComponentsLeft);
   TEST_EQUALITY(numFieldsPerFamilyLeft, vectorDataLeft.numFieldsInFamily(0));
   
-  Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > firstFamilyRight  {tensorDataRight,tensorDataRight,tensorDataRight};
-  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim>, numFamilies> vectorComponentsRight {firstFamilyRight};
+  Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > firstFamilyRight  {tensorDataRight,tensorDataRight,tensorDataRight};
+  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim>, numFamilies> vectorComponentsRight {firstFamilyRight};
    
-   VectorData<DataScalar,ExecSpaceType> vectorDataRight(vectorComponentsRight);
+   VectorData<DataScalar,DeviceType> vectorDataRight(vectorComponentsRight);
    TEST_EQUALITY(numFieldsPerFamilyRight, vectorDataRight.numFieldsInFamily(0));
    
-   TransformedVectorData<DataScalar,ExecSpaceType>  transformedUnitVectorDataLeft(explicitIdentityMatrix,vectorDataLeft);
-   TransformedVectorData<DataScalar,ExecSpaceType> transformedUnitVectorDataRight(explicitIdentityMatrix,vectorDataRight);
+   TransformedVectorData<DataScalar,DeviceType>  transformedUnitVectorDataLeft(explicitIdentityMatrix,vectorDataLeft);
+   TransformedVectorData<DataScalar,DeviceType> transformedUnitVectorDataRight(explicitIdentityMatrix,vectorDataRight);
    
-   Data<DataScalar,ExecSpaceType>  constantCellMeasuresCellComponent(1.0, Kokkos::Array<int,1>{numCells});
-   Data<DataScalar,ExecSpaceType> constantCellMeasuresPointComponent(1.0, Kokkos::Array<int,1>{numComponentPoints});
-   std::vector< Data<DataScalar,ExecSpaceType> > cellMeasuresComponents { constantCellMeasuresCellComponent, constantCellMeasuresPointComponent, constantCellMeasuresPointComponent, constantCellMeasuresPointComponent};
+   Data<DataScalar,DeviceType>  constantCellMeasuresCellComponent(1.0, Kokkos::Array<int,1>{numCells});
+   Data<DataScalar,DeviceType> constantCellMeasuresPointComponent(1.0, Kokkos::Array<int,1>{numComponentPoints});
+   std::vector< Data<DataScalar,DeviceType> > cellMeasuresComponents { constantCellMeasuresCellComponent, constantCellMeasuresPointComponent, constantCellMeasuresPointComponent, constantCellMeasuresPointComponent};
    
    const bool separateFirstComponent = true; // so that constantCellMeasures advertises shape (C,P), instead of folding cell dimension into the point tensor product...
-   TensorData<DataScalar,ExecSpaceType> constantCellMeasures(cellMeasuresComponents, separateFirstComponent);
+   TensorData<DataScalar,DeviceType> constantCellMeasures(cellMeasuresComponents, separateFirstComponent);
    
    testIntegrateMatchesBaseline(transformedUnitVectorDataLeft, constantCellMeasures, transformedUnitVectorDataRight, out, success);
 }
@@ -1132,7 +1135,7 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_AxisAlignedPath_Ca
 TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case6_3D )
 {
   using DataScalar  = double;
-  using ExecSpaceType = Kokkos::DefaultExecutionSpace;
+  using DeviceType = DefaultTestDeviceType;
   
   const int spaceDim = 3;
   
@@ -1145,18 +1148,18 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case6_
   const int numFieldsPerFamilyLeft  = numFields1 * numFields2 * numFields3;
   const int numFieldsPerFamilyRight = numFields1 * numFields3 * numFields2;
   
-  auto fieldComponentDataView1 = getFixedRankView<DataScalar>("field component data 1", numFields1);
+  auto fieldComponentDataView1 = getFixedRankViewDefaultTestDT<DataScalar>("field component data 1", numFields1);
   auto fieldComponentDataViewHost1 = Kokkos::create_mirror_view(fieldComponentDataView1);
   fieldComponentDataViewHost1(0) = 1.0;
 //  fieldComponentDataViewHost1(1) = 3.0;
   
-  auto fieldComponentDataView2 = getFixedRankView<DataScalar>("field component data 2", numFields2);
+  auto fieldComponentDataView2 = getFixedRankViewDefaultTestDT<DataScalar>("field component data 2", numFields2);
   auto fieldComponentDataViewHost2 = Kokkos::create_mirror_view(fieldComponentDataView2);
   fieldComponentDataViewHost2(0) = 1.0/2.0;
   fieldComponentDataViewHost2(1) = 1.0/3.0;
   fieldComponentDataViewHost2(2) = 1.0/4.0;
   
-  auto fieldComponentDataView3 = getFixedRankView<DataScalar>("field component data 3", numFields3);
+  auto fieldComponentDataView3 = getFixedRankViewDefaultTestDT<DataScalar>("field component data 3", numFields3);
   auto fieldComponentDataViewHost3 = Kokkos::create_mirror_view(fieldComponentDataView3);
   fieldComponentDataViewHost3(0) = 0.5;
   fieldComponentDataViewHost3(1) = 0.25;
@@ -1168,16 +1171,16 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case6_
   const int fieldComponentDataRank = 2;
   Kokkos::Array<int,fieldComponentDataRank> fieldComponentExtents {numFields1,numComponentPoints};
   Kokkos::Array<DataVariationType,fieldComponentDataRank> fieldComponentVariationTypes {GENERAL,GENERAL};
-  Data<DataScalar,ExecSpaceType> fieldComponentData1(fieldComponentDataView1,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData1(fieldComponentDataView1,fieldComponentExtents,fieldComponentVariationTypes);
   fieldComponentExtents[0] = numFields2;
-  Data<DataScalar,ExecSpaceType> fieldComponentData2(fieldComponentDataView2,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData2(fieldComponentDataView2,fieldComponentExtents,fieldComponentVariationTypes);
   fieldComponentExtents[0] = numFields3;
-  Data<DataScalar,ExecSpaceType> fieldComponentData3(fieldComponentDataView3,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData3(fieldComponentDataView3,fieldComponentExtents,fieldComponentVariationTypes);
   
-   TensorData<DataScalar,ExecSpaceType>  tensorDataLeft(std::vector< Data<DataScalar,ExecSpaceType> >{fieldComponentData1,fieldComponentData2,fieldComponentData3});
-   TensorData<DataScalar,ExecSpaceType> tensorDataRight(std::vector< Data<DataScalar,ExecSpaceType> >{fieldComponentData1,fieldComponentData3,fieldComponentData2});
+   TensorData<DataScalar,DeviceType>  tensorDataLeft(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData1,fieldComponentData2,fieldComponentData3});
+   TensorData<DataScalar,DeviceType> tensorDataRight(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData1,fieldComponentData3,fieldComponentData2});
    
-   auto identityMatrixView = getFixedRankView<DataScalar>("identity matrix", spaceDim, spaceDim);
+   auto identityMatrixView = getFixedRankViewDefaultTestDT<DataScalar>("identity matrix", spaceDim, spaceDim);
    auto identityMatrixViewHost = getHostCopy(identityMatrixView);
    
    for (int d1=0; d1<spaceDim; d1++)
@@ -1193,44 +1196,44 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case6_
    Kokkos::Array<int,4> transformationExtents {numCells, numPoints, spaceDim, spaceDim};
    Kokkos::Array<DataVariationType,4> transformationVariationType {CONSTANT, CONSTANT, GENERAL, GENERAL};
    
-   Data<DataScalar,ExecSpaceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType);
+   Data<DataScalar,DeviceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType);
    
 //   const int numFamilies = 3;
-//   Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > firstFamilyLeft  {tensorDataLeft,TensorData<DataScalar,ExecSpaceType>(),TensorData<DataScalar,ExecSpaceType>()};
-//   Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > secondFamilyLeft {TensorData<DataScalar,ExecSpaceType>(),tensorDataLeft,TensorData<DataScalar,ExecSpaceType>()};
-//   Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > thirdFamilyLeft  {TensorData<DataScalar,ExecSpaceType>(),TensorData<DataScalar,ExecSpaceType>(),tensorDataLeft};
-//   Kokkos::Array< Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim>, numFamilies> vectorComponentsLeft {firstFamilyLeft, secondFamilyLeft, thirdFamilyLeft};
+//   Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > firstFamilyLeft  {tensorDataLeft,TensorData<DataScalar,DeviceType>(),TensorData<DataScalar,DeviceType>()};
+//   Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > secondFamilyLeft {TensorData<DataScalar,DeviceType>(),tensorDataLeft,TensorData<DataScalar,DeviceType>()};
+//   Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > thirdFamilyLeft  {TensorData<DataScalar,DeviceType>(),TensorData<DataScalar,DeviceType>(),tensorDataLeft};
+//   Kokkos::Array< Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim>, numFamilies> vectorComponentsLeft {firstFamilyLeft, secondFamilyLeft, thirdFamilyLeft};
 //
-//   VectorData<DataScalar,ExecSpaceType> vectorDataLeft(vectorComponentsLeft);
+//   VectorData<DataScalar,DeviceType> vectorDataLeft(vectorComponentsLeft);
 //   TEST_EQUALITY(numFieldsPerFamilyLeft, vectorDataLeft.numFieldsInFamily(0));
 //   TEST_EQUALITY(numFieldsPerFamilyLeft, vectorDataLeft.numFieldsInFamily(1));
 //
-//   Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > firstFamilyRight  {tensorDataRight,TensorData<DataScalar,ExecSpaceType>(),TensorData<DataScalar,ExecSpaceType>()};
-//   Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > secondFamilyRight {TensorData<DataScalar,ExecSpaceType>(),tensorDataRight,TensorData<DataScalar,ExecSpaceType>()};
-//   Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > thirdFamilyRight  {TensorData<DataScalar,ExecSpaceType>(),TensorData<DataScalar,ExecSpaceType>(),tensorDataRight};
-//   Kokkos::Array< Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim>, numFamilies> vectorComponentsRight {firstFamilyRight, secondFamilyRight, thirdFamilyRight};
-//  VectorData<DataScalar,ExecSpaceType> vectorDataRight(vectorComponentsRight);
+//   Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > firstFamilyRight  {tensorDataRight,TensorData<DataScalar,DeviceType>(),TensorData<DataScalar,DeviceType>()};
+//   Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > secondFamilyRight {TensorData<DataScalar,DeviceType>(),tensorDataRight,TensorData<DataScalar,DeviceType>()};
+//   Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > thirdFamilyRight  {TensorData<DataScalar,DeviceType>(),TensorData<DataScalar,DeviceType>(),tensorDataRight};
+//   Kokkos::Array< Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim>, numFamilies> vectorComponentsRight {firstFamilyRight, secondFamilyRight, thirdFamilyRight};
+//  VectorData<DataScalar,DeviceType> vectorDataRight(vectorComponentsRight);
 //  TEST_EQUALITY(numFieldsPerFamilyRight, vectorDataRight.numFieldsInFamily(0));
 //  TEST_EQUALITY(numFieldsPerFamilyRight, vectorDataRight.numFieldsInFamily(1));
   
   const int numFamilies = 1;
-  Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > firstFamilyLeft  {tensorDataLeft,TensorData<DataScalar,ExecSpaceType>(),TensorData<DataScalar,ExecSpaceType>()};
-  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim>, numFamilies> vectorComponentsLeft {firstFamilyLeft};
+  Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > firstFamilyLeft  {tensorDataLeft,TensorData<DataScalar,DeviceType>(),TensorData<DataScalar,DeviceType>()};
+  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim>, numFamilies> vectorComponentsLeft {firstFamilyLeft};
   
-  VectorData<DataScalar,ExecSpaceType> vectorDataLeft(vectorComponentsLeft);
+  VectorData<DataScalar,DeviceType> vectorDataLeft(vectorComponentsLeft);
   TEST_EQUALITY(numFieldsPerFamilyLeft, vectorDataLeft.numFieldsInFamily(0));
   
-  Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > firstFamilyRight  {tensorDataRight,TensorData<DataScalar,ExecSpaceType>(),TensorData<DataScalar,ExecSpaceType>()};
-  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim>, numFamilies> vectorComponentsRight {firstFamilyRight};
+  Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > firstFamilyRight  {tensorDataRight,TensorData<DataScalar,DeviceType>(),TensorData<DataScalar,DeviceType>()};
+  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim>, numFamilies> vectorComponentsRight {firstFamilyRight};
    
-   VectorData<DataScalar,ExecSpaceType> vectorDataRight(vectorComponentsRight);
+   VectorData<DataScalar,DeviceType> vectorDataRight(vectorComponentsRight);
    TEST_EQUALITY(numFieldsPerFamilyRight, vectorDataRight.numFieldsInFamily(0));
    
-   TransformedVectorData<DataScalar,ExecSpaceType>  transformedUnitVectorDataLeft(explicitIdentityMatrix,vectorDataLeft);
-   TransformedVectorData<DataScalar,ExecSpaceType> transformedUnitVectorDataRight(explicitIdentityMatrix,vectorDataRight);
+   TransformedVectorData<DataScalar,DeviceType>  transformedUnitVectorDataLeft(explicitIdentityMatrix,vectorDataLeft);
+   TransformedVectorData<DataScalar,DeviceType> transformedUnitVectorDataRight(explicitIdentityMatrix,vectorDataRight);
    
-   Data<DataScalar,ExecSpaceType> constantCellMeasuresData(1.0, Kokkos::Array<int,2>{numCells,numPoints});
-   TensorData<DataScalar,ExecSpaceType> constantCellMeasures(constantCellMeasuresData);
+   Data<DataScalar,DeviceType> constantCellMeasuresData(1.0, Kokkos::Array<int,2>{numCells,numPoints});
+   TensorData<DataScalar,DeviceType> constantCellMeasures(constantCellMeasuresData);
    
    testIntegrateMatchesBaseline(transformedUnitVectorDataLeft, constantCellMeasures, transformedUnitVectorDataRight, out, success);
 }
@@ -1241,7 +1244,7 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case7_
   // super-simple case for 3D: symmetric data, 1 point, 1 field.
   
   using DataScalar  = double;
-  using ExecSpaceType = Kokkos::DefaultExecutionSpace;
+  using DeviceType = DefaultTestDeviceType;
   
   const int spaceDim = 3;
   
@@ -1254,15 +1257,15 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case7_
   const int numFieldsPerFamilyLeft  = numFields1 * numFields2 * numFields3;
   const int numFieldsPerFamilyRight = numFields1 * numFields3 * numFields2;
   
-  auto fieldComponentDataView1 = getFixedRankView<DataScalar>("field component data 1", numFields1);
+  auto fieldComponentDataView1 = getFixedRankViewDefaultTestDT<DataScalar>("field component data 1", numFields1);
   auto fieldComponentDataViewHost1 = Kokkos::create_mirror_view(fieldComponentDataView1);
   fieldComponentDataViewHost1(0) = 1.0;
   
-  auto fieldComponentDataView2 = getFixedRankView<DataScalar>("field component data 2", numFields2);
+  auto fieldComponentDataView2 = getFixedRankViewDefaultTestDT<DataScalar>("field component data 2", numFields2);
   auto fieldComponentDataViewHost2 = Kokkos::create_mirror_view(fieldComponentDataView2);
   fieldComponentDataViewHost2(0) = 1.0;
   
-  auto fieldComponentDataView3 = getFixedRankView<DataScalar>("field component data 3", numFields3);
+  auto fieldComponentDataView3 = getFixedRankViewDefaultTestDT<DataScalar>("field component data 3", numFields3);
   auto fieldComponentDataViewHost3 = Kokkos::create_mirror_view(fieldComponentDataView3);
   fieldComponentDataViewHost3(0) = 1.0;
   
@@ -1273,16 +1276,16 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case7_
   const int fieldComponentDataRank = 2;
   Kokkos::Array<int,fieldComponentDataRank> fieldComponentExtents {numFields1,numComponentPoints};
   Kokkos::Array<DataVariationType,fieldComponentDataRank> fieldComponentVariationTypes {GENERAL,GENERAL};
-  Data<DataScalar,ExecSpaceType> fieldComponentData1(fieldComponentDataView1,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData1(fieldComponentDataView1,fieldComponentExtents,fieldComponentVariationTypes);
   fieldComponentExtents[0] = numFields2;
-  Data<DataScalar,ExecSpaceType> fieldComponentData2(fieldComponentDataView2,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData2(fieldComponentDataView2,fieldComponentExtents,fieldComponentVariationTypes);
   fieldComponentExtents[0] = numFields3;
-  Data<DataScalar,ExecSpaceType> fieldComponentData3(fieldComponentDataView3,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData3(fieldComponentDataView3,fieldComponentExtents,fieldComponentVariationTypes);
   
-   TensorData<DataScalar,ExecSpaceType>  tensorDataLeft(std::vector< Data<DataScalar,ExecSpaceType> >{fieldComponentData1,fieldComponentData2,fieldComponentData3});
-   TensorData<DataScalar,ExecSpaceType> tensorDataRight(std::vector< Data<DataScalar,ExecSpaceType> >{fieldComponentData1,fieldComponentData3,fieldComponentData2});
+   TensorData<DataScalar,DeviceType>  tensorDataLeft(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData1,fieldComponentData2,fieldComponentData3});
+   TensorData<DataScalar,DeviceType> tensorDataRight(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData1,fieldComponentData3,fieldComponentData2});
    
-   auto identityMatrixView = getFixedRankView<DataScalar>("identity matrix", spaceDim, spaceDim);
+   auto identityMatrixView = getFixedRankViewDefaultTestDT<DataScalar>("identity matrix", spaceDim, spaceDim);
    auto identityMatrixViewHost = getHostCopy(identityMatrixView);
    
    for (int d1=0; d1<spaceDim; d1++)
@@ -1298,26 +1301,26 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case7_
    Kokkos::Array<int,4> transformationExtents {numCells, numPoints, spaceDim, spaceDim};
    Kokkos::Array<DataVariationType,4> transformationVariationType {CONSTANT, CONSTANT, GENERAL, GENERAL};
    
-   Data<DataScalar,ExecSpaceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType);
+   Data<DataScalar,DeviceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType);
      
    const int numFamilies = 1;
-   Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > firstFamilyLeft  {tensorDataLeft,TensorData<DataScalar,ExecSpaceType>(),TensorData<DataScalar,ExecSpaceType>()};
-   Kokkos::Array< Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim>, numFamilies> vectorComponentsLeft {firstFamilyLeft};
+   Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > firstFamilyLeft  {tensorDataLeft,TensorData<DataScalar,DeviceType>(),TensorData<DataScalar,DeviceType>()};
+   Kokkos::Array< Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim>, numFamilies> vectorComponentsLeft {firstFamilyLeft};
   
-   VectorData<DataScalar,ExecSpaceType> vectorDataLeft(vectorComponentsLeft);
+   VectorData<DataScalar,DeviceType> vectorDataLeft(vectorComponentsLeft);
    TEST_EQUALITY(numFieldsPerFamilyLeft, vectorDataLeft.numFieldsInFamily(0));
   
-   Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > firstFamilyRight  {tensorDataRight,TensorData<DataScalar,ExecSpaceType>(),TensorData<DataScalar,ExecSpaceType>()};
-   Kokkos::Array< Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim>, numFamilies> vectorComponentsRight {firstFamilyRight};
+   Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > firstFamilyRight  {tensorDataRight,TensorData<DataScalar,DeviceType>(),TensorData<DataScalar,DeviceType>()};
+   Kokkos::Array< Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim>, numFamilies> vectorComponentsRight {firstFamilyRight};
    
-   VectorData<DataScalar,ExecSpaceType> vectorDataRight(vectorComponentsRight);
+   VectorData<DataScalar,DeviceType> vectorDataRight(vectorComponentsRight);
    TEST_EQUALITY(numFieldsPerFamilyRight, vectorDataRight.numFieldsInFamily(0));
    
-   TransformedVectorData<DataScalar,ExecSpaceType>  transformedUnitVectorDataLeft(explicitIdentityMatrix,vectorDataLeft);
-   TransformedVectorData<DataScalar,ExecSpaceType> transformedUnitVectorDataRight(explicitIdentityMatrix,vectorDataRight);
+   TransformedVectorData<DataScalar,DeviceType>  transformedUnitVectorDataLeft(explicitIdentityMatrix,vectorDataLeft);
+   TransformedVectorData<DataScalar,DeviceType> transformedUnitVectorDataRight(explicitIdentityMatrix,vectorDataRight);
    
-   Data<DataScalar,ExecSpaceType> constantCellMeasuresData(1.0, Kokkos::Array<int,2>{numCells,numPoints});
-   TensorData<DataScalar,ExecSpaceType> constantCellMeasures(constantCellMeasuresData);
+   Data<DataScalar,DeviceType> constantCellMeasuresData(1.0, Kokkos::Array<int,2>{numCells,numPoints});
+   TensorData<DataScalar,DeviceType> constantCellMeasures(constantCellMeasuresData);
    
    testIntegrateMatchesBaseline(transformedUnitVectorDataLeft, constantCellMeasures, transformedUnitVectorDataRight, out, success);
 }
@@ -1327,7 +1330,7 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case8_
 {
   // like case 7, but multi-family
   using DataScalar  = double;
-  using ExecSpaceType = Kokkos::DefaultExecutionSpace;
+  using DeviceType = DefaultTestDeviceType;
   
   const int spaceDim = 3;
   
@@ -1340,15 +1343,15 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case8_
   const int numFieldsPerFamilyLeft  = numFields1 * numFields2 * numFields3;
   const int numFieldsPerFamilyRight = numFields1 * numFields3 * numFields2;
   
-  auto fieldComponentDataView1 = getFixedRankView<DataScalar>("field component data 1", numFields1);
+  auto fieldComponentDataView1 = getFixedRankViewDefaultTestDT<DataScalar>("field component data 1", numFields1);
   auto fieldComponentDataViewHost1 = Kokkos::create_mirror_view(fieldComponentDataView1);
   fieldComponentDataViewHost1(0) = 1.0;
   
-  auto fieldComponentDataView2 = getFixedRankView<DataScalar>("field component data 2", numFields2);
+  auto fieldComponentDataView2 = getFixedRankViewDefaultTestDT<DataScalar>("field component data 2", numFields2);
   auto fieldComponentDataViewHost2 = Kokkos::create_mirror_view(fieldComponentDataView2);
   fieldComponentDataViewHost2(0) = 1.0/2.0;
   
-  auto fieldComponentDataView3 = getFixedRankView<DataScalar>("field component data 3", numFields3);
+  auto fieldComponentDataView3 = getFixedRankViewDefaultTestDT<DataScalar>("field component data 3", numFields3);
   auto fieldComponentDataViewHost3 = Kokkos::create_mirror_view(fieldComponentDataView3);
   fieldComponentDataViewHost3(0) = 0.5;
   
@@ -1359,16 +1362,16 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case8_
   const int fieldComponentDataRank = 2;
   Kokkos::Array<int,fieldComponentDataRank> fieldComponentExtents {numFields1,numComponentPoints};
   Kokkos::Array<DataVariationType,fieldComponentDataRank> fieldComponentVariationTypes {GENERAL,GENERAL};
-  Data<DataScalar,ExecSpaceType> fieldComponentData1(fieldComponentDataView1,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData1(fieldComponentDataView1,fieldComponentExtents,fieldComponentVariationTypes);
   fieldComponentExtents[0] = numFields2;
-  Data<DataScalar,ExecSpaceType> fieldComponentData2(fieldComponentDataView2,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData2(fieldComponentDataView2,fieldComponentExtents,fieldComponentVariationTypes);
   fieldComponentExtents[0] = numFields3;
-  Data<DataScalar,ExecSpaceType> fieldComponentData3(fieldComponentDataView3,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData3(fieldComponentDataView3,fieldComponentExtents,fieldComponentVariationTypes);
   
-   TensorData<DataScalar,ExecSpaceType>  tensorDataLeft(std::vector< Data<DataScalar,ExecSpaceType> >{fieldComponentData1,fieldComponentData2,fieldComponentData3});
-   TensorData<DataScalar,ExecSpaceType> tensorDataRight(std::vector< Data<DataScalar,ExecSpaceType> >{fieldComponentData1,fieldComponentData3,fieldComponentData2});
+   TensorData<DataScalar,DeviceType>  tensorDataLeft(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData1,fieldComponentData2,fieldComponentData3});
+   TensorData<DataScalar,DeviceType> tensorDataRight(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData1,fieldComponentData3,fieldComponentData2});
    
-   auto identityMatrixView = getFixedRankView<DataScalar>("identity matrix", spaceDim, spaceDim);
+   auto identityMatrixView = getFixedRankViewDefaultTestDT<DataScalar>("identity matrix", spaceDim, spaceDim);
    auto identityMatrixViewHost = getHostCopy(identityMatrixView);
    
    for (int d1=0; d1<spaceDim; d1++)
@@ -1384,31 +1387,31 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case8_
    Kokkos::Array<int,4> transformationExtents {numCells, numPoints, spaceDim, spaceDim};
    Kokkos::Array<DataVariationType,4> transformationVariationType {CONSTANT, CONSTANT, GENERAL, GENERAL};
    
-   Data<DataScalar,ExecSpaceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType);
+   Data<DataScalar,DeviceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType);
    
    const int numFamilies = 3;
-   Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > firstFamilyLeft  {tensorDataLeft,TensorData<DataScalar,ExecSpaceType>(),TensorData<DataScalar,ExecSpaceType>()};
-   Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > secondFamilyLeft {TensorData<DataScalar,ExecSpaceType>(),tensorDataLeft,TensorData<DataScalar,ExecSpaceType>()};
-   Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > thirdFamilyLeft  {TensorData<DataScalar,ExecSpaceType>(),TensorData<DataScalar,ExecSpaceType>(),tensorDataLeft};
-   Kokkos::Array< Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim>, numFamilies> vectorComponentsLeft {firstFamilyLeft, secondFamilyLeft, thirdFamilyLeft};
+   Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > firstFamilyLeft  {tensorDataLeft,TensorData<DataScalar,DeviceType>(),TensorData<DataScalar,DeviceType>()};
+   Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > secondFamilyLeft {TensorData<DataScalar,DeviceType>(),tensorDataLeft,TensorData<DataScalar,DeviceType>()};
+   Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > thirdFamilyLeft  {TensorData<DataScalar,DeviceType>(),TensorData<DataScalar,DeviceType>(),tensorDataLeft};
+   Kokkos::Array< Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim>, numFamilies> vectorComponentsLeft {firstFamilyLeft, secondFamilyLeft, thirdFamilyLeft};
 
-   VectorData<DataScalar,ExecSpaceType> vectorDataLeft(vectorComponentsLeft);
+   VectorData<DataScalar,DeviceType> vectorDataLeft(vectorComponentsLeft);
    TEST_EQUALITY(numFieldsPerFamilyLeft, vectorDataLeft.numFieldsInFamily(0));
    TEST_EQUALITY(numFieldsPerFamilyLeft, vectorDataLeft.numFieldsInFamily(1));
 
-   Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > firstFamilyRight  {tensorDataRight,TensorData<DataScalar,ExecSpaceType>(),TensorData<DataScalar,ExecSpaceType>()};
-   Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > secondFamilyRight {TensorData<DataScalar,ExecSpaceType>(),tensorDataRight,TensorData<DataScalar,ExecSpaceType>()};
-   Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > thirdFamilyRight  {TensorData<DataScalar,ExecSpaceType>(),TensorData<DataScalar,ExecSpaceType>(),tensorDataRight};
-   Kokkos::Array< Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim>, numFamilies> vectorComponentsRight {firstFamilyRight, secondFamilyRight, thirdFamilyRight};
-   VectorData<DataScalar,ExecSpaceType> vectorDataRight(vectorComponentsRight);
+   Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > firstFamilyRight  {tensorDataRight,TensorData<DataScalar,DeviceType>(),TensorData<DataScalar,DeviceType>()};
+   Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > secondFamilyRight {TensorData<DataScalar,DeviceType>(),tensorDataRight,TensorData<DataScalar,DeviceType>()};
+   Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > thirdFamilyRight  {TensorData<DataScalar,DeviceType>(),TensorData<DataScalar,DeviceType>(),tensorDataRight};
+   Kokkos::Array< Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim>, numFamilies> vectorComponentsRight {firstFamilyRight, secondFamilyRight, thirdFamilyRight};
+   VectorData<DataScalar,DeviceType> vectorDataRight(vectorComponentsRight);
    TEST_EQUALITY(numFieldsPerFamilyRight, vectorDataRight.numFieldsInFamily(0));
    TEST_EQUALITY(numFieldsPerFamilyRight, vectorDataRight.numFieldsInFamily(1));
   
-   TransformedVectorData<DataScalar,ExecSpaceType>  transformedUnitVectorDataLeft(explicitIdentityMatrix,vectorDataLeft);
-   TransformedVectorData<DataScalar,ExecSpaceType> transformedUnitVectorDataRight(explicitIdentityMatrix,vectorDataRight);
+   TransformedVectorData<DataScalar,DeviceType>  transformedUnitVectorDataLeft(explicitIdentityMatrix,vectorDataLeft);
+   TransformedVectorData<DataScalar,DeviceType> transformedUnitVectorDataRight(explicitIdentityMatrix,vectorDataRight);
    
-   Data<DataScalar,ExecSpaceType> constantCellMeasuresData(1.0, Kokkos::Array<int,2>{numCells,numPoints});
-   TensorData<DataScalar,ExecSpaceType> constantCellMeasures(constantCellMeasuresData);
+   Data<DataScalar,DeviceType> constantCellMeasuresData(1.0, Kokkos::Array<int,2>{numCells,numPoints});
+   TensorData<DataScalar,DeviceType> constantCellMeasures(constantCellMeasuresData);
    
    testIntegrateMatchesBaseline(transformedUnitVectorDataLeft, constantCellMeasures, transformedUnitVectorDataRight, out, success);
 }
@@ -1417,7 +1420,7 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case8_
 TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case9_3D )
 {
   using DataScalar  = double;
-  using ExecSpaceType = Kokkos::DefaultExecutionSpace;
+  using DeviceType = DefaultTestDeviceType;
   
   const int spaceDim = 3;
   
@@ -1429,13 +1432,13 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case9_
   const int numFieldsPerFamilyLeft  = numFields1 * numFields2 * numFields1;
   const int numFieldsPerFamilyRight = numFields1 * numFields2 * numFields1;
   
-  auto fieldComponentDataView1 = getFixedRankView<DataScalar>("imitation VALUE data", numFields1, numComponentPoints);
+  auto fieldComponentDataView1 = getFixedRankViewDefaultTestDT<DataScalar>("imitation VALUE data", numFields1, numComponentPoints);
   auto fieldComponentDataViewHost1 = Kokkos::create_mirror_view(fieldComponentDataView1);
   fieldComponentDataViewHost1(0,0) = 1.0;
   fieldComponentDataViewHost1(0,1) = 2.0;
   fieldComponentDataViewHost1(0,2) = 3.0;
   
-  auto fieldComponentDataView2 = getFixedRankView<DataScalar>("imitation GRAD data", numFields2, numComponentPoints);
+  auto fieldComponentDataView2 = getFixedRankViewDefaultTestDT<DataScalar>("imitation GRAD data", numFields2, numComponentPoints);
   auto fieldComponentDataViewHost2 = Kokkos::create_mirror_view(fieldComponentDataView2);
   fieldComponentDataViewHost2(0,0) = 1./1.0;
   fieldComponentDataViewHost2(0,1) = 1./2.0;
@@ -1447,19 +1450,19 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case9_
   const int fieldComponentDataRank = 2;
   Kokkos::Array<int,fieldComponentDataRank> fieldComponentExtents {numFields1,numComponentPoints};
   Kokkos::Array<DataVariationType,fieldComponentDataRank> fieldComponentVariationTypes {GENERAL,GENERAL};
-  Data<DataScalar,ExecSpaceType> fieldComponentData1(fieldComponentDataView1,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData1(fieldComponentDataView1,fieldComponentExtents,fieldComponentVariationTypes);
   fieldComponentExtents[0] = numFields2;
-  Data<DataScalar,ExecSpaceType> fieldComponentData2(fieldComponentDataView2,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData2(fieldComponentDataView2,fieldComponentExtents,fieldComponentVariationTypes);
   
-  TensorData<DataScalar,ExecSpaceType>  tensorDataLeft1(std::vector< Data<DataScalar,ExecSpaceType> >{fieldComponentData2,fieldComponentData1,fieldComponentData1});
-  TensorData<DataScalar,ExecSpaceType>  tensorDataLeft2(std::vector< Data<DataScalar,ExecSpaceType> >{fieldComponentData1,fieldComponentData2,fieldComponentData1});
-  TensorData<DataScalar,ExecSpaceType>  tensorDataLeft3(std::vector< Data<DataScalar,ExecSpaceType> >{fieldComponentData1,fieldComponentData1,fieldComponentData2});
-  TensorData<DataScalar,ExecSpaceType> tensorDataRight1 = tensorDataLeft1;
-  TensorData<DataScalar,ExecSpaceType> tensorDataRight2 = tensorDataLeft2;
-  TensorData<DataScalar,ExecSpaceType> tensorDataRight3 = tensorDataLeft3;
+  TensorData<DataScalar,DeviceType>  tensorDataLeft1(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData2,fieldComponentData1,fieldComponentData1});
+  TensorData<DataScalar,DeviceType>  tensorDataLeft2(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData1,fieldComponentData2,fieldComponentData1});
+  TensorData<DataScalar,DeviceType>  tensorDataLeft3(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData1,fieldComponentData1,fieldComponentData2});
+  TensorData<DataScalar,DeviceType> tensorDataRight1 = tensorDataLeft1;
+  TensorData<DataScalar,DeviceType> tensorDataRight2 = tensorDataLeft2;
+  TensorData<DataScalar,DeviceType> tensorDataRight3 = tensorDataLeft3;
    
   const int numPoints = numComponentPoints * numComponentPoints * numComponentPoints;
-  auto identityMatrixView = getFixedRankView<DataScalar>("identity matrix", numPoints, spaceDim, spaceDim);
+  auto identityMatrixView = getFixedRankViewDefaultTestDT<DataScalar>("identity matrix", numPoints, spaceDim, spaceDim);
   auto identityMatrixViewHost = getHostCopy(identityMatrixView);
   
   for (int pointOrdinal=0; pointOrdinal<numPoints; pointOrdinal++)
@@ -1478,25 +1481,25 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case9_
   Kokkos::Array<int,4> transformationExtents {numCells, numPoints, spaceDim, spaceDim};
   Kokkos::Array<DataVariationType,4> transformationVariationType {CONSTANT, GENERAL, GENERAL, GENERAL};
   
-  Data<DataScalar,ExecSpaceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType);
+  Data<DataScalar,DeviceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType);
   
   const int numFamilies = 1;
-  Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > firstFamilyLeft  {tensorDataLeft1,tensorDataLeft2,tensorDataLeft3};
-  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim>, numFamilies> vectorComponentsLeft {firstFamilyLeft};
+  Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > firstFamilyLeft  {tensorDataLeft1,tensorDataLeft2,tensorDataLeft3};
+  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim>, numFamilies> vectorComponentsLeft {firstFamilyLeft};
 
-  VectorData<DataScalar,ExecSpaceType> vectorDataLeft(vectorComponentsLeft);
+  VectorData<DataScalar,DeviceType> vectorDataLeft(vectorComponentsLeft);
   TEST_EQUALITY(numFieldsPerFamilyLeft, vectorDataLeft.numFieldsInFamily(0));
 
-  Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > firstFamilyRight  {tensorDataRight1,tensorDataRight2,tensorDataRight3};
-  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim>, numFamilies> vectorComponentsRight {firstFamilyRight};
-  VectorData<DataScalar,ExecSpaceType> vectorDataRight(vectorComponentsRight);
+  Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > firstFamilyRight  {tensorDataRight1,tensorDataRight2,tensorDataRight3};
+  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim>, numFamilies> vectorComponentsRight {firstFamilyRight};
+  VectorData<DataScalar,DeviceType> vectorDataRight(vectorComponentsRight);
   TEST_EQUALITY(numFieldsPerFamilyRight, vectorDataRight.numFieldsInFamily(0));
   
-  TransformedVectorData<DataScalar,ExecSpaceType>  transformedUnitVectorDataLeft(explicitIdentityMatrix,vectorDataLeft);
-  TransformedVectorData<DataScalar,ExecSpaceType> transformedUnitVectorDataRight(explicitIdentityMatrix,vectorDataRight);
+  TransformedVectorData<DataScalar,DeviceType>  transformedUnitVectorDataLeft(explicitIdentityMatrix,vectorDataLeft);
+  TransformedVectorData<DataScalar,DeviceType> transformedUnitVectorDataRight(explicitIdentityMatrix,vectorDataRight);
   
-  Data<DataScalar,ExecSpaceType> constantCellMeasuresData(1.0, Kokkos::Array<int,2>{numCells,numPoints});
-  TensorData<DataScalar,ExecSpaceType> constantCellMeasures(constantCellMeasuresData);
+  Data<DataScalar,DeviceType> constantCellMeasuresData(1.0, Kokkos::Array<int,2>{numCells,numPoints});
+  TensorData<DataScalar,DeviceType> constantCellMeasures(constantCellMeasuresData);
   
   testIntegrateMatchesBaseline(transformedUnitVectorDataLeft, constantCellMeasures, transformedUnitVectorDataRight, out, success);
 }
@@ -1506,7 +1509,7 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case10
 {
   // test with variable quadrature weights
   using DataScalar  = double;
-  using ExecSpaceType = Kokkos::DefaultExecutionSpace;
+  using DeviceType = DefaultTestDeviceType;
   
   const int spaceDim = 3;
   
@@ -1518,12 +1521,12 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case10
   const int numFieldsPerFamilyLeft  = numFields1 * numFields2 * numFields1;
   const int numFieldsPerFamilyRight = numFields1 * numFields2 * numFields1;
   
-  auto fieldComponentDataView1 = getFixedRankView<DataScalar>("imitation VALUE data", numFields1, numComponentPoints);
+  auto fieldComponentDataView1 = getFixedRankViewDefaultTestDT<DataScalar>("imitation VALUE data", numFields1, numComponentPoints);
   auto fieldComponentDataViewHost1 = Kokkos::create_mirror_view(fieldComponentDataView1);
   fieldComponentDataViewHost1(0,0) = 1;
   fieldComponentDataViewHost1(0,1) = 1;
   
-  auto fieldComponentDataView2 = getFixedRankView<DataScalar>("imitation GRAD data", numFields2, numComponentPoints);
+  auto fieldComponentDataView2 = getFixedRankViewDefaultTestDT<DataScalar>("imitation GRAD data", numFields2, numComponentPoints);
   auto fieldComponentDataViewHost2 = Kokkos::create_mirror_view(fieldComponentDataView2);
   fieldComponentDataViewHost2(0,0) = 1;
   fieldComponentDataViewHost2(0,1) = 1;
@@ -1534,18 +1537,18 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case10
   const int fieldComponentDataRank = 2;
   Kokkos::Array<int,fieldComponentDataRank> fieldComponentExtents {numFields1,numComponentPoints};
   Kokkos::Array<DataVariationType,fieldComponentDataRank> fieldComponentVariationTypes {GENERAL,GENERAL};
-  Data<DataScalar,ExecSpaceType> fieldComponentData1(fieldComponentDataView1,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData1(fieldComponentDataView1,fieldComponentExtents,fieldComponentVariationTypes);
   fieldComponentExtents[0] = numFields2;
-  Data<DataScalar,ExecSpaceType> fieldComponentData2(fieldComponentDataView2,fieldComponentExtents,fieldComponentVariationTypes);
+  Data<DataScalar,DeviceType> fieldComponentData2(fieldComponentDataView2,fieldComponentExtents,fieldComponentVariationTypes);
   
-  TensorData<DataScalar,ExecSpaceType>  tensorDataLeft1(std::vector< Data<DataScalar,ExecSpaceType> >{fieldComponentData2,fieldComponentData1,fieldComponentData1});
-  TensorData<DataScalar,ExecSpaceType>  tensorDataLeft2(std::vector< Data<DataScalar,ExecSpaceType> >{fieldComponentData1,fieldComponentData2,fieldComponentData1});
-  TensorData<DataScalar,ExecSpaceType>  tensorDataLeft3(std::vector< Data<DataScalar,ExecSpaceType> >{fieldComponentData1,fieldComponentData1,fieldComponentData2});
-  TensorData<DataScalar,ExecSpaceType> tensorDataRight1 = tensorDataLeft1;
-  TensorData<DataScalar,ExecSpaceType> tensorDataRight2 = tensorDataLeft2;
-  TensorData<DataScalar,ExecSpaceType> tensorDataRight3 = tensorDataLeft3;
+  TensorData<DataScalar,DeviceType>  tensorDataLeft1(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData2,fieldComponentData1,fieldComponentData1});
+  TensorData<DataScalar,DeviceType>  tensorDataLeft2(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData1,fieldComponentData2,fieldComponentData1});
+  TensorData<DataScalar,DeviceType>  tensorDataLeft3(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData1,fieldComponentData1,fieldComponentData2});
+  TensorData<DataScalar,DeviceType> tensorDataRight1 = tensorDataLeft1;
+  TensorData<DataScalar,DeviceType> tensorDataRight2 = tensorDataLeft2;
+  TensorData<DataScalar,DeviceType> tensorDataRight3 = tensorDataLeft3;
    
-  auto identityMatrixView = getFixedRankView<DataScalar>("identity matrix", spaceDim, spaceDim);
+  auto identityMatrixView = getFixedRankViewDefaultTestDT<DataScalar>("identity matrix", spaceDim, spaceDim);
   auto identityMatrixViewHost = getHostCopy(identityMatrixView);
   
   for (int d1=0; d1<spaceDim; d1++)
@@ -1561,24 +1564,24 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case10
   Kokkos::Array<int,4> transformationExtents {numCells, numPoints, spaceDim, spaceDim};
   Kokkos::Array<DataVariationType,4> transformationVariationType {CONSTANT, CONSTANT, GENERAL, GENERAL};
   
-  Data<DataScalar,ExecSpaceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType);
+  Data<DataScalar,DeviceType> explicitIdentityMatrix(identityMatrixView, transformationExtents, transformationVariationType);
   
   const int numFamilies = 1;
-  Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > firstFamilyLeft  {tensorDataLeft1,tensorDataLeft2,tensorDataLeft3};
-  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim>, numFamilies> vectorComponentsLeft {firstFamilyLeft};
+  Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > firstFamilyLeft  {tensorDataLeft1,tensorDataLeft2,tensorDataLeft3};
+  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim>, numFamilies> vectorComponentsLeft {firstFamilyLeft};
 
-  VectorData<DataScalar,ExecSpaceType> vectorDataLeft(vectorComponentsLeft);
+  VectorData<DataScalar,DeviceType> vectorDataLeft(vectorComponentsLeft);
   TEST_EQUALITY(numFieldsPerFamilyLeft, vectorDataLeft.numFieldsInFamily(0));
 
-  Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim > firstFamilyRight  {tensorDataRight1,tensorDataRight2,tensorDataRight3};
-  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,ExecSpaceType>, spaceDim>, numFamilies> vectorComponentsRight {firstFamilyRight};
-  VectorData<DataScalar,ExecSpaceType> vectorDataRight(vectorComponentsRight);
+  Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim > firstFamilyRight  {tensorDataRight1,tensorDataRight2,tensorDataRight3};
+  Kokkos::Array< Kokkos::Array<TensorData<DataScalar,DeviceType>, spaceDim>, numFamilies> vectorComponentsRight {firstFamilyRight};
+  VectorData<DataScalar,DeviceType> vectorDataRight(vectorComponentsRight);
   TEST_EQUALITY(numFieldsPerFamilyRight, vectorDataRight.numFieldsInFamily(0));
   
-  TransformedVectorData<DataScalar,ExecSpaceType>  transformedUnitVectorDataLeft(explicitIdentityMatrix,vectorDataLeft);
-  TransformedVectorData<DataScalar,ExecSpaceType> transformedUnitVectorDataRight(explicitIdentityMatrix,vectorDataRight);
+  TransformedVectorData<DataScalar,DeviceType>  transformedUnitVectorDataLeft(explicitIdentityMatrix,vectorDataLeft);
+  TransformedVectorData<DataScalar,DeviceType> transformedUnitVectorDataRight(explicitIdentityMatrix,vectorDataRight);
   
-  auto cellMeasures = getFixedRankView<DataScalar>("cellMeasures", numCells, numPoints);
+  auto cellMeasures = getFixedRankViewDefaultTestDT<DataScalar>("cellMeasures", numCells, numPoints);
   
   auto cellMeasuresHost = getHostCopy(cellMeasures);
   
@@ -1591,8 +1594,8 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case10
   }
   Kokkos::deep_copy(cellMeasures, cellMeasuresHost);
   
-  Data<DataScalar,ExecSpaceType> cellMeasuresData(cellMeasures, Kokkos::Array<int,2>{numCells,numPoints}, Kokkos::Array<DataVariationType,2>{GENERAL,GENERAL});
-  TensorData<DataScalar,ExecSpaceType> cellMeasuresTensorData(cellMeasuresData);
+  Data<DataScalar,DeviceType> cellMeasuresData(cellMeasures, Kokkos::Array<int,2>{numCells,numPoints}, Kokkos::Array<DataVariationType,2>{GENERAL,GENERAL});
+  TensorData<DataScalar,DeviceType> cellMeasuresTensorData(cellMeasuresData);
   
   testIntegrateMatchesBaseline(transformedUnitVectorDataLeft, cellMeasuresTensorData, transformedUnitVectorDataRight, out, success);
 }

--- a/packages/intrepid2/unit-test/MonolithicExecutable/StructuredIntegrationTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/StructuredIntegrationTests.cpp
@@ -139,7 +139,7 @@ void integrate_baseline(Data<Scalar,DeviceType> integrals, const TransformedVect
     }
   });
   
-  int approximateFlopCount = (spaceDim*2 + 2) * numPoints * numFieldsLeft * numFieldsRight * cellDataExtent;
+//  int approximateFlopCount = (spaceDim*2 + 2) * numPoints * numFieldsLeft * numFieldsRight * cellDataExtent;
 //  printView(integralView, std::cout, "stiffness in " + std::to_string(spaceDim) + "D");
 //  std::cout << "\n\nApproximate flop count (baseline): " << approximateFlopCount << std::endl;
 }

--- a/packages/intrepid2/unit-test/MonolithicExecutable/StructuredIntegrationTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/StructuredIntegrationTests.cpp
@@ -179,7 +179,7 @@ ScalarView<Scalar,DeviceType> performStandardQuadratureHypercube(int meshWidth, 
   else if (spaceDim == 2) cellTopo = shards::getCellTopologyData< shards::Quadrilateral<> >();
   else if (spaceDim == 3) cellTopo = shards::getCellTopologyData< shards::Hexahedron<>    >();
   
-  auto basis = Intrepid2::getBasis< Intrepid2::NodalBasisFamily<> >(cellTopo, fs, polyOrder);
+  auto basis = Intrepid2::getBasis< Intrepid2::NodalBasisFamily<DeviceType> >(cellTopo, fs, polyOrder);
   
   int numFields = basis->getCardinality();
   int numHypercubes = 1;

--- a/packages/intrepid2/unit-test/MonolithicExecutable/StructuredIntegrationTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/StructuredIntegrationTests.cpp
@@ -85,8 +85,6 @@ template<class Scalar, typename DeviceType>
 void integrate_baseline(Data<Scalar,DeviceType> integrals, const TransformedVectorData<Scalar,DeviceType> vectorDataLeft,
                         const TensorData<Scalar,DeviceType> cellMeasures, const TransformedVectorData<Scalar,DeviceType> vectorDataRight)
 {
-  const int numFieldsLeft  = vectorDataLeft.numFields();
-  const int numFieldsRight = vectorDataRight.numFields();
   const int spaceDim       = vectorDataLeft.spaceDim();
   
   // use the CFPD operator() provided by the vector data objects; don't take advantage of tensor product structure at all
@@ -110,7 +108,7 @@ void integrate_baseline(Data<Scalar,DeviceType> integrals, const TransformedVect
   const int integralViewRank = integrals.getUnderlyingViewRank();
   
   using ExecutionSpace = typename DeviceType::execution_space;
-  auto policy = Kokkos::MDRangePolicy<ExecutionSpace,Kokkos::Rank<3>>({0,0,0},{integrals.getDataExtent(0),numFieldsLeft,numFieldsRight});
+  auto policy = Kokkos::MDRangePolicy<ExecutionSpace,Kokkos::Rank<3>>({0,0,0},{integrals.getDataExtent(0),vectorDataLeft.numFields(),vectorDataRight.numFields()});
   Kokkos::parallel_for("fill expanded cell nodes", policy,
   KOKKOS_LAMBDA (const int &cellDataOrdinal, const int &fieldOrdinalLeft, const int &fieldOrdinalRight)
   {
@@ -137,7 +135,8 @@ void integrate_baseline(Data<Scalar,DeviceType> integrals, const TransformedVect
       integralView(fieldOrdinalLeft,fieldOrdinalRight) = integral;
     }
   });
-  
+//  const int numFieldsLeft  = vectorDataLeft.numFields();
+//  const int numFieldsRight = vectorDataRight.numFields();
 //  int approximateFlopCount = (spaceDim*2 + 2) * numPoints * numFieldsLeft * numFieldsRight * cellDataExtent;
 //  printView(integralView, std::cout, "stiffness in " + std::to_string(spaceDim) + "D");
 //  std::cout << "\n\nApproximate flop count (baseline): " << approximateFlopCount << std::endl;

--- a/packages/intrepid2/unit-test/MonolithicExecutable/StructuredIntegrationTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/StructuredIntegrationTests.cpp
@@ -649,7 +649,7 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_AxisAlignedPath_Ca
   Data<DataScalar,DeviceType> unitData(1.0, Kokkos::Array<int,2>{numFields,numComponentPoints});
   TensorData<DataScalar,DeviceType> unitTensorData(std::vector< Data<DataScalar,DeviceType> >{unitData,unitData});
   
-  auto identityMatrixView = getFixedRankViewDefaultTestDT<DataScalar>("identity matrix", spaceDim);
+  auto identityMatrixView = getFixedRankView<DataScalar>("identity matrix", spaceDim);
   Kokkos::deep_copy(identityMatrixView, 1.0);
   
   Kokkos::Array<int,4> transformationExtents {numCells, numPoints, spaceDim, spaceDim};
@@ -692,7 +692,7 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case1 
   Data<DataScalar,DeviceType> unitData(1.0, Kokkos::Array<int,2>{numFields,numPoints});
   TensorData<DataScalar,DeviceType> unitTensorData(std::vector< Data<DataScalar,DeviceType> >{unitData,unitData});
   
-  auto identityMatrixView = getFixedRankViewDefaultTestDT<DataScalar>("identity matrix", spaceDim, spaceDim);
+  auto identityMatrixView = getFixedRankView<DataScalar>("identity matrix", spaceDim, spaceDim);
   auto identityMatrixViewHost = getHostCopy(identityMatrixView);
   
   for (int d1=0; d1<spaceDim; d1++)
@@ -736,11 +736,11 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case2 
   const int numComponentPoints = 1;
   const int numComponentFields = 1;
   
-  auto fieldComponentDataView1 = getFixedRankViewDefaultTestDT<DataScalar>("field component data 1", numComponentFields);
+  auto fieldComponentDataView1 = getFixedRankView<DataScalar>("field component data 1", numComponentFields);
   auto fieldComponentDataViewHost1 = Kokkos::create_mirror_view(fieldComponentDataView1);
   fieldComponentDataViewHost1(0) = 1.0;
   
-  auto fieldComponentDataView2 = getFixedRankViewDefaultTestDT<DataScalar>("field component data 2", numComponentFields);
+  auto fieldComponentDataView2 = getFixedRankView<DataScalar>("field component data 2", numComponentFields);
   auto fieldComponentDataViewHost2 = Kokkos::create_mirror_view(fieldComponentDataView2);
   fieldComponentDataViewHost2(0) = 2.0;
   
@@ -755,7 +755,7 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case2 
   
   TensorData<DataScalar,DeviceType> tensorData(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData1,fieldComponentData2});
   
-  auto identityMatrixView = getFixedRankViewDefaultTestDT<DataScalar>("identity matrix", spaceDim, spaceDim);
+  auto identityMatrixView = getFixedRankView<DataScalar>("identity matrix", spaceDim, spaceDim);
   auto identityMatrixViewHost = getHostCopy(identityMatrixView);
   
   for (int d1=0; d1<spaceDim; d1++)
@@ -812,14 +812,14 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case3 
   const int numComponentPoints = 2;
   const int numFields = 2;
   
-  auto fieldComponentDataView1 = getFixedRankViewDefaultTestDT<DataScalar>("field component data 1", numFields,numComponentPoints);
+  auto fieldComponentDataView1 = getFixedRankView<DataScalar>("field component data 1", numFields,numComponentPoints);
   auto fieldComponentDataViewHost1 = Kokkos::create_mirror_view(fieldComponentDataView1);
   fieldComponentDataViewHost1(0,0) = 1.0;
   fieldComponentDataViewHost1(0,1) = 2.0;
   fieldComponentDataViewHost1(1,0) = 3.0;
   fieldComponentDataViewHost1(1,1) = 4.0;
   
-  auto fieldComponentDataView2 = getFixedRankViewDefaultTestDT<DataScalar>("field component data 2", numFields,numComponentPoints);
+  auto fieldComponentDataView2 = getFixedRankView<DataScalar>("field component data 2", numFields,numComponentPoints);
   auto fieldComponentDataViewHost2 = Kokkos::create_mirror_view(fieldComponentDataView2);
   fieldComponentDataViewHost2(0,0) = 1.0/1.0;
   fieldComponentDataViewHost2(0,1) = 1.0/2.0;
@@ -837,7 +837,7 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case3 
     
   TensorData<DataScalar,DeviceType> tensorData(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData1,fieldComponentData2});
   
-  auto identityMatrixView = getFixedRankViewDefaultTestDT<DataScalar>("identity matrix", spaceDim, spaceDim);
+  auto identityMatrixView = getFixedRankView<DataScalar>("identity matrix", spaceDim, spaceDim);
   auto identityMatrixViewHost = getHostCopy(identityMatrixView);
   
   for (int d1=0; d1<spaceDim; d1++)
@@ -884,12 +884,12 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case4 
   const int numFields2 = 1;
   const int numFieldsPerFamily = numFields1 * numFields2;
   
-  auto fieldComponentDataView1 = getFixedRankViewDefaultTestDT<DataScalar>("field component data 1", numFields1);
+  auto fieldComponentDataView1 = getFixedRankView<DataScalar>("field component data 1", numFields1);
   auto fieldComponentDataViewHost1 = Kokkos::create_mirror_view(fieldComponentDataView1);
   fieldComponentDataViewHost1(0) = 1.0;
   fieldComponentDataViewHost1(1) = 3.0;
   
-  auto fieldComponentDataView2 = getFixedRankViewDefaultTestDT<DataScalar>("field component data 2", numFields2);
+  auto fieldComponentDataView2 = getFixedRankView<DataScalar>("field component data 2", numFields2);
   auto fieldComponentDataViewHost2 = Kokkos::create_mirror_view(fieldComponentDataView2);
   fieldComponentDataViewHost2(0) = 1.0/2.0;
   
@@ -905,7 +905,7 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case4 
     
   TensorData<DataScalar,DeviceType> nonzeroTensorData(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData1,fieldComponentData2});
   
-  auto identityMatrixView = getFixedRankViewDefaultTestDT<DataScalar>("identity matrix", spaceDim, spaceDim);
+  auto identityMatrixView = getFixedRankView<DataScalar>("identity matrix", spaceDim, spaceDim);
   auto identityMatrixViewHost = getHostCopy(identityMatrixView);
   
   for (int d1=0; d1<spaceDim; d1++)
@@ -956,12 +956,12 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case5 
   const int numFieldsPerFamilyLeft  = numFields1 * numFields2;
   const int numFieldsPerFamilyRight = numFields2 * numFields2;
   
-  auto fieldComponentDataView1 = getFixedRankViewDefaultTestDT<DataScalar>("field component data 1", numFields1);
+  auto fieldComponentDataView1 = getFixedRankView<DataScalar>("field component data 1", numFields1);
   auto fieldComponentDataViewHost1 = Kokkos::create_mirror_view(fieldComponentDataView1);
   fieldComponentDataViewHost1(0) = 1.0;
   fieldComponentDataViewHost1(1) = 3.0;
   
-  auto fieldComponentDataView2 = getFixedRankViewDefaultTestDT<DataScalar>("field component data 2", numFields2);
+  auto fieldComponentDataView2 = getFixedRankView<DataScalar>("field component data 2", numFields2);
   auto fieldComponentDataViewHost2 = Kokkos::create_mirror_view(fieldComponentDataView2);
   fieldComponentDataViewHost2(0) = 1.0/2.0;
   fieldComponentDataViewHost2(1) = 1.0/3.0;
@@ -980,7 +980,7 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case5 
   TensorData<DataScalar,DeviceType>  tensorDataLeft(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData1,fieldComponentData2});
   TensorData<DataScalar,DeviceType> tensorDataRight(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData2,fieldComponentData2});
   
-  auto identityMatrixView = getFixedRankViewDefaultTestDT<DataScalar>("identity matrix", spaceDim, spaceDim);
+  auto identityMatrixView = getFixedRankView<DataScalar>("identity matrix", spaceDim, spaceDim);
   auto identityMatrixViewHost = getHostCopy(identityMatrixView);
   
   for (int d1=0; d1<spaceDim; d1++)
@@ -1041,18 +1041,18 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_AxisAlignedPath_Ca
   const int numFieldsPerFamilyLeft  = numFields1 * numFields2 * numFields3;
   const int numFieldsPerFamilyRight = numFields1 * numFields3 * numFields2;
   
-  auto fieldComponentDataView1 = getFixedRankViewDefaultTestDT<DataScalar>("field component data 1", numFields1);
+  auto fieldComponentDataView1 = getFixedRankView<DataScalar>("field component data 1", numFields1);
   auto fieldComponentDataViewHost1 = Kokkos::create_mirror_view(fieldComponentDataView1);
   fieldComponentDataViewHost1(0) = 1.0;
 //  fieldComponentDataViewHost1(1) = 3.0;
   
-  auto fieldComponentDataView2 = getFixedRankViewDefaultTestDT<DataScalar>("field component data 2", numFields2);
+  auto fieldComponentDataView2 = getFixedRankView<DataScalar>("field component data 2", numFields2);
   auto fieldComponentDataViewHost2 = Kokkos::create_mirror_view(fieldComponentDataView2);
   fieldComponentDataViewHost2(0) = 1.0;
   fieldComponentDataViewHost2(1) = 1.0/3.0;
   fieldComponentDataViewHost2(2) = 1.0/4.0;
   
-  auto fieldComponentDataView3 = getFixedRankViewDefaultTestDT<DataScalar>("field component data 3", numFields3);
+  auto fieldComponentDataView3 = getFixedRankView<DataScalar>("field component data 3", numFields3);
   auto fieldComponentDataViewHost3 = Kokkos::create_mirror_view(fieldComponentDataView3);
   fieldComponentDataViewHost3(0) = 1.0;
   fieldComponentDataViewHost3(1) = 0.25;
@@ -1075,7 +1075,7 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_AxisAlignedPath_Ca
    
    const int numPoints = numComponentPoints * numComponentPoints * numComponentPoints;
    
-   auto identityMatrixView = getFixedRankViewDefaultTestDT<DataScalar>("identity matrix", spaceDim);
+   auto identityMatrixView = getFixedRankView<DataScalar>("identity matrix", spaceDim);
    Kokkos::deep_copy(identityMatrixView, 1.0);
    
    Kokkos::Array<int,4> transformationExtents {numCells, numPoints, spaceDim, spaceDim};
@@ -1130,18 +1130,18 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case6_
   const int numFieldsPerFamilyLeft  = numFields1 * numFields2 * numFields3;
   const int numFieldsPerFamilyRight = numFields1 * numFields3 * numFields2;
   
-  auto fieldComponentDataView1 = getFixedRankViewDefaultTestDT<DataScalar>("field component data 1", numFields1);
+  auto fieldComponentDataView1 = getFixedRankView<DataScalar>("field component data 1", numFields1);
   auto fieldComponentDataViewHost1 = Kokkos::create_mirror_view(fieldComponentDataView1);
   fieldComponentDataViewHost1(0) = 1.0;
 //  fieldComponentDataViewHost1(1) = 3.0;
   
-  auto fieldComponentDataView2 = getFixedRankViewDefaultTestDT<DataScalar>("field component data 2", numFields2);
+  auto fieldComponentDataView2 = getFixedRankView<DataScalar>("field component data 2", numFields2);
   auto fieldComponentDataViewHost2 = Kokkos::create_mirror_view(fieldComponentDataView2);
   fieldComponentDataViewHost2(0) = 1.0/2.0;
   fieldComponentDataViewHost2(1) = 1.0/3.0;
   fieldComponentDataViewHost2(2) = 1.0/4.0;
   
-  auto fieldComponentDataView3 = getFixedRankViewDefaultTestDT<DataScalar>("field component data 3", numFields3);
+  auto fieldComponentDataView3 = getFixedRankView<DataScalar>("field component data 3", numFields3);
   auto fieldComponentDataViewHost3 = Kokkos::create_mirror_view(fieldComponentDataView3);
   fieldComponentDataViewHost3(0) = 0.5;
   fieldComponentDataViewHost3(1) = 0.25;
@@ -1162,7 +1162,7 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case6_
    TensorData<DataScalar,DeviceType>  tensorDataLeft(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData1,fieldComponentData2,fieldComponentData3});
    TensorData<DataScalar,DeviceType> tensorDataRight(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData1,fieldComponentData3,fieldComponentData2});
    
-   auto identityMatrixView = getFixedRankViewDefaultTestDT<DataScalar>("identity matrix", spaceDim, spaceDim);
+   auto identityMatrixView = getFixedRankView<DataScalar>("identity matrix", spaceDim, spaceDim);
    auto identityMatrixViewHost = getHostCopy(identityMatrixView);
    
    for (int d1=0; d1<spaceDim; d1++)
@@ -1239,15 +1239,15 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case7_
   const int numFieldsPerFamilyLeft  = numFields1 * numFields2 * numFields3;
   const int numFieldsPerFamilyRight = numFields1 * numFields3 * numFields2;
   
-  auto fieldComponentDataView1 = getFixedRankViewDefaultTestDT<DataScalar>("field component data 1", numFields1);
+  auto fieldComponentDataView1 = getFixedRankView<DataScalar>("field component data 1", numFields1);
   auto fieldComponentDataViewHost1 = Kokkos::create_mirror_view(fieldComponentDataView1);
   fieldComponentDataViewHost1(0) = 1.0;
   
-  auto fieldComponentDataView2 = getFixedRankViewDefaultTestDT<DataScalar>("field component data 2", numFields2);
+  auto fieldComponentDataView2 = getFixedRankView<DataScalar>("field component data 2", numFields2);
   auto fieldComponentDataViewHost2 = Kokkos::create_mirror_view(fieldComponentDataView2);
   fieldComponentDataViewHost2(0) = 1.0;
   
-  auto fieldComponentDataView3 = getFixedRankViewDefaultTestDT<DataScalar>("field component data 3", numFields3);
+  auto fieldComponentDataView3 = getFixedRankView<DataScalar>("field component data 3", numFields3);
   auto fieldComponentDataViewHost3 = Kokkos::create_mirror_view(fieldComponentDataView3);
   fieldComponentDataViewHost3(0) = 1.0;
   
@@ -1267,7 +1267,7 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case7_
    TensorData<DataScalar,DeviceType>  tensorDataLeft(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData1,fieldComponentData2,fieldComponentData3});
    TensorData<DataScalar,DeviceType> tensorDataRight(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData1,fieldComponentData3,fieldComponentData2});
    
-   auto identityMatrixView = getFixedRankViewDefaultTestDT<DataScalar>("identity matrix", spaceDim, spaceDim);
+   auto identityMatrixView = getFixedRankView<DataScalar>("identity matrix", spaceDim, spaceDim);
    auto identityMatrixViewHost = getHostCopy(identityMatrixView);
    
    for (int d1=0; d1<spaceDim; d1++)
@@ -1325,15 +1325,15 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case8_
   const int numFieldsPerFamilyLeft  = numFields1 * numFields2 * numFields3;
   const int numFieldsPerFamilyRight = numFields1 * numFields3 * numFields2;
   
-  auto fieldComponentDataView1 = getFixedRankViewDefaultTestDT<DataScalar>("field component data 1", numFields1);
+  auto fieldComponentDataView1 = getFixedRankView<DataScalar>("field component data 1", numFields1);
   auto fieldComponentDataViewHost1 = Kokkos::create_mirror_view(fieldComponentDataView1);
   fieldComponentDataViewHost1(0) = 1.0;
   
-  auto fieldComponentDataView2 = getFixedRankViewDefaultTestDT<DataScalar>("field component data 2", numFields2);
+  auto fieldComponentDataView2 = getFixedRankView<DataScalar>("field component data 2", numFields2);
   auto fieldComponentDataViewHost2 = Kokkos::create_mirror_view(fieldComponentDataView2);
   fieldComponentDataViewHost2(0) = 1.0/2.0;
   
-  auto fieldComponentDataView3 = getFixedRankViewDefaultTestDT<DataScalar>("field component data 3", numFields3);
+  auto fieldComponentDataView3 = getFixedRankView<DataScalar>("field component data 3", numFields3);
   auto fieldComponentDataViewHost3 = Kokkos::create_mirror_view(fieldComponentDataView3);
   fieldComponentDataViewHost3(0) = 0.5;
   
@@ -1353,7 +1353,7 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case8_
    TensorData<DataScalar,DeviceType>  tensorDataLeft(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData1,fieldComponentData2,fieldComponentData3});
    TensorData<DataScalar,DeviceType> tensorDataRight(std::vector< Data<DataScalar,DeviceType> >{fieldComponentData1,fieldComponentData3,fieldComponentData2});
    
-   auto identityMatrixView = getFixedRankViewDefaultTestDT<DataScalar>("identity matrix", spaceDim, spaceDim);
+   auto identityMatrixView = getFixedRankView<DataScalar>("identity matrix", spaceDim, spaceDim);
    auto identityMatrixViewHost = getHostCopy(identityMatrixView);
    
    for (int d1=0; d1<spaceDim; d1++)
@@ -1414,13 +1414,13 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case9_
   const int numFieldsPerFamilyLeft  = numFields1 * numFields2 * numFields1;
   const int numFieldsPerFamilyRight = numFields1 * numFields2 * numFields1;
   
-  auto fieldComponentDataView1 = getFixedRankViewDefaultTestDT<DataScalar>("imitation VALUE data", numFields1, numComponentPoints);
+  auto fieldComponentDataView1 = getFixedRankView<DataScalar>("imitation VALUE data", numFields1, numComponentPoints);
   auto fieldComponentDataViewHost1 = Kokkos::create_mirror_view(fieldComponentDataView1);
   fieldComponentDataViewHost1(0,0) = 1.0;
   fieldComponentDataViewHost1(0,1) = 2.0;
   fieldComponentDataViewHost1(0,2) = 3.0;
   
-  auto fieldComponentDataView2 = getFixedRankViewDefaultTestDT<DataScalar>("imitation GRAD data", numFields2, numComponentPoints);
+  auto fieldComponentDataView2 = getFixedRankView<DataScalar>("imitation GRAD data", numFields2, numComponentPoints);
   auto fieldComponentDataViewHost2 = Kokkos::create_mirror_view(fieldComponentDataView2);
   fieldComponentDataViewHost2(0,0) = 1./1.0;
   fieldComponentDataViewHost2(0,1) = 1./2.0;
@@ -1444,7 +1444,7 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case9_
   TensorData<DataScalar,DeviceType> tensorDataRight3 = tensorDataLeft3;
    
   const int numPoints = numComponentPoints * numComponentPoints * numComponentPoints;
-  auto identityMatrixView = getFixedRankViewDefaultTestDT<DataScalar>("identity matrix", numPoints, spaceDim, spaceDim);
+  auto identityMatrixView = getFixedRankView<DataScalar>("identity matrix", numPoints, spaceDim, spaceDim);
   auto identityMatrixViewHost = getHostCopy(identityMatrixView);
   
   for (int pointOrdinal=0; pointOrdinal<numPoints; pointOrdinal++)
@@ -1503,12 +1503,12 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case10
   const int numFieldsPerFamilyLeft  = numFields1 * numFields2 * numFields1;
   const int numFieldsPerFamilyRight = numFields1 * numFields2 * numFields1;
   
-  auto fieldComponentDataView1 = getFixedRankViewDefaultTestDT<DataScalar>("imitation VALUE data", numFields1, numComponentPoints);
+  auto fieldComponentDataView1 = getFixedRankView<DataScalar>("imitation VALUE data", numFields1, numComponentPoints);
   auto fieldComponentDataViewHost1 = Kokkos::create_mirror_view(fieldComponentDataView1);
   fieldComponentDataViewHost1(0,0) = 1;
   fieldComponentDataViewHost1(0,1) = 1;
   
-  auto fieldComponentDataView2 = getFixedRankViewDefaultTestDT<DataScalar>("imitation GRAD data", numFields2, numComponentPoints);
+  auto fieldComponentDataView2 = getFixedRankView<DataScalar>("imitation GRAD data", numFields2, numComponentPoints);
   auto fieldComponentDataViewHost2 = Kokkos::create_mirror_view(fieldComponentDataView2);
   fieldComponentDataViewHost2(0,0) = 1;
   fieldComponentDataViewHost2(0,1) = 1;
@@ -1530,7 +1530,7 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case10
   TensorData<DataScalar,DeviceType> tensorDataRight2 = tensorDataLeft2;
   TensorData<DataScalar,DeviceType> tensorDataRight3 = tensorDataLeft3;
    
-  auto identityMatrixView = getFixedRankViewDefaultTestDT<DataScalar>("identity matrix", spaceDim, spaceDim);
+  auto identityMatrixView = getFixedRankView<DataScalar>("identity matrix", spaceDim, spaceDim);
   auto identityMatrixViewHost = getHostCopy(identityMatrixView);
   
   for (int d1=0; d1<spaceDim; d1++)
@@ -1563,7 +1563,7 @@ TEUCHOS_UNIT_TEST( StructuredIntegration, QuadratureSynthetic_GeneralPath_Case10
   TransformedVectorData<DataScalar,DeviceType>  transformedUnitVectorDataLeft(explicitIdentityMatrix,vectorDataLeft);
   TransformedVectorData<DataScalar,DeviceType> transformedUnitVectorDataRight(explicitIdentityMatrix,vectorDataRight);
   
-  auto cellMeasures = getFixedRankViewDefaultTestDT<DataScalar>("cellMeasures", numCells, numPoints);
+  auto cellMeasures = getFixedRankView<DataScalar>("cellMeasures", numCells, numPoints);
   
   auto cellMeasuresHost = getHostCopy(cellMeasures);
   

--- a/packages/intrepid2/unit-test/MonolithicExecutable/StructuredIntegrationTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/StructuredIntegrationTests.cpp
@@ -85,7 +85,6 @@ template<class Scalar, typename DeviceType>
 void integrate_baseline(Data<Scalar,DeviceType> integrals, const TransformedVectorData<Scalar,DeviceType> vectorDataLeft,
                         const TensorData<Scalar,DeviceType> cellMeasures, const TransformedVectorData<Scalar,DeviceType> vectorDataRight)
 {
-  const int cellDataExtent = integrals.getDataExtent(0);
   const int numFieldsLeft  = vectorDataLeft.numFields();
   const int numFieldsRight = vectorDataRight.numFields();
   const int spaceDim       = vectorDataLeft.spaceDim();
@@ -111,7 +110,7 @@ void integrate_baseline(Data<Scalar,DeviceType> integrals, const TransformedVect
   const int integralViewRank = integrals.getUnderlyingViewRank();
   
   using ExecutionSpace = typename DeviceType::execution_space;
-  auto policy = Kokkos::MDRangePolicy<ExecutionSpace,Kokkos::Rank<3>>({0,0,0},{cellDataExtent,numFieldsLeft,numFieldsRight});
+  auto policy = Kokkos::MDRangePolicy<ExecutionSpace,Kokkos::Rank<3>>({0,0,0},{integrals.getDataExtent(0),numFieldsLeft,numFieldsRight});
   Kokkos::parallel_for("fill expanded cell nodes", policy,
   KOKKOS_LAMBDA (const int &cellDataOrdinal, const int &fieldOrdinalLeft, const int &fieldOrdinalRight)
   {

--- a/packages/intrepid2/unit-test/MonolithicExecutable/StructuredIntegrationTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/StructuredIntegrationTests.cpp
@@ -215,16 +215,16 @@ ScalarView<Scalar,DeviceType> performStandardQuadratureHypercube(int meshWidth, 
   
   const int numNodesPerCell = cellNodes.numNodesPerCell();
   ScalarView<PointScalar,DeviceType> expandedCellNodes("expanded cell nodes",numCells,numNodesPerCell,spaceDim);
-  for (int cellOrdinal=0; cellOrdinal<numCells; cellOrdinal++)
+  using ExecutionSpace = typename DeviceType::execution_space;
+  auto policy = Kokkos::MDRangePolicy<ExecutionSpace,Kokkos::Rank<2>>({0,0},{numCells,numNodesPerCell});
+  Kokkos::parallel_for("fill expanded cell nodes", policy,
+  KOKKOS_LAMBDA (const int &cellOrdinal, const int &nodeOrdinal)
   {
-    for (int nodeOrdinal=0; nodeOrdinal<numNodesPerCell; nodeOrdinal++)
+    for (int d=0; d<spaceDim; d++)
     {
-      for (int d=0; d<spaceDim; d++)
-      {
-        expandedCellNodes(cellOrdinal,nodeOrdinal,d) = cellNodes(cellOrdinal,nodeOrdinal,d);
-      }
+      expandedCellNodes(cellOrdinal,nodeOrdinal,d) = cellNodes(cellOrdinal,nodeOrdinal,d);
     }
-  }
+  });
   
   // goal here is to do a weighted Poisson; i.e. (f grad u, grad v) on each cell
 

--- a/packages/intrepid2/unit-test/MonolithicExecutable/SubBasisInclusionTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/SubBasisInclusionTests.cpp
@@ -117,11 +117,11 @@ namespace
     if (polyOrderDim > 2) degrees[2] = polyOrder_z;
     
     int numPoints_1D = 5;
-    auto inputPoints = getInputPointsView<PointScalar>(cellTopo, numPoints_1D);
+    auto inputPoints = getInputPointsView<PointScalar,DeviceType>(cellTopo, numPoints_1D);
     int numPoints = inputPoints.extent_int(0);
     
     auto op = Intrepid2::OPERATOR_VALUE;
-    auto outputValues = getOutputView<OutputScalar>(fs, op, basis->getCardinality(), numPoints, spaceDim);
+    auto outputValues = getOutputView<OutputScalar,DeviceType>(fs, op, basis->getCardinality(), numPoints, spaceDim);
     
     basis->getValues(outputValues, inputPoints, op);
     out << "Testing sub-basis inclusion in degree ";
@@ -205,7 +205,7 @@ namespace
         continue; // next test case
       }
       
-      auto subBasisOutputValues = getOutputView<OutputScalar>(fs, op, subBasis->getCardinality(), numPoints, spaceDim);
+      auto subBasisOutputValues = getOutputView<OutputScalar,DeviceType>(fs, op, subBasis->getCardinality(), numPoints, spaceDim);
       subBasis->getValues(subBasisOutputValues, inputPoints, op);
       Kokkos::fence();
       bool vectorValued = (outputValues.rank() == 3); // F,P,D -- if scalar-valued, F,P

--- a/packages/intrepid2/unit-test/MonolithicExecutable/SubBasisInclusionTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/SubBasisInclusionTests.cpp
@@ -210,6 +210,10 @@ namespace
       Kokkos::fence();
       bool vectorValued = (outputValues.rank() == 3); // F,P,D -- if scalar-valued, F,P
       
+      auto inputPointsHost          = getHostCopy(inputPoints);
+      auto outputValuesHost         = getHostCopy(outputValues);
+      auto subBasisOutputValuesHost = getHostCopy(subBasisOutputValues);
+      
       for (int pointOrdinal=0; pointOrdinal<numPoints; pointOrdinal++)
       {
         // by construction, the sub-basis should have fields in the same order as the original basis
@@ -219,8 +223,8 @@ namespace
         {
           if (!vectorValued)
           {
-            double originalValue = outputValues(fieldOrdinal,pointOrdinal);
-            double subBasisValue = subBasisOutputValues(subBasisFieldOrdinal,pointOrdinal);
+            double originalValue = outputValuesHost(fieldOrdinal,pointOrdinal);
+            double subBasisValue = subBasisOutputValuesHost(subBasisFieldOrdinal,pointOrdinal);
             
             bool valuesMatch = essentiallyEqual(originalValue, subBasisValue, tol);
             
@@ -236,9 +240,9 @@ namespace
                 // scalar values are the div values
                 out << "div ";
               }
-              double x = inputPoints(pointOrdinal,0);
-              double y = (spaceDim > 1) ? inputPoints(pointOrdinal,1) : -2.0;
-              double z = (spaceDim > 2) ? inputPoints(pointOrdinal,2) : -2.0;
+              double x = inputPointsHost(pointOrdinal,0);
+              double y = (spaceDim > 1) ? inputPointsHost(pointOrdinal,1) : -2.0;
+              double z = (spaceDim > 2) ? inputPointsHost(pointOrdinal,2) : -2.0;
               
               if (spaceDim == 1)
                 out << "values for "  << x  << " differ for field ordinal " << fieldOrdinal;
@@ -256,8 +260,8 @@ namespace
             bool valuesMatch = true;
             for (int d=0; d<spaceDim; d++)
             {
-              double originalValue = outputValues(fieldOrdinal,pointOrdinal,d);
-              double subBasisValue = subBasisOutputValues(subBasisFieldOrdinal,pointOrdinal,d);
+              double originalValue = outputValuesHost(fieldOrdinal,pointOrdinal,d);
+              double subBasisValue = subBasisOutputValuesHost(subBasisFieldOrdinal,pointOrdinal,d);
               
               if (!essentiallyEqual(originalValue, subBasisValue, tol))
               {
@@ -267,9 +271,9 @@ namespace
             
             if (!valuesMatch)
             {
-              double x = inputPoints(pointOrdinal,0);
-              double y = (spaceDim > 1) ? inputPoints(pointOrdinal,1) : -2.0;
-              double z = (spaceDim > 2) ? inputPoints(pointOrdinal,2) : -2.0;
+              double x = inputPointsHost(pointOrdinal,0);
+              double y = (spaceDim > 1) ? inputPointsHost(pointOrdinal,1) : -2.0;
+              double z = (spaceDim > 2) ? inputPointsHost(pointOrdinal,2) : -2.0;
               
               if (spaceDim == 1)
                 out << "values for "  << x  << " differ for field ordinal " << fieldOrdinal;
@@ -280,13 +284,13 @@ namespace
               out << ": expected value (lower-order basis fieldOrdinal " << subBasisFieldOrdinal << "): (";
               for (int d=0; d<spaceDim; d++)
               {
-                out << subBasisOutputValues(subBasisFieldOrdinal,pointOrdinal,d);
+                out << subBasisOutputValuesHost(subBasisFieldOrdinal,pointOrdinal,d);
                 if (d<spaceDim-1) out << ",";
               }
               out << "); actual (larger basis fieldOrdinal " << fieldOrdinal << ") was (";
               for (int d=0; d<spaceDim; d++)
               {
-                out << outputValues(fieldOrdinal,pointOrdinal,d);
+                out << outputValuesHost(fieldOrdinal,pointOrdinal,d);
                 if (d<spaceDim-1) out << ",";
               }
               out << ")" << std::endl;

--- a/packages/intrepid2/unit-test/MonolithicExecutable/SubBasisInclusionTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/SubBasisInclusionTests.cpp
@@ -62,11 +62,11 @@ namespace
   bool testSubBasis(shards::CellTopology cellTopo, Intrepid2::EFunctionSpace fs, const double tol, Teuchos::FancyOStream &out, bool &success,
                     int polyOrder_x, int polyOrder_y=-1, int polyOrder_z = -1, bool defineVertexFunctions = true)
   {
-    using ExecSpace = Kokkos::DefaultExecutionSpace;
+    using DeviceType = DefaultTestDeviceType;
     using OutputScalar = double;
     using PointScalar  = double;
     using namespace Intrepid2;
-    using Basis = Basis<ExecSpace,OutputScalar,PointScalar>;
+    using Basis = Basis<DeviceType,OutputScalar,PointScalar>;
     
     auto vectorsMatch = [](std::vector<int> lhs,std::vector<int> rhs)
     {

--- a/packages/intrepid2/unit-test/MonolithicExecutable/TensorViewFunctorTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/TensorViewFunctorTests.cpp
@@ -122,6 +122,7 @@ namespace
     
     // TEST 1: simple contraction
     // we'll use trivial fields so as to factor out problems in the tensor product logic
+    out << "TEST 1: simple contraction.\n";
     int num_fields1 = 1;
     int num_fields2 = 1;
     int num_fields = num_fields1 * num_fields2;
@@ -156,6 +157,7 @@ namespace
     runTensorViewFunctorTest(tensor_expected, view1, view2, weight, tensor_points, out, success);
     
     // TEST 2: tensor product ordering
+    out << "TEST 2: tensor product ordering.\n";
     num_fields1 = 2;
     num_fields2 = 2;
     num_fields = num_fields1 * num_fields2;
@@ -187,6 +189,7 @@ namespace
     runTensorViewFunctorTest(tensor_expected, view1, view2, weight, tensor_points, out, success);
     
     // TEST 3: like TEST 2, but include non-trivial weight
+    out << "TEST 3: like TEST 2, but include non-trivial weight.\n";
     weight = 2.0;
     for (int i=0; i<num_fields; i++)
     {
@@ -195,6 +198,7 @@ namespace
     runTensorViewFunctorTest(tensor_expected, view1, view2, weight, tensor_points, out, success);
     
     // TEST 4: scalar times vector
+    out << "TEST 4: scalar times vector.\n";
     num_fields1 = 2;
     num_fields2 = 2;
     num_fields = num_fields1 * num_fields2;
@@ -233,6 +237,7 @@ namespace
     runTensorViewFunctorTest(tensor_expected, view1, view2, weight, tensor_points, out, success);
     
     // TEST 5: scalar times vector, nontrivial points, but still matching in point dimension
+    out << "TEST 5: scalar times vector, nontrivial points, but still matching in point dimension.\n";
     num_fields1 = 2;
     num_fields2 = 2;
     num_fields = num_fields1 * num_fields2;
@@ -277,6 +282,7 @@ namespace
     runTensorViewFunctorTest(tensor_expected, view1, view2, weight, tensor_points, out, success);
     
     // TEST 6: like TEST 2 above, but with different field counts
+    out << "TEST 6: like TEST 2 above, but with different field counts.\n";
     num_fields1 = 2;
     num_fields2 = 3;
     num_fields = num_fields1 * num_fields2;

--- a/packages/intrepid2/unit-test/MonolithicExecutable/TensorViewFunctorTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/TensorViewFunctorTests.cpp
@@ -103,27 +103,15 @@ namespace
     FunctorType functor(tensor_actual, view1, view2, tensorPoints, weight);
     Kokkos::parallel_for( policy , functor, "TensorViewFunctor");
     
-    auto tensor_actual_host   = getHostCopy(tensor_actual);
-    auto tensor_expected_host = getHostCopy(tensor_expected);
-    
-    using ViewIterator = ViewIterator<ScalarViewType, Scalar>;
-    ViewIterator it_actual(tensor_actual_host);
-    ViewIterator it_expected(tensor_expected_host);
-    
-    do
+    switch (tensor_expected.rank())
     {
-      auto actual_value   = it_actual.get();
-      auto expected_value = it_expected.get();
-      
-      if (!approximatelyEqual(actual_value, expected_value, tol))
-      {
-        success = false;
-        std::cout << "FAILURE: In entry " << it_actual.getEnumerationIndex() << ", ";
-        std::cout << "actual (" << actual_value << ") differs from expected (" << expected_value << ")";
-        std::cout << " by " << std::abs(actual_value-expected_value) << std::endl;
-      }
-      
-    } while ((it_actual.increment() >= 0) && (it_expected.increment() >= 0));
+      case 1: testFloatingEquality1(tensor_actual,tensor_expected,tol,tol,out,success); break;
+      case 2: testFloatingEquality2(tensor_actual,tensor_expected,tol,tol,out,success); break;
+      case 3: testFloatingEquality3(tensor_actual,tensor_expected,tol,tol,out,success); break;
+      case 4: testFloatingEquality4(tensor_actual,tensor_expected,tol,tol,out,success); break;
+      default:
+        TEUCHOS_TEST_FOR_EXCEPTION(true, std::invalid_argument, "Test does not yet support this output rank");
+    }
   }
   
   template<typename Scalar>

--- a/packages/intrepid2/unit-test/MonolithicExecutable/TensorViewFunctorTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/TensorViewFunctorTests.cpp
@@ -129,7 +129,8 @@ namespace
   template<typename Scalar>
   void runTensorViewFunctorTests(Teuchos::FancyOStream &out, bool &success)
   {
-    using ScalarViewType = ViewType<Scalar>;
+    using DeviceType = DefaultTestDeviceType;
+    using ScalarViewType = ViewType<Scalar,DeviceType>;
     
     // TEST 1: simple contraction
     // we'll use trivial fields so as to factor out problems in the tensor product logic

--- a/packages/intrepid2/unit-test/MonolithicExecutable/TensorViewFunctorTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/TensorViewFunctorTests.cpp
@@ -193,8 +193,9 @@ namespace
     weight = 2.0;
     for (int i=0; i<num_fields; i++)
     {
-      tensor_expected(i,0) *= weight;
+      tensor_expected_host(i,0) *= weight;
     }
+    Kokkos::deep_copy(tensor_expected, tensor_expected_host);
     runTensorViewFunctorTest(tensor_expected, view1, view2, weight, tensor_points, out, success);
     
     // TEST 4: scalar times vector

--- a/packages/intrepid2/unit-test/MonolithicExecutable/TensorViewFunctorTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/TensorViewFunctorTests.cpp
@@ -59,15 +59,15 @@ namespace
 {
   using namespace Intrepid2;
 
-  template<typename Scalar>
-  void runTensorViewFunctorTest(ViewType<Scalar> tensor_expected, ViewType<Scalar> view1, ViewType<Scalar> view2, double weight, bool tensorPoints,
+  template<typename ScalarViewType>
+  void runTensorViewFunctorTest(ScalarViewType tensor_expected, ScalarViewType view1, ScalarViewType view2, double weight, bool tensorPoints,
                                 Teuchos::FancyOStream &out, bool &success)
   {
     double tol = 1e-15;
     using namespace Intrepid2;
     
-    using ExecutionSpace = Kokkos::DefaultExecutionSpace;
-    using ScalarViewType = ViewType<Scalar>;
+    using ExecutionSpace = typename ScalarViewType::execution_space;
+    using Scalar         = typename ScalarViewType::value_type;
     
     const bool hasADType = false;
     const int vectorSize = hasADType ? FAD_VECTOR_SIZE : VECTOR_SIZE;

--- a/packages/intrepid2/unit-test/MonolithicExecutable/TensorViewFunctorTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/TensorViewFunctorTests.cpp
@@ -243,9 +243,15 @@ namespace
     num_fields2 = 2;
     num_fields = num_fields1 * num_fields2;
     num_points = 2;
-    Kokkos::resize(tensor_expected_host,num_fields, num_points,space_dim);
-    Kokkos::resize(view1_host,          num_fields1,num_points);
-    Kokkos::resize(view2_host,          num_fields2,num_points,space_dim);
+    
+    Kokkos::resize(tensor_expected,      num_fields,  num_points, space_dim);
+    Kokkos::resize(view1,                num_fields1, num_points);
+    Kokkos::resize(view2,                num_fields2, num_points, space_dim);
+    
+    Kokkos::resize(tensor_expected_host, num_fields,  num_points, space_dim);
+    Kokkos::resize(view1_host,           num_fields1, num_points);
+    Kokkos::resize(view2_host,           num_fields2, num_points, space_dim);
+    
     view1_host(0,0)   = 3.0;
     view1_host(1,0)   = 2.0;
     view2_host(0,0,0) = 1.0;

--- a/packages/intrepid2/unit-test/MonolithicExecutable/TransformedVectorDataTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/TransformedVectorDataTests.cpp
@@ -191,7 +191,7 @@ namespace
     
     using ExecutionSpace = typename DeviceType::execution_space;
     auto policy = Kokkos::MDRangePolicy<ExecutionSpace,Kokkos::Rank<2>>({0,0},{numCells,numNodesPerCell});
-    Kokkos::parallel_for("compute componentIntegrals", policy,
+    Kokkos::parallel_for("fill expanded cell nodes", policy,
     KOKKOS_LAMBDA (const int &cellOrdinal, const int &nodeOrdinal)
     {
       for (int d=0; d<spaceDim; d++)

--- a/packages/intrepid2/unit-test/MonolithicExecutable/TransformedVectorDataTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/TransformedVectorDataTests.cpp
@@ -77,6 +77,7 @@ namespace
   template<int spaceDim>
   void testVectorTransformation(const int &polyOrder, const int &meshWidth, Teuchos::FancyOStream &out, bool &success)
   {
+    using DeviceType = DefaultTestDeviceType;
     using Scalar = double;
     using PointScalar = double;
     
@@ -85,7 +86,7 @@ namespace
     
     auto fs = Intrepid2::FUNCTION_SPACE_HGRAD;
     
-    auto lineBasis = Intrepid2::getLineBasis< Intrepid2::NodalBasisFamily<> >(fs, polyOrder);
+    auto lineBasis = Intrepid2::getLineBasis< Intrepid2::NodalBasisFamily<DeviceType> >(fs, polyOrder);
     
     int numFields_1D = lineBasis->getCardinality();
     
@@ -104,17 +105,16 @@ namespace
     else if (spaceDim == 2) cellTopo = shards::getCellTopologyData< shards::Quadrilateral<> >();
     else if (spaceDim == 3) cellTopo = shards::getCellTopologyData< shards::Hexahedron<>    >();
     
-    using ExecSpaceType = Kokkos::DefaultExecutionSpace;
-    auto lineCubature = Intrepid2::DefaultCubatureFactory::create<ExecSpaceType>(lineTopo,polyOrder*2);
+    auto lineCubature = Intrepid2::DefaultCubatureFactory::create<DeviceType>(lineTopo,polyOrder*2);
     int numPoints_1D = lineCubature->getNumPoints();
-    ScalarView<PointScalar,ExecSpaceType> lineCubaturePoints("line cubature points",numPoints_1D,1);
-    ScalarView<double,ExecSpaceType> lineCubatureWeights("line cubature weights", numPoints_1D);
+    ScalarView<PointScalar,DeviceType> lineCubaturePoints("line cubature points",numPoints_1D,1);
+    ScalarView<double,DeviceType> lineCubatureWeights("line cubature weights", numPoints_1D);
     
     lineCubature->getCubature(lineCubaturePoints, lineCubatureWeights);
     
     // Allocate some intermediate containers
-    ScalarView<Scalar,ExecSpaceType> lineBasisValues    ("line basis values",      numFields_1D, numPoints_1D   );
-    ScalarView<Scalar,ExecSpaceType> lineBasisGradValues("line basis grad values", numFields_1D, numPoints_1D, 1);
+    ScalarView<Scalar,DeviceType> lineBasisValues    ("line basis values",      numFields_1D, numPoints_1D   );
+    ScalarView<Scalar,DeviceType> lineBasisGradValues("line basis grad values", numFields_1D, numPoints_1D, 1);
     
     // for now, we use 1D values to build up the 2D or 3D gradients
     // eventually, TensorBasis should offer a getValues() variant that returns tensor basis data
@@ -124,21 +124,21 @@ namespace
     // drop the trivial space dimension in line gradient values:
     Kokkos::resize(lineBasisGradValues, numFields_1D, numPoints_1D);
       
-    Kokkos::Array<TensorData<Scalar,ExecSpaceType>, spaceDim> vectorComponents;
+    Kokkos::Array<TensorData<Scalar,DeviceType>, spaceDim> vectorComponents;
     
     for (int d=0; d<spaceDim; d++)
     {
-      Kokkos::Array<Data<Scalar,ExecSpaceType>, spaceDim> gradComponent_d;
+      Kokkos::Array<Data<Scalar,DeviceType>, spaceDim> gradComponent_d;
       for (int d2=0; d2<spaceDim; d2++)
       {
-        if (d2 == d) gradComponent_d[d2] = Data<Scalar,ExecSpaceType>(lineBasisGradValues);
-        else         gradComponent_d[d2] = Data<Scalar,ExecSpaceType>(lineBasisValues);
+        if (d2 == d) gradComponent_d[d2] = Data<Scalar,DeviceType>(lineBasisGradValues);
+        else         gradComponent_d[d2] = Data<Scalar,DeviceType>(lineBasisValues);
       }
-      vectorComponents[d] = TensorData<Scalar,ExecSpaceType>(gradComponent_d);
+      vectorComponents[d] = TensorData<Scalar,DeviceType>(gradComponent_d);
     }
-    VectorData<Scalar,ExecSpaceType> gradientValues(vectorComponents, false); // false: not axis-aligned
+    VectorData<Scalar,DeviceType> gradientValues(vectorComponents, false); // false: not axis-aligned
     
-    CellGeometry<PointScalar,spaceDim,ExecSpaceType> cellNodes = uniformCartesianMesh<PointScalar,spaceDim,ExecSpaceType>(1.0, meshWidth);
+    CellGeometry<PointScalar,spaceDim,DeviceType> cellNodes = uniformCartesianMesh<PointScalar,spaceDim,DeviceType>(1.0, meshWidth);
     
     // goal here is to do a weighted Poisson; i.e. (f grad u, grad v) on each cell
     
@@ -149,14 +149,14 @@ namespace
     }
     
     auto jacobian = cellNodes.allocateJacobianData(pointsPerCell);
-    auto jacobianDet = CellTools<ExecSpaceType>::allocateJacobianDet(jacobian);
-    auto jacobianInv = CellTools<ExecSpaceType>::allocateJacobianInv(jacobian);
+    auto jacobianDet = CellTools<DeviceType>::allocateJacobianDet(jacobian);
+    auto jacobianInv = CellTools<DeviceType>::allocateJacobianInv(jacobian);
     cellNodes.setJacobian(                   jacobian, pointsPerCell);
-    CellTools<ExecSpaceType>::setJacobianDet(jacobianDet, jacobian);
-    CellTools<ExecSpaceType>::setJacobianInv(jacobianInv, jacobian);
+    CellTools<DeviceType>::setJacobianDet(jacobianDet, jacobian);
+    CellTools<DeviceType>::setJacobianInv(jacobianInv, jacobian);
     
     // lazily-evaluated transformed gradient values:
-    auto transformedGradientData = FunctionSpaceTools<ExecSpaceType>::getHGRADtransformGRAD(jacobianInv, gradientValues);
+    auto transformedGradientData = FunctionSpaceTools<DeviceType>::getHGRADtransformGRAD(jacobianInv, gradientValues);
 
     int numPoints = 1;
     for (int d=0; d<spaceDim; d++)
@@ -165,22 +165,21 @@ namespace
     }
     
     // now, compute transformed values in the classic, expanded way
-    ScalarView<Scalar,ExecSpaceType> expandedTransformedGradValues("transformed grad values", numCells, numFields, numPoints, spaceDim);
+    ScalarView<Scalar,DeviceType> expandedTransformedGradValues("transformed grad values", numCells, numFields, numPoints, spaceDim);
     
-    auto basis = Intrepid2::getBasis< Intrepid2::NodalBasisFamily<> >(cellTopo, fs, polyOrder);
+    auto basis = Intrepid2::getBasis< Intrepid2::NodalBasisFamily<DeviceType> >(cellTopo, fs, polyOrder);
     
     // Allocate some intermediate containers
-    ScalarView<Scalar,ExecSpaceType> basisValues    ("basis values", numFields, numPoints );
-    ScalarView<Scalar,ExecSpaceType> basisGradValues("basis grad values", numFields, numPoints, spaceDim);
+    ScalarView<Scalar,DeviceType> basisValues    ("basis values", numFields, numPoints );
+    ScalarView<Scalar,DeviceType> basisGradValues("basis grad values", numFields, numPoints, spaceDim);
 
-    ScalarView<Scalar,ExecSpaceType> transformedGradValues("transformed grad values", numCells, numFields, numPoints, spaceDim);
-    ScalarView<Scalar,ExecSpaceType> transformedWeightedGradValues("transformed weighted grad values", numCells, numFields, numPoints, spaceDim);
+    ScalarView<Scalar,DeviceType> transformedGradValues("transformed grad values", numCells, numFields, numPoints, spaceDim);
+    ScalarView<Scalar,DeviceType> transformedWeightedGradValues("transformed weighted grad values", numCells, numFields, numPoints, spaceDim);
     
-    using Kokkos::DefaultExecutionSpace;
-    auto cubature = Intrepid2::DefaultCubatureFactory::create<DefaultExecutionSpace>(cellTopo,polyOrder*2);
+    auto cubature = Intrepid2::DefaultCubatureFactory::create<DeviceType>(cellTopo,polyOrder*2);
     TEST_EQUALITY( numPoints, cubature->getNumPoints());
-    ScalarView<PointScalar,ExecSpaceType> cubaturePoints("cubature points",numPoints,spaceDim);
-    ScalarView<double,ExecSpaceType> cubatureWeights("cubature weights", numPoints);
+    ScalarView<PointScalar,DeviceType> cubaturePoints("cubature points",numPoints,spaceDim);
+    ScalarView<double,DeviceType> cubatureWeights("cubature weights", numPoints);
     
     cubature->getCubature(cubaturePoints, cubatureWeights);
     
@@ -188,7 +187,7 @@ namespace
     basis->getValues(basisGradValues, cubaturePoints, Intrepid2::OPERATOR_GRAD  );
     
     const int numNodesPerCell = cellNodes.numNodesPerCell();
-    ScalarView<PointScalar,ExecSpaceType> expandedCellNodes("expanded cell nodes",numCells,numNodesPerCell,spaceDim);
+    ScalarView<PointScalar,DeviceType> expandedCellNodes("expanded cell nodes",numCells,numNodesPerCell,spaceDim);
     for (int cellOrdinal=0; cellOrdinal<numCells; cellOrdinal++)
     {
       for (int nodeOrdinal=0; nodeOrdinal<numNodesPerCell; nodeOrdinal++)
@@ -200,11 +199,12 @@ namespace
       }
     }
     
-    ScalarView<Scalar,ExecSpaceType> expandedJacobian("jacobian", numCells, numPoints, spaceDim, spaceDim);
-    ScalarView<Scalar,ExecSpaceType> expandedJacobianInverse("jacobian inverse", numCells, numPoints, spaceDim, spaceDim);
+    ScalarView<Scalar,DeviceType> expandedJacobian("jacobian", numCells, numPoints, spaceDim, spaceDim);
+    ScalarView<Scalar,DeviceType> expandedJacobianInverse("jacobian inverse", numCells, numPoints, spaceDim, spaceDim);
     
-    using CellTools = Intrepid2::CellTools<Kokkos::DefaultExecutionSpace>;
-    using FunctionSpaceTools = Intrepid2::FunctionSpaceTools<Kokkos::DefaultExecutionSpace>;
+    using CellTools = Intrepid2::CellTools<DeviceType>;
+    using ExecutionSpace = typename DeviceType::execution_space;
+    using FunctionSpaceTools = Intrepid2::FunctionSpaceTools<ExecutionSpace>; // TODO: once FunctionSpaceTools supports DeviceType, change the template argument here.
     
     CellTools::setJacobian(expandedJacobian, cubaturePoints, expandedCellNodes, cellTopo);
     CellTools::setJacobianInv(expandedJacobianInverse, expandedJacobian);

--- a/packages/intrepid2/unit-test/MonolithicExecutable/VectorDataTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/VectorDataTests.cpp
@@ -196,7 +196,7 @@ namespace
     const int numFields          = numComponentFields * numComponentFields;
     const int numPoints          = numComponentPoints * numComponentPoints;
     
-    ScalarView<Scalar,DeviceType> fieldComponentDataView = getView<Scalar>("field component data", numComponentFields);
+    ScalarView<Scalar,DeviceType> fieldComponentDataView = getView<Scalar,DeviceType>("field component data", numComponentFields);
     auto fieldComponentDataViewHost = Kokkos::create_mirror_view(fieldComponentDataView);
     fieldComponentDataViewHost(0) = 1.0;
     

--- a/packages/intrepid2/unit-test/MonolithicExecutable/VectorDataTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/VectorDataTests.cpp
@@ -70,8 +70,13 @@ namespace
   template<int spaceDim>
   void testRefSpaceVectorValues(Teuchos::FancyOStream &out, bool &success)
   {
+    using DeviceType = DefaultTestDeviceType;
     using Scalar = double;
     using PointScalar = double;
+    using WeightScalar = double;
+    using CubatureType   = Cubature<DeviceType,PointScalar,WeightScalar>;
+    using PointViewType  = typename CubatureType::PointViewTypeAllocatable;
+    using WeightViewType = typename CubatureType::WeightViewTypeAllocatable;
     
     const double relTol = 1e-12;
     const double absTol = 1e-12;
@@ -81,7 +86,7 @@ namespace
     
     auto fs = Intrepid2::FUNCTION_SPACE_HGRAD;
     
-    auto lineBasis = Intrepid2::getLineBasis< Intrepid2::NodalBasisFamily<> >(fs, polyOrder);
+    auto lineBasis = Intrepid2::getLineBasis< Intrepid2::NodalBasisFamily<DeviceType> >(fs, polyOrder);
     
     int numFields_1D = lineBasis->getCardinality();
     
@@ -99,17 +104,16 @@ namespace
     else if (spaceDim == 2) cellTopo = shards::getCellTopologyData< shards::Quadrilateral<> >();
     else if (spaceDim == 3) cellTopo = shards::getCellTopologyData< shards::Hexahedron<>    >();
     
-    using ExecSpaceType = Kokkos::DefaultExecutionSpace;
-    auto lineCubature = Intrepid2::DefaultCubatureFactory::create<ExecSpaceType>(lineTopo,polyOrder*2);
+    auto lineCubature = Intrepid2::DefaultCubatureFactory::create<DeviceType>(lineTopo,polyOrder*2);
     int numPoints_1D = lineCubature->getNumPoints();
-    ScalarView<PointScalar,ExecSpaceType> lineCubaturePoints("line cubature points",numPoints_1D,1);
-    ScalarView<double,ExecSpaceType> lineCubatureWeights("line cubature weights", numPoints_1D);
+    PointViewType lineCubaturePoints("line cubature points",numPoints_1D,1);
+    WeightViewType lineCubatureWeights("line cubature weights", numPoints_1D);
     
     lineCubature->getCubature(lineCubaturePoints, lineCubatureWeights);
     
     // Allocate some intermediate containers
-    ScalarView<Scalar,ExecSpaceType> lineBasisValues    ("line basis values",      numFields_1D, numPoints_1D   );
-    ScalarView<Scalar,ExecSpaceType> lineBasisGradValues("line basis grad values", numFields_1D, numPoints_1D, 1);
+    ScalarView<Scalar,DeviceType> lineBasisValues    ("line basis values",      numFields_1D, numPoints_1D   );
+    ScalarView<Scalar,DeviceType> lineBasisGradValues("line basis grad values", numFields_1D, numPoints_1D, 1);
     
     // for now, we use 1D values to build up the 2D or 3D gradients
     // eventually, TensorBasis should offer a getValues() variant that returns tensor basis data
@@ -119,23 +123,23 @@ namespace
     // drop the trivial space dimension in line gradient values:
     Kokkos::resize(lineBasisGradValues, numFields_1D, numPoints_1D);
       
-    Kokkos::Array<TensorData<Scalar,ExecSpaceType>, spaceDim> vectorComponents;
+    Kokkos::Array<TensorData<Scalar,DeviceType>, spaceDim> vectorComponents;
     
     for (int d=0; d<spaceDim; d++)
     {
-      Kokkos::Array<Data<Scalar,ExecSpaceType>, spaceDim> gradComponent_d;
+      Kokkos::Array<Data<Scalar,DeviceType>, spaceDim> gradComponent_d;
       // gradComponent_d stores vector component d of the gradient, expressed as the product of values corresponding to each coordinate dimension
       // The gradient operator is (dx,dy,dz) in 3D; that is, the derivative taken is in the coordinate dimension that matches d.
       // Therefore, the operator leaves the tensorial components in dimension d2≠d unaffected, and results in a 1D "gradient" being taken in the dimension for which d2=d.
       // Hence, the assignment below.
       for (int d2=0; d2<spaceDim; d2++)
       {
-        if (d2 == d) gradComponent_d[d2] = Data<Scalar,ExecSpaceType>(lineBasisGradValues);
-        else         gradComponent_d[d2] = Data<Scalar,ExecSpaceType>(lineBasisValues);
+        if (d2 == d) gradComponent_d[d2] = Data<Scalar,DeviceType>(lineBasisGradValues);
+        else         gradComponent_d[d2] = Data<Scalar,DeviceType>(lineBasisValues);
       }
-      vectorComponents[d] = TensorData<Scalar,ExecSpaceType>(gradComponent_d);
+      vectorComponents[d] = TensorData<Scalar,DeviceType>(gradComponent_d);
     }
-    VectorData<Scalar,ExecSpaceType> gradientValues(vectorComponents, false); // false: not axis-aligned
+    VectorData<Scalar,DeviceType> gradientValues(vectorComponents, false); // false: not axis-aligned
     
     int numPoints = 1;
     for (int d=0; d<spaceDim; d++)
@@ -143,17 +147,16 @@ namespace
       numPoints *= numPoints_1D;
     }
     
-    auto basis = Intrepid2::getBasis< Intrepid2::NodalBasisFamily<> >(cellTopo, fs, polyOrder);
+    auto basis = Intrepid2::getBasis< Intrepid2::NodalBasisFamily<DeviceType> >(cellTopo, fs, polyOrder);
     
     // Allocate some intermediate containers
-    ScalarView<Scalar,ExecSpaceType> basisValues    ("basis values", numFields, numPoints );
-    ScalarView<Scalar,ExecSpaceType> basisGradValues("basis grad values", numFields, numPoints, spaceDim);
+    ScalarView<Scalar,DeviceType> basisValues    ("basis values", numFields, numPoints );
+    ScalarView<Scalar,DeviceType> basisGradValues("basis grad values", numFields, numPoints, spaceDim);
 
-    using Kokkos::DefaultExecutionSpace;
-    auto cubature = Intrepid2::DefaultCubatureFactory::create<DefaultExecutionSpace>(cellTopo,polyOrder*2);
+    auto cubature = Intrepid2::DefaultCubatureFactory::create<DeviceType>(cellTopo,polyOrder*2);
     TEST_EQUALITY( numPoints, cubature->getNumPoints());
-    ScalarView<PointScalar,ExecSpaceType> cubaturePoints("cubature points",numPoints,spaceDim);
-    ScalarView<double,ExecSpaceType> cubatureWeights("cubature weights", numPoints);
+    PointViewType cubaturePoints("cubature points",numPoints,spaceDim);
+    WeightViewType cubatureWeights("cubature weights", numPoints);
     
     cubature->getCubature(cubaturePoints, cubatureWeights);
     
@@ -184,7 +187,7 @@ namespace
   TEUCHOS_UNIT_TEST( VectorData, ZeroFirstComponent )
   {
     using Scalar  = double;
-    using ExecSpaceType = Kokkos::DefaultExecutionSpace;
+    using DeviceType = Kokkos::DefaultExecutionSpace;
     
     const int spaceDim = 2;
     
@@ -193,7 +196,7 @@ namespace
     const int numFields          = numComponentFields * numComponentFields;
     const int numPoints          = numComponentPoints * numComponentPoints;
     
-    ScalarView<Scalar,ExecSpaceType> fieldComponentDataView = getView<Scalar>("field component data", numComponentFields);
+    ScalarView<Scalar,DeviceType> fieldComponentDataView = getView<Scalar>("field component data", numComponentFields);
     auto fieldComponentDataViewHost = Kokkos::create_mirror_view(fieldComponentDataView);
     fieldComponentDataViewHost(0) = 1.0;
     
@@ -202,15 +205,15 @@ namespace
     const int fieldComponentDataRank = 2;
     Kokkos::Array<int,fieldComponentDataRank> fieldComponentExtents {numComponentFields,numComponentPoints};
     Kokkos::Array<DataVariationType,fieldComponentDataRank> fieldComponentVariationTypes {GENERAL,CONSTANT};
-    Data<Scalar,ExecSpaceType> fieldComponentData(fieldComponentDataView,fieldComponentExtents,fieldComponentVariationTypes);
+    Data<Scalar,DeviceType> fieldComponentData(fieldComponentDataView,fieldComponentExtents,fieldComponentVariationTypes);
     
-    TensorData<Scalar,ExecSpaceType> nonzeroTensorData(std::vector< Data<Scalar,ExecSpaceType> >{fieldComponentData,fieldComponentData});
+    TensorData<Scalar,DeviceType> nonzeroTensorData(std::vector< Data<Scalar,DeviceType> >{fieldComponentData,fieldComponentData});
     
     const int numFamilies = 1;
-    Kokkos::Array<TensorData<Scalar,ExecSpaceType>, spaceDim > family {TensorData<Scalar,ExecSpaceType>(), nonzeroTensorData}; // empty first component
-    Kokkos::Array< Kokkos::Array<TensorData<Scalar,ExecSpaceType>, spaceDim>, numFamilies> vectorComponents {family};
+    Kokkos::Array<TensorData<Scalar,DeviceType>, spaceDim > family {TensorData<Scalar,DeviceType>(), nonzeroTensorData}; // empty first component
+    Kokkos::Array< Kokkos::Array<TensorData<Scalar,DeviceType>, spaceDim>, numFamilies> vectorComponents {family};
     
-    VectorData<Scalar,ExecSpaceType> vectorData(vectorComponents);
+    VectorData<Scalar,DeviceType> vectorData(vectorComponents);
     
     TEST_EQUALITY(numFields, vectorData.extent_int(0)); // (F,P,D)
     TEST_EQUALITY(numPoints, vectorData.extent_int(1)); // (F,P,D)

--- a/packages/intrepid2/unit-test/MonolithicExecutable/ViewIteratorTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/ViewIteratorTests.cpp
@@ -62,13 +62,14 @@ namespace
     
     // note that this test does not involve any access of View data; therefore, it should work fine regardless of the memory space of the View
     
-    using ViewIteratorScalar = ViewIterator<ViewType<Scalar>, Scalar>;
+    using DeviceType = DefaultTestDeviceType;
+    using ViewIteratorScalar = ViewIterator<ViewType<Scalar,DeviceType>, Scalar>;
     
     // check that the increment operator works to give us the right number of entries
     // we'll use trivial fields so as to factor out problems in the tensor product logic
     int num_fields = 2;
     int num_points = 64;
-    ViewType<Scalar> view("view to iterate over",num_fields,num_points);
+    ViewType<Scalar,DeviceType> view("view to iterate over",num_fields,num_points);
     ViewIteratorScalar view_iterator(view);
     int entry_count = 0;
     do

--- a/packages/intrepid2/unit-test/MonolithicExecutable/ViewIteratorTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/ViewIteratorTests.cpp
@@ -60,6 +60,8 @@ namespace
     using namespace Intrepid2;
     using Scalar = double;
     
+    // note that this test does not involve any access of View data; therefore, it should work fine regardless of the memory space of the View
+    
     using ViewIteratorScalar = ViewIterator<ViewType<Scalar>, Scalar>;
     
     // check that the increment operator works to give us the right number of entries


### PR DESCRIPTION
@trilinos/intrepid2 

## Motivation
This PR adds DeviceType compatibility to the newer Intrepid2 container types, including:
- BasisValues
- CellGeometry
- Data
- ProjectedGeometry
- TensorData
- TensorPoints
- TransformedVectorData
- VectorData

In addition, the new DeviceType compatibility is exercised in all the tests in MonolothicExecutable, replacing earlier use of `Kokkos::DefaultExecutionSpace` with the `DefaultTestDeviceType` defined in `Intrepid2_TestUtils.hpp`, which resolves to a UVM-free DeviceType on CUDA, and the Kokkos default DeviceType on other platforms.  Thus, the tests in MonolothicExecutable now run UVM-free on CUDA.

Along the way, a couple other notable changes were necessary:
- Added a `DeviceType` typedef to the Basis base class.  This is defined as whatever the Basis was instantiated with (so it may be a non-device-type ExecutionSpace); this is useful when setting the types for BasisValues, etc., in derived classes.
- Because some CellTools is not yet fully compatible with DeviceType, but the tests in MonolithicExecutable are using DeviceType-templated containers for methods in CellTools, we need to allow CellTools to be templated on a DeviceType; to avoid cascading to all of CellTools, we add an ExecSpaceType typedef defined in terms of the DeviceType; this is used for all types in CellTools methods besides the ones required by the present PR.  This is inelegant, and a temporary solution until we complete the CellTools conversion.  I can confirm that it does build and pass tests under CUDA on vortex.

## Related Issues
- Part of #8310.

## Testing
This PR includes extensive tests.  Additionally, tests have been manually verified to pass on vortex (CUDA release build) and on Intel serial debug (under MacOS).