### PR TITLE
Piro: work on the Hessain based implementation of ROL dot product

### DIFF
--- a/packages/piro/src/Piro_ThyraProductME_Objective_SimOpt.hpp
+++ b/packages/piro/src/Piro_ThyraProductME_Objective_SimOpt.hpp
@@ -268,14 +268,15 @@ public:
 
   void hessian_22(const Teuchos::RCP<Thyra::PhysicallyBlockedLinearOpBase<Real>> H,
                   const ROL::Vector<Real> &u,
-                  const ROL::Vector<Real> &z) {
+                  const ROL::Vector<Real> &z,
+                  const int g_idx) {
     if(verbosityLevel >= Teuchos::VERB_MEDIUM)
       *out << "ROL::ThyraProductME_Objective_SimOpt::hessian_22" << std::endl;
 
     Thyra::ModelEvaluatorBase::OutArgs<Real> outArgs = thyra_model.createOutArgs();
     bool supports_deriv = true;
     for(std::size_t i=0; i<p_indices.size(); ++i)
-      supports_deriv = supports_deriv &&  outArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_hess_g_pp, g_index, p_indices[i], p_indices[i]);
+      supports_deriv = supports_deriv &&  outArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_hess_g_pp, g_idx, p_indices[i], p_indices[i]);
 
     if(supports_deriv) { //use derivatives computed by model evaluator
       const ROL::ThyraVector<Real>  & thyra_p = dynamic_cast<const ROL::ThyraVector<Real>&>(z);
@@ -294,18 +295,18 @@ public:
       }
       inArgs.set_x(thyra_x.getVector());
 
-      Teuchos::RCP< Thyra::VectorBase<Real> > multiplier_g = Thyra::createMember<Real>(thyra_model.get_g_multiplier_space(g_index));
+      Teuchos::RCP< Thyra::VectorBase<Real> > multiplier_g = Thyra::createMember<Real>(thyra_model.get_g_multiplier_space(g_idx));
       Thyra::put_scalar(1.0, multiplier_g.ptr());
-      inArgs.set_g_multiplier(g_index, multiplier_g);
+      inArgs.set_g_multiplier(g_idx, multiplier_g);
 
       Thyra::ModelEvaluatorBase::OutArgs<Real> outArgs = thyra_model.createOutArgs();
 
       for(std::size_t i=0; i<p_indices.size(); ++i) {
-        bool supports_deriv = outArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_hess_g_pp, g_index, p_indices[i], p_indices[i]);
+        bool supports_deriv = outArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_hess_g_pp, g_idx, p_indices[i], p_indices[i]);
         ROL_TEST_FOR_EXCEPTION( !supports_deriv, std::logic_error, "ROL::ThyraProductME_Objective_SimOpt: H_pp is not supported");
 
-        Teuchos::RCP<Thyra::LinearOpBase<Real>> hess_g_pp = thyra_model.create_hess_g_pp(g_index, p_indices[i], p_indices[i]);
-        outArgs.set_hess_g_pp(g_index, p_indices[i], p_indices[i], hess_g_pp);
+        Teuchos::RCP<Thyra::LinearOpBase<Real>> hess_g_pp = thyra_model.create_hess_g_pp(g_idx, p_indices[i], p_indices[i]);
+        outArgs.set_hess_g_pp(g_idx, p_indices[i], p_indices[i], hess_g_pp);
         H->setBlock(p_indices[i], p_indices[i], hess_g_pp);
       }
       H->endBlockFill();

--- a/packages/piro/test/_input_Analysis_ROL_Tpetra.xml
+++ b/packages/piro/test/_input_Analysis_ROL_Tpetra.xml
@@ -181,7 +181,40 @@
 
         <Parameter name="Step Method" type="string" value="Line Search" />
         <Parameter name="Full Space" type="bool" value="false" />
-        <Parameter name="Hessian Dot Product" type="bool" value="true" />
+        
+        <ParameterList name="Matrix Based Dot Product">
+          <Parameter name="Matrix Type" type="string" value="Hessian Of Response" />
+          <ParameterList name="Matrix Types">
+            <ParameterList name="Hessian Of Response">
+              <Parameter name="Response Index" type="int" value="0" />
+              <ParameterList name="Block Diagonal Solver">
+                <ParameterList name="Block 0">
+                  <Parameter name="Linear Solver Type" type="string" value="Belos" />
+                  <ParameterList name="Linear Solver Types">
+                    <ParameterList name="Belos">
+                      <Parameter name="Solver Type" type="string" value="Block GMRES" />
+                      <ParameterList name="Solver Types">
+                        <ParameterList name="Block GMRES">
+                          <Parameter name="Maximum Iterations" type="int" value="200" />
+                          <Parameter name="Num Blocks" type="int" value="200" />
+                          <Parameter name="Verbosity" type="int" value="33" />
+                          <Parameter name="Output Frequency" type="int" value="20" />
+                          <Parameter name="Output Style" type="int" value="1" />
+                          <Parameter name="Convergence Tolerance" type="double" value="1e-7" />
+                        </ParameterList>
+                      </ParameterList>
+                      <ParameterList name="VerboseObject">
+                        <Parameter name="Verbosity Level" type="string" value="medium" />
+                      </ParameterList>
+                    </ParameterList>
+                  </ParameterList>
+                  <Parameter name="Preconditioner Type" type="string" value="None" />
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+          
         <Parameter name="Use NOX Solver" type="bool" value="false" />
 
         <!-- =========== BEGIN ROL INPUT PARAMETER SUBLIST =========== -->


### PR DESCRIPTION
Generalization of  the parameter list for defining Hessian based dot product.
Now the parameter list looks like:

```
  Matrix Based Dot Product:
    Matrix Type: Hessian Of Response
    Matrix Types:
      Hessian Of Response:
        Response Index: 0
        Block Diagonal Solver:
          Block 0:
            Linear Solver Type: Belos
```

At the moment `Matrix Type` can either be `Identity` (usual l2 dot product) or the `Hessian Of Response`.
The user also has to provide the Index of the Reponse used to compute the Hessian dot product

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/piro

## Motivation
This makes the input file easier to read and allows to future extension to different matrix based dot product.

<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->


## Testing

Modified Piro test input file to exercise the new syntax.

