### PR TITLE
Framework: Create Build w/Deprecated Code OFF

### DIFF
--- a/cmake/std/PullRequestLinuxGCC8.3.0DeprecatedOffTestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxGCC8.3.0DeprecatedOffTestingSettings.cmake
@@ -1,0 +1,55 @@
+# This file contains the options needed to both run the pull request testing
+# for Trilinos for the Linux GCC 8.3.0 pull request testing builds, and to reproduce
+# the errors reported by those builds. Prior to using this this file, the
+# appropriate set of SEMS modules must be loaded and accessible through the
+# SEMS NFS mount. (See the sems/PullRequestGCC*TestingEnv.sh files.)
+
+# Usage: cmake -C PullRequestLinuxGCC8.3.0DeprecatedOffTestingSettings.cmake
+
+set (CMAKE_CXX_STANDARD "17" CACHE STRING "Set C++ standard to C++17")
+
+# Misc options typically added by CI testing mode in TriBITS
+
+# Use the below option only when submitting to the dashboard
+#set (CTEST_USE_LAUNCHERS ON CACHE BOOL "Set by default for PR testing")
+
+set (Trilinos_ENABLE_OpenMP ON CACHE BOOL "Set by default for PR testing")
+set (MPI_EXEC_PRE_NUMPROCS_FLAGS "--bind-to;none" CACHE STRING "Set by default for PR testing")
+# NOTE: The above is a workaround for the problem of having threads on MPI
+# ranks bind to the same cores (see #2422).
+
+set(Tpetra_INST_SERIAL ON CACHE BOOL "Set by default for PR testing")
+# note: mortar uses serial mode no matter what so we need to instantiate this to get it's examples to work
+
+set (Trilinos_ENABLE_COMPLEX_DOUBLE ON CACHE BOOL "Set by default for PR testing to exercise complex doubles case")
+
+set (CMAKE_CXX_EXTENSIONS OFF CACHE BOOL "Kokkos turns off CXX extensions")
+
+# Disable just one Teko sub-unit test that fails with openmpi 1.10 (#2712)
+set (Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D ON CACHE BOOL "Temporarily disabled in PR testing")
+
+# this build is different from the others in using static libraries
+set (BUILD_SHARED_LIBS OFF CACHE BOOL "Off by default for PR testing in GCC 4.8.4")
+
+set(CMAKE_CXX_FLAGS "-fno-strict-aliasing -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-inline -Wno-nonnull-compare -Wno-address -Werror -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS" CACHE STRING "Warnings as errors settings")
+
+set(KOKKOS_ENABLE_DEPRECATED_CODE OFF CACHE BOOL "Set deprecated code flags")
+set(Tpetra_ENABLE_DEPRECATED_CODE OFF CACHE BOOL "Set deprecated code flags")
+set(Belos_HIDE_DEPRECATED_CODE ON CACHE BOOL "Set deprecated code flags")
+set(Epetra_HIDE_DEPRECATED_CODE ON CACHE BOOL "Set deprecated code flags")
+set(Ifpack2_HIDE_DEPRECATED_CODE ON CACHE BOOL "Set deprecated code flags")
+set(Ifpack2_ENABLE_DEPRECATED_CODE OFF CACHE BOOL "Set deprecated code flags")
+set(MueLu_ENABLE_DEPRECATED_CODE OFF CACHE BOOL "Set deprecated code flags")
+set(Panzer_HIDE_DEPRECATED_CODE ON CACHE BOOL "Set deprecated code flags")
+set(Phalanx_HIDE_DEPRECATED_CODE ON CACHE BOOL "Set deprecated code flags")
+set(RTop_HIDE_DEPRECATED_CODE ON CACHE BOOL "Set deprecated code flags")
+set(STK_HIDE_DEPRECATED_CODE ON CACHE BOOL "Set deprecated code flags")
+set(Teuchos_HIDE_DEPRECATED_CODE ON CACHE BOOL "Set deprecated code flags")
+set(Thyra_HIDE_DEPRECATED_CODE ON CACHE BOOL "Set deprecated code flags")
+set(Claps_HIDE_DEPRECATED_CODE ON CACHE BOOL "Set deprecated code flags")
+set(GlobiPack_HIDE_DEPRECATED_CODE ON CACHE BOOL "Set deprecated code flags")
+set(OptiPack_HIDE_DEPRECATED_CODE ON CACHE BOOL "Set deprecated code flags")
+set(Trios_HIDE_DEPRECATED_CODE ON CACHE BOOL "Set deprecated code flags")
+set(Xpetra_ENABLE_DEPRECATED_CODE OFF CACHE BOOL "Set deprecated code flags")
+
+include("${CMAKE_CURRENT_LIST_DIR}/PullRequestLinuxCommonTestingSettings.cmake")

