### PR TITLE
tpetra:  return packed indices always in getNodePackedIndices

### DIFF
--- a/packages/tpetra/core/inout/Tpetra_DistributionLowerTriangularBlock.hpp
+++ b/packages/tpetra/core/inout/Tpetra_DistributionLowerTriangularBlock.hpp
@@ -373,10 +373,6 @@ public:
     Teuchos::broadcast<int,gno_t>(*comm, 0, chunkCuts(0,nChunks+1));
     chunksComputed = true;
 
-    //std::cout << comm->getRank() << " KDDKDD chunkCuts: ";
-    //for (int kdd=0; kdd <= nChunks; kdd++) std::cout << chunkCuts[kdd] << " ";
-    //std::cout << std::endl;
-
     // Determine new owner of each nonzero; buffer for sending
     Teuchos::Array<gno_t> iOut(localNZ.size());
     Teuchos::Array<gno_t> jOut(localNZ.size());
@@ -393,13 +389,6 @@ public:
         vOut[sendCnt] = it->second;
         pOut[sendCnt] = procFromChunks(iOut[sendCnt], jOut[sendCnt]);
 
-        //std::cout << comm->getRank() 
-        //          << "    KDDKDD IJ (" 
-        //          << it->first.first << "," << it->first.second
-        //          << ") permuted to ("
-        //          << iOut[sendCnt] << "," << jOut[sendCnt] 
-        //          << ") being sent to " << pOut[sendCnt]
-        //          << std::endl;
         sendCnt++;
       }
     }

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -306,21 +306,6 @@ public:
     using offset_device_view_type =
           typename row_ptrs_device_view_type::non_const_type;
 
-
-//KDDKDD INROW    using local_inds_host_view_type = 
-//KDDKDD INROW          typename local_inds_dualv_type::t_host::const_type;
-
-//KDDKDD INROW    using global_inds_host_view_type = 
-//KDDKDD INROW          typename global_inds_dualv_type::t_host::const_type;
-
-    //! The Kokkos::View type for views of local ordinals on device
-//KDDKDD INROW    using local_inds_device_view_type = 
-//KDDKDD INROW          typename local_inds_dualv_type::t_dev::const_type;
-
-    //! The Kokkos::View type for views of global ordinals on device
-//KDDKDD INROW    using global_inds_device_view_type = 
-//KDDKDD INROW          typename global_inds_dualv_type::t_dev::const_type;
-
     //! @name Constructor/Destructor Methods
     //@{
 
@@ -2298,11 +2283,6 @@ public:
     // indices array.  (Karen is skeptical that !OptimizedStorage works)
     // When OptimizedStorage, rowPtrsUnpacked_ = k_rowPtrsPacked_
 
-//KDDKDD INROW    using row_ptrs_device_view_type = 
-//KDDKDD INROW          Kokkos::View<const typename local_graph_device_type::size_type *, 
-//KDDKDD INROW                       device_type> ;
-//KDDKDD INROW    using row_ptrs_host_view_type = 
-//KDDKDD INROW          typename row_ptrs_device_view_type::HostMirror::const_type;
     row_ptrs_device_view_type rowPtrsUnpacked_dev_;
     row_ptrs_host_view_type rowPtrsUnpacked_host_;
 
@@ -2329,9 +2309,8 @@ public:
     }
     
   
-//KDDKDD Make private -- matrix shouldn't access directly
     /// \brief Local ordinals of colum indices for all rows
-    /// KDDKDD UVM Removal:   Device view takes place of k_lclInds1D_
+    /// UVM REMOVAL:   Device view takes place of k_lclInds1D_
     /// Valid when isLocallyIndexed is true
     /// If OptimizedStorage, storage is PACKED after fillComplete
     /// If not OptimizedStorate, storage is UNPACKED after fillComplete; 
@@ -2342,10 +2321,12 @@ public:
     ///
     ///   - The calling process has a nonzero number of entries
     ///   - The graph is locally indexed
+
+    // TODO: Make private -- matrix shouldn't access directly
     local_inds_wdv_type lclIndsUnpacked_wdv;
 
     /// \brief Local ordinals of colum indices for all rows
