### PR TITLE
Framework: Intel oneapi blake initial build

### DIFF
--- a/cmake/std/atdm/blake/all_supported_builds.sh
+++ b/cmake/std/atdm/blake/all_supported_builds.sh
@@ -1,0 +1,7 @@
+
+export ATDM_CONFIG_CTEST_S_BUILD_NAME_PREFIX=Trilinos-atdm-blake-
+
+export ATDM_CONFIG_ALL_SUPPORTED_BUILDS=(
+  oneapi-debug-openmp
+  oneapi-opt-openmp
+  )

--- a/cmake/std/atdm/blake/environment.sh
+++ b/cmake/std/atdm/blake/environment.sh
@@ -1,0 +1,86 @@
+################################################################################
+#
+# Set up env on blake (intel skylake) for ATMD builds of Trilinos
+#
+# This source script gets the settings from the ATDM_CONFIG_BUILD_NAME var.
+#
+################################################################################
+
+if [ "$ATDM_CONFIG_COMPILER" == "DEFAULT" ] ; then
+    export ATDM_CONFIG_COMPILER=ONEAPI_2021.2.0
+elif [ "$ATDM_CONFIG_COMPILER" == "ONEAPI-2021.2.0" ] ; then
+    export ATDM_CONFIG_COMPILER=ONEAPI_2021.2.0
+elif [ "$ATDM_CONFIG_COMPILER" == "ONEAPI-2021.1.1" ] ; then
+    export ATDM_CONFIG_COMPILER=ONEAPI_2021.1.1
+fi
+
+echo "Using blake compiler stack $ATDM_CONFIG_COMPILER to build $ATDM_CONFIG_BUILD_TYPE code with Kokkos node type $ATDM_CONFIG_NODE_TYPE"
+
+export ATDM_CONFIG_USE_NINJA=ON
+export ATDM_CONFIG_BUILD_COUNT=12
+# export ATDM_CONFIG_CMAKE_JOB_POOL_LINK=2
+# NOTE: Above, currently setting CMAKE_JOB_POOL_LINK results in build
+# failures with Ninja.  See https://gitlab.kitware.com/snl/project-1/issues/60
+
+module purge
+
+if [ "$ATDM_CONFIG_NODE_TYPE" == "OPENMP" ] ; then
+    export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=8
+    export OMP_NUM_THREADS=2
+else
+    export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=16
+fi
+
+if [ "$ATDM_CONFIG_COMPILER" == "ONEAPI" ]; then
+    module load devpack/20210420/openmpi/4.0.5/intel/oneapi/2021.2.0
+
+    export OMPI_CXX=`which icpx`
+    export OMPI_CC=`which icx`
+    export OMPI_FC=`which ifx`
+    export ATDM_CONFIG_LAPACK_LIBS="-mkl"
+    export ATDM_CONFIG_BLAS_LIBS="-mkl"
+elif [ "$ATDM_CONFIG_COMPILER" == "ONEAPI_2021.2.0" ]; then
+    module load devpack/20210420/openmpi/4.0.5/intel/oneapi/2021.2.0
+
+    export OMPI_CXX=`which icpx`
+    export OMPI_CC=`which icx`
+    export OMPI_FC=`which ifx`
+    export ATDM_CONFIG_LAPACK_LIBS="-mkl"
+    export ATDM_CONFIG_BLAS_LIBS="-mkl"
+elif [ "$ATDM_CONFIG_COMPILER" == "ONEAPI_2021.1.1" ]; then
+    module load devpack/20210310/openmpi/4.0.5/intel/oneapi/2021.1.1
+
+    export OMPI_CXX=`which icpx`
+    export OMPI_CC=`which icx`
+    export OMPI_FC=`which ifx`
+    export ATDM_CONFIG_LAPACK_LIBS="-mkl"
+    export ATDM_CONFIG_BLAS_LIBS="-mkl"
+else
+    echo
+    echo "***"
+    echo "*** ERROR: COMPILER=$ATDM_CONFIG_COMPILER is not supported on this system!"
+    echo "***"
+    return
+fi
+
+export ATDM_CONFIG_USE_HWLOC=OFF
+export ATDM_CONFIG_HDF5_LIBS="-L${HDF5_ROOT}/lib;${HDF5_ROOT}/lib/libhdf5_hl.a;${HDF5_ROOT}/lib/libhdf5.a;-lz;-ldl"
+export ATDM_CONFIG_NETCDF_LIBS="-L${NETCDF_ROOT}/lib;-L${HDF5_ROOT}/lib;${NETCDF_ROOT}/lib64/libnetcdf.a;${PNETCDF_ROOT}/lib64/libpnetcdf.a;${ATDM_CONFIG_HDF5_LIBS};-lcurl"
+
+
+# Set MPI wrappers
+export MPICC=`which mpicc`
+export MPICXX=`which mpicxx`
+export MPIF90=`which mpif90`
+
+export ATDM_CONFIG_MPI_EXEC=mpirun
+export ATDM_CONFIG_MPI_PRE_FLAGS=""
+export ATDM_CONFIG_MPI_EXEC_NUMPROCS_FLAG=--np
+
+# Set the default compilers
+export CC=mpicc
+export CXX=mpicxx
+export FC=mpif77
+export F90=mpif90
+
+export ATDM_CONFIG_COMPLETED_ENV_SETUP=TRUE

