### PR TITLE
MueLu RefMaxwell: Change default behavior for applying BCs to A_nodal

### DIFF
--- a/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_def.hpp
+++ b/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_def.hpp
@@ -280,7 +280,7 @@ namespace MueLu {
     syncTimers_                = list.get("sync timers",                       false);
     numItersH_                 = list.get("refmaxwell: num iters H",           1);
     numIters22_                = list.get("refmaxwell: num iters 22",          1);
-    applyBCsToAnodal_          = list.get("refmaxwell: apply BCs to Anodal",   true);
+    applyBCsToAnodal_          = list.get("refmaxwell: apply BCs to Anodal",   false);
     applyBCsToH_               = list.get("refmaxwell: apply BCs to H",        true);
     applyBCsTo22_              = list.get("refmaxwell: apply BCs to 22",       true);
 


### PR DESCRIPTION
@trilinos/muelu 

## Motivation
Fixes an ALEGRA test, and does not seem to adversely affect any MiniEM or EMPIRE results. 

@skennon10 