### PR TITLE
Piro: use nominal parameter values by default in NOXSolver

### DIFF
--- a/packages/piro/src/Piro_NOXSolver_Def.hpp
+++ b/packages/piro/src/Piro_NOXSolver_Def.hpp
@@ -136,7 +136,11 @@ void Piro::NOXSolver<Scalar>::evalModelImpl(
   // Forward all parameters to underlying model
   Thyra::ModelEvaluatorBase::InArgs<Scalar> modelInArgs = this->getModel().createInArgs();
   for (int l = 0; l < num_p; ++l) {
-    modelInArgs.set_p(l, inArgs.get_p(l));
+    if (Teuchos::nonnull(inArgs.get_p(l)))
+      modelInArgs.set_p(l, inArgs.get_p(l));
+    else
+      modelInArgs.set_p(l, this->getModel().getNominalValues().get_p(l));
+
     modelInArgs.set_p_direction(l, inArgs.get_p_direction(l));
   }
 


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/piro
@mperego 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

Before this PR, the `Piro::NOXSolver` was the only child class of `Piro::SteadyStateSolver` which was not using the nominal parameter values by default.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

This branch has been tested on Blake successfully.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->