### PR TITLE
MiniTensor: fix or at least work around some __host__ __device__ marking problems for CUDA build

### DIFF
--- a/packages/minitensor/src/MiniTensor_LinearAlgebra.h
+++ b/packages/minitensor/src/MiniTensor_LinearAlgebra.h
@@ -183,10 +183,7 @@ I3(Tensor<T, N> const & A);
 /// Exponential map.
 /// \return \f$ \exp A \f$
 ///
-template<typename T, Index N>
-KOKKOS_INLINE_FUNCTION
-Tensor<T, N>
-exp(Tensor<T, N> const & A);
+template <typename T, Index N> Tensor<T, N> exp(Tensor<T, N> const &A);
 
 ///
 /// Exponential map by Taylor series, radius of convergence is infinity
@@ -202,10 +199,7 @@ exp_taylor(Tensor<T, N> const & A);
 /// See algorithm 10.20 in Functions of Matrices, N.J. Higham, SIAM, 2008.
 /// \return \f$ \exp A \f$
 ///
-template<typename T, Index N>
-KOKKOS_INLINE_FUNCTION
-Tensor<T, N>
-exp_pade(Tensor<T, N> const & A);
+template <typename T, Index N> Tensor<T, N> exp_pade(Tensor<T, N> const &A);
 
 ///
 /// Logarithmic map.
@@ -338,20 +332,16 @@ norm_off_diagonal(Tensor<T, N> const & A);
 /// that rely on Jacobi-type procedures.
 /// \return \f$ (p,q) = arg max_{i,j} |a_{ij}| \f$
 ///
-template<typename T, Index N>
-KOKKOS_INLINE_FUNCTION
-std::pair<Index, Index>
-arg_max_abs(Tensor<T, N> const & A);
+template <typename T, Index N>
+std::pair<Index, Index> arg_max_abs(Tensor<T, N> const &A);
 
 ///
 /// Arg max off-diagonal. Useful for SVD and other algorithms
 /// that rely on Jacobi-type procedures.
 /// \return \f$ (p,q) = arg max_{i \neq j} |a_{ij}| \f$
 ///
-template<typename T, Index N>
-KOKKOS_INLINE_FUNCTION
-std::pair<Index, Index>
-arg_max_off_diagonal(Tensor<T, N> const & A);
+template <typename T, Index N>
+std::pair<Index, Index> arg_max_off_diagonal(Tensor<T, N> const &A);
 
 ///
 /// Sort and index. Useful for ordering singular values
@@ -360,18 +350,15 @@ arg_max_off_diagonal(Tensor<T, N> const & A);
 /// \param u vector to sort
 /// \return v P sorted vector, permutation matrix such that v = P^T u
 ///
-template<typename T, Index N>
-KOKKOS_INLINE_FUNCTION
-std::pair<Vector<T, N>, Tensor<T, N>>
-sort_permutation(Vector<T, N> const & u);
+template <typename T, Index N>
+std::pair<Vector<T, N>, Tensor<T, N>> sort_permutation(Vector<T, N> const &u);
 
 ///
 /// Singular value decomposition (SVD)
 /// \return \f$ A = USV^T\f$
 ///
-template<typename T, Index N>
-boost::tuple<Tensor<T, N>, Tensor<T, N>, Tensor<T, N>>
-svd(Tensor<T, N> const & A);
+template <typename T, Index N>
+std::tuple<Tensor<T, N>, Tensor<T, N>, Tensor<T, N>> svd(Tensor<T, N> const &A);
 
 ///
 /// Project to O(N) (Orthogonal Group) using a Newton-type algorithm.
@@ -392,62 +379,54 @@ polar_rotation(Tensor<T, N> const & A);
 /// \param A tensor (often a deformation-gradient-like tensor)
 /// \return \f$ VR = A \f$ with \f$ R \in SO(N) \f$ and \f$ V \in SPD(N) \f$
 ///
-template<typename T, Index N>
-KOKKOS_INLINE_FUNCTION
-std::pair<Tensor<T, N>, Tensor<T, N>>
-polar_left(Tensor<T, N> const & A);
+template <typename T, Index N>
+std::pair<Tensor<T, N>, Tensor<T, N>> polar_left(Tensor<T, N> const &A);
 
 ///
 /// Right polar decomposition
 /// \param A tensor (often a deformation-gradient-like tensor)
 /// \return \f$ RU = A \f$ with \f$ R \in SO(N) \f$ and \f$ U \in SPD(N) \f$
 ///
-template<typename T, Index N>
-KOKKOS_INLINE_FUNCTION
-std::pair<Tensor<T, N>, Tensor<T, N>>
-polar_right(Tensor<T, N> const & A);
+template <typename T, Index N>
+std::pair<Tensor<T, N>, Tensor<T, N>> polar_right(Tensor<T, N> const &A);
 
 ///
 /// Left polar decomposition computed with eigenvalue decomposition
 /// \param A tensor (often a deformation-gradient-like tensor)
 /// \return \f$ VR = A \f$ with \f$ R \in SO(N) \f$ and \f$ V \in SPD(N) \f$
 ///
-template<typename T, Index N>
-KOKKOS_INLINE_FUNCTION
-std::pair<Tensor<T, N>, Tensor<T, N>>
-polar_left_eig(Tensor<T, N> const & A);
+template <typename T, Index N>
+std::pair<Tensor<T, N>, Tensor<T, N>> polar_left_eig(Tensor<T, N> const &A);
 
 ///
 /// R^3 right polar decomposition
 /// \param A tensor (often a deformation-gradient-like tensor)
 /// \return \f$ RU = F \f$ with \f$ R \in SO(N) \f$ and \f$ U \in SPD(N) \f$
 ///
-template<typename T, Index N>
-KOKKOS_INLINE_FUNCTION
-std::pair<Tensor<T, N>, Tensor<T, N>>
-polar_right_eig(Tensor<T, N> const & A);
+template <typename T, Index N>
+std::pair<Tensor<T, N>, Tensor<T, N>> polar_right_eig(Tensor<T, N> const &A);
 
 ///
 /// Left polar decomposition with matrix logarithm for V
 /// \param F tensor (often a deformation-gradient-like tensor)
 /// \return \f$ VR = F \f$ with \f$ R \in SO(N) \f$ and V SPD, and log V
 ///
-template<typename T, Index N>
-boost::tuple<Tensor<T, N>, Tensor<T, N>, Tensor<T, N>>
-polar_left_logV(Tensor<T, N> const & F);
+template <typename T, Index N>
+std::tuple<Tensor<T, N>, Tensor<T, N>, Tensor<T, N>>
+polar_left_logV(Tensor<T, N> const &F);
 
-template<typename T, Index N>
-boost::tuple<Tensor<T, N>, Tensor<T, N>, Tensor<T, N>>
-polar_left_logV_eig(Tensor<T, N> const & F);
+template <typename T, Index N>
+std::tuple<Tensor<T, N>, Tensor<T, N>, Tensor<T, N>>
+polar_left_logV_eig(Tensor<T, N> const &F);
 
 ///
 /// Left polar decomposition with matrix logarithm for V using eig_spd_cos
 /// \param F tensor (often a deformation-gradient-like tensor)
 /// \return \f$ VR = F \f$ with \f$ R \in SO(N) \f$ and V SPD, and log V
 ///
-template<typename T, Index N>
-boost::tuple<Tensor<T, N>, Tensor<T, N>, Tensor<T, N>>
-polar_left_logV_lame(Tensor<T, N> const & F);
+template <typename T, Index N>
+std::tuple<Tensor<T, N>, Tensor<T, N>, Tensor<T, N>>
+polar_left_logV_lame(Tensor<T, N> const &F);
 
 ///
 /// Logarithmic map using BCH expansion (4 terms)
@@ -465,37 +444,28 @@ bch(Tensor<T, N> const & v, Tensor<T, N> const & r);
 /// \param \f$ A = [f, g; g, h] \in S(2) \f$
 /// \return \f$ c, s \rightarrow [c, -s; s, c]\f$ diagonalizes A$
 ///
-template<typename T>
-KOKKOS_INLINE_FUNCTION
-std::pair<T, T>
-schur_sym(const T f, const T g, const T h);
+template <typename T>
+std::pair<T, T> schur_sym(const T f, const T g, const T h);
 
 ///
 /// Givens rotation. [c, -s; s, c] [a; b] = [r; 0]
 /// \return c and s
 ///
-template<typename T>
-KOKKOS_INLINE_FUNCTION
-std::pair<T, T>
-givens(T const & a, T const & b);
+template <typename T> std::pair<T, T> givens(T const &a, T const &b);
 
 ///
 /// Eigenvalue decomposition for symmetric 2nd-order tensor
 /// \return V eigenvectors, D eigenvalues in diagonal Matlab-style
 ///
