### PR TITLE
Framework: Dashboard restructuring to reflect triaging support model

### DIFF
--- a/cmake/ctest/drivers/atdm/ats1/drivers/Trilinos-atdm-ats1-hsw_intel-19.0.4_mpich-7.7.15_openmp_static_dbg.sh
+++ b/cmake/ctest/drivers/atdm/ats1/drivers/Trilinos-atdm-ats1-hsw_intel-19.0.4_mpich-7.7.15_openmp_static_dbg.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=Specialized
+  export Trilinos_TRACK=SparcATDM
 fi
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ats1/local-driver.sh

--- a/cmake/ctest/drivers/atdm/ats1/drivers/Trilinos-atdm-ats1-hsw_intel-19.0.4_mpich-7.7.15_openmp_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/ats1/drivers/Trilinos-atdm-ats1-hsw_intel-19.0.4_mpich-7.7.15_openmp_static_opt.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=Specialized
+  export Trilinos_TRACK=SparcATDM
 fi
 export Trilinos_SKIP_CTEST_ADD_TEST=FALSE
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ats1/local-driver.sh

--- a/cmake/ctest/drivers/atdm/ats1/drivers/Trilinos-atdm-ats1-knl_intel-19.0.4_mpich-7.7.15_openmp_static_dbg.sh
+++ b/cmake/ctest/drivers/atdm/ats1/drivers/Trilinos-atdm-ats1-knl_intel-19.0.4_mpich-7.7.15_openmp_static_dbg.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=Specialized
+  export Trilinos_TRACK=SparcATDM
 fi
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ats1/local-driver.sh

--- a/cmake/ctest/drivers/atdm/ats1/drivers/Trilinos-atdm-ats1-knl_intel-19.0.4_mpich-7.7.15_openmp_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/ats1/drivers/Trilinos-atdm-ats1-knl_intel-19.0.4_mpich-7.7.15_openmp_static_opt.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=Specialized
+  export Trilinos_TRACK=PrimaryATDM
 fi
 export Trilinos_SKIP_CTEST_ADD_TEST=FALSE
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ats1/local-driver.sh

--- a/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_complex_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_complex_static_opt.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=Specialized
+  export Trilinos_TRACK=SecondaryATDM
 fi
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ats2/local-driver.sh

--- a/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_static_dbg.sh
+++ b/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_static_dbg.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=ATDM
+  export Trilinos_TRACK=SecondaryATDM
 fi
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ats2/local-driver.sh

--- a/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_static_opt.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=ATDM
+  export Trilinos_TRACK=PrimaryATDM
 fi
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ats2/local-driver.sh

--- a/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-cuda-10.1.243-xl-2020.03.18_spmpi-rolling_static_dbg.sh
+++ b/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-cuda-10.1.243-xl-2020.03.18_spmpi-rolling_static_dbg.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=ATDM
+  export Trilinos_TRACK=SparcATDM
 fi
 
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ats2/local-driver.sh

--- a/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-cuda-10.1.243-xl-2020.03.18_spmpi-rolling_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-cuda-10.1.243-xl-2020.03.18_spmpi-rolling_static_opt.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=ATDM
+  export Trilinos_TRACK=PrimaryATDM
 fi
 
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ats2/local-driver.sh

--- a/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-gnu-7.3.1-spmpi-rolling_serial_static_dbg.sh
+++ b/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-gnu-7.3.1-spmpi-rolling_serial_static_dbg.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=ATDM
+  export Trilinos_TRACK=SecondaryATDM
 fi
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ats2/local-driver.sh

--- a/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-gnu-7.3.1-spmpi-rolling_serial_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-gnu-7.3.1-spmpi-rolling_serial_static_opt.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=ATDM
+  export Trilinos_TRACK=SecondaryATDM
 fi
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ats2/local-driver.sh

--- a/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-xl-2020.03.18_spmpi-rolling_serial_static_dbg.sh
+++ b/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-xl-2020.03.18_spmpi-rolling_serial_static_dbg.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=ATDM
+  export Trilinos_TRACK=SparcATDM
 fi
 
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ats2/local-driver.sh

