### PR TITLE
Zoltan2: (Coloring) Fixed D1 performance bug, added timing argument to coloring code

### DIFF
--- a/packages/zoltan2/core/src/algorithms/color/Zoltan2_AlgHybridD1-2GL.hpp
+++ b/packages/zoltan2/core/src/algorithms/color/Zoltan2_AlgHybridD1-2GL.hpp
@@ -210,7 +210,9 @@ class AlgDistance1TwoGhostLayer : public AlgTwoGhostLayer<Adapter> {
         }
       },recoloringSize(0));
       Kokkos::fence();
-      Kokkos::parallel_for(femv_colors.size(), KOKKOS_LAMBDA (const size_t& i){
+      Kokkos::parallel_for("rebuild verts_to_send and verts_to_recolor",
+		           Kokkos::RangePolicy<ExecutionSpace>(0,femv_colors.size()), 
+			   KOKKOS_LAMBDA (const size_t& i){
         if(femv_colors(i) == 0){
           if(i < n_local){
             verts_to_send_view(verts_to_send_size_atomic(0)++) = i;

--- a/packages/zoltan2/core/src/algorithms/color/Zoltan2_AlgHybridD1.hpp
+++ b/packages/zoltan2/core/src/algorithms/color/Zoltan2_AlgHybridD1.hpp
@@ -232,11 +232,13 @@ class AlgDistance1 : public Algorithm<Adapter>
           }
         }
       },recoloringSize(0));
+      Kokkos::fence();
       Kokkos::parallel_for(n_local, KOKKOS_LAMBDA(const int& i){
         if(femv_colors(i) == 0){
           verts_to_send_view(verts_to_send_size_atomic(0)++) = i;
         }
       });
+      Kokkos::fence();
     }
 
   private:
@@ -317,8 +319,8 @@ class AlgDistance1 : public Algorithm<Adapter>
       std::vector<int> recvcnts(comm->getSize(), 0);
       Teuchos::ArrayView<int> recvcnts_view = Teuchos::arrayViewFromVector(recvcnts);
 
-      //if we're computing statistics, remove the computation imbalance from the comm timer.
-      if(verbose) comm->barrier();
+      //if we're reporting timings, remove the computation imbalance from the comm timer.
+      if(timing) comm->barrier();
       double comm_total = 0.0;
       double comm_temp = timer();
 
@@ -346,7 +348,7 @@ class AlgDistance1 : public Algorithm<Adapter>
     RCP<Environment> env;
     RCP<const Teuchos::Comm<int> > comm;
     bool verbose;
-
+    bool timing;
   public:
     //constructor for the  hybrid distributed distance-1 algorithm
     AlgDistance1(
@@ -356,6 +358,7 @@ class AlgDistance1 : public Algorithm<Adapter>
       const RCP<const Teuchos::Comm<int> > &comm_)
     : adapter(adapter_), pl(pl_), env(env_), comm(comm_) {
       verbose = pl->get<bool>("verbose",false);
+      timing = pl->get<bool>("timing", false);
       if(verbose) std::cout<<comm->getRank()<<": inside coloring constructor\n";
       modelFlag_t flags;
       flags.reset();
@@ -724,18 +727,18 @@ class AlgDistance1 : public Algorithm<Adapter>
       if(verbose) std::cout<<comm->getRank()<<": Coloring interior\n";
       //initialize interior and total timers, barrier to prevent any imbalance from setup.
       //Only use a barrier if timing is happening.
-      if(verbose) comm->barrier();
+      if(timing) comm->barrier();
       interior_time = timer();
       total_time = timer();
       //call the KokkosKernels coloring function with the Tpetra default spaces.
       bool use_vbbit = (global_max_degree < 6000);
       this->colorInterior<execution_space,memory_space>
                  (nVtx, dist_adjs, dist_offsets, femv,dist_adjs,0,use_vbbit);
-      if(verbose){
+      if(timing){
         interior_time = timer() - interior_time;
         comp_time = interior_time;
-        std::cout<<comm->getRank()<<": Going to recolor\n";
       }
+      if(verbose) std::cout<<comm->getRank()<<": Going to recolor\n";
       bool recolor_degrees = this->pl->template get<bool>("recolor_degrees", true);
 
       //if there is more than a single process, check distributed conflicts and recolor
@@ -819,7 +822,6 @@ class AlgDistance1 : public Algorithm<Adapter>
         if(distributedRounds < numStatisticRecordingRounds) {
           vertsPerRound[distributedRounds] = recoloringSize_host(0);
         }
-        if(verbose) std::cout<<comm->getRank()<<": starting to recolor\n";
 	
 	//copying the send view to the recolor view is necessary because
 	//KokkosKernels can change the view passed in, and we need the send view
@@ -844,9 +846,12 @@ class AlgDistance1 : public Algorithm<Adapter>
           comp_time += recoloringPerRound[distributedRounds];
           compPerRound[distributedRounds] = recoloringPerRound[distributedRounds];
           totalPerRound[distributedRounds] = recoloringPerRound[distributedRounds];
+	} else if(timing) {
+	  double recolor_round_time = timer() - recolor_temp;
+	  recoloring_time += recolor_round_time;
+	  comp_time += recolor_round_time;
 	}
         
-        if(verbose) std::cout<<comm->getRank()<<": done recoloring\n";
 	//reset the recoloringSize device host and device views
 	//to zero
         recoloringSize_host(0) = 0;
@@ -874,10 +879,6 @@ class AlgDistance1 : public Algorithm<Adapter>
         comm_time += curr_comm_time;
         if(distributedRounds < numStatisticRecordingRounds){
 	  commPerRound[distributedRounds] = curr_comm_time;
-	  if(verbose){
-            std::cout<<comm->getRank()<<": total sent in round "<<distributedRounds<<" = "<<sent<<"\n";
-            std::cout<<comm->getRank()<<": total recv in round "<<distributedRounds<<" = "<<recv<<"\n";
-  	  }
           sentPerRound[distributedRounds] = sent;
           recvPerRound[distributedRounds] = recv;
           totalPerRound[distributedRounds] += commPerRound[distributedRounds];
@@ -913,6 +914,10 @@ class AlgDistance1 : public Algorithm<Adapter>
           compPerRound[distributedRounds] += conflictDetectionPerRound[distributedRounds];
           totalPerRound[distributedRounds] += conflictDetectionPerRound[distributedRounds];
           comp_time += conflictDetectionPerRound[distributedRounds];
+	} else if(timing){
+	  double conflict_detection_round_time = timer()- detection_temp;
+	  conflict_detection += conflict_detection_round_time;
+	  comp_time += conflict_detection_round_time;
 	}
         //do a reduction to determine if we're done
         int globalDone = 0;
@@ -942,7 +947,6 @@ class AlgDistance1 : public Algorithm<Adapter>
 	if(distributedRounds < 100){
 	  vertsPerRound[distributedRounds] = recoloringSize_host(0);
 	}
-	if(verbose) std::cout<<comm->getRank()<<": starting to recolor, serial\n";
 
 	double recolor_temp = timer();
 	//use KokkosKernels to recolor the conflicting vertices
@@ -958,9 +962,12 @@ class AlgDistance1 : public Algorithm<Adapter>
 	  comp_time += recoloringPerRound[distributedRounds];
 	  compPerRound[distributedRounds] = recoloringPerRound[distributedRounds];
 	  totalPerRound[distributedRounds] = recoloringPerRound[distributedRounds];
-        }
+        } else if(timing){
+	  double recolor_serial_round_time = timer() - recolor_temp;
+	  recoloring_time += recolor_serial_round_time;
+	  comp_time += recolor_serial_round_time;
+	}
 
