### PR TITLE
Add support for subpackage-specific compiler flags (#10111)

### DIFF
--- a/cmake/tribits/core/package_arch/TribitsPackageSetupCompilerFlags.cmake
+++ b/cmake/tribits/core/package_arch/TribitsPackageSetupCompilerFlags.cmake
@@ -58,9 +58,9 @@ macro(tribits_apply_warnings_as_error_flags_lang LANG)
 endmacro()
 
 
-macro(tribits_set_package_language_flags LANG)
+macro(tribits_set_package_compiler_lang_flags LANG)
 
-  #message("Entering tribits_set_package_language_flags(${LANG})")
+  #message("Entering tribits_set_package_compiler_lang_flags(${LANG})")
   #print_var(${PROJECT_NAME}_ENABLE_STRONG_${LANG}_COMPILE_WARNINGS)
 
   if (${PACKAGE_NAME}_${LANG}_FLAGS)
@@ -68,65 +68,77 @@ macro(tribits_set_package_language_flags LANG)
       "${${PACKAGE_NAME}_${LANG}_FLAGS}")
   endif()
 
-  if(${PROJECT_NAME}_VERBOSE_CONFIGURE)
-    message(STATUS "Adding strong ${LANG} warning flags \"${${LANG}_STRONG_COMPILE_WARNING_FLAGS}\"")
-    print_var(CMAKE_${LANG}_FLAGS)
-  endif()
-
 endmacro()
 
 
-function(tribits_setup_add_package_compile_flags)
+function(tribits_print_package_compiler_lang_flags LANG SUFFIX)
+    message("-- " "${PACKAGE_NAME}: CMAKE_${LANG}_FLAGS${SUFFIX}=\"${CMAKE_${LANG}_FLAGS${SUFFIX}}\"")
+endfunction()
 
-  #message("Entering tribits_setup_add_package_compile_flags()")
 
-  #
+# Function that appends package-specific compiler flags for each language
+#
+function(tribits_append_package_specific_compiler_flags)
+
+  #message("Entering tribits_append_package_specific_compiler_flags() for ${PACKAGE_NAME}")
+
   # C compiler options
-  #
-
   assert_defined(${PROJECT_NAME}_ENABLE_C CMAKE_C_COMPILER_ID)
   if (${PROJECT_NAME}_ENABLE_C)
-    tribits_set_package_language_flags(C)
+    tribits_set_package_compiler_lang_flags(C)
   endif()
 
-  #
   # C++ compiler options
-  #
-
   assert_defined(${PROJECT_NAME}_ENABLE_CXX CMAKE_CXX_COMPILER_ID)
   if (${PROJECT_NAME}_ENABLE_CXX)
-    tribits_set_package_language_flags(CXX)
+    tribits_set_package_compiler_lang_flags(CXX)
   endif()
 
-  #
   # Fortran compiler options
-  #
-
   assert_defined(${PROJECT_NAME}_ENABLE_Fortran)
   if (${PROJECT_NAME}_ENABLE_Fortran)
-    tribits_set_package_language_flags(Fortran)
+    tribits_set_package_compiler_lang_flags(Fortran)
   endif()
 
 endfunction()
 
 
-
-
-
-
-
-
-
-
-
-
-
+# Function that prints out all of the compiler flags for a package
 #
-# Macro that sets up compiler flags for a package
+function(tribits_print_package_compiler_flags)
+
+  if(${PROJECT_NAME}_VERBOSE_CONFIGURE OR ${PROJECT_NAME}_PRINT_PACKAGE_COMPILER_FLAGS)
+
+    string(TOUPPER "${CMAKE_BUILD_TYPE}" upperBuildType)
+    set(buildNameSuffix "_${upperBuildType}")
+
+    # C compiler options
+    if (${PROJECT_NAME}_ENABLE_C)
+      tribits_print_package_compiler_lang_flags(C "")
+      tribits_print_package_compiler_lang_flags(C ${buildNameSuffix})
+    endif()
+
+    # C++ compiler options
+    if (${PROJECT_NAME}_ENABLE_CXX)
+      tribits_print_package_compiler_lang_flags(CXX "")
+      tribits_print_package_compiler_lang_flags(CXX ${buildNameSuffix})
+    endif()
+
+    # Fortran compiler options
+    if (${PROJECT_NAME}_ENABLE_Fortran)
+      tribits_print_package_compiler_lang_flags(Fortran "")
+      tribits_print_package_compiler_lang_flags(Fortran ${buildNameSuffix})
+    endif()
+
+  endif()
+
+endfunction()
+
+
+# Macro that sets up compiler flags for a top-level package (not subpackage)
 #
 # This CMake code is broken out in order to allow it to be unit tested.
 #
