### PR TITLE
Tempus: ParameterList Constructor for IntegratorBasic.

### DIFF
--- a/packages/tempus/src/Tempus_Integrator.hpp
+++ b/packages/tempus/src/Tempus_Integrator.hpp
@@ -82,6 +82,8 @@ public:
     virtual void setTempusParameterList(Teuchos::RCP<Teuchos::ParameterList> pl) = 0;
     /// Returns the SolutionHistory for this Integrator
     virtual Teuchos::RCP<const SolutionHistory<Scalar> > getSolutionHistory() const = 0;
+    /// Returns the SolutionHistory for this Integrator
+    virtual Teuchos::RCP<SolutionHistory<Scalar> > getNonConstSolutionHistory() = 0;
     /// Returns the TimeStepControl for this Integrator
     virtual Teuchos::RCP<const TimeStepControl<Scalar> > getTimeStepControl() const = 0;
     virtual Teuchos::RCP<TimeStepControl<Scalar> > getNonConstTimeStepControl() = 0;

--- a/packages/tempus/src/Tempus_IntegratorAdjointSensitivity_decl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorAdjointSensitivity_decl.hpp
@@ -108,6 +108,8 @@ public:
   virtual void setTempusParameterList(Teuchos::RCP<Teuchos::ParameterList> pl) override;
   /// Get the SolutionHistory
   virtual Teuchos::RCP<const SolutionHistory<Scalar> > getSolutionHistory() const override;
+  /// Get the SolutionHistory
+  virtual Teuchos::RCP<SolutionHistory<Scalar> > getNonConstSolutionHistory() override;
    /// Get the TimeStepControl
   virtual Teuchos::RCP<const TimeStepControl<Scalar> > getTimeStepControl() const override;
   virtual Teuchos::RCP<TimeStepControl<Scalar> > getNonConstTimeStepControl() override;

--- a/packages/tempus/src/Tempus_IntegratorAdjointSensitivity_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorAdjointSensitivity_impl.hpp
@@ -281,6 +281,14 @@ getSolutionHistory() const
 }
 
 template<class Scalar>
+Teuchos::RCP<SolutionHistory<Scalar> >
+IntegratorAdjointSensitivity<Scalar>::
+getNonConstSolutionHistory()
+{
+  return solutionHistory_;
+}
+
+template<class Scalar>
 Teuchos::RCP<const TimeStepControl<Scalar> >
 IntegratorAdjointSensitivity<Scalar>::
 getTimeStepControl() const
@@ -376,12 +384,13 @@ describe(
   Teuchos::FancyOStream          &out,
   const Teuchos::EVerbosityLevel verbLevel) const
 {
-
   auto l_out = Teuchos::fancyOStream( out.getOStream() );
+  Teuchos::OSTab ostab(*l_out, 2, this->description());
   l_out->setOutputToRootOnly(0);
+
   *l_out << description() << "::describe" << std::endl;
-  state_integrator_->describe(out, verbLevel);
-  adjoint_integrator_->describe(out, verbLevel);
+  state_integrator_->describe(*l_out, verbLevel);
+  adjoint_integrator_->describe(*l_out, verbLevel);
 }
 
 template<class Scalar>