--- a/cmake/std/atdm/utils/get_known_system_info.sh
+++ b/cmake/std/atdm/utils/get_known_system_info.sh
@@ -101,6 +101,9 @@ hostnameMatchSystemName=
 if [[ $realHostname == "hansen"* ]] ; then
   hostnameMatch=hansen
   hostnameMatchSystemName=shiller
+elif [[ $realHostname == *"blake"* ]] ; then
+  hostnameMatch=blake
+  hostnameMatchSystemName=blake
 elif [[ $realHostname == "shiller"* ]] ; then
   hostnameMatch=shiller
   hostnameMatchSystemName=shiller

--- a/cmake/std/atdm/utils/set_build_options.sh
+++ b/cmake/std/atdm/utils/set_build_options.sh
@@ -108,6 +108,8 @@ elif atdm_match_any_buildname_keyword cuda-10.1-gnu-7.2.0 cuda-10.1_gnu-7.2.0 \
   export ATDM_CONFIG_COMPILER=CUDA-10.1_GNU-7.2.0
 elif atdm_match_buildname_keyword cuda-10.1; then
   export ATDM_CONFIG_COMPILER=CUDA-10.1
+elif atdm_match_buildname_keyword cuda-10.2; then
+  export ATDM_CONFIG_COMPILER=CUDA-10.2
 elif atdm_match_buildname_keyword cuda-10; then
   export ATDM_CONFIG_COMPILER=CUDA-10
 elif atdm_match_buildname_keyword cuda; then
@@ -124,18 +126,22 @@ elif atdm_match_buildname_keyword gnu-7.4.0; then
   export ATDM_CONFIG_COMPILER=GNU-7.4.0
 elif atdm_match_buildname_keyword gnu; then
   export ATDM_CONFIG_COMPILER=GNU
-elif atdm_match_buildname_keyword intel-17.0.1; then
- export ATDM_CONFIG_COMPILER=INTEL-17.0.1
+elif atdm_match_buildname_keyword oneapi-2021.1.1; then
+  export ATDM_CONFIG_COMPILER=ONEAPI-2021.1.1
+elif atdm_match_buildname_keyword oneapi-2021.2.0; then
+  export ATDM_CONFIG_COMPILER=ONEAPI-2021.2.0
+elif atdm_match_buildname_keyword oneapi; then
+  export ATDM_CONFIG_COMPILER=ONEAPI
 elif atdm_match_buildname_keyword intel-17; then
