### PR TITLE
Piro: Create a Forward Only Tempus Solver

### DIFF
--- a/packages/piro/src/Piro_TempusSolverForwardOnly.hpp
+++ b/packages/piro/src/Piro_TempusSolverForwardOnly.hpp
@@ -1,0 +1,180 @@
+// @HEADER
+// ************************************************************************
+//
+//        Piro: Strategy package for embedded analysis capabilitites
+//                  Copyright (2010) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Andy Salinger (agsalin@sandia.gov), Sandia
+// National Laboratories.
+//
+// ************************************************************************
+// @HEADER
+
+#ifndef PIRO_TEMPUSSOLVERMIMIC_H
+#define PIRO_TEMPUSSOLVERMIMIC_H
+
+#include "Piro_ConfigDefs.hpp"
+#include "Thyra_ResponseOnlyModelEvaluatorBase.hpp"
+
+//#include "Rythmos_DefaultIntegrator.hpp"
+//#include "Rythmos_IntegrationObserverBase.hpp"
+//#include "Rythmos_TimeStepNonlinearSolver.hpp"
+
+#include "Tempus_IntegratorBasic.hpp"
+#include "Tempus_Stepper.hpp"
+#include "Tempus_IntegratorObserver.hpp"
+
+#include "Piro_ObserverBase.hpp"
+
+//#include "Piro_RythmosStepperFactory.hpp"
+//#include "Piro_RythmosStepControlFactory.hpp"
+
+#include <map>
+#include <string>
+
+namespace Piro {
+
+/** \brief Thyra-based Model Evaluator for Tempus solves
+ *  that mimics Piro_TempusSolverForwardOnly.hpp.
+ */
+template <typename Scalar>
+class TempusSolverForwardOnly
+    : public Thyra::ResponseOnlyModelEvaluatorBase<Scalar>
+{
+public:
+  /** \name Constructors/initializers */
+  //@{
+
+  /** \brief Initializes the internals, though the object is a blank slate. To initialize it call <code>initialize</code> */
+  TempusSolverForwardOnly();
+
+  /** \brief Initialize with internally built objects according to the given parameter list. */
+  TempusSolverForwardOnly(
+      const Teuchos::RCP<Teuchos::ParameterList> &appParams,
+      const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > &in_model,
+      const Teuchos::RCP<Tempus::IntegratorObserver<Scalar> > &observer = Teuchos::null);
+
+  /** \brief Initialize using prebuilt objects. */
+  TempusSolverForwardOnly(
+      const Teuchos::RCP<Tempus::IntegratorBasic<Scalar> > &stateIntegrator,
+      const Teuchos::RCP<Tempus::Stepper<Scalar> > &stateStepper,
+      const Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > &timeStepSolver,
+      const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > &in_model,
+      Scalar finalTime,
+      const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > &initialConditionModel = Teuchos::null,
+      Teuchos::EVerbosityLevel verbosityLevel = Teuchos::VERB_DEFAULT);
+  //@}
+
+  /** \brief Initialize using prebuilt objects - supplying initial time value. */
+  TempusSolverForwardOnly(
+      const Teuchos::RCP<Tempus::IntegratorBasic<Scalar> > &stateIntegrator,
+      const Teuchos::RCP<Tempus::Stepper<Scalar> > &stateStepper,
+      const Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > &timeStepSolver,
+      const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > &in_model,
+      Scalar initialTime,
+      Scalar finalTime,
+      const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > &initialConditionModel = Teuchos::null,
+      Teuchos::EVerbosityLevel verbosityLevel = Teuchos::VERB_DEFAULT);
+  //@}
+
+  void initialize(
+      const Teuchos::RCP<Teuchos::ParameterList> &appParams,
+      const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > &in_model,
+      const Teuchos::RCP<Tempus::IntegratorObserver<Scalar> > &observer = Teuchos::null);
+
+  Teuchos::RCP<const Tempus::IntegratorBasic<Scalar> > getTempusIntegrator() const;
+
+  Teuchos::RCP<const Thyra::NonlinearSolverBase<Scalar> > getTimeStepSolver() const;
+
+  /** \name Overridden from Thyra::ModelEvaluatorBase. */
+  //@{
+  /** \brief . */
+  Thyra::ModelEvaluatorBase::InArgs<Scalar> getNominalValues() const;
+  /** \brief . */
+  Thyra::ModelEvaluatorBase::InArgs<Scalar> createInArgs() const;
+  /** \brief . */
+  Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> > get_p_space(int l) const;
+  /** \brief . */
+  Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> > get_g_space(int j) const;
+  //@}
+
+
+private:
+  /** \name Overridden from Thyra::ModelEvaluatorDefaultBase. */
+  //@{
+  /** \brief . */
+  Thyra::ModelEvaluatorBase::OutArgs<Scalar> createOutArgsImpl() const;
+
+  /** \brief . */
+  void evalModelImpl(
+      const Thyra::ModelEvaluatorBase::InArgs<Scalar>& inArgs,
+      const Thyra::ModelEvaluatorBase::OutArgs<Scalar>& outArgs) const;
+  //@}
+
+  Teuchos::RCP<Thyra::LinearOpBase<Scalar> > create_DgDp_op_impl(int j, int l) const;
+
+  /** \brief . */
+  Teuchos::RCP<const Teuchos::ParameterList> getValidTempusParameters() const;
+  Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > getUnderlyingModel() const;
+  Scalar get_t_initial() const;
+  Scalar get_t_final() const;
+  int get_num_p() const;
+  int get_num_g() const;
+
+  Teuchos::RCP<Tempus::IntegratorBasic<Scalar> > fwdStateIntegrator;
+
+  Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > initialConditionModel;
+
+  Teuchos::RCP<Teuchos::FancyOStream> out;
+  Teuchos::EVerbosityLevel solnVerbLevel;
+
+  bool isInitialized;
+};
+
+/** \brief Non-member constructor function */
+template <typename Scalar>
+Teuchos::RCP<TempusSolverForwardOnly<Scalar> >
+tempusSolverForwardOnly(
+    const Teuchos::RCP<Teuchos::ParameterList> &appParams,
+    const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > &in_model,
+    const Teuchos::RCP<ObserverBase<Scalar> > &piroObserver);
+
+}
+
+/** \class Piro::TempusSolverForwardOnly
+ *  \ingroup Piro_Thyra_solver_grp
+ * */
+
+#include "Piro_TempusSolverForwardOnly_Def.hpp"
+
+#endif

