### PR TITLE
Panzer: make the edge/face block parameters consistent across mesh factories

### DIFF
--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_CubeHexMeshFactory.hpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_CubeHexMeshFactory.hpp
@@ -109,6 +109,8 @@ protected:
 
    bool buildInterfaceSidesets_;
    bool buildSubcells_;
+   bool createEdgeBlocks_;
+   bool createFaceBlocks_;
 
    mutable Teuchos::Tuple<std::size_t,3> procTuple_;
 };

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_CubeTetMeshFactory.hpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_CubeTetMeshFactory.hpp
@@ -112,6 +112,9 @@ protected:
    mutable unsigned int machRank_, machSize_;
 
    mutable Teuchos::Tuple<std::size_t,3> procTuple_;
+
+   bool createEdgeBlocks_;
+   bool createFaceBlocks_;
 };
 
 }

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_ExodusReaderFactory.cpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_ExodusReaderFactory.cpp
@@ -363,7 +363,6 @@ void STK_ExodusReaderFactory::setParameterList(const Teuchos::RCP<Teuchos::Param
    levelsOfRefinement_ = paramList->get<int>("Levels of Uniform Refinement");
 
    createEdgeBlocks_ = paramList->get<bool>("Create Edge Blocks");
-
    createFaceBlocks_ = paramList->get<bool>("Create Face Blocks");
 }
 
@@ -401,10 +400,8 @@ Teuchos::RCP<const Teuchos::ParameterList> STK_ExodusReaderFactory::getValidPara
 
       validParams->set("Rebalancing","default","The type of rebalancing to be performed on the mesh after creation (default, none)");
 
-      // default to false to prevent massive exodiff test failures
+      // default to false for backward compatibility
       validParams->set("Create Edge Blocks",false,"Create or copy edge blocks in the mesh");
-
-      // default to false to prevent massive exodiff test failures
       validParams->set("Create Face Blocks",false,"Create or copy face blocks in the mesh");
    }
 

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_SquareQuadMeshFactory.hpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_SquareQuadMeshFactory.hpp
@@ -96,6 +96,7 @@ protected:
 
    void addSideSets(STK_Interface & mesh) const;
    void addNodeSets(STK_Interface & mesh) const;
+   void addEdgeBlocks(STK_Interface & mesh) const;
 
    double x0_, y0_;
    double xf_, yf_;
@@ -107,6 +108,8 @@ protected:
 
    mutable unsigned int machRank_, machSize_;
    mutable Teuchos::Tuple<std::size_t,2> procTuple_;
+
+   bool createEdgeBlocks_;
 
   /// If true, offset mesh GIDs to exercise 32-bit limits.
   bool offsetGIDs_;

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_SquareTriMeshFactory.hpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_SquareTriMeshFactory.hpp
@@ -96,6 +96,7 @@ protected:
 
    void addSideSets(STK_Interface & mesh) const;
    void addNodeSets(STK_Interface & mesh) const;
+   void addEdgeBlocks(STK_Interface & mesh) const;
 
    double x0_, y0_;
    double xf_, yf_;
@@ -107,6 +108,8 @@ protected:
 
    mutable unsigned int machRank_, machSize_;
    mutable Teuchos::Tuple<std::size_t,2> procTuple_;
+
+   bool createEdgeBlocks_;
 };
 
 }

