### PR TITLE
Tempus: Replace Logical Operators

### DIFF
--- a/packages/tempus/src/Tempus_IntegratorBasic_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorBasic_impl.hpp
@@ -391,8 +391,8 @@ bool IntegratorBasic<Scalar>::advanceTime()
     startIntegrator();
     integratorObserver_->observeStartIntegrator(*this);
 
-    while (integratorStatus_ == WORKING and
-        timeStepControl_->timeInRange (solutionHistory_->getCurrentTime()) and
+    while (integratorStatus_ == WORKING &&
+        timeStepControl_->timeInRange (solutionHistory_->getCurrentTime()) &&
         timeStepControl_->indexInRange(solutionHistory_->getCurrentIndex())){
 
       stepperTimer_->reset();
@@ -489,11 +489,11 @@ void IntegratorBasic<Scalar>::checkTimeStep()
   }
 
   // Check Stepper failure.
-  if (ws->getSolutionStatus() == Status::FAILED or
+  if (ws->getSolutionStatus() == Status::FAILED ||
        // Constant time step failure
-       ((timeStepControl_->getStepType() == "Constant") and
-        (ws->getTimeStep() != timeStepControl_->getInitTimeStep()) and
-        (ws->getOutput() != true) and
+       ((timeStepControl_->getStepType() == "Constant") &&
+        (ws->getTimeStep() != timeStepControl_->getInitTimeStep()) &&
+        (ws->getOutput() != true) &&
         (ws->getTime() != timeStepControl_->getFinalTime())
        )
      )
@@ -509,7 +509,7 @@ void IntegratorBasic<Scalar>::checkTimeStep()
     if (ws->getSolutionStatus() == Status::FAILED) {
       *out << "Solution Status = " << toString(ws->getSolutionStatus())
            << std::endl;
-    } else if ((timeStepControl_->getStepType() == "Constant") and
+    } else if ((timeStepControl_->getStepType() == "Constant") &&
                (ws->getTimeStep() != timeStepControl_->getInitTimeStep())) {
       *out << "dt != Constant dt (="<<timeStepControl_->getInitTimeStep()<<")"
            << std::endl;
@@ -533,7 +533,7 @@ void IntegratorBasic<Scalar>::endIntegrator()
 {
   std::string exitStatus;
   if (solutionHistory_->getCurrentState()->getSolutionStatus() ==
-      Status::FAILED or integratorStatus_ == Status::FAILED) {
+      Status::FAILED || integratorStatus_ == Status::FAILED) {
     exitStatus = "Time integration FAILURE!";
   } else {
     integratorStatus_ = Status::PASSED;

--- a/packages/tempus/src/Tempus_IntegratorObserverBasic_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorObserverBasic_impl.hpp
@@ -66,8 +66,8 @@ observeEndTimeStep(const Integrator<Scalar>& integrator){
   using Teuchos::RCP;
   auto cs = integrator.getSolutionHistory()->getCurrentState();
 
-  if ((cs->getOutputScreen() == true) or
-      (cs->getOutput() == true) or
+  if ((cs->getOutputScreen() == true) ||
+      (cs->getOutput() == true) ||
       (cs->getTime() == integrator.getTimeStepControl()->getFinalTime())) {
 
      const Scalar steppertime = integrator.getStepperTimer()->totalElapsedTime();
@@ -98,7 +98,7 @@ observeEndIntegrator(const Integrator<Scalar>& integrator){
   std::string exitStatus;
   //const Scalar runtime = integrator.getIntegratorTimer()->totalElapsedTime();
   if (integrator.getSolutionHistory()->getCurrentState()->getSolutionStatus() ==
-      Status::FAILED or integrator.getStatus() == Status::FAILED) {
+      Status::FAILED || integrator.getStatus() == Status::FAILED) {
     exitStatus = "Time integration FAILURE!";
   } else {
     exitStatus = "Time integration complete.";

--- a/packages/tempus/src/Tempus_IntegratorObserverSubcycling_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorObserverSubcycling_impl.hpp
@@ -58,8 +58,8 @@ observeEndTimeStep(const Integrator<Scalar>& integrator){
   using Teuchos::RCP;
   auto cs = integrator.getSolutionHistory()->getCurrentState();
 
-  if ((cs->getOutputScreen() == true) or
-      (cs->getOutput() == true) or
+  if ((cs->getOutputScreen() == true) ||
+      (cs->getOutput() == true) ||
       (cs->getTime() == integrator.getTimeStepControl()->getFinalTime())) {
 
      const Scalar steppertime = integrator.getStepperTimer()->totalElapsedTime();

--- a/packages/tempus/src/Tempus_SolutionHistory_decl.hpp
+++ b/packages/tempus/src/Tempus_SolutionHistory_decl.hpp
@@ -190,7 +190,7 @@ public:
     /// Subscript operator
     Teuchos::RCP<SolutionState<Scalar> > operator[](const int i) {
       TEUCHOS_TEST_FOR_EXCEPTION(
-        !((0 <= i) and (i < (int)history_->size())), std::out_of_range,
+        !((0 <= i) && (i < (int)history_->size())), std::out_of_range,
         "Error - SolutionHistory index is out of range.\n"
         << "    [Min, Max] = [ 0, " << history_->size()<< "]\n"
         << "    index = " << i << "\n");
@@ -200,7 +200,7 @@ public:
     /// Subscript operator (const version)
     Teuchos::RCP<const SolutionState<Scalar> > operator[](const int i) const {
       TEUCHOS_TEST_FOR_EXCEPTION(
-        !((0 <= i) and (i < (int)history_->size())), std::out_of_range,
+        !((0 <= i) && (i < (int)history_->size())), std::out_of_range,
         "Error - SolutionHistory index is out of range.\n"
         << "    [Min, Max] = [ 0, " << history_->size()<< "]\n"
         << "    index = " << i << "\n");
@@ -213,7 +213,7 @@ public:
       const int m = history_->size();
       Teuchos::RCP<SolutionState<Scalar> > state;
       if (m == 0)                                        state=Teuchos::null;
-      else if (m == 1 or workingState_ == Teuchos::null) state=(*history_)[m-1];
+      else if (m == 1 || workingState_ == Teuchos::null) state=(*history_)[m-1];
       else if (m > 1)                                    state=(*history_)[m-2];
       return state;
     }

--- a/packages/tempus/src/Tempus_SolutionHistory_impl.hpp
+++ b/packages/tempus/src/Tempus_SolutionHistory_impl.hpp
@@ -183,7 +183,7 @@ Teuchos::RCP<SolutionState<Scalar> >
 SolutionHistory<Scalar>::findState(const Scalar time) const
 {
   TEUCHOS_TEST_FOR_EXCEPTION(
-    !(minTime() <= time and time <= maxTime()), std::logic_error,
+    !(minTime() <= time && time <= maxTime()), std::logic_error,
     "Error - SolutionHistory::findState() Requested time out of range!\n"
     "        [Min, Max] = [" << minTime() << ", " << maxTime() << "]\n"
     "        time = "<< time <<"\n");
@@ -614,7 +614,7 @@ void SolutionHistory<Scalar>::printHistory(std::string verb) const
     else if (state->getIsInterpolated() == true) *out<<"i - ";
     else *out << "    ";
     *out << "[" << i << "] = " << state << std::endl;
-    if (verb == "medium" or verb == "high") {
+    if (verb == "medium" || verb == "high") {
       if (state != Teuchos::null) {
         auto x = state->getX();
         *out << "      x       = " << x << std::endl

--- a/packages/tempus/src/Tempus_SolutionStateMetaData_decl.hpp
+++ b/packages/tempus/src/Tempus_SolutionStateMetaData_decl.hpp
@@ -142,12 +142,12 @@ protected:
   bool   computeNorms_;      ///< flag to compute norms of solution
 
   /** \brief The solutionStatus is used to indicate
-      - if the solution is still being worked on; WORKING
-      - if the solution is accepted and completed (e.g., past solutions
-        in SolutionHistory); PASSED.
-      - if the time step has FAILED.  This may be caused by the Stepper
-        failing, or Integrator not accepting the time step.
-  */
+   *  - if the solution is still being worked on; WORKING
+   *  - if the solution is accepted and completed (e.g., past solutions
+   *    in SolutionHistory); PASSED.
+   *  - if the time step has FAILED.  This may be caused by the Stepper
+   *    failing, or Integrator not accepting the time step.
+   */
   Status solutionStatus_;
   bool   output_;         ///< SolutionState should be or has been outputted
   bool   outputScreen_;   ///< Output screen dump

--- a/packages/tempus/src/Tempus_StepperBDF2_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperBDF2_decl.hpp
@@ -152,7 +152,7 @@ public:
   virtual bool isExplicit()         const {return false;}
   virtual bool isImplicit()         const {return true;}
   virtual bool isExplicitImplicit() const
-  {return isExplicit() and isImplicit();}
+  {return isExplicit() && isImplicit();}
   virtual bool isOneStepMethod()   const {return false;}
   virtual bool isMultiStepMethod() const {return !isOneStepMethod();}
   virtual OrderODE getOrderODE()   const {return FIRST_ORDER_ODE;}

--- a/packages/tempus/src/Tempus_StepperBackwardEuler_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperBackwardEuler_decl.hpp
@@ -125,7 +125,7 @@ public:
     virtual bool isExplicit()         const {return false;}
     virtual bool isImplicit()         const {return true;}
     virtual bool isExplicitImplicit() const
-      {return isExplicit() and isImplicit();}
+      {return isExplicit() && isImplicit();}
     virtual bool isOneStepMethod()   const {return true;}
     virtual bool isMultiStepMethod() const {return !isOneStepMethod();}
     virtual OrderODE getOrderODE()   const {return FIRST_ORDER_ODE;}

--- a/packages/tempus/src/Tempus_StepperDIRK_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperDIRK_decl.hpp
@@ -190,7 +190,7 @@ public:
     }
     virtual bool isImplicit()         const {return true;}
     virtual bool isExplicitImplicit() const
-      {return isExplicit() and isImplicit();}
+      {return isExplicit() && isImplicit();}
     virtual bool isOneStepMethod()   const {return true;}
     virtual bool isMultiStepMethod() const {return !isOneStepMethod();}
 

--- a/packages/tempus/src/Tempus_StepperDIRK_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperDIRK_impl.hpp
@@ -89,7 +89,7 @@ void StepperDIRK<Scalar>::initialize()
   xTilde_    = Thyra::createMember(this->wrapperModel_->get_x_space());
   assign(xTilde_.ptr(),    Teuchos::ScalarTraits<Scalar>::zero());
 
-  if (this->tableau_->isEmbedded() and this->getUseEmbedded()) {
+  if (this->tableau_->isEmbedded() && this->getUseEmbedded()) {
     this->ee_    = Thyra::createMember(this->wrapperModel_->get_f_space());
     this->abs_u0 = Thyra::createMember(this->wrapperModel_->get_f_space());
     this->abs_u  = Thyra::createMember(this->wrapperModel_->get_f_space());
@@ -236,7 +236,7 @@ void StepperDIRK<Scalar>::takeStep(
       }
     }
 
-    if (this->tableau_->isEmbedded() and this->getUseEmbedded()) {
+    if (this->tableau_->isEmbedded() && this->getUseEmbedded()) {
       const Scalar tolRel = workingState->getTolRel();
       const Scalar tolAbs = workingState->getTolAbs();
 

--- a/packages/tempus/src/Tempus_StepperExplicitRK_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperExplicitRK_decl.hpp
@@ -124,7 +124,7 @@ public:
     virtual bool isExplicit()         const {return true;}
     virtual bool isImplicit()         const {return false;}
     virtual bool isExplicitImplicit() const
-      {return isExplicit() and isImplicit();}
+      {return isExplicit() && isImplicit();}
     virtual bool isOneStepMethod()   const {return true;}
     virtual bool isMultiStepMethod() const {return !isOneStepMethod();}
 

--- a/packages/tempus/src/Tempus_StepperExplicitRK_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperExplicitRK_impl.hpp
@@ -165,7 +165,7 @@ void StepperExplicitRK<Scalar>::initialize()
     assign(stageXDot_[i].ptr(), Teuchos::ScalarTraits<Scalar>::zero());
   }
 
-  if ( this->tableau_->isEmbedded() and this->getUseEmbedded() ){
+  if ( this->tableau_->isEmbedded() && this->getUseEmbedded() ){
      this->ee_ = Thyra::createMember(this->appModel_->get_f_space());
      this->abs_u0 = Thyra::createMember(this->appModel_->get_f_space());
      this->abs_u = Thyra::createMember(this->appModel_->get_f_space());
@@ -293,7 +293,7 @@ void StepperExplicitRK<Scalar>::takeStep(
     // can change the step status
     workingState->setSolutionStatus(Status::PASSED);
 
-    if (this->tableau_->isEmbedded() and this->getUseEmbedded()) {
+    if (this->tableau_->isEmbedded() && this->getUseEmbedded()) {
 
       const Scalar tolRel = workingState->getTolRel();
       const Scalar tolAbs = workingState->getTolAbs();

--- a/packages/tempus/src/Tempus_StepperExplicit_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperExplicit_decl.hpp
@@ -22,13 +22,14 @@ class ExplicitODEParameters
     ExplicitODEParameters()
       : timeStepSize_(Scalar(0.0)), stageNumber_(0)
     {}
+
     /// Constructor
     ExplicitODEParameters(Scalar timeStepSize, int stageNumber = 0)
       : timeStepSize_(timeStepSize), stageNumber_(stageNumber)
     {}
 
-    Scalar                                timeStepSize_;
-    int                                   stageNumber_;
+    Scalar timeStepSize_;
+    int    stageNumber_;
 };
 
 
@@ -73,7 +74,7 @@ public:
     virtual bool isExplicit()         const {return true;}
     virtual bool isImplicit()         const {return false;}
     virtual bool isExplicitImplicit() const
-      {return isExplicit() and isImplicit();}
+      {return isExplicit() && isImplicit();}
     virtual bool isOneStepMethod()    const {return true;}
     virtual bool isMultiStepMethod()  const {return !isOneStepMethod();}
 

--- a/packages/tempus/src/Tempus_StepperHHTAlpha_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperHHTAlpha_decl.hpp
@@ -100,7 +100,7 @@ public:
     virtual bool isExplicit()         const {return false;}
     virtual bool isImplicit()         const {return true;}
     virtual bool isExplicitImplicit() const
-      {return isExplicit() and isImplicit();}
+      {return isExplicit() && isImplicit();}
     virtual bool isOneStepMethod()   const {return true;}
     virtual bool isMultiStepMethod() const {return !isOneStepMethod();}
     virtual OrderODE getOrderODE()   const {return SECOND_ORDER_ODE;}

--- a/packages/tempus/src/Tempus_StepperIMEX_RK_Partition_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperIMEX_RK_Partition_decl.hpp
@@ -407,7 +407,7 @@ public:
     virtual bool isExplicit()         const {return true;}
     virtual bool isImplicit()         const {return true;}
     virtual bool isExplicitImplicit() const
-      {return isExplicit() and isImplicit();}
+      {return isExplicit() && isImplicit();}
     virtual bool isOneStepMethod()   const {return true;}
     virtual bool isMultiStepMethod() const {return !isOneStepMethod();}
     virtual OrderODE getOrderODE()   const {return FIRST_ORDER_ODE;}

--- a/packages/tempus/src/Tempus_StepperIMEX_RK_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperIMEX_RK_decl.hpp
@@ -376,7 +376,7 @@ public:
     virtual bool isExplicit()         const {return true;}
     virtual bool isImplicit()         const {return true;}
     virtual bool isExplicitImplicit() const
-      {return isExplicit() and isImplicit();}
+      {return isExplicit() && isImplicit();}
     virtual bool isOneStepMethod()   const {return true;}
     virtual bool isMultiStepMethod() const {return !isOneStepMethod();}
     virtual OrderODE getOrderODE()   const {return FIRST_ORDER_ODE;}

--- a/packages/tempus/src/Tempus_StepperImplicit_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperImplicit_decl.hpp
@@ -48,180 +48,180 @@ class ImplicitODEParameters
 
 /** \brief Thyra Base interface for implicit time steppers.
  *
-    For first-order ODEs, we can write the implicit ODE as
-    \f[
-      \mathcal{F}(\dot{x}_n,x_n,t_n) = 0
-    \f]
-    where \f$x_n\f$ is the solution vector, \f$\dot{x}\f$ is the
-    time derivative, \f$t_n\f$ is the time and \f$n\f$ indicates
-    the \f$n^{th}\f$ time level.  Note that \f$\dot{x}_n\f$ is
-    different for each time stepper and is a function of other
-    solution states, e.g., for Backward Euler,
-    \f[
-      \dot{x}_n(x_n) = \frac{x_n - x_{n-1}}{\Delta t}
-    \f]
-
-    <b> Defining the Iteration Matrix</b>
-
-    Often we use Newton's method or one of its variations to solve
-    for \f$x_n\f$, such as
-    \f[
-      \left[
-      \frac{\partial}{\partial x_n}
-      \left(
-        \mathcal{F}(\dot{x}_n,x_n,t_n)
-      \right)
-      \right] \Delta x_n^\nu = - \mathcal{F}(\dot{x}_n^\nu,x_n^\nu,t_n)
-    \f]
-    where \f$\Delta x_n^\nu = x_n^{\nu+1} - x_n^\nu\f$ and \f$\nu\f$
-    is the iteration index.  Using the chain rule for a function
-    with multiple variables, we can write
-    \f[
-      \left[
-
-      \frac{\partial \dot{x}_n(x_n) }{\partial x_n}
-      \frac{\partial}{\partial \dot{x}_n}
-      \left(
-        \mathcal{F}(\dot{x}_n,x_n,t_n)
-      \right)
-      +
-      \frac{\partial x_n}{\partial x_n}
-      \frac{\partial}{\partial x_n}
-      \left(
-        \mathcal{F}(\dot{x}_n,x_n,t_n)
-      \right)
-
-      \right] \Delta x_n^\nu = - \mathcal{F}(\dot{x}_n^\nu,x_n^\nu,t_n)
-    \f]
-    Defining the iteration matrix, \f$W\f$, we have
-    \f[
-      W \Delta x_n^\nu = - \mathcal{F}(\dot{x}_n^\nu,x_n^\nu,t_n)
-    \f]
-    using \f$\mathcal{F}_n = \mathcal{F}(\dot{x}_n,x_n,t_n)\f$, where
-    \f[
-      W = \alpha \frac{\partial \mathcal{F}_n}{\partial \dot{x}_n}
-        + \beta  \frac{\partial \mathcal{F}_n}{\partial x_n}
-    \f]
-    and
-    \f[
-      W = \alpha M + \beta J
-    \f]
-    where
-    \f[
-      \alpha \equiv \frac{\partial \dot{x}_n(x_n) }{\partial x_n},
-      \quad \quad
-      \beta \equiv \frac{\partial x_n}{\partial x_n} = 1,
-      \quad \quad
-      M = \frac{\partial \mathcal{F}_n}{\partial \dot{x}_n},
-      \quad \quad
-      J = \frac{\partial \mathcal{F}_n}{\partial x_n}
-    \f]
-    and \f$M\f$ is the mass matrix and \f$J\f$ is the Jacobian.
-
-    Note that sometimes it is helpful to set \f$\alpha=0\f$ and
-    \f$\beta = 1\f$ to obtain the Jacobian, \f$J\f$, from the
-    iteration matrix (i.e., ModelEvaluator), or set \f$\alpha=1\f$
-    and \f$\beta = 0\f$ to obtain the mass matrix, \f$M\f$, from
-    the iteration matrix (i.e., the ModelEvaluator).
-
-    As a concrete example, the time derivative for Backward Euler is
-    \f[
-      \dot{x}_n(x_n) = \frac{x_n - x_{n-1}}{\Delta t}
-    \f]
-    thus
-    \f[
-      \alpha \equiv \frac{\partial \dot{x}_n(x_n) }{\partial x_n}
-             = \frac{1}{\Delta t}
-      \quad \quad
-      \beta \equiv \frac{\partial x_n}{\partial x_n} = 1
-    \f]
-    and the iteration matrix for Backward Euler is
-    \f[
-      W = \frac{1}{\Delta t} \frac{\partial \mathcal{F}_n}{\partial \dot{x}_n}
-        + \frac{\partial \mathcal{F}_n}{\partial x_n}
-    \f]
-
-    <b> Dangers of multiplying through by \f$\Delta t\f$. </b>
-    In some time-integration schemes, the application might want
-    to multiply the governing equations by the time-step size,
-    \f$\Delta t\f$, for scaling or other reasons.  Here we illustrate
-    what that means and the complications that follow from it.
-
-    Starting with a simple implicit ODE and multiplying through by
-    \f$\Delta t\f$, we have
-    \f[
-      \mathcal{F}_n = \Delta t \dot{x}_n - \Delta t \bar{f}(x_n,t_n) = 0
-    \f]
-    For the Backward Euler stepper, we recall from above that
-    \f[
-      \dot{x}_n(x_n) = \frac{x_n - x_{n-1}}{\Delta t}
-      \quad\quad
-      \alpha \equiv \frac{\partial \dot{x}_n(x_n) }{\partial x_n}
-             = \frac{1}{\Delta t}
-      \quad \quad
-      \beta \equiv \frac{\partial x_n}{\partial x_n} = 1
-    \f]
-    and we can find for our simple implicit ODE, \f$\mathcal{F}_n\f$,
-    \f[
-      M = \frac{\partial \mathcal{F}_n}{\partial \dot{x}_n} = \Delta t,
-      \quad \quad
-      J = \frac{\partial \mathcal{F}_n}{\partial x_n}
-        = -\Delta t \frac{\partial \bar{f}_n}{\partial x_n}
-    \f]
-    Thus this iteration matrix, \f$W^\ast\f$, is
-    \f[
-      W^\ast = \alpha \frac{\partial \mathcal{F}_n}{\partial \dot{x}_n}
-             + \beta  \frac{\partial \mathcal{F}_n}{\partial x_n}
-             = \frac{1}{\Delta t} \Delta t
-             + (1) \left( - \Delta t \frac{\partial \bar{f}_n}{\partial x_n}
-                   \right)
-    \f]
-    or simply
-    \f[
-      W^\ast = 1 - \Delta t \frac{\partial \bar{f}_n}{\partial x_n}
-    \f]
-    Note that \f$W^\ast\f$ is not the same as \f$W\f$ from above
-    (i.e., \f$W = \frac{1}{\Delta t} - \frac{\partial \bar{f}_n}{\partial
-    x_n}\f$).  But we should <b>not</b> infer from this is that
-    \f$\alpha = 1\f$ or \f$\beta = -\Delta t\f$, as those definitions
-    are unchanged (i.e., \f$\alpha \equiv \frac{\partial \dot{x}_n(x_n)}
-    {\partial x_n} = \frac{1}{\Delta t}\f$ and \f$\beta \equiv
-    \frac{\partial x_n}{\partial x_n} = 1 \f$).  However, the mass
-    matrix, \f$M\f$, the Jacobian, \f$J\f$ and the residual,
-    \f$-\mathcal{F}_n\f$, all need to include \f$\Delta t\f$ in
-    their evaluations (i.e., be included in the ModelEvaluator
-    return values for these terms).
-
-    <b> Dangers of explicitly including time-derivative definition.</b>
-    If we explicitly include the time-derivative defintion for
-    Backward Euler, we find for our simple implicit ODE,
-    \f[
-      \mathcal{F}_n = \frac{x_n - x_{n-1}}{\Delta t} - \bar{f}(x_n,t_n) = 0
-    \f]
-    that the iteration matrix is
-    \f[
-      W^{\ast\ast} =
-               \alpha \frac{\partial \mathcal{F}_n}{\partial \dot{x}_n}
-             + \beta  \frac{\partial \mathcal{F}_n}{\partial x_n}
-             = \frac{1}{\Delta t} (0)
-             + (1) \left(\frac{1}{\Delta t}
-                         - \frac{\partial \bar{f}_n}{\partial x_n}
-                   \right)
-    \f]
-    or simply
-    \f[
-      W^{\ast\ast} =
-        \frac{1}{\Delta t} - \frac{\partial \bar{f}_n}{\partial x_n}
-    \f]
-    which is the same as \f$W\f$ from above for Backward Euler, but
-    again we should <b>not</b> infer that \f$\alpha = \frac{1}{\Delta
-    t}\f$ or \f$\beta = -1\f$.  However the major drawback is the
-    mass matrix, \f$M\f$, the Jacobian, \f$J\f$, and the residual,
-    \f$-\mathcal{F}_n\f$ (i.e., the ModelEvaluator) are explicitly
-    written only for Backward Euler.  The application would need
-    to write separate ModelEvaluators for each stepper, thus
-    destroying the ability to re-use the ModelEvaluator with any
-    stepper.
+ *  For first-order ODEs, we can write the implicit ODE as
+ *  \f[
+ *    \mathcal{F}(\dot{x}_n,x_n,t_n) = 0
+ *  \f]
+ *  where \f$x_n\f$ is the solution vector, \f$\dot{x}\f$ is the
+ *  time derivative, \f$t_n\f$ is the time and \f$n\f$ indicates
+ *  the \f$n^{th}\f$ time level.  Note that \f$\dot{x}_n\f$ is
+ *  different for each time stepper and is a function of other
+ *  solution states, e.g., for Backward Euler,
+ *  \f[
+ *    \dot{x}_n(x_n) = \frac{x_n - x_{n-1}}{\Delta t}
+ *  \f]
+ *
+ *  <b> Defining the Iteration Matrix</b>
+ *
+ *  Often we use Newton's method or one of its variations to solve
+ *  for \f$x_n\f$, such as
+ *  \f[
+ *    \left[
+ *    \frac{\partial}{\partial x_n}
+ *    \left(
+ *      \mathcal{F}(\dot{x}_n,x_n,t_n)
+ *    \right)
+ *    \right] \Delta x_n^\nu = - \mathcal{F}(\dot{x}_n^\nu,x_n^\nu,t_n)
+ *  \f]
+ *  where \f$\Delta x_n^\nu = x_n^{\nu+1} - x_n^\nu\f$ and \f$\nu\f$
+ *  is the iteration index.  Using the chain rule for a function
+ *  with multiple variables, we can write
+ *  \f[
+ *    \left[
+ *
+ *    \frac{\partial \dot{x}_n(x_n) }{\partial x_n}
+ *    \frac{\partial}{\partial \dot{x}_n}
+ *    \left(
+ *      \mathcal{F}(\dot{x}_n,x_n,t_n)
+ *    \right)
+ *    +
+ *    \frac{\partial x_n}{\partial x_n}
+ *    \frac{\partial}{\partial x_n}
+ *    \left(
+ *      \mathcal{F}(\dot{x}_n,x_n,t_n)
+ *    \right)
+ *
+ *    \right] \Delta x_n^\nu = - \mathcal{F}(\dot{x}_n^\nu,x_n^\nu,t_n)
+ *  \f]
+ *  Defining the iteration matrix, \f$W\f$, we have
+ *  \f[
+ *    W \Delta x_n^\nu = - \mathcal{F}(\dot{x}_n^\nu,x_n^\nu,t_n)
+ *  \f]
+ *  using \f$\mathcal{F}_n = \mathcal{F}(\dot{x}_n,x_n,t_n)\f$, where
+ *  \f[
+ *    W = \alpha \frac{\partial \mathcal{F}_n}{\partial \dot{x}_n}
+ *      + \beta  \frac{\partial \mathcal{F}_n}{\partial x_n}
+ *  \f]
+ *  and
+ *  \f[
+ *    W = \alpha M + \beta J
+ *  \f]
+ *  where
+ *  \f[
+ *    \alpha \equiv \frac{\partial \dot{x}_n(x_n) }{\partial x_n},
+ *    \quad \quad
+ *    \beta \equiv \frac{\partial x_n}{\partial x_n} = 1,
+ *    \quad \quad
+ *    M = \frac{\partial \mathcal{F}_n}{\partial \dot{x}_n},
+ *    \quad \quad
+ *    J = \frac{\partial \mathcal{F}_n}{\partial x_n}
+ *  \f]
+ *  and \f$M\f$ is the mass matrix and \f$J\f$ is the Jacobian.
+ *
+ *  Note that sometimes it is helpful to set \f$\alpha=0\f$ and
+ *  \f$\beta = 1\f$ to obtain the Jacobian, \f$J\f$, from the
+ *  iteration matrix (i.e., ModelEvaluator), or set \f$\alpha=1\f$
+ *  and \f$\beta = 0\f$ to obtain the mass matrix, \f$M\f$, from
+ *  the iteration matrix (i.e., the ModelEvaluator).
+ *
+ *  As a concrete example, the time derivative for Backward Euler is
+ *  \f[
+ *    \dot{x}_n(x_n) = \frac{x_n - x_{n-1}}{\Delta t}
+ *  \f]
+ *  thus
+ *  \f[
+ *    \alpha \equiv \frac{\partial \dot{x}_n(x_n) }{\partial x_n}
+ *           = \frac{1}{\Delta t}
+ *    \quad \quad
+ *    \beta \equiv \frac{\partial x_n}{\partial x_n} = 1
+ *  \f]
+ *  and the iteration matrix for Backward Euler is
+ *  \f[
+ *    W = \frac{1}{\Delta t} \frac{\partial \mathcal{F}_n}{\partial \dot{x}_n}
+ *      + \frac{\partial \mathcal{F}_n}{\partial x_n}
+ *  \f]
+ *
+ *  <b> Dangers of multiplying through by \f$\Delta t\f$. </b>
+ *  In some time-integration schemes, the application might want
+ *  to multiply the governing equations by the time-step size,
+ *  \f$\Delta t\f$, for scaling or other reasons.  Here we illustrate
+ *  what that means and the complications that follow from it.
+ *
+ *  Starting with a simple implicit ODE and multiplying through by
+ *  \f$\Delta t\f$, we have
+ *  \f[
+ *    \mathcal{F}_n = \Delta t \dot{x}_n - \Delta t \bar{f}(x_n,t_n) = 0
+ *  \f]
+ *  For the Backward Euler stepper, we recall from above that
+ *  \f[
+ *    \dot{x}_n(x_n) = \frac{x_n - x_{n-1}}{\Delta t}
+ *    \quad\quad
+ *    \alpha \equiv \frac{\partial \dot{x}_n(x_n) }{\partial x_n}
+ *           = \frac{1}{\Delta t}
+ *    \quad \quad
+ *    \beta \equiv \frac{\partial x_n}{\partial x_n} = 1
+ *  \f]
+ *  and we can find for our simple implicit ODE, \f$\mathcal{F}_n\f$,
+ *  \f[
+ *    M = \frac{\partial \mathcal{F}_n}{\partial \dot{x}_n} = \Delta t,
+ *    \quad \quad
+ *    J = \frac{\partial \mathcal{F}_n}{\partial x_n}
+ *      = -\Delta t \frac{\partial \bar{f}_n}{\partial x_n}
+ *  \f]
+ *  Thus this iteration matrix, \f$W^\ast\f$, is
+ *  \f[
+ *    W^\ast = \alpha \frac{\partial \mathcal{F}_n}{\partial \dot{x}_n}
+ *           + \beta  \frac{\partial \mathcal{F}_n}{\partial x_n}
+ *           = \frac{1}{\Delta t} \Delta t
+ *           + (1) \left( - \Delta t \frac{\partial \bar{f}_n}{\partial x_n}
+ *                 \right)
+ *  \f]
+ *  or simply
+ *  \f[
+ *    W^\ast = 1 - \Delta t \frac{\partial \bar{f}_n}{\partial x_n}
+ *  \f]
+ *  Note that \f$W^\ast\f$ is not the same as \f$W\f$ from above
+ *  (i.e., \f$W = \frac{1}{\Delta t} - \frac{\partial \bar{f}_n}{\partial
+ *  x_n}\f$).  But we should <b>not</b> infer from this is that
+ *  \f$\alpha = 1\f$ or \f$\beta = -\Delta t\f$, as those definitions
+ *  are unchanged (i.e., \f$\alpha \equiv \frac{\partial \dot{x}_n(x_n)}
+ *  {\partial x_n} = \frac{1}{\Delta t}\f$ and \f$\beta \equiv
+ *  \frac{\partial x_n}{\partial x_n} = 1 \f$).  However, the mass
+ *  matrix, \f$M\f$, the Jacobian, \f$J\f$ and the residual,
+ *  \f$-\mathcal{F}_n\f$, all need to include \f$\Delta t\f$ in
+ *  their evaluations (i.e., be included in the ModelEvaluator
+ *  return values for these terms).
+ *
+ *  <b> Dangers of explicitly including time-derivative definition.</b>
+ *  If we explicitly include the time-derivative defintion for
+ *  Backward Euler, we find for our simple implicit ODE,
+ *  \f[
+ *    \mathcal{F}_n = \frac{x_n - x_{n-1}}{\Delta t} - \bar{f}(x_n,t_n) = 0
+ *  \f]
+ *  that the iteration matrix is
+ *  \f[
+ *    W^{\ast\ast} =
+ *             \alpha \frac{\partial \mathcal{F}_n}{\partial \dot{x}_n}
+ *           + \beta  \frac{\partial \mathcal{F}_n}{\partial x_n}
+ *           = \frac{1}{\Delta t} (0)
+ *           + (1) \left(\frac{1}{\Delta t}
+ *                       - \frac{\partial \bar{f}_n}{\partial x_n}
+ *                 \right)
+ *  \f]
+ *  or simply
+ *  \f[
+ *    W^{\ast\ast} =
+ *      \frac{1}{\Delta t} - \frac{\partial \bar{f}_n}{\partial x_n}
+ *  \f]
+ *  which is the same as \f$W\f$ from above for Backward Euler, but
+ *  again we should <b>not</b> infer that \f$\alpha = \frac{1}{\Delta
+ *  t}\f$ or \f$\beta = -1\f$.  However the major drawback is the
+ *  mass matrix, \f$M\f$, the Jacobian, \f$J\f$, and the residual,
+ *  \f$-\mathcal{F}_n\f$ (i.e., the ModelEvaluator) are explicitly
+ *  written only for Backward Euler.  The application would need
+ *  to write separate ModelEvaluators for each stepper, thus
+ *  destroying the ability to re-use the ModelEvaluator with any
+ *  stepper.
  *
  */
 template<class Scalar>

--- a/packages/tempus/src/Tempus_StepperLeapfrog_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperLeapfrog_decl.hpp
@@ -140,7 +140,7 @@ public:
     virtual bool isExplicit()         const {return true;}
     virtual bool isImplicit()         const {return false;}
     virtual bool isExplicitImplicit() const
-      {return isExplicit() and isImplicit();}
+      {return isExplicit() && isImplicit();}
     virtual bool isOneStepMethod()   const {return true;}
     virtual bool isMultiStepMethod() const {return !isOneStepMethod();}
     virtual OrderODE getOrderODE()   const {return SECOND_ORDER_ODE;}

--- a/packages/tempus/src/Tempus_StepperNewmarkExplicitAForm_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkExplicitAForm_decl.hpp
@@ -138,7 +138,7 @@ public:
     virtual bool isExplicit()         const {return true;}
     virtual bool isImplicit()         const {return false;}
     virtual bool isExplicitImplicit() const
-      {return isExplicit() and isImplicit();}
+      {return isExplicit() && isImplicit();}
     virtual bool isOneStepMethod()   const {return true;}
     virtual bool isMultiStepMethod() const {return !isOneStepMethod();}
     virtual void setUseFSAL(bool a) { this->useFSAL_ = a; this->isInitialized_ = false; }

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitAForm_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitAForm_decl.hpp
@@ -146,7 +146,7 @@ public:
     virtual bool isExplicit()         const {return false;}
     virtual bool isImplicit()         const {return true;}
     virtual bool isExplicitImplicit() const
-      {return isExplicit() and isImplicit();}
+      {return isExplicit() && isImplicit();}
     virtual bool isOneStepMethod()   const {return true;}
     virtual bool isMultiStepMethod() const {return !isOneStepMethod();}
     virtual void setUseFSAL(bool a) { this->setUseFSALTrueOnly(a); }

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitDForm_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitDForm_decl.hpp
@@ -134,7 +134,7 @@ class StepperNewmarkImplicitDForm : virtual public Tempus::StepperImplicit<Scala
     virtual bool isExplicit()         const {return false;}
     virtual bool isImplicit()         const {return true;}
     virtual bool isExplicitImplicit() const
-      {return isExplicit() and isImplicit();}
+      {return isExplicit() && isImplicit();}
     virtual bool isOneStepMethod()   const {return true;}
     virtual bool isMultiStepMethod() const {return !isOneStepMethod();}
     virtual OrderODE getOrderODE()   const {return SECOND_ORDER_ODE;}

--- a/packages/tempus/src/Tempus_StepperOperatorSplit_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperOperatorSplit_decl.hpp
@@ -156,7 +156,7 @@ public:
       return isImplicit;
     }
     virtual bool isExplicitImplicit() const
-      {return isExplicit() and isImplicit();}
+      {return isExplicit() && isImplicit();}
     virtual bool isOneStepMethod()   const
     {
       bool isOneStepMethod = true;

--- a/packages/tempus/src/Tempus_StepperOperatorSplit_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperOperatorSplit_impl.hpp
@@ -286,7 +286,7 @@ void StepperOperatorSplit<Scalar>::takeStep(
     bool pass = true;
     typename std::vector<Teuchos::RCP<Stepper<Scalar> > >::iterator
       subStepperIter = subStepperList_.begin();
-    for (; subStepperIter < subStepperList_.end() and pass; subStepperIter++) {
+    for (; subStepperIter < subStepperList_.end() && pass; subStepperIter++) {
 
       stepperOSAppAction_->execute(solutionHistory, thisStepper,
         StepperOperatorSplitAppAction<Scalar>::ACTION_LOCATION::BEFORE_STEPPER);

--- a/packages/tempus/src/Tempus_StepperRKBase.hpp
+++ b/packages/tempus/src/Tempus_StepperRKBase.hpp
@@ -150,7 +150,7 @@ public:
         c(i) = values[i];
     }
 
-    if (tableauPL->isParameter("bstar") and
+    if (tableauPL->isParameter("bstar") &&
         tableauPL->get<std::string>("bstar") != "") {
       bstar.size(Teuchos::as<int>(numStages));
       // read in the bstar vector

--- a/packages/tempus/src/Tempus_StepperRKButcherTableau.hpp
+++ b/packages/tempus/src/Tempus_StepperRKButcherTableau.hpp
@@ -2518,8 +2518,8 @@ public:
   void setGammaType(std::string gammaType)
   {
     TEUCHOS_TEST_FOR_EXCEPTION(
-      !(gammaType == "3rd Order A-stable" or
-        gammaType == "2nd Order L-stable" or
+      !(gammaType == "3rd Order A-stable" ||
+        gammaType == "2nd Order L-stable" ||
         gammaType == "gamma"), std::logic_error,
       "gammaType needs to be '3rd Order A-stable', '2nd Order L-stable' "
       "or 'gamma'.");

--- a/packages/tempus/src/Tempus_StepperStaggeredForwardSensitivity_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperStaggeredForwardSensitivity_decl.hpp
@@ -108,14 +108,14 @@ public:
       {return Scalar(1.0e+99);}
 
     virtual bool isExplicit()         const
-      {return stateStepper_->isExplicit() or sensitivityStepper_->isExplicit();}
+      {return stateStepper_->isExplicit() || sensitivityStepper_->isExplicit();}
     virtual bool isImplicit()         const
-      {return stateStepper_->isImplicit() or sensitivityStepper_->isImplicit();}
+      {return stateStepper_->isImplicit() || sensitivityStepper_->isImplicit();}
     virtual bool isExplicitImplicit() const
-      {return isExplicit() and isImplicit();}
+      {return isExplicit() && isImplicit();}
 
     virtual bool isOneStepMethod()   const
-      {return stateStepper_->isOneStepMethod() and
+      {return stateStepper_->isOneStepMethod() &&
               sensitivityStepper_->isOneStepMethod();}
     virtual bool isMultiStepMethod() const {return !isOneStepMethod();}
 

--- a/packages/tempus/src/Tempus_StepperTrapezoidal_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperTrapezoidal_decl.hpp
@@ -126,7 +126,7 @@ public:
     virtual bool isExplicit()         const {return false;}
     virtual bool isImplicit()         const {return true;}
     virtual bool isExplicitImplicit() const
-      {return isExplicit() and isImplicit();}
+      {return isExplicit() && isImplicit();}
     virtual bool isOneStepMethod()   const {return true;}
     virtual bool isMultiStepMethod() const {return !isOneStepMethod();}
     virtual void setUseFSAL(bool a) { this->setUseFSALTrueOnly(a); }

--- a/packages/tempus/src/Tempus_Stepper_impl.hpp
+++ b/packages/tempus/src/Tempus_Stepper_impl.hpp
@@ -251,7 +251,7 @@ void validExplicitODE(
   typedef Thyra::ModelEvaluatorBase MEB;
   const MEB::InArgs<Scalar>  inArgs  = model->createInArgs();
   const MEB::OutArgs<Scalar> outArgs = model->createOutArgs();
-  const bool supports = inArgs.supports(MEB::IN_ARG_x) and
+  const bool supports = inArgs.supports(MEB::IN_ARG_x) &&
                         outArgs.supports(MEB::OUT_ARG_f);
 
   TEUCHOS_TEST_FOR_EXCEPTION( supports == false, std::logic_error,
@@ -278,8 +278,8 @@ void validSecondOrderExplicitODE(
   typedef Thyra::ModelEvaluatorBase MEB;
   const MEB::InArgs<Scalar>  inArgs  = model->createInArgs();
   const MEB::OutArgs<Scalar> outArgs = model->createOutArgs();
-  const bool supports = inArgs.supports(MEB::IN_ARG_x) and
-                        inArgs.supports(MEB::IN_ARG_x_dot) and
+  const bool supports = inArgs.supports(MEB::IN_ARG_x) &&
+                        inArgs.supports(MEB::IN_ARG_x_dot) &&
                         outArgs.supports(MEB::OUT_ARG_f);
 
   TEUCHOS_TEST_FOR_EXCEPTION( supports == false, std::logic_error,
@@ -309,12 +309,12 @@ void validImplicitODE_DAE(
   typedef Thyra::ModelEvaluatorBase MEB;
   const MEB::InArgs<Scalar>  inArgs  = model->createInArgs();
   const MEB::OutArgs<Scalar> outArgs = model->createOutArgs();
-  const bool supports = inArgs.supports(MEB::IN_ARG_x) and
-                        inArgs.supports(MEB::IN_ARG_x_dot) and
-                        inArgs.supports(MEB::IN_ARG_alpha) and
-                        inArgs.supports(MEB::IN_ARG_beta) and
-                       !inArgs.supports(MEB::IN_ARG_W_x_dot_dot_coeff) and
-                        outArgs.supports(MEB::OUT_ARG_f) and
+  const bool supports = inArgs.supports(MEB::IN_ARG_x) &&
+                        inArgs.supports(MEB::IN_ARG_x_dot) &&
+                        inArgs.supports(MEB::IN_ARG_alpha) &&
+                        inArgs.supports(MEB::IN_ARG_beta) &&
+                       !inArgs.supports(MEB::IN_ARG_W_x_dot_dot_coeff) &&
+                        outArgs.supports(MEB::OUT_ARG_f) &&
                         outArgs.supports(MEB::OUT_ARG_W);
 
   TEUCHOS_TEST_FOR_EXCEPTION( supports == false, std::logic_error,
@@ -354,13 +354,13 @@ void validSecondOrderODE_DAE(
   typedef Thyra::ModelEvaluatorBase MEB;
   const MEB::InArgs<Scalar>  inArgs  = model->createInArgs();
   const MEB::OutArgs<Scalar> outArgs = model->createOutArgs();
-  const bool supports = inArgs.supports(MEB::IN_ARG_x) and
-                        inArgs.supports(MEB::IN_ARG_x_dot) and
-                        inArgs.supports(MEB::IN_ARG_x_dot_dot) and
-                        inArgs.supports(MEB::IN_ARG_alpha) and
-                        inArgs.supports(MEB::IN_ARG_beta) and
-                        inArgs.supports(MEB::IN_ARG_W_x_dot_dot_coeff) and
-                        outArgs.supports(MEB::OUT_ARG_f) and
+  const bool supports = inArgs.supports(MEB::IN_ARG_x) &&
+                        inArgs.supports(MEB::IN_ARG_x_dot) &&
+                        inArgs.supports(MEB::IN_ARG_x_dot_dot) &&
+                        inArgs.supports(MEB::IN_ARG_alpha) &&
+                        inArgs.supports(MEB::IN_ARG_beta) &&
+                        inArgs.supports(MEB::IN_ARG_W_x_dot_dot_coeff) &&
+                        outArgs.supports(MEB::OUT_ARG_f) &&
                         outArgs.supports(MEB::OUT_ARG_W);
 
   TEUCHOS_TEST_FOR_EXCEPTION( supports == false, std::logic_error,

--- a/packages/tempus/src/Tempus_TimeStepControlStrategyIntegralController.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategyIntegralController.hpp
@@ -151,7 +151,7 @@ public:
     // new (optimal) suggested time step
     dt = beta * dt;
 
-    if (workingState->getSolutionStatus() == Status::PASSED or
+    if (workingState->getSolutionStatus() == Status::PASSED ||
         workingState->getSolutionStatus() == Status::WORKING) {
       if(lastStepRejected_){
          dt = std::min(dt, workingState->getTimeStep());
@@ -233,8 +233,8 @@ public:
     "Error - Invalid value of Minimum Safety Factory= " << facMin_ << "!  \n"
     << "Minimum Safety Factor must be > 0.0.\n");
 
-    TEUCHOS_TEST_FOR_EXCEPTION(((controller_ != "I") and
-                                (controller_ != "PI") and
+    TEUCHOS_TEST_FOR_EXCEPTION(((controller_ != "I") &&
+                                (controller_ != "PI") &&
                                 (controller_ != "PID")), std::invalid_argument,
     "Error - Invalid choice of Controller Type = " << controller_ << "!  \n"
     << "Valid Choice are ['I', 'PI', 'PID'].\n");

--- a/packages/tempus/src/Tempus_TimeStepControl_impl.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControl_impl.hpp
@@ -148,7 +148,7 @@ void TimeStepControl<Scalar>::initialize() const
     <<getMaxRelError()<<")\n");
 
   TEUCHOS_TEST_FOR_EXCEPTION(
-    (getStepType() != "Constant" and getStepType() != "Variable"),
+    (getStepType() != "Constant" && getStepType() != "Variable"),
     std::out_of_range,
       "Error - 'Step Type' does not equal one of these:\n"
     << "  'Constant' - Integrator will take constant time step sizes.\n"
@@ -403,14 +403,14 @@ bool TimeStepControl<Scalar>::timeInRange(const Scalar time) const
   const bool test1 = getInitTime() - absTolInit <= time;
   const bool test2 = time < getFinalTime() - absTolFinal;
 
-  return (test1 and test2);
+  return (test1 && test2);
 }
 
 
 /// Test if index is within range: include initIndex and exclude finalIndex.
 template<class Scalar>
 bool TimeStepControl<Scalar>::indexInRange(const int iStep) const{
-  bool iir = (getInitIndex() <= iStep and iStep < getFinalIndex());
+  bool iir = (getInitIndex() <= iStep && iStep < getFinalIndex());
   return iir;
 }
 

--- a/packages/tempus/src/Tempus_WrapperModelEvaluatorPairPartIMEX_Basic_impl.hpp
+++ b/packages/tempus/src/Tempus_WrapperModelEvaluatorPairPartIMEX_Basic_impl.hpp
@@ -89,7 +89,7 @@ initialize()
 
   int numBlocks = zPVector->productSpace()->numBlocks();
 
-  TEUCHOS_TEST_FOR_EXCEPTION( !(0 <= numExplicitOnlyBlocks_ and
+  TEUCHOS_TEST_FOR_EXCEPTION( !(0 <= numExplicitOnlyBlocks_ &&
                                    numExplicitOnlyBlocks_ < numBlocks),
     std::logic_error,
     "Error - WrapperModelEvaluatorPairPartIMEX_Basic::initialize()\n"
@@ -437,7 +437,7 @@ evalModelImpl(const Thyra::ModelEvaluatorBase::InArgs<Scalar>  & inArgs,
   appImplicitInArgs.set_x_dot(x_dot);
   for (int i=0; i<implicitModel_->Np(); ++i) {
     // Copy over parameters except for the parameter for explicit-only vector!
-    if ((inArgs.get_p(i) != Teuchos::null) and (i != parameterIndex_))
+    if ((inArgs.get_p(i) != Teuchos::null) && (i != parameterIndex_))
       appImplicitInArgs.set_p(i, inArgs.get_p(i));
   }
 

--- a/packages/tempus/src/Tempus_WrapperModelEvaluatorPairPartIMEX_CombinedFSA_impl.hpp
+++ b/packages/tempus/src/Tempus_WrapperModelEvaluatorPairPartIMEX_CombinedFSA_impl.hpp
@@ -98,7 +98,7 @@ initialize()
 
   int numBlocks = zPVector->productSpace()->numBlocks();
 
-  TEUCHOS_TEST_FOR_EXCEPTION( !(0 <= this->numExplicitOnlyBlocks_ and
+  TEUCHOS_TEST_FOR_EXCEPTION( !(0 <= this->numExplicitOnlyBlocks_ &&
                                 this->numExplicitOnlyBlocks_ < numBlocks),
     std::logic_error,
     "Error - WrapperModelEvaluatorPairPartIMEX_CombinedFSA::initialize()\n"
@@ -351,7 +351,7 @@ evalModelImpl(const Thyra::ModelEvaluatorBase::InArgs<Scalar>  & inArgs,
   fsaImplicitInArgs.set_x_dot(x_dot);
   for (int i=0; i<fsaImplicitModel_->Np(); ++i) {
     // Copy over parameters except for the parameter for explicit-only vector!
-    if ((inArgs.get_p(i) != Teuchos::null) and (i != p_index))
+    if ((inArgs.get_p(i) != Teuchos::null) && (i != p_index))
       fsaImplicitInArgs.set_p(i, inArgs.get_p(i));
   }
 

--- a/packages/tempus/src/Tempus_WrapperModelEvaluatorPairPartIMEX_StaggeredFSA_impl.hpp
+++ b/packages/tempus/src/Tempus_WrapperModelEvaluatorPairPartIMEX_StaggeredFSA_impl.hpp
@@ -96,7 +96,7 @@ initialize()
 
   int numBlocks = zPVector->productSpace()->numBlocks();
 
-  TEUCHOS_TEST_FOR_EXCEPTION( !(0 <= this->numExplicitOnlyBlocks_ and
+  TEUCHOS_TEST_FOR_EXCEPTION( !(0 <= this->numExplicitOnlyBlocks_ &&
                                 this->numExplicitOnlyBlocks_ < numBlocks),
     std::logic_error,
     "Error - WrapperModelEvaluatorPairPartIMEX_StaggeredFSA::initialize()\n"
@@ -409,7 +409,7 @@ evalModelImpl(const Thyra::ModelEvaluatorBase::InArgs<Scalar>  & inArgs,
   fsaImplicitInArgs.set_x_dot(x_dot);
   for (int i=0; i<fsaImplicitModel_->Np(); ++i) {
     // Copy over parameters except for the parameter for explicit-only vector!
-    if ((inArgs.get_p(i) != Teuchos::null) and (i != p_index))
+    if ((inArgs.get_p(i) != Teuchos::null) && (i != p_index))
       fsaImplicitInArgs.set_p(i, inArgs.get_p(i));
   }
 

--- a/packages/tempus/test/BDF2/Tempus_BDF2Test.cpp
+++ b/packages/tempus/test/BDF2/Tempus_BDF2Test.cpp
@@ -695,7 +695,7 @@ TEUCHOS_UNIT_TEST(BDF2, VanDerPol)
 
     // Output finest temporal solution for plotting
     // This only works for ONE MPI process
-    if ((n == 0) or (n == nTimeStepSizes-1)) {
+    if ((n == 0) || (n == nTimeStepSizes-1)) {
       std::string fname = "Tempus_BDF2_VanDerPol-Ref.dat";
       if (n == 0) fname = "Tempus_BDF2_VanDerPol.dat";
       std::ofstream ftmp(fname);

--- a/packages/tempus/test/BackwardEuler/Tempus_BackwardEulerTest.cpp
+++ b/packages/tempus/test/BackwardEuler/Tempus_BackwardEulerTest.cpp
@@ -531,7 +531,7 @@ TEUCHOS_UNIT_TEST(BackwardEuler, VanDerPol)
 
     // Output finest temporal solution for plotting
     // This only works for ONE MPI process
-    if ((n == 0) or (n == nTimeStepSizes-1)) {
+    if ((n == 0) || (n == nTimeStepSizes-1)) {
       std::string fname = "Tempus_BackwardEuler_VanDerPol-Ref.dat";
       if (n == 0) fname = "Tempus_BackwardEuler_VanDerPol.dat";
       RCP<const SolutionHistory<double> > solutionHistory =

--- a/packages/tempus/test/DIRK/Tempus_DIRKTest.cpp
+++ b/packages/tempus/test/DIRK/Tempus_DIRKTest.cpp
@@ -619,7 +619,7 @@ TEUCHOS_UNIT_TEST(DIRK, VanDerPol)
 
     // Output finest temporal solution for plotting
     // This only works for ONE MPI process
-    if ((n == 0) or (n == nTimeStepSizes-1)) {
+    if ((n == 0) || (n == nTimeStepSizes-1)) {
       std::string fname = "Tempus_"+RKMethod+"_VanDerPol-Ref.dat";
       if (n == 0) fname = "Tempus_"+RKMethod+"_VanDerPol.dat";
       RCP<const SolutionHistory<double> > solutionHistory =

--- a/packages/tempus/test/ExplicitRK/Tempus_ExplicitRKTest.cpp
+++ b/packages/tempus/test/ExplicitRK/Tempus_ExplicitRKTest.cpp
@@ -577,7 +577,7 @@ TEUCHOS_UNIT_TEST(ExplicitRK, EmbeddedVanDerPol)
      const double L2norm = Thyra::norm_2(*xdiff);
 
      // Test number of steps, failures, and accuracy
-     if ((integratorChoice == "Embedded_Integrator_PID") or
+     if ((integratorChoice == "Embedded_Integrator_PID") ||
            (integratorChoice == "Embedded_Integrator_PID_General")) {
 
         const double absTol = pl->sublist(integratorChoice).

--- a/packages/tempus/test/ForwardEuler/Tempus_ForwardEulerTest.cpp
+++ b/packages/tempus/test/ForwardEuler/Tempus_ForwardEulerTest.cpp
@@ -379,7 +379,7 @@ TEUCHOS_UNIT_TEST(ForwardEuler, VanDerPol)
 
     // Output finest temporal solution for plotting
     // This only works for ONE MPI process
-    if ((n == 0) or (n == nTimeStepSizes-1)) {
+    if ((n == 0) || (n == nTimeStepSizes-1)) {
       std::string fname = "Tempus_ForwardEuler_VanDerPol-Ref.dat";
       if (n == 0) fname = "Tempus_ForwardEuler_VanDerPol.dat";
       RCP<const SolutionHistory<double> > solutionHistory =

--- a/packages/tempus/test/IMEX_RK/Tempus_IMEX_RKTest.cpp
+++ b/packages/tempus/test/IMEX_RK/Tempus_IMEX_RKTest.cpp
@@ -246,7 +246,7 @@ TEUCHOS_UNIT_TEST(IMEX_RK, VanDerPol)
 
       // Output finest temporal solution for plotting
       // This only works for ONE MPI process
-      if ((n == 0) or (n == nTimeStepSizes-1)) {
+      if ((n == 0) || (n == nTimeStepSizes-1)) {
         std::string fname = "Tempus_"+stepperName+"_VanDerPol-Ref.dat";
         if (n == 0) fname = "Tempus_"+stepperName+"_VanDerPol.dat";
         RCP<const SolutionHistory<double> > solutionHistory =

--- a/packages/tempus/test/IMEX_RK/Tempus_IMEX_RK_FSA.hpp
+++ b/packages/tempus/test/IMEX_RK/Tempus_IMEX_RK_FSA.hpp
@@ -182,7 +182,7 @@ void test_vdp_fsa(const bool use_combined_method,
       StepSize.push_back(dt);
 
       // Output finest temporal solution for plotting
-      if (comm->getRank() == 0 and ((n == 0) or (n == nTimeStepSizes-1))) {
+      if (comm->getRank() == 0 && ((n == 0) || (n == nTimeStepSizes-1))) {
         typedef Thyra::DefaultMultiVectorProductVector<double> DMVPV;
 
         std::string fname = "Tempus_"+stepperName+"_VanDerPol_Sens-Ref.dat";

--- a/packages/tempus/test/IMEX_RK_Partitioned/Tempus_IMEX_RK_PartitionedTest.cpp
+++ b/packages/tempus/test/IMEX_RK_Partitioned/Tempus_IMEX_RK_PartitionedTest.cpp
@@ -244,7 +244,7 @@ TEUCHOS_UNIT_TEST(IMEX_RK_Partitioned, VanDerPol)
 
       // Output finest temporal solution for plotting
       // This only works for ONE MPI process
-      if ((n == 0) or (n == nTimeStepSizes-1)) {
+      if ((n == 0) || (n == nTimeStepSizes-1)) {
         std::string fname = "Tempus_"+stepperName+"_VanDerPol-Ref.dat";
         if (n == 0) fname = "Tempus_"+stepperName+"_VanDerPol.dat";
         RCP<const SolutionHistory<double> > solutionHistory =

--- a/packages/tempus/test/IMEX_RK_Partitioned/Tempus_IMEX_RK_Partitioned_FSA.hpp
+++ b/packages/tempus/test/IMEX_RK_Partitioned/Tempus_IMEX_RK_Partitioned_FSA.hpp
@@ -226,7 +226,7 @@ void test_vdp_fsa(const std::string& method_name,
       StepSize.push_back(dt);
 
       // Output finest temporal solution for plotting
-      if ((n == 0) or (n == nTimeStepSizes-1)) {
+      if ((n == 0) || (n == nTimeStepSizes-1)) {
         typedef Thyra::DefaultMultiVectorProductVector<double> DMVPV;
 
         std::string fname = "Tempus_"+stepperName+"_VanDerPol_Sens-Ref.dat";

--- a/packages/tempus/test/OperatorSplit/Tempus_OperatorSplitTest.cpp
+++ b/packages/tempus/test/OperatorSplit/Tempus_OperatorSplitTest.cpp
@@ -198,7 +198,7 @@ TEUCHOS_UNIT_TEST(OperatorSplit, VanDerPol)
 
     // Output finest temporal solution for plotting
     // This only works for ONE MPI process
-    if ((n == 0) or (n == nTimeStepSizes-1)) {
+    if ((n == 0) || (n == nTimeStepSizes-1)) {
       std::string fname = "Tempus_OperatorSplit_VanDerPol-Ref.dat";
       if (n == 0) fname = "Tempus_OperatorSplit_VanDerPol.dat";
       RCP<const SolutionHistory<double> > solutionHistory =

--- a/packages/tempus/test/Subcycling/Tempus_SubcyclingTest.cpp
+++ b/packages/tempus/test/Subcycling/Tempus_SubcyclingTest.cpp
@@ -510,7 +510,7 @@ TEUCHOS_UNIT_TEST(Subcycling, VanDerPolOperatorSplit)
 
     // Output finest temporal solution for plotting
     // This only works for ONE MPI process
-    if ((n == 0) or (n == nTimeStepSizes-1)) {
+    if ((n == 0) || (n == nTimeStepSizes-1)) {
       std::string fname = "Tempus_Subcycling_VanDerPol-Ref.dat";
       if (n == 0) fname = "Tempus_Subcycling_VanDerPol.dat";
       writeSolution(fname, integrator->getSolutionHistory());

--- a/packages/tempus/test/Trapezoidal/Tempus_TrapezoidalTest.cpp
+++ b/packages/tempus/test/Trapezoidal/Tempus_TrapezoidalTest.cpp
@@ -390,7 +390,7 @@ TEUCHOS_UNIT_TEST(Trapezoidal, VanDerPol)
 
     // Output finest temporal solution for plotting
     // This only works for ONE MPI process
-    if ((n == 0) or (n == nTimeStepSizes-1)) {
+    if ((n == 0) || (n == nTimeStepSizes-1)) {
       std::string fname = "Tempus_Trapezoidal_VanDerPol-Ref.dat";
       if (n == 0) fname = "Tempus_Trapezoidal_VanDerPol.dat";
       RCP<const SolutionHistory<double> > solutionHistory =


### PR DESCRIPTION
The ROL team has received requests from Windows users to remove the
alternative logical operators 'and' and 'or' in favor of && and ||.
The C++ standard includes 'and' and 'or', of course. However, the
MS compiler only supports them in the -permissive mode, which
apparently isn't allowed in many companies, due to the quality
control niceties that the non-permissive (standard) mode provides.

Trilinos is not supporting Windows and do not have even platforms
to test on. This change should be straight forward, but there is
not any mechanism to prevent regression. Microsoft needs to support
the c++ standard!

Not sure all instances were found and there is no compiler flag
to throw on this.

@trilinos/tempus 
@trilinos/rol

## Motivation
See above

## Related Issues
* Closes #9017 

## Stakeholder Feedback
Not at this time.

## Testing
Passes all tests on Mac.
