### PR TITLE
Panzer: fix doxygen tag file

### DIFF
--- a/packages/panzer/doc/Doxyfile
+++ b/packages/panzer/doc/Doxyfile
@@ -11,7 +11,7 @@ TAGFILES += \
   $(TRILINOS_HOME)/packages/common/tag_files/ifpack.tag=$(TRILINOS_HOME)/packages/ifpack/doc/html \
   $(TRILINOS_HOME)/packages/common/tag_files/ml.tag=$(TRILINOS_HOME)/packages/ml/doc/html \
   $(TRILINOS_HOME)/packages/common/tag_files/nox.tag=$(TRILINOS_HOME)/packages/nox/doc/html \
-  $(TRILINOS_HOME)/packages/common/tag_files/ml.tag=$(TRILINOS_HOME)/packages/phalanx/doc/html
+  $(TRILINOS_HOME)/packages/common/tag_files/phalanx.tag=$(TRILINOS_HOME)/packages/phalanx/doc/html
 #
 # Package options
 #


### PR DESCRIPTION
Thanks to Curt for finding this!

## Motivation
doxygen file had a cut and paste error for path to phalanx tags

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->