### PR TITLE
tpetra:  fixes for MatrixMatrix products

### DIFF
--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_Cuda.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_Cuda.hpp
@@ -265,10 +265,10 @@ template<class Scalar,
 void KernelWrappers<Scalar,LocalOrdinal,GlobalOrdinal,Kokkos::Compat::KokkosCudaWrapperNode,LocalOrdinalViewType>::mult_A_B_reuse_kernel_wrapper(
                CrsMatrixStruct<Scalar, LocalOrdinal, GlobalOrdinal, Kokkos::Compat::KokkosCudaWrapperNode>& Aview,
                                                                                                CrsMatrixStruct<Scalar, LocalOrdinal, GlobalOrdinal, Kokkos::Compat::KokkosCudaWrapperNode>& Bview,
-                                                                                               const LocalOrdinalViewType & targetMapToOrigRow,
-                                                                                               const LocalOrdinalViewType & targetMapToImportRow,
-                                                                                               const LocalOrdinalViewType & Bcol2Ccol,
-                                                                                               const LocalOrdinalViewType & Icol2Ccol,
+                                                                                               const LocalOrdinalViewType & targetMapToOrigRow_dev,
+                                                                                               const LocalOrdinalViewType & targetMapToImportRow_dev,
+                                                                                               const LocalOrdinalViewType & Bcol2Ccol_dev,
+                                                                                               const LocalOrdinalViewType & Icol2Ccol_dev,
                                                                                                CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Kokkos::Compat::KokkosCudaWrapperNode>& C,
                                                                                                Teuchos::RCP<const Import<LocalOrdinal,GlobalOrdinal,Kokkos::Compat::KokkosCudaWrapperNode> > Cimport,
                                                                                                const std::string& label,
@@ -303,8 +303,24 @@ void KernelWrappers<Scalar,LocalOrdinal,GlobalOrdinal,Kokkos::Compat::KokkosCuda
   const LO LO_INVALID = Teuchos::OrdinalTraits<LO>::invalid();
   const SC SC_ZERO = Teuchos::ScalarTraits<Scalar>::zero();
 
-  // Since this is being run on Cuda, we need to fence because the below host code will use UVM
-  typename graph_t::execution_space().fence();
+  // Since this is being run on Cuda, we need to fence because the below code will use UVM
+  // typename graph_t::execution_space().fence();
+  
+  // KDDKDD UVM Without UVM, need to copy targetMap arrays to host.
+  // KDDKDD UVM Ideally, this function would run on device and use 
+  // KDDKDD UVM KokkosKernels instead of this host implementation.
+  auto targetMapToOrigRow = 
+       Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), 
+                                           targetMapToOrigRow_dev);
+  auto targetMapToImportRow = 
+       Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), 
+                                           targetMapToImportRow_dev);
+  auto Bcol2Ccol =
+       Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), 
+                                           Bcol2Ccol_dev);
+  auto Icol2Ccol = 
+       Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), 
+                                           Icol2Ccol_dev);
 
   // Sizes
   RCP<const map_type> Ccolmap = C.getColMap();
@@ -478,10 +494,10 @@ void KernelWrappers2<Scalar,LocalOrdinal,GlobalOrdinal,Kokkos::Compat::KokkosCud
                                                                                                const Vector<Scalar,LocalOrdinal,GlobalOrdinal,Kokkos::Compat::KokkosCudaWrapperNode> & Dinv,
                                                                                                CrsMatrixStruct<Scalar, LocalOrdinal, GlobalOrdinal, Kokkos::Compat::KokkosCudaWrapperNode>& Aview,
                                                                                                CrsMatrixStruct<Scalar, LocalOrdinal, GlobalOrdinal, Kokkos::Compat::KokkosCudaWrapperNode>& Bview,
-                                                                                               const LocalOrdinalViewType & targetMapToOrigRow,
-                                                                                               const LocalOrdinalViewType & targetMapToImportRow,
-                                                                                               const LocalOrdinalViewType & Bcol2Ccol,
-                                                                                               const LocalOrdinalViewType & Icol2Ccol,
+                                                                                               const LocalOrdinalViewType & targetMapToOrigRow_dev,
+                                                                                               const LocalOrdinalViewType & targetMapToImportRow_dev,
+                                                                                               const LocalOrdinalViewType & Bcol2Ccol_dev,
+                                                                                               const LocalOrdinalViewType & Icol2Ccol_dev,
                                                                                                CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Kokkos::Compat::KokkosCudaWrapperNode>& C,
                                                                                                Teuchos::RCP<const Import<LocalOrdinal,GlobalOrdinal,Kokkos::Compat::KokkosCudaWrapperNode> > Cimport,
                                                                                                const std::string& label,
@@ -517,7 +533,24 @@ void KernelWrappers2<Scalar,LocalOrdinal,GlobalOrdinal,Kokkos::Compat::KokkosCud
   const SC SC_ZERO = Teuchos::ScalarTraits<Scalar>::zero();
 
   // Since this is being run on Cuda, we need to fence because the below host code will use UVM
-  typename graph_t::execution_space().fence();
+  // KDDKDD typename graph_t::execution_space().fence();
+
+  // KDDKDD UVM Without UVM, need to copy targetMap arrays to host.
+  // KDDKDD UVM Ideally, this function would run on device and use 
+  // KDDKDD UVM KokkosKernels instead of this host implementation.
+  auto targetMapToOrigRow = 
+       Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), 
+                                           targetMapToOrigRow_dev);
+  auto targetMapToImportRow = 
+       Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), 
+                                           targetMapToImportRow_dev);
+  auto Bcol2Ccol =
+       Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), 
+                                           Bcol2Ccol_dev);
+  auto Icol2Ccol = 
+       Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), 
+                                           Icol2Ccol_dev);
+  
  
   // Sizes
   RCP<const map_type> Ccolmap = C.getColMap();

