### PR TITLE
Tpetra: Update Tpetra_TestBlockCrs

### DIFF
--- a/packages/tpetra/core/example/BlockCrs/Tpetra_TestBlockCrs.cpp
+++ b/packages/tpetra/core/example/BlockCrs/Tpetra_TestBlockCrs.cpp
@@ -423,7 +423,7 @@ int main (int argc, char *argv[])
           const auto end = rowptr_host(row+1);
           typedef typename std::remove_const<decltype (beg) >::type offset_type;
           for (offset_type loc = beg; loc < end; ++loc) {
-            blocks_host(loc) = A_bcrs->getLocalBlockDeviceNonConst(row, colidx_host(loc));
+            blocks_host(loc) = A_bcrs->getLocalBlockHostNonConst(row, colidx_host(loc));
           }
         }
         //   });
@@ -637,11 +637,14 @@ int main (int argc, char *argv[])
         B_bcrs->dot(*B_bcrs, norm2);
         B_crs->dot(*B_crs, diff2);
 
-        if (myProcessPrintsDuringTheTest) {
-          for (LO i = 0; i < nrhs; ++i) {
+        for (LO i = 0; i < nrhs; ++i) {
+          const value_type err = std::sqrt(diff2(i)/norm2(i));
+          if (myProcessPrintsDuringTheTest) {
             std::cout << "Column = " << i << "  Error norm = "
-                      << std::sqrt(diff2(i)/norm2(i)) << endl;
+                      << err << endl;
           }
+          const value_type epsilon = 100.*Teuchos::ScalarTraits<value_type>::eps();
+          TEUCHOS_ASSERT(err<epsilon);
         }
       }
 


### PR DESCRIPTION
Make updates to Tpetra_TestBlockCrs example.

Changes:
- Fix Host call of getLocalBlockDeviceNonConst() to getLocalBlockHostNonConst()
- Add assert to ensure BlockCrs and Crs matvec yield same results (up to a tolerance)

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

Found that BlockCrs::apply() gave a diff to Crs::aaply() when doing some benchmarking.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

Added an assert within the example which requires both BlockCrs and Crs apply to give the same results (up to a tol).

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->