### PR TITLE
Panzer: implemet a method to add IOSS information records to the output

### DIFF
--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.cpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.cpp
@@ -281,6 +281,11 @@ void STK_Interface::addMeshCoordFields(const std::string & blockId,
    }
 }
 
+void STK_Interface::addInformationRecords(const std::vector<std::string> & info_records)
+{
+   informationRecords_.insert(info_records.begin(), info_records.end());
+}
+
 void STK_Interface::initialize(stk::ParallelMachine parallelMach,bool setupIO,
                                const bool buildRefinementSupport)
 {
@@ -711,6 +716,10 @@ setupExodusFile(const std::string& filename,
       meshData_->add_field(meshIndex_, *fields[i]);
     }
   }
+
+  // convert the set to a vector
+  std::vector<std::string> deduped_info_records(informationRecords_.begin(),informationRecords_.end());
+  meshData_->add_info_records(meshIndex_, deduped_info_records);
 #else
   TEUCHOS_ASSERT(false)
 #endif

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.hpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.hpp
@@ -180,6 +180,12 @@ public:
                            const std::vector<std::string> & coordField,
                            const std::string & dispPrefix);
 
+   /** Add a vector of strings to the Information Records block.  Each string
+     * will be it's own record.  The info records will be deduped before they
+     * are added to IOSS.
+     */
+   void addInformationRecords(const std::vector<std::string> & info_records);
+
    //////////////////////////////////////////
 
    /** Initialize the mesh with the current dimension This also calls
@@ -1316,6 +1322,9 @@ protected:
    std::map<std::pair<std::string,std::string>,SolutionFieldType*> fieldNameToCellField_;
    std::map<std::pair<std::string,std::string>,SolutionFieldType*> fieldNameToEdgeField_;
    std::map<std::pair<std::string,std::string>,SolutionFieldType*> fieldNameToFaceField_;
+
+   // use a set to maintain a list of unique information records
+   std::set<std::string> informationRecords_;
 
    unsigned dimension_;
 

--- a/packages/panzer/adapters-stk/test/stk_interface_test/tSTK_IO.cpp
+++ b/packages/panzer/adapters-stk/test/stk_interface_test/tSTK_IO.cpp
@@ -49,6 +49,7 @@
 #include "Panzer_STK_Version.hpp"
 #include "PanzerAdaptersSTK_config.hpp"
 #include "Panzer_STK_Interface.hpp"
+#include "Panzer_STK_CubeHexMeshFactory.hpp"
 #include "Panzer_STK_SquareQuadMeshFactory.hpp"
 #include "Panzer_STK_ExodusReaderFactory.hpp"
 #include "Kokkos_ViewFactory.hpp"
@@ -235,6 +236,59 @@ TEUCHOS_UNIT_TEST(tSTK_IO, transient_fields)
    RCP<STK_Interface> mesh_read = factory.buildMesh(MPI_COMM_WORLD);
    TEST_EQUALITY(mesh_read->getInitialStateTime(),4.5);
    TEST_EQUALITY(mesh_read->getCurrentStateTime(),0.0); // writeToExodus has not yet been called
+}
+
+TEUCHOS_UNIT_TEST(tSTK_IO, addInformationRecords)
+{
+   using Teuchos::RCP;
+
+   std::vector<std::string> info_records_1 = {
+     "DG::eblock-0_0_0::basis::Basis_HGRAD_HEX_C1_FEM",
+     "DG::eblock-0_0_0::field::Ex"
+   };
+   std::vector<std::string> info_records_2 = {
+     "DG::eblock-0_0_0::basis::Basis_HGRAD_HEX_C1_FEM",
+     "DG::eblock-0_0_0::field::Ey"
+   };
+   std::vector<std::string> info_records_3 = {
+     "DG::eblock-0_0_0::basis::Basis_HGRAD_HEX_C1_FEM",
+     "DG::eblock-0_0_0::field::Ez"
+   };
+   std::vector<std::string> info_records_4 = {
+     "DG::eblock-1_1_1::basis::Basis_HGRAD_HEX_C1_FEM",
+     "DG::eblock-1_1_1::field::Ex"
+   };
+   std::vector<std::string> info_records_5 = {
+     "DG::eblock-1_1_1::basis::Basis_HGRAD_HEX_C1_FEM",
+     "DG::eblock-1_1_1::field::Ey"
+   };
+   std::vector<std::string> info_records_6 = {
+     "DG::eblock-1_1_1::basis::Basis_HGRAD_HEX_C1_FEM",
+     "DG::eblock-1_1_1::field::Ez"
+   };
+
+   RCP<Teuchos::ParameterList> pl = rcp(new Teuchos::ParameterList);
+   pl->set("X Blocks",1);
+   pl->set("Y Blocks",1);
+   pl->set("Z Blocks",1);
+   pl->set("X Elements",2);
+   pl->set("Y Elements",4);
+   pl->set("Z Elements",5);
+
+   CubeHexMeshFactory factory;
+   factory.setParameterList(pl);
+   RCP<STK_Interface> mesh = factory.buildUncommitedMesh(MPI_COMM_WORLD);
+   mesh->addInformationRecords(info_records_1);
+   mesh->addInformationRecords(info_records_2);
+   mesh->addInformationRecords(info_records_3);
+   mesh->addInformationRecords(info_records_4);
+   mesh->addInformationRecords(info_records_5);
+   mesh->addInformationRecords(info_records_6);
+   factory.completeMeshConstruction(*mesh,MPI_COMM_WORLD);
+
+   TEST_ASSERT(mesh!=Teuchos::null);
+
+   mesh->writeToExodus("info_records.exo");
 }
 
 RCP<STK_Interface> buildMesh(int xElements,int yElements)


### PR DESCRIPTION
Implement an addInformationRecords() method that adds a vector of strings
to the Panzer STK Interface.  The strings are depuped as they are added
and then added to the STK mesh during setupExodusFile().

@trilinos/panzer 

* Closes #9436 

## Testing

addInformationRecords() is tested by PanzerAdaptersSTK_tSTK_IO.exe.
