### PR TITLE
KokkosKernels: Fix bug in Serial specialization of spmv

### DIFF
--- a/packages/kokkos-kernels/src/sparse/impl/KokkosSparse_spmv_impl.hpp
+++ b/packages/kokkos-kernels/src/sparse/impl/KokkosSparse_spmv_impl.hpp
@@ -386,8 +386,6 @@ spmv_beta_no_transpose (const KokkosKernels::Experimental::Controls& controls,
 	  }
           if (dobeta == 0) {
             y_ptr[i] = alpha*(tmp1 + tmp2 + tmp3 + tmp4);
-          } else if (dobeta == -1) {
-            y_ptr[i] -= alpha*(tmp1 + tmp2 + tmp3 + tmp4);
           } else if (dobeta == 1) {
             y_ptr[i] += alpha*(tmp1 + tmp2 + tmp3 + tmp4);
           } else {


### PR DESCRIPTION
Will only hit spmvs with a beta of exactly -1 using the Serial backend.

@trilinos/kokkos-kernels 

Bug reported by some apps after the last release. Could be the reason for: #9070 