### PR TITLE
Stokhos:  Fix static initialization

### DIFF
--- a/packages/stokhos/src/sacado/Sacado_ETPCE_OrthogPoly.hpp
+++ b/packages/stokhos/src/sacado/Sacado_ETPCE_OrthogPoly.hpp
@@ -358,18 +358,13 @@ namespace Sacado {
       //! Cast of expansion class to QuadExpansion
       Teuchos::RCP<quad_expansion_type> quad_expansion_;
 
-      //! Static constant expansion class for constants
-      static Teuchos::RCP<expansion_type> const_expansion_;
+      //! Constant expansion class for constants
+      Teuchos::RCP<expansion_type> const_expansion_;
 
       //! Handle to underlying OrthogPolyApprox
       Sacado::Handle< Stokhos::OrthogPolyApprox<int,value_type,Storage> > th_;
 
     }; // class OrthogPolyImpl
-
-    template <typename T, typename Storage>
-    Teuchos::RCP<typename OrthogPolyImpl<T, Storage>::expansion_type>
-    OrthogPolyImpl<T,Storage>::const_expansion_ =
-      Teuchos::rcp(new Stokhos::ConstantOrthogPolyExpansion<int,T>);
 
     //! OrthogPolyImpl expression template specialization
     /*!

--- a/packages/stokhos/src/sacado/Sacado_ETPCE_OrthogPolyImp.hpp
+++ b/packages/stokhos/src/sacado/Sacado_ETPCE_OrthogPolyImp.hpp
@@ -120,19 +120,23 @@ expressionCopy(const Expr<S>& x)
 template <typename T, typename Storage> 
 OrthogPolyImpl<T,Storage>::
 OrthogPolyImpl() :
-  expansion_(const_expansion_),
+  expansion_(),
   quad_expansion_(),
   th_(new Stokhos::OrthogPolyApprox<int,value_type,Storage>)
 {
+  const_expansion_ = Teuchos::rcp(new Stokhos::ConstantOrthogPolyExpansion<int,T>);
+  expansion_ = const_expansion_;
 }
 
 template <typename T, typename Storage> 
 OrthogPolyImpl<T,Storage>::
 OrthogPolyImpl(const typename OrthogPolyImpl<T,Storage>::value_type& x) :
-  expansion_(const_expansion_),
+  expansion_(),
   quad_expansion_(),
   th_(new Stokhos::OrthogPolyApprox<int,value_type,Storage>(Teuchos::null, 1, &x))
 {
+  const_expansion_ = Teuchos::rcp(new Stokhos::ConstantOrthogPolyExpansion<int,T>);
+  expansion_ = const_expansion_;
 }
 
 template <typename T, typename Storage> 
@@ -142,16 +146,18 @@ OrthogPolyImpl(const Teuchos::RCP<expansion_type>& expansion) :
   quad_expansion_(Teuchos::rcp_dynamic_cast<quad_expansion_type>(expansion_)),
   th_(new Stokhos::OrthogPolyApprox<int,value_type,Storage>(expansion_->getBasis()))
 {
+  const_expansion_ = Teuchos::rcp(new Stokhos::ConstantOrthogPolyExpansion<int,T>);
 }
 
 template <typename T, typename Storage> 
 OrthogPolyImpl<T,Storage>::
 OrthogPolyImpl(const Teuchos::RCP<expansion_type>& expansion,
-	   ordinal_type sz) :
+               ordinal_type sz) :
   expansion_(expansion),
   quad_expansion_(Teuchos::rcp_dynamic_cast<quad_expansion_type>(expansion_)),
   th_(new Stokhos::OrthogPolyApprox<int,value_type,Storage>(expansion_->getBasis(), sz))
 {
+  const_expansion_ = Teuchos::rcp(new Stokhos::ConstantOrthogPolyExpansion<int,T>);
 }
 
 template <typename T, typename Storage> 
@@ -161,6 +167,7 @@ OrthogPolyImpl(const OrthogPolyImpl<T,Storage>& x) :
   quad_expansion_(x.quad_expansion_),
   th_(x.th_)
 {
+  const_expansion_ = Teuchos::rcp(new Stokhos::ConstantOrthogPolyExpansion<int,T>);
 }
 
 template <typename T, typename Storage> 
@@ -171,6 +178,7 @@ OrthogPolyImpl(const Expr<S>& x) :
   quad_expansion_(Teuchos::rcp_dynamic_cast<quad_expansion_type>(expansion_)),
   th_(new Stokhos::OrthogPolyApprox<int,value_type,Storage>(expansion_->getBasis(), x.size()))
 {
+  const_expansion_ = Teuchos::rcp(new Stokhos::ConstantOrthogPolyExpansion<int,T>);
   expressionCopy(x);
 }
 
@@ -225,7 +233,7 @@ isEqualTo(const Expr<S>& x) const {
     if (x.size() != 1)
       return false;
     if ((expansion_ != const_expansion_) && 
-	(x.expansion_ != const_expansion_))
+	(x.expansion_ != x.const_expansion_))
       return false;
   }
   bool eq = true;

--- a/packages/stokhos/src/sacado/Sacado_PCE_OrthogPoly.hpp
+++ b/packages/stokhos/src/sacado/Sacado_PCE_OrthogPoly.hpp
@@ -337,17 +337,12 @@ namespace Sacado {
       //! Expansion class
       Teuchos::RCP<expansion_type> expansion_;
 
-      //! Static constant expansion class for constants
-      static Teuchos::RCP<expansion_type> const_expansion_;
+      //! Constant expansion class for constants
+      Teuchos::RCP<expansion_type> const_expansion_;
 
       Sacado::Handle< Stokhos::OrthogPolyApprox<int,value_type,Storage> > th;
 
     }; // class Hermite
-
-    template <typename T, typename Storage>
-    Teuchos::RCP<typename OrthogPoly<T, Storage>::expansion_type>
-    OrthogPoly<T,Storage>::const_expansion_ =
-      Teuchos::rcp(new Stokhos::ConstantOrthogPolyExpansion<int,T>);
 
     // Operations
     template <typename T, typename Storage> OrthogPoly<T,Storage> 

--- a/packages/stokhos/src/sacado/Sacado_PCE_OrthogPolyImp.hpp
+++ b/packages/stokhos/src/sacado/Sacado_PCE_OrthogPolyImp.hpp
@@ -49,17 +49,21 @@ namespace PCE {
 template <typename T, typename Storage> 
 OrthogPoly<T,Storage>::
 OrthogPoly() :
-  expansion_(const_expansion_),
+  expansion_(),
   th(new Stokhos::OrthogPolyApprox<int,value_type,Storage>)
-{ 
+{
+  const_expansion_ = Teuchos::rcp(new Stokhos::ConstantOrthogPolyExpansion<int,T>);
+  expansion_ = const_expansion_;
 }
 
 template <typename T, typename Storage> 
 OrthogPoly<T,Storage>::
 OrthogPoly(const typename OrthogPoly<T,Storage>::value_type& x) :
-  expansion_(const_expansion_),
+  expansion_(),
   th(new Stokhos::OrthogPolyApprox<int,value_type,Storage>(Teuchos::null, 1, &x))
 {
+  const_expansion_ = Teuchos::rcp(new Stokhos::ConstantOrthogPolyExpansion<int,T>);
+  expansion_ = const_expansion_;
 }
 
 template <typename T, typename Storage> 
@@ -68,6 +72,7 @@ OrthogPoly(const Teuchos::RCP<expansion_type>& expansion) :
   expansion_(expansion),
   th(new Stokhos::OrthogPolyApprox<int,value_type,Storage>(expansion_->getBasis()))
 {
+  const_expansion_ = Teuchos::rcp(new Stokhos::ConstantOrthogPolyExpansion<int,T>);
 }
 
 template <typename T, typename Storage> 
@@ -77,6 +82,7 @@ OrthogPoly(const Teuchos::RCP<expansion_type>& expansion,
   expansion_(expansion),
   th(new Stokhos::OrthogPolyApprox<int,value_type,Storage>(expansion_->getBasis(), sz))
 {
+  const_expansion_ = Teuchos::rcp(new Stokhos::ConstantOrthogPolyExpansion<int,T>);
 }
 
 template <typename T, typename Storage> 
@@ -85,6 +91,7 @@ OrthogPoly(const OrthogPoly<T,Storage>& x) :
   expansion_(x.expansion_),
   th(x.th)
 {
+  const_expansion_ = Teuchos::rcp(new Stokhos::ConstantOrthogPolyExpansion<int,T>);
 }
 
 template <typename T, typename Storage> 
@@ -141,7 +148,7 @@ isEqualTo(const OrthogPoly& x) const {
     if (x.size() != 1)
       return false;
     if ((expansion_ != const_expansion_) && 
-	(x.expansion_ != const_expansion_))
+	(x.expansion_ != x.const_expansion_))
       return false;
   }
   bool eq = true;


### PR DESCRIPTION
A couple of Stokhos classes have static data members that internally have RCP's
in them.  On blake with the clang compiler, these static data members were
being initialized before some static data used internally within RCP, leading
to exceptions and failed tests.  This removes the static data to workaround
this problem.

For issue #10228.