### PR TITLE
Xpetra: Epetra changes

### DIFF
--- a/packages/xpetra/src/BlockedMultiVector/Xpetra_BlockedMultiVector_decl.hpp
+++ b/packages/xpetra/src/BlockedMultiVector/Xpetra_BlockedMultiVector_decl.hpp
@@ -322,9 +322,14 @@ namespace Xpetra {
 
     virtual void randomize(bool bUseXpetraImplementation = false);
 
+    virtual void randomize(const Scalar& minVal, const Scalar& maxVal, bool bUseXpetraImplementation = false);
+
 
     //! Set multi-vector values to random numbers. XPetra implementation
     virtual void Xpetra_randomize();
+
+    //! Set multi-vector values to random numbers. XPetra implementation
+    virtual void Xpetra_randomize(const Scalar& minVal, const Scalar& maxVal);
 
 
     //@}

--- a/packages/xpetra/src/BlockedMultiVector/Xpetra_BlockedMultiVector_def.hpp
+++ b/packages/xpetra/src/BlockedMultiVector/Xpetra_BlockedMultiVector_def.hpp
@@ -824,9 +824,30 @@ randomize(bool bUseXpetraImplementation)
 template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void
 BlockedMultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
+randomize(const Scalar& minVal, const Scalar& maxVal, bool bUseXpetraImplementation)
+{
+    for(size_t r = 0; r < map_->getNumMaps(); ++r)
+    {
+      getMultiVector(r)->randomize(minVal, maxVal, bUseXpetraImplementation);
+    }
+}
+
+
+template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+void
+BlockedMultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 Xpetra_randomize()
 {
     Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Xpetra_randomize();
+}
+
+
+template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+void
+BlockedMultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
+Xpetra_randomize(const Scalar& minVal, const Scalar& maxVal)
+{
+    Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Xpetra_randomize(minVal, maxVal);
 }
 
 

--- a/packages/xpetra/src/BlockedVector/Xpetra_BlockedVector_decl.hpp
+++ b/packages/xpetra/src/BlockedVector/Xpetra_BlockedVector_decl.hpp
@@ -363,8 +363,13 @@ class BlockedVector
 
     virtual void randomize(bool bUseXpetraImplementation = false);
 
+    virtual void randomize(const Scalar& minVal, const Scalar& maxVal, bool bUseXpetraImplementation = false);
+
     //! Set vector values to random numbers. XPetra implementation
     virtual void Xpetra_randomize();
+
+    //! Set vector values to random numbers. XPetra implementation
+    virtual void Xpetra_randomize(const Scalar& minVal, const Scalar& maxVal);
 
     //@}
 

--- a/packages/xpetra/src/BlockedVector/Xpetra_BlockedVector_def.hpp
+++ b/packages/xpetra/src/BlockedVector/Xpetra_BlockedVector_def.hpp
@@ -591,10 +591,33 @@ randomize(bool bUseXpetraImplementation)
 template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void
 BlockedVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
+randomize(const Scalar& minVal, const Scalar& maxVal, bool bUseXpetraImplementation)
+{
+    for(size_t r = 0; r < this->getBlockedMap()->getNumMaps(); ++r)
+    {
+        getMultiVector(r)->randomize(minVal, maxVal, bUseXpetraImplementation);
+    }
+}
+
+
+template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+void
+BlockedVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 Xpetra_randomize()
 {
     {
         Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Xpetra_randomize();
+    }
+}
+
+
+template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+void
+BlockedVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
+Xpetra_randomize(const Scalar& minVal, const Scalar& maxVal)
+{
+    {
+        Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Xpetra_randomize(minVal, maxVal);
     }
 }
 

--- a/packages/xpetra/src/CrsMatrix/Xpetra_EpetraCrsMatrix.hpp
+++ b/packages/xpetra/src/CrsMatrix/Xpetra_EpetraCrsMatrix.hpp
@@ -1292,12 +1292,35 @@ typename local_matrix_type::HostMirror getLocalMatrixHost () const {
     return localMatrix_;
   }
 
-  void setAllValues (const typename local_matrix_type::row_map_type& /* ptr */,
-                     const typename local_matrix_type::StaticCrsGraphType::entries_type::non_const_type& /* ind */,
-                     const typename local_matrix_type::values_type& /* val */)
+  void setAllValues (const typename local_matrix_type::row_map_type& ptr,
+                     const typename local_matrix_type::StaticCrsGraphType::entries_type::non_const_type& ind,
+                     const typename local_matrix_type::values_type& val)
   {
-    TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::RuntimeError,
-                               "Xpetra::EpetraCrsMatrix::setAllValues is not implemented");
+
+    // Check sizes
+    TEUCHOS_TEST_FOR_EXCEPTION(Teuchos::as<size_t>(ptr.size()) != getNodeNumRows()+1, Xpetra::Exceptions::RuntimeError,
+                               "An exception is thrown to let you know that the size of your rowptr array is incorrect.");
+    TEUCHOS_TEST_FOR_EXCEPTION(val.size() != ind.size(), Xpetra::Exceptions::RuntimeError,
+                               "An exception is thrown to let you know that you mismatched your pointers.");
+
+    // Check pointers
+    if (val.size() > 0) {
+      std::cout << ind.data() << " " << mtx_->ExpertExtractIndices().Values() << std::endl;
+      TEUCHOS_TEST_FOR_EXCEPTION(ind.data() != mtx_->ExpertExtractIndices().Values(), Xpetra::Exceptions::RuntimeError,
+                                 "An exception is thrown to let you know that you mismatched your pointers.");
+      TEUCHOS_TEST_FOR_EXCEPTION(val.data() != mtx_->ExpertExtractValues(), Xpetra::Exceptions::RuntimeError,
+                                 "An exception is thrown to let you know that you mismatched your pointers.");
+    }
+
+    // We have to make a copy here, it is unavoidable
+    // See comments in allocateAllValues
+    const size_t N = getNodeNumRows();
+
+    Epetra_IntSerialDenseVector& myRowptr = mtx_->ExpertExtractIndexOffset();
+    myRowptr.Resize(N+1);
+    for (size_t i = 0; i < N+1; i++)
+      myRowptr[i] = Teuchos::as<int>(ptr(i));
+
   }
 
 