--- a/cmake/std/pr_config/pullrequest.ini
+++ b/cmake/std/pr_config/pullrequest.ini
@@ -97,6 +97,7 @@ Trilinos_pullrequest_gcc_7.2.0:        PullRequestLinuxGCC7.2.0TestingSettings.c
 Trilinos_pullrequest_gcc_7.2.0_debug:  PullRequestLinuxGCC7.2.0DebugTestingSettings.cmake
 Trilinos_pullrequest_gcc_7.2.0_serial: PullRequestLinuxGCC7.2.0SerialTestingSettings.cmake
 Trilinos_pullrequest_gcc_8.3.0:        PullRequestLinuxGCC8.3.0TestingSettings.cmake
+Trilinos_pullrequest_gcc_8.3.0_deprecated_off:        PullRequestLinuxGCC8.3.0DeprecatedOffTestingSettings.cmake
 
 # Intel Builds
 Trilinos_pullrequest_intel_17.0.1:     PullRequestLinuxIntel17.0.1TestingSettings.cmake
@@ -406,7 +407,8 @@ unsetenv PATH_TMP:
 [Trilinos_pullrequest_gcc_8.3.0_installation_testing]
 use Trilinos_pullrequest_gcc_8.3.0:
 
-
+[Trilinos_pullrequest_gcc_8.3.0_deprecated_off]
+use Trilinos_pullrequest_gcc_8.3.0:
 
 [Trilinos_pullrequest_python_3]
 use SEMS-ENV:


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/framework 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Issue #6347, later moved to TRILFRAME-94, requested a build that turns off deprecated code. I am unsure of the source of that request.
This is the first iteration in efforts to get such a build in place, created such that it will become a PR build for the autotester.
There are various ways to accomplish this, but for this iteration the cmake file uses the flags provided in the referenced issue, [here](https://github.com/trilinos/Trilinos/issues/6347#issuecomment-558382990) & [here](https://github.com/trilinos/Trilinos/issues/6347#issuecomment-558413592).
This currently produces 100+ build failures across various packages. To implement this as a PR build, those would need to be cleaned up before such a build can be turned on in the PR autotester.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

<!--- 
## Stakeholder Feedback

If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
[CDash Results](https://testing.sandia.gov/cdash/index.php?project=Trilinos&display=project&filtercount=2&showfilters=1&filtercombine=and&field1=buildname&compare1=63&value1=deprecated_off&field2=buildstamp&compare2=63&value2=Experimental)
Summary of each:
- Build...**_-2_**: Both `[packagename]_ENABLE_DEPRECATED_CODE OFF` & `[packagename]_HIDE_DEPRECATED_CODE ON` created for all packages mentioned in issue
- ~~Build...**_-3_**: Instead removed `-DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS`, but missed `-Wno-deprecated-declarations`, so no effect.~~
- Build...**_-4_**: Used only flags mentioned in issue, including separately mentioned Xpetra flag noted above.
- Build...**_-5_**: Instead removed both `-DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS` & `-Wno-deprecated-declarations`.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->