### PR TITLE
Tpetra: Xpetra: fix matrix reader

### DIFF
--- a/packages/tpetra/core/inout/MatrixMarket_Tpetra.hpp
+++ b/packages/tpetra/core/inout/MatrixMarket_Tpetra.hpp
@@ -3609,7 +3609,6 @@ namespace Tpetra {
         ArrayRCP<size_t> rowPtr;
         ArrayRCP<global_ordinal_type> colInd;
         ArrayRCP<scalar_type> values;
-        size_t maxNumEntriesPerRow = 0;
 
         // Proc 0 first merges duplicate entries, and then converts
         // the coordinate-format matrix data to CSR.
@@ -3790,8 +3789,6 @@ namespace Tpetra {
         ArrayRCP<size_t> gatherNumEntriesPerRow = arcp<size_t>(myNumRows);
         for (size_type i_ = 0; i_ < myNumRows; i_++) {
           gatherNumEntriesPerRow[i_] = numEntriesPerRow[myRows[i_]-indexBase];
-          if (gatherNumEntriesPerRow[i_] > maxNumEntriesPerRow)
-            maxNumEntriesPerRow = gatherNumEntriesPerRow[i_];
         }
 
         // Create a matrix using this Map, and fill in on Proc 0.  We
@@ -3839,9 +3836,6 @@ namespace Tpetra {
           colInd = null;
           values = null;
         } // if myRank == rootRank
-
-        //FIXME this is no longer needed
-        broadcast<int,size_t> (*pComm, 0, &maxNumEntriesPerRow);
 
         RCP<sparse_matrix_type> A;
         typedef Export<local_ordinal_type, global_ordinal_type, node_type> export_type;

--- a/packages/tpetra/core/inout/MatrixMarket_Tpetra.hpp
+++ b/packages/tpetra/core/inout/MatrixMarket_Tpetra.hpp
@@ -3840,18 +3840,36 @@ namespace Tpetra {
           values = null;
         } // if myRank == rootRank
 
+        //FIXME this is no longer needed
         broadcast<int,size_t> (*pComm, 0, &maxNumEntriesPerRow);
 
         RCP<sparse_matrix_type> A;
-        if (colMap.is_null ()) {
-          A = rcp (new sparse_matrix_type (rowMap, maxNumEntriesPerRow));
-        } else {
-          A = rcp (new sparse_matrix_type (rowMap, colMap, maxNumEntriesPerRow));
-        }
         typedef Export<local_ordinal_type, global_ordinal_type, node_type> export_type;
         export_type exp (gatherRowMap, rowMap);
-        A->doExport (*A_proc0, exp, INSERT);
 
+        // Communicate the precise number of nonzeros per row, which was already
+        // calculated above.
+        typedef local_ordinal_type LO;
+        typedef global_ordinal_type GO;
+        typedef Tpetra::MultiVector<GO, LO, GO, node_type> mv_type_go;
+        mv_type_go target_nnzPerRow(rowMap,1);
+        mv_type_go source_nnzPerRow(gatherRowMap,1);
+        Teuchos::ArrayRCP<GO> srcData = source_nnzPerRow.getDataNonConst(0);
+        for (int i=0; i<myNumRows; i++)
+          srcData[i] = gatherNumEntriesPerRow[i];
+        srcData = Teuchos::null;
+        target_nnzPerRow.doExport(source_nnzPerRow,exp,Tpetra::INSERT);
+        Teuchos::ArrayRCP<GO> targetData = target_nnzPerRow.getDataNonConst(0);
+        ArrayRCP<size_t> targetData_size_t = arcp<size_t>(targetData.size());
+        for (int i=0; i<targetData.size(); i++)
+          targetData_size_t[i] = targetData[i];
+
+        if (colMap.is_null ()) {
+          A = rcp (new sparse_matrix_type (rowMap, targetData_size_t()));
+        } else {
+          A = rcp (new sparse_matrix_type (rowMap, colMap, targetData_size_t()));
+        }
+        A->doExport (*A_proc0, exp, INSERT);
         if (callFillComplete) {
           A->fillComplete (domainMap, rangeMap);
         }

--- a/packages/xpetra/sup/Utils/Xpetra_IO.hpp
+++ b/packages/xpetra/sup/Utils/Xpetra_IO.hpp
@@ -96,6 +96,7 @@
 #include "Xpetra_MatrixFactory.hpp"
 
 #include <Teuchos_MatrixMarket_Raw_Writer.hpp>
+#include <Teuchos_MatrixMarket_Raw_Reader.hpp>
 #include <string>
 
 
@@ -586,49 +587,156 @@ namespace Xpetra {
           throw Exceptions::RuntimeError("Utils::Read : you must specify Xpetra::UseEpetra or Xpetra::UseTpetra.");
         }
       } else {
-        // Custom file format (binary)
-        std::ifstream ifs(filename.c_str(), std::ios::binary);
+
+        // Read in on rank 0.
+        auto tempA = Read(filename, lib, rowMap->getComm(), binary);
+
+        auto A = Xpetra::MatrixFactory<Scalar,LocalOrdinal,GlobalOrdinal,Node>::Build(rowMap, colMap, 0);
+        auto importer  = Xpetra::ImportFactory<LocalOrdinal,GlobalOrdinal,Node>::Build(tempA->getRowMap(), rowMap);
+        A->doImport(*tempA, *importer, Xpetra::INSERT);
+        if (callFillComplete)
+          A->fillComplete(domainMap, rangeMap);
+
+        return A;
+      }
+
+      TEUCHOS_UNREACHABLE_RETURN(Teuchos::null);
+    }
+
+    /*! @brief Read matrix from local files in Matrix Market or binary format.
+
+      The file name format is filename.SIZE.RANK, where SIZE is the
+      size of the communicator of the rowMap and RANK is the MPI ranks
+      of the calling process.
+
+      If only rowMap is specified, then it is used for the domainMap and rangeMap, as well.
+      */
+    static Teuchos::RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > ReadLocal(const std::string&   filename,
+                                                                                              const RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > rowMap,
+                                                                                              RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > colMap,
+                                                                                              const RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > domainMap        = Teuchos::null,
+                                                                                              const RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > rangeMap         = Teuchos::null,
+                                                                                              const bool           callFillComplete = true,
+                                                                                              const bool           binary           = false,
+                                                                                              const bool           tolerant         = false,
+                                                                                              const bool           debug            = false) {
+      TEUCHOS_TEST_FOR_EXCEPTION(rowMap.is_null(), Exceptions::RuntimeError, "Utils::ReadLocal() : rowMap cannot be null");
+      TEUCHOS_TEST_FOR_EXCEPTION(colMap.is_null(), Exceptions::RuntimeError, "Utils::ReadLocal() : colMap cannot be null");
+
+      using matrix_type = Xpetra::Matrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
+      using crs_wrap_type = Xpetra::CrsMatrixWrap<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
+      using crs_type = Xpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
+
+      RCP<const Xpetra::Map<LocalOrdinal,GlobalOrdinal,Node> > domain = (domainMap.is_null() ? rowMap : domainMap);
+      RCP<const Xpetra::Map<LocalOrdinal,GlobalOrdinal,Node> > range  = (rangeMap .is_null() ? rowMap : rangeMap);
+
+      std::string rankFilename = filename + "." + std::to_string(rowMap->getComm()->getSize()) + "." + std::to_string(rowMap->getComm()->getRank());
+      RCP<matrix_type> A = rcp(new crs_wrap_type(rowMap, colMap, 0));
+
+      if (binary == false) {
+
+        RCP<Teuchos::ParameterList> params = rcp(new Teuchos::ParameterList());
+        params->set("Parse tolerantly", tolerant);
+        params->set("Debug mode", debug);
+
+        LocalOrdinal numRows = rowMap->getNodeNumElements();
+        LocalOrdinal numCols = colMap->getNodeNumElements();
+
+        ArrayRCP<LocalOrdinal> rowptr2_RCP;
+        ArrayRCP<LocalOrdinal> colind2_RCP;
+        ArrayRCP<Scalar> vals2_RCP;
+
+        Teuchos::MatrixMarket::Raw::Reader<Scalar,LocalOrdinal> reader;
+        reader.readFile(rowptr2_RCP,colind2_RCP,vals2_RCP,
+                        numRows,numCols,
+                        rankFilename);
+
+
+        RCP<crs_type>    ACrs = Teuchos::rcp_dynamic_cast<crs_wrap_type>(A)->getCrsMatrix();
+
+        ArrayRCP<size_t>       rowptr_RCP;
+        ArrayRCP<LocalOrdinal> colind_RCP;
+        ArrayRCP<Scalar>       vals_RCP;
+        ACrs->allocateAllValues(colind2_RCP.size(), rowptr_RCP, colind_RCP, vals_RCP);
+
+        rowptr_RCP.assign(rowptr2_RCP.begin(), rowptr2_RCP.end());
+        colind_RCP = colind2_RCP;
+        vals_RCP = vals2_RCP;
+
+        ACrs->setAllValues(rowptr_RCP, colind_RCP, vals_RCP);
+      } else {
+                // Custom file format (binary)
+        std::ifstream ifs = std::ifstream(rankFilename.c_str(), std::ios::binary);
         TEUCHOS_TEST_FOR_EXCEPTION(!ifs.good(), Exceptions::RuntimeError, "Can not read \"" << filename << "\"");
+
         int m, n, nnz;
         ifs.read(reinterpret_cast<char*>(&m),   sizeof(m));
         ifs.read(reinterpret_cast<char*>(&n),   sizeof(n));
         ifs.read(reinterpret_cast<char*>(&nnz), sizeof(nnz));
 
-        //2020-June-05 JHU : for Tpetra, this will probably fail because Tpetra now requires staticly-sized matrix graphs.
-        RCP<Xpetra::Matrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > A = Xpetra::MatrixFactory<Scalar,LocalOrdinal,GlobalOrdinal,Node>::Build(rowMap, colMap, 1);
+        TEUCHOS_ASSERT_EQUALITY(Teuchos::as<int>(rowMap->getNodeNumElements()), m);
 
-        //2019-06-07 JHU I don't see why this should matter.
-        //TEUCHOS_TEST_FOR_EXCEPTION(sizeof(int) != sizeof(GO), Exceptions::RuntimeError, "Incompatible sizes");
+        Teuchos::ArrayRCP<size_t>       rowptrRCP;
+        Teuchos::ArrayRCP<LocalOrdinal> indicesRCP;
+        Teuchos::ArrayRCP<Scalar>       valuesRCP;
 
-        Teuchos::ArrayView<const GlobalOrdinal> rowElements = rowMap->getNodeElementList();
-        Teuchos::ArrayView<const GlobalOrdinal> colElements = colMap->getNodeElementList();
+        RCP<crs_type>    ACrs = Teuchos::rcp_dynamic_cast<crs_wrap_type>(A)->getCrsMatrix();
 
-        Teuchos::Array<GlobalOrdinal> inds;
-        Teuchos::Array<Scalar> vals;
+        ACrs->allocateAllValues(nnz, rowptrRCP, indicesRCP, valuesRCP);
+
+        Teuchos::ArrayView<size_t>       rowptr = rowptrRCP();
+        Teuchos::ArrayView<LocalOrdinal> indices = indicesRCP();
+        Teuchos::ArrayView<Scalar>       values = valuesRCP();
+
+        // Read in rowptr
         for (int i = 0; i < m; i++) {
           int row, rownnz;
           ifs.read(reinterpret_cast<char*>(&row),    sizeof(row));
           ifs.read(reinterpret_cast<char*>(&rownnz), sizeof(rownnz));
-          inds.resize(rownnz);
-          vals.resize(rownnz);
+
+          rowptr[row+1] += rownnz;
+          ifs.seekg(sizeof(int)*rownnz + sizeof(double)*rownnz, ifs.cur);
+        }
+        for (int i = 0; i < m; i++)
+          rowptr[i+1] += rowptr[i];
+        TEUCHOS_ASSERT(Teuchos::as<int>(rowptr[m]) == nnz);
+
+        // reset to where the data starts
+        ifs.seekg(sizeof(int)*3, ifs.beg);
+
+        // read in entries
+        for (int i = 0; i < m; i++) {
+          int row, rownnz;
+          ifs.read(reinterpret_cast<char*>(&row),    sizeof(row));
+          ifs.read(reinterpret_cast<char*>(&rownnz), sizeof(rownnz));
+          size_t ptr = rowptr[row];
           for (int j = 0; j < rownnz; j++) {
             int index;
             ifs.read(reinterpret_cast<char*>(&index), sizeof(index));
-            inds[j] = colElements[Teuchos::as<LocalOrdinal>(index)];
+            indices[ptr] = Teuchos::as<LocalOrdinal>(index);
+            ++ptr;
           }
+          ptr = rowptr[row];
           for (int j = 0; j < rownnz; j++) {
             double value;
             ifs.read(reinterpret_cast<char*>(&value), sizeof(value));
-            vals[j] = Teuchos::as<SC>(value);
+            values[ptr] = Teuchos::as<Scalar>(value);
+            ++ptr;
           }
-          //This implies that row is not a global index.
-          A->insertGlobalValues(rowElements[row], inds, vals);
+          rowptr[row] += rownnz;
         }
-        A->fillComplete(domainMap, rangeMap);
-        return A;
+        for (int i = m; i > 0; i--)
+          rowptr[i] = rowptr[i-1];
+        rowptr[0] = 0;
+
+        ACrs->setAllValues(rowptrRCP, indicesRCP, valuesRCP);
+
       }
 
-      TEUCHOS_UNREACHABLE_RETURN(Teuchos::null);
+      if (callFillComplete)
+        A->fillComplete(domainMap, rangeMap);
+      return A;
+
     }
     //@}
 
