### PR TITLE
ShyLU -DD Frosch : fix build error with new Kokkos-Kernels

### DIFF
--- a/packages/shylu/shylu_dd/frosch/src/InterfaceSets/FROSch_InterfaceEntity_decl.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/InterfaceSets/FROSch_InterfaceEntity_decl.hpp
@@ -88,14 +88,14 @@ namespace FROSch {
 
     protected:
 
-        using XMatrix               = Matrix<SC,LO,GO,NO>;
+        using XMatrix               = Xpetra::Matrix<SC,LO,GO,NO>;
         using XMatrixPtr            = RCP<XMatrix>;
         using ConstXMatrixPtr       = RCP<const XMatrix>;
 
-        using XVector               = Vector<SC,LO,GO,NO>;
+        using XVector               = Xpetra::Vector<SC,LO,GO,NO>;
         using XVectorPtr            = RCP<XVector>;
 
-        using XMultiVector          = MultiVector<SC,LO,GO,NO>;
+        using XMultiVector          = Xpetra::MultiVector<SC,LO,GO,NO>;
         using XMultiVectorPtr       = RCP<XMultiVector>;
         using ConstXMultiVectorPtr  = RCP<const XMultiVector>;
 

--- a/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_Tools_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_Tools_def.hpp
@@ -433,6 +433,7 @@ namespace FROSch {
                                              bool useCreateOneToOneMap,
                                              RCP<Tpetra::Details::TieBreak<LO,GO> > tieBreak)
     {
+        using Xpetra::Vector;
         FROSCH_DETAILTIMER_START(buildUniqueMapTime,"BuildUniqueMap");
         if (useCreateOneToOneMap && map->lib()==UseTpetra) {
             // Obtain the underlying Tpetra Map
@@ -1446,6 +1447,7 @@ namespace FROSch {
     RCP<MultiVector<SC,LO,GO,NO> > ModifiedGramSchmidt(RCP<const MultiVector<SC,LO,GO,NO> > multiVector,
                                                        ArrayView<unsigned> zero)
     {
+        using Xpetra::Vector;
         FROSCH_DETAILTIMER_START(modifiedGramSchmidtTime,"ModifiedGramSchmidt");
         /*
          n = size(V,1);


### PR DESCRIPTION
@trilinos/shylu 

## Motivation

This PR specifies that FROsch is using Xpetra for Matrix, Vector, MultiVector types. 



## Related Issues

- Kokkos-Kernels [Issue 1170](https://github.com/kokkos/kokkos-kernels/issues/1170)
  - Corresponding [PR 1171](https://github.com/kokkos/kokkos-kernels/pull/1171) 
- Albany [Issue 758](https://github.com/sandialabs/Albany/issues/758)

## Stakeholder Feedback

## Testing

@mperego has tested the fix with Albany for us.


## Additional Information

This is a minimum patch to fix the build issue, and may require more consistent fix later.
