### PR TITLE
Tpetra: add backup of scripts for perf testing

### DIFF
--- a/packages/tpetra/scripts/PerformanceTesting/README.txt
+++ b/packages/tpetra/scripts/PerformanceTesting/README.txt
@@ -1,0 +1,7 @@
+These directories (eclipse, stria, vortex) should be placed in the
+trilinos-performance SEMS data store, in a subdirectory 'Scripts'.
+
+This is accessible on the SRN machine 'sherlock' at
+/storage/elements/sems-data-store/trilinos-performance/Scripts
+
+The Jenkins jobs download these scripts from the data store.

--- a/packages/tpetra/scripts/PerformanceTesting/eclipse/JenkinsAction.sh
+++ b/packages/tpetra/scripts/PerformanceTesting/eclipse/JenkinsAction.sh
@@ -1,0 +1,26 @@
+#Set up other env variables
+#$DATASTORE is the path to SEMS data store on sherlock
+export DATASTORE="/storage/elements/sems-data-store/trilinos-performance"
+export DATASTORE_MIRROR="/storage/elements/sems-data-store/trilinos-performance-son"
+export WATCHR_PERF_DIR="$WORKSPACE/EclipseData"
+export TRILINOS_SRC="$WORKSPACE/Trilinos"
+#Remove script dir, if it exists
+rm -rf EclipsePerfScripts
+#Get a fresh copy
+scp -rp jenkins@sherlock.sandia.gov:$DATASTORE/Scripts/eclipse EclipsePerfScripts || true
+#Copy the newest performance report tarball from data store
+scp -p jenkins@sherlock.sandia.gov:$DATASTORE/EclipseData.tar.gz EclipseData.tar.gz || true
+#Unpack it
+rm -rf EclipseData
+tar -xf EclipseData.tar.gz
+#Create build dir, if not already there.
+#Don't need to clear it out, since script will reconfigure everything.
+#Even with reconfigure, this is an incremental build, saving a lot of time.
+mkdir -p build
+#Configure and build on a compute node, then run run tests on 4 compute nodes.
+$WORKSPACE/EclipsePerfScripts/launch.sh
+#Repack the up to date tarball of data, and put back in both datastores
+tar -czf EclipseData.tar.gz EclipseData
+scp -p EclipseData.tar.gz jenkins@sherlock.sandia.gov:$DATASTORE/EclipseData.tar.gz || true
+scp -p EclipseData.tar.gz jenkins@watson.sandia.gov:$DATASTORE_MIRROR/EclipseData.tar.gz || true
+

--- a/packages/tpetra/scripts/PerformanceTesting/eclipse/configBuildTest.sh
+++ b/packages/tpetra/scripts/PerformanceTesting/eclipse/configBuildTest.sh
@@ -1,0 +1,47 @@
+#!/bin/bash -e
+
+export WATCHR_BUILD_NAME="Eclipse Serial"
+source $TRILINOS_SRC/cmake/std/atdm/load-env.sh cts1-intel-19.0.4_openmpi-4.0.3_serial_static_opt
+
+#Update Trilinos (should always be on develop branch)
+cd $TRILINOS_SRC
+git fetch origin
+git reset --hard origin/develop
+export TRILINOS_GIT_SHA=`git rev-parse HEAD`
+
+cd $WORKSPACE/build
+
+rm -rf CMakeFiles
+rm -f CMakeCache.txt
+
+cmake \
+-DCMAKE_BUILD_TYPE=Release \
+-DTrilinos_TEST_CATEGORIES=PERFORMANCE \
+-DTrilinos_ENABLE_TESTS=ON \
+-DTrilinos_ENABLE_EXAMPLES=ON \
+-DTrilinos_ENABLE_Tpetra=ON \
+-DTrilinos_ENABLE_MueLu=ON \
+-DTrilinos_ENABLE_PanzerMiniEM=ON \
+-DTrilinos_ENABLE_Percept=OFF \
+-DTpetra_INST_SERIAL=ON \
+-DTpetra_INST_INT_INT=ON \
+-DXpetra_ENABLE_Epetra=ON \
+-DMueLu_ENABLE_Epetra=ON \
+-DTPL_ENABLE_HDF5=ON \
+-DTPL_ENABLE_Netcdf=OFF \
+-DHDF5_INCLUDE_DIRS="$HDF5_ROOT/include" \
+-DHDF5_LIBRARY_DIRS="$HDF5_ROOT/lib" \
+-DTPL_ENABLE_Matio=OFF \
+-DTPL_ENABLE_X11=OFF \
+-DTPL_ENABLE_CGNS=OFF \
+-DTrilinos_ENABLE_EXPLICIT_INSTANTIATION=ON \
+-DTrilinos_CONFIGURE_OPTIONS_FILE:STRING=$TRILINOS_SRC/cmake/std/atdm/ATDMDevEnv.cmake \
+-DTPL_ENABLE_MPI=ON \
+-DKokkos_ENABLE_SERIAL=ON \
+-DMPI_EXEC_MAX_NUMPROCS=36 \
+-DTrilinos_ENABLE_PyTrilinos=OFF \
+$TRILINOS_SRC
+
+make -j36
+
+ctest || true

