### PR TITLE
Tempus: Remove ParameterList from IntegratorBasic

### DIFF
--- a/packages/piro/src/Piro_TempusIntegrator.hpp
+++ b/packages/piro/src/Piro_TempusIntegrator.hpp
@@ -45,7 +45,7 @@
 
 #include "Piro_ConfigDefs.hpp"
 
-#include "Tempus_IntegratorBasic.hpp"
+#include "Tempus_IntegratorBasicOld.hpp"
 #include "Tempus_IntegratorForwardSensitivity.hpp"
 #include "Tempus_IntegratorAdjointSensitivity.hpp"
 #include "Piro_Helpers.hpp"
@@ -106,7 +106,7 @@ public:
 
 private:
 
-  Teuchos::RCP<Tempus::IntegratorBasic<Scalar> > basicIntegrator_;
+  Teuchos::RCP<Tempus::IntegratorBasicOld<Scalar> > basicIntegrator_;
   Teuchos::RCP<Tempus::IntegratorForwardSensitivity<Scalar> > fwdSensIntegrator_;
   Teuchos::RCP<Tempus::IntegratorAdjointSensitivity<Scalar> > adjSensIntegrator_;
   Teuchos::RCP<Teuchos::FancyOStream> out_;

--- a/packages/rol/example/PinT/nonlinear/example_01.cpp
+++ b/packages/rol/example/PinT/nonlinear/example_01.cpp
@@ -42,7 +42,7 @@
 // @HEADER
 
 /*! \file  example_01.cpp
-    \brief Shows how to solve a control problem governed by a semilinear 
+    \brief Shows how to solve a control problem governed by a semilinear
            parabolic equation,
            \f[
               \min_{u,z} \;\sum_{n=1}^N frac{\delta_t}{2} (u_{n-1}-1)^2 (u_n-1)^2 (z_n-1)^2
@@ -69,7 +69,7 @@
 #include <fenv.h>
 
 int main(int argc, char *argv[]) {
-  feenableexcept(FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW);
+  //feenableexcept(FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW);
   using RealT = double;
   using uint  = std::vector<RealT>::size_type;
 

--- a/packages/rol/example/PinT/parabolic-control/example_01.cpp
+++ b/packages/rol/example/PinT/parabolic-control/example_01.cpp
@@ -42,13 +42,13 @@
 // @HEADER
 
 /*! \file  example_01.cpp
-    \brief Shows how to solve a control problem governed by a semilinear 
+    \brief Shows how to solve a control problem governed by a semilinear
            parabolic equation,
            \f[
               \min_{u,z} \;\frac{1}{2} \int_0^T\int_0^1 (u(t,x)-\bar{u}(x))^2\,\mathrm{d}x\mathrm{d}t
                          \frac{\alpha}{2} \int_0^T z(t)^2\,\mathrm{d}t
            \f]
-           subject to 
+           subject to
            \f[
                u_t(t,x) - u_{xx}(t,x) + f(u(t,x),x) = z(t,x) \quad t\in (0,T], \; x\in (0,1)
            \f]
@@ -78,7 +78,7 @@
 #include <fenv.h>
 
 int main(int argc, char *argv[]) {
-  feenableexcept(FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW);
+  //feenableexcept(FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW);
   using RealT = double;
   using uint  = std::vector<RealT>::size_type;
 

--- a/packages/rol/example/tempus/ROL_TempusReducedObjective.hpp
+++ b/packages/rol/example/tempus/ROL_TempusReducedObjective.hpp
@@ -49,7 +49,7 @@
 #include "Teuchos_RCP.hpp"
 #include "Teuchos_ParameterList.hpp"
 
-#include "Tempus_IntegratorBasic.hpp"
+#include "Tempus_IntegratorBasicOld.hpp"
 #include "Tempus_IntegratorForwardSensitivity.hpp"
 #include "Tempus_IntegratorAdjointSensitivity.hpp"
 #include "Tempus_IntegratorPseudoTransientForwardSensitivity.hpp"
@@ -425,7 +425,7 @@ run_tempus(const Thyra::ModelEvaluatorBase::InArgs<Real>&  inArgs,
       << " and Pseudotransient Adjoint.");
   }
   else {
-    RCP<Tempus::IntegratorBasic<Real> > integrator =
+    RCP<Tempus::IntegratorBasicOld<Real> > integrator =
       Tempus::integratorBasic<Real>(tempus_params_, wrapped_model);
     const bool integratorStatus = integrator->advanceTime();
     TEUCHOS_TEST_FOR_EXCEPTION(

--- a/packages/rol/example/tempus/example_01.cpp
+++ b/packages/rol/example/tempus/example_01.cpp
@@ -52,7 +52,7 @@
 #include "Teuchos_GlobalMPISession.hpp"
 #include "Teuchos_XMLParameterListHelpers.hpp"
 
-#include "Tempus_IntegratorBasic.hpp"
+#include "Tempus_IntegratorBasicOld.hpp"
 
 #include <fstream>
 
@@ -96,7 +96,7 @@ int main(int argc, char *argv[]) {
     RCP<Teuchos::ParameterList> tempusParList = sublist(parList, "Tempus", true);
     RCP<SinCosModelEvaluator<RealT>> model = Teuchos::rcp(new SinCosModelEvaluator<RealT>());
 
-    RCP<Tempus::IntegratorBasic<RealT> > integrator = Tempus::integratorBasic<RealT>(tempusParList, model);
+    RCP<Tempus::IntegratorBasicOld<RealT> > integrator = Tempus::integratorBasic<RealT>(tempusParList, model);
 
     integrator->advanceTime();
 

--- a/packages/rol/example/tempus/example_parabolic_modeleval.cpp
+++ b/packages/rol/example/tempus/example_parabolic_modeleval.cpp
@@ -48,7 +48,7 @@
               \min_{u,z} \;\frac{1}{2} \int_0^T\int_0^1 (u(t,x)-\bar{u}(x))^2\,\mathrm{d}x\mathrm{d}t
                          \frac{\alpha}{2} \int_0^T z(t)^2\,\mathrm{d}t
            \f]
-           subject to 
+           subject to
            \f[
                u_t(t,x) - u_{xx}(t,x) + f(u(t,x),x) = z(t,x) \quad t\in (0,T], \; x\in (0,1)
            \f]
@@ -66,7 +66,7 @@
 
 #include "Teuchos_GlobalMPISession.hpp"
 
-#include "Tempus_IntegratorBasic.hpp"
+#include "Tempus_IntegratorBasicOld.hpp"
 
 #include "ROL_Stream.hpp"
 #include "ROL_ParameterList.hpp"
@@ -82,7 +82,7 @@
 #include <ctime>
 
 int main(int argc, char *argv[]) {
-  feenableexcept(FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW);
+  //feenableexcept(FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW);
   using RealT = double;
   using uint  = std::vector<RealT>::size_type;
 
@@ -114,7 +114,7 @@ int main(int argc, char *argv[]) {
 
     // Create Tempus Integrator from ModelEvaluator.
     ROL::Ptr<Tempus::Integrator<RealT>> integrator =
-      ROL::makePtr<Tempus::IntegratorBasic<RealT>>(ROL::makePtrFromRef(pl_tempus), meval);
+      ROL::makePtr<Tempus::IntegratorBasicOld<RealT>>(ROL::makePtrFromRef(pl_tempus), meval);
 
     // Initialize objective function.
     ROL::Ptr<ROL::DynamicObjective<RealT>> dyn_obj =

--- a/packages/rol/example/tempus/example_parabolic_modeleval_forward-adjoint.cpp
+++ b/packages/rol/example/tempus/example_parabolic_modeleval_forward-adjoint.cpp
@@ -48,7 +48,7 @@
               \min_{u,z} \;\frac{1}{2} \int_0^T\int_0^1 (u(t,x)-\bar{u}(x))^2\,\mathrm{d}x\mathrm{d}t
                          \frac{\alpha}{2} \int_0^T z(t)^2\,\mathrm{d}t
            \f]
-           subject to 
+           subject to
            \f[
                u_t(t,x) - u_{xx}(t,x) + f(u(t,x),x) = z(t,x) \quad t\in (0,T], \; x\in (0,1)
            \f]
@@ -66,7 +66,7 @@
 
 #include "Teuchos_GlobalMPISession.hpp"
 
-#include "Tempus_IntegratorBasic.hpp"
+#include "Tempus_IntegratorBasicOld.hpp"
 
 #include "ROL_Stream.hpp"
 #include "ROL_ParameterList.hpp"
@@ -82,7 +82,7 @@
 #include <ctime>
 
 int main(int argc, char *argv[]) {
-  feenableexcept(FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW);
+  //feenableexcept(FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW);
   using RealT = double;
   using uint  = std::vector<RealT>::size_type;
 
@@ -118,11 +118,11 @@ int main(int argc, char *argv[]) {
 
     // Create FORWARD Tempus Integrator from ModelEvaluator.
     ROL::Ptr<Tempus::Integrator<RealT>> forward_integrator =
-      ROL::makePtr<Tempus::IntegratorBasic<RealT>>(ROL::makePtrFromRef(pl_tempus), forward_meval);
+      ROL::makePtr<Tempus::IntegratorBasicOld<RealT>>(ROL::makePtrFromRef(pl_tempus), forward_meval);
 
     // Create ADJOINT Tempus Integrator from ModelEvaluator.
     ROL::Ptr<Tempus::Integrator<RealT>> adjoint_integrator =
-      ROL::makePtr<Tempus::IntegratorBasic<RealT>>(ROL::makePtrFromRef(pl_tempus), adjoint_meval);
+      ROL::makePtr<Tempus::IntegratorBasicOld<RealT>>(ROL::makePtrFromRef(pl_tempus), adjoint_meval);
 
     // Initialize objective function.
     ROL::Ptr<ROL::DynamicObjective<RealT>> dyn_obj =

--- a/packages/rol/example/tempus/example_parabolic_thyravec.cpp
+++ b/packages/rol/example/tempus/example_parabolic_thyravec.cpp
@@ -48,7 +48,7 @@
               \min_{u,z} \;\frac{1}{2} \int_0^T\int_0^1 (u(t,x)-\bar{u}(x))^2\,\mathrm{d}x\mathrm{d}t
                          \frac{\alpha}{2} \int_0^T z(t)^2\,\mathrm{d}t
            \f]
-           subject to 
+           subject to
            \f[
                u_t(t,x) - u_{xx}(t,x) + f(u(t,x),x) = z(t,x) \quad t\in (0,T], \; x\in (0,1)
            \f]
@@ -77,7 +77,7 @@
 #include <fenv.h>
 
 int main(int argc, char *argv[]) {
-  feenableexcept(FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW);
+  //feenableexcept(FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW);
   using RealT = double;
   using uint  = std::vector<RealT>::size_type;
 

--- a/packages/tempus/src/Tempus_Integrator.hpp
+++ b/packages/tempus/src/Tempus_Integrator.hpp
@@ -13,7 +13,6 @@
 #include "Tempus_Types.hpp"
 #include "Teuchos_VerboseObject.hpp"
 #include "Teuchos_Describable.hpp"
-#include "Teuchos_ParameterListAcceptorDefaultBase.hpp"
 
 #include <string>
 
@@ -62,8 +61,7 @@ namespace Tempus {
 template<class Scalar>
 class Integrator
   : virtual public Teuchos::Describable,
-    virtual public Teuchos::VerboseObject<Tempus::Integrator<Scalar> >,
-    virtual public Teuchos::ParameterListAcceptor
+    virtual public Teuchos::VerboseObject<Tempus::Integrator<Scalar> >
 {
 public:
 
@@ -93,5 +91,7 @@ public:
   //@}
 
 };
+
+
 } // namespace Tempus
 #endif // Tempus_Integrator_hpp

--- a/packages/tempus/src/Tempus_IntegratorAdjointSensitivity_decl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorAdjointSensitivity_decl.hpp
@@ -11,7 +11,7 @@
 
 // Tempus
 #include "Tempus_config.hpp"
-#include "Tempus_IntegratorBasic.hpp"
+#include "Tempus_IntegratorBasicOld.hpp"
 #include "Tempus_AdjointAuxSensitivityModelEvaluator.hpp"
 
 namespace Tempus {
@@ -42,7 +42,8 @@ namespace Tempus {
  */
 template<class Scalar>
 class IntegratorAdjointSensitivity :
-    virtual public Tempus::Integrator<Scalar>
+    virtual public Tempus::Integrator<Scalar>,
+    virtual public Teuchos::ParameterListAcceptor
 {
 public:
 
@@ -176,8 +177,8 @@ protected:
 
   Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > model_;
   Teuchos::RCP<AdjointAuxSensitivityModelEvaluator<Scalar> > adjoint_model_;
-  Teuchos::RCP<IntegratorBasic<Scalar> > state_integrator_;
-  Teuchos::RCP<IntegratorBasic<Scalar> > adjoint_integrator_;
+  Teuchos::RCP<IntegratorBasicOld<Scalar> > state_integrator_;
+  Teuchos::RCP<IntegratorBasicOld<Scalar> > adjoint_integrator_;
   Teuchos::RCP<SolutionHistory<Scalar> > solutionHistory_;
   int p_index_;
   int g_index_;

--- a/packages/tempus/src/Tempus_IntegratorBasicOld.cpp
+++ b/packages/tempus/src/Tempus_IntegratorBasicOld.cpp
@@ -9,28 +9,28 @@
 #include "Tempus_ExplicitTemplateInstantiation.hpp"
 
 #ifdef HAVE_TEMPUS_EXPLICIT_INSTANTIATION
-#include "Tempus_IntegratorBasic.hpp"
-#include "Tempus_IntegratorBasic_impl.hpp"
+#include "Tempus_IntegratorBasicOld.hpp"
+#include "Tempus_IntegratorBasicOld_impl.hpp"
 
 namespace Tempus {
 
-  TEMPUS_INSTANTIATE_TEMPLATE_CLASS(IntegratorBasic)
+  TEMPUS_INSTANTIATE_TEMPLATE_CLASS(IntegratorBasicOld)
 
   // Nonmember ctor
-  template Teuchos::RCP<IntegratorBasic<double> > createIntegratorBasic(
+  template Teuchos::RCP<IntegratorBasicOld<double> > integratorBasic(
     Teuchos::RCP<Teuchos::ParameterList>        parameterList,
     const Teuchos::RCP<Thyra::ModelEvaluator<double> >& model);
 
   // Nonmember ctor
-  template Teuchos::RCP<IntegratorBasic<double> > createIntegratorBasic(
+  template Teuchos::RCP<IntegratorBasicOld<double> > integratorBasic(
     const Teuchos::RCP<Thyra::ModelEvaluator<double> >& model,
     std::string stepperType);
 
   // Nonmember ctor
-  template Teuchos::RCP<IntegratorBasic<double> > createIntegratorBasic();
+  template Teuchos::RCP<IntegratorBasicOld<double> > integratorBasic();
 
   // Nonmember ctor
-  template Teuchos::RCP<IntegratorBasic<double> > createIntegratorBasic(
+  template Teuchos::RCP<IntegratorBasicOld<double> > integratorBasic(
     Teuchos::RCP<Teuchos::ParameterList>                     pList,
     std::vector<Teuchos::RCP<const Thyra::ModelEvaluator<double> > > models);
 

--- a/packages/tempus/src/Tempus_IntegratorBasicOld_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorBasicOld_impl.hpp
@@ -1,0 +1,703 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#ifndef Tempus_IntegratorBasicOld_impl_hpp
+#define Tempus_IntegratorBasicOld_impl_hpp
+
+#include "Thyra_VectorStdOps.hpp"
+
+#include "Tempus_StepperFactory.hpp"
+
+
+namespace Tempus {
+
+template<class Scalar>
+IntegratorBasicOld<Scalar>::IntegratorBasicOld(
+  Teuchos::RCP<Teuchos::ParameterList>                inputPL,
+  const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model)
+    : integratorObserver_(Teuchos::null),
+      integratorStatus_(WORKING), isInitialized_(false)
+{
+  this->setTempusParameterList(inputPL);
+  this->setStepper(model);
+  this->initialize();
+}
+
+
+template<class Scalar>
+IntegratorBasicOld<Scalar>::IntegratorBasicOld(
+  const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model,
+  std::string stepperType)
+    : integratorObserver_(Teuchos::null),
+      integratorStatus_(WORKING), isInitialized_(false)
+{
+  using Teuchos::RCP;
+  RCP<StepperFactory<Scalar> > sf = Teuchos::rcp(new StepperFactory<Scalar>());
+  RCP<Stepper<Scalar> > stepper = sf->createStepper(stepperType, model);
+
+  this->setTempusParameterList(Teuchos::null);
+  this->setStepperWStepper(stepper);
+  this->initialize();
+}
+
+
+template<class Scalar>
+IntegratorBasicOld<Scalar>::IntegratorBasicOld()
+  : integratorObserver_(Teuchos::null),
+    integratorStatus_(WORKING), isInitialized_(false)
+{
+  this->setTempusParameterList(Teuchos::null);
+}
+
+
+template<class Scalar>
+IntegratorBasicOld<Scalar>::IntegratorBasicOld(
+  Teuchos::RCP<Teuchos::ParameterList>                inputPL,
+  std::vector<Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > > models)
+    : integratorObserver_(Teuchos::null),
+      integratorStatus_(WORKING), isInitialized_(false)
+{
+  this->setTempusParameterList(inputPL);
+  this->setStepper(models);
+  this->initialize();
+}
+
+
+template<class Scalar>
+void IntegratorBasicOld<Scalar>::setStepper(
+  Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > model)
+{
+  using Teuchos::RCP;
+  using Teuchos::ParameterList;
+
+  if (stepper_ == Teuchos::null) {
+    // Construct from Integrator ParameterList
+    RCP<StepperFactory<Scalar> > sf =Teuchos::rcp(new StepperFactory<Scalar>());
+    std::string stepperName = integratorPL_->get<std::string>("Stepper Name");
+
+    RCP<ParameterList> stepperPL = Teuchos::sublist(tempusPL_,stepperName,true);
+    stepper_ = sf->createStepper(stepperPL, model);
+  } else {
+    stepper_->setModel(model);
+  }
+}
+
+
+template<class Scalar>
+void IntegratorBasicOld<Scalar>::setStepper(
+  std::vector<Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > > models)
+{
+  using Teuchos::RCP;
+  using Teuchos::ParameterList;
+
+  // Construct from Integrator ParameterList
+  RCP<StepperFactory<Scalar> > sf =Teuchos::rcp(new StepperFactory<Scalar>());
+  std::string stepperName = integratorPL_->get<std::string>("Stepper Name");
+
+  RCP<ParameterList> stepperPL = Teuchos::sublist(tempusPL_,stepperName,true);
+  stepper_ = sf->createStepper(stepperPL, models);
+}
+
+
+template<class Scalar>
+void IntegratorBasicOld<Scalar>::setStepperWStepper(
+  Teuchos::RCP<Stepper<Scalar> > newStepper)
+{
+  stepper_ = newStepper;
+}
+
+/// This resets the SolutionHistory and sets the first SolutionState as the IC.
+template<class Scalar>
+void IntegratorBasicOld<Scalar>::
+initializeSolutionHistory(Teuchos::RCP<SolutionState<Scalar> > state)
+{
+  using Teuchos::RCP;
+  using Teuchos::ParameterList;
+
+  // Construct from Integrator ParameterList
+  RCP<ParameterList> shPL =
+    Teuchos::sublist(integratorPL_, "Solution History", true);
+  solutionHistory_ = createSolutionHistoryPL<Scalar>(shPL);
+
+  if (state == Teuchos::null) {
+    // Construct default IC from the application model
+    RCP<SolutionState<Scalar> > newState = createSolutionStateME(
+      stepper_->getModel(), stepper_->getDefaultStepperState());
+
+    // Set SolutionState from TimeStepControl
+    newState->setTime    (timeStepControl_->getInitTime());
+    newState->setIndex   (timeStepControl_->getInitIndex());
+    newState->setTimeStep(timeStepControl_->getInitTimeStep());
+    newState->setTolRel  (timeStepControl_->getMaxRelError());
+    newState->setTolAbs  (timeStepControl_->getMaxAbsError());
+    newState->setOrder   (stepper_->getOrder());
+    newState->setSolutionStatus(Status::PASSED);  // ICs are considered passing.
+
+    solutionHistory_->addState(newState);
+
+  } else {
+    // Use state as IC
+    solutionHistory_->addState(state);
+  }
+
+  // Get IC from the application model via the stepper and ensure consistency.
+  stepper_->setInitialConditions(solutionHistory_);
+}
+
+
+template<class Scalar>
+void IntegratorBasicOld<Scalar>::
+initializeSolutionHistory(Scalar t0,
+  Teuchos::RCP<const Thyra::VectorBase<Scalar> > x0,
+  Teuchos::RCP<const Thyra::VectorBase<Scalar> > xdot0,
+  Teuchos::RCP<const Thyra::VectorBase<Scalar> > xdotdot0)
+{
+  using Teuchos::RCP;
+  using Teuchos::ParameterList;
+
+  // Construct from Integrator ParameterList
+  RCP<ParameterList> shPL =
+    Teuchos::sublist(integratorPL_, "Solution History", true);
+  solutionHistory_ = createSolutionHistoryPL<Scalar>(shPL);
+
+  // Create and set xdot and xdotdot.
+  RCP<Thyra::VectorBase<Scalar> > xdot    = x0->clone_v();
+  RCP<Thyra::VectorBase<Scalar> > xdotdot = x0->clone_v();
+  if (xdot0 == Teuchos::null)
+    Thyra::assign(xdot.ptr(),    Teuchos::ScalarTraits<Scalar>::zero());
+  else
+    Thyra::assign(xdot.ptr(),    *(xdot0));
+  if (xdotdot0 == Teuchos::null)
+    Thyra::assign(xdotdot.ptr(), Teuchos::ScalarTraits<Scalar>::zero());
+  else
+    Thyra::assign(xdotdot.ptr(), *(xdotdot0));
+
+  RCP<SolutionState<Scalar> > newState = createSolutionStateX(
+    x0->clone_v(), xdot, xdotdot);
+  newState->setStepperState(stepper_->getDefaultStepperState());
+
+  // Set SolutionState from TimeStepControl
+  newState->setTime    (t0);
+  newState->setIndex   (timeStepControl_->getInitIndex());
+  newState->setTimeStep(timeStepControl_->getInitTimeStep());
+  newState->setOrder(stepper_->getOrder());
+
+  newState->setSolutionStatus(Status::PASSED);  // ICs are considered passing.
+
+  solutionHistory_->addState(newState);
+
+  // Get IC from the application model via the stepper and ensure consistency.
+  stepper_->setInitialConditions(solutionHistory_);
+}
+
+
+template<class Scalar>
+void IntegratorBasicOld<Scalar>::setSolutionHistory(
+  Teuchos::RCP<SolutionHistory<Scalar> > sh)
+{
+  using Teuchos::RCP;
+  using Teuchos::ParameterList;
+
+  if (sh == Teuchos::null) {
+    // Create default SolutionHistory, otherwise keep current history.
+    if (solutionHistory_ == Teuchos::null) initializeSolutionHistory();
+  } else {
+
+    TEUCHOS_TEST_FOR_EXCEPTION( sh->getNumStates() < 1,
+      std::out_of_range,
+         "Error - setSolutionHistory requires at least one SolutionState.\n"
+      << "        Supplied SolutionHistory has only " << sh->getNumStates()
+      << " SolutionStates.\n");
+
+    solutionHistory_ = sh;
+  }
+}
+
+
+template<class Scalar>
+void IntegratorBasicOld<Scalar>::setTimeStepControl(
+  Teuchos::RCP<TimeStepControl<Scalar> > tsc)
+{
+  using Teuchos::RCP;
+  using Teuchos::ParameterList;
+
+  if (tsc == Teuchos::null) {
+    // Create timeStepControl_ if null, otherwise keep current parameters.
+    if (timeStepControl_ == Teuchos::null) {
+      if (integratorPL_->isSublist("Time Step Control")) {
+        // Construct from Integrator ParameterList
+        RCP<ParameterList> tscPL =
+          Teuchos::sublist(integratorPL_,"Time Step Control",true);
+        timeStepControl_ = createTimeStepControl<Scalar>(tscPL);
+      } else {
+        // Construct default TimeStepControl
+        timeStepControl_ = rcp(new TimeStepControl<Scalar>());
+        RCP<const ParameterList> tscPL = timeStepControl_->getValidParameters();
+        integratorPL_->set("Time Step Control", tscPL->name());
+        integratorPL_->set(tscPL->name(), *tscPL);
+      }
+    }
+
+  } else {
+    // Make integratorPL_ consistent with new TimeStepControl.
+    timeStepControl_ = tsc;
+    RCP<const ParameterList> tscPL = timeStepControl_->getValidParameters();
+    integratorPL_->set(tscPL->name(), *tscPL);
+  }
+
+  timeStepControl_->initialize();
+}
+
+
+template<class Scalar>
+void IntegratorBasicOld<Scalar>::setObserver(
+  Teuchos::RCP<IntegratorObserver<Scalar> > obs)
+{
+
+  if (obs == Teuchos::null) {
+    // Create default IntegratorObserverBasic, otherwise keep current observer.
+    if (integratorObserver_ == Teuchos::null) {
+      integratorObserver_ =
+        Teuchos::rcp(new IntegratorObserverComposite<Scalar>);
+      // Add basic observer to output time step info
+      Teuchos::RCP<IntegratorObserverBasic<Scalar> > basicObs =
+          Teuchos::rcp(new IntegratorObserverBasic<Scalar>);
+      integratorObserver_->addObserver(basicObs);
+    }
+  } else {
+    if (integratorObserver_ == Teuchos::null) {
+      integratorObserver_ =
+        Teuchos::rcp(new IntegratorObserverComposite<Scalar>);
+    }
+    integratorObserver_->addObserver(obs);
+  }
+
+}
+
+
+template<class Scalar>
+void IntegratorBasicOld<Scalar>::initialize()
+{
+  TEUCHOS_TEST_FOR_EXCEPTION( stepper_ == Teuchos::null, std::logic_error,
+    "Error - Need to set the Stepper, setStepper(), before calling "
+    "IntegratorBasicOld::initialize()\n");
+
+  this->setTimeStepControl();
+  this->parseScreenOutput();
+  this->setSolutionHistory();
+  this->setObserver();
+
+  // Set initial conditions, make them consistent, and set stepper memory.
+  stepper_->setInitialConditions(solutionHistory_);
+
+  if (integratorTimer_ == Teuchos::null)
+    integratorTimer_ = rcp(new Teuchos::Time("Integrator Timer"));
+  if (stepperTimer_ == Teuchos::null)
+    stepperTimer_    = rcp(new Teuchos::Time("Stepper Timer"));
+
+  if (Teuchos::as<int>(this->getVerbLevel()) >=
+      Teuchos::as<int>(Teuchos::VERB_HIGH)) {
+    Teuchos::RCP<Teuchos::FancyOStream> out = this->getOStream();
+    Teuchos::OSTab ostab(out,1,"IntegratorBasicOld::IntegratorBasicOld");
+    *out << this->description() << std::endl;
+  }
+
+  isInitialized_ = true;
+}
+
+
+template<class Scalar>
+std::string IntegratorBasicOld<Scalar>::description() const
+{
+  std::string name = "Tempus::IntegratorBasicOld";
+  return(name);
+}
+
+
+template<class Scalar>
+void IntegratorBasicOld<Scalar>::describe(
+  Teuchos::FancyOStream          &out,
+  const Teuchos::EVerbosityLevel verbLevel) const
+{
+  out << description() << "::describe" << std::endl;
+  out << "solutionHistory= " << solutionHistory_->description()<<std::endl;
+  out << "timeStepControl= " << timeStepControl_->description()<<std::endl;
+  out << "stepper        = " << stepper_        ->description()<<std::endl;
+
+  if (Teuchos::as<int>(verbLevel) >=
+              Teuchos::as<int>(Teuchos::VERB_HIGH)) {
+    out << "solutionHistory= " << std::endl;
+    solutionHistory_->describe(out,verbLevel);
+    out << "timeStepControl= " << std::endl;
+    timeStepControl_->describe(out,verbLevel);
+    out << "stepper        = " << std::endl;
+    stepper_        ->describe(out,verbLevel);
+  }
+}
+
+
+template <class Scalar>
+bool IntegratorBasicOld<Scalar>::advanceTime(const Scalar timeFinal)
+{
+  if (timeStepControl_->timeInRange(timeFinal))
+    timeStepControl_->setFinalTime(timeFinal);
+  bool itgrStatus = advanceTime();
+  return itgrStatus;
+}
+
+
+template <class Scalar>
+void IntegratorBasicOld<Scalar>::startIntegrator()
+{
+  Teuchos::RCP<Teuchos::FancyOStream> out = this->getOStream();
+  if (isInitialized_ == false) {
+    Teuchos::OSTab ostab(out,1,"StartIntegrator");
+    *out << "Failure - IntegratorBasicOld is not initialized." << std::endl;
+    integratorStatus_ = Status::FAILED;
+    return;
+  }
+
+  //set the Abs/Rel tolerance
+  auto cs = solutionHistory_->getCurrentState();
+  cs->setTolRel(timeStepControl_->getMaxRelError());
+  cs->setTolAbs(timeStepControl_->getMaxAbsError());
+
+  integratorTimer_->start();
+  // get optimal initial time step
+  const Scalar initDt =
+     std::min(timeStepControl_->getInitTimeStep(),
+              stepper_->getInitTimeStep(solutionHistory_));
+  // update initial time step
+  timeStepControl_->setInitTimeStep(initDt);
+  timeStepControl_->initialize();
+  integratorStatus_ = WORKING;
+}
+
+
+template <class Scalar>
+bool IntegratorBasicOld<Scalar>::advanceTime()
+{
+  TEMPUS_FUNC_TIME_MONITOR("Tempus::IntegratorBasicOld::advanceTime()");
+  {
+    startIntegrator();
+    integratorObserver_->observeStartIntegrator(*this);
+
+    while (integratorStatus_ == WORKING and
+        timeStepControl_->timeInRange (solutionHistory_->getCurrentTime()) and
+        timeStepControl_->indexInRange(solutionHistory_->getCurrentIndex())){
+
+      stepperTimer_->reset();
+      stepperTimer_->start();
+      solutionHistory_->initWorkingState();
+
+      startTimeStep();
+      integratorObserver_->observeStartTimeStep(*this);
+
+      timeStepControl_->setNextTimeStep(solutionHistory_, integratorStatus_);
+      integratorObserver_->observeNextTimeStep(*this);
+
+      if (integratorStatus_ == Status::FAILED) break;
+      solutionHistory_->getWorkingState()->setSolutionStatus(WORKING);
+
+      integratorObserver_->observeBeforeTakeStep(*this);
+
+      stepper_->takeStep(solutionHistory_);
+
+      integratorObserver_->observeAfterTakeStep(*this);
+
+      stepperTimer_->stop();
+      checkTimeStep();
+      integratorObserver_->observeAfterCheckTimeStep(*this);
+
+      solutionHistory_->promoteWorkingState();
+      integratorObserver_->observeEndTimeStep(*this);
+    }
+
+    endIntegrator();
+    integratorObserver_->observeEndIntegrator(*this);
+  }
+
+  return (integratorStatus_ == Status::PASSED);
+}
+
+
+template <class Scalar>
+void IntegratorBasicOld<Scalar>::startTimeStep()
+{
+  auto ws = solutionHistory_->getWorkingState();
+
+  //set the Abs/Rel tolerance
+  ws->setTolRel(timeStepControl_->getMaxRelError());
+  ws->setTolAbs(timeStepControl_->getMaxAbsError());
+
+  // Check if we need to dump screen output this step
+  std::vector<int>::const_iterator it =
+    std::find(outputScreenIndices_.begin(),
+              outputScreenIndices_.end(),
+              ws->getIndex());
+  if (it == outputScreenIndices_.end())
+    ws->setOutputScreen(false);
+  else
+    ws->setOutputScreen(true);
+
+  const int initial = timeStepControl_->getInitIndex();
+  const int interval = integratorPL_->get<int>("Screen Output Index Interval");
+  if ( (ws->getIndex() - initial) % interval == 0)
+    ws->setOutputScreen(true);
+}
+
+
+template <class Scalar>
+void IntegratorBasicOld<Scalar>::checkTimeStep()
+{
+  using Teuchos::RCP;
+  auto ws = solutionHistory_->getWorkingState();
+
+  // Too many TimeStep failures, Integrator fails.
+  if (ws->getNFailures() >= timeStepControl_->getMaxFailures()) {
+    RCP<Teuchos::FancyOStream> out = this->getOStream();
+    Teuchos::OSTab ostab(out,2,"checkTimeStep");
+    *out << "Failure - Stepper has failed more than the maximum allowed.\n"
+         << "  (nFailures = "<<ws->getNFailures()<< ") >= (nFailuresMax = "
+         << timeStepControl_->getMaxFailures()<<")" << std::endl;
+    integratorStatus_ = Status::FAILED;
+    return;
+  }
+  if (ws->getNConsecutiveFailures()
+      >= timeStepControl_->getMaxConsecFailures()){
+    RCP<Teuchos::FancyOStream> out = this->getOStream();
+    Teuchos::OSTab ostab(out,1,"checkTimeStep");
+    *out << "Failure - Stepper has failed more than the maximum "
+         << "consecutive allowed.\n"
+         << "  (nConsecutiveFailures = "<<ws->getNConsecutiveFailures()
+         << ") >= (nConsecutiveFailuresMax = "
+         << timeStepControl_->getMaxConsecFailures()
+         << ")" << std::endl;
+    integratorStatus_ = Status::FAILED;
+    return;
+  }
+
+  // Check Stepper failure.
+  if (ws->getSolutionStatus() == Status::FAILED or
+       // Constant time step failure
+       ((timeStepControl_->getStepType() == "Constant") and
+        (ws->getTimeStep() != timeStepControl_->getInitTimeStep()) and
+        (ws->getOutput() != true) and
+        (ws->getTime() != timeStepControl_->getFinalTime())
+       )
+     )
+  {
+    RCP<Teuchos::FancyOStream> out = this->getOStream();
+    Teuchos::OSTab ostab(out,0,"checkTimeStep");
+    *out <<std::scientific
+      <<std::setw( 6)<<std::setprecision(3)<<ws->getIndex()
+      <<std::setw(11)<<std::setprecision(3)<<ws->getTime()
+      <<std::setw(11)<<std::setprecision(3)<<ws->getTimeStep()
+      << "  STEP FAILURE!! - ";
+    if (ws->getSolutionStatus() == Status::FAILED) {
+      *out << "Solution Status = " << toString(ws->getSolutionStatus())
+           << std::endl;
+    } else if ((timeStepControl_->getStepType() == "Constant") and
+               (ws->getTimeStep() != timeStepControl_->getInitTimeStep())) {
+      *out << "dt != Constant dt (="<<timeStepControl_->getInitTimeStep()<<")"
+           << std::endl;
+    }
+
+    ws->setNFailures(ws->getNFailures()+1);
+    ws->setNRunningFailures(ws->getNRunningFailures()+1);
+    ws->setNConsecutiveFailures(ws->getNConsecutiveFailures()+1);
+    ws->setSolutionStatus(Status::FAILED);
+    return;
+  }
+
+  // TIME STEP PASSED basic tests!  Ensure it is set as such.
+  ws->setSolutionStatus(Status::PASSED);
+
+}
+
+
+template <class Scalar>
+void IntegratorBasicOld<Scalar>::endIntegrator()
+{
+  std::string exitStatus;
+  if (solutionHistory_->getCurrentState()->getSolutionStatus() ==
+      Status::FAILED or integratorStatus_ == Status::FAILED) {
+    exitStatus = "Time integration FAILURE!";
+  } else {
+    integratorStatus_ = Status::PASSED;
+    exitStatus = "Time integration complete.";
+  }
+
+  integratorTimer_->stop();
+  runtime_ = integratorTimer_->totalElapsedTime();
+}
+
+
+template <class Scalar>
+void IntegratorBasicOld<Scalar>::parseScreenOutput()
+{
+  // This has been delayed until timeStepControl has been constructed.
+
+  // Parse output indices
+  outputScreenIndices_.clear();
+  std::string str =
+    integratorPL_->get<std::string>("Screen Output Index List", "");
+  std::string delimiters(",");
+  std::string::size_type lastPos = str.find_first_not_of(delimiters, 0);
+  std::string::size_type pos     = str.find_first_of(delimiters, lastPos);
+  while ((pos != std::string::npos) || (lastPos != std::string::npos)) {
+    std::string token = str.substr(lastPos,pos-lastPos);
+    outputScreenIndices_.push_back(int(std::stoi(token)));
+    if(pos==std::string::npos)
+      break;
+
+    lastPos = str.find_first_not_of(delimiters, pos);
+    pos = str.find_first_of(delimiters, lastPos);
+  }
+
+  // order output indices and remove duplicates.
+  std::sort(outputScreenIndices_.begin(),outputScreenIndices_.end());
+  outputScreenIndices_.erase(std::unique(outputScreenIndices_.begin(),
+                                         outputScreenIndices_.end()   ),
+                                         outputScreenIndices_.end()     );
+  return;
+}
+
+
+template <class Scalar>
+void IntegratorBasicOld<Scalar>::setParameterList(
+  const Teuchos::RCP<Teuchos::ParameterList> & inputPL)
+{
+  if (inputPL == Teuchos::null) {
+    if (tempusPL_->isParameter("Integrator Name")) {
+      // Set Integrator PL from Tempus PL
+      std::string integratorName_ =
+         tempusPL_->get<std::string>("Integrator Name");
+      integratorPL_ = Teuchos::sublist(tempusPL_, integratorName_, true);
+    } else {
+      // Build default Integrator PL
+      integratorPL_ = Teuchos::parameterList();
+      integratorPL_->setName("Default Integrator");
+      *integratorPL_ = *(this->getValidParameters());
+      tempusPL_->set("Integrator Name", "Default Integrator");
+      tempusPL_->set("Default Integrator", *integratorPL_);
+    }
+  } else {
+    *integratorPL_ = *inputPL;
+    tempusPL_->set("Integrator Name", integratorPL_->name());
+    tempusPL_->set(integratorPL_->name(), *integratorPL_);
+  }
+
+  integratorPL_->validateParametersAndSetDefaults(*this->getValidParameters());
+
+  std::string integratorType =
+    integratorPL_->get<std::string>("Integrator Type");
+  TEUCHOS_TEST_FOR_EXCEPTION( integratorType != "Integrator Basic",
+    std::logic_error,
+    "Error - Inconsistent Integrator Type for IntegratorBasicOld\n"
+    << "    Integrator Type = " << integratorType << "\n");
+
+  return;
+}
+
+
+/** \brief Create valid IntegratorBasicOld ParameterList.
+ */
+template<class Scalar>
+Teuchos::RCP<const Teuchos::ParameterList>
+IntegratorBasicOld<Scalar>::getValidParameters() const
+{
+  Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
+
+  std::ostringstream tmp;
+  tmp << "'Integrator Type' must be 'Integrator Basic'.";
+  pl->set("Integrator Type", "Integrator Basic", tmp.str());
+
+  tmp.clear();
+  tmp << "Screen Output Index List.  Required to be in TimeStepControl range "
+      << "['Minimum Time Step Index', 'Maximum Time Step Index']";
+  pl->set("Screen Output Index List", "", tmp.str());
+  pl->set("Screen Output Index Interval", 1000000,
+    "Screen Output Index Interval (e.g., every 100 time steps)");
+
+  pl->set("Stepper Name", "",
+    "'Stepper Name' selects the Stepper block to construct (Required).");
+
+  // Solution History
+  pl->sublist("Solution History",false,"solutionHistory_docs")
+      .disableRecursiveValidation();
+
+  // Time Step Control
+  pl->sublist("Time Step Control",false,"solutionHistory_docs")
+      .disableRecursiveValidation();
+
+  return pl;
+}
+
+
+template <class Scalar>
+Teuchos::RCP<Teuchos::ParameterList>
+IntegratorBasicOld<Scalar>::getNonconstParameterList()
+{
+  return(integratorPL_);
+}
+
+
+template <class Scalar>
+Teuchos::RCP<Teuchos::ParameterList>
+IntegratorBasicOld<Scalar>::unsetParameterList()
+{
+  Teuchos::RCP<Teuchos::ParameterList> temp_param_list = integratorPL_;
+  integratorPL_ = Teuchos::null;
+  return(temp_param_list);
+}
+
+/// Nonmember constructor
+template<class Scalar>
+Teuchos::RCP<IntegratorBasicOld<Scalar> > integratorBasic(
+  Teuchos::RCP<Teuchos::ParameterList>                     pList,
+  const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >&      model)
+{
+  Teuchos::RCP<IntegratorBasicOld<Scalar> > integrator =
+    Teuchos::rcp(new IntegratorBasicOld<Scalar>(pList, model));
+  return(integrator);
+}
+
+/// Nonmember constructor
+template<class Scalar>
+Teuchos::RCP<IntegratorBasicOld<Scalar> > integratorBasic(
+  const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >&      model,
+  std::string stepperType)
+{
+  Teuchos::RCP<IntegratorBasicOld<Scalar> > integrator =
+    Teuchos::rcp(new IntegratorBasicOld<Scalar>(model, stepperType));
+  return(integrator);
+}
+
+/// Nonmember constructor
+template<class Scalar>
+Teuchos::RCP<IntegratorBasicOld<Scalar> > integratorBasic()
+{
+  Teuchos::RCP<IntegratorBasicOld<Scalar> > integrator =
+    Teuchos::rcp(new IntegratorBasicOld<Scalar>());
+  return(integrator);
+}
+
+/// Nonmember constructor
+template<class Scalar>
+Teuchos::RCP<IntegratorBasicOld<Scalar> > integratorBasic(
+  Teuchos::RCP<Teuchos::ParameterList>                     pList,
+  std::vector<Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > > models)
+{
+  Teuchos::RCP<IntegratorBasicOld<Scalar> > integrator =
+    Teuchos::rcp(new IntegratorBasicOld<Scalar>(pList, models));
+  return(integrator);
+}
+
+} // namespace Tempus
+#endif // Tempus_IntegratorBasicOld_impl_hpp

--- a/packages/tempus/src/Tempus_IntegratorBasic_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorBasic_impl.hpp
@@ -12,103 +12,86 @@
 #include "Thyra_VectorStdOps.hpp"
 
 #include "Tempus_StepperFactory.hpp"
+#include "Tempus_StepperForwardEuler.hpp"
 
 
 namespace Tempus {
 
 template<class Scalar>
-IntegratorBasic<Scalar>::IntegratorBasic(
-  Teuchos::RCP<Teuchos::ParameterList>                inputPL,
-  const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model)
-    : integratorObserver_(Teuchos::null),
-      integratorStatus_(WORKING), isInitialized_(false)
-{
-  this->setTempusParameterList(inputPL);
-  this->setStepper(model);
-  this->initialize();
-}
-
-
-template<class Scalar>
-IntegratorBasic<Scalar>::IntegratorBasic(
-  const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model,
-  std::string stepperType)
-    : integratorObserver_(Teuchos::null),
-      integratorStatus_(WORKING), isInitialized_(false)
-{
-  using Teuchos::RCP;
-  RCP<StepperFactory<Scalar> > sf = Teuchos::rcp(new StepperFactory<Scalar>());
-  RCP<Stepper<Scalar> > stepper = sf->createStepper(stepperType, model);
-
-  this->setTempusParameterList(Teuchos::null);
-  this->setStepperWStepper(stepper);
-  this->initialize();
-}
-
-
-template<class Scalar>
 IntegratorBasic<Scalar>::IntegratorBasic()
-  : integratorObserver_(Teuchos::null),
-    integratorStatus_(WORKING), isInitialized_(false)
+  : outputScreenIndices_(std::vector<int>()),
+    outputScreenInterval_(1000000),
+    integratorStatus_(WORKING),
+    isInitialized_(false)
 {
-  this->setTempusParameterList(Teuchos::null);
+  setIntegratorName("Integrator Basic");
+  setIntegratorType("Integrator Basic");
+  setStepper(Teuchos::null);
+  setSolutionHistory(Teuchos::null);
+  setTimeStepControl(Teuchos::null);
+  setObserver(Teuchos::null);
+
+  integratorTimer_ = rcp(new Teuchos::Time("Integrator Timer"));
+  stepperTimer_    = rcp(new Teuchos::Time("Stepper Timer"));
+
 }
 
 
 template<class Scalar>
 IntegratorBasic<Scalar>::IntegratorBasic(
-  Teuchos::RCP<Teuchos::ParameterList>                inputPL,
-  std::vector<Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > > models)
-    : integratorObserver_(Teuchos::null),
-      integratorStatus_(WORKING), isInitialized_(false)
+  Teuchos::RCP<Stepper<Scalar> >            stepper,
+  Teuchos::RCP<SolutionHistory<Scalar> >    solutionHistory,
+  Teuchos::RCP<TimeStepControl<Scalar> >    timeStepControl,
+  Teuchos::RCP<IntegratorObserver<Scalar> > integratorObserver,
+  std::vector<int>                          outputScreenIndices,
+  int                                       outputScreenInterval)
+  : outputScreenIndices_(outputScreenIndices),
+    outputScreenInterval_(outputScreenInterval),
+    integratorStatus_(WORKING),
+    isInitialized_(false)
 {
-  this->setTempusParameterList(inputPL);
-  this->setStepper(models);
-  this->initialize();
+  setIntegratorName("Integrator Basic");
+  setIntegratorType("Integrator Basic");
+  setStepper(stepper);
+  setSolutionHistory(solutionHistory);
+  setTimeStepControl(timeStepControl);
+  setObserver(integratorObserver);
+
+  integratorTimer_ = rcp(new Teuchos::Time("Integrator Timer"));
+  stepperTimer_    = rcp(new Teuchos::Time("Stepper Timer"));
+
 }
 
 
 template<class Scalar>
-void IntegratorBasic<Scalar>::setStepper(
+void IntegratorBasic<Scalar>::setIntegratorType(std::string i)
+{
+  TEUCHOS_TEST_FOR_EXCEPTION( i != "Integrator Basic", std::logic_error,
+    "Error - Integrator Type should be 'Integrator Basic'\n");
+
+  this->integratorType_ = i;
+}
+
+
+template<class Scalar>
+void IntegratorBasic<Scalar>::setModel(
   Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > model)
 {
-  using Teuchos::RCP;
-  using Teuchos::ParameterList;
+  TEUCHOS_TEST_FOR_EXCEPTION( stepper_ == Teuchos::null, std::logic_error,
+    "Error - setModel(), need to set stepper first!\n");
 
-  if (stepper_ == Teuchos::null) {
-    // Construct from Integrator ParameterList
-    RCP<StepperFactory<Scalar> > sf =Teuchos::rcp(new StepperFactory<Scalar>());
-    std::string stepperName = integratorPL_->get<std::string>("Stepper Name");
-
-    RCP<ParameterList> stepperPL = Teuchos::sublist(tempusPL_,stepperName,true);
-    stepper_ = sf->createStepper(stepperPL, model);
-  } else {
-    stepper_->setModel(model);
-  }
+  stepper_->setModel(model);
 }
 
 
 template<class Scalar>
 void IntegratorBasic<Scalar>::setStepper(
-  std::vector<Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > > models)
+  Teuchos::RCP<Stepper<Scalar> > stepper)
 {
-  using Teuchos::RCP;
-  using Teuchos::ParameterList;
-
-  // Construct from Integrator ParameterList
-  RCP<StepperFactory<Scalar> > sf =Teuchos::rcp(new StepperFactory<Scalar>());
-  std::string stepperName = integratorPL_->get<std::string>("Stepper Name");
-
-  RCP<ParameterList> stepperPL = Teuchos::sublist(tempusPL_,stepperName,true);
-  stepper_ = sf->createStepper(stepperPL, models);
-}
-
-
-template<class Scalar>
-void IntegratorBasic<Scalar>::setStepperWStepper(
-  Teuchos::RCP<Stepper<Scalar> > newStepper)
-{
-  stepper_ = newStepper;
+  if (stepper == Teuchos::null)
+    stepper_ = Teuchos::rcp(new StepperForwardEuler<Scalar>());
+  else
+    stepper_ = stepper;
 }
 
 /// This resets the SolutionHistory and sets the first SolutionState as the IC.
@@ -117,35 +100,38 @@ void IntegratorBasic<Scalar>::
 initializeSolutionHistory(Teuchos::RCP<SolutionState<Scalar> > state)
 {
   using Teuchos::RCP;
-  using Teuchos::ParameterList;
 
-  // Construct from Integrator ParameterList
-  RCP<ParameterList> shPL =
-    Teuchos::sublist(integratorPL_, "Solution History", true);
-  solutionHistory_ = createSolutionHistoryPL<Scalar>(shPL);
-
-  if (state == Teuchos::null) {
-    // Construct default IC from the application model
-    RCP<SolutionState<Scalar> > newState = createSolutionStateME(
-      stepper_->getModel(), stepper_->getDefaultStepperState());
-
-    // Set SolutionState from TimeStepControl
-    newState->setTime    (timeStepControl_->getInitTime());
-    newState->setIndex   (timeStepControl_->getInitIndex());
-    newState->setTimeStep(timeStepControl_->getInitTimeStep());
-    newState->setTolRel  (timeStepControl_->getMaxRelError());
-    newState->setTolAbs  (timeStepControl_->getMaxAbsError());
-    newState->setOrder   (stepper_->getOrder());
-    newState->setSolutionStatus(Status::PASSED);  // ICs are considered passing.
-
-    solutionHistory_->addState(newState);
-
+  if (solutionHistory_ == Teuchos::null) {
+    solutionHistory_ = rcp(new SolutionHistory<Scalar>());
   } else {
-    // Use state as IC
-    solutionHistory_->addState(state);
+    solutionHistory_->clear();
   }
 
-  // Get IC from the application model via the stepper and ensure consistency.
+  TEUCHOS_TEST_FOR_EXCEPTION( stepper_ == Teuchos::null, std::logic_error,
+    "Error - initializeSolutionHistory(), need to set stepper first!\n");
+
+  if (state == Teuchos::null) {
+    TEUCHOS_TEST_FOR_EXCEPTION( stepper_->getModel() == Teuchos::null,
+      std::logic_error,
+      "Error - initializeSolutionHistory(), need to set stepper's model first!\n");
+    // Construct default IC from the application model
+    state = createSolutionStateME( stepper_->getModel(),
+      stepper_->getDefaultStepperState());
+
+    if (timeStepControl_ != Teuchos::null) {
+      // Set SolutionState from TimeStepControl
+      state->setTime    (timeStepControl_->getInitTime());
+      state->setIndex   (timeStepControl_->getInitIndex());
+      state->setTimeStep(timeStepControl_->getInitTimeStep());
+      state->setTolRel  (timeStepControl_->getMaxRelError());
+      state->setTolAbs  (timeStepControl_->getMaxAbsError());
+    }
+    state->setOrder         (stepper_->getOrder());
+    state->setSolutionStatus(Status::PASSED);  // ICs are considered passing.
+  }
+
+  solutionHistory_->addState(state);
+
   stepper_->setInitialConditions(solutionHistory_);
 }
 
@@ -158,12 +144,6 @@ initializeSolutionHistory(Scalar t0,
   Teuchos::RCP<const Thyra::VectorBase<Scalar> > xdotdot0)
 {
   using Teuchos::RCP;
-  using Teuchos::ParameterList;
-
-  // Construct from Integrator ParameterList
-  RCP<ParameterList> shPL =
-    Teuchos::sublist(integratorPL_, "Solution History", true);
-  solutionHistory_ = createSolutionHistoryPL<Scalar>(shPL);
 
   // Create and set xdot and xdotdot.
   RCP<Thyra::VectorBase<Scalar> > xdot    = x0->clone_v();
@@ -177,22 +157,24 @@ initializeSolutionHistory(Scalar t0,
   else
     Thyra::assign(xdotdot.ptr(), *(xdotdot0));
 
-  RCP<SolutionState<Scalar> > newState = createSolutionStateX(
-    x0->clone_v(), xdot, xdotdot);
-  newState->setStepperState(stepper_->getDefaultStepperState());
+  TEUCHOS_TEST_FOR_EXCEPTION( stepper_ == Teuchos::null, std::logic_error,
+    "Error - initializeSolutionHistory(), need to set stepper first!\n");
 
-  // Set SolutionState from TimeStepControl
-  newState->setTime    (t0);
-  newState->setIndex   (timeStepControl_->getInitIndex());
-  newState->setTimeStep(timeStepControl_->getInitTimeStep());
-  newState->setOrder(stepper_->getOrder());
+  auto state = createSolutionStateX(x0->clone_v(), xdot, xdotdot);
+  state->setStepperState(stepper_->getDefaultStepperState());
 
-  newState->setSolutionStatus(Status::PASSED);  // ICs are considered passing.
+  state->setTime    (t0);
+  if (timeStepControl_ != Teuchos::null) {
+    // Set SolutionState from TimeStepControl
+    state->setIndex   (timeStepControl_->getInitIndex());
+    state->setTimeStep(timeStepControl_->getInitTimeStep());
+    state->setTolRel  (timeStepControl_->getMaxRelError());
+    state->setTolAbs  (timeStepControl_->getMaxAbsError());
+  }
+  state->setOrder         (stepper_->getOrder());
+  state->setSolutionStatus(Status::PASSED);  // ICs are considered passing.
 
-  solutionHistory_->addState(newState);
-
-  // Get IC from the application model via the stepper and ensure consistency.
-  stepper_->setInitialConditions(solutionHistory_);
+  initializeSolutionHistory(state);
 }
 
 
@@ -200,20 +182,11 @@ template<class Scalar>
 void IntegratorBasic<Scalar>::setSolutionHistory(
   Teuchos::RCP<SolutionHistory<Scalar> > sh)
 {
-  using Teuchos::RCP;
-  using Teuchos::ParameterList;
-
   if (sh == Teuchos::null) {
     // Create default SolutionHistory, otherwise keep current history.
-    if (solutionHistory_ == Teuchos::null) initializeSolutionHistory();
+    if (solutionHistory_ == Teuchos::null)
+      solutionHistory_ = rcp(new SolutionHistory<Scalar>());
   } else {
-
-    TEUCHOS_TEST_FOR_EXCEPTION( sh->getNumStates() < 1,
-      std::out_of_range,
-         "Error - setSolutionHistory requires at least one SolutionState.\n"
-      << "        Supplied SolutionHistory has only " << sh->getNumStates()
-      << " SolutionStates.\n");
-
     solutionHistory_ = sh;
   }
 }
@@ -223,34 +196,15 @@ template<class Scalar>
 void IntegratorBasic<Scalar>::setTimeStepControl(
   Teuchos::RCP<TimeStepControl<Scalar> > tsc)
 {
-  using Teuchos::RCP;
-  using Teuchos::ParameterList;
-
   if (tsc == Teuchos::null) {
     // Create timeStepControl_ if null, otherwise keep current parameters.
     if (timeStepControl_ == Teuchos::null) {
-      if (integratorPL_->isSublist("Time Step Control")) {
-        // Construct from Integrator ParameterList
-        RCP<ParameterList> tscPL =
-          Teuchos::sublist(integratorPL_,"Time Step Control",true);
-        timeStepControl_ = createTimeStepControl<Scalar>(tscPL);
-      } else {
-        // Construct default TimeStepControl
-        timeStepControl_ = rcp(new TimeStepControl<Scalar>());
-        RCP<const ParameterList> tscPL = timeStepControl_->getValidParameters();
-        integratorPL_->set("Time Step Control", tscPL->name());
-        integratorPL_->set(tscPL->name(), *tscPL);
-      }
+      // Construct default TimeStepControl
+      timeStepControl_ = rcp(new TimeStepControl<Scalar>());
     }
-
   } else {
-    // Make integratorPL_ consistent with new TimeStepControl.
     timeStepControl_ = tsc;
-    RCP<const ParameterList> tscPL = timeStepControl_->getValidParameters();
-    integratorPL_->set(tscPL->name(), *tscPL);
   }
-
-  timeStepControl_->initialize();
 }
 
 
@@ -258,25 +212,10 @@ template<class Scalar>
 void IntegratorBasic<Scalar>::setObserver(
   Teuchos::RCP<IntegratorObserver<Scalar> > obs)
 {
-
-  if (obs == Teuchos::null) {
-    // Create default IntegratorObserverBasic, otherwise keep current observer.
-    if (integratorObserver_ == Teuchos::null) {
-      integratorObserver_ =
-        Teuchos::rcp(new IntegratorObserverComposite<Scalar>);
-      // Add basic observer to output time step info
-      Teuchos::RCP<IntegratorObserverBasic<Scalar> > basicObs =
-          Teuchos::rcp(new IntegratorObserverBasic<Scalar>);
-      integratorObserver_->addObserver(basicObs);
-    }
-  } else {
-    if (integratorObserver_ == Teuchos::null) {
-      integratorObserver_ =
-        Teuchos::rcp(new IntegratorObserverComposite<Scalar>);
-    }
-    integratorObserver_->addObserver(obs);
-  }
-
+  if (obs == Teuchos::null)
+    integratorObserver_ = Teuchos::rcp(new IntegratorObserverBasic<Scalar>());
+  else
+    integratorObserver_ = obs;
 }
 
 
@@ -287,26 +226,15 @@ void IntegratorBasic<Scalar>::initialize()
     "Error - Need to set the Stepper, setStepper(), before calling "
     "IntegratorBasic::initialize()\n");
 
-  this->setTimeStepControl();
-  this->parseScreenOutput();
-  this->setSolutionHistory();
-  this->setObserver();
+  TEUCHOS_TEST_FOR_EXCEPTION( solutionHistory_->getNumStates() < 1,
+    std::out_of_range,
+       "Error - SolutionHistory requires at least one SolutionState.\n"
+    << "        Supplied SolutionHistory has only "
+    << solutionHistory_->getNumStates() << " SolutionStates.\n");
 
-  // Set initial conditions, make them consistent, and set stepper memory.
-  stepper_->setInitialConditions(solutionHistory_);
-
-  if (integratorTimer_ == Teuchos::null)
-    integratorTimer_ = rcp(new Teuchos::Time("Integrator Timer"));
-  if (stepperTimer_ == Teuchos::null)
-    stepperTimer_    = rcp(new Teuchos::Time("Stepper Timer"));
-
-  if (Teuchos::as<int>(this->getVerbLevel()) >=
-      Teuchos::as<int>(Teuchos::VERB_HIGH)) {
-    Teuchos::RCP<Teuchos::FancyOStream> out = this->getOStream();
-    out->setOutputToRootOnly(0);
-    Teuchos::OSTab ostab(out,1,"IntegratorBasic::IntegratorBasic");
-    *out << this->description() << std::endl;
-  }
+  stepper_->initialize();
+  solutionHistory_->initialize();
+  timeStepControl_->initialize();
 
   isInitialized_ = true;
 }
@@ -450,8 +378,7 @@ void IntegratorBasic<Scalar>::startTimeStep()
     ws->setOutputScreen(true);
 
   const int initial = timeStepControl_->getInitIndex();
-  const int interval = integratorPL_->get<int>("Screen Output Index Interval");
-  if ( (ws->getIndex() - initial) % interval == 0)
+  if ( (ws->getIndex() - initial) % outputScreenInterval_ == 0)
     ws->setOutputScreen(true);
 }
 
@@ -541,19 +468,13 @@ void IntegratorBasic<Scalar>::endIntegrator()
   }
 
   integratorTimer_->stop();
-  runtime_ = integratorTimer_->totalElapsedTime();
 }
 
 
 template <class Scalar>
-void IntegratorBasic<Scalar>::parseScreenOutput()
+void IntegratorBasic<Scalar>::setScreenOutputIndexList(std::string str)
 {
-  // This has been delayed until timeStepControl has been constructed.
-
   // Parse output indices
-  outputScreenIndices_.clear();
-  std::string str =
-    integratorPL_->get<std::string>("Screen Output Index List", "");
   std::string delimiters(",");
   std::string::size_type lastPos = str.find_first_not_of(delimiters, 0);
   std::string::size_type pos     = str.find_first_of(delimiters, lastPos);
@@ -577,39 +498,14 @@ void IntegratorBasic<Scalar>::parseScreenOutput()
 
 
 template <class Scalar>
-void IntegratorBasic<Scalar>::setParameterList(
-  const Teuchos::RCP<Teuchos::ParameterList> & inputPL)
+std::string IntegratorBasic<Scalar>::getScreenOutputIndexListString() const
 {
-  if (inputPL == Teuchos::null) {
-    if (tempusPL_->isParameter("Integrator Name")) {
-      // Set Integrator PL from Tempus PL
-      std::string integratorName_ =
-         tempusPL_->get<std::string>("Integrator Name");
-      integratorPL_ = Teuchos::sublist(tempusPL_, integratorName_, true);
-    } else {
-      // Build default Integrator PL
-      integratorPL_ = Teuchos::parameterList();
-      integratorPL_->setName("Default Integrator");
-      *integratorPL_ = *(this->getValidParameters());
-      tempusPL_->set("Integrator Name", "Default Integrator");
-      tempusPL_->set("Default Integrator", *integratorPL_);
-    }
-  } else {
-    *integratorPL_ = *inputPL;
-    tempusPL_->set("Integrator Name", integratorPL_->name());
-    tempusPL_->set(integratorPL_->name(), *integratorPL_);
+  std::stringstream ss;
+  for(size_t i = 0; i < outputScreenIndices_.size(); ++i) {
+    if(i != 0) ss << ", ";
+    ss << outputScreenIndices_[i];
   }
-
-  integratorPL_->validateParametersAndSetDefaults(*this->getValidParameters());
-
-  std::string integratorType =
-    integratorPL_->get<std::string>("Integrator Type");
-  TEUCHOS_TEST_FOR_EXCEPTION( integratorType != "Integrator Basic",
-    std::logic_error,
-    "Error - Inconsistent Integrator Type for IntegratorBasic\n"
-    << "    Integrator Type = " << integratorType << "\n");
-
-  return;
+  return ss.str();
 }
 
 
@@ -619,92 +515,250 @@ template<class Scalar>
 Teuchos::RCP<const Teuchos::ParameterList>
 IntegratorBasic<Scalar>::getValidParameters() const
 {
-  Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
+  Teuchos::RCP<Teuchos::ParameterList> pl =
+    Teuchos::parameterList(getIntegratorName());
 
-  std::ostringstream tmp;
-  tmp << "'Integrator Type' must be 'Integrator Basic'.";
-  pl->set("Integrator Type", "Integrator Basic", tmp.str());
+  pl->set("Integrator Type", getIntegratorType(),
+          "'Integrator Type' must be 'Integrator Basic'.");
 
-  tmp.clear();
-  tmp << "Screen Output Index List.  Required to be in TimeStepControl range "
-      << "['Minimum Time Step Index', 'Maximum Time Step Index']";
-  pl->set("Screen Output Index List", "", tmp.str());
-  pl->set("Screen Output Index Interval", 1000000,
-    "Screen Output Index Interval (e.g., every 100 time steps)");
+  pl->set("Screen Output Index List", getScreenOutputIndexListString(),
+          "Screen Output Index List.  Required to be in TimeStepControl range "
+          "['Minimum Time Step Index', 'Maximum Time Step Index']");
 
-  pl->set("Stepper Name", "",
-    "'Stepper Name' selects the Stepper block to construct (Required).");
+  pl->set("Screen Output Index Interval", getScreenOutputIndexInterval(),
+          "Screen Output Index Interval (e.g., every 100 time steps)");
 
-  // Solution History
-  pl->sublist("Solution History",false,"solutionHistory_docs")
-      .disableRecursiveValidation();
+  pl->set("Stepper Name", stepper_->getStepperName(),
+          "'Stepper Name' selects the Stepper block to construct (Required).");
 
-  // Time Step Control
-  pl->sublist("Time Step Control",false,"solutionHistory_docs")
-      .disableRecursiveValidation();
+  pl->set("Solution History", *solutionHistory_->getValidParameters());
+  pl->set("Time Step Control", *timeStepControl_->getValidParameters());
 
-  return pl;
+
+  Teuchos::RCP<Teuchos::ParameterList> tempusPL =
+    Teuchos::parameterList("Tempus");
+
+  tempusPL->set("Integrator Name", pl->name());
+  tempusPL->set(pl->name(), *pl);
+  tempusPL->set(stepper_->getStepperName(), *stepper_->getValidParameters());
+
+  return tempusPL;
 }
 
 
-template <class Scalar>
-Teuchos::RCP<Teuchos::ParameterList>
-IntegratorBasic<Scalar>::getNonconstParameterList()
-{
-  return(integratorPL_);
-}
-
-
-template <class Scalar>
-Teuchos::RCP<Teuchos::ParameterList>
-IntegratorBasic<Scalar>::unsetParameterList()
-{
-  Teuchos::RCP<Teuchos::ParameterList> temp_param_list = integratorPL_;
-  integratorPL_ = Teuchos::null;
-  return(temp_param_list);
-}
-
-/// Nonmember constructor
+// Nonmember constructor
+// ------------------------------------------------------------------------
 template<class Scalar>
-Teuchos::RCP<IntegratorBasic<Scalar> > integratorBasic(
-  Teuchos::RCP<Teuchos::ParameterList>                     pList,
+Teuchos::RCP<IntegratorBasic<Scalar> > createIntegratorBasic(
+  Teuchos::RCP<Teuchos::ParameterList>                     tempusPL,
   const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >&      model)
 {
-  Teuchos::RCP<IntegratorBasic<Scalar> > integrator =
-    Teuchos::rcp(new IntegratorBasic<Scalar>(pList, model));
-  return(integrator);
+  auto integratorName = tempusPL->get<std::string>("Integrator Name");
+  auto integratorPL = Teuchos::sublist(tempusPL, integratorName, true);
+
+  std::string integratorType = integratorPL->get<std::string>("Integrator Type");
+  TEUCHOS_TEST_FOR_EXCEPTION( integratorType != "Integrator Basic",
+    std::logic_error,
+    "Error - For IntegratorBasic, 'Integrator Type' should be "
+    << "'Integrator Basic'.\n"
+    << "    Integrator Type = " << integratorType << "\n");
+
+  auto integrator = Teuchos::rcp(new IntegratorBasic<Scalar>());
+  integrator->setIntegratorName(integratorName);
+
+  // Set Stepper
+  if (integratorPL->isParameter("Stepper Name")) {
+    // Construct from Integrator ParameterList
+    auto stepperName = integratorPL->get<std::string>("Stepper Name");
+    auto stepperPL = Teuchos::sublist(tempusPL, stepperName, true);
+    stepperPL->setName(stepperName);
+    auto sf = Teuchos::rcp(new StepperFactory<Scalar>());
+    integrator->setStepper(sf->createStepper(stepperPL, model));
+  } else {
+    // Construct default Stepper
+    Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > constModel = model;
+    integrator->setStepper(
+      createStepperForwardEuler(constModel, Teuchos::null));
+  }
+
+  // Set TimeStepControl
+  if (integratorPL->isSublist("Time Step Control")) {
+    // Construct from Integrator ParameterList
+    auto tscPL = Teuchos::sublist(integratorPL, "Time Step Control", true);
+    integrator->setTimeStepControl(createTimeStepControl<Scalar>(tscPL));
+  } else {
+    // Construct default TimeStepControl
+    integrator->setTimeStepControl(rcp(new TimeStepControl<Scalar>()));
+  }
+
+  // Construct default IC state from the application model and TimeStepControl
+  auto newState = createSolutionStateME(integrator->getStepper()->getModel(),
+    integrator->getStepper()->getDefaultStepperState());
+  newState->setTime    (integrator->getTimeStepControl()->getInitTime());
+  newState->setIndex   (integrator->getTimeStepControl()->getInitIndex());
+  newState->setTimeStep(integrator->getTimeStepControl()->getInitTimeStep());
+  newState->setTolRel  (integrator->getTimeStepControl()->getMaxRelError());
+  newState->setTolAbs  (integrator->getTimeStepControl()->getMaxAbsError());
+  newState->setOrder   (integrator->getStepper()->getOrder());
+  newState->setSolutionStatus(Status::PASSED);  // ICs are considered passing.
+
+  // Set SolutionHistory
+  auto shPL = Teuchos::sublist(integratorPL, "Solution History", true);
+  auto sh   = createSolutionHistoryPL<Scalar>(shPL);
+  sh->addState(newState);
+  integrator->getStepper()->setInitialConditions(sh);
+  integrator->setSolutionHistory(sh);
+
+  // Set Observer to default.
+  integrator->setObserver(Teuchos::null);
+
+  // Set screen output interval.
+  integrator->setScreenOutputIndexInterval(
+    integratorPL->get<int>("Screen Output Index Interval",
+    integrator->getScreenOutputIndexInterval()));
+
+  // Parse screen output indices
+  auto str = integratorPL->get<std::string>("Screen Output Index List", "");
+  integrator->setScreenOutputIndexList(str);
+
+  auto validPL = Teuchos::rcp_const_cast<Teuchos::ParameterList>(integrator->getValidParameters());
+
+  // Validate the Integrator ParameterList
+  auto vIntegratorName = validPL->template get<std::string>("Integrator Name");
+  auto vIntegratorPL = Teuchos::sublist(validPL, vIntegratorName, true);
+  integratorPL->validateParametersAndSetDefaults(*vIntegratorPL);
+
+  // Validate the Stepper ParameterList
+  auto stepperName = integratorPL->get<std::string>("Stepper Name");
+  auto stepperPL   = Teuchos::sublist(tempusPL, stepperName, true);
+  auto vStepperName = vIntegratorPL->template get<std::string>("Stepper Name");
+  auto vStepperPL   = Teuchos::sublist(validPL, vStepperName, true);
+  stepperPL->validateParametersAndSetDefaults(*vStepperPL);
+
+  integrator->initialize();
+
+  return integrator;
 }
+
 
 /// Nonmember constructor
 template<class Scalar>
-Teuchos::RCP<IntegratorBasic<Scalar> > integratorBasic(
+Teuchos::RCP<IntegratorBasic<Scalar> > createIntegratorBasic(
   const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >&      model,
   std::string stepperType)
 {
-  Teuchos::RCP<IntegratorBasic<Scalar> > integrator =
-    Teuchos::rcp(new IntegratorBasic<Scalar>(model, stepperType));
-  return(integrator);
+  using Teuchos::rcp;
+  auto integrator = rcp(new IntegratorBasic<Scalar>());
+
+  auto sf = Teuchos::rcp(new StepperFactory<Scalar>());
+  auto stepper = sf->createStepper(stepperType, model);
+  integrator->setStepper(stepper);
+  integrator->initializeSolutionHistory();
+  integrator->initialize();
+
+  return integrator;
 }
+
 
 /// Nonmember constructor
 template<class Scalar>
-Teuchos::RCP<IntegratorBasic<Scalar> > integratorBasic()
+Teuchos::RCP<IntegratorBasic<Scalar> > createIntegratorBasic()
 {
-  Teuchos::RCP<IntegratorBasic<Scalar> > integrator =
-    Teuchos::rcp(new IntegratorBasic<Scalar>());
-  return(integrator);
+  return Teuchos::rcp(new IntegratorBasic<Scalar>());
 }
+
 
 /// Nonmember constructor
 template<class Scalar>
-Teuchos::RCP<IntegratorBasic<Scalar> > integratorBasic(
-  Teuchos::RCP<Teuchos::ParameterList>                     pList,
+Teuchos::RCP<IntegratorBasic<Scalar> > createIntegratorBasic(
+  Teuchos::RCP<Teuchos::ParameterList>                             tempusPL,
   std::vector<Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > > models)
 {
-  Teuchos::RCP<IntegratorBasic<Scalar> > integrator =
-    Teuchos::rcp(new IntegratorBasic<Scalar>(pList, models));
-  return(integrator);
+  auto integratorName = tempusPL->get<std::string>("Integrator Name");
+  auto integratorPL = Teuchos::sublist(tempusPL, integratorName, true);
+
+  std::string integratorType = integratorPL->get<std::string>("Integrator Type");
+  TEUCHOS_TEST_FOR_EXCEPTION( integratorType != "Integrator Basic",
+    std::logic_error,
+    "Error - For IntegratorBasic, 'Integrator Type' should be "
+    << "'Integrator Basic'.\n"
+    << "    Integrator Type = " << integratorType << "\n");
+
+  auto integrator = Teuchos::rcp(new IntegratorBasic<Scalar>());
+  integrator->setIntegratorName(integratorName);
+
+  TEUCHOS_TEST_FOR_EXCEPTION( !integratorPL->isParameter("Stepper Name"),
+    std::logic_error,
+    "Error - Need to set the 'Stepper Name' in 'Integrator Basic'.\n");
+
+  auto stepperName = integratorPL->get<std::string>("Stepper Name");
+  TEUCHOS_TEST_FOR_EXCEPTION( stepperName == "Operator Split",
+    std::logic_error,
+    "Error - 'Stepper Name' should be 'Operator Split'.\n");
+
+  // Construct Steppers from Integrator ParameterList
+  auto stepperPL = Teuchos::sublist(tempusPL, stepperName, true);
+  stepperPL->setName(stepperName);
+  auto sf = Teuchos::rcp(new StepperFactory<Scalar>());
+  integrator->setStepper(sf->createStepper(stepperPL, models));
+
+  // Set TimeStepControl
+  if (integratorPL->isSublist("Time Step Control")) {
+    // Construct from Integrator ParameterList
+    auto tscPL = Teuchos::sublist(integratorPL, "Time Step Control", true);
+    integrator->setTimeStepControl(createTimeStepControl<Scalar>(tscPL));
+  } else {
+    // Construct default TimeStepControl
+    integrator->setTimeStepControl(rcp(new TimeStepControl<Scalar>()));
+  }
+
+  // Construct default IC state from the application model and TimeStepControl
+  auto newState = createSolutionStateME(integrator->getStepper()->getModel(),
+    integrator->getStepper()->getDefaultStepperState());
+  newState->setTime    (integrator->getTimeStepControl()->getInitTime());
+  newState->setIndex   (integrator->getTimeStepControl()->getInitIndex());
+  newState->setTimeStep(integrator->getTimeStepControl()->getInitTimeStep());
+  newState->setTolRel  (integrator->getTimeStepControl()->getMaxRelError());
+  newState->setTolAbs  (integrator->getTimeStepControl()->getMaxAbsError());
+  newState->setOrder   (integrator->getStepper()->getOrder());
+  newState->setSolutionStatus(Status::PASSED);  // ICs are considered passing.
+
+  // Set SolutionHistory
+  auto shPL = Teuchos::sublist(integratorPL, "Solution History", true);
+  auto sh   = createSolutionHistoryPL<Scalar>(shPL);
+  sh->addState(newState);
+  integrator->getStepper()->setInitialConditions(sh);
+  integrator->setSolutionHistory(sh);
+
+  // Set Observer to default.
+  integrator->setObserver(Teuchos::null);
+
+  // Set screen output interval.
+  integrator->setScreenOutputIndexInterval(
+    integratorPL->get<int>("Screen Output Index Interval",
+    integrator->getScreenOutputIndexInterval()));
+
+  // Parse screen output indices
+  auto str = integratorPL->get<std::string>("Screen Output Index List", "");
+  integrator->setScreenOutputIndexList(str);
+
+  auto validPL = Teuchos::rcp_const_cast<Teuchos::ParameterList>(integrator->getValidParameters());
+
+  // Validate the Integrator ParameterList
+  auto vIntegratorName = validPL->template get<std::string>("Integrator Name");
+  auto vIntegratorPL = Teuchos::sublist(validPL, vIntegratorName, true);
+  integratorPL->validateParametersAndSetDefaults(*vIntegratorPL);
+
+  // Validate the Stepper ParameterList
+  auto vStepperName = vIntegratorPL->template get<std::string>("Stepper Name");
+  auto vStepperPL   = Teuchos::sublist(validPL, vStepperName, true);
+  stepperPL->validateParametersAndSetDefaults(*vStepperPL);
+
+  integrator->initialize();
+
+  return integrator;
 }
+
 
 } // namespace Tempus
 #endif // Tempus_IntegratorBasic_impl_hpp

--- a/packages/tempus/src/Tempus_IntegratorForwardSensitivity_decl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorForwardSensitivity_decl.hpp
@@ -11,7 +11,7 @@
 
 // Tempus
 #include "Tempus_config.hpp"
-#include "Tempus_IntegratorBasic.hpp"
+#include "Tempus_IntegratorBasicOld.hpp"
 #include "Tempus_SensitivityModelEvaluatorBase.hpp"
 #include "Tempus_StepperStaggeredForwardSensitivity.hpp"
 
@@ -37,14 +37,16 @@ namespace Tempus {
  * </ul>
  *
  * Note that this integrator implements all of the same functions as the
- * IntegratorBasic, but is not derived from IntegratorBasic.  It also provides
+ * IntegratorBasicOld, but is not derived from IntegratorBasicOld.  It also provides
  * functions for setting the sensitivity initial conditions and extracting the
  * sensitivity at the final time.  Also the vectors stored in the solution
  * history store product vectors of the state and sensitivities using
  * Thyra;:DefaultMultiVectorProductVector.
  */
 template<class Scalar>
-class IntegratorForwardSensitivity : virtual public Tempus::Integrator<Scalar>
+class IntegratorForwardSensitivity
+  : virtual public Tempus::Integrator<Scalar>,
+    virtual public Teuchos::ParameterListAcceptor
 {
 public:
 
@@ -237,7 +239,7 @@ protected:
   Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > model_;
   Teuchos::RCP<SensitivityModelEvaluatorBase<Scalar> > sens_model_;
   Teuchos::RCP<StepperStaggeredForwardSensitivity<Scalar> > sens_stepper_;
-  Teuchos::RCP<IntegratorBasic<Scalar> > integrator_;
+  Teuchos::RCP<IntegratorBasicOld<Scalar> > integrator_;
   Teuchos::RCP<Teuchos::ParameterList> tempus_pl_;
   Teuchos::RCP<Teuchos::ParameterList> sens_pl_;
   Teuchos::RCP<Teuchos::ParameterList> stepper_pl_;

--- a/packages/tempus/src/Tempus_IntegratorObserver.hpp
+++ b/packages/tempus/src/Tempus_IntegratorObserver.hpp
@@ -70,8 +70,8 @@ public:
     /// Observe the end of the time integrator.
     virtual void observeEndIntegrator(const Integrator<Scalar>& integrator) = 0;
 
-   /// default destructor
-   virtual ~IntegratorObserver() = default;
+    /// default destructor
+    virtual ~IntegratorObserver() = default;
   //@}
 
 };

--- a/packages/tempus/src/Tempus_IntegratorPseudoTransientAdjointSensitivity_decl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorPseudoTransientAdjointSensitivity_decl.hpp
@@ -10,7 +10,7 @@
 #define Tempus_IntegratorPseudoTransientAdjointSensitivity_decl_hpp
 
 #include "Tempus_config.hpp"
-#include "Tempus_IntegratorBasic.hpp"
+#include "Tempus_IntegratorBasicOld.hpp"
 #include "Tempus_AdjointSensitivityModelEvaluator.hpp"
 
 
@@ -49,8 +49,9 @@ namespace Tempus {
  * (since the eigenvalues of df/dx^T are the same as df/dx).
  */
 template<class Scalar>
-class IntegratorPseudoTransientAdjointSensitivity :
-    virtual public Tempus::Integrator<Scalar>
+class IntegratorPseudoTransientAdjointSensitivity
+  : virtual public Tempus::Integrator<Scalar>,
+    virtual public Teuchos::ParameterListAcceptor
 {
 public:
 
@@ -170,8 +171,8 @@ protected:
 
   Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > model_;
   Teuchos::RCP<AdjointSensitivityModelEvaluator<Scalar> > sens_model_;
-  Teuchos::RCP<IntegratorBasic<Scalar> > state_integrator_;
-  Teuchos::RCP<IntegratorBasic<Scalar> > sens_integrator_;
+  Teuchos::RCP<IntegratorBasicOld<Scalar> > state_integrator_;
+  Teuchos::RCP<IntegratorBasicOld<Scalar> > sens_integrator_;
   Teuchos::RCP<SolutionHistory<Scalar> > solutionHistory_;
   Teuchos::RCP<DMVPV> dgdp_;
 };

--- a/packages/tempus/src/Tempus_IntegratorPseudoTransientForwardSensitivity_decl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorPseudoTransientForwardSensitivity_decl.hpp
@@ -11,7 +11,7 @@
 
 // Tempus
 #include "Tempus_config.hpp"
-#include "Tempus_IntegratorBasic.hpp"
+#include "Tempus_IntegratorBasicOld.hpp"
 #include "Tempus_SensitivityModelEvaluatorBase.hpp"
 
 namespace Tempus {
@@ -47,8 +47,9 @@ namespace Tempus {
  * since it has the same Jacobian matrix as the forward equations.
  */
 template<class Scalar>
-class IntegratorPseudoTransientForwardSensitivity :
-    virtual public Tempus::Integrator<Scalar>
+class IntegratorPseudoTransientForwardSensitivity
+  : virtual public Tempus::Integrator<Scalar>,
+    virtual public Teuchos::ParameterListAcceptor
 {
 public:
 
@@ -182,8 +183,8 @@ protected:
 
   Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > model_;
   Teuchos::RCP<SensitivityModelEvaluatorBase<Scalar> > sens_model_;
-  Teuchos::RCP<IntegratorBasic<Scalar> > state_integrator_;
-  Teuchos::RCP<IntegratorBasic<Scalar> > sens_integrator_;
+  Teuchos::RCP<IntegratorBasicOld<Scalar> > state_integrator_;
+  Teuchos::RCP<IntegratorBasicOld<Scalar> > sens_integrator_;
   Teuchos::RCP<SolutionHistory<Scalar> > solutionHistory_;
   bool reuse_solver_;
   bool force_W_update_;

--- a/packages/tempus/src/Tempus_Interpolator.hpp
+++ b/packages/tempus/src/Tempus_Interpolator.hpp
@@ -66,7 +66,7 @@ public:
 
 };
 
-/// Nonmember constructor
+/// Nonmember functions
 template<class Scalar>
 void interpolate(const Interpolator<Scalar>& interpolator,
                  const Scalar& t,
@@ -75,7 +75,7 @@ void interpolate(const Interpolator<Scalar>& interpolator,
   interpolator.interpolate(t, state_out);
 }
 
-/// Nonmember constructor
+/// Nonmember functions
 template<class Scalar>
 void interpolate(Interpolator<Scalar>& interpolator,
                  const Teuchos::RCP<const std::vector<Teuchos::RCP<SolutionState<Scalar> > > >&  nodes,

--- a/packages/tempus/src/Tempus_SolutionHistory_decl.hpp
+++ b/packages/tempus/src/Tempus_SolutionHistory_decl.hpp
@@ -167,7 +167,11 @@ public:
     /// Promote the working state to current state
     void promoteWorkingState();
 
+    /// Clear the history.
     void clear() {history_->clear(); isInitialized_ = false;}
+
+    /// Make a shallow copy of SolutionHistory (i.e., only RCPs to states and interpolator).
+    void copy(Teuchos::RCP<const SolutionHistory<Scalar> > sh);
   //@}
 
   /// \name Accessor methods
@@ -305,7 +309,8 @@ public:
   /// \name Interpolation Methods
   //@{
     /// Set the interpolator for this history
-    void setInterpolator(const Teuchos::RCP<Interpolator<Scalar> >& interpolator);
+    void setInterpolator(
+      const Teuchos::RCP<Interpolator<Scalar> >& interpolator);
     Teuchos::RCP<Interpolator<Scalar> > getNonconstInterpolator();
     Teuchos::RCP<const Interpolator<Scalar> > getInterpolator() const;
     /// Unset the interpolator for this history

--- a/packages/tempus/src/Tempus_SolutionHistory_impl.hpp
+++ b/packages/tempus/src/Tempus_SolutionHistory_impl.hpp
@@ -282,6 +282,26 @@ void SolutionHistory<Scalar>::promoteWorkingState()
 
 
 template<class Scalar>
+void SolutionHistory<Scalar>::copy(Teuchos::RCP<const SolutionHistory<Scalar> > sh)
+{
+  this->setName(sh->getName());
+
+  this->clear();
+  auto sh_history = sh->getHistory();
+  typename std::vector<Teuchos::RCP<SolutionState<Scalar> > >::iterator
+    state_it = sh_history->begin();
+  for (; state_it < sh_history->end(); state_it++)
+    this->addState( *state_it );
+
+  auto interpolator = Teuchos::rcp_const_cast<Interpolator<Scalar> >(sh->getInterpolator());
+  this->setInterpolator(interpolator);
+
+  this->setStorageType(sh->getStorageType());
+  this->setStorageLimit(sh->getStorageLimit());
+}
+
+
+template<class Scalar>
 void SolutionHistory<Scalar>::setStorageLimit(int storage_limit)
 {
   storageLimit_ = std::max(1,storage_limit);
@@ -565,12 +585,6 @@ void SolutionHistory<Scalar>::setInterpolator(
     interpolator_ = InterpolatorFactory<Scalar>::createInterpolator();
   } else {
     interpolator_ = interpolator;
-  }
-  if (Teuchos::as<int>(this->getVerbLevel()) >=
-      Teuchos::as<int>(Teuchos::VERB_HIGH)) {
-    Teuchos::RCP<Teuchos::FancyOStream> out = this->getOStream();
-    Teuchos::OSTab ostab(out,1,"SolutionHistory::setInterpolator");
-    *out << "interpolator = " << interpolator_->description() << std::endl;
   }
   isInitialized_ = false;
 }

--- a/packages/tempus/src/Tempus_SolutionStateMetaData_decl.hpp
+++ b/packages/tempus/src/Tempus_SolutionStateMetaData_decl.hpp
@@ -160,6 +160,8 @@ protected:
   Scalar accuracy_;       ///< Interpolation accuracy of solution
 
 };
+
+
 } // namespace Tempus
 
 #endif // Tempus_SolutionStateMetaData_decl_hpp

--- a/packages/tempus/src/Tempus_Stepper.cpp
+++ b/packages/tempus/src/Tempus_Stepper.cpp
@@ -16,10 +16,6 @@ namespace Tempus {
 
   TEMPUS_INSTANTIATE_TEMPLATE_CLASS(Stepper)
 
-  // Provide basic parameters to Steppers.
-  void getValidParametersBasic(
-    Teuchos::RCP<Teuchos::ParameterList> pl, std::string stepperType);
-
   // Validate that the model supports explicit ODE evaluation, f(x,t) [=xdot]
   template void validExplicitODE(
     const Teuchos::RCP<const Thyra::ModelEvaluator<double> >& model);

--- a/packages/tempus/src/Tempus_StepperBDF2_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperBDF2_impl.hpp
@@ -20,6 +20,7 @@ namespace Tempus {
 template<class Scalar>
 StepperBDF2<Scalar>::StepperBDF2()
 {
+  this->setStepperName(        "BDF2");
   this->setStepperType(        "BDF2");
   this->setUseFSAL(            false);
   this->setICConsistency(      "None");
@@ -43,6 +44,7 @@ StepperBDF2<Scalar>::StepperBDF2(
   bool zeroInitialGuess,
   const Teuchos::RCP<StepperBDF2AppAction<Scalar> >& stepperBDF2AppAction)
 {
+  this->setStepperName(        "BDF2");
   this->setStepperType(        "BDF2");
   this->setUseFSAL(            useFSAL);
   this->setICConsistency(      ICConsistency);
@@ -321,15 +323,8 @@ template<class Scalar>
 Teuchos::RCP<const Teuchos::ParameterList>
 StepperBDF2<Scalar>::getValidParameters() const
 {
-  Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
-  getValidParametersBasic(pl, this->getStepperType());
-  pl->set<bool>("Initial Condition Consistency Check", false);
-  pl->set<std::string>("Solver Name", "Default Solver");
-  pl->set<bool>("Zero Initial Guess", false);
-  pl->set<std::string>("Start Up Stepper Type", "DIRK 1 Stage Theta Method");
-  Teuchos::RCP<Teuchos::ParameterList> solverPL = defaultSolverParameters();
-  pl->set("Default Solver", *solverPL);
-
+  auto pl = this->getValidParametersBasicImplicit();
+  pl->set("Start Up Stepper Type", startUpStepper_->getStepperType());
   return pl;
 }
 

--- a/packages/tempus/src/Tempus_StepperBackwardEuler_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperBackwardEuler_impl.hpp
@@ -20,6 +20,7 @@ namespace Tempus {
 template<class Scalar>
 StepperBackwardEuler<Scalar>::StepperBackwardEuler()
 {
+  this->setStepperName(        "Backward Euler");
   this->setStepperType(        "Backward Euler");
   this->setUseFSAL(            false);
   this->setICConsistency(      "None");
@@ -43,6 +44,7 @@ StepperBackwardEuler<Scalar>::StepperBackwardEuler(
   bool zeroInitialGuess,
   const Teuchos::RCP<StepperBackwardEulerAppAction<Scalar> >& stepperBEAppAction)
 {
+  this->setStepperName(        "Backward Euler");
   this->setStepperType(        "Backward Euler");
   this->setUseFSAL(            useFSAL);
   this->setICConsistency(      ICConsistency);
@@ -250,14 +252,14 @@ void StepperBackwardEuler<Scalar>::describe(
   StepperImplicit<Scalar>::describe(out, verbLevel);
 
   out << "--- StepperBackwardEuler ---\n";
+  out << "  predictorStepper_                  = "
+      << predictorStepper_ << std::endl;
   if (predictorStepper_ != Teuchos::null) {
+    out << "  predictorStepper_->isInitialized() = "
+        << Teuchos::toString(predictorStepper_->isInitialized()) << std::endl;
     out << "  predictor stepper type             = "
         << predictorStepper_->description() << std::endl;
   }
-  out << "  predictorStepper_                  = "
-      << predictorStepper_ << std::endl;
-  out << "  predictorStepper_->isInitialized() = "
-      << Teuchos::toString(predictorStepper_->isInitialized()) << std::endl;
   out << "  stepperBEAppAction_                = "
       << stepperBEAppAction_ << std::endl;
   out << "----------------------------" << std::endl;
@@ -292,14 +294,11 @@ template<class Scalar>
 Teuchos::RCP<const Teuchos::ParameterList>
 StepperBackwardEuler<Scalar>::getValidParameters() const
 {
-  Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
-  getValidParametersBasic(pl, this->getStepperType());
-  pl->set<std::string>("Solver Name", "Default Solver");
-  pl->set<bool>       ("Zero Initial Guess", false);
-  pl->set<std::string>("Predictor Stepper Type", "None");
-  Teuchos::RCP<Teuchos::ParameterList> solverPL = defaultSolverParameters();
-  pl->set("Default Solver", *solverPL);
-
+  auto pl = this->getValidParametersBasicImplicit();
+  if (predictorStepper_ == Teuchos::null)
+    pl->set("Predictor Stepper Type", "None");
+  else
+    pl->set("Predictor Stepper Type", predictorStepper_->getStepperType());
   return pl;
 }
 

--- a/packages/tempus/src/Tempus_StepperDIRK_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperDIRK_decl.hpp
@@ -196,9 +196,6 @@ public:
 
     virtual OrderODE getOrderODE()   const {return FIRST_ORDER_ODE;}
 
-    void getValidParametersBasicDIRK(
-      Teuchos::RCP<Teuchos::ParameterList> pl) const;
-
     virtual std::string getDescription() const = 0;
   //@}
 
@@ -214,7 +211,9 @@ public:
   /// Return beta  = d(x)/dx.
   virtual Scalar getBeta (const Scalar   ) const { return Scalar(1.0); }
 
-  Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
+  virtual Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
+
+  Teuchos::RCP<Teuchos::ParameterList> getValidParametersBasicDIRK() const;
 
   /// \name Overridden from Teuchos::Describable
   //@{

--- a/packages/tempus/src/Tempus_StepperDIRK_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperDIRK_impl.hpp
@@ -58,21 +58,18 @@ void StepperDIRK<Scalar>::setup(
 
 
 template<class Scalar>
-void StepperDIRK<Scalar>::getValidParametersBasicDIRK(
-  Teuchos::RCP<Teuchos::ParameterList> pl) const
+Teuchos::RCP<Teuchos::ParameterList>
+StepperDIRK<Scalar>::getValidParametersBasicDIRK() const
 {
-  getValidParametersBasic(pl, this->getStepperType());
-  pl->set<bool>("Use Embedded", false,
+  auto pl = this->getValidParametersBasicImplicit();
+  pl->template set<bool>("Use Embedded", this->getUseEmbedded(),
     "'Whether to use Embedded Stepper (if available) or not\n"
     "  'true' - Stepper will compute embedded solution and is adaptive.\n"
     "  'false' - Stepper is not embedded(adaptive).\n");
-  pl->set<std::string>("Description", this->getDescription());
-  pl->set<std::string>("Solver Name", "Default Solver",
-    "Name of ParameterList containing the solver specifications.");
-  pl->set<bool>("Zero Initial Guess", false);
-  pl->set<bool>("Reset Initial Guess", true);
-  Teuchos::RCP<Teuchos::ParameterList> solverPL = defaultSolverParameters();
-  pl->set("Default Solver", *solverPL);
+  pl->template set<std::string>("Description", this->getDescription());
+  pl->template set<bool>("Reset Initial Guess", this->getResetInitialGuess());
+
+  return pl;
 }
 
 
@@ -354,10 +351,7 @@ template<class Scalar>
 Teuchos::RCP<const Teuchos::ParameterList>
 StepperDIRK<Scalar>::getValidParameters() const
 {
-  Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
-  this->getValidParametersBasicDIRK(pl);
-
-  return pl;
+  return this->getValidParametersBasicDIRK();
 }
 
 

--- a/packages/tempus/src/Tempus_StepperExplicitRK_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperExplicitRK_decl.hpp
@@ -130,11 +130,12 @@ public:
 
     virtual OrderODE getOrderODE()   const {return FIRST_ORDER_ODE;}
 
-    void getValidParametersBasicERK(Teuchos::RCP<Teuchos::ParameterList> pl) const;
     virtual std::string getDescription() const = 0;
   //@}
 
-  Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
+  virtual Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
+
+  Teuchos::RCP<Teuchos::ParameterList> getValidParametersBasicERK() const;
 
   /// \name Overridden from Teuchos::Describable
   //@{

--- a/packages/tempus/src/Tempus_StepperExplicitRK_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperExplicitRK_impl.hpp
@@ -134,15 +134,25 @@ Scalar StepperExplicitRK<Scalar>::getInitTimeStep(
 
 
 template<class Scalar>
-void StepperExplicitRK<Scalar>::getValidParametersBasicERK(
-  Teuchos::RCP<Teuchos::ParameterList> pl) const
+Teuchos::RCP<const Teuchos::ParameterList>
+StepperExplicitRK<Scalar>::getValidParameters() const
 {
-  getValidParametersBasic(pl, this->getStepperType());
-  pl->set<bool>("Use Embedded", false,
+  return this->getValidParametersBasicERK();
+}
+
+
+template<class Scalar>
+Teuchos::RCP<Teuchos::ParameterList>
+StepperExplicitRK<Scalar>::getValidParametersBasicERK() const
+{
+  auto pl = this->getValidParametersBasic();
+  pl->template set<bool>("Use Embedded", this->getUseEmbedded(),
     "'Whether to use Embedded Stepper (if available) or not\n"
     "  'true' - Stepper will compute embedded solution and is adaptive.\n"
     "  'false' - Stepper is not embedded(adaptive).\n");
-  pl->set<std::string>("Description", this->getDescription());
+  pl->template set<std::string>("Description", this->getDescription());
+
+  return pl;
 }
 
 
@@ -402,16 +412,6 @@ bool StepperExplicitRK<Scalar>::isValidSetup(Teuchos::FancyOStream & out) const
   }
 
   return isValidSetup;
-}
-
-
-template<class Scalar>
-Teuchos::RCP<const Teuchos::ParameterList>
-StepperExplicitRK<Scalar>::getValidParameters() const
-{
-  Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
-  this->getValidParametersBasicERK(pl);
-  return pl;
 }
 
 

--- a/packages/tempus/src/Tempus_StepperFactory_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperFactory_impl.hpp
@@ -48,7 +48,7 @@ createStepper(
 {
   std::string stepperType = "Forward Euler";
   if (stepperPL != Teuchos::null)
-    stepperType = stepperPL->get<std::string>("Stepper Type","Forward Euler");
+    stepperType = stepperPL->get<std::string>("Stepper Type", "Forward Euler");
   return this->createStepper(stepperType, stepperPL, model);
 }
 

--- a/packages/tempus/src/Tempus_StepperFactory_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperFactory_impl.hpp
@@ -114,7 +114,7 @@ createStepper(
     return createStepperERK_3Stage3rdOrder(model, stepperPL);
   else if (stepperType == "RK Explicit 3 Stage 3rd order TVD" ||
            stepperType == "SSPERK33" || stepperType == "SSPRK3" )
-    return createStepperERK_3Stage3rdOrderTVD(model, stepperPL, stepperType);
+    return createStepperERK_3Stage3rdOrderTVD(model, stepperPL);
   else if (stepperType == "RK Explicit 3 Stage 3rd order by Heun" )
     return createStepperERK_3Stage3rdOrderHeun(model, stepperPL);
   else if (stepperType == "RK Explicit Midpoint" )
@@ -122,9 +122,9 @@ createStepper(
   else if (stepperType == "RK Explicit Trapezoidal" ||
            stepperType == "Heuns Method" || stepperType == "SSPERK22" ||
            stepperType == "SSPRK2" )
-    return createStepperERK_Trapezoidal(model, stepperPL, stepperType);
+    return createStepperERK_Trapezoidal(model, stepperPL);
   else if (stepperType == "RK Explicit Ralston" || stepperType == "RK2" )
-    return createStepperERK_Ralston(model, stepperPL, stepperType);
+    return createStepperERK_Ralston(model, stepperPL);
   else if (stepperType == "SSPERK54" )
     return createStepperERK_SSPERK54(model, stepperPL);
   else if (stepperType == "Bogacki-Shampine 3(2) Pair" )

--- a/packages/tempus/src/Tempus_StepperForwardEuler_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperForwardEuler_decl.hpp
@@ -118,8 +118,6 @@ public:
     virtual OrderODE getOrderODE()   const {return FIRST_ORDER_ODE;}
   //@}
 
-  Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
-
   /// \name Overridden from Teuchos::Describable
   //@{
     virtual void describe(Teuchos::FancyOStream        & out,

--- a/packages/tempus/src/Tempus_StepperForwardEuler_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperForwardEuler_impl.hpp
@@ -19,6 +19,7 @@ namespace Tempus {
 template<class Scalar>
 StepperForwardEuler<Scalar>::StepperForwardEuler()
 {
+  this->setStepperName(        "Forward Euler");
   this->setStepperType(        "Forward Euler");
   this->setUseFSAL(            true);
   this->setICConsistency(      "Consistent");
@@ -34,6 +35,7 @@ StepperForwardEuler<Scalar>::StepperForwardEuler(
   bool ICConsistencyCheck,
   const Teuchos::RCP<StepperForwardEulerAppAction<Scalar> >& stepperFEAppAction)
 {
+  this->setStepperName(        "Forward Euler");
   this->setStepperType(        "Forward Euler");
   this->setUseFSAL(            useFSAL);
   this->setICConsistency(      ICConsistency);
@@ -204,18 +206,6 @@ bool StepperForwardEuler<Scalar>::isValidSetup(Teuchos::FancyOStream & out) cons
     out << "The Forward Euler AppAction is not set!\n";
   }
   return isValidSetup;
-}
-
-
-template<class Scalar>
-Teuchos::RCP<const Teuchos::ParameterList>
-StepperForwardEuler<Scalar>::getValidParameters() const
-{
-  Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
-  getValidParametersBasic(pl, this->getStepperType());
-  pl->set<bool>("Use FSAL", true);
-  pl->set<std::string>("Initial Condition Consistency", "Consistent");
-  return pl;
 }
 
 

--- a/packages/tempus/src/Tempus_StepperHHTAlpha_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperHHTAlpha_impl.hpp
@@ -245,6 +245,7 @@ StepperHHTAlpha<Scalar>::StepperHHTAlpha() :
   *out_ << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
 #endif
 
+  this->setStepperName(        "HHT-Alpha");
   this->setStepperType(        "HHT-Alpha");
   this->setUseFSAL(            false);
   this->setICConsistency(      "None");
@@ -273,6 +274,7 @@ StepperHHTAlpha<Scalar>::StepperHHTAlpha(
   const Teuchos::RCP<StepperHHTAlphaAppAction<Scalar> >& stepperHHTAlphaAppAction)
   : out_(Teuchos::VerboseObjectBase::getDefaultOStream())
 {
+  this->setStepperName(        "HHT-Alpha");
   this->setStepperType(        "HHT-Alpha");
   this->setUseFSAL(            useFSAL);
   this->setICConsistency(      ICConsistency);
@@ -541,17 +543,15 @@ StepperHHTAlpha<Scalar>::getValidParameters() const
 #ifdef VERBOSE_DEBUG_OUTPUT
   *out_ << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
 #endif
-  Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
-  getValidParametersBasic(pl, this->getStepperType());
-  pl->set<std::string>("Scheme Name", "Newmark Beta Average Acceleration");
-  pl->set<double>     ("Beta",    0.25);
-  pl->set<double>     ("Gamma",   0.5 );
-  pl->set<double>     ("Alpha_f", 0.0 );
-  pl->set<double>     ("Alpha_m", 0.0 );
-  pl->set<std::string>("Solver Name", "Default Solver");
-  pl->set<bool>       ("Zero Initial Guess", false);
-  Teuchos::RCP<Teuchos::ParameterList> solverPL = defaultSolverParameters();
-  pl->set("Default Solver", *solverPL);
+  auto pl = this->getValidParametersBasicImplicit();
+
+  auto hhtalphaPL = Teuchos::parameterList("HHT-Alpha Parameters");
+  hhtalphaPL->set<std::string>("Scheme Name", schemeName_);
+  hhtalphaPL->set<double>     ("Beta",    beta_);
+  hhtalphaPL->set<double>     ("Gamma",   gamma_ );
+  hhtalphaPL->set<double>     ("Alpha_f", alpha_f_ );
+  hhtalphaPL->set<double>     ("Alpha_m", alpha_m_ );
+  pl->set("HHT-Alpha Parameters", *hhtalphaPL);
 
   return pl;
 }

--- a/packages/tempus/src/Tempus_StepperIMEX_RK_Partition_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperIMEX_RK_Partition_decl.hpp
@@ -327,7 +327,7 @@ public:
    *  Requires subsequent setModel(), setSolver() and initialize()
    *  calls before calling takeStep().
   */
-  StepperIMEX_RK_Partition();
+  StepperIMEX_RK_Partition(std::string stepperType = "Partitioned IMEX RK SSP2");
 
   /// Constructor to for all member data.
   StepperIMEX_RK_Partition(

--- a/packages/tempus/src/Tempus_StepperIMEX_RK_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperIMEX_RK_decl.hpp
@@ -296,7 +296,7 @@ public:
    *  Requires subsequent setModel(), setSolver() and initialize()
    *  calls before calling takeStep().
   */
-  StepperIMEX_RK();
+  StepperIMEX_RK(std::string stepperType = "IMEX RK SSP2");
 
   /// Constructor for all member data.
   StepperIMEX_RK(

--- a/packages/tempus/src/Tempus_StepperImplicit_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperImplicit_decl.hpp
@@ -299,8 +299,8 @@ public:
     virtual bool getZeroInitialGuess() const { return zeroInitialGuess_; }
 
     virtual Scalar getInitTimeStep(
-        const Teuchos::RCP<SolutionHistory<Scalar> >& /* solutionHistory */) const
-      {return Scalar(1.0e+99);}
+      const Teuchos::RCP<SolutionHistory<Scalar> >& /* solutionHistory */) const
+    {return Scalar(1.0e+99);}
   //@}
 
   /// \name Overridden from Teuchos::Describable
@@ -311,11 +311,20 @@ public:
 
   virtual bool isValidSetup(Teuchos::FancyOStream & out) const;
 
+  virtual Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
+
+  Teuchos::RCP<Teuchos::ParameterList> getValidParametersBasicImplicit() const;
+
   /// Set StepperImplicit member data from the ParameterList.
   void setStepperImplicitValues(Teuchos::RCP<Teuchos::ParameterList> pl);
 
   /// Set solver from ParameterList.
   void setStepperSolverValues(Teuchos::RCP<Teuchos::ParameterList> pl);
+
+  /// Set the Solver Name
+  void setSolverName(std::string i) { solverName_ = i; }
+  /// Get the Solver Name.
+  std::string getSolverName() const { return solverName_; }
 
 protected:
 
@@ -323,6 +332,7 @@ protected:
   Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> >   solver_;
   Teuchos::RCP<const Thyra::VectorBase<Scalar> >      initialGuess_;
   bool zeroInitialGuess_;
+  std::string solverName_;
 
 };
 

--- a/packages/tempus/src/Tempus_StepperImplicit_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperImplicit_impl.hpp
@@ -212,7 +212,8 @@ template<class Scalar>
 void StepperImplicit<Scalar>::setDefaultSolver()
 {
   solver_ = rcp(new Thyra::NOXNonlinearSolver());
-  auto solverPL = Tempus::defaultSolverParameters();
+  auto solverPL = defaultSolverParameters();
+  this->setSolverName("Default Solver");
   auto subPL = sublist(solverPL, "NOX");
   solver_->setParameterList(subPL);
 
@@ -368,6 +369,30 @@ bool StepperImplicit<Scalar>::isValidSetup(Teuchos::FancyOStream & out) const
 
 
 template<class Scalar>
+Teuchos::RCP<const Teuchos::ParameterList>
+StepperImplicit<Scalar>::getValidParameters() const
+{
+  return this->getValidParametersBasicImplicit();
+}
+
+
+template<class Scalar>
+Teuchos::RCP<Teuchos::ParameterList>
+StepperImplicit<Scalar>::getValidParametersBasicImplicit() const
+{
+  auto pl = this->getValidParametersBasic();
+  pl->template set<std::string>("Solver Name", this->getSolverName());
+  pl->template set<bool>("Zero Initial Guess", this->getZeroInitialGuess());
+  auto noxSolverPL = this->getSolver()->getParameterList();
+  auto solverPL = Teuchos::parameterList(this->getSolverName());
+  solverPL->set("NOX", *noxSolverPL);
+  pl->set(this->getSolverName(), *solverPL);
+
+  return pl;
+}
+
+
+template<class Scalar>
 void StepperImplicit<Scalar>::
 setStepperImplicitValues(
   Teuchos::RCP<Teuchos::ParameterList> pl)
@@ -392,6 +417,7 @@ setStepperSolverValues(Teuchos::RCP<Teuchos::ParameterList> pl)
     if ( pl->isSublist(solverName) ) {
       auto solverPL = Teuchos::parameterList();
       solverPL = Teuchos::sublist(pl, solverName);
+      this->setSolverName(solverName);
       Teuchos::RCP<Teuchos::ParameterList> noxPL =
         Teuchos::sublist(solverPL,"NOX",true);
       getSolver()->setParameterList(noxPL);

--- a/packages/tempus/src/Tempus_StepperLeapfrog_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperLeapfrog_decl.hpp
@@ -146,8 +146,6 @@ public:
     virtual OrderODE getOrderODE()   const {return SECOND_ORDER_ODE;}
   //@}
 
-  Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
-
   /// \name Overridden from Teuchos::Describable
   //@{
     virtual void describe(Teuchos::FancyOStream        & out,

--- a/packages/tempus/src/Tempus_StepperLeapfrog_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperLeapfrog_impl.hpp
@@ -20,6 +20,7 @@ namespace Tempus {
 template<class Scalar>
 StepperLeapfrog<Scalar>::StepperLeapfrog()
 {
+  this->setStepperName(        "Leapfrog");
   this->setStepperType(        "Leapfrog");
   this->setUseFSAL(            false);
   this->setICConsistency(      "Consistent");
@@ -36,6 +37,7 @@ StepperLeapfrog<Scalar>::StepperLeapfrog(
   bool ICConsistencyCheck,
   const Teuchos::RCP<StepperLeapfrogAppAction<Scalar> >& stepperLFAppAction)
   {
+    this->setStepperName(        "Leapfrog");
     this->setStepperType(        "Leapfrog");
     this->setUseFSAL(            useFSAL);
     this->setICConsistency(      ICConsistency);
@@ -212,17 +214,6 @@ bool StepperLeapfrog<Scalar>::isValidSetup(Teuchos::FancyOStream & out) const
 
 
   return isValidSetup;
-}
-
-
-template<class Scalar>
-Teuchos::RCP<const Teuchos::ParameterList>
-StepperLeapfrog<Scalar>::getValidParameters() const
-{
-  Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
-  getValidParametersBasic(pl, this->getStepperType());
-  pl->set<std::string>("Initial Condition Consistency", "Consistent");
-  return pl;
 }
 
 

--- a/packages/tempus/src/Tempus_StepperNewmarkExplicitAForm_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkExplicitAForm_impl.hpp
@@ -62,6 +62,7 @@ template<class Scalar>
 StepperNewmarkExplicitAForm<Scalar>::StepperNewmarkExplicitAForm()
   : gammaDefault_(Scalar(0.5)), gamma_(Scalar(0.5))
 {
+  this->setStepperName(        "Newmark Explicit a-Form");
   this->setStepperType(        "Newmark Explicit a-Form");
   this->setUseFSAL(            true);
   this->setICConsistency(      "Consistent");
@@ -79,6 +80,7 @@ StepperNewmarkExplicitAForm<Scalar>::StepperNewmarkExplicitAForm(
   const Teuchos::RCP<StepperNewmarkExplicitAFormAppAction<Scalar> >& stepperAppAction)
   : gammaDefault_(Scalar(0.5)), gamma_(Scalar(0.5))
 {
+  this->setStepperName(        "Newmark Explicit a-Form");
   this->setStepperType(        "Newmark Explicit a-Form");
   this->setUseFSAL(            useFSAL);
   this->setICConsistency(      ICConsistency);
@@ -367,13 +369,10 @@ template<class Scalar>
 Teuchos::RCP<const Teuchos::ParameterList>
 StepperNewmarkExplicitAForm<Scalar>::getValidParameters() const
 {
-  Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
-  getValidParametersBasic(pl, this->getStepperType());
-  pl->set<bool>("Use FSAL", true);
-  pl->set<std::string>("Initial Condition Consistency", "Consistent");
+  auto pl = this->getValidParametersBasic();
   pl->sublist("Newmark Explicit Parameters", false, "");
   pl->sublist("Newmark Explicit Parameters", false, "").set("Gamma",
-               0.5, "Newmark Explicit parameter");
+               gamma_, "Newmark Explicit parameter");
   return pl;
 }
 

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitAForm_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitAForm_impl.hpp
@@ -184,6 +184,7 @@ StepperNewmarkImplicitAForm<Scalar>::StepperNewmarkImplicitAForm() :
   *out_ << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
 #endif
 
+  this->setStepperName(        "Newmark Implicit a-Form");
   this->setStepperType(        "Newmark Implicit a-Form");
   this->setUseFSAL(            true);
   this->setICConsistency(      "Consistent");
@@ -210,6 +211,7 @@ StepperNewmarkImplicitAForm<Scalar>::StepperNewmarkImplicitAForm(
     const Teuchos::RCP<StepperNewmarkImplicitAFormAppAction<Scalar> >& stepperAppAction)
   : out_(Teuchos::VerboseObjectBase::getDefaultOStream())
 {
+  this->setStepperName(        "Newmark Implicit a-Form");
   this->setStepperType(        "Newmark Implicit a-Form");
   this->setUseFSAL(            useFSAL);
   this->setICConsistency(      ICConsistency);
@@ -584,17 +586,13 @@ StepperNewmarkImplicitAForm<Scalar>::getValidParameters() const
 #ifdef VERBOSE_DEBUG_OUTPUT
   *out_ << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
 #endif
-  Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
-  getValidParametersBasic(pl, this->getStepperType());
-  pl->set<std::string>("Scheme Name", "Average Acceleration");
-  pl->set<double>     ("Beta" , 0.25);
-  pl->set<double>     ("Gamma", 0.5 );
-  pl->set<bool>       ("Use FSAL", true);
-  pl->set<std::string>("Initial Condition Consistency", "Consistent");
-  pl->set<std::string>("Solver Name", "Default Solver");
-  pl->set<bool>       ("Zero Initial Guess", false);
-  Teuchos::RCP<Teuchos::ParameterList> solverPL = defaultSolverParameters();
-  pl->set("Default Solver", *solverPL);
+  auto pl = this->getValidParametersBasicImplicit();
+
+  auto newmarkPL = Teuchos::parameterList("Newmark Parameters");
+  newmarkPL->set<std::string>("Scheme Name", schemeName_);
+  newmarkPL->set<double>     ("Beta",    beta_);
+  newmarkPL->set<double>     ("Gamma",   gamma_ );
+  pl->set("Newmark Parameters", *newmarkPL);
 
   return pl;
 }

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitDForm_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitDForm_impl.hpp
@@ -175,6 +175,7 @@ StepperNewmarkImplicitDForm<Scalar>::StepperNewmarkImplicitDForm()
   *out_ << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
 #endif
 
+  this->setStepperName(        "Newmark Implicit d-Form");
   this->setStepperType(        "Newmark Implicit d-Form");
   this->setUseFSAL(            false);
   this->setICConsistency(      "None");
@@ -200,6 +201,7 @@ StepperNewmarkImplicitDForm<Scalar>::StepperNewmarkImplicitDForm(
     const Teuchos::RCP<StepperNewmarkImplicitDFormAppAction<Scalar> >& stepperAppAction)
   : out_(Teuchos::VerboseObjectBase::getDefaultOStream())
 {
+  this->setStepperName(        "Newmark Implicit d-Form");
   this->setStepperType(        "Newmark Implicit d-Form");
   this->setUseFSAL(            useFSAL);
   this->setICConsistency(      ICConsistency);
@@ -498,15 +500,13 @@ StepperNewmarkImplicitDForm<Scalar>::getValidParameters() const {
 #ifdef VERBOSE_DEBUG_OUTPUT
   *out_ << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
 #endif
-  Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
-  getValidParametersBasic(pl, this->getStepperType());
-  pl->set<std::string>("Scheme Name", "Average Acceleration");
-  pl->set<double>     ("Beta" , 0.25);
-  pl->set<double>     ("Gamma", 0.5 );
-  pl->set<std::string>("Solver Name", "Default Solver");
-  pl->set<bool>       ("Zero Initial Guess", false);
-  Teuchos::RCP<Teuchos::ParameterList> solverPL = defaultSolverParameters();
-  pl->set("Default Solver", *solverPL);
+  auto pl = this->getValidParametersBasicImplicit();
+
+  auto newmarkPL = Teuchos::parameterList("Newmark Parameters");
+  newmarkPL->set<std::string>("Scheme Name", schemeName_);
+  newmarkPL->set<double>     ("Beta",    beta_);
+  newmarkPL->set<double>     ("Gamma",   gamma_ );
+  pl->set("Newmark Parameters", *newmarkPL);
 
   return pl;
 }

--- a/packages/tempus/src/Tempus_StepperOperatorSplit_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperOperatorSplit_impl.hpp
@@ -476,7 +476,7 @@ void StepperOperatorSplit<Scalar>::createSubSteppers(
     for (; aMI<appModels.end() || sLSI<stepperListStr.end(); aMI++, sLSI++) {
       RCP<ParameterList> subStepperPL = Teuchos::sublist(stepperPL,*sLSI,true);
       auto name = subStepperPL->name();
-      auto lastPos = name.rfind("->");
+      lastPos = name.rfind("->");
       std::string newName = name.substr(lastPos+2,name.length());
       subStepperPL->setName(newName);
       bool useFSAL = subStepperPL->template get<bool>("Use FSAL",false);

--- a/packages/tempus/src/Tempus_StepperOperatorSplit_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperOperatorSplit_impl.hpp
@@ -19,6 +19,7 @@ namespace Tempus {
 template<class Scalar>
 StepperOperatorSplit<Scalar>::StepperOperatorSplit()
 {
+  this->setStepperName(        "Operator Split");
   this->setStepperType(        "Operator Split");
   this->setUseFSAL(            false);
   this->setICConsistency(      "None");
@@ -47,6 +48,7 @@ StepperOperatorSplit<Scalar>::StepperOperatorSplit(
   int orderMax,
   const Teuchos::RCP<StepperOperatorSplitAppAction<Scalar> >& stepperOSAppAction)
 {
+  this->setStepperName(        "Operator Split");
   this->setStepperType(        "Operator Split");
   this->setUseFSAL(            useFSAL);
   this->setICConsistency(      ICConsistency);
@@ -137,7 +139,6 @@ void StepperOperatorSplit<Scalar>::addStepper(
   Teuchos::RCP<Stepper<Scalar> > stepper, bool useFSAL)
 {
     stepper->setUseFSAL(useFSAL);
-    stepper->initialize();
     subStepperList_.push_back(stepper);
 }
 
@@ -196,7 +197,6 @@ void StepperOperatorSplit<Scalar>::setModels(
     auto appModel = *(appModelIter);
     auto subStepper = *(subStepperIter);
     subStepper->setModel(appModel);
-    subStepper->initialize();
   }
 
   this->isInitialized_ = false;
@@ -226,6 +226,12 @@ void StepperOperatorSplit<Scalar>::initialize()
     TEUCHOS_TEST_FOR_EXCEPTION(!isOneStepMethod(), std::logic_error,
     "Error - OperatorSplit only works for one-step methods!\n");
   }
+
+  // Ensure that subSteppers are initialized.
+  typename std::vector<Teuchos::RCP<Stepper<Scalar> > >::const_iterator
+    subStepperIter = subStepperList_.begin();
+  for (; subStepperIter < subStepperList_.end(); subStepperIter++)
+    (*subStepperIter)->initialize();
 
   Stepper<Scalar>::initialize();
 }
@@ -402,17 +408,26 @@ template<class Scalar>
 Teuchos::RCP<const Teuchos::ParameterList>
 StepperOperatorSplit<Scalar>::getValidParameters() const
 {
-  Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
-  getValidParametersBasic(pl, this->getStepperType());
-  pl->set<int>   ("Minimum Order", 1,
+  auto pl = this->getValidParametersBasic();
+  pl->template set<int>("Minimum Order", orderMin_,
     "Minimum Operator-split order.  (default = 1)\n");
-  pl->set<int>   ("Order", 1,
+  pl->template set<int>("Order", order_,
     "Operator-split order.  (default = 1)\n");
-  pl->set<int>   ("Maximum Order", 1,
+  pl->template set<int>("Maximum Order", orderMax_,
     "Maximum Operator-split order.  (default = 1)\n");
 
-  pl->set<std::string>("Stepper List", "",
+  std::ostringstream list;
+  size_t size = subStepperList_.size();
+  for(std::size_t i = 0; i < size-1; ++i) {
+    list << "'" << subStepperList_[i]->getStepperName() << "', ";
+  }
+  list << "'" << subStepperList_[size-1]->getStepperName() << "'";
+  pl->template set<std::string>("Stepper List", list.str(),
     "Comma deliminated list of single quoted Steppers, e.g., \"'Operator 1', 'Operator 2'\".");
+
+  for(std::size_t i = 0; i < size; ++i) {
+    pl->set(subStepperList_[i]->getStepperName(), *(subStepperList_[i]->getValidParameters()));
+  }
 
   return pl;
 }
@@ -460,6 +475,10 @@ void StepperOperatorSplit<Scalar>::createSubSteppers(
 
     for (; aMI<appModels.end() || sLSI<stepperListStr.end(); aMI++, sLSI++) {
       RCP<ParameterList> subStepperPL = Teuchos::sublist(stepperPL,*sLSI,true);
+      auto name = subStepperPL->name();
+      auto lastPos = name.rfind("->");
+      std::string newName = name.substr(lastPos+2,name.length());
+      subStepperPL->setName(newName);
       bool useFSAL = subStepperPL->template get<bool>("Use FSAL",false);
       auto sf = Teuchos::rcp(new StepperFactory<Scalar>());
       auto subStepper = sf->createStepper(subStepperPL, *aMI);

--- a/packages/tempus/src/Tempus_StepperRKButcherTableau.hpp
+++ b/packages/tempus/src/Tempus_StepperRKButcherTableau.hpp
@@ -115,6 +115,23 @@ createStepperERK_ForwardEuler(
   Teuchos::RCP<Teuchos::ParameterList> pl)
 {
   auto stepper = Teuchos::rcp(new StepperERK_ForwardEuler<Scalar>());
+
+  // Test for aliases.
+  if (pl != Teuchos::null) {
+    auto stepperType =
+      pl->get<std::string>("Stepper Type", stepper->getStepperType());
+
+    TEUCHOS_TEST_FOR_EXCEPTION(
+      stepperType != stepper->getStepperType() &&
+      stepperType != "RK1", std::logic_error,
+      "  ParameterList 'Stepper Type' (='" + stepperType +"')\n"
+      "  does not match type for this Stepper (='" + stepper->getStepperType() +
+      "')\n  or one of its aliases ('RK1').\n");
+
+    // Reset default StepperType.
+    pl->set<std::string>("Stepper Type", stepper->getStepperType());
+  }
+
   stepper->setStepperRKValues(pl);
 
   if (model != Teuchos::null) {
@@ -1192,11 +1209,26 @@ template<class Scalar>
 Teuchos::RCP<StepperERK_3Stage3rdOrderTVD<Scalar> >
 createStepperERK_3Stage3rdOrderTVD(
   const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& model,
-  Teuchos::RCP<Teuchos::ParameterList> pl,
-  const std::string stepperType)
+  Teuchos::RCP<Teuchos::ParameterList> pl)
 {
   auto stepper = Teuchos::rcp(new StepperERK_3Stage3rdOrderTVD<Scalar>());
-  stepper->setStepperType(stepperType);
+
+  // Test for aliases.
+  if (pl != Teuchos::null) {
+    auto stepperType =
+      pl->get<std::string>("Stepper Type", stepper->getStepperType());
+
+    TEUCHOS_TEST_FOR_EXCEPTION(
+      stepperType != stepper->getStepperType() &&
+      stepperType != "SSPERK33" && stepperType != "SSPRK3", std::logic_error,
+      "  ParameterList 'Stepper Type' (='" + stepperType +"')\n"
+      "  does not match type for this Stepper (='" + stepper->getStepperType() +
+      "')\n  or one of its aliases ('SSPERK33' or 'SSPRK3').\n");
+
+    // Reset default StepperType.
+    pl->set<std::string>("Stepper Type", stepper->getStepperType());
+  }
+
   stepper->setStepperRKValues(pl);
 
   if (model != Teuchos::null) {
@@ -1562,11 +1594,26 @@ template<class Scalar>
 Teuchos::RCP<StepperERK_Ralston<Scalar> >
 createStepperERK_Ralston(
   const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& model,
-  Teuchos::RCP<Teuchos::ParameterList> pl,
-  std::string stepperType)
+  Teuchos::RCP<Teuchos::ParameterList> pl)
 {
   auto stepper = Teuchos::rcp(new StepperERK_Ralston<Scalar>());
-  stepper->setStepperType(stepperType);
+
+  // Test for aliases.
+  if (pl != Teuchos::null) {
+    auto stepperType =
+      pl->get<std::string>("Stepper Type", stepper->getStepperType());
+
+    TEUCHOS_TEST_FOR_EXCEPTION(
+      stepperType != stepper->getStepperType() &&
+      stepperType != "RK2", std::logic_error,
+      "  ParameterList 'Stepper Type' (='" + stepperType +"')\n"
+      "  does not match type for this Stepper (='" + stepper->getStepperType() +
+      "')\n  or one of its aliases ('RK2').\n");
+
+    // Reset default StepperType.
+    pl->set<std::string>("Stepper Type", stepper->getStepperType());
+  }
+
   stepper->setStepperRKValues(pl);
 
   if (model != Teuchos::null) {
@@ -1689,11 +1736,27 @@ template<class Scalar>
 Teuchos::RCP<StepperERK_Trapezoidal<Scalar> >
 createStepperERK_Trapezoidal(
   const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& model,
-  Teuchos::RCP<Teuchos::ParameterList> pl,
-  std::string stepperType)
+  Teuchos::RCP<Teuchos::ParameterList> pl)
 {
   auto stepper = Teuchos::rcp(new StepperERK_Trapezoidal<Scalar>());
-  stepper->setStepperType(stepperType);
+
+  // Test for aliases.
+  if (pl != Teuchos::null) {
+    auto stepperType =
+      pl->get<std::string>("Stepper Type", stepper->getStepperType());
+
+    TEUCHOS_TEST_FOR_EXCEPTION(
+      stepperType != stepper->getStepperType() &&
+      stepperType != "Heuns Method" && stepperType != "SSPERK22" &&
+      stepperType != "SSPRK2", std::logic_error,
+      "  ParameterList 'Stepper Type' (='" + stepperType +"')\n"
+      "  does not match type for this Stepper (='" + stepper->getStepperType() +
+      "')\n  or one of its aliases ('Heuns Method' or 'SSPERK22' or 'SSPRK2').\n");
+
+    // Reset default StepperType.
+    pl->set<std::string>("Stepper Type", stepper->getStepperType());
+  }
+
   stepper->setStepperRKValues(pl);
 
   if (model != Teuchos::null) {
@@ -3296,12 +3359,24 @@ createStepperEDIRK_TrapezoidalRule(
   const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& model,
   Teuchos::RCP<Teuchos::ParameterList> pl)
 {
-  // This stepper goes by various names (e.g., 'RK Trapezoidal Rule'
-  // and 'RK Crank-Nicolson').  Make sure it is set to the default name.
-  if (pl != Teuchos::null)
-    pl->set("Stepper Type", "RK Trapezoidal Rule");
-
   auto stepper = Teuchos::rcp(new StepperEDIRK_TrapezoidalRule<Scalar>());
+
+  // Test for aliases.
+  if (pl != Teuchos::null) {
+    auto stepperType =
+      pl->get<std::string>("Stepper Type", stepper->getStepperType());
+
+    TEUCHOS_TEST_FOR_EXCEPTION(
+      stepperType != stepper->getStepperType() &&
+      stepperType != "RK Crank-Nicolson", std::logic_error,
+      "  ParameterList 'Stepper Type' (='" + stepperType +"')\n"
+      "  does not match type for this Stepper (='" + stepper->getStepperType() +
+      "')\n  or one of its aliases ('RK Crank-Nicolson').\n");
+
+    // Reset default StepperType.
+    pl->set<std::string>("Stepper Type", stepper->getStepperType());
+  }
+
   stepper->setStepperDIRKValues(pl);
 
   if (model != Teuchos::null) {

--- a/packages/tempus/src/Tempus_StepperRKButcherTableau.hpp
+++ b/packages/tempus/src/Tempus_StepperRKButcherTableau.hpp
@@ -49,6 +49,7 @@ public:
   */
   StepperERK_ForwardEuler()
   {
+    this->setStepperName("RK Forward Euler");
     this->setStepperType("RK Forward Euler");
     this->setupTableau();
     this->setupDefault();
@@ -65,6 +66,7 @@ public:
     bool useEmbedded,
     const Teuchos::RCP<StepperRKAppAction<Scalar> >& stepperRKAppAction)
   {
+    this->setStepperName("RK Forward Euler");
     this->setStepperType("RK Forward Euler");
     this->setupTableau();
     this->setup(appModel, useFSAL, ICConsistency,
@@ -153,6 +155,7 @@ public:
   */
   StepperERK_4Stage4thOrder()
   {
+    this->setStepperName("RK Explicit 4 Stage");
     this->setStepperType("RK Explicit 4 Stage");
     this->setupTableau();
     this->setupDefault();
@@ -169,6 +172,7 @@ public:
     bool useEmbedded,
     const Teuchos::RCP<StepperRKAppAction<Scalar> >& stepperRKAppAction)
   {
+    this->setStepperName("RK Explicit 4 Stage");
     this->setStepperType("RK Explicit 4 Stage");
     this->setupTableau();
     this->setup(appModel, useFSAL, ICConsistency,
@@ -281,6 +285,7 @@ public:
   */
   StepperERK_BogackiShampine32()
   {
+    this->setStepperName("Bogacki-Shampine 3(2) Pair");
     this->setStepperType("Bogacki-Shampine 3(2) Pair");
     this->setupTableau();
     this->setupDefault();
@@ -297,6 +302,7 @@ public:
     bool useEmbedded,
     const Teuchos::RCP<StepperRKAppAction<Scalar> >& stepperRKAppAction)
   {
+    this->setStepperName("Bogacki-Shampine 3(2) Pair");
     this->setStepperType("Bogacki-Shampine 3(2) Pair");
     this->setupTableau();
     this->setup(appModel, useFSAL, ICConsistency,
@@ -424,6 +430,7 @@ public:
   */
   StepperERK_Merson45()
   {
+    this->setStepperName("Merson 4(5) Pair");
     this->setStepperType("Merson 4(5) Pair");
     this->setupTableau();
     this->setupDefault();
@@ -440,6 +447,7 @@ public:
     bool useEmbedded,
     const Teuchos::RCP<StepperRKAppAction<Scalar> >& stepperRKAppAction)
   {
+    this->setStepperName("Merson 4(5) Pair");
     this->setStepperType("Merson 4(5) Pair");
     this->setupTableau();
     this->setup(appModel, useFSAL, ICConsistency,
@@ -568,6 +576,7 @@ public:
 
   StepperERK_3_8Rule()
   {
+    this->setStepperName("RK Explicit 3/8 Rule");
     this->setStepperType("RK Explicit 3/8 Rule");
     this->setupTableau();
     this->setupDefault();
@@ -584,6 +593,7 @@ public:
     bool useEmbedded,
     const Teuchos::RCP<StepperRKAppAction<Scalar> >& stepperRKAppAction)
   {
+    this->setStepperName("RK Explicit 3/8 Rule");
     this->setStepperType("RK Explicit 3/8 Rule");
     this->setupTableau();
     this->setup(appModel, useFSAL, ICConsistency,
@@ -699,6 +709,7 @@ public:
   */
   StepperERK_4Stage3rdOrderRunge()
   {
+    this->setStepperName("RK Explicit 4 Stage 3rd order by Runge");
     this->setStepperType("RK Explicit 4 Stage 3rd order by Runge");
     this->setupTableau();
     this->setupDefault();
@@ -715,6 +726,7 @@ public:
     bool useEmbedded,
     const Teuchos::RCP<StepperRKAppAction<Scalar> >& stepperRKAppAction)
   {
+    this->setStepperName("RK Explicit 4 Stage 3rd order by Runge");
     this->setStepperType("RK Explicit 4 Stage 3rd order by Runge");
     this->setupTableau();
     this->setup(appModel, useFSAL, ICConsistency,
@@ -825,6 +837,7 @@ public:
   */
   StepperERK_5Stage3rdOrderKandG()
   {
+    this->setStepperName("RK Explicit 5 Stage 3rd order by Kinnmark and Gray");
     this->setStepperType("RK Explicit 5 Stage 3rd order by Kinnmark and Gray");
     this->setupTableau();
     this->setupDefault();
@@ -841,6 +854,7 @@ public:
     bool useEmbedded,
     const Teuchos::RCP<StepperRKAppAction<Scalar> >& stepperRKAppAction)
   {
+    this->setStepperName("RK Explicit 5 Stage 3rd order by Kinnmark and Gray");
     this->setStepperType("RK Explicit 5 Stage 3rd order by Kinnmark and Gray");
     this->setupTableau();
     this->setup(appModel, useFSAL, ICConsistency,
@@ -951,6 +965,7 @@ public:
   */
   StepperERK_3Stage3rdOrder()
   {
+    this->setStepperName("RK Explicit 3 Stage 3rd order");
     this->setStepperType("RK Explicit 3 Stage 3rd order");
     this->setupTableau();
     this->setupDefault();
@@ -967,6 +982,7 @@ public:
     bool useEmbedded,
     const Teuchos::RCP<StepperRKAppAction<Scalar> >& stepperRKAppAction)
   {
+    this->setStepperName("RK Explicit 3 Stage 3rd order");
     this->setStepperType("RK Explicit 3 Stage 3rd order");
     this->setupTableau();
     this->setup(appModel, useFSAL, ICConsistency,
@@ -1080,6 +1096,7 @@ public:
   */
   StepperERK_3Stage3rdOrderTVD()
   {
+    this->setStepperName("RK Explicit 3 Stage 3rd order TVD");
     this->setStepperType("RK Explicit 3 Stage 3rd order TVD");
     this->setupTableau();
     this->setupDefault();
@@ -1096,6 +1113,7 @@ public:
     bool useEmbedded,
     const Teuchos::RCP<StepperRKAppAction<Scalar> >& stepperRKAppAction)
   {
+    this->setStepperName("RK Explicit 3 Stage 3rd order TVD");
     this->setStepperType("RK Explicit 3 Stage 3rd order TVD");
     this->setupTableau();
     this->setup(appModel, useFSAL, ICConsistency,
@@ -1222,6 +1240,7 @@ public:
   */
   StepperERK_3Stage3rdOrderHeun()
   {
+    this->setStepperName("RK Explicit 3 Stage 3rd order by Heun");
     this->setStepperType("RK Explicit 3 Stage 3rd order by Heun");
     this->setupTableau();
     this->setupDefault();
@@ -1238,6 +1257,7 @@ public:
     bool useEmbedded,
     const Teuchos::RCP<StepperRKAppAction<Scalar> >& stepperRKAppAction)
   {
+    this->setStepperName("RK Explicit 3 Stage 3rd order by Heun");
     this->setStepperType("RK Explicit 3 Stage 3rd order by Heun");
     this->setupTableau();
     this->setup(appModel, useFSAL, ICConsistency,
@@ -1347,6 +1367,7 @@ public:
   */
   StepperERK_Midpoint()
   {
+    this->setStepperName("RK Explicit Midpoint");
     this->setStepperType("RK Explicit Midpoint");
     this->setupTableau();
     this->setupDefault();
@@ -1363,6 +1384,7 @@ public:
     bool useEmbedded,
     const Teuchos::RCP<StepperRKAppAction<Scalar> >& stepperRKAppAction)
   {
+    this->setStepperName("RK Explicit Midpoint");
     this->setStepperType("RK Explicit Midpoint");
     this->setupTableau();
     this->setup(appModel, useFSAL, ICConsistency,
@@ -1463,6 +1485,7 @@ public:
   */
   StepperERK_Ralston()
   {
+    this->setStepperName("RK Explicit Ralston");
     this->setStepperType("RK Explicit Ralston");
     this->setupTableau();
     this->setupDefault();
@@ -1479,6 +1502,7 @@ public:
     bool useEmbedded,
     const Teuchos::RCP<StepperRKAppAction<Scalar> >& stepperRKAppAction)
   {
+    this->setStepperName("RK Explicit Ralston");
     this->setStepperType("RK Explicit Ralston");
     this->setupTableau();
     this->setup(appModel, useFSAL, ICConsistency,
@@ -1582,6 +1606,7 @@ public:
   */
   StepperERK_Trapezoidal()
   {
+    this->setStepperName("RK Explicit Trapezoidal");
     this->setStepperType("RK Explicit Trapezoidal");
     this->setupTableau();
     this->setupDefault();
@@ -1598,6 +1623,7 @@ public:
     bool useEmbedded,
     const Teuchos::RCP<StepperRKAppAction<Scalar> >& stepperRKAppAction)
   {
+    this->setStepperName("RK Explicit Trapezoidal");
     this->setStepperType("RK Explicit Trapezoidal");
     this->setupTableau();
     this->setup(appModel, useFSAL, ICConsistency,
@@ -1704,6 +1730,7 @@ class StepperERK_SSPERK54 :
   public:
   StepperERK_SSPERK54()
   {
+    this->setStepperName("SSPERK54");
     this->setStepperType("SSPERK54");
     this->setupTableau();
     this->setupDefault();
@@ -1720,6 +1747,7 @@ class StepperERK_SSPERK54 :
     bool useEmbedded,
     const Teuchos::RCP<StepperRKAppAction<Scalar> >& stepperRKAppAction)
   {
+    this->setStepperName("SSPERK54");
     this->setStepperType("SSPERK54");
     this->setupTableau();
     this->setup(appModel, useFSAL, ICConsistency,
@@ -1856,6 +1884,7 @@ class StepperERK_General :
 public:
   StepperERK_General()
   {
+    this->setStepperName("General ERK");
     this->setStepperType("General ERK");
     this->setupTableau();
     this->setupDefault();
@@ -1879,6 +1908,7 @@ public:
     const Teuchos::SerialDenseVector<int,Scalar>& bstar,
     const Teuchos::RCP<StepperRKAppAction<Scalar> >& stepperRKAppAction=Teuchos::null)
   {
+    this->setStepperName("General ERK");
     this->setStepperType("General ERK");
     this->setTableau(A,b,c,order,orderMin,orderMax,bstar);
 
@@ -1946,20 +1976,57 @@ public:
   Teuchos::RCP<const Teuchos::ParameterList>
   getValidParameters() const
   {
-    Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
-    this->getValidParametersBasicERK(pl);
-    pl->set<std::string>("Initial Condition Consistency",
-                         this->getDefaultICConsistency());
+    auto pl = this->getValidParametersBasicERK();
 
     // Tableau ParameterList
+    Teuchos::SerialDenseMatrix<int,Scalar> A = this->tableau_->A();
+    Teuchos::SerialDenseVector<int,Scalar> b = this->tableau_->b();
+    Teuchos::SerialDenseVector<int,Scalar> c = this->tableau_->c();
+    Teuchos::SerialDenseVector<int,Scalar> bstar = this->tableau_->bstar();
+
     Teuchos::RCP<Teuchos::ParameterList> tableauPL = Teuchos::parameterList();
-    tableauPL->set<std::string>("A",
-     "0.0 0.0 0.0 0.0; 0.5 0.0 0.0 0.0; 0.0 0.5 0.0 0.0; 0.0 0.0 1.0 0.0");
-    tableauPL->set<std::string>("b",
-     "0.166666666666667 0.333333333333333 0.333333333333333 0.166666666666667");
-    tableauPL->set<std::string>("c", "0.0 0.5 0.5 1.0");
-    tableauPL->set<int>("order", 4);
-    tableauPL->set<std::string>("bstar", "");
+
+    std::ostringstream Astream;
+    Astream.precision(15);
+    for(int i = 0; i < A.numRows(); i++) {
+      for(int j = 0; j < A.numCols()-1; j++) {
+        Astream << A(i,j) << " ";
+      }
+      Astream << A(i,A.numCols()-1);
+      if ( i != A.numRows()-1 ) Astream << "; ";
+    }
+    tableauPL->set<std::string>("A", Astream.str());
+
+    std::ostringstream bstream;
+    bstream.precision(15);
+    for(int i = 0; i < b.length()-1; i++) {
+        bstream << b(i) << " ";
+    }
+    bstream << b(b.length()-1);
+    tableauPL->set<std::string>("b", bstream.str());
+
+    std::ostringstream cstream;
+    cstream.precision(15);
+    for(int i = 0; i < c.length()-1; i++) {
+        cstream << c(i) << " ";
+    }
+    cstream << c(c.length()-1);
+    tableauPL->set<std::string>("c", cstream.str());
+
+    tableauPL->set<int>("order", this->tableau_->order());
+
+    if ( bstar.length() == 0 ) {
+      tableauPL->set("bstar", "");
+    } else {
+      std::ostringstream bstarstream;
+      bstarstream.precision(15);
+      for(int i = 0; i < bstar.length()-1; i++) {
+          bstarstream << bstar(i) << " ";
+      }
+      bstarstream << bstar(bstar.length()-1);
+      tableauPL->set<std::string>("bstar", bstarstream.str());
+    }
+
     pl->set("Tableau", *tableauPL);
 
     return pl;
@@ -2025,6 +2092,7 @@ public:
   */
   StepperDIRK_BackwardEuler()
   {
+    this->setStepperName("RK Backward Euler");
     this->setStepperType("RK Backward Euler");
     this->setupTableau();
     this->setupDefault();
@@ -2043,6 +2111,7 @@ public:
     bool zeroInitialGuess,
     const Teuchos::RCP<StepperRKAppAction<Scalar> >& stepperRKAppAction)
   {
+    this->setStepperName("RK Backward Euler");
     this->setStepperType("RK Backward Euler");
     this->setupTableau();
     this->setup(appModel, solver, useFSAL, ICConsistency, ICConsistencyCheck,
@@ -2057,14 +2126,6 @@ public:
                 << "A = [ 1 ]\n"
                 << "b = [ 1 ]'";
     return Description.str();
-  }
-
-  Teuchos::RCP<const Teuchos::ParameterList>
-  getValidParameters() const
-  {
-    Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
-    this->getValidParametersBasicDIRK(pl);
-    return pl;
   }
 
 protected:
@@ -2156,6 +2217,7 @@ public:
     const Scalar one = ST::one();
     gammaDefault_ = Teuchos::as<Scalar>((2*one-ST::squareroot(2*one))/(2*one));
 
+    this->setStepperName("SDIRK 2 Stage 2nd order");
     this->setStepperType("SDIRK 2 Stage 2nd order");
     this->setGamma(gammaDefault_);
     this->setupTableau();
@@ -2180,6 +2242,7 @@ public:
     const Scalar one = ST::one();
     gammaDefault_ = Teuchos::as<Scalar>((2*one-ST::squareroot(2*one))/(2*one));
 
+    this->setStepperName("SDIRK 2 Stage 2nd order");
     this->setStepperType("SDIRK 2 Stage 2nd order");
     this->setGamma(gamma);
     this->setupTableau();
@@ -2194,7 +2257,7 @@ public:
     this->setupTableau();
   }
 
-  Scalar getGamma() { return gamma_; }
+  Scalar getGamma() const { return gamma_; }
 
   std::string getDescription() const
   {
@@ -2214,9 +2277,8 @@ public:
   Teuchos::RCP<const Teuchos::ParameterList>
   getValidParameters() const
   {
-    Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
-    this->getValidParametersBasicDIRK(pl);
-    pl->set<double>("gamma",gammaDefault_,
+    auto pl = this->getValidParametersBasicDIRK();
+    pl->template set<double>("gamma", this->getGamma(),
       "The default value is gamma = (2-sqrt(2))/2. "
       "This will produce an L-stable 2nd order method with the stage "
       "times within the timestep.  Other values of gamma will still "
@@ -2323,6 +2385,7 @@ public:
   */
   StepperSDIRK_3Stage2ndOrder()
   {
+    this->setStepperName("SDIRK 3 Stage 2nd order");
     this->setStepperType("SDIRK 3 Stage 2nd order");
     this->setupTableau();
     this->setupDefault();
@@ -2342,6 +2405,7 @@ public:
     const Teuchos::RCP<StepperRKAppAction<Scalar> >& stepperRKAppAction)
   {
 
+    this->setStepperName("SDIRK 3 Stage 2nd order");
     this->setStepperType("SDIRK 3 Stage 2nd order");
     this->setupTableau();
     this->setup(appModel, solver, useFSAL, ICConsistency, ICConsistencyCheck,
@@ -2364,14 +2428,6 @@ public:
                 << "    [ 1/2-gamma   0      gamma  ]\n"
                 << "b = [  1/6       1/6       2/3  ]'";
     return Description.str();
-  }
-
-  Teuchos::RCP<const Teuchos::ParameterList>
-  getValidParameters() const
-  {
-    Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
-    this->getValidParametersBasicDIRK(pl);
-    return pl;
   }
 
 protected:
@@ -2479,6 +2535,7 @@ public:
     gammaDefault_ = as<Scalar>((3*one+ST::squareroot(3*one))/(6*one));
     gammaTypeDefault_ = "3rd Order A-stable";
 
+    this->setStepperName("SDIRK 2 Stage 3rd order");
     this->setStepperType("SDIRK 2 Stage 3rd order");
     this->setGammaType(gammaTypeDefault_);
     this->setGamma(gammaDefault_);
@@ -2507,6 +2564,7 @@ public:
     gammaDefault_ = as<Scalar>((3*one+ST::squareroot(3*one))/(6*one));
     gammaTypeDefault_ = "3rd Order A-stable";
 
+    this->setStepperName("SDIRK 2 Stage 3rd order");
     this->setStepperType("SDIRK 2 Stage 3rd order");
     this->setGammaType(gammaType);
     this->setGamma(gamma);
@@ -2529,7 +2587,7 @@ public:
     this->setupTableau();
   }
 
-  std::string getGammaType() { return gammaType_; }
+  std::string getGammaType() const { return gammaType_; }
 
   void setGamma(Scalar gamma)
   {
@@ -2540,7 +2598,7 @@ public:
     this->isInitialized_ = false;
   }
 
-  Scalar getGamma() { return gamma_; }
+  Scalar getGamma() const { return gamma_; }
 
   std::string getDescription() const
   {
@@ -2562,15 +2620,13 @@ public:
   Teuchos::RCP<const Teuchos::ParameterList>
   getValidParameters() const
   {
-    Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
-    this->getValidParametersBasicDIRK(pl);
+    auto pl = this->getValidParametersBasicDIRK();
 
-    pl->set<bool>("Initial Condition Consistency Check", false);
-    pl->set<std::string>("Gamma Type", gammaTypeDefault_,
+    pl->template set<std::string>("Gamma Type", this->getGammaType(),
       "Valid values are '3rd Order A-stable' ((3+sqrt(3))/6.), "
       "'2nd Order L-stable' ((2-sqrt(2))/2) and 'gamma' (user defined).  "
       "The default value is '3rd Order A-stable'.");
-    pl->set<double>("gamma", gammaDefault_,
+    pl->template set<double>("gamma", this->getGamma(),
       "Equal to (3+sqrt(3))/6 if 'Gamma Type' = '3rd Order A-stable', or "
       "(2-sqrt(2))/2 if 'Gamma Type' = '2nd Order L-stable', or "
       "user-defined gamma value if 'Gamma Type = 'gamma'.  "
@@ -2683,6 +2739,7 @@ public:
   */
   StepperEDIRK_2Stage3rdOrder()
   {
+    this->setStepperName("EDIRK 2 Stage 3rd order");
     this->setStepperType("EDIRK 2 Stage 3rd order");
     this->setupTableau();
     this->setupDefault();
@@ -2701,6 +2758,7 @@ public:
     bool zeroInitialGuess,
     const Teuchos::RCP<StepperRKAppAction<Scalar> >& stepperRKAppAction)
   {
+    this->setStepperName("EDIRK 2 Stage 3rd order");
     this->setStepperType("EDIRK 2 Stage 3rd order");
     this->setupTableau();
     this->setup(appModel, solver, useFSAL, ICConsistency, ICConsistencyCheck,
@@ -2721,14 +2779,6 @@ public:
                 << "    [ 1/3  1/3 ]\n"
                 << "b = [ 1/4  3/4 ]'";
     return Description.str();
-  }
-
-  Teuchos::RCP<const Teuchos::ParameterList>
-  getValidParameters() const
-  {
-    Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
-    this->getValidParametersBasicDIRK(pl);
-    return pl;
   }
 
 protected:
@@ -2823,6 +2873,7 @@ public:
     typedef Teuchos::ScalarTraits<Scalar> ST;
     thetaDefault_ = ST::one()/(2*ST::one());
 
+    this->setStepperName("DIRK 1 Stage Theta Method");
     this->setStepperType("DIRK 1 Stage Theta Method");
     this->setTheta(thetaDefault_);
     this->setupTableau();
@@ -2846,6 +2897,7 @@ public:
     typedef Teuchos::ScalarTraits<Scalar> ST;
     thetaDefault_ = ST::one()/(2*ST::one());
 
+    this->setStepperName("DIRK 1 Stage Theta Method");
     this->setStepperType("DIRK 1 Stage Theta Method");
     this->setTheta(theta);
     this->setupTableau();
@@ -2864,7 +2916,7 @@ public:
     this->isInitialized_ = false;
   }
 
-  Scalar getTheta() { return theta_; }
+  Scalar getTheta() const { return theta_; }
 
   std::string getDescription() const
   {
@@ -2883,10 +2935,9 @@ public:
   Teuchos::RCP<const Teuchos::ParameterList>
   getValidParameters() const
   {
-    Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
-    this->getValidParametersBasicDIRK(pl);
+    auto pl = this->getValidParametersBasicDIRK();
 
-    pl->set<double>("theta",thetaDefault_,
+    pl->template set<double>("theta", getTheta(),
       "Valid values are 0 <= theta <= 1, where theta = 0 "
       "implies Forward Euler, theta = 1/2 implies implicit midpoint "
       "method (default), and theta = 1 implies Backward Euler. "
@@ -2989,6 +3040,7 @@ public:
     typedef Teuchos::ScalarTraits<Scalar> ST;
     thetaDefault_ = ST::one()/(2*ST::one());
 
+    this->setStepperName("EDIRK 2 Stage Theta Method");
     this->setStepperType("EDIRK 2 Stage Theta Method");
     this->setTheta(thetaDefault_);
     this->setupTableau();
@@ -3012,6 +3064,7 @@ public:
     typedef Teuchos::ScalarTraits<Scalar> ST;
     thetaDefault_ = ST::one()/(2*ST::one());
 
+    this->setStepperName("EDIRK 2 Stage Theta Method");
     this->setStepperType("EDIRK 2 Stage Theta Method");
     this->setTheta(theta);
     this->setupTableau();
@@ -3030,7 +3083,7 @@ public:
     this->setupTableau();
   }
 
-  Scalar getTheta() { return theta_; }
+  Scalar getTheta() const { return theta_; }
 
   std::string getDescription() const
   {
@@ -3049,10 +3102,9 @@ public:
   Teuchos::RCP<const Teuchos::ParameterList>
   getValidParameters() const
   {
-    Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
-    this->getValidParametersBasicDIRK(pl);
+    auto pl = this->getValidParametersBasicDIRK();
 
-    pl->set<double>("theta",thetaDefault_,
+    pl->template set<double>("theta", getTheta(),
       "Valid values are 0 < theta <= 1, where theta = 0 "
       "implies Forward Euler, theta = 1/2 implies trapezoidal "
       "method (default), and theta = 1 implies Backward Euler. "
@@ -3160,6 +3212,7 @@ public:
   */
   StepperEDIRK_TrapezoidalRule()
   {
+    this->setStepperName("RK Trapezoidal Rule");
     this->setStepperType("RK Trapezoidal Rule");
     this->setupTableau();
     this->setupDefault();
@@ -3178,6 +3231,7 @@ public:
     bool zeroInitialGuess,
     const Teuchos::RCP<StepperRKAppAction<Scalar> >& stepperRKAppAction)
   {
+    this->setStepperName("RK Trapezoidal Rule");
     this->setStepperType("RK Trapezoidal Rule");
     this->setupTableau();
     this->setup(appModel, solver, useFSAL, ICConsistency, ICConsistencyCheck,
@@ -3194,14 +3248,6 @@ public:
                 << "    [ 1/2  1/2 ]\n"
                 << "b = [ 1/2  1/2 ]'";
     return Description.str();
-  }
-
-  Teuchos::RCP<const Teuchos::ParameterList>
-  getValidParameters() const
-  {
-    Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
-    this->getValidParametersBasicDIRK(pl);
-    return pl;
   }
 
   void setUseFSAL(bool a) { this->useFSAL_ = a; this->isInitialized_ = false; }
@@ -3253,7 +3299,7 @@ createStepperEDIRK_TrapezoidalRule(
   // This stepper goes by various names (e.g., 'RK Trapezoidal Rule'
   // and 'RK Crank-Nicolson').  Make sure it is set to the default name.
   if (pl != Teuchos::null)
-    pl->set<std::string>("Stepper Type", "RK Trapezoidal Rule");
+    pl->set("Stepper Type", "RK Trapezoidal Rule");
 
   auto stepper = Teuchos::rcp(new StepperEDIRK_TrapezoidalRule<Scalar>());
   stepper->setStepperDIRKValues(pl);
@@ -3304,6 +3350,7 @@ public:
   */
   StepperSDIRK_ImplicitMidpoint()
   {
+    this->setStepperName("RK Implicit Midpoint");
     this->setStepperType("RK Implicit Midpoint");
     this->setupTableau();
     this->setupDefault();
@@ -3322,6 +3369,7 @@ public:
     bool zeroInitialGuess,
     const Teuchos::RCP<StepperRKAppAction<Scalar> >& stepperRKAppAction)
   {
+    this->setStepperName("RK Implicit Midpoint");
     this->setStepperType("RK Implicit Midpoint");
     this->setupTableau();
     this->setup(appModel, solver, useFSAL, ICConsistency, ICConsistencyCheck,
@@ -3346,14 +3394,6 @@ public:
                 << "A = [ 1/2 ]\n"
                 << "b = [  1  ]'";
     return Description.str();
-  }
-
-  Teuchos::RCP<const Teuchos::ParameterList>
-  getValidParameters() const
-  {
-    Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
-    this->getValidParametersBasicDIRK(pl);
-    return pl;
   }
 
 protected:
@@ -3433,6 +3473,7 @@ class StepperSDIRK_SSPDIRK22 :
   public:
   StepperSDIRK_SSPDIRK22()
   {
+    this->setStepperName("SSPDIRK22");
     this->setStepperType("SSPDIRK22");
     this->setupTableau();
     this->setupDefault();
@@ -3451,6 +3492,7 @@ class StepperSDIRK_SSPDIRK22 :
     bool zeroInitialGuess,
     const Teuchos::RCP<StepperRKAppAction<Scalar> >& stepperRKAppAction)
   {
+    this->setStepperName("SSPDIRK22");
     this->setStepperType("SSPDIRK22");
     this->setupTableau();
     this->setup(appModel, solver, useFSAL, ICConsistency, ICConsistencyCheck,
@@ -3468,14 +3510,6 @@ class StepperSDIRK_SSPDIRK22 :
       << "        [ 1/2   1/4 ]\n"
       << "b     = [ 1/2   1/2 ]\n" << std::endl;
     return Description.str();
-  }
-
-  Teuchos::RCP<const Teuchos::ParameterList>
-  getValidParameters() const
-  {
-    Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
-    this->getValidParametersBasicDIRK(pl);
-    return pl;
   }
 
 protected:
@@ -3562,6 +3596,7 @@ class StepperSDIRK_SSPDIRK32 :
   public:
   StepperSDIRK_SSPDIRK32()
   {
+    this->setStepperName("SSPDIRK32");
     this->setStepperType("SSPDIRK32");
     this->setupTableau();
     this->setupDefault();
@@ -3580,6 +3615,7 @@ class StepperSDIRK_SSPDIRK32 :
     bool zeroInitialGuess,
     const Teuchos::RCP<StepperRKAppAction<Scalar> >& stepperRKAppAction)
   {
+    this->setStepperName("SSPDIRK32");
     this->setStepperType("SSPDIRK32");
     this->setupTableau();
     this->setup(appModel, solver, useFSAL, ICConsistency, ICConsistencyCheck,
@@ -3598,14 +3634,6 @@ class StepperSDIRK_SSPDIRK32 :
                 << "    [ 1/3   1/3   1/6 ]\n"
                 << "b = [ 1/3   1/3   1/3 ]\n" << std::endl;
     return Description.str();
-  }
-
-  Teuchos::RCP<const Teuchos::ParameterList>
-  getValidParameters() const
-  {
-    Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
-    this->getValidParametersBasicDIRK(pl);
-    return pl;
   }
 
 protected:
@@ -3693,6 +3721,7 @@ class StepperSDIRK_SSPDIRK23 :
   public:
   StepperSDIRK_SSPDIRK23()
   {
+    this->setStepperName("SSPDIRK23");
     this->setStepperType("SSPDIRK23");
     this->setupTableau();
     this->setupDefault();
@@ -3711,6 +3740,7 @@ class StepperSDIRK_SSPDIRK23 :
     bool zeroInitialGuess,
     const Teuchos::RCP<StepperRKAppAction<Scalar> >& stepperRKAppAction)
   {
+    this->setStepperName("SSPDIRK23");
     this->setStepperType("SSPDIRK23");
     this->setupTableau();
     this->setup(appModel, solver, useFSAL, ICConsistency, ICConsistencyCheck,
@@ -3728,14 +3758,6 @@ class StepperSDIRK_SSPDIRK23 :
       << "        [ 1/sqrt( 3 )        1/(3 + sqrt( 3 ))    ] \n"
       << "b     = [ 1/2                   1/2               ] \n" << std::endl;
     return Description.str();
-  }
-
-  Teuchos::RCP<const Teuchos::ParameterList>
-  getValidParameters() const
-  {
-    Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
-    this->getValidParametersBasicDIRK(pl);
-    return pl;
   }
 
 protected:
@@ -3824,6 +3846,7 @@ class StepperSDIRK_SSPDIRK33 :
   public:
   StepperSDIRK_SSPDIRK33()
   {
+    this->setStepperName("SSPDIRK33");
     this->setStepperType("SSPDIRK33");
     this->setupTableau();
     this->setupDefault();
@@ -3842,6 +3865,7 @@ class StepperSDIRK_SSPDIRK33 :
     bool zeroInitialGuess,
     const Teuchos::RCP<StepperRKAppAction<Scalar> >& stepperRKAppAction)
   {
+    this->setStepperName("SSPDIRK33");
     this->setStepperType("SSPDIRK33");
     this->setupTableau();
     this->setup(appModel, solver, useFSAL, ICConsistency, ICConsistencyCheck,
@@ -3861,14 +3885,6 @@ class StepperSDIRK_SSPDIRK33 :
       << "b     = [ 1/3                    1/3                1/3           ] \n"
       << std::endl;
     return Description.str();
-  }
-
-  Teuchos::RCP<const Teuchos::ParameterList>
-  getValidParameters() const
-  {
-    Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
-    this->getValidParametersBasicDIRK(pl);
-    return pl;
   }
 
 protected:
@@ -3962,6 +3978,7 @@ public:
   */
   StepperDIRK_1Stage1stOrderRadauIA()
   {
+    this->setStepperName("RK Implicit 1 Stage 1st order Radau IA");
     this->setStepperType("RK Implicit 1 Stage 1st order Radau IA");
     this->setupTableau();
     this->setupDefault();
@@ -3980,6 +3997,7 @@ public:
     bool zeroInitialGuess,
     const Teuchos::RCP<StepperRKAppAction<Scalar> >& stepperRKAppAction)
   {
+    this->setStepperName("RK Implicit 1 Stage 1st order Radau IA");
     this->setStepperType("RK Implicit 1 Stage 1st order Radau IA");
     this->setupTableau();
     this->setup(appModel, solver, useFSAL, ICConsistency, ICConsistencyCheck,
@@ -4000,14 +4018,6 @@ public:
                 << "A = [ 1 ]\n"
                 << "b = [ 1 ]'";
     return Description.str();
-  }
-
-  Teuchos::RCP<const Teuchos::ParameterList>
-  getValidParameters() const
-  {
-    Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
-    this->getValidParametersBasicDIRK(pl);
-    return pl;
   }
 
 protected:
@@ -4086,6 +4096,7 @@ public:
   */
   StepperDIRK_2Stage2ndOrderLobattoIIIB()
   {
+    this->setStepperName("RK Implicit 2 Stage 2nd order Lobatto IIIB");
     this->setStepperType("RK Implicit 2 Stage 2nd order Lobatto IIIB");
     this->setupTableau();
     this->setupDefault();
@@ -4104,6 +4115,7 @@ public:
     bool zeroInitialGuess,
     const Teuchos::RCP<StepperRKAppAction<Scalar> >& stepperRKAppAction)
   {
+    this->setStepperName("RK Implicit 2 Stage 2nd order Lobatto IIIB");
     this->setStepperType("RK Implicit 2 Stage 2nd order Lobatto IIIB");
     this->setupTableau();
     this->setup(appModel, solver, useFSAL, ICConsistency, ICConsistencyCheck,
@@ -4125,14 +4137,6 @@ public:
                 << "    [ 1/2   0   ]\n"
                 << "b = [ 1/2  1/2  ]'";
     return Description.str();
-  }
-
-  Teuchos::RCP<const Teuchos::ParameterList>
-  getValidParameters() const
-  {
-    Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
-    this->getValidParametersBasicDIRK(pl);
-    return pl;
   }
 
 protected:
@@ -4230,6 +4234,7 @@ public:
   */
   StepperSDIRK_5Stage4thOrder()
   {
+    this->setStepperName("SDIRK 5 Stage 4th order");
     this->setStepperType("SDIRK 5 Stage 4th order");
     this->setupTableau();
     this->setupDefault();
@@ -4248,6 +4253,7 @@ public:
     bool zeroInitialGuess,
     const Teuchos::RCP<StepperRKAppAction<Scalar> >& stepperRKAppAction)
   {
+    this->setStepperName("SDIRK 5 Stage 4th order");
     this->setStepperType("SDIRK 5 Stage 4th order");
     this->setupTableau();
     this->setup(appModel, solver, useFSAL, ICConsistency, ICConsistencyCheck,
@@ -4273,14 +4279,6 @@ public:
       << "b     = [ 25/24     -49/48     125/16  -85/12  1/4 ]'";
       // << "b     = [ 59/48     -17/96     225/32  -85/12  0   ]'";
     return Description.str();
-  }
-
-  Teuchos::RCP<const Teuchos::ParameterList>
-  getValidParameters() const
-  {
-    Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
-    this->getValidParametersBasicDIRK(pl);
-    return pl;
   }
 
 protected:
@@ -4414,6 +4412,7 @@ public:
   */
   StepperSDIRK_3Stage4thOrder()
   {
+    this->setStepperName("SDIRK 3 Stage 4th order");
     this->setStepperType("SDIRK 3 Stage 4th order");
     this->setupTableau();
     this->setupDefault();
@@ -4432,6 +4431,7 @@ public:
     bool zeroInitialGuess,
     const Teuchos::RCP<StepperRKAppAction<Scalar> >& stepperRKAppAction)
   {
+    this->setStepperName("SDIRK 3 Stage 4th order");
     this->setStepperType("SDIRK 3 Stage 4th order");
     this->setupTableau();
     this->setup(appModel, solver, useFSAL, ICConsistency, ICConsistencyCheck,
@@ -4456,14 +4456,6 @@ public:
                 << "    [ 2*gamma    1-4*gamma  gamma   ]\n"
                 << "b = [ delta      1-2*delta  delta   ]'";
     return Description.str();
-  }
-
-  Teuchos::RCP<const Teuchos::ParameterList>
-  getValidParameters() const
-  {
-    Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
-    this->getValidParametersBasicDIRK(pl);
-    return pl;
   }
 
 protected:
@@ -4569,6 +4561,7 @@ public:
   */
   StepperSDIRK_5Stage5thOrder()
   {
+    this->setStepperName("SDIRK 5 Stage 5th order");
     this->setStepperType("SDIRK 5 Stage 5th order");
     this->setupTableau();
     this->setupDefault();
@@ -4587,6 +4580,7 @@ public:
     bool zeroInitialGuess,
     const Teuchos::RCP<StepperRKAppAction<Scalar> >& stepperRKAppAction)
   {
+    this->setStepperName("SDIRK 5 Stage 5th order");
     this->setStepperType("SDIRK 5 Stage 5th order");
     this->setupTableau();
     this->setup(appModel, solver, useFSAL, ICConsistency, ICConsistencyCheck,
@@ -4639,14 +4633,6 @@ public:
       << "    [ (16-sqrt(6))/36 ]\n"
       << "    [ (16+sqrt(6))/36 ]'";
     return Description.str();
-  }
-
-  Teuchos::RCP<const Teuchos::ParameterList>
-  getValidParameters() const
-  {
-    Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
-    this->getValidParametersBasicDIRK(pl);
-    return pl;
   }
 
 protected:
@@ -4766,6 +4752,7 @@ public:
   */
   StepperSDIRK_21Pair()
   {
+    this->setStepperName("SDIRK 2(1) Pair");
     this->setStepperType("SDIRK 2(1) Pair");
     this->setupTableau();
     this->setupDefault();
@@ -4784,6 +4771,7 @@ public:
     bool zeroInitialGuess,
     const Teuchos::RCP<StepperRKAppAction<Scalar> >& stepperRKAppAction)
   {
+    this->setStepperName("SDIRK 2(1) Pair");
     this->setStepperType("SDIRK 2(1) Pair");
     this->setupTableau();
     this->setup(appModel, solver, useFSAL, ICConsistency, ICConsistencyCheck,
@@ -4800,14 +4788,6 @@ public:
                 << "b     = [ 1/2 1/2 ]'\n"
                 << "bstar = [  1  0   ]'";
     return Description.str();
-  }
-
-  Teuchos::RCP<const Teuchos::ParameterList>
-  getValidParameters() const
-  {
-    Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
-    this->getValidParametersBasicDIRK(pl);
-    return pl;
   }
 
 protected:
@@ -4911,6 +4891,7 @@ public:
   */
   StepperDIRK_General()
   {
+    this->setStepperName("General DIRK");
     this->setStepperType("General DIRK");
     this->setupTableau();
     this->setupDefault();
@@ -4936,6 +4917,7 @@ public:
     const int orderMax,
     const Teuchos::SerialDenseVector<int,Scalar>& bstar)
   {
+    this->setStepperName("General DIRK");
     this->setStepperType("General DIRK");
     this->setTableau(A,b,c,order,orderMin,orderMax,bstar);
 
@@ -5004,18 +4986,57 @@ public:
   Teuchos::RCP<const Teuchos::ParameterList>
   getValidParameters() const
   {
-    Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
-    this->getValidParametersBasicDIRK(pl);
+    auto pl = this->getValidParametersBasicDIRK();
 
     // Tableau ParameterList
+    Teuchos::SerialDenseMatrix<int,Scalar> A = this->tableau_->A();
+    Teuchos::SerialDenseVector<int,Scalar> b = this->tableau_->b();
+    Teuchos::SerialDenseVector<int,Scalar> c = this->tableau_->c();
+    Teuchos::SerialDenseVector<int,Scalar> bstar = this->tableau_->bstar();
+
     Teuchos::RCP<Teuchos::ParameterList> tableauPL = Teuchos::parameterList();
-    tableauPL->set<std::string>("A",
-     "0.2928932188134524 0.0; 0.7071067811865476 0.2928932188134524");
-    tableauPL->set<std::string>("b",
-     "0.7071067811865476 0.2928932188134524");
-    tableauPL->set<std::string>("c", "0.2928932188134524 1.0");
-    tableauPL->set<int>("order", 2);
-    tableauPL->set<std::string>("bstar", "");
+
+    std::ostringstream Astream;
+    Astream.precision(15);
+    for(int i = 0; i < A.numRows(); i++) {
+      for(int j = 0; j < A.numCols()-1; j++) {
+        Astream << A(i,j) << " ";
+      }
+      Astream << A(i,A.numCols()-1);
+      if ( i != A.numRows()-1 ) Astream << "; ";
+    }
+    tableauPL->set<std::string>("A", Astream.str());
+
+    std::ostringstream bstream;
+    bstream.precision(15);
+    for(int i = 0; i < b.length()-1; i++) {
+        bstream << b(i) << " ";
+    }
+    bstream << b(b.length()-1);
+    tableauPL->set<std::string>("b", bstream.str());
+
+    std::ostringstream cstream;
+    cstream.precision(15);
+    for(int i = 0; i < c.length()-1; i++) {
+        cstream << c(i) << " ";
+    }
+    cstream << c(c.length()-1);
+    tableauPL->set<std::string>("c", cstream.str());
+
+    tableauPL->set<int>("order", this->tableau_->order());
+
+    if ( bstar.length() == 0 ) {
+      tableauPL->set("bstar", "");
+    } else {
+      std::ostringstream bstarstream;
+      bstarstream.precision(15);
+      for(int i = 0; i < bstar.length()-1; i++) {
+          bstarstream << bstar(i) << " ";
+      }
+      bstarstream << bstar(bstar.length()-1);
+      tableauPL->set<std::string>("bstar", bstarstream.str());
+    }
+
     pl->set("Tableau", *tableauPL);
 
     return pl;

--- a/packages/tempus/src/Tempus_StepperStaggeredForwardSensitivity_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperStaggeredForwardSensitivity_impl.hpp
@@ -26,6 +26,7 @@ template<class Scalar>
 StepperStaggeredForwardSensitivity<Scalar>::
 StepperStaggeredForwardSensitivity()
 {
+  this->setStepperName(        "StaggeredForwardSensitivity");
   this->setStepperType(        "StaggeredForwardSensitivity");
   this->setParams(Teuchos::null, Teuchos::null);
 }
@@ -39,6 +40,7 @@ StepperStaggeredForwardSensitivity(
   const Teuchos::RCP<Teuchos::ParameterList>& sens_pList)
 {
   // Set all the input parameters and call initialize
+  this->setStepperName(        "StaggeredForwardSensitivity");
   this->setStepperType(        "StaggeredForwardSensitivity");
   this->setParams(pList, sens_pList);
   this->setModel(appModel);

--- a/packages/tempus/src/Tempus_StepperSubcycling_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperSubcycling_impl.hpp
@@ -28,6 +28,7 @@ StepperSubcycling<Scalar>::StepperSubcycling()
   using Teuchos::RCP;
   using Teuchos::ParameterList;
 
+  this->setStepperName(        "Subcycling");
   this->setStepperType(        "Subcycling");
   this->setUseFSAL(            false);
   this->setICConsistency(      "None");
@@ -39,7 +40,9 @@ StepperSubcycling<Scalar>::StepperSubcycling()
   scIntegrator_->setObserver(
     Teuchos::rcp(new IntegratorObserverNoOp<Scalar>()));
 
-  RCP<ParameterList> tempusPL = scIntegrator_->getTempusParameterList();
+  RCP<ParameterList> tempusPL =
+    Teuchos::rcp_const_cast<Teuchos::ParameterList> (
+      scIntegrator_->getValidParameters());
 
   { // Set default subcycling Stepper to Forward Euler.
     tempusPL->sublist("Default Integrator")
@@ -85,6 +88,7 @@ StepperSubcycling<Scalar>::StepperSubcycling(
   bool ICConsistencyCheck,
   const Teuchos::RCP<StepperSubcyclingAppAction<Scalar> >& stepperSCAppAction)
 {
+  this->setStepperName(        "Subcycling");
   this->setStepperType(        "Subcycling");
   this->setUseFSAL(            useFSAL);
   this->setICConsistency(      ICConsistency);
@@ -103,7 +107,7 @@ template<class Scalar>
 void StepperSubcycling<Scalar>::setSubcyclingStepper(
   Teuchos::RCP<Stepper<Scalar> > stepper)
 {
-  scIntegrator_->setStepperWStepper(stepper);
+  scIntegrator_->setStepper(stepper);
   this->isInitialized_ = false;
 }
 
@@ -238,7 +242,7 @@ int StepperSubcycling<Scalar>::getSubcyclingScreenOutputIndexInterval() const
 
 template<class Scalar>
 std::string StepperSubcycling<Scalar>::getSubcyclingScreenOutputIndexList() const
-{ return scIntegrator_->getScreenOutputIndexList(); }
+{ return scIntegrator_->getScreenOutputIndexListString(); }
 
 
 template<class Scalar>
@@ -260,7 +264,7 @@ template<class Scalar>
 void StepperSubcycling<Scalar>::setModel(
   const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel)
 {
-  scIntegrator_->setStepper(appModel);
+  scIntegrator_->setModel(appModel);
   this->isInitialized_ = false;
 }
 
@@ -380,7 +384,10 @@ void StepperSubcycling<Scalar>::setInitialGuess(
 template<class Scalar>
 void StepperSubcycling<Scalar>::setInitialConditions(
   const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory)
-{ scIntegrator_->getStepper()->setInitialConditions(solutionHistory); }
+{
+  scIntegrator_->getStepper()->setInitialConditions(solutionHistory);
+  scIntegrator_->setSolutionHistory(solutionHistory);
+}
 
 
 template<class Scalar>
@@ -520,11 +527,7 @@ StepperSubcycling<Scalar>::getValidParameters() const
     "Error - StepperSubcycling<Scalar>::getValidParameters()\n"
     "  is not implemented yet.\n");
 
-  Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
-  getValidParametersBasic(pl, this->getStepperType());
-  pl->set<bool>("Use FSAL", false);
-  pl->set<std::string>("Initial Condition Consistency", "None");
-  return pl;
+  return this->getValidParametersBasic();
 }
 
 
@@ -544,11 +547,7 @@ createStepperSubcycling(
 
   if (pl != Teuchos::null) {
     stepper->setStepperValues(pl);
-    //stepper->setStepperSubcyclingValues(pl);
   }
-  //else {
-  //  integrator->setTempusParameterList(Teuchos::null);
-  //}
 
   if (model != Teuchos::null) {
     stepper->setModel(model);

--- a/packages/tempus/src/Tempus_StepperTrapezoidal_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperTrapezoidal_decl.hpp
@@ -138,8 +138,6 @@ public:
   /// Return beta  = d(x)/dx.
   virtual Scalar getBeta (const Scalar   ) const { return Scalar(1.0); }
 
-  Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
-
   /// \name Overridden from Teuchos::Describable
   //@{
     virtual void describe(Teuchos::FancyOStream        & out,

--- a/packages/tempus/src/Tempus_StepperTrapezoidal_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperTrapezoidal_impl.hpp
@@ -41,8 +41,8 @@ StepperTrapezoidal<Scalar>::StepperTrapezoidal(
   bool zeroInitialGuess,
   const Teuchos::RCP<StepperTrapezoidalAppAction<Scalar> >& stepperTrapAppAction)
 {
-  this->setStepperName(        "Trapezoidal");
-  this->setStepperType(        "Trapezoidal");
+  this->setStepperName(        "Trapezoidal Method");
+  this->setStepperType(        "Trapezoidal Method");
   this->setUseFSAL(            useFSAL);
   this->setICConsistency(      ICConsistency);
   this->setICConsistencyCheck( ICConsistencyCheck);

--- a/packages/tempus/src/Tempus_StepperTrapezoidal_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperTrapezoidal_impl.hpp
@@ -19,6 +19,7 @@ namespace Tempus {
 template<class Scalar>
 StepperTrapezoidal<Scalar>::StepperTrapezoidal()
 {
+  this->setStepperName(        "Trapezoidal Method");
   this->setStepperType(        "Trapezoidal Method");
   this->setUseFSAL(            true);
   this->setICConsistency(      "Consistent");
@@ -40,6 +41,7 @@ StepperTrapezoidal<Scalar>::StepperTrapezoidal(
   bool zeroInitialGuess,
   const Teuchos::RCP<StepperTrapezoidalAppAction<Scalar> >& stepperTrapAppAction)
 {
+  this->setStepperName(        "Trapezoidal");
   this->setStepperType(        "Trapezoidal");
   this->setUseFSAL(            useFSAL);
   this->setICConsistency(      ICConsistency);
@@ -210,24 +212,6 @@ bool StepperTrapezoidal<Scalar>::isValidSetup(Teuchos::FancyOStream & out) const
   }
 
   return isValidSetup;
-}
-
-
-template<class Scalar>
-Teuchos::RCP<const Teuchos::ParameterList>
-StepperTrapezoidal<Scalar>::getValidParameters() const
-{
-  Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
-  getValidParametersBasic(pl, this->getStepperType());
-  pl->set<bool>       ("Use FSAL", true);
-  pl->set<std::string>("Initial Condition Consistency", "Consistent");
-  pl->set<bool>       ("Initial Condition Consistency Check", false);
-  pl->set<std::string>("Solver Name", "Default Solver");
-  pl->set<bool>       ("Zero Initial Guess", false);
-  Teuchos::RCP<Teuchos::ParameterList> solverPL = defaultSolverParameters();
-  pl->set("Default Solver", *solverPL);
-
-  return pl;
 }
 
 

--- a/packages/tempus/src/Tempus_Stepper_decl.hpp
+++ b/packages/tempus/src/Tempus_Stepper_decl.hpp
@@ -117,12 +117,32 @@ public:
     virtual bool isOneStepMethod() const = 0;
     virtual bool isMultiStepMethod() const = 0;
 
+    /// Set the stepper name.
     void setStepperName(std::string s) { stepperName_ = s;
       isInitialized_ = false; }
+
+    /** \brief Get the stepper name.
+     *
+     * The stepper name is just a name used to distinguish it during
+     * I/O and in ParameterLists, and can be anything the user would
+     * like.  One example is when two steppers of the same type
+     * (see getStepperType()) are being used during the same
+     * simulation.  The user can name one as "Stepper with settings 1"
+     * and the other as "Stepper with settings 2".  The default
+     * name is the stepper type (e.g., "BDF2" or "Bogacki-Shampine 3(2) Pair").
+     */
     std::string getStepperName() const { return stepperName_; }
 
+protected:
+    /// Set the stepper type.
     void setStepperType(std::string s) { stepperType_ = s;
       isInitialized_ = false; }
+
+public:
+    /** \brief Get the stepper type.
+     *  The stepper type is used as an identifier for the stepper,
+     *  and can only be set by the derived Stepper class.
+     */
     std::string getStepperType() const { return stepperType_; }
 
     virtual void setUseFSAL(bool a) { setUseFSALFalseOnly(a); }

--- a/packages/tempus/src/Tempus_Stepper_decl.hpp
+++ b/packages/tempus/src/Tempus_Stepper_decl.hpp
@@ -117,6 +117,10 @@ public:
     virtual bool isOneStepMethod() const = 0;
     virtual bool isMultiStepMethod() const = 0;
 
+    void setStepperName(std::string s) { stepperName_ = s;
+      isInitialized_ = false; }
+    std::string getStepperName() const { return stepperName_; }
+
     void setStepperType(std::string s) { stepperType_ = s;
       isInitialized_ = false; }
     std::string getStepperType() const { return stepperType_; }
@@ -163,13 +167,17 @@ public:
 
   virtual bool isValidSetup(Teuchos::FancyOStream & out) const;
 
-  virtual Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const = 0;
-
   /// Set Stepper member data from ParameterList.
   void setStepperValues(const Teuchos::RCP<Teuchos::ParameterList> pl);
 
+  virtual Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
+
+  /// Add basic parameters to Steppers ParameterList.
+  Teuchos::RCP<Teuchos::ParameterList> getValidParametersBasic() const;
+
 private:
 
+  std::string stepperName_;        ///< Name used for output and ParameterLists
   std::string stepperType_;        ///< Name of stepper type
   std::string ICConsistency_ = std::string("None");  ///< Type of consistency to apply to ICs.
   bool ICConsistencyCheck_ = false; ///< Check if the initial condition is consistent
@@ -200,10 +208,6 @@ protected:
 
 /// \name Helper functions
 //@{
-  /// Provide basic parameters to Steppers.
-  void getValidParametersBasic(
-    Teuchos::RCP<Teuchos::ParameterList> pl, std::string stepperType);
-
   /// Validate that the model supports explicit ODE evaluation, f(x,t) [=xdot]
   /** Currently the convention to evaluate f(x,t) is to set xdot=null!
    *  There is no InArgs support to test if xdot is null, so we set

--- a/packages/tempus/src/Tempus_Stepper_impl.hpp
+++ b/packages/tempus/src/Tempus_Stepper_impl.hpp
@@ -9,6 +9,8 @@
 #ifndef Tempus_Stepper_impl_hpp
 #define Tempus_Stepper_impl_hpp
 
+#include "NOX_Thyra.H"
+
 
 namespace Tempus {
 
@@ -160,6 +162,7 @@ void Stepper<Scalar>::
 setStepperValues(Teuchos::RCP<Teuchos::ParameterList> pl)
 {
   if (pl != Teuchos::null) {
+    this->setStepperName(pl->name());
     auto stepperType =
       pl->get<std::string>("Stepper Type", this->getStepperType());
     TEUCHOS_TEST_FOR_EXCEPTION(
@@ -169,25 +172,33 @@ setStepperValues(Teuchos::RCP<Teuchos::ParameterList> pl)
       + this->getStepperType() + "').");
     this->setStepperType(stepperType);
 
-    this->setUseFSAL(pl->get<bool>("Use FSAL", false));
+    this->setUseFSAL(pl->get<bool>("Use FSAL", this->getUseFSAL()));
     this->setICConsistency(
-      pl->get<std::string>("Initial Condition Consistency", "None"));
+      pl->get<std::string>("Initial Condition Consistency",
+                           this->getICConsistency()));
     this->setICConsistencyCheck(
-      pl->get<bool>("Initial Condition Consistency Check", false));
+      pl->get<bool>("Initial Condition Consistency Check",
+                    this->getICConsistencyCheck()));
   }
 }
 
 
-// Nonmember Helper Functions.
-// ------------------------------------------------------------------------
-
-void getValidParametersBasic(
-  Teuchos::RCP<Teuchos::ParameterList> pl, std::string stepperType)
+template<class Scalar>
+Teuchos::RCP<const Teuchos::ParameterList>
+Stepper<Scalar>::getValidParameters() const
 {
-  pl->setName("Default Stepper - " + stepperType);
-  pl->set<std::string>("Stepper Type", stepperType);
+  return this->getValidParametersBasic();
+}
 
-  pl->set<bool>("Use FSAL", false,
+
+template<class Scalar>
+Teuchos::RCP<Teuchos::ParameterList>
+Stepper<Scalar>::getValidParametersBasic() const
+{
+  auto pl = Teuchos::parameterList(this->getStepperName());
+  pl->template set<std::string>("Stepper Type", this->getStepperType());
+
+  pl->template set<bool>("Use FSAL", this->getUseFSAL(),
     "The First-Same-As-Last (FSAL) principle is the situation where the\n"
     "last function evaluation, f(x^{n-1},t^{n-1}) [a.k.a. xDot^{n-1}],\n"
     "can be used for the first function evaluation, f(x^n,t^n)\n"
@@ -208,7 +219,7 @@ void getValidParametersBasic(
     "Default in general for explicit and implicit steppers is false,\n"
     "but individual steppers can override this default.");
 
-  pl->set<std::string>("Initial Condition Consistency", "None",
+  pl->template set<std::string>("Initial Condition Consistency",this->getICConsistency(),
     "This indicates which type of consistency should be applied to\n"
     "the initial conditions (ICs):\n"
     "\n"
@@ -233,15 +244,20 @@ void getValidParametersBasic(
     "another Jacobian from the application.  Individual steppers may\n"
     "override these defaults.");
 
-  pl->set<bool>("Initial Condition Consistency Check", false,
+  pl->template set<bool>("Initial Condition Consistency Check", this->getICConsistencyCheck(),
     "Check if the initial condition, x and xDot, is consistent with the\n"
     "governing equations, xDot = f(x,t), or f(x, xDot, t) = 0.\n"
     "\n"
     "In general for explicit and implicit steppers, the default is true,\n"
     "because it is fairly cheap with just one residual evaluation.\n"
     "Individual steppers may override this default.");
+
+  return pl;
 }
 
+
+// Nonmember Helper Functions.
+// ------------------------------------------------------------------------
 
 template<class Scalar>
 void validExplicitODE(
@@ -403,64 +419,64 @@ Teuchos::RCP<Teuchos::ParameterList> defaultSolverParameters()
   // NOX Solver ParameterList
   RCP<ParameterList> noxPL = Teuchos::parameterList();
 
-    // Direction ParameterList
-    RCP<ParameterList> directionPL = Teuchos::parameterList();
-    directionPL->set<std::string>("Method", "Newton");
-      RCP<ParameterList> newtonPL = Teuchos::parameterList();
-      newtonPL->set<std::string>("Forcing Term Method", "Constant");
-      newtonPL->set<bool>       ("Rescue Bad Newton Solve", 1);
-      directionPL->set("Newton", *newtonPL);
-    noxPL->set("Direction", *directionPL);
+  // Direction ParameterList
+  RCP<ParameterList> directionPL = Teuchos::parameterList();
+  directionPL->set<std::string>("Method", "Newton");
+    RCP<ParameterList> newtonPL = Teuchos::parameterList();
+    newtonPL->set<std::string>("Forcing Term Method", "Constant");
+    newtonPL->set<bool>       ("Rescue Bad Newton Solve", 1);
+    directionPL->set("Newton", *newtonPL);
+  noxPL->set("Direction", *directionPL);
 
-    // Line Search ParameterList
-    RCP<ParameterList> lineSearchPL = Teuchos::parameterList();
-    lineSearchPL->set<std::string>("Method", "Full Step");
-      RCP<ParameterList> fullStepPL = Teuchos::parameterList();
-      fullStepPL->set<double>("Full Step", 1);
-      lineSearchPL->set("Full Step", *fullStepPL);
-    noxPL->set("Line Search", *lineSearchPL);
+  // Line Search ParameterList
+  RCP<ParameterList> lineSearchPL = Teuchos::parameterList();
+  lineSearchPL->set<std::string>("Method", "Full Step");
+    RCP<ParameterList> fullStepPL = Teuchos::parameterList();
+    fullStepPL->set<double>("Full Step", 1);
+    lineSearchPL->set("Full Step", *fullStepPL);
+  noxPL->set("Line Search", *lineSearchPL);
 
-    noxPL->set<std::string>("Nonlinear Solver", "Line Search Based");
+  noxPL->set<std::string>("Nonlinear Solver", "Line Search Based");
 
-    // Printing ParameterList
-    RCP<ParameterList> printingPL = Teuchos::parameterList();
-    printingPL->set<int>("Output Precision", 3);
-    printingPL->set<int>("Output Processor", 0);
-      RCP<ParameterList> outputPL = Teuchos::parameterList();
-      outputPL->set<bool>("Error", 1);
-      outputPL->set<bool>("Warning", 1);
-      outputPL->set<bool>("Outer Iteration", 0);
-      outputPL->set<bool>("Parameters", 0);
-      outputPL->set<bool>("Details", 0);
-      outputPL->set<bool>("Linear Solver Details", 1);
-      outputPL->set<bool>("Stepper Iteration", 1);
-      outputPL->set<bool>("Stepper Details", 1);
-      outputPL->set<bool>("Stepper Parameters", 1);
-      printingPL->set("Output Information", *outputPL);
-    noxPL->set("Printing", *printingPL);
+  // Printing ParameterList
+  RCP<ParameterList> printingPL = Teuchos::parameterList();
+  printingPL->set<int>("Output Precision", 3);
+  printingPL->set<int>("Output Processor", 0);
+    RCP<ParameterList> outputPL = Teuchos::parameterList();
+    outputPL->set<bool>("Error", 1);
+    outputPL->set<bool>("Warning", 1);
+    outputPL->set<bool>("Outer Iteration", 0);
+    outputPL->set<bool>("Parameters", 0);
+    outputPL->set<bool>("Details", 0);
+    outputPL->set<bool>("Linear Solver Details", 1);
+    outputPL->set<bool>("Stepper Iteration", 1);
+    outputPL->set<bool>("Stepper Details", 1);
+    outputPL->set<bool>("Stepper Parameters", 1);
+    printingPL->set("Output Information", *outputPL);
+  noxPL->set("Printing", *printingPL);
 
-    // Solver Options ParameterList
-    RCP<ParameterList> solverOptionsPL = Teuchos::parameterList();
-    solverOptionsPL->set<std::string>("Status Test Check Type", "Minimal");
-    noxPL->set("Solver Options", *solverOptionsPL);
+  // Solver Options ParameterList
+  RCP<ParameterList> solverOptionsPL = Teuchos::parameterList();
+  solverOptionsPL->set<std::string>("Status Test Check Type", "Minimal");
+  noxPL->set("Solver Options", *solverOptionsPL);
 
-    // Status Tests ParameterList
-    RCP<ParameterList> statusTestsPL = Teuchos::parameterList();
-    statusTestsPL->set<std::string>("Test Type", "Combo");
-    statusTestsPL->set<std::string>("Combo Type", "OR");
-    statusTestsPL->set<int>("Number of Tests", 2);
-      RCP<ParameterList> test0PL = Teuchos::parameterList();
-      test0PL->set<std::string>("Test Type", "NormF");
-      test0PL->set<double>("Tolerance", 1e-08);
-      statusTestsPL->set("Test 0", *test0PL);
-      RCP<ParameterList> test1PL = Teuchos::parameterList();
-      test1PL->set<std::string>("Test Type", "MaxIters");
-      test1PL->set<int>("Maximum Iterations", 10);
-      statusTestsPL->set("Test 1", *test1PL);
-    noxPL->set("Status Tests", *statusTestsPL);
+  // Status Tests ParameterList
+  RCP<ParameterList> statusTestsPL = Teuchos::parameterList();
+  statusTestsPL->set<std::string>("Test Type", "Combo");
+  statusTestsPL->set<std::string>("Combo Type", "OR");
+  statusTestsPL->set<int>("Number of Tests", 2);
+    RCP<ParameterList> test0PL = Teuchos::parameterList();
+    test0PL->set<std::string>("Test Type", "NormF");
+    test0PL->set<double>("Tolerance", 1e-08);
+    statusTestsPL->set("Test 0", *test0PL);
+    RCP<ParameterList> test1PL = Teuchos::parameterList();
+    test1PL->set<std::string>("Test Type", "MaxIters");
+    test1PL->set<int>("Maximum Iterations", 10);
+    statusTestsPL->set("Test 1", *test1PL);
+  noxPL->set("Status Tests", *statusTestsPL);
 
   // Solver ParameterList
-  RCP<ParameterList> solverPL = Teuchos::parameterList();
+  RCP<ParameterList> solverPL = Teuchos::parameterList("Default Solver");
   solverPL->set("NOX", *noxPL);
 
   return solverPL;

--- a/packages/tempus/src/Tempus_TimeStepControlStrategy.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategy.hpp
@@ -9,9 +9,6 @@
 #ifndef Tempus_TimeStepControlStrategy_hpp
 #define Tempus_TimeStepControlStrategy_hpp
 
-// Teuchos
-#include "Teuchos_ParameterListAcceptorDefaultBase.hpp"
-
 #include "Tempus_config.hpp"
 #include "Tempus_SolutionHistory.hpp"
 

--- a/packages/tempus/test/BDF2/Tempus_BDF2Test.cpp
+++ b/packages/tempus/test/BDF2/Tempus_BDF2Test.cpp
@@ -65,12 +65,12 @@ TEUCHOS_UNIT_TEST(BDF2, ParameterList)
   // Test constructor IntegratorBasic(tempusPL, model)
   {
     RCP<Tempus::IntegratorBasic<double> > integrator =
-      Tempus::integratorBasic<double>(tempusPL, model);
+      Tempus::createIntegratorBasic<double>(tempusPL, model);
 
     RCP<ParameterList> stepperPL = sublist(tempusPL, "Default Stepper", true);
     RCP<const ParameterList> defaultPL =
       integrator->getStepper()->getValidParameters();
-    bool pass = haveSameValues(*stepperPL, *defaultPL, true);
+    bool pass = haveSameValuesSorted(*stepperPL, *defaultPL, true);
     if (!pass) {
       std::cout << std::endl;
       std::cout << "stepperPL -------------- \n" << *stepperPL << std::endl;
@@ -82,13 +82,13 @@ TEUCHOS_UNIT_TEST(BDF2, ParameterList)
   // Test constructor IntegratorBasic(model, stepperType)
   {
     RCP<Tempus::IntegratorBasic<double> > integrator =
-      Tempus::integratorBasic<double>(model, "BDF2");
+      Tempus::createIntegratorBasic<double>(model, "BDF2");
 
     RCP<ParameterList> stepperPL = sublist(tempusPL, "Default Stepper", true);
     RCP<const ParameterList> defaultPL =
       integrator->getStepper()->getValidParameters();
 
-    bool pass = haveSameValues(*stepperPL, *defaultPL, true);
+    bool pass = haveSameValuesSorted(*stepperPL, *defaultPL, true);
     if (!pass) {
       std::cout << std::endl;
       std::cout << "stepperPL -------------- \n" << *stepperPL << std::endl;
@@ -140,8 +140,7 @@ TEUCHOS_UNIT_TEST(BDF2, ConstructingFromDefaults)
     timeStepControl->initialize();
 
     // Setup initial condition SolutionState --------------------
-    Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
-      stepper->getModel()->getNominalValues();
+    auto inArgsIC = model->getNominalValues();
     auto icSolution = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
     auto icState = Tempus::createSolutionStateX(icSolution);
     icState->setTime    (timeStepControl->getInitTime());
@@ -157,10 +156,13 @@ TEUCHOS_UNIT_TEST(BDF2, ConstructingFromDefaults)
     solutionHistory->setStorageLimit(3);
     solutionHistory->addState(icState);
 
+    // Ensure ICs are consistent and stepper memory is set (e.g., xDot is set).
+    stepper->setInitialConditions(solutionHistory);
+
     // Setup Integrator -----------------------------------------
     RCP<Tempus::IntegratorBasic<double> > integrator =
-      Tempus::integratorBasic<double>();
-    integrator->setStepperWStepper(stepper);
+      Tempus::createIntegratorBasic<double>();
+    integrator->setStepper(stepper);
     integrator->setTimeStepControl(timeStepControl);
     integrator->setSolutionHistory(solutionHistory);
     //integrator->setObserver(...);
@@ -216,35 +218,33 @@ TEUCHOS_UNIT_TEST(BDF2, SinCos)
   // Read params from .xml file
   RCP<ParameterList> pList = getParametersFromXmlFile("Tempus_BDF2_SinCos.xml");
   //Set initial time step = 2*dt specified in input file (for convergence study)
-  //
-  RCP<ParameterList> pl = sublist(pList, "Tempus", true);
-  double dt = pl->sublist("Default Integrator")
-       .sublist("Time Step Control").get<double>("Initial Time Step");
+  double dt = pList->sublist("Tempus")
+             .sublist("Default Integrator")
+             .sublist("Time Step Control").get<double>("Initial Time Step");
   dt *= 2.0;
 
   // Setup the SinCosModel
   RCP<ParameterList> scm_pl = sublist(pList, "SinCosModel", true);
   const int nTimeStepSizes = scm_pl->get<int>("Number of Time Step Sizes", 7);
   std::string output_file_string =
-                    scm_pl->get<std::string>("Output File Name", "Tempus_BDF2_SinCos");
+    scm_pl->get<std::string>("Output File Name", "Tempus_BDF2_SinCos");
   std::string output_file_name = output_file_string + ".dat";
   std::string ref_out_file_name = output_file_string + "-Ref.dat";
   std::string err_out_file_name = output_file_string + "-Error.dat";
   double time = 0.0;
   for (int n=0; n<nTimeStepSizes; n++) {
 
-    //std::ofstream ftmp("PL.txt");
-    //pList->print(ftmp);
-    //ftmp.close();
-
     auto model = rcp(new SinCosModel<double>(scm_pl));
 
     dt /= 2;
 
     // Setup the Integrator and reset initial time step
+    RCP<ParameterList> tempusPL =
+      getParametersFromXmlFile("Tempus_BDF2_SinCos.xml");
+    RCP<ParameterList> pl = sublist(tempusPL, "Tempus", true);
     pl->sublist("Default Integrator")
        .sublist("Time Step Control").set("Initial Time Step", dt);
-    integrator = Tempus::integratorBasic<double>(pl, model);
+    integrator = Tempus::createIntegratorBasic<double>(pl, model);
 
     // Initial Conditions
     // During the Integrator construction, the initial SolutionState
@@ -260,7 +260,7 @@ TEUCHOS_UNIT_TEST(BDF2, SinCos)
 
     // Test if at 'Final Time'
     time = integrator->getTime();
-    double timeFinal =pl->sublist("Default Integrator")
+    double timeFinal = pl->sublist("Default Integrator")
        .sublist("Time Step Control").get<double>("Final Time");
     TEST_FLOATING_EQUALITY(time, timeFinal, 1.0e-14);
 
@@ -341,8 +341,9 @@ TEUCHOS_UNIT_TEST(BDF2, SinCosAdapt)
     getParametersFromXmlFile("Tempus_BDF2_SinCos_AdaptDt.xml");
   //Set initial time step = 2*dt specified in input file (for convergence study)
   RCP<ParameterList> pl = sublist(pList, "Tempus", true);
-  double dt = pl->sublist("Default Integrator")
-       .sublist("Time Step Control").get<double>("Initial Time Step");
+  double dt = pList->sublist("Tempus")
+             .sublist("Default Integrator")
+             .sublist("Time Step Control").get<double>("Initial Time Step");
   dt *= 2.0;
 
   // Setup the SinCosModel
@@ -355,13 +356,13 @@ TEUCHOS_UNIT_TEST(BDF2, SinCosAdapt)
   double time = 0.0;
   for (int n=0; n<nTimeStepSizes; n++) {
 
-    //std::ofstream ftmp("PL.txt");
-    //pList->print(ftmp);
-    //ftmp.close();
-
     auto model = rcp(new SinCosModel<double>(scm_pl));
 
     dt /= 2;
+
+    RCP<ParameterList> tempusPL =
+      getParametersFromXmlFile("Tempus_BDF2_SinCos_AdaptDt.xml");
+    RCP<ParameterList> pl = sublist(tempusPL, "Tempus", true);
 
     // Setup the Integrator and reset initial time step
     pl->sublist("Default Integrator")
@@ -378,7 +379,7 @@ TEUCHOS_UNIT_TEST(BDF2, SinCosAdapt)
        .sublist("Time Step Control")
        .sublist("Time Step Control Strategy")
        .set("Minimum Value Monitoring Function", dt*0.99);
-    integrator = Tempus::integratorBasic<double>(pl, model);
+    integrator = Tempus::createIntegratorBasic<double>(pl, model);
 
     // Initial Conditions
     // During the Integrator construction, the initial SolutionState
@@ -539,7 +540,7 @@ TEUCHOS_UNIT_TEST(BDF2, CDR)
     // Setup the Integrator and reset initial time step
     pl->sublist("Demo Integrator")
        .sublist("Time Step Control").set("Initial Time Step", dt);
-    integrator = Tempus::integratorBasic<double>(pl, model);
+    integrator = Tempus::createIntegratorBasic<double>(pl, model);
 
     // Integrate to timeMax
     bool integratorStatus = integrator->advanceTime();
@@ -673,7 +674,7 @@ TEUCHOS_UNIT_TEST(BDF2, VanDerPol)
     pl->sublist("Demo Integrator")
        .sublist("Time Step Control").set("Initial Time Step", dt);
     RCP<Tempus::IntegratorBasic<double> > integrator =
-      Tempus::integratorBasic<double>(pl, model);
+      Tempus::createIntegratorBasic<double>(pl, model);
     order = integrator->getStepper()->getOrder();
 
     // Integrate to timeMax

--- a/packages/tempus/test/BDF2/Tempus_BDF2_SteadyQuadratic.xml
+++ b/packages/tempus/test/BDF2/Tempus_BDF2_SteadyQuadratic.xml
@@ -41,7 +41,7 @@
       <Parameter name="Initial Condition Consistency Check" type="bool" value="false"/>
       <Parameter name="Zero Initial Guess" type="bool" value="0"/>
       <Parameter name="Solver Name"    type="string" value="Default Solver"/>
-      <Parameter name="Start Up Stepper Name" type="string" value="RK Forward Euler"/>
+      <Parameter name="Start Up Stepper Type" type="string" value="RK Forward Euler"/>
       <ParameterList name="Default Solver">
         <ParameterList name="NOX">
           <ParameterList name="Direction">

--- a/packages/tempus/test/BDF2/Tempus_BDF2_VanDerPol.xml
+++ b/packages/tempus/test/BDF2/Tempus_BDF2_VanDerPol.xml
@@ -54,7 +54,7 @@
       <Parameter name="Initial Condition Consistency Check" type="bool" value="false"/>
       <Parameter name="Zero Initial Guess" type="bool" value="0"/>
       <Parameter name="Solver Name"    type="string" value="Demo Solver"/>
-      <Parameter name="Start Up Stepper Name" type="string" value="Backward Euler"/>
+      <Parameter name="Start Up Stepper Type" type="string" value="Backward Euler"/>
       <ParameterList name="Demo Solver">
         <ParameterList name="NOX">
           <ParameterList name="Direction">

--- a/packages/tempus/test/BackwardEuler/Tempus_BackwardEulerTest.cpp
+++ b/packages/tempus/test/BackwardEuler/Tempus_BackwardEulerTest.cpp
@@ -65,15 +65,13 @@ TEUCHOS_UNIT_TEST(BackwardEuler, ParameterList)
   // Test constructor IntegratorBasic(tempusPL, model)
   {
     RCP<Tempus::IntegratorBasic<double> > integrator =
-      Tempus::integratorBasic<double>(tempusPL, model);
+      Tempus::createIntegratorBasic<double>(tempusPL, model);
 
     RCP<ParameterList> stepperPL = sublist(tempusPL, "Default Stepper", true);
-    // Match Predictor for comparison
-    stepperPL->set("Predictor Stepper Type", "None");
     RCP<const ParameterList> defaultPL =
       integrator->getStepper()->getValidParameters();
 
-    bool pass = haveSameValues(*stepperPL, *defaultPL, true);
+    bool pass = haveSameValuesSorted(*stepperPL, *defaultPL, true);
     if (!pass) {
       std::cout << std::endl;
       std::cout << "stepperPL -------------- \n" << *stepperPL << std::endl;
@@ -85,13 +83,15 @@ TEUCHOS_UNIT_TEST(BackwardEuler, ParameterList)
   // Test constructor IntegratorBasic(model, stepperType)
   {
     RCP<Tempus::IntegratorBasic<double> > integrator =
-      Tempus::integratorBasic<double>(model, "Backward Euler");
+      Tempus::createIntegratorBasic<double>(model, "Backward Euler");
 
     RCP<ParameterList> stepperPL = sublist(tempusPL, "Default Stepper", true);
+    // Match Predictor for comparison
+    stepperPL->set("Predictor Stepper Type", "None");
     RCP<const ParameterList> defaultPL =
       integrator->getStepper()->getValidParameters();
 
-    bool pass = haveSameValues(*stepperPL, *defaultPL, true);
+    bool pass = haveSameValuesSorted(*stepperPL, *defaultPL, true);
     if (!pass) {
       std::cout << std::endl;
       std::cout << "stepperPL -------------- \n" << *stepperPL << std::endl;
@@ -143,8 +143,7 @@ TEUCHOS_UNIT_TEST(BackwardEuler, ConstructingFromDefaults)
     timeStepControl->initialize();
 
     // Setup initial condition SolutionState --------------------
-    Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
-      stepper->getModel()->getNominalValues();
+    auto inArgsIC = model->getNominalValues();
     auto icSolution =
       rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
     auto icState = Tempus::createSolutionStateX(icSolution);
@@ -161,10 +160,13 @@ TEUCHOS_UNIT_TEST(BackwardEuler, ConstructingFromDefaults)
     solutionHistory->setStorageLimit(2);
     solutionHistory->addState(icState);
 
+    // Ensure ICs are consistent and stepper memory is set (e.g., xDot is set).
+    stepper->setInitialConditions(solutionHistory);
+
     // Setup Integrator -----------------------------------------
     RCP<Tempus::IntegratorBasic<double> > integrator =
-      Tempus::integratorBasic<double>();
-    integrator->setStepperWStepper(stepper);
+      Tempus::createIntegratorBasic<double>();
+    integrator->setStepper(stepper);
     integrator->setTimeStepControl(timeStepControl);
     integrator->setSolutionHistory(solutionHistory);
     //integrator->setObserver(...);
@@ -242,7 +244,7 @@ TEUCHOS_UNIT_TEST(BackwardEuler, SinCos)
     RCP<ParameterList> pl = sublist(pList, "Tempus", true);
     pl->sublist("Default Integrator")
        .sublist("Time Step Control").set("Initial Time Step", dt);
-    integrator = Tempus::integratorBasic<double>(pl, model);
+    integrator = Tempus::createIntegratorBasic<double>(pl, model);
 
     // Initial Conditions
     // During the Integrator construction, the initial SolutionState
@@ -382,7 +384,7 @@ TEUCHOS_UNIT_TEST(BackwardEuler, CDR)
     RCP<ParameterList> pl = sublist(pList, "Tempus", true);
     pl->sublist("Demo Integrator")
        .sublist("Time Step Control").set("Initial Time Step", dt);
-    integrator = Tempus::integratorBasic<double>(pl, model);
+    integrator = Tempus::createIntegratorBasic<double>(pl, model);
 
     // Integrate to timeMax
     bool integratorStatus = integrator->advanceTime();
@@ -507,7 +509,7 @@ TEUCHOS_UNIT_TEST(BackwardEuler, VanDerPol)
     RCP<ParameterList> pl = sublist(pList, "Tempus", true);
     pl->sublist("Demo Integrator")
        .sublist("Time Step Control").set("Initial Time Step", dt);
-    integrator = Tempus::integratorBasic<double>(pl, model);
+    integrator = Tempus::createIntegratorBasic<double>(pl, model);
 
     // Integrate to timeMax
     bool integratorStatus = integrator->advanceTime();
@@ -576,7 +578,7 @@ TEUCHOS_UNIT_TEST(BackwardEuler, OptInterface)
   // Setup the Integrator
   RCP<ParameterList> pl = sublist(pList, "Tempus", true);
   RCP<Tempus::IntegratorBasic<double> >integrator =
-    Tempus::integratorBasic<double>(pl, model);
+    Tempus::createIntegratorBasic<double>(pl, model);
 
   // Integrate to timeMax
   bool integratorStatus = integrator->advanceTime();

--- a/packages/tempus/test/DIRK/Tempus_DIRKTest.cpp
+++ b/packages/tempus/test/DIRK/Tempus_DIRKTest.cpp
@@ -81,6 +81,8 @@ TEUCHOS_UNIT_TEST(DIRK, ParameterList)
       RCP<ParameterList> stepperPL = sublist(tempusPL, "Default Stepper", true);
       RCP<ParameterList> solverPL = parameterList();
       *solverPL  = *(sublist(stepperPL, "Default Solver", true));
+      if (RKMethods[m] == "EDIRK 2 Stage Theta Method")
+        tempusPL->sublist("Default Stepper").set<bool>("Use FSAL", 1);
       tempusPL->sublist("Default Stepper").remove("Zero Initial Guess");
       tempusPL->sublist("Default Stepper").remove("Default Solver");
       tempusPL->sublist("Default Stepper").set<bool>("Zero Initial Guess", 0);
@@ -116,16 +118,19 @@ TEUCHOS_UNIT_TEST(DIRK, ParameterList)
            .set<std::string>("Gamma Type", "3rd Order A-stable");
       tempusPL->sublist("Default Stepper")
            .set<double>("gamma", 0.7886751345948128);
+    } else if (RKMethods[m] == "RK Trapezoidal Rule") {
+      tempusPL->sublist("Default Stepper").set<bool>("Use FSAL", 1);
     } else if (RKMethods[m] == "RK Crank-Nicolson") {
+      tempusPL->sublist("Default Stepper").set<bool>("Use FSAL", 1);
       // Match default Stepper Type
       tempusPL->sublist("Default Stepper")
                    .set("Stepper Type", "RK Trapezoidal Rule");
     } else if (RKMethods[m] == "General DIRK") {
       // Add the default tableau.
       Teuchos::RCP<Teuchos::ParameterList> tableauPL = Teuchos::parameterList();
-      tableauPL->set<std::string>("A", "0.2928932188134524 0.0; 0.7071067811865476 0.2928932188134524");
-      tableauPL->set<std::string>("b", "0.7071067811865476 0.2928932188134524");
-      tableauPL->set<std::string>("c", "0.2928932188134524 1.0");
+      tableauPL->set<std::string>("A", "0.292893218813452 0; 0.707106781186548 0.292893218813452");
+      tableauPL->set<std::string>("b", "0.707106781186548 0.292893218813452");
+      tableauPL->set<std::string>("c", "0.292893218813452 1");
       tableauPL->set<int>("order", 2);
       tableauPL->set<std::string>("bstar", "");
       tempusPL->sublist("Default Stepper").set("Tableau", *tableauPL);
@@ -135,15 +140,14 @@ TEUCHOS_UNIT_TEST(DIRK, ParameterList)
     // Test constructor IntegratorBasic(tempusPL, model)
     {
       RCP<Tempus::IntegratorBasic<double> > integrator =
-        Tempus::integratorBasic<double>(tempusPL, model);
+        Tempus::createIntegratorBasic<double>(tempusPL, model);
 
       RCP<ParameterList> stepperPL = sublist(tempusPL, "Default Stepper", true);
       RCP<ParameterList> defaultPL =
         Teuchos::rcp_const_cast<Teuchos::ParameterList>(
           integrator->getStepper()->getValidParameters());
-      defaultPL->remove("Description");
 
-      bool pass = haveSameValues(*stepperPL, *defaultPL, true);
+      bool pass = haveSameValuesSorted(*stepperPL, *defaultPL, true);
       if (!pass) {
         std::cout << std::endl;
         std::cout << "stepperPL -------------- \n" << *stepperPL << std::endl;
@@ -155,15 +159,26 @@ TEUCHOS_UNIT_TEST(DIRK, ParameterList)
     // Test constructor IntegratorBasic(model, stepperType)
     {
       RCP<Tempus::IntegratorBasic<double> > integrator =
-        Tempus::integratorBasic<double>(model, RKMethods[m]);
+        Tempus::createIntegratorBasic<double>(model, RKMethods[m]);
 
       RCP<ParameterList> stepperPL = sublist(tempusPL, "Default Stepper", true);
       RCP<ParameterList> defaultPL =
         Teuchos::rcp_const_cast<Teuchos::ParameterList>(
           integrator->getStepper()->getValidParameters());
-      defaultPL->remove("Description");
 
-      bool pass = haveSameValues(*stepperPL, *defaultPL, true);
+      // These Steppers have 'Initial Condition Consistency = Consistent'
+      // set as the default, so the ParameterList has been modified by
+      // NOX (filled in default parameters).  Thus solver comparison
+      // will be removed.
+      if (RKMethods[m] == "EDIRK 2 Stage Theta Method" ||
+          RKMethods[m] == "RK Trapezoidal Rule" ||
+          RKMethods[m] == "RK Crank-Nicolson") {
+        stepperPL->set<std::string>("Initial Condition Consistency", "Consistent");
+        stepperPL->remove("Default Solver");
+        defaultPL->remove("Default Solver");
+      }
+
+      bool pass = haveSameValuesSorted(*stepperPL, *defaultPL, true);
       if (!pass) {
         std::cout << std::endl;
         std::cout << "stepperPL -------------- \n" << *stepperPL << std::endl;
@@ -219,8 +234,7 @@ TEUCHOS_UNIT_TEST(DIRK, ConstructingFromDefaults)
     timeStepControl->initialize();
 
     // Setup initial condition SolutionState --------------------
-    Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
-      stepper->getModel()->getNominalValues();
+    auto inArgsIC = model->getNominalValues();
     auto icSolution = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
     auto icState = Tempus::createSolutionStateX(icSolution);
     icState->setTime    (timeStepControl->getInitTime());
@@ -238,8 +252,8 @@ TEUCHOS_UNIT_TEST(DIRK, ConstructingFromDefaults)
 
     // Setup Integrator -----------------------------------------
     RCP<Tempus::IntegratorBasic<double> > integrator =
-      Tempus::integratorBasic<double>();
-    integrator->setStepperWStepper(stepper);
+      Tempus::createIntegratorBasic<double>();
+    integrator->setStepper(stepper);
     integrator->setTimeStepControl(timeStepControl);
     integrator->setSolutionHistory(solutionHistory);
     //integrator->setObserver(...);
@@ -312,7 +326,7 @@ TEUCHOS_UNIT_TEST(DIRK, useFSAL_false)
     timeStepControl->initialize();
 
     // Setup initial condition SolutionState --------------------
-    auto inArgsIC = stepper->getModel()->getNominalValues();
+    auto inArgsIC = model->getNominalValues();
     auto icSolution = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
     auto icState = Tempus::createSolutionStateX(icSolution);
     icState->setTime    (timeStepControl->getInitTime());
@@ -329,8 +343,8 @@ TEUCHOS_UNIT_TEST(DIRK, useFSAL_false)
     solutionHistory->addState(icState);
 
     // Setup Integrator -----------------------------------------
-    auto integrator = Tempus::integratorBasic<double>();
-    integrator->setStepperWStepper(stepper);
+    auto integrator = Tempus::createIntegratorBasic<double>();
+    integrator->setStepper(stepper);
     integrator->setTimeStepControl(timeStepControl);
     integrator->setSolutionHistory(solutionHistory);
     integrator->initialize();
@@ -471,7 +485,7 @@ TEUCHOS_UNIT_TEST(DIRK, SinCos)
       // Setup the Integrator and reset initial time step
       pl->sublist("Default Integrator")
          .sublist("Time Step Control").set("Initial Time Step", dt);
-      integrator = Tempus::integratorBasic<double>(pl, model);
+      integrator = Tempus::createIntegratorBasic<double>(pl, model);
 
       // Initial Conditions
       // During the Integrator construction, the initial SolutionState
@@ -595,7 +609,7 @@ TEUCHOS_UNIT_TEST(DIRK, VanDerPol)
     // Setup the Integrator and reset initial time step
     pl->sublist("Default Integrator")
        .sublist("Time Step Control").set("Initial Time Step", dt);
-    integrator = Tempus::integratorBasic<double>(pl, model);
+    integrator = Tempus::createIntegratorBasic<double>(pl, model);
 
     // Integrate to timeMax
     bool integratorStatus = integrator->advanceTime();
@@ -679,7 +693,7 @@ TEUCHOS_UNIT_TEST(DIRK, EmbeddedVanDerPol)
 
       // Setup the Integrator
       RCP<Tempus::IntegratorBasic<double> > integrator =
-         Tempus::integratorBasic<double>(pl, model);
+         Tempus::createIntegratorBasic<double>(pl, model);
 
      const std::string RKMethod_ =
         pl->sublist(integratorChoice).get<std::string>("Stepper Name");

--- a/packages/tempus/test/ExplicitRK/Tempus_ExplicitRKTest.cpp
+++ b/packages/tempus/test/ExplicitRK/Tempus_ExplicitRKTest.cpp
@@ -80,14 +80,10 @@ TEUCHOS_UNIT_TEST(ExplicitRK, ParameterList)
       tempusPL->sublist("Demo Stepper").set("Stepper Type", RKMethods[m]);
     }
 
-    // Set IC consistency to default value.
-    tempusPL->sublist("Demo Stepper")
-                 .set("Initial Condition Consistency", "None");
-
     // Test constructor IntegratorBasic(tempusPL, model)
     {
       RCP<Tempus::IntegratorBasic<double> > integrator =
-        Tempus::integratorBasic<double>(tempusPL, model);
+        Tempus::createIntegratorBasic<double>(tempusPL, model);
 
       RCP<ParameterList> stepperPL = sublist(tempusPL, "Demo Stepper", true);
       if (RKMethods[m] == "General ERK")
@@ -95,9 +91,8 @@ TEUCHOS_UNIT_TEST(ExplicitRK, ParameterList)
       RCP<ParameterList> defaultPL =
         Teuchos::rcp_const_cast<Teuchos::ParameterList>(
           integrator->getStepper()->getValidParameters());
-      defaultPL->remove("Description");
 
-      bool pass = haveSameValues(*stepperPL, *defaultPL, true);
+      bool pass = haveSameValuesSorted(*stepperPL, *defaultPL, true);
       if (!pass) {
         std::cout << std::endl;
         std::cout << "stepperPL -------------- \n" << *stepperPL << std::endl;
@@ -106,10 +101,26 @@ TEUCHOS_UNIT_TEST(ExplicitRK, ParameterList)
       TEST_ASSERT(pass)
     }
 
+    // Adjust tempusPL to default values.
+    if (RKMethods[m] == "General ERK") {
+      tempusPL->sublist("Demo Stepper 2")
+                   .set("Initial Condition Consistency", "None");
+    }
+    if (RKMethods[m] == "RK Forward Euler" ||
+        RKMethods[m] == "Bogacki-Shampine 3(2) Pair") {
+      tempusPL->sublist("Demo Stepper")
+                   .set("Initial Condition Consistency", "Consistent");
+      tempusPL->sublist("Demo Stepper")
+                   .set("Use FSAL", true);
+    } else {
+      tempusPL->sublist("Demo Stepper")
+                   .set("Initial Condition Consistency", "None");
+    }
+
     // Test constructor IntegratorBasic(model, stepperType)
     {
       RCP<Tempus::IntegratorBasic<double> > integrator =
-        Tempus::integratorBasic<double>(model, RKMethods[m]);
+        Tempus::createIntegratorBasic<double>(model, RKMethods[m]);
 
       RCP<ParameterList> stepperPL = sublist(tempusPL, "Demo Stepper", true);
       if (RKMethods[m] == "General ERK")
@@ -117,9 +128,8 @@ TEUCHOS_UNIT_TEST(ExplicitRK, ParameterList)
       RCP<ParameterList> defaultPL =
         Teuchos::rcp_const_cast<Teuchos::ParameterList>(
           integrator->getStepper()->getValidParameters());
-      defaultPL->remove("Description");
 
-      bool pass = haveSameValues(*stepperPL, *defaultPL, true);
+      bool pass = haveSameValuesSorted(*stepperPL, *defaultPL, true);
       if (!pass) {
         std::cout << std::endl;
         std::cout << "stepperPL -------------- \n" << *stepperPL << std::endl;
@@ -175,8 +185,7 @@ TEUCHOS_UNIT_TEST(ExplicitRK, ConstructingFromDefaults)
     timeStepControl->initialize();
 
     // Setup initial condition SolutionState --------------------
-    Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
-      stepper->getModel()->getNominalValues();
+    auto inArgsIC = model->getNominalValues();
     auto icSolution = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
     auto icState = Tempus::createSolutionStateX(icSolution);
     icState->setTime    (timeStepControl->getInitTime());
@@ -194,8 +203,8 @@ TEUCHOS_UNIT_TEST(ExplicitRK, ConstructingFromDefaults)
 
     // Setup Integrator -----------------------------------------
     RCP<Tempus::IntegratorBasic<double> > integrator =
-      Tempus::integratorBasic<double>();
-    integrator->setStepperWStepper(stepper);
+      Tempus::createIntegratorBasic<double>();
+    integrator->setStepper(stepper);
     integrator->setTimeStepControl(timeStepControl);
     integrator->setSolutionHistory(solutionHistory);
     //integrator->setObserver(...);
@@ -268,7 +277,7 @@ TEUCHOS_UNIT_TEST(ExplicitRK, useFSAL_false)
     timeStepControl->initialize();
 
     // Setup initial condition SolutionState --------------------
-    auto inArgsIC = stepper->getModel()->getNominalValues();
+    auto inArgsIC = model->getNominalValues();
     auto icSolution = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
     auto icState = Tempus::createSolutionStateX(icSolution);
     icState->setTime    (timeStepControl->getInitTime());
@@ -285,8 +294,8 @@ TEUCHOS_UNIT_TEST(ExplicitRK, useFSAL_false)
     solutionHistory->addState(icState);
 
     // Setup Integrator -----------------------------------------
-    auto integrator = Tempus::integratorBasic<double>();
-    integrator->setStepperWStepper(stepper);
+    auto integrator = Tempus::createIntegratorBasic<double>();
+    integrator->setStepper(stepper);
     integrator->setTimeStepControl(timeStepControl);
     integrator->setSolutionHistory(solutionHistory);
     integrator->initialize();
@@ -423,7 +432,7 @@ TEUCHOS_UNIT_TEST(ExplicitRK, SinCos)
       // Setup the Integrator and reset initial time step
       pl->sublist("Demo Integrator")
         .sublist("Time Step Control").set("Initial Time Step", dt);
-      integrator = Tempus::integratorBasic<double>(pl, model);
+      integrator = Tempus::createIntegratorBasic<double>(pl, model);
 
       // Initial Conditions
       // During the Integrator construction, the initial SolutionState
@@ -549,7 +558,7 @@ TEUCHOS_UNIT_TEST(ExplicitRK, EmbeddedVanDerPol)
 
      // Setup the Integrator
      RCP<Tempus::IntegratorBasic<double> > integrator =
-        Tempus::integratorBasic<double>(pl, model);
+        Tempus::createIntegratorBasic<double>(pl, model);
 
      const std::string RKMethod =
         pl->sublist(integratorChoice).get<std::string>("Stepper Name");
@@ -662,8 +671,7 @@ TEUCHOS_UNIT_TEST(ExplicitRK, stage_number)
   timeStepControl->initialize();
 
   // Setup initial condition SolutionState --------------------
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
-    stepper->getModel()->getNominalValues();
+  auto inArgsIC = model->getNominalValues();
   auto icSolution = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
   auto icState = Tempus::createSolutionStateX(icSolution);
   icState->setTime    (timeStepControl->getInitTime());
@@ -681,8 +689,8 @@ TEUCHOS_UNIT_TEST(ExplicitRK, stage_number)
 
   // Setup Integrator -----------------------------------------
   RCP<Tempus::IntegratorBasic<double> > integrator =
-    Tempus::integratorBasic<double>();
-  integrator->setStepperWStepper(stepper);
+    Tempus::createIntegratorBasic<double>();
+  integrator->setStepper(stepper);
   integrator->setTimeStepControl(timeStepControl);
   integrator->setSolutionHistory(solutionHistory);
   //integrator->setObserver(...);

--- a/packages/tempus/test/ExplicitRK/Tempus_ExplicitRK_SinCos.xml
+++ b/packages/tempus/test/ExplicitRK/Tempus_ExplicitRK_SinCos.xml
@@ -56,11 +56,11 @@
         <Parameter name="Use Embedded" type="bool" value="false"/>
         <ParameterList name="Tableau">
             <Parameter name="A" type="string"
-                value="0.0 0.0 0.0 0.0; 0.5 0.0 0.0 0.0; 0.0 0.5 0.0 0.0; 0.0 0.0 1.0 0.0"/>
+                value="0 0 0 0; 0.5 0 0 0; 0 0.5 0 0; 0 0 1 0"/>
             <Parameter name="b" type="string"
                 value="0.166666666666667 0.333333333333333 0.333333333333333 0.166666666666667"/>
             <Parameter name="c" type="string"
-                value="0.0 0.5 0.5 1.0"/>
+                value="0 0.5 0.5 1"/>
             <Parameter name="order" type="int" value="4"/>
             <Parameter name="bstar" type="string" value=""/>
         </ParameterList>
@@ -74,14 +74,14 @@
         <Parameter name="Use Embedded" type="bool" value="false"/>
         <ParameterList name="Tableau">
             <Parameter name="A" type="string"
-                value="0.0 0.0 0.0 0.0;
-                0.5 0.0 0.0 0.0;
-                0.0 0.75 0.0 0.0;
-                0.222222222222222 0.333333333333333 0.444444444444444 0.0"/>
+                value="0 0 0 0;
+                0.5 0 0 0;
+                0 0.75 0 0;
+                0.222222222222222 0.333333333333333 0.444444444444444 0"/>
             <Parameter name="b" type="string"
-                value="0.222222222222222 0.333333333333333 0.444444444444444 0.0"/>
+                value="0.222222222222222 0.333333333333333 0.444444444444444 0"/>
             <Parameter name="c" type="string"
-                value="0.0 0.5 0.75 1.0"/>
+                value="0 0.5 0.75 1"/>
             <Parameter name="bstar" type="string"
                 value="0.29166666666 0.25 0.333333333333333 0.125"/>
             <Parameter name="order" type="int" value="3"/>

--- a/packages/tempus/test/ExplicitRK/Tempus_ExplicitRK_VanDerPol.xml
+++ b/packages/tempus/test/ExplicitRK/Tempus_ExplicitRK_VanDerPol.xml
@@ -123,11 +123,13 @@
 
         <ParameterList name="Bogacki Shampine Stepper Embedded">
             <Parameter name="Stepper Type" type="string" value="Bogacki-Shampine 3(2) Pair"/>
+            <Parameter name="Use FSAL"       type="bool" value="false"/>
             <Parameter name="Use Embedded" type="bool" value="true"/>
         </ParameterList>
 
         <ParameterList name="General ERK Bogacki Shampine Stepper Embedded">
             <Parameter name="Use Embedded" type="bool" value="true"/>
+            <Parameter name="Use FSAL"       type="bool" value="false"/>
             <Parameter name="Stepper Type" type="string" value="General ERK"/>
             <ParameterList name="Tableau">
                 <Parameter name="A" type="string"

--- a/packages/tempus/test/ForwardEuler/Tempus_ForwardEulerTest.cpp
+++ b/packages/tempus/test/ForwardEuler/Tempus_ForwardEulerTest.cpp
@@ -59,13 +59,13 @@ TEUCHOS_UNIT_TEST(ForwardEuler, ParameterList)
   // Test constructor IntegratorBasic(tempusPL, model)
   {
     RCP<Tempus::IntegratorBasic<double> > integrator =
-      Tempus::integratorBasic<double>(tempusPL, model);
+      Tempus::createIntegratorBasic<double>(tempusPL, model);
 
     RCP<ParameterList> stepperPL = sublist(tempusPL, "Demo Stepper", true);
     RCP<const ParameterList> defaultPL =
       integrator->getStepper()->getValidParameters();
 
-    bool pass = haveSameValues(*stepperPL, *defaultPL, true);
+    bool pass = haveSameValuesSorted(*stepperPL, *defaultPL, true);
     if (!pass) {
       std::cout << std::endl;
       std::cout << "stepperPL -------------- \n" << *stepperPL << std::endl;
@@ -77,13 +77,13 @@ TEUCHOS_UNIT_TEST(ForwardEuler, ParameterList)
   // Test constructor IntegratorBasic(model, stepperType)
   {
     RCP<Tempus::IntegratorBasic<double> > integrator =
-      Tempus::integratorBasic<double>(model, "Forward Euler");
+      Tempus::createIntegratorBasic<double>(model, "Forward Euler");
 
     RCP<ParameterList> stepperPL = sublist(tempusPL, "Demo Stepper", true);
     RCP<const ParameterList> defaultPL =
       integrator->getStepper()->getValidParameters();
 
-    bool pass = haveSameValues(*stepperPL, *defaultPL, true);
+    bool pass = haveSameValuesSorted(*stepperPL, *defaultPL, true);
     if (!pass) {
       std::cout << std::endl;
       std::cout << "stepperPL -------------- \n" << *stepperPL << std::endl;
@@ -138,8 +138,7 @@ TEUCHOS_UNIT_TEST(ForwardEuler, ConstructingFromDefaults)
     timeStepControl->initialize();
 
     // Setup initial condition SolutionState --------------------
-    Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
-      stepper->getModel()->getNominalValues();
+    auto inArgsIC = model()->getNominalValues();
     auto icSolution = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
     auto icState = Tempus::createSolutionStateX(icSolution);
     icState->setTime    (timeStepControl->getInitTime());
@@ -154,10 +153,13 @@ TEUCHOS_UNIT_TEST(ForwardEuler, ConstructingFromDefaults)
     solutionHistory->setStorageLimit(2);
     solutionHistory->addState(icState);
 
+    // Ensure ICs are consistent and stepper memory is set (e.g., xDot is set).
+    stepper->setInitialConditions(solutionHistory);
+
     // Setup Integrator -----------------------------------------
     RCP<Tempus::IntegratorBasic<double> > integrator =
-      Tempus::integratorBasic<double>();
-    integrator->setStepperWStepper(stepper);
+      Tempus::createIntegratorBasic<double>();
+    integrator->setStepper(stepper);
     integrator->setTimeStepControl(timeStepControl);
     integrator->setSolutionHistory(solutionHistory);
     //integrator->setObserver(...);
@@ -235,7 +237,7 @@ TEUCHOS_UNIT_TEST(ForwardEuler, SinCos)
     RCP<ParameterList> pl = sublist(pList, "Tempus", true);
     pl->sublist("Demo Integrator")
        .sublist("Time Step Control").set("Initial Time Step", dt);
-    integrator = Tempus::integratorBasic<double>(pl, model);
+    integrator = Tempus::createIntegratorBasic<double>(pl, model);
 
     // Initial Conditions
     // During the Integrator construction, the initial SolutionState
@@ -244,6 +246,7 @@ TEUCHOS_UNIT_TEST(ForwardEuler, SinCos)
     RCP<Thyra::VectorBase<double> > x0 =
       model->getNominalValues().get_x()->clone_v();
     integrator->initializeSolutionHistory(0.0, x0);
+    integrator->initialize();
 
     // Integrate to timeMax
     bool integratorStatus = integrator->advanceTime();
@@ -355,7 +358,7 @@ TEUCHOS_UNIT_TEST(ForwardEuler, VanDerPol)
     RCP<ParameterList> pl = sublist(pList, "Tempus", true);
     pl->sublist("Demo Integrator")
        .sublist("Time Step Control").set("Initial Time Step", dt);
-    integrator = Tempus::integratorBasic<double>(pl, model);
+    integrator = Tempus::createIntegratorBasic<double>(pl, model);
 
     // Integrate to timeMax
     bool integratorStatus = integrator->advanceTime();
@@ -438,7 +441,7 @@ TEUCHOS_UNIT_TEST(ForwardEuler, NumberTimeSteps)
                                 .get<int>("Number of Time Steps");
 
     RCP<Tempus::IntegratorBasic<double> > integrator =
-      Tempus::integratorBasic<double>(pl, model);
+      Tempus::createIntegratorBasic<double>(pl, model);
 
     // Integrate to timeMax
     bool integratorStatus = integrator->advanceTime();
@@ -488,7 +491,7 @@ TEUCHOS_UNIT_TEST(ForwardEuler, Variable_TimeSteps)
      .sublist("Solution History").set("Storage Limit", 3);
 
   RCP<Tempus::IntegratorBasic<double> > integrator =
-    Tempus::integratorBasic<double>(pl, model);
+    Tempus::createIntegratorBasic<double>(pl, model);
 
   // Integrate to timeMax
   bool integratorStatus = integrator->advanceTime();

--- a/packages/tempus/test/ForwardEuler/Tempus_ForwardEuler_SinCos.xml
+++ b/packages/tempus/test/ForwardEuler/Tempus_ForwardEuler_SinCos.xml
@@ -39,7 +39,7 @@
         <Parameter name="Maximum Number of Consecutive Stepper Failures" type="int" value="5"/>
         <ParameterList name="Time Step Control Strategy">
            <Parameter name="Strategy Type" type="string" value="Constant Time Step"/>
-           <Parameter name="Time Step Size" type="double" value="1.0"/>
+           <Parameter name="Time Step" type="double" value="1.0"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>

--- a/packages/tempus/test/HHTAlpha/Tempus_HHTAlphaTest.cpp
+++ b/packages/tempus/test/HHTAlpha/Tempus_HHTAlphaTest.cpp
@@ -67,7 +67,7 @@ TEUCHOS_UNIT_TEST(HHTAlpha, BallParabolic)
   RCP<ParameterList> pl = sublist(pList, "Tempus", true);
 
   RCP<Tempus::IntegratorBasic<double> > integrator =
-    Tempus::integratorBasic<double>(pl, model);
+    Tempus::createIntegratorBasic<double>(pl, model);
 
   // Integrate to timeMax
   bool integratorStatus = integrator->advanceTime();
@@ -145,8 +145,7 @@ TEUCHOS_UNIT_TEST(HHTAlpha, ConstructingFromDefaults)
   timeStepControl->initialize();
 
   // Setup initial condition SolutionState --------------------
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
-    stepper->getModel()->getNominalValues();
+  auto inArgsIC = model->getNominalValues();
   auto icX = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
   auto icXDot = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x_dot());
   auto icXDotDot = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x_dot_dot());
@@ -166,8 +165,8 @@ TEUCHOS_UNIT_TEST(HHTAlpha, ConstructingFromDefaults)
 
   // Setup Integrator -----------------------------------------
   RCP<Tempus::IntegratorBasic<double> > integrator =
-    Tempus::integratorBasic<double>();
-  integrator->setStepperWStepper(stepper);
+    Tempus::createIntegratorBasic<double>();
+  integrator->setStepper(stepper);
   integrator->setTimeStepControl(timeStepControl);
   integrator->setSolutionHistory(solutionHistory);
   //integrator->setObserver(...);
@@ -246,7 +245,7 @@ TEUCHOS_UNIT_TEST(HHTAlpha, SinCos_SecondOrder)
               << nTimeStepSizes-1 << "), dt = " << dt << "\n";
     pl->sublist("Default Integrator")
        .sublist("Time Step Control").set("Initial Time Step", dt);
-    integrator = Tempus::integratorBasic<double>(pl, model);
+    integrator = Tempus::createIntegratorBasic<double>(pl, model);
 
     // Integrate to timeMax
     bool integratorStatus = integrator->advanceTime();
@@ -391,7 +390,7 @@ TEUCHOS_UNIT_TEST(HHTAlpha, SinCos_FirstOrder)
               << nTimeStepSizes-1 << "), dt = " << dt << "\n";
     pl->sublist("Default Integrator")
        .sublist("Time Step Control").set("Initial Time Step", dt);
-    integrator = Tempus::integratorBasic<double>(pl, model);
+    integrator = Tempus::createIntegratorBasic<double>(pl, model);
 
     // Integrate to timeMax
     bool integratorStatus = integrator->advanceTime();
@@ -537,7 +536,7 @@ TEUCHOS_UNIT_TEST(HHTAlpha, SinCos_CD)
               << nTimeStepSizes-1 << "), dt = " << dt << "\n";
     pl->sublist("Default Integrator")
        .sublist("Time Step Control").set("Initial Time Step", dt);
-    integrator = Tempus::integratorBasic<double>(pl, model);
+    integrator = Tempus::createIntegratorBasic<double>(pl, model);
 
     // Integrate to timeMax
     bool integratorStatus = integrator->advanceTime();

--- a/packages/tempus/test/IMEX_RK/Tempus_IMEX_RKTest.cpp
+++ b/packages/tempus/test/IMEX_RK/Tempus_IMEX_RKTest.cpp
@@ -76,8 +76,7 @@ TEUCHOS_UNIT_TEST(IMEX_RK, ConstructingFromDefaults)
   timeStepControl->initialize();
 
   // Setup initial condition SolutionState --------------------
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
-    stepper->getModel()->getNominalValues();
+  auto inArgsIC = model->getNominalValues();
   auto icSolution = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
   auto icState = Tempus::createSolutionStateX(icSolution);
   icState->setTime    (timeStepControl->getInitTime());
@@ -95,8 +94,8 @@ TEUCHOS_UNIT_TEST(IMEX_RK, ConstructingFromDefaults)
 
   // Setup Integrator -----------------------------------------
   RCP<Tempus::IntegratorBasic<double> > integrator =
-    Tempus::integratorBasic<double>();
-  integrator->setStepperWStepper(stepper);
+    Tempus::createIntegratorBasic<double>();
+  integrator->setStepper(stepper);
   integrator->setTimeStepControl(timeStepControl);
   integrator->setSolutionHistory(solutionHistory);
   integrator->initialize();
@@ -222,7 +221,7 @@ TEUCHOS_UNIT_TEST(IMEX_RK, VanDerPol)
       // Setup the Integrator and reset initial time step
       pl->sublist("Default Integrator")
          .sublist("Time Step Control").set("Initial Time Step", dt);
-      integrator = Tempus::integratorBasic<double>(pl, model);
+      integrator = Tempus::createIntegratorBasic<double>(pl, model);
 
       // Integrate to timeMax
       bool integratorStatus = integrator->advanceTime();

--- a/packages/tempus/test/IMEX_RK_Partitioned/Tempus_IMEX_RK_PartitionedTest.cpp
+++ b/packages/tempus/test/IMEX_RK_Partitioned/Tempus_IMEX_RK_PartitionedTest.cpp
@@ -81,8 +81,7 @@ TEUCHOS_UNIT_TEST(IMEX_RK_Partitioned, ConstructingFromDefaults)
   timeStepControl->initialize();
 
   // Setup initial condition SolutionState --------------------
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
-    stepper->getModel()->getNominalValues();
+  auto inArgsIC = model->getNominalValues();
   auto icSolution = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
   auto icState = Tempus::createSolutionStateX(icSolution);
   icState->setTime    (timeStepControl->getInitTime());
@@ -100,8 +99,8 @@ TEUCHOS_UNIT_TEST(IMEX_RK_Partitioned, ConstructingFromDefaults)
 
   // Setup Integrator -----------------------------------------
   RCP<Tempus::IntegratorBasic<double> > integrator =
-    Tempus::integratorBasic<double>();
-  integrator->setStepperWStepper(stepper);
+    Tempus::createIntegratorBasic<double>();
+  integrator->setStepper(stepper);
   integrator->setTimeStepControl(timeStepControl);
   integrator->setSolutionHistory(solutionHistory);
   //integrator->setObserver(...);
@@ -220,7 +219,7 @@ TEUCHOS_UNIT_TEST(IMEX_RK_Partitioned, VanDerPol)
       // Setup the Integrator and reset initial time step
       pl->sublist("Default Integrator")
          .sublist("Time Step Control").set("Initial Time Step", dt);
-      integrator = Tempus::integratorBasic<double>(pl, model);
+      integrator = Tempus::createIntegratorBasic<double>(pl, model);
 
       // Integrate to timeMax
       bool integratorStatus = integrator->advanceTime();

--- a/packages/tempus/test/Integrator/Tempus_IntegratorBasic_ref2.xml
+++ b/packages/tempus/test/Integrator/Tempus_IntegratorBasic_ref2.xml
@@ -1,10 +1,10 @@
 <ParameterList name="Tempus">
-  <Parameter docString="" id="0" isDefault="false" isUsed="true" name="Integrator Name" type="string" value="Default Integrator"/>
-  <ParameterList id="28" name="Default Integrator">
+  <Parameter docString="" id="0" isDefault="false" isUsed="true" name="Integrator Name" type="string" value="Integrator Basic"/>
+  <ParameterList id="28" name="Integrator Basic">
     <Parameter docString="'Integrator Type' must be 'Integrator Basic'." id="1" isDefault="false" isUsed="true" name="Integrator Type" type="string" value="Integrator Basic"/>
     <Parameter docString="'Integrator Type' must be 'Integrator Basic'.Screen Output Index List.  Required to be in TimeStepControl range ['Minimum Time Step Index', 'Maximum Time Step Index']" id="2" isDefault="false" isUsed="true" name="Screen Output Index List" type="string" value=""/>
     <Parameter docString="Screen Output Index Interval (e.g., every 100 time steps" id="3" isDefault="false" isUsed="true" name="Screen Output Index Interval" type="int" value="1000000"/>
-    <Parameter docString="'Stepper Name' selects the Stepper block to construct (Required)." id="4" isDefault="false" isUsed="true" name="Stepper Name" type="string" value="Demo Stepper"/>
+    <Parameter docString="'Stepper Name' selects the Stepper block to construct (Required)." id="4" isDefault="false" isUsed="true" name="Stepper Name" type="string" value="Forward Euler"/>
     <ParameterList id="7" name="Solution History">
       <Parameter docString="" id="5" isDefault="true" isUsed="true" name="Storage Type" type="string" value="Undo"/>
       <Parameter docString="" id="6" isDefault="true" isUsed="true" name="Storage Limit" type="int" value="2"/>
@@ -38,7 +38,7 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-  <ParameterList id="30" name="Demo Stepper">
+  <ParameterList id="30" name="Forward Euler">
     <Parameter docString="" id="29" isDefault="false" isUsed="true" name="Stepper Type" type="string" value="Forward Euler"/>
     <Parameter docString="" id="34" isDefault="false" isUsed="true" name="Use FSAL" type="bool" value="true"/>
     <Parameter docString="" id="35" isDefault="false" isUsed="true" name="Initial Condition Consistency" type="string" value="Consistent"/>

--- a/packages/tempus/test/Integrator/Tempus_IntegratorTest.cpp
+++ b/packages/tempus/test/Integrator/Tempus_IntegratorTest.cpp
@@ -39,10 +39,10 @@ TEUCHOS_UNIT_TEST(IntegratorBasic, PL_ME_Construction)
   // 3) Setup the Integrator
   RCP<ParameterList> tempusPL = sublist(pl, "Tempus", true);
   RCP<Tempus::IntegratorBasic<double> > integrator =
-    Tempus::integratorBasic<double>(tempusPL, model);
+    Tempus::createIntegratorBasic<double>(tempusPL, model);
 
   // Test the ParameterList
-  RCP<ParameterList> testPL = integrator->getTempusParameterList();
+  auto testPL = integrator->getValidParameters();
   // Write out ParameterList to rebaseline test.
   //writeParameterListToXmlFile(*testPL, "Tempus_IntegratorBasic_ref-test.xml");
 
@@ -50,7 +50,7 @@ TEUCHOS_UNIT_TEST(IntegratorBasic, PL_ME_Construction)
   RCP<ParameterList> referencePL =
     getParametersFromXmlFile("Tempus_IntegratorBasic_ref.xml");
 
-  bool pass = haveSameValues(*testPL, *referencePL, true);
+  bool pass = haveSameValuesSorted(*testPL, *referencePL, true);
   if (!pass) {
     std::cout << std::endl;
     std::cout << "testPL      -------------- \n" << *testPL << std::endl;
@@ -66,29 +66,26 @@ TEUCHOS_UNIT_TEST(IntegratorBasic, Construction)
 {
   // 1) Setup the Integrator
   RCP<Tempus::IntegratorBasic<double> > integrator =
-    Tempus::integratorBasic<double>();
+    Tempus::createIntegratorBasic<double>();
 
   // 2) Setup the ParameterList
   //    - Start with the default Tempus PL
   //    - Add Stepper PL
-  RCP<ParameterList> tempusPL = integrator->getTempusParameterList();
+  RCP<ParameterList> tempusPL = Teuchos::rcp_const_cast<ParameterList>(
+    integrator->getValidParameters());
 
   tempusPL->sublist("Default Integrator").set("Stepper Name", "Demo Stepper");
   RCP<ParameterList> stepperPL = Teuchos::parameterList();
   stepperPL->set("Stepper Type", "Forward Euler");
   tempusPL->set("Demo Stepper", *stepperPL);
 
-  integrator->setTempusParameterList(tempusPL);
-
-  // 3) Setup the Stepper
+  // 3) Create integrator
   RCP<SinCosModel<double> > model = Teuchos::rcp(new SinCosModel<double> ());
-  integrator->setStepper(model);
-
-  // 4) Initialize integrator
+  integrator = Tempus::createIntegratorBasic<double>(tempusPL, model);
   integrator->initialize();
 
   // Test the ParameterList
-  RCP<ParameterList> testPL = integrator->getTempusParameterList();
+  auto testPL = integrator->getValidParameters();
   // Write out ParameterList to rebaseline test.
   //writeParameterListToXmlFile(*testPL,"Tempus_IntegratorBasic_ref2-test.xml");
 
@@ -96,7 +93,7 @@ TEUCHOS_UNIT_TEST(IntegratorBasic, Construction)
   RCP<ParameterList> referencePL =
     getParametersFromXmlFile("Tempus_IntegratorBasic_ref2.xml");
 
-  bool pass = haveSameValues(*testPL, *referencePL, true);
+  bool pass = haveSameValuesSorted(*testPL, *referencePL, true);
   if (!pass) {
     std::cout << std::endl;
     std::cout << "testPL      -------------- \n" << *testPL << std::endl;

--- a/packages/tempus/test/Leapfrog/Tempus_LeapfrogTest.cpp
+++ b/packages/tempus/test/Leapfrog/Tempus_LeapfrogTest.cpp
@@ -86,8 +86,7 @@ TEUCHOS_UNIT_TEST(Leapfrog, ConstructingFromDefaults)
     timeStepControl->initialize();
 
     // Setup initial condition SolutionState --------------------
-    Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
-      stepper->getModel()->getNominalValues();
+    auto inArgsIC = model->getNominalValues();
     auto icX = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
     auto icXDot = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x_dot());
     auto icXDotDot = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x_dot_dot());
@@ -105,10 +104,13 @@ TEUCHOS_UNIT_TEST(Leapfrog, ConstructingFromDefaults)
     solutionHistory->setStorageLimit(2);
     solutionHistory->addState(icState);
 
+    // Ensure ICs are consistent and stepper memory is set (e.g., xDot is set).
+    stepper->setInitialConditions(solutionHistory);
+
     // Setup Integrator -----------------------------------------
     RCP<Tempus::IntegratorBasic<double> > integrator =
-      Tempus::integratorBasic<double>();
-    integrator->setStepperWStepper(stepper);
+      Tempus::createIntegratorBasic<double>();
+    integrator->setStepper(stepper);
     integrator->setTimeStepControl(timeStepControl);
     integrator->setSolutionHistory(solutionHistory);
     //integrator->setObserver(...);
@@ -186,7 +188,7 @@ TEUCHOS_UNIT_TEST(Leapfrog, SinCos)
               << " (out of " << nTimeStepSizes-1 << "), dt = " << dt << "\n";
     pl->sublist("Default Integrator")
        .sublist("Time Step Control").set("Initial Time Step", dt);
-    integrator = Tempus::integratorBasic<double>(pl, model);
+    integrator = Tempus::createIntegratorBasic<double>(pl, model);
 
     // Integrate to timeMax
     bool integratorStatus = integrator->advanceTime();

--- a/packages/tempus/test/Newmark/Tempus_NewmarkTest.cpp
+++ b/packages/tempus/test/Newmark/Tempus_NewmarkTest.cpp
@@ -84,7 +84,7 @@ TEUCHOS_UNIT_TEST(NewmarkExplicitAForm, BallParabolic)
     }
 
     RCP<Tempus::IntegratorBasic<double> > integrator =
-      Tempus::integratorBasic<double>(pl, model);
+      Tempus::createIntegratorBasic<double>(pl, model);
 
     // Integrate to timeMax
     bool integratorStatus = integrator->advanceTime();
@@ -182,7 +182,7 @@ TEUCHOS_UNIT_TEST(NewmarkExplicitAForm, SinCos)
               << nTimeStepSizes-1 << "), dt = " << dt << "\n";
     pl->sublist("Default Integrator")
        .sublist("Time Step Control").set("Initial Time Step", dt);
-    integrator = Tempus::integratorBasic<double>(pl, model);
+    integrator = Tempus::createIntegratorBasic<double>(pl, model);
 
     // Integrate to timeMax
     bool integratorStatus = integrator->advanceTime();
@@ -296,7 +296,7 @@ TEUCHOS_UNIT_TEST(NewmarkExplicitAForm, HarmonicOscillatorDamped)
               << nTimeStepSizes-1 << "), dt = " << dt << "\n";
     pl->sublist("Default Integrator")
        .sublist("Time Step Control").set("Initial Time Step", dt);
-    integrator = Tempus::integratorBasic<double>(pl, model);
+    integrator = Tempus::createIntegratorBasic<double>(pl, model);
 
     // Integrate to timeMax
     bool integratorStatus = integrator->advanceTime();
@@ -411,8 +411,7 @@ TEUCHOS_UNIT_TEST(NewmarkImplicitAForm, ConstructingFromDefaults)
 
     // Setup initial condition SolutionState --------------------
     using Teuchos::rcp_const_cast;
-    Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
-      stepper->getModel()->getNominalValues();
+    auto inArgsIC = model->getNominalValues();
     RCP<Thyra::VectorBase<double> > icX =
       rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
     RCP<Thyra::VectorBase<double> > icXDot =
@@ -435,10 +434,13 @@ TEUCHOS_UNIT_TEST(NewmarkImplicitAForm, ConstructingFromDefaults)
     solutionHistory->setStorageLimit(2);
     solutionHistory->addState(icState);
 
+    // Ensure ICs are consistent.
+    stepper->setInitialConditions(solutionHistory);
+
     // Setup Integrator -----------------------------------------
     RCP<Tempus::IntegratorBasic<double> > integrator =
-      Tempus::integratorBasic<double>();
-    integrator->setStepperWStepper(stepper);
+      Tempus::createIntegratorBasic<double>();
+    integrator->setStepper(stepper);
     integrator->setTimeStepControl(timeStepControl);
     integrator->setSolutionHistory(solutionHistory);
     //integrator->setObserver(...);
@@ -509,8 +511,7 @@ TEUCHOS_UNIT_TEST(NewmarkImplicitDForm, Constructing_From_Defaults)
 
   // Setup initial condition SolutionState --------------------
   using Teuchos::rcp_const_cast;
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
-    stepper->getModel()->getNominalValues();
+  auto inArgsIC = model->getNominalValues();
   RCP<Thyra::VectorBase<double> > icX =
     rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
   RCP<Thyra::VectorBase<double> > icXDot =
@@ -535,8 +536,8 @@ TEUCHOS_UNIT_TEST(NewmarkImplicitDForm, Constructing_From_Defaults)
 
   // Setup Integrator -----------------------------------------
   RCP<Tempus::IntegratorBasic<double> > integrator =
-    Tempus::integratorBasic<double>();
-  integrator->setStepperWStepper(stepper);
+    Tempus::createIntegratorBasic<double>();
+  integrator->setStepper(stepper);
   integrator->setTimeStepControl(timeStepControl);
   integrator->setSolutionHistory(solutionHistory);
   //integrator->setObserver(...);
@@ -613,7 +614,7 @@ TEUCHOS_UNIT_TEST(NewmarkImplicitAForm, HarmonicOscillatorDamped_SecondOrder)
               << nTimeStepSizes-1 << "), dt = " << dt << "\n";
     pl->sublist("Default Integrator")
        .sublist("Time Step Control").set("Initial Time Step", dt);
-    integrator = Tempus::integratorBasic<double>(pl, model);
+    integrator = Tempus::createIntegratorBasic<double>(pl, model);
 
     // Integrate to timeMax
     bool integratorStatus = integrator->advanceTime();
@@ -725,7 +726,7 @@ TEUCHOS_UNIT_TEST(NewmarkImplicitDForm, HarmonicOscillatorDamped_SecondOrder)
               << nTimeStepSizes-1 << "), dt = " << dt << "\n";
     pl->sublist("Default Integrator")
        .sublist("Time Step Control").set("Initial Time Step", dt);
-    integrator = Tempus::integratorBasic<double>(pl, model);
+    integrator = Tempus::createIntegratorBasic<double>(pl, model);
 
     // Integrate to timeMax
     bool integratorStatus = integrator->advanceTime();
@@ -837,7 +838,7 @@ TEUCHOS_UNIT_TEST(NewmarkImplicitAForm, HarmonicOscillatorDamped_FirstOrder)
               << nTimeStepSizes-1 << "), dt = " << dt << "\n";
     pl->sublist("Default Integrator")
        .sublist("Time Step Control").set("Initial Time Step", dt);
-    integrator = Tempus::integratorBasic<double>(pl, model);
+    integrator = Tempus::createIntegratorBasic<double>(pl, model);
 
     // Integrate to timeMax
     bool integratorStatus = integrator->advanceTime();

--- a/packages/tempus/test/OperatorSplit/Tempus_OperatorSplitTest.cpp
+++ b/packages/tempus/test/OperatorSplit/Tempus_OperatorSplitTest.cpp
@@ -82,8 +82,7 @@ TEUCHOS_UNIT_TEST(OperatorSplit, ConstructingFromDefaults)
   timeStepControl->initialize();
 
   // Setup initial condition SolutionState --------------------
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
-  stepper->getModel()->getNominalValues();
+  auto inArgsIC = stepper->getModel()->getNominalValues();
   auto icX    = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
   auto icXDot = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x_dot());
   auto icState = Tempus::createSolutionStateX(icX, icXDot);
@@ -102,8 +101,8 @@ TEUCHOS_UNIT_TEST(OperatorSplit, ConstructingFromDefaults)
 
   // Setup Integrator -----------------------------------------
   RCP<Tempus::IntegratorBasic<double> > integrator =
-    Tempus::integratorBasic<double>();
-  integrator->setStepperWStepper(stepper);
+    Tempus::createIntegratorBasic<double>();
+  integrator->setStepper(stepper);
   integrator->setTimeStepControl(timeStepControl);
   integrator->setSolutionHistory(solutionHistory);
   //integrator->setObserver(...);
@@ -174,7 +173,7 @@ TEUCHOS_UNIT_TEST(OperatorSplit, VanDerPol)
     RCP<ParameterList> pl = sublist(pList, "Tempus", true);
     pl->sublist("Demo Integrator")
        .sublist("Time Step Control").set("Initial Time Step", dt);
-    integrator = Tempus::integratorBasic<double>(pl, models);
+    integrator = Tempus::createIntegratorBasic<double>(pl, models);
 
     // Integrate to timeMax
     bool integratorStatus = integrator->advanceTime();

--- a/packages/tempus/test/PhysicsState/Tempus_PhysicsStateTest.cpp
+++ b/packages/tempus/test/PhysicsState/Tempus_PhysicsStateTest.cpp
@@ -67,13 +67,13 @@ TEUCHOS_UNIT_TEST(PhysicsState, SinCos)
     pl->sublist("Demo Integrator")
        .sublist("Time Step Control").set("Initial Time Step", dt);
     RCP<Tempus::IntegratorBasic<double> > integrator =
-      Tempus::integratorBasic<double>(pl, model);
+      Tempus::createIntegratorBasic<double>(pl, model);
 
     // Replace Tempus::StepperForwardEuler with
     // Tempus_Test::StepperPhysicsStateTest
     Teuchos::RCP<Tempus::Stepper<double> > physicsStepper = Teuchos::rcp(
       new StepperPhysicsStateTest<double>(model));
-    integrator->setStepperWStepper(physicsStepper);
+    integrator->setStepper(physicsStepper);
     order = integrator->getStepper()->getOrder();
 
     // Initial Conditions

--- a/packages/tempus/test/Subcycling/Tempus_SubcyclingTest.cpp
+++ b/packages/tempus/test/Subcycling/Tempus_SubcyclingTest.cpp
@@ -67,13 +67,13 @@ TEUCHOS_UNIT_TEST(Subcycling, ParameterList)
   // Test constructor IntegratorBasic(tempusPL, model)
   {
     RCP<Tempus::IntegratorBasic<double> > integrator =
-      Tempus::integratorBasic<double>(tempusPL, model);
+      Tempus::createIntegratorBasic<double>(tempusPL, model);
 
     RCP<ParameterList> stepperPL = sublist(tempusPL, "Demo Stepper", true);
     RCP<const ParameterList> defaultPL =
       integrator->getStepper()->getValidParameters();
 
-    bool pass = haveSameValues(*stepperPL, *defaultPL, true);
+    bool pass = haveSameValuesSorted(*stepperPL, *defaultPL, true);
     if (!pass) {
       std::cout << std::endl;
       std::cout << "stepperPL -------------- \n" << *stepperPL << std::endl;
@@ -85,13 +85,13 @@ TEUCHOS_UNIT_TEST(Subcycling, ParameterList)
   // Test constructor IntegratorBasic(model, stepperType)
   {
     RCP<Tempus::IntegratorBasic<double> > integrator =
-      Tempus::integratorBasic<double>(model, "Forward Euler");
+      Tempus::createIntegratorBasic<double>(model, "Forward Euler");
 
     RCP<ParameterList> stepperPL = sublist(tempusPL, "Demo Stepper", true);
     RCP<const ParameterList> defaultPL =
       integrator->getStepper()->getValidParameters();
 
-    bool pass = haveSameValues(*stepperPL, *defaultPL, true);
+    bool pass = haveSameValuesSorted(*stepperPL, *defaultPL, true);
     if (!pass) {
       std::cout << std::endl;
       std::cout << "stepperPL -------------- \n" << *stepperPL << std::endl;
@@ -131,8 +131,6 @@ TEUCHOS_UNIT_TEST(Subcycling, ConstructingFromDefaults)
   auto subStrategy = rcp(new Tempus::TimeStepControlStrategyConstant<double>(dt));
   stepper->setSubcyclingTimeStepControlStrategy(subStrategy);
 
-  stepper->initialize();
-
   // Setup TimeStepControl ------------------------------------
   auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
   timeStepControl->setInitIndex(0);
@@ -149,8 +147,7 @@ TEUCHOS_UNIT_TEST(Subcycling, ConstructingFromDefaults)
   timeStepControl->initialize();
 
   // Setup initial condition SolutionState --------------------
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
-    stepper->getModel()->getNominalValues();
+  auto inArgsIC = stepper->getModel()->getNominalValues();
   auto icSolution = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
   auto icState = Tempus::createSolutionStateX(icSolution);
   icState->setTime    (timeStepControl->getInitTime());
@@ -165,10 +162,14 @@ TEUCHOS_UNIT_TEST(Subcycling, ConstructingFromDefaults)
   solutionHistory->setStorageLimit(2);
   solutionHistory->addState(icState);
 
+  // Ensure ICs are consistent and stepper memory is set (e.g., xDot is set).
+  stepper->setInitialConditions(solutionHistory);
+  stepper->initialize();
+
   // Setup Integrator -----------------------------------------
   RCP<Tempus::IntegratorBasic<double> > integrator =
-    Tempus::integratorBasic<double>();
-  integrator->setStepperWStepper(stepper);
+    Tempus::createIntegratorBasic<double>();
+  integrator->setStepper(stepper);
   integrator->setTimeStepControl(timeStepControl);
   integrator->setSolutionHistory(solutionHistory);
   integrator->setScreenOutputIndexInterval(1);
@@ -257,8 +258,6 @@ TEUCHOS_UNIT_TEST(Subcycling, SinCosAdapt)
     strategy->initialize();
     stepper->setSubcyclingTimeStepControlStrategy(strategy);
 
-    stepper->initialize();
-
     // Setup TimeStepControl ------------------------------------
     auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
     timeStepControl->setInitIndex(0);
@@ -270,8 +269,7 @@ TEUCHOS_UNIT_TEST(Subcycling, SinCosAdapt)
     timeStepControl->initialize();
 
     // Setup initial condition SolutionState --------------------
-    Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
-      stepper->getModel()->getNominalValues();
+    auto inArgsIC = stepper->getModel()->getNominalValues();
     auto icSolution = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
     auto icState = Tempus::createSolutionStateX(icSolution);
     icState->setTime    (timeStepControl->getInitTime());
@@ -286,9 +284,13 @@ TEUCHOS_UNIT_TEST(Subcycling, SinCosAdapt)
     solutionHistory->setStorageLimit(2);
     solutionHistory->addState(icState);
 
+    // Ensure ICs are consistent and stepper memory is set (e.g., xDot is set).
+    stepper->setInitialConditions(solutionHistory);
+    stepper->initialize();
+
     // Setup Integrator -----------------------------------------
-    integrator = Tempus::integratorBasic<double>();
-    integrator->setStepperWStepper(stepper);
+    integrator = Tempus::createIntegratorBasic<double>();
+    integrator->setStepper(stepper);
     integrator->setTimeStepControl(timeStepControl);
     integrator->setSolutionHistory(solutionHistory);
     integrator->setScreenOutputIndexInterval(10);
@@ -427,7 +429,6 @@ TEUCHOS_UNIT_TEST(Subcycling, VanDerPolOperatorSplit)
     strategySC->setMaxEta(0.01);
     strategySC->initialize();
     stepperSC->setSubcyclingTimeStepControlStrategy(strategySC);
-    stepperSC->initialize();
 
     // Implicit Stepper
     auto stepperBE = Tempus::createStepperBackwardEuler(implicitModel, Teuchos::null);
@@ -436,7 +437,6 @@ TEUCHOS_UNIT_TEST(Subcycling, VanDerPolOperatorSplit)
     auto stepper = rcp(new Tempus::StepperOperatorSplit<double>());
     stepper->addStepper(stepperSC);
     stepper->addStepper(stepperBE);
-    stepper->initialize();
 
     // Setup TimeStepControl ------------------------------------
     auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
@@ -460,8 +460,7 @@ TEUCHOS_UNIT_TEST(Subcycling, VanDerPolOperatorSplit)
     timeStepControl->initialize();
 
     // Setup initial condition SolutionState --------------------
-    Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
-      stepper->getModel()->getNominalValues();
+    auto inArgsIC = stepper->getModel()->getNominalValues();
     auto icX    = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
     auto icXDot = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x_dot());
     auto icState = Tempus::createSolutionStateX(icX, icXDot);
@@ -479,9 +478,13 @@ TEUCHOS_UNIT_TEST(Subcycling, VanDerPolOperatorSplit)
     solutionHistory->setStorageLimit(3);
     solutionHistory->addState(icState);
 
+    // Ensure ICs are consistent and stepper memory is set (e.g., xDot is set).
+    stepperSC->setInitialConditions(solutionHistory);
+    stepper->initialize();
+
     // Setup Integrator -----------------------------------------
-    integrator = Tempus::integratorBasic<double>();
-    integrator->setStepperWStepper(stepper);
+    integrator = Tempus::createIntegratorBasic<double>();
+    integrator->setStepper(stepper);
     integrator->setTimeStepControl(timeStepControl);
     integrator->setSolutionHistory(solutionHistory);
     integrator->setScreenOutputIndexInterval(10);

--- a/packages/tempus/test/Trapezoidal/Tempus_TrapezoidalTest.cpp
+++ b/packages/tempus/test/Trapezoidal/Tempus_TrapezoidalTest.cpp
@@ -64,13 +64,13 @@ TEUCHOS_UNIT_TEST(Trapezoidal, ParameterList)
   // Test constructor IntegratorBasic(tempusPL, model)
   {
     RCP<Tempus::IntegratorBasic<double> > integrator =
-      Tempus::integratorBasic<double>(tempusPL, model);
+      Tempus::createIntegratorBasic<double>(tempusPL, model);
 
     RCP<ParameterList> stepperPL = sublist(tempusPL, "Default Stepper", true);
 
     RCP<const ParameterList> defaultPL =
       integrator->getStepper()->getValidParameters();
-    bool pass = haveSameValues(*stepperPL, *defaultPL, true);
+    bool pass = haveSameValuesSorted(*stepperPL, *defaultPL, true);
     if (!pass) {
       std::cout << std::endl;
       std::cout << "stepperPL -------------- \n" << *stepperPL << std::endl;
@@ -82,13 +82,13 @@ TEUCHOS_UNIT_TEST(Trapezoidal, ParameterList)
   // Test constructor IntegratorBasic(model, stepperType)
   {
     RCP<Tempus::IntegratorBasic<double> > integrator =
-      Tempus::integratorBasic<double>(model, "Trapezoidal Method");
+      Tempus::createIntegratorBasic<double>(model, "Trapezoidal Method");
 
     RCP<ParameterList> stepperPL = sublist(tempusPL, "Default Stepper", true);
     RCP<const ParameterList> defaultPL =
       integrator->getStepper()->getValidParameters();
 
-    bool pass = haveSameValues(*stepperPL, *defaultPL, true);
+    bool pass = haveSameValuesSorted(*stepperPL, *defaultPL, true);
     if (!pass) {
       std::cout << std::endl;
       std::cout << "stepperPL -------------- \n" << *stepperPL << std::endl;
@@ -153,8 +153,7 @@ TEUCHOS_UNIT_TEST(Trapezoidal, ConstructingFromDefaults)
     timeStepControl->initialize();
 
     // Setup initial condition SolutionState --------------------
-    Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
-      stepper->getModel()->getNominalValues();
+    auto inArgsIC = model->getNominalValues();
     auto icSoln = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
     auto icSolnDot =
       rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x_dot());
@@ -174,8 +173,8 @@ TEUCHOS_UNIT_TEST(Trapezoidal, ConstructingFromDefaults)
 
     // Setup Integrator -----------------------------------------
     RCP<Tempus::IntegratorBasic<double> > integrator =
-      Tempus::integratorBasic<double>();
-    integrator->setStepperWStepper(stepper);
+      Tempus::createIntegratorBasic<double>();
+    integrator->setStepper(stepper);
     integrator->setTimeStepControl(timeStepControl);
     integrator->setSolutionHistory(solutionHistory);
     //integrator->setObserver(...);
@@ -253,7 +252,7 @@ TEUCHOS_UNIT_TEST(Trapezoidal, SinCos)
     RCP<ParameterList> pl = sublist(pList, "Tempus", true);
     pl->sublist("Default Integrator")
        .sublist("Time Step Control").set("Initial Time Step", dt);
-    integrator = Tempus::integratorBasic<double>(pl, model);
+    integrator = Tempus::createIntegratorBasic<double>(pl, model);
 
     // Initial Conditions
     // During the Integrator construction, the initial SolutionState
@@ -366,7 +365,7 @@ TEUCHOS_UNIT_TEST(Trapezoidal, VanDerPol)
     RCP<ParameterList> pl = sublist(pList, "Tempus", true);
     pl->sublist("Demo Integrator")
        .sublist("Time Step Control").set("Initial Time Step", dt);
-    integrator = Tempus::integratorBasic<double>(pl, model);
+    integrator = Tempus::createIntegratorBasic<double>(pl, model);
 
     // Integrate to timeMax
     bool integratorStatus = integrator->advanceTime();

--- a/packages/tempus/unit_test/Tempus_UnitTest_BDF2.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_BDF2.cpp
@@ -164,20 +164,19 @@ public:
   std::string testType;
 };
 
-  TEUCHOS_UNIT_TEST(BDF2, AppAction_Modifier)
-  {
-    auto model = rcp(new Tempus_Test::SinCosModel<double>());
+TEUCHOS_UNIT_TEST(BDF2, AppAction_Modifier)
+{
+  auto model = rcp(new Tempus_Test::SinCosModel<double>());
 
-    // Setup Stepper for field solve ----------------------------
-    auto stepper = rcp(new Tempus::StepperBDF2<double>());
-    stepper->setModel(model);
-    auto modifier = rcp(new StepperBDF2ModifierTest());
-    stepper->setAppAction(modifier);
-    stepper->initialize();
+  // Setup Stepper for field solve ----------------------------
+  auto stepper = rcp(new Tempus::StepperBDF2<double>());
+  stepper->setModel(model);
+  auto modifier = rcp(new StepperBDF2ModifierTest());
+  stepper->setAppAction(modifier);
+  stepper->initialize();
 
-    // Setup initial condition SolutionState --------------------
-    Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
-      stepper->getModel()->getNominalValues();
+  // Setup initial condition SolutionState --------------------
+  auto inArgsIC = model->getNominalValues();
   auto icSolution =
     rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
   auto icState = Tempus::createSolutionStateX(icSolution);
@@ -304,8 +303,7 @@ TEUCHOS_UNIT_TEST(BDF2, AppAction_Observer)
   stepper->initialize();
 
   // Setup initial condition SolutionState --------------------
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
-    stepper->getModel()->getNominalValues();
+  auto inArgsIC = model->getNominalValues();
   auto icSolution =
     rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
   auto icState = Tempus::createSolutionStateX(icSolution);
@@ -428,8 +426,7 @@ TEUCHOS_UNIT_TEST(BDF2, AppAction_ModifierX)
   stepper->initialize();
 
   // Setup initial condition SolutionState --------------------
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
-    stepper->getModel()->getNominalValues();
+  auto inArgsIC = model->getNominalValues();
   auto icSolution =
     rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
   auto icState = Tempus::createSolutionStateX(icSolution);

--- a/packages/tempus/unit_test/Tempus_UnitTest_BackwardEuler.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_BackwardEuler.cpp
@@ -117,7 +117,7 @@ public:
     : testBEGIN_STEP(false), testBEFORE_SOLVE(false),
       testAFTER_SOLVE(false), testEND_STEP(false),
       testCurrentValue(-0.99), testWorkingValue(-0.99),
-      testDt(-1.5), testType("")
+      testDt(-1.5), testName("")
   {}
 
   /// Destructor
@@ -147,8 +147,8 @@ public:
       case StepperBackwardEulerAppAction<double>::AFTER_SOLVE:
       {
         testAFTER_SOLVE = true;
-        testType = "Backward Euler - Modifier";
-        stepper->setStepperType(testType);
+        testName = "Backward Euler - Modifier";
+        stepper->setStepperName(testName);
         break;
       }
       case StepperBackwardEulerAppAction<double>::END_STEP:
@@ -171,7 +171,7 @@ public:
   double testCurrentValue;
   double testWorkingValue;
   double testDt;
-  std::string testType;
+  std::string testName;
 };
 
 TEUCHOS_UNIT_TEST(BackwardEuler, AppAction_Modifier)
@@ -210,7 +210,7 @@ TEUCHOS_UNIT_TEST(BackwardEuler, AppAction_Modifier)
   auto Dt = solutionHistory->getWorkingState()->getTimeStep();
   TEST_FLOATING_EQUALITY(modifier->testDt, Dt, 1.0e-14);
 
-  TEST_COMPARE(modifier->testType, ==, "Backward Euler - Modifier");
+  TEST_COMPARE(modifier->testName, ==, "Backward Euler - Modifier");
 
 }
 
@@ -227,7 +227,7 @@ public:
     : testBEGIN_STEP(false), testBEFORE_SOLVE(false),
       testAFTER_SOLVE(false), testEND_STEP(false),
       testCurrentValue(-0.99), testWorkingValue(-0.99),
-      testDt(-1.5), testType("")
+      testDt(-1.5), testName("")
   {}
 
   /// Destructor
@@ -256,7 +256,7 @@ public:
       case StepperBackwardEulerAppAction<double>::AFTER_SOLVE:
       {
         testAFTER_SOLVE = true;
-        testType = stepper->getStepperType();
+        testName = stepper->getStepperType();
         break;
       }
       case StepperBackwardEulerAppAction<double>::END_STEP:
@@ -279,7 +279,7 @@ public:
   double testCurrentValue;
   double testWorkingValue;
   double testDt;
-  std::string testType;
+  std::string testName;
 };
 
 TEUCHOS_UNIT_TEST(BackwardEuler, AppAction_Observer)
@@ -317,7 +317,7 @@ TEUCHOS_UNIT_TEST(BackwardEuler, AppAction_Observer)
   TEST_FLOATING_EQUALITY(observer->testWorkingValue, get_ele(*(x), 0), 1.0e-14);
   TEST_FLOATING_EQUALITY(observer->testDt, dt, 1.0e-14);
 
-  TEST_COMPARE(observer->testType, ==, "Backward Euler");
+  TEST_COMPARE(observer->testName, ==, "Backward Euler");
 }
 
 

--- a/packages/tempus/unit_test/Tempus_UnitTest_DIRK_BackwardEuler.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_DIRK_BackwardEuler.cpp
@@ -12,7 +12,7 @@
 #include "Teuchos_DefaultComm.hpp"
 
 #include "Thyra_VectorStdOps.hpp"
-#include "Tempus_IntegratorBasic.hpp" 
+#include "Tempus_IntegratorBasic.hpp"
 
 #include "Tempus_UnitTest_Utils.hpp"
 
@@ -56,23 +56,23 @@ TEUCHOS_UNIT_TEST(DIRK_BackwardEuler, StepperFactory_Construction)
 
 
 // ************************************************************
-//* Test: construct the integrator from PL and make sure that 
-//* the solver PL is the same as the provided solver PL 
+//* Test: construct the integrator from PL and make sure that
+//* the solver PL is the same as the provided solver PL
 //* and not the default solver PL
 // ************************************************************
 
 TEUCHOS_UNIT_TEST(DIRK_BackwardEuler, App_PL)
 {
   auto model = rcp(new Tempus_Test::SinCosModel<double>());
-  
+
   // read the params from xml file
   auto pList = getParametersFromXmlFile("Tempus_DIRK_VanDerPol.xml");
   auto pl = sublist(pList, "Tempus", true);
   auto appSolverPL = pl->sublist("App Stepper").sublist("App Solver");
-  
-  
+
+
   // setup the Integrator
-  auto integrator = Tempus::integratorBasic<double>(pl, model);
+  auto integrator = Tempus::createIntegratorBasic<double>(pl, model);
   auto stepperSolverPL = Teuchos::ParameterList();
   stepperSolverPL.set("NOX", *(integrator->getStepper()->getSolver()->getParameterList()));
 

--- a/packages/tempus/unit_test/Tempus_UnitTest_ForwardEuler.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_ForwardEuler.cpp
@@ -102,7 +102,7 @@ public:
   StepperForwardEulerModifierTest()
     : testBEGIN_STEP(false), testBEFORE_EXPLICIT_EVAL(false),
       testEND_STEP(false), testCurrentValue(-0.99), testWorkingValue(-0.99),
-      testDt(-1.5), testType("")
+      testDt(-1.5), testName("")
   {}
 
   /// Destructor
@@ -127,8 +127,8 @@ public:
         testBEFORE_EXPLICIT_EVAL = true;
         testDt = sh->getWorkingState()->getTimeStep()/10.0;
         sh->getWorkingState()->setTimeStep(testDt);
-        testType = "Forward Euler - Modifier";
-        stepper->setStepperType(testType);
+        testName = "Forward Euler - Modifier";
+        stepper->setStepperName(testName);
         break;
       }
     case StepperForwardEulerAppAction<double>::END_STEP:
@@ -149,7 +149,7 @@ public:
   double testCurrentValue;
   double testWorkingValue;
   double testDt;
-  std::string testType;
+  std::string testName;
 };
 
 TEUCHOS_UNIT_TEST(ForwardEuler, AppAction_Modifier)
@@ -199,7 +199,7 @@ TEUCHOS_UNIT_TEST(ForwardEuler, AppAction_Modifier)
   auto Dt = solutionHistory->getWorkingState()->getTimeStep();
   TEST_FLOATING_EQUALITY(modifier->testDt, Dt, 1.0e-14);
 
-  TEST_COMPARE(modifier->testType, ==, "Forward Euler - Modifier");
+  TEST_COMPARE(modifier->testName, ==, "Forward Euler - Modifier");
 }
 
 
@@ -214,7 +214,7 @@ public:
   StepperForwardEulerObserverTest()
     : testBEGIN_STEP(false), testBEFORE_EXPLICIT_EVAL(false),
       testEND_STEP(false), testCurrentValue(-0.99),
-      testWorkingValue(-0.99),testDt(-1.5), testType("")
+      testWorkingValue(-0.99),testDt(-1.5), testName("")
   {}
 
   /// Destructor
@@ -238,7 +238,7 @@ public:
       {
         testBEFORE_EXPLICIT_EVAL = true;
         testDt = sh->getWorkingState()->getTimeStep();
-        testType = stepper->getStepperType();
+        testName = stepper->getStepperName();
         break;
       }
     case StepperForwardEulerAppAction<double>::END_STEP:
@@ -260,7 +260,7 @@ public:
   double testCurrentValue;
   double testWorkingValue;
   double testDt;
-  std::string testType;
+  std::string testName;
 };
 
 TEUCHOS_UNIT_TEST(ForwardEuler, AppAction_Observer)
@@ -309,7 +309,7 @@ TEUCHOS_UNIT_TEST(ForwardEuler, AppAction_Observer)
   TEST_FLOATING_EQUALITY(observer->testWorkingValue, get_ele(*(x), 0), 1.0e-14);
   TEST_FLOATING_EQUALITY(observer->testDt, dt, 1.0e-14);
 
-  TEST_COMPARE(observer->testType, ==, "Forward Euler");
+  TEST_COMPARE(observer->testName, ==, "Forward Euler");
 }
 
 

--- a/packages/tempus/unit_test/Tempus_UnitTest_ForwardEuler.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_ForwardEuler.cpp
@@ -164,8 +164,7 @@ TEUCHOS_UNIT_TEST(ForwardEuler, AppAction_Modifier)
   stepper->initialize();
 
   // Setup initial condition SolutionState --------------------
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
-    stepper->getModel()->getNominalValues();
+  auto inArgsIC = model->getNominalValues();
   auto icSolution =
     rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
   auto icState = Tempus::createSolutionStateX(icSolution);
@@ -264,20 +263,19 @@ public:
   std::string testType;
 };
 
-  TEUCHOS_UNIT_TEST(ForwardEuler, AppAction_Observer)
-  {
-    auto model = rcp(new Tempus_Test::SinCosModel<double>());
+TEUCHOS_UNIT_TEST(ForwardEuler, AppAction_Observer)
+{
+  auto model = rcp(new Tempus_Test::SinCosModel<double>());
 
-    // Setup Stepper for field solve ----------------------------
-    auto stepper = rcp(new Tempus::StepperForwardEuler<double>());
-    stepper->setModel(model);
-    auto observer = rcp(new StepperForwardEulerObserverTest());
-    stepper->setAppAction(observer);
-    stepper->initialize();
+  // Setup Stepper for field solve ----------------------------
+  auto stepper = rcp(new Tempus::StepperForwardEuler<double>());
+  stepper->setModel(model);
+  auto observer = rcp(new StepperForwardEulerObserverTest());
+  stepper->setAppAction(observer);
+  stepper->initialize();
 
-    // Setup initial condition SolutionState --------------------
-    Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
-      stepper->getModel()->getNominalValues();
+  // Setup initial condition SolutionState --------------------
+  auto inArgsIC = model->getNominalValues();
   auto icSolution =
     rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
   auto icState = Tempus::createSolutionStateX(icSolution);
@@ -372,20 +370,19 @@ public:
   double testTime;
 };
 
-  TEUCHOS_UNIT_TEST(ForwardEuler, AppAction_ModifierX)
-  {
-    auto model = rcp(new Tempus_Test::SinCosModel<double>());
+TEUCHOS_UNIT_TEST(ForwardEuler, AppAction_ModifierX)
+{
+  auto model = rcp(new Tempus_Test::SinCosModel<double>());
 
-    // Setup Stepper for field solve ----------------------------
-    auto stepper = rcp(new Tempus::StepperForwardEuler<double>());
-    stepper->setModel(model);
-    auto modifierX = rcp(new StepperForwardEulerModifierXTest());
-    stepper->setAppAction(modifierX);
-    stepper->initialize();
+  // Setup Stepper for field solve ----------------------------
+  auto stepper = rcp(new Tempus::StepperForwardEuler<double>());
+  stepper->setModel(model);
+  auto modifierX = rcp(new StepperForwardEulerModifierXTest());
+  stepper->setAppAction(modifierX);
+  stepper->initialize();
 
-    // Setup initial condition SolutionState --------------------
-    Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
-      stepper->getModel()->getNominalValues();
+  // Setup initial condition SolutionState --------------------
+  auto inArgsIC = model->getNominalValues();
   auto icSolution =
     rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
   auto icState = Tempus::createSolutionStateX(icSolution);

--- a/packages/tempus/unit_test/Tempus_UnitTest_HHTAlpha.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_HHTAlpha.cpp
@@ -121,7 +121,7 @@ public:
     : testBEGIN_STEP(false), testBEFORE_SOLVE(false),
       testAFTER_SOLVE(false), testEND_STEP(false),
       testCurrentValue(-0.99), testWorkingValue(-0.99),
-      testDt(-1.5), testType("")
+      testDt(-1.5), testName("")
   {}
 
   /// Destructor
@@ -151,8 +151,8 @@ public:
     case StepperHHTAlphaAppAction<double>::AFTER_SOLVE:
       {
         testAFTER_SOLVE = true;
-        testType = "HHT Alpha - Modifier";
-        stepper->setStepperType(testType);
+        testName = "HHT Alpha - Modifier";
+        stepper->setStepperName(testName);
         break;
       }
     case StepperHHTAlphaAppAction<double>::END_STEP:
@@ -174,7 +174,7 @@ public:
   double testCurrentValue;
   double testWorkingValue;
   double testDt;
-  std::string testType;
+  std::string testName;
 };
 
 TEUCHOS_UNIT_TEST(HHTAlpha, AppAction_Modifier)
@@ -212,7 +212,7 @@ TEUCHOS_UNIT_TEST(HHTAlpha, AppAction_Modifier)
   TEST_FLOATING_EQUALITY(modifier->testWorkingValue, get_ele(*(x), 0), 1.0e-14);
   auto Dt = solutionHistory->getWorkingState()->getTimeStep();
   TEST_FLOATING_EQUALITY(modifier->testDt, Dt, 1.0e-14);
-  TEST_COMPARE(modifier->testType, ==, "HHT Alpha - Modifier");
+  TEST_COMPARE(modifier->testName, ==, "HHT Alpha - Modifier");
 }
 
   // ************************************************************
@@ -226,7 +226,7 @@ public:
     : testBEGIN_STEP(false), testBEFORE_SOLVE(false),
       testAFTER_SOLVE(false), testEND_STEP(false),
       testCurrentValue(-0.99), testWorkingValue(-0.99),
-      testDt(-1.5), testType("")
+      testDt(-1.5), testName("")
   {}
 
   /// Destructor
@@ -255,7 +255,7 @@ public:
     case StepperHHTAlphaAppAction<double>::AFTER_SOLVE:
     {
       testAFTER_SOLVE = true;
-      testType = stepper->getStepperType();
+      testName = stepper->getStepperType();
       break;
     }
     case StepperHHTAlphaAppAction<double>::END_STEP:
@@ -278,7 +278,7 @@ public:
   double testCurrentValue;
   double testWorkingValue;
   double testDt;
-  std::string testType;
+  std::string testName;
 };
 
 TEUCHOS_UNIT_TEST(HHTAlpha, AppAction_Observer)
@@ -315,7 +315,7 @@ TEUCHOS_UNIT_TEST(HHTAlpha, AppAction_Observer)
   TEST_FLOATING_EQUALITY(observer->testWorkingValue, get_ele(*(x), 0), 1.0e-14);
   TEST_FLOATING_EQUALITY(observer->testDt, dt, 1.0e-14);
 
-  TEST_COMPARE(observer->testType, ==, "HHT-Alpha");
+  TEST_COMPARE(observer->testName, ==, "HHT-Alpha");
 }
 
 // ************************************************************

--- a/packages/tempus/unit_test/Tempus_UnitTest_IMEX_RK.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_IMEX_RK.cpp
@@ -83,7 +83,7 @@ TEUCHOS_UNIT_TEST(IMEX_RK, Default_Construction)
   stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
   stepper->setZeroInitialGuess(zeroInitialGuess);      stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
 
-  stepper->setStepperType(stepperType);                stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setStepperName(stepperType);                stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
   stepper->setExplicitTableau(explicitTableau);        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
   stepper->setImplicitTableau(implicitTableau);        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
   stepper->setOrder(order);                            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());

--- a/packages/tempus/unit_test/Tempus_UnitTest_IMEX_RK_Partition.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_IMEX_RK_Partition.cpp
@@ -72,7 +72,7 @@ TEUCHOS_UNIT_TEST(IMEX_RK_Partition, Default_Construction)
   std::string ICConsistency = stepper->getICConsistency();
   bool ICConsistencyCheck   = stepper->getICConsistencyCheck();
   bool zeroInitialGuess     = stepper->getZeroInitialGuess();
-  std::string stepperType   = "IMEX RK SSP2";
+  std::string stepperType   = "Partitioned IMEX RK SSP2";
   auto stepperERK = Teuchos::rcp(new Tempus::StepperERK_Trapezoidal<double>());
   auto explicitTableau      = stepperERK->getTableau();
   auto stepperSDIRK = Teuchos::rcp(new Tempus::StepperSDIRK_2Stage3rdOrder<double>());
@@ -90,7 +90,7 @@ TEUCHOS_UNIT_TEST(IMEX_RK_Partition, Default_Construction)
   stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
   stepper->setZeroInitialGuess(zeroInitialGuess);      stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
 
-  stepper->setStepperType(stepperType);                stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setStepperName(stepperType);                stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
   stepper->setExplicitTableau(explicitTableau);        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
   stepper->setImplicitTableau(implicitTableau);        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
   stepper->setOrder(order);                            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());

--- a/packages/tempus/unit_test/Tempus_UnitTest_Leapfrog.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_Leapfrog.cpp
@@ -178,8 +178,7 @@ TEUCHOS_UNIT_TEST(Leapfrog, AppAction_Modifier)
   timeStepControl->initialize();
 
   // Setup initial condition SolutionState --------------------
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
-    stepper->getModel()->getNominalValues();
+  auto inArgsIC = model->getNominalValues();
   auto icX = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
   auto icXDot = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x_dot());
   auto icXDotDot = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x_dot_dot());
@@ -305,8 +304,7 @@ TEUCHOS_UNIT_TEST(LeapFrog, AppAction_ModifierX)
   timeStepControl->initialize();
 
   // Setup initial condition SolutionState --------------------
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
-    stepper->getModel()->getNominalValues();
+  auto inArgsIC = model->getNominalValues();
   auto icX = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
   auto icXDot = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x_dot());
   auto icXDotDot = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x_dot_dot());
@@ -435,8 +433,7 @@ TEUCHOS_UNIT_TEST(Leapfrog, AppAction_Observer)
   timeStepControl->initialize();
 
   // Setup initial condition SolutionState --------------------
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
-    stepper->getModel()->getNominalValues();
+  auto inArgsIC = model->getNominalValues();
   auto icX = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
   auto icXDot = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x_dot());
   auto icXDotDot = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x_dot_dot());

--- a/packages/tempus/unit_test/Tempus_UnitTest_Leapfrog.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_Leapfrog.cpp
@@ -99,7 +99,7 @@ public:
       testBEFORE_EXPLICIT_EVAL(false), testBEFORE_XDOT_UPDATE(false),
       testEND_STEP(false),
       testCurrentValue(-0.99), testWorkingValue(-0.99),
-      testDt(-1.5), testType("")
+      testDt(-1.5), testName("")
   {}
 
   /// Destructor
@@ -129,8 +129,8 @@ public:
     case StepperLeapfrogAppAction<double>::BEFORE_X_UPDATE:
       {
         testBEFORE_X_UPDATE = true;
-        testType = "Leapfrog - Modifier";
-        stepper->setStepperType(testType);
+        testName = "Leapfrog - Modifier";
+        stepper->setStepperName(testName);
         break;
       }
     case StepperLeapfrogAppAction<double>::BEFORE_XDOT_UPDATE:
@@ -158,7 +158,7 @@ public:
   double testCurrentValue;
   double testWorkingValue;
   double testDt;
-  std::string testType;
+  std::string testName;
 };
 
 TEUCHOS_UNIT_TEST(Leapfrog, AppAction_Modifier)
@@ -215,7 +215,7 @@ TEUCHOS_UNIT_TEST(Leapfrog, AppAction_Modifier)
   auto Dt = solutionHistory->getWorkingState()->getTimeStep();
   TEST_FLOATING_EQUALITY(modifier->testDt, Dt, 1.0e-15);
 
-  TEST_COMPARE(modifier->testType, ==, "Leapfrog - Modifier");
+  TEST_COMPARE(modifier->testName, ==, "Leapfrog - Modifier");
 }
 // ************************************************************
 // ************************************************************
@@ -229,7 +229,7 @@ public:
     : testX_BEGIN_STEP(false), testX_BEFORE_EXPLICIT_EVAL(false),
       testX_BEFORE_X_UPDATE(false), testX_BEFORE_XDOT_UPDATE(false),
       testX_END_STEP(false),
-      testX(0.0), testDt(-1.25), testTime(-1.25),testType("")
+      testX(0.0), testDt(-1.25), testTime(-1.25),testName("")
   {}
 
   /// Destructor
@@ -263,7 +263,7 @@ public:
     case StepperLeapfrogModifierXBase<double>::X_BEFORE_XDOT_UPDATE:
       {
         testX_BEFORE_XDOT_UPDATE = true;
-        testType = "Leapfrog - ModifierX";
+        testName = "Leapfrog - ModifierX";
         break;
       }
     case StepperLeapfrogModifierXBase<double>::X_END_STEP:
@@ -284,7 +284,7 @@ public:
   double testX;
   double testDt;
   double testTime;
-  std::string testType;
+  std::string testName;
 };
 
 TEUCHOS_UNIT_TEST(LeapFrog, AppAction_ModifierX)
@@ -340,7 +340,7 @@ TEUCHOS_UNIT_TEST(LeapFrog, AppAction_ModifierX)
   TEST_FLOATING_EQUALITY(modifierX->testDt, Dt, 1.0e-15);
   auto time = solutionHistory->getWorkingState()->getTime();
   TEST_FLOATING_EQUALITY(modifierX->testTime, time, 1.0e-15);
-  TEST_COMPARE(modifierX->testType, ==, "Leapfrog - ModifierX");
+  TEST_COMPARE(modifierX->testName, ==, "Leapfrog - ModifierX");
 
 }
 
@@ -356,7 +356,7 @@ public:
       testBEFORE_X_UPDATE(false), testBEFORE_XDOT_UPDATE(false),
       testEND_STEP(false),
       testCurrentValue(-0.99), testWorkingValue(-0.99),
-      testDt(-1.5), testType("")
+      testDt(-1.5), testName("")
   {}
   /// Destructor
   virtual ~StepperLeapfrogObserverTest(){}
@@ -384,7 +384,7 @@ public:
     case StepperLeapfrogAppAction<double>::BEFORE_X_UPDATE:
       {
         testBEFORE_X_UPDATE = true;
-        testType = stepper->getStepperType();
+        testName = stepper->getStepperType();
         break;
       }
     case StepperLeapfrogAppAction<double>::BEFORE_XDOT_UPDATE:
@@ -412,7 +412,7 @@ public:
   double testCurrentValue;
   double testWorkingValue;
   double testDt;
-  std::string testType;
+  std::string testName;
 };
 
 TEUCHOS_UNIT_TEST(Leapfrog, AppAction_Observer)
@@ -470,7 +470,7 @@ TEUCHOS_UNIT_TEST(Leapfrog, AppAction_Observer)
   TEST_FLOATING_EQUALITY(observer->testWorkingValue, get_ele(*(x), 0), 1.0e-15);
   TEST_FLOATING_EQUALITY(observer->testDt, dt, 1.0e-15);
 
-  TEST_COMPARE(observer->testType, ==, "Leapfrog");
+  TEST_COMPARE(observer->testName, ==, "Leapfrog");
 }
 
 

--- a/packages/tempus/unit_test/Tempus_UnitTest_NewmarkExplicitAForm.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_NewmarkExplicitAForm.cpp
@@ -54,7 +54,7 @@ public:
     : testBEGIN_STEP(false), testBEFORE_EXPLICIT_EVAL(false),
       testAFTER_EXPLICIT_EVAL(false), testEND_STEP(false),
       testCurrentValue(-0.99),
-      testDt(-1.5), testType("")
+      testDt(-1.5), testName("")
   {}
 
   /// Destructor
@@ -75,8 +75,8 @@ public:
       case StepperNewmarkExplicitAFormAppAction<double>::BEFORE_EXPLICIT_EVAL:
       {
         testBEFORE_EXPLICIT_EVAL = true;
-        testType = "Newmark Explicit A Form - Modifier";
-        stepper->setStepperType(testType);
+        testName = "Newmark Explicit A Form - Modifier";
+        stepper->setStepperName(testName);
         break;
       }
       case StepperNewmarkExplicitAFormAppAction<double>::AFTER_EXPLICIT_EVAL:
@@ -105,7 +105,7 @@ public:
   bool testEND_STEP;
   double testCurrentValue;
   double testDt;
-  std::string testType;
+  std::string testName;
 };
 
 
@@ -234,7 +234,7 @@ TEUCHOS_UNIT_TEST(NewmarkExplicitAForm, AppAction_Modifier)
   auto Dt = integrator->getTime();
   TEST_FLOATING_EQUALITY(modifier->testDt, Dt, 1.0e-14);
   TEST_FLOATING_EQUALITY(modifier->testCurrentValue, get_ele(*(x), 0), 1.0e-14);
-  TEST_COMPARE(modifier->testType, ==, stepper->getStepperType());
+  TEST_COMPARE(modifier->testName, ==, stepper->getStepperName());
 }
 
 

--- a/packages/tempus/unit_test/Tempus_UnitTest_NewmarkExplicitAForm.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_NewmarkExplicitAForm.cpp
@@ -209,7 +209,7 @@ TEUCHOS_UNIT_TEST(NewmarkExplicitAForm, AppAction_Modifier)
 
   pl->sublist("Default Integrator")
     .sublist("Time Step Control").set("Initial Time Step", dt);
-  integrator = Tempus::integratorBasic<double>(pl, model);
+  integrator = Tempus::createIntegratorBasic<double>(pl, model);
 
   RCP<Tempus::StepperNewmarkExplicitAForm<double> > stepper =
     Teuchos::rcp_dynamic_cast<Tempus::StepperNewmarkExplicitAForm<double> >(integrator->getStepper(), true);
@@ -269,7 +269,7 @@ TEUCHOS_UNIT_TEST(NewmarkExplicitAForm, AppAction_ModifierX)
 
   pl->sublist("Default Integrator")
     .sublist("Time Step Control").set("Initial Time Step", dt);
-  integrator = Tempus::integratorBasic<double>(pl, model);
+  integrator = Tempus::createIntegratorBasic<double>(pl, model);
 
   RCP<Tempus::StepperNewmarkExplicitAForm<double> > stepper =
     Teuchos::rcp_dynamic_cast<Tempus::StepperNewmarkExplicitAForm<double> >(integrator->getStepper(), true);

--- a/packages/tempus/unit_test/Tempus_UnitTest_NewmarkImplicitAForm.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_NewmarkImplicitAForm.cpp
@@ -281,8 +281,7 @@ TEUCHOS_UNIT_TEST(NewmarkImplicitAForm, AppAction_Modifier)
 
   // Setup initial condition SolutionState --------------------
   using Teuchos::rcp_const_cast;
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
-    stepper->getModel()->getNominalValues();
+  auto inArgsIC = model->getNominalValues();
   RCP<Thyra::VectorBase<double> > icX =
     rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
   RCP<Thyra::VectorBase<double> > icXDot =
@@ -307,8 +306,8 @@ TEUCHOS_UNIT_TEST(NewmarkImplicitAForm, AppAction_Modifier)
 
   // Setup Integrator -----------------------------------------
   RCP<Tempus::IntegratorBasic<double> > integrator =
-    Tempus::integratorBasic<double>();
-  integrator->setStepperWStepper(stepper);
+    Tempus::createIntegratorBasic<double>();
+  integrator->setStepper(stepper);
   integrator->setTimeStepControl(timeStepControl);
   integrator->setSolutionHistory(solutionHistory);
   integrator->initialize();
@@ -373,8 +372,7 @@ TEUCHOS_UNIT_TEST(NewmarkImplicitAForm, AppAction_ModifierX)
 
   // Setup initial condition SolutionState --------------------
   using Teuchos::rcp_const_cast;
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
-    stepper->getModel()->getNominalValues();
+  auto inArgsIC = model->getNominalValues();
   RCP<Thyra::VectorBase<double> > icX =
     rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
   RCP<Thyra::VectorBase<double> > icXDot =
@@ -399,8 +397,8 @@ TEUCHOS_UNIT_TEST(NewmarkImplicitAForm, AppAction_ModifierX)
 
   // Setup Integrator -----------------------------------------
   RCP<Tempus::IntegratorBasic<double> > integrator =
-    Tempus::integratorBasic<double>();
-  integrator->setStepperWStepper(stepper);
+    Tempus::createIntegratorBasic<double>();
+  integrator->setStepper(stepper);
   integrator->setTimeStepControl(timeStepControl);
   integrator->setSolutionHistory(solutionHistory);
   integrator->initialize();

--- a/packages/tempus/unit_test/Tempus_UnitTest_NewmarkImplicitAForm.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_NewmarkImplicitAForm.cpp
@@ -120,7 +120,7 @@ public:
     : testBEGIN_STEP(false), testBEFORE_SOLVE(false),
       testAFTER_SOLVE(false), testEND_STEP(false),
       testCurrentValue(-0.99),
-      testDt(-1.5), testType("")
+      testDt(-1.5), testName("")
   {}
 
   /// Destructor
@@ -148,8 +148,8 @@ public:
       case StepperNewmarkImplicitAFormAppAction<double>::AFTER_SOLVE:
       {
         testAFTER_SOLVE = true;
-        testType = "Newmark Implicit A Form - Modifier";
-        stepper->setStepperType(testType);
+        testName = "Newmark Implicit A Form - Modifier";
+        stepper->setStepperName(testName);
         break;
       }
       case StepperNewmarkImplicitAFormAppAction<double>::END_STEP:
@@ -171,7 +171,7 @@ public:
   bool testEND_STEP;
   double testCurrentValue;
   double testDt;
-  std::string testType;
+  std::string testName;
 };
 
 
@@ -328,7 +328,7 @@ TEUCHOS_UNIT_TEST(NewmarkImplicitAForm, AppAction_Modifier)
   auto Dt = integrator->getTime();
   TEST_FLOATING_EQUALITY(modifier->testDt, Dt, 1.0e-14);
   TEST_FLOATING_EQUALITY(modifier->testCurrentValue, get_ele(*(x), 0), 1.0e-14);
-  TEST_COMPARE(modifier->testType, ==, stepper->getStepperType());
+  TEST_COMPARE(modifier->testName, ==, stepper->getStepperName());
 }
 
 

--- a/packages/tempus/unit_test/Tempus_UnitTest_NewmarkImplicitDForm.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_NewmarkImplicitDForm.cpp
@@ -56,7 +56,7 @@ public:
     : testBEGIN_STEP(false), testBEFORE_SOLVE(false),
       testAFTER_SOLVE(false), testEND_STEP(false),
       testCurrentValue(-0.99),
-      testDt(-1.5), testType("")
+      testDt(-1.5), testName("")
   {}
 
   /// Destructor
@@ -84,8 +84,8 @@ public:
       case StepperNewmarkImplicitDFormAppAction<double>::AFTER_SOLVE:
       {
         testAFTER_SOLVE = true;
-        testType = "Newmark Implicit A Form - Modifier";
-        stepper->setStepperType(testType);
+        testName = "Newmark Implicit A Form - Modifier";
+        stepper->setStepperName(testName);
         break;
       }
       case StepperNewmarkImplicitDFormAppAction<double>::END_STEP:
@@ -107,7 +107,7 @@ public:
   bool testEND_STEP;
   double testCurrentValue;
   double testDt;
-  std::string testType;
+  std::string testName;
 };
 
 
@@ -327,7 +327,7 @@ TEUCHOS_UNIT_TEST(NewmarkImplicitDForm, AppAction_Modifier)
   auto Dt = integrator->getTime();
   TEST_FLOATING_EQUALITY(modifier->testDt, Dt, 1.0e-14);
   TEST_FLOATING_EQUALITY(modifier->testCurrentValue, get_ele(*(x), 0), 1.0e-14);
-  TEST_COMPARE(modifier->testType, ==, stepper->getStepperType());
+  TEST_COMPARE(modifier->testName, ==, stepper->getStepperName());
 }
 
 TEUCHOS_UNIT_TEST(NewmarkImplicitDForm, AppAction_ModifierX)

--- a/packages/tempus/unit_test/Tempus_UnitTest_NewmarkImplicitDForm.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_NewmarkImplicitDForm.cpp
@@ -280,8 +280,7 @@ TEUCHOS_UNIT_TEST(NewmarkImplicitDForm, AppAction_Modifier)
 
   // Setup initial condition SolutionState --------------------
   using Teuchos::rcp_const_cast;
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
-    stepper->getModel()->getNominalValues();
+  auto inArgsIC = model->getNominalValues();
   RCP<Thyra::VectorBase<double> > icX =
     rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
   RCP<Thyra::VectorBase<double> > icXDot =
@@ -306,8 +305,8 @@ TEUCHOS_UNIT_TEST(NewmarkImplicitDForm, AppAction_Modifier)
 
   // Setup Integrator -----------------------------------------
   RCP<Tempus::IntegratorBasic<double> > integrator =
-    Tempus::integratorBasic<double>();
-  integrator->setStepperWStepper(stepper);
+    Tempus::createIntegratorBasic<double>();
+  integrator->setStepper(stepper);
   integrator->setTimeStepControl(timeStepControl);
   integrator->setSolutionHistory(solutionHistory);
   integrator->initialize();
@@ -371,8 +370,7 @@ TEUCHOS_UNIT_TEST(NewmarkImplicitDForm, AppAction_ModifierX)
 
   // Setup initial condition SolutionState --------------------
   using Teuchos::rcp_const_cast;
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
-    stepper->getModel()->getNominalValues();
+  auto inArgsIC = model->getNominalValues();
   RCP<Thyra::VectorBase<double> > icX =
     rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
   RCP<Thyra::VectorBase<double> > icXDot =
@@ -397,8 +395,8 @@ TEUCHOS_UNIT_TEST(NewmarkImplicitDForm, AppAction_ModifierX)
 
   // Setup Integrator -----------------------------------------
   RCP<Tempus::IntegratorBasic<double> > integrator =
-    Tempus::integratorBasic<double>();
-  integrator->setStepperWStepper(stepper);
+    Tempus::createIntegratorBasic<double>();
+  integrator->setStepper(stepper);
   integrator->setTimeStepControl(timeStepControl);
   integrator->setSolutionHistory(solutionHistory);
   integrator->initialize();

--- a/packages/tempus/unit_test/Tempus_UnitTest_OperatorSplit.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_OperatorSplit.cpp
@@ -143,7 +143,7 @@ public:
   StepperOperatorSplitModifierTest()
     : testBEGIN_STEP(false), testEND_STEP(false),
       testCurrentValue(-0.99), testWorkingValue(-0.99),
-      testDt(-1.5), testType("")
+      testDt(-1.5), testName("")
   {}
 
   /// Destructor
@@ -173,8 +173,8 @@ public:
       case StepperOperatorSplitAppAction<double>::AFTER_STEPPER:
       {
         testAFTER_STEPPER = true;
-        testType = "OperatorSplit - Modifier";
-        stepper->setStepperType(testType);
+        testName = "OperatorSplit - Modifier";
+        stepper->setStepperName(testName);
         break;
       }
       case StepperOperatorSplitAppAction<double>::END_STEP:
@@ -197,7 +197,7 @@ public:
   double testCurrentValue;
   double testWorkingValue;
   double testDt;
-  std::string testType;
+  std::string testName;
 };
 
 TEUCHOS_UNIT_TEST(OperatorSplit, AppAction_Modifier)
@@ -254,7 +254,7 @@ TEUCHOS_UNIT_TEST(OperatorSplit, AppAction_Modifier)
   auto Dt = solutionHistory->getWorkingState()->getTimeStep();
   TEST_FLOATING_EQUALITY(modifier->testDt, Dt, 1.0e-14);
 
-  TEST_COMPARE(modifier->testType, ==, "OperatorSplit - Modifier");
+  TEST_COMPARE(modifier->testName, ==, "OperatorSplit - Modifier");
 }
 
 // ************************************************************
@@ -269,7 +269,7 @@ public:
     : testBEGIN_STEP(false), testBEFORE_STEPPER(false),
       testAFTER_STEPPER(false), testEND_STEP(false),
       testCurrentValue(-0.99), testWorkingValue(-0.99),
-      testDt(-1.5), testType("Operator Split")
+      testDt(-1.5), testName("Operator Split")
   {}
 
   /// Destructor
@@ -298,7 +298,7 @@ public:
     case StepperOperatorSplitAppAction<double>::AFTER_STEPPER:
       {
         testAFTER_STEPPER = true;
-        testType = stepper->getStepperType();
+        testName = stepper->getStepperType();
         break;
       }
     case StepperOperatorSplitAppAction<double>::END_STEP:
@@ -321,7 +321,7 @@ public:
   double testCurrentValue;
   double testWorkingValue;
   double testDt;
-  std::string testType;
+  std::string testName;
 };
 
 TEUCHOS_UNIT_TEST(OperatorSplit, AppAction_Observer)
@@ -377,7 +377,7 @@ TEUCHOS_UNIT_TEST(OperatorSplit, AppAction_Observer)
   TEST_FLOATING_EQUALITY(observer->testWorkingValue, get_ele(*(x), 0), 1.0e-14);
   TEST_FLOATING_EQUALITY(observer->testDt, -1.5, 1.0e-14);
 
-  TEST_COMPARE(observer->testType, ==, "Operator Split");
+  TEST_COMPARE(observer->testName, ==, "Operator Split");
 }
 
 // ************************************************************

--- a/packages/tempus/unit_test/Tempus_UnitTest_OperatorSplit.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_OperatorSplit.cpp
@@ -217,8 +217,7 @@ TEUCHOS_UNIT_TEST(OperatorSplit, AppAction_Modifier)
   stepper->initialize();
 
   // Setup initial condition SolutionState --------------------
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
-    stepper->getModel()->getNominalValues();
+  auto inArgsIC = stepper->getModel()->getNominalValues();
   auto icX    = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
   auto icXDot = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x_dot());
   auto icState = Tempus::createSolutionStateX(icX, icXDot);
@@ -342,8 +341,7 @@ TEUCHOS_UNIT_TEST(OperatorSplit, AppAction_Observer)
   stepper->initialize();
 
   // Setup initial condition SolutionState --------------------
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
-    stepper->getModel()->getNominalValues();
+  auto inArgsIC = stepper->getModel()->getNominalValues();
   auto icX    = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
   auto icXDot = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x_dot());
   auto icState = Tempus::createSolutionStateX(icX, icXDot);
@@ -464,8 +462,7 @@ TEUCHOS_UNIT_TEST(OperatorSplit, AppAction_ModifierX)
   stepper->initialize();
 
   // Setup initial condition SolutionState --------------------
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
-    stepper->getModel()->getNominalValues();
+  auto inArgsIC = stepper->getModel()->getNominalValues();
   auto icX    = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
   auto icXDot = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x_dot());
   auto icState = Tempus::createSolutionStateX(icX, icXDot);

--- a/packages/tempus/unit_test/Tempus_UnitTest_SolutionHistory.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_SolutionHistory.cpp
@@ -43,7 +43,7 @@ TEUCHOS_UNIT_TEST(SolutionHistory, Default_Construction)
                                                  // as no State is set.
 
   auto model = rcp(new Tempus_Test::SinCosModel<double>());
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =model->getNominalValues();
+  auto inArgsIC = model->getNominalValues();
   auto icSolution = rcp_const_cast<Thyra::VectorBase<double> >(inArgsIC.get_x());
   auto icState = Tempus::createSolutionStateX<double>(icSolution);
   sh->addState(icState);
@@ -81,7 +81,7 @@ TEUCHOS_UNIT_TEST(SolutionHistory, Full_Construction)
 
   auto history = rcp(new std::vector<RCP<Tempus::SolutionState<double> > >);;
   auto model = rcp(new Tempus_Test::SinCosModel<double>());
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =model->getNominalValues();
+  auto inArgsIC = model->getNominalValues();
   auto icSolution = rcp_const_cast<Thyra::VectorBase<double> >(inArgsIC.get_x());
   Teuchos::RCP<Tempus::SolutionState<double> >
     icState = Tempus::createSolutionStateX<double>(icSolution);
@@ -140,7 +140,7 @@ TEUCHOS_UNIT_TEST(SolutionHistory, addState_With_Keep_Newest)
                                                  // as no State is set.
 
   auto model = rcp(new Tempus_Test::DahlquistTestModel<double>(-1.0, false));
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =model->getNominalValues();
+  auto inArgsIC = model->getNominalValues();
   auto icSoln = rcp_const_cast<Thyra::VectorBase<double> >(inArgsIC.get_x());
   auto state0 = Tempus::createSolutionStateX<double>(icSoln);
   state0->setTime (0.0);
@@ -230,7 +230,7 @@ TEUCHOS_UNIT_TEST(SolutionHistory, addState_With_Undo)
                                                  // as no State is set.
 
   auto model = rcp(new Tempus_Test::DahlquistTestModel<double>(-1.0, false));
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =model->getNominalValues();
+  auto inArgsIC = model->getNominalValues();
   auto icSoln = rcp_const_cast<Thyra::VectorBase<double> >(inArgsIC.get_x());
   auto state0 = Tempus::createSolutionStateX<double>(icSoln);
   state0->setTime (0.0);
@@ -347,7 +347,7 @@ TEUCHOS_UNIT_TEST(SolutionHistory, addState_With_Static)
   sh->setStorageLimit(7);
 
   auto model = rcp(new Tempus_Test::DahlquistTestModel<double>(-1.0, false));
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =model->getNominalValues();
+  auto inArgsIC = model->getNominalValues();
 
   // Sequential insertion.
   // ---------------------------------------------------------------------------
@@ -455,7 +455,7 @@ TEUCHOS_UNIT_TEST(SolutionHistory, removeState)
   sh->setStorageLimit(7);
 
   auto model = rcp(new Tempus_Test::DahlquistTestModel<double>(-1.0, false));
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =model->getNominalValues();
+  auto inArgsIC = model->getNominalValues();
 
   // ---------------------------------------------------------------------------
   for (size_t i=0; i < 13; ++i) {
@@ -511,7 +511,7 @@ TEUCHOS_UNIT_TEST(SolutionHistory, initWorkingState_Passing)
                                                  // as no State is set.
 
   auto model = rcp(new Tempus_Test::DahlquistTestModel<double>(-1.0, false));
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =model->getNominalValues();
+  auto inArgsIC = model->getNominalValues();
   auto icSoln = rcp_const_cast<Thyra::VectorBase<double> >(inArgsIC.get_x());
   auto state0 = Tempus::createSolutionStateX<double>(icSoln);
   state0->setTime (0.0);
@@ -564,7 +564,7 @@ TEUCHOS_UNIT_TEST(SolutionHistory, initWorkingState_Failing)
                                                  // as no State is set.
 
   auto model = rcp(new Tempus_Test::DahlquistTestModel<double>(-1.0, false));
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =model->getNominalValues();
+  auto inArgsIC = model->getNominalValues();
   auto icSoln = rcp_const_cast<Thyra::VectorBase<double> >(inArgsIC.get_x());
   auto state0 = Tempus::createSolutionStateX<double>(icSoln);
   state0->setTime (0.0);
@@ -637,7 +637,7 @@ TEUCHOS_UNIT_TEST(SolutionHistory, promoteWorkingState_Passing)
                                                  // as no State is set.
 
   auto model = rcp(new Tempus_Test::DahlquistTestModel<double>(-1.0, false));
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =model->getNominalValues();
+  auto inArgsIC = model->getNominalValues();
   auto icSoln = rcp_const_cast<Thyra::VectorBase<double> >(inArgsIC.get_x());
   auto state0 = Tempus::createSolutionStateX<double>(icSoln);
   state0->setTime (0.0);
@@ -690,7 +690,7 @@ TEUCHOS_UNIT_TEST(SolutionHistory, promoteWorkingState_Failing)
                                                  // as no State is set.
 
   auto model = rcp(new Tempus_Test::DahlquistTestModel<double>(-1.0, false));
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =model->getNominalValues();
+  auto inArgsIC = model->getNominalValues();
   auto icSoln = rcp_const_cast<Thyra::VectorBase<double> >(inArgsIC.get_x());
   auto state0 = Tempus::createSolutionStateX<double>(icSoln);
   state0->setTime (0.0);

--- a/packages/tempus/unit_test/Tempus_UnitTest_Subcycling.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_Subcycling.cpp
@@ -150,7 +150,7 @@ public:
   StepperSubcyclingModifierTest()
     : testBEGIN_STEP(false), testEND_STEP(false),
       testCurrentValue(-0.99), testWorkingValue(-0.99),
-      testDt(1.5), testType("")
+      testDt(1.5), testName("")
   {}
   /// Destructor
   virtual ~StepperSubcyclingModifierTest(){}
@@ -167,8 +167,8 @@ public:
       testBEGIN_STEP = true;
       auto x = sh->getCurrentState()->getX();
       testCurrentValue = get_ele(*(x), 0);
-      testType = "Subcycling - Modifier";
-      stepper->setStepperType(testType);
+      testName = "Subcycling - Modifier";
+      stepper->setStepperName(testName);
       break;
     }
     case StepperSubcyclingAppAction<double>::END_STEP:
@@ -191,7 +191,7 @@ public:
   double testCurrentValue;
   double testWorkingValue;
   double testDt;
-  std::string testType;
+  std::string testName;
 };
 
 TEUCHOS_UNIT_TEST(Subcycling, AppAction_Modifier)
@@ -261,7 +261,7 @@ TEUCHOS_UNIT_TEST(Subcycling, AppAction_Modifier)
   auto Dt = solutionHistory->getWorkingState()->getTimeStep();
   TEST_FLOATING_EQUALITY(modifier->testDt, Dt, 1.0e-14);
 
-  TEST_COMPARE(modifier->testType, ==, "Subcycling - Modifier");
+  TEST_COMPARE(modifier->testName, ==, "Subcycling - Modifier");
 }
 
 // ************************************************************
@@ -275,7 +275,7 @@ public:
   StepperSubcyclingObserverTest()
     : testBEGIN_STEP(false), testEND_STEP(false),
       testCurrentValue(-0.99), testWorkingValue(-0.99),
-      testDt(15.0), testType("Subcyling")
+      testDt(15.0), testName("Subcyling")
   {}
 
   /// Destructor
@@ -313,7 +313,7 @@ public:
   double testCurrentValue;
   double testWorkingValue;
   double testDt;
-  std::string testType;
+  std::string testName;
 };
 
 TEUCHOS_UNIT_TEST(Subcycling, AppAction_Observer)
@@ -382,7 +382,7 @@ TEUCHOS_UNIT_TEST(Subcycling, AppAction_Observer)
   TEST_FLOATING_EQUALITY(observer->testWorkingValue, get_ele(*(x), 0), 1.0e-14);
   TEST_FLOATING_EQUALITY(observer->testDt, 15.0, 1.0e-14);
 
-  TEST_COMPARE(observer->testType, ==, "Subcyling");
+  TEST_COMPARE(observer->testName, ==, "Subcyling");
 }
 
   // ************************************************************

--- a/packages/tempus/unit_test/Tempus_UnitTest_Subcycling.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_Subcycling.cpp
@@ -52,10 +52,19 @@ TEUCHOS_UNIT_TEST(Subcycling, Default_Construction)
   auto model   = rcp(new Tempus_Test::SinCosModel<double>());
   auto modelME = rcp_dynamic_cast<const Thyra::ModelEvaluator<double> > (model);
 
+  // Setup SolutionHistory ------------------------------------
+  auto inArgsIC = model->getNominalValues();
+  auto icSolution =rcp_const_cast<Thyra::VectorBase<double> >(inArgsIC.get_x());
+  auto icState = Tempus::createSolutionStateX(icSolution);
+  auto solutionHistory = rcp(new Tempus::SolutionHistory<double>());
+  solutionHistory->addState(icState);
+  solutionHistory->initWorkingState();
+
   // Default construction.
   auto stepper = rcp(new Tempus::StepperSubcycling<double>());
   auto stepperBE = Tempus::createStepperBackwardEuler(modelME, Teuchos::null);
   stepper->setSubcyclingStepper(stepperBE);
+  stepper->setInitialConditions(solutionHistory);
   stepper->initialize();
   TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
 
@@ -83,7 +92,8 @@ TEUCHOS_UNIT_TEST(Subcycling, Default_Construction)
   // Full argument list construction.
   auto scIntegrator = Teuchos::rcp(new Tempus::IntegratorBasic<double>());
   auto stepperFE = Tempus::createStepperForwardEuler(modelME, Teuchos::null);
-  scIntegrator->setStepperWStepper(stepperFE);
+  scIntegrator->setStepper(stepperFE);
+  scIntegrator->setSolutionHistory(solutionHistory);
   scIntegrator->initialize();
 
   stepper = rcp(new Tempus::StepperSubcycling<double>(
@@ -105,16 +115,18 @@ TEUCHOS_UNIT_TEST(Subcycling, MaxTimeStepDoesNotChangeDuring_takeStep)
   auto stepper = rcp(new Tempus::StepperSubcycling<double>());
   auto stepperBE = Tempus::createStepperBackwardEuler(modelME, Teuchos::null);
   stepper->setSubcyclingStepper(stepperBE);
-  stepper->initialize();
 
   // Setup SolutionHistory ------------------------------------
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
-    stepper->getModel()->getNominalValues();
+  auto inArgsIC = model->getNominalValues();
   auto icSolution =rcp_const_cast<Thyra::VectorBase<double> >(inArgsIC.get_x());
   auto icState = Tempus::createSolutionStateX(icSolution);
   auto solutionHistory = rcp(new Tempus::SolutionHistory<double>());
   solutionHistory->addState(icState);
   solutionHistory->initWorkingState();
+
+  // Ensure ICs are consistent and stepper memory is set (e.g., xDot is set).
+  stepper->setInitialConditions(solutionHistory);
+  stepper->initialize();
 
   // Test
   stepper->setSubcyclingInitTimeStep(0.25);
@@ -202,7 +214,6 @@ TEUCHOS_UNIT_TEST(Subcycling, AppAction_Modifier)
   stepper->setSubcyclingMaxConsecFailures(5);
   stepper->setSubcyclingScreenOutputIndexInterval(1);
   stepper->setSubcyclingPrintDtChanges(true);
-  stepper->initialize();
 
   // Setup TimeStepControl ------------------------------------
   auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
@@ -213,8 +224,7 @@ TEUCHOS_UNIT_TEST(Subcycling, AppAction_Modifier)
   timeStepControl->initialize();
 
   // Setup initial condition SolutionState --------------------
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
-    stepper->getModel()->getNominalValues();
+  auto inArgsIC = model->getNominalValues();
   auto icSolution = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
   auto icState = Tempus::createSolutionStateX(icSolution);
   icState->setTime    (timeStepControl->getInitTime());;
@@ -228,6 +238,10 @@ TEUCHOS_UNIT_TEST(Subcycling, AppAction_Modifier)
   solutionHistory->setStorageType(Tempus::STORAGE_TYPE_STATIC);
   solutionHistory->setStorageLimit(2);
   solutionHistory->addState(icState);
+
+  // Ensure ICs are consistent and stepper memory is set (e.g., xDot is set).
+  stepper->setInitialConditions(solutionHistory);
+  stepper->initialize();
 
   // Take one time step.
   stepper->setInitialConditions(solutionHistory);
@@ -322,7 +336,6 @@ TEUCHOS_UNIT_TEST(Subcycling, AppAction_Observer)
   stepper->setSubcyclingMaxConsecFailures(5);
   stepper->setSubcyclingScreenOutputIndexInterval(1);
   stepper->setSubcyclingPrintDtChanges(true);
-  stepper->initialize();
 
   // Setup TimeStepControl ------------------------------------
   auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
@@ -333,8 +346,7 @@ TEUCHOS_UNIT_TEST(Subcycling, AppAction_Observer)
   timeStepControl->initialize();
 
   // Setup initial condition SolutionState --------------------
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
-    stepper->getModel()->getNominalValues();
+  auto inArgsIC = model->getNominalValues();
   auto icSolution = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
   auto icState = Tempus::createSolutionStateX(icSolution);
   icState->setTime    (timeStepControl->getInitTime());;
@@ -348,6 +360,10 @@ TEUCHOS_UNIT_TEST(Subcycling, AppAction_Observer)
   solutionHistory->setStorageType(Tempus::STORAGE_TYPE_STATIC);
   solutionHistory->setStorageLimit(2);
   solutionHistory->addState(icState);
+
+  // Ensure ICs are consistent and stepper memory is set (e.g., xDot is set).
+  stepper->setInitialConditions(solutionHistory);
+  stepper->initialize();
 
   // Take one time step.
   stepper->setInitialConditions(solutionHistory);
@@ -441,7 +457,6 @@ TEUCHOS_UNIT_TEST(Subcycling, AppAction_ModifierX)
   stepper->setSubcyclingMaxConsecFailures(5);
   stepper->setSubcyclingScreenOutputIndexInterval(1);
   stepper->setSubcyclingPrintDtChanges(true);
-  stepper->initialize();
 
   // Setup TimeStepControl ------------------------------------
   auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
@@ -452,8 +467,7 @@ TEUCHOS_UNIT_TEST(Subcycling, AppAction_ModifierX)
   timeStepControl->initialize();
 
   // Setup initial condition SolutionState --------------------
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
-    stepper->getModel()->getNominalValues();
+  auto inArgsIC = model->getNominalValues();
   auto icSolution = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
   auto icSolutionDot = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x_dot());
   auto icState = Tempus::createSolutionStateX(icSolution,icSolutionDot);
@@ -468,6 +482,10 @@ TEUCHOS_UNIT_TEST(Subcycling, AppAction_ModifierX)
   solutionHistory->setStorageType(Tempus::STORAGE_TYPE_STATIC);
   solutionHistory->setStorageLimit(2);
   solutionHistory->addState(icState);
+
+  // Ensure ICs are consistent and stepper memory is set (e.g., xDot is set).
+  stepper->setInitialConditions(solutionHistory);
+  stepper->initialize();
 
   // Take one time step.
   stepper->setInitialConditions(solutionHistory);

--- a/packages/tempus/unit_test/Tempus_UnitTest_TimeStepControl.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_TimeStepControl.cpp
@@ -476,8 +476,6 @@ TEUCHOS_UNIT_TEST(TimeStepControl, getValidParameters)
       "WARNING: Parameter \"Time Step Control Strategy\"    [unused] is unused\n");
   }
 
-  std::cout << "\n pl = \n" << *pl << std::endl;
-
   auto tscs_PL = pl->sublist("Time Step Control Strategy");
   TEST_COMPARE          ( tscs_PL.get<std::string>("Strategy Type")  , ==, "Constant");
   TEST_FLOATING_EQUALITY( tscs_PL.get<double>("Time Step"), 0.0, 1.0e-14);
@@ -533,7 +531,7 @@ TEUCHOS_UNIT_TEST(TimeStepControl, SetDtAfterOutput_Variable)
 {
   // Setup the SolutionHistory --------------------------------
   auto model   = rcp(new Tempus_Test::SinCosModel<double>());
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =model->getNominalValues();
+  auto inArgsIC = model->getNominalValues();
   auto icSolution = rcp_const_cast<Thyra::VectorBase<double> >(inArgsIC.get_x());
   auto icState = Tempus::createSolutionStateX<double>(icSolution);
   auto solutionHistory = rcp(new Tempus::SolutionHistory<double>());
@@ -598,7 +596,7 @@ TEUCHOS_UNIT_TEST(TimeStepControl, SetDtAfterOutput_Constant)
 {
   // Setup the SolutionHistory --------------------------------
   auto model   = rcp(new Tempus_Test::SinCosModel<double>());
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =model->getNominalValues();
+  auto inArgsIC = model->getNominalValues();
   auto icSolution =rcp_const_cast<Thyra::VectorBase<double> >(inArgsIC.get_x());
   auto icState = Tempus::createSolutionStateX<double>(icSolution);
   auto solutionHistory = rcp(new Tempus::SolutionHistory<double>());
@@ -660,7 +658,7 @@ TEUCHOS_UNIT_TEST(TimeStepControl, ConstantTimeStep_Roundoff)
 {
   // Setup the SolutionHistory --------------------------------
   auto model   = rcp(new Tempus_Test::SinCosModel<double>());
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =model->getNominalValues();
+  auto inArgsIC = model->getNominalValues();
   auto icSolution =rcp_const_cast<Thyra::VectorBase<double> >(inArgsIC.get_x());
   auto icState = Tempus::createSolutionStateX<double>(icSolution);
   auto solutionHistory = rcp(new Tempus::SolutionHistory<double>());

--- a/packages/tempus/unit_test/Tempus_UnitTest_TimeStepControlStrategyBasicVS.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_TimeStepControlStrategyBasicVS.cpp
@@ -129,7 +129,7 @@ TEUCHOS_UNIT_TEST(TimeStepControlStrategyBasicVS, setNextTimeStep)
 
   // Setup the SolutionHistory --------------------------------
   auto model = rcp(new Tempus_Test::DahlquistTestModel<double>());
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =model->getNominalValues();
+  auto inArgsIC = model->getNominalValues();
   auto icSolution = rcp_const_cast<Thyra::VectorBase<double> >(inArgsIC.get_x());
   auto icState = Tempus::createSolutionStateX<double>(icSolution);
   auto solutionHistory = rcp(new Tempus::SolutionHistory<double>());

--- a/packages/tempus/unit_test/Tempus_UnitTest_TimeStepControlStrategyConstant.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_TimeStepControlStrategyConstant.cpp
@@ -100,7 +100,7 @@ TEUCHOS_UNIT_TEST(TimeStepControlStrategyConstant, setNextTimeStep)
 
   // Setup the SolutionHistory --------------------------------
   auto model   = rcp(new Tempus_Test::SinCosModel<double>());
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =model->getNominalValues();
+  auto inArgsIC = model->getNominalValues();
   auto icSolution = rcp_const_cast<Thyra::VectorBase<double> >(inArgsIC.get_x());
   auto icState = Tempus::createSolutionStateX<double>(icSolution);
   auto solutionHistory = rcp(new Tempus::SolutionHistory<double>());

--- a/packages/tempus/unit_test/Tempus_UnitTest_TimeStepControlStrategyIntegralController.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_TimeStepControlStrategyIntegralController.cpp
@@ -156,7 +156,7 @@ TEUCHOS_UNIT_TEST(TimeStepControlStrategyIntegralController, setNextTimeStep)
 
   // Setup the SolutionHistory --------------------------------
   auto model = rcp(new Tempus_Test::DahlquistTestModel<double>());
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =model->getNominalValues();
+  auto inArgsIC = model->getNominalValues();
   auto icSolution = rcp_const_cast<Thyra::VectorBase<double> >(inArgsIC.get_x());
   auto icState = Tempus::createSolutionStateX<double>(icSolution);
   auto solutionHistory = rcp(new Tempus::SolutionHistory<double>());

--- a/packages/tempus/unit_test/Tempus_UnitTest_Trapezoidal.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_Trapezoidal.cpp
@@ -103,7 +103,7 @@ public:
     : testBEGIN_STEP(false), testBEFORE_SOLVE(false),
       testAFTER_SOLVE(false), testEND_STEP(false),
       testCurrentValue(-0.99), testWorkingValue(-0.99),
-      testDt(-1.5), testType("")
+      testDt(-1.5), testName("")
   {}
 
   /// Destructor
@@ -133,8 +133,8 @@ public:
     case StepperTrapezoidalAppAction<double>::AFTER_SOLVE:
       {
         testAFTER_SOLVE = true;
-        testType = "Trapezoidal - Modifier";
-        stepper->setStepperType(testType);
+        testName = "Trapezoidal - Modifier";
+        stepper->setStepperName(testName);
         break;
       }
     case StepperTrapezoidalAppAction<double>::END_STEP:
@@ -157,7 +157,7 @@ public:
   double testCurrentValue;
   double testWorkingValue;
   double testDt;
-  std::string testType;
+  std::string testName;
 };
 
 TEUCHOS_UNIT_TEST(Trapezoidal, AppAction_Modifier)
@@ -195,7 +195,7 @@ TEUCHOS_UNIT_TEST(Trapezoidal, AppAction_Modifier)
   TEST_FLOATING_EQUALITY(modifier->testWorkingValue, get_ele(*(x), 0), 1.0e-14);
   auto Dt = solutionHistory->getWorkingState()->getTimeStep();
   TEST_FLOATING_EQUALITY(modifier->testDt, Dt, 1.0e-14);
-  TEST_COMPARE(modifier->testType, ==, "Trapezoidal - Modifier");
+  TEST_COMPARE(modifier->testName, ==, "Trapezoidal - Modifier");
 }
 
 // ************************************************************
@@ -210,7 +210,7 @@ public:
     : testBEGIN_STEP(false), testBEFORE_SOLVE(false),
       testAFTER_SOLVE(false), testEND_STEP(false),
       testCurrentValue(-0.99), testWorkingValue(-0.99),
-      testDt(-1.5), testType("")
+      testDt(-1.5), testName("")
   {}
 
   /// Destructor
@@ -239,7 +239,7 @@ public:
     case StepperTrapezoidalAppAction<double>::AFTER_SOLVE:
     {
       testAFTER_SOLVE = true;
-      testType = stepper->getStepperType();
+      testName = stepper->getStepperType();
       break;
     }
     case StepperTrapezoidalAppAction<double>::END_STEP:
@@ -261,7 +261,7 @@ public:
   double testCurrentValue;
   double testWorkingValue;
   double testDt;
-  std::string testType;
+  std::string testName;
 };
 
 TEUCHOS_UNIT_TEST(Trapezoidal, AppAction_Observer)
@@ -298,7 +298,7 @@ TEUCHOS_UNIT_TEST(Trapezoidal, AppAction_Observer)
   x = solutionHistory->getWorkingState()->getX();
   TEST_FLOATING_EQUALITY(observer->testWorkingValue, get_ele(*(x), 0), 1.0e-14);
   TEST_FLOATING_EQUALITY(observer->testDt, dt, 1.0e-14);
-  TEST_COMPARE(observer->testType, ==, "Trapezoidal Method");
+  TEST_COMPARE(observer->testName, ==, "Trapezoidal Method");
 }
 
 // ************************************************************

--- a/packages/tempus/unit_test/Tempus_UnitTest_Utils.hpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_Utils.hpp
@@ -317,7 +317,7 @@ public:
       testCurrentValue(-0.99),
       testWorkingValue(-0.99),
       testDt(-1.5),
-      testType("")
+      testName("")
   {}
 
   /// Destructor
@@ -335,8 +335,8 @@ public:
         testBEGIN_STEP = true;
         auto x = sh->getCurrentState()->getX();
         testCurrentValue = get_ele(*(x), 0);
-        testType = stepper->getStepperType() + " - Modifier";
-        stepper->setStepperType(testType);
+        testName = stepper->getStepperType() + " - Modifier";
+        stepper->setStepperName(testName);
         break;
       }
       case StepperRKAppAction<double>::BEGIN_STAGE:
@@ -388,7 +388,7 @@ public:
   double testCurrentValue;
   double testWorkingValue;
   double testDt;
-  std::string testType;
+  std::string testName;
 };
 
 
@@ -411,7 +411,7 @@ public:
       testCurrentValue(-0.99),
       testWorkingValue(-0.99),
       testDt(-1.5),
-      testType("")
+      testName("")
   {}
 
   /// Destructor
@@ -445,7 +445,7 @@ public:
       case StepperRKAppAction<double>::AFTER_SOLVE:
       {
         testAFTER_SOLVE = true;
-        testType = stepper->getStepperType() + " - Observer";
+        testName = stepper->getStepperType() + " - Observer";
         break;
       }
       case StepperRKAppAction<double>::BEFORE_EXPLICIT_EVAL:
@@ -481,7 +481,7 @@ public:
   double testCurrentValue;
   double testWorkingValue;
   double testDt;
-  std::string testType;
+  std::string testName;
 };
 
 
@@ -588,7 +588,7 @@ void testRKAppAction(
   const Teuchos::RCP<const Thyra::ModelEvaluator<double> >& model,
   Teuchos::FancyOStream &out, bool &success)
 {
-  auto testTypeOrig = stepper->getStepperType();
+  auto testNameOrig = stepper->getStepperType();
 
   // Test Modifier.
   {
@@ -597,7 +597,7 @@ void testRKAppAction(
     stepper->setAppAction(modifier);
     stepper->initialize();
     TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
-    auto testType = testTypeOrig + " - Modifier";
+    auto testName = testNameOrig + " - Modifier";
 
     // Create a SolutionHistory.
     auto solutionHistory = Tempus::createSolutionHistoryME(model);
@@ -626,7 +626,7 @@ void testRKAppAction(
     auto Dt = solutionHistory->getWorkingState()->getTimeStep();
     TEST_FLOATING_EQUALITY(modifier->testDt, Dt/10.0, 1.0e-14);
 
-    TEST_COMPARE(modifier->testType, ==, testType);
+    TEST_COMPARE(modifier->testName, ==, testName);
   }
 
   // Test Observer.
@@ -634,7 +634,7 @@ void testRKAppAction(
     stepper->setModel(model);
     auto observer = rcp(new StepperRKObserverTest());
     stepper->setAppAction(observer);
-    stepper->setStepperType(testTypeOrig);
+    stepper->setStepperName(testNameOrig);
     stepper->initialize();
     TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
 
@@ -665,8 +665,8 @@ void testRKAppAction(
     auto Dt = solutionHistory->getWorkingState()->getTimeStep();
     TEST_FLOATING_EQUALITY(observer->testDt, Dt/10.0, 1.0e-14);
 
-    auto testType = testTypeOrig + " - Observer";
-    TEST_COMPARE(observer->testType, ==, testType);
+    auto testName = testNameOrig + " - Observer";
+    TEST_COMPARE(observer->testName, ==, testName);
   }
 
   // Test ModifierX.
@@ -674,7 +674,7 @@ void testRKAppAction(
     stepper->setModel(model);
     auto modifierX = rcp(new StepperRKModifierXTest());
     stepper->setAppAction(modifierX);
-    stepper->setStepperType(testTypeOrig);
+    stepper->setStepperName(testNameOrig);
     stepper->initialize();
     TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
 
@@ -881,8 +881,8 @@ void testRKAppAction(
     TEST_FLOATING_EQUALITY(modifier->testWorkingValue, get_ele(*(xWS), 0),relTol);
     TEST_FLOATING_EQUALITY(modifier->testDt, Dt/10.0, relTol);
 
-    auto testType = testTypeOrig + " - Modifier";
-    TEST_COMPARE(modifier->testType, ==, testType);
+    auto testName = testNameOrig + " - Modifier";
+    TEST_COMPARE(modifier->testName, ==, testName);
 
 
     // Test Observer.
@@ -900,8 +900,8 @@ void testRKAppAction(
     TEST_FLOATING_EQUALITY(observer->testWorkingValue, get_ele(*(xWS), 0),relTol);
     TEST_FLOATING_EQUALITY(observer->testDt, Dt/10.0, relTol);
 
-    testType = testType + " - Observer";
-    TEST_COMPARE(observer->testType, ==, testType);
+    testName = testNameOrig + " - Observer";
+    TEST_COMPARE(observer->testName, ==, testName);
 
 
     // Test ModifierX.


### PR DESCRIPTION
Remove all the internal uses of ParameterList from IntegratorBasic.
This means moving the variables in the IntegratorBasic ParameterList
to member data. Integrator will not longer inherit from
Teuchos::ParameterListAcceptor. However IntegratorBasic can still
be built from a ParameterList, and will still provide a valid
ParameterList.

 * To break up these changes, created a copy of IntegratorBasic
   (i.e., IntegratorBasicOld) for the sensitivity analysis integrators
    - IntegratorAdjointSensitivity
    - IntegratorForwardSensitivity
    - IntegratorPseudoTransientAdjointSensitivity
    - IntegratorPseudoTransientForwardSensitivity
   so these can be upgraded in another PR.
 * IntegratorBasic is no longer inherited from ParameterListAcceptor.
    - Removed setParameterList.
    - IntegratorBasic constructors using ParameterLists have moved to
      nonmember constructors, e.g.,
      . integratorBasic(pl, model) --> createIntegratorBasic(pl, model)
      . IntegratorBasic(pl, model) --> createIntegratorBasic(pl, model)
    - Member data ParameterLists are removed.
    - Kept getValidParameters(), which now returns a ParameterList
      with the current values. Still matches ParameterListAcceptor
      signature.
 * Ensured that ParameterList names were correctly set, so
   getValidParameters() could be used to create nested ParameterLists,
   e.g., IntegratorBasic->Stepper->Solver.
 * Made getValidParametersBasic() a member functions of Stepper class.
 * Simplified setting the Stepper to just setStepper(stepper).
 * Added method to set model on stepper in IntegratorBasic,
   i.e., setModel(model).
 * The integrator observer is no longer a composite observer.
   It is simply a base class observer.
 * All internal IntegratorBasic references to member ParameterLists
   are changed to member data.
 * Added member data for the integrator name and type.  Name is a
   label that used for identification, e.g., 'My Integrator Basic'.
   Type defines the derived class being used, e.g., 'Integrator Basic'.
 * Added a shallow copy for the SolutionHistory.

@trilinos/tempus 

## Motivation
Part of improving data transparency requested from ASC applications.

* Closes #8704 
