### PR TITLE
Ifpack2: fix refcount related errors

### DIFF
--- a/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_def.hpp
@@ -98,13 +98,19 @@ namespace Ifpack2 {
     impl_->tpetra_importer = Teuchos::null;
     impl_->async_importer  = Teuchos::null;
     
-    if (importer.is_null()) // there is no given importer, then create one
-      if (useSeqMethod) 
+    if (useSeqMethod)
+    {
+      if (importer.is_null()) // there is no given importer, then create one
         impl_->tpetra_importer = BlockTriDiContainerDetails::createBlockCrsTpetraImporter<MatrixType>(impl_->A);
-      else 
-        impl_->async_importer = BlockTriDiContainerDetails::createBlockCrsAsyncImporter<MatrixType>(impl_->A);
-    else 
-      impl_->tpetra_importer = importer; // if there is a given importer, use it
+      else
+        impl_->tpetra_importer = importer; // if there is a given importer, use it
+    }
+    else
+    {
+      //Leave tpetra_importer null even if user provided an importer.
+      //It is not used in the performant codepath (!useSeqMethod)
+      impl_->async_importer = BlockTriDiContainerDetails::createBlockCrsAsyncImporter<MatrixType>(impl_->A);
+    }
 
     // as a result, there are 
     // 1) tpetra_importer is     null , async_importer is     null (no need for importer)

--- a/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
@@ -1471,8 +1471,7 @@ namespace Ifpack2 {
       using impl_type = ImplType<MatrixType>;
       using local_ordinal_type_1d_view = typename impl_type::local_ordinal_type_1d_view;
       using size_type_1d_view = typename impl_type::size_type_1d_view;
-      using impl_scalar_type_1d_view_tpetra = typename impl_type::impl_scalar_type_1d_view_tpetra;
-
+      using impl_scalar_type_1d_view_tpetra = Unmanaged<typename impl_type::impl_scalar_type_1d_view_tpetra>;
       // rowptr points to the start of each row of A_colindsub.
       size_type_1d_view rowptr, rowptr_remote;
       // Indices into A's rows giving the blocks to extract. rowptr(i) points to
@@ -3784,6 +3783,13 @@ namespace Ifpack2 {
                                   "The seq method for applyInverseJacobi, " <<
                                   "which in any case is for developer use only, " <<
                                   "does not support norm-based termination.");
+      const bool device_accessible_from_host = Kokkos::SpaceAccessibility<
+        Kokkos::DefaultHostExecutionSpace, node_memory_space>::accessible;
+      TEUCHOS_TEST_FOR_EXCEPTION(is_seq_method_requested && !device_accessible_from_host,
+                                 std::invalid_argument,
+                                 "The seq method for applyInverseJacobi, " <<
+                                 "which in any case is for developer use only, " <<
+                                 "only supports memory spaces accessible from host.");
 
       // if workspace is needed more, resize it
       const size_type work_span_required = num_blockrows*num_vectors*blocksize;

--- a/packages/ifpack2/src/Ifpack2_RILUK_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_RILUK_def.hpp
@@ -775,16 +775,16 @@ void RILUK<MatrixType>::compute ()
 
     // Now start the factorization.
 
-    // Need some integer workspace and pointers
-    size_t NumUU;
-    local_inds_host_view_type UUI;
-    values_host_view_type UUV;
     for (size_t j = 0; j < num_cols; ++j) {
       colflag[j] = -1;
     }
     using IST = typename row_matrix_type::impl_scalar_type;
     for (size_t i = 0; i < L_->getNodeNumRows (); ++i) {
       local_ordinal_type local_row = i;
+      // Need some integer workspace and pointers
+      size_t NumUU;
+      local_inds_host_view_type UUI;
+      values_host_view_type UUV;
 
       // Fill InV, InI with current row of L, D and U combined
 

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestBlockCrsUtil.hpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestBlockCrsUtil.hpp
@@ -64,6 +64,7 @@ struct BlockCrsMatrixMaker {
   typedef LO Int;
   typedef typename Teuchos::ScalarTraits<Scalar>::magnitudeType Magnitude;
   typedef Tpetra::Map<LO, GO> Tpetra_Map;
+  typedef typename Tpetra_Map::node_type::device_type DeviceType;
   typedef Tpetra::Import<LO, GO> Tpetra_Import;
   typedef Tpetra::Export<LO, GO> Tpetra_Export;
   typedef Tpetra::MultiVector<Scalar, LO, GO> Tpetra_MultiVector;

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestBlockTriDiContainer.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestBlockTriDiContainer.cpp
@@ -270,7 +270,12 @@ static LO run_teuchos_tests (const Input& in, Teuchos::FancyOStream& out, bool& 
         nerr += ne;
       }
       for (const bool jacobi : {false, true})
-        for (const bool seq_method : {false, true})
+        for (const bool seq_method : {false, true}) {
+          //The sequential method only works when 'device' memory space is host-accessible (aka UVM semantics)
+          if(seq_method && !Kokkos::SpaceAccessibility<Kokkos::DefaultHostExecutionSpace,
+              typename bcmm::DeviceType::memory_space>::accessible) {
+            continue;
+          }
           for (const bool overlap_comm : {false, true}) { // temporary disabling overlap comm version
             if (seq_method && overlap_comm) continue;
             for (const bool nonuniform_lines : {false, true}) {
@@ -302,6 +307,7 @@ static LO run_teuchos_tests (const Input& in, Teuchos::FancyOStream& out, bool& 
               }
             }
           }
+        }
     }
   }
   return nerr;


### PR DESCRIPTION
- RILUK: move some host views into smaller scope that doesn't overlap with
scope of device views.
- BlockTriDi: make A values view unmanaged so that holding it doesn't
increment use count. This code is still responsible for managing syncs.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Make RILUK, BlockTriDiContainer obey the new Tpetra DualView semantics (don't hold host and device view simultaneously). Fixes tests for UVM off: ``Ifpack2_RILUK_HTS_hb_belos``, ``Ifpack2_BlockTriDiContainerUnitAndPerfTests``
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->