### PR TITLE
Tpetra: fix several warnings

### DIFF
--- a/packages/tpetra/core/example/Lesson07-Kokkos-Fill/05_solve.cpp
+++ b/packages/tpetra/core/example/Lesson07-Kokkos-Fill/05_solve.cpp
@@ -420,9 +420,7 @@ int main (int argc, char* argv[]) {
     //
     // u(x) = -4.0 * (x - 0.5) * (x - 0.5) + 1.0 + (T_left - T_right)x.
     Tpetra::Vector<> x_exact (x, Teuchos::Copy);
-    typedef Tpetra::Vector<>::dual_view_type dual_view_type;
     typedef typename device_type::execution_space execution_space;
-    typedef typename device_type::memory_space memory_space;
     typedef Kokkos::RangePolicy<execution_space, LO> policy_type;
 
     auto x_exact_lcl = x_exact.getLocalViewDevice (Tpetra::Access::ReadWrite);

--- a/packages/tpetra/core/example/advanced/Benchmarks/blockCrsMatrixMatVec.cpp
+++ b/packages/tpetra/core/example/advanced/Benchmarks/blockCrsMatrixMatVec.cpp
@@ -79,7 +79,6 @@ localApplyBlockNoTrans (Tpetra::BlockCrsMatrix<Scalar, LO, GO, Node>& A,
     block_crs_matrix_type;
   typedef typename block_crs_matrix_type::impl_scalar_type IST;
   typedef Kokkos::Details::ArithTraits<IST> KAT;
-  typedef typename block_crs_matrix_type::device_type::memory_space device_memory_space;
   typedef typename block_crs_matrix_type::little_vec_type little_vec_type;
   typedef typename block_crs_matrix_type::little_block_type little_blk_type;
 
@@ -494,7 +493,6 @@ getTpetraBlockCrsMatrix (Teuchos::FancyOStream& out,
   using Teuchos::rcp;
   using std::endl;
   typedef Tpetra::BlockCrsMatrix<> matrix_type;
-  typedef matrix_type::device_type device_type;
   typedef matrix_type::impl_scalar_type SC;
   typedef Kokkos::Details::ArithTraits<SC> KAT;
   typedef Tpetra::Map<>::local_ordinal_type LO;

--- a/packages/tpetra/core/example/advanced/Benchmarks/localView.cpp
+++ b/packages/tpetra/core/example/advanced/Benchmarks/localView.cpp
@@ -653,7 +653,6 @@ main (int argc, char* argv[])
 
     totalLclNumEnt = 0;
     if (opts.testTpetra) {
-      typedef Tpetra::CrsMatrix<>::scalar_type SC;
       typedef Tpetra::CrsMatrix<>::local_ordinal_type LO;
 
       auto timer = TimeMonitor::getNewCounter ("Tpetra getLocalRowView");

--- a/packages/tpetra/core/guide/src/Examples/SourceCode/power_method_1.cpp
+++ b/packages/tpetra/core/guide/src/Examples/SourceCode/power_method_1.cpp
@@ -190,7 +190,6 @@ main (int argc, char *argv[])
   typedef Tpetra::Vector<>::mag_type magnitude_type;
   typedef Tpetra::CrsMatrix<> crs_matrix_type;
   typedef Tpetra::CrsMatrix<>::nonconst_global_inds_host_view_type nonconst_global_inds_host_view_type;
-  typedef Tpetra::CrsMatrix<>::nonconst_local_inds_host_view_type nonconst_locaal_inds_host_view_type;
   typedef Tpetra::CrsMatrix<>::nonconst_values_host_view_type nonconst_values_host_view_type;
 
   Teuchos::oblackholestream blackhole;

--- a/packages/tpetra/core/src/Tpetra_Details_scaleBlockDiagonal.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_scaleBlockDiagonal.hpp
@@ -67,8 +67,6 @@ namespace Details {
 template<class MultiVectorType>        
 void inverseScaleBlockDiagonal(MultiVectorType & blockDiagonal, bool doTranspose, MultiVectorType & multiVectorToBeScaled) {
   using LO             = typename MultiVectorType::local_ordinal_type;
-  using local_mv_type  = typename MultiVectorType::dual_view_type::t_dev;
-  using local_mv_type_um  = typename MultiVectorType::dual_view_type::t_dev_um;
   using range_type     = Kokkos::RangePolicy<typename MultiVectorType::node_type::execution_space, LO>;
   using namespace KokkosBatched;
   typename MultiVectorType::impl_scalar_type SC_one = Teuchos::ScalarTraits<typename MultiVectorType::impl_scalar_type>::one();

--- a/packages/tpetra/core/src/Tpetra_Details_unpackCrsMatrixAndCombine_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_unpackCrsMatrixAndCombine_def.hpp
@@ -1212,9 +1212,6 @@ unpackCrsMatrixAndCombine(
   static_assert (std::is_same<device_type, typename local_matrix_device_type::device_type>::value,
                  "Node::device_type and LocalMatrix::device_type must be the same.");
 
-  // Execution space.
-  typedef typename device_type::execution_space XS;
-
   // Convert all Teuchos::Array to Kokkos::View.
   device_type outputDevice;
 
@@ -1463,7 +1460,6 @@ unpackAndCombineIntoCrsArrays (
   typedef LocalOrdinal LO;
 
   typedef typename Node::device_type DT;
-  typedef typename DT::execution_space XS;
 
   typedef CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> matrix_type;
   typedef typename matrix_type::impl_scalar_type ST;

--- a/packages/tpetra/core/src/Tpetra_RowMatrixTransposer_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_RowMatrixTransposer_def.hpp
@@ -128,7 +128,6 @@ createTransposeLocal (const Teuchos::RCP<Teuchos::ParameterList>& params)
   using Teuchos::rcp_dynamic_cast;
   using LO = LocalOrdinal;
   using GO = GlobalOrdinal;
-  using IST = typename CrsMatrix<Scalar, LO, GO, Node>::impl_scalar_type;
   using import_type = Tpetra::Import<LO, GO, Node>;
   using export_type = Tpetra::Export<LO, GO, Node>;
 
@@ -174,12 +173,6 @@ createTransposeLocal (const Teuchos::RCP<Teuchos::ParameterList>& params)
   }
 
   using local_matrix_device_type = typename crs_matrix_type::local_matrix_device_type;
-  using local_graph_device_type = typename crs_matrix_type::local_graph_device_type;
-  using offset_type = typename local_graph_device_type::size_type;
-  using row_map_type = typename local_matrix_device_type::row_map_type::non_const_type;
-  using index_type = typename local_matrix_device_type::index_type::non_const_type;
-  using values_type = typename local_matrix_device_type::values_type::non_const_type;
-  using execution_space = typename local_matrix_device_type::execution_space;
 
   local_matrix_device_type lclMatrix = crsMatrix->getLocalMatrixDevice ();
   local_matrix_device_type lclTransposeMatrix = KokkosKernels::Impl::transpose_matrix(lclMatrix);

--- a/packages/tpetra/core/test/Block/BlockCrsMatrix.cpp
+++ b/packages/tpetra/core/test/Block/BlockCrsMatrix.cpp
@@ -168,9 +168,6 @@ namespace {
     using values_host_view_type = typename BCM::values_host_view_type;
     using impl_scalar_type = typename BCM::impl_scalar_type;
 
-    // The typedef below is also a test.  BlockCrsMatrix must have
-    // this typedef, or this test won't compile.
-    typedef typename BCM::little_block_type little_block_type;
     typedef typename BCM::little_block_host_type little_block_host_type;
     typedef Teuchos::ScalarTraits<Scalar> STS;
     typedef typename STS::magnitudeType MT;
@@ -878,9 +875,6 @@ namespace {
     typedef Tpetra::BlockCrsMatrix<Scalar, LO, GO, Node> BCM;
     typedef Tpetra::CrsGraph<LO, GO, Node> graph_type;
     typedef Tpetra::Map<LO, GO, Node> map_type;
-    // The typedef below is also a test.  BlockCrsMatrix must have
-    // this typedef, or this test won't compile.
-    typedef typename BCM::little_block_type little_block_type;
     typedef typename BCM::little_block_host_type little_block_host_type;
     typedef Teuchos::ScalarTraits<Scalar> STS;
     typedef typename STS::magnitudeType MT;
@@ -1014,9 +1008,6 @@ namespace {
     typedef typename BCM::impl_scalar_type IST;
     typedef Tpetra::CrsGraph<LO, GO, Node> graph_type;
     typedef Tpetra::Map<LO, GO, Node> map_type;
-    // The typedef below is also a test.  BlockCrsMatrix must have
-    // this typedef, or this test won't compile.
-    typedef typename BCM::little_block_type little_block_type;
     typedef typename BCM::little_block_host_type little_block_host_type;
     typedef Teuchos::ScalarTraits<Scalar> STS;
 

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_LeftRightScale.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_LeftRightScale.cpp
@@ -119,7 +119,6 @@ namespace {
     typedef Teuchos::ScalarTraits<ST> STS;
     typedef typename STS::magnitudeType MT;
     typedef Teuchos::ScalarTraits<MT> STM;
-    typedef typename ArrayView<const LO>::size_type size_type;
     typedef CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> MAT;
 
     MT mySum = STM::zero ();

--- a/packages/tpetra/core/test/CrsMatrix/Regression/Albany182.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/Regression/Albany182.cpp
@@ -188,7 +188,6 @@ namespace { // (anonymous)
                                  const CrsMatrixType& A)
   {
     using std::endl;
-    typedef typename CrsMatrixType::scalar_type ST;
     typedef typename CrsMatrixType::map_type map_type;
     typedef typename CrsMatrixType::local_ordinal_type LO;
     typedef typename CrsMatrixType::global_ordinal_type GO;

--- a/packages/tpetra/core/test/MultiVector/Issue46.cpp
+++ b/packages/tpetra/core/test/MultiVector/Issue46.cpp
@@ -193,12 +193,6 @@ void issue46Test (bool& success, Teuchos::FancyOStream& out)
   typedef typename MV::global_ordinal_type GO;
   typedef typename MV::node_type NT;
   typedef Tpetra::Map<LO, GO, NT> map_type;
-  typedef typename MV::impl_scalar_type IST;
-  typedef typename MV::dual_view_type::array_layout array_layout;
-  typedef typename MV::device_type device_type;
-  typedef typename device_type::memory_space dev_memory_space;
-  typedef typename Kokkos::View<IST**, array_layout,
-    device_type>::HostMirror::memory_space host_memory_space;
 
   out << "Test Github Issue #46 (offset view of an offset view of a "
     "Tpetra::MultiVector)" << endl;

--- a/packages/tpetra/core/test/MultiVector/MultiVector_get2dView.cpp
+++ b/packages/tpetra/core/test/MultiVector/MultiVector_get2dView.cpp
@@ -78,7 +78,6 @@ namespace { // (anonymous)
     typedef Teuchos::ScalarTraits<Scalar> STS;
     typedef typename MV::mag_type mag_type;
     typedef Teuchos::ScalarTraits<mag_type> STM;
-    typedef typename MV::device_type device_type;
 
     out << "Test Tpetra::MultiVector::get2dView and get2dViewNonConst" << endl;
     Teuchos::OSTab tab1 (out);

--- a/packages/tpetra/core/test/RowMatrixTransposer/main.cpp
+++ b/packages/tpetra/core/test/RowMatrixTransposer/main.cpp
@@ -48,7 +48,6 @@
 
 template<class CrsMatrix_t>
 typename CrsMatrix_t::scalar_type getNorm(CrsMatrix_t& matrix){
-  typedef typename CrsMatrix_t::local_ordinal_type LO;
   typedef typename CrsMatrix_t::scalar_type Scalar;
   Scalar mySum = 0;
 

--- a/packages/tpetra/core/test/inout/MatrixMarket_Tpetra_CrsMatrix_FileTest.cpp
+++ b/packages/tpetra/core/test/inout/MatrixMarket_Tpetra_CrsMatrix_FileTest.cpp
@@ -135,7 +135,6 @@ template<class CrsMatrixType>
 bool
 compareCrsMatrix (const CrsMatrixType& A_orig, const CrsMatrixType& A, Teuchos::FancyOStream& out)
 {
-  typedef typename CrsMatrixType::scalar_type ST;
   typedef typename CrsMatrixType::global_ordinal_type GO;
   typedef typename ArrayView<const GO>::size_type size_type;
   typedef typename CrsMatrixType::nonconst_global_inds_host_view_type gids_type;

--- a/packages/tpetra/core/test/inout/MatrixMarket_Tpetra_CrsMatrix_InOutTest.cpp
+++ b/packages/tpetra/core/test/inout/MatrixMarket_Tpetra_CrsMatrix_InOutTest.cpp
@@ -261,7 +261,6 @@ compareCrsMatrix (const CrsMatrixType& A_orig, const CrsMatrixType& A, Teuchos::
   using Teuchos::RCP;
   using Teuchos::reduceAll;
   using Teuchos::REDUCE_MIN;
-  typedef typename CrsMatrixType::scalar_type ST;
   typedef typename CrsMatrixType::global_ordinal_type GO;
   typedef typename ArrayView<const GO>::size_type size_type;
   typedef typename CrsMatrixType::nonconst_global_inds_host_view_type gids_type;

--- a/packages/tpetra/core/test/inout/MatrixMarket_Tpetra_OperatorTest.cpp
+++ b/packages/tpetra/core/test/inout/MatrixMarket_Tpetra_OperatorTest.cpp
@@ -257,7 +257,6 @@ compareCrsMatrix (const CrsMatrixType& A_orig, const CrsMatrixType& A, Teuchos::
   using Teuchos::RCP;
   using Teuchos::reduceAll;
   using Teuchos::REDUCE_MIN;
-  typedef typename CrsMatrixType::scalar_type ST;
   typedef typename CrsMatrixType::global_ordinal_type GO;
   typedef typename ArrayView<const GO>::size_type size_type;
   using gids_type = typename CrsMatrixType::nonconst_global_inds_host_view_type;


### PR DESCRIPTION
@trilinos/tpetra

## Motivation
GCC compiler warnings for "unused typedefs" were getting very noisy.

## Testing
Continues to pass all Tpetra tests.