### PR TITLE
Tpetra: add missing fence in WrappedDualView

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_WrappedDualView.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_WrappedDualView.hpp
@@ -109,40 +109,20 @@ template <typename DualViewType>
 enableIfConstData<DualViewType>
 sync_device(DualViewType dualView) { }
 
-
-template <typename DualViewType>
-struct deviceMemoryIsHostAccessible {
-  using DeviceMemorySpace = typename DualViewType::t_dev::memory_space;
-  static constexpr bool value = Kokkos::SpaceAccessibility<Kokkos::Serial, DeviceMemorySpace>::accessible;
-};
-
-template <typename DualViewType>
-using enableIfUVM = std::enable_if_t<deviceMemoryIsHostAccessible<DualViewType>::value>;
-
-template <typename DualViewType>
-using enableIfNonUVM = std::enable_if_t<!deviceMemoryIsHostAccessible<DualViewType>::value>;
-
-template <typename DualViewType>
-enableIfUVM<DualViewType>
-fenceForUVM() {
-  Kokkos::fence();
-}
-
-template <typename DualViewType>
-enableIfNonUVM<DualViewType>
-fenceForUVM() { }
-
 }
 
 template <typename DualViewType>
 class WrappedDualView {
-private:
-  static constexpr bool dualViewHasNonConstData = !impl::hasConstData<DualViewType>::value;
-
 public:
   using HostViewType = typename DualViewType::t_host;
   using DeviceViewType = typename DualViewType::t_dev;
 
+private:
+  static constexpr bool dualViewHasNonConstData = !impl::hasConstData<DualViewType>::value;
+  static constexpr bool deviceMemoryIsHostAccessible =
+    Kokkos::SpaceAccessibility<Kokkos::Serial, typename DeviceViewType::memory_space>::accessible;
+
+public:
   WrappedDualView() {}
 
   WrappedDualView(DualViewType dualV)
@@ -207,7 +187,7 @@ public:
       return getHostView(Access::ReadWrite);
     }
     throwIfDeviceViewAlive();
-    impl::fenceForUVM<DualViewType>();
+    if (deviceMemoryIsHostAccessible) Kokkos::fence();
     dualView.clear_sync_state();
     dualView.modify_host();
     return dualView.view_host();


### PR DESCRIPTION
@trilinos/tpetra 

When we get the host view of a WrappedDualView with OverwriteAll, a device kernel is potentially still changing values on the device view, but we don't care because we're overwriting them anyway.  In UVM though, we need to wait to overwrite on host until device is done writing, because otherwise the things we write on host could be overwritten by the device kernel that hasn't finished yet.

### Testing

The need for this change was exposed by an existing WrappedDualView test.