### PR TITLE
Turn off 3 Zoltan tests that fail  due to a bug in spectrummpi

### DIFF
--- a/cmake/std/PullRequestLinuxCuda10.1.243TestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxCuda10.1.243TestingSettings.cmake
@@ -129,11 +129,10 @@ set (KokkosCore_UnitTest_Cuda_MPI_1_EXTRA_ARGS
   "--gtest_filter=-cuda.debug_pin_um_to_host:cuda.debug_serial_execution"
   CACHE STRING "Temporary disable for CUDA PR testing")
 
-# Disable a few failing tests for initial release of Cuda 10.1.105 PR build
-# set (EpetraExt_inout_test_LL_MPI_4_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
-# set (EpetraExt_inout_test_MPI_4_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
-# set (Teko_testdriver_MPI_4_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
-# set (Zoltan2_fix4785_MPI_4_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
+# Disable a few failing tests for initial release of Cuda 10.1.243 PR build
+set (Zoltan_ch_simple_zoltan_parallel_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
+set (Zoltan_hg_simple_zoltan_parallel_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
+set (Zoltan_mpiMinLoc_MPI_4_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
 
 # Disable SEACAS tests that grep results out of stderr...
 set (SEACASIoss_create_path_fpp_DISABLE ON CACHE BOOL "Temporary disable due to jsrun polluting stderr")

--- a/cmake/std/PullRequestLinuxCuda10.1.243TestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxCuda10.1.243TestingSettings.cmake
@@ -130,6 +130,7 @@ set (KokkosCore_UnitTest_Cuda_MPI_1_EXTRA_ARGS
   CACHE STRING "Temporary disable for CUDA PR testing")
 
 # Disable a few failing tests for initial release of Cuda 10.1.243 PR build
+# these fail due to a bug in spectrum-mpi : see issue #8798 for details
 set (Zoltan_ch_simple_zoltan_parallel_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
 set (Zoltan_hg_simple_zoltan_parallel_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
 set (Zoltan_mpiMinLoc_MPI_4_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")


### PR DESCRIPTION
See #8798 for the discussion

@trilinos/framework 

## Motivation
Cleaning up testing for the vortex Dev->Master build

Tested by a manual build and ctest run on vortex