### PR TITLE
Tpetra:  adding syncs of import buffers in MultiVector

### DIFF
--- a/packages/tpetra/core/src/Tpetra_DistObject_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_DistObject_def.hpp
@@ -1101,7 +1101,7 @@ namespace Tpetra {
                  numImportPacketsPerLID_av);
             }
           }
-          else { // pack on device
+          else { // comm on device
             Kokkos::fence(); // for UVM
             this->imports_.modify_device ();
             if (revOp == DoReverse) {

--- a/packages/tpetra/core/test/CrsMatrix/Bug8794.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/Bug8794.cpp
@@ -145,10 +145,11 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug8794, InsertDenseRows,
               << "  nrows     " << Amat.getNodeNumRows() << "\n"
               << "  nnz       " << Amat.getNodeNumEntries() << "\n"
               << "  maxPerRow " << Amat.getNodeMaxNumRowEntries() << "\n"
+              << "  norm      " << Amat.getFrobeniusNorm() << "\n"
               << std::endl;
 
-    Teuchos::FancyOStream foo(Teuchos::rcp(&std::cout,false));
-    Amat.describe(foo, Teuchos::VERB_EXTREME);
+//    Teuchos::FancyOStream foo(Teuchos::rcp(&std::cout,false));
+//    Amat.describe(foo, Teuchos::VERB_EXTREME);
   }
 
   // Initialize domain vector for SpMV


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 


## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
In https://github.com/Exawind/nalu-wind/issues/858, @rcknaus reported export errors when TPETRA_ASSUME_CUDA_AWARE_MPI=0 after #8821 was merged.
Similar errors were exposed by tpetra/core/test/CrsMatrix/Bug8794.cpp.

In Bug8794.cpp, many multivector elements are imported, due to the dense rows in the test matrix.
With TPETRA_ASSUME_CUDA_AWARE_MPI=0, DistObject decides to do communication on host.
With long rows, the number of imports is large, so MultiVector decides to unpack on device.
However, the sync of the import buffer between the communication and unpack was missing.
This PR adds the sync.

I still need to investigate what changed in #8821 to cause this error.  We should also set up nightly tests with TPETRA_ASSUME_CUDA_AWARE_MPI=0; Trilinos PR testing has TPETRA_ASSUME_CUDA_AWARE_MPI=1 (which, for Bug8794.cpp, meant communication and unpacking were done on device, so no problems).  Adding unit test reproducer (separate from Bug8794.cpp) would be nice as well.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
https://github.com/Exawind/nalu-wind/issues/858
@rcknaus
See https://github.com/Exawind/nalu-wind/issues/858#issuecomment-834808823

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Tested on ascicgpu with TPETRA_ASSUME_CUDA_AWARE_MPI=0 and 1.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->