### PR TITLE
ML: Fix socket references for Windows builds

### DIFF
--- a/packages/ml/src/CMakeLists.txt
+++ b/packages/ml/src/CMakeLists.txt
@@ -329,3 +329,7 @@ TRIBITS_ADD_LIBRARY(
   HEADERS ${HEADERS}
   SOURCES ${SOURCES}
   )
+
+if (WIN32)
+	target_link_libraries (ml PUBLIC ws2_32)
+endif ()

--- a/packages/ml/src/MLAPI/MLAPI_Workspace.cpp
+++ b/packages/ml/src/MLAPI/MLAPI_Workspace.cpp
@@ -16,6 +16,10 @@
 #ifdef _MSC_VER
 #include "winprocess.h"
 #endif
+#include <unistd.h>
+#ifdef _WIN32
+#include <winsock2.h>
+#endif
 
 namespace MLAPI {
 

--- a/packages/ml/src/Utils/ml_epetra_utils.cpp
+++ b/packages/ml/src/Utils/ml_epetra_utils.cpp
@@ -43,6 +43,10 @@
 #ifdef _MSC_VER
 # include "winprocess.h"
 #endif
+#include <unistd.h>
+#ifdef _WIN32
+#include <winsock2.h>
+#endif
 
 #ifdef HAVE_ML_TEUCHOS
 using namespace Teuchos;
@@ -51,7 +55,6 @@ using namespace Teuchos;
 #ifdef HAVE_ML_EPETRAEXT
 #include "EpetraExt_MatrixMatrix.h"
 #endif
-
 
 // ======================================================================
 


### PR DESCRIPTION
This fixes references to the Windows socket library used in the ML package (i.e., properly linking the winsock2.h header and linking to the Windows socket library); this is necessary to get Windows-based msys builds to work.

@trilinos/ @jhux2 

## Motivation
Somewhat related to #9802, in that it is blocking Trilinos from building on msys2 for a native windows build. (Note: refresh of prior PR, this time based off `develop`).

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->