### PR TITLE
TrilinosCouplings: Skip QR in Maxwell example

### DIFF
--- a/packages/trilinoscouplings/examples/scaling/Maxwell.xml
+++ b/packages/trilinoscouplings/examples/scaling/Maxwell.xml
@@ -57,6 +57,7 @@
       <Parameter name="number of equations" type="int" value="3"/>
       <Parameter name="aggregation: type" type="string" value="uncoupled"/>
       <Parameter name="aggregation: drop tol" type="double" value="0.01"/>
+      <Parameter name="tentative: calculate qr" type="bool" value="false"/>
       <Parameter name="coarse: max size" type="int" value="128"/>
       <Parameter name="coarse: type" type="string" value="Klu"/>
       <Parameter name="smoother: type" type="string" value="CHEBYSHEV"/>


### PR DESCRIPTION
@trilinos/trilinoscouplings 

MueLu's QR uses too much L0 scratch memory on GPU.