@@ -2322,12 +2345,34 @@ public:
     return localMatrix_;
   }
 
-  void setAllValues (const typename local_matrix_type::row_map_type& /* ptr */,
-                     const typename local_matrix_type::StaticCrsGraphType::entries_type::non_const_type& /* ind */,
-                     const typename local_matrix_type::values_type& /* val */)
+  void setAllValues (const typename local_matrix_type::row_map_type& ptr,
+                     const typename local_matrix_type::StaticCrsGraphType::entries_type::non_const_type& ind,
+                     const typename local_matrix_type::values_type& val)
   {
-    TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::RuntimeError,
-                               "Xpetra::EpetraCrsMatrix::setAllValues is not implemented");
+
+    // Check sizes
+    TEUCHOS_TEST_FOR_EXCEPTION(Teuchos::as<size_t>(ptr.size()) != getNodeNumRows()+1, Xpetra::Exceptions::RuntimeError,
+                               "An exception is thrown to let you know that the size of your rowptr array is incorrect.");
+    TEUCHOS_TEST_FOR_EXCEPTION(val.size() != ind.size(), Xpetra::Exceptions::RuntimeError,
+                               "An exception is thrown to let you know that you mismatched your pointers.");
+
+    // Check pointers
+    if (val.size() > 0) {
+      TEUCHOS_TEST_FOR_EXCEPTION(ind.data() != mtx_->ExpertExtractIndices().Values(), Xpetra::Exceptions::RuntimeError,
+                                 "An exception is thrown to let you know that you mismatched your pointers.");
+      TEUCHOS_TEST_FOR_EXCEPTION(val.data() != mtx_->ExpertExtractValues(), Xpetra::Exceptions::RuntimeError,
+                                 "An exception is thrown to let you know that you mismatched your pointers.");
+    }
+
+    // We have to make a copy here, it is unavoidable
+    // See comments in allocateAllValues
+    const size_t N = getNodeNumRows();
+
+    Epetra_IntSerialDenseVector& myRowptr = mtx_->ExpertExtractIndexOffset();
+    myRowptr.Resize(N+1);
+    for (size_t i = 0; i < N+1; i++)
+      myRowptr[i] = Teuchos::as<int>(ptr(i));
+
   }
 
  