-template<typename T, Index N>
-KOKKOS_INLINE_FUNCTION
-std::pair<Tensor<T, N>, Tensor<T, N>>
-eig_sym(Tensor<T, N> const & A);
+template <typename T, Index N>
+std::pair<Tensor<T, N>, Tensor<T, N>> eig_sym(Tensor<T, N> const &A);
 
 ///
 /// Eigenvalue decomposition for SPD 2nd-order tensor
 /// \return V eigenvectors, D eigenvalues in diagonal Matlab-style
 ///
-template<typename T, Index N>
-KOKKOS_INLINE_FUNCTION
-std::pair<Tensor<T, N>, Tensor<T, N>>
-eig_spd(Tensor<T, N> const & A);
+template <typename T, Index N>
+std::pair<Tensor<T, N>, Tensor<T, N>> eig_spd(Tensor<T, N> const &A);
 
 ///
 /// Eigenvalue decomposition for SPD 2nd-order tensor
@@ -503,10 +473,8 @@ eig_spd(Tensor<T, N> const & A);
 /// This algorithm comes from the journal article
 /// Scherzinger and Dohrmann, CMAME 197 (2008) 4007-4015
 ///
-template<typename T, Index N>
-KOKKOS_INLINE_FUNCTION
-std::pair<Tensor<T, N>, Tensor<T, N>>
-eig_spd_cos(Tensor<T, N> const & A);
+template <typename T, Index N>
+std::pair<Tensor<T, N>, Tensor<T, N>> eig_spd_cos(Tensor<T, N> const &A);
 
 ///
 /// Cholesky decomposition, rank-1 update algorithm
@@ -515,10 +483,8 @@ eig_spd_cos(Tensor<T, N> const & A);
 /// \return G Cholesky factor A = GG^T and completed (bool)
 /// algorithm ran to completion
 ///
-template<typename T, Index N>
-KOKKOS_INLINE_FUNCTION
-std::pair<Tensor<T, N>, bool >
-cholesky(Tensor<T, N> const & A);
+template <typename T, Index N>
+std::pair<Tensor<T, N>, bool> cholesky(Tensor<T, N> const &A);
 
 ///
 /// Preconditioner types
@@ -535,10 +501,9 @@ enum class PreconditionerType
 /// Compute a preconditioner for improving the conditioning of a
 /// linear system.
 ///
-template<typename T, Index N, typename RHS>
-KOKKOS_INLINE_FUNCTION
-std::pair<Tensor<T, N>, RHS>
-precon(PreconditionerType const pt, Tensor<T, N> const & A, RHS const & B);
+template <typename T, Index N, typename RHS>
+std::pair<Tensor<T, N>, RHS> precon(PreconditionerType const pt,
+                                    Tensor<T, N> const &A, RHS const &B);
 
 ///
 /// Solve linear system of equations.
@@ -551,11 +516,9 @@ precon(PreconditionerType const pt, Tensor<T, N> const & A, RHS const & B);
 /// \param b rhs of the system Ax=b
 /// \return x solution(s) to the system Ax=b
 ///
-template<typename T, Index N, typename RHS>
-KOKKOS_INLINE_FUNCTION
-RHS
-solve(Tensor<T, N> const & A, RHS const & b,
-    PreconditionerType const pt = PreconditionerType::IDENTITY);
+template <typename T, Index N, typename RHS>
+RHS solve(Tensor<T, N> const &A, RHS const &b,
+          PreconditionerType const pt = PreconditionerType::IDENTITY);
 
 template<typename T, Index N, typename RHS>
 KOKKOS_INLINE_FUNCTION
@@ -565,18 +528,12 @@ solve_full_pivot(Tensor<T, N> const & A, RHS const & b);
 ///
 /// Condition number: ratio of largest to smalest singular values.
 ///
-template<typename T, Index N>
-KOKKOS_INLINE_FUNCTION
-T
-cond(Tensor<T, N> const & A);
+template <typename T, Index N> T cond(Tensor<T, N> const &A);
 
 ///
 /// Reciprocal condition number: ratio of smallest to largest singular values.
 ///
-template<typename T, Index N>
-KOKKOS_INLINE_FUNCTION
-T
-inv_cond(Tensor<T, N> const & A);
+template <typename T, Index N> T inv_cond(Tensor<T, N> const &A);
 
 } // namespace minitensor
 