--- a/packages/panzer/adapters-stk/test/stk_interface_test/tCubeHexMeshFactory.cpp
+++ b/packages/panzer/adapters-stk/test/stk_interface_test/tCubeHexMeshFactory.cpp
@@ -72,8 +72,8 @@ void edge_face_block_test_helper(Teuchos::FancyOStream &out,
                                  bool &success,
                                  Teuchos::RCP<Teuchos::ParameterList> pl,
                                  std::string exodus_filename,
-                                 int expected_edge_block_count,
-                                 int expected_face_block_count)
+                                 uint32_t expected_edge_block_count,
+                                 uint32_t expected_face_block_count)
 {
    CubeHexMeshFactory factory; 
    factory.setParameterList(pl);
@@ -228,8 +228,6 @@ TEUCHOS_UNIT_TEST(tCubeHexMeshFactory, default_edge_face_blocks)
    using Teuchos::rcp;
    using Teuchos::rcpFromRef;
 
-   int rank = stk::parallel_machine_rank(MPI_COMM_WORLD);
-
    int xe = 2, ye = 2, ze = 2;
    int bx = 1, by = 1, bz = 1;
 
@@ -249,8 +247,6 @@ TEUCHOS_UNIT_TEST(tCubeHexMeshFactory, create_edge_blocks_pl)
    using Teuchos::RCP;
    using Teuchos::rcp;
    using Teuchos::rcpFromRef;
-
-   int rank = stk::parallel_machine_rank(MPI_COMM_WORLD);
 
    int xe = 2, ye = 2, ze = 2;
    int bx = 1, by = 1, bz = 1;
@@ -273,8 +269,6 @@ TEUCHOS_UNIT_TEST(tCubeHexMeshFactory, create_face_blocks_pl)
    using Teuchos::rcp;
    using Teuchos::rcpFromRef;
 
-   int rank = stk::parallel_machine_rank(MPI_COMM_WORLD);
-
    int xe = 2, ye = 2, ze = 2;
    int bx = 1, by = 1, bz = 1;
 
@@ -296,8 +290,6 @@ TEUCHOS_UNIT_TEST(tCubeHexMeshFactory, create_edge_face_blocks_pl)
    using Teuchos::RCP;
    using Teuchos::rcp;
    using Teuchos::rcpFromRef;
-
-   int rank = stk::parallel_machine_rank(MPI_COMM_WORLD);
 
    int xe = 2, ye = 2, ze = 2;
    int bx = 1, by = 1, bz = 1;

--- a/packages/panzer/adapters-stk/test/stk_interface_test/tCubeHexMeshFactory.cpp
+++ b/packages/panzer/adapters-stk/test/stk_interface_test/tCubeHexMeshFactory.cpp
@@ -60,7 +60,44 @@
    #include "Epetra_SerialComm.h"
 #endif
 
+#include "Ioss_DatabaseIO.h"
+#include "Ioss_IOFactory.h"
+#include "Ioss_Region.h"
+#include "Ioss_EdgeBlock.h"
+#include "Ioss_FaceBlock.h"
+
 namespace panzer_stk {
+
+void edge_face_block_test_helper(Teuchos::FancyOStream &out,
+                                 bool &success,
+                                 Teuchos::RCP<Teuchos::ParameterList> pl,
+                                 std::string exodus_filename,
+                                 int expected_edge_block_count,
+                                 int expected_face_block_count)
+{
+   CubeHexMeshFactory factory; 
+   factory.setParameterList(pl);
+   Teuchos::RCP<STK_Interface> mesh = factory.buildMesh(MPI_COMM_WORLD);
+   TEST_ASSERT(mesh!=Teuchos::null);
+ 
+   if(mesh->isWritable())
+      mesh->writeToExodus(exodus_filename.c_str());
+
+   {
+   Ioss::DatabaseIO *db_io = Ioss::IOFactory::create("exodus", 
+                                                     exodus_filename.c_str(), 
+                                                     Ioss::READ_MODEL);
+   TEST_ASSERT(db_io);
+
+   Ioss::Region region(db_io);
+   TEST_ASSERT(db_io->ok() == true);
+
+   auto all_edge_blocks = region.get_edge_blocks();
+   TEST_ASSERT(all_edge_blocks.size() == expected_edge_block_count);
+   auto all_face_blocks = region.get_face_blocks();
+   TEST_ASSERT(all_face_blocks.size() == expected_face_block_count);
+   }
+}
 
 TEUCHOS_UNIT_TEST(tCubeHexMeshFactory, defaults)
 {
@@ -183,6 +220,99 @@ TEUCHOS_UNIT_TEST(tCubeHexMeshFactory, disable_subcells)
    TEST_EQUALITY(mesh->getEntityCounts(mesh->getEdgeRank()),0);
    TEST_EQUALITY(mesh->getEntityCounts(mesh->getFaceRank()),2*4*2 + 2*5*2 + 4*5*2);
    TEST_EQUALITY(mesh->getEntityCounts(mesh->getNodeRank()),(4+1)*(2+1)*(5+1));
+}
+
+TEUCHOS_UNIT_TEST(tCubeHexMeshFactory, default_edge_face_blocks)
+{
+   using Teuchos::RCP;
+   using Teuchos::rcp;
+   using Teuchos::rcpFromRef;
+
+   int rank = stk::parallel_machine_rank(MPI_COMM_WORLD);
+
+   int xe = 2, ye = 2, ze = 2;
+   int bx = 1, by = 1, bz = 1;
+
+   RCP<Teuchos::ParameterList> pl = rcp(new Teuchos::ParameterList);
+   pl->set("X Blocks",bx);
+   pl->set("Y Blocks",by);
+   pl->set("Z Blocks",bz);
+   pl->set("X Elements",xe);
+   pl->set("Y Elements",ye);
+   pl->set("Z Elements",ze);
+
+   edge_face_block_test_helper(out, success, pl, "CubeHex_default_edge_face_blocks.exo", 0, 0);
+}
+
+TEUCHOS_UNIT_TEST(tCubeHexMeshFactory, create_edge_blocks_pl)
+{
+   using Teuchos::RCP;
+   using Teuchos::rcp;
+   using Teuchos::rcpFromRef;
+
+   int rank = stk::parallel_machine_rank(MPI_COMM_WORLD);
+
+   int xe = 2, ye = 2, ze = 2;
+   int bx = 1, by = 1, bz = 1;
+
+   RCP<Teuchos::ParameterList> pl = rcp(new Teuchos::ParameterList);
+   pl->set("X Blocks",bx);
+   pl->set("Y Blocks",by);
+   pl->set("Z Blocks",bz);
+   pl->set("X Elements",xe);
+   pl->set("Y Elements",ye);
+   pl->set("Z Elements",ze);
+   pl->set("Create Edge Blocks",true);
+
+   edge_face_block_test_helper(out, success, pl, "CubeHex_create_edge_blocks_pl.exo", 1, 0);
+}
+
+TEUCHOS_UNIT_TEST(tCubeHexMeshFactory, create_face_blocks_pl)
+{
+   using Teuchos::RCP;
+   using Teuchos::rcp;
+   using Teuchos::rcpFromRef;
+
+   int rank = stk::parallel_machine_rank(MPI_COMM_WORLD);
+
+   int xe = 2, ye = 2, ze = 2;
+   int bx = 1, by = 1, bz = 1;
+
+   RCP<Teuchos::ParameterList> pl = rcp(new Teuchos::ParameterList);
+   pl->set("X Blocks",bx);
+   pl->set("Y Blocks",by);
+   pl->set("Z Blocks",bz);
+   pl->set("X Elements",xe);
+   pl->set("Y Elements",ye);
+   pl->set("Z Elements",ze);
+   pl->set("Create Face Blocks",true);
+
+   edge_face_block_test_helper(out, success, pl, "CubeHex_create_face_blocks_pl.exo", 0, 1);
+}
+
+
+TEUCHOS_UNIT_TEST(tCubeHexMeshFactory, create_edge_face_blocks_pl)
+{
+   using Teuchos::RCP;
+   using Teuchos::rcp;
+   using Teuchos::rcpFromRef;
+
+   int rank = stk::parallel_machine_rank(MPI_COMM_WORLD);
+
+   int xe = 2, ye = 2, ze = 2;
+   int bx = 1, by = 1, bz = 1;
+
+   RCP<Teuchos::ParameterList> pl = rcp(new Teuchos::ParameterList);
+   pl->set("X Blocks",bx);
+   pl->set("Y Blocks",by);
+   pl->set("Z Blocks",bz);
+   pl->set("X Elements",xe);
+   pl->set("Y Elements",ye);
+   pl->set("Z Elements",ze);
+   pl->set("Create Edge Blocks",true);
+   pl->set("Create Face Blocks",true);
+
+   edge_face_block_test_helper(out, success, pl, "CubeHex_create_edge_face_blocks_pl.exo", 1, 1);
 }
 
 TEUCHOS_UNIT_TEST(tCubeHexMeshFactory, allblock)

--- a/packages/panzer/adapters-stk/test/stk_interface_test/tCubeTetMeshFactory.cpp
+++ b/packages/panzer/adapters-stk/test/stk_interface_test/tCubeTetMeshFactory.cpp
@@ -59,7 +59,44 @@
    #include "Epetra_SerialComm.h"
 #endif
 
+#include "Ioss_DatabaseIO.h"
+#include "Ioss_IOFactory.h"
+#include "Ioss_Region.h"
+#include "Ioss_EdgeBlock.h"
+#include "Ioss_FaceBlock.h"
+
 namespace panzer_stk {
+
+void edge_face_block_test_helper(Teuchos::FancyOStream &out,
+                                 bool &success,
+                                 Teuchos::RCP<Teuchos::ParameterList> pl,
+                                 std::string exodus_filename,
+                                 int expected_edge_block_count,
+                                 int expected_face_block_count)
+{
+   CubeTetMeshFactory factory; 
+   factory.setParameterList(pl);
+   Teuchos::RCP<STK_Interface> mesh = factory.buildMesh(MPI_COMM_WORLD);
+   TEST_ASSERT(mesh!=Teuchos::null);
+ 
+   if(mesh->isWritable())
+      mesh->writeToExodus(exodus_filename.c_str());
+
+   {
+   Ioss::DatabaseIO *db_io = Ioss::IOFactory::create("exodus", 
+                                                     exodus_filename.c_str(), 
+                                                     Ioss::READ_MODEL);
+   TEST_ASSERT(db_io);
+
+   Ioss::Region region(db_io);
+   TEST_ASSERT(db_io->ok() == true);
+
+   auto all_edge_blocks = region.get_edge_blocks();
+   TEST_ASSERT(all_edge_blocks.size() == expected_edge_block_count);
+   auto all_face_blocks = region.get_face_blocks();
+   TEST_ASSERT(all_face_blocks.size() == expected_face_block_count);
+   }
+}
 
 TEUCHOS_UNIT_TEST(tCubeTetMeshFactory, defaults)
 {
@@ -102,6 +139,99 @@ TEUCHOS_UNIT_TEST(tCubeTetMeshFactory, defaults)
  
    TEST_EQUALITY(nodesets.size(),1);
    TEST_EQUALITY(nodesets[0],"origin");
+}
+
+TEUCHOS_UNIT_TEST(tCubeHexMeshFactory, default_edge_face_blocks)
+{
+   using Teuchos::RCP;
+   using Teuchos::rcp;
+   using Teuchos::rcpFromRef;
+
+   int rank = stk::parallel_machine_rank(MPI_COMM_WORLD);
+
+   int xe = 2, ye = 2, ze = 2;
+   int bx = 1, by = 1, bz = 1;
+
+   RCP<Teuchos::ParameterList> pl = rcp(new Teuchos::ParameterList);
+   pl->set("X Blocks",bx);
+   pl->set("Y Blocks",by);
+   pl->set("Z Blocks",bz);
+   pl->set("X Elements",xe);
+   pl->set("Y Elements",ye);
+   pl->set("Z Elements",ze);
+
+   edge_face_block_test_helper(out, success, pl, "CubeTet_default_edge_face_blocks.exo", 0, 0);
+}
+
+TEUCHOS_UNIT_TEST(tCubeTetMeshFactory, create_edge_blocks_pl)
+{
+   using Teuchos::RCP;
+   using Teuchos::rcp;
+   using Teuchos::rcpFromRef;
+
+   int rank = stk::parallel_machine_rank(MPI_COMM_WORLD);
+
+   int xe = 2, ye = 2, ze = 2;
+   int bx = 1, by = 1, bz = 1;
+
+   RCP<Teuchos::ParameterList> pl = rcp(new Teuchos::ParameterList);
+   pl->set("X Blocks",bx);
+   pl->set("Y Blocks",by);
+   pl->set("Z Blocks",bz);
+   pl->set("X Elements",xe);
+   pl->set("Y Elements",ye);
+   pl->set("Z Elements",ze);
+   pl->set("Create Edge Blocks",true);
+
+   edge_face_block_test_helper(out, success, pl, "CubeTet_create_edge_blocks_pl.exo", 1, 0);
+}
+
+TEUCHOS_UNIT_TEST(tCubeTetMeshFactory, create_face_blocks_pl)
+{
+   using Teuchos::RCP;
+   using Teuchos::rcp;
+   using Teuchos::rcpFromRef;
+
+   int rank = stk::parallel_machine_rank(MPI_COMM_WORLD);
+
+   int xe = 2, ye = 2, ze = 2;
+   int bx = 1, by = 1, bz = 1;
+
+   RCP<Teuchos::ParameterList> pl = rcp(new Teuchos::ParameterList);
+   pl->set("X Blocks",bx);
+   pl->set("Y Blocks",by);
+   pl->set("Z Blocks",bz);
+   pl->set("X Elements",xe);
+   pl->set("Y Elements",ye);
+   pl->set("Z Elements",ze);
+   pl->set("Create Face Blocks",true);
+
+   edge_face_block_test_helper(out, success, pl, "CubeTet_create_face_blocks_pl.exo", 0, 1);
+}
+
+
+TEUCHOS_UNIT_TEST(tCubeTetMeshFactory, create_edge_face_blocks_pl)
+{
+   using Teuchos::RCP;
+   using Teuchos::rcp;
+   using Teuchos::rcpFromRef;
+
+   int rank = stk::parallel_machine_rank(MPI_COMM_WORLD);
+
+   int xe = 2, ye = 2, ze = 2;
+   int bx = 1, by = 1, bz = 1;
+
+   RCP<Teuchos::ParameterList> pl = rcp(new Teuchos::ParameterList);
+   pl->set("X Blocks",bx);
+   pl->set("Y Blocks",by);
+   pl->set("Z Blocks",bz);
+   pl->set("X Elements",xe);
+   pl->set("Y Elements",ye);
+   pl->set("Z Elements",ze);
+   pl->set("Create Edge Blocks",true);
+   pl->set("Create Face Blocks",true);
+
+   edge_face_block_test_helper(out, success, pl, "CubeTet_create_edge_face_blocks_pl.exo", 1, 1);
 }
 
 }

--- a/packages/panzer/adapters-stk/test/stk_interface_test/tCubeTetMeshFactory.cpp
+++ b/packages/panzer/adapters-stk/test/stk_interface_test/tCubeTetMeshFactory.cpp
@@ -71,8 +71,8 @@ void edge_face_block_test_helper(Teuchos::FancyOStream &out,
                                  bool &success,
                                  Teuchos::RCP<Teuchos::ParameterList> pl,
                                  std::string exodus_filename,
-                                 int expected_edge_block_count,
-                                 int expected_face_block_count)
+                                 uint32_t expected_edge_block_count,
+                                 uint32_t expected_face_block_count)
 {
    CubeTetMeshFactory factory; 
    factory.setParameterList(pl);
@@ -147,8 +147,6 @@ TEUCHOS_UNIT_TEST(tCubeHexMeshFactory, default_edge_face_blocks)
    using Teuchos::rcp;
    using Teuchos::rcpFromRef;
 
-   int rank = stk::parallel_machine_rank(MPI_COMM_WORLD);
-
    int xe = 2, ye = 2, ze = 2;
    int bx = 1, by = 1, bz = 1;
 
@@ -168,8 +166,6 @@ TEUCHOS_UNIT_TEST(tCubeTetMeshFactory, create_edge_blocks_pl)
    using Teuchos::RCP;
    using Teuchos::rcp;
    using Teuchos::rcpFromRef;
-
-   int rank = stk::parallel_machine_rank(MPI_COMM_WORLD);
 
    int xe = 2, ye = 2, ze = 2;
    int bx = 1, by = 1, bz = 1;
@@ -192,8 +188,6 @@ TEUCHOS_UNIT_TEST(tCubeTetMeshFactory, create_face_blocks_pl)
    using Teuchos::rcp;
    using Teuchos::rcpFromRef;
 
-   int rank = stk::parallel_machine_rank(MPI_COMM_WORLD);
-
    int xe = 2, ye = 2, ze = 2;
    int bx = 1, by = 1, bz = 1;
 
@@ -215,8 +209,6 @@ TEUCHOS_UNIT_TEST(tCubeTetMeshFactory, create_edge_face_blocks_pl)
    using Teuchos::RCP;
    using Teuchos::rcp;
    using Teuchos::rcpFromRef;
-
-   int rank = stk::parallel_machine_rank(MPI_COMM_WORLD);
 
    int xe = 2, ye = 2, ze = 2;
    int bx = 1, by = 1, bz = 1;

--- a/packages/panzer/adapters-stk/test/stk_interface_test/tExodusEdgeBlock.cpp
+++ b/packages/panzer/adapters-stk/test/stk_interface_test/tExodusEdgeBlock.cpp
@@ -84,6 +84,7 @@ TEUCHOS_UNIT_TEST(tExodusEdgeBlock, edge_count)
    pl->set("X Elements",(int)xelems);
    pl->set("Y Elements",(int)yelems);
    pl->set("Z Elements",(int)zelems);
+   pl->set("Create Edge Blocks",true);
    
    CubeHexMeshFactory factory; 
    factory.setParameterList(pl);
@@ -168,6 +169,7 @@ TEUCHOS_UNIT_TEST(tExodusEdgeBlock, is_edge_local)
    pl->set("X Elements",(int)xelems);
    pl->set("Y Elements",(int)yelems);
    pl->set("Z Elements",(int)zelems);
+   pl->set("Create Edge Blocks",true);
    
    CubeHexMeshFactory factory; 
    factory.setParameterList(pl);
@@ -218,6 +220,7 @@ TEUCHOS_UNIT_TEST(tExodusEdgeBlock, add_edge_field)
    pl->set("X Elements",2);
    pl->set("Y Elements",4);
    pl->set("Z Elements",5);
+   pl->set("Create Edge Blocks",true);
    
    CubeHexMeshFactory factory; 
    factory.setParameterList(pl);
@@ -274,6 +277,7 @@ TEUCHOS_UNIT_TEST(tExodusEdgeBlock, set_edge_field_data)
    pl->set("X Elements",2);
    pl->set("Y Elements",4);
    pl->set("Z Elements",5);
+   pl->set("Create Edge Blocks",true);
    
    CubeHexMeshFactory factory; 
    factory.setParameterList(pl);

--- a/packages/panzer/adapters-stk/test/stk_interface_test/tExodusFaceBlock.cpp
+++ b/packages/panzer/adapters-stk/test/stk_interface_test/tExodusFaceBlock.cpp
@@ -84,6 +84,7 @@ TEUCHOS_UNIT_TEST(tExodusFaceBlock, face_count)
    pl->set("X Elements",(int)xelems);
    pl->set("Y Elements",(int)yelems);
    pl->set("Z Elements",(int)zelems);
+   pl->set("Create Face Blocks",true);
 
    CubeHexMeshFactory factory; 
    factory.setParameterList(pl);
@@ -167,6 +168,7 @@ TEUCHOS_UNIT_TEST(tExodusFaceBlock, is_face_local)
    pl->set("X Elements",(int)xelems);
    pl->set("Y Elements",(int)yelems);
    pl->set("Z Elements",(int)zelems);
+   pl->set("Create Face Blocks",true);
 
    CubeHexMeshFactory factory; 
    factory.setParameterList(pl);
@@ -217,6 +219,7 @@ TEUCHOS_UNIT_TEST(tExodusFaceBlock, add_face_field)
    pl->set("X Elements",2);
    pl->set("Y Elements",4);
    pl->set("Z Elements",5);
+   pl->set("Create Face Blocks",true);
 
    CubeHexMeshFactory factory; 
    factory.setParameterList(pl);
@@ -273,6 +276,7 @@ TEUCHOS_UNIT_TEST(tExodusFaceBlock, set_face_field_data)
    pl->set("X Elements",2);
    pl->set("Y Elements",4);
    pl->set("Z Elements",5);
+   pl->set("Create Face Blocks",true);
 
    CubeHexMeshFactory factory; 
    factory.setParameterList(pl);

--- a/packages/panzer/adapters-stk/test/stk_interface_test/tExodusReaderFactory.cpp
+++ b/packages/panzer/adapters-stk/test/stk_interface_test/tExodusReaderFactory.cpp
@@ -75,8 +75,8 @@ namespace panzer_stk {
 void edge_face_block_test_helper(Teuchos::FancyOStream &out,
                                  bool &success,
                                  std::string exodus_filename,
-                                 int expected_edge_block_count,
-                                 int expected_face_block_count)
+                                 uint32_t expected_edge_block_count,
+                                 uint32_t expected_face_block_count)
 {
    Ioss::DatabaseIO *db_io = Ioss::IOFactory::create("exodus", 
                                                      exodus_filename.c_str(), 

--- a/packages/panzer/adapters-stk/test/stk_interface_test/tExodusReaderFactory.cpp
+++ b/packages/panzer/adapters-stk/test/stk_interface_test/tExodusReaderFactory.cpp
@@ -62,9 +62,36 @@
    #include "Epetra_SerialComm.h"
 #endif
 
+#include "Ioss_DatabaseIO.h"
+#include "Ioss_IOFactory.h"
+#include "Ioss_Region.h"
+#include "Ioss_EdgeBlock.h"
+#include "Ioss_FaceBlock.h"
+
 #ifdef PANZER_HAVE_IOSS
 
 namespace panzer_stk {
+  
+void edge_face_block_test_helper(Teuchos::FancyOStream &out,
+                                 bool &success,
+                                 std::string exodus_filename,
+                                 int expected_edge_block_count,
+                                 int expected_face_block_count)
+{
+   Ioss::DatabaseIO *db_io = Ioss::IOFactory::create("exodus", 
+                                                     exodus_filename.c_str(), 
+                                                     Ioss::READ_MODEL);
+   TEST_ASSERT(db_io);
+
+   Ioss::Region region(db_io);
+   TEST_ASSERT(db_io->ok() == true);
+
+   auto all_edge_blocks = region.get_edge_blocks();
+   TEST_ASSERT(all_edge_blocks.size() == expected_edge_block_count);
+   auto all_face_blocks = region.get_face_blocks();
+   TEST_ASSERT(all_face_blocks.size() == expected_face_block_count);
+}
+
 
 TEUCHOS_UNIT_TEST(tExodusReaderFactory, basic_test)
 {
@@ -173,16 +200,54 @@ TEUCHOS_UNIT_TEST(tExodusReaderFactory, basic_test)
 }
 
 /*
- * This is basically the same as "basic_test" except
- * that it will confirm that the edge block is created in
+ * This is a much simplified copy of the "basic_test" 
+ * which confirms that by default the edge and face 
+ * blocks are NOT created when reading in an Exodus 
+ * file that doesn't already have edge or face blocks.
+*/
+TEUCHOS_UNIT_TEST(tExodusReaderFactory, default_edge_face_block_test)
+{
+   auto erf = Teuchos::rcp(new STK_ExodusReaderFactory());
+
+   Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::rcp(new Teuchos::ParameterList);
+   pl->set("File Name","meshes/basic3d.gen");
+   erf->setParameterList(pl);
+
+   // read from file and build mesh
+   Teuchos::RCP<STK_Interface> mesh = erf->buildUncommitedMesh(MPI_COMM_WORLD);
+   erf->completeMeshConstruction(*mesh,MPI_COMM_WORLD);
+
+   TEST_ASSERT(mesh!=Teuchos::null);
+   TEST_ASSERT(mesh->getDimension()==3);
+   TEST_ASSERT(mesh->isWritable());
+   TEST_ASSERT(not mesh->isModifiable());
+
+   mesh->writeToExodus("meshes/default_edge_face_block_check.gen");
+
+   // check edge blocks
+   std::vector<std::string> edgeblocks;
+   mesh->getEdgeBlockNames(edgeblocks);
+   TEST_EQUALITY((int) edgeblocks.size(),0);
+
+   // check face blocks
+   std::vector<std::string> faceblocks;
+   mesh->getFaceBlockNames(faceblocks);
+   TEST_EQUALITY((int) faceblocks.size(),0);
+
+   edge_face_block_test_helper(out,
+                               success,
+                               "meshes/default_edge_face_block_check.gen",
+                               0,
+                               0);
+}
+
+/*
+ * This is a much simplified copy of the "basic_test" 
+ * which confirms that the edge block is created in
  * step 1 and copied in step 2.
 */
 TEUCHOS_UNIT_TEST(tExodusReaderFactory, edge_block_test)
 {
-   int numprocs = stk::parallel_machine_size(MPI_COMM_WORLD);
-   int rank = stk::parallel_machine_rank(MPI_COMM_WORLD);
-   out << "Running numprocs = " << numprocs << " rank = " << rank << std::endl;
-
    {
    auto erf = Teuchos::rcp(new STK_ExodusReaderFactory());
 
@@ -191,7 +256,6 @@ TEUCHOS_UNIT_TEST(tExodusReaderFactory, edge_block_test)
    pl->set("Create Edge Blocks",true);
    erf->setParameterList(pl);
 
-   out << "\n***reading from meshes/basic.gen ... writes to meshes/edge_block_check.gen" << std::endl;
    // read from file and build mesh
    Teuchos::RCP<STK_Interface> mesh = erf->buildUncommitedMesh(MPI_COMM_WORLD);
    erf->completeMeshConstruction(*mesh,MPI_COMM_WORLD);
@@ -201,64 +265,22 @@ TEUCHOS_UNIT_TEST(tExodusReaderFactory, edge_block_test)
    TEST_ASSERT(mesh->isWritable());
    TEST_ASSERT(not mesh->isModifiable());
 
-   out << "Begin writing to meshes/edge_block_check.gen" << std::endl;
    mesh->writeToExodus("meshes/edge_block_check.gen");
-   out << "Finished writing to meshes/edge_block_check.gen" << std::endl;
-
-   // check element blocks
-   std::vector<std::string> eBlocks;
-   mesh->getElementBlockNames(eBlocks);
-   TEST_EQUALITY((int) eBlocks.size(),2);
-   out << "E-Blocks: ";
-   for(std::size_t j=0;j<eBlocks.size();++j)
-      out << "\"" << eBlocks[j] << "\" ";
-   out << std::endl;
-
-   // check side sets
-   std::vector<std::string> sidesets;
-   mesh->getSidesetNames(sidesets);
-   TEST_EQUALITY((int) sidesets.size(),7);
-   out << "Sides: ";
-   for(std::size_t j=0;j<sidesets.size();++j)
-      out << "\"" << sidesets[j] << "\" ";
-   out << std::endl;
-
-   // check node sets
-   std::vector<std::string> nodesets;
-   mesh->getNodesetNames(nodesets);
-   TEST_EQUALITY((int) nodesets.size(),2);
-   out << "Nodesets: ";
-   for(std::size_t j=0;j<nodesets.size();++j)
-      out << "\"" << nodesets[j] << "\" ";
-   out << std::endl;
 
    // check edge blocks
    std::vector<std::string> edgeblocks;
    mesh->getEdgeBlockNames(edgeblocks);
    TEST_EQUALITY((int) edgeblocks.size(),1);
-   out << "Edge Blocks: ";
-   for(std::size_t j=0;j<edgeblocks.size();++j)
-      out << "\"" << edgeblocks[j] << "\" ";
-   out << std::endl;
 
-   // check face blocks
-   std::vector<std::string> faceblocks;
-   mesh->getFaceBlockNames(faceblocks);
-   TEST_EQUALITY((int) faceblocks.size(),0);
-   out << "Edge Blocks: ";
-   for(std::size_t j=0;j<faceblocks.size();++j)
-      out << "\"" << faceblocks[j] << "\" ";
-   out << std::endl;
-
-   TEST_EQUALITY(mesh->getSideRank(),mesh->getEdgeRank());
-   TEST_EQUALITY(mesh->getEntityCounts(mesh->getElementRank()),8);
-   TEST_EQUALITY(mesh->getEntityCounts(mesh->getSideRank()),22);
-   TEST_EQUALITY(mesh->getEntityCounts(mesh->getNodeRank()),15);
+   edge_face_block_test_helper(out,
+                               success,
+                               "meshes/edge_block_check.gen",
+                               1,
+                               0);
    }
    {
    // in an effort to be as cerebral as possible I read in the
    // outputed mesh and then re-output it
-   out << "\n***reading from meshes/edge_block_check.gen ... writes to meshes/edge_block_check2.gen" << std::endl;
 
    // read from file and build mesh
    auto erf = Teuchos::rcp(new STK_ExodusReaderFactory());
@@ -270,80 +292,36 @@ TEUCHOS_UNIT_TEST(tExodusReaderFactory, edge_block_test)
 
    Teuchos::RCP<STK_Interface> mesh = erf->buildMesh(MPI_COMM_WORLD);
 
-  // check element blocks
-   std::vector<std::string> eBlocks;
-   mesh->getElementBlockNames(eBlocks);
-   TEST_EQUALITY((int) eBlocks.size(),2);
-   out << "E-Blocks: ";
-   for(std::size_t j=0;j<eBlocks.size();++j)
-      out << "\"" << eBlocks[j] << "\" ";
-   out << std::endl;
-
-   // check side sets
-   std::vector<std::string> sidesets;
-   mesh->getSidesetNames(sidesets);
-   TEST_EQUALITY((int) sidesets.size(),7);
-   out << "Sides: ";
-   for(std::size_t j=0;j<sidesets.size();++j)
-      out << "\"" << sidesets[j] << "\" ";
-   out << std::endl;
-
-   // check node sets
-   std::vector<std::string> nodesets;
-   mesh->getNodesetNames(nodesets);
-   TEST_EQUALITY((int) nodesets.size(),2);
-   out << "Nodesets: ";
-   for(std::size_t j=0;j<nodesets.size();++j)
-      out << "\"" << nodesets[j] << "\" ";
-   out << std::endl;
-
    // check edge blocks
    std::vector<std::string> edgeblocks;
    mesh->getEdgeBlockNames(edgeblocks);
    TEST_EQUALITY((int) edgeblocks.size(),1);
-   out << "Edge Blocks: ";
-   for(std::size_t j=0;j<edgeblocks.size();++j)
-      out << "\"" << edgeblocks[j] << "\" ";
-   out << std::endl;
-
-   // check face blocks
-   std::vector<std::string> faceblocks;
-   mesh->getFaceBlockNames(faceblocks);
-   TEST_EQUALITY((int) faceblocks.size(),0);
-   out << "Edge Blocks: ";
-   for(std::size_t j=0;j<faceblocks.size();++j)
-      out << "\"" << faceblocks[j] << "\" ";
-   out << std::endl;
 
    mesh->writeToExodus("meshes/edge_block_check2.gen");
-   TEST_EQUALITY(mesh->getSideRank(),mesh->getEdgeRank());
-   TEST_EQUALITY(mesh->getEntityCounts(mesh->getElementRank()),8);
-   TEST_EQUALITY(mesh->getEntityCounts(mesh->getSideRank()),22);
-   TEST_EQUALITY(mesh->getEntityCounts(mesh->getNodeRank()),15);
+
+   edge_face_block_test_helper(out,
+                               success,
+                               "meshes/edge_block_check2.gen",
+                               1,
+                               0);
    }
 }
 
 /*
- * This is basically the same as "edge_block_test" except
- * that it will confirm that the face block is created in
+ * This is a much simplified copy of the "basic_test" 
+ * which confirms that the face block is created in
  * step 1 and copied in step 2.
 */
 TEUCHOS_UNIT_TEST(tExodusReaderFactory, face_block_test)
 {
-   int numprocs = stk::parallel_machine_size(MPI_COMM_WORLD);
-   int rank = stk::parallel_machine_rank(MPI_COMM_WORLD);
-   out << "Running numprocs = " << numprocs << " rank = " << rank << std::endl;
-
    {
    auto erf = Teuchos::rcp(new STK_ExodusReaderFactory());
 
    Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::rcp(new Teuchos::ParameterList);
    pl->set("File Name","meshes/basic3d.gen");
-   pl->set("Create Edge Blocks",true);
    pl->set("Create Face Blocks",true);
    erf->setParameterList(pl);
 
-   out << "\n***reading from meshes/basic3d.gen ... writes to meshes/face_block_check.gen" << std::endl;
    // read from file and build mesh
    Teuchos::RCP<STK_Interface> mesh = erf->buildUncommitedMesh(MPI_COMM_WORLD);
    erf->completeMeshConstruction(*mesh,MPI_COMM_WORLD);
@@ -353,126 +331,45 @@ TEUCHOS_UNIT_TEST(tExodusReaderFactory, face_block_test)
    TEST_ASSERT(mesh->isWritable());
    TEST_ASSERT(not mesh->isModifiable());
 
-   out << "Begin writing to meshes/face_block_check.gen" << std::endl;
    mesh->writeToExodus("meshes/face_block_check.gen");
-   out << "Finished writing to meshes/face_block_check.gen" << std::endl;
-
-   // check element blocks
-   std::vector<std::string> eBlocks;
-   mesh->getElementBlockNames(eBlocks);
-   TEST_EQUALITY((int) eBlocks.size(),1);
-   out << "E-Blocks: ";
-   for(std::size_t j=0;j<eBlocks.size();++j)
-      out << "\"" << eBlocks[j] << "\" ";
-   out << std::endl;
-
-   // check side sets
-   std::vector<std::string> sidesets;
-   mesh->getSidesetNames(sidesets);
-   TEST_EQUALITY((int) sidesets.size(),6);
-   out << "Sides: ";
-   for(std::size_t j=0;j<sidesets.size();++j)
-      out << "\"" << sidesets[j] << "\" ";
-   out << std::endl;
-
-   // check node sets
-   std::vector<std::string> nodesets;
-   mesh->getNodesetNames(nodesets);
-   TEST_EQUALITY((int) nodesets.size(),1);
-   out << "Nodesets: ";
-   for(std::size_t j=0;j<nodesets.size();++j)
-      out << "\"" << nodesets[j] << "\" ";
-   out << std::endl;
-
-   // check edge blocks
-   std::vector<std::string> edgeblocks;
-   mesh->getEdgeBlockNames(edgeblocks);
-   TEST_EQUALITY((int) edgeblocks.size(),1);
-   out << "Edge Blocks: ";
-   for(std::size_t j=0;j<edgeblocks.size();++j)
-      out << "\"" << edgeblocks[j] << "\" ";
-   out << std::endl;
 
    // check face blocks
    std::vector<std::string> faceblocks;
    mesh->getFaceBlockNames(faceblocks);
    TEST_EQUALITY((int) faceblocks.size(),1);
-   out << "Edge Blocks: ";
-   for(std::size_t j=0;j<faceblocks.size();++j)
-      out << "\"" << faceblocks[j] << "\" ";
-   out << std::endl;
 
-   TEST_EQUALITY(mesh->getSideRank(),mesh->getFaceRank());
-   TEST_EQUALITY(mesh->getEntityCounts(mesh->getElementRank()),40);
-   TEST_EQUALITY(mesh->getEntityCounts(mesh->getSideRank()),158);
-   TEST_EQUALITY(mesh->getEntityCounts(mesh->getNodeRank()),90);
+   edge_face_block_test_helper(out,
+                               success,
+                               "meshes/face_block_check.gen",
+                               0,
+                               1);
    }
    {
    // in an effort to be as cerebral as possible I read in the
    // outputed mesh and then re-output it
-   out << "\n***reading from meshes/face_block_check.gen ... writes to meshes/face_block_check2.gen" << std::endl;
 
    // read from file and build mesh
    auto erf = Teuchos::rcp(new STK_ExodusReaderFactory());
 
    Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::rcp(new Teuchos::ParameterList);
    pl->set("File Name","meshes/face_block_check.gen");
-   pl->set("Create Edge Blocks",true);
    pl->set("Create Face Blocks",true);
    erf->setParameterList(pl);
 
    Teuchos::RCP<STK_Interface> mesh = erf->buildMesh(MPI_COMM_WORLD);
 
-   // check element blocks
-   std::vector<std::string> eBlocks;
-   mesh->getElementBlockNames(eBlocks);
-   TEST_EQUALITY((int) eBlocks.size(),1);
-   out << "E-Blocks: ";
-   for(std::size_t j=0;j<eBlocks.size();++j)
-      out << "\"" << eBlocks[j] << "\" ";
-   out << std::endl;
-
-   // check side sets
-   std::vector<std::string> sidesets;
-   mesh->getSidesetNames(sidesets);
-   TEST_EQUALITY((int) sidesets.size(),6);
-   out << "Sides: ";
-   for(std::size_t j=0;j<sidesets.size();++j)
-      out << "\"" << sidesets[j] << "\" ";
-   out << std::endl;
-
-   // check node sets
-   std::vector<std::string> nodesets;
-   mesh->getNodesetNames(nodesets);
-   TEST_EQUALITY((int) nodesets.size(),1);
-   out << "Nodesets: ";
-   for(std::size_t j=0;j<nodesets.size();++j)
-      out << "\"" << nodesets[j] << "\" ";
-   out << std::endl;
-
-   // check edge blocks
-   std::vector<std::string> edgeblocks;
-   mesh->getEdgeBlockNames(edgeblocks);
-   TEST_EQUALITY((int) edgeblocks.size(),1);
-   out << "Edge Blocks: ";
-   for(std::size_t j=0;j<edgeblocks.size();++j)
-      out << "\"" << edgeblocks[j] << "\" ";
-   out << std::endl;
-
    // check face blocks
    std::vector<std::string> faceblocks;
    mesh->getFaceBlockNames(faceblocks);
    TEST_EQUALITY((int) faceblocks.size(),1);
-   out << "Edge Blocks: ";
-   for(std::size_t j=0;j<faceblocks.size();++j)
-      out << "\"" << faceblocks[j] << "\" ";
-   out << std::endl;
 
    mesh->writeToExodus("meshes/face_block_check2.gen");
-   TEST_EQUALITY(mesh->getSideRank(),mesh->getFaceRank());
-   TEST_EQUALITY(mesh->getEntityCounts(mesh->getElementRank()),40);
-   TEST_EQUALITY(mesh->getEntityCounts(mesh->getSideRank()),158);
-   TEST_EQUALITY(mesh->getEntityCounts(mesh->getNodeRank()),90);
+
+   edge_face_block_test_helper(out,
+                               success,
+                               "meshes/face_block_check2.gen",
+                               0,
+                               1);
    }
 }
 

--- a/packages/panzer/adapters-stk/test/stk_interface_test/tSquareQuadMeshFactory.cpp
+++ b/packages/panzer/adapters-stk/test/stk_interface_test/tSquareQuadMeshFactory.cpp
@@ -63,6 +63,11 @@
 #include "stk_mesh/base/GetEntities.hpp"
 #include "stk_mesh/base/Selector.hpp"
 
+#include "Ioss_DatabaseIO.h"
+#include "Ioss_IOFactory.h"
+#include "Ioss_Region.h"
+#include "Ioss_EdgeBlock.h"
+
 namespace panzer_stk {
 
 inline bool XOR(bool A,bool B)
@@ -87,6 +92,34 @@ static const double * getNode(const Teuchos::RCP<const STK_Interface> & mesh, st
    return mesh->getNodeCoordinates(nodeIds[id]); 
 }
 */
+
+void edge_block_test_helper(Teuchos::FancyOStream &out,
+                            bool &success,
+                            Teuchos::RCP<Teuchos::ParameterList> pl,
+                            std::string exodus_filename,
+                            int expected_edge_block_count)
+{
+   SquareQuadMeshFactory factory; 
+   factory.setParameterList(pl);
+   Teuchos::RCP<STK_Interface> mesh = factory.buildMesh(MPI_COMM_WORLD);
+   TEST_ASSERT(mesh!=Teuchos::null);
+ 
+   if(mesh->isWritable())
+      mesh->writeToExodus(exodus_filename.c_str());
+
+   {
+   Ioss::DatabaseIO *db_io = Ioss::IOFactory::create("exodus", 
+                                                     exodus_filename.c_str(), 
+                                                     Ioss::READ_MODEL);
+   TEST_ASSERT(db_io);
+
+   Ioss::Region region(db_io);
+   TEST_ASSERT(db_io->ok() == true);
+
+   auto all_edge_blocks = region.get_edge_blocks();
+   TEST_ASSERT(all_edge_blocks.size() == expected_edge_block_count);
+   }
+}
 
 TEUCHOS_UNIT_TEST(tSquareQuadMeshFactory, periodic_input)
 {
@@ -895,4 +928,36 @@ void test4(Teuchos::FancyOStream &out, bool &success,MPI_Comm & comm)
    else TEST_ASSERT(false);
 }
 
+TEUCHOS_UNIT_TEST(tSquareQuadMeshFactory, default_edge_blocks)
+{
+   using Teuchos::RCP;
+
+   int xe = 2, ye = 2;
+   int bx = 1, by = 1;
+
+   RCP<Teuchos::ParameterList> pl = rcp(new Teuchos::ParameterList);
+   pl->set("X Blocks",bx);
+   pl->set("Y Blocks",by);
+   pl->set("X Elements",xe);
+   pl->set("Y Elements",ye);
+
+   edge_block_test_helper(out, success, pl, "SquareQuad_default_edge_blocks.exo", 0);
+}
+
+TEUCHOS_UNIT_TEST(tSquareQuadMeshFactory, create_edge_blocks_pl)
+{
+   using Teuchos::RCP;
+
+   int xe = 2, ye = 2;
+   int bx = 1, by = 1;
+
+   RCP<Teuchos::ParameterList> pl = rcp(new Teuchos::ParameterList);
+   pl->set("X Blocks",bx);
+   pl->set("Y Blocks",by);
+   pl->set("X Elements",xe);
+   pl->set("Y Elements",ye);
+   pl->set("Create Edge Blocks",true);
+
+   edge_block_test_helper(out, success, pl, "SquareQuad_create_edge_blocks_pl.exo", 1);
+}
 }

--- a/packages/panzer/adapters-stk/test/stk_interface_test/tSquareQuadMeshFactory.cpp
+++ b/packages/panzer/adapters-stk/test/stk_interface_test/tSquareQuadMeshFactory.cpp
@@ -97,7 +97,7 @@ void edge_block_test_helper(Teuchos::FancyOStream &out,
                             bool &success,
                             Teuchos::RCP<Teuchos::ParameterList> pl,
                             std::string exodus_filename,
-                            int expected_edge_block_count)
+                            uint32_t expected_edge_block_count)
 {
    SquareQuadMeshFactory factory; 
    factory.setParameterList(pl);

--- a/packages/panzer/adapters-stk/test/stk_interface_test/tSquareTriMeshFactory.cpp
+++ b/packages/panzer/adapters-stk/test/stk_interface_test/tSquareTriMeshFactory.cpp
@@ -67,7 +67,7 @@ void edge_block_test_helper(Teuchos::FancyOStream &out,
                             bool &success,
                             Teuchos::RCP<Teuchos::ParameterList> pl,
                             std::string exodus_filename,
-                            int expected_edge_block_count)
+                            uint32_t expected_edge_block_count)
 {
    SquareTriMeshFactory factory; 
    factory.setParameterList(pl);

--- a/packages/panzer/adapters-stk/test/stk_interface_test/tSquareTriMeshFactory.cpp
+++ b/packages/panzer/adapters-stk/test/stk_interface_test/tSquareTriMeshFactory.cpp
@@ -56,7 +56,40 @@
 #include "stk_mesh/base/GetEntities.hpp"
 #include "stk_mesh/base/Selector.hpp"
 
+#include "Ioss_DatabaseIO.h"
+#include "Ioss_IOFactory.h"
+#include "Ioss_Region.h"
+#include "Ioss_EdgeBlock.h"
+
 namespace panzer_stk {
+
+void edge_block_test_helper(Teuchos::FancyOStream &out,
+                            bool &success,
+                            Teuchos::RCP<Teuchos::ParameterList> pl,
+                            std::string exodus_filename,
+                            int expected_edge_block_count)
+{
+   SquareTriMeshFactory factory; 
+   factory.setParameterList(pl);
+   Teuchos::RCP<STK_Interface> mesh = factory.buildMesh(MPI_COMM_WORLD);
+   TEST_ASSERT(mesh!=Teuchos::null);
+ 
+   if(mesh->isWritable())
+      mesh->writeToExodus(exodus_filename.c_str());
+
+   {
+   Ioss::DatabaseIO *db_io = Ioss::IOFactory::create("exodus", 
+                                                     exodus_filename.c_str(), 
+                                                     Ioss::READ_MODEL);
+   TEST_ASSERT(db_io);
+
+   Ioss::Region region(db_io);
+   TEST_ASSERT(db_io->ok() == true);
+
+   auto all_edge_blocks = region.get_edge_blocks();
+   TEST_ASSERT(all_edge_blocks.size() == expected_edge_block_count);
+   }
+}
 
 TEUCHOS_UNIT_TEST(tSquareTriMeshFactory, defaults)
 {
@@ -96,6 +129,39 @@ TEUCHOS_UNIT_TEST(tSquareTriMeshFactory, defaults)
  
    TEST_EQUALITY(nodesets.size(),1);
    TEST_EQUALITY(nodesets[0],"origin");
+}
+
+TEUCHOS_UNIT_TEST(tSquareTriMeshFactory, default_edge_face_blocks)
+{
+   using Teuchos::RCP;
+
+   int xe = 2, ye = 2;
+   int bx = 1, by = 1;
+
+   RCP<Teuchos::ParameterList> pl = rcp(new Teuchos::ParameterList);
+   pl->set("X Blocks",bx);
+   pl->set("Y Blocks",by);
+   pl->set("X Elements",xe);
+   pl->set("Y Elements",ye);
+
+   edge_block_test_helper(out, success, pl, "SquareTri_default_edge_blocks.exo", 0);
+}
+
+TEUCHOS_UNIT_TEST(tSquareTriMeshFactory, create_edge_blocks_pl)
+{
+   using Teuchos::RCP;
+
+   int xe = 2, ye = 2;
+   int bx = 1, by = 1;
+
+   RCP<Teuchos::ParameterList> pl = rcp(new Teuchos::ParameterList);
+   pl->set("X Blocks",bx);
+   pl->set("Y Blocks",by);
+   pl->set("X Elements",xe);
+   pl->set("Y Elements",ye);
+   pl->set("Create Edge Blocks",true);
+
+   edge_block_test_helper(out, success, pl, "SquareTri_create_edge_blocks_pl.exo", 1);
 }
 
 }


### PR DESCRIPTION
@trilinos/panzer 

## Motivation
The CubeHex, CubeTet, SquareQuad and SquareTri mesh factories and Exodus reader had inconsistent parameter names and defaults for the creation of edge and face blocks.  This PR gives all of them 2 parameters (`Create Edge Blocks` and `Create Face Blocks`) which default to `false`.  In addition, if the CubeHex parameter `Build Subcells` is `false` both of the new parameters will forced to `false` and a message printed to `out`.

## Related Issues

* Closes #9447
* Is blocked by #9490
* Follows #9490

## Testing
Each factory has an associated test that has been updated with new tests to cover the new parameters.  The `tExodusEdgeBlock` and `tExodusFaceBlock` tests have been updated also.
