### PR TITLE
MueLu: enable user-supplied eigen-value for SaP

### DIFF
--- a/packages/muelu/src/Smoothers/MueLu_Ifpack2Smoother_def.hpp
+++ b/packages/muelu/src/Smoothers/MueLu_Ifpack2Smoother_def.hpp
@@ -833,6 +833,9 @@ namespace MueLu {
       else
         lambdaMax = paramList.get<SC>(maxEigString);
       this->GetOStream(Statistics1) << label << maxEigString << " (cached with smoother parameter list) = " << lambdaMax << std::endl;
+      RCP<Matrix> matA = rcp_dynamic_cast<Matrix>(A_);
+      if (!matA.is_null())
+        matA->SetMaxEigenvalueEstimate(lambdaMax);
       
     } else {
       lambdaMax = currentA->GetMaxEigenvalueEstimate();


### PR DESCRIPTION
If the user __supplies__ an eigenvalue estimate for Chebyshev smoothing, cache it for later use in prolongator smoothing. (There is already an option to force a new eigenvalue estimate in the SaPFactory.)

This is a bit of corner case, since MueLu already has the capability to cache an eigenvalue estimate __calculated__ by Chebyshev for later use in the SaPFactory.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/<teamName>

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Tested locally on ascicgpu031.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->