-	if(verbose) std::cout<<comm->getRank()<<": done recoloring\n";
 	recoloringSize_host(0) = 0;
 
 	for(size_t i = 0; i < rand.size() -nVtx; i++){
@@ -980,10 +987,6 @@ class AlgDistance1 : public Algorithm<Adapter>
 
 	if(distributedRounds < numStatisticRecordingRounds){
 	  commPerRound[distributedRounds] = curr_comm_time;
-	  if(verbose){
-	    std::cout<<comm->getRank()<<": total sent in round "<<distributedRounds<<" = "<<sent<<"\n";
-	    std::cout<<comm->getRank()<<": total recv in round "<<distributedRounds<<" = "<<recv<<"\n";
-	  }
 	  sentPerRound[distributedRounds] = sent;
 	  recvPerRound[distributedRounds] = recv;
 	  totalPerRound[distributedRounds] += commPerRound[distributedRounds];
@@ -1012,7 +1015,11 @@ class AlgDistance1 : public Algorithm<Adapter>
 	  compPerRound[distributedRounds] += conflictDetectionPerRound[distributedRounds];
 	  totalPerRound[distributedRounds] += conflictDetectionPerRound[distributedRounds];
 	  comp_time += conflictDetectionPerRound[distributedRounds];
-        }
+        } else if(timing){
+	  double conflict_detection_serial_round_time = timer() - detection_temp;
+	  conflict_detection += conflict_detection_serial_round_time;
+	  comp_time += conflict_detection_serial_round_time;
+	}
 	//do a reduction to determine if we're done
 	int globalDone = 0;
 	int localDone = recoloringSize_host(0);
