### PR TITLE
Change The intel license info temporarily

### DIFF
--- a/cmake/std/pr_config/pullrequest.ini
+++ b/cmake/std/pr_config/pullrequest.ini
@@ -281,7 +281,7 @@ module-remove sems-superlu:
 module-load sems-superlu_dist: 5.2.2/32bit_parallel
 use ATDM-DEFAULT:
 setenv LDFLAGS: -lifcore
-unsetenv: INTEL_LICENSE_FILE
+unsetenv INTEL_LICENSE_FILE:
 setenv LM_LICENSE_FILE: 28518@cee-infra009.sandia.gov
 
 
@@ -296,7 +296,7 @@ use SEMS-DEFAULT:
 module-remove sems-openmpi:
 use ATDM-DEFAULT:
 setenv LDFLAGS: -lifcore
-unsetenv: INTEL_LICENSE_FILE
+unsetenv INTEL_LICENSE_FILE:
 setenv LM_LICENSE_FILE: 28518@cee-infra009.sandia.gov
 
 

--- a/cmake/std/pr_config/pullrequest.ini
+++ b/cmake/std/pr_config/pullrequest.ini
@@ -281,6 +281,8 @@ module-remove sems-superlu:
 module-load sems-superlu_dist: 5.2.2/32bit_parallel
 use ATDM-DEFAULT:
 setenv LDFLAGS: -lifcore
+unsetenv: INTEL_LICENSE_FILE
+setenv LM_LICENSE_FILE: 28518@cee-infra009.sandia.gov
 
 
 
@@ -294,6 +296,8 @@ use SEMS-DEFAULT:
 module-remove sems-openmpi:
 use ATDM-DEFAULT:
 setenv LDFLAGS: -lifcore
+unsetenv: INTEL_LICENSE_FILE
+setenv LM_LICENSE_FILE: 28518@cee-infra009.sandia.gov
 
 
 

--- a/cmake/std/sems/PullRequestIntel17.0.1TestingEnv.sh
+++ b/cmake/std/sems/PullRequestIntel17.0.1TestingEnv.sh
@@ -32,6 +32,10 @@ module load sems-git/2.10.1
 module unload sems-python
 module load sems-python/3.5.2
 
+# Change the intel license reference until sems can correct it
+unset INTEL_LICENSE_FILE
+export LM_LICENSE_FILE=28518@cee-infra009.sandia.gov
+
 # add the OpenMP environment variable we need
 export OMP_NUM_THREADS=2
 

--- a/cmake/std/sems/PullRequestIntel19.0.5TestingEnv.sh
+++ b/cmake/std/sems/PullRequestIntel19.0.5TestingEnv.sh
@@ -32,6 +32,10 @@ module load sems-git/2.10.1
 module unload sems-python
 module load sems-python/3.5.2
 
+# Change the intel license reference until sems can correct it
+unset INTEL_LICENSE_FILE
+export LM_LICENSE_FILE=28518@cee-infra009.sandia.gov
+
 # add the OpenMP environment variable we need
 export OMP_NUM_THREADS=2
 


### PR DESCRIPTION
Currently the sems module for intel compilers
does not find a license. This uses the info from
the system compilers modules instead.

@trilinos/framework 

## Motivation
This is a temporary resolution until the module becomes useable again.

## Related Issues

* Part of #9293 

## Testing
I was able to confirm both the problem and the solution at the command line by doing 'icc --version' and compiling a simple test source.
