### PR TITLE
Tpetra: fix MiniFE example vectors for >1 rank

### DIFF
--- a/packages/tpetra/core/test/PerformanceCGSolve/cg_solve_file.cpp
+++ b/packages/tpetra/core/test/PerformanceCGSolve/cg_solve_file.cpp
@@ -69,7 +69,6 @@ bool cg_solve (Teuchos::RCP<CrsMatrix> A, Teuchos::RCP<Vector> b, Teuchos::RCP<V
   std::string addTimerName = "CG: axpby";
   std::string matvecTimerName = "CG: spmv";
   std::string dotTimerName = "CG: dot";
-  std::string replaceValsName = "CG: replaceLocalValues";
   static_assert (std::is_same<typename CrsMatrix::scalar_type, typename Vector::scalar_type>::value,
                  "The CrsMatrix and Vector template parameters must have the same scalar_type.");
 
@@ -82,16 +81,6 @@ bool cg_solve (Teuchos::RCP<CrsMatrix> A, Teuchos::RCP<Vector> b, Teuchos::RCP<V
   r = Tpetra::createVector<ScalarType>(A->getRangeMap());
   p = Tpetra::createVector<ScalarType>(A->getRangeMap());
   Ap = Tpetra::createVector<ScalarType>(A->getRangeMap());
-
-  {
-    TimeMonitor t(*TimeMonitor::getNewTimer(replaceValsName));
-    int length = r->getLocalLength();
-    for(int i = 0;i<length;i++) {
-      x->replaceLocalValue(i,0);
-      r->replaceLocalValue(i,1);
-      Ap->replaceLocalValue(i,1);
-    }
-  }
 
   magnitude_type normr = 0;
   magnitude_type rtrans = 0;
@@ -216,8 +205,6 @@ int run()
   typedef Tpetra::Vector<Scalar,LO,GO,Node>             vec_type;
   typedef Tpetra::Map<LO,GO,Node>                       map_type;
 
-  typedef typename vec_type::mag_type                   mag_type;
-
   //
   // Get the communicator and node
   //
@@ -268,8 +255,7 @@ int run()
                                      map);
   } else {
     typedef Tpetra::Utils::MatrixGenerator<crs_matrix_type> gen_type;
-    b = gen_type::generate_miniFE_vector (nsize, map->getComm ()
-                                         );
+    b = gen_type::generate_miniFE_vector (nsize, map->getComm ());
   }
 
   // The vector x on input is the initial guess for the CG solve.


### PR DESCRIPTION
``generate_miniFE_vector`` was only setting values owned by rank 0 (higher ranks locally got all zeros).
This is used to generate the RHS (b) in PerformanceCGSolve, so this caused
the initial residuals and number of CG iterations to go down as ranks increased.
So it wasn't really a valid strong scaling study. Now the vector is always the same for a given grid size, as it should be.

Also got rid of the x, r, Ap vector initialization using replaceLocalValue(). @jennloe pointed out that r and Ap are
actually completely overwritten by apply/update before they are read, and
x is a freshly constructed (0-initialized) vector. This saves a
significant amount of time and makes the StackedTimer total more
representative of SpMV/BLAS time that it's supposed to be measuring.
It's good of course that ``replaceLocalValue()`` got much faster during UVM removal, but that's not the primary thing this test is benchmarking.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
This is changing just a test, and a Tpetra::Vector generator used by tests. The fix can be verified by running PerformanceCGSolve with varying numbers of ranks and seeing that the initial residual/iteration counts never change.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->