### PR TITLE
Tpetra: Remove some output from the Bug7758 test

### DIFF
--- a/packages/tpetra/core/test/MultiVector/Bug7758.cpp
+++ b/packages/tpetra/core/test/MultiVector/Bug7758.cpp
@@ -82,9 +82,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7758, DefaultToDefault, Scalar,LO,GO,Node)
   Teuchos::RCP<const map_t> defaultMap = 
            rcp(new map_t(nGlobalEntries, 0, comm));
 
-  std::cout << me << " DEFAULT MAP" << std::endl;
-  defaultMap->describe(foo, Teuchos::VERB_EXTREME);
-
   // Create vectors; see what the result is with CombineMode=ADD
 
   vector_t defaultVecTgt(defaultMap);
@@ -97,9 +94,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7758, DefaultToDefault, Scalar,LO,GO,Node)
 
   Tpetra::Export<LO,GO,Node> defaultToDefault(defaultMap, defaultMap);
   defaultVecTgt.doExport(defaultVecSrc, defaultToDefault, Tpetra::ADD);
-
-  std::cout << me << " DEFAULT TO DEFAULT " << std::endl;
-  defaultVecTgt.describe(foo, Teuchos::VERB_EXTREME);
 
   // Check result; all vector entries should be srcScalar
   auto data = defaultVecTgt.getLocalViewHost(Tpetra::Access::ReadOnly);
@@ -144,9 +138,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7758, CyclicToDefault, Scalar,LO,GO,Node)
   Teuchos::RCP<const map_t> defaultMap = 
            rcp(new map_t(nGlobalEntries, 0, comm));
 
-  std::cout << me << " DEFAULT MAP" << std::endl;
-  defaultMap->describe(foo, Teuchos::VERB_EXTREME);
-
   // One-to-one cyclic map:  deal out entries like cards
 
   int nMyEntries = 0;
@@ -161,9 +152,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7758, CyclicToDefault, Scalar,LO,GO,Node)
   Teuchos::RCP<const map_t> cyclicMap = 
            rcp(new map_t(dummy, myEntries(0,nMyEntries), 0, comm));
 
-  std::cout << me << " CYCLIC MAP" << std::endl;
-  cyclicMap->describe(foo, Teuchos::VERB_EXTREME);
-
   // Create vectors; see what the result is with CombineMode=ADD
 
   vector_t defaultVecTgt(defaultMap);
@@ -176,9 +164,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7758, CyclicToDefault, Scalar,LO,GO,Node)
 
   Tpetra::Export<LO,GO,Node> cyclicToDefault(cyclicMap, defaultMap);
   defaultVecTgt.doExport(cyclicVecSrc, cyclicToDefault, Tpetra::ADD);
-
-  std::cout << me << " CYCLIC TO DEFAULT " << std::endl;
-  defaultVecTgt.describe(foo, Teuchos::VERB_EXTREME);
 
   // Check result
 
@@ -234,9 +219,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7758, OverlapToDefault, Scalar,LO,GO,Node)
     Teuchos::RCP<const map_t> defaultMap = 
              rcp(new map_t(nGlobalEntries, 0, comm));
 
-    std::cout << me << " DEFAULT MAP" << std::endl;
-    defaultMap->describe(foo, Teuchos::VERB_EXTREME);
-
     // Overlap map; some entries are stored on two procs
     int nMyEntries = 0;
     for (size_t i = 0; i < defaultMap->getNodeNumElements()/2; i++) {
@@ -252,9 +234,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7758, OverlapToDefault, Scalar,LO,GO,Node)
     Teuchos::RCP<const map_t> overlapMap = 
              rcp(new map_t(dummy, myEntries(0,nMyEntries), 0, comm));
   
-    std::cout << me << " OVERLAP MAP" << std::endl;
-    overlapMap->describe(foo, Teuchos::VERB_EXTREME);
-
     // Create vectors; see what the result is with CombineMode=ADD
 
     vector_t defaultVecTgt(defaultMap);
@@ -267,9 +246,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7758, OverlapToDefault, Scalar,LO,GO,Node)
 
     Tpetra::Export<LO,GO,Node> overlapToDefault(overlapMap, defaultMap);
     defaultVecTgt.doExport(overlapVecSrc, overlapToDefault, Tpetra::ADD);
-
-    std::cout << me << " OVERLAP TO DEFAULT " << std::endl;
-    defaultVecTgt.describe(foo, Teuchos::VERB_EXTREME);
 
     auto data = defaultVecTgt.getLocalViewHost(Tpetra::Access::ReadOnly);
     for (size_t i = 0; i < defaultVecTgt.getLocalLength()/2; i++) {
@@ -331,18 +307,12 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7758, OddEvenToSerial, Scalar,LO,GO,Node)
   Teuchos::RCP<const map_t> oddEvenMap = 
            rcp(new map_t(dummy, myEntries(0,nMyEntries), 0, comm));
 
