### PR TITLE
Sacado/Stokhos:  Put create_mirror() overload declarations in separate file

### DIFF
--- a/packages/sacado/src/CMakeLists.txt
+++ b/packages/sacado/src/CMakeLists.txt
@@ -308,6 +308,7 @@ SET(HEADERS ${HEADERS}
   Kokkos_DynRankView_Fad_Contiguous.hpp
   Kokkos_LayoutContiguous.hpp
   Kokkos_LayoutNatural.hpp
+  Kokkos_View_Fad_Fwd.hpp
   KokkosExp_View_Fad.hpp
   KokkosExp_View_Fad_Contiguous.hpp
   Kokkos_ViewFactory.hpp

--- a/packages/sacado/src/KokkosExp_View_Fad.hpp
+++ b/packages/sacado/src/KokkosExp_View_Fad.hpp
@@ -35,9 +35,8 @@
 
 // Only include forward declarations so any overloads appear before they
 // might be used inside Kokkos
-#include "Kokkos_Core_fwd.hpp"
+#include "Kokkos_View_Fad_Fwd.hpp"
 #include "Kokkos_Layout.hpp"
-#include "Kokkos_View.hpp"
 
 // Some definition that should exist whether the specializations exist or not
 
@@ -118,72 +117,6 @@ struct is_view_fad_contiguous< View<T,P...> > {
 };
 
 }
-
-namespace Kokkos {
-namespace Impl {
-
-// Overload view_copy for Fad View's:
-//   1.  Should be faster than using Fad directly
-//   2.  Fixes issues with hierarchical parallelism since the default
-//       implementation uses MDRangePolicy which doesn't work with hierarchical
-//       parallelism.
-// Needs to go before include of Kokkos_Core.hpp so it is in scope when
-// Kokkos_CopyViews.hpp is included by Kokkos_Core.hpp, which internally
-// calls view_copy().
-template<class DT, class ... DP,
-         class ST, class ... SP>
-typename std::enable_if< is_view_fad< Kokkos::View<DT,DP...> >::value &&
-                         is_view_fad< Kokkos::View<ST,SP...> >::value
-                       >::type
-view_copy(const Kokkos::View<DT,DP...>& dst, const Kokkos::View<ST,SP...>& src);
-
-template<class Space, class T, class ... P>
-struct MirrorType;
-
-} // namespace Impl
-
-// Declare overloads of create_mirror() so they are in scope
-// Kokkos_Core.hpp is included below
-
-template< class T , class ... P >
-inline
-typename Kokkos::View<T,P...>::HostMirror
-create_mirror(
-  const Kokkos::View<T,P...> & src,
-  typename std::enable_if<
-    ( std::is_same< typename ViewTraits<T,P...>::specialize ,
-        Kokkos::Impl::ViewSpecializeSacadoFad >::value ||
-      std::is_same< typename ViewTraits<T,P...>::specialize ,
-        Kokkos::Impl::ViewSpecializeSacadoFadContiguous >::value ) &&
-    !std::is_same< typename Kokkos::ViewTraits<T,P...>::array_layout,
-        Kokkos::LayoutStride >::value >::type * = 0);
-
-
-template< class T , class ... P >
-inline
-typename Kokkos::View<T,P...>::HostMirror
-create_mirror(
-  const Kokkos::View<T,P...> & src,
-  typename std::enable_if<
-    ( std::is_same< typename ViewTraits<T,P...>::specialize ,
-        Kokkos::Impl::ViewSpecializeSacadoFad >::value ||
-      std::is_same< typename ViewTraits<T,P...>::specialize ,
-        Kokkos::Impl::ViewSpecializeSacadoFadContiguous >::value ) &&
-    std::is_same< typename Kokkos::ViewTraits<T,P...>::array_layout,
-      Kokkos::LayoutStride >::value >::type * = 0);
-
-template<class Space, class T, class ... P>
-typename Impl::MirrorType<Space,T,P ...>::view_type
-create_mirror(
-  const Space&,
-  const Kokkos::View<T,P...> & src,
-  typename std::enable_if<
-    std::is_same< typename ViewTraits<T,P...>::specialize ,
-      Kokkos::Impl::ViewSpecializeSacadoFad >::value ||
-    std::is_same< typename ViewTraits<T,P...>::specialize ,
-      Kokkos::Impl::ViewSpecializeSacadoFadContiguous >::value >::type * = 0);
-
-} // namespace Kokkos
 
 #include "Sacado_Traits.hpp"
 #include "Kokkos_Core.hpp"

