### PR TITLE
Tempus: Deprecate Some Functions

### DIFF
--- a/packages/tempus/src/Tempus_Integrator.hpp
+++ b/packages/tempus/src/Tempus_Integrator.hpp
@@ -79,9 +79,13 @@ public:
     virtual void setStatus(const Tempus::Status st) = 0;
     /// Get the stepper
     virtual Teuchos::RCP<Stepper<Scalar> > getStepper() const = 0;
+#ifndef TEMPUS_HIDE_DEPRECATED_CODE
     /// Return a copy of the Tempus ParameterList
+    TEMPUS_DEPRECATED
     virtual Teuchos::RCP<Teuchos::ParameterList> getTempusParameterList() = 0;
+    TEMPUS_DEPRECATED
     virtual void setTempusParameterList(Teuchos::RCP<Teuchos::ParameterList> pl) = 0;
+#endif
     /// Returns the SolutionHistory for this Integrator
     virtual Teuchos::RCP<const SolutionHistory<Scalar> > getSolutionHistory() const = 0;
     /// Returns the SolutionHistory for this Integrator

--- a/packages/tempus/src/Tempus_IntegratorAdjointSensitivity_decl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorAdjointSensitivity_decl.hpp
@@ -52,12 +52,12 @@ class IntegratorAdjointSensitivity :
 {
 public:
 
-  /** \brief Full Constructor with model, and will be fully initialized. 
+  /** \brief Full Constructor with model, and will be fully initialized.
    *
    * \param[in] model                 The forward physics ModelEvaluator
    * \param[in] state_integrator      Forward state Integrator for the forward problem
-   * \param[in] adjoint_model         ModelEvaluator for the adjoint physics/problem 
-   * \param[in] adjoint_aux_model     ModelEvaluator for the auxiliary adjoint physics/problem 
+   * \param[in] adjoint_model         ModelEvaluator for the adjoint physics/problem
+   * \param[in] adjoint_aux_model     ModelEvaluator for the auxiliary adjoint physics/problem
    * \param[in] adjoint_integrator    Time integrator for the adjoint problem
    * \param[in] solution_history      The forward state solution history
    * \param[in] p_index               Sensitivity parameter index
@@ -145,9 +145,13 @@ public:
   virtual void setStatus(const Status st) override;
   /// Get the Stepper
   virtual Teuchos::RCP<Stepper<Scalar> > getStepper() const override;
+#ifndef TEMPUS_HIDE_DEPRECATED_CODE
   /// Return a copy of the Tempus ParameterList
+  TEMPUS_DEPRECATED
   virtual Teuchos::RCP<Teuchos::ParameterList> getTempusParameterList() override;
+  TEMPUS_DEPRECATED
   virtual void setTempusParameterList(Teuchos::RCP<Teuchos::ParameterList> pl) override;
+#endif
   /// Get the SolutionHistory
   virtual Teuchos::RCP<const SolutionHistory<Scalar> > getSolutionHistory() const override;
   /// Get the SolutionHistory

--- a/packages/tempus/src/Tempus_IntegratorAdjointSensitivity_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorAdjointSensitivity_impl.hpp
@@ -337,6 +337,7 @@ getStepper() const
   return state_integrator_->getStepper();
 }
 
+#ifndef TEMPUS_HIDE_DEPRECATED_CODE
 template<class Scalar>
 Teuchos::RCP<Teuchos::ParameterList>
 IntegratorAdjointSensitivity<Scalar>::
@@ -354,6 +355,7 @@ setTempusParameterList(Teuchos::RCP<Teuchos::ParameterList> pl)
   adjoint_integrator_->setTempusParameterList(pl);
 }
 
+#endif
 template<class Scalar>
 Teuchos::RCP<const SolutionHistory<Scalar> >
 IntegratorAdjointSensitivity<Scalar>::

--- a/packages/tempus/src/Tempus_IntegratorBasicOld_decl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorBasicOld_decl.hpp
@@ -69,9 +69,9 @@ public:
     virtual void endIntegrator();
     /// Return a copy of the Tempus ParameterList
     virtual Teuchos::RCP<Teuchos::ParameterList> getTempusParameterList()
-      override { return tempusPL_; }
+      { return tempusPL_; }
     virtual void setTempusParameterList(
-      Teuchos::RCP<Teuchos::ParameterList> pl) override
+      Teuchos::RCP<Teuchos::ParameterList> pl)
     {
       if (tempusPL_==Teuchos::null) tempusPL_=Teuchos::parameterList("Tempus");
       if (pl != Teuchos::null) *tempusPL_ = *pl;

--- a/packages/tempus/src/Tempus_IntegratorBasic_decl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorBasic_decl.hpp
@@ -60,15 +60,20 @@ public:
     virtual void checkTimeStep();
     /// Perform tasks after end of integrator.
     virtual void endIntegrator();
+#ifndef TEMPUS_HIDE_DEPRECATED_CODE
     /// Return a copy of the Tempus ParameterList DEPRECATED!
+    TEMPUS_DEPRECATED
     virtual Teuchos::RCP<Teuchos::ParameterList> getTempusParameterList()
       override { return Teuchos::rcp_const_cast<Teuchos::ParameterList> (this->getValidParameters()); }
+
+    TEMPUS_DEPRECATED
     virtual void setTempusParameterList(
       Teuchos::RCP<Teuchos::ParameterList> pl) override
     {
       TEUCHOS_TEST_FOR_EXCEPTION( true, std::logic_error,
         "  IntegratorBasic::setTempusParameterList() --  Deprecated!\n");
     }
+#endif
   //@}
 
   /// \name Accessor methods

--- a/packages/tempus/src/Tempus_IntegratorForwardSensitivity_decl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorForwardSensitivity_decl.hpp
@@ -51,7 +51,7 @@ class IntegratorForwardSensitivity
 {
 public:
 
-  /** \brief Full Constructor with model, and will be fully initialized. 
+  /** \brief Full Constructor with model, and will be fully initialized.
    *
    * \param[in] model               The forward physics ModelEvaluator
    * \param[in] integrator          Forward state Integrator
@@ -123,11 +123,15 @@ public:
   /// Perform tasks after end of integrator.
   virtual void endIntegrator()
     { integrator_->endIntegrator(); }
+#ifndef TEMPUS_HIDE_DEPRECATED_CODE
   /// Return a copy of the Tempus ParameterList
+  TEMPUS_DEPRECATED
   virtual Teuchos::RCP<Teuchos::ParameterList> getTempusParameterList() override
     { return integrator_->getTempusParameterList(); }
+  TEMPUS_DEPRECATED
   virtual void setTempusParameterList(Teuchos::RCP<Teuchos::ParameterList> pl) override
     { integrator_->setTempusParameterList(pl); }
+#endif
   //@}
 
   /// \name Accessor methods
@@ -208,11 +212,11 @@ public:
    * @brief Get the current solution, x, only. If looking for the solution
    * vector and the sensitivities, use `SolutionState->getX()` which will return a
    * Block MultiVector with the first block containing the current solution, x,
-   * and the remaining blocks are the forward sensitivities \f$dx/dp\f$. 
+   * and the remaining blocks are the forward sensitivities \f$dx/dp\f$.
    *
    * Use `getDxDp` to get the forward sensitivities \f$dx/dp\f$ only.
    *
-   * @return The current solution, x, without the sensitivities. 
+   * @return The current solution, x, without the sensitivities.
    * */
   virtual Teuchos::RCP<const Thyra::VectorBase<Scalar> > getX() const;
 
@@ -222,7 +226,7 @@ public:
    * @brief Get current the time derivative of the solution, xdot, only.  This
    * is the first block only and not the full Block MultiVector.
    *
-   * @return Get current the time derivative of the solution, xdot. 
+   * @return Get current the time derivative of the solution, xdot.
    * */
   virtual Teuchos::RCP<const Thyra::VectorBase<Scalar> > getXDot() const;
   virtual Teuchos::RCP<const Thyra::MultiVectorBase<Scalar> > getDXDotDp() const;
@@ -232,7 +236,7 @@ public:
    *
    * Use `getDXDotDp` to get the forward sensitivities.
    *
-   * @return Get current the second time derivative of the solution, xdotdot. 
+   * @return Get current the second time derivative of the solution, xdotdot.
    * */
   virtual Teuchos::RCP<const Thyra::VectorBase<Scalar> > getXDotDot() const;
   virtual Teuchos::RCP<const Thyra::MultiVectorBase<Scalar> > getDXDotDotDp() const;

--- a/packages/tempus/src/Tempus_IntegratorPseudoTransientAdjointSensitivity_decl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorPseudoTransientAdjointSensitivity_decl.hpp
@@ -141,9 +141,13 @@ public:
   virtual void setStatus(const Status st) override;
   /// Get the Stepper
   virtual Teuchos::RCP<Stepper<Scalar> > getStepper() const override;
+#ifndef TEMPUS_HIDE_DEPRECATED_CODE
   /// Return a copy of the Tempus ParameterList
+  TEMPUS_DEPRECATED
   virtual Teuchos::RCP<Teuchos::ParameterList> getTempusParameterList() override;
+  TEMPUS_DEPRECATED
   virtual void setTempusParameterList(Teuchos::RCP<Teuchos::ParameterList> pl) override;
+#endif
   /// Get the SolutionHistory
   virtual Teuchos::RCP<const SolutionHistory<Scalar> > getSolutionHistory() const override;
   /// Get the SolutionHistory

--- a/packages/tempus/src/Tempus_IntegratorPseudoTransientAdjointSensitivity_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorPseudoTransientAdjointSensitivity_impl.hpp
@@ -176,6 +176,7 @@ getStepper() const
   return state_integrator_->getStepper();
 }
 