--- a/packages/xpetra/src/MultiVector/Xpetra_EpetraIntMultiVector.hpp
+++ b/packages/xpetra/src/MultiVector/Xpetra_EpetraIntMultiVector.hpp
@@ -112,6 +112,8 @@ const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal
     //! Set multi-vector values to random numbers.
     void randomize(bool bUseXpetraImplementation = true) { XPETRA_MONITOR("EpetraIntMultiVectorT::randomize"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraIntMultiVectorT::randomize(): Functionnality not available in Epetra"); }
 
+    //! Set multi-vector values to random numbers.
+    void randomize(const Scalar& minVal, const Scalar& maxVal, bool bUseXpetraImplementation = true) { XPETRA_MONITOR("EpetraIntMultiVectorT::randomize"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraIntMultiVectorT::randomize(): Functionnality not available in Epetra"); }
 
     //! Set seed for Random function.
     /** Note: this method does not exist in Tpetra interface. Added for MueLu. */
@@ -399,6 +401,9 @@ const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal
 
       //! Set multi-vector values to random numbers.
       void randomize(bool /* bUseXpetraImplementation */ = true) { XPETRA_MONITOR("EpetraIntMultiVectorT::randomize"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraIntMultiVectorT::randomize(): Functionnality not available in Epetra"); }
+
+      //! Set multi-vector values to random numbers.
+      void randomize(const Scalar& minVal, const Scalar& maxVal, bool bUseXpetraImplementation = true) { XPETRA_MONITOR("EpetraIntMultiVectorT::randomize"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraIntMultiVectorT::randomize(): Functionnality not available in Epetra"); }
 
 
       //! Set seed for Random function.
@@ -785,6 +790,9 @@ const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal
 
       //! Set multi-vector values to random numbers.
       void randomize(bool /* bUseXpetraImplementation */ = true) { XPETRA_MONITOR("EpetraIntMultiVectorT::randomize"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraIntMultiVectorT::randomize(): Functionnality not available in Epetra"); }
+
+      //! Set multi-vector values to random numbers.
+      void randomize(const Scalar& minVal, const Scalar& maxVal, bool bUseXpetraImplementation = true) { XPETRA_MONITOR("EpetraIntMultiVectorT::randomize"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraIntMultiVectorT::randomize(): Functionnality not available in Epetra"); }
 
 
       //! Set seed for Random function.

--- a/packages/xpetra/src/MultiVector/Xpetra_EpetraMultiVector.hpp
+++ b/packages/xpetra/src/MultiVector/Xpetra_EpetraMultiVector.hpp
@@ -241,6 +241,9 @@ namespace Xpetra {
     //! Set multi-vector values to random numbers.
     void randomize(bool bUseXpetraImplementation = false) { }
 
+    //! Set multi-vector values to random numbers.
+    void randomize(const Scalar& minVal, const Scalar& maxVal, bool bUseXpetraImplementation = false) { }
+
     //! Implements DistObject interface
     //{@
 
@@ -522,6 +525,28 @@ namespace Xpetra {
         Xpetra::MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node >::Xpetra_randomize();
       else
         vec_->Random();
+    }
+
+    //! Set multi-vector values to random numbers.
+    void randomize(const Scalar& minVal, const Scalar& maxVal, bool bUseXpetraImplementation = false) {
+      XPETRA_MONITOR("EpetraMultiVectorT::randomize");
+
+      if (bUseXpetraImplementation)
+        Xpetra::MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node >::Xpetra_randomize(minVal, maxVal);
+      else {
+        vec_->Random();
+        const size_t numVectors = getNumVectors();
+        for(size_t i = 0; i < numVectors; i++)
+          {
+            Teuchos::ArrayRCP<Scalar> datai = getDataNonConst(i);
+
+            const size_t myLength = getLocalLength();
+            for(size_t j = 0; j < myLength; j++)
+              {
+                datai[ j ] = 0.5*(maxVal-minVal)*datai[ j ]+0.5*(maxVal+minVal);
+              }
+          }
+      }
     }
 
     //! Implements DistObject interface
@@ -923,6 +948,28 @@ namespace Xpetra {
         Xpetra::MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node >::Xpetra_randomize();
       else
         vec_->Random();
+    }
+
+    //! Set multi-vector values to random numbers.
+    void randomize(const Scalar& minVal, const Scalar& maxVal, bool bUseXpetraImplementation = false) {
+      XPETRA_MONITOR("EpetraMultiVectorT::randomize");
+
+      if (bUseXpetraImplementation)
+        Xpetra::MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node >::Xpetra_randomize(minVal, maxVal);
+      else {
+        vec_->Random();
+        const size_t numVectors = getNumVectors();
+        for(size_t i = 0; i < numVectors; i++)
+          {
+            Teuchos::ArrayRCP<Scalar> datai = getDataNonConst(i);
+
+            const size_t myLength = getLocalLength();
+            for(size_t j = 0; j < myLength; j++)
+              {
+                datai[ j ] = 0.5*(maxVal-minVal)*datai[ j ]+0.5*(maxVal+minVal);
+              }
+          }
+      }
     }
 
     //! Implements DistObject interface

--- a/packages/xpetra/src/MultiVector/Xpetra_EpetraMultiVector.hpp
+++ b/packages/xpetra/src/MultiVector/Xpetra_EpetraMultiVector.hpp
@@ -670,13 +670,7 @@ namespace Xpetra {
       return ret;
     }
 
-    typename dual_view_type::t_dev_um getDeviceLocalView(Access::ReadWriteStruct) const override {
-      throw std::runtime_error("Epetra does not support device views! in "+std::string(__FILE__)+":"+std::to_string(__LINE__));
-#ifndef __NVCC__ //prevent nvcc warning
-      typename dual_view_type::t_dev_um ret;
-#endif
-      TEUCHOS_UNREACHABLE_RETURN(ret);
-    }
+    typename dual_view_type::t_dev_um getDeviceLocalView(Access::ReadWriteStruct) const override { return getHostLocalView(Access::ReadWrite); }
 
 #endif
 

--- a/packages/xpetra/src/MultiVector/Xpetra_MultiVector_decl.hpp
+++ b/packages/xpetra/src/MultiVector/Xpetra_MultiVector_decl.hpp
@@ -303,9 +303,14 @@ class MultiVector
     //! Set multi-vector values to random numbers.
     virtual void randomize(bool bUseXpetraImplementation = false) = 0;
 
+    //! Set multi-vector values to random numbers.
+    virtual void randomize(const Scalar& minVal, const Scalar& maxVal, bool bUseXpetraImplementation = false) = 0;
 
     //! Set multi-vector values to random numbers. XPetra implementation
     virtual void Xpetra_randomize();
+
+    //! Set multi-vector values to random numbers. XPetra implementation
+    virtual void Xpetra_randomize(const Scalar& minVal, const Scalar& maxVal);
 
 
 #ifdef HAVE_XPETRA_KOKKOS_REFACTOR

--- a/packages/xpetra/src/MultiVector/Xpetra_MultiVector_def.hpp
+++ b/packages/xpetra/src/MultiVector/Xpetra_MultiVector_def.hpp
@@ -89,6 +89,26 @@ Xpetra_randomize()
     }
 }
 
+template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+void
+MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
+Xpetra_randomize(const Scalar& minVal, const Scalar& maxVal)
+{
+    typedef Teuchos::ScalarTraits<Scalar> SCT;
+
+    const size_t numVectors = getNumVectors();
+    for(size_t i = 0; i < numVectors; i++)
+    {
+        Teuchos::ArrayRCP<Scalar> datai = getDataNonConst(i);
+
+        const size_t myLength = getLocalLength();
+        for(size_t j = 0; j < myLength; j++)
+        {
+          datai[ j ] = 0.5*(maxVal-minVal)*SCT::random()+0.5*(maxVal+minVal);
+        }
+    }
+}
+
 
 }      // namespace Xpetra
 

--- a/packages/xpetra/src/MultiVector/Xpetra_TpetraMultiVector_decl.hpp
+++ b/packages/xpetra/src/MultiVector/Xpetra_TpetraMultiVector_decl.hpp
@@ -248,6 +248,8 @@ namespace Xpetra {
     //! Set multi-vector values to random numbers.
     void randomize(bool bUseXpetraImplementation = false);
 
+    void randomize(const Scalar& minVal, const Scalar& maxVal, bool bUseXpetraImplementation = false);
+
     //{@
     // Implements DistObject interface
 

--- a/packages/xpetra/src/MultiVector/Xpetra_TpetraMultiVector_def.hpp
+++ b/packages/xpetra/src/MultiVector/Xpetra_TpetraMultiVector_def.hpp
@@ -295,6 +295,18 @@ namespace Xpetra {
       vec_->randomize();
   }
 
+  //! Set multi-vector values to random numbers.
+  template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+  void TpetraMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>::
+  randomize(const Scalar& minVal, const Scalar& maxVal, bool bUseXpetraImplementation) {
+    XPETRA_MONITOR("TpetraMultiVector::randomize");
+
+    if(bUseXpetraImplementation)
+      MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node >::Xpetra_randomize(minVal, maxVal);
+    else
+      vec_->randomize(minVal, maxVal);
+  }
+
   template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   Teuchos::RCP< const Map<LocalOrdinal,GlobalOrdinal,Node> > 
   TpetraMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>::    
@@ -730,6 +742,9 @@ namespace Xpetra {
     //! Set multi-vector values to random numbers.
     void randomize(bool bUseXpetraImplementation = false) { }
 
+    //! Set multi-vector values to random numbers.
+    void randomize(const Scalar& minVal, const Scalar& maxVal, bool bUseXpetraImplementation = false) { }
+
     //{@
     // Implements DistObject interface
 
@@ -969,6 +984,9 @@ namespace Xpetra {
 
     //! Set multi-vector values to random numbers.
     void randomize(bool bUseXpetraImplementation = false) { }
+
+    //! Set multi-vector values to random numbers.
+    void randomize(const Scalar& minVal, const Scalar& maxVal, bool bUseXpetraImplementation = false) { }
 
     //{@
     // Implements DistObject interface

--- a/packages/xpetra/src/Vector/Xpetra_EpetraIntVector.hpp
+++ b/packages/xpetra/src/Vector/Xpetra_EpetraIntVector.hpp
@@ -136,6 +136,9 @@ const Epetra_IntVector & toEpetra(const Vector<int, int, GlobalOrdinal, Node> &)
     //! Set multi-vector values to random numbers.
     void randomize(bool bUseXpetraImplementation = true) { XPETRA_MONITOR("EpetraIntVectorT::randomize"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraIntVectorT::randomize(): Functionnality not available in Epetra"); }
 
+    //! Set multi-vector values to random numbers.
+    void randomize(const Scalar& /*minVal*/, const Scalar& /*maxVal*/, bool bUseXpetraImplementation = true) { XPETRA_MONITOR("EpetraIntVectorT::randomize"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraIntVectorT::randomize(): Functionnality not available in Epetra"); }
+
 
     //! Set seed for Random function.
     /** Note: this method does not exist in Tpetra interface. Added for MueLu. */
@@ -393,6 +396,8 @@ const Epetra_IntVector & toEpetra(const Vector<int, int, GlobalOrdinal, Node> &)
       //! Set multi-vector values to random numbers.
       void randomize(bool /* bUseXpetraImplementation */ = true) { XPETRA_MONITOR("EpetraIntVectorT::randomize"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraIntVectorT::randomize(): Functionnality not available in Epetra"); }
 
+      //! Set multi-vector values to random numbers.
+      void randomize(const Scalar& /*minVal*/, const Scalar& /*maxVal*/, bool /* bUseXpetraImplementation */ = true) { XPETRA_MONITOR("EpetraIntVectorT::randomize"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraIntVectorT::randomize(): Functionnality not available in Epetra"); }
 
       //! Set seed for Random function.
       /** Note: this method does not exist in Tpetra interface. Added for MueLu. */
@@ -775,6 +780,8 @@ const Epetra_IntVector & toEpetra(const Vector<int, int, GlobalOrdinal, Node> &)
       //! Set multi-vector values to random numbers.
       void randomize(bool /* bUseXpetraImplementation */ = true) { XPETRA_MONITOR("EpetraIntVectorT::randomize"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraIntVectorT::randomize(): Functionnality not available in Epetra"); }
 
+      //! Set multi-vector values to random numbers.
+      void randomize(const Scalar& /*minVal*/, const Scalar& /*maxVal*/, bool /* bUseXpetraImplementation */ = true) { XPETRA_MONITOR("EpetraIntVectorT::randomize"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraIntVectorT::randomize(): Functionnality not available in Epetra"); }
 
       //! Set seed for Random function.
       /** Note: this method does not exist in Tpetra interface. Added for MueLu. */

--- a/packages/xpetra/test/CrsMatrix/CrsMatrix_UnitTests.cpp
+++ b/packages/xpetra/test/CrsMatrix/CrsMatrix_UnitTests.cpp
@@ -1294,7 +1294,13 @@ namespace {
       
       // check that the local_matrix_type taken the second time is the same
       auto view3 = A->getLocalMatrixHost();
-      TEST_EQUALITY(view2.graph.row_map.data(), view3.graph.row_map.data());
+      // The row pointer is only identical for Tpetra. For Epetra, the
+      // rowptr has a different type than what the local matrix wants,
+      // so we are copying to a new Kokkos view..
+      if (map->lib() == Xpetra::UseTpetra)
+        TEST_EQUALITY(view2.graph.row_map.data(), view3.graph.row_map.data());
+      TEST_EQUALITY(view2.graph.entries.data(), view3.graph.entries.data());
+      TEST_EQUALITY(view2.values.data(), view3.values.data());
 
       for (LO r = 0; r < view2.numRows(); ++r) {
 	// extract data from current row r


### PR DESCRIPTION
@trilinos/xpetra 

## Motivation
- Add `randomize` method with limits to Xpetra's MV.
- Don't throw from `Xpetra::EpetraMultiVectorT::getDeviceLocalView`, but return a host view, add `setAllValues`.
- `EpetraCrsMatrixT` was caching its local matrix, since the rowptr had the wrong type and hence needed to be converted. I ran into some issue where the cache wasn't invalidated on reuse, so I removed the caching entirely.