### PR TITLE
Tpetra: add test and fix for #9160

### DIFF
--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -971,8 +971,8 @@ namespace Tpetra {
     // Check whether the source object is a MultiVector.  If not, then
     // we can't even compare sizes, so it's definitely not OK to
     // Import or Export from it.
-    typedef MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> this_type;
-    const this_type* src = dynamic_cast<const this_type*> (&sourceObj);
+    typedef MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> MV;
+    const MV* src = dynamic_cast<const MV*> (&sourceObj);
     if (src == nullptr) {
       return false;
     }
@@ -3251,18 +3251,7 @@ namespace Tpetra {
       (rowOffset, rowOffset + newNumRows);
 
     dual_view_type newOrigView = subview (X.origView_, origRowRng, ALL ());
-    // FIXME (mfh 29 Sep 2016) If we just use X.view_ here, it breaks
-    // Ifpack2's Gauss-Seidel implementation (which assumes the
-    // ability to create domain Map views of column Map MultiVectors,
-    // and then get the original column Map MultiVector out again).
-    // If we just use X.origView_ here, it breaks the fix for #46.
-    // The test for rowOffset == 0 is a hack that makes both tests
-    // pass, but doesn't actually fix the more general issue.  In
-    // particular, the right way to fix Gauss-Seidel would be to fix
-    // #385; that would make "getting the original column Map
-    // MultiVector out again" unnecessary.
-    dual_view_type newView =
-      subview (rowOffset == 0 ? X.origView_ : X.view_, rowRng, ALL ());
+    dual_view_type newView = subview (X.view_, rowRng, ALL ());
 
     // NOTE (mfh 06 Jan 2015) Work-around to deal with Kokkos not
     // handling subviews of degenerate Views quite so well.  For some


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:
-->
## Related Issues

* Closes #9160
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 

## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
Originally reported by Sierra although it wasn't a blocker for them. 
## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
There were already lots of unit tests for offset view MVs, just none that took offset views of column subviews. So I added a test for that in MultiVector_UnitTests.
## Additional Information

Mark had left this comment in the offset view constructor:
```
    // FIXME (mfh 29 Sep 2016) If we just use X.view_ here, it breaks
    // Ifpack2's Gauss-Seidel implementation (which assumes the
    // ability to create domain Map views of column Map MultiVectors,
    // and then get the original column Map MultiVector out again).
    // If we just use X.origView_ here, it breaks the fix for #46.
    // The test for rowOffset == 0 is a hack that makes both tests
    // pass, but doesn't actually fix the more general issue.  In
    // particular, the right way to fix Gauss-Seidel would be to fix
    // #385; that would make "getting the original column Map
    // MultiVector out again" unnecessary.
```
However, Ifpack2's Gauss-Seidel no longer does what's described here. It keeps an X_colMap that's used for the local apply, and uses a domainMap offset view of that (using the code changed here). This "rowOffset == 0 hack" was really the cause of 9160, so I just used ``X.view_`` in the offset view. ``X.view_.extent(1)`` has the correct num vectors for the offset view if constant stride.