### PR TITLE
MueLu: control if dropping creates new Dirichlet

### DIFF
--- a/packages/muelu/src/Graph/MatrixTransformation/MueLu_CoalesceDropFactory_def.hpp
+++ b/packages/muelu/src/Graph/MatrixTransformation/MueLu_CoalesceDropFactory_def.hpp
@@ -194,7 +194,7 @@ namespace MueLu {
 
     GetOStream(Parameters0) << "lightweight wrap = " << doExperimentalWrap << std::endl;
     std::string algo = pL.get<std::string>("aggregation: drop scheme");
-    const bool filteringMayCreateDirichlet = pL.get<bool>("aggregation: dropping may create Dirichlet");
+    const bool aggregationMayCreateDirichlet = pL.get<bool>("aggregation: dropping may create Dirichlet");
     
     RCP<RealValuedMultiVector> Coords;
     RCP<Matrix> A;
@@ -672,7 +672,7 @@ namespace MueLu {
           columns.resize(realnnz);
           numTotal = A->getNodeNumEntries();
 
-          if (filteringMayCreateDirichlet) {
+          if (aggregationMayCreateDirichlet) {
             // If the only element remaining after filtering is diagonal, mark node as boundary
             for (LO row = 0; row < Teuchos::as<LO>(A->getRowMap()->getNodeNumElements()); ++row) {
               if (rows[row+1]- rows[row] <= 1)

--- a/packages/muelu/src/Graph/MatrixTransformation/MueLu_CoalesceDropFactory_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/MatrixTransformation/MueLu_CoalesceDropFactory_kokkos_def.hpp
@@ -188,7 +188,8 @@ namespace MueLu {
                     typename rows_type::non_const_type rows_,
                     typename cols_type::non_const_type colsAux_,
                     typename vals_type::non_const_type valsAux_,
-                    bool reuseGraph_, bool lumping_, SC /* threshold_ */) :
+                    bool reuseGraph_, bool lumping_, SC /* threshold_ */,
+                    bool filteringMayCreateDirichlet_ ) :
           A(A_),
           bndNodes(bndNodes_),
           dropFunctor(dropFunctor_),
@@ -196,7 +197,8 @@ namespace MueLu {
           colsAux(colsAux_),
           valsAux(valsAux_),
           reuseGraph(reuseGraph_),
-          lumping(lumping_)
+          lumping(lumping_),
+          filteringMayCreateDirichlet(filteringMayCreateDirichlet_)
       {
         rowsA = A.graph.row_map;
         zero = ATS::zero();
@@ -250,7 +252,7 @@ namespace MueLu {
         //        boundaryNodes[row] = true;
         // We do not do it this way now because there is no framework for distinguishing isolated
         // and boundary nodes in the aggregation algorithms
-        bndNodes(row) = (rownnz == 1);
+        bndNodes(row) = (rownnz == 1 && filteringMayCreateDirichlet);
 
         nnz += rownnz;
       }
@@ -268,6 +270,7 @@ namespace MueLu {
 
       bool                                  reuseGraph;
       bool                                  lumping;
+      bool                                  filteringMayCreateDirichlet;
       SC                                    zero;
     };
 
@@ -453,6 +456,7 @@ namespace MueLu {
     SET_VALID_ENTRY("aggregation: drop tol");
     SET_VALID_ENTRY("aggregation: Dirichlet threshold");
     SET_VALID_ENTRY("aggregation: drop scheme");
+    SET_VALID_ENTRY("aggregation: dropping may create Dirichlet");
     SET_VALID_ENTRY("filtered matrix: use lumping");
     SET_VALID_ENTRY("filtered matrix: reuse graph");
     SET_VALID_ENTRY("filtered matrix: reuse eigenvalue");
@@ -558,6 +562,8 @@ namespace MueLu {
       if (lumping)
         GetOStream(Runtime0) << "Lumping dropped entries" << std::endl;
 
+      const bool filteringMayCreateDirichlet = pL.get<bool>("aggregation: dropping may create Dirichlet");
+
       // FIXME_KOKKOS: replace by ViewAllocateWithoutInitializing + setting a single value
       rows_type rows   ("FA_rows",     numRows+1);
       cols_type colsAux(Kokkos::ViewAllocateWithoutInitializing("FA_aux_cols"), nnzA);
@@ -603,7 +609,7 @@ namespace MueLu {
 
             CoalesceDrop_Kokkos_Details::ClassicalDropFunctor<LO, decltype(ghostedDiagView)> dropFunctor(ghostedDiagView, threshold);
             CoalesceDrop_Kokkos_Details::ScalarFunctor<typename ATS::val_type, LO, local_matrix_type, decltype(bndNodes), decltype(dropFunctor)>
-              scalarFunctor(kokkosMatrix, bndNodes, dropFunctor, rows, colsAux, valsAux, reuseGraph, lumping, threshold);
+              scalarFunctor(kokkosMatrix, bndNodes, dropFunctor, rows, colsAux, valsAux, reuseGraph, lumping, threshold, filteringMayCreateDirichlet);
 
             Kokkos::parallel_reduce("MueLu:CoalesceDropF:Build:scalar_filter:main_loop", range_type(0,numRows),
                                     scalarFunctor, nnzFA);
@@ -674,7 +680,7 @@ namespace MueLu {
             CoalesceDrop_Kokkos_Details::DistanceLaplacianDropFunctor<LO, decltype(ghostedLaplDiagView), decltype(distFunctor)>
                 dropFunctor(ghostedLaplDiagView, distFunctor, threshold);
             CoalesceDrop_Kokkos_Details::ScalarFunctor<SC, LO, local_matrix_type, decltype(bndNodes), decltype(dropFunctor)>
-                scalarFunctor(kokkosMatrix, bndNodes, dropFunctor, rows, colsAux, valsAux, reuseGraph, lumping, threshold);
+                scalarFunctor(kokkosMatrix, bndNodes, dropFunctor, rows, colsAux, valsAux, reuseGraph, lumping, threshold, true);
 
             Kokkos::parallel_reduce("MueLu:CoalesceDropF:Build:scalar_filter:main_loop", range_type(0,numRows),
                                     scalarFunctor, nnzFA);

--- a/packages/muelu/src/Graph/MatrixTransformation/MueLu_CoalesceDropFactory_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/MatrixTransformation/MueLu_CoalesceDropFactory_kokkos_def.hpp
@@ -189,7 +189,7 @@ namespace MueLu {
                     typename cols_type::non_const_type colsAux_,
                     typename vals_type::non_const_type valsAux_,
                     bool reuseGraph_, bool lumping_, SC /* threshold_ */,
-                    bool filteringMayCreateDirichlet_ ) :
+                    bool aggregationMayCreateDirichlet_ ) :
           A(A_),
           bndNodes(bndNodes_),
           dropFunctor(dropFunctor_),
@@ -198,7 +198,7 @@ namespace MueLu {
           valsAux(valsAux_),
           reuseGraph(reuseGraph_),
           lumping(lumping_),
-          filteringMayCreateDirichlet(filteringMayCreateDirichlet_)
+          aggregationMayCreateDirichlet(aggregationMayCreateDirichlet_)
       {
         rowsA = A.graph.row_map;
         zero = ATS::zero();
@@ -252,7 +252,7 @@ namespace MueLu {
         //        boundaryNodes[row] = true;
         // We do not do it this way now because there is no framework for distinguishing isolated
         // and boundary nodes in the aggregation algorithms
-        bndNodes(row) = (rownnz == 1 && filteringMayCreateDirichlet);
+        bndNodes(row) = (rownnz == 1 && aggregationMayCreateDirichlet);
 
         nnz += rownnz;
       }
@@ -270,7 +270,7 @@ namespace MueLu {
 
       bool                                  reuseGraph;
       bool                                  lumping;
-      bool                                  filteringMayCreateDirichlet;
+      bool                                  aggregationMayCreateDirichlet;
       SC                                    zero;
     };
 
@@ -562,7 +562,7 @@ namespace MueLu {
       if (lumping)
         GetOStream(Runtime0) << "Lumping dropped entries" << std::endl;
 
-      const bool filteringMayCreateDirichlet = pL.get<bool>("aggregation: dropping may create Dirichlet");
+      const bool aggregationMayCreateDirichlet = pL.get<bool>("aggregation: dropping may create Dirichlet");
 
       // FIXME_KOKKOS: replace by ViewAllocateWithoutInitializing + setting a single value
       rows_type rows   ("FA_rows",     numRows+1);
@@ -609,7 +609,7 @@ namespace MueLu {
 
             CoalesceDrop_Kokkos_Details::ClassicalDropFunctor<LO, decltype(ghostedDiagView)> dropFunctor(ghostedDiagView, threshold);
             CoalesceDrop_Kokkos_Details::ScalarFunctor<typename ATS::val_type, LO, local_matrix_type, decltype(bndNodes), decltype(dropFunctor)>
-              scalarFunctor(kokkosMatrix, bndNodes, dropFunctor, rows, colsAux, valsAux, reuseGraph, lumping, threshold, filteringMayCreateDirichlet);
+              scalarFunctor(kokkosMatrix, bndNodes, dropFunctor, rows, colsAux, valsAux, reuseGraph, lumping, threshold, aggregationMayCreateDirichlet);
 
             Kokkos::parallel_reduce("MueLu:CoalesceDropF:Build:scalar_filter:main_loop", range_type(0,numRows),
                                     scalarFunctor, nnzFA);


### PR DESCRIPTION
This commit adds a CoalesceDrop option (Kokkos factory path) to control
whether filtering can create new Dirichlet rows.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/muelu

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
This option is already available in the non-Kokkos aggregation path.  (PR #9993.)

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
N/A

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
This PR includes a unit test.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->