### PR TITLE
Framework: Add the Kokkos_ENABLE_SERIAL=OFF option to the GCC 8.3.0 PR build

### DIFF
--- a/cmake/std/PullRequestLinuxGCC8.3.0TestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxGCC8.3.0TestingSettings.cmake
@@ -18,7 +18,7 @@ set (MPI_EXEC_PRE_NUMPROCS_FLAGS "--bind-to;none" CACHE STRING "Set by default f
 # NOTE: The above is a workaround for the problem of having threads on MPI
 # ranks bind to the same cores (see #2422).
 
-set(Tpetra_INST_SERIAL ON CACHE BOOL "Set by default for PR testing")
+#set(Tpetra_INST_SERIAL ON CACHE BOOL "Set by default for PR testing")
 set (Kokkos_ENABLE_SERIAL OFF CACHE BOOL "Set Kokkos Serial to OFF for PR test")
 # note: mortar uses serial mode no matter what so we need to instantiate this to get it's examples to work
 

--- a/cmake/std/PullRequestLinuxGCC8.3.0TestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxGCC8.3.0TestingSettings.cmake
@@ -19,6 +19,7 @@ set (MPI_EXEC_PRE_NUMPROCS_FLAGS "--bind-to;none" CACHE STRING "Set by default f
 # ranks bind to the same cores (see #2422).
 
 set(Tpetra_INST_SERIAL ON CACHE BOOL "Set by default for PR testing")
+set (Kokkos_ENABLE_SERIAL OFF CACHE BOOL "Set Kokkos Serial to OFF for PR test")
 # note: mortar uses serial mode no matter what so we need to instantiate this to get it's examples to work
 
 set (Trilinos_ENABLE_COMPLEX_DOUBLE ON CACHE BOOL "Set by default for PR testing to exercise complex doubles case")


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/Framework

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
This was originally requested by @mperego and filed as #7441. That system has been migrated to Jira.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->
The request was to have this added to the GCC 4.8.4 PR build. Since that has been retired, GCC 8.3.0 was suggested.

The Kokkos_ENABLE_SERIAL OFF flag conflicts with the Tpetra_INST_SERIAL ON.
It appears the Tpetra_INST_SERIAL ON flag was only added to 8.3.0 because the GCC 4.8.4 build that use it was being retired when we moved to C++14. #8324
I did check to make sure at least one PR build still uses Tpetra_INST_SERIAL ON. It still exists in the Cuda PR builds, Cuda 10.1.105, Cuda 10.1.105 UVM OFF, and Cuda 10.1.243.

This flag can be added with minimal build issues. However, those issues will need to be taken care of before this can be merged.
As of [the last time I ran a test](https://testing.sandia.gov/cdash/index.php?project=Trilinos&parentid=10048936&filtercount=1&showfilters=1&field1=buildstamp&compare1=63&value1=Experimental&filtercombine=and), pacakges with build errors included @trilinos/moertel, @trilinos/tpetra, @trilinos/stk, & @trilinos/trilinoscouplings. Most all of them seem to be related to making serial specific calls when serial is off.
<!--- 
## Stakeholder Feedback

If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
<!---
## Testing

Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->


## Additional Information
<!--- 
Anything else we need to know in evaluating this merge request?
 -->
I've run through a few different possible PR builds for this and GCC 8.3.0 seems to be the best candidate. [CDash](https://testing.sandia.gov/cdash/index.php?project=Trilinos&display=project&filtercount=2&showfilters=1&filtercombine=and&field1=buildname&compare1=63&value1=Kokkos_ENABLE_SERIAL&field2=buildstamp&compare2=63&value2=Experimental)