### PR TITLE
This just changes the python job name to match the jenkins job

### DIFF
--- a/packages/framework/pr_tools/pullrequest-specs.ini
+++ b/packages/framework/pr_tools/pullrequest-specs.ini
@@ -11,7 +11,7 @@
 # - `package_subproject_list.cmake` and
 #
 # Instead of using the TriBiTS tool to determine changes.
-Trilinos-pullrequest-python-3: TrilinosFrameworkTests
+python-3: TrilinosFrameworkTests
 Trilinos-pullrequest-gcc-8.3.0-installation-testing A: Teuchos
 Trilinos-pullrequest-gcc-8.3.0-installation-testing B: Tpetra
 #

--- a/packages/framework/pr_tools/trilinosprhelpers/unittests/pullrequest-specs.ini
+++ b/packages/framework/pr_tools/trilinosprhelpers/unittests/pullrequest-specs.ini
@@ -11,7 +11,7 @@
 # - `package_subproject_list.cmake` and
 #
 # Instead of using the TriBiTS tool to determine changes.
-Trilinos-pullrequest-python-3: TrilinosFrameworkTests
+python-3: TrilinosFrameworkTests
 Trilinos-pullrequest-gcc-8.3.0-installation-testing A: Teuchos
 Trilinos-pullrequest-gcc-8.3.0-installation-testing B: Tpetra
 #

--- a/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationBase.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationBase.py
@@ -246,8 +246,8 @@ class TrilinosPRConfigurationTest(unittest.TestCase):
         Generate dummy command line arguments
         """
         args = copy.deepcopy(self.dummy_args())
-        args.pullrequest_build_name = "Trilinos-pullrequest-python-3"
-        args.genconfig_build_name = "Trilinos-pullrequest-python-3"
+        args.pullrequest_build_name = "python-3"
+        args.genconfig_build_name = "python-3"
         return args
 
 
@@ -363,7 +363,7 @@ class TrilinosPRConfigurationTest(unittest.TestCase):
         self.assertEqual(build_name, expected_build_name)
 
 
-    def test_TrilinosPRConfigurationBasePackageEnablesPython2(self):
+    def test_TrilinosPRConfigurationBasePackageEnablesPython3(self):
         print("")
         args = self.dummy_args_python3()
         pr_config = trilinosprhelpers.TrilinosPRConfigurationBase(args)
@@ -380,7 +380,7 @@ class TrilinosPRConfigurationTest(unittest.TestCase):
                 m_open.assert_has_calls(calls, any_order=True)
 
 
-    def test_TrilinosPRConfigurationBasePackageEnablesPython2_dryrun(self):
+    def test_TrilinosPRConfigurationBasePackageEnablesPython3_dryrun(self):
         """
         Test the PackageEnables generator in DryRun mode
         """

--- a/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationStandard.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationStandard.py
@@ -232,7 +232,7 @@ class TrilinosPRConfigurationStandardTest(TestCase):
         - Change args to enable dry_run mode.
         """
         args = self.dummy_args()
-        args.pullrequest_build_name = "Trilinos-pullrequest-python-3"
+        args.pullrequest_build_name = "python-3"
         pr_config = trilinosprhelpers.TrilinosPRConfigurationStandard(args)
 
         # prepare step


### PR DESCRIPTION
Without this the python job will build and test
everything the gcc 7.2 job does as we do not
generate a specific packageEnables.cmake file
but instead use the one based on the diffs.

@trilinos/framework 

## Motivation
Too much testing 

## Testing
Used the unit testing after changing the default

