### PR TITLE
Pytrilinos: Actually use MPI_BASE_DIR

### DIFF
--- a/packages/PyTrilinos/src/gen_teuchos_rcp.py.in
+++ b/packages/PyTrilinos/src/gen_teuchos_rcp.py.in
@@ -53,7 +53,7 @@ if WITH_MPI:
 ################################################################################
 
 def get_mpi_version():
-    header = "${MPI_BASE_DIR}/include/mpi.h"
+    header = os.path.join(MPI_BASE_DIR, "include/mpi.h")
     version = ""
     for line in open(header, 'r').readlines():
         if "MPI_VERSION" in line:


### PR DESCRIPTION
@trilinos/pytrilinos

This should fix 1eaf4cb0ee266d9e8ba309a8ee07a68dc4e6e988, which currently appears to do nothing.