### PR TITLE
comment out all the instances of TPETRA_DEPRECATED

### DIFF
--- a/packages/tpetra/core/src/Tpetra_BlockMultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockMultiVector_decl.hpp
@@ -457,19 +457,19 @@ public:
   ///   it, by calling the modify() method with the appropriate
   ///   template parameter.
   template<class TargetMemorySpace>
-  TPETRA_DEPRECATED
+  //TPETRA_DEPRECATED
   void sync () {
     mv_.template sync<typename TargetMemorySpace::memory_space> ();
   }
 
   /// \brief Update data to the host
-  TPETRA_DEPRECATED
+  //TPETRA_DEPRECATED
   void sync_host() {
     mv_.sync_host();
   }
 
   /// \brief Update data to the device
-  TPETRA_DEPRECATED
+  //TPETRA_DEPRECATED
   void sync_device() {
     mv_.sync_device();
   }
@@ -500,19 +500,19 @@ public:
   /// object's memory space, then mark the device's data as modified.
   /// Otherwise, mark the host's data as modified.
   template<class TargetMemorySpace>
-  TPETRA_DEPRECATED
+  //TPETRA_DEPRECATED
   void modify () {
     mv_.template modify<typename TargetMemorySpace::memory_space> ();
   }
 
   /// \brief Mark data as modified on the host
-  TPETRA_DEPRECATED
+  //TPETRA_DEPRECATED
   void modify_host() {
     mv_.modify_host();
   }
 
   /// \brief Mark data as modified on the device
-  TPETRA_DEPRECATED
+  //TPETRA_DEPRECATED
   void modify_device() {
     mv_.modify_device();
   }
@@ -589,8 +589,9 @@ public:
   /// \c little_vec_type typedef to deduce the correct return type;
   /// don't try to hard-code the return type yourself.
 #ifdef TPETRA_ENABLE_DEPRECATED_CODE
-  TPETRA_DEPRECATED little_host_vec_type getLocalBlock (const LO localRowIndex, const LO colIndex) const;
-#endif // TPETRA_DEPRECATED
+  //TPETRA_DEPRECATED 
+  little_host_vec_type getLocalBlock (const LO localRowIndex, const LO colIndex) const;
+#endif //TPETRA_DEPRECATED
 
   const_little_host_vec_type getLocalBlock(
     const LO localRowIndex, 

--- a/packages/tpetra/core/src/Tpetra_BlockVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockVector_decl.hpp
@@ -328,7 +328,8 @@ public:
   /// porting strategy to move from "classic" Tpetra to the Kokkos
   /// refactor version.
 #ifdef TPETRA_ENABLE_DEPRECATED_CODE
-  TPETRA_DEPRECATED little_host_vec_type getLocalBlock (const LO localRowIndex) const;
+  //TPETRA_DEPRECATED 
+  little_host_vec_type getLocalBlock (const LO localRowIndex) const;
 #endif
   const_little_host_vec_type getLocalBlock (const LO localRowIndex,
                                             Access::ReadOnlyStruct) const;

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -1303,7 +1303,7 @@ namespace Tpetra {
     /// it only tells us whether boundForAllLocalRows has a meaningful
     /// value on output.  We don't necessarily check whether all
     /// entries of boundPerLocalRow are the same.
-    TPETRA_DEPRECATED
+    //TPETRA_DEPRECATED
     void
     getNumEntriesPerLocalRowUpperBound (Teuchos::ArrayRCP<const size_t>& boundPerLocalRow,
                                         size_t& boundForAllLocalRows,

--- a/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
@@ -1435,7 +1435,7 @@ namespace Tpetra {
 
 #ifdef TPETRA_ENABLE_DEPRECATED_CODE
     //! Clear "modified" flags on both host and device sides.
-    TPETRA_DEPRECATED
+    //TPETRA_DEPRECATED
     void clear_sync_state ();
 
     /// \brief Update data on device or host only if data in the other
@@ -1457,17 +1457,17 @@ namespace Tpetra {
     ///   it, by calling the modify() method with the appropriate
     ///   template parameter.
     template<class TargetDeviceType>
-    TPETRA_DEPRECATED
+    //TPETRA_DEPRECATED
     void sync () {
       view_.template sync<TargetDeviceType> ();
     }
 
     //! Synchronize to Host
-    TPETRA_DEPRECATED
+    //TPETRA_DEPRECATED
     void sync_host ();
 
     //! Synchronize to Device
-    TPETRA_DEPRECATED
+    //TPETRA_DEPRECATED
     void sync_device ();
 #endif // TPETRA_ENABLE_DEPRECATED_CODE
 
@@ -1491,17 +1491,17 @@ namespace Tpetra {
     /// device type, then mark the device's data as modified.
     /// Otherwise, mark the host's data as modified.
     template<class TargetDeviceType>
-    TPETRA_DEPRECATED
+    //TPETRA_DEPRECATED
     void modify () {
       view_.template modify<TargetDeviceType> ();
     }
 
     //! Mark data as modified on the device side.
-    TPETRA_DEPRECATED
+    //TPETRA_DEPRECATED
     void modify_device ();
 
     //! Mark data as modified on the host side.
-    TPETRA_DEPRECATED
+    //TPETRA_DEPRECATED
     void modify_host ();
 #endif // TPETRA_ENABLE_DEPRECATED_CODE
 
@@ -1700,17 +1700,20 @@ namespace Tpetra {
     /// host_view_type hostView = DV.getLocalView<host_execution_space> ();
     /// \endcode
     template<class TargetDeviceType>
-    TPETRA_DEPRECATED typename std::remove_reference<decltype(std::declval<dual_view_type>().template view<TargetDeviceType>())>::type
+    //TPETRA_DEPRECATED 
+    typename std::remove_reference<decltype(std::declval<dual_view_type>().template view<TargetDeviceType>())>::type
     getLocalView () const
     {
       return view_.template view<TargetDeviceType>();
     }
 
     //! A local Kokkos::View of host memory. This is a low-level expert function - it requires you to call sync_host() and modify_host() on this MultiVector as needed.
-    TPETRA_DEPRECATED typename dual_view_type::t_host getLocalViewHost () const;
+    //TPETRA_DEPRECATED 
+    typename dual_view_type::t_host getLocalViewHost () const;
 
     //! A local Kokkos::View of device memory. This is a low-level expert function - it requires you to call sync_device() and modify_device() on this MultiVector as needed.
-    TPETRA_DEPRECATED typename dual_view_type::t_dev getLocalViewDevice () const;
+    //TPETRA_DEPRECATED 
+    typename dual_view_type::t_dev getLocalViewDevice () const;
 #endif
 
     //@}


### PR DESCRIPTION
pull out the deprecated warnings so that downstream doesn't see warnings while building with a "normal" build.