### PR TITLE
Fixed include ordering errors, create_mirror_view now works for panze…

### DIFF
--- a/packages/phalanx/src/Phalanx_KokkosDeviceTypes.hpp
+++ b/packages/phalanx/src/Phalanx_KokkosDeviceTypes.hpp
@@ -2,8 +2,9 @@
 #define PHALANX_KOKKOS_DEVICE_TYPES_HPP
 
 //Kokkos includes
-#include "Kokkos_Core.hpp"
 #include "Kokkos_View_Fad.hpp"
+#include "Kokkos_DynRankView_Fad.hpp"
+#include "Kokkos_Core.hpp"
 #include "Phalanx_config.hpp"
 #include "Sacado_Fad_ExpressionTraits.hpp"
 #include <type_traits>

--- a/packages/phalanx/src/Phalanx_Traits.hpp
+++ b/packages/phalanx/src/Phalanx_Traits.hpp
@@ -45,8 +45,9 @@
 #ifndef PHX_TRAITS_HPP
 #define PHX_TRAITS_HPP
 
-#include "Kokkos_View.hpp"
 #include "Kokkos_View_Fad.hpp"
+#include "Kokkos_DynRankView_Fad.hpp"
+#include "Kokkos_View.hpp"
 #include "Phalanx_config.hpp"
 
 namespace PHX {


### PR DESCRIPTION
Fixed it so you can create_mirror_views without UVM enabled. 
@trilinos/phalanx 