### PR TITLE
Panzer: fix edge vs face typo that could crash in faceGlobalId()

### DIFF
--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.hpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.hpp
@@ -811,12 +811,12 @@ public:
    /** Get a face's global index
      */
    inline stk::mesh::EntityId faceGlobalId(std::size_t lid) const
-   { return bulkData_->identifier((*orderedEdgeVector_)[lid]); }
+   { return bulkData_->identifier((*orderedFaceVector_)[lid]); }
 
    /** Get a face's global index
      */
-   inline stk::mesh::EntityId faceGlobalId(stk::mesh::Entity edge) const
-   { return bulkData_->identifier(edge); }
+   inline stk::mesh::EntityId faceGlobalId(stk::mesh::Entity face) const
+   { return bulkData_->identifier(face); }
 
   /** Get an Entity's parallel owner (process rank)
    */


### PR DESCRIPTION
@trilinos/panzer

This PR fixes typos in `faceGlobalId()` that reference edge instead of face.  The first is just a parameter with the wrong name.  The second is the use of the wrong lookup vector which could cause a crash.

## Related Issues

* Blocks #9491
* Precedes #9491 

## Testing
These changes are tested by tExodusEdgeBlock and tExodusFaceBlock which have been updated in the related PR.

