### PR TITLE
Ifpack2: rebaselining long double test

### DIFF
--- a/packages/ifpack2/test/belos/belos_solve_longdouble.cpp
+++ b/packages/ifpack2/test/belos/belos_solve_longdouble.cpp
@@ -166,7 +166,7 @@ int main(int argc, char *argv[]) {
     out->precision(ldbl::max_digits10);
     *out << "cout precision = " << ldbl::max_digits10 << "\n"; 
     *out << "||x|| = " << norm_x << "\n";
-    scalar_type norm_x_gold = 1695.64442027167615379;
+    scalar_type norm_x_gold = 1695.64442027183031314;
     scalar_type diff = std::abs(norm_x-norm_x_gold); 
     *out << "diff = " << diff << "\n"; 
     if (diff < 1.0e-15) {


### PR DESCRIPTION
Something in Trilinos changed that changed slightly the matrices / vectors defined in this problem.  The problem signed up in the ST = long double build in the Trilinos tests: https://sems-cdash-son.sandia.gov/cdash/test/1838303.  Verified that precision of result given new matrix/vector is correct.
