### PR TITLE
Tempus: Unable to Reconcile Inherited Objects

### DIFF
--- a/packages/tempus/src/Tempus_IntegratorBasic_decl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorBasic_decl.hpp
@@ -187,6 +187,12 @@ public:
   /// Get the Integrator Type.
   std::string getIntegratorType() const { return integratorType_; }
 
+  /// Get isInitialized.
+  bool getIsInitialized() const { return isInitialized_; }
+
+  /// Make a shallow copy from another IntegratorBasic.
+  virtual void copy(Teuchos::RCP<IntegratorBasic<Scalar> > integrator);
+
 protected:
 
   /// Set the Integrator Type

--- a/packages/tempus/src/Tempus_IntegratorBasic_decl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorBasic_decl.hpp
@@ -43,6 +43,13 @@ public:
     std::vector<int>                          outputScreenIndices,
     int                                       outputScreenInterval);
 
+#ifndef TEMPUS_HIDE_DEPRECATED_CODE
+  /// Old Constructor with ParameterList and model, and will be fully initialized.
+  IntegratorBasic(
+    Teuchos::RCP<Teuchos::ParameterList>                inputPL,
+    const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model);
+#endif
+
   /// Destructor
   virtual ~IntegratorBasic() {}
 

--- a/packages/tempus/src/Tempus_IntegratorBasic_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorBasic_impl.hpp
@@ -71,7 +71,7 @@ IntegratorBasic<Scalar>::IntegratorBasic(
   Teuchos::RCP<Teuchos::ParameterList>                inputPL,
   const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model)
 {
-  *this = *createIntegratorBasic(inputPL, model);
+  this->copy(createIntegratorBasic(inputPL, model));
 }
 #endif
 
@@ -556,6 +556,26 @@ IntegratorBasic<Scalar>::getValidParameters() const
   tempusPL->set(stepper_->getStepperName(), *stepper_->getValidParameters());
 
   return tempusPL;
+}
+
+
+// Shallow copy.
+template<class Scalar>
+void IntegratorBasic<Scalar>::copy(
+  Teuchos::RCP<IntegratorBasic<Scalar> > integrator)
+{
+  this->setIntegratorName     (integrator->getIntegratorName() );
+  this->setIntegratorType     (integrator->getIntegratorType() );
+  this->setStepper            (integrator->getStepper()        );
+  this->setSolutionHistory    (Teuchos::rcp_const_cast<SolutionHistory<Scalar> >(integrator->getSolutionHistory()));
+  this->setTimeStepControl    (Teuchos::rcp_const_cast<TimeStepControl<Scalar> >(integrator->getTimeStepControl()));
+  this->integratorObserver_ = (integrator->getObserver()       );
+  this->setScreenOutputIndexList    (integrator->getScreenOutputIndexList());
+  this->setScreenOutputIndexInterval(integrator->getScreenOutputIndexInterval());
+  this->integratorStatus_   = (integrator->getStatus()         );
+  this->isInitialized_      = (integrator->getIsInitialized()  );
+  this->integratorTimer_    = (integrator->getIntegratorTimer());
+  this->stepperTimer_       = (integrator->getStepperTimer()   );
 }
 
 

--- a/packages/tempus/src/Tempus_IntegratorBasic_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorBasic_impl.hpp
@@ -63,6 +63,19 @@ IntegratorBasic<Scalar>::IntegratorBasic(
 }
 
 