--- a/packages/minitensor/src/MiniTensor_LinearAlgebra.i.h
+++ b/packages/minitensor/src/MiniTensor_LinearAlgebra.i.h
@@ -96,6 +96,8 @@ KOKKOS_INLINE_FUNCTION
 T
 norm_1(Tensor<T, N> const & A)
 {
+  using KAT = Kokkos::ArithTraits<T>;
+
   Index const
   dimension = A.get_dimension();
 
@@ -107,40 +109,39 @@ norm_1(Tensor<T, N> const & A)
 
   switch (dimension) {
 
-    default:
+  default:
 
-      for (Index i = 0; i < dimension; ++i) {
-        T t = 0.0;
-        for (Index j = 0; j < dimension; ++j) {
-          t += std::abs(A(j, i));
-        }
-        v(i) = t;
+    for (Index i = 0; i < dimension; ++i) {
+      T t = 0.0;
+      for (Index j = 0; j < dimension; ++j) {
+        t += KAT::abs(A(j, i));
       }
+      v(i) = t;
+    }
 
-      for (Index i = 0; i < dimension; ++i) {
-        s = std::max(s, v(i));
-      }
-      break;
+    for (Index i = 0; i < dimension; ++i) {
+      s = max(s, v(i));
+    }
+    break;
 
-    case 3:
-      v(0) = std::abs(A(0,0)) + std::abs(A(1,0)) + std::abs(A(2,0));
-      v(1) = std::abs(A(0,1)) + std::abs(A(1,1)) + std::abs(A(2,1));
-      v(2) = std::abs(A(0,2)) + std::abs(A(1,2)) + std::abs(A(2,2));
+  case 3:
+    v(0) = KAT::abs(A(0, 0)) + KAT::abs(A(1, 0)) + KAT::abs(A(2, 0));
+    v(1) = KAT::abs(A(0, 1)) + KAT::abs(A(1, 1)) + KAT::abs(A(2, 1));
+    v(2) = KAT::abs(A(0, 2)) + KAT::abs(A(1, 2)) + KAT::abs(A(2, 2));
 
-      s = std::max(std::max(v(0),v(1)),v(2));
-      break;
+    s = max(max(v(0), v(1)), v(2));
+    break;
 
-    case 2:
-      v(0) = std::abs(A(0,0)) + std::abs(A(1,0));
-      v(1) = std::abs(A(0,1)) + std::abs(A(1,1));
+  case 2:
+    v(0) = KAT::abs(A(0, 0)) + KAT::abs(A(1, 0));
+    v(1) = KAT::abs(A(0, 1)) + KAT::abs(A(1, 1));
 
-      s = std::max(v(0),v(1));
-      break;
+    s = max(v(0), v(1));
+    break;
 
-    case 1:
-      s = std::abs(A(0,0));
-      break;
-
+  case 1:
+    s = KAT::abs(A(0, 0));
+    break;
   }
 
   return s;
@@ -155,6 +156,8 @@ KOKKOS_INLINE_FUNCTION
 T
 norm_infinity(Tensor<T, N> const & A)
 {
+  using KAT = Kokkos::ArithTraits<T>;
+
   Index const
   dimension = A.get_dimension();
 
@@ -169,33 +172,33 @@ norm_infinity(Tensor<T, N> const & A)
       for (Index i = 0; i < dimension; ++i) {
         T t = 0.0;
         for (Index j = 0; j < dimension; ++j) {
-          t += std::abs(A(i, j));
+          t += KAT::abs(A(i, j));
         }
         v(i) = t;
       }
 
       for (Index i = 0; i < dimension; ++i) {
-        s = std::max(s, v(i));
+        s = max(s, v(i));
       }
       break;
 
     case 3:
-      v(0) = std::abs(A(0,0)) + std::abs(A(0,1)) + std::abs(A(0,2));
-      v(1) = std::abs(A(1,0)) + std::abs(A(1,1)) + std::abs(A(1,2));
-      v(2) = std::abs(A(2,0)) + std::abs(A(2,1)) + std::abs(A(2,2));
+      v(0) = KAT::abs(A(0, 0)) + KAT::abs(A(0, 1)) + KAT::abs(A(0, 2));
+      v(1) = KAT::abs(A(1, 0)) + KAT::abs(A(1, 1)) + KAT::abs(A(1, 2));
+      v(2) = KAT::abs(A(2, 0)) + KAT::abs(A(2, 1)) + KAT::abs(A(2, 2));
 
-      s = std::max(std::max(v(0),v(1)),v(2));
+      s = max(max(v(0), v(1)), v(2));
       break;
 
     case 2:
-      v(0) = std::abs(A(0,0)) + std::abs(A(0,1));
-      v(1) = std::abs(A(1,0)) + std::abs(A(1,1));
+      v(0) = KAT::abs(A(0, 0)) + KAT::abs(A(0, 1));
+      v(1) = KAT::abs(A(1, 0)) + KAT::abs(A(1, 1));
 
-      s = std::max(v(0),v(1));
+      s = max(v(0), v(1));
       break;
 
     case 1:
-      s = std::abs(A(0,0));
+      s = KAT::abs(A(0, 0));
       break;
 
   }
@@ -375,10 +378,11 @@ I2(Tensor<T, N> const & A)
     default:
 #ifdef KOKKOS_ENABLE_CUDA
       Kokkos::abort("I2 for N > 3 not implemented.");
+      return T();
 #else
       std::cerr << "I2 for N > 3 not implemented." << std::endl;
-#endif
       exit(1);
+#endif
       break;
 
     case 3:
@@ -420,10 +424,11 @@ I3(Tensor<T, N> const & A)
     default:
 #ifdef KOKKOS_ENABLE_CUDA
       Kokkos::abort("I3 for N > 3 not implemented.");
-#else 
+      return T();
+#else
       std::cerr << "I3 for N > 3 not implemented." << std::endl;
-#endif
       exit(1);
+#endif
       break;
 
     case 3:
@@ -446,16 +451,11 @@ I3(Tensor<T, N> const & A)
 //
 // Condition number.
 //
-template<typename T, Index N>
-KOKKOS_INLINE_FUNCTION
-T
-cond(Tensor<T, N> const & A)
-{
+template <typename T, Index N> T cond(Tensor<T, N> const &A) {
   Index const
   dimension = A.get_dimension();
 
-  Tensor<T, N> const
-  S = boost::get<1>(svd(A));
+  Tensor<T, N> const S = std::get<1>(svd(A));
 
   T const
   k = S(0, 0) / S(dimension - 1, dimension - 1);
@@ -466,16 +466,11 @@ cond(Tensor<T, N> const & A)
 //
 // Reciprocal condition number.
 //
-template<typename T, Index N>
-KOKKOS_INLINE_FUNCTION
-T
-inv_cond(Tensor<T, N> const & A)
-{
+template <typename T, Index N> T inv_cond(Tensor<T, N> const &A) {
   Index const
   dimension = A.get_dimension();
 
-  Tensor<T, N> const
-  S = boost::get<1>(svd(A));
+  Tensor<T, N> const S = std::get<1>(svd(A));
 
   T const
   k = S(dimension - 1, dimension - 1) / S(0, 0);
@@ -487,11 +482,8 @@ inv_cond(Tensor<T, N> const & A)
 // Sort and index in descending order. Useful for ordering singular values
 // and eigenvalues and corresponding vectors in the respective decompositions.
 //
-template<typename T, Index N>
-KOKKOS_INLINE_FUNCTION
-std::pair<Vector<T, N>, Tensor<T, N>>
-sort_permutation(Vector<T, N> const & u)
-{
+template <typename T, Index N>
+std::pair<Vector<T, N>, Tensor<T, N>> sort_permutation(Vector<T, N> const &u) {
 
   Index const
   dimension = u.get_dimension();
@@ -517,7 +509,6 @@ sort_permutation(Vector<T, N> const & u)
   }
 
   return std::make_pair(v, P);
-
 }
 
 } // namespace minitensor

--- a/packages/minitensor/src/MiniTensor_LinearAlgebra.t.h
+++ b/packages/minitensor/src/MiniTensor_LinearAlgebra.t.h
@@ -39,6 +39,7 @@
 // ************************************************************************
 // @HEADER
 
+#include "Kokkos_ArithTraits.hpp"
 #if !defined(MiniTensor_LinearAlgebra_t_h)
 #define MiniTensor_LinearAlgebra_t_h
 
@@ -289,11 +290,7 @@ subtensor(Tensor<T, N> const & A, Index const i, Index const j)
 //
 // Exponential map
 //
-template<typename T, Index N>
-KOKKOS_INLINE_FUNCTION
-Tensor<T, N>
-exp(Tensor<T, N> const & A)
-{
+template <typename T, Index N> Tensor<T, N> exp(Tensor<T, N> const &A) {
   return exp_pade(A);
 }
 
@@ -438,11 +435,9 @@ polynomial_coefficient(Index const order, Index const index)
 //
 // Padé approximant polynomial odd and even terms.
 //
-template<typename T, Index N>
-KOKKOS_INLINE_FUNCTION
+template <typename T, Index N>
 std::pair<Tensor<T, N>, Tensor<T, N>>
-pade_polynomial_terms(Tensor<T, N> const & A, Index const order)
-{
+pade_polynomial_terms(Tensor<T, N> const &A, Index const order) {
   Index const
   dimension = A.get_dimension();
 
@@ -549,11 +544,7 @@ binary_powering(Tensor<T, N> const & A, Index const exponent)
 // \param A tensor
 // \return \f$ \exp A \f$
 //
-template<typename T, Index N>
-KOKKOS_INLINE_FUNCTION
-Tensor<T, N>
-exp_pade(Tensor<T, N> const & A)
-{
+template <typename T, Index N> Tensor<T, N> exp_pade(Tensor<T, N> const &A) {
   Index const
   dimension = A.get_dimension();
 
@@ -588,7 +579,7 @@ exp_pade(Tensor<T, N> const & A)
       Tensor<T, N>
       V;
 
-      boost::tie(U, V) = pade_polynomial_terms(A, order);
+      std::tie(U, V) = pade_polynomial_terms(A, order);
 
       B = inverse(V - U) * (U + V);
 
@@ -810,7 +801,7 @@ log_eig_sym(Tensor<T, N> const & A)
   Tensor<T, N>
   D(dimension);
 
-  boost::tie(V, D) = eig_sym(A);
+  std::tie(V, D) = eig_sym(A);
 
   for (Index i = 0; i < dimension; ++i) {
     D(i, i) = std::log(D(i, i));
@@ -1159,11 +1150,8 @@ norm_off_diagonal(Tensor<T, N> const & A)
 // \param A
 // \return \f$ (p,q) = arg max_{i,j} |a_{ij}| \f$
 //
-template<typename T, Index N>
-//KOKKOS_INLINE_FUNCTION
-std::pair<Index, Index>
-arg_max_abs(Tensor<T, N> const & A)
-{
+template <typename T, Index N>
+std::pair<Index, Index> arg_max_abs(Tensor<T, N> const &A) {
 
   Index p = 0;
   Index q = 0;
@@ -1193,11 +1181,8 @@ arg_max_abs(Tensor<T, N> const & A)
 // \param A
 // \return \f$ (p,q) = arg max_{i \neq j} |a_{ij}| \f$
 //
-template<typename T, Index N>
-KOKKOS_INLINE_FUNCTION
-std::pair<Index, Index>
-arg_max_off_diagonal(Tensor<T, N> const & A)
-{
+template <typename T, Index N>
+std::pair<Index, Index> arg_max_off_diagonal(Tensor<T, N> const &A) {
   Index p = 0;
   Index q = 1;
 
@@ -1229,10 +1214,9 @@ namespace {
 // \param f, g, h where A = [f, g; 0, h]
 // \return \f$ A = USV^T\f$
 //
-template<typename T, Index N>
-boost::tuple<Tensor<T, N>, Tensor<T, N>, Tensor<T, N>>
-svd_bidiagonal(T f, T g, T h)
-{
+template <typename T, Index N>
+std::tuple<Tensor<T, N>, Tensor<T, N>, Tensor<T, N>> svd_bidiagonal(T f, T g,
+                                                                    T h) {
   T fa = std::abs(f);
   T ga = std::abs(g);
   T ha = std::abs(h);
@@ -1312,7 +1296,7 @@ svd_bidiagonal(T f, T g, T h)
   Tensor<T, N> S(s0, 0.0, 0.0, s1);
   Tensor<T, N> V(cv, -sv, sv, cv);
 
-  return boost::make_tuple(U, S, V);
+  return std::make_tuple(U, S, V);
 }
 
 //
@@ -1320,16 +1304,15 @@ svd_bidiagonal(T f, T g, T h)
 // \param A tensor
 // \return \f$ A = USV^T\f$
 //
-template<typename T, Index N>
-boost::tuple<Tensor<T, N>, Tensor<T, N>, Tensor<T, N>>
-svd_2x2(Tensor<T, N> const & A)
-{
+template <typename T, Index N>
+std::tuple<Tensor<T, N>, Tensor<T, N>, Tensor<T, N>>
+svd_2x2(Tensor<T, N> const &A) {
   assert(A.get_dimension() == 2);
 
   // First compute a givens rotation to eliminate 1,0 entry in tensor
   T c = 1.0;
   T s = 0.0;
-  boost::tie(c, s) = givens(A(0,0), A(1,0));
+  std::tie(c, s) = givens(A(0, 0), A(1, 0));
 
   Tensor<T, N>
   R(c, -s, s, c);
@@ -1341,13 +1324,13 @@ svd_2x2(Tensor<T, N> const & A)
   Tensor<T, N>
   X(2), S(2), V(2);
 
-  boost::tie(X, S, V) = svd_bidiagonal<T, N>(B(0,0), B(0,1), B(1,1));
+  std::tie(X, S, V) = svd_bidiagonal<T, N>(B(0, 0), B(0, 1), B(1, 1));
 
   // Complete general 2x2 SVD with givens rotation calculated above
   Tensor<T, N>
   U = transpose(R) * X;
 
-  return boost::make_tuple(U, S, V);
+  return std::make_tuple(U, S, V);
 }
 
 //
@@ -1355,10 +1338,9 @@ svd_2x2(Tensor<T, N> const & A)
 // \param A tensor
 // \return \f$ A = USV^T\f$
 //
-template<typename T, Index N>
-boost::tuple<Tensor<T, N>, Tensor<T, N>, Tensor<T, N>>
-svd_NxN(Tensor<T, N> const & A)
-{
+template <typename T, Index N>
+std::tuple<Tensor<T, N>, Tensor<T, N>, Tensor<T, N>>
+svd_NxN(Tensor<T, N> const &A) {
   // Scale first
   T const
   norm_a = norm(A);
@@ -1399,7 +1381,7 @@ svd_NxN(Tensor<T, N> const & A)
     Index
     q = 0;
 
-    boost::tie(p,q) = arg_max_off_diagonal(S);
+    std::tie(p, q) = arg_max_off_diagonal(S);
 
     if (p > q) {
       std::swap(p, q);
@@ -1412,7 +1394,7 @@ svd_NxN(Tensor<T, N> const & A)
     Tensor <T, 2>
     L(2), D(2), R(2);
 
-    boost::tie(L, D, R) = svd_2x2(Spq);
+    std::tie(L, D, R) = svd_2x2(Spq);
 
     T const &
     cl = L(0,0);
@@ -1456,12 +1438,12 @@ svd_NxN(Tensor<T, N> const & A)
   Vector<T, N> s(dimension);
   Tensor<T, N> P(dimension);
 
-  boost::tie(s, P) = sort_permutation(diag(S));
+  std::tie(s, P) = sort_permutation(diag(S));
   S = scale * diag(s);
   U = U * P;
   V = V * P;
 
-  return boost::make_tuple(U, diag(diag(S)), transpose(V));
+  return std::make_tuple(U, diag(diag(S)), transpose(V));
 }
 
 } // anonymous namespace
@@ -1471,10 +1453,9 @@ svd_NxN(Tensor<T, N> const & A)
 // \param A tensor
 // \return \f$ A = USV^T\f$
 //
-template<typename T, Index N>
-boost::tuple<Tensor<T, N>, Tensor<T, N>, Tensor<T, N>>
-svd(Tensor<T, N> const & A)
-{
+template <typename T, Index N>
+std::tuple<Tensor<T, N>, Tensor<T, N>, Tensor<T, N>>
+svd(Tensor<T, N> const &A) {
   Index const
   dimension = A.get_dimension();
 
@@ -1484,16 +1465,16 @@ svd(Tensor<T, N> const & A)
   switch (dimension) {
 
     default:
-      boost::tie(U, S, V) = svd_NxN(A);
+      std::tie(U, S, V) = svd_NxN(A);
       break;
 
     case 2:
-      boost::tie(U, S, V) = svd_2x2(A);
+      std::tie(U, S, V) = svd_2x2(A);
       break;
 
   }
 
-  return boost::make_tuple(U, S, V);
+  return std::make_tuple(U, S, V);
 }
 
 //
@@ -1519,8 +1500,8 @@ polar_rotation(Tensor<T, N> const & A)
   T const
   tol_scale = 0.01;
 
-  T const
-  tol_conv = std::sqrt(dimension) * machine_epsilon<T>();
+  T const tol_conv =
+      Kokkos::ArithTraits<Index>::sqrt(dimension) * machine_epsilon<T>();
 
   Tensor<T, N>
   X = A;
@@ -1588,11 +1569,8 @@ polar_rotation(Tensor<T, N> const & A)
 // \param A tensor (often a deformation-gradient-like tensor)
 // \return \f$ VR = A \f$ with \f$ R \in SO(N) \f$ and \f$ V \in SPD(N) \f$
 //
-template<typename T, Index N>
-KOKKOS_INLINE_FUNCTION
-std::pair<Tensor<T, N>, Tensor<T, N>>
-polar_left(Tensor<T, N> const & A)
-{
+template <typename T, Index N>
+std::pair<Tensor<T, N>, Tensor<T, N>> polar_left(Tensor<T, N> const &A) {
   Tensor<T, N>
   R = polar_rotation(A);
 
@@ -1607,11 +1585,8 @@ polar_left(Tensor<T, N> const & A)
 // \param A tensor (often a deformation-gradient-like tensor)
 // \return \f$ RU = A \f$ with \f$ R \in SO(N) \f$ and \f$ U \in SPD(N) \f$
 //
-template<typename T, Index N>
-KOKKOS_INLINE_FUNCTION
-std::pair<Tensor<T, N>, Tensor<T, N>>
-polar_right(Tensor<T, N> const & A)
-{
+template <typename T, Index N>
+std::pair<Tensor<T, N>, Tensor<T, N>> polar_right(Tensor<T, N> const &A) {
   Tensor<T, N>
   R = polar_rotation(A);
 
@@ -1626,11 +1601,8 @@ polar_right(Tensor<T, N> const & A)
 // \param F tensor (often a deformation-gradient-like tensor)
 // \return \f$ VR = F \f$ with \f$ R \in SO(3) \f$ and V SPD(3)
 //
-template<typename T, Index N>
-KOKKOS_INLINE_FUNCTION
-std::pair<Tensor<T, N>, Tensor<T, N>>
-polar_left_eig(Tensor<T, N> const & F)
-{
+template <typename T, Index N>
+std::pair<Tensor<T, N>, Tensor<T, N>> polar_left_eig(Tensor<T, N> const &F) {
   assert(F.get_dimension() == 3);
 
   // set up return tensors
@@ -1654,7 +1626,7 @@ polar_left_eig(Tensor<T, N> const & F)
 
   Tensor<T, N>
   eVec(3);
-  boost::tie(eVec, eVal) = eig_spd(b);
+  std::tie(eVec, eVal) = eig_spd(b);
 
   // compute sqrt() and inv(sqrt()) of eigenvalues
   Tensor<T, N>
@@ -1683,11 +1655,8 @@ polar_left_eig(Tensor<T, N> const & F)
 // \param F tensor (often a deformation-gradient-like tensor)
 // \return \f$ RU = F \f$ with \f$ R \in SO(3) \f$ and U SPD(3)
 //
-template<typename T, Index N>
-KOKKOS_INLINE_FUNCTION
-std::pair<Tensor<T, N>, Tensor<T, N>>
-polar_right_eig(Tensor<T, N> const & F)
-{
+template <typename T, Index N>
+std::pair<Tensor<T, N>, Tensor<T, N>> polar_right_eig(Tensor<T, N> const &F) {
   Index const
   dimension = F.get_dimension();
 
@@ -1714,7 +1683,7 @@ polar_right_eig(Tensor<T, N> const & F)
   Tensor<T, N>
   eVec(dimension);
 
-  boost::tie(eVec, eVal) = eig_spd(C);
+  std::tie(eVec, eVal) = eig_spd(C);
 
   // compute sqrt() and inv(sqrt()) of eigenvalues
   Tensor<T, N>
@@ -1744,17 +1713,16 @@ polar_right_eig(Tensor<T, N> const & F)
 // \param F tensor (often a deformation-gradient-like tensor)
 // \return \f$ VR = F \f$ with \f$ R \in SO(N) \f$ and V SPD(N), and log V
 //
-template<typename T, Index N>
-boost::tuple<Tensor<T, N>, Tensor<T, N>, Tensor<T, N>>
-polar_left_logV(Tensor<T, N> const & F)
-{
+template <typename T, Index N>
+std::tuple<Tensor<T, N>, Tensor<T, N>, Tensor<T, N>>
+polar_left_logV(Tensor<T, N> const &F) {
   Index const
   dimension = F.get_dimension();
 
   Tensor<T, N>
   X(dimension), S(dimension), Y(dimension);
 
-  boost::tie(X, S, Y) = svd(F);
+  std::tie(X, S, Y) = svd(F);
 
   Tensor<T, N>
   R = X * transpose(Y);
@@ -1772,13 +1740,12 @@ polar_left_logV(Tensor<T, N> const & F)
   Tensor<T, N>
   v = X * s * transpose(X);
 
-  return boost::make_tuple(V, R, v);
+  return std::make_tuple(V, R, v);
 }
 
-template<typename T, Index N>
-boost::tuple<Tensor<T, N>, Tensor<T, N>, Tensor<T, N>>
-polar_left_logV_eig(Tensor<T, N> const & F)
-{
+template <typename T, Index N>
+std::tuple<Tensor<T, N>, Tensor<T, N>, Tensor<T, N>>
+polar_left_logV_eig(Tensor<T, N> const &F) {
   Index const
   dimension = F.get_dimension();
 
@@ -1788,7 +1755,7 @@ polar_left_logV_eig(Tensor<T, N> const & F)
   Tensor<T, N>
   V(dimension), D(dimension);
 
-  boost::tie(V, D) = eig_sym(b);
+  std::tie(V, D) = eig_sym(b);
 
   Tensor<T, N>
   DQ(dimension, Filler::ZEROS), DI(dimension, Filler::ZEROS), DL(dimension, Filler::ZEROS);
@@ -1808,7 +1775,7 @@ polar_left_logV_eig(Tensor<T, N> const & F)
   Tensor<T, N> const
   x = V * dot_t(DL, V);
 
-  return boost::make_tuple(X, R, x);
+  return std::make_tuple(X, R, x);
 }
 
 //
@@ -1816,10 +1783,9 @@ polar_left_logV_eig(Tensor<T, N> const & F)
 // \param F tensor (often a deformation-gradient-like tensor)
 // \return \f$ VR = F \f$ with \f$ R \in SO(N) \f$ and V SPD(N), and log V
 //
-template<typename T, Index N>
-boost::tuple<Tensor<T, N>, Tensor<T, N>, Tensor<T, N>>
-polar_left_logV_lame(Tensor<T, N> const & F)
-{
+template <typename T, Index N>
+std::tuple<Tensor<T, N>, Tensor<T, N>, Tensor<T, N>>
+polar_left_logV_lame(Tensor<T, N> const &F) {
   Index const
   dimension = F.get_dimension();
 
@@ -1832,7 +1798,7 @@ polar_left_logV_lame(Tensor<T, N> const & F)
   // get eigenvalues/eigenvectors
   Tensor<T, N> eVal(dimension);
   Tensor<T, N> eVec(dimension);
-  boost::tie(eVec,eVal) = eig_spd_cos(b);
+  std::tie(eVec, eVal) = eig_spd_cos(b);
 
   // compute sqrt() and inv(sqrt()) of eigenvalues
   Tensor<T, N> x = zero<T, N>(3);
@@ -1853,7 +1819,7 @@ polar_left_logV_lame(Tensor<T, N> const & F)
   v    = eVec*lnx*transpose(eVec);
   R    = Vinv*F;
 
-  return boost::make_tuple(V,R,v);
+  return std::make_tuple(V, R, v);
 }
 
 //
@@ -1888,11 +1854,8 @@ bch(Tensor<T, N> const & x, Tensor<T, N> const & y)
 // \param \f$ A = [f, g; g, h] \in S(2) \f$
 // \return \f$ c, s \rightarrow [c, -s; s, c]\f diagonalizes A$
 //
-template<typename T>
-KOKKOS_INLINE_FUNCTION
-std::pair<T, T>
-schur_sym(T const f, T const g, T const h)
-{
+template <typename T>
+std::pair<T, T> schur_sym(T const f, T const g, T const h) {
   T c = 1.0;
   T s = 0.0;
 
@@ -1916,11 +1879,7 @@ schur_sym(T const f, T const g, T const h)
 // \param a, b
 // \return c, s
 //
-template<typename T>
-KOKKOS_INLINE_FUNCTION
-std::pair<T, T>
-givens(T const & a, T const & b)
-{
+template <typename T> std::pair<T, T> givens(T const &a, T const &b) {
   T c = 1.0;
   T s = 0.0;
 
@@ -1947,11 +1906,8 @@ namespace {
 // \return V eigenvectors, D eigenvalues in diagonal Matlab-style
 // See algorithm 8.4.2 in Matrix Computations, Golub & Van Loan 1996
 //
-template<typename T, Index N>
-KOKKOS_INLINE_FUNCTION
-std::pair<Tensor<T, N>, Tensor<T, N>>
-eig_sym_NxN(Tensor<T, N> const & A)
-{
+template <typename T, Index N>
+std::pair<Tensor<T, N>, Tensor<T, N>> eig_sym_NxN(Tensor<T, N> const &A) {
   Tensor<T, N>
   D = sym(A);
 
@@ -1984,7 +1940,7 @@ eig_sym_NxN(Tensor<T, N> const & A)
     Index
     q = 0;
 
-    boost::tie(p,q) = arg_max_off_diagonal(D);
+    std::tie(p, q) = arg_max_off_diagonal(D);
     if (p > q) {
       std::swap(p,q);
     }
@@ -2002,7 +1958,7 @@ eig_sym_NxN(Tensor<T, N> const & A)
     T
     c, s;
 
-    boost::tie(c, s) = schur_sym(f, g, h);
+    std::tie(c, s) = schur_sym(f, g, h);
 
     // Apply Givens rotation to matrices
     // that are converging to eigenvalues and eigenvectors
@@ -2018,7 +1974,7 @@ eig_sym_NxN(Tensor<T, N> const & A)
   Vector<T, N> d(dimension);
   Tensor<T, N> P(dimension);
 
-  boost::tie(d, P) = sort_permutation(diag(D));
+  std::tie(d, P) = sort_permutation(diag(D));
   D = diag(d);
   V = V * P;
 
@@ -2030,11 +1986,8 @@ eig_sym_NxN(Tensor<T, N> const & A)
 // \param A tensor
 // \return V eigenvectors, D eigenvalues in diagonal Matlab-style
 //
-template<typename T, Index N>
-KOKKOS_INLINE_FUNCTION
-std::pair<Tensor<T, N>, Tensor<T, N>>
-eig_sym_2x2(Tensor<T, N> const & A)
-{
+template <typename T, Index N>
+std::pair<Tensor<T, N>, Tensor<T, N>> eig_sym_2x2(Tensor<T, N> const &A) {
   assert(A.get_dimension() == 2);
 
   T const f = A(0,0);
@@ -2093,15 +2046,15 @@ eig_sym_2x2(Tensor<T, N> const & A)
   T
   c, s;
 
-  boost::tie(c, s) = schur_sym(f, g, h);
+  std::tie(c, s) = schur_sym(f, g, h);
 
   Tensor<T, N>
   V(c, -s, s, c);
 
   if (swap_diag == true) {
     // swap eigenvectors if eigenvalues were swapped
-    std::swap(V(0,0), V(0,1));
-    std::swap(V(1,0), V(1,1));
+    std::swap(V(0, 0), V(0, 1));
+    std::swap(V(1, 0), V(1, 1));
   }
 
   return std::make_pair(V, D);
@@ -2114,11 +2067,8 @@ eig_sym_2x2(Tensor<T, N> const & A)
 // \param A tensor
 // \return V eigenvectors, D eigenvalues in diagonal Matlab-style
 //
-template<typename T, Index N>
-KOKKOS_INLINE_FUNCTION
-std::pair<Tensor<T, N>, Tensor<T, N>>
-eig_sym(Tensor<T, N> const & A)
-{
+template <typename T, Index N>
+std::pair<Tensor<T, N>, Tensor<T, N>> eig_sym(Tensor<T, N> const &A) {
   Index const
   dimension = A.get_dimension();
 
@@ -2128,11 +2078,11 @@ eig_sym(Tensor<T, N> const & A)
   switch (dimension) {
 
     default:
-      boost::tie(V, D) = eig_sym_NxN(A);
+      std::tie(V, D) = eig_sym_NxN(A);
       break;
 
     case 2:
-      boost::tie(V, D) = eig_sym_2x2(A);
+      std::tie(V, D) = eig_sym_2x2(A);
       break;
 
   }
@@ -2145,11 +2095,8 @@ eig_sym(Tensor<T, N> const & A)
 // \param A tensor
 // \return V eigenvectors, D eigenvalues in diagonal Matlab-style
 //
-template<typename T, Index N>
-KOKKOS_INLINE_FUNCTION
-std::pair<Tensor<T, N>, Tensor<T, N>>
-eig_spd(Tensor<T, N> const & A)
-{
+template <typename T, Index N>
+std::pair<Tensor<T, N>, Tensor<T, N>> eig_spd(Tensor<T, N> const &A) {
   return eig_sym(A);
 }
 
@@ -2158,11 +2105,8 @@ eig_spd(Tensor<T, N> const & A)
 // \param A tensor
 // \return V eigenvectors, D eigenvalues in diagonal Matlab-style
 //
-template<typename T, Index N>
-KOKKOS_INLINE_FUNCTION
-std::pair<Tensor<T, N>, Tensor<T, N>>
-eig_spd_cos(Tensor<T, N> const & A)
-{
+template <typename T, Index N>
+std::pair<Tensor<T, N>, Tensor<T, N>> eig_spd_cos(Tensor<T, N> const &A) {
   Index const
   dimension = A.get_dimension();
 
@@ -2415,11 +2359,8 @@ eig_spd_cos(Tensor<T, N> const & A)
 // \return G Cholesky factor A = GG^T
 // \return completed (bool) algorithm ran to completion
 //
-template<typename T, Index N>
-KOKKOS_INLINE_FUNCTION
-std::pair<Tensor<T, N>, bool >
-cholesky(Tensor<T, N> const & A)
-{
+template <typename T, Index N>
+std::pair<Tensor<T, N>, bool> cholesky(Tensor<T, N> const &A) {
   Tensor<T, N>
   G = sym(A);
 
@@ -2465,22 +2406,18 @@ namespace {
 //
 //
 //
-template<typename T, Index N, typename RHS>
-KOKKOS_INLINE_FUNCTION
-std::pair<Tensor<T, N>, RHS>
-identity_precon(Tensor<T, N> const & A, RHS const & B)
-{
+template <typename T, Index N, typename RHS>
+std::pair<Tensor<T, N>, RHS> identity_precon(Tensor<T, N> const &A,
+                                             RHS const &B) {
   return std::make_pair(A, B);
 }
 
 //
 //
 //
-template<typename T, Index N, typename RHS>
-KOKKOS_INLINE_FUNCTION
-std::pair<Tensor<T, N>, RHS>
-diagonal_precon(Tensor<T, N> const & A, RHS const & B)
-{
+template <typename T, Index N, typename RHS>
+std::pair<Tensor<T, N>, RHS> diagonal_precon(Tensor<T, N> const &A,
+                                             RHS const &B) {
   Vector<T, N> const
   d = diag(A);
 
@@ -2496,11 +2433,8 @@ diagonal_precon(Tensor<T, N> const & A, RHS const & B)
 //
 //
 //
-template<typename T, Index N, typename RHS>
-KOKKOS_INLINE_FUNCTION
-std::pair<Tensor<T, N>, RHS>
-maxabsrow_precon(Tensor<T, N> const & A, RHS & B)
-{
+template <typename T, Index N, typename RHS>
+std::pair<Tensor<T, N>, RHS> maxabsrow_precon(Tensor<T, N> const &A, RHS &B) {
   Index const
   dimension = A.get_dimension();
 
@@ -2519,11 +2453,9 @@ maxabsrow_precon(Tensor<T, N> const & A, RHS & B)
 //
 //
 //
-template<typename T, Index N, typename RHS>
-KOKKOS_INLINE_FUNCTION
-std::pair<Tensor<T, N>, RHS>
-precon(PreconditionerType const pt, Tensor<T, N> const & A, RHS const & B)
-{
+template <typename T, Index N, typename RHS>
+std::pair<Tensor<T, N>, RHS> precon(PreconditionerType const pt,
+                                    Tensor<T, N> const &A, RHS const &B) {
   switch (pt) {
   default:
     MT_ERROR_EXIT("Unknown preconditioner type.");
@@ -2550,18 +2482,15 @@ precon(PreconditionerType const pt, Tensor<T, N> const & A, RHS const & B)
 // as it just Gauss-Jordan elimination. It is intended to be used in
 // conjunction with Kokkos to take advantage of thread parallelism.
 //
-template<typename T, Index N, typename RHS>
-KOKKOS_INLINE_FUNCTION
-RHS
-solve(Tensor<T, N> const & A, RHS const & b, PreconditionerType const pt)
-{
+template <typename T, Index N, typename RHS>
+RHS solve(Tensor<T, N> const &A, RHS const &b, PreconditionerType const pt) {
   Tensor<T, N>
   PA;
 
   RHS
   Pb;
 
-  boost::tie(PA, Pb) = precon(pt, A, b);
+  std::tie(PA, Pb) = precon(pt, A, b);
 
   return solve_full_pivot(PA, Pb);
 }

--- a/packages/minitensor/src/MiniTensor_Mechanics.t.h
+++ b/packages/minitensor/src/MiniTensor_Mechanics.t.h
@@ -663,7 +663,7 @@ check_strong_ellipticity(Tensor4<T, N> const & A)
     Tensor<T, N>
     D;
 
-    boost::tie(V, D) = eig_sym(Q);
+    std::tie(V, D) = eig_sym(Q);
 
     curr_eigenvalue = D(dimension - 1, dimension - 1);
 

--- a/packages/minitensor/src/MiniTensor_Solvers.t.h
+++ b/packages/minitensor/src/MiniTensor_Solvers.t.h
@@ -564,7 +564,7 @@ step(Tensor<T, N> const & Hessian, Vector<T, N> const & gradient)
     bool
     is_posdef{false};
 
-    boost::tie(L, is_posdef) = cholesky(K);
+    std::tie(L, is_posdef) = cholesky(K);
 
     if (is_posdef == false) {
       MT_ERROR_EXIT("Trust region subproblem encountered singular Hessian.");
@@ -635,7 +635,7 @@ step(Tensor<T, N> const & Hessian, Vector<T, N> const & gradient)
     bool
     is_posdef{false};
 
-    boost::tie(L, is_posdef) = cholesky(K);
+    std::tie(L, is_posdef) = cholesky(K);
 
     if (is_posdef == false) {
       MT_ERROR_EXIT("Trust region subproblem encountered singular Hessian.");

--- a/packages/minitensor/src/MiniTensor_Storage.h
+++ b/packages/minitensor/src/MiniTensor_Storage.h
@@ -39,6 +39,7 @@
 // ************************************************************************
 // @HEADER
 
+#include "Kokkos_Macros.hpp"
 #if !defined(MiniTensor_Storage_h)
 #define MiniTensor_Storage_h
 
@@ -49,12 +50,12 @@ namespace minitensor {
 /// Set to constant value if not dynamic
 template<Index N, Index C>
 struct dimension_const {
-  static Index const value = C;
+  static constexpr Index value = C;
 };
 
 template<Index C>
 struct dimension_const<DYNAMIC, C> {
-  static Index const value = DYNAMIC;
+  static constexpr Index value = DYNAMIC;
 };
 
 /// Validate dimension
@@ -64,13 +65,13 @@ struct check_static {
 #if defined(KOKKOS_ENABLE_CUDA)
     // Empty
 #else
-  static Index const
-  maximum_dimension = static_cast<Index>(std::numeric_limits<Index>::digits);
+  static constexpr Index maximum_dimension =
+      static_cast<Index>(std::numeric_limits<Index>::digits);
 
   static_assert(D > maximum_dimension, "Dimension is too large");
 #endif
 
-  static Index const value = D;
+    static constexpr Index value = D;
 };
 
 template<typename Store>
@@ -91,132 +92,105 @@ check_dynamic(Index const dimension)
 /// Integer power template restricted to orders defined below
 template<Index D, Index O>
 struct dimension_power {
-  static Index const value = 0;
+  static constexpr Index value = 0;
 };
 
 template<Index D>
 struct dimension_power<D, 1> {
-  static Index const value = D;
+  static constexpr Index value = D;
 };
 
 template<Index D>
 struct dimension_power<D, 2> {
-  static Index const value = D * D;
+  static constexpr Index value = D * D;
 };
 
 template<Index D>
 struct dimension_power<D, 3> {
-  static Index const value = D * D * D;
+  static constexpr Index value = D * D * D;
 };
 
 template<Index D>
 struct dimension_power<D, 4> {
-  static Index const value = D * D * D * D;
+  static constexpr Index value = D * D * D * D;
 };
 
 /// Integer square for manipulations between 2nd and 4rd-order tensors.
 template<Index N>
 struct dimension_square {
-  static Index const value = 0;
+  static constexpr Index value = 0;
 };
 
 template<>
 struct dimension_square<DYNAMIC> {
-  static Index const value = DYNAMIC;
+  static constexpr Index value = DYNAMIC;
 };
 
-template<>
-struct dimension_square<1> {
-  static Index const value = 1;
-};
+template <> struct dimension_square<1> { static constexpr Index value = 1; };
 
-template<>
-struct dimension_square<2> {
-  static Index const value = 4;
-};
+template <> struct dimension_square<2> { static constexpr Index value = 4; };
 
-template<>
-struct dimension_square<3> {
-  static Index const value = 9;
-};
+template <> struct dimension_square<3> { static constexpr Index value = 9; };
 
-template<>
-struct dimension_square<4> {
-  static Index const value = 16;
-};
+template <> struct dimension_square<4> { static constexpr Index value = 16; };
 
 /// Integer square root template restricted to dimensions defined below.
 /// Useful for constructing a 2nd-order tensor from a 4th-order
 /// tensor with static storage.
-template<Index N>
-struct dimension_sqrt {
-  static Index const value = 0;
-};
+template <Index N> struct dimension_sqrt { static constexpr Index value = 0; };
 
 template<>
 struct dimension_sqrt<DYNAMIC> {
-  static Index const value = DYNAMIC;
+  static constexpr Index value = DYNAMIC;
 };
 
-template<>
-struct dimension_sqrt<1> {
-  static Index const value = 1;
-};
+template <> struct dimension_sqrt<1> { static constexpr Index value = 1; };
 
-template<>
-struct dimension_sqrt<4> {
-  static Index const value = 2;
-};
+template <> struct dimension_sqrt<4> { static constexpr Index value = 2; };
 
-template<>
-struct dimension_sqrt<9> {
-  static Index const value = 3;
-};
+template <> struct dimension_sqrt<9> { static constexpr Index value = 3; };
 
-template<>
-struct dimension_sqrt<16> {
-  static Index const value = 4;
-};
+template <> struct dimension_sqrt<16> { static constexpr Index value = 4; };
 
 /// Manipulation of static and dynamic dimensions.
 template<Index N, Index P>
 struct dimension_add {
-  static Index const value = N + P;
+  static constexpr Index value = N + P;
 };
 
 template<Index P>
 struct dimension_add<DYNAMIC, P> {
-  static Index const value = DYNAMIC;
+  static constexpr Index value = DYNAMIC;
 };
 
 template<Index N, Index P>
 struct dimension_subtract {
-  static Index const value = N - P;
+  static constexpr Index value = N - P;
 };
 
 template<Index P>
 struct dimension_subtract<DYNAMIC, P> {
-  static Index const value = DYNAMIC;
+  static constexpr Index value = DYNAMIC;
 };
 
 template<Index N, Index P>
 struct dimension_product {
-  static Index const value = N * P;
+  static constexpr Index value = N * P;
 };
 
 template<Index N>
 struct dimension_product<N, DYNAMIC> {
-  static Index const value = DYNAMIC;
+  static constexpr Index value = DYNAMIC;
 };
 
 template<Index P>
 struct dimension_product<DYNAMIC, P> {
-  static Index const value = DYNAMIC;
+  static constexpr Index value = DYNAMIC;
 };
 
 template<>
 struct dimension_product<DYNAMIC, DYNAMIC> {
-  static Index const value = DYNAMIC;
+  static constexpr Index value = DYNAMIC;
 };
 
 ///
@@ -240,13 +214,12 @@ public:
   bool
   IS_DYNAMIC = false;
 
+  KOKKOS_INLINE_FUNCTION
   Storage()
   {
   }
 
-  explicit
-  Storage(Index const number_entries)
-  {
+  explicit KOKKOS_INLINE_FUNCTION Storage(Index const number_entries) {
     resize(number_entries);
   }
 
@@ -255,6 +228,7 @@ public:
   Storage<T, N> &
   operator=(Storage<T, N> const & s) = delete;
 
+  KOKKOS_INLINE_FUNCTION
   ~Storage()
   {
   }
@@ -316,12 +290,7 @@ public:
     return &storage_[0];
   }
 
-  static constexpr
-  Index
-  static_size()
-  {
-    return N;
-  }
+  static KOKKOS_INLINE_FUNCTION constexpr Index static_size() { return N; }
 
 private:
 
@@ -353,13 +322,12 @@ public:
   bool
   IS_STATIC = false;
 
+  KOKKOS_INLINE_FUNCTION
   Storage()
   {
   }
 
-  explicit
-  Storage(Index const number_entries)
-  {
+  explicit KOKKOS_INLINE_FUNCTION Storage(Index const number_entries) {
     resize(number_entries);
   }
 
@@ -368,6 +336,7 @@ public:
   Storage<T, DYNAMIC> &
   operator=(Storage<T, DYNAMIC> const & s) = delete;
 
+  KOKKOS_INLINE_FUNCTION
   ~Storage()
   {
     clear();
@@ -432,12 +401,7 @@ public:
     return storage_;
   }
 
-  static constexpr
-  Index
-  static_size()
-  {
-    return 0;
-  }
+  static KOKKOS_INLINE_FUNCTION constexpr Index static_size() { return 0; }
 
 private:
 

--- a/packages/minitensor/src/MiniTensor_Tensor.i.h
+++ b/packages/minitensor/src/MiniTensor_Tensor.i.h
@@ -1646,25 +1646,31 @@ transpose(Tensor<T, N> const & A)
   Tensor<T, N>
   B = A;
 
+  auto my_swap = [&](T &a, T &b) {
+    T c = a;
+    a = b;
+    b = c;
+  };
+
   switch (dimension) {
   default:
     for (Index i = 0; i < dimension; ++i) {
       for (Index j = i + 1; j < dimension; ++j) {
-        std::swap(B(i, j), B(j, i));
+        my_swap(B(i, j), B(j, i));
       }
     }
     break;
 
   case 3:
-    std::swap(B(0, 1), B(1, 0));
-    std::swap(B(0, 2), B(2, 0));
+    my_swap(B(0, 1), B(1, 0));
+    my_swap(B(0, 2), B(2, 0));
 
-    std::swap(B(1, 2), B(2, 1));
+    my_swap(B(1, 2), B(2, 1));
 
     break;
 
   case 2:
-    std::swap(B(0, 1), B(1, 0));
+    my_swap(B(0, 1), B(1, 0));
 
     break;
   }

--- a/packages/minitensor/src/MiniTensor_TensorBase.i.h
+++ b/packages/minitensor/src/MiniTensor_TensorBase.i.h
@@ -399,6 +399,8 @@ TensorBase<T, ST>::fill(Filler const value)
     }
     break;
 
+#ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
+
   case Filler::RANDOM:
     for (Index i = 0; i < number_components; ++i) {
       auto & entry = (*this)[i];
@@ -423,6 +425,8 @@ TensorBase<T, ST>::fill(Filler const value)
     }
     break;
 
+#endif
+
   case Filler::NANS:
     for (Index i = 0; i < number_components; ++i) {
       auto & entry = (*this)[i];
@@ -432,7 +436,8 @@ TensorBase<T, ST>::fill(Filler const value)
     break;
 
   default:
-    MT_ERROR_EXIT("Unknown specification of value for filling components.");
+    MT_ERROR_EXIT("Unknown or undefined (in execution space) specification of "
+                  "value for filling components.");
     break;
   }
 

--- a/packages/minitensor/src/MiniTensor_Utilities.h
+++ b/packages/minitensor/src/MiniTensor_Utilities.h
@@ -141,26 +141,17 @@ tau();
 /// Random number generation. Uniform distribution U(-1,1)
 /// which is the Teuchos default (!).
 ///
-template<typename T>
-KOKKOS_INLINE_FUNCTION
-typename Sacado::ScalarType<T>::type
-random();
+template <typename T> typename Sacado::ScalarType<T>::type random();
 
 ///
 /// Random number generation. Uniform distribution U(0,1).
 ///
-template<typename T>
-KOKKOS_INLINE_FUNCTION
-typename Sacado::ScalarType<T>::type
-random_uniform();
+template <typename T> typename Sacado::ScalarType<T>::type random_uniform();
 
 ///
 /// Random number generation. Normal distribution N(0,1).
 ///
-template<typename T>
-KOKKOS_INLINE_FUNCTION
-typename Sacado::ScalarType<T>::type
-random_normal();
+template <typename T> typename Sacado::ScalarType<T>::type random_normal();
 
 ///
 /// Fill all levels of AD to specified constant.

--- a/packages/minitensor/src/MiniTensor_Utilities.i.h
+++ b/packages/minitensor/src/MiniTensor_Utilities.i.h
@@ -187,11 +187,7 @@ tau()
 //
 // Random number generation. Teuchos [-1,1]
 //
-template<typename T>
-KOKKOS_INLINE_FUNCTION
-typename Sacado::ScalarType<T>::type
-random()
-{
+template <typename T> typename Sacado::ScalarType<T>::type random() {
   using S = typename Sacado::ScalarType<T>::type;
   return Teuchos::ScalarTraits<S>().random();
 }
@@ -199,11 +195,7 @@ random()
 //
 // Uniform [0,1] random number generation.
 //
-template<typename T>
-KOKKOS_INLINE_FUNCTION
-typename Sacado::ScalarType<T>::type
-random_uniform()
-{
+template <typename T> typename Sacado::ScalarType<T>::type random_uniform() {
   using S = typename Sacado::ScalarType<T>::type;
   return static_cast<S>(0.5 * random<S>() + 0.5);
 }
@@ -211,11 +203,7 @@ random_uniform()
 //
 // Normal N(0,1) random number generation.
 //
-template<typename T>
-KOKKOS_INLINE_FUNCTION
-typename Sacado::ScalarType<T>::type
-random_normal()
-{
+template <typename T> typename Sacado::ScalarType<T>::type random_normal() {
   using S = typename Sacado::ScalarType<T>::type;
 
   S const

--- a/packages/minitensor/src/MiniTensor_Vector.h
+++ b/packages/minitensor/src/MiniTensor_Vector.h
@@ -506,7 +506,6 @@ unit(Vector<T, N> const & u);
 /// \return v, beta
 ///
 template<typename T, Index N>
-KOKKOS_INLINE_FUNCTION
 std::pair<Vector<T, N>, T>
 house(Vector<T, N> const & x);
 

--- a/packages/minitensor/src/MiniTensor_Vector.i.h
+++ b/packages/minitensor/src/MiniTensor_Vector.i.h
@@ -39,6 +39,7 @@
 // ************************************************************************
 // @HEADER
 
+#include "Kokkos_ArithTraits.hpp"
 #if !defined(MiniTensor_Vector_i_h)
 #define MiniTensor_Vector_i_h
 
@@ -802,6 +803,8 @@ KOKKOS_INLINE_FUNCTION
 T
 norm_infinity(Vector<T, N> const & u)
 {
+  using KAT = Kokkos::ArithTraits<T>;
+
   Index const
   dimension = u.get_dimension();
 
@@ -812,16 +815,16 @@ norm_infinity(Vector<T, N> const & u)
 
   default:
     for (Index i = 0; i < dimension; ++i) {
-      s = std::max(s, std::abs(u(i)));
+      s = max(KAT::abs(u(i)), s);
     }
     break;
 
   case 3:
-    s = std::max(std::max(std::abs(u(0)), std::abs(u(1))), std::abs(u(2)));
+    s = max(max(KAT::abs(u(0)), KAT::abs(u(1))), KAT::abs(u(2)));
     break;
 
   case 2:
-    s = std::max(std::abs(u(0)), std::abs(u(1)));
+    s = max(KAT::abs(u(0)), KAT::abs(u(1)));
     break;
   }
 
@@ -842,11 +845,8 @@ unit(Vector<T, N> const & u)
 //
 // Compute Householder vector
 //
-template<typename T, Index N>
-KOKKOS_INLINE_FUNCTION
-std::pair<Vector<T, N>, T>
-house(Vector<T, N> const & x)
-{
+template <typename T, Index N>
+std::pair<Vector<T, N>, T> house(Vector<T, N> const &x) {
   Vector<T, N>
   v = x;
 

--- a/packages/minitensor/test/test_01.cc
+++ b/packages/minitensor/test/test_01.cc
@@ -901,7 +901,7 @@ TEST(MiniTensor, SymmetricEigen)
   Tensor<Real> V(3);
   Tensor<Real> D(3);
 
-  boost::tie(V, D) = eig_sym(A);
+  std::tie(V, D) = eig_sym(A);
 
   ASSERT_LE(std::abs(D(0, 0) - 1.1), machine_epsilon<Real>());
   ASSERT_LE(std::abs(D(1, 1) - 1.0), machine_epsilon<Real>());
@@ -921,7 +921,7 @@ TEST(MiniTensor, LeftPolarDecomposition)
   Tensor<Real> V(3);
   Tensor<Real> R(3);
 
-  boost::tie(V, R) = polar_left(F);
+  std::tie(V, R) = polar_left(F);
 
   Real const
   error_x = norm(V - X) / norm(X);
@@ -1031,7 +1031,7 @@ TEST(MiniTensor, PolarLeftLog)
 
   Tensor<Real> V(3), R(3), v(3);
 
-  boost::tie(V, R, v) = polar_left_logV(F);
+  std::tie(V, R, v) = polar_left_logV(F);
 
   Real const error = norm(v - x) / norm(x);
 
@@ -1084,7 +1084,7 @@ TEST(MiniTensor, SVD2x2)
 
   Tensor<Real> U(2), S(2), V(2);
 
-  boost::tie(U, S, V) = svd(A);
+  std::tie(U, S, V) = svd(A);
 
   Tensor<Real> B = U * S * transpose(V);
 
@@ -1099,7 +1099,7 @@ TEST(MiniTensor, SVD3x3)
 
   Tensor<Real> U(3), S(3), V(3);
 
-  boost::tie(U, S, V) = svd(A);
+  std::tie(U, S, V) = svd(A);
 
   Tensor<Real> const B = U * S * transpose(V);
 
@@ -1115,7 +1115,7 @@ TEST(MiniTensor, SVD3x3Fad)
 
   Tensor<Sacado::Fad::DFad<Real>> U(3), S(3), V(3);
 
-  boost::tie(U, S, V) = svd(A);
+  std::tie(U, S, V) = svd(A);
 
   Tensor<Sacado::Fad::DFad<Real>> const
   B = U * S * transpose(V);
@@ -1183,7 +1183,7 @@ TEST(MiniTensor, SymmetricEigen2x2)
 
   Tensor<Real> V(2), D(2);
 
-  boost::tie(V, D) = eig_sym(A);
+  std::tie(V, D) = eig_sym(A);
 
   Tensor<Real> const B = V * D * transpose(V);
 
@@ -1198,7 +1198,7 @@ TEST(MiniTensor, SymmetricEigen3x3)
 
   Tensor<Real> V(3), D(3);
 
-  boost::tie(V, D) = eig_sym(A);
+  std::tie(V, D) = eig_sym(A);
 
   Tensor<Real> const B = V * D * transpose(V);
 
@@ -1213,11 +1213,11 @@ TEST(MiniTensor, Polar3x3)
 
   Tensor<Real> R(3), U(3);
 
-  boost::tie(R, U) = polar_right(A);
+  std::tie(R, U) = polar_right(A);
 
   Tensor<Real> X(3), D(3), Y(3);
 
-  boost::tie(X, D, Y) = svd(A);
+  std::tie(X, D, Y) = svd(A);
 
   Tensor<Real> const B = R - X * transpose(Y) + U - Y * D * transpose(Y);
 
@@ -1234,7 +1234,7 @@ TEST(MiniTensor, Cholesky)
 
   bool is_spd;
 
-  boost::tie(G, is_spd) = cholesky(A);
+  std::tie(G, is_spd) = cholesky(A);
 
   Tensor<Real> const B(1.0, 0.0, 0.0, 1.0, 2.0, 0.0, 1.0, 1.0, 1.0);
 


### PR DESCRIPTION
Fix a bunch of `KOKKOS_INLINE_FUNCTION` markings on functions. std::pair, boost::tuple, and associated helper functions were the primary problem.

The MiniTensor class `Storage` still needs some work with the `DYNAMIC` option, as memory will need to be allocated using some flavor of `cudaMalloc` in these cases. I left markings in place for now to avoid so many warnings.

@trilinos/MiniTensor @lxmota

## Motivation
Fix CUDA build warnings; hundreds or thousands were showing up in application builds.

## Related Issues
* Closes #9805

## Stakeholder Feedback

## Testing
Could use more tests with a variety of instantiations to expose problems with other potential use cases.