### PR TITLE
Amesos2 : SuperLU_MT adjusts 'nprocs' default parameter

### DIFF
--- a/packages/amesos2/src/Amesos2_Superlumt_def.hpp
+++ b/packages/amesos2/src/Amesos2_Superlumt_def.hpp
@@ -462,8 +462,8 @@ namespace Amesos2 {
 
     RCP<const Teuchos::ParameterList> valid_params = getValidParameters_impl();
 
-
-    data_.options.nprocs = parameterList->get<int>("nprocs", 1);
+    int default_nprocs = Kokkos::DefaultHostExecutionSpace::concurrency();
+    data_.options.nprocs = parameterList->get<int>("nprocs", default_nprocs);
 
     data_.options.trans = this->control_.useTranspose_ ? SLUMT::TRANS : SLUMT::NOTRANS;
     // SuperLU_MT "trans" option can override the Amesos2 option
@@ -521,10 +521,11 @@ namespace Amesos2 {
     if( is_null(valid_params) ){
       Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
 
+      int default_nprocs = Kokkos::DefaultHostExecutionSpace::concurrency();
       Teuchos::RCP<EnhancedNumberValidator<int> > nprocs_validator
         = Teuchos::rcp( new EnhancedNumberValidator<int>() );
-      nprocs_validator->setMin(1);
-      pl->set("nprocs", 1, "The number of processors to factorize with", nprocs_validator);
+      nprocs_validator->setMin(default_nprocs);
+      pl->set("nprocs", default_nprocs, "The number of processors to factorize with", nprocs_validator);
 
       setStringToIntegralParameter<SLUMT::trans_t>("trans", "NOTRANS",
                                                    "Solve for the transpose system or not",


### PR DESCRIPTION

@trilinos/amesos2 

## Motivation

This PR likes to adjust the default parameter value for `nprocs` such that it is the current number of threads, e.g., OMP_NUM_THREADS (the default value was always one).