### PR TITLE
van1-tx2: Add deprecation notice

### DIFF
--- a/cmake/std/atdm/van1-tx2/environment.sh
+++ b/cmake/std/atdm/van1-tx2/environment.sh
@@ -193,6 +193,14 @@ export ATMD_CONFIG_MPI_USE_COMPILER_WRAPPERS=ON
 
 export ATDM_CONFIG_WCID_ACCOUNT_DEFAULT=fy150090
 
+# Print deprecation warning
+if [[ "$ATDM_CONFIG_COMPILER" != "ARM-20.1_OPENMPI-4.0.5" ]]; then
+    echo "***"
+    echo "*** DEPRECATION NOTICE:"
+    echo "****   WARNING: \"$ATDM_CONFIG_COMPILER\" will no longer be supported on 07-15-2021."
+    echo "***"
+fi
+
 #
 # Done
 #


### PR DESCRIPTION
CC: @sebrowne, @jwillenbring

## How was this tested?
### On van1-tx2:
```bash
$ source cmake/std/atdm/load-env.sh default
Hostname 'van1-tx2' matches known ATDM host 'van1-tx2' and system 'van1-tx2'
Setting compiler and build options for build-name 'default'
Using ARM ATSE compiler stack ARM-20.1_OPENMPI-4.0.5 to build DEBUG code with Kokkos node type SERIAL

$ source cmake/std/atdm/load-env.sh arm-20.0
Hostname 'van1-tx2' matches known ATDM host 'van1-tx2' and system 'van1-tx2'
Setting compiler and build options for build-name 'arm-20.0'
Using ARM ATSE compiler stack ARM-20.0_OPENMPI-4.0.2 to build DEBUG code with Kokkos node type SERIAL
***
*** DEPRECATION NOTICE:
****   WARNING: "ARM-20.0_OPENMPI-4.0.2" will no longer be supported on 07-15-2021.
***
```

Related to #9100.