### PR TITLE
KokkosKernels: gemv/gemm perf improvements

### DIFF
--- a/packages/kokkos-kernels/src/blas/KokkosBlas3_gemm.hpp
+++ b/packages/kokkos-kernels/src/blas/KokkosBlas3_gemm.hpp
@@ -48,11 +48,72 @@
 
 #include <KokkosKernels_Macros.hpp>
 #include <KokkosBlas3_gemm_spec.hpp>
+#include <KokkosBlas2_gemv.hpp>
 #include <KokkosKernels_helpers.hpp>
 #include <sstream>
 #include <type_traits>
 
 namespace KokkosBlas {
+
+namespace Impl {
+  // Special codepath for when B/C have 1 column: use GEMV (matrix-vector) instead.
+  // GEMV performs better than tiled GEMM in this case.
+  //
+  // Returns true if the criteria are met and GEMV was run, false otherwise.
+  //
+  // This case must be intercepted here rather than impl in order to call TPL
+  // GEMV instead of TPL GEMM. This codepath was measured to be profitable with cuBLAS.
+  template<class AViewType,
+           class BViewType,
+           class CViewType>
+  bool
+  gemv_based_gemm
+       (const char transA[],
+        const char transB[],
+        typename AViewType::const_value_type& alpha,
+        const AViewType& A,
+        const BViewType& B,
+        typename CViewType::const_value_type& beta,
+        const CViewType& C,
+        typename std::enable_if<
+          !std::is_same<typename BViewType::array_layout, Kokkos::LayoutStride>::value &&
+          !std::is_same<typename CViewType::array_layout, Kokkos::LayoutStride>::value>::type* = nullptr)
+  {
+    if(toupper(transA[0]) == 'N' && toupper(transB[0]) == 'N' && B.extent(1) == size_t(1))
+    {
+      // since B/C both have a single column and are not LayoutStride,
+      // can create a raw contiguous rank-1 vector from them rather than using subview.
+      Kokkos::View<typename BViewType::value_type*, typename BViewType::array_layout,
+        typename BViewType::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>> Bvec(B.data(), B.extent(0));
+      Kokkos::View<typename CViewType::value_type*, typename CViewType::array_layout,
+        typename CViewType::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>> Cvec(C.data(), C.extent(0));
+      KokkosBlas::gemv("N", alpha, A, Bvec, beta, Cvec);
+      return true;
+    }
+    return false;
+  }
+
+  // Don't attempt to call GEMV with LayoutStride vectors.
+  // GEMV is not ETI'd for this case, so there would be undefined symbol errors in tests.
+  template<class AViewType,
+           class BViewType,
+           class CViewType>
+  bool
+  gemv_based_gemm
+       (const char transA[],
+        const char transB[],
+        typename AViewType::const_value_type& alpha,
+        const AViewType& A,
+        const BViewType& B,
+        typename CViewType::const_value_type& beta,
+        const CViewType& C,
+        typename std::enable_if<
+          std::is_same<typename BViewType::array_layout, Kokkos::LayoutStride>::value ||
+          std::is_same<typename CViewType::array_layout, Kokkos::LayoutStride>::value>::type* = nullptr)
+  {
+    return false;
+  }
+}
 
 /// \brief Dense matrix-matrix multiply: C = beta*C + alpha*op(A)*op(B).
 ///
@@ -140,6 +201,10 @@ gemm (const char transA[],
 
   // Return if degenerated matrices are provided
   if((A.extent(0) == 0) || (A.extent(1) == 0) || (C.extent(1) == 0))
+    return;
+
+  // Check if gemv code path is allowed and profitable, and if so run it.
+  if(Impl::gemv_based_gemm(transA, transB, alpha, A, B, beta, C))
     return;
 
   // Minimize the number of Impl::GEMV instantiations, by

--- a/packages/kokkos-kernels/src/blas/impl/KokkosBlas2_gemv_impl.hpp
+++ b/packages/kokkos-kernels/src/blas/impl/KokkosBlas2_gemv_impl.hpp
@@ -566,12 +566,10 @@ public:
       IndexType yrow = team.league_rank() * 32 + i;
       if(yrow < (IndexType) A_.extent(0))
       {
-        Scalar betaTerm;
         if(beta_ == KAT::zero())
-          betaTerm = KAT::zero();
+          y_(yrow) = alpha_ * blockResult[i];
         else
-          betaTerm = beta_ * y_(yrow);
-        y_(yrow) = betaTerm + alpha_ * blockResult[i];
+          y_(yrow) = beta_ * y_(yrow) + alpha_ * blockResult[i];
       }
     });
   }

--- a/packages/kokkos-kernels/src/blas/impl/KokkosBlas2_gemv_impl.hpp
+++ b/packages/kokkos-kernels/src/blas/impl/KokkosBlas2_gemv_impl.hpp
@@ -46,6 +46,7 @@
 
 #include "KokkosKernels_config.h"
 #include "Kokkos_Core.hpp"
