### PR TITLE
Framework: update messaging on issue autocloser bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -35,7 +35,7 @@ jobs:
         # We specifically DO NOT exempt PR's from autoclosing.
         #exempt-pr-labels: ''
         remove-stale-when-updated: true
-        operations-per-run: 55
+        operations-per-run: 70
         stale-issue-message: >
           This issue has had no activity for **365** days and is marked for
           closure. It will be closed after an additional **30** days of inactivity.

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -40,11 +40,16 @@ jobs:
           This issue has had no activity for **365** days and is marked for
           closure. It will be closed after an additional **30** days of inactivity.
 
-          If you would like to keep this issue open please add a comment and remove
+          If you would like to keep this issue open please add a comment and/or remove
           the `MARKED_FOR_CLOSURE` label.
 
           If this issue should be kept open even with no activity beyond the time
           limits you can add the label `DO_NOT_AUTOCLOSE`.
+
+          If it is ok for this issue to be closed, feel free to go ahead and close it.
+          Please **do not** add any comments or change any labels or otherwise touch
+          this issue unless your intention is to reset the inactivity counter for an
+          additional year.
 
         close-issue-message: >
           This issue was closed due to inactivity for **395** days.
@@ -57,8 +62,13 @@ jobs:
           considered to be abandoned and will be automatically closed after **30**
           additional days of inactivity from when it was marked inactive.
 
-          If this should be kept open, please post a comment and remove the
+          If this should be kept open, please post a comment and/or remove the
           label `MARKED_FOR_CLOSURE` to reset the inactivity timer.
+
+          If it is ok for this pull request to be closed, feel free to go ahead and close it.
+          Please **do not** add any comments or change any labels or otherwise touch
+          this issue unless your intention is to reset the inactivity counter for an
+          additional year.
 
         close-pr-message: >
           This Pull Request has been automatically closed due to **395** days of inactivity.


### PR DESCRIPTION
@trilinos/framework 

## Motivation
In some cases, when the issue autocloser bot flags an issue for removal people are posting responses to the bot in the issue to confirm that "yes, it can be closed"... they may not realize that what they're _actually_ doing is telling the bot "oh no, please don't close this issue... we'd like to reset that clock for another year".

This update just adds more content to the text from the bot to be a bit more explicit to tell the users that if they're ok with the issue being closed out that they can either go ahead and close the issue (the best option) or they can let the autocloser do it after 30 days... but they **should not touch the issue** unless they want to reset that clock for another year.

This is actually a problem because the autocloser bot looks at issues  from oldest to newest and 'repoened' old issues mess with its ability to process new old issues.  Currently we have about 17 issues that are still open that are 'older' than where the current autocloser pointer is. Given the github rate limiter issues we've had in the past we tuned the autocloser way down so it maybe processed about 80 issues a month. Now we're down to the 60's.

I'll take a quick pass at those issues and see how many are just 'confirming that they can be closed' and close them out.

I'll also bump the rate limiter on the bot by 15, from 55 to 70, to see if that gets us a bit more throughput without adversely affecting our rate limit issues. I'll note, when we initially rolled this out we had it set to 100+ I think. It's not 100% certain that the rate limiter issues we had back in December were due to this tool either but since we've also adjusted its CRON timing so it only runs a couple times in the week and only on the weekends.
