### PR TITLE
Update get_default_modules.sh

### DIFF
--- a/cmake/std/sems/get_default_modules.sh
+++ b/cmake/std/sems/get_default_modules.sh
@@ -1,7 +1,7 @@
 PLATFORM_TYPE=`uname`
 
 if [ "$PLATFORM_TYPE" = "Linux" ] ; then
-  sems_compiler_and_version_default=sems-gcc/4.8.4
+  sems_compiler_and_version_default=sems-gcc/5.3.0
 elif [ "$PLATFORM_TYPE" = "Darwin" ] ; then
   sems_compiler_and_version_default=sems-gcc/5.3.0
 else


### PR DESCRIPTION
@trilinos/framework 

## Motivation
The checkin-test-sems.sh script no longer works due to the gcc 5.3.0 requirement.

## Related Issues

* Related to #8980 

## Testing
Ran the checkin-test-sems.sh script locally and all tests passed.
