### PR TITLE
SEACAS: Aprepro -- remove bad stream deletion

### DIFF
--- a/packages/seacas/libraries/aprepro_lib/apr_aprepro.cc
+++ b/packages/seacas/libraries/aprepro_lib/apr_aprepro.cc
@@ -56,9 +56,9 @@ namespace SEAMS {
       outputStream.top()->flush();
     }
 
-    if (infoStream != &std::cout) {
-      delete infoStream;
-    }
+    // May need to delete this if set via --info=file, but need a way to determine this.
+    // For now, flush so all data written and leave as is.
+    infoStream->flush();
 
     if ((stringScanner != nullptr) && stringScanner != lexer) {
       delete stringScanner;


### PR DESCRIPTION
It is not always correct to delete infoStream when it is not set to default. It could be set to the same stream as warnStream and errorStream or it could be a std stream.  For now, remove the deletion and flush the stream.  Will determine how to know whether to delete soon...

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/seacas 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->