### PR TITLE
Panzer: Allow for multiple types of mesh rebalancing in ExodusReaderFactory

### DIFF
--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_ExodusReaderFactory.cpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_ExodusReaderFactory.cpp
@@ -77,7 +77,7 @@ int getMeshDimension(const std::string & meshStr,
 
 STK_ExodusReaderFactory::STK_ExodusReaderFactory()
   : fileName_(""), restartIndex_(0), isExodus_(true), userMeshScaling_(false), keepPerceptData_(false),
-    keepPerceptParentElements_(false), meshScaleFactor_(0.0), levelsOfRefinement_(0),
+    keepPerceptParentElements_(false), rebalancing_("default"), meshScaleFactor_(0.0), levelsOfRefinement_(0),
     createEdgeBlocks_(false), createFaceBlocks_(false)
 { }
 
@@ -85,8 +85,8 @@ STK_ExodusReaderFactory::STK_ExodusReaderFactory(const std::string & fileName,
                                                  const int restartIndex,
                                                  const bool isExodus)
   : fileName_(fileName), restartIndex_(restartIndex), isExodus_(isExodus), userMeshScaling_(false),
-    keepPerceptData_(false), keepPerceptParentElements_(false), meshScaleFactor_(0.0), levelsOfRefinement_(0),
-    createEdgeBlocks_(false), createFaceBlocks_(false)
+    keepPerceptData_(false), keepPerceptParentElements_(false), rebalancing_("default"), 
+    meshScaleFactor_(0.0), levelsOfRefinement_(0), createEdgeBlocks_(false), createFaceBlocks_(false)
 { }
 
 Teuchos::RCP<STK_Interface> STK_ExodusReaderFactory::buildMesh(stk::ParallelMachine parallelMach) const
@@ -274,8 +274,14 @@ void STK_ExodusReaderFactory::completeMeshConstruction(STK_Interface & mesh,stk:
    // clean up mesh data object
    delete meshData;
 
-   // calls Stk_MeshFactory::rebalance
-   this->rebalance(mesh);
+   if(rebalancing_ == "default")
+     // calls Stk_MeshFactory::rebalance
+     this->rebalance(mesh);
+   else if(rebalancing_ != "none")
+   {
+     TEUCHOS_TEST_FOR_EXCEPTION(true,std::logic_error,
+				"ERROR: Rebalancing was not set to a valid choice");
+   }
 }
 
 //! From ParameterListAcceptor
@@ -314,6 +320,9 @@ void STK_ExodusReaderFactory::setParameterList(const Teuchos::RCP<Teuchos::Param
    if(!paramList->isParameter("Keep Percept Parent Elements"))
      paramList->set<bool>("Keep Percept Parent Elements", false);
 
+   if(!paramList->isParameter("Rebalancing"))
+     paramList->set<std::string>("Rebalancing", "default");
+
    if(!paramList->isParameter("Create Edge Blocks"))
      // default to false to prevent massive exodiff test failures
      paramList->set<bool>("Create Edge Blocks", false);
@@ -348,6 +357,8 @@ void STK_ExodusReaderFactory::setParameterList(const Teuchos::RCP<Teuchos::Param
    keepPerceptData_ = paramList->get<bool>("Keep Percept Data");
 
    keepPerceptParentElements_ = paramList->get<bool>("Keep Percept Parent Elements");
+
+   rebalancing_ = paramList->get<std::string>("Rebalancing");
 
    levelsOfRefinement_ = paramList->get<int>("Levels of Uniform Refinement");
 
@@ -387,6 +398,8 @@ Teuchos::RCP<const Teuchos::ParameterList> STK_ExodusReaderFactory::getValidPara
       validParams->set("Keep Percept Data",false,"Keep the Percept mesh after uniform refinement is applied");
 
       validParams->set("Keep Percept Parent Elements",false,"Keep the parent element information in the Percept data");
+
+      validParams->set("Rebalancing","default","The type of rebalancing to be performed on the mesh after creation (default, none)");
 
       // default to false to prevent massive exodiff test failures
       validParams->set("Create Edge Blocks",false,"Create or copy edge blocks in the mesh");

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_ExodusReaderFactory.hpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_ExodusReaderFactory.hpp
@@ -155,6 +155,9 @@ private:
   //! Did the user request to keep the Percept parent element data
   bool keepPerceptParentElements_;
 
+  //! The type of mesh rebalancing to be performed after creation
+  std::string rebalancing_;
+
   //! If requested, scale the input mesh by this factor
   double meshScaleFactor_;
 


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/panzer 
@rppawlo 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
This follows our discussion in the Drekar meeting today. This is an initial PR to change the framework to allow for more options when it comes to rebalancing. A following PR will add an option to the list to rebalance the mesh according to Percept family trees if the information is available.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Testing it on my end now so I won't set automerge, but also the autotester should catch any issues, and I designed the code to make sure it's backwards compatible.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->