### PR TITLE
Belos: Fix Output Style Crash, Issue #9522

### DIFF
--- a/packages/belos/src/BelosPseudoBlockGmresSolMgr.hpp
+++ b/packages/belos/src/BelosPseudoBlockGmresSolMgr.hpp
@@ -708,7 +708,7 @@ setParameters (const Teuchos::RCP<Teuchos::ParameterList>& params)
     }
 
     // Update parameter in our list.
-    params_->set ("Output Style", verbosity_);
+    params_->set ("Output Style", outputStyle_);
     if (! outputTest_.is_null ()) {
       isSTSet_ = false;
     }

--- a/packages/belos/src/BelosStatusTestOutputFactory.hpp
+++ b/packages/belos/src/BelosStatusTestOutputFactory.hpp
@@ -141,7 +141,16 @@ class StatusTestOutputFactory {
           outputTest = Teuchos::rcp( new StatusTestUserOutput<ScalarType,MV,OP>( printer, test, taggedTests_, 1 ) );
         }
         break;
+      default: //Default to General if invalid outputStyle_ given.
+        if (mod > 0) {
+          outputTest = Teuchos::rcp( new StatusTestGeneralOutput<ScalarType,MV,OP>( printer, test, mod, printStates ) );
+        }
+        else {
+          outputTest = Teuchos::rcp( new StatusTestGeneralOutput<ScalarType,MV,OP>( printer, test, 1 ) );
+        }
+        break;
       }
+
 
       return outputTest;
     }


### PR DESCRIPTION
@trilinos/belos 

This PR addresses issue #9522 where the PseudoBlockGmresSolMgr was crashing due to an attempt to change the Output Style.  The Output Factory was getting invalid input.  I have fixed the pseudoblock GMRES solver manager to pass in the correct input.  I have also added a 'default' case to the output factory so that it cannot crash due to an invalid output style. 

I checked the other Belos solver managers, and none of them seem to have the same issue of passing invalid input to the Output Factory.  

Note: An alternative (possibly more 'correct') fix for this issue would have been to change the Output Factory to accept a `Belos::OutputType` instead of `int`.  Since this change would require updating all the solver managers, I did not make that change at this time.  