### PR TITLE
tpetra:  #9799 changed HAVE_TEUCHOS_DEBUG to HAVE_TPETRA_DEBUG

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_DistributorActor.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorActor.hpp
@@ -517,7 +517,7 @@ void DistributorActor::doPosts(const DistributorPlan& plan,
   const int myProcID = plan.getComm()->getRank ();
   size_t selfReceiveOffset = 0;
 
-#ifdef HAVE_TEUCHOS_DEBUG
+#ifdef HAVE_TPETRA_DEBUG
   // Different messages may have different numbers of packets.
   size_t totalNumImportPackets = 0;
   for (size_type ii = 0; ii < numImportPacketsPerLID.size (); ++ii) {
@@ -529,7 +529,7 @@ void DistributorActor::doPosts(const DistributorPlan& plan,
       "enough entries to hold the expected number of import packets.  "
       "imports.extent(0) = " << imports.extent (0) << " < "
       "totalNumImportPackets = " << totalNumImportPackets << ".");
-#endif // HAVE_TEUCHOS_DEBUG
+#endif // HAVE_TPETRA_DEBUG
 
   // MPI tag for nonblocking receives and blocking sends in this
   // method.  Some processes might take the "fast" path
@@ -539,12 +539,12 @@ void DistributorActor::doPosts(const DistributorPlan& plan,
   const int pathTag = 1;
   const int tag = plan.getTag(pathTag);
 
-#ifdef HAVE_TEUCHOS_DEBUG
+#ifdef HAVE_TPETRA_DEBUG
   TEUCHOS_TEST_FOR_EXCEPTION
     (requests_.size () != 0, std::logic_error, "Tpetra::Distributor::"
      "doPosts(4 args, Kokkos): Process " << myProcID << ": requests_.size () = "
      << requests_.size () << " != 0.");
-#endif // HAVE_TEUCHOS_DEBUG
+#endif // HAVE_TPETRA_DEBUG
   // Distributor uses requests_.size() as the number of outstanding
   // nonblocking message requests, so we resize to zero to maintain
   // this invariant.

--- a/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.cpp
@@ -663,24 +663,25 @@ void DistributorPlan::computeReceives()
   // either be 0 or 1.
   {
     Array<int> toProcsFromMe (numProcs, 0);
-#ifdef HAVE_TEUCHOS_DEBUG
+#ifdef HAVE_TPETRA_DEBUG
     bool counting_error = false;
-#endif // HAVE_TEUCHOS_DEBUG
+#endif // HAVE_TPETRA_DEBUG
     for (size_t i = 0; i < (numSendsToOtherProcs_ + (sendMessageToSelf_ ? 1 : 0)); ++i) {
-#ifdef HAVE_TEUCHOS_DEBUG
+#ifdef HAVE_TPETRA_DEBUG
       if (toProcsFromMe[procIdsToSendTo_[i]] != 0) {
         counting_error = true;
       }
-#endif // HAVE_TEUCHOS_DEBUG
+#endif // HAVE_TPETRA_DEBUG
       toProcsFromMe[procIdsToSendTo_[i]] = 1;
     }
-#ifdef HAVE_TEUCHOS_DEBUG
+#ifdef HAVE_TPETRA_DEBUG
+    // Note that SHARED_TEST_FOR_EXCEPTION does a global reduction
     SHARED_TEST_FOR_EXCEPTION(counting_error, std::logic_error,
         "Tpetra::Distributor::computeReceives: There was an error on at least "
         "one process in counting the number of messages send by that process to "
         "the other processs.  Please report this bug to the Tpetra developers.",
         *comm_);
-#endif // HAVE_TEUCHOS_DEBUG
+#endif // HAVE_TPETRA_DEBUG
 
     // Compute the number of receives that this process needs to
     // post.  The number of receives includes any self sends (i.e.,

--- a/packages/tpetra/core/src/Tpetra_Details_checkGlobalError.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_checkGlobalError.cpp
@@ -86,12 +86,12 @@ checkGlobalError(std::ostream& globalOutputStream,
       Details::gathervPrint(globalOutputStream, lclMsg.str(), comm);
     }
 
-#ifdef HAVE_TEUCHOS_MPI
+#ifdef HAVE_TPETRA_MPI
     (void) MPI_Abort(MPI_COMM_WORLD, -1);
 #else
     TEUCHOS_TEST_FOR_EXCEPTION
       (true, std::runtime_error, "Tpetra reports a global error.");
-#endif // HAVE_TEUCHOS_MPI
+#endif // HAVE_TPETRA_MPI
   }
 }
 

--- a/packages/tpetra/core/src/Tpetra_HashTable_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_HashTable_decl.hpp
@@ -88,10 +88,10 @@ class HashTable : public Teuchos::Describable {
   Node ** Container_; //!< The table; an array of linked lists.
   KeyType Size_;
   unsigned int Seed_; //!< Parameter for hash function; not used.
-#ifdef HAVE_TEUCHOS_DEBUG
+#ifdef HAVE_TPETRA_DEBUG
   int maxc_; // Max size of the list among all entries w/ collisions. debug only.
   int nc_;   // Number of entries with collisions; use only in debug mode.
-#endif // HAVE_TEUCHOS_DEBUG
+#endif // HAVE_TPETRA_DEBUG
 
   /// The hash function.
   /// It returns \c int no matter the value type.

--- a/packages/tpetra/core/src/Tpetra_HashTable_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_HashTable_def.hpp
@@ -147,7 +147,7 @@ HashTable( const int size, const unsigned int seed )
   Size_ = getRecommendedSize(size);
   Container_ = new Node * [Size_];
   for( KeyType i = 0; i < Size_; ++i ) Container_[i] = NULL;
-#ifdef HAVE_TEUCHOS_DEBUG
+#ifdef HAVE_TPETRA_DEBUG
   maxc_ = 0;
   nc_ = 0;
 #endif
@@ -160,7 +160,7 @@ HashTable( const HashTable & obj )
     Size_(obj.Size_),
     Seed_(obj.Seed_)
 {
-#ifdef HAVE_TEUCHOS_DEBUG
+#ifdef HAVE_TPETRA_DEBUG
   maxc_ = 0;
   nc_ = 0;
 #endif
@@ -199,19 +199,19 @@ HashTable<KeyType, ValueType>::
 get( const KeyType key ) {
   Node * n = Container_[ hashFunc(key) ];
 
-#ifdef HAVE_TEUCHOS_DEBUG
+#ifdef HAVE_TPETRA_DEBUG
   int k = 0;
 #endif
 
   while( n && (n->Key != key) ){
     n = n->Ptr;
-#ifdef HAVE_TEUCHOS_DEBUG
+#ifdef HAVE_TPETRA_DEBUG
     ((k+1 > maxc_) ? maxc_ = k+1 : 0) ;
     k++;
 #endif
   }
 
-#ifdef HAVE_TEUCHOS_DEBUG
+#ifdef HAVE_TPETRA_DEBUG
   if (k != 0) nc_++;
 #endif
   if( n ) return n->Value;
@@ -272,7 +272,7 @@ void HashTable<KeyType, ValueType>::describe(
         out << "Size_: " << Size_ << endl;
       }
       out << "}" << endl;
-#ifdef HAVE_TEUCHOS_DEBUG
+#ifdef HAVE_TPETRA_DEBUG
       out << "Debug info: {" << endl;
       {
         OSTab tab2 (rcpFromRef (out));
@@ -280,7 +280,7 @@ void HashTable<KeyType, ValueType>::describe(
             << "Total number of collisions: " << nc_ << endl;
       }
       out << "}" << endl;
-#endif // HAVE_TEUCHOS_DEBUG
+#endif // HAVE_TPETRA_DEBUG
 
       if (vl >= VERB_EXTREME) {
         out << "Contents: ";

--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -2741,22 +2741,6 @@ namespace Tpetra {
     // was replaced with a Map with fewer processes, and finally the
     // original Map was restored on this call to replaceMap.
 
-#ifdef HAVE_TEUCHOS_DEBUG
-    // mfh 28 Mar 2013: We can't check for compatibility across the
-    // whole communicator, unless we know that the current and new
-    // Maps are nonnull on _all_ participating processes.
-    // TEUCHOS_TEST_FOR_EXCEPTION(
-    //   origNumProcs == newNumProcs && ! this->getMap ()->isCompatible (*map),
-    //   std::invalid_argument, "Tpetra::MultiVector::project: "
-    //   "If the input Map's communicator is compatible (has the same number of "
-    //   "processes as) the current Map's communicator, then the two Maps must be "
-    //   "compatible.  The replaceMap() method is not for data redistribution; "
-    //   "use Import or Export for that purpose.");
-
-    // TODO (mfh 28 Mar 2013) Add compatibility checks for projections
-    // of the Map, in case the process counts don't match.
-#endif // HAVE_TEUCHOS_DEBUG
-
     if (this->getMap ().is_null ()) { // current Map is null
       // If this->getMap() is null, that means that this MultiVector
       // has already had replaceMap happen to it.  In that case, just

--- a/packages/tpetra/core/src/Tpetra_Util.hpp
+++ b/packages/tpetra/core/src/Tpetra_Util.hpp
@@ -206,20 +206,6 @@
       msg << " Failure on at least one process, including process " << gbl_throw-1 << "." << std::endl); \
 }
 
-#ifdef HAVE_TEUCHOS_DEBUG
-//! If TEUCHOS_DEBUG is defined, then it calls SHARED_TEST_FOR_EXCEPTION. Otherwise, it calls TEUCHOS_TEST_FOR_EXCEPTION
-#define SWITCHED_TEST_FOR_EXCEPTION(throw_exception_test,Exception,msg,comm) \
-{ \
-    SHARED_TEST_FOR_EXCEPTION(throw_exception_test,Exception,msg,comm); \
-}
-#else
-//! If TEUCHOS_DEBUG is defined, then it calls SHARED_TEST_FOR_EXCEPTION. Otherwise, it calls TEUCHOS_TEST_FOR_EXCEPTION
-#define SWITCHED_TEST_FOR_EXCEPTION(throw_exception_test,Exception,msg,comm) \
-{ \
-    TEUCHOS_TEST_FOR_EXCEPTION(throw_exception_test,Exception,msg); \
-}
-#endif
-
 namespace Tpetra {
 
   /// \brief Efficiently insert or replace an entry in an std::map.

--- a/packages/tpetra/core/test/MultiVector/MultiVector_UnitTests.cpp
+++ b/packages/tpetra/core/test/MultiVector/MultiVector_UnitTests.cpp
@@ -1699,7 +1699,7 @@ namespace {
       // incompatible numvecs
       TEST_THROW(mv22.dot(mv21,dots()),std::runtime_error);
       // too small output array
-#ifdef TEUCHOS_DEBUG
+#ifdef HAVE_TPETRA_DEBUG
       TEST_THROW(mv22.dot(mv22,dots(0,1)),std::runtime_error);
 #endif
     }
@@ -1711,7 +1711,7 @@ namespace {
       TEST_THROW(v2.dot(v1),std::runtime_error);
       // wrong size output array through MultiVector interface
       Array<Scalar> dots(2);
-#ifdef TEUCHOS_DEBUG
+#ifdef HAVE_TPETRA_DEBUG
       TEST_THROW(v1.dot(v2,dots()),std::runtime_error);
       TEST_THROW(v2.dot(v1,dots()),std::runtime_error);
 #endif


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 


## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

To me, it was weird to control Tpetra code with Teuchos' DEBUG macros.
This PR changes HAVE_TEUCHOS_DEBUG to HAVE_TPETRA_DEBUG in Tpetra code.

It also changes HAVE_TEUCHOS_MPI to HAVE_TPETRA_MPI in some cases.
In a few examples that also use Epetra, I let HAVE_TEUCHOS_MPI remain.

I removed a few never-used things, too.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Tested on ascicgpu030 with sems compilers, serial node.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->