### PR TITLE
Tpetra CrsMatrix: Add CombineMode option to "insertLocalValues"

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -1031,11 +1031,17 @@ namespace Tpetra {
     ///   insert the entries.  All of the column indices must be owned
     ///   by the column Map on the calling process.
     /// \param vals [in] Values to insert into the above columns.
+    /// \param CM [in] How values should be inserted. Valid options
+    ///   are: ADD (default) inserts values that are not yet in the
+    ///   matrix graph, and sums values that are already present. INSERT
+    ///   inserts values that are not yet in the matrix graph, and
+    ///   replaces values that are already present.
     ///
     /// For all k in 0, ..., <tt>cols.size()-1</tt>, insert the value
     /// <tt>values[k]</tt> into entry <tt>(globalRow, cols[k])</tt> of
     /// the matrix.  If that entry already exists, add the new value
-    /// to the old value.
+    /// to the old value, if <tt>CM=ADD</tt>, otherwise replace
+    /// the old value.
     ///
     /// In order to call this method, the matrix must be locally
     /// indexed, and it must have a column Map.
@@ -1060,7 +1066,8 @@ namespace Tpetra {
     void
     insertLocalValues (const LocalOrdinal localRow,
                        const Teuchos::ArrayView<const LocalOrdinal> &cols,
-                       const Teuchos::ArrayView<const Scalar> &vals);
+                       const Teuchos::ArrayView<const Scalar> &vals,
+                       const CombineMode CM=ADD);
 
     /// \brief Epetra compatibility version of insertLocalValues (see
     ///   above) that takes arguments as raw pointers, rather than
@@ -1076,11 +1083,17 @@ namespace Tpetra {
     /// \param vals [in] Values to insert.
     /// \param cols [in] Global indices of the columns into which
     ///   to insert the entries.
+    /// \param CM [in] How values should be inserted. Valid options
+    ///   are: ADD (default) inserts values that are not yet in the
+    ///   matrix graph, and sums values that are already present. INSERT
+    ///   inserts values that are not yet in the matrix graph, and
+    ///   replaces values that are already present.
     void
     insertLocalValues (const LocalOrdinal localRow,
                        const LocalOrdinal numEnt,
                        const Scalar vals[],
-                       const LocalOrdinal cols[]);
+                       const LocalOrdinal cols[],
+                       const CombineMode CM=ADD);
 
   protected:
     /// \brief Implementation detail of replaceGlobalValues.

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests.cpp
@@ -418,6 +418,82 @@ namespace { // (anonymous)
     }
   }
 
