### PR TITLE
Re-enable TrilinosCouplings tests that were previously disabled for Cuda UVM off

### DIFF
--- a/cmake/std/PullRequestLinuxCuda10.1.105uvmOffTestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxCuda10.1.105uvmOffTestingSettings.cmake
@@ -101,8 +101,8 @@ set (ROL_example_PDE-OPT_topo-opt_poisson_example_01_MPI_4_DISABLE ON CACHE BOOL
 set (ROL_test_elementwise_TpetraMultiVector_MPI_4_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
 #set (PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-4_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
 #set (PanzerAdaptersSTK_MixedPoissonExample-ConvTest-Hex-Order-3_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
-set (TrilinosCouplings_Example_Maxwell_MueLu_MPI_1_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
-set (TrilinosCouplings_Example_Maxwell_MueLu_MPI_4_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
+# set (TrilinosCouplings_Example_Maxwell_MueLu_MPI_1_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
+# set (TrilinosCouplings_Example_Maxwell_MueLu_MPI_4_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
 
 # Disable some tests that should not need to be disabled but do because the
 # Trilinos PR tester is using too high a parallel level for ctest. (If the


### PR DESCRIPTION
Both `TrilinosCouplings_Example_Maxwell_MueLu_MPI_1` and `TrilinosCouplings_Example_Maxwell_MueLu_MPI_4` seem to be fixed already. We can re-enable them.