--- a/packages/sacado/src/Kokkos_View_Fad_Fwd.hpp
+++ b/packages/sacado/src/Kokkos_View_Fad_Fwd.hpp
@@ -1,0 +1,125 @@
+// @HEADER
+// ***********************************************************************
+//
+//                           Sacado Package
+//                 Copyright (2006) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// This library is free software; you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as
+// published by the Free Software Foundation; either version 2.1 of the
+// License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+// USA
+// Questions? Contact David M. Gay (dmgay@sandia.gov) or Eric T. Phipps
+// (etphipp@sandia.gov).
+//
+// ***********************************************************************
+// @HEADER
+
+#ifndef KOKKOS_VIEW_FAD_FWD_HPP
+#define KOKKOS_VIEW_FAD_FWD_HPP
+
+#include "Sacado_ConfigDefs.h"
+#if defined(HAVE_SACADO_KOKKOSCORE)
+
+// Only include forward declarations so any overloads appear before they
+// might be used inside Kokkos
+#include "Kokkos_Core_fwd.hpp"
+#include "Kokkos_View.hpp"
+
+namespace Kokkos {
+
+// Whether a given type is a view with Sacado FAD scalar type
+template <typename view_type>
+struct is_view_fad;
+
+}
+
+// Make sure the user really wants these View specializations
+#if defined(HAVE_SACADO_VIEW_SPEC) && !defined(SACADO_DISABLE_FAD_VIEW_SPEC)
+
+namespace Kokkos {
+namespace Impl {
+
+struct ViewSpecializeSacadoFad;
+struct ViewSpecializeSacadoFadContiguous;
+
+// Overload view_copy for Fad View's:
+//   1.  Should be faster than using Fad directly
+//   2.  Fixes issues with hierarchical parallelism since the default
+//       implementation uses MDRangePolicy which doesn't work with hierarchical
+//       parallelism.
+// Needs to go before include of Kokkos_Core.hpp so it is in scope when
+// Kokkos_CopyViews.hpp is included by Kokkos_Core.hpp, which internally
+// calls view_copy().
+template<class DT, class ... DP,
+         class ST, class ... SP>
+typename std::enable_if< is_view_fad< Kokkos::View<DT,DP...> >::value &&
+                         is_view_fad< Kokkos::View<ST,SP...> >::value
+                       >::type
+view_copy(const Kokkos::View<DT,DP...>& dst, const Kokkos::View<ST,SP...>& src);
+
+template<class Space, class T, class ... P>
+struct MirrorType;
+
+} // namespace Impl
+
+// Declare overloads of create_mirror() so they are in scope
+// Kokkos_Core.hpp is included later
+
+template< class T , class ... P >
+inline
+typename Kokkos::View<T,P...>::HostMirror
+create_mirror(
+  const Kokkos::View<T,P...> & src,
+  typename std::enable_if<
+    ( std::is_same< typename ViewTraits<T,P...>::specialize ,
+        Kokkos::Impl::ViewSpecializeSacadoFad >::value ||
+      std::is_same< typename ViewTraits<T,P...>::specialize ,
+        Kokkos::Impl::ViewSpecializeSacadoFadContiguous >::value ) &&
+    !std::is_same< typename Kokkos::ViewTraits<T,P...>::array_layout,
+        Kokkos::LayoutStride >::value >::type * = 0);
+
+
+template< class T , class ... P >
+inline
+typename Kokkos::View<T,P...>::HostMirror
+create_mirror(
+  const Kokkos::View<T,P...> & src,
+  typename std::enable_if<
+    ( std::is_same< typename ViewTraits<T,P...>::specialize ,
+        Kokkos::Impl::ViewSpecializeSacadoFad >::value ||
+      std::is_same< typename ViewTraits<T,P...>::specialize ,
+        Kokkos::Impl::ViewSpecializeSacadoFadContiguous >::value ) &&
+    std::is_same< typename Kokkos::ViewTraits<T,P...>::array_layout,
+      Kokkos::LayoutStride >::value >::type * = 0);
+
+template<class Space, class T, class ... P>
+typename Impl::MirrorType<Space,T,P ...>::view_type
+create_mirror(
+  const Space&,
+  const Kokkos::View<T,P...> & src,
+  typename std::enable_if<
+    std::is_same< typename ViewTraits<T,P...>::specialize ,
+      Kokkos::Impl::ViewSpecializeSacadoFad >::value ||
+    std::is_same< typename ViewTraits<T,P...>::specialize ,
+      Kokkos::Impl::ViewSpecializeSacadoFadContiguous >::value >::type * = 0);
+
+} // namespace Kokkos
+
+#endif // defined(HAVE_SACADO_VIEW_SPEC) && !defined(SACADO_DISABLE_FAD_VIEW_SPEC)
+
+#endif // defined(HAVE_SACADO_KOKKOSCORE)
+
+#endif /* #ifndef KOKKOS_VIEW_FAD_FWD_HPP */

--- a/packages/stokhos/src/CMakeLists.txt
+++ b/packages/stokhos/src/CMakeLists.txt
@@ -665,6 +665,7 @@ IF (Stokhos_ENABLE_Sacado)
       sacado/kokkos/vector/Sacado_MP_Vector_SFS_unary_func_tmpl.hpp
       sacado/kokkos/vector/Sacado_MP_Vector_SFS_binary_op_tmpl.hpp
       sacado/kokkos/vector/Sacado_MP_Vector_SFS_binary_func_tmpl.hpp