-
 macro(tribits_setup_compiler_flags  PACKAGE_NAME_IN)
 
   # Set up strong warning flags
@@ -149,17 +161,11 @@ macro(tribits_setup_compiler_flags  PACKAGE_NAME_IN)
     tribits_apply_warnings_as_error_flags_lang(CXX)
   endif()
 
-  # Append package specific options
-  tribits_setup_add_package_compile_flags()
+  tribits_append_package_specific_compiler_flags()
 
-  if (${PROJECT_NAME}_VERBOSE_CONFIGURE)
-    message("Final compiler flags:")
-    print_var(CMAKE_CXX_FLAGS)
-    print_var(CMAKE_CXX_FLAGS_${CMAKE_BUILD_TYPE})
-    print_var(CMAKE_C_FLAGS)
-    print_var(CMAKE_C_FLAGS_${CMAKE_BUILD_TYPE})
-    print_var(CMAKE_Fortran_FLAGS)
-    print_var(CMAKE_Fortran_FLAGS_${CMAKE_BUILD_TYPE})
+  if(${PROJECT_NAME}_VERBOSE_CONFIGURE)
+    message("Final package compiler flags:")
   endif()
+  tribits_print_package_compiler_flags()
 
 endmacro()

--- a/cmake/tribits/core/package_arch/TribitsSubPackageMacros.cmake
+++ b/cmake/tribits/core/package_arch/TribitsSubPackageMacros.cmake
@@ -41,7 +41,6 @@ include(TribitsPackageMacros)
 include(TribitsReportInvalidTribitsUsage)
 
 
-#
 # @MACRO: tribits_subpackage()
 #
 # Forward declare a `TriBITS Subpackage`_ called at the top of the
@@ -78,18 +77,42 @@ macro(tribits_subpackage SUBPACKAGE_NAME_IN)
     message("\nSUBPACKAGE: ${SUBPACKAGE_NAME_IN}")
   endif()
 
+  tribits_subpackage_assert_call_context()
+
+  # To provide context for various macros
+  set(PACKAGE_NAME ${SUBPACKAGE_FULLNAME})
+
+  set(PARENT_PACKAGE_SOURCE_DIR "${PACKAGE_SOURCE_DIR}")
+  set(PARENT_PACKAGE_BINARY_DIR "${PACKAGE_BINARY_DIR}")
+
+  # Now override the package-like variables
+  tribits_set_common_vars(${SUBPACKAGE_FULLNAME})
+  tribits_define_linkage_vars(${SUBPACKAGE_FULLNAME})
+
+  tribits_append_package_specific_compiler_flags()
+  if(${PROJECT_NAME}_VERBOSE_CONFIGURE)
+    message("Final subpackage compiler flags:")
+  endif()
+  tribits_print_package_compiler_flags()
+
+  # Set flags that are used  to check that macros are called in the correct order
+  set(${SUBPACKAGE_FULLNAME}_TRIBITS_SUBPACKAGE_CALLED TRUE)
+  set(${SUBPACKAGE_FULLNAME}_TRIBITS_SUBPACKAGE_POSTPROCESS_CALLED FALSE)
+
+endmacro()
+
+
+function(tribits_subpackage_assert_call_context)
+
   # check that this is not being called from a package
   if (NOT CURRENTLY_PROCESSING_SUBPACKAGE)
-  # we are in a package
-
+    # we are in a package
     tribits_report_invalid_tribits_usage(
       "Cannot call tribits_subpackage() from a package."
       " Use tribits_package() instead"
       " ${CURRENT_PACKAGE_CMAKELIST_FILE}")
-
   else()
