### PR TITLE
Tempus: Make TimeStepControlIntegralController Restartable

### DIFF
--- a/packages/tempus/src/Tempus_SolutionStateMetaData_decl.hpp
+++ b/packages/tempus/src/Tempus_SolutionStateMetaData_decl.hpp
@@ -38,6 +38,8 @@ public:
     const Scalar dt,
     const Scalar errorAbs,
     const Scalar errorRel,
+    const Scalar errorRelNm1,
+    const Scalar errorRelNm2,
     const int    order,
     const int    nFailures,
     const int    nRunningFailures,
@@ -74,6 +76,8 @@ public:
     Scalar getDt()                   const {return dt_;}
     Scalar getErrorAbs()             const {return errorAbs_;}
     Scalar getErrorRel()             const {return errorRel_;}
+    Scalar getErrorRelNm1()          const {return errorRelNm1_;}
+    Scalar getErrorRelNm2()          const {return errorRelNm2_;}
     Scalar getOrder()                const {return order_;}
     int    getNFailures()            const {return nFailures_;}
     int    getNRunningFailures()     const {return nRunningFailures_;}
@@ -95,7 +99,11 @@ public:
     void setIStep(int iStep)                   {iStep_ = iStep;}
     void setDt(Scalar dt)                      {dt_ = dt;}
     void setErrorAbs (Scalar errorAbs)         {errorAbs_ = errorAbs;}
-    void setErrorRel (Scalar errorRel)         {errorRel_ = errorRel;}
+    void setErrorRel (Scalar errorRel)         {errorRelNm2_ = errorRelNm1_;
+                                                errorRelNm1_ = errorRel_;
+                                                errorRel_ = errorRel;}
+    void setErrorRelNm1 (Scalar errorRelNm1)   {errorRelNm1_ = errorRelNm1;}
+    void setErrorRelNm2 (Scalar errorRelNm2)   {errorRelNm2_ = errorRelNm2;}
     void setOrder(Scalar order)                {order_ = order;}
     void setNFailures(int nFailures)           {nFailures_ = nFailures;}
     void setNRunningFailures(int nFailures)    {nRunningFailures_ = nFailures;}
@@ -128,8 +136,10 @@ protected:
   Scalar time_;              ///< Time of solution
   int    iStep_;             ///< Time step index for this solution
   Scalar dt_;                ///< Time step for this solution
-  Scalar errorAbs_;          ///< Absolute local truncation error
-  Scalar errorRel_;          ///< Relative local truncation error
+  Scalar errorAbs_;          ///< Absolute local truncation error (@ t_n)
+  Scalar errorRel_;          ///< Relative local truncation error (@ t_n)
+  Scalar errorRelNm1_;       ///< Relative local truncation error (@ t_{n-1})
+  Scalar errorRelNm2_;       ///< Relative local truncation error (@ t_{n-2})
   Scalar order_;             ///< Order of this solution
   int nFailures_;            ///< Total number of stepper failures
   int nRunningFailures_;     ///< Total number of running stepper failures

--- a/packages/tempus/src/Tempus_SolutionStateMetaData_impl.hpp
+++ b/packages/tempus/src/Tempus_SolutionStateMetaData_impl.hpp
@@ -20,6 +20,8 @@ SolutionStateMetaData<Scalar>::SolutionStateMetaData()
    dt_            (0.0),
    errorAbs_      (0.0),
    errorRel_      (0.0),
+   errorRelNm1_   (0.0),
+   errorRelNm2_   (0.0),
    order_         (1),
    nFailures_     (0),
    nRunningFailures_(0),