--- a/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-xl-2020.03.18_spmpi-rolling_serial_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-xl-2020.03.18_spmpi-rolling_serial_static_opt.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=ATDM
+  export Trilinos_TRACK=SparcATDM
 fi
 
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ats2/local-driver.sh

--- a/cmake/ctest/drivers/atdm/cee-rhel7/drivers/Trilinos-atdm-cee-rhel7_clang-9.0.1_openmpi-4.0.3_serial_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/cee-rhel7/drivers/Trilinos-atdm-cee-rhel7_clang-9.0.1_openmpi-4.0.3_serial_static_opt.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 if [ "${Trilinos_TRACK}" == "" ]; then
-  export Trilinos_TRACK=ATDM
+  export Trilinos_TRACK=PrimaryATDM
 fi
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cee-rhel7/local-driver.sh

--- a/cmake/ctest/drivers/atdm/cee-rhel7/drivers/Trilinos-atdm-cee-rhel7_cuda-10.1.243_gnu-7.2.0_openmpi-4.0.3_shared_dbg.sh
+++ b/cmake/ctest/drivers/atdm/cee-rhel7/drivers/Trilinos-atdm-cee-rhel7_cuda-10.1.243_gnu-7.2.0_openmpi-4.0.3_shared_dbg.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-export Trilinos_TRACK=Specialized
+export Trilinos_TRACK=SecondaryATDM
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cee-rhel7/local-driver.sh

--- a/cmake/ctest/drivers/atdm/cee-rhel7/drivers/Trilinos-atdm-cee-rhel7_cuda-10.1.243_gnu-7.2.0_openmpi-4.0.3_shared_opt.sh
+++ b/cmake/ctest/drivers/atdm/cee-rhel7/drivers/Trilinos-atdm-cee-rhel7_cuda-10.1.243_gnu-7.2.0_openmpi-4.0.3_shared_opt.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-export Trilinos_TRACK=Specialized
+export Trilinos_TRACK=PrimaryATDM
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cee-rhel7/local-driver.sh

--- a/cmake/ctest/drivers/atdm/cee-rhel7/drivers/Trilinos-atdm-cee-rhel7_gnu-7.2.0_openmpi-4.0.3_serial_shared_opt.sh
+++ b/cmake/ctest/drivers/atdm/cee-rhel7/drivers/Trilinos-atdm-cee-rhel7_gnu-7.2.0_openmpi-4.0.3_serial_shared_opt.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 if [ "${Trilinos_TRACK}" == "" ]; then
-  export Trilinos_TRACK=ATDM
+  export Trilinos_TRACK=SecondaryATDM
 fi
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cee-rhel7/local-driver.sh

--- a/cmake/ctest/drivers/atdm/cee-rhel7/drivers/Trilinos-atdm-cee-rhel7_intel-19.0.3_intelmpi-2018.4_serial_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/cee-rhel7/drivers/Trilinos-atdm-cee-rhel7_intel-19.0.3_intelmpi-2018.4_serial_static_opt.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-export Trilinos_TRACK=ATDM
+export Trilinos_TRACK=SparcATDM
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cee-rhel7/local-driver.sh

--- a/cmake/ctest/drivers/atdm/cee-rhel7/drivers/Trilinos-atdm-cee-rhel7_intel-19.0.3_mpich2-3.2_openmp_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/cee-rhel7/drivers/Trilinos-atdm-cee-rhel7_intel-19.0.3_mpich2-3.2_openmp_static_opt.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-export Trilinos_TRACK=ATDM
+export Trilinos_TRACK=SparcATDM
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cee-rhel7/local-driver.sh

--- a/cmake/ctest/drivers/atdm/cee-rhel7/drivers/Trilinos-atdm-cee-rhel7_mini-no-mpi_clang-9.0.1_serial_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/cee-rhel7/drivers/Trilinos-atdm-cee-rhel7_mini-no-mpi_clang-9.0.1_serial_static_opt.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-export Trilinos_TRACK=ATDM
+export Trilinos_TRACK=SparcATDM
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cee-rhel7/local-driver.sh

