### PR TITLE
Teuchos: Fix TimeMonitor in MPI builds if MPI not initialized. 

### DIFF
--- a/packages/teuchos/comm/src/Teuchos_TimeMonitor.cpp
+++ b/packages/teuchos/comm/src/Teuchos_TimeMonitor.cpp
@@ -878,7 +878,7 @@ namespace Teuchos {
       // this should be a "serial" (no MPI, one "process")
       // communicator.
 
-      Teuchos::RCP<const Teuchos::Comm<OrdinalType> > comm;
+      Teuchos::RCP<const Teuchos::Comm<int> > comm;
 
   #ifdef HAVE_MPI
       int mpiStarted = 0;


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/teuchos 

## Motivation
This fix is similar to PR #7803.  For builds with MPI enabled but MPI has not been initialized.  Allows user to call Teuchos::TimeMonitor functions without crashing.  The previous version was crashing at the call to `getComm` before reaching the `#ifdef HAVE_MPI` logic. 

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->






<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->