### PR TITLE
Stokhos: Remove power of two

### DIFF
--- a/packages/stokhos/src/kokkos/Stokhos_CrsProductTensor.hpp
+++ b/packages/stokhos/src/kokkos/Stokhos_CrsProductTensor.hpp
@@ -817,7 +817,7 @@ public:
                       const size_type thread_rank ) const
   {
     enum { work_align = 64 / sizeof(VectorValue) };
-    enum { work_shift = Kokkos::Impl::power_of_two< work_align >::value };
+    enum { work_shift = Kokkos::Impl::integral_power_of_two( work_align ) };
     enum { work_mask  = work_align - 1 };
 
     const size_type work_per_thread =

--- a/packages/stokhos/src/kokkos/Stokhos_Multiply.hpp
+++ b/packages/stokhos/src/kokkos/Stokhos_Multiply.hpp
@@ -172,7 +172,7 @@ compute_work_range( const execution_space device,
 #endif
 
   enum { work_align = cache_line / sizeof(scalar_type) };
-  enum { work_shift = Kokkos::Impl::power_of_two< work_align >::value };
+  enum { work_shift = Kokkos::Impl::integral_power_of_two( work_align ) };
   enum { work_mask  = work_align - 1 };
 
   const size_type work_per_thread =


### PR DESCRIPTION

@trilinos/stokhos 

## Motivation
Kokkos is removing Kokkos::Impl::power_of_two, this update is for compatibility with kokkos/kokkos#4578

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Testing
Autotester
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->