### PR TITLE
Sacado:  Add overloaded function scalarValue() for extracting scalars.

### DIFF
--- a/packages/sacado/src/Sacado_Traits.hpp
+++ b/packages/sacado/src/Sacado_Traits.hpp
@@ -393,6 +393,13 @@ namespace Sacado {
     }
   };
 
+  //! A simple template function for invoking ScalarValue<>
+  template <typename T>
+  SACADO_INLINE_FUNCTION
+  typename ScalarType<T>::type scalarValue(const T& x) {
+    return ScalarValue<T>::eval(x);
+  }
+
   //! Base template specification for marking constants
   template <typename T> struct MarkConstant {
     SACADO_INLINE_FUNCTION


### PR DESCRIPTION
Sacado has always provided ScalarValue<T>::eval() for extracting the
scalar value of any Fad type, but being a class template specialization
isn't always the easiest to call (since it requires explicitly
specifying the type).  This commit adds a template function to make
it easier to call, leveraging the compilers template deduction
mechanisms.  Also added a test for it.