### PR TITLE
Intrepid2: fix 8801 (second attempt)

### DIFF
--- a/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefJacobian.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefJacobian.hpp
@@ -238,7 +238,7 @@ namespace Intrepid2 {
           const int numDiagonals = data.extent_int(2) - blockWidth * blockWidth;
           const int spaceDim     = blockWidth + numDiagonals;
           
-          PointScalar det;
+          PointScalar det = 1.0;
           switch (blockWidth)
           {
             case 0:
@@ -321,7 +321,7 @@ namespace Intrepid2 {
           const int numDiagonals = data.extent_int(2) - blockWidth * blockWidth;
           const int spaceDim     = blockWidth + numDiagonals;
           
-          PointScalar det;
+          PointScalar det = 1.0;
           switch (blockWidth)
           {
             case 0:
@@ -381,7 +381,7 @@ namespace Intrepid2 {
           const int numDiagonals = jacobian.extent_int(2) - blockWidth * blockWidth;
           const int spaceDim     = blockWidth + numDiagonals;
                   
-          PointScalar det;
+          PointScalar det = 1.0;
           switch (blockWidth)
           {
             case 0:


### PR DESCRIPTION
@trilinos/intrepid2 

## Motivation
The test failure when building optimized with CUDA 10.1.243, documented in #8801, has recurred.  This is an issue that is sensitive to compilation details: it does not occur in debug builds, and the previous fix was to replace a 2D MDRangePolicy with a 1D RangePolicy in the Kokkos::parallel_for.  Adding console output immediately prior to the parallel_for can make the issue go away.  Switching back to a 1D RangePolicy does not fix it.  What I found does fix it, at least for the moment, is to replace the lambda in the body of the parallel_for with a functor.  That's what this PR does.

While I was at it, I also resolved a few uninitialized variable warnings.

## Related Issues
Closes #8801 (for now).