+#include "KokkosKernels_ExecSpaceUtils.hpp"
 #include "Kokkos_ArithTraits.hpp"
 
 namespace KokkosBlas {
@@ -95,17 +96,17 @@ struct SingleLevelNontransposeGEMV {
   KOKKOS_INLINE_FUNCTION void
   operator () (const IndexType& i) const
   {
-    using y_value_type = typename std::decay<decltype (y_[i]) >::type;
+    using y_value_type = typename YViewType::non_const_value_type;
 
     y_value_type y_i;
     if (betaPreset == 0) {
-      y_i = Kokkos::Details::ArithTraits<y_value_type>::zero ();
+      y_i = Kokkos::ArithTraits<y_value_type>::zero ();
     }
     else if (betaPreset == 1) {
-      y_i = y_[i];
+      y_i = y_(i);
     }
     else { // beta_ != 0 and beta != 1
-      y_i = beta_ * y_[i];
+      y_i = beta_ * y_(i);
     }
 
     const IndexType numCols = A_.extent(1);
@@ -123,7 +124,7 @@ struct SingleLevelNontransposeGEMV {
       }
     }
 
-    y_[i] = y_i;
+    y_(i) = y_i;
   }
 
 private:
@@ -214,8 +215,8 @@ public:
       const y_value_type y_j =
         beta_ == ArithTraits<BetaCoeffType>::zero () ?
         ArithTraits<y_value_type>::zero () :
-        beta_ * y_[j];
-      y_[j] = y_j + y_result[j];
+        beta_ * y_(j);
+      y_(j) = y_j + y_result[j];
     }
   }
 
@@ -480,6 +481,130 @@ singleLevelGemv (const char trans[],
   }
 }
 
+struct TwoLevelGEMV_LayoutLeftTag {};
+struct TwoLevelGEMV_LayoutRightTag {};
+
+// ---------------------------------------------------------------------------------------------
+// Functor for a two-level parallel_reduce version of GEMV (non-transpose),
+// designed for performance on GPU. Kernel depends on the layout of A.
+template<class AViewType,
+         class XViewType,
+         class YViewType,
+         class IndexType = typename AViewType::size_type>
+struct TwoLevelGEMV {
+  using y_value_type   = typename YViewType::non_const_value_type;
+  using AlphaCoeffType = typename AViewType::non_const_value_type;
+  using BetaCoeffType  = typename YViewType::non_const_value_type;
+
+
+  using execution_space = typename AViewType::execution_space;
+  using policy_type = Kokkos::TeamPolicy<execution_space>;
+  using member_type = typename policy_type::member_type;
+
+  TwoLevelGEMV (const AlphaCoeffType& alpha,
+                         const AViewType& A,
+                         const XViewType& x,
+                         const BetaCoeffType& beta,
+                         const YViewType& y) :
+    alpha_ (alpha), A_ (A), x_ (x), beta_ (beta), y_ (y)
+  {
+    static_assert (Kokkos::Impl::is_view<AViewType>::value,
+                   "AViewType must be a Kokkos::View.");
+    static_assert (Kokkos::Impl::is_view<XViewType>::value,
+                   "XViewType must be a Kokkos::View.");
+    static_assert (Kokkos::Impl::is_view<YViewType>::value,
+                   "YViewType must be a Kokkos::View.");
+    static_assert (static_cast<int> (AViewType::rank) == 2,
+                   "AViewType must have rank 2.");
+    static_assert (static_cast<int> (XViewType::rank) == 1,
+                   "XViewType must have rank 1.");
+    static_assert (static_cast<int> (YViewType::rank) == 1,
+                   "YViewType must have rank 1.");
+    static_assert (std::is_integral<IndexType>::value,
+                   "IndexType must be an integer.");
+  }
+
+public:
+  //LayoutLeft version: 32xK blocks.
+  //  -Each team handles block rows. 
+  //  -Groups of 32 threads handle N/teamsize columns sequentially, placing results into shared.
+  //  -Then individual thread results are combined with parallel_reduce.
+  KOKKOS_INLINE_FUNCTION void
+  operator () (TwoLevelGEMV_LayoutLeftTag, const member_type& team) const
+  {
+    using Kokkos::Details::ArithTraits;
+    using Scalar = typename YViewType::non_const_value_type;
+    using KAT = ArithTraits<Scalar>;
+    //Allocate a Scalar in shared for each thread
+    Scalar* blockResult = (Scalar*) team.team_shmem().get_shmem(32 * sizeof(Scalar));
+    Kokkos::parallel_for(Kokkos::TeamThreadRange(team, 32),
+    [&](int i)
+    {
+      blockResult[i] = KAT::zero();
+    });
+    team.team_barrier();
+    //Which block this thread will work on
+    int block = team.team_rank() / 32;
+    //Which row in the block this thread will work on
+    IndexType row = team.league_rank() * 32 + team.team_rank() % 32;
+    IndexType blockColStart = columnsPerThread * block;
+    Scalar localSum = KAT::zero();
+    //compute local sum
+    if(row < (IndexType) A_.extent(0))
+    {
+      for(IndexType col = blockColStart; col < blockColStart + columnsPerThread && col < A_.extent(1); col++)
+      {
+        //A access is coalesced, x access is a broadcast
+        localSum += A_(row, col) * x_(col);
+      }
+    }
+    //atomically combine local result into shared
+    Kokkos::atomic_add(&blockResult[team.team_rank() % 32], localSum);
+    team.team_barrier();
+    Kokkos::parallel_for(Kokkos::TeamThreadRange(team, 32),
+    [&](int i)
+    {
+      IndexType yrow = team.league_rank() * 32 + i;
+      if(yrow < (IndexType) A_.extent(0))
+      {
+        y_(yrow) = beta_ * y_(yrow) + alpha_ * blockResult[i];
+      }
+    });
+  }
+
+  //LayoutRight version: one team per row
+  KOKKOS_INLINE_FUNCTION void
+  operator () (TwoLevelGEMV_LayoutRightTag, const member_type& team) const
+  {
+    using Kokkos::Details::ArithTraits;
+    using KAT = ArithTraits<typename AViewType::non_const_value_type>;
+
+    const IndexType N = A_.extent(1);
+    const int i = team.league_rank(); // batch id
+
+    // parallel-reduce to compute val += A(:,j)' * x
+    y_value_type val = KAT:: zero();
+    Kokkos::parallel_reduce( Kokkos::TeamThreadRange( team, N ), [&] ( const int j, y_value_type &update ) {
+      update += A_(i, j) * x_(j);
+    }, val);
+
+    // compute yj = beta*yj + alpha*val
+    Kokkos::single(Kokkos::PerTeam(team),
+    [=]()
+    {
+      y_(i) = beta_ * y_(i) + alpha_ * val;
+    });
+  }
+
+  IndexType columnsPerThread;
+private:
+  AlphaCoeffType alpha_;
+  typename AViewType::const_type A_;
+  typename XViewType::const_type x_;
+  BetaCoeffType beta_;
+  YViewType y_;
+};
+
 
 // ---------------------------------------------------------------------------------------------
 // Functor for a two-level parallel_reduce version of (conjugate)
