### PR TITLE
Sacado:  Reorder SFad<> val and dx fields for stria

### DIFF
--- a/packages/sacado/src/new_design/Sacado_Fad_Exp_StaticFixedStorage.hpp
+++ b/packages/sacado/src/new_design/Sacado_Fad_Exp_StaticFixedStorage.hpp
@@ -239,11 +239,11 @@ namespace Sacado {
 
     protected:
 
-      //! Derivative array
-      T dx_[Num];
-
       //! Value
       T val_;
+
+      //! Derivative array
+      T dx_[Num];
 
     }; // class StaticFixedStorage
 


### PR DESCRIPTION
This reverts to the previous ordering of the val and dx fields
in the StaticFixedStorage type for SFad (with val first and dx
second) to workaround compiler seg faults on stria.