### PR TITLE
Patch in Kokkos Kernels #1204 to fix #9856

### DIFF
--- a/packages/anasazi/tpetra/test/MVOPTester/MultiVecTraitsTest2.cpp
+++ b/packages/anasazi/tpetra/test/MVOPTester/MultiVecTraitsTest2.cpp
@@ -570,7 +570,7 @@ namespace {
       out << "]" << endl;
 
       for (size_t j = 0; j < static_cast<size_t> (ind.size ()); ++j) {
-        TEST_EQUALITY( B_view_norms[j], normsB1[ind[j]] );
+        TEST_FLOATING_EQUALITY( B_view_norms[j], normsB1[ind[j]], STS::eps() );
       }
 
       out << "Check that modifying B_view modifies the corresponding columns "

--- a/packages/anasazi/tpetra/test/MVOPTester/MultiVecTraitsTest2.cpp
+++ b/packages/anasazi/tpetra/test/MVOPTester/MultiVecTraitsTest2.cpp
@@ -135,7 +135,7 @@ namespace {
       out << "Expected 1-norm of X_" << j << ": " << X_norms[j] << endl;
       out << "Actual 1-norm of X_" << j << ": " << norms[j] << endl;
       TEST_ASSERT( X_norms[j] != STN::zero () );
-      TEST_ASSERT( norms[j] == X_norms[j] );
+      TEST_FLOATING_EQUALITY( norms[j], X_norms[j], STS::eps() );
     }
 
     out << "Create MultiVector Y" << endl;
@@ -147,7 +147,7 @@ namespace {
     // Test that the norms of the columns of Y have their expected values.
     Y.norm1 (norms);
     for (size_t j = 0; j < numCols; ++j) {
-      TEST_ASSERT( norms[j] == X_norms[j] );
+      TEST_FLOATING_EQUALITY( norms[j], X_norms[j], STS::eps() );
     }
 
     out << "Call SetBlock(X, [1, 2], Y)" << endl;
@@ -163,19 +163,19 @@ namespace {
     // Test that the norms of the columns of X have not changed.
     X.norm1 (norms);
     for (size_t j = 0; j < numCols; ++j) {
-      TEST_ASSERT( norms[j] == X_norms[j] );
+      TEST_FLOATING_EQUALITY( norms[j], X_norms[j], STS::eps() );
     }
 
     out << "Test the norms of the columns of Y" << endl;
 
     // Test that the norm of the first column of Y has not changed.
     Y.norm1 (norms);
-    TEST_ASSERT( norms[0] == X_norms[0] );
+    TEST_FLOATING_EQUALITY( norms[0], X_norms[0], STS::eps() );
 
     // Test that the norms of the remaining columns of Y have their
     // expected values.
-    TEST_ASSERT( norms[1] == X_norms[0] );
-    TEST_ASSERT( norms[2] == X_norms[1] );
+    TEST_FLOATING_EQUALITY( norms[1], X_norms[0], STS::eps() );
+    TEST_FLOATING_EQUALITY( norms[2], X_norms[1], STS::eps() );
 
     out << "Test the values in the columns of Y" << endl;
 
@@ -193,9 +193,9 @@ namespace {
     // Test that overwriting X doesn't affect the new values of Y.
     X.putScalar (STS::zero ());
     Y.norm1 (norms);
-    TEST_ASSERT( norms[0] == X_norms[0] );
-    TEST_ASSERT( norms[1] == X_norms[0] );
-    TEST_ASSERT( norms[2] == X_norms[1] );
+    TEST_FLOATING_EQUALITY( norms[0], X_norms[0], STS::eps() );
+    TEST_FLOATING_EQUALITY( norms[1], X_norms[0], STS::eps() );
+    TEST_FLOATING_EQUALITY( norms[2], X_norms[1], STS::eps() );
   }
 
   //
@@ -257,7 +257,7 @@ namespace {
       out << "Expected 1-norm of X_" << j << ": " << X_norms[j] << endl;
       out << "Actual 1-norm of X_" << j << ": " << norms[j] << endl;
       TEST_ASSERT( X_norms[j] != STN::zero () );
-      TEST_ASSERT( norms[j] == X_norms[j] );
+      TEST_FLOATING_EQUALITY( norms[j], X_norms[j], STS::eps() );
     }
 
     out << "Create MultiVector Y" << endl;
@@ -269,7 +269,7 @@ namespace {
     // Test that the norms of the columns of Y have their expected values.
     Y.norm1 (norms);
     for (size_t j = 0; j < numCols; ++j) {
-      TEST_ASSERT( norms[j] == X_norms[j] );
+      TEST_FLOATING_EQUALITY( norms[j], X_norms[j], STS::eps() );
     }
 
     out << "Call SetBlock(X, Range1D(1, 2), Y)" << endl;
@@ -284,19 +284,19 @@ namespace {
     // Test that the norms of the columns of X have not changed.
     X.norm1 (norms);
     for (size_t j = 0; j < numCols; ++j) {
-      TEST_ASSERT( norms[j] == X_norms[j] );
+      TEST_FLOATING_EQUALITY( norms[j], X_norms[j], STS::eps() );
     }
 
     out << "Test the norms of the columns of Y" << endl;
 
     // Test that the norm of the first column of Y has not changed.
     Y.norm1 (norms);
-    TEST_ASSERT( norms[0] == X_norms[0] );
+    TEST_FLOATING_EQUALITY( norms[0], X_norms[0], STS::eps() );
 
     // Test that the norms of the remaining columns of Y have their
     // expected values.
-    TEST_ASSERT( norms[1] == X_norms[0] );
-    TEST_ASSERT( norms[2] == X_norms[1] );
+    TEST_FLOATING_EQUALITY( norms[1], X_norms[0], STS::eps() );
+    TEST_FLOATING_EQUALITY( norms[2], X_norms[1], STS::eps() );
 
     // Test that after calling SetBlock, Y(:,1:2) == X(:,0:1) (where
     // 0:1 means [0, 1] (inclusive range) and 1:2 means [1, 2]).
@@ -333,9 +333,9 @@ namespace {
     // Test that overwriting X doesn't affect the new values of Y.
     X.putScalar (STS::zero ());
     Y.norm1 (norms);
-    TEST_ASSERT( norms[0] == X_norms[0] );
-    TEST_ASSERT( norms[1] == X_norms[0] );
-    TEST_ASSERT( norms[2] == X_norms[1] );
+    TEST_FLOATING_EQUALITY( norms[0], X_norms[0], STS::eps() );
+    TEST_FLOATING_EQUALITY( norms[1], X_norms[0], STS::eps() );
+    TEST_FLOATING_EQUALITY( norms[2], X_norms[1], STS::eps() );
   }
 
   //
@@ -393,7 +393,7 @@ namespace {
       out << "Expected 1-norm of X_" << j << ": " << X_norms[j] << endl;
       out << "Actual 1-norm of X_" << j << ": " << norms[j] << endl;
       TEST_ASSERT( X_norms[j] != STN::zero () );
-      TEST_ASSERT( norms[j] == X_norms[j] );
+      TEST_FLOATING_EQUALITY( norms[j], X_norms[j], STS::eps() );
     }
 
     // Create a MultiVector Y, and make it a deep copy of X.
@@ -403,7 +403,7 @@ namespace {
     // Test that the norms of the columns of Y have their expected values.
     Y.norm1 (norms);
     for (size_t j = 0; j < numCols; ++j) {
-      TEST_ASSERT( norms[j] == X_norms[j] );
+      TEST_FLOATING_EQUALITY( norms[j], X_norms[j], STS::eps() );
     }
 
     // Y(:, [2,1]) := X(:, [0,1])
@@ -415,17 +415,17 @@ namespace {
     // Test that the norms of the columns of X have not changed.
     X.norm1 (norms);
     for (size_t j = 0; j < numCols; ++j) {
-      TEST_ASSERT( norms[j] == X_norms[j] );
+      TEST_FLOATING_EQUALITY( norms[j], X_norms[j], STS::eps() );
     }
 
     // Test that the norm of the first column of Y has not changed.
     Y.norm1 (norms);
-    TEST_ASSERT( norms[0] == X_norms[0] );
+    TEST_FLOATING_EQUALITY( norms[0], X_norms[0], STS::eps() );
 
     // Test that the norms of the remaining columns of Y have their
     // expected values.
-    TEST_ASSERT( norms[1] == X_norms[1] );
-    TEST_ASSERT( norms[2] == X_norms[0] );
+    TEST_FLOATING_EQUALITY( norms[1], X_norms[1], STS::eps() );
+    TEST_FLOATING_EQUALITY( norms[2], X_norms[0], STS::eps() );
   }
 
   //
@@ -485,7 +485,7 @@ namespace {
       out << "Expected 1-norm of X_" << j << ": " << X_norms[j] << endl;
       out << "Actual 1-norm of X_" << j << ": " << norms[j] << endl;
       TEST_ASSERT( X_norms[j] != STN::zero () );
-      TEST_ASSERT( norms[j] == X_norms[j] );
+      TEST_FLOATING_EQUALITY( norms[j], X_norms[j], STS::eps() );
     }
 
     out << "Create (non-copy) clones of X: B and C" << endl;
@@ -613,14 +613,14 @@ namespace {
       Array<norm_type> B_norms (numVecsB);
       B->norm2 (B_norms);
       for (size_t j = 0; j < numVecsB; ++j) {
-        TEST_EQUALITY( B_norms[j], normsB1[j] );
+        TEST_FLOATING_EQUALITY( B_norms[j], normsB1[j], STS::eps() );
       }
 
       out << "Make sure that \\|B_view_1\\| still equals \\|B(:,2)\\|" << endl;
       const norm_type B_view_1_norm2_new = B_view_1->norm2 ();
-      TEST_EQUALITY( normsB1[2], B_view_1_norm2_new );
+      TEST_FLOATING_EQUALITY( normsB1[2], B_view_1_norm2_new, STS::eps() );
       const norm_type B_2_norm2_new = B_2->norm2 ();
-      TEST_EQUALITY( normsB1[2], B_2_norm2_new );
+      TEST_FLOATING_EQUALITY( normsB1[2], B_2_norm2_new, STS::eps() );
       // In theory, it's possible for these two numbers to be equal,
       // since B_2_norm2 comes from a random assignment of B.
       // However, it should be unlikely.
@@ -628,7 +628,7 @@ namespace {
       // Make sure that no fishy stuff (e.g., copy instead of view) is
       // going on with getVector().
       B_2 = B->getVector (2);
-      TEST_EQUALITY( normsB1[2], B_2->norm2 () );
+      TEST_FLOATING_EQUALITY( normsB1[2], B_2->norm2 (), STS::eps() );
 
       // TODO: Make sure that changing B_copy doesn't change B.
     }
@@ -667,16 +667,16 @@ namespace {
 
     out << "Check that C was not changed by SetBlock" << endl;
     for (size_t j = 0; j < numVecsC; ++j) {
-      TEST_ASSERT( normsC1[j] == normsC2[j] );
+      TEST_FLOATING_EQUALITY( normsC1[j], normsC2[j], STS::eps() );
     }
     out << "Check that only the vectors of B that _should_ have changed did"
         << endl;
     for (size_t j = 0; j < numVecsB; ++j) {
       if (j % static_cast<size_t> (2) == 0) { // should be a vector from C
-        TEST_ASSERT( normsB2[j] == normsC1[j/2] );
+        TEST_FLOATING_EQUALITY( normsB2[j], normsC1[j/2], STS::eps() );
       }
       else { // should be an original vector
-        TEST_ASSERT( normsB1[j] == normsB2[j] );
+        TEST_FLOATING_EQUALITY( normsB1[j], normsB2[j], STS::eps() );
       }
     }
 
@@ -684,7 +684,7 @@ namespace {
     MVT::MvInit (*C, STS::zero ());
     MVT::MvNorm (*B, normsB1);
     for (size_t j = 0; j < numVecsB; ++j) {
-      TEST_ASSERT( normsB1[j] == normsB2[j] );
+      TEST_FLOATING_EQUALITY( normsB1[j], normsB2[j], STS::eps() );
     }
   }
 

--- a/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_dot_mv_impl.hpp
+++ b/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_dot_mv_impl.hpp
@@ -44,630 +44,122 @@
 #ifndef KOKKOSBLAS1_IMPL_DOT_MV_IMPL_HPP_
 #define KOKKOSBLAS1_IMPL_DOT_MV_IMPL_HPP_
 
-#ifndef KOKKOSBLAS_OPTIMIZATION_LEVEL_DOT
-#define KOKKOSBLAS_OPTIMIZATION_LEVEL_DOT 2
-#endif // KOKKOSBLAS_OPTIMIZATION_LEVEL_DOT
-
 #include <KokkosKernels_config.h>
 #include <Kokkos_Core.hpp>
 #include <Kokkos_InnerProductSpaceTraits.hpp>
-#include <type_traits>
-#include <KokkosBlas1_dot_impl.hpp>
+#include <KokkosBlas_util.hpp>
+#include <sstream>
 
 namespace KokkosBlas {
 namespace Impl {
 
+template <class ExecSpace, class RV, class XV, class YV, class size_type>
+struct Dot_MV_Functor {
+  using Scalar = typename RV::non_const_value_type;
+  using IPT    = Kokkos::Details::InnerProductSpaceTraits<
+      typename XV::non_const_value_type>;
+  using dot_type = typename IPT::dot_type;
+  using KAT      = Kokkos::ArithTraits<dot_type>;
 
-/// \brief Dot product functor for a multivector times a single
-///   vector, or vice versa.
-///
-/// "Multivector dot a single vector" means that each column of the
-/// multivector gets dotted with the same vector, as if the latter
-/// vector were replicated.  "Single vector dot a multivector" means
-/// the (conjugate) transpose of that.  We combine both (multivector
-/// dot vector) and (vector dot multivector) cases into a single
-/// functor, to avoid code duplication.
-///
-/// \tparam RV 1-D output View
-/// \tparam XMV 2-D input View (the multivector)
-/// \tparam YV 1-D input View (the single vector)
-/// \tparam SizeType Index type.  Use int (32 bits) if possible.
-template<class RV, class XMV, class YV, class SizeType = typename XMV::size_type>
-struct MV_V_Dot_Functor
-{
-  typedef typename XMV::execution_space              execution_space;
-  typedef SizeType                                         size_type;
-  typedef typename XMV::non_const_value_type             xvalue_type;
-  typedef Kokkos::Details::InnerProductSpaceTraits<xvalue_type>  IPT;
-  typedef Kokkos::Details::ArithTraits<typename IPT::dot_type>    AT;
-  typedef typename IPT::dot_type                        value_type[];
+  using TeamMem = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
 
-  size_type value_count;
-  RV m_r;
-  typename XMV::const_type m_x;
-  typename YV::const_type m_y;
-  //! If true, do y dot x instead of x dot y.
-  bool reverseOrder_;
+  RV r;
+  XV x;
+  YV y;
 
-  MV_V_Dot_Functor (const RV& r, const XMV& x, const YV& y,
-                    const bool reverseOrder) :
-    value_count (x.extent(1)), m_r (r), m_x (x), m_y (y),
-    reverseOrder_ (reverseOrder)
-  {
-    static_assert (Kokkos::Impl::is_view<RV>::value, "KokkosBlas::Impl::"
-                   "MV_V_Dot_Functor: R is not a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<XMV>::value, "KokkosBlas::Impl::"
-                   "MV_V_Dot_Functor: X is not a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<YV>::value, "KokkosBlas::Impl::"
-                   "MV_V_Dot_Functor: Y is not a Kokkos::View.");
-    static_assert (std::is_same<typename RV::value_type,
-                   typename RV::non_const_value_type>::value,
-                   "KokkosBlas::Impl::MV_V_Dot_Functor: R is const.  "
-                   "It must be nonconst, because it is an output argument "
-                   "(we have to be able to write to its entries).");
-    static_assert (static_cast<int> (XMV::rank) == 2,
-                   "KokkosBlas::Impl::MV_V_Dot_Functor: X must have rank 2.");
-    static_assert (static_cast<int> (YV::rank) == 1,
-                   "KokkosBlas::Impl::MV_V_Dot_Functor: Y must have rank 1.");
-    static_assert (static_cast<int> (RV::rank) == 1,
-                   "KokkosBlas::Impl::MV_V_Dot_Functor: RV must have rank 1.");
-  }
+  size_type
+      teamsPerDot;  // number of teams collectively performing a dot product
+
+  Dot_MV_Functor(const RV& r_, const XV& x_, const YV& y_, int teamsPerDot_)
+      : r(r_), x(x_), y(y_), teamsPerDot(teamsPerDot_) {}
 
   KOKKOS_INLINE_FUNCTION
-  void operator() (const size_type& i, value_type sum) const
-  {
-    const size_type numVecs = value_count;
-    if (reverseOrder_) {
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-      for (size_type k = 0; k < numVecs; ++k) {
-        sum[k] += IPT::dot (m_y(i), m_x(i,k)); // m_x(i,k) * m_y(i)
-      }
-    }
-    else {
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-      for (size_type k = 0; k < numVecs; ++k) {
-        sum[k] += IPT::dot (m_x(i,k), m_y(i)); // m_x(i,k) * m_y(i)
-      }
-    }
-  }
+  void operator()(const TeamMem& t) const {
+    size_type globalRank = t.league_rank();
+    size_type localRank  = globalRank % teamsPerDot;
+    size_type i          = globalRank / teamsPerDot;
+    size_type xcol       = x.extent(1) == 1 ? 0 : i;
+    size_type ycol       = y.extent(1) == 1 ? 0 : i;
 
-  KOKKOS_INLINE_FUNCTION void init (value_type update) const
-  {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type k = 0; k < numVecs; ++k) {
-      update[k] = AT::zero ();
-    }
-  }
+    dot_type localResult = KAT::zero();
+    size_type begin      = localRank * (x.extent(0) / teamsPerDot);
+    size_type end        = (localRank + 1) * (x.extent(0) / teamsPerDot);
+    if (localRank == teamsPerDot - 1) end = x.extent(0);
+    Kokkos::parallel_reduce(
+        Kokkos::TeamThreadRange(t, begin, end),
+        [&](size_type k, dot_type& update) {
+          Kokkos::Details::updateDot(update, x.access(k, xcol),
+                                     y.access(k, ycol));
+        },
+        localResult);
 
-  KOKKOS_INLINE_FUNCTION void
-  join (volatile value_type update,
-        const volatile value_type source) const
-  {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type k = 0; k < numVecs; ++k) {
-      update[k] += source[k];
-    }
-  }
-
-  // On device, write the reduction result to the output View.
-  /*KOKKOS_INLINE_FUNCTION void
-  final (const value_type dst) const
-  {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type k = 0; k < numVecs; ++k) {
-      m_r(k) = dst[k];
-    }
-  }*/
-};
-
-/// \brief Column-wise dot product functor for multivectors; works for
-///   any layout, but best performance with LayoutRight.
-///
-/// \tparam RV 1-D output View
-/// \tparam XMV 2-D input View
-/// \tparam YMV 2-D input View
-/// \tparam SizeType Index type.  Use int (32 bits) if possible.
-template<class RV, class XMV, class YMV, class SizeType = typename XMV::size_type>
-struct MV_Dot_Right_FunctorVector
-{
-  typedef typename XMV::execution_space             execution_space;
-  typedef SizeType                                        size_type;
-  typedef typename XMV::non_const_value_type            xvalue_type;
-  typedef Kokkos::Details::InnerProductSpaceTraits<xvalue_type> IPT;
-  typedef Kokkos::Details::ArithTraits<typename IPT::dot_type>   AT;
-  typedef typename IPT::dot_type                       value_type[];
-
-  size_type value_count;
-  RV m_r;
-  typename XMV::const_type m_x;
-  typename YMV::const_type m_y;
-
-  MV_Dot_Right_FunctorVector (const RV& r, const XMV& x, const YMV& y) :
-    value_count (x.extent(1)), m_r (r), m_x (x), m_y (y)
-  {
-    static_assert (Kokkos::Impl::is_view<RV>::value, "KokkosBlas::Impl::"
-                   "MV_Dot_Right_FunctorVector: R is not a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<XMV>::value, "KokkosBlas::Impl::"
-                   "MV_Dot_Right_FunctorVector: X is not a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<YMV>::value, "KokkosBlas::Impl::"
-                   "MV_Dot_Right_FunctorVector: Y is not a Kokkos::View.");
-    static_assert (std::is_same<typename RV::value_type,
-                   typename RV::non_const_value_type>::value,
-                   "KokkosBlas::Impl::MV_Dot_Right_FunctorVector: R is const.  "
-                   "It must be nonconst, because it is an output argument "
-                   "(we have to be able to write to its entries).");
-    static_assert (XMV::rank == YMV::rank,
-                   "KokkosBlas::Impl::MV_Dot_Right_FunctorVector: "
-                   "X and Y must have the same rank.");
-    static_assert (RV::rank == 1 && XMV::rank == 2,
-                   "KokkosBlas::Impl::MV_Dot_Right_FunctorVector: "
-                   "RV must have rank 1 and XMV and YMV must have rank 2.");
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator() (const size_type& i, value_type sum) const
-  {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type k = 0; k < numVecs; ++k) {
-      sum[k] += IPT::dot (m_x(i,k), m_y(i,k)); // m_x(i,k) * m_y(i,k)
-    }
-  }
-
-  KOKKOS_INLINE_FUNCTION void init (value_type update) const
-  {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type k = 0; k < numVecs; ++k) {
-      update[k] = AT::zero ();
-    }
-  }
-
-  KOKKOS_INLINE_FUNCTION void
-  join (volatile value_type update,
-        const volatile value_type source) const
-  {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type k = 0; k < numVecs; ++k) {
-      update[k] += source[k];
-    }
-  }
-
-  // On device, write the reduction result to the output View.
-  /*KOKKOS_INLINE_FUNCTION void
-  final (const value_type dst) const
-  {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type k = 0; k < numVecs; ++k) {
-      m_r(k) = dst[k];
-    }
-  }*/
-};
-
-/// \brief Column-wise dot product functor for multivectors with
-///   number of columns known at compile time; works for any layout,
-///   but best performance with LayoutRight.
-///
-/// \tparam RV 1-D output View
-/// \tparam XMV 2-D input View
-/// \tparam YMV 2-D input View
-/// \tparam UNROLL Number of columns (vectors)
-/// \tparam SizeType Index type.  Use int (32 bits) if possible.
-template<class RV, class XMV, class YMV, int UNROLL, class SizeType = typename XMV::size_type>
-struct MV_Dot_Right_FunctorUnroll
-{
-  typedef typename XMV::execution_space             execution_space;
-  typedef SizeType                                        size_type;
-  typedef typename XMV::non_const_value_type            xvalue_type;
-  typedef Kokkos::Details::InnerProductSpaceTraits<xvalue_type> IPT;
-  typedef Kokkos::Details::ArithTraits<typename IPT::dot_type>   AT;
-  typedef typename IPT::dot_type                       value_type[];
-
-  size_type value_count;
-  RV m_r;
-  typename XMV::const_type m_x;
-  typename YMV::const_type m_y;
-
-  MV_Dot_Right_FunctorUnroll (const RV& r, const XMV& x, const YMV& y) :
-    value_count (x.extent(1)), m_r (r), m_x (x), m_y (y)
-  {
-    static_assert (Kokkos::Impl::is_view<RV>::value, "KokkosBlas::Impl::"
-                   "MV_Dot_Right_FunctorUnroll: R is not a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<XMV>::value, "KokkosBlas::Impl::"
-                   "MV_Dot_Right_FunctorUnroll: X is not a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<YMV>::value, "KokkosBlas::Impl::"
-                   "MV_Dot_Right_FunctorUnroll: Y is not a Kokkos::View.");
-    static_assert (std::is_same<typename RV::value_type,
-                   typename RV::non_const_value_type>::value,
-                   "KokkosBlas::Impl::MV_Dot_Right_FunctorUnroll: R is const.  "
-                   "It must be nonconst, because it is an output argument "
-                   "(we have to be able to write to its entries).");
-    static_assert (int(XMV::rank) == int(YMV::rank),
-                   "KokkosBlas::Impl::MV_Dot_Right_FunctorUnroll: "
-                   "X and Y must have the same rank.");
-    static_assert (RV::rank == 1 && XMV::rank == 2,
-                   "KokkosBlas::Impl::MV_Dot_Right_FunctorUnroll: "
-                   "RV must have rank 1 and XMV and YMV must have rank 2.");
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator() (const size_type& i, value_type sum) const
-  {
-#ifdef KOKKOS_ENABLE_PRAGMA_UNROLL
-#pragma unroll
-#endif
-    for (int k = 0; k < UNROLL; ++k) {
-      sum[k] += IPT::dot (m_x(i,k), m_y(i,k)); // m_x(i,k) * m_y(i,k)
-    }
-  }
-
-  KOKKOS_INLINE_FUNCTION void init (volatile value_type update) const
-  {
-#ifdef KOKKOS_ENABLE_PRAGMA_UNROLL
-#pragma unroll
-#endif
-    for (int k = 0; k < UNROLL; ++k) {
-      update[k] = AT::zero ();
-    }
-  }
-
-  KOKKOS_INLINE_FUNCTION void
-  join (volatile value_type update,
-        const volatile value_type source) const
-  {
-#ifdef KOKKOS_ENABLE_PRAGMA_UNROLL
-#pragma unroll
-#endif
-    for (int k = 0; k < UNROLL; ++k) {
-      update[k] += source[k];
-    }
-  }
-
-  // On device, write the reduction result to the output View.
-  /*KOKKOS_INLINE_FUNCTION void
-  final (const value_type dst) const
-  {
-#ifdef KOKKOS_ENABLE_PRAGMA_UNROLL
-#pragma unroll
-#endif
-    for (int k = 0; k < UNROLL; ++k) {
-      m_r(k) = dst[k];
-    }
-  }*/
-};
-
-
-//! Implementation detail of MV_V_Dot_Invoke (see below).
-template<class RV, class XMV, class YMV, class SizeType,
-         const int XMV_rank = XMV::rank,
-         const int YMV_rank = YMV::rank>
-struct MV_V_Dot_Invoke_Impl
-{
-  static void
-  run (const RV& r, const XMV& X, const YMV& Y, const SizeType numRows);
-};
-
-template<class RV, class XMV, class YMV, class SizeType>
-struct MV_V_Dot_Invoke_Impl<RV, XMV, YMV, SizeType, 2, 1>
-{
-  static void
-  run (const RV& r, const XMV& X, const YMV& Y, const SizeType numRows)
-  {
-    static_assert (static_cast<int> (XMV::rank) == 2 && static_cast<int> (YMV::rank) == 1,
-                   "XMV must have rank 2, and YMV must have rank 1.");
-    static_assert (static_cast<int> (RV::rank) == 1, "Rank of r must be 1.");
-    static_assert (std::is_integral<SizeType>::value,
-                   "SizeType must be a built-in integer type.");
-
-    typedef typename XMV::execution_space execution_space;
-    typedef SizeType size_type;
-    typedef Kokkos::RangePolicy<execution_space, size_type> range_type;
-
-    typedef MV_V_Dot_Functor<RV, XMV, YMV, size_type> op_type;
-    constexpr bool reverseOrder = false;
-    op_type op (r, X, Y, reverseOrder);
-    Kokkos::parallel_reduce ("KokkosBlas::Dot::2_1", range_type (0, numRows), op, r);
+    Kokkos::single(Kokkos::PerTeam(t),
+                   [&]() { Kokkos::atomic_add(&r(i), Scalar(localResult)); });
   }
 };
 
-template<class RV, class XMV, class YMV, class SizeType>
-struct MV_V_Dot_Invoke_Impl<RV, XMV, YMV, SizeType, 1, 2>
-{
-  static void
-  run (const RV& r, const XMV& X, const YMV& Y, const SizeType numRows)
-  {
-    static_assert (static_cast<int> (XMV::rank) == 1 && static_cast<int> (YMV::rank) == 2,
-                   "XMV must have rank 1, and YMV must have rank 2.");
-    static_assert (static_cast<int> (RV::rank) == 1, "Rank of r must be 1.");
-    static_assert (std::is_integral<SizeType>::value,
-                   "SizeType must be a built-in integer type.");
-
-    typedef typename XMV::execution_space execution_space;
-    typedef SizeType size_type;
-    typedef Kokkos::RangePolicy<execution_space, size_type> range_type;
-
-    // Use the "reverse arguments" mode of the functor.
-    typedef MV_V_Dot_Functor<RV, YMV, XMV, size_type> op_type;
-    constexpr bool reverseOrder = true;
-    op_type op (r, Y, X, reverseOrder);
-    Kokkos::parallel_reduce ("KokkosBlas::Dot::1_2", range_type (0, numRows), op, r);
+// Main version: the result view is accessible from execution space, so it can
+// be computed in-place
+template <class RV, class XV, class YV, class size_type>
+void MV_Dot_Invoke(
+    const RV& r, const XV& x, const YV& y,
+    typename std::enable_if<Kokkos::SpaceAccessibility<
+        typename XV::execution_space,
+        typename RV::memory_space>::accessible>::type* = nullptr) {
+  using execution_space = typename XV::execution_space;
+  size_type numDots     = std::max(x.extent(1), y.extent(1));
+  if (x.extent(0) != y.extent(0)) {
+    std::ostringstream oss;
+    oss << "KokkosBlas::dot (rank-2): x and y have different lengths ("
+        << x.extent(0) << " and " << y.extent(0) << ")";
+    throw std::runtime_error(oss.str());
   }
-};
-
-//! Special case where XMV has rank 2 and YMV has rank 1, or vice versa.
-template<class RV, class XMV, class YMV, class SizeType>
-void
-MV_V_Dot_Invoke (const RV& r, const XMV& X, const YMV& Y, const SizeType numRows)
-{
-  MV_V_Dot_Invoke_Impl<RV, XMV, YMV, SizeType>::run (r, X, Y, numRows);
+  if ((x.extent(1) != size_t(1) && x.extent(1) != size_t(numDots)) ||
+      (y.extent(1) != size_t(1) && y.extent(1) != size_t(numDots))) {
+    std::ostringstream oss;
+    oss << "KokkosBlas::dot (rank-2): x and y have incompatible numbers of "
+           "columns ("
+        << x.extent(1) << " and " << y.extent(1) << ")";
+    throw std::runtime_error(oss.str());
+  }
+  if (r.extent(0) != size_t(numDots)) {
+    std::ostringstream oss;
+    oss << "KokkosBlas::dot (rank-2): result vector has wrong length ("
+        << r.extent(0) << ", but " << numDots
+        << " dot products will be computed)";
+    throw std::runtime_error(oss.str());
+  }
+  // Zero out the result vector
+  Kokkos::deep_copy(
+      r, Kokkos::ArithTraits<typename RV::non_const_value_type>::zero());
+  size_type teamsPerDot;
+  KokkosBlas::Impl::multipleReductionWorkDistribution<execution_space,
+                                                      size_type>(
+      x.extent(0), numDots, teamsPerDot);
+  size_type numTeams = numDots * teamsPerDot;
+  Kokkos::TeamPolicy<execution_space> pol(numTeams, Kokkos::AUTO);
+  Kokkos::parallel_for("Dot_MV", pol,
+                       Dot_MV_Functor<execution_space, RV, XV, YV, size_type>(
+                           r, x, y, teamsPerDot));
 }
 
-//! Special case where XMV and YMV both have rank 2.
-template<class RV, class XMV, class YMV, class SizeType>
-void
-MV_Dot_Invoke (const RV& r, const XMV& X, const YMV& Y)
-{
-  const SizeType numRows = static_cast<SizeType> (X.extent(0));
-  const SizeType numCols = static_cast<SizeType> (X.extent(1));
-  Kokkos::RangePolicy<typename XMV::execution_space, SizeType> policy (0, numRows);
-
-  if (static_cast<int> (X.extent(1)) != 1 && static_cast<int> (Y.extent(1)) == 1) {
-    // X has > 1 columns, and Y has 1 column.
-    auto Y_0 = Kokkos::subview (Y, Kokkos::ALL (), 0);
-    typedef typename decltype (Y_0)::const_type YV;
-    MV_V_Dot_Invoke<RV, XMV, YV, SizeType> (r, X, Y_0, numRows);
-    return;
-  }
-  else if (static_cast<int> (X.extent(1)) == 1 && static_cast<int> (Y.extent(1)) != 1) {
-    // X has 1 column, and Y has > 1 columns.
-    auto X_0 = Kokkos::subview (X, Kokkos::ALL (), 0);
-    typedef typename decltype (X_0)::const_type XV;
-    MV_V_Dot_Invoke<RV, XV, YMV, SizeType> (r, X_0, Y, numRows);
-    return;
-  }
-
-#if KOKKOSBLAS_OPTIMIZATION_LEVEL_DOT <= 2
-
-  // Strip-mine by 8, then 4.  After that, do one column at a time.
-  // We limit the number of strip-mine values in order to keep down
-  // the amount of code to compile.
-
-  SizeType j = 0; // the current column of X and Y
-  for ( ; j + 8 <= numCols; j += 8) {
-    auto X_cur = Kokkos::subview (X, Kokkos::ALL (), std::make_pair (j, j+8));
-    auto Y_cur = Kokkos::subview (Y, Kokkos::ALL (), std::make_pair (j, j+8));
-    auto r_cur = Kokkos::subview (r, std::make_pair (j, j+8));
-
-    MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 8, SizeType> op (r_cur, X_cur, Y_cur);
-    Kokkos::parallel_reduce ("KokkosBlas::Dot::2_2::8", policy, op, r_cur);
-  }
-  for ( ; j + 4 <= numCols; j += 4) {
-    auto X_cur = Kokkos::subview (X, Kokkos::ALL (), std::make_pair (j, j+4));
-    auto Y_cur = Kokkos::subview (Y, Kokkos::ALL (), std::make_pair (j, j+4));
-    auto r_cur = Kokkos::subview (r, std::make_pair (j, j+4));
-
-    MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 4, SizeType> op (r_cur, X_cur, Y_cur);
-    Kokkos::parallel_reduce ("KokkosBlas::Dot::2_2::4", policy, op, r_cur);
-  }
-  for ( ; j < numCols; ++j) {
-    // RV needs to turn 0-D, and XMV and YMV need to turn 1-D.
-    auto x_cur = Kokkos::subview (X, Kokkos::ALL (), j);
-    auto y_cur = Kokkos::subview (Y, Kokkos::ALL (), j);
-    auto r_cur = Kokkos::subview (r, j);
-    typedef decltype (r_cur) RV0D;
-    typedef decltype (x_cur) XMV1D;
-    typedef decltype (y_cur) YMV1D;
-
-    DotFunctor<RV0D, XMV1D, YMV1D, SizeType> op(x_cur, y_cur);
-    Kokkos::parallel_reduce ("KokkosBlas::Dot::2_2::1", policy, op, r_cur);
-  }
-
-#else // KOKKOSBLAS_OPTIMIZATION_LEVEL_DOT > 2
-
-  if (numCols > 16) {
-    MV_Dot_Right_FunctorVector<RV, XMV, YMV, SizeType> op (r, X, Y);
-    Kokkos::parallel_reduce ("KokkosBlas::Dot::NumCols::16Above", policy, op, r);
-  }
-  else {
-    switch (numCols) {
-    case 16: {
-      MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 16, SizeType> op (r, X, Y);
-      Kokkos::parallel_reduce ("KokkosBlas::Dot::NumCols::16", policy, op, r);
-      break;
-    }
-    case 15: {
-      MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 15, SizeType> op (r, X, Y);
-      Kokkos::parallel_reduce ("KokkosBlas::Dot::NumCols::15", policy, op, r);
-      break;
-    }
-    case 14: {
-      MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 14, SizeType> op (r, X, Y);
-      Kokkos::parallel_reduce ("KokkosBlas::Dot::NumCols::14", policy, op, r);
-      break;
-    }
-    case 13: {
-      MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 13, SizeType> op (r, X, Y);
-      Kokkos::parallel_reduce ("KokkosBlas::Dot::NumCols::13", policy, op, r);
-      break;
-    }
-    case 12: {
-      MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 12, SizeType> op (r, X, Y);
-      Kokkos::parallel_reduce ("KokkosBlas::Dot::NumCols::12", policy, op, r);
-      break;
-    }
-    case 11: {
-      MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 11, SizeType> op (r, X, Y);
-      Kokkos::parallel_reduce ("KokkosBlas::Dot::NumCols::11", policy, op, r);
-      break;
-    }
-    case 10: {
-      MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 10, SizeType> op (r, X, Y);
-      Kokkos::parallel_reduce ("KokkosBlas::Dot::NumCols::10", policy, op, r);
-      break;
-    }
-    case 9: {
-      MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 9, SizeType> op (r, X, Y);
-      Kokkos::parallel_reduce ("KokkosBlas::Dot::NumCols::9", policy, op, r);
-      break;
-    }
-    case 8: {
-      MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 8, SizeType> op (r, X, Y);
-      Kokkos::parallel_reduce ("KokkosBlas::Dot::NumCols::8", policy, op, r);
-      break;
-    }
-    case 7: {
-      MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 7, SizeType> op (r, X, Y);
-      Kokkos::parallel_reduce ("KokkosBlas::Dot::NumCols::7", policy, op, r);
-      break;
-    }
-    case 6: {
-      MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 6, SizeType> op (r, X, Y);
-      Kokkos::parallel_reduce ("KokkosBlas::Dot::NumCols::6", policy, op, r);
-      break;
-    }
-    case 5: {
-      MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 5, SizeType> op (r, X, Y);
-      Kokkos::parallel_reduce ("KokkosBlas::Dot::NumCols::5", policy, op, r);
-      break;
-    }
-    case 4: {
-      MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 4, SizeType> op (r, X, Y);
-      Kokkos::parallel_reduce ("KokkosBlas::Dot::NumCols::4", policy, op, r);
-      break;
-    }
-    case 3: {
-      MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 3, SizeType> op (r, X, Y);
-      Kokkos::parallel_reduce ("KokkosBlas::Dot::NumCols::3", policy, op, r);
-      break;
-    }
-    case 2: {
-      MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 2, SizeType> op (r, X, Y);
-      Kokkos::parallel_reduce ("KokkosBlas::Dot::NumCols::2", policy, op, r);
-      break;
-    }
-    case 1: {
-      // RV needs to turn 0-D, and XMV and YMV need to turn 1-D.
-      auto r_0 = Kokkos::subview (r, 0);
-      auto X_0 = Kokkos::subview (X, Kokkos::ALL (), 0);
-      auto Y_0 = Kokkos::subview (Y, Kokkos::ALL (), 0);
-      typedef decltype (r_0) RV0D;
-      typedef decltype (X_0) XMV1D;
-      typedef decltype (Y_0) YMV1D;
-
-      typedef V_Dot_Functor<RV0D, XMV1D, YMV1D, SizeType> op_type;
-      op_type op (r_0, X_0, Y_0);
-      Kokkos::parallel_reduce ("KokkosBlas::Dot::NumCols::1", policy, op, r_0);
-      break;
-    }
-    } // switch
-  } // if-else
-
-#endif // KOKKOSBLAS_OPTIMIZATION_LEVEL_DOT
+// Version for when a temporary result view is needed (implemented in terms of
+// the other version)
+template <class RV, class XV, class YV, class size_type>
+void MV_Dot_Invoke(
+    const RV& r, const XV& x, const YV& y,
+    typename std::enable_if<!Kokkos::SpaceAccessibility<
+        typename XV::execution_space,
+        typename RV::memory_space>::accessible>::type* = nullptr) {
+  Kokkos::View<typename RV::non_const_value_type*, typename XV::memory_space>
+      tempResult(
+          Kokkos::view_alloc(Kokkos::WithoutInitializing, "Dot_MV temp result"),
+          r.extent(0));
+  MV_Dot_Invoke<decltype(tempResult), XV, YV, size_type>(tempResult, x, y);
+  Kokkos::deep_copy(r, tempResult);
 }
 
-/// \brief Implementation of KokkosBlas::dot for multivectors or
-///   single vectors.
-///
-/// \tparam RV Type of return View of dot product results.
-/// \tparam XMV Type of first input (multi)vector X View.
-/// \tparam YMV Type of second input (multi)vector Y View.
-/// \tparam XMV_rank The rank of XMY.  If 2, it is a multivector; if
-///   1, it is a single vector.
-/// \tparam YMV_rank The rank of YMV.  If 2, it is a multivector; if
-///   1, it is a single vector.
-template<class RV, class XMV, class YMV, class SizeType,
-         const int XMV_rank = XMV::rank,
-         const int YMV_rnak = YMV::rank>
-struct Dot_MV;
+}  // namespace Impl
+}  // namespace KokkosBlas
 
-template<class RV, class XMV, class YMV, class SizeType>
-struct Dot_MV<RV, XMV, YMV, SizeType, 2, 2>
-{
-  /// \brief Compute the dot product(s) of the column(s) of the
-  ///   multivectors (2-D views) X and Y, and store result(s) in the
-  ///   1-D View r.
-  static void dot (const RV& r, const XMV& X, const YMV& Y)
-  {
-      MV_Dot_Invoke<RV, XMV, YMV, SizeType> (r, X, Y);
-  }
-};
-
-/// \brief Partial specialization for XMV_rank == 2 and YMV_rank == 1
-///   (X is a multivector, and Y is a single column).
-template<class RV, class XMV, class YV, class SizeType>
-struct Dot_MV<RV, XMV, YV, SizeType, 2, 1> {
-  /// \brief Compute the dot product(s) of each column of X with the
-  ///   single vector Y, and store result(s) in the 1-D View r.
-  static void dot (const RV& r, const XMV& X, const YV& Y)
-  {
-    MV_V_Dot_Invoke<RV, XMV, YV, SizeType> (r, X, Y, static_cast<int> (X.extent(0)));
-  }
-};
-
-/// \brief Partial specialization for XMV_rank == 1 and YMV_rank == 2
-///   (X is a single column, and Y is a multivector).
-template<class RV, class XV, class YMV, class SizeType>
-struct Dot_MV<RV, XV, YMV, SizeType, 1, 2> {
-  /// \brief Compute the dot product(s) of the single vector X with
-  ///   each column of Y, and store result(s) in the 1-D View r.
-  static void dot (const RV& r, const XV& X, const YMV& Y)
-  {
-    const SizeType numRows = X.extent(0);
-    MV_V_Dot_Invoke<RV, XV, YMV, SizeType> (r, X, Y, numRows);
-  }
-};
-
-} // namespace Impl
-} // namespace KokkosBlas
-
-#endif // KOKKOSBLAS1_IMPL_DOT_MV_IMPL_HPP_
+#endif  // KOKKOSBLAS1_IMPL_DOT_MV_IMPL_HPP_

--- a/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_dot_spec.hpp
+++ b/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_dot_spec.hpp
@@ -63,40 +63,39 @@ namespace Impl {
 // failures by using a higher-precision type for intermediate dot
 // product sums.
 //
-// Note that this is not the same thing as InnerProductSpaceTraits<scalar>::dot_type
-template<typename scalar_t>
-struct DotAccumulatingScalar
-{
+// Note that this is not the same thing as
+// InnerProductSpaceTraits<scalar>::dot_type
+template <typename scalar_t>
+struct DotAccumulatingScalar {
   using type = scalar_t;
 };
 
-template<>
-struct DotAccumulatingScalar<float>
-{
+template <>
+struct DotAccumulatingScalar<float> {
   using type = double;
 };
 
-template<>
-struct DotAccumulatingScalar<Kokkos::complex<float>>
-{
+template <>
+struct DotAccumulatingScalar<Kokkos::complex<float>> {
   using type = Kokkos::complex<double>;
 };
 
-template<typename scalar_t>
-struct HasSpecialAccumulator
-{
+template <typename scalar_t>
+struct HasSpecialAccumulator {
   enum : bool {
-      value = !std::is_same<scalar_t, typename DotAccumulatingScalar<scalar_t>::type>::value
+    value = !std::is_same<scalar_t,
+                          typename DotAccumulatingScalar<scalar_t>::type>::value
   };
 };
 
 // Specialization struct which defines whether a specialization exists
-template<class AV, class XV, class YV, int Xrank = XV::rank, int Yrank = YV::rank>
+template <class AV, class XV, class YV, int Xrank = XV::rank,
+          int Yrank = YV::rank>
 struct dot_eti_spec_avail {
   enum : bool { value = false };
 };
-}
-}
+}  // namespace Impl
+}  // namespace KokkosBlas
 
 //
 // Macro for declaration of full specialization availability
@@ -104,25 +103,33 @@ struct dot_eti_spec_avail {
 // the declarations of full specializations go in this header file.
 // We may spread out definitions (see _INST macro below) across one or
 // more .cpp files.
-#define KOKKOSBLAS1_DOT_ETI_SPEC_AVAIL( SCALAR, LAYOUT, EXEC_SPACE, MEM_SPACE ) \
-    template<> \
-    struct dot_eti_spec_avail< \
-        Kokkos::View<SCALAR, LAYOUT, Kokkos::HostSpace, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        1,1> { enum : bool { value = true }; }; \
-    template<> \
-    struct dot_eti_spec_avail< \
-        Kokkos::View<SCALAR, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        1,1> { enum : bool { value = true }; };
+#define KOKKOSBLAS1_DOT_ETI_SPEC_AVAIL(SCALAR, LAYOUT, EXEC_SPACE, MEM_SPACE) \
+  template <>                                                                 \
+  struct dot_eti_spec_avail<                                                  \
+      Kokkos::View<SCALAR, LAYOUT, Kokkos::HostSpace,                         \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                  \
+      Kokkos::View<const SCALAR*, LAYOUT,                                     \
+                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                     \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                  \
+      Kokkos::View<const SCALAR*, LAYOUT,                                     \
+                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                     \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                  \
+      1, 1> {                                                                 \
+    enum : bool { value = true };                                             \
+  };                                                                          \
+  template <>                                                                 \
+  struct dot_eti_spec_avail<                                                  \
+      Kokkos::View<SCALAR, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,     \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                  \
+      Kokkos::View<const SCALAR*, LAYOUT,                                     \
+                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                     \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                  \
+      Kokkos::View<const SCALAR*, LAYOUT,                                     \
+                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                     \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                  \
+      1, 1> {                                                                 \
+    enum : bool { value = true };                                             \
+  };
 
 //
 // Macro for declaration of full specialization availability
@@ -131,233 +138,276 @@ struct dot_eti_spec_avail {
 // We may spread out definitions (see _DEF macro below) across one or
 // more .cpp files.
 //
-#define KOKKOSBLAS1_DOT_MV_ETI_SPEC_AVAIL( SCALAR, LAYOUT, EXEC_SPACE, MEM_SPACE ) \
-    template<> \
-    struct dot_eti_spec_avail< \
-        Kokkos::View<SCALAR*, LAYOUT, \
-                     Kokkos::Device<Kokkos::DefaultHostExecutionSpace,Kokkos::HostSpace>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        2,2> { enum : bool { value = true }; }; \
-    template<> \
-    struct dot_eti_spec_avail< \
-        Kokkos::View<SCALAR*, LAYOUT, \
-                     Kokkos::Device<Kokkos::DefaultHostExecutionSpace,Kokkos::HostSpace>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        2,1> { enum : bool { value = true }; }; \
-    template<> \
-    struct dot_eti_spec_avail< \
-        Kokkos::View<SCALAR*, \
-                     LAYOUT, \
-                     Kokkos::Device<Kokkos::DefaultHostExecutionSpace,Kokkos::HostSpace>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        1,2> { enum : bool { value = true }; };
-
+#define KOKKOSBLAS1_DOT_MV_ETI_SPEC_AVAIL(SCALAR, LAYOUT, EXEC_SPACE, \
+                                          MEM_SPACE)                  \
+  template <>                                                         \
+  struct dot_eti_spec_avail<                                          \
+      Kokkos::View<SCALAR*, LAYOUT,                                   \
+                   Kokkos::Device<Kokkos::DefaultHostExecutionSpace,  \
+                                  Kokkos::HostSpace>,                 \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,          \
+      Kokkos::View<const SCALAR**, LAYOUT,                            \
+                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>,             \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,          \
+      Kokkos::View<const SCALAR**, LAYOUT,                            \
+                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>,             \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,          \
+      2, 2> {                                                         \
+    enum : bool { value = true };                                     \
+  };                                                                  \
+  template <>                                                         \
+  struct dot_eti_spec_avail<                                          \
+      Kokkos::View<SCALAR*, LAYOUT,                                   \
+                   Kokkos::Device<Kokkos::DefaultHostExecutionSpace,  \
+                                  Kokkos::HostSpace>,                 \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,          \
+      Kokkos::View<const SCALAR**, LAYOUT,                            \
+                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>,             \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,          \
+      Kokkos::View<const SCALAR**, LAYOUT,                            \
+                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>,             \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,          \
+      2, 1> {                                                         \
+    enum : bool { value = true };                                     \
+  };                                                                  \
+  template <>                                                         \
+  struct dot_eti_spec_avail<                                          \
+      Kokkos::View<SCALAR*, LAYOUT,                                   \
+                   Kokkos::Device<Kokkos::DefaultHostExecutionSpace,  \
+                                  Kokkos::HostSpace>,                 \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,          \
+      Kokkos::View<const SCALAR**, LAYOUT,                            \
+                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>,             \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,          \
+      Kokkos::View<const SCALAR**, LAYOUT,                            \
+                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>,             \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,          \
+      1, 2> {                                                         \
+    enum : bool { value = true };                                     \
+  };
 
 // Include the actual specialization declarations
-#include<KokkosBlas1_dot_tpl_spec_avail.hpp>
-#include<generated_specializations_hpp/KokkosBlas1_dot_eti_spec_avail.hpp>
-#include<generated_specializations_hpp/KokkosBlas1_dot_mv_eti_spec_avail.hpp>
+#include <KokkosBlas1_dot_tpl_spec_avail.hpp>
+#include <generated_specializations_hpp/KokkosBlas1_dot_eti_spec_avail.hpp>
+#include <generated_specializations_hpp/KokkosBlas1_dot_mv_eti_spec_avail.hpp>
 
 namespace KokkosBlas {
 namespace Impl {
 
 // Unification layer
-template<class RV, class XV, class YV, int XV_Rank = XV::rank, int YV_Rank = YV::rank,
-         bool tpl_spec_avail = dot_tpl_spec_avail<RV,XV,YV>::value,
-         bool eti_spec_avail = dot_eti_spec_avail<RV,XV,YV>::value>
+template <class RV, class XV, class YV, int XV_Rank = XV::rank,
+          int YV_Rank         = YV::rank,
+          bool tpl_spec_avail = dot_tpl_spec_avail<RV, XV, YV>::value,
+          bool eti_spec_avail = dot_eti_spec_avail<RV, XV, YV>::value>
 struct Dot {
-  static void dot (const RV&, const XV& R, const YV& X);
+  static void dot(const RV&, const XV& R, const YV& X);
 };
 
-//This version never has TPL support, but it does use the same ETI system
-template<class RV, class XV, class YV, bool eti_spec_avail = dot_eti_spec_avail<RV,XV,YV>::value>
+// This version never has TPL support, but it does use the same ETI system
+template <class RV, class XV, class YV,
+          bool eti_spec_avail = dot_eti_spec_avail<RV, XV, YV>::value>
 struct DotSpecialAccumulator {
-  //Note: not doing the static_asserts to validate RV, XV, YV since those errors
-  //would have already arisen when building the library.
+  // Note: not doing the static_asserts to validate RV, XV, YV since those
+  // errors would have already arisen when building the library.
   using size_type = typename YV::size_type;
-  using dot_type = typename Kokkos::Details::InnerProductSpaceTraits<
-    typename XV::non_const_value_type>::dot_type;
+  using dot_type  = typename Kokkos::Details::InnerProductSpaceTraits<
+      typename XV::non_const_value_type>::dot_type;
   using accum_type = typename DotAccumulatingScalar<dot_type>::type;
-  //This is the same View type as RV, but using the special accumulator as the value type
+  // This is the same View type as RV, but using the special accumulator as the
+  // value type
   using RV_Result = Kokkos::View<accum_type, typename RV::array_layout,
-        typename RV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
+                                 typename RV::device_type,
+                                 Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
 
-  static void dot (const RV_Result& R, const XV& X, const YV& Y);
+  static void dot(const RV_Result& R, const XV& X, const YV& Y);
 };
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) || KOKKOSKERNELS_IMPL_COMPILE_LIBRARY
 //! Full specialization of Dot for single vectors (1-D Views).
-//  The rank-1 case is currently the only one that may use a different accumulator
-//  type than <tt>InnerProductSpaceTraits::dot_type</tt>.
-template<class RV, class XV, class YV>
-struct Dot<RV, XV, YV, 1, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
-{
-  //Check some things about the template parameters at compile time to get nice error messages,
-  //before using them under the assumption they are valid.
-  static_assert (Kokkos::Impl::is_view<XV>::value, "KokkosBlas::Impl::"
-                 "Dot<1-D>: XV is not a Kokkos::View.");
-  static_assert (Kokkos::Impl::is_view<YV>::value, "KokkosBlas::Impl::"
-                 "Dot<1-D>: YV is not a Kokkos::View.");
-  static_assert (Kokkos::Impl::is_view<RV>::value, "KokkosBlas::Impl::"
-                 "Dot<1-D>: RV is not a Kokkos::View.");
-  static_assert (RV::rank == 0, "KokkosBlas::Impl::Dot<1-D>: "
-                 "RV is not rank 0.");
-  static_assert (XV::rank == 1, "KokkosBlas::Impl::Dot<1-D>: "
-                 "XV is not rank 1.");
-  static_assert (YV::rank == 1, "KokkosBlas::Impl::Dot<1-D>: "
-                 "YV is not rank 1.");
-  static_assert (std::is_same<typename RV::value_type,typename RV::non_const_value_type>::value,
-                 "KokkosBlas::Dot<1D>: R is const.  "
-                 "It must be nonconst, because it is an output argument "
-                 "(we have to be able to write to its entries).");
+//  The rank-1 case is currently the only one that may use a different
+//  accumulator type than <tt>InnerProductSpaceTraits::dot_type</tt>.
+template <class RV, class XV, class YV>
+struct Dot<RV, XV, YV, 1, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
+  // Check some things about the template parameters at compile time to get nice
+  // error messages, before using them under the assumption they are valid.
+  static_assert(Kokkos::is_view<XV>::value,
+                "KokkosBlas::Impl::"
+                "Dot<1-D>: XV is not a Kokkos::View.");
+  static_assert(Kokkos::is_view<YV>::value,
+                "KokkosBlas::Impl::"
+                "Dot<1-D>: YV is not a Kokkos::View.");
+  static_assert(Kokkos::is_view<RV>::value,
+                "KokkosBlas::Impl::"
+                "Dot<1-D>: RV is not a Kokkos::View.");
+  static_assert(RV::rank == 0,
+                "KokkosBlas::Impl::Dot<1-D>: "
+                "RV is not rank 0.");
+  static_assert(XV::rank == 1,
+                "KokkosBlas::Impl::Dot<1-D>: "
+                "XV is not rank 1.");
+  static_assert(YV::rank == 1,
+                "KokkosBlas::Impl::Dot<1-D>: "
+                "YV is not rank 1.");
+  static_assert(std::is_same<typename RV::value_type,
+                             typename RV::non_const_value_type>::value,
+                "KokkosBlas::Dot<1D>: R is const.  "
+                "It must be nonconst, because it is an output argument "
+                "(we have to be able to write to its entries).");
 
   typedef typename YV::size_type size_type;
   typedef typename RV::non_const_value_type dot_type;
   typedef typename DotAccumulatingScalar<dot_type>::type special_result_type;
 
-  //This is the same View type as RV, but using the special accumulator as the value type
-  typedef Kokkos::View<
-    special_result_type,
-    typename RV::array_layout,
-    typename RV::device_type,
-    Kokkos::MemoryTraits<Kokkos::Unmanaged> > RV_Result;
+  // This is the same View type as RV, but using the special accumulator as the
+  // value type
+  typedef Kokkos::View<special_result_type, typename RV::array_layout,
+                       typename RV::device_type,
+                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>
+      RV_Result;
 
-  static void dot (const RV& R, const XV& X, const YV& Y)
-  {
-    Kokkos::Profiling::pushRegion(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY?"KokkosBlas::dot[ETI]":"KokkosBlas::dot[noETI]");
-    #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
-    if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
-      printf("KokkosBlas::dot<> ETI specialization for < %s , %s >\n",typeid(XV).name(),typeid(YV).name());
+  static void dot(const RV& R, const XV& X, const YV& Y) {
+    Kokkos::Profiling::pushRegion(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY
+                                      ? "KokkosBlas::dot[ETI]"
+                                      : "KokkosBlas::dot[noETI]");
+#ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
+    if (KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
+      printf("KokkosBlas::dot<> ETI specialization for < %s , %s >\n",
+             typeid(XV).name(), typeid(YV).name());
     else {
-      printf("KokkosBlas::dot<> non-ETI specialization for < %s , %s >\n",typeid(XV).name(),typeid(YV).name());
+      printf("KokkosBlas::dot<> non-ETI specialization for < %s , %s >\n",
+             typeid(XV).name(), typeid(YV).name());
     }
-    #endif
+#endif
     const size_type numElems = X.extent(0);
 
-    if (numElems < static_cast<size_type> (INT_MAX)) {
+    if (numElems < static_cast<size_type>(INT_MAX)) {
       typedef int index_type;
-      DotFunctor<RV,XV,YV,index_type> f(X,Y);
-      f.run("KokkosBlas::dot<1D>",R);
-    }
-    else {
+      DotFunctor<RV, XV, YV, index_type> f(X, Y);
+      f.run("KokkosBlas::dot<1D>", R);
+    } else {
       typedef int64_t index_type;
-      DotFunctor<RV,XV,YV,index_type> f(X,Y);
-      f.run("KokkosBlas::dot<1D>",R);
+      DotFunctor<RV, XV, YV, index_type> f(X, Y);
+      f.run("KokkosBlas::dot<1D>", R);
     }
     Kokkos::Profiling::popRegion();
   }
 };
 
-//Implementation that has the same template args as Dot, but which internally uses
-//DotAccumulatingScalar for the result view.
+// Implementation that has the same template args as Dot, but which internally
+// uses DotAccumulatingScalar for the result view.
 //
-//Is never supported by TPLs, but uses the same dot_eti_spec_avail::value.
-template<class RV, class XV, class YV>
-struct DotSpecialAccumulator<RV, XV, YV, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
-{
-  static_assert (Kokkos::Impl::is_view<XV>::value, "KokkosBlas::Impl::"
-                 "DotSpecialAccumulator: XV is not a Kokkos::View.");
-  static_assert (Kokkos::Impl::is_view<YV>::value, "KokkosBlas::Impl::"
-                 "DotSpecialAccumulator: YV is not a Kokkos::View.");
-  static_assert (XV::rank == YV::rank, "KokkosBlas::Impl::"
-                 "DotSpecialAccumulator: X and Y have different ranks.");
-  static_assert (XV::rank == 1, "KokkosBlas::Impl::"
-                 "DotSpecialAccumulator: X and Y are not rank-1 Views.");
-  static_assert (Kokkos::Impl::is_view<RV>::value, "KokkosBlas::Impl::"
-                 "DotSpecialAccumulator: RV is not a Kokkos::View.");
-  static_assert (std::is_same<typename XV::non_const_value_type, typename YV::non_const_value_type>::value,
-                 "KokkosBlas::Impl::DotSpecialAccumulator: X and Y have different scalar types.");
-  static_assert (std::is_same<typename RV::value_type,typename RV::non_const_value_type>::value,
-                 "KokkosBlas::Dot<1D>: R is const.  "
-                 "It must be nonconst, because it is an output argument "
-                 "(we have to be able to write to its entries).");
+// Is never supported by TPLs, but uses the same dot_eti_spec_avail::value.
+template <class RV, class XV, class YV>
+struct DotSpecialAccumulator<RV, XV, YV, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
+  static_assert(Kokkos::is_view<XV>::value,
+                "KokkosBlas::Impl::"
+                "DotSpecialAccumulator: XV is not a Kokkos::View.");
+  static_assert(Kokkos::is_view<YV>::value,
+                "KokkosBlas::Impl::"
+                "DotSpecialAccumulator: YV is not a Kokkos::View.");
+  static_assert(XV::rank == YV::rank,
+                "KokkosBlas::Impl::"
+                "DotSpecialAccumulator: X and Y have different ranks.");
+  static_assert(XV::rank == 1,
+                "KokkosBlas::Impl::"
+                "DotSpecialAccumulator: X and Y are not rank-1 Views.");
+  static_assert(Kokkos::is_view<RV>::value,
+                "KokkosBlas::Impl::"
+                "DotSpecialAccumulator: RV is not a Kokkos::View.");
+  static_assert(std::is_same<typename XV::non_const_value_type,
+                             typename YV::non_const_value_type>::value,
+                "KokkosBlas::Impl::DotSpecialAccumulator: X and Y have "
+                "different scalar types.");
+  static_assert(std::is_same<typename RV::value_type,
+                             typename RV::non_const_value_type>::value,
+                "KokkosBlas::Dot<1D>: R is const.  "
+                "It must be nonconst, because it is an output argument "
+                "(we have to be able to write to its entries).");
 
   using size_type = typename YV::size_type;
-  using dot_type = typename Kokkos::Details::InnerProductSpaceTraits<
-    typename XV::non_const_value_type>::dot_type;
+  using dot_type  = typename Kokkos::Details::InnerProductSpaceTraits<
+      typename XV::non_const_value_type>::dot_type;
   using accum_type = typename DotAccumulatingScalar<dot_type>::type;
-  //This is the same View type as RV, but using the special accumulator as the value type
+  // This is the same View type as RV, but using the special accumulator as the
+  // value type
   using RV_Result = Kokkos::View<accum_type, typename RV::array_layout,
-        typename RV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
+                                 typename RV::device_type,
+                                 Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
 
-  static void dot (const RV_Result& R, const XV& X, const YV& Y)
-  {
-    Kokkos::Profiling::pushRegion(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY?"KokkosBlas::dot[ETI]":"KokkosBlas::dot[noETI]");
-    #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
-    if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
-      printf("KokkosBlas::dot<> ETI specialization for < %s , %s >\n",typeid(XV).name(),typeid(YV).name());
+  static void dot(const RV_Result& R, const XV& X, const YV& Y) {
+    Kokkos::Profiling::pushRegion(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY
+                                      ? "KokkosBlas::dot[ETI]"
+                                      : "KokkosBlas::dot[noETI]");
+#ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
+    if (KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
+      printf("KokkosBlas::dot<> ETI specialization for < %s , %s >\n",
+             typeid(XV).name(), typeid(YV).name());
     else {
-      printf("KokkosBlas::dot<> non-ETI specialization for < %s , %s >\n",typeid(XV).name(),typeid(YV).name());
+      printf("KokkosBlas::dot<> non-ETI specialization for < %s , %s >\n",
+             typeid(XV).name(), typeid(YV).name());
     }
-    #endif
+#endif
     const size_type numElems = X.extent(0);
 
-    if (numElems < static_cast<size_type> (INT_MAX)) {
+    if (numElems < static_cast<size_type>(INT_MAX)) {
       typedef int index_type;
-      DotFunctor<RV_Result,XV,YV,index_type> f(X,Y);
-      f.run("KokkosBlas::dot<1D>",R);
-    }
-    else {
+      DotFunctor<RV_Result, XV, YV, index_type> f(X, Y);
+      f.run("KokkosBlas::dot<1D>", R);
+    } else {
       typedef int64_t index_type;
-      DotFunctor<RV_Result,XV,YV,index_type> f(X,Y);
-      f.run("KokkosBlas::dot<1D>",R);
+      DotFunctor<RV_Result, XV, YV, index_type> f(X, Y);
+      f.run("KokkosBlas::dot<1D>", R);
     }
     Kokkos::Profiling::popRegion();
   }
 };
 
-template<class RV,class XV, class YV, int X_Rank, int Y_Rank>
-struct Dot<RV, XV, YV, X_Rank, Y_Rank, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
-  static_assert (Kokkos::Impl::is_view<XV>::value, "KokkosBlas::Impl::"
-                 "Dot<2-D>: XV is not a Kokkos::View.");
-  static_assert (Kokkos::Impl::is_view<YV>::value, "KokkosBlas::Impl::"
-                 "Dot<2-D>: YV is not a Kokkos::View.");
-  static_assert (RV::rank == 1, "KokkosBlas::Impl::Dot<2-D>: "
-                 "RV is not rank 1.");
+template <class RV, class XV, class YV, int X_Rank, int Y_Rank>
+struct Dot<RV, XV, YV, X_Rank, Y_Rank, false,
+           KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
+  static_assert(Kokkos::is_view<XV>::value,
+                "KokkosBlas::Impl::"
+                "Dot<2-D>: XV is not a Kokkos::View.");
+  static_assert(Kokkos::is_view<YV>::value,
+                "KokkosBlas::Impl::"
+                "Dot<2-D>: YV is not a Kokkos::View.");
+  static_assert(RV::rank == 1,
+                "KokkosBlas::Impl::Dot<2-D>: "
+                "RV is not rank 1.");
 
   typedef typename YV::size_type size_type;
 
-  static void dot (const RV& R, const XV& X, const YV& Y)
-  {
-    Kokkos::Profiling::pushRegion(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY?"KokkosBlas::dot[ETI]":"KokkosBlas::dot[noETI]");
-    #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
-    if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
-      printf("KokkosBlas1::dot<> ETI specialization for < %s , %s , %s >\n",typeid(RV).name(),typeid(XV).name(),typeid(YV).name());
+  static void dot(const RV& R, const XV& X, const YV& Y) {
+    Kokkos::Profiling::pushRegion(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY
+                                      ? "KokkosBlas::dot[ETI]"
+                                      : "KokkosBlas::dot[noETI]");
+#ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
+    if (KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
+      printf("KokkosBlas1::dot<> ETI specialization for < %s , %s , %s >\n",
+             typeid(RV).name(), typeid(XV).name(), typeid(YV).name());
     else {
-      printf("KokkosBlas1::dot<> non-ETI specialization for < %s , %s , %s >\n",typeid(RV).name(),typeid(XV).name(),typeid(YV).name());
+      printf("KokkosBlas1::dot<> non-ETI specialization for < %s , %s , %s >\n",
+             typeid(RV).name(), typeid(XV).name(), typeid(YV).name());
     }
-    #endif
+#endif
 
     const size_type numRows = X.extent(0);
     const size_type numCols = X.extent(1);
-    if (numRows < static_cast<size_type> (INT_MAX) &&
-        numRows * numCols < static_cast<size_type> (INT_MAX)) {
+    if (numRows < static_cast<size_type>(INT_MAX) &&
+        numRows * numCols < static_cast<size_type>(INT_MAX)) {
       typedef int index_type;
-      Dot_MV<RV,XV,YV,index_type>::dot(R,X,Y);
-    }
-    else {
+      MV_Dot_Invoke<RV, XV, YV, index_type>(R, X, Y);
+    } else {
       typedef std::int64_t index_type;
-      Dot_MV<RV,XV,YV,index_type>::dot(R,X,Y);
+      MV_Dot_Invoke<RV, XV, YV, index_type>(R, X, Y);
     }
     Kokkos::Profiling::popRegion();
   }
 };
 #endif
 
-}
-}
+}  // namespace Impl
+}  // namespace KokkosBlas
 
 //
 // Macro for declaration of full specialization of
@@ -366,69 +416,88 @@ struct Dot<RV, XV, YV, X_Rank, Y_Rank, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY
 // We may spread out definitions (see _DEF macro below) across one or
 // more .cpp files.
 //
-#define KOKKOSBLAS1_DOT_ETI_SPEC_DECL( SCALAR, LAYOUT, EXEC_SPACE, MEM_SPACE ) \
-extern template struct Dot< \
-        Kokkos::View<SCALAR, LAYOUT, Kokkos::HostSpace, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        1,1,false,true>; \
-extern template struct Dot< \
-        Kokkos::View<SCALAR, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        1,1,false,true>; \
-extern template struct DotSpecialAccumulator< \
-        Kokkos::View<SCALAR, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, true>; \
-extern template struct DotSpecialAccumulator< \
-        Kokkos::View<SCALAR, LAYOUT, Kokkos::HostSpace, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, true>;
+#define KOKKOSBLAS1_DOT_ETI_SPEC_DECL(SCALAR, LAYOUT, EXEC_SPACE, MEM_SPACE) \
+  extern template struct Dot<                                                \
+      Kokkos::View<SCALAR, LAYOUT, Kokkos::HostSpace,                        \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                 \
+      Kokkos::View<const SCALAR*, LAYOUT,                                    \
+                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                 \
+      Kokkos::View<const SCALAR*, LAYOUT,                                    \
+                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                 \
+      1, 1, false, true>;                                                    \
+  extern template struct Dot<                                                \
+      Kokkos::View<SCALAR, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                 \
+      Kokkos::View<const SCALAR*, LAYOUT,                                    \
+                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                 \
+      Kokkos::View<const SCALAR*, LAYOUT,                                    \
+                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                 \
+      1, 1, false, true>;                                                    \
+  extern template struct DotSpecialAccumulator<                              \
+      Kokkos::View<SCALAR, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                 \
+      Kokkos::View<const SCALAR*, LAYOUT,                                    \
+                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                 \
+      Kokkos::View<const SCALAR*, LAYOUT,                                    \
+                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                 \
+      true>;                                                                 \
+  extern template struct DotSpecialAccumulator<                              \
+      Kokkos::View<SCALAR, LAYOUT, Kokkos::HostSpace,                        \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                 \
+      Kokkos::View<const SCALAR*, LAYOUT,                                    \
+                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                 \
+      Kokkos::View<const SCALAR*, LAYOUT,                                    \
+                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                 \
+      true>;
 
-#define KOKKOSBLAS1_DOT_ETI_SPEC_INST( SCALAR, LAYOUT, EXEC_SPACE, MEM_SPACE ) \
-template struct Dot< \
-        Kokkos::View<SCALAR, LAYOUT, Kokkos::HostSpace, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        1,1,false,true>; \
-template struct Dot< \
-        Kokkos::View<SCALAR, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        1,1,false,true>; \
-template struct DotSpecialAccumulator< \
-        Kokkos::View<SCALAR, LAYOUT, Kokkos::HostSpace, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, true>; \
-template struct DotSpecialAccumulator< \
-        Kokkos::View<SCALAR, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, true>;
+#define KOKKOSBLAS1_DOT_ETI_SPEC_INST(SCALAR, LAYOUT, EXEC_SPACE, MEM_SPACE) \
+  template struct Dot<Kokkos::View<SCALAR, LAYOUT, Kokkos::HostSpace,        \
+                                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
+                      Kokkos::View<const SCALAR*, LAYOUT,                    \
+                                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>,    \
+                                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
+                      Kokkos::View<const SCALAR*, LAYOUT,                    \
+                                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>,    \
+                                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
+                      1, 1, false, true>;                                    \
+  template struct Dot<                                                       \
+      Kokkos::View<SCALAR, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                 \
+      Kokkos::View<const SCALAR*, LAYOUT,                                    \
+                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                 \
+      Kokkos::View<const SCALAR*, LAYOUT,                                    \
+                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                 \
+      1, 1, false, true>;                                                    \
+  template struct DotSpecialAccumulator<                                     \
+      Kokkos::View<SCALAR, LAYOUT, Kokkos::HostSpace,                        \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                 \
+      Kokkos::View<const SCALAR*, LAYOUT,                                    \
+                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                 \
+      Kokkos::View<const SCALAR*, LAYOUT,                                    \
+                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                 \
+      true>;                                                                 \
+  template struct DotSpecialAccumulator<                                     \
+      Kokkos::View<SCALAR, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                 \
+      Kokkos::View<const SCALAR*, LAYOUT,                                    \
+                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                 \
+      Kokkos::View<const SCALAR*, LAYOUT,                                    \
+                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                 \
+      true>;
 
 //
 //
@@ -436,66 +505,86 @@ template struct DotSpecialAccumulator< \
 // KokkosBlas::Impl::Dot for rank == 2.  This is NOT for users!!!  We
 // use this macro in one or more .cpp files in this directory.
 //
-#define KOKKOSBLAS1_DOT_MV_ETI_SPEC_DECL( SCALAR, LAYOUT, EXEC_SPACE, MEM_SPACE ) \
-extern template struct Dot< \
-        Kokkos::View<SCALAR*, LAYOUT, \
-                     Kokkos::Device<Kokkos::DefaultHostExecutionSpace,Kokkos::HostSpace>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        2,2,false,true>; \
-extern template struct Dot< \
-        Kokkos::View<SCALAR*, LAYOUT, \
-                     Kokkos::Device<Kokkos::DefaultHostExecutionSpace,Kokkos::HostSpace>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        2,1,false,true>; \
-extern template struct Dot< \
-        Kokkos::View<SCALAR*, LAYOUT, \
-                     Kokkos::Device<Kokkos::DefaultHostExecutionSpace,Kokkos::HostSpace>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        1,2,false,true>;
+#define KOKKOSBLAS1_DOT_MV_ETI_SPEC_DECL(SCALAR, LAYOUT, EXEC_SPACE, \
+                                         MEM_SPACE)                  \
+  extern template struct Dot<                                        \
+      Kokkos::View<SCALAR*, LAYOUT,                                  \
+                   Kokkos::Device<Kokkos::DefaultHostExecutionSpace, \
+                                  Kokkos::HostSpace>,                \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,         \
+      Kokkos::View<const SCALAR**, LAYOUT,                           \
+                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>,            \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,         \
+      Kokkos::View<const SCALAR**, LAYOUT,                           \
+                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>,            \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,         \
+      2, 2, false, true>;                                            \
+  extern template struct Dot<                                        \
+      Kokkos::View<SCALAR*, LAYOUT,                                  \
+                   Kokkos::Device<Kokkos::DefaultHostExecutionSpace, \
+                                  Kokkos::HostSpace>,                \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,         \
+      Kokkos::View<const SCALAR**, LAYOUT,                           \
+                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>,            \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,         \
+      Kokkos::View<const SCALAR*, LAYOUT,                            \
+                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>,            \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,         \
+      2, 1, false, true>;                                            \
+  extern template struct Dot<                                        \
+      Kokkos::View<SCALAR*, LAYOUT,                                  \
+                   Kokkos::Device<Kokkos::DefaultHostExecutionSpace, \
+                                  Kokkos::HostSpace>,                \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,         \
+      Kokkos::View<const SCALAR*, LAYOUT,                            \
+                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>,            \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,         \
+      Kokkos::View<const SCALAR**, LAYOUT,                           \
+                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>,            \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,         \
+      1, 2, false, true>;
 
-#define KOKKOSBLAS1_DOT_MV_ETI_SPEC_INST( SCALAR, LAYOUT, EXEC_SPACE, MEM_SPACE ) \
-template struct Dot< \
-        Kokkos::View<SCALAR*, LAYOUT, \
-                     Kokkos::Device<Kokkos::DefaultHostExecutionSpace,Kokkos::HostSpace>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        2,2,false,true>; \
-template struct Dot< \
-        Kokkos::View<SCALAR*, LAYOUT, \
-                     Kokkos::Device<Kokkos::DefaultHostExecutionSpace,Kokkos::HostSpace>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        2,1,false,true>; \
-template struct Dot< \
-        Kokkos::View<SCALAR*, LAYOUT, \
-                     Kokkos::Device<Kokkos::DefaultHostExecutionSpace,Kokkos::HostSpace>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        1,2,false,true>;
+#define KOKKOSBLAS1_DOT_MV_ETI_SPEC_INST(SCALAR, LAYOUT, EXEC_SPACE, \
+                                         MEM_SPACE)                  \
+  template struct Dot<                                               \
+      Kokkos::View<SCALAR*, LAYOUT,                                  \
+                   Kokkos::Device<Kokkos::DefaultHostExecutionSpace, \
+                                  Kokkos::HostSpace>,                \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,         \
+      Kokkos::View<const SCALAR**, LAYOUT,                           \
+                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>,            \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,         \
+      Kokkos::View<const SCALAR**, LAYOUT,                           \
+                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>,            \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,         \
+      2, 2, false, true>;                                            \
+  template struct Dot<                                               \
+      Kokkos::View<SCALAR*, LAYOUT,                                  \
+                   Kokkos::Device<Kokkos::DefaultHostExecutionSpace, \
+                                  Kokkos::HostSpace>,                \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,         \
+      Kokkos::View<const SCALAR**, LAYOUT,                           \
+                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>,            \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,         \
+      Kokkos::View<const SCALAR*, LAYOUT,                            \
+                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>,            \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,         \
+      2, 1, false, true>;                                            \
+  template struct Dot<                                               \
+      Kokkos::View<SCALAR*, LAYOUT,                                  \
+                   Kokkos::Device<Kokkos::DefaultHostExecutionSpace, \
+                                  Kokkos::HostSpace>,                \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,         \
+      Kokkos::View<const SCALAR*, LAYOUT,                            \
+                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>,            \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,         \
+      Kokkos::View<const SCALAR**, LAYOUT,                           \
+                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>,            \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,         \
+      1, 2, false, true>;
 
-#include<KokkosBlas1_dot_tpl_spec_decl.hpp>
-#include<generated_specializations_hpp/KokkosBlas1_dot_eti_spec_decl.hpp>
-#include<generated_specializations_hpp/KokkosBlas1_dot_mv_eti_spec_decl.hpp>
+#include <KokkosBlas1_dot_tpl_spec_decl.hpp>
+#include <generated_specializations_hpp/KokkosBlas1_dot_eti_spec_decl.hpp>
+#include <generated_specializations_hpp/KokkosBlas1_dot_mv_eti_spec_decl.hpp>
 
-#endif // KOKKOS_BLAS1_MV_IMPL_DOT_HPP_
+#endif  // KOKKOS_BLAS1_MV_IMPL_DOT_HPP_

--- a/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_iamax_impl.hpp
+++ b/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_iamax_impl.hpp
@@ -57,244 +57,97 @@ namespace Impl {
 /// \tparam XV 1-D input View
 /// \tparam MagType Magnitude type
 /// \tparam SizeType Index type.  Use int (32 bits) if possible.
-template<class RV, class XV, class MagType, class SizeType = typename XV::size_type>
-struct V_Iamax_Functor
-{
+template <class RV, class XV, class MagType,
+          class SizeType = typename XV::size_type>
+struct V_Iamax_Functor {
   using size_type   = SizeType;
   using mag_type    = MagType;
   using xvalue_type = typename XV::non_const_value_type;
   using IPT         = Kokkos::Details::InnerProductSpaceTraits<xvalue_type>;
   using value_type  = typename RV::value_type;
-  
+
   typename XV::const_type m_x;
 
-  V_Iamax_Functor (const XV& x) :
-    m_x (x)
-  {
-    static_assert (Kokkos::Impl::is_view<RV>::value,
-                   "KokkosBlas::Impl::V_Iamax_Functor: "
-                   "R is not a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<XV>::value,
-                   "KokkosBlas::Impl::V_Iamax_Functor: "
-                   "X is not a Kokkos::View.");
-    static_assert (std::is_same<typename RV::value_type,
-                   typename RV::non_const_value_type>::value,
-                   "KokkosBlas::Impl::V_Iamax_Functor: R is const.  "
-                   "It must be nonconst, because it is an output argument "
-                   "(we have to be able to write to its entries).");
-    static_assert (RV::rank == 0 && XV::rank == 1,
-                   "KokkosBlas::Impl::V_Iamax_Functor: "
-                   "RV must have rank 0 and XV must have rank 1.");
+  V_Iamax_Functor(const XV& x) : m_x(x) {
+    static_assert(Kokkos::is_view<RV>::value,
+                  "KokkosBlas::Impl::V_Iamax_Functor: "
+                  "R is not a Kokkos::View.");
+    static_assert(Kokkos::is_view<XV>::value,
+                  "KokkosBlas::Impl::V_Iamax_Functor: "
+                  "X is not a Kokkos::View.");
+    static_assert(std::is_same<typename RV::value_type,
+                               typename RV::non_const_value_type>::value,
+                  "KokkosBlas::Impl::V_Iamax_Functor: R is const.  "
+                  "It must be nonconst, because it is an output argument "
+                  "(we have to be able to write to its entries).");
+    static_assert(RV::rank == 0 && XV::rank == 1,
+                  "KokkosBlas::Impl::V_Iamax_Functor: "
+                  "RV must have rank 0 and XV must have rank 1.");
   }
 
-  KOKKOS_INLINE_FUNCTION void
-  operator() (const size_type i, value_type& lmaxloc) const
-  {
-    mag_type val    = IPT::norm (m_x(i-1));
-    mag_type maxval = IPT::norm (m_x(lmaxloc-1));
-    if(val > maxval) lmaxloc = i;
-  }  
- 
-  KOKKOS_INLINE_FUNCTION void
-  init (value_type& update) const
-  {
-    update = Kokkos::reduction_identity<typename RV::value_type>::max()+1;
-  }
-  
-  KOKKOS_INLINE_FUNCTION void
-  join (volatile value_type& update, const volatile value_type& source) const
-  {
-    mag_type source_val = IPT::norm (m_x(source-1));
-    mag_type update_val = IPT::norm (m_x(update-1));
-    if(update_val < source_val)
-      update = source;
+  KOKKOS_INLINE_FUNCTION void operator()(const size_type i,
+                                         value_type& lmaxloc) const {
+    mag_type val    = IPT::norm(m_x(i - 1));
+    mag_type maxval = IPT::norm(m_x(lmaxloc - 1));
+    if (val > maxval) lmaxloc = i;
   }
 
-  KOKKOS_INLINE_FUNCTION void
-  join (value_type& update, const value_type& source) const
-  {
-    mag_type source_val = IPT::norm (m_x(source-1));
-    mag_type update_val = IPT::norm (m_x(update-1));
-    if(update_val < source_val)
-      update = source;
+  KOKKOS_INLINE_FUNCTION void init(value_type& update) const {
+    update = Kokkos::reduction_identity<typename RV::value_type>::max() + 1;
+  }
+
+  KOKKOS_INLINE_FUNCTION void join(volatile value_type& update,
+                                   const volatile value_type& source) const {
+    mag_type source_val = IPT::norm(m_x(source - 1));
+    mag_type update_val = IPT::norm(m_x(update - 1));
+    if (update_val < source_val) update = source;
+  }
+
+  KOKKOS_INLINE_FUNCTION void join(value_type& update,
+                                   const value_type& source) const {
+    mag_type source_val = IPT::norm(m_x(source - 1));
+    mag_type update_val = IPT::norm(m_x(update - 1));
+    if (update_val < source_val) update = source;
   }
 };
 
-/// \brief Column-wise Iamax functor for multivectors.
-///
-/// \tparam RV 1-D output View
-/// \tparam XMV 2-D input View
-/// \tparam MagType Magnitude type
-/// \tparam SizeType Index type.  Use int (32 bits) if possible.
-template<class RV, class XMV, class MagType, class SizeType = typename XMV::size_type>
-struct MV_Iamax_FunctorVector
-{
-  using execution_space = typename XMV::execution_space;
-  using memory_space    = typename XMV::memory_space;
-  using size_type       = SizeType;
-  using mag_type        = MagType;
-  using xvalue_type     = typename XMV::non_const_value_type;
-  using IPT             = Kokkos::Details::InnerProductSpaceTraits<xvalue_type>;
-  using value_type      = typename RV::value_type[];
-
-  size_type value_count;
-  typename XMV::const_type m_x;
-  
-  MV_Iamax_FunctorVector (const XMV& x) :
-    value_count (x.extent(1)), m_x (x)
-  {
-    static_assert (Kokkos::Impl::is_view<RV>::value,
-                   "KokkosBlas::Impl::MV_Iamax_FunctorVector: "
-                   "R is not a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<XMV>::value,
-                   "KokkosBlas::Impl::MV_Iamax_FunctorVector: "
-                   "X is not a Kokkos::View.");
-    static_assert (std::is_same<typename RV::value_type,
-                   typename RV::non_const_value_type>::value,
-                   "KokkosBlas::Impl::MV_Iamax_FunctorVector: "
-                   "R is const.  It must be nonconst, because it is an output "
-                   "argument (we must be able to write to its entries).");
-    static_assert (RV::rank == 1 && XMV::rank == 2,
-                   "KokkosBlas::Impl::MV_Iamax_FunctorVector: "
-                   "RV must have rank 1 and XMV must have rank 2.");
-  }
-
-  KOKKOS_INLINE_FUNCTION void
-  operator() (const size_type i, value_type lmaxloc) const
-  {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type j = 0; j < numVecs; ++j) {
-      mag_type val    = IPT::norm (m_x(i-1,j));
-      mag_type maxval = IPT::norm (m_x(lmaxloc[j]-1,j));
-      if(val > maxval) lmaxloc[j] = i;
-    }
-  }  
- 
-  KOKKOS_INLINE_FUNCTION void
-  init (value_type update) const
-  {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type j = 0; j < numVecs; ++j) {
-      update[j] = Kokkos::reduction_identity<typename RV::value_type>::max()+1;
-    }
-  }
-  
-  KOKKOS_INLINE_FUNCTION void
-  join (volatile value_type update, const volatile value_type source) const
-  {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type j = 0; j < numVecs; ++j) {
-      mag_type source_val = IPT::norm (m_x(source[j]-1,j));
-      mag_type update_val = IPT::norm (m_x(update[j]-1,j));
-      if(update_val < source_val)
-        update[j] = source[j];
-    }
-  }
-
-  KOKKOS_INLINE_FUNCTION void
-  join (value_type update, const value_type source) const
-  {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type j = 0; j < numVecs; ++j) {
-      mag_type source_val = IPT::norm (m_x(source[j]-1,j));
-      mag_type update_val = IPT::norm (m_x(update[j]-1,j));
-      if(update_val < source_val)
-        update[j] = source[j];
-    }
-  }
-};
-
-
-/// \brief Find the index of the element with the maximum magnitude of the single vector (1-D
+/// \brief Find the index of the element with the maximum magnitude of the
+/// single vector (1-D
 ///   View) X, and store the result in the 0-D View r.
-template<class RV, class XV, class SizeType>
-void
-V_Iamax_Invoke (const RV& r, const XV& X)
-{
+template <class RV, class XV, class SizeType>
+void V_Iamax_Invoke(const RV& r, const XV& X) {
   using execution_space = typename XV::execution_space;
-  using AT              = Kokkos::Details::ArithTraits<typename XV::non_const_value_type>;
-  using mag_type        = typename AT::mag_type;
+  using AT = Kokkos::Details::ArithTraits<typename XV::non_const_value_type>;
+  using mag_type = typename AT::mag_type;
 
-  const SizeType numRows = static_cast<SizeType> (X.extent(0));
+  const SizeType numRows = static_cast<SizeType>(X.extent(0));
 
   // Avoid MaxLoc Reduction if this is a zero length view
-  if( numRows == 0 ) {
-    Kokkos::deep_copy(r,0);
+  if (numRows == 0) {
+    Kokkos::deep_copy(r, 0);
     return;
   }
 
-  Kokkos::RangePolicy<execution_space, SizeType> policy (1, numRows+1);
+  Kokkos::RangePolicy<execution_space, SizeType> policy(1, numRows + 1);
 
   using functor_type = V_Iamax_Functor<RV, XV, mag_type, SizeType>;
-  functor_type op (X);
-  Kokkos::parallel_reduce ("KokkosBlas::Iamax::S0", policy, op, r);
+  functor_type op(X);
+  Kokkos::parallel_reduce("KokkosBlas::Iamax::S0", policy, op, r);
 }
 
-
-/// \brief Find the index of the element with the maximum magnitude of the columns of the
+/// \brief Find the index of the element with the maximum magnitude of the
+/// columns of the
 ///   multivector (2-D View) X, and store result(s) in the 1-D View r.
-template<class RV, class XMV, class SizeType>
-void
-MV_Iamax_Invoke (const RV& r, const XMV& X)
-{
-  using execution_space = typename XMV::execution_space;
-  using AT              = Kokkos::Details::ArithTraits<typename XMV::non_const_value_type>;
-  using mag_type        = typename AT::mag_type;
-
-  const SizeType numRows = static_cast<SizeType> (X.extent(0));
-
-  // Avoid MaxLoc Reduction if this is a zero length view
-  if( numRows == 0 ) {
-    Kokkos::deep_copy(r,0);
-    return;
-  }
-
-  Kokkos::RangePolicy<execution_space, SizeType> policy (1, numRows+1);
-
-  // If the input multivector (2-D View) has only one column, invoke
-  // the single-vector version of the kernel.
-  if (X.extent(1) == 1) {
-    using RV0D = Kokkos::View<typename RV::non_const_value_type,
-                              typename RV::array_layout,
-                              typename RV::device_type,
-                              Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
-    RV0D r_0(r, 0);
-    auto X_0 = Kokkos::subview (X, Kokkos::ALL (), 0);
-    using XV1D = decltype(X_0);
-    V_Iamax_Invoke<RV0D, XV1D, SizeType> (r_0, X_0);
-  }
-  else {
-    using functor_type = MV_Iamax_FunctorVector<RV, XMV, mag_type, SizeType>;
-    functor_type op (X);
-    Kokkos::parallel_reduce ("KokkosBlas::Iamax::S1", policy, op, r);
+template <class RV, class XMV, class SizeType>
+void MV_Iamax_Invoke(const RV& r, const XMV& X) {
+  for (size_t i = 0; i < X.extent(1); i++) {
+    auto ri = Kokkos::subview(r, i);
+    auto Xi = Kokkos::subview(X, Kokkos::ALL(), i);
+    V_Iamax_Invoke<decltype(ri), decltype(Xi), SizeType>(ri, Xi);
   }
 }
 
-} // namespace Impl
-} // namespace KokkosBlas
+}  // namespace Impl
+}  // namespace KokkosBlas
 
-#endif // KOKKOSBLAS1_IAMAX_IMPL_HPP_
+#endif  // KOKKOSBLAS1_IAMAX_IMPL_HPP_

--- a/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_nrm1_impl.hpp
+++ b/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_nrm1_impl.hpp
@@ -47,6 +47,7 @@
 #include <KokkosKernels_config.h>
 #include <Kokkos_Core.hpp>
 #include <KokkosBlas1_nrm1_spec.hpp>
+#include <KokkosBlas_util.hpp>
 
 namespace KokkosBlas {
 namespace Impl {
@@ -60,210 +61,144 @@ namespace Impl {
 /// \tparam RV 0-D output View
 /// \tparam XV 1-D input View
 /// \tparam SizeType Index type.  Use int (32 bits) if possible.
-template<class RV, class XV, class SizeType = typename XV::size_type>
-struct V_Nrm1_Functor
-{
-  typedef typename XV::execution_space      execution_space;
-  typedef SizeType                          size_type;
+template <class RV, class XV, class SizeType = typename XV::size_type>
+struct V_Nrm1_Functor {
+  typedef typename XV::execution_space execution_space;
+  typedef SizeType size_type;
   typedef typename XV::non_const_value_type xvalue_type;
-  typedef Kokkos::ArithTraits<xvalue_type>  XAT;
-  typedef typename XAT::mag_type            value_type;
-  typedef Kokkos::ArithTraits<value_type>   MAT;
+  typedef Kokkos::ArithTraits<xvalue_type> XAT;
+  typedef typename XAT::mag_type value_type;
+  typedef Kokkos::ArithTraits<value_type> MAT;
 
   typename XV::const_type m_x;
 
-  V_Nrm1_Functor (const XV& x) :
-    m_x (x)
-  {
-    static_assert (Kokkos::Impl::is_view<RV>::value,
-                   "KokkosBlas::Impl::V_Nrm1_Functor: "
-                   "R is not a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<XV>::value,
-                   "KokkosBlas::Impl::V_Nrm1_Functor: "
-                   "X is not a Kokkos::View.");
-    static_assert (std::is_same<typename RV::value_type,
-                   typename RV::non_const_value_type>::value,
-                   "KokkosBlas::Impl::V_Nrm1_Functor: R is const.  "
-                   "It must be nonconst, because it is an output argument "
-                   "(we have to be able to write to its entries).");
-    static_assert (RV::rank == 0 && XV::rank == 1,
-                   "KokkosBlas::Impl::V_Nrm1_Functor: "
-                   "RV must have rank 0 and XV must have rank 1.");
+  V_Nrm1_Functor(const XV& x) : m_x(x) {
+    static_assert(Kokkos::is_view<RV>::value,
+                  "KokkosBlas::Impl::V_Nrm1_Functor: "
+                  "R is not a Kokkos::View.");
+    static_assert(Kokkos::is_view<XV>::value,
+                  "KokkosBlas::Impl::V_Nrm1_Functor: "
+                  "X is not a Kokkos::View.");
+    static_assert(std::is_same<typename RV::value_type,
+                               typename RV::non_const_value_type>::value,
+                  "KokkosBlas::Impl::V_Nrm1_Functor: R is const.  "
+                  "It must be nonconst, because it is an output argument "
+                  "(we have to be able to write to its entries).");
+    static_assert(RV::rank == 0 && XV::rank == 1,
+                  "KokkosBlas::Impl::V_Nrm1_Functor: "
+                  "RV must have rank 0 and XV must have rank 1.");
   }
 
   KOKKOS_INLINE_FUNCTION
-  void operator() (const size_type& i, value_type& sum) const
-  {
+  void operator()(const size_type& i, value_type& sum) const {
     xvalue_type val = m_x(i);
     sum += MAT::abs(XAT::real(val)) + MAT::abs(XAT::imag(val));
   }
-
-  KOKKOS_INLINE_FUNCTION void init (value_type& update) const
-  {
-    update = MAT::zero ();
-  }
-
-  KOKKOS_INLINE_FUNCTION void
-  join (value_type& update,
-        const value_type& source) const
-  {
-    update += source;
-  }
-
-  KOKKOS_INLINE_FUNCTION void
-  join (volatile value_type& update,
-        const volatile value_type& source) const
-  {
-    update += source;
-  }
 };
 
-/// \brief Column-wise 1-norm functor for multivectors; works for
-///   any layout, but best performance with LayoutRight.
-///
-/// \tparam RV 1-D output View
-/// \tparam XMV 2-D input View
-/// \tparam SizeType Index type.  Use int (32 bits) if possible.
-template<class RV, class XMV, class SizeType = typename XMV::size_type>
-struct MV_Nrm1_Right_FunctorVector
-{
-  typedef typename XMV::execution_space               execution_space;
-  typedef SizeType                                    size_type;
-  typedef typename XMV::non_const_value_type          xvalue_type;
-  typedef Kokkos::ArithTraits<xvalue_type>            XAT;
-  typedef Kokkos::ArithTraits<typename XAT::mag_type> MAT;
-  typedef typename XAT::mag_type                      value_type[];
+template <class ExecSpace, class RV, class XV, class size_type>
+struct Nrm1_MV_Functor {
+  typedef typename RV::non_const_value_type rvalue_type;
+  typedef typename XV::non_const_value_type xvalue_type;
+  typedef Kokkos::ArithTraits<xvalue_type> XAT;
+  typedef typename XAT::mag_type value_type;
+  typedef Kokkos::ArithTraits<value_type> MAT;
 
-  size_type value_count;
-  typename XMV::const_type m_x;
+  using TeamMem = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
 
-  MV_Nrm1_Right_FunctorVector (const XMV& x) :
-    value_count (x.extent(1)), m_x (x)
-  {
-    static_assert (Kokkos::Impl::is_view<RV>::value,
-                   "KokkosBlas::Impl::MV_Nrm1_Right_FunctorVector: "
-                   "R is not a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<XMV>::value,
-                   "KokkosBlas::Impl::MV_Nrm1_Right_FunctorVector: "
-                   "X is not a Kokkos::View.");
-    static_assert (std::is_same<typename RV::value_type,
-                   typename RV::non_const_value_type>::value,
-                   "KokkosBlas::Impl::MV_Nrm1_Right_FunctorVector: "
-                   "R is const.  It must be nonconst, because it is an output "
-                   "argument (we must be able to write to its entries).");
-    static_assert (RV::rank == 1 && XMV::rank == 2,
-                   "KokkosBlas::Impl::MV_Nrm1_Right_FunctorVector: "
-                   "RV must have rank 1 and XMV must have rank 2.");
-  }
+  RV r;
+  XV x;
 
-  KOKKOS_INLINE_FUNCTION void
-  operator() (const size_type i, value_type sum) const
-  {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type j = 0; j < numVecs; ++j) {
-      xvalue_type val = m_x(i, j);
-      sum[j] += MAT::abs(XAT::real(val)) + MAT::abs(XAT::imag(val));
-    }
-  }
+  size_type
+      teamsPerVec;  // number of teams collectively performing a dot product
 
-  KOKKOS_INLINE_FUNCTION void
-  init (value_type update) const
-  {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type j = 0; j < numVecs; ++j) {
-      update[j] = MAT::zero ();
-    }
-  }
+  Nrm1_MV_Functor(const RV& r_, const XV& x_, int teamsPerVec_)
+      : r(r_), x(x_), teamsPerVec(teamsPerVec_) {}
 
-  KOKKOS_INLINE_FUNCTION void
-  join (volatile value_type update,
-        const volatile value_type source) const
-  {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type j = 0; j < numVecs; ++j) {
-      update[j] += source[j];
-    }
-  }
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const TeamMem& t) const {
+    size_type globalRank = t.league_rank();
+    size_type localRank  = globalRank % teamsPerVec;
+    size_type i          = globalRank / teamsPerVec;
+    size_type begin      = localRank * (x.extent(0) / teamsPerVec);
+    size_type end        = (localRank + 1) * (x.extent(0) / teamsPerVec);
+    if (localRank == teamsPerVec - 1) end = x.extent(0);
+    value_type localResult = MAT::zero();
+    Kokkos::parallel_reduce(
+        Kokkos::TeamThreadRange(t, begin, end),
+        [&](size_type k, value_type& update) {
+          auto val = x(k, i);
+          update += MAT::abs(XAT::real(val)) + MAT::abs(XAT::imag(val));
+        },
+        localResult);
 
-  KOKKOS_INLINE_FUNCTION void
-  join (value_type update,
-        const value_type source) const
-  {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type j = 0; j < numVecs; ++j) {
-      update[j] += source[j];
-    }
+    Kokkos::single(Kokkos::PerTeam(t), [&]() {
+      Kokkos::atomic_add(&r(i), rvalue_type(localResult));
+    });
   }
 };
-
 
 /// \brief Compute the 2-norm (or its square) of the single vector (1-D
 ///   View) X, and store the result in the 0-D View r.
-template<class RV, class XV, class SizeType>
-void
-V_Nrm1_Invoke (const RV& r, const XV& X)
-{
+template <class RV, class XV, class SizeType>
+void V_Nrm1_Invoke(const RV& r, const XV& X) {
   typedef typename XV::execution_space execution_space;
-  const SizeType numRows = static_cast<SizeType> (X.extent(0));
-  Kokkos::RangePolicy<execution_space, SizeType> policy (0, numRows);
+  const SizeType numRows = static_cast<SizeType>(X.extent(0));
+  Kokkos::RangePolicy<execution_space, SizeType> policy(0, numRows);
 
   typedef V_Nrm1_Functor<RV, XV, SizeType> functor_type;
-  functor_type op (X);
-  Kokkos::parallel_reduce ("KokkosBlas1::Nrm1::S0", policy, op, r);
+  functor_type op(X);
+  Kokkos::parallel_reduce("KokkosBlas1::Nrm1::S0", policy, op, r);
 }
-
 
 /// \brief Compute the 2-norms (or their square) of the columns of the
 ///   multivector (2-D View) X, and store result(s) in the 1-D View r.
-template<class RV, class XMV, class SizeType>
-void
-MV_Nrm1_Invoke (const RV& r, const XMV& X)
-{
-  typedef typename XMV::execution_space execution_space;
-  const SizeType numRows = static_cast<SizeType> (X.extent(0));
-  Kokkos::RangePolicy<execution_space, SizeType> policy (0, numRows);
-
-  // If the input multivector (2-D View) has only one column, invoke
-  // the single-vector version of the kernel.
-  if (X.extent(1) == 1) {
-    auto r_0 = Kokkos::subview (r, 0);
-    auto X_0 = Kokkos::subview (X, Kokkos::ALL (), 0);
-    typedef decltype (r_0) RV0D;
-    typedef decltype (X_0) XV1D;
-    V_Nrm1_Invoke<RV0D, XV1D, SizeType> (r_0, X_0);
+// Main version: the result view is accessible from execution space, so it can
+// be computed in-place
+template <class RV, class XV, class size_type>
+void MV_Nrm1_Invoke(
+    const RV& r, const XV& x,
+    typename std::enable_if<Kokkos::SpaceAccessibility<
+        typename XV::execution_space,
+        typename RV::memory_space>::accessible>::type* = nullptr) {
+  using execution_space = typename XV::execution_space;
+  if (r.extent(0) != x.extent(1)) {
+    std::ostringstream oss;
+    oss << "KokkosBlas::nrm1 (rank-2): result vector has wrong length ("
+        << r.extent(0) << ", but x has " << x.extent(1) << " columns)";
+    throw std::runtime_error(oss.str());
   }
-  else {
-    typedef MV_Nrm1_Right_FunctorVector<RV, XMV, SizeType> functor_type;
-    functor_type op (X);
-    Kokkos::parallel_reduce ("KokkosBlas1::Nrm1::S1", policy, op, r);
-  }
+  // Zero out the result vector
+  Kokkos::deep_copy(
+      r, Kokkos::ArithTraits<typename RV::non_const_value_type>::zero());
+  size_type teamsPerVec;
+  KokkosBlas::Impl::multipleReductionWorkDistribution<execution_space,
+                                                      size_type>(
+      x.extent(0), x.extent(1), teamsPerVec);
+  size_type numTeams = x.extent(1) * teamsPerVec;
+  Kokkos::TeamPolicy<execution_space> pol(numTeams, Kokkos::AUTO);
+  Kokkos::parallel_for(
+      "KokkosBlas1::Nrm1::S1", pol,
+      Nrm1_MV_Functor<execution_space, RV, XV, size_type>(r, x, teamsPerVec));
 }
 
-} // namespace Impl
-} // namespace KokkosBlas
+// Version for when a temporary result view is needed (implemented in terms of
+// the other version)
+template <class RV, class XV, class size_type>
+void MV_Nrm1_Invoke(
+    const RV& r, const XV& x,
+    typename std::enable_if<!Kokkos::SpaceAccessibility<
+        typename XV::execution_space,
+        typename RV::memory_space>::accessible>::type* = nullptr) {
+  Kokkos::View<typename RV::non_const_value_type*, typename XV::memory_space>
+      tempResult(
+          Kokkos::view_alloc(Kokkos::WithoutInitializing, "Nrm1 temp result"),
+          r.extent(0));
+  MV_Nrm1_Invoke<decltype(tempResult), XV, size_type>(tempResult, x);
+  Kokkos::deep_copy(r, tempResult);
+}
 
-#endif // KOKKOSBLAS1_NRM1_IMPL_HPP_
+}  // namespace Impl
+}  // namespace KokkosBlas
+
+#endif  // KOKKOSBLAS1_NRM1_IMPL_HPP_

--- a/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_nrm2_impl.hpp
+++ b/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_nrm2_impl.hpp
@@ -47,6 +47,7 @@
 #include <KokkosKernels_config.h>
 #include <Kokkos_Core.hpp>
 #include <KokkosBlas1_nrm2_spec.hpp>
+#include <KokkosBlas_util.hpp>
 
 namespace KokkosBlas {
 namespace Impl {
@@ -60,234 +61,179 @@ namespace Impl {
 /// \tparam RV 0-D output View
 /// \tparam XV 1-D input View
 /// \tparam SizeType Index type.  Use int (32 bits) if possible.
-template<class RV, class XV, class SizeType = typename XV::size_type>
-struct V_Nrm2_Functor
-{
-  typedef typename XV::execution_space              execution_space;
-  typedef SizeType                                        size_type;
-  typedef typename XV::non_const_value_type             xvalue_type;
+template <class RV, class XV, class SizeType = typename XV::size_type>
+struct V_Nrm2_Functor {
+  typedef typename XV::execution_space execution_space;
+  typedef SizeType size_type;
+  typedef typename XV::non_const_value_type xvalue_type;
   typedef Kokkos::Details::InnerProductSpaceTraits<xvalue_type> IPT;
-  typedef Kokkos::Details::ArithTraits<typename IPT::mag_type>   AT;
-  typedef typename IPT::mag_type                         value_type;
+  typedef Kokkos::Details::ArithTraits<typename IPT::mag_type> AT;
+  typedef typename IPT::mag_type value_type;
 
   typename XV::const_type m_x;
   bool m_take_sqrt;
 
-  V_Nrm2_Functor (const XV& x, bool take_sqrt) :
-    m_x (x),m_take_sqrt(take_sqrt)
-  {
-    static_assert (Kokkos::Impl::is_view<RV>::value,
-                   "KokkosBlas::Impl::V_Nrm2_Functor: "
-                   "R is not a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<XV>::value,
-                   "KokkosBlas::Impl::V_Nrm2_Functor: "
-                   "X is not a Kokkos::View.");
-    static_assert (std::is_same<typename RV::value_type,
-                   typename RV::non_const_value_type>::value,
-                   "KokkosBlas::Impl::V_Nrm2_Functor: R is const.  "
-                   "It must be nonconst, because it is an output argument "
-                   "(we have to be able to write to its entries).");
-    static_assert (RV::rank == 0 && XV::rank == 1,
-                   "KokkosBlas::Impl::V_Nrm2_Functor: "
-                   "RV must have rank 0 and XV must have rank 1.");
+  V_Nrm2_Functor(const XV& x, bool take_sqrt) : m_x(x), m_take_sqrt(take_sqrt) {
+    static_assert(Kokkos::is_view<RV>::value,
+                  "KokkosBlas::Impl::V_Nrm2_Functor: "
+                  "R is not a Kokkos::View.");
+    static_assert(Kokkos::is_view<XV>::value,
+                  "KokkosBlas::Impl::V_Nrm2_Functor: "
+                  "X is not a Kokkos::View.");
+    static_assert(std::is_same<typename RV::value_type,
+                               typename RV::non_const_value_type>::value,
+                  "KokkosBlas::Impl::V_Nrm2_Functor: R is const.  "
+                  "It must be nonconst, because it is an output argument "
+                  "(we have to be able to write to its entries).");
+    static_assert(RV::rank == 0 && XV::rank == 1,
+                  "KokkosBlas::Impl::V_Nrm2_Functor: "
+                  "RV must have rank 0 and XV must have rank 1.");
   }
 
   KOKKOS_INLINE_FUNCTION
-  void operator() (const size_type& i, value_type& sum) const
-  {
-    const typename IPT::mag_type tmp = IPT::norm (m_x(i));
+  void operator()(const size_type& i, value_type& sum) const {
+    const typename IPT::mag_type tmp = IPT::norm(m_x(i));
     sum += tmp * tmp;
   }
 
-  KOKKOS_INLINE_FUNCTION void init (value_type& update) const
-  {
-    update = AT::zero ();
+  KOKKOS_INLINE_FUNCTION void init(value_type& update) const {
+    update = AT::zero();
   }
 
-  KOKKOS_INLINE_FUNCTION void
-  join (value_type& update,
-        const value_type& source) const
-  {
+  KOKKOS_INLINE_FUNCTION void join(value_type& update,
+                                   const value_type& source) const {
     update += source;
   }
 
-  KOKKOS_INLINE_FUNCTION void
-  join (volatile value_type& update,
-        const volatile value_type& source) const
-  {
+  KOKKOS_INLINE_FUNCTION void join(volatile value_type& update,
+                                   const volatile value_type& source) const {
     update += source;
   }
 
-  KOKKOS_INLINE_FUNCTION void
-  final (value_type& update) const {
-    if(m_take_sqrt)
-      update = Kokkos::Details::ArithTraits<typename RV::non_const_value_type>::sqrt(update);
+  KOKKOS_INLINE_FUNCTION void final(value_type& update) const {
+    if (m_take_sqrt)
+      update =
+          Kokkos::Details::ArithTraits<typename RV::non_const_value_type>::sqrt(
+              update);
   }
 };
 
 /// \brief Column-wise 2-norm functor for multivectors; works for
-///   any layout, but best performance with LayoutRight.
+///   any layout, but best performance with LayoutLeft.
 ///
 /// \tparam RV 1-D output View
 /// \tparam XMV 2-D input View
 /// \tparam SizeType Index type.  Use int (32 bits) if possible.
-template<class RV, class XMV, class SizeType = typename XMV::size_type>
-struct MV_Nrm2_Right_FunctorVector
-{
-  typedef typename XMV::execution_space             execution_space;
-  typedef SizeType                                        size_type;
-  typedef typename XMV::non_const_value_type            xvalue_type;
+template <class ExecSpace, class RV, class XV, class size_type>
+struct Nrm2_MV_Functor {
+  typedef typename RV::non_const_value_type rvalue_type;
+  typedef typename XV::non_const_value_type xvalue_type;
   typedef Kokkos::Details::InnerProductSpaceTraits<xvalue_type> IPT;
-  typedef Kokkos::Details::ArithTraits<typename IPT::mag_type>   AT;
-  typedef typename IPT::mag_type                       value_type[];
+  typedef Kokkos::Details::ArithTraits<typename IPT::mag_type> AT;
+  typedef typename IPT::mag_type value_type;
 
-  size_type value_count;
-  typename XMV::const_type m_x;
-  bool m_take_sqrt;
+  using TeamMem = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
 
-  MV_Nrm2_Right_FunctorVector (const XMV& x, const bool& take_sqrt) :
-    value_count (x.extent(1)), m_x (x), m_take_sqrt(take_sqrt)
-  {
-    static_assert (Kokkos::Impl::is_view<RV>::value,
-                   "KokkosBlas::Impl::MV_Nrm2_Right_FunctorVector: "
-                   "R is not a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<XMV>::value,
-                   "KokkosBlas::Impl::MV_Nrm2_Right_FunctorVector: "
-                   "X is not a Kokkos::View.");
-    static_assert (std::is_same<typename RV::value_type,
-                   typename RV::non_const_value_type>::value,
-                   "KokkosBlas::Impl::MV_Nrm2_Right_FunctorVector: "
-                   "R is const.  It must be nonconst, because it is an output "
-                   "argument (we must be able to write to its entries).");
-    static_assert (RV::rank == 1 && XMV::rank == 2,
-                   "KokkosBlas::Impl::MV_Nrm2_Right_FunctorVector: "
-                   "RV must have rank 1 and XMV must have rank 2.");
-  }
+  RV r;
+  XV x;
 
-  KOKKOS_INLINE_FUNCTION void
-  operator() (const size_type i, value_type sum) const
-  {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type j = 0; j < numVecs; ++j) {
-      const typename IPT::mag_type tmp = IPT::norm (m_x(i,j));
-      sum[j] += tmp * tmp;
-    }
-  }
+  size_type
+      teamsPerVec;  // number of teams collectively performing a dot product
 
-  KOKKOS_INLINE_FUNCTION void
-  init (value_type update) const
-  {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type j = 0; j < numVecs; ++j) {
-      update[j] = AT::zero ();
-    }
-  }
+  Nrm2_MV_Functor(const RV& r_, const XV& x_, int teamsPerVec_)
+      : r(r_), x(x_), teamsPerVec(teamsPerVec_) {}
 
-  KOKKOS_INLINE_FUNCTION void
-  join (volatile value_type update,
-        const volatile value_type source) const
-  {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type j = 0; j < numVecs; ++j) {
-      update[j] += source[j];
-    }
-  }
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const TeamMem& t) const {
+    size_type globalRank = t.league_rank();
+    size_type localRank  = globalRank % teamsPerVec;
+    size_type i          = globalRank / teamsPerVec;
 
-  KOKKOS_INLINE_FUNCTION void
-  join (value_type update,
-        const value_type source) const
-  {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type j = 0; j < numVecs; ++j) {
-      update[j] += source[j];
-    }
-  }
+    value_type localResult = AT::zero();
+    size_type begin        = localRank * (x.extent(0) / teamsPerVec);
+    size_type end          = (localRank + 1) * (x.extent(0) / teamsPerVec);
+    if (localRank == teamsPerVec - 1) end = x.extent(0);
 
-  KOKKOS_INLINE_FUNCTION void
-  final (value_type update) const {
-    if(m_take_sqrt) {
-      const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-      for (size_type j = 0; j < numVecs; ++j) {
-        update[j] = Kokkos::Details::ArithTraits<typename RV::non_const_value_type>::sqrt(update[j]);
-      }
-    }
+    Kokkos::parallel_reduce(
+        Kokkos::TeamThreadRange(t, begin, end),
+        [&](size_type k, value_type& update) {
+          value_type tmp = IPT::norm(x(k, i));
+          update += tmp * tmp;
+        },
+        localResult);
+
+    Kokkos::single(Kokkos::PerTeam(t), [&]() {
+      Kokkos::atomic_add(&r(i), rvalue_type(localResult));
+    });
   }
 };
 
-
 /// \brief Compute the 2-norm (or its square) of the single vector (1-D
 ///   View) X, and store the result in the 0-D View r.
-template<class RV, class XV, class SizeType>
-void
-V_Nrm2_Invoke (const RV& r, const XV& X, const bool& take_sqrt)
-{
+template <class RV, class XV, class SizeType>
+void V_Nrm2_Invoke(const RV& r, const XV& X, const bool& take_sqrt) {
   typedef typename XV::execution_space execution_space;
-  const SizeType numRows = static_cast<SizeType> (X.extent(0));
-  Kokkos::RangePolicy<execution_space, SizeType> policy (0, numRows);
+  const SizeType numRows = static_cast<SizeType>(X.extent(0));
+  Kokkos::RangePolicy<execution_space, SizeType> policy(0, numRows);
 
   typedef V_Nrm2_Functor<RV, XV, SizeType> functor_type;
-  functor_type op (X, take_sqrt);
-  Kokkos::parallel_reduce ("KokkosBlas::Nrm2::S0", policy,  op, r);
+  functor_type op(X, take_sqrt);
+  Kokkos::parallel_reduce("KokkosBlas::Nrm2::S0", policy, op, r);
 }
-
 
 /// \brief Compute the 2-norms (or their square) of the columns of the
 ///   multivector (2-D View) X, and store result(s) in the 1-D View r.
-template<class RV, class XMV, class SizeType>
-void
-MV_Nrm2_Invoke (const RV& r, const XMV& X, const bool& take_sqrt)
-{
-  typedef typename XMV::execution_space execution_space;
-  const SizeType numRows = static_cast<SizeType> (X.extent(0));
-  Kokkos::RangePolicy<execution_space, SizeType> policy (0, numRows);
-
-  // If the input multivector (2-D View) has only one column, invoke
-  // the single-vector version of the kernel.
-  if (X.extent(1) == 1) {
-    auto r_0 = Kokkos::subview (r, 0);
-    auto X_0 = Kokkos::subview (X, Kokkos::ALL (), 0);
-    typedef decltype (r_0) RV0D;
-    typedef decltype (X_0) XV1D;
-    V_Nrm2_Invoke<RV0D, XV1D, SizeType> (r_0, X_0, take_sqrt);
+// Main version: the result view is accessible from execution space, so it can
+// be computed in-place
+template <class RV, class XV, class size_type>
+void MV_Nrm2_Invoke(
+    const RV& r, const XV& x, bool take_sqrt,
+    typename std::enable_if<Kokkos::SpaceAccessibility<
+        typename XV::execution_space,
+        typename RV::memory_space>::accessible>::type* = nullptr) {
+  using execution_space = typename XV::execution_space;
+  if (r.extent(0) != x.extent(1)) {
+    std::ostringstream oss;
+    oss << "KokkosBlas::nrm2 (rank-2): result vector has wrong length ("
+        << r.extent(0) << ", but x has " << x.extent(1) << " columns)";
+    throw std::runtime_error(oss.str());
   }
-  else {
-    typedef MV_Nrm2_Right_FunctorVector<RV, XMV, SizeType> functor_type;
-    functor_type op (X, take_sqrt);
-    Kokkos::parallel_reduce ("KokkosBlas::Nrm2::S1", policy,  op, r);
+  // Zero out the result vector
+  Kokkos::deep_copy(
+      r, Kokkos::ArithTraits<typename RV::non_const_value_type>::zero());
+  size_type teamsPerVec;
+  KokkosBlas::Impl::multipleReductionWorkDistribution<execution_space,
+                                                      size_type>(
+      x.extent(0), x.extent(1), teamsPerVec);
+  size_type numTeams = x.extent(1) * teamsPerVec;
+  Kokkos::TeamPolicy<execution_space> pol(numTeams, Kokkos::AUTO);
+  Kokkos::parallel_for(
+      "KokkosBlas1::Nrm2::S1", pol,
+      Nrm2_MV_Functor<execution_space, RV, XV, size_type>(r, x, teamsPerVec));
+  if (take_sqrt) {
+    Kokkos::parallel_for("KokkosBlas1::Nrm2::Sqrt",
+                         Kokkos::RangePolicy<execution_space>(0, r.extent(0)),
+                         TakeSqrtFunctor<RV>(r));
   }
 }
 
-} // namespace Impl
-} // namespace KokkosBlas
+// Version for when a temporary result view is needed (implemented in terms of
+// the other version)
+template <class RV, class XV, class size_type>
+void MV_Nrm2_Invoke(
+    const RV& r, const XV& x, bool take_sqrt,
+    typename std::enable_if<!Kokkos::SpaceAccessibility<
+        typename XV::execution_space,
+        typename RV::memory_space>::accessible>::type* = nullptr) {
+  Kokkos::View<typename RV::non_const_value_type*, typename XV::memory_space>
+      tempResult(
+          Kokkos::view_alloc(Kokkos::WithoutInitializing, "Nrm2 temp result"),
+          r.extent(0));
+  MV_Nrm2_Invoke<decltype(tempResult), XV, size_type>(tempResult, x, take_sqrt);
+  Kokkos::deep_copy(r, tempResult);
+}
 
-#endif // KOKKOSBLAS1_NRM2_IMPL_HPP_
+}  // namespace Impl
+}  // namespace KokkosBlas
+
+#endif  // KOKKOSBLAS1_NRM2_IMPL_HPP_

--- a/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_nrm2w_impl.hpp
+++ b/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_nrm2w_impl.hpp
@@ -48,6 +48,7 @@
 #include <Kokkos_Core.hpp>
 #include <Kokkos_InnerProductSpaceTraits.hpp>
 #include <KokkosBlas1_nrm2w_spec.hpp>
+#include <KokkosBlas_util.hpp>
 
 namespace KokkosBlas {
 namespace Impl {
@@ -61,235 +62,178 @@ namespace Impl {
 /// \tparam RV 0-D output View
 /// \tparam XV 1-D input View
 /// \tparam SizeType Index type.  Use int (32 bits) if possible.
-template<class RV, class XV, class SizeType = typename XV::size_type>
-struct V_Nrm2w_Functor
-{
-  typedef typename XV::execution_space              execution_space;
-  typedef SizeType                                        size_type;
-  typedef typename XV::non_const_value_type             xvalue_type;
+template <class RV, class XV, class SizeType = typename XV::size_type>
+struct V_Nrm2w_Functor {
+  typedef typename XV::execution_space execution_space;
+  typedef SizeType size_type;
+  typedef typename XV::non_const_value_type xvalue_type;
   typedef Kokkos::Details::InnerProductSpaceTraits<xvalue_type> IPT;
-  typedef Kokkos::Details::ArithTraits<typename IPT::mag_type>   AT;
-  typedef typename IPT::mag_type                         value_type;
+  typedef Kokkos::Details::ArithTraits<typename IPT::mag_type> AT;
+  typedef typename IPT::mag_type value_type;
 
   typename XV::const_type m_x, m_w;
   bool m_take_sqrt;
 
-  V_Nrm2w_Functor (const XV& x, const XV& w, bool take_sqrt) :
-    m_x (x), m_w (w), m_take_sqrt (take_sqrt)
-  {
-    static_assert (Kokkos::Impl::is_view<RV>::value,
-                   "KokkosBlas::Impl::V_Nrm2w_Functor: "
-                   "R is not a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<XV>::value,
-                   "KokkosBlas::Impl::V_Nrm2w_Functor: "
-                   "X is not a Kokkos::View.");
-    static_assert (std::is_same<typename RV::value_type,
-                   typename RV::non_const_value_type>::value,
-                   "KokkosBlas::Impl::V_Nrm2w_Functor: R is const.  "
-                   "It must be nonconst, because it is an output argument "
-                   "(we have to be able to write to its entries).");
-    static_assert (RV::rank == 0 && XV::rank == 1,
-                   "KokkosBlas::Impl::V_Nrm2w_Functor: "
-                   "RV must have rank 0 and XV must have rank 1.");
+  V_Nrm2w_Functor(const XV& x, const XV& w, bool take_sqrt)
+      : m_x(x), m_w(w), m_take_sqrt(take_sqrt) {
+    static_assert(Kokkos::is_view<RV>::value,
+                  "KokkosBlas::Impl::V_Nrm2w_Functor: "
+                  "R is not a Kokkos::View.");
+    static_assert(Kokkos::is_view<XV>::value,
+                  "KokkosBlas::Impl::V_Nrm2w_Functor: "
+                  "X is not a Kokkos::View.");
+    static_assert(std::is_same<typename RV::value_type,
+                               typename RV::non_const_value_type>::value,
+                  "KokkosBlas::Impl::V_Nrm2w_Functor: R is const.  "
+                  "It must be nonconst, because it is an output argument "
+                  "(we have to be able to write to its entries).");
+    static_assert(RV::rank == 0 && XV::rank == 1,
+                  "KokkosBlas::Impl::V_Nrm2w_Functor: "
+                  "RV must have rank 0 and XV must have rank 1.");
   }
 
   KOKKOS_INLINE_FUNCTION
-  void operator() (const size_type& i, value_type& sum) const
-  {
-    const value_type tmp =  IPT::norm (m_x(i))/IPT::norm (m_w(i));
-    sum += tmp * tmp;;
+  void operator()(const size_type& i, value_type& sum) const {
+    const value_type tmp = IPT::norm(m_x(i)) / IPT::norm(m_w(i));
+    sum += tmp * tmp;
+    ;
   }
 
-  KOKKOS_INLINE_FUNCTION void init (value_type& update) const
-  {
-    update = AT::zero ();
+  KOKKOS_INLINE_FUNCTION void init(value_type& update) const {
+    update = AT::zero();
   }
 
-  KOKKOS_INLINE_FUNCTION void
-  join (value_type& update,
-        const value_type& source) const
-  {
+  KOKKOS_INLINE_FUNCTION void join(value_type& update,
+                                   const value_type& source) const {
     update += source;
   }
 
-  KOKKOS_INLINE_FUNCTION void
-  join (volatile value_type& update,
-        const volatile value_type& source) const
-  {
+  KOKKOS_INLINE_FUNCTION void join(volatile value_type& update,
+                                   const volatile value_type& source) const {
     update += source;
   }
 
-  KOKKOS_INLINE_FUNCTION void
-  final (value_type& update) const {
-    if(m_take_sqrt)
-      update = Kokkos::Details::ArithTraits<typename RV::non_const_value_type>::sqrt(update);
+  KOKKOS_INLINE_FUNCTION void final(value_type& update) const {
+    if (m_take_sqrt)
+      update =
+          Kokkos::Details::ArithTraits<typename RV::non_const_value_type>::sqrt(
+              update);
   }
 };
 
-/// \brief Column-wise 2-norm functor for multivectors; works for
-///   any layout, but best performance with LayoutRight.
-///
-/// \tparam RV 1-D output View
-/// \tparam XMV 2-D input View
-/// \tparam SizeType Index type.  Use int (32 bits) if possible.
-template<class RV, class XMV, class SizeType = typename XMV::size_type>
-struct MV_Nrm2w_Right_FunctorVector
-{
-  typedef typename XMV::execution_space             execution_space;
-  typedef SizeType                                        size_type;
-  typedef typename XMV::non_const_value_type            xvalue_type;
+template <class ExecSpace, class RV, class XV, class size_type>
+struct Nrm2w_MV_Functor {
+  typedef typename RV::non_const_value_type rvalue_type;
+  typedef typename XV::non_const_value_type xvalue_type;
   typedef Kokkos::Details::InnerProductSpaceTraits<xvalue_type> IPT;
-  typedef Kokkos::Details::ArithTraits<typename IPT::mag_type>   AT;
-  typedef typename IPT::mag_type                       value_type[];
+  typedef Kokkos::Details::ArithTraits<typename IPT::mag_type> AT;
+  typedef typename IPT::mag_type value_type;
 
-  size_type value_count;
-  typename XMV::const_type m_x, m_w;
-  bool m_take_sqrt;
+  using TeamMem = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
 
-  MV_Nrm2w_Right_FunctorVector (const XMV& x, const XMV& /* w */, const bool& take_sqrt) :
-    value_count (x.extent(1)), m_x (x), m_w (x), m_take_sqrt(take_sqrt)
-  {
-    static_assert (Kokkos::Impl::is_view<RV>::value,
-                   "KokkosBlas::Impl::MV_Nrm2w_Right_FunctorVector: "
-                   "R is not a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<XMV>::value,
-                   "KokkosBlas::Impl::MV_Nrm2w_Right_FunctorVector: "
-                   "X is not a Kokkos::View.");
-    static_assert (std::is_same<typename RV::value_type,
-                   typename RV::non_const_value_type>::value,
-                   "KokkosBlas::Impl::MV_Nrm2w_Right_FunctorVector: "
-                   "R is const.  It must be nonconst, because it is an output "
-                   "argument (we must be able to write to its entries).");
-    static_assert (RV::rank == 1 && XMV::rank == 2,
-                   "KokkosBlas::Impl::MV_Nrm2w_Right_FunctorVector: "
-                   "RV must have rank 1 and XMV must have rank 2.");
-  }
+  RV r;
+  XV x;
+  XV w;
 
-  KOKKOS_INLINE_FUNCTION void
-  operator() (const size_type i, value_type sum) const
-  {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type j = 0; j < numVecs; ++j) {
-      const typename IPT::mag_type tmp =  IPT::norm (m_x(i,j))/IPT::norm (m_w(i,j));
-      sum[j] += tmp * tmp;;
-    }
-  }
+  size_type
+      teamsPerVec;  // number of teams collectively performing a dot product
 
-  KOKKOS_INLINE_FUNCTION void
-  init (value_type update) const
-  {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type j = 0; j < numVecs; ++j) {
-      update[j] = AT::zero ();
-    }
-  }
+  Nrm2w_MV_Functor(const RV& r_, const XV& x_, const XV& w_, int teamsPerVec_)
+      : r(r_), x(x_), w(w_), teamsPerVec(teamsPerVec_) {}
 
-  KOKKOS_INLINE_FUNCTION void
-  join (volatile value_type update,
-        const volatile value_type source) const
-  {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type j = 0; j < numVecs; ++j) {
-      update[j] += source[j];
-    }
-  }
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const TeamMem& t) const {
+    size_type globalRank = t.league_rank();
+    size_type localRank  = globalRank % teamsPerVec;
+    size_type i          = globalRank / teamsPerVec;
 
-  KOKKOS_INLINE_FUNCTION void
-  join (value_type update,
-        const value_type source) const
-  {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type j = 0; j < numVecs; ++j) {
-      update[j] += source[j];
-    }
-  }
+    value_type localResult = AT::zero();
+    size_type begin        = localRank * (x.extent(0) / teamsPerVec);
+    size_type end          = (localRank + 1) * (x.extent(0) / teamsPerVec);
+    if (localRank == teamsPerVec - 1) end = x.extent(0);
+    Kokkos::parallel_reduce(
+        Kokkos::TeamThreadRange(t, begin, end),
+        [&](size_type k, value_type& update) {
+          const typename IPT::mag_type tmp =
+              IPT::norm(x(k, i)) / IPT::norm(w(k, i));
+          update += tmp * tmp;
+        },
+        localResult);
 
-  KOKKOS_INLINE_FUNCTION void
-  final (value_type update) const {
-    if(m_take_sqrt) {
-      const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-      for (size_type j = 0; j < numVecs; ++j) {
-        update[j] = Kokkos::Details::ArithTraits<typename RV::non_const_value_type>::sqrt(update[j]);
-      }
-    }
+    Kokkos::single(Kokkos::PerTeam(t), [&]() {
+      Kokkos::atomic_add(&r(i), rvalue_type(localResult));
+    });
   }
 };
-
 
 /// \brief Compute the 2-norm (or its square) of the single vector (1-D
 ///   View) X, and store the result in the 0-D View r.
-template<class RV, class XV, class SizeType>
-void
-V_Nrm2w_Invoke (const RV& r, const XV& X, const XV& W, const bool& take_sqrt)
-{
+template <class RV, class XV, class SizeType>
+void V_Nrm2w_Invoke(const RV& r, const XV& X, const XV& W,
+                    const bool& take_sqrt) {
   typedef typename XV::execution_space execution_space;
-  const SizeType numRows = static_cast<SizeType> (X.extent(0));
-  Kokkos::RangePolicy<execution_space, SizeType> policy (0, numRows);
+  const SizeType numRows = static_cast<SizeType>(X.extent(0));
+  Kokkos::RangePolicy<execution_space, SizeType> policy(0, numRows);
 
   typedef V_Nrm2w_Functor<RV, XV, SizeType> functor_type;
-  functor_type op (X, W, take_sqrt);
-  Kokkos::parallel_reduce ("KokkosBlas::Nrm2w::S0", policy, op, r);
+  functor_type op(X, W, take_sqrt);
+  Kokkos::parallel_reduce("KokkosBlas::Nrm2w::S0", policy, op, r);
 }
 
-
-/// \brief Compute the 2-norms (or their square) of the columns of the
+/// \brief Compute the weighted 2-norms (or their square) of the columns of the
 ///   multivector (2-D View) X, and store result(s) in the 1-D View r.
-template<class RV, class XMV, class SizeType>
-void
-MV_Nrm2w_Invoke (const RV& r, const XMV& X, const XMV& W, const bool& take_sqrt)
-{
-  typedef typename XMV::execution_space execution_space;
-  const SizeType numRows = static_cast<SizeType> (X.extent(0));
-  Kokkos::RangePolicy<execution_space, SizeType> policy (0, numRows);
-
-  // If the input multivector (2-D View) has only one column, invoke
-  // the single-vector version of the kernel.
-  if (X.extent(1) == 1) {
-    auto r_0 = Kokkos::subview (r, 0);
-    auto X_0 = Kokkos::subview (X, Kokkos::ALL (), 0);
-    auto W_0 = Kokkos::subview (W, Kokkos::ALL (), 0);
-    typedef decltype (r_0) RV0D;
-    typedef decltype (X_0) XV1D;
-    V_Nrm2w_Invoke<RV0D, XV1D, SizeType> (r_0, X_0, W_0, take_sqrt);
+// Main version: the result view is accessible from execution space, so it can
+// be computed in-place
+template <class RV, class XV, class size_type>
+void MV_Nrm2w_Invoke(
+    const RV& r, const XV& x, const XV& w, bool take_sqrt,
+    typename std::enable_if<Kokkos::SpaceAccessibility<
+        typename XV::execution_space,
+        typename RV::memory_space>::accessible>::type* = nullptr) {
+  using execution_space = typename XV::execution_space;
+  if (r.extent(0) != x.extent(1)) {
+    std::ostringstream oss;
+    oss << "KokkosBlas::nrm2w (rank-2): result vector has wrong length ("
+        << r.extent(0) << ", but x has " << x.extent(1) << " columns)";
+    throw std::runtime_error(oss.str());
   }
-  else {
-    typedef MV_Nrm2w_Right_FunctorVector<RV, XMV, SizeType> functor_type;
-    functor_type op (X, W, take_sqrt);
-    Kokkos::parallel_reduce ("KokkosBlas::Nrm2w::S1", policy, op, r);
+  // Zero out the result vector
+  Kokkos::deep_copy(
+      r, Kokkos::ArithTraits<typename RV::non_const_value_type>::zero());
+  size_type teamsPerVec;
+  KokkosBlas::Impl::multipleReductionWorkDistribution<execution_space,
+                                                      size_type>(
+      x.extent(0), x.extent(1), teamsPerVec);
+  size_type numTeams = x.extent(1) * teamsPerVec;
+  Kokkos::TeamPolicy<execution_space> pol(numTeams, Kokkos::AUTO);
+  Kokkos::parallel_for("KokkosBlas1::Nrm2w::S1", pol,
+                       Nrm2w_MV_Functor<execution_space, RV, XV, size_type>(
+                           r, x, w, teamsPerVec));
+  if (take_sqrt) {
+    Kokkos::parallel_for("KokkosBlas1::Nrm2w::Sqrt",
+                         Kokkos::RangePolicy<execution_space>(0, r.extent(0)),
+                         TakeSqrtFunctor<RV>(r));
   }
 }
 
-} // namespace Impl
-} // namespace KokkosBlas
+// Version for when a temporary result view is needed (implemented in terms of
+// the other version)
+template <class RV, class XV, class size_type>
+void MV_Nrm2w_Invoke(
+    const RV& r, const XV& x, const XV& w, bool take_sqrt,
+    typename std::enable_if<!Kokkos::SpaceAccessibility<
+        typename XV::execution_space,
+        typename RV::memory_space>::accessible>::type* = nullptr) {
+  Kokkos::View<typename RV::non_const_value_type*, typename XV::memory_space>
+      tempResult(
+          Kokkos::view_alloc(Kokkos::WithoutInitializing, "Nrm2w temp result"),
+          r.extent(0));
+  MV_Nrm2w_Invoke<decltype(tempResult), XV, size_type>(tempResult, x, w,
+                                                       take_sqrt);
+  Kokkos::deep_copy(r, tempResult);
+}
 
-#endif // KOKKOSBLAS1_NRM2W_IMPL_HPP_
+}  // namespace Impl
+}  // namespace KokkosBlas
+
+#endif  // KOKKOSBLAS1_NRM2W_IMPL_HPP_

--- a/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_nrminf_impl.hpp
+++ b/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_nrminf_impl.hpp
@@ -60,214 +60,76 @@ namespace Impl {
 /// \tparam RV 0-D output View
 /// \tparam XV 1-D input View
 /// \tparam SizeType Index type.  Use int (32 bits) if possible.
-template<class RV, class XV, class SizeType = typename XV::size_type>
-struct V_NrmInf_Functor
-{
-  typedef typename XV::execution_space              execution_space;
-  typedef SizeType                                        size_type;
-  typedef typename XV::non_const_value_type             xvalue_type;
+template <class RV, class XV, class SizeType = typename XV::size_type>
+struct V_NrmInf_Functor {
+  typedef typename XV::execution_space execution_space;
+  typedef SizeType size_type;
+  typedef typename XV::non_const_value_type xvalue_type;
   typedef Kokkos::Details::InnerProductSpaceTraits<xvalue_type> IPT;
-  typedef Kokkos::Details::ArithTraits<typename IPT::mag_type>   AT;
-  typedef typename IPT::mag_type                         value_type;
+  typedef Kokkos::Details::ArithTraits<typename IPT::mag_type> AT;
+  typedef typename IPT::mag_type value_type;
 
   typename XV::const_type m_x;
 
-  V_NrmInf_Functor (const XV& x) :
-    m_x (x)
-  {
-    static_assert (Kokkos::Impl::is_view<RV>::value,
-                   "KokkosBlas::Impl::V_NrmInf_Functor: "
-                   "R is not a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<XV>::value,
-                   "KokkosBlas::Impl::V_NrmInf_Functor: "
-                   "X is not a Kokkos::View.");
-    static_assert (std::is_same<typename RV::value_type,
-                   typename RV::non_const_value_type>::value,
-                   "KokkosBlas::Impl::V_NrmInf_Functor: R is const.  "
-                   "It must be nonconst, because it is an output argument "
-                   "(we have to be able to write to its entries).");
-    static_assert (RV::rank == 0 && XV::rank == 1,
-                   "KokkosBlas::Impl::V_NrmInf_Functor: "
-                   "RV must have rank 0 and XV must have rank 1.");
+  V_NrmInf_Functor(const XV& x) : m_x(x) {
+    static_assert(Kokkos::is_view<RV>::value,
+                  "KokkosBlas::Impl::V_NrmInf_Functor: "
+                  "R is not a Kokkos::View.");
+    static_assert(Kokkos::is_view<XV>::value,
+                  "KokkosBlas::Impl::V_NrmInf_Functor: "
+                  "X is not a Kokkos::View.");
+    static_assert(std::is_same<typename RV::value_type,
+                               typename RV::non_const_value_type>::value,
+                  "KokkosBlas::Impl::V_NrmInf_Functor: R is const.  "
+                  "It must be nonconst, because it is an output argument "
+                  "(we have to be able to write to its entries).");
+    static_assert(RV::rank == 0 && XV::rank == 1,
+                  "KokkosBlas::Impl::V_NrmInf_Functor: "
+                  "RV must have rank 0 and XV must have rank 1.");
   }
 
   KOKKOS_INLINE_FUNCTION
-  void operator() (const size_type& i, value_type& max) const
-  {
-    value_type val =  IPT::norm (m_x(i));
-    if(val>max) max = val;
+  void operator()(const size_type& i, value_type& max) const {
+    value_type val = IPT::norm(m_x(i));
+    if (val > max) max = val;
   }
 };
-
-/// \brief Column-wise 2-norm functor for multivectors; works for
-///   any layout, but best performance with LayoutRight.
-///
-/// \tparam RV 1-D output View
-/// \tparam XMV 2-D input View
-/// \tparam SizeType Index type.  Use int (32 bits) if possible.
-template<class RV, class XMV, class SizeType = typename XMV::size_type>
-struct MV_NrmInf_Right_FunctorVector
-{
-  typedef typename XMV::execution_space             execution_space;
-  typedef SizeType                                        size_type;
-  typedef typename XMV::non_const_value_type            xvalue_type;
-  typedef Kokkos::Details::InnerProductSpaceTraits<xvalue_type> IPT;
-  typedef Kokkos::Details::ArithTraits<typename IPT::mag_type>   AT;
-  typedef typename IPT::mag_type                       value_type[];
-
-  size_type value_count;
-  typename XMV::const_type m_x;
-
-  MV_NrmInf_Right_FunctorVector (const XMV& x) :
-    value_count (x.extent(1)), m_x (x)
-  {
-    static_assert (Kokkos::Impl::is_view<RV>::value,
-                   "KokkosBlas::Impl::MV_NrmInf_Right_FunctorVector: "
-                   "R is not a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<XMV>::value,
-                   "KokkosBlas::Impl::MV_NrmInf_Right_FunctorVector: "
-                   "X is not a Kokkos::View.");
-    static_assert (std::is_same<typename RV::value_type,
-                   typename RV::non_const_value_type>::value,
-                   "KokkosBlas::Impl::MV_NrmInf_Right_FunctorVector: "
-                   "R is const.  It must be nonconst, because it is an output "
-                   "argument (we must be able to write to its entries).");
-    static_assert (RV::rank == 1 && XMV::rank == 2,
-                   "KokkosBlas::Impl::MV_NrmInf_Right_FunctorVector: "
-                   "RV must have rank 1 and XMV must have rank 2.");
-  }
-
-  KOKKOS_INLINE_FUNCTION void
-  operator() (const size_type i, value_type max) const
-  {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type j = 0; j < numVecs; ++j) {
-      typename IPT::mag_type val =  IPT::norm (m_x(i,j));
-      if(val>max[j]) max[j] = val;
-    }
-  }
-
-  KOKKOS_INLINE_FUNCTION void
-  init (value_type update) const
-  {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type j = 0; j < numVecs; ++j) {
-      update[j] = AT::min ();
-    }
-  }
-
-  KOKKOS_INLINE_FUNCTION void
-  join (volatile value_type update,
-        const volatile value_type source) const
-  {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type j = 0; j < numVecs; ++j) {
-      if(update[j] < source[j])
-        update[j] = source[j];
-    }
-  }
-
-  KOKKOS_INLINE_FUNCTION void
-  join (value_type update,
-        const value_type source) const
-  {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type j = 0; j < numVecs; ++j) {
-      if(update[j] < source[j])
-        update[j] = source[j];
-    }
-  }
-};
-
 
 /// \brief Compute the 2-norm (or its square) of the single vector (1-D
 ///   View) X, and store the result in the 0-D View r.
-template<class RV, class XV, class SizeType>
-void
-V_NrmInf_Invoke (const RV& r, const XV& X)
-{
+template <class RV, class XV, class SizeType>
+void V_NrmInf_Invoke(const RV& r, const XV& X) {
   typedef typename XV::execution_space execution_space;
   typedef Kokkos::Details::ArithTraits<typename RV::non_const_value_type> AT;
 
-  const SizeType numRows = static_cast<SizeType> (X.extent(0));
+  const SizeType numRows = static_cast<SizeType>(X.extent(0));
 
   // Avoid Max Reduction if this is a zero length view
-  if( numRows == 0 ) {
-    Kokkos::deep_copy(r,AT::zero());
+  if (numRows == 0) {
+    Kokkos::deep_copy(r, AT::zero());
     return;
   }
 
-  Kokkos::RangePolicy<execution_space, SizeType> policy (0, numRows);
+  Kokkos::RangePolicy<execution_space, SizeType> policy(0, numRows);
 
   typedef V_NrmInf_Functor<RV, XV, SizeType> functor_type;
-  functor_type op (X);
-  Kokkos::parallel_reduce ("KokkosBlas::NrmInf::S0", policy, op, Kokkos::Max<typename RV::non_const_value_type>(r()));
+  functor_type op(X);
+  Kokkos::parallel_reduce("KokkosBlas::NrmInf::S0", policy, op,
+                          Kokkos::Max<typename RV::non_const_value_type>(r()));
 }
-
 
 /// \brief Compute the 2-norms (or their square) of the columns of the
 ///   multivector (2-D View) X, and store result(s) in the 1-D View r.
-template<class RV, class XMV, class SizeType>
-void
-MV_NrmInf_Invoke (const RV& r, const XMV& X)
-{
-  typedef typename XMV::execution_space execution_space;
-  typedef Kokkos::Details::ArithTraits<typename RV::non_const_value_type> AT;
-
-  const SizeType numRows = static_cast<SizeType> (X.extent(0));
-
-  // Avoid Max Reduction if this is a zero length view
-  if( numRows == 0 ) {
-    Kokkos::deep_copy(r,AT::zero());
-    return;
-  }
-
-  Kokkos::RangePolicy<execution_space, SizeType> policy (0, numRows);
-
-  // If the input multivector (2-D View) has only one column, invoke
-  // the single-vector version of the kernel.
-  if (X.extent(1) == 1) {
-    typedef Kokkos::View<typename RV::non_const_value_type,
-                         typename RV::array_layout,
-                         typename RV::device_type,
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged>> RV0D;
-    RV0D r_0(r, 0);
-    auto X_0 = Kokkos::subview (X, Kokkos::ALL (), 0);
-    typedef decltype (X_0) XV1D;
-    V_NrmInf_Invoke<RV0D, XV1D, SizeType> (r_0, X_0);
-  }
-  else {
-    typedef MV_NrmInf_Right_FunctorVector<RV, XMV, SizeType> functor_type;
-    functor_type op (X);
-    Kokkos::parallel_reduce ("KokkosBlas::NrmInf::S1", policy, op, r);
+template <class RV, class XMV, class SizeType>
+void MV_NrmInf_Invoke(const RV& r, const XMV& X) {
+  for (size_t i = 0; i < X.extent(1); i++) {
+    auto ri = Kokkos::subview(r, i);
+    auto Xi = Kokkos::subview(X, Kokkos::ALL(), i);
+    V_NrmInf_Invoke<decltype(ri), decltype(Xi), SizeType>(ri, Xi);
   }
 }
 
-} // namespace Impl
-} // namespace KokkosBlas
+}  // namespace Impl
+}  // namespace KokkosBlas
 
-#endif // KOKKOSBLAS1_NRMINF_IMPL_HPP_
+#endif  // KOKKOSBLAS1_NRMINF_IMPL_HPP_

--- a/packages/kokkos-kernels/src/blas/impl/KokkosBlas_util.hpp
+++ b/packages/kokkos-kernels/src/blas/impl/KokkosBlas_util.hpp
@@ -1,0 +1,106 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Brian Kelley (bmkelle@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_BLAS_UTIL_HPP
+#define KOKKOS_BLAS_UTIL_HPP
+
+namespace KokkosBlas {
+namespace Impl {
+
+// Helper to choose the work distribution for a TeamPolicy computing multiple
+// reductions. Each team computes a partial reduction and atomically contributes
+// to the final result.
+//
+// This was originally written for dot-based GEMM, but can also be applied to
+// multivector dots/norms.
+
+// Input params:
+//  * length: size of each vector to reduce
+//  * numReductions: number of reductions to compute
+// Output params:
+//  * teamsPerReduction: number of teams to use for each reduction
+template <typename ExecSpace, typename size_type>
+void multipleReductionWorkDistribution(size_type length,
+                                       size_type numReductions,
+                                       size_type& teamsPerDot) {
+  constexpr size_type workPerTeam = 4096;  // Amount of work per team
+  size_type appxNumTeams =
+      (length * numReductions) / workPerTeam;  // Estimation for appxNumTeams
+
+  // Adjust appxNumTeams in case it is too small or too large
+  if (appxNumTeams < 1) appxNumTeams = 1;
+  if (appxNumTeams > 1024) appxNumTeams = 1024;
+
+  // If there are more reductions than the number of teams,
+  // then set the number of teams to be number of reductions.
+  // We don't want a team to contribute to more than one reduction.
+  if (numReductions >= appxNumTeams) {
+    teamsPerDot = 1;
+  }
+  // If there are more teams than reductions, each reduction can
+  // potentially be performed by multiple teams. First, compute
+  // teamsPerDot as an integer (take the floor, not ceiling), then,
+  // compute actual number of teams by using this factor.
+  else {
+    teamsPerDot = appxNumTeams / numReductions;
+  }
+}
+
+// Functor to apply sqrt() to each element of a 1D view.
+
+template <class RV>
+struct TakeSqrtFunctor {
+  TakeSqrtFunctor(const RV& r_) : r(r_) {}
+
+  KOKKOS_INLINE_FUNCTION void operator()(int i) const {
+    r(i) = Kokkos::ArithTraits<typename RV::non_const_value_type>::sqrt(r(i));
+  }
+
+  RV r;
+};
+
+}  // namespace Impl
+}  // namespace KokkosBlas
+
+#endif


### PR DESCRIPTION
Patching in https://github.com/kokkos/kokkos-kernels/pull/1204 :

Remove runtime-sized array reductions from BLAS-1 MV functions. Where
possible, use the same approach as dot-based GEMM (have multiple teams
work on a reduction, and use atomics to contribute to the final result).
If that is not possible, just process each column one at a time. Both
approaches give better performance than array reductions, and also work
for any number of columns (before, both Cuda and HIP had limits, see #9856).

I checked that the tests to replicate the issue (from #9860), pass with these changes.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/kokkos-kernels 
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
All the changes are within Kokkos Kernels. KokkosKernels_blas_* has unit tests for each of these functions.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->