### PR TITLE
Panzer: Make sure that panzer::ScatterResidual_BlockedTpetra checks for LOCir_GlobalEvaluationData for Residual evaluation.

### DIFF
--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterResidual_BlockedTpetra_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterResidual_BlockedTpetra_impl.hpp
@@ -184,8 +184,16 @@ template <typename TRAITS,typename LO,typename GO,typename NodeT>
 void panzer::ScatterResidual_BlockedTpetra<panzer::Traits::Residual, TRAITS,LO,GO,NodeT>::
 preEvaluate(typename TRAITS::PreEvalData d)
 {
+   using Teuchos::RCP;
+   using Teuchos::rcp_dynamic_cast;
+
    // extract linear object container
-   blockedContainer_ = Teuchos::rcp_dynamic_cast<const ContainerType>(d.gedc->getDataObject(globalDataKey_),true);
+   blockedContainer_ = rcp_dynamic_cast<const ContainerType>(d.gedc->getDataObject(globalDataKey_));
+
+   if(blockedContainer_==Teuchos::null) {
+     RCP<const LOCPair_GlobalEvaluationData> gdata = rcp_dynamic_cast<const LOCPair_GlobalEvaluationData>(d.gedc->getDataObject(globalDataKey_),true);
+     blockedContainer_ = rcp_dynamic_cast<const ContainerType>(gdata->getGhostedLOC());
+   }
 }
 
 // **********************************************************************


### PR DESCRIPTION

@trilinos/panzer @rppawlo 

## Motivation

Incorporate additional checks to support response vectors into ScatterResidual_BlockedTpetra for the Residual evaluation type. The Jacobian evaluation already does this, and the non-blocked version also does this for both Residual and Jacobian evaluations currently.
