### PR TITLE
atdm: mark KokkosKernels_sparse_cuda as RUN_SERIAL

### DIFF
--- a/cmake/std/atdm/ATDMDisables.cmake
+++ b/cmake/std/atdm/ATDMDisables.cmake
@@ -327,4 +327,7 @@ IF (ATDM_NODE_TYPE STREQUAL "CUDA")
   ATDM_SET_ENABLE(KokkosCore_UnitTest_CudaInterOpStreams_MPI_1_SET_RUN_SERIAL ON)
   # See #8543.
   ATDM_SET_ENABLE(KokkosCore_UnitTest_CudaInterOpInit_MPI_1_SET_RUN_SERIAL ON)
+
+  # Attempt to address intermittent timeouts reported in #6805
+  ATDM_SET_ENABLE(KokkosKernels_sparse_cuda_MPI_1_SET_RUN_SERIAL ON)
 ENDIF()


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/kokkos-kernels 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

Per our discussion in the meeting today, attempt to address intermittent timeout reported in #6805.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Verified change via `nohup env ATDM_CTEST_S_DEFAULT_ENV=cee-rhel7-default Trilinos_PACKAGES=KokkosKernels ./ctest-s-local-test-driver.sh cee-rhel7_cuda-10.1.243_gnu-7.2.0_openmpi-4.0.3_shared_opt &> ctest-s-local-test-driver.out &` - see [cdash](https://testing.sandia.gov/cdash/index.php?project=Trilinos&date=2021-08-24&filtercount=2&showfilters=1&filtercombine=and&field1=buildname&compare1=63&value1=Trilinos-atdm-cee-rhel7_cuda-10.1.243_gnu-7.2.0_openmpi-4.0.3_shared_opt&field2=groupname&compare2=63&value2=Experimental). Looking in the cmake cache shows:
```
$ grep -i run_serial CMakeCache.txt
KokkosCore_UnitTest_CudaInterOpInit_MPI_1_SET_RUN_SERIAL:BOOL=ON
KokkosCore_UnitTest_CudaInterOpStreams_MPI_1_SET_RUN_SERIAL:BOOL=ON
KokkosKernels_sparse_cuda_MPI_1_SET_RUN_SERIAL:BOOL=ON
```

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
Merging this into atdm-nightly or develop gives us more data for iterating on this in next weeks meeting.