### PR TITLE
Xpetra: Fix CMake warnings about missing source file extensions

### DIFF
--- a/packages/xpetra/test/BlockedCrsMatrix/CMakeLists.txt
+++ b/packages/xpetra/test/BlockedCrsMatrix/CMakeLists.txt
@@ -4,8 +4,8 @@ IF (${PACKAGE_NAME}_ENABLE_Epetra)
   TRIBITS_ADD_EXECUTABLE_AND_TEST(
     BlockedCrsMatrix_UnitTests
     SOURCES
-      BlockedCrsMatrix_UnitTests
-      ../Xpetra_UnitTests
+      BlockedCrsMatrix_UnitTests.cpp
+      ../Xpetra_UnitTests.cpp
     COMM serial mpi
     STANDARD_PASS_OUTPUT
     )
@@ -14,8 +14,8 @@ IF (${PACKAGE_NAME}_ENABLE_Thyra)
   TRIBITS_ADD_EXECUTABLE_AND_TEST(
     ThyraBlockedOperator_UnitTests
     SOURCES
-      ThyraBlockedOperator_UnitTests
-      ../Xpetra_UnitTests
+      ThyraBlockedOperator_UnitTests.cpp
+      ../Xpetra_UnitTests.cpp
     COMM serial mpi
     STANDARD_PASS_OUTPUT
     )

--- a/packages/xpetra/test/BlockedMultiVector/CMakeLists.txt
+++ b/packages/xpetra/test/BlockedMultiVector/CMakeLists.txt
@@ -2,8 +2,8 @@
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   BlockedMultiVector_UnitTests
   SOURCES
-    BlockedMultiVector_UnitTests
-    ../Xpetra_UnitTests
+    BlockedMultiVector_UnitTests.cpp
+    ../Xpetra_UnitTests.cpp
   COMM serial mpi
   STANDARD_PASS_OUTPUT
   )
@@ -12,10 +12,9 @@ IF (${PACKAGE_NAME}_ENABLE_Thyra)
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   BlockedMultiVector_UnitTestsThyraSpecific
   SOURCES
-    ThyraBlockedMultiVector_UnitTests
-    ../Xpetra_UnitTests
+    ThyraBlockedMultiVector_UnitTests.cpp
+    ../Xpetra_UnitTests.cpp
   COMM serial mpi
   STANDARD_PASS_OUTPUT
   )
 ENDIF()
-  

--- a/packages/xpetra/test/CrsMatrix/CMakeLists.txt
+++ b/packages/xpetra/test/CrsMatrix/CMakeLists.txt
@@ -6,7 +6,7 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   CrsMatrix_UnitTests
   SOURCES
     CrsMatrix_UnitTests.cpp
-    ../Xpetra_UnitTests
+    ../Xpetra_UnitTests.cpp
   COMM serial mpi
   STANDARD_PASS_OUTPUT
   )
@@ -17,7 +17,7 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   CrsMatrixUtils_UnitTests
   SOURCES
     CrsMatrixUtils_UnitTests.cpp
-    ../Xpetra_UnitTests
+    ../Xpetra_UnitTests.cpp
   COMM serial mpi
   STANDARD_PASS_OUTPUT
   )

--- a/packages/xpetra/test/Map/CMakeLists.txt
+++ b/packages/xpetra/test/Map/CMakeLists.txt
@@ -3,8 +3,8 @@
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   Map_UnitTests
   SOURCES
-    Map_UnitTests
-    ../Xpetra_UnitTests
+    Map_UnitTests.cpp
+    ../Xpetra_UnitTests.cpp
   COMM serial mpi
   STANDARD_PASS_OUTPUT
   )
@@ -12,8 +12,8 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   Map_UnitTests2
   SOURCES
-    Map_UnitTests2
-    ../Xpetra_UnitTests
+    Map_UnitTests2.cpp
+    ../Xpetra_UnitTests.cpp
   COMM serial mpi
   STANDARD_PASS_OUTPUT
   )
@@ -21,8 +21,8 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   MapFactory_UnitTests
   SOURCES
-    MapFactory_UnitTests
-    ../Xpetra_UnitTests
+    MapFactory_UnitTests.cpp
+    ../Xpetra_UnitTests.cpp
   COMM serial mpi
   STANDARD_PASS_OUTPUT
   )
@@ -30,8 +30,8 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   StridedMap_UnitTests
   SOURCES
-    StridedMap_UnitTests
-    ../Xpetra_UnitTests
+    StridedMap_UnitTests.cpp
+    ../Xpetra_UnitTests.cpp
   COMM serial mpi
   STANDARD_PASS_OUTPUT
 )
