### PR TITLE
[Intrepid2]  Allow using Intrepid2::Kernels::Serial::norm also for rank-1 views 

### DIFF
--- a/packages/intrepid2/src/Shared/Intrepid2_Kernels.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_Kernels.hpp
@@ -275,14 +275,14 @@ namespace Intrepid2 {
         case NORM_TWO:{
           for (ordinal_type i=0;i<m;++i)
             for (ordinal_type j=0;j<n;++j)
-              r_val += A(i,j)*A(i,j);
+              r_val += A.access(i,j)*A.access(i,j);
           r_val = sqrt(r_val);
           break;
         }
         case NORM_INF:{
           for (ordinal_type i=0;i<m;++i)
             for (ordinal_type j=0;j<n;++j) {
-              const value_type current = Util<value_type>::abs(A(i,j));
+              const value_type current = Util<value_type>::abs(A.access(i,j));
               r_val = (r_val < current ? current : r_val);
             }
           break;
@@ -290,7 +290,7 @@ namespace Intrepid2 {
         case NORM_ONE:{
           for (ordinal_type i=0;i<m;++i)
             for (ordinal_type j=0;j<n;++j)
-              r_val += Util<value_type>::abs(A(i,j));
+              r_val += Util<value_type>::abs(A.access(i,j));
           break;
         }
         default: {


### PR DESCRIPTION
@trilinos/intrepid2

## Motivation

Fixes https://github.com/xsdk-project/xsdk-issues/issues/141, most likely broken by https://github.com/trilinos/trilinos/commit/2dd64d20e518ab2694aa2534981abe35146a7b64, i.e, https://github.com/trilinos/Trilinos/pull/8917. Before that pull request `Intrepid2::Impl::CellTools::Serial::mapToReferenceFrame` could be used for rank-1 views.

## Related Issues

Fixes https://github.com/xsdk-project/xsdk-issues/issues/141.

## Testing
In combination with https://github.com/ORNL-CEES/DataTransferKit/pull/600 `DataTransferKit`'s tests run successfully with a recent Trilinos commit.

## Additional Information
Since this only allows using `norm` for rank-1 Kokkos::Views, this pull request should be backward-compatible.