### PR TITLE
Stokhos: Include power_of_two from Kokkos

### DIFF
--- a/packages/stokhos/src/kokkos/Stokhos_CrsProductTensor.hpp
+++ b/packages/stokhos/src/kokkos/Stokhos_CrsProductTensor.hpp
@@ -817,7 +817,7 @@ public:
                       const size_type thread_rank ) const
   {
     enum { work_align = 64 / sizeof(VectorValue) };
-    enum { work_shift = Kokkos::Impl::power_of_two< work_align >::value };
+    enum { work_shift = Stokhos::power_of_two< work_align >::value };
     enum { work_mask  = work_align - 1 };
 
     const size_type work_per_thread =

--- a/packages/stokhos/src/kokkos/Stokhos_Multiply.hpp
+++ b/packages/stokhos/src/kokkos/Stokhos_Multiply.hpp
@@ -52,6 +52,29 @@
 
 namespace Stokhos {
 
+template <size_t N>
+struct is_power_of_two {
+  enum type { value = (N > 0) && !(N & (N - 1)) };
+};
+
+template <size_t N, bool OK = is_power_of_two<N>::value>
+struct power_of_two;
+
+template <size_t N>
+struct power_of_two<N, true> {
+  enum type { value = 1 + power_of_two<(N >> 1), true>::value };
+};
+
+template <>
+struct power_of_two<2, true> {
+  enum type { value = 1 };
+};
+
+template <>
+struct power_of_two<1, true> {
+  enum type { value = 0 };
+};
+
 class DefaultMultiply {};
 
 template <unsigned> class IntegralRank {};
@@ -172,7 +195,7 @@ compute_work_range( const execution_space device,
 #endif
 
   enum { work_align = cache_line / sizeof(scalar_type) };
-  enum { work_shift = Kokkos::Impl::power_of_two< work_align >::value };
+  enum { work_shift = power_of_two< work_align >::value };
   enum { work_mask  = work_align - 1 };
 
   const size_type work_per_thread =


### PR DESCRIPTION
Kokkos removed Kokkos::Impl::power_of_two with kokkos/kokkos#4578
This update moves the routines to Stokhos for compatibility

@trilinos/stokhos

## Motivation
Compatibility change

## Related Issues
 
* Replaces #9985

## Testing
Autotester
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->