### PR TITLE
Tpetra: Remove Distributor from pack/unpack interfaces (WIP)

### DIFF
--- a/packages/tpetra/core/inout/Tpetra_Details_CooMatrix.hpp
+++ b/packages/tpetra/core/inout/Tpetra_Details_CooMatrix.hpp
@@ -1209,8 +1209,7 @@ protected:
      buffer_device_type>& exports,
    Kokkos::DualView<size_t*,
      buffer_device_type> numPacketsPerLID,
-   size_t& constantNumPackets,
-   ::Tpetra::Distributor& /* distor */)
+   size_t& constantNumPackets)
   {
     using Teuchos::Comm;
     using Teuchos::RCP;
@@ -1406,7 +1405,6 @@ protected:
    Kokkos::DualView<size_t*,
      buffer_device_type> numPacketsPerLID,
    const size_t /* constantNumPackets */,
-   ::Tpetra::Distributor& /* distor */,
    const ::Tpetra::CombineMode /* combineMode */)
   {
     using Teuchos::Comm;

--- a/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_decl.hpp
@@ -740,8 +740,7 @@ protected:
      buffer_device_type>& exports,
    Kokkos::DualView<size_t*,
      buffer_device_type> numPacketsPerLID,
-   size_t& constantNumPackets,
-   Distributor& /* distor */) override;
+   size_t& constantNumPackets) override;
 
   virtual void
   unpackAndCombine
@@ -752,7 +751,6 @@ protected:
    Kokkos::DualView<size_t*,
      buffer_device_type> numPacketsPerLID,
    const size_t constantNumPackets,
-   Distributor& /* distor */,
    const CombineMode combineMode) override;
   //@}
 

--- a/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_def.hpp
@@ -2377,8 +2377,7 @@ public:
      buffer_device_type>& exports, // output
    Kokkos::DualView<size_t*,
      buffer_device_type> numPacketsPerLID, // output
-   size_t& constantNumPackets,
-   Distributor& /* distor */)
+   size_t& constantNumPackets)
   {
     using ::Tpetra::Details::Behavior;
     using ::Tpetra::Details::dualViewStatusToString;
@@ -2634,7 +2633,6 @@ public:
    Kokkos::DualView<size_t*,
      buffer_device_type> numPacketsPerLID,
    const size_t /* constantNumPackets */,
-   Distributor& /* distor */,
    const CombineMode combineMode)
   {
     using ::Tpetra::Details::Behavior;

--- a/packages/tpetra/core/src/Tpetra_BlockMultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockMultiVector_decl.hpp
@@ -665,8 +665,7 @@ protected:
      buffer_device_type>& exports,
    Kokkos::DualView<size_t*,
      buffer_device_type> numPacketsPerLID,
-   size_t& constantNumPackets,
-   Distributor& distor);
+   size_t& constantNumPackets);
 
   virtual void
   unpackAndCombine
@@ -677,7 +676,6 @@ protected:
    Kokkos::DualView<size_t*,
      buffer_device_type> numPacketsPerLID,
    const size_t constantNumPackets,
-   Distributor& distor,
    const CombineMode combineMode);
 
   //@}

--- a/packages/tpetra/core/src/Tpetra_BlockMultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockMultiVector_def.hpp
@@ -571,8 +571,7 @@ packAndPrepare
  buffer_device_type>& exports,
  Kokkos::DualView<size_t*,
  buffer_device_type> numPacketsPerLID,
- size_t& constantNumPackets,
- Distributor& distor)
+ size_t& constantNumPackets)
 {
   TEUCHOS_TEST_FOR_EXCEPTION
     (true, std::logic_error,
@@ -590,7 +589,6 @@ unpackAndCombine
  Kokkos::DualView<size_t*,
  buffer_device_type> numPacketsPerLID,
  const size_t constantNumPackets,
- Distributor& distor,
  const CombineMode combineMode)
 {
   TEUCHOS_TEST_FOR_EXCEPTION

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -1302,22 +1302,19 @@ public:
       const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& exportLIDs,
       Kokkos::DualView<packet_type*, buffer_device_type>& exports,
       Kokkos::DualView<size_t*, buffer_device_type> numPacketsPerLID,
-      size_t& constantNumPackets,
-      Distributor& distor) override;
+      size_t& constantNumPackets) override;
 
     virtual void
     pack (const Teuchos::ArrayView<const local_ordinal_type>& exportLIDs,
           Teuchos::Array<global_ordinal_type>& exports,
           const Teuchos::ArrayView<size_t>& numPacketsPerLID,
-          size_t& constantNumPackets,
-          Distributor& distor) const override;
+          size_t& constantNumPackets) const override;
 
     void
     packFillActive (const Teuchos::ArrayView<const local_ordinal_type>& exportLIDs,
                     Teuchos::Array<global_ordinal_type>& exports,
                     const Teuchos::ArrayView<size_t>& numPacketsPerLID,
-                    size_t& constantNumPackets,
-                    Distributor& distor) const;
+                    size_t& constantNumPackets) const;
 
     void
     packFillActiveNew (const Kokkos::DualView<const local_ordinal_type*,
@@ -1326,8 +1323,7 @@ public:
                          buffer_device_type>& exports,
                        Kokkos::DualView<size_t*,
                          buffer_device_type> numPacketsPerLID,
-                       size_t& constantNumPackets,
-                       Distributor& distor) const;
+                       size_t& constantNumPackets) const;
 
     virtual void
     unpackAndCombine
@@ -1338,7 +1334,6 @@ public:
      Kokkos::DualView<size_t*,
        buffer_device_type> numPacketsPerLID,
      const size_t constantNumPackets,
-     Distributor& distor,
      const CombineMode combineMode) override;
 
     //@}

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -5690,8 +5690,7 @@ namespace Tpetra {
      buffer_device_type>& exports,
    Kokkos::DualView<size_t*,
      buffer_device_type> numPacketsPerLID,
-   size_t& constantNumPackets,
-   Distributor& distor)
+   size_t& constantNumPackets)
   {
     using Tpetra::Details::ProfilingRegion;
     using GO = global_ordinal_type;
@@ -5759,7 +5758,7 @@ namespace Tpetra {
       ArrayView<size_t> numPacketsPerLID_av (numPacketsPerLID_h.data (),
                                              numPacketsPerLID_h.extent (0));
       srcRowGraphPtr->pack (exportLIDs_av, exports_a, numPacketsPerLID_av,
-                            constantNumPackets, distor);
+                            constantNumPackets);
       const size_t newSize = static_cast<size_t> (exports_a.size ());
       if (static_cast<size_t> (exports.extent (0)) != newSize) {
         using exports_dv_type = Kokkos::DualView<packet_type*, buffer_device_type>;
@@ -5788,11 +5787,11 @@ namespace Tpetra {
       using Tpetra::Details::packCrsGraphNew;
       packCrsGraphNew<LO,GO,NT> (*srcCrsGraphPtr, exportLIDs, exportPIDs,
                                  exports, numPacketsPerLID,
-                                 constantNumPackets, false, distor);
+                                 constantNumPackets, false);
     }
     else {
       srcCrsGraphPtr->packFillActiveNew (exportLIDs, exports, numPacketsPerLID,
-                                         constantNumPackets, distor);
+                                         constantNumPackets);
     }
 
     if (verbose) {
@@ -5808,19 +5807,18 @@ namespace Tpetra {
   pack (const Teuchos::ArrayView<const LocalOrdinal>& exportLIDs,
         Teuchos::Array<GlobalOrdinal>& exports,
         const Teuchos::ArrayView<size_t>& numPacketsPerLID,
-        size_t& constantNumPackets,
-        Distributor& distor) const
+        size_t& constantNumPackets) const
   {
     auto col_map = this->getColMap();
     // packCrsGraph requires k_rowPtrsPacked to be set
     if( !col_map.is_null() && (rowPtrsPacked_dev_.extent(0) != 0  ||  getRowMap()->getNodeNumElements() ==0)) {
       using Tpetra::Details::packCrsGraph;
       packCrsGraph<LocalOrdinal,GlobalOrdinal,Node>(*this, exports, numPacketsPerLID,
-                                                    exportLIDs, constantNumPackets, distor);
+                                                    exportLIDs, constantNumPackets);
     }
     else {
       this->packFillActive(exportLIDs, exports, numPacketsPerLID,
-                           constantNumPackets, distor);
+                           constantNumPackets);
     }
   }
 
