### PR TITLE
Tpetra:  first step toward #9289 -- DO NOT MERGE YET

### DIFF
--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_decl.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_decl.hpp
@@ -567,7 +567,7 @@ struct AddKernels
   typedef typename map_type::local_map_type local_map_type;
   typedef typename Kokkos::View<GlobalOrdinal*, device_type> global_col_inds_array;
   typedef Kokkos::RangePolicy<execution_space> range_type;
-  typedef KokkosKernels::Experimental::KokkosKernelsHandle<size_t, LocalOrdinal, impl_scalar_type,
+  typedef KokkosKernels::Experimental::KokkosKernelsHandle<Details::DefaultTypes::offset_type, LocalOrdinal, impl_scalar_type,
               execution_space, memory_space, memory_space> KKH;
 
   /// \brief Given two matrices in CRS format, return their sum

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
@@ -3285,7 +3285,7 @@ convertToGlobalAndAdd(
   using Teuchos::TimeMonitor;
   //Need to use a different KokkosKernelsHandle type than other versions,
   //since the ordinals are now GO
-  using KKH_GO = KokkosKernels::Experimental::KokkosKernelsHandle<size_t, GO, impl_scalar_type,
+  using KKH_GO = KokkosKernels::Experimental::KokkosKernelsHandle<Details::DefaultTypes::offset_type, GO, impl_scalar_type,
               typename NO::execution_space, typename NO::memory_space, typename NO::memory_space>;
 
   const values_array Avals = A.values;

--- a/packages/tpetra/core/src/Tpetra_CrsGraphTransposer_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraphTransposer_def.hpp
@@ -258,9 +258,11 @@ namespace Tpetra {
     auto lclGraph  = graph->getLocalGraphDevice();
     auto lclGraphT = graphT->getLocalGraphDevice();
 
-    using KKH_LO = KokkosKernels::Experimental::KokkosKernelsHandle<size_t, LocalOrdinal, impl_scalar_type,
+    using KKH_LO = KokkosKernels::Experimental::KokkosKernelsHandle<Details::DefaultTypes::offset_type,
+                                                                    LocalOrdinal, impl_scalar_type,
                                                                     typename Node::execution_space, typename Node::memory_space, typename Node::memory_space>;
-    using KKH_GO = KokkosKernels::Experimental::KokkosKernelsHandle<size_t, GlobalOrdinal, impl_scalar_type,
+    using KKH_GO = KokkosKernels::Experimental::KokkosKernelsHandle<Details::DefaultTypes::offset_type,
+                                                                    GlobalOrdinal, impl_scalar_type,
                                                                     typename Node::execution_space, typename Node::memory_space, typename Node::memory_space>;
 
     auto rowptrs  = lclGraph.row_map;

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -252,7 +252,8 @@ namespace Tpetra {
     //! The type of the part of the sparse graph on each MPI process.
     using local_graph_device_type =
            Kokkos::StaticCrsGraph<local_ordinal_type, Kokkos::LayoutLeft,
-                                  device_type, void, size_t>;
+                                  device_type, void,
+                                  Details::DefaultTypes::offset_type>;
 #ifdef TPETRA_ENABLE_DEPRECATED_CODE
     using local_graph_type = local_graph_device_type;
 #endif
@@ -550,7 +551,7 @@ public:
     ///   default values.
     CrsGraph (const Teuchos::RCP<const map_type>& rowMap,
               const Teuchos::RCP<const map_type>& colMap,
-              const Teuchos::ArrayRCP<size_t>& rowPointers,
+              const Teuchos::ArrayRCP<Details::DefaultTypes::offset_type>& rowPointers,
               const Teuchos::ArrayRCP<local_ordinal_type>& columnIndices,
               const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 
@@ -1491,7 +1492,7 @@ public:
     /// \warning This method is intended for expert developer use
     ///   only, and should never be called by user code.
     void
-    setAllIndices (const Teuchos::ArrayRCP<size_t> & rowPointers,
+    setAllIndices (const Teuchos::ArrayRCP<Details::DefaultTypes::offset_type> & rowPointers,
                    const Teuchos::ArrayRCP<local_ordinal_type> & columnIndices);
 
     /// \brief Get a host view of the packed row offsets.
@@ -2488,7 +2489,7 @@ public:
     /// inexplicable test failures only on CUDA.  Thus, I left it as a
     /// HostMirror, which means (given Trilinos' current UVM
     /// requirement) that it will be a UVM allocation.
-    typedef typename Kokkos::View<size_t*, Kokkos::LayoutLeft, device_type>::HostMirror num_row_entries_type;
+    typedef typename Kokkos::View<Details::DefaultTypes::offset_type*, Kokkos::LayoutLeft, device_type>::HostMirror num_row_entries_type;
 
     // typedef Kokkos::View<
     //   size_t*,

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -665,7 +665,7 @@ namespace Tpetra {
   CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
   CrsGraph (const Teuchos::RCP<const map_type>& rowMap,
             const Teuchos::RCP<const map_type>& colMap,
-            const Teuchos::ArrayRCP<size_t>& rowPointers,
+            const Teuchos::ArrayRCP<Details::DefaultTypes::offset_type>& rowPointers,
             const Teuchos::ArrayRCP<LocalOrdinal> & columnIndices,
             const Teuchos::RCP<Teuchos::ParameterList>& params) :
     dist_object_type (rowMap)
@@ -3163,14 +3163,14 @@ namespace Tpetra {
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   void
   CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
-  setAllIndices (const Teuchos::ArrayRCP<size_t>& rowPointers,
+  setAllIndices (const Teuchos::ArrayRCP<Details::DefaultTypes::offset_type>& rowPointers,
                  const Teuchos::ArrayRCP<LocalOrdinal>& columnIndices)
   {
     using Kokkos::View;
     typedef typename local_graph_device_type::row_map_type row_map_type;
     typedef typename row_map_type::array_layout layout_type;
     typedef typename row_map_type::non_const_value_type row_offset_type;
-    typedef View<size_t*, layout_type , Kokkos::HostSpace,
+    typedef View<Details::DefaultTypes::offset_type*, layout_type , Kokkos::HostSpace,
       Kokkos::MemoryUnmanaged> input_view_type;
     typedef typename row_map_type::non_const_type nc_row_map_type;
 
@@ -3205,7 +3205,7 @@ namespace Tpetra {
         // FIXME (mfh 24 Mar 2015) If CUDA UVM, running in the host's
         // execution space would avoid the double copy.
         //
-        View<size_t*, layout_type, device_type> ptr_st ("Tpetra::CrsGraph::ptr", size);
+        View<Details::DefaultTypes::offset_type*, layout_type, device_type> ptr_st ("Tpetra::CrsGraph::ptr", size);
         Kokkos::deep_copy (ptr_st, ptr_in);
         // Copy on device (casting from size_t to row_offset_type,
         // with bounds checking if necessary) to ptr_rot.  This
@@ -7602,7 +7602,7 @@ namespace Tpetra {
     size_t N = BaseRowMap->getNodeNumElements();
 
     // Allocations
-    ArrayRCP<size_t> CSR_rowptr(N+1);
+    ArrayRCP<Details::DefaultTypes::offset_type> CSR_rowptr(N+1);
     ArrayRCP<GO> CSR_colind_GID;
     ArrayRCP<LO> CSR_colind_LID;
     CSR_colind_GID.resize(mynnz);

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -834,7 +834,7 @@ namespace Tpetra {
     ///   default values.
     CrsMatrix (const Teuchos::RCP<const map_type>& rowMap,
                const Teuchos::RCP<const map_type>& colMap,
-               const Teuchos::ArrayRCP<size_t>& rowPointers,
+               const Teuchos::ArrayRCP<Details::DefaultTypes::offset_type>& rowPointers,
                const Teuchos::ArrayRCP<LocalOrdinal>& columnIndices,
                const Teuchos::ArrayRCP<Scalar>& values,
                const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
@@ -1919,7 +1919,7 @@ namespace Tpetra {
     ///   shallow copy.  Any method that changes the matrix's values
     ///   may then change this.
     void
-    setAllValues (const Teuchos::ArrayRCP<size_t>& ptr,
+    setAllValues (const Teuchos::ArrayRCP<Details::DefaultTypes::offset_type>& ptr,
                   const Teuchos::ArrayRCP<LocalOrdinal>& ind,
                   const Teuchos::ArrayRCP<Scalar>& val);
 

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -575,7 +575,7 @@ namespace Tpetra {
   CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   CrsMatrix (const Teuchos::RCP<const map_type>& rowMap,
              const Teuchos::RCP<const map_type>& colMap,
-             const Teuchos::ArrayRCP<size_t>& ptr,
+             const Teuchos::ArrayRCP<Details::DefaultTypes::offset_type>& ptr,
              const Teuchos::ArrayRCP<LocalOrdinal>& ind,
              const Teuchos::ArrayRCP<Scalar>& val,
              const Teuchos::RCP<Teuchos::ParameterList>& params) :
@@ -3961,7 +3961,7 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void
   CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-  setAllValues (const Teuchos::ArrayRCP<size_t>& ptr,
+  setAllValues (const Teuchos::ArrayRCP<Details::DefaultTypes::offset_type>& ptr,
                 const Teuchos::ArrayRCP<LocalOrdinal>& ind,
                 const Teuchos::ArrayRCP<Scalar>& val)
   {
@@ -3979,7 +3979,7 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     // copy.  We need to make a deep copy anyway so that Kokkos can
     // own the memory.  Regardless, ptrIn gets the copy.
     typename row_map_type::non_const_type ptrNative ("ptr", ptr.size ());
-    Kokkos::View<const size_t*,
+    Kokkos::View<const Details::DefaultTypes::offset_type*,
       typename row_map_type::array_layout,
       Kokkos::HostSpace,
       Kokkos::MemoryUnmanaged> ptrSizeT (ptr.getRawPtr (), ptr.size ());
@@ -5526,10 +5526,12 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     if(nrows != 0)
       maxRowImbalance = getNodeMaxNumRowEntries() - (getNodeNumEntries() / nrows);
 
-    if(size_t(maxRowImbalance) >= Tpetra::Details::Behavior::rowImbalanceThreshold())
+    if(size_t(maxRowImbalance) >= Tpetra::Details::Behavior::rowImbalanceThreshold()) {
       matrix_lcl->applyImbalancedRows (X_lcl, Y_lcl, mode, alpha, beta);
-    else
+    }
+    else {
       matrix_lcl->apply (X_lcl, Y_lcl, mode, alpha, beta);
+    }
   }
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
@@ -8907,7 +8909,7 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     size_t N = BaseRowMap->getNodeNumElements ();
 
     // Allocations
-    ArrayRCP<size_t> CSR_rowptr(N+1);
+    ArrayRCP<Details::DefaultTypes::offset_type> CSR_rowptr(N+1);
     ArrayRCP<GO> CSR_colind_GID;
     ArrayRCP<LO> CSR_colind_LID;
     ArrayRCP<Scalar> CSR_vals;

--- a/packages/tpetra/core/src/Tpetra_Details_DefaultTypes.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DefaultTypes.hpp
@@ -85,6 +85,12 @@ namespace DefaultTypes {
     #error "Tpetra: No global ordinal types in the set {int, long long, long, unsigned long, unsigned} have been enabled."
 #endif
 
+  //! Default offset type
+  using offset_type = size_t;  // For #9289, change this line to local_ordinal_type
+                               // On 2/22/22, Tpetra would compile and pass tests
+                               // with offset_type = local_ordinal_type
+                               // (albeit with lots of unsigned vs signed compiler warnings)
+
   /// \typedef execution_space
   /// \brief Default Tpetra execution space and Node type.
 #if defined(HAVE_TPETRA_DEFAULTNODE_SYCLWRAPPERNODE)

--- a/packages/tpetra/core/src/Tpetra_Details_getGraphDiagOffsets_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_getGraphDiagOffsets_decl.hpp
@@ -86,7 +86,9 @@ public:
   typedef ::Kokkos::StaticCrsGraph<LO,
                                    ::Kokkos::LayoutLeft,
                                    device_type,
-                                   void, size_t> local_graph_device_type;
+                                   void,
+                                   Details::DefaultTypes::offset_type> 
+                    local_graph_device_type;
   typedef ::Tpetra::Details::LocalMap<LO, GO, device_type> local_map_type;
   typedef ::Kokkos::View<const typename local_graph_device_type::size_type*,
                          ::Kokkos::LayoutLeft,

--- a/packages/tpetra/core/src/Tpetra_Details_getGraphOffRankOffsets_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_getGraphOffRankOffsets_decl.hpp
@@ -75,7 +75,7 @@ namespace Impl {
 template<class LO,
          class GO,
          class DeviceType,
-         class OffsetType = size_t>
+         class OffsetType = Details::DefaultTypes::offset_type>
 class GetGraphOffRankOffsets {
 public:
   typedef typename DeviceType::device_type device_type;
@@ -86,7 +86,9 @@ public:
   typedef ::Kokkos::StaticCrsGraph<LO,
                                    ::Kokkos::LayoutLeft,
                                    device_type,
-                                   void, size_t> local_graph_type;
+                                   void, 
+                                   Details::DefaultTypes::offset_type> 
+                    local_graph_type;
   typedef ::Tpetra::Details::LocalMap<LO, GO, device_type> local_map_type;
   typedef ::Kokkos::View<const typename local_graph_type::size_type*,
                          ::Kokkos::LayoutLeft,

--- a/packages/tpetra/core/src/Tpetra_Details_localDeepCopyRowMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_localDeepCopyRowMatrix_decl.hpp
@@ -65,7 +65,7 @@ KokkosSparse::CrsMatrix<
     LO,
     typename NT::device_type,
     void,
-    size_t>
+    Details::DefaultTypes::offset_type>
 localDeepCopyLocallyIndexedRowMatrix
   (const RowMatrix<SC, LO, GO, NT>& A,
    const char label[]);

--- a/packages/tpetra/core/src/Tpetra_Details_localDeepCopyRowMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_localDeepCopyRowMatrix_def.hpp
@@ -68,7 +68,7 @@ KokkosSparse::CrsMatrix<
     LO,
     typename NT::device_type,
     void,
-    size_t>
+    Details::DefaultTypes::offset_type>
 localDeepCopyLocallyIndexedRowMatrix
 (const RowMatrix<SC, LO, GO, NT>& A,
  const char label[])
@@ -96,7 +96,8 @@ localDeepCopyLocallyIndexedRowMatrix
   using Kokkos::WithoutInitializing;
   using IST = typename Kokkos::ArithTraits<SC>::val_type;
   using local_matrix_device_type = KokkosSparse::CrsMatrix<
-    IST, LO, typename NT::device_type, void, size_t>;
+    IST, LO, typename NT::device_type, void,
+    Details::DefaultTypes::offset_type>;
   using local_graph_device_type =
     typename local_matrix_device_type::staticcrsgraph_type;
   using inds_type = typename local_graph_device_type::entries_type;
@@ -168,7 +169,7 @@ localDeepCopyLocallyIndexedRowMatrix
 namespace Details { \
   template KokkosSparse::CrsMatrix< \
     Kokkos::ArithTraits<SC>::val_type, \
-    LO, NT::device_type, void, size_t> \
+    LO, NT::device_type, void, Details::DefaultTypes::offset_type> \
   localDeepCopyLocallyIndexedRowMatrix<SC, LO, GO, NT> \
     (const RowMatrix<SC, LO, GO, NT>& A, \
      const char label[]); \

--- a/packages/tpetra/core/src/Tpetra_Details_localRowOffsets_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_localRowOffsets_decl.hpp
@@ -58,7 +58,8 @@ struct LocalRowOffsetsResult {
 private:
   using local_graph_device_type =
     typename KokkosSparse::CrsMatrix<
-      double, int, typename NT::device_type, void, size_t>::
+      double, int, typename NT::device_type, void, 
+      Details::DefaultTypes::offset_type>::
         staticcrsgraph_type;
 public:
   using offsets_type =

--- a/packages/tpetra/core/src/Tpetra_Details_unpackCrsGraphAndCombine_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_unpackCrsGraphAndCombine_decl.hpp
@@ -175,7 +175,7 @@ unpackAndCombineIntoCrsArrays(
     size_t TargetNumRows,
     size_t TargetNumNonzeros,
     const int MyTargetPID,
-    const Teuchos::ArrayView<size_t>& CRS_rowptr,
+    const Teuchos::ArrayView<Details::DefaultTypes::offset_type>& CRS_rowptr,
     const Teuchos::ArrayView<GO>& CRS_colind,
     const Teuchos::ArrayView<const int>& SourcePids,
     Teuchos::Array<int>& TargetPids);

--- a/packages/tpetra/core/src/Tpetra_Details_unpackCrsGraphAndCombine_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_unpackCrsGraphAndCombine_def.hpp
@@ -434,7 +434,7 @@ unpackAndCombineWithOwningPIDsCount(
 template<class Packet, class LO, class Device, class BufferDevice>
 void
 setupRowPointersForRemotes(
-  const Kokkos::View<size_t*, Device>& tgt_rowptr,
+  const Kokkos::View<Details::DefaultTypes::offset_type*, Device>& tgt_rowptr,
   const Kokkos::View<const LO*, BufferDevice>& import_lids,
   const Kokkos::View<const Packet*, BufferDevice>& /* imports */,
   const Kokkos::View<const size_t*, BufferDevice>& num_packets_per_lid)
@@ -460,8 +460,8 @@ setupRowPointersForRemotes(
 template<class Device>
 void
 makeCrsRowPtrFromLengths(
-    const Kokkos::View<size_t*,Device,Kokkos::MemoryUnmanaged>& tgt_rowptr,
-    const Kokkos::View<size_t*,Device>& new_start_row)
+    const Kokkos::View<Details::DefaultTypes::offset_type*,Device,Kokkos::MemoryUnmanaged>& tgt_rowptr,
+    const Kokkos::View<Details::DefaultTypes::offset_type*,Device>& new_start_row)
 {
   using Kokkos::parallel_scan;
   using device_type = Device;
@@ -488,8 +488,8 @@ copyDataFromSameIDs(
     const Kokkos::View<typename LocalMap::global_ordinal_type*,
                        typename LocalMap::device_type>& tgt_colind,
     const Kokkos::View<int*, typename LocalMap::device_type>& tgt_pids,
-    const Kokkos::View<size_t*,typename LocalMap::device_type>& new_start_row,
-    const Kokkos::View<size_t*, typename LocalMap::device_type>& tgt_rowptr,
+    const Kokkos::View<Details::DefaultTypes::offset_type*,typename LocalMap::device_type>& new_start_row,
+    const Kokkos::View<Details::DefaultTypes::offset_type*, typename LocalMap::device_type>& tgt_rowptr,
     const Kokkos::View<const int*, typename LocalMap::device_type>& src_pids,
     const LocalGraph& local_graph,
     const LocalMap& local_col_map,
@@ -534,9 +534,9 @@ copyDataFromPermuteIDs(
                        typename LocalMap::device_type>& tgt_colind,
     const Kokkos::View<int*,
                        typename LocalMap::device_type>& tgt_pids,
-    const Kokkos::View<size_t*,
+    const Kokkos::View<Details::DefaultTypes::offset_type*,
                        typename LocalMap::device_type>& new_start_row,
-    const Kokkos::View<size_t*,
+    const Kokkos::View<Details::DefaultTypes::offset_type*,
                        typename LocalMap::device_type>& tgt_rowptr,
     const Kokkos::View<const int*,
                        typename LocalMap::device_type>& src_pids,
@@ -587,8 +587,8 @@ void
 unpackAndCombineIntoCrsArrays2(
     const Kokkos::View<typename LocalMap::global_ordinal_type*, typename LocalMap::device_type>& tgt_colind,
     const Kokkos::View<int*, typename LocalMap::device_type>& tgt_pids,
-    const Kokkos::View<size_t*,typename LocalMap::device_type>& new_start_row,
-    const Kokkos::View<const size_t*, typename LocalMap::device_type>& offsets,
+    const Kokkos::View<Details::DefaultTypes::offset_type*,typename LocalMap::device_type>& new_start_row,
+    const Kokkos::View<const Details::DefaultTypes::offset_type*, typename LocalMap::device_type>& offsets,
     const Kokkos::View<
       const typename LocalMap::local_ordinal_type*,
       BufferDevice,
@@ -668,7 +668,7 @@ unpackAndCombineIntoCrsArrays(
     const Kokkos::View<const typename LocalMap::local_ordinal_type*,
                        BufferDevice,
                        Kokkos::MemoryUnmanaged>& permute_from_lids,
-    const Kokkos::View<size_t*,
+    const Kokkos::View<Details::DefaultTypes::offset_type*,
                        typename LocalMap::device_type,
                        Kokkos::MemoryUnmanaged>& tgt_rowptr,
     const Kokkos::View<typename LocalMap::global_ordinal_type*,
@@ -746,7 +746,7 @@ unpackAndCombineIntoCrsArrays(
 
   // Get the offsets from the number of packets per LID
   const size_type num_import_lids = import_lids.extent(0);
-  View<size_t*, device_type> offsets("offsets", num_import_lids+1);
+  View<Details::DefaultTypes::offset_type*, device_type> offsets("offsets", num_import_lids+1);
   computeOffsetsFromCounts(offsets, num_packets_per_lid);
 
 #ifdef HAVE_TPETRA_DEBUG
@@ -768,7 +768,7 @@ unpackAndCombineIntoCrsArrays(
 
   // If multiple processes contribute to the same row, we may need to
   // update row offsets.  This tracks that.
-  View<size_t*, device_type> new_start_row("new_start_row", N+1);
+  View<Details::DefaultTypes::offset_type*, device_type> new_start_row("new_start_row", N+1);
 
   // Turn row length into a real CRS row pointer
   makeCrsRowPtrFromLengths(tgt_rowptr, new_start_row);
@@ -935,7 +935,7 @@ unpackAndCombineIntoCrsArrays(
     size_t TargetNumRows,
     size_t TargetNumNonzeros,
     const int MyTargetPID,
-    const Teuchos::ArrayView<size_t>& CRS_rowptr,
+    const Teuchos::ArrayView<Details::DefaultTypes::offset_type>& CRS_rowptr,
     const Teuchos::ArrayView<GlobalOrdinal>& CRS_colind,
     const Teuchos::ArrayView<const int>& SourcePids,
     Teuchos::Array<int>& TargetPids)
@@ -1011,7 +1011,7 @@ unpackAndCombineIntoCrsArrays(
       permuteFromLIDs.getRawPtr(), permuteFromLIDs.size(),
       true, "permute_from_lids");
 
-  Kokkos::View<size_t*, device_type> crs_rowptr_d =
+  Kokkos::View<Details::DefaultTypes::offset_type*, device_type> crs_rowptr_d =
     create_mirror_view_from_raw_host_array(outputDevice,
       CRS_rowptr.getRawPtr(), CRS_rowptr.size(),
       true, "crs_rowptr");
@@ -1073,7 +1073,7 @@ unpackAndCombineIntoCrsArrays(
     size_t, \
     size_t, \
     const int, \
-    const Teuchos::ArrayView<size_t>&, \
+    const Teuchos::ArrayView<Details::DefaultTypes::offset_type>&, \
     const Teuchos::ArrayView<GO>&, \
     const Teuchos::ArrayView<const int>&, \
     Teuchos::Array<int>&); \

--- a/packages/tpetra/core/src/Tpetra_Details_unpackCrsMatrixAndCombine_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_unpackCrsMatrixAndCombine_decl.hpp
@@ -240,7 +240,7 @@ unpackAndCombineIntoCrsArrays (
     size_t TargetNumRows,
     size_t TargetNumNonzeros,
     const int MyTargetPID,
-    const Teuchos::ArrayView<size_t>& CRS_rowptr,
+    const Teuchos::ArrayView<Details::DefaultTypes::offset_type>& CRS_rowptr,
     const Teuchos::ArrayView<GlobalOrdinal>& CRS_colind,
     const Teuchos::ArrayView<typename CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::impl_scalar_type>& CRS_vals,
     const Teuchos::ArrayView<const int>& SourcePids,

--- a/packages/tpetra/core/src/Tpetra_Details_unpackCrsMatrixAndCombine_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_unpackCrsMatrixAndCombine_def.hpp
@@ -191,7 +191,7 @@ struct UnpackCrsMatrixAndCombineFunctor {
 
   typedef Kokkos::View<const size_t*, BufferDeviceType>
     num_packets_per_lid_type;
-  typedef Kokkos::View<const size_t*, DT> offsets_type;
+  typedef Kokkos::View<const Details::DefaultTypes::offset_type*, DT> offsets_type;
   typedef Kokkos::View<const char*, BufferDeviceType> input_buffer_type;
   typedef Kokkos::View<const LO*, BufferDeviceType> import_lids_type;
 
@@ -434,7 +434,7 @@ template<class LO, class DT, class BDT>
 class NumEntriesFunctor {
 public:
   typedef Kokkos::View<const size_t*, BDT> num_packets_per_lid_type;
-  typedef Kokkos::View<const size_t*, DT> offsets_type;
+  typedef Kokkos::View<const Details::DefaultTypes::offset_type*, DT> offsets_type;
   typedef Kokkos::View<const char*, BDT> input_buffer_type;
   // This needs to be public, since it appears in the argument list of
   // public methods (see below).  Otherwise, build errors may happen.
@@ -500,7 +500,7 @@ template<class LO, class DT, class BDT>
 size_t
 compute_maximum_num_entries (
   const Kokkos::View<const size_t*, BDT>& num_packets_per_lid,
-  const Kokkos::View<const size_t*, DT>& offsets,
+  const Kokkos::View<const Details::DefaultTypes::offset_type*, DT>& offsets,
   const Kokkos::View<const char*, BDT>& imports)
 {
   typedef typename DT::execution_space XS;
@@ -529,7 +529,7 @@ template<class LO, class DT, class BDT>
 size_t
 compute_total_num_entries (
   const Kokkos::View<const size_t*, BDT>& num_packets_per_lid,
-  const Kokkos::View<const size_t*, DT>& offsets,
+  const Kokkos::View<const Details::DefaultTypes::offset_type*, DT>& offsets,
   const Kokkos::View<const char*, BDT>& imports)
 {
   typedef typename DT::execution_space XS;
@@ -653,7 +653,7 @@ unpackAndCombineIntoCrsMatrix(
   } // end QA error checking
 
   // Get the offsets
-  Kokkos::View<size_t*, DT> offsets("offsets", num_import_lids+1);
+  Kokkos::View<Details::DefaultTypes::offset_type*, DT> offsets("offsets", num_import_lids+1);
   computeOffsetsFromCounts(offsets, num_packets_per_lid);
 
   // Determine the sizes of the unpack batches
@@ -785,7 +785,7 @@ unpackAndCombineWithOwningPIDsCount(
   {
     // Count entries received from other MPI processes.
     const size_type np = num_packets_per_lid.extent(0);
-    Kokkos::View<size_t*, device_type> offsets("offsets", np+1);
+    Kokkos::View<Details::DefaultTypes::offset_type*, device_type> offsets("offsets", np+1);
     computeOffsetsFromCounts(offsets, num_packets_per_lid);
     count +=
       compute_total_num_entries<LO, device_type, BDT> (num_packets_per_lid,
@@ -799,11 +799,11 @@ unpackAndCombineWithOwningPIDsCount(
 template<class LO, class DT, class BDT>
 int
 setupRowPointersForRemotes(
-  const typename PackTraits<size_t>::output_array_type& tgt_rowptr,
+  const typename PackTraits<Details::DefaultTypes::offset_type>::output_array_type& tgt_rowptr,
   const typename PackTraits<LO>::input_array_type& import_lids,
   const Kokkos::View<const char*, BDT>& imports,
   const Kokkos::View<const size_t*, BDT>& num_packets_per_lid,
-  const typename PackTraits<size_t>::input_array_type& offsets)
+  const typename PackTraits<Details::DefaultTypes::offset_type>::input_array_type& offsets)
 {
   using Kokkos::parallel_reduce;
   typedef typename DT::execution_space XS;
@@ -833,12 +833,12 @@ setupRowPointersForRemotes(
 template<class DT>
 void
 makeCrsRowPtrFromLengths(
-    const typename PackTraits<size_t>::output_array_type& tgt_rowptr,
-    const Kokkos::View<size_t*,DT>& new_start_row)
+    const typename PackTraits<Details::DefaultTypes::offset_type>::output_array_type& tgt_rowptr,
+    const Kokkos::View<Details::DefaultTypes::offset_type*,DT>& new_start_row)
 {
   using Kokkos::parallel_scan;
   typedef typename DT::execution_space XS;
-  typedef typename Kokkos::View<size_t*,DT>::size_type size_type;
+  typedef typename Kokkos::View<Details::DefaultTypes::offset_type*,DT>::size_type size_type;
   typedef Kokkos::RangePolicy<XS, Kokkos::IndexType<size_type> > range_policy;
   const size_type N = new_start_row.extent(0);
   parallel_scan(range_policy(0, N),
@@ -859,8 +859,8 @@ copyDataFromSameIDs(
     const typename PackTraits<typename LocalMap::global_ordinal_type>::output_array_type& tgt_colind,
     const typename PackTraits<int>::output_array_type& tgt_pids,
     const typename PackTraits<typename LocalMatrix::value_type>::output_array_type& tgt_vals,
-    const Kokkos::View<size_t*, typename LocalMap::device_type>& new_start_row,
-    const typename PackTraits<size_t>::output_array_type& tgt_rowptr,
+    const Kokkos::View<Details::DefaultTypes::offset_type*, typename LocalMap::device_type>& new_start_row,
+    const typename PackTraits<Details::DefaultTypes::offset_type>::output_array_type& tgt_rowptr,
     const typename PackTraits<int>::input_array_type& src_pids,
     const LocalMatrix& local_matrix,
     const LocalMap& local_col_map,
@@ -904,8 +904,8 @@ copyDataFromPermuteIDs(
     const typename PackTraits<typename LocalMap::global_ordinal_type>::output_array_type& tgt_colind,
     const typename PackTraits<int>::output_array_type& tgt_pids,
     const typename PackTraits<typename LocalMatrix::value_type>::output_array_type& tgt_vals,
-    const Kokkos::View<size_t*,typename LocalMap::device_type>& new_start_row,
-    const typename PackTraits<size_t>::output_array_type& tgt_rowptr,
+    const Kokkos::View<Details::DefaultTypes::offset_type*,typename LocalMap::device_type>& new_start_row,
+    const typename PackTraits<Details::DefaultTypes::offset_type>::output_array_type& tgt_rowptr,
     const typename PackTraits<int>::input_array_type& src_pids,
     const typename PackTraits<typename LocalMap::local_ordinal_type>::input_array_type& permute_to_lids,
     const typename PackTraits<typename LocalMap::local_ordinal_type>::input_array_type& permute_from_lids,
@@ -953,8 +953,8 @@ unpackAndCombineIntoCrsArrays2(
     const typename PackTraits<typename LocalMap::global_ordinal_type>::output_array_type& tgt_colind,
     const typename PackTraits<int>::output_array_type& tgt_pids,
     const typename PackTraits<typename LocalMatrix::value_type>::output_array_type& tgt_vals,
-    const Kokkos::View<size_t*,typename LocalMap::device_type>& new_start_row,
-    const typename PackTraits<size_t>::input_array_type& offsets,
+    const Kokkos::View<Details::DefaultTypes::offset_type*,typename LocalMap::device_type>& new_start_row,
+    const typename PackTraits<Details::DefaultTypes::offset_type>::input_array_type& offsets,
     const typename PackTraits<typename LocalMap::local_ordinal_type>::input_array_type& import_lids,
     const Kokkos::View<const char*, BufferDeviceType>& imports,
     const Kokkos::View<const size_t*, BufferDeviceType>& num_packets_per_lid,
@@ -1035,7 +1035,7 @@ unpackAndCombineIntoCrsArrays(
     const Kokkos::View<const size_t*, BufferDeviceType>& num_packets_per_lid,
     const typename PackTraits<typename LocalMap::local_ordinal_type>::input_array_type& permute_to_lids,
     const typename PackTraits<typename LocalMap::local_ordinal_type>::input_array_type& permute_from_lids,
-    const typename PackTraits<size_t>::output_array_type& tgt_rowptr,
+    const typename PackTraits<Details::DefaultTypes::offset_type>::output_array_type& tgt_rowptr,
     const typename PackTraits<typename LocalMap::global_ordinal_type>::output_array_type& tgt_colind,
     const typename PackTraits<typename LocalMatrix::value_type>::output_array_type& tgt_vals,
     const typename PackTraits<int>::input_array_type& src_pids,
@@ -1096,106 +1096,106 @@ unpackAndCombineIntoCrsArrays(
 
   // Get the offsets from the number of packets per LID
   const size_type num_import_lids = import_lids.extent(0);
-  View<size_t*, DT> offsets("offsets", num_import_lids+1);
+  View<Details::DefaultTypes::offset_type*, DT> offsets("offsets", num_import_lids+1);
   computeOffsetsFromCounts(offsets, num_packets_per_lid);
 
 #ifdef HAVE_TPETRA_DEBUG
   {
     auto nth_offset_h = getEntryOnHost(offsets, num_import_lids);
     const bool condition =
-      nth_offset_h != static_cast<size_t>(imports.extent (0));
-    TEUCHOS_TEST_FOR_EXCEPTION
-      (condition, std::logic_error, prefix
-       << "The final offset in bytes " << nth_offset_h
-       << " != imports.size() = " << imports.extent(0)
-       << ".  Please report this bug to the Tpetra developers.");
-  }
-#endif // HAVE_TPETRA_DEBUG
+	      nth_offset_h != static_cast<size_t>(imports.extent (0));
+	    TEUCHOS_TEST_FOR_EXCEPTION
+	      (condition, std::logic_error, prefix
+	       << "The final offset in bytes " << nth_offset_h
+	       << " != imports.size() = " << imports.extent(0)
+	       << ".  Please report this bug to the Tpetra developers.");
+	  }
+	#endif // HAVE_TPETRA_DEBUG
 
-  // Setup row pointers for remotes
-  int k_error =
-    setupRowPointersForRemotes<LO,DT,BDT>(tgt_rowptr,
-      import_lids, imports, num_packets_per_lid, offsets);
-  TEUCHOS_TEST_FOR_EXCEPTION(k_error != 0, std::logic_error, prefix
-    << " Error transferring data to target row pointers.  "
-       "Please report this bug to the Tpetra developers.");
+	  // Setup row pointers for remotes
+	  int k_error =
+	    setupRowPointersForRemotes<LO,DT,BDT>(tgt_rowptr,
+	      import_lids, imports, num_packets_per_lid, offsets);
+	  TEUCHOS_TEST_FOR_EXCEPTION(k_error != 0, std::logic_error, prefix
+	    << " Error transferring data to target row pointers.  "
+	       "Please report this bug to the Tpetra developers.");
 
-  // If multiple processes contribute to the same row, we may need to
-  // update row offsets.  This tracks that.
-  View<size_t*, DT> new_start_row ("new_start_row", N+1);
+	  // If multiple processes contribute to the same row, we may need to
+	  // update row offsets.  This tracks that.
+	  View<Details::DefaultTypes::offset_type*, DT> new_start_row ("new_start_row", N+1);
 
-  // Turn row length into a real CRS row pointer
-  makeCrsRowPtrFromLengths(tgt_rowptr, new_start_row);
+	  // Turn row length into a real CRS row pointer
+	  makeCrsRowPtrFromLengths(tgt_rowptr, new_start_row);
 
-  // SameIDs: Copy the data over
-  copyDataFromSameIDs(tgt_colind, tgt_pids, tgt_vals, new_start_row,
-      tgt_rowptr, src_pids, local_matrix, local_col_map, num_same_ids, my_pid);
+	  // SameIDs: Copy the data over
+	  copyDataFromSameIDs(tgt_colind, tgt_pids, tgt_vals, new_start_row,
+	      tgt_rowptr, src_pids, local_matrix, local_col_map, num_same_ids, my_pid);
 
-  copyDataFromPermuteIDs(tgt_colind, tgt_pids, tgt_vals, new_start_row,
-      tgt_rowptr, src_pids, permute_to_lids, permute_from_lids,
-      local_matrix, local_col_map, my_pid);
+	  copyDataFromPermuteIDs(tgt_colind, tgt_pids, tgt_vals, new_start_row,
+	      tgt_rowptr, src_pids, permute_to_lids, permute_from_lids,
+	      local_matrix, local_col_map, my_pid);
 
-  if (imports.extent(0) <= 0) {
-    return;
-  }
+	  if (imports.extent(0) <= 0) {
+	    return;
+	  }
 
-  int unpack_err = unpackAndCombineIntoCrsArrays2(tgt_colind, tgt_pids,
-      tgt_vals, new_start_row, offsets, import_lids, imports, num_packets_per_lid,
-      local_matrix, local_col_map, my_pid, bytes_per_value);
-  TEUCHOS_TEST_FOR_EXCEPTION(
-    unpack_err != 0, std::logic_error, prefix << "unpack loop failed.  This "
-    "should never happen.  Please report this bug to the Tpetra developers.");
+	  int unpack_err = unpackAndCombineIntoCrsArrays2(tgt_colind, tgt_pids,
+	      tgt_vals, new_start_row, offsets, import_lids, imports, num_packets_per_lid,
+	      local_matrix, local_col_map, my_pid, bytes_per_value);
+	  TEUCHOS_TEST_FOR_EXCEPTION(
+	    unpack_err != 0, std::logic_error, prefix << "unpack loop failed.  This "
+	    "should never happen.  Please report this bug to the Tpetra developers.");
 
-  return;
-}
+	  return;
+	}
 
-} // namespace UnpackAndCombineCrsMatrixImpl
+	} // namespace UnpackAndCombineCrsMatrixImpl
 
-/// \brief Unpack the imported column indices and values, and combine into matrix.
-///
-/// \tparam ST The type of the numerical entries of the matrix.
-///   (You can use real-valued or complex-valued types here, unlike
-///   in Epetra, where the scalar type is always \c double.)
-/// \tparam LO The type of local indices.  See the
-///   documentation of Map for requirements.
-/// \tparam GO The type of global indices.  See the
-///   documentation of Map for requirements.
-/// \tparam Node The Kokkos Node type.  See the documentation of Map
-///   for requirements.
-///
-/// \param sourceMatrix [in] the CrsMatrix source
-///
-/// \param imports [in] Input pack buffer
-///
-/// \param numPacketsPerLID [out] Entry k gives the number of bytes
-///   packed for row exportLIDs[k] of the local matrix.
-///
-/// \param importLIDs [in] Local indices of the rows to pack.
-///
-/// \param constantNumPackets [out] Setting this to zero tells the caller
-///   to expect a possibly /// different ("nonconstant") number of packets per local index
-///   (i.e., a possibly different number of entries per row).
-///
-/// \param distor [in] The distributor (not used)
-///
-/// \param combineMode [in] the mode to use for combining values
-///
-/// \param atomic [in] whether or not do atomic adds/replaces in to the matrix
-///
-/// \warning The allowed \c combineMode are:
-///   ADD, REPLACE, and ABSMAX. INSERT is not allowed.
-///
-/// This is the public interface to the unpack and combine machinery and
-/// converts passed Teuchos::ArrayView objects to Kokkos::View objects (and
-/// copies back in to the Teuchos::ArrayView objects, if needed).  When
-/// CrsMatrix migrates fully to adopting Kokkos::DualView objects for its storage
-/// of data, this procedure could be bypassed.
-template<typename ST, typename LO, typename GO, typename Node>
-void
-unpackCrsMatrixAndCombine(
-    const CrsMatrix<ST, LO, GO, Node>& sourceMatrix,
-    const Teuchos::ArrayView<const char>& imports,
-    const Teuchos::ArrayView<const size_t>& numPacketsPerLID,
+	/// \brief Unpack the imported column indices and values, and combine into matrix.
+	///
+	/// \tparam ST The type of the numerical entries of the matrix.
+	///   (You can use real-valued or complex-valued types here, unlike
+	///   in Epetra, where the scalar type is always \c double.)
+	/// \tparam LO The type of local indices.  See the
+	///   documentation of Map for requirements.
+	/// \tparam GO The type of global indices.  See the
+	///   documentation of Map for requirements.
+	/// \tparam Node The Kokkos Node type.  See the documentation of Map
+	///   for requirements.
+	///
+	/// \param sourceMatrix [in] the CrsMatrix source
+	///
+	/// \param imports [in] Input pack buffer
+	///
+	/// \param numPacketsPerLID [out] Entry k gives the number of bytes
+	///   packed for row exportLIDs[k] of the local matrix.
+	///
+	/// \param importLIDs [in] Local indices of the rows to pack.
+	///
+	/// \param constantNumPackets [out] Setting this to zero tells the caller
+	///   to expect a possibly /// different ("nonconstant") number of packets per local index
+	///   (i.e., a possibly different number of entries per row).
+	///
+	/// \param distor [in] The distributor (not used)
+	///
+	/// \param combineMode [in] the mode to use for combining values
+	///
+	/// \param atomic [in] whether or not do atomic adds/replaces in to the matrix
+	///
+	/// \warning The allowed \c combineMode are:
+	///   ADD, REPLACE, and ABSMAX. INSERT is not allowed.
+	///
+	/// This is the public interface to the unpack and combine machinery and
+	/// converts passed Teuchos::ArrayView objects to Kokkos::View objects (and
+	/// copies back in to the Teuchos::ArrayView objects, if needed).  When
+	/// CrsMatrix migrates fully to adopting Kokkos::DualView objects for its storage
+	/// of data, this procedure could be bypassed.
+	template<typename ST, typename LO, typename GO, typename Node>
+	void
+	unpackCrsMatrixAndCombine(
+	    const CrsMatrix<ST, LO, GO, Node>& sourceMatrix,
+	    const Teuchos::ArrayView<const char>& imports,
+	    const Teuchos::ArrayView<const size_t>& numPacketsPerLID,
     const Teuchos::ArrayView<const LO>& importLIDs,
     size_t /* constantNumPackets */,
     CombineMode combineMode)
@@ -1432,7 +1432,7 @@ unpackAndCombineIntoCrsArrays (
     size_t TargetNumRows,
     size_t TargetNumNonzeros,
     const int MyTargetPID,
-    const Teuchos::ArrayView<size_t>& CRS_rowptr,
+    const Teuchos::ArrayView<Details::DefaultTypes::offset_type>& CRS_rowptr,
     const Teuchos::ArrayView<GlobalOrdinal>& CRS_colind,
     const Teuchos::ArrayView<typename CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::impl_scalar_type>& CRS_vals,
     const Teuchos::ArrayView<const int>& SourcePids,
@@ -1642,7 +1642,7 @@ unpackAndCombineIntoCrsArrays (
     size_t, \
     size_t, \
     const int, \
-    const Teuchos::ArrayView<size_t>&, \
+    const Teuchos::ArrayView<Details::DefaultTypes::offset_type>&, \
     const Teuchos::ArrayView<GO>&, \
     const Teuchos::ArrayView<CrsMatrix<ST, LO, GO, NT>::impl_scalar_type>&, \
     const Teuchos::ArrayView<const int>&, \

--- a/packages/tpetra/core/src/Tpetra_Import_Util2.hpp
+++ b/packages/tpetra/core/src/Tpetra_Import_Util2.hpp
@@ -70,13 +70,13 @@ namespace Import_Util {
 ///   within each row.
 template<typename Scalar, typename Ordinal>
 void
-sortCrsEntries (const Teuchos::ArrayView<size_t>& CRS_rowptr,
+sortCrsEntries (const Teuchos::ArrayView<Details::DefaultTypes::offset_type>& CRS_rowptr,
                 const Teuchos::ArrayView<Ordinal>& CRS_colind,
                 const Teuchos::ArrayView<Scalar>&CRS_vals);
 
 template<typename Ordinal>
 void
-sortCrsEntries (const Teuchos::ArrayView<size_t>& CRS_rowptr,
+sortCrsEntries (const Teuchos::ArrayView<Details::DefaultTypes::offset_type>& CRS_rowptr,
                 const Teuchos::ArrayView<Ordinal>& CRS_colind);
 
 template<typename rowptr_array_type, typename colind_array_type, typename vals_array_type>
@@ -96,13 +96,13 @@ sortCrsEntries (const rowptr_array_type& CRS_rowptr,
 /// Entries with the same column index get merged additively.
 template<typename Scalar, typename Ordinal>
 void
-sortAndMergeCrsEntries (const Teuchos::ArrayView<size_t>& CRS_rowptr,
+sortAndMergeCrsEntries (const Teuchos::ArrayView<Details::DefaultTypes::offset_type>& CRS_rowptr,
                         const Teuchos::ArrayView<Ordinal>& CRS_colind,
                         const Teuchos::ArrayView<Scalar>& CRS_vals);
 
 template<typename Ordinal>
 void
-sortAndMergeCrsEntries (const Teuchos::ArrayView<size_t>& CRS_rowptr,
+sortAndMergeCrsEntries (const Teuchos::ArrayView<Details::DefaultTypes::offset_type>& CRS_rowptr,
                         const Teuchos::ArrayView<Ordinal>& CRS_colind);
 
 /// \brief lowCommunicationMakeColMapAndReindex
@@ -122,7 +122,7 @@ sortAndMergeCrsEntries (const Teuchos::ArrayView<size_t>& CRS_rowptr,
 ///   and should never be called by user code.
 template <typename LocalOrdinal, typename GlobalOrdinal, typename Node>
 void
-lowCommunicationMakeColMapAndReindex (const Teuchos::ArrayView<const size_t> &rowPointers,
+lowCommunicationMakeColMapAndReindex (const Teuchos::ArrayView<const Details::DefaultTypes::offset_type> &rowPointers,
                                       const Teuchos::ArrayView<LocalOrdinal> &columnIndices_LID,
                                       const Teuchos::ArrayView<GlobalOrdinal> &columnIndices_GID,
                                       const Teuchos::RCP<const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> > & domainMap,
@@ -455,7 +455,7 @@ reverseNeighborDiscovery(const CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, No
 // Note: This should get merged with the other Tpetra sort routines eventually.
 template<typename Scalar, typename Ordinal>
 void
-sortCrsEntries (const Teuchos::ArrayView<size_t> &CRS_rowptr,
+sortCrsEntries (const Teuchos::ArrayView<Details::DefaultTypes::offset_type> &CRS_rowptr,
                 const Teuchos::ArrayView<Ordinal> & CRS_colind,
                 const Teuchos::ArrayView<Scalar> &CRS_vals)
 {
@@ -505,7 +505,7 @@ sortCrsEntries (const Teuchos::ArrayView<size_t> &CRS_rowptr,
 
 template<typename Ordinal>
 void
-sortCrsEntries (const Teuchos::ArrayView<size_t> &CRS_rowptr,
+sortCrsEntries (const Teuchos::ArrayView<Details::DefaultTypes::offset_type> &CRS_rowptr,
                 const Teuchos::ArrayView<Ordinal> & CRS_colind)
 {
   // Generate dummy values array
@@ -630,7 +630,7 @@ sortCrsEntries (const rowptr_array_type& CRS_rowptr,
 // Note: This should get merged with the other Tpetra sort routines eventually.
 template<typename Scalar, typename Ordinal>
 void
-sortAndMergeCrsEntries (const Teuchos::ArrayView<size_t> &CRS_rowptr,
+sortAndMergeCrsEntries (const Teuchos::ArrayView<Details::DefaultTypes::offset_type> &CRS_rowptr,
                         const Teuchos::ArrayView<Ordinal> & CRS_colind,
                         const Teuchos::ArrayView<Scalar> &CRS_vals)
 {
@@ -705,7 +705,7 @@ sortAndMergeCrsEntries (const Teuchos::ArrayView<size_t> &CRS_rowptr,
 
 template<typename Ordinal>
 void
-sortAndMergeCrsEntries (const Teuchos::ArrayView<size_t> &CRS_rowptr,
+sortAndMergeCrsEntries (const Teuchos::ArrayView<Details::DefaultTypes::offset_type> &CRS_rowptr,
                         const Teuchos::ArrayView<Ordinal> & CRS_colind)
 {
   Teuchos::ArrayView<Tpetra::Details::DefaultTypes::scalar_type> CRS_vals;
@@ -715,7 +715,7 @@ sortAndMergeCrsEntries (const Teuchos::ArrayView<size_t> &CRS_rowptr,
 
 template <typename LocalOrdinal, typename GlobalOrdinal, typename Node>
 void
-lowCommunicationMakeColMapAndReindex (const Teuchos::ArrayView<const size_t> &rowptr,
+lowCommunicationMakeColMapAndReindex (const Teuchos::ArrayView<const Details::DefaultTypes::offset_type> &rowptr,
                                       const Teuchos::ArrayView<LocalOrdinal> &colind_LID,
                                       const Teuchos::ArrayView<GlobalOrdinal> &colind_GID,
                                       const Teuchos::RCP<const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> >& domainMapRCP,

--- a/packages/tpetra/core/src/Tpetra_LocalCrsMatrixOperator_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_LocalCrsMatrixOperator_decl.hpp
@@ -77,7 +77,7 @@ namespace Tpetra {
                               local_ordinal_type,
                               device_type,
                               void,
-                              size_t>;
+                              Details::DefaultTypes::offset_type>;
   private:
     //The type of a matrix with offset=ordinal, but otherwise the same as local_matrix_device_type
     using local_cusparse_matrix_type =

--- a/packages/tpetra/core/src/Tpetra_RowGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_RowGraph_decl.hpp
@@ -98,7 +98,7 @@ namespace Tpetra {
         nonconst_global_inds_host_view_type;
 
     typedef typename 
-        Kokkos::View<const size_t*, typename Node::device_type>::const_type
+        Kokkos::View<const Details::DefaultTypes::offset_type*, typename Node::device_type>::const_type
         row_ptrs_device_view_type;
     typedef typename row_ptrs_device_view_type::HostMirror::const_type
         row_ptrs_host_view_type;

--- a/packages/tpetra/core/src/Tpetra_RowMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_RowMatrix_decl.hpp
@@ -142,7 +142,8 @@ namespace Tpetra {
 
 
     typedef typename
-        Kokkos::View<const size_t*, typename Node::device_type>::const_type
+        Kokkos::View<const Details::DefaultTypes::offset_type*,
+                     typename Node::device_type>::const_type
         row_ptrs_device_view_type;
     typedef typename row_ptrs_device_view_type::HostMirror::const_type
         row_ptrs_host_view_type;

--- a/packages/tpetra/core/test/CrsGraph/CrsGraph_UnitTests1.cpp
+++ b/packages/tpetra/core/test/CrsGraph/CrsGraph_UnitTests1.cpp
@@ -497,7 +497,7 @@ namespace { // (anonymous)
       const size_t numLocal = 2;
       const RCP<const map_type> rmap =
         rcp (new map_type (INVALID, numLocal, 0, comm));
-      ArrayRCP<size_t> rowptr(numLocal+1);
+      ArrayRCP<::Tpetra::Details::DefaultTypes::offset_type> rowptr(numLocal+1);
       ArrayRCP<LO>     colind(numLocal); // one unknown per row
       rowptr[0] = 0; rowptr[1] = 1; rowptr[2] = 2;
       colind[0] = Teuchos::as<LO>(0);
@@ -538,7 +538,7 @@ namespace { // (anonymous)
       const size_t numLocal = 2;
       RCP<const map_type> rmap =
         rcp (new map_type (INVALID, numLocal, 0, comm));
-      ArrayRCP<size_t> rowptr(numLocal+1);
+      ArrayRCP<::Tpetra::Details::DefaultTypes::offset_type> rowptr(numLocal+1);
       ArrayRCP<LO>     colind(numLocal); // one unknown per row
       rowptr[0] = 0; rowptr[1] = 1; rowptr[2] = 2;
       colind[0] = Teuchos::as<LO>(0);
@@ -601,7 +601,7 @@ namespace { // (anonymous)
       cmap_ind[1] = ((comm->getRank()+1)*numLocal) % (numProcs*numLocal);
       RCP<const map_type> cmap =
         rcp (new map_type (INVALID, cmap_ind(), 0, comm));
-      ArrayRCP<size_t> rowptr(numLocal+1);
+      ArrayRCP<::Tpetra::Details::DefaultTypes::offset_type> rowptr(numLocal+1);
       ArrayRCP<LO>     colind(numLocal); // one unknown per row
       rowptr[0] = 0; rowptr[1] = 1; rowptr[2] = 2;
       colind[0] = Teuchos::as<LO>(0);

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests4.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests4.cpp
@@ -438,7 +438,7 @@ inline void tupleToArray(Array<T> &arr, const tuple &tup)
     mvrand.randomize();
 
     // create the identity matrix, via three arrays constructor
-    ArrayRCP<size_t> rowptr(numLocal+1);
+    ArrayRCP<::Tpetra::Details::DefaultTypes::offset_type> rowptr(numLocal+1);
     ArrayRCP<LO>     colind(numLocal); // one unknown per row
     ArrayRCP<Scalar> values(numLocal); // one unknown per row
 
@@ -505,7 +505,7 @@ inline void tupleToArray(Array<T> &arr, const tuple &tup)
     mvrand.randomize();
 
     // create the identity matrix, via three arrays constructor
-    ArrayRCP<size_t> rowptr(numLocal+1);
+    ArrayRCP<::Tpetra::Details::DefaultTypes::offset_type> rowptr(numLocal+1);
     ArrayRCP<LO>     colind(numLocal); // one unknown per row
     ArrayRCP<Scalar> values(numLocal); // one unknown per row
 
@@ -635,7 +635,7 @@ inline void tupleToArray(Array<T> &arr, const tuple &tup)
     mvrand.randomize();
 
     // create the identity matrix, via three arrays constructor
-    ArrayRCP<size_t> rowptr(numLocal+1);
+    ArrayRCP<::Tpetra::Details::DefaultTypes::offset_type> rowptr(numLocal+1);
     ArrayRCP<LO>     colind(numLocal); // one unknown per row
     ArrayRCP<Scalar> values(numLocal); // one unknown per row
 
@@ -708,7 +708,7 @@ inline void tupleToArray(Array<T> &arr, const tuple &tup)
     mvrand.randomize();
 
     // create the identity matrix, via three arrays constructor
-    ArrayRCP<size_t> rowptr(numLocal+1);
+    ArrayRCP<::Tpetra::Details::DefaultTypes::offset_type> rowptr(numLocal+1);
     ArrayRCP<LO>     colind(numLocal); // one unknown per row
     ArrayRCP<Scalar> values(numLocal); // one unknown per row
 
@@ -787,7 +787,7 @@ inline void tupleToArray(Array<T> &arr, const tuple &tup)
     RCP<const Map<LO,GO,Node> > map = createContigMapWithNode<LO,GO,Node>(INVALID,numLocal,comm);
 
     // create block lower-triangular, via three arrays constructor
-    ArrayRCP<size_t> rowptr(numLocal+1);
+    ArrayRCP<::Tpetra::Details::DefaultTypes::offset_type> rowptr(numLocal+1);
     ArrayRCP<LO>     colind((int)(1.5*numLocal)); // 1.5 unknowns per row
     ArrayRCP<Scalar> values((int)(1.5*numLocal)); // 1.5 two unknowns per row
 
@@ -886,7 +886,7 @@ inline void tupleToArray(Array<T> &arr, const tuple &tup)
     RCP<const Map<LO,GO,Node> > map = createContigMapWithNode<LO,GO,Node>(INVALID,numLocal,comm);
 
     // create block lower-triangular, via three arrays constructor
-    ArrayRCP<size_t> rowptr(numLocal+1);
+    ArrayRCP<::Tpetra::Details::DefaultTypes::offset_type> rowptr(numLocal+1);
     ArrayRCP<LO>     colind((int)(1.5*numLocal)); // 1.5 unknowns per row
     ArrayRCP<Scalar> values((int)(1.5*numLocal)); // 1.5 two unknowns per row
 

--- a/packages/tpetra/core/test/ImportExport2/ImportExport2_CrsSortingUtils.cpp
+++ b/packages/tpetra/core/test/ImportExport2/ImportExport2_CrsSortingUtils.cpp
@@ -176,7 +176,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( Import_Util, SortCrsEntries, Scalar, LO, GO)
   using Tpetra::Import_Util::sortCrsEntries;
   using Tpetra::Import_Util::sortAndMergeCrsEntries;
 
-  typedef size_t index_type;
+  typedef ::Tpetra::Details::DefaultTypes::offset_type index_type;
   typedef Scalar scalar_type;
   typedef GO ordinal_type;
 

--- a/packages/tpetra/core/test/ImportExport2/ImportExport2_UnitTests.cpp
+++ b/packages/tpetra/core/test/ImportExport2/ImportExport2_UnitTests.cpp
@@ -1872,7 +1872,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FusedImportExport, doImport, LO, GO, Scalar )
     build_test_matrix_with_row_overlap<CrsMatrixType>(Comm,A);
     Ag = A->getCrsGraph();
 
-    Teuchos::ArrayRCP<const size_t> rowptr;
+    Teuchos::ArrayRCP<const ::Tpetra::Details::DefaultTypes::offset_type> rowptr;
     Teuchos::ArrayRCP<const LO> colind;
     Teuchos::ArrayRCP<const Scalar> vals;
 
@@ -2387,7 +2387,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( Import_Util, UnpackAndCombineWithOwningPIDs, 
     /////////////////////////////////////////////////////////
     // Test #2: Actual combine test
     /////////////////////////////////////////////////////////
-    Teuchos::Array<size_t>  rowptr (MapTarget->getNodeNumElements () + 1);
+    Teuchos::Array<::Tpetra::Details::DefaultTypes::offset_type>  rowptr (MapTarget->getNodeNumElements () + 1);
     Teuchos::Array<GO>      colind (nnz2);
     Teuchos::Array<Scalar>  vals (nnz2);
     Teuchos::Array<int>     TargetPids;


### PR DESCRIPTION


<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
This PR is a first step toward #9289.

I added a new default type: Tpetra::Details::DefaultTypes::offset_type
For now, it is set to size_t, to maintain backward compatibility with current code.  
Every place in Tpetra that creates offset arrays now uses this default type instead of size_t.

To implement #9289, change this default offset_type to local_ordinal_type.

Caveats:
-  deprecated function getAllValues (and, perhaps, other deprecated functions) has not been retrofitted to use the offset_type, as we cannot cast views of size_t to be viest of local_ordinal_type.  Rather than retrofit deprecated functions, changing to local_ordinal_type can be delayed until deprecated code is removed.
- using Tpetra::Details::DefaultTypes::offset_type in the Tpetra API exposes a Details member -- bad form.  We should either use local_ordinal_type or add an offset_type typedef to RowGraph so that users don't have to type "Details::"
- Details::DefaultTypes::offset_type is easy to grep and replace with a better interface

Unfortunately, changing the offset_type to local_ordinal_type didn't really speed up SpMV on SerialNode as hoped.  Its benefit should be most seen when using CUSparse as an additional offset array will not be needed.  See #9289

These changes were more work than I expected, so I didn't want to just throw them away after my timing experiment.  @trilinos/tpetra can decide how to proceed with them.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
@brian-kelley 
## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Tested with SerialNode on ascicgpu machines, with offset_type = local_ordinal_type and offset_type = size_t.

The Tpetra tests build and pass in both cases -- yea!
With offset_type = local_ordinal_type, many compiler warnings about comparing signed and unsigned are emitted.  Some code cleanup will be needed.


<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->