### PR TITLE
Implementing fix to resolve compilation error in Amesos2 with SuperLU 5 and clang 12

### DIFF
--- a/packages/amesos2/src/Amesos2_Superlu_FunctionMap.hpp
+++ b/packages/amesos2/src/Amesos2_Superlu_FunctionMap.hpp
@@ -99,28 +99,6 @@ at_plus_a(
       extern void sgscon (char *, SuperMatrix *, SuperMatrix *,
                           float, float *, SuperLUStat_t*, int *);
 
-#ifdef HAVE_AMESOS2_SUPERLU5_API
-		typedef struct {
-			int     *xsup;    /* supernode and column mapping */
-			int     *supno;
-			int     *lsub;    /* compressed L subscripts */
-			int     *xlsub;
-			float  *lusup;   /* L supernodes */
-			int     *xlusup;
-			float  *ucol;    /* U columns */
-			int     *usub;
-			int     *xusub;
-			int     nzlmax;   /* current max size of lsub */
-			int     nzumax;   /*    "    "    "      ucol */
-			int     nzlumax;  /*    "    "    "     lusup */
-			int     n;        /* number of columns in the matrix */
-			LU_space_t MemModel; /* 0 - system malloc'd; 1 - user provided */
-			int     num_expansions;
-			ExpHeader *expanders; /* Array of pointers to 4 types of memory */
-			LU_stack_t stack;     /* use user supplied memory */
-		} GlobalLU_t;
-#endif
-
       extern void
       sCompRow_to_CompCol(int, int, int, float*, int*, int*,
              float **, int **, int **);
@@ -130,7 +108,7 @@ at_plus_a(
              void *, int, SLU::SuperMatrix *, SLU::SuperMatrix *,
              float *, float *, float *, float *,
 #ifdef HAVE_AMESOS2_SUPERLU5_API
-             GlobalLU_t*,
+             SLU::GlobalLU_t*,
 #endif
              SLU::mem_usage_t *, SLU::SuperLUStat_t *, int *);
       extern void
@@ -138,7 +116,7 @@ at_plus_a(
               int, int, int*, void *, int, int *, int *,
               SLU::SuperMatrix *, SLU::SuperMatrix *, 
 #ifdef HAVE_AMESOS2_SUPERLU5_API
-              GlobalLU_t*,
+              SLU::GlobalLU_t*,
 #endif
               SLU::SuperLUStat_t*, int *);
       extern void
@@ -147,7 +125,7 @@ at_plus_a(
              void *, int, SLU::SuperMatrix *, SLU::SuperMatrix *,
              float *, float *, 
 #ifdef HAVE_AMESOS2_SUPERLU5_API
-             GlobalLU_t*,
+             SLU::GlobalLU_t*,
 #endif
              SLU::mem_usage_t *, SLU::SuperLUStat_t *, int *);
       extern void
@@ -155,7 +133,7 @@ at_plus_a(
               int, int, int*, void *, int, int *, int *,
               SLU::SuperMatrix *, SLU::SuperMatrix *, 
 #ifdef HAVE_AMESOS2_SUPERLU5_API
-              GlobalLU_t*,
+              SLU::GlobalLU_t*,
 #endif
               SLU::SuperLUStat_t*, int *);
       extern void
@@ -186,28 +164,6 @@ at_plus_a(
       extern void dgscon (char *, SuperMatrix *, SuperMatrix *,
                           double, double *, SuperLUStat_t*, int *);
 
-#ifdef HAVE_AMESOS2_SUPERLU5_API
-		typedef struct {
-			int     *xsup;    /* supernode and column mapping */
-			int     *supno;
-			int     *lsub;    /* compressed L subscripts */
-			int     *xlsub;
-			double  *lusup;   /* L supernodes */
-			int     *xlusup;
-			double  *ucol;    /* U columns */
-			int     *usub;
-			int     *xusub;
-			int     nzlmax;   /* current max size of lsub */
-			int     nzumax;   /*    "    "    "      ucol */
-			int     nzlumax;  /*    "    "    "     lusup */
-			int     n;        /* number of columns in the matrix */
-			LU_space_t MemModel; /* 0 - system malloc'd; 1 - user provided */
-			int     num_expansions;
-			ExpHeader *expanders; /* Array of pointers to 4 types of memory */
-			LU_stack_t stack;     /* use user supplied memory */
-		} GlobalLU_t;
-#endif
-
       extern void
       dCompRow_to_CompCol(int, int, int, double*, int*, int*,
              double **, int **, int **);
@@ -217,7 +173,7 @@ at_plus_a(
              void *, int, SLU::SuperMatrix *, SLU::SuperMatrix *,
              double *, double *, double *, double *,
 #ifdef HAVE_AMESOS2_SUPERLU5_API
-             GlobalLU_t*,
+             SLU::GlobalLU_t*,
 #endif
              SLU::mem_usage_t *, SLU::SuperLUStat_t *, int *);
       extern void
@@ -225,7 +181,7 @@ at_plus_a(
               int, int, int*, void *, int, int *, int *,
               SLU::SuperMatrix *, SLU::SuperMatrix *, 
 #ifdef HAVE_AMESOS2_SUPERLU5_API
-              GlobalLU_t*,
+              SLU::GlobalLU_t*,
 #endif
               SLU::SuperLUStat_t*, int *);
       extern void
@@ -234,7 +190,7 @@ at_plus_a(
              void *, int, SLU::SuperMatrix *, SLU::SuperMatrix *,
              double *, double *, 
 #ifdef HAVE_AMESOS2_SUPERLU5_API
-             GlobalLU_t*,
+             SLU::GlobalLU_t*,
 #endif
              SLU::mem_usage_t *, SLU::SuperLUStat_t *, int *);
       extern void
@@ -242,7 +198,7 @@ at_plus_a(
               int, int, int*, void *, int, int *, int *,
               SLU::SuperMatrix *, SLU::SuperMatrix *, 
 #ifdef HAVE_AMESOS2_SUPERLU5_API
-              GlobalLU_t*,
+              SLU::GlobalLU_t*,
 #endif
               SLU::SuperLUStat_t*, int *);
       extern void
@@ -274,28 +230,6 @@ at_plus_a(
       extern void cgscon (char *, SuperMatrix *, SuperMatrix *,
                           float, float *, SuperLUStat_t*, int *);
 
-#ifdef HAVE_AMESOS2_SUPERLU5_API
-		typedef struct {
-			int     *xsup;    /* supernode and column mapping */
-			int     *supno;
-			int     *lsub;    /* compressed L subscripts */
-			int     *xlsub;
-			complex  *lusup;   /* L supernodes */
-			int     *xlusup;
-			complex  *ucol;    /* U columns */
-			int     *usub;
-			int     *xusub;
-			int     nzlmax;   /* current max size of lsub */
-			int     nzumax;   /*    "    "    "      ucol */
-			int     nzlumax;  /*    "    "    "     lusup */
-			int     n;        /* number of columns in the matrix */
-			LU_space_t MemModel; /* 0 - system malloc'd; 1 - user provided */
-			int     num_expansions;
-			ExpHeader *expanders; /* Array of pointers to 4 types of memory */
-			LU_stack_t stack;     /* use user supplied memory */
-		} GlobalLU_t;
-#endif
-
       extern void
       cCompRow_to_CompCol(int, int, int, complex*, int*, int*,
             complex **, int **, int **);
@@ -305,7 +239,7 @@ at_plus_a(
              void *, int, SLU::SuperMatrix *, SLU::SuperMatrix *,
              float *, float *, float *, float *,
 #ifdef HAVE_AMESOS2_SUPERLU5_API
-             GlobalLU_t*,
+             SLU::GlobalLU_t*,
 #endif
              SLU::mem_usage_t *, SLU::SuperLUStat_t *, int *);
       extern void
@@ -313,7 +247,7 @@ at_plus_a(
               int, int, int*, void *, int, int *, int *,
               SLU::SuperMatrix *, SLU::SuperMatrix *, 
 #ifdef HAVE_AMESOS2_SUPERLU5_API
-             GlobalLU_t*,
+             SLU::GlobalLU_t*,
 #endif
               SLU::SuperLUStat_t*, int *);
       extern void
@@ -322,7 +256,7 @@ at_plus_a(
              void *, int, SLU::SuperMatrix *, SLU::SuperMatrix *,
              float *, float *, 
 #ifdef HAVE_AMESOS2_SUPERLU5_API
-             GlobalLU_t*,
+             SLU::GlobalLU_t*,
 #endif
              SLU::mem_usage_t *, SLU::SuperLUStat_t *, int *);
       extern void
@@ -330,7 +264,7 @@ at_plus_a(
               int, int, int*, void *, int, int *, int *,
               SLU::SuperMatrix *, SLU::SuperMatrix *, 
 #ifdef HAVE_AMESOS2_SUPERLU5_API
-              GlobalLU_t*,
+              SLU::GlobalLU_t*,
 #endif
               SLU::SuperLUStat_t*, int *);
       extern void
@@ -361,28 +295,6 @@ at_plus_a(
       extern void zgscon (char *, SuperMatrix *, SuperMatrix *,
                           double, double *, SuperLUStat_t*, int *);
 
-#ifdef HAVE_AMESOS2_SUPERLU5_API
-		typedef struct {
-			int     *xsup;    /* supernode and column mapping */
-			int     *supno;
-			int     *lsub;    /* compressed L subscripts */
-			int     *xlsub;
-			doublecomplex  *lusup;   /* L supernodes */
-			int     *xlusup;
-			doublecomplex  *ucol;    /* U columns */
-			int     *usub;
-			int     *xusub;
-			int     nzlmax;   /* current max size of lsub */
-			int     nzumax;   /*    "    "    "      ucol */
-			int     nzlumax;  /*    "    "    "     lusup */
-			int     n;        /* number of columns in the matrix */
-			LU_space_t MemModel; /* 0 - system malloc'd; 1 - user provided */
-			int     num_expansions;
-			ExpHeader *expanders; /* Array of pointers to 4 types of memory */
-			LU_stack_t stack;     /* use user supplied memory */
-		} GlobalLU_t;
-#endif
-
       extern void
       zCompRow_to_CompCol(int, int, int, doublecomplex*, int*, int*,
             doublecomplex **, int **, int **);
@@ -392,7 +304,7 @@ at_plus_a(
              void *, int, SLU::SuperMatrix *, SLU::SuperMatrix *,
              double *, double *, double *, double *,
 #ifdef HAVE_AMESOS2_SUPERLU5_API
-             GlobalLU_t*,
+             SLU::GlobalLU_t*,
 #endif
              SLU::mem_usage_t *, SLU::SuperLUStat_t *, int *);
       extern void
@@ -400,7 +312,7 @@ at_plus_a(
               int, int, int*, void *, int, int *, int *,
               SLU::SuperMatrix *, SLU::SuperMatrix *, 
 #ifdef HAVE_AMESOS2_SUPERLU5_API
-             GlobalLU_t*,
+             SLU::GlobalLU_t*,
 #endif
               SLU::SuperLUStat_t*, int *);
       extern void
@@ -409,7 +321,7 @@ at_plus_a(
              void *, int, SLU::SuperMatrix *, SLU::SuperMatrix *,
              double *, double *, 
 #ifdef HAVE_AMESOS2_SUPERLU5_API
-             GlobalLU_t*,
+             SLU::GlobalLU_t*,
 #endif
              SLU::mem_usage_t *, SLU::SuperLUStat_t *, int *);
       extern void
@@ -417,7 +329,7 @@ at_plus_a(
               int, int, int*, void *, int, int *, int *,
               SLU::SuperMatrix *, SLU::SuperMatrix *, 
 #ifdef HAVE_AMESOS2_SUPERLU5_API
-              GlobalLU_t*,
+              SLU::GlobalLU_t*,
 #endif
               SLU::SuperLUStat_t*, int *);
       extern void
@@ -482,10 +394,6 @@ namespace Amesos2 {
   {
     typedef TypeMap<Superlu,float> type_map;
 
-#ifdef HAVE_AMESOS2_SUPERLU5_API
-    typedef typename SLU::S::GlobalLU_t GlobalLU_type;
-#endif
-
     static float langs(char *norm, SLU::SuperMatrix *A)
     {
       return SLU::S::slangs(norm, A);
@@ -506,7 +414,7 @@ namespace Amesos2 {
 		      SLU::SuperMatrix* B, SLU::SuperMatrix* X, float* recip_pivot_growth,
 		      float* rcond, float* ferr, float* berr, 
 #ifdef HAVE_AMESOS2_SUPERLU5_API
-          GlobalLU_type* lu, 
+          SLU::GlobalLU_t* lu, 
 #endif
           SLU::mem_usage_t* mem_usage,
 		      SLU::SuperLUStat_t* stat, int* info)
@@ -525,7 +433,7 @@ namespace Amesos2 {
 		      SLU::SuperMatrix* B, SLU::SuperMatrix* X, float* recip_pivot_growth,
 		      float* rcond, 
 #ifdef HAVE_AMESOS2_SUPERLU5_API
-          GlobalLU_type* lu, 
+          SLU::GlobalLU_t* lu, 
 #endif
           SLU::mem_usage_t* mem_usage,
 		      SLU::SuperLUStat_t* stat, int* info)
@@ -562,7 +470,7 @@ namespace Amesos2 {
 		      int lwork, int* perm_c, int* perm_r, SLU::SuperMatrix* L,
 		      SLU::SuperMatrix* U, 
 #ifdef HAVE_AMESOS2_SUPERLU5_API
-          GlobalLU_type* lu, 
+          SLU::GlobalLU_t* lu, 
 #endif
           SLU::SuperLUStat_t* stat, int* info)
     {
@@ -579,7 +487,7 @@ namespace Amesos2 {
 		      int lwork, int* perm_c, int* perm_r, SLU::SuperMatrix* L,
 		      SLU::SuperMatrix* U, 
 #ifdef HAVE_AMESOS2_SUPERLU5_API
-          GlobalLU_type* lu, 
+          SLU::GlobalLU_t* lu, 
 #endif
           SLU::SuperLUStat_t* stat, int* info)
     {
@@ -678,10 +586,6 @@ namespace Amesos2 {
   {
     typedef TypeMap<Superlu,double> type_map;
 
-#ifdef HAVE_AMESOS2_SUPERLU5_API
-    typedef typename SLU::D::GlobalLU_t GlobalLU_type;
-#endif
-
     static double langs(char *norm, SLU::SuperMatrix *A)
     {
       return SLU::D::dlangs(norm, A);
@@ -699,7 +603,7 @@ namespace Amesos2 {
 		      SLU::SuperMatrix* B, SLU::SuperMatrix* X, double* recip_pivot_growth,
 		      double* rcond, double* ferr, double* berr, 
 #ifdef HAVE_AMESOS2_SUPERLU5_API
-          GlobalLU_type* lu, 
+          SLU::GlobalLU_t* lu, 
 #endif
           SLU::mem_usage_t* mem_usage,
 		      SLU::SuperLUStat_t* stat, int* info)
@@ -716,7 +620,7 @@ namespace Amesos2 {
 		      int relax, int panel_size, int* etree, void* work, int lwork, int* perm_c,
 		      int* perm_r, SLU::SuperMatrix* L, SLU::SuperMatrix* U, 
 #ifdef HAVE_AMESOS2_SUPERLU5_API
-          GlobalLU_type* lu, 
+          SLU::GlobalLU_t* lu, 
 #endif
 		      SLU::SuperLUStat_t* stat, int* info)
     {
@@ -734,7 +638,7 @@ namespace Amesos2 {
 		      SLU::SuperMatrix* B, SLU::SuperMatrix* X, double* recip_pivot_growth,
 		      double* rcond, 
 #ifdef HAVE_AMESOS2_SUPERLU5_API
-          GlobalLU_type* lu, 
+          SLU::GlobalLU_t* lu, 
 #endif
           SLU::mem_usage_t* mem_usage,
 		      SLU::SuperLUStat_t* stat, int* info)
@@ -751,7 +655,7 @@ namespace Amesos2 {
 		       int relax, int panel_size, int* etree, void* work, int lwork, int* perm_c,
 		       int* perm_r, SLU::SuperMatrix* L, SLU::SuperMatrix* U,
 #ifdef HAVE_AMESOS2_SUPERLU5_API
-		       GlobalLU_type* lu, 
+		       SLU::GlobalLU_t* lu, 
 #endif
            SLU::SuperLUStat_t* stat, int* info)
     {
@@ -819,9 +723,6 @@ namespace Amesos2 {
   template <>
   struct FunctionMap<Superlu, Kokkos::complex<float>>
   {
-#ifdef HAVE_AMESOS2_SUPERLU5_API
-    typedef typename SLU::C::GlobalLU_t GlobalLU_type;
-#endif
 
     static float langs(char *norm, SLU::SuperMatrix *A)
     {
@@ -840,7 +741,7 @@ namespace Amesos2 {
 		      SLU::SuperMatrix* B, SLU::SuperMatrix* X, float* recip_pivot_growth,
 		      float* rcond, float* ferr, float* berr, 
 #ifdef HAVE_AMESOS2_SUPERLU5_API
-          GlobalLU_type* lu, 
+          SLU::GlobalLU_t* lu, 
 #endif
           SLU::mem_usage_t* mem_usage,
 		      SLU::SuperLUStat_t* stat, int* info)
@@ -857,7 +758,7 @@ namespace Amesos2 {
 		      int relax, int panel_size, int* etree, void* work, int lwork, int* perm_c,
 		      int* perm_r, SLU::SuperMatrix* L, SLU::SuperMatrix* U, 
 #ifdef HAVE_AMESOS2_SUPERLU5_API
-          GlobalLU_type* lu, 
+          SLU::GlobalLU_t* lu, 
 #endif
 		      SLU::SuperLUStat_t* stat, int* info)
     {
@@ -875,7 +776,7 @@ namespace Amesos2 {
 		      SLU::SuperMatrix* B, SLU::SuperMatrix* X, float* recip_pivot_growth,
 		      float* rcond, 
 #ifdef HAVE_AMESOS2_SUPERLU5_API
-          GlobalLU_type* lu, 
+          SLU::GlobalLU_t* lu, 
 #endif
           SLU::mem_usage_t* mem_usage,
 		      SLU::SuperLUStat_t* stat, int* info)
@@ -892,7 +793,7 @@ namespace Amesos2 {
 		       int relax, int panel_size, int* etree, void* work, int lwork, int* perm_c,
 		       int* perm_r, SLU::SuperMatrix* L, SLU::SuperMatrix* U, 
 #ifdef HAVE_AMESOS2_SUPERLU5_API
-           GlobalLU_type* lu, 
+           SLU::GlobalLU_t* lu, 
 #endif
 		       SLU::SuperLUStat_t* stat, int* info)
     {
@@ -971,9 +872,6 @@ namespace Amesos2 {
   template <>
   struct FunctionMap<Superlu,Kokkos::complex<double>>
   {
-#ifdef HAVE_AMESOS2_SUPERLU5_API
-    typedef typename SLU::Z::GlobalLU_t GlobalLU_type;
-#endif
 
     static double langs(char *norm, SLU::SuperMatrix *A)
     {
@@ -992,7 +890,7 @@ namespace Amesos2 {
 		      SLU::SuperMatrix* B, SLU::SuperMatrix* X, double* recip_pivot_growth,
 		      double* rcond, double* ferr, double* berr, 
 #ifdef HAVE_AMESOS2_SUPERLU5_API
-          GlobalLU_type* lu, 
+          SLU::GlobalLU_t* lu, 
 #endif
           SLU::mem_usage_t* mem_usage,
 		      SLU::SuperLUStat_t* stat, int* info)
@@ -1009,7 +907,7 @@ namespace Amesos2 {
 		      int relax, int panel_size, int* etree, void* work, int lwork, int* perm_c,
 		      int* perm_r, SLU::SuperMatrix* L, SLU::SuperMatrix* U, 
 #ifdef HAVE_AMESOS2_SUPERLU5_API
-          GlobalLU_type* lu, 
+          SLU::GlobalLU_t* lu, 
 #endif
 		      SLU::SuperLUStat_t* stat, int* info)
     {
@@ -1027,7 +925,7 @@ namespace Amesos2 {
 		      SLU::SuperMatrix* B, SLU::SuperMatrix* X, double* recip_pivot_growth,
 		      double* rcond, 
 #ifdef HAVE_AMESOS2_SUPERLU5_API
-          GlobalLU_type* lu, 
+          SLU::GlobalLU_t* lu, 
 #endif
           SLU::mem_usage_t* mem_usage,
 		      SLU::SuperLUStat_t* stat, int* info)
@@ -1044,7 +942,7 @@ namespace Amesos2 {
 		       int relax, int panel_size, int* etree, void* work, int lwork, int* perm_c,
 		       int* perm_r, SLU::SuperMatrix* L, SLU::SuperMatrix* U, 
 #ifdef HAVE_AMESOS2_SUPERLU5_API
-           GlobalLU_type* lu, 
+           SLU::GlobalLU_t* lu, 
 #endif
 		       SLU::SuperLUStat_t* stat, int* info)
     {

--- a/packages/amesos2/src/Amesos2_Superlu_decl.hpp
+++ b/packages/amesos2/src/Amesos2_Superlu_decl.hpp
@@ -105,10 +105,6 @@ public:
 
   typedef FunctionMap<Amesos2::Superlu,slu_type>               function_map;
 
-#ifdef HAVE_AMESOS2_SUPERLU5_API
-  typedef typename function_map::GlobalLU_type                   GlobalLU_t;
-#endif
-
   /// \name Constructor/Destructor methods
   //@{
 
@@ -246,7 +242,7 @@ private:
     SLU::superlu_options_t options;
     SLU::mem_usage_t mem_usage;
 #ifdef HAVE_AMESOS2_SUPERLU5_API
-    GlobalLU_t lu;      // Use for gssvx and gsisx in SuperLU 5.0
+    SLU::GlobalLU_t lu;      // Use for gssvx and gsisx in SuperLU 5.0
 #endif
     SLU::SuperLUStat_t stat;
 


### PR DESCRIPTION
Building drekar under clang/12.0.1 with superlu/5.2.1 enabled results in a compilation error in Amesos2:
```
FAILED: packages/amesos2/src/CMakeFiles/amesos2.dir/Amesos2_Superlu.cpp.o
/home/mmcrock/spack/opt/ubuntu18.04-skylake/clang-12.0.1/openmpi-3.1.6-r2obqojc4zs57voilrpsbigtrf4ey7si/bin/mpicxx  -I. -I/mnt/array/drekar/builds/master/drekar/src/Trilinos -Ipackages/amesos2/src -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/amesos2/src -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/amesos2/src/KLU2/Include -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/amesos2/src/KLU2/Source -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Include -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/common/auxiliarySoftware/SuiteSparse/src/COLAMD/Include -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/common/auxiliarySoftware/SuiteSparse/src/BTF/Include -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/common/auxiliarySoftware/SuiteSparse/src/UFconfig -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/common/auxiliarySoftware/SuiteSparse/src/CAMD/Include -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/common/auxiliarySoftware/SuiteSparse/src/CCOLAMD/Include -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/common/auxiliarySoftware/SuiteSparse/src/KLU/Include -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/tpetra/core/ext -Ipackages/tpetra/core/ext -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/tpetra/core/inout -Ipackages/tpetra/core/inout -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/tpetra/core/src -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/tpetra/core/src/kokkos_refactor -Ipackages/tpetra/core/src -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/tpetra/tsqr/src -Ipackages/tpetra/tsqr/src -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/tpetra/classic/LinAlg -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/tpetra/classic/NodeAPI -Ipackages/tpetra/classic/NodeAPI -Ipackages/tpetra/classic/src -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/tpetra/classic/src -Ipackages/teuchos/kokkoscomm/src -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/teuchos/kokkoscomm/src -Ipackages/teuchos/kokkoscompat/src -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/teuchos/kokkoscompat/src -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/teuchos/parameterlist/src -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/teuchos/parser/src -Ipackages/teuchos/core/src -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/teuchos/core/src -Ipackages/kokkos/core/src -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/kokkos/core/src -Ipackages/kokkos -I/home/mmcrock/spack/opt/ubuntu18.04-skylake/clang-12.0.1/boost-1.77.0-vzf5higzlbyky65krhwpb3ugjdrbgil7/include -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/teuchos/comm/src -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/teuchos/remainder/src -Ipackages/teuchos/remainder/src -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/teuchos/numerics/src -Ipackages/kokkos-kernels/src -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/kokkos-kernels/src -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/kokkos-kernels/src/impl -Ipackages/kokkos-kernels/src/impl -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/kokkos-kernels/src/impl/tpls -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/kokkos-kernels/src/blas -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/kokkos-kernels/src/blas/impl -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/kokkos-kernels/src/sparse -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/kokkos-kernels/src/sparse/impl -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/kokkos-kernels/src/graph -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/kokkos-kernels/src/graph/impl -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/kokkos-kernels/src/batched -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/kokkos-kernels/src/batched/dense -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/kokkos-kernels/src/batched/dense/impl -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/kokkos-kernels/src/batched/sparse -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/kokkos-kernels/src/batched/sparse/impl -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/kokkos-kernels/src/common -Ipackages/kokkos/algorithms/src -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/kokkos/algorithms/src -Ipackages/kokkos/containers/src -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/kokkos/containers/src -I/home/mmcrock/spack/opt/ubuntu18.04-skylake/clang-12.0.1/superlu-5.2.1-hq72msiga4oos6g5nj73q3aqr5uxaggj/include -I/home/mmcrock/spack/opt/ubuntu18.04-skylake/clang-12.0.1/metis-5.1.0-x5nyfnhjbm6eanpy345xk7nlyqs7p23m/include -Ipackages/epetra/src -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/epetra/src -Ipackages/epetraext/src -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/epetraext/src -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/epetraext/src/transform -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/epetraext/src/inout -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/epetraext/src/coloring -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/epetraext/src/model_evaluator -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/epetraext/src/block -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/epetraext/src/restrict -Ipackages/triutils/src -I/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/triutils/src -I/home/mmcrock/spack/opt/ubuntu18.04-skylake/clang-12.0.1/parmetis-4.0.3-fi6icvg5zbiek6jqigqznrwx266dix7e/include -D ENABLE_LINUX_MEM_SUMMARY -D KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK=ON  -w -fdiagnostics-color=always -march=core-avx2 -mtune=core-avx2 -mrtm  -O3 -DNDEBUG -std=c++17 -MD -MT packages/amesos2/src/CMakeFiles/amesos2.dir/Amesos2_Superlu.cpp.o -MF packages/amesos2/src/CMakeFiles/amesos2.dir/Amesos2_Superlu.cpp.o.d -o packages/amesos2/src/CMakeFiles/amesos2.dir/Amesos2_Superlu.cpp.o -c /mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/amesos2/src/Amesos2_Superlu.cpp
In file included from /mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/amesos2/src/Amesos2_Superlu.cpp:48:
In file included from /mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/amesos2/src/Amesos2_Superlu_def.hpp:70:
In file included from /mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/kokkos-kernels/src/sparse/KokkosSparse_sptrsv_superlu.hpp:58:
/home/mmcrock/spack/opt/ubuntu18.04-skylake/clang-12.0.1/superlu-5.2.1-hq72msiga4oos6g5nj73q3aqr5uxaggj/include/slu_ddefs.h:111:1: error: conflicting types for 'dgssvx'
dgssvx(superlu_options_t *, SuperMatrix *, int *, int *, int *,
^
/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/amesos2/src/Amesos2_Superlu_FunctionMap.hpp:215:7: note: previous declaration is here
      dgssvx(SLU::superlu_options_t *, SLU::SuperMatrix *, int *, int *, int *,
      ^
In file included from /mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/amesos2/src/Amesos2_Superlu.cpp:48:
In file included from /mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/amesos2/src/Amesos2_Superlu_def.hpp:70:
In file included from /mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/kokkos-kernels/src/sparse/KokkosSparse_sptrsv_superlu.hpp:58:
/home/mmcrock/spack/opt/ubuntu18.04-skylake/clang-12.0.1/superlu-5.2.1-hq72msiga4oos6g5nj73q3aqr5uxaggj/include/slu_ddefs.h:121:1: error: conflicting types for 'dgsisx'
dgsisx(superlu_options_t *, SuperMatrix *, int *, int *, int *,
^
/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/amesos2/src/Amesos2_Superlu_FunctionMap.hpp:232:7: note: previous declaration is here
      dgsisx(SLU::superlu_options_t *, SLU::SuperMatrix *, int *, int *, int *,
      ^
In file included from /mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/amesos2/src/Amesos2_Superlu.cpp:48:
In file included from /mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/amesos2/src/Amesos2_Superlu_def.hpp:70:
In file included from /mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/kokkos-kernels/src/sparse/KokkosSparse_sptrsv_superlu.hpp:58:
/home/mmcrock/spack/opt/ubuntu18.04-skylake/clang-12.0.1/superlu-5.2.1-hq72msiga4oos6g5nj73q3aqr5uxaggj/include/slu_ddefs.h:151:16: error: conflicting types for 'dgstrf'
extern void    dgstrf (superlu_options_t*, SuperMatrix*,
               ^
/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/amesos2/src/Amesos2_Superlu_FunctionMap.hpp:224:7: note: previous declaration is here
      dgstrf (SLU::superlu_options_t*, SLU::SuperMatrix*,
      ^
In file included from /mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/amesos2/src/Amesos2_Superlu.cpp:48:
In file included from /mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/amesos2/src/Amesos2_Superlu_def.hpp:70:
In file included from /mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/kokkos-kernels/src/sparse/KokkosSparse_sptrsv_superlu.hpp:58:
/home/mmcrock/spack/opt/ubuntu18.04-skylake/clang-12.0.1/superlu-5.2.1-hq72msiga4oos6g5nj73q3aqr5uxaggj/include/slu_ddefs.h:183:16: error: conflicting types for 'dgsitrf'
extern void    dgsitrf (superlu_options_t*, SuperMatrix*, int, int, int*,
               ^
/mnt/array/drekar/builds/master/drekar/src/Trilinos/packages/amesos2/src/Amesos2_Superlu_FunctionMap.hpp:241:7: note: previous declaration is here
      dgsitrf (SLU::superlu_options_t*, SLU::SuperMatrix*,
      ^
4 errors generated.
```

SuperLU 5 support was added in trilinos/Trilinos#1643. The definitions of `GlobalLU_t` in Amesos2 (https://github.com/trilinos/Trilinos/blob/f13a2cf0e4c5f2108ec4dc730312ee8e0251a846/packages/amesos2/src/Amesos2_Superlu_FunctionMap.hpp#L189) do not match those in `slu_util.h` from SuperLU (`double *` vs `void *` here)
```
typedef struct {
    int     *xsup;    /* supernode and column mapping */
    int     *supno;
    int     *lsub;    /* compressed L subscripts */
    int	    *xlsub;
    void    *lusup;   /* L supernodes */
    int     *xlusup;
    void    *ucol;    /* U columns */
    int     *usub;
    int	    *xusub;
    int     nzlmax;   /* current max size of lsub */
    int     nzumax;   /*    "    "    "      ucol */
    int     nzlumax;  /*    "    "    "     lusup */
    int     n;        /* number of columns in the matrix */
    LU_space_t MemModel; /* 0 - system malloc'd; 1 - user provided */
    int     num_expansions;
    ExpHeader *expanders; /* Array of pointers to 4 types of memory */
    LU_stack_t stack;     /* use user supplied memory */
} GlobalLU_t;
```

The commit in this pull request seems to resolve this issue by simply using the definition from SuperLU directly (tested as working with clang/12.0.1 and gcc/9.4.0).

@trilinos/amesos2
@srajama1 
