### PR TITLE
Tribits, Amesos: Remove spaces around time.h, allow superlu_dist without parmetis

### DIFF
--- a/cmake/tribits/win_interface/include/gettimeofday.c
+++ b/cmake/tribits/win_interface/include/gettimeofday.c
@@ -1,4 +1,4 @@
-#include < time.h >
+#include <time.h>
 #include <Winsock2.h> /* to get timeval struct */
 
 struct timezone 

--- a/packages/amesos/CMakeLists.txt
+++ b/packages/amesos/CMakeLists.txt
@@ -9,10 +9,11 @@ TRIBITS_PACKAGE(Amesos)
 #
 # B) Set up package-specific options
 #
-
-# if using SuperLUDist, must also link in ParMETIS for some reason
-IF(${PACKAGE_NAME}_ENABLE_SuperLUDist AND NOT ${PACKAGE_NAME}_ENABLE_ParMETIS)
-  MESSAGE(FATAL_ERROR "The Amesos support for the SuperLUIDist TPL requires the ParMETIS TPL.  Either disable Amesos SuperLUDist support or enable the ParMETIS TPL.")
+# One can now configure SuperLUDist without ParMETIS
+if (NOT TPL_ENABLE_SuperLUDist_Without_ParMETIS)
+  IF(${PACKAGE_NAME}_ENABLE_SuperLUDist AND NOT ${PACKAGE_NAME}_ENABLE_ParMETIS)
+    MESSAGE(FATAL_ERROR "The Amesos support for the SuperLUDist TPL requires the ParMETIS TPL.  Either disable Amesos SuperLUDist support or enable the ParMETIS TPL.")
+  ENDIF()
 ENDIF()
 
 IF(${PACKAGE_NAME}_ENABLE_PARAKLETE)

--- a/packages/amesos/CMakeLists.txt
+++ b/packages/amesos/CMakeLists.txt
@@ -9,8 +9,9 @@ TRIBITS_PACKAGE(Amesos)
 #
 # B) Set up package-specific options
 #
-# One can now configure SuperLUDist without ParMETIS
-if (NOT TPL_ENABLE_SuperLUDist_Without_ParMETIS)
+ADVANCED_SET(Amesos_Allow_SuperLUDist_Without_ParMETIS OFF
+  CACHE BOOL "Allow Amesos to use the SuperLUDist TPL without the enable of the ParMETIS TPL")
+if (NOT Amesos_Allow_SuperLUDist_Without_ParMETIS)
   IF(${PACKAGE_NAME}_ENABLE_SuperLUDist AND NOT ${PACKAGE_NAME}_ENABLE_ParMETIS)
     MESSAGE(FATAL_ERROR "The Amesos support for the SuperLUDist TPL requires the ParMETIS TPL.  Either disable Amesos SuperLUDist support or enable the ParMETIS TPL.")
   ENDIF()


### PR DESCRIPTION
In tribits/win_interface/include/gettimeofday.c:

Remove spaces around time.h in its include, which spaces clang some version did not
like.

In packages/amesos/CMakeLists.txt:
With TPL_ENABLE_SuperLUDist_Without_ParMETIS=true, one can now
configure with superlu_dist and without parmetis - for the case where
superlu_dist is built without parmetis as is now possible with
-Denable_parmetislib:BOOL='OFF' when configuring superlu_dist.

@trilinos/<Tribits>
@trilinos/<Amesos>

These changes allow compilation of gettimeofday.c on Windows with LLVM,
and they allow building of Trilinos with superlu_dist and without parmetis, as
superlu_dist can now be built without parmetis.



* Closes #9094
