### PR TITLE
Framework: Update the stale bot to use v4.x

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,7 +20,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v3
+    - uses: actions/stale@v4
       with:
         debug-only: false
         ascending: true


### PR DESCRIPTION
@trilinos/framework 

## Motivation
The stale issue/pr actions bot has updated to v4.x

This PR updates the version number of the bot to the 4.x branch.