### PR TITLE
WIP Tempus:  Add support for specifying the adjoint through a 2nd ME

### DIFF
--- a/packages/tempus/src/Tempus_AdjointAuxSensitivityModelEvaluator_decl.hpp
+++ b/packages/tempus/src/Tempus_AdjointAuxSensitivityModelEvaluator_decl.hpp
@@ -81,12 +81,17 @@ public:
    */
   AdjointAuxSensitivityModelEvaluator(
     const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > & model,
+    const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > & adjoint_model,
     const Scalar& t_final,
     const Teuchos::RCP<const Teuchos::ParameterList>& pList = Teuchos::null);
 
   //! Get the underlying model 'f'
   Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > getModel() const
   { return model_; }
+
+  //! Get the underlying adjoint model
+  Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > getAdjointModel() const
+  { return adjoint_model_; }
 
   //! Set solution history from forward evaluation
   void setForwardSolutionHistory(
@@ -134,6 +139,7 @@ private:
   Thyra::ModelEvaluatorBase::OutArgs<Scalar> prototypeOutArgs_;
 
   Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > model_;
+  Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > adjoint_model_;
 
   Teuchos::RCP<const DMVPVS> adjoint_space_;
   Teuchos::RCP<const DMVPVS> residual_space_;

--- a/packages/tempus/src/Tempus_AdjointAuxSensitivityModelEvaluator_impl.hpp
+++ b/packages/tempus/src/Tempus_AdjointAuxSensitivityModelEvaluator_impl.hpp
@@ -11,9 +11,6 @@
 
 #include "Thyra_MultiVectorLinearOp.hpp"
 #include "Thyra_MultiVectorLinearOpWithSolveFactory.hpp"
-#include "Thyra_DefaultScaledAdjointLinearOp.hpp"
-#include "Thyra_DefaultAdjointLinearOpWithSolve.hpp"
-#include "Thyra_AdjointLinearOpWithSolveFactory.hpp"
 #include "Thyra_ScaledIdentityLinearOpWithSolve.hpp"
 #include "Thyra_ScaledIdentityLinearOpWithSolveFactory.hpp"
 #include "Thyra_DefaultBlockedLinearOp.hpp"
@@ -27,9 +24,11 @@ template <typename Scalar>
 AdjointAuxSensitivityModelEvaluator<Scalar>::
 AdjointAuxSensitivityModelEvaluator(
   const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > & model,
+  const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > & adjoint_model,
   const Scalar& t_final,
   const Teuchos::RCP<const Teuchos::ParameterList>& pList) :
   model_(model),
+  adjoint_model_(adjoint_model),
   t_final_(t_final),
   mass_matrix_is_computed_(false),
   t_interp_(Teuchos::ScalarTraits<Scalar>::rmax())
@@ -88,6 +87,7 @@ AdjointAuxSensitivityModelEvaluator(
   prototypeInArgs_ = inArgs;
 
   MEB::OutArgs<Scalar> me_outArgs = model_->createOutArgs();
+  MEB::OutArgs<Scalar> adj_me_outArgs = adjoint_model_->createOutArgs();
   MEB::OutArgsSetup<Scalar> outArgs;
   outArgs.setModelEvalDescription(this->description());
   outArgs.set_Np_Ng(me_inArgs.Np(),0);
@@ -95,10 +95,10 @@ AdjointAuxSensitivityModelEvaluator(
   outArgs.setSupports(MEB::OUT_ARG_W_op);
   prototypeOutArgs_ = outArgs;
 
-  // ME must support W_op to define adjoint ODE/DAE.
+  // Adjoint ME must support W_op to define adjoint ODE/DAE.
   // Must support alpha, beta if it suports x_dot
   TEUCHOS_ASSERT(me_inArgs.supports(MEB::IN_ARG_x));
-  TEUCHOS_ASSERT(me_outArgs.supports(MEB::OUT_ARG_W_op));
+  TEUCHOS_ASSERT(adj_me_outArgs.supports(MEB::OUT_ARG_W_op));
   if (me_inArgs.supports(MEB::IN_ARG_x_dot)) {
     TEUCHOS_ASSERT(me_inArgs.supports(MEB::IN_ARG_alpha));
     TEUCHOS_ASSERT(me_inArgs.supports(MEB::IN_ARG_beta));
@@ -158,10 +158,9 @@ create_W_op() const
   using Teuchos::RCP;
   using Thyra::LinearOpBase;
 
-  RCP<LinearOpBase<Scalar> > op = model_->create_W_op();
+  RCP<LinearOpBase<Scalar> > adjoint_op = adjoint_model_->create_W_op();
   RCP<LinearOpBase<Scalar> > mv_adjoint_op =
-    Thyra::nonconstMultiVectorLinearOp(Thyra::nonconstAdjoint(op),
-                                       num_adjoint_);
+    Thyra::nonconstMultiVectorLinearOp(adjoint_op, num_adjoint_);
   RCP<const Thyra::VectorSpaceBase<Scalar> > g_space = response_space_;
   RCP<LinearOpBase<Scalar> > g_op =
     Thyra::scaledIdentity(g_space, Scalar(1.0));
@@ -178,11 +177,10 @@ get_W_factory() const
   using Teuchos::rcp_dynamic_cast;
   typedef Thyra::LinearOpWithSolveFactoryBase<Scalar> LOWSFB;
 
-  RCP<const LOWSFB > factory = model_->get_W_factory();
-  if (factory == Teuchos::null)
+  RCP<const LOWSFB > alowsfb = adjoint_model_->get_W_factory();
+  if (alowsfb == Teuchos::null)
     return Teuchos::null; // model_ doesn't support W_factory
 
-  RCP<const LOWSFB > alowsfb = Thyra::adjointLinearOpWithSolveFactory(factory);
   RCP<const LOWSFB > mv_alowsfb =
     Thyra::multiVectorLinearOpWithSolveFactory(alowsfb, residual_space_,
                                                adjoint_space_);
@@ -256,6 +254,11 @@ evalModelImpl(const Thyra::ModelEvaluatorBase::InArgs<Scalar> &inArgs,
   using Teuchos::RCP;
   using Teuchos::rcp_dynamic_cast;
 
+  // Note:  adjoint_model computes the transposed W (either explicitly or
+  // implicitly.  Thus we need to always call adjoint_model->evalModel()
+  // whenever computing the adjoint operator, and subsequent calls to apply()
+  // do not transpose it.
+
   // Interpolate forward solution at supplied time, reusing previous
   // interpolation if possible
   TEUCHOS_ASSERT(sh_ != Teuchos::null);
@@ -295,12 +298,11 @@ evalModelImpl(const Thyra::ModelEvaluatorBase::InArgs<Scalar> &inArgs,
     RCP<Thyra::MultiVectorLinearOp<Scalar> > mv_adjoint_op =
       rcp_dynamic_cast<Thyra::MultiVectorLinearOp<Scalar> >(
         block_op->getNonconstBlock(0,0),true);
-    RCP<Thyra::DefaultScaledAdjointLinearOp<Scalar> > adjoint_op =
-      rcp_dynamic_cast<Thyra::DefaultScaledAdjointLinearOp<Scalar> >(
-        mv_adjoint_op->getNonconstLinearOp(),true);
-    MEB::OutArgs<Scalar> me_outArgs = model_->createOutArgs();
-    me_outArgs.set_W_op(adjoint_op->getNonconstOp());
-    model_->evalModel(me_inArgs, me_outArgs);
+    RCP<Thyra::LinearOpBase<Scalar> > adjoint_op =
+      mv_adjoint_op->getNonconstLinearOp();
+    MEB::OutArgs<Scalar> adj_me_outArgs = adjoint_model_->createOutArgs();
+    adj_me_outArgs.set_W_op(adjoint_op);
+    adjoint_model_->evalModel(me_inArgs, adj_me_outArgs);
 
     // g W
     RCP<Thyra::ScaledIdentityLinearOpWithSolve<Scalar> > si_op =
@@ -328,19 +330,19 @@ evalModelImpl(const Thyra::ModelEvaluatorBase::InArgs<Scalar> &inArgs,
     RCP<Thyra::MultiVectorBase<Scalar> > adjoint_f_mv =
       rcp_dynamic_cast<DMVPV>(adjoint_f,true)->getNonconstMultiVector();
 
-    MEB::OutArgs<Scalar> me_outArgs = model_->createOutArgs();
+    MEB::OutArgs<Scalar> adj_me_outArgs = adjoint_model_->createOutArgs();
 
     if (my_dfdx_ == Teuchos::null)
-      my_dfdx_ = model_->create_W_op();
-    me_outArgs.set_W_op(my_dfdx_);
+      my_dfdx_ = adjoint_model_->create_W_op();
+    adj_me_outArgs.set_W_op(my_dfdx_);
     if (me_inArgs.supports(MEB::IN_ARG_alpha))
       me_inArgs.set_alpha(0.0);
     if (me_inArgs.supports(MEB::IN_ARG_beta))
       me_inArgs.set_beta(1.0);
-    model_->evalModel(me_inArgs, me_outArgs);
+    adjoint_model_->evalModel(me_inArgs, adj_me_outArgs);
 
     // Explicit form residual F(y) = -df/dx^T*y
-    my_dfdx_->apply(Thyra::CONJTRANS, *adjoint_x_mv, adjoint_f_mv.ptr(),
+    my_dfdx_->apply(Thyra::NOTRANS, *adjoint_x_mv, adjoint_f_mv.ptr(),
                     Scalar(-1.0), Scalar(0.0));
 
     // Implicit form residual df/dx_dot^T*y_dot + df/dx^T*y using the second
@@ -361,16 +363,16 @@ evalModelImpl(const Thyra::ModelEvaluatorBase::InArgs<Scalar> &inArgs,
         }
         else {
           if (my_dfdxdot_ == Teuchos::null)
-            my_dfdxdot_ = model_->create_W_op();
+            my_dfdxdot_ = adjoint_model_->create_W_op();
           if (!mass_matrix_is_constant_ || !mass_matrix_is_computed_) {
-            me_outArgs.set_W_op(my_dfdxdot_);
+            adj_me_outArgs.set_W_op(my_dfdxdot_);
             me_inArgs.set_alpha(1.0);
             me_inArgs.set_beta(0.0);
-            model_->evalModel(me_inArgs, me_outArgs);
+            adjoint_model_->evalModel(me_inArgs, adj_me_outArgs);
 
             mass_matrix_is_computed_ = true;
           }
-          my_dfdxdot_->apply(Thyra::CONJTRANS, *adjoint_x_dot_mv,
+          my_dfdxdot_->apply(Thyra::NOTRANS, *adjoint_x_dot_mv,
                              adjoint_f_mv.ptr(), Scalar(1.0), Scalar(-1.0));
         }
       }

--- a/packages/tempus/src/Tempus_AdjointAuxSensitivityModelEvaluator_impl.hpp
+++ b/packages/tempus/src/Tempus_AdjointAuxSensitivityModelEvaluator_impl.hpp
@@ -72,7 +72,10 @@ AdjointAuxSensitivityModelEvaluator(
   x_prod_space_ = Thyra::productVectorSpace(x_spaces());
   f_prod_space_ = Thyra::productVectorSpace(f_spaces());
 
+  // forward and adjoint models must support same InArgs
   MEB::InArgs<Scalar> me_inArgs = model_->createInArgs();
+  me_inArgs.assertSameSupport(adjoint_model_->createInArgs());
+
   MEB::InArgsSetup<Scalar> inArgs;
   inArgs.setModelEvalDescription(this->description());
   inArgs.setSupports(MEB::IN_ARG_x);

--- a/packages/tempus/src/Tempus_AdjointSensitivityModelEvaluator_decl.hpp
+++ b/packages/tempus/src/Tempus_AdjointSensitivityModelEvaluator_decl.hpp
@@ -78,6 +78,7 @@ public:
    */
   AdjointSensitivityModelEvaluator(
     const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > & model,
+    const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > & adjoint_model,
     const Scalar& t_final,
     const bool is_pseudotransient,
     const Teuchos::RCP<const Teuchos::ParameterList>& pList = Teuchos::null);
@@ -85,6 +86,10 @@ public:
   //! Get the underlying model 'f'
   Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > getModel() const
   { return model_; }
+
+  //! Get the underlying adjoint model
+  Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > getAdjointModel() const
+  { return adjoint_model_; }
 
   //! Set solution history from forward evaluation
   void setForwardSolutionHistory(
@@ -132,6 +137,7 @@ private:
   Thyra::ModelEvaluatorBase::OutArgs<Scalar> prototypeOutArgs_;
 
   Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > model_;
+  Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > adjoint_model_;
 
   Teuchos::RCP<const DMVPVS> adjoint_space_;
   Teuchos::RCP<const DMVPVS> residual_space_;

--- a/packages/tempus/src/Tempus_AdjointSensitivityModelEvaluator_impl.hpp
+++ b/packages/tempus/src/Tempus_AdjointSensitivityModelEvaluator_impl.hpp
@@ -25,10 +25,12 @@ template <typename Scalar>
 AdjointSensitivityModelEvaluator<Scalar>::
 AdjointSensitivityModelEvaluator(
   const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > & model,
+  const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > & adjoint_model,
   const Scalar& t_final,
   const bool is_pseudotransient,
   const Teuchos::RCP<const Teuchos::ParameterList>& pList) :
   model_(model),
+  adjoint_model_(adjoint_model),
   t_final_(t_final),
   is_pseudotransient_(is_pseudotransient),
   mass_matrix_is_computed_(false),
@@ -79,6 +81,7 @@ AdjointSensitivityModelEvaluator(
   prototypeInArgs_ = inArgs;
 
   MEB::OutArgs<Scalar> me_outArgs = model_->createOutArgs();
+  MEB::OutArgs<Scalar> adj_me_outArgs = adjoint_model_->createOutArgs();
   MEB::OutArgsSetup<Scalar> outArgs;
   outArgs.setModelEvalDescription(this->description());
   outArgs.set_Np_Ng(me_inArgs.Np(),1);
@@ -89,7 +92,7 @@ AdjointSensitivityModelEvaluator(
   // ME must support W_op to define adjoint ODE/DAE.
   // Must support alpha, beta if it suports x_dot
   TEUCHOS_ASSERT(me_inArgs.supports(MEB::IN_ARG_x));
-  TEUCHOS_ASSERT(me_outArgs.supports(MEB::OUT_ARG_W_op));
+  TEUCHOS_ASSERT(adj_me_outArgs.supports(MEB::OUT_ARG_W_op));
   if (me_inArgs.supports(MEB::IN_ARG_x_dot)) {
     TEUCHOS_ASSERT(me_inArgs.supports(MEB::IN_ARG_alpha));
     TEUCHOS_ASSERT(me_inArgs.supports(MEB::IN_ARG_beta));
@@ -165,9 +168,9 @@ Teuchos::RCP<Thyra::LinearOpBase<Scalar> >
 AdjointSensitivityModelEvaluator<Scalar>::
 create_W_op() const
 {
-  Teuchos::RCP<Thyra::LinearOpBase<Scalar> > op = model_->create_W_op();
-  return Thyra::nonconstMultiVectorLinearOp( Thyra::nonconstAdjoint(op),
-                                             num_adjoint_);
+  Teuchos::RCP<Thyra::LinearOpBase<Scalar> > adjoint_op =
+    adjoint_model_->create_W_op();
+  return Thyra::nonconstMultiVectorLinearOp(adjoint_op, num_adjoint_);
 }
 
 template <typename Scalar>
@@ -179,11 +182,10 @@ get_W_factory() const
   using Teuchos::rcp_dynamic_cast;
   typedef Thyra::LinearOpWithSolveFactoryBase<Scalar> LOWSFB;
 
-  RCP<const LOWSFB> factory = model_->get_W_factory();
-  if (factory == Teuchos::null)
+  RCP<const LOWSFB> alowsfb = adjoint_model_->get_W_factory();
+  if (alowsfb == Teuchos::null)
     return Teuchos::null; // model_ doesn't support W_factory
 
-  RCP<const LOWSFB> alowsfb = Thyra::adjointLinearOpWithSolveFactory(factory);
   return Thyra::multiVectorLinearOpWithSolveFactory(
     alowsfb, residual_space_, adjoint_space_);
 }
@@ -247,6 +249,11 @@ evalModelImpl(const Thyra::ModelEvaluatorBase::InArgs<Scalar> &inArgs,
   using Teuchos::RCP;
   using Teuchos::rcp_dynamic_cast;
 
+  // Note:  adjoint_model computes the transposed W (either explicitly or
+  // implicitly.  Thus we need to always call adjoint_model->evalModel()
+  // whenever computing the adjoint operator, and subsequent calls to apply()
+  // do not transpose it.
+
   // Interpolate forward solution at supplied time, reusing previous
   // interpolation if possible
   TEUCHOS_ASSERT(sh_ != Teuchos::null);
@@ -309,12 +316,11 @@ evalModelImpl(const Thyra::ModelEvaluatorBase::InArgs<Scalar> &inArgs,
 
     RCP<Thyra::MultiVectorLinearOp<Scalar> > mv_adjoint_op =
       rcp_dynamic_cast<Thyra::MultiVectorLinearOp<Scalar> >(op,true);
-    RCP<Thyra::DefaultScaledAdjointLinearOp<Scalar> > adjoint_op =
-      rcp_dynamic_cast<Thyra::DefaultScaledAdjointLinearOp<Scalar> >(
-        mv_adjoint_op->getNonconstLinearOp(),true);
-    MEB::OutArgs<Scalar> me_outArgs = model_->createOutArgs();
-    me_outArgs.set_W_op(adjoint_op->getNonconstOp());
-    model_->evalModel(me_inArgs, me_outArgs);
+    RCP<Thyra::LinearOpBase<Scalar> > adjoint_op =
+      mv_adjoint_op->getNonconstLinearOp();
+    MEB::OutArgs<Scalar> adj_me_outArgs = adjoint_model_->createOutArgs();
+    adj_me_outArgs.set_W_op(adjoint_op);
+    adjoint_model_->evalModel(me_inArgs, adj_me_outArgs);
   }
 
   RCP<Thyra::VectorBase<Scalar> > adjoint_f = outArgs.get_f();
@@ -337,6 +343,7 @@ evalModelImpl(const Thyra::ModelEvaluatorBase::InArgs<Scalar> &inArgs,
       rcp_dynamic_cast<DMVPV>(adjoint_f,true)->getNonconstMultiVector();
 
     MEB::OutArgs<Scalar> me_outArgs = model_->createOutArgs();
+    MEB::OutArgs<Scalar> adj_me_outArgs = adjoint_model_->createOutArgs();
 
     // dg/dx^T
     // Don't re-evaluate dg/dx for pseudotransient
@@ -357,15 +364,15 @@ evalModelImpl(const Thyra::ModelEvaluatorBase::InArgs<Scalar> &inArgs,
     // Don't re-evaluate df/dx for pseudotransient
     if (!is_pseudotransient_ || my_dfdx_ == Teuchos::null) {
       if (my_dfdx_ == Teuchos::null)
-        my_dfdx_ = model_->create_W_op();
-      me_outArgs.set_W_op(my_dfdx_);
+        my_dfdx_ = adjoint_model_->create_W_op();
+      adj_me_outArgs.set_W_op(my_dfdx_);
       if (me_inArgs.supports(MEB::IN_ARG_alpha))
         me_inArgs.set_alpha(0.0);
       if (me_inArgs.supports(MEB::IN_ARG_beta))
         me_inArgs.set_beta(1.0);
-      model_->evalModel(me_inArgs, me_outArgs);
+      adjoint_model_->evalModel(me_inArgs, adj_me_outArgs);
     }
-    my_dfdx_->apply(Thyra::CONJTRANS, *adjoint_x_mv, adjoint_f_mv.ptr(),
+    my_dfdx_->apply(Thyra::NOTRANS, *adjoint_x_mv, adjoint_f_mv.ptr(),
                     Scalar(-1.0), Scalar(1.0));
 
     // Implicit form residual F(y) df/dx_dot^T*y_dot + df/dx^T*y - dg/dx^T
@@ -385,16 +392,16 @@ evalModelImpl(const Thyra::ModelEvaluatorBase::InArgs<Scalar> &inArgs,
         else {
           if (!is_pseudotransient_ || my_dfdxdot_ == Teuchos::null) {
             if (my_dfdxdot_ == Teuchos::null)
-              my_dfdxdot_ = model_->create_W_op();
+              my_dfdxdot_ = adjoint_model_->create_W_op();
             if (!mass_matrix_is_constant_ || !mass_matrix_is_computed_) {
-              me_outArgs.set_W_op(my_dfdxdot_);
+              adj_me_outArgs.set_W_op(my_dfdxdot_);
               me_inArgs.set_alpha(1.0);
               me_inArgs.set_beta(0.0);
-              model_->evalModel(me_inArgs, me_outArgs);
+              adjoint_model_->evalModel(me_inArgs, adj_me_outArgs);
               mass_matrix_is_computed_ = true;
             }
           }
-          my_dfdxdot_->apply(Thyra::CONJTRANS, *adjoint_x_dot_mv,
+          my_dfdxdot_->apply(Thyra::NOTRANS, *adjoint_x_dot_mv,
                              adjoint_f_mv.ptr(), Scalar(1.0), Scalar(-1.0));
         }
       }

--- a/packages/tempus/src/Tempus_AdjointSensitivityModelEvaluator_impl.hpp
+++ b/packages/tempus/src/Tempus_AdjointSensitivityModelEvaluator_impl.hpp
@@ -64,7 +64,10 @@ AdjointSensitivityModelEvaluator(
     Thyra::multiVectorProductVectorSpace(model_->get_p_space(p_index_),
                                          num_adjoint_);
 
+  // forward and adjoint models must support same InArgs
   MEB::InArgs<Scalar> me_inArgs = model_->createInArgs();
+  me_inArgs.assertSameSupport(adjoint_model_->createInArgs());
+
   MEB::InArgsSetup<Scalar> inArgs;
   inArgs.setModelEvalDescription(this->description());
   inArgs.setSupports(MEB::IN_ARG_x);

--- a/packages/tempus/src/Tempus_IntegratorAdjointSensitivity.cpp
+++ b/packages/tempus/src/Tempus_IntegratorAdjointSensitivity.cpp
@@ -24,6 +24,13 @@ namespace Tempus {
 
   // Nonmember ctor
   template Teuchos::RCP<IntegratorAdjointSensitivity<double> >
+  integratorAdjointSensitivity(
+    Teuchos::RCP<Teuchos::ParameterList>        parameterList,
+    const Teuchos::RCP<Thyra::ModelEvaluator<double> >& model,
+    const Teuchos::RCP<Thyra::ModelEvaluator<double> >& adjoint_model);
+
+  // Nonmember ctor
+  template Teuchos::RCP<IntegratorAdjointSensitivity<double> >
   integratorAdjointSensitivity();
 
 } // namespace Tempus

--- a/packages/tempus/src/Tempus_IntegratorAdjointSensitivity_decl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorAdjointSensitivity_decl.hpp
@@ -39,6 +39,12 @@ namespace Tempus {
  *
  * Because of limitations on the steppers, the implementation currently assumes
  * df/dxdot is a constant matrix.
+ *
+ * To extract the final solution x(T) and sensitivity dg/dp(T) one should use
+ * the getX() and getDgDp() methods, which return these quantities directly.
+ * One can also extract this data for all times from the solution history,
+ * however the data is stored in Thyra product vectors which requires
+ * knowledge of the internal implementation.
  */
 template<class Scalar>
 class IntegratorAdjointSensitivity :

--- a/packages/tempus/src/Tempus_IntegratorAdjointSensitivity_decl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorAdjointSensitivity_decl.hpp
@@ -76,6 +76,24 @@ public:
    *    <li> "Mass Matrix Is Identity" (default: false) Whether the mass matrix
    *         is the identity matrix, in which some computations can be skipped.
    * </ul>
+   *
+   * To support use-cases with explicitly computed adjoint operators, the
+   * constructor takes an additional model evaluator for computing the adjoint
+   * W/W_op.  It is assumed the operator returned by this model evaluator is
+   * the adjoint, and so will not be transposed.  It is also assumed this
+   * model evaluator accepts the same inArgs as the forward model, however it
+   * only requires supporting the adjoint W/W_op outArgs.
+   */
+  IntegratorAdjointSensitivity(
+    Teuchos::RCP<Teuchos::ParameterList>                pList,
+    const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model,
+    const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& adjoint_model);
+
+  /*! \brief Version of the constructor taking a single model evaluator. */
+  /*!
+   * This version takes a single model evaluator for the case when the adjoint
+   * is implicitly determined from the forward operator by the (conjugate)
+   * transpose.
    */
   IntegratorAdjointSensitivity(
     Teuchos::RCP<Teuchos::ParameterList>                pList,
@@ -173,6 +191,7 @@ protected:
   Teuchos::RCP<AdjointAuxSensitivityModelEvaluator<Scalar> >
   createAdjointModel(
     const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model,
+    const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& adjoint_model,
     const Teuchos::RCP<Teuchos::ParameterList>& inputPL);
 
   void buildSolutionHistory(
@@ -180,7 +199,8 @@ protected:
     const Teuchos::RCP<const SolutionHistory<Scalar> >& adjoint_solution_history);
 
   Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > model_;
-  Teuchos::RCP<AdjointAuxSensitivityModelEvaluator<Scalar> > adjoint_model_;
+  Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > adjoint_model_;
+  Teuchos::RCP<AdjointAuxSensitivityModelEvaluator<Scalar> > adjoint_aux_model_;
   Teuchos::RCP<IntegratorBasicOld<Scalar> > state_integrator_;
   Teuchos::RCP<IntegratorBasicOld<Scalar> > adjoint_integrator_;
   Teuchos::RCP<SolutionHistory<Scalar> > solutionHistory_;
@@ -200,6 +220,14 @@ Teuchos::RCP<IntegratorAdjointSensitivity<Scalar> >
 integratorAdjointSensitivity(
   Teuchos::RCP<Teuchos::ParameterList>                pList,
   const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model);
+
+/// Nonmember constructor
+template<class Scalar>
+Teuchos::RCP<IntegratorAdjointSensitivity<Scalar> >
+integratorAdjointSensitivity(
+  Teuchos::RCP<Teuchos::ParameterList>                pList,
+  const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model,
+  const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& adjoint_model);
 
 /// Nonmember constructor
 template<class Scalar>

--- a/packages/tempus/src/Tempus_IntegratorForwardSensitivity_decl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorForwardSensitivity_decl.hpp
@@ -39,9 +39,11 @@ namespace Tempus {
  * Note that this integrator implements all of the same functions as the
  * IntegratorBasicOld, but is not derived from IntegratorBasicOld.  It also provides
  * functions for setting the sensitivity initial conditions and extracting the
- * sensitivity at the final time.  Also the vectors stored in the solution
- * history store product vectors of the state and sensitivities using
- * Thyra;:DefaultMultiVectorProductVector.
+ * sensitivity at the final time.  One should use the getX() and getDxDp()
+ * methods for extracting the final sultion and its parameter sensitivity
+ * as a multi-vector.  This data can also be extracted from the solution
+ * history, but is stored as a Thyra product vector which requires knowledge
+ * of the internal implementation.
  */
 template<class Scalar>
 class IntegratorForwardSensitivity

--- a/packages/tempus/src/Tempus_IntegratorPseudoTransientAdjointSensitivity.cpp
+++ b/packages/tempus/src/Tempus_IntegratorPseudoTransientAdjointSensitivity.cpp
@@ -30,6 +30,20 @@ namespace Tempus {
 
   // Nonmember ctor
   template Teuchos::RCP<IntegratorPseudoTransientAdjointSensitivity<double> >
+  integratorPseudoTransientAdjointSensitivity(
+    Teuchos::RCP<Teuchos::ParameterList>        parameterList,
+    const Teuchos::RCP<Thyra::ModelEvaluator<double> >& model,
+    const Teuchos::RCP<Thyra::ModelEvaluator<double> >& adjoint_model);
+
+  // Nonmember ctor
+  template Teuchos::RCP<IntegratorPseudoTransientAdjointSensitivity<double> >
+  integratorPseudoTransientAdjointSensitivity(
+    const Teuchos::RCP<Thyra::ModelEvaluator<double> >& model,
+    const Teuchos::RCP<Thyra::ModelEvaluator<double> >& adjoint_model,
+    std::string stepperType);
+
+  // Nonmember ctor
+  template Teuchos::RCP<IntegratorPseudoTransientAdjointSensitivity<double> >
   integratorPseudoTransientAdjointSensitivity();
 
 } // namespace Tempus

--- a/packages/tempus/src/Tempus_IntegratorPseudoTransientAdjointSensitivity_decl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorPseudoTransientAdjointSensitivity_decl.hpp
@@ -47,6 +47,12 @@ namespace Tempus {
  * One can see that y^s is the only steady-state solution of the adjoint
  * equations, since df/dx and dg/dx are constant, and must be linearly stable
  * (since the eigenvalues of df/dx^T are the same as df/dx).
+ *
+ * To extract the final solution x(T) and sensitivity dg/dp one should use
+ * the getX() and getDgDp() methods, which return these quantities directly.
+ * One can also extract this data for all times from the solution history,
+ * however the data is stored in Thyra product vectors which requires
+ * knowledge of the internal implementation.
  */
 template<class Scalar>
 class IntegratorPseudoTransientAdjointSensitivity

--- a/packages/tempus/src/Tempus_IntegratorPseudoTransientAdjointSensitivity_decl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorPseudoTransientAdjointSensitivity_decl.hpp
@@ -72,12 +72,41 @@ public:
    *    <li> "Mass Matrix Is Identity" (default: false) Whether the mass matrix
    *         is the identity matrix, in which some computations can be skipped.
    * </ul>
+   *
+   * To support use-cases with explicitly computed adjoint operators, the
+   * constructor takes an additional model evaluator for computing the adjoint
+   * W/W_op.  It is assumed the operator returned by this model evaluator is
+   * the adjoint, and so will not be transposed.  It is also assumed this
+   * model evaluator accepts the same inArgs as the forward model, however it
+   * only requires supporting the adjoint W/W_op outArgs.
+   */
+  IntegratorPseudoTransientAdjointSensitivity(
+    Teuchos::RCP<Teuchos::ParameterList>                pList,
+    const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model,
+    const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& adjoint_model);
+
+  /** \brief Constructor with model and "Stepper Type" and is fully initialized with default settings. */
+  IntegratorPseudoTransientAdjointSensitivity(
+    const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model,
+    const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& adjoint_model,
+    std::string stepperType);
+
+  /*! \brief Version of the constructor taking a single model evaluator. */
+  /*!
+   * This version takes a single model evaluator for the case when the adjoint
+   * is implicitly determined from the forward operator by the (conjugate)
+   * transpose.
    */
   IntegratorPseudoTransientAdjointSensitivity(
     Teuchos::RCP<Teuchos::ParameterList>                pList,
     const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model);
 
-  /** \brief Constructor with model and "Stepper Type" and is fully initialized with default settings. */
+  /*! \brief Version of the constructor taking a single model evaluator. */
+  /*!
+   * This version takes a single model evaluator for the case when the adjoint
+   * is implicitly determined from the forward operator by the (conjugate)
+   * transpose.
+   */
   IntegratorPseudoTransientAdjointSensitivity(
     const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model,
     std::string stepperType);
@@ -169,11 +198,13 @@ protected:
   Teuchos::RCP<AdjointSensitivityModelEvaluator<Scalar> >
   createSensitivityModel(
     const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model,
+    const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& adjoint_model,
     const Teuchos::RCP<Teuchos::ParameterList>& inputPL);
 
   void buildSolutionHistory();
 
   Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > model_;
+  Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > adjoint_model_;
   Teuchos::RCP<AdjointSensitivityModelEvaluator<Scalar> > sens_model_;
   Teuchos::RCP<IntegratorBasicOld<Scalar> > state_integrator_;
   Teuchos::RCP<IntegratorBasicOld<Scalar> > sens_integrator_;
@@ -193,6 +224,22 @@ template<class Scalar>
 Teuchos::RCP<Tempus::IntegratorPseudoTransientAdjointSensitivity<Scalar> >
 integratorPseudoTransientAdjointSensitivity(
   const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model,
+  std::string stepperType);
+
+/// Nonmember constructor
+template<class Scalar>
+Teuchos::RCP<Tempus::IntegratorPseudoTransientAdjointSensitivity<Scalar> >
+integratorPseudoTransientAdjointSensitivity(
+  Teuchos::RCP<Teuchos::ParameterList>                pList,
+  const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model,
+  const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& adjoint_model);
+
+/// Nonmember constructor
+template<class Scalar>
+Teuchos::RCP<Tempus::IntegratorPseudoTransientAdjointSensitivity<Scalar> >
+integratorPseudoTransientAdjointSensitivity(
+  const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model,
+  const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& adjoint_model,
   std::string stepperType);
 
 /// Nonmember constructor

--- a/packages/tempus/src/Tempus_IntegratorPseudoTransientForwardSensitivity_decl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorPseudoTransientForwardSensitivity_decl.hpp
@@ -45,6 +45,12 @@ namespace Tempus {
  * One can see that z^s is the only steady-state solution of the sensitivity
  * equations, since df/dx and df/dp are constant, and must be linearly stable
  * since it has the same Jacobian matrix as the forward equations.
+ *
+ * One should use the getX() and getDxDp()
+ * methods for extracting the final sultion and its parameter sensitivity
+ * as a multi-vector.  This data can also be extracted from the solution
+ * history, but is stored as a Thyra product vector which requires knowledge
+ * of the internal implementation.
  */
 template<class Scalar>
 class IntegratorPseudoTransientForwardSensitivity

--- a/packages/tempus/src/Thyra_ImplicitAdjointModelEvaluator.hpp
+++ b/packages/tempus/src/Thyra_ImplicitAdjointModelEvaluator.hpp
@@ -1,0 +1,119 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#ifndef Thyra_ImplicitAdjointModelEvaluator_hpp
+#define Thyra_ImplicitAdjointModelEvaluator_hpp
+
+#include "Thyra_ModelEvaluatorDelegatorBase.hpp"
+#include "Thyra_DefaultScaledAdjointLinearOp.hpp"
+#include "Thyra_DefaultAdjointLinearOpWithSolve.hpp"
+#include "Thyra_AdjointLinearOpWithSolveFactory.hpp"
+#include "Thyra_AdjointPreconditionerFactory.hpp"
+
+namespace Thyra {
+
+/** \brief An implementation of AdjointModelEvaluatorBase that creates an
+ implicit adjoint from the supplied model evaluator. */
+/**
+ */
+template <typename Scalar>
+class ImplicitAdjointModelEvaluator :
+    public ModelEvaluatorDelegatorBase<Scalar>{
+public:
+
+  //! Constructor
+  ImplicitAdjointModelEvaluator(
+    const RCP<const ModelEvaluator<Scalar> >& model) :
+    ModelEvaluatorDelegatorBase<Scalar>(model) {}
+
+  //! Constructor
+  ImplicitAdjointModelEvaluator(
+    const RCP<ModelEvaluator<Scalar> >& model) :
+    ModelEvaluatorDelegatorBase<Scalar>(model) {}
+
+  //! Destructor
+  virtual ~ImplicitAdjointModelEvaluator() = default;
+
+  //! Create adjoint solver
+  RCP<LinearOpWithSolveBase<Scalar> > create_W() const {
+    return nonconstAdjointLows(this->getUnderlyingModel()->create_W());
+  }
+
+  //! Create adjoint op
+  RCP<LinearOpBase<Scalar> > create_W_op() const {
+    return nonconstAdjoint(this->getUnderlyingModel()->create_W_op());
+  }
+
+  //! Create adjoint preconditioner
+  RCP<PreconditionerBase<Scalar> > create_W_prec() const {
+    return nonconstAdjointPreconditioner(
+      this->getUnderlyingModel()->create_W_prec());
+  }
+
+  //! Get adjoint solver factory
+  RCP<const LinearOpWithSolveFactoryBase<Scalar> > get_W_factory() const {
+    return adjointLinearOpWithSolveFactory(
+      this->getUnderlyingModel()->get_W_factory());
+  }
+
+private:
+
+  void evalModelImpl(
+    const ModelEvaluatorBase::InArgs<Scalar> &inArgs,
+    const ModelEvaluatorBase::OutArgs<Scalar> &outArgs) const
+  {
+    typedef Thyra::ModelEvaluatorBase MEB;
+    MEB::OutArgs<Scalar> model_outArgs =
+      this->getUnderlyingModel()->createOutArgs();;
+
+    if (model_outArgs.supports(MEB::OUT_ARG_W) &&
+        outArgs.get_W() != Teuchos::null) {
+      RCP<DefaultAdjointLinearOpWithSolve<Scalar> > adjoint_op =
+        Teuchos::rcp_dynamic_cast<DefaultAdjointLinearOpWithSolve<Scalar> >(
+          outArgs.get_W(),true);
+      model_outArgs.set_W(adjoint_op->getNonconstOp());
+    }
+
+    if (model_outArgs.supports(MEB::OUT_ARG_W_op) &&
+        outArgs.get_W_op() != Teuchos::null) {
+      RCP<DefaultScaledAdjointLinearOp<Scalar> > adjoint_op =
+        Teuchos::rcp_dynamic_cast<DefaultScaledAdjointLinearOp<Scalar> >(
+          outArgs.get_W_op(),true);
+      model_outArgs.set_W_op(adjoint_op->getNonconstOp());
+    }
+
+    if (model_outArgs.supports(MEB::OUT_ARG_W_prec) &&
+        outArgs.get_W_prec() != Teuchos::null) {
+      RCP<AdjointPreconditioner<Scalar> > adjoint_op =
+        Teuchos::rcp_dynamic_cast<AdjointPreconditioner<Scalar> >(
+          outArgs.get_W_prec(),true);
+      model_outArgs.set_W_prec(adjoint_op->getNonconstPreconditioner());
+    }
+
+    this->getUnderlyingModel()->evalModel(inArgs, model_outArgs);
+  }
+
+};
+
+template <typename Scalar>
+RCP<ImplicitAdjointModelEvaluator<Scalar> > implicitAdjointModelEvaluator(
+  const RCP<const ModelEvaluator<Scalar> >& model)
+{
+  return Teuchos::rcp(new ImplicitAdjointModelEvaluator<Scalar>(model));
+}
+
+template <typename Scalar>
+RCP<ImplicitAdjointModelEvaluator<Scalar> > implicitAdjointModelEvaluator(
+  const RCP<ModelEvaluator<Scalar> >& model)
+{
+  return Teuchos::rcp(new ImplicitAdjointModelEvaluator<Scalar>(model));
+}
+
+} // namespace Thyra
+
+#endif

--- a/packages/tempus/src/Thyra_TpetraExplicitAdjointModelEvaluator.hpp
+++ b/packages/tempus/src/Thyra_TpetraExplicitAdjointModelEvaluator.hpp
@@ -1,0 +1,143 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#ifndef Thyra_TpetraExplicitAdjointModelEvaluator_hpp
+#define Thyra_TpetraExplicitAdjointModelEvaluator_hpp
+
+#include "Thyra_ModelEvaluatorDelegatorBase.hpp"
+#include "Thyra_TpetraLinearOp.hpp"
+#include "Tpetra_RowMatrixTransposer.hpp"
+
+namespace Thyra {
+
+/** \brief A model evaluator decorator for computing an explicit adjoint. */
+/**
+ * This ModelEvaluator only supports computing W_op and forms the adjoint by
+ * computing W_op from the underlying ModelEvaluator and then explicitly
+ * transposes it.
+ *
+ * Since it derives from ModelEvaluatorDelegatorBase, it forwards all
+ * ModelEvaluator methods to the supplied underlying ModelEvaluator except
+ * those overloaded here.
+ */
+  template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal=LocalOrdinal, typename Node=KokkosClassic::DefaultNode::DefaultNodeType>
+class TpetraExplicitAdjointModelEvaluator :
+    public ModelEvaluatorDelegatorBase<Scalar>{
+public:
+
+  //! Constructor
+  TpetraExplicitAdjointModelEvaluator(
+    const RCP<const ModelEvaluator<Scalar> >& model) :
+    ModelEvaluatorDelegatorBase<Scalar>(model) {}
+
+  //! Constructor
+  TpetraExplicitAdjointModelEvaluator(
+    const RCP<ModelEvaluator<Scalar> >& model) :
+    ModelEvaluatorDelegatorBase<Scalar>(model) {}
+
+  //! Destructor
+  virtual ~TpetraExplicitAdjointModelEvaluator() = default;
+
+  RCP<LinearOpBase<Scalar> > create_W_op() const {
+    typedef TpetraLinearOp<Scalar,LocalOrdinal,GlobalOrdinal,Node> TLO;
+    typedef Tpetra::Operator<Scalar,LocalOrdinal,GlobalOrdinal,Node> TO;
+    typedef Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> TCM;
+    typedef Tpetra::RowMatrixTransposer<Scalar,LocalOrdinal,GlobalOrdinal,Node> TRMT;
+    if (thyra_fwd_op == Teuchos::null)
+      thyra_fwd_op = this->getUnderlyingModel()->create_W_op();
+    RCP<TLO> thyra_tpetra_fwd_op =
+      Teuchos::rcp_dynamic_cast<TLO>(thyra_fwd_op,true);
+    RCP<TO> tpetra_fwd_op = thyra_tpetra_fwd_op->getTpetraOperator();
+    RCP<TCM> tpetra_fwd_mat =
+      Teuchos::rcp_dynamic_cast<TCM>(tpetra_fwd_op,true);
+    TRMT transposer(tpetra_fwd_mat);
+    RCP<TCM> tpetra_trans_mat = transposer.createTranspose();
+    return tpetraLinearOp(thyra_op->range(), thyra_op->domain(),
+                          tpetra_trans_mat);
+  }
+
+private:
+
+  mutable RCP< Thyra::LinearOpBase<Scalar> > thyra_fwd_op;
+
+  ModelEvaluatorBase::OutArgs<Scalar> createOutArgsImpl() const
+  {
+    typedef ModelEvaluatorBase MEB;
+    MEB::OutArgs<Scalar> model_outArgs =
+      this->getUnderlyingModel()->createOutArgs();
+    MEB::OutArgsSetup<Scalar> outArgs;
+    outArgs.setModelEvalDescription(this->description());
+    if (model_outArgs.supports(MEB::OUT_ARG_W_op))
+      outArgs.setSupports(MEB::OUT_ARG_W_op);
+    return outArgs;
+  }
+
+  void evalModelImpl(
+    const ModelEvaluatorBase::InArgs<Scalar> &inArgs,
+    const ModelEvaluatorBase::OutArgs<Scalar> &outArgs) const
+  {
+    typedef ModelEvaluatorBase MEB;
+    typedef TpetraLinearOp<Scalar,LocalOrdinal,GlobalOrdinal,Node> TLO;
+    typedef Tpetra::Operator<Scalar,LocalOrdinal,GlobalOrdinal,Node> TO;
+    typedef Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> TCM;
+    typedef Tpetra::RowMatrixTransposer<Scalar,LocalOrdinal,GlobalOrdinal,Node> TRMT;
+
+    MEB::OutArgs<Scalar> model_outArgs =
+      this->getUnderlyingModel()->createOutArgs();
+
+    if (model_outArgs.supports(MEB::OUT_ARG_W_op) &&
+        outArgs.get_W_op() != Teuchos::null) {
+      // Compute underlying W_op.
+      if (thyra_fwd_op == Teuchos::null)
+        thyra_fwd_op = this->getUnderlyingModel()->create_W_op();
+      model_outArgs->set_W_op(thyra_fwd_op);
+      this->getUnderlyingModel()->evalModel(inArgs, model_outArgs);
+
+      // Transpose W_op
+      // Unfortunately, because of the horrendous design of the Tpetra
+      // RowMatrixTransposer, this creates a new transposed matrix each time
+      RCP<TLO> thyra_tpetra_fwd_op =
+        Teuchos::rcp_dynamic_cast<TLO>(thyra_fwd_op,true);
+      RCP<TO> tpetra_fwd_op = thyra_tpetra_fwd_op->getTpetraOperator();
+      RCP<TCM> tpetra_fwd_mat =
+        Teuchos::rcp_dynamic_cast<TCM>(tpetra_fwd_op,true);
+      TRMT transposer(tpetra_fwd_mat);
+      RCP<TCM> tpetra_trans_mat = transposer.createTranspose();
+
+      // Copy transposed matrix into our outArg
+      RCP<LOB> thyra_adj_op = outArgs.get_W_op();
+      RCP<TLO> thyra_tpetra_adj_op =
+        Teuchos::rcp_dynamic_cast<TLO>(thyra_adj_op,true);
+      RCP<TO> tpetra_adj_op = thyra_tpetra_adj_op->getTpetraOperator();
+      RCP<TCM> tpetra_adj_mat =
+        Teuchos::rcp_dynamic_cast<TCM>(tpetra_adj_op,true);
+      *tpetra_adj_mat = *tpetra_trans_mat;
+    }
+  }
+
+};
+
+template <typename Scalar>
+RCP<TpetraExplicitAdjointModelEvaluator<Scalar> >
+tpetraExplicitAdjointModelEvaluator(
+  const RCP<const ModelEvaluator<Scalar> >& model)
+{
+  return Teuchos::rcp(new TpetraExplicitAdjointModelEvaluator<Scalar>(model));
+}
+
+template <typename Scalar>
+RCP<TpetraExplicitAdjointModelEvaluator<Scalar> >
+tpetraExplicitAdjointModelEvaluator(
+  const RCP<ModelEvaluator<Scalar> >& model)
+{
+  return Teuchos::rcp(new TpetraExplicitAdjointModelEvaluator<Scalar>(model));
+}
+
+} // namespace Thyra
+
+#endif

--- a/packages/tempus/test/BackwardEuler/Tempus_BackwardEuler_ASA.cpp
+++ b/packages/tempus/test/BackwardEuler/Tempus_BackwardEuler_ASA.cpp
@@ -64,9 +64,12 @@ TEUCHOS_UNIT_TEST(BackwardEuler, SinCos_ASA)
       getParametersFromXmlFile("Tempus_BackwardEuler_SinCos.xml");
 
     // Setup the SinCosModel
+    // Here we test using an explicit adjoint model for adjoint sensitivities
     RCP<ParameterList> scm_pl = sublist(pList, "SinCosModel", true);
     RCP<SinCosModel<double> > model =
       Teuchos::rcp(new SinCosModel<double>(scm_pl));
+    RCP<SinCosModelAdjoint<double> > adjoint_model =
+      Teuchos::rcp(new SinCosModelAdjoint<double>(scm_pl));
 
     dt /= 2;
 
@@ -91,7 +94,7 @@ TEUCHOS_UNIT_TEST(BackwardEuler, SinCos_ASA)
     pl->sublist("Default Integrator")
        .sublist("Time Step Control").set("Initial Time Step", dt);
     RCP<Tempus::IntegratorAdjointSensitivity<double> > integrator =
-      Tempus::integratorAdjointSensitivity<double>(pl, model);
+      Tempus::integratorAdjointSensitivity<double>(pl, model, adjoint_model);
     order = integrator->getStepper()->getOrder();
 
     // Initial Conditions

--- a/packages/tempus/test/TestModels/SinCosModel.cpp
+++ b/packages/tempus/test/TestModels/SinCosModel.cpp
@@ -14,6 +14,7 @@
 
 namespace Tempus_Test {
   TEMPUS_INSTANTIATE_TEMPLATE_CLASS(SinCosModel)
+  TEMPUS_INSTANTIATE_TEMPLATE_CLASS(SinCosModelAdjoint)
 }
 
 #endif

--- a/packages/tempus/test/TestModels/SinCosModel_decl.hpp
+++ b/packages/tempus/test/TestModels/SinCosModel_decl.hpp
@@ -198,6 +198,7 @@ class SinCosModelAdjoint
   /** \name Public functions overridden from ModelEvaluator. */
   //@{
 
+  Thyra::ModelEvaluatorBase::InArgs<Scalar> createInArgs() const;
   Teuchos::RCP<Thyra::LinearOpWithSolveBase<Scalar> > create_W() const;
   Teuchos::RCP<Thyra::LinearOpBase<Scalar> > create_W_op() const;
 

--- a/packages/tempus/test/TestModels/SinCosModel_decl.hpp
+++ b/packages/tempus/test/TestModels/SinCosModel_decl.hpp
@@ -141,7 +141,7 @@ private:
 
   void calculateCoeffFromIC_();
 
-private:
+protected:
   int dim_;         ///< Number of state unknowns (2)
   int Np_;          ///< Number of parameter vectors (1)
   int np_;          ///< Number of parameters in this vector (2)
@@ -181,6 +181,39 @@ private:
 //  return(model);
 //}
 
+//! Adjoint for SinCosModel
+/*!
+ * This model evaluator modifies evalModel() to compute the adjoint operator
+ * instead of the forward operator.
+ */
+template<class Scalar>
+class SinCosModelAdjoint
+  : public SinCosModel<Scalar>
+{
+  public:
+
+  // Constructor
+  SinCosModelAdjoint(Teuchos::RCP<Teuchos::ParameterList> pList = Teuchos::null) : SinCosModel<Scalar>(pList) {}
+
+  /** \name Public functions overridden from ModelEvaluator. */
+  //@{
+
+  Teuchos::RCP<Thyra::LinearOpWithSolveBase<Scalar> > create_W() const;
+  Teuchos::RCP<Thyra::LinearOpBase<Scalar> > create_W_op() const;
+
+  //@}
+
+private:
+
+  /** \name Private functions overridden from ModelEvaluatorDefaultBase. */
+  //@{
+  Thyra::ModelEvaluatorBase::OutArgs<Scalar> createOutArgsImpl() const;
+  void evalModelImpl(
+    const Thyra::ModelEvaluatorBase::InArgs<Scalar> &inArgs_bar,
+    const Thyra::ModelEvaluatorBase::OutArgs<Scalar> &outArgs_bar
+    ) const;
+  //@}
+};
 
 } // namespace Tempus_Test
 #endif // TEMPUS_TEST_SINCOS_MODEL_DECL_HPP

--- a/packages/tempus/test/TestModels/SinCosModel_impl.hpp
+++ b/packages/tempus/test/TestModels/SinCosModel_impl.hpp
@@ -722,14 +722,14 @@ evalModelImpl(
   Thyra::ConstDetachedVectorView<Scalar> x_in_view( *x_in );
 
   //double t = inArgs.get_t();
-  Scalar a = this->a_;
+  //Scalar a = this->a_;
   Scalar f = this->f_;
   Scalar L = this->L_;
   if (this->acceptModelParams_) {
     const RCP<const VectorBase<Scalar> > p_in =
       inArgs.get_p(0).assert_not_null();
     Thyra::ConstDetachedVectorView<Scalar> p_in_view( *p_in );
-    a = p_in_view[0];
+    //a = p_in_view[0];
     f = p_in_view[1];
     L = p_in_view[2];
   }

--- a/packages/tempus/test/TestModels/SinCosModel_impl.hpp
+++ b/packages/tempus/test/TestModels/SinCosModel_impl.hpp
@@ -641,5 +641,133 @@ calculateCoeffFromIC_()
   b_ = x1_ic_/((f_/L_)*cos((f_/L_)*t0_ic_+phi_));
 }
 
+template<class Scalar>
+Teuchos::RCP<Thyra::LinearOpWithSolveBase<Scalar> >
+SinCosModelAdjoint<Scalar>::
+create_W() const
+{
+  using Teuchos::RCP;
+  RCP<const Thyra::LinearOpWithSolveFactoryBase<Scalar> > W_factory = this->get_W_factory();
+  RCP<Thyra::LinearOpBase<Scalar> > matrix = this->create_W_op();
+  {
+    // 01/20/09 tscoffe:  This is a total hack to provide a full rank matrix to
+    // linearOpWithSolve because it ends up factoring the matrix during
+    // initialization, which it really shouldn't do, or I'm doing something
+    // wrong here.   The net effect is that I get exceptions thrown in
+    // optimized mode due to the matrix being rank deficient unless I do this.
+    RCP<Thyra::MultiVectorBase<Scalar> > multivec = Teuchos::rcp_dynamic_cast<Thyra::MultiVectorBase<Scalar> >(matrix,true);
+    {
+      RCP<Thyra::VectorBase<Scalar> > vec = Thyra::createMember(this->f_space_);
+      {
+        Thyra::DetachedVectorView<Scalar> vec_view( *vec );
+        vec_view[0] = 0.0;
+        vec_view[1] = 1.0;
+      }
+      V_V(multivec->col(0).ptr(),*vec);
+      {
+        Thyra::DetachedVectorView<Scalar> vec_view( *vec );
+        vec_view[0] = 1.0;
+        vec_view[1] = 0.0;
+      }
+      V_V(multivec->col(1).ptr(),*vec);
+    }
+  }
+  RCP<Thyra::LinearOpWithSolveBase<Scalar> > W =
+    Thyra::linearOpWithSolve<Scalar>(
+      *W_factory,
+      matrix
+      );
+  return W;
+}
+
+template<class Scalar>
+Teuchos::RCP<Thyra::LinearOpBase<Scalar> >
+SinCosModelAdjoint<Scalar>::
+create_W_op() const
+{
+  Teuchos::RCP<Thyra::MultiVectorBase<Scalar> > matrix = Thyra::createMembers(this->f_space_, this->dim_);
+  return(matrix);
+}
+
+template<class Scalar>
+Thyra::ModelEvaluatorBase::OutArgs<Scalar>
+SinCosModelAdjoint<Scalar>::
+createOutArgsImpl() const
+{
+  typedef Thyra::ModelEvaluatorBase MEB;
+  MEB::OutArgsSetup<Scalar> outArgs;
+  outArgs.setModelEvalDescription(this->description());
+  outArgs.setSupports( MEB::OUT_ARG_f ); // Apparently all models have to support f
+  outArgs.setSupports( MEB::OUT_ARG_W_op );
+  return outArgs;
+}
+
+template<class Scalar>
+void
+SinCosModelAdjoint<Scalar>::
+evalModelImpl(
+  const Thyra::ModelEvaluatorBase::InArgs<Scalar> &inArgs,
+  const Thyra::ModelEvaluatorBase::OutArgs<Scalar> &outArgs
+  ) const
+{
+  typedef Thyra::DefaultMultiVectorProductVector<Scalar> DMVPV;
+  using Teuchos::RCP;
+  using Thyra::VectorBase;
+  using Thyra::MultiVectorBase;
+  using Teuchos::rcp_dynamic_cast;
+  TEUCHOS_TEST_FOR_EXCEPTION( !this->isInitialized_, std::logic_error,
+      "Error, setupInOutArgs_ must be called first!\n");
+
+  const RCP<const VectorBase<Scalar> > x_in = inArgs.get_x().assert_not_null();
+  Thyra::ConstDetachedVectorView<Scalar> x_in_view( *x_in );
+
+  //double t = inArgs.get_t();
+  Scalar a = this->a_;
+  Scalar f = this->f_;
+  Scalar L = this->L_;
+  if (this->acceptModelParams_) {
+    const RCP<const VectorBase<Scalar> > p_in =
+      inArgs.get_p(0).assert_not_null();
+    Thyra::ConstDetachedVectorView<Scalar> p_in_view( *p_in );
+    a = p_in_view[0];
+    f = p_in_view[1];
+    L = p_in_view[2];
+  }
+
+  Scalar beta = inArgs.get_beta();
+
+  const RCP<Thyra::LinearOpBase<Scalar> > W_out = outArgs.get_W_op();
+  if (inArgs.get_x_dot().is_null()) {
+
+    // Evaluate the Explicit ODE f(x,t) [= 0]
+    if (!is_null(W_out)) {
+      RCP<Thyra::MultiVectorBase<Scalar> > matrix =
+        Teuchos::rcp_dynamic_cast<Thyra::MultiVectorBase<Scalar> >(W_out,true);
+      Thyra::DetachedMultiVectorView<Scalar> matrix_view( *matrix );
+      matrix_view(0,0) = 0.0;               // d(f0)/d(x0_n)
+      matrix_view(1,0) = +beta;             // d(f0)/d(x1_n)
+      matrix_view(0,1) = -beta*(f/L)*(f/L); // d(f1)/d(x0_n)
+      matrix_view(1,1) = 0.0;               // d(f1)/d(x1_n)
+      // Note: alpha = d(xdot)/d(x_n) and beta = d(x)/d(x_n)
+    }
+  } else {
+
+    // Evaluate the implicit ODE f(xdot, x, t) [= 0]
+    RCP<const VectorBase<Scalar> > x_dot_in;
+    x_dot_in = inArgs.get_x_dot().assert_not_null();
+    Scalar alpha = inArgs.get_alpha();
+    if (!is_null(W_out)) {
+      RCP<Thyra::MultiVectorBase<Scalar> > matrix =
+        Teuchos::rcp_dynamic_cast<Thyra::MultiVectorBase<Scalar> >(W_out,true);
+      Thyra::DetachedMultiVectorView<Scalar> matrix_view( *matrix );
+      matrix_view(0,0) = alpha;             // d(f0)/d(x0_n)
+      matrix_view(1,0) = -beta;             // d(f0)/d(x1_n)
+      matrix_view(0,1) = +beta*(f/L)*(f/L); // d(f1)/d(x0_n)
+      matrix_view(1,1) = alpha;             // d(f1)/d(x1_n)
+      // Note: alpha = d(xdot)/d(x_n) and beta = d(x)/d(x_n)
+    }
+  }
+}
+
 } // namespace Tempus_Test
 #endif // TEMPUS_TEST_SINCOS_MODEL_IMPL_HPP

--- a/packages/tempus/test/TestModels/SinCosModel_impl.hpp
+++ b/packages/tempus/test/TestModels/SinCosModel_impl.hpp
@@ -690,6 +690,22 @@ create_W_op() const
 }
 
 template<class Scalar>
+Thyra::ModelEvaluatorBase::InArgs<Scalar>
+SinCosModelAdjoint<Scalar>::
+createInArgs() const
+{
+  // This ME should use the same InArgs as the base SinCosModel.  However
+  // we can't just use it's InArgs directly because the description won't
+  // match (which is checked in debug builds).  Instead create a new InArgsSetup
+  // initialized by SinCosModel::createInArgs() and set the description
+  // appropriately.
+  typedef Thyra::ModelEvaluatorBase MEB;
+  MEB::InArgsSetup<Scalar> inArgs = SinCosModel<Scalar>::createInArgs();
+  inArgs.setModelEvalDescription(this->description());
+  return inArgs;
+}
+
+template<class Scalar>
 Thyra::ModelEvaluatorBase::OutArgs<Scalar>
 SinCosModelAdjoint<Scalar>::
 createOutArgsImpl() const
@@ -699,6 +715,7 @@ createOutArgsImpl() const
   outArgs.setModelEvalDescription(this->description());
   outArgs.setSupports( MEB::OUT_ARG_f ); // Apparently all models have to support f
   outArgs.setSupports( MEB::OUT_ARG_W_op );
+  outArgs.set_Np_Ng(this->Np_,0);
   return outArgs;
 }
 

--- a/packages/thyra/adapters/tpetra/src/Thyra_TpetraExplicitAdjointModelEvaluator.hpp
+++ b/packages/thyra/adapters/tpetra/src/Thyra_TpetraExplicitAdjointModelEvaluator.hpp
@@ -1,9 +1,42 @@
 // @HEADER
-// ****************************************************************************
-//                Tempus: Copyright (2017) Sandia Corporation
+// ***********************************************************************
+// 
+//    Thyra: Interfaces and Support for Abstract Numerical Algorithms
+//                 Copyright (2004) Sandia Corporation
+// 
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
 //
-// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
-// ****************************************************************************
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Roscoe A. Bartlett (bartlettra@ornl.gov) 
+// 
+// ***********************************************************************
 // @HEADER
 
 #ifndef Thyra_TpetraExplicitAdjointModelEvaluator_hpp


### PR DESCRIPTION
Very few Trilinos solvers/preconditioners support solving transposed
linear systems, therefore we often have to resort to explicitly
transposing the matrix or assembling a transposed matrix directly for
adjoint sensitivities.  To better support this case, I extended the
Tempus adjoint integrator implementations to accept an additional
"adjoint" model evaluator for computing the adjoint W/W_op.  This is
necessary because there is currently no adjoint outArg that can be
requested.  I also included an adapter for the case of an implicitly
computed transpose, allowing for a single implementation.  I also
included a prototype Tpetra implementation that explicitly forms the
transpose, but it isn't tested.  Finally I modified the SinCosModel to
provide an explicit adjoint ME, and modified one of the tests to use it.

In a subsequent commit, the Thyra and Tpetra files will be moved to their
proper locations.