-  # We are in a subpackage
-
+    # We are in a subpackage
     # check to see if postprocess is called before subpackage
     if(${SUBPACKAGE_FULLNAME}_TRIBITS_SUBPACKAGE_POSTPROCESS_CALLED)
       tribits_report_invalid_tribits_usage(
@@ -113,25 +136,10 @@ macro(tribits_subpackage SUBPACKAGE_NAME_IN)
     endif()
   endif()
 
-
-  # To provide context for various macros
-  set(PACKAGE_NAME ${SUBPACKAGE_FULLNAME})
-
-  set(PARENT_PACKAGE_SOURCE_DIR "${PACKAGE_SOURCE_DIR}")
-  set(PARENT_PACKAGE_BINARY_DIR "${PACKAGE_BINARY_DIR}")
-
-  # Now override the package-like variables
-  tribits_set_common_vars(${SUBPACKAGE_FULLNAME})
-  tribits_define_linkage_vars(${SUBPACKAGE_FULLNAME})
-
-  # Set flags that are used  to check that macros are called in the correct order
-  set(${SUBPACKAGE_FULLNAME}_TRIBITS_SUBPACKAGE_CALLED TRUE)
-  set(${SUBPACKAGE_FULLNAME}_TRIBITS_SUBPACKAGE_POSTPROCESS_CALLED FALSE)
-
-endmacro()
+endfunction()
 
 
-#
+
 # @MACRO: tribits_subpackage_postprocess()
 #
 # Macro that performs standard post-processing after defining a `TriBITS


### PR DESCRIPTION
Fixes #10111

This brings in just the commit https://github.com/TriBITSPub/TriBITS/pull/453/commits/8ddc37c53fc67b28167d09c56bdd56db3572052f from PR TriBITSPub/TriBITS#453:

* TriBITSPub/TriBITS#453 (see the detailed automated tests there)
 
I could not sync all of TriBITS due to outstanding Trilinos PR #9978 (see TriBITSPub/TriBITS#433).  This make the Git work more tricky.

The git gymnastics to cherry-pick and snapshot just the commit https://github.com/TriBITSPub/TriBITS/pull/453/commits/8ddc37c53fc67b28167d09c56bdd56db3572052f were a bit involved but I will explain it in detail below.  (I need to document this workflow in a technical document about how to patch a snapshot with just cherry-picked commits from the other repo being snapshotted in.)

<details>

<summary><b>Git operations to snapshot just the cherry-picked commit from TriBITS</b> (click to expand)</summary>

.

In order to allow Git to do all the work to adjust for the different base versions of TriBITS, you have to:

1. Find the version of TriBITS in the most recent snapshot of TriBITS into Trilinos 'develop' (in this case, it was Trilinos commit 5ab3736f0ebbc8a2da3944e768ae359e8fc0284d)

2. Get the version of TriBITS from that most recent snapshot (in this case, it was commit TriBITSPub/TriBITS@1241168)

3. Create a temp branch 'tril-10111-subpackage-lang-flags-patch' in the TriBITS repo off that TriBITS version TriBITSPub/TriBITS@1241168

4. Cherry-pick the TriBITS commit https://github.com/TriBITSPub/TriBITS/pull/453/commits/8ddc37c53fc67b28167d09c56bdd56db3572052f from TriBITS PR https://github.com/TriBITSPub/TriBITS/pull/453 onto the TriBITS repo branch 'tril-10111-subpackage-lang-flags-patch'.

5. Push the new TriBITS branch 'tril-10111-subpackage-lang-flags-patch' to a remote repo.

6. Back in the Trilinos repo, create a temp branch '10111-subpackage-lang-flags-tribits-snapshot' off of the most recent Trilinos TriBITS snapshot commit 5ab3736f0ebbc8a2da3944e768ae359e8fc0284d

7. Snapshot the TriBITS version on TriBITS branch 'tril-10111-subpackage-lang-flags-patch' into the temp Trilinos branch '10111-subpackage-lang-flags-tribits-snapshot'.

8. Create a new Trilinos branch '10111-subpackage-lang-flags' off of Trilinos 'develop'

9. Merge the temp Trilinos branch '10111-subpackage-lang-flags-tribits-snapshot' into the branch '10111-subpackage-lang-flags'.

10. Push the branch '10111-subpackage-lang-flags' to a remote.

11. Create this PR from the branch '10111-subpackage-lang-flags'

Yes, that is a lot of git commands but the magic of this is that the patch from a future version of TriBITS from PR TriBITSPub/TriBITS#453 is adjusted back to the older version of TriBITS currently in Trilinos 'develop' and then merged back into Trilinos 'develop' cleanly.  And the version info is sustained the whole time.

</details> 