### PR TITLE
ShyLU/HTS: Fix incorrect placement of omp flush.

### DIFF
--- a/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
@@ -123,6 +123,7 @@ public:
     Teuchos::ArrayRCP<const local_ordinal_type> colidx;
     Teuchos::ArrayRCP<const scalar_type> val;
     T_in.getAllValues(rowptr, colidx, val);
+    Kokkos::fence();
 
     Teuchos::RCP<HtsCrsMatrix> T_hts = Teuchos::rcpWithDealloc(
       HTST::make_CrsMatrix(rowptr.size() - 1,
@@ -195,6 +196,7 @@ public:
 #ifdef HAVE_IFPACK2_SHYLU_NODEHTS
     const auto& X_view = X.getLocalViewHost ();
     const auto& Y_view = Y.getLocalViewHost ();
+    Kokkos::fence();
 
     // Only does something if #rhs > current capacity.
     HTST::reset_max_nrhs(Timpl_.get(), X_view.extent(1));

--- a/packages/shylu/shylu_node/hts/src/shylu_hts_impl_def.hpp
+++ b/packages/shylu/shylu_node/hts/src/shylu_hts_impl_def.hpp
@@ -3989,6 +3989,7 @@ LevelSetTri::solve (const Sclr* b, Sclr* x, const Int ldx,
           while (*done != p2p_done_value) ;
         }
       }
+      // Flush (acquire) the global to the local view of x.
 #ifdef _OPENMP
 #     pragma omp flush
 #endif
@@ -4001,6 +4002,7 @@ LevelSetTri::solve (const Sclr* b, Sclr* x, const Int ldx,
           a -= x[jc[j]] * d[j];
         x[r] = a * d[j++];
       }
+      // Flush (release) the local to the global view of x.
 #ifdef _OPENMP
 #     pragma omp flush
 #endif

--- a/packages/shylu/shylu_node/hts/src/shylu_hts_impl_def.hpp
+++ b/packages/shylu/shylu_node/hts/src/shylu_hts_impl_def.hpp
@@ -3989,7 +3989,8 @@ LevelSetTri::solve (const Sclr* b, Sclr* x, const Int ldx,
           while (*done != p2p_done_value) ;
         }
       }
-      // Flush (acquire) the global to the local view of x.
+      // Flush (acquire) the global to the local view of x. With OpenMP 5.0, we
+      // can specify acquire, release, or both, but for now we don't have 5.0.
 #ifdef _OPENMP
 #     pragma omp flush
 #endif
@@ -4025,7 +4026,13 @@ inline void Impl<Int, Size, Sclr>::
 rbwait (volatile p2p_Done* const s_done, const Size* s_ids,
         const Int* const s_idx, const Int i, const p2p_Done done_symbol) {
   const Int si = s_idx[i], si1 = s_idx[i+1];
-  if (si == si1) return;
+  if (si == si1) {
+    // acquire
+#ifdef _OPENMP
+#   pragma omp flush
+#endif
+    return;
+  }
   const Size* id = s_ids + si;
   const Size* const idn = s_ids + si1;
   while (id != idn) {
@@ -4033,7 +4040,7 @@ rbwait (volatile p2p_Done* const s_done, const Size* s_ids,
     while (*d != done_symbol) ;
     ++id;
   }
-  // Make sure x is updated.
+  // acquire
 #ifdef _OPENMP
 # pragma omp flush
 #endif
@@ -4047,6 +4054,7 @@ ondiag_solve (const OnDiagTri& t, Sclr* x, const Int ldx, const Int nrhs,
   const Int nthreads = t.nthreads();
   if (nthreads == 1) {
     t.solve(x, ldx, x, ldx, nrhs);
+    // release
 #ifdef _OPENMP
 #   pragma omp flush
 #endif
@@ -4054,6 +4062,7 @@ ondiag_solve (const OnDiagTri& t, Sclr* x, const Int ldx, const Int nrhs,
   } else {
     // Solve T wrk_ = x.
     t.solve(x, ldx, wrk_.data(), t.get_n(), nrhs);
+    // release
 #ifdef _OPENMP
 #   pragma omp flush
 #endif
@@ -4063,6 +4072,7 @@ ondiag_solve (const OnDiagTri& t, Sclr* x, const Int ldx, const Int nrhs,
       for (Int i = 0; i < nthreads; ++i)
         while (inv_tri_done[i] < done) ;
     }
+    // acquire
 #ifdef _OPENMP
 #   pragma omp flush
 #endif
@@ -4072,6 +4082,7 @@ ondiag_solve (const OnDiagTri& t, Sclr* x, const Int ldx, const Int nrhs,
       memcpy(x + irhs*ldx + row_start,
              wrk_.data() + irhs*t.get_n() + row_start,
              nr*sizeof(Sclr));
+    // release
 #ifdef _OPENMP
 #   pragma omp flush
 #endif
@@ -4083,9 +4094,6 @@ ondiag_solve (const OnDiagTri& t, Sclr* x, const Int ldx, const Int nrhs,
       for (Int i = 0; i < nthreads; ++i)
         while (inv_tri_done[i] < done) ;
     }
-#ifdef _OPENMP
-#   pragma omp flush
-#endif
     if (tid == 0)
       *t_barrier = step;
   }
@@ -4110,10 +4118,11 @@ RecursiveTri::solve (const Sclr* b, Sclr* x, const Int ldx,
   const Size* const s_ids = nd_.s_ids[tid].empty() ? 0 : nd_.s_ids[tid].data();
   const Int* const s_idx = nd_.s_idx[tid].empty() ? 0 : nd_.s_idx[tid].data();
   const p2p_Done done_symbol = nd_.done_symbol;
-  { const OnDiagTri& t = nd_.t[0];
+  {
+    const OnDiagTri& t = nd_.t[0];
     if (tid < t.nthreads())
       ondiag_solve(t, x, ldx, nrhs, tid, 0, t_barrier, inv_tri_done);
-    }
+  }
   if ( ! nd_.os.empty()) {
     os += nd_.t[0].get_n();
     x_osi = x + nd_.os[0];
@@ -4129,6 +4138,7 @@ RecursiveTri::solve (const Sclr* b, Sclr* x, const Int ldx,
     if ( ! s.empty() && (s.parallel() || tid == 0)) {
       rbwait(s_done, s_ids, s_idx, i, done_symbol);
       s.n1Axpy(x_osi, ldx, nrhs, x_os, ldx, tid);
+      // release
 #ifdef _OPENMP
 #     pragma omp flush
 #endif


### PR DESCRIPTION
Running hts_test on a new architecture revealed a bug: one omp flush line was
incorrectly placed, the one after s.n1Axpy. Fix this; the flush release should
be before the s_done lock is set, not after.

This achitecture is quite sensitive to omp flush, so I also took the opportunity
to rearrange placement of some others.

Also fix two cases of using int instead of size.

Closes #8485.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/shylu 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->