### PR TITLE
KokkosKernels: Fix #9155: spgemm on ampere

### DIFF
--- a/packages/kokkos-kernels/src/common/KokkosKernels_HashmapAccumulator.hpp
+++ b/packages/kokkos-kernels/src/common/KokkosKernels_HashmapAccumulator.hpp
@@ -495,8 +495,8 @@ struct HashmapAccumulator
       keys[my_write_index] = key;
       values[my_write_index] = value;
 
-      #if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_VOLTA70) || defined(KOKKOS_ARCH_VOLTA72)
-      //this is an issue on VOLTA because warps do not go in SIMD fashion anymore.
+      #if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || defined(KOKKOS_ARCH_AMPERE)
+      //this is an issue on VOLTA and up because warps do not go in SIMD fashion anymore.
       //while some thread might insert my_write_index into linked list, another
       //thread in the warp might be reading keys in above loop.
       //before inserting the new value in liked list -- which is done with atomic exchange below,
@@ -572,8 +572,8 @@ struct HashmapAccumulator
       keys[my_write_index] = key;
       values[my_write_index] = value;
 
-      #if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_VOLTA70) || defined(KOKKOS_ARCH_VOLTA72)
-      //this is an issue on VOLTA because warps do not go in SIMD fashion anymore.
+      #if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || defined(KOKKOS_ARCH_AMPERE)
+      //this is an issue on VOLTA and up because warps do not go in SIMD fashion anymore.
       //while some thread might insert my_write_index into linked list, another
       //thread in the warp might be reading keys in above loop.
       //before inserting the new value in liked list -- which is done with atomic exchange below,
@@ -659,8 +659,8 @@ struct HashmapAccumulator
 
       keys[my_write_index] = key;
 
-      #if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_VOLTA70) || defined(KOKKOS_ARCH_VOLTA72)
-      //this is an issue on VOLTA because warps do not go in SIMD fashion anymore.
+      #if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || defined(KOKKOS_ARCH_AMPERE)
+      //this is an issue on VOLTA and up because warps do not go in SIMD fashion anymore.
       //while some thread might insert my_write_index into linked list, another
       //thread in the warp might be reading keys in above loop.
       //before inserting the new value in liked list -- which is done with atomic exchange below,
@@ -714,8 +714,8 @@ struct HashmapAccumulator
       keys[my_write_index] = key;
       values[my_write_index] = value;
 
-      #if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_VOLTA70) || defined(KOKKOS_ARCH_VOLTA72)
-      //this is an issue on VOLTA because warps do not go in SIMD fashion anymore.
+      #if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || defined(KOKKOS_ARCH_AMPERE)
+      //this is an issue on VOLTA and up because warps do not go in SIMD fashion anymore.
       //while some thread might insert my_write_index into linked list, another
       //thread in the warp might be reading keys in above loop.
       //before inserting the new value in liked list -- which is done with atomic exchange below,
@@ -771,8 +771,8 @@ struct HashmapAccumulator
       keys[my_write_index] = key;
       values[my_write_index] = value;
 
-      #if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_VOLTA70) || defined(KOKKOS_ARCH_VOLTA72)
-      //this is an issue on VOLTA because warps do not go in SIMD fashion anymore.
+      #if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || defined(KOKKOS_ARCH_AMPERE)
+      //this is an issue on VOLTA and up because warps do not go in SIMD fashion anymore.
       //while some thread might insert my_write_index into linked list, another
       //thread in the warp might be reading keys in above loop.
       //before inserting the new value in liked list -- which is done with atomic exchange below,
@@ -822,8 +822,8 @@ struct HashmapAccumulator
 
       keys[my_write_index] = key;
 
-      #if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_VOLTA70) || defined(KOKKOS_ARCH_VOLTA72)
-      //this is an issue on VOLTA because warps do not go in SIMD fashion anymore.
+      #if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || defined(KOKKOS_ARCH_AMPERE)
+      //this is an issue on VOLTA and up because warps do not go in SIMD fashion anymore.
       //while some thread might insert my_write_index into linked list, another
       //thread in the warp might be reading keys in above loop.
       //before inserting the new value in liked list -- which is done with atomic exchange below,

--- a/packages/kokkos-kernels/src/sparse/impl/KokkosSparse_spgemm_impl_compression.hpp
+++ b/packages/kokkos-kernels/src/sparse/impl/KokkosSparse_spgemm_impl_compression.hpp
@@ -596,7 +596,8 @@ struct KokkosSPGEMM
           Kokkos::ThreadVectorRange(teamMember, vector_size),
           [&] (nnz_lno_t i) {
         result_keys[i] = -1;
-#if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_VOLTA70) || defined(KOKKOS_ARCH_VOLTA72)
+        //This is required for Nvidia architectures with "independent thread scheduling"
+#if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || defined(KOKKOS_ARCH_AMPERE)
         result_vals[i] = 0;
 #endif
       });
@@ -626,7 +627,7 @@ struct KokkosSPGEMM
 	    //once the keys are set, some other vector lane might be doing a
 	    //fetch_or before we set with n_set. Therefore it is necessary to do
 	    //atomic, and set it with zero as above.
-#if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_VOLTA70) || defined(KOKKOS_ARCH_VOLTA72)
+#if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || defined(KOKKOS_ARCH_AMPERE)
             Kokkos::atomic_fetch_or(result_vals + new_hash, n_set);
 #else
             result_vals[new_hash] = n_set;
@@ -690,7 +691,7 @@ struct KokkosSPGEMM
 	      //new_row_map(row_ind) = rowBeginP + used_hash_sizes[0] + used_hash_sizes[1];
 	      //to execute before the below insertion finishes.
 	      //parallel_for will provide this mechanism.
-#if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_VOLTA70) || defined(KOKKOS_ARCH_VOLTA72)
+#if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || defined(KOKKOS_ARCH_AMPERE)
               Kokkos::parallel_for(
                  Kokkos::ThreadVectorRange(teamMember, vector_size),
 	          [&] (nnz_lno_t i) {
@@ -701,7 +702,7 @@ struct KokkosSPGEMM
 			      n_set_index,n_set, used_hash_sizes + 1,
 			      globally_used_hash_count, globally_used_hash_indices);
         }
-#if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_VOLTA70) || defined(KOKKOS_ARCH_VOLTA72)
+#if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || defined(KOKKOS_ARCH_AMPERE)
 		});
 #endif
       }


### PR DESCRIPTION
(patching in changes from KokkosKernels #1118)

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/kokkos-kernels 

Note: already reviewed and merged in KokkosKernels. Just patching it in rather than waiting for next release.

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Fixes SpGEMM on Nvidia Turing and Ampere by enabling the codepath for "independent thread scheduling", where a subset of threads in a warp can make progress while others are blocked.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
SpGEMM unit tests (in sparse) failed on Perlmutter A100 without this change, but pass with this change.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->