### PR TITLE
Zoltan2:  Temporary fix to #9909

### DIFF
--- a/packages/zoltan2/core/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
+++ b/packages/zoltan2/core/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
@@ -4819,6 +4819,7 @@ mj_create_new_partitions(
   // the last member is utility used for atomically inserting the values.
   // Sorting here avoids potential indeterminancy in the partitioning results
   if(track_on_cuts.size() > 0) { // size 0 unused, or size is minimum of 2
+    Kokkos::fence("TODO RemoveThisFenceAfterKokkosGithub4526IsFixed; see Trilinos #9909");
     auto track_on_cuts_sort = Kokkos::subview(track_on_cuts,
       std::pair<mj_lno_t, mj_lno_t>(0, track_on_cuts.size() - 1)); // do not sort last element
     Kokkos::sort(track_on_cuts_sort);


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/zoltan2 @trilinos/kokkos 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

The semantics of Kokkos::sort changed in the last snapshot to Trilinos.  With UVM=ON, Kokkos::sort needs a fence before it, as it may sort on host.  See https://github.com/kokkos/kokkos/issues/4526

A fix is available in Kokkos:
https://github.com/kokkos/kokkos/pull/4490

Thus, this PR may not be needed if the fix can be patched into Trilinos in a timely manner.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->