### PR TITLE
Sacado fix non cuda aware mpi

### DIFF
--- a/packages/sacado/test/performance/fenl_assembly/fenl_functors.hpp
+++ b/packages/sacado/test/performance/fenl_assembly/fenl_functors.hpp
@@ -293,6 +293,8 @@ public:
   KOKKOS_INLINE_FUNCTION
   void fill_graph_entries( const unsigned iset ) const
   {
+    typedef typename std::remove_reference< decltype( row_count(0) ) >::type atomic_incr_type;
+
     if ( node_node_set.valid_at(iset) ) {
       // Add each entry to the graph entries.
 
@@ -301,13 +303,11 @@ public:
       const unsigned col_node = key.second ;
 
       if ( row_node < row_count.extent(0) ) {
-        typedef typename std::remove_reference< decltype( row_count(0) ) >::type atomic_incr_type;
         const unsigned offset = graph.row_map( row_node ) + atomic_fetch_add( & row_count( row_node ) , atomic_incr_type(1) );
         graph.entries( offset ) = col_node ;
       }
 
       if ( col_node < row_count.extent(0) && col_node != row_node ) {
-        typedef typename std::remove_reference< decltype( row_count(0) ) >::type atomic_incr_type;
         const unsigned offset = graph.row_map( col_node ) + atomic_fetch_add( & row_count( col_node ) , atomic_incr_type(1) );
         graph.entries( offset ) = row_node ;
       }

--- a/packages/sacado/test/performance/fenl_assembly_view/fenl_functors.hpp
+++ b/packages/sacado/test/performance/fenl_assembly_view/fenl_functors.hpp
@@ -293,6 +293,8 @@ public:
   KOKKOS_INLINE_FUNCTION
   void fill_graph_entries( const unsigned iset ) const
   {
+    typedef typename std::remove_reference< decltype( row_count(0) ) >::type atomic_incr_type;
+
     if ( node_node_set.valid_at(iset) ) {
       // Add each entry to the graph entries.
 
@@ -301,13 +303,11 @@ public:
       const unsigned col_node = key.second ;
 
       if ( row_node < row_count.extent(0) ) {
-        typedef typename std::remove_reference< decltype( row_count(0) ) >::type atomic_incr_type;
         const unsigned offset = graph.row_map( row_node ) + atomic_fetch_add( & row_count( row_node ) , atomic_incr_type(1) );
         graph.entries( offset ) = col_node ;
       }
 
       if ( col_node < row_count.extent(0) && col_node != row_node ) {
-        typedef typename std::remove_reference< decltype( row_count(0) ) >::type atomic_incr_type;
         const unsigned offset = graph.row_map( col_node ) + atomic_fetch_add( & row_count( col_node ) , atomic_incr_type(1) );
         graph.entries( offset ) = row_node ;
       }


### PR DESCRIPTION
Fixes possible seg-faults in the Fad Kokkos Comm tests on CUDA when not using CUDA-aware MPI and UVM is disabled.  This is a kludge and should really be addressed at a higher level in Trilinos/Teuchos.