### PR TITLE
Tpetra: Skip unpackAndCombine

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_Transfer_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Transfer_decl.hpp
@@ -201,6 +201,13 @@ public:
   /// Maps in the way that you expect.
   bool isLocallyComplete () const;
 
+
+  void detectRemoteExportLIDsContiguous() const;
+
+  bool areRemoteLIDsContiguous() const;
+
+  bool areExportLIDsContiguous() const;
+
   /// \brief Describe this object in a human-readable way to the given
   ///   output stream.
   ///

--- a/packages/tpetra/core/src/Tpetra_Details_Transfer_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Transfer_def.hpp
@@ -63,6 +63,35 @@ namespace { // (anonymous)
     return Teuchos::ArrayView<const ElementType> (size == 0 ? nullptr : hostView.data (), size);
   }
 
+  template<class DeviceType, class LocalOrdinal>
+    struct OrderedViewFunctor {
+      OrderedViewFunctor (const Kokkos::View<LocalOrdinal*, DeviceType>& viewToCheck) :
+        viewToCheck_ (viewToCheck) {}
+      KOKKOS_INLINE_FUNCTION void operator() (const size_t i, unsigned int& isUnordered) const {
+        isUnordered |= static_cast<unsigned int>(viewToCheck_(i)+1 != viewToCheck_(i+1));
+      }
+      Kokkos::View<const LocalOrdinal*, DeviceType> viewToCheck_;
+    };
+
+    template<class DeviceType, class LocalOrdinal>
+    bool
+    isViewOrdered (const Kokkos::View<LocalOrdinal*, DeviceType>& viewToCheck)
+    {
+      using Kokkos::parallel_reduce;
+      typedef DeviceType DT;
+      typedef typename DT::execution_space DES;
+      typedef Kokkos::RangePolicy<DES, size_t> range_type;
+
+      const size_t size = viewToCheck.extent (0);
+      unsigned int isUnordered = 0;
+      if (size>1)
+        parallel_reduce ("isViewOrdered",
+                         range_type (0, size-1),
+                         OrderedViewFunctor<DeviceType, LocalOrdinal> (viewToCheck),
+                         isUnordered);
+      return isUnordered == 0;
+    }
+
 } // namespace (anonymous)
 
 namespace Tpetra {
@@ -269,6 +298,58 @@ Transfer<LO, GO, NT>::
 isLocallyComplete () const {
   return TransferData_->isLocallyComplete_;
 }
+
+template <class LO, class GO, class NT>
+void
+Transfer<LO, GO, NT>::
+detectRemoteExportLIDsContiguous () const {
+
+  // Check that maps are locally fitted
+  // TODO: We really want to check here that remote LIDs are sorted last.
+  //       The current check is too restrictive in special cases.
+  bool ordered = (getNumSameIDs() == std::min(getSourceMap()->getNodeNumElements(),
+                                              getTargetMap()->getNodeNumElements()));
+  ordered &= (getTargetMap()->getNodeNumElements() == getNumSameIDs() + getNumRemoteIDs());
+  if (ordered) {
+    const auto& dv = TransferData_->remoteLIDs_;
+    TEUCHOS_TEST_FOR_EXCEPTION
+      (dv.need_sync_device (), std::logic_error,
+       "Tpetra::Details::Transfer::getRemoteLIDs_dv: "
+       "DualView needs sync to device" );
+    auto v_d = dv.view_device ();
+    ordered &= isViewOrdered<device_type, LO>(v_d);
+  }
+  TransferData_->remoteLIDsContiguous_ = ordered;
+
+  ordered = (getNumSameIDs() == std::min(getSourceMap()->getNodeNumElements(),
+                                         getTargetMap()->getNodeNumElements()));
+  ordered &= (getSourceMap()->getNodeNumElements() == getNumSameIDs() + getNumExportIDs());
+  if (ordered) {
+    const auto& dv = TransferData_->exportLIDs_;
+    TEUCHOS_TEST_FOR_EXCEPTION
+      (dv.need_sync_device (), std::logic_error,
+       "Tpetra::Details::Transfer::getRemoteLIDs_dv: "
+       "DualView needs sync to device" );
+    auto v_d = dv.view_device ();
+    ordered &= isViewOrdered<device_type, LO>(v_d);
+  }
+  TransferData_->exportLIDsContiguous_ = ordered;
+}
+
+template <class LO, class GO, class NT>
+bool
+Transfer<LO, GO, NT>::
+areRemoteLIDsContiguous () const {
+  return TransferData_->remoteLIDsContiguous_;
+}
+
+template <class LO, class GO, class NT>
+bool
+Transfer<LO, GO, NT>::
+areExportLIDsContiguous () const {
+  return TransferData_->exportLIDsContiguous_;
+}
+
 
 template <class LO, class GO, class NT>
 void

--- a/packages/tpetra/core/src/Tpetra_DistObject_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_DistObject_decl.hpp
@@ -787,7 +787,9 @@ namespace Tpetra {
                  size_t constantNumPackets,
                  bool commOnHost,
                  ReverseOption revOp,
-                 std::shared_ptr<std::string> prefix);
+                 std::shared_ptr<std::string> prefix,
+                 const bool canTryAliasing,
+                 const CombineMode CM);
 
     void doWaits(Distributor& distor,
                  ReverseOption revOp);
