### PR TITLE
atdm/cee-rhel7: unset NVCC_WRAPPER_TMPDIR

### DIFF
--- a/cmake/std/atdm/cee-rhel7/environment.sh
+++ b/cmake/std/atdm/cee-rhel7/environment.sh
@@ -161,6 +161,7 @@ elif [ "$ATDM_CONFIG_COMPILER" == "CUDA-10.1.243_GNU-7.2.0_OPENMPI-4.0.3" ]; the
   export MPIF90=`which mpif90`
 
   # CUDA Settings
+  unset NVCC_WRAPPER_TMPDIR
   if [[ ! -d /tmp/${USER} ]] ; then
     echo "Creating /tmp/${USER} for nvcc wrapper!"
     mkdir /tmp/${USER}


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/framework

atdm/cee-rhel7: unset NVCC_WRAPPER_TMPDIR

  - An update to packages/kokkos/bin/nvcc_wrapper causes
  nvcc_wrapper to set its internal 'temp_dir' to 'x' when NVCC_WRAPPER_TMPDIR
  is set. It is unclear whether a module update which sets NVCC_WRAPPER_TMPDIR
  or kokkos/kokkos@fd0bd40
  broke the cee-rhel7 builds.

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The primary ats2 builds have been down since 10/30/21: https://testing.sandia.gov/cdash/index.php?project=Trilinos&begin=2021-10-01&end=2021-11-17&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=cee-rhel7

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Testing is running and will continue to post here: https://testing.sandia.gov/cdash/index.php?project=Trilinos&filtercount=2&showfilters=1&filtercombine=and&field1=buildname&compare1=61&value1=Trilinos-atdm-cee-rhel7_cuda-10.1.243_gnu-7.2.0_openmpi-4.0.3_shared_opt-exp&field2=buildstamp&compare2=61&value2=20211118-1557-Experimental

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->