### PR TITLE
Tpetra: residual changes

### DIFF
--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestOverlappingRowMatrix.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestOverlappingRowMatrix.cpp
@@ -67,6 +67,7 @@
 #endif
 
 #include "Tpetra_Details_residual.hpp"
+#include "KokkosSparse_spmv_impl.hpp"
 
 #include <Ifpack2_UnitTestHelpers.hpp>
 #include <Ifpack2_OverlappingRowMatrix.hpp>
@@ -133,8 +134,7 @@ void localReducedMatvec(const MatrixClass & A_lcl,
   int64_t numLocalRows = userNumRows;
   int64_t myNnz = A_lcl.nnz();
 
-  int64_t rows_per_team = 
-    Tpetra::Details::residual_launch_parameters<execution_space>(numLocalRows, myNnz, rows_per_thread, team_size, vector_length);
+  int64_t rows_per_team = KokkosSparse::Impl::spmv_launch_parameters<execution_space>(numLocalRows, myNnz, rows_per_thread, team_size, vector_length);
   int64_t worksets = (X_lcl.extent (0) + rows_per_team - 1) / rows_per_team;
 
   using policy_type = typename Kokkos::TeamPolicy<execution_space>;

--- a/packages/tpetra/core/src/CMakeLists.txt
+++ b/packages/tpetra/core/src/CMakeLists.txt
@@ -317,7 +317,7 @@ FUNCTION(TPETRA_PROCESS_ALL_LGN_TEMPLATES OUTPUT_FILES TEMPLATE_FILE
       FOREACH(LO ${LOCALORDINAL_TYPES})
         TPETRA_MANGLE_TEMPLATE_PARAMETER(LO_MANGLED "${LO}")
         TPETRA_SLG_MACRO_NAME(LO_MACRO_NAME "${LO}")
-        
+
         TPETRA_PROCESS_ONE_LGN_TEMPLATE(OUT_FILE "${TEMPLATE_FILE}"
           "${CLASS_NAME}" "${CLASS_MACRO_NAME}"
           "${LO_MANGLED}" "${GO_MANGLED}" "${NT_MANGLED}"
@@ -619,7 +619,7 @@ IF (${PACKAGE_NAME}_ENABLE_EXPLICIT_INSTANTIATION)
       "${TpetraCore_ETI_NODES}"
       TRUE)
     LIST(APPEND SOURCES ${LOCALDEEPCOPYROWMATRIX_OUTPUT_FILES})
-  
+
     # Generate ETI .cpp files for the RowMatrix -> CrsMatrix overload of
     # Tpetra::createDeepCopy.  Do this only for non-integer Scalar
     # types, since we really only need this function for linear solvers.
@@ -634,7 +634,7 @@ IF (${PACKAGE_NAME}_ENABLE_EXPLICIT_INSTANTIATION)
       FALSE)
     LIST(APPEND SOURCES ${CREATEDEEPCOPY_CRSMATRIX_OUTPUT_FILES})
   ENDIF ()
-  
+
   # Generate ETI .cpp files for Tpetra::LocalCrsMatrixOperator.
   TPETRA_PROCESS_ALL_SN_TEMPLATES(LOCALCRSMATRIXOPERATOR_OUTPUT_FILES
     "Tpetra_ETI_SC_NT.tmpl" "LocalCrsMatrixOperator"
@@ -777,5 +777,5 @@ SET_PROPERTY(
 # / from this directory, or to / from the 'impl' subdirectory.  That ensures
 # that running "make" will also rerun CMake in order to regenerate Makefiles.
 #
-# Here's another change, another, and another.
+# Here's another change, another, and another and yet another.
 #

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -303,6 +303,9 @@ public:
     using nonconst_global_inds_host_view_type =
           typename row_graph_type::nonconst_global_inds_host_view_type;
 
+    using offset_device_view_type =
+          typename row_ptrs_device_view_type::non_const_type;
+
 
 //KDDKDD INROW    using local_inds_host_view_type = 
 //KDDKDD INROW          typename local_inds_dualv_type::t_host::const_type;
@@ -1387,6 +1390,10 @@ public:
     void
     getLocalDiagOffsets (const Kokkos::View<size_t*, device_type, Kokkos::MemoryUnmanaged>& offsets) const;
 
+    /// \brief Get offsets of the off-rank entries in the graph.
+    void
+    getLocalOffRankOffsets (offset_device_view_type& offsets) const;
+
     /// \brief Backwards compatibility overload of the above method.
     ///
     /// This method takes a Teuchos::ArrayRCP instead of a
@@ -2064,6 +2071,8 @@ public:
     /// </ul>
     void computeGlobalConstants ();
 
+    bool haveLocalOffRankOffsets() const { return haveLocalOffRankOffsets_;}
+
   protected:
     /// \brief Compute local constants, if they have not yet been computed.
     ///
@@ -2410,6 +2419,13 @@ public:
     /// This may also exist with 1-D storage, if storage is unpacked.
     num_row_entries_type k_numRowEntries_;
 
+    /// \brief The offsets for off-rank entries.
+    ///
+    /// When off-rank entries are sorted last, this rowPtr-lile view
+    /// contains the offsets. It is compute on the first call to
+    /// getLocalOffRankOffsets().
+    mutable offset_device_view_type k_offRankOffsets_;
+
     //@}
 
     /// \brief Status of the graph's storage, when not in a
@@ -2438,6 +2454,8 @@ public:
     bool haveLocalConstants_ = false;
     //! Whether all processes have computed global constants.
     bool haveGlobalConstants_ = false;
+    //!
+    mutable bool haveLocalOffRankOffsets_ = false;
 
     typedef typename std::map<global_ordinal_type, std::vector<global_ordinal_type> > nonlocals_type;
 

--- a/packages/tpetra/core/src/Tpetra_Details_Behavior.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Behavior.cpp
@@ -549,6 +549,29 @@ bool Behavior::hierarchicalUnpack ()
                                                    defaultValue);
 }
 
+bool Behavior::skipCopyAndPermuteIfPossible ()
+{
+  constexpr char envVarName[] = "TPETRA_SKIP_COPY_AND_PERMUTE";
+  constexpr bool defaultValue(false);
+
+  static bool value_ = defaultValue;
+  static bool initialized_ = false;
+  return idempotentlyGetEnvironmentVariableAsBool
+    (value_, initialized_, envVarName, defaultValue);
+}
+
+bool Behavior::overlapCommunicationAndComputation ()
+{
+  constexpr char envVarName[] = "TPETRA_OVERLAP";
+  constexpr bool defaultValue(false);
+
+  static bool value_ = defaultValue;
+  static bool initialized_ = false;
+  return idempotentlyGetEnvironmentVariableAsBool
+    (value_, initialized_, envVarName, defaultValue);
+}
+
+
 } // namespace Details
 } // namespace Tpetra
 

