### PR TITLE
Fix unclosed <tt> in tpetra lesson04 documentation

### DIFF
--- a/packages/tpetra/core/example/Lesson04-Sparse-Matrix-Fill/index.doc
+++ b/packages/tpetra/core/example/Lesson04-Sparse-Matrix-Fill/index.doc
@@ -233,7 +233,7 @@ and local indices.
 In the sparse matrix's final state, it represents column indices as
 local indices.  This is faster for operations like sparse
 matrix-vector multiply.  It saves storage as well, especially if
-<tt>sizeof(LocalOrdinal) < sizeof(GlobalOrdinal)<tt>.  However,
+<tt>sizeof(LocalOrdinal) < sizeof(GlobalOrdinal)</tt>.  However,
 accessing or inserting entries by local index is only allowed under
 certain conditions.  In particular, the matrix must have a column Map,
 which tells it how to convert between global and local indices for the


### PR DESCRIPTION

@trilinos/tpetra

## Motivation
This change closes an unclosed `<tt>` tag in the Tpetra lesson 04 documentation.
The problem can be seen at the bottom of https://docs.trilinos.org/dev/packages/tpetra/doc/html/Tpetra_Lesson04.html

## Related Issues

## Stakeholder Feedback

## Testing
N/A