### PR TITLE
Belos: Update Gmres polynomial so degrees match in all versions

### DIFF
--- a/packages/belos/src/BelosGmresPolyOp.hpp
+++ b/packages/belos/src/BelosGmresPolyOp.hpp
@@ -417,7 +417,7 @@ namespace Belos {
   template <class ScalarType, class MV, class OP>
   void GmresPolyOp<ScalarType, MV, OP>::generateGmresPoly()
   {
-    Teuchos::RCP< MV > V = MVT::Clone( *problem_->getRHS(), maxDegree_+2 );   
+    Teuchos::RCP< MV > V = MVT::Clone( *problem_->getRHS(), maxDegree_+1 );   
 
     //Make power basis:
     std::vector<int> index(1,0);
@@ -436,7 +436,7 @@ namespace Belos {
       problem_->apply( *Vtemp, *V0);
     }
 
-    for(int i=0; i< maxDegree_+1; i++)
+    for(int i=0; i< maxDegree_; i++)
     {
       index[0] = i;
       Teuchos::RCP< const MV > Vi = MVT::CloneView(*V, index);
@@ -446,11 +446,11 @@ namespace Belos {
     }
 
     //Consider AV:
-    Teuchos::Range1D range( 1, maxDegree_+1);
+    Teuchos::Range1D range( 1, maxDegree_);
     Teuchos::RCP< const MV > AV = MVT::CloneView( *V, range);
    
     //Make lhs (AV)^T(AV)
-    Teuchos::SerialDenseMatrix< OT, ScalarType > AVtransAV( maxDegree_+1, maxDegree_+1);
+    Teuchos::SerialDenseMatrix< OT, ScalarType > AVtransAV( maxDegree_, maxDegree_);
     MVT::MvTransMv( SCT::one(), *AV, *AV, AVtransAV);
     //This process adds pDeg*pDeg + pDeg inner products that aren't in the final count.
 
@@ -462,8 +462,8 @@ namespace Belos {
     Teuchos::SerialDenseMatrix< OT, ScalarType > lhs;
     while( status && dim_ >= 1)
     {
-      Teuchos::SerialDenseMatrix< OT, ScalarType > lhstemp(Teuchos::Copy, AVtransAV,  dim_+1, dim_+1);
-      lapack.POTRF( 'U', dim_+1, lhstemp.values(), lhstemp.stride(), &infoInt);
+      Teuchos::SerialDenseMatrix< OT, ScalarType > lhstemp(Teuchos::Copy, AVtransAV,  dim_, dim_);
+      lapack.POTRF( 'U', dim_, lhstemp.values(), lhstemp.stride(), &infoInt);
       
       if(autoDeg == false)
       { 
@@ -498,14 +498,14 @@ namespace Belos {
     } 
     else
     {
-      pCoeff_.shape( dim_+1, 1);
+      pCoeff_.shape( dim_, 1);
       //Get correct submatrix of AV:
-      Teuchos::Range1D rangeSub( 1, dim_+1);
+      Teuchos::Range1D rangeSub( 1, dim_);
       Teuchos::RCP< const MV > AVsub = MVT::CloneView( *V, rangeSub);
       
       //Compute rhs (AV)^T V0
       MVT::MvTransMv( SCT::one(), *AVsub, *V0, pCoeff_);
-      lapack.POTRS( 'U', dim_+1, 1, lhs.values(), lhs.stride(), pCoeff_.values(), pCoeff_.stride(), &infoInt);
+      lapack.POTRS( 'U', dim_, 1, lhs.values(), lhs.stride(), pCoeff_.values(), pCoeff_.stride(), &infoInt);
       if(infoInt != 0) 
       {
         std::cout << "BelosGmresPolyOp.hpp: LAPACK POTRS was not successful!!" << std::endl;

--- a/packages/belos/src/BelosGmresPolyOp.hpp
+++ b/packages/belos/src/BelosGmresPolyOp.hpp
@@ -920,7 +920,7 @@ namespace Belos {
 #endif
       MVT::MvAddMv(pCoeff_(0,0), *AX, SCT::zero(), y, y); //y= coeff_i(A^ix)
     }
-    for( int i=1; i < dim_+1; i++)
+    for( int i=1; i < dim_; i++)
     {
       Teuchos::RCP<MV> X, Y;
       if ( i%2 )

--- a/packages/belos/src/BelosGmresPolySolMgr.hpp
+++ b/packages/belos/src/BelosGmresPolySolMgr.hpp
@@ -111,7 +111,9 @@ class GmresPolySolMgrPolynomialFailure : public BelosError {public:
 ///   - "Polynomial Tolerance" (\c MagnitudeType): The level that
 ///     residual norms must reach to decide convergence. Default:
 ///     1e-8.
-///   - "Maximum Degree" (\c int): Requested maximum degree for the polynomial. Default: 25
+///   - "Maximum Degree" (\c int): Requested maximum degree for the polynomial. 
+///      The preconditioned problem Ap(A) will have this degree, while the polynomial
+//       p(A) will have degree deg-1.  Default: 25
 ///   - "Random RHS" (\c bool): to generate the polynomial using a random vector. Default: true
 ///   - "Add Roots" (\c bool): to add roots to the polynomial as needed for stability. Default: true
 ///   - "Damp Poly" (\c bool): to damp polynomial. Default: false

--- a/packages/belos/src/BelosGmresPolySolMgr.hpp
+++ b/packages/belos/src/BelosGmresPolySolMgr.hpp
@@ -113,7 +113,7 @@ class GmresPolySolMgrPolynomialFailure : public BelosError {public:
 ///     1e-8.
 ///   - "Maximum Degree" (\c int): Requested maximum degree for the polynomial. 
 ///      The preconditioned problem Ap(A) will have this degree, while the polynomial
-//       p(A) will have degree deg-1.  Default: 25
+///       p(A) will have degree deg-1.  Default: 25
 ///   - "Random RHS" (\c bool): to generate the polynomial using a random vector. Default: true
 ///   - "Add Roots" (\c bool): to add roots to the polynomial as needed for stability. Default: true
 ///   - "Damp Poly" (\c bool): to damp polynomial. Default: false


### PR DESCRIPTION
This is a very minor fix so that all three versions (Gmres, Arnoldi, and Roots) of the Gmres polynomial solver/preconditioner have consistent degree implementations.  Previously, the Gmres version was 'off by one'.  The GMRES polynomial would apply "max-degree" to p(A), while the other versions let "max-degree" indicate the degree of Ap(A).  Now all three versions do the latter.  

This code is tested in Belos_Tpetra_HybridGMRES_hb_test.exe.