### PR TITLE
Amesos2, Superludist : fixing compilation errors with Tpetra deprecatated code off

### DIFF
--- a/packages/amesos2/src/Amesos2_Superludist_decl.hpp
+++ b/packages/amesos2/src/Amesos2_Superludist_decl.hpp
@@ -117,6 +117,10 @@ public:
 
   typedef FunctionMap<Amesos2::Superludist,slu_type>           function_map;
 
+  typedef Kokkos::DefaultHostExecutionSpace HostExecSpaceType;
+  typedef Kokkos::View<SLUD::int_t*, HostExecSpaceType>   host_size_type_array;
+  typedef Kokkos::View<SLUD::int_t*, HostExecSpaceType>   host_ordinal_type_array;
+  typedef Kokkos::View<slu_type*,    HostExecSpaceType>   host_value_type_array;
 
   /// \name Constructor/Destructor methods
   //@{
@@ -308,11 +312,11 @@ private:
 
   // The following Arrays are persisting storage arrays for A, X, and B
   /// Stores the values of the nonzero entries for SuperLU_DIST
-  Teuchos::Array<slu_type> nzvals_;
+  host_value_type_array nzvals_view_;
   /// Stores the row indices of the nonzero entries
-  Teuchos::Array<SLUD::int_t> colind_;
+  host_ordinal_type_array colind_view_;
   /// Stores the location in \c Ai_ and Aval_ that starts row j
-  Teuchos::Array<SLUD::int_t> rowptr_;
+  host_size_type_array rowptr_view_;
   /// 1D store for B values
   mutable Teuchos::Array<slu_type> bvals_;
   /// 1D store for X values

--- a/packages/amesos2/src/Amesos2_Superludist_def.hpp
+++ b/packages/amesos2/src/Amesos2_Superludist_def.hpp
@@ -69,9 +69,6 @@ namespace Amesos2 {
                                           Teuchos::RCP<Vector> X,
                                           Teuchos::RCP<const Vector> B)
     : SolverCore<Amesos2::Superludist,Matrix,Vector>(A, X, B)
-    , nzvals_()                 // initialization to empty arrays
-    , colind_()
-    , rowptr_()
     , bvals_()
     , xvals_()
     , in_grid_(false)
@@ -441,7 +438,7 @@ namespace Amesos2 {
 
       // Apply the column ordering, so that AC is the column-permuted A, and compute etree
       size_t nnz_loc = ((SLUD::NRformat_loc*)data_.A.Store)->nnz_loc;
-      for( size_t i = 0; i < nnz_loc; ++i ) colind_[i] = data_.perm_c[colind_[i]];
+      for( size_t i = 0; i < nnz_loc; ++i ) colind_view_(i) = data_.perm_c[colind_view_(i)];
 
       // Distribute data from the symbolic factorization
       if( same_symbolic_ ){
@@ -857,20 +854,19 @@ namespace Amesos2 {
     g_cols = g_rows;            // we deal with square matrices
     fst_global_row = as<int_t>(superlu_rowmap_->getMinGlobalIndex());
 
-    nzvals_.resize(l_nnz);
-    colind_.resize(l_nnz);
-    rowptr_.resize(l_rows + 1);
-
+    Kokkos::resize(nzvals_view_, l_nnz);
+    Kokkos::resize(colind_view_, l_nnz);
+    Kokkos::resize(rowptr_view_, l_rows + 1);
     int_t nnz_ret = 0;
     {
 #ifdef HAVE_AMESOS2_TIMERS
       Teuchos::TimeMonitor mtxRedistTimer( this->timers_.mtxRedistTime_ );
 #endif
 
-      Util::get_crs_helper<
-      MatrixAdapter<Matrix>,
-        slu_type, int_t, int_t >::do_get(redist_mat.ptr(),
-                                         nzvals_(), colind_(), rowptr_(),
+      Util::get_crs_helper_kokkos_view<MatrixAdapter<Matrix>,
+        host_value_type_array,host_ordinal_type_array, host_size_type_array >::do_get(
+                                         redist_mat.ptr(),
+                                         nzvals_view_, colind_view_, rowptr_view_,
                                          nnz_ret,
                                          ptrInArg(*superlu_rowmap_),
                                          ROOTED,
@@ -888,9 +884,9 @@ namespace Amesos2 {
     function_map::create_CompRowLoc_Matrix(&(data_.A),
                                            g_rows, g_cols,
                                            l_nnz, l_rows, fst_global_row,
-                                           nzvals_.getRawPtr(),
-                                           colind_.getRawPtr(),
-                                           rowptr_.getRawPtr(),
+                                           nzvals_view_.data(),
+                                           colind_view_.data(),
+                                           rowptr_view_.data(),
                                            SLUD::SLU_NR_loc,
                                            dtype, SLUD::SLU_GE);
   }


### PR DESCRIPTION
@trilinos/amesos2 

## Motivation

This PR tries fixing the compilation errors with Amesos2/SuperLU_DIST when Tpetra's deprecated codes are turned off.


## Related Issues

This may fix https://github.com/trilinos/Trilinos/issues/9639.

## Testing

Tested on Weaver with SuperLU_DIST 6.00 and Tpetra deprecated code off.
