### PR TITLE
Framework: Master new proxies

### DIFF
--- a/cmake/std/PullRequestLinuxDriver-old.sh
+++ b/cmake/std/PullRequestLinuxDriver-old.sh
@@ -20,8 +20,8 @@
 # and we get the correct behavior for PR testing.
 #
 
-export https_proxy=http://wwwproxy.sandia.gov:80
-export http_proxy=http://wwwproxy.sandia.gov:80
+export https_proxy=http://proxy.sandia.gov:80
+export http_proxy=http://proxy.sandia.gov:80
 no_proxy='localhost,localnets,.sandia.gov,127.0.0.1,169.254.0.0/16,forge.sandia.gov'
 
 whoami

--- a/cmake/std/PullRequestLinuxDriver.sh
+++ b/cmake/std/PullRequestLinuxDriver.sh
@@ -70,7 +70,7 @@ print_banner "PullRequestLinuxDriver.sh"
 # Set up Sandia PROXY environment vars
 export https_proxy=http://proxy.sandia.gov:80
 export http_proxy=http://proxy.sandia.gov:80
-export no_proxy='localhost,localnets,127.0.0.1,169.254.0.0/16,forge.sandia.gov'
+export no_proxy='localhost,.sandia.gov,localnets,127.0.0.1,169.254.0.0/16,forge.sandia.gov'
 
 
 # bootstrap the python and git modules for this system

--- a/cmake/std/PullRequestLinuxDriver.sh
+++ b/cmake/std/PullRequestLinuxDriver.sh
@@ -68,8 +68,8 @@ function bootstrap_modules() {
 print_banner "PullRequestLinuxDriver.sh"
 
 # Set up Sandia PROXY environment vars
-export https_proxy=http://wwwproxy.sandia.gov:80
-export http_proxy=http://wwwproxy.sandia.gov:80
+export https_proxy=http://proxy.sandia.gov:80
+export http_proxy=http://proxy.sandia.gov:80
 export no_proxy='localhost,localnets,127.0.0.1,169.254.0.0/16,forge.sandia.gov'
 
 

--- a/cmake/std/common.bash
+++ b/cmake/std/common.bash
@@ -182,7 +182,7 @@ function get_md5sum() {
 #
 #    get_pip_args=(
 #        --user
-#        --proxy="http://user:nopass@wwwproxy.sandia.gov:80"
+#        --proxy="http://user:nopass@proxy.sandia.gov:80"
 #        --no-setuptools
 #        --no-wheel
 #    )


### PR DESCRIPTION

@trilinos/framework

## Motivation
The changes made to get proxies working for develop are needed to get master working again as well. These will need to be force pushed for the same reason that we had to do a force push into develop (bootstrapping problem as the failure happens before the merge - often during the initial fetch.)

## Related Issues

* Part of #9293 


