### PR TITLE
Tpetra:  another test update to allow Zoltan tests to build

### DIFF
--- a/cmake/ctest/drivers/ascicgpu031/TrilinosCTestDriverCore.ascicgpu031.gcc-cuda.cmake
+++ b/cmake/ctest/drivers/ascicgpu031/TrilinosCTestDriverCore.ascicgpu031.gcc-cuda.cmake
@@ -91,9 +91,10 @@ MACRO(TRILINOS_SYSTEM_SPECIFIC_CTEST_DRIVER)
   SET(EXTRA_SYSTEM_CONFIGURE_OPTIONS
       "-DCMAKE_BUILD_TYPE:STRING=${BUILD_TYPE}"
 
-      "-DTrilinos_ENABLE_COMPLEX:BOOL=OFF"
       # Adding the following as a possible fix for github issue #2115.
-      "-DCMAKE_CXX_USE_RESPONSE_FILE_FOR_OBJECTS:BOOL=ON"
+      #KDD This flag appears to be unnecessary in April 2021, and it
+      #KDD breaks building of Zoltan tests
+      #KDD "-DCMAKE_CXX_USE_RESPONSE_FILE_FOR_OBJECTS:BOOL=ON"
 
       ### ALWAYS AND EVERYWHERE ###
       "-DTrilinos_ENABLE_EXPLICIT_INSTANTIATION:BOOL=ON"
@@ -102,6 +103,10 @@ MACRO(TRILINOS_SYSTEM_SPECIFIC_CTEST_DRIVER)
       "-DTrilinos_ENABLE_EXAMPLES:BOOL=ON"
       "-DTrilinos_ENABLE_DEPENDENCY_UNIT_TESTS:BOOL=OFF"
       "-DTeuchos_GLOBALLY_REDUCE_UNITTEST_RESULTS:BOOL=ON"
+
+      "-DTrilinos_ENABLE_COMPLEX=ON"
+      "-DTeuchos_ENABLE_COMPLEX=ON"
+      "-DTpetra_INST_COMPLEX_DOUBLE=ON"
 
       ### COMPILERS AND FLAGS ###
       "-DCMAKE_CXX_FLAGS:STRING='-Wall -Wno-unknown-pragmas -Wno-unused-but-set-variable -Wno-inline -Wshadow'"

--- a/cmake/ctest/drivers/ascicgpu031/TrilinosCTestDriverCore.ascicgpu031.gcc-cuda.crs.cmake
+++ b/cmake/ctest/drivers/ascicgpu031/TrilinosCTestDriverCore.ascicgpu031.gcc-cuda.crs.cmake
@@ -91,9 +91,10 @@ MACRO(TRILINOS_SYSTEM_SPECIFIC_CTEST_DRIVER)
   SET(EXTRA_SYSTEM_CONFIGURE_OPTIONS
       "-DCMAKE_BUILD_TYPE:STRING=${BUILD_TYPE}"
 
-      "-DTrilinos_ENABLE_COMPLEX:BOOL=OFF"
       # Adding the following as a possible fix for github issue #2115.
-      "-DCMAKE_CXX_USE_RESPONSE_FILE_FOR_OBJECTS:BOOL=ON"
+      #KDD This flag appears to be unnecessary in April 2021, and it
+      #KDD breaks building of Zoltan tests
+      #KDD "-DCMAKE_CXX_USE_RESPONSE_FILE_FOR_OBJECTS:BOOL=ON"
 
       ### ALWAYS AND EVERYWHERE ###
       "-DTrilinos_ENABLE_EXPLICIT_INSTANTIATION:BOOL=ON"

--- a/cmake/ctest/drivers/ascicgpu031/ctest_linux_nightly_mpi_debug_nouvm_ascicgpu031_crs.cmake
+++ b/cmake/ctest/drivers/ascicgpu031/ctest_linux_nightly_mpi_debug_nouvm_ascicgpu031_crs.cmake
@@ -88,10 +88,6 @@ SET(EXTRA_CONFIGURE_OPTIONS
 
   "-D Tpetra_ENABLE_DEPRECATED_CODE=OFF"
 
-  ### Zoltan tests do not build correctly in this framework; unknown reason
-  ### But we don't need them in UVM-removal testing, so disable them
-  "-D Zoltan_ENABLE_TESTS=OFF"
-  "-D Zoltan_ENABLE_EXAMPLES=OFF"
 )
 
 #

--- a/cmake/ctest/drivers/ascicgpu031/ctest_linux_nightly_mpi_debug_uvm_deprecated_ascicgpu031_crs.cmake
+++ b/cmake/ctest/drivers/ascicgpu031/ctest_linux_nightly_mpi_debug_uvm_deprecated_ascicgpu031_crs.cmake
@@ -88,10 +88,6 @@ SET(EXTRA_CONFIGURE_OPTIONS
 
   "-DTpetra_ENABLE_DEPRECATED_CODE:BOOL=ON" 
 
-  ### Zoltan tests do not build correctly in this framework; unknown reason
-  ### But we don't need them in UVM-removal testing, so disable them
-  "-D Zoltan_ENABLE_TESTS=OFF"
-  "-D Zoltan_ENABLE_EXAMPLES=OFF"
 )
 
 #

--- a/cmake/ctest/drivers/ascicgpu031/ctest_linux_nightly_mpi_debug_uvm_nodeprecated_ascicgpu031_crs.cmake
+++ b/cmake/ctest/drivers/ascicgpu031/ctest_linux_nightly_mpi_debug_uvm_nodeprecated_ascicgpu031_crs.cmake
@@ -88,10 +88,6 @@ SET(EXTRA_CONFIGURE_OPTIONS
 
   "-DTpetra_ENABLE_DEPRECATED_CODE:BOOL=OFF" 
 
-  ### Zoltan tests do not build correctly in this framework; unknown reason
-  ### But we don't need them in UVM-removal testing, so disable them
-  "-D Zoltan_ENABLE_TESTS=OFF"
-  "-D Zoltan_ENABLE_EXAMPLES=OFF"
 )
 
 #

--- a/cmake/ctest/drivers/ascicgpu031/ctest_linux_nightly_mpi_release_nouvm_ascicgpu031.cmake
+++ b/cmake/ctest/drivers/ascicgpu031/ctest_linux_nightly_mpi_release_nouvm_ascicgpu031.cmake
@@ -87,10 +87,6 @@ SET(EXTRA_CONFIGURE_OPTIONS
   "-D Kokkos_ENABLE_CUDA_UVM=OFF"
   "-D Tpetra_ENABLE_DEPRECATED_CODE=OFF"
 
-  ### Zoltan tests do not build correctly in this framework; unknown reason
-  ### But we don't need them in UVM-removal testing, so disable them
-  "-D Zoltan_ENABLE_TESTS=OFF"
-  "-D Zoltan_ENABLE_EXAMPLES=OFF"
 )
 
 #

--- a/cmake/ctest/drivers/ascicgpu031/ctest_linux_nightly_mpi_release_uvm_deprecated_ascicgpu031.cmake
+++ b/cmake/ctest/drivers/ascicgpu031/ctest_linux_nightly_mpi_release_uvm_deprecated_ascicgpu031.cmake
@@ -88,10 +88,6 @@ SET(EXTRA_CONFIGURE_OPTIONS
 
   "-DTpetra_ENABLE_DEPRECATED_CODE:BOOL=ON" 
 
-  ### Zoltan tests do not build correctly in this framework; unknown reason
-  ### But we don't need them in UVM-removal testing, so disable them
-  "-D Zoltan_ENABLE_TESTS=OFF"
-  "-D Zoltan_ENABLE_EXAMPLES=OFF"
 )
 
 #

--- a/cmake/ctest/drivers/ascicgpu031/ctest_linux_nightly_mpi_release_uvm_nodeprecated_ascicgpu031.cmake
+++ b/cmake/ctest/drivers/ascicgpu031/ctest_linux_nightly_mpi_release_uvm_nodeprecated_ascicgpu031.cmake
@@ -88,10 +88,6 @@ SET(EXTRA_CONFIGURE_OPTIONS
 
   "-DTpetra_ENABLE_DEPRECATED_CODE:BOOL=OFF" 
 
-  ### Zoltan tests do not build correctly in this framework; unknown reason
-  ### But we don't need them in UVM-removal testing, so disable them
-  "-D Zoltan_ENABLE_TESTS=OFF"
-  "-D Zoltan_ENABLE_EXAMPLES=OFF"
 )
 
 #


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Trying to get tpetra's nightly tests to run.
Removing flag CMAKE_CXX_USE_RESPONSE_FILE_FOR_OBJECTS allows the Zoltan tests to builds.
Kokkos-kernels  seems to build fine as well, without the concerns in #2115.


<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Built on ascicgpu with shared libraries, complex double instantiated, and no flag CMAKE_CXX_USE_RESPONSE_FILE_FOR_OBJECTS
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->