### PR TITLE
Tpetra: Performance script timing percentage support

### DIFF
--- a/packages/tpetra/scripts/PerformanceTesting/eclipse/JenkinsAction.sh
+++ b/packages/tpetra/scripts/PerformanceTesting/eclipse/JenkinsAction.sh
@@ -8,6 +8,7 @@ export TRILINOS_SRC="$WORKSPACE/Trilinos"
 rm -rf EclipsePerfScripts
 #Get a fresh copy
 scp -rp jenkins@sherlock.sandia.gov:$DATASTORE/Scripts/eclipse EclipsePerfScripts || true
+scp -rp jenkins@sherlock.sandia.gov:$DATASTORE/Scripts/timingPercentages EclipsePerfScripts || true
 #Copy the newest performance report tarball from data store
 scp -p jenkins@sherlock.sandia.gov:$DATASTORE/EclipseData.tar.gz EclipseData.tar.gz || true
 #Unpack it
@@ -19,6 +20,8 @@ tar -xf EclipseData.tar.gz
 mkdir -p build
 #Configure and build on a compute node, then run run tests on 4 compute nodes.
 $WORKSPACE/EclipsePerfScripts/launch.sh
+#put the time percentages in each xml file
+python $WORKSPACE/EclipsePerfScripts/timing_extractor.py -p EclipseData
 #Repack the up to date tarball of data, and put back in both datastores
 tar -czf EclipseData.tar.gz EclipseData
 scp -p EclipseData.tar.gz jenkins@sherlock.sandia.gov:$DATASTORE/EclipseData.tar.gz || true

--- a/packages/tpetra/scripts/PerformanceTesting/stria/JenkinsAction.sh
+++ b/packages/tpetra/scripts/PerformanceTesting/stria/JenkinsAction.sh
@@ -8,6 +8,7 @@ export TRILINOS_SRC="$WORKSPACE/Trilinos"
 rm -rf StriaPerfScripts
 #Get a fresh copy
 scp -rp jenkins@sherlock.sandia.gov:$DATASTORE/Scripts/stria StriaPerfScripts || true
+scp -rp jenkins@sherlock.sandia.gov:$DATASTORE/Scripts/timingPercentages StriaPerfScripts || true
 #Copy the newest performance report tarball from data store
 scp -p jenkins@sherlock.sandia.gov:$DATASTORE/StriaData.tar.gz StriaData.tar.gz || true
 #Unpack it, is directory "VortexData"
@@ -19,6 +20,8 @@ tar -xf StriaData.tar.gz
 mkdir -p build
 #Configure and build on a compute node, then run run tests on 4 compute nodes.
 $WORKSPACE/StriaPerfScripts/launch.sh
+#put the time percentages in each xml file
+python $WORKSPACE/StriaPerfScripts/timing_extractor.py -p StriaData
 #Repack the up to date tarball of data, and put back in datastore
 tar -czf StriaData.tar.gz StriaData
 scp -p StriaData.tar.gz jenkins@sherlock.sandia.gov:$DATASTORE/StriaData.tar.gz || true

--- a/packages/tpetra/scripts/PerformanceTesting/timingPercentages/timing_extractor.py
+++ b/packages/tpetra/scripts/PerformanceTesting/timingPercentages/timing_extractor.py
@@ -1,24 +1,46 @@
 import xml.etree.ElementTree as et
 import os
+import getopt
+import sys
 
-path = '.'
+def main():
+        try:
+                opts, args = getopt.getopt(sys.argv[1:], "p:", ["path="])
+        except getopt.GetoptError as err:
+                print(err)
+                usage()
+                sys.exit(2)
+        path = '.'
+        for k, v in opts:
+                if k in ("-p", "--path"):
+                        path = v
+                else:
+                        assert False, "unhandled option"
+        addPercent(path)
 
