### PR TITLE
Piro: fix to avoid errors for ACE problems in Albany

### DIFF
--- a/packages/piro/src/Piro_TempusSolver_Def.hpp
+++ b/packages/piro/src/Piro_TempusSolver_Def.hpp
@@ -437,7 +437,7 @@ void Piro::TempusSolver<Scalar>::evalModelImpl(
   // Set initial time and initial condition 
   Thyra::ModelEvaluatorBase::InArgs<Scalar> state_ic = model_->getNominalValues();
   Teuchos::RCP<const Thyra::VectorBase<Scalar>> xinit, xdotinit, xdotdotinit; 
-  if(t_initial_ > 0.0 && state_ic.supports(Thyra::ModelEvaluatorBase::IN_ARG_t)) {
+  if(state_ic.supports(Thyra::ModelEvaluatorBase::IN_ARG_t)) {
     state_ic.set_t(t_initial_);
     //If initial state has not been reset, get the initial state from ME in args
     if (!initial_state_reset_) { 


### PR DESCRIPTION
Small change that is required to avoid errors for ACE problems in Albany, that came up due to recent changes in Tempus.

@lxmota , can you please review?