### PR TITLE
Tpetra: Remove statistics from Distributor

### DIFF
--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
@@ -1069,53 +1069,53 @@ void Add(
 namespace MMdetails{
 
 /*********************************************************************************************************/
-// Prints MMM-style statistics on communication done with an Import or Export object
-template <class TransferType>
-void printMultiplicationStatistics(Teuchos::RCP<TransferType > Transfer, const std::string &label) {
-  if (Transfer.is_null())
-    return;
-
-  const Distributor & Distor                   = Transfer->getDistributor();
-  Teuchos::RCP<const Teuchos::Comm<int> > Comm = Transfer->getSourceMap()->getComm();
-
-  size_t rows_send   = Transfer->getNumExportIDs();
-  size_t rows_recv   = Transfer->getNumRemoteIDs();
-
-  size_t round1_send = Transfer->getNumExportIDs() * sizeof(size_t);
-  size_t round1_recv = Transfer->getNumRemoteIDs() * sizeof(size_t);
-  size_t num_send_neighbors = Distor.getNumSends();
-  size_t num_recv_neighbors = Distor.getNumReceives();
-  size_t round2_send, round2_recv;
-  Distor.getLastDoStatistics(round2_send,round2_recv);
-
-  int myPID    = Comm->getRank();
-  int NumProcs = Comm->getSize();
-
-  // Processor by processor statistics
-  //    printf("[%d] %s Statistics: neigh[s/r]=%d/%d rows[s/r]=%d/%d r1bytes[s/r]=%d/%d r2bytes[s/r]=%d/%d\n",
-  //    myPID, label.c_str(),num_send_neighbors,num_recv_neighbors,rows_send,rows_recv,round1_send,round1_recv,round2_send,round2_recv);
-
-  // Global statistics
-  size_t lstats[8] = {num_send_neighbors,num_recv_neighbors,rows_send,rows_recv,round1_send,round1_recv,round2_send,round2_recv};
-  size_t gstats_min[8], gstats_max[8];
-
-  double lstats_avg[8], gstats_avg[8];
-  for(int i=0; i<8; i++)
-    lstats_avg[i] = ((double)lstats[i])/NumProcs;
-
-  Teuchos::reduceAll(*Comm(),Teuchos::REDUCE_MIN,8,lstats,gstats_min);
-  Teuchos::reduceAll(*Comm(),Teuchos::REDUCE_MAX,8,lstats,gstats_max);
-  Teuchos::reduceAll(*Comm(),Teuchos::REDUCE_SUM,8,lstats_avg,gstats_avg);
-
-  if(!myPID) {
-    printf("%s Send Statistics[min/avg/max]: neigh=%d/%4.1f/%d rows=%d/%4.1f/%d round1=%d/%4.1f/%d round2=%d/%4.1f/%d\n", label.c_str(),
-           (int)gstats_min[0],gstats_avg[0],(int)gstats_max[0], (int)gstats_min[2],gstats_avg[2],(int)gstats_max[2],
-           (int)gstats_min[4],gstats_avg[4],(int)gstats_max[4], (int)gstats_min[6],gstats_avg[6],(int)gstats_max[6]);
-    printf("%s Recv Statistics[min/avg/max]: neigh=%d/%4.1f/%d rows=%d/%4.1f/%d round1=%d/%4.1f/%d round2=%d/%4.1f/%d\n", label.c_str(),
-           (int)gstats_min[1],gstats_avg[1],(int)gstats_max[1], (int)gstats_min[3],gstats_avg[3],(int)gstats_max[3],
-           (int)gstats_min[5],gstats_avg[5],(int)gstats_max[5], (int)gstats_min[7],gstats_avg[7],(int)gstats_max[7]);
-  }
-}
+//// Prints MMM-style statistics on communication done with an Import or Export object
+//template <class TransferType>
+//void printMultiplicationStatistics(Teuchos::RCP<TransferType > Transfer, const std::string &label) {
+//  if (Transfer.is_null())
+//    return;
+//
+//  const Distributor & Distor                   = Transfer->getDistributor();
+//  Teuchos::RCP<const Teuchos::Comm<int> > Comm = Transfer->getSourceMap()->getComm();
+//
+//  size_t rows_send   = Transfer->getNumExportIDs();
+//  size_t rows_recv   = Transfer->getNumRemoteIDs();
+//
+//  size_t round1_send = Transfer->getNumExportIDs() * sizeof(size_t);
+//  size_t round1_recv = Transfer->getNumRemoteIDs() * sizeof(size_t);
+//  size_t num_send_neighbors = Distor.getNumSends();
+//  size_t num_recv_neighbors = Distor.getNumReceives();
+//  size_t round2_send, round2_recv;
+//  Distor.getLastDoStatistics(round2_send,round2_recv);
+//
+//  int myPID    = Comm->getRank();
+//  int NumProcs = Comm->getSize();
+//
+//  // Processor by processor statistics
+//  //    printf("[%d] %s Statistics: neigh[s/r]=%d/%d rows[s/r]=%d/%d r1bytes[s/r]=%d/%d r2bytes[s/r]=%d/%d\n",
+//  //    myPID, label.c_str(),num_send_neighbors,num_recv_neighbors,rows_send,rows_recv,round1_send,round1_recv,round2_send,round2_recv);
+//
+//  // Global statistics
+//  size_t lstats[8] = {num_send_neighbors,num_recv_neighbors,rows_send,rows_recv,round1_send,round1_recv,round2_send,round2_recv};
+//  size_t gstats_min[8], gstats_max[8];
+//
+//  double lstats_avg[8], gstats_avg[8];
+//  for(int i=0; i<8; i++)
+//    lstats_avg[i] = ((double)lstats[i])/NumProcs;
+//
+//  Teuchos::reduceAll(*Comm(),Teuchos::REDUCE_MIN,8,lstats,gstats_min);
+//  Teuchos::reduceAll(*Comm(),Teuchos::REDUCE_MAX,8,lstats,gstats_max);
+//  Teuchos::reduceAll(*Comm(),Teuchos::REDUCE_SUM,8,lstats_avg,gstats_avg);
+//
+//  if(!myPID) {
+//    printf("%s Send Statistics[min/avg/max]: neigh=%d/%4.1f/%d rows=%d/%4.1f/%d round1=%d/%4.1f/%d round2=%d/%4.1f/%d\n", label.c_str(),
+//           (int)gstats_min[0],gstats_avg[0],(int)gstats_max[0], (int)gstats_min[2],gstats_avg[2],(int)gstats_max[2],
+//           (int)gstats_min[4],gstats_avg[4],(int)gstats_max[4], (int)gstats_min[6],gstats_avg[6],(int)gstats_max[6]);
+//    printf("%s Recv Statistics[min/avg/max]: neigh=%d/%4.1f/%d rows=%d/%4.1f/%d round1=%d/%4.1f/%d round2=%d/%4.1f/%d\n", label.c_str(),
+//           (int)gstats_min[1],gstats_avg[1],(int)gstats_max[1], (int)gstats_min[3],gstats_avg[3],(int)gstats_max[3],
+//           (int)gstats_min[5],gstats_avg[5],(int)gstats_max[5], (int)gstats_min[7],gstats_avg[7],(int)gstats_max[7]);
+//  }
+//}
 
 // Kernel method for computing the local portion of C = A*B
 template<class Scalar,

--- a/packages/tpetra/core/src/Tpetra_Distributor.cpp
+++ b/packages/tpetra/core/src/Tpetra_Distributor.cpp
@@ -75,8 +75,6 @@ namespace Tpetra {
                const Teuchos::RCP<Teuchos::FancyOStream>& /* out */,
                const Teuchos::RCP<Teuchos::ParameterList>& plist)
     : plan_(comm)
-    , lastRoundBytesSend_ (0)
-    , lastRoundBytesRecv_ (0)
   {
     this->setParameterList(plist);
   }
@@ -104,8 +102,6 @@ namespace Tpetra {
     , actor_(distributor.actor_)
     , verbose_ (distributor.verbose_)
     , reverseDistributor_ (distributor.reverseDistributor_)
-    , lastRoundBytesSend_ (distributor.lastRoundBytesSend_)
-    , lastRoundBytesRecv_ (distributor.lastRoundBytesRecv_)
   {
     using Teuchos::ParameterList;
     using Teuchos::RCP;
@@ -126,8 +122,6 @@ namespace Tpetra {
     std::swap (actor_, rhs.actor_);
     std::swap (verbose_, rhs.verbose_);
     std::swap (reverseDistributor_, rhs.reverseDistributor_);
-    std::swap (lastRoundBytesSend_, rhs.lastRoundBytesSend_);
-    std::swap (lastRoundBytesRecv_, rhs.lastRoundBytesRecv_);
 
     // Swap parameter lists.  If they are the same object, make a deep
     // copy first, so that modifying one won't modify the other one.
@@ -305,13 +299,6 @@ namespace Tpetra {
 
     // requests_: Allocated on demand.
     // reverseDistributor_: See note below
-
-    // mfh 31 Mar 2016: These are statistics, kept on calls to
-    // doPostsAndWaits or doReversePostsAndWaits.  They weren't here
-    // when I started, and I didn't add them, so I don't know if they
-    // are accurate.
-    reverseDistributor_->lastRoundBytesSend_ = 0;
-    reverseDistributor_->lastRoundBytesRecv_ = 0;
 
     // I am my reverse Distributor's reverse Distributor.
     // Thus, it would be legit to do the following:

--- a/packages/tpetra/core/src/Tpetra_Distributor.hpp
+++ b/packages/tpetra/core/src/Tpetra_Distributor.hpp
@@ -716,14 +716,6 @@ namespace Tpetra {
                     const ImpView &imports,
                     const Teuchos::ArrayView<const size_t>& numImportPacketsPerLID);
 
-    /// \brief Information on the last call to do/doReverse
-    ///
-    /// Returns the amount of data sent & recv'd on this processor in bytes
-    void getLastDoStatistics(size_t & bytes_sent,  size_t & bytes_recvd) const{
-      bytes_sent  = lastRoundBytesSend_;
-      bytes_recvd = lastRoundBytesRecv_;
-    }
-
     //@}
     //! @name Implementation of Teuchos::Describable
     //@{
@@ -789,12 +781,6 @@ namespace Tpetra {
     /// This is created on demand in getReverse() and cached for
     /// later reuse.  This is why it is declared "mutable".
     mutable Teuchos::RCP<Distributor> reverseDistributor_;
-
-    /// \brief The number of bytes sent by this proc in the last call to do/doReverse
-    size_t lastRoundBytesSend_;
-
-    /// \brief The number of bytes received by this proc in the last call to do/doReverse
-    size_t lastRoundBytesRecv_;
 
     /// \brief Compute send (GID,PID) pairs from receive (GID,PID) pairs.
     ///
@@ -866,9 +852,6 @@ namespace Tpetra {
              numPackets,
              arcp<Packet> (imports.getRawPtr (), 0, imports.size (), false));
     doWaits ();
-
-    lastRoundBytesSend_ = exports.size () * sizeof (Packet);
-    lastRoundBytesRecv_ = imports.size () * sizeof (Packet);
   }
 
   template <class Packet>
@@ -905,9 +888,6 @@ namespace Tpetra {
              arcp<Packet> (imports.getRawPtr (), 0, imports.size (), false),
              numImportPacketsPerLID);
     doWaits ();
-
-    lastRoundBytesSend_ = exports.size () * sizeof (Packet);
-    lastRoundBytesRecv_ = imports.size () * sizeof (Packet);
   }
 
 
@@ -965,9 +945,6 @@ namespace Tpetra {
                     numPackets,
                     arcp<Packet> (imports.getRawPtr (), 0, imports.size (), false));
     doReverseWaits ();
-
-    lastRoundBytesSend_ = exports.size() * sizeof(Packet);
-    lastRoundBytesRecv_ = imports.size() * sizeof(Packet);
   }
 
   template <class Packet>
@@ -1000,9 +977,6 @@ namespace Tpetra {
                     arcp<Packet> (imports.getRawPtr (), 0, imports.size (), false),
                     numImportPacketsPerLID);
     doReverseWaits ();
-
-    lastRoundBytesSend_ = exports.size() * sizeof(Packet);
-    lastRoundBytesRecv_ = imports.size() * sizeof(Packet);
   }
 
   template <class Packet>


### PR DESCRIPTION
@trilinos/tpetra

Deleted the getLastDoStatistics functionality of Distributor since it was largely unused.  We could deprecate instead, but the only user of this function was the printMultiplicationStatistics function in MatrixMatrix, which is not currently used in production.  As per team request, I've commented out printMultiplicationStatistics instead of deleting it, in case someone wants to refer back to it.

## Testing
Tpetra builds and tests pass on a local CPU build.