### PR TITLE
Adding unique identifier to partitioned worksets

### DIFF
--- a/packages/panzer/disc-fe/src/Panzer_SetupPartitionedWorksetUtilities.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_SetupPartitionedWorksetUtilities.cpp
@@ -82,9 +82,15 @@ buildPartitionedWorksets(const panzer::LocalMeshInfo & mesh_info,
   std::vector<panzer::LocalMeshPartition> partitions;
   panzer::generateLocalMeshPartitions(mesh_info, description, partitions);
 
+  int i=0;
   for(const auto & partition : partitions){
     worksets->push_back(panzer::Workset());
     convertMeshPartitionToWorkset(partition, orientations, worksets->back());
+
+    // We hash in a unique id the the given workset
+    size_t id = std::hash<WorksetDescriptor>()(description);
+    panzer::hash_combine(id, i++);
+    worksets->back().setIdentifier(id);
   }
 
   return worksets;


### PR DESCRIPTION
@trilinos/panzer 

## Motivation

Found bug relating to uniquely identifying worksets constructed using the partitioned workset path.


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->