### PR TITLE
NOX: update solver stats

### DIFF
--- a/packages/nox/src/NOX_Observer_Print.cpp
+++ b/packages/nox/src/NOX_Observer_Print.cpp
@@ -43,6 +43,7 @@
 #include "NOX_Abstract_Group.H"
 #include "NOX_SolverStats.hpp"
 #include "NOX_Utils.H"
+#include "NOX_Solver_LineSearchBased.H"
 
 NOX::ObserverPrint::ObserverPrint(const Teuchos::RCP<NOX::Utils>& os) :
   os_(os)
@@ -58,12 +59,19 @@ void NOX::ObserverPrint::runPreIterate(const NOX::Solver::Generic& solver)
     os.width(5);
     os << "N";
 
-    os.width(12);
+    os.width(13);
     os << "Status";
 
     os.setf(std::ios::left);
     os.width(14);
     os << "||F||";
+
+    const auto* is_linesearch = dynamic_cast<const NOX::Solver::LineSearchBased*>(&solver);
+    if (is_linesearch) {
+      os.setf(std::ios::left);
+      os.width(14);
+      os << "Step Size";
+    }
 
     os.setf(std::ios::left);
     os.width(11);
@@ -96,7 +104,7 @@ void NOX::ObserverPrint::printStep(const NOX::Solver::Generic& solver)
   os.setf(std::ios::left);
   os << stats.numNonlinearIterations;
 
-  os.width(12);
+  os.width(13);
   if (solver.getStatus() == NOX::StatusTest::Unconverged)
     os << "Unconverged";
   else if (solver.getStatus() == NOX::StatusTest::Converged)
@@ -111,6 +119,14 @@ void NOX::ObserverPrint::printStep(const NOX::Solver::Generic& solver)
   if (!grp.isF())
     const_cast<NOX::Abstract::Group&>(grp).computeF();
   os << grp.getNormF();
+
+  const auto* is_linesearch = dynamic_cast<const NOX::Solver::LineSearchBased*>(&solver);
+  if (is_linesearch) {
+    os.width(14);
+    os.setf(std::ios::left|std::ios::scientific);
+    os.precision(precision);
+    os << is_linesearch->getStepSize();
+  }
 
   os.width(11);
   os.setf(std::ios::left);