+#ifndef TEMPUS_HIDE_DEPRECATED_CODE
 template<class Scalar>
 Teuchos::RCP<Teuchos::ParameterList>
 IntegratorPseudoTransientAdjointSensitivity<Scalar>::
@@ -193,6 +194,7 @@ setTempusParameterList(Teuchos::RCP<Teuchos::ParameterList> pl)
   sens_integrator_->setTempusParameterList(pl);
 }
 
+#endif
 template<class Scalar>
 Teuchos::RCP<const SolutionHistory<Scalar> >
 IntegratorPseudoTransientAdjointSensitivity<Scalar>::

--- a/packages/tempus/src/Tempus_IntegratorPseudoTransientForwardSensitivity_decl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorPseudoTransientForwardSensitivity_decl.hpp
@@ -123,11 +123,15 @@ public:
   virtual void setStatus(const Status st) override;
   /// Get the Stepper
   virtual Teuchos::RCP<Stepper<Scalar> > getStepper() const override;
+#ifndef TEMPUS_HIDE_DEPRECATED_CODE
   /// Return a copy of the Tempus ParameterList
+  TEMPUS_DEPRECATED
   virtual Teuchos::RCP<Teuchos::ParameterList> getTempusParameterList() override
   { return state_integrator_->getTempusParameterList(); }
