### PR TITLE
Belos: fix issue with MultiVector modify flags

### DIFF
--- a/packages/belos/tpetra/test/Native/diagonal_matrix.cpp
+++ b/packages/belos/tpetra/test/Native/diagonal_matrix.cpp
@@ -109,9 +109,9 @@ public:
       auto X_j = X.getVector (j);
       auto Y_j = Y.getVectorNonConst (j);
 
-      auto X_j_lcl_2d = X_j->template getLocalView<device_type> (Tpetra::Access::ReadOnly);
+      auto X_j_lcl_2d = X_j->getLocalViewDevice (Tpetra::Access::ReadOnly);
       auto X_j_lcl = Kokkos::subview (X_j_lcl_2d, Kokkos::ALL (), 0);
-      auto Y_j_lcl_2d = Y_j->template getLocalView<device_type> (Tpetra::Access::ReadWrite);
+      auto Y_j_lcl_2d = Y_j->getLocalViewDevice (Tpetra::Access::ReadWrite);
       auto Y_j_lcl = Kokkos::subview (Y_j_lcl_2d, Kokkos::ALL (), 0);
 
       KokkosBlas::mult (static_cast<ISC> (beta), Y_j_lcl,


### PR DESCRIPTION
Belos's diagonal matrix apply was using Tpetra's ``MultiVector::getLocalView<device_type>(...)``
but this was incorrectly setting the "modified on host" flag when the device is
Cuda/CudaUVMSpace. The resulting view's execution space is Cuda, so it should definitely be considered a device view even though (being UVM) it's accessible from host. Instead, using ``MultiVector::getLocalViewDevice(...)`` correctly sets the
"modified on device" flag. This fixes 2 Belos test failures for when UVM
enabled in Tpetra, but this doesn't fix the behavior of ``getLocalView<device_type>`` for UVM - that can be a separate issue.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra
@trilinos/belos 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
In a build with ``Tpetra_ENABLE_CUDA_UVM=ON``, these two tests were failing:
```
Belos_Tpetra_Native_CG_PIPELINE_diagonal_matrix_MPI_4
Belos_Tpetra_Native_CG_SINGLE_REDUCE_diagonal_matrix_MPI_4
```
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
This was really an issue in the test itself, not in tested code.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->