### PR TITLE
Geminga: Disable AMGX build

### DIFF
--- a/cmake/ctest/drivers/geminga/cron_driver.sh
+++ b/cmake/ctest/drivers/geminga/cron_driver.sh
@@ -124,7 +124,7 @@ env
 pushd $TRILINOS_SOURCE
 ctest -S $BUILDS_DIR/ctest_linux_nightly_mpi_release_muelu_kokkos_refactor_cuda_geminga.cmake
 # ctest -S $BUILDS_DIR/ctest_linux_nightly_mpi_release_muelu_amgx_cuda_geminga.cmake
-ctest -S $BUILDS_DIR/ctest_linux_nightly_mpi_release_muelu_cuda_no_uvm_geminga.cmake
+# ctest -S $BUILDS_DIR/ctest_linux_nightly_mpi_release_muelu_cuda_no_uvm_geminga.cmake
 popd
 
 module unload muelu-gcc

--- a/cmake/ctest/drivers/geminga/cron_driver.sh
+++ b/cmake/ctest/drivers/geminga/cron_driver.sh
@@ -123,7 +123,7 @@ env
 
 pushd $TRILINOS_SOURCE
 ctest -S $BUILDS_DIR/ctest_linux_nightly_mpi_release_muelu_kokkos_refactor_cuda_geminga.cmake
-ctest -S $BUILDS_DIR/ctest_linux_nightly_mpi_release_muelu_amgx_cuda_geminga.cmake
+# ctest -S $BUILDS_DIR/ctest_linux_nightly_mpi_release_muelu_amgx_cuda_geminga.cmake
 ctest -S $BUILDS_DIR/ctest_linux_nightly_mpi_release_muelu_cuda_no_uvm_geminga.cmake
 popd
 


### PR DESCRIPTION
@trilinos/muelu 

## Motivation
Disable the AMGX build, since it seems to crash the machine, and the no-UVM build, since it's no longer needed.