### PR TITLE
New proxy setting to match the change Friday

### DIFF
--- a/cmake/std/PullRequestLinuxDriver-old.sh
+++ b/cmake/std/PullRequestLinuxDriver-old.sh
@@ -20,8 +20,8 @@
 # and we get the correct behavior for PR testing.
 #
 
-export https_proxy=http://wwwproxy.sandia.gov:80
-export http_proxy=http://wwwproxy.sandia.gov:80
+export https_proxy=http://proxy.sandia.gov:80
+export http_proxy=http://proxy.sandia.gov:80
 no_proxy='localhost,localnets,.sandia.gov,127.0.0.1,169.254.0.0/16,forge.sandia.gov'
 
 whoami

--- a/cmake/std/PullRequestLinuxDriver.sh
+++ b/cmake/std/PullRequestLinuxDriver.sh
@@ -68,8 +68,8 @@ function bootstrap_modules() {
 print_banner "PullRequestLinuxDriver.sh"
 
 # Set up Sandia PROXY environment vars
-export https_proxy=http://wwwproxy.sandia.gov:80
-export http_proxy=http://wwwproxy.sandia.gov:80
+export https_proxy=http://proxy.sandia.gov:80
+export http_proxy=http://proxy.sandia.gov:80
 export no_proxy='localhost,localnets,127.0.0.1,169.254.0.0/16,forge.sandia.gov'
 
 

--- a/cmake/std/common.bash
+++ b/cmake/std/common.bash
@@ -182,7 +182,7 @@ function get_md5sum() {
 #
 #    get_pip_args=(
 #        --user
-#        --proxy="http://user:nopass@wwwproxy.sandia.gov:80"
+#        --proxy="http://user:nopass@proxy.sandia.gov:80"
 #        --no-setuptools
 #        --no-wheel
 #    )


### PR DESCRIPTION
@trilinos/framework 

## Motivation
Now that the python systems are using the correct proxies and cert files we are failing due to the internal script settings. This just changes them to the new proxy.

