### PR TITLE
Thyra: fix invalid enum reference for SpmdVectorDefaultBase

### DIFF
--- a/packages/thyra/core/src/support/operator_vector/adapter_support/Thyra_SpmdVectorDefaultBase_def.hpp
+++ b/packages/thyra/core/src/support/operator_vector/adapter_support/Thyra_SpmdVectorDefaultBase_def.hpp
@@ -57,7 +57,7 @@
 #include "Teuchos_Assert.hpp"
 #include "Teuchos_dyn_cast.hpp"
 #include "Teuchos_Assert.hpp"
-
+#include "Teuchos_Range1D.hpp"
 
 namespace Thyra {
 
@@ -200,7 +200,7 @@ void SpmdVectorDefaultBase<Scalar>::acquireDetachedVectorViewImpl(
 #ifdef THYRA_DEBUG
   TEUCHOS_ASSERT(sub_vec);
 #endif
-  if( rng_in == Range1D::Invalid ) {
+  if( rng_in == Range1D::INVALID ) {
     // Just return an null view
     *sub_vec = RTOpPack::ConstSubVectorView<Scalar>();
     return;
@@ -270,7 +270,7 @@ void SpmdVectorDefaultBase<Scalar>::acquireNonconstDetachedVectorViewImpl(
 #ifdef THYRA_DEBUG
   TEUCHOS_ASSERT(sub_vec);
 #endif
-  if( rng_in == Range1D::Invalid ) {
+  if( rng_in == Range1D::INVALID ) {
     // Just return an null view
     *sub_vec = RTOpPack::SubVectorView<Scalar>();
     return;


### PR DESCRIPTION
@trilinos/ Thyra

## Motivation
When compiling using gcc-10.3.0 using msys2-ming64, I get an error regarding an undefined reference to `Teuchos:Range1D:Invalid`, which appears to be referring to the enum value `INVALID`, i.e.:

```
  enum EInvalidRange { INVALID };

  /** \brief Used for Range1D(INVALID) */
  static const Range1D Invalid;
```

(This surprised me a little, as I'd assumed the declared static constant would work as-declared, however it appears to require the use of `INVALID` to properly compile.)

## Related Issues

* Related to #9802

## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->