### PR TITLE
Fix RCP initialization in NOX thyra group to avoid null pointer dereference

### DIFF
--- a/packages/nox/src-thyra/NOX_Thyra_Group.C
+++ b/packages/nox/src-thyra/NOX_Thyra_Group.C
@@ -244,7 +244,7 @@ NOX::Thyra::Group::Group(const NOX::Thyra::Group& source, NOX::CopyType type) :
   if (nonnull(source.weight_vec_))
     weight_vec_ = source.weight_vec_;
 
-  if (nonnull(source.right_weight_vec_) && (type == NOX::DeepCopy))
+  if (nonnull(source.right_weight_vec_))
     scaled_x_vec_ = Teuchos::rcp(new NOX::Thyra::Vector(*source.scaled_x_vec_, type));
 
   in_args_ = model_->createInArgs();


### PR DESCRIPTION

@trilinos/nox @rppawlo 

## Motivation

Certain tests in drekar have run into an issue when right scaling weights are used that results in a null pointer dereference and segfault. This has been traced back to `scaled_x_vec_` not being initialized in all cases. This pull request resolves the issue by making sure `scaled_x_vec_` gets allocated whenever `right_weight_vec_` is not null.

## Related Issues

* Closes rppawlo/DrekarBase#583
