### PR TITLE
Removes unnecessary BLAS/LAPACK class usage and exception handling

### DIFF
--- a/packages/belos/src/BelosBiCGStabIter.hpp
+++ b/packages/belos/src/BelosBiCGStabIter.hpp
@@ -57,7 +57,6 @@
 #include "BelosOperatorTraits.hpp"
 #include "BelosMultiVecTraits.hpp"
 
-#include "Teuchos_BLAS.hpp"
 #include "Teuchos_SerialDenseMatrix.hpp"
 #include "Teuchos_SerialDenseVector.hpp"
 #include "Teuchos_ScalarTraits.hpp"

--- a/packages/belos/src/BelosBiCGStabSolMgr.hpp
+++ b/packages/belos/src/BelosBiCGStabSolMgr.hpp
@@ -58,16 +58,14 @@
 #include "BelosStatusTestCombo.hpp"
 #include "BelosStatusTestOutputFactory.hpp"
 #include "BelosOutputManager.hpp"
-#include "Teuchos_BLAS.hpp"
-#include "Teuchos_LAPACK.hpp"
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
 #include "Teuchos_TimeMonitor.hpp"
 #endif
 
-/** \example BiCGStab/BiCGStabEpetraExFile.cpp
+/** \example BiCGStab/BiCGStabExFile.cpp
     This is an example of how to use the Belos::BiCGStabSolMgr solver manager.
 */
-/** \example BiCGStab/PseudoBlockPrecCGEpetraExFile.cpp
+/** \example BiCGStab/PrecBiCGStabExFile.cpp
     This is an example of how to use the Belos::BiCGStabSolMgr solver manager with an Ifpack preconditioner.
 */
 
