### PR TITLE
MueLu: Adding complete hierarchy Factory graph dump capability

### DIFF
--- a/packages/muelu/doc/UsersGuide/masterList.xml
+++ b/packages/muelu/doc/UsersGuide/masterList.xml
@@ -1766,8 +1766,8 @@ optimized neighbor discovery for Importer construction.</description>
     <parameter>
       <name>debug: graph level</name>
       <type>int</type>
-      <default>-1</default>
-      <description>Output dependency graph.</description>
+      <default>-2</default>
+      <description>Output dependency graph on level X (use -1 for all levels).</description>
       <comment-ML>not supported by ML</comment-ML>
       <visible>false</visible>
     </parameter>

--- a/packages/muelu/doc/UsersGuide/paramlist_hidden.tex
+++ b/packages/muelu/doc/UsersGuide/paramlist_hidden.tex
@@ -395,7 +395,7 @@ optimized neighbor discovery for Importer construction.}
         
 \cba{amgx:params}{\parameterlist}{Sublist for listing AMGX configuration parameters}
         
-\cbb{debug: graph level}{int}{-1}{Output dependency graph.}
+\cbb{debug: graph level}{int}{-2}{Output dependency graph on level X (use -1 for all levels).}
         
 \cbb{refmaxwell: mode}{string}{"additive"}{Specifying the order of solve of the block system. Allowed values are: "additive" (default), "121", "212", "1", "2"}
         

--- a/packages/muelu/src/Interface/MueLu_HierarchyManager.hpp
+++ b/packages/muelu/src/Interface/MueLu_HierarchyManager.hpp
@@ -95,7 +95,8 @@ namespace MueLu {
         implicitTranspose_      (MasterList::getDefault<bool>("transpose: use implicit")),
         fuseProlongationAndUpdate_ (MasterList::getDefault<bool>("fuse prolongation and update")),
         sizeOfMultiVectors_     (MasterList::getDefault<int>("number of vectors")),
-        graphOutputLevel_(-1) { }
+        // -2 = no output, -1 = all levels
+        graphOutputLevel_(-2) { }
 
     //!
     virtual ~HierarchyManager() { }
@@ -173,7 +174,7 @@ namespace MueLu {
       // Setup Hierarchy
       H.SetMaxCoarseSize(maxCoarseSize_);
       VerboseObject::SetDefaultVerbLevel(verbosity_);
-      if (graphOutputLevel_ >= 0)
+      if (graphOutputLevel_ >= 0 || graphOutputLevel_ == -1)
         H.EnableGraphDumping("dep_graph", graphOutputLevel_);
 
       if (VerboseObject::IsPrint(Statistics2)) {

--- a/packages/muelu/src/MueCentral/MueLu_Hierarchy_decl.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_Hierarchy_decl.hpp
@@ -169,7 +169,7 @@ namespace MueLu {
 
   private:
     int  LastLevelID()      const { return Levels_.size() - 1; }
-    void DumpCurrentGraph() const;
+    void DumpCurrentGraph(int level) const;
 
   public:
 
@@ -404,6 +404,7 @@ namespace MueLu {
     If enabled, we dump the graph on a specified level into a specified file
     */
     bool isDumpingEnabled_;
+    // -1 = dump all levels, -2 = dump nothing
     int  dumpLevel_;
     std::string dumpFile_;
 

--- a/packages/muelu/src/MueCentral/MueLu_MasterList.cpp
+++ b/packages/muelu/src/MueCentral/MueLu_MasterList.cpp
@@ -348,7 +348,7 @@ namespace MueLu {
   "<Parameter name=\"reuse: type\" type=\"string\" value=\"none\"/>"
   "<Parameter name=\"use external multigrid package\" type=\"string\" value=\"none\"/>"
   "<ParameterList name=\"amgx:params\"/>"
-  "<Parameter name=\"debug: graph level\" type=\"int\" value=\"-1\"/>"
+  "<Parameter name=\"debug: graph level\" type=\"int\" value=\"-2\"/>"
   "<Parameter name=\"refmaxwell: mode\" type=\"string\" value=\"additive\"/>"
   "<Parameter name=\"refmaxwell: disable addon\" type=\"bool\" value=\"true\"/>"
   "<ParameterList name=\"refmaxwell: 11list\"/>"


### PR DESCRIPTION
If you set:
```
    <Parameter name="debug: graph level" type="int" value="-1"/>
```

you now get *all* the levels.


Tests: n/a (debugging capability)

Issue: n/a (non-ASC)

Stakeholder feedback: n/a (developer-only feature).