@@ -5830,8 +5828,7 @@ namespace Tpetra {
   packFillActive (const Teuchos::ArrayView<const LocalOrdinal>& exportLIDs,
                   Teuchos::Array<GlobalOrdinal>& exports,
                   const Teuchos::ArrayView<size_t>& numPacketsPerLID,
-                  size_t& constantNumPackets,
-                  Distributor& /* distor */) const
+                  size_t& constantNumPackets) const
   {
     using std::endl;
     using LO = LocalOrdinal;
@@ -6021,8 +6018,7 @@ namespace Tpetra {
                        buffer_device_type>& exports,
                      Kokkos::DualView<size_t*,
                        buffer_device_type> numPacketsPerLID,
-                     size_t& constantNumPackets,
-                     Distributor& distor) const
+                     size_t& constantNumPackets) const
   {
     using std::endl;
     using LO = local_ordinal_type;
@@ -6251,7 +6247,6 @@ namespace Tpetra {
    Kokkos::DualView<size_t*,
      buffer_device_type> numPacketsPerLID,
    const size_t /* constantNumPackets */,
-   Distributor& /* distor */,
    const CombineMode /* combineMode */ )
   {
     using Details::ProfilingRegion;
@@ -7067,7 +7062,7 @@ namespace Tpetra {
 
     // The basic algorithm here is:
     //
-    // 1. Call the moral equivalent of "distor.do" to handle the import.
+    // 1. Call the moral equivalent of "Distor.do" to handle the import.
     // 2. Copy all the Imported and Copy/Permuted data into the raw
     //    CrsGraph pointers, still using GIDs.
     // 3. Call an optimized version of MakeColMap that avoids the
@@ -7274,7 +7269,7 @@ namespace Tpetra {
       // Pack & Prepare w/ owning PIDs
       packCrsGraphWithOwningPIDs(*this, destGraph->exports_,
                                  numExportPacketsPerLID, ExportLIDs,
-                                 SourcePids, constantNumPackets, Distor);
+                                 SourcePids, constantNumPackets);
     }
 
     // Do the exchange of remote data.
@@ -7401,7 +7396,7 @@ namespace Tpetra {
     size_t mynnz =
       unpackAndCombineWithOwningPIDsCount(*this, RemoteLIDs, hostImports,
                                            numImportPacketsPerLID,
-                                           constantNumPackets, Distor, INSERT,
+                                           constantNumPackets, INSERT,
                                            NumSameIDs, PermuteToLIDs, PermuteFromLIDs);
     size_t N = BaseRowMap->getNodeNumElements();
 
@@ -7427,7 +7422,7 @@ namespace Tpetra {
     // takes five methods.
     unpackAndCombineIntoCrsArrays(*this, RemoteLIDs, hostImports,
                                   numImportPacketsPerLID, constantNumPackets,
-                                  Distor, INSERT, NumSameIDs, PermuteToLIDs,
+                                  INSERT, NumSameIDs, PermuteToLIDs,
                                   PermuteFromLIDs, N, mynnz, MyPID,
                                   CSR_rowptr(), CSR_colind_GID(),
                                   SourcePids(), TargetPids);

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -3074,8 +3074,7 @@ public:
        buffer_device_type>& exportLIDs,
      Kokkos::DualView<char*, buffer_device_type>& exports,
      Kokkos::DualView<size_t*, buffer_device_type> numPacketsPerLID,
-     size_t& constantNumPackets,
-     Distributor& distor) override;
+     size_t& constantNumPackets) override;
 
   private:
     /// \brief Unpack the imported column indices and values, and
@@ -3087,7 +3086,6 @@ public:
       Kokkos::DualView<char*, buffer_device_type> imports,
       Kokkos::DualView<size_t*, buffer_device_type> numPacketsPerLID,
       const size_t constantNumPackets,
-      Distributor& distor,
       const CombineMode combineMode,
       const bool verbose);
 
@@ -3100,7 +3098,6 @@ public:
       Kokkos::DualView<char*, buffer_device_type> imports,
       Kokkos::DualView<size_t*, buffer_device_type> numPacketsPerLID,
       const size_t constantNumPackets,
-      Distributor& distor,
       const CombineMode combineMode);
 
   public:
@@ -3119,7 +3116,6 @@ public:
      Kokkos::DualView<char*, buffer_device_type> imports,
      Kokkos::DualView<size_t*, buffer_device_type> numPacketsPerLID,
      const size_t constantNumPackets,
-     Distributor& distor,
      const CombineMode CM) override;
 
     /// \brief Pack this object's data for an Import or Export.
@@ -3138,8 +3134,6 @@ public:
     ///   output, then that number gives the constant number of
     ///   entries for all packed rows <i>on all processes in the
     ///   matrix's communicator</i>.
-    /// \param distor [in/out] The Distributor object which implements
-    ///   the Import or Export operation that is calling this method.
     ///
     /// \subsection Tpetra_CrsMatrix_packNew_summary Packing scheme
     ///
@@ -3233,8 +3227,7 @@ public:
     packNew (const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& exportLIDs,
              Kokkos::DualView<char*, buffer_device_type>& exports,
              const Kokkos::DualView<size_t*, buffer_device_type>& numPacketsPerLID,
-             size_t& constantNumPackets,
-             Distributor& dist) const;
+             size_t& constantNumPackets) const;
 
   private:
     /// \brief Pack this matrix (part of implementation of packAndPrepare).
@@ -3247,8 +3240,7 @@ public:
     packNonStaticNew (const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& exportLIDs,
                       Kokkos::DualView<char*, buffer_device_type>& exports,
                       const Kokkos::DualView<size_t*, buffer_device_type>& numPacketsPerLID,
-                      size_t& constantNumPackets,
-                      Distributor& distor) const;
+                      size_t& constantNumPackets) const;
 
     /// \brief Pack data for the current row to send.
     ///

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -6521,8 +6521,7 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
    const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& exportLIDs,
    Kokkos::DualView<char*, buffer_device_type>& exports,
    Kokkos::DualView<size_t*, buffer_device_type> numPacketsPerLID,
-   size_t& constantNumPackets,
-   Distributor& distor)
+   size_t& constantNumPackets)
   {
     using Details::Behavior;
     using Details::dualViewStatusToString;
@@ -6599,7 +6598,7 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       }
       try {
         srcCrsMat->packNew (exportLIDs, exports, numPacketsPerLID,
-                            constantNumPackets, distor);
+                            constantNumPackets);
       }
       catch (std::exception& e) {
         lclBad = 1;
@@ -6659,7 +6658,7 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       // Teuchos::Array* objects.
       try {
         srcRowMat->pack (exportLIDs_av, exports_a, numPacketsPerLID_av,
-                         constantNumPackets, distor);
+                         constantNumPackets);
       }
       catch (std::exception& e) {
         lclBad = 1;
@@ -6996,19 +6995,18 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   packNew (const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& exportLIDs,
            Kokkos::DualView<char*, buffer_device_type>& exports,
            const Kokkos::DualView<size_t*, buffer_device_type>& numPacketsPerLID,
-           size_t& constantNumPackets,
-           Distributor& dist) const
+           size_t& constantNumPackets) const
   {
     // The call to packNew in packAndPrepare catches and handles any exceptions.
     Details::ProfilingRegion region_pack_new("Tpetra::CrsMatrix::packNew", "Import/Export");
     if (this->isStaticGraph ()) {
       using ::Tpetra::Details::packCrsMatrixNew;
       packCrsMatrixNew (*this, exports, numPacketsPerLID, exportLIDs,
-                        constantNumPackets, dist);
+                        constantNumPackets);
     }
     else {
       this->packNonStaticNew (exportLIDs, exports, numPacketsPerLID,
-                              constantNumPackets, dist);
+                              constantNumPackets);
     }
   }
 
