### PR TITLE
MueLu: fix ReitzingerPFactory for non-UVM

### DIFF
--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_ReitzingerPFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_ReitzingerPFactory_def.hpp
@@ -388,13 +388,13 @@ namespace MueLu {
         ArrayView<const LO>  columns;
         ArrayView<const SC>  values;
         Pe->getLocalRowView(i,columns,values);
-        // FIXME: This won't work on fancy nodes
-        ArrayView<SC> values_nc = Teuchos::av_const_cast<SC>(values);
+        Teuchos::Array<SC> newValues(values.size());
         for (LO j=0; j<(LO)values.size(); j++)
-          if ((values_nc[j] == one || values_nc[j] == neg_one))
-            values_nc[j] = zero;       
+          if ((values[j] == one || values[j] == neg_one))
+            newValues[j] = zero;
           else
-            values_nc[j] /= two;
+            newValues[j] = values[j] / two;
+        Pe->replaceLocalValues(i,columns,newValues());
       }//end for i < Ne
       Pe->fillComplete(Pe->getDomainMap(),Pe->getRangeMap());
     }


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/muelu 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Makes RefMaxwell tests using Reitzinger pass in non-UVM Cuda build. It was casting away const on a read-only local row view so those changes were not synced back to device.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
Makes MueLu_ReitzingerPFactory_MPI_4 and MueLu_Maxwell3D-Tpetra_2_MPI_4 pass with ``-DTpetra_ENABLE_CUDA_UVM=OFF`` - those failed before.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->