### PR TITLE
Xpetra: HIP support

### DIFF
--- a/packages/xpetra/src/CrsGraph/Xpetra_EpetraCrsGraph.cpp
+++ b/packages/xpetra/src/CrsGraph/Xpetra_EpetraCrsGraph.cpp
@@ -100,6 +100,12 @@ template class EpetraCrsGraphT<int, default_node_type >;
 template RCP< const CrsGraph<int, int, default_node_type > > toXpetra<int, default_node_type>(const Epetra_CrsGraph &g);
 template const Epetra_CrsGraph & toEpetra<int, default_node_type >(const RCP< const CrsGraph<int, int, default_node_type > > &graph);
 #endif
+#ifdef HAVE_TPETRA_INST_HIP
+typedef Kokkos::Compat::KokkosHIPWrapperNode default_node_type;
+template class EpetraCrsGraphT<int, default_node_type >;
+template RCP< const CrsGraph<int, int, default_node_type > > toXpetra<int, default_node_type>(const Epetra_CrsGraph &g);
+template const Epetra_CrsGraph & toEpetra<int, default_node_type >(const RCP< const CrsGraph<int, int, default_node_type > > &graph);
+#endif
 #else
 // Tpetra is disabled and Kokkos not available: use dummy node type
 typedef Xpetra::EpetraNode default_node_type;
@@ -135,6 +141,12 @@ template const Epetra_CrsGraph & toEpetra<long long, Kokkos::Compat::KokkosOpenM
 #endif
 #ifdef HAVE_TPETRA_INST_CUDA
 typedef Kokkos::Compat::KokkosCudaWrapperNode default_node_type;
+template class EpetraCrsGraphT<long long, default_node_type >;
+template RCP< const CrsGraph<int, long long, default_node_type > > toXpetra<long long, default_node_type>(const Epetra_CrsGraph &g);
+template const Epetra_CrsGraph & toEpetra<long long, default_node_type >(const RCP< const CrsGraph<int, long long, default_node_type > > &graph);
+#endif
+#ifdef HAVE_TPETRA_INST_HIP
+typedef Kokkos::Compat::KokkosHIPWrapperNode default_node_type;
 template class EpetraCrsGraphT<long long, default_node_type >;
 template RCP< const CrsGraph<int, long long, default_node_type > > toXpetra<long long, default_node_type>(const Epetra_CrsGraph &g);
 template const Epetra_CrsGraph & toEpetra<long long, default_node_type >(const RCP< const CrsGraph<int, long long, default_node_type > > &graph);

