### PR TITLE
 Eliminate warnings when using BUILD_SHARED_LIBS=ON (#8498)

### DIFF
--- a/demos/simpleBuildAgainstTrilinos/CMakeLists.txt
+++ b/demos/simpleBuildAgainstTrilinos/CMakeLists.txt
@@ -2,6 +2,13 @@
 
 cmake_minimum_required(VERSION 3.17.1)
 
+# Declare project but don't process compilers yet
+#
+# You must do this before calling find_package(Trilinos) when
+# BUILD_SHARED_LIBS=ON or you get a lot of nasty warnings.
+#
+project(MyApp NONE)
+
 # Disable Kokkos warning about not supporting C++ extensions
 set(CMAKE_CXX_EXTENSIONS OFF)
 
@@ -33,11 +40,11 @@ set(CMAKE_C_FLAGS  "${Trilinos_C_COMPILER_FLAGS} ${CMAKE_C_FLAGS}")
 set(CMAKE_Fortran_FLAGS  "${Trilinos_Fortran_COMPILER_FLAGS} ${CMAKE_Fortran_FLAGS}")
 
 # End of setup and error checking.
-#
-# NOTE: PROJECT command checks for compilers, so this statement
-# is moved AFTER setting compilers.
 
-project(MyApp)
+# Now enable the compilers now that we have gotten them from Trilinos
+enable_language(C)
+enable_language(CXX)
+enable_language(Fortran)
 
 # Build the APP and link to Trilinos
 add_executable(MyApp ${CMAKE_CURRENT_SOURCE_DIR}/app.cpp)

--- a/demos/simpleBuildAgainstTrilinos/README.md
+++ b/demos/simpleBuildAgainstTrilinos/README.md
@@ -47,7 +47,7 @@ This will put a file called `TrilinosConfig.cmake` under a subdirectory of
   $ mkdir <app-build-dir>
   $ cd <app-build-dir>/
   $ cmake \
-    CMAKE_PREFIX_PATH=<tril-install-prefix> \
+    -D CMAKE_PREFIX_PATH=<tril-install-prefix> \
     <trilinos-src>/demos/simpleBuildAgainstTrilinos
 ```
 


### PR DESCRIPTION
This eliminates configure-time warnings when using `-D BUILD_SHARED_LIBS=ON`.   See the commit logs and updated code and comments for more details.

This was flagged by an internal customer trying to switch over to use CMake and drop the needs for `Makefile.export.*` files to allow #8498.

<details>

<summary><b>Detailed reproduction of warnings and notes:</b> (click to expand)</summary>

.

How I will try to reproduce the configure warning reported by an important internal customer blocking the execution.

So here I go:

```
$ cd ~/Trilinos.base2/BUILDS/ATDM/gnu-shared-opt/

$ cat load-env.sh
. ~/Trilinos.base2/Trilinos/cmake/std/atdm/load-env.sh gnu-shared-opt

$ . load-env.sh
Hostname 'crf450' matches known ATDM host 'crf450' and system 'sems-rhel7'
Setting compiler and build options for build-name 'gnu-shared-opt'
Using SEMS RHEL7 compiler stack GNU-7.2.0 to build RELEASE code with Kokkos node type SERIAL

$ cat do-configure
#!/bin/bash
cmake \
-GNinja \
-DTrilinos_CONFIGURE_OPTIONS_FILE:STRING=cmake/std/atdm/ATDMDevEnv.cmake \
-DTrilinos_ENABLE_TESTS=ON \
"$@" \
~/Trilinos.base2/Trilinos

$ rm -r CMake*

$ time ./do-configure \
  -DCMAKE_INSTALL_PREFIX=$PWD/install \
  -DBUILD_SHARED_LIBS=ON \
  -DTrilinos_ENABLE_Teuchos=ON \
  -DTrilinos_ENABLE_Tpetra=ON \
  &> configure.out

real    0m13.360s
user    0m8.750s
sys     0m4.007s

$ time make install &> make.install.out

real    2m37.588s
user    75m1.803s
sys     4m39.285s

$ tail -n2 make.install.out

-- Installing: /ascldap/users/rabartl/Trilinos.base2/BUILDS/ATDM/gnu-shared-opt/install/lib/cmake/tribits/win_interface/include/unistd.h
-- Installing: /ascldap/users/rabartl/Trilinos.base2/BUILDS/ATDM/gnu-shared-opt/install/lib/cmake/tribits/TriBITSConfig.cmake

$ cd simpleBuildAgainstTrilinos/

$ cat do-configure
#!/bin/bash
cmake \
-GNinja \
-DCMAKE_PREFIX_PATH=$HOME/Trilinos.base2/BUILDS/ATDM/gnu-shared-opt/install \
~/Trilinos.base2/Trilinos/demos/simpleBuildAgainstTrilinos

$ time ./do-configure &> configure.out

real    0m0.140s
user    0m0.098s
sys     0m0.042s
```

That produced warnings like:

```
CMake Warning (dev) at /ascldap/users/rabartl/Trilinos.base2/BUILDS/ATDM/gnu-shared-opt/install/lib/cmake/KokkosCore/KokkosCoreTargets.cmake:54 (add_library):
  ADD_LIBRARY called with SHARED option but the target platform does not
  support dynamic linking.  Building a STATIC library instead.  This may lead
  to problems.
Call Stack (most recent call first):
  /ascldap/users/rabartl/Trilinos.base2/BUILDS/ATDM/gnu-shared-opt/install/lib/cmake/KokkosCore/KokkosCoreConfig.cmake:153 (INCLUDE)
  /ascldap/users/rabartl/Trilinos.base2/BUILDS/ATDM/gnu-shared-opt/install/lib/cmake/TeuchosCore/TeuchosCoreConfig.cmake:153 (INCLUDE)
  /ascldap/users/rabartl/Trilinos.base2/BUILDS/ATDM/gnu-shared-opt/install/lib/cmake/TeuchosParser/TeuchosParserConfig.cmake:153 (INCLUDE)
  /ascldap/users/rabartl/Trilinos.base2/BUILDS/ATDM/gnu-shared-opt/install/lib/cmake/TeuchosParameterList/TeuchosParameterListConfig.cmake:153 (INCLUDE)
  /ascldap/users/rabartl/Trilinos.base2/BUILDS/ATDM/gnu-shared-opt/install/lib/cmake/TeuchosKokkosCompat/TeuchosKokkosCompatConfig.cmake:153 (INCLUDE)
  /ascldap/users/rabartl/Trilinos.base2/BUILDS/ATDM/gnu-shared-opt/install/lib/cmake/TeuchosKokkosComm/TeuchosKokkosCommConfig.cmake:153 (INCLUDE)
  /ascldap/users/rabartl/Trilinos.base2/BUILDS/ATDM/gnu-shared-opt/install/lib/cmake/Teuchos/TeuchosConfig.cmake:153 (INCLUDE)
  /ascldap/users/rabartl/Trilinos.base2/BUILDS/ATDM/gnu-shared-opt/install/lib/cmake/Trilinos/TrilinosConfig.cmake:130 (INCLUDE)
  CMakeLists.txt:9 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

Now I am going to try to fix this by doing `project(MyApp NONE)`, then `find_package(Trilinos)`, then `enable_langauge()` calls ... Sure enough, the eliminates the configure warnings and things build just fine.  Now I get a clean configure with no warnings and the project builds and test runs.

</details>
 