+      sacado/kokkos/vector/Kokkos_View_MP_Vector_Fwd.hpp
       sacado/kokkos/vector/Kokkos_View_MP_Vector.hpp
       sacado/kokkos/vector/KokkosExp_View_MP_Vector_Contiguous.hpp
       sacado/kokkos/vector/Kokkos_View_MP_Vector_Interlaced.hpp
@@ -709,6 +710,7 @@ IF (Stokhos_ENABLE_Sacado)
       sacado/kokkos/pce/Sacado_UQ_PCE_Imp.hpp
       sacado/kokkos/pce/Sacado_UQ_PCE_Traits.hpp
       sacado/kokkos/pce/Sacado_UQ_PCE_ScalarTraitsImp.hpp
+      sacado/kokkos/pce/Kokkos_View_UQ_PCE_Fwd.hpp
       sacado/kokkos/pce/Kokkos_View_UQ_PCE.hpp
       sacado/kokkos/pce/KokkosExp_View_UQ_PCE_Contiguous.hpp
       sacado/kokkos/pce/Kokkos_View_UQ_PCE_Utils.hpp

--- a/packages/stokhos/src/sacado/kokkos/pce/KokkosExp_View_UQ_PCE_Contiguous.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/KokkosExp_View_UQ_PCE_Contiguous.hpp
@@ -44,8 +44,7 @@
 
 // Only include forward declarations so any overloads appear before they
 // might be used inside Kokkos
-#include "Kokkos_Core_fwd.hpp"
-#include "Kokkos_View.hpp"
+#include "Kokkos_View_UQ_PCE_Fwd.hpp"
 #include "Kokkos_Layout.hpp"
 
 #include "Kokkos_AnalyzeStokhosShape.hpp"
@@ -54,22 +53,6 @@
 
 
 //----------------------------------------------------------------------------
