### PR TITLE
ATDM/van1-tx2: Add openmpi 4.0.5 toolchain

### DIFF
--- a/cmake/ctest/drivers/atdm/van1-tx2/drivers/Trilinos-atdm-van1-tx2_arm-20.1_openmpi-4.0.5_openmp_static_dbg.sh
+++ b/cmake/ctest/drivers/atdm/van1-tx2/drivers/Trilinos-atdm-van1-tx2_arm-20.1_openmpi-4.0.5_openmp_static_dbg.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+#export SALLOC_CTEST_TIME_LIMIT_MINUTES=1:00:00
+
+if [ "${Trilinos_TRACK}" == "" ] ; then
+  export Trilinos_TRACK=Specialized
+fi
+
+$WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/van1-tx2/local-driver.sh

--- a/cmake/ctest/drivers/atdm/van1-tx2/drivers/Trilinos-atdm-van1-tx2_arm-20.1_openmpi-4.0.5_openmp_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/van1-tx2/drivers/Trilinos-atdm-van1-tx2_arm-20.1_openmpi-4.0.5_openmp_static_opt.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+#export SALLOC_CTEST_TIME_LIMIT_MINUTES=1:00:00
+
+if [ "${Trilinos_TRACK}" == "" ] ; then
+  export Trilinos_TRACK=Specialized
+fi
+
+$WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/van1-tx2/local-driver.sh

--- a/cmake/ctest/drivers/atdm/van1-tx2/local-driver.sh
+++ b/cmake/ctest/drivers/atdm/van1-tx2/local-driver.sh
@@ -10,7 +10,7 @@ if [[ "${SALLOC_CTEST_LIMIT_MINUTES}" == "" ]] ; then
 fi
 
 if [[ "${Trilinos_ENABLE_BUILD_STATS}" == "" ]] ; then
-  export Trilinos_ENABLE_BUILD_STATS=ON
+  export Trilinos_ENABLE_BUILD_STATS=OFF
 fi
 
 source $WORKSPACE/Trilinos/cmake/std/atdm/load-env.sh $JOB_NAME

--- a/cmake/std/atdm/van1-tx2/all_supported_builds.sh
+++ b/cmake/std/atdm/van1-tx2/all_supported_builds.sh
@@ -7,4 +7,6 @@ export ATDM_CONFIG_ALL_SUPPORTED_BUILDS=(
   van1-tx2_arm-20.0_openmpi-4.0.2_openmp_static_dbg
   van1-tx2_arm-20.1_openmpi-4.0.3_openmp_static_opt
   van1-tx2_arm-20.1_openmpi-4.0.3_openmp_static_dbg
+  van1-tx2_arm-20.1_openmpi-4.0.5_openmp_static_opt
+  van1-tx2_arm-20.1_openmpi-4.0.5_openmp_static_dbg
   )

--- a/cmake/std/atdm/van1-tx2/custom_builds.sh
+++ b/cmake/std/atdm/van1-tx2/custom_builds.sh
@@ -4,16 +4,16 @@
 
 # Try matching against arm-20.1 before arm-20 or arm
 if atdm_match_any_buildname_keyword \
+     arm-20.1-openmpi-4.0.5 \
+     arm-20.1_openmpi-4.0.5 \
+  ; then
+  export ATDM_CONFIG_COMPILER=ARM-20.1_OPENMPI-4.0.5
+elif atdm_match_any_buildname_keyword \
      arm-20.1-openmpi-4.0.3 \
      arm-20.1_openmpi-4.0.3 \
      arm-20.1 \
   ; then
   export ATDM_CONFIG_COMPILER=ARM-20.1_OPENMPI-4.0.3
-elif atdm_match_any_buildname_keyword \
-     arm-20.1-openmpi-4.0.5 \
-     arm-20.1_openmpi-4.0.5 \
-  ; then
-  export ATDM_CONFIG_COMPILER=ARM-20.1_OPENMPI-4.0.5
 elif atdm_match_any_buildname_keyword \
      arm-20.0-openmpi-4.0.2 \
      arm-20.0_openmpi-4.0.2 \

--- a/cmake/std/atdm/van1-tx2/custom_builds.sh
+++ b/cmake/std/atdm/van1-tx2/custom_builds.sh
@@ -10,6 +10,11 @@ if atdm_match_any_buildname_keyword \
   ; then
   export ATDM_CONFIG_COMPILER=ARM-20.1_OPENMPI-4.0.3
 elif atdm_match_any_buildname_keyword \
+     arm-20.1-openmpi-4.0.5 \
+     arm-20.1_openmpi-4.0.5 \
+  ; then
+  export ATDM_CONFIG_COMPILER=ARM-20.1_OPENMPI-4.0.5
+elif atdm_match_any_buildname_keyword \
      arm-20.0-openmpi-4.0.2 \
      arm-20.0_openmpi-4.0.2 \
      arm-20.0 \
@@ -27,6 +32,7 @@ else
   echo "***"
   echo "****  arm-20.0-openmpi-4.0.2    (arm-20.0, default)"
   echo "****  arm-20.1-openmpi-4.0.3    (arm-20.1)"
+  echo "****  arm-20.1-openmpi-4.0.5"
   echo "***"
   return
 