--- a/packages/tpetra/scripts/PerformanceTesting/eclipse/launch.sh
+++ b/packages/tpetra/scripts/PerformanceTesting/eclipse/launch.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+#Allow 90 minutes for all steps
+salloc -N1 --time=90 -p short,batch --account=FY150090 $WORKSPACE/EclipsePerfScripts/configBuildTest.sh

--- a/packages/tpetra/scripts/PerformanceTesting/stria/JenkinsAction.sh
+++ b/packages/tpetra/scripts/PerformanceTesting/stria/JenkinsAction.sh
@@ -1,0 +1,26 @@
+#Set up other env variables
+#$DATASTORE is the path to SEMS data store on sherlock
+export DATASTORE="/storage/elements/sems-data-store/trilinos-performance"
+export DATASTORE_MIRROR="/storage/elements/sems-data-store/trilinos-performance-son"
+export WATCHR_PERF_DIR="$WORKSPACE/StriaData"
+export TRILINOS_SRC="$WORKSPACE/Trilinos"
+#Remove script dir, if it exists
+rm -rf StriaPerfScripts
+#Get a fresh copy
+scp -rp jenkins@sherlock.sandia.gov:$DATASTORE/Scripts/stria StriaPerfScripts || true
+#Copy the newest performance report tarball from data store
+scp -p jenkins@sherlock.sandia.gov:$DATASTORE/StriaData.tar.gz StriaData.tar.gz || true
+#Unpack it, is directory "VortexData"
+rm -rf StriaData
+tar -xf StriaData.tar.gz
+#Create build dir, if not already there.
+#Don't need to clear it out, since script will reconfigure everything.
+#Even with reconfigure, this is an incremental build, saving a lot of time.
+mkdir -p build
+#Configure and build on a compute node, then run run tests on 4 compute nodes.
+$WORKSPACE/StriaPerfScripts/launch.sh
+#Repack the up to date tarball of data, and put back in datastore
+tar -czf StriaData.tar.gz StriaData
+scp -p StriaData.tar.gz jenkins@sherlock.sandia.gov:$DATASTORE/StriaData.tar.gz || true
+scp -p StriaData.tar.gz jenkins@watson.sandia.gov:$DATASTORE_MIRROR/StriaData.tar.gz || true
+