+#ifndef TEMPUS_HIDE_DEPRECATED_CODE
+// This is just a wrapper to the nonmember constructor to circumvent
+// a compiler problem of reconciling objects through Teuchos::RCPs.
+template<class Scalar>
+IntegratorBasic<Scalar>::IntegratorBasic(
+  Teuchos::RCP<Teuchos::ParameterList>                inputPL,
+  const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model)
+{
+  *this = *createIntegratorBasic(inputPL, model);
+}
+#endif
+
+
 template<class Scalar>
 void IntegratorBasic<Scalar>::setIntegratorType(std::string i)
 {

--- a/packages/tempus/test/Integrator/Tempus_IntegratorTest.cpp
+++ b/packages/tempus/test/Integrator/Tempus_IntegratorTest.cpp
@@ -51,13 +51,42 @@ TEUCHOS_UNIT_TEST(IntegratorBasic, PL_ME_Construction)
     getParametersFromXmlFile("Tempus_IntegratorBasic_ref.xml");
 
   bool pass = haveSameValuesSorted(*testPL, *referencePL, true);
-  if (!pass) {
-    std::cout << std::endl;
-    std::cout << "testPL      -------------- \n" << *testPL << std::endl;
-    std::cout << "referencePL -------------- \n" << *referencePL << std::endl;
-  }
+  out << std::endl;
+  out << "testPL      -------------- \n" << *testPL << std::endl;
+  out << "referencePL -------------- \n" << *referencePL << std::endl;
   TEST_ASSERT(pass)
 }
+
+#ifndef TEMPUS_HIDE_DEPRECATED_CODE
+// Test OLD Integrator construction from ParameterList and ModelEvaluator.
+TEUCHOS_UNIT_TEST(IntegratorBasic, PL_ME_Construction_DEP)
+{
+  // 1) Setup the ParameterList (here we start with params from .xml file)
+  RCP<ParameterList> pl = getParametersFromXmlFile("Tempus_default.xml");
+
+  // 2) Setup the ModelEvaluator
+  RCP<SinCosModel<double> > model = Teuchos::rcp(new SinCosModel<double> ());
+
+  // 3) Setup the Integrator
+  RCP<ParameterList> tempusPL = sublist(pl, "Tempus", true);
+  auto integrator = rcp(new Tempus::IntegratorBasic<double>(tempusPL, model));
+
+  // Test the ParameterList
+  auto testPL = integrator->getValidParameters();
+  // Write out ParameterList to rebaseline test.
+  //writeParameterListToXmlFile(*testPL, "Tempus_IntegratorBasic_ref-test.xml");
+
+  // Read params from reference .xml file
+  RCP<ParameterList> referencePL =
+    getParametersFromXmlFile("Tempus_IntegratorBasic_ref.xml");
+
+  bool pass = haveSameValuesSorted(*testPL, *referencePL, true);
+  out << std::endl;
+  out << "testPL      -------------- \n" << *testPL << std::endl;
+  out << "referencePL -------------- \n" << *referencePL << std::endl;
+  TEST_ASSERT(pass)
+}
+#endif
 
 
 // Test integator construction, and then setParameterList, setStepper, and
@@ -94,11 +123,9 @@ TEUCHOS_UNIT_TEST(IntegratorBasic, Construction)
     getParametersFromXmlFile("Tempus_IntegratorBasic_ref2.xml");
 
   bool pass = haveSameValuesSorted(*testPL, *referencePL, true);
-  if (!pass) {
-    std::cout << std::endl;
-    std::cout << "testPL      -------------- \n" << *testPL << std::endl;
-    std::cout << "referencePL -------------- \n" << *referencePL << std::endl;
-  }
+  out << std::endl;
+  out << "testPL      -------------- \n" << *testPL << std::endl;
+  out << "referencePL -------------- \n" << *referencePL << std::endl;
   TEST_ASSERT(pass)
 }
 


### PR DESCRIPTION
Reinstate a IntegratorBasic constructor to work around an issue
where compilers cannot reconcile inherited objects (possibly due
to being within a Teuchos:RCP).

@trilinos/tempus 

## Motivation
Provide a work around so compiler can work around issue in reconciling inherited objects through
the argument list.  This is possibly due to being within a Teuchos:RCP.

* Closes #9188 


## Stakeholder Feedback
@dridzal reported and is the reviewer.

## Testing
Added a test to cover the new constructor, and will ask @dridzal to test it in his application.