@@ -1036,8 +1043,8 @@ class AlgDistance1 : public Algorithm<Adapter>
         }
         //print how many rounds of speculating/correcting happened (this should be the same for all ranks):
         if(comm->getRank()==0) printf("did %d rounds of distributed coloring\n", distributedRounds);
+	int totalBoundarySize = 0;
         int totalVertsPerRound[numStatisticRecordingRounds];
-        int totalBoundarySize = 0;
         double finalTotalPerRound[numStatisticRecordingRounds];
         double maxRecoloringPerRound[numStatisticRecordingRounds];
         double finalSerialRecoloringPerRound[numStatisticRecordingRounds];
@@ -1072,6 +1079,7 @@ class AlgDistance1 : public Algorithm<Adapter>
         Teuchos::reduceAll<int,gno_t> (*comm, Teuchos::REDUCE_SUM,numStatisticRecordingRounds,sentPerRound, finalSentPerRound);
         
         printf("Rank %d: boundary size: %d\n",comm->getRank(),localBoundaryVertices);
+        if(comm->getRank()==0) printf("Total boundary size: %d\n",totalBoundarySize);
         for(int i = 0; i < std::min(distributedRounds,numStatisticRecordingRounds); i++){
           printf("Rank %d: recolor %d vertices in round %d\n",comm->getRank(),vertsPerRound[i],i);
           if(comm->getRank()==0) printf("recolored %d vertices in round %d\n",totalVertsPerRound[i],i);
@@ -1085,7 +1093,7 @@ class AlgDistance1 : public Algorithm<Adapter>
           if(comm->getRank()==0) printf("total recv in round %d: %lld\n",i,finalRecvPerRound[i]);
           if(comm->getRank()==0) printf("comp time in round %d: %f\n",i,finalCompPerRound[i]);
         }
-        
+      } else if(timing){
         double global_total_time = 0.0;
         double global_recoloring_time=0.0;
         double global_min_recoloring_time=0.0;
@@ -1103,7 +1111,6 @@ class AlgDistance1 : public Algorithm<Adapter>
         comm->barrier();
         fflush(stdout);
         if(comm->getRank()==0){
-          printf("Boundary size: %d\n",totalBoundarySize);
           printf("Total Time: %f\n",global_total_time);
           printf("Interior Time: %f\n",global_interior_time);
           printf("Recoloring Time: %f\n",global_recoloring_time);
@@ -1112,8 +1119,8 @@ class AlgDistance1 : public Algorithm<Adapter>
           printf("Comm Time: %f\n",global_comm_time);
           printf("Comp Time: %f\n",global_comp_time);
         }
-        std::cout<<comm->getRank()<<": exiting coloring\n";
       }
+      if(verbose) std::cout<<comm->getRank()<<": exiting coloring\n";
     }
 };
 

--- a/packages/zoltan2/core/src/algorithms/color/Zoltan2_AlgHybridD1.hpp
+++ b/packages/zoltan2/core/src/algorithms/color/Zoltan2_AlgHybridD1.hpp
@@ -233,7 +233,9 @@ class AlgDistance1 : public Algorithm<Adapter>
         }
       },recoloringSize(0));
       Kokkos::fence();
