### PR TITLE
atdm/ats2: Only run Adelus tests with TPETRA_ASSUME_CUDA_AWARE_MPI=1

### DIFF
--- a/cmake/ctest/drivers/atdm/ats2/local-driver.sh
+++ b/cmake/ctest/drivers/atdm/ats2/local-driver.sh
@@ -32,6 +32,8 @@ fi
 
 # Allow default setting for TPETRA_ASSUME_CUDA_AWARE_MPI=0 in trilinos_jsrun
 unset TPETRA_ASSUME_CUDA_AWARE_MPI
+atdm_config_ctest_regex_old="$ATDM_CONFIG_CTEST_REGEX"
+export ATDM_CONFIG_CTEST_REGEX="$ATDM_CONFIG_CTEST_REGEX -E Adelus*"
 
 echo
 echo "======================================================================="
@@ -43,6 +45,8 @@ echo
 set -x
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ats2/local-driver-single-build.sh
 set +x
+
+export ATDM_CONFIG_CTEST_REGEX="$atdm_config_ctest_regex_old"
 
 if [[ "${Trilinos_CTEST_RUN_CUDA_AWARE_MPI}" == "1" ]]; then
   echo

--- a/cmake/std/atdm/ats2/tweaks/Tweaks.cmake
+++ b/cmake/std/atdm/ats2/tweaks/Tweaks.cmake
@@ -10,6 +10,12 @@ ATDM_SET_CACHE(Trilinos_CUDA_SLOTS_PER_GPU 2 CACHE STRING)
 # Disables across multiple builds on 'ats2'
 #
 
+IF (ATDM_NODE_TYPE STREQUAL "CUDA")
+  # Adelus always needs -M -gpu passed to jsrun, but trilinos_jsrun cannot support this
+  # for single rank MPI processes without breaking the invocation of other Trilinos tests
+  ATDM_SET_ENABLE(Adelus_vector_random_MPI_1_DISABLE ON)
+ENDIF()
+
 IF (ATDM_CMAKE_BUILD_TYPE STREQUAL "DEBUG")
 
   # Disable some expensive KokkosKernels tests in pure debug builds (#6464)


### PR DESCRIPTION
  - Skip Adelus tests when TPETRA_ASSUME_CUDA_AWARE_MPI is 0.
  Related to #8477.

## How was this tested?
On ats2 via:
```
nohup env Trilinos_PACKAGES=Kokkos,Adelus ./ctest-s-local-test-driver.sh all &>ctest-s-local-test-driver.out &
```

Test results posted [here](https://testing-dev.sandia.gov/cdash/index.php?project=Trilinos&date=2021-03-29&filtercount=2&showfilters=1&filtercombine=and&field1=buildname&compare1=63&value1=ats2&field2=groupname&compare2=63&value2=Experimental).