### PR TITLE
Turn on Intrepid2 in UVM = OFF build

### DIFF
--- a/cmake/std/PullRequestLinuxCuda10.1.105uvmTestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxCuda10.1.105uvmTestingSettings.cmake
@@ -127,7 +127,6 @@ set (EpetraExt_inout_test_LL_MPI_4_DISABLE ON CACHE BOOL "Temporary disable for 
 set (EpetraExt_inout_test_MPI_4_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
 set (Teko_testdriver_MPI_4_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
 set (Zoltan2_fix4785_MPI_4_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
-set (Intrepid2_unit-test_Discretization_Basis_HierarchicalBases_Hierarchical_Basis_Tests_MPI_1_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
 
 
 # UVM = OFF
@@ -135,7 +134,6 @@ set (Kokkos_ENABLE_CUDA_UVM OFF CACHE BOOL "Set by default for CUDA PR testing")
 set (Tpetra_ENABLE_CUDA_UVM OFF CACHE BOOL "Set by default for CUDA PR testing")
 
 # Turn off packages currently failing with UVM = OFF
-set (Trilinos_ENABLE_Intrepid2 OFF CACHE BOOL "Turn off packages for non-UVM build")
 set (Trilinos_ENABLE_Panzer OFF CACHE BOOL "Turn off packages for non-UVM build")
 set (Trilinos_ENABLE_Stokhos OFF CACHE BOOL "Turn off packages for non-UVM build")
 set (Trilinos_ENABLE_TrilinosCouplings OFF CACHE BOOL "Turn off packages for non-UVM build")


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/framework @trilinos/intrepid2 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Per #8310, Intrepid2 is now UVM free.
So, this will reenable it for the dev to master Trilinos_pullrequest_cuda_10.1.105_uvm [off] PR build.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

<!--- 
## Stakeholder Feedback

If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Since this doesn't affect PR testing, it was manually tested. [CDash results](https://testing.sandia.gov/cdash/index.php?project=Trilinos&display=project&filtercount=2&showfilters=1&filtercombine=and&field1=buildname&compare1=61&value1=PR-Intrepid2_UVM_Free-test-Trilinos_pullrequest_cuda_10.1.105_uvm-103&field2=buildstamp&compare2=61&value2=20210426-0539-Experimental) show it's building and testing successfully.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->