### PR TITLE
Panzer: Add tests to cover mesh rebalancing options

### DIFF
--- a/packages/panzer/adapters-stk/test/stk_interface_test/CMakeLists.txt
+++ b/packages/panzer/adapters-stk/test/stk_interface_test/CMakeLists.txt
@@ -170,6 +170,13 @@ IF(${PACKAGE_NAME}_ENABLE_Pamgen)
     )
 
   TRIBITS_ADD_EXECUTABLE_AND_TEST(
+    tSTKRebalancing
+    SOURCES tSTKRebalancing.cpp ${UNIT_TEST_DRIVER}
+    NUM_MPI_PROCS 4
+    COMM mpi
+    )
+
+  TRIBITS_ADD_EXECUTABLE_AND_TEST(
     pamgen_writer
     SOURCES pamgen_writer.cpp
     )

--- a/packages/panzer/adapters-stk/test/stk_interface_test/tSTKRebalancing.cpp
+++ b/packages/panzer/adapters-stk/test/stk_interface_test/tSTKRebalancing.cpp
@@ -1,0 +1,115 @@
+// @HEADER
+// ***********************************************************************
+//
+//           Panzer: A partial differential equation assembly
+//       engine for strongly coupled complex multiphysics systems
+//                 Copyright (2011) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Roger P. Pawlowski (rppawlo@sandia.gov) and
+// Eric C. Cyr (eccyr@sandia.gov)
+// ***********************************************************************
+// @HEADER
+
+#include <Teuchos_ConfigDefs.hpp>
+#include <Teuchos_UnitTestHarness.hpp>
+#include "Teuchos_DefaultComm.hpp"
+#include "Teuchos_GlobalMPISession.hpp"
+#include "Teuchos_ParameterList.hpp"
+
+#include "Panzer_STK_Version.hpp"
+#include "PanzerAdaptersSTK_config.hpp"
+#include "Panzer_STK_Interface.hpp"
+#include "Panzer_STK_ExodusReaderFactory.hpp"
+#include "Panzer_STK_SetupUtilities.hpp"
+
+#ifdef PANZER_HAVE_PERCEPT
+#include "percept/PerceptMesh.hpp"
+#endif
+
+#include "stk_mesh/base/GetEntities.hpp"
+#include "stk_mesh/base/Selector.hpp"
+#include "stk_mesh/base/CreateAdjacentEntities.hpp"
+
+namespace panzer_stk {
+
+// Test to make sure the default option for mesh rebalancing doesn't throw
+TEUCHOS_UNIT_TEST(tSTKRebalancing, default)
+{
+  using namespace Teuchos;
+  using Teuchos::RCP;
+  using Teuchos::rcp;
+
+  TEST_EQUALITY(Teuchos::DefaultComm<int>::getComm()->getSize(),4);
+
+  {
+    out << "\nCreating pamgen mesh" << std::endl;
+    RCP<ParameterList> p = parameterList();
+    const std::string input_file_name = "pamgen_test.gen";
+    p->set("File Name",input_file_name);
+    p->set("File Type","Pamgen");
+    p->set("Rebalancing","default");
+
+    RCP<STK_ExodusReaderFactory> pamgenFactory = rcp(new STK_ExodusReaderFactory());
+    TEST_NOTHROW(pamgenFactory->setParameterList(p));
+
+    RCP<STK_Interface> mesh = pamgenFactory->buildMesh(MPI_COMM_WORLD);
+    TEST_ASSERT(mesh!=Teuchos::null);
+  }
+}
+
+// Test to make sure the none option for mesh rebalancing doesn't throw
+TEUCHOS_UNIT_TEST(tSTKRebalancing, none)
+{
+  using namespace Teuchos;
+  using Teuchos::RCP;
+  using Teuchos::rcp;
+
+  TEST_EQUALITY(Teuchos::DefaultComm<int>::getComm()->getSize(),4);
+
+  {
+    out << "\nCreating pamgen mesh" << std::endl;
+    RCP<ParameterList> p = parameterList();
+    const std::string input_file_name = "pamgen_test.gen";
+    p->set("File Name",input_file_name);
+    p->set("File Type","Pamgen");
+    p->set("Rebalancing","none");
+
+    RCP<STK_ExodusReaderFactory> pamgenFactory = rcp(new STK_ExodusReaderFactory());
+    TEST_NOTHROW(pamgenFactory->setParameterList(p));
+
+    RCP<STK_Interface> mesh = pamgenFactory->buildMesh(MPI_COMM_WORLD);
+    TEST_ASSERT(mesh!=Teuchos::null);
+  }
+}
+
+} // namespace panzer_stk


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/panzer 
@rppawlo 

## Motivation
I'm working on Percept-based mesh rebalancing for use with multigrid for Drekar (i.e. next PR will add the "percept" option for the "Rebalancing" parameter), but I'd like to add new tests first so that I can make sure this is the right direction for testing. I'm setting this test to use only 4 MPI ranks because rebalancing really doesn't make sense on 1 MPI rank, and later I will need 4 MPI ranks to make sure it's behaving as I'd like. I'm using Pamgen meshes for the tests because it doesn't make sense to regularly refine an inline mesh, but I cannot open an exodus file in emacs.


<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Testing
I've tested this on my machine, vaporwave, and it runs and passes.