### PR TITLE
Ifpack2 Chebyshev: Add CG option for computation of spectral radius

### DIFF
--- a/packages/ifpack2/src/Ifpack2_Details_Chebyshev_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Chebyshev_decl.hpp
@@ -482,6 +482,9 @@ private:
   //! Whether the iteration vectors of the power method should be saved.
   bool eigKeepVectors_;
 
+  //! Type of eigen-analysis, i.e. power method or cg.
+  std::string eigenAnalysisType_;
+
   //! Iteration vectors of the power method. Can be saved for the purpose of multiple setups.
   Teuchos::RCP<V> eigVector_;
   Teuchos::RCP<V> eigVector2_;
@@ -692,6 +695,33 @@ private:
   /// \return Estimate of the maximum eigenvalue of A*D_inv.
   ST
   powerMethod (const op_type& A, const V& D_inv, const int numIters);
+
+  /// \brief Use the cg method to estimate the maximum eigenvalue
+  ///   of A*D_inv, given an initial guess vector x.
+  ///
+  /// \param A [in] The Operator to use.
+  /// \param D_inv [in] Vector to use as implicit right scaling of A.
+  /// \param numIters [in] Maximum number of iterations of the power
+  ///   method.
+  /// \param x [in/out] On input: Initial guess Vector for the cg
+  ///   method.  Its Map must be the same as that of the domain Map of
+  ///   A.  This method may use this Vector as scratch space.
+  ///
+  /// \return Estimate of the maximum eigenvalue of A*D_inv.
+  ST
+  cgMethodWithInitGuess (const op_type& A, const V& D_inv, const int numIters, V& x);
+
+  /// \brief Use the cg method to estimate the maximum eigenvalue
+  ///   of A*D_inv.
+  ///
+  /// \param A [in] The Operator to use.
+  /// \param D_inv [in] Vector to use as implicit right scaling of A.
+  /// \param numIters [in] Maximum number of iterations of the power
+  ///   method.
+  ///
+  /// \return Estimate of the maximum eigenvalue of A*D_inv.
+  ST
+  cgMethod (const op_type& A, const V& D_inv, const int numIters);
 
   //! The maximum infinity norm of all the columns of X.
   static MT maxNormInf (const MV& X);

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestChebyshev.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestChebyshev.cpp
@@ -151,6 +151,30 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2Chebyshev, Test0, Scalar, LocalOrdinal,
     Teuchos::ArrayRCP<const Scalar> yview = y.get1dView();
     TEST_COMPARE_FLOATING_ARRAYS(yview, halfs(), tol);
   }
+
+  crsmatrix = tif_utest::create_test_matrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>(rowmap, -one);
+  Scalar n = Teuchos::as<Scalar>(rowmap->getGlobalNumElements());
+  Scalar expectedLambdaMax = one-std::cos(Teuchos::ScalarTraits<Scalar>::pi()*n/(n+1));
+
+  prec.setMatrix(crsmatrix);
+
+  params.set("debug", true);
+  params.remove("chebyshev: max eigenvalue");
+  params.remove("chebyshev: min eigenvalue");
+
+  params.set("eigen-analysis: type", "power method");
+  params.set("chebyshev: eigenvalue max iterations",30);
+  prec.setParameters(params);
+  prec.compute();
+
+  TEST_FLOATING_EQUALITY(prec.getLambdaMaxForApply(),expectedLambdaMax,2e-2);
+
+  params.set("eigen-analysis: type", "cg");
+  params.set("chebyshev: eigenvalue max iterations",10);
+  prec.setParameters(params);
+  prec.compute();
+
+  TEST_FLOATING_EQUALITY(prec.getLambdaMaxForApply(),expectedLambdaMax,2e-2);
 }
 
 #define UNIT_TEST_GROUP_SC_LO_GO(Scalar,LocalOrdinal,GlobalOrdinal) \

--- a/packages/muelu/src/Interface/MueLu_ML2MueLuParameterTranslator.cpp
+++ b/packages/muelu/src/Interface/MueLu_ML2MueLuParameterTranslator.cpp
@@ -164,6 +164,8 @@ namespace MueLu {
       else { mueluss << "<Parameter name=\"chebyshev: degree\" type=\"int\" value=\"2\"/>" << std::endl; }
       if ( paramList.isParameter("smoother: Chebyshev alpha") ) { mueluss << "<Parameter name=\"chebyshev: ratio eigenvalue\" type=\"double\" value=\"" << paramList.get<double>("smoother: Chebyshev alpha") << "\"/>" << std::endl; adaptingParamList.remove("smoother: Chebyshev alpha",false); }
       else { mueluss << "<Parameter name=\"chebyshev: ratio eigenvalue\" type=\"double\" value=\"20\"/>" << std::endl; adaptingParamList.remove("smoother: Chebyshev alpha",false); }
+      if ( paramList.isParameter("eigen-analysis: type") ) {  mueluss << "<Parameter name=\"eigen-analysis: type\" type=\"string\" value=\"" << paramList.get<std::string>("eigen-analysis: type") << "\"/>" << std::endl; adaptingParamList.remove("eigen-analysis: type",false); }
+      else { mueluss << "<Parameter name=\"eigen-analysis: type\" type=\"string\" value=\"cg\"/>" << std::endl; }
     }
 
     // MLS
