### PR TITLE
Change name of the UVM PR build to include UVM Off

### DIFF
--- a/cmake/std/PullRequestLinuxCuda10.1.105uvmOffTestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxCuda10.1.105uvmOffTestingSettings.cmake
@@ -2,9 +2,9 @@
 # for Trilinos for the CUDA 10.1.105 UVM pull request testing builds, and to reproduce
 # the errors reported by those builds. Prior to using this this file, the
 # appropriate set of modules must be loaded and path must be augmented.
-# (See the sems/PullRequestCuda10.1.105uvmTestingEnv.sh files.)
+# (See the sems/PullRequestCuda10.1.105uvmOffTestingEnv.sh files.)
 
-# Usage: cmake -C PullRequestLinuxCUDA10.1.105uvmTestingSettings.cmake
+# Usage: cmake -C PullRequestLinuxCUDA10.1.105uvmOffTestingSettings.cmake
 
 set (CMAKE_CXX_STANDARD "14" CACHE STRING "Set C++ standard to C++14")
 

--- a/cmake/std/pr_config/pullrequest.ini
+++ b/cmake/std/pr_config/pullrequest.ini
@@ -87,7 +87,7 @@ Trilinos_pullrequest_clang_10.0.0:     PullRequestLinuxClang10.0.0TestingSetting
 # CUDA Testing
 Trilinos_pullrequest_cuda_9.2:         PullRequestLinuxCuda9.2TestingSettings.cmake
 Trilinos_pullrequest_cuda_10.1.105:    PullRequestLinuxCuda10.1.105TestingSettings.cmake
-Trilinos_pullrequest_cuda_10.1.105_uvm: PullRequestLinuxCuda10.1.105uvmTestingSettings.cmake
+Trilinos_pullrequest_cuda_10.1.105_uvm_off: PullRequestLinuxCuda10.1.105uvmOffTestingSettings.cmake
 Trilinos_pullrequest_cuda_10.1.243:    PullRequestLinuxCuda10.1.243TestingSettings.cmake
 
 # GCC Builds
@@ -385,7 +385,7 @@ unsetenv PATH_TMP:
 
 
 
-[Trilinos_pullrequest_cuda_10.1.105_uvm]
+[Trilinos_pullrequest_cuda_10.1.105_uvm_off]
 module-load git: 2.10.1
 module-load devpack: 20190404/openmpi/4.0.1/gcc/7.2.0/cuda/10.1.105
 module-swap openblas/0.3.4/gcc/7.4.0: netlib/3.8.0/gcc/7.2.0

--- a/cmake/std/sems/PullRequestCuda10.1.105uvmOffTestingEnv.sh
+++ b/cmake/std/sems/PullRequestCuda10.1.105uvmOffTestingEnv.sh
@@ -1,7 +1,7 @@
 # This script can be used to load the appropriate environment for the
 # PR build on ride using CUDA.
 
-# usage: $ source PullRequestCUDA10.1.105uvmTestingEnv.sh
+# usage: $ source PullRequestCUDA10.1.105uvmOffTestingEnv.sh
 
 module load git/2.10.1
 module load devpack/20190404/openmpi/4.0.1/gcc/7.2.0/cuda/10.1.105

--- a/cmake/std/trilinosprhelpers/unittests/trilinos_pr_test.ini
+++ b/cmake/std/trilinosprhelpers/unittests/trilinos_pr_test.ini
@@ -86,7 +86,7 @@ Trilinos_pullrequest_clang_9.0.0:      PullRequestLinuxClang9.0.0TestingSettings
 # CUDA Testing
 Trilinos_pullrequest_cuda_9.2:         PullRequestLinuxCuda9.2TestingSettings.cmake
 Trilinos_pullrequest_cuda_10.1.105:         PullRequestLinuxCuda10.1.105TestingSettings.cmake
-Trilinos_pullrequest_cuda_10.1.105_uvm:         PullRequestLinuxCuda10.1.105uvmTestingSettings.cmake
+Trilinos_pullrequest_cuda_10.1.105_uvm_off:         PullRequestLinuxCuda10.1.105uvmOffTestingSettings.cmake
 
 # GCC Builds
 Trilinos_pullrequest_gcc_4.8.4:        PullRequestLinuxGCC4.8.4TestingSettings.cmake
@@ -307,7 +307,7 @@ unsetenv PATH_TMP:
 
 
 
-[Trilinos_pullrequest_cuda_10.1.105_uvm]
+[Trilinos_pullrequest_cuda_10.1.105_uvm_off]
 module-load git: 2.10.1
 module-load devpack: 20190404/openmpi/4.0.1/gcc/7.2.0/cuda/10.1.105
 module-swap openblas/0.3.4/gcc/7.4.0: netlib/3.8.0/gcc/7.2.0


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/framework

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Naming the UVM = OFF build as `Trilinos_pullrequest_cuda_10.1.105_uvm` is a bit of a misnomer as it sounds like the opposite, UVM = On. #9068 So, to avoid confusion, this will change the name to `Trilinos_pullrequest_cuda_10.1.105_uvm_off` in the code.
Once the PR is tested and reviewed, I'll merge it manually as to time it with changing of the job name itself.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

<!--- 
## Stakeholder Feedback

If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
<!---
## Testing

Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->