### PR TITLE
Teuchos: add hooks to disable/reenable stacked timers for async tasks.

### DIFF
--- a/packages/teuchos/comm/src/Teuchos_StackedTimer.cpp
+++ b/packages/teuchos/comm/src/Teuchos_StackedTimer.cpp
@@ -822,4 +822,10 @@ void StackedTimer::enableVerboseTimestamps(const unsigned levels)
 void StackedTimer::setVerboseOstream(const Teuchos::RCP<std::ostream>& os)
 {verbose_ostream_ = os;}
 
+void StackedTimer::disableTimers()
+{enable_timers_ = false;}
+
+void StackedTimer::enableTimers()
+{enable_timers_ = true;}
+
 } //namespace Teuchos


### PR DESCRIPTION
## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
We have applications that are now using cuda streams. If tasks are launched asynchronously, the stop() call to stacked timers can trigger errors due to stopping out of sequence. We've added a method to pause timers by making the start() and stop() methods no-op. A second method can reenable. This will be used to pause timers when using tasking with cuda streams.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->
EMPIRE 1088

## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
Fixes issue!

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
new unit test added to packages/teuchos/comm/tests/stacked_timer.cpp 

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->