### PR TITLE
Amesos2: disable NON_CONTIGUOUS_AND_ROOTED option for SuperLU_MT

### DIFF
--- a/packages/amesos2/src/Amesos2_Superlumt_def.hpp
+++ b/packages/amesos2/src/Amesos2_Superlumt_def.hpp
@@ -352,15 +352,8 @@ namespace Amesos2 {
               ROOTED, this->rowIndexBase_);
       }
       else {
-        #if 1
         TEUCHOS_TEST_FOR_EXCEPTION(true, std::runtime_error,
           "NON_CONTIGUOUS_AND_ROOTED not supported.");
-        #else
-        Util::get_1d_copy_helper<MultiVecAdapter<Vector>,
-          slu_type>::do_get(B, bxvals_(),
-              ldbx_,
-              NON_CONTIGUOUS_AND_ROOTED, this->rowIndexBase_);
-        #endif
       }
     }
 
@@ -438,13 +431,8 @@ namespace Amesos2 {
           MultiVecAdapter<Vector>, slu_type>::do_put(X, bxvals_(), ldbx_, ROOTED);
       }
       else {
-        #if 1
         TEUCHOS_TEST_FOR_EXCEPTION(true, std::runtime_error,
           "NON_CONTIGUOUS_AND_ROOTED not supported.");
-        #else
-        Util::put_1d_data_helper<
-          MultiVecAdapter<Vector>, slu_type>::do_put(X, bxvals_(), ldbx_, NON_CONTIGUOUS_AND_ROOTED);
-        #endif
       }
     }
 
@@ -643,15 +631,8 @@ namespace Amesos2 {
               nnz_ret, ROOTED, ARBITRARY, this->rowIndexBase_);
       }
       else {
-        #if 1
         TEUCHOS_TEST_FOR_EXCEPTION(true, std::runtime_error,
           "NON_CONTIGUOUS_AND_ROOTED not supported.");
-        #else
-        Util::get_ccs_helper<
-          MatrixAdapter<Matrix>,slu_type,int,int>::do_get(this->matrixA_.ptr(),
-              nzvals_, rowind_, colptr_,
-              nnz_ret, NON_CONTIGUOUS_AND_ROOTED, ARBITRARY, this->rowIndexBase_);
-        #endif
       }
     }
 

--- a/packages/amesos2/src/Amesos2_Superlumt_def.hpp
+++ b/packages/amesos2/src/Amesos2_Superlumt_def.hpp
@@ -352,10 +352,15 @@ namespace Amesos2 {
               ROOTED, this->rowIndexBase_);
       }
       else {
+        #if 1
+        TEUCHOS_TEST_FOR_EXCEPTION(true, std::runtime_error,
+          "NON_CONTIGUOUS_AND_ROOTED not supported.");
+        #else
         Util::get_1d_copy_helper<MultiVecAdapter<Vector>,
           slu_type>::do_get(B, bxvals_(),
               ldbx_,
               NON_CONTIGUOUS_AND_ROOTED, this->rowIndexBase_);
+        #endif
       }
     }
 
@@ -433,8 +438,13 @@ namespace Amesos2 {
           MultiVecAdapter<Vector>, slu_type>::do_put(X, bxvals_(), ldbx_, ROOTED);
       }
       else {
+        #if 1
+        TEUCHOS_TEST_FOR_EXCEPTION(true, std::runtime_error,
+          "NON_CONTIGUOUS_AND_ROOTED not supported.");
+        #else
         Util::put_1d_data_helper<
           MultiVecAdapter<Vector>, slu_type>::do_put(X, bxvals_(), ldbx_, NON_CONTIGUOUS_AND_ROOTED);
+        #endif
       }
     }
 
@@ -633,10 +643,15 @@ namespace Amesos2 {
               nnz_ret, ROOTED, ARBITRARY, this->rowIndexBase_);
       }
       else {
+        #if 1
+        TEUCHOS_TEST_FOR_EXCEPTION(true, std::runtime_error,
+          "NON_CONTIGUOUS_AND_ROOTED not supported.");
+        #else
         Util::get_ccs_helper<
           MatrixAdapter<Matrix>,slu_type,int,int>::do_get(this->matrixA_.ptr(),
               nzvals_, rowind_, colptr_,
               nnz_ret, NON_CONTIGUOUS_AND_ROOTED, ARBITRARY, this->rowIndexBase_);
+        #endif
       }
     }
 


### PR DESCRIPTION

@trilinos/amesos2 

## Motivation

This PR disables NON_CONTIGUOUS_AND_ROOTED option for SuperLU_MT interface in Amesos2. This option does not exist anywhere else in Amesos2, and this change allows me to build Amesos2 with SuperLU-MT (< version 3).

## Testing

I am running a stand-alone solver test with SuperLU on Blake.

