### PR TITLE
Tpetra: fix performance in LocalCrsMatrixOp

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -44,7 +44,7 @@
 /// \brief Declaration of the Tpetra::CrsMatrix class
 
 #include "Tpetra_CrsMatrix_fwd.hpp"
-#include "Tpetra_LocalCrsMatrixOperator_fwd.hpp"
+#include "Tpetra_LocalCrsMatrixOperator.hpp"
 #include "Tpetra_RowMatrix_decl.hpp"
 #include "Tpetra_Exceptions.hpp"
 #include "Tpetra_DistObject.hpp"
@@ -2456,6 +2456,16 @@ protected:
           Details::WrappedDualView<values_dualv_type>;
     values_wdv_type valuesUnpacked_wdv;
     mutable values_wdv_type valuesPacked_wdv;
+
+    using ordinal_rowptrs_type = typename local_multiply_op_type::ordinal_view_type;
+    /// \brief local_ordinal typed version of local matrix's rowptrs.
+    ///   This allows the LocalCrsMatrixOperator to have rowptrs and entries be the same type,
+    ///   so cuSPARSE SpMV (including merge-path) can be used for apply.
+    ///   This is allocated and populated lazily in getLocalMultiplyOperator(), only if all 4 conditions are met:
+    ///     - node_type is KokkosCudaWrapperNode
+    ///     - the cuSPARSE TPL is enabled
+    ///     - local_ordinal_type can represent getNodeNumEntries()
+    mutable ordinal_rowptrs_type ordinalRowptrs;
 
 public:
 

--- a/packages/tpetra/core/src/Tpetra_LocalCrsMatrixOperator_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_LocalCrsMatrixOperator_decl.hpp
@@ -87,10 +87,12 @@ namespace Tpetra {
                               void,
                               local_ordinal_type>;
     using local_graph_device_type = typename local_matrix_device_type::StaticCrsGraphType;
-    using ordinal_view_type = typename local_graph_device_type::entries_type::non_const_type;
 
   public:
+    using ordinal_view_type = typename local_graph_device_type::entries_type::non_const_type;
+
     LocalCrsMatrixOperator (const std::shared_ptr<local_matrix_device_type>& A);
+    LocalCrsMatrixOperator (const std::shared_ptr<local_matrix_device_type>& A, const ordinal_view_type& A_ordinal_rowptrs);
     ~LocalCrsMatrixOperator () override = default;
 
     void
@@ -118,12 +120,8 @@ namespace Tpetra {
 
   private:
     std::shared_ptr<local_matrix_device_type> A_;
-    //If the number of entries in A_ can be represented as ordinal,
-    //make a copy of the rowptrs as ordinal. This allows the use of cuSPARSE spmv.
-    //If cusparse is not enabled or there would be no benefit from using these,
-    //they are not allocated/initialized.
-    ordinal_view_type A_ordinal_rowptrs;
     local_cusparse_matrix_type A_cusparse;
+    const bool have_A_cusparse;
   };
 
 } // namespace Tpetra