-      Kokkos::parallel_for(n_local, KOKKOS_LAMBDA(const int& i){
+      Kokkos::parallel_for("Rebuild verts_to_send_view",
+		           Kokkos::RangePolicy<ExecutionSpace>(0,n_local), 
+			   KOKKOS_LAMBDA(const int& i){
         if(femv_colors(i) == 0){
           verts_to_send_view(verts_to_send_size_atomic(0)++) = i;
         }

--- a/packages/zoltan2/core/src/algorithms/color/Zoltan2_AlgHybridD2.hpp
+++ b/packages/zoltan2/core/src/algorithms/color/Zoltan2_AlgHybridD2.hpp
@@ -255,7 +255,9 @@ class AlgDistance2 : public AlgTwoGhostLayer<Adapter> {
       Kokkos::fence();
 
       //update the verts_to_send and verts_to_recolor views.
-      Kokkos::parallel_for(femv_colors.size(), KOKKOS_LAMBDA(const uint64_t& i){
+      Kokkos::parallel_for("rebuild verts_to_send and verts_to_recolor",
+		           Kokkos::RangePolicy<ExecutionSpace>(0,femv_colors.size()), 
+			   KOKKOS_LAMBDA(const uint64_t& i){
         if(femv_colors(i) == 0){
 	  //we only send vertices owned by the current process
           if(i < n_local){

--- a/packages/zoltan2/core/src/algorithms/color/Zoltan2_AlgHybridPD2.hpp
+++ b/packages/zoltan2/core/src/algorithms/color/Zoltan2_AlgHybridPD2.hpp
@@ -218,7 +218,9 @@ class AlgPartialDistance2 : public AlgTwoGhostLayer<Adapter> {
         },recoloringSize(0));
         Kokkos::fence();
 	//update the verts_to_send and verts_to_recolor views
-        Kokkos::parallel_for(femv_colors.size(), KOKKOS_LAMBDA(const uint64_t& i){
+        Kokkos::parallel_for("rebuild verts_to_send and verts_to_recolor",
+			     Kokkos::RangePolicy<ExecutionSpace>(0,femv_colors.size()),
+			     KOKKOS_LAMBDA(const uint64_t& i){
           if(femv_colors(i) == 0){
             if(i < n_local){
 	      //we only send vertices owned by the current process

--- a/packages/zoltan2/core/src/problems/Zoltan2_ColoringProblem.hpp
+++ b/packages/zoltan2/core/src/problems/Zoltan2_ColoringProblem.hpp
@@ -139,6 +139,7 @@ public:
     pl.set("color_method", "SerialGreedy", "coloring algorithm",
      color_method_Validator);
     pl.set("verbose", false, "print all output", Environment::getBoolValidator());
+    pl.set("timing", false, "print timing data", Environment::getBoolValidator());
     pl.set("serial_threshold",0,"vertices to recolor in serial",Environment::getAnyIntValidator());
     pl.set("recolor_degrees",true,"recolor based on vertex degrees",Environment::getBoolValidator());
   }

--- a/packages/zoltan2/test/core/color/CMakeLists.txt
+++ b/packages/zoltan2/test/core/color/CMakeLists.txt
@@ -37,7 +37,7 @@ TRIBITS_ADD_TEST(
   NUM_MPI_PROCS 4
   COMM serial mpi
   ARGS
-  "--inputFile=simple --colorMethod=D1"
+  "--inputFile=simple --colorMethod=D1 --timing"
   PASS_REGULAR_EXPRESSION "PASS"
   FAIL_REGULAR_EXPRESSION "FAIL"
   )
@@ -155,7 +155,7 @@ TRIBITS_ADD_TEST(
   NUM_MPI_PROCS 4
   COMM serial mpi
   ARGS
-  "--inputFile=simple --colorMethod=D1-2GL"
+  "--inputFile=simple --colorMethod=D1-2GL --timing"
   PASS_REGULAR_EXPRESSION "PASS"
   FAIL_REGULAR_EXPRESSION "FAIL"
   )

--- a/packages/zoltan2/test/core/color/coloring1.cpp
+++ b/packages/zoltan2/test/core/color/coloring1.cpp
@@ -197,6 +197,7 @@ int main(int narg, char** arg)
   std::string outputFile = "";           // Output file to write
   std::string colorAlg = "SerialGreedy"; // Default algorithm is the serial greedy
   bool verbose = false;                  // Verbosity of output
+  bool timing = false;                   // If true, report coloring times.
   int testReturn = 0;
   bool recolorDegrees = false;
   std::string prepartition = "";    	 // Call Zoltan2 partitioning to better distribute
@@ -229,6 +230,8 @@ int main(int narg, char** arg)
 		 "number of vertices to recolor in serial");
   cmdp.setOption("recolorDegrees","recolorRandom",&recolorDegrees,
 		 "recolor based on vertex degrees or random numbers");
+  cmdp.setOption("timing", "notimes", &timing,
+		  "report how long coloring takes");
   std::cout << "Starting everything" << std::endl;
 
   //////////////////////////////////
@@ -341,6 +344,7 @@ int main(int narg, char** arg)
   params.set("color_choice", colorMethod);
   params.set("color_method", colorAlg);
   params.set("verbose", verbose);
+  params.set("timing", timing);
   params.set("serial_threshold",serialThreshold);
   params.set("recolor_degrees",recolorDegrees);
   //params.set("balance_colors", balanceColors); // TODO


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/zoltan2 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
This fixes a  performance bug in the distance-1 coloring in Zoltan2, as well as adding the capability to report accurate times without any other output to all coloring implementations.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
These changes are covered by existing tests.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->