### PR TITLE
MueLu: Tag isolated nodes as Dirichlet

### DIFF
--- a/packages/muelu/src/Graph/MatrixTransformation/MueLu_CoalesceDropFactory_def.hpp
+++ b/packages/muelu/src/Graph/MatrixTransformation/MueLu_CoalesceDropFactory_def.hpp
@@ -635,6 +635,13 @@ namespace MueLu {
 
           columns.resize(realnnz);
           numTotal = A->getNodeNumEntries();
+
+          // If the only element remaining after filtering is diagonal, mark node as boundary
+          for (LO row = 0; row < Teuchos::as<LO>(A->getRowMap()->getNodeNumElements()); ++row) {
+            if (rows[row+1]- rows[row] <= 1)
+              boundaryNodes[row] = true;
+          }
+
           RCP<GraphBase> graph = rcp(new LWGraph(rows, columns, A->getRowMap(), A->getColMap(), "thresholded graph of A"));
           graph->SetBoundaryNodeMap(boundaryNodes);
           if (GetVerbLevel() & Statistics1) {


### PR DESCRIPTION
@trilinos/muelu 

## Motivation
When `CoalesceDrop` is dropping quite aggressively, it can happen that only the diagonal element of a row remains. In that case, this row should also be tagged as a Dirichlet boundary.