### PR TITLE
Zoltan2:  remove use of deprecated doPostsAndWaits as required by #10164

### DIFF
--- a/packages/zoltan2/core/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
+++ b/packages/zoltan2/core/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
@@ -6736,10 +6736,8 @@ void AlgMJ<mj_scalar_t, mj_lno_t, mj_gno_t, mj_part_t, mj_node_t>::
     auto host_dst_weights = Kokkos::create_mirror_view(Kokkos::HostSpace(),
                                                        dst_weights);
 
-    Kokkos::View<mj_scalar_t**, Kokkos::HostSpace> host_src_weights(
-      Kokkos::ViewAllocateWithoutInitializing("host_weights"),
-      this->mj_weights.extent(0), this->mj_weights.extent(1));
-    Kokkos::deep_copy(host_src_weights, this->mj_weights);
+    auto host_src_weights = Kokkos::create_mirror_view_and_copy(
+                                    Kokkos::HostSpace(), this->mj_weights);
 
     // contiguous buffers to gather potentially strided data
     Kokkos::View<mj_scalar_t*, Kokkos::HostSpace> sent_weight(
@@ -8872,10 +8870,8 @@ bool Zoltan2_AlgMJ<Adapter>::mj_premigrate_to_subset(
     num_incoming_gnos, this->num_weights_per_coord);
   auto host_dst_weights = Kokkos::create_mirror_view(dst_weights);
 
-  Kokkos::View<mj_scalar_t**, Kokkos::HostSpace> host_src_weights(
-    Kokkos::ViewAllocateWithoutInitializing("host_weights"),
-    this->mj_weights.extent(0), this->mj_weights.extent(1));
-  Kokkos::deep_copy(host_src_weights, this->mj_weights);
+  auto host_src_weights = Kokkos::create_mirror_view_and_copy(
+                                  Kokkos::HostSpace(), this->mj_weights);
 
   // contiguous buffers to gather potentially strided data
   Kokkos::View<mj_scalar_t*, Kokkos::HostSpace> sent_weight(

--- a/packages/zoltan2/test/core/helpers/GeometricGenerator.hpp
+++ b/packages/zoltan2/test/core/helpers/GeometricGenerator.hpp
@@ -2346,30 +2346,29 @@ public:
 
 	  Tpetra::Distributor distributor(comm);
 	  ArrayView<const int> pIds( coordinate_grid_parts, this->numLocalCoords);
-	  /*
-	  for (int i = 0 ; i < this->numLocalCoords; ++i){
-		  std::cout << "me:" << this->myRank << " to part:" << coordinate_grid_parts[i] << std::endl;
-	  }
-	  */
 	  gno_t numMyNewGnos = distributor.createFromSends(pIds);
 
-	  //std::cout << "distribution step 1 me:" << this->myRank << " numLocal:"  <<numMyNewGnos << " old:" <<  numLocalCoords << std::endl;
 
-	  this->numLocalCoords = numMyNewGnos;
-
-
-	  ArrayRCP<scalar_t> recvBuf2(distributor.getTotalReceiveLength());
+          Kokkos::View<scalar_t*, Kokkos::HostSpace> recvBuf2(
+            Kokkos::ViewAllocateWithoutInitializing("recvBuf2"),
+            numMyNewGnos);
 
 	  for (int i = 0; i < this->coordinate_dimension; ++i){
-		  ArrayView<scalar_t> s(this->coords[i], this->numLocalCoords);
-	      distributor.doPostsAndWaits<scalar_t>(s, 1, recvBuf2());
-		  delete [] this->coords[i];
-		  this->coords[i] = new scalar_t[this->numLocalCoords];
-	      for (lno_t j = 0; j < this->numLocalCoords; ++j){
+              Kokkos::View<scalar_t*, Kokkos::HostSpace> s;
+              if (this->numLocalCoords > 0) 
+                s = Kokkos::View<scalar_t *, Kokkos::HostSpace>(
+                            this->coords[i], this->numLocalCoords); //unmanaged
+
+	      distributor.doPostsAndWaits(s, 1, recvBuf2);
+
+	      delete [] this->coords[i];
+	      this->coords[i] = new scalar_t[numMyNewGnos];
+	      for (lno_t j = 0; j < numMyNewGnos; ++j){
 	    	  this->coords[i][j] = recvBuf2[j];
 	      }
 
 	  }
+	  this->numLocalCoords = numMyNewGnos;
   }
 
   //calls MJ for p = numProcs


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/zoltan2 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
#10164 deprecated Teuchos::ArrayView interfaces to the distributor, favoring Kokkos::View interfaces.
This change affected several parts of the MultiJagged algorithm, as MJ uses Distributors to migrate data to subsets of processors.

In most cases in this PR, I removed creation of ArrayViews from Kokkos::Views.  I ensured that all views passed to the Distributor were HostSpace views, as UVM views are disallowed.  In many cases, fewer copies are needed with the new interface, as we avoid copies from/to ArrayRCPs and host views.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Tested on ascicgpu machines:
serial node with and without Tpetra deprecated code
cude node with and without UVM

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->