### PR TITLE
PyTrilinos: Fix PyTrilinos.Teuchos build error

### DIFF
--- a/packages/PyTrilinos/src/Teuchos_ParameterList.i
+++ b/packages/PyTrilinos/src/Teuchos_ParameterList.i
@@ -195,8 +195,8 @@ class any;
 // Implement internal storage of Teuchos::ParameterList objects via
 // Teuchos::RCP<>
 %teuchos_rcp(Teuchos::ParameterList)
-%teuchos_rcp_pydict_overrides(PYTRILINOS_NULLSTR, Teuchos::ParameterList)
-%teuchos_rcp_pydict_overrides(const             , Teuchos::ParameterList)
+%teuchos_rcp_pydict_overrides(SWIGEMPTYHACK, Teuchos::ParameterList)
+%teuchos_rcp_pydict_overrides(const        , Teuchos::ParameterList)
 
 %feature("docstring") Teuchos::ParameterList
 "The ``ParameterList`` class is an important utility class that is used
@@ -460,13 +460,26 @@ Teuchos::ParameterList::values
 {
   /******************************************************************/
   // Dictionary constructor
-  ParameterList(PyObject * dict, string name = string("ANONYMOUS"))
+  ParameterList(PyObject * dict, const string & name = string("ANONYMOUS"))
   {
     Teuchos::ParameterList * plist =
       PyTrilinos::pyDictToNewParameterList(dict, PyTrilinos::raiseError);
     if (plist == NULL) goto fail;
 
     plist->setName(name);
+    return plist;
+  fail:
+    return NULL;
+  }
+
+  /******************************************************************/
+  // String constructor (required because in C++, this constructor has
+  // an optional ParameterListModifier, and we are ignoring
+  // ParameterListModifiers
+  ParameterList(const string & name)
+  {
+    Teuchos::ParameterList * plist = new Teuchos::ParameterList(name);
+    if (plist == NULL) goto fail;
     return plist;
   fail:
     return NULL;
@@ -933,18 +946,19 @@ Teuchos::ParameterList::values
   }
 }    // %extend ParameterList
 
-%{
-  using Teuchos::Array;
-  using Teuchos::null;
-  using Teuchos::ParameterListModifier;
-%}
-
+%ignore Teuchos::ParameterList::ParameterList(const std::string &,
+                                              RCP<const ParameterListModifier> const &);
 %ignore Teuchos::ParameterList::set;
 %ignore Teuchos::ParameterList::setEntry;
+%ignore Teuchos::ParameterList::setModifier;
 %ignore Teuchos::ParameterList::get;
 %ignore Teuchos::ParameterList::getPtr;
 %ignore Teuchos::ParameterList::getEntryPtr;
+%ignore Teuchos::ParameterList::getModifier;
 %ignore Teuchos::ParameterList::sublist(const std::string &) const;
+%ignore Teuchos::ParameterList::sublist(const std::string &,
+                                        RCP<const ParameterListModifier> const &,
+                                        const std::string &);
 %ignore Teuchos::ParameterList::isType(const std::string &) const;
 %ignore Teuchos::ParameterList::isType(const std::string &, any*) const;
 %ignore Teuchos::ParameterList::unused(ostream &) const;
@@ -954,7 +968,7 @@ Teuchos::ParameterList::values
 %ignore Teuchos::ParameterList::name(ConstIterator) const;
 %include "Teuchos_ParameterList.hpp"
 // SWIG thinks that PrintOptions is an un-nested Teuchos class, so we
-// need to trick the C++ compiler into understanding this so-called
+// need to trick the C++ compiler into understanding this so called
 // un-nested Teuchos type.
 %{
 namespace Teuchos
@@ -967,10 +981,3 @@ typedef ParameterList::PrintOptions PrintOptions;
 // Teuchos::ParameterListAcceptor support //
 ////////////////////////////////////////////
 %include "Teuchos_ParameterListAcceptor.hpp"
-
-////////////////////////////////////////////
-// Teuchos::ParameterListModifier support //
-////////////////////////////////////////////
-%teuchos_rcp(Teuchos::ParameterListModifier)
-%include "Teuchos_ParameterListModifier.hpp"
-


### PR DESCRIPTION
The Teuchos::ParameterList was updated to utilize a Teuchos::ParameterListModifier class, which was not wrapped, so SWIG did not know how to handle it.  The temporary fix implemented here is that all methods (including a constructor) that reference ParameterListModifier are now ignored.  A better fix might be to wrap the ParameterListModifier and not ignore those methods.

@trilinos/pytrilinos 

## Motivation
Bug report in Trillinos issue #9013

## Related Issues

* Closes #9013
