### PR TITLE
Move the TPETRA_ASSUME_CUDA_AWARE_MPI to the environment

### DIFF
--- a/cmake/std/PullRequestLinuxCuda10.1.243TestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxCuda10.1.243TestingSettings.cmake
@@ -31,7 +31,8 @@ set (Trilinos_ENABLE_DEBUG OFF CACHE BOOL "Set by default for CUDA PR testing")
 set (Trilinos_ENABLE_DEBUG_SYMBOLS OFF CACHE BOOL "Set by default for CUDA PR testing")
 set (BUILD_SHARED_LIBS OFF CACHE BOOL "Set by default for CUDA PR testing")
 set (Tpetra_INST_SERIAL ON CACHE BOOL "Set by default for CUDA PR testing")
-set (TPETRA_ASSUME_CUDA_AWARE_MPI ON CACHE BOOL "Set by default for CUDA PR testing")
+## this was moved to the environment settings in sems/PullRequestCuda10.1.243TestingEnv.sh
+## set (TPETRA_ASSUME_CUDA_AWARE_MPI ON CACHE BOOL "Set by default for CUDA PR testing")
 
 set (Trilinos_ENABLE_SECONDARY_TESTED_CODE OFF CACHE BOOL "Set by default for CUDA PR testing")
 set (EpetraExt_ENABLE_HDF5 OFF CACHE BOOL "Set by default for CUDA PR testing")

--- a/cmake/std/pr_config/pullrequest.ini
+++ b/cmake/std/pr_config/pullrequest.ini
@@ -378,6 +378,7 @@ setenv OMPI_FC: gfortran
 setenv TRILINOS_DIR: ${WORKSPACE}/Trilinos
 setenv CUDA_LAUNCH_BLOCKING: 1
 setenv CUDA_MANAGED_FORCE_DEVICE_ALLOC: 1
+setenv TPETRA_ASSUME_CUDA_AWARE_MPI: 1
 setenv PATH_TMP: /projects/atdm_devops/vortex/cmake-3.17.2/bin:${PATH}
 setenv PATH:     /projects/atdm_devops/vortex/ninja-fortran-1.8.2:${PATH_TMP}
 unsetenv PATH_TMP:

--- a/cmake/std/sems/PullRequestCuda10.1.243TestingEnv.sh
+++ b/cmake/std/sems/PullRequestCuda10.1.243TestingEnv.sh
@@ -16,6 +16,10 @@ export OMPI_FC=`which gfortran`
 export CUDA_LAUNCH_BLOCKING=1
 export CUDA_MANAGED_FORCE_DEVICE_ALLOC=1
 
+## Set the cuda_aware_mpi in the environment as the shell script
+## will not get the CMake variable settings.
+export TPETRA_ASSUME_CUDA_AWARE_MPI=1
+
 # Use manually installed cmake and ninja to try to avoid module loading
 # problems (see TRIL-208)
 export PATH=/projects/atdm_devops/vortex/cmake-3.17.2/bin:$PATH


### PR DESCRIPTION
It looks like the trilinos_jsrun is not getting
CMake variables settings (of course) so I am moving
this into the environemnt settings.

@trilinos/framework 

## Related Issues

* Part of #8796


