### PR TITLE
Tempus: add default flag to delay initialization

### DIFF
--- a/packages/tempus/src/Tempus_IntegratorBasic.cpp
+++ b/packages/tempus/src/Tempus_IntegratorBasic.cpp
@@ -18,12 +18,14 @@ namespace Tempus {
 
   // Nonmember ctor
   template Teuchos::RCP<IntegratorBasic<double> > createIntegratorBasic(
-    Teuchos::RCP<Teuchos::ParameterList>        parameterList);
+    Teuchos::RCP<Teuchos::ParameterList>        parameterList,
+    bool runInitialize);
 
   // Nonmember ctor
   template Teuchos::RCP<IntegratorBasic<double> > createIntegratorBasic(
     Teuchos::RCP<Teuchos::ParameterList>        parameterList,
-    const Teuchos::RCP<Thyra::ModelEvaluator<double> >& model);
+    const Teuchos::RCP<Thyra::ModelEvaluator<double> >& model,
+    bool runInitialize);
 
   // Nonmember ctor
   template Teuchos::RCP<IntegratorBasic<double> > createIntegratorBasic(
@@ -36,7 +38,8 @@ namespace Tempus {
   // Nonmember ctor
   template Teuchos::RCP<IntegratorBasic<double> > createIntegratorBasic(
     Teuchos::RCP<Teuchos::ParameterList>                     pList,
-    std::vector<Teuchos::RCP<const Thyra::ModelEvaluator<double> > > models);
+    std::vector<Teuchos::RCP<const Thyra::ModelEvaluator<double> > > models,
+    bool runInitialize);
 
 } // namespace Tempus
 

--- a/packages/tempus/src/Tempus_IntegratorBasic_decl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorBasic_decl.hpp
@@ -216,14 +216,16 @@ protected:
 /// Nonmember constructor
 template<class Scalar>
 Teuchos::RCP<IntegratorBasic<Scalar> > createIntegratorBasic(
-  Teuchos::RCP<Teuchos::ParameterList>                pList);
+  Teuchos::RCP<Teuchos::ParameterList>                pList,
+  bool runInitialize=true);
 
 
 /// Nonmember constructor
 template<class Scalar>
 Teuchos::RCP<IntegratorBasic<Scalar> > createIntegratorBasic(
   Teuchos::RCP<Teuchos::ParameterList>                pList,
-  const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model);
+  const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model,
+  bool runInitialize=true);
 
 
 /// Nonmember constructor
@@ -242,7 +244,8 @@ Teuchos::RCP<IntegratorBasic<Scalar> > createIntegratorBasic();
 template<class Scalar>
 Teuchos::RCP<IntegratorBasic<Scalar> > createIntegratorBasic(
   Teuchos::RCP<Teuchos::ParameterList>                pList,
-  std::vector<Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > > models);
+  std::vector<Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > > models,
+  bool runInitialize=true);
 
 
 } // namespace Tempus

