### PR TITLE
NOX: Tpetra householder solver can optionally update prec with U*V^T

### DIFF
--- a/packages/nox/src-loca/src-tpetra/LOCA_BorderedSolver_TpetraHouseholder.cpp
+++ b/packages/nox/src-loca/src-tpetra/LOCA_BorderedSolver_TpetraHouseholder.cpp
@@ -56,8 +56,10 @@
 #include "LOCA_Thyra_Group.H"
 #include "NOX_TpetraTypedefs.hpp"
 #include "NOX_Thyra_MultiVector.H"
+#include "Thyra_TpetraVectorSpace.hpp"
 #include "Thyra_TpetraMultiVector.hpp"
 #include "Thyra_TpetraLinearOp.hpp"
+#include "Thyra_DefaultLinearOpSource.hpp"
 #include "LOCA_Tpetra_LowRankUpdateRowMatrix.hpp"
 
 #include "Teuchos_ParameterList.hpp"
@@ -71,6 +73,9 @@
 
 // To suppress unreachable return warnings on cuda
 #include "Teuchos_CompilerCodeTweakMacros.hpp"
+
+// For debugging output
+#include <fstream>
 
 // Forward declaration needed for ParameterList validation
 namespace LOCA {
@@ -748,14 +753,61 @@ LOCA::BorderedSolver::TpetraHouseholder::solve(
     //                                                        false));
   }
 
-  // Overwrite J with J + U*V^T if it's a CRS matrix and we aren't
-  // using P for the preconditioner
-  Teuchos::RCP<NOX::TCrsMatrix> jac_crs;
+  // Allocate a separate matrix for the preconditioner. Don't want to
+  // corrupt J with U*V^T if not using P for Prec (we can't for
+  // tpetra).  Copy J values and add in U*V^T if it's a CRS matrix
+  // and we aren't using P for the preconditioner
   if (includeUV && !use_P_For_Prec) {
-    jac_crs = Teuchos::rcp_dynamic_cast<NOX::TCrsMatrix>(tpetraOp);
-    if (jac_crs != Teuchos::null) {
-      updateJacobianForPreconditioner(*U, *V, *jac_crs);
+    auto jac_crs = Teuchos::rcp_dynamic_cast<NOX::TCrsMatrix>(tpetraOp,true);
+    if (tpetraPrecMatrix.is_null()) {
+      tpetraPrecMatrix = Teuchos::rcp(new NOX::TCrsMatrix(*jac_crs,Teuchos::Copy));
+      Teuchos::RCP<::Thyra::VectorSpaceBase<double>> domain = ::Thyra::tpetraVectorSpace<double>(tpetraPrecMatrix->getDomainMap());
+      Teuchos::RCP<::Thyra::VectorSpaceBase<double>> range = ::Thyra::tpetraVectorSpace<double>(tpetraPrecMatrix->getRangeMap());
+      auto prec_thyra_op = Teuchos::rcp(new ::Thyra::TpetraLinearOp<ST,LO,GO,NT>);
+      prec_thyra_op->initialize(range,domain,tpetraPrecMatrix);
+      Teuchos::RCP<::Thyra::LinearOpBase<double>> tmp_for_thyra_ambiguity = prec_thyra_op;
+      prec_losb = Teuchos::rcp(new ::Thyra::DefaultLinearOpSource<double>(tmp_for_thyra_ambiguity));
     }
+
+    // Copy J values into preconditioner matrix
+    //*tpetraPrecMatrix = *jac_crs;
+    {
+      tpetraPrecMatrix->resumeFill();
+      auto jac_view = jac_crs->getLocalMatrix().values;
+      auto prec_view = tpetraPrecMatrix->getLocalMatrix().values;
+      Kokkos::deep_copy(prec_view,jac_view);
+      tpetraPrecMatrix->fillComplete();
+    }
+
+    bool print_debug = false;
+    if (print_debug) {
+      std::fstream fsj("jac_matrix_before.out",std::fstream::out|std::fstream::trunc);
+      Teuchos::FancyOStream tfsj(Teuchos::rcpFromRef(fsj));
+      jac_crs->describe(tfsj,Teuchos::VERB_EXTREME);
+      std::fstream fsp("prec_matrix_before.out",std::fstream::out|std::fstream::trunc);
+      Teuchos::FancyOStream tfsp(Teuchos::rcpFromRef(fsp));
+      tpetraPrecMatrix->describe(tfsp,Teuchos::VERB_EXTREME);
+      std::fstream fsu("u_vector.out",std::fstream::out|std::fstream::trunc);
+      Teuchos::FancyOStream tfsu(Teuchos::rcpFromRef(fsu));
+      tpetra_U->describe(tfsu,Teuchos::VERB_EXTREME);
+      std::fstream fsv("v_vector.out",std::fstream::out|std::fstream::trunc);
+      Teuchos::FancyOStream tfsv(Teuchos::rcpFromRef(fsv));
+      tpetra_V->describe(tfsv,Teuchos::VERB_EXTREME);
+    }
+
+    // Update locally owned non-zero values for U*V^T
+    updateCrsMatrixForPreconditioner(*U, *V, *tpetraPrecMatrix);
+
+    if (print_debug) {
+      std::fstream fsj("jac_matrix_after.out",std::fstream::out|std::fstream::trunc);
+      Teuchos::FancyOStream tfsj(Teuchos::rcpFromRef(fsj));
+      jac_crs->describe(tfsj,Teuchos::VERB_EXTREME);
+      std::fstream fsp("prec_matrix_after.out",std::fstream::out|std::fstream::trunc);
+      Teuchos::FancyOStream tfsp(Teuchos::rcpFromRef(fsp));
+      tpetraPrecMatrix->describe(tfsp,Teuchos::VERB_EXTREME);
+    }
+
+    grp->setPreconditionerMatrix(prec_losb);
   }
 
   // Set operator in solver to compute preconditioner
@@ -1055,13 +1107,58 @@ LOCA::BorderedSolver::TpetraHouseholder::computeUV(
 }
 
 void
-LOCA::BorderedSolver::TpetraHouseholder::updateJacobianForPreconditioner(
-              const NOX::Abstract::MultiVector& UU,
-              const NOX::Abstract::MultiVector& VV,
-              NOX::TCrsMatrix& jac) const
+LOCA::BorderedSolver::TpetraHouseholder::
+updateCrsMatrixForPreconditioner(const NOX::Abstract::MultiVector& UU,
+                                 const NOX::Abstract::MultiVector& VV,
+                                 NOX::TCrsMatrix& matrix) const
 {
-  TEUCHOS_TEST_FOR_EXCEPTION(true,std::runtime_error,
-                             "ERROR: LOCA::BorderedSolver::TpetraHouseholder::updateJacobianForPreconditioner - NOT IMPLEMENTED YET!");
+  matrix.resumeFill();
+
+  auto& UU_tpetra = NOX::Tpetra::getTpetraMultiVector(UU);
+  auto& VV_tpetra = NOX::Tpetra::getTpetraMultiVector(VV);
+  const_cast<NOX::TMultiVector&>(UU_tpetra).sync_device();
+  const_cast<NOX::TMultiVector&>(VV_tpetra).sync_device();
+  const auto uu = UU_tpetra.getLocalViewDevice();
+  const auto vv = VV_tpetra.getLocalViewDevice();
+
+  const auto numRows = matrix.getNodeNumRows();
+  const auto rowMap = matrix.getRowMap()->getLocalMap();
+  const auto colMap = matrix.getColMap()->getLocalMap();
+  const auto uMap = UU_tpetra.getMap()->getLocalMap();
+  const auto vMap = VV_tpetra.getMap()->getLocalMap();
+  auto J_view = matrix.getLocalMatrix();
+  auto numConstraintsLocal = numConstraints; // for cuda lambda capture
+
+  TEUCHOS_ASSERT(static_cast<size_t>(matrix.getRowMap()->getNodeNumElements()) == uu.extent(0));
+  TEUCHOS_ASSERT(static_cast<size_t>(matrix.getRowMap()->getNodeNumElements()) == vv.extent(0));
+  TEUCHOS_ASSERT(numConstraintsLocal == static_cast<int>(uu.extent(1)));
+  TEUCHOS_ASSERT(numConstraintsLocal == static_cast<int>(vv.extent(1)));
+
+  Kokkos::parallel_for("Add UV^T to M",Kokkos::RangePolicy<NOX::DeviceSpace>(0,numRows),KOKKOS_LAMBDA (const int row) {
+    const GO row_gid = rowMap.getGlobalElement(row);
+    const LO u_row_lid = uMap.getLocalElement(row_gid);
+    auto rowView = J_view.row(row);
+
+    const auto numEntries = rowView.length;
+    for (int col=0; col<numEntries; ++col) {
+
+      // Only included contributions from U*V^T on this proc
+      const GO col_gid = colMap.getGlobalElement(rowView.colidx(col));
+      int v_row_lid = vMap.getLocalElement(col_gid);
+      if (v_row_lid != ::Tpetra::Details::OrdinalTraits<LO>::invalid()) {
+
+        // val = sum_{k=0}^m U(i,k)*V(j,k)
+        ST val = 0.0;
+        for (int k=0; k<numConstraintsLocal; ++k)
+          val += uu(u_row_lid,k) * vv(v_row_lid,k);
+
+        // replace J(row,col) with J(row,col) + U*V^T
+        rowView.value(col) += val;
+      }
+    }
+  });
+  Kokkos::fence();
+  matrix.fillComplete();
 
   /*
   // Get number of rows on this processor

--- a/packages/nox/src-loca/src-tpetra/LOCA_Tpetra_LowRankUpdateRowMatrix.hpp
+++ b/packages/nox/src-loca/src-tpetra/LOCA_Tpetra_LowRankUpdateRowMatrix.hpp
@@ -133,13 +133,13 @@ namespace LOCA {
       //***************************************
       // Derived from Tpetra::Operator interface
       //***************************************
-      virtual Teuchos::RCP<const NOX::TMap> getDomainMap() const;
-      virtual Teuchos::RCP<const NOX::TMap> getRangeMap() const;
+      virtual Teuchos::RCP<const NOX::TMap> getDomainMap() const override;
+      virtual Teuchos::RCP<const NOX::TMap> getRangeMap() const override;
       virtual void apply(const NOX::TMultiVector &X,
                          NOX::TMultiVector &Y,
                          Teuchos::ETransp mode = Teuchos::NO_TRANS,
                          NOX::Scalar alpha = Teuchos::ScalarTraits<NOX::Scalar>::one(),
-                         NOX::Scalar beta = Teuchos::ScalarTraits<NOX::Scalar>::zero()) const;
+                         NOX::Scalar beta = Teuchos::ScalarTraits<NOX::Scalar>::zero()) const override;
 
     protected:
 

--- a/packages/nox/src-thyra/NOX_Thyra_Group.C
+++ b/packages/nox/src-thyra/NOX_Thyra_Group.C
@@ -436,9 +436,9 @@ void NOX::Thyra::Group::setJacobianOperator(const Teuchos::RCP<::Thyra::LinearOp
   lop_ = op;
 }
 
-void NOX::Thyra::Group::setPreconditionerOperator(const Teuchos::RCP<::Thyra::PreconditionerBase<double>>& op)
+void NOX::Thyra::Group::setPreconditionerMatrix(const Teuchos::RCP<const ::Thyra::DefaultLinearOpSource<double>>& op)
 {
-  prec_ = op;
+  losb_ = op;
 }
 
 void NOX::Thyra::Group::setX(const NOX::Abstract::Vector& y)

--- a/packages/nox/src-thyra/NOX_Thyra_Group.H
+++ b/packages/nox/src-thyra/NOX_Thyra_Group.H
@@ -191,8 +191,8 @@ namespace NOX {
       /// Dangerous power user function for LOCA Householder bordered algorithm.
       void setJacobianOperator(const Teuchos::RCP<::Thyra::LinearOpBase<double>>& op);
 
-      /// Dangerous power user function for LOCA Householder bordered algorithm.
-      void setPreconditionerOperator(const Teuchos::RCP<::Thyra::PreconditionerBase<double>>& op);
+      /// Dangerous power user function for LOCA Householder bordered algorithm. This is the Matrix M that is used to initialize a stratimikos preconditioner. NOTE: this sets the losb_ object used to update prec_!
+      void setPreconditionerMatrix(const Teuchos::RCP<const ::Thyra::DefaultLinearOpSource<double>>& op);
 
       /** @name "Compute" functions. */
       //@{

--- a/packages/nox/test/tpetra/CMakeLists.txt
+++ b/packages/nox/test/tpetra/CMakeLists.txt
@@ -51,6 +51,11 @@ IF(NOX_ENABLE_ABSTRACT_IMPLEMENTATION_THYRA AND
       )
 
     TRIBITS_ADD_EXECUTABLE_AND_TEST(
+      Tpetra_HouseholderBorderedSolve_WithUVInPrec
+      SOURCES  ${UNIT_TEST_DRIVER} ME_Tpetra_1DFEM.hpp ME_Tpetra_1DFEM_def.hpp tTpetra_HouseholderBorderedSolve_WithUVInPrec.cpp
+      )
+
+    TRIBITS_ADD_EXECUTABLE_AND_TEST(
       Tpetra_ConstraintModelEvaluator
       SOURCES  ${UNIT_TEST_DRIVER} ME_Tpetra_1DFEM.hpp ME_Tpetra_1DFEM_def.hpp tTpetra_ConstraintModelEvaluator.cpp
       )

--- a/packages/nox/test/tpetra/tTpetra_HouseholderBorderedSolve_WithUVInPrec.cpp
+++ b/packages/nox/test/tpetra/tTpetra_HouseholderBorderedSolve_WithUVInPrec.cpp
@@ -1,0 +1,310 @@
+//@HEADER
+// ************************************************************************
+//
+//            NOX: An Object-Oriented Nonlinear Solver Package
+//                 Copyright (2002) Sandia Corporation
+//
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Roger Pawlowski (rppawlo@sandia.gov) or
+// Eric Phipps (etphipp@sandia.gov), Sandia National Laboratories.
+// ************************************************************************
+//  CVS Information
+//  $Source$
+//  $Author$
+//  $Date$
+//  $Revision$
+// ************************************************************************
+//@HEADER
+#include "Teuchos_ConfigDefs.hpp"
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_StackedTimer.hpp"
+
+// NOX Objects
+#include "NOX.H"
+#include "NOX_Thyra.H"
+
+// Trilinos Objects
+#include "Teuchos_Comm.hpp"
+#include "Teuchos_ParameterList.hpp"
+#include "Teuchos_RCP.hpp"
+#include "Teuchos_FancyOStream.hpp"
+#include "Teuchos_AbstractFactoryStd.hpp"
+
+#include "Tpetra_Core.hpp"
+#include "Tpetra_Vector.hpp"
+
+#include "BelosTypes.hpp"
+#include "Stratimikos_DefaultLinearSolverBuilder.hpp"
+#include "Thyra_LinearOpWithSolveFactoryHelpers.hpp"
+#include "Thyra_Ifpack2PreconditionerFactory.hpp"
+#include "ME_Tpetra_1DFEM.hpp"
+
+#include "NOX_Thyra_MatrixFreeJacobianOperator.hpp"
+#include "NOX_MatrixFree_ModelEvaluatorDecorator.hpp"
+#include "NOX_TpetraTypedefs.hpp"
+#include "LOCA_Tpetra_Factory.hpp"
+#include "LOCA_Thyra_Group.H"
+#include "LOCA_MultiContinuation_ConstrainedGroup.H"
+#include "LOCA_Tpetra_ConstraintModelEvaluator.hpp"
+#include "LOCA_Parameter_SublistParser.H"
+#include "NOX_SolverStats.hpp"
+
+// For solution io
+#include "Thyra_TpetraVector.hpp"
+#include <iostream>
+#include <fstream>
+
+TEUCHOS_UNIT_TEST(NOX_Tpetra_Householder, BasicSolve)
+{
+  Teuchos::RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm();
+
+  // Get default Tpetra template types
+  using Scalar = NOX::Scalar;
+  using LO = NOX::LocalOrdinal;
+  using GO = NOX::GlobalOrdinal;
+  using Node = NOX::NodeType;
+
+  // Create the model evaluator object
+  Scalar x00 = 0.0;
+  Scalar x01 = 1.0;
+  const Tpetra::global_size_t numGlobalElements = 100;
+  Teuchos::RCP<EvaluatorTpetra1DFEM<Scalar,LO,GO,Node> > model =
+    evaluatorTpetra1DFEM<Scalar,LO,GO,Node>(comm, numGlobalElements, x00, x01);
+
+  // Create the linear solver and register on model evaluator
+  {
+    Stratimikos::DefaultLinearSolverBuilder builder;
+    typedef Thyra::PreconditionerFactoryBase<Scalar> Base;
+    typedef Thyra::Ifpack2PreconditionerFactory<Tpetra::CrsMatrix<Scalar, LO, GO, Node> > Impl;
+    builder.setPreconditioningStrategyFactory(Teuchos::abstractFactoryStd<Base, Impl>(), "Ifpack2");
+
+    Teuchos::RCP<Teuchos::ParameterList> p = Teuchos::parameterList();
+    p->set("Linear Solver Type", "Belos");
+    Teuchos::ParameterList& belosList = p->sublist("Linear Solver Types").sublist("Belos");
+    belosList.set("Solver Type", "Pseudo Block GMRES");
+    belosList.sublist("Solver Types").sublist("Pseudo Block GMRES").set<int>("Maximum Iterations", 200);
+    belosList.sublist("Solver Types").sublist("Pseudo Block GMRES").set<int>("Num Blocks", 200);
+    belosList.sublist("Solver Types").sublist("Pseudo Block GMRES").set("Verbosity", Belos::Errors+Belos::IterationDetails+Belos::FinalSummary);
+    belosList.sublist("Solver Types").sublist("Pseudo Block GMRES").set("Output Frequency", 5);
+    belosList.sublist("VerboseObject").set("Verbosity Level", "medium");
+    p->set("Preconditioner Type", "Ifpack2");
+    // p->set("Preconditioner Type", "None");
+    Teuchos::ParameterList& ifpackList = p->sublist("Preconditioner Types").sublist("Ifpack2");
+    ifpackList.set("Prec Type", "ILUT");
+
+    builder.setParameterList(p);
+
+    Teuchos::RCP<Thyra::LinearOpWithSolveFactoryBase<Scalar> >
+      lowsFactory = builder.createLinearSolveStrategy("");
+
+    model->set_W_factory(lowsFactory);
+  }
+
+  // Create the initial guess
+  Teuchos::RCP<Thyra::VectorBase<Scalar> >
+    initial_guess = model->getNominalValues().get_x()->clone_v();
+  Thyra::V_S(initial_guess.ptr(),Teuchos::ScalarTraits<Scalar>::one());
+
+  // Create top level nox/loca solver parameter list
+  Teuchos::RCP<Teuchos::ParameterList> pList = Teuchos::parameterList("Top Level");
+
+  // Create nox parameter list
+  auto& nl_params = pList->sublist("NOX");
+  nl_params.set("Nonlinear Solver", "Line Search Based");
+  nl_params.sublist("Direction").sublist("Newton").sublist("Linear Solver").set("Tolerance", 1.0e-8);
+  auto& ls_params = nl_params.sublist("Line Search");
+  ls_params.set("Method","Full Step");
+  auto& output_list = nl_params.sublist("Printing").sublist("Output Information");
+  output_list.set("Debug",true);
+  output_list.set("Warning",true);
+  output_list.set("Error",true);
+  output_list.set("Test Details",true);
+  output_list.set("Details",true);
+  output_list.set("Parameters",true);
+  output_list.set("Linear Solver Details",true);
+  output_list.set("Inner Iteration",true);
+  output_list.set("Outer Iteration",true);
+  output_list.set("Outer Iteration StatusTest",true);
+
+  // Create the LOCA Group:
+  // (NOX::Thyra::Group-->LOCA::Thyra::Group-->LOCA::Constrained::Group)
+  // For Tpetra Householder, we need to actively set the
+  // preconditioner and preconditioner factory so that it uses the
+  // precOp separate from the Jacobian operator. Householder replaces
+  // the Jacobian operator with a matrix-free version that has the
+  // uv^T tacked on.
+  auto explicit_jacobian = model->create_W_op();
+  auto prec_matrix = Teuchos::rcp(new Thyra::DefaultPreconditioner<NOX::Scalar>(Teuchos::null,explicit_jacobian));
+  TEST_ASSERT(nonnull(model->get_W_factory()->getPreconditionerFactory()));
+  Teuchos::RCP<NOX::Thyra::Group> nox_group =
+    Teuchos::rcp(new NOX::Thyra::Group(*initial_guess,
+                                       model,
+                                       explicit_jacobian,
+                                       model->get_W_factory(),
+                                       prec_matrix, // Reuse Jac for approx preconditioner
+                                       model->get_W_factory()->getPreconditionerFactory(),
+                                       Teuchos::null));
+
+  Teuchos::RCP<LOCA::Abstract::Factory> tpetra_factory = Teuchos::rcp(new LOCA::Tpetra::Factory);
+
+  Teuchos::RCP<LOCA::GlobalData> global_data = LOCA::createGlobalData(pList, tpetra_factory);
+
+  Teuchos::RCP<LOCA::ParameterVector> p_vec = Teuchos::rcp(new LOCA::ParameterVector);
+  p_vec->addParameter("k", 1.0); // Source term multiplier
+  p_vec->addParameter("T_left", 1.2); // Source term multiplier
+
+  std::vector<int> me_p_indices;
+  me_p_indices.push_back(2);
+  me_p_indices.push_back(4);
+  Teuchos::RCP<LOCA::Thyra::Group> loca_group = Teuchos::rcp(new LOCA::Thyra::Group(global_data,
+                                                                                    *nox_group,
+                                                                                    *p_vec,
+                                                                                    me_p_indices));
+
+  auto g_names = Teuchos::rcp(new std::vector<std::string>);
+  g_names->push_back("Constraint: T_right=2");
+  g_names->push_back("Constraint: 2*T_left=T_right");
+  auto x_thyra = ::Thyra::createMember(model->get_x_space(),"x");
+  NOX::Thyra::Vector x(x_thyra);
+  auto constraints = Teuchos::rcp(new LOCA::MultiContinuation::ConstraintModelEvaluator(model,*p_vec,*g_names,x));
+
+  // Set initial parameter conditions
+  constraints->setX(x);
+  constraints->setParam(0,1.0);
+  constraints->setParam(1,1.2);
+
+  // Create the constraints list
+  auto& locaParamsList = pList->sublist("LOCA");
+  auto& constraint_list = locaParamsList.sublist("Constraints");
+  constraint_list.set("Bordered Solver Method", "Householder");
+  constraint_list.set("Constraint Object", constraints);
+  constraint_list.set("Constraint Parameter Names", g_names);
+  constraint_list.set("Include UV In Preconditioner",true);
+
+  auto loca_parser = Teuchos::rcp(new LOCA::Parameter::SublistParser(global_data));
+  loca_parser->parseSublists(pList);
+
+  std::vector<int> param_ids(2);
+  param_ids[0] = 0;
+  param_ids[1] = 1;
+  auto constraint_list_ptr = Teuchos::rcpFromRef(constraint_list);
+  Teuchos::RCP<LOCA::MultiContinuation::ConstrainedGroup> loca_constrained_group =
+    Teuchos::rcp(new LOCA::MultiContinuation::ConstrainedGroup(global_data,
+                                                               loca_parser,
+                                                               constraint_list_ptr,
+                                                               loca_group,
+                                                               constraints,
+                                                               param_ids,
+                                                               false));
+
+  loca_constrained_group->computeF();
+
+  // Create the NOX status tests and the solver
+  // Create the convergence tests
+  Teuchos::RCP<NOX::StatusTest::NormF> absresid =
+    Teuchos::rcp(new NOX::StatusTest::NormF(1.0e-8));
+  Teuchos::RCP<NOX::StatusTest::NormWRMS> wrms =
+    Teuchos::rcp(new NOX::StatusTest::NormWRMS(1.0e-2, 1.0e-8));
+  Teuchos::RCP<NOX::StatusTest::Combo> converged =
+    Teuchos::rcp(new NOX::StatusTest::Combo(NOX::StatusTest::Combo::AND));
+  converged->addStatusTest(absresid);
+  converged->addStatusTest(wrms);
+  Teuchos::RCP<NOX::StatusTest::MaxIters> maxiters =
+    Teuchos::rcp(new NOX::StatusTest::MaxIters(10));
+  Teuchos::RCP<NOX::StatusTest::FiniteValue> fv =
+    Teuchos::rcp(new NOX::StatusTest::FiniteValue);
+  Teuchos::RCP<NOX::StatusTest::Combo> combo =
+    Teuchos::rcp(new NOX::StatusTest::Combo(NOX::StatusTest::Combo::OR));
+  combo->addStatusTest(fv);
+  combo->addStatusTest(converged);
+  combo->addStatusTest(maxiters);
+
+  // Create the solver
+  // auto solver = NOX::Solver::buildSolver(nox_group, combo, Teuchos::rcpFromRef(pList->sublist("NOX")));
+  // auto solver = NOX::Solver::buildSolver(loca_group, combo, Teuchos::rcpFromRef(pList->sublist("NOX")));
+  auto solver = NOX::Solver::buildSolver(loca_constrained_group, combo, Teuchos::rcpFromRef(pList->sublist("NOX")));
+
+  NOX::StatusTest::StatusType solvStatus = solver->solve();
+
+  // Output
+  {
+    Teuchos::TimeMonitor::getStackedTimer()->stopBaseTimer();
+    Teuchos::StackedTimer::OutputOptions options;
+    options.output_fraction = true;
+    options.output_minmax = true;
+    Teuchos::TimeMonitor::getStackedTimer()->report(out,comm,options);
+  }
+
+  // Write solution to file
+  const bool printSolution = true;
+  if (printSolution) {
+    for (int i=0; i < comm->getSize(); ++i) {
+      if (comm->getRank() == i) {
+        std::ofstream file;
+        if (comm->getRank() == 0)
+          file.open("householder_solution.txt",std::ios::trunc);
+        else
+          file.open("householder_solution.txt",std::ios::app);
+        
+        const auto& final_x = solver->getSolutionGroup().getX();
+        const auto& final_x_nox = *(dynamic_cast<const LOCA::MultiContinuation::ExtendedVector&>(final_x).getXVec());
+        const auto& final_x_thyra = dynamic_cast<const NOX::Thyra::Vector&>(final_x_nox).getThyraVector();
+        const auto& final_x_tpetra_const = *(dynamic_cast<const ::Thyra::TpetraVector<NOX::Scalar,NOX::LocalOrdinal,NOX::GlobalOrdinal,NOX::NodeType>&>(final_x_thyra).getConstTpetraVector());
+        auto& final_x_tpetra = const_cast<::Tpetra::Vector<NOX::Scalar,NOX::LocalOrdinal,NOX::GlobalOrdinal,NOX::NodeType>&>(final_x_tpetra_const);
+        final_x_tpetra.sync_host();
+        const auto& final_x_view = final_x_tpetra.getLocalViewHost();
+        for (size_t j=0; j < final_x_view.extent(0); ++j)
+          file << final_x_view(j,0) << std::endl;
+      }
+      comm->barrier();
+    }
+  }
+
+  TEST_ASSERT(solvStatus == NOX::StatusTest::Converged);
+  TEST_EQUALITY(solver->getSolverStatistics()->numNonlinearIterations,5);
+
+  // Check final values
+  {
+    const auto& group = solver->getSolutionGroup();
+    const auto& c_group = dynamic_cast<const LOCA::MultiContinuation::ConstrainedGroup&>(group);
+
+    out << "\nFinal Parameter Value for \"k\" = " << std::setprecision(10) << c_group.getParam(0) << std::endl;
+    out << "Final Parameter Value for \"T_left\" = " << std::setprecision(10) << c_group.getParam(1) << std::endl;
+
+    const double tol = 1.0e-3;
+    TEST_FLOATING_EQUALITY(c_group.getParam(0),-0.5993277206,tol);
+    TEST_FLOATING_EQUALITY(c_group.getParam(1),1.0,tol);
+  }
+
+  // Breaks RCP cyclic dependency
+  LOCA::destroyGlobalData(global_data);
+}


### PR DESCRIPTION
## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Improves preconditioning matrix

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
Requested for Charon2 problem

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
New test added:  nox/test/tpetra/tTpetra_HouseholderBorderedSolve_WithUVInPrec.cpp

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->