### PR TITLE
Intrepid2: fix shadowed DeviceType declarations in function scope

### DIFF
--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_TensorBasis.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_TensorBasis.hpp
@@ -896,7 +896,6 @@ struct OperatorTensorDecomposition
       
       using ValueType    = typename BasisBase::ScalarViewType::value_type;
       using ResultLayout = typename DeduceLayout< typename BasisBase::ScalarViewType >::result_layout;
-      using DeviceType   = typename BasisBase::ScalarViewType::device_type;
       using ViewType     = Kokkos::DynRankView<ValueType, ResultLayout, DeviceType >;
       
       const ordinal_type basisCardinality1 = basis1_->getCardinality();
@@ -938,7 +937,6 @@ struct OperatorTensorDecomposition
     {
       using ValueType    = typename BasisBase::ScalarViewType::value_type;
       using ResultLayout = typename DeduceLayout< typename BasisBase::ScalarViewType >::result_layout;
-      using DeviceType   = typename BasisBase::ScalarViewType::device_type;
       using ViewType     = Kokkos::DynRankView<ValueType, ResultLayout, DeviceType >;
 
       ViewType dofCoeffs1("dofCoeffs1",basis1_->getCardinality());


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/Intrepid2
@mperego @kyungjoo-kim

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Shadowed declaration of `DeviceType` in class scope; there are several other declarations in function scope which seem to be no longer needed.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
N/A

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
N/A

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->