+  TEMPUS_DEPRECATED
   virtual void setTempusParameterList(Teuchos::RCP<Teuchos::ParameterList> pl) override
   { state_integrator_->setTempusParameterList(pl); }
+#endif
   /// Get the SolutionHistory
   virtual Teuchos::RCP<const SolutionHistory<Scalar> > getSolutionHistory() const override;
   /// Get the SolutionHistory
@@ -190,7 +194,7 @@ protected:
  *              sensitivity model evaluator, and the sensisitivity integrator
  * @param model Physics model
  *
- * @return 
+ * @return
  */
 template<class Scalar>
 Teuchos::RCP<Tempus::IntegratorPseudoTransientForwardSensitivity<Scalar> >
@@ -203,7 +207,7 @@ createIntegratorPseudoTransientForwardSensitivity(
  * @brief Default ctor
  *
  * Instantiates a default IntegratorBasic for both the state and the sensitivity
- * integrator. 
+ * integrator.
  *
  * @return IntegratorPseudoTransientForwardSensitivity
  */

--- a/packages/tempus/src/Tempus_SolutionState_decl.hpp
+++ b/packages/tempus/src/Tempus_SolutionState_decl.hpp
@@ -67,6 +67,7 @@ public:
   SolutionState();
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
+  TEMPUS_DEPRECATED
   SolutionState(
     const Teuchos::RCP<Thyra::VectorBase<Scalar> >& x,
     const Teuchos::RCP<Thyra::VectorBase<Scalar> >& xdot    = Teuchos::null,
@@ -74,14 +75,15 @@ public:
     const Teuchos::RCP<StepperState<Scalar> >& stepperState = Teuchos::null,
     const Teuchos::RCP<PhysicsState<Scalar> >& physicsState = Teuchos::null);
 
+  TEMPUS_DEPRECATED
   SolutionState(
     const Teuchos::RCP<const Thyra::VectorBase<Scalar> >& x,
     const Teuchos::RCP<const Thyra::VectorBase<Scalar> >& xdot = Teuchos::null,
     const Teuchos::RCP<const Thyra::VectorBase<Scalar> >& xddot= Teuchos::null,
     const Teuchos::RCP<const StepperState<Scalar> >& stepperSt = Teuchos::null,
     const Teuchos::RCP<const PhysicsState<Scalar> >& physicsSt = Teuchos::null);
-#endif
 
+#endif
   SolutionState(
     const Teuchos::RCP<SolutionStateMetaData<Scalar> > ssmd,
     const Teuchos::RCP<Thyra::VectorBase<Scalar> >& x,
@@ -99,12 +101,13 @@ public:
     const Teuchos::RCP<const PhysicsState<Scalar> >& physicsState);
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
+  TEMPUS_DEPRECATED
   SolutionState(
     const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& model,
     const Teuchos::RCP<StepperState<Scalar> >& stepperState = Teuchos::null,
     const Teuchos::RCP<PhysicsState<Scalar> >& physicsState = Teuchos::null);
-#endif
 
+#endif
   /// This is a shallow copy constructor, use clone for a deep copy constructor
   SolutionState(const SolutionState<Scalar>& ss);
 

--- a/packages/tempus/src/Tempus_StepperHHTAlpha_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperHHTAlpha_impl.hpp
@@ -409,7 +409,7 @@ void StepperHHTAlpha<Scalar>::takeStep(
         Thyra::put_scalar(0.0, a_init.ptr());
       }
       wrapperModel->initializeNewmark(v_init,d_init,0.0,time,beta_,gamma_);
-      const Thyra::SolveStatus<Scalar> sStatus=this->solveImplicitODE(a_init);
+      const Thyra::SolveStatus<Scalar> sStatus=(*(this->solver_)).solve(&*a_init);
 
       workingState->setSolutionStatus(sStatus);  // Converged --> pass.
       Thyra::copy(*a_init, a_old.ptr());
@@ -439,7 +439,7 @@ void StepperHHTAlpha<Scalar>::takeStep(
       StepperHHTAlphaAppAction<Scalar>::ACTION_LOCATION::BEFORE_SOLVE);
 
     //Solve for new acceleration
-    const Thyra::SolveStatus<Scalar> sStatus = this->solveImplicitODE(a_new);
+    const Thyra::SolveStatus<Scalar> sStatus = (*(this->solver_)).solve(&*a_new);
 
     stepperHHTAlphaAppAction_->execute(solutionHistory, thisStepper,
       StepperHHTAlphaAppAction<Scalar>::ACTION_LOCATION::AFTER_SOLVE);

--- a/packages/tempus/src/Tempus_StepperImplicit_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperImplicit_decl.hpp
@@ -264,16 +264,21 @@ public:
     /// Return beta  = d(x)/dx.
     virtual Scalar getBeta (const Scalar dt) const = 0;
 
+#ifndef TEMPUS_HIDE_DEPRECATED_CODE
     /// Solve problem using x in-place.  (Needs to be deprecated!)
+    TEMPUS_DEPRECATED
     const Thyra::SolveStatus<Scalar> solveImplicitODE(
       const Teuchos::RCP<Thyra::VectorBase<Scalar> > & x);
 
+#endif
     /// Solve implicit ODE, f(x, xDot, t, p) = 0.
     const Thyra::SolveStatus<Scalar> solveImplicitODE(
       const Teuchos::RCP<Thyra::VectorBase<Scalar> > & x,
       const Teuchos::RCP<Thyra::VectorBase<Scalar> > & xDot,
       const Scalar time,
-      const Teuchos::RCP<ImplicitODEParameters<Scalar> > & p );
+      const Teuchos::RCP<ImplicitODEParameters<Scalar> > & p,
+      const Teuchos::RCP<Thyra::VectorBase<Scalar> > & y = Teuchos::null,
+      const int index = 0     /* index and y are for IMEX_RK_Partition */ );
 
     /// Evaluate implicit ODE residual, f(x, xDot, t, p).
     void evaluateImplicitODE(

--- a/packages/tempus/src/Tempus_StepperImplicit_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperImplicit_impl.hpp
@@ -237,6 +237,7 @@ void StepperImplicit<Scalar>::setSolver(
 }
 
 
+#ifndef TEMPUS_HIDE_DEPRECATED_CODE
 template<class Scalar>
 const Thyra::SolveStatus<Scalar>
 StepperImplicit<Scalar>::solveImplicitODE(
@@ -251,18 +252,22 @@ StepperImplicit<Scalar>::solveImplicitODE(
 }
 
 
+#endif
 template<class Scalar>
 const Thyra::SolveStatus<Scalar>
 StepperImplicit<Scalar>::solveImplicitODE(
   const Teuchos::RCP<Thyra::VectorBase<Scalar> > & x,
   const Teuchos::RCP<Thyra::VectorBase<Scalar> > & xDot,
   const Scalar time,
-  const Teuchos::RCP<ImplicitODEParameters<Scalar> > & p )
+  const Teuchos::RCP<ImplicitODEParameters<Scalar> > & p,
+  const Teuchos::RCP<Thyra::VectorBase<Scalar> > & y,
+  const int index                                         )
 {
   typedef Thyra::ModelEvaluatorBase MEB;
   MEB::InArgs<Scalar>  inArgs  = wrapperModel_->getInArgs();
   MEB::OutArgs<Scalar> outArgs = wrapperModel_->getOutArgs();
   inArgs.set_x(x);
+  if ( y != Teuchos::null ) inArgs.set_p(index, y);
   if (inArgs.supports(MEB::IN_ARG_x_dot    )) inArgs.set_x_dot    (xDot);
   if (inArgs.supports(MEB::IN_ARG_t        )) inArgs.set_t        (time);
   if (inArgs.supports(MEB::IN_ARG_step_size))

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitAForm_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitAForm_impl.hpp
@@ -352,7 +352,7 @@ void StepperNewmarkImplicitAForm<Scalar>::setInitialConditions(
         this->wrapperModel_);
 
     wrapperModel->initializeNewmark(xDot, x, 0.0, time, beta_, gamma_);
-    const Thyra::SolveStatus<Scalar> sStatus = this->solveImplicitODE(xDotDot);
+    const Thyra::SolveStatus<Scalar> sStatus = (*(this->solver_)).solve(&*xDotDot);
 
     TEUCHOS_TEST_FOR_EXCEPTION(
       sStatus.solveStatus != Thyra::SOLVE_STATUS_CONVERGED, std::logic_error,
@@ -482,8 +482,11 @@ void StepperNewmarkImplicitAForm<Scalar>::takeStep(
     stepperNewmarkImpAppAction_->execute(solutionHistory, thisStepper,
       StepperNewmarkImplicitAFormAppAction<Scalar>::ACTION_LOCATION::BEFORE_SOLVE);
 
+    if (this->getZeroInitialGuess())
+      Thyra::assign(a_new.ptr(), Teuchos::ScalarTraits<Scalar>::zero());
+
     // Solve nonlinear system with a_new as initial guess
-    const Thyra::SolveStatus<Scalar> sStatus = this->solveImplicitODE(a_new);
+    const Thyra::SolveStatus<Scalar> sStatus = (*(this->solver_)).solve(&*a_new);
 
     stepperNewmarkImpAppAction_->execute(solutionHistory, thisStepper,
       StepperNewmarkImplicitAFormAppAction<Scalar>::ACTION_LOCATION::AFTER_SOLVE);

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitDForm_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitDForm_impl.hpp
@@ -381,15 +381,14 @@ StepperNewmarkImplicitDForm<Scalar>::takeStep(
 
 
     //Set d_pred as initial guess for NOX solver, and solve nonlinear system.
-    const Thyra::SolveStatus<Scalar> sStatus =
-      this->solveImplicitODE(initial_guess);
+    const Thyra::SolveStatus<Scalar> sStatus = (*(this->solver_)).solve(&*initial_guess);
 
     workingState->setSolutionStatus(sStatus);  // Converged --> pass.
 
     stepperNewmarkImpAppAction_->execute(solutionHistory, thisStepper,
       StepperNewmarkImplicitDFormAppAction<Scalar>::ACTION_LOCATION::AFTER_SOLVE);
 
-    //solveImplicitODE will return converged solution in initial_guess
+    //solve will return converged solution in initial_guess
     //vector.  Copy it here to d_new, to define the new displacement.
     Thyra::copy(*initial_guess, d_new.ptr());
 

--- a/packages/tempus/src/Tempus_Stepper_decl.hpp
+++ b/packages/tempus/src/Tempus_Stepper_decl.hpp
@@ -66,6 +66,7 @@ public:
       const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel) {}
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
+    TEMPUS_DEPRECATED
     virtual void setNonConstModel(
       const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& /* appModel */){}
 

--- a/packages/tempus/src/Tempus_Stepper_impl.hpp
+++ b/packages/tempus/src/Tempus_Stepper_impl.hpp
@@ -102,7 +102,7 @@ Stepper<Scalar>::getStepperXDotDot()
   return stepperXDotDot_;
 }
 
-// Need to deprecate.
+
 template<class Scalar>
 Teuchos::RCP<Thyra::VectorBase<Scalar> >
 Stepper<Scalar>::getStepperXDotDot(Teuchos::RCP<SolutionState<Scalar> > state)

--- a/packages/tempus/src/Tempus_TimeStepControlStrategy.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategy.hpp
@@ -45,6 +45,7 @@ public:
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
   /// Deprecated get the time step size.
+  TEMPUS_DEPRECATED
   virtual void getNextTimeStep(
     const TimeStepControl<Scalar> tsc,
     Teuchos::RCP<SolutionHistory<Scalar> > sh,
@@ -52,8 +53,8 @@ public:
   {
     this->setNextTimeStep(tsc, sh, integratorStatus);
   }
-#endif
 
+#endif
   /// Set the time step size.
   virtual void setNextTimeStep(
     const TimeStepControl<Scalar> & /* tsc */,

--- a/packages/tempus/src/Tempus_TimeStepControl_decl.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControl_decl.hpp
@@ -84,14 +84,15 @@ public:
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
   /// Deprecated get the time step size.
+  TEMPUS_DEPRECATED
   virtual void getNextTimeStep(
     const Teuchos::RCP<SolutionHistory<Scalar> > & sh,
     Status & integratorStatus)
   {
     this->setNextTimeStep(sh, integratorStatus);
   };
-#endif
 
+#endif
   /** \brief Determine the time step size.*/
   virtual void setNextTimeStep(
     const Teuchos::RCP<SolutionHistory<Scalar> > & solutionHistory,


### PR DESCRIPTION
Several functions can be labelled for deprecation in preparation
for the next major release.

 * IntegratorBasic::getTempusParameterList() and
   IntegratorBasic::setTempusParameterList. IntegratorBasic is no
   longer a ParameterList Acceptor. One can still get a ParameterList
   from IntegratorBasic::getValidParameters(), but setting the
   ParameterList is essentially resetting the IntegratorBasic, so
   just recreate it with createIntegratorBasic(pl).
 * Three constructors for SolutionState. These have been replaced with
   non-member constructor functions.
 * Stepper::solveImplicitODE(x).  This has been replaced with
   Stepper::solveImplicitODE(x, xDot, t, p) which includes many
   steps needed for the solve. Some steppers are not ready for
   the new solveImplicitODE(x, xDot, t, p), so the solveImplicitODE(x)
   functionality has been inlined.
 * Stepper::setNonConstModel()
 * TimeStepControl::getNextTimeStep() and
   TimeStepControlStrategy::getNextTimeStep(). This has been
   replaced with TimeStepControlStrategy::setNextTimeStep() as it
   reflects that it sets the timestep on the SolutionState.

@trilinos/tempus 

## Related Issues

* Closes #10034 