@@ -544,7 +669,7 @@ public:
 
     // compute yj = beta*yj + alpha*val
     if (team.team_rank() == 0) {
-      y_[j] = beta_*y_[j] + alpha_ * val;
+      y_(j) = beta_*y_(j) + alpha_ * val;
     }
   }
 
@@ -589,38 +714,68 @@ twoLevelGemv (const char trans[],
   using team_policy_type  = Kokkos::TeamPolicy<execution_space>;
   using range_policy_type = Kokkos::RangePolicy<execution_space, IndexType>;
 
-  using BetaCoeffType = typename YViewType::non_const_value_type;
-
   using Kokkos::Details::ArithTraits;
   using KAT = ArithTraits<typename AViewType::non_const_value_type>;
+  using YKAT = ArithTraits<typename YViewType::non_const_value_type>;
 
-  const char tr = trans[0];
+  const char tr = toupper(trans[0]);
 
   // The transpose and conjugate transpose cases where A has zero rows
   // need special handling.  These are equivalent to y := beta*y.  We
   // could implement this using KokkosBlas::scal, but we don't want to
   // depend on that or its implementation details.  Instead, we reuse
   // an instantiation of the non-transpose case for alpha=0.
-  if (A.extent(0) == 0 && (tr != 'N' && tr != 'n')) {
-    if (beta == KAT::zero ()) {
+  if (y.extent(0) == 0)
+  {
+    //no entries to update
+    return;
+  }
+  else if (x.extent(0) == 0)
+  {
+    if (beta == YKAT::zero ()) {
       Kokkos::deep_copy (y, KAT::zero ());
     }
-    else if (beta != Kokkos::Details::ArithTraits<BetaCoeffType>::one ()) {
+    else if (beta != YKAT::one ()) {
       // "Fake out" a scal() by using the non-transpose alpha=0,
       // general beta case.  This assumes that the functor doesn't
       // check dimensions.
       using functor_type = SingleLevelNontransposeGEMV<AViewType, XViewType, YViewType,
                                                        0, -1, IndexType>;
       functor_type functor (alpha, A, x, beta, y);
-      Kokkos::parallel_for ("KokkosBlas::gemv[SingleLevel]",range_policy_type (0, A.extent(1)), functor);
+      Kokkos::parallel_for ("KokkosBlas::gemv[SingleLevel]",range_policy_type (0, y.extent(0)), functor);
     }
     return;
   }
 
-  if (tr == 'N' || tr == 'n') {
-    // NOTE: not implemented, so just call single-level version
-    singleLevelGemv<AViewType, XViewType, YViewType, IndexType>
-         (trans, alpha, A, x, beta, y);
+  if (tr == 'N') {
+    constexpr bool isLayoutLeft = std::is_same<typename AViewType::array_layout, Kokkos::LayoutLeft>::value;
+    using layout_tag = typename std::conditional<isLayoutLeft,
+      TwoLevelGEMV_LayoutLeftTag, TwoLevelGEMV_LayoutRightTag>::type;
+    using tagged_policy = Kokkos::TeamPolicy<execution_space, layout_tag>;
+    using functor_type = TwoLevelGEMV<AViewType, XViewType, YViewType, IndexType>;
+    functor_type functor (alpha, A, x, beta, y);
+    tagged_policy team;
+    if(isLayoutLeft)
+    {
+      size_t sharedPerTeam = 32 * sizeof(y_value_type);
+      IndexType numTeams = (A.extent(0) + 31) / 32;
+      tagged_policy temp(1, 1);
+      int teamSize = temp.team_size_max(functor, Kokkos::ParallelForTag());
+      //make sure teamSize is a multiple of 32
+      teamSize -= teamSize % 32;
+      //don't make teamSize larger than what's useful
+      if((size_t) teamSize > 32 * A.extent(1))
+        teamSize = 32 * A.extent(1);
+      int numBlocks = teamSize / 32;
+      functor.columnsPerThread = (A.extent(1) + numBlocks - 1) / numBlocks;
+      team = tagged_policy(numTeams, teamSize).set_scratch_size(0, Kokkos::PerTeam(sharedPerTeam));
+    }
+    else
+    {
+      //LayoutRight: one team per row
+      team = tagged_policy(A.extent(0), Kokkos::AUTO);
+    }
+    Kokkos::parallel_for ("KokkosBlas::gemv[twoLevel]", team, functor);
   }
   else {
     if (alpha == KAT::zero () && beta == KAT::zero ()) {
@@ -630,7 +785,7 @@ twoLevelGemv (const char trans[],
     else if (alpha == KAT::zero () && beta == KAT::one ()) {
       // Do nothing (y := 1 * y)
     }
-    else if (tr == 'T' || tr == 't') {
+    else if (tr == 'T') {
       // transpose, and not conj transpose
       team_policy_type  team (A.extent(1), Kokkos::AUTO);
       using functor_type = TwoLevelTransposeGEMV<AViewType, XViewType, YViewType,
@@ -638,7 +793,7 @@ twoLevelGemv (const char trans[],
       functor_type functor (alpha, A, x, beta, y);
       Kokkos::parallel_for ("KokkosBlas::gemv[twoLevelTranspose]", team, functor);
     }
-    else if (tr == 'C' || tr == 'c' || tr == 'H' || tr == 'h') {
+    else if (tr == 'C' || tr == 'H') {
       // conjugate transpose
       team_policy_type  team (A.extent(1), Kokkos::AUTO);
       using functor_type = TwoLevelTransposeGEMV<AViewType, XViewType, YViewType,
@@ -647,6 +802,43 @@ twoLevelGemv (const char trans[],
       Kokkos::parallel_for ("KokkosBlas::gemv[twoLevelTranspose]", team, functor);
     }
   }
+}
+
+//generalGemv: use 1 level (Range) or 2 level (Team) implementation,
+//depending on whether execution space is CPU or GPU. enable_if makes sure
+//unused kernels are not instantiated.
+template<class AViewType,
+         class XViewType,
+         class YViewType,
+         class IndexType,
+         typename std::enable_if<!KokkosKernels::Impl::kk_is_gpu_exec_space
+           <typename AViewType::execution_space>()>::type* = nullptr>
+void
+generalGemvImpl (const char trans[],
+                 typename AViewType::const_value_type& alpha,
+                 const AViewType& A,
+                 const XViewType& x,
+                 typename YViewType::const_value_type& beta,
+                 const YViewType& y)
+{
+  singleLevelGemv (trans, alpha, A, x, beta, y);
+}
+
+template<class AViewType,
+         class XViewType,
+         class YViewType,
+         class IndexType,
+         typename std::enable_if<KokkosKernels::Impl::kk_is_gpu_exec_space
+           <typename AViewType::execution_space>()>::type* = nullptr>
+void
+generalGemvImpl (const char trans[],
+                 typename AViewType::const_value_type& alpha,
+                 const AViewType& A,
+                 const XViewType& x,
+                 typename YViewType::const_value_type& beta,
+                 const YViewType& y)
+{
+  twoLevelGemv (trans, alpha, A, x, beta, y);
 }
 
 } // namespace Impl

--- a/packages/kokkos-kernels/src/blas/impl/KokkosBlas2_gemv_spec.hpp
+++ b/packages/kokkos-kernels/src/blas/impl/KokkosBlas2_gemv_spec.hpp
@@ -136,22 +136,12 @@ struct GEMV {
     // Prefer int as the index type, but use a larger type if needed.
     if (numRows < static_cast<size_type> (INT_MAX) &&
         numCols < static_cast<size_type> (INT_MAX)) {
-      #if 1
-      twoLevelGemv<AViewType, XViewType, YViewType, int>
+      generalGemvImpl<AViewType, XViewType, YViewType, int>
          (trans, alpha, A, x, beta, y);
-      #else
-      singleLevelGemv<AViewType, XViewType, YViewType, int>
-         (trans, alpha, A, x, beta, y);
-      #endif
     }
     else {
-      #if 1
-      twoLevelGemv<AViewType, XViewType, YViewType, int64_t>
+      generalGemvImpl<AViewType, XViewType, YViewType, int64_t>
          (trans, alpha, A, x, beta, y);
-      #else
-      singleLevelGemv<AViewType, XViewType, YViewType, int64_t>
-         (trans, alpha, A, x, beta, y);
-      #endif
     }
     Kokkos::Profiling::popRegion();
   }

--- a/packages/kokkos-kernels/test_common/KokkosKernels_TestUtils.hpp
+++ b/packages/kokkos-kernels/test_common/KokkosKernels_TestUtils.hpp
@@ -214,6 +214,46 @@ namespace Test {
     }
   };
 
+  template<class ViewTypeA, class ViewTypeX, class ViewTypeY>
+  void vanillaGEMV(char mode,
+      typename ViewTypeA::non_const_value_type alpha, const ViewTypeA& A, const ViewTypeX& x, 
+      typename ViewTypeY::non_const_value_type beta, const ViewTypeY& y)
+  {
+    using ScalarY = typename ViewTypeY::non_const_value_type;
+    using KAT_A = Kokkos::ArithTraits<typename ViewTypeA::non_const_value_type>;
+    using KAT_Y = Kokkos::ArithTraits<ScalarY>;
+    int M = A.extent(0);
+    int N = A.extent(1);
+    if(beta == KAT_Y::zero())
+      Kokkos::deep_copy(y, KAT_Y::zero());
+    if(mode == 'N') {
+      for(int i = 0; i < M; i++) {
+        ScalarY y_i = beta * y(i);
+        for(int j = 0; j < N; j++) {
+           y_i += alpha * A(i,j) * x(j);
+        }
+        y(i) = y_i;
+      }
+    } else if(mode == 'T') {
+      for(int j = 0; j < N; j++) {
+        ScalarY y_j = beta * y(j);
+        for(int i = 0; i < M; i++) {
+           y_j += alpha * A(i,j) * x(i);
+        }
+        y(j) = y_j;
+      }
+    } else if(mode == 'C') {
+      for(int j = 0; j < N; j++) {
+        ScalarY y_j = beta * y(j);
+        for(int i = 0; i < M; i++) {
+           y_j += alpha * KAT_A::conj (A(i,j)) * x(i);
+        }
+        y(j) = y_j;
+      }
+    }
+  }
+
+
   template<class T>
   class epsilon {
     public:

--- a/packages/kokkos-kernels/unit_test/blas/Test_Blas2_gemv.hpp
+++ b/packages/kokkos-kernels/unit_test/blas/Test_Blas2_gemv.hpp
@@ -26,7 +26,7 @@ namespace Test {
 
     ScalarA alpha = 3;
     ScalarX beta = 5;
-    double eps = (std::is_same<typename Kokkos::ArithTraits<ScalarY>::mag_type, float>::value ? 1e-3 : 1e-10);
+    double eps = (std::is_same<typename Kokkos::ArithTraits<ScalarY>::mag_type, float>::value ? 1e-3 : 5e-10);
 
     int ldx;
     int ldy;
@@ -115,26 +115,35 @@ namespace Test {
 
     KokkosBlas::gemv(mode, alpha, A, x, beta, y);
     Kokkos::deep_copy(h_b_y, b_y);
+    int numErrors = 0;
     for(int i = 0; i < ldy; i++)
     {
-      EXPECT_NEAR_KK(expected(i), h_y(i), eps * expected(i));
+      if(KAT::abs(expected(i) - h_y(i)) > KAT::abs(eps * expected(i)))
+        numErrors++;
     }
+    EXPECT_EQ(numErrors, 0) << "Nonconst input, " << M << 'x' << N << ", alpha = " << alpha << ", beta = " << beta << ", mode " << mode << ": gemv incorrect";
  
     Kokkos::deep_copy(b_y, b_org_y);
     KokkosBlas::gemv(mode, alpha,A ,c_x, beta, y);
     Kokkos::deep_copy(h_b_y, b_y);
+    numErrors = 0;
     for(int i = 0; i < ldy; i++)
     {
-      EXPECT_NEAR_KK(expected(i), h_y(i), eps);
+      if(KAT::abs(expected(i) - h_y(i)) > KAT::abs(eps * expected(i)))
+        numErrors++;
     }
+    EXPECT_EQ(numErrors, 0) << "Const vector input, " << M << 'x' << N << ", alpha = " << alpha << ", beta = " << beta << ", mode " << mode << ": gemv incorrect";
 
     Kokkos::deep_copy(b_y, b_org_y);
     KokkosBlas::gemv(mode, alpha, c_A, c_x, beta, y);
     Kokkos::deep_copy(h_b_y, b_y);
+    numErrors = 0;
     for(int i = 0; i < ldy; i++)
     {
-      EXPECT_NEAR_KK(expected(i), h_y(i), eps);
+      if(KAT::abs(expected(i) - h_y(i)) > KAT::abs(eps * expected(i)))
+        numErrors++;
     }
+    EXPECT_EQ(numErrors, 0) << "Const matrix/vector input, " << M << 'x' << N << ", alpha = " << alpha << ", beta = " << beta << ", mode " << mode << ": gemv incorrect";
   }
 }
 
@@ -156,8 +165,12 @@ int test_gemv(const char* mode) {
   Test::impl_test_gemv<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(mode,200,10);
   #endif
   Test::impl_test_gemv<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(mode,0,1024);
+  Test::impl_test_gemv<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(mode,1024,0);
+  Test::impl_test_gemv<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(mode,13,13);
   Test::impl_test_gemv<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(mode,13,1024);
+  Test::impl_test_gemv<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(mode,50,40);
   Test::impl_test_gemv<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(mode,1024,1024);
+  Test::impl_test_gemv<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(mode,4321,4321);
   //Test::impl_test_gemv<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(mode,132231,1024);
 #endif
 
@@ -166,8 +179,12 @@ int test_gemv(const char* mode) {
   typedef Kokkos::View<ScalarX*, Kokkos::LayoutRight, Device> view_type_b_lr;
   typedef Kokkos::View<ScalarY*, Kokkos::LayoutRight, Device> view_type_c_lr;
   Test::impl_test_gemv<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(mode,0,1024);
+  Test::impl_test_gemv<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(mode,1024,0);
+  Test::impl_test_gemv<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(mode,13,13);
   Test::impl_test_gemv<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(mode,13,1024);
+  Test::impl_test_gemv<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(mode,50,40);
   Test::impl_test_gemv<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(mode,1024,1024);
+  Test::impl_test_gemv<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(mode,4321,4321);
   //Test::impl_test_gemv<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(mode,132231,1024);
 #endif
 
@@ -176,8 +193,12 @@ int test_gemv(const char* mode) {
   typedef Kokkos::View<ScalarX*, Kokkos::LayoutStride, Device> view_type_b_ls;
   typedef Kokkos::View<ScalarY*, Kokkos::LayoutStride, Device> view_type_c_ls;
   Test::impl_test_gemv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(mode,0,1024);
+  Test::impl_test_gemv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(mode,1024,0);
+  Test::impl_test_gemv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(mode,13,13);
   Test::impl_test_gemv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(mode,13,1024);
+  Test::impl_test_gemv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(mode,50,40);
   Test::impl_test_gemv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(mode,1024,1024);
+  Test::impl_test_gemv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(mode,4321,4321);
   //Test::impl_test_gemv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(mode,132231,1024);
 #endif
 

--- a/packages/kokkos-kernels/unit_test/blas/Test_Blas3_gemm.hpp
+++ b/packages/kokkos-kernels/unit_test/blas/Test_Blas3_gemm.hpp
@@ -7,7 +7,7 @@
 namespace Test {
 
   template<class ViewTypeA, class ViewTypeB, class ViewTypeC, class ExecutionSpace>
-  struct VanillaGEMM {
+  struct gemm_VanillaGEMM {
     bool A_t, B_t, A_c, B_c;
     int N,K;
     ViewTypeA A;
@@ -114,8 +114,9 @@ namespace Test {
     // Kokkos::fill_random(C,rand_pool,ScalarC(10));
     
     Kokkos::deep_copy(C2,C);
-
-    struct VanillaGEMM<ViewTypeA,ViewTypeB,ViewTypeC,execution_space> vgemm;
+    Kokkos::fence();
+ 
+    struct gemm_VanillaGEMM<ViewTypeA,ViewTypeB,ViewTypeC,execution_space> vgemm;
     vgemm.A_t = A_t; vgemm.B_t = B_t;
     vgemm.A_c = A_c; vgemm.B_c = B_c;
     vgemm.N = N;     vgemm.K = K;
@@ -124,7 +125,7 @@ namespace Test {
     vgemm.alpha = alpha;
     vgemm.beta = beta;
 
-    Kokkos::parallel_for("KokkosBlas::Test::VanillaGEMM", Kokkos::TeamPolicy<execution_space>(M,Kokkos::AUTO,16), vgemm);
+    Kokkos::parallel_for("KokkosBlas::Test::gemm_VanillaGEMM", Kokkos::TeamPolicy<execution_space>(M,Kokkos::AUTO,16), vgemm);
 
     KokkosBlas::gemm(TA,TB,alpha,A,B,beta,C);
 
@@ -151,67 +152,49 @@ namespace Test {
   }
 }
 
+template<typename Scalar, typename Layout>
+void test_gemm()
+{
+  typedef Kokkos::View<Scalar**, Layout, TestExecSpace> view_type_a;
+  typedef Kokkos::View<Scalar**, Layout, TestExecSpace> view_type_b;
+  typedef Kokkos::View<Scalar**, Layout, TestExecSpace> view_type_c;
+  std::vector<const char*> modes = {"N", "T"};
+  if(std::is_same<Scalar, Kokkos::complex<float>>::value || std::is_same<Scalar, Kokkos::complex<double>>::value)
+    modes.push_back("C");
+  Scalar alpha = 4.5;
+  std::vector<Scalar> betas = {0.0, 3.0};
+  for(Scalar beta : betas)
+  {
+    for(auto amode : modes)
+    {
+      for(auto bmode : modes)
+      {
+        Test::impl_test_gemm<view_type_a, view_type_b, view_type_c, TestExecSpace>(amode,bmode,0,0,0,alpha,beta);
+        //BMK: N = 1 exercises the special GEMV code path in GEMM (currently, only for modes N/N)
+        Test::impl_test_gemm<view_type_a, view_type_b, view_type_c, TestExecSpace>(amode,bmode,50,1,40,alpha,beta);
+        Test::impl_test_gemm<view_type_a, view_type_b, view_type_c, TestExecSpace>(amode,bmode,13,15,17,alpha,beta);
+        Test::impl_test_gemm<view_type_a, view_type_b, view_type_c, TestExecSpace>(amode,bmode,179,15,211,alpha,beta);
+        Test::impl_test_gemm<view_type_a, view_type_b, view_type_c, TestExecSpace>(amode,bmode,12,3071,517,alpha,beta);
+      }
+    }
+  }
+}
 
-
-template<class ScalarA, class ScalarB, class ScalarC, class Device>
-int test_gemm(const char* mode, ScalarA alpha, ScalarB beta) {
-
+template<typename Scalar>
+void test_gemm_enabled_layouts()
+{
 #if defined(KOKKOSKERNELS_INST_LAYOUTLEFT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-  typedef Kokkos::View<ScalarA**, Kokkos::LayoutLeft, Device> view_type_a_ll;
-  typedef Kokkos::View<ScalarB**, Kokkos::LayoutLeft, Device> view_type_b_ll;
-  typedef Kokkos::View<ScalarC**, Kokkos::LayoutLeft, Device> view_type_c_ll;
-  Test::impl_test_gemm<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(&mode[0],&mode[1],0,0,0,alpha,beta);
-  Test::impl_test_gemm<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(&mode[0],&mode[1],13,15,17,alpha,beta);
-  Test::impl_test_gemm<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(&mode[0],&mode[1],179,15,211,alpha,beta);
-  Test::impl_test_gemm<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(&mode[0],&mode[1],12,3071,517,alpha,beta);
-  //Test::impl_test_gemm<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(&mode[0],&mode[1],1024,1024,2048,alpha,beta);
+  test_gemm<Scalar, Kokkos::LayoutLeft>();
 #endif
-
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-  typedef Kokkos::View<ScalarA**, Kokkos::LayoutRight, Device> view_type_a_lr;
-  typedef Kokkos::View<ScalarB**, Kokkos::LayoutRight, Device> view_type_b_lr;
-  typedef Kokkos::View<ScalarC**, Kokkos::LayoutRight, Device> view_type_c_lr;
-  Test::impl_test_gemm<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(&mode[0],&mode[1],0,0,0,alpha,beta);
-  Test::impl_test_gemm<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(&mode[0],&mode[1],13,15,17,alpha,beta);
-  Test::impl_test_gemm<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(&mode[0],&mode[1],179,15,211,alpha,beta);
-  Test::impl_test_gemm<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(&mode[0],&mode[1],12,3071,517,alpha,beta);
-  //Test::impl_test_gemm<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(&mode[0],&mode[1],1024,1024,2048,alpha,beta);
+  test_gemm<Scalar, Kokkos::LayoutRight>();
 #endif
-/*
-#if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-  typedef Kokkos::View<ScalarA**, Kokkos::LayoutStride, Device> view_type_a_ls;
-  typedef Kokkos::View<ScalarX*, Kokkos::LayoutStride, Device> view_type_b_ls;
-  typedef Kokkos::View<ScalarY*, Kokkos::LayoutStride, Device> view_type_c_ls;
-  Test::impl_test_gemv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(mode,0,1024);
-  Test::impl_test_gemv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(mode,13,1024);
-  Test::impl_test_gemv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(mode,1024,1024);
-  Test::impl_test_gemv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(mode,132231,1024);
-#endif
-
-#if !defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
-  Test::impl_test_gemv<view_type_a_ls, view_type_b_ll, view_type_c_lr, Device>(mode,1024,1024);
-  Test::impl_test_gemv<view_type_a_ll, view_type_b_ls, view_type_c_lr, Device>(mode,1024,1024);
-#endif
-*/
-  return 1;
 }
 
 #if defined(KOKKOSKERNELS_INST_FLOAT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, gemm_float ) {
   Kokkos::Profiling::pushRegion("KokkosBlas::Test::gemm_float");
-    float alpha = 5.0f;
-    float beta = 3.0f;
-    test_gemm<float,float,float,TestExecSpace> ("NN",alpha,beta);
-    test_gemm<float,float,float,TestExecSpace> ("TN",alpha,beta);
-    test_gemm<float,float,float,TestExecSpace> ("NT",alpha,beta);
-    test_gemm<float,float,float,TestExecSpace> ("TT",alpha,beta);
-
-    alpha = 4.5f;
-    beta = 0.0f;
-    test_gemm<float,float,float,TestExecSpace> ("NN",alpha,beta);
-    test_gemm<float,float,float,TestExecSpace> ("TN",alpha,beta);
-    test_gemm<float,float,float,TestExecSpace> ("NT",alpha,beta);
-    test_gemm<float,float,float,TestExecSpace> ("TT",alpha,beta);
+  test_gemm_enabled_layouts<float>();
   Kokkos::Profiling::popRegion();
 }
 #endif
@@ -219,19 +202,7 @@ TEST_F( TestCategory, gemm_float ) {
 #if defined(KOKKOSKERNELS_INST_DOUBLE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, gemm_double ) {
   Kokkos::Profiling::pushRegion("KokkosBlas::Test::gemm_double");
-    double alpha = 5.0;
-    double beta = 3.0;
-    test_gemm<double,double,double,TestExecSpace> ("NN",alpha,beta);
-    test_gemm<double,double,double,TestExecSpace> ("TN",alpha,beta);
-    test_gemm<double,double,double,TestExecSpace> ("NT",alpha,beta);
-    test_gemm<double,double,double,TestExecSpace> ("TT",alpha,beta);
-
-    alpha = 4.5;
-    beta = 0.0;
-    test_gemm<double,double,double,TestExecSpace> ("NN",alpha,beta);
-    test_gemm<double,double,double,TestExecSpace> ("TN",alpha,beta);
-    test_gemm<double,double,double,TestExecSpace> ("NT",alpha,beta);
-    test_gemm<double,double,double,TestExecSpace> ("TT",alpha,beta);
+    test_gemm_enabled_layouts<double>();
   Kokkos::Profiling::popRegion();
 }
 #endif
@@ -239,19 +210,7 @@ TEST_F( TestCategory, gemm_double ) {
 #if defined(KOKKOSKERNELS_INST_COMPLEX_DOUBLE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, gemm_complex_double ) {
   Kokkos::Profiling::pushRegion("KokkosBlas::Test::gemm_complex_double");
-    Kokkos::complex<double> alpha = 5.0;
-    Kokkos::complex<double> beta = 3.0;
-    test_gemm<Kokkos::complex<double>,Kokkos::complex<double>,Kokkos::complex<double>,TestExecSpace> ("NN",alpha,beta);
-    test_gemm<Kokkos::complex<double>,Kokkos::complex<double>,Kokkos::complex<double>,TestExecSpace> ("CN",alpha,beta);
-    test_gemm<Kokkos::complex<double>,Kokkos::complex<double>,Kokkos::complex<double>,TestExecSpace> ("NC",alpha,beta);
-    test_gemm<Kokkos::complex<double>,Kokkos::complex<double>,Kokkos::complex<double>,TestExecSpace> ("CC",alpha,beta);
-
-    alpha = Kokkos::complex<double>(4.5,0.0);
-    beta = 0.0;
-    test_gemm<Kokkos::complex<double>,Kokkos::complex<double>,Kokkos::complex<double>,TestExecSpace> ("NN",alpha,beta);
-    test_gemm<Kokkos::complex<double>,Kokkos::complex<double>,Kokkos::complex<double>,TestExecSpace> ("CN",alpha,beta);
-    test_gemm<Kokkos::complex<double>,Kokkos::complex<double>,Kokkos::complex<double>,TestExecSpace> ("NC",alpha,beta);
-    test_gemm<Kokkos::complex<double>,Kokkos::complex<double>,Kokkos::complex<double>,TestExecSpace> ("CC",alpha,beta);
+    test_gemm_enabled_layouts<Kokkos::complex<double>>();
   Kokkos::Profiling::popRegion();
 }
 #endif
@@ -259,33 +218,8 @@ TEST_F( TestCategory, gemm_complex_double ) {
 #if defined(KOKKOSKERNELS_INST_COMPLEX_FLOAT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, gemm_complex_float ) {
   Kokkos::Profiling::pushRegion("KokkosBlas::Test::gemm_complex_float");
-    Kokkos::complex<float> alpha = 5.0f;
-    Kokkos::complex<float> beta = 3.0f;
-    test_gemm<Kokkos::complex<float>,Kokkos::complex<float>,Kokkos::complex<float>,TestExecSpace> ("NN",alpha,beta);
-    test_gemm<Kokkos::complex<float>,Kokkos::complex<float>,Kokkos::complex<float>,TestExecSpace> ("CN",alpha,beta);
-    test_gemm<Kokkos::complex<float>,Kokkos::complex<float>,Kokkos::complex<float>,TestExecSpace> ("NC",alpha,beta);
-    test_gemm<Kokkos::complex<float>,Kokkos::complex<float>,Kokkos::complex<float>,TestExecSpace> ("CC",alpha,beta);
-
-    alpha = Kokkos::complex<float>(4.5f,0.0f);
-    beta = 0.0;
-    test_gemm<Kokkos::complex<float>,Kokkos::complex<float>,Kokkos::complex<float>,TestExecSpace> ("NN",alpha,beta);
-    test_gemm<Kokkos::complex<float>,Kokkos::complex<float>,Kokkos::complex<float>,TestExecSpace> ("CN",alpha,beta);
-    test_gemm<Kokkos::complex<float>,Kokkos::complex<float>,Kokkos::complex<float>,TestExecSpace> ("NC",alpha,beta);
-    test_gemm<Kokkos::complex<float>,Kokkos::complex<float>,Kokkos::complex<float>,TestExecSpace> ("CC",alpha,beta);
+    test_gemm_enabled_layouts<Kokkos::complex<float>>();
   Kokkos::Profiling::popRegion();
 }
 #endif
 
-/*
-#if defined(KOKKOSKERNELS_INST_INT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-TEST_F( TestCategory, gemm_int ) {
-    test_gemm<int,int,int,TestExecSpace> ("N");
-}
-#endif
-
-#if !defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
-TEST_F( TestCategory, gemm_double_int ) {
-    test_gemm<double,int,float,TestExecSpace> ("N");
-}
-#endif
-*/


### PR DESCRIPTION
Patch in KokkosKernels PRs #939 and #948. These are to improve
general GEMV performance on GPUs, and GEMM performance in a certain case:
C=AB where B and C have 1 column. Trilinos issue #8923 is about this
GEMM case.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/kokkos-kernels 
@trilinos/tpetra 
@trilinos/belos 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
- Improves general GEMV performance by using 2-level parallelism. Except for extreme tall-skinny cases, KokkosKernels GEMV now gets performance very close to cuBLAS (see https://github.com/kokkos/kokkos-kernels/pull/939), and performs equally well for both matrix layouts.
- Significantly improves GEMM performance for a case that appears in ICGS orthogonalization (see #8923 for request, https://github.com/kokkos/kokkos-kernels/issues/929 for results)
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
The GEMV work was requested by @vbrunini for Sierra TF. The GEMM work was requested by @jennloe to benefit Belos (``Tpetra::MultiVector::multiply`` is implemented using KokkosKernels gemm).
## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
This adds a test to exercise the new single column B path in GEMM. It also adds a larger test case for GEMV.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->