### PR TITLE
Allow ATDM Trilinos 'ats1', 'ats2', 'cts1', and 'van1-tx2' envs to be used with SPARC TPL installer (ATDV-408)

### DIFF
--- a/cmake/std/atdm/ats1/environment.sh
+++ b/cmake/std/atdm/ats1/environment.sh
@@ -30,12 +30,12 @@ export ATDM_CONFIG_BUILD_COUNT=32
 # ATDV-361)
 
 if [[ "$ATDM_CONFIG_KOKKOS_ARCH" == "HSW" ]]; then
-  module load sparc-dev/intel-19.0.4_mpich-7.7.15_hsw
+  atdm_config_load_sparc_dev_module sparc-dev/intel-19.0.4_mpich-7.7.15_hsw
   export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=16
   export OMP_NUM_THREADS=2
   unset OMP_PLACES
 elif [[ "$ATDM_CONFIG_KOKKOS_ARCH" == "KNL" ]]; then
-  module load sparc-dev/intel-19.0.4_mpich-7.7.15_knl
+  atdm_config_load_sparc_dev_module sparc-dev/intel-19.0.4_mpich-7.7.15_knl
   export SLURM_TASKS_PER_NODE=16
   # Ensure that no more than 8 tasks, per srun command, are launched.
   export ATDM_CONFIG_MPI_PRE_FLAGS="--mpi=pmi2;--ntasks-per-node=8"

--- a/cmake/std/atdm/ats1/environment.sh
+++ b/cmake/std/atdm/ats1/environment.sh
@@ -59,6 +59,11 @@ else
   return
 fi
 
+if [[ "${SPARC_MODULE}" == "" ]] ; then
+  echo "No SPARC_MODULE loaded so existing!"
+  return
+fi
+
 echo "Using ats1 compiler stack $ATDM_CONFIG_COMPILER to build $ATDM_CONFIG_BUILD_TYPE code with Kokkos node type $ATDM_CONFIG_NODE_TYPE and KOKKOS_ARCH=$ATDM_CONFIG_KOKKOS_ARCH"
 
 # Exclude bad nodes.

--- a/cmake/std/atdm/ats1/environment.sh
+++ b/cmake/std/atdm/ats1/environment.sh
@@ -60,7 +60,7 @@ else
 fi
 
 if [[ "${SPARC_MODULE}" == "" ]] ; then
-  echo "No SPARC_MODULE loaded so existing!"
+  echo "No SPARC_MODULE loaded so exiting!"
   return
 fi
 

--- a/cmake/std/atdm/ats2/environment.sh
+++ b/cmake/std/atdm/ats2/environment.sh
@@ -68,12 +68,16 @@ fi
 
 # Purge then load StdEnv to get back to a fresh env in case previous other
 # modules were loaded.
-module purge --silent
-module load StdEnv
+if [[ "${ATDM_CONFIG_DONT_LOAD_SPARC_MODULES_PLEASE}" != "1" ]] ; then
+  module purge --silent
+  module load StdEnv
+else
+  echo "NOTE: ATDM_CONFIG_DONT_LOAD_SPARC_MODULES_PLEASE=1 is set so using pre-loaded sparc-dev module!"
+fi
 
 # Load the sparc-dev/xxx module
 sparc_module_name=$(get_sparc_dev_module_name "$ATDM_CONFIG_COMPILER")
-module load ${sparc_module_name}
+atdm_config_load_sparc_dev_module ${sparc_module_name}
 
 module unload cmake
 module load cmake/3.18.0

--- a/cmake/std/atdm/common/toss3/environment_new.sh
+++ b/cmake/std/atdm/common/toss3/environment_new.sh
@@ -15,10 +15,16 @@ export ATDM_CONFIG_BUILD_COUNT=8
 # NOTE: Above, currently setting CMAKE_JOB_POOL_LINK results in a build
 # failures with Ninja.  See https://gitlab.kitware.com/snl/project-1/issues/60
 