@@ -45,6 +47,8 @@ SolutionStateMetaData<Scalar>::SolutionStateMetaData(
   const Scalar dt,
   const Scalar errorAbs,
   const Scalar errorRel,
+  const Scalar errorRelNm1,
+  const Scalar errorRelNm2,
   const int    order,
   const int    nFailures,
   const int    nRunningFailures,
@@ -66,6 +70,8 @@ SolutionStateMetaData<Scalar>::SolutionStateMetaData(
    dt_            (dt),
    errorAbs_      (errorAbs),
    errorRel_      (errorRel),
+   errorRelNm1_   (errorRelNm1),
+   errorRelNm2_   (errorRelNm2),
    order_         (order),
    nFailures_     (nFailures),
    nRunningFailures_(nRunningFailures),
@@ -91,6 +97,8 @@ SolutionStateMetaData<Scalar>::SolutionStateMetaData(const SolutionStateMetaData
    dt_            (ssmd.dt_),
    errorAbs_      (ssmd.errorAbs_),
    errorRel_      (ssmd.errorRel_),
+   errorRelNm1_   (ssmd.errorRelNm1_),
+   errorRelNm2_   (ssmd.errorRelNm2_),
    order_         (ssmd.order_),
    nFailures_     (ssmd.nFailures_),
    nRunningFailures_(ssmd.nRunningFailures_),
@@ -119,6 +127,8 @@ Teuchos::RCP<SolutionStateMetaData<Scalar> > SolutionStateMetaData<Scalar>::clon
       dt_,
       errorAbs_,
       errorRel_,
+      errorRelNm1_,
+      errorRelNm2_,
       order_,
       nFailures_,
       nRunningFailures_,
@@ -149,6 +159,8 @@ copy(const Teuchos::RCP<const SolutionStateMetaData<Scalar> >& ssmd)
   dt_             = ssmd->dt_;
   errorAbs_       = ssmd->errorAbs_;
   errorRel_       = ssmd->errorRel_;
+  errorRelNm1_    = ssmd->errorRelNm1_;
+  errorRelNm2_    = ssmd->errorRelNm2_;
   order_          = ssmd->order_;
   nFailures_      = ssmd->nFailures_;
   nRunningFailures_= ssmd->nRunningFailures_;
@@ -193,6 +205,8 @@ void SolutionStateMetaData<Scalar>::describe(
            << "  dt             = " << dt_ << std::endl
            << "  errorAbs       = " << errorAbs_ << std::endl
            << "  errorRel       = " << errorRel_ << std::endl
+           << "  errorRelNm1    = " << errorRelNm1_ << std::endl
+           << "  errorRelNm2    = " << errorRelNm2_ << std::endl
            << "  order          = " << order_ << std::endl
            << "  nFailures      = " << nFailures_ << std::endl
            << "  nRunningFailures = " << nRunningFailures_<< std::endl

--- a/packages/tempus/src/Tempus_SolutionState_decl.hpp
+++ b/packages/tempus/src/Tempus_SolutionState_decl.hpp
@@ -134,6 +134,8 @@ public:
     virtual Scalar getTimeStep()         const {return metaData_->getDt();}
     virtual Scalar getErrorAbs()         const {return metaData_->getErrorAbs();}
     virtual Scalar getErrorRel()         const {return metaData_->getErrorRel();}
+    virtual Scalar getErrorRelNm1()      const {return metaData_->getErrorRelNm1();}
+    virtual Scalar getErrorRelNm2()      const {return metaData_->getErrorRelNm2();}
     virtual int    getOrder()            const {return metaData_->getOrder();}
     virtual int    getNFailures()        const {return metaData_->getNFailures();}
     virtual int    getNRunningFailures() const {return metaData_->getNRunningFailures();}

--- a/packages/tempus/src/Tempus_TimeStepControlStrategyIntegralController.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategyIntegralController.hpp
@@ -66,9 +66,6 @@ public:
       safetyFactor_(0.90), safetyFactorAfterReject_(0.9),
       facMax_(5.0), facMin_(0.5)
   {
-    errN_ = Scalar(1.0);
-    errNm1_ = Scalar(1.0);
-    errNm2_ = Scalar(1.0);
     facMaxINPUT_ = facMax_;
 
     this->setStrategyType("Integral Controller");
@@ -87,9 +84,6 @@ public:
       safetyFactorAfterReject_(safetyFactorAfterReject),
       facMax_(facMax), facMin_(facMin)
   {
-    errN_ = Scalar(1.0);
-    errNm1_ = Scalar(1.0);
-    errNm2_ = Scalar(1.0);
     facMaxINPUT_ = facMax_;
 
     this->setStrategyType("Integral Controller");
@@ -118,25 +112,29 @@ public:
     }
 
     RCP<SolutionState<Scalar> > workingState=solutionHistory->getWorkingState();
-    const Scalar errorRel = workingState->getErrorRel();
     Scalar beta = 1.0;
 
     // assumes the embedded solution is the low order solution
     int order = workingState->getOrder() - 1;
     Scalar dt = workingState->getTimeStep();
 
-    // update errors
-    errNm2_ = errNm1_;
-    errNm1_ = errN_;
-    errN_ = errorRel;
+    // Get the relative errors.
+    Scalar errN   = workingState->getErrorRel();
+    Scalar errNm1 = workingState->getErrorRelNm1();
+    Scalar errNm2 = workingState->getErrorRelNm2();
+
+    const Scalar numericalTol = 1.0e-14;
+    if ( errN   < numericalTol) errN   = 1.0;
+    if ( errNm1 < numericalTol) errNm1 = 1.0;
+    if ( errNm2 < numericalTol) errNm2 = 1.0;
 
     Scalar k1 = Teuchos::as<Scalar>(-KI_ / order);
     Scalar k2 = Teuchos::as<Scalar>( KP_ / order);
     Scalar k3 = Teuchos::as<Scalar>(-KD_ / order);
 
-    k1 = std::pow(errN_, k1);
-    k2 = std::pow(errNm1_, k2);
-    k3 = std::pow(errNm2_, k3);
+    k1 = std::pow(errN, k1);
+    k2 = std::pow(errNm1, k2);
+    k3 = std::pow(errNm2, k3);
 
     if (controller_ == "I")
        beta = safetyFactor_*k1;
@@ -191,9 +189,6 @@ public:
             << "  KI                                 = " << getKI()                 << std::endl
             << "  KP                                 = " << getKP()                 << std::endl
             << "  KD                                 = " << getKD()                 << std::endl
-            << "  errN_                              = " << errN_                   << std::endl
-            << "  errNm1_                            = " << errNm1_                 << std::endl
-            << "  errNm2_                            = " << errNm2_                 << std::endl
             << "  Safety Factor                      = " << getSafetyFactor()       << std::endl
             << "  Safety Factor After Step Rejection = " << getSafetyFactorAfterReject() << std::endl
             << "  Maximum Safety Factor (INPUT)      = " << facMaxINPUT_            << std::endl
@@ -274,9 +269,6 @@ private:
   Scalar KI_;                       ///< Integral gain
   Scalar KP_;                       ///< Proportional gain
   Scalar KD_;                       ///< Derivative gain
-  Scalar errN_;
-  Scalar errNm1_;
-  Scalar errNm2_;
   Scalar safetyFactor_;             ///< Safety Factor
   Scalar safetyFactorAfterReject_;  ///< Safety Factor Following Step Rejection
   Scalar facMaxINPUT_;              ///< Maximum Safety Factor from input

--- a/packages/tempus/unit_test/Tempus_UnitTest_TimeStepControlStrategyIntegralController.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_TimeStepControlStrategyIntegralController.cpp
@@ -168,12 +168,17 @@ TEUCHOS_UNIT_TEST(TimeStepControlStrategyIntegralController, setNextTimeStep)
   solutionHistory->getCurrentState()->setIndex(0);
   solutionHistory->getCurrentState()->setOrder(order);
 
+
   // Mock Integrator
 
   // -- First Time Step
   solutionHistory->initWorkingState();
   auto currentState = solutionHistory->getCurrentState();
   auto workingState = solutionHistory->getWorkingState();
+
+  TEST_FLOATING_EQUALITY(workingState->getErrorRel()   , 0.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(workingState->getErrorRelNm1(), 0.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(workingState->getErrorRelNm2(), 0.0, 1.0e-14);
 
   tsc->setNextTimeStep(solutionHistory, status);
 
@@ -193,6 +198,10 @@ TEUCHOS_UNIT_TEST(TimeStepControlStrategyIntegralController, setNextTimeStep)
   currentState = solutionHistory->getCurrentState();
   workingState = solutionHistory->getWorkingState();
   double dt = workingState->getTimeStep();
+
+  TEST_FLOATING_EQUALITY(workingState->getErrorRel()   , 0.1, 1.0e-14);
+  TEST_FLOATING_EQUALITY(workingState->getErrorRelNm1(), 0.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(workingState->getErrorRelNm2(), 0.0, 1.0e-14);
 
   tsc->setNextTimeStep(solutionHistory, status);
 
@@ -214,6 +223,10 @@ TEUCHOS_UNIT_TEST(TimeStepControlStrategyIntegralController, setNextTimeStep)
   workingState = solutionHistory->getWorkingState();
   dt = workingState->getTimeStep();
 
+  TEST_FLOATING_EQUALITY(workingState->getErrorRel()   , 0.2, 1.0e-14);
+  TEST_FLOATING_EQUALITY(workingState->getErrorRelNm1(), 0.1, 1.0e-14);
+  TEST_FLOATING_EQUALITY(workingState->getErrorRelNm2(), 0.0, 1.0e-14);
+
   tsc->setNextTimeStep(solutionHistory, status);
 
   dtNew = dt*safetyFactor*std::pow(errN,   -KI/p)
@@ -234,6 +247,10 @@ TEUCHOS_UNIT_TEST(TimeStepControlStrategyIntegralController, setNextTimeStep)
   currentState = solutionHistory->getCurrentState();
   workingState = solutionHistory->getWorkingState();
   dt = workingState->getTimeStep();
+
+  TEST_FLOATING_EQUALITY(workingState->getErrorRel()   , 0.3, 1.0e-14);
+  TEST_FLOATING_EQUALITY(workingState->getErrorRelNm1(), 0.2, 1.0e-14);
+  TEST_FLOATING_EQUALITY(workingState->getErrorRelNm2(), 0.1, 1.0e-14);
 
   tsc->setNextTimeStep(solutionHistory, status);
 


### PR DESCRIPTION
In TimeStepControlStrategyIntegralController, there was member
data (relative error norms for current timestep and the last
two timesteps) being stored that is related to the solution.
This data should be stored in SolutionStateMetaData, so that
when restart data is being written, it can be with the other
solution metadata and read back in.

Unit tests were added to cover the new functionality.


@trilinos/tempus 

## Motivation
See above.


## Related Issues

* Closes #8399


## Testing
See above.