### PR TITLE
Tempus: Remove IntegratorBasicOld

### DIFF
--- a/packages/piro/src/Piro_TempusIntegrator.hpp
+++ b/packages/piro/src/Piro_TempusIntegrator.hpp
@@ -45,7 +45,7 @@
 
 #include "Piro_ConfigDefs.hpp"
 
-#include "Tempus_IntegratorBasicOld.hpp"
+#include "Tempus_IntegratorBasic.hpp"
 #include "Tempus_IntegratorForwardSensitivity.hpp"
 #include "Tempus_IntegratorAdjointSensitivity.hpp"
 #include "Piro_Helpers.hpp"
@@ -115,7 +115,7 @@ public:
 
 private:
 
-  Teuchos::RCP<Tempus::IntegratorBasicOld<Scalar> > basicIntegrator_;
+  Teuchos::RCP<Tempus::IntegratorBasic<Scalar> > basicIntegrator_;
   Teuchos::RCP<Tempus::IntegratorForwardSensitivity<Scalar> > fwdSensIntegrator_;
   Teuchos::RCP<Tempus::IntegratorAdjointSensitivity<Scalar> > adjSensIntegrator_;
   Teuchos::RCP<Teuchos::FancyOStream> out_;

--- a/packages/piro/src/Piro_TempusIntegrator_Def.hpp
+++ b/packages/piro/src/Piro_TempusIntegrator_Def.hpp
@@ -53,16 +53,16 @@
 #include <iostream>
 
 template <typename Scalar>
-Piro::TempusIntegrator<Scalar>::TempusIntegrator(Teuchos::RCP< Teuchos::ParameterList > pList, 
+Piro::TempusIntegrator<Scalar>::TempusIntegrator(Teuchos::RCP< Teuchos::ParameterList > pList,
    const Teuchos::RCP< Thyra::ModelEvaluator< Scalar > > &model,
-   const SENS_METHOD sens_method) : 
+   const SENS_METHOD sens_method) :
    out_(Teuchos::VerboseObjectBase::getDefaultOStream())
 {
   if (sens_method == NONE) {
     //no sensitivities
-    basicIntegrator_ = Tempus::integratorBasic<Scalar>(pList, model);
-    fwdSensIntegrator_ = Teuchos::null; 
-    adjSensIntegrator_ = Teuchos::null; 
+    basicIntegrator_ = Tempus::createIntegratorBasic<Scalar>(pList, model);
+    fwdSensIntegrator_ = Teuchos::null;
+    adjSensIntegrator_ = Teuchos::null;
   }
   else if (sens_method == FORWARD) {
     //forward sensitivities
@@ -76,27 +76,27 @@ Piro::TempusIntegrator<Scalar>::TempusIntegrator(Teuchos::RCP< Teuchos::Paramete
       }
     }
     fwdSensIntegrator_ = Tempus::createIntegratorForwardSensitivity<Scalar>(pList, model);
-    adjSensIntegrator_ = Teuchos::null; 
+    adjSensIntegrator_ = Teuchos::null;
   }
   else if (sens_method == ADJOINT) {
     //adjoint sensitivities
     basicIntegrator_ = Teuchos::null;
-    fwdSensIntegrator_ = Teuchos::null; 
+    fwdSensIntegrator_ = Teuchos::null;
     adjSensIntegrator_ = Tempus::createIntegratorAdjointSensitivity<Scalar>(pList, model);
   }
 }
 
 template <typename Scalar>
