### PR TITLE
Teuchos and Kokkos: adding support for long double ScalarType

### DIFF
--- a/packages/kokkos/algorithms/src/Kokkos_Random.hpp
+++ b/packages/kokkos/algorithms/src/Kokkos_Random.hpp
@@ -494,6 +494,7 @@ struct rand<Generator, double> {
   }
 };
 
+#ifndef KOKKOS_ENABLE_CUDA
 template <class Generator>
 struct rand<Generator, long double> {
   KOKKOS_INLINE_FUNCTION
@@ -509,6 +510,7 @@ struct rand<Generator, long double> {
     return gen.ldrand(start, end);
   }
 };
+#endif
 
 template <class Generator>
 struct rand<Generator, Kokkos::complex<float> > {
@@ -863,6 +865,7 @@ class Random_XorShift64 {
     return drand(end - start) + start;
   }
 
+#ifndef KOKKOS_ENABLE_CUDA
   KOKKOS_INLINE_FUNCTION
   long double ldrand() { return urand64() / static_cast<long double>(MAX_URAND64); }
 
@@ -875,6 +878,7 @@ class Random_XorShift64 {
   double ldrand(const long double& start, const long double& end) {
     return ldrand(end - start) + start;
   }
+#endif
 
   // Marsaglia polar method for drawing a standard normal distributed random
   // number

--- a/packages/kokkos/algorithms/src/Kokkos_Random.hpp
+++ b/packages/kokkos/algorithms/src/Kokkos_Random.hpp
@@ -210,6 +210,21 @@ namespace Kokkos {
     KOKKOS_INLINE_FUNCTION
     double drand(const double& start, const double& end );
 
+    //Draw a equidistributed long double in the range [0,1.0)
+    KOKKOS_INLINE_FUNCTION
+    long double ldrand();
+
+    //Draw a equidistributed long double in the range [0,range)
+    KOKKOS_INLINE_FUNCTION
+    long double ldrand(const long double& range);
+
+    //Draw a equidistributed long double in the range [start,end)
+    KOKKOS_INLINE_FUNCTION
+    long double ldrand(const long double& start, const long double& end );
+
+    //Draw a standard normal distributed double
+    KOKKOS_INLINE_FUNCTION
+    double normal() ;
     //Draw a standard normal distributed double
     KOKKOS_INLINE_FUNCTION
     double normal() ;
@@ -476,6 +491,22 @@ struct rand<Generator, double> {
   KOKKOS_INLINE_FUNCTION
   static double draw(Generator& gen, const double& start, const double& end) {
     return gen.drand(start, end);
+  }
+};
+
+template <class Generator>
+struct rand<Generator, long double> {
+  KOKKOS_INLINE_FUNCTION
+  static long double max() { return 1.0; }
+  KOKKOS_INLINE_FUNCTION
+  static long double draw(Generator& gen) { return gen.ldrand(); }
+  KOKKOS_INLINE_FUNCTION
+  static long double draw(Generator& gen, const long double& range) {
+    return gen.ldrand(range);
+  }
+  KOKKOS_INLINE_FUNCTION
+  static long double draw(Generator& gen, const long double& start, const long double& end) {
+    return gen.ldrand(start, end);
   }
 };
 
@@ -830,6 +861,19 @@ class Random_XorShift64 {
   KOKKOS_INLINE_FUNCTION
   double drand(const double& start, const double& end) {
     return drand(end - start) + start;
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  long double ldrand() { return urand64() / static_cast<long double>(MAX_URAND64); }
+
+  KOKKOS_INLINE_FUNCTION
+  long double ldrand(const long double& range) {
+    return range * urand64() / static_cast<long double>(MAX_URAND64);
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  double ldrand(const long double& start, const long double& end) {
+    return ldrand(end - start) + start;
   }
 
   // Marsaglia polar method for drawing a standard normal distributed random

--- a/packages/kokkos/algorithms/src/Kokkos_Random.hpp
+++ b/packages/kokkos/algorithms/src/Kokkos_Random.hpp
@@ -210,21 +210,6 @@ namespace Kokkos {
     KOKKOS_INLINE_FUNCTION
     double drand(const double& start, const double& end );
 
-    //Draw a equidistributed long double in the range [0,1.0)
-    KOKKOS_INLINE_FUNCTION
-    long double ldrand();
-
-    //Draw a equidistributed long double in the range [0,range)
-    KOKKOS_INLINE_FUNCTION
-    long double ldrand(const long double& range);
-
-    //Draw a equidistributed long double in the range [start,end)
-    KOKKOS_INLINE_FUNCTION
-    long double ldrand(const long double& start, const long double& end );
-
-    //Draw a standard normal distributed double
-    KOKKOS_INLINE_FUNCTION
-    double normal() ;
     //Draw a standard normal distributed double
     KOKKOS_INLINE_FUNCTION
     double normal() ;
@@ -493,24 +478,6 @@ struct rand<Generator, double> {
     return gen.drand(start, end);
   }
 };
-
-#ifndef KOKKOS_ENABLE_CUDA
-template <class Generator>
-struct rand<Generator, long double> {
-  KOKKOS_INLINE_FUNCTION
-  static long double max() { return 1.0; }
-  KOKKOS_INLINE_FUNCTION
-  static long double draw(Generator& gen) { return gen.ldrand(); }
-  KOKKOS_INLINE_FUNCTION
-  static long double draw(Generator& gen, const long double& range) {
-    return gen.ldrand(range);
-  }
-  KOKKOS_INLINE_FUNCTION
-  static long double draw(Generator& gen, const long double& start, const long double& end) {
-    return gen.ldrand(start, end);
-  }
-};
-#endif
 
 template <class Generator>
 struct rand<Generator, Kokkos::complex<float> > {
@@ -864,21 +831,6 @@ class Random_XorShift64 {
   double drand(const double& start, const double& end) {
     return drand(end - start) + start;
   }
-
-#ifndef KOKKOS_ENABLE_CUDA
-  KOKKOS_INLINE_FUNCTION
-  long double ldrand() { return urand64() / static_cast<long double>(MAX_URAND64); }
-
-  KOKKOS_INLINE_FUNCTION
-  long double ldrand(const long double& range) {
-    return range * urand64() / static_cast<long double>(MAX_URAND64);
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  double ldrand(const long double& start, const long double& end) {
-    return ldrand(end - start) + start;
-  }
-#endif
 
   // Marsaglia polar method for drawing a standard normal distributed random
   // number

--- a/packages/teuchos/comm/src/Teuchos_SerializationTraits.hpp
+++ b/packages/teuchos/comm/src/Teuchos_SerializationTraits.hpp
@@ -91,7 +91,7 @@ struct UndefinedSerializationTraits {
  *
  * Teuchos defines specializations of this class for many commonly
  * used types in distributed-memory communication, such as char, int
- * (signed and unsigned), float, double, and std::pair<P1, P2> for
+ * (signed and unsigned), float, double, long double and std::pair<P1, P2> for
  * certain types P1 and P2.  Depending on your Trilinos build options,
  * other specializations may be defined as well, for example for long
  * long int, double-double and quad-double real types (dd_real
@@ -413,6 +413,12 @@ template<typename Ordinal>
 class SerializationTraits<Ordinal,double>
   : public DirectSerializationTraits<Ordinal,double>
 {};
+
+template<typename Ordinal>
+class SerializationTraits<Ordinal,long double>
+  : public DirectSerializationTraits<Ordinal,long double>
+{};
+
 
 // FIXME: How do we know that P1 and P2 are directly serializable?
 template<typename Ordinal, typename P1, typename P2>

--- a/packages/teuchos/comm/src/Teuchos_SerializationTraits.hpp
+++ b/packages/teuchos/comm/src/Teuchos_SerializationTraits.hpp
@@ -92,7 +92,8 @@ struct UndefinedSerializationTraits {
  * Teuchos defines specializations of this class for many commonly
  * used types in distributed-memory communication, such as char, int
  * (signed and unsigned), float, double, long double and std::pair<P1, P2> for
- * certain types P1 and P2.  Depending on your Trilinos build options,
+ * certain types P1 and P2.  Note that long double does not work with Kokkos + CUDA. 
+ * Depending on your Trilinos build options,
  * other specializations may be defined as well, for example for long
  * long int, double-double and quad-double real types (dd_real
  * resp. qd_real), or certain std::complex<T> specializations.  If a
@@ -414,11 +415,12 @@ class SerializationTraits<Ordinal,double>
   : public DirectSerializationTraits<Ordinal,double>
 {};
 
+#ifndef Kokkos_ENABLE_CUDA
 template<typename Ordinal>
 class SerializationTraits<Ordinal,long double>
   : public DirectSerializationTraits<Ordinal,long double>
 {};
-
+#endif
 
 // FIXME: How do we know that P1 and P2 are directly serializable?
 template<typename Ordinal, typename P1, typename P2>

--- a/packages/teuchos/core/src/Teuchos_ScalarTraits.hpp
+++ b/packages/teuchos/core/src/Teuchos_ScalarTraits.hpp
@@ -783,6 +783,99 @@ struct ScalarTraits<double>
 };
 
 
+template<>
+struct ScalarTraits<long double>
+{
+  typedef long double magnitudeType;
+  typedef double halfPrecision;
+  typedef double doublePrecision;    
+  typedef long double coordinateType;
+  static const bool isComplex = false;
+  static const bool isOrdinal = false;
+  static const bool isComparable = true;
+  static const bool hasMachineParameters = true;
+  static inline long double eps()   {
+    return std::numeric_limits<long double>::epsilon();
+  }
+  static inline long double sfmin() {
+    return std::numeric_limits<long double>::min();
+  }
+  static inline long double base()  {
+    return std::numeric_limits<long double>::radix;
+  }
+  static inline long double prec()  {
+    return eps()*base();
+  }
+  static inline long double t()     {
+    return std::numeric_limits<long double>::digits;
+  }
+  static inline long double rnd()   {
+    return ( std::numeric_limits<long double>::round_style == std::round_to_nearest ? (long double)(1.0) : (long double)(0.0) );
+  }
+  static inline long double emin()  {
+    return std::numeric_limits<long double>::min_exponent;
+  }
+  static inline long double rmin()  {
+    return std::numeric_limits<long double>::min();
+  }
+  static inline long double emax()  {
+    return std::numeric_limits<long double>::max_exponent;
+  }
+  static inline long double rmax()  {
+    return std::numeric_limits<long double>::max();
+  }
+  static inline magnitudeType magnitude(long double a)
+    {
+#ifdef TEUCHOS_DEBUG
+      TEUCHOS_SCALAR_TRAITS_NAN_INF_ERR(
+        a, "Error, the input value to magnitude(...) a = " << a << " can not be NaN!" );
+#endif
+      return std::fabs(a);
+    }
+  static inline long double zero()  { return 0.0; }
+  static inline long double one()   { return 1.0; }
+  static inline long double conjugate(long double x)   { return(x); }
+  static inline long double real(long double x) { return(x); }
+  static inline long double imag(long double) { return(0); }
+  static inline long double nan() {
+#ifdef __sun
+    return 0.0/std::sin(0.0);
+#else
+    return std::numeric_limits<long double>::quiet_NaN();
+#endif
+  }
+  static inline bool isnaninf(long double x) {
+    return generic_real_isnaninf<long double>(x);
+  }
+  static inline void seedrandom(unsigned int s) {
+    std::srand(s);
+#ifdef __APPLE__
+    // throw away first random number to address bug 3655
+    // http://software.sandia.gov/bugzilla/show_bug.cgi?id=3655
+    random();
+#endif
+  }
+  static inline long double random() { long double rnd = (long double) std::rand() / RAND_MAX; return (long double)(-1.0 + 2.0 * rnd); }
+  static inline std::string name() { return "long double"; }
+  static inline long double squareroot(long double x)
+    {
+#ifdef TEUCHOS_DEBUG
+      TEUCHOS_SCALAR_TRAITS_NAN_INF_ERR(
+        x, "Error, the input value to squareroot(...) x = " << x << " can not be NaN!" );
+#endif
+      errno = 0;
+      const long double rtn = std::sqrt(x);
+      if (errno)
+        return nan();
+      return rtn;
+    }
+  static inline long double pow(long double x, long double y) { return std::pow(x,y); }
+  static inline long double pi() { return 3.14159265358979323846264338327950288419716939937510; }
+  static inline long double log(double x) { return std::log(x); }
+  static inline long double log10(double x) { return std::log10(x); }
+};
+
+
 #ifdef HAVE_TEUCHOSCORE_QUADMATH
 
 template<>

--- a/packages/teuchos/core/src/Teuchos_ScalarTraits.hpp
+++ b/packages/teuchos/core/src/Teuchos_ScalarTraits.hpp
@@ -783,6 +783,7 @@ struct ScalarTraits<double>
 };
 
 
+#ifndef Kokkos_ENABLE_CUDA
 template<>
 struct ScalarTraits<long double>
 {
@@ -874,7 +875,7 @@ struct ScalarTraits<long double>
   static inline long double log(double x) { return std::log(x); }
   static inline long double log10(double x) { return std::log10(x); }
 };
-
+#endif
 
 #ifdef HAVE_TEUCHOSCORE_QUADMATH
 


### PR DESCRIPTION
This capability is needed for Alegra and currently supports a build with ETI off. 