### PR TITLE
Tempus: Fix Failing Tests Due to FPE

### DIFF
--- a/packages/tempus/src/Tempus_Stepper_ErrorNorm_decl.hpp
+++ b/packages/tempus/src/Tempus_Stepper_ErrorNorm_decl.hpp
@@ -16,37 +16,69 @@
 #include "Thyra_VectorSpaceFactoryBase.hpp"
 namespace Tempus {
 
+/** \brief Stepper_ErrorNorm provides error norm calcualtions for variable time stepping.
+ *
+ */
 template<class Scalar>
 class Stepper_ErrorNorm
 {
+public:
 
-  public:
+  /// Default Constructor
+  Stepper_ErrorNorm();
 
-    // ctor
-    Stepper_ErrorNorm();
+  /// Constructor
+  Stepper_ErrorNorm(const Scalar relTol, const Scalar absTol);
 
-    Stepper_ErrorNorm(const Scalar relTol, const Scalar absTol);
+  /// Destructor
+  ~Stepper_ErrorNorm() {};
 
-    ~Stepper_ErrorNorm() {};
+  /** \brief Compute the weigthed root mean square norm.
+   *
+   *  The WRMS norm is
+   *  \f[
+   *    e_{wrms} \equiv \sqrt{ \frac{1}{N} \sum_{i=1}^N \left( \frac
+   *       {u^n_i}{A_{tol} + \max (|u^n_i|, |u^{n+1}_i|) R_{tol}} \right) ^2 }
+   *  \f]
+   *  where
+   *  - \f$A_{tol}\f$ is the absolute tolerance,
+   *  - \f$R_{tol}\f$ is the relative tolerance,
+   *  - \f$\max\f$ is the pairwise maximum,
+   *  - \f$u^n\f$ is the current solution, and
+   *  - \f$u^{n+1}\f$ is the next solution.
+   *  - \f$ u_i^n\f$ denotes component \f$i\f$ of time step \f$n\f$.
+   *  - \f$ N\f$ denotes the number of unknowns
+   */
+  Scalar computeWRMSNorm(
+    const Teuchos::RCP<const Thyra::VectorBase<Scalar>> &x,
+    const Teuchos::RCP<const Thyra::VectorBase<Scalar>> &xNext,
+    const Teuchos::RCP<const Thyra::VectorBase<Scalar>> &err);
 
-    Scalar computeWRMSNorm(const Teuchos::RCP<const Thyra::VectorBase<Scalar>> &x,
-        const Teuchos::RCP<const Thyra::VectorBase<Scalar>> &xNext,
-        const Teuchos::RCP<const Thyra::VectorBase<Scalar>> &err);
+  /** \brief Compute the error Norm.
+   *
+   *  The error norm is
+   *  \f[
+   *    e = \max_i ( u_i / ( A_{tol} + |u_i| R_{tol}))
+   *  \f]
+   *  where
+   *  \f$A_{tol}\f$ is the absolute tolerance,
+   *  \f$R_{tol}\f$ is the relative tolerance, and
+   *  \f$\max_i\f$ is the maximum over all elements in \f$x\f$.
+   */
+  Scalar errorNorm(const Teuchos::RCP<const Thyra::VectorBase<Scalar>> &x);
 
-    Scalar errorNorm(const Teuchos::RCP<const Thyra::VectorBase<Scalar>> &x);
+  void setRelativeTolerance(const Scalar relTol) { relTol_ = relTol; }
+  void setAbsoluteTolerance(const Scalar absTol) { abssTol_ = absTol; }
 
-    void setRelativeTolerance(const Scalar relTol) { relTol_ = relTol; }
-    void setAbsoluteTolerance(const Scalar absTol) { abssTol_ = absTol; }
 
-  
-  protected:
+protected:
 
-    Scalar relTol_;
-    Scalar abssTol_;
-    Teuchos::RCP<Thyra::VectorBase<Scalar>> u_;
-    Teuchos::RCP<Thyra::VectorBase<Scalar>> uNext_;
-    Teuchos::RCP<Thyra::VectorBase<Scalar>> errorWeightVector_;
-    Teuchos::RCP<Thyra::VectorBase<Scalar>> scratchVector_;
+  Scalar relTol_;
+  Scalar abssTol_;
+  Teuchos::RCP<Thyra::VectorBase<Scalar>> u_;
+  Teuchos::RCP<Thyra::VectorBase<Scalar>> uNext_;
+  Teuchos::RCP<Thyra::VectorBase<Scalar>> errorWeightVector_;
+  Teuchos::RCP<Thyra::VectorBase<Scalar>> scratchVector_;
 
 };
 

--- a/packages/tempus/test/TestUtils/Tempus_UnitTestMainUtils.hpp
+++ b/packages/tempus/test/TestUtils/Tempus_UnitTestMainUtils.hpp
@@ -9,7 +9,7 @@
 #ifndef TEMPUS_UNIT_TEST_MAIN_UTILS_HPP
 #define TEMPUS_UNIT_TEST_MAIN_UTILS_HPP
 
-#if defined(__linux__) && defined(__GNUC__)
+#if defined(__linux__) && defined(__GNUC__) && !defined(__INTEL_COMPILER)
   #include <fenv.h>
 #elif defined(__APPLE__) && defined(__GNUC__) && defined(__SSE__)
   #include <xmmintrin.h>
@@ -33,7 +33,7 @@ void enableFPE(bool enableFPE)
 #endif
 
   if (enableFPE) {
-#if defined(__linux__) && defined(__GNUC__)
+#if defined(__linux__) && defined(__GNUC__) && !defined(__INTEL_COMPILER)
     feenableexcept(FE_DIVBYZERO | FE_OVERFLOW | FE_INVALID);
 #elif defined(__APPLE__) && defined(__GNUC__) && defined(__SSE__)
     eMask = _MM_GET_EXCEPTION_MASK();  // Save current eMask so we can disable.
@@ -42,7 +42,7 @@ void enableFPE(bool enableFPE)
                                  & ~_MM_MASK_INVALID);
 #endif
   } else {
-#if defined(__linux__) && defined(__GNUC__)
+#if defined(__linux__) && defined(__GNUC__) && !defined(__INTEL_COMPILER)
     fedisableexcept(FE_DIVBYZERO | FE_OVERFLOW | FE_INVALID);
 #elif defined(__APPLE__) && defined(__GNUC__) && defined(__SSE__)
     _MM_SET_EXCEPTION_MASK(eMask);

--- a/packages/tempus/unit_test/CMakeLists.txt
+++ b/packages/tempus/unit_test/CMakeLists.txt
@@ -421,6 +421,13 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   NUM_MPI_PROCS 1
   )
 
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_Stepper_ErrorNorm
+  SOURCES Tempus_UnitTest_Stepper_ErrorNorm.cpp ${TEMPUS_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
 TRIBITS_COPY_FILES_TO_BINARY_DIR(UnitTest_NewmarkImplicitAForm_CopyFiles
   DEST_FILES Tempus_NewmarkImplicitAForm_HarmonicOscillator_Damped_SecondOrder.xml Tempus_NewmarkExplicitAForm_HarmonicOscillator_Damped.xml Tempus_DIRK_VanDerPol.xml
   EXEDEPS UnitTest_NewmarkImplicitAForm

--- a/packages/tempus/unit_test/Tempus_UnitTest_Stepper_ErrorNorm.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_Stepper_ErrorNorm.cpp
@@ -1,0 +1,72 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Tempus_UnitTest_Utils.hpp"
+
+#include "Thyra_DefaultSpmdVectorSpace.hpp"
+
+#include "Tempus_NumericalUtils.hpp"
+#include "Tempus_Stepper_ErrorNorm.hpp"
+
+#include "../TestModels/DahlquistTestModel.hpp"
+
+
+namespace Tempus_Unit_Test {
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(Stepper_ErrorNorm, computeWRMSNorm)
+{
+
+  int N = 3;
+  Teuchos::RCP<const Thyra::VectorSpaceBase<double> > xSpace =
+    Thyra::defaultSpmdVectorSpace<double>(N);
+  auto x      = Thyra::createMember(xSpace);
+  auto xNext  = Thyra::createMember(xSpace);
+  auto eVec   = Thyra::createMember(xSpace);
+
+  auto tol = Tempus::numericalTol<double>();
+  auto eNorm = Teuchos::rcp(new Tempus::Stepper_ErrorNorm<double>(tol, 0.0));
+
+  Thyra::assign(x.ptr(),     0.0);
+  Thyra::assign(xNext.ptr(), 0.0);
+  Thyra::assign(eVec.ptr(),  0.0);
+  double rmsNorm = eNorm->computeWRMSNorm(x, xNext, eVec);
+  TEST_FLOATING_EQUALITY(rmsNorm, 0.0, 1.0e-12);
+
+  Thyra::assign(x.ptr(),     1.0);
+  Thyra::assign(xNext.ptr(), 1.0+tol);
+  Thyra::assign(eVec.ptr(),  tol);
+  rmsNorm = eNorm->computeWRMSNorm(x, xNext, eVec);
+  TEST_FLOATING_EQUALITY(rmsNorm, 1.0/std::sqrt(N), 1.0e-12);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(Stepper_ErrorNorm, errorNorm)
+{
+
+  Teuchos::RCP<const Thyra::VectorSpaceBase<double> > xSpace =
+    Thyra::defaultSpmdVectorSpace<double>(3);
+  auto x      = Thyra::createMember(xSpace);
+
+  auto tol = Tempus::numericalTol<double>();
+  auto eNorm = Teuchos::rcp(new Tempus::Stepper_ErrorNorm<double>(tol, tol));
+
+  Thyra::assign(x.ptr(),     0.0);
+  double norm = eNorm->errorNorm(x);
+  TEST_FLOATING_EQUALITY(norm, tol, 1.0e-12);
+
+  Thyra::assign(x.ptr(),     1.0);
+  norm = eNorm->errorNorm(x);
+  TEST_FLOATING_EQUALITY(norm, 1.0/(2.0*tol), 1.0e-12);
+}
+
+
+} // namespace Tempus_Test


### PR DESCRIPTION
Investigated failing tests from Tempus_*_MPI_1 failing in Trilinos-atdm-ats1-knl_intel-19.0.4_mpich-7.7.15_openmp_static_opt build starting 2021-10-15 #9881

 * Excluded the Intel compiler for FPE testing.
 * Fixed an FPE divide-by-zero in Stepper_ErrorNorm
   - Added unit test to cover it
 * Added some doxygen on Stepper_ErrorNorm

@trilinos/tempus 

## Motivation
Failing tests noted in #9881 

## Related Issues
* Related to #9881 

## Testing
Added unit test to cover discovered divide-by-zero.