@@ -997,10 +999,12 @@ namespace Tpetra {
     /// <tt>exports_</tt> always gets passed into packAndPrepare()
     /// by nonconst reference.  Thus, that method can resize the
     /// DualView without needing to call other DistObject methods.
-    bool
+    virtual bool
     reallocImportsIfNeeded (const size_t newSize,
                             const bool verbose,
-                            const std::string* prefix);
+                            const std::string* prefix,
+                            const bool remoteLIDsContiguous=false,
+                            const CombineMode CM=INSERT);
 
     /// \brief Number of packets to receive for each receive operation.
     ///

--- a/packages/tpetra/core/src/Tpetra_Export_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Export_def.hpp
@@ -92,6 +92,8 @@ namespace Tpetra {
     TEUCHOS_ASSERT( ! this->TransferData_->exportLIDs_.need_sync_device () );
     TEUCHOS_ASSERT( ! this->TransferData_->exportLIDs_.need_sync_host () );
 
+    this->detectRemoteExportLIDsContiguous();
+
     if (this->verbose ()) {
       std::ostringstream os;
       const int myRank = source->getComm ()->getRank ();

--- a/packages/tpetra/core/src/Tpetra_ImportExportData_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_ImportExportData_decl.hpp
@@ -185,6 +185,12 @@ namespace Tpetra {
     /// other processes.
     Kokkos::DualView<LocalOrdinal*, device_type> remoteLIDs_;
 
+    //! Whether the remote LIDs are contiguous.
+    bool remoteLIDsContiguous_ = false;
+
+    //! Whether the export LIDs are contiguous.
+    bool exportLIDsContiguous_ = false;
+
     /// \brief "Outgoing" local indices.
     ///
     /// This array holds the LIDs of the GIDs that are owned by the

--- a/packages/tpetra/core/src/Tpetra_Import_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Import_def.hpp
@@ -174,6 +174,8 @@ namespace Tpetra {
     TEUCHOS_ASSERT( ! this->TransferData_->exportLIDs_.need_sync_device () );
     TEUCHOS_ASSERT( ! this->TransferData_->exportLIDs_.need_sync_host () );
 
+    this->detectRemoteExportLIDsContiguous();
+
     if (this->verbose ()) {
       std::ostringstream os;
       os << *verbPrefix << "Done!" << endl;
@@ -409,6 +411,8 @@ namespace Tpetra {
       distributor.createFromSendsAndRecvs (this->TransferData_->exportPIDs_, tRemotePIDs);
     }
 
+    this->detectRemoteExportLIDsContiguous();
+
     TEUCHOS_ASSERT( ! this->TransferData_->permuteFromLIDs_.need_sync_device () );
     TEUCHOS_ASSERT( ! this->TransferData_->permuteFromLIDs_.need_sync_host () );
     TEUCHOS_ASSERT( ! this->TransferData_->permuteToLIDs_.need_sync_device () );
@@ -486,6 +490,8 @@ namespace Tpetra {
                     size_t (exportLIDs.size ()) );
     this->TransferData_->exportPIDs_.swap (exportPIDs);
     this->TransferData_->distributor_.swap (distributor);
+
+    this->detectRemoteExportLIDsContiguous();
 
     TEUCHOS_ASSERT( ! this->TransferData_->permuteFromLIDs_.need_sync_device () );
     TEUCHOS_ASSERT( ! this->TransferData_->permuteFromLIDs_.need_sync_host () );

--- a/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
@@ -2574,6 +2574,46 @@ namespace Tpetra {
      const size_t constantNumPackets,
      Distributor& /* distor */,
      const CombineMode CM);
+
+  private:
+
+    // If comm buffers can be aliased to the data view, use this
+    // implementation.
+    template<class NO=Node>
+    typename std::enable_if<std::is_same<typename Tpetra::Details::DefaultTypes::CommBufferMemorySpace<typename NO::execution_space>::type,
+                                         typename NO::device_type::memory_space>::value, bool>::type
+    reallocImportsIfNeededImpl (const size_t newSize,
+                                 const bool verbose,
+                                 const std::string* prefix,
+                                 const bool areRemoteLIDsContiguous,
+                                 const CombineMode CM);
+
+    // If comm buffers cannot be aliased to the data view, use this
+    // implementation. (Just calls DistObject::reallocImportsIfNeeded.)
+    template<class NO=Node>
+    typename std::enable_if<!std::is_same<typename Tpetra::Details::DefaultTypes::CommBufferMemorySpace<typename NO::execution_space>::type,
+                                          typename NO::device_type::memory_space>::value, bool>::type
+    reallocImportsIfNeededImpl (const size_t newSize,
+                                 const bool verbose,
+                                 const std::string* prefix,
+                                 const bool areRemoteLIDsContiguous,
+                                 const CombineMode CM);
+  protected:
+
+    virtual bool
+    reallocImportsIfNeeded (const size_t newSize,
+                                 const bool verbose,
+                                 const std::string* prefix,
+                                 const bool areRemoteLIDsContiguous=false,
+                                 const CombineMode CM=INSERT);
+
+
+  public:
+    bool importsAreAliased();
+
+  protected:
+    Kokkos::DualView<impl_scalar_type*, buffer_device_type> unaliased_imports_;
+
     //@}
   }; // class MultiVector
 

--- a/packages/tpetra/core/test/ImportExport2/ImportExport2_UnitTests.cpp
+++ b/packages/tpetra/core/test/ImportExport2/ImportExport2_UnitTests.cpp
@@ -49,6 +49,7 @@
 #include <Teuchos_Tuple.hpp>
 #include "Tpetra_CrsGraph.hpp"
 #include "Tpetra_CrsMatrix.hpp"
+#include "Tpetra_MultiVector.hpp"
 #include "Tpetra_Core.hpp"
 #include "Tpetra_Distributor.hpp"
 #include "Tpetra_Map.hpp"
@@ -94,6 +95,7 @@ namespace {
   using Tpetra::createContigMap;
   using Tpetra::CrsGraph;
   using Tpetra::CrsMatrix;
+  using Tpetra::MultiVector;
   using Tpetra::Export;
   using Tpetra::Import;
   using Tpetra::INSERT;
@@ -676,6 +678,170 @@ namespace {
       Tpetra::Details::gathervPrint (out, err.str (), *comm);
       out << "Above test failed; aborting further tests" << endl;
       return;
+    }
+  }
+
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( MultiVectorImport, doImport, LO, GO, Scalar )
+  {
+    typedef Tpetra::global_size_t GST;
+    typedef Map<LO, GO> map_type;
+    typedef MultiVector<Scalar, LO, GO> mv_type;
+
+    out << "(MultiVectorImport,doImport) test" << endl;
+    OSTab tab1 (out); // Add one tab level
+
+    const GST INVALID = Teuchos::OrdinalTraits<GST>::invalid ();
+    // get a comm
+    RCP<const Comm<int> > comm = getDefaultComm();
+    const int numImages = comm->getSize();
+    const int myImageID = comm->getRank();
+
+    if (numImages < 2) {
+      out << "This test is only meaningful if running with multiple MPI "
+        "processes, but you ran it with only 1 process." << endl;
+      return;
+    }
+
+    for (int collectRank = 0; collectRank < 2; collectRank++) {
+      std::ostringstream err;
+      int lclErr = 0;
+      int gblErr = 0;
+
+      OSTab tab2 (out);
+      const GO indexBase = 0;
+      const LO src_num_local_elements = 3;
+      const LO tgt_num_local_elements = (myImageID == collectRank) ?
+        static_cast<LO> (numImages*src_num_local_elements) :
+        static_cast<LO> (0);
+
+      // Create maps for the source and target
+      RCP<const map_type> src_map =
+        rcp (new map_type (INVALID,
+                           static_cast<size_t> (src_num_local_elements),
+                           indexBase, comm));
+      RCP<const map_type> tgt_map =
+        rcp (new map_type (INVALID,
+                           static_cast<size_t> (tgt_num_local_elements),
+                           indexBase, comm));
+
+      // Create CrsMatrix objects.
+      RCP<mv_type> src_mv = rcp(new mv_type(src_map, 1));
+      RCP<mv_type> tgt_mv = rcp(new mv_type(tgt_map, 1));
+      src_mv->putScalar(Teuchos::ScalarTraits<Scalar>::one ());
+      tgt_mv->putScalar(Teuchos::ScalarTraits<Scalar>::zero ());
+
+      try {
+        // Create the importer
+        Import<LO, GO> importer (src_map, tgt_map, getImportParameterList ());
+
+        // Do the import
+        tgt_mv->doImport (*src_mv, importer, INSERT);
+
+        // When collectRank == 0, rank 0 has the GIDs the source map owns ordered first.
+        // When collectRank == 1, rank 1 has the GIDs of rank 0 ordered first.
+        // On all other ranks, there are no remote LIDs.
+        if ((collectRank == 0) || (myImageID != collectRank)) {
+          TEUCHOS_ASSERT(importer.areRemoteLIDsContiguous());
+        }
+        else {
+          TEUCHOS_ASSERT(!importer.areRemoteLIDsContiguous());
+        }
+
+        // When there are remote LIDs and they are contiguous, and
+        // MV::imports_ and MV::view_ have the same memory space, the
+        // imports_ view is aliased to the data view of the target MV.
+        if ((myImageID == collectRank) && (myImageID == 0)) {
+          if (mv_type::dual_view_type::impl_dualview_is_single_device::value)
+            TEUCHOS_ASSERT(tgt_mv->importsAreAliased());
+          // else {
+          //   We do not know if copyAndPermute was run on host or device.
+          // }
+        }
+        else {
+          TEUCHOS_ASSERT(!tgt_mv->importsAreAliased());
+        }
+
+        // Loop through tgt_mv and make sure the import worked.
+        if (tgt_num_local_elements != 0) {
+          auto data = tgt_mv->getLocalViewHost(Tpetra::Access::ReadOnly);
+          for (GO gblRow = tgt_map->getMinGlobalIndex ();
+               gblRow <= tgt_map->getMaxGlobalIndex ();
+               ++gblRow) {
+            const LO lclRow = tgt_map->getLocalElement (gblRow);
+
+            TEST_EQUALITY(data(lclRow,0), Teuchos::ScalarTraits<Scalar>::one ());
+          }
+        }
+      }
+      catch (std::exception& e) { // end of the first test
+        err << "Proc " << myImageID << ": " << e.what () << endl;
+        lclErr = 1;
+      }
+
+      reduceAll<int, int> (*comm, REDUCE_MAX, lclErr, outArg (gblErr));
+      TEST_EQUALITY_CONST( gblErr, 0 );
+      if (gblErr != 0) {
+        Tpetra::Details::gathervPrint (out, err.str (), *comm);
+        out << "Above test failed; aborting further tests" << endl;
+        return;
+      }
+
+      try{
+        // Create the exporter
+        Export<LO, GO> exporter (tgt_map, src_map, getImportParameterList ());
+
+        // Do the import using reverse mode
+        tgt_mv->doImport (*src_mv, exporter, INSERT);
+
+        // When collectRank == 0, rank 0 has the GIDs the source map owns ordered first.
+        // When collectRank == 1, rank 1 has the GIDs of rank 0 ordered first.
+        // On all other ranks, there are no remote LIDs.
+        if ((collectRank == 0) || (myImageID != collectRank)) {
+          TEUCHOS_ASSERT(exporter.areExportLIDsContiguous());
+        }
+        else {
+          TEUCHOS_ASSERT(!exporter.areExportLIDsContiguous());
+        }
+
+        // When there are export LIDs and they are contiguous, and
+        // MV::imports_ and MV::view_ have the same memory space, the
+        // imports_ view is aliased to the data view of the target MV.
+        if ((myImageID == collectRank) && (myImageID == 0)) {
+          if (mv_type::dual_view_type::impl_dualview_is_single_device::value)
+            TEUCHOS_ASSERT(tgt_mv->importsAreAliased());
+          // else {
+          //   We do not know if copyAndPermute was run on host or device.
+          // }
+        }
+        else {
+          TEUCHOS_ASSERT(!tgt_mv->importsAreAliased());
+        }
+
+        // Loop through tgt_mv and make sure the import worked.
+        if (tgt_num_local_elements != 0) {
+          auto data = tgt_mv->getLocalViewHost(Tpetra::Access::ReadOnly);
+          for (GO gblRow = tgt_map->getMinGlobalIndex ();
+               gblRow <= tgt_map->getMaxGlobalIndex ();
+               ++gblRow) {
+            const LO lclRow = tgt_map->getLocalElement (gblRow);
+
+            TEST_EQUALITY(data(lclRow,0), Teuchos::ScalarTraits<Scalar>::one ());
+          }
+        }
+
+      }
+      catch (std::exception& e) { // end of the first test
+        err << "Proc " << myImageID << ": " << e.what () << endl;
+        lclErr = 1;
+      }
+
+      reduceAll<int, int> (*comm, REDUCE_MAX, lclErr, outArg (gblErr));
+      TEST_EQUALITY_CONST( gblErr, 0 );
+      if (gblErr != 0) {
+        Tpetra::Details::gathervPrint (out, err.str (), *comm);
+        out << "Above test failed; aborting further tests" << endl;
+        return;
+      }
     }
   }
 
@@ -2847,6 +3013,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL( Import_Util,GetTwoTransferOwnershipVector, LO
 
 #define UNIT_TEST_GROUP_SC_LO_GO( SC, LO, GO )                   \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( CrsMatrixImportExport, doImport, LO, GO, SC ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( MultiVectorImport, doImport, LO, GO, SC ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( FusedImportExport, doImport, LO, GO, SC ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Import_Util, UnpackAndCombineWithOwningPIDs, LO, GO, SC ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( FusedImportExport, MueLuStyle, LO, GO, SC )


### PR DESCRIPTION
@trilinos/tpetra 

Allow to skip `unpackAndCombine` in the following (common) situation:
- import of a MV
- MV has single column
- from a 1-to-1 map into an overlapping map
- CombineMode == INSERT
- off-rank entries are grouped by rank
- memory spaces for comm and data buffers match
- no additional syncs are required, i.e. copyAndPermute and communication are both either on host or on device

If these conditions hold, then the `imports_` view can be aliased to part of the MV's data view, and `unpackAndCombine` can be skipped.