### PR TITLE
Tempus: Fix Erroneous Warning from TimeEventComposite

### DIFF
--- a/packages/tempus/src/Tempus_IntegratorBasic_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorBasic_impl.hpp
@@ -578,6 +578,9 @@ Teuchos::RCP<IntegratorBasic<Scalar> > createIntegratorBasic(
   Teuchos::RCP<Teuchos::ParameterList>                     tempusPL,
   bool runInitialize)
 {
+  auto integrator = Teuchos::rcp(new IntegratorBasic<Scalar>());
+  if (tempusPL == Teuchos::null || tempusPL->numParams() == 0) return integrator;
+
   auto integratorName = tempusPL->get<std::string>("Integrator Name");
   auto integratorPL = Teuchos::sublist(tempusPL, integratorName, true);
 
@@ -588,7 +591,6 @@ Teuchos::RCP<IntegratorBasic<Scalar> > createIntegratorBasic(
     << "'Integrator Basic'.\n"
     << "    Integrator Type = " << integratorType << "\n");
 
-  auto integrator = Teuchos::rcp(new IntegratorBasic<Scalar>());
   integrator->setIntegratorName(integratorName);
 
   // Set Stepper

--- a/packages/tempus/src/Tempus_SolutionHistory_impl.hpp
+++ b/packages/tempus/src/Tempus_SolutionHistory_impl.hpp
@@ -709,7 +709,7 @@ Teuchos::RCP<SolutionHistory<Scalar> > createSolutionHistoryPL(
   auto sh = rcp(new SolutionHistory<Scalar>());
   sh->setName("From createSolutionHistoryPL");
 
-  if (pl == Teuchos::null) return sh;  // Return default SolutionHistory.
+  if (pl == Teuchos::null || pl->numParams() == 0) return sh;
 
   pl->validateParametersAndSetDefaults(*sh->getValidParameters());
 

--- a/packages/tempus/src/Tempus_TimeEventComposite.hpp
+++ b/packages/tempus/src/Tempus_TimeEventComposite.hpp
@@ -627,7 +627,7 @@ createTimeEventComposite(Teuchos::RCP<Teuchos::ParameterList> const& pList)
   using Teuchos::ParameterList;
 
   auto tec = Teuchos::rcp(new TimeEventComposite<Scalar>());
-  if (pList == Teuchos::null) return tec;  // Return default TimeEventComposite.
+  if (pList == Teuchos::null || pList->numParams() == 0) return tec;
 
   TEUCHOS_TEST_FOR_EXCEPTION(
     pList->get<std::string>("Type", "Composite") != "Composite",
@@ -681,7 +681,7 @@ createTimeEventComposite(Teuchos::RCP<Teuchos::ParameterList> const& pList)
         Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
       out->setOutputToRootOnly(0);
       Teuchos::OSTab ostab(out,1, "createTimeEventComposite()");
-      *out << "Warning -- Unknown Time Event Type!\n"
+      *out << "Warning -- createTimeEventComposite() - Unknown Time Event Type!\n"
            << "'Type' = '" << timeEventType << "'\n"
            << "Should call add() with this "
            << "(app-specific?) Time Event.\n" << std::endl;
@@ -693,9 +693,11 @@ createTimeEventComposite(Teuchos::RCP<Teuchos::ParameterList> const& pList)
       Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
     out->setOutputToRootOnly(0);
     Teuchos::OSTab ostab(out,1, "createTimeEventComposite()");
-    *out << "Warning -- Did not find a Tempus Time Events to create!\n"
-         << "Should call add() with this (app-specific?) "
-         << "Time Event.\n" << std::endl;
+    *out << "Warning -- createTimeEventComposite() - Did not\n"
+         << "           find/recognize any TimeEvents to create!\n"
+         << "           If there is a app-specific TimeEvent,\n"
+         << "           explicitly add it to this TimeEventComposite.\n"
+         << std::endl;
   }
 
   return tec;

--- a/packages/tempus/src/Tempus_TimeStepControlStrategyBasicVS.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategyBasicVS.hpp
@@ -293,7 +293,7 @@ createTimeStepControlStrategyBasicVS(
   std::string name = "Basic VS")
 {
   auto tscs = Teuchos::rcp(new TimeStepControlStrategyBasicVS<Scalar>());
-  if (pList == Teuchos::null) return tscs;
+  if (pList == Teuchos::null || pList->numParams() == 0) return tscs;
 
   TEUCHOS_TEST_FOR_EXCEPTION(
     pList->get<std::string>("Strategy Type", "Basic VS") != "Basic VS",

--- a/packages/tempus/src/Tempus_TimeStepControlStrategyConstant.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategyConstant.hpp
@@ -180,7 +180,7 @@ createTimeStepControlStrategyConstant(
   std::string name = "Constant")
 {
   auto tscs = Teuchos::rcp(new TimeStepControlStrategyConstant<Scalar>());
-  if (pList == Teuchos::null) return tscs;
+  if (pList == Teuchos::null || pList->numParams() == 0) return tscs;
 
   TEUCHOS_TEST_FOR_EXCEPTION(
     pList->get<std::string>("Strategy Type", "Constant") != "Constant",

--- a/packages/tempus/src/Tempus_TimeStepControlStrategyIntegralController.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategyIntegralController.hpp
@@ -289,7 +289,7 @@ createTimeStepControlStrategyIntegralController(
 {
   using Teuchos::rcp;
   auto tscs = rcp(new TimeStepControlStrategyIntegralController<Scalar>());
-  if (pList == Teuchos::null) return tscs;
+  if (pList == Teuchos::null || pList->numParams() == 0) return tscs;
 
   TEUCHOS_TEST_FOR_EXCEPTION(
     pList->get<std::string>("Strategy Type", "Integral Controller") !=

--- a/packages/tempus/test/Integrator/Tempus_IntegratorBasic_ref.xml
+++ b/packages/tempus/test/Integrator/Tempus_IntegratorBasic_ref.xml
@@ -30,11 +30,6 @@
       <Parameter docString="" id="19" isDefault="true" isUsed="true" name="Output Time List" type="string" value=""/>
       <Parameter docString="" id="23" isDefault="true" isUsed="true" name="Maximum Number of Stepper Failures" type="int" value="10"/>
       <Parameter docString="" id="24" isDefault="true" isUsed="true" name="Maximum Number of Consecutive Stepper Failures" type="int" value="5"/>
-      <ParameterList id="40" name="Time Step Control Events">
-          <Parameter docString="" id="41" isDefault="true" isUsed="true" name="Name" type="string" value="TimeEventComposite"/>
-          <Parameter docString="" id="42" isDefault="true" isUsed="true" name="Type" type="string" value="Composite"/>
-          <Parameter docString="" id="43" isDefault="true" isUsed="true" name="Time Events" type="string" value=""/>
-      </ParameterList>
       <ParameterList id="32" name="Time Step Control Strategy">
           <Parameter docString="" id="39" isDefault="true" isUsed="true" name="Strategy Type" type="string" value="Constant"/>
           <Parameter docString="" id="33" isDefault="true" isUsed="true" name="Time Step" type="double" value="1.0e+99"/>

--- a/packages/tempus/test/Integrator/Tempus_IntegratorBasic_ref2.xml
+++ b/packages/tempus/test/Integrator/Tempus_IntegratorBasic_ref2.xml
@@ -32,11 +32,6 @@
       <Parameter docString="" id="21" isDefault="true" isUsed="true" name="Output Time List" type="string" value=""/>
       <Parameter docString="" id="25" isDefault="true" isUsed="true" name="Maximum Number of Stepper Failures" type="int" value="10"/>
       <Parameter docString="" id="26" isDefault="true" isUsed="true" name="Maximum Number of Consecutive Stepper Failures" type="int" value="5"/>
-      <ParameterList id="39" name="Time Step Control Events">
-          <Parameter docString="" id="40" isDefault="true" isUsed="true" name="Name" type="string" value="TimeEventComposite"/>
-          <Parameter docString="" id="41" isDefault="true" isUsed="true" name="Type" type="string" value="Composite"/>
-          <Parameter docString="" id="42" isDefault="true" isUsed="true" name="Time Events" type="string" value=""/>
-      </ParameterList>
       <ParameterList id="32" name="Time Step Control Strategy">
           <Parameter docString="" id="20" isDefault="true" isUsed="true" name="Strategy Type" type="string" value="Constant"/>
           <Parameter docString="" id="33" isDefault="true" isUsed="true" name="Time Step" type="double" value="1.0e+99"/>

--- a/packages/tempus/unit_test/Tempus_UnitTest_TimeStepControl.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_TimeStepControl.cpp
@@ -535,7 +535,6 @@ TEUCHOS_UNIT_TEST(TimeStepControl, getValidParameters)
     std::ostringstream unusedParameters;
     pl->unused(unusedParameters);
     TEST_COMPARE ( unusedParameters.str(), ==,
-      "WARNING: Parameter \"Time Step Control Events\"    [unused] is unused\n"
       "WARNING: Parameter \"Time Step Control Strategy\"    [unused] is unused\n");
   }
 


### PR DESCRIPTION
During normal construction, TimeStepControl::getValidParameters()
could contruct a ParameterList with a TimeEventComposite sublist
without any events.  Later, createTimeEventComposite would warn
that the ParameterList did not have any TimeEvents to construct.

Fix:
 * TimeStepControl::getValidParameters() no longer contructs
   a ParameterList with an empty TimeEventComposite.
 * createTimeStepControl can now handle ParameterLists with
   the optional "Time Step Control Events" sublist.
 * Adjusted tests and unit tests to reflect these changes.
 * Added capability to handle some cases where the ParameterList
   is empty.

@trilinos/tempus 

## Motivation
See #10116.  Remove warnings that are Tempus generated.

## Related Issues
* Closes #10116 

## Stakeholder Feedback
@etphipp noted this in SPARC and will follow-up that this warning is no longer appearing.

## Testing
Tests were adjusted to account for new behavior.
