### PR TITLE
Tpetra: fix modify flags of WDV::getView<T>

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_WrappedDualView.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_WrappedDualView.hpp
@@ -146,8 +146,8 @@ public:
 
   // This is an expert-only constructor
   // For WrappedDualView to manage synchronizations correctly,
-  // it must have an DualView which is not a subview to due the 
-  // sync's on.  This is what origDualV is for.  In this case, 
+  // it must have an DualView which is not a subview to due the
+  // sync's on.  This is what origDualV is for.  In this case,
   // dualV is a subview of origDualV.
   WrappedDualView(DualViewType dualV,DualViewType origDualV)
     : originalDualView(origDualV),
@@ -201,7 +201,7 @@ public:
   size_t extent(const int i) const {
     return dualView.h_view.extent(i);
   }
-  
+
   void stride(size_t * stride_) const {
     dualView.stride(stride_);
   }
@@ -210,7 +210,7 @@ public:
   size_t origExtent(const int i) const {
     return originalDualView.h_view.extent(i);
   }
-  
+
   const char * label() const {
     return dualView.d_view.label();
   }
@@ -219,7 +219,7 @@ public:
   typename t_host::const_type
   getHostView(Access::ReadOnlyStruct
     DEBUG_UVM_REMOVAL_ARGUMENT
-  ) const 
+  ) const
   {
     DEBUG_UVM_REMOVAL_PRINT_CALLER("getHostViewReadOnly");
     if(needsSyncPath()) {
@@ -232,7 +232,7 @@ public:
   t_host
   getHostView(Access::ReadWriteStruct
     DEBUG_UVM_REMOVAL_ARGUMENT
-  ) 
+  )
   {
     DEBUG_UVM_REMOVAL_PRINT_CALLER("getHostViewReadWrite");
     static_assert(dualViewHasNonConstData,
@@ -249,7 +249,7 @@ public:
   t_host
   getHostView(Access::OverwriteAllStruct
     DEBUG_UVM_REMOVAL_ARGUMENT
-  ) 
+  )
   {
     DEBUG_UVM_REMOVAL_PRINT_CALLER("getHostViewOverwriteAll");
     static_assert(dualViewHasNonConstData,
@@ -259,7 +259,7 @@ public:
     }
     if(needsSyncPath()) {
       throwIfDeviceViewAlive();
-      if (deviceMemoryIsHostAccessible) Kokkos::fence();      
+      if (deviceMemoryIsHostAccessible) Kokkos::fence();
       dualView.clear_sync_state();
       dualView.modify_host();
     }
@@ -269,7 +269,7 @@ public:
   typename t_dev::const_type
   getDeviceView(Access::ReadOnlyStruct
     DEBUG_UVM_REMOVAL_ARGUMENT
-  ) const 
+  ) const
   {
     DEBUG_UVM_REMOVAL_PRINT_CALLER("getDeviceViewReadOnly");
     if(needsSyncPath()) {
@@ -282,7 +282,7 @@ public:
   t_dev
   getDeviceView(Access::ReadWriteStruct
     DEBUG_UVM_REMOVAL_ARGUMENT
-  ) 
+  )
   {
     DEBUG_UVM_REMOVAL_PRINT_CALLER("getDeviceViewReadWrite");
     static_assert(dualViewHasNonConstData,
@@ -298,7 +298,7 @@ public:
   t_dev
   getDeviceView(Access::OverwriteAllStruct
     DEBUG_UVM_REMOVAL_ARGUMENT
-  ) 
+  )
   {
     DEBUG_UVM_REMOVAL_PRINT_CALLER("getDeviceViewOverwriteAll");
     static_assert(dualViewHasNonConstData,
@@ -317,13 +317,10 @@ public:
 
   template<class TargetDeviceType>
   typename std::remove_reference<decltype(std::declval<DualViewType>().template view<TargetDeviceType>())>::type::const_type
-  getView (Access::ReadOnlyStruct s DEBUG_UVM_REMOVAL_ARGUMENT) const {    
-    bool returnDevice = true;
-    {
-      auto tmp = dualView.template view<TargetDeviceType>();
-      if (tmp == this->dualView.view_host()) returnDevice = false;
-    }
-
+  getView (Access::ReadOnlyStruct s DEBUG_UVM_REMOVAL_ARGUMENT) const {
+    using ReturnViewType = typename std::remove_reference<decltype(std::declval<DualViewType>().template view<TargetDeviceType>())>::type::const_type;
+    using ReturnDeviceType = typename ReturnViewType::device_type;
+    constexpr bool returnDevice = std::is_same<ReturnDeviceType, DeviceType>::value;
     if(returnDevice) {
       DEBUG_UVM_REMOVAL_PRINT_CALLER("getView<Device>ReadOnly");
       if(needsSyncPath()) {
@@ -338,19 +335,17 @@ public:
 	impl::sync_host(originalDualView);
       }
     }
-    
+
     return dualView.template view<TargetDeviceType>();
-  } 
+  }
 
 
   template<class TargetDeviceType>
   typename std::remove_reference<decltype(std::declval<DualViewType>().template view<TargetDeviceType>())>::type
-  getView (Access::ReadWriteStruct s DEBUG_UVM_REMOVAL_ARGUMENT) const {    
-    bool returnDevice = true;
-    {
-      auto tmp = dualView.template view<TargetDeviceType>();
-      if (tmp == this->dualView.view_host()) returnDevice = false;
-    }
+  getView (Access::ReadWriteStruct s DEBUG_UVM_REMOVAL_ARGUMENT) const {
+    using ReturnViewType = typename std::remove_reference<decltype(std::declval<DualViewType>().template view<TargetDeviceType>())>::type;
+    using ReturnDeviceType = typename ReturnViewType::device_type;
+    constexpr bool returnDevice = std::is_same<ReturnDeviceType, DeviceType>::value;
 
     if(returnDevice) {
       DEBUG_UVM_REMOVAL_PRINT_CALLER("getView<Device>ReadWrite");
@@ -369,26 +364,25 @@ public:
       if(needsSyncPath()) {
 	throwIfDeviceViewAlive();
 	impl::sync_host(originalDualView);
-	originalDualView.modify_host();      
+	originalDualView.modify_host();
       }
     }
-    
+
     return dualView.template view<TargetDeviceType>();
-  } 
+  }
 
 
   template<class TargetDeviceType>
   typename std::remove_reference<decltype(std::declval<DualViewType>().template view<TargetDeviceType>())>::type
-  getView (Access::OverwriteAllStruct s DEBUG_UVM_REMOVAL_ARGUMENT) const {    
+  getView (Access::OverwriteAllStruct s DEBUG_UVM_REMOVAL_ARGUMENT) const {
+    using ReturnViewType = typename std::remove_reference<decltype(std::declval<DualViewType>().template view<TargetDeviceType>())>::type;
+    using ReturnDeviceType = typename ReturnViewType::device_type;
+
     if (iAmASubview())
       return getView<TargetDeviceType>(Access::ReadWrite);
 
-    bool returnDevice = true;
-    {
-      auto tmp = dualView.template view<TargetDeviceType>();
-      if (tmp == this->dualView.view_host()) returnDevice = false;
-    }
-    
+    constexpr bool returnDevice = std::is_same<ReturnDeviceType, DeviceType>::value;
+
     if(returnDevice) {
       DEBUG_UVM_REMOVAL_PRINT_CALLER("getView<Device>OverwriteAll");
       static_assert(dualViewHasNonConstData,
@@ -399,25 +393,25 @@ public:
 	dualView.modify_host();
       }
     }
-    else { 
+    else {
       DEBUG_UVM_REMOVAL_PRINT_CALLER("getView<Host>OverwriteAll");
       static_assert(dualViewHasNonConstData,
                     "OverwriteAll views are not available for DualView with const data");
       if(needsSyncPath()) {
 	throwIfDeviceViewAlive();
 	dualView.clear_sync_state();
-	dualView.modify_device();     
+	dualView.modify_device();
       }
     }
-    
+
     return dualView.template view<TargetDeviceType>();
-  } 
+  }
 
 
   typename t_host::const_type
   getHostSubview(int offset, int numEntries, Access::ReadOnlyStruct
     DEBUG_UVM_REMOVAL_ARGUMENT
-  ) const 
+  ) const
   {
     DEBUG_UVM_REMOVAL_PRINT_CALLER("getHostSubviewReadOnly");
     if(needsSyncPath()) {
@@ -430,7 +424,7 @@ public:
   t_host
   getHostSubview(int offset, int numEntries, Access::ReadWriteStruct
     DEBUG_UVM_REMOVAL_ARGUMENT
-  ) 
+  )
   {
     DEBUG_UVM_REMOVAL_PRINT_CALLER("getHostSubviewReadWrite");
     static_assert(dualViewHasNonConstData,
@@ -446,7 +440,7 @@ public:
   t_host
   getHostSubview(int offset, int numEntries, Access::OverwriteAllStruct
     DEBUG_UVM_REMOVAL_ARGUMENT
-  ) 
+  )
   {
     DEBUG_UVM_REMOVAL_PRINT_CALLER("getHostSubviewOverwriteAll");
     static_assert(dualViewHasNonConstData,
@@ -470,7 +464,7 @@ public:
   t_dev
   getDeviceSubview(int offset, int numEntries, Access::ReadWriteStruct
     DEBUG_UVM_REMOVAL_ARGUMENT
-  ) 
+  )
   {
     DEBUG_UVM_REMOVAL_PRINT_CALLER("getDeviceSubviewReadWrite");
     static_assert(dualViewHasNonConstData,
@@ -486,7 +480,7 @@ public:
   t_dev
   getDeviceSubview(int offset, int numEntries, Access::OverwriteAllStruct
     DEBUG_UVM_REMOVAL_ARGUMENT
-  ) 
+  )
   {
     DEBUG_UVM_REMOVAL_PRINT_CALLER("getDeviceSubviewOverwriteAll");
     static_assert(dualViewHasNonConstData,
@@ -543,7 +537,7 @@ public:
   bool need_sync_device() const {
     return originalDualView.need_sync_device();
   }
-    
+
   int host_view_use_count() const {
     return originalDualView.h_view.use_count();
   }
@@ -553,14 +547,14 @@ public:
   }
 
 
-  // MultiVector really needs to get at the raw DualViews, 
+  // MultiVector really needs to get at the raw DualViews,
   // but we'd very much prefer that users not.
   template<typename SC, typename LO, typename GO, typename NO>
   friend class ::Tpetra::MultiVector;
 
 private:
   // A Kokkos implementation of WrappedDualView will have to make these
-  // functions publically accessable, but in the Tpetra version, we'd 
+  // functions publically accessable, but in the Tpetra version, we'd
   // really rather not.
   DualViewType getOriginalDualView() const {
     return originalDualView;
@@ -596,22 +590,22 @@ private:
   }
 
   bool needsSyncPath() const {
-    // needsSyncPath tells us whether we need the "sync path" where we (potentially) fence, 
+    // needsSyncPath tells us whether we need the "sync path" where we (potentially) fence,
     // check use counts and take care of sync/modify for the underlying DualView
     //
-    // The logic is this:  
+    // The logic is this:
     // 1) For non-CUDA archtectures where there the host/device pointers are aliased
     // we don't need the "sync path."
-    // 2) For CUDA, we always need the "sync path" if we're using the CudaUVMSpace (we need to make sure 
+    // 2) For CUDA, we always need the "sync path" if we're using the CudaUVMSpace (we need to make sure
     // to fence before reading memory on host) OR if the host/device pointers are aliased.
     //
-    // Avoiding the "sync path" speeds up calculations on architectures where we can 
+    // Avoiding the "sync path" speeds up calculations on architectures where we can
     // avoid it (e.g. SerialNode) by not not touching the modify flags.
     //
-    // Note for the future: Memory spaces that can be addressed on both host and device 
-    // that don't otherwise have an intrinsic fencing mechanism will need to trigger the 
+    // Note for the future: Memory spaces that can be addressed on both host and device
+    // that don't otherwise have an intrinsic fencing mechanism will need to trigger the
     // "sync path"
-    
+
 #ifdef KOKKOS_ENABLE_CUDA
     return std::is_same<typename t_dev::memory_space,Kokkos::CudaUVMSpace>::value || !memoryIsAliased();
 #else
@@ -622,7 +616,7 @@ private:
   void throwIfHostViewAlive() const {
     if (dualView.h_view.use_count() > dualView.d_view.use_count()) {
       std::ostringstream msg;
-      msg << "Tpetra::Details::WrappedDualView (name = " << dualView.d_view.label() 
+      msg << "Tpetra::Details::WrappedDualView (name = " << dualView.d_view.label()
           << "; host use_count = " << dualView.h_view.use_count()
           << "; device use_count = " << dualView.d_view.use_count() << "): "
           << "Cannot access data on device while a host view is alive";
@@ -630,7 +624,7 @@ private:
     }
   }
 
-  void throwIfDeviceViewAlive() const {  
+  void throwIfDeviceViewAlive() const {
     if (dualView.d_view.use_count() > dualView.h_view.use_count()) {
       std::ostringstream msg;
       msg << "Tpetra::Details::WrappedDualView (name = " << dualView.d_view.label()

--- a/packages/tpetra/core/test/MultiVector/MultiVector_LocalViewTests.cpp
+++ b/packages/tpetra/core/test/MultiVector/MultiVector_LocalViewTests.cpp
@@ -322,6 +322,54 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( MultiVector, DeviceHostView, LO, GO, Scalar ,
   TEST_ASSERT(gerr == 0);
 }
 
+TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( MultiVector, TemplatedGetLocalView, LO, GO, Scalar , Node )
+{
+  Teuchos::RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm();
+  int np = comm->getSize();
+
+  using vector_t = Tpetra::Vector<Scalar,LO,GO,Node>;
+  using map_t = Tpetra::Map<LO,GO,Node>;
+  using WDV = typename vector_t::wrapped_dual_view_type;
+  using device_t = typename WDV::DeviceType;
+  using host_t = typename WDV::HostType;
+
+  const size_t nGlobalEntries = 8 * np;
+  Teuchos::Array<GO> myEntries(nGlobalEntries); 
+
+  // Default one-to-one linear block map in Trilinos
+  Teuchos::RCP<const map_t> defaultMap = 
+           rcp(new map_t(nGlobalEntries, 0, comm));
+
+  // Create vector
+  vector_t x(defaultMap);
+
+  {
+    // Check that getLocalView<device_t> produces a view with the correct device type
+    auto deviceView = x.template getLocalView<device_t>(Tpetra::Access::ReadWrite);
+    static_assert(std::is_same<typename decltype(deviceView)::device_type, device_t>::value,
+        "getLocalView<Vector::device_t> should produce a view with that device_type.");
+  }
+  // For UVM: check that x is now marked as modified on device, but not on host
+#ifdef KOKKOS_ENABLE_CUDA
+  if(std::is_same<Kokkos::CudaUVMSpace, typename device_t::memory_space>::value)
+  {
+    TEST_ASSERT(x.need_sync_host());
+    TEST_ASSERT(!x.need_sync_device());
+  }
+#endif
+  // Assuming device/host device types aren't the same, make sure getting the host view also works
+  if(!std::is_same<device_t, host_t>::value)
+  {
+    {
+      auto hostView = x.template getLocalView<host_t>(Tpetra::Access::ReadWrite);
+      static_assert(std::is_same<typename decltype(hostView)::device_type, host_t>::value,
+          "getLocalView<Vector::wrapped_dual_view_type::HostType> should produce a host view.");
+      TEST_ASSERT(x.need_sync_device());
+      TEST_ASSERT(!x.need_sync_host());
+    }
+  }
+}
+
 //
 // INSTANTIATIONS
 //
@@ -331,7 +379,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( MultiVector, DeviceHostView, LO, GO, Scalar ,
   TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( MultiVector, HostView, LO, GO, SCALAR, NODE ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( MultiVector, DeviceView, LO, GO, SCALAR, NODE ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( MultiVector, HostDeviceView, LO, GO, SCALAR, NODE ) \
-  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( MultiVector, DeviceHostView, LO, GO, SCALAR, NODE ) 
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( MultiVector, DeviceHostView, LO, GO, SCALAR, NODE ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( MultiVector, TemplatedGetLocalView, LO, GO, SCALAR, NODE ) 
 
   TPETRA_ETI_MANGLING_TYPEDEFS()
 


### PR DESCRIPTION
Use compile-time logic to figure out whether WrappedDualView::getView<T>
will return a host or device view. Add test to make sure the correct
modify flags based on the device type T. #9897 fixed one example of incorrect modify flags, but this is a permanent fix for the general issue.

The general issue was, for a MultiVector with the device and host being the same (e.g. UVM), doing
``mv.template getLocalView<DeviceType>(ReadWrite)`` would set the host modify flag. But now, plugging in the device consistently sets the device modify flag.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:
-->
## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows #9897
* Precedes 
* Related to 
* Part of 
* Composed of 


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Added a test in MultiVector/LocalViewTests to replicate the previous issue and make sure the modify flags are set correctly.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->