@@ -7018,8 +7016,7 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   packNonStaticNew (const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& exportLIDs,
                     Kokkos::DualView<char*, buffer_device_type>& exports,
                     const Kokkos::DualView<size_t*, buffer_device_type>& numPacketsPerLID,
-                    size_t& constantNumPackets,
-                    Distributor& /* distor */) const
+                    size_t& constantNumPackets) const
   {
     using Details::Behavior;
     using Details::dualViewStatusToString;
@@ -7302,7 +7299,6 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
    Kokkos::DualView<char*, buffer_device_type> imports,
    Kokkos::DualView<size_t*, buffer_device_type> numPacketsPerLID,
    const size_t constantNumPackets,
-   Distributor& distor,
    const CombineMode combineMode)
   {
     using Details::Behavior;
@@ -7374,7 +7370,7 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       int lclBad = 0;
       try {
         unpackAndCombineImpl(importLIDs, imports, numPacketsPerLID,
-                             constantNumPackets, distor, combineMode,
+                             constantNumPackets, combineMode,
                              verbose);
       } catch (std::exception& e) {
         lclBad = 1;
@@ -7401,7 +7397,7 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     }
     else {
       unpackAndCombineImpl(importLIDs, imports, numPacketsPerLID,
-                           constantNumPackets, distor, combineMode,
+                           constantNumPackets, combineMode,
                            verbose);
     }
 
@@ -7430,7 +7426,6 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     Kokkos::DualView<char*, buffer_device_type> imports,
     Kokkos::DualView<size_t*, buffer_device_type> numPacketsPerLID,
     const size_t constantNumPackets,
-    Distributor & distor,
     const CombineMode combineMode,
     const bool verbose)
   {
@@ -7460,7 +7455,7 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       using Details::unpackCrsMatrixAndCombineNew;
       unpackCrsMatrixAndCombineNew(*this, imports, numPacketsPerLID,
                                    importLIDs, constantNumPackets,
-                                   distor, combineMode);
+                                   combineMode);
     }
     else {
       {
@@ -7495,7 +7490,7 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       unpackAndCombineImplNonStatic(importLIDs, imports,
                                     numPacketsPerLID,
                                     constantNumPackets,
-                                    distor, combineMode);
+                                    combineMode);
     }
 
     if (verbose) {
@@ -7514,7 +7509,6 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     Kokkos::DualView<char*, buffer_device_type> imports,
     Kokkos::DualView<size_t*, buffer_device_type> numPacketsPerLID,
     const size_t constantNumPackets,
-    Distributor& distor,
     const CombineMode combineMode)
   {
     using Kokkos::View;
@@ -8348,7 +8342,7 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 
     // The basic algorithm here is:
     //
-    // 1. Call the moral equivalent of "distor.do" to handle the import.
+    // 1. Call the moral equivalent of "Distor.do" to handle the import.
     // 2. Copy all the Imported and Copy/Permuted data into the raw
     //    CrsMatrix / CrsGraphData pointers, still using GIDs.
     // 3. Call an optimized version of MakeColMap that avoids the
@@ -8603,8 +8597,7 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
                                      numExportPacketsPerLID,
                                      ExportLIDs,
                                      SourcePids,
-                                     constantNumPackets,
-                                     Distor);
+                                     constantNumPackets);
       }
       catch (std::exception& e) {
         errStrm << "Proc " << myRank << ": packCrsMatrixWithOwningPIDs threw: "
@@ -8650,8 +8643,7 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
                                    numExportPacketsPerLID,
                                    ExportLIDs,
                                    SourcePids,
-                                   constantNumPackets,
-                                   Distor);
+                                   constantNumPackets);
       if (verbose) {
         std::ostringstream os;
         os << *verbosePrefix << "Done with packCrsMatrixWithOwningPIDs"
@@ -8892,7 +8884,6 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
                                            hostImports,
                                            numImportPacketsPerLID,
                                            constantNumPackets,
-                                           Distor,
                                            INSERT,
                                            NumSameIDs,
                                            PermuteToLIDs,
@@ -8938,7 +8929,6 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
                                    hostImports,
                                    numImportPacketsPerLID,
                                    constantNumPackets,
-                                   Distor,
                                    INSERT,
                                    NumSameIDs,
                                    PermuteToLIDs,

--- a/packages/tpetra/core/src/Tpetra_Details_packCrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_packCrsGraph_decl.hpp
@@ -79,11 +79,6 @@ template<class T> class ArrayView;
 
 namespace Tpetra {
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
-// Forward declaration of Distributor
-class Distributor;
-#endif // DOXYGEN_SHOULD_SKIP_THIS
-
 //
 // Users must never rely on anything in the Details namespace.
 //
@@ -112,8 +107,6 @@ namespace Details {
 ///   to expect a possibly /// different ("nonconstant") number of packets per local index
 ///   (i.e., a possibly different number of entries per row).
 ///
-/// \param distor [in] The distributor (not used)
-///
 /// This is the public interface to the pack machinery
 /// converts passed Teuchos::ArrayView objects to Kokkos::View objects (and
 /// copies back in to the Teuchos::ArrayView objects, if needed).  When
@@ -125,8 +118,7 @@ packCrsGraph (const CrsGraph<LO, GO, NT>& sourceGraph,
                Teuchos::Array<typename CrsGraph<LO,GO,NT>::packet_type>& exports,
                const Teuchos::ArrayView<size_t>& numPacketsPerLID,
                const Teuchos::ArrayView<const LO>& exportLIDs,
-               size_t& constantNumPackets,
-               Distributor& distor);
+               size_t& constantNumPackets);
 
 /// \brief Pack specified entries of the given local sparse graph for
 ///   communication, for "new" DistObject interface.
@@ -152,8 +144,6 @@ packCrsGraph (const CrsGraph<LO, GO, NT>& sourceGraph,
 ///   output argument of Tpetra::DistObject::packAndPrepare (which
 ///   see).
 ///
-/// \param distor [in] (Not used.)
-///
 /// This method implements CrsGraph::packNew, and thus
 /// CrsGraph::packAndPrepare, for the case where the graph to
 /// pack has a valid KokkosSparse::CrsGraph.
@@ -177,8 +167,7 @@ packCrsGraphNew (const CrsGraph<LO, GO, NT>& sourceGraph,
                    typename CrsGraph<LO, GO, NT>::buffer_device_type
                  > numPacketsPerLID,
                  size_t& constantNumPackets,
-                 const bool pack_pids,
-                 Distributor& distor);
+                 const bool pack_pids);
 
 /// \brief Pack specified entries of the given local sparse graph for
 ///   communication.
@@ -203,8 +192,6 @@ packCrsGraphNew (const CrsGraph<LO, GO, NT>& sourceGraph,
 ///   to expect a possibly /// different ("nonconstant") number of packets per local index
 ///   (i.e., a possibly different number of entries per row).
 ///
-/// \param distor [in] The distributor (not used)
-///
 /// This is the public interface to the pack machinery
 /// converts passed Teuchos::ArrayView objects to Kokkos::View objects (and
 /// copies back in to the Teuchos::ArrayView objects, if needed).  When
@@ -219,8 +206,7 @@ packCrsGraphWithOwningPIDs (const CrsGraph<LO,GO,NT>& sourceGraph,
                             const Teuchos::ArrayView<size_t>& numPacketsPerLID,
                             const Teuchos::ArrayView<const LO>& exportLIDs,
                             const Teuchos::ArrayView<const int>& sourcePIDs,
-                            size_t& constantNumPackets,
-                            Distributor& distor);
+                            size_t& constantNumPackets);
 
 } // namespace Details
 } // namespace Tpetra

--- a/packages/tpetra/core/src/Tpetra_Details_packCrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_packCrsGraph_def.hpp
@@ -77,11 +77,6 @@
 
 namespace Tpetra {
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
-// Forward declaration of Distributor
-class Distributor;
-#endif // DOXYGEN_SHOULD_SKIP_THIS
-
 //
 // Users must never rely on anything in the Details namespace.
 //
@@ -678,8 +673,7 @@ packCrsGraph
    typename CrsGraph<LO, GO, NT>::buffer_device_type
  >& export_pids,
  size_t& constant_num_packets,
- const bool pack_pids,
- Distributor& /* dist */)
+ const bool pack_pids)
 {
   using Kokkos::View;
   using crs_graph_type = CrsGraph<LO, GO, NT>;
@@ -769,8 +763,7 @@ packCrsGraph (const CrsGraph<LO, GO, NT>& sourceGraph,
               Teuchos::Array<typename CrsGraph<LO,GO,NT>::packet_type>& exports,
               const Teuchos::ArrayView<size_t>& numPacketsPerLID,
               const Teuchos::ArrayView<const LO>& exportLIDs,
-              size_t& constantNumPackets,
-              Distributor& distor)
+              size_t& constantNumPackets)
 {
   using Kokkos::HostSpace;
   using Kokkos::MemoryUnmanaged;
@@ -828,7 +821,7 @@ packCrsGraph (const CrsGraph<LO, GO, NT>& sourceGraph,
 
   PackCrsGraphImpl::packCrsGraph
     (sourceGraph, exports_dv, num_packets_per_lid_d, export_lids_d,
-     export_pids_d, constantNumPackets, pack_pids, distor);
+     export_pids_d, constantNumPackets, pack_pids);
 
   // The counts are an output of packCrsGraph, so we have to copy
   // them back to host.
@@ -872,8 +865,7 @@ packCrsGraphNew (const CrsGraph<LO,GO,NT>& sourceGraph,
                    typename CrsGraph<LO,GO,NT>::buffer_device_type
                  > num_packets_per_lid,
                  size_t& constant_num_packets,
-                 const bool pack_pids,
-                 Distributor& /* dist */)
+                 const bool pack_pids)
 {
   using Kokkos::View;
   using crs_graph_type = CrsGraph<LO,GO,NT>;
@@ -962,8 +954,7 @@ packCrsGraphWithOwningPIDs
  const Teuchos::ArrayView<size_t>& numPacketsPerLID,
  const Teuchos::ArrayView<const LO>& exportLIDs,
  const Teuchos::ArrayView<const int>& sourcePIDs,
- size_t& constantNumPackets,
- Distributor& distor)
+ size_t& constantNumPackets)
 {
   using Kokkos::HostSpace;
   using Kokkos::MemoryUnmanaged;
@@ -998,7 +989,7 @@ packCrsGraphWithOwningPIDs
   constexpr bool pack_pids = true;
   PackCrsGraphImpl::packCrsGraph
     (sourceGraph, exports_dv, num_packets_per_lid_d, export_lids_d,
-     export_pids_d, constantNumPackets, pack_pids, distor);
+     export_pids_d, constantNumPackets, pack_pids);
 
   // The counts are an output of packCrsGraph, so we
   // have to copy them back to host.
@@ -1017,8 +1008,7 @@ packCrsGraphWithOwningPIDs
     Teuchos::Array<CrsGraph<LO,GO,NT>::packet_type>&, \
     const Teuchos::ArrayView<size_t>&, \
     const Teuchos::ArrayView<const LO>&, \