--- a/packages/xpetra/src/CrsMatrix/Xpetra_CrsMatrix.hpp
+++ b/packages/xpetra/src/CrsMatrix/Xpetra_CrsMatrix.hpp
@@ -311,20 +311,20 @@ namespace Xpetra {
     //@{
 #ifdef HAVE_XPETRA_KOKKOS_REFACTOR
 #ifdef HAVE_XPETRA_TPETRA
-    typedef typename Kokkos::Details::ArithTraits<Scalar>::val_type impl_scalar_type;
-    typedef typename node_type::execution_space execution_space;
+    using impl_scalar_type  = typename Kokkos::Details::ArithTraits<Scalar>::val_type;
+    using execution_space   = typename node_type::device_type;
 
     // that is the local_graph_type in Tpetra::CrsGraph...
-    typedef Kokkos::StaticCrsGraph<LocalOrdinal,
-                                       Kokkos::LayoutLeft,
-                                       execution_space,
-                                       void,
-                                       size_t> local_graph_type;
+    using local_graph_type  = Kokkos::StaticCrsGraph<LocalOrdinal,
+						    Kokkos::LayoutLeft,
+						    execution_space,
+						    void,
+						    size_t>;
     /// \brief The specialization of Kokkos::CrsMatrix that represents
     ///   the part of the sparse matrix on each MPI process.
     ///  The same as for Tpetra
-    typedef KokkosSparse::CrsMatrix<impl_scalar_type, LocalOrdinal, execution_space,void,
-                              typename local_graph_type::size_type> local_matrix_type;
+    using local_matrix_type = KokkosSparse::CrsMatrix<impl_scalar_type, LocalOrdinal, execution_space,void,
+						      typename local_graph_type::size_type>;
 
 #ifdef TPETRA_ENABLE_DEPRECATED_CODE
     /// \brief Access the underlying local KokkosSparse::CrsMatrix object

--- a/packages/xpetra/src/CrsMatrix/Xpetra_EpetraCrsMatrix.cpp
+++ b/packages/xpetra/src/CrsMatrix/Xpetra_EpetraCrsMatrix.cpp
@@ -69,6 +69,10 @@ template class EpetraCrsMatrixT<int, Kokkos::Compat::KokkosOpenMPWrapperNode >;
 typedef Kokkos::Compat::KokkosCudaWrapperNode default_node_type;
 template class EpetraCrsMatrixT<int, default_node_type >;
 #endif
+#ifdef HAVE_TPETRA_INST_HIP
+typedef Kokkos::Compat::KokkosHIPWrapperNode default_node_type;
+template class EpetraCrsMatrixT<int, default_node_type >;
+#endif
 #else
 // Tpetra is disabled and Kokkos not available: use dummy node type
 typedef Xpetra::EpetraNode default_node_type;
@@ -95,6 +99,10 @@ template class EpetraCrsMatrixT<long long, Kokkos::Compat::KokkosOpenMPWrapperNo
 #endif
 #ifdef HAVE_TPETRA_INST_CUDA
 typedef Kokkos::Compat::KokkosCudaWrapperNode default_node_type;
+template class EpetraCrsMatrixT<long long, default_node_type >;
+#endif
+#ifdef HAVE_TPETRA_INST_HIP
+typedef Kokkos::Compat::KokkosHIPWrapperNode default_node_type;
 template class EpetraCrsMatrixT<long long, default_node_type >;
 #endif
 #else

--- a/packages/xpetra/src/Export/Xpetra_EpetraExport.cpp
+++ b/packages/xpetra/src/Export/Xpetra_EpetraExport.cpp
@@ -84,6 +84,11 @@ typedef Kokkos::Compat::KokkosCudaWrapperNode default_node_type;
 template class EpetraExportT<int, default_node_type >;
 template RCP<const Export<int, int, default_node_type> > toXpetra<int,default_node_type>(const Epetra_Export *);
 #endif
+#ifdef HAVE_TPETRA_INST_HIP
+typedef Kokkos::Compat::KokkosHIPWrapperNode default_node_type;
+template class EpetraExportT<int, default_node_type >;
+template RCP<const Export<int, int, default_node_type> > toXpetra<int,default_node_type>(const Epetra_Export *);
+#endif
 #else
 // Tpetra is disabled and Kokkos not available: use dummy node type
 typedef Xpetra::EpetraNode default_node_type;
@@ -115,6 +120,11 @@ template RCP<const Export<int, long long, Kokkos::Compat::KokkosOpenMPWrapperNod
 #endif
 #ifdef HAVE_TPETRA_INST_CUDA
 typedef Kokkos::Compat::KokkosCudaWrapperNode default_node_type;
+template class EpetraExportT<long long, default_node_type >;
+template RCP<const Export<int, long long, default_node_type> > toXpetra<long long,default_node_type>(const Epetra_Export *);
+#endif
+#ifdef HAVE_TPETRA_INST_HIP
+typedef Kokkos::Compat::KokkosHIPWrapperNode default_node_type;
 template class EpetraExportT<long long, default_node_type >;
 template RCP<const Export<int, long long, default_node_type> > toXpetra<long long,default_node_type>(const Epetra_Export *);
 #endif

--- a/packages/xpetra/src/Import/Xpetra_EpetraImport.cpp
+++ b/packages/xpetra/src/Import/Xpetra_EpetraImport.cpp
@@ -85,6 +85,11 @@ typedef Kokkos::Compat::KokkosCudaWrapperNode default_node_type;
 template class EpetraImportT<int, default_node_type >;
 template RCP<const Import<int, int, default_node_type> > toXpetra<int,default_node_type>(const Epetra_Import *);
 #endif
+#ifdef HAVE_TPETRA_INST_HIP
+typedef Kokkos::Compat::KokkosHIPWrapperNode default_node_type;
+template class EpetraImportT<int, default_node_type >;
+template RCP<const Import<int, int, default_node_type> > toXpetra<int,default_node_type>(const Epetra_Import *);
+#endif
 #else
 // Tpetra is disabled and Kokkos not available: use dummy node type
 typedef Xpetra::EpetraNode default_node_type;
@@ -114,8 +119,8 @@ template RCP<const Import<int,long long,Kokkos::Compat::KokkosThreadsWrapperNode
 template class EpetraImportT<long long, Kokkos::Compat::KokkosOpenMPWrapperNode >;
 template RCP<const Import<int, long long, Kokkos::Compat::KokkosOpenMPWrapperNode> > toXpetra<long long,Kokkos::Compat::KokkosOpenMPWrapperNode>(const Epetra_Import *);
 #endif
-#ifdef HAVE_TPETRA_INST_CUDA
-typedef Kokkos::Compat::KokkosCudaWrapperNode default_node_type;
+#ifdef HAVE_TPETRA_INST_HIP
+typedef Kokkos::Compat::KokkosHIPWrapperNode default_node_type;
 template class EpetraImportT<long long, default_node_type >;
 template RCP<const Import<int, long long, default_node_type> > toXpetra<long long,default_node_type>(const Epetra_Import *);
 #endif

--- a/packages/xpetra/src/Import/Xpetra_EpetraImport.cpp
+++ b/packages/xpetra/src/Import/Xpetra_EpetraImport.cpp
@@ -119,6 +119,11 @@ template RCP<const Import<int,long long,Kokkos::Compat::KokkosThreadsWrapperNode
 template class EpetraImportT<long long, Kokkos::Compat::KokkosOpenMPWrapperNode >;
 template RCP<const Import<int, long long, Kokkos::Compat::KokkosOpenMPWrapperNode> > toXpetra<long long,Kokkos::Compat::KokkosOpenMPWrapperNode>(const Epetra_Import *);
 #endif
+#ifdef HAVE_TPETRA_INST_CUDA
+typedef Kokkos::Compat::KokkosCudaWrapperNode default_node_type;
+template class EpetraImportT<long long, default_node_type >;
+template RCP<const Import<int, long long, default_node_type> > toXpetra<long long,default_node_type>(const Epetra_Import *);
+#endif
 #ifdef HAVE_TPETRA_INST_HIP
 typedef Kokkos::Compat::KokkosHIPWrapperNode default_node_type;
 template class EpetraImportT<long long, default_node_type >;

--- a/packages/xpetra/src/Map/Xpetra_EpetraMap.cpp
+++ b/packages/xpetra/src/Map/Xpetra_EpetraMap.cpp
@@ -109,6 +109,13 @@ template const RCP< const Map<int, int, default_node_type > > toXpetra<int, defa
 template const Epetra_Map & toEpetra<int, default_node_type >(const RCP< const Map<int, int, default_node_type > > &map);
 template const Epetra_Map & toEpetra<int, default_node_type >(const Map< int, int, default_node_type> & map);
 #endif
+#ifdef HAVE_TPETRA_INST_HIP
+typedef Kokkos::Compat::KokkosHIPWrapperNode default_node_type;
+//template class EpetraMapT<int, default_node_type >;
+template const RCP< const Map<int, int, default_node_type > > toXpetra<int, default_node_type>(const Epetra_BlockMap &map);
+template const Epetra_Map & toEpetra<int, default_node_type >(const RCP< const Map<int, int, default_node_type > > &map);
+template const Epetra_Map & toEpetra<int, default_node_type >(const Map< int, int, default_node_type> & map);
+#endif
 #else
 // Tpetra is disabled and Kokkos not available: use dummy node type
 typedef Xpetra::EpetraNode default_node_type;
@@ -155,6 +162,14 @@ template const Epetra_Map & toEpetra<long long, Kokkos::Compat::KokkosOpenMPWrap
 
 #ifdef HAVE_TPETRA_INST_CUDA
 typedef Kokkos::Compat::KokkosCudaWrapperNode default_node_type;
+//template class EpetraMapT<long long, default_node_type >;
+template const RCP< const Map<int, long long, default_node_type > > toXpetra<long long, default_node_type>(const Epetra_BlockMap &map);
+template const Epetra_Map & toEpetra<long long, default_node_type >(const RCP< const Map<int, long long, default_node_type > > &map);
+template const Epetra_Map & toEpetra<long long, default_node_type >(const Map< int, long long, default_node_type> & map);
+#endif
+
+#ifdef HAVE_TPETRA_INST_HIP
+typedef Kokkos::Compat::KokkosHIPWrapperNode default_node_type;
 //template class EpetraMapT<long long, default_node_type >;
 template const RCP< const Map<int, long long, default_node_type > > toXpetra<long long, default_node_type>(const Epetra_BlockMap &map);
 template const Epetra_Map & toEpetra<long long, default_node_type >(const RCP< const Map<int, long long, default_node_type > > &map);

--- a/packages/xpetra/src/MultiVector/Xpetra_EpetraIntMultiVector.cpp
+++ b/packages/xpetra/src/MultiVector/Xpetra_EpetraIntMultiVector.cpp
@@ -94,6 +94,12 @@ template class EpetraIntMultiVectorT<int, default_node_type >;
 template Epetra_IntMultiVector & toEpetra<int,default_node_type >(MultiVector<int, int, int, default_node_type> &);
 template const Epetra_IntMultiVector & toEpetra<int,default_node_type >(const MultiVector<int, int, int, default_node_type> &);
 #endif
+#ifdef HAVE_TPETRA_INST_HIP
+typedef Kokkos::Compat::KokkosHIPWrapperNode default_node_type;
+template class EpetraIntMultiVectorT<int, default_node_type >;
+template Epetra_IntMultiVector & toEpetra<int,default_node_type >(MultiVector<int, int, int, default_node_type> &);
+template const Epetra_IntMultiVector & toEpetra<int,default_node_type >(const MultiVector<int, int, int, default_node_type> &);
+#endif
 #else
 // Tpetra is disabled and Kokkos not available: use dummy node type
 typedef Xpetra::EpetraNode default_node_type;
@@ -127,8 +133,8 @@ template class EpetraIntMultiVectorT<long long, Kokkos::Compat::KokkosOpenMPWrap
 template Epetra_IntMultiVector & toEpetra<long long,Kokkos::Compat::KokkosOpenMPWrapperNode >(MultiVector<int, int, long long, Kokkos::Compat::KokkosOpenMPWrapperNode> &);
 template const Epetra_IntMultiVector & toEpetra<long long, Kokkos::Compat::KokkosOpenMPWrapperNode >(const MultiVector<int, int, long long, Kokkos::Compat::KokkosOpenMPWrapperNode> &);
 #endif
-#ifdef HAVE_TPETRA_INST_CUDA
-typedef Kokkos::Compat::KokkosCudaWrapperNode default_node_type;
+#ifdef HAVE_TPETRA_INST_HIP
+typedef Kokkos::Compat::KokkosHIPWrapperNode default_node_type;
 template class EpetraIntMultiVectorT<long long, default_node_type >;
 template Epetra_IntMultiVector & toEpetra<long long,default_node_type >(MultiVector<int, int, long long, default_node_type> &);
 template const Epetra_IntMultiVector & toEpetra<long long,default_node_type >(const MultiVector<int, int, long long, default_node_type> &);

--- a/packages/xpetra/src/MultiVector/Xpetra_EpetraIntMultiVector.cpp
+++ b/packages/xpetra/src/MultiVector/Xpetra_EpetraIntMultiVector.cpp
@@ -133,6 +133,12 @@ template class EpetraIntMultiVectorT<long long, Kokkos::Compat::KokkosOpenMPWrap
 template Epetra_IntMultiVector & toEpetra<long long,Kokkos::Compat::KokkosOpenMPWrapperNode >(MultiVector<int, int, long long, Kokkos::Compat::KokkosOpenMPWrapperNode> &);
 template const Epetra_IntMultiVector & toEpetra<long long, Kokkos::Compat::KokkosOpenMPWrapperNode >(const MultiVector<int, int, long long, Kokkos::Compat::KokkosOpenMPWrapperNode> &);
 #endif
+#ifdef HAVE_TPETRA_INST_CUDA
+typedef Kokkos::Compat::KokkosCudaWrapperNode default_node_type;
+template class EpetraIntMultiVectorT<long long, default_node_type >;
+template Epetra_IntMultiVector & toEpetra<long long,default_node_type >(MultiVector<int, int, long long, default_node_type> &);
+template const Epetra_IntMultiVector & toEpetra<long long,default_node_type >(const MultiVector<int, int, long long, default_node_type> &);
+#endif
 #ifdef HAVE_TPETRA_INST_HIP
 typedef Kokkos::Compat::KokkosHIPWrapperNode default_node_type;
 template class EpetraIntMultiVectorT<long long, default_node_type >;

--- a/packages/xpetra/src/MultiVector/Xpetra_EpetraMultiVector.cpp
+++ b/packages/xpetra/src/MultiVector/Xpetra_EpetraMultiVector.cpp
@@ -143,6 +143,12 @@ template RCP<MultiVector<double, int, int, Kokkos::Compat::KokkosCudaWrapperNode
 template Epetra_MultiVector & toEpetra<int,Kokkos::Compat::KokkosCudaWrapperNode >(MultiVector<double, int, int,Kokkos::Compat::KokkosCudaWrapperNode> &);
 template const Epetra_MultiVector & toEpetra<int, Kokkos::Compat::KokkosCudaWrapperNode >(const MultiVector<double, int, int, Kokkos::Compat::KokkosCudaWrapperNode > &);
 #endif
+#ifdef HAVE_TPETRA_INST_HIP
+template class EpetraMultiVectorT<int, Kokkos::Compat::KokkosHIPWrapperNode >;
+template RCP<MultiVector<double, int, int, Kokkos::Compat::KokkosHIPWrapperNode > > toXpetra<int, Kokkos::Compat::KokkosHIPWrapperNode>(RCP<Epetra_MultiVector>);
+template Epetra_MultiVector & toEpetra<int,Kokkos::Compat::KokkosHIPWrapperNode >(MultiVector<double, int, int,Kokkos::Compat::KokkosHIPWrapperNode> &);
+template const Epetra_MultiVector & toEpetra<int, Kokkos::Compat::KokkosHIPWrapperNode >(const MultiVector<double, int, int, Kokkos::Compat::KokkosHIPWrapperNode > &);
+#endif
 #else // Tpetra is disabled
 typedef Xpetra::EpetraNode default_node_type;
 template class EpetraMultiVectorT<int, default_node_type >;
@@ -186,6 +192,12 @@ template class EpetraMultiVectorT<long long, Kokkos::Compat::KokkosCudaWrapperNo
 template RCP<MultiVector<double, int, long long, Kokkos::Compat::KokkosCudaWrapperNode > > toXpetra<long long, Kokkos::Compat::KokkosCudaWrapperNode>(RCP<Epetra_MultiVector>);
 template Epetra_MultiVector & toEpetra<long long,Kokkos::Compat::KokkosCudaWrapperNode >(MultiVector<double, int, long long, Kokkos::Compat::KokkosCudaWrapperNode> &);
 template const Epetra_MultiVector & toEpetra<long long, Kokkos::Compat::KokkosCudaWrapperNode >(const MultiVector<double, int, long long, Kokkos::Compat::KokkosCudaWrapperNode > &);
+#endif
+#ifdef HAVE_TPETRA_INST_HIP
+template class EpetraMultiVectorT<long long, Kokkos::Compat::KokkosHIPWrapperNode >;
+template RCP<MultiVector<double, int, long long, Kokkos::Compat::KokkosHIPWrapperNode > > toXpetra<long long, Kokkos::Compat::KokkosHIPWrapperNode>(RCP<Epetra_MultiVector>);
+template Epetra_MultiVector & toEpetra<long long,Kokkos::Compat::KokkosHIPWrapperNode >(MultiVector<double, int, long long, Kokkos::Compat::KokkosHIPWrapperNode> &);
+template const Epetra_MultiVector & toEpetra<long long, Kokkos::Compat::KokkosHIPWrapperNode >(const MultiVector<double, int, long long, Kokkos::Compat::KokkosHIPWrapperNode > &);
 #endif
 #else // Tpetra is disabled
 typedef Xpetra::EpetraNode default_node_type;

--- a/packages/xpetra/src/MultiVector/Xpetra_MultiVector_decl.hpp
+++ b/packages/xpetra/src/MultiVector/Xpetra_MultiVector_decl.hpp
@@ -310,13 +310,13 @@ class MultiVector
 
 #ifdef HAVE_XPETRA_KOKKOS_REFACTOR
 
-    typedef typename Kokkos::Details::ArithTraits<Scalar>::val_type                                                                  impl_scalar_type;
-    typedef Kokkos::DualView<impl_scalar_type**, Kokkos::LayoutStride, typename node_type::execution_space, Kokkos::MemoryUnmanaged> dual_view_type;
-    typedef Kokkos::DualView<const impl_scalar_type**, Kokkos::LayoutStride, typename node_type::execution_space, Kokkos::MemoryUnmanaged> dual_view_type_const;
-    typedef typename dual_view_type::host_mirror_space      host_execution_space;
-    typedef typename dual_view_type::t_dev::execution_space dev_execution_space;
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+    using impl_scalar_type     = typename Kokkos::Details::ArithTraits<Scalar>::val_type;
+    using dual_view_type       = Kokkos::DualView<impl_scalar_type**, Kokkos::LayoutStride, typename node_type::device_type, Kokkos::MemoryUnmanaged>;
+    using dual_view_type_const = Kokkos::DualView<const impl_scalar_type**, Kokkos::LayoutStride, typename node_type::device_type, Kokkos::MemoryUnmanaged>;
+    using host_execution_space = typename dual_view_type::host_mirror_space;
+    using dev_execution_space  = typename dual_view_type::t_dev::execution_space;
 
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
     /// \brief Return an unmanaged non-const view of the local data on a specific device.
     /// \tparam TargetDeviceType The Kokkos Device type whose data to return.
     ///

--- a/packages/xpetra/src/Vector/Xpetra_EpetraIntVector.cpp
+++ b/packages/xpetra/src/Vector/Xpetra_EpetraIntVector.cpp
@@ -94,6 +94,12 @@ template class EpetraIntVectorT<int, default_node_type >;
 template Epetra_IntVector & toEpetra<int,default_node_type >(Vector<int, int, int, default_node_type> &);
 template const Epetra_IntVector & toEpetra<int,default_node_type >(const Vector<int, int, int, default_node_type> &);
 #endif
+#ifdef HAVE_TPETRA_INST_HIP
+typedef Kokkos::Compat::KokkosHIPWrapperNode default_node_type;
+template class EpetraIntVectorT<int, default_node_type >;
+template Epetra_IntVector & toEpetra<int,default_node_type >(Vector<int, int, int, default_node_type> &);
+template const Epetra_IntVector & toEpetra<int,default_node_type >(const Vector<int, int, int, default_node_type> &);
+#endif
 #else
 // Tpetra is disabled and Kokkos not available: use dummy node type
 typedef Xpetra::EpetraNode default_node_type;
@@ -129,6 +135,12 @@ template const Epetra_IntVector & toEpetra<long long, Kokkos::Compat::KokkosOpen
 #endif
 #ifdef HAVE_TPETRA_INST_CUDA
 typedef Kokkos::Compat::KokkosCudaWrapperNode default_node_type;
+template class EpetraIntVectorT<long long, default_node_type >;
+template Epetra_IntVector & toEpetra<long long,default_node_type >(Vector<int, int, long long, default_node_type> &);
+template const Epetra_IntVector & toEpetra<long long,default_node_type >(const Vector<int, int, long long, default_node_type> &);
+#endif
+#ifdef HAVE_TPETRA_INST_HIP
+typedef Kokkos::Compat::KokkosHIPWrapperNode default_node_type;
 template class EpetraIntVectorT<long long, default_node_type >;
 template Epetra_IntVector & toEpetra<long long,default_node_type >(Vector<int, int, long long, default_node_type> &);
 template const Epetra_IntVector & toEpetra<long long,default_node_type >(const Vector<int, int, long long, default_node_type> &);

--- a/packages/xpetra/src/Vector/Xpetra_EpetraVector.cpp
+++ b/packages/xpetra/src/Vector/Xpetra_EpetraVector.cpp
@@ -94,6 +94,12 @@ template class EpetraVectorT<int, default_node_type >;
 template Epetra_Vector & toEpetra<int,default_node_type >(Vector<double, int, int, default_node_type> &);
 template const Epetra_Vector & toEpetra<int, default_node_type >(const Vector<double, int, int, default_node_type> &);
 #endif
+#ifdef HAVE_TPETRA_INST_HIP
+typedef Kokkos::Compat::KokkosHIPWrapperNode default_node_type;
+template class EpetraVectorT<int, default_node_type >;
+template Epetra_Vector & toEpetra<int,default_node_type >(Vector<double, int, int, default_node_type> &);
+template const Epetra_Vector & toEpetra<int, default_node_type >(const Vector<double, int, int, default_node_type> &);
+#endif
 #else
 // Tpetra is disabled and Kokkos not available: use dummy node type
 typedef Xpetra::EpetraNode default_node_type;
@@ -128,8 +134,8 @@ template class EpetraVectorT<long long, Kokkos::Compat::KokkosOpenMPWrapperNode 
 template Epetra_Vector & toEpetra<long long,Kokkos::Compat::KokkosOpenMPWrapperNode>(Vector<double, int, long long, Kokkos::Compat::KokkosOpenMPWrapperNode> &);
 template const Epetra_Vector & toEpetra<long long,Kokkos::Compat::KokkosOpenMPWrapperNode>(const Vector<double, int, long long, Kokkos::Compat::KokkosOpenMPWrapperNode> &);
 #endif
-#ifdef HAVE_TPETRA_INST_CUDA
-typedef Kokkos::Compat::KokkosCudaWrapperNode default_node_type;
+#ifdef HAVE_TPETRA_INST_HIP
+typedef Kokkos::Compat::KokkosHIPWrapperNode default_node_type;
 template class EpetraVectorT<long long, default_node_type >;
 template Epetra_Vector & toEpetra<long long,default_node_type >(Vector<double, int, long long, default_node_type> &);
 template const Epetra_Vector & toEpetra<long long, default_node_type >(const Vector<double, int, long long, default_node_type> &);

--- a/packages/xpetra/src/Vector/Xpetra_EpetraVector.cpp
+++ b/packages/xpetra/src/Vector/Xpetra_EpetraVector.cpp
@@ -134,6 +134,12 @@ template class EpetraVectorT<long long, Kokkos::Compat::KokkosOpenMPWrapperNode 
 template Epetra_Vector & toEpetra<long long,Kokkos::Compat::KokkosOpenMPWrapperNode>(Vector<double, int, long long, Kokkos::Compat::KokkosOpenMPWrapperNode> &);
 template const Epetra_Vector & toEpetra<long long,Kokkos::Compat::KokkosOpenMPWrapperNode>(const Vector<double, int, long long, Kokkos::Compat::KokkosOpenMPWrapperNode> &);
 #endif
+#ifdef HAVE_TPETRA_INST_CUDA
+typedef Kokkos::Compat::KokkosCudaWrapperNode default_node_type;
+template class EpetraVectorT<long long, default_node_type >;
+template Epetra_Vector & toEpetra<long long,default_node_type >(Vector<double, int, long long, default_node_type> &);
+template const Epetra_Vector & toEpetra<long long, default_node_type >(const Vector<double, int, long long, default_node_type> &);
+#endif
 #ifdef HAVE_TPETRA_INST_HIP
 typedef Kokkos::Compat::KokkosHIPWrapperNode default_node_type;
 template class EpetraVectorT<long long, default_node_type >;

--- a/packages/xpetra/test/CrsMatrix/CrsMatrix_UnitTests.cpp
+++ b/packages/xpetra/test/CrsMatrix/CrsMatrix_UnitTests.cpp
@@ -537,6 +537,14 @@ namespace {
       TEST_THROW(mx(Teuchos::null, 0), Xpetra::Exceptions::RuntimeError);
     }
 #endif
+#if defined(HAVE_XPETRA_TPETRA) && defined(HAVE_TPETRA_INST_HIP)
+    {
+      typedef Xpetra::EpetraMapT<GO, Kokkos::Compat::KokkosHIPWrapperNode> mm;
+      TEST_THROW(mm(10, 0, comm), Xpetra::Exceptions::RuntimeError);
+      typedef Xpetra::EpetraCrsMatrixT<GO, Kokkos::Compat::KokkosHIPWrapperNode> mx;
+      TEST_THROW(mx(Teuchos::null, 0), Xpetra::Exceptions::RuntimeError);
+    }
+#endif
 
 #endif
   }