@@ -1164,6 +1272,10 @@ namespace Xpetra {
             A->insertGlobalValues(row, inds, vals);
           }
         } //if (myRank == 0)
+        else {
+          Teuchos::ArrayRCP<size_t> numEntriesPerRow(0);
+          A   = Xpetra::MatrixFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(rowMap, colMap, numEntriesPerRow);
+        }
 
         A->fillComplete(domainMap, rangeMap);
 
@@ -1255,49 +1367,156 @@ namespace Xpetra {
           throw Exceptions::RuntimeError("Utils::Read : you must specify Xpetra::UseEpetra or Xpetra::UseTpetra.");
         }
       } else {
-        // Custom file format (binary)
-        std::ifstream ifs(filename.c_str(), std::ios::binary);
+
+        // Read in on rank 0.
+        auto tempA = Read(filename, lib, rowMap->getComm(), binary);
+
+        auto A = Xpetra::MatrixFactory<Scalar,LocalOrdinal,GlobalOrdinal,Node>::Build(rowMap, colMap, 0);
+        auto importer  = Xpetra::ImportFactory<LocalOrdinal,GlobalOrdinal,Node>::Build(tempA->getRowMap(), rowMap);
+        A->doImport(*tempA, *importer, Xpetra::INSERT);
+        if (callFillComplete)
+          A->fillComplete(domainMap, rangeMap);
+
+        return A;
+      }
+
+      TEUCHOS_UNREACHABLE_RETURN(Teuchos::null);
+    }
+
+    /*! @brief Read matrix from local files in Matrix Market or binary format.
+
+      The file name format is filename.SIZE.RANK, where SIZE is the
+      size of the communicator of the rowMap and RANK is the MPI ranks
+      of the calling process.
+
+      If only rowMap is specified, then it is used for the domainMap and rangeMap, as well.
+      */
+    static Teuchos::RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > ReadLocal(const std::string&   filename,
+                                                                                              const RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > rowMap,
+                                                                                              RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > colMap,
+                                                                                              const RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > domainMap        = Teuchos::null,
+                                                                                              const RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > rangeMap         = Teuchos::null,
+                                                                                              const bool           callFillComplete = true,
+                                                                                              const bool           binary           = false,
+                                                                                              const bool           tolerant         = false,
+                                                                                              const bool           debug            = false) {
+      TEUCHOS_TEST_FOR_EXCEPTION(rowMap.is_null(), Exceptions::RuntimeError, "Utils::ReadLocal() : rowMap cannot be null");
+      TEUCHOS_TEST_FOR_EXCEPTION(colMap.is_null(), Exceptions::RuntimeError, "Utils::ReadLocal() : colMap cannot be null");
+
+      using matrix_type = Xpetra::Matrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
+      using crs_wrap_type = Xpetra::CrsMatrixWrap<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
+      using crs_type = Xpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
+
+      RCP<const Xpetra::Map<LocalOrdinal,GlobalOrdinal,Node> > domain = (domainMap.is_null() ? rowMap : domainMap);
+      RCP<const Xpetra::Map<LocalOrdinal,GlobalOrdinal,Node> > range  = (rangeMap .is_null() ? rowMap : rangeMap);
+
+      std::string rankFilename = filename + "." + std::to_string(rowMap->getComm()->getSize()) + "." + std::to_string(rowMap->getComm()->getRank());
+      RCP<matrix_type> A = rcp(new crs_wrap_type(rowMap, colMap, 0));
+
+      if (binary == false) {
+
+        RCP<Teuchos::ParameterList> params = rcp(new Teuchos::ParameterList());
+        params->set("Parse tolerantly", tolerant);
+        params->set("Debug mode", debug);
+
+        LocalOrdinal numRows = rowMap->getNodeNumElements();
+        LocalOrdinal numCols = colMap->getNodeNumElements();
+
+        ArrayRCP<LocalOrdinal> rowptr2_RCP;
+        ArrayRCP<LocalOrdinal> colind2_RCP;
+        ArrayRCP<Scalar> vals2_RCP;
+
+        Teuchos::MatrixMarket::Raw::Reader<Scalar,LocalOrdinal> reader;
+        reader.readFile(rowptr2_RCP,colind2_RCP,vals2_RCP,
+                        numRows,numCols,
+                        rankFilename);
+
+
+        RCP<crs_type>    ACrs = Teuchos::rcp_dynamic_cast<crs_wrap_type>(A)->getCrsMatrix();
+
+        ArrayRCP<size_t>       rowptr_RCP;
+        ArrayRCP<LocalOrdinal> colind_RCP;
+        ArrayRCP<Scalar>       vals_RCP;
+        ACrs->allocateAllValues(colind2_RCP.size(), rowptr_RCP, colind_RCP, vals_RCP);
+
+        rowptr_RCP.assign(rowptr2_RCP.begin(), rowptr2_RCP.end());
+        colind_RCP = colind2_RCP;
+        vals_RCP = vals2_RCP;
+
+        ACrs->setAllValues(rowptr_RCP, colind_RCP, vals_RCP);
+      } else {
+                // Custom file format (binary)
+        std::ifstream ifs = std::ifstream(rankFilename.c_str(), std::ios::binary);
         TEUCHOS_TEST_FOR_EXCEPTION(!ifs.good(), Exceptions::RuntimeError, "Can not read \"" << filename << "\"");
+
         int m, n, nnz;
         ifs.read(reinterpret_cast<char*>(&m),   sizeof(m));
         ifs.read(reinterpret_cast<char*>(&n),   sizeof(n));
         ifs.read(reinterpret_cast<char*>(&nnz), sizeof(nnz));
 
-        //2020-June-05 JHU : for Tpetra, this will probably fail because Tpetra now requires staticly-sized matrix graphs.
-        RCP<Xpetra::Matrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > A = Xpetra::MatrixFactory<Scalar,LocalOrdinal,GlobalOrdinal,Node>::Build(rowMap, colMap, 1);
+        TEUCHOS_ASSERT_EQUALITY(Teuchos::as<int>(rowMap->getNodeNumElements()), m);
 
-        //2019-06-07 JHU I don't see why this should matter.
-        //TEUCHOS_TEST_FOR_EXCEPTION(sizeof(int) != sizeof(GlobalOrdinal), Exceptions::RuntimeError, "Incompatible sizes");
+        Teuchos::ArrayRCP<size_t>       rowptrRCP;
+        Teuchos::ArrayRCP<LocalOrdinal> indicesRCP;
+        Teuchos::ArrayRCP<Scalar>       valuesRCP;
 
-        Teuchos::ArrayView<const GlobalOrdinal> rowElements = rowMap->getNodeElementList();
-        Teuchos::ArrayView<const GlobalOrdinal> colElements = colMap->getNodeElementList();
+        RCP<crs_type>    ACrs = Teuchos::rcp_dynamic_cast<crs_wrap_type>(A)->getCrsMatrix();
 
-        Teuchos::Array<GlobalOrdinal> inds;
-        Teuchos::Array<Scalar> vals;
+        ACrs->allocateAllValues(nnz, rowptrRCP, indicesRCP, valuesRCP);
+
+        Teuchos::ArrayView<size_t>       rowptr = rowptrRCP();
+        Teuchos::ArrayView<LocalOrdinal> indices = indicesRCP();
+        Teuchos::ArrayView<Scalar>       values = valuesRCP();
+
+        // Read in rowptr
         for (int i = 0; i < m; i++) {
           int row, rownnz;
           ifs.read(reinterpret_cast<char*>(&row),    sizeof(row));
           ifs.read(reinterpret_cast<char*>(&rownnz), sizeof(rownnz));
-          inds.resize(rownnz);
-          vals.resize(rownnz);
+
+          rowptr[row+1] += rownnz;
+          ifs.seekg(sizeof(int)*rownnz + sizeof(double)*rownnz, ifs.cur);
+        }
+        for (int i = 0; i < m; i++)
+          rowptr[i+1] += rowptr[i];
+        TEUCHOS_ASSERT(Teuchos::as<int>(rowptr[m]) == nnz);
+
+        // reset to where the data starts
+        ifs.seekg(sizeof(int)*3, ifs.beg);
+
+        // read in entries
+        for (int i = 0; i < m; i++) {
+          int row, rownnz;
+          ifs.read(reinterpret_cast<char*>(&row),    sizeof(row));
+          ifs.read(reinterpret_cast<char*>(&rownnz), sizeof(rownnz));
+          size_t ptr = rowptr[row];
           for (int j = 0; j < rownnz; j++) {
             int index;
             ifs.read(reinterpret_cast<char*>(&index), sizeof(index));
-            inds[j] = colElements[Teuchos::as<LocalOrdinal>(index)];
+            indices[ptr] = Teuchos::as<LocalOrdinal>(index);
+            ++ptr;
           }
+          ptr = rowptr[row];
           for (int j = 0; j < rownnz; j++) {
             double value;
             ifs.read(reinterpret_cast<char*>(&value), sizeof(value));
-            vals[j] = Teuchos::as<Scalar>(value);
+            values[ptr] = Teuchos::as<Scalar>(value);
+            ++ptr;
           }
-          //This implies that row is not a global index.
-          A->insertGlobalValues(rowElements[row], inds, vals);
+          rowptr[row] += rownnz;
         }
-        A->fillComplete(domainMap, rangeMap);
-        return A;
+        for (int i = m; i > 0; i--)
+          rowptr[i] = rowptr[i-1];
+        rowptr[0] = 0;
+
+        ACrs->setAllValues(rowptrRCP, indicesRCP, valuesRCP);
+
       }
 
-      TEUCHOS_UNREACHABLE_RETURN(Teuchos::null);
+      if (callFillComplete)
+        A->fillComplete(domainMap, rangeMap);
+      return A;
+
     }
     //@}
 

