### PR TITLE
Fix bug with mkl spgemm

### DIFF
--- a/packages/kokkos-kernels/src/sparse/impl/KokkosSparse_spgemm_mkl_impl.hpp
+++ b/packages/kokkos-kernels/src/sparse/impl/KokkosSparse_spgemm_mkl_impl.hpp
@@ -408,7 +408,6 @@ void mkl_symbolic(
     typedef typename KernelHandle::HandleTempMemorySpace HandleTempMemorySpace;
     typedef typename Kokkos::View<int *, HandleTempMemorySpace> int_temp_work_view_t;
 
-  typedef typename KernelHandle::HandleExecSpace MyExecSpace;
   /*
       if (!(
           (Kokkos::SpaceAccessibility<typename
@@ -425,12 +424,6 @@ void mkl_symbolic(
      MKL\n"); return;
       }
   */
-  if (std::is_same<idx, int>::value) {
-    int *a_xadj = NULL;
-    int *b_xadj = NULL;
-    int_temp_work_view_t a_xadj_v, b_xadj_v;
-
-
     typedef typename KernelHandle::nnz_scalar_t value_type;
 
     


### PR DESCRIPTION
PR fixes errors reported by @hkthorn of type:

```
/ascldap/users/ndellin/trilinos/Trilinos/Build/XyceConfig/packages/kokkos-kernels/src/impl/generated_specializations_cpp/spgemm_symbolic/Sparse_spgemm_symbolic_eti_DOUBLE_ORDINAL_INT_OFFSET_INT_LAYOUTLEFT_EXECSPACE_SERIAL_MEMSPACE_HOSTSPACE_MEMSPACE_HOSTSPACE.cpp(53): error: expected a "}"
```

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/kokkos-kernels 

## Motivation
Resolve compilation error with intel compilers and mkl tpls

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
@hkthorn please report that this resolves the problem in your builds as well

## Testing
Reproduced error and tested that compilation succeeds with this change

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->