@@ -39,9 +39,8 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   StridedMapFactory_UnitTests
   SOURCES
-    StridedMapFactory_UnitTests
-    ../Xpetra_UnitTests
+    StridedMapFactory_UnitTests.cpp
+    ../Xpetra_UnitTests.cpp
   COMM serial mpi
   STANDARD_PASS_OUTPUT
 )
-

--- a/packages/xpetra/test/MapExtractor/CMakeLists.txt
+++ b/packages/xpetra/test/MapExtractor/CMakeLists.txt
@@ -3,8 +3,8 @@
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   MapExtractorFactory_UnitTests
   SOURCES
-    MapExtractorFactory_UnitTests
-    ../Xpetra_UnitTests
+    MapExtractorFactory_UnitTests.cpp
+    ../Xpetra_UnitTests.cpp
   COMM serial mpi
   STANDARD_PASS_OUTPUT
   )

--- a/packages/xpetra/test/Matrix/CMakeLists.txt
+++ b/packages/xpetra/test/Matrix/CMakeLists.txt
@@ -4,8 +4,8 @@
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   Matrix_UnitTests
   SOURCES
-    Matrix_UnitTests
-    ../Xpetra_UnitTests
+    Matrix_UnitTests.cpp
+    ../Xpetra_UnitTests.cpp
   COMM serial mpi
   STANDARD_PASS_OUTPUT
   )

--- a/packages/xpetra/test/MatrixMatrix/CMakeLists.txt
+++ b/packages/xpetra/test/MatrixMatrix/CMakeLists.txt
@@ -3,7 +3,7 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   MatrixMatrix_UnitTests
   SOURCES
     MatrixMatrix_UnitTests.cpp
-    ../Xpetra_UnitTests
+    ../Xpetra_UnitTests.cpp
   COMM serial mpi
   STANDARD_PASS_OUTPUT
   )

--- a/packages/xpetra/test/MatrixUtils/CMakeLists.txt
+++ b/packages/xpetra/test/MatrixUtils/CMakeLists.txt
@@ -2,8 +2,8 @@
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   MatrixUtils_UnitTests
   SOURCES
-    MatrixUtils_UnitTests
-    ../Xpetra_UnitTests
+    MatrixUtils_UnitTests.cpp
+    ../Xpetra_UnitTests.cpp
   COMM serial mpi
   STANDARD_PASS_OUTPUT
   )

--- a/packages/xpetra/test/MultiVector/CMakeLists.txt
+++ b/packages/xpetra/test/MultiVector/CMakeLists.txt
@@ -3,8 +3,8 @@
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   MultiVector_UnitTests
   SOURCES
-    MultiVector_UnitTests
-    ../Xpetra_UnitTests
+    MultiVector_UnitTests.cpp
+    ../Xpetra_UnitTests.cpp
   COMM serial mpi
   STANDARD_PASS_OUTPUT
   )
@@ -13,8 +13,8 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   MultiVector_UnitTestsXpetraSpecific
   SOURCES
-    MultiVector_UnitTestsXpetraSpecific
-    ../Xpetra_UnitTests
+    MultiVector_UnitTestsXpetraSpecific.cpp
+    ../Xpetra_UnitTests.cpp
   COMM serial mpi
   STANDARD_PASS_OUTPUT
   )
@@ -24,10 +24,9 @@ IF (HAVE_XPETRA_THYRA)
   TRIBITS_ADD_EXECUTABLE_AND_TEST(
     MultiVector_UnitTestsThyraSpecific
     SOURCES
-      MultiVector_UnitTestsThyraSpecific
-      ../Xpetra_UnitTests
+      MultiVector_UnitTestsThyraSpecific.cpp
+      ../Xpetra_UnitTests.cpp
     COMM serial mpi
     STANDARD_PASS_OUTPUT
     )
 ENDIF()
-

--- a/packages/xpetra/test/Vector/CMakeLists.txt
+++ b/packages/xpetra/test/Vector/CMakeLists.txt
@@ -3,6 +3,6 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   Vector_UnitTests2
   SOURCES
     Vector_UnitTests2.cpp
-    ../Xpetra_UnitTests
+    ../Xpetra_UnitTests.cpp
   COMM serial mpi
   )


### PR DESCRIPTION
@trilinos/xpetra 

## Motivation
CMake complains about tests that have source files that don't have their extension specified.

https://cmake.org/cmake/help/git-stage/policy/CMP0115.html