--- a/packages/piro/src/Piro_TempusSolverForwardOnly_Def.hpp
+++ b/packages/piro/src/Piro_TempusSolverForwardOnly_Def.hpp
@@ -1,0 +1,591 @@
+// @HEADER
+// ************************************************************************
+//
+//        Piro: Strategy package for embedded analysis capabilitites
+//                  Copyright (2010) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Andy Salinger (agsalin@sandia.gov), Sandia
+// National Laboratories.
+//
+// ************************************************************************
+// @HEADER
+
+#include "Piro_TempusSolverForwardOnly.hpp"
+
+#include "Piro_ObserverToTempusIntegrationObserverAdapter.hpp"
+#include "Piro_ValidPiroParameters.hpp"
+#include "Piro_MatrixFreeDecorator.hpp"
+
+#include "Teuchos_ScalarTraits.hpp"
+#include "Teuchos_Array.hpp"
+#include "Teuchos_Tuple.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_Assert.hpp"
+
+#include "Thyra_DefaultAddedLinearOp.hpp"
+#include "Thyra_DefaultMultipliedLinearOp.hpp"
+#include "Thyra_DefaultZeroLinearOp.hpp"
+#include "Thyra_VectorStdOps.hpp"
+#include "Thyra_DefaultModelEvaluatorWithSolveFactory.hpp"
+
+#include "Stratimikos_DefaultLinearSolverBuilder.hpp"
+
+#include "Piro_InvertMassMatrixDecorator.hpp"
+
+#ifdef HAVE_PIRO_IFPACK2
+#include "Thyra_Ifpack2PreconditionerFactory.hpp"
+#include "Tpetra_CrsMatrix.hpp"
+#endif
+
+#ifdef HAVE_PIRO_MUELU
+#include <Thyra_MueLuPreconditionerFactory.hpp>
+#include "Stratimikos_MueLuHelpers.hpp"
+#endif
+
+#ifdef HAVE_PIRO_NOX
+#  include "Thyra_NonlinearSolver_NOX.hpp"
+#endif
+
+#include <string>
+#include <stdexcept>
+#include <iostream>
+
+template <typename Scalar>
+Piro::TempusSolverForwardOnly<Scalar>::TempusSolverForwardOnly() :
+  out(Teuchos::VerboseObjectBase::getDefaultOStream()),
+  isInitialized(false)
+{
+}
+
+template <typename Scalar>
+Piro::TempusSolverForwardOnly<Scalar>::TempusSolverForwardOnly(
+  const Teuchos::RCP<Teuchos::ParameterList> &appParams,
+  const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > &in_model,
+  const Teuchos::RCP<Tempus::IntegratorObserver<Scalar> > &observer)
+  : out(Teuchos::VerboseObjectBase::getDefaultOStream()),
+    isInitialized(false)
+{
+  std::string jacobianSource = appParams->get("Jacobian Operator", "Have Jacobian");
+  if (jacobianSource == "Matrix-Free") {
+    Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > mf_model;
+    if (appParams->isParameter("Matrix-Free Perturbation")) {
+      mf_model = Teuchos::rcp(new Piro::MatrixFreeDecorator<Scalar>(in_model,
+                           appParams->get<double>("Matrix-Free Perturbation")));
+    }
+    else mf_model = Teuchos::rcp(new Piro::MatrixFreeDecorator<Scalar>(in_model));
+    initialize(appParams, mf_model, observer);
+  }
+  else
+    initialize(appParams, in_model, observer);
+}
+
+template <typename Scalar>
+void Piro::TempusSolverForwardOnly<Scalar>::initialize(
+    const Teuchos::RCP<Teuchos::ParameterList> &appParams,
+    const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > &in_model,
+    const Teuchos::RCP<Tempus::IntegratorObserver<Scalar> > &observer)
+{
+
+  using Teuchos::ParameterList;
+  using Teuchos::parameterList;
+  using Teuchos::RCP;
+  using Teuchos::rcp;
+
+  //
+  *out << "\nA) Get the base parameter list ...\n";
+  //
+
+  TEUCHOS_TEST_FOR_EXCEPTION(appParams->isSublist("Tempus"),
+      Teuchos::Exceptions::InvalidParameter, std::endl <<
+      "Error! Piro::TempusSolverForwardOnly: must have Tempus sublist ");
+
+  RCP<Teuchos::ParameterList> tempusPL = sublist(appParams, "Tempus", true);
+  tempusPL->validateParameters(*getValidTempusParameters(),0);
+
+  //
+  *out << "\nD) Create the stepper and integrator for the forward problem ...\n";
+  //
+
+  fwdStateIntegrator = Tempus::createIntegratorBasic(tempusPL, in_model);
+
+
+  // Tempus does not have a Verbosity parameter, so set to default.
+  solnVerbLevel = Teuchos::VERB_DEFAULT;
+
+  if (Teuchos::nonnull(observer))
+    fwdStateIntegrator->setObserver(observer);
+
+  fwdStateIntegrator->initialize();
+
+  isInitialized = true;
+}
+
+template <typename Scalar>
+Piro::TempusSolverForwardOnly<Scalar>::TempusSolverForwardOnly(
+  const Teuchos::RCP<Tempus::IntegratorBasic<Scalar> > &stateIntegrator,
+  const Teuchos::RCP<Tempus::Stepper<Scalar> > &stateStepper,
+  const Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > &timeStepSolver,
+  const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > &underlyingModel,
+  Scalar finalTime,
+  const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > &icModel,
+  Teuchos::EVerbosityLevel verbosityLevel)
+  : fwdStateIntegrator(stateIntegrator),
+    initialConditionModel(icModel),
+    out(Teuchos::VerboseObjectBase::getDefaultOStream()),
+    solnVerbLevel(verbosityLevel),
+    isInitialized(true)
+{
+  if (fwdStateIntegrator->getStepper() != stateStepper) {
+    *out << "\nTempusSolverForwardOnly: Resetting the Stepper!\n";
+    fwdStateIntegrator->setStepper(stateStepper);
+  }
+
+  if (getTimeStepSolver() != timeStepSolver) {
+    *out << "\nTempusSolverForwardOnly: Resetting the solver!\n";
+    fwdStateIntegrator->getStepper()->setSolver(timeStepSolver);
+  }
+
+  if (getUnderlyingModel() != underlyingModel) {
+    *out << "\nTempusSolverForwardOnly: Resetting the model!\n";
+    fwdStateIntegrator->getStepper()->setModel(underlyingModel);
+  }
+
+  fwdStateIntegrator->getNonConstTimeStepControl()->setInitTime(0.0);
+  fwdStateIntegrator->getNonConstTimeStepControl()->setFinalTime(finalTime);
+}
+
+template <typename Scalar>
+Piro::TempusSolverForwardOnly<Scalar>::TempusSolverForwardOnly(
+  const Teuchos::RCP<Tempus::IntegratorBasic<Scalar> > &stateIntegrator,
+  const Teuchos::RCP<Tempus::Stepper<Scalar> > &stateStepper,
+  const Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > &timeStepSolver,
+  const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > &underlyingModel,
+  Scalar initialTime,
+  Scalar finalTime,
+  const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > &icModel,
+  Teuchos::EVerbosityLevel verbosityLevel)
+  : fwdStateIntegrator(stateIntegrator),
+    initialConditionModel(icModel),
+    out(Teuchos::VerboseObjectBase::getDefaultOStream()),
+    solnVerbLevel(verbosityLevel),
+    isInitialized(true)
+{
+  if (fwdStateIntegrator->getStepper() != stateStepper) {
+    *out << "\nTempusSolverForwardOnly: Resetting the Stepper!\n";
+    fwdStateIntegrator->setStepper(stateStepper);
+  }
+
+  if (fwdStateIntegrator->getStepper()->getSolver() != timeStepSolver) {
+    *out << "\nTempusSolverForwardOnly: Resetting the solver!\n";
+    fwdStateIntegrator->getStepper()->setSolver(timeStepSolver);
+  }
+
+  if (getUnderlyingModel() != underlyingModel) {
+    *out << "\nTempusSolverForwardOnly: Resetting the model!\n";
+    fwdStateIntegrator->getStepper()->setModel(underlyingModel);
+  }
+
+  fwdStateIntegrator->getNonConstTimeStepControl()->setInitTime(initialTime);
+  fwdStateIntegrator->getNonConstTimeStepControl()->setFinalTime(finalTime);
+}
+
+template <typename Scalar>
+Teuchos::RCP<const Tempus::IntegratorBasic<Scalar> >
+Piro::TempusSolverForwardOnly<Scalar>::getTempusIntegrator() const
+{
+  return fwdStateIntegrator;
+}
+
+
+template <typename Scalar>
+Teuchos::RCP<const Thyra::NonlinearSolverBase<Scalar> >
+Piro::TempusSolverForwardOnly<Scalar>::getTimeStepSolver() const
+{
+  return fwdStateIntegrator->getStepper()->getSolver();
+}
+
+template<typename Scalar>
+Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
+Piro::TempusSolverForwardOnly<Scalar>::get_p_space(int l) const
+{
+  TEUCHOS_TEST_FOR_EXCEPTION(
+      l >= get_num_p() || l < 0,
+      Teuchos::Exceptions::InvalidParameter,
+      std::endl <<
+      "Error in Piro::TempusSolverForwardOnly::get_p_map():  " <<
+      "Invalid parameter index l = " <<
+      l << std::endl);
+
+  return getUnderlyingModel()->get_p_space(l);
+}
+
+template<typename Scalar>
+Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
+Piro::TempusSolverForwardOnly<Scalar>::get_g_space(int j) const
+{
+  TEUCHOS_TEST_FOR_EXCEPTION(
+      j > get_num_g() || j < 0,
+      Teuchos::Exceptions::InvalidParameter,
+      std::endl <<
+      "Error in Piro::TempusSolverForwardOnly::get_g_map():  " <<
+      "Invalid response index j = " <<
+      j << std::endl);
+
+  if (j < get_num_g()) {
+    return getUnderlyingModel()->get_g_space(j);
+  } else {
+    // j == get_num_g()
+    return getUnderlyingModel()->get_x_space();
+  }
+}
+
+template<typename Scalar>
+Thyra::ModelEvaluatorBase::InArgs<Scalar>
+Piro::TempusSolverForwardOnly<Scalar>::getNominalValues() const
+{
+  Thyra::ModelEvaluatorBase::InArgs<Scalar> result = this->createInArgs();
+  const Thyra::ModelEvaluatorBase::InArgs<Scalar> modelNominalValues = getUnderlyingModel()->getNominalValues();
+  for (int l = 0; l < get_num_p(); ++l) {
+    result.set_p(l, modelNominalValues.get_p(l));
+  }
+  return result;
+}
+
+template <typename Scalar>
+Thyra::ModelEvaluatorBase::InArgs<Scalar>
+Piro::TempusSolverForwardOnly<Scalar>::createInArgs() const
+{
+  Thyra::ModelEvaluatorBase::InArgsSetup<Scalar> inArgs;
+  inArgs.setModelEvalDescription(this->description());
+  inArgs.set_Np(get_num_p());
+  return inArgs;
+}
+
+template <typename Scalar>
+Thyra::ModelEvaluatorBase::OutArgs<Scalar>
+Piro::TempusSolverForwardOnly<Scalar>::createOutArgsImpl() const
+{
+  Thyra::ModelEvaluatorBase::OutArgsSetup<Scalar> outArgs;
+  outArgs.setModelEvalDescription(this->description());
+
+  // One additional response slot for the solution vector
+  outArgs.set_Np_Ng(get_num_p(), get_num_g() + 1);
+
+  const Thyra::ModelEvaluatorBase::OutArgs<Scalar> modelOutArgs = getUnderlyingModel()->createOutArgs();
+
+  if (get_num_p() > 0) {
+    // Only one parameter supported
+    const int l = 0;
+
+    if (Teuchos::nonnull(initialConditionModel)) {
+      const Thyra::ModelEvaluatorBase::OutArgs<Scalar> initCondOutArgs =
+        initialConditionModel->createOutArgs();
+      const Thyra::ModelEvaluatorBase::DerivativeSupport init_dxdp_support =
+        initCondOutArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DgDp, initCondOutArgs.Ng() - 1, l);
+      if (!init_dxdp_support.supports(Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM)) {
+        // Ok to return early since only one parameter supported
+        return outArgs;
+      }
+    }
+
+    // Computing the DxDp sensitivity for a transient problem currently requires the evaluation of
+    // the mutilivector-based, Jacobian-oriented DfDp derivatives of the underlying transient model.
+    const Thyra::ModelEvaluatorBase::DerivativeSupport model_dfdp_support =
+      modelOutArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DfDp, l);
+    if (!model_dfdp_support.supports(Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM)) {
+      // Ok to return early since only one parameter supported
+      return outArgs;
+    }
+
+    // Solution sensitivity
+    outArgs.setSupports(
+        Thyra::ModelEvaluatorBase::OUT_ARG_DgDp,
+        get_num_g(),
+        l,
+        Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM);
+
+    if (get_num_g() > 0) {
+      // Only one response supported
+      const int j = 0;
+
+      const Thyra::ModelEvaluatorBase::DerivativeSupport model_dgdx_support =
+        modelOutArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DgDx, j);
+      if (!model_dgdx_support.none()) {
+        const Thyra::ModelEvaluatorBase::DerivativeSupport model_dgdp_support =
+          modelOutArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DgDp, j, l);
+        // Response sensitivity
+        Thyra::ModelEvaluatorBase::DerivativeSupport dgdp_support;
+        if (model_dgdp_support.supports(Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM)) {
+          dgdp_support.plus(Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM);
+        }
+        if (model_dgdp_support.supports(Thyra::ModelEvaluatorBase::DERIV_LINEAR_OP)) {
+          dgdp_support.plus(Thyra::ModelEvaluatorBase::DERIV_LINEAR_OP);
+        }
+        outArgs.setSupports(
+            Thyra::ModelEvaluatorBase::OUT_ARG_DgDp,
+            j,
+            l,
+            dgdp_support);
+      }
+    }
+  }
+
+  return outArgs;
+}
+
+template <typename Scalar>
+void Piro::TempusSolverForwardOnly<Scalar>::evalModelImpl(
+    const Thyra::ModelEvaluatorBase::InArgs<Scalar>& inArgs,
+    const Thyra::ModelEvaluatorBase::OutArgs<Scalar>& outArgs) const
+{
+  using Teuchos::RCP;
+  using Teuchos::rcp;
+
+  // TODO: Support more than 1 parameter and 1 response
+  const int j = 0;
+  const int l = 0;
+
+  // Parse InArgs
+  RCP<const Thyra::VectorBase<Scalar> > p_in;
+  if (get_num_p() > 0) {
+    p_in = inArgs.get_p(l);
+  }
+  RCP<const Thyra::VectorBase<Scalar> > p_in2;  //JF add for multipoint
+  if (get_num_p() > 1) {
+    p_in2 = inArgs.get_p(l+1);
+  }
+
+  // Parse OutArgs
+  RCP<Thyra::VectorBase<Scalar> > g_out;
+  if (get_num_g() > 0) {
+    g_out = outArgs.get_g(j);
+  }
+  const RCP<Thyra::VectorBase<Scalar> > gx_out = outArgs.get_g(get_num_g());
+
+  Thyra::ModelEvaluatorBase::InArgs<Scalar> state_ic = getUnderlyingModel()->getNominalValues();
+
+  // Set initial time in ME if needed
+
+  if(get_t_initial() > 0.0 && state_ic.supports(Thyra::ModelEvaluatorBase::IN_ARG_t))
+
+    state_ic.set_t(get_t_initial());
+
+  if (Teuchos::nonnull(initialConditionModel)) {
+    // The initial condition depends on the parameter
+    // It is found by querying the auxiliary model evaluator as the last response
+    const RCP<Thyra::VectorBase<Scalar> > initialState =
+      Thyra::createMember(getUnderlyingModel()->get_x_space());
+
+    {
+      Thyra::ModelEvaluatorBase::InArgs<Scalar> initCondInArgs = initialConditionModel->createInArgs();
+      if (get_num_p() > 0) {
+        initCondInArgs.set_p(l, inArgs.get_p(l));
+      }
+
+      Thyra::ModelEvaluatorBase::OutArgs<Scalar> initCondOutArgs = initialConditionModel->createOutArgs();
+      initCondOutArgs.set_g(initCondOutArgs.Ng() - 1, initialState);
+
+      initialConditionModel->evalModel(initCondInArgs, initCondOutArgs);
+    }
+
+    state_ic.set_x(initialState);
+  }
+
+  // Set paramters p_in as part of initial conditions
+  if (get_num_p() > 0) {
+    if (Teuchos::nonnull(p_in)) {
+      state_ic.set_p(l, p_in);
+    }
+  }
+  if (get_num_p() > 1) { //JF added for multipoint
+    if (Teuchos::nonnull(p_in2)) {
+      state_ic.set_p(l+1, p_in2);
+    }
+  }
+
+  *out << "\nstate_ic:\n" << Teuchos::describe(state_ic, solnVerbLevel);
+
+  //JF  may need a version of the following for multipoint, i.e. get_num_p()>1, l+1, if we want sensitivities
+  RCP<Thyra::MultiVectorBase<Scalar> > dgxdp_out;
+  Thyra::ModelEvaluatorBase::Derivative<Scalar> dgdp_deriv_out;
+  if (get_num_p() > 0) {
+    const Thyra::ModelEvaluatorBase::DerivativeSupport dgxdp_support =
+      outArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DgDp, get_num_g(), l);
+    if (dgxdp_support.supports(Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM)) {
+      const Thyra::ModelEvaluatorBase::Derivative<Scalar> dgxdp_deriv =
+        outArgs.get_DgDp(get_num_g(), l);
+      dgxdp_out = dgxdp_deriv.getMultiVector();
+    }
+
+    if (get_num_g() > 0) {
+      const Thyra::ModelEvaluatorBase::DerivativeSupport dgdp_support =
+        outArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DgDp, j, l);
+      if (!dgdp_support.none()) {
+        dgdp_deriv_out = outArgs.get_DgDp(j, l);
+      }
+    }
+  }
+
+  const bool requestedSensitivities =
+    Teuchos::nonnull(dgxdp_out) || !dgdp_deriv_out.isEmpty();
+
+  RCP<const Thyra::VectorBase<Scalar> > finalSolution;
+  if (!requestedSensitivities) {
+    //
+    *out << "\nE) Solve the forward problem ...\n";
+    //
+
+    Teuchos::RCP<const Thyra::VectorBase<Scalar>> xinit, xdotinit, xdotdotinit;
+    typedef Thyra::ModelEvaluatorBase MEB;
+    if (state_ic.supports(MEB::IN_ARG_t)) state_ic.set_t(get_t_initial());
+    if (state_ic.supports(MEB::IN_ARG_x))         xinit       = state_ic.get_x();
+    if (state_ic.supports(MEB::IN_ARG_x_dot))     xdotinit    = state_ic.get_x_dot();
+    if (state_ic.supports(MEB::IN_ARG_x_dot_dot)) xdotdotinit = state_ic.get_x_dot_dot();
+    fwdStateIntegrator->initializeSolutionHistory(get_t_initial(), xinit, xdotinit, xdotdotinit);
+    fwdStateIntegrator->initialize();
+
+    Scalar t_final = get_t_final();
+    *out << "T final requested: " << t_final << " \n";
+    fwdStateIntegrator->advanceTime(t_final);
+    double time = fwdStateIntegrator->getTime();
+    *out << "T final actual: " << time << "\n";
+
+    Scalar diff = 0.0;
+    if (abs(t_final) == 0) diff = abs(time-t_final);
+    else diff = abs(time-t_final)/abs(t_final);
+    if (diff > 1.0e-10)
+      *out << "\n WARNING: Piro::TempusSolverForwardOnly did not make it to final time.\n";
+
+    finalSolution = fwdStateIntegrator->getX();
+
+    if (Teuchos::VERB_MEDIUM <= solnVerbLevel)
+      std::cout << "Final Solution\n" << *finalSolution << std::endl;
+
+  }
+
+  //
+  // Removed the "computing sensitivities" section that was copied from Piro_RythmosSolver.hpp,
+  // as did not need to convert it for Charon needs.
+  //
+
+  *out << "\nF) Check the solution to the forward problem ...\n";
+
+  // As post-processing step, calculate responses at final solution
+  {
+    Thyra::ModelEvaluatorBase::InArgs<Scalar> modelInArgs = getUnderlyingModel()->createInArgs();
+    {
+      modelInArgs.set_x(finalSolution);
+      if (get_num_p() > 0) {
+        modelInArgs.set_p(l, p_in);
+      }
+      if (get_num_p() > 1) {  //JF added for multipoint
+        modelInArgs.set_p(l+1, p_in2);
+      }
+      //Set time to be final time at which the solve occurs (< t_final in the case we don't make it to t_final).
+      modelInArgs.set_t(fwdStateIntegrator->getSolutionHistory()->getCurrentState()->getTime());
+    }
+
+    Thyra::ModelEvaluatorBase::OutArgs<Scalar> modelOutArgs = getUnderlyingModel()->createOutArgs();
+    if (Teuchos::nonnull(g_out)) {
+      Thyra::put_scalar(Teuchos::ScalarTraits<Scalar>::zero(), g_out.ptr());
+      modelOutArgs.set_g(j, g_out);
+    }
+
+    getUnderlyingModel()->evalModel(modelInArgs, modelOutArgs);
+  }
+
+  // Return the final solution as an additional g-vector, if requested
+  if (Teuchos::nonnull(gx_out))
+    Thyra::copy(*finalSolution, gx_out.ptr());
+}
+
+template <typename Scalar>
+Teuchos::RCP<Thyra::LinearOpBase<Scalar> >
+Piro::TempusSolverForwardOnly<Scalar>::create_DgDp_op_impl(int j, int l) const
+{
+  TEUCHOS_ASSERT(j != get_num_g());
+  const Teuchos::Array<Teuchos::RCP<const Thyra::LinearOpBase<Scalar> > > dummy =
+    Teuchos::tuple(Thyra::zero<Scalar>(this->get_g_space(j), this->get_p_space(l)));
+  return Teuchos::rcp(new Thyra::DefaultAddedLinearOp<Scalar>(dummy));
+}
+
+template <typename Scalar>
+Teuchos::RCP<const Teuchos::ParameterList>
+Piro::TempusSolverForwardOnly<Scalar>::getValidTempusParameters() const
+{
+  Teuchos::RCP<Teuchos::ParameterList> validPL;
+  if (fwdStateIntegrator != Teuchos::null) {
+    validPL = fwdStateIntegrator->getValidParameters();
+  } else {
+    auto integrator =Teuchos::rcp(new Tempus::IntegratorBasic<Scalar>());
+    validPL = integrator->getValidParameters();
+  }
+  return validPL;
+}
+
+template <typename Scalar>
+Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >
+Piro::TempusSolverForwardOnly<Scalar>::getUnderlyingModel() const
+{
+  return Teuchos::rcp_const_cast<Thyra::ModelEvaluator<Scalar> > (
+    fwdStateIntegrator->getStepper()->getModel());
+}
+
+template <typename Scalar>
+Scalar
+Piro::TempusSolverForwardOnly<Scalar>::get_t_initial() const
+{
+  return fwdStateIntegrator->getTimeStepControl()->getInitTime();
+}
+
+template <typename Scalar>
+Scalar
+Piro::TempusSolverForwardOnly<Scalar>::get_t_final() const
+{
+  return fwdStateIntegrator->getTimeStepControl()->getFinalTime();
+}
+
+template <typename Scalar>
+int
+Piro::TempusSolverForwardOnly<Scalar>::get_num_p() const
+{
+  return getUnderlyingModel()->Np();
+}
+
+template <typename Scalar>
+int
+Piro::TempusSolverForwardOnly<Scalar>::get_num_g() const
+{
+  return getUnderlyingModel()->Ng();
+}
+