--- a/packages/tpetra/scripts/PerformanceTesting/stria/configBuildTest.sh
+++ b/packages/tpetra/scripts/PerformanceTesting/stria/configBuildTest.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+export WATCHR_BUILD_NAME="Stria Serial"
+source $TRILINOS_SRC/cmake/std/atdm/load-env.sh stria-arm-release
+
+#Update Trilinos (should always be on develop branch)
+cd $TRILINOS_SRC
+git fetch origin
+git reset --hard origin/develop
+export TRILINOS_GIT_SHA=`git rev-parse HEAD`
+
+cd $WORKSPACE/build
+
+rm -rf CMakeFiles
+rm -f CMakeCache.txt
+
+cmake \
+-DCMAKE_BUILD_TYPE=Release \
+-DTrilinos_TEST_CATEGORIES=PERFORMANCE \
+-DTrilinos_ENABLE_TESTS=ON \
+-DTrilinos_ENABLE_EXAMPLES=ON \
+-DTrilinos_ENABLE_Tpetra=ON \
+-DTrilinos_ENABLE_MueLu=ON \
+-DTrilinos_ENABLE_PanzerMiniEM=ON \
+-DTrilinos_ENABLE_Percept=OFF \
+-DTpetra_INST_SERIAL=ON \
+-DTpetra_INST_INT_INT=ON \
+-DXpetra_ENABLE_Epetra=ON \
+-DMueLu_ENABLE_Epetra=ON \
+-DTPL_ENABLE_HDF5=ON \
+-DTPL_ENABLE_Netcdf=ON \
+-DTPL_ENABLE_Matio=OFF \
+-DTPL_ENABLE_X11=OFF \
+-DTrilinos_ENABLE_EXPLICIT_INSTANTIATION=ON \
+-DTrilinos_CONFIGURE_OPTIONS_FILE:STRING=$TRILINOS_SRC/cmake/std/atdm/ATDMDevEnv.cmake \
+-DTPL_ENABLE_MPI=ON \
+-DKokkos_ENABLE_SERIAL=ON \
+-DMPI_EXEC_MAX_NUMPROCS=36 \
+-DTrilinos_ENABLE_PyTrilinos=OFF \
+$TRILINOS_SRC
+
+make -j36
+
+ctest || true
+

--- a/packages/tpetra/scripts/PerformanceTesting/stria/launch.sh
+++ b/packages/tpetra/scripts/PerformanceTesting/stria/launch.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+#Allow 90 minutes for all steps
+salloc -N1 --time=90 -p short,batch --account=FY150090 $WORKSPACE/StriaPerfScripts/configBuildTest.sh

--- a/packages/tpetra/scripts/PerformanceTesting/vortex/JenkinsAction.sh
+++ b/packages/tpetra/scripts/PerformanceTesting/vortex/JenkinsAction.sh
@@ -1,0 +1,25 @@
+#Set up other env variables
+#$DATASTORE is the path to SEMS data store on sherlock
+export DATASTORE="/storage/elements/sems-data-store/trilinos-performance"
+export DATASTORE_MIRROR="/storage/elements/sems-data-store/trilinos-performance-son"
+export WATCHR_PERF_DIR="$WORKSPACE/VortexData"
+export TRILINOS_SRC="$WORKSPACE/Trilinos"
+#Remove script dir, if it exists
+rm -rf VortexPerfScripts
+#Get a fresh copy
+scp -rp jenkins@sherlock.sandia.gov:$DATASTORE/Scripts/vortex VortexPerfScripts || true
+#Copy the newest performance report tarball from data store
+scp -p jenkins@sherlock.sandia.gov:$DATASTORE/VortexData.tar.gz VortexData.tar.gz || true
+#Unpack it, is directory "VortexData"
+rm -rf VortexData
+tar -xf VortexData.tar.gz
+#Create build dir, if not already there.
+#Don't need to clear it out, since script will reconfigure everything.
+#Even with reconfigure, this is an incremental build, saving a lot of time.
+mkdir -p build
+#Configure and build on a compute node, then run run tests on 4 compute nodes.
+$WORKSPACE/VortexPerfScripts/launch.sh
+#Repack the up to date tarball of data, and put back in datastore
+tar -czf VortexData.tar.gz VortexData
+scp -p VortexData.tar.gz jenkins@sherlock.sandia.gov:$DATASTORE/VortexData.tar.gz || true
+scp -p VortexData.tar.gz jenkins@watson.sandia.gov:$DATASTORE_MIRROR/VortexData.tar.gz || true

