### PR TITLE
9184 winllvmparbuild: fix winllvm parallel builds with modification to muelu, zoltan2, belos

### DIFF
--- a/packages/belos/src/BelosBiCGStabSolMgr.hpp
+++ b/packages/belos/src/BelosBiCGStabSolMgr.hpp
@@ -284,7 +284,13 @@ namespace Belos {
     static constexpr int defQuorum_default_ = 1;
     static constexpr const char * resScale_default_ = "Norm of Initial Residual";
     static constexpr const char * label_default_ = "Belos";
+// https://stackoverflow.com/questions/24398102/constexpr-and-initialization-of-a-static-const-void-pointer-with-reinterpret-cas
+#if defined(_WIN32) && defined(__clang__)
+    static constexpr std::ostream * outputStream_default_ =
+       __builtin_constant_p(reinterpret_cast<const std::ostream*>(&std::cout));
+#else
     static constexpr std::ostream * outputStream_default_ = &std::cout;
+#endif
 
     // Current solver values.
     MagnitudeType convtol_,achievedTol_;

--- a/packages/belos/src/BelosBlockCGSolMgr.hpp
+++ b/packages/belos/src/BelosBlockCGSolMgr.hpp
@@ -374,7 +374,13 @@ namespace Belos {
     static constexpr const char * label_default_ = "Belos";
     static constexpr const char * orthoType_default_ = "ICGS";
     static constexpr bool assertPositiveDefiniteness_default_ = true;
+// https://stackoverflow.com/questions/24398102/constexpr-and-initialization-of-a-static-const-void-pointer-with-reinterpret-cas
+#if defined(_WIN32) && defined(__clang__)
+    static constexpr std::ostream * outputStream_default_ =
+       __builtin_constant_p(reinterpret_cast<const std::ostream*>(&std::cout));
+#else
     static constexpr std::ostream * outputStream_default_ = &std::cout;
+#endif
 
     //
     // Current solver parameters and other values.

--- a/packages/belos/src/BelosBlockGmresSolMgr.hpp
+++ b/packages/belos/src/BelosBlockGmresSolMgr.hpp
@@ -333,7 +333,13 @@ private:
   static constexpr const char * expResScale_default_ = "Norm of Initial Residual";
   static constexpr const char * label_default_ = "Belos";
   static constexpr const char * orthoType_default_ = "ICGS";
-  static constexpr std::ostream * outputStream_default_ = &std::cout;
+// https://stackoverflow.com/questions/24398102/constexpr-and-initialization-of-a-static-const-void-pointer-with-reinterpret-cas
+#if defined(_WIN32) && defined(__clang__)
+    static constexpr std::ostream * outputStream_default_ =
+       __builtin_constant_p(reinterpret_cast<const std::ostream*>(&std::cout));
+#else
+    static constexpr std::ostream * outputStream_default_ = &std::cout;
+#endif
 
   // Current solver values.
   MagnitudeType convtol_, orthoKappa_, achievedTol_;

--- a/packages/belos/src/BelosFixedPointSolMgr.hpp
+++ b/packages/belos/src/BelosFixedPointSolMgr.hpp
@@ -287,7 +287,13 @@ namespace Belos {
     static constexpr int outputStyle_default_ = Belos::General;
     static constexpr int outputFreq_default_ = -1;
     static constexpr const char * label_default_ = "Belos";
+// https://stackoverflow.com/questions/24398102/constexpr-and-initialization-of-a-static-const-void-pointer-with-reinterpret-cas
+#if defined(_WIN32) && defined(__clang__)
+    static constexpr std::ostream * outputStream_default_ =
+       __builtin_constant_p(reinterpret_cast<const std::ostream*>(&std::cout));
+#else
     static constexpr std::ostream * outputStream_default_ = &std::cout;
+#endif
 
     //
     // Current solver parameters and other values.

--- a/packages/belos/src/BelosGCRODRSolMgr.hpp
+++ b/packages/belos/src/BelosGCRODRSolMgr.hpp
@@ -470,7 +470,13 @@ Systems," SIAM Journal on Scientific Computing, 28(5), pp. 1651-1674,
     static constexpr const char * expResScale_default_ = "Norm of Initial Residual";
     static constexpr const char * label_default_ = "Belos";
     static constexpr const char * orthoType_default_ = "ICGS";
+// https://stackoverflow.com/questions/24398102/constexpr-and-initialization-of-a-static-const-void-pointer-with-reinterpret-cas
+#if defined(_WIN32) && defined(__clang__)
+    static constexpr std::ostream * outputStream_default_ =
+       __builtin_constant_p(reinterpret_cast<const std::ostream*>(&std::cout));
+#else
     static constexpr std::ostream * outputStream_default_ = &std::cout;
+#endif
 
     // Current solver values.
     MagnitudeType convTol_, orthoKappa_, achievedTol_;

--- a/packages/belos/src/BelosGmresPolyOp.hpp
+++ b/packages/belos/src/BelosGmresPolyOp.hpp
@@ -302,7 +302,13 @@ namespace Belos {
     static constexpr const char * label_default_ = "Belos";
     static constexpr const char * polyType_default_ = "Roots";
     static constexpr const char * orthoType_default_ = "DGKS";
+// https://stackoverflow.com/questions/24398102/constexpr-and-initialization-of-a-static-const-void-pointer-with-reinterpret-cas
+#if defined(_WIN32) && defined(__clang__)
+    static constexpr std::ostream * outputStream_default_ =
+       __builtin_constant_p(reinterpret_cast<const std::ostream*>(&std::cout));
+#else
     static constexpr std::ostream * outputStream_default_ = &std::cout;
+#endif
     static constexpr bool damp_default_ = false;
     static constexpr bool addRoots_default_ = true;
 

--- a/packages/belos/src/BelosGmresPolySolMgr.hpp
+++ b/packages/belos/src/BelosGmresPolySolMgr.hpp
@@ -322,7 +322,13 @@ private:
   static constexpr bool addRoots_default_ = true;
   static constexpr bool dampPoly_default_ = false;
   static constexpr bool randomRHS_default_ = true; 
-  static constexpr std::ostream * outputStream_default_ = &std::cout;
+// https://stackoverflow.com/questions/24398102/constexpr-and-initialization-of-a-static-const-void-pointer-with-reinterpret-cas
+#if defined(_WIN32) && defined(__clang__)
+    static constexpr std::ostream * outputStream_default_ =
+       __builtin_constant_p(reinterpret_cast<const std::ostream*>(&std::cout));
+#else
+    static constexpr std::ostream * outputStream_default_ = &std::cout;
+#endif
 
   // Current solver values.
   MagnitudeType polyTol_;

--- a/packages/belos/src/BelosPCPGSolMgr.hpp
+++ b/packages/belos/src/BelosPCPGSolMgr.hpp
@@ -378,7 +378,13 @@ namespace Belos {
     static constexpr int outputFreq_default_ = -1;
     static constexpr const char * label_default_ = "Belos";
     static constexpr const char * orthoType_default_ = "ICGS";
+// https://stackoverflow.com/questions/24398102/constexpr-and-initialization-of-a-static-const-void-pointer-with-reinterpret-cas
+#if defined(_WIN32) && defined(__clang__)
+    static constexpr std::ostream * outputStream_default_ =
+       __builtin_constant_p(reinterpret_cast<const std::ostream*>(&std::cout));
+#else
     static constexpr std::ostream * outputStream_default_ = &std::cout;
+#endif
 
     //
     // Current solver values.

--- a/packages/belos/src/BelosPseudoBlockCGSolMgr.hpp
+++ b/packages/belos/src/BelosPseudoBlockCGSolMgr.hpp
@@ -340,7 +340,13 @@ namespace Belos {
     static constexpr bool foldConvergenceDetectionIntoAllreduce_default_ = false;
     static constexpr const char * resScale_default_ = "Norm of Initial Residual";
     static constexpr const char * label_default_ = "Belos";
+// https://stackoverflow.com/questions/24398102/constexpr-and-initialization-of-a-static-const-void-pointer-with-reinterpret-cas
+#if defined(_WIN32) && defined(__clang__)
+    static constexpr std::ostream * outputStream_default_ =
+       __builtin_constant_p(reinterpret_cast<const std::ostream*>(&std::cout));
+#else
     static constexpr std::ostream * outputStream_default_ = &std::cout;
+#endif
     static constexpr bool genCondEst_default_ = false;
 
     // Current solver values.

--- a/packages/belos/src/BelosPseudoBlockGmresSolMgr.hpp
+++ b/packages/belos/src/BelosPseudoBlockGmresSolMgr.hpp
@@ -502,7 +502,13 @@ namespace Belos {
     static constexpr const char * expResScale_default_ = "Norm of Initial Residual";
     static constexpr const char * label_default_ = "Belos";
     static constexpr const char * orthoType_default_ = "ICGS";
+// https://stackoverflow.com/questions/24398102/constexpr-and-initialization-of-a-static-const-void-pointer-with-reinterpret-cas
+#if defined(_WIN32) && defined(__clang__)
+    static constexpr std::ostream * outputStream_default_ =
+       __builtin_constant_p(reinterpret_cast<const std::ostream*>(&std::cout));
+#else
     static constexpr std::ostream * outputStream_default_ = &std::cout;
+#endif
 
     // Current solver values.
     MagnitudeType convtol_, orthoKappa_, achievedTol_;

--- a/packages/belos/src/BelosPseudoBlockStochasticCGSolMgr.hpp
+++ b/packages/belos/src/BelosPseudoBlockStochasticCGSolMgr.hpp
@@ -266,7 +266,13 @@ namespace Belos {
     static constexpr int defQuorum_default_ = 1;
     static constexpr const char * resScale_default_ = "Norm of Initial Residual";
     static constexpr const char * label_default_ = "Belos";
+// https://stackoverflow.com/questions/24398102/constexpr-and-initialization-of-a-static-const-void-pointer-with-reinterpret-cas
+#if defined(_WIN32) && defined(__clang__)
+    static constexpr std::ostream * outputStream_default_ =
+       __builtin_constant_p(reinterpret_cast<const std::ostream*>(&std::cout));
+#else
     static constexpr std::ostream * outputStream_default_ = &std::cout;
+#endif
 
     // Current solver values.
     MagnitudeType convtol_;

--- a/packages/belos/src/BelosPseudoBlockTFQMRSolMgr.hpp
+++ b/packages/belos/src/BelosPseudoBlockTFQMRSolMgr.hpp
@@ -280,7 +280,13 @@ namespace Belos {
     static constexpr const char * impResScale_default_ = "Norm of Preconditioned Initial Residual";
     static constexpr const char * expResScale_default_ = "Norm of Initial Residual";
     static constexpr const char * label_default_ = "Belos";
+// https://stackoverflow.com/questions/24398102/constexpr-and-initialization-of-a-static-const-void-pointer-with-reinterpret-cas
+#if defined(_WIN32) && defined(__clang__)
+    static constexpr std::ostream * outputStream_default_ =
+       __builtin_constant_p(reinterpret_cast<const std::ostream*>(&std::cout));
+#else
     static constexpr std::ostream * outputStream_default_ = &std::cout;
+#endif
 
     // Current solver values.
     MagnitudeType convtol_, impTolScale_, achievedTol_;

--- a/packages/belos/src/BelosRCGSolMgr.hpp
+++ b/packages/belos/src/BelosRCGSolMgr.hpp
@@ -373,7 +373,13 @@ namespace Belos {
     static constexpr int outputStyle_default_ = Belos::General;
     static constexpr int outputFreq_default_ = -1;
     static constexpr const char * label_default_ = "Belos";
+// https://stackoverflow.com/questions/24398102/constexpr-and-initialization-of-a-static-const-void-pointer-with-reinterpret-cas
+#if defined(_WIN32) && defined(__clang__)
+    static constexpr std::ostream * outputStream_default_ =
+       __builtin_constant_p(reinterpret_cast<const std::ostream*>(&std::cout));
+#else
     static constexpr std::ostream * outputStream_default_ = &std::cout;
+#endif
 
     //
     // Current solver values.

--- a/packages/belos/src/BelosTFQMRSolMgr.hpp
+++ b/packages/belos/src/BelosTFQMRSolMgr.hpp
@@ -279,7 +279,13 @@ namespace Belos {
     static constexpr const char * impResScale_default_ = "Norm of Preconditioned Initial Residual";
     static constexpr const char * expResScale_default_ = "Norm of Initial Residual";
     static constexpr const char * label_default_ = "Belos";
+// https://stackoverflow.com/questions/24398102/constexpr-and-initialization-of-a-static-const-void-pointer-with-reinterpret-cas
+#if defined(_WIN32) && defined(__clang__)
+    static constexpr std::ostream * outputStream_default_ =
+       __builtin_constant_p(reinterpret_cast<const std::ostream*>(&std::cout));
+#else
     static constexpr std::ostream * outputStream_default_ = &std::cout;
+#endif
 
     // Current solver values.
     MagnitudeType convtol_, impTolScale_, achievedTol_;

--- a/packages/muelu/src/Utils/MueLu_Utilities.cpp
+++ b/packages/muelu/src/Utils/MueLu_Utilities.cpp
@@ -54,8 +54,12 @@
 
 #ifdef HAVE_MPI
 #include <mpi.h>
+#ifdef _WIN32
+#include <winsock2.h>
+#else
 #include <netdb.h>
 #include <arpa/inet.h>
+#endif
 #endif
 
 
@@ -265,7 +269,7 @@ bool IsParamValidVariable(const std::string& name)
        int len;
        MPI_Get_processor_name(hostname,&len);
        struct hostent * host = gethostbyname(hostname);
-       int myaddr = (int) htonl(inet_network(inet_ntoa(*(struct in_addr *)host->h_addr)));
+       int myaddr = (int) inet_addr(inet_ntoa(*(struct in_addr *)host->h_addr));
 
        // All-to-all exchange of address integers
        std::vector<int> addressList(numRanks);

--- a/packages/zoltan2/core/src/algorithms/color/Zoltan2_AlgHybrid2GL.hpp
+++ b/packages/zoltan2/core/src/algorithms/color/Zoltan2_AlgHybrid2GL.hpp
@@ -5,7 +5,11 @@
 #include <unordered_map>
 #include <iostream>
 #include <queue>
+#ifdef _WIN32
+#include <time.h>
+#else
 #include <sys/time.h>
+#endif
 
 #include "Zoltan2_Algorithm.hpp"
 #include "Zoltan2_GraphModel.hpp"

--- a/packages/zoltan2/core/src/algorithms/color/Zoltan2_AlgHybridD1-2GL.hpp
+++ b/packages/zoltan2/core/src/algorithms/color/Zoltan2_AlgHybridD1-2GL.hpp
@@ -5,7 +5,11 @@
 #include <unordered_map>
 #include <iostream>
 #include <queue>
+#ifdef _WIN32
+#include <time.h>
+#else
 #include <sys/time.h>
+#endif
 
 #include "Zoltan2_Algorithm.hpp"
 #include "Zoltan2_GraphModel.hpp"

--- a/packages/zoltan2/core/src/algorithms/color/Zoltan2_AlgHybridD1.hpp
+++ b/packages/zoltan2/core/src/algorithms/color/Zoltan2_AlgHybridD1.hpp
@@ -6,7 +6,11 @@
 #include <iostream>
 #include <fstream>
 #include <queue>
+#ifdef _WIN32
+#include <time.h>
+#else
 #include <sys/time.h>
+#endif
 #include <algorithm>
 
 #include "Zoltan2_Algorithm.hpp"

--- a/packages/zoltan2/core/src/algorithms/color/Zoltan2_AlgHybridD2.hpp
+++ b/packages/zoltan2/core/src/algorithms/color/Zoltan2_AlgHybridD2.hpp
@@ -5,7 +5,11 @@
 #include <unordered_map>
 #include <iostream>
 #include <queue>
+#ifdef _WIN32
+#include <time.h>
+#else
 #include <sys/time.h>
+#endif
 
 #include "Zoltan2_Algorithm.hpp"
 #include "Zoltan2_GraphModel.hpp"

--- a/packages/zoltan2/core/src/algorithms/color/Zoltan2_AlgHybridPD2.hpp
+++ b/packages/zoltan2/core/src/algorithms/color/Zoltan2_AlgHybridPD2.hpp
@@ -5,7 +5,11 @@
 #include <unordered_map>
 #include <iostream>
 #include <queue>
+#ifdef _WIN32
+#include <time.h>
+#else
 #include <sys/time.h>
+#endif
 
 #include "Zoltan2_Algorithm.hpp"
 #include "Zoltan2_GraphModel.hpp"

--- a/packages/zoltan2/core/src/input/Zoltan2_InputTraits.hpp
+++ b/packages/zoltan2/core/src/input/Zoltan2_InputTraits.hpp
@@ -211,6 +211,10 @@ struct InputTraits {
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
+#ifdef _MSC_VER
+  typedef SSIZE_T ssize_t;
+#endif
+
 // This combination of macros is used to define a single line
 // Z2_STATIC_ASSERT_TYPES for each InputTraits with custom template types
 #define Z2_ISSAME(s,type) (std::is_same< s, type >::value)


### PR DESCRIPTION
@trilinos/belos
@trilinos/zoltan2
@trilinos/muelu

## Motivation
Failure to build on Windows with LLVM

Closes issues #8202 and #9184

The problems were:

Belos: uses addressof to create a constexpr, which is not allowed, but for which there is a workaround.

Zoltan2: Need to use time.h instead of sys/time.h on Windows.  Need to define ssize_t on Windows.

MueLu: Need implementation to get host-order IP address without using inet_network, which does not exist on windows.
