### PR TITLE
8202 llvmwinbld: Fix miscellaneous windows build issues with llvm-clang

### DIFF
--- a/packages/amesos2/src/Amesos2_Factory.cpp
+++ b/packages/amesos2/src/Amesos2_Factory.cpp
@@ -169,11 +169,10 @@ namespace Amesos2 {
 
   std::string tolower (const std::string& s)
   {
-    std::locale loc;
     std::string rtn = s;
     const size_t len = rtn.length ();
     for (size_t i = 0; i < len; ++i) {
-      rtn[i] = tolower (rtn[i], loc);
+      rtn[i] = ::tolower (rtn[i]);
     }
     return rtn;
   }

--- a/packages/amesos2/src/KLU2/Include/klu2_ordinaltraits.h
+++ b/packages/amesos2/src/KLU2/Include/klu2_ordinaltraits.h
@@ -110,35 +110,37 @@ struct KLU_OrdinalTraits<int>
 };
 
 template<>
-struct KLU_OrdinalTraits<long int>
+struct KLU_OrdinalTraits<ptrdiff_t>
 {
-    static inline long int btf_order (long int n, long int *Ap, long int *Ai,
-        double maxwork, double *work, long int *P, long int *Q, long int *R, long int *nmatch,
-        long int *Work)
+// These should all be UF_long, which I presume is resolving to ptrdiff_t
+// ptrdiff_t is ptrdiff_t on Linux64, but just to be safe
+    static inline ptrdiff_t btf_order (ptrdiff_t n, ptrdiff_t *Ap, ptrdiff_t *Ai,
+        double maxwork, double *work, ptrdiff_t *P, ptrdiff_t *Q, ptrdiff_t *R, ptrdiff_t *nmatch,
+        ptrdiff_t *Work)
     {
         return (trilinos_btf_l_order (n, Ap, Ai, maxwork, work, P, Q, R, nmatch,
                     Work));
     }
 
-    static inline long int btf_strongcomp (long int n, long int *Ap, long int *Ai, long int *Q,
-        long int *P, long int *R, long int *Work)
+    static inline ptrdiff_t btf_strongcomp (ptrdiff_t n, ptrdiff_t *Ap, ptrdiff_t *Ai, ptrdiff_t *Q,
+        ptrdiff_t *P, ptrdiff_t *R, ptrdiff_t *Work)
     {
         return(trilinos_btf_l_strongcomp (n, Ap, Ai, Q, P, R, Work)) ;
     }
 
-    static inline long int amd_order (long int n, long int *Ap, long int *Ai, long int *P,
+    static inline ptrdiff_t amd_order (ptrdiff_t n, ptrdiff_t *Ap, ptrdiff_t *Ai, ptrdiff_t *P,
         double *Control, double *Info)
     {
         return (trilinos_amd_l_order(n, Ap, Ai, P, Control, Info)) ;
     }
 
-    static inline long int colamd (long int n_row, long int n_col, long int Alen, long int *A,
-        long int *p, double *knobs, long int *stats)
+    static inline ptrdiff_t colamd (ptrdiff_t n_row, ptrdiff_t n_col, ptrdiff_t Alen, ptrdiff_t *A,
+        ptrdiff_t *p, double *knobs, ptrdiff_t *stats)
     {
         return(trilinos_colamd_l (n_row, n_col, Alen, A, p, knobs, stats));
     }
 
-    static inline long int colamd_recommended (long int nnz, long int n_row, long int n_col)
+    static inline ptrdiff_t colamd_recommended (ptrdiff_t nnz, ptrdiff_t n_row, ptrdiff_t n_col)
     {
         return(trilinos_colamd_l_recommended(nnz, n_row, n_col));
     }

--- a/packages/epetra/src/Epetra_Comm.h
+++ b/packages/epetra/src/Epetra_Comm.h
@@ -460,6 +460,10 @@ class EPETRA_LIB_DLL_EXPORT Epetra_Comm {
   //! Create a distributor object.
   virtual Epetra_Distributor * CreateDistributor() const = 0;
   //! Create a directory object for the given Epetra_BlockMap.
+// CreateDirectory is defined in Winbase.h as a macro!
+#ifdef CreateDirectory
+#undef CreateDirectory
+#endif
   virtual Epetra_Directory * CreateDirectory(const Epetra_BlockMap & Map) const = 0;
   //@}
 

--- a/packages/epetra/src/Epetra_MpiComm.h
+++ b/packages/epetra/src/Epetra_MpiComm.h
@@ -474,6 +474,10 @@ class EPETRA_LIB_DLL_EXPORT Epetra_MpiComm: public Epetra_Object, public virtual
   //! Create a distributor object.
   Epetra_Distributor * CreateDistributor() const;
   //! Create a directory object for the given Epetra_BlockMap.
+// CreateDirectory is defined in Winbase.h as a macro!
+#ifdef CreateDirectory
+#undef CreateDirectory
+#endif
   Epetra_Directory * CreateDirectory(const Epetra_BlockMap & Map) const;
   //@}
 

--- a/packages/epetra/src/Epetra_SerialComm.h
+++ b/packages/epetra/src/Epetra_SerialComm.h
@@ -441,6 +441,10 @@ class EPETRA_LIB_DLL_EXPORT Epetra_SerialComm: public Epetra_Object, public virt
   //! Create a distributor object.
   Epetra_Distributor * CreateDistributor() const;
   //! Create a directory object for the given Epetra_BlockMap.
+// CreateDirectory is defined in Winbase.h as a macro!
+#ifdef CreateDirectory
+#undef CreateDirectory
+#endif
   Epetra_Directory * CreateDirectory(const Epetra_BlockMap & Map) const;
   //@}
 

--- a/packages/ifpack2/adapters/thyra/Thyra_Ifpack2PreconditionerFactory_def.hpp
+++ b/packages/ifpack2/adapters/thyra/Thyra_Ifpack2PreconditionerFactory_def.hpp
@@ -170,9 +170,8 @@ void Ifpack2PreconditionerFactory<MatrixType>::initializePrec(
   // precTypeUpper is the upper-case version of preconditionerType.
   std::string precTypeUpper (preconditionerType);
   if (precTypeUpper.size () > 0) {
-    std::locale locale;
     for (size_t k = 0; k < precTypeUpper.size (); ++k) {
-      precTypeUpper[k] = std::toupper<char> (precTypeUpper[k], locale);
+      precTypeUpper[k] = ::toupper(precTypeUpper[k]);
     }
   }
   

--- a/packages/ifpack2/src/Ifpack2_Details_Factory_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Factory_def.hpp
@@ -122,9 +122,8 @@ create (const std::string& precType,
   // precTypeUpper is the upper-case version of precType.
   std::string precTypeUpper (precType);
   if (precTypeUpper.size () > 0) {
-    std::locale locale;
     for (size_t k = 0; k < precTypeUpper.size (); ++k) {
-      precTypeUpper[k] = std::toupper<char> (precTypeUpper[k], locale);
+      precTypeUpper[k] = ::toupper(precTypeUpper[k]);
     }
   }
 

--- a/packages/ifpack2/src/Ifpack2_Utilities.cpp
+++ b/packages/ifpack2/src/Ifpack2_Utilities.cpp
@@ -49,9 +49,8 @@ namespace Details {
     // precTypeUpper is the upper-case version of precType.
     std::string precTypeUpper (precType);
     if (precTypeUpper.size () > 0) {
-      std::locale locale;
       for (size_t k = 0; k < precTypeUpper.size (); ++k) {
-        precTypeUpper[k] = std::toupper<char> (precTypeUpper[k], locale);
+        precTypeUpper[k] = ::toupper(precTypeUpper[k]);
       }
     }
     return precTypeUpper;

--- a/packages/intrepid2/src/Shared/Intrepid2_PointToolsDef.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_PointToolsDef.hpp
@@ -48,6 +48,13 @@
 #ifndef __INTREPID2_POINTTOOLS_DEF_HPP__
 #define __INTREPID2_POINTTOOLS_DEF_HPP__
 
+#if defined(_MSC_VER) || defined(_WIN32) && defined(__ICL)
+// M_PI, M_SQRT2, etc. are hidden in MSVC by #ifdef _USE_MATH_DEFINES
+  #ifndef _USE_MATH_DEFINES
+  #define _USE_MATH_DEFINES
+  #endif
+  #include <math.h>
+#endif
 
 namespace Intrepid2 {
 

--- a/packages/intrepid2/src/Shared/Intrepid2_PolylibDef.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_PolylibDef.hpp
@@ -95,6 +95,14 @@
 #ifndef __INTREPID2_POLYLIB_DEF_HPP__
 #define __INTREPID2_POLYLIB_DEF_HPP__
 
+#if defined(_MSC_VER) || defined(_WIN32) && defined(__ICL)
+// M_PI, M_SQRT2, etc. are hidden in MSVC by #ifdef _USE_MATH_DEFINES
+  #ifndef _USE_MATH_DEFINES
+  #define _USE_MATH_DEFINES
+  #endif
+  #include <math.h>
+#endif
+
 namespace Intrepid2 {
 
   // -----------------------------------------------------------------------

--- a/packages/muelu/src/Transfers/PCoarsen/MueLu_IntrepidPCoarsenFactory_def.hpp
+++ b/packages/muelu/src/Transfers/PCoarsen/MueLu_IntrepidPCoarsenFactory_def.hpp
@@ -104,7 +104,7 @@ namespace MueLu {
 namespace MueLuIntrepid {
 inline std::string tolower(const std::string & str) {
   std::string data(str);
-  std::transform(data.begin(), data.end(), data.begin(), [](unsigned char c) { return std::tolower(c); });
+  std::transform(data.begin(), data.end(), data.begin(), ::tolower);
   return data;
 }
 


### PR DESCRIPTION
This should close out Issue #8202.

* Getting git date fails
* std::to{low,upp}er does not exist
* trilinos_btf_l_order and siblings use long, but the correct type on Win64 is ptrdiff_t (long long)
* Epetra_*Comm have problems because CreateDirectory is a macro in Winbase.h
* Need to define _USE_MATH_DEFINES to get M_PI defined on Windows.

An index of packages affected by commit is below.

Package    commit
@trilinos/tribits 94fe325cd4fcd6fd3de2e21454d3825bda07803a
@trilinos/epetra ed5b0c26006e87cb7ec88cf93b8a82bb0ec0af8e
@trilinos/amesos2 @trilinos/ifpack2 @trilinos/muelu 1c858848df7caecc8bbbe254cfdb5a09d40a9061
@trilinos/amesos2 c46ef3fd0bcef35f4b9fd1d993bef09f24587b5a
@trilinos/intrepid2 5b901c3a5cf1737db1959746288d3102a83241d6


## Motivation

Need to build trilinos on Windows with LLVM

## Related Issues

Will not be done until kokkos-kernels accepts PR 958 and they/we come up with a fix for Issue 967 in that project.


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing

All changes are in the middle of code that I presume is well tested.

## Additional Information

I am happy to modify any commit.  I tried to make my changes as local and as Windows-specific as possible, but some could be done more generally.