-  std::cout << me << " ODDEVEN MAP" << std::endl;
-  oddEvenMap->describe(foo, Teuchos::VERB_EXTREME);
-
   // Map with all entries on one processor
 
   dummy = Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid();
   size_t nSerialEntries = (me == 0 ? nGlobalEntries : 0);
   Teuchos::RCP<const map_t> serialMap = 
            rcp(new map_t(dummy, nSerialEntries, 0, comm));
-
-  std::cout << me << " SERIAL MAP" << std::endl;
-  serialMap->describe(foo, Teuchos::VERB_EXTREME);
 
   // Create vectors; see what the result is with CombineMode=ADD
 
@@ -356,9 +326,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7758, OddEvenToSerial, Scalar,LO,GO,Node)
 
   Tpetra::Export<LO,GO,Node> oddEvenToSerial(oddEvenMap, serialMap);
   serialVecTgt.doExport(oddEvenVecSrc, oddEvenToSerial, Tpetra::ADD);
-
-  std::cout << me << " ODDEVEN TO SERIAL " << std::endl;
-  serialVecTgt.describe(foo, Teuchos::VERB_EXTREME);
 
   // Check result
 
@@ -408,9 +375,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7758, SupersetToDefault, Scalar,LO,GO,Node)
     Teuchos::RCP<const map_t> defaultMap = 
              rcp(new map_t(nGlobalEntries, 0, comm));
 
-    std::cout << me << " DEFAULT MAP" << std::endl;
-    defaultMap->describe(foo, Teuchos::VERB_EXTREME);
-
     // Superset map; some entries are stored on two procs
     int nMyEntries = 0;
     for (size_t i = 0; i < defaultMap->getNodeNumElements(); i++) {
@@ -426,9 +390,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7758, SupersetToDefault, Scalar,LO,GO,Node)
     Teuchos::RCP<const map_t> supersetMap =
              rcp(new map_t(dummy, myEntries(0,nMyEntries), 0, comm));
   
-    std::cout << me << " SUPERSET MAP" << std::endl;
-    supersetMap->describe(foo, Teuchos::VERB_EXTREME);
-
     // Create vectors; see what the result is with CombineMode=ADD
 
     vector_t defaultVecTgt(defaultMap);
@@ -441,9 +402,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7758, SupersetToDefault, Scalar,LO,GO,Node)
 
     Tpetra::Export<LO,GO,Node> supersetToDefault(supersetMap, defaultMap);
     defaultVecTgt.doExport(supersetVecSrc, supersetToDefault, Tpetra::ADD);
-
-    std::cout << me << " SUPERSET TO DEFAULT " << std::endl;
-    defaultVecTgt.describe(foo, Teuchos::VERB_EXTREME);
 
     auto data = defaultVecTgt.getLocalViewHost(Tpetra::Access::ReadOnly);
     for (size_t i = 0; i < defaultVecTgt.getLocalLength()/2; i++)
@@ -490,9 +448,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7758, NoSamesToDefault, Scalar,LO,GO,Node)
     Teuchos::RCP<const map_t> defaultMap = 
              rcp(new map_t(nGlobalEntries, 0, comm));
 
-    std::cout << me << " DEFAULT MAP" << std::endl;
-    defaultMap->describe(foo, Teuchos::VERB_EXTREME);
-
     // Map with no sames or permutes
     int nMyEntries = 0;
     for (size_t i = 0; i < defaultMap->getNodeNumElements(); i++) {
@@ -505,9 +460,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7758, NoSamesToDefault, Scalar,LO,GO,Node)
     Teuchos::RCP<const map_t> noSamesMap = 
              rcp(new map_t(dummy, myEntries(0,nMyEntries), 0, comm));
   
-    std::cout << me << " NOSAMES MAP" << std::endl;
-    noSamesMap->describe(foo, Teuchos::VERB_EXTREME);
-
     // Create vectors; see what the result is with CombineMode=ADD
 
     vector_t defaultVecTgt(defaultMap);
@@ -520,9 +472,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7758, NoSamesToDefault, Scalar,LO,GO,Node)
 
     Tpetra::Export<LO,GO,Node> noSamesToDefault(noSamesMap, defaultMap);
     defaultVecTgt.doExport(noSamesVecSrc, noSamesToDefault, Tpetra::ADD);
-
-    std::cout << me << " NOSAMES TO DEFAULT " << std::endl;
-    defaultVecTgt.describe(foo, Teuchos::VERB_EXTREME);
 
     auto data = defaultVecTgt.getLocalViewHost(Tpetra::Access::ReadOnly);
     for (size_t i = 0; i < defaultVecTgt.getLocalLength(); i++)


### PR DESCRIPTION
@trilinos/tpetra @bartlettroscoe 

## Motivation
Some test output was overlapping with the "TEST PASSED" printout, likely due
to different buffering from different streams, and causing passing tests
to report failures on the dashboard.

This PR removes all printouts to std::cout from these tests, except those that
only print in case of a failure.

Thanks @bartlettroscoe for pointing this out.

## Related Issues

* Closes #9307 

## Testing
N/A -- this is a fix for a flaky test.