### PR TITLE
Adjust default parameters of GmresSingleReduce

### DIFF
--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresSingleReduce.hpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresSingleReduce.hpp
@@ -28,7 +28,6 @@ public:
     base_type::Gmres (),
     stepSize_ (1)
   {
-    //this->input_.computeRitzValues = true;
     this->input_.computeRitzValues = false;
   }
 
@@ -36,7 +35,6 @@ public:
     base_type::Gmres (A),
     stepSize_ (1)
   {
-    //this->input_.computeRitzValues = true;
     this->input_.computeRitzValues = false;
   }
 
@@ -67,7 +65,7 @@ protected:
     if (ortho == "MGS" || ortho == "CGS" || ortho == "CGS2") {
       this->input_.orthoType = ortho;
     } else {
-      this->input_.orthoType = "CGS";
+      this->input_.orthoType = "MGS";
       //base_type::setOrthogonalizer (ortho);
     }
   }

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresSingleReduce.hpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresSingleReduce.hpp
@@ -91,7 +91,7 @@ private:
     int rank = 1;
     if (input.orthoType != "CGS") {
       vec_type Qn  = * (Q.getVectorNonConst (n));
-      if (input.needToReortho) {
+      if (input.delayedNorm) {
         // compute norm
         real_type newNorm (0.0);
         {
@@ -191,7 +191,7 @@ private:
     // ----------------------------------------------------------
     Teuchos::Range1D index_new (n+1, n+1);
     MV Qnew = * (Q.subView (index_new));
-    if (input.needToReortho) {
+    if (input.delayedNorm) {
       // check
       real_type prevNorm = STS::real (T(n, n));
       TEUCHOS_TEST_FOR_EXCEPTION
@@ -294,7 +294,7 @@ private:
 
     real_type newNorm = STS::real (H(n+1, n));
     if (newNorm <= oldNorm * tolOrtho) {
-      if (input.needToReortho) {
+      if (input.delayedNorm) {
         // something might have gone wrong, and let re-norm take care of
         if (outPtr != nullptr) {
           *outPtr << " > newNorm = " << newNorm << " -> H(" << n+1 << ", " << n << ") = one"
@@ -382,7 +382,7 @@ private:
     real_type oldNorm = STS::real (H(n+1, n));
 
     // reorthogonalize if requested
-    if (input.needToReortho) {
+    if (input.delayedNorm) {
       // Q(:,0:j+1)'*Q(:,j+1)
       dense_matrix_type w_all (Teuchos::View, WORK, n+2, 1, 0, n);
       dense_matrix_type w_prev (Teuchos::View, WORK, n+1, 1, 0, n);
@@ -575,7 +575,7 @@ private:
     y[0] = SC {r_norm};
     const int s = getStepSize ();
     // main loop
-    bool delayed_ortho = ((input.orthoType == "MGS" && input.needToReortho) ||
+    bool delayed_ortho = ((input.orthoType == "MGS" && input.delayedNorm) ||
                           (input.orthoType == "CGS2"));
     int iter = 0;
     while (output.numIters < input.maxNumIters && ! output.converged) {

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_Krylov_parameters.hpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_Krylov_parameters.hpp
@@ -53,6 +53,7 @@ public:
   int stepSize = 5;
   bool needToScale = true;
   bool needToReortho = false;
+  bool delayedNorm = true;
   int maxOrthoSteps = 0;
   std::string orthoType {"ICGS"};
   std::string precoSide {"none"};


### PR DESCRIPTION

@trilinos/belos 

## Motivation
This PR adjusts the default parameters for GmresSingleReduce in belos/tpetra (to make it more robust/efficient):
- Previously, single-reduce CGS with Newton basis was the default
- Now, single-reduce MGS with delayed normalization is the default, without Newton basis
