### PR TITLE
Belos: Add error message to avoid divide by zero crash. 

### DIFF
--- a/packages/belos/src/BelosGmresPolyOp.hpp
+++ b/packages/belos/src/BelosGmresPolyOp.hpp
@@ -711,12 +711,12 @@ namespace Belos {
 
     // Set index for sort function, verify roots are non-zero,
     // and sort Harmonic Ritz Values:
-    const MagnitudeType tol = (MagnitudeType) 10 * Teuchos::ScalarTraits<ScalarType>::eps();
+    const MagnitudeType tol = 10.0 * Teuchos::ScalarTraits<MagnitudeType>::eps();
     std::vector<int> index(dim_);
     for(int i=0; i<dim_; ++i){ 
       index[i] = i; 
       // Check if real + imag parts of roots < tol. 
-      TEUCHOS_TEST_FOR_EXCEPTION(hypot(theta_(i,0),theta_(i,1)) < tol, std::runtime_error, "Error: One of the computed polynomial roots is approximately zero.  This will cause a divide by zero error!  Your matrix may be close to singular.  Please select a lower polynomial degree or give a shifted matrix.");
+      TEUCHOS_TEST_FOR_EXCEPTION(hypot(theta_(i,0),theta_(i,1)) < tol, std::runtime_error, "BelosGmresPolyOp Error: One of the computed polynomial roots is approximately zero.  This will cause a divide by zero error!  Your matrix may be close to singular.  Please select a lower polynomial degree or give a shifted matrix.");
     }
     SortModLeja(theta_,index);
 

--- a/packages/belos/src/BelosGmresPolyOp.hpp
+++ b/packages/belos/src/BelosGmresPolyOp.hpp
@@ -709,10 +709,14 @@ namespace Belos {
       std::cout << "GEEV solve : info = " << info << std::endl;
     }
 
-    // Set index for sort function and sort Harmonic Ritz Values:
+    // Set index for sort function, verify roots are non-zero,
+    // and sort Harmonic Ritz Values:
+    const MagnitudeType tol = (MagnitudeType) 10 * Teuchos::ScalarTraits<ScalarType>::eps();
     std::vector<int> index(dim_);
     for(int i=0; i<dim_; ++i){ 
       index[i] = i; 
+      // Check if real + imag parts of roots < tol. 
+      TEUCHOS_TEST_FOR_EXCEPTION(hypot(theta_(i,0),theta_(i,1)) < tol, std::runtime_error, "Error: One of the computed polynomial roots is approximately zero.  This will cause a divide by zero error!  Your matrix may be close to singular.  Please select a lower polynomial degree or give a shifted matrix.");
     }
     SortModLeja(theta_,index);
 


### PR DESCRIPTION
This PR is in response to issue #8540. This outputs an error message to the user in the event that one of the GMRES polynomial roots is near zero and gives instructions to reduce the polynomial degree or shift the matrix.  I have verified that this error check does catch the issue presented with the singular Laplacian in Zoltan2.  