### PR TITLE
SEACAS: Move logic to disable SEACAS subpackages that depend on Fortran (trilinos/Trilinos#3346)

### DIFF
--- a/cmake/RepositoryDependenciesSetup.cmake
+++ b/cmake/RepositoryDependenciesSetup.cmake
@@ -105,6 +105,13 @@ IF(KDD_INT_LONG OR KDD_INT_LONG_LONG OR KDD_INT_UNSIGNED)
    ENDIF()
 ENDIF()
 
+# Special logic to disable SEACAS subpackages depending on Fortran enabled or not
+
+if (SEACAS_SOURCE_DIR)
+  include("${SEACAS_SOURCE_DIR}/cmake/SeacasDisableSubpackagesDependingOnFortran.cmake")
+  seacas_disable_subpackages_depending_on_fortran()
+endif()
+
 # Enable Build Status package and enable reporting the reporting test
 
 set(bulidStats "${${PROJECT_NAME}_ENABLE_BUILD_STATS}")

--- a/packages/seacas/CMakeLists.txt
+++ b/packages/seacas/CMakeLists.txt
@@ -61,47 +61,6 @@ TRIBITS_ADD_OPTION_AND_DEFINE(
   OFF
   )
 
-function(disable_if_no_fortran package)
-IF (NOT ${PROJECT_NAME}_ENABLE_Fortran)
-  IF (${PROJECT_NAME}_ENABLE_SEACAS${package})
-    MESSAGE("-- "
-      "WARNING: Setting ${PROJECT_NAME}_ENABLE_SEACAS${package}=OFF"
-      " even though it was set to ${${PROJECT_NAME}_ENABLE_SEACAS${package}}"
-      " because ${PROJECT_NAME}_ENABLE_Fortran=OFF!"
-      )
-  ELSEIF("${${PROJECT_NAME}_ENABLE_SEACAS${package}}" STREQUAL "")
-     MESSAGE("-- "
-      "NOTE: Setting ${PROJECT_NAME}_ENABLE_SEACAS${package}=OFF"
-      " because ${PROJECT_NAME}_ENABLE_Fortran=OFF!"
-       )
-  ENDIF()
-  SET(${PROJECT_NAME}_ENABLE_SEACAS${package} OFF PARENT_SCOPE)
-ENDIF()
-endfunction()
-
-disable_if_no_fortran(Mapvarlib)
-disable_if_no_fortran(Exodus_for)
-disable_if_no_fortran(ExoIIv2for32)
-disable_if_no_fortran(Supes)
-disable_if_no_fortran(Suplib)
-disable_if_no_fortran(PLT)
-disable_if_no_fortran(Blot)
-disable_if_no_fortran(Fastq)
-disable_if_no_fortran(SVDI)
-disable_if_no_fortran(Algebra)
-disable_if_no_fortran(Exotxt)
-disable_if_no_fortran(Gjoin)
-disable_if_no_fortran(Gen3D)
-disable_if_no_fortran(Genshell)
-disable_if_no_fortran(Grepos)
-disable_if_no_fortran(Explore)
-disable_if_no_fortran(Mapvar)
-disable_if_no_fortran(Mapvar-kd)
-disable_if_no_fortran(Numbers)
-disable_if_no_fortran(Txtexo)
-disable_if_no_fortran(Ex2ex1v2)
-disable_if_no_fortran(Ex1ex2v2)
-
 IF (NOT ${PROJECT_NAME}_ENABLE_Fortran)
 # For some reason, this variable is undefined if fortran is disabled and it causes a cmake error.
 # define it to a nonsense variable to avoid error.

--- a/packages/seacas/cmake/SeacasDisableSubpackagesDependingOnFortran.cmake
+++ b/packages/seacas/cmake/SeacasDisableSubpackagesDependingOnFortran.cmake
@@ -1,0 +1,45 @@
+
+macro(seacas_disable_subpackages_depending_on_fortran)
+  if (NOT ${PROJECT_NAME}_ENABLE_Fortran)
+    seacas_disable_subpackage_since_no_fortran(Mapvarlib)
+    seacas_disable_subpackage_since_no_fortran(Exodus_for)
+    seacas_disable_subpackage_since_no_fortran(ExoIIv2for32)
+    seacas_disable_subpackage_since_no_fortran(Supes)
+    seacas_disable_subpackage_since_no_fortran(Suplib)
+    seacas_disable_subpackage_since_no_fortran(PLT)
+    seacas_disable_subpackage_since_no_fortran(Blot)
+    seacas_disable_subpackage_since_no_fortran(Fastq)
+    seacas_disable_subpackage_since_no_fortran(SVDI)
+    seacas_disable_subpackage_since_no_fortran(Algebra)
+    seacas_disable_subpackage_since_no_fortran(Exotxt)
+    seacas_disable_subpackage_since_no_fortran(Gjoin)
+    seacas_disable_subpackage_since_no_fortran(Gen3D)
+    seacas_disable_subpackage_since_no_fortran(Genshell)
+    seacas_disable_subpackage_since_no_fortran(Grepos)
+    seacas_disable_subpackage_since_no_fortran(Explore)
+    seacas_disable_subpackage_since_no_fortran(Mapvar)
+    seacas_disable_subpackage_since_no_fortran(Mapvar-kd)
+    seacas_disable_subpackage_since_no_fortran(Numbers)
+    seacas_disable_subpackage_since_no_fortran(Txtexo)
+    seacas_disable_subpackage_since_no_fortran(Ex2ex1v2)
+    seacas_disable_subpackage_since_no_fortran(Ex1ex2v2)
+  endif()
+endmacro()
+
+
+macro(seacas_disable_subpackage_since_no_fortran subpackage)
+  if (${PROJECT_NAME}_ENABLE_SEACAS${subpackage})
+    message("-- "
+      "WARNING: Setting ${PROJECT_NAME}_ENABLE_SEACAS${subpackage}=OFF"
+      " even though it was set to ${${PROJECT_NAME}_ENABLE_SEACAS${subpackage}}"
+      " because ${PROJECT_NAME}_ENABLE_Fortran=${${PROJECT_NAME}_ENABLE_Fortran}!"
+      )
+  elseif("${${PROJECT_NAME}_ENABLE_SEACAS${subpackage}}" STREQUAL "")
+     message("-- "
+      "NOTE: Setting ${PROJECT_NAME}_ENABLE_SEACAS${subpackage}=OFF"
+      " because ${PROJECT_NAME}_ENABLE_Fortran=${${PROJECT_NAME}_ENABLE_Fortran}!"
+       )
+  endif()
+  set(${PROJECT_NAME}_ENABLE_SEACAS${subpackage} OFF)
+endmacro()
+


### PR DESCRIPTION
@gsjaardema, @trilinos/seacas 

As per the TriBITS User's Guide section [How to check for and tweak TriBITS 'ENABLE' cache variables](https://tribitspub.github.io/TriBITS/users_guide/index.html#how-to-check-for-and-tweak-tribits-enable-cache-variables), logic that enables/disables subpackages needs to be performed before the package's `CMakeLists.txt` files start getting processed since this disable info needs to be feed into the global enable/disable logic. For example, if there is a downstream subpackage in say Panzer that depends on a specific subpackage in SEACAS, then we need to know that that SEACAS subpackage is disabled when processing the full set of enable/disable logic so we can disable the downstream Panzer subpackage that depends on that disabled
SEACAS subpackage.  Otherwise, if packages can disable some of their subpackages in the middle of their configuration while processing their `<packageDir>/CMakeLists.txt` files, then that would require a much more complex implementation of TriBITS to handle scenarios like that.

This should fix a problem with broken SEACAS <Package>Config.cmake files reported in trilinos/Trilinos#3346.

## Testing

To test this, I used the [SEMS Dev Env](https://github.com/trilinos/Trilinos/wiki/SEMS-Dev-Env) and loaded the env with:

```
$ source ../../../Trilinos/cmake/load_sems_dev_env.sh

$ module list
Currently Loaded Modulefiles:
  1) sems-env                                     6) sems-gcc/7.2.0                              11) sems-netcdf/4.7.3/parallel
  2) sems-python/2.7.9                            7) sems-openmpi/1.10.1                         12) sems-parmetis/4.0.3/parallel
  3) sems-cmake/3.17.1                            8) sems-boost/1.63.0/base                      13) sems-scotch/6.0.3/nopthread_64bit_parallel
  4) sems-ninja_fortran/1.8.2                     9) sems-zlib/1.2.8/base                        14) sems-superlu/4.3/base
  5) sems-git/2.10.1                             10) sems-hdf5/1.10.6/parallel
```

and with the configuration files:

```
$ cat do-configure.base
#!/bin/bash

if [[ -e CMakeCache.txt ]] ; then
  rm CMakeCache.txt
fi

if [[ -d CMakeFiles ]] ; then
  rm -r CMakeFiles
fi

cmake \
-GNinja \
-DTrilinos_CONFIGURE_OPTIONS_FILE:STRING=cmake/std/sems/SEMSDevEnv.cmake \
-DBUILD_SHARED_LIBS=ON \
-DTPL_ENABLE_MPI=ON \
-DCMAKE_BUILD_TYPE=DEBUG \
-DTrilinos_ENABLE_DEBUG=ON \
-DTrilinos_ENABLE_TESTS=ON \
-DCMAKE_INSTALL_PREFIX=${PWD}/install \
"$@" \
../../../Trilinos

$ cat do-configure
#!/bin/bash
./do-configure.base \
-DTPL_ENABLE_Matio=OFF \
-DTrilinos_ENABLE_Fortran=OFF \
-DTrilinos_ENABLE_SEACAS=ON \
"$@"
```

I configured, built, and installed SEACAS through Trilinos with:

```
$ ./do-confiugre

$ make

$ ctest -j16
...
100% tests passed, 0 tests failed out of 27

Subproject Time Summary:
SEACAS    = 108.43 sec*proc (27 tests)

Total Test time (real) =  46.09 sec

$ make install
```

The configure output showed:

```
...

Processing Project, Repository, and Package dependency files and building internal dependencies graph ...

-- NOTE: Setting Trilinos_ENABLE_SEACASMapvarlib=OFF because Trilinos_ENABLE_Fortran=OFF!
-- NOTE: Setting Trilinos_ENABLE_SEACASExodus_for=OFF because Trilinos_ENABLE_Fortran=OFF!
-- NOTE: Setting Trilinos_ENABLE_SEACASExoIIv2for32=OFF because Trilinos_ENABLE_Fortran=OFF!
-- NOTE: Setting Trilinos_ENABLE_SEACASSupes=OFF because Trilinos_ENABLE_Fortran=OFF!
-- NOTE: Setting Trilinos_ENABLE_SEACASSuplib=OFF because Trilinos_ENABLE_Fortran=OFF!
-- NOTE: Setting Trilinos_ENABLE_SEACASPLT=OFF because Trilinos_ENABLE_Fortran=OFF!
-- NOTE: Setting Trilinos_ENABLE_SEACASBlot=OFF because Trilinos_ENABLE_Fortran=OFF!
-- NOTE: Setting Trilinos_ENABLE_SEACASFastq=OFF because Trilinos_ENABLE_Fortran=OFF!
-- NOTE: Setting Trilinos_ENABLE_SEACASSVDI=OFF because Trilinos_ENABLE_Fortran=OFF!
-- NOTE: Setting Trilinos_ENABLE_SEACASAlgebra=OFF because Trilinos_ENABLE_Fortran=OFF!
-- NOTE: Setting Trilinos_ENABLE_SEACASExotxt=OFF because Trilinos_ENABLE_Fortran=OFF!
-- NOTE: Setting Trilinos_ENABLE_SEACASGjoin=OFF because Trilinos_ENABLE_Fortran=OFF!
-- NOTE: Setting Trilinos_ENABLE_SEACASGen3D=OFF because Trilinos_ENABLE_Fortran=OFF!
-- NOTE: Setting Trilinos_ENABLE_SEACASGenshell=OFF because Trilinos_ENABLE_Fortran=OFF!
-- NOTE: Setting Trilinos_ENABLE_SEACASGrepos=OFF because Trilinos_ENABLE_Fortran=OFF!
-- NOTE: Setting Trilinos_ENABLE_SEACASExplore=OFF because Trilinos_ENABLE_Fortran=OFF!
-- NOTE: Setting Trilinos_ENABLE_SEACASMapvar=OFF because Trilinos_ENABLE_Fortran=OFF!
-- NOTE: Setting Trilinos_ENABLE_SEACASMapvar-kd=OFF because Trilinos_ENABLE_Fortran=OFF!
-- NOTE: Setting Trilinos_ENABLE_SEACASNumbers=OFF because Trilinos_ENABLE_Fortran=OFF!
-- NOTE: Setting Trilinos_ENABLE_SEACASTxtexo=OFF because Trilinos_ENABLE_Fortran=OFF!
-- NOTE: Setting Trilinos_ENABLE_SEACASEx2ex1v2=OFF because Trilinos_ENABLE_Fortran=OFF!
-- NOTE: Setting Trilinos_ENABLE_SEACASEx1ex2v2=OFF because Trilinos_ENABLE_Fortran=OFF!
-- Trilinos_NUM_SE_PACKAGES='161'
-- Tentatively enabling TPL 'DLlib'

Explicitly enabled packages on input (by user):  SEACAS 1

...

Final set of enabled packages:  Kokkos Zoltan Pamgen SEACAS 4

Final set of enabled SE packages:  KokkosCore KokkosContainers KokkosAlgorithms Kokkos Zoltan Pamgen SEACASExodus SEACASNemesis SEACASIoss SEACASChaco SEACASAprepro_lib SEACASSuplibC SEACASSuplibCpp SEACASAprepro SEACASConjoin SEACASEjoin SEACASEpu SEACASCpup SEACASExodiff SEACASExomatlab SEACASExo_format SEACASNas2exo SEACASZellij SEACASNemslice SEACASNemspread SEACAS 26

...

Processing enabled package: SEACAS (Exodus, Nemesis, Ioss, Chaco, Aprepro_lib, SuplibC, SuplibCpp, Aprepro, Conjoin, Ejoin, Epu, Cpup, Exodiff, Exomatlab, Exo_format, Nas2exo, Zellij, Nemslice, Nemspread, Tests, Examples)
-- WARNING: Setting CMAKE_Fortran_LINK_EXECUTABLE to a random value to avoid CMake error
-- Looking for sys/resource.h
-- Looking for sys/resource.h - found
-- A Python-2 version of exodus.py and exomerge.py will be installed.
```

Then I tested this installed `SEACASConfig.cmake` with a simple CMake project `use_seacas` with the `CMakeLists.txt` file:

```
cmake_minimum_required(VERSION 3.17.0 FATAL_ERROR)
project(UseSEACAS)
set(CMAKE_CXX_EXTENSIONS OFF)
find_package(SEACAS)
message("SEACAS_LIBRARIES = '${SEACAS_LIBRARIES}'")
```

and I configured it with:

```
$ mkdir use_seacas_build

$ cd use_seacas_build/

$ cmake -D CMAKE_PREFIX_PATH=${PWD}/../install ../use_seacas
...
-- Enabled Kokkos devices: SERIAL
SEACAS_LIBRARIES = 'suplib_cpp;suplib_c;aprepro_lib;chaco;io_info_lib;Ionit;Iotr;Iohb;Iogs;Iogn;Iovs;Iopg;Ioex;Ioss;nemesis;exodus;pamgen_extras;pamgen;zoltan;kokkosalgorithms;kokkoscontainers;kokkoscore'
-- Configuring done
-- Generating done
-- Build files have been written to: /scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/use_seacas_build
```

**NOTE:** Before this commit, when I do the above process and build the dummy project `use_seacas` that calls `find_package(SEACAS)`, I get the same errors described in #3346 shown below:

<details>

<summary><b>Errors when calling find_package(SEACAS)</b></summary>

<br>

```
CMake Error at /scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/install/lib/cmake/SEACAS/SEACASConfig.cmake:153 (include):
  include could not find load file:

    /scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/install/lib/cmake/SEACAS/../SEACASEx2ex1v2/SEACASEx2ex1v2Config.cmake
Call Stack (most recent call first):
  CMakeLists.txt:4 (find_package)


CMake Error at /scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/install/lib/cmake/SEACAS/SEACASConfig.cmake:154 (include):
  include could not find load file:

    /scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/install/lib/cmake/SEACAS/../SEACASTxtexo/SEACASTxtexoConfig.cmake
Call Stack (most recent call first):
  CMakeLists.txt:4 (find_package)


CMake Error at /scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/install/lib/cmake/SEACAS/SEACASConfig.cmake:155 (include):
  include could not find load file:

    /scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/install/lib/cmake/SEACAS/../SEACASNumbers/SEACASNumbersConfig.cmake
Call Stack (most recent call first):
  CMakeLists.txt:4 (find_package)


-- Enabled Kokkos devices: SERIAL
CMake Error at /scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/install/lib/cmake/SEACAS/SEACASConfig.cmake:160 (include):
  include could not find load file:

    /scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/install/lib/cmake/SEACAS/../SEACASMapvar-kd/SEACASMapvar-kdConfig.cmake
Call Stack (most recent call first):
  CMakeLists.txt:4 (find_package)


CMake Error at /scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/install/lib/cmake/SEACAS/SEACASConfig.cmake:161 (include):
  include could not find load file:

    /scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/install/lib/cmake/SEACAS/../SEACASMapvar/SEACASMapvarConfig.cmake
Call Stack (most recent call first):
  CMakeLists.txt:4 (find_package)


CMake Error at /scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/install/lib/cmake/SEACAS/SEACASConfig.cmake:162 (include):
  include could not find load file:

    /scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/install/lib/cmake/SEACAS/../SEACASMapvarlib/SEACASMapvarlibConfig.cmake
Call Stack (most recent call first):
  CMakeLists.txt:4 (find_package)


CMake Error at /scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/install/lib/cmake/SEACAS/SEACASConfig.cmake:163 (include):
  include could not find load file:

    /scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/install/lib/cmake/SEACAS/../SEACASExplore/SEACASExploreConfig.cmake
Call Stack (most recent call first):
  CMakeLists.txt:4 (find_package)


CMake Error at /scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/install/lib/cmake/SEACAS/SEACASConfig.cmake:164 (include):
  include could not find load file:

    /scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/install/lib/cmake/SEACAS/../SEACASGrepos/SEACASGreposConfig.cmake
Call Stack (most recent call first):
  CMakeLists.txt:4 (find_package)


CMake Error at /scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/install/lib/cmake/SEACAS/SEACASConfig.cmake:165 (include):
  include could not find load file:

    /scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/install/lib/cmake/SEACAS/../SEACASGenshell/SEACASGenshellConfig.cmake
Call Stack (most recent call first):
  CMakeLists.txt:4 (find_package)


CMake Error at /scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/install/lib/cmake/SEACAS/SEACASConfig.cmake:166 (include):
  include could not find load file:

    /scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/install/lib/cmake/SEACAS/../SEACASGen3D/SEACASGen3DConfig.cmake
Call Stack (most recent call first):
  CMakeLists.txt:4 (find_package)


CMake Error at /scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/install/lib/cmake/SEACAS/SEACASConfig.cmake:167 (include):
  include could not find load file:

    /scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/install/lib/cmake/SEACAS/../SEACASGjoin/SEACASGjoinConfig.cmake
Call Stack (most recent call first):
  CMakeLists.txt:4 (find_package)


CMake Error at /scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/install/lib/cmake/SEACAS/SEACASConfig.cmake:168 (include):
  include could not find load file:

    /scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/install/lib/cmake/SEACAS/../SEACASFastq/SEACASFastqConfig.cmake
Call Stack (most recent call first):
  CMakeLists.txt:4 (find_package)


CMake Error at /scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/install/lib/cmake/SEACAS/SEACASConfig.cmake:169 (include):
  include could not find load file:

    /scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/install/lib/cmake/SEACAS/../SEACASEx1ex2v2/SEACASEx1ex2v2Config.cmake
Call Stack (most recent call first):
  CMakeLists.txt:4 (find_package)


CMake Error at /scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/install/lib/cmake/SEACAS/SEACASConfig.cmake:171 (include):
  include could not find load file:

    /scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/install/lib/cmake/SEACAS/../SEACASExotxt/SEACASExotxtConfig.cmake
Call Stack (most recent call first):
  CMakeLists.txt:4 (find_package)


CMake Error at /scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/install/lib/cmake/SEACAS/SEACASConfig.cmake:178 (include):
  include could not find load file:

    /scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/install/lib/cmake/SEACAS/../SEACASBlot/SEACASBlotConfig.cmake
Call Stack (most recent call first):
  CMakeLists.txt:4 (find_package)


CMake Error at /scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/install/lib/cmake/SEACAS/SEACASConfig.cmake:180 (include):
  include could not find load file:

    /scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/install/lib/cmake/SEACAS/../SEACASAlgebra/SEACASAlgebraConfig.cmake
Call Stack (most recent call first):
  CMakeLists.txt:4 (find_package)


CMake Error at /scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/install/lib/cmake/SEACAS/SEACASConfig.cmake:181 (include):
  include could not find load file:

    /scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/install/lib/cmake/SEACAS/../SEACASPLT/SEACASPLTConfig.cmake
Call Stack (most recent call first):
  CMakeLists.txt:4 (find_package)


CMake Error at /scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/install/lib/cmake/SEACAS/SEACASConfig.cmake:182 (include):
  include could not find load file:

    /scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/install/lib/cmake/SEACAS/../SEACASSVDI/SEACASSVDIConfig.cmake
Call Stack (most recent call first):
  CMakeLists.txt:4 (find_package)


CMake Error at /scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/install/lib/cmake/SEACAS/SEACASConfig.cmake:185 (include):
  include could not find load file:

    /scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/install/lib/cmake/SEACAS/../SEACASSuplib/SEACASSuplibConfig.cmake
Call Stack (most recent call first):
  CMakeLists.txt:4 (find_package)


CMake Error at /scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/install/lib/cmake/SEACAS/SEACASConfig.cmake:186 (include):
  include could not find load file:

    /scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/install/lib/cmake/SEACAS/../SEACASSupes/SEACASSupesConfig.cmake
Call Stack (most recent call first):
  CMakeLists.txt:4 (find_package)


CMake Error at /scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/install/lib/cmake/SEACAS/SEACASConfig.cmake:191 (include):
  include could not find load file:

    /scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/install/lib/cmake/SEACAS/../SEACASExoIIv2for32/SEACASExoIIv2for32Config.cmake
Call Stack (most recent call first):
  CMakeLists.txt:4 (find_package)


CMake Error at /scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/install/lib/cmake/SEACAS/SEACASConfig.cmake:192 (include):
  include could not find load file:

    /scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/install/lib/cmake/SEACAS/../SEACASExodus_for/SEACASExodus_forConfig.cmake
Call Stack (most recent call first):
  CMakeLists.txt:4 (find_package)


SEACAS_LIBRARIES = 'suplib_cpp;suplib_c;aprepro_lib;chaco;io_info_lib;Ionit;Iotr;Iohb;Iogs;Iogn;Iovs;Iopg;Ioex;Ioss;nemesis;exodus;pamgen_extras;pamgen;zoltan;kokkosalgorithms;kokkoscontainers;kokkoscore'
-- Configuring incomplete, errors occurred!
See also "/scratch/rabartl/Trilinos.base/BUILDS/SEMS/gnu-7.2.0-opt-dbg/use_seacas_build/CMakeFiles/CMakeOutput.log".
```

</details>