--- a/packages/piro/test/CMakeLists.txt
+++ b/packages/piro/test/CMakeLists.txt
@@ -248,6 +248,17 @@ IF (Piro_ENABLE_Tempus)
     STANDARD_PASS_OUTPUT
   )
   TRIBITS_ADD_EXECUTABLE_AND_TEST(
+    TempusSolverForwardOnly_UnitTests
+    SOURCES
+    Piro_TempusSolverForwardOnly_UnitTests.cpp
+    ${TEUCHOS_STD_UNIT_TEST_MAIN}
+    Piro_Test_ThyraSupport.hpp
+    MockModelEval_A.hpp
+    MockModelEval_A.cpp
+    NUM_MPI_PROCS 1-4
+    STANDARD_PASS_OUTPUT
+  )
+  TRIBITS_ADD_EXECUTABLE_AND_TEST(
     TempusSolver_SensitivityUnitTests
     SOURCES
     Piro_TempusSolver_SensitivityUnitTests.cpp

--- a/packages/piro/test/Piro_TempusSolverForwardOnly_UnitTests.cpp
+++ b/packages/piro/test/Piro_TempusSolverForwardOnly_UnitTests.cpp
@@ -1,0 +1,373 @@
+/*
+// @HEADER
+// ************************************************************************
+//
+//        Piro: Strategy package for embedded analysis capabilitites
+//                  Copyright (2010) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Andy Salinger (agsalin@sandia.gov), Sandia
+// National Laboratories.
+//
+// ************************************************************************
+// @HEADER
+*/
+
+#include "Piro_ConfigDefs.hpp"
+
+#ifdef HAVE_PIRO_TEMPUS
+#include "Piro_TempusSolverForwardOnly.hpp"
+#include "Tempus_StepperBackwardEuler.hpp"
+
+#ifdef HAVE_PIRO_NOX
+#include "Piro_NOXSolver.hpp"
+#endif /* HAVE_PIRO_NOX */
+
+#include "Piro_Test_ThyraSupport.hpp"
+#include "Piro_Test_WeakenedModelEvaluator.hpp"
+#include "Piro_Test_MockObserver.hpp"
+
+#include "MockModelEval_A.hpp"
+
+#include "Thyra_EpetraModelEvaluator.hpp"
+#include "Thyra_ModelEvaluatorHelpers.hpp"
+
+#include "Thyra_DefaultNominalBoundsOverrideModelEvaluator.hpp"
+
+#include "Thyra_AmesosLinearOpWithSolveFactory.hpp"
+
+#include "Teuchos_UnitTestHarness.hpp"
+
+#include "Teuchos_Ptr.hpp"
+#include "Teuchos_Array.hpp"
+#include "Teuchos_Tuple.hpp"
+
+#include <stdexcept>
+
+using namespace Teuchos;
+using namespace Piro;
+using namespace Piro::Test;
+
+namespace Thyra {
+  typedef ModelEvaluatorBase MEB;
+} // namespace Thyra
+
+// Setup support
+
+const RCP<EpetraExt::ModelEvaluator> epetraModelNew()
+{
+#ifdef HAVE_MPI
+  const MPI_Comm comm = MPI_COMM_WORLD;
+#else /*HAVE_MPI*/
+  const int comm = 0;
+#endif /*HAVE_MPI*/
+  return rcp(new MockModelEval_A(comm));
+}
+
+const RCP<Thyra::ModelEvaluatorDefaultBase<double> >
+  thyraModelNew(const RCP<EpetraExt::ModelEvaluator> &epetraModel)
+{
+  const RCP<Thyra::LinearOpWithSolveFactoryBase<double> > lowsFactory(new Thyra::AmesosLinearOpWithSolveFactory);
+  return epetraModelEvaluator(epetraModel, lowsFactory);
+}
+
+RCP<Thyra::ModelEvaluatorDefaultBase<double> > defaultModelNew()
+{
+  return thyraModelNew(epetraModelNew());
+}
+
+const RCP<TempusSolverForwardOnly<double> > solverNew(
+    const RCP<Thyra::ModelEvaluatorDefaultBase<double> > &thyraModel,
+    double finalTime)
+{
+  const RCP<Tempus::IntegratorBasic<double> > integrator =
+    Tempus::createIntegratorBasic<double>();
+
+  const RCP<Tempus::Stepper<double> > stepper =
+    Teuchos::rcp(new Tempus::StepperBackwardEuler<double>());
+  integrator->setStepper(stepper);
+
+  const RCP<Thyra::NonlinearSolverBase<double> > stepSolver =
+    integrator->getStepper()->getSolver();
+
+  return rcp(new TempusSolverForwardOnly<double>(integrator, stepper, stepSolver, thyraModel, finalTime));
+}
+
+const RCP<TempusSolverForwardOnly<double> > solverNew(
+    const RCP<Thyra::ModelEvaluatorDefaultBase<double> > &thyraModel,
+    double initialTime,
+    double finalTime,
+    const RCP<Piro::ObserverBase<double> > &observer)
+{
+  // Construct Tempus ParameterList
+  const RCP<ParameterList> tempusPL(new ParameterList("Tempus"));
+  tempusPL->set("Integrator Name", "Demo Integrator");
+  tempusPL->sublist("Demo Integrator").set("Integrator Type", "Integrator Basic");
+  tempusPL->sublist("Demo Integrator").set("Stepper Name", "Demo Stepper");
+  tempusPL->sublist("Demo Integrator").sublist("Solution History").set("Storage Type", "Unlimited");
+  tempusPL->sublist("Demo Integrator").sublist("Solution History").set("Storage Limit", 20);
+  tempusPL->sublist("Demo Integrator").sublist("Time Step Control").set("Initial Time", initialTime);
+  tempusPL->sublist("Demo Integrator").sublist("Time Step Control").set("Final Time", finalTime);
+  tempusPL->sublist("Demo Stepper").set("Stepper Type", "Backward Euler");
+  tempusPL->sublist("Demo Stepper").set("Zero Initial Guess", false);
+  tempusPL->sublist("Demo Stepper").set("Solver Name", "Demo Solver");
+  tempusPL->sublist("Demo Stepper").sublist("Demo Solver").sublist("NOX").sublist("Direction").set("Method","Newton");
+
+  auto integrator = Tempus::createIntegratorBasic<double>(tempusPL, thyraModel);
+
+  // Add Observer
+  const RCP<const Tempus::SolutionHistory<double> > solutionHistory = integrator->getSolutionHistory();
+  const RCP<const Tempus::TimeStepControl<double> > timeStepControl = integrator->getTimeStepControl();
+  const Teuchos::RCP<Tempus::IntegratorObserver<double> > tempusObserver =
+	  Teuchos::rcp(new ObserverToTempusIntegrationObserverAdapter<double>(
+      solutionHistory, timeStepControl, observer, false, false, Piro::NONE));
+  integrator->setObserver(tempusObserver);
+  integrator->initialize();
+
+  RCP<Tempus::Stepper<double> > stepper = integrator->getStepper();
+  RCP<Thyra::NonlinearSolverBase<double> > stepSolver = stepper->getSolver();
+
+  return rcp(new TempusSolverForwardOnly<double>(integrator, stepper, stepSolver, thyraModel, initialTime, finalTime));
+}
+
+const RCP<TempusSolverForwardOnly<double> > solverNew(
+    const RCP<Thyra::ModelEvaluatorDefaultBase<double> > &thyraModel,
+    double initialTime,
+    double finalTime,
+    double fixedTimeStep,
+    const RCP<Piro::ObserverBase<double> > &observer)
+{
+  // Construct Tempus ParameterList
+  const RCP<ParameterList> tempusPL(new ParameterList("Tempus"));
+  tempusPL->set("Integrator Name", "Demo Integrator");
+  tempusPL->sublist("Demo Integrator").set("Integrator Type", "Integrator Basic");
+  tempusPL->sublist("Demo Integrator").set("Stepper Name", "Demo Stepper");
+  tempusPL->sublist("Demo Integrator").sublist("Solution History").set("Storage Type", "Unlimited");
+  tempusPL->sublist("Demo Integrator").sublist("Solution History").set("Storage Limit", 20);
+  tempusPL->sublist("Demo Integrator").sublist("Time Step Control").set("Initial Time", initialTime);
+  tempusPL->sublist("Demo Integrator").sublist("Time Step Control").set("Final Time", finalTime);
+  tempusPL->sublist("Demo Integrator").sublist("Time Step Control").set("Minimum Time Step", fixedTimeStep);
+  tempusPL->sublist("Demo Integrator").sublist("Time Step Control").set("Initial Time Step", fixedTimeStep);
+  tempusPL->sublist("Demo Integrator").sublist("Time Step Control").set("Maximum Time Step", fixedTimeStep);
+  tempusPL->sublist("Demo Stepper").set("Stepper Type", "Backward Euler");
+  tempusPL->sublist("Demo Stepper").set("Zero Initial Guess", false);
+  tempusPL->sublist("Demo Stepper").set("Solver Name", "Demo Solver");
+  tempusPL->sublist("Demo Stepper").sublist("Demo Solver").sublist("NOX").sublist("Direction").set("Method","Newton");
+
+  auto integrator = Tempus::createIntegratorBasic<double>(tempusPL, thyraModel);
+
+  // Add Observer
+  const RCP<const Tempus::SolutionHistory<double> > solutionHistory = integrator->getSolutionHistory();
+  const RCP<const Tempus::TimeStepControl<double> > timeStepControl = integrator->getTimeStepControl();
+  const Teuchos::RCP<Tempus::IntegratorObserver<double> > tempusObserver =
+	  Teuchos::rcp(new ObserverToTempusIntegrationObserverAdapter<double>(
+      solutionHistory, timeStepControl, observer, false, false, Piro::NONE));
+  integrator->setObserver(tempusObserver);
+  integrator->initialize();
+
+  RCP<Tempus::Stepper<double> > stepper = integrator->getStepper();
+  RCP<Thyra::NonlinearSolverBase<double> > stepSolver = stepper->getSolver();
+
+  return rcp(new TempusSolverForwardOnly<double>(integrator, stepper, stepSolver, thyraModel, initialTime, finalTime));
+}
+
+Thyra::ModelEvaluatorBase::InArgs<double> getStaticNominalValues(const Thyra::ModelEvaluator<double> &model)
+{
+  Thyra::ModelEvaluatorBase::InArgs<double> result = model.getNominalValues();
+  if (result.supports(Thyra::ModelEvaluatorBase::IN_ARG_x_dot)) {
+    result.set_x_dot(Teuchos::null);
+  }
+  return result;
+}
+
+// Floating point tolerance
+const double tol = 1.0e-8;
+
+TEUCHOS_UNIT_TEST(Piro_TempusSolverForwardOnly, TimeZero_Solution)
+{
+  const RCP<Thyra::ModelEvaluatorDefaultBase<double> > model = defaultModelNew();
+  const double finalTime = 0.0;
+
+  const RCP<TempusSolverForwardOnly<double> > solver = solverNew(model, finalTime);
+
+  const Thyra::MEB::InArgs<double> inArgs = solver->getNominalValues();
+
+  Thyra::MEB::OutArgs<double> outArgs = solver->createOutArgs();
+  const int solutionResponseIndex = solver->Ng() - 1;
+  const RCP<Thyra::VectorBase<double> > solution =
+    Thyra::createMember(solver->get_g_space(solutionResponseIndex));
+  outArgs.set_g(solutionResponseIndex, solution);
+
+  solver->evalModel(inArgs, outArgs);
+
+  const RCP<const Thyra::VectorBase<double> > initialCondition =
+    model->getNominalValues().get_x();
+
+  TEST_COMPARE_FLOATING_ARRAYS(
+      arrayFromVector(*solution),
+      arrayFromVector(*initialCondition),
+      tol);
+}
+
+TEUCHOS_UNIT_TEST(Piro_TempusSolverForwardOnly, TimeZero_Response)
+{
+  const RCP<Thyra::ModelEvaluatorDefaultBase<double> > model = defaultModelNew();
+
+  const int responseIndex = 0;
+
+  const RCP<Thyra::VectorBase<double> > expectedResponse =
+    Thyra::createMember(model->get_g_space(responseIndex));
+  {
+    const Thyra::MEB::InArgs<double> modelInArgs = getStaticNominalValues(*model);
+    Thyra::MEB::OutArgs<double> modelOutArgs = model->createOutArgs();
+    modelOutArgs.set_g(responseIndex, expectedResponse);
+    model->evalModel(modelInArgs, modelOutArgs);
+  }
+
+  const double finalTime = 0.0;
+  const RCP<TempusSolverForwardOnly<double> > solver = solverNew(model, finalTime);
+
+  const Thyra::MEB::InArgs<double> inArgs = solver->getNominalValues();
+
+  Thyra::MEB::OutArgs<double> outArgs = solver->createOutArgs();
+  const RCP<Thyra::VectorBase<double> > response =
+    Thyra::createMember(solver->get_g_space(responseIndex));
+  outArgs.set_g(responseIndex, response);
+
+  solver->evalModel(inArgs, outArgs);
+
+  const Array<double> expected = arrayFromVector(*expectedResponse);
+  const Array<double> actual = arrayFromVector(*response);
+  TEST_COMPARE_FLOATING_ARRAYS(actual, expected, tol);
+}
+
+TEUCHOS_UNIT_TEST(Piro_TempusSolverForwardOnly, TimeZero_NoDfDpMv_NoSensitivity)
+{
+  const RCP<Thyra::ModelEvaluatorDefaultBase<double> > model(
+      new WeakenedModelEvaluator_NoDfDpMv(defaultModelNew()));
+
+  const double finalTime = 0.0;
+  const RCP<TempusSolverForwardOnly<double> > solver = solverNew(model, finalTime);
+
+  const Thyra::MEB::InArgs<double> inArgs = solver->getNominalValues();
+  Thyra::MEB::OutArgs<double> outArgs = solver->createOutArgs();
+
+  const int responseIndex = 0;
+  const int solutionResponseIndex = solver->Ng() - 1;
+  const int parameterIndex = 0;
+
+  TEST_ASSERT(outArgs.supports(Thyra::MEB::OUT_ARG_DgDp, responseIndex, parameterIndex).none());
+  TEST_ASSERT(outArgs.supports(Thyra::MEB::OUT_ARG_DgDp, solutionResponseIndex, parameterIndex).none());
+
+  TEST_NOTHROW(solver->evalModel(inArgs, outArgs));
+}
+
+TEUCHOS_UNIT_TEST(Piro_TempusSolverForwardOnly, TimeZero_NoDgDp_NoResponseSensitivity)
+{
+  const RCP<Thyra::ModelEvaluatorDefaultBase<double> > model(
+      new WeakenedModelEvaluator_NoDgDp(defaultModelNew()));
+
+  const double finalTime = 0.0;
+  const RCP<TempusSolverForwardOnly<double> > solver = solverNew(model, finalTime);
+
+  const Thyra::MEB::InArgs<double> inArgs = solver->getNominalValues();
+  Thyra::MEB::OutArgs<double> outArgs = solver->createOutArgs();
+
+  const int responseIndex = 0;
+  const int solutionResponseIndex = solver->Ng() - 1;
+  const int parameterIndex = 0;
+
+  TEST_ASSERT(outArgs.supports(Thyra::MEB::OUT_ARG_DgDp, responseIndex, parameterIndex).none());
+  TEST_ASSERT(!outArgs.supports(Thyra::MEB::OUT_ARG_DgDp, solutionResponseIndex, parameterIndex).none());
+
+  TEST_NOTHROW(solver->evalModel(inArgs, outArgs));
+}
+
+TEUCHOS_UNIT_TEST(Piro_TempusSolverForwardOnly, ObserveInitialCondition)
+{
+  const RCP<Thyra::ModelEvaluatorDefaultBase<double> > model = defaultModelNew();
+  const RCP<MockObserver<double> > observer(new MockObserver<double>);
+  const double timeStamp = 2.0;
+
+  const RCP<TempusSolverForwardOnly<double> > solver = solverNew(model, timeStamp, timeStamp, observer);
+
+  const Thyra::MEB::InArgs<double> inArgs = solver->getNominalValues();
+  const Thyra::MEB::OutArgs<double> outArgs = solver->createOutArgs();
+  solver->evalModel(inArgs, outArgs);
+
+  {
+    const RCP<const Thyra::VectorBase<double> > solution =
+      observer->lastSolution();
+
+    const RCP<const Thyra::VectorBase<double> > initialCondition =
+      model->getNominalValues().get_x();
+
+    TEST_COMPARE_FLOATING_ARRAYS(
+        arrayFromVector(*solution),
+        arrayFromVector(*initialCondition),
+        tol);
+  }
+
+  TEST_FLOATING_EQUALITY(observer->lastStamp(), timeStamp, tol);
+}
+
+TEUCHOS_UNIT_TEST(Piro_TempusSolverForwardOnly, ObserveFinalSolution)
+{
+  const RCP<Thyra::ModelEvaluatorDefaultBase<double> > model = defaultModelNew();
+  const RCP<MockObserver<double> > observer(new MockObserver<double>);
+  const double initialTime = 0.0;
+  const double finalTime = 0.1;
+  const double timeStepSize = 0.05;
+
+  const RCP<TempusSolverForwardOnly<double> > solver =
+    solverNew(model, initialTime, finalTime, timeStepSize, observer);
+
+  const Thyra::MEB::InArgs<double> inArgs = solver->getNominalValues();
+
+  Thyra::MEB::OutArgs<double> outArgs = solver->createOutArgs();
+  const int solutionResponseIndex = solver->Ng() - 1;
+  const RCP<Thyra::VectorBase<double> > solution =
+    Thyra::createMember(solver->get_g_space(solutionResponseIndex));
+  outArgs.set_g(solutionResponseIndex, solution);
+
+  solver->evalModel(inArgs, outArgs);
+
+  TEST_COMPARE_FLOATING_ARRAYS(
+      arrayFromVector(*observer->lastSolution()),
+      arrayFromVector(*solution),
+      tol);
+
+  TEST_FLOATING_EQUALITY(observer->lastStamp(), finalTime, tol);
+}
+
+
+#endif /* HAVE_PIRO_TEMPUS */


### PR DESCRIPTION
An application requires a forward only version of TempusSolver. We
will derive it from RythmosSolver and replace Rythmos calls with
Tempus calls.  Removed all the Rythmos solver portions and the
sensitivities are not needed.

@trilinos/piro 
@trilinos/tempus 

## Motivation
Help application move from Rythmos to Tempus.

## Related Issues
* Closes #10225 

## Stakeholder Feedback
Stakeholder will test this feature in their application.

## Testing
Added unit tests covering the basic usage.
