### PR TITLE
Update panzer Tpetra (blocked and non-blocked) ScatterResidual evaluators to handle arbitrary numbers of LIDs

### DIFF
--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterResidual_BlockedTpetra.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterResidual_BlockedTpetra.hpp
@@ -257,7 +257,10 @@ private:
   Teuchos::RCP<const BlockedTpetraLinearObjContainer<RealType,LO,GO,NodeT> > blockedContainer_;
 
   //! Local indices for unknowns
-  PHX::View<LO**> worksetLIDs_;
+  Kokkos::View<LO**, Kokkos::LayoutRight, PHX::Device> worksetLIDs_;
+
+  //! Scratch space for local values.
+  Kokkos::View<typename Sacado::ScalarType<ScalarT>::type**, Kokkos::LayoutRight, PHX::Device> workset_vals_;
 
   //! Offset into the cell lids for each field. Size of number of fields to scatter.
   std::vector<PHX::View<int*>> fieldOffsets_;

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterResidual_Tpetra_decl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterResidual_Tpetra_decl.hpp
@@ -244,7 +244,8 @@ private:
 
   ScatterResidual_Tpetra();
 
-  PHX::View<int**> scratch_lids_;
+  Kokkos::View<LO**, Kokkos::LayoutRight, PHX::Device> scratch_lids_;
+  Kokkos::View<typename Sacado::ScalarType<ScalarT>::type**, Kokkos::LayoutRight, PHX::Device> scratch_vals_;
   std::vector<PHX::View<int*> > scratch_offsets_;
 
   int my_derivative_size_;

--- a/packages/panzer/dof-mgr/src/Panzer_GlobalIndexer.hpp
+++ b/packages/panzer/dof-mgr/src/Panzer_GlobalIndexer.hpp
@@ -261,10 +261,10 @@ public:
    /** Access the local IDs for an element. The local ordering is according to
      * the <code>getOwnedAndGhostedIndices</code> method. Note
      */
-   void getElementLIDs(PHX::View<const int*> cellIds,
-                       PHX::View<panzer::LocalOrdinal**> lids) const
+   template <typename ArrayT>
+   void getElementLIDs(PHX::View<const int*> cellIds, ArrayT lids) const
    { 
-     CopyCellLIDsFunctor functor;
+     CopyCellLIDsFunctor<ArrayT> functor;
      functor.cellIds = cellIds;
      functor.global_lids = localIDs_k_;
      functor.local_lids = lids; // we assume this array is sized correctly!
@@ -283,13 +283,14 @@ public:
      */
    virtual Teuchos::RCP<const ConnManager> getConnManager() const = 0;
 
+   template <typename ArrayT>
    class CopyCellLIDsFunctor {
    public:
      typedef typename PHX::Device execution_space;
 
      PHX::View<const int*> cellIds;
      Kokkos::View<const panzer::LocalOrdinal**,Kokkos::LayoutRight,PHX::Device> global_lids;
-     PHX::View<panzer::LocalOrdinal**> local_lids;
+     ArrayT local_lids;
 
      KOKKOS_INLINE_FUNCTION
      void operator()(const int cell) const


### PR DESCRIPTION
@trilinos/panzer @rppawlo 

## Motivation

The existing implementations of the Jacobian specializations of the ScatterResidual evaluators for Tpetra in panzer make use of temporary arrays with a fixed size of 256 elements. When running problems with large numbers of equations, it is possible to exceed this limit. This pull request modifies the implementation of these evaluators to use Kokkos::Views as scratch space, in order to support arbitrary system sizes.

## Related Issues

* Closes rppawlo/DrekarBase#379

## Testing

Existing tests are passing on a serial CPU build. The performance impact on CUDA builds has not yet been evaluated.