--- a/cmake/ctest/drivers/atdm/cee-rhel7/drivers/Trilinos-atdm-cee-rhel7_mini-no-mpi_cuda-10.1.243_gnu-7.2.0_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/cee-rhel7/drivers/Trilinos-atdm-cee-rhel7_mini-no-mpi_cuda-10.1.243_gnu-7.2.0_static_opt.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-export Trilinos_TRACK=ATDM
+export Trilinos_TRACK=SparcATDM
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cee-rhel7/local-driver.sh

--- a/cmake/ctest/drivers/atdm/cee-rhel7/drivers/Trilinos-atdm-cee-rhel7_mini-no-mpi_gnu-7.2.0_serial_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/cee-rhel7/drivers/Trilinos-atdm-cee-rhel7_mini-no-mpi_gnu-7.2.0_serial_static_opt.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-export Trilinos_TRACK=ATDM
+export Trilinos_TRACK=SparcATDM
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cee-rhel7/local-driver.sh

--- a/cmake/ctest/drivers/atdm/cee-rhel7/drivers/Trilinos-atdm-cee-rhel7_mini-no-mpi_intel-19.0.3_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/cee-rhel7/drivers/Trilinos-atdm-cee-rhel7_mini-no-mpi_intel-19.0.3_static_opt.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-export Trilinos_TRACK=ATDM
+export Trilinos_TRACK=SparcATDM
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cee-rhel7/local-driver.sh

--- a/cmake/ctest/drivers/atdm/cee-rhel7/drivers/Trilinos-atdm-cee-rhel7_mini_clang-9.0.1_openmpi-4.0.3_serial_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/cee-rhel7/drivers/Trilinos-atdm-cee-rhel7_mini_clang-9.0.1_openmpi-4.0.3_serial_static_opt.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-export Trilinos_TRACK=ATDM
+export Trilinos_TRACK=SparcATDM
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cee-rhel7/local-driver.sh

--- a/cmake/ctest/drivers/atdm/cee-rhel7/drivers/Trilinos-atdm-cee-rhel7_mini_cuda-10.1.243_gnu-7.2.0_openmpi-4.0.3_static_dbg.sh
+++ b/cmake/ctest/drivers/atdm/cee-rhel7/drivers/Trilinos-atdm-cee-rhel7_mini_cuda-10.1.243_gnu-7.2.0_openmpi-4.0.3_static_dbg.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-export Trilinos_TRACK=ATDM
+export Trilinos_TRACK=SparcATDM
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cee-rhel7/local-driver.sh

--- a/cmake/ctest/drivers/atdm/cee-rhel7/drivers/Trilinos-atdm-cee-rhel7_mini_cuda-10.1.243_gnu-7.2.0_openmpi-4.0.3_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/cee-rhel7/drivers/Trilinos-atdm-cee-rhel7_mini_cuda-10.1.243_gnu-7.2.0_openmpi-4.0.3_static_opt.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-export Trilinos_TRACK=ATDM
+export Trilinos_TRACK=SparcATDM
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cee-rhel7/local-driver.sh

--- a/cmake/ctest/drivers/atdm/cee-rhel7/drivers/Trilinos-atdm-cee-rhel7_mini_gnu-7.2.0_openmpi-4.0.3_serial_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/cee-rhel7/drivers/Trilinos-atdm-cee-rhel7_mini_gnu-7.2.0_openmpi-4.0.3_serial_static_opt.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-export Trilinos_TRACK=ATDM
+export Trilinos_TRACK=SparcATDM
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cee-rhel7/local-driver.sh