--- a/cmake/std/atdm/van1-tx2/custom_builds_unit_tests.sh
+++ b/cmake/std/atdm/van1-tx2/custom_builds_unit_tests.sh
@@ -55,6 +55,14 @@ testAll() {
   . ${ATDM_CONFIG_SCRIPT_DIR}/utils/set_build_options.sh
   ${_ASSERT_EQUALS_} ARM-20.1_OPENMPI-4.0.3 ${ATDM_CONFIG_COMPILER}
 
+  ATDM_CONFIG_BUILD_NAME=before-arm-20.1-openmpi-4.0.5_after
+  . ${ATDM_CONFIG_SCRIPT_DIR}/utils/set_build_options.sh
+  ${_ASSERT_EQUALS_} ARM-20.1_OPENMPI-4.0.5 ${ATDM_CONFIG_COMPILER}
+
+  ATDM_CONFIG_BUILD_NAME=before-arm-20.1_openmpi-4.0.5-after
+  . ${ATDM_CONFIG_SCRIPT_DIR}/utils/set_build_options.sh
+  ${_ASSERT_EQUALS_} ARM-20.1_OPENMPI-4.0.5 ${ATDM_CONFIG_COMPILER}
+
   ATDM_CONFIG_BUILD_NAME=before_arm-20.1-after
   . ${ATDM_CONFIG_SCRIPT_DIR}/utils/set_build_options.sh
   ${_ASSERT_EQUALS_}  ARM-20.1_OPENMPI-4.0.3 ${ATDM_CONFIG_COMPILER}

--- a/cmake/std/atdm/van1-tx2/environment.sh
+++ b/cmake/std/atdm/van1-tx2/environment.sh
@@ -96,6 +96,27 @@ elif [[ "$ATDM_CONFIG_COMPILER" == "ARM-20.1_OPENMPI-4.0.3" ]]; then
   export PARMETIS_ROOT=${PARMETIS_DIR}
   export SUPERLUDIST_ROOT=${SUPERLU_DIST_DIR}
   export BINUTILS_ROOT=${BINUTILS_DIR}
+elif [[ "$ATDM_CONFIG_COMPILER" == "ARM-20.1_OPENMPI-4.0.5" ]]; then
+  module load sparc-dev/arm-20.1_openmpi-4.0.5
+  module unload yaml-cpp
+
+  if [ "$ATDM_CONFIG_NODE_TYPE" == "OPENMP" ] ; then
+    unset OMP_PLACES
+    unset OMP_PROC_BIND
+  fi
+
+  # We'll use TPL_ROOT for consistency across ATDM environments
+  export MPI_ROOT=${MPI_DIR}
+  export BLAS_ROOT=${ARMPL_DIR}
+  export HDF5_ROOT=${HDF5_DIR}
+  export NETCDF_ROOT=${NETCDF_DIR}
+  export PNETCDF_ROOT=${PNETCDF_DIR}
+  export ZLIB_ROOT=${ZLIB_DIR}
+  export CGNS_ROOT=${CGNS_DIR}
+  export METIS_ROOT=${METIS_DIR}
+  export PARMETIS_ROOT=${PARMETIS_DIR}
+  export SUPERLUDIST_ROOT=${SUPERLU_DIST_DIR}
+  export BINUTILS_ROOT=${BINUTILS_DIR}
 else
   echo
   echo "***"


### PR DESCRIPTION
CC: @jwillenbring, @tcfisher

@sebrowne: Thank you for all your hard work on this. Apologies for the delay due to testing and proxy issues. When testing the tip of https://github.com/sebrowne/Trilinos/tree/develop, I saw all the builds fail [here](https://testing-dev.sandia.gov/cdash/index.php?project=Trilinos&date=2021-04-9&filtercount=2&showfilters=1&filtercombine=and&field1=buildname&compare1=63&value1=van1&field2=groupname&compare2=63&value2=Experiment) on cdash. I rebased your changes on-top of the Trilinos develop branch and things are running smoothly now. We can either merge this PR and close #8850 or close this one and update your PR accordingly.

Since `van1-tx2_arm-20.1_openmpi-4.0.3_openmp_static_opt` is marked as a 'Primary Build' I have marked `van1-tx2_arm-20.1_openmpi-4.0.5_openmp_static_opt` as a 'Primary Build' meaning that it will be monitored and triaged on a daily basis by the framework team. I flagged @jmgate as a reviewer since this includes changes to `van1-tx2_arm-20.1_openmpi-4.0.3_openmp_static_opt`.

## How was this tested?
On van1-tx2 via:
1. A quick 'preliminary test'
```bash
nohup env CTEST_DO_SUBMIT=OFF Trilinos_PACKAGES=Kokkos ./ctest-s-local-test-driver.sh van1-tx2_arm-20.1_openmpi-4.0.5_openmp_static_opt &>ctest-s-local-test-driver.out &
```
2. A 'full test':
```bash
nohup env ./ctest-s-local-test-driver.sh all &>ctest-s-local-test-driver.out &
```
The 'full test' is still running and posting to cdash [here](https://testing-dev.sandia.gov/cdash/index.php?project=Trilinos&date=2021-04-12&filtercount=2&showfilters=1&filtercombine=and&field1=buildname&compare1=63&value1=van1&field2=groupname&compare2=63&value2=Experiment).