--- a/packages/tpetra/core/src/Tpetra_Details_Behavior.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Behavior.hpp
@@ -263,6 +263,18 @@ public:
   /// environment variable.
   static bool profilingRegionUseKokkosProfiling();
 
+  /// \brief Skip copyAndPermute if possible
+  ///
+  /// This is disabled by default.  You may control this at run time via the
+  /// <tt>TPETRA_SKIP_COPY_AND_PERMUTE</tt> environment variable.
+  static bool skipCopyAndPermuteIfPossible();
+
+  /// \brief Overlap communication and computation.
+  ///
+  /// This is disabled by default.  You may control this at run time via the
+  /// <tt>TPETRA_OVERLAP</tt> environment variable.
+  static bool overlapCommunicationAndComputation();
+
 
 };
 

--- a/packages/tpetra/core/src/Tpetra_Details_Transfer_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Transfer_decl.hpp
@@ -233,6 +233,14 @@ public:
   void expertSetExportLIDsContiguous<LO,GO,NT>(Transfer<LO, GO, NT> transfer, bool contig);
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
+  /// \brief Are source and target map locally fitted?
+  ///
+  /// Returns whether source and target map are locally fitted on the
+  /// calling rank. This is can be more efficient that calling
+  /// isLocallyFitted() on the maps directly, since no indices need to
+  /// be compared.
+  bool isLocallyFitted () const;
+
   /// \brief Describe this object in a human-readable way to the given
   ///   output stream.
   ///

--- a/packages/tpetra/core/src/Tpetra_Details_Transfer_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Transfer_def.hpp
@@ -300,6 +300,14 @@ isLocallyComplete () const {
 }
 
 template <class LO, class GO, class NT>