-    size_t&, \
-    Distributor&); \
+    size_t&); \
   template void \
   Details::packCrsGraphNew<LO, GO, NT> ( \
     const CrsGraph<LO, GO, NT>&, \
@@ -1035,8 +1025,7 @@ packCrsGraphWithOwningPIDs
       size_t*, \
       CrsGraph<LO,GO,NT>::buffer_device_type>, \
     size_t&, \
-    const bool, \
-    Distributor&); \
+    const bool); \
   template void \
   Details::packCrsGraphWithOwningPIDs<LO, GO, NT> ( \
     const CrsGraph<LO, GO, NT>&, \
@@ -1044,7 +1033,6 @@ packCrsGraphWithOwningPIDs
     const Teuchos::ArrayView<size_t>&, \
     const Teuchos::ArrayView<const LO>&, \
     const Teuchos::ArrayView<const int>&, \
-    size_t&, \
-    Distributor&);
+    size_t&);
 
 #endif // TPETRA_DETAILS_PACKCRSGRAPH_DEF_HPP

--- a/packages/tpetra/core/src/Tpetra_Details_packCrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_packCrsMatrix_decl.hpp
@@ -80,11 +80,6 @@ template<class T> class ArrayView;
 
 namespace Tpetra {
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
-// Forward declaration of Distributor
-class Distributor;
-#endif // DOXYGEN_SHOULD_SKIP_THIS
-
 //
 // Users must never rely on anything in the Details namespace.
 //
@@ -116,8 +111,6 @@ namespace Details {
 ///   to expect a possibly /// different ("nonconstant") number of packets per local index
 ///   (i.e., a possibly different number of entries per row).
 ///
-/// \param distor [in] The distributor (not used)
-///
 /// This is the public interface to the pack machinery
 /// converts passed Teuchos::ArrayView objects to Kokkos::View objects (and
 /// copies back in to the Teuchos::ArrayView objects, if needed).  When
@@ -129,8 +122,7 @@ packCrsMatrix (const CrsMatrix<ST, LO, GO, NT>& sourceMatrix,
                Teuchos::Array<char>& exports,
                const Teuchos::ArrayView<size_t>& numPacketsPerLID,
                const Teuchos::ArrayView<const LO>& exportLIDs,
-               size_t& constantNumPackets,
-               Distributor& distor);
+               size_t& constantNumPackets);
 
 /// \brief Pack specified entries of the given local sparse matrix for
 ///   communication, for "new" DistObject interface.
@@ -158,8 +150,6 @@ packCrsMatrix (const CrsMatrix<ST, LO, GO, NT>& sourceMatrix,
 ///   output argument of Tpetra::DistObject::packAndPrepare (which
 ///   see).
 ///
-/// \param distor [in] (Not used.)
-///
 /// This method implements CrsMatrix::packNew, and thus
 /// CrsMatrix::packAndPrepare, for the case where the matrix to
 /// pack has a valid KokkosSparse::CrsMatrix.
@@ -172,8 +162,7 @@ packCrsMatrixNew (const CrsMatrix<ST, LO, GO, NT>& sourceMatrix,
                     typename DistObject<char, LO, GO, NT>::buffer_device_type>& numPacketsPerLID,
                   const Kokkos::DualView<const LO*,
                     typename DistObject<char, LO, GO, NT>::buffer_device_type>& exportLIDs,
-                  size_t& constantNumPackets,
-                  Distributor& distor);
+                  size_t& constantNumPackets);
 
 /// \brief Pack specified entries of the given local sparse matrix for
 ///   communication.
@@ -201,8 +190,6 @@ packCrsMatrixNew (const CrsMatrix<ST, LO, GO, NT>& sourceMatrix,
 ///   to expect a possibly /// different ("nonconstant") number of packets per local index
 ///   (i.e., a possibly different number of entries per row).
 ///
-/// \param distor [in] The distributor (not used)
-///
 /// This is the public interface to the pack machinery
 /// converts passed Teuchos::ArrayView objects to Kokkos::View objects (and
 /// copies back in to the Teuchos::ArrayView objects, if needed).  When
@@ -215,8 +202,7 @@ packCrsMatrixWithOwningPIDs (const CrsMatrix<ST, LO, GO, NT>& sourceMatrix,
                              const Teuchos::ArrayView<size_t>& numPacketsPerLID,
                              const Teuchos::ArrayView<const LO>& exportLIDs,
                              const Teuchos::ArrayView<const int>& sourcePIDs,
-                             size_t& constantNumPackets,
-                             Distributor& distor);
+                             size_t& constantNumPackets);
 
 } // namespace Details
 } // namespace Tpetra

--- a/packages/tpetra/core/src/Tpetra_Details_packCrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_packCrsMatrix_def.hpp
@@ -81,11 +81,6 @@
 
 namespace Tpetra {
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
-// Forward declaration of Distributor
-class Distributor;
-#endif // DOXYGEN_SHOULD_SKIP_THIS
-
 //
 // Users must never rely on anything in the Details namespace.
 //
@@ -731,8 +726,7 @@ packCrsMatrix (const CrsMatrix<ST, LO, GO, NT>& sourceMatrix,
                const Kokkos::View<const LO*, BufferDeviceType>& export_lids,
                const Kokkos::View<const int*, typename NT::device_type>& export_pids,
                size_t& constant_num_packets,
-               const bool pack_pids,
-               Distributor& /* dist */)
+               const bool pack_pids)
 {
   ::Tpetra::Details::ProfilingRegion region_pack_crs_matrix(
     "Tpetra::Details::PackCrsMatrixImpl::packCrsMatrix",
@@ -864,8 +858,7 @@ packCrsMatrix (const CrsMatrix<ST, LO, GO, NT>& sourceMatrix,
                Teuchos::Array<char>& exports,
                const Teuchos::ArrayView<size_t>& numPacketsPerLID,
                const Teuchos::ArrayView<const LO>& exportLIDs,
-               size_t& constantNumPackets,
-               Distributor& distor)
+               size_t& constantNumPackets)
 {
   using local_matrix_device_type = typename CrsMatrix<ST,LO,GO,NT>::local_matrix_device_type;
   using device_type = typename local_matrix_device_type::device_type;
@@ -899,7 +892,7 @@ packCrsMatrix (const CrsMatrix<ST, LO, GO, NT>& sourceMatrix,
   constexpr bool pack_pids = false;
   PackCrsMatrixImpl::packCrsMatrix<ST, LO, GO, NT, buffer_device_type> (
       sourceMatrix, exports_dv, num_packets_per_lid_d, export_lids_d,
-      export_pids_d, constantNumPackets, pack_pids, distor);
+      export_pids_d, constantNumPackets, pack_pids);
 
   // The counts are an output of PackCrsMatrixImpl::packCrsMatrix, so we have to
   // copy them back to host.
@@ -929,9 +922,7 @@ packCrsMatrixNew(
   Kokkos::DualView<char*, typename DistObject<char, LO, GO, NT>::buffer_device_type>& exports,
   const Kokkos::DualView<size_t*, typename DistObject<char, LO, GO, NT>::buffer_device_type>& numPacketsPerLID,
   const Kokkos::DualView<const LO*, typename DistObject<char, LO, GO, NT>::buffer_device_type>& exportLIDs,
-  size_t& constantNumPackets,
-  Distributor& distor
-)
+  size_t& constantNumPackets)
 {
   using device_type = typename CrsMatrix<ST, LO, GO, NT>::device_type;
   using buffer_device_type = typename DistObject<char, LO, GO, NT>::buffer_device_type;
@@ -956,7 +947,7 @@ packCrsMatrixNew(
   );
   PackCrsMatrixImpl::packCrsMatrix<ST,LO,GO,NT,buffer_device_type> (
       sourceMatrix, exports, numPacketsPerLID_d, exportLIDs_d,
-      exportPIDs_d, constantNumPackets, pack_pids, distor);
+      exportPIDs_d, constantNumPackets, pack_pids);
 }
 
 template<typename ST, typename LO, typename GO, typename NT>