@@ -93,16 +91,6 @@ namespace Belos {
    */
   class BiCGStabSolMgrLinearProblemFailure : public BelosError {public:
     BiCGStabSolMgrLinearProblemFailure(const std::string& what_arg) : BelosError(what_arg)
-    {}};
-
-  /** \brief BiCGStabSolMgrOrthoFailure is thrown when the orthogonalization manager is
-   * unable to generate orthonormal columns from the initial basis vectors.
-   *
-   * This std::exception is thrown from the BiCGStabSolMgr::solve() method.
-   *
-   */
-  class BiCGStabSolMgrOrthoFailure : public BelosError {public:
-    BiCGStabSolMgrOrthoFailure(const std::string& what_arg) : BelosError(what_arg)
     {}};
 
   template<class ScalarType, class MV, class OP>
@@ -629,8 +617,6 @@ ReturnType BiCGStabSolMgr<ScalarType,MV,OP>::solve ()
   if (! isSet_) {
     setParameters (params_);
   }
-
-  Teuchos::BLAS<int,ScalarType> blas;
 
   TEUCHOS_TEST_FOR_EXCEPTION
     (! problem_->isProblemSet (), BiCGStabSolMgrLinearProblemFailure,

--- a/packages/belos/src/BelosBlockCGIter.hpp
+++ b/packages/belos/src/BelosBlockCGIter.hpp
@@ -57,7 +57,6 @@
 #include "BelosOperatorTraits.hpp"
 #include "BelosMultiVecTraits.hpp"
 
-#include "Teuchos_BLAS.hpp"
 #include "Teuchos_LAPACK.hpp"
 #include "Teuchos_SerialDenseMatrix.hpp"
 #include "Teuchos_SerialDenseVector.hpp"

--- a/packages/belos/src/BelosBlockCGSolMgr.hpp
+++ b/packages/belos/src/BelosBlockCGSolMgr.hpp
@@ -61,7 +61,6 @@
 #include "BelosStatusTestCombo.hpp"
 #include "BelosStatusTestOutputFactory.hpp"
 #include "BelosOutputManager.hpp"
-#include "Teuchos_BLAS.hpp"
 #include "Teuchos_LAPACK.hpp"
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
 #  include "Teuchos_TimeMonitor.hpp"
@@ -101,17 +100,6 @@ namespace Belos {
   class BlockCGSolMgrLinearProblemFailure : public BelosError {public:
     BlockCGSolMgrLinearProblemFailure(const std::string& what_arg) : BelosError(what_arg)
     {}};
-
-  /** \brief BlockCGSolMgrOrthoFailure is thrown when the orthogonalization manager is
-   * unable to generate orthonormal columns from the initial basis vectors.
-   *
-   * This std::exception is thrown from the BlockCGSolMgr::solve() method.
-   *
-   */
-  class BlockCGSolMgrOrthoFailure : public BelosError {public:
-    BlockCGSolMgrOrthoFailure(const std::string& what_arg) : BelosError(what_arg)
-    {}};
-
 
   template<class ScalarType, class MV, class OP,
            const bool lapackSupportsScalarType =
@@ -840,7 +828,6 @@ ReturnType BlockCGSolMgr<ScalarType,MV,OP,true>::solve() {
     setParameters(Teuchos::parameterList(*getValidParameters()));
   }
 
-  Teuchos::BLAS<int,ScalarType> blas;
   Teuchos::LAPACK<int,ScalarType> lapack;
 
   TEUCHOS_TEST_FOR_EXCEPTION( !problem_->isProblemSet(),

--- a/packages/belos/src/BelosBlockGCRODRSolMgr.hpp
+++ b/packages/belos/src/BelosBlockGCRODRSolMgr.hpp
@@ -59,7 +59,6 @@
 #include "BelosStatusTestCombo.hpp"
 #include "BelosStatusTestOutputFactory.hpp"
 #include "BelosOutputManager.hpp"
-#include "Teuchos_BLAS.hpp"
 #include "Teuchos_LAPACK.hpp"
 #include "Teuchos_as.hpp"
 #ifdef BELOS_TEUCHOS_TIME_MONITOR

--- a/packages/belos/src/BelosBlockGmresSolMgr.hpp
+++ b/packages/belos/src/BelosBlockGmresSolMgr.hpp
@@ -63,7 +63,6 @@
 #include "BelosStatusTestOutput.hpp"
 #include "BelosStatusTestOutputFactory.hpp"
 #include "BelosOutputManager.hpp"
-#include "Teuchos_BLAS.hpp"
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
 #include "Teuchos_TimeMonitor.hpp"
 #endif
@@ -888,8 +887,6 @@ ReturnType BlockGmresSolMgr<ScalarType,MV,OP>::solve() {
   if (!isSet_) {
     setParameters(Teuchos::parameterList(*getValidParameters()));
   }
-
-  Teuchos::BLAS<int,ScalarType> blas;
 
   TEUCHOS_TEST_FOR_EXCEPTION(problem_ == Teuchos::null,BlockGmresSolMgrLinearProblemFailure,
     "Belos::BlockGmresSolMgr::solve(): Linear problem is not a valid object.");

--- a/packages/belos/src/BelosFixedPointIteration.hpp
+++ b/packages/belos/src/BelosFixedPointIteration.hpp
@@ -100,26 +100,6 @@ namespace Belos {
     FixedPointIterateFailure(const std::string& what_arg) : BelosError(what_arg)
     {}};
   
-  /** \brief FixedPointIterationOrthoFailure is thrown when the FixedPointIteration object is unable to
-   * compute independent direction vectors in the FixedPointIteration::iterate() routine. 
-   *
-   * This std::exception is thrown from the FixedPointIteration::iterate() method.
-   *
-   */
-  class FixedPointIterationOrthoFailure : public BelosError {public:
-    FixedPointIterationOrthoFailure(const std::string& what_arg) : BelosError(what_arg)
-    {}};
-
-  /** \brief FixedPointIterationLAPACKFailure is thrown when a nonzero return value is passed back
-   * from an LAPACK routine.
-   *
-   * This std::exception is thrown from the FixedPointIteration::iterate() method.
-   *
-   */
-  class FixedPointIterationLAPACKFailure : public BelosError {public:
-    FixedPointIterationLAPACKFailure(const std::string& what_arg) : BelosError(what_arg)
-    {}};
-  
   //@}
 
 

--- a/packages/belos/src/BelosFixedPointSolMgr.hpp
+++ b/packages/belos/src/BelosFixedPointSolMgr.hpp
@@ -59,8 +59,6 @@
 #include "BelosStatusTestCombo.hpp"
 #include "BelosStatusTestOutputFactory.hpp"
 #include "BelosOutputManager.hpp"
-#include "Teuchos_BLAS.hpp"
-#include "Teuchos_LAPACK.hpp"
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
 #  include "Teuchos_TimeMonitor.hpp"
 #endif
@@ -599,9 +597,6 @@ ReturnType FixedPointSolMgr<ScalarType,MV,OP>::solve() {
   if (!isSet_) {
     setParameters(Teuchos::parameterList(*getValidParameters()));
   }
-
-  Teuchos::BLAS<int,ScalarType> blas;
-  Teuchos::LAPACK<int,ScalarType> lapack;
 
   TEUCHOS_TEST_FOR_EXCEPTION( !problem_->isProblemSet(),
     FixedPointSolMgrLinearProblemFailure,

--- a/packages/belos/src/BelosLSQRIter.hpp
+++ b/packages/belos/src/BelosLSQRIter.hpp
@@ -55,9 +55,7 @@
 #include "BelosStatusTest.hpp"
 #include "BelosOperatorTraits.hpp"
 #include "BelosMultiVecTraits.hpp"
-//#include "BelosMatOrthoManager.hpp"  (needed for blocks)
 
-//#include "Teuchos_BLAS.hpp"  (needed for blocks)
 #include "Teuchos_SerialDenseMatrix.hpp"
 #include "Teuchos_SerialDenseVector.hpp"
 #include "Teuchos_ScalarTraits.hpp"

--- a/packages/belos/src/BelosLSQRIteration.hpp
+++ b/packages/belos/src/BelosLSQRIteration.hpp
@@ -130,26 +130,6 @@ class LSQRIterateFailure : public BelosError {public:
       LSQRIterateFailure(const std::string& what_arg) : BelosError(what_arg)
     {}};
   
-  /** \brief LSQRIterationOrthoFailure is thrown when the LSQRIteration object is unable to
-   * compute independent direction vectors in the iterate() routine. 
-   *
-   * This std::exception is thrown from the iterate() method.
-   *
-   */
-class LSQRIterationOrthoFailure : public BelosError {public:
-      LSQRIterationOrthoFailure(const std::string& what_arg) : BelosError(what_arg)
-    {}};
-
-  /** \brief LSQRIterationLAPACKFailure is thrown when a nonzero return value is passed back
-   * from an LAPACK routine.
-   *
-   * This std::exception is thrown from the iterate() method.
-   *
-   */
-class LSQRIterationLAPACKFailure : public BelosError {public:
-      LSQRIterationLAPACKFailure(const std::string& what_arg) : BelosError(what_arg)
-    {}};
-  
   //@}
 
 } // end Belos namespace

--- a/packages/belos/src/BelosLSQRSolMgr.hpp
+++ b/packages/belos/src/BelosLSQRSolMgr.hpp
@@ -59,8 +59,6 @@
 #include "BelosStatusTestOutputFactory.hpp"
 #include "BelosOutputManager.hpp"
 #include "Teuchos_as.hpp"
-#include "Teuchos_BLAS.hpp"
-#include "Teuchos_LAPACK.hpp"
 
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
 #include "Teuchos_TimeMonitor.hpp"
@@ -81,21 +79,6 @@ namespace Belos {
 class LSQRSolMgrLinearProblemFailure : public BelosError {
 public:
   LSQRSolMgrLinearProblemFailure(const std::string& what_arg)
-    : BelosError(what_arg)
-  {}
-};
-
-/** \brief LSQRSolMgrOrthoFailure is thrown when the orthogonalization manager is
- * unable to generate orthonormal columns from the initial basis vectors.
- *
- * \warning DO NOT USE; DEPRECATED.
- *
- * This std::exception is thrown from the LSQRSolMgr::solve() method.
- *
- */
-class LSQRSolMgrOrthoFailure : public BelosError {
-public:
-  LSQRSolMgrOrthoFailure(const std::string& what_arg)
     : BelosError(what_arg)
   {}
 };

--- a/packages/belos/src/BelosMinresIter.hpp
+++ b/packages/belos/src/BelosMinresIter.hpp
@@ -74,7 +74,6 @@
 #include "Teuchos_ScalarTraits.hpp"
 #include "Teuchos_ParameterList.hpp"
 #include "Teuchos_TimeMonitor.hpp"
-#include "Teuchos_BLAS.hpp"
 
 namespace Belos {
 
@@ -464,8 +463,6 @@ class MinresIter : virtual public MinresIteration<ScalarType,MV,OP> {
     if (initialized_ == false) {
       initialize();
     }
-
-    Teuchos::BLAS<int,ScalarType> blas;
 
     // Create convenience variables for zero and one.
     const ScalarType one = SCT::one();

--- a/packages/belos/src/BelosMinresIteration.hpp
+++ b/packages/belos/src/BelosMinresIteration.hpp
@@ -117,26 +117,6 @@ namespace Belos {
     MinresIterateFailure(const std::string& what_arg) : BelosError(what_arg)
     {}};
   
-  /** \brief MinresIterationOrthoFailure is thrown when the MinresIteration object is unable to
-   * compute independent direction vectors in the MinresIteration::iterate() routine.
-   *
-   * This std::exception is thrown from the MinresIteration::iterate() method.
-   *
-   */
-  class MinresIterationOrthoFailure : public BelosError {public:
-    MinresIterationOrthoFailure(const std::string& what_arg) : BelosError(what_arg)
-    {}};
-
-  /** \brief MinresIterationLAPACKFailure is thrown when a nonzero return value is passed back
-   * from an LAPACK routine.
-   *
-   * This std::exception is thrown from the MinresIteration::iterate() method.
-   *
-   */
-  class MinresIterationLAPACKFailure : public BelosError {public:
-    MinresIterationLAPACKFailure(const std::string& what_arg) : BelosError(what_arg)
-    {}};
-  
   //@}
 
 

--- a/packages/belos/src/BelosMinresSolMgr.hpp
+++ b/packages/belos/src/BelosMinresSolMgr.hpp
@@ -57,8 +57,6 @@
 #include "BelosStatusTestCombo.hpp"
 #include "BelosStatusTestOutputFactory.hpp"
 #include "BelosOutputManager.hpp"
-#include "Teuchos_BLAS.hpp"
-#include "Teuchos_LAPACK.hpp"
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
 #include "Teuchos_TimeMonitor.hpp"
 #endif

--- a/packages/belos/src/BelosPCPGIter.hpp
+++ b/packages/belos/src/BelosPCPGIter.hpp
@@ -56,8 +56,6 @@
 #include "BelosOperatorTraits.hpp"
 #include "BelosMultiVecTraits.hpp"
 
-#include "Teuchos_BLAS.hpp"
-#include "Teuchos_LAPACK.hpp"
 #include "Teuchos_SerialDenseMatrix.hpp"
 #include "Teuchos_SerialDenseVector.hpp"
 #include "Teuchos_ScalarTraits.hpp"
@@ -156,8 +154,6 @@ namespace Belos {
     PCPGIterateFailure(const std::string& what_arg) : BelosError(what_arg)
     {}};
 
-
-  
   /** \brief PCPGIterOrthoFailure is thrown when the PCPGIter object is unable to
    * compute independent direction vectors in the PCPGIter::iterate() routine.
    *
@@ -167,20 +163,7 @@ namespace Belos {
   class PCPGIterOrthoFailure : public BelosError {public:
     PCPGIterOrthoFailure(const std::string& what_arg) : BelosError(what_arg)
     {}};
-  
-  /** \brief PCPGIterLAPACKFailure is thrown when a nonzero return value is passed back
-   * from an LAPACK routine.
-   *
-   * This std::exception is thrown from the PCPGIter::iterate() method.
-   *
-   */
-  class PCPGIterLAPACKFailure : public BelosError {public:
-    PCPGIterLAPACKFailure(const std::string& what_arg) : BelosError(what_arg)
-    {}};
-  
-  //@}
-  
-  
+
   template<class ScalarType, class MV, class OP>
   class PCPGIter : virtual public Iteration<ScalarType,MV,OP> {
     
@@ -233,7 +216,7 @@ namespace Belos {
      * -# the search direction P is projected into a complement of the seed space U.
      *
      * The status test is queried at the beginning of the iteration.
-     * Potential CG exceptions include IterationInit, Iterate and IterationLAPACKFailure
+     * Potential CG exceptions include IterationInit, Iterate
      *
      */
     void iterate();

--- a/packages/belos/src/BelosPCPGSolMgr.hpp
+++ b/packages/belos/src/BelosPCPGSolMgr.hpp
@@ -59,7 +59,6 @@
 #include "BelosStatusTestCombo.hpp"
 #include "BelosStatusTestOutputFactory.hpp"
 #include "BelosOutputManager.hpp"
-#include "Teuchos_BLAS.hpp"
 #include "Teuchos_LAPACK.hpp"
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
 #  include "Teuchos_TimeMonitor.hpp"
@@ -738,7 +737,6 @@ ReturnType PCPGSolMgr<ScalarType,MV,OP,true>::solve() {
   // Set the current parameters if are not set already.
   if (!isSet_) { setParameters( params_ ); }
 
-  Teuchos::BLAS<int,ScalarType> blas;
   Teuchos::LAPACK<int,ScalarType> lapack;
   ScalarType one = Teuchos::ScalarTraits<ScalarType>::one();
   ScalarType zero = Teuchos::ScalarTraits<ScalarType>::zero();

--- a/packages/belos/src/BelosPseudoBlockCGIter.hpp
+++ b/packages/belos/src/BelosPseudoBlockCGIter.hpp
@@ -57,7 +57,6 @@
 #include "BelosOperatorTraits.hpp"
 #include "BelosMultiVecTraits.hpp"
 
-#include "Teuchos_BLAS.hpp"
 #include "Teuchos_SerialDenseMatrix.hpp"
 #include "Teuchos_SerialDenseVector.hpp"
 #include "Teuchos_ScalarTraits.hpp"

--- a/packages/belos/src/BelosPseudoBlockCGSolMgr.hpp
+++ b/packages/belos/src/BelosPseudoBlockCGSolMgr.hpp
@@ -60,7 +60,6 @@
 #include "BelosStatusTestCombo.hpp"
 #include "BelosStatusTestOutputFactory.hpp"
 #include "BelosOutputManager.hpp"
-#include "Teuchos_BLAS.hpp"
 #include "Teuchos_LAPACK.hpp"
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
 #include "Teuchos_TimeMonitor.hpp"

--- a/packages/belos/src/BelosPseudoBlockGmresSolMgr.hpp
+++ b/packages/belos/src/BelosPseudoBlockGmresSolMgr.hpp
@@ -57,7 +57,6 @@
 #include "BelosStatusTestFactory.hpp"
 #include "BelosStatusTestOutputFactory.hpp"
 #include "BelosOutputManager.hpp"
-#include "Teuchos_BLAS.hpp"
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
 #include "Teuchos_TimeMonitor.hpp"
 #endif
@@ -1194,8 +1193,6 @@ ReturnType PseudoBlockGmresSolMgr<ScalarType,MV,OP>::solve() {
   // NOTE:  This may occur if the user generated the solver manager with the default constructor and
   // then didn't set any parameters using setParameters().
   if (!isSet_) { setParameters( params_ ); }
-
-  Teuchos::BLAS<int,ScalarType> blas;
 
   TEUCHOS_TEST_FOR_EXCEPTION(!problem_->isProblemSet(),PseudoBlockGmresSolMgrLinearProblemFailure,
                      "Belos::PseudoBlockGmresSolMgr::solve(): Linear problem is not ready, setProblem() has not been called.");

--- a/packages/belos/src/BelosPseudoBlockStochasticCGIter.hpp
+++ b/packages/belos/src/BelosPseudoBlockStochasticCGIter.hpp
@@ -57,7 +57,6 @@
 #include "BelosOperatorTraits.hpp"
 #include "BelosMultiVecTraits.hpp"
 
-#include "Teuchos_BLAS.hpp"
 #include "Teuchos_SerialDenseMatrix.hpp"
 #include "Teuchos_SerialDenseVector.hpp"
 #include "Teuchos_SerialDenseHelpers.hpp"

--- a/packages/belos/src/BelosPseudoBlockStochasticCGSolMgr.hpp
+++ b/packages/belos/src/BelosPseudoBlockStochasticCGSolMgr.hpp
@@ -58,7 +58,6 @@
 #include "BelosStatusTestCombo.hpp"
 #include "BelosStatusTestOutputFactory.hpp"
 #include "BelosOutputManager.hpp"
-#include "Teuchos_BLAS.hpp"
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
 #include "Teuchos_TimeMonitor.hpp"
 #endif
@@ -85,16 +84,6 @@ namespace Belos {
    */
   class PseudoBlockStochasticCGSolMgrLinearProblemFailure : public BelosError {public:
     PseudoBlockStochasticCGSolMgrLinearProblemFailure(const std::string& what_arg) : BelosError(what_arg)
-    {}};
-
-  /** \brief PseudoBlockStochasticCGSolMgrOrthoFailure is thrown when the orthogonalization manager is
-   * unable to generate orthonormal columns from the initial basis vectors.
-   *
-   * This std::exception is thrown from the PseudoBlockStochasticCGSolMgr::solve() method.
-   *
-   */
-  class PseudoBlockStochasticCGSolMgrOrthoFailure : public BelosError {public:
-    PseudoBlockStochasticCGSolMgrOrthoFailure(const std::string& what_arg) : BelosError(what_arg)
     {}};
 
   template<class ScalarType, class MV, class OP>
@@ -628,8 +617,6 @@ ReturnType PseudoBlockStochasticCGSolMgr<ScalarType,MV,OP>::solve() {
   // NOTE:  This may occur if the user generated the solver manager with the default constructor and
   // then didn't set any parameters using setParameters().
   if (!isSet_) { setParameters( params_ ); }
-
-  Teuchos::BLAS<int,ScalarType> blas;
 
   TEUCHOS_TEST_FOR_EXCEPTION(!problem_->isProblemSet(),PseudoBlockStochasticCGSolMgrLinearProblemFailure,
                      "Belos::PseudoBlockStochasticCGSolMgr::solve(): Linear problem is not ready, setProblem() has not been called.");

--- a/packages/belos/src/BelosPseudoBlockTFQMRIter.hpp
+++ b/packages/belos/src/BelosPseudoBlockTFQMRIter.hpp
@@ -67,7 +67,6 @@
 #include "BelosOperatorTraits.hpp"
 #include "BelosMultiVecTraits.hpp"
 
-#include "Teuchos_BLAS.hpp"
 #include "Teuchos_ScalarTraits.hpp"
 #include "Teuchos_ParameterList.hpp"
 #include "Teuchos_TimeMonitor.hpp"

--- a/packages/belos/src/BelosPseudoBlockTFQMRSolMgr.hpp
+++ b/packages/belos/src/BelosPseudoBlockTFQMRSolMgr.hpp
@@ -90,16 +90,6 @@ namespace Belos {
     PseudoBlockTFQMRSolMgrLinearProblemFailure(const std::string& what_arg) : BelosError(what_arg)
     {}};
 
-  /** \brief PseudoBlockTFQMRSolMgrOrthoFailure is thrown when the orthogonalization manager is
-   * unable to generate orthonormal columns from the initial basis vectors.
-   *
-   * This std::exception is thrown from the PseudoBlockTFQMRSolMgr::solve() method.
-   *
-   */
-  class PseudoBlockTFQMRSolMgrOrthoFailure : public BelosError {public:
-    PseudoBlockTFQMRSolMgrOrthoFailure(const std::string& what_arg) : BelosError(what_arg)
-    {}};
-
   template<class ScalarType, class MV, class OP>
   class PseudoBlockTFQMRSolMgr : public SolverManager<ScalarType,MV,OP> {
 

--- a/packages/belos/src/BelosRCGIter.hpp
+++ b/packages/belos/src/BelosRCGIter.hpp
@@ -56,7 +56,6 @@
 #include "BelosOperatorTraits.hpp"
 #include "BelosMultiVecTraits.hpp"
 
-#include "Teuchos_BLAS.hpp"
 #include "Teuchos_LAPACK.hpp"
 #include "Teuchos_SerialDenseMatrix.hpp"
 #include "Teuchos_SerialDenseVector.hpp"
@@ -167,16 +166,6 @@ namespace Belos {
    */
   class RCGIterFailure : public BelosError {public:
     RCGIterFailure(const std::string& what_arg) : BelosError(what_arg)
-    {}};
-
-  /** \brief RCGIterOrthoFailure is thrown when the RCGIter object is unable to
-   * compute independent direction vectors in the RCGIter::iterate() routine.
-   *
-   * This std::exception is thrown from the RCGIter::iterate() method.
-   *
-   */
-  class RCGIterOrthoFailure : public BelosError {public:
-    RCGIterOrthoFailure(const std::string& what_arg) : BelosError(what_arg)
     {}};
 
   /** \brief RCGIterLAPACKFailure is thrown when a nonzero return value is passed back

--- a/packages/belos/src/BelosRCGSolMgr.hpp
+++ b/packages/belos/src/BelosRCGSolMgr.hpp
@@ -58,7 +58,6 @@
 #include "BelosStatusTestCombo.hpp"
 #include "BelosStatusTestOutputFactory.hpp"
 #include "BelosOutputManager.hpp"
-#include "Teuchos_BLAS.hpp"
 #include "Teuchos_LAPACK.hpp"
 #include "Teuchos_as.hpp"
 #ifdef BELOS_TEUCHOS_TIME_MONITOR

--- a/packages/belos/src/BelosTFQMRIter.hpp
+++ b/packages/belos/src/BelosTFQMRIter.hpp
@@ -67,7 +67,6 @@
 #include "BelosOperatorTraits.hpp"
 #include "BelosMultiVecTraits.hpp"
 
-#include "Teuchos_BLAS.hpp"
 #include "Teuchos_SerialDenseMatrix.hpp"
 #include "Teuchos_SerialDenseVector.hpp"
 #include "Teuchos_ScalarTraits.hpp"

--- a/packages/belos/src/BelosTFQMRSolMgr.hpp
+++ b/packages/belos/src/BelosTFQMRSolMgr.hpp
@@ -90,16 +90,6 @@ namespace Belos {
     TFQMRSolMgrLinearProblemFailure(const std::string& what_arg) : BelosError(what_arg)
     {}};
 
-  /** \brief TFQMRSolMgrOrthoFailure is thrown when the orthogonalization manager is
-   * unable to generate orthonormal columns from the initial basis vectors.
-   *
-   * This std::exception is thrown from the TFQMRSolMgr::solve() method.
-   *
-   */
-  class TFQMRSolMgrOrthoFailure : public BelosError {public:
-    TFQMRSolMgrOrthoFailure(const std::string& what_arg) : BelosError(what_arg)
-    {}};
-
   template<class ScalarType, class MV, class OP>
   class TFQMRSolMgr : public SolverManager<ScalarType,MV,OP> {
 

--- a/packages/belos/src/BelosTsqrOrthoManagerImpl.hpp
+++ b/packages/belos/src/BelosTsqrOrthoManagerImpl.hpp
@@ -50,7 +50,6 @@
 #include "BelosOrthoManager.hpp" // OrthoError, etc.
 
 #include "Teuchos_as.hpp"
-#include "Teuchos_LAPACK.hpp"
 #include "Teuchos_ParameterList.hpp"
 #include "Teuchos_ParameterListAcceptorDefaultBase.hpp"
 #ifdef BELOS_TEUCHOS_TIME_MONITOR


### PR DESCRIPTION


<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/belos 
## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
This is just a small clean up of the solvers in Belos to remove
the unnecessary inclusion of BLAS/LAPACK classes and exception handling
that likely resulted from copying old solvers to create new ones.
The impending refactor of the code to address the dense matrix
object used internally by most solvers necessitates a clear understanding
of the dependencies of each solver on BLAS/LAPACK methods.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->