### PR TITLE
MueLu: Don't require Epetra for ML defaults

### DIFF
--- a/packages/muelu/src/Interface/MueLu_ML2MueLuParameterTranslator.cpp
+++ b/packages/muelu/src/Interface/MueLu_ML2MueLuParameterTranslator.cpp
@@ -45,7 +45,7 @@
 // @HEADER
 
 #include "MueLu_ConfigDefs.hpp"
-#if defined(HAVE_MUELU_ML) && defined(HAVE_MUELU_EPETRA)
+#if defined(HAVE_MUELU_ML)
 #include <ml_ValidateParameters.h>
 #include <ml_MultiLevelPreconditioner.h> // for default values
 #include <ml_RefMaxwell.h>
@@ -198,7 +198,7 @@ namespace MueLu {
 
     RCP<Teuchos::FancyOStream> out = Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout)); // TODO: use internal out (GetOStream())
 
-#if defined(HAVE_MUELU_ML) && defined(HAVE_MUELU_EPETRA)
+#if defined(HAVE_MUELU_ML)
 
     // TODO alternative with standard parameterlist from ML user guide?
 
@@ -240,7 +240,7 @@ namespace MueLu {
       bool validate = paramList.get("ML validate parameter list", true); /* true = default in ML */
       if (validate && defaultVals!="refmaxwell") {
 
-#if defined(HAVE_MUELU_ML) && defined(HAVE_MUELU_EPETRA)
+#if defined(HAVE_MUELU_ML)
         // Validate parameter list using ML validator
         int depth = paramList.get("ML validate depth", 5); /* 5 = default in ML */
         TEUCHOS_TEST_FOR_EXCEPTION(! ML_Epetra::ValidateMLPParameters(paramList, depth), Exceptions::RuntimeError,

--- a/packages/muelu/src/Interface/MueLu_MLParameterListInterpreter_def.hpp
+++ b/packages/muelu/src/Interface/MueLu_MLParameterListInterpreter_def.hpp
@@ -49,7 +49,7 @@
 #include <Teuchos_XMLParameterListHelpers.hpp>
 
 #include "MueLu_ConfigDefs.hpp"
-#if defined(HAVE_MUELU_ML) && defined(HAVE_MUELU_EPETRA)
+#if defined(HAVE_MUELU_ML)
 #include <ml_ValidateParameters.h>
 #endif
 
@@ -228,7 +228,7 @@ namespace MueLu {
       bool validate = paramList.get("ML validate parameter list", true); /* true = default in ML */
       if (validate) {
 
-#if defined(HAVE_MUELU_ML) && defined(HAVE_MUELU_EPETRA)
+#if defined(HAVE_MUELU_ML)
         // Validate parameter list using ML validator
         int depth = paramList.get("ML validate depth", 5); /* 5 = default in ML */
         TEUCHOS_TEST_FOR_EXCEPTION(! ML_Epetra::ValidateMLPParameters(paramList, depth), Exceptions::RuntimeError,


### PR DESCRIPTION
@trilinos/muelu 

## Motivation
Using the defaults from ML shouldn't require Epetra.