### PR TITLE
Tpetra: add transferArrived function to DistObject

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_DistributorActor.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorActor.cpp
@@ -70,6 +70,14 @@ namespace Details {
     }
   }
 
+  bool DistributorActor::isReady() const {
+    bool result = true;
+    for (auto& request : requests_) {
+      result &= request->isReady();
+    }
+    return result;
+  }
+
 #ifdef HAVE_TPETRA_DISTRIBUTOR_TIMINGS
   void DistributorActor::makeTimers () {
     timer_doWaits_ = Teuchos::TimeMonitor::getNewTimer (

--- a/packages/tpetra/core/src/Tpetra_Details_DistributorActor.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorActor.hpp
@@ -88,6 +88,8 @@ public:
 
   void doWaits(const DistributorPlan& plan);
 
+  bool isReady() const;
+
 private:
   Teuchos::Array<Teuchos::RCP<Teuchos::CommRequest<int>>> requests_;
 

--- a/packages/tpetra/core/src/Tpetra_DistObject_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_DistObject_decl.hpp
@@ -564,6 +564,9 @@ namespace Tpetra {
               const CombineMode CM,
               const bool restrictedMode = false);
 
+    bool
+    transferArrived() const;
+
     //@}
     //! @name Attribute accessor methods
     //@{

--- a/packages/tpetra/core/src/Tpetra_DistObject_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_DistObject_decl.hpp
@@ -564,8 +564,9 @@ namespace Tpetra {
               const CombineMode CM,
               const bool restrictedMode = false);
 
-    bool
-    transferArrived() const;
+    /// \brief Whether the data from an import/export operation has
+    ///        arrived, and is ready for the unpack and combine step.
+    bool transferArrived() const;
 
     //@}
     //! @name Attribute accessor methods

--- a/packages/tpetra/core/src/Tpetra_DistObject_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_DistObject_def.hpp
@@ -650,7 +650,7 @@ namespace Tpetra {
   bool
   DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
   transferArrived() const {
-    return true;
+    return distributorActor_.isReady();
   }
 
   template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>

--- a/packages/tpetra/core/src/Tpetra_DistObject_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_DistObject_def.hpp
@@ -649,6 +649,13 @@ namespace Tpetra {
   template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
   bool
   DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
+  transferArrived() const {
+    return true;
+  }
+
+  template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
+  bool
+  DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
   isDistributed () const {
     return map_->isDistributed ();
   }

--- a/packages/tpetra/core/test/ImportExport2/AsyncTransfer_UnitTests.cpp
+++ b/packages/tpetra/core/test/ImportExport2/AsyncTransfer_UnitTests.cpp
@@ -839,9 +839,16 @@ namespace {
 
       Import<LO, GO> importer(source->getMap(), target->getMap());
 
-      if (numProcs > 1 && myRank == 0) {
-        target->beginImport(*source, importer, INSERT);
-        TEST_ASSERT(!target->transferArrived());
+      if (numProcs > 1) {
+        if (myRank == 0) {
+          target->beginImport(*source, importer, INSERT);
+          TEST_ASSERT(!target->transferArrived());
+        }
+        comm->barrier();
+        if (myRank != 0) {
+          target->beginImport(*source, importer, INSERT);
+        }
+        target->endImport(*source, importer, INSERT);
       }
     }
 
@@ -877,9 +884,16 @@ namespace {
 
       Export<LO, GO> exporter(source->getMap(), target->getMap());
 
-      if (numProcs > 1 && myRank == 0) {
-        target->beginExport(*source, exporter, INSERT);
-        TEST_ASSERT(!target->transferArrived());
+      if (numProcs > 1) {
+        if (myRank == 0) {
+          target->beginExport(*source, exporter, INSERT);
+          TEST_ASSERT(!target->transferArrived());
+        }
+        comm->barrier();
+        if (myRank != 0) {
+          target->beginExport(*source, exporter, INSERT);
+        }
+        target->endExport(*source, exporter, INSERT);
       }
     }
 

--- a/packages/tpetra/core/test/ImportExport2/AsyncTransfer_UnitTests.cpp
+++ b/packages/tpetra/core/test/ImportExport2/AsyncTransfer_UnitTests.cpp
@@ -833,10 +833,13 @@ namespace {
     { }
 
     void operator()(DistObjectRCP source, DistObjectRCP target) const {
-      Import<LO, GO> importer(source->getMap(), target->getMap());
-      int myRank = target->getMap()->getComm()->getRank();
+      auto comm = target->getMap()->getComm();
+      int myRank = comm->getRank();
+      int numProcs = comm->getSize();
 
-      if (myRank == 0) {
+      Import<LO, GO> importer(source->getMap(), target->getMap());
+
+      if (numProcs > 1 && myRank == 0) {
         target->beginImport(*source, importer, INSERT);
         TEST_ASSERT(!target->transferArrived());
       }
@@ -868,10 +871,13 @@ namespace {
     { }
 
     void operator()(DistObjectRCP source, DistObjectRCP target) const {
-      Export<LO, GO> exporter(source->getMap(), target->getMap());
-      int myRank = target->getMap()->getComm()->getRank();
+      auto comm = target->getMap()->getComm();
+      int myRank = comm->getRank();
+      int numProcs = comm->getSize();
 
-      if (myRank == 0) {
+      Export<LO, GO> exporter(source->getMap(), target->getMap());
+
+      if (numProcs > 1 && myRank == 0) {
         target->beginExport(*source, exporter, INSERT);
         TEST_ASSERT(!target->transferArrived());
       }

--- a/packages/tpetra/core/test/ImportExport2/AsyncTransfer_UnitTests.cpp
+++ b/packages/tpetra/core/test/ImportExport2/AsyncTransfer_UnitTests.cpp
@@ -743,9 +743,11 @@ namespace {
 
     void operator()(DistObjectRCP source, DistObjectRCP target) const {
       Import<LO, GO> importer(source->getMap(), target->getMap());
+
       target->beginImport(*source, importer, INSERT);
       while (!target->transferArrived());
       target->endImport(*source, importer, INSERT);
+
       TEST_ASSERT(target->transferArrived());
     }
 
@@ -770,6 +772,51 @@ namespace {
     fixture.setup();
     fixture.performTransfer(CheckTransferArrivedForwardImport<char, LO, GO>(out, success));
     fixture.checkResults(ReferenceImportMatrix<Scalar, LO, GO>());
+  }
+
+
+  template <typename Packet, typename LO, typename GO>
+  class CheckTransferArrivedForwardExport {
+  private:
+    using DistObjectRCP = RCP<DistObject<Packet, LO, GO>>;
+
+  public:
+    CheckTransferArrivedForwardExport(FancyOStream& o, bool& s)
+      : out(o),
+        success(s)
+    { }
+
+    void operator()(DistObjectRCP source, DistObjectRCP target) const {
+      Export<LO, GO> exporter(source->getMap(), target->getMap());
+
+      target->beginExport(*source, exporter, INSERT);
+      while (!target->transferArrived());
+      target->endExport(*source, exporter, INSERT);
+
+      TEST_ASSERT(target->transferArrived());
+    }
+
+  private:
+    FancyOStream& out;
+    bool& success;
+  };
+
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( TransferArrived, MultiVector_forwardExportTrue, Scalar, LO, GO )
+  {
+    MultiVectorTransferFixture<Scalar, LO, GO> fixture(out, success);
+
+    fixture.setup(0);
+    fixture.performTransfer(CheckTransferArrivedForwardExport<Scalar, LO, GO>(out, success));
+    fixture.checkResults(ReferenceExportMultiVector<Scalar, LO, GO>());
+  }
+
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( TransferArrived, CrsMatrix_forwardExportTrue, Scalar, LO, GO )
+  {
+    DiagonalCrsMatrixTransferFixture<Scalar, LO, GO> fixture(out, success);
+
+    fixture.setup();
+    fixture.performTransfer(CheckTransferArrivedForwardExport<char, LO, GO>(out, success));
+    fixture.checkResults(ReferenceExportMatrix<Scalar, LO, GO>());
   }
 
 
@@ -798,6 +845,8 @@ namespace {
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( TransferArrived, CrsMatrix_defaultTrue, SC, LO, GO ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( TransferArrived, MultiVector_forwardImportTrue, SC, LO, GO ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( TransferArrived, CrsMatrix_forwardImportTrue, SC, LO, GO ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( TransferArrived, MultiVector_forwardExportTrue, SC, LO, GO ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( TransferArrived, CrsMatrix_forwardExportTrue, SC, LO, GO ) \
 
   TPETRA_ETI_MANGLING_TYPEDEFS()
 

--- a/packages/tpetra/core/test/ImportExport2/AsyncTransfer_UnitTests.cpp
+++ b/packages/tpetra/core/test/ImportExport2/AsyncTransfer_UnitTests.cpp
@@ -111,11 +111,6 @@ namespace {
       transfer(sourceMV, targetMV);
     }
 
-    template <typename TransferMethod>
-    void checkTransferStatus(const TransferMethod& transfer) {
-      transfer(sourceMV, targetMV);
-    }
-
     template <typename ReferenceSolution>
     void checkResults(const ReferenceSolution& referenceSolution) {
       RCP<const mv_type> referenceMV = referenceSolution.generateWithClassicalCodePath(sourceMV, targetMap);
@@ -699,12 +694,12 @@ namespace {
 
 
   template <typename Packet, typename LO, typename GO>
-  class DefaultNoTransfer {
+  class CheckDefaultTransferStatus {
   private:
     using DistObjectRCP = RCP<DistObject<Packet, LO, GO>>;
 
   public:
-    DefaultNoTransfer(Teuchos::FancyOStream& o, bool& s)
+    CheckDefaultTransferStatus(FancyOStream& o, bool& s)
       : out(o),
         success(s)
     { }
@@ -714,7 +709,7 @@ namespace {
     }
 
   private:
-    Teuchos::FancyOStream& out;
+    FancyOStream& out;
     bool& success;
   };
 
@@ -723,7 +718,58 @@ namespace {
     MultiVectorTransferFixture<Scalar, LO, GO> fixture(out, success);
 
     fixture.setup(0);
-    fixture.checkTransferStatus(DefaultNoTransfer<Scalar, LO, GO>(out, success));
+    fixture.performTransfer(CheckDefaultTransferStatus<Scalar, LO, GO>(out, success));
+  }
+
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( TransferArrived, CrsMatrix_defaultTrue, Scalar, LO, GO )
+  {
+    DiagonalCrsMatrixTransferFixture<Scalar, LO, GO> fixture(out, success);
+
+    fixture.setup();
+    fixture.performTransfer(CheckDefaultTransferStatus<char, LO, GO>(out, success));
+  }
+
+
+  template <typename Packet, typename LO, typename GO>
+  class CheckTransferArrivedForwardImport {
+  private:
+    using DistObjectRCP = RCP<DistObject<Packet, LO, GO>>;
+
+  public:
+    CheckTransferArrivedForwardImport(FancyOStream& o, bool& s)
+      : out(o),
+        success(s)
+    { }
+
+    void operator()(DistObjectRCP source, DistObjectRCP target) const {
+      Import<LO, GO> importer(source->getMap(), target->getMap());
+      target->beginImport(*source, importer, INSERT);
+      while (!target->transferArrived());
+      target->endImport(*source, importer, INSERT);
+      TEST_ASSERT(target->transferArrived());
+    }
+
+  private:
+    FancyOStream& out;
+    bool& success;
+  };
+
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( TransferArrived, MultiVector_forwardImportTrue, Scalar, LO, GO )
+  {
+    MultiVectorTransferFixture<Scalar, LO, GO> fixture(out, success);
+
+    fixture.setup(0);
+    fixture.performTransfer(CheckTransferArrivedForwardImport<Scalar, LO, GO>(out, success));
+    fixture.checkResults(ReferenceImportMultiVector<Scalar, LO, GO>());
+  }
+
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( TransferArrived, CrsMatrix_forwardImportTrue, Scalar, LO, GO )
+  {
+    DiagonalCrsMatrixTransferFixture<Scalar, LO, GO> fixture(out, success);
+
+    fixture.setup();
+    fixture.performTransfer(CheckTransferArrivedForwardImport<char, LO, GO>(out, success));
+    fixture.checkResults(ReferenceImportMatrix<Scalar, LO, GO>());
   }
 
 
@@ -749,6 +795,9 @@ namespace {
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( AsyncReverseExport, DiagonalCrsMatrix, SC, LO, GO ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( AsyncReverseExport, LowerTriangularCrsMatrix, SC, LO, GO ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( TransferArrived, MultiVector_defaultTrue, SC, LO, GO ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( TransferArrived, CrsMatrix_defaultTrue, SC, LO, GO ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( TransferArrived, MultiVector_forwardImportTrue, SC, LO, GO ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( TransferArrived, CrsMatrix_forwardImportTrue, SC, LO, GO ) \
 
   TPETRA_ETI_MANGLING_TYPEDEFS()
 

--- a/packages/tpetra/core/test/ImportExport2/AsyncTransfer_UnitTests.cpp
+++ b/packages/tpetra/core/test/ImportExport2/AsyncTransfer_UnitTests.cpp
@@ -111,6 +111,11 @@ namespace {
       transfer(sourceMV, targetMV);
     }
 
+    template <typename TransferMethod>
+    void checkTransferStatus(const TransferMethod& transfer) {
+      transfer(sourceMV, targetMV);
+    }
+
     template <typename ReferenceSolution>
     void checkResults(const ReferenceSolution& referenceSolution) {
       RCP<const mv_type> referenceMV = referenceSolution.generateWithClassicalCodePath(sourceMV, targetMap);
@@ -693,6 +698,35 @@ namespace {
   }
 
 
+  template <typename Packet, typename LO, typename GO>
+  class DefaultNoTransfer {
+  private:
+    using DistObjectRCP = RCP<DistObject<Packet, LO, GO>>;
+
+  public:
+    DefaultNoTransfer(Teuchos::FancyOStream& o, bool& s)
+      : out(o),
+        success(s)
+    { }
+
+    void operator()(DistObjectRCP source, DistObjectRCP target) const {
+      TEST_ASSERT(target->transferArrived());
+    }
+
+  private:
+    Teuchos::FancyOStream& out;
+    bool& success;
+  };
+
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( TransferArrived, MultiVector_defaultTrue, Scalar, LO, GO )
+  {
+    MultiVectorTransferFixture<Scalar, LO, GO> fixture(out, success);
+
+    fixture.setup(0);
+    fixture.checkTransferStatus(DefaultNoTransfer<Scalar, LO, GO>(out, success));
+  }
+
+
   //
   // INSTANTIATIONS
   //
@@ -714,6 +748,7 @@ namespace {
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( AsyncReverseExport, MultiVector_rank1, SC, LO, GO ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( AsyncReverseExport, DiagonalCrsMatrix, SC, LO, GO ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( AsyncReverseExport, LowerTriangularCrsMatrix, SC, LO, GO ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( TransferArrived, MultiVector_defaultTrue, SC, LO, GO ) \
 
   TPETRA_ETI_MANGLING_TYPEDEFS()
 


### PR DESCRIPTION
@trilinos/tpetra @vbrunini 

## Motivation
Provides a transferArrived function for DistObject, that will return true once the data from transfer started by beginImport etc. has been communicated appropriately and is ready for the unpack and combine step performed by endImport etc.

This is a repost of #9902 to attempt to work around autotester issues.

## Related Issues

* Related to #9251

## Testing
This PR includes unit tests for the new transferArrived function.  There are no specific tests that transferArrived returns false for CrsMatrix when beginImport is only called on one rank, because CrsMatrix uses the "variable number of packets per LID" code path, which requires a blocking communication across all ranks to establish the number of packets each rank should expect to receive.  However, the conditions under which transferArrived returns false are still tested through the MultiVector.