### PR TITLE
Removes HAVE_COMPLEX from complex-valued tests

### DIFF
--- a/packages/belos/test/BlockCG/test_bl_cg_complex_hb.cpp
+++ b/packages/belos/test/BlockCG/test_bl_cg_complex_hb.cpp
@@ -70,16 +70,7 @@ using namespace Teuchos;
 
 int main(int argc, char *argv[]) {
   //
-#ifdef HAVE_COMPLEX
-  typedef std::complex<double> ST;
-#elif HAVE_COMPLEX_H
-  typedef std::complex<double> ST;
-#else
-  std::cout << "Not compiled with std::complex support." << std::endl;
-  std::cout << "End Result: TEST FAILED" << std::endl;
-  return EXIT_FAILURE;
-#endif
-
+  typedef std::complex<double>              ST;
   typedef ScalarTraits<ST>                 SCT;
   typedef SCT::magnitudeType                MT;
   typedef Belos::MultiVec<ST>               MV;

--- a/packages/belos/test/BlockGmres/test_bl_gmres_complex_diag.cpp
+++ b/packages/belos/test/BlockGmres/test_bl_gmres_complex_diag.cpp
@@ -65,16 +65,7 @@ using namespace Teuchos;
 
 int main(int argc, char *argv[]) {
   //
-#ifdef HAVE_COMPLEX
-  typedef std::complex<double> ST;
-#elif HAVE_COMPLEX_H
-  typedef std::complex<double> ST;
-#else
-  std::cout << "Not compiled with std::complex support." << std::endl;
-  std::cout << "End Result: TEST FAILED" << std::endl;
-  return EXIT_FAILURE;
-#endif
-
+  typedef std::complex<double>              ST;
   typedef ScalarTraits<ST>                 SCT;
   typedef SCT::magnitudeType                MT;
   typedef Belos::MultiVec<ST>               MV;

--- a/packages/belos/test/BlockGmres/test_bl_gmres_complex_hb.cpp
+++ b/packages/belos/test/BlockGmres/test_bl_gmres_complex_hb.cpp
@@ -72,16 +72,7 @@ using namespace Teuchos;
 
 int main(int argc, char *argv[]) {
   //
-#ifdef HAVE_COMPLEX
-  typedef std::complex<double> ST;
-#elif HAVE_COMPLEX_H
-  typedef std::complex<double> ST;
-#else
-  std::cout << "Not compiled with std::complex support." << std::endl;
-  std::cout << "End Result: TEST FAILED" << std::endl;
-  return EXIT_FAILURE;
-#endif
-
+  typedef std::complex<double>              ST;
   typedef ScalarTraits<ST>                 SCT;
   typedef SCT::magnitudeType                MT;
   typedef Belos::MultiVec<ST>               MV;

--- a/packages/belos/test/BlockGmres/test_hybrid_gmres_complex_hb.cpp
+++ b/packages/belos/test/BlockGmres/test_hybrid_gmres_complex_hb.cpp
@@ -71,16 +71,7 @@ using namespace Teuchos;
 
 int main(int argc, char *argv[]) {
   //
-#ifdef HAVE_COMPLEX
-  typedef std::complex<double> ST;
-#elif HAVE_COMPLEX_H
-  typedef std::complex<double> ST;
-#else
-  std::cout << "Not compiled with std::complex support." << std::endl;
-  std::cout << "End Result: TEST FAILED" << std::endl;
-  return EXIT_FAILURE;
-#endif
-
+  typedef std::complex<double>              ST;
   typedef ScalarTraits<ST>                 SCT;
   typedef SCT::magnitudeType                MT;
   typedef Belos::MultiVec<ST>               MV;

--- a/packages/belos/test/GCRODR/test_gcrodr_complex_hb.cpp
+++ b/packages/belos/test/GCRODR/test_gcrodr_complex_hb.cpp
@@ -68,16 +68,7 @@ using namespace Teuchos;
 
 int main(int argc, char *argv[]) {
   //
-#ifdef HAVE_COMPLEX
-  typedef std::complex<double> ST;
-#elif HAVE_COMPLEX_H
-  typedef std::complex<double> ST;
-#else
-  std::cout << "Not compiled with std::complex support." << std::endl;
-  std::cout << "End Result: TEST FAILED" << std::endl;
-  return EXIT_FAILURE;
-#endif
-
+  typedef std::complex<double>              ST;
   typedef ScalarTraits<ST>                 SCT;
   typedef SCT::magnitudeType                MT;
   typedef Belos::MultiVec<ST>               MV;

--- a/packages/belos/test/MINRES/test_minres_complex_hb.cpp
+++ b/packages/belos/test/MINRES/test_minres_complex_hb.cpp
@@ -68,16 +68,7 @@ using namespace Teuchos;
 
 int main(int argc, char *argv[]) {
   //
-#ifdef HAVE_COMPLEX
-  typedef std::complex<double> ST;
-#elif HAVE_COMPLEX_H
-  typedef std::complex<double> ST;
-#else
-  std::cout << "Not compiled with std::complex support." << std::endl;
-  std::cout << "End Result: TEST FAILED" << std::endl;
-  return -1;
-#endif
-
+  typedef std::complex<double>              ST;
   typedef ScalarTraits<ST>                 SCT;
   typedef SCT::magnitudeType                MT;
   typedef Belos::MultiVec<ST>               MV;

--- a/packages/belos/test/MVOPTester/cxx_main_complex.cpp
+++ b/packages/belos/test/MVOPTester/cxx_main_complex.cpp
@@ -101,24 +101,7 @@ int main(int argc, char *argv[])
       return -1;
     }
 
-#ifdef HAVE_COMPLEX
     typedef std::complex<double> ST;
-#elif HAVE_COMPLEX_H
-    typedef std::complex<double> ST;
-#else
-    typedef double ST;
-    // no std::complex. quit with failure.
-    if (verbose && MyPID==0) {
-      std::cout << "Not compiled with std::complex support." << std::endl;
-      if (verbose && MyPID==0) {
-        std::cout << "End Result: TEST FAILED" << std::endl;
-      }
-#ifdef HAVE_MPI
-      MPI_Finalize();
-#endif
-      return -1;
-    }
-#endif
 
     // Issue several useful typedefs;
     typedef Belos::MultiVec<ST> MV;

--- a/packages/belos/test/TFQMR/test_pseudo_tfqmr_complex_hb.cpp
+++ b/packages/belos/test/TFQMR/test_pseudo_tfqmr_complex_hb.cpp
@@ -69,16 +69,7 @@ using namespace Teuchos;
 
 int main(int argc, char *argv[]) {
   //
-#ifdef HAVE_COMPLEX
-  typedef std::complex<double> ST;
-#elif HAVE_COMPLEX_H
-  typedef std::complex<double> ST;
-#else
-  std::cout << "Not compiled with std::complex support." << std::endl;
-  std::cout << "End Result: TEST FAILED" << std::endl;
-  return EXIT_FAILURE;
-#endif
-
+  typedef std::complex<double>              ST;
   typedef ScalarTraits<ST>                 SCT;
   typedef SCT::magnitudeType                MT;
   typedef Belos::MultiVec<ST>               MV;

--- a/packages/belos/test/TFQMR/test_tfqmr_complex_diag.cpp
+++ b/packages/belos/test/TFQMR/test_tfqmr_complex_diag.cpp
@@ -64,16 +64,7 @@ using namespace Teuchos;
 
 int main(int argc, char *argv[]) {
   //
-#ifdef HAVE_COMPLEX
-  typedef std::complex<double> ST;
-#elif HAVE_COMPLEX_H
-  typedef std::complex<double> ST;
-#else
-  std::cout << "Not compiled with std::complex support." << std::endl;
-  std::cout << "End Result: TEST FAILED" << std::endl;
-  return EXIT_FAILURE;
-#endif
-
+  typedef std::complex<double>              ST;
   typedef ScalarTraits<ST>                 SCT;
   typedef SCT::magnitudeType                MT;
   typedef Belos::MultiVec<ST>               MV;

--- a/packages/belos/test/TFQMR/test_tfqmr_complex_hb.cpp
+++ b/packages/belos/test/TFQMR/test_tfqmr_complex_hb.cpp
@@ -69,16 +69,7 @@ using namespace Teuchos;
 
 int main(int argc, char *argv[]) {
   //
-#ifdef HAVE_COMPLEX
-  typedef std::complex<double> ST;
-#elif HAVE_COMPLEX_H
-  typedef std::complex<double> ST;
-#else
-  std::cout << "Not compiled with std::complex support." << std::endl;
-  std::cout << "End Result: TEST FAILED" << std::endl;
-  return EXIT_FAILURE;
-#endif
-
+  typedef std::complex<double>              ST;
   typedef ScalarTraits<ST>                 SCT;
   typedef SCT::magnitudeType                MT;
   typedef Belos::MultiVec<ST>               MV;


### PR DESCRIPTION

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/belos

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The HAVE_COMPLEX macro is a deprecated conditional from the days when
the complex<> class had non-uniform support across compilers.  It can,
and should, be removed, as mentioned in Github issue #1995

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of #1995 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Serial OSX GCC10.x 

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->