### PR TITLE
Fix Panzer's workset_builder tests with UVM disabled (1/2)

### DIFF
--- a/packages/panzer/adapters-stk/test/panzer_workset_builder/d_workset_builder.cpp
+++ b/packages/panzer/adapters-stk/test/panzer_workset_builder/d_workset_builder.cpp
@@ -108,7 +108,7 @@ namespace panzer {
     std::vector<Teuchos::RCP<panzer::PhysicsBlock> > physicsBlocks;
     {
       Teuchos::RCP<user_app::MyFactory> eqset_factory = Teuchos::rcp(new user_app::MyFactory);
-    
+
       std::map<std::string,std::string> block_ids_to_physics_ids;
       block_ids_to_physics_ids["eblock-0_0"] = "test physics";
       block_ids_to_physics_ids["eblock-1_0"] = "test physics";
@@ -116,7 +116,7 @@ namespace panzer {
       std::map<std::string,Teuchos::RCP<const shards::CellTopology> > block_ids_to_cell_topo;
       block_ids_to_cell_topo["eblock-0_0"] = mesh->getCellTopology("eblock-0_0");
       block_ids_to_cell_topo["eblock-1_0"] = mesh->getCellTopology("eblock-1_0");
-      
+
       Teuchos::RCP<panzer::GlobalData> gd = panzer::createGlobalData();
 
       panzer::buildPhysicsBlocks(block_ids_to_physics_ids,
@@ -137,7 +137,7 @@ namespace panzer {
       Teuchos::RCP<std::map<unsigned,panzer::Workset> > worksets = panzer_stk::buildBCWorksets(
           *mesh, pb_a->getWorksetNeeds(),pb_a->elementBlockID(),
                  pb_b->getWorksetNeeds(),pb_b->elementBlockID(), sideset);
-     
+
       if(myRank==0) {
         TEST_EQUALITY(worksets->size(),0); // no elements on this processor
       }
@@ -149,7 +149,7 @@ namespace panzer {
         TEST_EQUALITY(workset.num_cells,2);
         TEST_EQUALITY(workset.subcell_dim,1);
         TEST_EQUALITY(workset.numDetails(),2);
-  
+
         // this is identical to workset(0)
         TEST_EQUALITY(workset.subcell_index, 1);
         TEST_EQUALITY(workset.block_id, "eblock-0_0");
@@ -170,7 +170,7 @@ namespace panzer {
         TEST_EQUALITY(workset(0).int_rules.size(),1);
         TEST_EQUALITY(workset(0).basis_names->size(),2);
         TEST_EQUALITY(workset(0).bases.size(),2);
-  
+
         TEST_EQUALITY(workset(1).subcell_index, 3);
         TEST_EQUALITY(workset(1).block_id, "eblock-1_0");
         TEST_EQUALITY(workset(1).cell_local_ids[0],5);
@@ -191,7 +191,7 @@ namespace panzer {
       Teuchos::RCP<std::map<unsigned,panzer::Workset> > worksets = panzer_stk::buildBCWorksets(
           *mesh, pb_a->getWorksetNeeds(),pb_a->elementBlockID(),
                  pb_b->getWorksetNeeds(),pb_b->elementBlockID(), sideset);
-     
+
       if(myRank==1) {
         TEST_EQUALITY(worksets->size(),0); // no elements on this processor
       }
@@ -202,7 +202,7 @@ namespace panzer {
         TEST_EQUALITY(workset.num_cells,2);
         TEST_EQUALITY(workset.subcell_dim,1);
         TEST_EQUALITY(workset.numDetails(),2);
-  
+
         // this is identical to details[0]
         TEST_EQUALITY(workset.subcell_index, 3);
         TEST_EQUALITY(workset.block_id, "eblock-1_0");
@@ -223,7 +223,7 @@ namespace panzer {
         TEST_EQUALITY(workset(0).int_rules.size(),1);
         TEST_EQUALITY(workset(0).basis_names->size(),2);
         TEST_EQUALITY(workset(0).bases.size(),2);
-  
+
         TEST_EQUALITY(workset(1).subcell_index, 1);
         TEST_EQUALITY(workset(1).block_id, "eblock-0_0");
         TEST_EQUALITY(workset(1).cell_local_ids[0],4);
@@ -236,7 +236,7 @@ namespace panzer {
         testIpMatch(workset(0), workset(1), workset.num_cells, out, success);
       }
     }
-    
+
   }
 
   void testInitialzation(const Teuchos::RCP<Teuchos::ParameterList>& ipb,
@@ -273,10 +273,10 @@ namespace panzer {
       double value = 5.0;
       Teuchos::ParameterList p;
       p.set("Value",value);
-      panzer::BC bc(bc_id, neumann, sideset_id, element_block_id, dof_name, 
+      panzer::BC bc(bc_id, neumann, sideset_id, element_block_id, dof_name,
 		    strategy, p);
       bcs.push_back(bc);
-    }    
+    }
     {
       std::size_t bc_id = 0;
       panzer::BCType neumann = BCT_Dirichlet;
@@ -287,10 +287,10 @@ namespace panzer {
       double value = 5.0;
       Teuchos::ParameterList p;
       p.set("Value",value);
-      panzer::BC bc(bc_id, neumann, sideset_id, element_block_id, dof_name, 
+      panzer::BC bc(bc_id, neumann, sideset_id, element_block_id, dof_name,
 		    strategy, p);
       bcs.push_back(bc);
-    }   
+    }
     {
       std::size_t bc_id = 0;
       panzer::BCType neumann = BCT_Dirichlet;
@@ -301,7 +301,7 @@ namespace panzer {
       double value = 5.0;
       Teuchos::ParameterList p;
       p.set("Value",value);
-      panzer::BC bc(bc_id, neumann, sideset_id, element_block_id, dof_name, 
+      panzer::BC bc(bc_id, neumann, sideset_id, element_block_id, dof_name,
 		    strategy, p);
       bcs.push_back(bc);
     }
@@ -310,17 +310,24 @@ namespace panzer {
   void testIpMatch(const panzer::WorksetDetails& d0, const panzer::WorksetDetails& d1,
                    const index_t num_cells, Teuchos::FancyOStream& out, bool& success)
   {
-#define TED01(m) TEST_EQUALITY(d0.m, d1.m)
-    TED01(int_rules.size());
+    TEST_EQUALITY(d0.int_rules.size(), d1.int_rules.size());
     for (std::size_t iri = 0; iri < d0.int_rules.size(); ++iri) {
       const std::size_t num_ip = d0.int_rules[iri]->cub_points.extent(0),
         num_dim = d0.int_rules[iri]->cub_points.extent(1);
+
+      auto d0_rules_view = d0.int_rules[iri]->ip_coordinates.get_view();
+      auto d0_rules_h = Kokkos::create_mirror_view(d0_rules_view);
+      Kokkos::deep_copy(d0_rules_h, d0_rules_view);
+
+      auto d1_rules_view = d1.int_rules[iri]->ip_coordinates.get_view();
+      auto d1_rules_h = Kokkos::create_mirror_view(d1_rules_view);
+      Kokkos::deep_copy(d1_rules_h, d1_rules_view);
+
       for (index_t cell = 0; cell < num_cells; ++cell)
         for (std::size_t ip = 0; ip < num_ip; ++ip)
           for (std::size_t dim = 0; dim < num_dim; ++dim)
-            TED01(int_rules[iri]->ip_coordinates(cell, ip, dim));
+            TEST_EQUALITY(d0_rules_h(cell, ip, dim), d1_rules_h(cell, ip, dim))
     }
-#undef TED01
   }
 
 }

--- a/packages/panzer/adapters-stk/test/panzer_workset_builder/d_workset_builder_3d.cpp
+++ b/packages/panzer/adapters-stk/test/panzer_workset_builder/d_workset_builder_3d.cpp
@@ -178,7 +178,7 @@ TEUCHOS_UNIT_TEST(workset_builder, stk_edge)
   std::vector<Teuchos::RCP<panzer::PhysicsBlock> > physicsBlocks;
   {
     Teuchos::RCP<user_app::MyFactory> eqset_factory = Teuchos::rcp(new user_app::MyFactory);
-    
+
     std::map<std::string,std::string> block_ids_to_physics_ids;
     block_ids_to_physics_ids["eblock-0_0_0"] = "test physics";
     block_ids_to_physics_ids["eblock-1_0_0"] = "test physics";
@@ -186,7 +186,7 @@ TEUCHOS_UNIT_TEST(workset_builder, stk_edge)
     std::map<std::string,Teuchos::RCP<const shards::CellTopology> > block_ids_to_cell_topo;
     block_ids_to_cell_topo["eblock-0_0_0"] = mesh->getCellTopology("eblock-0_0_0");
     block_ids_to_cell_topo["eblock-1_0_0"] = mesh->getCellTopology("eblock-1_0_0");
-      
+
     Teuchos::RCP<panzer::GlobalData> gd = panzer::createGlobalData();
 
     panzer::buildPhysicsBlocks(block_ids_to_physics_ids,
@@ -208,7 +208,7 @@ TEUCHOS_UNIT_TEST(workset_builder, stk_edge)
     Teuchos::RCP<std::map<unsigned,panzer::Workset> > worksets = panzer_stk::buildBCWorksets(
       *mesh,
       pb_a->getWorksetNeeds(),pb_a->elementBlockID(),
-      pb_b->getWorksetNeeds(),pb_b->elementBlockID(), 
+      pb_b->getWorksetNeeds(),pb_b->elementBlockID(),
       sideset);
 
     TEST_EQUALITY(worksets->size(), 1);
@@ -216,7 +216,7 @@ TEUCHOS_UNIT_TEST(workset_builder, stk_edge)
     //std::cout << "prws(workset) for element block index " << ebi << ":\n" << prws(workset) << "\n";
     TEST_EQUALITY(workset.numDetails(), 2);
     testIpMatch(workset.details(0), workset.details(1), workset.num_cells, out, success);
-  }    
+  }
 }
 
 void testInitialization(const Teuchos::RCP<Teuchos::ParameterList>& ipb,
@@ -253,10 +253,10 @@ void testInitialization(const Teuchos::RCP<Teuchos::ParameterList>& ipb,
     double value = 5.0;
     Teuchos::ParameterList p;
     p.set("Value",value);
-    panzer::BC bc(bc_id, neumann, sideset_id, element_block_id, dof_name, 
+    panzer::BC bc(bc_id, neumann, sideset_id, element_block_id, dof_name,
                   strategy, p);
     bcs.push_back(bc);
-  }    
+  }
   {
     std::size_t bc_id = 0;
     panzer::BCType neumann = BCT_Dirichlet;
@@ -267,10 +267,10 @@ void testInitialization(const Teuchos::RCP<Teuchos::ParameterList>& ipb,
     double value = 5.0;
     Teuchos::ParameterList p;
     p.set("Value",value);
-    panzer::BC bc(bc_id, neumann, sideset_id, element_block_id, dof_name, 
+    panzer::BC bc(bc_id, neumann, sideset_id, element_block_id, dof_name,
                   strategy, p);
     bcs.push_back(bc);
-  }   
+  }
   {
     std::size_t bc_id = 0;
     panzer::BCType neumann = BCT_Dirichlet;
@@ -281,7 +281,7 @@ void testInitialization(const Teuchos::RCP<Teuchos::ParameterList>& ipb,
     double value = 5.0;
     Teuchos::ParameterList p;
     p.set("Value",value);
-    panzer::BC bc(bc_id, neumann, sideset_id, element_block_id, dof_name, 
+    panzer::BC bc(bc_id, neumann, sideset_id, element_block_id, dof_name,
                   strategy, p);
     bcs.push_back(bc);
   }
@@ -290,17 +290,24 @@ void testInitialization(const Teuchos::RCP<Teuchos::ParameterList>& ipb,
 void testIpMatch(const panzer::WorksetDetails& d0, const panzer::WorksetDetails& d1,
                  const index_t num_cells, Teuchos::FancyOStream& out, bool& success)
 {
-#define TED01(m) TEST_EQUALITY(d0.m, d1.m)
-  TED01(int_rules.size());
+  TEST_EQUALITY(d0.int_rules.size(), d1.int_rules.size());
   for (std::size_t iri = 0; iri < d0.int_rules.size(); ++iri) {
     const std::size_t num_ip = d0.int_rules[iri]->cub_points.extent(0),
       num_dim = d0.int_rules[iri]->cub_points.extent(1);
+
+    auto d0_rules_view = d0.int_rules[iri]->ip_coordinates.get_view();
+    auto d0_rules_h = Kokkos::create_mirror_view(d0_rules_view);
+    Kokkos::deep_copy(d0_rules_h, d0_rules_view);
+
+    auto d1_rules_view = d1.int_rules[iri]->ip_coordinates.get_view();
+    auto d1_rules_h = Kokkos::create_mirror_view(d1_rules_view);
+    Kokkos::deep_copy(d1_rules_h, d1_rules_view);
+
     for (index_t cell = 0; cell < num_cells; ++cell)
       for (std::size_t ip = 0; ip < num_ip; ++ip)
         for (std::size_t dim = 0; dim < num_dim; ++dim)
-          TED01(int_rules[iri]->ip_coordinates(cell, ip, dim));
+          TEST_EQUALITY(d0_rules_h(cell, ip, dim), d1_rules_h(cell, ip, dim))
   }
-#undef TED01
 }
 
 }

--- a/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.cpp
@@ -544,15 +544,15 @@ generateSurfaceCubatureValues(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_
       Scalar normal[3];
 
       for(int i=0;i<3;i++){normal[i]=0.;}
-        
+
       for(int dim=0; dim<cell_dim; ++dim){
         normal[dim] = surface_normals_k(cell,point,dim);
       }
-      
+
       Scalar transverse[3];
       Scalar binormal[3];
       panzer::convertNormalToRotationMatrix(normal,transverse,binormal);
-      
+
       for(int dim=0; dim<3; ++dim){
         surface_rotation_matrices_k(cell,point,0,dim) = normal[dim];
         surface_rotation_matrices_k(cell,point,1,dim) = transverse[dim];
@@ -564,7 +564,7 @@ generateSurfaceCubatureValues(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_
 
   // =========================================================
   // Enforce alignment across surface quadrature points
-  
+
   const int num_points = ip_coordinates.extent_int(1);
   const int num_faces_per_cell = face_connectivity.numSubcellsOnCellHost(0);
   const int num_points_per_face = num_points / num_faces_per_cell;
@@ -612,7 +612,7 @@ generateSurfaceCubatureValues(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_
 
       // If the cell exists, then the local face index needs to exist
       KOKKOS_ASSERT(lidx_1 >= 0);
-      
+
       // To compare points on planes, it is good to center the planes around the origin
       // Find the face center for the left and right cell (may not be the same point - e.g. periodic conditions)
       // We also define a length scale r2 which gives an order of magnitude approximation to the cell size squared
@@ -622,7 +622,7 @@ generateSurfaceCubatureValues(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_
         for(int dim=0; dim<cell_dim; ++dim){
           xc0[dim] += ip_coordinates_k(cell_0,lidx_0*num_points_per_face + face_point,dim);
           xc1[dim] += ip_coordinates_k(cell_1,lidx_1*num_points_per_face + face_point,dim);
-          const Scalar dx = ip_coordinates_k(cell_0,lidx_0*num_points_per_face + face_point,dim) - ip_coordinates_k(cell_0,lidx_0*num_points_per_face,dim); 
+          const Scalar dx = ip_coordinates_k(cell_0,lidx_0*num_points_per_face + face_point,dim) - ip_coordinates_k(cell_0,lidx_0*num_points_per_face,dim);
           dx2 += dx*dx;
         }
 
@@ -642,14 +642,14 @@ generateSurfaceCubatureValues(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_
       // We use the first point on the face to define the normal (may break for curved faces)
       const int example_point_0 = lidx_0*num_points_per_face;
       const int example_point_1 = lidx_1*num_points_per_face;
-      
+
       // Load the transverse and binormal for the 0 cell (default)
       Scalar t[3] = {surface_rotation_matrices_k(cell_0,example_point_0,1,0), surface_rotation_matrices_k(cell_0,example_point_0,1,1), surface_rotation_matrices_k(cell_0,example_point_0,1,2)};
       Scalar b[3] = {surface_rotation_matrices_k(cell_0,example_point_0,2,0), surface_rotation_matrices_k(cell_0,example_point_0,2,1), surface_rotation_matrices_k(cell_0,example_point_0,2,2)};
 
       // In case the faces are not antiparallel (e.g. periodic wedge), we may need to change the transverse and binormal
       {
-      
+
         // Get the normals for each face for constructing one of the plane vectors (transverse)
         const Scalar n0[3] = {surface_rotation_matrices_k(cell_0,example_point_0,0,0), surface_rotation_matrices_k(cell_0,example_point_0,0,1), surface_rotation_matrices_k(cell_0,example_point_0,0,2)};
         const Scalar n1[3] = {surface_rotation_matrices_k(cell_1,example_point_1,0,0), surface_rotation_matrices_k(cell_1,example_point_1,0,1), surface_rotation_matrices_k(cell_1,example_point_1,0,2)};
@@ -686,7 +686,7 @@ generateSurfaceCubatureValues(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_
           b[0] /= mag_b;
           b[1] /= mag_b;
           b[2] /= mag_b;
-          
+
         }
       }
 
@@ -715,7 +715,7 @@ generateSurfaceCubatureValues(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_
 
         // Set the default for the point order
         point_order(face,face_point_1) = face_point_1;
-        
+
         // Compare to points on the other surface
         for(int face_point_0=0; face_point_0<num_points_per_face; ++face_point_0){
 
@@ -770,12 +770,12 @@ generateSurfaceCubatureValues(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_
     });
     PHX::Device::execution_space().fence();
   }
-    
+
 #undef PANZER_DOT
 #undef PANZER_CROSS
 
   // =========================================================
-    
+
   // I'm not sure if these should exist for surface integrals, but here we go!
 
   // Shakib contravarient metric tensor
@@ -806,7 +806,7 @@ generateSurfaceCubatureValues(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_
     auto s_contravarient = Kokkos::subview(contravarient.get_view(), std::make_pair(0,num_cells),Kokkos::ALL,Kokkos::ALL,Kokkos::ALL);
     auto s_covarient = Kokkos::subview(covarient.get_view(), std::make_pair(0,num_cells),Kokkos::ALL,Kokkos::ALL,Kokkos::ALL);
     Intrepid2::RealSpaceTools<PHX::Device::execution_space>::inverse(s_contravarient, s_covarient);
-    PHX::Device::execution_space().fence();    
+    PHX::Device::execution_space().fence();
   }
 
   // norm of g_ij
@@ -823,7 +823,7 @@ generateSurfaceCubatureValues(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_
       }
       norm_contravarient_k(cell,ip) = Kokkos::Experimental::sqrt(norm_contravarient_k(cell,ip));
     });
-    PHX::Device::execution_space().fence();    
+    PHX::Device::execution_space().fence();
   }
 
 }
@@ -962,6 +962,15 @@ permuteToOther(const PHX::MDField<Scalar,Cell,IP,Dim>& coords,
   const size_type num_ip = coords.extent(1), num_dim = coords.extent(2);
   permutation.resize(num_ip);
   std::vector<char> taken(num_ip, 0);
+
+  auto coords_view = coords.get_view();
+  auto coords_h = Kokkos::create_mirror_view(coords_view);
+  Kokkos::deep_copy(coords_h, coords_view);
+
+  auto other_coords_view = other_coords.get_view();
+  auto other_coords_h = Kokkos::create_mirror_view(other_coords_view);
+  Kokkos::deep_copy(other_coords_h, other_coords_view);
+
   for (size_type ip = 0; ip < num_ip; ++ip) {
     // Find an other point to associate with ip.
     size_type i_min = 0;
@@ -972,7 +981,7 @@ permuteToOther(const PHX::MDField<Scalar,Cell,IP,Dim>& coords,
       // Compute the distance between the two points.
       Scalar d(0);
       for (size_type dim = 0; dim < num_dim; ++dim) {
-        const Scalar diff = coords(cell, ip, dim) - other_coords(cell, other_ip, dim);
+        const Scalar diff = coords_h(cell, ip, dim) - other_coords_h(cell, other_ip, dim);
         d += diff*diff;
       }
       if (d_min < 0 || d < d_min) {


### PR DESCRIPTION
Tests fixed:
- [x] d_workset_builder
- [x] d_workset_builder_3d

There're lots of whitespace trim changes, so for easier readability I'd suggest using GitHub's "Hide whitespace changes" option.

### EDIT 
Main workset_builder test will be added in separate PR.