### PR TITLE
Tpetra: remove obsolete configure option

### DIFF
--- a/packages/tpetra/core/CMakeLists.txt
+++ b/packages/tpetra/core/CMakeLists.txt
@@ -25,24 +25,6 @@ TRIBITS_ADD_OPTION_AND_DEFINE(
   )
 
 
-TRIBITS_ADD_OPTION_AND_DEFINE(
-  ${PACKAGE_NAME}_ENABLE_CUDA_UVM
-  HAVE_TPETRA_ENABLE_CUDA_UVM
-  "Build Tpetra with UVM."
-  ON
-  )
-
-ASSERT_DEFINED(Kokkos_ENABLE_CUDA)
-ASSERT_DEFINED(Kokkos_ENABLE_CUDA_UVM)
-ASSERT_DEFINED(Tpetra_ENABLE_CUDA)
-IF (Kokkos_ENABLE_CUDA AND NOT Kokkos_ENABLE_CUDA_UVM AND Tpetra_ENABLE_CUDA)
-  IF (Tpetra_ENABLE_CUDA_UVM)
-    MESSAGE (FATAL_ERROR "If CUDA is enabled in Kokkos, Tpetra requires that Kokkos' UVM support be enabled.  You may do this by setting the CMake option Kokkos_ENABLE_CUDA_UVM:BOOL=ON (WARNING: IT IS CASE SENSITIVE!) and running CMake again.\n\nDetails for developers: UVM stands for \"Unified Virtual Memory\".  It lets code running on the host processor access GPU memory.  There is a difference between CUDA's support for UVM, and Kokkos' support for UVM.  Versions of CUDA >= 6 have UVM support built in by default.  Kokkos always supports this.  In particular, Kokkos always has a memory space for UVM allocations, called Kokkos::CudaUVMSpace.  \"Turning on UVM support in Kokkos\" means two things:\n\n1. Kokkos::Cuda::memory_space (the CUDA execution space's default memory space) is Kokkos::CudaUVMSpace, rather than Kokkos::CudaSpace.\n\n2. Kokkos::DualView<T, Kokkos::Cuda> only uses a single allocation, in the Kokkos::CudaUVMSpace memory space.")
-  ELSE ()
-    MESSAGE (WARNING "CUDA UVM is disabled in Kokkos and in Tpetra. THERE IS NO GUARANTEE THAT THIS WORKS!")
-  ENDIF ()
-ENDIF ()
-
 SET(Tpetra_MACHINE_XML_FILE_DIR
     ${CMAKE_CURRENT_SOURCE_DIR}/machine_files
     CACHE INTERNAL "")


### PR DESCRIPTION
@trilinos/tpetra 

## Motivation
During the UVM removal process, a configure option was added to allow developers to build Tpetra without UVM, even though it (UVM-off) was not guaranteed to work.  Now that it works, this option is obsolete and redundant -- users and developers can build with/without UVM by changing the value of Kokkos_ENABLE_CUDA_UVM.

## Testing
N/A -- this is a build system change.