### PR TITLE
Tpetra / Teuchos / Tacho: Removing deprecated use to Kokkos::Impl::SpaceAccessibility and Kokkos::Impl::is_space

### DIFF
--- a/packages/shylu/shylu_node/tacho/src/Tacho.hpp
+++ b/packages/shylu/shylu_node/tacho/src/Tacho.hpp
@@ -82,7 +82,7 @@ namespace Tacho {
   ///
   template<typename SpT>
   void printExecSpaceConfiguration(std::string name, const bool detail = false) {
-    if (!Kokkos::Impl::is_space<SpT>::value) {
+    if (!Kokkos::is_space<SpT>::value) {
       std::string msg("SpT is not Kokkos execution space");
       fprintf(stderr, ">> Error in file %s, line %d\n",__FILE__,__LINE__);
       fprintf(stderr, "   %s\n", msg.c_str());

--- a/packages/teuchos/kokkoscompat/src/KokkosCompat_View.hpp
+++ b/packages/teuchos/kokkoscompat/src/KokkosCompat_View.hpp
@@ -82,7 +82,7 @@ namespace Kokkos {
     getKokkosViewDeepCopy (const Teuchos::ArrayView<T>& a)
     {
       typedef typename Kokkos::Impl::if_c<
-        Impl::SpaceAccessibility< D, Kokkos::HostSpace>::accessible,
+        SpaceAccessibility< D, Kokkos::HostSpace>::accessible,
         typename D::execution_space, Kokkos::HostSpace>::type
         HostDevice;
       typedef Kokkos::View<T*, D> view_type;
@@ -102,7 +102,7 @@ namespace Kokkos {
     getKokkosViewDeepCopy(const Teuchos::ArrayView<const T>& a)
     {
       typedef typename Kokkos::Impl::if_c<
-        Impl::SpaceAccessibility< D, Kokkos::HostSpace>::accessible,
+        SpaceAccessibility< D, Kokkos::HostSpace>::accessible,
         typename D::execution_space, Kokkos::HostSpace>::type
         HostDevice;
       typedef Kokkos::View<T*, D>  view_type;

--- a/packages/tpetra/core/src/Tpetra_Details_computeOffsets.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_computeOffsets.hpp
@@ -292,7 +292,7 @@ computeOffsetsFromCounts (const ExecutionSpace& execSpace,
       typename offsets_device_type::memory_space;
     using counts_memory_space = typename CountsViewType::memory_space;
     constexpr bool countsAccessibleFromOffsetsExecSpace =
-      Kokkos::Impl::SpaceAccessibility<
+      Kokkos::SpaceAccessibility<
         offsets_memory_space, counts_memory_space>::accessible;
     if (countsAccessibleFromOffsetsExecSpace) {
       // NOTE (mfh 21 Aug 2019) Some compilers have trouble deducing

--- a/packages/tpetra/core/src/Tpetra_Details_copyConvert.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_copyConvert.hpp
@@ -235,7 +235,7 @@ namespace { // (anonymous)
            const bool canUseKokkosDeepCopy =
              CanUseKokkosDeepCopy<OutputViewType, InputViewType>::value,
            const bool outputExecSpaceCanAccessInputMemSpace =
-             Kokkos::Impl::SpaceAccessibility<
+             Kokkos::SpaceAccessibility<
                typename OutputViewType::memory_space,
                typename InputViewType::memory_space>::accessible>
   struct CopyConvertImpl {

--- a/packages/tpetra/core/src/Tpetra_Details_copyOffsets.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_copyOffsets.hpp
@@ -234,7 +234,7 @@ namespace { // (anonymous)
     CopyOffsetsFunctor (const OutputViewType& dst, const InputViewType& src) :
       dst_ (dst), src_ (src)
     {
-      static_assert (Kokkos::Impl::SpaceAccessibility<
+      static_assert (Kokkos::SpaceAccessibility<
                        typename OutputViewType::memory_space,
                        typename InputViewType::memory_space>::accessible,
                      "CopyOffsetsFunctor (implements copyOffsets): Output "
@@ -285,7 +285,7 @@ namespace { // (anonymous)
       dst_ (dst),
       src_ (src)
     {
-      static_assert (Kokkos::Impl::SpaceAccessibility<
+      static_assert (Kokkos::SpaceAccessibility<
                        typename OutputViewType::memory_space,
                        typename InputViewType::memory_space>::accessible,
                      "CopyOffsetsFunctor (implements copyOffsets): Output "
@@ -342,7 +342,7 @@ namespace { // (anonymous)
              std::is_same<typename OutputViewType::non_const_value_type,
                           typename InputViewType::non_const_value_type>::value,
            const bool outputExecSpaceCanAccessInputMemSpace =
-             Kokkos::Impl::SpaceAccessibility<
+             Kokkos::SpaceAccessibility<
                typename OutputViewType::memory_space,
                typename InputViewType::memory_space>::accessible>
   struct CopyOffsetsImpl {
@@ -413,7 +413,7 @@ namespace { // (anonymous)
                      "must be false.  That is, either the input and output "
                      "must have different array layouts, or their value types "
                      "must differ.");
-      static_assert (Kokkos::Impl::SpaceAccessibility<
+      static_assert (Kokkos::SpaceAccessibility<
                        typename OutputViewType::memory_space,
                        typename InputViewType::memory_space>::accessible,
                      "CopyOffsetsImpl (implements copyOffsets): In order to "

--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -243,7 +243,7 @@ namespace { // (anonymous)
     // around this default execution space issue.
     //
     typedef typename Kokkos::Impl::if_c<
-      Kokkos::Impl::SpaceAccessibility<
+      Kokkos::SpaceAccessibility<
         typename ExecSpace::memory_space,
         Kokkos::HostSpace>::accessible,
       typename ExecSpace::device_type,

--- a/packages/tpetra/core/src/Tpetra_applyDirichletBoundaryCondition.hpp
+++ b/packages/tpetra/core/src/Tpetra_applyDirichletBoundaryCondition.hpp
@@ -473,7 +473,7 @@ applyDirichletBoundaryConditionToLocalMatrixRows
     ApplyDirichletBoundaryConditionToLocalMatrixRows<SC, LO, GO, NT>;
 
   // Only run on host if we can access the data
-  const bool runOnHost = Kokkos::Impl::SpaceAccessibility<Kokkos::Serial,memory_space>::accessible;
+  const bool runOnHost = Kokkos::SpaceAccessibility<Kokkos::Serial,memory_space>::accessible;
   if(runOnHost) {
     using local_row_indices_type = Kokkos::View<const LO*, Kokkos::AnonymousSpace>;
     const local_row_indices_type lclRowInds_a (lclRowInds);


### PR DESCRIPTION
Issue: #9994; Tests: Kokkos deprecated off; Stakeholder feedback: n/a