### PR TITLE
ats2: Disable IBM optimized collectives for complex builds (#8474)

### DIFF
--- a/cmake/std/atdm/ats2/environment.sh
+++ b/cmake/std/atdm/ats2/environment.sh
@@ -186,7 +186,7 @@ export ATDM_CONFIG_MPI_POST_FLAGS="--rs_per_socket;4"
 export ATDM_CONFIG_MPI_EXEC_NUMPROCS_FLAG="-p"
 
 if [[ "${ATDM_CONFIG_COMPLEX}" == "ON" ]] ; then
-  export ATDM_CONFIG_MPI_PRE_FLAGS="-M;-mca coll_hcoll_enable 1 -mca coll_hcoll_np 0 -mca coll ^basic -mca coll ^ibm -async"
+  export ATDM_CONFIG_MPI_PRE_FLAGS="-M;-mca coll ^ibm"
   # NOTE: We have to use the '-M' option name and not '--smpiarg' since
   # 'trilinos_jsrun' has special logic
 fi

--- a/cmake/std/atdm/ats2/environment.sh
+++ b/cmake/std/atdm/ats2/environment.sh
@@ -185,6 +185,10 @@ export ATDM_CONFIG_MPI_EXEC=${ATDM_SCRIPT_DIR}/ats2/trilinos_jsrun
 export ATDM_CONFIG_MPI_POST_FLAGS="--rs_per_socket;4"
 export ATDM_CONFIG_MPI_EXEC_NUMPROCS_FLAG="-p"
 
+if [[ "${ATDM_CONFIG_COMPLEX}" == "ON" ]] ; then
+  export ATDM_CONFIG_MPI_PRE_FLAGS="--smpiargs;-HCOLL -FCA -mca coll_hcoll_enable 1 -mca coll_hcoll_np 0 -mca coll ^basic -mca coll ^ibm -async"
+fi
+
 # NOTE: We used to check for the launch node but at one point that changed
 # from 'vortex59' to 'vortex5' without warning.  That caused all of the tests
 # run with 'trilinos_jsrun' to fail on 2020-08-11 so we got no test results.

--- a/cmake/std/atdm/ats2/environment.sh
+++ b/cmake/std/atdm/ats2/environment.sh
@@ -186,7 +186,7 @@ export ATDM_CONFIG_MPI_POST_FLAGS="--rs_per_socket;4"
 export ATDM_CONFIG_MPI_EXEC_NUMPROCS_FLAG="-p"
 
 if [[ "${ATDM_CONFIG_COMPLEX}" == "ON" ]] ; then
-  export ATDM_CONFIG_MPI_PRE_FLAGS="-M;-HCOLL -FCA -mca coll_hcoll_enable 1 -mca coll_hcoll_np 0 -mca coll ^basic -mca coll ^ibm -async"
+  export ATDM_CONFIG_MPI_PRE_FLAGS="-M;-mca coll_hcoll_enable 1 -mca coll_hcoll_np 0 -mca coll ^basic -mca coll ^ibm -async"
   # NOTE: We have to use the '-M' option name and not '--smpiarg' since
   # 'trilinos_jsrun' has special logic
 fi

--- a/cmake/std/atdm/ats2/environment.sh
+++ b/cmake/std/atdm/ats2/environment.sh
@@ -186,7 +186,9 @@ export ATDM_CONFIG_MPI_POST_FLAGS="--rs_per_socket;4"
 export ATDM_CONFIG_MPI_EXEC_NUMPROCS_FLAG="-p"
 
 if [[ "${ATDM_CONFIG_COMPLEX}" == "ON" ]] ; then
-  export ATDM_CONFIG_MPI_PRE_FLAGS="--smpiargs;-HCOLL -FCA -mca coll_hcoll_enable 1 -mca coll_hcoll_np 0 -mca coll ^basic -mca coll ^ibm -async"
+  export ATDM_CONFIG_MPI_PRE_FLAGS="-M;-HCOLL -FCA -mca coll_hcoll_enable 1 -mca coll_hcoll_np 0 -mca coll ^basic -mca coll ^ibm -async"
+  # NOTE: We have to use the '-M' option name and not '--smpiarg' since
+  # 'trilinos_jsrun' has special logic
 fi
 
 # NOTE: We used to check for the launch node but at one point that changed

--- a/cmake/std/atdm/ats2/trilinos_jsrun
+++ b/cmake/std/atdm/ats2/trilinos_jsrun
@@ -191,8 +191,6 @@ if [[ "$TPETRA_ASSUME_CUDA_AWARE_MPI" == "1" ]] && [[ "$np_is_one" == "false" ]]
     args=("-M -gpu" "${args[@]}")
   fi
 
-  # Point jsrun to pami
-  args=("-E LD_PRELOAD=$OPAL_PREFIX/lib/pami_451/libpami.so" "${args[@]}")
 fi
 
 evaluate_jsrun_command

--- a/cmake/std/atdm/ats2/trilinos_jsrun
+++ b/cmake/std/atdm/ats2/trilinos_jsrun
@@ -42,9 +42,9 @@ function evaluate_jsrun_command {
   #out_file="$CTEST_TEST_NAME"."$out_file"
 
   if [ "$ECHO_CMD" == "1" ]; then
-    echo "BEFORE: jsrun " $(printf "'%s' " "${orig_args[@]}")
+    echo "BEFORE: jsrun " $(printf "\"%s\" " "${orig_args[@]}")
     echo "AFTER: export TPETRA_ASSUME_CUDA_AWARE_MPI=${TPETRA_ASSUME_CUDA_AWARE_MPI}; jsrun " \
-      $(printf "'%s' " "${args[@]}")
+      $(printf "\"%s\" " "${args[@]}")
   fi
 
   # Set retry, assume JSRUN_WRAPPER_NUM_RETRIES is valid if set
@@ -77,7 +77,7 @@ function evaluate_jsrun_command {
   #fi
   #cat $out_file
   #rm $out_file
-  eval jsrun $(printf "'%s' " "${args[@]}")
+  eval jsrun $(printf "\"%s\" " "${args[@]}")
   jsrun_ret=$?
   echo "jsrun return value: ${jsrun_ret}"
   return $jsrun_ret

--- a/cmake/std/atdm/ats2/trilinos_jsrun
+++ b/cmake/std/atdm/ats2/trilinos_jsrun
@@ -42,9 +42,9 @@ function evaluate_jsrun_command {
   #out_file="$CTEST_TEST_NAME"."$out_file"
 
   if [ "$ECHO_CMD" == "1" ]; then
-    echo "BEFORE: jsrun " $(printf "\"%s\" " "${orig_args[@]}")
+    echo "BEFORE: jsrun " $(printf "'%s' " "${orig_args[@]}")
     echo "AFTER: export TPETRA_ASSUME_CUDA_AWARE_MPI=${TPETRA_ASSUME_CUDA_AWARE_MPI}; jsrun " \
-      $(printf "\"%s\" " "${args[@]}")
+      $(printf "'%s' " "${args[@]}")
   fi
 
   # Set retry, assume JSRUN_WRAPPER_NUM_RETRIES is valid if set
@@ -77,7 +77,7 @@ function evaluate_jsrun_command {
   #fi
   #cat $out_file
   #rm $out_file
-  eval jsrun $(printf "\"%s\" " "${args[@]}")
+  eval jsrun $(printf "'%s' " "${args[@]}")
   jsrun_ret=$?
   echo "jsrun return value: ${jsrun_ret}"
   return $jsrun_ret


### PR DESCRIPTION
This should avoid a known defect with Spectrum MPI with MPI collectives and complex data-types (see #8474).

## How was this tested?

On 'vortex', I ran:

```
$ ssh vortex

$ . .bash_profile

$ cd vscratch1/rabartl/Trilinos.base/BUILDS/VORTEX/CHECKIN//

$  ./checkin-test-atdm.sh ats2-cuda-complex-opt --enable-packages=TeuchosComm --configure --build

$ cd ats2-cuda-complex-opt/

$ . load-env.sh

$  bsub -Is -W 2:00 ctest -j4 -E TeuchosCore_testTeuchosTestForTermination

...


99% tests passed, 1 tests failed out of 118

Subproject Time Summary:
Teuchos    = 205.18 sec*proc (118 tests)

Total Test time (real) =  51.95 sec

The following tests FAILED:
         91 - TeuchosComm_UnitTestHarness_Parallel_UnitTests_MPI_4 (Failed)
Errors while running CTest
```

The jsrun command commandline showed:

```
BEFORE: jsrun  '--smpiargs' '-HCOLL -FCA -mca coll_hcoll_enable 1 -mca coll_hcoll_np 0 -mca coll ^basic -mca coll ^ibm -async' '-p' '2' '--rs_per_socket' '4' '/vscratch1/rabartl/Trilinos.base/BUILDS/VORTEX/CHECKIN/ats2-cuda-complex-opt/packages/teuchos/comm/test/UnitTesting/TeuchosComm_UnitTestHarness_Parallel_UnitTests.exe' '--output-show-proc-rank' '--teuchos-suppress-startup-banner'
AFTER: export TPETRA_ASSUME_CUDA_AWARE_MPI=0; jsrun  '--smpiargs' '-HCOLL -FCA -mca coll_hcoll_enable 1 -mca coll_hcoll_np 0 -mca coll ^basic -mca coll ^ibm -async' '-p' '2' '--rs_per_socket' '4' '/vscratch1/rabartl/Trilinos.base/BUILDS/VORTEX/CHECKIN/ats2-cuda-complex-opt/packages/teuchos/comm/test/UnitTesting/TeuchosComm_UnitTestHarness_Parallel_UnitTests.exe' '--output-show-proc-rank' '--teuchos-suppress-startup-banner'
```

NOTE:
* I excluded the tests `TeuchosCore_testTeuchosTestForTermination*` because they take over 60s to run.
* The test  `TeuchosComm_UnitTestHarness_Parallel_UnitTests_MPI_4` failure is a known failure (see #8759).

