### PR TITLE
ATDM/van1-tx2: Default to arm-20.1-openmpi-4.0.5

### DIFF
--- a/cmake/std/atdm/van1-tx2/custom_builds.sh
+++ b/cmake/std/atdm/van1-tx2/custom_builds.sh
@@ -4,25 +4,25 @@
 
 # Try matching against arm-20.1 before arm-20 or arm
 if atdm_match_any_buildname_keyword \
-     arm-20.1-openmpi-4.0.5 \
-     arm-20.1_openmpi-4.0.5 \
-  ; then
-  export ATDM_CONFIG_COMPILER=ARM-20.1_OPENMPI-4.0.5
-elif atdm_match_any_buildname_keyword \
-     arm-20.1-openmpi-4.0.3 \
-     arm-20.1_openmpi-4.0.3 \
-     arm-20.1 \
-  ; then
-  export ATDM_CONFIG_COMPILER=ARM-20.1_OPENMPI-4.0.3
-elif atdm_match_any_buildname_keyword \
      arm-20.0-openmpi-4.0.2 \
      arm-20.0_openmpi-4.0.2 \
      arm-20.0 \
+  ; then
+  export ATDM_CONFIG_COMPILER=ARM-20.0_OPENMPI-4.0.2
+elif atdm_match_any_buildname_keyword \
+     arm-20.1-openmpi-4.0.3 \
+     arm-20.1_openmpi-4.0.3 \
+  ; then
+  export ATDM_CONFIG_COMPILER=ARM-20.1_OPENMPI-4.0.3
+elif atdm_match_any_buildname_keyword \
+     arm-20.1-openmpi-4.0.5 \
+     arm-20.1_openmpi-4.0.5 \
+     arm-20.1 \
      arm-20 \
      arm \
      default \
   ; then
-  export ATDM_CONFIG_COMPILER=ARM-20.0_OPENMPI-4.0.2
+  export ATDM_CONFIG_COMPILER=ARM-20.1_OPENMPI-4.0.5
 else
   echo
   echo "***"
@@ -30,9 +30,9 @@ else
   echo "***"
   echo "*** Supported compilers include:"
   echo "***"
-  echo "****  arm-20.0-openmpi-4.0.2    (arm-20.0, default)"
-  echo "****  arm-20.1-openmpi-4.0.3    (arm-20.1)"
-  echo "****  arm-20.1-openmpi-4.0.5"
+  echo "****  arm-20.0-openmpi-4.0.2    (arm-20.0)"
+  echo "****  arm-20.1-openmpi-4.0.3"
+  echo "****  arm-20.1-openmpi-4.0.5    (arm, arm-20, arm-20.1, default)"
   echo "***"
   return
 

