### PR TITLE
tpetra:  added test and correction for MV copies to/from Teuchos::SerialDenseMatrix for #9164

### DIFF
--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -4738,12 +4738,9 @@ namespace Tpetra {
     input_view_type src_view =
       Kokkos::subview (src_orig, pair_type (0, numRows), Kokkos::ALL ());
 
-    /// KJ : this does not sound correct
-    //dst.clear_sync_state ();
-    //dst.modify_device ();
     constexpr bool src_isConstantStride = true;
     Teuchos::ArrayView<const size_t> srcWhichVectors (nullptr, 0);
-    localDeepCopy (dst.getLocalViewDevice(Access::ReadWrite),
+    localDeepCopy (dst.getLocalViewHost(Access::ReadWrite),
                    src_view,
                    dst.isConstantStride (),
                    src_isConstantStride,
@@ -4784,22 +4781,12 @@ namespace Tpetra {
     Teuchos::ArrayView<const size_t> dstWhichVectors (nullptr, 0);
 
     // Prefer the host version of src's data.
-    if (src.need_sync_host ()) { // last modified on device
-      localDeepCopy (dst_view,
-                     src.getLocalViewDevice(Access::ReadOnly),
-                     dst_isConstantStride,
-                     src.isConstantStride (),
-                     dstWhichVectors,
-                     getMultiVectorWhichVectors (src));
-    }
-    else {
-      localDeepCopy (dst_view,
-                     src.getLocalViewHost(Access::ReadOnly),
-                     dst_isConstantStride,
-                     src.isConstantStride (),
-                     dstWhichVectors,
-                     getMultiVectorWhichVectors (src));
-    }
+    localDeepCopy (dst_view,
+                   src.getLocalViewHost(Access::ReadOnly),
+                   dst_isConstantStride,
+                   src.isConstantStride (),
+                   dstWhichVectors,
+                   getMultiVectorWhichVectors (src));
   }
 #endif // HAVE_TPETRACORE_TEUCHOSNUMERICS
 

--- a/packages/tpetra/core/test/MultiVector/deep_copy_to_SDM.cpp
+++ b/packages/tpetra/core/test/MultiVector/deep_copy_to_SDM.cpp
@@ -281,20 +281,38 @@ namespace { // (anonymous)
       const LO numColsVals[] = {3, 2, 5, 0, 1};
       for (LO lclNumRows : lclNumRowsVals) {
         for (LO numCols : numColsVals) {
-          for (bool modify_MV_on_host : {false, true}) {
-            Teuchos::SerialDenseMatrix<int, ST> Y (lclNumRows, numCols);
-            Y.putScalar (flagValue);
+          for (bool take_subvector : {false, true}) {
+            for (bool modify_MV_on_host : {false, true}) {
 
-            const GO gblNumRows = static_cast<GO> (comm->getSize ()) *
-              static_cast<GO> (lclNumRows);
-            RCP<const map_type> map =
-              rcp (new map_type (gblNumRows, lclNumRows, indexBase, comm));
-            MV X (map, numCols);
+              const GO gblNumRows = static_cast<GO> (comm->getSize ()) *
+                static_cast<GO> (lclNumRows);
+              RCP<const map_type> map =
+                rcp (new map_type (gblNumRows, lclNumRows, indexBase, comm));
+              MV entireX (map, numCols);
+              MV X;
 
-            multiVectorIota (X, startValue, modify_MV_on_host);
+              if (take_subvector && lclNumRows > 0) {
+                const LO subLclNumRows = lclNumRows-1;
+                const GO subGblNumRows = static_cast<GO> (comm->getSize ()) *
+                  static_cast<GO> (lclNumRows-1);
+                RCP<const map_type> subMap =
+                  rcp (new map_type (subGblNumRows, subLclNumRows,
+                                     indexBase, comm));
+                 X = *(entireX.offsetView(subMap, 0));
+              }
+              else {
+                X = entireX;
+              }
 
-            Tpetra::deep_copy (Y, X);
-            TEST_ASSERT( serialDenseMatrix_multiVector_same (X, Y) );
+              multiVectorIota (X, startValue, modify_MV_on_host);
+
+              Teuchos::SerialDenseMatrix<int, ST> Y (X.getLocalLength(),
+                                                     numCols);
+              Y.putScalar (flagValue);
+
+              Tpetra::deep_copy (Y, X);
+              TEST_ASSERT( serialDenseMatrix_multiVector_same (X, Y) );
+            }
           }
         }
       }


### PR DESCRIPTION

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

Copies between Tpetra MultiVector and Teuchos SerialDenseMatrix used the device MultiVector if the device data was most up-to-date.  But when the MultiVector is a subset of the rows of a MultiVector (i.e., obtained by offsetView), device copies to/from host SerialDenseMatrix failed. 

This PR changes all copies between SDM and MV to use MV's host view.
It also adds tests of this use-case to deep_copy_*_SDM.cpp tests; the added tests fail with the original code but pass with the host-only copies.

Since SerialDenseMatrix is a host-only data structure, it makes sense to do the copies from MV's host view.  MV's getLocalViewHost and access tags correctly manage needed synchronization.

## Related Issues

* Closes  #9164 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 



## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
@iyamazaki 

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

Tested on ascicgpu with UVM=OFF.
New tests added that get subview multivectors with offsetView

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->