### PR TITLE
MueLu: Avoid CMake warning about source file extensions

### DIFF
--- a/packages/muelu/test/scaling/CMakeLists.txt
+++ b/packages/muelu/test/scaling/CMakeLists.txt
@@ -69,13 +69,13 @@ IF (${PACKAGE_NAME}_HAVE_TPETRA_SOLVER_STACK OR ${PACKAGE_NAME}_HAVE_EPETRA_SOLV
 
  TRIBITS_ADD_EXECUTABLE(
    ImportPerformance
-   SOURCES ImportPerformance
+   SOURCES ImportPerformance.cpp
    COMM mpi
    )
 
  TRIBITS_ADD_EXECUTABLE(
    TAFCPerformance
-   SOURCES TAFCPerformance
+   SOURCES TAFCPerformance.cpp
    COMM mpi
    )
 

--- a/packages/muelu/test/unit_tests/CMakeLists.txt
+++ b/packages/muelu/test/unit_tests/CMakeLists.txt
@@ -58,7 +58,7 @@ APPEND_SET(SOURCES
   TransPFactory.cpp
   UnsmooshFactory.cpp
   UserData/CreateXpetraPreconditioner.cpp
-  Utilities
+  Utilities.cpp
   VariableContainer.cpp
   VariableDofLaplacianFactory.cpp
 )


### PR DESCRIPTION
@trilinos/muelu 

## Motivation
CMake >= 3.20 complains about missing extensions for source files https://cmake.org/cmake/help/git-stage/policy/CMP0115.html