--- a/cmake/std/atdm/van1-tx2/custom_builds_unit_tests.sh
+++ b/cmake/std/atdm/van1-tx2/custom_builds_unit_tests.sh
@@ -13,10 +13,6 @@ testAll() {
   ATDM_CONFIG_SYSTEM_DIR=${ATDM_CONFIG_SCRIPT_DIR}/van1-tx2
 
   #### TEST ARM-20.0 ####
-  ATDM_CONFIG_BUILD_NAME=default
-  . ${ATDM_CONFIG_SCRIPT_DIR}/utils/set_build_options.sh
-  ${_ASSERT_EQUALS_} ARM-20.0_OPENMPI-4.0.2 ${ATDM_CONFIG_COMPILER}
-
   ATDM_CONFIG_BUILD_NAME=before-arm-20.0-openmpi-4.0.2_after
   . ${ATDM_CONFIG_SCRIPT_DIR}/utils/set_build_options.sh
   ${_ASSERT_EQUALS_} ARM-20.0_OPENMPI-4.0.2 ${ATDM_CONFIG_COMPILER}
@@ -28,23 +24,6 @@ testAll() {
   ATDM_CONFIG_BUILD_NAME=before_arm-20.0-after
   . ${ATDM_CONFIG_SCRIPT_DIR}/utils/set_build_options.sh
   ${_ASSERT_EQUALS_} ARM-20.0_OPENMPI-4.0.2 ${ATDM_CONFIG_COMPILER}
-
-  ATDM_CONFIG_BUILD_NAME=before_arm-20-afert
-  . ${ATDM_CONFIG_SCRIPT_DIR}/utils/set_build_options.sh
-  ${_ASSERT_EQUALS_} ARM-20.0_OPENMPI-4.0.2 ${ATDM_CONFIG_COMPILER}
-
-  ATDM_CONFIG_BUILD_NAME=before-arm-after
-  . ${ATDM_CONFIG_SCRIPT_DIR}/utils/set_build_options.sh
-  ${_ASSERT_EQUALS_} ARM-20.0_OPENMPI-4.0.2 ${ATDM_CONFIG_COMPILER}
-
-  ATDM_CONFIG_BUILD_NAME=BEFORE-ARM-AFTER
-  . ${ATDM_CONFIG_SCRIPT_DIR}/utils/set_build_options.sh
-  ${_ASSERT_EQUALS_} ARM-20.0_OPENMPI-4.0.2 ${ATDM_CONFIG_COMPILER}
-
-  # Make sure 'arms' does not match 'arm'
-  ATDM_CONFIG_BUILD_NAME=anything-arms
-  . ${ATDM_CONFIG_SCRIPT_DIR}/utils/set_build_options.sh
-  ${_ASSERT_EQUALS_} DEFAULT ${ATDM_CONFIG_COMPILER}
 
   #### Test ARM-20.1 ####
   ATDM_CONFIG_BUILD_NAME=before-arm-20.1-openmpi-4.0.3_after
@@ -63,9 +42,30 @@ testAll() {
   . ${ATDM_CONFIG_SCRIPT_DIR}/utils/set_build_options.sh
   ${_ASSERT_EQUALS_} ARM-20.1_OPENMPI-4.0.5 ${ATDM_CONFIG_COMPILER}
 
+  ATDM_CONFIG_BUILD_NAME=default
+  . ${ATDM_CONFIG_SCRIPT_DIR}/utils/set_build_options.sh
+  ${_ASSERT_EQUALS_} ARM-20.1_OPENMPI-4.0.5 ${ATDM_CONFIG_COMPILER}
+
+  ATDM_CONFIG_BUILD_NAME=before_arm-20-afert
+  . ${ATDM_CONFIG_SCRIPT_DIR}/utils/set_build_options.sh
+  ${_ASSERT_EQUALS_} ARM-20.1_OPENMPI-4.0.5 ${ATDM_CONFIG_COMPILER}
+
+  ATDM_CONFIG_BUILD_NAME=before-arm-after
+  . ${ATDM_CONFIG_SCRIPT_DIR}/utils/set_build_options.sh
+  ${_ASSERT_EQUALS_} ARM-20.1_OPENMPI-4.0.5 ${ATDM_CONFIG_COMPILER}
+
+  ATDM_CONFIG_BUILD_NAME=BEFORE-ARM-AFTER
+  . ${ATDM_CONFIG_SCRIPT_DIR}/utils/set_build_options.sh
+  ${_ASSERT_EQUALS_} ARM-20.1_OPENMPI-4.0.5 ${ATDM_CONFIG_COMPILER}
+
+  # Make sure 'arms' does not match 'arm'
+  ATDM_CONFIG_BUILD_NAME=anything-arms
+  . ${ATDM_CONFIG_SCRIPT_DIR}/utils/set_build_options.sh
+  ${_ASSERT_EQUALS_} DEFAULT ${ATDM_CONFIG_COMPILER}
+
   ATDM_CONFIG_BUILD_NAME=before_arm-20.1-after
   . ${ATDM_CONFIG_SCRIPT_DIR}/utils/set_build_options.sh
-  ${_ASSERT_EQUALS_}  ARM-20.1_OPENMPI-4.0.3 ${ATDM_CONFIG_COMPILER}
+  ${_ASSERT_EQUALS_} ARM-20.1_OPENMPI-4.0.5 ${ATDM_CONFIG_COMPILER}
 
 }
 


### PR DESCRIPTION
## How was this tested?
Via the auto-tester and `custom_builds_unit_tests.sh`.

Related to #9100.