### PR TITLE
Tpetra:  added methods to replace Domain and Range maps in CrsMatrix and CrsGraph

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -1544,6 +1544,32 @@ public:
     replaceDomainMapAndImporter (const Teuchos::RCP<const map_type>& newDomainMap,
                                  const Teuchos::RCP<const import_type>& newImporter);
 
+    /// \brief Replace the current Range Map with the given objects.
+    ///
+    /// The Graph's Export object will be recomputed if needed.
+    ///
+    /// \pre <tt>isFillComplete() == true<tt>
+    /// \pre <tt>isFillActive() == false<tt>
+    void
+    replaceRangeMap (const Teuchos::RCP<const map_type>& newRangeMap);
+
+    /// \brief Replace the current Range Map and Export with the
+    ///   given parameters.
+    ///
+    /// \warning This method is ONLY for use by experts.
+    /// \warning We make NO promises of backwards compatibility.
+    ///   This method may change or disappear at any time.
+    ///
+    /// \pre <tt>isFillComplete() == true<tt>
+    /// \pre <tt>isFillActive() == false<tt>
+    /// \pre Either the given Export object is null, or the target Map
+    ///   of the given Export is the same as this graph's Range Map.
+    /// \pre Either the given Export object is null, or the source Map
+    ///    of the given Export is the same as this graph's Row Map.
+    void
+    replaceRangeMapAndExporter (const Teuchos::RCP<const map_type>& newRangeMap,
+                                const Teuchos::RCP<const export_type>& newExporter);
+
     /// \brief Remove processes owning zero rows from the Maps and
     ///   their communicator.
     ///

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -1518,6 +1518,15 @@ public:
                     const Teuchos::RCP<const import_type>& newImport = Teuchos::null,
                     const bool sortIndicesInEachRow = true);
 
+    /// \brief Replace the current domain Map with the given objects.
+    ///
+    /// The Graph's Import object will be recomputed if needed.
+    ///
+    /// \pre <tt>isFillComplete() == true<tt>
+    /// \pre <tt>isFillActive() == false<tt>
+    void
+    replaceDomainMap (const Teuchos::RCP<const map_type>& newDomainMap);
+
     /// \brief Replace the current domain Map and Import with the
     ///   given parameters.
     ///

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -647,6 +647,7 @@ public:
     ///   parameters from \c params sublist "CrsGraph". The domain map
     ///   and range maps passed to fillComplete() are those of the map
     ///   being cloned, if they exist. Otherwise, the row map is used.