-    /// KDDKDD UVM Removal:   Device view takes place of lclGraph_.entries
+    /// UVM REMOVAL:   Device view takes place of lclGraph_.entries
     /// Valid when isLocallyIndexed is true
     /// Built during fillComplete or non-fillComplete constructors
     /// Storage is PACKED after fillComplete
@@ -2358,15 +2339,15 @@ public:
     ///   - The graph is locally indexed
     mutable local_inds_wdv_type lclIndsPacked_wdv;
 
-//KDDKDD Make private -- matrix shouldn't access directly
     /// \brief Global ordinals of column indices for all rows
-    /// KDDKDD UVM Removal:   Device view takes place of k_gblInds1D_
+    /// UVM REMOVAL:   Device view takes place of k_gblInds1D_
     ///
     /// This is allocated only if
     ///
     ///   - The calling process has a nonzero number of entries
     ///   - The graph is globally indexed
 
+    // TODO: Make private -- matrix shouldn't access directly
     global_inds_wdv_type gblInds_wdv;
 
     /// \brief Get a const, locally indexed view of the

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -4067,19 +4067,6 @@ public:
     Teuchos::RCP<      Graph>     myGraph_;
     //@}
 
-    //! The local sparse matrix, wrapped in a multiply operator.
-// KDDKDD DELETE
-//    std::shared_ptr<local_multiply_op_type> lclMatrix_;
-// KDDKDD DELETE
-
-    /// \brief Sparse matrix values, as part of compressed sparse row
-    ///   ("1-D") storage.
-    ///
-    /// Before allocation, this array is empty.
-// KDDKDD DELETE
-    typename local_matrix_device_type::values_type k_values1D_;
-// KDDKDD DELETE
-
 protected:
     /// \brief Status of the matrix's storage, when not in a
     ///   fill-complete state.

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -1307,9 +1307,20 @@ namespace Tpetra {
         "Caught exception while calling graph->getNodePackedIndices(): "
         << e.what ());
     }
+
+    // UVM REMOVAL:  10/21
+    // This function originally returned unpacked values.  But ...
+    // (1) it was used in tandem with getNodePackedIndices, which intends
+    //     to return packed indices;
+    // (2) unpacked values are not useful without a count of number
+    //     of valid indices in the row, which is not provided by this function;
+    // (3) in most cases, graphs are storageOptimized, so packed and unpacked
+    //     row pointers are the same.
+    // To match getNodePackedIndices, we change this function to return 
+    // packed values
     Teuchos::ArrayRCP<const impl_scalar_type> vals =
 //      Kokkos::Compat::persistingView (k_values1D_);
-      Kokkos::Compat::persistingView (valuesUnpacked_wdv.getHostView(Access::ReadOnly));
+      Kokkos::Compat::persistingView (valuesPacked_wdv.getHostView(Access::ReadOnly));
     values = Teuchos::arcp_reinterpret_cast<const Scalar> (vals);
   }
 
@@ -1324,7 +1335,7 @@ namespace Tpetra {
       relevantGraph.is_null (), std::runtime_error,
       "Requires that getCrsGraph() is not null.");
     Teuchos::ArrayRCP<impl_scalar_type> vals =
-      Kokkos::Compat::persistingView (k_values1D_);
+      Kokkos::Compat::persistingView (valuesPacked_wdv.getHostView(Access::ReadWrite));
     values = Teuchos::arcp_reinterpret_cast<Scalar> (vals);
   }
 


### PR DESCRIPTION


<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->


As we removed UVM dependence from Tpetra, we saw that CrsGraph::getNodePackedIndices returned k_lclInds1D_, which was packed iff fillComplete was called with storageOptimized. Thus, if not storageOptimized, this function might return unpacked indices. However, unpacked indices aren't useful without the number of entries in each row, so the function's intent (indicated by its name) was more appropriate.

In the first round of UVM removal, we kept the existing behavior by returning views of the unpacked indices.

Now, with this PR, we change the behavior of CrsGraph's getNodePackedIndices and getNodeRowPtrs, and CrsMatrix's getAllValues (which uses the CrsGraph functions) to truly return packed indices, row pointers, and values, respectively, in all use cases.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

Tested on ascicgpu030 with sems modules and Serial node, and with sierra nvidia modules and CUDA node, no UVM.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->