### PR TITLE
Tempus:  Fix two more adjoint sensitivity problems when t0 != 0

### DIFF
--- a/packages/tempus/src/Tempus_AdjointAuxSensitivityModelEvaluator_decl.hpp
+++ b/packages/tempus/src/Tempus_AdjointAuxSensitivityModelEvaluator_decl.hpp
@@ -94,6 +94,9 @@ public:
   Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > getAdjointModel() const
   { return adjoint_model_; }
 
+  //! Set the final time from the forward evaluation
+  void setFinalTime(const Scalar t_final);
+
   //! Set solution history from forward evaluation
   void setForwardSolutionHistory(
     const Teuchos::RCP<const Tempus::SolutionHistory<Scalar> >& sh);

--- a/packages/tempus/src/Tempus_AdjointAuxSensitivityModelEvaluator_impl.hpp
+++ b/packages/tempus/src/Tempus_AdjointAuxSensitivityModelEvaluator_impl.hpp
@@ -113,6 +113,14 @@ AdjointAuxSensitivityModelEvaluator(
 template <typename Scalar>
 void
 AdjointAuxSensitivityModelEvaluator<Scalar>::
+setFinalTime(const Scalar t_final)
+{
+  t_final_ = t_final;
+}
+
+template <typename Scalar>
+void
+AdjointAuxSensitivityModelEvaluator<Scalar>::
 setForwardSolutionHistory(
   const Teuchos::RCP<const Tempus::SolutionHistory<Scalar> >& sh)
 {

--- a/packages/tempus/src/Tempus_AdjointSensitivityModelEvaluator_decl.hpp
+++ b/packages/tempus/src/Tempus_AdjointSensitivityModelEvaluator_decl.hpp
@@ -92,6 +92,9 @@ public:
   Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > getAdjointModel() const
   { return adjoint_model_; }
 
+  //! Set the final time from the forward evaluation
+  void setFinalTime(const Scalar t_final);
+
   //! Set solution history from forward evaluation
   void setForwardSolutionHistory(
     const Teuchos::RCP<const Tempus::SolutionHistory<Scalar> >& sh);

--- a/packages/tempus/src/Tempus_AdjointSensitivityModelEvaluator_impl.hpp
+++ b/packages/tempus/src/Tempus_AdjointSensitivityModelEvaluator_impl.hpp
@@ -113,6 +113,14 @@ AdjointSensitivityModelEvaluator(
 template <typename Scalar>
 void
 AdjointSensitivityModelEvaluator<Scalar>::
+setFinalTime(const Scalar t_final)
+{
+  t_final_ = t_final;
+}
+
+template <typename Scalar>
+void
+AdjointSensitivityModelEvaluator<Scalar>::
 setForwardSolutionHistory(
   const Teuchos::RCP<const Tempus::SolutionHistory<Scalar> >& sh)
 {

--- a/packages/tempus/src/Tempus_IntegratorAdjointSensitivity_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorAdjointSensitivity_impl.hpp
@@ -108,6 +108,12 @@ advanceTime(const Scalar timeFinal)
   // Run state integrator and get solution
   bool state_status = state_integrator_->advanceTime(timeFinal);
 
+  // For at least some time-stepping methods, the time of the last time step
+  // may not be timeFinal (e.g., it may be greater by at most delta_t).
+  // But since the adjoint model requires timeFinal in its formulation, reset
+  // it to the achieved final time.
+  adjoint_aux_model_->setFinalTime(state_integrator_->getTime());
+
   // Set solution history in adjoint stepper
   adjoint_aux_model_->setForwardSolutionHistory(state_solution_history);
 

--- a/packages/tempus/src/Tempus_IntegratorPseudoTransientAdjointSensitivity_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorPseudoTransientAdjointSensitivity_impl.hpp
@@ -95,6 +95,12 @@ advanceTime(const Scalar timeFinal)
   // Run state integrator and get solution
   bool state_status = state_integrator_->advanceTime(timeFinal);
 
+  // For at least some time-stepping methods, the time of the last time step
+  // may not be timeFinal (e.g., it may be greater by at most delta_t).
+  // But since the adjoint model requires timeFinal in its formulation, reset
+  // it to the achieved final time.
+  sens_model_->setFinalTime(state_integrator_->getTime());
+
   // Set solution in sensitivity ME
   sens_model_->setForwardSolutionHistory(
     state_integrator_->getSolutionHistory());


### PR DESCRIPTION
For issue #9737:
  * Add a fudge factor in findState() to allow for round-off
  * Reset timeFinal in the adjoint model evaluators after the forward integration, because it may not match the final time requested.