--- a/packages/nox/src/NOX_SolverStats.hpp
+++ b/packages/nox/src/NOX_SolverStats.hpp
@@ -68,12 +68,14 @@ namespace NOX {
 
       void logLinearSolve(const bool converged,
                           const int numIterations,
-                          const double /* achievedTolerance */,
-                          const double /* initialResidualNorm */,
+                          const double achievedTolerance,
+                          const double initialResidualNorm,
                           const double finalResidualNorm)
       {
         lastLinearSolve_Converged = converged;
         lastLinearSolve_NumIterations = numIterations;
+        lastLinearSolve_AchievedTolerance = achievedTolerance;
+        lastLinearSolve_InitialResidualNorm = initialResidualNorm;
         lastLinearSolve_FinalResidualNorm = finalResidualNorm;
         ++lastNonlinearSolve_NumLinearSolves;
         lastNonlinearSolve_NumLinearIterations += numIterations;

--- a/packages/nox/test/tpetra/Tpetra_Heq.cpp
+++ b/packages/nox/test/tpetra/Tpetra_Heq.cpp
@@ -67,6 +67,7 @@
 
 #include "NOX_Thyra_MatrixFreeJacobianOperator.hpp"
 #include "NOX_MatrixFree_ModelEvaluatorDecorator.hpp"
+#include "NOX_Observer_Print.hpp"
 
 #if defined HAVE_TPETRACORE_CUDA
 #define NUM_ELEMENTS 10000
@@ -409,3 +410,96 @@ TEUCHOS_UNIT_TEST(NOX_Tpetra_Heq, JFNK_UserPrec)
   Teuchos::TimeMonitor::summarize();
 }
 
+TEUCHOS_UNIT_TEST(NOX_Tpetra_Heq, ObserverPrint)
+{
+  Teuchos::TimeMonitor::zeroOutTimers();
+
+  Teuchos::RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm();
+
+  // Get default Tpetra template types
+  typedef Tpetra::Vector<>::scalar_type Scalar;
+  typedef Tpetra::Vector<>::local_ordinal_type LO;
+  typedef Tpetra::Vector<>::global_ordinal_type GO;
+  typedef Tpetra::Vector<>::node_type Node;
+
+  // Create the model evaluator object
+  Scalar omega = 0.95;
+  const Tpetra::global_size_t numGlobalElements = NUM_ELEMENTS;
+  Teuchos::RCP<EvaluatorTpetraHeq<Scalar,LO,GO,Node> > model =
+    evaluatorTpetraHeq<Scalar,LO,GO,Node>(comm, numGlobalElements, omega);
+
+  Stratimikos::DefaultLinearSolverBuilder builder;
+
+  Teuchos::RCP<Teuchos::ParameterList> p = Teuchos::parameterList();
+  p->set("Linear Solver Type", "Belos");
+  Teuchos::ParameterList& belosList = p->sublist("Linear Solver Types").sublist("Belos");
+  belosList.set("Solver Type", "Pseudo Block GMRES");
+  belosList.sublist("Solver Types").sublist("Pseudo Block GMRES").set<int>("Maximum Iterations", numGlobalElements);
+  belosList.sublist("Solver Types").sublist("Pseudo Block GMRES").set<int>("Num Blocks", 200);
+  belosList.sublist("Solver Types").sublist("Pseudo Block GMRES").set<int>("Maximum Restarts", numGlobalElements);
+  belosList.sublist("Solver Types").sublist("Pseudo Block GMRES").set("Verbosity", 0);
+  belosList.sublist("Solver Types").sublist("Pseudo Block GMRES").set("Output Frequency", 100);
+  belosList.sublist("VerboseObject").set("Verbosity Level", "none");
+  p->set("Preconditioner Type", "None");
+  builder.setParameterList(p);
+
+  Teuchos::RCP<Thyra::LinearOpWithSolveFactoryBase<Scalar> >
+    lowsFactory = builder.createLinearSolveStrategy("");
+
+  model->set_W_factory(lowsFactory);
+
+  // Create the initial guess
+  Teuchos::RCP<Thyra::VectorBase<Scalar> >
+    initial_guess = model->getNominalValues().get_x()->clone_v();
+
+  Thyra::V_S(initial_guess.ptr(),Teuchos::ScalarTraits<Scalar>::one());
+
+  Teuchos::RCP<NOX::Thyra::Group> nox_group =
+    Teuchos::rcp(new NOX::Thyra::Group(*initial_guess, model, model->create_W_op(), lowsFactory, Teuchos::null, Teuchos::null, Teuchos::null));
+
+  nox_group->computeF();
+
+  // Create the NOX status tests and the solver
+  // Create the convergence tests
+  Teuchos::RCP<NOX::StatusTest::NormF> absresid =
+    Teuchos::rcp(new NOX::StatusTest::NormF(1.0e-8));
+  Teuchos::RCP<NOX::StatusTest::NormWRMS> wrms =
+    Teuchos::rcp(new NOX::StatusTest::NormWRMS(1.0e-2, 1.0e-8));
+  Teuchos::RCP<NOX::StatusTest::Combo> converged =
+    Teuchos::rcp(new NOX::StatusTest::Combo(NOX::StatusTest::Combo::AND));
+  converged->addStatusTest(absresid);
+  converged->addStatusTest(wrms);
+  Teuchos::RCP<NOX::StatusTest::MaxIters> maxiters =
+    Teuchos::rcp(new NOX::StatusTest::MaxIters(20));
+  Teuchos::RCP<NOX::StatusTest::FiniteValue> fv =
+    Teuchos::rcp(new NOX::StatusTest::FiniteValue);
+  Teuchos::RCP<NOX::StatusTest::Combo> combo =
+    Teuchos::rcp(new NOX::StatusTest::Combo(NOX::StatusTest::Combo::OR));
+  combo->addStatusTest(fv);
+  combo->addStatusTest(converged);
+  combo->addStatusTest(maxiters);
+
+  // Create nox parameter list
+  Teuchos::RCP<Teuchos::ParameterList> nl_params = Teuchos::parameterList();
+  nl_params->set("Nonlinear Solver", "Line Search Based");
+  nl_params->sublist("Direction").sublist("Newton").sublist("Linear Solver").set("Tolerance", 1.0e-4);
+
+  // Register Print Observer (and disable normal printing)
+  nl_params->sublist("Printing").set("Output Information",NOX::Utils::Error);
+  Teuchos::RCP<NOX::Utils> os = Teuchos::rcp(new NOX::Utils(nl_params->sublist("Printing")));
+  Teuchos::RCP<NOX::Observer> printObserver = Teuchos::rcp(new NOX::ObserverPrint(os));
+  nl_params->sublist("Solver Options").set("Observer",printObserver);
+
+  os->out() << "\n\nStarting Nonlinear Solve:\n\n";
+
+  // Create the solver
+  Teuchos::RCP<NOX::Solver::Generic> solver =
+    NOX::Solver::buildSolver(nox_group, combo, nl_params);
+  NOX::StatusTest::StatusType solvStatus = solver->solve();
+
+  os->out() << "\n";
+
+  TEST_ASSERT(solvStatus == NOX::StatusTest::Converged);
+
+  Teuchos::TimeMonitor::summarize();
+}


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/<teamName>

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Two of the solver statistics were not being logged. This update fixes the issue.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
new unit test added using H eqn

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->