### PR TITLE
Tpetra: Fix compiling and running with SYCL and MPI

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Distributor.hpp
+++ b/packages/tpetra/core/src/Tpetra_Distributor.hpp
@@ -2122,6 +2122,15 @@ namespace Tpetra {
        "See Trilinos GitHub issue #1088.");
 #endif // KOKKOS_ENABLE_CUDA
 
+#ifdef KOKKOS_ENABLE_SYCL
+    static_assert
+      (! std::is_same<typename ExpView::memory_space, Kokkos::Experimental::SYCLSharedUSMSpace>::value &&
+       ! std::is_same<typename ImpView::memory_space, Kokkos::Experimental::SYCLSharedUSMSpace>::value,
+       "Please do not use Tpetra::Distributor with SharedUSM allocations.  "
+       "See Trilinos GitHub issue #1088 (corresponding to CUDA).");
+#endif // KOKKOS_ENABLE_SYCL
+
+
 #ifdef HAVE_TPETRA_DISTRIBUTOR_TIMINGS
     Teuchos::TimeMonitor timeMon (*timer_doPosts3KV_);
 #endif // HAVE_TPETRA_DISTRIBUTOR_TIMINGS
@@ -2564,6 +2573,14 @@ namespace Tpetra {
                    "Please do not use Tpetra::Distributor with UVM "
                    "allocations.  See GitHub issue #1088.");
 #endif // KOKKOS_ENABLE_CUDA
+
+#ifdef KOKKOS_ENABLE_SYCL
+    static_assert (! std::is_same<typename ExpView::memory_space, Kokkos::Experimental::SYCLSharedUSMSpace>::value &&
+                   ! std::is_same<typename ImpView::memory_space, Kokkos::Experimental::SYCLSharedUSMSpace>::value,
+                   "Please do not use Tpetra::Distributor with SharedUSM "
+                   "allocations.  See GitHub issue #1088 (corresponding to CUDA).");
+#endif // KOKKOS_ENABLE_SYCL
+
 
     std::unique_ptr<std::string> prefix;
     if (verbose_) {

--- a/packages/tpetra/core/test/Distributor/Issue1454.cpp
+++ b/packages/tpetra/core/test/Distributor/Issue1454.cpp
@@ -98,9 +98,14 @@ TEUCHOS_UNIT_TEST( Distributor, Issue1454 )
   std::is_same<typename device_type::execution_space, Kokkos::Cuda>::value,
     Kokkos::CudaSpace,
     typename device_type::memory_space>::type;
+#elif defined(KOKKOS_ENABLE_SYCL)
+  using buffer_memory_space = typename std::conditional<
+  std::is_same<typename device_type::execution_space, Kokkos::Experimental::SYCL>::value,
+    Kokkos::Experimental::SYCLDeviceUSMSpace,
+    typename device_type::memory_space>::type;
 #else
   using buffer_memory_space = typename device_type::memory_space;
-#endif // KOKKOS_ENABLE_CUDA
+#endif
   using buffer_execution_space = typename device_type::execution_space;
   using buffer_device_type = Kokkos::Device<buffer_execution_space, buffer_memory_space>;
 

--- a/packages/tpetra/core/test/PerformanceCGSolve/cg_solve_file.cpp
+++ b/packages/tpetra/core/test/PerformanceCGSolve/cg_solve_file.cpp
@@ -306,6 +306,8 @@ int main(int argc, char *argv[]) {
     numgpus = std::atoi(rawKokkosNumDevices);
   int skipgpu = 999;
 
+  bool useSYCL = false;
+  bool useHIP = false;
   bool useCuda = false;
   bool useOpenMP = false;
   bool useThreads = false;
@@ -327,6 +329,12 @@ int main(int argc, char *argv[]) {
   cmdp.setOption("tol_small",&tol_small,"Tolerance for total CG-Time and final residual.");
   cmdp.setOption("tol_large",&tol_large,"Tolerance for individual times.");
   //Only provide the option to use Node types that are actually enabled in this build
+#ifdef HAVE_TPETRA_INST_SYCL
+  cmdp.setOption("sycl","no-sycl",&useSYCL,"Use SYCL node");
+#endif
+  #ifdef HAVE_TPETRA_INST_HIP
+  cmdp.setOption("hip","no-hip",&useHIP,"Use HIP node");
+#endif
 #ifdef HAVE_TPETRA_INST_CUDA
   cmdp.setOption("cuda","no-cuda",&useCuda,"Use Cuda node");
 #endif
@@ -344,8 +352,22 @@ int main(int argc, char *argv[]) {
   }
 
   //If no node type was explicitly requested, use Tpetra's default node
-  if(!useCuda && !useOpenMP && !useThreads && !useSerial)
+  if(!useSYCL && !useHIP && !useCuda && !useOpenMP && !useThreads && !useSerial)
   {
+#ifdef HAVE_TPETRA_INST_SYCL
+    if(std::is_same<default_exec, Kokkos::Experimental::SYCL>::value)
+    {
+      std::cout << "No node specified in command-line args, so using default (SYCL)\n";
+      useSYCL = true;
+    }
+#endif
+#ifdef HAVE_TPETRA_INST_HIP
+    if(std::is_same<default_exec, Kokkos::Experimental::HIP>::value)
+    {
+      std::cout << "No node specified in command-line args, so using default (HIP)\n";
+      useHIP = true;
+    }
+#endif
 #ifdef HAVE_TPETRA_INST_CUDA
     if(std::is_same<default_exec, Kokkos::Cuda>::value)
     {
@@ -389,6 +411,14 @@ int main(int argc, char *argv[]) {
 
   Kokkos::initialize (kokkosArgs);
   {
+#ifdef HAVE_TPETRA_INST_SYCL
+    if(useSYCL)
+      return run<KokkosSYCLWrapperNode>();
+#endif
+#ifdef HAVE_TPETRA_INST_HIP
+    if(useHIP)
+      return run<KokkosHIPWrapperNode>();
+#endif
 #ifdef HAVE_TPETRA_INST_CUDA
     if(useCuda)
       return run<KokkosCudaWrapperNode>();


### PR DESCRIPTION
@trilinos/tpetra

## Motivation
The changes in this pull request are necessary to pass the tests when building with `Tpetra` and `MPI` enabled using the `SYCL` backend in `Kokkos`. In particular, there were some changes necessary to run the PerformanceCGTest benchmark. This pull request also adds the corresponding changes for `HIP`.
It's debatable if we just want to allow using `SYCLSharedUSMSpace` for MPI communication or not, but I decided to mirror `CUDA` instead of `HIP` here since `SYCLSharedUSMSpace` corresponds to `SYCLSharedUSMSpace` whereas `HIPHostPinnedSpace` is somewhat different.

## Testing
I checked that the tests run correctly on Intel GPUs.