--- a/packages/xpetra/sup/Utils/Xpetra_IO.hpp
+++ b/packages/xpetra/sup/Utils/Xpetra_IO.hpp
@@ -456,12 +456,12 @@ namespace Xpetra {
           Teuchos::Array<GlobalOrdinal> inds;
           Teuchos::Array<Scalar> vals;
           // Scan matrix to determine the exact nnz per row.
-          Teuchos::ArrayRCP<size_t> numEntriesPerRow(m);
+          Teuchos::ArrayRCP<size_t> numEntriesPerRow(m,(size_t)(0));
           for (int i = 0; i < m; i++) {
             int row, rownnz;
             ifs.read(reinterpret_cast<char*>(&row),    sizeof(row));
             ifs.read(reinterpret_cast<char*>(&rownnz), sizeof(rownnz));
-            numEntriesPerRow[i] = rownnz;
+            numEntriesPerRow[row] = rownnz;
             for (int j = 0; j < rownnz; j++) {
               int index;
               ifs.read(reinterpret_cast<char*>(&index), sizeof(index));


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra @trilinos/xpetra 
## Motivation
This fixes two bugs in matrix reading:
1) The Tpetra matrix reader was allocating space based on a scalar max nnz per row, which could cause an out-of-memory error if one of the rows is (nearly) dense.
2) The Xpetra binary reader was calculating the number of nonzeros per row incorrectly.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback

Used primarily by developers.

## Testing

Tested locally.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->