### PR TITLE
Tempus: Utilize TimeEvent in TimeStepControl

### DIFF
--- a/packages/tempus/src/Tempus_TimeEventBase.hpp
+++ b/packages/tempus/src/Tempus_TimeEventBase.hpp
@@ -19,17 +19,17 @@ namespace Tempus {
 
 
 /** \brief This class defines time events which can be used to "trigger" an action.
+ *
  *  Time events are points in time and/or timestep index where an
  *  an action should occur, such as, solution output (mesh and solution)
  *  diagnostic output, restart, screen dump, in-situ visualization,
  *  user-specified, or any other action.
  *
  *  This class will store a collection time events, so that an object
- *  may quiry it and take appropriate action.  Time events (time and
+ *  may query it and take appropriate action.  Time events (time and
  *  timestep index) can be specified via
  *    - start, stop and stride
  *    - list of events
- *
  */
 template<class Scalar>
 class TimeEventBase
@@ -38,10 +38,11 @@ public:
 
   /// Constructor
   TimeEventBase()
-    : name_("TimeEventBase"),
-      defaultTime_ (-std::numeric_limits<Scalar>::max()*1.0e-16),
-      defaultTol_  ( std::numeric_limits<Scalar>::min()),
-      defaultIndex_( std::numeric_limits<int>::min())
+    : timeEventType_("Base"),
+      name_("TimeEventBase"),
+      defaultTime_ (std::numeric_limits<Scalar>::max()),
+      defaultTol_  (std::numeric_limits<Scalar>::min()),
+      defaultIndex_(std::numeric_limits<int>::max())
   {}
 
   /// Destructor
@@ -49,68 +50,177 @@ public:
 
   /// \name Basic methods
   //@{
-    /// Test if time is near a TimeEvent (within tolerance).
+    /** \brief Test if time is near a TimeEvent (within tolerance).
+     *
+     *  For TimeEventBase, always return false since it has no events.
+     *
+     *  \param time [in] The input time.
+     *  \return True if time is near an event (within absolute tolerance).
+     */
     virtual bool isTime(Scalar time) const
     { return false; }
 
+    /** \brief Return the absolute tolerance.
+     *
+     *  The absolute tolerance is the TimeEvent time scale multiplied by
+     *  the relative tolerance (e.g., timeScale_*relTol_).
+     *
+     *  For TimeEventBase, the absolute tolerance is the default tolerance.
+     *
+     *  \return The absolute tolerance.
+     */
     virtual Scalar getAbsTol() const
     { return defaultTol_; }
 
-    /// How much time until the next event. Negative indicating the last event is in the past.
+    /** \brief How much time until the next event.
+     *
+     *  For TimeEventBase, the time to the next event is the default time,
+     *  since TimeEventBace has no events.
+     *
+     *  \return The time to the next event.
+     */
     virtual Scalar timeToNextEvent(Scalar time) const
     { return defaultTime_; }
 
-    /// Time of the next event. Negative indicating the last event is in the past.
+    /** \brief Return the time of the next time event following the input time.
+     *
+     *  Returns the time of the next event that follows the input time.
+     *  If the input time is before all events, the time of the first
+     *  event is returned.  If the input time is after all events, the
+     *  default time (a time in the distant future) is returned.  If the
+     *  input time is an event time, the time of the next event is returned.
+     *
+     *  For TimeEventBase, always return the default time.
+     *
+     *  \param time [in] Input time.
+     *  \return Time of the next event.
+     */
     virtual Scalar timeOfNextEvent(Scalar time) const
     { return defaultTime_; }
 
-    /// Test if an event occurs within the time range.
+    /** \brief Test if an event occurs within the time range.
+     *
+     *  Find if an event is within the input range, inclusively
+     *  ( time1 <= event <= time2 ).  This may require testing
+     *  each event in the TimeEvent.
+     *
+     *  For TimeEventBase, always return false since it has no events.
+     *
+     *  \param time1 [in] Input time of one end of the range.
+     *  \param time2 [in] Input time of the other end of the range.
+     *
+     *  \return True if a time event is within the range.
+     */
     virtual bool eventInRange(Scalar time1, Scalar time2) const
     { return false; }
 
-    /// Test if index is a time event.
+    /** \brief Test if index is a time event.
+     *
+     *  For TimeEventBase, always return false since it has no events.
+     *
+     *  \param index [in] The input index.
+     *  \return True if index is an event.
+     */
     virtual bool isIndex(int index) const
     { return false; }
 
-    /// How many indices until the next event. Negative indicating the last event is in the past.
+    /** \brief How many indices until the next event.
+     *
+     *  For TimeEventBase, the index to the next event is the default index.
+     *
+     *  \return The index to the next event.
+     */
     virtual int indexToNextEvent(int index) const
     { return defaultIndex_; }
 
-    /// Index of the next event. Negative indicating the last event is in the past.
+    /** \brief Return the index of the next event following the input index.
+     *
+     *  Returns the index of the next event that follows the input index.
+     *  If the input index is before all events, the index of the first
+     *  event is returned.  If the input index is after all events, the
+     *  default index (an index in the distant future) is returned.  If the
+     *  input index is an event index, the index of the next event is returned.
+     *
+     *  For TimeEventBase, always return the default index.
+     *
+     *  \param index [in] Input index.
+     *  \return Index of the next event.
+     */
     virtual int indexOfNextEvent(int index) const
     { return defaultIndex_; }
 
-    /// Test if an event occurs within the time range.
+    /** \brief Test if an event occurs within the index range.
+     *
+     *  Find if an event is within the input range, inclusively
+     *  ( index1 <= event <= index2 ).  This may require testing
+     *  each event in the TimeEvent.
+     *
+     *  For TimeEventBase, always return false since it has no events.
+     *
+     *  \param index1 [in] Input index of one end of the range.
+     *  \param index2 [in] Input index of the other end of the range.
+     *
+     *  \return True if a index event is within the range.
+     */
     virtual bool eventInRangeIndex(int index1, int index2) const
     { return false; }
 
     /// Describe member data.
-    virtual void describe() const
+    virtual void describe(Teuchos::FancyOStream          &out,
+                          const Teuchos::EVerbosityLevel verbLevel) const
     {
-      Teuchos::RCP<Teuchos::FancyOStream> out =
-        Teuchos::VerboseObjectBase::getDefaultOStream();
-      out->setOutputToRootOnly(0);
-      *out << "TimeEventBase name = " << getName() << std::endl;
+      auto l_out = Teuchos::fancyOStream( out.getOStream() );
+      Teuchos::OSTab ostab(*l_out, 2, "TimeEventBase");
+      l_out->setOutputToRootOnly(0);
+
+      *l_out << "TimeEventBase name = " << getName() << std::endl;
     }
   //@}
 
   /// \name Accessor methods
   //@{
+    /** \brief Return the name of the TimeEvent.
+     *
+     *  The name of the TimeEvent can be used to identify
+     *  specific TimeEvents in order to take action related
+     *  to that TimeEvent (e.g., a name of "Output Special"
+     *  may indicate to output some special information).
+     *
+     *  \return The name of the TimeEvent.
+     */
     virtual std::string getName() const { return name_; }
+    /// Set the name of the TimeEvent.
     virtual void setName(std::string name) { name_ = name; }
-
+    /** \brief Return the type of TimeEvent.
+     *
+     *  Each derived class of TimeEventBase has a type that
+     *  can be used to identify the type of the TimeEvent.
+     */
+    virtual std::string getType() const { return timeEventType_; }
+    /// Return the default time used for TimeEvents.
     virtual Scalar getDefaultTime () const { return defaultTime_; }
+    /// Return the default tolerance used by TimeEvents.
     virtual Scalar getDefaultTol  () const { return defaultTol_; }
+    /// Return the default index used by TimeEvents.
     virtual int    getDefaultIndex() const { return defaultIndex_; }
   //@}
 
 
+  /// Return ParameterList with current values.
+  virtual Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const
+  { return Teuchos::null; }
+
+protected:
+
+  virtual void setType(std::string s) { timeEventType_ = s; }
+
 private:
 
-  std::string  name_;
-  const Scalar defaultTime_;
-  const Scalar defaultTol_;
-  const int    defaultIndex_;
+  std::string  timeEventType_;   ///< Time Event type
+  std::string  name_;            ///< Name to identify the TimeEvent
+  const Scalar defaultTime_;     ///< Default time
+  const Scalar defaultTol_;      ///< Default tolerance
+  const int    defaultIndex_;    ///< Default index
 
 };
 

--- a/packages/tempus/src/Tempus_TimeEventBase.hpp
+++ b/packages/tempus/src/Tempus_TimeEventBase.hpp
@@ -41,7 +41,7 @@ public:
     : timeEventType_("Base"),
       name_("TimeEventBase"),
       defaultTime_ (std::numeric_limits<Scalar>::max()),
-      defaultTol_  (std::numeric_limits<Scalar>::min()),
+      defaultTol_  (std::numeric_limits<Scalar>::epsilon()*Scalar(100.0)),
       defaultIndex_(std::numeric_limits<int>::max())
   {}
 
@@ -208,7 +208,16 @@ public:
 
   /// Return ParameterList with current values.
   virtual Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const
-  { return Teuchos::null; }
+  {
+    Teuchos::RCP<Teuchos::ParameterList> pl =
+      Teuchos::parameterList("Time Event Base");
+
+    pl->setName(this->getName());
+    pl->set("Name", this->getName());
+    pl->set("Type", this->getType());
+
+    return pl;
+  }
 
 protected:
 

--- a/packages/tempus/src/Tempus_TimeEventComposite.hpp
+++ b/packages/tempus/src/Tempus_TimeEventComposite.hpp
@@ -9,12 +9,16 @@
 #ifndef Tempus_TimeEventComposite_decl_hpp
 #define Tempus_TimeEventComposite_decl_hpp
 
-// Teuchos
 #include "Teuchos_Time.hpp"
+#include "Teuchos_ParameterList.hpp"
 
-// Tempus
 #include "Tempus_config.hpp"
 #include "Tempus_TimeEventBase.hpp"
+#include "Tempus_TimeEventComposite.hpp"
+#include "Tempus_TimeEventRange.hpp"
+#include "Tempus_TimeEventRangeIndex.hpp"
+#include "Tempus_TimeEventList.hpp"
+#include "Tempus_TimeEventListIndex.hpp"
 
 
 namespace Tempus {
@@ -30,10 +34,21 @@ class TimeEventComposite : virtual public TimeEventBase<Scalar>
 {
 public:
 
-  /// Constructor
+  /// Default Constructor
   TimeEventComposite()
   {
+    this->setType("Composite");
     this->setName("TimeEventComposite");
+  }
+
+  /// Construct with full argument list of data members.
+  TimeEventComposite(
+    std::vector<Teuchos::RCP<TimeEventBase<Scalar> > > te,
+    std::string name = "TimeEventComposite")
+  {
+    this->setType("Composite");
+    this->setName(name);
+    this->setTimeEvents(te);
   }
 
   /// Destructor
@@ -41,121 +56,334 @@ public:
 
   /// \name Basic methods
   //@{
-    /// Test if time is near a TimeEvent (within tolerance).
+    /// Get a copy of the current set of TimeEvents.
+    virtual std::vector<Teuchos::RCP<TimeEventBase<Scalar > > > getTimeEvents() const
+    {
+      std::vector<Teuchos::RCP<TimeEventBase<Scalar > > > te = timeEvents_;
+      return te;
+    }
+
+    /** \brief Set the TimeEvents.
+     *
+     *  This completely replaces the current set of TimeEvents with
+     *  the input TimeEvents
+     *
+     *  \param te [in] The input set of TimeEvents.
+     */
+    virtual void setTimeEvents(
+      std::vector<Teuchos::RCP<TimeEventBase<Scalar> > > te)
+    { timeEvents_ = te; }
+
+    /** \brief Test if time is near a TimeEvent (within tolerance).
+     *
+     *  Return true if one of the TimeEvents in the composite is near
+     *  the input time.
+     *
+     *  \param time [in] The input time.
+     *  \return True if time is near an event (within absolute tolerance).
+     */
     virtual bool isTime(Scalar time) const
     {
+      Teuchos::RCP<TimeEventBase<Scalar> > timeEvent;
+      return isTime(time, timeEvent);
+    }
+
+    /** \brief Test if time is near a TimeEvent (within tolerance) plus the constraining TimeEvent.
+     *
+     *  Return true if one of the TimeEvents in the composite is near
+     *  the input time, and the constraining TimeEvent so additional details
+     *  about the event can be queried.
+     *
+     *  \param time      [in] The input time.
+     *  \param timeEvent [out] The constraining TimeEvent.
+     *  \return True if time is near an event (within absolute tolerance).
+     */
+    virtual bool isTime(Scalar time, Teuchos::RCP<TimeEventBase<Scalar> > & timeEvent) const
+    {
+      timeEvent = Teuchos::rcp(new TimeEventBase<Scalar>());
       bool is_time = false;
       for(auto& e : timeEvents_) {
         if (e->isTime(time)) {
           is_time = true;
+          timeEvent = e;
           break;
         }
       }
       return is_time;
     }
 
-    /// How much time until the next event. Negative indicating the last event is in the past.
+    /** \brief How much time until the next event.
+     *
+     *  Return the amount of time to the next event (i.e., time of
+     *  next event minus the input time).
+     *
+     *  \param time      [in] The input time.
+     *  \return The time to the next event.
+     */
     virtual Scalar timeToNextEvent(Scalar time) const
+    { return timeOfNextEvent(time) - time; }
+
+    /** \brief How much time until the next event plus the constraining TimeEvent.
+     *
+     *  Return the amount of time to the next event (i.e., time of
+     *  next event minus the input time), and the constraining TimeEvent
+     *  so additional details about the event can be queried.
+     *
+     *  \param time      [in] The input time.
+     *  \param timeEvent [out] The constraining TimeEvent.
+     *  \return The time to the next event.
+     */
+    virtual Scalar timeToNextEvent(
+      Scalar time, Teuchos::RCP<TimeEventBase<Scalar> > & timeEvent) const
     {
-      return timeOfNextEvent(time) - time;
+      timeEvent = Teuchos::rcp(new TimeEventBase<Scalar>());
+      return timeOfNextEvent(time, timeEvent) - time;
     }
 
-    /// Time of the next event. Negative indicating the last event is in the past.
+    /** \brief Return the time of the next time event following the input time.
+     *
+     *  See timeOfNextEvent(Scalar time, & timeEvent).
+     *
+     *  \param time [in] Input time.
+     *  \return Time of the next event.
+     */
     virtual Scalar timeOfNextEvent(Scalar time) const
     {
-      std::vector< std::pair<Scalar, Scalar> > timeAbs;
+      Teuchos::RCP<TimeEventBase<Scalar> > timeEvent;
+      return timeOfNextEvent(time, timeEvent);
+    }
+
+    /** \brief Return the time of the next time event and constraining TimeEvent.
+     *
+     *  Returns the time of the next event that follows the input time.
+     *  If the input time is before all events, the time of the first
+     *  event is returned.  If the input time is after all events, the
+     *  default time (a time in the distant future) is returned.  If the
+     *  input time is an event time, the time of the next event is returned.
+     *
+     *  For TimeEventComposite, find the next time event from all the
+     *  TimeEvents in the composite.
+     *
+     *  Additionally, output the constraining TimeEvent
+     *  so additional details about the event can be queried.
+     *
+     *  \param time      [in]  Input time.
+     *  \param timeEvent [out] Constraining TimeEvent.
+     *  \return Time of the next event.
+     */
+    virtual Scalar timeOfNextEvent(
+      Scalar time, Teuchos::RCP<TimeEventBase<Scalar> > & timeEvent) const
+    {
+      timeEvent = Teuchos::rcp(new TimeEventBase<Scalar>());
+      std::vector<std::pair<Scalar, Teuchos::RCP<TimeEventBase<Scalar> > > > timeEventPair;
       for(auto& e : timeEvents_)
-        timeAbs.push_back(std::make_pair(e->timeOfNextEvent(time), e->getAbsTol()));
-      std::sort(timeAbs.begin(), timeAbs.end());
+        timeEventPair.push_back(std::make_pair(e->timeOfNextEvent(time), e));
 
-      if (timeAbs.size() == 0) return this->getDefaultTime();
+      if (timeEventPair.size() == 0) {
+        return this->getDefaultTime();
+      }
 
-      // Check if before or close to first event.
-      if (timeAbs.front().first >= time-timeAbs.front().second)
-        return timeAbs.front().first;
+      auto compare = [](std::pair<Scalar, Teuchos::RCP<TimeEventBase<Scalar> > > a,
+                        std::pair<Scalar, Teuchos::RCP<TimeEventBase<Scalar> > > b)
+        { return a.first < b.first; };
+      std::sort(timeEventPair.begin(), timeEventPair.end(), compare);
+
+      // Check if before first event.
+      Scalar tone   = timeEventPair.front().first;
+      Scalar absTol = timeEventPair.front().second->getAbsTol();
+      if (time < tone-absTol) {
+        timeEvent = timeEventPair.front().second;
+        return tone;
+      }
 
       // Check if after or close to last event.
-      if (timeAbs.back().first <= time+timeAbs.front().second)
-        return timeAbs.back().first;
+      tone   = timeEventPair.back().first;
+      absTol = timeEventPair.back().second->getAbsTol();
+      if (time > tone-absTol) {
+        return this->getDefaultTime();
+      }
 
-      typename std::vector< std::pair<Scalar, Scalar> >::const_iterator it =
-        std::upper_bound(timeAbs.begin(), timeAbs.end(), std::make_pair(time, 0.0));
+      // Check timeOfNextEvent is near time.  If so, return the next event.
+      typename std::vector< std::pair<Scalar, Teuchos::RCP<TimeEventBase<Scalar> > > >::const_iterator it =
+        std::upper_bound(timeEventPair.begin(), timeEventPair.end(),
+                         std::make_pair(time, timeEventPair.front().second), compare);
+      tone   = (*it).first;
+      absTol = (*it).second->getAbsTol();
+      if ( tone-absTol < time && time < tone+absTol) {
+        timeEvent = (*(it+1)).second;
+        return (*(it+1)).first;
+      }
 
-      // Check if close to left-side time event
-      const Scalar timeOfLeftEvent   = (*(it-1)).first;
-      const Scalar absTolOfLeftEvent = (*(it-1)).second;
-      if (timeOfLeftEvent > time - absTolOfLeftEvent &&
-          timeOfLeftEvent < time + absTolOfLeftEvent)
-        return timeOfLeftEvent;
-
-      // Otherwise it is the next event.
-      return (*it).first;
+      timeEvent = (*it).second;
+      return tone;
     }
 
-    /// Test if an event occurs within the time range.
+    /** \brief Test if an event occurs within the time range.
+     *
+     *  Find if an event is within the input range, inclusively
+     *  ( time1 <= event <= time2 ).  For TimeEventComposite,
+     *  test each TimeEvent to determine if the input time is
+     *  within the range.
+     *
+     *  \param time1 [in] Input time of one end of the range.
+     *  \param time2 [in] Input time of the other end of the range.
+     *
+     *  \return True if a time event is within the range.
+     */
     virtual bool eventInRange(Scalar time1, Scalar time2) const
     {
-      bool inRange = false;
-      for(auto& e : timeEvents_) {
-        if (e->eventInRange(time1, time2)) {
-          inRange = true;
-          break;
-        }
-      }
-      return inRange;
+      for(auto& e : timeEvents_)
+        if (e->eventInRange(time1, time2)) return true;
+
+      return false;
     }
 
-    /// Test if index is a time event.TimeEventBase
+    /** \brief Test if index is a time event.
+     *
+     *  Return true if one of the TimeEvents in the composite is
+     *  the input index.
+     *
+     *  \param index [in] The input index.
+     *  \return True if index is an event.
+     */
     virtual bool isIndex(int index) const
     {
+      Teuchos::RCP<TimeEventBase<Scalar> > timeEvent;
+      return isIndex(index, timeEvent);
+    }
+
+    /** \brief Test if index is a time event.
+     *
+     *  Return true if one of the TimeEvents' indices in the composite is near
+     *  the input index, and the constraining TimeEvent so additional details
+     *  about the event can be queried.
+     *
+     *  \param index     [in]  The input index.
+     *  \param timeEvent [out] The constraining TimeEvent.
+     *  \return True if index is an event.
+     */
+    virtual bool isIndex(int index,
+      Teuchos::RCP<TimeEventBase<Scalar> > & timeEvent) const
+    {
+      timeEvent = Teuchos::rcp(new TimeEventBase<Scalar>());
       bool is_index = false;
       for(auto& e : timeEvents_) {
         if (e->isIndex(index)) {
           is_index = true;
+          timeEvent = e;
           break;
         }
       }
       return is_index;
     }
 
-    /// How many indices until the next event. Negative indicating the last event is in the past.
+    /** \brief How many indices until the next event.
+     *
+     *  \param index [in] The input index.
+     *  \return The number of steps (indices) to the next event.
+     */
     virtual int indexToNextEvent(int index) const
     {
-      return indexOfNextEvent(index) - index;
+      Teuchos::RCP<TimeEventBase<Scalar> > timeEvent;
+      return indexOfNextEvent(index, timeEvent) - index;
     }
 
-    /// Index of the next event. Negative indicating the last event is in the past.
+    /** \brief How many indices until the next event.
+     *
+     *  \param index [in] The input index.
+     *  \param timeEvent [out] The constraining TimeEvent.
+     *  \return The number of steps (indices) to the next event.
+     */
+    virtual int indexToNextEvent(int index,
+      Teuchos::RCP<TimeEventBase<Scalar> > & timeEvent) const
+    { return indexOfNextEvent(index, timeEvent) - index; }
+
+    /** \brief Return the index of the next event following the input index plus.
+     *
+     *  Returns the index of the next event that follows the input index.
+     *  If the input index is before all events, the index of the first
+     *  event is returned.  If the input index is after all events, the
+     *  default index (an index in the distant future) is returned.  If the
+     *  input index is an event index, the index of the next event is returned.
+     *
+     *  \param index     [in] Input index.
+     *  \return Index of the next event.
+     */
     virtual int indexOfNextEvent(int index) const
     {
-      std::vector<int> indexList;
-      for(auto& e : timeEvents_)
-        indexList.push_back(e->indexOfNextEvent(index));
-
-      std::sort(indexList.begin(), indexList.end());
-      indexList.erase(std::unique(
-        indexList.begin(), indexList.end()), indexList.end());
-
-      if (indexList.size() == 0) return this->getDefaultIndex();
-
-      // Check if before first event.
-      if (indexList.front() >= index) return indexList.front();
-
-      // Check if after last event.
-      if (indexList.back() <= index) return indexList.back();
-
-      std::vector<int>::const_iterator it =
-        std::upper_bound(indexList.begin(), indexList.end(), index);
-
-      // Check if left-side index event
-      const Scalar indexOfLeftEvent = *(it-1);
-      if (indexOfLeftEvent == index) return indexOfLeftEvent;
-
-      // Otherwise it is the next event.
-      return *it;
-
+      Teuchos::RCP<TimeEventBase<Scalar> > timeEvent;
+      return indexOfNextEvent(index, timeEvent);
     }
 
-    /// Test if an event occurs within the time range.
+    /** \brief Return the index of the next event following the input index plus the constraining TimeEvent.
+     *
+     *  Returns the index of the next event that follows the input index.
+     *  If the input index is before all events, the index of the first
+     *  event is returned.  If the input index is after all events, the
+     *  default index (a index in the distant future) is returned.  If the
+     *  input index is an event index, the index of the next event is returned.
+     *
+     *  \param index     [in] Input index.
+     *  \param timeEvent [out] The constraining TimeEvent.
+     *  \return Index of the next event.
+     */
+    virtual int indexOfNextEvent(int index,
+      Teuchos::RCP<TimeEventBase<Scalar> > & timeEvent) const
+    {
+      timeEvent = Teuchos::rcp(new TimeEventBase<Scalar>());
+      std::vector<std::pair<int, Teuchos::RCP<TimeEventBase<Scalar> > > > timeEventPair;
+      for(auto& e : timeEvents_)
+        timeEventPair.push_back(std::make_pair(e->indexOfNextEvent(index), e));
+
+      if (timeEventPair.size() == 0) return this->getDefaultIndex();
+
+      auto compare = [](std::pair<int, Teuchos::RCP<TimeEventBase<Scalar> > > a,
+                        std::pair<int, Teuchos::RCP<TimeEventBase<Scalar> > > b)
+        { return a.first < b.first; };
+      std::sort(timeEventPair.begin(), timeEventPair.end(), compare);
+
+      if (timeEventPair.size() == 0) return this->getDefaultIndex();
+
+      // Check if before first event.
+      int ione   = timeEventPair.front().first;
+      if (index <= ione) {
+        timeEvent = timeEventPair.front().second;
+        return ione;
+      }
+
+      // Check if after last event.
+      ione   = timeEventPair.back().first;
+      if (index >= ione) {
+        timeEvent = timeEventPair.back().second;
+        return ione;
+      }
+
+      // Check if left-side index event
+      typename std::vector< std::pair<int, Teuchos::RCP<TimeEventBase<Scalar> > > >::const_iterator it =
+        std::upper_bound(timeEventPair.begin(), timeEventPair.end(),
+                         std::make_pair(index, timeEventPair.front().second), compare);
+      ione   = (*(it-1)).first;
+      if (index == ione) {
+        timeEvent = (*(it-1)).second;
+        return ione;
+      }
+
+      // Otherwise it is the next event.
+      timeEvent = (*it).second;
+      return (*it).first;
+    }
+
+    /** \brief Test if an event occurs within the index range.
+     *
+     *  Find if an event is within the input range, inclusively
+     *  ( index1 <= event <= index2 ).  This may require testing
+     *  each event in the TimeEvent.
+     *
+     *  \param index1 [in] Input index of one end of the range.
+     *  \param index2 [in] Input index of the other end of the range.
+     *
+     *  \return True if a index event is within the range.
+     */
     virtual bool eventInRangeIndex(int index1, int index2) const
     {
       bool inRange = false;
@@ -170,41 +398,234 @@ public:
   //@}
 
 
-  // Add TimeEvent to the TimeEvent vector.
-  void addTimeEvent(Teuchos::RCP<TimeEventBase<Scalar> > timeEvent)
+  /** \brief Add TimeEvent to the TimeEvent vector.
+   *
+   *  Add the TimeEvent to the composite vector.  If the
+   *  TimeEvent is already in the composite (based on the
+   *  TimeEvent's name), the input TimeEvent will replace
+   *  the one in the composite.
+   *
+   *  \param timeEvent [in] The input TimeEvent.
+   */
+  void add(Teuchos::RCP<TimeEventBase<Scalar> > timeEvent)
   {
+    std::string name = timeEvent->getName();
+    Teuchos::RCP<TimeEventBase<Scalar> > te = find(name);
+    if (!te.is_null()) {
+      //auto l_out = Teuchos::fancyOStream( Teuchos::rcpFromRef(std::cout) );
+      //Teuchos::OSTab ostab(*l_out, 2, "TimeEventComposite::add");
+      //l_out->setOutputToRootOnly(0);
+
+      //*l_out << "TimeEventComposite::add: Replacing Time Event, "
+      //       << name << "." << "\n";
+      remove(name);
+    }
     timeEvents_.push_back(timeEvent);
   }
 
-  // Clear the TimeEvent vector.
-  void clearTimeEvents()
-  { timeEvents_.clear(); }
+  /** \brief Remove TimeEvent based on name.
+   *
+   *  If the TimeEvent is not in the composite based on the
+   *  TimeEvent's name, nothing is done.
+   *
+   *  \param name [in] The name of the TimeEvent to remove.
+   */
+  void remove(std::string name)
+  {
+    for (std::size_t i = 0; i < timeEvents_.size(); ++i) {
+      if (timeEvents_[i]->getName() == name) {
+        timeEvents_.erase(timeEvents_.begin()+i);
+        break;
+      }
+    }
+    // Did not find 'name', so did nothing.
+  }
 
-  // Return the size of the TimeEvent vector.
+  /** \brief Find TimeEvent based on name.
+   *
+   *  If the TimeEvent is not found, Teuchos::null is returned.
+   *
+   *  \param name [in] The name of the TimeEvent to find.
+   *  \return RCP of TimeEvent with matching input name.
+   */
+  Teuchos::RCP<TimeEventBase<Scalar> > find(std::string name)
+  {
+    for (std::size_t i = 0; i < timeEvents_.size(); ++i)
+      if (timeEvents_[i]->getName() == name) return timeEvents_[i];
+
+    return Teuchos::null;
+  }
+
+  /// Clear the TimeEvent vector.
+  void clear() { timeEvents_.clear(); }
+
+  /// Return the size of the TimeEvent vector.
   std::size_t getSize() const { return timeEvents_.size(); }
 
-  /// Describe member data.
-  virtual void describe() const
+  /// Return a string of the names of Time Events (comma separated).
+  std::string getTimeEventNames() const
   {
-    Teuchos::RCP<Teuchos::FancyOStream> out =
-      Teuchos::VerboseObjectBase::getDefaultOStream();
-    out->setOutputToRootOnly(0);
-    *out << "TimeEventComposite:" << "\n"
-        << "name                 = " << this->getName() << "\n"
-        << "Number of TimeEvents = " << timeEvents_.size() << std::endl;
-    *out << "--------------------------------------------" << std::endl;
-    for(auto& e : timeEvents_) {
-      (*e).describe();
-      *out << "--------------------------------------------" << std::endl;
+    std::stringstream tecList;
+    for(std::size_t i = 0; i < timeEvents_.size(); ++i) {
+      tecList << timeEvents_[i]->getName();
+      if (i < timeEvents_.size()-1) tecList << ", ";
     }
+    return tecList.str();
+  }
+
+  /// Describe member data.
+  virtual void describe(Teuchos::FancyOStream          &out,
+                        const Teuchos::EVerbosityLevel verbLevel) const
+  {
+    auto l_out = Teuchos::fancyOStream( out.getOStream() );
+    Teuchos::OSTab ostab(*l_out, 2, "TimeEventComposite");
+    l_out->setOutputToRootOnly(0);
+
+    *l_out << "TimeEventComposite:" << "\n"
+           << "  name                 = " << this->getName() << "\n"
+           << "  Type                 = " << this->getType() << "\n"
+           << "  Number of TimeEvents = " << this->getSize() << "\n"
+           << "  Time Events          = " << this->getTimeEventNames()<<std::endl;
+    *l_out << "--------------------------------------------" << std::endl;
+    for(auto& e : timeEvents_) {
+      (*e).describe(*l_out, verbLevel);
+      *l_out << "--------------------------------------------" << std::endl;
+    }
+  }
+
+
+  /** \brief Return a valid ParameterList with current settings.
+   *
+   *  The returned ParameterList will contain the current parameters
+   *  and can be used to reconstruct the TimeEventComposite using
+   *  createTimeEventComposite(...).  The ParameterList will have
+   *  the TimeEventComposite parameters along with all the parameters
+   *  for the TimeEvents contained in the composite.
+   *
+   * \return Teuchos::ParameterList of TimeEventComposite.
+   */
+  virtual Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const
+  {
+    Teuchos::RCP<Teuchos::ParameterList> pl =
+      Teuchos::parameterList("Time Event Composite");
+
+    pl->setName(this->getName());
+    pl->set("Name", this->getName());
+    pl->set("Type", this->getType());
+    pl->set<std::string>("Time Events", this->getTimeEventNames());
+
+    for(auto& s : timeEvents_)
+      pl->set(s->getName(), *s->getValidParameters());
+
+    return pl;
   }
 
 
 protected:
 
-  std::vector<Teuchos::RCP<TimeEventBase<Scalar > > > timeEvents_;
+  std::vector<Teuchos::RCP<TimeEventBase<Scalar> > > timeEvents_;
 
 };
+
+
+// Nonmember constructor - ParameterList
+// ------------------------------------------------------------------------
+
+/** \brief TimeEventComposite nonmember constructor via ParameterList.
+ *
+ *  If the input ParameterList is Teuchos::null, return a default
+ *  TimeEventComposite, which has no TimeEvents but TimeEvents can be added.
+ *  A valid ParameterList for TimeEventComposite can be obtained
+ *  from TimeEventComposite::getValidParameters().
+ *
+ *  Limitation: Although possible, nesting TimeEventComposite within a
+ *  TimeEventComposite is not a good idea and is not supported in this
+ *  constructor.
+ *
+ *  \param pList [in] The input ParameterList to construct from.
+ *  \return Constructed TimeEventComposite.
+ */
+template<class Scalar>
+Teuchos::RCP<TimeEventComposite<Scalar> >
+createTimeEventComposite(Teuchos::RCP<Teuchos::ParameterList> const& pList)
+{
+  using Teuchos::RCP;
+  using Teuchos::ParameterList;
+
+  auto tec = Teuchos::rcp(new TimeEventComposite<Scalar>());
+  if (pList == Teuchos::null) return tec;  // Return default TimeEventComposite.
+
+  TEUCHOS_TEST_FOR_EXCEPTION(
+    pList->get<std::string>("Type", "Composite") != "Composite",
+    std::logic_error,
+    "Error - Time Event Type != 'Composite'.  (='"
+    + pList->get<std::string>("Type")+"')\n");
+
+  tec->setName(pList->get("Name", "From createTimeEventComposite"));
+
+  // string tokenizer
+  std::vector<std::string> teList;
+  teList.clear();
+  std::string str = pList->get<std::string>("Time Events");
+  std::string delimiters(",");
+  const char* WhiteSpace = " \t\v\r\n";
+  // Skip delimiters at the beginning
+  std::string::size_type lastPos = str.find_first_not_of(delimiters, 0);
+  // Find the first delimiter
+  std::string::size_type pos     = str.find_first_of(delimiters, lastPos);
+  while ((pos != std::string::npos) || (lastPos != std::string::npos)) {
+    // Found a token, add it to the vector
+    std::string token = str.substr(lastPos,pos-lastPos);
+
+    std::size_t start = token.find_first_not_of(WhiteSpace);
+    std::size_t end = token.find_last_not_of(WhiteSpace);
+    token = (start == end ? std::string() : token.substr(start, end-start+1));
+
+    teList.push_back(token);
+    if(pos==std::string::npos) break;
+
+    lastPos = str.find_first_not_of(delimiters, pos); // Skip delimiters
+    pos = str.find_first_of(delimiters, lastPos);     // Find next delimiter
+  }
+
+  // For each sublist name tokenized, add the TimeEvent.
+  for ( auto teName: teList) {
+    RCP<ParameterList> pl =
+      Teuchos::rcp(new ParameterList(pList->sublist(teName)));
+
+    auto timeEventType = pl->get<std::string>("Type", "Unknown");
+    if (timeEventType == "Range") {
+      tec->add(createTimeEventRange<Scalar>(pl));
+    } else if (timeEventType == "Range Index") {
+      tec->add(createTimeEventRangeIndex<Scalar>(pl));
+    } else if (timeEventType == "List") {
+      tec->add(createTimeEventList<Scalar>(pl));
+    } else if (timeEventType == "List Index") {
+      tec->add(createTimeEventListIndex<Scalar>(pl));
+    } else {
+      RCP<Teuchos::FancyOStream> out =
+        Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
+      out->setOutputToRootOnly(0);
+      Teuchos::OSTab ostab(out,1, "createTimeEventComposite()");
+      *out << "Warning -- Unknown Time Event Type!\n"
+           << "'Type' = '" << timeEventType << "'\n"
+           << "Should call add() with this "
+           << "(app-specific?) Time Event.\n" << std::endl;
+    }
+  }
+
+  if (tec->getSize() == 0) {
+    RCP<Teuchos::FancyOStream> out =
+      Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
+    out->setOutputToRootOnly(0);
+    Teuchos::OSTab ostab(out,1, "createTimeEventComposite()");
+    *out << "Warning -- Did not find a Tempus Time Events to create!\n"
+         << "Should call add() with this (app-specific?) "
+         << "Time Event.\n" << std::endl;
+  }
+
+  return tec;
+}
 
 
 } // namespace Tempus

--- a/packages/tempus/src/Tempus_TimeEventList.cpp
+++ b/packages/tempus/src/Tempus_TimeEventList.cpp
@@ -16,6 +16,10 @@ namespace Tempus {
 
   TEMPUS_INSTANTIATE_TEMPLATE_CLASS(TimeEventList)
 
+  // Nonmember constructor
+  template Teuchos::RCP<TimeEventList<double> >
+  createTimeEventList(Teuchos::RCP<Teuchos::ParameterList> pl);
+
 } // namespace Tempus
 
 #endif

--- a/packages/tempus/src/Tempus_TimeEventListIndex.cpp
+++ b/packages/tempus/src/Tempus_TimeEventListIndex.cpp
@@ -16,6 +16,10 @@ namespace Tempus {
 
   TEMPUS_INSTANTIATE_TEMPLATE_CLASS(TimeEventListIndex)
 
+  // Nonmember constructor
+  template Teuchos::RCP<TimeEventListIndex<double> >
+  createTimeEventListIndex(Teuchos::RCP<Teuchos::ParameterList> pl);
+
 } // namespace Tempus
 
 #endif

--- a/packages/tempus/src/Tempus_TimeEventListIndex_decl.hpp
+++ b/packages/tempus/src/Tempus_TimeEventListIndex_decl.hpp
@@ -11,10 +11,9 @@
 
 #include <vector>
 
-// Teuchos
 #include "Teuchos_Time.hpp"
+#include "Teuchos_ParameterList.hpp"
 
-// Tempus
 #include "Tempus_config.hpp"
 #include "Tempus_TimeEventBase.hpp"
 
@@ -35,36 +34,95 @@ public:
   TimeEventListIndex();
 
   /// Construct with full argument list of data members.
-  TimeEventListIndex(std::string name, std::vector<int> indexList);
+  TimeEventListIndex(std::vector<int> indexList, std::string name = "TimeEventListIndex");
 
   /// Destructor
   virtual ~TimeEventListIndex() {}
 
   /// \name Basic methods
   //@{
-    /// Test if index is near a index event (within tolerance).
+    /** \brief Test if index is a time event.
+     *
+     *  Return true if an event is the input index.
+     *
+     *  \param index [in] The input index.
+     *  \return True if index is an event.
+     */
     virtual bool isIndex(int index) const;
 
-    /// How many indices until the next event. Negative indicating the last event is in the past.
+    /** \brief How many indices until the next event.
+     *
+     *  \param index [in] The input index.
+     *  \return The number of steps (indices) to the next event.
+     */
     virtual int indexToNextEvent(int index) const;
 
-    /// Index of the next event. Negative indicating the last event is in the past.
+    /** \brief Return the index of the next event following the input index.
+     *
+     *  Returns the index of the next event that follows the input index.
+     *  If the input index is before all events, the index of the first
+     *  event is returned.  If the input index is after all events, the
+     *  default index (an index in the distant future) is returned.  If the
+     *  input index is an event index, the index of the next event is returned.
+     *
+     *  \param index     [in] Input index.
+     *  \return Index of the next event.
+     */
     virtual int indexOfNextEvent(int index) const;
 
-    /// Test if an event occurs within the index range.
+    /** \brief Test if an event occurs within the index range.
+     *
+     *  Find if an event is within the input range, inclusively
+     *  ( index1 <= event <= index2 ).
+     *
+     *  \param index1 [in] Input index of one end of the range.
+     *  \param index2 [in] Input index of the other end of the range.
+     *  \return True if an index event is within the range.
+     */
     virtual bool eventInRangeIndex(int index1, int index2) const;
 
     /// Describe member data.
-    virtual void describe() const;
+    virtual void describe(Teuchos::FancyOStream          &out,
+                          const Teuchos::EVerbosityLevel verbLevel) const;
   //@}
 
   /// \name Accessor methods
   //@{
+    /// \brief Return a vector of event indices.
     virtual std::vector<int> getIndexList() const { return indexList_; }
+
+    /** \brief Set the vector of event indices.
+     *
+     *  This will completely replace the vector of event indices.
+     *
+     *  \param indexList [in] Vector of event indices.
+     *  \param sort      [in] Sort vector into ascending order, if true.
+     */
     virtual void setIndexList(std::vector<int> indexList, bool sort = true);
+
+    /** \brief Add the index to event vector.
+     *
+     *  The input index will be inserted into the vector of
+     *  events in ascending order.  If the index is already
+     *  present, it is not added to keep the vector unique.
+     *
+     *  \param index [in] Index to insert to vector of events.
+     */
     virtual void addIndex(int index);
+
+    /// Clear the vector of all events.
     virtual void clearIndexList() { indexList_.clear(); }
   //@}
+
+  /** \brief Return a valid ParameterList with current settings.
+   *
+   *  The returned ParameterList will contain the current parameters
+   *  and can be used to reconstruct the exact same object using
+   *  createTimeEventListIndex(...).
+   *
+   * \return Teuchos::ParameterList of TimeEventListIndex.
+   */
+  Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
 
 
 protected:
@@ -72,6 +130,23 @@ protected:
   std::vector<int> indexList_; // Sorted and unique list of index events.
 
 };
+
+
+// Nonmember Contructors
+// ------------------------------------------------------------------------
+
+/** \brief Nonmember Constructor via ParameterList.
+ *
+ *  If the input ParameterList is Teuchos::null, return a default
+ *  TimeEventListIndex.  A valid ParameterList can be obtained
+ *  from getValidParameters().
+ *
+ *  \param pList [in] The input ParameterList to construct from.
+ *  \return Constructed TimeEventListIndex.
+ */
+template<class Scalar>
+Teuchos::RCP<TimeEventListIndex<Scalar> >
+createTimeEventListIndex(Teuchos::RCP<Teuchos::ParameterList> pList);
 
 
 } // namespace Tempus

--- a/packages/tempus/src/Tempus_TimeEventListIndex_decl.hpp
+++ b/packages/tempus/src/Tempus_TimeEventListIndex_decl.hpp
@@ -34,7 +34,8 @@ public:
   TimeEventListIndex();
 
   /// Construct with full argument list of data members.
-  TimeEventListIndex(std::vector<int> indexList, std::string name = "TimeEventListIndex");
+  TimeEventListIndex(std::vector<int> indexList,
+                     std::string name = "TimeEventListIndex");
 
   /// Destructor
   virtual ~TimeEventListIndex() {}
@@ -72,8 +73,8 @@ public:
 
     /** \brief Test if an event occurs within the index range.
      *
-     *  Find if an event is within the input range, inclusively
-     *  ( index1 <= event <= index2 ).
+     *  Find if an event is within the input range,
+     *  ( index1 < event <= index2 ).
      *
      *  \param index1 [in] Input index of one end of the range.
      *  \param index2 [in] Input index of the other end of the range.

--- a/packages/tempus/src/Tempus_TimeEventListIndex_impl.hpp
+++ b/packages/tempus/src/Tempus_TimeEventListIndex_impl.hpp
@@ -71,7 +71,7 @@ void TimeEventListIndex<Scalar>::addIndex(int index)
 template<class Scalar>
 bool TimeEventListIndex<Scalar>::isIndex(int index) const
 {
-  return (indexToNextEvent(index) == 0);
+  return (std::find(indexList_.begin(), indexList_.end(), index) != indexList_.end() );
 }
 
 
@@ -88,20 +88,15 @@ int TimeEventListIndex<Scalar>::indexOfNextEvent(int index) const
   if (indexList_.size() == 0) return this->getDefaultIndex();
 
   // Check if before first event.
-  if (indexList_.front() >= index) return indexList_.front();
+  if (index < indexList_.front()) return indexList_.front();
 
   // Check if after last event.
-  if (indexList_.back() <= index) return indexList_.back();
+  if (index >= indexList_.back()) return this->getDefaultIndex();
 
   std::vector<int>::const_iterator it =
     std::upper_bound(indexList_.begin(), indexList_.end(), index);
 
-  // Check if left-side index event
-  const Scalar indexOfLeftEvent = *(it-1);
-  if (indexOfLeftEvent == index) return indexOfLeftEvent;
-
-  // Otherwise it is the next event.
-  return *it;
+  return int(*it);
 }
 
 
@@ -125,7 +120,7 @@ bool TimeEventListIndex<Scalar>::eventInRangeIndex(int index1, int index2) const
   if (indexEvent1 != indexEvent2) return true;
 
   // Check if indices bracket index event.
-  if (index1 <= indexEvent1 && indexEvent1 <= index2) return true;
+  if (index1 < indexEvent1 && indexEvent1 <= index2) return true;
 
   return false;
 }

--- a/packages/tempus/src/Tempus_TimeEventList_decl.hpp
+++ b/packages/tempus/src/Tempus_TimeEventList_decl.hpp
@@ -45,20 +45,31 @@ public:
 
   /// \name Basic methods
   //@{
-    /// Test if time is near a TimeEvent (within tolerance).
+    /** \brief Test if time is near an event (within tolerance).
+     *
+     *  Test if any of the events in the list is near the input time.
+     *
+     *  \param[in] time The input time to check if it is near an event.
+     *
+     *  \return Return true if time is near a TimeEvent
+     *          ( timeEvent-absTol < time < timeEvent+absTol ), otherwise
+     *          return false.
+     */
     virtual bool isTime(Scalar time) const;
 
     /** \brief How much time until the next event.
      *
-     *  Return the amount of time to the next event (i.e., time of
-     *  next event minus the input time).
+     *  Determine the amount of time until the next timeEvent in the
+     *  list (i.e., time of next event minus the input time).
+     *  If the input time is after all events, the default time
+     *  (a time in the distant future) minus the input time is returned.
      *
      *  \param time      [in] The input time.
      *  \return The time to the next event.
      */
     virtual Scalar timeToNextEvent(Scalar time) const;
 
-    /** \brief Return the time of the next time event following the input time.
+    /** \brief Return the time of the next event following the input time.
      *
      *  Returns the time of the next event that follows the input time.
      *  If the input time is before all events, the time of the first
@@ -73,10 +84,10 @@ public:
 
     /** \brief Test if an event occurs within the time range.
      *
-     *  Find if an event is within the input range, inclusively
-     *  ( time1 <= event <= time2 ).  For TimeEventComposite,
-     *  test each TimeEvent to determine if the input time is
-     *  within the range.
+     *  Find if an event is within the input list,
+     *  (time1 < timeEvent-absTol and timeEvent-absTol <= time2),
+     *  including the event's absolute tolerance.  Note, this
+     *  does not include time1, but does include time2.
      *
      *  \param time1 [in] Input time of one end of the range.
      *  \param time2 [in] Input time of the other end of the range.
@@ -126,8 +137,9 @@ public:
     /** \brief Set the relative tolerance.
      *
      *  The relative tolerance is used to set the absolute
-     *  tolerance along with the TimeEvent time scale
-     *  (see getAbsTol() and setTimeScale()).
+     *  tolerance along with the TimeEvent time scale i.e.,
+     *  absTol_ = timeScale_ * relTol_.
+     *  Also see getAbsTol() and setTimeScale().
      *
      *  \param relTol [in] The input relative tolerance.
      */
@@ -137,16 +149,15 @@ public:
      *
      *  The absolute tolerance is primarily used to determine
      *  if two times are equal (i.e., t1 is equal to t2, if
-     *  t1-absTol_ < t2 < t1+absTol_).
+     *  t2-absTol_ < t1 < t2+absTol_).
+     *
+     *  For TimeEventList,
      *
      *  \return The absolute tolerance.
      */
     virtual Scalar getAbsTol() const { return absTol_; }
 
-    /// Return if the time event should be landed on exactly.
-    virtual bool getLandOnExactly() const { return landOnExactly_; }
-
-    /** \brief Set if the time events need to be landed on exactly.
+    /** \brief Return if the time events need to be landed on exactly.
      *
      *  If true, this sets whether the time events need to be landed
      *  on exactly, e.g., the time step needs to be adjusted so the
@@ -155,8 +166,11 @@ public:
      *  If false, this indicates that time event will still occur but
      *  can be stepped over without changing the time step.
      *
-     *  \param LOE [in] Flag indicating if TimeEvent should land on the time event exactly.
+     *  \return LOE Flag indicating if TimeEvent should land on the time event exactly.
      */
+    virtual bool getLandOnExactly() const { return landOnExactly_; }
+
+    /// Set if the time event should be landed on exactly.
     virtual void setLandOnExactly(bool LOE) { landOnExactly_ = LOE; }
   //@}
 
@@ -181,7 +195,7 @@ protected:
    *  determined from the time events in timeList_ (this is
    *  why it is a protected function).  It tries to find
    *  an appropriate scale for the time events, e.g.,
-   *  max(t0, ... , tn).
+   *  max(t0, ..., tn).
    */
   virtual void setTimeScale();
 

--- a/packages/tempus/src/Tempus_TimeEventList_decl.hpp
+++ b/packages/tempus/src/Tempus_TimeEventList_decl.hpp
@@ -34,10 +34,11 @@ public:
   TimeEventList();
 
   /// Construct with full argument list of data members.
-  TimeEventList(std::vector<Scalar> timeList,
-                std::string name = "TimeEventList",
-                bool landOnExactly = true,
-                Scalar relTol = 1.0e-14);
+  TimeEventList(
+    std::vector<Scalar> timeList,
+    std::string name = "TimeEventList",
+    bool landOnExactly = true,
+    Scalar relTol = std::numeric_limits<Scalar>::epsilon()*Scalar(100.0));
 
   /// Destructor
   virtual ~TimeEventList() {}

--- a/packages/tempus/src/Tempus_TimeEventList_decl.hpp
+++ b/packages/tempus/src/Tempus_TimeEventList_decl.hpp
@@ -11,10 +11,9 @@
 
 #include <vector>
 
-// Teuchos
 #include "Teuchos_Time.hpp"
+#include "Teuchos_ParameterList.hpp"
 
-// Tempus
 #include "Tempus_config.hpp"
 #include "Tempus_TimeEventBase.hpp"
 
@@ -35,8 +34,10 @@ public:
   TimeEventList();
 
   /// Construct with full argument list of data members.
-  TimeEventList(std::string name, std::vector<Scalar> timeList,
-                 Scalar relTol, bool landOnExactly);
+  TimeEventList(std::vector<Scalar> timeList,
+                std::string name = "TimeEventList",
+                bool landOnExactly = true,
+                Scalar relTol = 1.0e-14);
 
   /// Destructor
   virtual ~TimeEventList() {}
@@ -46,47 +47,167 @@ public:
     /// Test if time is near a TimeEvent (within tolerance).
     virtual bool isTime(Scalar time) const;
 
-    /// How much time until the next event. Negative indicating the last event is in the past.
+    /** \brief How much time until the next event.
+     *
+     *  Return the amount of time to the next event (i.e., time of
+     *  next event minus the input time).
+     *
+     *  \param time      [in] The input time.
+     *  \return The time to the next event.
+     */
     virtual Scalar timeToNextEvent(Scalar time) const;
 
-    /// Time of the next event. Negative indicating the last event is in the past.
+    /** \brief Return the time of the next time event following the input time.
+     *
+     *  Returns the time of the next event that follows the input time.
+     *  If the input time is before all events, the time of the first
+     *  event is returned.  If the input time is after all events, the
+     *  default time (a time in the distant future) is returned.  If the
+     *  input time is an event time, the time of the next event is returned.
+     *
+     *  \param time [in] Input time.
+     *  \return Time of the next event.
+     */
     virtual Scalar timeOfNextEvent(Scalar time) const;
 
-    /// Test if an event occurs within the time range.
+    /** \brief Test if an event occurs within the time range.
+     *
+     *  Find if an event is within the input range, inclusively
+     *  ( time1 <= event <= time2 ).  For TimeEventComposite,
+     *  test each TimeEvent to determine if the input time is
+     *  within the range.
+     *
+     *  \param time1 [in] Input time of one end of the range.
+     *  \param time2 [in] Input time of the other end of the range.
+     *
+     *  \return True if a time event is within the range.
+     */
     virtual bool eventInRange(Scalar time1, Scalar time2) const;
 
     /// Describe member data.
-    virtual void describe() const;
+    virtual void describe(Teuchos::FancyOStream          &out,
+                          const Teuchos::EVerbosityLevel verbLevel) const;
   //@}
 
   /// \name Accessor methods
   //@{
+    /// Return the list of time events.
     virtual std::vector<Scalar> getTimeList() const { return timeList_; }
-    virtual void setTimeList(std::vector<Scalar> timeList);
+
+    /** \brief Set the list of time events.
+     *
+     *  This will completely replace the vector of time events.
+     *  If sort=true, the vector will be sorted and duplicate
+     *  entries removed (i.e., only has unique entries).
+     *
+     *  \param timeList [in] Vector of time event.
+     *  \param sort     [in] Sort vector into ascending order, if true.
+     */
+    virtual void setTimeList(std::vector<Scalar> timeList, bool sort = true);
+
+    /** \brief Add the time to event vector.
+     *
+     *  The input time will be inserted into the vector of
+     *  events in ascending order.  If the time is already
+     *  present (within tolerance), it is not added to keep
+     *  the vector unique.
+     *
+     *  \param time [in] Time to insert to vector of events.
+     */
     virtual void addTime(Scalar time);
+
+    /// Clear the vector of all events.
     virtual void clearTimeList() { timeList_.clear(); }
 
+    /// Return the relative tolerance.
     virtual Scalar getRelTol() const { return relTol_; }
+
+    /** \brief Set the relative tolerance.
+     *
+     *  The relative tolerance is used to set the absolute
+     *  tolerance along with the TimeEvent time scale
+     *  (see getAbsTol() and setTimeScale()).
+     *
+     *  \param relTol [in] The input relative tolerance.
+     */
     virtual void setRelTol(Scalar relTol);
 
+    /** \brief Return the absolute tolerance.
+     *
+     *  The absolute tolerance is primarily used to determine
+     *  if two times are equal (i.e., t1 is equal to t2, if
+     *  t1-absTol_ < t2 < t1+absTol_).
+     *
+     *  \return The absolute tolerance.
+     */
     virtual Scalar getAbsTol() const { return absTol_; }
 
+    /// Return if the time event should be landed on exactly.
     virtual bool getLandOnExactly() const { return landOnExactly_; }
+
+    /** \brief Set if the time events need to be landed on exactly.
+     *
+     *  If true, this sets whether the time events need to be landed
+     *  on exactly, e.g., the time step needs to be adjusted so the
+     *  solution is determined at the time event.
+     *
+     *  If false, this indicates that time event will still occur but
+     *  can be stepped over without changing the time step.
+     *
+     *  \param LOE [in] Flag indicating if TimeEvent should land on the time event exactly.
+     */
     virtual void setLandOnExactly(bool LOE) { landOnExactly_ = LOE; }
   //@}
+
+  /** \brief Return a valid ParameterList with current settings.
+   *
+   *  The returned ParameterList will contain the current parameters
+   *  and can be used to reconstruct the TimeEventList using
+   *  createTimeEventList(...).  The ParameterList will have
+   *  the TimeEventList parameters along with all the parameters
+   *  for the TimeEvents contained in the composite.
+   *
+   * \return Teuchos::ParameterList of TimeEventList.
+   */
+  Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
 
 
 protected:
 
+  /** \brief Set the time scale for the time events
+   *
+   *  This sets the reference time scale, which is solely
+   *  determined from the time events in timeList_ (this is
+   *  why it is a protected function).  It tries to find
+   *  an appropriate scale for the time events, e.g.,
+   *  max(t0, ... , tn).
+   */
   virtual void setTimeScale();
 
   std::vector<Scalar> timeList_; ///< Sorted and unique list of time events.
 
-  Scalar timeScale_;     ///< A reference time scale, max(abs(start_,stop_)).
+  Scalar timeScale_;     ///< A reference time scale.
   Scalar relTol_;        ///< Relative time tolerance for matching time events.
   Scalar absTol_;        ///< Absolute time tolerance, relTol_*timeScale_.
   bool   landOnExactly_; ///< Should these time events be landed on exactly, i.e, adjust the timestep to hit time event, versus stepping over and keeping the time step unchanged.
 };
+
+
+// Nonmember Contructors
+// ------------------------------------------------------------------------
+
+/** \brief Nonmember Constructor via ParameterList.
+ *
+ *  If the input ParameterList is Teuchos::null, return a default
+ *  TimeEventList.  A valid ParameterList can be obtained
+ *  from getValidParameters().
+ *
+ *  \param pList [in] The input ParameterList to construct from.
+ *  \return Constructed TimeEventList.
+ */
+template<class Scalar>
+Teuchos::RCP<TimeEventList<Scalar> >
+createTimeEventList(Teuchos::RCP<Teuchos::ParameterList> pList);
 
 
 } // namespace Tempus

--- a/packages/tempus/src/Tempus_TimeEventList_impl.hpp
+++ b/packages/tempus/src/Tempus_TimeEventList_impl.hpp
@@ -15,6 +15,7 @@ namespace Tempus {
 template<class Scalar>
 TimeEventList<Scalar>::TimeEventList()
 {
+  this->setType("List");
   this->setName("TimeEventList");
   setRelTol(1.0e-14);
   setTimeScale();
@@ -24,9 +25,10 @@ TimeEventList<Scalar>::TimeEventList()
 
 template<class Scalar>
 TimeEventList<Scalar>::TimeEventList(
-  std::string name, std::vector<Scalar> timeList,
-  Scalar relTol, bool landOnExactly)
+  std::vector<Scalar> timeList, std::string name,
+  bool landOnExactly, Scalar relTol)
 {
+  this->setType("List");
   this->setName(name);
   setRelTol(relTol);
   setTimeScale();
@@ -39,7 +41,7 @@ template<class Scalar>
 void TimeEventList<Scalar>::setTimeScale()
 {
   if (timeList_.size() == 0) {
-    timeScale_ = std::abs(this->getDefaultTime());
+    timeScale_ = 1.0;
     absTol_ = relTol_*timeScale_;
     return;
   }
@@ -57,10 +59,15 @@ void TimeEventList<Scalar>::setTimeScale()
 
 
 template<class Scalar>
-void TimeEventList<Scalar>::setTimeList(std::vector<Scalar> timeList)
+void TimeEventList<Scalar>::setTimeList(std::vector<Scalar> timeList, bool sort)
 {
-  for(auto it = std::begin(timeList); it != std::end(timeList); ++it)
-    addTime(*it);
+  timeList_ = timeList;
+  if (sort) {
+    std::sort(timeList_.begin(),timeList_.end());
+    timeList_.erase(std::unique(timeList_.begin(),
+                                  timeList_.end()   ),
+                                  timeList_.end()     );
+  }
 }
 
 
@@ -108,7 +115,10 @@ void TimeEventList<Scalar>::setRelTol(Scalar relTol)
 template<class Scalar>
 bool TimeEventList<Scalar>::isTime(Scalar time) const
 {
-  return (std::abs(timeToNextEvent(time)) <= absTol_);
+  for (auto it = timeList_.begin(); it != timeList_.end(); ++it)
+    if (*it-absTol_ < time && time < *it+absTol_) return true;
+
+  return false;
 }
 
 
@@ -124,22 +134,22 @@ Scalar TimeEventList<Scalar>::timeOfNextEvent(Scalar time) const
 {
   if (timeList_.size() == 0) return this->getDefaultTime();
 
-  // Check if before or close to first event.
-  if (timeList_.front() >= time-absTol_) return timeList_.front();
+  // Check if before first event.
+  if (time < timeList_.front()-absTol_) return timeList_.front();
 
   // Check if after or close to last event.
-  if (timeList_.back() <= time+absTol_) return timeList_.back();
+  if (time > timeList_.back()-absTol_)
+    return std::numeric_limits<Scalar>::max();
 
   typename std::vector<Scalar>::const_iterator it =
     std::upper_bound(timeList_.begin(), timeList_.end(), time);
+  const Scalar timeEvent = *it;
 
-  // Check if close to left-side time event
-  const Scalar timeOfLeftEvent = *(it-1);
-  if (timeOfLeftEvent > time-absTol_ &&
-      timeOfLeftEvent < time+absTol_) return timeOfLeftEvent;
+  // Check timeEvent is near time.  If so, return the next event.
+  if ( timeEvent-absTol_ < time && time < timeEvent+absTol_)
+    return *(it+1);
 
-  // Otherwise it is the next event.
-  return *it;
+  return timeEvent;
 }
 
 
@@ -155,38 +165,110 @@ bool TimeEventList<Scalar>::eventInRange(
 
   if (timeList_.size() == 0) return false;
 
-  // Check if range is completely outside time events.
-  if (time2+absTol_ < timeList_.front() ||
-       timeList_.back() < time1-absTol_) return false;
-
-  Scalar timeEvent1 = timeOfNextEvent(time1);
-  Scalar timeEvent2 = timeOfNextEvent(time2);
-  // Check if the next time event is different for the two times.
-  if (timeEvent1 != timeEvent2) return true;
-
-  // Check if times bracket time event.
-  if (time1-absTol_ <= timeEvent1 && timeEvent1 <= time2+absTol_) return true;
+  for (auto it = timeList_.begin(); it != timeList_.end(); ++it)
+    if (time1-absTol_ < *it && *it < time2+absTol_) return true;
 
   return false;
 }
 
 
 template<class Scalar>
-void TimeEventList<Scalar>::describe() const
+void TimeEventList<Scalar>::describe(Teuchos::FancyOStream          &out,
+                               const Teuchos::EVerbosityLevel verbLevel) const
 {
-  Teuchos::RCP<Teuchos::FancyOStream> out =
-    Teuchos::VerboseObjectBase::getDefaultOStream();
-  out->setOutputToRootOnly(0);
-  *out << "TimeEventList:" << "\n"
-       << "name           = " << this->getName() << "\n"
-       << "timeScale_     = " << timeScale_     << "\n"
-       << "relTol_        = " << relTol_        << "\n"
-       << "absTol_        = " << absTol_        << "\n"
-       << "landOnExactly_ = " << landOnExactly_ << "\n"
-       << "timeList_      = " << std::endl;
-  for (auto it = timeList_.begin(); it != timeList_.end()-1; ++it)
-    *out << *it << ", ";
-  *out << *(timeList_.end()-1) << "\n";
+  auto l_out = Teuchos::fancyOStream( out.getOStream() );
+  Teuchos::OSTab ostab(*l_out, 2, "TimeEventList");
+  l_out->setOutputToRootOnly(0);
+
+  *l_out << "TimeEventList:" << "\n"
+         << "  name            = " << this->getName() << "\n"
+         << "  Type            = " << this->getType() << "\n"
+         << "  timeScale_      = " << timeScale_      << "\n"
+         << "  relTol_         = " << relTol_         << "\n"
+         << "  absTol_         = " << absTol_         << "\n"
+         << "  landOnExactly_  = " << landOnExactly_  << "\n"
+         << "  timeList_       = ";
+  if (!timeList_.empty()) {
+    for (auto it = timeList_.begin(); it != timeList_.end()-1; ++it)
+      *l_out << *it << ", ";
+    *l_out << *(timeList_.end()-1) << std::endl;
+  } else {
+    *l_out << "<empty>" << std::endl;
+  }
+}
+
+
+template<class Scalar>
+Teuchos::RCP<const Teuchos::ParameterList>
+TimeEventList<Scalar>::getValidParameters() const
+{
+  Teuchos::RCP<Teuchos::ParameterList> pl =
+    Teuchos::parameterList("Time Event List");
+
+  pl->setName(this->getName());
+  pl->set("Name", this->getName());
+  pl->set("Type", this->getType());
+
+  pl->set("Relative Tolerance", this->getRelTol(),
+          "Relative time tolerance for matching time events.");
+
+  pl->set("Land On Exactly",    this->getLandOnExactly(),
+          "Should these time events be landed on exactly, i.e, adjust the timestep to hit time event, versus stepping over and keeping the time step unchanged.");
+
+  std::vector<Scalar> times = this->getTimeList();
+  std::ostringstream list;
+  if (!times.empty()) {
+    for(std::size_t i = 0; i < times.size()-1; ++i) list << times[i] << ", ";
+    list << times[times.size()-1];
+  }
+  pl->set<std::string>("Time List", list.str(),
+    "Comma deliminated list of times");
+
+  return pl;
+}
+
+
+// Nonmember constructors.
+// ------------------------------------------------------------------------
+
+template<class Scalar>
+Teuchos::RCP<TimeEventList<Scalar> > createTimeEventList(
+  Teuchos::RCP<Teuchos::ParameterList> pl)
+{
+  auto tel = Teuchos::rcp(new TimeEventList<Scalar>());
+  if (pl == Teuchos::null) return tel;  // Return default TimeEventList.
+
+  TEUCHOS_TEST_FOR_EXCEPTION(
+    pl->get<std::string>("Type", "List") != "List",
+    std::logic_error,
+    "Error - Time Event Type != 'List'.  (='"
+    + pl->get<std::string>("Type")+"')\n");
+
+  pl->validateParametersAndSetDefaults(*tel->getValidParameters());
+
+  tel->setName          (pl->get("Name",    "From createTimeEventList"));
+  tel->setRelTol        (pl->get("Relative Tolerance", tel->getRelTol()));
+  tel->setLandOnExactly (pl->get("Land On Exactly", tel->getLandOnExactly()));
+
+  std::vector<Scalar> timeList;
+  std::string str = pl->get<std::string>("Time List");
+  std::string delimiters(",");
+  // Skip delimiters at the beginning
+  std::string::size_type lastPos = str.find_first_not_of(delimiters, 0);
+  // Find the first delimiter
+  std::string::size_type pos     = str.find_first_of(delimiters, lastPos);
+  while ((pos != std::string::npos) || (lastPos != std::string::npos)) {
+    // Found a token, add it to the vector
+    std::string token = str.substr(lastPos,pos-lastPos);
+    timeList.push_back(Scalar(std::stod(token)));
+    if(pos==std::string::npos) break;
+
+    lastPos = str.find_first_not_of(delimiters, pos); // Skip delimiters
+    pos = str.find_first_of(delimiters, lastPos);     // Find next delimiter
+  }
+  tel->setTimeList(timeList);
+
+  return tel;
 }
 
 

--- a/packages/tempus/src/Tempus_TimeEventList_impl.hpp
+++ b/packages/tempus/src/Tempus_TimeEventList_impl.hpp
@@ -17,7 +17,7 @@ TimeEventList<Scalar>::TimeEventList()
 {
   this->setType("List");
   this->setName("TimeEventList");
-  setRelTol(1.0e-14);
+  setRelTol(this->getDefaultTol());
   setTimeScale();
   setLandOnExactly(true);
 }

--- a/packages/tempus/src/Tempus_TimeEventList_impl.hpp
+++ b/packages/tempus/src/Tempus_TimeEventList_impl.hpp
@@ -166,7 +166,7 @@ bool TimeEventList<Scalar>::eventInRange(
   if (timeList_.size() == 0) return false;
 
   for (auto it = timeList_.begin(); it != timeList_.end(); ++it)
-    if (time1-absTol_ < *it && *it < time2+absTol_) return true;
+    if (time1+absTol_ < *it && *it < time2+absTol_) return true;
 
   return false;
 }

--- a/packages/tempus/src/Tempus_TimeEventRange.cpp
+++ b/packages/tempus/src/Tempus_TimeEventRange.cpp
@@ -16,6 +16,10 @@ namespace Tempus {
 
   TEMPUS_INSTANTIATE_TEMPLATE_CLASS(TimeEventRange)
 
+  // Nonmember constructor
+  template Teuchos::RCP<TimeEventRange<double> >
+  createTimeEventRange(Teuchos::RCP<Teuchos::ParameterList> pl);
+
 } // namespace Tempus
 
 #endif

--- a/packages/tempus/src/Tempus_TimeEventRangeIndex.cpp
+++ b/packages/tempus/src/Tempus_TimeEventRangeIndex.cpp
@@ -16,6 +16,10 @@ namespace Tempus {
 
   TEMPUS_INSTANTIATE_TEMPLATE_CLASS(TimeEventRangeIndex)
 
+  // Nonmember constructor
+  template Teuchos::RCP<TimeEventRangeIndex<double> >
+  createTimeEventRangeIndex(Teuchos::RCP<Teuchos::ParameterList> pl);
+
 } // namespace Tempus
 
 #endif

--- a/packages/tempus/src/Tempus_TimeEventRangeIndex_decl.hpp
+++ b/packages/tempus/src/Tempus_TimeEventRangeIndex_decl.hpp
@@ -11,10 +11,9 @@
 
 #include <tuple>
 
-// Teuchos
 #include "Teuchos_Time.hpp"
+#include "Teuchos_ParameterList.hpp"
 
-// Tempus
 #include "Tempus_config.hpp"
 #include "Tempus_TimeEventBase.hpp"
 
@@ -35,56 +34,129 @@ public:
   TimeEventRangeIndex();
 
   /// Construct with full argument list of data members.
-  TimeEventRangeIndex(std::string name, int start, int stop, int stride);
+  TimeEventRangeIndex(int start, int stop, int stride, std::string name = "");
 
   /// Destructor
   virtual ~TimeEventRangeIndex() {}
 
   /// \name Basic methods
   //@{
-    /// Test if index is a time event.
+    /** \brief Test if index is a time event.
+     *
+     *  Return true if an event is the input index.
+     *
+     *  \param index [in] The input index.
+     *  \return True if index is an event.
+     */
     virtual bool isIndex(int index) const;
 
-    /// How many indices until the next event. Negative indicating the last event is in the past.
+    /** \brief How many indices until the next event.
+     *
+     *  \param index [in] The input index.
+     *  \return The number of steps (indices) to the next event.
+     */
     virtual int indexToNextEvent(int index) const;
 
-    /// Index of the next event. Negative indicating the last event is in the past.
+    /** \brief Return the index of the next event following the input index.
+     *
+     *  Returns the index of the next event that follows the input index.
+     *  If the input index is before all events, the index of the first
+     *  event is returned.  If the input index is after all events, the
+     *  default index (an index in the distant future) is returned.  If the
+     *  input index is an event index, the index of the next event is returned.
+     *
+     *  \param index     [in] Input index.
+     *  \return Index of the next event.
+     */
     virtual int indexOfNextEvent(int index) const;
 
-    /// Test if an event occurs within the index range.
+    /** \brief Test if an event occurs within the index range.
+     *
+     *  Find if an event is within the input range, inclusively
+     *  ( index1 <= event <= index2 ).
+     *
+     *  \param index1 [in] Input index of one end of the range.
+     *  \param index2 [in] Input index of the other end of the range.
+     *  \return True if an index event is within the range.
+     */
     virtual bool eventInRangeIndex(int index1, int index2) const;
 
     /// Describe member data.
-    virtual void describe() const;
+    virtual void describe(Teuchos::FancyOStream          &out,
+                          const Teuchos::EVerbosityLevel verbLevel) const;
   //@}
 
   /// \name Accessor methods
   //@{
+    /** \brief Set the range of event indices.
+     *
+     *  This will completely replace the range
+     *
+     *  \param start  [in] The start of the index range.
+     *  \param stop   [in] The stop of the index range.
+     *  \param stride [in] The stride of the index range.
+     */
     virtual void setIndexRange(int start, int stop, int stride)
     { setIndexStart(start); setIndexStop(stop); setIndexStride(stride); }
 
+    /// Return the start of the index range.
     virtual int getIndexStart() const { return start_; }
+    /// Set the start of the index range.
     virtual void setIndexStart(int start);
 
+    /// Return the stop of the index range.
     virtual int getIndexStop() const { return stop_; }
+    /// Set the stop of the index range.
     virtual void setIndexStop(int stop);
 
+    /// Return the stride of the index range.
     virtual int getIndexStride() const { return stride_; }
+    /// Set the stride of the index range.
     virtual void setIndexStride(int stride);
 
+    /// Return the number of events.
     virtual int getNumEvents() const { return numEvents_; }
+
+    /// Set the number of events from start_, stop_ and stride_.
     virtual void setNumEvents();
   //@}
+
+  /** \brief Return a valid ParameterList with current settings.
+   *
+   *  The returned ParameterList will contain the current parameters
+   *  and can be used to reconstruct the exact same object using
+   *  createTimeEventRangeIndex(...).
+   *
+   * \return Teuchos::ParameterList of TimeEventRangeIndex.
+   */
+  Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
 
 
 protected:
 
-  int start_;
-  int stop_;
-  int stride_;
-  unsigned numEvents_;
+  int start_;           ///< Start of index range.
+  int stop_;            ///< Stop of index range.
+  int stride_;          ///< Stride of index range.
+  unsigned numEvents_;  ///< Number of events in index range.
 
 };
+
+
+// Nonmember Contructors
+// ------------------------------------------------------------------------
+
+/** \brief Nonmember Constructor via ParameterList.
+ *
+ *  If the input ParameterList is Teuchos::null, return a default
+ *  TimeEventRangeIndex.  A valid ParameterList can be obtained
+ *  from getValidParameters().
+ *
+ *  \param pList [in] The input ParameterList to construct from.
+ *  \return Constructed TimeEventRangeIndex.
+ */
+template<class Scalar>
+Teuchos::RCP<TimeEventRangeIndex<Scalar> >
+createTimeEventRangeIndex(Teuchos::RCP<Teuchos::ParameterList> pList);
 
 
 } // namespace Tempus

--- a/packages/tempus/src/Tempus_TimeEventRangeIndex_impl.hpp
+++ b/packages/tempus/src/Tempus_TimeEventRangeIndex_impl.hpp
@@ -115,8 +115,8 @@ int TimeEventRangeIndex<Scalar>::indexOfNextEvent(int index) const
   // Check if after or equal to last index.
   if (index >= indexOfLast) return this->getDefaultIndex();
 
-  // check if index is an event.  If so, return next event.
-  if ((index - start_) % stride_ == 0) return index+stride_;
+  // Check if index is an event.  If so, return next event.
+  if (isIndex(index)) return index+stride_;
 
   const int numStrides = (index - start_) / stride_ + 1;
   const Scalar indexOfNext = start_ + numStrides * stride_;
@@ -145,7 +145,7 @@ bool TimeEventRangeIndex<Scalar>::eventInRangeIndex(int index1, int index2) cons
 
   for ( int i = strideJustBeforeIndex1; i <= strideJustAfterIndex2; i++ ) {
     const int indexEvent = start_ + i * stride_;
-    if (index1 <= indexEvent && indexEvent <= index2) return true;
+    if (index1 < indexEvent && indexEvent <= index2) return true;
   }
 
   return false;

--- a/packages/tempus/src/Tempus_TimeEventRangeIndex_impl.hpp
+++ b/packages/tempus/src/Tempus_TimeEventRangeIndex_impl.hpp
@@ -16,16 +16,27 @@ template<class Scalar>
 TimeEventRangeIndex<Scalar>::TimeEventRangeIndex()
   : start_(0), stop_(0), stride_(1)
 {
-  this->setName("TimeEventRangeIndex");
+  this->setType("Range Index");
+  std::ostringstream oss;
+  oss << "TimeEventRangeIndex (" << start_<< "; " << stop_<< "; " << stride_<< ")";
+  this->setName(oss.str());
   setNumEvents();
 }
 
 
 template<class Scalar>
 TimeEventRangeIndex<Scalar>::TimeEventRangeIndex(
-  std::string name, int start, int stop, int stride)
+  int start, int stop, int stride, std::string name)
 {
-  this->setName(name);
+  this->setType("Range Index");
+  if (name == "") {
+    std::ostringstream oss;
+    oss << "TimeEventRangeIndex (" << start << "; " << stop << "; " << stride << ")";
+    this->setName(oss.str());
+  } else {
+    this->setName(name);
+  }
+
   this->setIndexRange(start, stop, stride);
 }
 
@@ -79,7 +90,11 @@ void TimeEventRangeIndex<Scalar>::setNumEvents()
 template<class Scalar>
 bool TimeEventRangeIndex<Scalar>::isIndex(int index) const
 {
-  return (indexToNextEvent(index) == 0);
+  const int indexOfLast = start_ + (numEvents_-1) * stride_;
+  if (index < start_ || index > indexOfLast) return false;
+  if ((index - start_) % stride_ == 0) return true;
+
+  return false;
 }
 
 
@@ -93,15 +108,15 @@ int TimeEventRangeIndex<Scalar>::indexToNextEvent(int index) const
 template<class Scalar>
 int TimeEventRangeIndex<Scalar>::indexOfNextEvent(int index) const
 {
-  // Check if before or equal to the first index.
-  if (index <= start_) return start_;
+  // Check if before the first index.
+  if (index < start_) return start_;
 
   const int indexOfLast = start_ + (numEvents_-1) * stride_;
   // Check if after or equal to last index.
-  if (indexOfLast <= index) return indexOfLast;
+  if (index >= indexOfLast) return this->getDefaultIndex();
 
-  // check if index is an event.
-  if ((index - start_) % stride_ == 0) return index;
+  // check if index is an event.  If so, return next event.
+  if ((index - start_) % stride_ == 0) return index+stride_;
 
   const int numStrides = (index - start_) / stride_ + 1;
   const Scalar indexOfNext = start_ + numStrides * stride_;
@@ -118,35 +133,87 @@ bool TimeEventRangeIndex<Scalar>::eventInRangeIndex(int index1, int index2) cons
     index2 = tmp;
   }
 
+  // Check if range is completely outside index events.
   const Scalar indexOfLast = start_ + (numEvents_-1) * stride_;
   if (index2 < start_ || indexOfLast < index1) return false;
 
-  Scalar indexEvent1 = indexOfNextEvent(index1);
-  Scalar indexEvent2 = indexOfNextEvent(index2);
-  // Check if the next index event is different for the two indices.
-  if (indexEvent1 != indexEvent2) return true;
+  const int strideJustBeforeIndex1 = std::min(int(numEvents_-1),
+    std::max(int(0), int((index1 - start_) / stride_)));
 
-  // Check if indices bracket index event.
-  if (index1 <= indexEvent1 && indexEvent1 <= index2) return true;
+  const int strideJustAfterIndex2 = std::max(int(0), std::min(int(numEvents_-1),
+    int((index2 - start_) / stride_)));
+
+  for ( int i = strideJustBeforeIndex1; i <= strideJustAfterIndex2; i++ ) {
+    const int indexEvent = start_ + i * stride_;
+    if (index1 <= indexEvent && indexEvent <= index2) return true;
+  }
 
   return false;
 }
 
 
 template<class Scalar>
-void TimeEventRangeIndex<Scalar>::describe() const
+void TimeEventRangeIndex<Scalar>::describe(Teuchos::FancyOStream          &out,
+                               const Teuchos::EVerbosityLevel verbLevel) const
 {
-  Teuchos::RCP<Teuchos::FancyOStream> out =
-    Teuchos::VerboseObjectBase::getDefaultOStream();
-  out->setOutputToRootOnly(0);
-  *out << "TimeEventRange:" << "\n"
-       << "name       = " << this->getName() << "\n"
-       << "start_     = " << start_     << "\n"
-       << "stop_      = " << stop_      << "\n"
-       << "stride_    = " << stride_    << "\n"
-       << "numEvents_ = " << numEvents_ << std::endl;
+  auto l_out = Teuchos::fancyOStream( out.getOStream() );
+  Teuchos::OSTab ostab(*l_out, 2, "TimeEventRangeIndex");
+  l_out->setOutputToRootOnly(0);
+
+  *l_out << "TimeEventRangeIndex:" << "\n"
+         << "  name       = " << this->getName() << "\n"
+         << "  Type       = " << this->getType() << "\n"
+         << "  start_     = " << start_          << "\n"
+         << "  stop_      = " << stop_           << "\n"
+         << "  stride_    = " << stride_         << "\n"
+         << "  numEvents_ = " << numEvents_      << std::endl;
 }
 
+
+template<class Scalar>
+Teuchos::RCP<const Teuchos::ParameterList>
+TimeEventRangeIndex<Scalar>::getValidParameters() const
+{
+  Teuchos::RCP<Teuchos::ParameterList> pl =
+    Teuchos::parameterList("Time Event Range Index");
+
+  pl->setName(this->getName());
+  pl->set("Name", this->getName());
+  pl->set("Type", "Range Index");
+
+  pl->set("Start Index", getIndexStart(), "Start of Index range");
+  pl->set("Stop Index",  getIndexStop(),  "Stop of Index range");
+  pl->set("Stride Index", getIndexStride(), "Stride of Index range");
+
+  return pl;
+}
+
+
+// Nonmember constructors.
+// ------------------------------------------------------------------------
+
+template<class Scalar>
+Teuchos::RCP<TimeEventRangeIndex<Scalar> > createTimeEventRangeIndex(
+  Teuchos::RCP<Teuchos::ParameterList> pl)
+{
+  auto teri = Teuchos::rcp(new TimeEventRangeIndex<Scalar>());
+  if (pl == Teuchos::null) return teri;  // Return default TimeEventRangeIndex.
+
+  TEUCHOS_TEST_FOR_EXCEPTION(
+    pl->get<std::string>("Type", "Range Index") != "Range Index",
+    std::logic_error,
+    "Error - Time Event Type != 'Range Index'.  (='"
+    + pl->get<std::string>("Type")+"')\n");
+
+  pl->validateParametersAndSetDefaults(*teri->getValidParameters());
+
+  teri->setName          (pl->get("Name",    "From createTimeEventRangeIndex"));
+  teri->setIndexStart    (pl->get("Start Index",     teri->getIndexStart()));
+  teri->setIndexStop     (pl->get("Stop Index",      teri->getIndexStop()));
+  teri->setIndexStride   (pl->get("Stride Index",    teri->getIndexStride()));
+
+  return teri;
+}
 
 
 } // namespace Tempus

--- a/packages/tempus/src/Tempus_TimeEventRange_decl.hpp
+++ b/packages/tempus/src/Tempus_TimeEventRange_decl.hpp
@@ -34,14 +34,16 @@ public:
   TimeEventRange();
 
   /// Construct from start, stop and stride.
-  TimeEventRange(Scalar start, Scalar stop, Scalar stride,
-                 std::string name = "", bool landOnExactly = true,
-                 Scalar relTol = 1.0e-14);
+  TimeEventRange(
+    Scalar start, Scalar stop, Scalar stride,
+    std::string name = "", bool landOnExactly = true,
+    Scalar relTol = std::numeric_limits<Scalar>::epsilon()*Scalar(100.0));
 
   /// Construct from start, stop and number of events.
-  TimeEventRange(Scalar start, Scalar stop, int numEvents,
-                 std::string name = "", bool landOnExactly = true,
-                 Scalar relTol = 1.0e-14);
+  TimeEventRange(
+    Scalar start, Scalar stop, int numEvents,
+    std::string name = "", bool landOnExactly = true,
+    Scalar relTol = std::numeric_limits<Scalar>::epsilon()*Scalar(100.0));
 
   /// Destructor
   virtual ~TimeEventRange() {}

--- a/packages/tempus/src/Tempus_TimeEventRange_decl.hpp
+++ b/packages/tempus/src/Tempus_TimeEventRange_decl.hpp
@@ -11,10 +11,9 @@
 
 #include <tuple>
 
-// Teuchos
 #include "Teuchos_Time.hpp"
+#include "Teuchos_ParameterList.hpp"
 
-// Tempus
 #include "Tempus_config.hpp"
 #include "Tempus_TimeEventBase.hpp"
 
@@ -34,66 +33,200 @@ public:
   /// Default constructor.
   TimeEventRange();
 
-  /// Construct with full argument list of data members.
-  TimeEventRange(std::string name, Scalar start, Scalar stop, Scalar stride,
-                 Scalar relTol, bool landOnExactly);
+  /// Construct from start, stop and stride.
+  TimeEventRange(Scalar start, Scalar stop, Scalar stride,
+                 std::string name = "", bool landOnExactly = true,
+                 Scalar relTol = 1.0e-14);
 
-  /// Construct with full argument list of data members.
-  TimeEventRange(std::string name, Scalar start, Scalar stop, int numEvents,
-                 Scalar relTol, bool landOnExactly);
+  /// Construct from start, stop and number of events.
+  TimeEventRange(Scalar start, Scalar stop, int numEvents,
+                 std::string name = "", bool landOnExactly = true,
+                 Scalar relTol = 1.0e-14);
 
   /// Destructor
   virtual ~TimeEventRange() {}
 
   /// \name Basic methods
   //@{
-    /// Test if time is near a TimeEvent (within tolerance).
+    /** \brief Test if time is near a TimeEvent (within tolerance).
+     *
+     *  Test if any of the events in the range is near time.
+     *
+     *  \param[in] time The time to check if it is near a TimeEvent.
+     *
+     *  \return Return true if time is near a TimeEvent
+     *          ( timeEvent-absTol < time < timeEvent+absTol ), otherwise
+     *          return false.
+     */
     virtual bool isTime(Scalar time) const;
 
-    /// How much time until the next event. Negative indicating the last event is in the past.
+    /** \brief How much time until the next event.
+     *
+     *  Determine the amount of time until the next timeEvent in the range.
+     *  If the closest timeEvent is in the past, the amount of time is
+     *  negative.
+     *
+     *  \param[in] time The time to measure to the next TimeEvent.
+     *
+     *  \return Return the amount of time to next TimeEvent
+     *          ( nextTimeEvent-time ).
+     */
     virtual Scalar timeToNextEvent(Scalar time) const;
 
-    /// Time of the next event. Negative indicating the last event is in the past.
+    /** \brief Return the time of the next time event following the input time.
+     *
+     *  Returns the time of the next event that follows the input time.
+     *  If the input time is before all events, the time of the first
+     *  event is returned.  If the input time is after all events, the
+     *  default time (a time in the distant future) is returned.  If the
+     *  input time is an event time, the time of the next event is returned.
+     *
+     *  \param time [in] Input time.
+     *  \return Time of the next event.
+     */
     virtual Scalar timeOfNextEvent(Scalar time) const;
 
-    /// Test if an event occurs within the time range.
+    /** \brief Test if an event occurs within the time range.
+     *
+     *  Find if an event is within the input range, inclusively
+     *  ( time1 <= event <= time2 ).
+     *
+     *  \param time1 [in] Input time of one end of the range.
+     *  \param time2 [in] Input time of the other end of the range.
+     *  \return True if an time event is within the range.
+     */
     virtual bool eventInRange(Scalar time1, Scalar time2) const;
   //@}
 
   /// \name Accessor methods
   //@{
-    virtual void setTimeRange(Scalar start, Scalar stop, Scalar stride)
-    { setTimeStart(start); setTimeStop(stop); setTimeStride(stride); }
-    virtual void setTimeRange(Scalar start, Scalar stop, int numEvents)
-    { setTimeStart(start); setTimeStop(stop); setNumEvents(numEvents); }
+    /** \brief Set the range of time events from start, stop and stride.
+     *
+     *  This will completely replace the time range
+     *
+     *  \param start  [in] The start of the time range.
+     *  \param stop   [in] The stop of the time range.
+     *  \param stride [in] The stride of the time range.
+     */
+    virtual void setTimeRange(Scalar start, Scalar stop, Scalar stride);
 
+    /** \brief Set the range of time events from start, stop and number of events.
+     *
+     *  This will completely replace the time range
+     *
+     *  \param start     [in] The start of the time range.
+     *  \param stop      [in] The stop of the time range.
+     *  \param numEvents [in] The number of events in time range.
+     */
+    virtual void setTimeRange(Scalar start, Scalar stop, int numEvents);
+
+    /// Return the start of the time range.
     virtual Scalar getTimeStart() const { return start_; }
+    /// Set the start of the time range.
     virtual void setTimeStart(Scalar start);
 
+    /// Return the stop of the time range.
     virtual Scalar getTimeStop() const { return stop_; }
+    /// Set the stop of the time range.
     virtual void setTimeStop(Scalar stop);
 
+    /// Return the stride of the time range.
     virtual Scalar getTimeStride() const { return stride_; }
+    /** \brief Set the stride of the time range.
+     *
+     *  If start_ = stop_, then stride_ = 0.0, set numEvents_ = 1, and return.
+     *  If stride_ > stop_-start_ or stride_ < 2*absTol_, then stride = stop_-start_.
+     *
+     *  Reset numEvents_ = (stop_-start_)/stride_ + 1.
+     *
+     *  \param stride [in] The time stride for the time range.
+     */
     virtual void setTimeStride(Scalar stride);
 
+    /// Return the number of time events in the time range.
     virtual int getNumEvents() const { return numEvents_; }
+    /** \brief Set the number of time events.
+     *
+     *  - If numEvents_ < 0, then reset numEvents from start_, stop_ and stride_.
+     *  - ElseIf start_ = stop_, numEvents = 1, and reset stride = 0.
+     *  - ElseIf numEvents_ < 2, numEvents = 2, and stride = stop_ - start_.
+     *  - Else stride = (stop_ - start_)/(numEvents_-1).
+     *
+     *  If the resulting stride is less than twise the absolute tolerance,
+     *  the stride is set to 2*absTol_.
+     *
+     *  \param numEvents [in] The number of events in time range.
+     */
     virtual void setNumEvents(int numEvents);
 
+    /// Return the relative tolerance.
     virtual Scalar getRelTol() const { return relTol_; }
+
+    /** \brief Set the relative tolerance.
+     *
+     *  The relative tolerance is used to set the absolute
+     *  tolerance along with the TimeEvent time scale
+     *  (see getAbsTol() and setTimeScale()).
+     *
+     *  \param relTol [in] The input relative tolerance.
+     */
     virtual void setRelTol(Scalar relTol);
 
+    /** \brief Return the absolute tolerance.
+     *
+     *  The absolute tolerance is primarily used to determine
+     *  if two times are equal (i.e., t1 is equal to t2, if
+     *  t1-absTol_ < t2 < t1+absTol_).
+     *
+     *  \return The absolute tolerance.
+     */
     virtual Scalar getAbsTol() const { return absTol_; }
 
+    /// Return if the time event should be landed on exactly.
     virtual bool getLandOnExactly() const { return landOnExactly_; }
+
+    /** \brief Set if the time events need to be landed on exactly.
+     *
+     *  If true, this sets whether the time events need to be landed
+     *  on exactly, e.g., the time step needs to be adjusted so the
+     *  solution is determined at the time event.
+     *
+     *  If false, this indicates that time event will still occur but
+     *  can be stepped over without changing the time step.
+     *
+     *  \param LOE [in] Flag indicating if TimeEvent should land on the time event exactly.
+     */
     virtual void setLandOnExactly(bool LOE) { landOnExactly_ = LOE; }
 
-    /// Describe member data.
-    virtual void describe() const;
   //@}
+
+  /// Describe member data.
+  virtual void describe(Teuchos::FancyOStream          &out,
+                        const Teuchos::EVerbosityLevel verbLevel) const;
+
+  /** \brief Return a valid ParameterList with current settings.
+   *
+   *  The returned ParameterList will contain the current parameters
+   *  and can be used to reconstruct the TimeEventRange using
+   *  createTimeEventRange(...).  The ParameterList will have
+   *  the TimeEventRange parameters along with all the parameters
+   *  for the TimeEvents contained in the composite.
+   *
+   * \return Teuchos::ParameterList of TimeEventRange.
+   */
+  Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
 
 
 protected:
 
+  /** \brief Set the time scale for the time events
+   *
+   *  This sets the reference time scale, which is solely
+   *  determined from the time events in the range (this is
+   *  why it is a protected function).  It tries to find
+   *  an appropriate scale for the time events, e.g.,
+   *  max(t0, ... , tn).
+   */
   virtual void setTimeScale();
 
   Scalar start_;         ///< Start of time range.
@@ -107,6 +240,23 @@ protected:
   bool   landOnExactly_; ///< Should these time events be landed on exactly, i.e, adjust the timestep to hit time event, versus stepping over and keeping the time step unchanged.
 
 };
+
+
+// Nonmember Contructors
+// ------------------------------------------------------------------------
+
+/** \brief Nonmember Constructor via ParameterList.
+ *
+ *  If the input ParameterList is Teuchos::null, return a default
+ *  TimeEventRange.  A valid ParameterList can be obtained
+ *  from getValidParameters().
+ *
+ *  \param pList [in] The input ParameterList to construct from.
+ *  \return Constructed TimeEventRange.
+ */
+template<class Scalar>
+Teuchos::RCP<TimeEventRange<Scalar> >
+createTimeEventRange(Teuchos::RCP<Teuchos::ParameterList> pList);
 
 
 } // namespace Tempus

--- a/packages/tempus/src/Tempus_TimeEventRange_decl.hpp
+++ b/packages/tempus/src/Tempus_TimeEventRange_decl.hpp
@@ -50,11 +50,11 @@ public:
 
   /// \name Basic methods
   //@{
-    /** \brief Test if time is near a TimeEvent (within tolerance).
+    /** \brief Test if time is near an event (within tolerance).
      *
-     *  Test if any of the events in the range is near time.
+     *  Test if any of the events in the range is near the input time.
      *
-     *  \param[in] time The time to check if it is near a TimeEvent.
+     *  \param[in] time The input time to check if it is near an event.
      *
      *  \return Return true if time is near a TimeEvent
      *          ( timeEvent-absTol < time < timeEvent+absTol ), otherwise
@@ -64,18 +64,18 @@ public:
 
     /** \brief How much time until the next event.
      *
-     *  Determine the amount of time until the next timeEvent in the range.
-     *  If the closest timeEvent is in the past, the amount of time is
-     *  negative.
+     *  Determine the amount of time until the next timeEvent in the
+     *  range (i.e., time of next event minus the input time).
+     *  If the input time is after all events, the default time
+     *  (a time in the distant future) minus the input time is returned.
      *
-     *  \param[in] time The time to measure to the next TimeEvent.
+     *  \param[in] time The input time to measure to the next TimeEvent.
      *
-     *  \return Return the amount of time to next TimeEvent
-     *          ( nextTimeEvent-time ).
+     *  \return The amount of time to next TimeEvent ( nextTimeEvent-time ).
      */
     virtual Scalar timeToNextEvent(Scalar time) const;
 
-    /** \brief Return the time of the next time event following the input time.
+    /** \brief Return the time of the next event following the input time.
      *
      *  Returns the time of the next event that follows the input time.
      *  If the input time is before all events, the time of the first
@@ -90,8 +90,10 @@ public:
 
     /** \brief Test if an event occurs within the time range.
      *
-     *  Find if an event is within the input range, inclusively
-     *  ( time1 <= event <= time2 ).
+     *  Find if an event is within the input range,
+     *  (time1 < timeEvent-absTol and timeEvent-absTol <= time2),
+     *  including the event's absolute tolerance.  Note, this
+     *  does not include time1, but does include time2.
      *
      *  \param time1 [in] Input time of one end of the range.
      *  \param time2 [in] Input time of the other end of the range.
@@ -104,7 +106,7 @@ public:
   //@{
     /** \brief Set the range of time events from start, stop and stride.
      *
-     *  This will completely replace the time range
+     *  This will completely replace the time range.
      *
      *  \param start  [in] The start of the time range.
      *  \param stop   [in] The stop of the time range.
@@ -134,6 +136,7 @@ public:
 
     /// Return the stride of the time range.
     virtual Scalar getTimeStride() const { return stride_; }
+
     /** \brief Set the stride of the time range.
      *
      *  If start_ = stop_, then stride_ = 0.0, set numEvents_ = 1, and return.
@@ -147,6 +150,7 @@ public:
 
     /// Return the number of time events in the time range.
     virtual int getNumEvents() const { return numEvents_; }
+
     /** \brief Set the number of time events.
      *
      *  - If numEvents_ < 0, then reset numEvents from start_, stop_ and stride_.
@@ -154,7 +158,7 @@ public:
      *  - ElseIf numEvents_ < 2, numEvents = 2, and stride = stop_ - start_.
      *  - Else stride = (stop_ - start_)/(numEvents_-1).
      *
-     *  If the resulting stride is less than twise the absolute tolerance,
+     *  If the resulting stride is less than twice the absolute tolerance,
      *  the stride is set to 2*absTol_.
      *
      *  \param numEvents [in] The number of events in time range.
@@ -167,8 +171,9 @@ public:
     /** \brief Set the relative tolerance.
      *
      *  The relative tolerance is used to set the absolute
-     *  tolerance along with the TimeEvent time scale
-     *  (see getAbsTol() and setTimeScale()).
+     *  tolerance along with the TimeEvent time scale, i.e.,
+     *  absTol_ = timeScale_ * relTol_.
+     *  Also see getAbsTol() and setTimeScale().
      *
      *  \param relTol [in] The input relative tolerance.
      */
@@ -178,14 +183,11 @@ public:
      *
      *  The absolute tolerance is primarily used to determine
      *  if two times are equal (i.e., t1 is equal to t2, if
-     *  t1-absTol_ < t2 < t1+absTol_).
+     *  t2-absTol_ < t1 < t2+absTol_).
      *
      *  \return The absolute tolerance.
      */
     virtual Scalar getAbsTol() const { return absTol_; }
-
-    /// Return if the time event should be landed on exactly.
-    virtual bool getLandOnExactly() const { return landOnExactly_; }
 
     /** \brief Set if the time events need to be landed on exactly.
      *
@@ -196,8 +198,11 @@ public:
      *  If false, this indicates that time event will still occur but
      *  can be stepped over without changing the time step.
      *
-     *  \param LOE [in] Flag indicating if TimeEvent should land on the time event exactly.
+     *  \return LOE Flag indicating if TimeEvent should land on the time event exactly.
      */
+    virtual bool getLandOnExactly() const { return landOnExactly_; }
+
+    /// Set if the time event should be landed on exactly.
     virtual void setLandOnExactly(bool LOE) { landOnExactly_ = LOE; }
 
   //@}

--- a/packages/tempus/src/Tempus_TimeEventRange_impl.hpp
+++ b/packages/tempus/src/Tempus_TimeEventRange_impl.hpp
@@ -253,7 +253,7 @@ bool TimeEventRange<Scalar>::eventInRange(Scalar time1, Scalar time2) const
 
   // Check if range is completely outside time events.
   const Scalar timeOfLast = start_ + (numEvents_-1) * stride_;
-  if (time2+absTol_ < start_ || timeOfLast < time1-absTol_) return false;
+  if (time2 < start_-absTol_ || timeOfLast+absTol_ < time1) return false;
 
   const int strideJustBeforeTime1 = std::min(int(numEvents_-1),
     std::max(int(0), int((time1 - start_ + absTol_) / stride_ - 0.5)));
@@ -263,7 +263,7 @@ bool TimeEventRange<Scalar>::eventInRange(Scalar time1, Scalar time2) const
 
   for ( int i = strideJustBeforeTime1; i <= strideJustAfterTime2; i++ ) {
     const Scalar timeEvent = start_ + i * stride_;
-    if (time1-absTol_ < timeEvent && timeEvent < time2+absTol_) return true;
+    if (time1 < timeEvent-absTol_ && timeEvent-absTol_ <= time2) return true;
   }
 
   return false;

--- a/packages/tempus/src/Tempus_TimeEventRange_impl.hpp
+++ b/packages/tempus/src/Tempus_TimeEventRange_impl.hpp
@@ -14,8 +14,8 @@ namespace Tempus {
 
 template<class Scalar>
 TimeEventRange<Scalar>::TimeEventRange()
-  : start_(this->getDefaultTime()),
-    stop_ (this->getDefaultTime()),
+  : start_ (0.0),
+    stop_  (0.0),
     stride_(0.0),
     numEvents_(1),
     timeScale_(1.0),
@@ -23,46 +23,90 @@ TimeEventRange<Scalar>::TimeEventRange()
     absTol_(1.0e-14),
     landOnExactly_(true)
 {
-  this->setName("TimeEventRange");
+  this->setType("Range");
+  std::ostringstream oss;
+  oss << "TimeEventRange (" << start_<< "; " << stop_<< "; " << stride_<< ")";
+  this->setName(oss.str());
   setTimeRange(start_, stop_, stride_);
 }
 
 
 template<class Scalar>
 TimeEventRange<Scalar>::TimeEventRange(
-  std::string name, Scalar start, Scalar stop, Scalar stride,
-  Scalar relTol, bool landOnExactly)
-  : start_(start),
-    stop_ (stop),
-    stride_(stride),
-    numEvents_(std::abs(stop-start)/stride+1),
-    timeScale_(start),
+  Scalar start, Scalar stop, Scalar stride,
+  std::string name, bool landOnExactly, Scalar relTol)
+  : start_ (start),
+    stop_  (stop),
+    timeScale_(std::max(std::abs(start_), std::abs(stop_))),
     relTol_(relTol),
-    absTol_(relTol*start),
-    landOnExactly_(landOnExactly)
+    absTol_(relTol_*timeScale_)
 {
-  this->setName(name);
+  this->setType("Range");
+  if (name == "") {
+    std::ostringstream oss;
+    oss << "TimeEventRange (" << start << "; " << stop << "; " << stride << ")";
+    this->setName(oss.str());
+  } else {
+    this->setName(name);
+  }
+  setRelTol(relTol);
   setTimeRange(start, stop, stride);
+  setLandOnExactly(landOnExactly);
 }
 
 
 template<class Scalar>
 TimeEventRange<Scalar>::TimeEventRange(
-  std::string name, Scalar start, Scalar stop, int numEvents,
-  Scalar relTol, bool landOnExactly)
-  : start_(start),
-    stop_ (stop),
-    stride_(std::abs(stop-start)/(numEvents-1)),
-    numEvents_(numEvents),
-    timeScale_(start),
+  Scalar start, Scalar stop, int numEvents,
+  std::string name, bool landOnExactly, Scalar relTol)
+  : start_ (start),
+    stop_  (stop),
+    timeScale_(std::max(std::abs(start_), std::abs(stop_))),
     relTol_(relTol),
-    absTol_(relTol*start),
-    landOnExactly_(landOnExactly)
+    absTol_(relTol_*timeScale_)
 {
-  this->setName(name);
-  setTimeRange(start, stop, numEvents);
+  if (name == "") {
+    std::ostringstream oss;
+    oss << "TimeEventRange (" << start << "; " << stop << "; " << numEvents << ")";
+    this->setName(oss.str());
+  } else {
+    this->setName(name);
+  }
   setRelTol(relTol);
+  setTimeRange(start, stop, numEvents);
   setLandOnExactly(landOnExactly);
+}
+
+
+template<class Scalar>
+void TimeEventRange<Scalar>::setTimeRange(
+  Scalar start, Scalar stop, Scalar stride)
+{
+  start_  = start;
+  stop_   = stop;
+  if (stop_ < start_) {
+    Scalar tmp = start_;
+    start_ = stop_;
+    stop_ = tmp;
+  }
+  setTimeScale();
+  setTimeStride(stride);
+}
+
+
+template<class Scalar>
+void TimeEventRange<Scalar>::setTimeRange(
+  Scalar start, Scalar stop, int numEvents)
+{
+  start_  = start;
+  stop_   = stop;
+  if (stop_ < start_) {
+    Scalar tmp = start_;
+    start_ = stop_;
+    stop_ = tmp;
+  }
+  setTimeScale();
+  setNumEvents(numEvents);
 }
 
 
@@ -71,8 +115,8 @@ void TimeEventRange<Scalar>::setTimeStart(Scalar start)
 {
   start_ = start;
   if (stop_ < start_) stop_ = start_;
-  setTimeStride(stride_);  // Reset numEvents with the current stride.
   setTimeScale();
+  setTimeStride(stride_);  // Reset numEvents with the current stride.
 }
 
 
@@ -81,8 +125,8 @@ void TimeEventRange<Scalar>::setTimeStop(Scalar stop)
 {
   stop_ = stop;
   if (start_ > stop_) start_ = stop_;
-  setTimeStride(stride_);  // Reset numEvents with the current stride.
   setTimeScale();
+  setTimeStride(stride_);  // Reset numEvents with the current stride.
 }
 
 
@@ -122,12 +166,22 @@ template<class Scalar>
 void TimeEventRange<Scalar>::setNumEvents(int numEvents)
 {
   numEvents_ = numEvents;
-  if (numEvents_ < 1) numEvents_ = 1;
-  stride_ = (stop_ - start_)/Scalar(numEvents_-1);
-
-  if (stride_ < 2 * absTol_) {
-    setTimeStride(2*absTol_);
+  if (numEvents_ < 0) {  // Do not use numEvents_ to set stride!  Reset numEvents_ from stride_.
+    if (stride_ < 2 * absTol_) stride_ = 2*absTol_;
+    numEvents_ = int((stop_+absTol_ - start_) / stride_) + 1;
+    return;
+  } else if ((start_ >= stop_-absTol_) && (start_ <= stop_+absTol_)) {
+    numEvents_ = 1;
+    stride_ = 0.0;
+    stride_ = stop_ - start_;
+  } else {
+    if (numEvents_ < 2) numEvents_ = 2;
+    stride_ = (stop_ - start_)/Scalar(numEvents_-1);
   }
+
+  // If stride_ is smaller than twice the absolute tolerance,
+  // the time steps cannot be differentiated!
+  if (stride_ <= 2 * absTol_) setTimeStride(2*absTol_);
 }
 
 
@@ -135,14 +189,35 @@ template<class Scalar>
 void TimeEventRange<Scalar>::setRelTol(Scalar relTol)
 {
   relTol_ = std::abs(relTol);
-  absTol_ = relTol_*timeScale_;
+  setTimeScale();
 }
 
 
 template<class Scalar>
 bool TimeEventRange<Scalar>::isTime(Scalar time) const
 {
-  return (std::abs(timeToNextEvent(time)) <= absTol_);
+  // Check if before first event.
+  if (time < start_-absTol_) return false;
+
+  // Check if after last event.
+  const Scalar timeOfLast = start_ + (numEvents_-1) * stride_;
+  if (time > timeOfLast+absTol_) return false;
+
+  int numStrides = (time - start_) / stride_;
+  numStrides = std::max(0, numStrides);
+  numStrides = std::min(numStrides, int(numEvents_-1));
+  const Scalar leftBracket = start_ + numStrides * stride_;
+
+  // Check if close to left bracket.
+  if ( leftBracket-absTol_ < time && time < leftBracket+absTol_ )
+    return true;
+
+  // Check if close to right bracket.
+  const Scalar rightBracket = leftBracket + stride_;
+  if ( rightBracket-absTol_ < time && time < rightBracket+absTol_ )
+    return true;
+
+  return false;
 }
 
 
@@ -156,22 +231,20 @@ Scalar TimeEventRange<Scalar>::timeToNextEvent(Scalar time) const
 template<class Scalar>
 Scalar TimeEventRange<Scalar>::timeOfNextEvent(Scalar time) const
 {
-  // Check if before or close to first event.
-  if (start_ >= time-absTol_) return start_;
+  // Check if before first event.
+  if (time < start_-absTol_) return start_;
 
   const Scalar timeOfLast = start_ + (numEvents_-1) * stride_;
   // Check if after or close to last event.
-  if (timeOfLast <= time+absTol_) return timeOfLast;
+  if (time > timeOfLast-absTol_) return std::numeric_limits<Scalar>::max();
 
-  const int numStrides = (time - start_) / stride_;
-  const Scalar timeOfNext = start_ + numStrides * stride_;
+  const Scalar timeEvent = start_ + ceil((time - start_)/stride_)*stride_;
 
-  // Check if close to left-side time event
-  if (timeOfNext > time-absTol_ &&
-      timeOfNext < time+absTol_) return timeOfNext;
+  // Check timeEvent is near time.  If so, return the next event.
+  if ( timeEvent-absTol_ < time && time < timeEvent+absTol_ )
+    return timeEvent + stride_;
 
-  // Otherwise it is the next event.
-  return timeOfNext + stride_;
+  return timeEvent;
 }
 
 
@@ -184,38 +257,108 @@ bool TimeEventRange<Scalar>::eventInRange(Scalar time1, Scalar time2) const
     time2 = tmp;
   }
 
-  const Scalar timeOfLast = start_ + (numEvents_-1) * stride_;
   // Check if range is completely outside time events.
+  const Scalar timeOfLast = start_ + (numEvents_-1) * stride_;
   if (time2+absTol_ < start_ || timeOfLast < time1-absTol_) return false;
 
-  Scalar timeEvent1 = timeOfNextEvent(time1);
-  Scalar timeEvent2 = timeOfNextEvent(time2);
-  // Check if the next time event is different for the two times.
-  if (timeEvent1 != timeEvent2) return true;
+  const int strideJustBeforeTime1 = std::min(int(numEvents_-1),
+    std::max(int(0), int((time1 - start_ + absTol_) / stride_ - 0.5)));
 
-  // Check if times bracket time event.
-  if (time1-absTol_ <= timeEvent1 && timeEvent1 <= time2+absTol_) return true;
+  const int strideJustAfterTime2 = std::max(int(0), std::min(int(numEvents_-1),
+    int((time2 - start_ + absTol_) / stride_ + 0.5)));
+
+  for ( int i = strideJustBeforeTime1; i <= strideJustAfterTime2; i++ ) {
+    const Scalar timeEvent = start_ + i * stride_;
+    if (time1-absTol_ < timeEvent && timeEvent < time2+absTol_) return true;
+  }
 
   return false;
 }
 
 
 template<class Scalar>
-void TimeEventRange<Scalar>::describe() const
+void TimeEventRange<Scalar>::describe(Teuchos::FancyOStream          &out,
+                                const Teuchos::EVerbosityLevel verbLevel) const
 {
-  Teuchos::RCP<Teuchos::FancyOStream> out =
-    Teuchos::VerboseObjectBase::getDefaultOStream();
-  out->setOutputToRootOnly(0);
-  *out << "TimeEventRange:" << "\n"
-       << "name           = " << this->getName() << "\n"
-       << "start_         = " << start_         << "\n"
-       << "stop_          = " << stop_          << "\n"
-       << "stride_        = " << stride_        << "\n"
-       << "numEvents_     = " << numEvents_     << "\n"
-       << "timeScale_     = " << timeScale_     << "\n"
-       << "relTol_        = " << relTol_        << "\n"
-       << "absTol_        = " << absTol_        << "\n"
-       << "landOnExactly_ = " << landOnExactly_ << std::endl;
+  auto l_out = Teuchos::fancyOStream( out.getOStream() );
+  Teuchos::OSTab ostab(*l_out, 2, "TimeEventRange");
+  l_out->setOutputToRootOnly(0);
+
+  *l_out << "TimeEventRange:" << "\n"
+         << "  name            = " << this->getName() << "\n"
+         << "  Type            = " << this->getType() << "\n"
+         << "  start_          = " << start_         << "\n"
+         << "  stop_           = " << stop_          << "\n"
+         << "  stride_         = " << stride_        << "\n"
+         << "  numEvents_      = " << numEvents_     << "\n"
+         << "  timeScale_      = " << timeScale_     << "\n"
+         << "  relTol_         = " << relTol_        << "\n"
+         << "  absTol_         = " << absTol_        << "\n"
+         << "  landOnExactly_  = " << landOnExactly_ << std::endl;
+}
+
+
+template<class Scalar>
+Teuchos::RCP<const Teuchos::ParameterList>
+TimeEventRange<Scalar>::getValidParameters() const
+{
+  Teuchos::RCP<Teuchos::ParameterList> pl =
+    Teuchos::parameterList("Time Event Range");
+
+  pl->setName(this->getName());
+  pl->set("Name", this->getName());
+  pl->set("Type", this->getType());
+
+  pl->set("Start Time", getTimeStart(), "Start of time range");
+  pl->set("Stop Time",  getTimeStop(),  "Stop of time range");
+  pl->set("Stride Time", getTimeStride(), "Stride of time range");
+
+  if ( getTimeStride()*Scalar(getNumEvents()-1) - (getTimeStop()-getTimeStart()) < getAbsTol() )
+    pl->set("Number of Events", getNumEvents(),
+      "Number of events in time range.  If specified, 'Stride Time' is reset.");
+
+  pl->set("Relative Tolerance", getRelTol(),
+          "Relative time tolerance for matching time events.");
+
+  pl->set("Land On Exactly", getLandOnExactly(),
+          "Should these time events be landed on exactly, i.e, adjust the timestep to hit time event, versus stepping over and keeping the time step unchanged.");
+
+  return pl;
+}
+
+
+// Nonmember constructors.
+// ------------------------------------------------------------------------
+
+template<class Scalar>
+Teuchos::RCP<TimeEventRange<Scalar> > createTimeEventRange(
+  Teuchos::RCP<Teuchos::ParameterList> pl)
+{
+  auto ter = Teuchos::rcp(new TimeEventRange<Scalar>());
+  if (pl == Teuchos::null) return ter;  // Return default TimeEventRange.
+
+  TEUCHOS_TEST_FOR_EXCEPTION(
+    pl->get<std::string>("Type", "Range") != "Range",
+    std::logic_error,
+    "Error - Time Event Type != 'Range'.  (='"
+    + pl->get<std::string>("Type")+"')\n");
+
+  auto validPL = *ter->getValidParameters();
+  bool numEventsFound = pl->isParameter("Number of Events");
+  if (!numEventsFound) validPL.remove("Number of Events");
+
+  pl->validateParametersAndSetDefaults(validPL);
+
+  ter->setName          (pl->get("Name",       "From createTimeEventRange"));
+  ter->setTimeStart     (pl->get("Start Time",       ter->getTimeStart()));
+  ter->setTimeStop      (pl->get("Stop Time",        ter->getTimeStop()));
+  ter->setTimeStride    (pl->get("Stride Time",      ter->getTimeStride()));
+  if (numEventsFound)
+    ter->setNumEvents   (pl->get("Number of Events", ter->getNumEvents()));
+  ter->setRelTol        (pl->get("Relative Tolerance", ter->getRelTol()));
+  ter->setLandOnExactly (pl->get("Land On Exactly", ter->getLandOnExactly()));
+
+  return ter;
 }
 
 

--- a/packages/tempus/src/Tempus_TimeEventRange_impl.hpp
+++ b/packages/tempus/src/Tempus_TimeEventRange_impl.hpp
@@ -14,20 +14,14 @@ namespace Tempus {
 
 template<class Scalar>
 TimeEventRange<Scalar>::TimeEventRange()
-  : start_ (0.0),
-    stop_  (0.0),
-    stride_(0.0),
-    numEvents_(1),
-    timeScale_(1.0),
-    relTol_(1.0e-14),
-    absTol_(1.0e-14),
-    landOnExactly_(true)
 {
   this->setType("Range");
+  setRelTol(this->getDefaultTol()),
+  setTimeRange(0.0, 0.0, 0.0);
+  setLandOnExactly(true);
   std::ostringstream oss;
   oss << "TimeEventRange (" << start_<< "; " << stop_<< "; " << stride_<< ")";
   this->setName(oss.str());
-  setTimeRange(start_, stop_, stride_);
 }
 
 

--- a/packages/tempus/src/Tempus_TimeStepControlStrategyComposite.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategyComposite.hpp
@@ -279,7 +279,7 @@ template<class Scalar>
 Teuchos::RCP<Teuchos::ParameterList> getTimeStepControlStrategyCompositePL()
 {
   auto t = rcp(new Tempus::TimeStepControlStrategyComposite<Scalar>());
-  auto tscs = rcp(new Tempus::TimeStepControlStrategyConstant<double>());
+  auto tscs = rcp(new Tempus::TimeStepControlStrategyConstant<Scalar>());
   t->addStrategy(tscs);
   return Teuchos::rcp_const_cast<Teuchos::ParameterList> (t->getValidParameters());
 }

--- a/packages/tempus/src/Tempus_TimeStepControl_decl.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControl_decl.hpp
@@ -125,7 +125,17 @@ public:
     virtual int getFinalIndex() const { return finalIndex_; }
     virtual Scalar getMaxAbsError() const { return maxAbsError_; }
     virtual Scalar getMaxRelError() const { return maxRelError_; }
+
+    /** \brief Return if the output needs to exactly happen on output time.
+     *
+     *  Output TimeEvents, "Output Time Interval" and "Output Time List",
+     *  will always have the same OutputExactly value, so just
+     *  find one or the other.  Otherwise return the default of true.
+     *
+     *  \return True if output needs to happen exactly on output times.
+     */
     virtual bool getOutputExactly() const;
+
     virtual std::vector<int> getOutputIndices() const;
     virtual std::vector<Scalar> getOutputTimes() const;
     virtual int getOutputIndexInterval() const;

--- a/packages/tempus/src/Tempus_TimeStepControl_decl.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControl_decl.hpp
@@ -19,6 +19,7 @@
 #include "Tempus_config.hpp"
 #include "Tempus_SolutionHistory.hpp"
 #include "Tempus_TimeStepControlStrategy.hpp"
+#include "Tempus_TimeEventComposite.hpp"
 
 
 namespace Tempus {
@@ -75,6 +76,7 @@ public:
     std::vector<Scalar> outputTimes,
     int                 outputIndexInterval,
     Scalar              outputTimeInterval,
+    Teuchos::RCP<TimeEventComposite<Scalar> > timeEvent,
     Teuchos::RCP<TimeStepControlStrategy<Scalar>> stepControlStrategy);
 
   /// Destructor
@@ -113,7 +115,7 @@ public:
 
   /// \name Get accessors
   //@{
-    virtual std::string getStepType() const { return stepControlStrategy_->getStepType(); }
+    virtual std::string getStepType() const;
     virtual Scalar getInitTime() const { return initTime_; }
     virtual Scalar getFinalTime() const { return finalTime_; }
     virtual Scalar getMinTimeStep() const { return minTimeStep_; }
@@ -123,18 +125,19 @@ public:
     virtual int getFinalIndex() const { return finalIndex_; }
     virtual Scalar getMaxAbsError() const { return maxAbsError_; }
     virtual Scalar getMaxRelError() const { return maxRelError_; }
-    virtual bool getOutputExactly() const { return outputExactly_; }
-    virtual std::vector<int> getOutputIndices() const { return outputIndices_; }
-    virtual std::vector<Scalar> getOutputTimes() const { return outputTimes_; }
+    virtual bool getOutputExactly() const;
+    virtual std::vector<int> getOutputIndices() const;
+    virtual std::vector<Scalar> getOutputTimes() const;
+    virtual int getOutputIndexInterval() const;
+    virtual Scalar getOutputTimeInterval() const;
     virtual int getMaxFailures() const { return maxFailures_; }
     virtual int getMaxConsecFailures() const { return maxConsecFailures_; }
     virtual bool getPrintDtChanges() const { return printDtChanges_; }
     virtual int getNumTimeSteps() const { return numTimeSteps_; }
-
+    virtual Teuchos::RCP<TimeEventComposite<Scalar> >
+       getTimeEvents() const { return timeEvent_; }
     virtual Teuchos::RCP<TimeStepControlStrategy<Scalar>>
        getTimeStepControlStrategy() const { return stepControlStrategy_;}
-    virtual int getOutputIndexInterval() const { return outputIndexInterval_;}
-    virtual Scalar getOutputTimeInterval() const { return outputTimeInterval_;}
   //@}
 
   /// \name Set accessors
@@ -152,13 +155,13 @@ public:
     virtual void setMaxConsecFailures(int i) { maxConsecFailures_ = i; isInitialized_ = false; }
     virtual void setPrintDtChanges(bool b) { printDtChanges_ = b; isInitialized_ = false; }
     virtual void setNumTimeSteps(int numTimeSteps);
-
-    virtual void setOutputExactly(bool b) { outputExactly_ = b; isInitialized_ = false; }
-    virtual void setOutputIndices(std::vector<int> v) { outputIndices_ = v; isInitialized_ = false; }
-    virtual void setOutputTimes(std::vector<Scalar> v) { outputTimes_ = v; isInitialized_ = false; }
-    virtual void setOutputIndexInterval(int i) { outputIndexInterval_ = i; isInitialized_ = false; }
-    virtual void setOutputTimeInterval(Scalar t) { outputTimeInterval_ = t; isInitialized_ = false; }
-
+    virtual void setOutputExactly(bool b);
+    virtual void setOutputIndices(std::vector<int> v);
+    virtual void setOutputTimes(std::vector<Scalar> outputTimes);
+    virtual void setOutputIndexInterval(int i);
+    virtual void setOutputTimeInterval(Scalar t);
+    virtual void setTimeEvents(
+      Teuchos::RCP<TimeEventComposite<Scalar> > teb = Teuchos::null);
     virtual void setTimeStepControlStrategy(
       Teuchos::RCP<TimeStepControlStrategy<Scalar> > tscs = Teuchos::null);
   //@}
@@ -187,14 +190,10 @@ protected:
   int          numTimeSteps_;      ///< Number of time steps for Constant time step
   bool         printDtChanges_;    ///< Print timestep size when it changes
 
-  bool                outputExactly_;  ///< Output Exactly On Output Times
-  std::vector<int>    outputIndices_;  ///< Vector of output indices
-  std::vector<Scalar> outputTimes_;    ///< Vector of output times
-  int outputIndexInterval_;
-  Scalar outputTimeInterval_;
+  Teuchos::RCP<TimeEventComposite<Scalar> > timeEvent_;
 
-  bool outputAdjustedDt_; ///< Flag indicating that dt was adjusted for output.
-  Scalar dtAfterOutput_;  ///< dt to reinstate after output step.
+  bool teAdjustedDt_;   ///< Flag indicating that dt was adjusted for time event.
+  Scalar dtAfterTimeEvent_;  ///< dt to reinstate after TimeEvent step.
 
   Teuchos::RCP<TimeStepControlStrategy<Scalar>> stepControlStrategy_;
 

--- a/packages/tempus/src/Tempus_TimeStepControl_impl.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControl_impl.hpp
@@ -15,6 +15,10 @@
 #include "Tempus_TimeStepControlStrategyComposite.hpp"
 #include "Tempus_TimeStepControlStrategyBasicVS.hpp"
 #include "Tempus_TimeStepControlStrategyIntegralController.hpp"
+#include "Tempus_TimeEventRange.hpp"
+#include "Tempus_TimeEventRangeIndex.hpp"
+#include "Tempus_TimeEventList.hpp"
+#include "Tempus_TimeEventListIndex.hpp"
 
 
 namespace Tempus {
@@ -25,7 +29,7 @@ TimeStepControl<Scalar>::TimeStepControl()
     initTime_           (0.0),
     finalTime_          (1.0e+99),
     minTimeStep_        (0.0),
-    initTimeStep_       (1.0),
+    initTimeStep_       (1.0e+99),
     maxTimeStep_        (1.0e+99),
     initIndex_          (0),
     finalIndex_         (1000000),
@@ -35,15 +39,11 @@ TimeStepControl<Scalar>::TimeStepControl()
     maxConsecFailures_  (5),
     numTimeSteps_       (-1),
     printDtChanges_     (true),
-    outputExactly_      (true),
-    //outputIndices_      (),
-    //outputTimes_        (),
-    outputIndexInterval_(1000000),
-    outputTimeInterval_ (1.0e+99),
-    outputAdjustedDt_(false),
-    dtAfterOutput_(0.0)
+    teAdjustedDt_       (false),
+    dtAfterTimeEvent_   (0.0)
 {
   setTimeStepControlStrategy();
+  setTimeEvents();
   this->initialize();
 }
 
@@ -68,6 +68,7 @@ TimeStepControl<Scalar>::TimeStepControl(
   std::vector<Scalar> outputTimes,
   int                 outputIndexInterval,
   Scalar              outputTimeInterval,
+  Teuchos::RCP<TimeEventComposite<Scalar> > timeEvent,
   Teuchos::RCP<TimeStepControlStrategy<Scalar>> stepControlStrategy)
   : isInitialized_      (false              ),
     initTime_           (initTime           ),
@@ -81,18 +82,41 @@ TimeStepControl<Scalar>::TimeStepControl(
     maxRelError_        (maxRelError        ),
     maxFailures_        (maxFailures        ),
     maxConsecFailures_  (maxConsecFailures  ),
-    numTimeSteps_       (numTimeSteps       ),
     printDtChanges_     (printDtChanges     ),
-    outputExactly_      (outputExactly      ),
-    outputIndices_      (outputIndices      ),
-    outputTimes_        (outputTimes        ),
-    outputIndexInterval_(outputIndexInterval),
-    outputTimeInterval_ (outputTimeInterval ),
-    outputAdjustedDt_   (false              ),
-    dtAfterOutput_      (0.0                ),
-    stepControlStrategy_(stepControlStrategy)
+    teAdjustedDt_       (false              ),
+    dtAfterTimeEvent_   (0.0                )
 {
-  setNumTimeSteps(getNumTimeSteps());
+  using Teuchos::rcp;
+
+  setTimeStepControlStrategy(stepControlStrategy);
+  setNumTimeSteps(numTimeSteps);
+
+  auto tec = rcp(new TimeEventComposite<Scalar>());
+  tec->setName("Time Step Control Events");
+  auto tes = timeEvent->getTimeEvents();
+  for(auto& e : tes) tec->add(e);
+
+  // Add a range of times.
+  auto teRange = rcp(new TimeEventRange<Scalar>(
+    initTime, finalTime, outputTimeInterval, "Output Time Interval", outputExactly));
+  tec->add(teRange);
+
+  // Add a list of times.
+  if (!outputTimes.empty())
+    tec->add(rcp(new TimeEventList<Scalar>(
+      outputTimes, "Output Time List", outputExactly)));
+
+  // Add a range of indices.
+  tec->add(rcp(new TimeEventRangeIndex<Scalar>(
+    initIndex, finalIndex, outputIndexInterval, "Output Index Interval")));
+
+  // Add a list of indices.
+  if (!outputTimes.empty())
+    tec->add(rcp(new TimeEventListIndex<Scalar>(
+      outputIndices, "Output Index List")));
+
+  setTimeEvents(tec);
+
   this->initialize();
 }
 
@@ -148,18 +172,18 @@ void TimeStepControl<Scalar>::initialize() const
     <<getMaxRelError()<<")\n");
 
   TEUCHOS_TEST_FOR_EXCEPTION(
+    (stepControlStrategy_ == Teuchos::null), std::logic_error,
+    "Error - Strategy is unset!\n");
+
+  stepControlStrategy_->initialize();
+
+  TEUCHOS_TEST_FOR_EXCEPTION(
     (getStepType() != "Constant" && getStepType() != "Variable"),
     std::out_of_range,
       "Error - 'Step Type' does not equal one of these:\n"
     << "  'Constant' - Integrator will take constant time step sizes.\n"
     << "  'Variable' - Integrator will allow changes to the time step size.\n"
     << "  stepType = " << getStepType() << "\n");
-
-  TEUCHOS_TEST_FOR_EXCEPTION(
-    (stepControlStrategy_ == Teuchos::null), std::logic_error,
-    "Error - Strategy is unset!\n");
-
-  stepControlStrategy_->initialize();
 
   isInitialized_ = true;   // Only place where this is set to true!
 }
@@ -202,6 +226,7 @@ void TimeStepControl<Scalar>::setNextTimeStep(
   Status & integratorStatus)
 {
   using Teuchos::RCP;
+  using Teuchos::rcp_dynamic_cast;
 
   checkInitialized();
 
@@ -212,18 +237,17 @@ void TimeStepControl<Scalar>::setNextTimeStep(
     const int iStep = workingState->getIndex();
     Scalar dt   = workingState->getTimeStep();
     Scalar time = workingState->getTime();
-    bool output = false;
 
     RCP<StepperState<Scalar> > stepperState = workingState->getStepperState();
 
-    // If last time step was adjusted for output, reinstate previous dt.
+    // If last time step was adjusted for time event, reinstate previous dt.
     if (getStepType() == "Variable") {
-      if (outputAdjustedDt_ == true) {
-        printDtChanges(iStep, dt, dtAfterOutput_, "Reset dt after output.");
-        dt = dtAfterOutput_;
+      if (teAdjustedDt_ == true) {
+        printDtChanges(iStep, dt, dtAfterTimeEvent_, "Reset dt after time event.");
+        dt = dtAfterTimeEvent_;
         time = lastTime + dt;
-        outputAdjustedDt_ = false;
-        dtAfterOutput_ = 0.0;
+        teAdjustedDt_ = false;
+        dtAfterTimeEvent_ = 0.0;
       }
 
       if (dt <= 0.0) {
@@ -247,7 +271,7 @@ void TimeStepControl<Scalar>::setNextTimeStep(
     stepControlStrategy_->setNextTimeStep(*this, solutionHistory,
                                           integratorStatus);
 
-    // Get the dt (probably have changed by stepControlStrategy_)
+    // Get the dt (It was probably changed by stepControlStrategy_.)
     dt = workingState->getTimeStep();
     time = workingState->getTime();
 
@@ -267,90 +291,84 @@ void TimeStepControl<Scalar>::setNextTimeStep(
     }
 
 
-    // Check if we need to output this step index
-    std::vector<int>::const_iterator it =
-      std::find(getOutputIndices().begin(), getOutputIndices().end(), iStep);
-    if (it != getOutputIndices().end()) output = true;
+    // Check if this index is a TimeEvent and wheather it is an output event.
+    bool outputDueToIndex = false;
+    Teuchos::RCP<TimeEventBase<Scalar> > constrainingTE;
+    bool teThisStep = timeEvent_->isIndex(iStep, constrainingTE);
+    if (teThisStep &&
+        (constrainingTE->getName() == "Output Index Interval" ||
+         constrainingTE->getName() == "Output Index List"        ))
+    { outputDueToIndex = true; }
 
-    const int iInterval = getOutputIndexInterval();
-    if ( (iStep - getInitIndex()) % iInterval == 0) output = true;
+    // Check if during this time step is there a TimeEvent.
+    Scalar endTime = lastTime+dt;
+    // For "Variable", need to check t+dt+t_min in case we need to split
+    // the time step into two steps (e.g., time step lands within dt_min).
+    if (getStepType() == "Variable") endTime = lastTime+dt+getMinTimeStep();
 
-    // Check if we need to output in the next timestep based on
-    // outputTimes_ or "Output Time Interval".
+    Scalar tone = timeEvent_->timeOfNextEvent(lastTime, constrainingTE);
+    teThisStep = lastTime < tone && tone <= endTime;
+
+    bool outputDueToTime = false;
+    if (teThisStep &&
+        (constrainingTE->getName() == "Output Time Interval" ||
+         constrainingTE->getName() == "Output Time List"        ))
+    { outputDueToTime = true; }
+
     Scalar reltol = 1.0e-6;
-    Scalar endTime = lastTime+dt+getMinTimeStep();
-    // getMinTimeStep() = dt for constant time step
-    // so we can't add it on here
-    if (getStepType() == "Constant") endTime = lastTime+dt;
-    bool checkOutput = false;
-    Scalar oTime = getInitTime();
-    for (size_t i=0; i < outputTimes_.size(); ++i) {
-      oTime = outputTimes_[i];
-      if (lastTime < oTime && oTime <= endTime) {
-        checkOutput = true;
-        break;
+    if (teThisStep &&  getStepType() == "Variable") {
+      bool landOnExactly = true;
+      // Check if we need to "land on exactly" the next TimeEvent.
+      if (constrainingTE->getType() == "Range") {
+        auto ter = rcp_dynamic_cast<TimeEventRange<Scalar> >(constrainingTE);
+        landOnExactly = ter->getLandOnExactly();
       }
-    }
-    const Scalar tInterval = getOutputTimeInterval();
-    Scalar oTime2 =  ceil((lastTime-getInitTime())/tInterval)*tInterval
-                   + getInitTime();
-    if (lastTime < oTime2 && oTime2 <= endTime) {
-      if (checkOutput == true) {
-        if (oTime2 < oTime) oTime = oTime2;  // Use the first output time.
-      } else {
-        checkOutput = true;
-        oTime = oTime2;
+      if (constrainingTE->getType() == "List" ) {
+        auto tel = rcp_dynamic_cast<TimeEventList<Scalar> >(constrainingTE);
+        landOnExactly = tel->getLandOnExactly();
       }
-    }
-
-    if (checkOutput == true) {
-      const bool outputExactly = getOutputExactly();
-      if (getStepType() == "Variable" && outputExactly == true) {
-        // Adjust time step to hit output times.
-        if ( time > oTime ) {
-          output = true;
-          printDtChanges(iStep, dt, oTime - lastTime,
-            "Adjusting dt to hit the next output time.");
-          // Next output time is not near next time
-          // (>getMinTimeStep() away from it).
-          // Take time step to hit output time.
-          outputAdjustedDt_ = true;
-          dtAfterOutput_ = dt;
-          dt = oTime - lastTime;
+      if (landOnExactly == true) {
+        // Adjust time step to hit TimeEvent.
+        if ( time > tone ) {
+          // Next TimeEvent is not near next time.  It is more than
+          // getMinTimeStep() away from it.
+          printDtChanges(iStep, dt, tone - lastTime,
+            "Adjusting dt to hit the next TimeEvent.");
+          teAdjustedDt_ = true;
+          dtAfterTimeEvent_ = dt;
+          dt = tone - lastTime;
           time = lastTime + dt;
-        } else if (std::fabs((time-oTime)/(time)) < reltol) {
-          output = true;
-          printDtChanges(iStep, dt, oTime - lastTime,
-            "Adjusting dt for numerical roundoff to hit the next output time.");
-          // Next output time IS VERY near next time (<reltol away from it),
-          // e.g., adjust for numerical roundoff.
-          outputAdjustedDt_ = true;
-          dtAfterOutput_ = dt;
-          dt = oTime - lastTime;
+        } else if (std::fabs(time-tone) < reltol*std::fabs(time)) {
+          // Next TimeEvent IS VERY near next time.  It is less than
+          // reltol away from it, e.g., adjust for numerical roundoff.
+          printDtChanges(iStep, dt, tone - lastTime,
+            "Adjusting dt for numerical roundoff to hit the next TimeEvent.");
+          teAdjustedDt_ = true;
+          dtAfterTimeEvent_ = dt;
+          dt = tone - lastTime;
           time = lastTime + dt;
-        } else  if (std::fabs((time + getMinTimeStep() - oTime)/oTime) < reltol ) {
-          printDtChanges(iStep, dt, (oTime - lastTime)/2.0,
-            "The next output time is within the minimum dt of the next time. "
+        } else  if (std::fabs(time + getMinTimeStep() - tone)
+                    < reltol*std::fabs(tone)) {
+          // Next TimeEvent IS near next time.  It is less than
+          // getMinTimeStep() away from it.  Take two time steps
+          // to get to next TimeEvent.
+          printDtChanges(iStep, dt, (tone - lastTime)/2.0,
+            "The next TimeEvent is within the minimum dt of the next time. "
             "Adjusting dt to take two steps.");
-          // Next output time IS near next time
-          // (<getMinTimeStep() away from it).
-          // Take two time steps to get to next output time.
-          dt = (oTime - lastTime)/2.0;
+          dt = (tone - lastTime)/2.0;
           time = lastTime + dt;
+          // This time step is no longer an output step due the time constraint.
+          outputDueToTime = false;
         }
-      } else {
-        // Stepping over output time and want this time step for output,
-        // but do not want to change dt. Either because of 'Constant' time
-        // step or user specification, "Output Exactly On Output Times"=false.
-        output = true;
       }
     }
 
     // Adjust time step to hit final time or correct for small
     // numerical differences.
     if (getStepType() == "Variable") {
-      if ((lastTime + dt > getFinalTime() ) ||
-          (std::fabs((lastTime+dt-getFinalTime())/(lastTime+dt)) < reltol)) {
+      if ( (lastTime+dt > getFinalTime()) ||
+           (std::fabs((lastTime+dt-getFinalTime()))
+            < reltol*std::fabs(lastTime+dt)) ) {
         printDtChanges(iStep, dt, getFinalTime() - lastTime,
           "Adjusting dt to hit final time.");
         dt = getFinalTime() - lastTime;
@@ -381,7 +399,7 @@ void TimeStepControl<Scalar>::setNextTimeStep(
 
     workingState->setTimeStep(dt);
     workingState->setTime(time);
-    workingState->setOutput(output);
+    workingState->setOutput(outputDueToIndex || outputDueToTime);
   }
   return;
 }
@@ -409,20 +427,94 @@ bool TimeStepControl<Scalar>::timeInRange(const Scalar time) const
 
 /// Test if index is within range: include initIndex and exclude finalIndex.
 template<class Scalar>
-bool TimeStepControl<Scalar>::indexInRange(const int iStep) const{
+bool TimeStepControl<Scalar>::indexInRange(const int iStep) const
+{
   bool iir = (getInitIndex() <= iStep && iStep < getFinalIndex());
   return iir;
 }
 
 
 template<class Scalar>
+std::string TimeStepControl<Scalar>::getStepType() const
+{
+  TEUCHOS_TEST_FOR_EXCEPTION(
+    (stepControlStrategy_ == Teuchos::null), std::logic_error,
+    "Error - getStepType() - Strategy is unset!\n");
+  return stepControlStrategy_->getStepType();
+}
+
+
+template<class Scalar>
+bool TimeStepControl<Scalar>::getOutputExactly() const
+{
+  auto event = timeEvent_->find("Output Time Interval");
+  if (event != Teuchos::null) {
+    auto ter = Teuchos::rcp_dynamic_cast<TimeEventRange<Scalar> >(event);
+    return ter->getLandOnExactly();
+  }
+  event = timeEvent_->find("Output Time List");
+  if (event != Teuchos::null) {
+    auto tel = Teuchos::rcp_dynamic_cast<TimeEventList<Scalar> >(event);
+    return tel->getLandOnExactly();
+  }
+  return true;
+}
+
+
+template<class Scalar>
+std::vector<int> TimeStepControl<Scalar>::getOutputIndices() const
+{
+  std::vector<int> indices;
+  if ( timeEvent_->find("Output Index List") == Teuchos::null)
+    return indices;
+  auto teli = Teuchos::rcp_dynamic_cast<TimeEventListIndex<Scalar> >(
+    timeEvent_->find("Output Index List"));
+  return teli->getIndexList();
+}
+
+
+template<class Scalar>
+std::vector<Scalar> TimeStepControl<Scalar>::getOutputTimes() const
+{
+  std::vector<Scalar> times;
+  if ( timeEvent_->find("Output Time List") == Teuchos::null)
+    return times;
+  auto tel = Teuchos::rcp_dynamic_cast<TimeEventList<Scalar> >(
+    timeEvent_->find("Output Time List"));
+  return tel->getTimeList();
+}
+
+
+template<class Scalar>
+int TimeStepControl<Scalar>::getOutputIndexInterval() const
+{
+  if ( timeEvent_->find("Output Index Interval") == Teuchos::null)
+    return 1000000;
+  auto teri = Teuchos::rcp_dynamic_cast<TimeEventRangeIndex<Scalar> >(
+    timeEvent_->find("Output Index Interval"));
+  return teri->getIndexStride();
+}
+
+
+template<class Scalar>
+Scalar TimeStepControl<Scalar>::getOutputTimeInterval() const
+{
+  if ( timeEvent_->find("Output Time Interval") == Teuchos::null)
+    return 1.0e+99;
+  auto ter = Teuchos::rcp_dynamic_cast<TimeEventRange<Scalar> >(
+    timeEvent_->find("Output Time Interval"));
+  return ter->getTimeStride();
+}
+
+
+template<class Scalar>
 void TimeStepControl<Scalar>::setNumTimeSteps(int numTimeSteps)
 {
-  TEUCHOS_TEST_FOR_EXCEPTION( getStepType() != "Constant", std::out_of_range,
-      "Error - Can only use setNumTimeSteps() when 'Step Type' == 'Constant'.\n");
+  TEUCHOS_TEST_FOR_EXCEPTION( (getStepType() != "Constant"), std::out_of_range,
+    "Error - Can only use setNumTimeSteps() when 'Step Type' == 'Constant'.\n");
 
-  if (numTimeSteps >= 0) {
-    numTimeSteps_ = numTimeSteps;
+  numTimeSteps_ = numTimeSteps;
+  if (numTimeSteps_ >= 0) {
     setFinalIndex(getInitIndex() + numTimeSteps_);
     Scalar initTimeStep;
     if (numTimeSteps_ == 0)
@@ -444,6 +536,95 @@ void TimeStepControl<Scalar>::setNumTimeSteps(int numTimeSteps)
 
     isInitialized_ = false;
   }
+}
+
+
+template<class Scalar>
+void TimeStepControl<Scalar>::setOutputExactly(bool b)
+{
+  auto event = timeEvent_->find("Output Time Interval");
+  if (event != Teuchos::null) {
+    auto ter = Teuchos::rcp_dynamic_cast<TimeEventRange<Scalar> >(event);
+    ter->setLandOnExactly(b);
+  }
+  event = timeEvent_->find("Output Time List");
+  if (event != Teuchos::null) {
+    auto tel = Teuchos::rcp_dynamic_cast<TimeEventList<Scalar> >(event);
+    tel->setLandOnExactly(b);
+  }
+}
+
+
+template<class Scalar>
+void TimeStepControl<Scalar>::setOutputIndices(std::vector<int> outputIndices)
+{
+  timeEvent_->add(Teuchos::rcp(new Tempus::TimeEventListIndex<Scalar>(
+    outputIndices, "Output Index List")));
+  isInitialized_ = false;
+}
+
+
+template<class Scalar>
+void TimeStepControl<Scalar>::setOutputTimes(std::vector<Scalar> outputTimes)
+{
+  timeEvent_->add(Teuchos::rcp(new Tempus::TimeEventList<Scalar>(
+    outputTimes, "Output Time List", getOutputExactly())));
+  isInitialized_ = false;
+}
+
+
+template<class Scalar>
+void TimeStepControl<Scalar>::setOutputIndexInterval(int i)
+{
+  timeEvent_->add(Teuchos::rcp(new TimeEventRangeIndex<Scalar>(
+    getInitIndex(), getFinalIndex(), i, "Output Index Interval")));
+  isInitialized_ = false;
+}
+
+
+template<class Scalar>
+void TimeStepControl<Scalar>::setOutputTimeInterval(Scalar t)
+{
+  timeEvent_->add(Teuchos::rcp(new TimeEventRange<Scalar>(
+    getInitTime(), getFinalTime(), t, "Output Time Interval", getOutputExactly())));
+  isInitialized_ = false;
+}
+
+
+template<class Scalar>
+void TimeStepControl<Scalar>::setTimeEvents(
+  Teuchos::RCP<TimeEventComposite<Scalar> > timeEvent)
+{
+  using Teuchos::rcp;
+
+  if ( timeEvent != Teuchos::null ) {
+    timeEvent_ = timeEvent;
+  } else {
+    auto tec = rcp(new TimeEventComposite<Scalar>());
+    tec->setName("Time Step Control Events");
+    tec->add(rcp(new TimeEventRangeIndex<Scalar>(
+      getInitIndex(), getFinalIndex(), 1000000, "Output Index Interval")));
+    tec->add(rcp(new TimeEventRange<Scalar>(
+      getInitTime(), getFinalTime(), 1.0e+99, "Output Time Interval", true)));
+    timeEvent_ = tec;
+  }
+  isInitialized_ = false;
+}
+
+
+template<class Scalar>
+void TimeStepControl<Scalar>::setTimeStepControlStrategy(
+  Teuchos::RCP<TimeStepControlStrategy<Scalar> > tscs)
+{
+  using Teuchos::rcp;
+
+  if ( tscs != Teuchos::null ) {
+    stepControlStrategy_ = tscs;
+  } else {
+    stepControlStrategy_ =
+      rcp(new TimeStepControlStrategyConstant<Scalar>(getInitTimeStep()));
+  }
+  isInitialized_ = false;
 }
 
 
@@ -501,28 +682,13 @@ void TimeStepControl<Scalar>::describe(
            << "  outputTimes        = " << listTimes.str()          << std::endl
            << "  outputIndexInterval= " << getOutputIndexInterval() << std::endl
            << "  outputTimeInterval = " << getOutputTimeInterval()  << std::endl
-           << "  outputAdjustedDt   = " << outputAdjustedDt_        << std::endl
-           << "  dtAfterOutput      = " << dtAfterOutput_           <<std::endl;
+           << "  outputAdjustedDt   = " << teAdjustedDt_            << std::endl
+           << "  dtAfterOutput      = " << dtAfterTimeEvent_        << std::endl;
            stepControlStrategy_->describe(*l_out, verbLevel);
+           timeEvent_->describe(*l_out, verbLevel);
   }
   *l_out << std::string(this->description().length()+8, '-') <<std::endl;
 
-}
-
-
-template<class Scalar>
-void TimeStepControl<Scalar>::setTimeStepControlStrategy(
-  Teuchos::RCP<TimeStepControlStrategy<Scalar> > tscs)
-{
-  using Teuchos::rcp;
-
-  if ( tscs != Teuchos::null ) {
-    stepControlStrategy_ = tscs;
-  } else {
-    stepControlStrategy_ =
-      rcp(new TimeStepControlStrategyConstant<Scalar>(getInitTimeStep()));
-  }
-  isInitialized_ = false;
 }
 
 
@@ -551,34 +717,62 @@ TimeStepControl<Scalar>::getValidParameters() const
   pl->set<bool>  ("Print Time Step Changes", getPrintDtChanges(),
     "Print timestep size when it changes");
 
+  auto event = timeEvent_->find("Output Index Interval");
+  if (event != Teuchos::null) {
+    auto teri = Teuchos::rcp_dynamic_cast<TimeEventRangeIndex<Scalar> >(event);
+    pl->set<int>   ("Output Index Interval", teri->getIndexStride(), "Output Index Interval");
+  }
+
+  event = timeEvent_->find("Output Time Interval");
+  if (event != Teuchos::null) {
+    auto ter = Teuchos::rcp_dynamic_cast<TimeEventRange<Scalar> >(event);
+    pl->set<double>("Output Time Interval", ter->getTimeStride(), "Output time interval");
+  }
+
   pl->set<bool>("Output Exactly On Output Times", getOutputExactly(),
     "This determines if the timestep size will be adjusted to exactly land\n"
     "on the output times for 'Variable' timestepping (default=true).\n"
     "When set to 'false' or for 'Constant' time stepping, the timestep\n"
     "following the output time will be flagged for output.\n");
 
-  pl->set<int>   ("Output Index Interval", getOutputIndexInterval(), "Output index interval");
-  pl->set<double>("Output Time Interval", getOutputTimeInterval(), "Output time interval");
-
   {
-    std::vector<int> idx = getOutputIndices();
+    event = timeEvent_->find("Output Index List");
     std::ostringstream list;
-    if (!idx.empty()) {
-      for(std::size_t i = 0; i < idx.size()-1; ++i) list << idx[i] << ", ";
-      list << idx[idx.size()-1];
+    if (event != Teuchos::null) {
+      auto teli = Teuchos::rcp_dynamic_cast<TimeEventListIndex<Scalar> >(event);
+      std::vector<int> idx = teli->getIndexList();
+      if (!idx.empty()) {
+        for(std::size_t i = 0; i < idx.size()-1; ++i) list << idx[i] << ", ";
+        list << idx[idx.size()-1];
+      }
     }
     pl->set<std::string>("Output Index List", list.str(),
       "Comma deliminated list of output indices");
   }
+
   {
-    std::vector<Scalar> times = getOutputTimes();
+    event = timeEvent_->find("Output Time List");
     std::ostringstream list;
-    if (!times.empty()) {
-      for(std::size_t i = 0; i < times.size()-1; ++i) list << times[i] << ", ";
-      list << times[times.size()-1];
+    if (event != Teuchos::null) {
+      auto teli = Teuchos::rcp_dynamic_cast<TimeEventList<Scalar> >(event);
+      std::vector<Scalar> times = teli->getTimeList();
+      if (!times.empty()) {
+        for(std::size_t i = 0; i < times.size()-1; ++i) list << times[i] << ", ";
+        list << times[times.size()-1];
+      }
     }
     pl->set<std::string>("Output Time List", list.str(),
       "Comma deliminated list of output times");
+  }
+
+  { // Do not duplicate the above "Output" events in "Time Step Control Events".
+    auto tecTmp = Teuchos::rcp(new TimeEventComposite<Scalar>());
+    tecTmp->setTimeEvents(timeEvent_->getTimeEvents());
+    tecTmp->remove("Output Index Interval");
+    tecTmp->remove("Output Time Interval");
+    tecTmp->remove("Output Index List");
+    tecTmp->remove("Output Time List");
+    pl->set("Time Step Control Events", *tecTmp->getValidParameters());
   }
 
   pl->set<int>   ("Maximum Number of Stepper Failures", getMaxFailures(),
@@ -599,6 +793,7 @@ Teuchos::RCP<TimeStepControl<Scalar> > createTimeStepControl(
   Teuchos::RCP<Teuchos::ParameterList> const& pList, bool runInitialize)
 {
   using Teuchos::RCP;
+  using Teuchos::rcp;
   using Teuchos::ParameterList;
 
   auto tsc = Teuchos::rcp(new TimeStepControl<Scalar>());
@@ -620,10 +815,11 @@ Teuchos::RCP<TimeStepControl<Scalar> > createTimeStepControl(
   tsc->setPrintDtChanges(   pList->get<bool>  ("Print Time Step Changes"));
   tsc->setNumTimeSteps(     pList->get<int>   ("Number of Time Steps"));
 
-  tsc->setOutputExactly(    pList->get<bool>  ("Output Exactly On Output Times"));
 
-  // Parse output indices
-  {
+  auto tec = rcp(new TimeEventComposite<Scalar>());
+  tec->setName("Time Step Control Events");
+
+  { // Parse output indices, "Output Index List".
     std::vector<int> outputIndices;
     outputIndices.clear();
     std::string str = pList->get<std::string>("Output Index List");
@@ -639,15 +835,27 @@ Teuchos::RCP<TimeStepControl<Scalar> > createTimeStepControl(
       pos = str.find_first_of(delimiters, lastPos);
     }
 
-    // order output indices
-    std::sort(outputIndices.begin(),outputIndices.end());
-    tsc->setOutputIndices(outputIndices);
+    if (!outputIndices.empty()) {
+      // order output indices
+      std::sort(outputIndices.begin(),outputIndices.end());
+      outputIndices.erase(std::unique(outputIndices.begin(),
+                                      outputIndices.end()   ),
+                                      outputIndices.end()     );
+
+      tec->add(rcp(new Tempus::TimeEventListIndex<Scalar>(
+                   outputIndices, "Output Index List")));
+    }
   }
 
-  tsc->setOutputIndexInterval(pList->get<int>("Output Index Interval"));
+  // Parse output index internal
+  tec->add(rcp(new TimeEventRangeIndex<Scalar>(
+    tsc->getInitIndex(), tsc->getFinalIndex(),
+    pList->get<int>("Output Index Interval"),
+    "Output Index Interval")));
 
-  // Parse output times
-  {
+  auto outputExactly = pList->get<bool>("Output Exactly On Output Times",true);
+
+  { // Parse output times, "Output Time List".
     std::vector<Scalar> outputTimes;
     outputTimes.clear();
     std::string str = pList->get<std::string>("Output Time List");
@@ -666,16 +874,54 @@ Teuchos::RCP<TimeStepControl<Scalar> > createTimeStepControl(
       pos = str.find_first_of(delimiters, lastPos);     // Find next delimiter
     }
 
-    // order output times
-    std::sort(outputTimes.begin(),outputTimes.end());
-    outputTimes.erase(std::unique(outputTimes.begin(),
-                                  outputTimes.end()   ),
-                                  outputTimes.end()     );
-    tsc->setOutputTimes(outputTimes);
+    if (!outputTimes.empty()) {
+      // order output times
+      std::sort(outputTimes.begin(),outputTimes.end());
+      outputTimes.erase(std::unique(outputTimes.begin(),
+                                    outputTimes.end()   ),
+                                    outputTimes.end()     );
+
+      tec->add(rcp(new Tempus::TimeEventList<Scalar>(
+                   outputTimes, "Output Time List", outputExactly)));
+    }
   }
 
-  tsc->setOutputTimeInterval(pList->get<double>("Output Time Interval"));
+  // Parse output time interval
+  tec->add(rcp(new TimeEventRange<Scalar>(
+    tsc->getInitTime(), tsc->getFinalTime(),
+    pList->get<double>("Output Time Interval"),
+    "Output Time Interval", outputExactly)));
 
+  if (pList->isSublist("Time Step Control Events")) {
+    RCP<ParameterList> tsctePL =
+      Teuchos::sublist(pList, "Time Step Control Events", true);
+
+    auto timeEventType = tsctePL->get<std::string>("Type", "Unknown");
+    if (timeEventType == "Range") {
+      tec->add(createTimeEventRange<Scalar>(tsctePL));
+    } else if (timeEventType == "Range Index") {
+      tec->add(createTimeEventRangeIndex<Scalar>(tsctePL));
+    } else if (timeEventType == "List") {
+      tec->add(createTimeEventList<Scalar>(tsctePL));
+    } else if (timeEventType == "List Index") {
+      tec->add(createTimeEventListIndex<Scalar>(tsctePL));
+    } else if (timeEventType == "Composite") {
+      auto tecTmp = createTimeEventComposite<Scalar>(tsctePL);
+      auto timeEvents = tecTmp->getTimeEvents();
+      for(auto& e : timeEvents) tec->add(e);
+    } else {
+      RCP<Teuchos::FancyOStream> out =
+        Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
+      out->setOutputToRootOnly(0);
+      Teuchos::OSTab ostab(out,1, "createTimeStepControl()");
+      *out << "Warning -- Unknown Time Event Type!\n"
+           << "'Type' = '" << timeEventType << "'\n"
+           << "Should call add() with this "
+           << "(app-specific?) Time Event.\n" << std::endl;
+    }
+  }
+
+  tsc->setTimeEvents(tec);
 
   if ( !pList->isParameter("Time Step Control Strategy") ) {
 

--- a/packages/tempus/test/ForwardEuler/Tempus_ForwardEulerTest.cpp
+++ b/packages/tempus/test/ForwardEuler/Tempus_ForwardEulerTest.cpp
@@ -46,10 +46,6 @@ TEUCHOS_UNIT_TEST(ForwardEuler, ParameterList)
   RCP<ParameterList> pList =
     getParametersFromXmlFile("Tempus_ForwardEuler_SinCos.xml");
 
-  //std::ofstream ftmp("PL.txt");
-  //pList->print(ftmp);
-  //ftmp.close();
-
   // Setup the SinCosModel
   RCP<ParameterList> scm_pl = sublist(pList, "SinCosModel", true);
   auto model = rcp(new SinCosModel<double> (scm_pl));

--- a/packages/tempus/test/ForwardEuler/Tempus_ForwardEuler_SinCos.xml
+++ b/packages/tempus/test/ForwardEuler/Tempus_ForwardEuler_SinCos.xml
@@ -38,7 +38,7 @@
         <Parameter name="Maximum Number of Stepper Failures" type="int" value="10"/>
         <Parameter name="Maximum Number of Consecutive Stepper Failures" type="int" value="5"/>
         <ParameterList name="Time Step Control Strategy">
-           <Parameter name="Strategy Type" type="string" value="Constant Time Step"/>
+           <Parameter name="Strategy Type" type="string" value="Constant"/>
            <Parameter name="Time Step" type="double" value="1.0"/>
         </ParameterList>
       </ParameterList>

--- a/packages/tempus/test/Integrator/Tempus_IntegratorBasic_ref.xml
+++ b/packages/tempus/test/Integrator/Tempus_IntegratorBasic_ref.xml
@@ -15,7 +15,7 @@
       <Parameter docString="" id="6" isDefault="true" isUsed="true" name="Initial Time" type="double" value="0.00000000000000000e+00"/>
       <Parameter docString="" id="7" isDefault="true" isUsed="true" name="Final Time" type="double" value="1.0e+99"/>
       <Parameter docString="" id="10" isDefault="true" isUsed="true" name="Minimum Time Step" type="double" value="0.0"/>
-      <Parameter docString="" id="11" isDefault="true" isUsed="true" name="Initial Time Step" type="double" value="1.0"/>
+      <Parameter docString="" id="11" isDefault="true" isUsed="true" name="Initial Time Step" type="double" value="1.0e+99"/>
       <Parameter docString="" id="12" isDefault="true" isUsed="true" name="Maximum Time Step" type="double" value="1.0e+99"/>
       <Parameter docString="" id="8" isDefault="true" isUsed="true" name="Initial Time Index" type="int" value="0"/>
       <Parameter docString="" id="9" isDefault="true" isUsed="true" name="Final Time Index" type="int" value="1000000"/>
@@ -30,9 +30,14 @@
       <Parameter docString="" id="19" isDefault="true" isUsed="true" name="Output Time List" type="string" value=""/>
       <Parameter docString="" id="23" isDefault="true" isUsed="true" name="Maximum Number of Stepper Failures" type="int" value="10"/>
       <Parameter docString="" id="24" isDefault="true" isUsed="true" name="Maximum Number of Consecutive Stepper Failures" type="int" value="5"/>
+      <ParameterList id="40" name="Time Step Control Events">
+          <Parameter docString="" id="41" isDefault="true" isUsed="true" name="Name" type="string" value="TimeEventComposite"/>
+          <Parameter docString="" id="42" isDefault="true" isUsed="true" name="Type" type="string" value="Composite"/>
+          <Parameter docString="" id="43" isDefault="true" isUsed="true" name="Time Events" type="string" value=""/>
+      </ParameterList>
       <ParameterList id="32" name="Time Step Control Strategy">
           <Parameter docString="" id="39" isDefault="true" isUsed="true" name="Strategy Type" type="string" value="Constant"/>
-          <Parameter docString="" id="33" isDefault="true" isUsed="true" name="Time Step" type="double" value="1.0"/>
+          <Parameter docString="" id="33" isDefault="true" isUsed="true" name="Time Step" type="double" value="1.0e+99"/>
       </ParameterList>
     </ParameterList>
     <Parameter docString="" id="27" isDefault="true" isUsed="true" name="Screen Output Index List" type="string" value=""/>

--- a/packages/tempus/test/Integrator/Tempus_IntegratorBasic_ref2.xml
+++ b/packages/tempus/test/Integrator/Tempus_IntegratorBasic_ref2.xml
@@ -17,7 +17,7 @@
       <Parameter docString="" id="8" isDefault="true" isUsed="true" name="Initial Time" type="double" value="0.00000000000000000e+00"/>
       <Parameter docString="" id="9" isDefault="true" isUsed="true" name="Final Time" type="double" value="1.0e+99"/>
       <Parameter docString="" id="12" isDefault="true" isUsed="true" name="Minimum Time Step" type="double" value="0.0"/>
-      <Parameter docString="" id="13" isDefault="true" isUsed="true" name="Initial Time Step" type="double" value="1.0"/>
+      <Parameter docString="" id="13" isDefault="true" isUsed="true" name="Initial Time Step" type="double" value="1.0e+99"/>
       <Parameter docString="" id="14" isDefault="true" isUsed="true" name="Maximum Time Step" type="double" value="1.0e+99"/>
       <Parameter docString="" id="10" isDefault="true" isUsed="true" name="Initial Time Index" type="int" value="0"/>
       <Parameter docString="" id="11" isDefault="true" isUsed="true" name="Final Time Index" type="int" value="1000000"/>
@@ -32,9 +32,14 @@
       <Parameter docString="" id="21" isDefault="true" isUsed="true" name="Output Time List" type="string" value=""/>
       <Parameter docString="" id="25" isDefault="true" isUsed="true" name="Maximum Number of Stepper Failures" type="int" value="10"/>
       <Parameter docString="" id="26" isDefault="true" isUsed="true" name="Maximum Number of Consecutive Stepper Failures" type="int" value="5"/>
+      <ParameterList id="39" name="Time Step Control Events">
+          <Parameter docString="" id="40" isDefault="true" isUsed="true" name="Name" type="string" value="TimeEventComposite"/>
+          <Parameter docString="" id="41" isDefault="true" isUsed="true" name="Type" type="string" value="Composite"/>
+          <Parameter docString="" id="42" isDefault="true" isUsed="true" name="Time Events" type="string" value=""/>
+      </ParameterList>
       <ParameterList id="32" name="Time Step Control Strategy">
           <Parameter docString="" id="20" isDefault="true" isUsed="true" name="Strategy Type" type="string" value="Constant"/>
-          <Parameter docString="" id="33" isDefault="true" isUsed="true" name="Time Step" type="double" value="1.0"/>
+          <Parameter docString="" id="33" isDefault="true" isUsed="true" name="Time Step" type="double" value="1.0e+99"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>

--- a/packages/tempus/test/Integrator/Tempus_IntegratorTest.cpp
+++ b/packages/tempus/test/Integrator/Tempus_IntegratorTest.cpp
@@ -129,7 +129,7 @@ TEUCHOS_UNIT_TEST(IntegratorBasic, Describe)
   auto npos = std::string::npos;
   TEST_ASSERT(npos != testS.find("--- Tempus::IntegratorBasic ---"));
   TEST_ASSERT(npos != testS.find("--- Tempus::SolutionHistory"));
-  TEST_ASSERT(npos != testS.find("--- SolutionState (index =     0; time =         0; dt =         1) ---"));
+  TEST_ASSERT(npos != testS.find("--- SolutionState (index =     0; time =         0; dt =     1e+99) ---"));
   TEST_ASSERT(npos != testS.find("--- Tempus::SolutionStateMetaData ---"));
   TEST_ASSERT(npos != testS.find("--- Tempus::StepperState"));
   TEST_ASSERT(npos != testS.find("--- Tempus::PhysicsState"));

--- a/packages/tempus/test/TestModels/SinCosModel_impl.hpp
+++ b/packages/tempus/test/TestModels/SinCosModel_impl.hpp
@@ -727,7 +727,6 @@ evalModelImpl(
   const Thyra::ModelEvaluatorBase::OutArgs<Scalar> &outArgs
   ) const
 {
-  typedef Thyra::DefaultMultiVectorProductVector<Scalar> DMVPV;
   using Teuchos::RCP;
   using Thyra::VectorBase;
   using Thyra::MultiVectorBase;

--- a/packages/tempus/unit_test/Tempus_UnitTest_TimeEventBase.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_TimeEventBase.cpp
@@ -37,7 +37,7 @@ TEUCHOS_UNIT_TEST(TimeEventBase, Default_Construction)
   TEST_COMPARE(te->getName(), ==, "TestName");
 
   TEST_COMPARE(te->isTime(0.0), ==, false);
-  TEST_FLOATING_EQUALITY(te->getAbsTol(), std::numeric_limits<double>::min(), 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->getAbsTol(), std::numeric_limits<double>::epsilon()*100.0, 1.0e-14);
   TEST_FLOATING_EQUALITY(te->timeToNextEvent(0.0), te->getDefaultTime(), 1.0e-14);
   TEST_FLOATING_EQUALITY(te->timeOfNextEvent(0.0), te->getDefaultTime(), 1.0e-14);
   TEST_FLOATING_EQUALITY(te->getDefaultTol(), te->getAbsTol(), 1.0e-14);
@@ -54,7 +54,25 @@ TEUCHOS_UNIT_TEST(TimeEventBase, Default_Construction)
   TEST_COMPARE(te->indexOfNextEvent(1), ==, te->getDefaultIndex());
   TEST_COMPARE(te->eventInRangeIndex(1,4), ==, false);
 
-  TEST_COMPARE(te->getValidParameters(), ==, Teuchos::null);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventBase, getValidParameters)
+{
+  auto teb = rcp(new Tempus::TimeEventBase<double>());
+
+  auto pl = teb->getValidParameters();
+
+  TEST_COMPARE          (pl->get<std::string>("Type"), ==, "Base");
+  TEST_COMPARE          (pl->get<std::string>("Name"), ==, "TimeEventBase");
+
+  { // Ensure that parameters are "used", excluding sublists.
+    std::ostringstream unusedParameters;
+    pl->unused(unusedParameters);
+    TEST_COMPARE ( unusedParameters.str(), ==, "");
+  }
 }
 
 

--- a/packages/tempus/unit_test/Tempus_UnitTest_TimeEventBase.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_TimeEventBase.cpp
@@ -30,13 +30,17 @@ TEUCHOS_UNIT_TEST(TimeEventBase, Default_Construction)
 {
   auto te = rcp(new Tempus::TimeEventBase<double>());
 
+  TEST_COMPARE(te->getType(), ==, "Base");
+
   TEST_COMPARE(te->getName(), ==, "TimeEventBase");
   te->setName("TestName");
   TEST_COMPARE(te->getName(), ==, "TestName");
 
   TEST_COMPARE(te->isTime(0.0), ==, false);
+  TEST_FLOATING_EQUALITY(te->getAbsTol(), std::numeric_limits<double>::min(), 1.0e-14);
   TEST_FLOATING_EQUALITY(te->timeToNextEvent(0.0), te->getDefaultTime(), 1.0e-14);
   TEST_FLOATING_EQUALITY(te->timeOfNextEvent(0.0), te->getDefaultTime(), 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->getDefaultTol(), te->getAbsTol(), 1.0e-14);
   TEST_COMPARE(te->eventInRange(0.0, 1.0), ==, false);
 
   TEST_COMPARE(te->isIndex(0), ==, false);
@@ -44,11 +48,13 @@ TEUCHOS_UNIT_TEST(TimeEventBase, Default_Construction)
   TEST_COMPARE(te->indexOfNextEvent(0), ==, te->getDefaultIndex());
   TEST_COMPARE(te->eventInRange(0, 10), ==, false);
 
-  // Check base class defaults (functions not implemented in TimeEventRange).
+  // Check base class defaults.
   TEST_COMPARE(te->isIndex(1), ==, false);
   TEST_COMPARE(te->indexToNextEvent(1), ==, te->getDefaultIndex());
   TEST_COMPARE(te->indexOfNextEvent(1), ==, te->getDefaultIndex());
   TEST_COMPARE(te->eventInRangeIndex(1,4), ==, false);
+
+  TEST_COMPARE(te->getValidParameters(), ==, Teuchos::null);
 }
 
 

--- a/packages/tempus/unit_test/Tempus_UnitTest_TimeEventComposite.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_TimeEventComposite.cpp
@@ -194,6 +194,7 @@ TEUCHOS_UNIT_TEST(TimeEventComposite, Full_Construction)
 
   auto tec = rcp(new Tempus::TimeEventComposite<double>(timeEvents,
                 "Test TimeEventComposite"));
+  //tec->describe(out, Teuchos::VERB_EXTREME);
 
   TEST_COMPARE(tec->getType(), ==, "Composite");
   TEST_COMPARE(tec->getName(), ==, "Test TimeEventComposite");
@@ -210,7 +211,7 @@ TEUCHOS_UNIT_TEST(TimeEventComposite, Full_Construction)
 
   TEST_COMPARE(tec->indexToNextEvent(-6), ==,  1);
   TEST_COMPARE(tec->indexToNextEvent( 1), ==,  1);
-  TEST_COMPARE(tec->indexToNextEvent( 7), ==,  0);
+  TEST_COMPARE(tec->indexToNextEvent( 7), ==,  1);
   TEST_COMPARE(tec->indexToNextEvent( 9), ==, tec->getDefaultIndex()-9);
 
   TEST_FLOATING_EQUALITY(tec->timeOfNextEvent( -PI), -1.0, 1.0e-14);
@@ -220,7 +221,7 @@ TEUCHOS_UNIT_TEST(TimeEventComposite, Full_Construction)
 
   TEST_COMPARE(tec->indexOfNextEvent(-6), ==, -5);
   TEST_COMPARE(tec->indexOfNextEvent( 1), ==,  2);
-  TEST_COMPARE(tec->indexOfNextEvent( 7), ==,  7);
+  TEST_COMPARE(tec->indexOfNextEvent( 7), ==,  8);
   TEST_COMPARE(tec->indexOfNextEvent( 9), ==,  tec->getDefaultIndex());
 
   TEST_COMPARE(tec->eventInRange(-5.0, -2.0), ==, false);
@@ -232,7 +233,7 @@ TEUCHOS_UNIT_TEST(TimeEventComposite, Full_Construction)
   TEST_COMPARE(tec->eventInRangeIndex(-8, -6), ==, false);
   TEST_COMPARE(tec->eventInRangeIndex( 1,  1), ==, false);
   TEST_COMPARE(tec->eventInRangeIndex( 5,  7), ==, true );
-  TEST_COMPARE(tec->eventInRangeIndex( 8, 10), ==, true );
+  TEST_COMPARE(tec->eventInRangeIndex( 8, 10), ==, false);
   TEST_COMPARE(tec->eventInRangeIndex(12, 14), ==, false);
 
   timeEvents = tec->getTimeEvents();
@@ -462,11 +463,11 @@ TEUCHOS_UNIT_TEST(TimeEventComposite, TwoSeparate_TimeEventRangeIndex)
   TEST_COMPARE(tec->indexOfNextEvent( 6), ==,  7);
   TEST_COMPARE(tec->indexOfNextEvent(16), ==, tec->getDefaultIndex());
   TEST_COMPARE(tec->eventInRangeIndex(-3, -2), ==, false);
-  TEST_COMPARE(tec->eventInRangeIndex(-1,  0), ==, true );
+  TEST_COMPARE(tec->eventInRangeIndex(-2,  0), ==, true );
   TEST_COMPARE(tec->eventInRangeIndex( 1,  2), ==, false);
-  TEST_COMPARE(tec->eventInRangeIndex( 7,  8), ==, true );
-  TEST_COMPARE(tec->eventInRangeIndex( 8,  9), ==, false);
-  TEST_COMPARE(tec->eventInRangeIndex(10, 13), ==, true );
+  TEST_COMPARE(tec->eventInRangeIndex( 6,  7), ==, true );
+  TEST_COMPARE(tec->eventInRangeIndex( 7,  8), ==, false);
+  TEST_COMPARE(tec->eventInRangeIndex(10, 13), ==, false);
   TEST_COMPARE(tec->eventInRangeIndex(14, 20), ==, true );
 
   auto timeEvents = tec->getTimeEvents();
@@ -507,7 +508,7 @@ TEUCHOS_UNIT_TEST(TimeEventComposite, TwoOverlapping_TimeEventListIndex)
   //tec->describe(out, Teuchos::VERB_EXTREME);
 
   TEST_COMPARE(tec->isIndex(2), ==, true );
-  TEST_COMPARE(tec->indexToNextEvent(0), ==, 0);
+  TEST_COMPARE(tec->indexToNextEvent(0), ==, 2);
   TEST_COMPARE(tec->indexOfNextEvent(1), ==, 2);
   TEST_COMPARE(tec->eventInRangeIndex(-1, 3), ==, true );
 
@@ -529,9 +530,9 @@ TEUCHOS_UNIT_TEST(TimeEventComposite, TwoSeparate_TimeEventListIndex)
   //tec->describe(out, Teuchos::VERB_EXTREME);
 
   TEST_COMPARE(tec->isIndex(14), ==, true );
-  TEST_COMPARE(tec->indexOfNextEvent(2), ==, 2);
+  TEST_COMPARE(tec->indexOfNextEvent(2), ==, 9);
   TEST_COMPARE(tec->indexOfNextEvent(5), ==, 9);
-  TEST_COMPARE(tec->indexOfNextEvent(19), ==, 14);
+  TEST_COMPARE(tec->indexOfNextEvent(19), ==, tec->getDefaultIndex());
   TEST_COMPARE(tec->eventInRangeIndex( 0,  1), ==, false);
   TEST_COMPARE(tec->eventInRangeIndex( 3, 10), ==, true );
   TEST_COMPARE(tec->eventInRangeIndex(15, 20), ==, false);
@@ -555,7 +556,7 @@ TEUCHOS_UNIT_TEST(TimeEventComposite, OneOfEach_TimeEvent)
   tec->add(teList1);
   tec->add(teRangeIndex1);
   tec->add(teListIndex1);
-  tec->describe(out, Teuchos::VERB_EXTREME);
+  //tec->describe(out, Teuchos::VERB_EXTREME);
 
   TEST_COMPARE(tec->isTime (3.0), ==, true );
   TEST_COMPARE(tec->isTime (2.0), ==, true );
@@ -569,7 +570,7 @@ TEUCHOS_UNIT_TEST(TimeEventComposite, OneOfEach_TimeEvent)
 
   TEST_COMPARE(tec->indexToNextEvent(-6), ==,  1);
   TEST_COMPARE(tec->indexToNextEvent( 1), ==,  1);
-  TEST_COMPARE(tec->indexToNextEvent( 7), ==,  0);
+  TEST_COMPARE(tec->indexToNextEvent( 7), ==,  1);
   TEST_COMPARE(tec->indexToNextEvent( 9), ==, tec->getDefaultIndex()-9);
 
   TEST_FLOATING_EQUALITY(tec->timeOfNextEvent( -PI), -1.0, 1.0e-14);
@@ -579,7 +580,7 @@ TEUCHOS_UNIT_TEST(TimeEventComposite, OneOfEach_TimeEvent)
 
   TEST_COMPARE(tec->indexOfNextEvent(-6), ==, -5);
   TEST_COMPARE(tec->indexOfNextEvent( 1), ==,  2);
-  TEST_COMPARE(tec->indexOfNextEvent( 7), ==,  7);
+  TEST_COMPARE(tec->indexOfNextEvent( 7), ==,  8);
   TEST_COMPARE(tec->indexOfNextEvent( 9), ==,  tec->getDefaultIndex());
 
   TEST_COMPARE(tec->eventInRange(-5.0, -2.0), ==, false);
@@ -591,7 +592,7 @@ TEUCHOS_UNIT_TEST(TimeEventComposite, OneOfEach_TimeEvent)
   TEST_COMPARE(tec->eventInRangeIndex(-8, -6), ==, false);
   TEST_COMPARE(tec->eventInRangeIndex( 1,  1), ==, false);
   TEST_COMPARE(tec->eventInRangeIndex( 5,  7), ==, true );
-  TEST_COMPARE(tec->eventInRangeIndex( 8, 10), ==, true );
+  TEST_COMPARE(tec->eventInRangeIndex( 7, 10), ==, true );
   TEST_COMPARE(tec->eventInRangeIndex(12, 14), ==, false);
 
   auto timeEvents = tec->getTimeEvents();
@@ -613,37 +614,347 @@ TEUCHOS_UNIT_TEST(TimeEventComposite, OneOfEach_Plus_TimeEvent)
   tec->add(teList1);
   tec->add(teRangeIndex1);
   tec->add(teListIndex1);
-  tec->describe(out, Teuchos::VERB_EXTREME);
+  //tec->describe(out, Teuchos::VERB_EXTREME);
 
-  // Constraining TimeEvent
-  auto teCon = Teuchos::rcp(new Tempus::TimeEventBase<double>());
+  // Constraining TimeEvent(s)
+  std::vector<Teuchos::RCP<Tempus::TimeEventBase<double> > > teCons;
 
-  TEST_COMPARE(tec->isTime ( 3.0, teCon), ==, true ); TEST_COMPARE(teCon->getName(), ==, "teRange1");
-  TEST_COMPARE(tec->isTime (-1.0, teCon), ==, true ); TEST_COMPARE(teCon->getName(), ==, "teList1");
-  TEST_COMPARE(tec->isIndex(   2, teCon), ==, true ); TEST_COMPARE(teCon->getName(), ==, "teRangeIndex1");
-  TEST_COMPARE(tec->isIndex(  -2, teCon), ==, true ); TEST_COMPARE(teCon->getName(), ==, "teListIndex1");
+  TEST_COMPARE(tec->isTime ( 3.0, teCons), ==, true );
+  TEST_COMPARE(teCons.size(), ==, 1);
+  TEST_COMPARE(teCons[0]->getName(), ==, "teRange1");
 
+  TEST_COMPARE(tec->isTime (-1.0, teCons), ==, true );
+  TEST_COMPARE(teCons.size(), ==, 1);
+  TEST_COMPARE(teCons[0]->getName(), ==, "teList1");
 
-  TEST_FLOATING_EQUALITY(tec->timeToNextEvent(-2.5, teCon),  1.5, 1.0e-14);  TEST_COMPARE(teCon->getName(), ==, "teList1");
-  TEST_FLOATING_EQUALITY(tec->timeToNextEvent( 0.5, teCon),  0.5, 1.0e-14);  TEST_COMPARE(teCon->getName(), ==, "teRange1");
-  TEST_FLOATING_EQUALITY(tec->timeToNextEvent( 4.5, teCon),  0.5, 1.0e-14);  TEST_COMPARE(teCon->getName(), ==, "teList1");
-  TEST_FLOATING_EQUALITY(tec->timeToNextEvent( 7.5, teCon), tec->getDefaultTime(), 1.0e-14);  TEST_COMPARE(teCon->getName(), ==, "teRange1");
+  TEST_COMPARE(tec->isIndex(   2, teCons), ==, true );
+  TEST_COMPARE(teCons.size(), ==, 1);
+  TEST_COMPARE(teCons[0]->getName(), ==, "teRangeIndex1");
 
-  TEST_COMPARE(tec->indexToNextEvent(-6, teCon), ==,  1);  TEST_COMPARE(teCon->getName(), ==, "teListIndex1");
-  TEST_COMPARE(tec->indexToNextEvent( 1, teCon), ==,  1);  TEST_COMPARE(teCon->getName(), ==, "teRangeIndex1");
-  TEST_COMPARE(tec->indexToNextEvent( 7, teCon), ==,  0);  TEST_COMPARE(teCon->getName(), ==, "teListIndex1");
-  TEST_COMPARE(tec->indexToNextEvent( 9, teCon), ==, tec->getDefaultIndex()-9);  TEST_COMPARE(teCon->getName(), ==, "teRange1");
-
-  TEST_FLOATING_EQUALITY(tec->timeOfNextEvent( -PI, teCon), -1.0, 1.0e-14);  TEST_COMPARE(teCon->getName(), ==, "teList1");
-  TEST_FLOATING_EQUALITY(tec->timeOfNextEvent(-0.5, teCon),  0.0, 1.0e-14);  TEST_COMPARE(teCon->getName(), ==, "teRange1");
-  TEST_FLOATING_EQUALITY(tec->timeOfNextEvent( 2.5, teCon),  3.0, 1.0e-14);  TEST_COMPARE(teCon->getName(), ==, "teRange1");
-  TEST_FLOATING_EQUALITY(tec->timeOfNextEvent( 7.5, teCon), tec->getDefaultTime(), 1.0e-14);  TEST_COMPARE(teCon->getName(), ==, "teRange1");
+  TEST_COMPARE(tec->isIndex(  -2, teCons), ==, true );
+  TEST_COMPARE(teCons.size(), ==, 1);
+  TEST_COMPARE(teCons[0]->getName(), ==, "teListIndex1");
 
 
-  TEST_COMPARE(tec->indexOfNextEvent(-6, teCon), ==, -5);  TEST_COMPARE(teCon->getName(), ==, "teListIndex1");
-  TEST_COMPARE(tec->indexOfNextEvent( 1, teCon), ==,  2);  TEST_COMPARE(teCon->getName(), ==, "teRangeIndex1");
-  TEST_COMPARE(tec->indexOfNextEvent( 7, teCon), ==,  7);  TEST_COMPARE(teCon->getName(), ==, "teListIndex1");
-  TEST_COMPARE(tec->indexOfNextEvent( 9, teCon), ==, tec->getDefaultIndex());  TEST_COMPARE(teCon->getName(), ==, "teRange1");
+  TEST_FLOATING_EQUALITY(tec->timeToNextEvent(-2.5, teCons),  1.5, 1.0e-14);
+  TEST_COMPARE(teCons.size(), ==, 1);
+  TEST_COMPARE(teCons[0]->getName(), ==, "teList1");
+
+  TEST_FLOATING_EQUALITY(tec->timeToNextEvent( 0.5, teCons),  0.5, 1.0e-14);
+  TEST_COMPARE(teCons.size(), ==, 1);
+  TEST_COMPARE(teCons[0]->getName(), ==, "teRange1");
+
+  TEST_FLOATING_EQUALITY(tec->timeToNextEvent( 4.5, teCons),  0.5, 1.0e-14);
+  TEST_COMPARE(teCons.size(), ==, 1);
+  TEST_COMPARE(teCons[0]->getName(), ==, "teList1");
+
+  TEST_FLOATING_EQUALITY(tec->timeToNextEvent( 7.5, teCons), tec->getDefaultTime(), 1.0e-14);
+  TEST_COMPARE(teCons.size(), ==, 0);
+
+
+  TEST_COMPARE(tec->indexToNextEvent(-6, teCons), ==,  1);
+  TEST_COMPARE(teCons.size(), ==, 1);
+  TEST_COMPARE(teCons[0]->getName(), ==, "teListIndex1");
+
+  TEST_COMPARE(tec->indexToNextEvent( 1, teCons), ==,  1);
+  TEST_COMPARE(teCons.size(), ==, 1);
+  TEST_COMPARE(teCons[0]->getName(), ==, "teRangeIndex1");
+
+  TEST_COMPARE(tec->indexToNextEvent( 7, teCons), ==,  1);
+  TEST_COMPARE(teCons.size(), ==, 1);
+  TEST_COMPARE(teCons[0]->getName(), ==, "teRangeIndex1");
+
+  TEST_COMPARE(tec->indexToNextEvent( 9, teCons), ==, tec->getDefaultIndex()-9);
+  TEST_COMPARE(teCons.size(), ==, 0);
+
+
+  TEST_FLOATING_EQUALITY(tec->timeOfNextEvent( -PI, teCons), -1.0, 1.0e-14);
+  TEST_COMPARE(teCons.size(), ==, 1);
+  TEST_COMPARE(teCons[0]->getName(), ==, "teList1");
+
+  TEST_FLOATING_EQUALITY(tec->timeOfNextEvent(-0.5, teCons),  0.0, 1.0e-14);
+  TEST_COMPARE(teCons.size(), ==, 2);
+  TEST_COMPARE(teCons[0]->getName(), ==, "teRange1");
+  TEST_COMPARE(teCons[1]->getName(), ==, "teList1");
+
+  TEST_FLOATING_EQUALITY(tec->timeOfNextEvent( 2.5, teCons),  3.0, 1.0e-14);
+  TEST_COMPARE(teCons.size(), ==, 1);
+  TEST_COMPARE(teCons[0]->getName(), ==, "teRange1");
+
+  TEST_FLOATING_EQUALITY(tec->timeOfNextEvent( 7.5, teCons), tec->getDefaultTime(), 1.0e-14);
+  TEST_COMPARE(teCons.size(), ==, 0);
+
+
+  TEST_COMPARE(tec->indexOfNextEvent(-6, teCons), ==, -5);
+  TEST_COMPARE(teCons.size(), ==, 1);
+  TEST_COMPARE(teCons[0]->getName(), ==, "teListIndex1");
+
+  TEST_COMPARE(tec->indexOfNextEvent( 1, teCons), ==,  2);
+  TEST_COMPARE(teCons.size(), ==, 1);
+  TEST_COMPARE(teCons[0]->getName(), ==, "teRangeIndex1");
+
+  TEST_COMPARE(tec->indexOfNextEvent( 7, teCons), ==,  8);
+  TEST_COMPARE(teCons.size(), ==, 1);
+  TEST_COMPARE(teCons[0]->getName(), ==, "teRangeIndex1");
+
+  TEST_COMPARE(tec->indexOfNextEvent( 9, teCons), ==, tec->getDefaultIndex());
+  TEST_COMPARE(teCons.size(), ==, 0);
+
+  TEST_COMPARE(tec->eventInRange(-5.0, -2.0, teCons), ==, false);
+  TEST_COMPARE(teCons.size(), ==, 0);
+  TEST_COMPARE(tec->eventInRange(-2.0, -0.5, teCons), ==, true );
+  TEST_COMPARE(teCons.size(), ==, 1);
+  TEST_COMPARE(tec->eventInRange( 1.2,  1.8, teCons), ==, false);
+  TEST_COMPARE(teCons.size(), ==, 0);
+  TEST_COMPARE(tec->eventInRange( 3.1,  4.0, teCons), ==, true );
+  TEST_COMPARE(teCons.size(), ==, 1);
+  TEST_COMPARE(tec->eventInRange( 4.5,  6.0, teCons), ==, true );
+  TEST_COMPARE(teCons.size(), ==, 1);
+
+  TEST_COMPARE(tec->eventInRangeIndex(-8, -6, teCons), ==, false);
+  TEST_COMPARE(teCons.size(), ==, 0);
+  TEST_COMPARE(tec->eventInRangeIndex( 1,  1, teCons), ==, false);
+  TEST_COMPARE(teCons.size(), ==, 0);
+  TEST_COMPARE(tec->eventInRangeIndex( 5,  7, teCons), ==, true );
+  TEST_COMPARE(teCons.size(), ==, 1);
+  TEST_COMPARE(tec->eventInRangeIndex( 8, 10, teCons), ==, false);
+  TEST_COMPARE(teCons.size(), ==, 0);
+  TEST_COMPARE(tec->eventInRangeIndex(12, 14, teCons), ==, false);
+  TEST_COMPARE(teCons.size(), ==, 0);
+
+  auto timeEvents = tec->getTimeEvents();
+  TEST_COMPARE(timeEvents.size(), ==, 4);
+
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventComposite, Multiple_Simultaneous_Events)
+{
+  // Define Events
+  auto ter1 = rcp(new Tempus::TimeEventRange<double>(
+    0.0, 20.0, 5.0, "ter1", true, 1.0e-14));
+  auto ter2 = rcp(new Tempus::TimeEventRange<double>(
+    0.0, 20.0, 2.0, "ter2", false, 1.0e-14));
+
+  std::vector<double> testList1;
+  testList1.push_back( 0.0);
+  testList1.push_back( 4.0);
+  testList1.push_back( 5.0);
+  testList1.push_back( 9.0);
+  testList1.push_back(20.0);
+  auto tel1 = rcp(new Tempus::TimeEventList<double>(
+                  testList1, "tel1", true, 1.0e-14));
+
+  std::vector<double> testList2;
+  testList2.push_back( 0.0);
+  testList2.push_back( 3.0);
+  testList2.push_back( 5.0);
+  testList2.push_back(13.0);
+  testList2.push_back(20.0);
+  auto tel2 = rcp(new Tempus::TimeEventList<double>(
+                  testList2, "tel2", false, 1.0e-14));
+
+  auto teri1 = rcp(new Tempus::TimeEventRangeIndex<double>(
+                   0, 200, 50, "teri1"));
+  auto teri2 = rcp(new Tempus::TimeEventRangeIndex<double>(
+                   0, 200, 20, "teri2"));
+
+  std::vector<int> testListIndex1;
+  testListIndex1.push_back(  0);
+  testListIndex1.push_back( 40);
+  testListIndex1.push_back( 50);
+  testListIndex1.push_back( 90);
+  testListIndex1.push_back(200);
+  auto teli1 = rcp(new Tempus::TimeEventListIndex<double>(
+                   testListIndex1, "teli1"));
+
+  std::vector<int> testListIndex2;
+  testListIndex2.push_back(  0);
+  testListIndex2.push_back( 30);
+  testListIndex2.push_back( 50);
+  testListIndex2.push_back(130);
+  testListIndex2.push_back(200);
+  auto teli2 = rcp(new Tempus::TimeEventListIndex<double>(
+                   testListIndex2, "teli2"));
+
+
+  auto tec  = rcp(new Tempus::TimeEventComposite<double>());
+  tec->add(ter1 );
+  tec->add(ter2 );
+  tec->add(tel1 );
+  tec->add(tel2 );
+  tec->add(teri1);
+  tec->add(teri2);
+  tec->add(teli1);
+  tec->add(teli2);
+
+  //tec->describe(out, Teuchos::VERB_EXTREME);
+
+  // Constraining TimeEvent(s)
+  std::vector<Teuchos::RCP<Tempus::TimeEventBase<double> > > teCons;
+
+  TEST_COMPARE(tec->isTime ( 0.0, teCons), ==, true );
+  TEST_COMPARE(teCons.size(), ==, 4);
+  TEST_COMPARE(teCons[0]->getName(), ==, "ter1");
+  TEST_COMPARE(teCons[1]->getName(), ==, "ter2");
+  TEST_COMPARE(teCons[2]->getName(), ==, "tel1");
+  TEST_COMPARE(teCons[3]->getName(), ==, "tel2");
+
+  TEST_COMPARE(tec->isTime ( 5.0, teCons), ==, true );
+  TEST_COMPARE(teCons.size(), ==, 3);
+  TEST_COMPARE(teCons[0]->getName(), ==, "ter1");
+  TEST_COMPARE(teCons[1]->getName(), ==, "tel1");
+  TEST_COMPARE(teCons[2]->getName(), ==, "tel2");
+
+  TEST_COMPARE(tec->isTime (10.0, teCons), ==, true );
+  TEST_COMPARE(teCons.size(), ==, 2);
+  TEST_COMPARE(teCons[0]->getName(), ==, "ter1");
+  TEST_COMPARE(teCons[1]->getName(), ==, "ter2");
+
+  TEST_COMPARE(tec->isTime (20.0, teCons), ==, true );
+  TEST_COMPARE(teCons.size(), ==, 4);
+  TEST_COMPARE(teCons[0]->getName(), ==, "ter1");
+  TEST_COMPARE(teCons[1]->getName(), ==, "ter2");
+  TEST_COMPARE(teCons[2]->getName(), ==, "tel1");
+  TEST_COMPARE(teCons[3]->getName(), ==, "tel2");
+
+  TEST_COMPARE(tec->isIndex ( 0, teCons), ==, true );
+  TEST_COMPARE(teCons.size(), ==, 4);
+  TEST_COMPARE(teCons[0]->getName(), ==, "teri1");
+  TEST_COMPARE(teCons[1]->getName(), ==, "teri2");
+  TEST_COMPARE(teCons[2]->getName(), ==, "teli1");
+  TEST_COMPARE(teCons[3]->getName(), ==, "teli2");
+
+  TEST_COMPARE(tec->isIndex ( 50, teCons), ==, true );
+  TEST_COMPARE(teCons.size(), ==, 3);
+  TEST_COMPARE(teCons[0]->getName(), ==, "teri1");
+  TEST_COMPARE(teCons[1]->getName(), ==, "teli1");
+  TEST_COMPARE(teCons[2]->getName(), ==, "teli2");
+
+  TEST_COMPARE(tec->isIndex (100, teCons), ==, true );
+  TEST_COMPARE(teCons.size(), ==, 2);
+  TEST_COMPARE(teCons[0]->getName(), ==, "teri1");
+  TEST_COMPARE(teCons[1]->getName(), ==, "teri2");
+
+  TEST_COMPARE(tec->isIndex (200, teCons), ==, true );
+  TEST_COMPARE(teCons.size(), ==, 4);
+  TEST_COMPARE(teCons[0]->getName(), ==, "teri1");
+  TEST_COMPARE(teCons[1]->getName(), ==, "teri2");
+  TEST_COMPARE(teCons[2]->getName(), ==, "teli1");
+  TEST_COMPARE(teCons[3]->getName(), ==, "teli2");
+
+  TEST_FLOATING_EQUALITY(tec->timeOfNextEvent( -1.0, teCons), 0.0, 1.0e-14);
+  TEST_COMPARE(teCons.size(), ==, 4);
+  TEST_COMPARE(teCons[0]->getName(), ==, "ter1");
+  TEST_COMPARE(teCons[1]->getName(), ==, "ter2");
+  TEST_COMPARE(teCons[2]->getName(), ==, "tel1");
+  TEST_COMPARE(teCons[3]->getName(), ==, "tel2");
+
+  TEST_FLOATING_EQUALITY(tec->timeOfNextEvent( 4.0, teCons), 5.0, 1.0e-14);
+  TEST_COMPARE(teCons.size(), ==, 3);
+  TEST_COMPARE(teCons[0]->getName(), ==, "ter1");
+  TEST_COMPARE(teCons[1]->getName(), ==, "tel1");
+  TEST_COMPARE(teCons[2]->getName(), ==, "tel2");
+
+  TEST_FLOATING_EQUALITY(tec->timeOfNextEvent( 9.0, teCons), 10.0, 1.0e-14);
+  TEST_COMPARE(teCons.size(), ==, 2);
+  TEST_COMPARE(teCons[0]->getName(), ==, "ter1");
+  TEST_COMPARE(teCons[1]->getName(), ==, "ter2");
+
+  TEST_FLOATING_EQUALITY(tec->timeOfNextEvent( 19.0, teCons), 20.0, 1.0e-14);
+  TEST_COMPARE(teCons.size(), ==, 4);
+  TEST_COMPARE(teCons[0]->getName(), ==, "ter1");
+  TEST_COMPARE(teCons[1]->getName(), ==, "ter2");
+  TEST_COMPARE(teCons[2]->getName(), ==, "tel1");
+  TEST_COMPARE(teCons[3]->getName(), ==, "tel2");
+
+  TEST_COMPARE(tec->indexOfNextEvent(-1, teCons), ==, 0);
+  TEST_COMPARE(teCons.size(), ==, 4);
+  TEST_COMPARE(teCons[0]->getName(), ==, "teri1");
+  TEST_COMPARE(teCons[1]->getName(), ==, "teri2");
+  TEST_COMPARE(teCons[2]->getName(), ==, "teli1");
+  TEST_COMPARE(teCons[3]->getName(), ==, "teli2");
+
+  TEST_COMPARE(tec->indexOfNextEvent( 40, teCons), ==, 50);
+  TEST_COMPARE(teCons.size(), ==, 3);
+  TEST_COMPARE(teCons[0]->getName(), ==, "teri1");
+  TEST_COMPARE(teCons[1]->getName(), ==, "teli1");
+  TEST_COMPARE(teCons[2]->getName(), ==, "teli2");
+
+  TEST_COMPARE(tec->indexOfNextEvent( 90, teCons), ==, 100);
+  TEST_COMPARE(teCons.size(), ==, 2);
+  TEST_COMPARE(teCons[0]->getName(), ==, "teri1");
+  TEST_COMPARE(teCons[1]->getName(), ==, "teri2");
+
+  TEST_COMPARE(tec->indexOfNextEvent(190, teCons), ==, 200);
+  TEST_COMPARE(teCons.size(), ==, 4);
+  TEST_COMPARE(teCons[0]->getName(), ==, "teri1");
+  TEST_COMPARE(teCons[1]->getName(), ==, "teri2");
+  TEST_COMPARE(teCons[2]->getName(), ==, "teli1");
+  TEST_COMPARE(teCons[3]->getName(), ==, "teli2");
+
+  // Sorted order is still input order.
+  TEST_COMPARE(tec->eventInRange(-1.0, 21.0, teCons), ==, true);
+  TEST_COMPARE(teCons.size(), ==, 4);
+  TEST_COMPARE(teCons[0]->getName(), ==, "ter1");
+  TEST_COMPARE(teCons[1]->getName(), ==, "ter2");
+  TEST_COMPARE(teCons[2]->getName(), ==, "tel1");
+  TEST_COMPARE(teCons[3]->getName(), ==, "tel2");
+
+  // Sorted order is based on "time of next event".
+  TEST_COMPARE(tec->eventInRange( 0.0, 21.0, teCons), ==, true);
+  TEST_COMPARE(teCons.size(), ==, 4);
+  TEST_COMPARE(teCons[0]->getName(), ==, "ter2");  TEST_FLOATING_EQUALITY(teCons[0]->timeOfNextEvent( 0.0), 2.0, 1.0e-14);
+  TEST_COMPARE(teCons[1]->getName(), ==, "tel2");  TEST_FLOATING_EQUALITY(teCons[1]->timeOfNextEvent( 0.0), 3.0, 1.0e-14);
+  TEST_COMPARE(teCons[2]->getName(), ==, "tel1");  TEST_FLOATING_EQUALITY(teCons[2]->timeOfNextEvent( 0.0), 4.0, 1.0e-14);
+  TEST_COMPARE(teCons[3]->getName(), ==, "ter1");  TEST_FLOATING_EQUALITY(teCons[3]->timeOfNextEvent( 0.0), 5.0, 1.0e-14);
+
+  TEST_COMPARE(tec->eventInRange( 7.0, 21.0, teCons), ==, true);
+  TEST_COMPARE(teCons.size(), ==, 4);
+  TEST_COMPARE(teCons[0]->getName(), ==, "ter2");  TEST_FLOATING_EQUALITY(teCons[0]->timeOfNextEvent( 7.0), 8.0, 1.0e-14);
+  TEST_COMPARE(teCons[1]->getName(), ==, "tel1");  TEST_FLOATING_EQUALITY(teCons[1]->timeOfNextEvent( 7.0), 9.0, 1.0e-14);
+  TEST_COMPARE(teCons[2]->getName(), ==, "ter1");  TEST_FLOATING_EQUALITY(teCons[2]->timeOfNextEvent( 7.0),10.0, 1.0e-14);
+  TEST_COMPARE(teCons[3]->getName(), ==, "tel2");  TEST_FLOATING_EQUALITY(teCons[3]->timeOfNextEvent( 7.0),13.0, 1.0e-14);
+
+  TEST_COMPARE(tec->eventInRange(19.0, 21.0, teCons), ==, true);
+  TEST_COMPARE(teCons.size(), ==, 4);
+  TEST_COMPARE(teCons[0]->getName(), ==, "ter1");  TEST_FLOATING_EQUALITY(teCons[0]->timeOfNextEvent(19.0),20.0, 1.0e-14);
+  TEST_COMPARE(teCons[1]->getName(), ==, "ter2");  TEST_FLOATING_EQUALITY(teCons[1]->timeOfNextEvent(19.0),20.0, 1.0e-14);
+  TEST_COMPARE(teCons[2]->getName(), ==, "tel1");  TEST_FLOATING_EQUALITY(teCons[2]->timeOfNextEvent(19.0),20.0, 1.0e-14);
+  TEST_COMPARE(teCons[3]->getName(), ==, "tel2");  TEST_FLOATING_EQUALITY(teCons[3]->timeOfNextEvent(19.0),20.0, 1.0e-14);
+
+  // Sorted order is still input order.
+  TEST_COMPARE(tec->eventInRangeIndex(-10, 210, teCons), ==, true);
+  TEST_COMPARE(teCons.size(), ==, 4);
+  TEST_COMPARE(teCons[0]->getName(), ==, "teri1");
+  TEST_COMPARE(teCons[1]->getName(), ==, "teri2");
+  TEST_COMPARE(teCons[2]->getName(), ==, "teli1");
+  TEST_COMPARE(teCons[3]->getName(), ==, "teli2");
+
+  // Sorted order is based on "time of next event".
+  TEST_COMPARE(tec->eventInRangeIndex( 0, 210, teCons), ==, true);
+  TEST_COMPARE(teCons.size(), ==, 4);
+  TEST_COMPARE(teCons[0]->getName(), ==, "teri2");  TEST_COMPARE(teCons[0]->indexOfNextEvent( 0), == , 20);
+  TEST_COMPARE(teCons[1]->getName(), ==, "teli2");  TEST_COMPARE(teCons[1]->indexOfNextEvent( 0), == , 30);
+  TEST_COMPARE(teCons[2]->getName(), ==, "teli1");  TEST_COMPARE(teCons[2]->indexOfNextEvent( 0), == , 40);
+  TEST_COMPARE(teCons[3]->getName(), ==, "teri1");  TEST_COMPARE(teCons[3]->indexOfNextEvent( 0), == , 50);
+
+  TEST_COMPARE(tec->eventInRangeIndex( 70, 210, teCons), ==, true);
+  TEST_COMPARE(teCons.size(), ==, 4);
+  TEST_COMPARE(teCons[0]->getName(), ==, "teri2");  TEST_COMPARE(teCons[0]->indexOfNextEvent( 70), == , 80);
+  TEST_COMPARE(teCons[1]->getName(), ==, "teli1");  TEST_COMPARE(teCons[1]->indexOfNextEvent( 70), == , 90);
+  TEST_COMPARE(teCons[2]->getName(), ==, "teri1");  TEST_COMPARE(teCons[2]->indexOfNextEvent( 70), == ,100);
+  TEST_COMPARE(teCons[3]->getName(), ==, "teli2");  TEST_COMPARE(teCons[3]->indexOfNextEvent( 70), == ,130);
+
+  TEST_COMPARE(tec->eventInRangeIndex(190, 210, teCons), ==, true);
+  TEST_COMPARE(teCons.size(), ==, 4);
+  TEST_COMPARE(teCons[0]->getName(), ==, "teri1");  TEST_COMPARE(teCons[0]->indexOfNextEvent(190), == ,200);
+  TEST_COMPARE(teCons[1]->getName(), ==, "teri2");  TEST_COMPARE(teCons[1]->indexOfNextEvent(190), == ,200);
+  TEST_COMPARE(teCons[2]->getName(), ==, "teli1");  TEST_COMPARE(teCons[2]->indexOfNextEvent(190), == ,200);
+  TEST_COMPARE(teCons[3]->getName(), ==, "teli2");  TEST_COMPARE(teCons[3]->indexOfNextEvent(190), == ,200);
+
 }
 
 

--- a/packages/tempus/unit_test/Tempus_UnitTest_TimeEventComposite.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_TimeEventComposite.cpp
@@ -811,7 +811,9 @@ TEUCHOS_UNIT_TEST(TimeEventComposite, getValidParameters)
   TEST_FLOATING_EQUALITY( terPL.get<double>("Stop Time") ,   0.0, 1.0e-14);
   TEST_FLOATING_EQUALITY( terPL.get<double>("Stride Time") , 0.0, 1.0e-14);
   TEST_COMPARE          ( terPL.get<int>("Number of Events"), ==, 1);
-  TEST_FLOATING_EQUALITY( terPL.get<double>("Relative Tolerance"), 1.0e-14, 1.0e-14);
+  TEST_FLOATING_EQUALITY( terPL.get<double>("Relative Tolerance"),
+                         std::numeric_limits<double>::epsilon()*100.0, 1.0e-14);
+
   TEST_COMPARE          ( terPL.get<bool>("Land On Exactly"), ==, true);
 
   { // Ensure that parameters are "used", excluding sublists.
@@ -836,7 +838,8 @@ TEUCHOS_UNIT_TEST(TimeEventComposite, getValidParameters)
   auto telPL = pl->sublist("Test List");
   TEST_COMPARE          ( telPL.get<std::string>("Type"), ==, "List");
   TEST_COMPARE          ( telPL.get<std::string>("Name"), ==, "Test List");
-  TEST_FLOATING_EQUALITY( telPL.get<double>("Relative Tolerance"), 1.0e-14, 1.0e-14);
+  TEST_FLOATING_EQUALITY( telPL.get<double>("Relative Tolerance"),
+                         std::numeric_limits<double>::epsilon()*100.0, 1.0e-14);
   TEST_COMPARE          ( telPL.get<bool>("Land On Exactly"), ==, true);
   TEST_COMPARE          ( telPL.get<std::string>("Time List"), ==, "");
 

--- a/packages/tempus/unit_test/Tempus_UnitTest_TimeEventComposite.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_TimeEventComposite.cpp
@@ -36,21 +36,21 @@ using Teuchos::rcp_dynamic_cast;
 Teuchos::RCP<Tempus::TimeEventRange<double> > getTestRange1()
 {
   auto teRange1 = rcp(new Tempus::TimeEventRange<double>(
-    "teRange1", 0.0, PI, 1.0, 1.0e-14, true));
+    0.0, PI, 1.0, "teRange1", true, 1.0e-14));
   return teRange1;
 }
 
 Teuchos::RCP<Tempus::TimeEventRange<double> > getTestRange2()
 {
   auto teRange2 = rcp(new Tempus::TimeEventRange<double>(
-    "teRange2", -PI/2.0, PI/2.0, PI/4.0, 1.0e-14, true));
+    -PI/2.0, PI/2.0, PI/4.0, "teRange2", true, 1.0e-14));
   return teRange2;
 }
 
 Teuchos::RCP<Tempus::TimeEventRange<double> > getTestRange3()
 {
   auto teRange3 = rcp(new Tempus::TimeEventRange<double>(
-    "teRange3", 4.0, 10.0, 4.0, 1.0e-14, true));
+    4.0, 10.0, 4.0, "teRange3", true, 1.0e-14));
   return teRange3;
 }
 
@@ -67,7 +67,7 @@ Teuchos::RCP<Tempus::TimeEventList<double> > getTestList1()
   testList1.push_back(  PI);
 
   auto teList1 = rcp(new Tempus::TimeEventList<double>(
-                     "teList1", testList1, 1.0e-14, true));
+                     testList1, "teList1", true, 1.0e-14));
   return teList1;
 }
 
@@ -80,7 +80,7 @@ Teuchos::RCP<Tempus::TimeEventList<double> > getTestList2()
   testList2.push_back(12.34);
 
   auto teList2 = rcp(new Tempus::TimeEventList<double>(
-                     "teList2", testList2, 1.0e-14, true));
+                     testList2, "teList2", true, 1.0e-14));
   return teList2;
 }
 
@@ -91,7 +91,7 @@ Teuchos::RCP<Tempus::TimeEventList<double> > getTestList3()
   testList3.push_back(-PI);
 
   auto teList3 = rcp(new Tempus::TimeEventList<double>(
-                     "teList3", testList3, 1.0e-14, true));
+                     testList3, "teList3", true, 1.0e-14));
   return teList3;
 }
 
@@ -101,21 +101,21 @@ Teuchos::RCP<Tempus::TimeEventList<double> > getTestList3()
 Teuchos::RCP<Tempus::TimeEventRangeIndex<double> > getTestRangeIndex1()
 {
   auto teRangeIndex1 = rcp(new Tempus::TimeEventRangeIndex<double>(
-                           "teRangeIndex1", -1, 10, 3));
+                           -1, 10, 3, "teRangeIndex1"));
   return teRangeIndex1;
 }
 
 Teuchos::RCP<Tempus::TimeEventRangeIndex<double> > getTestRangeIndex2()
 {
   auto teRangeIndex2 = rcp(new Tempus::TimeEventRangeIndex<double>(
-                           "teRangeIndex2", -5, 8, 4));
+                           -5, 8, 4, "teRangeIndex2"));
   return teRangeIndex2;
 }
 
 Teuchos::RCP<Tempus::TimeEventRangeIndex<double> > getTestRangeIndex3()
 {
   auto teRangeIndex3 = rcp(new Tempus::TimeEventRangeIndex<double>(
-                           "teRangeIndex3", 10, 17, 5));
+                           10, 17, 5, "teRangeIndex3"));
   return teRangeIndex3;
 }
 
@@ -132,7 +132,7 @@ Teuchos::RCP<Tempus::TimeEventListIndex<double> > getTestListIndex1()
   testListIndex1.push_back(-5);
 
   auto teListIndex1 = rcp(new Tempus::TimeEventListIndex<double>(
-                          "teListIndex1", testListIndex1));
+                          testListIndex1, "teListIndex1"));
   return teListIndex1;
 }
 
@@ -142,7 +142,7 @@ Teuchos::RCP<Tempus::TimeEventListIndex<double> > getTestListIndex2()
   testListIndex2.push_back( 2);
 
   auto teListIndex2 = rcp(new Tempus::TimeEventListIndex<double>(
-                          "teListIndex2", testListIndex2));
+                          testListIndex2, "teListIndex2"));
   return teListIndex2;
 }
 
@@ -153,7 +153,7 @@ Teuchos::RCP<Tempus::TimeEventListIndex<double> > getTestListIndex3()
   testListIndex3.push_back( 9);
 
   auto teListIndex3 = rcp(new Tempus::TimeEventListIndex<double>(
-                          "teListIndex3", testListIndex3));
+                          testListIndex3, "teListIndex3"));
 
   return teListIndex3;
 }
@@ -163,17 +163,99 @@ Teuchos::RCP<Tempus::TimeEventListIndex<double> > getTestListIndex3()
 // ************************************************************
 TEUCHOS_UNIT_TEST(TimeEventComposite, Default_Construction)
 {
-  auto te = rcp(new Tempus::TimeEventComposite<double>());
+  auto tec = rcp(new Tempus::TimeEventComposite<double>());
 
-  TEST_COMPARE(te->isTime(0.0), ==, false);
-  TEST_FLOATING_EQUALITY(te->timeToNextEvent(0.0), te->getDefaultTime(), 1.0e-14);
-  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(0.0), te->getDefaultTime(), 1.0e-14);
-  TEST_COMPARE(te->eventInRange(0.0, 1.0), ==, false);
+  TEST_COMPARE(tec->getType(), ==, "Composite");
+  TEST_COMPARE(tec->getName(), ==, "TimeEventComposite");
+  TEST_COMPARE(tec->isTime(0.0), ==, false);
+  TEST_FLOATING_EQUALITY(tec->timeToNextEvent(0.0), tec->getDefaultTime(), 1.0e-14);
+  TEST_FLOATING_EQUALITY(tec->timeOfNextEvent(0.0), tec->getDefaultTime(), 1.0e-14);
+  TEST_COMPARE(tec->eventInRange(0.0, 1.0), ==, false);
 
-  TEST_COMPARE(te->isIndex(0), ==, false);
-  TEST_COMPARE(te->indexToNextEvent(0), ==, te->getDefaultIndex());
-  TEST_COMPARE(te->indexOfNextEvent(0), ==, te->getDefaultIndex());
-  TEST_COMPARE(te->eventInRange(0, 10), ==, false);
+  TEST_COMPARE(tec->isIndex(0), ==, false);
+  TEST_COMPARE(tec->indexToNextEvent(0), ==, tec->getDefaultIndex());
+  TEST_COMPARE(tec->indexOfNextEvent(0), ==, tec->getDefaultIndex());
+  TEST_COMPARE(tec->eventInRange(0, 10), ==, false);
+
+  auto timeEvents = tec->getTimeEvents();
+  TEST_COMPARE(timeEvents.size(), ==, 0);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventComposite, Full_Construction)
+{
+  std::vector<Teuchos::RCP<Tempus::TimeEventBase<double> > >  timeEvents;
+  timeEvents.push_back(getTestRange1());
+  timeEvents.push_back(getTestList1());
+  timeEvents.push_back(getTestRangeIndex1());
+  timeEvents.push_back(getTestListIndex1());
+
+  auto tec = rcp(new Tempus::TimeEventComposite<double>(timeEvents,
+                "Test TimeEventComposite"));
+
+  TEST_COMPARE(tec->getType(), ==, "Composite");
+  TEST_COMPARE(tec->getName(), ==, "Test TimeEventComposite");
+
+  TEST_COMPARE(tec->isTime (3.0), ==, true );
+  TEST_COMPARE(tec->isTime (2.0), ==, true );
+  TEST_COMPARE(tec->isIndex(  2), ==, true );
+  TEST_COMPARE(tec->isIndex(  3), ==, true );
+
+  TEST_FLOATING_EQUALITY(tec->timeToNextEvent(-2.5),  1.5, 1.0e-14);
+  TEST_FLOATING_EQUALITY(tec->timeToNextEvent( 0.5),  0.5, 1.0e-14);
+  TEST_FLOATING_EQUALITY(tec->timeToNextEvent( 4.5),  0.5, 1.0e-14);
+  TEST_FLOATING_EQUALITY(tec->timeToNextEvent( 7.5), tec->getDefaultTime(), 1.0e-14);
+
+  TEST_COMPARE(tec->indexToNextEvent(-6), ==,  1);
+  TEST_COMPARE(tec->indexToNextEvent( 1), ==,  1);
+  TEST_COMPARE(tec->indexToNextEvent( 7), ==,  0);
+  TEST_COMPARE(tec->indexToNextEvent( 9), ==, tec->getDefaultIndex()-9);
+
+  TEST_FLOATING_EQUALITY(tec->timeOfNextEvent( -PI), -1.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(tec->timeOfNextEvent(-0.5),  0.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(tec->timeOfNextEvent( 2.5),  3.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(tec->timeOfNextEvent( 7.5), tec->getDefaultTime(), 1.0e-14);
+
+  TEST_COMPARE(tec->indexOfNextEvent(-6), ==, -5);
+  TEST_COMPARE(tec->indexOfNextEvent( 1), ==,  2);
+  TEST_COMPARE(tec->indexOfNextEvent( 7), ==,  7);
+  TEST_COMPARE(tec->indexOfNextEvent( 9), ==,  tec->getDefaultIndex());
+
+  TEST_COMPARE(tec->eventInRange(-5.0, -2.0), ==, false);
+  TEST_COMPARE(tec->eventInRange(-2.0, -0.5), ==, true );
+  TEST_COMPARE(tec->eventInRange( 1.2,  1.8), ==, false);
+  TEST_COMPARE(tec->eventInRange( 3.1,  4.0), ==, true );
+  TEST_COMPARE(tec->eventInRange( 4.5,  6.0), ==, true );
+
+  TEST_COMPARE(tec->eventInRangeIndex(-8, -6), ==, false);
+  TEST_COMPARE(tec->eventInRangeIndex( 1,  1), ==, false);
+  TEST_COMPARE(tec->eventInRangeIndex( 5,  7), ==, true );
+  TEST_COMPARE(tec->eventInRangeIndex( 8, 10), ==, true );
+  TEST_COMPARE(tec->eventInRangeIndex(12, 14), ==, false);
+
+  timeEvents = tec->getTimeEvents();
+  TEST_COMPARE(timeEvents.size(), ==, 4);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventComposite, setTimeEvents)
+{
+  std::vector<Teuchos::RCP<Tempus::TimeEventBase<double> > >  timeEvents;
+  timeEvents.push_back(getTestRange1());
+  timeEvents.push_back(getTestList1());
+  timeEvents.push_back(getTestRangeIndex1());
+  timeEvents.push_back(getTestListIndex1());
+
+  auto tec = rcp(new Tempus::TimeEventComposite<double>());
+
+  tec->setTimeEvents(timeEvents);
+
+  auto timeEventsSet = tec->getTimeEvents();
+  TEST_COMPARE(timeEventsSet.size(), ==, 4);
 }
 
 
@@ -181,15 +263,19 @@ TEUCHOS_UNIT_TEST(TimeEventComposite, Default_Construction)
 // ************************************************************
 TEUCHOS_UNIT_TEST(TimeEventComposite, One_TimeEventRange)
 {
-  auto te = rcp(new Tempus::TimeEventComposite<double>());
+  auto tec = rcp(new Tempus::TimeEventComposite<double>());
   auto teRange1 = getTestRange1();
 
-  te->addTimeEvent(teRange1);
+  tec->add(teRange1);
+  //tec->describe(out, Teuchos::VERB_EXTREME);
 
-  TEST_COMPARE(te->isTime(0.0), ==, true );
-  TEST_FLOATING_EQUALITY(te->timeToNextEvent(0.0), 0.0, 1.0e-14);
-  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(1.1), 2.0, 1.0e-14);
-  TEST_COMPARE(te->eventInRange(0.0, 1.0), ==, true );
+  TEST_COMPARE(tec->isTime(0.0), ==, true );
+  TEST_FLOATING_EQUALITY(tec->timeToNextEvent(0.0), 1.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(tec->timeOfNextEvent(1.1), 2.0, 1.0e-14);
+  TEST_COMPARE(tec->eventInRange(0.0, 1.0), ==, true );
+
+  auto timeEvents = tec->getTimeEvents();
+  TEST_COMPARE(timeEvents.size(), ==, 1);
 }
 
 
@@ -197,18 +283,21 @@ TEUCHOS_UNIT_TEST(TimeEventComposite, One_TimeEventRange)
 // ************************************************************
 TEUCHOS_UNIT_TEST(TimeEventComposite, TwoOverlapping_TimeEventRanges)
 {
-  auto te = rcp(new Tempus::TimeEventComposite<double>());
+  auto tec = rcp(new Tempus::TimeEventComposite<double>());
   auto teRange1 = getTestRange1();
   auto teRange2 = getTestRange2();
 
-  te->addTimeEvent(teRange1);
-  te->addTimeEvent(teRange2);
-  //te->describe();
+  tec->add(teRange1);
+  tec->add(teRange2);
+  //tec->describe(out, Teuchos::VERB_EXTREME);
 
-  TEST_COMPARE(te->isTime(0.0), ==, true );
-  TEST_FLOATING_EQUALITY(te->timeToNextEvent(0.1), PI/4.0-0.1, 1.0e-14);
-  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(1.1), PI/2.0, 1.0e-14);
-  TEST_COMPARE(te->eventInRange(0.0, 1.0), ==, true );
+  TEST_COMPARE(tec->isTime(0.0), ==, true );
+  TEST_FLOATING_EQUALITY(tec->timeToNextEvent(0.1), PI/4.0-0.1, 1.0e-14);
+  TEST_FLOATING_EQUALITY(tec->timeOfNextEvent(1.1), PI/2.0, 1.0e-14);
+  TEST_COMPARE(tec->eventInRange(0.0, 1.0), ==, true );
+
+  auto timeEvents = tec->getTimeEvents();
+  TEST_COMPARE(timeEvents.size(), ==, 2);
 }
 
 
@@ -216,26 +305,29 @@ TEUCHOS_UNIT_TEST(TimeEventComposite, TwoOverlapping_TimeEventRanges)
 // ************************************************************
 TEUCHOS_UNIT_TEST(TimeEventComposite, TwoSeparated_TimeEventRanges)
 {
-  auto te = rcp(new Tempus::TimeEventComposite<double>());
+  auto tec = rcp(new Tempus::TimeEventComposite<double>());
   auto teRange3 = getTestRange3();
   auto teRange2 = getTestRange2();
 
-  te->addTimeEvent(teRange3);
-  te->addTimeEvent(teRange2);
-  //te->describe();
+  tec->add(teRange3);
+  tec->add(teRange2);
+  tec->describe(out, Teuchos::VERB_EXTREME);
 
-  TEST_COMPARE(te->isTime(4.0), ==, true );
-  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(1.1), PI/2.0, 1.0e-14);
-  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(3.0),    4.0, 1.0e-14);
-  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(5.0),    8.0, 1.0e-14);
-  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(10.0),   8.0, 1.0e-14);
-  TEST_COMPARE(te->eventInRange(-3.0, -2.0), ==, false);
-  TEST_COMPARE(te->eventInRange(-1.0,  0.0), ==, true );
-  TEST_COMPARE(te->eventInRange( 1.0,  2.0), ==, true );
-  TEST_COMPARE(te->eventInRange( 2.0,  3.0), ==, false);
-  TEST_COMPARE(te->eventInRange( 5.0,  7.0), ==, false);
-  TEST_COMPARE(te->eventInRange( 7.0,  9.0), ==, true );
-  TEST_COMPARE(te->eventInRange( 9.0, 11.0), ==, false);
+  TEST_COMPARE(tec->isTime(4.0), ==, true );
+  TEST_FLOATING_EQUALITY(tec->timeOfNextEvent(1.1), PI/2.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(tec->timeOfNextEvent(3.0),    4.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(tec->timeOfNextEvent(5.0),    8.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(tec->timeOfNextEvent(10.0), tec->getDefaultTime(), 1.0e-14);
+  TEST_COMPARE(tec->eventInRange(-3.0, -2.0), ==, false);
+  TEST_COMPARE(tec->eventInRange(-1.0,  0.0), ==, true );
+  TEST_COMPARE(tec->eventInRange( 1.0,  2.0), ==, true );
+  TEST_COMPARE(tec->eventInRange( 2.0,  3.0), ==, false);
+  TEST_COMPARE(tec->eventInRange( 5.0,  7.0), ==, false);
+  TEST_COMPARE(tec->eventInRange( 7.0,  9.0), ==, true );
+  TEST_COMPARE(tec->eventInRange( 9.0, 11.0), ==, false);
+
+  auto timeEvents = tec->getTimeEvents();
+  TEST_COMPARE(timeEvents.size(), ==, 2);
 }
 
 
@@ -243,15 +335,19 @@ TEUCHOS_UNIT_TEST(TimeEventComposite, TwoSeparated_TimeEventRanges)
 // ************************************************************
 TEUCHOS_UNIT_TEST(TimeEventComposite, One_TimeEventList)
 {
-  auto te = rcp(new Tempus::TimeEventComposite<double>());
+  auto tec = rcp(new Tempus::TimeEventComposite<double>());
   auto teList1 = getTestList1();
 
-  te->addTimeEvent(teList1);
+  tec->add(teList1);
+  //tec->describe(out, Teuchos::VERB_EXTREME);
 
-  TEST_COMPARE(te->isTime(2.0), ==, true );
-  TEST_FLOATING_EQUALITY(te->timeToNextEvent(3.5), 1.5, 1.0e-14);
-  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(-2.0), -1.0, 1.0e-14);
-  TEST_COMPARE(te->eventInRange(4.99, 10.0), ==, true );
+  TEST_COMPARE(tec->isTime(2.0), ==, true );
+  TEST_FLOATING_EQUALITY(tec->timeToNextEvent(3.5), 1.5, 1.0e-14);
+  TEST_FLOATING_EQUALITY(tec->timeOfNextEvent(-2.0), -1.0, 1.0e-14);
+  TEST_COMPARE(tec->eventInRange(4.99, 10.0), ==, true );
+
+  auto timeEvents = tec->getTimeEvents();
+  TEST_COMPARE(timeEvents.size(), ==, 1);
 }
 
 
@@ -259,18 +355,21 @@ TEUCHOS_UNIT_TEST(TimeEventComposite, One_TimeEventList)
 // ************************************************************
 TEUCHOS_UNIT_TEST(TimeEventComposite, TwoOverlapping_TimeEventLists)
 {
-  auto te = rcp(new Tempus::TimeEventComposite<double>());
+  auto tec = rcp(new Tempus::TimeEventComposite<double>());
   auto teList1 = getTestList1();
   auto teList2 = getTestList2();
 
-  te->addTimeEvent(teList1);
-  te->addTimeEvent(teList2);
-  //te->describe();
+  tec->add(teList1);
+  tec->add(teList2);
+  //tec->describe(out, Teuchos::VERB_EXTREME);
 
-  TEST_COMPARE(te->isTime(1.25), ==, true );
-  TEST_FLOATING_EQUALITY(te->timeToNextEvent(4.0), 0.95, 1.0e-14);
-  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(6.5), 12.34, 1.0e-14);
-  TEST_COMPARE(te->eventInRange(0.1, 1.0), ==, false);
+  TEST_COMPARE(tec->isTime(1.25), ==, true );
+  TEST_FLOATING_EQUALITY(tec->timeToNextEvent(4.0), 0.95, 1.0e-14);
+  TEST_FLOATING_EQUALITY(tec->timeOfNextEvent(6.5), 12.34, 1.0e-14);
+  TEST_COMPARE(tec->eventInRange(0.1, 1.0), ==, false);
+
+  auto timeEvents = tec->getTimeEvents();
+  TEST_COMPARE(timeEvents.size(), ==, 2);
 }
 
 
@@ -278,25 +377,28 @@ TEUCHOS_UNIT_TEST(TimeEventComposite, TwoOverlapping_TimeEventLists)
 // ************************************************************
 TEUCHOS_UNIT_TEST(TimeEventComposite, TwoSeparated_TimeEventLists)
 {
-  auto te = rcp(new Tempus::TimeEventComposite<double>());
+  auto tec = rcp(new Tempus::TimeEventComposite<double>());
   auto teList3 = getTestList3();
   auto teList2 = getTestList2();
 
-  te->addTimeEvent(teList3);
-  te->addTimeEvent(teList2);
-  //te->describe();
+  tec->add(teList3);
+  tec->add(teList2);
+  //tec->describe(out, Teuchos::VERB_EXTREME);
 
-  TEST_COMPARE(te->isTime(4.0), ==, false);
-  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(-8.9),  -5.0, 1.0e-14);
-  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(-0.3),  1.25, 1.0e-14);
-  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(-4.0),   -PI, 1.0e-14);
-  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(20.0), 12.34, 1.0e-14);
-  TEST_COMPARE(te->eventInRange(-6.0, -4.0), ==, true );
-  TEST_COMPARE(te->eventInRange(-3.0,  0.0), ==, true );
-  TEST_COMPARE(te->eventInRange( 2.0,  3.0), ==, false);
-  TEST_COMPARE(te->eventInRange( 4.9,  5.1), ==, true );
-  TEST_COMPARE(te->eventInRange(12.0, 12.4), ==, true );
-  TEST_COMPARE(te->eventInRange(14.0, 15.0), ==, false);
+  TEST_COMPARE(tec->isTime(4.0), ==, false);
+  TEST_FLOATING_EQUALITY(tec->timeOfNextEvent(-8.9),  -5.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(tec->timeOfNextEvent(-0.3),  1.25, 1.0e-14);
+  TEST_FLOATING_EQUALITY(tec->timeOfNextEvent(-4.0),   -PI, 1.0e-14);
+  TEST_FLOATING_EQUALITY(tec->timeOfNextEvent(20.0), tec->getDefaultTime(), 1.0e-14);
+  TEST_COMPARE(tec->eventInRange(-6.0, -4.0), ==, true );
+  TEST_COMPARE(tec->eventInRange(-3.0,  0.0), ==, true );
+  TEST_COMPARE(tec->eventInRange( 2.0,  3.0), ==, false);
+  TEST_COMPARE(tec->eventInRange( 4.9,  5.1), ==, true );
+  TEST_COMPARE(tec->eventInRange(12.0, 12.4), ==, true );
+  TEST_COMPARE(tec->eventInRange(14.0, 15.0), ==, false);
+
+  auto timeEvents = tec->getTimeEvents();
+  TEST_COMPARE(timeEvents.size(), ==, 2);
 }
 
 
@@ -304,15 +406,19 @@ TEUCHOS_UNIT_TEST(TimeEventComposite, TwoSeparated_TimeEventLists)
 // ************************************************************
 TEUCHOS_UNIT_TEST(TimeEventComposite, One_TimeEventRangeIndex)
 {
-  auto te = rcp(new Tempus::TimeEventComposite<double>());
+  auto tec = rcp(new Tempus::TimeEventComposite<double>());
   auto teRangeIndex1 = getTestRangeIndex1();
 
-  te->addTimeEvent(teRangeIndex1);
+  tec->add(teRangeIndex1);
+  //tec->describe(out, Teuchos::VERB_EXTREME);
 
-  TEST_COMPARE(te->isIndex(5), ==, true );
-  TEST_COMPARE(te->indexToNextEvent(3), ==, 2);
-  TEST_COMPARE(te->indexOfNextEvent(3), ==, 5);
-  TEST_COMPARE(te->eventInRangeIndex(3, 9), ==, true );
+  TEST_COMPARE(tec->isIndex(5), ==, true );
+  TEST_COMPARE(tec->indexToNextEvent(3), ==, 2);
+  TEST_COMPARE(tec->indexOfNextEvent(3), ==, 5);
+  TEST_COMPARE(tec->eventInRangeIndex(3, 9), ==, true );
+
+  auto timeEvents = tec->getTimeEvents();
+  TEST_COMPARE(timeEvents.size(), ==, 1);
 }
 
 
@@ -320,18 +426,21 @@ TEUCHOS_UNIT_TEST(TimeEventComposite, One_TimeEventRangeIndex)
 // ************************************************************
 TEUCHOS_UNIT_TEST(TimeEventComposite, TwoOverlapping_TimeEventRangeIndex)
 {
-  auto te = rcp(new Tempus::TimeEventComposite<double>());
+  auto tec = rcp(new Tempus::TimeEventComposite<double>());
   auto teRangeIndex1 = getTestRangeIndex1();
   auto teRangeIndex2 = getTestRangeIndex2();
 
-  te->addTimeEvent(teRangeIndex1);
-  te->addTimeEvent(teRangeIndex2);
-  //te->describe();
+  tec->add(teRangeIndex1);
+  tec->add(teRangeIndex2);
+  //tec->describe(out, Teuchos::VERB_EXTREME);
 
-  TEST_COMPARE(te->isIndex(-1), ==, true );
-  TEST_COMPARE(te->indexToNextEvent(-2), ==, 1);
-  TEST_COMPARE(te->indexOfNextEvent( 2), ==, 2);
-  TEST_COMPARE(te->eventInRangeIndex(0, 1), ==, false);
+  TEST_COMPARE(tec->isIndex(-1), ==, true );
+  TEST_COMPARE(tec->indexToNextEvent(-2), ==, 1);
+  TEST_COMPARE(tec->indexOfNextEvent( 2), ==, 3);
+  TEST_COMPARE(tec->eventInRangeIndex(0, 1), ==, false);
+
+  auto timeEvents = tec->getTimeEvents();
+  TEST_COMPARE(timeEvents.size(), ==, 2);
 }
 
 
@@ -339,26 +448,29 @@ TEUCHOS_UNIT_TEST(TimeEventComposite, TwoOverlapping_TimeEventRangeIndex)
 // ************************************************************
 TEUCHOS_UNIT_TEST(TimeEventComposite, TwoSeparate_TimeEventRangeIndex)
 {
-  auto te = rcp(new Tempus::TimeEventComposite<double>());
+  auto tec = rcp(new Tempus::TimeEventComposite<double>());
   auto teRangeIndex3 = getTestRangeIndex3();
   auto teRangeIndex2 = getTestRangeIndex2();
 
-  te->addTimeEvent(teRangeIndex3);
-  te->addTimeEvent(teRangeIndex2);
-  //te->describe();
+  tec->add(teRangeIndex3);
+  tec->add(teRangeIndex2);
+  //tec->describe(out, Teuchos::VERB_EXTREME);
 
-  TEST_COMPARE(te->isIndex(15), ==, true );
-  TEST_COMPARE(te->indexOfNextEvent( 9), ==, 10);
-  TEST_COMPARE(te->indexOfNextEvent(-6), ==, -5);
-  TEST_COMPARE(te->indexOfNextEvent( 6), ==,  7);
-  TEST_COMPARE(te->indexOfNextEvent(16), ==, 15);
-  TEST_COMPARE(te->eventInRangeIndex(-3, -2), ==, false);
-  TEST_COMPARE(te->eventInRangeIndex(-1,  0), ==, true );
-  TEST_COMPARE(te->eventInRangeIndex( 1,  2), ==, false);
-  TEST_COMPARE(te->eventInRangeIndex( 7,  8), ==, true );
-  TEST_COMPARE(te->eventInRangeIndex( 8,  9), ==, false);
-  TEST_COMPARE(te->eventInRangeIndex(10, 13), ==, true );
-  TEST_COMPARE(te->eventInRangeIndex(14, 20), ==, true );
+  TEST_COMPARE(tec->isIndex(15), ==, true );
+  TEST_COMPARE(tec->indexOfNextEvent( 9), ==, 10);
+  TEST_COMPARE(tec->indexOfNextEvent(-6), ==, -5);
+  TEST_COMPARE(tec->indexOfNextEvent( 6), ==,  7);
+  TEST_COMPARE(tec->indexOfNextEvent(16), ==, tec->getDefaultIndex());
+  TEST_COMPARE(tec->eventInRangeIndex(-3, -2), ==, false);
+  TEST_COMPARE(tec->eventInRangeIndex(-1,  0), ==, true );
+  TEST_COMPARE(tec->eventInRangeIndex( 1,  2), ==, false);
+  TEST_COMPARE(tec->eventInRangeIndex( 7,  8), ==, true );
+  TEST_COMPARE(tec->eventInRangeIndex( 8,  9), ==, false);
+  TEST_COMPARE(tec->eventInRangeIndex(10, 13), ==, true );
+  TEST_COMPARE(tec->eventInRangeIndex(14, 20), ==, true );
+
+  auto timeEvents = tec->getTimeEvents();
+  TEST_COMPARE(timeEvents.size(), ==, 2);
 }
 
 
@@ -366,15 +478,19 @@ TEUCHOS_UNIT_TEST(TimeEventComposite, TwoSeparate_TimeEventRangeIndex)
 // ************************************************************
 TEUCHOS_UNIT_TEST(TimeEventComposite, One_TimeEventListIndex)
 {
-  auto te = rcp(new Tempus::TimeEventComposite<double>());
+  auto tec = rcp(new Tempus::TimeEventComposite<double>());
   auto teListIndex1 = getTestListIndex1();
 
-  te->addTimeEvent(teListIndex1);
+  tec->add(teListIndex1);
+  //tec->describe(out, Teuchos::VERB_EXTREME);
 
-  TEST_COMPARE(te->isIndex(3), ==, true );
-  TEST_COMPARE(te->indexToNextEvent(1), ==, 2);
-  TEST_COMPARE(te->indexOfNextEvent(4), ==, 7);
-  TEST_COMPARE(te->eventInRangeIndex(1, 3), ==, true );
+  TEST_COMPARE(tec->isIndex(3), ==, true );
+  TEST_COMPARE(tec->indexToNextEvent(1), ==, 2);
+  TEST_COMPARE(tec->indexOfNextEvent(4), ==, 7);
+  TEST_COMPARE(tec->eventInRangeIndex(1, 3), ==, true );
+
+  auto timeEvents = tec->getTimeEvents();
+  TEST_COMPARE(timeEvents.size(), ==, 1);
 }
 
 
@@ -382,18 +498,21 @@ TEUCHOS_UNIT_TEST(TimeEventComposite, One_TimeEventListIndex)
 // ************************************************************
 TEUCHOS_UNIT_TEST(TimeEventComposite, TwoOverlapping_TimeEventListIndex)
 {
-  auto te = rcp(new Tempus::TimeEventComposite<double>());
+  auto tec = rcp(new Tempus::TimeEventComposite<double>());
   auto teListIndex1 = getTestListIndex1();
   auto teListIndex2 = getTestListIndex2();
 
-  te->addTimeEvent(teListIndex1);
-  te->addTimeEvent(teListIndex2);
-  //te->describe();
+  tec->add(teListIndex1);
+  tec->add(teListIndex2);
+  //tec->describe(out, Teuchos::VERB_EXTREME);
 
-  TEST_COMPARE(te->isIndex(2), ==, true );
-  TEST_COMPARE(te->indexToNextEvent(0), ==, 0);
-  TEST_COMPARE(te->indexOfNextEvent(1), ==, 2);
-  TEST_COMPARE(te->eventInRangeIndex(-1, 3), ==, true );
+  TEST_COMPARE(tec->isIndex(2), ==, true );
+  TEST_COMPARE(tec->indexToNextEvent(0), ==, 0);
+  TEST_COMPARE(tec->indexOfNextEvent(1), ==, 2);
+  TEST_COMPARE(tec->eventInRangeIndex(-1, 3), ==, true );
+
+  auto timeEvents = tec->getTimeEvents();
+  TEST_COMPARE(timeEvents.size(), ==, 2);
 }
 
 
@@ -401,21 +520,24 @@ TEUCHOS_UNIT_TEST(TimeEventComposite, TwoOverlapping_TimeEventListIndex)
 // ************************************************************
 TEUCHOS_UNIT_TEST(TimeEventComposite, TwoSeparate_TimeEventListIndex)
 {
-  auto te = rcp(new Tempus::TimeEventComposite<double>());
+  auto tec = rcp(new Tempus::TimeEventComposite<double>());
   auto teListIndex3 = getTestListIndex3();
   auto teListIndex2 = getTestListIndex2();
 
-  te->addTimeEvent(teListIndex3);
-  te->addTimeEvent(teListIndex2);
-  //te->describe();
+  tec->add(teListIndex3);
+  tec->add(teListIndex2);
+  //tec->describe(out, Teuchos::VERB_EXTREME);
 
-  TEST_COMPARE(te->isIndex(14), ==, true );
-  TEST_COMPARE(te->indexOfNextEvent(2), ==, 2);
-  TEST_COMPARE(te->indexOfNextEvent(5), ==, 9);
-  TEST_COMPARE(te->indexOfNextEvent(19), ==, 14);
-  TEST_COMPARE(te->eventInRangeIndex( 0,  1), ==, false);
-  TEST_COMPARE(te->eventInRangeIndex( 3, 10), ==, true );
-  TEST_COMPARE(te->eventInRangeIndex(15, 20), ==, false);
+  TEST_COMPARE(tec->isIndex(14), ==, true );
+  TEST_COMPARE(tec->indexOfNextEvent(2), ==, 2);
+  TEST_COMPARE(tec->indexOfNextEvent(5), ==, 9);
+  TEST_COMPARE(tec->indexOfNextEvent(19), ==, 14);
+  TEST_COMPARE(tec->eventInRangeIndex( 0,  1), ==, false);
+  TEST_COMPARE(tec->eventInRangeIndex( 3, 10), ==, true );
+  TEST_COMPARE(tec->eventInRangeIndex(15, 20), ==, false);
+
+  auto timeEvents = tec->getTimeEvents();
+  TEST_COMPARE(timeEvents.size(), ==, 2);
 }
 
 
@@ -423,53 +545,389 @@ TEUCHOS_UNIT_TEST(TimeEventComposite, TwoSeparate_TimeEventListIndex)
 // ************************************************************
 TEUCHOS_UNIT_TEST(TimeEventComposite, OneOfEach_TimeEvent)
 {
-  auto te = rcp(new Tempus::TimeEventComposite<double>());
+  auto tec = rcp(new Tempus::TimeEventComposite<double>());
   auto teRange1      = getTestRange1();
   auto teList1       = getTestList1();
   auto teRangeIndex1 = getTestRangeIndex1();
   auto teListIndex1  = getTestListIndex1();
 
-  te->addTimeEvent(teRange1);
-  te->addTimeEvent(teList1);
-  te->addTimeEvent(teRangeIndex1);
-  te->addTimeEvent(teListIndex1);
+  tec->add(teRange1);
+  tec->add(teList1);
+  tec->add(teRangeIndex1);
+  tec->add(teListIndex1);
+  tec->describe(out, Teuchos::VERB_EXTREME);
 
-  TEST_COMPARE(te->isTime (3.0), ==, true );
-  TEST_COMPARE(te->isTime (2.0), ==, true );
-  TEST_COMPARE(te->isIndex(  2), ==, true );
-  TEST_COMPARE(te->isIndex(  3), ==, true );
+  TEST_COMPARE(tec->isTime (3.0), ==, true );
+  TEST_COMPARE(tec->isTime (2.0), ==, true );
+  TEST_COMPARE(tec->isIndex(  2), ==, true );
+  TEST_COMPARE(tec->isIndex(  3), ==, true );
 
-  TEST_FLOATING_EQUALITY(te->timeToNextEvent(-2.5),  1.5, 1.0e-14);
-  TEST_FLOATING_EQUALITY(te->timeToNextEvent( 0.5),  0.5, 1.0e-14);
-  TEST_FLOATING_EQUALITY(te->timeToNextEvent( 4.5),  0.5, 1.0e-14);
-  TEST_FLOATING_EQUALITY(te->timeToNextEvent( 7.5), -2.5, 1.0e-14);
+  TEST_FLOATING_EQUALITY(tec->timeToNextEvent(-2.5),  1.5, 1.0e-14);
+  TEST_FLOATING_EQUALITY(tec->timeToNextEvent( 0.5),  0.5, 1.0e-14);
+  TEST_FLOATING_EQUALITY(tec->timeToNextEvent( 4.5),  0.5, 1.0e-14);
+  TEST_FLOATING_EQUALITY(tec->timeToNextEvent( 7.5), tec->getDefaultTime(), 1.0e-14);
 
-  TEST_COMPARE(te->indexToNextEvent(-6), ==,  1);
-  TEST_COMPARE(te->indexToNextEvent( 1), ==,  1);
-  TEST_COMPARE(te->indexToNextEvent( 7), ==,  0);
-  TEST_COMPARE(te->indexToNextEvent( 9), ==, -1);
+  TEST_COMPARE(tec->indexToNextEvent(-6), ==,  1);
+  TEST_COMPARE(tec->indexToNextEvent( 1), ==,  1);
+  TEST_COMPARE(tec->indexToNextEvent( 7), ==,  0);
+  TEST_COMPARE(tec->indexToNextEvent( 9), ==, tec->getDefaultIndex()-9);
 
-  TEST_FLOATING_EQUALITY(te->timeOfNextEvent( -PI), -1.0, 1.0e-14);
-  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(-0.5),  0.0, 1.0e-14);
-  TEST_FLOATING_EQUALITY(te->timeOfNextEvent( 2.5),  3.0, 1.0e-14);
-  TEST_FLOATING_EQUALITY(te->timeOfNextEvent( 7.5),  5.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(tec->timeOfNextEvent( -PI), -1.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(tec->timeOfNextEvent(-0.5),  0.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(tec->timeOfNextEvent( 2.5),  3.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(tec->timeOfNextEvent( 7.5), tec->getDefaultTime(), 1.0e-14);
 
-  TEST_COMPARE(te->indexOfNextEvent(-6), ==, -5);
-  TEST_COMPARE(te->indexOfNextEvent( 1), ==,  2);
-  TEST_COMPARE(te->indexOfNextEvent( 7), ==,  7);
-  TEST_COMPARE(te->indexOfNextEvent( 9), ==,  8);
+  TEST_COMPARE(tec->indexOfNextEvent(-6), ==, -5);
+  TEST_COMPARE(tec->indexOfNextEvent( 1), ==,  2);
+  TEST_COMPARE(tec->indexOfNextEvent( 7), ==,  7);
+  TEST_COMPARE(tec->indexOfNextEvent( 9), ==,  tec->getDefaultIndex());
 
-  TEST_COMPARE(te->eventInRange(-5.0, -2.0), ==, false);
-  TEST_COMPARE(te->eventInRange(-2.0, -0.5), ==, true );
-  TEST_COMPARE(te->eventInRange( 1.2,  1.8), ==, false);
-  TEST_COMPARE(te->eventInRange( 3.1,  4.0), ==, true );
-  TEST_COMPARE(te->eventInRange( 4.5,  6.0), ==, true );
+  TEST_COMPARE(tec->eventInRange(-5.0, -2.0), ==, false);
+  TEST_COMPARE(tec->eventInRange(-2.0, -0.5), ==, true );
+  TEST_COMPARE(tec->eventInRange( 1.2,  1.8), ==, false);
+  TEST_COMPARE(tec->eventInRange( 3.1,  4.0), ==, true );
+  TEST_COMPARE(tec->eventInRange( 4.5,  6.0), ==, true );
 
-  TEST_COMPARE(te->eventInRangeIndex(-8, -6), ==, false);
-  TEST_COMPARE(te->eventInRangeIndex( 1,  1), ==, false);
-  TEST_COMPARE(te->eventInRangeIndex( 5,  7), ==, true );
-  TEST_COMPARE(te->eventInRangeIndex( 8, 10), ==, true );
-  TEST_COMPARE(te->eventInRangeIndex(12, 14), ==, false);
+  TEST_COMPARE(tec->eventInRangeIndex(-8, -6), ==, false);
+  TEST_COMPARE(tec->eventInRangeIndex( 1,  1), ==, false);
+  TEST_COMPARE(tec->eventInRangeIndex( 5,  7), ==, true );
+  TEST_COMPARE(tec->eventInRangeIndex( 8, 10), ==, true );
+  TEST_COMPARE(tec->eventInRangeIndex(12, 14), ==, false);
+
+  auto timeEvents = tec->getTimeEvents();
+  TEST_COMPARE(timeEvents.size(), ==, 4);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventComposite, OneOfEach_Plus_TimeEvent)
+{
+  auto tec = rcp(new Tempus::TimeEventComposite<double>());
+  auto teRange1      = getTestRange1();
+  auto teList1       = getTestList1();
+  auto teRangeIndex1 = getTestRangeIndex1();
+  auto teListIndex1  = getTestListIndex1();
+
+  tec->add(teRange1);
+  tec->add(teList1);
+  tec->add(teRangeIndex1);
+  tec->add(teListIndex1);
+  tec->describe(out, Teuchos::VERB_EXTREME);
+
+  // Constraining TimeEvent
+  auto teCon = Teuchos::rcp(new Tempus::TimeEventBase<double>());
+
+  TEST_COMPARE(tec->isTime ( 3.0, teCon), ==, true ); TEST_COMPARE(teCon->getName(), ==, "teRange1");
+  TEST_COMPARE(tec->isTime (-1.0, teCon), ==, true ); TEST_COMPARE(teCon->getName(), ==, "teList1");
+  TEST_COMPARE(tec->isIndex(   2, teCon), ==, true ); TEST_COMPARE(teCon->getName(), ==, "teRangeIndex1");
+  TEST_COMPARE(tec->isIndex(  -2, teCon), ==, true ); TEST_COMPARE(teCon->getName(), ==, "teListIndex1");
+
+
+  TEST_FLOATING_EQUALITY(tec->timeToNextEvent(-2.5, teCon),  1.5, 1.0e-14);  TEST_COMPARE(teCon->getName(), ==, "teList1");
+  TEST_FLOATING_EQUALITY(tec->timeToNextEvent( 0.5, teCon),  0.5, 1.0e-14);  TEST_COMPARE(teCon->getName(), ==, "teRange1");
+  TEST_FLOATING_EQUALITY(tec->timeToNextEvent( 4.5, teCon),  0.5, 1.0e-14);  TEST_COMPARE(teCon->getName(), ==, "teList1");
+  TEST_FLOATING_EQUALITY(tec->timeToNextEvent( 7.5, teCon), tec->getDefaultTime(), 1.0e-14);  TEST_COMPARE(teCon->getName(), ==, "teRange1");
+
+  TEST_COMPARE(tec->indexToNextEvent(-6, teCon), ==,  1);  TEST_COMPARE(teCon->getName(), ==, "teListIndex1");
+  TEST_COMPARE(tec->indexToNextEvent( 1, teCon), ==,  1);  TEST_COMPARE(teCon->getName(), ==, "teRangeIndex1");
+  TEST_COMPARE(tec->indexToNextEvent( 7, teCon), ==,  0);  TEST_COMPARE(teCon->getName(), ==, "teListIndex1");
+  TEST_COMPARE(tec->indexToNextEvent( 9, teCon), ==, tec->getDefaultIndex()-9);  TEST_COMPARE(teCon->getName(), ==, "teRange1");
+
+  TEST_FLOATING_EQUALITY(tec->timeOfNextEvent( -PI, teCon), -1.0, 1.0e-14);  TEST_COMPARE(teCon->getName(), ==, "teList1");
+  TEST_FLOATING_EQUALITY(tec->timeOfNextEvent(-0.5, teCon),  0.0, 1.0e-14);  TEST_COMPARE(teCon->getName(), ==, "teRange1");
+  TEST_FLOATING_EQUALITY(tec->timeOfNextEvent( 2.5, teCon),  3.0, 1.0e-14);  TEST_COMPARE(teCon->getName(), ==, "teRange1");
+  TEST_FLOATING_EQUALITY(tec->timeOfNextEvent( 7.5, teCon), tec->getDefaultTime(), 1.0e-14);  TEST_COMPARE(teCon->getName(), ==, "teRange1");
+
+
+  TEST_COMPARE(tec->indexOfNextEvent(-6, teCon), ==, -5);  TEST_COMPARE(teCon->getName(), ==, "teListIndex1");
+  TEST_COMPARE(tec->indexOfNextEvent( 1, teCon), ==,  2);  TEST_COMPARE(teCon->getName(), ==, "teRangeIndex1");
+  TEST_COMPARE(tec->indexOfNextEvent( 7, teCon), ==,  7);  TEST_COMPARE(teCon->getName(), ==, "teListIndex1");
+  TEST_COMPARE(tec->indexOfNextEvent( 9, teCon), ==, tec->getDefaultIndex());  TEST_COMPARE(teCon->getName(), ==, "teRange1");
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventComposite, remove)
+{
+  // Construct ParmeterList for testing.
+  auto tec  = rcp(new Tempus::TimeEventComposite<double>());
+  auto ter  = rcp(new Tempus::TimeEventRange<double>());
+  auto teri = rcp(new Tempus::TimeEventRangeIndex<double>());
+  auto tel  = rcp(new Tempus::TimeEventList<double>());
+  auto teli = rcp(new Tempus::TimeEventListIndex<double>());
+
+  ter-> setName("Test Range");
+  teri->setName("Test Range Index");
+  tel-> setName("Test List");
+  teli->setName("Test List Index");
+
+  tec->add(ter );
+  tec->add(teri);
+  tec->add(tel );
+  tec->add(teli);
+  //tec->describe(out, Teuchos::VERB_EXTREME);
+
+  tec->remove("Blah Blah");
+  TEST_COMPARE( tec->getSize() , ==, 4);
+
+  tec->remove("Test Range Index");
+  TEST_COMPARE( tec->getSize() , ==, 3);
+  auto names = tec->getTimeEventNames();
+  TEST_COMPARE( names, ==, "Test Range, Test List, Test List Index");
+
+  tec->remove("Test List Index");
+  TEST_COMPARE( tec->getSize() , ==, 2);
+  names = tec->getTimeEventNames();
+  TEST_COMPARE( names, ==, "Test Range, Test List");
+
+  tec->remove("Test Range");
+  TEST_COMPARE( tec->getSize() , ==, 1);
+  names = tec->getTimeEventNames();
+  TEST_COMPARE( names, ==, "Test List");
+
+  tec->remove("Test List");
+  TEST_COMPARE( tec->getSize() , ==, 0);
+  names = tec->getTimeEventNames();
+  TEST_COMPARE( names, ==, "");
+
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventComposite, find)
+{
+  // Construct ParmeterList for testing.
+  auto tec  = rcp(new Tempus::TimeEventComposite<double>());
+  auto ter  = rcp(new Tempus::TimeEventRange<double>());
+  auto teri = rcp(new Tempus::TimeEventRangeIndex<double>());
+  auto tel  = rcp(new Tempus::TimeEventList<double>());
+  auto teli = rcp(new Tempus::TimeEventListIndex<double>());
+
+  ter-> setName("Test Range");
+  teri->setName("Test Range Index");
+  tel-> setName("Test List");
+  teli->setName("Test List Index");
+
+  tec->add(ter );
+  tec->add(teri);
+  tec->add(tel );
+  tec->add(teli);
+  //tec->describe(out, Teuchos::VERB_EXTREME);
+
+  auto teTest = tec->find("Test Range");
+  TEST_COMPARE( teTest->getName(), ==, "Test Range");
+
+  teTest = tec->find("Test Range Index");
+  TEST_COMPARE( teTest->getName(), ==, "Test Range Index");
+
+  teTest = tec->find("Test List");
+  TEST_COMPARE( teTest->getName(), ==, "Test List");
+
+  teTest = tec->find("Test List Index");
+  TEST_COMPARE( teTest->getName(), ==, "Test List Index");
+
+  teTest = tec->find("Blah Blah");
+  TEST_COMPARE( teTest, ==, Teuchos::null);
+
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventComposite, clear)
+{
+  // Construct ParmeterList for testing.
+  auto tec  = rcp(new Tempus::TimeEventComposite<double>());
+  auto ter  = rcp(new Tempus::TimeEventRange<double>());
+  auto teri = rcp(new Tempus::TimeEventRangeIndex<double>());
+  auto tel  = rcp(new Tempus::TimeEventList<double>());
+  auto teli = rcp(new Tempus::TimeEventListIndex<double>());
+
+  tec->add(ter );
+  tec->add(teri);
+  tec->add(tel );
+  tec->add(teli);
+  //tec->describe(out, Teuchos::VERB_EXTREME);
+
+  TEST_COMPARE( tec->getSize() , ==, 4);
+  tec->clear();
+  TEST_COMPARE( tec->getSize() , ==, 0);
+
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventComposite, getValidParameters)
+{
+  // Construct ParmeterList for testing.
+  auto tec  = rcp(new Tempus::TimeEventComposite<double>());
+  auto ter  = rcp(new Tempus::TimeEventRange<double>());
+  auto teri = rcp(new Tempus::TimeEventRangeIndex<double>());
+  auto tel  = rcp(new Tempus::TimeEventList<double>());
+  auto teli = rcp(new Tempus::TimeEventListIndex<double>());
+
+  ter-> setName("Test Range");
+  teri->setName("Test Range Index");
+  tel-> setName("Test List");
+  teli->setName("Test List Index");
+
+  tec->add(ter );
+  tec->add(teri);
+  tec->add(tel );
+  tec->add(teli);
+  //tec->describe(out, Teuchos::VERB_EXTREME);
+
+  auto timeEvents = tec->getTimeEvents();
+  TEST_COMPARE(timeEvents.size(), ==, 4);
+
+  auto pl = tec->getValidParameters();
+
+  TEST_COMPARE( pl->get<std::string>("Name"), ==, "TimeEventComposite");
+  TEST_COMPARE( pl->get<std::string>("Type"), ==, "Composite");
+  TEST_COMPARE( pl->get<std::string>("Time Events"), ==, "Test Range, Test Range Index, Test List, Test List Index");
+  TEST_COMPARE( pl->isSublist("Test Range")       , ==, true);
+  TEST_COMPARE( pl->isSublist("Test Range Index") , ==, true);
+  TEST_COMPARE( pl->isSublist("Test List")        , ==, true);
+  TEST_COMPARE( pl->isSublist("Test List Index")  , ==, true);
+
+  { // Ensure that parameters are "used", excluding sublists.
+    std::ostringstream unusedParameters;
+    pl->unused(unusedParameters);
+    TEST_COMPARE ( unusedParameters.str(), ==,
+      "WARNING: Parameter \"Test Range\"    [unused] is unused\n"
+      "WARNING: Parameter \"Test Range Index\"    [unused] is unused\n"
+      "WARNING: Parameter \"Test List\"    [unused] is unused\n"
+      "WARNING: Parameter \"Test List Index\"    [unused] is unused\n");
+  }
+
+  auto terPL = pl->sublist("Test Range");
+  TEST_COMPARE          ( terPL.get<std::string>("Type"), ==, "Range");
+  TEST_COMPARE          ( terPL.get<std::string>("Name"), ==, "Test Range");
+  TEST_FLOATING_EQUALITY( terPL.get<double>("Start Time"),   0.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY( terPL.get<double>("Stop Time") ,   0.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY( terPL.get<double>("Stride Time") , 0.0, 1.0e-14);
+  TEST_COMPARE          ( terPL.get<int>("Number of Events"), ==, 1);
+  TEST_FLOATING_EQUALITY( terPL.get<double>("Relative Tolerance"), 1.0e-14, 1.0e-14);
+  TEST_COMPARE          ( terPL.get<bool>("Land On Exactly"), ==, true);
+
+  { // Ensure that parameters are "used", excluding sublists.
+    std::ostringstream unusedParameters;
+    terPL.unused(unusedParameters);
+    TEST_COMPARE ( unusedParameters.str(), ==, "");
+  }
+
+  auto teriPL = pl->sublist("Test Range Index");
+  TEST_COMPARE( teriPL.get<std::string>("Type"), ==, "Range Index");
+  TEST_COMPARE( teriPL.get<std::string>("Name"), ==, "Test Range Index");
+  TEST_COMPARE( teriPL.get<int>("Start Index") , ==, 0);
+  TEST_COMPARE( teriPL.get<int>("Stop Index")  , ==, 0);
+  TEST_COMPARE( teriPL.get<int>("Stride Index"), ==, 1);
+
+  { // Ensure that parameters are "used", excluding sublists.
+    std::ostringstream unusedParameters;
+    teriPL.unused(unusedParameters);
+    TEST_COMPARE ( unusedParameters.str(), ==, "");
+  }
+
+  auto telPL = pl->sublist("Test List");
+  TEST_COMPARE          ( telPL.get<std::string>("Type"), ==, "List");
+  TEST_COMPARE          ( telPL.get<std::string>("Name"), ==, "Test List");
+  TEST_FLOATING_EQUALITY( telPL.get<double>("Relative Tolerance"), 1.0e-14, 1.0e-14);
+  TEST_COMPARE          ( telPL.get<bool>("Land On Exactly"), ==, true);
+  TEST_COMPARE          ( telPL.get<std::string>("Time List"), ==, "");
+
+  { // Ensure that parameters are "used", excluding sublists.
+    std::ostringstream unusedParameters;
+    telPL.unused(unusedParameters);
+    TEST_COMPARE ( unusedParameters.str(), ==, "");
+  }
+
+  auto teliPL = pl->sublist("Test List Index");
+  TEST_COMPARE( teliPL.get<std::string>("Type"), ==, "List Index");
+  TEST_COMPARE( teliPL.get<std::string>("Name"), ==, "Test List Index");
+  TEST_COMPARE( teliPL.get<std::string>("Index List"), ==, "");
+
+  { // Ensure that parameters are "used", excluding sublists.
+    std::ostringstream unusedParameters;
+    teliPL.unused(unusedParameters);
+    TEST_COMPARE ( unusedParameters.str(), ==, "");
+  }
+
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventComposite, createTimeEventComposite)
+{
+  using Teuchos::ParameterList;
+  using Teuchos::rcp_const_cast;
+
+  { // Construct from default ParameterList.
+    auto tecTmp  = rcp(new Tempus::TimeEventComposite<double>());
+    auto pl = rcp_const_cast<ParameterList>(tecTmp->getValidParameters());
+
+    auto tec = Tempus::createTimeEventComposite<double>(pl);
+    //tec->describe(out, Teuchos::VERB_EXTREME);
+
+    TEST_COMPARE( tec->getName()          , ==, "TimeEventComposite");
+    TEST_COMPARE( tec->getType()          , ==, "Composite");
+    TEST_COMPARE( tec->getSize()          , ==, 0);
+    TEST_COMPARE( tec->getTimeEventNames(), ==, "");
+  }
+
+  { // Construct with TimeEvents.
+    auto tecTmp = rcp(new Tempus::TimeEventComposite<double>());
+    auto ter  = rcp(new Tempus::TimeEventRange<double>());
+    auto teri = rcp(new Tempus::TimeEventRangeIndex<double>());
+    auto tel  = rcp(new Tempus::TimeEventList<double>());
+    auto teli = rcp(new Tempus::TimeEventListIndex<double>());
+
+    ter-> setName("Test Range");
+    teri->setName("Test Range Index");
+    tel-> setName("Test List");
+    teli->setName("Test List Index");
+
+    tecTmp->add(ter );
+    tecTmp->add(teri);
+    tecTmp->add(tel );
+    tecTmp->add(teli);
+
+    auto pl = rcp_const_cast<ParameterList>(tecTmp->getValidParameters());
+
+    auto tec = Tempus::createTimeEventComposite<double>(pl);
+    //tec->describe(out, Teuchos::VERB_EXTREME);
+
+    TEST_COMPARE( tec->getName()          , ==, "TimeEventComposite");
+    TEST_COMPARE( tec->getType()          , ==, "Composite");
+    TEST_COMPARE( tec->getSize()          , ==, 4);
+    TEST_COMPARE( tec->getTimeEventNames(), ==, "Test Range, Test Range Index, Test List, Test List Index");
+  }
+
+  { // Construct with non-Tempus TimeEvent.
+    auto tecTmp = rcp(new Tempus::TimeEventComposite<double>());
+    auto pl = rcp_const_cast<ParameterList>(tecTmp->getValidParameters());
+
+    auto nonTempusTE =
+      Teuchos::parameterList("Application Time Event");
+    nonTempusTE->set<std::string>("Name", "Application Time Event");
+    nonTempusTE->set<std::string>("Type", "Application Time Event Type");
+    nonTempusTE->set<double>("Secret Sauce", 1.2345);
+    pl->set("Application Time Event", *nonTempusTE);
+    pl->set("Time Events", "Application Time Event");
+
+    auto tec = Tempus::createTimeEventComposite<double>(pl);
+    //tec->describe(out, Teuchos::VERB_EXTREME);
+
+    TEST_COMPARE( tec->getName()          , ==, "TimeEventComposite");
+    TEST_COMPARE( tec->getType()          , ==, "Composite");
+    TEST_COMPARE( tec->getSize()          , ==, 0);
+    TEST_COMPARE( tec->getTimeEventNames(), ==, "");
+  }
 
 }
 

--- a/packages/tempus/unit_test/Tempus_UnitTest_TimeEventList.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_TimeEventList.cpp
@@ -48,7 +48,7 @@ TEUCHOS_UNIT_TEST(TimeEventList, Default_Construction)
 
 // ************************************************************
 // ************************************************************
-TEUCHOS_UNIT_TEST(TimeEventList, Construction)
+TEUCHOS_UNIT_TEST(TimeEventList, Full_Construction)
 {
   std::vector<double> testVector;
   testVector.push_back(-1.0);
@@ -58,7 +58,7 @@ TEUCHOS_UNIT_TEST(TimeEventList, Construction)
   testVector.push_back(  PI);
 
   auto te = rcp(new Tempus::TimeEventList<double>(
-                "TestName", testVector, 1.0e-14, true));
+                testVector, "TestName", true, 1.0e-14));
 
   TEST_COMPARE(te->getName(), ==, "TestName");
   TEST_FLOATING_EQUALITY(te->getRelTol(), 1.0e-14, 1.0e-14);
@@ -112,6 +112,16 @@ TEUCHOS_UNIT_TEST(TimeEventList, Basic_Accessors)
   TEST_COMPARE(te->getTimeList().size(), ==, 5);
   te->addTime( 2.0 + 1.0e-13);
   TEST_COMPARE(te->getTimeList().size(), ==, 6);
+
+  // Test setTimeList()
+  te->clearTimeList();
+  te->setTimeList(testList);
+  TEST_COMPARE(testList.size(), ==, 5);
+  TEST_FLOATING_EQUALITY(testList[0], -1.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(testList[1],  0.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(testList[2],  2.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(testList[3],   PI, 1.0e-14);
+  TEST_FLOATING_EQUALITY(testList[4],  5.0, 1.0e-14);
 }
 
 
@@ -129,23 +139,23 @@ TEUCHOS_UNIT_TEST(TimeEventList, isTime)
   // Test isTime.
   //   Around first event.
   TEST_COMPARE(te->isTime(-10.0e-14), ==, false);   // Just outside tolerance.
-  TEST_COMPARE(te->isTime( -1.0e-14), ==, true );   // Just inside tolerance.
+  TEST_COMPARE(te->isTime( -0.1e-14), ==, true );   // Just inside tolerance.
   TEST_COMPARE(te->isTime(  0.0    ), ==, true );   // Right on timeEvent.
-  TEST_COMPARE(te->isTime(  1.0e-14), ==, true );   // Just inside tolerance.
+  TEST_COMPARE(te->isTime(  0.1e-14), ==, true );   // Just inside tolerance.
   TEST_COMPARE(te->isTime( 10.0e-14), ==, false);   // Just outside tolerance.
 
   //   Around mid event.
   TEST_COMPARE(te->isTime(PI + -10.0e-14), ==, false); // Just outside tolerance.
-  TEST_COMPARE(te->isTime(PI +  -1.0e-14), ==, true ); // Just inside tolerance.
+  TEST_COMPARE(te->isTime(PI +  -0.1e-14), ==, true ); // Just inside tolerance.
   TEST_COMPARE(te->isTime(PI +   0.0    ), ==, true ); // Right on timeEvent.
-  TEST_COMPARE(te->isTime(PI +   1.0e-14), ==, true ); // Just inside tolerance.
+  TEST_COMPARE(te->isTime(PI +   0.1e-14), ==, true ); // Just inside tolerance.
   TEST_COMPARE(te->isTime(PI +  10.0e-14), ==, false); // Just outside tolerance.
 
   //   Around last event.
   TEST_COMPARE(te->isTime(5.0 + -10.0e-14), ==, false); // Just outside tolerance.
-  TEST_COMPARE(te->isTime(5.0 +  -1.0e-14), ==, true ); // Just inside tolerance.
+  TEST_COMPARE(te->isTime(5.0 +  -0.1e-14), ==, true ); // Just inside tolerance.
   TEST_COMPARE(te->isTime(5.0 +   0.0    ), ==, true ); // Right on timeEvent.
-  TEST_COMPARE(te->isTime(5.0 +   1.0e-14), ==, true ); // Just inside tolerance.
+  TEST_COMPARE(te->isTime(5.0 +   0.1e-14), ==, true ); // Just inside tolerance.
   TEST_COMPARE(te->isTime(5.0 +  10.0e-14), ==, false); // Just outside tolerance.
 }
 
@@ -162,29 +172,29 @@ TEUCHOS_UNIT_TEST(TimeEventList, timeToNextEvent)
   testList.push_back( 5.0);
 
   auto te = rcp(new Tempus::TimeEventList<double>(
-                "testList", testList, 1.0e-14, true));
+                testList, "testList", true, 1.0e-14));
 
   // Test timeToNextEvent.
   //   Around first event.
   TEST_FLOATING_EQUALITY(te->timeToNextEvent(-1.0 + -10.0e-14),     1.0e-13, 1.0e-02);
-  TEST_FLOATING_EQUALITY(te->timeToNextEvent(-1.0 +  -1.0e-14),     1.0e-14, 1.0e-02);
-  TEST_FLOATING_EQUALITY(te->timeToNextEvent(-1.0 +   0.0    ),     0.0    , 1.0e-02);
-  TEST_FLOATING_EQUALITY(te->timeToNextEvent(-1.0 +   1.0e-14),    -1.0e-14, 1.0e-02);
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(-1.0 +  -0.1e-14), 1.0+0.1e-14, 1.0e-01);
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(-1.0 +   0.0    ), 1.0+0.0    , 1.0e-02);
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(-1.0 +   0.1e-14), 1.0-0.1e-14, 1.0e-02);
   TEST_FLOATING_EQUALITY(te->timeToNextEvent(-1.0 +  10.0e-14), 1.0-1.0e-13, 1.0e-14);
 
   //   Around mid event.
   TEST_FLOATING_EQUALITY(te->timeToNextEvent(PI + -10.0e-14),        1.0e-13, 1.0e-02);
-  TEST_FLOATING_EQUALITY(te->timeToNextEvent(PI +  -1.0e-14),        1.0e-14, 1.0e-01);
-  TEST_FLOATING_EQUALITY(te->timeToNextEvent(PI +   0.0    ),        0.0    , 1.0e-02);
-  TEST_FLOATING_EQUALITY(te->timeToNextEvent(PI +   1.0e-14),       -1.0e-14, 1.0e-01);
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(PI +  -0.1e-14), 5.0-PI+0.1e-14, 1.0e-01);
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(PI +   0.0    ), 5.0-PI+0.0    , 1.0e-02);
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(PI +   0.1e-14), 5.0-PI-0.1e-14, 1.0e-01);
   TEST_FLOATING_EQUALITY(te->timeToNextEvent(PI +  10.0e-14), 5.0-PI-1.0e-13, 1.0e-14);
 
   //   Around last event.
   TEST_FLOATING_EQUALITY(te->timeToNextEvent(5.0+ -10.0e-14),  1.0e-13, 1.0e-02);
-  TEST_FLOATING_EQUALITY(te->timeToNextEvent(5.0+  -1.0e-14),  1.0e-14, 1.0e-01);
-  TEST_FLOATING_EQUALITY(te->timeToNextEvent(5.0+   0.0    ),  0.0    , 1.0e-02);
-  TEST_FLOATING_EQUALITY(te->timeToNextEvent(5.0+   1.0e-14), -1.0e-14, 1.0e-01);
-  TEST_FLOATING_EQUALITY(te->timeToNextEvent(5.0+  10.0e-14), -1.0e-13, 1.0e-02);
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(5.0+  -0.1e-14), te->getDefaultTime(), 1.0e-01);
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(5.0+   0.0    ), te->getDefaultTime(), 1.0e-02);
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(5.0+   0.1e-14), te->getDefaultTime(), 1.0e-01);
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(5.0+  10.0e-14), te->getDefaultTime(), 1.0e-02);
 }
 
 
@@ -200,29 +210,29 @@ TEUCHOS_UNIT_TEST(TimeEventList, timeOfNextEvent)
   testList.push_back( 5.0);
 
   auto te = rcp(new Tempus::TimeEventList<double>(
-                "testList", testList, 1.0e-14, true));
+                testList, "testList", true, 2.0e-14));
 
   // Test timeOfNextEvent.
   //   Around first event.
   TEST_FLOATING_EQUALITY(te->timeOfNextEvent(-1.0 + -10.0e-14), -1.0, 1.0e-14);
-  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(-1.0 +  -1.0e-14), -1.0, 1.0e-14);
-  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(-1.0 +   0.0    ), -1.0, 1.0e-14);
-  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(-1.0 +   1.0e-14), -1.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(-1.0 +  -0.1e-14),  0.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(-1.0 +   0.0    ),  0.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(-1.0 +   0.1e-14),  0.0, 1.0e-14);
   TEST_FLOATING_EQUALITY(te->timeOfNextEvent(-1.0 +  10.0e-14),  0.0, 1.0e-14);
 
   //   Around mid event.
-  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(2.0+ -10.0e-14),  2.0, 1.0e-14);
-  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(2.0+  -1.0e-14),  2.0, 1.0e-14);
-  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(2.0+   0.0    ),  2.0, 1.0e-14);
-  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(2.0+   1.0e-14),  2.0, 1.0e-14);
-  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(2.0+  10.0e-14), PI, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(2.0+ -10.0e-14), 2.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(2.0+  -0.1e-14),  PI, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(2.0+   0.0    ),  PI, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(2.0+   0.1e-14),  PI, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(2.0+  10.0e-14),  PI, 1.0e-14);
 
   //   Around last event.
-  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(5.0+ -10.0e-14), 5.0, 1.0e-14);
-  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(5.0+  -1.0e-14), 5.0, 1.0e-14);
-  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(5.0+   0.0    ), 5.0, 1.0e-14);
-  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(5.0+   1.0e-14), 5.0, 1.0e-14);
-  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(5.0+  10.0e-14), 5.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(5.0+ -10.0e-14),      5.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(5.0+  -0.1e-14), te->getDefaultTime(), 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(5.0+   0.0    ), te->getDefaultTime(), 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(5.0+   0.1e-14), te->getDefaultTime(), 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(5.0+  10.0e-14), te->getDefaultTime(), 1.0e-14);
 }
 
 
@@ -238,46 +248,109 @@ TEUCHOS_UNIT_TEST(TimeEventList, eventInRange)
   testList.push_back( 5.0);
 
   auto te = rcp(new Tempus::TimeEventList<double>(
-                "testList", testList, 1.0e-14, true));
+                testList, "testList", true, 1.0e-14));
 
   // Test eventInRange.
   //   Right end.
   TEST_COMPARE(te->eventInRange(-2.0, -1.0 + -10.0e-14), ==, false);   // Around first event.
-  TEST_COMPARE(te->eventInRange(-2.0, -1.0 +  -1.0e-14), ==, true );
+  TEST_COMPARE(te->eventInRange(-2.0, -1.0 +  -0.1e-14), ==, true );
   TEST_COMPARE(te->eventInRange(-2.0, -1.0 +   0.0    ), ==, true );
-  TEST_COMPARE(te->eventInRange(-2.0, -1.0 +   1.0e-14), ==, true );
+  TEST_COMPARE(te->eventInRange(-2.0, -1.0 +   0.1e-14), ==, true );
   TEST_COMPARE(te->eventInRange(-2.0, -1.0 +  10.0e-14), ==, true );
 
   TEST_COMPARE(te->eventInRange(3.0, PI + -10.0e-14), ==, false);   // Around mid event.
-  TEST_COMPARE(te->eventInRange(3.0, PI +  -1.0e-14), ==, true );
+  TEST_COMPARE(te->eventInRange(3.0, PI +  -0.1e-14), ==, true );
   TEST_COMPARE(te->eventInRange(3.0, PI +   0.0    ), ==, true );
-  TEST_COMPARE(te->eventInRange(3.0, PI +   1.0e-14), ==, true );
+  TEST_COMPARE(te->eventInRange(3.0, PI +   0.1e-14), ==, true );
   TEST_COMPARE(te->eventInRange(3.0, PI +  10.0e-14), ==, true );
 
   TEST_COMPARE(te->eventInRange(4.5, 5.0 + -10.0e-14), ==, false);   // Around last event.
-  TEST_COMPARE(te->eventInRange(4.5, 5.0 +  -1.0e-14), ==, true );
+  TEST_COMPARE(te->eventInRange(4.5, 5.0 +  -0.1e-14), ==, true );
   TEST_COMPARE(te->eventInRange(4.5, 5.0 +   0.0    ), ==, true );
-  TEST_COMPARE(te->eventInRange(4.5, 5.0 +   1.0e-14), ==, true );
+  TEST_COMPARE(te->eventInRange(4.5, 5.0 +   0.1e-14), ==, true );
   TEST_COMPARE(te->eventInRange(4.5, 5.0 +  10.0e-14), ==, true );
 
   //   Left end.
   TEST_COMPARE(te->eventInRange(-1.0 + -10.0e-14, -0.5), ==, true );   // Around first event.
-  TEST_COMPARE(te->eventInRange(-1.0 +  -1.0e-14, -0.5), ==, true );
+  TEST_COMPARE(te->eventInRange(-1.0 +  -0.1e-14, -0.5), ==, true );
   TEST_COMPARE(te->eventInRange(-1.0 +   0.0    , -0.5), ==, true );
-  TEST_COMPARE(te->eventInRange(-1.0 +   1.0e-14, -0.5), ==, true );
+  TEST_COMPARE(te->eventInRange(-1.0 +   0.1e-14, -0.5), ==, true );
   TEST_COMPARE(te->eventInRange(-1.0 +  10.0e-14, -0.5), ==, false );
 
   TEST_COMPARE(te->eventInRange(PI + -10.0e-14, 3.5), ==, true );   // Around mid event.
-  TEST_COMPARE(te->eventInRange(PI +  -1.0e-14, 3.5), ==, true );
+  TEST_COMPARE(te->eventInRange(PI +  -0.1e-14, 3.5), ==, true );
   TEST_COMPARE(te->eventInRange(PI +   0.0    , 3.5), ==, true );
-  TEST_COMPARE(te->eventInRange(PI +   1.0e-14, 3.5), ==, true );
+  TEST_COMPARE(te->eventInRange(PI +   0.1e-14, 3.5), ==, true );
   TEST_COMPARE(te->eventInRange(PI +  10.0e-14, 3.5), ==, false);
 
   TEST_COMPARE(te->eventInRange(5.0 + -10.0e-14, 6.0), ==, true );   // Around last event.
-  TEST_COMPARE(te->eventInRange(5.0 +  -1.0e-14, 6.0), ==, true );
+  TEST_COMPARE(te->eventInRange(5.0 +  -0.1e-14, 6.0), ==, true );
   TEST_COMPARE(te->eventInRange(5.0 +   0.0    , 6.0), ==, true );
-  TEST_COMPARE(te->eventInRange(5.0 +   1.0e-14, 6.0), ==, true );
+  TEST_COMPARE(te->eventInRange(5.0 +   0.1e-14, 6.0), ==, true );
   TEST_COMPARE(te->eventInRange(5.0 +  10.0e-14, 6.0), ==, false);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventList, getValidParameters)
+{
+  auto tel = rcp(new Tempus::TimeEventList<double>());
+
+  auto pl = tel->getValidParameters();
+
+  TEST_COMPARE          ( pl->get<std::string>("Type"), ==, "List");
+  TEST_COMPARE          ( pl->get<std::string>("Name"), ==, "TimeEventList");
+  TEST_FLOATING_EQUALITY( pl->get<double>("Relative Tolerance"), 1.0e-14, 1.0e-14);
+  TEST_COMPARE          ( pl->get<bool>("Land On Exactly"), ==, true);
+  TEST_COMPARE          ( pl->get<std::string>("Time List"), ==, "");
+
+  { // Ensure that parameters are "used", excluding sublists.
+    std::ostringstream unusedParameters;
+    pl->unused(unusedParameters);
+    TEST_COMPARE ( unusedParameters.str(), ==, "");
+  }
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventList, createTimeEventList)
+{
+  // Construct parameterList similar to getValidParameters().
+  Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList("Time Event List");
+
+  pl->set("Name",               "Unit Test Time Event List");
+  pl->set("Type",               "List");
+  pl->set("Relative Tolerance", 1.0e-10);
+  pl->set("Land On Exactly",    false);
+
+  std::vector<double> times;
+  times.push_back(-0.1);
+  times.push_back( 0.1);
+  times.push_back( 0.5);
+  times.push_back( 1.1);
+  std::ostringstream list;
+  for(std::size_t i = 0; i < times.size()-1; ++i) list << times[i] << ", ";
+  list << times[times.size()-1];
+  pl->set<std::string>("Time List", list.str());
+
+  // Construct TimeEventList from ParameterList.
+  auto tel = Tempus::createTimeEventList<double>(pl);
+
+  //Teuchos::RCP<Teuchos::FancyOStream> my_out =
+  //  Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
+  //tel->describe(*my_out, Teuchos::VERB_EXTREME);
+
+  TEST_COMPARE          ( tel->getName()         , ==, "Unit Test Time Event List");
+  TEST_COMPARE          ( tel->getType()         , ==, "List"      );
+  TEST_FLOATING_EQUALITY( tel->getRelTol()       , 1.0e-10, 1.0e-14);
+  TEST_COMPARE          ( tel->getLandOnExactly(), ==, false       );
+  auto teList = tel->getTimeList();
+  TEST_FLOATING_EQUALITY( teList[0],              -0.1,     1.0e-14);
+  TEST_FLOATING_EQUALITY( teList[1],               0.1,     1.0e-14);
+  TEST_FLOATING_EQUALITY( teList[2],               0.5,     1.0e-14);
+  TEST_FLOATING_EQUALITY( teList[3],               1.1,     1.0e-14);
 }
 
 

--- a/packages/tempus/unit_test/Tempus_UnitTest_TimeEventList.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_TimeEventList.cpp
@@ -35,7 +35,9 @@ TEUCHOS_UNIT_TEST(TimeEventList, Default_Construction)
   TEST_COMPARE(te->getName(), ==, "TimeEventList");
 
   TEST_COMPARE(te->getTimeList().size(), ==, 0);
-  TEST_FLOATING_EQUALITY(te->getRelTol(), 1.0e-14, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->getRelTol(), std::numeric_limits<double>::epsilon()*100.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->getAbsTol(), std::numeric_limits<double>::epsilon()*100.0, 1.0e-14);
+
   TEST_COMPARE(te->getLandOnExactly(), ==, true);
 
   // Check base class defaults (functions not implemented in TimeEventList).
@@ -135,6 +137,7 @@ TEUCHOS_UNIT_TEST(TimeEventList, isTime)
   te->addTime(-1.0);
   te->addTime( 2.0);
   te->addTime( 5.0);
+  te->setRelTol(1.0e-14);
 
   // Test isTime.
   //   Around first event.
@@ -210,7 +213,7 @@ TEUCHOS_UNIT_TEST(TimeEventList, timeOfNextEvent)
   testList.push_back( 5.0);
 
   auto te = rcp(new Tempus::TimeEventList<double>(
-                testList, "testList", true, 2.0e-14));
+                testList, "testList", true, 1.0e-14));
 
   // Test timeOfNextEvent.
   //   Around first event.
@@ -299,11 +302,12 @@ TEUCHOS_UNIT_TEST(TimeEventList, getValidParameters)
 
   auto pl = tel->getValidParameters();
 
-  TEST_COMPARE          ( pl->get<std::string>("Type"), ==, "List");
-  TEST_COMPARE          ( pl->get<std::string>("Name"), ==, "TimeEventList");
-  TEST_FLOATING_EQUALITY( pl->get<double>("Relative Tolerance"), 1.0e-14, 1.0e-14);
-  TEST_COMPARE          ( pl->get<bool>("Land On Exactly"), ==, true);
-  TEST_COMPARE          ( pl->get<std::string>("Time List"), ==, "");
+  TEST_COMPARE          (pl->get<std::string>("Type"), ==, "List");
+  TEST_COMPARE          (pl->get<std::string>("Name"), ==, "TimeEventList");
+  TEST_FLOATING_EQUALITY(pl->get<double>("Relative Tolerance"),
+                         std::numeric_limits<double>::epsilon()*100.0, 1.0e-14);
+  TEST_COMPARE          (pl->get<bool>("Land On Exactly"), ==, true);
+  TEST_COMPARE          (pl->get<std::string>("Time List"), ==, "");
 
   { // Ensure that parameters are "used", excluding sublists.
     std::ostringstream unusedParameters;

--- a/packages/tempus/unit_test/Tempus_UnitTest_TimeEventList.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_TimeEventList.cpp
@@ -275,21 +275,21 @@ TEUCHOS_UNIT_TEST(TimeEventList, eventInRange)
 
   //   Left end.
   TEST_COMPARE(te->eventInRange(-1.0 + -10.0e-14, -0.5), ==, true );   // Around first event.
-  TEST_COMPARE(te->eventInRange(-1.0 +  -0.1e-14, -0.5), ==, true );
-  TEST_COMPARE(te->eventInRange(-1.0 +   0.0    , -0.5), ==, true );
-  TEST_COMPARE(te->eventInRange(-1.0 +   0.1e-14, -0.5), ==, true );
-  TEST_COMPARE(te->eventInRange(-1.0 +  10.0e-14, -0.5), ==, false );
+  TEST_COMPARE(te->eventInRange(-1.0 +  -0.1e-14, -0.5), ==, false);
+  TEST_COMPARE(te->eventInRange(-1.0 +   0.0    , -0.5), ==, false);
+  TEST_COMPARE(te->eventInRange(-1.0 +   0.1e-14, -0.5), ==, false);
+  TEST_COMPARE(te->eventInRange(-1.0 +  10.0e-14, -0.5), ==, false);
 
   TEST_COMPARE(te->eventInRange(PI + -10.0e-14, 3.5), ==, true );   // Around mid event.
-  TEST_COMPARE(te->eventInRange(PI +  -0.1e-14, 3.5), ==, true );
-  TEST_COMPARE(te->eventInRange(PI +   0.0    , 3.5), ==, true );
-  TEST_COMPARE(te->eventInRange(PI +   0.1e-14, 3.5), ==, true );
+  TEST_COMPARE(te->eventInRange(PI +  -0.1e-14, 3.5), ==, false);
+  TEST_COMPARE(te->eventInRange(PI +   0.0    , 3.5), ==, false);
+  TEST_COMPARE(te->eventInRange(PI +   0.1e-14, 3.5), ==, false);
   TEST_COMPARE(te->eventInRange(PI +  10.0e-14, 3.5), ==, false);
 
   TEST_COMPARE(te->eventInRange(5.0 + -10.0e-14, 6.0), ==, true );   // Around last event.
-  TEST_COMPARE(te->eventInRange(5.0 +  -0.1e-14, 6.0), ==, true );
-  TEST_COMPARE(te->eventInRange(5.0 +   0.0    , 6.0), ==, true );
-  TEST_COMPARE(te->eventInRange(5.0 +   0.1e-14, 6.0), ==, true );
+  TEST_COMPARE(te->eventInRange(5.0 +  -0.1e-14, 6.0), ==, false);
+  TEST_COMPARE(te->eventInRange(5.0 +   0.0    , 6.0), ==, false);
+  TEST_COMPARE(te->eventInRange(5.0 +   0.1e-14, 6.0), ==, false);
   TEST_COMPARE(te->eventInRange(5.0 +  10.0e-14, 6.0), ==, false);
 }
 

--- a/packages/tempus/unit_test/Tempus_UnitTest_TimeEventListIndex.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_TimeEventListIndex.cpp
@@ -62,7 +62,7 @@ TEUCHOS_UNIT_TEST(TimeEventListIndex, Construction)
   testVector.push_back(-5);
 
   auto te = rcp(new Tempus::TimeEventListIndex<double>(
-                "TestName", testVector));
+                testVector, "TestName"));
 
   TEST_COMPARE(te->getName(), ==, "TestName");
 
@@ -129,7 +129,7 @@ TEUCHOS_UNIT_TEST(TimeEventListIndex, indexToNextEvent)
   testListIndex.push_back(-9);
 
   auto te = rcp(new Tempus::TimeEventListIndex<double>(
-                "teListIndex", testListIndex));
+                testListIndex, "teListIndex"));
 
   // Test indexToNextEvent.
   //   Around first event.
@@ -161,7 +161,7 @@ TEUCHOS_UNIT_TEST(TimeEventListIndex, indexOfNextEvent)
   testListIndex.push_back(-9);
 
   auto te = rcp(new Tempus::TimeEventListIndex<double>(
-                "teListIndex", testListIndex));
+                testListIndex, "teListIndex"));
 
   // Test indexOfNextEvent.
   //   Around first event.
@@ -193,7 +193,7 @@ TEUCHOS_UNIT_TEST(TimeEventListIndex, eventInRangeIndex)
   testListIndex.push_back(-9);
 
   auto te = rcp(new Tempus::TimeEventListIndex<double>(
-                "teListIndex", testListIndex));
+                testListIndex, "teListIndex"));
 
   // Test eventInRangeIndex.
   //   Right end.
@@ -221,6 +221,66 @@ TEUCHOS_UNIT_TEST(TimeEventListIndex, eventInRangeIndex)
   TEST_COMPARE(te->eventInRangeIndex(3, 8), ==, true );   // Around last event.
   TEST_COMPARE(te->eventInRangeIndex(4, 8), ==, true );
   TEST_COMPARE(te->eventInRangeIndex(5, 8), ==, false);
+}
+
+
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventListIndex, getValidParameters)
+{
+  auto teli = rcp(new Tempus::TimeEventListIndex<double>());
+
+  auto pl = teli->getValidParameters();
+
+  TEST_COMPARE( pl->get<std::string>("Type"), ==, "List Index");
+  TEST_COMPARE( pl->get<std::string>("Name"), ==, "TimeEventListIndex");
+  TEST_COMPARE( pl->get<std::string>("Index List"), ==, "");
+
+  { // Ensure that parameters are "used", excluding sublists.
+    std::ostringstream unusedParameters;
+    pl->unused(unusedParameters);
+    TEST_COMPARE ( unusedParameters.str(), ==, "");
+  }
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventListIndex, createTimeEventListIndex)
+{
+  // Construct parameterList similar to getValidParameters().
+  Teuchos::RCP<Teuchos::ParameterList> pl =
+    Teuchos::parameterList("Time Event List Index");
+
+  pl->set("Name", "Unit Test Time Event List Index");
+  pl->set("Type", "List Index");
+
+  std::vector<int> indices;
+  indices.push_back(-99);
+  indices.push_back( 13);
+  indices.push_back( 97);
+  indices.push_back(101);
+  std::ostringstream list;
+  for(std::size_t i = 0; i < indices.size()-1; ++i) list << indices[i] << ", ";
+  list << indices[indices.size()-1];
+  pl->set<std::string>("Index List", list.str());
+
+  // Construct TimeEventListIndex from ParameterList.
+  auto teli = Tempus::createTimeEventListIndex<double>(pl);
+
+  //Teuchos::RCP<Teuchos::FancyOStream> my_out =
+  //  Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
+  //teli->describe(*my_out, Teuchos::VERB_EXTREME);
+
+  TEST_COMPARE( teli->getName()         , ==, "Unit Test Time Event List Index");
+  TEST_COMPARE( teli->getType()         , ==, "List Index");
+  auto teList = teli->getIndexList();
+  TEST_COMPARE( teList[0]               , ==, -99);
+  TEST_COMPARE( teList[1]               , ==,  13);
+  TEST_COMPARE( teList[2]               , ==,  97);
+  TEST_COMPARE( teList[3]               , ==, 101);
 }
 
 

--- a/packages/tempus/unit_test/Tempus_UnitTest_TimeEventListIndex.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_TimeEventListIndex.cpp
@@ -35,7 +35,7 @@ TEUCHOS_UNIT_TEST(TimeEventListIndex, Default_Construction)
   TEST_COMPARE(te->getIndexList().size(), ==, 0);
 
   TEST_COMPARE(te->isIndex(-1), ==, false);
-  TEST_COMPARE(te->isIndex(te->getDefaultIndex()), ==, true );
+  TEST_COMPARE(te->isIndex( 0), ==, false);
   TEST_COMPARE(te->isIndex( 1), ==, false);
 
   TEST_COMPARE(te->indexToNextEvent(0), ==, te->getDefaultIndex());
@@ -134,18 +134,18 @@ TEUCHOS_UNIT_TEST(TimeEventListIndex, indexToNextEvent)
   // Test indexToNextEvent.
   //   Around first event.
   TEST_COMPARE(te->indexToNextEvent(-12), ==,  3);
-  TEST_COMPARE(te->indexToNextEvent( -9), ==,  0);
+  TEST_COMPARE(te->indexToNextEvent( -9), ==,  4);
   TEST_COMPARE(te->indexToNextEvent( -8), ==,  3);
 
   //   Around mid event.
   TEST_COMPARE(te->indexToNextEvent(-4), ==,  2);
-  TEST_COMPARE(te->indexToNextEvent(-2), ==,  0);
+  TEST_COMPARE(te->indexToNextEvent(-2), ==,  3);
   TEST_COMPARE(te->indexToNextEvent( 0), ==,  1);
 
   //   Around last event.
   TEST_COMPARE(te->indexToNextEvent(2), ==,  2);
-  TEST_COMPARE(te->indexToNextEvent(4), ==,  0);
-  TEST_COMPARE(te->indexToNextEvent(9), ==, -5);
+  TEST_COMPARE(te->indexToNextEvent(4), ==,  te->getDefaultIndex()-4);
+  TEST_COMPARE(te->indexToNextEvent(9), ==,  te->getDefaultIndex()-9);
 }
 
 
@@ -166,18 +166,18 @@ TEUCHOS_UNIT_TEST(TimeEventListIndex, indexOfNextEvent)
   // Test indexOfNextEvent.
   //   Around first event.
   TEST_COMPARE(te->indexOfNextEvent(-12), ==, -9);
-  TEST_COMPARE(te->indexOfNextEvent( -9), ==, -9);
+  TEST_COMPARE(te->indexOfNextEvent( -9), ==, -5);
   TEST_COMPARE(te->indexOfNextEvent( -8), ==, -5);
 
   //   Around mid event.
   TEST_COMPARE(te->indexOfNextEvent(-4), ==, -2);
-  TEST_COMPARE(te->indexOfNextEvent(-2), ==, -2);
+  TEST_COMPARE(te->indexOfNextEvent(-2), ==,  1);
   TEST_COMPARE(te->indexOfNextEvent( 0), ==,  1);
 
   //   Around last event.
   TEST_COMPARE(te->indexOfNextEvent(2), ==,  4);
-  TEST_COMPARE(te->indexOfNextEvent(4), ==,  4);
-  TEST_COMPARE(te->indexOfNextEvent(9), ==,  4);
+  TEST_COMPARE(te->indexOfNextEvent(4), ==,  te->getDefaultIndex());
+  TEST_COMPARE(te->indexOfNextEvent(9), ==,  te->getDefaultIndex());
 }
 
 
@@ -211,15 +211,15 @@ TEUCHOS_UNIT_TEST(TimeEventListIndex, eventInRangeIndex)
 
   //   Left end.
   TEST_COMPARE(te->eventInRangeIndex(-12, -7), ==, true );   // Around first event.
-  TEST_COMPARE(te->eventInRangeIndex( -9, -7), ==, true );
+  TEST_COMPARE(te->eventInRangeIndex( -9, -7), ==, false);
   TEST_COMPARE(te->eventInRangeIndex( -8, -7), ==, false);
 
   TEST_COMPARE(te->eventInRangeIndex(-3, 0), ==, true );   // Around mid event.
-  TEST_COMPARE(te->eventInRangeIndex(-2, 0), ==, true );
+  TEST_COMPARE(te->eventInRangeIndex(-2, 0), ==, false);
   TEST_COMPARE(te->eventInRangeIndex(-1, 0), ==, false);
 
   TEST_COMPARE(te->eventInRangeIndex(3, 8), ==, true );   // Around last event.
-  TEST_COMPARE(te->eventInRangeIndex(4, 8), ==, true );
+  TEST_COMPARE(te->eventInRangeIndex(4, 8), ==, false);
   TEST_COMPARE(te->eventInRangeIndex(5, 8), ==, false);
 }
 

--- a/packages/tempus/unit_test/Tempus_UnitTest_TimeEventRange.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_TimeEventRange.cpp
@@ -32,12 +32,12 @@ TEUCHOS_UNIT_TEST(TimeEventRange, Default_Construction)
 {
   auto te = rcp(new Tempus::TimeEventRange<double>());
 
-  TEST_COMPARE(te->getName(), ==, "TimeEventRange");
+  TEST_COMPARE(te->getName(), ==, "TimeEventRange (0; 0; 0)");
   te->setName("TestName");
   TEST_COMPARE(te->getName(), ==, "TestName");
 
-  TEST_FLOATING_EQUALITY(te->getTimeStart (), te->getDefaultTime(), 1.0e-14);
-  TEST_FLOATING_EQUALITY(te->getTimeStop  (), te->getDefaultTime(), 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->getTimeStart (), 0.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->getTimeStop  (), 0.0, 1.0e-14);
   TEST_FLOATING_EQUALITY(te->getTimeStride(), 0.0, 1.0e-14);
   TEST_COMPARE(te->getNumEvents (), ==, 1);
 
@@ -48,10 +48,12 @@ TEUCHOS_UNIT_TEST(TimeEventRange, Default_Construction)
 
 // ************************************************************
 // ************************************************************
-TEUCHOS_UNIT_TEST(TimeEventRange, Construction_Stride)
+TEUCHOS_UNIT_TEST(TimeEventRange, Full_Construction_Stride)
 {
   auto te = rcp(new Tempus::TimeEventRange<double>(
-                "TestName", 0.0, PI, 1.0, 1.0e-14, true));
+                0.0, PI, 1.0, "TestName", true, 1.0e-14));
+
+  //te->describe(out, Teuchos::VERB_EXTREME);
 
   TEST_COMPARE(te->getName(), ==, "TestName");
 
@@ -62,7 +64,7 @@ TEUCHOS_UNIT_TEST(TimeEventRange, Construction_Stride)
   TEST_COMPARE(te->getNumEvents (), ==, 4);
 
   auto teRange2 = rcp(new Tempus::TimeEventRange<double>(
-      "teRange2", -PI/2.0, PI/2.0, PI/4.0, 1.0e-14, true));
+      -PI/2.0, PI/2.0, PI/4.0, "teRange2", true, 1.0e-14));
 
   TEST_FLOATING_EQUALITY(teRange2->timeToNextEvent(0.1), PI/4.0-0.1, 1.0e-14);
 
@@ -71,10 +73,10 @@ TEUCHOS_UNIT_TEST(TimeEventRange, Construction_Stride)
 
 // ************************************************************
 // ************************************************************
-TEUCHOS_UNIT_TEST(TimeEventRange, Construction_NumEvents)
+TEUCHOS_UNIT_TEST(TimeEventRange, Full_Construction_NumEvents)
 {
   auto te = rcp(new Tempus::TimeEventRange<double>(
-                "TestName", 0.0, PI, 5, 1.0e-14, true));
+                0.0, PI, 5, "TestName", true, 1.0e-14));
 
   TEST_COMPARE(te->getName(), ==, "TestName");
 
@@ -176,27 +178,41 @@ TEUCHOS_UNIT_TEST(TimeEventRange, isTime)
   auto te = rcp(new Tempus::TimeEventRange<double>());
   te->setTimeRange(0.0, PI, 1.0);
 
-  // Test isTime.
+  //   Before first event.  (This is exactly one stride before range.)
+  TEST_COMPARE(te->isTime(-1.0 + -10.0e-14), ==, false);   // Just outside tolerance.
+  TEST_COMPARE(te->isTime(-1.0 +  -0.1e-14), ==, false);   // Just inside tolerance.
+  TEST_COMPARE(te->isTime(-1.0 +   0.0    ), ==, false);   // Right on timeEvent.
+  TEST_COMPARE(te->isTime(-1.0 +   0.1e-14), ==, false);   // Just inside tolerance.
+  TEST_COMPARE(te->isTime(-1.0 +  10.0e-14), ==, false);   // Just outside tolerance.
+
   //   Around first event.
   TEST_COMPARE(te->isTime(-10.0e-14), ==, false);   // Just outside tolerance.
-  TEST_COMPARE(te->isTime( -1.0e-14), ==, true );   // Just inside tolerance.
+  TEST_COMPARE(te->isTime( -0.1e-14), ==, true );   // Just inside tolerance.
   TEST_COMPARE(te->isTime(  0.0    ), ==, true );   // Right on timeEvent.
-  TEST_COMPARE(te->isTime(  1.0e-14), ==, true );   // Just inside tolerance.
+  TEST_COMPARE(te->isTime(  0.1e-14), ==, true );   // Just inside tolerance.
   TEST_COMPARE(te->isTime( 10.0e-14), ==, false);   // Just outside tolerance.
 
   //   Around mid event.
   TEST_COMPARE(te->isTime(1.0 + -10.0e-14), ==, false); // Just outside tolerance.
-  TEST_COMPARE(te->isTime(1.0 +  -1.0e-14), ==, true ); // Just inside tolerance.
+  TEST_COMPARE(te->isTime(1.0 +  -0.1e-14), ==, true ); // Just inside tolerance.
   TEST_COMPARE(te->isTime(1.0 +   0.0    ), ==, true ); // Right on timeEvent.
-  TEST_COMPARE(te->isTime(1.0 +   1.0e-14), ==, true ); // Just inside tolerance.
+  TEST_COMPARE(te->isTime(1.0 +   0.1e-14), ==, true ); // Just inside tolerance.
   TEST_COMPARE(te->isTime(1.0 +  10.0e-14), ==, false); // Just outside tolerance.
 
   //   Around last event.
   TEST_COMPARE(te->isTime(3.0 + -10.0e-14), ==, false); // Just outside tolerance.
-  TEST_COMPARE(te->isTime(3.0 +  -1.0e-14), ==, true ); // Just inside tolerance.
+  TEST_COMPARE(te->isTime(3.0 +  -0.1e-14), ==, true ); // Just inside tolerance.
   TEST_COMPARE(te->isTime(3.0 +   0.0    ), ==, true ); // Right on timeEvent.
-  TEST_COMPARE(te->isTime(3.0 +   1.0e-14), ==, true ); // Just inside tolerance.
+  TEST_COMPARE(te->isTime(3.0 +   0.1e-14), ==, true ); // Just inside tolerance.
   TEST_COMPARE(te->isTime(3.0 +  10.0e-14), ==, false); // Just outside tolerance.
+
+  //   After last event.  (This is exactly one stride after range.)
+  TEST_COMPARE(te->isTime(4.0 + -10.0e-14), ==, false);   // Just outside tolerance.
+  TEST_COMPARE(te->isTime(4.0 +  -0.1e-14), ==, false);   // Just inside tolerance.
+  TEST_COMPARE(te->isTime(4.0 +   0.0    ), ==, false);   // Right on timeEvent.
+  TEST_COMPARE(te->isTime(4.0 +   0.1e-14), ==, false);   // Just inside tolerance.
+  TEST_COMPARE(te->isTime(4.0 +  10.0e-14), ==, false);   // Just outside tolerance.
+
 }
 
 
@@ -209,25 +225,25 @@ TEUCHOS_UNIT_TEST(TimeEventRange, timeToNextEvent)
 
   // Test timeToNextEvent.
   //   Around first event.
-  TEST_FLOATING_EQUALITY(te->timeToNextEvent(-10.0e-14),  1.0e-13, 1.0e-14);     // Just outside tolerance.
-  TEST_FLOATING_EQUALITY(te->timeToNextEvent( -1.0e-14),  1.0e-14, 1.0e-14);     // Just inside tolerance.
-  TEST_FLOATING_EQUALITY(te->timeToNextEvent(  0.0    ),  0.0    , 1.0e-14);     // Right on timeEvent.
-  TEST_FLOATING_EQUALITY(te->timeToNextEvent(  1.0e-14), -1.0e-14, 1.0e-14);     // Just inside tolerance.
-  TEST_FLOATING_EQUALITY(te->timeToNextEvent( 10.0e-14), 1.0-1.0e-13, 1.0e-14);  // Just outside tolerance.
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(     -10.0e-14),     10.0e-14, 1.0e-14);  // Just outside tolerance.
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(      -0.1e-14), 1.0+ 0.1e-14, 1.0e-14);  // Just inside tolerance.
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(       0.0    ), 1.0+ 0.0    , 1.0e-14);  // Right on timeEvent.
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(       0.1e-14), 1.0- 0.1e-14, 1.0e-14);  // Just inside tolerance.
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(      10.0e-14), 1.0-10.0e-14, 1.0e-14);  // Just outside tolerance.
 
   //   Around mid event.
-  TEST_FLOATING_EQUALITY(te->timeToNextEvent(1.0+ -10.0e-14),  1.0e-13, 1.0e-02);    // Just outside tolerance.
-  TEST_FLOATING_EQUALITY(te->timeToNextEvent(1.0+  -1.0e-14),  1.0e-14, 1.0e-01);    // Just inside tolerance.
-  TEST_FLOATING_EQUALITY(te->timeToNextEvent(1.0+   0.0    ),  0.0    , 1.0e-02);    // Right on timeEvent.
-  TEST_FLOATING_EQUALITY(te->timeToNextEvent(1.0+   1.0e-14), -1.0e-14, 1.0e-01);    // Just inside tolerance.
-  TEST_FLOATING_EQUALITY(te->timeToNextEvent(1.0+  10.0e-14), 1.0-1.0e-13, 1.0e-14); // Just outside tolerance.
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(1.0+ -10.0e-14),     10.0e-14, 1.0e-02);  // Just outside tolerance.
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(1.0+  -0.1e-14), 1.0+ 0.1e-14, 1.0e-01);  // Just inside tolerance.
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(1.0+   0.0    ), 1.0+ 0.0    , 1.0e-02);  // Right on timeEvent.
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(1.0+   0.1e-14), 1.0- 0.1e-14, 1.0e-01);  // Just inside tolerance.
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(1.0+  10.0e-14), 1.0-10.0e-14, 1.0e-14);  // Just outside tolerance.
 
   //   Around last event.
-  TEST_FLOATING_EQUALITY(te->timeToNextEvent(3.0+ -10.0e-14),  1.0e-13, 1.0e-02);  // Just outside tolerance.
-  TEST_FLOATING_EQUALITY(te->timeToNextEvent(3.0+  -1.0e-14),  1.0e-14, 1.0e-01);  // Just inside tolerance.
-  TEST_FLOATING_EQUALITY(te->timeToNextEvent(3.0+   0.0    ),  0.0    , 1.0e-02);  // Right on timeEvent.
-  TEST_FLOATING_EQUALITY(te->timeToNextEvent(3.0+   1.0e-14), -1.0e-14, 1.0e-01);  // Just inside tolerance.
-  TEST_FLOATING_EQUALITY(te->timeToNextEvent(3.0+  10.0e-14), -1.0e-13, 1.0e-02);  // Just outside tolerance.
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(3.0+ -10.0e-14), 10.0e-14, 1.0e-02);  // Just outside tolerance.
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(3.0+  -0.1e-14), te->getDefaultTime(), 1.0e-01);  // Just inside tolerance.
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(3.0+   0.0    ), te->getDefaultTime(), 1.0e-02);  // Right on timeEvent.
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(3.0+   0.1e-14), te->getDefaultTime(), 1.0e-01);  // Just inside tolerance.
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(3.0+  10.0e-14), te->getDefaultTime(), 1.0e-02);  // Just outside tolerance.
 }
 
 
@@ -240,25 +256,25 @@ TEUCHOS_UNIT_TEST(TimeEventRange, timeOfNextEvent)
 
   // Test timeOfNextEvent.
   //   Around first event.
-  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(-10.0e-14), 0.0, 1.0e-14);  // Just outside tolerance.
-  TEST_FLOATING_EQUALITY(te->timeOfNextEvent( -1.0e-14), 0.0, 1.0e-14);  // Just inside tolerance.
-  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(  0.0    ), 0.0, 1.0e-14);  // Right on timeEvent.
-  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(  1.0e-14), 0.0, 1.0e-14);  // Just inside tolerance.
-  TEST_FLOATING_EQUALITY(te->timeOfNextEvent( 10.0e-14), 1.0, 1.0e-14);  // Just outside tolerance.
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(     -10.0e-14), 0.0, 1.0e-14);  // Just outside tolerance.
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(      -0.1e-14), 1.0, 1.0e-14);  // Just inside tolerance.
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(       0.0    ), 1.0, 1.0e-14);  // Right on timeEvent.
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(       0.1e-14), 1.0, 1.0e-14);  // Just inside tolerance.
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(      10.0e-14), 1.0, 1.0e-14);  // Just outside tolerance.
 
   //   Around mid event.
   TEST_FLOATING_EQUALITY(te->timeOfNextEvent(1.0+ -10.0e-14), 1.0, 1.0e-14);  // Just outside tolerance.
-  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(1.0+  -1.0e-14), 1.0, 1.0e-14);  // Just inside tolerance.
-  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(1.0+   0.0    ), 1.0, 1.0e-14);  // Right on timeEvent.
-  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(1.0+   1.0e-14), 1.0, 1.0e-14);  // Just inside tolerance.
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(1.0+  -0.1e-14), 2.0, 1.0e-14);  // Just inside tolerance.
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(1.0+   0.0    ), 2.0, 1.0e-14);  // Right on timeEvent.
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(1.0+   0.1e-14), 2.0, 1.0e-14);  // Just inside tolerance.
   TEST_FLOATING_EQUALITY(te->timeOfNextEvent(1.0+  10.0e-14), 2.0, 1.0e-14);  // Just outside tolerance.
 
   //   Around last event.
-  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(3.0+ -10.0e-14), 3.0, 1.0e-14);  // Just outside tolerance.
-  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(3.0+  -1.0e-14), 3.0, 1.0e-14);  // Just inside tolerance.
-  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(3.0+   0.0    ), 3.0, 1.0e-14);  // Right on timeEvent.
-  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(3.0+   1.0e-14), 3.0, 1.0e-14);  // Just inside tolerance.
-  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(3.0+  10.0e-14), 3.0, 1.0e-14);  // Just outside tolerance.
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(3.0+ -10.0e-14),      3.0, 1.0e-14);  // Just outside tolerance.
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(3.0+  -0.1e-14), te->getDefaultTime(), 1.0e-14);  // Just inside tolerance.
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(3.0+   0.0    ), te->getDefaultTime(), 1.0e-14);  // Right on timeEvent.
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(3.0+   0.1e-14), te->getDefaultTime(), 1.0e-14);  // Just inside tolerance.
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(3.0+  10.0e-14), te->getDefaultTime(), 1.0e-14);  // Just outside tolerance.
 }
 
 
@@ -273,46 +289,104 @@ TEUCHOS_UNIT_TEST(TimeEventRange, eventInRange)
   //   Right end.
   //   Around first event.
   TEST_COMPARE(te->eventInRange(-1.0, -10.0e-14), ==, false);  // Just outside tolerance.
-  TEST_COMPARE(te->eventInRange(-1.0,  -1.0e-14), ==, true );  // Just inside tolerance.
+  TEST_COMPARE(te->eventInRange(-1.0,  -0.1e-14), ==, true );  // Just inside tolerance.
   TEST_COMPARE(te->eventInRange(-1.0,   0.0    ), ==, true );  // Right on timeEvent.
-  TEST_COMPARE(te->eventInRange(-1.0,   1.0e-14), ==, true );  // Just inside tolerance.
+  TEST_COMPARE(te->eventInRange(-1.0,   0.1e-14), ==, true );  // Just inside tolerance.
   TEST_COMPARE(te->eventInRange(-1.0,  10.0e-14), ==, true );  // Just outside tolerance.
 
   //   Around mid event.
   TEST_COMPARE(te->eventInRange(0.5, 1.0 + -10.0e-14), ==, false);  // Just outside tolerance.
-  TEST_COMPARE(te->eventInRange(0.5, 1.0 +  -1.0e-14), ==, true );  // Just inside tolerance.
+  TEST_COMPARE(te->eventInRange(0.5, 1.0 +  -0.1e-14), ==, true );  // Just inside tolerance.
   TEST_COMPARE(te->eventInRange(0.5, 1.0 +   0.0    ), ==, true );  // Right on timeEvent.
-  TEST_COMPARE(te->eventInRange(0.5, 1.0 +   1.0e-14), ==, true );  // Just inside tolerance.
+  TEST_COMPARE(te->eventInRange(0.5, 1.0 +   0.1e-14), ==, true );  // Just inside tolerance.
   TEST_COMPARE(te->eventInRange(0.5, 1.0 +  10.0e-14), ==, true );  // Just outside tolerance.
 
   //   Around last event.
   TEST_COMPARE(te->eventInRange(2.5, 3.0 + -10.0e-14), ==, false);  // Just outside tolerance.
-  TEST_COMPARE(te->eventInRange(2.5, 3.0 +  -1.0e-14), ==, true );  // Just inside tolerance.
+  TEST_COMPARE(te->eventInRange(2.5, 3.0 +  -0.1e-14), ==, true );  // Just inside tolerance.
   TEST_COMPARE(te->eventInRange(2.5, 3.0 +   0.0    ), ==, true );  // Right on timeEvent.
-  TEST_COMPARE(te->eventInRange(2.5, 3.0 +   1.0e-14), ==, true );  // Just inside tolerance.
+  TEST_COMPARE(te->eventInRange(2.5, 3.0 +   0.1e-14), ==, true );  // Just inside tolerance.
   TEST_COMPARE(te->eventInRange(2.5, 3.0 +  10.0e-14), ==, true );  // Just outside tolerance.
 
   //   Left end.
   //   Around first event.
   TEST_COMPARE(te->eventInRange(-10.0e-14, 0.5), ==, true );  // Just outside tolerance.
-  TEST_COMPARE(te->eventInRange( -1.0e-14, 0.5), ==, true );  // Just inside tolerance.
+  TEST_COMPARE(te->eventInRange( -0.1e-14, 0.5), ==, true );  // Just inside tolerance.
   TEST_COMPARE(te->eventInRange(  0.0    , 0.5), ==, true );  // Right on timeEvent.
-  TEST_COMPARE(te->eventInRange(  1.0e-14, 0.5), ==, true );  // Just inside tolerance.
+  TEST_COMPARE(te->eventInRange(  0.1e-14, 0.5), ==, true );  // Just inside tolerance.
   TEST_COMPARE(te->eventInRange( 10.0e-14, 0.5), ==, false);  // Just outside tolerance.
 
   //   Around mid event.
   TEST_COMPARE(te->eventInRange(1.0 + -10.0e-14, 1.5), ==, true );  // Just outside tolerance.
-  TEST_COMPARE(te->eventInRange(1.0 +  -1.0e-14, 1.5), ==, true );  // Just inside tolerance.
+  TEST_COMPARE(te->eventInRange(1.0 +  -0.1e-14, 1.5), ==, true );  // Just inside tolerance.
   TEST_COMPARE(te->eventInRange(1.0 +   0.0    , 1.5), ==, true );  // Right on timeEvent.
-  TEST_COMPARE(te->eventInRange(1.0 +   1.0e-14, 1.5), ==, true );  // Just inside tolerance.
+  TEST_COMPARE(te->eventInRange(1.0 +   0.1e-14, 1.5), ==, true );  // Just inside tolerance.
   TEST_COMPARE(te->eventInRange(1.0 +  10.0e-14, 1.5), ==, false);  // Just outside tolerance.
 
   //   Around last event.
   TEST_COMPARE(te->eventInRange(3.0 + -10.0e-14, 4.0), ==, true );  // Just outside tolerance.
-  TEST_COMPARE(te->eventInRange(3.0 +  -1.0e-14, 4.0), ==, true );  // Just inside tolerance.
+  TEST_COMPARE(te->eventInRange(3.0 +  -0.1e-14, 4.0), ==, true );  // Just inside tolerance.
   TEST_COMPARE(te->eventInRange(3.0 +   0.0    , 4.0), ==, true );  // Right on timeEvent.
-  TEST_COMPARE(te->eventInRange(3.0 +   1.0e-14, 4.0), ==, true );  // Just inside tolerance.
+  TEST_COMPARE(te->eventInRange(3.0 +   0.1e-14, 4.0), ==, true );  // Just inside tolerance.
   TEST_COMPARE(te->eventInRange(3.0 +  10.0e-14, 4.0), ==, false);  // Just outside tolerance.
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventRange, getValidParameters)
+{
+  auto ter = rcp(new Tempus::TimeEventRange<double>());
+
+  auto pl = ter->getValidParameters();
+
+  TEST_COMPARE          ( pl->get<std::string>("Type"), ==, "Range");
+  TEST_COMPARE          ( pl->get<std::string>("Name"), ==, "TimeEventRange (0; 0; 0)");
+  TEST_FLOATING_EQUALITY( pl->get<double>("Start Time"),   0.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY( pl->get<double>("Stop Time") ,   0.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY( pl->get<double>("Stride Time") , 0.0, 1.0e-14);
+  TEST_COMPARE          ( pl->get<int>("Number of Events"), ==, 1);
+  TEST_FLOATING_EQUALITY( pl->get<double>("Relative Tolerance"), 1.0e-14, 1.0e-14);
+  TEST_COMPARE          ( pl->get<bool>("Land On Exactly"), ==, true);
+
+  { // Ensure that parameters are "used", excluding sublists.
+    std::ostringstream unusedParameters;
+    pl->unused(unusedParameters);
+    TEST_COMPARE ( unusedParameters.str(), ==, "");
+  }
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventRange, createTimeEventRange)
+{
+  // Construct parameterList similar to getValidParameters().
+  Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList("Time Event Range");
+
+  pl->set("Name", "Unit Test Time Event Range");
+  pl->set("Type", "Range");
+  pl->set("Start Time",         -0.1);
+  pl->set("Stop Time",           1.1);
+  pl->set("Stride Time",         0.1);
+  pl->set("Relative Tolerance", 1.0e-10);
+  pl->set("Land On Exactly",    false);
+
+  // Construct TimeEventRange from ParameterList.
+  auto ter = Tempus::createTimeEventRange<double>(pl);
+
+  //Teuchos::RCP<Teuchos::FancyOStream> my_out =
+  //  Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
+  //ter->describe(*my_out, Teuchos::VERB_EXTREME);
+
+  TEST_COMPARE          ( ter->getName()         , ==, "Unit Test Time Event Range");
+  TEST_COMPARE          ( ter->getType()         , ==, "Range"     );
+  TEST_FLOATING_EQUALITY( ter->getTimeStart()    ,    -0.1, 1.0e-14);
+  TEST_FLOATING_EQUALITY( ter->getTimeStop()     ,     1.1, 1.0e-14);
+  TEST_FLOATING_EQUALITY( ter->getTimeStride()   ,     0.1, 1.0e-14);
+  TEST_COMPARE          ( ter->getNumEvents()    , ==, 13          );
+  TEST_FLOATING_EQUALITY( ter->getRelTol()       , 1.0e-10, 1.0e-14);
+  TEST_COMPARE          ( ter->getLandOnExactly(), ==, false       );
 }
 
 

--- a/packages/tempus/unit_test/Tempus_UnitTest_TimeEventRange.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_TimeEventRange.cpp
@@ -41,7 +41,9 @@ TEUCHOS_UNIT_TEST(TimeEventRange, Default_Construction)
   TEST_FLOATING_EQUALITY(te->getTimeStride(), 0.0, 1.0e-14);
   TEST_COMPARE(te->getNumEvents (), ==, 1);
 
-  TEST_FLOATING_EQUALITY(te->getRelTol(), 1.0e-14, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->getRelTol(), std::numeric_limits<double>::epsilon()*100.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->getAbsTol(), std::numeric_limits<double>::epsilon()*100.0, 1.0e-14);
+
   TEST_COMPARE(te->getLandOnExactly(), ==, true);
 }
 
@@ -177,6 +179,7 @@ TEUCHOS_UNIT_TEST(TimeEventRange, isTime)
 {
   auto te = rcp(new Tempus::TimeEventRange<double>());
   te->setTimeRange(0.0, PI, 1.0);
+  te->setRelTol(1.0e-14);
 
   //   Before first event.  (This is exactly one stride before range.)
   TEST_COMPARE(te->isTime(-1.0 + -10.0e-14), ==, false);   // Just outside tolerance.
@@ -222,6 +225,7 @@ TEUCHOS_UNIT_TEST(TimeEventRange, timeToNextEvent)
 {
   auto te = rcp(new Tempus::TimeEventRange<double>());
   te->setTimeRange(0.0, PI, 1.0);
+  te->setRelTol(1.0e-14);
 
   // Test timeToNextEvent.
   //   Around first event.
@@ -253,6 +257,7 @@ TEUCHOS_UNIT_TEST(TimeEventRange, timeOfNextEvent)
 {
   auto te = rcp(new Tempus::TimeEventRange<double>());
   te->setTimeRange(0.0, PI, 1.0);
+  te->setRelTol(1.0e-14);
 
   // Test timeOfNextEvent.
   //   Around first event.
@@ -284,6 +289,7 @@ TEUCHOS_UNIT_TEST(TimeEventRange, eventInRange)
 {
   auto te = rcp(new Tempus::TimeEventRange<double>());
   te->setTimeRange(0.0, PI, 1.0);
+  te->setRelTol(1.0e-14);
 
   // Test eventInRange.
   //   Right end.
@@ -340,14 +346,15 @@ TEUCHOS_UNIT_TEST(TimeEventRange, getValidParameters)
 
   auto pl = ter->getValidParameters();
 
-  TEST_COMPARE          ( pl->get<std::string>("Type"), ==, "Range");
-  TEST_COMPARE          ( pl->get<std::string>("Name"), ==, "TimeEventRange (0; 0; 0)");
-  TEST_FLOATING_EQUALITY( pl->get<double>("Start Time"),   0.0, 1.0e-14);
-  TEST_FLOATING_EQUALITY( pl->get<double>("Stop Time") ,   0.0, 1.0e-14);
-  TEST_FLOATING_EQUALITY( pl->get<double>("Stride Time") , 0.0, 1.0e-14);
-  TEST_COMPARE          ( pl->get<int>("Number of Events"), ==, 1);
-  TEST_FLOATING_EQUALITY( pl->get<double>("Relative Tolerance"), 1.0e-14, 1.0e-14);
-  TEST_COMPARE          ( pl->get<bool>("Land On Exactly"), ==, true);
+  TEST_COMPARE          (pl->get<std::string>("Type"), ==, "Range");
+  TEST_COMPARE          (pl->get<std::string>("Name"), ==, "TimeEventRange (0; 0; 0)");
+  TEST_FLOATING_EQUALITY(pl->get<double>("Start Time"),   0.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(pl->get<double>("Stop Time") ,   0.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(pl->get<double>("Stride Time") , 0.0, 1.0e-14);
+  TEST_COMPARE          (pl->get<int>("Number of Events"), ==, 1);
+  TEST_FLOATING_EQUALITY(pl->get<double>("Relative Tolerance"),
+                         std::numeric_limits<double>::epsilon()*100.0, 1.0e-14);
+  TEST_COMPARE          (pl->get<bool>("Land On Exactly"), ==, true);
 
   { // Ensure that parameters are "used", excluding sublists.
     std::ostringstream unusedParameters;

--- a/packages/tempus/unit_test/Tempus_UnitTest_TimeEventRange.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_TimeEventRange.cpp
@@ -292,7 +292,7 @@ TEUCHOS_UNIT_TEST(TimeEventRange, eventInRange)
   te->setRelTol(1.0e-14);
 
   // Test eventInRange.
-  //   Right end.
+  //   Right end of input range.
   //   Around first event.
   TEST_COMPARE(te->eventInRange(-1.0, -10.0e-14), ==, false);  // Just outside tolerance.
   TEST_COMPARE(te->eventInRange(-1.0,  -0.1e-14), ==, true );  // Just inside tolerance.
@@ -314,26 +314,26 @@ TEUCHOS_UNIT_TEST(TimeEventRange, eventInRange)
   TEST_COMPARE(te->eventInRange(2.5, 3.0 +   0.1e-14), ==, true );  // Just inside tolerance.
   TEST_COMPARE(te->eventInRange(2.5, 3.0 +  10.0e-14), ==, true );  // Just outside tolerance.
 
-  //   Left end.
+  //   Left end of input range.
   //   Around first event.
   TEST_COMPARE(te->eventInRange(-10.0e-14, 0.5), ==, true );  // Just outside tolerance.
-  TEST_COMPARE(te->eventInRange( -0.1e-14, 0.5), ==, true );  // Just inside tolerance.
-  TEST_COMPARE(te->eventInRange(  0.0    , 0.5), ==, true );  // Right on timeEvent.
-  TEST_COMPARE(te->eventInRange(  0.1e-14, 0.5), ==, true );  // Just inside tolerance.
+  TEST_COMPARE(te->eventInRange( -0.1e-14, 0.5), ==, false);  // Just inside tolerance.
+  TEST_COMPARE(te->eventInRange(  0.0    , 0.5), ==, false);  // Right on timeEvent.
+  TEST_COMPARE(te->eventInRange(  0.1e-14, 0.5), ==, false);  // Just inside tolerance.
   TEST_COMPARE(te->eventInRange( 10.0e-14, 0.5), ==, false);  // Just outside tolerance.
 
   //   Around mid event.
   TEST_COMPARE(te->eventInRange(1.0 + -10.0e-14, 1.5), ==, true );  // Just outside tolerance.
-  TEST_COMPARE(te->eventInRange(1.0 +  -0.1e-14, 1.5), ==, true );  // Just inside tolerance.
-  TEST_COMPARE(te->eventInRange(1.0 +   0.0    , 1.5), ==, true );  // Right on timeEvent.
-  TEST_COMPARE(te->eventInRange(1.0 +   0.1e-14, 1.5), ==, true );  // Just inside tolerance.
+  TEST_COMPARE(te->eventInRange(1.0 +  -0.1e-14, 1.5), ==, false);  // Just inside tolerance.
+  TEST_COMPARE(te->eventInRange(1.0 +   0.0    , 1.5), ==, false);  // Right on timeEvent.
+  TEST_COMPARE(te->eventInRange(1.0 +   0.1e-14, 1.5), ==, false);  // Just inside tolerance.
   TEST_COMPARE(te->eventInRange(1.0 +  10.0e-14, 1.5), ==, false);  // Just outside tolerance.
 
   //   Around last event.
   TEST_COMPARE(te->eventInRange(3.0 + -10.0e-14, 4.0), ==, true );  // Just outside tolerance.
-  TEST_COMPARE(te->eventInRange(3.0 +  -0.1e-14, 4.0), ==, true );  // Just inside tolerance.
-  TEST_COMPARE(te->eventInRange(3.0 +   0.0    , 4.0), ==, true );  // Right on timeEvent.
-  TEST_COMPARE(te->eventInRange(3.0 +   0.1e-14, 4.0), ==, true );  // Just inside tolerance.
+  TEST_COMPARE(te->eventInRange(3.0 +  -0.1e-14, 4.0), ==, false);  // Just inside tolerance.
+  TEST_COMPARE(te->eventInRange(3.0 +   0.0    , 4.0), ==, false);  // Right on timeEvent.
+  TEST_COMPARE(te->eventInRange(3.0 +   0.1e-14, 4.0), ==, false);  // Just inside tolerance.
   TEST_COMPARE(te->eventInRange(3.0 +  10.0e-14, 4.0), ==, false);  // Just outside tolerance.
 }
 

--- a/packages/tempus/unit_test/Tempus_UnitTest_TimeEventRangeIndex.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_TimeEventRangeIndex.cpp
@@ -213,15 +213,15 @@ TEUCHOS_UNIT_TEST(TimeEventRangeIndex, eventInRangeIndex)
 
   //   Left end.
   TEST_COMPARE(te->eventInRangeIndex(-6.0, -3), ==, true );   // Around first event.
-  TEST_COMPARE(te->eventInRangeIndex(-5.0, -3), ==, true );
+  TEST_COMPARE(te->eventInRangeIndex(-5.0, -3), ==, false);
   TEST_COMPARE(te->eventInRangeIndex(-4.0, -3), ==, false);
 
   TEST_COMPARE(te->eventInRangeIndex(-3, 0), ==, true );   // Around mid event.
-  TEST_COMPARE(te->eventInRangeIndex(-2, 0), ==, true );
+  TEST_COMPARE(te->eventInRangeIndex(-2, 0), ==, false);
   TEST_COMPARE(te->eventInRangeIndex(-1, 0), ==, false);
 
   TEST_COMPARE(te->eventInRangeIndex(3, 8), ==, true );   // Around last event.
-  TEST_COMPARE(te->eventInRangeIndex(4, 8), ==, true );
+  TEST_COMPARE(te->eventInRangeIndex(4, 8), ==, false);
   TEST_COMPARE(te->eventInRangeIndex(5, 8), ==, false);
 }
 

--- a/packages/tempus/unit_test/Tempus_UnitTest_TimeEventRangeIndex.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_TimeEventRangeIndex.cpp
@@ -30,7 +30,7 @@ TEUCHOS_UNIT_TEST(TimeEventRangeIndex, Default_Construction)
 {
   auto te = rcp(new Tempus::TimeEventRangeIndex<double>());
 
-  TEST_COMPARE(te->getName(), ==, "TimeEventRangeIndex");
+  TEST_COMPARE(te->getName(), ==, "TimeEventRangeIndex (0; 0; 1)");
 
   // Test when everything is zero.
   TEST_COMPARE(te->getIndexStart (), ==, 0);
@@ -51,7 +51,7 @@ TEUCHOS_UNIT_TEST(TimeEventRangeIndex, Default_Construction)
 TEUCHOS_UNIT_TEST(TimeEventRangeIndex, Construction)
 {
   auto te = rcp(new Tempus::TimeEventRangeIndex<double>(
-                "TestName", -1, 10, 2));
+                -1, 10, 2, "TestName"));
 
   TEST_COMPARE(te->getName(), ==, "TestName");
 
@@ -155,16 +155,16 @@ TEUCHOS_UNIT_TEST(TimeEventRangeIndex, indexToNextEvent)
 
   // Test indexToNextEvent.
   TEST_COMPARE(te->indexToNextEvent(-9), ==, 4); //   Around first event.
-  TEST_COMPARE(te->indexToNextEvent(-5), ==, 0);
+  TEST_COMPARE(te->indexToNextEvent(-5), ==, 3);
   TEST_COMPARE(te->indexToNextEvent(-4), ==, 2);
 
   TEST_COMPARE(te->indexToNextEvent(-1), ==, 2); //   Around mid event.
-  TEST_COMPARE(te->indexToNextEvent( 1), ==, 0);
+  TEST_COMPARE(te->indexToNextEvent( 1), ==, 3);
   TEST_COMPARE(te->indexToNextEvent( 3), ==, 1);
 
   TEST_COMPARE(te->indexToNextEvent( 2), ==, 2); //   Around last event.
-  TEST_COMPARE(te->indexToNextEvent( 4), ==, 0);
-  TEST_COMPARE(te->indexToNextEvent( 8), ==,-4);
+  TEST_COMPARE(te->indexToNextEvent( 4), ==, te->getDefaultIndex()-4);
+  TEST_COMPARE(te->indexToNextEvent( 8), ==, te->getDefaultIndex()-8);
 }
 
 
@@ -177,16 +177,16 @@ TEUCHOS_UNIT_TEST(TimeEventRangeIndex, indexOfNextEvent)
 
   // Test indexOfNextEvent.
   TEST_COMPARE(te->indexOfNextEvent(-9), ==, -5); //   Around first event.
-  TEST_COMPARE(te->indexOfNextEvent(-5), ==, -5);
+  TEST_COMPARE(te->indexOfNextEvent(-5), ==, -2);
   TEST_COMPARE(te->indexOfNextEvent(-4), ==, -2);
 
   TEST_COMPARE(te->indexOfNextEvent(-1), ==, 1); //   Around mid event.
-  TEST_COMPARE(te->indexOfNextEvent( 1), ==, 1);
+  TEST_COMPARE(te->indexOfNextEvent( 1), ==, 4);
   TEST_COMPARE(te->indexOfNextEvent( 3), ==, 4);
 
   TEST_COMPARE(te->indexOfNextEvent( 2), ==, 4); //   Around last event.
-  TEST_COMPARE(te->indexOfNextEvent( 4), ==, 4);
-  TEST_COMPARE(te->indexOfNextEvent( 8), ==, 4);
+  TEST_COMPARE(te->indexOfNextEvent( 4), ==, te->getDefaultIndex());
+  TEST_COMPARE(te->indexOfNextEvent( 8), ==, te->getDefaultIndex());
 }
 
 
@@ -223,6 +223,58 @@ TEUCHOS_UNIT_TEST(TimeEventRangeIndex, eventInRangeIndex)
   TEST_COMPARE(te->eventInRangeIndex(3, 8), ==, true );   // Around last event.
   TEST_COMPARE(te->eventInRangeIndex(4, 8), ==, true );
   TEST_COMPARE(te->eventInRangeIndex(5, 8), ==, false);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventRangeIndex, getValidParameters)
+{
+  auto teri = rcp(new Tempus::TimeEventRangeIndex<double>());
+
+  auto pl = teri->getValidParameters();
+
+  TEST_COMPARE( pl->get<std::string>("Type"), ==, "Range Index");
+  TEST_COMPARE( pl->get<std::string>("Name"), ==, "TimeEventRangeIndex (0; 0; 1)");
+  TEST_COMPARE( pl->get<int>("Start Index") , ==, 0);
+  TEST_COMPARE( pl->get<int>("Stop Index")  , ==, 0);
+  TEST_COMPARE( pl->get<int>("Stride Index"), ==, 1);
+
+  { // Ensure that parameters are "used", excluding sublists.
+    std::ostringstream unusedParameters;
+    pl->unused(unusedParameters);
+    TEST_COMPARE ( unusedParameters.str(), ==, "");
+  }
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventRangeIndex, createTimeEventRange)
+{
+  // Construct parameterList similar to getValidParameters().
+  Teuchos::RCP<Teuchos::ParameterList> pl =
+    Teuchos::parameterList("Time Event Range Index");
+
+  pl->set("Name",         "Unit Test Time Event Range Index");
+  pl->set("Type",         "Range Index");
+  pl->set("Start Index",  -1);
+  pl->set("Stop Index",   11);
+  pl->set("Stride Index",  2);
+
+  // Construct TimeEventRangeIndex from ParameterList.
+  auto teri = Tempus::createTimeEventRangeIndex<double>(pl);
+
+  //Teuchos::RCP<Teuchos::FancyOStream> my_out =
+  //  Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
+  //teri->describe(*my_out, Teuchos::VERB_EXTREME);
+
+  TEST_COMPARE( teri->getName()       , ==, "Unit Test Time Event Range Index");
+  TEST_COMPARE( teri->getType()       , ==, "Range Index");
+  TEST_COMPARE( teri->getIndexStart() , ==, -1           );
+  TEST_COMPARE( teri->getIndexStop()  , ==, 11           );
+  TEST_COMPARE( teri->getIndexStride(), ==,  2           );
+  TEST_COMPARE( teri->getNumEvents()  , ==,  7           );
 }
 
 


### PR DESCRIPTION
 * Added nonmember contructors for ParamterLists, getValidParameters(),
   and changed full constructors signatures for
   - TimeEventRange
   - TimeEventRangeIndex
   - TimeEventList
   - TimeEventListIndex
   - TimeEventComposite
 * Added TimeEvents to TimeStepControl::getValidParameters().
 * Added reading TimeEvents to createTimestepControl().
 * Added timeEventType_ member data to identify the type of TimeEvent.
 * In TimeStepControl
   - Default construction of TimeEvents match previous specification
     of output times and indices.
 * Ensured the timeOfNextEvent(time) returns the NEXT event and not
   event at current time.
 * In TimeEventComposite
   - Added means to find and replace a TimeEvent.
   - Added method to return names on TimeEvents in composite.
 * Added doxygen commments for many TimeEvent funcitons.
 * Added unit testing for TimeEvents and TimeStepControl.
 * Dropped the idea about returning negative time to indicate
   the closest event was in the past.  This caused confusing
   results, and not sure provided useful information.

@trilinos/tempus 

## Motivation
Improve time step control and provide methods for Charon events.

* Closes #8219 


## Testing
Added tests that cover new features.