@@ -966,8 +957,7 @@ packCrsMatrixWithOwningPIDs (const CrsMatrix<ST, LO, GO, NT>& sourceMatrix,
                              const Teuchos::ArrayView<size_t>& numPacketsPerLID,
                              const Teuchos::ArrayView<const LO>& exportLIDs,
                              const Teuchos::ArrayView<const int>& sourcePIDs,
-                             size_t& constantNumPackets,
-                             Distributor& distor)
+                             size_t& constantNumPackets)
 {
   typedef typename CrsMatrix<ST,LO,GO,NT>::local_matrix_device_type local_matrix_device_type;
   typedef typename DistObject<char, LO, GO, NT>::buffer_device_type buffer_device_type;
@@ -1027,7 +1017,7 @@ packCrsMatrixWithOwningPIDs (const CrsMatrix<ST, LO, GO, NT>& sourceMatrix,
   try {
     PackCrsMatrixImpl::packCrsMatrix
       (sourceMatrix, exports_dv, num_packets_per_lid_d, export_lids_d,
-       export_pids_d, constantNumPackets, pack_pids, distor);
+       export_pids_d, constantNumPackets, pack_pids);
   }
   catch (std::exception& e) {
     if (verbose) {
@@ -1091,22 +1081,19 @@ packCrsMatrixWithOwningPIDs (const CrsMatrix<ST, LO, GO, NT>& sourceMatrix,
     Teuchos::Array<char>&, \
     const Teuchos::ArrayView<size_t>&, \
     const Teuchos::ArrayView<const LO>&, \
-    size_t&, \
-    Distributor&); \
+    size_t&); \
   template void \
   Details::packCrsMatrixNew<ST, LO, GO, NT> (const CrsMatrix<ST, LO, GO, NT>&, \
     Kokkos::DualView<char*, DistObject<char, LO, GO, NT>::buffer_device_type>&, \
     const Kokkos::DualView<size_t*, DistObject<char, LO, GO, NT>::buffer_device_type>&, \
     const Kokkos::DualView<const LO*, DistObject<char, LO, GO, NT>::buffer_device_type>&, \
-    size_t&, \
-    Distributor&); \
+    size_t&); \
   template void \
   Details::packCrsMatrixWithOwningPIDs<ST, LO, GO, NT> (const CrsMatrix<ST, LO, GO, NT>&, \
     Kokkos::DualView<char*, DistObject<char, LO, GO, NT>::buffer_device_type>&, \
     const Teuchos::ArrayView<size_t>&, \
     const Teuchos::ArrayView<const LO>&, \
     const Teuchos::ArrayView<const int>&, \
-    size_t&, \
-    Distributor&);
+    size_t&);
 
 #endif // TPETRA_DETAILS_PACKCRSMATRIX_DEF_HPP

