### PR TITLE
SEACAS: Aprepro - do not diff stderr in tests

### DIFF
--- a/packages/seacas/applications/aprepro/CMakeLists.txt
+++ b/packages/seacas/applications/aprepro/CMakeLists.txt
@@ -30,19 +30,11 @@ TRIBITS_ADD_ADVANCED_TEST(
  aprepro_unit_test
  TEST_0 EXEC aprepro
         ARGS -q ${CMAKE_CURRENT_SOURCE_DIR}/test.inp_app test_unit.output
-  OUTPUT_FILE test-1.stderr
   NOEXEPREFIX NOEXESUFFIX
   PASS_ANY
- TEST_1 CMND sed ARGS s+${CMAKE_CURRENT_SOURCE_DIR}++
-		       ${CMAKE_CURRENT_BINARY_DIR}/test-1.stderr
-  OUTPUT_FILE filtered.output
-  PASS_ANY
- TEST_2 CMND diff ARGS -w
+ TEST_1 CMND diff ARGS -w
 		       ${CMAKE_CURRENT_SOURCE_DIR}/test_standard.out
 		       ${CMAKE_CURRENT_BINARY_DIR}/test_unit.output
- TEST_3 CMND diff ARGS -w
-		       ${CMAKE_CURRENT_SOURCE_DIR}/test.stderr.gold
-		       ${CMAKE_CURRENT_BINARY_DIR}/filtered.output
  COMM mpi serial
  OVERALL_NUM_MPI_PROCS 1
  FINAL_PASS_REGULAR_EXPRESSION

--- a/packages/seacas/applications/aprepro/test.stderr.gold
+++ b/packages/seacas/applications/aprepro/test.stderr.gold
@@ -1,6 +1,0 @@
-Aprepro: ERROR: syntax error, unexpected UNDVAR (/test.inp_app, line 78)
-Aprepro: WARNING: Undefined variable 'This' (/test.inp_app, line 79)
-Aprepro: ERROR: syntax error, unexpected UNDVAR (/test.inp_app, line 79)
-Aprepro: WARNING: User-defined Variable 'a' redefined (_string_, line 1)
-Aprepro: WARNING: Undefined variable 'T' (/test.inp_app, line 199)
-Aprepro: WARNING: Undefined variable 'new_var' (/test.inp_app, line 232)

--- a/packages/seacas/libraries/aprepro_lib/CMakeLists.txt
+++ b/packages/seacas/libraries/aprepro_lib/CMakeLists.txt
@@ -105,7 +105,6 @@ if (${CMAKE_PROJECT_NAME} STREQUAL "SEACASProj")
    endif()
 endif()
 
-# Currently doesn't run on windows due to use of sed...
 if (${CMAKE_PROJECT_NAME}_ENABLE_TESTS)
   TRIBITS_ADD_EXECUTABLE(aprepro_test_app NOEXEPREFIX NOEXESUFFIX SOURCES apr_test.cc LINKER_LANGUAGE CXX)
 
@@ -113,19 +112,11 @@ TRIBITS_ADD_ADVANCED_TEST(
  aprepro_lib_unit_test
  TEST_0 EXEC aprepro_test_app
         ARGS -o test.output ${CMAKE_CURRENT_SOURCE_DIR}/test.inp_app
-  OUTPUT_FILE test.stderr
   NOEXEPREFIX NOEXESUFFIX
   PASS_ANY
- TEST_1 CMND sed ARGS s+${CMAKE_CURRENT_SOURCE_DIR}++
-		       ${CMAKE_CURRENT_BINARY_DIR}/test.stderr
-  OUTPUT_FILE filtered.output
-  PASS_ANY
- TEST_2 CMND diff ARGS -w
+ TEST_1 CMND diff ARGS -w
 		       ${CMAKE_CURRENT_SOURCE_DIR}/test_standard.out
 		       ${CMAKE_CURRENT_BINARY_DIR}/test.output
- TEST_3 CMND diff ARGS -w
-		       ${CMAKE_CURRENT_SOURCE_DIR}/test.stderr.gold
-		       ${CMAKE_CURRENT_BINARY_DIR}/filtered.output
  COMM mpi serial
  OVERALL_NUM_MPI_PROCS 1
  FINAL_PASS_REGULAR_EXPRESSION

--- a/packages/seacas/libraries/aprepro_lib/test.stderr.gold
+++ b/packages/seacas/libraries/aprepro_lib/test.stderr.gold
@@ -1,7 +1,0 @@
-Aprepro: ERROR: syntax error, unexpected UNDVAR (/test.inp_app, line 78)
-Aprepro: WARNING: Undefined variable 'This' (/test.inp_app, line 79)
-Aprepro: ERROR: syntax error, unexpected UNDVAR (/test.inp_app, line 79)
-Aprepro: WARNING: User-defined Variable 'a' redefined (_string_, line 1)
-Aprepro: WARNING: Undefined variable 'T' (/test.inp_app, line 199)
-Aprepro: WARNING: Undefined variable 'new_var' (/test.inp_app, line 232)
-Aprepro: There were 2 errors detected during parsing.


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
Replaced the last test that was relying on a robust diff of stderr to no longer do that.  Many HPC platforms were polluting the stderr output and that resulted in non-robust testing.  The test no longer relies on a diff of stderr and instead just checks the contents of files that apepro itself writes directly.

@trilinos/seacas 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->