### PR TITLE
Skip view initializations

### DIFF
--- a/packages/ifpack2/src/Ifpack2_Details_Chebyshev_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Chebyshev_def.hpp
@@ -1043,7 +1043,7 @@ makeInverseDiagonal (const row_matrix_type& A, const bool useDiagOffsets) const
       *out_ << "Reusing pre-existing vector for diagonal extraction" << std::endl;
     D_rowMap = Teuchos::rcp_const_cast<V>(D_);
   } else {
-    D_rowMap = Teuchos::rcp(new V (A.getGraph ()->getRowMap ()));
+    D_rowMap = Teuchos::rcp(new V (A.getGraph ()->getRowMap (), /*zeroOut=*/false));
     if (debug_)
       *out_ << "Allocated new vector for diagonal extraction" << std::endl;
   }
@@ -1571,10 +1571,9 @@ makeTempMultiVector (const MV& B)
   // null, but also if the number of columns match, since some multi-RHS
   // solvers (e.g., Belos) may call apply() with different numbers of columns.
 
-  //W must be initialized to zero when it is used as a multigrid smoother.
   const size_t B_numVecs = B.getNumVectors ();
   if (W_.is_null () || W_->getNumVectors () != B_numVecs) {
-    W_ = Teuchos::rcp (new MV (B.getMap (), B_numVecs, true));
+    W_ = Teuchos::rcp (new MV (B.getMap (), B_numVecs, false));
   }
   return W_;
 }

--- a/packages/muelu/adapters/tpetra/MueLu_TpetraOperator_def.hpp
+++ b/packages/muelu/adapters/tpetra/MueLu_TpetraOperator_def.hpp
@@ -114,8 +114,7 @@ void TpetraOperator<Scalar,LocalOrdinal,GlobalOrdinal,Node>::apply(const Tpetra:
     const XTMV tX(rcpFromRef(temp_x));
     XTMV       tY(rcpFromRef(Y));
 
-    tY.putScalar(Teuchos::ScalarTraits<Scalar>::zero());
-    if(!Hierarchy_.is_null()) 
+    if(!Hierarchy_.is_null())
       Hierarchy_->Iterate(tX, tY, 1, true);
     else
       Operator_->apply(tX, tY);

--- a/packages/muelu/adapters/xpetra/MueLu_XpetraOperator_decl.hpp
+++ b/packages/muelu/adapters/xpetra/MueLu_XpetraOperator_decl.hpp
@@ -118,8 +118,6 @@ namespace MueLu {
         TEUCHOS_TEST_FOR_EXCEPTION(A->getDomainMap()->isSameAs(*(Yop->getMap())) == false, std::logic_error,
                                    "MueLu::XpetraOperator::apply: map of Y is incompatible with domain map of A");
 #endif
-
-        Y.putScalar(Teuchos::ScalarTraits<Scalar>::zero());
         Hierarchy_->Iterate(X, Y, 1, true);
       } catch (std::exception& e) {
         //FIXME add message and rethrow


### PR DESCRIPTION
@trilinos/tpetra @trilinos/ifpack2 @trilinos/muelu 

## Motivation
- Skip unneeded view initializations.
- Tpetra global norm: use in-place reduction, similar to https://github.com/trilinos/Trilinos/blob/5242864373cc43d2fd8bedfd775c236daddeaf2c/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp#L1962-L1982