--- a/packages/tpetra/scripts/PerformanceTesting/vortex/configBuild.sh
+++ b/packages/tpetra/scripts/PerformanceTesting/vortex/configBuild.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+source $TRILINOS_SRC/cmake/std/atdm/load-env.sh cuda-10.1.243_gnu-7.3.1_spmpi-2019.06.24-release
+
+echo "Switching to develop branch."
+cd $TRILINOS_SRC
+git fetch origin
+git reset --hard origin/develop
+
+cd $WORKSPACE/build
+
+rm -rf CMakeFiles
+rm -f CMakeCache.txt
+
+#NOTE: the options Trilinos_CUDA_NUM_GPUS and Trilinos_CUDA_SLOTS_PER_GPU override the ATDM
+#defaults. This is required to make ctest use all GPUs of 4 nodes.
+
+cmake \
+-DCMAKE_BUILD_TYPE=Release \
+-DTrilinos_TEST_CATEGORIES=PERFORMANCE \
+-DTrilinos_ENABLE_TESTS=ON \
+-DTrilinos_ENABLE_EXAMPLES=ON \
+-DTrilinos_ENABLE_Tpetra=ON \
+-DTrilinos_ENABLE_MueLu=ON \
+-DTrilinos_ENABLE_PanzerMiniEM=ON \
+-DTrilinos_ENABLE_Percept=OFF \
+-DTpetra_INST_SERIAL=ON \
+-DTpetra_INST_INT_INT=ON \
+-DXpetra_ENABLE_Epetra=ON \
+-DMueLu_ENABLE_Epetra=ON \
+-DTPL_ENABLE_HDF5=ON \
+-DTPL_ENABLE_Netcdf=ON \
+-DTPL_ENABLE_Matio=OFF \
+-DTPL_ENABLE_X11=OFF \
+-DTrilinos_ENABLE_EXPLICIT_INSTANTIATION=ON \
+-DTrilinos_CONFIGURE_OPTIONS_FILE:STRING=$TRILINOS_SRC/cmake/std/atdm/ATDMDevEnv.cmake \
+-DTPL_ENABLE_MPI=ON \
+-DKokkos_ENABLE_SERIAL=ON \
+-DMPI_EXEC_MAX_NUMPROCS=16 \
+-DTrilinos_AUTOGENERATE_TEST_RESOURCE_FILE=OFF \
+-DTrilinos_ENABLE_PyTrilinos=OFF \
+$TRILINOS_SRC
+
+make -j36

--- a/packages/tpetra/scripts/PerformanceTesting/vortex/launch.sh
+++ b/packages/tpetra/scripts/PerformanceTesting/vortex/launch.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+#Run configure/build on 1 node, but testing on 4 nodes (for 16 total GPUs/ranks)
+#Allow 1 hour for building, and 15 minutes for testing
+bsub -q normal -Is -nnodes 1 -W 60 $WORKSPACE/VortexPerfScripts/configBuild.sh
+bsub -q normal --shared-launch -Is -nnodes 4 -W 25 $WORKSPACE/VortexPerfScripts/test.sh
+

--- a/packages/tpetra/scripts/PerformanceTesting/vortex/test.sh
+++ b/packages/tpetra/scripts/PerformanceTesting/vortex/test.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+export WATCHR_BUILD_NAME="Vortex CUDA"
+source $TRILINOS_SRC/cmake/std/atdm/load-env.sh cuda-10.1.243_gnu-7.3.1_spmpi-2019.06.24-release
+cd $TRILINOS_SRC
+export TRILINOS_GIT_SHA=`git rev-parse HEAD`
+export TPETRA_ASSUME_CUDA_AWARE_MPI=1
+
+cd $WORKSPACE/build
+
+#Don't fail the whole Jenkins build if tests fail. There will just
+#be a gap in the data series for failing tests.
+ctest -V || true


### PR DESCRIPTION
eclipse, vortex and stria env/build scripts for performance testing of Tpetra, MueLu and MiniEM.

These are used on SRN Jenkins to do performance testing, with the data visualized using Watchr.
This is just a backup of the scripts that are stored in the trilinos-performance SEMS data store. The copies in the data store are what actually get run on the clusters, and those can only be changed manually by someone with data store access.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
We thought it would be a good idea for the data store to not be the only place these are saved.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
Not a code change. These scripts are currently being used in the nightly performance testing on these 3 machines.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->