### PR TITLE
TrilinosCouplings: Fix scaling of CurlCurl in Maxwell example

### DIFF
--- a/packages/trilinoscouplings/examples/scaling/example_Maxwell.cpp
+++ b/packages/trilinoscouplings/examples/scaling/example_Maxwell.cpp
@@ -1713,7 +1713,7 @@ int main(int argc, char *argv[]) {
 
     // multiply by weighted measure
     IntrepidFSTools::multiplyMeasure<double>(HCurlsTransformedWeighted,
-                                             weightedMeasure, HCurlsTransformed);
+                                             weightedMeasureMuInv, HCurlsTransformed);
 
     // integrate to compute element stiffness matrix
     IntrepidFSTools::integrate<double>(stiffMatrixHCurl,


### PR DESCRIPTION
@trilinos/trilinoscouplings 

## Motivation
curl-curl term needs to be scales by 1/mu.