### PR TITLE
Tpetra: FECrsMatrix: add separate Assemble and Modify stages

### DIFF
--- a/cmake/std/PullRequestLinuxDriver.sh
+++ b/cmake/std/PullRequestLinuxDriver.sh
@@ -70,7 +70,7 @@ print_banner "PullRequestLinuxDriver.sh"
 # Set up Sandia PROXY environment vars
 export https_proxy=http://proxy.sandia.gov:80
 export http_proxy=http://proxy.sandia.gov:80
-export no_proxy='localhost,localnets,127.0.0.1,169.254.0.0/16,forge.sandia.gov'
+export no_proxy='localhost,.sandia.gov,localnets,127.0.0.1,169.254.0.0/16,forge.sandia.gov'
 
 
 # bootstrap the python and git modules for this system

--- a/cmake/std/PullRequestLinuxDriver.sh
+++ b/cmake/std/PullRequestLinuxDriver.sh
@@ -26,7 +26,7 @@ function bootstrap_modules() {
         elif [[ ${NODE_NAME:?} =~ ${vortex_regex} ]]; then
             echo -e "Job is CUDA node is vortex"
             module load git/2.20.0
-            module load python/3.7.2 
+            module load python/3.7.2
             get_python_packages pip3
             export PYTHON_EXE=python3
         else
@@ -70,7 +70,7 @@ print_banner "PullRequestLinuxDriver.sh"
 # Set up Sandia PROXY environment vars
 export https_proxy=http://proxy.sandia.gov:80
 export http_proxy=http://proxy.sandia.gov:80
-export no_proxy='localhost,.sandia.gov,localnets,127.0.0.1,169.254.0.0/16,forge.sandia.gov'
+export no_proxy='localhost,localnets,127.0.0.1,169.254.0.0/16,forge.sandia.gov'
 
 
 # bootstrap the python and git modules for this system

--- a/packages/panzer/dof-mgr/test/fe_assembly/test_fe_assembly_HEX.hpp
+++ b/packages/panzer/dof-mgr/test/fe_assembly/test_fe_assembly_HEX.hpp
@@ -46,10 +46,10 @@
 
   The mesh topology and global numbering of the Degrees of Freedom (DoFs) are computed using Panzer Dof Manager package
   Local matrices and right-hand-side are computed using high-order HGRAD elements on Hexahedra provided by the package Intrepid2
-  Local matrices and right-hand-side are assembled into global matrix A and right-hand-side b using the 
+  Local matrices and right-hand-side are assembled into global matrix A and right-hand-side b using the
   FECrsMatrix and FEMultivector provided by Tpetra package
-  
-  The code is then verified by checking the norm of the residual r = b - A x. 
+
+  The code is then verified by checking the norm of the residual r = b - A x.
   When the solution belong to the chosen finite element space, the residual norm should be close to machine eps.
 
   Command line arguments:
@@ -212,7 +212,7 @@ int feAssemblyHex(int argc, char *argv[]) {
 
   try {
 
-    
+
     // ************************************ GET INPUTS **************************************
     constexpr local_ordinal_t dim = 3;
     int degree = 4;
@@ -240,7 +240,7 @@ int feAssemblyHex(int argc, char *argv[]) {
     clp.setOption("timings-file",&timingsFile);
     clp.setOption("verbose", &verbose);
     auto cmdResult = clp.parse(argc,argv);
-    cubDegree = (cubDegree == -1) ? 2*degree : cubDegree;    
+    cubDegree = (cubDegree == -1) ? 2*degree : cubDegree;
 
     if(cmdResult!=Teuchos::CommandLineProcessor::PARSE_SUCCESSFUL) {
       clp.printHelpMessage(argv[0], std::cout);
@@ -250,12 +250,12 @@ int feAssemblyHex(int argc, char *argv[]) {
     outStream = ((comm.getRank () == 0) && verbose) ?
       getFancyOStream(Teuchos::rcpFromRef (std::cout)) :
       getFancyOStream(Teuchos::rcp (new Teuchos::oblackholestream ()));
-   
+
     *outStream << "DeviceSpace::  "; DeviceSpaceType::print_configuration(*outStream, false);
     *outStream << "HostSpace::    ";   HostSpaceType::print_configuration(*outStream, false);
     *outStream << "\n";
 
- 
+
     auto meshTimer =  Teuchos::rcp(new Teuchos::TimeMonitor(*Teuchos::TimeMonitor::getNewTimer("Mesh Generation")));
 
     // *********************************** MESH TOPOLOGY **********************************
@@ -304,7 +304,7 @@ int feAssemblyHex(int argc, char *argv[]) {
     *outStream << std::setw(5) << px <<
         std::setw(5) << py <<
         std::setw(5) << pz << "\n\n";
-    
+
     global_ordinal_t totalNumElements = numOwnedElems*px*py*pz;
      *outStream << "Total number of elements: " << totalNumElements << ", number of DoFs per element: " << basisCardinality << "\n";
 
@@ -330,9 +330,9 @@ int feAssemblyHex(int argc, char *argv[]) {
       DynRankView ConstructWithLabel(refVertices, numNodesPerElem, dim);
       Intrepid2::Basis_HGRAD_HEX_C1_FEM<DeviceSpaceType,scalar_t,scalar_t> hexaLinearBasis;
       hexaLinearBasis.getDofCoords(refVertices);
-      auto refVerticesHost = Kokkos::create_mirror_view(refVertices);   
+      auto refVerticesHost = Kokkos::create_mirror_view(refVertices);
       Kokkos::deep_copy(refVerticesHost, refVertices);
-   
+
       auto elemTriplet = connManager->getMyBrickElementsTriplet();
       double h[3] = {hx, hy, hz};
 
@@ -349,7 +349,7 @@ int feAssemblyHex(int argc, char *argv[]) {
 
     meshTimer = Teuchos::null;
 
-    
+
     // *********************************** COMPUTE ELEMENTS' ORIENTATION BASED ON GLOBAL IDs  ************************************
 
 
@@ -450,7 +450,7 @@ int feAssemblyHex(int argc, char *argv[]) {
     fst::integrate(elemsMat, transformedBasisValuesAtQPointsOriented, weightedTransformedBasisValuesAtQPointsOriented, true);
     Kokkos::fence(); //make sure that funAtQPoints has been evaluated
     fst::integrate(elemsRHS, funAtQPoints, weightedTransformedBasisValuesAtQPointsOriented);
-    
+
     localFeAssemblyTimer =  Teuchos::null;
 
 
@@ -466,7 +466,7 @@ int feAssemblyHex(int argc, char *argv[]) {
     Teuchos::RCP<const map_t> ownedAndGhostedMap = Teuchos::rcp(new const map_t(Teuchos::OrdinalTraits<global_ordinal_t>::invalid(),ownedAndGhostedIndices,0,Teuchos::rcpFromRef(comm)));
 
      *outStream << "Total number of DoFs: " << ownedMap->getGlobalNumElements() << ", number of owned DoFs: " << ownedMap->getNodeNumElements() << "\n";
-    
+
     mapsTimer = Teuchos::null;
     auto graphGenerationTimer =  Teuchos::rcp(new Teuchos::TimeMonitor(*Teuchos::TimeMonitor::getNewTimer("Graph Generation")));
 
@@ -490,7 +490,7 @@ int feAssemblyHex(int argc, char *argv[]) {
 
     // fill graph
     // for each element in the mesh...
-    Tpetra::beginFill(*feGraph);
+    Tpetra::beginAssembly(*feGraph);
     for(int elemId=0; elemId<numOwnedElems; elemId++)
     {
       // Populate globalIdsInRow:
@@ -514,14 +514,14 @@ int feAssemblyHex(int argc, char *argv[]) {
         feGraph->insertGlobalIndices(globalIdsInRow[nodeId], globalIdsInRow());
       }
     }
-    Tpetra::endFill(*feGraph);
+    Tpetra::endAssembly(*feGraph);
 
     graphGenerationTimer = Teuchos::null;
 
     // ************************************ MATRIX ASSEMBLY **************************************
 
     auto matrixAndRhsAllocationTimer =  Teuchos::rcp(new Teuchos::TimeMonitor(*Teuchos::TimeMonitor::getNewTimer("Allocation of Matrix and Rhs")));
-   
+
     auto A = Teuchos::rcp(new fe_matrix_t(feGraph));
     auto b = Teuchos::rcp (new fe_multivector_t(ownedMap, feGraph->getImporter(), 1));
 
@@ -539,7 +539,7 @@ int feAssemblyHex(int argc, char *argv[]) {
 
     //fill matrix
     // Loop over elements
-    Tpetra::beginFill(*A,*b);
+    Tpetra::beginAssembly(*A, *b);
 
     std::vector<global_ordinal_t> elementGIDs(basisCardinality);
     auto elementLIDs = globalIndexer->getLIDs();
@@ -558,7 +558,7 @@ int feAssemblyHex(int argc, char *argv[]) {
           const local_ordinal_t localRowId = elemLIds(elmtOffsetKokkos(nodeId));
 
           // Force atomics on sums
-          for (local_ordinal_t colId = 0; colId < basisCardinality; ++colId) 
+          for (local_ordinal_t colId = 0; colId < basisCardinality; ++colId)
             localMatrix.sumIntoValues (localRowId, &elemLIds(elmtOffsetKokkos(colId)), 1, &(elemMat(nodeId,colId)), true, true);
 
           Kokkos::atomic_add (&(localRHS(localRowId,0)), elemRHS(nodeId));
@@ -568,7 +568,7 @@ int feAssemblyHex(int argc, char *argv[]) {
     // Release the device view
     localRHS = decltype(localRHS)("empty",0,0);
 
-    Tpetra::endFill(*A, *b);
+    Tpetra::endAssembly(*A, *b);
 
     matrixAndRhsFillTimer =  Teuchos::null;
 
@@ -581,9 +581,9 @@ int feAssemblyHex(int argc, char *argv[]) {
       Teuchos::TimeMonitor liTimer =  *Teuchos::TimeMonitor::getNewTimer("Verification, locally interpolate analytic solution");
       DynRankView ConstructWithLabel(dofCoordsOriented, numOwnedElems, basisCardinality, dim);
       DynRankView ConstructWithLabel(dofCoeffsPhys, numOwnedElems, basisCardinality);
-      
+
       li::getDofCoordsAndCoeffs(dofCoordsOriented,  dofCoeffsPhys, basis.getRawPtr(), elemOrts);
- 
+
       DynRankView ConstructWithLabel(funAtDofPoints, numOwnedElems, basisCardinality);
       {
         DynRankView ConstructWithLabel(physDofPoints, numOwnedElems, basisCardinality, dim);
@@ -594,7 +594,7 @@ int feAssemblyHex(int argc, char *argv[]) {
         Kokkos::parallel_for("loop for evaluating the function at DoF points", numOwnedElems,functor);
         Kokkos::fence(); //make sure that funAtDofPoints has been evaluated
       }
-    
+
       li::getBasisCoeffs(basisCoeffsLI, funAtDofPoints, dofCoeffsPhys);
     }
 
@@ -615,7 +615,7 @@ int feAssemblyHex(int argc, char *argv[]) {
             x.replaceGlobalValue(gid, basisCoeffsLIHost(elemId, nodeId));
         }
       }
-     
+
       {
         Teuchos::TimeMonitor vTimer2 =  *Teuchos::TimeMonitor::getNewTimer("Verification,compute rhs (matrix-vector product)");
         A->apply(x, *b, Teuchos::NO_TRANS, -1.0, 1.0);   // b - A x
@@ -636,8 +636,8 @@ int feAssemblyHex(int argc, char *argv[]) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   }
- 
- 
+
+
   Teuchos::RCP<Teuchos::ParameterList> reportParams = parameterList(* (Teuchos::TimeMonitor::getValidReportParameters()));
   reportParams->set("Report format", "YAML");
   reportParams->set("YAML style", "spacious");

--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_InsertGlobalIndices_FE.hpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_InsertGlobalIndices_FE.hpp
@@ -167,7 +167,7 @@ int executeInsertGlobalIndicesFESP_(const Teuchos::RCP<const Teuchos::Comm<int> 
   Teuchos::Array<global_ordinal_type> global_ids_in_row(4);
 
   // for each element in the mesh...
-  Tpetra::beginFill(*fe_graph);
+  Tpetra::beginAssembly(*fe_graph);
   for(size_t element_gidx=0; element_gidx<mesh.getNumOwnedElements(); element_gidx++)
   {
     // Populate global_ids_in_row:
@@ -196,7 +196,7 @@ int executeInsertGlobalIndicesFESP_(const Teuchos::RCP<const Teuchos::Comm<int> 
   // Call fillComplete on the fe_graph to 'finalize' it.
   {
     TimeMonitor timer(*TimeMonitor::getNewTimer("2) FillComplete (Graph)"));
-    Tpetra::endFill(*fe_graph);
+    Tpetra::endAssembly(*fe_graph);
   }
 
   // Print out verbose information about the fe_graph.
@@ -255,7 +255,7 @@ int executeInsertGlobalIndicesFESP_(const Teuchos::RCP<const Teuchos::Comm<int> 
     Teuchos::Array<Scalar> column_scalar_values(4);         // scalar values for each column
 
     // Loop over elements
-    Tpetra::beginFill(*fe_matrix,*rhs);
+    Tpetra::beginAssembly(*fe_matrix,*rhs);
     for (size_t element_gidx = 0;
          element_gidx < mesh.getNumOwnedElements ();
          ++element_gidx) {
@@ -292,13 +292,13 @@ int executeInsertGlobalIndicesFESP_(const Teuchos::RCP<const Teuchos::Comm<int> 
   // After the contributions are added, 'finalize' the matrix using fillComplete()
   {
     TimeMonitor timer(*TimeMonitor::getNewTimer("4) FillComplete (Matrix)"));
-    Tpetra::endFill(*fe_matrix);
+    Tpetra::endAssembly(*fe_matrix);
   }
 
   {
     // Global assemble the RHS
     TimeMonitor timer(*TimeMonitor::getNewTimer("5) GlobalAssemble (RHS)"));
-    Tpetra::endFill(*rhs);
+    Tpetra::endAssembly(*rhs);
   }
 
   Teuchos::TimeMonitor::getStackedTimer()->stopBaseTimer();
@@ -392,7 +392,7 @@ int executeInsertGlobalIndicesFESPKokkos_(const Teuchos::RCP<const Teuchos::Comm
       (*TimeMonitor::getNewTimer("1) ElementLoop  (Graph)"));
 
     // for each element in the mesh...
-    Tpetra::beginFill(*fe_graph);
+    Tpetra::beginAssembly(*fe_graph);
     for (size_t element_gidx = 0;
          element_gidx < mesh.getNumOwnedElements ();
          ++element_gidx) {
@@ -424,7 +424,7 @@ int executeInsertGlobalIndicesFESPKokkos_(const Teuchos::RCP<const Teuchos::Comm
   // Call fillComplete on the fe_graph to 'finalize' it.
   {
     TimeMonitor timer(*TimeMonitor::getNewTimer("2) FillComplete (Graph)"));
-    Tpetra::endFill(*fe_graph);
+    Tpetra::endAssembly(*fe_graph);
   }
 
   // Print out verbose information about the fe_graph.
@@ -491,7 +491,7 @@ int executeInsertGlobalIndicesFESPKokkos_(const Teuchos::RCP<const Teuchos::Comm
       (*TimeMonitor::getNewTimer ("3.2) ElementLoop  (Matrix)"));
 
     // Loop over elements
-    Tpetra::beginFill(*fe_matrix,*rhs);
+    Tpetra::beginAssembly(*fe_matrix,*rhs);
     Kokkos::parallel_for
       ("Assemble FE matrix and right-hand side",
        Kokkos::RangePolicy<execution_space, int> (0, numOwnedElements),
@@ -534,13 +534,13 @@ int executeInsertGlobalIndicesFESPKokkos_(const Teuchos::RCP<const Teuchos::Comm
   // After the contributions are added, 'finalize' the matrix using fillComplete()
   {
     TimeMonitor timer(*TimeMonitor::getNewTimer("4) FillComplete (Matrix)"));
-    Tpetra::endFill(*fe_matrix);
+    Tpetra::endAssembly(*fe_matrix);
   }
 
   {
     // Global assemble the RHS
     TimeMonitor timer(*TimeMonitor::getNewTimer("5) GlobalAssemble (RHS)"));
-    Tpetra::endFill(*rhs);
+    Tpetra::endAssembly(*rhs);
   }
 
   Teuchos::TimeMonitor::getStackedTimer()->stopBaseTimer();

--- a/packages/tpetra/core/src/Tpetra_Assembly_Helpers.hpp
+++ b/packages/tpetra/core/src/Tpetra_Assembly_Helpers.hpp
@@ -73,6 +73,52 @@ void endFill(Args &&... args)
 
 }
 
+template <typename... Args>
+void beginAssembly(Args &&... args)
+{
+  // use the comma operator to transform a potentially void function call
+  // into a argument to allow proper parameter expansion for c++11
+  Impl::foreach_pack( (args.beginAssembly(),1)... );
+
+  // using c++17 the code would be
+  // (args.beginAssembly()...);
+}
+
+template <typename... Args>
+void endAssembly(Args &&... args)
+{
+  // use the comma operator to transform a potentially void function call
+  // into a argument to allow proper parameter expansion for c++11
+  Impl::foreach_pack( (args.endAssembly(),1)... );
+
+  // using c++17 the code would be
+  // (args.endAssembly()...);
+
+}
+
+template <typename... Args>
+void beginModify(Args &&... args)
+{
+  // use the comma operator to transform a potentially void function call
+  // into a argument to allow proper parameter expansion for c++11
+  Impl::foreach_pack( (args.beginModify(),1)... );
+
+  // using c++17 the code would be
+  // (args.beginModify()...);
+}
+
+template <typename... Args>
+void endModify(Args &&... args)
+{
+  // use the comma operator to transform a potentially void function call
+  // into a argument to allow proper parameter expansion for c++11
+  Impl::foreach_pack( (args.endModify(),1)... );
+
+  // using c++17 the code would be
+  // (args.endModify()...);
+
+}
+
 }// namespace Tpetra
 
 #endif // TPETRA_ASSEMBLY_HELPERS_HPP

--- a/packages/tpetra/core/src/Tpetra_Assembly_Helpers.hpp
+++ b/packages/tpetra/core/src/Tpetra_Assembly_Helpers.hpp
@@ -50,28 +50,6 @@ template <typename... Args>
 inline void foreach_pack(Args &&... args) {}
 } // namespace Impl
 
-template <typename... Args>
-void beginFill(Args &&... args)
-{
-  // use the comma operator to transform a potentially void function call
-  // into a argument to allow proper parameter expansion for c++11
-  Impl::foreach_pack( (args.beginFill(),1)... );
-
-  // using c++17 the code would be
-  // (args.beginFill()...);
-}
-
-template <typename... Args>
-void endFill(Args &&... args)
-{
-  // use the comma operator to transform a potentially void function call
-  // into a argument to allow proper parameter expansion for c++11
-  Impl::foreach_pack( (args.endFill(),1)... );
-
-  // using c++17 the code would be
-  // (args.endFill()...);
-
-}
 
 template <typename... Args>
 void beginAssembly(Args &&... args)

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -884,13 +884,14 @@ namespace Tpetra {
                                   MultiVector<S2,LO2,GO2,N2> & R);
 
     // This friend declaration allows for batching of apply calls
-    template <class MatrixArray, class MultiVectorArray> 
-    friend void batchedApply(const MatrixArray &Matrices, 
+    template <class MatrixArray, class MultiVectorArray>
+    friend void batchedApply(const MatrixArray &Matrices,
                              const typename std::remove_pointer<typename MultiVectorArray::value_type>::type & X,
                              MultiVectorArray &Y,
                              typename std::remove_pointer<typename MatrixArray::value_type>::type::scalar_type alpha,
                              typename std::remove_pointer<typename MatrixArray::value_type>::type::scalar_type beta,
                              Teuchos::RCP<Teuchos::ParameterList> params);
+
   public:
     //@}
     //! @name Methods for inserting, modifying, or removing entries
@@ -1055,7 +1056,7 @@ namespace Tpetra {
                        const Scalar vals[],
                        const LocalOrdinal cols[]);
 
-  private:
+  protected:
     /// \brief Implementation detail of replaceGlobalValues.
     ///
     /// \param rowVals [in/out] On input: Values of the row of the
@@ -1066,7 +1067,7 @@ namespace Tpetra {
     /// \param inds [in] Global column indices of that row to modify.
     /// \param newVals [in] For each k, replace the value in rowVals
     ///   corresponding to local column index inds[k] with newVals[k].
-    LocalOrdinal
+    virtual LocalOrdinal
     replaceGlobalValuesImpl (impl_scalar_type rowVals[],
                              const crs_graph_type& graph,
                              const RowInfo& rowInfo,
@@ -1144,7 +1145,7 @@ namespace Tpetra {
                          const Scalar vals[],
                          const GlobalOrdinal cols[]);
 
-  private:
+  protected:
     /// \brief Implementation detail of replaceLocalValues.
     ///
     /// \param rowVals [in/out] On input: Values of the row of the
@@ -1155,7 +1156,7 @@ namespace Tpetra {
     /// \param inds [in] Local column indices of that row to modify.
     /// \param newVals [in] For each k, replace the value in rowVals
     ///   corresponding to local column index inds[k] with newVals[k].
-    LocalOrdinal
+    virtual LocalOrdinal
     replaceLocalValuesImpl (impl_scalar_type rowVals[],
                             const crs_graph_type& graph,
                             const RowInfo& rowInfo,
@@ -1271,7 +1272,8 @@ namespace Tpetra {
     ///   error other than one or more invalid column indices, this
     ///   method returns
     ///   Teuchos::OrdinalTraits<LocalOrdinal>::invalid().
-    LocalOrdinal
+  protected:
+    virtual LocalOrdinal
     sumIntoGlobalValuesImpl (impl_scalar_type rowVals[],
                              const crs_graph_type& graph,
                              const RowInfo& rowInfo,
@@ -1352,7 +1354,7 @@ namespace Tpetra {
                          const GlobalOrdinal cols[],
                          const bool atomic = useAtomicUpdatesByDefault);
 
-  private:
+  protected:
     /// \brief Implementation detail of sumIntoLocalValues.
     ///
     /// \param rowVals [in/out] On input: Values of the row of the
@@ -1365,7 +1367,7 @@ namespace Tpetra {
     ///   corresponding to local column index inds[k] by newVals[k].
     /// \param atomic [in] Whether to use atomic updates (+=) when
     ///   incrementing values.
-    LocalOrdinal
+    virtual LocalOrdinal
     sumIntoLocalValuesImpl (impl_scalar_type rowVals[],
                             const crs_graph_type& graph,
                             const RowInfo& rowInfo,
@@ -3572,13 +3574,15 @@ public:
     ///      are in the column Map on the calling process.  That is, the
     ///      entries of gblColInds (and their corresponding vals entries)
     ///      are "prefiltered," if we needed to filter them.
-    void
+  protected:
+    virtual void
     insertGlobalValuesImpl (crs_graph_type& graph,
                             RowInfo& rowInfo,
                             const GlobalOrdinal gblColInds[],
                             const impl_scalar_type vals[],
                             const size_t numInputEnt);
 
+  private:
     /// \brief Like insertGlobalValues(), but with column filtering.
     ///
     /// "Column filtering" means that if the matrix has a column Map,

--- a/packages/tpetra/core/src/Tpetra_FECrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_FECrsGraph_decl.hpp
@@ -83,7 +83,7 @@ namespace Tpetra {
   ///       If you partition a mesh by node (N), then your owned+shared maps should contain all the
   ///       nodes that are in the patch of one of the owned nodes, which is precisely what
   ///       the colMap of the owned+shared graph should contain.
-  ///       On the other hand, if you partition the mesh by cell (C), then your owned+shared maps 
+  ///       On the other hand, if you partition the mesh by cell (C), then your owned+shared maps
   ///       should contain all nodes belonging to one of the owned elements. Such map does *NOT*
   ///       necessarily contain all the GID of all the nodes connected to one of the owned nodes
   ///       (which is what the colMap should contain). In this case, you are not likely to have
@@ -177,7 +177,7 @@ namespace Tpetra {
     /// \param ownedRangeMap [in] Optional range map for the owned graph.  If this is not provided, then ownedMap
     ///   will be used as range map for the owned graph.
     ///
-    /// \param params [in/out] Optional list of parameters.  If not 
+    /// \param params [in/out] Optional list of parameters.  If not
     ///   null, any missing parameters will be filled in with their
     ///   default values.
     FECrsGraph(const Teuchos::RCP<const map_type> & ownedRowMap,
@@ -470,6 +470,12 @@ namespace Tpetra {
     //! Activates the owned+shared mode for assembly.  This can only be called once.
     void beginFill();
 
+    //! Migrates data to the owned mode
+    void endAssembly();
+
+    //! Activates the owned+shared mode for assembly
+    void beginAssembly();
+
     /// \brief Tell the graph that you are done changing its structure.
     ///
     /// This tells the graph to optimize its data structures for
@@ -578,6 +584,12 @@ namespace Tpetra {
       FE_ACTIVE_OWNED_PLUS_SHARED
     };
 
+    enum class FillState
+    {
+      open,  // matrix is "open".  Values can freely inserted
+      closed
+    };
+    Teuchos::RCP<FillState> fillState_;
 
     // This is whichever graph isn't currently active
     Teuchos::RCP<CrsGraph<LocalOrdinal, GlobalOrdinal, Node> > inactiveCrsGraph_;
@@ -593,6 +605,44 @@ namespace Tpetra {
 
     // The rangeMap to use in endFill() for the owned graph
     Teuchos::RCP<const map_type> ownedRangeMap_;
+
+  protected:
+    /// \brief Insert global indices, using an input <i>local</i> row index.
+    ///
+    /// \param rowInfo [in] Result of getRowInfo() on the row in which
+    ///   to insert.
+    /// \param inputGblColInds [in] Input global column indices.
+    /// \param numInputInds [in] The number of input global column
+    ///   indices.
+    ///
+    /// \return The number of indices inserted.
+    size_t
+    insertGlobalIndicesImpl (const local_ordinal_type lclRow,
+                             const global_ordinal_type inputGblColInds[],
+                             const size_t numInputInds);
+
+    /// \brief Insert global indices, using an input RowInfo.
+    ///
+    /// \param rowInfo [in] Result of getRowInfo() on the row in which
+    ///   to insert.
+    /// \param inputGblColInds [in] Input global column indices.
+    /// \param numInputInds [in] The number of input global column
+    ///   indices.
+    ///
+    /// \return The number of indices inserted.
+    size_t
+    insertGlobalIndicesImpl (const RowInfo& rowInfo,
+                             const global_ordinal_type inputGblColInds[],
+                             const size_t numInputInds,
+                             std::function<void(const size_t, const size_t, const size_t)> fun =
+                                 std::function<void(const size_t, const size_t, const size_t)>());
+
+    void
+    insertLocalIndicesImpl (const local_ordinal_type lclRow,
+                            const Teuchos::ArrayView<const local_ordinal_type>& gblColInds,
+                            std::function<void(const size_t, const size_t, const size_t)> fun =
+                                std::function<void(const size_t, const size_t, const size_t)>());
+
   }; // class FECrsGraph
 
 

--- a/packages/tpetra/core/src/Tpetra_FECrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_FECrsGraph_decl.hpp
@@ -466,6 +466,7 @@ namespace Tpetra {
 
     //! Migrates data to the owned mode
     void endAssembly();
+    void endAssembly(const Teuchos::RCP<const map_type>& domainMap, const Teuchos::RCP<const map_type>& rangeMap);
 
     //! Activates the owned+shared mode for assembly
     void beginAssembly();
@@ -551,6 +552,7 @@ namespace Tpetra {
 
     //! Migrates data to the owned mode
     void endFill();
+    void endFill(const Teuchos::RCP<const map_type>& domainMap, const Teuchos::RCP<const map_type>& rangeMap);
 
     //! Activates the owned+shared mode for assembly.  This can only be called once.
     void beginFill();

--- a/packages/tpetra/core/src/Tpetra_FECrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_FECrsGraph_decl.hpp
@@ -465,12 +465,6 @@ namespace Tpetra {
     //@{
 
     //! Migrates data to the owned mode
-    void endFill();
-
-    //! Activates the owned+shared mode for assembly.  This can only be called once.
-    void beginFill();
-
-    //! Migrates data to the owned mode
     void endAssembly();
 
     //! Activates the owned+shared mode for assembly
@@ -554,6 +548,13 @@ namespace Tpetra {
 
 
   private:
+
+    //! Migrates data to the owned mode
+    void endFill();
+
+    //! Activates the owned+shared mode for assembly.  This can only be called once.
+    void beginFill();
+
     /// \brief Migrate data from the owned+shared to the owned graph
     /// Since this is non-unique -> unique, we need a combine mode.
     /// Precondition: Must be FE_ACTIVE_OWNED_PLUS_SHARED mode

--- a/packages/tpetra/core/src/Tpetra_FECrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_FECrsGraph_def.hpp
@@ -54,7 +54,7 @@ namespace Tpetra {
 template<class LocalOrdinal, class GlobalOrdinal, class Node>
 FECrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
 FECrsGraph(const Teuchos::RCP<const map_type> & ownedRowMap,
-           const Teuchos::RCP<const map_type> & ownedPlusSharedRowMap, 
+           const Teuchos::RCP<const map_type> & ownedPlusSharedRowMap,
            const size_t maxNumEntriesPerRow,
            const Teuchos::RCP<const import_type> & ownedPlusSharedToOwnedimporter,
            const Teuchos::RCP<const map_type> & domainMap,
@@ -107,7 +107,7 @@ FECrsGraph (const Teuchos::RCP<const map_type> & ownedRowMap,
 template<class LocalOrdinal, class GlobalOrdinal, class Node>
 FECrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
 FECrsGraph (const Teuchos::RCP<const map_type> & ownedRowMap,
-            const Teuchos::RCP<const map_type> & ownedPlusSharedRowMap, 
+            const Teuchos::RCP<const map_type> & ownedPlusSharedRowMap,
             const Kokkos::DualView<const size_t*, device_type>& numEntPerRow,
             const Teuchos::RCP<const map_type> & ownedPlusSharedDomainMap,
             const Teuchos::RCP<const import_type> & ownedPlusSharedToOwnedimporter,
@@ -127,13 +127,13 @@ FECrsGraph (const Teuchos::RCP<const map_type> & ownedRowMap,
 template<class LocalOrdinal, class GlobalOrdinal, class Node>
 FECrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
 FECrsGraph(const Teuchos::RCP<const map_type> & ownedRowMap,
-           const Teuchos::RCP<const map_type> & ownedPlusSharedRowMap, 
-           const Teuchos::RCP<const map_type> & ownedPlusSharedColMap, 
+           const Teuchos::RCP<const map_type> & ownedPlusSharedRowMap,
+           const Teuchos::RCP<const map_type> & ownedPlusSharedColMap,
            const size_t maxNumEntriesPerRow,
            const Teuchos::RCP<const import_type> & ownedPlusSharedToOwnedimporter,
            const Teuchos::RCP<const map_type> & domainMap,
            const Teuchos::RCP<const map_type> & ownedRangeMap,
-           const Teuchos::RCP<Teuchos::ParameterList>& params): 
+           const Teuchos::RCP<Teuchos::ParameterList>& params):
   FECrsGraph(ownedRowMap,ownedPlusSharedRowMap,ownedPlusSharedColMap,maxNumEntriesPerRow,
              domainMap.is_null() ? ownedRowMap : domainMap,
              ownedPlusSharedToOwnedimporter, domainMap, ownedRangeMap, params)
@@ -144,14 +144,14 @@ FECrsGraph(const Teuchos::RCP<const map_type> & ownedRowMap,
 template<class LocalOrdinal, class GlobalOrdinal, class Node>
 FECrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
 FECrsGraph(const Teuchos::RCP<const map_type> & ownedRowMap,
-           const Teuchos::RCP<const map_type> & ownedPlusSharedRowMap, 
-           const Teuchos::RCP<const map_type> & ownedPlusSharedColMap, 
+           const Teuchos::RCP<const map_type> & ownedPlusSharedRowMap,
+           const Teuchos::RCP<const map_type> & ownedPlusSharedColMap,
            const size_t maxNumEntriesPerRow,
            const Teuchos::RCP<const map_type> & ownedPlusSharedDomainMap,
            const Teuchos::RCP<const import_type> & ownedPlusSharedToOwnedimporter,
            const Teuchos::RCP<const map_type> & ownedDomainMap,
            const Teuchos::RCP<const map_type> & ownedRangeMap,
-           const Teuchos::RCP<Teuchos::ParameterList>& params): 
+           const Teuchos::RCP<Teuchos::ParameterList>& params):
   crs_graph_type(ownedPlusSharedRowMap, ownedPlusSharedColMap,maxNumEntriesPerRow, StaticProfile, params),
   ownedRowsImporter_(ownedPlusSharedToOwnedimporter),
   ownedDomainMap_(ownedDomainMap.is_null() ? ownedRowMap : ownedDomainMap),
@@ -164,8 +164,8 @@ FECrsGraph(const Teuchos::RCP<const map_type> & ownedRowMap,
 template<class LocalOrdinal, class GlobalOrdinal, class Node>
 FECrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
 FECrsGraph (const Teuchos::RCP<const map_type> & ownedRowMap,
-            const Teuchos::RCP<const map_type> & ownedPlusSharedRowMap, 
-            const Teuchos::RCP<const map_type> & ownedPlusSharedColMap, 
+            const Teuchos::RCP<const map_type> & ownedPlusSharedRowMap,
+            const Teuchos::RCP<const map_type> & ownedPlusSharedColMap,
             const Kokkos::DualView<const size_t*, device_type>& numEntPerRow,
             const Teuchos::RCP<const import_type> & ownedPlusSharedToOwnedimporter,
             const Teuchos::RCP<const map_type> & domainMap,
@@ -174,17 +174,17 @@ FECrsGraph (const Teuchos::RCP<const map_type> & ownedRowMap,
   FECrsGraph(ownedRowMap,ownedPlusSharedRowMap,ownedPlusSharedColMap,numEntPerRow,
              domainMap.is_null() ? ownedRowMap : domainMap,
              ownedPlusSharedToOwnedimporter, domainMap, ownedRangeMap, params)
-{  
+{
   // Nothing else to do here
 }
 
 template<class LocalOrdinal, class GlobalOrdinal, class Node>
 FECrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
 FECrsGraph (const Teuchos::RCP<const map_type> & ownedRowMap,
-            const Teuchos::RCP<const map_type> & ownedPlusSharedRowMap, 
-            const Teuchos::RCP<const map_type> & ownedPlusSharedColMap, 
+            const Teuchos::RCP<const map_type> & ownedPlusSharedRowMap,
+            const Teuchos::RCP<const map_type> & ownedPlusSharedColMap,
             const Kokkos::DualView<const size_t*, device_type>& numEntPerRow,
-            const Teuchos::RCP<const map_type> & ownedPlusSharedDomainMap, 
+            const Teuchos::RCP<const map_type> & ownedPlusSharedDomainMap,
             const Teuchos::RCP<const import_type> & ownedPlusSharedToOwnedimporter,
             const Teuchos::RCP<const map_type> & ownedDomainMap,
             const Teuchos::RCP<const map_type> & ownedRangeMap,
@@ -193,7 +193,7 @@ FECrsGraph (const Teuchos::RCP<const map_type> & ownedRowMap,
   ownedRowsImporter_(ownedPlusSharedToOwnedimporter),
   ownedDomainMap_(ownedDomainMap.is_null() ? ownedRowMap : ownedDomainMap),
   ownedRangeMap_(ownedRangeMap.is_null() ? ownedRowMap : ownedRangeMap)
-{  
+{
   this->domainMap_ = ownedPlusSharedDomainMap.is_null() ? ownedPlusSharedRowMap : ownedPlusSharedDomainMap;
   setup(ownedRowMap,ownedPlusSharedRowMap, ownedPlusSharedColMap,params);
 }
@@ -215,14 +215,15 @@ setup(const Teuchos::RCP<const map_type>  & ownedRowMap,
  else this->allocateIndices(LocalIndices);
 
  activeCrsGraph_     = Teuchos::rcp(new FEWhichActive(FE_ACTIVE_OWNED_PLUS_SHARED));
- 
+ fillState_ = Teuchos::rcp(new FillState(FillState::closed));
+
  // Use a very strong map equivalence check
  bool maps_are_the_same = ownedRowMap->isSameAs(*ownedPlusSharedRowMap);
  if(!maps_are_the_same) {
    // Make an importer if we need to, check map compatability if we don't
    if(ownedRowsImporter_.is_null()) {
        ownedRowsImporter_ = Teuchos::rcp(new import_type(ownedRowMap,ownedPlusSharedRowMap));
-   } 
+   }
    else {
      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(!ownedRowMap->isSameAs(*ownedRowsImporter_->getSourceMap()), std::runtime_error, "ownedRowMap does not match importer source map.");
      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(!ownedPlusSharedRowMap->isSameAs(*ownedRowsImporter_->getTargetMap()), std::runtime_error, "ownedPlusSharedRowMap does not match importer target map.");
@@ -230,17 +231,17 @@ setup(const Teuchos::RCP<const map_type>  & ownedRowMap,
 
    // Make sure the ownedPlusSharedRowMap has at least as many entries at the ownedRowMap (due to our superset requriement)
    TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC( ownedRowsImporter_->getNumSameIDs() != ownedRowsImporter_->getSourceMap()->getNodeNumElements(),
-                                          std::runtime_error,"ownedRowMap contains entries which are not in the ownedPlusSharedRowMap.");   
- 
+                                          std::runtime_error,"ownedRowMap contains entries which are not in the ownedPlusSharedRowMap.");
+
    TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC( ownedRowMap->getNodeNumElements() > ownedPlusSharedRowMap->getNodeNumElements(),
-                                          std::runtime_error,"ownedRowMap more entries than the ownedPlusSharedRowMap.");   
+                                          std::runtime_error,"ownedRowMap more entries than the ownedPlusSharedRowMap.");
 
    // The locallyFitted check is debug mode only since it is more expensive
    const bool debug = ::Tpetra::Details::Behavior::debug ();
    if(debug) {
      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC( !ownedPlusSharedRowMap->isLocallyFitted(*ownedRowMap),
                                             std::runtime_error,"ownedPlusSharedRowMap must be locally fitted to the ownedRowMap");
-     
+
    }
  } else {
    // We don't need the importer in this case, since the two row maps are identical (e.g., serial mode).
@@ -258,13 +259,13 @@ void FECrsGraph<LocalOrdinal, GlobalOrdinal, Node>::doOwnedPlusSharedToOwned(con
     // Do a self-export in "restricted mode"
     this->doExport(*this,*ownedRowsImporter_,CM,true);
 
-    // Under the "if you own an element, you own at least one of its nodes" assumption, 
+    // Under the "if you own an element, you own at least one of its nodes" assumption,
     // we can start by making a columnmap for ownedPlusShared
     if(!this->hasColMap()) {
       Teuchos::Array<int> remotePIDs (0);
       this->makeColMap(remotePIDs);
     }
-    
+
     // Now run CrsGraph's fillComplete to get the final importer
     crs_graph_type::fillComplete(this->domainMap_,this->getRowMap());
 
@@ -284,17 +285,17 @@ void FECrsGraph<LocalOrdinal, GlobalOrdinal, Node>::doOwnedPlusSharedToOwned(con
       for(size_t i=0; i<ownedRowMap->getNodeNumElements(); i++)  {
         size_t NumEntries=0;
         this->getLocalRowCopy(i,indices,NumEntries);
-        for(size_t j=0; j<NumEntries; j++) 
+        for(size_t j=0; j<NumEntries; j++)
           flag[indices[j]] = true;
       }
-      
+
       int lclCount = 0;
       for(size_t i=0; i<(size_t)flag.size(); i++)
         if(!flag[i])
           ++lclCount;
 
       // Perform a reduction over the input comm, so that ranks with success=true won't be hanging.
-      // Note: this only ensures things don't hang 
+      // Note: this only ensures things don't hang
       int gblCount = lclCount;
       auto comm = this->getComm();
       if (!comm.is_null()) {
@@ -344,23 +345,23 @@ template<class LocalOrdinal, class GlobalOrdinal, class Node>
 void FECrsGraph<LocalOrdinal, GlobalOrdinal, Node>::endFill() {
   const char tfecfFuncName[] = "FECrsGraph::endFill(): ";
 
-  /* What has to go on here is complicated.  
-     First off, if we don't really have two graphs (e.g. the rowMaps are the same, because we're in serial or 
+  /* What has to go on here is complicated.
+     First off, if we don't really have two graphs (e.g. the rowMaps are the same, because we're in serial or
      doing finite differences, things are easy --- just call fillComplete().
 
      If, we are in the parallel FE case, then:
      Precondition: FE_ACTIVE_OWNED_PLUS_SHARED mode
 
-     Postconditions: 
+     Postconditions:
      1) FE_ACTIVE_OWNED mode
      2) The OWNED graph has been fillCompleted with an Aztec-compatible column map
      3) rowptr & (local) colinds are aliased between the two graphs
      4) The OWNED_PLUS_SHARED graph has been fillCompleted with a column map whose first chunk
-        is the column map for the OWNED graph.  
+        is the column map for the OWNED graph.
         If we assume that (a) if you own an element, you also own at least one of the connected nodes and (b) elements are cliques, then
-        the columnMap is the same for both graphs!!! 
+        the columnMap is the same for both graphs!!!
 
-     5) The OWNED_PLUS_SHARED graph has neither an importer nor exporter.  Making these is expensive and we don't need them.       
+     5) The OWNED_PLUS_SHARED graph has neither an importer nor exporter.  Making these is expensive and we don't need them.
    */
   // Precondition
   TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(*activeCrsGraph_ != FE_ACTIVE_OWNED_PLUS_SHARED,std::runtime_error, "must be in owned+shared mode.");
@@ -371,7 +372,7 @@ void FECrsGraph<LocalOrdinal, GlobalOrdinal, Node>::endFill() {
     crs_graph_type::fillComplete(ownedDomainMap_,ownedRangeMap_);
   }
   else {
-    // The hard case: Two graphs   
+    // The hard case: Two graphs
 
     // fillComplete the owned+shared graph in a way that generates the owned+shared grep w/o an importer or exporter
     // Migrate data to the owned graph
@@ -387,11 +388,35 @@ void FECrsGraph<LocalOrdinal, GlobalOrdinal, Node>::endFill() {
 template<class LocalOrdinal, class GlobalOrdinal, class Node>
 void FECrsGraph<LocalOrdinal, GlobalOrdinal, Node>::beginFill() {
   const char tfecfFuncName[] = "FECrsGraph::beginFill(): ";
-  
+
   // Unlike FECrsMatrix and FEMultiVector, we do not allow you to call beginFill() after calling endFill()
   // So we throw an exception if you're in owned mode
   TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(*activeCrsGraph_ == FE_ACTIVE_OWNED,std::runtime_error, "can only be called once.");
 
+}
+
+template<class LocalOrdinal, class GlobalOrdinal, class Node>
+void FECrsGraph<LocalOrdinal, GlobalOrdinal, Node>::beginAssembly() {
+  const char tfecfFuncName[] = "FECrsGraph::beginAssembly: ";
+  TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
+    *fillState_ != FillState::closed,
+    std::runtime_error,
+    "Cannot beginAssembly, matrix is not in a closed state"
+  );
+  *fillState_ = FillState::open;
+  this->beginFill();
+}
+
+template<class LocalOrdinal, class GlobalOrdinal, class Node>
+void FECrsGraph<LocalOrdinal, GlobalOrdinal, Node>::endAssembly() {
+  const char tfecfFuncName[] = "FECrsGraph::endAssembly: ";
+  TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
+    *fillState_ != FillState::open,
+    std::runtime_error,
+    "Cannot endAssembly, matrix is not open to fill."
+  );
+  *fillState_ = FillState::closed;
+  this->endFill();
 }
 
 template <class LocalOrdinal, class GlobalOrdinal, class Node>
@@ -403,6 +428,61 @@ FECrsGraph<LocalOrdinal, GlobalOrdinal, Node>::getValidParameters () const
   valid_pl->set("Check Col GIDs In At Least One Owned Row",true);
 
   return valid_pl;
+}
+
+template <class LocalOrdinal, class GlobalOrdinal, class Node>
+size_t
+FECrsGraph<LocalOrdinal, GlobalOrdinal, Node>::insertGlobalIndicesImpl (
+  const local_ordinal_type lclRow,
+  const global_ordinal_type inputGblColInds[],
+  const size_t numInputInds
+){
+  const char tfecfFuncName[] = "FECrsGraph::insertGlobalIndices: ";
+  TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
+    *fillState_ != FillState::open,
+    std::runtime_error,
+    "Cannot replace global values, matrix is not open to fill."
+  );
+  return CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::insertGlobalIndicesImpl(
+    lclRow, inputGblColInds, numInputInds
+  );
+}
+
+template <class LocalOrdinal, class GlobalOrdinal, class Node>
+size_t
+FECrsGraph<LocalOrdinal, GlobalOrdinal, Node>::insertGlobalIndicesImpl (
+  const RowInfo& rowInfo,
+  const global_ordinal_type inputGblColInds[],
+  const size_t numInputInds,
+  std::function<void(const size_t, const size_t, const size_t)> fun
+){
+  const char tfecfFuncName[] = "FECrsGraph::insertGlobalIndices: ";
+  TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
+    *fillState_ != FillState::open,
+    std::runtime_error,
+    "Cannot replace global values, matrix is not open to fill."
+  );
+  return CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::insertGlobalIndicesImpl(
+    rowInfo, inputGblColInds, numInputInds, fun
+  );
+}
+
+template <class LocalOrdinal, class GlobalOrdinal, class Node>
+void
+FECrsGraph<LocalOrdinal, GlobalOrdinal, Node>::insertLocalIndicesImpl (
+  const local_ordinal_type lclRow,
+  const Teuchos::ArrayView<const local_ordinal_type>& gblColInds,
+  std::function<void(const size_t, const size_t, const size_t)> fun
+){
+  const char tfecfFuncName[] = "FECrsGraph::insertLocalIndices: ";
+  TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
+    *fillState_ != FillState::open,
+    std::runtime_error,
+    "Cannot replace global values, matrix is not open to fill."
+  );
+  return CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::insertLocalIndicesImpl(
+    lclRow, gblColInds, fun
+  );
 }
 
 }  // end namespace Tpetra

--- a/packages/tpetra/core/src/Tpetra_FECrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_FECrsGraph_def.hpp
@@ -418,8 +418,8 @@ void FECrsGraph<LocalOrdinal, GlobalOrdinal, Node>::endAssembly() {
   const char tfecfFuncName[] = "FECrsGraph::endAssembly: ";
   TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
     *fillState_ != FillState::open,
-    std::runtime_error,
-    "Cannot endAssembly, matrix is not open to fill."
+    std::logic_error,
+    "Cannot endAssembly, matrix is not open to fill but is closed."
   );
   *fillState_ = FillState::closed;
   this->endFill();
@@ -433,8 +433,8 @@ void FECrsGraph<LocalOrdinal, GlobalOrdinal, Node>::endAssembly(
   const char tfecfFuncName[] = "FECrsGraph::endAssembly: ";
   TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
     *fillState_ != FillState::open,
-    std::runtime_error,
-    "Cannot endAssembly, matrix is not open to fill."
+    std::logic_error,
+    "Cannot endAssembly, matrix is not open to fill but is closed."
   );
   *fillState_ = FillState::closed;
   this->endFill(domainMap, rangeMap);
@@ -461,8 +461,8 @@ FECrsGraph<LocalOrdinal, GlobalOrdinal, Node>::insertGlobalIndicesImpl (
   const char tfecfFuncName[] = "FECrsGraph::insertGlobalIndices: ";
   TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
     *fillState_ != FillState::open,
-    std::runtime_error,
-    "Cannot replace global values, matrix is not open to fill."
+    std::logic_error,
+    "Cannot replace global values, matrix is not open to fill but is closed."
   );
   return crs_graph_type::insertGlobalIndicesImpl(lclRow, inputGblColInds, numInputInds);
 }
@@ -478,8 +478,8 @@ FECrsGraph<LocalOrdinal, GlobalOrdinal, Node>::insertGlobalIndicesImpl (
   const char tfecfFuncName[] = "FECrsGraph::insertGlobalIndices: ";
   TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
     *fillState_ != FillState::open,
-    std::runtime_error,
-    "Cannot replace global values, matrix is not open to fill."
+    std::logic_error,
+    "Cannot replace global values, matrix is not open to fill but is closed."
   );
   return crs_graph_type::insertGlobalIndicesImpl(rowInfo, inputGblColInds, numInputInds, fun);
 }
@@ -494,8 +494,8 @@ FECrsGraph<LocalOrdinal, GlobalOrdinal, Node>::insertLocalIndicesImpl (
   const char tfecfFuncName[] = "FECrsGraph::insertLocalIndices: ";
   TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
     *fillState_ != FillState::open,
-    std::runtime_error,
-    "Cannot replace global values, matrix is not open to fill."
+    std::logic_error,
+    "Cannot replace global values, matrix is not open to fill but is closed."
   );
   return crs_graph_type::insertLocalIndicesImpl(lclRow, gblColInds, fun);
 }

--- a/packages/tpetra/core/src/Tpetra_FECrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_FECrsMatrix_decl.hpp
@@ -259,6 +259,8 @@ public:
       true;
 #endif // KOKKOS_ENABLE_SERIAL
 
+  protected:
+
     //! Overloads of modification methods
     LocalOrdinal
     replaceGlobalValuesImpl (impl_scalar_type rowVals[],

--- a/packages/tpetra/core/src/Tpetra_FECrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_FECrsMatrix_decl.hpp
@@ -266,7 +266,7 @@ public:
                              const RowInfo& rowInfo,
                              const GlobalOrdinal inds[],
                              const impl_scalar_type newVals[],
-                             const LocalOrdinal numElts) const;
+                             const LocalOrdinal numElts);
 
     LocalOrdinal
     replaceLocalValuesImpl (impl_scalar_type rowVals[],
@@ -274,7 +274,7 @@ public:
                             const RowInfo& rowInfo,
                             const LocalOrdinal inds[],
                             const impl_scalar_type newVals[],
-                            const LocalOrdinal numElts) const;
+                            const LocalOrdinal numElts);
 
     LocalOrdinal
     sumIntoGlobalValuesImpl (impl_scalar_type rowVals[],
@@ -283,7 +283,7 @@ public:
                              const GlobalOrdinal inds[],
                              const impl_scalar_type newVals[],
                              const LocalOrdinal numElts,
-                             const bool atomic = useAtomicUpdatesByDefault) const;
+                             const bool atomic = useAtomicUpdatesByDefault);
 
     LocalOrdinal
     sumIntoLocalValuesImpl (impl_scalar_type rowVals[],
@@ -292,7 +292,7 @@ public:
                             const LocalOrdinal inds[],
                             const impl_scalar_type newVals[],
                             const LocalOrdinal numElts,
-                            const bool atomic = useAtomicUpdatesByDefault) const;
+                            const bool atomic = useAtomicUpdatesByDefault);
 
     void
     insertGlobalValuesImpl (crs_graph_type& graph,

--- a/packages/tpetra/core/src/Tpetra_FECrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_FECrsMatrix_decl.hpp
@@ -229,12 +229,6 @@ public:
     void globalAssemble () {endFill();}
 
     //! Migrates data to the owned mode
-    void endFill();
-
-    //! Activates the owned+shared mode for assembly
-    void beginFill();
-
-    //! Migrates data to the owned mode
     void endAssembly();
 
     //! Activates the owned+shared mode for assembly
@@ -247,6 +241,10 @@ public:
     void beginModify();
 
   private:
+
+    //! Called by beginAssembly, endAssembly.
+    void endFill();
+    void beginFill();
 
     /// \brief Whether sumIntoLocalValues and sumIntoGlobalValues
     ///   should use atomic updates by default.

--- a/packages/tpetra/core/src/Tpetra_FECrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_FECrsMatrix_decl.hpp
@@ -234,6 +234,73 @@ public:
     //! Activates the owned+shared mode for assembly
     void beginFill();
 
+    //! Migrates data to the owned mode
+    void endAssembly();
+
+    //! Activates the owned+shared mode for assembly
+    void beginAssembly();
+
+    //! Closes modification phase
+    void endModify();
+
+    //! Activates the owned mode for modifying local values
+    void beginModify();
+
+  private:
+
+    /// \brief Whether sumIntoLocalValues and sumIntoGlobalValues
+    ///   should use atomic updates by default.
+    ///
+    /// \warning This is an implementation detail.
+    static const bool useAtomicUpdatesByDefault =
+#ifdef KOKKOS_ENABLE_SERIAL
+      ! std::is_same<execution_space, Kokkos::Serial>::value;
+#else
+      true;
+#endif // KOKKOS_ENABLE_SERIAL
+
+    //! Overloads of modification methods
+    LocalOrdinal
+    replaceGlobalValuesImpl (impl_scalar_type rowVals[],
+                             const crs_graph_type& graph,
+                             const RowInfo& rowInfo,
+                             const GlobalOrdinal inds[],
+                             const impl_scalar_type newVals[],
+                             const LocalOrdinal numElts) const;
+
+    LocalOrdinal
+    replaceLocalValuesImpl (impl_scalar_type rowVals[],
+                            const crs_graph_type& graph,
+                            const RowInfo& rowInfo,
+                            const LocalOrdinal inds[],
+                            const impl_scalar_type newVals[],
+                            const LocalOrdinal numElts) const;
+
+    LocalOrdinal
+    sumIntoGlobalValuesImpl (impl_scalar_type rowVals[],
+                             const crs_graph_type& graph,
+                             const RowInfo& rowInfo,
+                             const GlobalOrdinal inds[],
+                             const impl_scalar_type newVals[],
+                             const LocalOrdinal numElts,
+                             const bool atomic = useAtomicUpdatesByDefault) const;
+
+    LocalOrdinal
+    sumIntoLocalValuesImpl (impl_scalar_type rowVals[],
+                            const crs_graph_type& graph,
+                            const RowInfo& rowInfo,
+                            const LocalOrdinal inds[],
+                            const impl_scalar_type newVals[],
+                            const LocalOrdinal numElts,
+                            const bool atomic = useAtomicUpdatesByDefault) const;
+
+    void
+    insertGlobalValuesImpl (crs_graph_type& graph,
+                            RowInfo& rowInfo,
+                            const GlobalOrdinal gblColInds[],
+                            const impl_scalar_type vals[],
+                            const size_t numInputEnt);
+
   protected:
     /// \brief Migrate data from the owned+shared to the owned matrix
     /// Since this is non-unique -> unique, we need a combine mode.
@@ -263,6 +330,14 @@ public:
     Teuchos::RCP<CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > inactiveCrsMatrix_;
     // This is in RCP to make shallow copies of the FECrsMatrix work correctly
     Teuchos::RCP<FEWhichActive> activeCrsMatrix_;
+
+    enum class FillState
+    {
+      open,  // matrix is "open".  Values can freely summed in to and replaced
+      modify,  // matrix is open for modification.  *local* values can be replaced
+      closed
+    };
+    Teuchos::RCP<FillState> fillState_;
 
 };    // end class FECrsMatrix
 

--- a/packages/tpetra/core/src/Tpetra_FECrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_FECrsMatrix_def.hpp
@@ -154,7 +154,7 @@ void FECrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::endAssembly() {
   TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
     *fillState_ != FillState::open,
     std::runtime_error,
-    "Cannot endAssembly, matrix is not open to fill."
+    "Cannot endAssembly, matrix is not open for assembly."
   );
   *fillState_ = FillState::closed;
   this->endFill();
@@ -192,13 +192,13 @@ FECrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::replaceGlobalValuesImpl(
   const RowInfo& rowInfo,
   const GlobalOrdinal inds[],
   const impl_scalar_type newVals[],
-  const LocalOrdinal numElts) const
+  const LocalOrdinal numElts)
 {
   const char tfecfFuncName[] = "FECrsMatrix::replaceGlobalValues: ";
   TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
     *fillState_ != FillState::open,
     std::runtime_error,
-    "Cannot replace global values, matrix is not open to fill."
+    "Cannot replace global values, matrix is not open for assembly."
   );
   return CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::replaceGlobalValuesImpl(
     rowVals, graph, rowInfo, inds, newVals, numElts
@@ -213,7 +213,7 @@ FECrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::replaceLocalValuesImpl(
   const RowInfo& rowInfo,
   const LocalOrdinal inds[],
   const impl_scalar_type newVals[],
-  const LocalOrdinal numElts) const
+  const LocalOrdinal numElts)
 {
   const char tfecfFuncName[] = "FECrsMatrix::replaceLocalValues: ";
   TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
@@ -235,13 +235,13 @@ FECrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::sumIntoGlobalValuesImpl(
   const GlobalOrdinal inds[],
   const impl_scalar_type newVals[],
   const LocalOrdinal numElts,
-  const bool atomic) const
+  const bool atomic)
 {
   const char tfecfFuncName[] = "FECrsMatrix::sumIntoGlobalValues: ";
   TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
     *fillState_ != FillState::open,
     std::runtime_error,
-    "Cannot sum in to global values, matrix is not open to fill."
+    "Cannot sum in to global values, matrix is not open for assembly."
   );
   return CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::sumIntoGlobalValuesImpl(
     rowVals, graph, rowInfo, inds, newVals, numElts, atomic
@@ -257,13 +257,13 @@ FECrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::sumIntoLocalValuesImpl(
   const LocalOrdinal inds[],
   const impl_scalar_type newVals[],
   const LocalOrdinal numElts,
-  const bool atomic) const
+  const bool atomic)
 {
   const char tfecfFuncName[] = "FECrsMatrix::sumIntoLocalValues: ";
   TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
     *fillState_ != FillState::open,
     std::runtime_error,
-    "Cannot sum in to local values, matrix is not open to fill."
+    "Cannot sum in to local values, matrix is not open for assembly."
   );
   return CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::sumIntoLocalValuesImpl(
     rowVals, graph, rowInfo, inds, newVals, numElts, atomic
@@ -283,7 +283,7 @@ FECrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::insertGlobalValuesImpl(
   TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
     *fillState_ != FillState::open,
     std::runtime_error,
-    "Cannot sum in to local values, matrix is not open to fill."
+    "Cannot sum in to local values, matrix is not open for assembly."
   );
   return CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::insertGlobalValuesImpl(
     graph, rowInfo, gblColInds, vals, numInputEnt

--- a/packages/tpetra/core/src/Tpetra_FECrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_FECrsMatrix_def.hpp
@@ -144,7 +144,7 @@ void FECrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::beginAssembly() {
     std::ostringstream errmsg;
     errmsg << "Cannot begin assembly, matrix is not in a closed state "
            << "but is currently open for "
-           << (*fillState_ == FillState::open) ? "assembly" : "modification";
+           << (*fillState_ == FillState::open ? "assembly" : "modification");
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(true, std::logic_error, errmsg.str());
   }
   *fillState_ = FillState::open;
@@ -159,7 +159,7 @@ void FECrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::endAssembly() {
     std::ostringstream errmsg;
     errmsg << "Cannot end assembly, matrix is not open for assembly "
            << "but is currently "
-           << (*fillState_ == FillState::closed) ? "closed" : "open for modification";
+           << (*fillState_ == FillState::closed ? "closed" : "open for modification");
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(true, std::logic_error, errmsg.str());
   }
   *fillState_ = FillState::closed;
@@ -172,9 +172,9 @@ void FECrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::beginModify() {
   if (*fillState_ != FillState::closed)
   {
     std::ostringstream errmsg;
-    errmsg << "Cannot begin modifying, matrix is not in a closed state"
+    errmsg << "Cannot begin modifying, matrix is not in a closed state "
            << "but is currently open for "
-           << (*fillState_ == FillState::open) ? "assembly" : "modification";
+           << (*fillState_ == FillState::open ? "assembly" : "modification");
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(true, std::logic_error, errmsg.str());
   }
   *fillState_ = FillState::modify;
@@ -188,7 +188,7 @@ void FECrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::endModify() {
   {
     std::ostringstream errmsg;
     errmsg << "Cannot end modifying, matrix is not open to modify but is currently "
-           << (*fillState_ == FillState::open) ? "open for assembly" : "closed";
+           << (*fillState_ == FillState::open ? "open for assembly" : "closed");
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(true, std::logic_error, errmsg.str());
   }
   *fillState_ = FillState::closed;
@@ -211,7 +211,7 @@ FECrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::replaceGlobalValuesImpl(
     std::ostringstream errmsg;
     errmsg << "Cannot replace global values, matrix is not open for assembly "
            << "but is currently "
-           << (*fillState_ == FillState::modify) ? "open for modification" : "closed";
+           << (*fillState_ == FillState::modify ? "open for modification" : "closed");
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(true, std::logic_error, errmsg.str());
   }
   return crs_matrix_type::replaceGlobalValuesImpl(rowVals, graph, rowInfo, inds, newVals, numElts);
@@ -255,7 +255,7 @@ FECrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::sumIntoGlobalValuesImpl(
     std::ostringstream errmsg;
     errmsg << "Cannot sum in to global values, matrix is not open for assembly. "
            << "The matrix is currently "
-           << (*fillState_ == FillState::modify) ? "open for modification" : "closed";
+           << (*fillState_ == FillState::modify ? "open for modification" : "closed");
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(true, std::logic_error, errmsg.str());
   }
   return crs_matrix_type::sumIntoGlobalValuesImpl(
@@ -278,9 +278,9 @@ FECrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::sumIntoLocalValuesImpl(
   if (*fillState_ != FillState::open)
   {
     std::ostringstream errmsg;
-    errmsg << "Cannot sum in to local values, matrix is not open for assembly."
+    errmsg << "Cannot sum in to local values, matrix is not open for assembly. "
            << "The matrix is currently "
-           << (*fillState_ == FillState::modify) ? "open for modification" : "closed";
+           << (*fillState_ == FillState::modify ? "open for modification" : "closed");
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(true, std::logic_error, errmsg.str());
   }
   return crs_matrix_type::sumIntoLocalValuesImpl(
@@ -301,9 +301,9 @@ FECrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::insertGlobalValuesImpl(
   if (*fillState_ != FillState::open)
   {
     std::ostringstream errmsg;
-    errmsg << "Cannot insert global values, matrix is not open for assembly."
+    errmsg << "Cannot insert global values, matrix is not open for assembly. "
            << "The matrix is currently "
-           << (*fillState_ == FillState::modify) ? "open for modification" : "closed";
+           << (*fillState_ == FillState::modify ? "open for modification" : "closed");
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(true, std::logic_error, errmsg.str());
   }
   return crs_matrix_type::insertGlobalValuesImpl(graph, rowInfo, gblColInds, vals, numInputEnt);

--- a/packages/tpetra/core/src/Tpetra_FECrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_FECrsMatrix_def.hpp
@@ -228,12 +228,13 @@ FECrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::replaceLocalValuesImpl(
   const LocalOrdinal numElts)
 {
   const char tfecfFuncName[] = "FECrsMatrix::replaceLocalValues: ";
-  TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
-    *fillState_ != FillState::open && *fillState_ != FillState::modify,
-    std::runtime_error,
-    "Cannot replace local values, matrix is not open to fill/modify. "
-    "The matrix is currently closed"
-  );
+  if (*fillState_ != FillState::open && *fillState_ != FillState::modify)
+  {
+    std::ostringstream errmsg;
+    errmsg << "Cannot replace local values, matrix is not open to fill/modify. "
+           << "The matrix is currently closed";
+    TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(true, std::logic_error, errmsg.str());
+  }
   return crs_matrix_type::replaceLocalValuesImpl(rowVals, graph, rowInfo, inds, newVals, numElts);
 }
 

--- a/packages/tpetra/core/src/Tpetra_FEMultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_FEMultiVector_decl.hpp
@@ -165,6 +165,15 @@ namespace Tpetra {
     //! Declare the end of a phase of owned+shared modifications.
     void endFill ();
 
+    //! Declare the beginning of a phase of owned+shared modifications.
+    void beginAssembly ();
+
+    //! Declare the end of a phase of owned+shared modifications.
+    void endAssembly ();
+
+    void beginModify ();
+    void endModify ();
+
     /// \brief Declare the end of a phase of owned+shared
     ///   modifications; same as endFill().
     void globalAssemble ();
@@ -198,6 +207,14 @@ namespace Tpetra {
       FE_ACTIVE_OWNED_PLUS_SHARED,
       FE_ACTIVE_OWNED
     };
+
+    enum class FillState
+    {
+      open,  // matrix is "open".  Values can freely summed in to and replaced
+      modify,  // matrix is open for modification.  *local* values can be replaced
+      closed
+    };
+    Teuchos::RCP<FillState> fillState_;
 
     //! Whichever MultiVector is <i>not</i> currently active.
     Teuchos::RCP<base_type> inactiveMultiVector_;

--- a/packages/tpetra/core/src/Tpetra_FEMultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_FEMultiVector_decl.hpp
@@ -61,6 +61,12 @@ namespace Tpetra {
     using base_type = ::Tpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>;
     friend base_type;
 
+    //! Declare the beginning of a phase of owned+shared modifications.
+    void beginFill ();
+
+    //! Declare the end of a phase of owned+shared modifications.
+    void endFill ();
+
   public:
     //! @name Typedefs to facilitate template metaprogramming.
     //@{
@@ -158,12 +164,6 @@ namespace Tpetra {
     //@}
     //! @name Post-construction modification routines
     //@{
-
-    //! Declare the beginning of a phase of owned+shared modifications.
-    void beginFill ();
-
-    //! Declare the end of a phase of owned+shared modifications.
-    void endFill ();
 
     //! Declare the beginning of a phase of owned+shared modifications.
     void beginAssembly ();

--- a/packages/tpetra/core/test/FECrsGraph/FECrsGraph_UnitTests.cpp
+++ b/packages/tpetra/core/test/FECrsGraph/FECrsGraph_UnitTests.cpp
@@ -94,13 +94,13 @@ bool compare_final_graph_structure(Teuchos::FancyOStream &out,Tpetra::CrsGraph<L
   auto colind1 = g1.getLocalGraphHost().entries;
   auto colind2 = g2.getLocalGraphHost().entries;
 
-  if (rowptr1.extent(0) != rowptr2.extent(0)) {out<<"Compare: rowptr extent failed"<<endl;return false;}      
+  if (rowptr1.extent(0) != rowptr2.extent(0)) {out<<"Compare: rowptr extent failed"<<endl;return false;}
   if (colind1.extent(0) != colind2.extent(0)) {out<<"Compare: colind extent failed: "<<colind1.extent(0)<<" vs "<<colind2.extent(0)<<endl;
     int rank = g1.getRowMap()->getComm()->getRank();
     print_graph(rank,"G1",rowptr1,colind1);
     print_graph(rank,"G2",rowptr2,colind2);
     return false;
-}      
+}
 
   bool success=true;
   TEST_COMPARE_ARRAYS(rowptr1,rowptr2);
@@ -215,7 +215,7 @@ public:
     out << "["<<rank<<"] Unique Map  : ";
     for(size_t i=0; i<uniqueMap->getNodeNumElements(); i++)
       out << uniqueMap->getGlobalElement(i) << " ";
-    out<<endl;      
+    out<<endl;
 
     out << "["<<rank<<"] Overlap Map : ";
     for(size_t i=0; i<overlapMap->getNodeNumElements(); i++)
@@ -401,13 +401,13 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FECrsGraph, Diagonal, LO, GO, Node )
     CG g1(map,1,StaticProfile);
     FEG g2(map,map,1);
 
-    Tpetra::beginFill(g2);
+    Tpetra::beginAssembly(g2);
     for(size_t i=0; i<numLocal; i++) {
       GO gid = map->getGlobalElement(i);
       g1.insertGlobalIndices(gid,1,&gid);
       g2.insertGlobalIndices(gid,1,&gid);
     }
-    Tpetra::endFill(g2);
+    Tpetra::endAssembly(g2);
     g1.fillComplete();
 
     success = compare_final_graph_structure(out,g1,g2);
@@ -433,14 +433,14 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FECrsGraph, Diagonal_LocalIndex, LO, GO, Node
     CG g1(map,1,StaticProfile);
     FEG g2(map,map,map,1);
 
-    Tpetra::beginFill(g2);
+    Tpetra::beginAssembly(g2);
     for(size_t i=0; i<numLocal; i++) {
       GO gid = map->getGlobalElement(i);
       LO lid = (LO) i;
       g1.insertGlobalIndices(gid,1,&gid);
       g2.insertLocalIndices(lid,1,&lid);
     }
-    Tpetra::endFill(g2);
+    Tpetra::endAssembly(g2);
     g1.fillComplete();
 
     success = compare_final_graph_structure(out,g1,g2);
@@ -453,10 +453,10 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FECrsGraph, Assemble1D, LO, GO, Node )
 {
   typedef Tpetra::FECrsGraph<LO,GO,Node> FEG;
   typedef Tpetra::CrsGraph<LO,GO,Node> CG;
-  
+
   // get a comm
   RCP<const Comm<int> > comm = getDefaultComm();
-  
+
   // create a Map
   const size_t numLocal = 10;
 
@@ -471,7 +471,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FECrsGraph, Assemble1D, LO, GO, Node )
   CG g1(pack.uniqueMap,4,StaticProfile);
   FEG g2(pack.uniqueMap,pack.overlapMap,4);
 
-  g2.beginFill();
+  g2.beginAssembly();
   for(size_t i=0; i<(size_t)pack.element2node.size(); i++) {
     for(size_t j=0; j<pack.element2node[i].size(); j++) {
       GO gid_j = pack.element2node[i][j];
@@ -484,7 +484,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FECrsGraph, Assemble1D, LO, GO, Node )
     }
   }
   g1.fillComplete();
-  g2.endFill();
+  g2.endAssembly();
 
   success = compare_final_graph_structure(out,g1,g2);
   TPETRA_GLOBAL_SUCCESS_CHECK(out,comm,success)
@@ -499,7 +499,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FECrsGraph, Assemble1D_LocalIndex, LO, GO, No
 
   // get a comm
   RCP<const Comm<int> > comm = getDefaultComm();
-  
+
   // create a Map
   const size_t numLocal = 10;
 
@@ -515,7 +515,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FECrsGraph, Assemble1D_LocalIndex, LO, GO, No
   CG g1(pack.uniqueMap,4,StaticProfile);
   FEG g2(pack.uniqueMap,pack.overlapMap,pack.overlapMap,4);
 
-  g2.beginFill();
+  g2.beginAssembly();
   for(size_t i=0; i<(size_t)pack.element2node.size(); i++) {
     for(size_t j=0; j<pack.element2node[i].size(); j++) {
       GO gid_j = pack.element2node[i][j];
@@ -530,7 +530,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FECrsGraph, Assemble1D_LocalIndex, LO, GO, No
     }
   }
   g1.fillComplete();
-  g2.endFill();
+  g2.endAssembly();
 
   success = compare_final_graph_structure(out,g1,g2);
   TPETRA_GLOBAL_SUCCESS_CHECK(out,comm,success)
@@ -543,7 +543,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FECrsGraph, Assemble2D_OPSDomain, LO, GO, Nod
 
   // get a comm
   RCP<const Comm<int> > comm = getDefaultComm();
-  
+
   const int numCells1D = 4;
 
   // Generate a mesh
@@ -557,8 +557,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FECrsGraph, Assemble2D_OPSDomain, LO, GO, Nod
   FEG g2(pack.uniqueMap,pack.overlapMap,9);
   FEG g3(pack.uniqueMap,pack.overlapMap,9,pack.overlapMap);
 
-  g2.beginFill();
-  g3.beginFill();
+  g2.beginAssembly();
+  g3.beginAssembly();
   for (const auto& cell_dofs : pack.element2node) {
     for (const auto& gid_i : cell_dofs) {
       for (const auto& gid_j : cell_dofs) {
@@ -571,17 +571,17 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FECrsGraph, Assemble2D_OPSDomain, LO, GO, Nod
   }
   g0.fillComplete();
   g1.fillComplete();
-  g2.endFill();
-  g3.endFill();
+  g2.endAssembly();
+  g3.endAssembly();
   Tpetra::Import<LO,GO,Node> import(pack.uniqueMap,pack.overlapMap);
-  
+
   Teuchos::FancyOStream myout(Teuchos::rcpFromRef(std::cout));
   CG  g11(pack.uniqueMap,9,StaticProfile);
   g11.doExport(g0,import,Tpetra::INSERT);
   g11.fillComplete(pack.uniqueMap,pack.uniqueMap);
   success = compare_final_graph_structure(out,g11,g1);
   TPETRA_GLOBAL_SUCCESS_CHECK(myout,comm,success)
-  
+
   success = compare_final_graph_structure(out,g1,g2);
   TPETRA_GLOBAL_SUCCESS_CHECK(myout,comm,success)
 

--- a/packages/tpetra/core/test/FECrsMatrix/FECrsMatrix_UnitTests.cpp
+++ b/packages/tpetra/core/test/FECrsMatrix/FECrsMatrix_UnitTests.cpp
@@ -267,7 +267,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( FECrsMatrix, Assemble1D, LO, GO, Scalar, Node
   // not being handled correctly.
   RCP<FEG> graph = rcp(new FEG(pack.uniqueMap,pack.overlapMap,4));
 
-  graph->beginFill();
+  graph->beginAssembly();
   for(size_t i=0; i<(size_t)pack.element2node.size(); i++) {
     for(size_t j=0; j<pack.element2node[i].size(); j++) {
       GO gid_j = pack.element2node[i][j];
@@ -278,7 +278,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( FECrsMatrix, Assemble1D, LO, GO, Scalar, Node
       }
     }
   }
-  graph->endFill();
+  graph->endAssembly();
 
 
   // Generate the "local stiffness matrix"
@@ -324,7 +324,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( FECrsMatrix, Assemble1D_2, LO, GO, Scalar, No
   // not being handled correctly.
   RCP<FEG> graph = rcp(new FEG(pack.uniqueMap, pack.overlapMap, 4));
 
-  graph->beginFill();
+  graph->beginAssembly();
   for(size_t i=0; i<(size_t)pack.element2node.size(); i++) {
     for(size_t j=0; j<pack.element2node[i].size(); j++) {
       GO gid_j = pack.element2node[i][j];
@@ -335,7 +335,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( FECrsMatrix, Assemble1D_2, LO, GO, Scalar, No
       }
     }
   }
-  graph->endFill();
+  graph->endAssembly();
 
 
   // Generate the "local stiffness matrix"
@@ -403,7 +403,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( FECrsMatrix, Assemble1D_Kokkos, LO, GO, Scala
   // not being handled correctly.
   RCP<FEG> graph = rcp(new FEG(pack.uniqueMap,pack.overlapMap,4));
 
-  graph->beginFill();
+  graph->beginAssembly();
   for(size_t i=0; i<(size_t)pack.element2node.size(); i++) {
     for(size_t j=0; j<pack.element2node[i].size(); j++) {
       GO gid_j = pack.element2node[i][j];
@@ -414,7 +414,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( FECrsMatrix, Assemble1D_Kokkos, LO, GO, Scala
       }
     }
   }
-  graph->endFill();
+  graph->endAssembly();
 
   // Generate the "local stiffness matrix"
   std::vector<std::vector<Scalar> > localValues = generate_fem1d_element_values<Scalar>();
@@ -478,7 +478,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( FECrsMatrix, Assemble1D_LocalIndex, LO, GO, S
   // Make the graph
   RCP<FEG> graph = rcp(new FEG(pack.uniqueMap,pack.overlapMap,pack.overlapMap,3));
 
-  graph->beginFill();
+  graph->beginAssembly();
   for(size_t i=0; i<(size_t)pack.element2node.size(); i++) {
     for(size_t j=0; j<pack.element2node[i].size(); j++) {
       GO gid_j = pack.element2node[i][j];
@@ -491,7 +491,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( FECrsMatrix, Assemble1D_LocalIndex, LO, GO, S
       }
     }
   }
-  graph->endFill();
+  graph->endAssembly();
 
 
   // Generate the "local stiffness matrix"
@@ -541,7 +541,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( FECrsMatrix, Assemble1D_LocalIndex_Kokkos, LO
   // Make the graph
   RCP<FEG> graph = rcp(new FEG(pack.uniqueMap,pack.overlapMap,pack.overlapMap,3));
 
-  graph->beginFill();
+  graph->beginAssembly();
   for(size_t i=0; i<(size_t)pack.element2node.size(); i++) {
     for(size_t j=0; j<pack.element2node[i].size(); j++) {
       GO gid_j = pack.element2node[i][j];
@@ -554,7 +554,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( FECrsMatrix, Assemble1D_LocalIndex_Kokkos, LO
       }
     }
   }
-  graph->endFill();
+  graph->endAssembly();
 
   // Generate the "local stiffness matrix"
   std::vector<std::vector<Scalar> > localValues = generate_fem1d_element_values<Scalar>();
@@ -621,7 +621,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( FECrsMatrix, Assemble1D_LocalIndex_Kokkos_Mul
   // Make the graph
   RCP<FEG> graph = rcp(new FEG(pack.uniqueMap,pack.overlapMap,pack.overlapMap,3));
 
-  graph->beginFill();
+  graph->beginAssembly();
   for(size_t i=0; i<(size_t)pack.element2node.size(); i++) {
     for(size_t j=0; j<pack.element2node[i].size(); j++) {
       GO gid_j = pack.element2node[i][j];
@@ -634,7 +634,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( FECrsMatrix, Assemble1D_LocalIndex_Kokkos_Mul
       }
     }
   }
-  graph->endFill();
+  graph->endAssembly();
 
   // Generate the "local stiffness matrix"
   std::vector<std::vector<Scalar> > localValues = generate_fem1d_element_values<Scalar>();

--- a/packages/tpetra/core/test/FEMultiVector/FEMultiVector_UnitTests.cpp
+++ b/packages/tpetra/core/test/FEMultiVector/FEMultiVector_UnitTests.cpp
@@ -159,11 +159,11 @@ namespace {
       Vdomain.doExport(Vcolumn,*importer,Tpetra::ADD);
 
 
-      Vfe.beginFill();
+      Vfe.beginAssembly();
       Vfe.putScalar(ZERO);
       for(size_t i=0; i<Ndomain; i++)
         Vfe.getDataNonConst(0)[i] = domainMap->getGlobalElement(i);
-      Vfe.endFill();
+      Vfe.endAssembly();
       vector_check(Ndomain,Vfe,Vdomain);
 
       // 2) Test column -> domain (with off-proc addition)
@@ -172,9 +172,9 @@ namespace {
       Vdomain.doExport(Vcolumn,*importer,Tpetra::ADD);
 
       Vfe.putScalar(ZERO);
-      Vfe.beginFill();
+      Vfe.beginAssembly();
       Vfe.putScalar(ONE);
-      Vfe.endFill();
+      Vfe.endAssembly();
       vector_check(Ncolumn,Vfe,Vdomain);
     } catch (std::exception& e) {
       err << "Proc " << myRank << ": " << e.what () << std::endl;
@@ -219,10 +219,10 @@ namespace {
     Tpetra::FEMultiVector<Scalar,LO,GO,Node> v2(map,importer,1);
     Tpetra::FEMultiVector<Scalar,LO,GO,Node> v3(map,importer,1);
 
-    // Just check to make sure beginFill() / endFill() compile
-    Tpetra::beginFill(v1,v2,v3);
+    // Just check to make sure beginAssembly() / endAssembly() compile
+    Tpetra::beginAssembly(v1,v2,v3);
 
-    Tpetra::endFill(v1,v2,v3);
+    Tpetra::endAssembly(v1,v2,v3);
   }
 
 #define UNIT_TEST_GROUP( SC, LO, GO, NO ) \

--- a/packages/tpetra/core/test/FEMultiVector/Fix3101.cpp
+++ b/packages/tpetra/core/test/FEMultiVector/Fix3101.cpp
@@ -113,13 +113,13 @@ int FEMultiVectorTest::intTest()
 
   // Add contributions to owned vertices and copies of off-processor vertices
   try {
-    femv->beginFill();
+    femv->beginAssembly();
     for (lno_t i = 0; i < nLocalOwned + nLocalCopy; i++) {
       gno_t gid = mapWithCopies->getGlobalElement(i);
       femv->replaceGlobalValue(gid, 0, gid);
       femv->replaceGlobalValue(gid, 1, me);
     }
-    femv->endFill();
+    femv->endAssembly();
   }
   catch (std::exception &e) {
     std::cout << "FAIL:  Exception thrown in Fill:  " << e.what() << std::endl;
@@ -140,7 +140,7 @@ int FEMultiVectorTest::intTest()
 
   printFEMV("After doOwnedToOwnedPlusShared ");
 
-  // Check results:  after ADD in endFill,
+  // Check results:  after ADD in endAssembly,
   // -  overlapping entries of vec 0 should be 2 * gid
   //    nonoverlapping entries of vec 0 should be gid
   // -  overlapping entries of vec 1 should be me + (np + me-1) % np;

--- a/packages/tpetra/core/test/MatrixMatrix/FECrs_MatrixMatrix_UnitTests.cpp
+++ b/packages/tpetra/core/test/MatrixMatrix/FECrs_MatrixMatrix_UnitTests.cpp
@@ -186,7 +186,7 @@ generate_fecrs_graph (const MeshInfo<4,LO,GO,NT>& mesh)
   using FEG = Tpetra::FECrsGraph<LO,GO,NT>;
 
   Teuchos::RCP<FEG> feg(new FEG(mesh.uniqueMap,mesh.overlapMap,9,mesh.overlapMap));
-  feg->beginFill();
+  feg->beginAssembly();
   for (const auto& elem_dofs : mesh.element2node) {
     for (const GO gid_i : elem_dofs) {
       for (const GO gid_j : elem_dofs) {
@@ -194,7 +194,7 @@ generate_fecrs_graph (const MeshInfo<4,LO,GO,NT>& mesh)
       }
     }
   }
-  feg->endFill();
+  feg->endAssembly();
 
   return feg;
 }
@@ -205,13 +205,13 @@ generate_fecrs_graph (const MeshInfo<4,LO,GO,NT>& mesh)
 // Note that such matrix is strictly diagonally dominant.
 template<typename ST, typename LO, typename GO, typename NT>
 void
-fill_matrices (Tpetra::FECrsMatrix<ST,LO,GO,NT>& fe_mat,  
-               Tpetra::CrsMatrix<ST,LO,GO,NT>& mat,  
+fill_matrices (Tpetra::FECrsMatrix<ST,LO,GO,NT>& fe_mat,
+               Tpetra::CrsMatrix<ST,LO,GO,NT>& mat,
                const MeshInfo<4,LO,GO,NT>& mesh)
 {
   const ST zero = Teuchos::ScalarTraits<ST>::zero();
 
-  fe_mat.beginFill();
+  fe_mat.beginAssembly();
   mat.resumeFill();
 
   fe_mat.setAllToScalar(zero);
@@ -230,13 +230,13 @@ fill_matrices (Tpetra::FECrsMatrix<ST,LO,GO,NT>& fe_mat,
       }
     }
   }
-  fe_mat.endFill();
+  fe_mat.endAssembly();
   mat.fillComplete();
 }
 
 template<typename ST, typename LO, typename GO, typename NT>
 bool compare_matrices (const Tpetra::CrsMatrix<ST,LO,GO,NT>& A,
-                       const Tpetra::CrsMatrix<ST,LO,GO,NT>& B, 
+                       const Tpetra::CrsMatrix<ST,LO,GO,NT>& B,
                        Teuchos::FancyOStream &out)
 {
   // They should have the same row/range/domain maps
@@ -334,7 +334,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL (Tpetra_MatMat, FECrsMatrix, SC, LO, GO, NT)
 
   // get a comm
   RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
-  
+
   // Generate a mesh
   const int numCells1D = 4;
   MeshInfo<4,LO,GO,NT> mesh;
@@ -359,7 +359,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL (Tpetra_MatMat, FECrsMatrix, SC, LO, GO, NT)
     for (bool transB : {false, true}) {
       Teuchos::RCP<Teuchos::ParameterList> params1(new Teuchos::ParameterList());
       Teuchos::RCP<Teuchos::ParameterList> params2(new Teuchos::ParameterList());
-      params2->set("MM_TAFC_OptimizationCoreCount",1);  
+      params2->set("MM_TAFC_OptimizationCoreCount",1);
       for (auto params : {params1, params2}) {
 
         // A and feA should have the same row map, so pick one.

--- a/packages/trilinoscouplings/examples/scaling/example_Maxwell_Tpetra.cpp
+++ b/packages/trilinoscouplings/examples/scaling/example_Maxwell_Tpetra.cpp
@@ -233,7 +233,7 @@ struct fecomp{
 template<class Container>
 double distance(Container &nodeCoord, int i1, int i2) {
   double dist = 0.0;
-  for(int j=0; j<3; j++) 
+  for(int j=0; j<3; j++)
     dist+= SQR( nodeCoord(i1,j) - nodeCoord(i2,j) );
   return sqrt(dist);
 }
@@ -541,11 +541,11 @@ int body(int argc, char *argv[]) {
 
   // Get the solver name from input deck or command line
   if(solverName == "default") {
-    if(inputList.isParameter("Preconditioner")) 
+    if(inputList.isParameter("Preconditioner"))
       solverName=inputList.get("Preconditioner","MueLu");
     else
       solverName="MueLu";
-  }  
+  }
 
 
 
@@ -700,7 +700,7 @@ int body(int argc, char *argv[]) {
       }
       muVal(telct) = mu[b];
       sigmaVal(telct) = sigma[b];
-      
+
       telct ++;
     }
   }
@@ -1024,8 +1024,8 @@ int body(int argc, char *argv[]) {
   for (int i=0; i<numEdges; i++)
     overlappedEdges[i]=(GO)globalEdgeIds[i];
   RCP<const Tpetra_Map> overlapMapC = rcp(new Tpetra_Map(GST_INVALID,overlappedEdges,0,comm));
- 
-  
+
+
   if (jiggle) {
     /***********************************************************************************/
     /* This block of code will create a randomly perturbed mesh by jiggling the node   */
@@ -1056,7 +1056,7 @@ int body(int argc, char *argv[]) {
       if (!nodeOnBoundary(inode)) {
         double rx = displacement.getData(0)[inode];
         double ry = displacement.getData(1)[inode];
-        double rz = displacement.getData(2)[inode]; 
+        double rz = displacement.getData(2)[inode];
 
         nodeCoord(inode,0) = nodeCoord(inode,0) + fac * hx * rx;
         nodeCoord(inode,1) = nodeCoord(inode,1) + fac * hy * ry;
@@ -1174,22 +1174,22 @@ int body(int argc, char *argv[]) {
   RCP<Tpetra_FECrsGraph> EdgeGraph = rcp(new Tpetra_FECrsGraph(globalMapC,overlapMapC,27*numFieldsC));
   RCP<Tpetra_FECrsGraph> NodeGraph = rcp(new Tpetra_FECrsGraph(globalMapG,overlapMapG,9*numFieldsG));
 
-  Tpetra::beginFill(*EdgeGraph,*NodeGraph);
-  for(int workset = 0; workset < numWorksets; workset++){    
+  Tpetra::beginAssembly(*EdgeGraph,*NodeGraph);
+  for(int workset = 0; workset < numWorksets; workset++){
     // Compute cell numbers where the workset starts and ends
     //    int worksetSize  = 0;
     int worksetBegin = (workset + 0)*desiredWorksetSize;
     int worksetEnd   = (workset + 1)*desiredWorksetSize;
-    
+
     // When numElems is not divisible by desiredWorksetSize, the last workset ends at numElems
     worksetEnd   = (worksetEnd <= numElems) ? worksetEnd : numElems;
-    
+
     // Now we know the actual workset size and can allocate the array for the cell nodes
     //    worksetSize  = worksetEnd - worksetBegin;
 
     // Loop over workset cells
     for(int cell = worksetBegin; cell < worksetEnd; cell++){
-      
+
       /*** Assemble H(grad) mass matrix ***/
       // loop over nodes for matrix row
       for (int cellNodeRow = 0; cellNodeRow < numFieldsG; cellNodeRow++){
@@ -1199,7 +1199,7 @@ int body(int argc, char *argv[]) {
         // loop over nodes for matrix column
         for (int cellNodeCol = 0; cellNodeCol < numFieldsG; cellNodeCol++){
           int localNodeCol = elemToNode(cell, cellNodeCol);
-          GO globalNodeCol = (GO) globalNodeIds[localNodeCol];          
+          GO globalNodeCol = (GO) globalNodeIds[localNodeCol];
           NodeGraph->insertGlobalIndices(globalNodeRow,1,&globalNodeCol);
 
         }// *** cell node col loop ***
@@ -1223,7 +1223,7 @@ int body(int argc, char *argv[]) {
 
     }// *** workset cell loop **
   }// *** workset loop ***
-  Tpetra::endFill(*EdgeGraph,*NodeGraph);
+  Tpetra::endAssembly(*EdgeGraph,*NodeGraph);
 
   /**********************************************************************************/
   /********************* BUILD MAPS FOR GLOBAL SOLUTION *****************************/
@@ -1261,8 +1261,8 @@ int body(int argc, char *argv[]) {
   RCP<const Tpetra_Map> globalMapElem = rcp(new Tpetra_Map(numElemsGlobal, numElems, 0, comm));
 
   // Put coordinates in multivector for output
-  Tpetra_MultiVector nCoord(globalMapG,3);  
-  {  
+  Tpetra_MultiVector nCoord(globalMapG,3);
+  {
     auto Nx_data=nCoord.getDataNonConst(0);
     auto Ny_data=nCoord.getDataNonConst(1);
     auto Nz_data=nCoord.getDataNonConst(2);
@@ -1279,7 +1279,7 @@ int body(int argc, char *argv[]) {
 
 
 
-  if (dump){  
+  if (dump){
     Tpetra::MatrixMarket::Writer<Tpetra_MultiVector>::writeDenseFile("coords.dat",nCoord);
 
     // Put element to node mapping in multivector for output
@@ -1293,7 +1293,7 @@ int body(int argc, char *argv[]) {
     Tpetra::MatrixMarket::Writer<Tpetra_MultiVector>::writeDenseFile("elem2node.dat",elem2node);
 
     // Put element to edge mapping in multivector for output
-    Tpetra_MultiVector elem2edge(globalMapElem, numEdgesPerElem);    
+    Tpetra_MultiVector elem2edge(globalMapElem, numEdgesPerElem);
     for (int iedge=0; iedge<numEdgesPerElem; iedge++) {
        auto data = elem2edge.getDataNonConst(iedge);
        for (int ielem=0; ielem<numElems; ielem++) {
@@ -1314,9 +1314,9 @@ int body(int argc, char *argv[]) {
         ownedEdge++;
       }
     }
-    Tpetra::MatrixMarket::Writer<Tpetra_MultiVector>::writeDenseFile("edge2node.dat",edge2node);    
+    Tpetra::MatrixMarket::Writer<Tpetra_MultiVector>::writeDenseFile("edge2node.dat",edge2node);
   }
-    
+
   // Define multi-vector for cell edge sign (fill during cell loop)
   Tpetra_MultiVector edgeSign(globalMapElem, numEdgesPerElem);
 
@@ -1335,7 +1335,7 @@ int body(int argc, char *argv[]) {
   Tpetra_Vector EDGE_Y(globalMapC);
   Tpetra_Vector EDGE_Z(globalMapC);
   {
-    auto ex_data = EDGE_X.getDataNonConst(0);   
+    auto ex_data = EDGE_X.getDataNonConst(0);
     auto ey_data = EDGE_Y.getDataNonConst(0);
     auto ez_data = EDGE_Z.getDataNonConst(0);
     double vals[2];
@@ -1354,14 +1354,14 @@ int body(int argc, char *argv[]) {
       }
     }
   }
-  
+
   DGrad.fillComplete(MassMatrixG.getRowMap(),MassMatrixC.getRowMap());
 
   if(MyPID==0) {std::cout << "Building incidence matrix                   \n";}
 
 
   // Local CFL Calculations
-  double DOUBLE_MAX = std::numeric_limits<double>::max();  
+  double DOUBLE_MAX = std::numeric_limits<double>::max();
   double l_max_sigma=0.0, l_max_mu = 0.0, l_max_cfl = 0.0, l_max_dx = 0.0, l_max_osm=0.0;
   double l_min_sigma=DOUBLE_MAX, l_min_mu= DOUBLE_MAX, l_min_cfl = DOUBLE_MAX, l_min_dx = DOUBLE_MAX, l_min_osm=DOUBLE_MAX;
 
@@ -1370,10 +1370,10 @@ int body(int argc, char *argv[]) {
       l_max_sigma = std::max(l_max_sigma,sigmaVal(idx));
       l_min_sigma = std::min(l_min_sigma,sigmaVal(idx));
       l_max_mu    = std::max(l_max_mu,muVal(idx));
-      l_min_mu    = std::min(l_min_mu,muVal(idx));  
+      l_min_mu    = std::min(l_min_mu,muVal(idx));
       l_max_osm   = std::max(l_max_osm,1/(sigmaVal(idx)*muVal(idx)));
       l_min_osm   = std::min(l_min_osm,1/(sigmaVal(idx)*muVal(idx)));
-      
+
       // We'll chose "dx" as the max/min edge length over the cell
       double my_edge_min = DOUBLE_MAX, my_edge_max=0.0;
       for(int j=0; j<numEdgesPerElem; j++) {
@@ -1391,7 +1391,7 @@ int body(int argc, char *argv[]) {
       double my_min_cfl = 1.0 / (sigmaVal(idx) * muVal(idx) * l_max_dx * l_max_dx);
       l_max_cfl = std::max(l_max_cfl,my_max_cfl);
       l_min_cfl = std::min(l_min_cfl,my_min_cfl);
-      
+
       idx++;
     }
   }
@@ -1912,7 +1912,7 @@ int body(int argc, char *argv[]) {
     /**********************************************************************************/
     /*                         Assemble into Global Matrix                            */
     /**********************************************************************************/
-    Tpetra::beginFill(MassMatrixG,MassMatrixC,MassMatrixC1,StiffMatrixC,SystemMatrix,rhsVector);
+    Tpetra::beginAssembly(MassMatrixG,MassMatrixC,MassMatrixC1,StiffMatrixC,SystemMatrix,rhsVector);
 
     // Loop over workset cells
     for(int cell = worksetBegin; cell < worksetEnd; cell++){
@@ -1987,7 +1987,7 @@ int body(int argc, char *argv[]) {
   /**********************************************************************************/
 
   // Assemble over multiple processors, if necessary
-  Tpetra::endFill(MassMatrixG,MassMatrixC,MassMatrixC1,StiffMatrixC,SystemMatrix,rhsVector);
+  Tpetra::endAssembly(MassMatrixG,MassMatrixC,MassMatrixC1,StiffMatrixC,SystemMatrix,rhsVector);
 
   MLStatistics.Phase2b(MassMatrixG.getCrsGraph(),rcp(&nCoord,false));
 
@@ -2016,7 +2016,7 @@ int body(int argc, char *argv[]) {
     Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeSparseFile("mag_t_matrix.dat",DGrad);
   }
 
-  
+
 
   /**********************************************************************************/
   /*********************** ADJUST MATRICES AND RHS FOR BCs **************************/
@@ -2030,7 +2030,7 @@ int body(int argc, char *argv[]) {
     MassMatrixG.apply(DiagG,DiagG);
     for(int i=0;i<(int)d_data.size();i++) {
       d_data[i]=1.0/d_data[i];
-    }      
+    }
   }
 
   Tpetra_CrsMatrix MassMatrixGinv(MassMatrixG.getRowMap(),MassMatrixG.getRowMap(),1);
@@ -2077,7 +2077,7 @@ int body(int argc, char *argv[]) {
       }
     }
   }
-  
+
   if (dump) {
     Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeSparseFile("edge_matrix_nobcs.mat",SystemMatrix);
   }
@@ -2147,11 +2147,11 @@ int body(int argc, char *argv[]) {
     //MueList22.set("coarse: type","Amesos-KLU");
   }
 
-  
+
 #if defined(HAVE_TRILINOSCOUPLINGS_AVATAR)
   Teuchos::ParameterList &MueList11=MueLuList.sublist("refmaxwell: 11list");
   Teuchos::ParameterList &MueList22=MueLuList.sublist("refmaxwell: 22list");
- 
+
   std::vector<std::string> AvatarSublists{"Avatar-MueLu-Fine","Avatar-MueLu-11","Avatar-MueLu-22"};
   std::vector<Teuchos::ParameterList *> MueLuSublists{&MueLuList,&MueList11,&MueList22};
   for (int i=0; i<(int)AvatarSublists.size(); i++) {
@@ -2159,7 +2159,7 @@ int body(int argc, char *argv[]) {
       Teuchos::ParameterList problemFeatures = problemStatistics;
       Teuchos::ParameterList avatarParams = inputList.sublist(AvatarSublists[i]);
       std::cout<<"*** Avatar["<<AvatarSublists[i]<<"] Parameters ***\n"<<avatarParams<<std::endl;
-      
+
       MueLu::AvatarInterface avatar(comm,avatarParams);
       std::cout<<"*** Avatar Setup ***"<<std::endl;
       avatar.Setup();
@@ -2176,7 +2176,7 @@ int body(int argc, char *argv[]) {
   int maxNumIters = 200;
   int num_steps = 1;
   double tol = 1e-10;
-  
+
   RCP<Tpetra_CrsMatrix> SystemMatrix_r   = rcp(&SystemMatrix,false);
   RCP<Tpetra_CrsMatrix> DGrad_r          = rcp(&DGrad,false);
   RCP<Tpetra_CrsMatrix> MassMatrixGinv_r = rcp(&MassMatrixGinv,false);
@@ -2185,23 +2185,23 @@ int body(int argc, char *argv[]) {
   RCP<Tpetra_MultiVector> nCoord_r       = rcp(&nCoord,false);
   RCP<Tpetra_MultiVector> xh_r           = rcp(&xh,false);
   RCP<Tpetra_MultiVector> rhsVector_r    = rcp(&rhsVector,false);
-  
+
   if (solverName == "MueLu") {
     // MueLu RefMaxwell
     if(MyPID==0) {std::cout << "\n\nMueLu solve \n";}
-    RCP<Xpetra_Operator>  preconditioner = 
+    RCP<Xpetra_Operator>  preconditioner =
       BuildPreconditioner_MueLu(probType,MueLuList,SystemMatrix_r,DGrad_r,MassMatrixGinv_r,MassMatrixC_r,MassMatrixC1_r,nCoord_r);
 
     RCP<Xpetra_Operator> A_x = toXpetra(SystemMatrix_r);
     RCP<Xpetra_MultiVector> xh_x = toXpetra(xh_r);
     RCP<Xpetra_MultiVector> rhsVector_x = toXpetra(rhsVector_r);
-    
+
     using BMV = Xpetra_MultiVector;
     using BOP = typename Belos::OperatorT<BMV>;
     RCP<BOP> belosOp = rcp(new Belos::XpetraOp<SC,LO,GO,NO>(A_x));
     RCP<BOP> precOp  = rcp(new Belos::XpetraOp<SC,LO,GO,NO>(preconditioner));
     RCP<BOP> dummy;
-    
+
     solverName="CG";
     TrilinosCouplings::IntrepidPoissonExample::
       solveWithBelos<SC,BMV,BOP>(converged,numItersPerformed,solverName,tol,maxNumIters,num_steps,
@@ -2463,7 +2463,7 @@ void solution_test(string msg, const Tpetra_Operator &A,const Tpetra_MultiVector
   auto xexact_data = xexact.getData(0);
   for(LO i=0 ; i<(LO)lhs.getMap()->getNodeNumElements() ; ++i )
     d += (lhs_data[i] - xexact_data[i]) * (lhs_data[i] - xexact_data[i]);
-  
+
   TC_sumAll(comm,d,d_tot);
 
   // ================== //

--- a/packages/xpetra/src/CrsMatrix/Xpetra_CrsMatrixFactory.hpp
+++ b/packages/xpetra/src/CrsMatrix/Xpetra_CrsMatrixFactory.hpp
@@ -528,7 +528,7 @@ namespace Xpetra {
 #endif
 #ifdef HAVE_XPETRA_EPETRA
       if(rowMap->lib() == UseEpetra)
-        return rcp( new EpetraCrsMatrixT<long long,Node>(rowMap));
+        return rcp( new EpetraCrsMatrixT<long long,Node>(rowMap,0));
 #endif
       XPETRA_FACTORY_END;
     }


### PR DESCRIPTION
Adds separate Assembly and Modify stages to FECrsMatrix objects.  These replace usage of `beginFill`, `endFill`, and `resumeFill` in client code.  Example usage:

```c++
Tpetra::FECrsMatrix<> A = Tpetra::FECrsMatrix(domain_map, range_map);
A.beginAssembly();
// Assembly
A.endAssembly();

A.beginModify();
// Apply boundary conditions to A
A.endModify();
```
@trilinos/tpetra

@ikalash - can you mention/tag any Albany developers that will be impacted?

## Motivation
Make semantics between `FECrsGraph`, `FECrsMatrix`, and `FEMultiVector` consistent with each other and consistent with FE literature.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->