+bool
+Transfer<LO, GO, NT>::
+isLocallyFitted () const {
+  return (getNumSameIDs() == std::min(getSourceMap()->getNodeNumElements(),
+                                      getTargetMap()->getNodeNumElements()));
+}
+
+template <class LO, class GO, class NT>
 void
 Transfer<LO, GO, NT>::
 detectRemoteExportLIDsContiguous () const {

--- a/packages/tpetra/core/src/Tpetra_Details_getGraphOffRankOffsets.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_getGraphOffRankOffsets.cpp
@@ -1,0 +1,67 @@
+/*
+// @HEADER
+// ***********************************************************************
+//
+//          Tpetra: Templated Linear Algebra Services Package
+//                 Copyright (2008) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+*/
+
+#include "TpetraCore_config.h"
+
+#if defined(HAVE_TPETRA_EXPLICIT_INSTANTIATION)
+
+// We protect the contents of this file with macros, to assist
+// applications that circumvent Trilinos' build system.  (We do NOT
+// recommend this.)  That way, they can still build this file, but as
+// long as the macros have correct definitions, they won't build
+// anything that's not enabled.
+
+#include "KokkosCompat_ClassicNodeAPI_Wrapper.hpp"
+#include "Tpetra_Details_getGraphOffRankOffsets_decl.hpp"
+#include "Tpetra_Details_getGraphOffRankOffsets_def.hpp"
+#include "TpetraCore_ETIHelperMacros.h"
+
+namespace Tpetra {
+
+  TPETRA_ETI_MANGLING_TYPEDEFS()
+
+  TPETRA_INSTANTIATE_LGN( TPETRA_DETAILS_IMPL_GETGRAPHOFFRANKOFFSETS_INSTANT )
+
+} // namespace Tpetra
+
+#endif // Whether we should build this specialization

--- a/packages/tpetra/core/src/Tpetra_Details_getGraphOffRankOffsets_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_getGraphOffRankOffsets_decl.hpp
@@ -1,0 +1,146 @@
+/*
+// @HEADER
+// ***********************************************************************
+//
+//          Tpetra: Templated Linear Algebra Services Package
+//                 Copyright (2008) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+*/
+
+#ifndef TPETRA_DETAILS_GETGRAPHOFFRANKOFFSETS_DECL_HPP
+#define TPETRA_DETAILS_GETGRAPHOFFRANKOFFSETS_DECL_HPP
+
+/// \file Tpetra_Details_getGraphOffRankOffsets_decl.hpp
+/// \brief Declare and define the function
+///   Tpetra::Details::getGraphOffRankOffsets, an implementation detail
+///   of Tpetra::CrsGraph.
+
+#include "TpetraCore_config.h"
+#include "Kokkos_Core.hpp"
+#include "Kokkos_StaticCrsGraph.hpp"
+#include "Tpetra_Details_LocalMap.hpp"
+#include <type_traits>
+
+namespace Tpetra {
+namespace Details {
+namespace Impl {
+
+/// \brief Implementation detail of
+///   Tpetra::Details::getGraphOffRankOffsets, which in turn is an
+///   implementation detail of Tpetra::CrsGraph.
+///
+/// FIXME (mfh 12 Mar 2016) There's currently no way to make a
+/// MemoryUnmanaged Kokkos::StaticCrsGraph.  Thus, we have to do this
+/// separately for its column indices.  We want the column indices to
+/// be unmanaged because we need to take subviews in this kernel.
+/// Taking a subview of a managed View updates the reference count,
+/// which is a thread scalability bottleneck.
+///
+/// mfh 12 Mar 2016: Tpetra::CrsGraph::getLocalOffRankOffsets returns
+/// offsets as size_t.  However, see Github Issue #213.
+template<class LO,
+         class GO,
+         class DeviceType,
+         class OffsetType = size_t>
+class GetGraphOffRankOffsets {
+public:
+  typedef typename DeviceType::device_type device_type;
+  typedef OffsetType offset_type;
+  typedef ::Kokkos::View<offset_type*,
+                         device_type,
+                         ::Kokkos::MemoryUnmanaged> offsets_type;
+  typedef ::Kokkos::StaticCrsGraph<LO,
+                                   ::Kokkos::LayoutLeft,
+                                   device_type,
+                                   void, size_t> local_graph_type;
+  typedef ::Tpetra::Details::LocalMap<LO, GO, device_type> local_map_type;
+  typedef ::Kokkos::View<const typename local_graph_type::size_type*,
+                         ::Kokkos::LayoutLeft,
+                         device_type,
+                         ::Kokkos::MemoryUnmanaged> row_offsets_type;
+  // This is unmanaged for performance, because we need to take
+  // subviews inside the functor.
+  typedef ::Kokkos::View<const LO*,
+                         ::Kokkos::LayoutLeft,
+                         device_type,
+                         ::Kokkos::MemoryUnmanaged> lcl_col_inds_type;
+
+  //! Constructor; also runs the functor.
+  GetGraphOffRankOffsets (const offsets_type& OffRankOffsets,
+                          const local_map_type& lclColMap,
+                          const local_map_type& lclDomMap,
+                          const row_offsets_type& ptr,
+                          const lcl_col_inds_type& ind);
+
+  //! Kokkos::parallel_for loop body.
+  KOKKOS_FUNCTION void operator() (const LO& lclRowInd) const;
+
+private:
+  offsets_type OffRankOffsets_;
+  local_map_type lclColMap_;
+  local_map_type lclDomMap_;
+  row_offsets_type ptr_;
+  lcl_col_inds_type ind_;
+  LO lclNumRows_;
+};
+
+} // namespace Impl
+
+template<class OffsetsType,
+         class LclMapType,
+         class LclGraphType>
+void
+getGraphOffRankOffsets (const OffsetsType& OffRankOffsets,
+                        const LclMapType& lclColMap,
+                        const LclMapType& lclDomMap,
+                        const LclGraphType& lclGraph)
+{
+  typedef typename OffsetsType::non_const_value_type offset_type;
+  typedef typename LclMapType::local_ordinal_type LO;
+  typedef typename LclMapType::global_ordinal_type GO;
+  typedef typename LclMapType::device_type DT;
+
+  typedef Impl::GetGraphOffRankOffsets<LO, GO, DT, offset_type> impl_type;
+
+  // The functor's constructor runs the functor.
+  impl_type impl (OffRankOffsets, lclColMap, lclDomMap, lclGraph.row_map, lclGraph.entries);
+}
+
+} // namespace Details
+} // namespace Tpetra
+
+#endif // TPETRA_DETAILS_GETGRAPHOFFRANKOFFSETS_DECL_HPP

--- a/packages/tpetra/core/src/Tpetra_Details_getGraphOffRankOffsets_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_getGraphOffRankOffsets_def.hpp
@@ -1,0 +1,134 @@
+/*
+// @HEADER
+// ***********************************************************************
+//
+//          Tpetra: Templated Linear Algebra Services Package
+//                 Copyright (2008) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+*/
+
+#ifndef TPETRA_DETAILS_GETGRAPHOFFRANKOFFSETS_DEF_HPP
+#define TPETRA_DETAILS_GETGRAPHOFFRANKOFFSETS_DEF_HPP
+
+/// \file Tpetra_Details_getGraphOffRankOffsets_def.hpp
+/// \brief Define the implementation of the function
+///   Tpetra::Details::getGraphOffRankOffsets, an implementation detail
+///   of Tpetra::CrsGraph.
+
+#include "Tpetra_Details_OrdinalTraits.hpp"
+#include "Tpetra_Map.hpp"
+#include "KokkosSparse_findRelOffset.hpp"
+
+namespace Tpetra {
+namespace Details {
+namespace Impl {
+
+/// \brief Implementation detail of
+///   Tpetra::Details::getGraphOffRankOffsets, which in turn is an
+///   implementation detail of Tpetra::CrsGraph.
+///
+/// FIXME (mfh 12 Mar 2016) There's currently no way to make a
+/// MemoryUnmanaged Kokkos::StaticCrsGraph.  Thus, we have to do this
+/// separately for its column indices.  We want the column indices to
+/// be unmanaged because we need to take subviews in this kernel.
+/// Taking a subview of a managed View updates the reference count,
+/// which is a thread scalability bottleneck.
+///
+/// mfh 12 Mar 2016: Tpetra::CrsGraph::getLocalOffRankOffsets returns
+/// offsets as size_t.  However, see Github Issue #213.
+template<class LO,
+         class GO,
+         class Node,
+         class OffsetType>
+GetGraphOffRankOffsets<LO, GO, Node, OffsetType>::
+GetGraphOffRankOffsets (const offsets_type& OffRankOffsets,
+                        const local_map_type& lclColMap,
+                        const local_map_type& lclDomMap,
+                        const row_offsets_type& ptr,
+                        const lcl_col_inds_type& ind) :
+  OffRankOffsets_ (OffRankOffsets),
+  lclColMap_ (lclColMap),
+  lclDomMap_ (lclDomMap),
+  ptr_ (ptr),
+  ind_ (ind)
+{
+  typedef typename device_type::execution_space execution_space;
+  typedef Kokkos::RangePolicy<execution_space, LO> policy_type;
+
+  lclNumRows_ = ptr.extent(0)-1;
+  policy_type range (0, ptr.extent(0));
+  Kokkos::parallel_for (range, *this);
+}
+
+template<class LO,
+         class GO,
+         class Node,
+         class OffsetType>
+KOKKOS_FUNCTION void
+GetGraphOffRankOffsets<LO, GO, Node, OffsetType>::
+operator() (const LO& lclRowInd) const
+{
+  const LO INVALID =
+    Tpetra::Details::OrdinalTraits<LO>::invalid ();
+
+  if (lclRowInd == lclNumRows_)
+    OffRankOffsets_[lclRowInd] = ptr_[lclRowInd];
+  else {
+    // TODO: use parallel reduce
+    size_t offset = ptr_[lclRowInd+1];
+    for (size_t j = ptr_[lclRowInd]; j < ptr_[lclRowInd+1]; j++) {
+      const LO lclColInd = ind_[j];
+      const GO gblColInd = lclColMap_.getGlobalElement (lclColInd);
+      const LO lclDomInd = lclDomMap_.getLocalElement (gblColInd);
+      if ((lclDomInd == INVALID) && (j < offset))
+        offset = j;
+    }
+    OffRankOffsets_[lclRowInd] = offset;
+  }
+}
+
+} // namespace Impl
+} // namespace Details
+} // namespace Tpetra
+
+// Explicit template instantiation macro for
+// Tpetra::Details::Impl::GetGraphOffRankOffsets.  NOT FOR USERS!!!  Must
+// be used inside the Tpetra namespace.
+#define TPETRA_DETAILS_IMPL_GETGRAPHOFFRANKOFFSETS_INSTANT( LO, GO, NODE ) \
+  template class Details::Impl::GetGraphOffRankOffsets< LO, GO, NODE::device_type >;
+
+#endif // TPETRA_DETAILS_GETGRAPHOFFRANKOFFSETS_DEF_HPP

--- a/packages/tpetra/core/test/CrsGraph/CrsGraph_UnitTests1.cpp
+++ b/packages/tpetra/core/test/CrsGraph/CrsGraph_UnitTests1.cpp
@@ -583,6 +583,62 @@ namespace { // (anonymous)
     TEST_EQUALITY_CONST(globalSuccess_int, 0);
   }
 
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( CrsGraph, Offsets, LO, GO , Node )
+  {
+    typedef Tpetra::CrsGraph<LO, GO, Node> GRAPH;
+    typedef Tpetra::Map<LO, GO, Node> map_type;
+    typedef typename GRAPH::device_type device_type;
+
+    const GST INVALID = Teuchos::OrdinalTraits<GST>::invalid ();
+    // get a comm
+    RCP<const Comm<int> > comm = getDefaultComm();
+    const int numProcs = comm->getSize();
+    // test filtering
+    if (numProcs > 1) {
+      const size_t numLocal = 2;
+      RCP<const map_type> rmap =
+        rcp (new map_type (INVALID, numLocal, 0, comm));
+      ArrayRCP<GO> cmap_ind(numLocal);
+      cmap_ind[0] = comm->getRank()*numLocal;
+      cmap_ind[1] = ((comm->getRank()+1)*numLocal) % (numProcs*numLocal);
+      RCP<const map_type> cmap =
+        rcp (new map_type (INVALID, cmap_ind(), 0, comm));
+      ArrayRCP<size_t> rowptr(numLocal+1);
+      ArrayRCP<LO>     colind(numLocal); // one unknown per row
+      rowptr[0] = 0; rowptr[1] = 1; rowptr[2] = 2;
+      colind[0] = Teuchos::as<LO>(0);
+      colind[1] = Teuchos::as<LO>(1);
+
+      RCP<GRAPH> G = rcp(new GRAPH(rmap,cmap,0,StaticProfile) );
+      TEST_NOTHROW( G->setAllIndices(rowptr,colind) );
+      TEST_EQUALITY_CONST( G->hasColMap(), true );
+
+      TEST_NOTHROW( G->expertStaticFillComplete(rmap,rmap) );
+      TEST_EQUALITY( G->getRowMap(), rmap );
+      TEST_EQUALITY( G->getColMap(), cmap );
+
+      auto diagOffsets = Kokkos::View<size_t*, device_type>("diagOffsets", numLocal);
+      G->getLocalDiagOffsets(diagOffsets);
+      auto diagOffsets_h = Kokkos::create_mirror_view(diagOffsets);
+      Kokkos::deep_copy(diagOffsets_h, diagOffsets);
+      TEST_EQUALITY( diagOffsets_h(0), 0 );
+      TEST_EQUALITY( diagOffsets_h(1), INVALID );
+
+      typename GRAPH::offset_device_view_type offRankOffsets;
+      G->getLocalOffRankOffsets(offRankOffsets);
+      auto offRankOffsets_h = Kokkos::create_mirror_view(offRankOffsets);
+      Kokkos::deep_copy(offRankOffsets_h, offRankOffsets);
+      TEST_EQUALITY( offRankOffsets_h(0), 1 );
+      TEST_EQUALITY( offRankOffsets_h(1), 1 );
+
+    }
+
+    // All procs fail if any node fails
+    int globalSuccess_int = -1;
+    Teuchos::reduceAll( *comm, Teuchos::REDUCE_SUM, success ? 0 : 1, outArg(globalSuccess_int) );
+    TEST_EQUALITY_CONST( globalSuccess_int, 0 );
+  }
+
 //
 // INSTANTIATIONS
 //
@@ -599,7 +655,8 @@ namespace { // (anonymous)
       TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( CrsGraph, SortingTests,      LO, GO, NODE ) \
       TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( CrsGraph, TwoArraysESFC,     LO, GO, NODE ) \
       TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( CrsGraph, SetAllIndices,     LO, GO, NODE ) \
-      TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( CrsGraph, StaticProfileMultiInsert, LO, GO, NODE )
+      TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( CrsGraph, StaticProfileMultiInsert, LO, GO, NODE ) \
+      TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( CrsGraph, Offsets,           LO, GO, NODE )
 
     TPETRA_ETI_MANGLING_TYPEDEFS()
 

--- a/packages/tpetra/core/test/ImportExport/ImportExport_UnitTests.cpp
+++ b/packages/tpetra/core/test/ImportExport/ImportExport_UnitTests.cpp
@@ -128,6 +128,7 @@ namespace {
 
     bool isvalid=Tpetra::Import_Util::checkImportValidity(*importer);
     TEST_EQUALITY(isvalid,true);
+    TEST_EQUALITY(importer->isLocallyFitted(), source->isLocallyFitted(*target));
   }
 
   TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( ImportExport, GetNeighborsForward, Scalar, LO, GO, Node )
@@ -185,11 +186,13 @@ namespace {
       TEST_EQUALITY( importer->getNumPermuteIDs(), static_cast<size_t>(myImageID == 0 ? 0 : 1) );
       TEST_EQUALITY( importer->getNumExportIDs(), (myImageID == 0 || myImageID == numImages - 1 ? 1 : 2) );
       TEST_EQUALITY( importer->getNumRemoteIDs(), (myImageID == 0 || myImageID == numImages - 1 ? 1 : 2) );
+      TEST_EQUALITY( importer->isLocallyFitted(), tmap->isLocallyFitted(*smap));
       // exporter testing
       TEST_EQUALITY_CONST( exporter->getSourceMap() == tmap, true );
       TEST_EQUALITY_CONST( exporter->getTargetMap() == smap, true );
       TEST_EQUALITY( importer->getNumSameIDs(), (myImageID == 0 ? 1 : 0) );
       TEST_EQUALITY( exporter->getNumPermuteIDs(), static_cast<size_t>(myImageID == 0 ? 0 : 1) );
+      TEST_EQUALITY( exporter->isLocallyFitted(), tmap->isLocallyFitted(*smap));
       // import neighbors, test their proper arrival
       //                   [ 0    n     2n    3n    4n ]
       // mvWithNeighbors = [...  ....  ....  ....  ....]
@@ -290,11 +293,13 @@ namespace {
       TEST_EQUALITY( importer->getNumPermuteIDs(), static_cast<size_t>(myImageID == 0 ? 0 : 1) );
       TEST_EQUALITY( importer->getNumExportIDs(), (myImageID == 0 || myImageID == numImages - 1 ? 1 : 2) );
       TEST_EQUALITY( importer->getNumRemoteIDs(), (myImageID == 0 || myImageID == numImages - 1 ? 1 : 2) );
+      TEST_EQUALITY( importer->isLocallyFitted(), tmap->isLocallyFitted(*smap));
       // exporter testing
       TEST_EQUALITY_CONST( exporter->getSourceMap() == tmap, true );
       TEST_EQUALITY_CONST( exporter->getTargetMap() == smap, true );
       TEST_EQUALITY( importer->getNumSameIDs(), (myImageID == 0 ? 1 : 0) );
       TEST_EQUALITY( exporter->getNumPermuteIDs(), static_cast<size_t>(myImageID == 0 ? 0 : 1) );
+      TEST_EQUALITY( exporter->isLocallyFitted(), tmap->isLocallyFitted(*smap));
       // import neighbors, test their proper arrival
       //                   [ 0    n     2n    3n    4n ]
       // mvWithNeighbors = [...  ....  ....  ....  ....]
@@ -371,6 +376,7 @@ namespace {
     // - the first will be over-written (by 1.0) from the source, while
     // - the second will be "combined", i.e., abs(max(1.0,3.0)) = 3.0 from the dest
     auto importer = Tpetra::createImport<LO, GO, Node> (smap, dmap);
+    TEST_EQUALITY( importer->isLocallyFitted(), dmap->isLocallyFitted(*smap));
     dstVec->doImport (*srcVec,*importer,Tpetra::ABSMAX);
     TEST_COMPARE_ARRAYS( tuple<SC>(-1.0,3.0), dstVec->get1dView() )
     // All procs fail if any proc fails
@@ -442,6 +448,8 @@ namespace {
 
     // Importer
     Tpetra_Import Importer(FromMap,ToMap);
+
+    TEST_EQUALITY( Importer.isLocallyFitted(), ToMap->isLocallyFitted(*FromMap));
 
     // Duplicating what Zoltan2/Tpetra Does
     IntVector FromVector(FromMap);


### PR DESCRIPTION
@trilinos/tpetra

## Motivation
- Add `isLocallyFitted` to `Details::Transfer` (and hence `Import` and `Export`). This can be cheaper than calling `Map`'s `isLocallyFitted`, since comparison of local indices is avoided.
- Skip `copyAndPermute` in `Details::residual` if domain and column map are locally fitted (OFF by default).
- Add method `computeLocalOffRankOffsets` to `CrsGraph`.
- Use Kokkos Kernels SpMV launch parameters for Tpetra's residual, they currently are a copy anyways, except for the HIP part that was recently added to Kokkos Kernels.
- Implement communication/computation overlap for Tpetra's residual (OFF by default).
- Add environment variables `TPETRA_SKIP_COPY_AND_PERMUTE` and `TPETRA_OVERLAP`

## Timing results
I ran `MueLu_Driver.exe` on 2 nodes, 8 GPUs of Lassen, UVM=OFF:
```
jsrun -M "-gpu" -p 8 -r 4 -g1 -c4 -brs ./MueLu_Driver.exe --nx=160 --ny=160 --nz=80 --matrixType=Laplace3D --resolve=19 --stacked-timer

--------------------------------------------------------------------------------
---                            Multigrid Summary Laplace3D                   ---
--------------------------------------------------------------------------------
Scalar              = double
Number of levels    = 4
Operator complexity = 1.58
Smoother complexity = 1.74
Cycle type          = V

level  rows     nnz       nnz/row  c ratio  procs
  0  2048000  14233600  6.95                  8  
  1  258240   7802664   30.21    7.93         8  
  2  6395     450867    70.50    40.38        1  
  3  90       4150      46.11    71.06        1  

Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Jacobi, sweeps: 4, damping factor: 1, Global matrix dimensions: [2048000, 2048000], Global nnz: 14233600}

Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Jacobi, sweeps: 4, damping factor: 1, Global matrix dimensions: [258240, 258240], Global nnz: 7802664}

Smoother (level 2) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Jacobi, sweeps: 4, damping factor: 1, Global matrix dimensions: [6395, 6395], Global nnz: 450867}

Smoother (level 3) pre  : KLU2 solver interface
Smoother (level 3) post : no smoother
```
I switched the smoother to Jacobi, since it uses `Tpetra::Details::residual` and switched to the `Isend` comm option.
The rows/GPU roughly corresponds to the regime EMPIRE is interested in.

I ran 7 different modes:
- using CuSparse (after setting `TPETRA_DETAILS_USE_REFERENCE_RESIDUAL`)
- using KokkosKernels SpMV (after setting `TPETRA_DETAILS_USE_REFERENCE_RESIDUAL`)
- without skipping `unpackAndCombine` (as added in #9133),
- with skipping `unpackAndCombine` (as added in #9133),
- with skipping `unpackAndCombine` and skipping `copyAndPermute`,
- with skipping `unpackAndCombine` and skipping `copyAndPermute` and overlapping of communication & computation,
- with skipping `unpackAndCombine` and skipping `copyAndPermute` and overlapping of communication & computation and persistent MPI requests #4782.

```
Belos: PseudoBlockCGSolMgr total solve time: 2.43972 - 95.7164% [20] {min=2.43859, max=2.44026, std dev=0.000710518} <2, 0, 0, 0, 0, 0, 1, 0, 1, 4>
Belos: PseudoBlockCGSolMgr total solve time: 2.68613 - 96.3204% [20] {min=2.68458, max=2.68874, std dev=0.00139822} <2, 1, 0, 1, 1, 2, 0, 0, 0, 1>
Belos: PseudoBlockCGSolMgr total solve time: 2.5866 - 96.1485% [20] {min=2.58586, max=2.58746, std dev=0.000520589} <1, 1, 0, 1, 2, 0, 1, 1, 0, 1>
Belos: PseudoBlockCGSolMgr total solve time: 2.49995 - 95.6433% [20] {min=2.49809, max=2.50577, std dev=0.00243848} <2, 3, 2, 0, 0, 0, 0, 0, 0, 1>
Belos: PseudoBlockCGSolMgr total solve time: 2.15975 - 94.9339% [20] {min=2.15824, max=2.16495, std dev=0.00229803} <4, 2, 0, 0, 1, 0, 0, 0, 0, 1>
Belos: PseudoBlockCGSolMgr total solve time: 2.17401 - 94.354% [20] {min=2.17236, max=2.17842, std dev=0.00197005} <2, 4, 0, 0, 1, 0, 0, 0, 0, 1>
Belos: PseudoBlockCGSolMgr total solve time: 2.04587 - 94.5417% [20] {min=2.04446, max=2.05102, std dev=0.00222172} <4, 2, 0, 1, 0, 0, 0, 0, 0, 1>
```
Looking at the residual in isolation:
```
MueLu: Laplace3D: Hierarchy: Solve : residual calculation (level=0): 0.0803768 - 8.82234% [360] {min=0.0801641, max=0.0804999, std dev=0.00010464} <1, 0, 0, 1, 0, 0, 2, 2, 1, 1>
MueLu: Laplace3D: Hierarchy: Solve : residual calculation (level=0): 0.109894 - 9.6762% [360] {min=0.10946, max=0.110719, std dev=0.000386159} <1, 2, 1, 2, 1, 0, 0, 0, 0, 1>
MueLu: Laplace3D: Hierarchy: Solve : residual calculation (level=0): 0.103716 - 9.60062% [360] {min=0.103493, max=0.104001, std dev=0.000160544} <1, 0, 2, 1, 1, 1, 0, 1, 0, 1>
MueLu: Laplace3D: Hierarchy: Solve : residual calculation (level=0): 0.100183 - 9.75137% [360] {min=0.0998461, max=0.100391, std dev=0.000189245} <1, 0, 1, 0, 1, 0, 1, 1, 1, 2>
MueLu: Laplace3D: Hierarchy: Solve : residual calculation (level=0): 0.0787843 - 9.1647% [360] {min=0.0785859, max=0.079288, std dev=0.000235638} <3, 2, 0, 1, 1, 0, 0, 0, 0, 1>
MueLu: Laplace3D: Hierarchy: Solve : residual calculation (level=0): 0.0783778 - 9.03264% [360] {min=0.0777182, max=0.0788482, std dev=0.000395684} <1, 0, 0, 2, 1, 0, 0, 1, 1, 2>
MueLu: Laplace3D: Hierarchy: Solve : residual calculation (level=0): 0.0757487 - 9.03905% [360] {min=0.0753943, max=0.0759687, std dev=0.000204847} <1, 1, 0, 0, 0, 0, 1, 2, 2, 1>
```
It looks like it might be worth to enable skipping of `copyAndPermute` by default.
I'm not really sure communication & computation overlap is worth it, but there might be some room for improvement.