### PR TITLE
Zoltan2:  remove compiler warnings by using std::cout<< instead of printf

### DIFF
--- a/packages/zoltan2/core/src/algorithms/color/Zoltan2_AlgHybrid2GL.hpp
+++ b/packages/zoltan2/core/src/algorithms/color/Zoltan2_AlgHybrid2GL.hpp
@@ -1640,7 +1640,7 @@ class AlgTwoGhostLayer : public Algorithm<Adapter> {
           }
         }      
         
-        if(comm->getRank() == 0) printf("did %d rounds of distributed coloring\n", distributedRounds);
+        //if(comm->getRank() == 0) printf("did %d rounds of distributed coloring\n", distributedRounds);
         uint64_t totalVertsPerRound[numStatisticRecordingRounds];
         uint64_t totalBoundarySize = 0;
         uint64_t totalIncorrectGhostsPerRound[numStatisticRecordingRounds];
@@ -1675,22 +1675,38 @@ class AlgTwoGhostLayer : public Algorithm<Adapter> {
 			               Teuchos::REDUCE_MAX,numStatisticRecordingRounds,conflictDetectionPerRound,finalConflictDetectionPerRound);
         Teuchos::reduceAll<int,gno_t> (*comm, Teuchos::REDUCE_SUM,numStatisticRecordingRounds,recvPerRound,finalRecvPerRound);
         Teuchos::reduceAll<int,gno_t> (*comm, Teuchos::REDUCE_SUM,numStatisticRecordingRounds,sentPerRound,finalSentPerRound);
-        printf("Rank %d: boundary size: %ld\n",comm->getRank(),localBoundaryVertices);
-        if(comm->getRank() == 0) printf("Total boundary size: %ld\n",totalBoundarySize);
+        std::cout << "Rank " << comm->getRank() 
+                  << ": boundary size: " << localBoundaryVertices << std::endl;
+        if(comm->getRank() == 0) 
+          std::cout << "Total boundary size: " << totalBoundarySize << std::endl;
         for(int i = 0; i < std::min((int)distributedRounds,numStatisticRecordingRounds); i++){
-          printf("Rank %d: recolor %ld vertices in round %d\n",comm->getRank(), vertsPerRound[i],i);
-          printf("Rank %d: sentbuf had %lld entries in round %d\n", comm->getRank(), sentPerRound[i],i);
+          std::cout << "Rank " << comm->getRank() 
+                    << ": recolor " << vertsPerRound[i] 
+                    << " vertices in round " << i << std::endl;
+          std::cout << "Rank " << comm->getRank() 
+                    << " sentbuf had " << sentPerRound[i] 
+                    << " entries in round " << i << std::endl;
           if(comm->getRank()==0){
-            printf("recolored %ld vertices in round %d\n",totalVertsPerRound[i], i);
-            printf("%ld inconsistent ghosts in round %d\n",totalIncorrectGhostsPerRound[i],i);
-            printf("total time in round %d: %f\n",i,finalTotalPerRound[i]);
-            printf("recoloring time in round %d: %f\n",i,maxRecoloringPerRound[i]);
-            printf("min recoloring time in round %d: %f\n",i,minRecoloringPerRound[i]);
-            printf("conflict detection time in round %d: %f\n",i,finalConflictDetectionPerRound[i]);
-            printf("comm time in round %d: %f\n",i,finalCommPerRound[i]);
-            printf("recvbuf size in round %d: %lld\n",i,finalRecvPerRound[i]);
-            printf("sendbuf size in round %d: %lld\n",i,finalSentPerRound[i]);
-            printf("comp time in round %d: %f\n",i,finalCompPerRound[i]);
+            std::cout << "recolored " << totalVertsPerRound[i] 
+                      << " vertices in round " << i << std::endl;
+            std::cout << totalIncorrectGhostsPerRound[i] 
+                      << " inconsistent ghosts in round " << i << std::endl;
+            std::cout << "total time in round " << i 
+                      << ": " << finalTotalPerRound[i] << std::endl;
+            std::cout << "recoloring time in round " << i 
+                      << ": " << maxRecoloringPerRound[i] << std::endl;
+            std::cout << "min recoloring time in round " << i 
+                      << ": " << minRecoloringPerRound[i] << std::endl;
+            std::cout << "conflict detection time in round " << i
+                      << ": " << finalConflictDetectionPerRound[i] << std::endl;
+            std::cout << "comm time in round " << i
+                      << ": " << finalCommPerRound[i] << std::endl;
+            std::cout << "recvbuf size in round " << i 
+                      << ": " << finalRecvPerRound[i] << std::endl;
+            std::cout << "sendbuf size in round " << i 
+                      << ": " << finalSentPerRound[i] << std::endl;
+            std::cout << "comp time in round " << i
+                      << ": " << finalCompPerRound[i] << std::endl;
           }
         }
       } else if (timing){
@@ -1711,13 +1727,13 @@ class AlgTwoGhostLayer : public Algorithm<Adapter> {
         comm->barrier();
         fflush(stdout);
         if(comm->getRank()==0){
-          printf("Total Time: %f\n",global_total_time);
-          printf("Interior Time: %f\n",global_interior_time);
-          printf("Recoloring Time: %f\n",global_recoloring_time);
-          printf("Min Recoloring Time: %f\n",global_min_recoloring_time);
-          printf("Conflict Detection Time: %f\n",global_conflict_detection);
-          printf("Comm Time: %f\n",global_comm_time);
-          printf("Comp Time: %f\n",global_comp_time);
+          std::cout << "Total Time: " << global_total_time << std::endl;
+          std::cout << "Interior Time: " << global_interior_time << std::endl;
+          std::cout << "Recoloring Time: " << global_recoloring_time << std::endl;
+          std::cout << "Min Recoloring Time: " << global_min_recoloring_time << std::endl;
+          std::cout << "Conflict Detection Time: " << global_conflict_detection << std::endl;
+          std::cout << "Comm Time: " << global_comm_time << std::endl;
+          std::cout << "Comp Time: " << global_comp_time << std::endl;
         }
       }
     }

