### PR TITLE
Teuchos: Convert KokkosCompat::deep_copy_offset to use 3-arg deep_copy to avoid fences

### DIFF
--- a/packages/teuchos/kokkoscompat/src/KokkosCompat_View.hpp
+++ b/packages/teuchos/kokkoscompat/src/KokkosCompat_View.hpp
@@ -265,7 +265,7 @@ namespace Kokkos {
         dst, std::make_pair (dst_offset, dst_end));
       SrcViewType src_sub = Kokkos::subview(
         src, std::make_pair (src_offset, src_end));
-      Kokkos::deep_copy(dst_sub, src_sub);
+      Kokkos::deep_copy(typename SrcViewType::execution_space(), dst_sub, src_sub);
     }
 
     template <class ViewType>


### PR DESCRIPTION
@trilinos/teuchos @trilinos/tpetra @trilinos/zoltan2 @seheracer @kddevin 

## Motivation
The source of the slowdown observed in #10194 seems to be that `KokkosCompat::deep_copy_offset` used the 2-arg version of `deep_copy`, which fences across all execution spaces.  Experiments with fencing seem to indicate that Zoltan2 was trying to overlap host-side communication with device-side work, and the fences in `deep_copy` were causing the communication to block until the device-side work had completed.  Changing to 3-arg deep copy, which doesn't unconditionally fence, seems to yield roughly equivalent performance to the `memcpy` solution in #10194.

## Related Issues

* Closes #10194

## Testing
Tpetra unit tests continue to pass in a Cuda (non-UVM) build on ascicgpu.