### PR TITLE
Xpetra: Fix bug in CheckRepairMainDiagonal

### DIFF
--- a/packages/xpetra/sup/Utils/Xpetra_MatrixUtils.hpp
+++ b/packages/xpetra/sup/Utils/Xpetra_MatrixUtils.hpp
@@ -480,7 +480,11 @@ public:
                                   missing += (offsets(i) == STINV);
                                 }, numMissingDiagonalEntries);
 
-        if (numMissingDiagonalEntries == 0) {
+        GlobalOrdinal gNumMissingDiagonalEntries;
+        Teuchos::reduceAll(*(Ac->getRowMap()->getComm()), Teuchos::REDUCE_SUM, Teuchos::as<GlobalOrdinal>(numMissingDiagonalEntries),
+                             Teuchos::outArg(gNumMissingDiagonalEntries));
+
+        if (gNumMissingDiagonalEntries == 0) {
           // Matrix has all diagonal entries, now we fix them
 
           auto lclA = tpCrsAc->getLocalMatrixDevice();


### PR DESCRIPTION
@trilinos/xpetra 

## Motivation
We can only take the shortcut in `CheckRepairDiagonal` if all diagonal entries are present on all ranks.

Should fix #9455 