### PR TITLE
ShyLU_DDD/FROSch: fix build without Tpetra deprecated code

### DIFF
--- a/packages/shylu/shylu_dd/frosch/src/CoarseSpaces/FROSch_CoarseSpace_decl.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/CoarseSpaces/FROSch_CoarseSpace_decl.hpp
@@ -44,6 +44,7 @@
 
 //#include <Xpetra_Operator_fwd.hpp>
 #include <Xpetra_MapFactory_fwd.hpp>
+#include <Xpetra_Access.hpp>
 
 #include<KokkosKernels_Utils.hpp>
 

--- a/packages/shylu/shylu_dd/frosch/src/CoarseSpaces/FROSch_CoarseSpace_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/CoarseSpaces/FROSch_CoarseSpace_def.hpp
@@ -244,7 +244,7 @@ namespace FROSch {
 
             // cout nnz
             UN nnz = 0; //Rowptr[numLocalRows];
-            Kokkos::parallel_reduce("FROSch_CoarseSpace::fillGlobalBasisMatrix:nnz", numLocalRows,
+            Kokkos::parallel_reduce("FROSch_CoarseSpace::fillGlobalBasisMatrix:nnz", 1+numLocalRows,
               KOKKOS_LAMBDA(const int &i, UN &lsum) { lsum += Rowptr[i]; },
               nnz);
 

--- a/packages/shylu/shylu_dd/frosch/src/CoarseSpaces/FROSch_CoarseSpace_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/CoarseSpaces/FROSch_CoarseSpace_def.hpp
@@ -242,12 +242,17 @@ namespace FROSch {
                 });
             Kokkos::fence();
 
+            // cout nnz
+            UN nnz = 0; //Rowptr[numLocalRows];
+            Kokkos::parallel_reduce("FROSch_CoarseSpace::fillGlobalBasisMatrix:nnz", numLocalRows,
+              KOKKOS_LAMBDA(const int &i, UN &lsum) { lsum += Rowptr[i]; },
+              nnz);
+
             // make it into offsets
             KokkosKernels::Impl::kk_inclusive_parallel_prefix_sum<rowptr_type, execution_space>
               (1+numLocalRows, Rowptr);
 
             // fill into the local matrix
-            UN nnz = Rowptr[numLocalRows];
             indices_type Indices ("Indices", nnz);
             values_type  Values  ("Values",  nnz);
             auto AssembledBasisLocalMap = AssembledBasisMap_->getLocalMap();

--- a/packages/shylu/shylu_dd/frosch/src/CoarseSpaces/FROSch_CoarseSpace_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/CoarseSpaces/FROSch_CoarseSpace_def.hpp
@@ -220,7 +220,7 @@ namespace FROSch {
 
             auto repeatedLocalMap = repeatedMap->getLocalMap();
             auto rowLocalMap = rowMap->getLocalMap();
-            auto AssembledBasisView = AssembledBasis_->getDeviceLocalView();
+            auto AssembledBasisView = AssembledBasis_->getDeviceLocalView(Access::ReadOnly);
 
             // count number of nonzeros per row
             UN numLocalRows = rowMap->getNodeNumElements();


### PR DESCRIPTION

@trilinos/shylu 

## Motivation
This PR fixes the build error of FROSch without Tpetra deprecated code


## Related Issues

* Closes #10078 


## Testing

Tested on Weaver without deprecated code