--- a/cmake/ctest/drivers/atdm/cee-rhel7/drivers/Trilinos-atdm-cee-rhel7_mini_intel-19.0.3_mpich2-3.2_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/cee-rhel7/drivers/Trilinos-atdm-cee-rhel7_mini_intel-19.0.3_mpich2-3.2_static_opt.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-export Trilinos_TRACK=ATDM
+export Trilinos_TRACK=SparcATDM
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cee-rhel7/local-driver.sh

--- a/cmake/ctest/drivers/atdm/cts1/drivers/Trilinos-atdm-cts1-intel-19.0.4_openmpi-4.0.3_openmp_static_dbg.sh
+++ b/cmake/ctest/drivers/atdm/cts1/drivers/Trilinos-atdm-cts1-intel-19.0.4_openmpi-4.0.3_openmp_static_dbg.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #export SLURM_CTEST_TIMEOUT=1:00:00
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=ATDM
+  export Trilinos_TRACK=SecondaryATDM
 fi
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cts1/local-driver.sh

--- a/cmake/ctest/drivers/atdm/cts1/drivers/Trilinos-atdm-cts1-intel-19.0.4_openmpi-4.0.3_openmp_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/cts1/drivers/Trilinos-atdm-cts1-intel-19.0.4_openmpi-4.0.3_openmp_static_opt.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #export SLURM_CTEST_TIMEOUT=1:00:00
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=ATDM
+  export Trilinos_TRACK=PrimaryATDM
 fi
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cts1/local-driver.sh

--- a/cmake/ctest/drivers/atdm/cts1empire/drivers/Trilinos-atdm-cts1empire-intel-18.0.2_openmpi-4.0.1_openmp_static_dbg.sh
+++ b/cmake/ctest/drivers/atdm/cts1empire/drivers/Trilinos-atdm-cts1empire-intel-18.0.2_openmpi-4.0.1_openmp_static_dbg.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #export SLURM_CTEST_TIMEOUT=1:00:00
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=Specialized
+  export Trilinos_TRACK=SecondaryATDM
 fi
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cts1/local-driver.sh

--- a/cmake/ctest/drivers/atdm/cts1empire/drivers/Trilinos-atdm-cts1empire-intel-18.0.2_openmpi-4.0.1_openmp_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/cts1empire/drivers/Trilinos-atdm-cts1empire-intel-18.0.2_openmpi-4.0.1_openmp_static_opt.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #export SLURM_CTEST_TIMEOUT=1:00:00
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=Specialized
+  export Trilinos_TRACK=PrimaryATDM
 fi
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cts1/local-driver.sh

--- a/cmake/ctest/drivers/atdm/ride/drivers/Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-debug.sh
+++ b/cmake/ctest/drivers/atdm/ride/drivers/Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-debug.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=ATDM
+  export Trilinos_TRACK=SecondaryATDM
 fi
 export EXCLUDE_NODES_FROM_BSUB="-R hname!=ride14"
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ride/local-driver.sh

--- a/cmake/ctest/drivers/atdm/ride/drivers/Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-rdc-release-debug.sh
+++ b/cmake/ctest/drivers/atdm/ride/drivers/Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-rdc-release-debug.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=Specialized
+  export Trilinos_TRACK=PrimaryATDM
 fi
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ride/local-driver.sh

--- a/cmake/ctest/drivers/atdm/ride/drivers/Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-release-debug.sh
+++ b/cmake/ctest/drivers/atdm/ride/drivers/Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-release-debug.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=ATDM
+  export Trilinos_TRACK=SecondaryATDM
 fi
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ride/local-driver.sh

--- a/cmake/ctest/drivers/atdm/ride/drivers/Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-release.sh
+++ b/cmake/ctest/drivers/atdm/ride/drivers/Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-release.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=ATDM
+  export Trilinos_TRACK=SecondaryATDM
 fi
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ride/local-driver.sh

