### PR TITLE
Ifpack2: fix arithmetic error on device

### DIFF
--- a/packages/ifpack2/src/Ifpack2_IlukGraph.hpp
+++ b/packages/ifpack2/src/Ifpack2_IlukGraph.hpp
@@ -305,8 +305,8 @@ void IlukGraph<GraphType, KKHandleType>::initialize()
                            // Heuristic to get the maximum number of entries per row.
                            int RowMaxNumIndices = localOverlapGraph.rowConst(i).length;
                            numEntPerRow_d(i) = (levelfill == 0) ? RowMaxNumIndices  // No additional storage needed
-                             : ceil(static_cast<double>(RowMaxNumIndices) 
-                                    * pow(overalloc, levelfill));
+                             : Kokkos::Experimental::ceil(static_cast<double>(RowMaxNumIndices) 
+                                    * Kokkos::Experimental::pow(overalloc, levelfill));
                          });
    
   };

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestHelpers.hpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestHelpers.hpp
@@ -351,7 +351,10 @@ Teuchos::RCP<Tpetra::CrsGraph<LocalOrdinal,GlobalOrdinal,Node> > create_dense_lo
 template<class Scalar,class LocalOrdinal,class GlobalOrdinal,class Node>
 Teuchos::RCP<const Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > create_test_matrix(const Teuchos::RCP<const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> >& rowmap, Scalar val=Teuchos::ScalarTraits<Scalar>::zero())
 {
-  Teuchos::RCP<Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > crsmatrix = Teuchos::rcp(new Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>(rowmap, 3/*tri-diagonal matrix*/, Tpetra::StaticProfile));
+  Teuchos::RCP<Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > crsmatrix =
+    Teuchos::rcp(new Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>(rowmap,
+									       3/*tri-diagonal matrix*/,
+									       Tpetra::StaticProfile));
 
   Teuchos::Array<GlobalOrdinal> col(3);
   Teuchos::Array<Scalar> coef(3);


### PR DESCRIPTION
When using arithmetic functions on device we must be careful to
call the proper Kokkos::Experimental::fun() to avoid portability
issues between device runtime libraries.


@trilinos/amesos2 @trilinos/belos @trilinos/ifpack2 

## Motivation
Some tests are still failing with Kokkos::HIPSpace enabled, these need to be fixed.

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to #9317
* Part of 
* Composed of 


## Stakeholder Feedback


## Testing
All testing is performed on Spock using rocm/4.2.0