--- a/packages/xpetra/test/MultiVector/MultiVector_UnitTests.cpp
+++ b/packages/xpetra/test/MultiVector/MultiVector_UnitTests.cpp
@@ -2509,6 +2509,14 @@ namespace {
       TEST_THROW(mx(Teuchos::null, 3), Xpetra::Exceptions::RuntimeError);
     }
 #endif
+#if defined(HAVE_XPETRA_TPETRA) && defined(HAVE_TPETRA_INST_HIP)
+    {
+      typedef Xpetra::EpetraMapT<GlobalOrdinal, Kokkos::Compat::KokkosHIPWrapperNode> mm;
+      TEST_THROW(mm(10, 0, comm), Xpetra::Exceptions::RuntimeError);
+      typedef Xpetra::EpetraMultiVectorT<GlobalOrdinal, Kokkos::Compat::KokkosHIPWrapperNode> mx;
+      TEST_THROW(mx(Teuchos::null, 3), Xpetra::Exceptions::RuntimeError);
+    }
+#endif
 
 #endif
   }


### PR DESCRIPTION
@trilinos/xpetra 

## Motivation
Enabling HIP support in Xpetra to allow propagation of HIP backend to Zoltan2 and MueLu

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to #9322 
* Part of 
* Composed of 


## Stakeholder Feedback
ExaWind, SPARC and EMPIRE care about this feature as they are targeting AMD architectures 

## Testing
All testing was performed on Spock (OLCF pre-Frontier AMD testbed)