-
-namespace Sacado {
-  namespace UQ {
-    template <typename Storage >
-    class PCE;
-  }
-}
-
-namespace Kokkos {
-
-  namespace Impl {
-    template<class Space, class T, class ... P>
-    struct MirrorType;
-  }
-
-}
 
 namespace Kokkos {
 namespace Experimental {
@@ -95,111 +78,6 @@ struct is_ViewPCEContiguous< Kokkos::View<D,P...> , Args... > {
 } // namespace Kokkos
 
 namespace Kokkos {
-
-// Declare overloads of create_mirror() so they are in scope
-// Kokkos_Core.hpp is included below
-
-template< class T , class ... P >
-inline
-typename Kokkos::View<T,P...>::HostMirror
-create_mirror(
-  const Kokkos::View<T,P...> & src,
-  typename std::enable_if<
-    std::is_same< typename ViewTraits<T,P...>::specialize ,
-      Kokkos::Experimental::Impl::ViewPCEContiguous >::value &&
-    !std::is_same< typename Kokkos::ViewTraits<T,P...>::array_layout,
-        Kokkos::LayoutStride >::value >::type * = 0);
-
-template< class T , class ... P >
-inline
-typename Kokkos::View<T,P...>::HostMirror
-create_mirror(
-  const Kokkos::View<T,P...> & src,
-  typename std::enable_if<
-    std::is_same< typename ViewTraits<T,P...>::specialize ,
-      Kokkos::Experimental::Impl::ViewPCEContiguous >::value &&
-    std::is_same< typename Kokkos::ViewTraits<T,P...>::array_layout,
-      Kokkos::LayoutStride >::value >::type * = 0);
-
-template<class Space, class T, class ... P>
-typename Impl::MirrorType<Space,T,P ...>::view_type
-create_mirror(
-  const Space&,
-  const Kokkos::View<T,P...> & src,
-  typename std::enable_if<
-    std::is_same< typename ViewTraits<T,P...>::specialize ,
-      Kokkos::Experimental::Impl::ViewPCEContiguous >::value >::type * = 0);
-
-// Overload of deep_copy for UQ::PCE views intializing to a constant scalar
-template< class DT, class ... DP >
-void deep_copy(
-  const View<DT,DP...> & view ,
-  const typename View<DT,DP...>::array_type::value_type & value
-  , typename std::enable_if<(
-  std::is_same< typename ViewTraits<DT,DP...>::specialize
-              , Kokkos::Experimental::Impl::ViewPCEContiguous >::value
-                 )>::type * = 0 );
-
-// Overload of deep_copy for UQ::PCE views intializing to a constant UQ::PCE
-template< class DT, class ... DP >
-void deep_copy(
-  const View<DT,DP...> & view ,
-  const typename View<DT,DP...>::value_type & value
-  , typename std::enable_if<(
-  std::is_same< typename ViewTraits<DT,DP...>::specialize
-              , Kokkos::Experimental::Impl::ViewPCEContiguous >::value
-                 )>::type * = 0 );
-
-// Overload of deep_copy for UQ::PCE views intializing to a constant scalar
-template< class ExecSpace , class DT, class ... DP >
-void deep_copy(
-  const ExecSpace &,
-  const View<DT,DP...> & view ,
-  const typename View<DT,DP...>::array_type::value_type & value
-  , typename std::enable_if<(
-  Kokkos::is_execution_space< ExecSpace >::value &&
-  std::is_same< typename ViewTraits<DT,DP...>::specialize
-              , Kokkos::Experimental::Impl::ViewPCEContiguous >::value
-                 )>::type * = 0 );
-
-// Overload of deep_copy for UQ::PCE views intializing to a constant UQ::PCE
-template< class ExecSpace , class DT, class ... DP >
-void deep_copy(
-  const ExecSpace &,
-  const View<DT,DP...> & view ,
-  const typename View<DT,DP...>::value_type & value
-  , typename std::enable_if<(
-  Kokkos::is_execution_space< ExecSpace >::value &&
-  std::is_same< typename ViewTraits<DT,DP...>::specialize
-              , Kokkos::Experimental::Impl::ViewPCEContiguous >::value
-                 )>::type * = 0 );
-
-/* Specialize for deep copy of UQ::PCE */
-template< class DT , class ... DP , class ST , class ... SP >
-inline
-void deep_copy( const View<DT,DP...> & dst ,
-                const View<ST,SP...> & src
-  , typename std::enable_if<(
-  std::is_same< typename ViewTraits<DT,DP...>::specialize
-              , Kokkos::Experimental::Impl::ViewPCEContiguous >::value
-  &&
-  std::is_same< typename ViewTraits<ST,SP...>::specialize
-              , Kokkos::Experimental::Impl::ViewPCEContiguous >::value
-                  )>::type * = 0 );
-
-/* Specialize for deep copy of UQ::PCE */
-template< class ExecSpace, class DT , class ... DP , class ST , class ... SP >
-inline
-void deep_copy( const ExecSpace &,
-                const View<DT,DP...> & dst ,
-                const View<ST,SP...> & src
-  , typename std::enable_if<(
-  std::is_same< typename ViewTraits<DT,DP...>::specialize
-              , Kokkos::Experimental::Impl::ViewPCEContiguous >::value
-  &&
-  std::is_same< typename ViewTraits<ST,SP...>::specialize
-              , Kokkos::Experimental::Impl::ViewPCEContiguous >::value
-                  )>::type * = 0 );
 
 template <typename T, typename ... P>
 struct is_view_uq_pce< View<T,P...> > {

--- a/packages/stokhos/src/sacado/kokkos/pce/Kokkos_View_UQ_PCE_Fwd.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/Kokkos_View_UQ_PCE_Fwd.hpp
@@ -1,0 +1,187 @@
+// @HEADER
+// ***********************************************************************
+//
+//                           Stokhos Package
+//                 Copyright (2009) Sandia Corporation
+//
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Eric T. Phipps (etphipp@sandia.gov).
+//
+// ***********************************************************************
+// @HEADER
+
+#ifndef KOKKOS_VIEW_UQ_PCE_FWD_HPP
+#define KOKKOS_VIEW_UQ_PCE_FWD_HPP
+
+// Only include forward declarations so any overloads appear before they
+// might be used inside Kokkos
+#include "Kokkos_Core_fwd.hpp"
+#include "Kokkos_View.hpp"
+
+//----------------------------------------------------------------------------
+
+namespace Sacado {
+  namespace UQ {
+    template <typename Storage >
+    class PCE;
+  }
+}
+
+namespace Kokkos {
+
+  namespace Impl {
+    template<class Space, class T, class ... P>
+    struct MirrorType;
+  }
+
+}
+
+namespace Kokkos {
+namespace Experimental {
+namespace Impl {
+
+struct ViewPCEContiguous;
+
+} // namespace Impl
+} // namespace Experimental
+} // namespace Kokkos
+
+namespace Kokkos {
+
+// Declare overloads of create_mirror() so they are in scope
+// Kokkos_Core.hpp is included below
+
+template< class T , class ... P >
+inline
+typename Kokkos::View<T,P...>::HostMirror
+create_mirror(
+  const Kokkos::View<T,P...> & src,
+  typename std::enable_if<
+    std::is_same< typename ViewTraits<T,P...>::specialize ,
+      Kokkos::Experimental::Impl::ViewPCEContiguous >::value &&
+    !std::is_same< typename Kokkos::ViewTraits<T,P...>::array_layout,
+        Kokkos::LayoutStride >::value >::type * = 0);
+
+template< class T , class ... P >
+inline
+typename Kokkos::View<T,P...>::HostMirror
+create_mirror(
+  const Kokkos::View<T,P...> & src,
+  typename std::enable_if<
+    std::is_same< typename ViewTraits<T,P...>::specialize ,
+      Kokkos::Experimental::Impl::ViewPCEContiguous >::value &&
+    std::is_same< typename Kokkos::ViewTraits<T,P...>::array_layout,
+      Kokkos::LayoutStride >::value >::type * = 0);
+
+template<class Space, class T, class ... P>
+typename Impl::MirrorType<Space,T,P ...>::view_type
+create_mirror(
+  const Space&,
+  const Kokkos::View<T,P...> & src,
+  typename std::enable_if<
+    std::is_same< typename ViewTraits<T,P...>::specialize ,
+      Kokkos::Experimental::Impl::ViewPCEContiguous >::value >::type * = 0);
+
+// Overload of deep_copy for UQ::PCE views intializing to a constant scalar
+template< class DT, class ... DP >
+void deep_copy(
+  const View<DT,DP...> & view ,
+  const typename View<DT,DP...>::array_type::value_type & value
+  , typename std::enable_if<(
+  std::is_same< typename ViewTraits<DT,DP...>::specialize
+              , Kokkos::Experimental::Impl::ViewPCEContiguous >::value
+                 )>::type * = 0 );
+
+// Overload of deep_copy for UQ::PCE views intializing to a constant UQ::PCE
+template< class DT, class ... DP >
+void deep_copy(
+  const View<DT,DP...> & view ,
+  const typename View<DT,DP...>::value_type & value
+  , typename std::enable_if<(
+  std::is_same< typename ViewTraits<DT,DP...>::specialize
+              , Kokkos::Experimental::Impl::ViewPCEContiguous >::value
+                 )>::type * = 0 );
+
+// Overload of deep_copy for UQ::PCE views intializing to a constant scalar
+template< class ExecSpace , class DT, class ... DP >
+void deep_copy(
+  const ExecSpace &,
+  const View<DT,DP...> & view ,
+  const typename View<DT,DP...>::array_type::value_type & value
+  , typename std::enable_if<(
+  Kokkos::is_execution_space< ExecSpace >::value &&
+  std::is_same< typename ViewTraits<DT,DP...>::specialize
+              , Kokkos::Experimental::Impl::ViewPCEContiguous >::value
+                 )>::type * = 0 );
+
+// Overload of deep_copy for UQ::PCE views intializing to a constant UQ::PCE
+template< class ExecSpace , class DT, class ... DP >
+void deep_copy(
+  const ExecSpace &,
+  const View<DT,DP...> & view ,
+  const typename View<DT,DP...>::value_type & value
+  , typename std::enable_if<(
+  Kokkos::is_execution_space< ExecSpace >::value &&
+  std::is_same< typename ViewTraits<DT,DP...>::specialize
+              , Kokkos::Experimental::Impl::ViewPCEContiguous >::value
+                 )>::type * = 0 );
+
+/* Specialize for deep copy of UQ::PCE */
+template< class DT , class ... DP , class ST , class ... SP >
+inline
+void deep_copy( const View<DT,DP...> & dst ,
+                const View<ST,SP...> & src
+  , typename std::enable_if<(
+  std::is_same< typename ViewTraits<DT,DP...>::specialize
+              , Kokkos::Experimental::Impl::ViewPCEContiguous >::value
+  &&
+  std::is_same< typename ViewTraits<ST,SP...>::specialize
+              , Kokkos::Experimental::Impl::ViewPCEContiguous >::value
+                  )>::type * = 0 );
+
+/* Specialize for deep copy of UQ::PCE */
+template< class ExecSpace, class DT , class ... DP , class ST , class ... SP >
+inline
+void deep_copy( const ExecSpace &,
+                const View<DT,DP...> & dst ,
+                const View<ST,SP...> & src
+  , typename std::enable_if<(
+  std::is_same< typename ViewTraits<DT,DP...>::specialize
+              , Kokkos::Experimental::Impl::ViewPCEContiguous >::value
+  &&
+  std::is_same< typename ViewTraits<ST,SP...>::specialize
+              , Kokkos::Experimental::Impl::ViewPCEContiguous >::value
+                  )>::type * = 0 );
+
+} // namespace Kokkos
+
+#endif /* #ifndef KOKKOS_VIEW_UQ_PCE_FWD_HPP */

--- a/packages/stokhos/src/sacado/kokkos/vector/KokkosExp_View_MP_Vector_Contiguous.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/KokkosExp_View_MP_Vector_Contiguous.hpp
@@ -42,29 +42,14 @@
 #ifndef KOKKOS_EXPERIMENTAL_VIEW_MP_VECTOR_CONTIGUOUS_HPP
 #define KOKKOS_EXPERIMENTAL_VIEW_MP_VECTOR_CONTIGUOUS_HPP
 
-#include "Sacado_Traits.hpp"
-#include "Sacado_MP_Vector.hpp"
-#include "Sacado_MP_VectorTraits.hpp"
-
 // Only include forward declarations so any overloads appear before they
 // might be used inside Kokkos
-#include "Kokkos_Core_fwd.hpp"
-#include "Kokkos_View.hpp"
+#include "Kokkos_View_MP_Vector_Fwd.hpp"
 #include "Kokkos_Layout.hpp"
 #include "Kokkos_View_Utils.hpp"
 #include "Kokkos_View_MP_Vector_Utils.hpp"
 
-
 //----------------------------------------------------------------------------
-
-namespace Kokkos {
-
-  namespace Impl {
-    template<class Space, class T, class ... P>
-    struct MirrorType;
-  }
-
-}
 
 namespace Kokkos {
 namespace Experimental {
@@ -107,115 +92,13 @@ dimension_scalar(const View<T,P...>& view) {
   return view.impl_map().dimension_scalar();
 }
 
-// Declare overloads of create_mirror() so they are in scope
-// Kokkos_Core.hpp is included below
-
-template< class T , class ... P >
-inline
-typename Kokkos::View<T,P...>::HostMirror
-create_mirror(
-  const Kokkos::View<T,P...> & src,
-  typename std::enable_if<
-    std::is_same< typename ViewTraits<T,P...>::specialize ,
-      Kokkos::Experimental::Impl::ViewMPVectorContiguous >::value &&
-    !std::is_same< typename Kokkos::ViewTraits<T,P...>::array_layout,
-        Kokkos::LayoutStride >::value >::type * = 0);
-
-template< class T , class ... P >
-inline
-typename Kokkos::View<T,P...>::HostMirror
-create_mirror(
-  const Kokkos::View<T,P...> & src,
-  typename std::enable_if<
-    std::is_same< typename ViewTraits<T,P...>::specialize ,
-      Kokkos::Experimental::Impl::ViewMPVectorContiguous >::value &&
-    std::is_same< typename Kokkos::ViewTraits<T,P...>::array_layout,
-      Kokkos::LayoutStride >::value >::type * = 0);
-
-template<class Space, class T, class ... P>
-typename Impl::MirrorType<Space,T,P ...>::view_type
-create_mirror(
-  const Space&,
-  const Kokkos::View<T,P...> & src,
-  typename std::enable_if<
-    std::is_same< typename ViewTraits<T,P...>::specialize ,
-      Kokkos::Experimental::Impl::ViewMPVectorContiguous >::value >::type * = 0);
-
-// Overload of deep_copy for MP::Vector views intializing to a constant scalar
-template< class DT, class ... DP >
-void deep_copy(
-  const View<DT,DP...> & view ,
-  const typename View<DT,DP...>::array_type::value_type & value
-  , typename std::enable_if<(
-  std::is_same< typename ViewTraits<DT,DP...>::specialize
-              , Kokkos::Experimental::Impl::ViewMPVectorContiguous >::value
-                 )>::type * = 0 );
-
-// Overload of deep_copy for MP::Vector views intializing to a constant MP::Vector
-template< class DT, class ... DP >
-void deep_copy(
-  const View<DT,DP...> & view ,
-  const typename View<DT,DP...>::value_type & value
-  , typename std::enable_if<(
-  std::is_same< typename ViewTraits<DT,DP...>::specialize
-              , Kokkos::Experimental::Impl::ViewMPVectorContiguous >::value
-                 )>::type * = 0 );
-
-// Overload of deep_copy for MP::Vector views intializing to a constant scalar
-template< class ExecSpace , class DT, class ... DP >
-void deep_copy(
-  const ExecSpace &,
-  const View<DT,DP...> & view ,
-  const typename View<DT,DP...>::array_type::value_type & value
-  , typename std::enable_if<(
-  Kokkos::is_execution_space< ExecSpace >::value &&
-  std::is_same< typename ViewTraits<DT,DP...>::specialize
-              , Kokkos::Experimental::Impl::ViewMPVectorContiguous >::value
-                 )>::type * = 0 );
-
-// Overload of deep_copy for MP::Vector views intializing to a constant MP::Vector
-template< class ExecSpace , class DT, class ... DP >
-void deep_copy(
-  const ExecSpace &,
-  const View<DT,DP...> & view ,
-  const typename View<DT,DP...>::value_type & value
-  , typename std::enable_if<(
-  Kokkos::is_execution_space< ExecSpace >::value &&
-  std::is_same< typename ViewTraits<DT,DP...>::specialize
-              , Kokkos::Experimental::Impl::ViewMPVectorContiguous >::value
-                 )>::type * = 0 );
-
-/* Specialize for deep copy of MP::Vector */
-template< class DT , class ... DP , class ST , class ... SP >
-inline
-void deep_copy( const View<DT,DP...> & dst ,
-                const View<ST,SP...> & src
-  , typename std::enable_if<(
-  std::is_same< typename ViewTraits<DT,DP...>::specialize
-              , Kokkos::Experimental::Impl::ViewMPVectorContiguous >::value
-  &&
-  std::is_same< typename ViewTraits<ST,SP...>::specialize
-              , Kokkos::Experimental::Impl::ViewMPVectorContiguous >::value
-    )>::type * = 0 );
-
-/* Specialize for deep copy of MP::Vector */
-template< class ExecSpace, class DT , class ... DP , class ST , class ... SP >
-inline
-void deep_copy( const ExecSpace &,
-                const View<DT,DP...> & dst ,
-                const View<ST,SP...> & src
-  , typename std::enable_if<(
-  std::is_same< typename ViewTraits<DT,DP...>::specialize
-              , Kokkos::Experimental::Impl::ViewMPVectorContiguous >::value
-  &&
-  std::is_same< typename ViewTraits<ST,SP...>::specialize
-              , Kokkos::Experimental::Impl::ViewMPVectorContiguous >::value
-    )>::type * = 0 );
-
 } // namespace Kokkos
 
 //----------------------------------------------------------------------------
 
+#include "Sacado_Traits.hpp"
+#include "Sacado_MP_Vector.hpp"
+#include "Sacado_MP_VectorTraits.hpp"
 #include "Kokkos_Core.hpp"
 
 namespace Kokkos {

--- a/packages/stokhos/src/sacado/kokkos/vector/Kokkos_View_MP_Vector_Fwd.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/Kokkos_View_MP_Vector_Fwd.hpp
@@ -1,0 +1,187 @@
+// @HEADER
+// ***********************************************************************
+//
+//                           Stokhos Package
+//                 Copyright (2009) Sandia Corporation
+//
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Eric T. Phipps (etphipp@sandia.gov).
+//
+// ***********************************************************************
+// @HEADER
+
+#ifndef KOKKOS_VIEW_MP_VECTOR_FWD_HPP
+#define KOKKOS_VIEW_MP_VECTOR_FWD_HPP
+
+// Only include forward declarations so any overloads appear before they
+// might be used inside Kokkos
+#include "Kokkos_Core_fwd.hpp"
+#include "Kokkos_View.hpp"
+
+//----------------------------------------------------------------------------
+
+namespace Sacado {
+  namespace MP {
+    template <typename Storage >
+    class Vector;
+  }
+}
+
+namespace Kokkos {
+
+  namespace Impl {
+    template<class Space, class T, class ... P>
+    struct MirrorType;
+  }
+
+}
+
+namespace Kokkos {
+namespace Experimental {
+namespace Impl {
+
+struct ViewMPVectorContiguous;
+
+} // namespace Impl
+} // namespace Experimental
+} // namespace Kokkos
+
+namespace Kokkos {
+
+// Declare overloads of create_mirror() so they are in scope
+// Kokkos_Core.hpp is included below
+
+template< class T , class ... P >
+inline
+typename Kokkos::View<T,P...>::HostMirror
+create_mirror(
+  const Kokkos::View<T,P...> & src,
+  typename std::enable_if<
+    std::is_same< typename ViewTraits<T,P...>::specialize ,
+      Kokkos::Experimental::Impl::ViewMPVectorContiguous >::value &&
+    !std::is_same< typename Kokkos::ViewTraits<T,P...>::array_layout,
+        Kokkos::LayoutStride >::value >::type * = 0);
+
+template< class T , class ... P >
+inline
+typename Kokkos::View<T,P...>::HostMirror
+create_mirror(
+  const Kokkos::View<T,P...> & src,
+  typename std::enable_if<
+    std::is_same< typename ViewTraits<T,P...>::specialize ,
+      Kokkos::Experimental::Impl::ViewMPVectorContiguous >::value &&
+    std::is_same< typename Kokkos::ViewTraits<T,P...>::array_layout,
+      Kokkos::LayoutStride >::value >::type * = 0);
+
+template<class Space, class T, class ... P>
+typename Impl::MirrorType<Space,T,P ...>::view_type
+create_mirror(
+  const Space&,
+  const Kokkos::View<T,P...> & src,
+  typename std::enable_if<
+    std::is_same< typename ViewTraits<T,P...>::specialize ,
+      Kokkos::Experimental::Impl::ViewMPVectorContiguous >::value >::type * = 0);
+
+// Overload of deep_copy for MP::Vector views intializing to a constant scalar
+template< class DT, class ... DP >
+void deep_copy(
+  const View<DT,DP...> & view ,
+  const typename View<DT,DP...>::array_type::value_type & value
+  , typename std::enable_if<(
+  std::is_same< typename ViewTraits<DT,DP...>::specialize
+              , Kokkos::Experimental::Impl::ViewMPVectorContiguous >::value
+                 )>::type * = 0 );
+
+// Overload of deep_copy for MP::Vector views intializing to a constant MP::Vector
+template< class DT, class ... DP >
+void deep_copy(
+  const View<DT,DP...> & view ,
+  const typename View<DT,DP...>::value_type & value
+  , typename std::enable_if<(
+  std::is_same< typename ViewTraits<DT,DP...>::specialize
+              , Kokkos::Experimental::Impl::ViewMPVectorContiguous >::value
+                 )>::type * = 0 );
+
+// Overload of deep_copy for MP::Vector views intializing to a constant scalar
+template< class ExecSpace , class DT, class ... DP >
+void deep_copy(
+  const ExecSpace &,
+  const View<DT,DP...> & view ,
+  const typename View<DT,DP...>::array_type::value_type & value
+  , typename std::enable_if<(
+  Kokkos::is_execution_space< ExecSpace >::value &&
+  std::is_same< typename ViewTraits<DT,DP...>::specialize
+              , Kokkos::Experimental::Impl::ViewMPVectorContiguous >::value
+                 )>::type * = 0 );
+
+// Overload of deep_copy for MP::Vector views intializing to a constant MP::Vector
+template< class ExecSpace , class DT, class ... DP >
+void deep_copy(
+  const ExecSpace &,
+  const View<DT,DP...> & view ,
+  const typename View<DT,DP...>::value_type & value
+  , typename std::enable_if<(
+  Kokkos::is_execution_space< ExecSpace >::value &&
+  std::is_same< typename ViewTraits<DT,DP...>::specialize
+              , Kokkos::Experimental::Impl::ViewMPVectorContiguous >::value
+                 )>::type * = 0 );
+
+/* Specialize for deep copy of MP::Vector */
+template< class DT , class ... DP , class ST , class ... SP >
+inline
+void deep_copy( const View<DT,DP...> & dst ,
+                const View<ST,SP...> & src
+  , typename std::enable_if<(
+  std::is_same< typename ViewTraits<DT,DP...>::specialize
+              , Kokkos::Experimental::Impl::ViewMPVectorContiguous >::value
+  &&
+  std::is_same< typename ViewTraits<ST,SP...>::specialize
+              , Kokkos::Experimental::Impl::ViewMPVectorContiguous >::value
+    )>::type * = 0 );
+
+/* Specialize for deep copy of MP::Vector */
+template< class ExecSpace, class DT , class ... DP , class ST , class ... SP >
+inline
+void deep_copy( const ExecSpace &,
+                const View<DT,DP...> & dst ,
+                const View<ST,SP...> & src
+  , typename std::enable_if<(
+  std::is_same< typename ViewTraits<DT,DP...>::specialize
+              , Kokkos::Experimental::Impl::ViewMPVectorContiguous >::value
+  &&
+  std::is_same< typename ViewTraits<ST,SP...>::specialize
+              , Kokkos::Experimental::Impl::ViewMPVectorContiguous >::value
+    )>::type * = 0 );
+
+} // namespace Kokkos
+
+#endif /* #ifndef KOKKOS_VIEW_MP_VECTOR_FWD_HPP */

--- a/packages/stokhos/src/sacado/kokkos/vector/Sacado_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/Sacado_MP_Vector.hpp
@@ -59,6 +59,7 @@
 #include "Stokhos_mpl_for_each.hpp"
 #include "Stokhos_MemoryTraits.hpp"
 #include "Stokhos_Is_Constant.hpp"
+#include "Stokhos_ViewStorage.hpp"
 
 #include "Kokkos_View_Utils.hpp"
 

--- a/packages/stokhos/test/UnitTest/Stokhos_KokkosViewFadMPVectorUnitTest.hpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_KokkosViewFadMPVectorUnitTest.hpp
@@ -43,6 +43,7 @@
 #include "Teuchos_UnitTestHelpers.hpp"
 #include "Stokhos_UnitTestHelpers.hpp"
 
+#include "Kokkos_View_Fad_Fwd.hpp"
 #include "Stokhos_Sacado_Kokkos_MP_Vector.hpp"
 #include "Stokhos_Ensemble_Sizes.hpp"
 #include "Sacado.hpp"

--- a/packages/trilinoscouplings/examples/fenl/main_pce.cpp
+++ b/packages/trilinoscouplings/examples/fenl/main_pce.cpp
@@ -1,3 +1,5 @@
+#include "Kokkos_View_MP_Vector_Fwd.hpp"
+#include "Kokkos_View_UQ_PCE_Fwd.hpp"
 #include "Stokhos_Sacado_Kokkos_UQ_PCE.hpp"
 #include "Stokhos_Sacado_Kokkos_MP_Vector.hpp"
 #include "Stokhos.hpp"


### PR DESCRIPTION
This allows for the proper include order when including multiple
Sacado/Stokhos scalar types in the same file, since all of the
create_mirror() overloads need to be declared before
Kokkos_CopyViews.hpp is included.  Fixes build errors in Stokhos and
TrilinosCouplings for CUDA when UVM is disabled.