### PR TITLE
Tpetra:  restore deprecated BlockMultiVector and BlockVector functions for #9082

### DIFF
--- a/packages/ifpack2/src/Ifpack2_Details_GaussSeidel.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_GaussSeidel.hpp
@@ -236,7 +236,7 @@ namespace Details
           row = useApplyRows ? applyRows[numApplyRows - 1 - i] : numApplyRows - 1 - i;
         for(LO v = 0; v < numVecs; v++)
         {
-          auto bRow = b.getLocalBlock (row, v, Tpetra::Access::ReadOnly);
+          auto bRow = b.getLocalBlockHost (row, v, Tpetra::Access::ReadOnly);
           for(LO k = 0; k < blockSize; k++)
           {
             accum(k, v) = KAT::zero();
@@ -250,7 +250,7 @@ namespace Details
           IST* blk = &Avalues(j * bs2);
           for(LO v = 0; v < numVecs; v++)
           {
-            auto xCol = x.getLocalBlock (col, v, Tpetra::Access::ReadOnly);
+            auto xCol = x.getLocalBlockHost (col, v, Tpetra::Access::ReadOnly);
             for(LO br = 0; br < blockSize; br++)
             {
               for(LO bc = 0; bc < blockSize; bc++)
@@ -266,7 +266,7 @@ namespace Details
         Kokkos::deep_copy(dinv_accum, KAT::zero());
         for(LO v = 0; v < numVecs; v++)
         {
-          auto bRow = b.getLocalBlock (row, v, Tpetra::Access::ReadOnly);
+          auto bRow = b.getLocalBlockHost (row, v, Tpetra::Access::ReadOnly);
           for(LO br = 0; br < blockSize; br++)
           {
             accum(br, v) = bRow(br) - accum(br, v);
@@ -285,7 +285,7 @@ namespace Details
         //Update x
         for(LO v = 0; v < numVecs; v++)
         {
-          auto xRow = x.getLocalBlock (row, v, Tpetra::Access::ReadWrite);
+          auto xRow = x.getLocalBlockHost (row, v, Tpetra::Access::ReadWrite);
           for(LO k = 0; k < blockSize; k++)
           {
             xRow(k) += omega * dinv_accum(k, v);

--- a/packages/ifpack2/src/Ifpack2_Experimental_RBILUK_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Experimental_RBILUK_def.hpp
@@ -846,8 +846,10 @@ apply (const Tpetra::MultiVector<scalar_type,local_ordinal_type,global_ordinal_t
           for (size_t i = 0; i < D_block_->getNodeNumRows(); ++i)
           {
             local_ordinal_type local_row = i;
-            const_host_little_vec_type xval = xBlock.getLocalBlock(local_row, imv, Tpetra::Access::ReadOnly);
-            little_host_vec_type cval = cBlock.getLocalBlock(local_row, imv, Tpetra::Access::OverwriteAll);
+            const_host_little_vec_type xval = 
+                   xBlock.getLocalBlockHost(local_row, imv, Tpetra::Access::ReadOnly);
+            little_host_vec_type cval = 
+                   cBlock.getLocalBlockHost(local_row, imv, Tpetra::Access::OverwriteAll);
             //cval.assign(xval);
             Tpetra::COPY (xval, cval);
 
@@ -860,7 +862,8 @@ apply (const Tpetra::MultiVector<scalar_type,local_ordinal_type,global_ordinal_t
             for (local_ordinal_type j = 0; j < NumL; ++j)
             {
               local_ordinal_type col = colValsL[j];
-              const_host_little_vec_type prevVal = cBlock.getLocalBlock(col, imv, Tpetra::Access::ReadOnly);
+              const_host_little_vec_type prevVal = 
+                    cBlock.getLocalBlockHost(col, imv, Tpetra::Access::ReadOnly);
 
               const local_ordinal_type matOffset = blockMatSize*j;
               little_block_type lij((typename little_block_type::value_type*) &valsL[matOffset],blockSize_,rowStride);
@@ -881,8 +884,10 @@ apply (const Tpetra::MultiVector<scalar_type,local_ordinal_type,global_ordinal_t
           for (local_ordinal_type i = 0; i < numRows; ++i)
           {
             local_ordinal_type local_row = (numRows-1)-i;
-            const_host_little_vec_type rval = rBlock.getLocalBlock(local_row, imv, Tpetra::Access::ReadOnly);
-            little_host_vec_type yval = yBlock.getLocalBlock(local_row, imv, Tpetra::Access::OverwriteAll);
+            const_host_little_vec_type rval = 
+                   rBlock.getLocalBlockHost(local_row, imv, Tpetra::Access::ReadOnly);
+            little_host_vec_type yval = 
+                   yBlock.getLocalBlockHost(local_row, imv, Tpetra::Access::OverwriteAll);
             //yval.assign(rval);
             Tpetra::COPY (rval, yval);
 
@@ -895,7 +900,8 @@ apply (const Tpetra::MultiVector<scalar_type,local_ordinal_type,global_ordinal_t
             for (local_ordinal_type j = 0; j < NumU; ++j)
             {
               local_ordinal_type col = colValsU[NumU-1-j];
-              const_host_little_vec_type prevVal = yBlock.getLocalBlock(col, imv, Tpetra::Access::ReadOnly);
+              const_host_little_vec_type prevVal = 
+                   yBlock.getLocalBlockHost(col, imv, Tpetra::Access::ReadOnly);
 
               const local_ordinal_type matOffset = blockMatSize*(NumU-1-j);
               little_block_type uij((typename little_block_type::value_type*) &valsU[matOffset], blockSize_, rowStride);

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestBlockRelaxation.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestBlockRelaxation.cpp
@@ -708,7 +708,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2BlockRelaxation, TestDiagonalBlockCrsMa
   const Scalar exactSol = 0.2;
 
   for (int k = 0; k < num_rows_per_proc; ++k) {
-    auto ylcl = yBlock.getLocalBlock(k, 0, Tpetra::Access::ReadOnly);
+    auto ylcl = yBlock.getLocalBlockHost(k, 0, Tpetra::Access::ReadOnly);
     for (int j = 0; j < blockSize; ++j) {
       TEST_FLOATING_EQUALITY(ylcl(j), exactSol, 1e-14);
     }
@@ -1269,7 +1269,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2BlockRelaxation, TestLowerTriangularBlo
 
   for (size_t k = 0; k < num_rows_per_proc; ++k) {
     LO lcl_row = k;
-    auto ylcl = yBlock.getLocalBlock(lcl_row, 0, Tpetra::Access::ReadOnly);
+    auto ylcl = yBlock.getLocalBlockHost(lcl_row, 0, Tpetra::Access::ReadOnly);
     for (int j = 0; j < blockSize; ++j) {
       TEST_FLOATING_EQUALITY(ylcl(j), exactSol[k], 1e-14);
     }
@@ -1329,7 +1329,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2BlockRelaxation, TestUpperTriangularBlo
   exactSol[2] = 0.5;
 
   for (int k = 0; k < num_rows_per_proc; ++k) {
-    auto ylcl = yBlock.getLocalBlock(k, 0, Tpetra::Access::ReadOnly);
+    auto ylcl = yBlock.getLocalBlockHost(k, 0, Tpetra::Access::ReadOnly);
     for (int j = 0; j < blockSize; ++j) {
       TEST_FLOATING_EQUALITY(ylcl(j), exactSol[k], 1e-14);
     }

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestRBILUK.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestRBILUK.cpp
@@ -207,7 +207,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(RBILUK, LowerTriangularBlockCrsMatrix, Scalar,
 
   for (size_t k = 0; k < num_rows_per_proc; ++k) {
     LO lcl_row = k;
-    auto ylcl = yBlock.getLocalBlock(lcl_row, 0, Tpetra::Access::ReadOnly);
+    auto ylcl = yBlock.getLocalBlockHost(lcl_row, 0, Tpetra::Access::ReadOnly);
     for (int j = 0; j < blockSize; ++j) {
       TEST_FLOATING_EQUALITY(ylcl(j),exactSol[k],1e-14);
     }
@@ -260,7 +260,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(RBILUK, UpperTriangularBlockCrsMatrix, Scalar,
   exactSol[2] = 0.5;
 
   for (int k = 0; k < num_rows_per_proc; ++k) {
-    auto ylcl = yBlock.getLocalBlock(k, 0, Tpetra::Access::ReadOnly);
+    auto ylcl = yBlock.getLocalBlockHost(k, 0, Tpetra::Access::ReadOnly);
     for (int j = 0; j < blockSize; ++j) {
       TEST_FLOATING_EQUALITY(ylcl(j), exactSol[k], 1e-14);
     }
@@ -313,7 +313,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(RBILUK, FullLocalBlockCrsMatrix, Scalar, Local
   exactSol[2] = 2.0/7.0;
 
   for (int k = 0; k < num_rows_per_proc; ++k) {
-    auto ylcl = yBlock.getLocalBlock(k, 0, Tpetra::Access::ReadOnly);
+    auto ylcl = yBlock.getLocalBlockHost(k, 0, Tpetra::Access::ReadOnly);
     for (int j = 0; j < blockSize; ++j) {
       TEST_FLOATING_EQUALITY(ylcl(j), exactSol[k], 1e-14);
     }
@@ -728,7 +728,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(RBILUK, DiagonalBlockCrsMatrix, Scalar, LocalO
   const Scalar exactSol = 0.2;
 
   for (int k = 0; k < num_rows_per_proc; ++k) {
-    auto ylcl = yBlock.getLocalBlock(k, 0, Tpetra::Access::ReadOnly);
+    auto ylcl = yBlock.getLocalBlockHost(k, 0, Tpetra::Access::ReadOnly);
     for (int j = 0; j < blockSize; ++j) {
       TEST_FLOATING_EQUALITY(ylcl(j), exactSol, 1e-14);
     }

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestRelaxation.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestRelaxation.cpp
@@ -915,7 +915,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2Relaxation, TestDiagonalBlockCrsMatrix,
   const auto tol = mag_type(100.0) * STS::eps();
 
   for (int k = 0; k < num_rows_per_proc; ++k) {
-    auto ylcl = yBlock.getLocalBlock(k, 0, Tpetra::Access::ReadOnly);
+    auto ylcl = yBlock.getLocalBlockHost(k, 0, Tpetra::Access::ReadOnly);
     for (int j = 0; j < blockSize; ++j) {
       TEST_FLOATING_EQUALITY(ylcl(j), exactSol, tol);
     }
@@ -1031,7 +1031,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2Relaxation, TestLowerTriangularBlockCrs
 
   for (size_t k = 0; k < num_rows_per_proc; ++k) {
     LO lcl_row = k;
-    auto ylcl = yBlock.getLocalBlock(lcl_row, 0, Tpetra::Access::ReadOnly);
+    auto ylcl = yBlock.getLocalBlockHost(lcl_row, 0, Tpetra::Access::ReadOnly);
     for (int j = 0; j < blockSize; ++j) {
       TEST_FLOATING_EQUALITY(ylcl(j), exactSol[k], 1e-14);
     }
@@ -1081,7 +1081,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2Relaxation, TestUpperTriangularBlockCrs
   exactSol[2] = 0.5;
 
   for (int k = 0; k < num_rows_per_proc; ++k) {
-    auto ylcl = yBlock.getLocalBlock(k, 0, Tpetra::Access::ReadOnly);
+    auto ylcl = yBlock.getLocalBlockHost(k, 0, Tpetra::Access::ReadOnly);
     for (int j = 0; j < blockSize; ++j) {
       TEST_FLOATING_EQUALITY(ylcl(j), exactSol[k], 1e-14);
     }

--- a/packages/tpetra/core/example/advanced/Benchmarks/blockCrsMatrixMatVec.cpp
+++ b/packages/tpetra/core/example/advanced/Benchmarks/blockCrsMatrixMatVec.cpp
@@ -115,7 +115,7 @@ localApplyBlockNoTrans (Tpetra::BlockCrsMatrix<Scalar, LO, GO, Node>& A,
 
   for (LO j = 0; j < numVecs; ++j) {
     for (LO lclRow = 0; lclRow < numLocalMeshRows; ++lclRow) {
-      auto Y_cur = Y.getLocalBlock (lclRow, j, Tpetra::Access::ReadWrite);
+      auto Y_cur = Y.getLocalBlockHost (lclRow, j, Tpetra::Access::ReadWrite);
       if (beta == zero) {
         FILL (Y_lcl, zero);
       } else if (beta == one) {
@@ -132,7 +132,7 @@ localApplyBlockNoTrans (Tpetra::BlockCrsMatrix<Scalar, LO, GO, Node>& A,
 
         auto A_cur_1d = Kokkos::subview (val, absBlkOff * blockSize * blockSize);
         little_blk_type A_cur (A_cur_1d.data (), blockSize, blockSize);
-        auto X_cur = X.getLocalBlock (meshCol, j, Tpetra::Access::ReadOnly);
+        auto X_cur = X.getLocalBlockHost (meshCol, j, Tpetra::Access::ReadOnly);
 
         GEMV (alpha, A_cur, X_cur, Y_lcl); // Y_lcl += alpha*A_cur*X_cur
       } // for each entry in the current local row of the matrix

--- a/packages/tpetra/core/src/Tpetra_BlockMultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockMultiVector_decl.hpp
@@ -577,39 +577,63 @@ public:
   ///   is invalid on the calling process.
   bool sumIntoGlobalValues (const GO globalRowIndex, const LO colIndex, const Scalar vals[]);
 
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+  /// \brief Get a writeable view of the entries at the given mesh
+  ///   point, using a local index.
+  ///
+  /// \param localRowIndex [in] Local index of the mesh point.
+  /// \param colIndex [in] Column (vector) to view.
+  /// \param vals [out] View of the entries at the given mesh point.
+  ///
+  /// \return true if successful, else false.  This method will
+  ///   <i>not</i> succeed if the given local index of the mesh point
+  ///   is invalid on the calling process.
+  // TPETRA_DEPRECATED
+  bool getLocalRowView (const LO localRowIndex, const LO colIndex, Scalar*& vals);
+
+  /// \brief Get a writeable view of the entries at the given mesh
+  ///   point, using a global index.
+  ///
+  /// \param globalRowIndex [in] Global index of the mesh point.
+  /// \param colIndex [in] Column (vector) to view.
+  /// \param vals [out] View of the entries at the given mesh point.
+  ///
+  /// \return true if successful, else false.  This method will
+  ///   <i>not</i> succeed if the given global index of the mesh point
+  ///   is invalid on the calling process.
+  // TPETRA_DEPRECATED
+  bool getGlobalRowView (const GO globalRowIndex, const LO colIndex, Scalar*& vals);
+
   /// \brief Get a host view of the degrees of freedom at the given
   ///   mesh point.
-  ///
-  /// \warning This method's interface may change or disappear at any
-  ///   time.  Please do not rely on it in your code yet.
   ///
   /// Prefer using \c auto to let the compiler compute the return
   /// type.  This gives us the freedom to change this type in the
   /// future.  If you insist not to use \c auto, then please use the
   /// \c little_vec_type typedef to deduce the correct return type;
   /// don't try to hard-code the return type yourself.
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
   //TPETRA_DEPRECATED 
-  little_host_vec_type getLocalBlock (const LO localRowIndex, const LO colIndex) const;
-#endif //TPETRA_DEPRECATED
+  little_host_vec_type getLocalBlock (const LO localRowIndex, const LO colIndex);
 
-  const_little_host_vec_type getLocalBlock(
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+
+  const_little_host_vec_type getLocalBlockHost(
     const LO localRowIndex, 
     const LO colIndex, 
-    Access::ReadOnlyStruct) const;
+    const Access::ReadOnlyStruct) const;
 
-  little_host_vec_type getLocalBlock(
+  little_host_vec_type getLocalBlockHost(
     const LO localRowIndex, 
     const LO colIndex, 
-    Access::ReadWriteStruct);
+    const Access::ReadWriteStruct);
 
   /// \brief Get a local block on host, with the intent to overwrite all blocks in the BlockMultiVector
-  ///   before accessing the data on device. If you only intend to modify some blocks on host, use ReadWrite
-  ///   instead (otherwise, previous changes on device may be lost)
-  little_host_vec_type getLocalBlock(
+  ///   before accessing the data on device. If you intend to modify only some blocks on host, use 
+  ///   Access::ReadWrite instead (otherwise, previous changes on device may be lost)
+  little_host_vec_type getLocalBlockHost(
     const LO localRowIndex, 
     const LO colIndex, 
-    Access::OverwriteAllStruct);
+    const Access::OverwriteAllStruct);
   //@}
 
 protected:

--- a/packages/tpetra/core/src/Tpetra_BlockVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockVector_decl.hpp
@@ -315,11 +315,35 @@ public:
   ///   is invalid on the calling process.
   bool sumIntoGlobalValues (const GO globalRowIndex, const Scalar vals[]);
 
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+  /// \brief Get a writeable view of the entries at the given mesh
+  ///   point, using a local index.
+  ///
+  /// \param localRowIndex [in] Local index of the mesh point.
+  /// \param vals [in] Input values with which to replace whatever
+  ///   existing values are at the mesh point.
+  ///
+  /// \return true if successful, else false.  This method will
+  ///   <i>not</i> succeed if the given local index of the mesh point
+  ///   is invalid on the calling process.
+  bool getLocalRowView (const LO localRowIndex, Scalar*& vals);
+
+  /// \brief Get a writeable view of the entries at the given mesh
+  ///   point, using a global index.
+  ///
+  /// \param globalRowIndex [in] Global index of the mesh point.
+  /// \param vals [in] Input values with which to replace whatever
+  ///   existing values are at the mesh point.
+  ///
+  /// \return true if successful, else false.  This method will
+  ///   <i>not</i> succeed if the given global index of the mesh point
+  ///   is invalid on the calling process.
+  bool getGlobalRowView (const GO globalRowIndex, Scalar*& vals);
+
+#endif //TPETRA_ENABLE_DEPRECATED_CODE
+
   /// \brief Get a view of the degrees of freedom at the given mesh point,
   ///   using a local index.
-  ///
-  /// \warning This method's interface may change or disappear at any
-  ///   time.  Please do not rely on it in your code yet.
   ///
   /// The preferred way to refer to little_vec_type is to get it from
   /// BlockVector's typedef.  This is because different
@@ -329,14 +353,14 @@ public:
   /// refactor version.
 #ifdef TPETRA_ENABLE_DEPRECATED_CODE
   //TPETRA_DEPRECATED 
-  little_host_vec_type getLocalBlock (const LO localRowIndex) const;
+  little_host_vec_type getLocalBlock (const LO localRowIndex);
 #endif
-  const_little_host_vec_type getLocalBlock (const LO localRowIndex,
-                                            Access::ReadOnlyStruct) const;
-  little_host_vec_type getLocalBlock (const LO localRowIndex,
-                                      Access::OverwriteAllStruct);
-  little_host_vec_type getLocalBlock (const LO localRowIndex,
-                                      Access::ReadWriteStruct);
+  const_little_host_vec_type getLocalBlockHost (const LO localRowIndex,
+                                                Access::ReadOnlyStruct) const;
+  little_host_vec_type getLocalBlockHost (const LO localRowIndex,
+                                          Access::OverwriteAllStruct);
+  little_host_vec_type getLocalBlockHost (const LO localRowIndex,
+                                          Access::ReadWriteStruct);
   //@}
 };
 

--- a/packages/tpetra/core/src/Tpetra_BlockVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockVector_def.hpp
@@ -146,10 +146,26 @@ namespace Tpetra {
 
 #ifdef TPETRA_ENABLE_DEPRECATED_CODE
   template<class Scalar, class LO, class GO, class Node>
-  typename BlockVector<Scalar, LO, GO, Node>::little_host_vec_type
-  TPETRA_DEPRECATED
+  bool
+  // TPETRA_DEPRECATED
   BlockVector<Scalar, LO, GO, Node>::
-  getLocalBlock (const LO localRowIndex) const
+  getLocalRowView (const LO localRowIndex, Scalar*& vals) {
+    return ((base_type*) this)->getLocalRowView (localRowIndex, 0, vals);
+  }
+
+  template<class Scalar, class LO, class GO, class Node>
+  bool
+  // TPETRA_DEPRECATED
+  BlockVector<Scalar, LO, GO, Node>::
+  getGlobalRowView (const GO globalRowIndex, Scalar*& vals) {
+    return ((base_type*) this)->getGlobalRowView (globalRowIndex, 0, vals);
+  }
+
+  template<class Scalar, class LO, class GO, class Node>
+  typename BlockVector<Scalar, LO, GO, Node>::little_host_vec_type
+  // TPETRA_DEPRECATED
+  BlockVector<Scalar, LO, GO, Node>::
+  getLocalBlock (const LO localRowIndex)
   {
     if (! this->isValidLocalMeshIndex (localRowIndex)) {
       return little_host_vec_type ();
@@ -165,30 +181,29 @@ namespace Tpetra {
   template<class Scalar, class LO, class GO, class Node>
   typename BlockVector<Scalar, LO, GO, Node>::const_little_host_vec_type
   BlockVector<Scalar, LO, GO, Node>::
-  getLocalBlock (const LO localRowIndex, Access::ReadOnlyStruct) const
+  getLocalBlockHost (const LO localRowIndex, Access::ReadOnlyStruct) const
   {
-    return ((const base_type*) this)->getLocalBlock(localRowIndex, 0, 
-                                                    Access::ReadOnly);
+    return ((const base_type*) this)->getLocalBlockHost(localRowIndex, 0, 
+                                                        Access::ReadOnly);
   }
 
   template<class Scalar, class LO, class GO, class Node>
   typename BlockVector<Scalar, LO, GO, Node>::little_host_vec_type
   BlockVector<Scalar, LO, GO, Node>::
-  getLocalBlock (const LO localRowIndex, Access::ReadWriteStruct)
+  getLocalBlockHost (const LO localRowIndex, Access::ReadWriteStruct)
   {
-    return ((base_type*) this)->getLocalBlock(localRowIndex, 0, 
-                                              Access::ReadWrite);
+    return ((base_type*) this)->getLocalBlockHost(localRowIndex, 0, 
+                                                  Access::ReadWrite);
   }
 
   template<class Scalar, class LO, class GO, class Node>
   typename BlockVector<Scalar, LO, GO, Node>::little_host_vec_type
   BlockVector<Scalar, LO, GO, Node>::
-  getLocalBlock (const LO localRowIndex, Access::OverwriteAllStruct)
+  getLocalBlockHost (const LO localRowIndex, Access::OverwriteAllStruct)
   {
-    return ((base_type*) this)->getLocalBlock(localRowIndex, 0, 
-                                              Access::OverwriteAll);
+    return ((base_type*) this)->getLocalBlockHost(localRowIndex, 0, 
+                                                  Access::OverwriteAll);
   }
-
 
 } // namespace Tpetra
 

--- a/packages/tpetra/core/test/Block/BlockCrsMatrix.cpp
+++ b/packages/tpetra/core/test/Block/BlockCrsMatrix.cpp
@@ -436,7 +436,7 @@ namespace {
       const map_type& meshDomainMap = * (graph.getDomainMap ());
       for (LO lclDomIdx = meshDomainMap.getMinLocalIndex ();
            lclDomIdx <= meshDomainMap.getMaxLocalIndex (); ++lclDomIdx) {
-        auto X_lcl = X.getLocalBlock (lclDomIdx, Tpetra::Access::OverwriteAll);
+        auto X_lcl = X.getLocalBlockHost (lclDomIdx, Tpetra::Access::OverwriteAll);
         TEST_ASSERT( X_lcl.data () != NULL );
         TEST_ASSERT( static_cast<size_t> (X_lcl.extent (0)) == static_cast<size_t> (blockSize) );
         for (LO i = 0; i < blockSize; ++i) {
@@ -450,7 +450,7 @@ namespace {
       const map_type& meshRangeMap = * (graph.getRangeMap ());
       for (LO lclRanIdx = meshRangeMap.getMinLocalIndex ();
            lclRanIdx <= meshRangeMap.getMaxLocalIndex (); ++lclRanIdx) {
-        auto Y_lcl = Y.getLocalBlock (lclRanIdx, Tpetra::Access::ReadOnly);
+        auto Y_lcl = Y.getLocalBlockHost (lclRanIdx, Tpetra::Access::ReadOnly);
         TEST_ASSERT( Y_lcl.data () != NULL );
         TEST_ASSERT( static_cast<size_t> (Y_lcl.extent (0)) == static_cast<size_t> (blockSize) );
 
@@ -482,7 +482,7 @@ namespace {
 
       for (LO lclRanIdx = meshRangeMap.getMinLocalIndex ();
            lclRanIdx <= meshRangeMap.getMaxLocalIndex (); ++lclRanIdx) {
-        auto Y_lcl = Y.getLocalBlock (lclRanIdx, Tpetra::Access::ReadOnly);
+        auto Y_lcl = Y.getLocalBlockHost (lclRanIdx, Tpetra::Access::ReadOnly);
         TEST_ASSERT( Y_lcl.data () != NULL );
         TEST_ASSERT( static_cast<size_t> (Y_lcl.extent (0)) == static_cast<size_t> (blockSize) );
 
@@ -547,7 +547,7 @@ namespace {
       for (LO lclDomIdx = meshDomainMap.getMinLocalIndex ();
            lclDomIdx <= meshDomainMap.getMaxLocalIndex (); ++lclDomIdx) {
         for (LO j = 0; j < numVecs; ++j) {
-          auto X_lcl = X.getLocalBlock(lclDomIdx, j, Tpetra::Access::OverwriteAll);
+          auto X_lcl = X.getLocalBlockHost(lclDomIdx, j, Tpetra::Access::OverwriteAll);
           TEST_ASSERT( X_lcl.data () != NULL );
           TEST_ASSERT( static_cast<size_t> (X_lcl.extent (0)) == static_cast<size_t> (blockSize) );
           for (LO i = 0; i < blockSize; ++i) {
@@ -563,7 +563,7 @@ namespace {
       for (LO lclRanIdx = meshRangeMap.getMinLocalIndex ();
            lclRanIdx <= meshRangeMap.getMaxLocalIndex (); ++lclRanIdx) {
         for (LO col = 0; col < numVecs; ++col) {
-          auto Y_lcl = Y.getLocalBlock (lclRanIdx, col, Tpetra::Access::ReadOnly);
+          auto Y_lcl = Y.getLocalBlockHost (lclRanIdx, col, Tpetra::Access::ReadOnly);
           TEST_ASSERT( Y_lcl.data () != NULL );
           TEST_ASSERT( static_cast<size_t> (Y_lcl.extent (0)) == static_cast<size_t> (blockSize) );
 
@@ -598,7 +598,7 @@ namespace {
       for (LO lclRanIdx = meshRangeMap.getMinLocalIndex ();
            lclRanIdx <= meshRangeMap.getMaxLocalIndex (); ++lclRanIdx) {
         for (LO col = 0; col < numVecs; ++col) {
-          auto Y_lcl = Y.getLocalBlock (lclRanIdx, col, Tpetra::Access::ReadOnly);
+          auto Y_lcl = Y.getLocalBlockHost (lclRanIdx, col, Tpetra::Access::ReadOnly);
           TEST_ASSERT( Y_lcl.data () != NULL );
           TEST_ASSERT( static_cast<size_t> (Y_lcl.extent (0)) == static_cast<size_t> (blockSize) );
 
@@ -659,7 +659,7 @@ namespace {
       const map_type& meshDomainMap = * (graph.getDomainMap ());
       for (LO lclDomIdx = meshDomainMap.getMinLocalIndex ();
            lclDomIdx <= meshDomainMap.getMaxLocalIndex (); ++lclDomIdx) {
-        auto X_lcl = X.getLocalBlock (lclDomIdx, Tpetra::Access::OverwriteAll);
+        auto X_lcl = X.getLocalBlockHost (lclDomIdx, Tpetra::Access::OverwriteAll);
         TEST_ASSERT( X_lcl.data () != NULL );
         TEST_ASSERT( static_cast<size_t> (X_lcl.extent (0)) == static_cast<size_t> (blockSize) );
         for (LO i = 0; i < blockSize; ++i) {
@@ -680,7 +680,7 @@ namespace {
       const map_type& meshRangeMap = * (graph.getRangeMap ());
       for (LO lclRanIdx = meshRangeMap.getMinLocalIndex ();
            lclRanIdx <= meshRangeMap.getMaxLocalIndex (); ++lclRanIdx) {
-        auto Y_lcl = Y.getLocalBlock (lclRanIdx, Tpetra::Access::ReadOnly);
+        auto Y_lcl = Y.getLocalBlockHost (lclRanIdx, Tpetra::Access::ReadOnly);
         TEST_ASSERT( Y_lcl.data () != NULL );
         TEST_ASSERT( static_cast<size_t> (Y_lcl.extent (0)) == static_cast<size_t> (blockSize) );
 
@@ -712,7 +712,7 @@ namespace {
 
       for (LO lclRanIdx = meshRangeMap.getMinLocalIndex ();
            lclRanIdx <= meshRangeMap.getMaxLocalIndex (); ++lclRanIdx) {
-        auto Y_lcl = Y.getLocalBlock (lclRanIdx, Tpetra::Access::ReadOnly);
+        auto Y_lcl = Y.getLocalBlockHost (lclRanIdx, Tpetra::Access::ReadOnly);
         TEST_ASSERT( Y_lcl.data () != NULL );
         TEST_ASSERT( static_cast<size_t> (Y_lcl.extent (0)) == static_cast<size_t> (blockSize) );
 
@@ -777,7 +777,7 @@ namespace {
       for (LO lclDomIdx = meshDomainMap.getMinLocalIndex ();
            lclDomIdx <= meshDomainMap.getMaxLocalIndex (); ++lclDomIdx) {
         for (LO j = 0; j < numVecs; ++j) {
-          auto X_lcl = X.getLocalBlock(lclDomIdx, j, Tpetra::Access::OverwriteAll);
+          auto X_lcl = X.getLocalBlockHost(lclDomIdx, j, Tpetra::Access::OverwriteAll);
           TEST_ASSERT( X_lcl.data () != NULL );
           TEST_ASSERT( static_cast<size_t> (X_lcl.extent (0)) == static_cast<size_t> (blockSize) );
           for (LO i = 0; i < blockSize; ++i) {
@@ -800,7 +800,7 @@ namespace {
       for (LO lclRanIdx = meshRangeMap.getMinLocalIndex ();
            lclRanIdx <= meshRangeMap.getMaxLocalIndex (); ++lclRanIdx) {
         for (LO col = 0; col < numVecs; ++col) {
-          auto Y_lcl = Y.getLocalBlock (lclRanIdx, col, Tpetra::Access::ReadOnly);
+          auto Y_lcl = Y.getLocalBlockHost (lclRanIdx, col, Tpetra::Access::ReadOnly);
           TEST_ASSERT( Y_lcl.data () != NULL );
           TEST_ASSERT( static_cast<size_t> (Y_lcl.extent (0)) == static_cast<size_t> (blockSize) );
 
@@ -835,7 +835,7 @@ namespace {
       for (LO lclRanIdx = meshRangeMap.getMinLocalIndex ();
            lclRanIdx <= meshRangeMap.getMaxLocalIndex (); ++lclRanIdx) {
         for (LO col = 0; col < numVecs; ++col) {
-          auto Y_lcl = Y.getLocalBlock (lclRanIdx, col, Tpetra::Access::ReadOnly);
+          auto Y_lcl = Y.getLocalBlockHost (lclRanIdx, col, Tpetra::Access::ReadOnly);
           TEST_ASSERT( Y_lcl.data () != NULL );
           TEST_ASSERT( static_cast<size_t> (Y_lcl.extent (0)) == static_cast<size_t> (blockSize) );
 
@@ -1343,7 +1343,7 @@ namespace {
     const LO myMinLclMeshRow = Y.getMap ()->getMinLocalIndex ();
     const LO myMaxLclMeshRow = Y.getMap ()->getMaxLocalIndex ();
     for (LO lclMeshRow = myMinLclMeshRow; lclMeshRow <= myMaxLclMeshRow; ++lclMeshRow) {
-      auto Y_lcl = Y.getLocalBlock (lclMeshRow, 0, Tpetra::Access::ReadOnly);
+      auto Y_lcl = Y.getLocalBlockHost (lclMeshRow, 0, Tpetra::Access::ReadOnly);
       for (LO i = 0; i < blockSize; ++i) {
         TEST_EQUALITY( static_cast<Scalar> (Y_lcl(i)), requiredValue );
       }
@@ -1354,7 +1354,7 @@ namespace {
     Kokkos::fence ();
 
     for (LO lclMeshRow = myMinLclMeshRow; lclMeshRow <= myMaxLclMeshRow; ++lclMeshRow) {
-      auto Y_lcl = Y.getLocalBlock (lclMeshRow, 0, Tpetra::Access::ReadOnly);
+      auto Y_lcl = Y.getLocalBlockHost (lclMeshRow, 0, Tpetra::Access::ReadOnly);
       for (LO i = 0; i < blockSize; ++i) {
         TEST_EQUALITY( static_cast<Scalar> (Y_lcl(i)), STS::zero () );
       }
@@ -1506,7 +1506,7 @@ namespace {
     const LO myMaxLclMeshRow = Y.getMap ()->getMaxLocalIndex ();
     bool valsMatch = true;
     for (LO lclMeshRow = myMinLclMeshRow; lclMeshRow <= myMaxLclMeshRow; ++lclMeshRow) {
-      auto Y_lcl = Y.getLocalBlock (lclMeshRow, 0, Tpetra::Access::ReadOnly);
+      auto Y_lcl = Y.getLocalBlockHost (lclMeshRow, 0, Tpetra::Access::ReadOnly);
       for (LO i = 0; i < blockSize; ++i) {
         if (static_cast<Scalar> (Y_lcl(i)) != requiredValue) {
           valsMatch = false;
@@ -1753,7 +1753,7 @@ namespace {
       // const LO myMaxLclMeshRow = Y.getMap ()->getMaxLocalIndex ();
       // bool valsMatch = true;
       // for (LO lclMeshRow = myMinLclMeshRow; lclMeshRow <= myMaxLclMeshRow; ++lclMeshRow) {
-      //   auto Y_lcl = Y.getLocalBlock(lclMeshRow, 0,Tpetra::Access::ReadOnly);
+      //   auto Y_lcl = Y.getLocalBlockHost(lclMeshRow, 0,Tpetra::Access::ReadOnly);
       //   for (LO i = 0; i < blockSize; ++i) {
       //     if (Y_lcl(i) != requiredValue) {
       //       valsMatch = false;

--- a/packages/tpetra/core/test/Block/BlockMultiVector.cpp
+++ b/packages/tpetra/core/test/Block/BlockMultiVector.cpp
@@ -289,7 +289,7 @@ namespace {
     // has 48 rows on each process: 12 mesh points, and 4 degrees of
     // freedom per mesh point ("block size").  Rows 20-23 thus
     // correspond to local mesh point 5.
-    auto X_5_1 = X.getLocalBlock (5, colToModify, Tpetra::Access::ReadWrite);
+    auto X_5_1 = X.getLocalBlockHost (5, colToModify, Tpetra::Access::ReadWrite);
 
     // All entries of X_5_1 must be zero.  First make a block with all
     // zero entries, then test.  It's not worth testing the
@@ -307,10 +307,10 @@ namespace {
     }
     TEST_ASSERT( ! equal (X_5_1, zeroLittleVector) && ! equal (zeroLittleVector, X_5_1) );
 
-    // Make sure that getLocalBlock() returns a read-and-write view,
-    // not a deep copy.  Do this by calling getLocalBlock(5,1) again,
+    // Make sure that getLocalBlockHost() returns a read-and-write view,
+    // not a deep copy.  Do this by calling getLocalBlockHost(5,1) again,
     // and testing that changes to X_5_1 are reflected in the result.
-    auto X_5_1_new = X.getLocalBlock (5, colToModify, Tpetra::Access::ReadOnly);
+    auto X_5_1_new = X.getLocalBlockHost (5, colToModify, Tpetra::Access::ReadOnly);
     TEST_ASSERT( equal (X_5_1_new, X_5_1) && equal (X_5_1, X_5_1_new) );
     TEST_ASSERT( ! equal (X_5_1_new, zeroLittleVector) &&
                  ! equal (zeroLittleVector, X_5_1_new) );
@@ -320,7 +320,7 @@ namespace {
          localMeshIndex < static_cast<LO> (numLocalMeshPoints);
          ++localMeshIndex) {
       for (LO curCol = 0; curCol < numVecs; ++curCol) {
-        auto X_cur = X.getLocalBlock (localMeshIndex, curCol,
+        auto X_cur = X.getLocalBlockHost (localMeshIndex, curCol,
                                       Tpetra::Access::ReadOnly);
         if (curCol != colToModify) {
           TEST_ASSERT( equal (X_cur, zeroLittleVector) &&
@@ -427,7 +427,7 @@ namespace {
     const LO colToModify = 1;
     {
       auto X_overlap =
-        X.getLocalBlock (meshMap.getLocalElement (meshMap.getMinGlobalIndex ()), 
+        X.getLocalBlockHost (meshMap.getLocalElement (meshMap.getMinGlobalIndex ()), 
                          colToModify, Tpetra::Access::OverwriteAll);
       TEST_ASSERT( X_overlap.data () != NULL );
       TEST_EQUALITY_CONST( static_cast<size_t> (X_overlap.extent (0)),
@@ -455,7 +455,7 @@ namespace {
 
     {
       auto X_overlap =
-           X.getLocalBlock (meshMap.getLocalElement(meshMap.getMinGlobalIndex()), 
+           X.getLocalBlockHost (meshMap.getLocalElement(meshMap.getMinGlobalIndex()), 
                             colToModify, Tpetra::Access::ReadOnly);
 
       typename BMV::little_host_vec_type zeroLittleVector ("zero", blockSize);
@@ -464,7 +464,7 @@ namespace {
       for (LO col = 0; col < numVecs; ++col) {
         for (LO localMeshRow = meshMap.getMinLocalIndex ();
              localMeshRow < meshMap.getMaxLocalIndex (); ++localMeshRow) {
-          auto Y_cur = Y.getLocalBlock (localMeshRow, col,
+          auto Y_cur = Y.getLocalBlockHost (localMeshRow, col,
                                         Tpetra::Access::ReadOnly);
           if (col != colToModify) {
             TEST_ASSERT( equal (Y_cur, zeroLittleVector) &&

--- a/packages/tpetra/core/test/Block/BlockMultiVector2.cpp
+++ b/packages/tpetra/core/test/Block/BlockMultiVector2.cpp
@@ -287,8 +287,8 @@ namespace {
       curScalingFactor = one;
       for (LO whichBlk = 0; whichBlk < numLocalMeshPoints; ++whichBlk) {
         for (LO whichVec = 0; whichVec < numVecs; ++whichVec) {
-          auto X_cur = X.getLocalBlock (whichBlk, whichVec,
-                                        Tpetra::Access::ReadWrite);
+          auto X_cur = X.getLocalBlockHost (whichBlk, whichVec,
+                                            Tpetra::Access::ReadWrite);
           // This doesn't actually assume UVM, since we're modifying
           // the current block of X on the host.  The sync below will
           // sync back to device memory.
@@ -315,8 +315,8 @@ namespace {
       curScalingFactor = one;
       for (LO whichBlk = 0; whichBlk < numLocalMeshPoints; ++whichBlk) {
         for (LO whichVec = 0; whichVec < numVecs; ++whichVec) {
-          auto Y_cur = Y.getLocalBlock (whichBlk, whichVec,
-                                        Tpetra::Access::ReadOnly);
+          auto Y_cur = Y.getLocalBlockHost (whichBlk, whichVec,
+                                            Tpetra::Access::ReadOnly);
 
           // Compare Y_cur normwise to prototypeY.  This doesn't
           // actually assume UVM, since we're modifying the host
@@ -350,8 +350,8 @@ namespace {
       curScalingFactor = one;
       for (LO whichBlk = 0; whichBlk < numLocalMeshPoints; ++whichBlk) {
         for (LO whichVec = 0; whichVec < numVecs; ++whichVec) {
-          auto Y_cur = Y.getLocalBlock (whichBlk, whichVec,
-                                        Tpetra::Access::ReadOnly);
+          auto Y_cur = Y.getLocalBlockHost (whichBlk, whichVec,
+                                            Tpetra::Access::ReadOnly);
 
           // Compare Y_cur normwise to prototypeY.  This doesn't
           // actually assume UVM, since we're modifying the host
@@ -519,8 +519,8 @@ namespace {
       curScalingFactor = one;
       for (LO whichBlk = 0; whichBlk < numLocalMeshPoints; ++whichBlk) {
         for (LO whichVec = 0; whichVec < numVecs; ++whichVec) {
-          auto X_cur = X.getLocalBlock (whichBlk, whichVec,
-                                        Tpetra::Access::ReadWrite);
+          auto X_cur = X.getLocalBlockHost (whichBlk, whichVec,
+                                            Tpetra::Access::ReadWrite);
           // This doesn't actually assume UVM, since we're modifying
           // the current block of X on the host.  The sync below will
           // sync back to device memory.


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

Functions getLocalRowView and getGlobalRowView were removed without deprecation from BlockMultiVector and BlockVector.  This removal without deprecation was reported in #9082.  This PR restores the functions.  

However, users should migrate away from use of BlockMultiVector's getLocalRowView and getGlobalRowView, as they are deprecated.  These functions are completely unsafe with UVM is disabled; their returning of a raw data pointer is not allowed in non-UVM Tpetra.

This PR also renames getLocalBlock to getLocalBlockHost, to more accurately reflect what is returned (and, indeed, what has always been returned by getLocalBlock, getLocalRowView and getGlobalRowView).



## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

Following Trilinos' deprecation policy.



## Related Issues

* Closes  #9082



## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
@tcfisher please let us know whether this PR resolves #9082

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
ascicgpu with UVM and Deprecated code; ascicgpu without UVM

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->