--- a/packages/zoltan2/core/src/algorithms/color/Zoltan2_AlgHybridD1.hpp
+++ b/packages/zoltan2/core/src/algorithms/color/Zoltan2_AlgHybridD1.hpp
@@ -1056,7 +1056,7 @@ class AlgDistance1 : public Algorithm<Adapter>
           }
         }
         //print how many rounds of speculating/correcting happened (this should be the same for all ranks):
-        if(comm->getRank()==0) printf("did %d rounds of distributed coloring\n", distributedRounds);
+        //if(comm->getRank()==0) printf("did %d rounds of distributed coloring\n", distributedRounds);
 	int totalBoundarySize = 0;
         int totalVertsPerRound[numStatisticRecordingRounds];
         double finalTotalPerRound[numStatisticRecordingRounds];
@@ -1092,20 +1092,36 @@ class AlgDistance1 : public Algorithm<Adapter>
         Teuchos::reduceAll<int,gno_t> (*comm, Teuchos::REDUCE_SUM,numStatisticRecordingRounds,recvPerRound, finalRecvPerRound);
         Teuchos::reduceAll<int,gno_t> (*comm, Teuchos::REDUCE_SUM,numStatisticRecordingRounds,sentPerRound, finalSentPerRound);
         
-        printf("Rank %d: boundary size: %d\n",comm->getRank(),localBoundaryVertices);
-        if(comm->getRank()==0) printf("Total boundary size: %d\n",totalBoundarySize);
+        std::cout << "Rank " << comm->getRank() 
+                  << ": boundary size: " << localBoundaryVertices << std::endl;
+        if(comm->getRank()==0) 
+          std::cout << "Total boundary size: " << totalBoundarySize << std::endl;
         for(int i = 0; i < std::min(distributedRounds,numStatisticRecordingRounds); i++){
-          printf("Rank %d: recolor %d vertices in round %d\n",comm->getRank(),vertsPerRound[i],i);
-          if(comm->getRank()==0) printf("recolored %d vertices in round %d\n",totalVertsPerRound[i],i);
-          if(comm->getRank()==0) printf("total time in round %d: %f\n",i,finalTotalPerRound[i]);
-          if(comm->getRank()==0) printf("recoloring time in round %d: %f\n",i,maxRecoloringPerRound[i]);
-          if(comm->getRank()==0) printf("serial recoloring time in round %d: %f\n",i,finalSerialRecoloringPerRound[i]);
-          if(comm->getRank()==0) printf("min recoloring time in round %d: %f\n",i,minRecoloringPerRound[i]);
-          if(comm->getRank()==0) printf("conflict detection time in round %d: %f\n",i,finalConflictDetectionPerRound[i]);
-          if(comm->getRank()==0) printf("comm time in round %d: %f\n",i,finalCommPerRound[i]);
-          if(comm->getRank()==0) printf("total sent in round %d: %lld\n",i,finalSentPerRound[i]);
-          if(comm->getRank()==0) printf("total recv in round %d: %lld\n",i,finalRecvPerRound[i]);
-          if(comm->getRank()==0) printf("comp time in round %d: %f\n",i,finalCompPerRound[i]);
+          std::cout << "Rank " << comm->getRank() 
+                    << ": recolor " << vertsPerRound[i]
+                    << " vertices in round " << i << std::endl;
+          if(comm->getRank()==0) {
+            std::cout << "recolored " << totalVertsPerRound[i]
+                      << " vertices in round " << i << std::endl;
+            std::cout << "total time in round " << i 
+                      << ":  " << finalTotalPerRound[i] << std::endl;;
+            std::cout << "recoloring time in round " << i
+                      << ": " << maxRecoloringPerRound[i] << std::endl;
+            std::cout << "serial recoloring time in round " << i
+                      << ": " << finalSerialRecoloringPerRound[i] << std::endl;
+            std::cout << "min recoloring time in round " << i
+                      << ": " << minRecoloringPerRound[i] << std::endl;
+            std::cout << "conflict detection time in round " << i
+                      << ": " << finalConflictDetectionPerRound[i] << std::endl;
+            std::cout << "comm time in round " << i
+                      << ": " << finalCommPerRound[i] << std::endl;
+            std::cout << "total sent in round " << i
+                      << ": " << finalSentPerRound[i] << std::endl;
+            std::cout << "total recv in round " << i
+                      << ": " << finalRecvPerRound[i] << std::endl;
+            std::cout << "comp time in round " << i
+                      << ": " << finalCompPerRound[i] << std::endl;
+          }
         }
       } else if(timing){
         double global_total_time = 0.0;
@@ -1125,13 +1141,13 @@ class AlgDistance1 : public Algorithm<Adapter>
         comm->barrier();
         fflush(stdout);
         if(comm->getRank()==0){
-          printf("Total Time: %f\n",global_total_time);
-          printf("Interior Time: %f\n",global_interior_time);
-          printf("Recoloring Time: %f\n",global_recoloring_time);
-          printf("Min Recoloring Time: %f\n",global_min_recoloring_time);
-          printf("Conflict Detection Time: %f\n",global_conflict_detection);
-          printf("Comm Time: %f\n",global_comm_time);
-          printf("Comp Time: %f\n",global_comp_time);
+          std::cout << "Total Time: " << global_total_time << std::endl;
+          std::cout << "Interior Time: " << global_interior_time << std::endl;
+          std::cout << "Recoloring Time: " << global_recoloring_time << std::endl;
+          std::cout << "Min Recoloring Time: " << global_min_recoloring_time << std::endl;
+          std::cout << "Conflict Detection Time: " << global_conflict_detection << std::endl;
+          std::cout << "Comm Time: " << global_comm_time << std::endl;
+          std::cout << "Comp Time: " << global_comp_time << std::endl;
         }
       }
       if(verbose) std::cout<<comm->getRank()<<": exiting coloring\n";


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/zoltan2

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

#9615 reports compilation warnings due to mismatched printf formats and arguments.
This PR replaces printf with std::cout<<, allowing C++ to determine the print format.

This PR replaces PR #9764; rather than remove the warning-generating print statements, this PR replaces them with equivalent C++ statements.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
@djglaze @tasmith4 

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Tested on ascicgpu with serial node, sems gcc compilers.
Tested with GO = int and GO = long long.


<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->