### PR TITLE
Piro: add routines to disable initial acceleration solve in Trap. Rule stepper

### DIFF
--- a/packages/piro/src/Piro_TrapezoidRuleSolver.hpp
+++ b/packages/piro/src/Piro_TrapezoidRuleSolver.hpp
@@ -150,7 +150,10 @@ class TrapezoidRuleSolver
   Teuchos::RCP<Piro::TrapezoidDecorator<Scalar> > getDecorator() const;
   /** \brief . */
   Teuchos::RCP<Thyra::AdaptiveSolutionManager> getSolutionManager() const;
+  /** \brief .*/
+  void disableCalcInitAccel() { calc_init_accel_ = false; }; 
   //@}
+
 
 private:
   /** \name Overridden from Thyra::ModelEvaluatorDefaultBase. */
@@ -188,6 +191,7 @@ private:
    int numTimeSteps;
    Scalar t_init, t_final, delta_t;
 
+   mutable bool calc_init_accel_{true}; 
 };
 
 }

--- a/packages/piro/src/Piro_TrapezoidRuleSolver.hpp
+++ b/packages/piro/src/Piro_TrapezoidRuleSolver.hpp
@@ -152,6 +152,8 @@ class TrapezoidRuleSolver
   Teuchos::RCP<Thyra::AdaptiveSolutionManager> getSolutionManager() const;
   /** \brief .*/
   void disableCalcInitAccel() { calc_init_accel_ = false; }; 
+  /** \brief .*/
+  void enableCalcInitAccel() { calc_init_accel_ = true; }; 
   //@}
 
 

--- a/packages/piro/src/Piro_TrapezoidRuleSolver_Def.hpp
+++ b/packages/piro/src/Piro_TrapezoidRuleSolver_Def.hpp
@@ -270,7 +270,7 @@ Piro::TrapezoidRuleSolver<Scalar>::evalModelImpl(
   Teuchos::RCP<Thyra::VectorBase<Scalar> > a = soln->col(2);
   assign(a.ptr(), *model->get_x_dotdot());
   Scalar a_nrm = norm_2(*a);
-  std::cout << "IKT a_norm before = " << a_nrm << "\n"; 
+  std::cout << "IKT a_norm passed into Piro::TrapezoidalRul = " << a_nrm << "\n"; 
 
 // Note that Thyra doesn't have x_dotdot - go get it from the transient decorator around the Albany model
 //  Teuchos::RCP<Thyra::VectorBase<Scalar> > a = model->get_x_dotdot()->clone_v();
@@ -308,7 +308,7 @@ Piro::TrapezoidRuleSolver<Scalar>::evalModelImpl(
     V_StVpStV(a.ptr(), pert, *gx_out,  -pert, *x_pred_a);
     nrm = norm_2(*a);
     *out << "Calculated a_init = " << nrm << std::endl;
-    std::cout << "IKT a_norm after = " << nrm << "\n"; 
+    std::cout << "IKT a_norm after initial acceleration solve = " << nrm << "\n"; 
    }
 
    // Start integration loop
@@ -347,7 +347,6 @@ Piro::TrapezoidRuleSolver<Scalar>::evalModelImpl(
        v = soln->col(1);
        a = soln->col(2);
        nrm = norm_2(*a);
-       std::cout << "IKT a_norm before2 = " << nrm << "\n"; 
 
        x_pred_a = Thyra::createMember<Scalar>(model->get_f_space());
        x_pred_v = Thyra::createMember<Scalar>(model->get_f_space());
@@ -386,7 +385,7 @@ Piro::TrapezoidRuleSolver<Scalar>::evalModelImpl(
      // Should be equivalent to: v->Update(tdt, *x, -tdt, *x_pred_v, 0.0);
      
      nrm = norm_2(*a);
-     std::cout << "IKT a_norm after2 = " << nrm << "\n"; 
+     std::cout << "IKT a_norm after time-integration finished in Piro::TrapezoidalRule = " << nrm << "\n"; 
 
      // Observe completed time step
      if (observer != Teuchos::null) observer->observeSolution(*soln, t);

--- a/packages/piro/src/Piro_TrapezoidRuleSolver_Def.hpp
+++ b/packages/piro/src/Piro_TrapezoidRuleSolver_Def.hpp
@@ -269,8 +269,6 @@ Piro::TrapezoidRuleSolver<Scalar>::evalModelImpl(
   assign(v.ptr(), *model->getNominalValues().get_x_dot());
   Teuchos::RCP<Thyra::VectorBase<Scalar> > a = soln->col(2);
   assign(a.ptr(), *model->get_x_dotdot());
-  Scalar a_nrm = norm_2(*a);
-  std::cout << "IKT a_norm passed into Piro::TrapezoidalRul = " << a_nrm << "\n"; 
 
 // Note that Thyra doesn't have x_dotdot - go get it from the transient decorator around the Albany model
 //  Teuchos::RCP<Thyra::VectorBase<Scalar> > a = model->get_x_dotdot()->clone_v();
@@ -294,7 +292,6 @@ Piro::TrapezoidRuleSolver<Scalar>::evalModelImpl(
 
    //calculate intial acceleration using small time step (1.0e-3*delta_t)
    // AGS: Check this for inital velocity
-  std::cout << "IKT calc_init_accel_ = " << calc_init_accel_ << "\n"; 
   if (calc_init_accel_ == true) {
     Scalar pert= 1.0e6 * 4.0 / (delta_t * delta_t);
     assign(x_pred_a.ptr(), *x);
@@ -308,7 +305,6 @@ Piro::TrapezoidRuleSolver<Scalar>::evalModelImpl(
     V_StVpStV(a.ptr(), pert, *gx_out,  -pert, *x_pred_a);
     nrm = norm_2(*a);
     *out << "Calculated a_init = " << nrm << std::endl;
-    std::cout << "IKT a_norm after initial acceleration solve = " << nrm << "\n"; 
    }
 
    // Start integration loop
@@ -385,7 +381,6 @@ Piro::TrapezoidRuleSolver<Scalar>::evalModelImpl(
      // Should be equivalent to: v->Update(tdt, *x, -tdt, *x_pred_v, 0.0);
      
      nrm = norm_2(*a);
-     std::cout << "IKT a_norm after time-integration finished in Piro::TrapezoidalRule = " << nrm << "\n"; 
 
      // Observe completed time step
      if (observer != Teuchos::null) observer->observeSolution(*soln, t);


### PR DESCRIPTION
This PR adds some routines to Piro that enable one to disable the initial acceleration solve within the TrapezoidalRule stepper.  This capability is of interest to Albany-LCM.