### PR TITLE
MueLu: Make MueLu free of Tpetra deprecated code

### DIFF
--- a/packages/muelu/test/unit_tests_kokkos/SemiCoarsenPFactory_kokkos.cpp
+++ b/packages/muelu/test/unit_tests_kokkos/SemiCoarsenPFactory_kokkos.cpp
@@ -146,7 +146,7 @@ namespace MueLuTests {
     // in this special case, the third layer will have the correct coordinates
     using impl_SC = typename Kokkos::ArithTraits<SC>::val_type;
     using impl_ATS = Kokkos::ArithTraits<impl_SC>;
-    const auto fineCoordsDiffView = fineCoordsDiff->getDeviceLocalView();
+    const auto fineCoordsDiffView = fineCoordsDiff->getDeviceLocalView(Xpetra::Access::ReadOnly);
     const int numNodes = fineCoordsDiff->getLocalLength();
     const int numVectors = fineCoordsDiff->getNumVectors();
     const auto fineMap = fineCoordsDiff->getMap()->getLocalMap();


### PR DESCRIPTION
MueLu can again be compiled with `Tpetra_ENABLE_DEPRECATED_CODE=OFF`
@trilinos/muelu