--- a/cmake/ctest/drivers/atdm/ride/drivers/Trilinos-atdm-white-ride-gnu-7.2.0-openmp-debug.sh
+++ b/cmake/ctest/drivers/atdm/ride/drivers/Trilinos-atdm-white-ride-gnu-7.2.0-openmp-debug.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 if [ "$Trilinos_TRACK" == "" ] ; then
-  export Trilinos_TRACK=ATDM
+  export Trilinos_TRACK=SecondaryATDM
 fi
 export EXCLUDE_NODES_FROM_BSUB="-R hname!=ride14"
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ride/local-driver.sh

--- a/cmake/ctest/drivers/atdm/ride/drivers/Trilinos-atdm-white-ride-gnu-7.2.0-openmp-release.sh
+++ b/cmake/ctest/drivers/atdm/ride/drivers/Trilinos-atdm-white-ride-gnu-7.2.0-openmp-release.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 if [ "$Trilinos_TRACK" == "" ] ; then
-  export Trilinos_TRACK=ATDM
+  export Trilinos_TRACK=SecondaryATDM
 fi
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ride/local-driver.sh

--- a/cmake/ctest/drivers/atdm/sems-rhel7/drivers/Trilinos-atdm-sems-rhel7-cuda-10.1-Volta70-complex-shared-release-debug.sh
+++ b/cmake/ctest/drivers/atdm/sems-rhel7/drivers/Trilinos-atdm-sems-rhel7-cuda-10.1-Volta70-complex-shared-release-debug.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=Specialized
+  export Trilinos_TRACK=PrimaryATDM
 fi
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/sems-rhel7/local-driver.sh

--- a/cmake/ctest/drivers/atdm/sems-rhel7/drivers/Trilinos-atdm-sems-rhel7-gnu-7.2.0-openmp-complex-shared-release-debug.sh
+++ b/cmake/ctest/drivers/atdm/sems-rhel7/drivers/Trilinos-atdm-sems-rhel7-gnu-7.2.0-openmp-complex-shared-release-debug.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=Specialized
+  export Trilinos_TRACK=GemmaATDM
 fi
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/sems-rhel7/local-driver.sh

--- a/cmake/ctest/drivers/atdm/sems-rhel7/drivers/Trilinos-atdm-sems-rhel7-intel-18.0.5-openmp-shared-debug.sh
+++ b/cmake/ctest/drivers/atdm/sems-rhel7/drivers/Trilinos-atdm-sems-rhel7-intel-18.0.5-openmp-shared-debug.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=Specialized
+  export Trilinos_TRACK=SecondaryATDM
 fi
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/sems-rhel7/local-driver.sh

--- a/cmake/ctest/drivers/atdm/sems-rhel7/drivers/Trilinos-atdm-sems-rhel7-intel-18.0.5-openmp-shared-release-debug.sh
+++ b/cmake/ctest/drivers/atdm/sems-rhel7/drivers/Trilinos-atdm-sems-rhel7-intel-18.0.5-openmp-shared-release-debug.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=Specialized
+  export Trilinos_TRACK=EmpireATDM
 fi
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/sems-rhel7/local-driver.sh

--- a/cmake/ctest/drivers/atdm/tlcc2/drivers/Trilinos-atdm-tlcc2-intel-debug-openmp.sh
+++ b/cmake/ctest/drivers/atdm/tlcc2/drivers/Trilinos-atdm-tlcc2-intel-debug-openmp.sh
@@ -5,7 +5,7 @@ if [[ "${SALLOC_CTEST_TIME_LIMIT_MINUTES}" == "" ]] ; then
 fi
 
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=ATDM
+  export Trilinos_TRACK=SecondaryATDM
 fi
 
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/tlcc2/local-driver.sh

--- a/cmake/ctest/drivers/atdm/tlcc2/drivers/Trilinos-atdm-tlcc2-intel-opt-openmp.sh
+++ b/cmake/ctest/drivers/atdm/tlcc2/drivers/Trilinos-atdm-tlcc2-intel-opt-openmp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #export SALLOC_CTEST_TIME_LIMIT_MINUTES=1:00:00
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=ATDM
+  export Trilinos_TRACK=PrimaryATDM
 fi
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/tlcc2/local-driver.sh