@@ -174,6 +176,8 @@ namespace MueLu {
       if ( paramList.isParameter("smoother: MLS alpha") ) { mueluss << "<Parameter name=\"chebyshev: ratio eigenvalue\" type=\"double\" value=\"" << paramList.get<double>("smoother: MLS alpha") << "\"/>" << std::endl; adaptingParamList.remove("smoother: MLS alpha",false); }
       else if ( paramList.isParameter("smoother: Chebyshev alpha") ) { mueluss << "<Parameter name=\"chebyshev: ratio eigenvalue\" type=\"double\" value=\"" << paramList.get<double>("smoother: Chebyshev alpha") << "\"/>" << std::endl; adaptingParamList.remove("smoother: Chebyshev alpha",false); }
       else { mueluss << "<Parameter name=\"chebyshev: ratio eigenvalue\" type=\"double\" value=\"20\"/>" << std::endl; }
+      if ( paramList.isParameter("eigen-analysis: type") ) {  mueluss << "<Parameter name=\"eigen-analysis: type\" type=\"string\" value=\"" << paramList.get<std::string>("eigen-analysis: type") << "\"/>" << std::endl; adaptingParamList.remove("eigen-analysis: type",false); }
+      else { mueluss << "<Parameter name=\"eigen-analysis: type\" type=\"string\" value=\"cg\"/>" << std::endl; }
     }
 
     // parameters for ILU based preconditioners

--- a/packages/muelu/src/Interface/MueLu_ML2MueLuParameterTranslator.cpp
+++ b/packages/muelu/src/Interface/MueLu_ML2MueLuParameterTranslator.cpp
@@ -46,9 +46,12 @@
 
 #include "MueLu_ConfigDefs.hpp"
 #if defined(HAVE_MUELU_ML)
-#include <ml_ValidateParameters.h>
-#include <ml_MultiLevelPreconditioner.h> // for default values
-#include <ml_RefMaxwell.h>
+# include <ml_config.h>
+# if defined(HAVE_ML_EPETRA) && defined(HAVE_ML_TEUCHOS)
+#  include <ml_ValidateParameters.h>
+#  include <ml_MultiLevelPreconditioner.h> // for default values
+#  include <ml_RefMaxwell.h>
+# endif
 #endif
 
 #include <MueLu_ML2MueLuParameterTranslator.hpp>
@@ -198,7 +201,7 @@ namespace MueLu {
 
     RCP<Teuchos::FancyOStream> out = Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout)); // TODO: use internal out (GetOStream())
 
-#if defined(HAVE_MUELU_ML)
+#if defined(HAVE_MUELU_ML) && defined(HAVE_ML_EPETRA) && defined(HAVE_ML_TEUCHOS)
 
     // TODO alternative with standard parameterlist from ML user guide?
 
@@ -218,9 +221,9 @@ namespace MueLu {
 #else
     if (defaultVals != "") {
         // If no validator available: issue a warning and set parameter value to false in the output list
-        *out << "Warning: MueLu_ENABLE_ML=OFF and/or MueLu_ENABLE_Epetra=OFF. No ML default values available." << std::endl;
+        *out << "Warning: MueLu_ENABLE_ML=OFF, ML_ENABLE_Epetra=OFF or ML_ENABLE_TEUCHOS=OFF. No ML default values available." << std::endl;
     }
-#endif // HAVE_MUELU_ML
+#endif // HAVE_MUELU_ML && HAVE_ML_EPETRA && HAVE_ML_TEUCHOS
 
     //
     // Move smoothers/aggregation/coarse parameters to sublists
@@ -240,17 +243,17 @@ namespace MueLu {
       bool validate = paramList.get("ML validate parameter list", true); /* true = default in ML */
       if (validate && defaultVals!="refmaxwell") {
 
-#if defined(HAVE_MUELU_ML)
+#if defined(HAVE_MUELU_ML) && defined(HAVE_ML_EPETRA) && defined(HAVE_ML_TEUCHOS)
         // Validate parameter list using ML validator
         int depth = paramList.get("ML validate depth", 5); /* 5 = default in ML */
         TEUCHOS_TEST_FOR_EXCEPTION(! ML_Epetra::ValidateMLPParameters(paramList, depth), Exceptions::RuntimeError,
                                    "ERROR: ML's Teuchos::ParameterList contains incorrect parameter!");
 #else
         // If no validator available: issue a warning and set parameter value to false in the output list
-        *out << "Warning: MueLu_ENABLE_ML=OFF and/or MueLu_ENABLE_Epetra=OFF. The parameter list cannot be validated." << std::endl;
+        *out << "Warning: MueLu_ENABLE_ML=OFF, ML_ENABLE_Epetra=OFF or ML_ENABLE_TEUCHOS=OFF. The parameter list cannot be validated." << std::endl;
         paramList.set("ML validate parameter list", false);
 
-#endif // HAVE_MUELU_ML
+#endif // HAVE_MUELU_ML && HAVE_ML_EPETRA && HAVE_ML_TEUCHOS
       } // if(validate)
     } // scope
 

--- a/packages/muelu/test/interface/default/Output/MLsmoother4b_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLsmoother4b_epetra.gold
@@ -4,6 +4,7 @@ Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
 smoother -> 
  chebyshev: degree = 2
  chebyshev: ratio eigenvalue = 20
+ eigen-analysis: type = cg
 Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -39,6 +40,7 @@ Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
 smoother -> 
  chebyshev: degree = 2
  chebyshev: ratio eigenvalue = 20   [unused]
+ eigen-analysis: type = cg
 Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -74,6 +76,7 @@ Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
 smoother -> 
  chebyshev: degree = 2
  chebyshev: ratio eigenvalue = 20   [unused]
+ eigen-analysis: type = cg
 Level 3
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -109,6 +112,7 @@ Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
 smoother -> 
  chebyshev: degree = 2
  chebyshev: ratio eigenvalue = 20   [unused]
+ eigen-analysis: type = cg
 Level 4
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)


### PR DESCRIPTION
@trilinos/ifpack2 

## Motivation
Add option to compute the spectral radius of D^-1 A using CG. Can be selected via "eigen-analysis: type" = "cg".

ML uses CG by default. This will simplify transitioning from ML to MueLu.