### PR TITLE
MueLu: refactor residual printout in Hierarchy::Iterate()

### DIFF
--- a/packages/muelu/src/MueCentral/MueLu_Hierarchy_decl.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_Hierarchy_decl.hpp
@@ -355,6 +355,9 @@ namespace MueLu {
     //! Copy constructor is not implemented.
     Hierarchy(const Hierarchy &h);
 
+    //! Decide if the residual needs to be computed and printed to screen
+    bool IsResidualHistoryNecessary(const LO startLevel, const ConvData& conv) const;
+
     //! Container for Level objects
     Array<RCP<Level> > Levels_;
 

--- a/packages/muelu/src/MueCentral/MueLu_Hierarchy_decl.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_Hierarchy_decl.hpp
@@ -355,8 +355,22 @@ namespace MueLu {
     //! Copy constructor is not implemented.
     Hierarchy(const Hierarchy &h);
 
-    //! Decide if the residual needs to be computed and printed to screen
-    bool IsResidualHistoryNecessary(const LO startLevel, const ConvData& conv) const;
+    //! Decide if the residual needs to be computed
+    bool IsCalculationOfResidualRequired(const LO startLevel, const ConvData& conv) const;
+
+    /*!
+    \brief Decide if the mulitgrid iteration is converged
+
+    We judge convergence by comparing the current \c residualNorm
+    to the user given \c convergenceTolerance and then return the
+    appropriate \c ReturnType
+    */
+    ReturnType IsConverged(const Teuchos::Array<MagnitudeType>& residualNorm,
+        const Scalar convergenceTolerance) const;
+
+    //! Print \c residualNorm for this \c iteration to the screen
+    void PrintResidualHistory(const LO iteration,
+        const Teuchos::Array<MagnitudeType>& residualNorm) const;
 
     //! Container for Level objects
     Array<RCP<Level> > Levels_;

--- a/packages/muelu/src/MueCentral/MueLu_Hierarchy_decl.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_Hierarchy_decl.hpp
@@ -372,6 +372,11 @@ namespace MueLu {
     void PrintResidualHistory(const LO iteration,
         const Teuchos::Array<MagnitudeType>& residualNorm) const;
 
+    //! Compute the residual norm and print it depending on the verbosity level
+    ReturnType ComputeResidualAndPrintHistory(const Operator& A, const MultiVector& X,
+        const MultiVector& B, const LO iteration,
+        const LO startLevel, const ConvData& conv, MagnitudeType& previousResidualNorm);
+
     //! Container for Level objects
     Array<RCP<Level> > Levels_;
 

--- a/packages/muelu/src/MueCentral/MueLu_Hierarchy_def.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_Hierarchy_def.hpp
@@ -920,8 +920,7 @@ namespace MueLu {
     typedef Teuchos::ScalarTraits<typename STS::magnitudeType> STM;
     MagnitudeType prevNorm = STM::one(), curNorm = STM::one();
     rate_ = 1.0;
-    if (startLevel == 0 && !isPreconditioner_ &&
-        (IsPrint(Statistics1) || tol > 0)) {
+    if (IsResidualHistoryNecessary(startLevel, conv)) {
       // We calculate the residual only if we want to print it out, or if we
       // want to stop once we achive the tolerance
       Teuchos::Array<MagnitudeType> rn;
@@ -1136,8 +1135,7 @@ namespace MueLu {
       }
       zeroGuess = false;
 
-      if (startLevel == 0 && !isPreconditioner_ &&
-          (IsPrint(Statistics1) || tol > 0)) {
+      if (IsResidualHistoryNecessary(startLevel, conv)) {
         // We calculate the residual only if we want to print it out, or if we
         // want to stop once we achive the tolerance
         Teuchos::Array<MagnitudeType> rn;
@@ -1608,6 +1606,13 @@ void Hierarchy<Scalar, LocalOrdinal, GlobalOrdinal, Node>::DeleteLevelMultiVecto
   sizeOfAllocatedLevelMultiVectors_ = 0;
 }
 
+
+template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+bool Hierarchy<Scalar, LocalOrdinal, GlobalOrdinal, Node>::IsResidualHistoryNecessary(
+    const LO startLevel, const ConvData& conv) const
+{
+  return (startLevel == 0 && !isPreconditioner_ && (IsPrint(Statistics1) || conv.tol_ > 0));
+}
 
 } //namespace MueLu
 

--- a/packages/muelu/src/MueCentral/MueLu_Hierarchy_def.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_Hierarchy_def.hpp
@@ -1350,29 +1350,29 @@ namespace MueLu {
     if (GetProcRankVerbose() != 0)
       return;
 #if defined(HAVE_MUELU_BOOST) && defined(HAVE_MUELU_BOOST_FOR_REAL) && defined(BOOST_VERSION) && (BOOST_VERSION >= 104400)
-    
+
     BoostGraph      graph;
-    
+
     BoostProperties dp;
     dp.property("label", boost::get(boost::vertex_name,  graph));
     dp.property("id",    boost::get(boost::vertex_index, graph));
     dp.property("label", boost::get(boost::edge_name,    graph));
     dp.property("color", boost::get(boost::edge_color,   graph));
-    
+
     // create local maps
     std::map<const FactoryBase*, BoostVertex>                                     vindices;
     typedef std::map<std::pair<BoostVertex,BoostVertex>, std::string> emap; emap  edges;
-    
+
     static int call_id=0;
-    
+
     RCP<Operator> A = Levels_[0]->template Get<RCP<Operator> >("A");
     int rank = A->getDomainMap()->getComm()->getRank();
-    
+
     //    printf("[%d] CMS: ----------------------\n",rank);
     for (int i = currLevel; i <= currLevel+1 && i < GetNumLevels(); i++) {
       edges.clear();
       Levels_[i]->UpdateGraph(vindices, edges, dp, graph);
-      
+
       for (emap::const_iterator eit = edges.begin(); eit != edges.end(); eit++) {
         std::pair<BoostEdge, bool> boost_edge = boost::add_edge(eit->first.first, eit->first.second, graph);
         // printf("[%d] CMS:   Hierarchy, adding edge (%d->%d) %d\n",rank,(int)eit->first.first,(int)eit->first.second,(int)boost_edge.second);
@@ -1385,7 +1385,7 @@ namespace MueLu {
           boost::put("color", dp, boost_edge.first, std::string("blue"));
       }
     }
-    
+
     std::ofstream out(dumpFile_.c_str()+std::string("_")+std::to_string(currLevel)+std::string("_")+std::to_string(call_id)+std::string("_")+ std::to_string(rank) + std::string(".dot"));
     boost::write_graphviz_dp(out, graph, dp, std::string("id"));
     out.close();

--- a/packages/muelu/src/MueCentral/MueLu_Hierarchy_def.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_Hierarchy_def.hpp
@@ -924,7 +924,7 @@ namespace MueLu {
       ComputeResidualAndPrintHistory(*A, X, B, Teuchos::ScalarTraits<LO>::zero(), startLevel, conv, prevNorm);
 
     SC one = STS::one(), zero = STS::zero();
-    for (LO i = 1; i <= nIts; i++) {
+    for (LO iteration = 1; iteration <= nIts; iteration++) {
 #ifdef HAVE_MUELU_DEBUG
 #if 0 // TODO fix me
       if (A->getDomainMap()->isCompatible(*(X.getMap())) == false) {
@@ -1115,7 +1115,7 @@ namespace MueLu {
 
 
       if (IsCalculationOfResidualRequired(startLevel, conv))
-        ComputeResidualAndPrintHistory(*A, X, B, i, startLevel, conv, prevNorm);
+        ComputeResidualAndPrintHistory(*A, X, B, iteration, startLevel, conv, prevNorm);
     }
     return (tol > 0 ? Unconverged : Undefined);
   }

--- a/packages/muelu/src/MueCentral/MueLu_Hierarchy_def.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_Hierarchy_def.hpp
@@ -1619,7 +1619,7 @@ void Hierarchy<Scalar, LocalOrdinal, GlobalOrdinal, Node>::PrintResidualHistory(
 {
   GetOStream(Statistics1) << "iter:    "
       << std::setiosflags(std::ios::left)
-      << std::setprecision(3) << iteration
+      << std::setprecision(3) << std::setw(4) << iteration
       << "           residual = "
       << std::setprecision(10) << residualNorm
       << std::endl;

--- a/packages/muelu/test/scaling/Driver.cpp
+++ b/packages/muelu/test/scaling/Driver.cpp
@@ -219,7 +219,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
   bool        printTimings      = true;               clp.setOption("timings", "notimings",  &printTimings,      "print timings to screen");
   std::string timingsFormat     = "table-fixed";      clp.setOption("time-format",           &timingsFormat,     "timings format (table-fixed | table-scientific | yaml)");
   int         writeMatricesOPT  = -2;                 clp.setOption("write",                 &writeMatricesOPT,  "write matrices to file (-1 means all; i>=0 means level i)");
-  std::string dsolveType        = "belos", solveType; clp.setOption("solver",                &dsolveType,        "solve type: (none | cg | gmres | standalone | matvec)");
+  std::string dsolveType        = "belos", solveType; clp.setOption("solver",                &dsolveType,        "solve type: (none | belos | standalone | matvec)");
   std::string belosType         = "cg";               clp.setOption("belosType",             &belosType,         "belos solver type: (Pseudoblock CG | Block CG | Pseudoblock GMRES | Block GMRES | ...) see BelosSolverFactory.hpp for exhaustive list of solvers");
   double      dtol              = 1e-12, tol;         clp.setOption("tol",                   &dtol,              "solver convergence tolerance");
   bool        binaryFormat      = false;              clp.setOption("binary", "ascii",       &binaryFormat,      "print timings to screen");
@@ -239,7 +239,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
   int         maxIts            = 200;                clp.setOption("its",                   &maxIts,            "maximum number of solver iterations");
   int         numVectors        = 1;                  clp.setOption("multivector",           &numVectors,        "number of rhs to solve simultaneously");
   bool        scaleResidualHist = true;               clp.setOption("scale", "noscale",      &scaleResidualHist, "scaled Krylov residual history");
-  bool        solvePreconditioned = true;             clp.setOption("solve-preconditioned","no-solve-preconditioned", &solvePreconditioned, "use MueLu preconditioner in solve");  
+  bool        solvePreconditioned = true;             clp.setOption("solve-preconditioned","no-solve-preconditioned", &solvePreconditioned, "use MueLu preconditioner in solve");
   bool        useStackedTimer   = false;              clp.setOption("stacked-timer","no-stacked-timer", &useStackedTimer, "use stacked timer");
 
 #ifdef HAVE_MUELU_TPETRA


### PR DESCRIPTION
@trilinos/muelu 

## Motivation

Reduce code redundancy related to the calculation and printing of the residual norm during `Hierarchy::Iterate()`.

Minor changes:

- Align residual printout horizontally if number of digits of iteration number switch from 1 to 2 and 2 to 3
- Use descriptive variable names
- Fix some white space errors
- Fix documentation of scaling driver's command line options for the solver type

## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing

Existing tests pass. Printout has been tested via the scaling driver in `packages/muelu/test/scaling/`

- `./MueLu_Driver.exe --solver=belos`
- `./MueLu_Driver.exe --solver=standalone`

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->