--- a/cmake/ctest/drivers/atdm/van1-tx2/drivers/Trilinos-atdm-van1-tx2_arm-20.0_openmpi-4.0.2_openmp_static_dbg.sh
+++ b/cmake/ctest/drivers/atdm/van1-tx2/drivers/Trilinos-atdm-van1-tx2_arm-20.0_openmpi-4.0.2_openmp_static_dbg.sh
@@ -3,7 +3,7 @@
 #export SALLOC_CTEST_TIME_LIMIT_MINUTES=1:00:00
 
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=Experimental
+  export Trilinos_TRACK=SecondaryATDM
 fi
 
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/van1-tx2/local-driver.sh

--- a/cmake/ctest/drivers/atdm/van1-tx2/drivers/Trilinos-atdm-van1-tx2_arm-20.0_openmpi-4.0.2_openmp_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/van1-tx2/drivers/Trilinos-atdm-van1-tx2_arm-20.0_openmpi-4.0.2_openmp_static_opt.sh
@@ -3,7 +3,7 @@
 #export SALLOC_CTEST_TIME_LIMIT_MINUTES=1:00:00
 
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=Specialized
+  export Trilinos_TRACK=SecondaryATDM
 fi
 
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/van1-tx2/local-driver.sh

--- a/cmake/ctest/drivers/atdm/van1-tx2/drivers/Trilinos-atdm-van1-tx2_arm-20.1_openmpi-4.0.3_openmp_static_dbg.sh
+++ b/cmake/ctest/drivers/atdm/van1-tx2/drivers/Trilinos-atdm-van1-tx2_arm-20.1_openmpi-4.0.3_openmp_static_dbg.sh
@@ -3,7 +3,7 @@
 #export SALLOC_CTEST_TIME_LIMIT_MINUTES=1:00:00
 
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=Specialized
+  export Trilinos_TRACK=SecondaryATDM
 fi
 
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/van1-tx2/local-driver.sh

--- a/cmake/ctest/drivers/atdm/van1-tx2/drivers/Trilinos-atdm-van1-tx2_arm-20.1_openmpi-4.0.3_openmp_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/van1-tx2/drivers/Trilinos-atdm-van1-tx2_arm-20.1_openmpi-4.0.3_openmp_static_opt.sh
@@ -3,7 +3,7 @@
 #export SALLOC_CTEST_TIME_LIMIT_MINUTES=1:00:00
 
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=Specialized
+  export Trilinos_TRACK=PrimaryATDM
 fi
 
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/van1-tx2/local-driver.sh

--- a/cmake/ctest/drivers/atdm/van1-tx2/drivers/Trilinos-atdm-van1-tx2_arm-20.1_openmpi-4.0.5_openmp_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/van1-tx2/drivers/Trilinos-atdm-van1-tx2_arm-20.1_openmpi-4.0.5_openmp_static_opt.sh
@@ -3,7 +3,7 @@
 #export SALLOC_CTEST_TIME_LIMIT_MINUTES=1:00:00
 
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=Specialized
+  export Trilinos_TRACK=PrimaryATDM
 fi
 
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/van1-tx2/local-driver.sh


### PR DESCRIPTION
CC: @dc-snl, @sebrowne, @glhenni, @jwillenbring 
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
To reflect the updated build ownership for triaging and maintaining ATDM nightly builds via cdash.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
Acceptance of this build ownership was provided via presentation of the new triaging support model.

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Once merged, the ATDM nightly tests will start submitting to the 5 new cdash groups:
- PrimaryATDM (owned by Trilinos Framework)
- SecondaryATDM (owned by Trilinos Framework)
- EmpireATDM
- GemmaATDM
- SparcATDM

