### PR TITLE
Tpetra:  reduce false alarms from test Bug7745.cpp

### DIFF
--- a/packages/tpetra/core/test/CrsMatrix/Bug7745.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/Bug7745.cpp
@@ -324,7 +324,7 @@ private:
     std::cout << me << " " << testName 
               << " YVEC alpha=" << alpha 
               << " beta=" << beta << std::endl;
-    yvec->describe(foo, Teuchos::VERB_EXTREME);
+    yvec->describe(foo, Teuchos::VERB_LOW);
   
     return checkResult(yvec, alpha, beta);
   }
@@ -346,7 +346,7 @@ private:
     std::cout << me << " " << testName 
               << " YVEC Transpose alpha=" << alpha
               << " beta=" << beta << std::endl;
-    yvec->describe(foo, Teuchos::VERB_EXTREME);
+    yvec->describe(foo, Teuchos::VERB_LOW);
   
     return checkResultTranspose(yvec, alpha, beta);
   }
@@ -373,11 +373,11 @@ private:
     std::cout << me << " " << testName 
               << " Y1 Batched alpha=" << alpha
               << " beta=" << beta << std::endl;
-    y1->describe(foo, Teuchos::VERB_EXTREME);
+    y1->describe(foo, Teuchos::VERB_LOW);
     std::cout << me << " " << testName 
               << " Y2 Batched alpha=" << alpha
               << " beta=" << beta << std::endl;
-    y2->describe(foo, Teuchos::VERB_EXTREME);
+    y2->describe(foo, Teuchos::VERB_LOW);
 
     return checkResultBatched(yvec, alpha, beta);
   }


### PR DESCRIPTION


<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The test Bug7745.cpp has more than normal false-alarm failures.  It spewed a lot of output, which would sometimes mess up the output that the Teuchos test harness seeks to determine pass/fail.
This PR reduces the amount of output produced by the test, with the hope that reducing the output will reduce the false alarms.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Tested on ascicgpu033
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->