--- a/packages/tempus/src/Tempus_IntegratorBasic_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorBasic_impl.hpp
@@ -558,7 +558,8 @@ IntegratorBasic<Scalar>::getValidParameters() const
 // ------------------------------------------------------------------------
 template<class Scalar>
 Teuchos::RCP<IntegratorBasic<Scalar> > createIntegratorBasic(
-  Teuchos::RCP<Teuchos::ParameterList>                     tempusPL)
+  Teuchos::RCP<Teuchos::ParameterList>                     tempusPL,
+  bool runInitialize)
 {
   auto integratorName = tempusPL->get<std::string>("Integrator Name");
   auto integratorPL = Teuchos::sublist(tempusPL, integratorName, true);
@@ -591,7 +592,7 @@ Teuchos::RCP<IntegratorBasic<Scalar> > createIntegratorBasic(
   if (integratorPL->isSublist("Time Step Control")) {
     // Construct from Integrator ParameterList
     auto tscPL = Teuchos::sublist(integratorPL, "Time Step Control", true);
-    integrator->setTimeStepControl(createTimeStepControl<Scalar>(tscPL));
+    integrator->setTimeStepControl(createTimeStepControl<Scalar>(tscPL, runInitialize));
   } else {
     // Construct default TimeStepControl
     integrator->setTimeStepControl(rcp(new TimeStepControl<Scalar>()));
@@ -643,9 +644,10 @@ Teuchos::RCP<IntegratorBasic<Scalar> > createIntegratorBasic(
 template<class Scalar>
 Teuchos::RCP<IntegratorBasic<Scalar> > createIntegratorBasic(
   Teuchos::RCP<Teuchos::ParameterList>                     tempusPL,
-  const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >&      model)
+  const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >&      model,
+  bool runInitialize)
 {
-  auto integrator = createIntegratorBasic<Scalar>(tempusPL);
+  auto integrator = createIntegratorBasic<Scalar>(tempusPL, runInitialize);
   if ( model == Teuchos::null ) return integrator;
 
   Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > constModel = model;
@@ -667,7 +669,7 @@ Teuchos::RCP<IntegratorBasic<Scalar> > createIntegratorBasic(
   sh->addState(newState);
   integrator->getStepper()->setInitialConditions(sh);
 
-  integrator->initialize();
+  if(runInitialize) integrator->initialize();
 
   return integrator;
 }
@@ -704,7 +706,8 @@ Teuchos::RCP<IntegratorBasic<Scalar> > createIntegratorBasic()
 template<class Scalar>
 Teuchos::RCP<IntegratorBasic<Scalar> > createIntegratorBasic(
   Teuchos::RCP<Teuchos::ParameterList>                             tempusPL,
-  std::vector<Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > > models)
+  std::vector<Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > > models,
+  bool runInitialize)
 {
   auto integratorName = tempusPL->get<std::string>("Integrator Name");
   auto integratorPL = Teuchos::sublist(tempusPL, integratorName, true);
@@ -738,7 +741,7 @@ Teuchos::RCP<IntegratorBasic<Scalar> > createIntegratorBasic(
   if (integratorPL->isSublist("Time Step Control")) {
     // Construct from Integrator ParameterList
     auto tscPL = Teuchos::sublist(integratorPL, "Time Step Control", true);
-    integrator->setTimeStepControl(createTimeStepControl<Scalar>(tscPL));
+    integrator->setTimeStepControl(createTimeStepControl<Scalar>(tscPL, runInitialize));
   } else {
     // Construct default TimeStepControl
     integrator->setTimeStepControl(rcp(new TimeStepControl<Scalar>()));

--- a/packages/tempus/test/BDF2/Tempus_BDF2Test.cpp
+++ b/packages/tempus/test/BDF2/Tempus_BDF2Test.cpp
@@ -82,7 +82,7 @@ TEUCHOS_UNIT_TEST(BDF2, ParameterList)
   // Test constructor IntegratorBasic(model, stepperType)
   {
     RCP<Tempus::IntegratorBasic<double> > integrator =
-      Tempus::createIntegratorBasic<double>(model, "BDF2");
+      Tempus::createIntegratorBasic<double>(model, std::string("BDF2"));
 
     RCP<ParameterList> stepperPL = sublist(tempusPL, "Default Stepper", true);
     RCP<const ParameterList> defaultPL =

--- a/packages/tempus/test/BackwardEuler/Tempus_BackwardEulerTest.cpp
+++ b/packages/tempus/test/BackwardEuler/Tempus_BackwardEulerTest.cpp
@@ -83,7 +83,7 @@ TEUCHOS_UNIT_TEST(BackwardEuler, ParameterList)
   // Test constructor IntegratorBasic(model, stepperType)
   {
     RCP<Tempus::IntegratorBasic<double> > integrator =
-      Tempus::createIntegratorBasic<double>(model, "Backward Euler");
+      Tempus::createIntegratorBasic<double>(model, std::string("Backward Euler"));
 
     RCP<ParameterList> stepperPL = sublist(tempusPL, "Default Stepper", true);
     // Match Predictor for comparison

--- a/packages/tempus/test/ExplicitRK/Tempus_ExplicitRKTest.cpp
+++ b/packages/tempus/test/ExplicitRK/Tempus_ExplicitRKTest.cpp
@@ -80,10 +80,20 @@ TEUCHOS_UNIT_TEST(ExplicitRK, ParameterList)
       tempusPL->sublist("Demo Stepper").set("Stepper Type", RKMethods[m]);
     }
 
-    // Test constructor IntegratorBasic(tempusPL, model)
+    // Test constructor IntegratorBasic(tempusPL, model, runInitialize)
     {
       RCP<Tempus::IntegratorBasic<double> > integrator =
-        Tempus::createIntegratorBasic<double>(tempusPL, model);
+        Tempus::createIntegratorBasic<double>(tempusPL, model,false);
+
+      // check initialization
+      {
+        // TSC should not be initialized
+        TEST_ASSERT(!integrator->getNonConstTimeStepControl()->isInitialized());
+        // now initialize everything (TSC should also be initilized)
+        integrator->initialize();
+        // TSC should be initialized
+        TEST_ASSERT(integrator->getNonConstTimeStepControl()->isInitialized());
+      }
 
       RCP<ParameterList> stepperPL = sublist(tempusPL, "Demo Stepper", true);
       if (RKMethods[m] == "General ERK")

--- a/packages/tempus/test/ForwardEuler/Tempus_ForwardEulerTest.cpp
+++ b/packages/tempus/test/ForwardEuler/Tempus_ForwardEulerTest.cpp
@@ -77,7 +77,7 @@ TEUCHOS_UNIT_TEST(ForwardEuler, ParameterList)
   // Test constructor IntegratorBasic(model, stepperType)
   {
     RCP<Tempus::IntegratorBasic<double> > integrator =
-      Tempus::createIntegratorBasic<double>(model, "Forward Euler");
+      Tempus::createIntegratorBasic<double>(model, std::string("Forward Euler"));
 
     RCP<ParameterList> stepperPL = sublist(tempusPL, "Demo Stepper", true);
     RCP<const ParameterList> defaultPL =

--- a/packages/tempus/test/Subcycling/Tempus_SubcyclingTest.cpp
+++ b/packages/tempus/test/Subcycling/Tempus_SubcyclingTest.cpp
@@ -85,7 +85,7 @@ TEUCHOS_UNIT_TEST(Subcycling, ParameterList)
   // Test constructor IntegratorBasic(model, stepperType)
   {
     RCP<Tempus::IntegratorBasic<double> > integrator =
-      Tempus::createIntegratorBasic<double>(model, "Forward Euler");
+      Tempus::createIntegratorBasic<double>(model, std::string("Forward Euler"));
 
     RCP<ParameterList> stepperPL = sublist(tempusPL, "Demo Stepper", true);
     RCP<const ParameterList> defaultPL =

--- a/packages/tempus/test/Trapezoidal/Tempus_TrapezoidalTest.cpp
+++ b/packages/tempus/test/Trapezoidal/Tempus_TrapezoidalTest.cpp
@@ -82,7 +82,7 @@ TEUCHOS_UNIT_TEST(Trapezoidal, ParameterList)
   // Test constructor IntegratorBasic(model, stepperType)
   {
     RCP<Tempus::IntegratorBasic<double> > integrator =
-      Tempus::createIntegratorBasic<double>(model, "Trapezoidal Method");
+      Tempus::createIntegratorBasic<double>(model, std::string("Trapezoidal Method"));
 
     RCP<ParameterList> stepperPL = sublist(tempusPL, "Default Stepper", true);
     RCP<const ParameterList> defaultPL =


### PR DESCRIPTION
Edge case: when app is only using its own TSCS in a composite, TSC
fails initialization because the app has not had the chance to add its
TSCS to the compose vector yet. So this `runInitialize` (default: true)
allow the app to delay the initialization until it has populated the
composite vector and explicitly calls the initialization.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tempus 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

In Drekar when only using `TimeScale` TSCS, Tempus tries initializing TSC but the vector size is zero since Drekar has not had the chance to add the App's own TSCS. This is not the case if the `Time Step Control Strategy List` contains at least one TSCS that Tempus can add to the composite vector. But if all the strategies are unique to the App, the composite vector size is zero and fails the assertion and the initialization.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->