The following builds (reflecting which team owns and therefore commits to triaging and maintaining the builds) will be posted to each group:
- PrimaryATDM (owned by Trilinos Framework)
  - Trilinos-atdm-ats1-knl_intel-19.0.4_mpich-7.7.15_openmp_static_opt
  - Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_static_opt
  - Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_static_opt_cuda-aware-mpi
  - Trilinos-atdm-ats2-cuda-10.1.243-xl-2020.03.18_spmpi-rolling_static_opt
  - Trilinos-atdm-cee-rhel7_cuda-10.1.243_gnu-7.2.0_openmpi-4.0.3_shared_opt
  - Trilinos-atdm-cee-rhel7_clang-9.0.1_openmpi-4.0.3_serial_static_opt
  - Trilinos-atdm-cts1-intel-19.0.4_openmpi-4.0.3_openmp_static_opt
  - Trilinos-atdm-cts1empire-intel-18.0.2_openmpi-4.0.1_openmp_static_opt
  - Trilinos-atdm-sems-rhel7-cuda-10.1-Volta70-complex-shared-release-debug
  - Trilinos-atdm-tlcc2-intel-opt-openmp
  - Trilinos-atdm-van1-tx2_arm-20.1_openmpi-4.0.3_openmp_static_opt
  - Trilinos-atdm-van1-tx2_arm-20.1_openmpi-4.0.5_openmp_static_opt
  - Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-rdc-release-debug
- SecondaryATDM (owned by Trilinos Framework)
  - Trilinos-atdm-ats2-gnu-7.3.1-spmpi-rolling_serial_static_opt
  - Trilinos-atdm-ats2-gnu-7.3.1-spmpi-rolling_serial_static_dbg
  - Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_static_dbg
  - Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_static_dbg_cuda-aware-mpi
  - Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_complex_static_opt
  - Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_complex_static_opt_cuda-aware-mpi
  - Trilinos-atdm-cee-rhel7_gnu-7.2.0_openmpi-4.0.3_serial_shared_opt
  - Trilinos-atdm-cee-rhel7_cuda-10.1.243_gnu-7.2.0_openmpi-4.0.3_shared_dbg
  - Trilinos-atdm-cts1-intel-19.0.4_openmpi-4.0.3_openmp_static_dbg
  - Trilinos-atdm-cts1empire-intel-18.0.2_openmpi-4.0.1_openmp_static_dbg
  - Trilinos-atdm-sems-rhel7-intel-18.0.5-openmp-shared-debug
  - Trilinos-atdm-tlcc2-intel-debug-openmp
  - Trilinos-atdm-van1-tx2_arm-20.0_openmpi-4.0.2_openmp_static_opt
  - Trilinos-atdm-van1-tx2_arm-20.0_openmpi-4.0.2_openmp_static_dbg
  - Trilinos-atdm-van1-tx2_arm-20.1_openmpi-4.0.3_openmp_static_dbg
  - Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-debug
  - Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-release
  - Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-release-debug
  - Trilinos-atdm-white-ride-gnu-7.2.0-openmp-debug
  - Trilinos-atdm-white-ride-gnu-7.2.0-openmp-releas
- EmpireATDM
  - Trilinos-atdm-sems-rhel7-intel-18.0.5-openmp-shared-release-debug
- GemmaATDM
  - Trilinos-atdm-sems-rhel7-gnu-7.2.0-openmp-complex-shared-release-debug
