### PR TITLE
Rythmos: null test failing

### DIFF
--- a/packages/rythmos/test/UnitTest/Rythmos_StepperBuilder_UnitTest.cpp
+++ b/packages/rythmos/test/UnitTest/Rythmos_StepperBuilder_UnitTest.cpp
@@ -56,7 +56,11 @@ TEUCHOS_UNIT_TEST( Rythmos_StepperBuilder, setParameterList ) {
   TEST_THROW(builder->setParameterList(pl), std::logic_error);
 #ifdef TEUCHOS_DEBUG
   // This throws because we changed the internal parameter list to an invalid one.
+#if !( (__clang_major__ == 7 && __clang_minor__ == 0) )
+  // As noted above, some compiler/versions have a problem catching
+  // exceptions when setting an RCP to null.  Excluding it here.
   TEST_THROW(builder = Teuchos::null, std::logic_error);
+#endif
 #else // TEUCHOS_DEBUG
   TEST_NOTHROW(builder = Teuchos::null );
 #endif // TEUCHOS_DEBUG


### PR DESCRIPTION
Some compiler/versions have trouble with testing throw
exceptions with setting RCP to Teuchos::null.

Excluding test for CLANG 7.0.

@trilinos/rythmos 

## Motivation
Get Rythmos passing on Astra.

* Closes #8489 