--- a/packages/tpetra/core/ext/TpetraExt_TripleMatrixMultiply_def.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_TripleMatrixMultiply_def.hpp
@@ -890,10 +890,10 @@ namespace Tpetra {
     void KernelWrappers3<Scalar,LocalOrdinal,GlobalOrdinal,Node,LocalOrdinalViewType>::mult_R_A_P_newmatrix_kernel_wrapper(CrsMatrixStruct<Scalar, LocalOrdinal, GlobalOrdinal, Node>& Rview,
                                                                                                                            CrsMatrixStruct<Scalar, LocalOrdinal, GlobalOrdinal, Node>& Aview,
                                                                                                                            CrsMatrixStruct<Scalar, LocalOrdinal, GlobalOrdinal, Node>& Pview,
-                                                                                                                           const LocalOrdinalViewType & Acol2Prow,
-                                                                                                                           const LocalOrdinalViewType & Acol2PIrow,
-                                                                                                                           const LocalOrdinalViewType & Pcol2Accol,
-                                                                                                                           const LocalOrdinalViewType & PIcol2Accol,
+                                                                                                                           const LocalOrdinalViewType & Acol2Prow_dev,
+                                                                                                                           const LocalOrdinalViewType & Acol2PIrow_dev,
+                                                                                                                           const LocalOrdinalViewType & Pcol2Accol_dev,
+                                                                                                                           const LocalOrdinalViewType & PIcol2Accol_dev,
                                                                                                                            CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>& Ac,
                                                                                                                            Teuchos::RCP<const Import<LocalOrdinal,GlobalOrdinal,Node> > Acimport,
                                                                                                                            const std::string& label,
@@ -932,6 +932,16 @@ namespace Tpetra {
       size_t m = Rview.origMatrix->getNodeNumRows();
       size_t n = Accolmap->getNodeNumElements();
       size_t p_max_nnz_per_row = Pview.origMatrix->getNodeMaxNumRowEntries();
+
+      // Routine runs on host; have to put arguments on host, too
+      auto Acol2Prow = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),
+                                                           Acol2Prow_dev);
+      auto Acol2PIrow = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),
+                                                            Acol2PIrow_dev);
+      auto Pcol2Accol = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),
+                                                            Pcol2Accol_dev);
+      auto PIcol2Accol = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),
+                                                             PIcol2Accol_dev);
 
       // Grab the  Kokkos::SparseCrsMatrices & inner stuff
       const auto Amat = Aview.origMatrix->getLocalMatrixHost();
@@ -1142,10 +1152,10 @@ namespace Tpetra {
     void KernelWrappers3<Scalar,LocalOrdinal,GlobalOrdinal,Node,LocalOrdinalViewType>::mult_R_A_P_reuse_kernel_wrapper(CrsMatrixStruct<Scalar, LocalOrdinal, GlobalOrdinal, Node>& Rview,
                                                                                                                            CrsMatrixStruct<Scalar, LocalOrdinal, GlobalOrdinal, Node>& Aview,
                                                                                                                            CrsMatrixStruct<Scalar, LocalOrdinal, GlobalOrdinal, Node>& Pview,
-                                                                                                                           const LocalOrdinalViewType & Acol2Prow,
-                                                                                                                           const LocalOrdinalViewType & Acol2PIrow,
-                                                                                                                           const LocalOrdinalViewType & Pcol2Accol,
-                                                                                                                           const LocalOrdinalViewType & PIcol2Accol,
+                                                                                                                           const LocalOrdinalViewType & Acol2Prow_dev,
+                                                                                                                           const LocalOrdinalViewType & Acol2PIrow_dev,
+                                                                                                                           const LocalOrdinalViewType & Pcol2Accol_dev,
+                                                                                                                           const LocalOrdinalViewType & PIcol2Accol_dev,
                                                                                                                            CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>& Ac,
                                                                                                                            Teuchos::RCP<const Import<LocalOrdinal,GlobalOrdinal,Node> > Acimport,
                                                                                                                            const std::string& label,
@@ -1183,6 +1193,16 @@ namespace Tpetra {
       size_t m = Rview.origMatrix->getNodeNumRows();
       size_t n = Accolmap->getNodeNumElements();
       size_t p_max_nnz_per_row = Pview.origMatrix->getNodeMaxNumRowEntries();
+
+      // Routine runs on host; have to put arguments on host, too
+      auto Acol2Prow = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),
+                                                           Acol2Prow_dev);
+      auto Acol2PIrow = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),
+                                                            Acol2PIrow_dev);
+      auto Pcol2Accol = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),
+                                                            Pcol2Accol_dev);
+      auto PIcol2Accol = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),
+                                                             PIcol2Accol_dev);
 
       // Grab the  Kokkos::SparseCrsMatrices & inner stuff
       const KCRS & Amat = Aview.origMatrix->getLocalMatrixHost();


### PR DESCRIPTION
@trilinos/tpetra 

Much of the CUDA mat-mat stuff is running on host.
This PR adds create_mirror_view_and_copy for device views needed on host
It would be better to use KokkosKernels.

@csiefer2 @lucbv or @brian-kelley  would you please take a look?  For full effect, you have to compare the branch against develop.  This PR compares only against tpetraCrsRefactor; there are other changes to these files (already in tpetraCrsRefactor) that you'll see if you compare with develop.  

If it looks OK to you, please feel free to merge into tpetraCrsRefactor.  If it doesn't look OK, let me know what's needed.

An alternate implementation might convert the views to host in the calls to these functions, rather than in these functions themselves.    Let me know if that makes more sense.


<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
MatrixMAtrix_UnitTests now pass with UVM=OFF.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->