### PR TITLE
drivers/atdm: Fix proxy environment

### DIFF
--- a/cmake/ctest/drivers/atdm/utils/setup_env.sh
+++ b/cmake/ctest/drivers/atdm/utils/setup_env.sh
@@ -33,10 +33,12 @@ if [ "${Trilinos_REPOSITORY_LOCATION}" == "" ] ; then
 fi
 
 unset http_proxy
-# NOTE: Above we have to unset http_proxy to allow the second submit to the
-# testing-dev.sandia.gov/cdash/ site which the jenkins job sets.  But we can't
-# unset https_proxy which is needed for the git operations with
-# https://github.com.
+unset HTTP_PROXY
+unset no_proxy
+unset NO_PROXY
+# NOTE: Above we have to unset http_proxy and no_proxy to allow the
+# cdash submits to go  through. Note that we can't  unset https_proxy
+# which is needed for the git operations with  https://github.com.
 
 #
 # C) Setup install-releated stuff


### PR DESCRIPTION
## How was this tested?
On van1-tx2 and cts1 via:
```bash
nohup env Trilinos_PACKAGES=Kokkos,Teuchos,TrilinosATDMConfigTests ./ctest-s-local-test-driver.sh all &>ctest-s-local-test-driver.out &
```
See https://testing-dev.sandia.gov/cdash/index.php?project=Trilinos&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=cts1 and https://testing-dev.sandia.gov/cdash/index.php?project=Trilinos&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=van1.

Related to #8837.