### PR TITLE
Zoltan2:  reduce output in GraphModel unit test

### DIFF
--- a/packages/zoltan2/test/core/unit/models/GraphModel.cpp
+++ b/packages/zoltan2/test/core/unit/models/GraphModel.cpp
@@ -241,8 +241,8 @@ void testAdapter(
     }
   }
 
-  if (nEdgeWeights > 0){
-    printf("TODO:  STILL NEED TO TEST EDGE WEIGHTS!\n");
+  if (nEdgeWeights > 0 && rank == 0){
+    std::cout << "TODO:  STILL NEED TO TEST EDGE WEIGHTS!" << std::endl;
   }
 
   // Create a matrix or graph input adapter.


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/zoltan2 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The GraphModel unit test produces spurious test failures in nightly testing.  The code executes correctly, but output of the "PASS" keyword gets interrupted by other output.  Teuchos reports a test failure when it cannot find "PASS" in the output.
This change attempts to reduce the incidence of these spurious failures by reducing the amount of output.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Compiled on mac with gcc8, openmpi 1.10.7
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->