+
     /// \brief True if and only if \c CrsGraph is identical to this CrsGraph
     ///
     /// \warning THIS METHOD IS FOR TPETRA DEVELOPERS ONLY.  DO NOT

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -4369,7 +4369,7 @@ namespace Tpetra {
         // than once.  It's polite for them to do so, but not required.
         const bool colSameAsDom = colMap_->isSameAs (*newDomainMap);
         TEUCHOS_TEST_FOR_EXCEPTION
-          (colSameAsDom, std::invalid_argument, "If the new Import is null, "
+          (!colSameAsDom, std::invalid_argument, "If the new Import is null, "
            "then the new domain Map must be the same as the current column Map.");
       }
       else {
@@ -4432,7 +4432,7 @@ namespace Tpetra {
         // than once.  It's polite for them to do so, but not required.
         const bool rowSameAsRange = rowMap_->isSameAs (*newRangeMap);
         TEUCHOS_TEST_FOR_EXCEPTION
-          (rowSameAsRange, std::invalid_argument, "If the new Export is null, "
+          (!rowSameAsRange, std::invalid_argument, "If the new Export is null, "
            "then the new range Map must be the same as the current row Map.");
       }
       else {

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -4389,6 +4389,69 @@ namespace Tpetra {
     importer_ = Teuchos::rcp_const_cast<import_type> (newImporter);
   }
 
+  template <class LocalOrdinal, class GlobalOrdinal, class Node>
+  void
+  CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
+  replaceRangeMap (const Teuchos::RCP<const map_type>& newRangeMap)
+  {
+    const char prefix[] = "Tpetra::CrsGraph::replaceRangeMap: ";
+    TEUCHOS_TEST_FOR_EXCEPTION(
+      rowMap_.is_null (), std::invalid_argument, prefix << "You may not call "
+      "this method unless the graph already has a row Map.");
+    TEUCHOS_TEST_FOR_EXCEPTION(
+      newRangeMap.is_null (), std::invalid_argument,
+      prefix << "The new range Map must be nonnull.");
+
+    // Create a new exporter, if needed
+    Teuchos::RCP<const export_type> newExporter = Teuchos::null;
+    if (newRangeMap != rowMap_ && (! newRangeMap->isSameAs (*rowMap_))) {
+      newExporter = rcp(new export_type(rowMap_, newRangeMap));
+    }
+    this->replaceRangeMapAndExporter(newRangeMap, newExporter);
+  }
+
+  template <class LocalOrdinal, class GlobalOrdinal, class Node>
+  void
+  CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
+  replaceRangeMapAndExporter (const Teuchos::RCP<const map_type>& newRangeMap,
+                              const Teuchos::RCP<const export_type>& newExporter)
+  {
+    const char prefix[] = "Tpetra::CrsGraph::replaceRangeMapAndExporter: ";
+    TEUCHOS_TEST_FOR_EXCEPTION(
+      rowMap_.is_null (), std::invalid_argument, prefix << "You may not call "
+      "this method unless the graph already has a column Map.");
+    TEUCHOS_TEST_FOR_EXCEPTION(
+      newRangeMap.is_null (), std::invalid_argument,
+      prefix << "The new domain Map must be nonnull.");
+
+    if (debug_) {
+      if (newExporter.is_null ()) {
+        // It's not a good idea to put expensive operations in a macro
+        // clause, even if they are side effect - free, because macros
+        // don't promise that they won't evaluate their arguments more
+        // than once.  It's polite for them to do so, but not required.
+        const bool rowSameAsRange = rowMap_->isSameAs (*newRangeMap);
+        TEUCHOS_TEST_FOR_EXCEPTION
+          (rowSameAsRange, std::invalid_argument, "If the new Export is null, "
+           "then the new range Map must be the same as the current row Map.");
+      }
+      else {
+        const bool newRangeSameAsTgt =
+          newRangeMap->isSameAs (* (newExporter->getTargetMap ()));
+        const bool rowSameAsSrc =
+          rowMap_->isSameAs (* (newExporter->getSourceMap ()));
+        TEUCHOS_TEST_FOR_EXCEPTION
+          (! rowSameAsSrc || ! newRangeSameAsTgt, std::invalid_argument, "If the "
+           "new Export is nonnull, then the current row Map must be the same "
+           "as the new Export's source Map, and the new range Map must be the "
+           "same as the new Export's target Map.");
+      }
+    }
+
+    rangeMap_ = newRangeMap;
+    exporter_ = Teuchos::rcp_const_cast<export_type> (newExporter);
+  }
+
 #ifdef TPETRA_ENABLE_DEPRECATED_CODE
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   typename CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::local_graph_device_type

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -4326,6 +4326,26 @@ namespace Tpetra {
     }
   }
 
+  template <class LocalOrdinal, class GlobalOrdinal, class Node>
+  void
+  CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
+  replaceDomainMap (const Teuchos::RCP<const map_type>& newDomainMap)
+  {
+    const char prefix[] = "Tpetra::CrsGraph::replaceDomainMap: ";
+    TEUCHOS_TEST_FOR_EXCEPTION(
+      colMap_.is_null (), std::invalid_argument, prefix << "You may not call "
+      "this method unless the graph already has a column Map.");
+    TEUCHOS_TEST_FOR_EXCEPTION(
+      newDomainMap.is_null (), std::invalid_argument,
+      prefix << "The new domain Map must be nonnull.");
+
+    // Create a new importer, if needed
+    Teuchos::RCP<const import_type> newImporter = Teuchos::null;
+    if (newDomainMap != colMap_ && (! newDomainMap->isSameAs (*colMap_))) {
+      newImporter = rcp(new import_type(newDomainMap, colMap_));
+    }
+    this->replaceDomainMapAndImporter(newDomainMap, newImporter);
+  }
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   void

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -2179,6 +2179,35 @@ namespace Tpetra {
     replaceDomainMapAndImporter (const Teuchos::RCP<const map_type>& newDomainMap,
                                  Teuchos::RCP<const import_type>& newImporter);
 
+    /// \brief Replace the current range Map with the given objects.
+    ///
+    /// The matrix's Export object will be recomputed if needed.
+    ///
+    /// \param newRangeMap [in] New Range Map.  Must be nonnull.
+    ///
+    /// \pre The matrix must be fill complete:
+    ///   <tt>isFillComplete() == true</tt>.
+    /// 
+    void
+    replaceRangeMap (const Teuchos::RCP<const map_type>& newRangeMap);
+
+    /// \brief Replace the current Range Map and Export with the given objects.
+    ///
+    /// \param newRangeMap [in] New domain Map.  Must be nonnull.
+    /// \param newExporter [in] Optional Export object.  If null, the new Range Map must equal the matrix's Row Map
+    ///
+    /// \pre The matrix must be fill complete:
+    ///   <tt>isFillComplete() == true</tt>.
+    /// \pre If the Export is provided, its target Map must be the
+    ///   same as the new Range Map of the matrix.
+    /// \pre If the Export is provided, its source Map must be the
+    ///   same as the Row Map of the matrix
+    /// \pre If the Export is not provided, the new Range Map must be the
+    ///   same as the matrix's Row Map.
+    void
+    replaceRangeMapAndExporter (const Teuchos::RCP<const map_type>& newRangeMap,
+                                Teuchos::RCP<const export_type>& newExporter);
+
     /// \brief Remove processes owning zero rows from the Maps and their communicator.
     ///
     /// \warning This method is ONLY for use by experts.  We highly

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -2150,11 +2150,22 @@ namespace Tpetra {
                     const Teuchos::RCP<const import_type>& newImport = Teuchos::null,
                     const bool sortEachRow = true);
 
+    /// \brief Replace the current domain Map with the given objects.
+    ///
+    /// The matrix's Import object will be recomputed if needed.
+    ///
+    /// \param newDomainMap [in] New domain Map.  Must be nonnull.
+    ///
+    /// \pre The matrix must be fill complete:
+    ///   <tt>isFillComplete() == true</tt>.
+    /// 
+    void
+    replaceDomainMap (const Teuchos::RCP<const map_type>& newDomainMap);
+
     /// \brief Replace the current domain Map and Import with the given objects.
     ///
     /// \param newDomainMap [in] New domain Map.  Must be nonnull.
-    /// \param newImporter [in] Optional Import object.  If null, we
-    ///   will compute it.
+    /// \param newImporter [in] Optional Import object.  If null, the new Domain Map must equal the matrix's Column Map
     ///
     /// \pre The matrix must be fill complete:
     ///   <tt>isFillComplete() == true</tt>.
@@ -2162,6 +2173,8 @@ namespace Tpetra {
     ///   same as the column Map of the matrix.
     /// \pre If the Import is provided, its source Map must be the
     ///   same as the provided new domain Map.
+    /// \pre If the Import is not provided, the new Domain Map must be the
+    ///   same as the matrix's Column Map.
     void
     replaceDomainMapAndImporter (const Teuchos::RCP<const map_type>& newDomainMap,
                                  Teuchos::RCP<const import_type>& newImporter);

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -52,6 +52,7 @@
 #include "Tpetra_Vector.hpp"
 #include "Tpetra_Details_PackTraits.hpp" // unused here, could delete
 #include "KokkosSparse_CrsMatrix.hpp"
+#include "Teuchos_DataAccess.hpp"
 
 #include <memory> // std::shared_ptr
 

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -4392,6 +4392,21 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void
   CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
+  replaceDomainMap (const Teuchos::RCP<const map_type>& newDomainMap)
+  {
+    const char tfecfFuncName[] = "replaceDomainMap: ";
+    TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
+      myGraph_.is_null (), std::runtime_error,
+      "This method does not work if the matrix has a const graph.  The whole "
+      "idea of a const graph is that you are not allowed to change it, but this"
+      " method necessarily must modify the graph, since the graph owns the "
+      "matrix's domain Map and Import objects.");
+    myGraph_->replaceDomainMap (newDomainMap);
+  }
+
+  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+  void
+  CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   replaceDomainMapAndImporter (const Teuchos::RCP<const map_type>& newDomainMap,
                                Teuchos::RCP<const import_type>& newImporter)
   {

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -4423,6 +4423,37 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void
   CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
+  replaceRangeMap (const Teuchos::RCP<const map_type>& newRangeMap)
+  {
+    const char tfecfFuncName[] = "replaceRangeMap: ";
+    TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
+      myGraph_.is_null (), std::runtime_error,
+      "This method does not work if the matrix has a const graph.  The whole "
+      "idea of a const graph is that you are not allowed to change it, but this"
+      " method necessarily must modify the graph, since the graph owns the "
+      "matrix's domain Map and Import objects.");
+    myGraph_->replaceRangeMap (newRangeMap);
+  }
+
+  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+  void
+  CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
+  replaceRangeMapAndExporter (const Teuchos::RCP<const map_type>& newRangeMap,
+                              Teuchos::RCP<const export_type>& newExporter)
+  {
+    const char tfecfFuncName[] = "replaceRangeMapAndExporter: ";
+    TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
+      myGraph_.is_null (), std::runtime_error,
+      "This method does not work if the matrix has a const graph.  The whole "
+      "idea of a const graph is that you are not allowed to change it, but this"
+      " method necessarily must modify the graph, since the graph owns the "
+      "matrix's domain Map and Import objects.");
+    myGraph_->replaceRangeMapAndExporter (newRangeMap, newExporter);
+  }
+
+  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+  void
+  CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   insertNonownedGlobalValues (const GlobalOrdinal globalRow,
                               const Teuchos::ArrayView<const GlobalOrdinal>& indices,
                               const Teuchos::ArrayView<const Scalar>& values)

--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -4162,6 +4162,7 @@ namespace Tpetra {
 
       const LO C_lclNumRows = C_tmp->getLocalLength ();
       const LO C_numVecs = C_tmp->getNumVectors ();
+
       auto C_lcl = C_tmp->getLocalViewDevice(Access::ReadWrite);
       auto C_sub = Kokkos::subview (C_lcl,
                                     std::make_pair (LO (0), C_lclNumRows),
@@ -4173,8 +4174,6 @@ namespace Tpetra {
       const impl_scalar_type alpha_IST (alpha);
 
       ProfilingRegion regionGemm ("Tpetra::MV::multiply-call-gemm");
-
-      //this->modify_device ();
 
       KokkosBlas::gemm (&ctransA, &ctransB, alpha_IST, A_sub, B_sub,
                         beta_local, C_sub);

--- a/packages/tpetra/core/test/CrsMatrix/CMakeLists.txt
+++ b/packages/tpetra/core/test/CrsMatrix/CMakeLists.txt
@@ -176,6 +176,17 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   STANDARD_PASS_OUTPUT
   )
 
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  CrsMatrix_ReplaceRangeMapAndExporter
+  SOURCES
+    CrsMatrix_ReplaceRangeMapAndExporter
+    ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  ARGS ""
+  COMM serial mpi
+  STANDARD_PASS_OUTPUT
+  )
+
+
 TRIBITS_COPY_FILES_TO_BINARY_DIR(CrsMatrixCopyFiles1
   SOURCE_FILES west0067.rua mhd1280b.cua
   EXEDEPS CrsMatrix_UnitTests

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_ReplaceDomainMapAndImporter.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_ReplaceDomainMapAndImporter.cpp
@@ -100,6 +100,99 @@ namespace {
   //
 
   ////
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( CrsMatrix, ReplaceDomainMap, LO, GO, Scalar, Node )
+  {
+    // Based on the FullTriDiag tests...
+
+    typedef CrsMatrix<Scalar,LO,GO,Node> MAT;
+    typedef ScalarTraits<Scalar> STS;
+    typedef typename STS::magnitudeType MT;
+    typedef ScalarTraits<MT> STM;
+
+    const size_t ONE  = OrdinalTraits<size_t>::one();
+    const size_t ZERO = OrdinalTraits<GO>::zero();
+    const global_size_t INVALID = OrdinalTraits<global_size_t>::invalid();
+    // get a comm
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
+    const size_t numImages = comm->getSize();
+    const size_t myImageID = comm->getRank();
+    if (numImages < 3) return;
+    // create a Map
+    RCP<const Map<LO,GO,Node> > map = createContigMapWithNode<LO,GO,Node>(INVALID,ONE,comm);
+
+    // RCP<FancyOStream> fos = Teuchos::fancyOStream(rcp(&std::cout,false));
+
+    /* Create the following matrix:
+    0  [2 1       ]   [2 1]
+    1  [1 4 1     ]   [1 2] + [2 1]
+    2  [  1 4 1   ]           [1 2] +
+    3  [    1     ] =
+       [       4 1]
+   n-1 [       1 2]
+    */
+
+    MAT A(map,4);
+    MAT B(map,4);
+    A.setObjectLabel("The Matrix");
+    B.setObjectLabel("The Other Matrix");
+    if (myImageID != numImages-1) { // last image assigns none
+      Array<Scalar> vals(tuple<Scalar>(static_cast<Scalar>(2)*STS::one(),
+                                       STS::one(),
+                                       static_cast<Scalar>(2)*STS::one()));
+      Array<GO> cols(tuple<GO>(myImageID,myImageID + 1));
+      A.insertGlobalValues(myImageID  ,cols(),vals(0,2)); // insert [2 1]
+      A.insertGlobalValues(myImageID+1,cols(),vals(1,2)); // insert [1 2]
+      B.insertGlobalValues(myImageID  ,cols(),vals(0,2)); // insert [2 1]
+      B.insertGlobalValues(myImageID+1,cols(),vals(1,2)); // insert [1 2]
+    }
+    A.fillComplete();
+    B.fillComplete();
+
+    // Build a one-process Map.
+    if (comm->getSize() > 1) {
+      MT norm = STM::zero ();
+
+      // we know the map is contiguous...
+      const size_t NumMyElements = (comm->getRank () == 0) ?
+        A.getDomainMap ()->getGlobalNumElements () : 0;
+      RCP<const Map<LO,GO,Node> > NewMap =
+        rcp (new Map<LO,GO,Node> (INVALID, NumMyElements, ZERO, comm));
+
+      B.replaceDomainMap (NewMap);
+
+      // Fill a random vector on the original map
+      Vector<Scalar,LO,GO,Node> AVecX(A.getDomainMap());
+      AVecX.randomize();
+
+      // Import this vector to the new domainmap
+      Vector<Scalar,LO,GO,Node> BVecX(B.getDomainMap());
+      Tpetra::Import<LO,GO,Node> TempImport(A.getDomainMap(),NewMap); 
+      BVecX.doImport(AVecX,TempImport,Tpetra::ADD);
+
+      // Now do some multiplies
+      Vector<Scalar,LO,GO,Node> AVecY(A.getRangeMap());
+      Vector<Scalar,LO,GO,Node> BVecY(B.getRangeMap());
+      A.apply(AVecX,AVecY);
+      B.apply(BVecX,BVecY);
+
+      BVecY.update (-STS::one (), AVecY, STS::one ());
+      norm = BVecY.norm2();
+
+      out << "Residual 2-norm: " << norm << endl
+          << "Residual 1-norm: " << BVecY.norm1 () << endl
+          << "Residual Inf-norm: " << BVecY.normInf () << endl;
+
+      // Macros don't like spaces, so we put the test outside the
+      // macro.  Use <= rather than <, so the test passes even if
+      // Scalar is an integer type.
+      //
+      // FIXME (mfh 10 Mar 2013) We should pick the tolerance relative
+      // to the Scalar type and problem size.
+      const bool normSmallEnough = norm <= as<MT> (1e-10);
+      TEST_EQUALITY ( normSmallEnough, true );
+    }
+  }
+ 
   TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( CrsMatrix, ReplaceDomainMapAndImporter, LO, GO, Scalar, Node )
   {
     // Based on the FullTriDiag tests...
@@ -134,9 +227,11 @@ namespace {
     MAT A(map,4);
     MAT B(map,4);
     A.setObjectLabel("The Matrix");
-    A.setObjectLabel("The Other Matrix");
+    B.setObjectLabel("The Other Matrix");
     if (myImageID != numImages-1) { // last image assigns none
-      Array<Scalar> vals(tuple<Scalar>(static_cast<Scalar>(2)*STS::one(),STS::one(),static_cast<Scalar>(2)*STS::one()));
+      Array<Scalar> vals(tuple<Scalar>(static_cast<Scalar>(2)*STS::one(),
+                                       STS::one(),
+                                       static_cast<Scalar>(2)*STS::one()));
       Array<GO> cols(tuple<GO>(myImageID,myImageID + 1));
       A.insertGlobalValues(myImageID  ,cols(),vals(0,2)); // insert [2 1]
       A.insertGlobalValues(myImageID+1,cols(),vals(1,2)); // insert [1 2]
@@ -193,12 +288,98 @@ namespace {
     }
   }
 
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( CrsMatrix, DomainMapEqualsColMap, LO, GO, Scalar, Node )
+  {
+    typedef CrsMatrix<Scalar,LO,GO,Node> MAT;
+    typedef ScalarTraits<Scalar> STS;
+    typedef typename STS::magnitudeType MT;
+    typedef ScalarTraits<MT> STM;
+
+    const global_size_t INVALID = OrdinalTraits<global_size_t>::invalid();
+    // get a comm
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
+    const size_t numImages = comm->getSize();
+    const size_t myImageID = comm->getRank();
+    if (numImages < 3) return;
+    // create a Map
+    RCP<const Map<LO,GO,Node> > map = 
+              createContigMapWithNode<LO,GO,Node>(INVALID,2,comm);
+
+    // RCP<FancyOStream> fos = Teuchos::fancyOStream(rcp(&std::cout,false));
+
+    /* Create the following matrix:
+    0  [2 1       ]   [2 1]
+    1  [1 2       ]   [1 2] 
+    2  [    2 1   ]         + [2 1]
+    3  [    1 2   ] =         [1 2] +
+       [       2 1]
+   n-1 [       1 2]
+    */
+
+    MAT A(map,2);
+    MAT B(map,2);
+    A.setObjectLabel("The Matrix");
+    B.setObjectLabel("The Other Matrix");
+    Array<Scalar> vals(tuple<Scalar>(static_cast<Scalar>(2)*STS::one(),
+                                     STS::one(),
+                                     static_cast<Scalar>(2)*STS::one()));
+    Array<GO> cols(tuple<GO>(2*myImageID,2*myImageID + 1));
+    A.insertGlobalValues(2*myImageID  ,cols(),vals(0,2)); // insert [2 1]
+    A.insertGlobalValues(2*myImageID+1,cols(),vals(1,2)); // insert [1 2]
+    B.insertGlobalValues(2*myImageID  ,cols(),vals(0,2)); // insert [2 1]
+    B.insertGlobalValues(2*myImageID+1,cols(),vals(1,2)); // insert [1 2]
+    A.fillComplete();
+    B.fillComplete();
+
+    {
+      MT norm = STM::zero ();
+
+      // Use the column map to exercise the check for Domain Map == Column Map
+      // in replaceDomainMap; By construction, Column Map is 1-to-1
+      RCP<const Map<LO,GO,Node> > NewMap = B.getColMap();
+
+      B.replaceDomainMap (NewMap);
+
+      // Fill a random vector on the original map
+      Vector<Scalar,LO,GO,Node> AVecX(A.getDomainMap());
+      AVecX.randomize();
+
+      // Import this vector to the new domainmap
+      Vector<Scalar,LO,GO,Node> BVecX(B.getDomainMap());
+      Tpetra::Import<LO,GO,Node> TempImport(A.getDomainMap(),NewMap); 
+      BVecX.doImport(AVecX,TempImport,Tpetra::ADD);
+
+      // Now do some multiplies
+      Vector<Scalar,LO,GO,Node> AVecY(A.getRangeMap());
+      Vector<Scalar,LO,GO,Node> BVecY(B.getRangeMap());
+      A.apply(AVecX,AVecY);
+      B.apply(BVecX,BVecY);
+
+      BVecY.update (-STS::one (), AVecY, STS::one ());
+      norm = BVecY.norm2();
+
+      out << "Residual 2-norm: " << norm << endl
+          << "Residual 1-norm: " << BVecY.norm1 () << endl
+          << "Residual Inf-norm: " << BVecY.normInf () << endl;
+
+      // Macros don't like spaces, so we put the test outside the
+      // macro.  Use <= rather than <, so the test passes even if
+      // Scalar is an integer type.
+      //
+      // FIXME (mfh 10 Mar 2013) We should pick the tolerance relative
+      // to the Scalar type and problem size.
+      const bool normSmallEnough = norm <= as<MT> (1e-10);
+      TEST_EQUALITY ( normSmallEnough, true );
+    }
+  }
 //
 // INSTANTIATIONS
 //
 
 #define UNIT_TEST_GROUP( SCALAR, LO, GO, NODE ) \
-  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( CrsMatrix, ReplaceDomainMapAndImporter, LO, GO, SCALAR, NODE )
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( CrsMatrix, ReplaceDomainMap, LO, GO, SCALAR, NODE ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( CrsMatrix, ReplaceDomainMapAndImporter, LO, GO, SCALAR, NODE ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( CrsMatrix, DomainMapEqualsColMap, LO, GO, SCALAR, NODE )
 
   TPETRA_ETI_MANGLING_TYPEDEFS()
 


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

Implementing replaceDomainMap, replaceRangeMap, replaceRangeMapAndExporter to complement existing replaceDomainMapAndImporter, as recommended in #9451 

Unfortunately, these methods do not resolve the issue #9391 (creating a new matrix with the same local graph, rowMap and columnMap as an existing matrix, but different Range and Domain maps).  See further notes in re-opened issue #9391.


<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

New tests added to CrsMatrix_replaceDomainMapAndImporter.cpp to exercise new replaceDomainMap (both with a different map and the same map).
New file of tests CrsMatrix_replaceRangeMapAndExporter.cpp to exercise new replaceRangeMap (both with a different map and the same map) and replaceRangeMapAndExporter.
Tested on mac with gcc 8.5 and openmpi 1.10.7.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->