+
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( CrsMatrix, InsertLocalValuesCombineModes, LO, GO, Scalar, Node )
+  {
+    typedef Tpetra::CrsMatrix<Scalar,LO,GO,Node> MAT;
+    typedef Teuchos::ScalarTraits<Scalar> ST;
+    // get a comm
+    RCP<const Comm<int> > comm = getDefaultComm();
+    // create a Map
+    const size_t numLocalRows = 3;
+    const size_t numLocalColumns = 3;
+    const int numRanks = comm->getSize();
+    RCP<const Tpetra::Map<LO,GO,Node> > rowMap =
+      createContigMapWithNode<LO,GO,Node>(numLocalRows * numRanks, numLocalRows, comm);
+    RCP<const Tpetra::Map<LO,GO,Node> > colMap =
+      createContigMapWithNode<LO,GO,Node>(numLocalColumns * numRanks, numLocalColumns, comm);
+
+    Teuchos::Array<size_t> entriesPerRow(numLocalRows);
+    for(size_t i = 0; i < numLocalRows; i++)
+      entriesPerRow[i] = 3;
+    MAT A(rowMap, colMap, entriesPerRow());
+
+    //Insert 1 as value in all entries.
+    Teuchos::Array<Scalar> vals(numLocalColumns-1, ST::one());
+    Teuchos::Array<LO> cols(numLocalColumns-1);
+    for(size_t i = 0; i < numLocalColumns-1; i++)
+      cols[i] = i;
+    auto valsView = vals();
+    auto colsView = cols();
+
+    Teuchos::Array<Scalar> vals2(numLocalColumns, ST::one());
+    Teuchos::Array<LO> cols2(numLocalColumns);
+    for(size_t i = 0; i < numLocalColumns; i++)
+      cols2[i] = i;
+    auto valsView2 = vals2();
+    auto colsView2 = cols2();
+
+    // only the second pair of (cols, vals) inserts into the third column
+
+    // default CombineMode = ADD
+    A.insertLocalValues(0, colsView, valsView);
+    A.insertLocalValues(0, colsView2, valsView2);
+    // ADD
+    A.insertLocalValues(1, colsView, valsView, Tpetra::ADD);
+    A.insertLocalValues(1, colsView2, valsView2, Tpetra::ADD);
+    //INSERT
+    A.insertLocalValues(2, colsView, valsView, Tpetra::INSERT);
+    A.insertLocalValues(2, colsView2, valsView2, Tpetra::INSERT);
+    A.fillComplete(colMap, rowMap);
+
+    //auto fancy = Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
+    //A.describe(*fancy,Teuchos::VERB_EXTREME);
+
+    const Scalar one = ST::one();
+    const Scalar two = one+one;
+
+    // Checks:
+    // The first two entries have been added/replaced according to the
+    // CombineMode
+    // The third entry should always be 1.
+
+    typename MAT::local_inds_host_view_type kColsView;
+    typename MAT::values_host_view_type kValsView;
+    A.getLocalRowView(0, kColsView, kValsView);
+    for(size_t i = 0; i < numLocalColumns-1; i++)
+      TEST_EQUALITY(kValsView(i), two);
+    TEST_EQUALITY(kValsView(numLocalColumns-1), one);
+    A.getLocalRowView(1, kColsView, kValsView);
+    for(size_t i = 0; i < numLocalColumns-1; i++)
+      TEST_EQUALITY(kValsView(i), two);
+    TEST_EQUALITY(kValsView(numLocalColumns-1), one);
+    A.getLocalRowView(2, kColsView, kValsView);
+    for(size_t i = 0; i < numLocalColumns-1; i++)
+      TEST_EQUALITY(kValsView(i), one);
+    TEST_EQUALITY(kValsView(numLocalColumns-1), one);
+  }
+
 //
 // INSTANTIATIONS
 //
@@ -428,14 +504,16 @@ namespace { // (anonymous)
       TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( CrsMatrix, TheEyeOfTruth,  LO, GO, SCALAR, NODE ) \
       TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( CrsMatrix, ZeroMatrix,     LO, GO, SCALAR, NODE ) \
       TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( CrsMatrix, BadCalls,       LO, GO, SCALAR, NODE ) \
-      TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( CrsMatrix, SimpleEigTest,  LO, GO, SCALAR, NODE )
+      TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( CrsMatrix, SimpleEigTest,  LO, GO, SCALAR, NODE ) \
+      TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( CrsMatrix, InsertLocalValuesCombineModes,  LO, GO, SCALAR, NODE )
 #else
 #define UNIT_TEST_GROUP( SCALAR, LO, GO, NODE ) \
       TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( CrsMatrix, TheEyeOfTruth,  LO, GO, SCALAR, NODE ) \
       TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( CrsMatrix, ZeroMatrix,     LO, GO, SCALAR, NODE ) \
       TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( CrsMatrix, ImbalancedRowMatrix, LO, GO, SCALAR, NODE ) \
       TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( CrsMatrix, BadCalls,       LO, GO, SCALAR, NODE ) \
-      TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( CrsMatrix, SimpleEigTest,  LO, GO, SCALAR, NODE )
+      TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( CrsMatrix, SimpleEigTest,  LO, GO, SCALAR, NODE ) \
+      TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( CrsMatrix, InsertLocalValuesCombineModes,  LO, GO, SCALAR, NODE )
 #endif
 
   TPETRA_ETI_MANGLING_TYPEDEFS()


### PR DESCRIPTION
@trilinos/tpetra 

## Motivation
The optional argument `CM` (`ADD` by default) allows to replace existing values instead of summing into them. The default behavior of `insertLocalValues` is not changed. Setting `CM=INSERT` instead replaces already existing values.

This is for example useful for constructing the strong form the gradient operator as used in MiniEM. The entry corresponding to a pair of HGrad and HCurl dofs is identical on each element that contains these dofs. It would be possible to track which entries have already been set in the sub-assembly, but this can be avoided by simply overwriting the entries in `insertLocalValues`.
 