-# We do this twice since sems modules are wacked and we get errors to the screen on a purge
-# The second purge will catch any real errors with purging ...
-module purge &> /dev/null
-module purge
+if [[ "${ATDM_CONFIG_DONT_LOAD_SPARC_MODULES_PLEASE}" != "1" ]] ; then
+  # We do this twice since sems modules are wacked and we get errors to the
+  # screen on a purge The second purge will catch any real errors with purging
+  # ...
+  module purge &> /dev/null
+  module purge
+else
+  echo "NOTE: ATDM_CONFIG_DONT_LOAD_SPARC_MODULES_PLEASE=1 is set so using pre-loaded sparc-dev module!"
+fi
+
 . /projects/sems/modulefiles/utils/sems-modules-init.sh
 module load sems-env
 module load sems-git/2.10.1
@@ -26,7 +32,7 @@ module load sems-git/2.10.1
 # Common paths and modules for both intel-1{8,9}
 module load sems-cmake/3.19.1
 
-module load sparc-dev/intel-19.0.4_openmpi-4.0.3
+atdm_config_load_sparc_dev_module sparc-dev/intel-19.0.4_openmpi-4.0.3
 
 if [ "$ATDM_CONFIG_COMPILER" == "INTEL-19.0.4_OPENMPI-4.0.3" ]; then
   # Correct module already loaded above

--- a/cmake/std/atdm/van1-tx2/environment.sh
+++ b/cmake/std/atdm/van1-tx2/environment.sh
@@ -39,7 +39,11 @@ fi
 # Load the modules
 #
 
-module purge
+if [[ "${ATDM_CONFIG_DONT_LOAD_SPARC_MODULES_PLEASE}" != "1" ]] ; then
+  module purge
+else
+  echo "NOTE: ATDM_CONFIG_DONT_LOAD_SPARC_MODULES_PLEASE=1 is set so using pre-loaded sparc-dev module!"
+fi
 
 if [[ "$ATDM_CONFIG_COMPILER" == "ARM-20.0_OPENMPI-4.0.2" ]]; then
   module load devpack-arm
@@ -76,7 +80,7 @@ if [[ "$ATDM_CONFIG_COMPILER" == "ARM-20.0_OPENMPI-4.0.2" ]]; then
 
   module load git/2.19.2
 elif [[ "$ATDM_CONFIG_COMPILER" == "ARM-20.1_OPENMPI-4.0.3" ]]; then
-  module load sparc-dev/arm-20.1_openmpi-4.0.3
+  atdm_config_load_sparc_dev_module sparc-dev/arm-20.1_openmpi-4.0.3
   module unload yaml-cpp
 
   if [ "$ATDM_CONFIG_NODE_TYPE" == "OPENMP" ] ; then
@@ -96,6 +100,7 @@ elif [[ "$ATDM_CONFIG_COMPILER" == "ARM-20.1_OPENMPI-4.0.3" ]]; then
   export PARMETIS_ROOT=${PARMETIS_DIR}
   export SUPERLUDIST_ROOT=${SUPERLU_DIST_DIR}
   export BINUTILS_ROOT=${BINUTILS_DIR}
+
 else
   echo
   echo "***"


### PR DESCRIPTION
This should be the last of the changes to the existing ATDM Trilinos configurations that will allow the SPARC TPL installer to switch over to the ATDM Trilinos configuration (other than updating the 'tlcc2' configuration to support the current sparc-dev module being used by SPARC).  This is mostly just responding to the new env var `ATDM_CONFIG_DONT_LOAD_SPARC_MODULES_PLEASE` that is set by the SPARC TPL installer.

SPARC will be upgrading Trilinos very soon (the last time it was upgraded from 'develop' version  3857fba from way back in 11/6/2020).

See [ATDV-408]

## Testing

I manually tested these on the various machines.  See Sub-Tasks of [ATDV-408].

<!-- References -->

[ATDV-408]: https://sems-atlassian-srn.sandia.gov/browse/ATDV-408