### PR TITLE
Teuchos:  Workaround nvcc-11 bug with ambiguous std::size/Teuchos::size

### DIFF
--- a/packages/teuchos/parser/src/Teuchos_vector.hpp
+++ b/packages/teuchos/parser/src/Teuchos_vector.hpp
@@ -9,10 +9,14 @@ namespace Teuchos {
 /* just some wrappers over std::vector to let us
    do all indexing with int */
 
+// This fixes a bug with nvcc-11, where it pulls in std::size(std::vector) and fails to compile
+// with an error that size(std::vector) is ambiguous.
+#if __cplusplus < 201703L
 template <typename T>
 inline int size(std::vector<T> const& v) {
   return int(v.size());
 }
+#endif
 
 template <typename T>
 inline typename std::vector<T>::reference at(std::vector<T>& v, int i) {


### PR DESCRIPTION
When I try to compile Trilinos with C++17 standard and Cuda enabled, I get compile errors that more than one instance of function `size(std::vector)` is defined.
My propesed change would not define `Teuchos::size(std::vector)`, because it is already defined in the std namespace. This compiled fine for me, but could potentially have side effects when the namespace std is not used by default.

A reproducer exposing the bug of nvcc-11:
```
// nvcc -x cu -std=c++17 test.cpp # fails with error: more than one instance of function template
// g++ -std=c++17 test.cpp # compiles fine
#include <iostream>
#include <vector>

namespace CSCS {
    template<typename T>
    inline int size(std::vector<T> const& v) {
        return v.size();
    }
}

namespace CSCS {
    using Cont = std::vector<int>;
    class Test {
    public:
        void print() {
            Cont c(10);
            std::cout << size(c) << std::endl;
        }
    };
}


int main() {
    CSCS::Test t;
    t.print();
    return 0;
}
```