### PR TITLE
Adding flag to NOX line search solver to enable catching of exceptions thrown by linear solvers

### DIFF
--- a/packages/nox/src/NOX_Solver_LineSearchBased.H
+++ b/packages/nox/src/NOX_Solver_LineSearchBased.H
@@ -199,6 +199,9 @@ protected:
   //! Number of nonlinear iterations.
   int nIter;
 
+  //! Determine if we want to catch and ignore exceptions thrown from the linear solver stack.
+  bool catchThrowsDuringSolve;
+
   //! %Status of nonlinear solver.
   NOX::StatusTest::StatusType status;
 


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/nox @rppawlo 

## Motivation

A number of packages inside the linear/nonlinear solver stack will throw an exception if a bad state is encountered. For time-dependent simulations that we are running in drekar, it is often possible to recover from such errors by reducing the timestep size and trying again. This pull request adds a boolean option `"Catch Throws During Solve"` for the line-search based solver in NOX that will:
- Catch an exception that is thrown during the call to `solve`.
- Print out a warning containing the text string defined within the exception that is thrown.
- Mark and return a solver status of `Failed`, so that the time integrator can make adjustments as needed.

## Related Issues

* Closes rppawlo/DrekarBase#375

## Testing

Brief testing in drekar gives the expected behavior with and without the flag present. I am not sure if there is a good place to put a permanent test in NOX. Not sure if you have any suggestions @rppawlo or if you think a test is even needed here.