### PR TITLE
Zoltan2:  fix indexing for non-contiguous row maps in TpetraCrsColorer's bipartite symmetrization

### DIFF
--- a/packages/zoltan2/core/src/TpetraCrsColorer/Zoltan2_TpetraCrsColorer_Zoltan.hpp
+++ b/packages/zoltan2/core/src/TpetraCrsColorer/Zoltan2_TpetraCrsColorer_Zoltan.hpp
@@ -270,7 +270,8 @@ ZoltanCrsColorer<CrsMatrixType>::computeColoring(
   // Do coloring of columns with Zoltan -- we can request colors for
   // columns we don't own
   const size_t num_local_cols  = this->graph->getNodeNumCols();
-  const size_t num_global_rows = this->graph->getGlobalNumRows();
+  const size_t num_global_rows = 
+               this->graph->getRowMap()->getMaxAllGlobalIndex()+1;
 
   Teuchos::Array<ZOLTAN_ID_TYPE> col_gids(num_local_cols);
   auto gids = this->graph->getColMap()->getNodeElementList();
@@ -351,7 +352,8 @@ ZoltanCrsColorer<CrsMatrixType>::get_vertex_list(
 
   const size_t num_local_rows  = zoltan_data->graph->getNodeNumRows();
   const size_t num_local_cols  = zoltan_data->trans_graph->getNodeNumRows();
-  const size_t num_global_rows = zoltan_data->graph->getGlobalNumRows();
+  const size_t num_global_rows = 
+               zoltan_data->graph->getRowMap()->getMaxAllGlobalIndex()+1;
   auto row_gids = zoltan_data->graph->getRowMap()->getNodeElementList();
   auto col_gids = zoltan_data->trans_graph->getRowMap()->getNodeElementList();
 
@@ -419,7 +421,8 @@ ZoltanCrsColorer<CrsMatrixType>::get_edge_list(
   *ierr = ZOLTAN_OK;
 
   const size_t num_local_rows = zoltan_data->graph->getNodeNumRows();
-  const size_t num_global_rows = zoltan_data->graph->getGlobalNumRows();
+  const size_t num_global_rows =
+               zoltan_data->graph->getRowMap()->getMaxAllGlobalIndex()+1;
   const ZOLTAN_ID_TYPE lid = *local_id;
 
   if (lid < num_local_rows)

--- a/packages/zoltan2/core/src/TpetraCrsColorer/Zoltan2_TpetraCrsColorer_Zoltan.hpp
+++ b/packages/zoltan2/core/src/TpetraCrsColorer/Zoltan2_TpetraCrsColorer_Zoltan.hpp
@@ -270,8 +270,10 @@ ZoltanCrsColorer<CrsMatrixType>::computeColoring(
   // Do coloring of columns with Zoltan -- we can request colors for
   // columns we don't own
   const size_t num_local_cols  = this->graph->getNodeNumCols();
-  const size_t num_global_rows = 
-               this->graph->getRowMap()->getMaxAllGlobalIndex()+1;
+  const size_t num_global_rows = std::max(
+                   static_cast<typename CrsMatrixType::global_ordinal_type>(
+                               this->graph->getGlobalNumRows()),
+                   this->graph->getRowMap()->getMaxAllGlobalIndex()+1);
 
   Teuchos::Array<ZOLTAN_ID_TYPE> col_gids(num_local_cols);
   auto gids = this->graph->getColMap()->getNodeElementList();
@@ -352,8 +354,10 @@ ZoltanCrsColorer<CrsMatrixType>::get_vertex_list(
 
   const size_t num_local_rows  = zoltan_data->graph->getNodeNumRows();
   const size_t num_local_cols  = zoltan_data->trans_graph->getNodeNumRows();
-  const size_t num_global_rows = 
-               zoltan_data->graph->getRowMap()->getMaxAllGlobalIndex()+1;
+  const size_t num_global_rows = std::max(
+                   static_cast<typename CrsMatrixType::global_ordinal_type>(
+                               zoltan_data->graph->getGlobalNumRows()),
+                   zoltan_data->graph->getRowMap()->getMaxAllGlobalIndex()+1);
   auto row_gids = zoltan_data->graph->getRowMap()->getNodeElementList();
   auto col_gids = zoltan_data->trans_graph->getRowMap()->getNodeElementList();
 
@@ -421,8 +425,10 @@ ZoltanCrsColorer<CrsMatrixType>::get_edge_list(
   *ierr = ZOLTAN_OK;
 
   const size_t num_local_rows = zoltan_data->graph->getNodeNumRows();
-  const size_t num_global_rows =
-               zoltan_data->graph->getRowMap()->getMaxAllGlobalIndex()+1;
+  const size_t num_global_rows = std::max(
+                   static_cast<typename CrsMatrixType::global_ordinal_type>(
+                               zoltan_data->graph->getGlobalNumRows()),
+                   zoltan_data->graph->getRowMap()->getMaxAllGlobalIndex()+1);
   const ZOLTAN_ID_TYPE lid = *local_id;
 
   if (lid < num_local_rows)

--- a/packages/zoltan2/test/core/TpetraCrsColorer/CMakeLists.txt
+++ b/packages/zoltan2/test/core/TpetraCrsColorer/CMakeLists.txt
@@ -1,5 +1,14 @@
 
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
+      Bug9500
+      NAME Bug9500
+      SOURCES Bug9500.cpp
+      COMM serial mpi
+      PASS_REGULAR_EXPRESSION "PASS"
+      FAIL_REGULAR_EXPRESSION "FAIL"
+    )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
       TpetraCrsColorer
       NAME TpetraCrsColorer_simple_sym
       SOURCES TpetraCrsColorer.cpp

--- a/packages/zoltan2/test/core/helpers/UserInputForTests.hpp
+++ b/packages/zoltan2/test/core/helpers/UserInputForTests.hpp
@@ -403,7 +403,7 @@ chaco_offset(0), chaco_break_pnt(CHACO_LINE_LENGTH)
   if (zoltan1)
     readZoltanTestData(path, testData, distributeInput);
   else
-    readMatrixMarketFile(path, testData, distributeInput);
+    readMatrixMarketFile(path, testData);
 
 #ifdef HAVE_EPETRA_DATA_TYPES
   ecomm_ = Xpetra::toEpetra(c);

--- a/packages/zoltan2/test/core/helpers/UserInputForTests.hpp
+++ b/packages/zoltan2/test/core/helpers/UserInputForTests.hpp
@@ -403,7 +403,7 @@ chaco_offset(0), chaco_break_pnt(CHACO_LINE_LENGTH)
   if (zoltan1)
     readZoltanTestData(path, testData, distributeInput);
   else
-    readMatrixMarketFile(path, testData);
+    readMatrixMarketFile(path, testData, distributeInput);
 
 #ifdef HAVE_EPETRA_DATA_TYPES
   ecomm_ = Xpetra::toEpetra(c);


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/zoltan2

## Motivation

In #9500, @kliegeois reported incorrect results from TpetraCrsColorer when using matrices in non-contiguous row maps.
This PR fixes the problem.

The bipartite symmetrization used the number of global entries in the row map as the first index of the column vertices.  However, for a non-contiguous map with the largest index greater than the global number of entries, the number of global entries is incorrect.  Using the maximum global ID instead solves the problem, at least for the new test Bug9500.cpp.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

#9500 

## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
@kliegeois 

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
New test added:  Bug9500.cpp -- builds row maps with GIDs that are multiples of a specified "multiple"; does coloring for matrices with contiguous (multiple=1) and non-contiguous (multiple=2, 5) row maps.  
Test failed for multiple > 1; this PR allows the test to run with all multiples.
Run on ascicgpu with SEMS modules (serial node, CPU only)

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->