--- a/packages/tempus/src/Tempus_IntegratorBasic.cpp
+++ b/packages/tempus/src/Tempus_IntegratorBasic.cpp
@@ -18,6 +18,10 @@ namespace Tempus {
 
   // Nonmember ctor
   template Teuchos::RCP<IntegratorBasic<double> > createIntegratorBasic(
+    Teuchos::RCP<Teuchos::ParameterList>        parameterList);
+
+  // Nonmember ctor
+  template Teuchos::RCP<IntegratorBasic<double> > createIntegratorBasic(
     Teuchos::RCP<Teuchos::ParameterList>        parameterList,
     const Teuchos::RCP<Thyra::ModelEvaluator<double> >& model);
 

--- a/packages/tempus/src/Tempus_IntegratorBasicOld_decl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorBasicOld_decl.hpp
@@ -111,6 +111,9 @@ public:
     /// Get the SolutionHistory
     virtual Teuchos::RCP<const SolutionHistory<Scalar> > getSolutionHistory() const override
       {return solutionHistory_;}
+    /// Get the SolutionHistory
+    virtual Teuchos::RCP<SolutionHistory<Scalar> > getNonConstSolutionHistory() override
+      {return solutionHistory_;}
     /// Set the SolutionHistory
     virtual void setSolutionHistory(
       Teuchos::RCP<SolutionHistory<Scalar> > sh = Teuchos::null);

--- a/packages/tempus/src/Tempus_IntegratorBasicOld_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorBasicOld_impl.hpp
@@ -387,8 +387,8 @@ bool IntegratorBasicOld<Scalar>::advanceTime()
     startIntegrator();
     integratorObserver_->observeStartIntegrator(*this);
 
-    while (integratorStatus_ == WORKING and
-        timeStepControl_->timeInRange (solutionHistory_->getCurrentTime()) and
+    while (integratorStatus_ == WORKING &&
+        timeStepControl_->timeInRange (solutionHistory_->getCurrentTime()) &&
         timeStepControl_->indexInRange(solutionHistory_->getCurrentIndex())){
 
       stepperTimer_->reset();
@@ -483,11 +483,11 @@ void IntegratorBasicOld<Scalar>::checkTimeStep()
   }
 
   // Check Stepper failure.
-  if (ws->getSolutionStatus() == Status::FAILED or
+  if (ws->getSolutionStatus() == Status::FAILED ||
        // Constant time step failure
-       ((timeStepControl_->getStepType() == "Constant") and
-        (ws->getTimeStep() != timeStepControl_->getInitTimeStep()) and
-        (ws->getOutput() != true) and
+       ((timeStepControl_->getStepType() == "Constant") &&
+        (ws->getTimeStep() != timeStepControl_->getInitTimeStep()) &&
+        (ws->getOutput() != true) &&
         (ws->getTime() != timeStepControl_->getFinalTime())
        )
      )
@@ -502,7 +502,7 @@ void IntegratorBasicOld<Scalar>::checkTimeStep()
     if (ws->getSolutionStatus() == Status::FAILED) {
       *out << "Solution Status = " << toString(ws->getSolutionStatus())
            << std::endl;
-    } else if ((timeStepControl_->getStepType() == "Constant") and
+    } else if ((timeStepControl_->getStepType() == "Constant") &&
                (ws->getTimeStep() != timeStepControl_->getInitTimeStep())) {
       *out << "dt != Constant dt (="<<timeStepControl_->getInitTimeStep()<<")"
            << std::endl;
@@ -526,7 +526,7 @@ void IntegratorBasicOld<Scalar>::endIntegrator()
 {
   std::string exitStatus;
   if (solutionHistory_->getCurrentState()->getSolutionStatus() ==
-      Status::FAILED or integratorStatus_ == Status::FAILED) {
+      Status::FAILED || integratorStatus_ == Status::FAILED) {
     exitStatus = "Time integration FAILURE!";
   } else {
     integratorStatus_ = Status::PASSED;

--- a/packages/tempus/src/Tempus_IntegratorBasic_decl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorBasic_decl.hpp
@@ -100,6 +100,9 @@ public:
     /// Get the SolutionHistory
     virtual Teuchos::RCP<const SolutionHistory<Scalar> > getSolutionHistory() const override
       {return solutionHistory_;}
+    /// Get the SolutionHistory
+    virtual Teuchos::RCP<SolutionHistory<Scalar> > getNonConstSolutionHistory() override
+      {return solutionHistory_;}
     /// Set the SolutionHistory
     virtual void setSolutionHistory(
       Teuchos::RCP<SolutionHistory<Scalar> > sh = Teuchos::null);
@@ -206,6 +209,12 @@ protected:
   Teuchos::RCP<Teuchos::Time> stepperTimer_;
 
 };
+
+
+/// Nonmember constructor
+template<class Scalar>
+Teuchos::RCP<IntegratorBasic<Scalar> > createIntegratorBasic(
+  Teuchos::RCP<Teuchos::ParameterList>                pList);
 
 
 /// Nonmember constructor

--- a/packages/tempus/src/Tempus_IntegratorBasic_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorBasic_impl.hpp
@@ -250,25 +250,33 @@ std::string IntegratorBasic<Scalar>::description() const
 
 template<class Scalar>
 void IntegratorBasic<Scalar>::describe(
-  Teuchos::FancyOStream          &in_out,
+  Teuchos::FancyOStream          &out,
   const Teuchos::EVerbosityLevel verbLevel) const
 {
-  auto out = Teuchos::fancyOStream( in_out.getOStream() );
-  out->setOutputToRootOnly(0);
-  *out << description() << "::describe" << std::endl;
-  *out << "solutionHistory= " << solutionHistory_->description()<<std::endl;
-  *out << "timeStepControl= " << timeStepControl_->description()<<std::endl;
-  *out << "stepper        = " << stepper_        ->description()<<std::endl;
+  auto l_out = Teuchos::fancyOStream( out.getOStream() );
+  Teuchos::OSTab ostab(*l_out, 2, this->description());
+  l_out->setOutputToRootOnly(0);
 
-  if (Teuchos::as<int>(verbLevel) >=
-              Teuchos::as<int>(Teuchos::VERB_HIGH)) {
-    *out << "solutionHistory= " << std::endl;
-    solutionHistory_->describe(in_out,verbLevel);
-    *out << "timeStepControl= " << std::endl;
-    timeStepControl_->describe(in_out,verbLevel);
-    *out << "stepper        = " << std::endl;
-    stepper_        ->describe(in_out,verbLevel);
+  *l_out << "\n--- " << this->description() << " ---" << std::endl;
+
+  if ( solutionHistory_ != Teuchos::null ) {
+    solutionHistory_->describe(*l_out,verbLevel);
+  } else {
+    *l_out << "solutionHistory = " << solutionHistory_ << std::endl;
   }
+
+  if ( timeStepControl_ != Teuchos::null ) {
+    timeStepControl_->describe(out,verbLevel);
+  } else {
+    *l_out << "timeStepControl = " << timeStepControl_ << std::endl;
+  }
+
+  if ( stepper_ != Teuchos::null ) {
+    stepper_->describe(out,verbLevel);
+  } else {
+    *l_out << "stepper         = " << stepper_ << std::endl;
+  }
+  *l_out << std::string(this->description().length()+8, '-') <<std::endl;
 }
 
 
@@ -393,7 +401,7 @@ void IntegratorBasic<Scalar>::checkTimeStep()
   if (ws->getNFailures() >= timeStepControl_->getMaxFailures()) {
     RCP<Teuchos::FancyOStream> out = this->getOStream();
     out->setOutputToRootOnly(0);
-    Teuchos::OSTab ostab(out,2,"checkTimeStep");
+    Teuchos::OSTab ostab(out, 2, "checkTimeStep");
     *out << "Failure - Stepper has failed more than the maximum allowed.\n"
          << "  (nFailures = "<<ws->getNFailures()<< ") >= (nFailuresMax = "
          << timeStepControl_->getMaxFailures()<<")" << std::endl;
@@ -404,7 +412,7 @@ void IntegratorBasic<Scalar>::checkTimeStep()
       >= timeStepControl_->getMaxConsecFailures()){
     RCP<Teuchos::FancyOStream> out = this->getOStream();
     out->setOutputToRootOnly(0);
-    Teuchos::OSTab ostab(out,1,"checkTimeStep");
+    Teuchos::OSTab ostab(out, 1, "checkTimeStep");
     *out << "Failure - Stepper has failed more than the maximum "
          << "consecutive allowed.\n"
          << "  (nConsecutiveFailures = "<<ws->getNConsecutiveFailures()
@@ -427,7 +435,7 @@ void IntegratorBasic<Scalar>::checkTimeStep()
   {
     RCP<Teuchos::FancyOStream> out = this->getOStream();
     out->setOutputToRootOnly(0);
-    Teuchos::OSTab ostab(out,0,"checkTimeStep");
+    Teuchos::OSTab ostab(out, 0, "checkTimeStep");
     *out <<std::scientific
       <<std::setw( 6)<<std::setprecision(3)<<ws->getIndex()
       <<std::setw(11)<<std::setprecision(3)<<ws->getTime()
@@ -550,8 +558,7 @@ IntegratorBasic<Scalar>::getValidParameters() const
 // ------------------------------------------------------------------------
 template<class Scalar>
 Teuchos::RCP<IntegratorBasic<Scalar> > createIntegratorBasic(
-  Teuchos::RCP<Teuchos::ParameterList>                     tempusPL,
-  const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >&      model)
+  Teuchos::RCP<Teuchos::ParameterList>                     tempusPL)
 {
   auto integratorName = tempusPL->get<std::string>("Integrator Name");
   auto integratorPL = Teuchos::sublist(tempusPL, integratorName, true);
@@ -573,12 +580,11 @@ Teuchos::RCP<IntegratorBasic<Scalar> > createIntegratorBasic(
     auto stepperPL = Teuchos::sublist(tempusPL, stepperName, true);
     stepperPL->setName(stepperName);
     auto sf = Teuchos::rcp(new StepperFactory<Scalar>());
-    integrator->setStepper(sf->createStepper(stepperPL, model));
+    integrator->setStepper(sf->createStepper(stepperPL));
   } else {
     // Construct default Stepper
-    Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > constModel = model;
-    integrator->setStepper(
-      createStepperForwardEuler(constModel, Teuchos::null));
+    auto stepper = Teuchos::rcp(new StepperForwardEuler<Scalar>());
+    integrator->setStepper(stepper);
   }
 
   // Set TimeStepControl
@@ -591,23 +597,16 @@ Teuchos::RCP<IntegratorBasic<Scalar> > createIntegratorBasic(
     integrator->setTimeStepControl(rcp(new TimeStepControl<Scalar>()));
   }
 
-  // Construct default IC state from the application model and TimeStepControl
-  auto newState = createSolutionStateME(integrator->getStepper()->getModel(),
-    integrator->getStepper()->getDefaultStepperState());
-  newState->setTime    (integrator->getTimeStepControl()->getInitTime());
-  newState->setIndex   (integrator->getTimeStepControl()->getInitIndex());
-  newState->setTimeStep(integrator->getTimeStepControl()->getInitTimeStep());
-  newState->setTolRel  (integrator->getTimeStepControl()->getMaxRelError());
-  newState->setTolAbs  (integrator->getTimeStepControl()->getMaxAbsError());
-  newState->setOrder   (integrator->getStepper()->getOrder());
-  newState->setSolutionStatus(Status::PASSED);  // ICs are considered passing.
-
   // Set SolutionHistory
-  auto shPL = Teuchos::sublist(integratorPL, "Solution History", true);
-  auto sh   = createSolutionHistoryPL<Scalar>(shPL);
-  sh->addState(newState);
-  integrator->getStepper()->setInitialConditions(sh);
-  integrator->setSolutionHistory(sh);
+  if (integratorPL->isSublist("Solution History")) {
+    // Construct from Integrator ParameterList
+    auto shPL = Teuchos::sublist(integratorPL, "Solution History", true);
+    auto sh   = createSolutionHistoryPL<Scalar>(shPL);
+    integrator->setSolutionHistory(sh);
+  } else {
+    // Construct default SolutionHistory
+    integrator->setSolutionHistory(createSolutionHistory<Scalar>());
+  }
 
   // Set Observer to default.
   integrator->setObserver(Teuchos::null);
@@ -634,6 +633,39 @@ Teuchos::RCP<IntegratorBasic<Scalar> > createIntegratorBasic(
   auto vStepperName = vIntegratorPL->template get<std::string>("Stepper Name");
   auto vStepperPL   = Teuchos::sublist(validPL, vStepperName, true);
   stepperPL->validateParametersAndSetDefaults(*vStepperPL);
+
+  return integrator;  // integrator is not initialized (missing model and IC).
+}
+
+
+// Nonmember constructor
+// ------------------------------------------------------------------------
+template<class Scalar>
+Teuchos::RCP<IntegratorBasic<Scalar> > createIntegratorBasic(
+  Teuchos::RCP<Teuchos::ParameterList>                     tempusPL,
+  const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >&      model)
+{
+  auto integrator = createIntegratorBasic<Scalar>(tempusPL);
+  if ( model == Teuchos::null ) return integrator;
+
+  Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > constModel = model;
+  integrator->setModel(constModel);
+
+  // Construct default IC state from the application model and TimeStepControl
+  auto newState = createSolutionStateME(integrator->getStepper()->getModel(),
+    integrator->getStepper()->getDefaultStepperState());
+  newState->setTime    (integrator->getTimeStepControl()->getInitTime());
+  newState->setIndex   (integrator->getTimeStepControl()->getInitIndex());
+  newState->setTimeStep(integrator->getTimeStepControl()->getInitTimeStep());
+  newState->setTolRel  (integrator->getTimeStepControl()->getMaxRelError());
+  newState->setTolAbs  (integrator->getTimeStepControl()->getMaxAbsError());
+  newState->setOrder   (integrator->getStepper()->getOrder());
+  newState->setSolutionStatus(Status::PASSED);  // ICs are considered passing.
+
+  // Set SolutionHistory IC
+  auto sh = integrator->getNonConstSolutionHistory();
+  sh->addState(newState);
+  integrator->getStepper()->setInitialConditions(sh);
 
   integrator->initialize();
 

--- a/packages/tempus/src/Tempus_IntegratorForwardSensitivity_decl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorForwardSensitivity_decl.hpp
@@ -164,6 +164,9 @@ public:
   /// Get the SolutionHistory
   virtual Teuchos::RCP<const SolutionHistory<Scalar> > getSolutionHistory() const override
     { return integrator_->getSolutionHistory(); }
+  /// Get the SolutionHistory
+  virtual Teuchos::RCP<SolutionHistory<Scalar> > getNonConstSolutionHistory() override
+    { return integrator_->getNonConstSolutionHistory(); }
   /// Set the SolutionHistory
   virtual void setSolutionHistory(
     Teuchos::RCP<SolutionHistory<Scalar> > sh = Teuchos::null)

--- a/packages/tempus/src/Tempus_IntegratorForwardSensitivity_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorForwardSensitivity_impl.hpp
@@ -242,13 +242,15 @@ template<class Scalar>
 void
 IntegratorForwardSensitivity<Scalar>::
 describe(
-  Teuchos::FancyOStream          &in_out,
+  Teuchos::FancyOStream          &out,
   const Teuchos::EVerbosityLevel verbLevel) const
 {
-  auto out = Teuchos::fancyOStream( in_out.getOStream() );
-  out->setOutputToRootOnly(0);
-  *out << description() << "::describe" << std::endl;
-  integrator_->describe(in_out, verbLevel);
+  auto l_out = Teuchos::fancyOStream( out.getOStream() );
+  Teuchos::OSTab ostab(*l_out, 2, this->description());
+  l_out->setOutputToRootOnly(0);
+
+  *l_out << description() << "::describe" << std::endl;
+  integrator_->describe(*l_out, verbLevel);
 }
 
 template<class Scalar>

--- a/packages/tempus/src/Tempus_IntegratorObserverBasic_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorObserverBasic_impl.hpp
@@ -76,7 +76,7 @@ observeEndTimeStep(const Integrator<Scalar>& integrator){
 
      const Teuchos::RCP<Teuchos::FancyOStream> out = integrator.getOStream();
      out->setOutputToRootOnly(0);
-     Teuchos::OSTab ostab(out,0,"ScreenOutput");
+     Teuchos::OSTab ostab(out, 0, "ScreenOutput");
      *out<<std::scientific
         <<std::setw( 6)<<std::setprecision(3)<<cs->getIndex()
         <<std::setw(11)<<std::setprecision(3)<<cs->getTime()

--- a/packages/tempus/src/Tempus_IntegratorObserverSubcycling_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorObserverSubcycling_impl.hpp
@@ -25,7 +25,7 @@ observeStartIntegrator(const Integrator<Scalar>& integrator){
 
   const Teuchos::RCP<Teuchos::FancyOStream> out = integrator.getOStream();
   out->setOutputToRootOnly(0);
-  Teuchos::OSTab ostab(out,0,"ScreenOutput");
+  Teuchos::OSTab ostab(out, 0, "ScreenOutput");
   *out << "\n    Begin Subcycling -------------------------------------------------------\n";
     // << "  Step       Time         dt  Abs Error  Rel Error  Order  nFail  dCompTime"
     // << std::endl;
@@ -68,7 +68,7 @@ observeEndTimeStep(const Integrator<Scalar>& integrator){
 
      const Teuchos::RCP<Teuchos::FancyOStream> out = integrator.getOStream();
      out->setOutputToRootOnly(0);
-     Teuchos::OSTab ostab(out,0,"ScreenOutput");
+     Teuchos::OSTab ostab(out, 0, "ScreenOutput");
      *out<<std::scientific
         <<std::setw( 6)<<std::setprecision(3)<<cs->getIndex()
         <<std::setw(11)<<std::setprecision(3)<<cs->getTime()
@@ -89,7 +89,7 @@ observeEndIntegrator(const Integrator<Scalar>& integrator){
 
   const Teuchos::RCP<Teuchos::FancyOStream> out = integrator.getOStream();
   out->setOutputToRootOnly(0);
-  Teuchos::OSTab ostab(out,0,"ScreenOutput");
+  Teuchos::OSTab ostab(out, 0, "ScreenOutput");
   *out << "    End Subcycling ---------------------------------------------------------\n\n";
 }
 

--- a/packages/tempus/src/Tempus_IntegratorPseudoTransientAdjointSensitivity_decl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorPseudoTransientAdjointSensitivity_decl.hpp
@@ -109,6 +109,8 @@ public:
   virtual void setTempusParameterList(Teuchos::RCP<Teuchos::ParameterList> pl) override;
   /// Get the SolutionHistory
   virtual Teuchos::RCP<const SolutionHistory<Scalar> > getSolutionHistory() const override;
+  /// Get the SolutionHistory
+  virtual Teuchos::RCP<SolutionHistory<Scalar> > getNonConstSolutionHistory() override;
    /// Get the TimeStepControl
   virtual Teuchos::RCP<const TimeStepControl<Scalar> > getTimeStepControl() const override;
   virtual Teuchos::RCP<TimeStepControl<Scalar> > getNonConstTimeStepControl() override;

--- a/packages/tempus/src/Tempus_IntegratorPseudoTransientAdjointSensitivity_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorPseudoTransientAdjointSensitivity_impl.hpp
@@ -164,6 +164,14 @@ getSolutionHistory() const
 }
 
 template<class Scalar>
+Teuchos::RCP<SolutionHistory<Scalar> >
+IntegratorPseudoTransientAdjointSensitivity<Scalar>::
+getNonConstSolutionHistory()
+{
+  return solutionHistory_;
+}
+
+template<class Scalar>
 Teuchos::RCP<const TimeStepControl<Scalar> >
 IntegratorPseudoTransientAdjointSensitivity<Scalar>::
 getTimeStepControl() const
@@ -271,13 +279,16 @@ template<class Scalar>
 void
 IntegratorPseudoTransientAdjointSensitivity<Scalar>::
 describe(
-  Teuchos::FancyOStream          &in_out,
+  Teuchos::FancyOStream          &out,
   const Teuchos::EVerbosityLevel verbLevel) const
 {
-  auto out = Teuchos::fancyOStream( in_out.getOStream() );
-  *out << description() << "::describe" << std::endl;
-  state_integrator_->describe(*out, verbLevel);
-  sens_integrator_->describe(*out, verbLevel);
+  auto l_out = Teuchos::fancyOStream( out.getOStream() );
+  Teuchos::OSTab ostab(*l_out, 2, this->description());
+  l_out->setOutputToRootOnly(0);
+
+  *l_out << description() << "::describe" << std::endl;
+  state_integrator_->describe(*l_out, verbLevel);
+  sens_integrator_->describe(*l_out, verbLevel);
 }
 
 template<class Scalar>

--- a/packages/tempus/src/Tempus_IntegratorPseudoTransientForwardSensitivity_decl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorPseudoTransientForwardSensitivity_decl.hpp
@@ -123,6 +123,8 @@ public:
   virtual void setTempusParameterList(Teuchos::RCP<Teuchos::ParameterList> pl) override;
   /// Get the SolutionHistory
   virtual Teuchos::RCP<const SolutionHistory<Scalar> > getSolutionHistory() const override;
+  /// Get the SolutionHistory
+  virtual Teuchos::RCP<SolutionHistory<Scalar> > getNonConstSolutionHistory() override;
    /// Get the TimeStepControl
   virtual Teuchos::RCP<const TimeStepControl<Scalar> > getTimeStepControl() const override;
   virtual Teuchos::RCP<TimeStepControl<Scalar> > getNonConstTimeStepControl() override;

--- a/packages/tempus/src/Tempus_IntegratorPseudoTransientForwardSensitivity_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorPseudoTransientForwardSensitivity_impl.hpp
@@ -177,6 +177,14 @@ getSolutionHistory() const
 }
 
 template<class Scalar>
+Teuchos::RCP<SolutionHistory<Scalar> >
+IntegratorPseudoTransientForwardSensitivity<Scalar>::
+getNonConstSolutionHistory()
+{
+  return solutionHistory_;
+}
+
+template<class Scalar>
 Teuchos::RCP<const TimeStepControl<Scalar> >
 IntegratorPseudoTransientForwardSensitivity<Scalar>::
 getTimeStepControl() const
@@ -343,14 +351,16 @@ template<class Scalar>
 void
 IntegratorPseudoTransientForwardSensitivity<Scalar>::
 describe(
-  Teuchos::FancyOStream          &in_out,
+  Teuchos::FancyOStream          &out,
   const Teuchos::EVerbosityLevel verbLevel) const
 {
-  auto out = Teuchos::fancyOStream( in_out.getOStream() );
-  out->setOutputToRootOnly(0);
-  *out << description() << "::describe" << std::endl;
-  state_integrator_->describe(in_out, verbLevel);
-  sens_integrator_->describe(in_out, verbLevel);
+  auto l_out = Teuchos::fancyOStream( out.getOStream() );
+  Teuchos::OSTab ostab(*l_out, 2, this->description());
+  l_out->setOutputToRootOnly(0);
+
+  *l_out << description() << "::describe" << std::endl;
+  state_integrator_->describe(*l_out, verbLevel);
+  sens_integrator_->describe(*l_out, verbLevel);
 }
 
 template<class Scalar>

--- a/packages/tempus/src/Tempus_InterpolatorLagrange_decl.hpp
+++ b/packages/tempus/src/Tempus_InterpolatorLagrange_decl.hpp
@@ -48,7 +48,10 @@ public:
   std::string description() const { return "Tempus::InterpolatorLagrange"; }
   void describe(Teuchos::FancyOStream &out,
                 const Teuchos::EVerbosityLevel /* verbLevel */) const
-  { out << description() << "::describe" << std::endl; }
+  {
+    out.setOutputToRootOnly(0);
+    out << description() << "::describe" << std::endl;
+  }
   //@}
 
   /// \name Overridden from Teuchos::ParameterListAcceptor

--- a/packages/tempus/src/Tempus_PhysicsState_impl.hpp
+++ b/packages/tempus/src/Tempus_PhysicsState_impl.hpp
@@ -67,7 +67,7 @@ void PhysicsState<Scalar>::describe(
   Teuchos::OSTab ostab(*l_out, 2, this->description());
   l_out->setOutputToRootOnly(0);
 
-  *l_out << "  --- " << this->description() << " ---" << std::endl;
+  *l_out << "\n--- " << this->description() << " ---" << std::endl;
 }
 
 

--- a/packages/tempus/src/Tempus_PhysicsState_impl.hpp
+++ b/packages/tempus/src/Tempus_PhysicsState_impl.hpp
@@ -55,18 +55,19 @@ void PhysicsState<Scalar>::setName(std::string pN)
 template<class Scalar>
 std::string PhysicsState<Scalar>::description() const
 {
-  return physicsName_;
+  return "Tempus::PhysicsState - '" + physicsName_ + "'";
 }
 
 template<class Scalar>
 void PhysicsState<Scalar>::describe(
-  Teuchos::FancyOStream        & in_out,
+  Teuchos::FancyOStream        & out,
   const Teuchos::EVerbosityLevel /* verbLevel */) const
 {
-  auto out = Teuchos::fancyOStream( in_out.getOStream() );
-  out->setOutputToRootOnly(0);
-  *out << description() << "::describe" << std::endl
-      << "  physicsName   = " << physicsName_ << std::endl;
+  auto l_out = Teuchos::fancyOStream( out.getOStream() );
+  Teuchos::OSTab ostab(*l_out, 2, this->description());
+  l_out->setOutputToRootOnly(0);
+
+  *l_out << "  --- " << this->description() << " ---" << std::endl;
 }
 
 

--- a/packages/tempus/src/Tempus_RKButcherTableau.hpp
+++ b/packages/tempus/src/Tempus_RKButcherTableau.hpp
@@ -158,6 +158,8 @@ class RKButcherTableau :
       virtual void describe( Teuchos::FancyOStream &out,
                              const Teuchos::EVerbosityLevel verbLevel) const
       {
+        out.setOutputToRootOnly(0);
+
         if (verbLevel != Teuchos::VERB_NONE) {
           out << this->description() << std::endl;
           out << "number of Stages = " << this->numStages() << std::endl;

--- a/packages/tempus/src/Tempus_SolutionHistory.cpp
+++ b/packages/tempus/src/Tempus_SolutionHistory.cpp
@@ -16,7 +16,7 @@ namespace Tempus {
 
   TEMPUS_INSTANTIATE_TEMPLATE_CLASS(SolutionHistory)
 
-  // Nonmember constructor from a ParameterList
+  // Nonmember constructor
   template Teuchos::RCP<SolutionHistory<double> >
   createSolutionHistory();
 

--- a/packages/tempus/src/Tempus_SolutionHistory.cpp
+++ b/packages/tempus/src/Tempus_SolutionHistory.cpp
@@ -18,8 +18,11 @@ namespace Tempus {
 
   // Nonmember constructor from a ParameterList
   template Teuchos::RCP<SolutionHistory<double> >
-  createSolutionHistoryPL(
-    Teuchos::RCP<Teuchos::ParameterList> pList);
+  createSolutionHistory();
+
+  // Nonmember constructor from a ParameterList
+  template Teuchos::RCP<SolutionHistory<double> >
+  createSolutionHistoryPL(Teuchos::RCP<Teuchos::ParameterList> pList);
 
   // Nonmember contructor from a SolutionState.
   template Teuchos::RCP<SolutionHistory<double> >

--- a/packages/tempus/src/Tempus_SolutionHistory_decl.hpp
+++ b/packages/tempus/src/Tempus_SolutionHistory_decl.hpp
@@ -350,6 +350,10 @@ protected:
 /// Nonmember constructor from a ParameterList
 template<class Scalar>
 Teuchos::RCP<SolutionHistory<Scalar> >
+createSolutionHistory();
+
+template<class Scalar>
+Teuchos::RCP<SolutionHistory<Scalar> >
 createSolutionHistoryPL(Teuchos::RCP<Teuchos::ParameterList> pList);
 
 /// Nonmember contructor from a SolutionState.

--- a/packages/tempus/src/Tempus_SolutionHistory_decl.hpp
+++ b/packages/tempus/src/Tempus_SolutionHistory_decl.hpp
@@ -347,11 +347,12 @@ protected:
 };
 
 
-/// Nonmember constructor from a ParameterList
+/// Nonmember constructor
 template<class Scalar>
 Teuchos::RCP<SolutionHistory<Scalar> >
 createSolutionHistory();
 
+/// Nonmember constructor from a ParameterList
 template<class Scalar>
 Teuchos::RCP<SolutionHistory<Scalar> >
 createSolutionHistoryPL(Teuchos::RCP<Teuchos::ParameterList> pList);

--- a/packages/tempus/src/Tempus_SolutionStateMetaData_impl.hpp
+++ b/packages/tempus/src/Tempus_SolutionStateMetaData_impl.hpp
@@ -185,7 +185,7 @@ void SolutionStateMetaData<Scalar>::describe(
   Teuchos::OSTab ostab(*l_out, 2, this->description());
   l_out->setOutputToRootOnly(0);
 
-  *l_out << "--- " << this->description() << " ---" <<std::endl;
+  *l_out << "\n--- " << this->description() << " ---" <<std::endl;
 
   if (verbLevel >= Teuchos::VERB_MEDIUM) {
     *l_out << "  time           = " << time_ << std::endl

--- a/packages/tempus/src/Tempus_SolutionStateMetaData_impl.hpp
+++ b/packages/tempus/src/Tempus_SolutionStateMetaData_impl.hpp
@@ -181,32 +181,36 @@ void SolutionStateMetaData<Scalar>::describe(
    Teuchos::FancyOStream               &out,
    const Teuchos::EVerbosityLevel      verbLevel) const
 {
-  if (verbLevel == Teuchos::VERB_EXTREME) {
-    auto l_out = Teuchos::fancyOStream( out.getOStream() );
-    l_out->setOutputToRootOnly(0);
-    *l_out << description() << "::describe:" << std::endl
-           << "time           = " << time_ << std::endl
-           << "iStep          = " << iStep_ << std::endl
-           << "dt             = " << dt_ << std::endl
-           << "errorAbs       = " << errorAbs_ << std::endl
-           << "errorRel       = " << errorRel_ << std::endl
-           << "order          = " << order_ << std::endl
-           << "nFailures      = " << nFailures_ << std::endl
-           << "nRunningFailures = " << nRunningFailures_<< std::endl
-           << "nConsecutiveFailures = " << nConsecutiveFailures_ << std::endl
-           << "tolRel         = " << tolRel_ << std::endl
-           << "tolAbs         = " << tolAbs_ << std::endl
-           << "xNormL2        = " << xNormL2_ << std::endl
-           << "dxNormL2Rel    = " << dxNormL2Rel_ << std::endl
-           << "dxNormL2Abs    = " << dxNormL2Abs_ << std::endl
-           << "computeNorms   = " << computeNorms_ << std::endl
-           << "solutionStatus = " << toString(solutionStatus_) << std::endl
-           << "output         = " << output_ << std::endl
-           << "outputScreen   = " << outputScreen_ << std::endl
-           << "isSynced       = " << isSynced_ << std::endl
-           << "isInterpolated = " << isInterpolated_ << std::endl
-           << "accuracy       = " << accuracy_ << std::endl;
+  auto l_out = Teuchos::fancyOStream( out.getOStream() );
+  Teuchos::OSTab ostab(*l_out, 2, this->description());
+  l_out->setOutputToRootOnly(0);
+
+  *l_out << "--- " << this->description() << " ---" <<std::endl;
+
+  if (verbLevel >= Teuchos::VERB_MEDIUM) {
+    *l_out << "  time           = " << time_ << std::endl
+           << "  iStep          = " << iStep_ << std::endl
+           << "  dt             = " << dt_ << std::endl
+           << "  errorAbs       = " << errorAbs_ << std::endl
+           << "  errorRel       = " << errorRel_ << std::endl
+           << "  order          = " << order_ << std::endl
+           << "  nFailures      = " << nFailures_ << std::endl
+           << "  nRunningFailures = " << nRunningFailures_<< std::endl
+           << "  nConsecutiveFailures = " << nConsecutiveFailures_ << std::endl
+           << "  tolRel         = " << tolRel_ << std::endl
+           << "  tolAbs         = " << tolAbs_ << std::endl
+           << "  xNormL2        = " << xNormL2_ << std::endl
+           << "  dxNormL2Rel    = " << dxNormL2Rel_ << std::endl
+           << "  dxNormL2Abs    = " << dxNormL2Abs_ << std::endl
+           << "  computeNorms   = " << computeNorms_ << std::endl
+           << "  solutionStatus = " << toString(solutionStatus_) << std::endl
+           << "  output         = " << output_ << std::endl
+           << "  outputScreen   = " << outputScreen_ << std::endl
+           << "  isSynced       = " << isSynced_ << std::endl
+           << "  isInterpolated = " << isInterpolated_ << std::endl
+           << "  accuracy       = " << accuracy_ << std::endl;
   }
+  *l_out << std::string(this->description().length()+8, '-') <<std::endl;
 }
 
 } // namespace Tempus

--- a/packages/tempus/src/Tempus_SolutionState_impl.hpp
+++ b/packages/tempus/src/Tempus_SolutionState_impl.hpp
@@ -399,8 +399,13 @@ bool SolutionState<Scalar>::operator== (const Scalar& t) const
 template<class Scalar>
 std::string SolutionState<Scalar>::description() const
 {
-  std::string name = "Tempus::SolutionState";
-  return (name);
+  std::ostringstream out;
+  out << "SolutionState"
+      << " (index =" <<std::setw(6)<< this->getIndex()
+      << "; time =" <<std::setw(10)<<std::setprecision(3)<<this->getTime()
+      << "; dt ="   <<std::setw(10)<<std::setprecision(3)<<this->getTimeStep()
+      << ")";
+  return out.str();
 }
 
 template<class Scalar>
@@ -408,35 +413,33 @@ void SolutionState<Scalar>::describe(
    Teuchos::FancyOStream               &out,
    const Teuchos::EVerbosityLevel      verbLevel) const
 {
-  if (verbLevel == Teuchos::VERB_MEDIUM) {
-    out << "(index =" <<std::setw(6)<< this->getIndex()
-        << "; time =" <<std::setw(10)<<std::setprecision(3)<<this->getTime()
-        << "; dt   =" <<std::setw(10)<<std::setprecision(3)<<this->getTimeStep()
-        << ")" << std::endl;
-  }
+  auto l_out = Teuchos::fancyOStream( out.getOStream() );
+  Teuchos::OSTab ostab(*l_out, 2, this->description());
+  l_out->setOutputToRootOnly(0);
 
-  if (verbLevel == Teuchos::VERB_EXTREME) {
-    out << description() << "::describe:" << std::endl
-        << "metaData = " << std::endl;
-        metaData_->describe(out,verbLevel);
-    out << "x = " << std::endl;
-    x_->describe(out,verbLevel);
+  *l_out << "\n--- " << this->description() << " ---" << std::endl;
+
+  if (Teuchos::as<int>(verbLevel) >= Teuchos::as<int>(Teuchos::VERB_EXTREME)) {
+
+    metaData_->describe(*l_out,verbLevel);
+    *l_out << "  x       = " << std::endl;
+    x_->describe(*l_out,verbLevel);
+
     if (xdot_ != Teuchos::null) {
-      out << "xdot_ = " << std::endl;
-      xdot_->describe(out,verbLevel);
+      *l_out << "  xdot_   = " << std::endl;
+      xdot_->describe(*l_out,verbLevel);
     }
     if (xdotdot_ != Teuchos::null) {
-      out << "xdotdot = " << std::endl;
-      xdotdot_->describe(out,verbLevel);
+      *l_out << "  xdotdot = " << std::endl;
+      xdotdot_->describe(*l_out,verbLevel);
     }
-    if (stepperState_ != Teuchos::null) {
-      out << "stepperState = " << std::endl;
-      stepperState_->describe(out,verbLevel);
-    }
-    if (physicsState_ != Teuchos::null) {
-      out << "physicsState = " << std::endl;
-      physicsState_->describe(out,verbLevel);
-    }
+
+    if (stepperState_ != Teuchos::null)
+      stepperState_->describe(*l_out,verbLevel);
+    if (physicsState_ != Teuchos::null)
+      physicsState_->describe(*l_out,verbLevel);
+
+    *l_out << std::string(this->description().length()+8, '-') <<std::endl;
   }
 }
 

--- a/packages/tempus/src/Tempus_StepperBDF2_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperBDF2_decl.hpp
@@ -63,7 +63,7 @@ namespace Tempus {
  *  The startup stepper allows BDF2 to use user-specified Stepper for the
  *  first timestep in order to populate the SolutionHistory with past states.
  *  A one-step startup stepper is perfect for this situation, e.g., Backward
- *  Euler or RK4.  The default startup stepper is 'IRK 1 Stage Theta Method',
+ *  Euler or RK4.  The default startup stepper is 'DIRK 1 Stage Theta Method',
  *  which is second order accurate and allows an overall second-order solution.
  *
  *  The First-Same-As-Last (FSAL) principle is not needed for BDF2.

--- a/packages/tempus/src/Tempus_StepperBDF2_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperBDF2_impl.hpp
@@ -66,6 +66,7 @@ void StepperBDF2<Scalar>::setModel(
   const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel)
 {
   StepperImplicit<Scalar>::setModel(appModel);
+  // If the startUpStepper's model is not set, set it to the stepper model.
   if (startUpStepper_->getModel() == Teuchos::null) {
     startUpStepper_->setModel(appModel);
     startUpStepper_->initialize();
@@ -275,6 +276,7 @@ void StepperBDF2<Scalar>::describe(
   const Teuchos::EVerbosityLevel      verbLevel ) const
 {
   auto l_out = Teuchos::fancyOStream( out.getOStream() );
+  Teuchos::OSTab ostab(*l_out, 2, this->description());
   l_out->setOutputToRootOnly(0);
   *l_out << std::endl;
   Stepper<Scalar>::describe(out, verbLevel);
@@ -340,13 +342,13 @@ createStepperBDF2(
   auto stepper = Teuchos::rcp(new StepperBDF2<Scalar>());
   stepper->setStepperImplicitValues(pl);
 
+  std::string startUpStepperName = "DIRK 1 Stage Theta Method";
+  if (pl != Teuchos::null) startUpStepperName =
+    pl->get<std::string>("Start Up Stepper Type", startUpStepperName);
+  stepper->setStartUpStepper(startUpStepperName);
+
   if (model != Teuchos::null) {
     stepper->setModel(model);
-
-    std::string startUpStepperName = "DIRK 1 Stage Theta Method";
-    if (pl != Teuchos::null) startUpStepperName =
-      pl->get<std::string>("Start Up Stepper Type", startUpStepperName);
-    stepper->setStartUpStepper(startUpStepperName);
     stepper->initialize();
   }
 

--- a/packages/tempus/src/Tempus_StepperBackwardEuler_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperBackwardEuler_decl.hpp
@@ -144,6 +144,7 @@ public:
   virtual void computePredictor(
     const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory);
 
+  /// Return a valid ParameterList with current settings.
   Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const override;
 
   /// \name Overridden from Teuchos::Describable

--- a/packages/tempus/src/Tempus_StepperBackwardEuler_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperBackwardEuler_decl.hpp
@@ -108,76 +108,80 @@ public:
     void setPredictor(std::string predictorType = "None");
     void setPredictor(Teuchos::RCP<Stepper<Scalar> > predictorStepper);
 
+    /// Set the model
+    virtual void setModel(
+      const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel) override;
+
     /// Set the initial conditions and make them consistent.
     virtual void setInitialConditions (
-      const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory);
+      const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory) override;
 
     /// Take the specified timestep, dt, and return true if successful.
     virtual void takeStep(
-      const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory);
+      const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory) override;
 
     /// Get a default (initial) StepperState
-    virtual Teuchos::RCP<Tempus::StepperState<Scalar> > getDefaultStepperState();
-    virtual Scalar getOrder() const {return 1.0;}
-    virtual Scalar getOrderMin() const {return 1.0;}
-    virtual Scalar getOrderMax() const {return 1.0;}
+    virtual Teuchos::RCP<Tempus::StepperState<Scalar> > getDefaultStepperState() override;
+    virtual Scalar getOrder() const override {return 1.0;}
+    virtual Scalar getOrderMin() const override {return 1.0;}
+    virtual Scalar getOrderMax() const override {return 1.0;}
 
-    virtual bool isExplicit()         const {return false;}
-    virtual bool isImplicit()         const {return true;}
-    virtual bool isExplicitImplicit() const
+    virtual bool isExplicit()         const override {return false;}
+    virtual bool isImplicit()         const override {return true;}
+    virtual bool isExplicitImplicit() const override
       {return isExplicit() && isImplicit();}
-    virtual bool isOneStepMethod()   const {return true;}
-    virtual bool isMultiStepMethod() const {return !isOneStepMethod();}
-    virtual OrderODE getOrderODE()   const {return FIRST_ORDER_ODE;}
+    virtual bool isOneStepMethod()   const override {return true;}
+    virtual bool isMultiStepMethod() const override {return !isOneStepMethod();}
+    virtual OrderODE getOrderODE()   const override {return FIRST_ORDER_ODE;}
   //@}
 
     /// Return alpha = d(xDot)/dx.
-  virtual Scalar getAlpha(const Scalar dt) const { return Scalar(1.0)/dt; }
+  virtual Scalar getAlpha(const Scalar dt) const override { return Scalar(1.0)/dt; }
   /// Return beta  = d(x)/dx.
-  virtual Scalar getBeta (const Scalar   ) const { return Scalar(1.0); }
+  virtual Scalar getBeta (const Scalar   ) const override { return Scalar(1.0); }
 
   /// Compute predictor given the supplied stepper
   virtual void computePredictor(
     const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory);
 
-  Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
+  Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const override;
 
   /// \name Overridden from Teuchos::Describable
   //@{
     virtual void describe(Teuchos::FancyOStream        & out,
-                          const Teuchos::EVerbosityLevel verbLevel) const;
+                          const Teuchos::EVerbosityLevel verbLevel) const override;
   //@}
 
-  virtual bool isValidSetup(Teuchos::FancyOStream & out) const;
+  virtual bool isValidSetup(Teuchos::FancyOStream & out) const override;
 
   /// \name Implementation of StepperOptimizationInterface
   //@{
-    virtual int stencilLength() const;
+    virtual int stencilLength() const override;
     virtual void computeStepResidual(
       Thyra::VectorBase<Scalar>& residual,
       const Teuchos::Array< Teuchos::RCP<const Thyra::VectorBase<Scalar> > >& x,
       const Teuchos::Array<Scalar>& t,
       const Thyra::VectorBase<Scalar>& p,
-      const int param_index) const;
+      const int param_index) const override;
     virtual void computeStepJacobian(
       Thyra::LinearOpBase<Scalar>& jacobian,
       const Teuchos::Array< Teuchos::RCP<const Thyra::VectorBase<Scalar> > >& x,
       const Teuchos::Array<Scalar>& t,
       const Thyra::VectorBase<Scalar>& p,
       const int param_index,
-      const int deriv_index) const;
+      const int deriv_index) const override;
     virtual void computeStepParamDeriv(
       Thyra::LinearOpBase<Scalar>& deriv,
       const Teuchos::Array< Teuchos::RCP<const Thyra::VectorBase<Scalar> > >& x,
       const Teuchos::Array<Scalar>& t,
       const Thyra::VectorBase<Scalar>& p,
-      const int param_index) const;
+      const int param_index) const override;
     virtual void computeStepSolver(
       Thyra::LinearOpWithSolveBase<Scalar>& jacobian_solver,
       const Teuchos::Array< Teuchos::RCP<const Thyra::VectorBase<Scalar> > >& x,
       const Teuchos::Array<Scalar>& t,
       const Thyra::VectorBase<Scalar>& p,
-      const int param_index) const;
+      const int param_index) const override;
   //@}
 
 private:

--- a/packages/tempus/src/Tempus_StepperDIRK_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperDIRK_decl.hpp
@@ -161,11 +161,15 @@ public:
   /// \name Basic stepper methods
   //@{
     /// Initialize after construction and changing input parameters.
-    virtual void initialize();
+    virtual void initialize() override;
+
+    /// Set the model
+    virtual void setModel(
+      const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel) override;
 
     /// Set the initial conditions and make them consistent.
     virtual void setInitialConditions (
-      const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory);
+      const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory) override;
 
     /// Set parameter so that the initial guess is reset at the beginning of each timestep.
     virtual void setResetInitialGuess(bool reset_guess)
@@ -175,12 +179,12 @@ public:
 
     /// Take the specified timestep, dt, and return true if successful.
     virtual void takeStep(
-      const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory);
+      const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory) override;
 
     /// Get a default (initial) StepperState
-    virtual Teuchos::RCP<Tempus::StepperState<Scalar> >getDefaultStepperState();
+    virtual Teuchos::RCP<Tempus::StepperState<Scalar> >getDefaultStepperState() override;
 
-    virtual bool isExplicit() const
+    virtual bool isExplicit() const override
     {
       const int numStages = this->tableau_->numStages();
       Teuchos::SerialDenseMatrix<int,Scalar> A = this->tableau_->A();
@@ -188,13 +192,13 @@ public:
       for (int i=0; i<numStages; ++i) if (A(i,i) == 0.0) isExplicit = true;
       return isExplicit;
     }
-    virtual bool isImplicit()         const {return true;}
-    virtual bool isExplicitImplicit() const
+    virtual bool isImplicit()         const override {return true;}
+    virtual bool isExplicitImplicit() const override
       {return isExplicit() && isImplicit();}
-    virtual bool isOneStepMethod()   const {return true;}
-    virtual bool isMultiStepMethod() const {return !isOneStepMethod();}
+    virtual bool isOneStepMethod()   const override {return true;}
+    virtual bool isMultiStepMethod() const override {return !isOneStepMethod();}
 
-    virtual OrderODE getOrderODE()   const {return FIRST_ORDER_ODE;}
+    virtual OrderODE getOrderODE()   const override {return FIRST_ORDER_ODE;}
 
     virtual std::string getDescription() const = 0;
   //@}
@@ -203,25 +207,25 @@ public:
   Teuchos::RCP<Thyra::VectorBase<Scalar> >& getXTilde() {return xTilde_;}
 
   /// Return alpha = d(xDot)/dx.
-  virtual Scalar getAlpha(const Scalar dt) const
+  virtual Scalar getAlpha(const Scalar dt) const override
   {
     const Teuchos::SerialDenseMatrix<int,Scalar> & A=this->tableau_->A();
     return Scalar(1.0)/(dt*A(0,0));  // Getting the first diagonal coeff!
   }
   /// Return beta  = d(x)/dx.
-  virtual Scalar getBeta (const Scalar   ) const { return Scalar(1.0); }
+  virtual Scalar getBeta (const Scalar   ) const override { return Scalar(1.0); }
 
-  virtual Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
+  virtual Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const override;
 
   Teuchos::RCP<Teuchos::ParameterList> getValidParametersBasicDIRK() const;
 
   /// \name Overridden from Teuchos::Describable
   //@{
     virtual void describe(Teuchos::FancyOStream        & out,
-                          const Teuchos::EVerbosityLevel verbLevel) const;
+                          const Teuchos::EVerbosityLevel verbLevel) const override;
   //@}
 
-  virtual bool isValidSetup(Teuchos::FancyOStream & out) const;
+  virtual bool isValidSetup(Teuchos::FancyOStream & out) const override;
 
   /// Set StepperDIRK member data from the ParameterList.
   virtual void setStepperDIRKValues(Teuchos::RCP<Teuchos::ParameterList> pl)
@@ -257,6 +261,9 @@ protected:
     const Teuchos::RCP<StepperRKAppAction<Scalar> >& stepperRKAppAction);
 
   virtual void setupTableau() = 0;
+
+  virtual void setEmbeddedMemory() override;
+
 
   std::vector<Teuchos::RCP<Thyra::VectorBase<Scalar> > > stageXDot_;
   Teuchos::RCP<Thyra::VectorBase<Scalar> >               xTilde_;

--- a/packages/tempus/src/Tempus_StepperExplicitRK_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperExplicitRK_decl.hpp
@@ -108,6 +108,10 @@ public:
     /// Initialize during construction and after changing input parameters.
     virtual void initialize();
 
+    /// Set model
+    virtual void setModel(
+      const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel);
+
     /// Set the initial conditions and make them consistent.
     virtual void setInitialConditions (
       const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory);
@@ -161,6 +165,8 @@ protected:
     const Teuchos::RCP<StepperRKAppAction<Scalar> >& stepperRKAppAction);
 
   virtual void setupTableau() = 0;
+
+  virtual void setEmbeddedMemory();
 
 
   std::vector<Teuchos::RCP<Thyra::VectorBase<Scalar> > > stageXDot_;

--- a/packages/tempus/src/Tempus_StepperExplicit_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperExplicit_decl.hpp
@@ -50,8 +50,9 @@ public:
     virtual void setModel(
       const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel);
 
+    /// Return the application ModelEvaluator.
     virtual Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >
-      getModel(){return appModel_;}
+      getModel() const {return appModel_;}
 
     virtual Scalar getInitTimeStep(
         const Teuchos::RCP<SolutionHistory<Scalar> >& /* solutionHistory */) const

--- a/packages/tempus/src/Tempus_StepperExplicit_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperExplicit_decl.hpp
@@ -46,6 +46,7 @@ public:
 
   /// \name Basic explicit stepper methods
   //@{
+    /// Set model
     virtual void setModel(
       const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel);
 

--- a/packages/tempus/src/Tempus_StepperExplicit_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperExplicit_impl.hpp
@@ -319,16 +319,21 @@ template<class Scalar>
 void StepperExplicit<Scalar>::describe(Teuchos::FancyOStream        & out,
                                const Teuchos::EVerbosityLevel verbLevel) const
 {
-  out << "--- StepperExplicit ---\n";
-  out << "  appModel_         = " << appModel_ << std::endl;
-  out << "  inArgs_           = " << inArgs_ << std::endl;
-  out << "  outArgs_          = " << outArgs_ << std::endl;
+  auto l_out = Teuchos::fancyOStream( out.getOStream() );
+  Teuchos::OSTab ostab(*l_out, 2, this->description());
+  l_out->setOutputToRootOnly(0);
+
+  *l_out << "--- StepperExplicit ---\n"
+         << "  appModel_         = " << appModel_ << std::endl
+         << "  inArgs_           = " << inArgs_   << std::endl
+         << "  outArgs_          = " << outArgs_  << std::endl;
 }
 
 
 template<class Scalar>
 bool StepperExplicit<Scalar>::isValidSetup(Teuchos::FancyOStream & out) const
 {
+  out.setOutputToRootOnly(0);
   bool isValidSetup = true;
 
   if (appModel_ == Teuchos::null) {

--- a/packages/tempus/src/Tempus_StepperFactory_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperFactory_impl.hpp
@@ -198,6 +198,7 @@ createStepper(
   else {
     Teuchos::RCP<Teuchos::FancyOStream> out =
       Teuchos::VerboseObjectBase::getDefaultOStream();
+    out->setOutputToRootOnly(0);
     Teuchos::OSTab ostab(out,1,"StepperFactory::createStepper");
     *out
     << "Unknown Stepper Type!  ('"+stepperType+"').\n"

--- a/packages/tempus/src/Tempus_StepperForwardEuler_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperForwardEuler_impl.hpp
@@ -185,18 +185,24 @@ void StepperForwardEuler<Scalar>::describe(
   Teuchos::FancyOStream               &out,
   const Teuchos::EVerbosityLevel      verbLevel) const
 {
-  out << std::endl;
-  Stepper<Scalar>::describe(out, verbLevel);
-  StepperExplicit<Scalar>::describe(out, verbLevel);
-  out << "  stepperFEAppAction_                = "
-      << stepperFEAppAction_ << std::endl;
-  out << "----------------------------" << std::endl;
+  auto l_out = Teuchos::fancyOStream( out.getOStream() );
+  Teuchos::OSTab ostab(*l_out, 2, this->description());
+  l_out->setOutputToRootOnly(0);
+
+  *l_out << std::endl;
+  Stepper<Scalar>::describe(*l_out, verbLevel);
+  StepperExplicit<Scalar>::describe(*l_out, verbLevel);
+  *l_out << "  stepperFEAppAction_ = "
+         << stepperFEAppAction_ << std::endl
+         << "----------------------------" << std::endl;
 }
 
 
 template<class Scalar>
 bool StepperForwardEuler<Scalar>::isValidSetup(Teuchos::FancyOStream & out) const
 {
+  out.setOutputToRootOnly(0);
+
   bool isValidSetup = true;
 
   if ( !Stepper<Scalar>::isValidSetup(out) ) isValidSetup = false;

--- a/packages/tempus/src/Tempus_StepperHHTAlpha_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperHHTAlpha_impl.hpp
@@ -488,17 +488,18 @@ void StepperHHTAlpha<Scalar>::describe(
    Teuchos::FancyOStream               &out,
    const Teuchos::EVerbosityLevel      verbLevel) const
 {
+  auto l_out = Teuchos::fancyOStream( out.getOStream() );
+  Teuchos::OSTab ostab(*l_out, 2, this->description());
+  l_out->setOutputToRootOnly(0);
 
 #ifdef VERBOSE_DEBUG_OUTPUT
   *out_ << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
 #endif
 
-  out << std::endl;
-  Stepper<Scalar>::describe(out, verbLevel);
-  StepperImplicit<Scalar>::describe(out, verbLevel);
+  *l_out << std::endl;
+  Stepper<Scalar>::describe(*l_out, verbLevel);
+  StepperImplicit<Scalar>::describe(*l_out, verbLevel);
 
-  auto l_out = Teuchos::fancyOStream( out.getOStream() );
-  l_out->setOutputToRootOnly(0);
   *l_out << "--- StepperHHTAlpha ---\n";
   *l_out << "  schemeName_ = " << schemeName_ << std::endl;
   *l_out << "  beta_       = " << beta_       << std::endl;
@@ -512,6 +513,7 @@ void StepperHHTAlpha<Scalar>::describe(
 template<class Scalar>
 bool StepperHHTAlpha<Scalar>::isValidSetup(Teuchos::FancyOStream & out) const
 {
+  out.setOutputToRootOnly(0);
   bool isValidSetup = true;
 
   if ( !Stepper<Scalar>::isValidSetup(out) ) isValidSetup = false;

--- a/packages/tempus/src/Tempus_StepperIMEX_RK_Partition_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperIMEX_RK_Partition_decl.hpp
@@ -377,7 +377,7 @@ public:
     virtual void setModel(
       const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel);
 
-    virtual Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > getModel()
+    virtual Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > getModel() const
      { return this->wrapperModel_; }
 
     virtual void setModelPair(

--- a/packages/tempus/src/Tempus_StepperIMEX_RK_Partition_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperIMEX_RK_Partition_impl.hpp
@@ -788,6 +788,7 @@ void StepperIMEX_RK_Partition<Scalar>::describe(
    Teuchos::FancyOStream               &out,
    const Teuchos::EVerbosityLevel      verbLevel) const
 {
+  out.setOutputToRootOnly(0);
   out << std::endl;
   Stepper<Scalar>::describe(out, verbLevel);
   StepperImplicit<Scalar>::describe(out, verbLevel);
@@ -817,6 +818,8 @@ void StepperIMEX_RK_Partition<Scalar>::describe(
 template<class Scalar>
 bool StepperIMEX_RK_Partition<Scalar>::isValidSetup(Teuchos::FancyOStream & out) const
 {
+  out.setOutputToRootOnly(0);
+
   bool isValidSetup = true;
 
   if ( !Stepper<Scalar>::isValidSetup(out) ) isValidSetup = false;

--- a/packages/tempus/src/Tempus_StepperIMEX_RK_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperIMEX_RK_decl.hpp
@@ -347,7 +347,7 @@ public:
     virtual void setModel(
       const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel);
 
-    virtual Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > getModel()
+    virtual Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > getModel() const
      { return this->wrapperModel_; }
 
     virtual void setModelPair(

--- a/packages/tempus/src/Tempus_StepperIMEX_RK_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperIMEX_RK_impl.hpp
@@ -859,6 +859,8 @@ void StepperIMEX_RK<Scalar>::describe(
    Teuchos::FancyOStream               &out,
    const Teuchos::EVerbosityLevel      verbLevel) const
 {
+  out.setOutputToRootOnly(0);
+
   out << std::endl;
   Stepper<Scalar>::describe(out, verbLevel);
   StepperImplicit<Scalar>::describe(out, verbLevel);
@@ -888,6 +890,7 @@ void StepperIMEX_RK<Scalar>::describe(
 template<class Scalar>
 bool StepperIMEX_RK<Scalar>::isValidSetup(Teuchos::FancyOStream & out) const
 {
+  out.setOutputToRootOnly(0);
   bool isValidSetup = true;
 
   if ( !Stepper<Scalar>::isValidSetup(out) ) isValidSetup = false;

--- a/packages/tempus/src/Tempus_StepperImplicit_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperImplicit_decl.hpp
@@ -231,10 +231,11 @@ public:
 
   /// \name Basic implicit stepper methods
   //@{
+    /// Set the model
     virtual void setModel(
-      const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel);
+      const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel) override;
 
-    virtual Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > getModel()
+    virtual Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > getModel() override
     {
       Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > model;
       if (wrapperModel_ != Teuchos::null) model = wrapperModel_->getAppModel();
@@ -248,14 +249,14 @@ public:
 
     /// Set solver.
     virtual void setSolver(
-      Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > solver);
+      Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > solver) override;
 
-    virtual Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > getSolver() const
+    virtual Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > getSolver() const override
       { return solver_; }
 
     /// Set the initial conditions and make them consistent.
     virtual void setInitialConditions (
-      const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory);
+      const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory) override;
 
     /// Return alpha = d(xDot)/dx.
     virtual Scalar getAlpha(const Scalar dt) const = 0;
@@ -284,7 +285,7 @@ public:
 
     /// Pass initial guess to Newton solver (only relevant for implicit solvers)
     virtual void setInitialGuess(
-      Teuchos::RCP<const Thyra::VectorBase<Scalar> > initialGuess)
+      Teuchos::RCP<const Thyra::VectorBase<Scalar> > initialGuess) override
     {
       initialGuess_ = initialGuess;
       this->isInitialized_ = false;
@@ -299,19 +300,19 @@ public:
     virtual bool getZeroInitialGuess() const { return zeroInitialGuess_; }
 
     virtual Scalar getInitTimeStep(
-      const Teuchos::RCP<SolutionHistory<Scalar> >& /* solutionHistory */) const
+      const Teuchos::RCP<SolutionHistory<Scalar> >& /* solutionHistory */) const override
     {return Scalar(1.0e+99);}
   //@}
 
   /// \name Overridden from Teuchos::Describable
   //@{
     virtual void describe(Teuchos::FancyOStream        & out,
-                          const Teuchos::EVerbosityLevel verbLevel) const;
+                          const Teuchos::EVerbosityLevel verbLevel) const override;
   //@}
 
-  virtual bool isValidSetup(Teuchos::FancyOStream & out) const;
+  virtual bool isValidSetup(Teuchos::FancyOStream & out) const override;
 
-  virtual Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
+  virtual Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const override;
 
   Teuchos::RCP<Teuchos::ParameterList> getValidParametersBasicImplicit() const;
 

--- a/packages/tempus/src/Tempus_StepperImplicit_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperImplicit_decl.hpp
@@ -235,7 +235,7 @@ public:
     virtual void setModel(
       const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel) override;
 
-    virtual Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > getModel() override
+    virtual Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > getModel() const override
     {
       Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > model;
       if (wrapperModel_ != Teuchos::null) model = wrapperModel_->getAppModel();

--- a/packages/tempus/src/Tempus_StepperImplicit_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperImplicit_impl.hpp
@@ -328,6 +328,7 @@ template<class Scalar>
 void StepperImplicit<Scalar>::describe(Teuchos::FancyOStream        & out,
                                const Teuchos::EVerbosityLevel verbLevel) const
 {
+  out.setOutputToRootOnly(0);
   out << "--- StepperImplicit ---\n";
   out << "  wrapperModel_     = " << wrapperModel_ << std::endl;
   out << "  solver_           = " << solver_ << std::endl;
@@ -340,6 +341,7 @@ void StepperImplicit<Scalar>::describe(Teuchos::FancyOStream        & out,
 template<class Scalar>
 bool StepperImplicit<Scalar>::isValidSetup(Teuchos::FancyOStream & out) const
 {
+  out.setOutputToRootOnly(0);
   bool isValidSetup = true;
 
   if (wrapperModel_->getAppModel() == Teuchos::null) {

--- a/packages/tempus/src/Tempus_StepperLeapfrog_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperLeapfrog_impl.hpp
@@ -189,6 +189,7 @@ void StepperLeapfrog<Scalar>::describe(
   Teuchos::FancyOStream               &out,
   const Teuchos::EVerbosityLevel      verbLevel) const
 {
+  out.setOutputToRootOnly(0);
   out << std::endl;
   Stepper<Scalar>::describe(out, verbLevel);
   StepperExplicit<Scalar>::describe(out, verbLevel);
@@ -203,6 +204,7 @@ void StepperLeapfrog<Scalar>::describe(
 template<class Scalar>
 bool StepperLeapfrog<Scalar>::isValidSetup(Teuchos::FancyOStream & out) const
 {
+  out.setOutputToRootOnly(0);
   bool isValidSetup = true;
 
   if ( !Stepper<Scalar>::isValidSetup(out) ) isValidSetup = false;

--- a/packages/tempus/src/Tempus_StepperNewmarkExplicitAForm_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkExplicitAForm_impl.hpp
@@ -343,6 +343,7 @@ void StepperNewmarkExplicitAForm<Scalar>::describe(
    Teuchos::FancyOStream               &out,
    const Teuchos::EVerbosityLevel      verbLevel) const
 {
+  out.setOutputToRootOnly(0);
   out << std::endl;
   Stepper<Scalar>::describe(out, verbLevel);
   StepperExplicit<Scalar>::describe(out, verbLevel);
@@ -356,6 +357,7 @@ void StepperNewmarkExplicitAForm<Scalar>::describe(
 template<class Scalar>
 bool StepperNewmarkExplicitAForm<Scalar>::isValidSetup(Teuchos::FancyOStream & out) const
 {
+  out.setOutputToRootOnly(0);
   bool isValidSetup = true;
 
   if ( !Stepper<Scalar>::isValidSetup(out) ) isValidSetup = false;

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitAForm_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitAForm_impl.hpp
@@ -549,6 +549,7 @@ void StepperNewmarkImplicitAForm<Scalar>::describe(
 template<class Scalar>
 bool StepperNewmarkImplicitAForm<Scalar>::isValidSetup(Teuchos::FancyOStream & out) const
 {
+  out.setOutputToRootOnly(0);
   bool isValidSetup = true;
   out.setOutputToRootOnly(0);
 

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitDForm_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitDForm_impl.hpp
@@ -455,6 +455,7 @@ StepperNewmarkImplicitDForm<Scalar>::describe(
   *out_ << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
 #endif
 
+  out.setOutputToRootOnly(0);
   out << std::endl;
   Stepper<Scalar>::describe(out, verbLevel);
   StepperImplicit<Scalar>::describe(out, verbLevel);
@@ -470,6 +471,7 @@ StepperNewmarkImplicitDForm<Scalar>::describe(
 template<class Scalar>
 bool StepperNewmarkImplicitDForm<Scalar>::isValidSetup(Teuchos::FancyOStream & out) const
 {
+  out.setOutputToRootOnly(0);
   bool isValidSetup = true;
 
   if ( !Stepper<Scalar>::isValidSetup(out) ) isValidSetup = false;

--- a/packages/tempus/src/Tempus_StepperOperatorSplit_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperOperatorSplit_decl.hpp
@@ -90,8 +90,7 @@ public:
     virtual void setModel(
       const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel);
 
-    virtual Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >
-      getModel();
+    virtual Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > getModel() const;
 
     virtual void setSolver(
         Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > solver);

--- a/packages/tempus/src/Tempus_StepperOperatorSplit_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperOperatorSplit_impl.hpp
@@ -85,7 +85,7 @@ void StepperOperatorSplit<Scalar>::setModel(
 
 template<class Scalar>
 Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >
-StepperOperatorSplit<Scalar>::getModel()
+StepperOperatorSplit<Scalar>::getModel() const
 {
   Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > model;
   typename std::vector<Teuchos::RCP<Stepper<Scalar> > >::const_iterator

--- a/packages/tempus/src/Tempus_StepperOperatorSplit_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperOperatorSplit_impl.hpp
@@ -350,6 +350,7 @@ void StepperOperatorSplit<Scalar>::describe(
    Teuchos::FancyOStream               &out,
    const Teuchos::EVerbosityLevel      verbLevel) const
 {
+  out.setOutputToRootOnly(0);
   out << std::endl;
   Stepper<Scalar>::describe(out, verbLevel);
 
@@ -375,6 +376,7 @@ void StepperOperatorSplit<Scalar>::describe(
 template<class Scalar>
 bool StepperOperatorSplit<Scalar>::isValidSetup(Teuchos::FancyOStream & out) const
 {
+  out.setOutputToRootOnly(0);
   bool isValidSetup = true;
 
   if ( !Stepper<Scalar>::isValidSetup(out) ) isValidSetup = false;

--- a/packages/tempus/src/Tempus_StepperRKBase.hpp
+++ b/packages/tempus/src/Tempus_StepperRKBase.hpp
@@ -43,7 +43,13 @@ public:
   virtual int getStageNumber() const { return stageNumber_; }
   virtual void setStageNumber(int s) { stageNumber_ = s; }
 
-  virtual void setUseEmbedded(bool a) { useEmbedded_ = a; }
+  virtual void setUseEmbedded(bool a)
+  {
+    useEmbedded_ = a;
+    this->setEmbeddedMemory();
+    this->isInitialized_ = false;
+  }
+
   virtual bool getUseEmbedded() const { return useEmbedded_; }
 
   virtual void setAppAction(Teuchos::RCP<StepperRKAppAction<Scalar> > appAction)
@@ -180,6 +186,8 @@ public:
 
 
 protected:
+
+  virtual void setEmbeddedMemory() {}
 
   Teuchos::RCP<RKButcherTableau<Scalar> >   tableau_;
 

--- a/packages/tempus/src/Tempus_StepperStaggeredForwardSensitivity_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperStaggeredForwardSensitivity_decl.hpp
@@ -82,7 +82,7 @@ public:
   //@{
     virtual void setModel(
       const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel);
-    virtual Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > getModel();
+    virtual Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > getModel() const;
 
     virtual void setSolver(
       Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > solver = Teuchos::null);

--- a/packages/tempus/src/Tempus_StepperStaggeredForwardSensitivity_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperStaggeredForwardSensitivity_impl.hpp
@@ -274,6 +274,7 @@ describe(
    Teuchos::FancyOStream               &out,
    const Teuchos::EVerbosityLevel      verbLevel) const
 {
+  out.setOutputToRootOnly(0);
   out << std::endl;
   Stepper<Scalar>::describe(out, verbLevel);
 
@@ -296,6 +297,7 @@ describe(
 template<class Scalar>
 bool StepperStaggeredForwardSensitivity<Scalar>::isValidSetup(Teuchos::FancyOStream & out) const
 {
+  out.setOutputToRootOnly(0);
   bool isValidSetup = true;
 
   if ( !Stepper<Scalar>::isValidSetup(out) ) isValidSetup = false;

--- a/packages/tempus/src/Tempus_StepperStaggeredForwardSensitivity_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperStaggeredForwardSensitivity_impl.hpp
@@ -89,7 +89,7 @@ setModel(
 template<class Scalar>
 Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >
 StepperStaggeredForwardSensitivity<Scalar>::
-getModel()
+getModel() const
 {
   return combined_fsa_model_;
 }

--- a/packages/tempus/src/Tempus_StepperState.hpp
+++ b/packages/tempus/src/Tempus_StepperState.hpp
@@ -59,13 +59,19 @@ public:
 
   /// \name Overridden from Teuchos::Describable
   //@{
-    virtual std::string description() const { return "Tempus::StepperState"; }
+    virtual std::string description() const
+    {
+      return "Tempus::StepperState - '" + stepperName_ + "'";
+    }
 
     virtual void describe(Teuchos::FancyOStream        & out,
                           const Teuchos::EVerbosityLevel /* verbLevel */) const
     {
-      out << description() << "::describe" << std::endl
-          << "  stepperName   = " << stepperName_ << std::endl;
+      auto l_out = Teuchos::fancyOStream( out.getOStream() );
+      Teuchos::OSTab ostab(*l_out,2, this->description());
+      l_out->setOutputToRootOnly(0);
+
+      *l_out << "  --- " << this->description() << " ---" << std::endl;
     }
   //@}
 

--- a/packages/tempus/src/Tempus_StepperState.hpp
+++ b/packages/tempus/src/Tempus_StepperState.hpp
@@ -71,7 +71,7 @@ public:
       Teuchos::OSTab ostab(*l_out,2, this->description());
       l_out->setOutputToRootOnly(0);
 
-      *l_out << "  --- " << this->description() << " ---" << std::endl;
+      *l_out << "\n--- " << this->description() << " ---" << std::endl;
     }
   //@}
 

--- a/packages/tempus/src/Tempus_StepperSubcycling_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperSubcycling_decl.hpp
@@ -80,7 +80,7 @@ public:
       const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& appModel);
 
     virtual Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >
-      getModel(){return scIntegrator_->getStepper()->getModel();}
+      getModel() const {return scIntegrator_->getStepper()->getModel();}
 
     virtual void setAppAction(
       Teuchos::RCP<StepperSubcyclingAppAction<Scalar> > appAction = Teuchos::null);

--- a/packages/tempus/src/Tempus_StepperSubcycling_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperSubcycling_impl.hpp
@@ -508,6 +508,7 @@ void StepperSubcycling<Scalar>::describe(
   Teuchos::FancyOStream               &out,
   const Teuchos::EVerbosityLevel      verbLevel) const
 {
+  out.setOutputToRootOnly(0);
   out << std::endl;
   Stepper<Scalar>::describe(out, verbLevel);
 

--- a/packages/tempus/src/Tempus_StepperTrapezoidal_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperTrapezoidal_impl.hpp
@@ -188,6 +188,7 @@ void StepperTrapezoidal<Scalar>::describe(
   Teuchos::FancyOStream               &out,
   const Teuchos::EVerbosityLevel      verbLevel) const
 {
+  out.setOutputToRootOnly(0);
   out << std::endl;
   Stepper<Scalar>::describe(out, verbLevel);
   StepperImplicit<Scalar>::describe(out, verbLevel);
@@ -201,6 +202,7 @@ void StepperTrapezoidal<Scalar>::describe(
 template<class Scalar>
 bool StepperTrapezoidal<Scalar>::isValidSetup(Teuchos::FancyOStream & out) const
 {
+  out.setOutputToRootOnly(0);
   bool isValidSetup = true;
 
   if ( !Stepper<Scalar>::isValidSetup(out) ) isValidSetup = false;

--- a/packages/tempus/src/Tempus_Stepper_decl.hpp
+++ b/packages/tempus/src/Tempus_Stepper_decl.hpp
@@ -70,7 +70,7 @@ public:
       const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& /* appModel */){}
 
 #endif
-    virtual Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > getModel()
+    virtual Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > getModel() const
     { return Teuchos::null; }
 
     /// Set solver.

--- a/packages/tempus/src/Tempus_Stepper_impl.hpp
+++ b/packages/tempus/src/Tempus_Stepper_impl.hpp
@@ -120,12 +120,14 @@ Stepper<Scalar>::getStepperXDotDot(Teuchos::RCP<SolutionState<Scalar> > state)
 
 
 template<class Scalar>
-void Stepper<Scalar>::describe(Teuchos::FancyOStream        & in_out,
+void Stepper<Scalar>::describe(Teuchos::FancyOStream        & out,
                                const Teuchos::EVerbosityLevel verbLevel) const
 {
-  auto out = Teuchos::fancyOStream( in_out.getOStream() );
-  out->setOutputToRootOnly(0);
-  *out << "--- Stepper ---\n"
+  auto l_out = Teuchos::fancyOStream( out.getOStream() );
+  Teuchos::OSTab ostab(*l_out, 2, this->description());
+  l_out->setOutputToRootOnly(0);
+
+  *l_out << "--- Stepper ---\n"
        << "  isInitialized_      = " << Teuchos::toString(isInitialized_) << std::endl
        << "  stepperType_        = " << stepperType_ << std::endl
        << "  useFSAL_            = " << Teuchos::toString(useFSAL_) << std::endl
@@ -139,18 +141,19 @@ void Stepper<Scalar>::describe(Teuchos::FancyOStream        & in_out,
 
 template<class Scalar>
 bool Stepper<Scalar>::isValidSetup(
-  Teuchos::FancyOStream & in_out) const
+  Teuchos::FancyOStream & out) const
 {
+  out.setOutputToRootOnly(0);
   bool isValidSetup = true;
 
   if ( !(ICConsistency_ == "None" || ICConsistency_ == "Zero" ||
          ICConsistency_ == "App"  || ICConsistency_ == "Consistent") ) {
     isValidSetup = false;
-    auto out = Teuchos::fancyOStream( in_out.getOStream() );
-    out->setOutputToRootOnly(0);
-    *out << "The IC consistency does not have a valid value!\n"
-         << "('None', 'Zero', 'App' or 'Consistent')\n"
-         << "  ICConsistency  = " << ICConsistency_ << "\n";
+    auto l_out = Teuchos::fancyOStream( out.getOStream() );
+    l_out->setOutputToRootOnly(0);
+    *l_out << "The IC consistency does not have a valid value!\n"
+           << "('None', 'Zero', 'App' or 'Consistent')\n"
+           << "  ICConsistency  = " << ICConsistency_ << "\n";
   }
 
   return isValidSetup;

--- a/packages/tempus/src/Tempus_TimeEventBase.hpp
+++ b/packages/tempus/src/Tempus_TimeEventBase.hpp
@@ -89,6 +89,7 @@ public:
     {
       Teuchos::RCP<Teuchos::FancyOStream> out =
         Teuchos::VerboseObjectBase::getDefaultOStream();
+      out->setOutputToRootOnly(0);
       *out << "TimeEventBase name = " << getName() << std::endl;
     }
   //@}

--- a/packages/tempus/src/Tempus_TimeEventComposite.hpp
+++ b/packages/tempus/src/Tempus_TimeEventComposite.hpp
@@ -188,6 +188,7 @@ public:
   {
     Teuchos::RCP<Teuchos::FancyOStream> out =
       Teuchos::VerboseObjectBase::getDefaultOStream();
+    out->setOutputToRootOnly(0);
     *out << "TimeEventComposite:" << "\n"
         << "name                 = " << this->getName() << "\n"
         << "Number of TimeEvents = " << timeEvents_.size() << std::endl;

--- a/packages/tempus/src/Tempus_TimeEventListIndex_impl.hpp
+++ b/packages/tempus/src/Tempus_TimeEventListIndex_impl.hpp
@@ -126,6 +126,7 @@ void TimeEventListIndex<Scalar>::describe() const
 {
   Teuchos::RCP<Teuchos::FancyOStream> out =
     Teuchos::VerboseObjectBase::getDefaultOStream();
+  out->setOutputToRootOnly(0);
   *out << "TimeEventListIndex:" << "\n"
        << "name       = " << this->getName() << "\n"
        << "IndexList_ = " << std::endl;

--- a/packages/tempus/src/Tempus_TimeEventList_impl.hpp
+++ b/packages/tempus/src/Tempus_TimeEventList_impl.hpp
@@ -176,6 +176,7 @@ void TimeEventList<Scalar>::describe() const
 {
   Teuchos::RCP<Teuchos::FancyOStream> out =
     Teuchos::VerboseObjectBase::getDefaultOStream();
+  out->setOutputToRootOnly(0);
   *out << "TimeEventList:" << "\n"
        << "name           = " << this->getName() << "\n"
        << "timeScale_     = " << timeScale_     << "\n"

--- a/packages/tempus/src/Tempus_TimeEventRangeIndex_impl.hpp
+++ b/packages/tempus/src/Tempus_TimeEventRangeIndex_impl.hpp
@@ -138,6 +138,7 @@ void TimeEventRangeIndex<Scalar>::describe() const
 {
   Teuchos::RCP<Teuchos::FancyOStream> out =
     Teuchos::VerboseObjectBase::getDefaultOStream();
+  out->setOutputToRootOnly(0);
   *out << "TimeEventRange:" << "\n"
        << "name       = " << this->getName() << "\n"
        << "start_     = " << start_     << "\n"

--- a/packages/tempus/src/Tempus_TimeEventRange_impl.hpp
+++ b/packages/tempus/src/Tempus_TimeEventRange_impl.hpp
@@ -205,6 +205,7 @@ void TimeEventRange<Scalar>::describe() const
 {
   Teuchos::RCP<Teuchos::FancyOStream> out =
     Teuchos::VerboseObjectBase::getDefaultOStream();
+  out->setOutputToRootOnly(0);
   *out << "TimeEventRange:" << "\n"
        << "name           = " << this->getName() << "\n"
        << "start_         = " << start_         << "\n"

--- a/packages/tempus/src/Tempus_TimeStepControlStrategyBasicVS.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategyBasicVS.hpp
@@ -212,13 +212,21 @@ public:
     void describe(Teuchos::FancyOStream          &out,
                   const Teuchos::EVerbosityLevel verbLevel) const override
     {
-      Teuchos::OSTab ostab(out,2,"describe");
-      out << description() << "::describe:" << std::endl
-          << "StrategyType                      = " << this->getStrategyType()<< std::endl
-          << "Amplification Factor              = " << getAmplFactor()   << std::endl
-          << "Reduction Factor                  = " << getReductFactor() << std::endl
-          << "Minimum Value Monitoring Function = " << getMinEta()       << std::endl
-          << "Maximum Value Monitoring Function = " << getMaxEta()       << std::endl;
+      auto l_out = Teuchos::fancyOStream( out.getOStream() );
+      Teuchos::OSTab ostab(*l_out, 2, this->description());
+      l_out->setOutputToRootOnly(0);
+
+      *l_out << "--- " << this->description() << " ---" << std::endl;
+
+      if (Teuchos::as<int>(verbLevel) >= Teuchos::as<int>(Teuchos::VERB_MEDIUM)) {
+        *l_out << "  StrategyType                      = " << this->getStrategyType()<< std::endl
+               << "  Step Type                         = " << this->getStepType() << std::endl
+               << "  Amplification Factor              = " << getAmplFactor()   << std::endl
+               << "  Reduction Factor                  = " << getReductFactor() << std::endl
+               << "  Minimum Value Monitoring Function = " << getMinEta()       << std::endl
+               << "  Maximum Value Monitoring Function = " << getMaxEta()       << std::endl;
+        *l_out << std::string(this->description().length()+8, '-') <<std::endl;
+      }
     }
   //@}
 

--- a/packages/tempus/src/Tempus_TimeStepControlStrategyBasicVS.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategyBasicVS.hpp
@@ -216,7 +216,7 @@ public:
       Teuchos::OSTab ostab(*l_out, 2, this->description());
       l_out->setOutputToRootOnly(0);
 
-      *l_out << "--- " << this->description() << " ---" << std::endl;
+      *l_out << "\n--- " << this->description() << " ---" << std::endl;
 
       if (Teuchos::as<int>(verbLevel) >= Teuchos::as<int>(Teuchos::VERB_MEDIUM)) {
         *l_out << "  StrategyType                      = " << this->getStrategyType()<< std::endl

--- a/packages/tempus/src/Tempus_TimeStepControlStrategyComposite.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategyComposite.hpp
@@ -76,7 +76,7 @@ public:
       Teuchos::OSTab ostab(*l_out, 2, this->description());
       l_out->setOutputToRootOnly(0);
 
-      *l_out << "--- " << this->description() << " ---" << std::endl;
+      *l_out << "\n--- " << this->description() << " ---" << std::endl;
 
       if (Teuchos::as<int>(verbLevel) >= Teuchos::as<int>(Teuchos::VERB_MEDIUM)) {
         *l_out << "  Strategy Type = " << this->getStrategyType()<< std::endl

--- a/packages/tempus/src/Tempus_TimeStepControlStrategyComposite.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategyComposite.hpp
@@ -69,25 +69,31 @@ public:
     std::string description() const override
     { return "Tempus::TimeStepControlComposite"; }
 
-    void describe(Teuchos::FancyOStream          &in_out,
+    void describe(Teuchos::FancyOStream          &out,
                   const Teuchos::EVerbosityLevel verbLevel) const override
     {
-      auto out = Teuchos::fancyOStream( in_out.getOStream() );
-      out->setOutputToRootOnly(0);
-      Teuchos::OSTab ostab(*out,2,"describe");
-      *out << description() << "::describe:" << std::endl
-           << "Strategy Type = " << this->getStrategyType()<< std::endl
-           << "Step Type     = " << this->getStepType()<< std::endl;
+      auto l_out = Teuchos::fancyOStream( out.getOStream() );
+      Teuchos::OSTab ostab(*l_out, 2, this->description());
+      l_out->setOutputToRootOnly(0);
 
-      std::stringstream sList;
-      for(std::size_t i = 0; i < strategies_.size(); ++i) {
-        sList << strategies_[i]->getStrategyType();
-        if (i < strategies_.size()-1) sList << ", ";
+      *l_out << "--- " << this->description() << " ---" << std::endl;
+
+      if (Teuchos::as<int>(verbLevel) >= Teuchos::as<int>(Teuchos::VERB_MEDIUM)) {
+        *l_out << "  Strategy Type = " << this->getStrategyType()<< std::endl
+             << "  Step Type     = " << this->getStepType()<< std::endl;
+
+        std::stringstream sList;
+        for(std::size_t i = 0; i < strategies_.size(); ++i) {
+          sList << strategies_[i]->getStrategyType();
+          if (i < strategies_.size()-1) sList << ", ";
+        }
+        *l_out << "  Strategy List = " << sList.str() << std::endl;
+
+        for(auto& s : strategies_)
+          s->describe(*l_out, verbLevel);
+
+        *l_out << std::string(this->description().length()+8, '-') <<std::endl;
       }
-      *out << "Strategy List = " << sList.str() << std::endl;
-
-      for(auto& s : strategies_)
-        s->describe(*out, verbLevel);
     }
   //@}
 

--- a/packages/tempus/src/Tempus_TimeStepControlStrategyConstant.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategyConstant.hpp
@@ -67,6 +67,7 @@ public:
 
     RCP<Teuchos::FancyOStream> out = tsc.getOStream();
     Teuchos::OSTab ostab(out,1,"setNextTimeStep");
+    out->setOutputToRootOnly(0);
 
 
     // Check constant time step
@@ -124,11 +125,19 @@ public:
     void describe(Teuchos::FancyOStream          &out,
                   const Teuchos::EVerbosityLevel verbLevel) const override
     {
-      Teuchos::OSTab ostab(out,2,"describe");
-      out << description() << std::endl
-          << "Strategy Type = " << this->getStrategyType() << std::endl
-          << "Step Type     = " << this->getStepType() << std::endl
-          << "Time Step     = " << getConstantTimeStep() << std::endl;
+      auto l_out = Teuchos::fancyOStream( out.getOStream() );
+      Teuchos::OSTab ostab(*l_out, 2, this->description());
+      l_out->setOutputToRootOnly(0);
+
+      *l_out << "--- " << this->description() << " ---" << std::endl;
+
+      if (Teuchos::as<int>(verbLevel) >= Teuchos::as<int>(Teuchos::VERB_MEDIUM)) {
+        *l_out << "  Strategy Type = " << this->getStrategyType() << std::endl
+               << "  Step Type     = " << this->getStepType() << std::endl
+               << "  Time Step     = " << getConstantTimeStep() << std::endl;
+
+        *l_out << std::string(this->description().length()+8, '-') <<std::endl;
+      }
     }
   //@}
 

--- a/packages/tempus/src/Tempus_TimeStepControlStrategyConstant.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategyConstant.hpp
@@ -129,7 +129,7 @@ public:
       Teuchos::OSTab ostab(*l_out, 2, this->description());
       l_out->setOutputToRootOnly(0);
 
-      *l_out << "--- " << this->description() << " ---" << std::endl;
+      *l_out << "\n--- " << this->description() << " ---" << std::endl;
 
       if (Teuchos::as<int>(verbLevel) >= Teuchos::as<int>(Teuchos::VERB_MEDIUM)) {
         *l_out << "  Strategy Type = " << this->getStrategyType() << std::endl

--- a/packages/tempus/src/Tempus_TimeStepControlStrategyIntegralController.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategyIntegralController.hpp
@@ -178,22 +178,29 @@ public:
     void describe(Teuchos::FancyOStream          &out,
                   const Teuchos::EVerbosityLevel verbLevel) const override
     {
-      Teuchos::OSTab ostab(out,2,"describe");
-      out << description() << "::describe:" << std::endl
-          << "Strategy Type                      = " << this->getStrategyType() << std::endl
-          << "Step Type                          = " << this->getStepType()     << std::endl
-          << "Controller Type                    = " << getController()         << std::endl
-          << "KI                                 = " << getKI()                 << std::endl
-          << "KP                                 = " << getKP()                 << std::endl
-          << "KD                                 = " << getKD()                 << std::endl
-          << "errN_                              = " << errN_                   << std::endl
-          << "errNm1_                            = " << errNm1_                 << std::endl
-          << "errNm2_                            = " << errNm2_                 << std::endl
-          << "Safety Factor                      = " << getSafetyFactor()       << std::endl
-          << "Safety Factor After Step Rejection = " << getSafetyFactorAfterReject() << std::endl
-          << "Maximum Safety Factor (INPUT)      = " << facMaxINPUT_            << std::endl
-          << "Maximum Safety Factor              = " << getFacMax()             << std::endl
-          << "Minimum Safety Factor              = " << getFacMin()             << std::endl;
+      auto l_out = Teuchos::fancyOStream( out.getOStream() );
+      Teuchos::OSTab ostab(*l_out, 2, this->description());
+      l_out->setOutputToRootOnly(0);
+
+      *l_out << "--- " << this->description() << " ---" << std::endl;
+
+      if (Teuchos::as<int>(verbLevel) >= Teuchos::as<int>(Teuchos::VERB_MEDIUM)) {
+       *l_out << "  Strategy Type                      = " << this->getStrategyType() << std::endl
+            << "  Step Type                          = " << this->getStepType()     << std::endl
+            << "  Controller Type                    = " << getController()         << std::endl
+            << "  KI                                 = " << getKI()                 << std::endl
+            << "  KP                                 = " << getKP()                 << std::endl
+            << "  KD                                 = " << getKD()                 << std::endl
+            << "  errN_                              = " << errN_                   << std::endl
+            << "  errNm1_                            = " << errNm1_                 << std::endl
+            << "  errNm2_                            = " << errNm2_                 << std::endl
+            << "  Safety Factor                      = " << getSafetyFactor()       << std::endl
+            << "  Safety Factor After Step Rejection = " << getSafetyFactorAfterReject() << std::endl
+            << "  Maximum Safety Factor (INPUT)      = " << facMaxINPUT_            << std::endl
+            << "  Maximum Safety Factor              = " << getFacMax()             << std::endl
+            << "  Minimum Safety Factor              = " << getFacMin()             << std::endl;
+        *l_out << std::string(this->description().length()+8, '-') <<std::endl;
+      }
     }
   //@}
 

--- a/packages/tempus/src/Tempus_TimeStepControlStrategyIntegralController.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategyIntegralController.hpp
@@ -182,7 +182,7 @@ public:
       Teuchos::OSTab ostab(*l_out, 2, this->description());
       l_out->setOutputToRootOnly(0);
 
-      *l_out << "--- " << this->description() << " ---" << std::endl;
+      *l_out << "\n--- " << this->description() << " ---" << std::endl;
 
       if (Teuchos::as<int>(verbLevel) >= Teuchos::as<int>(Teuchos::VERB_MEDIUM)) {
        *l_out << "  Strategy Type                      = " << this->getStrategyType() << std::endl

--- a/packages/tempus/src/Tempus_TimeStepControl_impl.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControl_impl.hpp
@@ -460,8 +460,13 @@ void TimeStepControl<Scalar>::describe(
    Teuchos::FancyOStream               &out,
    const Teuchos::EVerbosityLevel      verbLevel) const
 {
-  if (verbLevel == Teuchos::VERB_EXTREME) {
+  auto l_out = Teuchos::fancyOStream( out.getOStream() );
+  Teuchos::OSTab ostab(*l_out, 2, this->description());
+  l_out->setOutputToRootOnly(0);
 
+  *l_out << "\n--- " << this->description() << " ---" <<std::endl;
+
+  if (Teuchos::as<int>(verbLevel) >= Teuchos::as<int>(Teuchos::VERB_MEDIUM)) {
     std::vector<int> idx = getOutputIndices();
     std::ostringstream listIdx;
     if (!idx.empty()) {
@@ -472,37 +477,36 @@ void TimeStepControl<Scalar>::describe(
     std::vector<Scalar> times = getOutputTimes();
     std::ostringstream listTimes;
     if (!times.empty()) {
-      for(std::size_t i = 0; i < times.size()-1; ++i) listTimes << times[i] << ", ";
+      for(std::size_t i = 0; i < times.size()-1; ++i)
+        listTimes << times[i] << ", ";
       listTimes << times[times.size()-1];
     }
 
-    auto l_out = Teuchos::fancyOStream( out.getOStream() );
-    l_out->setOutputToRootOnly(0);
-    *l_out << description() << "::describe:" << std::endl
-           << "stepType           = " << getStepType()            << std::endl
-           << "initTime           = " << getInitTime()            << std::endl
-           << "finalTime          = " << getFinalTime()           << std::endl
-           << "minTimeStep        = " << getMinTimeStep()         << std::endl
-           << "initTimeStep       = " << getInitTimeStep()        << std::endl
-           << "maxTimeStep        = " << getMaxTimeStep()         << std::endl
-           << "initIndex          = " << getInitIndex()           << std::endl
-           << "finalIndex         = " << getFinalIndex()          << std::endl
-           << "maxAbsError        = " << getMaxAbsError()         << std::endl
-           << "maxRelError        = " << getMaxRelError()         << std::endl
-           << "maxFailures        = " << getMaxFailures()         << std::endl
-           << "maxConsecFailures  = " << getMaxConsecFailures()   << std::endl
-           << "numTimeSteps       = " << getNumTimeSteps()        << std::endl
-           << "printDtChanges     = " << getPrintDtChanges()      << std::endl
-           << "outputExactly      = " << getOutputExactly()       << std::endl
-           << "outputIndices      = " << listIdx.str()            << std::endl
-           << "outputTimes        = " << listTimes.str()          << std::endl
-           << "outputIndexInterval= " << getOutputIndexInterval() << std::endl
-           << "outputTimeInterval = " << getOutputTimeInterval()  << std::endl
-           << "outputAdjustedDt   = " << outputAdjustedDt_        << std::endl
-           << "dtAfterOutput      = " << dtAfterOutput_           << std::endl
-           << "stepControlSrategy = " << std::endl;
-           stepControlStrategy_->describe(out, verbLevel);
+    *l_out << "  stepType           = " << getStepType()            << std::endl
+           << "  initTime           = " << getInitTime()            << std::endl
+           << "  finalTime          = " << getFinalTime()           << std::endl
+           << "  minTimeStep        = " << getMinTimeStep()         << std::endl
+           << "  initTimeStep       = " << getInitTimeStep()        << std::endl
+           << "  maxTimeStep        = " << getMaxTimeStep()         << std::endl
+           << "  initIndex          = " << getInitIndex()           << std::endl
+           << "  finalIndex         = " << getFinalIndex()          << std::endl
+           << "  maxAbsError        = " << getMaxAbsError()         << std::endl
+           << "  maxRelError        = " << getMaxRelError()         << std::endl
+           << "  maxFailures        = " << getMaxFailures()         << std::endl
+           << "  maxConsecFailures  = " << getMaxConsecFailures()   << std::endl
+           << "  numTimeSteps       = " << getNumTimeSteps()        << std::endl
+           << "  printDtChanges     = " << getPrintDtChanges()      << std::endl
+           << "  outputExactly      = " << getOutputExactly()       << std::endl
+           << "  outputIndices      = " << listIdx.str()            << std::endl
+           << "  outputTimes        = " << listTimes.str()          << std::endl
+           << "  outputIndexInterval= " << getOutputIndexInterval() << std::endl
+           << "  outputTimeInterval = " << getOutputTimeInterval()  << std::endl
+           << "  outputAdjustedDt   = " << outputAdjustedDt_        << std::endl
+           << "  dtAfterOutput      = " << dtAfterOutput_           <<std::endl;
+           stepControlStrategy_->describe(*l_out, verbLevel);
   }
+  *l_out << std::string(this->description().length()+8, '-') <<std::endl;
+
 }
 
 

--- a/packages/tempus/test/Integrator/Tempus_IntegratorTest.cpp
+++ b/packages/tempus/test/Integrator/Tempus_IntegratorTest.cpp
@@ -124,9 +124,6 @@ TEUCHOS_UNIT_TEST(IntegratorBasic, Describe)
   integrator->describe(*myOut, Teuchos::VERB_EXTREME);
 
   auto testS = ss.str();
-  //std::cout << "\n\n+++++++++++++++++++++++++++++++++++++++ " << std::endl;
-  //std::cout << testS << std::endl;
-  //std::cout << "+++++++++++++++++++++++++++++++++++++++ " << std::endl;
 
   // Find major headers.
   auto npos = std::string::npos;

--- a/packages/tempus/test/Integrator/Tempus_IntegratorTest.cpp
+++ b/packages/tempus/test/Integrator/Tempus_IntegratorTest.cpp
@@ -27,6 +27,7 @@ using Tempus::IntegratorBasic;
 using Tempus::SolutionHistory;
 using Tempus::SolutionState;
 
+
 // Test Integrator construction from ParameterList and ModelEvaluator.
 TEUCHOS_UNIT_TEST(IntegratorBasic, PL_ME_Construction)
 {
@@ -60,7 +61,7 @@ TEUCHOS_UNIT_TEST(IntegratorBasic, PL_ME_Construction)
 }
 
 
-// Test integator construction, and then setParameterList, setStepper, and
+// Test integrator construction, and then setParameterList, setStepper, and
 // initialization.
 TEUCHOS_UNIT_TEST(IntegratorBasic, Construction)
 {
@@ -101,5 +102,46 @@ TEUCHOS_UNIT_TEST(IntegratorBasic, Construction)
   }
   TEST_ASSERT(pass)
 }
+
+
+TEUCHOS_UNIT_TEST(IntegratorBasic, Describe)
+{
+  // 1) Setup the ParameterList (here we start with params from .xml file)
+  RCP<ParameterList> pl = getParametersFromXmlFile("Tempus_default.xml");
+
+  // 2) Setup the ModelEvaluator
+  RCP<SinCosModel<double> > model = Teuchos::rcp(new SinCosModel<double> ());
+
+  // 3) Setup the Integrator
+  RCP<ParameterList> tempusPL = sublist(pl, "Tempus", true);
+  RCP<Tempus::IntegratorBasic<double> > integrator =
+    Tempus::createIntegratorBasic<double>(tempusPL, model);
+
+  std::ostringstream ss;
+  Teuchos::RCP<Teuchos::FancyOStream> myOut =
+    Teuchos::fancyOStream(Teuchos::rcpFromRef(ss));
+
+  integrator->describe(*myOut, Teuchos::VERB_EXTREME);
+
+  auto testS = ss.str();
+  //std::cout << "\n\n+++++++++++++++++++++++++++++++++++++++ " << std::endl;
+  //std::cout << testS << std::endl;
+  //std::cout << "+++++++++++++++++++++++++++++++++++++++ " << std::endl;
+
+  // Find major headers.
+  auto npos = std::string::npos;
+  TEST_ASSERT(npos != testS.find("--- Tempus::IntegratorBasic ---"));
+  TEST_ASSERT(npos != testS.find("--- Tempus::SolutionHistory"));
+  TEST_ASSERT(npos != testS.find("--- SolutionState (index =     0; time =         0; dt =         1) ---"));
+  TEST_ASSERT(npos != testS.find("--- Tempus::SolutionStateMetaData ---"));
+  TEST_ASSERT(npos != testS.find("--- Tempus::StepperState"));
+  TEST_ASSERT(npos != testS.find("--- Tempus::PhysicsState"));
+  TEST_ASSERT(npos != testS.find("--- Tempus::TimeStepControl ---"));
+  TEST_ASSERT(npos != testS.find("--- Tempus::TimeStepControlStrategyConstant ---"));
+  TEST_ASSERT(npos != testS.find("--- Stepper ---"));
+  TEST_ASSERT(npos != testS.find("stepperType_        = Forward Euler"));
+  TEST_ASSERT(npos != testS.find("--- StepperExplicit ---"));
+}
+
 
 } // namespace Tempus_Test


### PR DESCRIPTION
 * Made a nonmember function, createIntegratorBasic(ParameterList),
   that just takes a ParameterList.  This requires a subsequent
   setModel(ModelEvaluator) call to complete the construction.
   Many bug fixes were needed that were uncovered by separating the
   contruction with a ParamterList followed by setting the model.
    - Backward Euler and BDF2 steppers required specialized
      setModel() functions, because of the secondary steppers
      they use (i.e., predictor stepper and start-up stepper).
    - For RK methods with embedded error control, the necessary
      memory needed to be set after the model is specified.
 * createIntegratorBasic(ParameterList, ModelEvaluator) nows
   calls createIntegratorBasic(ParameterList) and follows with
   a setModel(ModelEvaluator) call.
 * Added getNonConstSolutionHistory() to allow external changes to
   a SolutionHistory.
 * Cleaned up many describe() functions to better handle output.
    - After copying the FancyOStream, the tabbing does not seem to
      propagate to the new FancyOstream.
 * Add a test for IntegratorBasic::describe().


@trilinos/tempus 

## Motivation
Drekar needed a new constructor that only takes the ParameterList.

* Closes #9180 

## Stakeholder Feedback
This request came form @sconde for Drekar, and he is the reviewer.

## Testing
Passes all tests on Mac, and an additional test has been added to cover some objects describe function.
