### PR TITLE
Panzer: remove UVM use from IntegrationValues

### DIFF
--- a/packages/panzer/disc-fe/src/Panzer_ConvertNormalToRotationMatrix.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_ConvertNormalToRotationMatrix.hpp
@@ -16,7 +16,7 @@ convertNormalToRotationMatrix(const Scalar normal[3], Scalar transverse[3], Scal
   if(n > 0.){
     // Make sure transverse is not parallel to normal within some margin of error
     transverse[0]=0.;transverse[1]=1.;transverse[2]=0.;
-    if(std::fabs(normal[0]*transverse[0]+normal[1]*transverse[1])>0.9){
+    if(Kokkos::Experimental::fabs(normal[0]*transverse[0]+normal[1]*transverse[1])>0.9){
       transverse[0]=1.;transverse[1]=0.;
     }
 

--- a/packages/panzer/disc-fe/src/Panzer_ConvertNormalToRotationMatrix.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_ConvertNormalToRotationMatrix.hpp
@@ -1,0 +1,61 @@
+#ifndef PANZER_CONVERT_NORMAL_TO_ROTATION_MATRIX_HPP
+#define PANZER_CONVERT_NORMAL_TO_ROTATION_MATRIX_HPP
+
+namespace panzer {
+
+template <typename Scalar>
+KOKKOS_INLINE_FUNCTION
+void
+convertNormalToRotationMatrix(const Scalar normal[3], Scalar transverse[3], Scalar binormal[3])
+{
+  using T = Scalar;
+  
+  const T n  = sqrt(normal[0]*normal[0]+normal[1]*normal[1]+normal[2]*normal[2]);
+
+  // If this fails then the geometry for this cell is probably undefined
+  if(n > 0.){
+    // Make sure transverse is not parallel to normal within some margin of error
+    transverse[0]=0.;transverse[1]=1.;transverse[2]=0.;
+    if(std::fabs(normal[0]*transverse[0]+normal[1]*transverse[1])>0.9){
+      transverse[0]=1.;transverse[1]=0.;
+    }
+
+    const T nt = normal[0]*transverse[0]+normal[1]*transverse[1]+normal[2]*transverse[2];
+
+    // Note normal has unit length
+    const T mult = nt/(n*n); // = nt
+
+    // Remove normal projection from transverse
+    for(int dim=0;dim<3;++dim){
+      transverse[dim] = transverse[dim] - mult * normal[dim];
+    }
+
+    const T t = sqrt(transverse[0]*transverse[0]+transverse[1]*transverse[1]+transverse[2]*transverse[2]);
+    KOKKOS_ASSERT(t != 0.);
+    for(int dim=0;dim<3;++dim){
+      transverse[dim] /= t;
+    }
+
+    // We assume a right handed system such that b = n \times t
+    binormal[0] = (normal[1] * transverse[2] - normal[2] * transverse[1]);
+    binormal[1] = (normal[2] * transverse[0] - normal[0] * transverse[2]);
+    binormal[2] = (normal[0] * transverse[1] - normal[1] * transverse[0]);
+
+    // Normalize binormal
+    const T b = sqrt(binormal[0]*binormal[0]+binormal[1]*binormal[1]+binormal[2]*binormal[2]);
+    for(int dim=0;dim<3;++dim){
+      binormal[dim] /= b;
+    }
+  } else {
+    transverse[0] = 0.;
+    transverse[1] = 0.;
+    transverse[2] = 0.;
+    binormal[0] = 0.;
+    binormal[1] = 0.;
+    binormal[2] = 0.;
+  }
+}
+
+}
+
+#endif

--- a/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.cpp
@@ -852,7 +852,7 @@ evaluateRemainingValues(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_coordi
     auto node_coordinates_k = node_coordinates.get_view();
     auto in_node_coordinates_k = in_node_coordinates.get_view();
 
-    Kokkos::MDRangePolicy<PHX::Device,Kokkos::Rank<3>> policy({0,0,0},{num_cells,num_nodes,num_dims});
+    Kokkos::MDRangePolicy<PHX::Device,Kokkos::Rank<3>> policy({0,0,0},{(int)num_cells,(int)num_nodes,(int)num_dims});
     Kokkos::parallel_for("node coordinates",policy,KOKKOS_LAMBDA (const int cell,const int node,const int dim) {
       node_coordinates_k(cell,node,dim) = in_node_coordinates_k(cell,node,dim);
     });

--- a/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.cpp
@@ -584,7 +584,7 @@ generateSurfaceCubatureValues(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_
     // functor to query the policy using the functor. We'll just live
     // with the extra memory since it is temporary scratch.
     // std::vector<int> point_order(num_points_per_face);
-    PHX::View<int**> point_order("scratch: point_order",face_connectivity.numSubcellsHost(),num_points_per_face);
+    PHX::View<int**> point_order("scratch: point_order",face_connectivity.numSubcells(),num_points_per_face);
 
     // Iterate through faces
     auto ref_ip_coordinates_k = ref_ip_coordinates.get_view();
@@ -595,7 +595,7 @@ generateSurfaceCubatureValues(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_
     auto jac_inv_k = jac_inv.get_view();
     auto surface_normals_k = surface_normals.get_view();
     auto surface_rotation_matrices_k = surface_rotation_matrices.get_view();
-    Kokkos::parallel_for("face iteration",face_connectivity.numSubcellsHost(),KOKKOS_LAMBDA (const int face) {
+    Kokkos::parallel_for("face iteration",face_connectivity.numSubcells(),KOKKOS_LAMBDA (const int face) {
       // Cells for sides 0 and 1
       const int cell_0 = face_connectivity.cellForSubcell(face,0);
       const int cell_1 = face_connectivity.cellForSubcell(face,1);

--- a/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.cpp
@@ -324,128 +324,6 @@ getCubature(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_coordinates,
                                 *(int_rule->topology));
 }
 
-  /*
-template <typename Scalar>
-void IntegrationValues2<Scalar>::
-convertNormalToRotationMatrix(const Scalar normal[3], Scalar transverse[3], Scalar binormal[3])
-{
-  using T = Scalar;
-  
-  const T n  = sqrt(normal[0]*normal[0]+normal[1]*normal[1]+normal[2]*normal[2]);
-
-  // If this fails then the geometry for this cell is probably undefined
-  if(n > 0.){
-    // Make sure transverse is not parallel to normal within some margin of error
-    transverse[0]=0.;transverse[1]=1.;transverse[2]=0.;
-    if(std::fabs(normal[0]*transverse[0]+normal[1]*transverse[1])>0.9){
-      transverse[0]=1.;transverse[1]=0.;
-    }
-
-    const T nt = normal[0]*transverse[0]+normal[1]*transverse[1]+normal[2]*transverse[2];
-
-    // Note normal has unit length
-    const T mult = nt/(n*n); // = nt
-
-    // Remove normal projection from transverse
-    for(int dim=0;dim<3;++dim){
-      transverse[dim] = transverse[dim] - mult * normal[dim];
-    }
-
-    const T t = sqrt(transverse[0]*transverse[0]+transverse[1]*transverse[1]+transverse[2]*transverse[2]);
-    KOKKOS_ASSERT(t != 0.);
-    for(int dim=0;dim<3;++dim){
-      transverse[dim] /= t;
-    }
-
-    // We assume a right handed system such that b = n \times t
-    binormal[0] = (normal[1] * transverse[2] - normal[2] * transverse[1]);
-    binormal[1] = (normal[2] * transverse[0] - normal[0] * transverse[2]);
-    binormal[2] = (normal[0] * transverse[1] - normal[1] * transverse[0]);
-
-    // Normalize binormal
-    const T b = sqrt(binormal[0]*binormal[0]+binormal[1]*binormal[1]+binormal[2]*binormal[2]);
-    for(int dim=0;dim<3;++dim){
-      binormal[dim] /= b;
-    }
-  } else {
-    transverse[0] = 0.;
-    transverse[1] = 0.;
-    transverse[2] = 0.;
-    binormal[0] = 0.;
-    binormal[1] = 0.;
-    binormal[2] = 0.;
-  }
-}
-  */
-  /*  
-template <typename Scalar>
-void IntegrationValues2<Scalar>::
-swapQuadraturePoints(int cell,
-                     int a,
-                     int b) const
-{
-  const int new_cell_point = a;
-  const int old_cell_point = b;
-
-  const int cell_dim = ref_ip_coordinates.extent(2);
-
-#ifdef PANZER_DEBUG
-  KOKKOS_ASSERT(cell < ip_coordinates.extent_int(0));
-  KOKKOS_ASSERT(a < ip_coordinates.extent_int(1));
-  KOKKOS_ASSERT(b < ip_coordinates.extent_int(1));
-  KOKKOS_ASSERT(cell >= 0);
-  KOKKOS_ASSERT(a >= 0);
-  KOKKOS_ASSERT(b >= 0);
-#endif
-
-  // Using scratch_for_compute_side_measure instead of hold. This
-  // works around UVM issues of DFAD temporaries in device code.
-  // Scalar hold;
-
-  scratch_for_compute_side_measure(0) = weighted_measure(cell,new_cell_point);
-  weighted_measure(cell,new_cell_point) = weighted_measure(cell,old_cell_point);
-  weighted_measure(cell,old_cell_point) = scratch_for_compute_side_measure(0);
-
-  scratch_for_compute_side_measure(0) = jac_det(cell,new_cell_point);
-  jac_det(cell,new_cell_point) = jac_det(cell,old_cell_point);
-  jac_det(cell,old_cell_point) = scratch_for_compute_side_measure(0);
-
-  for(int dim=0;dim<cell_dim;++dim){
-
-    scratch_for_compute_side_measure(0) = ref_ip_coordinates(cell,new_cell_point,dim);
-    ref_ip_coordinates(cell,new_cell_point,dim) = ref_ip_coordinates(cell,old_cell_point,dim);
-    ref_ip_coordinates(cell,old_cell_point,dim) = scratch_for_compute_side_measure(0);
-
-    scratch_for_compute_side_measure(0) = ip_coordinates(cell,new_cell_point,dim);
-    ip_coordinates(cell,new_cell_point,dim) = ip_coordinates(cell,old_cell_point,dim);
-    ip_coordinates(cell,old_cell_point,dim) = scratch_for_compute_side_measure(0);
-
-    scratch_for_compute_side_measure(0) = surface_normals(cell,new_cell_point,dim);
-    surface_normals(cell,new_cell_point,dim) = surface_normals(cell,old_cell_point,dim);
-    surface_normals(cell,old_cell_point,dim) = scratch_for_compute_side_measure(0);
-
-    for(int dim2=0;dim2<cell_dim;++dim2){
-
-      scratch_for_compute_side_measure(0) = jac(cell,new_cell_point,dim,dim2);
-      jac(cell,new_cell_point,dim,dim2) = jac(cell,old_cell_point,dim,dim2);
-      jac(cell,old_cell_point,dim,dim2) = scratch_for_compute_side_measure(0);
-
-      scratch_for_compute_side_measure(0) = jac_inv(cell,new_cell_point,dim,dim2);
-      jac_inv(cell,new_cell_point,dim,dim2) = jac_inv(cell,old_cell_point,dim,dim2);
-      jac_inv(cell,old_cell_point,dim,dim2) = scratch_for_compute_side_measure(0);
-    }
-  }
-
-  // Rotation matrices are always in 3D
-  for(int dim=0; dim<3; ++dim){
-    for(int dim2=0; dim2<3; ++dim2){
-      scratch_for_compute_side_measure(0) = surface_rotation_matrices(cell,new_cell_point,dim,dim2);
-      surface_rotation_matrices(cell,new_cell_point,dim,dim2) = surface_rotation_matrices(cell,old_cell_point,dim,dim2);
-      surface_rotation_matrices(cell,old_cell_point,dim,dim2) = scratch_for_compute_side_measure(0);
-    }
-  }
-}
-  */
 template <typename Scalar>
 void IntegrationValues2<Scalar>::
 generateSurfaceCubatureValues(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_coordinates,
@@ -708,9 +586,14 @@ generateSurfaceCubatureValues(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_
     PHX::View<int**> point_order("scratch: point_order",face_connectivity.numSubcellsHost(),num_points_per_face);
 
     // Iterate through faces
+    auto ref_ip_coordinates_k = ref_ip_coordinates.get_view();
     auto ip_coordinates_k = ip_coordinates.get_view();
+    auto weighted_measure_k = weighted_measure.get_view();
+    auto jac_k = jac.get_view();
+    auto jac_det_k = jac_det.get_view();
+    auto jac_inv_k = jac_inv.get_view();
+    auto surface_normals_k = surface_normals.get_view();
     auto surface_rotation_matrices_k = surface_rotation_matrices.get_view();
-    auto& int_values_device = *this; // for cuda
     Kokkos::parallel_for("face iteration",face_connectivity.numSubcellsHost(),KOKKOS_LAMBDA (const int face) {
       // Cells for sides 0 and 1
       const int cell_0 = face_connectivity.cellForSubcell(face,0);
@@ -866,7 +749,15 @@ generateSurfaceCubatureValues(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_
         while( face_point_1 != point_order(face,face_point_1) ){
           // We need to swap with the component in this position
           const int face_point_0 = point_order(face,face_point_1);
-          int_values_device.swapQuadraturePoints(cell_1,point_offset+face_point_1,point_offset+face_point_0);
+          panzer::swapQuadraturePoints<double>(cell_1,point_offset+face_point_1,point_offset+face_point_0,
+                                               ref_ip_coordinates_k,
+                                               ip_coordinates_k,
+                                               weighted_measure_k,
+                                               jac_k,
+                                               jac_det_k,
+                                               jac_inv_k,
+                                               surface_normals_k,
+                                               surface_rotation_matrices_k);
           std::swap( point_order(face,face_point_1), point_order(face,face_point_0) );
         }
       }

--- a/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.cpp
@@ -685,7 +685,7 @@ generateSurfaceCubatureValues(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_
   // Enforce alignment across surface quadrature points
   
   const int num_points = ip_coordinates.extent_int(1);
-  const int num_faces_per_cell = face_connectivity.numSubcellsOnCell(0);
+  const int num_faces_per_cell = face_connectivity.numSubcellsOnCellHost(0);
   const int num_points_per_face = num_points / num_faces_per_cell;
 
   // Now we need to align the cubature points for each face
@@ -703,7 +703,7 @@ generateSurfaceCubatureValues(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_
     std::vector<int> point_order(num_points_per_face);
 
     // Iterate through faces
-    for(int face=0; face<face_connectivity.numSubcells(); ++face){
+    for(int face=0; face<face_connectivity.numSubcellsHost(); ++face){
       // Cells for sides 0 and 1
       const int cell_0 = face_connectivity.cellForSubcell(face,0);
       const int cell_1 = face_connectivity.cellForSubcell(face,1);

--- a/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.cpp
@@ -57,6 +57,7 @@
 #include "Panzer_CommonArrayFactories.hpp"
 #include "Panzer_Traits.hpp"
 #include "Panzer_SubcellConnectivity.hpp"
+#include "Panzer_ConvertNormalToRotationMatrix.hpp"
 
 // For device member functions to avoid CUDA RDC in unit testing
 #include "Panzer_IntegrationValues2_impl.hpp"
@@ -548,7 +549,7 @@ generateSurfaceCubatureValues(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_
       
       Scalar transverse[3];
       Scalar binormal[3];
-      convertNormalToRotationMatrix(normal,transverse,binormal);
+      panzer::convertNormalToRotationMatrix(normal,transverse,binormal);
       
       for(int dim=0; dim<3; ++dim){
         surface_rotation_matrices_k(cell,point,0,dim) = normal[dim];

--- a/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.hpp
@@ -57,6 +57,31 @@ namespace panzer {
 
   class SubcellConnectivity;
 
+  /**
+   * \brief Swap the ordering of quadrature points in a specified cell.
+   *
+   * \param[in] cell   Cell index
+   * \param[in] a      Quadrature point a
+   * \param[in] b      Quadrature point b
+   *
+   * NOTE: this should be a member function of IntegrationValues but
+   * lambda capture generates a ton of cuda compiler warnings. Making
+   * it a stand alone function fixes this.
+   */
+  template<typename Scalar,
+           typename T0,typename T1,typename T2,typename T3,
+           typename T4,typename T5,typename T6,typename T7>
+  KOKKOS_INLINE_FUNCTION
+  void swapQuadraturePoints(int cell,int a,int b,
+                            T0& ref_ip_coordinates,
+                            T1& ip_coordinates,
+                            T2& weighted_measure,
+                            T3& jac,
+                            T4& jac_det,
+                            T5& jac_inv,
+                            T6& surface_normals,
+                            T7& surface_rotation_matrices);
+
   template <typename Scalar>
   class IntegrationValues2 {
   public:
@@ -148,18 +173,6 @@ namespace panzer {
     DblArrayDynamic dyn_phys_cub_points, dyn_phys_cub_weights, dyn_phys_cub_norms, dyn_node_coordinates;
 
     Array_Point scratch_for_compute_side_measure; // <Point> size: span() == jac.span()
-
-    /**
-     * \brief Swap the ordering of quadrature points in a specified cell.
-     *
-     * \param[in] cell   Cell index
-     * \param[in] a      Quadrature point a
-     * \param[in] b      Quadrature point b
-     *
-     * NOTE: this is a non-const function but we had to make it const to run on device.
-     */
-    KOKKOS_INLINE_FUNCTION
-    void swapQuadraturePoints(int cell,int a,int b) const;
 
     KOKKOS_INLINE_FUNCTION
     static void convertNormalToRotationMatrix(const Scalar normal[3], Scalar transverse[3], Scalar binormal[3]);

--- a/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.hpp
@@ -174,9 +174,6 @@ namespace panzer {
 
     Array_Point scratch_for_compute_side_measure; // <Point> size: span() == jac.span()
 
-    KOKKOS_INLINE_FUNCTION
-    static void convertNormalToRotationMatrix(const Scalar normal[3], Scalar transverse[3], Scalar binormal[3]);
-
     /// This should be a private method, but using lambdas on cuda forces this to be public.
     void evaluateRemainingValues(const PHX::MDField<Scalar,Cell,NODE,Dim> & in_node_coordinates, const int in_num_cells);
 

--- a/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.hpp
@@ -162,7 +162,6 @@ namespace panzer {
     void swapQuadraturePoints(int cell,int a,int b) const;
 
     KOKKOS_INLINE_FUNCTION
-    //void convertNormalToRotationMatrix(const Scalar normal[3], Scalar transverse[3], Scalar binormal[3]);
     static void convertNormalToRotationMatrix(const Scalar normal[3], Scalar transverse[3], Scalar binormal[3]);
 
     /// This should be a private method, but using lambdas on cuda forces this to be public.

--- a/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.hpp
@@ -161,6 +161,8 @@ namespace panzer {
     KOKKOS_INLINE_FUNCTION
     void swapQuadraturePoints(int cell,int a,int b) const;
 
+    KOKKOS_INLINE_FUNCTION
+    //void convertNormalToRotationMatrix(const Scalar normal[3], Scalar transverse[3], Scalar binormal[3]);
     static void convertNormalToRotationMatrix(const Scalar normal[3], Scalar transverse[3], Scalar binormal[3]);
 
     /// This should be a private method, but using lambdas on cuda forces this to be public.

--- a/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.hpp
@@ -159,14 +159,16 @@ namespace panzer {
     void swapQuadraturePoints(int cell,int a,int b);
 
     static void convertNormalToRotationMatrix(const Scalar normal[3], Scalar transverse[3], Scalar binormal[3]);
-    
+
+    /// This should be a private method, but using lambdas on cuda forces this to be public.
+    void evaluateRemainingValues(const PHX::MDField<Scalar,Cell,NODE,Dim> & in_node_coordinates, const int in_num_cells);
+    /// This should be a private method, but using lambdas on cuda forces this to be public.
+    void getCubatureCV(const PHX::MDField<Scalar,Cell,NODE,Dim> & in_node_coordinates, const int in_num_cells);
+
   protected:
-
-
 
     // TODO: Make this a utility function that only exists in source file
     Teuchos::RCP<Intrepid2::Cubature<PHX::Device::execution_space,double,double>> getIntrepidCubature(const panzer::IntegrationRule & ir) const;
-
 
   private:
     bool alloc_arrays;
@@ -175,8 +177,6 @@ namespace panzer {
 
     void generateSurfaceCubatureValues(const PHX::MDField<Scalar,Cell,NODE,Dim> & in_node_coordinates, const int in_num_cells,const SubcellConnectivity & face_connectivity);
     void getCubature(const PHX::MDField<Scalar,Cell,NODE,Dim> & in_node_coordinates, const int in_num_cells);
-    void getCubatureCV(const PHX::MDField<Scalar,Cell,NODE,Dim> & in_node_coordinates, const int in_num_cells);
-    void evaluateRemainingValues(const PHX::MDField<Scalar,Cell,NODE,Dim> & in_node_coordinates, const int in_num_cells);
     void evaluateValuesCV(const PHX::MDField<Scalar,Cell,NODE,Dim> & vertex_coordinates,const int in_num_cells);
   };
 

--- a/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.hpp
@@ -155,13 +155,17 @@ namespace panzer {
      * \param[in] cell   Cell index
      * \param[in] a      Quadrature point a
      * \param[in] b      Quadrature point b
+     *
+     * NOTE: this is a non-const function but we had to make it const to run on device.
      */
-    void swapQuadraturePoints(int cell,int a,int b);
+    KOKKOS_INLINE_FUNCTION
+    void swapQuadraturePoints(int cell,int a,int b) const;
 
     static void convertNormalToRotationMatrix(const Scalar normal[3], Scalar transverse[3], Scalar binormal[3]);
 
     /// This should be a private method, but using lambdas on cuda forces this to be public.
     void evaluateRemainingValues(const PHX::MDField<Scalar,Cell,NODE,Dim> & in_node_coordinates, const int in_num_cells);
+
     /// This should be a private method, but using lambdas on cuda forces this to be public.
     void getCubatureCV(const PHX::MDField<Scalar,Cell,NODE,Dim> & in_node_coordinates, const int in_num_cells);
 

--- a/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.hpp
@@ -169,6 +169,9 @@ namespace panzer {
     /// This should be a private method, but using lambdas on cuda forces this to be public.
     void getCubatureCV(const PHX::MDField<Scalar,Cell,NODE,Dim> & in_node_coordinates, const int in_num_cells);
 
+    /// This should be a private method, but using lambdas on cuda forces this to be public.
+    void generateSurfaceCubatureValues(const PHX::MDField<Scalar,Cell,NODE,Dim> & in_node_coordinates, const int in_num_cells,const SubcellConnectivity & face_connectivity);
+
   protected:
 
     // TODO: Make this a utility function that only exists in source file
@@ -179,7 +182,6 @@ namespace panzer {
     std::string prefix;
     std::vector<PHX::index_size_type> ddims_;
 
-    void generateSurfaceCubatureValues(const PHX::MDField<Scalar,Cell,NODE,Dim> & in_node_coordinates, const int in_num_cells,const SubcellConnectivity & face_connectivity);
     void getCubature(const PHX::MDField<Scalar,Cell,NODE,Dim> & in_node_coordinates, const int in_num_cells);
     void evaluateValuesCV(const PHX::MDField<Scalar,Cell,NODE,Dim> & vertex_coordinates,const int in_num_cells);
   };

--- a/packages/panzer/disc-fe/src/Panzer_IntegrationValues2_impl.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_IntegrationValues2_impl.hpp
@@ -88,58 +88,6 @@ swapQuadraturePoints(int cell,
   }
 }
 
-template <typename Scalar>
-void IntegrationValues2<Scalar>::
-convertNormalToRotationMatrix(const Scalar normal[3], Scalar transverse[3], Scalar binormal[3])
-{
-  using T = Scalar;
-  
-  const T n  = sqrt(normal[0]*normal[0]+normal[1]*normal[1]+normal[2]*normal[2]);
-
-  // If this fails then the geometry for this cell is probably undefined
-  if(n > 0.){
-    // Make sure transverse is not parallel to normal within some margin of error
-    transverse[0]=0.;transverse[1]=1.;transverse[2]=0.;
-    if(std::fabs(normal[0]*transverse[0]+normal[1]*transverse[1])>0.9){
-      transverse[0]=1.;transverse[1]=0.;
-    }
-
-    const T nt = normal[0]*transverse[0]+normal[1]*transverse[1]+normal[2]*transverse[2];
-
-    // Note normal has unit length
-    const T mult = nt/(n*n); // = nt
-
-    // Remove normal projection from transverse
-    for(int dim=0;dim<3;++dim){
-      transverse[dim] = transverse[dim] - mult * normal[dim];
-    }
-
-    const T t = sqrt(transverse[0]*transverse[0]+transverse[1]*transverse[1]+transverse[2]*transverse[2]);
-    KOKKOS_ASSERT(t != 0.);
-    for(int dim=0;dim<3;++dim){
-      transverse[dim] /= t;
-    }
-
-    // We assume a right handed system such that b = n \times t
-    binormal[0] = (normal[1] * transverse[2] - normal[2] * transverse[1]);
-    binormal[1] = (normal[2] * transverse[0] - normal[0] * transverse[2]);
-    binormal[2] = (normal[0] * transverse[1] - normal[1] * transverse[0]);
-
-    // Normalize binormal
-    const T b = sqrt(binormal[0]*binormal[0]+binormal[1]*binormal[1]+binormal[2]*binormal[2]);
-    for(int dim=0;dim<3;++dim){
-      binormal[dim] /= b;
-    }
-  } else {
-    transverse[0] = 0.;
-    transverse[1] = 0.;
-    transverse[2] = 0.;
-    binormal[0] = 0.;
-    binormal[1] = 0.;
-    binormal[2] = 0.;
-  }
-}
-
 }
 
 #endif

--- a/packages/panzer/disc-fe/src/Panzer_IntegrationValues2_impl.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_IntegrationValues2_impl.hpp
@@ -10,12 +10,22 @@
    testing).
  */
 namespace panzer {
-  
-template <typename Scalar>
-void IntegrationValues2<Scalar>::
+
+template<typename Scalar,
+         typename T0,typename T1,typename T2,typename T3,
+         typename T4,typename T5,typename T6,typename T7>
+void
 swapQuadraturePoints(int cell,
                      int a,
-                     int b) const
+                     int b,
+                     T0& ref_ip_coordinates,
+                     T1& ip_coordinates,
+                     T2& weighted_measure,
+                     T3& jac,
+                     T4& jac_det,
+                     T5& jac_inv,
+                     T6& surface_normals,
+                     T7& surface_rotation_matrices)
 {
   const int new_cell_point = a;
   const int old_cell_point = b;

--- a/packages/panzer/disc-fe/src/Panzer_IntegrationValues2_impl.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_IntegrationValues2_impl.hpp
@@ -71,9 +71,9 @@ swapQuadraturePoints(int cell,
   // Rotation matrices are always in 3D
   for(int dim=0; dim<3; ++dim){
     for(int dim2=0; dim2<3; ++dim2){
-      scratch_for_compute_side_measure(0) = surface_rotation_matrices(cell,new_cell_point,dim,dim2);
+      hold = surface_rotation_matrices(cell,new_cell_point,dim,dim2);
       surface_rotation_matrices(cell,new_cell_point,dim,dim2) = surface_rotation_matrices(cell,old_cell_point,dim,dim2);
-      surface_rotation_matrices(cell,old_cell_point,dim,dim2) = scratch_for_compute_side_measure(0);
+      surface_rotation_matrices(cell,old_cell_point,dim,dim2) = hold;
     }
   }
 }

--- a/packages/panzer/disc-fe/src/Panzer_IntegrationValues2_impl.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_IntegrationValues2_impl.hpp
@@ -1,0 +1,84 @@
+#ifndef PANZER_INTEGRATION_VALUES_2_IMPL_HPP
+#define PANZER_INTEGRATION_VALUES_2_IMPL_HPP
+
+/* Normally, we would fold this definition into the .cpp file since we
+   use ETI to compile this object. However, for unit testing the stand
+   alone device function swapQuadraturePoints, we need the definition
+   at the calling point to avoid requiring relocatable device code for
+   cuda. So for the IntegrationValues2 object, if there is a
+   standalone device member function, put it in this file (for unit
+   testing).
+ */
+namespace panzer {
+  
+template <typename Scalar>
+void IntegrationValues2<Scalar>::
+swapQuadraturePoints(int cell,
+                     int a,
+                     int b) const
+{
+  const int new_cell_point = a;
+  const int old_cell_point = b;
+
+  const int cell_dim = ref_ip_coordinates.extent(2);
+
+#ifdef PANZER_DEBUG
+  KOKKOS_ASSERT(cell < ip_coordinates.extent_int(0));
+  KOKKOS_ASSERT(a < ip_coordinates.extent_int(1));
+  KOKKOS_ASSERT(b < ip_coordinates.extent_int(1));
+  KOKKOS_ASSERT(cell >= 0);
+  KOKKOS_ASSERT(a >= 0);
+  KOKKOS_ASSERT(b >= 0);
+#endif
+
+  // Using scratch_for_compute_side_measure instead of hold. This
+  // works around UVM issues of DFAD temporaries in device code.
+  // Scalar hold;
+
+  scratch_for_compute_side_measure(0) = weighted_measure(cell,new_cell_point);
+  weighted_measure(cell,new_cell_point) = weighted_measure(cell,old_cell_point);
+  weighted_measure(cell,old_cell_point) = scratch_for_compute_side_measure(0);
+
+  scratch_for_compute_side_measure(0) = jac_det(cell,new_cell_point);
+  jac_det(cell,new_cell_point) = jac_det(cell,old_cell_point);
+  jac_det(cell,old_cell_point) = scratch_for_compute_side_measure(0);
+
+  for(int dim=0;dim<cell_dim;++dim){
+
+    scratch_for_compute_side_measure(0) = ref_ip_coordinates(cell,new_cell_point,dim);
+    ref_ip_coordinates(cell,new_cell_point,dim) = ref_ip_coordinates(cell,old_cell_point,dim);
+    ref_ip_coordinates(cell,old_cell_point,dim) = scratch_for_compute_side_measure(0);
+
+    scratch_for_compute_side_measure(0) = ip_coordinates(cell,new_cell_point,dim);
+    ip_coordinates(cell,new_cell_point,dim) = ip_coordinates(cell,old_cell_point,dim);
+    ip_coordinates(cell,old_cell_point,dim) = scratch_for_compute_side_measure(0);
+
+    scratch_for_compute_side_measure(0) = surface_normals(cell,new_cell_point,dim);
+    surface_normals(cell,new_cell_point,dim) = surface_normals(cell,old_cell_point,dim);
+    surface_normals(cell,old_cell_point,dim) = scratch_for_compute_side_measure(0);
+
+    for(int dim2=0;dim2<cell_dim;++dim2){
+
+      scratch_for_compute_side_measure(0) = jac(cell,new_cell_point,dim,dim2);
+      jac(cell,new_cell_point,dim,dim2) = jac(cell,old_cell_point,dim,dim2);
+      jac(cell,old_cell_point,dim,dim2) = scratch_for_compute_side_measure(0);
+
+      scratch_for_compute_side_measure(0) = jac_inv(cell,new_cell_point,dim,dim2);
+      jac_inv(cell,new_cell_point,dim,dim2) = jac_inv(cell,old_cell_point,dim,dim2);
+      jac_inv(cell,old_cell_point,dim,dim2) = scratch_for_compute_side_measure(0);
+    }
+  }
+
+  // Rotation matrices are always in 3D
+  for(int dim=0; dim<3; ++dim){
+    for(int dim2=0; dim2<3; ++dim2){
+      scratch_for_compute_side_measure(0) = surface_rotation_matrices(cell,new_cell_point,dim,dim2);
+      surface_rotation_matrices(cell,new_cell_point,dim,dim2) = surface_rotation_matrices(cell,old_cell_point,dim,dim2);
+      surface_rotation_matrices(cell,old_cell_point,dim,dim2) = scratch_for_compute_side_measure(0);
+    }
+  }
+}
+
+}
+
+#endif

--- a/packages/panzer/disc-fe/src/Panzer_IntrepidOrientation.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_IntrepidOrientation.cpp
@@ -94,7 +94,7 @@ namespace panzer {
       // construct orientation information
       for (int c=0;c<numElementsPerBlock;++c) {
         const int localCellId = elementBlock.at(c);
-        PHX::View<const panzer::GlobalOrdinal*>
+        Kokkos::View<const panzer::GlobalOrdinal*,Kokkos::HostSpace>
           nodes(connMgr.getConnectivity(localCellId), numVertexPerCell);
         orientation[localCellId] = (Intrepid2::Orientation::getOrientation(cellTopo, nodes));
       }

--- a/packages/panzer/disc-fe/src/Panzer_L2Projection.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_L2Projection.cpp
@@ -115,8 +115,8 @@ namespace panzer {
 
           const auto basisValues = workset.getBasisValues(targetBasisDescriptor_,integrationDescriptor_);
 
-          const auto unweightedBasis = basisValues.basis_scalar;
-          const auto weightedBasis = basisValues.weighted_basis_scalar;
+          const auto unweightedBasis = basisValues.basis_scalar.get_static_view();
+          const auto weightedBasis = basisValues.weighted_basis_scalar.get_static_view();
 
           // Offsets (this assumes UVM, need to fix)
           const std::vector<panzer::LocalOrdinal>& offsets = targetGlobalIndexer_->getGIDFieldOffsets(block,fieldIndex);
@@ -215,8 +215,8 @@ namespace panzer {
 
           const auto basisValues = workset.getBasisValues(targetBasisDescriptor_,integrationDescriptor_);
 
-          const auto unweightedBasis = basisValues.basis_vector;
-          const auto weightedBasis = basisValues.weighted_basis_vector;
+          const auto unweightedBasis = basisValues.basis_vector.get_static_view();
+          const auto weightedBasis = basisValues.weighted_basis_vector.get_static_view();
 
           // Offsets (this assumes UVM, need to fix)
           const std::vector<panzer::LocalOrdinal>& offsets = targetGlobalIndexer_->getGIDFieldOffsets(block,fieldIndex);

--- a/packages/panzer/disc-fe/src/Panzer_SubcellConnectivity.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_SubcellConnectivity.cpp
@@ -56,13 +56,24 @@ setup(const panzer::LocalMeshPartition & partition)
   const int num_cells_per_face = 2;
 
   _num_subcells = num_faces;
+  _num_subcells_device = PHX::View<int*>("_num_subcells_device",1);
+  Kokkos::deep_copy(_num_subcells_device,_num_subcells);
   _num_cells = num_cells;
+  _num_cells_device = PHX::View<int*>("_num_cells_device",1);
+  Kokkos::deep_copy(_num_cells_device,_num_cells);
 
   _subcell_to_cells_adj = PHX::View<int*>("subcell_to_cells_adj", num_faces+1);
   _subcell_to_cells = PHX::View<int*>("subcell_to_cells", num_faces*num_cells_per_face);
   _subcell_to_local_subcells = PHX::View<int*>("subcell_to_local_subcells", num_faces*num_cells_per_face);
   _cell_to_subcells_adj = PHX::View<int*>("cell_to_subcells_adj", num_cells+1);
   _cell_to_subcells = PHX::View<int*>("cell_to_subcells", num_cells*num_faces_per_cell);
+
+  // Host copies
+  _subcell_to_cells_adj_host = PHX::View<int*>::HostMirror("subcell_to_cells_adj_host", num_faces+1);
+  _subcell_to_cells_host = PHX::View<int*>::HostMirror("subcell_to_cells_host", num_faces*num_cells_per_face);
+  _subcell_to_local_subcells_host = PHX::View<int*>::HostMirror("subcell_to_local_subcells_host", num_faces*num_cells_per_face);
+  _cell_to_subcells_adj_host = PHX::View<int*>::HostMirror("cell_to_subcells_adj_host", num_cells+1);
+  _cell_to_subcells_host = PHX::View<int*>::HostMirror("cell_to_subcells_host", num_cells*num_faces_per_cell);
 
   // This line not needed since kokkos initializes the arrays above to zero
   //_subcell_to_cells_adj(0)=0;
@@ -99,6 +110,12 @@ setup(const panzer::LocalMeshPartition & partition)
     PHX::Device::execution_space().fence();
   }
 
+  // Copy values to host
+  Kokkos::deep_copy(_subcell_to_cells_adj_host, _subcell_to_cells_adj);
+  Kokkos::deep_copy(_subcell_to_cells_host, _subcell_to_cells);
+  Kokkos::deep_copy(_subcell_to_local_subcells_host,_subcell_to_local_subcells);
+  Kokkos::deep_copy(_cell_to_subcells_adj_host,_cell_to_subcells_adj);
+  Kokkos::deep_copy(_cell_to_subcells_host,_cell_to_subcells);
 }
 
 }

--- a/packages/panzer/disc-fe/src/Panzer_SubcellConnectivity.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_SubcellConnectivity.cpp
@@ -55,13 +55,6 @@ setup(const panzer::LocalMeshPartition & partition)
   const int num_faces_per_cell = partition.cell_to_faces.extent(1);
   const int num_cells_per_face = 2;
 
-  _num_subcells = num_faces;
-  _num_subcells_device = PHX::View<int*>("_num_subcells_device",1);
-  Kokkos::deep_copy(_num_subcells_device,_num_subcells);
-  _num_cells = num_cells;
-  _num_cells_device = PHX::View<int*>("_num_cells_device",1);
-  Kokkos::deep_copy(_num_cells_device,_num_cells);
-
   _subcell_to_cells_adj = PHX::View<int*>("subcell_to_cells_adj", num_faces+1);
   _subcell_to_cells = PHX::View<int*>("subcell_to_cells", num_faces*num_cells_per_face);
   _subcell_to_local_subcells = PHX::View<int*>("subcell_to_local_subcells", num_faces*num_cells_per_face);

--- a/packages/panzer/disc-fe/src/Panzer_SubcellConnectivity.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_SubcellConnectivity.cpp
@@ -64,21 +64,39 @@ setup(const panzer::LocalMeshPartition & partition)
   _cell_to_subcells_adj = PHX::View<int*>("cell_to_subcells_adj", num_cells+1);
   _cell_to_subcells = PHX::View<int*>("cell_to_subcells", num_cells*num_faces_per_cell);
 
-  _subcell_to_cells_adj(0)=0;
-  for(int face=0;face<num_faces;++face){
-    _subcell_to_cells_adj(face+1) =_subcell_to_cells_adj(face)+num_cells_per_face;
-    _subcell_to_cells(num_cells_per_face*face + 0) = partition.face_to_cells(face,0);
-    _subcell_to_cells(num_cells_per_face*face + 1) = partition.face_to_cells(face,1);
-    _subcell_to_local_subcells(num_cells_per_face*face + 0) = partition.face_to_lidx(face,0);
-    _subcell_to_local_subcells(num_cells_per_face*face + 1) = partition.face_to_lidx(face,1);
+  // This line not needed since kokkos initializes the arrays above to zero
+  //_subcell_to_cells_adj(0)=0;
+
+  {
+    auto face_to_cells = partition.face_to_cells;
+    auto face_to_lidx = partition.face_to_lidx;
+    auto subcell_to_cells_adj = _subcell_to_cells_adj;
+    auto subcell_to_cells = _subcell_to_cells;
+    auto subcell_to_local_subcells = _subcell_to_local_subcells;
+    Kokkos::parallel_for("subcell connectivity 0",num_faces,KOKKOS_LAMBDA (const int face) {
+      subcell_to_cells_adj(face+1) = (face * num_cells_per_face) + num_cells_per_face;
+      subcell_to_cells(num_cells_per_face*face + 0) = face_to_cells(face,0);
+      subcell_to_cells(num_cells_per_face*face + 1) = face_to_cells(face,1);
+      subcell_to_local_subcells(num_cells_per_face*face + 0) = face_to_lidx(face,0);
+      subcell_to_local_subcells(num_cells_per_face*face + 1) = face_to_lidx(face,1);
+    });
+    PHX::Device::execution_space().fence();
   }
 
-  _cell_to_subcells_adj(0)=0;
-  for(int cell=0;cell<num_cells;++cell){
-    _cell_to_subcells_adj(cell+1) =_cell_to_subcells_adj(cell)+num_faces_per_cell;
-    for(int local_face=0;local_face<num_faces_per_cell;++local_face){
-      _cell_to_subcells(num_faces_per_cell*cell+local_face) = partition.cell_to_faces(cell,local_face);
-    }
+  // This line not needed since kokkos initializes the arrays above to zero
+  //_cell_to_subcells_adj(0)=0;
+
+  {
+    auto cell_to_faces = partition.cell_to_faces;
+    auto cell_to_subcells_adj = _cell_to_subcells_adj;
+    auto cell_to_subcells = _cell_to_subcells;
+    Kokkos::parallel_for("subcell connectivity 1",num_cells,KOKKOS_LAMBDA (const int cell) {
+      cell_to_subcells_adj(cell+1) = (cell * num_faces_per_cell) + num_faces_per_cell;
+      for(int local_face=0;local_face<num_faces_per_cell;++local_face){
+        cell_to_subcells(num_faces_per_cell*cell+local_face) = cell_to_faces(cell,local_face);
+      }
+    });
+    PHX::Device::execution_space().fence();
   }
 
 }

--- a/packages/panzer/disc-fe/src/Panzer_SubcellConnectivity.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_SubcellConnectivity.hpp
@@ -69,7 +69,8 @@ public:
    * \return Number of subcells associated with the cells
    */
   KOKKOS_INLINE_FUNCTION
-  int numSubcells() const {return _num_subcells;}
+  int numSubcells() const {return _num_subcells_device(0);}
+  int numSubcellsHost() const {return _num_subcells;}
 
   /**
    * \brief Gives number of cells in connectivity
@@ -77,7 +78,8 @@ public:
    * \return Number of subcells associated with the cells
    */
   KOKKOS_INLINE_FUNCTION
-  int numCells() const {return _num_cells;}
+  int numCells() const {return _num_cells_device(0);}
+  int numCellsHost() const {return _num_cells;}
 
   /**
    * \brief gives number of subcells (e.g. faces) found on a given cell
@@ -90,6 +92,8 @@ public:
    */
   KOKKOS_INLINE_FUNCTION
   int numSubcellsOnCell(const int cell) const;
+  inline
+  int numSubcellsOnCellHost(const int cell) const;
 
   /**
    * \brief Returns the number of cells attached to a given subcell
@@ -104,6 +108,8 @@ public:
    */
   KOKKOS_INLINE_FUNCTION
   int numCellsOnSubcell(const int subcell) const;
+  inline
+  int numCellsOnSubcellHost(const int subcell) const;
 
   /**
    * \brief Get the subcell index for a given cell and local subcell index
@@ -121,6 +127,8 @@ public:
    */
   KOKKOS_INLINE_FUNCTION
   int subcellForCell(const int cell, const int local_subcell_index) const;
+  inline
+  int subcellForCellHost(const int cell, const int local_subcell_index) const;
 
   /**
    * \brief Get the cell for a given subcell and a local_cell_index
@@ -138,6 +146,8 @@ public:
    */
   KOKKOS_INLINE_FUNCTION
   int cellForSubcell(const int subcell, const int local_cell_index) const;
+  inline
+  int cellForSubcellHost(const int subcell, const int local_cell_index) const;
 
   /**
    * \brief Get the local subcell index given a subcell and a local cell index
@@ -151,29 +161,38 @@ public:
    */
   KOKKOS_INLINE_FUNCTION
   int localSubcellForSubcell(const int subcell, const int local_cell_index) const;
+  inline
+  int localSubcellForSubcellHost(const int subcell, const int local_cell_index) const;
 
 protected:
 
   /// Number of subcells for a given number of cells
   int _num_subcells;
+  PHX::View<int*> _num_subcells_device;
 
   /// Number of cells
   int _num_cells;
+  PHX::View<int*> _num_cells_device;
 
   /// Adjacency array for indexing into subcell_to_cells array
   PHX::View<int*> _subcell_to_cells_adj;
+  PHX::View<int*>::HostMirror _subcell_to_cells_adj_host;
 
   /// Mapping from subcells to cells
   PHX::View<int*> _subcell_to_cells;
+  PHX::View<int*>::HostMirror _subcell_to_cells_host;
 
   /// Mapping from subcell indexes to local subcell indexes
   PHX::View<int*> _subcell_to_local_subcells;
+  PHX::View<int*>::HostMirror _subcell_to_local_subcells_host;
 
   /// Adjacency array for indexing into cell_to_subcells array
   PHX::View<int*> _cell_to_subcells_adj;
+  PHX::View<int*>::HostMirror _cell_to_subcells_adj_host;
 
   /// Mapping from cells to subcells
   PHX::View<int*> _cell_to_subcells;
+  PHX::View<int*>::HostMirror _cell_to_subcells_host;
 
 };
 
@@ -211,11 +230,19 @@ SubcellConnectivity::
 numSubcellsOnCell(const int cell) const
 {
 #ifdef PANZER_DEBUG
-#ifndef KOKKOS_ENABLE_CUDA
-  TEUCHOS_ASSERT(cell >= 0 and cell < _num_cells);
-#endif
+  KOKKOS_ASSERT(cell >= 0 and cell < _num_cells_device(0));
 #endif
   return _cell_to_subcells_adj(cell+1)-_cell_to_subcells_adj(cell);
+}
+
+int
+SubcellConnectivity::
+numSubcellsOnCellHost(const int cell) const
+{
+#ifdef PANZER_DEBUG
+  KOKKOS_ASSERT(cell >= 0 and cell < _num_cells);
+#endif
+  return _cell_to_subcells_adj_host(cell+1)-_cell_to_subcells_adj_host(cell);
 }
 
 int
@@ -223,11 +250,19 @@ SubcellConnectivity::
 numCellsOnSubcell(const int subcell) const
 {
 #ifdef PANZER_DEBUG
-#ifndef KOKKOS_ENABLE_CUDA
-  TEUCHOS_ASSERT(subcell >= 0 and subcell < _num_subcells);
-#endif
+  KOKKOS_ASSERT(subcell >= 0 and subcell < _num_subcells_device(0));
 #endif
   return _subcell_to_cells_adj(subcell+1)-_subcell_to_cells_adj(subcell);
+}
+
+int
+SubcellConnectivity::
+numCellsOnSubcellHost(const int subcell) const
+{
+#ifdef PANZER_DEBUG
+  KOKKOS_ASSERT(subcell >= 0 and subcell < _num_subcells);
+#endif
+  return _subcell_to_cells_adj_host(subcell+1)-_subcell_to_cells_adj_host(subcell);
 }
 
 int
@@ -235,10 +270,8 @@ SubcellConnectivity::
 subcellForCell(const int cell, const int local_subcell_index) const
 {
 #ifdef PANZER_DEBUG
-#ifndef KOKKOS_ENABLE_CUDA
-  TEUCHOS_ASSERT(cell >= 0 and cell < _num_cells);
-  TEUCHOS_ASSERT(local_subcell_index < numSubcellsOnCell(cell));
-#endif
+  KOKKOS_ASSERT(cell >= 0 and cell < _num_cells_device(0));
+  KOKKOS_ASSERT(local_subcell_index < numSubcellsOnCell(cell));
 #endif
   const int index = _cell_to_subcells_adj(cell)+local_subcell_index;
   return _cell_to_subcells(index);
@@ -246,13 +279,23 @@ subcellForCell(const int cell, const int local_subcell_index) const
 
 int
 SubcellConnectivity::
+subcellForCellHost(const int cell, const int local_subcell_index) const
+{
+#ifdef PANZER_DEBUG
+  KOKKOS_ASSERT(cell >= 0 and cell < _num_cells);
+  KOKKOS_ASSERT(local_subcell_index < numSubcellsOnCellHost(cell));
+#endif
+  const int index = _cell_to_subcells_adj_host(cell)+local_subcell_index;
+  return _cell_to_subcells_host(index);
+}
+
+int
+SubcellConnectivity::
 cellForSubcell(const int subcell, const int local_cell_index) const
 {
 #ifdef PANZER_DEBUG
-#ifndef KOKKOS_ENABLE_CUDA
-  TEUCHOS_ASSERT(subcell >= 0 and subcell < _num_subcells);
-  TEUCHOS_ASSERT(local_cell_index < numCellsOnSubcell(subcell));
-#endif
+  KOKKOS_ASSERT(subcell >= 0 and subcell < _num_subcells_device(0));
+  KOKKOS_ASSERT(local_cell_index < numCellsOnSubcell(subcell));
 #endif
   const int index = _subcell_to_cells_adj(subcell)+local_cell_index;
   return _subcell_to_cells(index);
@@ -260,16 +303,38 @@ cellForSubcell(const int subcell, const int local_cell_index) const
 
 int
 SubcellConnectivity::
+cellForSubcellHost(const int subcell, const int local_cell_index) const
+{
+#ifdef PANZER_DEBUG
+  KOKKOS_ASSERT(subcell >= 0 and subcell < _num_subcells);
+  KOKKOS_ASSERT(local_cell_index < numCellsOnSubcellHost(subcell));
+#endif
+  const int index = _subcell_to_cells_adj_host(subcell)+local_cell_index;
+  return _subcell_to_cells_host(index);
+}
+
+int
+SubcellConnectivity::
 localSubcellForSubcell(const int subcell, const int local_cell_index) const
 {
 #ifdef PANZER_DEBUG
-#ifndef KOKKOS_ENABLE_CUDA
-  TEUCHOS_ASSERT(subcell >= 0 and subcell < _num_subcells);
-  TEUCHOS_ASSERT(local_cell_index < numCellsOnSubcell(subcell));
-#endif
+  KOKKOS_ASSERT(subcell >= 0 and subcell < _num_subcells_device(0));
+  KOKKOS_ASSERT(local_cell_index < numCellsOnSubcell(subcell));
 #endif
   const int index = _subcell_to_cells_adj(subcell)+local_cell_index;
   return _subcell_to_local_subcells(index);
+}
+
+int
+SubcellConnectivity::
+localSubcellForSubcellHost(const int subcell, const int local_cell_index) const
+{
+#ifdef PANZER_DEBUG
+  KOKKOS_ASSERT(subcell >= 0 and subcell < _num_subcells);
+  KOKKOS_ASSERT(local_cell_index < numCellsOnSubcellHost(subcell));
+#endif
+  const int index = _subcell_to_cells_adj_host(subcell)+local_cell_index;
+  return _subcell_to_local_subcells_host(index);
 }
 
 } // namespace panzer

--- a/packages/panzer/disc-fe/src/Panzer_Workset.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_Workset.cpp
@@ -52,7 +52,7 @@
 #include "Panzer_LocalMeshInfo.hpp"
 #include "Panzer_PointGenerator.hpp"
 #include "Panzer_PointValues2.hpp"
-#include "Panzer_IntegrationValues2_impl.hpp" // needed for lambda dispatch with convertNormalToRotationMatrix()
+#include "Panzer_ConvertNormalToRotationMatrix.hpp"
 
 #include "Panzer_SubcellConnectivity.hpp"
 #include "Panzer_OrientationsInterface.hpp"
@@ -148,7 +148,7 @@ correctVirtualNormals(const Teuchos::RCP<panzer::IntegrationValues2<double> > iv
           normal[d] = -n_d;
         }
 
-        panzer::IntegrationValues2<double>::convertNormalToRotationMatrix(normal,transverse,binormal);
+        panzer::convertNormalToRotationMatrix(normal,transverse,binormal);
 
         for(int dim=0; dim<3; ++dim){
           iv->surface_rotation_matrices(virtual_cell,virtual_cell_point,0,dim) = normal[dim];

--- a/packages/panzer/disc-fe/src/Panzer_Workset.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_Workset.cpp
@@ -52,6 +52,7 @@
 #include "Panzer_LocalMeshInfo.hpp"
 #include "Panzer_PointGenerator.hpp"
 #include "Panzer_PointValues2.hpp"
+#include "Panzer_IntegrationValues2_impl.hpp" // needed for lambda dispatch with convertNormalToRotationMatrix()
 
 #include "Panzer_SubcellConnectivity.hpp"
 #include "Panzer_OrientationsInterface.hpp"

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Sum_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Sum_impl.hpp
@@ -65,6 +65,7 @@ Sum(
 
   // check if the user wants to scale each term independently
   auto local_scalars = PHX::View<double *>("scalars",value_names->size());
+  auto local_scalars_host = Kokkos::create_mirror_view(local_scalars);
   if(p.isType<Teuchos::RCP<const std::vector<double> > >("Scalars")) {
     auto scalars_v = *p.get<Teuchos::RCP<const std::vector<double> > >("Scalars");
 
@@ -72,12 +73,13 @@ Sum(
     TEUCHOS_ASSERT(scalars_v.size()==value_names->size());
 
     for (std::size_t i=0; i < value_names->size(); ++i)
-      local_scalars(i) = scalars_v[i];
+      local_scalars_host(i) = scalars_v[i];
   }
   else {
     for (std::size_t i=0; i < value_names->size(); ++i)
-      local_scalars(i) = 1.0;
+      local_scalars_host(i) = 1.0;
   }
+  Kokkos::deep_copy(local_scalars,local_scalars_host);
 
   scalars = local_scalars; 
   

--- a/packages/panzer/disc-fe/test/core_tests/evaluators.cpp
+++ b/packages/panzer/disc-fe/test/core_tests/evaluators.cpp
@@ -96,8 +96,6 @@ namespace panzer {
 
   TEUCHOS_UNIT_TEST(evaluators, Sum)
   {
-    
-
     ParameterList p("Sum Test");
     p.set("Sum Name", "Sum of Sources");
     RCP<vector<string> > value_names = rcp(new vector<string>);
@@ -114,8 +112,6 @@ namespace panzer {
 
   TEUCHOS_UNIT_TEST(evaluators, ScalarToVector)
   {
-    
-
     ParameterList p("ScalarToVector Test");
     p.set("Vector Name", "U");
     RCP<vector<string> > scalar_names = rcp(new vector<string>);
@@ -136,8 +132,6 @@ namespace panzer {
 
   TEUCHOS_UNIT_TEST(evaluators, VectorToScalar)
   {
-    
-
     ParameterList p("VectorToScalar Test");
     p.set("Vector Name", "U");
     RCP<vector<string> > scalar_names = rcp(new vector<string>);
@@ -158,8 +152,6 @@ namespace panzer {
 
   TEUCHOS_UNIT_TEST(evaluators, DirichletResidual)
   {
-    
-
     ParameterList p("DirichletResidual Test");
     p.set("Residual Name", "Residual_TEMP");
     p.set("DOF Name", "TEMP");
@@ -173,7 +165,6 @@ namespace panzer {
 
   TEUCHOS_UNIT_TEST(evaluators, DOF)
   {
-    
     using panzer::IntegrationRule;
     using panzer::BasisIRLayout;
 
@@ -298,7 +289,6 @@ namespace panzer {
 
   TEUCHOS_UNIT_TEST(evaluators, Integrator_GradBasisDotVector)
   {
-    
     using panzer::IntegrationRule;
     using panzer::BasisIRLayout;
 

--- a/packages/panzer/disc-fe/test/core_tests/hierarchic_team_policy.cpp
+++ b/packages/panzer/disc-fe/test/core_tests/hierarchic_team_policy.cpp
@@ -44,6 +44,8 @@
 #include <Teuchos_UnitTestHarness.hpp>
 #include <Teuchos_RCP.hpp>
 
+#include "KokkosExp_View_Fad.hpp"
+#include "Kokkos_DynRankView_Fad.hpp"
 #include "Panzer_HierarchicParallelism.hpp"
 #include "Sacado.hpp"
 
@@ -88,7 +90,7 @@ namespace panzer_test {
 
     for (int i=0; i < M; ++i) {
       for (int j=0; j < N; ++j) {
-        TEST_FLOATING_EQUALITY(Sacado::ScalarValue<Scalar>::eval(a(i,j)),3.0,tol);
+        TEST_FLOATING_EQUALITY(Sacado::ScalarValue<Scalar>::eval(a_host(i,j)),3.0,tol);
       }
     }
   }

--- a/packages/panzer/disc-fe/test/core_tests/integration_values2.cpp
+++ b/packages/panzer/disc-fe/test/core_tests/integration_values2.cpp
@@ -441,19 +441,24 @@ namespace panzer {
       mesh.num_virtual_cells = 0;
       mesh.cell_topology = Teuchos::rcp(new shards::CellTopology(shards::getCellTopologyData< shards::Quadrilateral<4> >()));
       mesh.local_cells = PHX::View<panzer::LocalOrdinal*>("local_cells",2);
-      mesh.local_cells(0) = 0;
-      mesh.local_cells(1) = 1;
+      auto local_cells_host = Kokkos::create_mirror_view(mesh.local_cells);
+      local_cells_host(0) = 0;
+      local_cells_host(1) = 1;
+      Kokkos::deep_copy(mesh.local_cells,local_cells_host);
       mesh.cell_vertices = PHX::View<double***>("cell_vertices",2,4,2);
 
       PHX::View<double**> coordinates("coordinates",6,2);
-      coordinates(0,0) = 1.; coordinates(0,1) = 3.;
-      coordinates(1,0) = 3.; coordinates(1,1) = 3.;
-      coordinates(2,0) = 5.; coordinates(2,1) = 3.;
-      coordinates(3,0) = 2.; coordinates(3,1) = 1.;
-      coordinates(4,0) = 3.; coordinates(4,1) = 1.;
-      coordinates(5,0) = 4.; coordinates(5,1) = 1.;
-      
-#define SET_NC(cell,node,vertex) mesh.cell_vertices(cell,node,0) = coordinates(vertex,0); mesh.cell_vertices(cell,node,1) = coordinates(vertex,1);
+      auto coordinates_host = Kokkos::create_mirror_view(coordinates);
+      coordinates_host(0,0) = 1.; coordinates_host(0,1) = 3.;
+      coordinates_host(1,0) = 3.; coordinates_host(1,1) = 3.;
+      coordinates_host(2,0) = 5.; coordinates_host(2,1) = 3.;
+      coordinates_host(3,0) = 2.; coordinates_host(3,1) = 1.;
+      coordinates_host(4,0) = 3.; coordinates_host(4,1) = 1.;
+      coordinates_host(5,0) = 4.; coordinates_host(5,1) = 1.;
+      Kokkos::deep_copy(coordinates,coordinates_host);
+
+      auto cell_vertices_host = Kokkos::create_mirror_view(mesh.cell_vertices);
+#define SET_NC(cell,node,vertex) cell_vertices_host(cell,node,0) = coordinates_host(vertex,0); cell_vertices_host(cell,node,1) = coordinates_host(vertex,1);
       SET_NC(0,0, 0);
       SET_NC(0,1, 3);
       SET_NC(0,2, 4);
@@ -463,27 +468,33 @@ namespace panzer {
       SET_NC(1,2, 5);
       SET_NC(1,3, 2);
 #undef SET_NC
+      Kokkos::deep_copy(mesh.cell_vertices,cell_vertices_host);
 
       mesh.face_to_cells = PHX::View<panzer::LocalOrdinal*[2]>("face_to_cells",6);
-      mesh.face_to_cells(0,0) = 0; mesh.face_to_cells(0,1) =  1;
-      mesh.face_to_cells(1,0) = 0; mesh.face_to_cells(1,1) = -1;
-      mesh.face_to_cells(2,0) = 0; mesh.face_to_cells(2,1) =  1;
-      mesh.face_to_cells(3,0) = 0; mesh.face_to_cells(3,1) = -1;
-      mesh.face_to_cells(4,0) = 1; mesh.face_to_cells(4,1) = -1;
-      mesh.face_to_cells(5,0) = 1; mesh.face_to_cells(5,1) = -1;
+      auto face_to_cells_host = Kokkos::create_mirror_view(mesh.face_to_cells);
+      face_to_cells_host(0,0) = 0; face_to_cells_host(0,1) =  1;
+      face_to_cells_host(1,0) = 0; face_to_cells_host(1,1) = -1;
+      face_to_cells_host(2,0) = 0; face_to_cells_host(2,1) =  1;
+      face_to_cells_host(3,0) = 0; face_to_cells_host(3,1) = -1;
+      face_to_cells_host(4,0) = 1; face_to_cells_host(4,1) = -1;
+      face_to_cells_host(5,0) = 1; face_to_cells_host(5,1) = -1;
+      Kokkos::deep_copy(mesh.face_to_cells,face_to_cells_host);
 
       mesh.face_to_lidx = PHX::View<panzer::LocalOrdinal*[2]>("face_to_lidx",6);
-      mesh.face_to_lidx(0,0) = 0; mesh.face_to_lidx(0,1) =  2;
-      mesh.face_to_lidx(1,0) = 1; mesh.face_to_lidx(1,1) = -1;
-      mesh.face_to_lidx(2,0) = 2; mesh.face_to_lidx(2,1) =  0;
-      mesh.face_to_lidx(3,0) = 3; mesh.face_to_lidx(3,1) = -1;
-      mesh.face_to_lidx(4,0) = 1; mesh.face_to_lidx(4,1) = -1;
-      mesh.face_to_lidx(5,0) = 3; mesh.face_to_lidx(5,1) = -1;
+      auto face_to_lidx_host = Kokkos::create_mirror_view(mesh.face_to_lidx);
+      face_to_lidx_host(0,0) = 0; face_to_lidx_host(0,1) =  2;
+      face_to_lidx_host(1,0) = 1; face_to_lidx_host(1,1) = -1;
+      face_to_lidx_host(2,0) = 2; face_to_lidx_host(2,1) =  0;
+      face_to_lidx_host(3,0) = 3; face_to_lidx_host(3,1) = -1;
+      face_to_lidx_host(4,0) = 1; face_to_lidx_host(4,1) = -1;
+      face_to_lidx_host(5,0) = 3; face_to_lidx_host(5,1) = -1;
+      Kokkos::deep_copy(mesh.face_to_lidx,face_to_lidx_host);
 
       mesh.cell_to_faces = PHX::View<panzer::LocalOrdinal**>("cell_to_faces",2,4);
-      mesh.cell_to_faces(0,0) = 0; mesh.cell_to_faces(0,1) = 1; mesh.cell_to_faces(0,2) = 2; mesh.cell_to_faces(0,3) = 3;
-      mesh.cell_to_faces(1,0) = 2; mesh.cell_to_faces(1,1) = 4; mesh.cell_to_faces(1,2) = 0; mesh.cell_to_faces(1,3) = 5;
-      
+      auto cell_to_faces_host = Kokkos::create_mirror_view(mesh.cell_to_faces);
+      cell_to_faces_host(0,0) = 0; cell_to_faces_host(0,1) = 1; cell_to_faces_host(0,2) = 2; cell_to_faces_host(0,3) = 3;
+      cell_to_faces_host(1,0) = 2; cell_to_faces_host(1,1) = 4; cell_to_faces_host(1,2) = 0; cell_to_faces_host(1,3) = 5;
+      Kokkos::deep_copy(mesh.cell_to_faces,cell_to_faces_host);
     }
    
     const auto id = panzer::IntegrationDescriptor(2, panzer::IntegrationDescriptor::SURFACE);
@@ -494,11 +505,15 @@ namespace panzer {
     // Fill node coordinates
     panzer::MDFieldArrayFactory af("prefix_",true);
     auto node_coordinates = af.buildStaticArray<double,Cell,NODE,Dim>("node_coordinates",2,4,2);
-
-    for(int i=0; i<mesh.cell_vertices.extent_int(0); ++i)
-      for(int j=0; j<mesh.cell_vertices.extent_int(1); ++j)
-        for(int k=0; k<mesh.cell_vertices.extent_int(2); ++k)
-          node_coordinates(i,j,k) = mesh.cell_vertices(i,j,k);
+    {
+      auto node_coordinates_host = Kokkos::create_mirror_view(node_coordinates.get_static_view());
+      auto cell_vertices_host = Kokkos::create_mirror_view(mesh.cell_vertices);
+      for(int i=0; i<mesh.cell_vertices.extent_int(0); ++i)
+        for(int j=0; j<mesh.cell_vertices.extent_int(1); ++j)
+          for(int k=0; k<mesh.cell_vertices.extent_int(2); ++k)
+            node_coordinates_host(i,j,k) = cell_vertices_host(i,j,k);
+      Kokkos::deep_copy(node_coordinates.get_static_view(),node_coordinates_host);
+    }
 
     // Make sure the integration values fail to construct without the subcell connectivity
     TEST_THROW(int_values.evaluateValues(node_coordinates), std::logic_error);
@@ -511,8 +526,8 @@ namespace panzer {
     int_values.evaluateValues(node_coordinates,-1,connectivity);
     
     // This test will focus on normals and points
-    const auto normals = int_values.surface_normals;
-    const auto points = int_values.ip_coordinates;
+    const auto normals = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),int_values.surface_normals.get_static_view());
+    const auto points = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),int_values.ip_coordinates.get_static_view());
     const int num_points_per_cell = points.extent_int(1);
     const int num_points_per_face = num_points_per_cell / 4;
 

--- a/packages/panzer/disc-fe/test/core_tests/integration_values2.cpp
+++ b/packages/panzer/disc-fe/test/core_tests/integration_values2.cpp
@@ -93,27 +93,30 @@ namespace panzer {
     typedef panzer::ArrayTraits<double,PHX::MDField<double> >::size_type size_type;
     const size_type x = 0;
     const size_type y = 1;
-    for (size_type cell = 0; cell < node_coordinates.extent(0); ++cell) {
-      node_coordinates(cell,0,x) = 0.0;
-      node_coordinates(cell,0,y) = 0.0;
-      node_coordinates(cell,1,x) = 1.0;
-      node_coordinates(cell,1,y) = 0.0;
-      node_coordinates(cell,2,x) = 1.0;
-      node_coordinates(cell,2,y) = 1.0;
-      node_coordinates(cell,3,x) = 0.0;
-      node_coordinates(cell,3,y) = 1.0;
-    }
+    auto node_coordinates_k = node_coordinates.get_view();
+    Kokkos::parallel_for("initialize node coords",node_coordinates.extent(0),
+                         KOKKOS_LAMBDA (const int cell) {
+      node_coordinates_k(cell,0,x) = 0.0;
+      node_coordinates_k(cell,0,y) = 0.0;
+      node_coordinates_k(cell,1,x) = 1.0;
+      node_coordinates_k(cell,1,y) = 0.0;
+      node_coordinates_k(cell,2,x) = 1.0;
+      node_coordinates_k(cell,2,y) = 1.0;
+      node_coordinates_k(cell,3,x) = 0.0;
+      node_coordinates_k(cell,3,y) = 1.0;
+    });
 
     int_values.evaluateValues(node_coordinates);
     
     TEST_EQUALITY(int_values.ip_coordinates.extent(1), 4);
     double realspace_x_coord = (1.0/std::sqrt(3.0) + 1.0) / 2.0;
     double realspace_y_coord = (1.0/std::sqrt(3.0) + 1.0) / 2.0;
-    TEST_FLOATING_EQUALITY(int_values.ip_coordinates(0,0,0), 
+    auto tmp_coords = int_values.ip_coordinates;
+    auto tmp_coords_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),tmp_coords.get_view());
+    TEST_FLOATING_EQUALITY(tmp_coords_host(0,0,0), 
                            realspace_x_coord, 1.0e-8);
-    TEST_FLOATING_EQUALITY(int_values.ip_coordinates(0,0,1), 
+    TEST_FLOATING_EQUALITY(tmp_coords_host(0,0,1), 
                            realspace_y_coord, 1.0e-8);
-
   }
 
   TEUCHOS_UNIT_TEST(integration_values, control_volume)
@@ -158,16 +161,18 @@ namespace panzer {
     typedef panzer::ArrayTraits<double,PHX::MDField<double> >::size_type size_type;
     const size_type x = 0;
     const size_type y = 1;
-    for (size_type cell = 0; cell < node_coordinates.extent(0); ++cell) {
-      node_coordinates(cell,0,x) = 0.0;
-      node_coordinates(cell,0,y) = 0.0;
-      node_coordinates(cell,1,x) = 1.0;
-      node_coordinates(cell,1,y) = 0.0;
-      node_coordinates(cell,2,x) = 1.0;
-      node_coordinates(cell,2,y) = 1.0;
-      node_coordinates(cell,3,x) = 0.0;
-      node_coordinates(cell,3,y) = 1.0;
-    }
+    auto node_coordinates_k = node_coordinates.get_view();
+    Kokkos::parallel_for("initialize node coords",node_coordinates.extent(0),
+                         KOKKOS_LAMBDA (const int cell) {
+      node_coordinates_k(cell,0,x) = 0.0;
+      node_coordinates_k(cell,0,y) = 0.0;
+      node_coordinates_k(cell,1,x) = 1.0;
+      node_coordinates_k(cell,1,y) = 0.0;
+      node_coordinates_k(cell,2,x) = 1.0;
+      node_coordinates_k(cell,2,y) = 1.0;
+      node_coordinates_k(cell,3,x) = 0.0;
+      node_coordinates_k(cell,3,y) = 1.0;
+    });
 
     int_values_vol.evaluateValues(node_coordinates);
     int_values_side.evaluateValues(node_coordinates);
@@ -177,15 +182,19 @@ namespace panzer {
     TEST_EQUALITY(int_values_side.weighted_normals.extent(1), 4);
     double realspace_x_coord_1 = 0.25;
     double realspace_y_coord_1 = 0.25;
-    TEST_FLOATING_EQUALITY(int_values_vol.ip_coordinates(0,0,0), 
+    auto tmp_coords = int_values_vol.ip_coordinates;
+    auto tmp_coords_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),tmp_coords.get_view());
+    TEST_FLOATING_EQUALITY(tmp_coords_host(0,0,0), 
                            realspace_x_coord_1, 1.0e-8);
-    TEST_FLOATING_EQUALITY(int_values_vol.ip_coordinates(0,0,1), 
+    TEST_FLOATING_EQUALITY(tmp_coords_host(0,0,1), 
                            realspace_y_coord_1, 1.0e-8);
     double realspace_x_coord_2 = 0.5;
     double realspace_y_coord_2 = 0.25;
-    TEST_FLOATING_EQUALITY(int_values_side.ip_coordinates(0,0,0), 
+    auto tmp_side_coords = int_values_side.ip_coordinates;
+    auto tmp_side_coords_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),tmp_side_coords.get_view());
+    TEST_FLOATING_EQUALITY(tmp_side_coords_host(0,0,0), 
                            realspace_x_coord_2, 1.0e-8);
-    TEST_FLOATING_EQUALITY(int_values_side.ip_coordinates(0,0,1), 
+    TEST_FLOATING_EQUALITY(tmp_side_coords_host(0,0,1), 
                            realspace_y_coord_2, 1.0e-8);
 
   }
@@ -225,25 +234,29 @@ namespace panzer {
     typedef panzer::ArrayTraits<double,PHX::MDField<double> >::size_type size_type;
     const size_type x = 0;
     const size_type y = 1;
-    for (size_type cell = 0; cell < node_coordinates.extent(0); ++cell) {
-      node_coordinates(cell,0,x) = 0.0;
-      node_coordinates(cell,0,y) = 0.0;
-      node_coordinates(cell,1,x) = 1.0;
-      node_coordinates(cell,1,y) = 0.0;
-      node_coordinates(cell,2,x) = 1.0;
-      node_coordinates(cell,2,y) = 1.0;
-      node_coordinates(cell,3,x) = 0.0;
-      node_coordinates(cell,3,y) = 1.0;
-    }
+    auto node_coordinates_k = node_coordinates.get_view();
+    Kokkos::parallel_for("initialize node coords",node_coordinates.extent(0),
+                         KOKKOS_LAMBDA (const int cell) {
+      node_coordinates_k(cell,0,x) = 0.0;
+      node_coordinates_k(cell,0,y) = 0.0;
+      node_coordinates_k(cell,1,x) = 1.0;
+      node_coordinates_k(cell,1,y) = 0.0;
+      node_coordinates_k(cell,2,x) = 1.0;
+      node_coordinates_k(cell,2,y) = 1.0;
+      node_coordinates_k(cell,3,x) = 0.0;
+      node_coordinates_k(cell,3,y) = 1.0;
+    });
 
     int_values_bc.evaluateValues(node_coordinates);
+
+    auto ip_coords_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),int_values_bc.ip_coordinates.get_view());
     
     TEST_EQUALITY(int_values_bc.ip_coordinates.extent(1), 2);
     double realspace_x_coord_1 = 1.0;
     double realspace_y_coord_1 = 0.25;
-    TEST_FLOATING_EQUALITY(int_values_bc.ip_coordinates(0,0,0), 
+    TEST_FLOATING_EQUALITY(ip_coords_host(0,0,0), 
                            realspace_x_coord_1, 1.0e-8);
-    TEST_FLOATING_EQUALITY(int_values_bc.ip_coordinates(0,0,1), 
+    TEST_FLOATING_EQUALITY(ip_coords_host(0,0,1), 
                            realspace_y_coord_1, 1.0e-8);
 
   }
@@ -282,27 +295,29 @@ namespace panzer {
     typedef panzer::ArrayTraits<double,PHX::MDField<double> >::size_type size_type;
     const size_type x = 0;
     const size_type y = 1;
-    for (size_type cell = 0; cell < node_coordinates.extent(0); ++cell) {
-      node_coordinates(cell,0,x) = 0.0;
-      node_coordinates(cell,0,y) = 0.0;
-      node_coordinates(cell,1,x) = 1.0;
-      node_coordinates(cell,1,y) = 0.0;
-      node_coordinates(cell,2,x) = 1.5;
-      node_coordinates(cell,2,y) = 1.5;
-      node_coordinates(cell,3,x) = 0.0;
-      node_coordinates(cell,3,y) = 1.0;
-    }
+    auto node_coordinates_k = node_coordinates.get_view();
+    Kokkos::parallel_for("initialize node coords",node_coordinates.extent(0),
+                         KOKKOS_LAMBDA (const int cell) {
+      node_coordinates_k(cell,0,x) = 0.0;
+      node_coordinates_k(cell,0,y) = 0.0;
+      node_coordinates_k(cell,1,x) = 1.0;
+      node_coordinates_k(cell,1,y) = 0.0;
+      node_coordinates_k(cell,2,x) = 1.5;
+      node_coordinates_k(cell,2,y) = 1.5;
+      node_coordinates_k(cell,3,x) = 0.0;
+      node_coordinates_k(cell,3,y) = 1.0;
+    });
 
     int_values.evaluateValues(node_coordinates);
 
     // pull out arrays to look at
     
-    auto weighted_measure   = int_values.weighted_measure;
-    auto jac_det            = int_values.jac_det;
-    auto ref_ip_coordinates = int_values.ref_ip_coordinates;
-    auto ip_coordinates     = int_values.ip_coordinates;
-    auto jac                = int_values.jac;
-    auto jac_inv            = int_values.jac_inv;
+    auto weighted_measure   = Kokkos::create_mirror_view(int_values.weighted_measure.get_view());
+    auto jac_det            = Kokkos::create_mirror_view(int_values.jac_det.get_view());
+    auto ref_ip_coordinates = Kokkos::create_mirror_view(int_values.ref_ip_coordinates.get_view());
+    auto ip_coordinates     = Kokkos::create_mirror_view(int_values.ip_coordinates.get_view());
+    auto jac                = Kokkos::create_mirror_view(int_values.jac.get_view());
+    auto jac_inv            = Kokkos::create_mirror_view(int_values.jac_inv.get_view());
 
     int num_cells  = ip_coordinates.extent(0); 
     int num_points = ip_coordinates.extent(1); 
@@ -320,7 +335,13 @@ namespace panzer {
       int new_pt = 1;
 
       int_values.swapQuadraturePoints(tst_cell,org_pt,new_pt);
-   
+      Kokkos::deep_copy(weighted_measure,int_values.weighted_measure.get_view());
+      Kokkos::deep_copy(jac_det,int_values.jac_det.get_view());
+      Kokkos::deep_copy(ref_ip_coordinates,int_values.ref_ip_coordinates.get_view());
+      Kokkos::deep_copy(ip_coordinates,int_values.ip_coordinates.get_view());
+      Kokkos::deep_copy(jac,int_values.jac.get_view());
+      Kokkos::deep_copy(jac_inv,int_values.jac_inv.get_view());
+      
       TEST_EQUALITY(    weighted_measure(ref_cell,org_pt),     weighted_measure(tst_cell,new_pt));
       TEST_EQUALITY(             jac_det(ref_cell,org_pt),              jac_det(tst_cell,new_pt));
       TEST_EQUALITY(ref_ip_coordinates(ref_cell,org_pt,0), ref_ip_coordinates(tst_cell,new_pt,0));
@@ -343,6 +364,13 @@ namespace panzer {
       int new_pt = 3;
 
       int_values.swapQuadraturePoints(tst_cell,org_pt,new_pt);
+      Kokkos::deep_copy(weighted_measure,int_values.weighted_measure.get_view());
+      Kokkos::deep_copy(jac_det,int_values.jac_det.get_view());
+      Kokkos::deep_copy(ref_ip_coordinates,int_values.ref_ip_coordinates.get_view());
+      Kokkos::deep_copy(ip_coordinates,int_values.ip_coordinates.get_view());
+      Kokkos::deep_copy(jac,int_values.jac.get_view());
+      Kokkos::deep_copy(jac_inv,int_values.jac_inv.get_view());
+
    
       TEST_EQUALITY(    weighted_measure(ref_cell,org_pt),     weighted_measure(tst_cell,new_pt));
       TEST_EQUALITY(             jac_det(ref_cell,org_pt),              jac_det(tst_cell,new_pt));

--- a/packages/panzer/disc-fe/test/core_tests/integration_values2.cpp
+++ b/packages/panzer/disc-fe/test/core_tests/integration_values2.cpp
@@ -507,7 +507,7 @@ namespace panzer {
     auto node_coordinates = af.buildStaticArray<double,Cell,NODE,Dim>("node_coordinates",2,4,2);
     {
       auto node_coordinates_host = Kokkos::create_mirror_view(node_coordinates.get_static_view());
-      auto cell_vertices_host = Kokkos::create_mirror_view(mesh.cell_vertices);
+      auto cell_vertices_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),mesh.cell_vertices);
       for(int i=0; i<mesh.cell_vertices.extent_int(0); ++i)
         for(int j=0; j<mesh.cell_vertices.extent_int(1); ++j)
           for(int k=0; k<mesh.cell_vertices.extent_int(2); ++k)
@@ -549,11 +549,11 @@ namespace panzer {
     
     // Face 0
     {
-      const int cell_0 = connectivity->cellForSubcell(0,0);
-      const int cell_1 = connectivity->cellForSubcell(0,1);
+      const int cell_0 = connectivity->cellForSubcellHost(0,0);
+      const int cell_1 = connectivity->cellForSubcellHost(0,1);
 
-      const int lidx_0 = connectivity->localSubcellForSubcell(0,0);
-      const int lidx_1 = connectivity->localSubcellForSubcell(0,1);
+      const int lidx_0 = connectivity->localSubcellForSubcellHost(0,0);
+      const int lidx_1 = connectivity->localSubcellForSubcellHost(0,1);
 
       TEST_EQUALITY(cell_0,0);
       TEST_EQUALITY(cell_1,1);
@@ -585,11 +585,11 @@ namespace panzer {
     
     // Face 2
     {
-      const int cell_0 = connectivity->cellForSubcell(2,0);
-      const int cell_1 = connectivity->cellForSubcell(2,1);
+      const int cell_0 = connectivity->cellForSubcellHost(2,0);
+      const int cell_1 = connectivity->cellForSubcellHost(2,1);
 
-      const int lidx_0 = connectivity->localSubcellForSubcell(2,0);
-      const int lidx_1 = connectivity->localSubcellForSubcell(2,1);
+      const int lidx_0 = connectivity->localSubcellForSubcellHost(2,0);
+      const int lidx_1 = connectivity->localSubcellForSubcellHost(2,1);
 
       TEST_EQUALITY(cell_0,0);
       TEST_EQUALITY(cell_1,1);


### PR DESCRIPTION
@trilinos/panzer

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
All IntegrationValues2 tests updated to run without UVM.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->