-for filename in os.listdir(path):
-	if not filename.endswith('.xml'): continue
-	fname = os.path.join(path, filename)
-	xmlTree = et.parse(fname)
-	first = True
-	overallTime = 0.0
-	for elem in xmlTree.iter():
-		if elem.tag == 'timing':
-			if first == True :
-				overallTime = float(elem.attrib['value'])
-				elem.set('percent', '100.0')
-				first = False
-			else :			
-				temp = float(elem.attrib['value'])
-				pct = temp/overallTime * 100.0
-				elem.set('percent', str(pct))
+def usage():
+        print("please supply -p or --path arguments")
 
-	xmlTree.write(fname)
 
+def addPercent(path) :
+        for filename in os.listdir(path):
+                if not filename.endswith('.xml'): continue
+                fname = os.path.join(path, filename)
+                xmlTree = et.parse(fname)
+                first = True
+                overallTime = 0.0
+                for elem in xmlTree.iter():
+                        if elem.tag == 'timing':
+                                if first == True :
+                                        overallTime = float(elem.attrib['value'])
+                                        elem.set('percent', '100.0')
+                                        first = False
+                                else :			
+                                        temp = float(elem.attrib['value'])
+                                        pct = temp/overallTime * 100.0
+                                        elem.set('percent', str(pct))
+
+                xmlTree.write(fname)
+
+if __name__ == "__main__":
+        main()

--- a/packages/tpetra/scripts/PerformanceTesting/timingPercentages/timing_extractor.py
+++ b/packages/tpetra/scripts/PerformanceTesting/timingPercentages/timing_extractor.py
@@ -1,0 +1,24 @@
+import xml.etree.ElementTree as et
+import os
+
+path = '.'
+
+for filename in os.listdir(path):
+	if not filename.endswith('.xml'): continue
+	fname = os.path.join(path, filename)
+	xmlTree = et.parse(fname)
+	first = True
+	overallTime = 0.0
+	for elem in xmlTree.iter():
+		if elem.tag == 'timing':
+			if first == True :
+				overallTime = float(elem.attrib['value'])
+				elem.set('percent', '100.0')
+				first = False
+			else :			
+				temp = float(elem.attrib['value'])
+				pct = temp/overallTime * 100.0
+				elem.set('percent', str(pct))
+
+	xmlTree.write(fname)
+

--- a/packages/tpetra/scripts/PerformanceTesting/vortex/JenkinsAction.sh
+++ b/packages/tpetra/scripts/PerformanceTesting/vortex/JenkinsAction.sh
@@ -8,6 +8,7 @@ export TRILINOS_SRC="$WORKSPACE/Trilinos"
 rm -rf VortexPerfScripts
 #Get a fresh copy
 scp -rp jenkins@sherlock.sandia.gov:$DATASTORE/Scripts/vortex VortexPerfScripts || true
+scp -rp jenkins@sherlock.sandia.gov:$DATASTORE/Scripts/timingPercentages VortexPerfScripts || true
 #Copy the newest performance report tarball from data store
 scp -p jenkins@sherlock.sandia.gov:$DATASTORE/VortexData.tar.gz VortexData.tar.gz || true
 #Unpack it, is directory "VortexData"
@@ -19,6 +20,8 @@ tar -xf VortexData.tar.gz
 mkdir -p build
 #Configure and build on a compute node, then run run tests on 4 compute nodes.
 $WORKSPACE/VortexPerfScripts/launch.sh
+#put the time percentages in each xml file
+python $WORKSPACE/VortexPerfScripts/timing_extractor.py -p VortexData
 #Repack the up to date tarball of data, and put back in datastore
 tar -czf VortexData.tar.gz VortexData
 scp -p VortexData.tar.gz jenkins@sherlock.sandia.gov:$DATASTORE/VortexData.tar.gz || true


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
This brings the percentage of overall time spent in each stage of the teuchos timers instantiated in the performance tests on the various platforms into the xml files generated at the end of each run.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
This is a testing framework addition, it was tested against historical .xml files.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->