### PR TITLE
Belos, native-Tpetra : add new options for single-reduce and s-step GMRES

### DIFF
--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresS.hpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresS.hpp
@@ -227,7 +227,7 @@ private:
 		   P_prev, STS::one ());
       }
     }
-    const int rank = this->normalizeBelosOrthoManager (Q, G);
+    const int rank = this->normalizeBelosOrthoManager (outPtr, Q, G, output.numIters);
     if (outPtr != nullptr) {
       *outPtr << "Rank of s-step basis: " << rank << endl;
     }

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresSingleReduce.hpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresSingleReduce.hpp
@@ -571,9 +571,9 @@ private:
     Teuchos::BLAS<LO ,SC> blas;
     dense_matrix_type H (restart+1, restart,   true);
     dense_matrix_type T (restart+1, restart+2, true);
-    dense_vector_type y (restart+1, true);
-    dense_vector_type z (restart+1, true);
-    dense_vector_type w (restart+1, true);
+    dense_vector_type y (restart+1, true); // solution of least-square problem
+    dense_vector_type z (restart+1, true); // z and w save y and the last column of H,
+    dense_vector_type w (restart+1, true); //  to continue restart-cycle in case explicit convergence check failed at restart
     std::vector<real_type> cs (restart);
     std::vector<SC> sn (restart);
     

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresSstep.hpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresSstep.hpp
@@ -1431,6 +1431,9 @@ private:
                   *outPtr << " > break at step = " << iiter+1 << " (" << step << ") with metric = " << metric
                           << " and tol = " << input.tol << endl;
                 }
+                if (delayedNorm || lowSynch_) {
+                  iter = Iter;
+                }
                 step = iiter+1;
                 converged = true;
                 break;
@@ -1446,6 +1449,9 @@ private:
             #endif
             if (STM::isnaninf (metric)) {
               // metric is nan
+              if (delayedNorm || lowSynch_) {
+                iter = Iter;
+              }
               break;
             }
           }
@@ -1463,6 +1469,9 @@ private:
             Step = step;
             Rank = Step+1; // full-rank..
             delayedNorm = false;