- SparcATDM
  - Trilinos-atdm-ats1-hsw_intel-19.0.4_mpich-7.7.15_openmp_static_opt
  - Trilinos-atdm-ats1-knl_intel-19.0.4_mpich-7.7.15_openmp_static_dbg
  - Trilinos-atdm-ats1-hsw_intel-19.0.4_mpich-7.7.15_openmp_static_dbg
  - Trilinos-atdm-ats2-xl-2020.03.18_spmpi-rolling_serial_static_opt
  - Trilinos-atdm-ats2-xl-2020.03.18_spmpi-rolling_serial_static_dbg
  - Trilinos-atdm-ats2-cuda-10.1.243-xl-2020.03.18_spmpi-rolling_static_dbg
  - Trilinos-atdm-cee-rhel7_mini_cuda-10.1.243_gnu-7.2.0_openmpi-4.0.3_static_opt
  - Trilinos-atdm-cee-rhel7_mini_cuda-10.1.243_gnu-7.2.0_openmpi-4.0.3_static_dbg
  - Trilinos-atdm-cee-rhel7_mini-no-mpi_cuda-10.1.243_gnu-7.2.0_static_opt
  - Trilinos-atdm-cee-rhel7_intel-19.0.3_mpich2-3.2_openmp_static_opt
  - Trilinos-atdm-cee-rhel7_intel-19.0.3_intelmpi-2018.4_serial_static_opt
  - Trilinos-atdm-cee-rhel7_mini_clang-9.0.1_openmpi-4.0.3_serial_static_opt
  - Trilinos-atdm-cee-rhel7_mini_gnu-7.2.0_openmpi-4.0.3_serial_static_opt
  - Trilinos-atdm-cee-rhel7_mini_clang-9.0.1_openmpi-4.0.3_serial_static_opt
  - Trilinos-atdm-cee-rhel7_mini-no-mpi_gnu-7.2.0_serial_static_opt
  - Trilinos-atdm-cee-rhel7_mini-no-mpi_clang-9.0.1_serial_static_opt
  - Trilinos-atdm-cee-rhel7_mini_intel-19.0.3_mpich2-3.2_static_opt
  - Trilinos-atdm-cee-rhel7_mini-no-mpi_intel-19.0.3_static_opt
 
## Additional Information
The following 29 builds are not currently owned and therefore are not triaged and maintained:
- Trilinos-atdm-van1-tx2_arm-20.1_openmpi-4.0.5_openmp_static_dbg.sh
- Trilinos-atdm-cts1-intel-18.0.2_openmpi-4.0.3_openmp_static_opt.sh
- Trilinos-atdm-cts1-intel-18.0.2_openmpi-4.0.3_openmp_static_dbg.sh
- Trilinos-atdm-cee-rhel7_clang-9.0.1_openmpi-4.0.3_serial_static_dbg.sh
- Trilinos-atdm-white-ride-gnu-7.2.0-openmp-debug-panzer.sh
- Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-release-debug-pt.sh
- Trilinos-atdm-white-ride-gnu-7.2.0-release-debug-panzer.sh
- Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-release-panzer-Pascal60.sh
- Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-rdc-shared-release-debug-pt.sh
- Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-debug-panzer.sh
- Trilinos-atdm-white-ride-gnu-7.4.0-openmp-release-debug.sh
- Trilinos-atdm-white-ride-cuda-10.1-gnu-7.2.0-debug.sh
- Trilinos-atdm-white-ride-gnu-7.2.0-openmp-release-debug.sh
- Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-release-panzer.sh
- Trilinos-atdm-white-ride-cuda-10.1-gnu-7.2.0-rdc-release-debug.sh
- Trilinos-atdm-white-ride-gnu-7.4.0-openmp-release.sh
- Trilinos-atdm-white-ride-gnu-7.4.0-openmp-debug.sh
- Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-rdc-release-debug-pt.sh
- Trilinos-atdm-white-ride-cuda-10.1-gnu-7.2.0-rdc-release-debug-pt.sh
- Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-rdc-shared-release-debug.sh
- Trilinos-atdm-white-ride-cuda-10.1-gnu-7.2.0-release-debug.sh
- Trilinos-atdm-white-ride-cuda-10.1-gnu-7.2.0-release.sh
- Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-release-Pascal60.sh
- Trilinos-atdm-tlcc2-intel-debug-openmp-panzer.sh
- Trilinos-atdm-tlcc2-intel-opt-openmp-panzer.sh
- Trilinos-atdm-sems-rhel7-clang-7.0.1-openmp-shared-release.sh
- Trilinos-atdm-sems-rhel7-clang-7.0.1-openmp-shared-release-debug.sh
- Trilinos-atdm-sems-rhel7-intel-18.0.5-openmp-complex-shared-release-debug.sh
- Trilinos-atdm-sems-rhel7-intel-18.0.5-openmp-complex-shared-debug.sh