### PR TITLE
Tpetra MultiVector: Remove unnecessary check from isSameSize

### DIFF
--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -4684,16 +4684,6 @@ namespace Tpetra {
     if ((l1!=l2) || (this->getNumVectors() != vec.getNumVectors())) {
       return false;
     }
-    if (l1==0) {
-      return true;
-    }
-
-    auto v1 = this->getLocalViewHost(Access::ReadOnly);
-    auto v2 = vec.getLocalViewHost(Access::ReadOnly);
-    if (PackTraits<ST>::packValueCount (v1(0,0)) !=
-        PackTraits<ST>::packValueCount (v2(0,0))) {
-      return false;
-    }
 
     return true;
   }


### PR DESCRIPTION
@trilinos/tpetra 

## Motivation
Remove unnecessary check from `MV::isSameSize`. This avoids a potential memcopy to host.