### PR TITLE
Finish transition from sems-xyz to sems-archive-xyz (SEHELPD-2963)

### DIFF
--- a/cmake/load_sems_dev_env.sh
+++ b/cmake/load_sems_dev_env.sh
@@ -107,6 +107,17 @@ if [ "$sems_cmake_and_version_load" = "" ] || [ "$sems_cmake_and_version_load" =
 fi
 #echo "sems_cmake_and_version_load = $sems_cmake_and_version_load"
 
+# Load sems-archive-modules-init.sh if not already loaded
+grep_modulepath=$(echo $MODULEPATH | grep /projects/sems/modulefiles/projects)
+if [[ "${grep_modulepath}" == "" ]] ; then
+  #echo "sems-archive-modules-init.sh not already called so calling!"
+  source /projects/sems/modulefiles/utils/sems-archive-modules-init.sh
+else
+  #echo "sems-archive-modules-init.sh already called!"
+  : # No-op
+fi
+
+
 #
 # B) Purge the current set of modules
 #
@@ -117,7 +128,7 @@ module purge
 # C) Load the modules (in the correct order)
 #
 
-module load sems-env
+module load sems-archive-env
 module load $sems_python_and_version_default
 module load $sems_cmake_and_version_load
 module load $sems_ninja_and_version_default
@@ -128,9 +139,9 @@ module load $sems_git_and_version_default
 # Please see https://github.com/trilinos/Trilinos/issues/2142
 # for updates regarding the right solution.
 if [[ $sems_compiler_and_version_load = "sems-intel/17.0.1" ]]; then
-  module load sems-gcc/4.9.3
+  module load sems-archive-gcc/4.9.3
 elif [[ $sems_compiler_and_version_load = "sems-intel/"* ]]; then
-  module load sems-gcc/4.8.4
+  module load sems-archive-gcc/4.8.4
 fi
 
 module load $sems_compiler_and_version_load


### PR DESCRIPTION
This completes the transition started in the commit 18c4a2015d4:

```
18c4a2015d4 "change calls for sems-[TPLname] to sems-archive-[TPLname]."
Author: Henry Swantner <HRSwant@sandia.gov>
Date:   Mon Nov 22 16:52:04 2021 -0700
```

I tested this on a CEE RHEL7 machine manually and it seems to work correctly.

Note that I had to put in special logic to load source the script:

```
  /projects/sems/modulefiles/utils/sems-archive-modules-init.sh
```

if it has not already been sourced.  This logic was the most robust test could figure out.

This should address [SEHELPD-2963](https://sems-atlassian-son.sandia.gov/jira/servicedesk/customer/portal/4/SEHELPD-2963).

## Testing

I manually tested this on a CEE RHEL7 machine and it seems to work correctly.
