### PR TITLE
MueLu: fix agg export for multiple dofs per node

### DIFF
--- a/packages/muelu/src/Utils/MueLu_AggregationExportFactory_def.hpp
+++ b/packages/muelu/src/Utils/MueLu_AggregationExportFactory_def.hpp
@@ -186,7 +186,8 @@ namespace MueLu {
       dims_ = coords->getNumVectors();  //2D or 3D?
       if(numProcs > 1)
       {
-        {
+        if (aggregates->AggregatesCrossProcessors())
+        { // Do we want to use the map from aggregates here instead of the map from A? Using the map from A seems to be problematic with multiple dofs per node
           RCP<Import> coordImporter = Xpetra::ImportFactory<LocalOrdinal, GlobalOrdinal, Node>::Build(coords->getMap(), Amat->getColMap());
           RCP<Xpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::coordinateType, LocalOrdinal, GlobalOrdinal, Node> > ghostedCoords = Xpetra::MultiVectorFactory<typename Teuchos::ScalarTraits<Scalar>::coordinateType, LocalOrdinal, GlobalOrdinal, Node>::Build(Amat->getColMap(), dims_);
           ghostedCoords->doImport(*coords, *coordImporter, Xpetra::INSERT);
@@ -844,7 +845,10 @@ namespace MueLu {
     fout << indent;
     for(size_t i = 0; i < uniqueFine.size(); i++)
     {
-      fout << aggsOffset_ + vertex2AggId_[uniqueFine[i]] << " ";
+      if(vertex2AggId_[uniqueFine[i]]==-1)
+        fout << vertex2AggId_[uniqueFine[i]] << " ";
+      else
+        fout << aggsOffset_ + vertex2AggId_[uniqueFine[i]] << " ";
       if(i % 10 == 9)
         fout << endl << indent;
     }


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/muelu 

## Motivation
Aggregation export gives garbage when used for problems with multiple dofs per node (like elasticity). To fix this, ghost coordinates are no longer added when aggregates don't cross processors (no need for ghosts), which fixes the problems when there are multiple dofs per node.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

<!--- 
## Stakeholder Feedback
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
As far as I know, aggregation export is not tested.
Looking at the output in paraview, the aggregates for elasticity now resemble aggregates instead of a crazy blob of things. Scalar equations look the same as before (except for the "point cloud" which is also better now because it now gives aggregate labels to the nodes on processor interfaces).


## Additional Information
The map that is used to find ghost coordinates in the aggregation export might be wrong, in which case this just circumvents the problem instead of actually fixing it.
 