### PR TITLE
Ifpack2 Relaxation&Chebyshev: Use offsets in more cases

### DIFF
--- a/packages/ifpack2/src/Ifpack2_Details_Chebyshev_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Chebyshev_def.hpp
@@ -782,7 +782,7 @@ Chebyshev<ScalarType, MV>::compute ()
       Teuchos::rcp_dynamic_cast<const crs_matrix_type> (A_);
 
     if (D_.is_null ()) { // We haven't computed D_ before
-      if (! A_crsMat.is_null () && A_crsMat->isStaticGraph ()) {
+      if (! A_crsMat.is_null () && A_crsMat->isFillComplete ()) {
         // It's a CrsMatrix with a const graph; cache diagonal offsets.
         const size_t lclNumRows = A_crsMat->getNodeNumRows ();
         if (diagOffsets_.extent (0) < lclNumRows) {
@@ -798,7 +798,7 @@ Chebyshev<ScalarType, MV>::compute ()
       }
     }
     else if (! assumeMatrixUnchanged_) { // D_ exists but A_ may have changed
-      if (! A_crsMat.is_null () && A_crsMat->isStaticGraph ()) {
+      if (! A_crsMat.is_null () && A_crsMat->isFillComplete ()) {
         // It's a CrsMatrix with a const graph; cache diagonal offsets
         // if we haven't already.
         if (! savedDiagOffsets_) {

--- a/packages/ifpack2/src/Ifpack2_Relaxation_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Relaxation_def.hpp
@@ -1055,7 +1055,7 @@ void Relaxation<MatrixType>::compute ()
       // method (not inherited from RowMatrix's interface).  It's
       // perfectly valid to do relaxation on a RowMatrix which is not
       // a CrsMatrix.
-      if (crsMat == nullptr || ! crsMat->isStaticGraph ()) {
+      if (crsMat == nullptr || ! crsMat->isFillComplete ()) {
         A_->getLocalDiagCopy (*Diagonal_); // slow path
       }
       else {


### PR DESCRIPTION
@trilinos/ifpack2

## Motivation
Use offsets for diagonal extraction when the the matrix is fill completed, not just when `isStaticGraph` returns true.