### PR TITLE
Tpetra: remove some deprecated stuff

### DIFF
--- a/packages/tpetra/core/src/Tpetra_EpetraRowMatrix.hpp
+++ b/packages/tpetra/core/src/Tpetra_EpetraRowMatrix.hpp
@@ -178,22 +178,22 @@ EpetraRowMatrix<TpetraMatrixType>::EpetraRowMatrix(
   this->SetMaps (epetraRowMap, epetraColMap);
 }
 
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
 template<class TpetraMatrixType>
 int EpetraRowMatrix<TpetraMatrixType>::ExtractMyRowCopy(int MyRow, int Length, int & NumEntries, double *Values, int * Indices) const
 {
+  using inds_view = typename TpetraMatrixType::nonconst_local_inds_host_view_type;
+  using vals_view = typename TpetraMatrixType::nonconst_values_host_view_type;
   static_assert (std::is_same<typename TpetraMatrixType::scalar_type, double>::value,
                  "This code assumes that Tpetra::CrsMatrix's scalar_type is int.");
   static_assert (std::is_same<typename TpetraMatrixType::local_ordinal_type, int>::value,
                  "This code assumes that Tpetra::CrsMatrix's local_ordinal_type is int.");
-  Teuchos::ArrayView<int> inds(Indices, Length);
-  Teuchos::ArrayView<double> vals(Values, Length);
+  inds_view IndicesView(Indices, Length);
+  vals_view ValuesView(Values, Length);
   size_t num_entries = NumEntries;
-  tpetra_matrix_->getLocalRowCopy(MyRow, inds, vals, num_entries);
+  tpetra_matrix_->getLocalRowCopy(MyRow, IndicesView, ValuesView, num_entries);
   NumEntries = num_entries;
   return 0;
 }
-#endif
 
 template<class TpetraMatrixType>
 int EpetraRowMatrix<TpetraMatrixType>::ExtractMyEntryView(int CurEntry, double * & Value, int & RowIndex, int & ColIndex)

--- a/packages/tpetra/core/src/Tpetra_RowMatrixTransposer_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_RowMatrixTransposer_def.hpp
@@ -181,7 +181,7 @@ createTransposeLocal (const Teuchos::RCP<Teuchos::ParameterList>& params)
   using values_type = typename local_matrix_device_type::values_type::non_const_type;
   using execution_space = typename local_matrix_device_type::execution_space;
 
-  local_matrix_device_type lclMatrix = crsMatrix->getLocalMatrix ();
+  local_matrix_device_type lclMatrix = crsMatrix->getLocalMatrixDevice ();
   local_matrix_device_type lclTransposeMatrix = KokkosKernels::Impl::transpose_matrix(lclMatrix);
   if (sort)
     KokkosKernels::Impl::sort_crs_matrix(lclTransposeMatrix);


### PR DESCRIPTION
- EpetraRowMatrix: don't call ArrayView version of getLocalRowCopy, and un-deprecate ExtractMyRowCopy since it can just call the Kokkos::View version.
- RowMatrixTransposer: don't call getLocalMatrix

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Fix build of Tpetra (library+tests) with deprecated code off.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
@jennloe ran into the build error of RowMatrixTransposer in a build of Albany. Our nightly deprecated-off build on ascicgpu031 has been hitting it too, but I think we all ignored that :P
## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->