- export ATDM_CONFIG_COMPILER=INTEL-17.0.1
+  export ATDM_CONFIG_COMPILER=INTEL-17.0.1
 elif atdm_match_buildname_keyword intel-18.0.2; then
- export ATDM_CONFIG_COMPILER=INTEL-18.0.2
+  export ATDM_CONFIG_COMPILER=INTEL-18.0.2
 elif atdm_match_buildname_keyword intel-18.0.5; then
- export ATDM_CONFIG_COMPILER=INTEL-18.0.5
+  export ATDM_CONFIG_COMPILER=INTEL-18.0.5
 elif atdm_match_buildname_keyword intel-18; then
- export ATDM_CONFIG_COMPILER=INTEL-18.0.5
+  export ATDM_CONFIG_COMPILER=INTEL-18.0.5
 elif atdm_match_buildname_keyword intel; then
- export ATDM_CONFIG_COMPILER=INTEL
+  export ATDM_CONFIG_COMPILER=INTEL
 elif atdm_match_buildname_keyword clang-3.9.0; then
   export ATDM_CONFIG_COMPILER=CLANG-3.9.0
 elif atdm_match_buildname_keyword clang-5.0.1; then


### PR DESCRIPTION
@trilinos/framework 

## Motivation
I use the ATDM configuration to test new compiler/tpl installs on testbed machines.  These changes are to integrate the new oneAPI compiler and tpls into the ATDM config system on blake.  These are the new OneAPI compilers version 2021.1.1 (icx and icpx)

## Testing
This will get through configure and build but only passes ~67% of tests

```
67% tests passed, 630 tests failed out of 1928

Subproject Time Summary:
Adelus                     =  13.00 sec*proc (4 tests)
Amesos2                    =  11.50 sec*proc (6 tests)
Belos                      = 310.80 sec*proc (125 tests)
Ifpack2                    = 140.28 sec*proc (44 tests)
Intrepid2                  = 221.97 sec*proc (163 tests)
Kokkos                     = 1329.10 sec*proc (34 tests)
KokkosKernels              = 357.46 sec*proc (13 tests)
MueLu                      = 1055.04 sec*proc (89 tests)
NOX                        = 261.78 sec*proc (108 tests)
Panzer                     = 1033.52 sec*proc (181 tests)
Phalanx                    =  45.48 sec*proc (32 tests)
Rythmos                    = 216.61 sec*proc (83 tests)
SEACAS                     = 108.11 sec*proc (27 tests)
STK                        =  21.89 sec*proc (2 tests)
Sacado                     =  92.72 sec*proc (299 tests)
Stratimikos                = 131.42 sec*proc (39 tests)
Teko                       = 304.84 sec*proc (18 tests)
Teuchos                    = 164.74 sec*proc (146 tests)
Thyra                      = 193.15 sec*proc (82 tests)
Tpetra                     = 19703.02 sec*proc (259 tests)
TrilinosATDMConfigTests    =  64.91 sec*proc (12 tests)
TrilinosBuildStats         =   0.78 sec*proc (1 test)
Xpetra                     =  45.67 sec*proc (18 tests)
Zoltan2                    = 480.70 sec*proc (143 tests)
```

## To reproduce on blake
```
module purge

TRILINOS_DIR=/ascldap/users/jfrye/trilinos-testing/Trilinos
source $TRILINOS_DIR/cmake/std/atdm/load-env.sh oneapi-2021.1.1

cmake \                                                                                                                                                   
  -DTrilinos_CONFIGURE_OPTIONS_FILE:STRING=cmake/std/atdm/ATDMDevEnv.cmake \                                                                              
  -DTrilinos_ENABLE_TESTS=ON \                                                                                                                            
  -DTrilinos_ENABLE_ALL_PACKAGES=ON \                                                                                                                     
  $TRILINOS_DIR                                                                                                                                                                                                                       

make -j16
ctest -j4
```