### PR TITLE
Panzer: fix 1D line mesh issue on cuda

### DIFF
--- a/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.cpp
@@ -1717,6 +1717,7 @@ getCubaturePointsRef(const bool cache,
       Kokkos::parallel_for("copy values",policy,KOKKOS_LAMBDA (const int cell,const int point, const int dim) {
         aux(cell,point_offset + point,dim) = side_cub_points(point,dim);
       });
+      PHX::Device::execution_space().fence();
     }
 
   } else {


### PR DESCRIPTION
## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
empire's trilinos sync was was failing due to recent changes to panzer integration rules.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
Tests are now passing

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->