### PR TITLE
Tpetra:  removed need for matrix to have isFillActive()=true in scale() and setAllToScalar()

### DIFF
--- a/packages/muelu/src/Transfers/Energy-Minimization/Solvers/MueLu_CGSolver_def.hpp
+++ b/packages/muelu/src/Transfers/Energy-Minimization/Solvers/MueLu_CGSolver_def.hpp
@@ -106,9 +106,7 @@ namespace MueLu {
     // R_0 = -A*X_0
     R = Xpetra::MatrixFactory2<Scalar, LocalOrdinal, GlobalOrdinal, Node>::BuildCopy(T);
 
-    R->resumeFill();
     R->scale(-one);
-    R->fillComplete(R->getDomainMap(), R->getRangeMap());
 
     // Z_0 = M^{-1}R_0
     Z = Xpetra::MatrixFactory2<Scalar, LocalOrdinal, GlobalOrdinal, Node>::BuildCopy(R);

--- a/packages/muelu/src/Transfers/Energy-Minimization/Solvers/MueLu_GMRESSolver_def.hpp
+++ b/packages/muelu/src/Transfers/Energy-Minimization/Solvers/MueLu_GMRESSolver_def.hpp
@@ -122,9 +122,7 @@ namespace MueLu {
 
       rho = sqrt(Utilities::Frobenius(*V[0], *V[0]));
 
-      V[0]->resumeFill();
       V[0]->scale(-one/rho);
-      V[0]->fillComplete(V[0]->getDomainMap(), V[0]->getRangeMap());
     }
 
     std::vector<SC> h((nIts_+1) * (nIts_+1));
@@ -182,9 +180,7 @@ namespace MueLu {
       // Check for nonsymmetric case
       if (h[I(i+1,i)] != zero) {
         // Normalize V_i
-        V[i+1]->resumeFill();
         V[i+1]->scale(one/h[I(i+1,i)]);
-        V[i+1]->fillComplete(V[i+1]->getDomainMap(), V[i+1]->getRangeMap());
       }
 
       if (i > 0)

--- a/packages/panzer/disc-fe/src/lof/Panzer_TpetraLinearObjContainer.hpp
+++ b/packages/panzer/disc-fe/src/lof/Panzer_TpetraLinearObjContainer.hpp
@@ -90,9 +90,7 @@ public:
       if(get_f()!=Teuchos::null) get_f()->putScalar(0.0);
       if(get_A()!=Teuchos::null) {
         Teuchos::RCP<CrsMatrixType> mat = get_A(); 
-        mat->resumeFill();
         mat->setAllToScalar(0.0);
-        mat->fillComplete();
       }
    }
 
@@ -119,9 +117,7 @@ public:
 
    void initializeMatrix(ScalarT value)
    {  
-     A->resumeFill();
      A->setAllToScalar(value); 
-     A->fillComplete();
    }
 
    virtual void set_x_th(const Teuchos::RCP<Thyra::VectorBase<ScalarT> > & in) 

--- a/packages/panzer/disc-fe/test/la_factory/tBlockedTpetraLinearObjFactory.cpp
+++ b/packages/panzer/disc-fe/test/la_factory/tBlockedTpetraLinearObjFactory.cpp
@@ -127,9 +127,7 @@ void fillComplete(CrsMatrixType & A)
 
 void putScalar(ScalarT s,CrsMatrixType & A)
 {
-  resumeFill(A);
   A.setAllToScalar(s);
-  fillComplete(A);
 }
 
 template <typename Intrepid2Type>
@@ -470,9 +468,7 @@ TEUCHOS_UNIT_TEST(tBlockedTpetraLinearObjFactory, adjustDirichlet)
    for(int i=0;i<numBlocks;i++) {
       for(int j=0;j<numBlocks;j++) {
          RCP<CrsMatrixType> M = getSubBlock_tp(i,j,*b_sys->get_A());
-         M->resumeFill();
          M->setAllToScalar(-3.0);
-         M->fillComplete(M->getDomainMap(),M->getRangeMap());
       }
    }
 

--- a/packages/panzer/disc-fe/test/la_factory/tTpetraLinearObjFactory.cpp
+++ b/packages/panzer/disc-fe/test/la_factory/tTpetraLinearObjFactory.cpp
@@ -414,9 +414,7 @@ TEUCHOS_UNIT_TEST(tTpetraLinearObjFactory, adjustDirichlet)
    TEST_ASSERT(!Teuchos::is_null(t_sys->get_A()));
 
    t_sys->get_f()->putScalar(-3.0); // put some garbage in the systems
-   t_sys->get_A()->resumeFill();
    t_sys->get_A()->setAllToScalar(-3.0);
-   t_sys->get_A()->fillComplete();
 
    // there are 3 cases for adjustDirichlet
    //   1. Local set only for GID

--- a/packages/panzer/mini-em/src/solvers/MiniEM_FullMaxwellPreconditionerFactory.cpp
+++ b/packages/panzer/mini-em/src/solvers/MiniEM_FullMaxwellPreconditionerFactory.cpp
@@ -135,9 +135,7 @@ Teko::LinearOp FullMaxwellPreconditionerFactory::buildPreconditionerOperator(Tek
          RCP<const Thyra::TpetraLinearOp<Scalar,LocalOrdinal,GlobalOrdinal,Node> > tOp = rcp_dynamic_cast<const Thyra::TpetraLinearOp<Scalar,LocalOrdinal,GlobalOrdinal,Node> >(K2,true);
          RCP<Thyra::TpetraLinearOp<Scalar,LocalOrdinal,GlobalOrdinal,Node> > tOp2 = Teuchos::rcp_const_cast<Thyra::TpetraLinearOp<Scalar,LocalOrdinal,GlobalOrdinal,Node>>(tOp);
          RCP<Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > crsOp = rcp_dynamic_cast<Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> >(tOp2->getTpetraOperator(),true);
-         crsOp->resumeFill();
          crsOp->scale(dt);
-         crsOp->fillComplete(crsOp->getDomainMap(),crsOp->getRangeMap());
          diffK = Teko::explicitAdd(K, Teko::scale(-1.0,K2));
 
          writeOut("DiscreteCurl.mm",*C);

--- a/packages/teko/examples/BuildPreconditioner/example-driver-belos.cpp
+++ b/packages/teko/examples/BuildPreconditioner/example-driver-belos.cpp
@@ -130,9 +130,7 @@ int main(int argc,char * argv[])
    RCP<TP_Crs> crsMat = Tpetra::MatrixMarket::Reader<TP_Crs>::readSparseFile("../data/nsjac.mm", Tpetra::getDefaultComm());
 
    RCP<TP_Crs> zeroCrsMat = rcp(new TP_Crs(*crsMat, Teuchos::Copy));
-   zeroCrsMat->resumeFill();
    zeroCrsMat->setAllToScalar(0.0);
-   zeroCrsMat->fillComplete();
 
    RCP<TP_Op> Mat = crsMat;
    RCP<TP_Op> zeroMat = zeroCrsMat;

--- a/packages/teko/tests/src/Tpetra/tBlockedTpetraOperator.cpp
+++ b/packages/teko/tests/src/Tpetra/tBlockedTpetraOperator.cpp
@@ -236,9 +236,7 @@ bool tBlockedTpetraOperator::test_vector_constr(int verbosity,std::ostream & os)
       << "testing tolerance over many matrix vector multiplies ( " << max << " <= "
       << tolerance_ << " )");
 
-   A->resumeFill();
    A->scale(2.0); //double everything
-   A->fillComplete();
 
    ST afterNorm = A->getFrobeniusNorm();
    TEST_ASSERT(beforeNorm!=afterNorm,

--- a/packages/teko/tests/src/Tpetra/tStridedTpetraOperator.cpp
+++ b/packages/teko/tests/src/Tpetra/tStridedTpetraOperator.cpp
@@ -209,9 +209,7 @@ bool tStridedTpetraOperator::test_numvars_constr(int verbosity,std::ostream & os
       << "testing tolerance over many matrix vector multiplies ( " << max << " <= "
       << tolerance_ << " )");
 
-   A->resumeFill();
    A->scale(2.0); //double everything
-   A->fillComplete();
 
    ST afterNorm = A->getFrobeniusNorm();
    TEST_ASSERT(beforeNorm!=afterNorm,
@@ -320,9 +318,7 @@ bool tStridedTpetraOperator::test_vector_constr(int verbosity,std::ostream & os)
       << "testing tolerance over many matrix vector multiplies ( " << max << " <= "
       << tolerance_ << " )");
 
-   A->resumeFill();
    A->scale(2.0); // double everything
-   A->fillComplete();
 
    ST afterNorm = A->getFrobeniusNorm();
    TEST_ASSERT(beforeNorm!=afterNorm,

--- a/packages/teko/tests/src/tExplicitOps_tpetra.cpp
+++ b/packages/teko/tests/src/tExplicitOps_tpetra.cpp
@@ -274,14 +274,10 @@ bool tExplicitOps_tpetra::test_mult_modScaleMatProd(int verbosity,std::ostream &
 
    RCP<Thyra::TpetraLinearOp<ST,LO,GO,NT> > tF = Teuchos::rcp_dynamic_cast<Thyra::TpetraLinearOp<ST,LO,GO,NT> >(F_);
    RCP<Tpetra::CrsMatrix<ST,LO,GO,NT> > crsF = Teuchos::rcp_dynamic_cast<Tpetra::CrsMatrix<ST,LO,GO,NT> >(tF->getTpetraOperator(),true);
-   crsF->resumeFill();
    crsF->scale(5.0);
-   crsF->fillComplete();
    RCP<Thyra::TpetraLinearOp<ST,LO,GO,NT> > tG = Teuchos::rcp_dynamic_cast<Thyra::TpetraLinearOp<ST,LO,GO,NT> >(G_);
    RCP<Tpetra::CrsMatrix<ST,LO,GO,NT> > crsG = Teuchos::rcp_dynamic_cast<Tpetra::CrsMatrix<ST,LO,GO,NT> >(tG->getTpetraOperator(),true);
-   crsG->resumeFill();
    crsG->scale(2.0);
-   crsG->fillComplete();
 
    // do some random violence (oh my brothers) to one row
    size_t numEntries = crsF->getNumEntriesInLocalRow (3);
@@ -380,14 +376,10 @@ bool tExplicitOps_tpetra::test_add_mod(int verbosity,std::ostream & os)
 
    RCP<Thyra::TpetraLinearOp<ST,LO,GO,NT> > tF = Teuchos::rcp_dynamic_cast<Thyra::TpetraLinearOp<ST,LO,GO,NT> >(F_);
    RCP<Tpetra::CrsMatrix<ST,LO,GO,NT> > crsF = Teuchos::rcp_dynamic_cast<Tpetra::CrsMatrix<ST,LO,GO,NT> >(tF->getTpetraOperator(),true);
-   crsF->resumeFill();
    crsF->scale(5.0);
-   crsF->fillComplete();
    RCP<Thyra::TpetraLinearOp<ST,LO,GO,NT> > tG = Teuchos::rcp_dynamic_cast<Thyra::TpetraLinearOp<ST,LO,GO,NT> >(G_);
    RCP<Tpetra::CrsMatrix<ST,LO,GO,NT> > crsG = Teuchos::rcp_dynamic_cast<Tpetra::CrsMatrix<ST,LO,GO,NT> >(tG->getTpetraOperator(),true);
-   crsG->resumeFill();
    crsG->scale(2.0);
-   crsG->fillComplete();
 
    // do some random violence (oh my brothers) to one row
    size_t numEntries = crsF->getNumEntriesInLocalRow (3);

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -2920,10 +2920,6 @@ namespace Tpetra {
       allocateIndices (LocalIndices, verbose_);
     }
 
-    // FIXME (mfh 13 Aug 2014) What if they haven't been cleared on
-    // all processes?
-    clearGlobalConstants ();
-
     if (k_numRowEntries_.extent (0) != 0) {
       this->k_numRowEntries_(lrow) = 0;
     }

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -2441,10 +2441,6 @@ namespace Tpetra {
     ///   \|A\|_F = \sqrt{\sum_{i,j} \|A(i,j)\|^2}.
     /// \f\].
     ///
-    /// If the matrix is fill complete, then the computed value is
-    /// cached; the cache is cleared whenever resumeFill() is called.
-    /// Otherwise, the value is computed every time the method is
-    /// called.
     mag_type getFrobeniusNorm () const override;
 
     /// \brief Return \c true if getLocalRowView() and

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -3822,27 +3822,14 @@ public:
     sortAndMergeIndicesAndValues (const bool sorted,
                                   const bool merged);
 
-    /// \brief Clear matrix properties that require collectives.
-    ///
-    /// This clears whatever computeGlobalConstants() (which see)
-    /// computed, in preparation for changes to the matrix.  The
-    /// current implementation of this method does nothing.
-    ///
-    /// This method is called in resumeFill().
-    void clearGlobalConstants();
-
-    /// \brief Compute matrix properties that require collectives.
-    ///
-    /// The corresponding Epetra_CrsGraph method computes things
-    /// like the global number of nonzero entries, that require
-    /// collectives over the matrix's communicator.  The current
-    /// Tpetra implementation of this method does nothing.
-    ///
   public:
-    /// This method is called in fillComplete().
-    void computeGlobalConstants();
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+    TPETRA_DEPRECATED void computeGlobalConstants() {};
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+
     //! Returns true if globalConstants have been computed; false otherwise
     bool haveGlobalConstants() const;
+
   protected:
     /// \brief Column Map MultiVector used in apply().
     ///
@@ -4072,13 +4059,6 @@ protected:
     ///   to their owning processes.
     std::map<GlobalOrdinal, std::pair<Teuchos::Array<GlobalOrdinal>,
                                       Teuchos::Array<Scalar> > > nonlocals_;
-
-    /// \brief Cached Frobenius norm of the (global) matrix.
-    ///
-    /// The value -1 means that the norm has not yet been computed, or
-    /// that the values in the matrix may have changed and the norm
-    /// must be recomputed.
-    mutable mag_type frobNorm_ = -STM::one();
 
   public:
     // FIXME (mfh 24 Feb 2014) Is it _really_ necessary to make this a

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -635,14 +635,6 @@ namespace Tpetra {
     valuesPacked_wdv = values_wdv_type(lclMatrix.values);
     valuesUnpacked_wdv = valuesPacked_wdv;
 
-//    k_values1D_ = valuesUnpacked_wdv.getDeviceView(Access::ReadWrite);
-
-    const bool callComputeGlobalConstants = params.get () == nullptr ||
-      params->get ("compute global constants", true);
-    if (callComputeGlobalConstants) {
-      this->computeGlobalConstants ();
-    }
-
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
       (isFillActive (), std::logic_error,
        "At the end of a CrsMatrix constructor that should produce "
@@ -696,13 +688,6 @@ namespace Tpetra {
 
     valuesPacked_wdv = values_wdv_type(lclMatrix.values);
     valuesUnpacked_wdv = valuesPacked_wdv;
-//    k_values1D_ = valuesPacked_wdv.getDeviceView(Access::ReadWrite);
-
-    const bool callComputeGlobalConstants = params.get () == nullptr ||
-      params->get ("compute global constants", true);
-    if (callComputeGlobalConstants) {
-      this->computeGlobalConstants ();
-    }
 
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
       (isFillActive (), std::logic_error,
@@ -760,13 +745,6 @@ namespace Tpetra {
 
     valuesPacked_wdv = values_wdv_type(lclMatrix.values);
     valuesUnpacked_wdv = valuesPacked_wdv;
-//    k_values1D_ = valuesPacked_wdv.getDeviceView(Access::ReadWrite);
-
-    const bool callComputeGlobalConstants = params.get () == nullptr ||
-      params->get ("compute global constants", true);
-    if (callComputeGlobalConstants) {
-      this->computeGlobalConstants ();
-    }
 
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
       (isFillActive (), std::logic_error,
@@ -832,7 +810,6 @@ namespace Tpetra {
     std::swap(crs_matrix.storageStatus_, this->storageStatus_);
     std::swap(crs_matrix.fillComplete_,  this->fillComplete_);
     std::swap(crs_matrix.nonlocals_,     this->nonlocals_);
-    std::swap(crs_matrix.frobNorm_,      this->frobNorm_);
   }
 
   template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
@@ -1582,6 +1559,7 @@ namespace Tpetra {
       valuesPacked_wdv = values_wdv_type(k_vals);
     }
     else { // We don't have to pack, so just set the pointers.
+      // FIXME KDDKDD https://github.com/trilinos/Trilinos/issues/9657
       myGraph_->setRowPtrsPacked(myGraph_->rowPtrsUnpacked_dev_);
       myGraph_->lclIndsPacked_wdv = myGraph_->lclIndsUnpacked_wdv;
       valuesPacked_wdv = valuesUnpacked_wdv;
@@ -1678,10 +1656,10 @@ namespace Tpetra {
       myGraph_->k_numRowEntries_ = row_entries_type ();
 
       // Keep the new 1-D packed allocations.
+      // FIXME KDDKDD https://github.com/trilinos/Trilinos/issues/9657
       myGraph_->setRowPtrsUnpacked(myGraph_->rowPtrsPacked_dev_);
       myGraph_->lclIndsUnpacked_wdv = myGraph_->lclIndsPacked_wdv;
       valuesUnpacked_wdv = valuesPacked_wdv;
-//      k_values1D_ = valuesPacked_wdv.getDeviceView(Access::ReadWrite);
 
       myGraph_->storageStatus_ = Details::STORAGE_1D_PACKED;
       this->storageStatus_ = Details::STORAGE_1D_PACKED;
@@ -3830,13 +3808,7 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   scale (const Scalar& alpha)
   {
-    const char tfecfFuncName[] = "scale: ";
     const impl_scalar_type theAlpha = static_cast<impl_scalar_type> (alpha);
-
-    TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
-      ! isFillActive (), std::runtime_error,
-      "Fill must be active before you may call this method.  "
-      "Please call resumeFill() to make fill active.");
 
     const size_t nlrs = staticGraph_->getNodeNumRows ();
     const size_t numEntries = staticGraph_->getNodeNumEntries ();
@@ -3857,12 +3829,7 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   setAllToScalar (const Scalar& alpha)
   {
-    const char tfecfFuncName[] = "setAllToScalar: ";
     const impl_scalar_type theAlpha = static_cast<impl_scalar_type> (alpha);
-    TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
-      ! isFillActive (), std::runtime_error,
-      "Fill must be active before you may call this method.  "
-      "Please call resumeFill() to make fill active.");
 
     // replace all values in the matrix
     // it is easiest to replace all allocated values, instead of replacing only the ones with valid entries
@@ -4288,51 +4255,41 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     // this operation in the Kokkos::CrsMatrix.
 
     // check the cache first
-    mag_type frobNorm = frobNorm_;
-    if (frobNorm == -STM::one ()) {
-      mag_type mySum = STM::zero ();
-      if (getNodeNumEntries() > 0) {
-        if (isStorageOptimized ()) {
-          // "Optimized" storage is packed storage.  That means we can
-          // iterate in one pass through the 1-D values array.
-          const size_t numEntries = getNodeNumEntries ();
-          auto values = valuesPacked_wdv.getHostView(Access::ReadOnly);
+    mag_type mySum = STM::zero ();
+    if (getNodeNumEntries() > 0) {
+      if (isStorageOptimized ()) {
+        // "Optimized" storage is packed storage.  That means we can
+        // iterate in one pass through the 1-D values array.
+        const size_t numEntries = getNodeNumEntries ();
+        auto values = valuesPacked_wdv.getHostView(Access::ReadOnly);
+        for (size_t k = 0; k < numEntries; ++k) {
+          auto val = values[k];
+          // Note (etp 06 Jan 2015) We need abs() here for composite types
+          // (in general, if mag_type is on the left-hand-side, we need
+          // abs() on the right-hand-side)
+          const mag_type val_abs = STS::abs (val);
+          mySum += val_abs * val_abs;
+        }
+      }
+      else {
+        const LocalOrdinal numRows =
+          static_cast<LocalOrdinal> (this->getNodeNumRows ());
+        for (LocalOrdinal r = 0; r < numRows; ++r) {
+          const RowInfo rowInfo = myGraph_->getRowInfo (r);
+          const size_t numEntries = rowInfo.numEntries;
+          auto A_r = this->getValuesViewHost(rowInfo);
           for (size_t k = 0; k < numEntries; ++k) {
-            auto val = values[k];
-            // Note (etp 06 Jan 2015) We need abs() here for composite types
-            // (in general, if mag_type is on the left-hand-side, we need
-            // abs() on the right-hand-side)
+            const impl_scalar_type val = A_r[k];
             const mag_type val_abs = STS::abs (val);
             mySum += val_abs * val_abs;
           }
         }
-        else {
-          const LocalOrdinal numRows =
-            static_cast<LocalOrdinal> (this->getNodeNumRows ());
-          for (LocalOrdinal r = 0; r < numRows; ++r) {
-            const RowInfo rowInfo = myGraph_->getRowInfo (r);
-            const size_t numEntries = rowInfo.numEntries;
-            auto A_r = this->getValuesViewHost(rowInfo);
-            for (size_t k = 0; k < numEntries; ++k) {
-              const impl_scalar_type val = A_r[k];
-              const mag_type val_abs = STS::abs (val);
-              mySum += val_abs * val_abs;
-            }
-          }
-        }
       }
-      mag_type totalSum = STM::zero ();
-      reduceAll<int, mag_type> (* (getComm ()), REDUCE_SUM,
-                                mySum, outArg (totalSum));
-      frobNorm = STM::sqrt (totalSum);
     }
-    if (isFillComplete ()) {
-      // Only cache the result if the matrix is fill complete.
-      // Otherwise, the values might still change.  resumeFill clears
-      // the cache.
-      frobNorm_ = frobNorm;
-    }
-    return frobNorm;
+    mag_type totalSum = STM::zero ();
+    reduceAll<int, mag_type> (* (getComm ()), REDUCE_SUM,
+                              mySum, outArg (totalSum));
+    return STM::sqrt (totalSum);
   }
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
@@ -4690,22 +4647,7 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     if (! isStaticGraph ()) { // Don't resume fill of a nonowned graph.
       myGraph_->resumeFill (params);
     }
-    clearGlobalConstants ();
     fillComplete_ = false;
-  }
-
-  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-  void
-  CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-  computeGlobalConstants ()
-  {
-    // This method doesn't do anything.  The analogous method in
-    // CrsGraph does actually compute something.
-    //
-    // Oddly enough, clearGlobalConstants() clears frobNorm_ (by
-    // setting it to -1), but computeGlobalConstants() does _not_
-    // compute the Frobenius norm; this is done on demand in
-    // getFrobeniusNorm(), and the result is cached there.
   }
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
@@ -4713,21 +4655,6 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   haveGlobalConstants() const {
     return getCrsGraphRef ().haveGlobalConstants ();
-  }
-
-  template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-  void
-  CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-  clearGlobalConstants () {
-    // We use -1 to indicate that the Frobenius norm needs to be
-    // recomputed, since the values might change between now and the
-    // next fillComplete call.
-    //
-    // Oddly enough, clearGlobalConstants() clears frobNorm_, but
-    // computeGlobalConstants() does _not_ compute the Frobenius norm;
-    // this is done on demand in getFrobeniusNorm(), and the result is
-    // cached there.
-    frobNorm_ = -STM::one ();
   }
 
   template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
@@ -4912,8 +4839,8 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       const std::pair<size_t, std::string> makeIndicesLocalResult =
         this->myGraph_->makeIndicesLocal(verbose);
       // TODO (mfh 20 Jul 2017) Instead of throwing here, pass along
-      // the error state to makeImportExport or
-      // computeGlobalConstants, which may do all-reduces and thus may
+      // the error state to makeImportExport
+      // which may do all-reduces and thus may
       // have the opportunity to communicate that error state.
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
         (makeIndicesLocalResult.first != 0, std::runtime_error,
@@ -4942,17 +4869,6 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       }
       this->myGraph_->fillComplete_ = true;
       this->myGraph_->checkInternalState ();
-    }
-
-    {
-      Details::ProfilingRegion region_ccgc(
-        "Tpetra::CrsMatrix::fillCompete", "callComputeGlobalConstamnts"
-      );
-      const bool callComputeGlobalConstants = params.get () == nullptr ||
-	params->get ("compute global constants", true);
-      if (callComputeGlobalConstants) {
-	this->computeGlobalConstants ();
-      }
     }
 
     // FIXME (mfh 28 Aug 2014) "Preserve Local Graph" bool parameter no longer used.
@@ -4998,12 +4914,6 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 #endif
         // We will presume globalAssemble is not needed, so we do the ESFC on the graph
         myGraph_->expertStaticFillComplete (domainMap, rangeMap, importer, exporter,params);
-    }
-
-    const bool callComputeGlobalConstants = params.get () == nullptr ||
-      params->get ("compute global constants", true);
-    if (callComputeGlobalConstants) {
-        this->computeGlobalConstants ();
     }
 
     {

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests4.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests4.cpp
@@ -391,8 +391,6 @@ inline void tupleToArray(Array<T> &arr, const tuple &tup)
       numValid = matrix.sumIntoLocalValues (0, tuple<LO> (0), tuple<Scalar> (0));
       TEST_EQUALITY( numValid, Teuchos::OrdinalTraits<LO>::invalid () );
 
-      TEST_THROW( matrix.setAllToScalar(SZERO), std::runtime_error );
-      TEST_THROW( matrix.scale(SZERO),          std::runtime_error );
       TEST_THROW( matrix.globalAssemble(),      std::runtime_error );
       TEST_THROW( matrix.fillComplete(),        std::runtime_error );
     }

--- a/packages/tpetra/core/test/inout/MatrixMarket_Tpetra_CrsMatrix_Dist_Binary.cpp
+++ b/packages/tpetra/core/test/inout/MatrixMarket_Tpetra_CrsMatrix_Dist_Binary.cpp
@@ -133,9 +133,7 @@ public:
     // Set all values in A to one: This is needed because binary readers 
     // do not currently support numeric values
     const scalar_t ONE = Teuchos::ScalarTraits<scalar_t>::one();
-    A_baseline->resumeFill();
     A_baseline->setAllToScalar(ONE);
-    A_baseline->fillComplete(A_baseline->getDomainMap(), A_baseline->getRangeMap());
 
     nRow = A_baseline->getRowMap()->getMaxAllGlobalIndex() 
          + 1;  // Since Trilinos' reader converts one-based to zero-based

--- a/packages/xpetra/test/CrsMatrix/CrsMatrix_UnitTests.cpp
+++ b/packages/xpetra/test/CrsMatrix/CrsMatrix_UnitTests.cpp
@@ -1331,9 +1331,7 @@ namespace {
       TEST_EQUALITY(values[0], FORTY_TWO);  // changes in the view also changes matrix values
     }
 
-    A->resumeFill();
     A->setAllToScalar(-123.4);
-    A->fillComplete();
 
     {
       auto view2 = A->getLocalMatrixHost();

--- a/packages/zoltan2/test/core/TpetraCrsColorer/TpetraCrsColorer.cpp
+++ b/packages/zoltan2/test/core/TpetraCrsColorer/TpetraCrsColorer.cpp
@@ -166,9 +166,7 @@ public:
 
     // Reconstruct matrix from compression vector
     Teuchos::RCP<matrix_t> Jp = rcp(new matrix_t(*J, Teuchos::Copy));
-    Jp->resumeFill();
     Jp->setAllToScalar(static_cast<zscalar_t>(-1.));
-    Jp->fillComplete();
 
     colorer.reconstructMatrix(W, *Jp);
 


### PR DESCRIPTION

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra
@trilinos/muelu @trilinos/panzer @trilinos/teko @trilinos/xpetra @trilinos/zoltan2

Code changes to address #9640 and #9658 .



## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Removed tests for isFillActive() in scale() and setAllToScalar(), removing need for resumeFill/fillComplete around calls to these functions #9640

tpetra:  removed caching of Frobenius norm value; there was no way to guarantee that the cached value would be correct since resumeFill/fillComplete is not required to change matrix values. #9658

muelu, panzer, teko, xpetra, zoltan2:  removed resumeFill/fillComplete that are no longer needed in light of these changes.  Not calling fillComplete should reduce execution time.


## Related Issues

* Closes #9640 #9658
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 



## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Tested with clang PR test script on ascicgpu033
100% tests passed, 0 tests failed out of 1148

Subproject Time Summary:
Amesos2              =  13.00 sec*proc (8 tests)
Anasazi              =  36.96 sec*proc (12 tests)
Belos                = 198.69 sec*proc (56 tests)
Ifpack2              = 112.74 sec*proc (53 tests)
MueLu                = 975.81 sec*proc (97 tests)
NOX                  =  57.42 sec*proc (33 tests)
Panzer               =  51.81 sec*proc (27 tests)
Pike                 =   2.81 sec*proc (7 tests)
ROL                  = 3818.81 sec*proc (178 tests)
STK                  = 115.52 sec*proc (19 tests)
ShyLU_DD             = 193.98 sec*proc (70 tests)
Stokhos              = 123.49 sec*proc (51 tests)
Thyra                =  72.51 sec*proc (62 tests)
Tpetra               = 587.27 sec*proc (264 tests)
TrilinosCouplings    =  35.56 sec*proc (4 tests)
Xpetra               =  36.12 sec*proc (18 tests)
Zoltan2              = 542.74 sec*proc (189 tests)

Tested with CUDA UVM=OFF on ascicgpu033
100% tests passed, 0 tests failed out of 288

Subproject Time Summary:
Tpetra    = 6832.56 sec*proc (288 tests)


<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->