--- a/packages/tpetra/core/src/Tpetra_Details_unpackCrsGraphAndCombine_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_unpackCrsGraphAndCombine_decl.hpp
@@ -78,11 +78,6 @@ template<class T> class ArrayView;
 
 namespace Tpetra {
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
-// Forward declaration of Distributor
-class Distributor;
-#endif // DOXYGEN_SHOULD_SKIP_THIS
-
 //
 // Users must never rely on anything in the Details namespace.
 //
@@ -119,8 +114,6 @@ namespace Details {
 ///   to expect a possibly /// different ("nonconstant") number of packets per local index
 ///   (i.e., a possibly different number of entries per row).
 ///
-/// \param distor [in] The distributor (not used)
-///
 /// \param combineMode [in] the mode to use for combining
 ///
 /// \param numSameIds [in]
@@ -148,7 +141,6 @@ unpackAndCombineWithOwningPIDsCount(
     const Teuchos::ArrayView<const typename CrsGraph<LO,GO,NT>::packet_type> &imports,
     const Teuchos::ArrayView<const size_t>& numPacketsPerLID,
     size_t constantNumPackets,
-    Distributor &distor,
     CombineMode combineMode,
     size_t numSameIDs,
     const Teuchos::ArrayView<const LO>& permuteToLIDs,
@@ -176,7 +168,6 @@ unpackAndCombineIntoCrsArrays(
     const Teuchos::ArrayView<const typename CrsGraph<LO,GO,NT>::packet_type>& imports,
     const Teuchos::ArrayView<const size_t>& numPacketsPerLID,
     const size_t constantNumPackets,
-    Distributor& distor,
     const CombineMode combineMode,
     const size_t numSameIDs,
     const Teuchos::ArrayView<const LO>& permuteToLIDs,

--- a/packages/tpetra/core/src/Tpetra_Details_unpackCrsGraphAndCombine_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_unpackCrsGraphAndCombine_def.hpp
@@ -76,11 +76,6 @@
 
 namespace Tpetra {
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
-// Forward declaration of Distributor
-class Distributor;
-#endif // DOXYGEN_SHOULD_SKIP_THIS
-
 //
 // Users must never rely on anything in the Details namespace.
 //
@@ -838,8 +833,6 @@ unpackAndCombineIntoCrsArrays(
 ///   to expect a possibly /// different ("nonconstant") number of packets per local index
 ///   (i.e., a possibly different number of entries per row).
 ///
-/// \param distor [in] The distributor (not used)
-///
 /// \param combineMode [in] the mode to use for combining
 ///
 /// \param numSameIds [in]
@@ -864,7 +857,6 @@ unpackAndCombineWithOwningPIDsCount(
     const Teuchos::ArrayView<const typename CrsGraph<LocalOrdinal,GlobalOrdinal,Node>::packet_type> &imports,
     const Teuchos::ArrayView<const size_t>& numPacketsPerLID,
     size_t /* constantNumPackets */,
-    Distributor &/* distor */,
     CombineMode /* combineMode */,
     size_t numSameIDs,
     const Teuchos::ArrayView<const LocalOrdinal>& permuteToLIDs,
@@ -936,7 +928,6 @@ unpackAndCombineIntoCrsArrays(
     const Teuchos::ArrayView<const typename CrsGraph<LocalOrdinal,GlobalOrdinal,Node>::packet_type>& imports,
     const Teuchos::ArrayView<const size_t>& numPacketsPerLID,
     const size_t /* constantNumPackets */,
-    Distributor& /* distor */,
     const CombineMode /* combineMode */,
     const size_t numSameIDs,
     const Teuchos::ArrayView<const LocalOrdinal>& permuteToLIDs,
@@ -1075,7 +1066,6 @@ unpackAndCombineIntoCrsArrays(
     const Teuchos::ArrayView<const typename CrsGraph<LO,GO,NT>::packet_type>&, \
     const Teuchos::ArrayView<const size_t>&, \
     const size_t, \
-    Distributor&, \
     const CombineMode, \
     const size_t, \
     const Teuchos::ArrayView<const LO>&, \
@@ -1094,7 +1084,6 @@ unpackAndCombineIntoCrsArrays(
     const Teuchos::ArrayView<const typename CrsGraph<LO,GO,NT>::packet_type> &, \
     const Teuchos::ArrayView<const size_t>&, \
     size_t, \
-    Distributor &, \
     CombineMode, \
     size_t, \
     const Teuchos::ArrayView<const LO>&, \

--- a/packages/tpetra/core/src/Tpetra_Details_unpackCrsMatrixAndCombine_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_unpackCrsMatrixAndCombine_decl.hpp
@@ -78,11 +78,6 @@ template<class T> class ArrayView;
 
 namespace Tpetra {
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
-// Forward declaration of Distributor
-class Distributor;
-#endif // DOXYGEN_SHOULD_SKIP_THIS
-
 //
 // Users must never rely on anything in the Details namespace.
 //
@@ -133,7 +128,6 @@ unpackCrsMatrixAndCombine (const CrsMatrix<ST, LO, GO, NT>& sourceMatrix,
                            const Teuchos::ArrayView<const size_t>& numPacketsPerLID,
                            const Teuchos::ArrayView<const LO>& importLIDs,
                            size_t constantNumPackets,
-                           Distributor & distor,
                            CombineMode combineMode);
 
 template<typename ST, typename LO, typename GO, typename NT>
@@ -147,7 +141,6 @@ unpackCrsMatrixAndCombineNew(
   const Kokkos::DualView<const LO*,
     typename DistObject<char, LO, GO, NT>::buffer_device_type>& importLIDs,
   const size_t constantNumPackets,
-  Distributor& distor,
   const CombineMode combineMode);
 
 /// \brief Special version of Tpetra::Details::unpackCrsMatrixAndCombine
@@ -213,7 +206,6 @@ unpackAndCombineWithOwningPIDsCount (
     const Teuchos::ArrayView<const char> &imports,
     const Teuchos::ArrayView<const size_t>& numPacketsPerLID,
     size_t constantNumPackets,
-    Distributor &distor,
     CombineMode combineMode,
     size_t numSameIDs,
     const Teuchos::ArrayView<const LocalOrdinal>& permuteToLIDs,
@@ -241,7 +233,6 @@ unpackAndCombineIntoCrsArrays (
     const Teuchos::ArrayView<const char>& imports,
     const Teuchos::ArrayView<const size_t>& numPacketsPerLID,
     const size_t constantNumPackets,
-    Distributor& distor,
     const CombineMode combineMode,
     const size_t numSameIDs,
     const Teuchos::ArrayView<const LocalOrdinal>& permuteToLIDs,

--- a/packages/tpetra/core/src/Tpetra_Details_unpackCrsMatrixAndCombine_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_unpackCrsMatrixAndCombine_def.hpp
@@ -78,11 +78,6 @@
 
 namespace Tpetra {
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
-// Forward declaration of Distributor
-class Distributor;
-#endif // DOXYGEN_SHOULD_SKIP_THIS
-
 //
 // Users must never rely on anything in the Details namespace.
 //
@@ -1203,7 +1198,6 @@ unpackCrsMatrixAndCombine(
     const Teuchos::ArrayView<const size_t>& numPacketsPerLID,
     const Teuchos::ArrayView<const LO>& importLIDs,
     size_t /* constantNumPackets */,
-    Distributor & /* distor */,
     CombineMode combineMode)
 {
   using Kokkos::View;
@@ -1259,7 +1253,6 @@ unpackCrsMatrixAndCombineNew(
   const Kokkos::DualView<const LO*,
     typename DistObject<char, LO, GO, NT>::buffer_device_type>& importLIDs,
   const size_t /* constantNumPackets */,
-  Distributor& /* distor */,
   const CombineMode combineMode)
 {
   using Kokkos::View;
@@ -1362,7 +1355,6 @@ unpackAndCombineWithOwningPIDsCount (
     const Teuchos::ArrayView<const char> &imports,
     const Teuchos::ArrayView<const size_t>& numPacketsPerLID,
     size_t /* constantNumPackets */,
-    Distributor &/* distor */,
     CombineMode /* combineMode */,
     size_t numSameIDs,
     const Teuchos::ArrayView<const LocalOrdinal>& permuteToLIDs,
@@ -1433,7 +1425,6 @@ unpackAndCombineIntoCrsArrays (
     const Teuchos::ArrayView<const char>& imports,
     const Teuchos::ArrayView<const size_t>& numPacketsPerLID,
     const size_t /* constantNumPackets */,
-    Distributor& /* distor */,
     const CombineMode /* combineMode */,
     const size_t numSameIDs,
     const Teuchos::ArrayView<const LocalOrdinal>& permuteToLIDs,
@@ -1628,7 +1619,6 @@ unpackAndCombineIntoCrsArrays (
     const Teuchos::ArrayView<const size_t>&, \
     const Teuchos::ArrayView<const LO>&, \
     size_t, \
-    Distributor&, \
     CombineMode); \
   template void \
   Details::unpackCrsMatrixAndCombineNew<ST, LO, GO, NT> ( \
@@ -1637,7 +1627,6 @@ unpackAndCombineIntoCrsArrays (
     Kokkos::DualView<size_t*, typename DistObject<char, LO, GO, NT>::buffer_device_type>, \
     const Kokkos::DualView<const LO*, typename DistObject<char, LO, GO, NT>::buffer_device_type>&, \
     const size_t, \
-    Distributor&, \
     const CombineMode); \
   template void \
   Details::unpackAndCombineIntoCrsArrays<ST, LO, GO, NT> ( \
@@ -1646,7 +1635,6 @@ unpackAndCombineIntoCrsArrays (
     const Teuchos::ArrayView<const char>&, \
     const Teuchos::ArrayView<const size_t>&, \
     const size_t, \
-    Distributor&, \
     const CombineMode, \
     const size_t, \
     const Teuchos::ArrayView<const LO>&, \
@@ -1666,7 +1654,6 @@ unpackAndCombineIntoCrsArrays (
     const Teuchos::ArrayView<const char> &, \
     const Teuchos::ArrayView<const size_t>&, \
     size_t, \
-    Distributor &, \
     CombineMode, \
     size_t, \
     const Teuchos::ArrayView<const LO>&, \

--- a/packages/tpetra/core/src/Tpetra_DistObject_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_DistObject_decl.hpp
@@ -897,9 +897,6 @@ namespace Tpetra {
     /// \param constantNumPackets [out] On exit, 0 if the number of
     ///   packets per LID could differ, else (if nonzero) the number
     ///   of packets per LID (which must be constant).
-    ///
-    /// \param distor [in] The Distributor object we are using.  Most
-    ///   implementations will not use this.
     virtual void
     packAndPrepare (const SrcDistObject& source,
                     const Kokkos::DualView<const local_ordinal_type*,
@@ -908,8 +905,7 @@ namespace Tpetra {
                       buffer_device_type>& exports,
                     Kokkos::DualView<size_t*,
                       buffer_device_type> numPacketsPerLID,
-                    size_t& constantNumPackets,
-                    Distributor& distor);
+                    size_t& constantNumPackets);
 
     /// \brief Perform any unpacking and combining after
     ///   communication.
@@ -948,9 +944,6 @@ namespace Tpetra {
     ///   <tt>numPacketsPerLID[i]</tt> is the number of packets to
     ///   unpack for LID <tt>importLIDs[i]</tt>.
     ///
-    /// \param distor [in] The Distributor object we are using.  Most
-    ///   implementations will not use this.
-    ///
     /// \param combineMode [in] The CombineMode to use when combining
     ///   the imported entries with existing entries.
     virtual void
@@ -961,7 +954,6 @@ namespace Tpetra {
                       Kokkos::DualView<size_t*,
                         buffer_device_type> numPacketsPerLID,
                       const size_t constantNumPackets,
-                      Distributor& distor,
                       const CombineMode combineMode);
 
 

--- a/packages/tpetra/core/src/Tpetra_DistObject_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_DistObject_def.hpp
@@ -1637,7 +1637,7 @@ namespace Tpetra {
       try {
         this->packAndPrepare (src, exportLIDs, this->exports_,
             this->numExportPacketsPerLID_,
-            constantNumPackets, distor);
+            constantNumPackets);
         lclSuccess = true;
       }
       catch (std::exception& e) {
@@ -1659,7 +1659,7 @@ namespace Tpetra {
     else {
       this->packAndPrepare (src, exportLIDs, this->exports_,
           this->numExportPacketsPerLID_,
-          constantNumPackets, distor);
+          constantNumPackets);
     }
   }
 
@@ -1689,7 +1689,7 @@ namespace Tpetra {
       try {
         this->unpackAndCombine (remoteLIDs, this->imports_,
             this->numImportPacketsPerLID_,
-            constantNumPackets, distor, CM);
+            constantNumPackets, CM);
         lclSuccess = true;
       }
       catch (std::exception& e) {
@@ -1711,7 +1711,7 @@ namespace Tpetra {
     else {
       this->unpackAndCombine (remoteLIDs, this->imports_,
           this->numImportPacketsPerLID_,
-          constantNumPackets, distor, CM);
+          constantNumPackets, CM);
     }
   }
 
@@ -1744,8 +1744,7 @@ namespace Tpetra {
    Kokkos::DualView<
      size_t*,
      buffer_device_type>,
-   size_t&,
-   Distributor&)
+   size_t&)
   {}
 
   template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
@@ -1762,7 +1761,6 @@ namespace Tpetra {
      size_t*,
      buffer_device_type> /* numPacketsPerLID */,
    const size_t /* constantNumPackets */,
-   Distributor& /* distor */,
    const CombineMode /* combineMode */)
   {}
 

--- a/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
@@ -2563,8 +2563,7 @@ namespace Tpetra {
      Kokkos::DualView<
        size_t*,
        buffer_device_type> /* numPacketsPerLID */,
-     size_t& constantNumPackets,
-     Distributor& /* distor */);
+     size_t& constantNumPackets);
 
     virtual void
     unpackAndCombine
@@ -2578,7 +2577,6 @@ namespace Tpetra {
        size_t*,
        buffer_device_type> /* numPacketsPerLID */,
      const size_t constantNumPackets,
-     Distributor& /* distor */,
      const CombineMode CM);
 
   private:

--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -1365,8 +1365,7 @@ namespace Tpetra {
    const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& exportLIDs,
    Kokkos::DualView<impl_scalar_type*, buffer_device_type>& exports,
    Kokkos::DualView<size_t*, buffer_device_type> /* numExportPacketsPerLID */,
-   size_t& constantNumPackets,
-   Distributor & /* distor */ )
+   size_t& constantNumPackets)
   {
     using ::Tpetra::Details::Behavior;
     using ::Tpetra::Details::ProfilingRegion;
@@ -1742,7 +1741,6 @@ namespace Tpetra {
    Kokkos::DualView<impl_scalar_type*, buffer_device_type> imports,
    Kokkos::DualView<size_t*, buffer_device_type> /* numPacketsPerLID */,
    const size_t constantNumPackets,
-   Distributor& /* distor */,
    const CombineMode CM)
   {
     using ::Tpetra::Details::Behavior;

--- a/packages/tpetra/core/src/Tpetra_Packable.hpp
+++ b/packages/tpetra/core/src/Tpetra_Packable.hpp
@@ -54,9 +54,6 @@ namespace Teuchos {
   template <class T> class ArrayView;
 } // namespace Teuchos
 
-namespace Tpetra {
-  class Distributor; // forward declaration
-} // namespace Tpetra
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
 namespace Tpetra {
@@ -118,16 +115,11 @@ namespace Tpetra {
     ///   size for each local index).  If nonzero, then it is expected
     ///   that the number of packets per local index is constant, and
     ///   that <tt>constantNumPackets</tt> is that value.
-    ///
-    /// \param distor [in] The Distributor object we are using.
-    ///   Implementations may ignore this object.  We provide it for
-    ///   consistency with DistObject's packAndPrepare method.
     virtual void
     pack (const Teuchos::ArrayView<const LocalOrdinal>& exportLIDs,
           Teuchos::Array<Packet>& exports,
           const Teuchos::ArrayView<size_t>& numPacketsPerLID,
-          size_t& constantNumPackets,
-          Distributor &distor) const = 0;
+          size_t& constantNumPackets) const = 0;
 
     //! Destructor (virtual for memory safety of derived classes).
     virtual ~Packable () {}

--- a/packages/tpetra/core/src/Tpetra_RowGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_RowGraph_decl.hpp
@@ -322,8 +322,7 @@ namespace Tpetra {
     pack (const Teuchos::ArrayView<const LocalOrdinal>& exportLIDs,
           Teuchos::Array<GlobalOrdinal>& exports,
           const Teuchos::ArrayView<size_t>& numPacketsPerLID,
-          size_t& constantNumPackets,
-          Distributor& distor) const;
+          size_t& constantNumPackets) const;
     //@}
   }; // class RowGraph
 } // namespace Tpetra

--- a/packages/tpetra/core/src/Tpetra_RowGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_RowGraph_def.hpp
@@ -42,8 +42,6 @@
 #ifndef TPETRA_ROWGRAPH_DEF_HPP
 #define TPETRA_ROWGRAPH_DEF_HPP
 
-#include "Tpetra_Distributor.hpp" // avoid error C2027: use of undefined type 'Tpetra::Distributor' at (void) distor below
-
 namespace Tpetra {
   template<class LocalOrdinal, class GlobalOrdinal, class Node>
   void
@@ -51,15 +49,13 @@ namespace Tpetra {
   pack (const Teuchos::ArrayView<const LocalOrdinal>& exportLIDs,
         Teuchos::Array<GlobalOrdinal>& exports,
         const Teuchos::ArrayView<size_t>& numPacketsPerLID,
-        size_t& constantNumPackets,
-        Distributor& distor) const
+        size_t& constantNumPackets) const
   {
     using Teuchos::Array;
     typedef LocalOrdinal LO;
     typedef GlobalOrdinal GO;
     typedef Map<LO, GO, Node> map_type;
     const char tfecfFuncName[] = "packAndPrepare";
-    (void) distor; // forestall "unused argument" compiler warning
 
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
       exportLIDs.size() != numPacketsPerLID.size(), std::runtime_error,

--- a/packages/tpetra/core/src/Tpetra_RowMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_RowMatrix_decl.hpp
@@ -565,8 +565,7 @@ namespace Tpetra {
     packImpl (const Teuchos::ArrayView<const LocalOrdinal>& exportLIDs,
               Teuchos::Array<char>& exports,
               const Teuchos::ArrayView<size_t>& numPacketsPerLID,
-              size_t& constantNumPackets,
-              Distributor& distor) const;
+              size_t& constantNumPackets) const;
 
 
   public:
@@ -582,8 +581,7 @@ namespace Tpetra {
     pack (const Teuchos::ArrayView<const LocalOrdinal>& exportLIDs,
           Teuchos::Array<char>& exports,
           const Teuchos::ArrayView<size_t>& numPacketsPerLID,
-          size_t& constantNumPackets,
-          Distributor& distor) const;
+          size_t& constantNumPackets) const;
     //@}
   }; // class RowMatrix
 } // namespace Tpetra

--- a/packages/tpetra/core/src/Tpetra_RowMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_RowMatrix_def.hpp
@@ -302,8 +302,7 @@ namespace Tpetra {
   pack (const Teuchos::ArrayView<const LocalOrdinal>& exportLIDs,
         Teuchos::Array<char>& exports,
         const Teuchos::ArrayView<size_t>& numPacketsPerLID,
-        size_t& constantNumPackets,
-        Distributor &distor) const
+        size_t& constantNumPackets) const
   {
 #ifdef HAVE_TPETRA_DEBUG
     const char tfecfFuncName[] = "pack: ";
@@ -313,7 +312,7 @@ namespace Tpetra {
       int lclBad = 0;
       try {
         this->packImpl (exportLIDs, exports, numPacketsPerLID,
-                        constantNumPackets, distor);
+                        constantNumPackets);
       } catch (std::exception& e) {
         lclBad = 1;
         msg << e.what ();
@@ -342,7 +341,7 @@ namespace Tpetra {
     }
 #else
     this->packImpl (exportLIDs, exports, numPacketsPerLID,
-                    constantNumPackets, distor);
+                    constantNumPackets);
 #endif // HAVE_TPETRA_DEBUG
   }
 
@@ -491,8 +490,7 @@ namespace Tpetra {
   packImpl (const Teuchos::ArrayView<const LocalOrdinal>& exportLIDs,
             Teuchos::Array<char>& exports,
             const Teuchos::ArrayView<size_t>& numPacketsPerLID,
-            size_t& constantNumPackets,
-            Distributor& /* distor */) const
+            size_t& constantNumPackets) const
   {
     using Teuchos::Array;
     using Teuchos::ArrayView;

--- a/packages/tpetra/core/test/CrsGraph/CrsGraph_PackUnpack.cpp
+++ b/packages/tpetra/core/test/CrsGraph/CrsGraph_PackUnpack.cpp
@@ -45,7 +45,6 @@
 #include "TpetraCore_ETIHelperMacros.h"
 #include "Tpetra_CrsGraph.hpp"
 #include "Tpetra_Core.hpp"
-#include "Tpetra_Distributor.hpp"
 #include "Tpetra_Map.hpp"
 #include "Tpetra_Details_gathervPrint.hpp"
 #include "Tpetra_Details_packCrsGraph.hpp"
@@ -162,7 +161,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(CrsGraph, PackThenUnpackAndCombine, LO, GO, NT
   Array<packet_type> exports; // output argument; to be realloc'd
   Array<size_t> numPacketsPerLID (num_loc_rows, 0); // output argument
   size_t constantNumPackets; // output argument
-  Tpetra::Distributor distor (comm); // argument required, but not used
 
   out << "Calling packCrsGraph" << endl;
 
@@ -171,7 +169,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(CrsGraph, PackThenUnpackAndCombine, LO, GO, NT
     std::ostringstream msg;
     try {
       packCrsGraph<LO,GO,NT>(*A, exports, numPacketsPerLID(), exportLIDs(),
-          constantNumPackets, distor);
+          constantNumPackets);
       local_op_ok = 1;
     } catch (std::exception& e) {
       local_op_ok = 0;
@@ -331,13 +329,12 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(CrsGraph, PackWithError, LO, GO, NT)
     Array<packet_type> exports;
     Array<size_t> numPacketsPerLID(num_loc_rows, 0);
     size_t constantNumPackets;
-    Tpetra::Distributor distor(comm);
     {
       int local_op_ok;
       std::ostringstream msg;
       try {
         packCrsGraph<LO,GO,NT>(*A, exports, numPacketsPerLID(), exportLIDs(),
-            constantNumPackets, distor);
+            constantNumPackets);
         local_op_ok = 1;
       } catch (std::exception& e) {
         local_op_ok = 0;
@@ -374,14 +371,13 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(CrsGraph, PackWithError, LO, GO, NT)
     Array<packet_type> exports;
     Array<size_t> numPacketsPerLID(num_loc_rows, 0);
     size_t constantNumPackets;
-    Tpetra::Distributor distor(comm);
     out << "Calling packCrsGraph" << endl;
     {
       int local_op_ok;
       std::ostringstream msg;
       try {
         packCrsGraph<LO,GO,NT>(*A, exports, numPacketsPerLID(), exportLIDs(),
-            constantNumPackets, distor);
+            constantNumPackets);
         local_op_ok = 1;
       } catch (std::exception& e) {
         local_op_ok = 0;

--- a/packages/tpetra/core/test/CrsGraph/CrsGraph_UnpackIntoStaticGraph.cpp
+++ b/packages/tpetra/core/test/CrsGraph/CrsGraph_UnpackIntoStaticGraph.cpp
@@ -45,7 +45,6 @@
 #include "TpetraCore_ETIHelperMacros.h"
 #include "Tpetra_CrsGraph.hpp"
 #include "Tpetra_Core.hpp"
-#include "Tpetra_Distributor.hpp"
 #include "Tpetra_Map.hpp"
 #include "Tpetra_Details_gathervPrint.hpp"
 #include "Tpetra_Details_packCrsGraph.hpp"
@@ -134,13 +133,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(CrsGraph, PackThenUnpackAndCombine, LO, GO, NT
   auto num_packets_per_lid = Array<size_t>(num_loc_rows, 0); // output argument
   size_t const_num_packets; // output argument
 
-  // We're not actually communicating in this test; we just need the Distributor
-  // for the interface of packCrsGraph (which doesn't use it).  Consider changing
-  // packCrsGraph's interface so it doesn't take a Distributor?  No, because
-  // Distributor has index permutation information that we could use to pack in
-  // a particular order and thus avoid the slow path in Distributor::doPosts.
-  auto distor = Tpetra::Distributor(comm);
-
   out << "Calling packCrsGraph" << endl;
 
   {
@@ -148,7 +140,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(CrsGraph, PackThenUnpackAndCombine, LO, GO, NT
     std::ostringstream msg;
     try {
       packCrsGraph<LO,GO,NT>(*B, exports, num_packets_per_lid(), export_lids(),
-          const_num_packets, distor);
+          const_num_packets);
       local_op_ok = 1;
     } catch (std::exception& e) {
       local_op_ok = 0;
@@ -178,7 +170,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(CrsGraph, PackThenUnpackAndCombine, LO, GO, NT
     int local_op_ok;
     std::ostringstream msg;
     unpackCrsGraphAndCombine<LO,GO,NT>(*A, exports, num_packets_per_lid(),
-        export_lids(), const_num_packets, distor, Tpetra::REPLACE);
+        export_lids(), const_num_packets, Tpetra::REPLACE);
     local_op_ok = 1;
 
     TEST_ASSERT(local_op_ok == 1);

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_PackUnpack.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_PackUnpack.cpp
@@ -43,7 +43,6 @@
 #include "TpetraCore_ETIHelperMacros.h"
 #include "Tpetra_CrsMatrix.hpp"
 #include "Tpetra_Core.hpp"
-#include "Tpetra_Distributor.hpp"
 #include "Tpetra_Map.hpp"
 #include "Tpetra_Details_gathervPrint.hpp"
 #include "Tpetra_Details_packCrsMatrix.hpp"
@@ -170,7 +169,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(CrsMatrix, PackThenUnpackAndCombine, SC, LO, G
   Array<char> exports; // output argument; to be realloc'd
   Array<size_t> numPacketsPerLID (num_loc_rows, 0); // output argument
   size_t constantNumPackets; // output argument
-  Tpetra::Distributor distor (comm); // argument required, but not used
 
   out << "Calling packCrsMatrix" << endl;
 
@@ -180,7 +178,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(CrsMatrix, PackThenUnpackAndCombine, SC, LO, G
     try {
       packCrsMatrix (*A, exports, numPacketsPerLID (),
                      exportLIDs ().getConst (),
-                     constantNumPackets, distor);
+                     constantNumPackets);
       local_op_ok = 1;
     }
     catch (std::exception& e) {
@@ -220,7 +218,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(CrsMatrix, PackThenUnpackAndCombine, SC, LO, G
     try {
       unpackCrsMatrixAndCombine (*B, exports, numPacketsPerLID (),
                                  exportLIDs ().getConst (),
-                                 constantNumPackets, distor,
+                                 constantNumPackets,
                                  Tpetra::REPLACE);
       local_op_ok = 1;
     }
@@ -319,7 +317,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(CrsMatrix, PackThenUnpackAndCombine, SC, LO, G
     try {
       unpackCrsMatrixAndCombine (*B, exports, numPacketsPerLID (),
                                  exportLIDs ().getConst (),
-                                 constantNumPackets, distor,
+                                 constantNumPackets,
                                  Tpetra::ADD);
       local_op_ok = 1;
     }
@@ -438,14 +436,13 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(CrsMatrix, PackWithError, SC, LO, GO, NT)
     Array<char> exports;
     Array<size_t> numPacketsPerLID(num_loc_rows, 0);
     size_t constantNumPackets;
-    Tpetra::Distributor distor(comm);
     {
       int local_op_ok;
       std::ostringstream msg;
       try {
         packCrsMatrix (*A, exports, numPacketsPerLID (),
                        exportLIDs ().getConst (),
-                       constantNumPackets, distor);
+                       constantNumPackets);
         local_op_ok = 1;
       }
       catch (std::exception& e) {
@@ -483,7 +480,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(CrsMatrix, PackWithError, SC, LO, GO, NT)
     Array<char> exports;
     Array<size_t> numPacketsPerLID(num_loc_rows, 0);
     size_t constantNumPackets;
-    Tpetra::Distributor distor(comm);
     out << "Calling packCrsMatrix" << endl;
     {
       int local_op_ok;
@@ -491,7 +487,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(CrsMatrix, PackWithError, SC, LO, GO, NT)
       try {
         packCrsMatrix (*A, exports, numPacketsPerLID (),
                        exportLIDs ().getConst (),
-                       constantNumPackets, distor);
+                       constantNumPackets);
         local_op_ok = 1;
       }
       catch (std::exception& e) {
@@ -546,7 +542,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(CrsMatrix, PackPartial, SC, LO, GO, NT)
   Array<char> exports; // output argument; to be realloc'd
   Array<size_t> numPacketsPerLID (num_loc_rows, 0); // output argument
   size_t constantNumPackets; // output argument
-  Tpetra::Distributor distor (comm); // argument required, but not used
 
   out << "Calling packCrsMatrix" << endl;
 
@@ -556,7 +551,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(CrsMatrix, PackPartial, SC, LO, GO, NT)
     try {
       packCrsMatrix (*A, exports, numPacketsPerLID (),
                      exportLIDs ().getConst (),
-                     constantNumPackets, distor);
+                     constantNumPackets);
       local_op_ok = 1;
     }
     catch (std::exception& e) {
@@ -596,7 +591,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(CrsMatrix, PackPartial, SC, LO, GO, NT)
     try {
       unpackCrsMatrixAndCombine (*B, exports, numPacketsPerLID (),
                                  exportLIDs ().getConst (),
-                                 constantNumPackets, distor,
+                                 constantNumPackets,
                                  Tpetra::REPLACE);
       local_op_ok = 1;
     }

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_createDeepCopy.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_createDeepCopy.cpp
@@ -264,11 +264,10 @@ public:
   pack (const Teuchos::ArrayView<const LO>& exportLIDs,
         Teuchos::Array<GO>& exports,
         const Teuchos::ArrayView<size_t>& numPacketsPerLID,
-        size_t& constantNumPackets,
-        Tpetra::Distributor& distor) const override
+        size_t& constantNumPackets) const override
   {
     return G_->pack (exportLIDs, exports, numPacketsPerLID,
-                     constantNumPackets, distor);
+                     constantNumPackets);
   }
 
 private:
@@ -502,11 +501,10 @@ public:
   pack (const Teuchos::ArrayView<const LO>& exportLIDs,
         Teuchos::Array<char>& exports,
         const Teuchos::ArrayView<size_t>& numPacketsPerLID,
-        size_t& constantNumPackets,
-        Tpetra::Distributor& distor) const override
+        size_t& constantNumPackets) const override
   {
     return A_->pack (exportLIDs, exports, numPacketsPerLID,
-                     constantNumPackets, distor);
+                     constantNumPackets);
   }
 
   void

--- a/packages/tpetra/core/test/ImportExport2/ImportExport2_UnitTests.cpp
+++ b/packages/tpetra/core/test/ImportExport2/ImportExport2_UnitTests.cpp
@@ -2303,7 +2303,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( Import_Util, UnpackAndCombineWithOwningPIDs, 
     }
     Tpetra::Details::packCrsMatrixWithOwningPIDs<Scalar, LO, GO, Node>(
         *A, exports, numExportPackets(), Importer->getExportLIDs(),
-        SourcePids(), constantNumPackets, distor);
+        SourcePids(), constantNumPackets);
     if (verbose) {
       std::ostringstream os;
       os << *prefix << "Done with packCrsMatrixWithOwningPIDs" << std::endl;
@@ -2370,7 +2370,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( Import_Util, UnpackAndCombineWithOwningPIDs, 
     size_t nnz2 =
       unpackAndCombineWithOwningPIDsCount<Scalar, LO, GO, Node> (*A, Importer->getRemoteLIDs (),
                                                                  imports (), numImportPackets (),
-                                                                 constantNumPackets, distor,
+                                                                 constantNumPackets,
                                                                  Tpetra::INSERT,
                                                                  Importer->getNumSameIDs (),
                                                                  Importer->getPermuteToLIDs (),
@@ -2406,7 +2406,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( Import_Util, UnpackAndCombineWithOwningPIDs, 
       imports (),
       numImportPackets (),
       constantNumPackets,
-      distor,
       Tpetra::INSERT,
       Importer->getNumSameIDs (),
       Importer->getPermuteToLIDs (),


### PR DESCRIPTION
@trilinos/tpetra 

## Motivation
This PR removes the Distributor argument that was passed through to all the pack and unpack routines.  This argument was enforced by both the DistObject and Packable interfaces, but was not used in any Tpetra subclass of either of these interfaces.

This argument was complicating the split of Distributor to Actor/Plan within DistObject::begin/endImport/Export, since the new structure does not contain a Distributor object at any point.  Also, since the argument was unused everywhere, it was forcing unnecessary boilerplate on every class that wanted to inherit from DistObject or Packable.

In general, it seems this argument should not be needed, since other arguments to these routines pass the import/export arrays along with sizing information (so there should be no need to query the Distributor).  A comment in the test file CrsGraph_UnpackIntoStaticGraph.cpp suggests the reason for putting Distributor in the interface is to allow some optimized packing order based on some detailed information about index permutations that Distributor holds.  Since Tpetra never takes advantage of this option, it doesn't seem worth it to have the argument hanging around doing nothing.  It seems better from a design perspective to try to figure out an alternative way of getting the permutation information to the pack routines if this optimization became important in future.

Currently WIP:  Using the autotester to identify Trilinos packages outside Tpetra that might be implementing DistObject or Packable (believe this is unlikely based on cursory repo search).

## Testing
This is a refactor, that continues to pass PR and nightly testing.