### PR TITLE
MueLu: fix misleading indentation in unit test

### DIFF
--- a/packages/muelu/test/unit_tests/MapTransferFactory.cpp
+++ b/packages/muelu/test/unit_tests/MapTransferFactory.cpp
@@ -704,9 +704,10 @@ namespace MueLuTests {
     ArrayView<const GO> allRowGIDs = A->getRowMap()->getNodeElementList();
     Array<GO> myMapGIDs;
     for (LO lid = 0; lid < Teuchos::as<LO>(nx); ++lid) {
-      if (lid % 3 == 0)
+      if (lid % 3 == 0) {
         myMapGIDs.push_back(allRowGIDs[lid]);
         myMapGIDs.push_back(allRowGIDs[lid+1]);
+      }
     }
     GO gNumFineEntries = 0;
     reduceAll(*comm, Teuchos::REDUCE_SUM, Teuchos::as<GO>(myMapGIDs.size()), Teuchos::outArg(gNumFineEntries));


### PR DESCRIPTION
@trilinos/muelu 

## Motivation

Fix mismatch in indentation and curly braces around the body of an `if`-statement in a unit test of the `MapTransferFactory`.

## Related Issues

* Closes #9484 

## Stakeholder Feedback

n/a

## Testing

Existing tests pass. I also have verified, that the intention of the modified test is not altered and that it still tests the same feature of the `MapTransferFactory`.