--- a/packages/tpetra/core/src/Tpetra_LocalCrsMatrixOperator_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_LocalCrsMatrixOperator_def.hpp
@@ -51,32 +51,26 @@ namespace Tpetra {
 template<class MultiVectorScalar, class MatrixScalar, class Device>
 LocalCrsMatrixOperator<MultiVectorScalar, MatrixScalar, Device>::
 LocalCrsMatrixOperator (const std::shared_ptr<local_matrix_device_type>& A)
-  : A_ (A)
+  : A_ (A), have_A_cusparse(false)
 {
   const char tfecfFuncName[] = "LocalCrsMatrixOperator: ";
   TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
     (A_.get () == nullptr, std::invalid_argument,
      "Input matrix A is null.");
-#if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOSKERNELS_ENABLE_TPL_CUSPARSE)
-  //Only create A_ordinal_rowptrs if:
-  //  - KokkosKernels cuSPARSE support is enabled (otherwise, no benefit)
-  //  - The execution space is CUDA
-  //  - The local matrix offset and ordinal types are different (otherwise, no reason to enable)
-  //  - The number of entries can be represented by the ordinal type.
-  using kk_offset_t = typename std::remove_const<typename local_matrix_device_type::size_type>::type;
-  using kk_ordinal_t = typename std::remove_const<typename local_matrix_device_type::ordinal_type>::type;
-  using exec_space = typename Device::execution_space;
-  if(std::is_same<exec_space, Kokkos::Cuda>::value &&
-      !std::is_same<kk_offset_t, kk_ordinal_t>::value &&
-      A_->nnz() < static_cast<kk_offset_t>(Teuchos::OrdinalTraits<kk_ordinal_t>::max()))
-  {
-    A_ordinal_rowptrs = ordinal_view_type(Kokkos::ViewAllocateWithoutInitializing("A_ordinal_rowptrs"), A_->numRows() + 1);
-    //This is just like a deep copy, but it implicitly converts each element
-    KokkosKernels::Impl::copy_view<typename local_graph_device_type::row_map_type, ordinal_view_type, exec_space>
-      (A_ordinal_rowptrs.extent(0), A_->graph.row_map, A_ordinal_rowptrs);
-    A_cusparse = local_cusparse_matrix_type("A(cusparse)", A_->numRows(), A_->numCols(), A_->nnz(), A_->values, A_ordinal_rowptrs, A_->graph.entries);
-  }
-#endif
+}
+
+template<class MultiVectorScalar, class MatrixScalar, class Device>
+LocalCrsMatrixOperator<MultiVectorScalar, MatrixScalar, Device>::
+LocalCrsMatrixOperator (const std::shared_ptr<local_matrix_device_type>& A, const ordinal_view_type& A_ordinal_rowptrs) :
+  A_ (A),
+  A_cusparse("LocalCrsMatrixOperator_cuSPARSE", A->numRows(), A->numCols(), A->nnz(),
+      A->values, A_ordinal_rowptrs, A->graph.entries),
+  have_A_cusparse(true)
+{
+  const char tfecfFuncName[] = "LocalCrsMatrixOperator: ";
+  TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+    (A_.get () == nullptr, std::invalid_argument,
+     "Input matrix A is null.");
 }
 
 template<class MultiVectorScalar, class MatrixScalar, class Device>
@@ -120,7 +114,7 @@ apply (Kokkos::View<const mv_scalar_type**, array_layout,
      KokkosSparse::Transpose) : KokkosSparse::NoTranspose;
   //Currently KK has no cusparse wrapper for rank-2 (SpMM)
   //TODO: whent that is supported, use A_cusparse for that case also
-  if(X.extent(1) == size_t(1) && A_ordinal_rowptrs.extent(0))
+  if(X.extent(1) == size_t(1) && have_A_cusparse)
   {
     KokkosSparse::spmv (op, alpha, A_cusparse, Kokkos::subview(X, Kokkos::ALL(), 0),
                             beta, Kokkos::subview(Y, Kokkos::ALL(), 0));
@@ -169,7 +163,7 @@ applyImbalancedRows (
   //TODO BMK: If/when KokkosKernels gets its own SPMV implementation for imbalanced rows,
   //call that here or select it using Controls.
   //Ideally it supports multivectors from the beginning.
-  if((Details::Behavior::useMergePathMultiVector() || X.extent(1) == size_t(1)) && A_ordinal_rowptrs.extent(0))
+  if((Details::Behavior::useMergePathMultiVector() || X.extent(1) == size_t(1)) && have_A_cusparse)
   {
     KokkosKernels::Experimental::Controls controls;
     controls.setParameter("algorithm", "merge");


### PR DESCRIPTION
Lazily generate and cache the LO-typed rowptrs in CrsMatrix,
instead of recomputing every apply.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
After UVM removal, ``CrsMatrix::getLocalMultiplyOperator`` would construct a new LocalCrsMatrixOperator every time it was called. This constructor would convert the rowptrs from size_type to LocalOrdinal (int) in a parallel_for so that cuSparse SpMV can be used, but this is a nontrivial amount of work and shouldn't be done every apply.

This PR just caches the int-typed rowptrs in CrsMatrix, and then passes that to a new low-overhead constructor for LocalCrsMatrixOperator.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
@jennloe noticed this performance regression in Belos driver.
## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->