+            if (outPtr != nullptr) {
+              *outPtr << endl << " running clean up steps " << endl;
+            }
           } else {
             // done check
             doneCheck = true;

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_Krylov_parameters.hpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_Krylov_parameters.hpp
@@ -93,8 +93,10 @@ public:
   bool needToScale = true;
   bool needToReortho = false;
   bool delayedNorm = true;
+  bool delayedRenorm = false;
   int maxOrthoSteps = 0;
   std::string orthoType {"ICGS"};
+  std::string tsqrType  {"none"};
   std::string precoSide {"none"};
   bool computeRitzValues = true;
   bool computeRitzValuesOnFly = false;
@@ -195,6 +197,7 @@ operator<< (std::ostream& out,
   if (si.resCycle > 0) {
     out << " Restart cycle: " << si.resCycle << endl;
     out << " Orthogonalization: " << si.orthoType << endl;
+    out << " TSQR: " << si.tsqrType << endl;
   }
   out << " Step size: " << si.stepSize << endl
       << " Preconditioner: " << si.precoSide << endl;

--- a/packages/belos/tpetra/test/Native/CMakeLists.txt
+++ b/packages/belos/tpetra/test/Native/CMakeLists.txt
@@ -160,3 +160,27 @@ TRIBITS_ADD_TEST(
   COMM serial mpi
   STANDARD_PASS_OUTPUT
   )
+
+TRIBITS_ADD_TEST(
+  Tpetra_Native_solvers_nonsymm_matrix
+  NAME Tpetra_Native_GMRES_S_STEP_nonsymm_matrix_step5_mgs_lowsynch
+  ARGS "--solver=\"TPETRA GMRES S-STEP\" --restartLength=10 --stepSize=5 --ortho=\"MGS LowSynch\" --useSVQR2"
+  COMM serial mpi
+  STANDARD_PASS_OUTPUT
+  )
+
+TRIBITS_ADD_TEST(
+  Tpetra_Native_solvers_nonsymm_matrix
+  NAME Tpetra_Native_GMRES_S_STEP_nonsymm_matrix_step5_cgs2_lowsynch
+  ARGS "--solver=\"TPETRA GMRES S-STEP\" --restartLength=10 --stepSize=5 --ortho=\"CGS2 LowSynch\" --useSVQR2"
+  COMM serial mpi
+  STANDARD_PASS_OUTPUT
+  )
+
+TRIBITS_ADD_TEST(
+  Tpetra_Native_solvers_nonsymm_matrix
+  NAME Tpetra_Native_GMRES_S_STEP_nonsymm_matrix_step5_cgs2_delayed
+  ARGS "--solver=\"TPETRA GMRES S-STEP\" --restartLength=10 --stepSize=5 --ortho=\"CGS2 Delayed\" --useSVQR2"
+  COMM serial mpi
+  STANDARD_PASS_OUTPUT
+  )

--- a/packages/belos/tpetra/test/Native/nonsymm_matrix.cpp
+++ b/packages/belos/tpetra/test/Native/nonsymm_matrix.cpp
@@ -21,10 +21,12 @@ struct CommandLineOptions {
   int maxAllowedNumIters {30};
   int maxNumIters {100};
   int restartLength {30};
+  double tol {-1.0};
   std::string orthoType {"ICGS"};
   int stepSize {1};
   bool useCholQR {false};
   bool useCholQR2 {false};
+  bool useSVQR2 {false};
   bool computeRitzValues {true};
   bool zeroInitialGuess {true};
   bool verbose {true};
@@ -54,6 +56,8 @@ TEUCHOS_STATIC_SETUP()
                  "Maximum number of iterations per restart cycle.  "
                  "This corresponds to the standard Belos parameter "
                  "\"Num Blocks\".");
+  clp.setOption ("convergenceTol", &commandLineOptions.tol,
+                 "Convergence tolerance");
   clp.setOption ("ortho", &commandLineOptions.orthoType,
                  "Name of the orthogonalization procedure");
   clp.setOption ("stepSize", &commandLineOptions.stepSize,
@@ -62,6 +66,8 @@ TEUCHOS_STATIC_SETUP()
                  "Whether to use CholQR");
   clp.setOption ("useCholQR2", "noCholQR2", &commandLineOptions.useCholQR2,
                  "Whether to use CholQR2");
+  clp.setOption ("useSVQR2", "noSVQR2", &commandLineOptions.useSVQR2,
+                 "Whether to use SVQR2");
   clp.setOption ("computeRitzValues", "noRitzValues", &commandLineOptions.computeRitzValues,
                  "Whether to compute Ritz values");
   clp.setOption ("zeroInitialGuess", "nonzeroInitialGuess",
@@ -236,10 +242,14 @@ testSolver (Teuchos::FancyOStream& out,
   params->set ("Maximum Iterations", commandLineOptions.maxNumIters);
   params->set ("Num Blocks", commandLineOptions.restartLength);
   params->set ("Orthogonalization", commandLineOptions.orthoType);
+  if (commandLineOptions.tol > ZERO) {
+    params->set ("Convergence Tolerance",  commandLineOptions.tol );
+  }
   if (solverName == "TPETRA GMRES S-STEP") {
     params->set ("Step Size", commandLineOptions.stepSize);
     params->set ("CholeskyQR",  commandLineOptions.useCholQR);
     params->set ("CholeskyQR2", commandLineOptions.useCholQR2);
+    params->set ("SVQR2", commandLineOptions.useSVQR2);
   }
   if (solverName == "TPETRA GMRES S-STEP" || solverName == "TPETRA GMRES SINGLE REDUCE" || solverName == "TPETRA GMRES PIPELINE") {
     params->set ("Compute Ritz Values", commandLineOptions.computeRitzValues);


### PR DESCRIPTION

@trilinos/belos 

## Motivation
This PR contains new options for single-reduce GMRES to improve performance (e.g., merging some vector operations, convergence check before the delayed normalization to avoid extra SpMV). 

It also contains new orthogonalization options for s-step GMRES: 
- we included new options to use TSQR or SVQR for intra-block (panel) orthogonalization
- it also contains the initial integration of low-synch and delayed orthogonalization framework.

## Testing
I ran belos/tpetra/Native ctest on weaver.
