### PR TITLE
Update stale bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,7 +20,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v3.0.18
+    - uses: actions/stale@v3
       with:
         debug-only: false
         ascending: true
@@ -35,7 +35,7 @@ jobs:
         # We specifically DO NOT exempt PR's from autoclosing.
         #exempt-pr-labels: ''
         remove-stale-when-updated: true
-        operations-per-run: 70
+        operations-per-run: 75
         stale-issue-message: >
           This issue has had no activity for **365** days and is marked for
           closure. It will be closed after an additional **30** days of inactivity.


### PR DESCRIPTION
@trilinos/framework 

## Motivation
Update to the github action script that closes abandoned issues and PR's.

- Change version to `v3` instead of `v3.x.y` which will keep us using the latest version in the v3.x series.
- Upped the github rate limiter throttle level from 70 to 75 since we haven't seen any issues in a while related to rate limiters.

FYI @jwillenbring @prwolfe @ZUUL42 