-Piro::TempusIntegrator<Scalar>::TempusIntegrator(Teuchos::RCP< Teuchos::ParameterList > pList, 
+Piro::TempusIntegrator<Scalar>::TempusIntegrator(Teuchos::RCP< Teuchos::ParameterList > pList,
    const Teuchos::RCP< Thyra::ModelEvaluator< Scalar > > &model,
    const Teuchos::RCP< Thyra::ModelEvaluator< Scalar > > &adjoint_model,
-   const SENS_METHOD sens_method) : 
+   const SENS_METHOD sens_method) :
    out_(Teuchos::VerboseObjectBase::getDefaultOStream())
 {
   if (sens_method == ADJOINT) {
     //adjoint sensitivities
     basicIntegrator_ = Teuchos::null;
-    fwdSensIntegrator_ = Teuchos::null; 
+    fwdSensIntegrator_ = Teuchos::null;
     adjSensIntegrator_ = Tempus::createIntegratorAdjointSensitivity<Scalar>(pList, model, adjoint_model);
   }
   else { //throw
@@ -107,192 +107,188 @@ Piro::TempusIntegrator<Scalar>::TempusIntegrator(Teuchos::RCP< Teuchos::Paramete
 }
 
 template <typename Scalar>
-Teuchos::RCP<Tempus::Stepper<Scalar>> 
+Teuchos::RCP<Tempus::Stepper<Scalar>>
 Piro::TempusIntegrator<Scalar>::getStepper() const
 {
-  Teuchos::RCP<Tempus::Stepper<Scalar>> stepper; 
+  Teuchos::RCP<Tempus::Stepper<Scalar>> stepper;
   if (basicIntegrator_ != Teuchos::null) {
-    stepper = basicIntegrator_->getStepper(); 
+    stepper = basicIntegrator_->getStepper();
   }
   if (fwdSensIntegrator_ != Teuchos::null) {
-    stepper = fwdSensIntegrator_->getStepper(); 
+    stepper = fwdSensIntegrator_->getStepper();
   }
   if (adjSensIntegrator_ != Teuchos::null) {
-    stepper = adjSensIntegrator_->getStepper(); 
+    stepper = adjSensIntegrator_->getStepper();
   }
-  return stepper; 
+  return stepper;
 }
 
 template <typename Scalar>
-bool 
+bool
 Piro::TempusIntegrator<Scalar>::advanceTime(const Scalar time_final)
 {
-  bool out; 
+  bool out;
   if (basicIntegrator_ != Teuchos::null) {
-    out = basicIntegrator_->advanceTime(time_final); 
+    out = basicIntegrator_->advanceTime(time_final);
   }
   if (fwdSensIntegrator_ != Teuchos::null) {
-    out = fwdSensIntegrator_->advanceTime(time_final); 
+    out = fwdSensIntegrator_->advanceTime(time_final);
   }
   if (adjSensIntegrator_ != Teuchos::null) {
-    out = adjSensIntegrator_->advanceTime(time_final); 
+    out = adjSensIntegrator_->advanceTime(time_final);
   }
-  return out; 
+  return out;
 }
 
 template <typename Scalar>
-Scalar 
+Scalar
 Piro::TempusIntegrator<Scalar>::getTime() const
 {
-  Scalar time; 
+  Scalar time;
   if (basicIntegrator_ != Teuchos::null) {
-    time = basicIntegrator_->getTime(); 
+    time = basicIntegrator_->getTime();
   }
   if (fwdSensIntegrator_ != Teuchos::null) {
-    time = fwdSensIntegrator_->getTime(); 
+    time = fwdSensIntegrator_->getTime();
   }
   if (adjSensIntegrator_ != Teuchos::null) {
-    time = adjSensIntegrator_->getTime(); 
+    time = adjSensIntegrator_->getTime();
   }
-  return time; 
+  return time;
 }
 
 template <typename Scalar>
-Teuchos::RCP<const Thyra::VectorBase<Scalar>> 
+Teuchos::RCP<const Thyra::VectorBase<Scalar>>
 Piro::TempusIntegrator<Scalar>::getX() const
 {
-  Teuchos::RCP<const Thyra::VectorBase<Scalar>> x; 
+  Teuchos::RCP<const Thyra::VectorBase<Scalar>> x;
   if (basicIntegrator_ != Teuchos::null) {
-    x = basicIntegrator_->getX(); 
+    x = basicIntegrator_->getX();
   }
   if (fwdSensIntegrator_ != Teuchos::null) {
-    x = fwdSensIntegrator_->getX(); 
+    x = fwdSensIntegrator_->getX();
   }
   if (adjSensIntegrator_ != Teuchos::null) {
-    x = adjSensIntegrator_->getX(); 
+    x = adjSensIntegrator_->getX();
   }
-  return x; 
+  return x;
 }
- 
+
 template <typename Scalar>
-Teuchos::RCP<const Thyra::VectorBase<Scalar>> 
+Teuchos::RCP<const Thyra::VectorBase<Scalar>>
 Piro::TempusIntegrator<Scalar>::getXDot() const
 {
-  Teuchos::RCP<const Thyra::VectorBase<Scalar>> xdot; 
+  Teuchos::RCP<const Thyra::VectorBase<Scalar>> xdot;
   if (basicIntegrator_ != Teuchos::null) {
-    xdot = basicIntegrator_->getXDot(); 
+    xdot = basicIntegrator_->getXDot();
   }
   if (fwdSensIntegrator_ != Teuchos::null) {
-    xdot = fwdSensIntegrator_->getXDot(); 
+    xdot = fwdSensIntegrator_->getXDot();
   }
   if (adjSensIntegrator_ != Teuchos::null) {
-    xdot = adjSensIntegrator_->getXDot(); 
+    xdot = adjSensIntegrator_->getXDot();
   }
-  return xdot; 
+  return xdot;
 }
 
 template <typename Scalar>
-Teuchos::RCP<const Thyra::VectorBase<Scalar>> 
+Teuchos::RCP<const Thyra::VectorBase<Scalar>>
 Piro::TempusIntegrator<Scalar>::getXDotDot() const
 {
-  Teuchos::RCP<const Thyra::VectorBase<Scalar>> xdotdot; 
+  Teuchos::RCP<const Thyra::VectorBase<Scalar>> xdotdot;
   if (basicIntegrator_ != Teuchos::null) {
-    xdotdot = basicIntegrator_->getXDotDot(); 
+    xdotdot = basicIntegrator_->getXDotDot();
   }
   if (fwdSensIntegrator_ != Teuchos::null) {
-    xdotdot = fwdSensIntegrator_->getXDotDot(); 
+    xdotdot = fwdSensIntegrator_->getXDotDot();
   }
   if (adjSensIntegrator_ != Teuchos::null) {
-    xdotdot = adjSensIntegrator_->getXDotDot(); 
+    xdotdot = adjSensIntegrator_->getXDotDot();
   }
-  return xdotdot; 
+  return xdotdot;
 }
 
 template <typename Scalar>
-Teuchos::RCP<const Tempus::SolutionHistory<Scalar>> 
+Teuchos::RCP<const Tempus::SolutionHistory<Scalar>>
 Piro::TempusIntegrator<Scalar>::getSolutionHistory() const
 {
-  Teuchos::RCP<const Tempus::SolutionHistory<Scalar>> soln_history; 
+  Teuchos::RCP<const Tempus::SolutionHistory<Scalar>> soln_history;
   if (basicIntegrator_ != Teuchos::null) {
-    soln_history = basicIntegrator_->getSolutionHistory(); 
+    soln_history = basicIntegrator_->getSolutionHistory();
   }
   if (fwdSensIntegrator_ != Teuchos::null) {
-    soln_history = fwdSensIntegrator_->getSolutionHistory(); 
+    soln_history = fwdSensIntegrator_->getSolutionHistory();
   }
   if (adjSensIntegrator_ != Teuchos::null) {
-    soln_history = adjSensIntegrator_->getSolutionHistory(); 
+    soln_history = adjSensIntegrator_->getSolutionHistory();
   }
-  return soln_history; 
+  return soln_history;
 }
 
 template <typename Scalar>
-Teuchos::RCP<const Tempus::TimeStepControl<Scalar>> 
+Teuchos::RCP<const Tempus::TimeStepControl<Scalar>>
 Piro::TempusIntegrator<Scalar>::getTimeStepControl() const
 {
-  Teuchos::RCP<const Tempus::TimeStepControl<Scalar>> ts_control; 
+  Teuchos::RCP<const Tempus::TimeStepControl<Scalar>> ts_control;
   if (basicIntegrator_ != Teuchos::null) {
-    ts_control = basicIntegrator_->getTimeStepControl(); 
+    ts_control = basicIntegrator_->getTimeStepControl();
   }
   if (fwdSensIntegrator_ != Teuchos::null) {
-    ts_control = fwdSensIntegrator_->getTimeStepControl(); 
+    ts_control = fwdSensIntegrator_->getTimeStepControl();
   }
   if (adjSensIntegrator_ != Teuchos::null) {
-    ts_control = adjSensIntegrator_->getTimeStepControl(); 
+    ts_control = adjSensIntegrator_->getTimeStepControl();
   }
-  return ts_control; 
+  return ts_control;
 }
 
 template <typename Scalar>
-void 
+void
 Piro::TempusIntegrator<Scalar>::clearObservers()
 {
   if (basicIntegrator_ != Teuchos::null) {
-    basicIntegrator_->getObserver()->clearObservers();
+    basicIntegrator_->setObserver();
   }
-  //IKT: fwdSensIntegrator and adjSensIntegrator do not support composite 
-  //observer so clearObservers() routine is not relevant.  If a 
-  //composite observer is ever added to these integrators, we'd need 
-  //to uncomment the code below 
-  /*if (fwdSensIntegrator_ != Teuchos::null) {
-    fwdSensIntegrator_->getObserver()->clearObservers(); 
+  if (fwdSensIntegrator_ != Teuchos::null) {
+    fwdSensIntegrator_->setObserver();
   }
   if (adjSensIntegrator_ != Teuchos::null) {
-    adjSensIntegrator_->getObserver()->clearObservers(); 
-  }*/
+    adjSensIntegrator_->setObserver();
+  }
 }
 
 template <typename Scalar>
-void 
+void
 Piro::TempusIntegrator<Scalar>::setObserver(Teuchos::RCP<Tempus::IntegratorObserver<Scalar>> obs)
 {
   if (basicIntegrator_ != Teuchos::null) {
-    basicIntegrator_->setObserver(obs); 
+    basicIntegrator_->setObserver(obs);
   }
   if (fwdSensIntegrator_ != Teuchos::null) {
-    fwdSensIntegrator_->setObserver(obs); 
+    fwdSensIntegrator_->setObserver(obs);
   }
   if (adjSensIntegrator_ != Teuchos::null) {
-    adjSensIntegrator_->setObserver(obs); 
+    adjSensIntegrator_->setObserver(obs);
   }
 }
 
 template <typename Scalar>
-void 
+void
 Piro::TempusIntegrator<Scalar>::initialize()
 {
   if (basicIntegrator_ != Teuchos::null) {
     basicIntegrator_->initialize();
   }
   if (fwdSensIntegrator_ != Teuchos::null) {
-    fwdSensIntegrator_->initialize(); 
+    fwdSensIntegrator_->initialize();
   }
   if (adjSensIntegrator_ != Teuchos::null) {
-    adjSensIntegrator_->initialize(); 
+    adjSensIntegrator_->initialize();
   }
 }
 
 template <typename Scalar>
-void 
+void
 Piro::TempusIntegrator<Scalar>::initializeSolutionHistory(Scalar t0,
     Teuchos::RCP< const Thyra::VectorBase< Scalar > > x0,
     Teuchos::RCP< const Thyra::VectorBase< Scalar > > xdot0,
@@ -302,7 +298,7 @@ Piro::TempusIntegrator<Scalar>::initializeSolutionHistory(Scalar t0,
     Teuchos::RCP< const Thyra::MultiVectorBase< Scalar > > DxdotdotDp0)
 {
   if (basicIntegrator_ != Teuchos::null) {
-    basicIntegrator_->initializeSolutionHistory(t0, x0, xdot0, xdotdot0); 
+    basicIntegrator_->initializeSolutionHistory(t0, x0, xdot0, xdotdot0);
   }
   if (fwdSensIntegrator_ != Teuchos::null) {
     fwdSensIntegrator_->initializeSolutionHistory(t0, x0, xdot0, xdotdot0, DxDp0, DxdotDp0, DxdotdotDp0);
@@ -313,30 +309,30 @@ Piro::TempusIntegrator<Scalar>::initializeSolutionHistory(Scalar t0,
 }
 
 template <typename Scalar>
-Tempus::Status 
+Tempus::Status
 Piro::TempusIntegrator<Scalar>::getStatus() const
 {
-  Tempus::Status status; 
+  Tempus::Status status;
   if (basicIntegrator_ != Teuchos::null) {
-    status = basicIntegrator_->getStatus(); 
+    status = basicIntegrator_->getStatus();
   }
   if (fwdSensIntegrator_ != Teuchos::null) {
-    status = fwdSensIntegrator_->getStatus(); 
+    status = fwdSensIntegrator_->getStatus();
   }
   if (adjSensIntegrator_ != Teuchos::null) {
-    status = adjSensIntegrator_->getStatus(); 
+    status = adjSensIntegrator_->getStatus();
   }
-  return status; 
+  return status;
 }
 
 template <typename Scalar>
-Teuchos::RCP<const Thyra::MultiVectorBase<Scalar>> 
+Teuchos::RCP<const Thyra::MultiVectorBase<Scalar>>
 Piro::TempusIntegrator<Scalar>::getDxDp() const
 {
   if (fwdSensIntegrator_ != Teuchos::null) {
-    return fwdSensIntegrator_->getDxDp(); 
+    return fwdSensIntegrator_->getDxDp();
   }
-  else { 
+  else {
     TEUCHOS_TEST_FOR_EXCEPTION(true, Teuchos::Exceptions::InvalidParameter,
                  "Error in Piro::TempusIntegrator: getDxDp() is not valid for the requested integrator type, " <<
 		 "which is not of type Tempus::IntegratorForwardSensitivity!\n");
@@ -344,11 +340,11 @@ Piro::TempusIntegrator<Scalar>::getDxDp() const
 }
 
 template <typename Scalar>
-Teuchos::RCP<const Thyra::MultiVectorBase<Scalar>> 
+Teuchos::RCP<const Thyra::MultiVectorBase<Scalar>>
 Piro::TempusIntegrator<Scalar>::getDxDotDp() const
 {
   if (fwdSensIntegrator_ != Teuchos::null) {
-    return fwdSensIntegrator_->getDxDotDp(); 
+    return fwdSensIntegrator_->getDxDotDp();
   }
   else {
     TEUCHOS_TEST_FOR_EXCEPTION(true, Teuchos::Exceptions::InvalidParameter,
@@ -358,11 +354,11 @@ Piro::TempusIntegrator<Scalar>::getDxDotDp() const
 }
 
 template <typename Scalar>
-Teuchos::RCP<const Thyra::MultiVectorBase<Scalar>> 
+Teuchos::RCP<const Thyra::MultiVectorBase<Scalar>>
 Piro::TempusIntegrator<Scalar>::getDxDotDotDp() const
 {
   if (fwdSensIntegrator_ != Teuchos::null) {
-    return fwdSensIntegrator_->getDxDotDotDp(); 
+    return fwdSensIntegrator_->getDxDotDotDp();
   }
   else {
     TEUCHOS_TEST_FOR_EXCEPTION(true, Teuchos::Exceptions::InvalidParameter,
@@ -370,14 +366,14 @@ Piro::TempusIntegrator<Scalar>::getDxDotDotDp() const
 		 "which is not of type Tempus::IntegratorForwardSensitivity!\n");
   }
 }
-  
+
 
 template <typename Scalar>
-Teuchos::RCP<const Thyra::MultiVectorBase<Scalar>> 
+Teuchos::RCP<const Thyra::MultiVectorBase<Scalar>>
 Piro::TempusIntegrator<Scalar>::getDgDp() const
 {
   if (adjSensIntegrator_ != Teuchos::null) {
-    return adjSensIntegrator_->getDgDp(); 
+    return adjSensIntegrator_->getDgDp();
   }
   else {
     TEUCHOS_TEST_FOR_EXCEPTION(true, Teuchos::Exceptions::InvalidParameter,

--- a/packages/tempus/src/Tempus_IntegratorBasic_decl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorBasic_decl.hpp
@@ -43,8 +43,8 @@ public:
     std::vector<int>                          outputScreenIndices,
     int                                       outputScreenInterval);
 
-  /// Clone
-  virtual void clone(Teuchos::RCP<IntegratorBasic<Scalar> > integratorBasic);
+  /// Copy (a shallow copy)
+  virtual void copy(Teuchos::RCP<IntegratorBasic<Scalar> > iB);
 
   /// Destructor
   virtual ~IntegratorBasic() {}

--- a/packages/tempus/src/Tempus_IntegratorBasic_decl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorBasic_decl.hpp
@@ -43,6 +43,9 @@ public:
     std::vector<int>                          outputScreenIndices,
     int                                       outputScreenInterval);
 
+  /// Clone
+  virtual void clone(Teuchos::RCP<IntegratorBasic<Scalar> > integratorBasic);
+
   /// Destructor
   virtual ~IntegratorBasic() {}
 

--- a/packages/tempus/src/Tempus_IntegratorBasic_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorBasic_impl.hpp
@@ -64,6 +64,23 @@ IntegratorBasic<Scalar>::IntegratorBasic(
 
 
 template<class Scalar>
+void IntegratorBasic<Scalar>::clone(Teuchos::RCP<IntegratorBasic<Scalar> > iB)
+{
+  this->setIntegratorType      (iB->getIntegratorType()      );
+  this->setIntegratorName      (iB->getIntegratorName()      );
+  this->setStepper             (iB->getStepper()             );
+  this->setSolutionHistory     (iB->getSolutionHistory()     );
+  this->setTimeStepControl     (iB->getTimeStepControl()     );
+  this->setIntegratorObserver  (iB->getIntegratorObserver()  );
+  this->setOutputScreenIndices (iB->getOutputScreenIndices() );
+  this->setOutputScreenInterval(iB->getOutputScreenInterval());
+  this->setIntegratorStatus    (iB->getIntegratorStatus()    );
+  integratorTimer_ = iB->getIntegratorTimer();
+  stepperTimer_    = iB->getStepperTimer();
+}
+
+
+template<class Scalar>
 void IntegratorBasic<Scalar>::setIntegratorType(std::string i)
 {
   TEUCHOS_TEST_FOR_EXCEPTION( i != "Integrator Basic", std::logic_error,

--- a/packages/tempus/src/Tempus_IntegratorBasic_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorBasic_impl.hpp
@@ -64,17 +64,17 @@ IntegratorBasic<Scalar>::IntegratorBasic(
 
 
 template<class Scalar>
-void IntegratorBasic<Scalar>::clone(Teuchos::RCP<IntegratorBasic<Scalar> > iB)
+void IntegratorBasic<Scalar>::copy(Teuchos::RCP<IntegratorBasic<Scalar> > iB)
 {
-  this->setIntegratorType      (iB->getIntegratorType()      );
-  this->setIntegratorName      (iB->getIntegratorName()      );
-  this->setStepper             (iB->getStepper()             );
-  this->setSolutionHistory     (iB->getSolutionHistory()     );
-  this->setTimeStepControl     (iB->getTimeStepControl()     );
-  this->setIntegratorObserver  (iB->getIntegratorObserver()  );
-  this->setOutputScreenIndices (iB->getOutputScreenIndices() );
-  this->setOutputScreenInterval(iB->getOutputScreenInterval());
-  this->setIntegratorStatus    (iB->getIntegratorStatus()    );
+  this->setIntegratorType           (iB->getIntegratorType()           );
+  this->setIntegratorName           (iB->getIntegratorName()           );
+  this->setStepper                  (iB->getStepper()                  );
+  this->setSolutionHistory          (iB->getNonConstSolutionHistory()  );
+  this->setTimeStepControl          (iB->getNonConstTimeStepControl()  );
+  this->setObserver                 (iB->getObserver()                 );
+  this->setScreenOutputIndexList    (iB->getScreenOutputIndexList()    );
+  this->setScreenOutputIndexInterval(iB->getScreenOutputIndexInterval());
+  this->setStatus                   (iB->getStatus()                   );
   integratorTimer_ = iB->getIntegratorTimer();
   stepperTimer_    = iB->getStepperTimer();
 }

--- a/packages/tempus/src/Tempus_IntegratorPseudoTransientAdjointSensitivity_decl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorPseudoTransientAdjointSensitivity_decl.hpp
@@ -10,7 +10,7 @@
 #define Tempus_IntegratorPseudoTransientAdjointSensitivity_decl_hpp
 
 #include "Tempus_config.hpp"
-#include "Tempus_IntegratorBasicOld.hpp"
+#include "Tempus_IntegratorBasic.hpp"
 #include "Tempus_AdjointSensitivityModelEvaluator.hpp"
 
 
@@ -216,8 +216,8 @@ protected:
   Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > model_;
   Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > adjoint_model_;
   Teuchos::RCP<AdjointSensitivityModelEvaluator<Scalar> > sens_model_;
-  Teuchos::RCP<IntegratorBasicOld<Scalar> > state_integrator_;
-  Teuchos::RCP<IntegratorBasicOld<Scalar> > sens_integrator_;
+  Teuchos::RCP<IntegratorBasic<Scalar> > state_integrator_;
+  Teuchos::RCP<IntegratorBasic<Scalar> > sens_integrator_;
   Teuchos::RCP<SolutionHistory<Scalar> > solutionHistory_;
   Teuchos::RCP<DMVPV> dgdp_;
 };

--- a/packages/tempus/src/Tempus_IntegratorPseudoTransientAdjointSensitivity_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorPseudoTransientAdjointSensitivity_impl.hpp
@@ -339,13 +339,15 @@ setParameterList(const Teuchos::RCP<Teuchos::ParameterList> & inputPL)
   // IntegratorBasic is no longer a Teuchos::ParameterListAcceptor.
   // Since setting the ParameterList is essentially a complete reset,
   // we will rebuild from scratch and reuse the ModelEvaluator.
-  auto model = state_integrator_->getStepper()->getModel();
-  auto tmp_state_integrator = createIntegratorBasic(inputPL, model);
-  state_integrator_->clone(tmp_state_integrator);
+  auto model = Teuchos::rcp_const_cast<Thyra::ModelEvaluator<Scalar>> (
+    state_integrator_->getStepper()->getModel());
+  auto tmp_state_integrator = createIntegratorBasic<Scalar>(inputPL, model);
+  state_integrator_->copy(tmp_state_integrator);
 
-  model = sens_integrator_->getStepper()->getModel();
-  auto tmp_sens_integrator = createIntegratorBasic(inputPL, model);
-  sens_integrator_->clone(tmp_sens_integrator);
+  model = Teuchos::rcp_const_cast<Thyra::ModelEvaluator<Scalar>> (
+    sens_integrator_->getStepper()->getModel());
+  auto tmp_sens_integrator = createIntegratorBasic<Scalar>(inputPL, model);
+  sens_integrator_->copy(tmp_sens_integrator);
 }
 
 template<class Scalar>
@@ -356,15 +358,19 @@ unsetParameterList()
   // IntegratorBasic is no longer a Teuchos::ParameterListAcceptor.
   // We will treat unsetting the ParameterList as a reset to default
   // settings, and reuse the ModelEvaluator.
-  auto tmp_state_integrator = createIntegratorBasic();
+  auto tmp_state_integrator = createIntegratorBasic<Scalar>();
   auto model = state_integrator_->getStepper()->getModel();
   tmp_state_integrator->setModel(model);
-  state_integrator_->clone(tmp_state_integrator);
+  state_integrator_->copy(tmp_state_integrator);
 
-  auto tmp_sens_integrator = createIntegratorBasic();
+  auto tmp_sens_integrator = createIntegratorBasic<Scalar>();
   model = sens_integrator_->getStepper()->getModel();
   tmp_sens_integrator->setModel(model);
-  sens_integrator_->clone(tmp_sens_integrator);
+  sens_integrator_->copy(tmp_sens_integrator);
+
+  auto pl = Teuchos::rcp_const_cast<Teuchos::ParameterList> (
+    sens_integrator_->getValidParameters());
+  return pl;
 }
 
 template<class Scalar>

--- a/packages/tempus/src/Tempus_IntegratorPseudoTransientAdjointSensitivity_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorPseudoTransientAdjointSensitivity_impl.hpp
@@ -26,9 +26,9 @@ IntegratorPseudoTransientAdjointSensitivity(
 {
   model_ = model;
   adjoint_model_ = adjoint_model;
-  state_integrator_ = integratorBasic<Scalar>(inputPL, model_);
+  state_integrator_ = createIntegratorBasic<Scalar>(inputPL, model_);
   sens_model_ = createSensitivityModel(model_, adjoint_model_, inputPL);
-  sens_integrator_ = integratorBasic<Scalar>(inputPL, sens_model_);
+  sens_integrator_ = createIntegratorBasic<Scalar>(inputPL, sens_model_);
 }
 
 template<class Scalar>
@@ -40,9 +40,9 @@ IntegratorPseudoTransientAdjointSensitivity(
 {
   model_ = model;
   adjoint_model_ = adjoint_model;
-  state_integrator_ = integratorBasic<Scalar>(model_, stepperType);
+  state_integrator_ = createIntegratorBasic<Scalar>(model_, stepperType);
   sens_model_ = createSensitivityModel(model_, adjoint_model_, Teuchos::null);
-  sens_integrator_ = integratorBasic<Scalar>(sens_model_, stepperType);
+  sens_integrator_ = createIntegratorBasic<Scalar>(sens_model_, stepperType);
 }
 
 template<class Scalar>
@@ -69,8 +69,8 @@ template<class Scalar>
 IntegratorPseudoTransientAdjointSensitivity<Scalar>::
 IntegratorPseudoTransientAdjointSensitivity()
 {
-  state_integrator_ = integratorBasic<Scalar>();
-  sens_integrator_ = integratorBasic<Scalar>();
+  state_integrator_ = createIntegratorBasic<Scalar>();
+  sens_integrator_ = createIntegratorBasic<Scalar>();
 }
 
 template<class Scalar>
@@ -336,8 +336,16 @@ void
 IntegratorPseudoTransientAdjointSensitivity<Scalar>::
 setParameterList(const Teuchos::RCP<Teuchos::ParameterList> & inputPL)
 {
-  state_integrator_->setParameterList(inputPL);
-  sens_integrator_->setParameterList(inputPL);
+  // IntegratorBasic is no longer a Teuchos::ParameterListAcceptor.
+  // Since setting the ParameterList is essentially a complete reset,
+  // we will rebuild from scratch and reuse the ModelEvaluator.
+  auto model = state_integrator_->getStepper()->getModel();
+  auto tmp_state_integrator = createIntegratorBasic(inputPL, model);
+  state_integrator_->clone(tmp_state_integrator);
+
+  model = sens_integrator_->getStepper()->getModel();
+  auto tmp_sens_integrator = createIntegratorBasic(inputPL, model);
+  sens_integrator_->clone(tmp_sens_integrator);
 }
 
 template<class Scalar>
@@ -345,8 +353,18 @@ Teuchos::RCP<Teuchos::ParameterList>
 IntegratorPseudoTransientAdjointSensitivity<Scalar>::
 unsetParameterList()
 {
-  state_integrator_->unsetParameterList();
-  return sens_integrator_->unsetParameterList();
+  // IntegratorBasic is no longer a Teuchos::ParameterListAcceptor.
+  // We will treat unsetting the ParameterList as a reset to default
+  // settings, and reuse the ModelEvaluator.
+  auto tmp_state_integrator = createIntegratorBasic();
+  auto model = state_integrator_->getStepper()->getModel();
+  tmp_state_integrator->setModel(model);
+  state_integrator_->clone(tmp_state_integrator);
+
+  auto tmp_sens_integrator = createIntegratorBasic();
+  model = sens_integrator_->getStepper()->getModel();
+  tmp_sens_integrator->setModel(model);
+  sens_integrator_->clone(tmp_sens_integrator);
 }
 
 template<class Scalar>
@@ -371,7 +389,9 @@ Teuchos::RCP<Teuchos::ParameterList>
 IntegratorPseudoTransientAdjointSensitivity<Scalar>::
 getNonconstParameterList()
 {
-  return state_integrator_->getNonconstParameterList();
+  auto pl = Teuchos::rcp_const_cast<Teuchos::ParameterList> (
+    state_integrator_->getValidParameters());
+  return pl;
 }
 
 template <class Scalar>
@@ -412,9 +432,8 @@ buildSolutionHistory()
 
   // Create combined solution histories, first for the states with zero
   // adjoint and then for the adjoint with frozen states
-  RCP<ParameterList> shPL =
-    Teuchos::sublist(state_integrator_->getIntegratorParameterList(),
-                     "Solution History", true);
+  auto shPL = Teuchos::rcp_const_cast<Teuchos::ParameterList> (
+    state_integrator_->getSolutionHistory()->getValidParameters());
   solutionHistory_ = createSolutionHistoryPL<Scalar>(shPL);
 
   RCP<const VectorSpaceBase<Scalar> > x_space =

--- a/packages/tempus/src/deprecated/CMakeLists.txt
+++ b/packages/tempus/src/deprecated/CMakeLists.txt
@@ -1,0 +1,23 @@
+set(HEADERS "")
+set(SOURCES "")
+
+set_and_inc_dirs(DIR ${CMAKE_CURRENT_SOURCE_DIR})
+append_glob(HEADERS ${DIR}/*.hpp)
+append_glob(SOURCES ${DIR}/*.cpp)
+
+if (NOT ${PACKAGE_NAME}_HIDE_DEPRECATED_CODE)
+  include_directories(${CMAKE_CURRENT_SOURCE_DIR}/deprecated)
+  append_set(HEADERS
+    Tempus_IntegratorBasicOld_decl.hpp
+    Tempus_IntegratorBasicOld_impl.hpp
+    )
+  append_set(SOURCES
+    Tempus_IntegratorBasicOld.cpp
+    )
+endif()
+
+tribits_add_library(
+  tempus
+  HEADERS ${HEADERS}
+  SOURCES ${SOURCES}
+  )

--- a/packages/tempus/src/deprecated/Readme.txt
+++ b/packages/tempus/src/deprecated/Readme.txt
@@ -1,0 +1,1 @@
+This directory stores deprecated code.

--- a/packages/tempus/src/deprecated/Tempus_IntegratorBasicOld.cpp
+++ b/packages/tempus/src/deprecated/Tempus_IntegratorBasicOld.cpp
@@ -6,6 +6,10 @@
 // ****************************************************************************
 // @HEADER
 
+#ifdef __GNUC__
+#  warning "This file Tempus_IntegratorBasicOld.cpp is deprecated!  Use Tempus_IntegratorBasic.cpp instead!"
+#endif
+
 #include "Tempus_ExplicitTemplateInstantiation.hpp"
 
 #ifdef HAVE_TEMPUS_EXPLICIT_INSTANTIATION

--- a/packages/tempus/src/deprecated/Tempus_IntegratorBasicOld_decl.hpp
+++ b/packages/tempus/src/deprecated/Tempus_IntegratorBasicOld_decl.hpp
@@ -6,6 +6,10 @@
 // ****************************************************************************
 // @HEADER
 
+#ifdef __GNUC__
+#  warning "This file Tempus_IntegratorBasicOld_decl.hpp is deprecated!  Use Tempus_IntegratorBasic_decl.hpp instead!"
+#endif
+
 #ifndef Tempus_IntegratorBasicOld_decl_hpp
 #define Tempus_IntegratorBasicOld_decl_hpp
 

--- a/packages/tempus/src/deprecated/Tempus_IntegratorBasicOld_impl.hpp
+++ b/packages/tempus/src/deprecated/Tempus_IntegratorBasicOld_impl.hpp
@@ -6,6 +6,11 @@
 // ****************************************************************************
 // @HEADER
 
+#ifdef __GNUC__
+#  warning "This file Tempus_IntegratorBasicOld_impl.hpp is deprecated!  Use Tempus_IntegratorBasic_impl.hpp instead!"
+#endif
+
+
 #ifndef Tempus_IntegratorBasicOld_impl_hpp
 #define Tempus_IntegratorBasicOld_impl_hpp
 


### PR DESCRIPTION
@trilinos/tempus 

## Motivation
Remove the IntegratorBasicOld class. It was used to allow transition
to the new IntegratorBasic that removed internal usage of ParameterLists
and a few other improvements. The last derived classes using
IntegratorBasicOld have been move to inherit from the new
IntegratorBasic, so it is time to deprecate IntegratorBasicOld.

## Related Issues
* Closes #10023 