### PR TITLE
Tpetra:  fixed used of deprecated code

### DIFF
--- a/packages/tpetra/core/src/CMakeLists.txt
+++ b/packages/tpetra/core/src/CMakeLists.txt
@@ -809,6 +809,17 @@ IF (${PACKAGE_NAME}_ENABLE_EXPLICIT_INSTANTIATION)
       "${TpetraCore_ETI_NODES}"
       FALSE)
     LIST(APPEND SOURCES ${CREATEDEEPCOPY_CRSMATRIX_OUTPUT_FILES})
+
+    # Generate ETI .cpp files for Tpetra::Details::localRowOffsets.
+    TPETRA_PROCESS_ALL_LGN_TEMPLATES(LOCALROWOFFSETS_OUTPUT_FILES
+      "Tpetra_ETI_LO_GO_NT.tmpl"
+      "Details_localRowOffsets"
+      "DETAILS_LOCALROWOFFSETS"
+      "${TpetraCore_ETI_LORDS}"
+      "${TpetraCore_ETI_GORDS}"
+      "${TpetraCore_ETI_NODES}")
+    LIST(APPEND SOURCES ${LOCALROWOFFSETS_OUTPUT_FILES})
+
   ENDIF ()
 
   # Generate ETI .cpp files for Tpetra::LocalCrsMatrixOperator.
@@ -917,16 +928,6 @@ IF (${PACKAGE_NAME}_ENABLE_EXPLICIT_INSTANTIATION)
     "${TpetraCore_ETI_GORDS}"
     "${TpetraCore_ETI_NODES}")
   LIST(APPEND SOURCES ${UNPACKCRSGRAPHANDCOMBINE_OUTPUT_FILES})
-
-  # Generate ETI .cpp files for Tpetra::Details::localRowOffsets.
-  TPETRA_PROCESS_ALL_LGN_TEMPLATES(LOCALROWOFFSETS_OUTPUT_FILES
-    "Tpetra_ETI_LO_GO_NT.tmpl"
-    "Details_localRowOffsets"
-    "DETAILS_LOCALROWOFFSETS"
-    "${TpetraCore_ETI_LORDS}"
-    "${TpetraCore_ETI_GORDS}"
-    "${TpetraCore_ETI_NODES}")
-  LIST(APPEND SOURCES ${LOCALROWOFFSETS_OUTPUT_FILES})
 
   #MESSAGE(STATUS "SOURCES = ${SOURCES}")
 ENDIF()

--- a/packages/tpetra/core/src/Tpetra_Details_localDeepCopyRowMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_localDeepCopyRowMatrix_decl.hpp
@@ -40,8 +40,6 @@
 #ifndef TPETRA_DETAILS_LOCALDEEPCOPYROWMATRIX_DECL_HPP
 #define TPETRA_DETAILS_LOCALDEEPCOPYROWMATRIX_DECL_HPP
 
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-
 /// \file Tpetra_Details_localDeepCopyRowMatrix_decl.hpp
 /// \brief Declaration of function for making a deep copy of a
 ///   Tpetra::RowMatrix's local matrix.
@@ -49,6 +47,9 @@
 #include "Tpetra_RowMatrix_fwd.hpp"
 #include "KokkosSparse_CrsMatrix.hpp"
 #include "Kokkos_ArithTraits.hpp"
+
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+// This file can be deleted when deprecated code is removed
 
 namespace Tpetra {
 namespace Details {

--- a/packages/tpetra/core/src/Tpetra_Details_localDeepCopyRowMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_localDeepCopyRowMatrix_def.hpp
@@ -40,7 +40,6 @@
 #ifndef TPETRA_DETAILS_LOCALDEEPCOPYROWMATRIX_DEF_HPP
 #define TPETRA_DETAILS_LOCALDEEPCOPYROWMATRIX_DEF_HPP
 
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
 /// \file Tpetra_Details_localDeepCopyRowMatrix_def.hpp
 /// \brief Definition of function for making a deep copy of a
 ///   Tpetra::RowMatrix's local matrix.
@@ -53,6 +52,9 @@
 #include "Kokkos_Core.hpp"
 #include <algorithm>
 #include <stdexcept>
+
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+// This file can be deleted when deprecated code is removed
 
 namespace Tpetra {
 namespace Details {

--- a/packages/tpetra/core/src/Tpetra_Details_localRowOffsets_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_localRowOffsets_decl.hpp
@@ -44,10 +44,14 @@
 /// \brief Declaration of function for getting local row offsets from
 ///   a Tpetra::RowGraph.
 
+#include "TpetraCore_config.h"
 #include "Tpetra_CrsGraph_fwd.hpp"
 #include "Tpetra_RowGraph_fwd.hpp"
 #include "KokkosSparse_CrsMatrix.hpp"
 #include <utility> // pair
+
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE 
+// This file can be deleted when deprecated code is removed
 
 namespace Tpetra {
 namespace Details {
@@ -95,4 +99,5 @@ localRowOffsets (const RowGraph<LO, GO, NT>& G);
 } // namespace Details
 } // namespace Tpetra
 
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
 #endif // TPETRA_DETAILS_LOCALROWOFFSETS_DECL_HPP

--- a/packages/tpetra/core/src/Tpetra_Details_localRowOffsets_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_localRowOffsets_def.hpp
@@ -187,10 +187,6 @@ template LocalRowOffsetsResult<NT> \
 localRowOffsets (const RowGraph<LO, GO, NT>& A); \
 }
 
-#else  // !TPETRA_ENABLE_DEPRECATED_CODE
-
-#define TPETRA_DETAILS_LOCALROWOFFSETS_INSTANT(LO, GO, NT)
-
 #endif // TPETRA_ENABLE_DEPRECATED_CODE
 
 #endif // TPETRA_DETAILS_LOCALROWOFFSETS_DEF_HPP

--- a/packages/tpetra/core/src/Tpetra_Details_localRowOffsets_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_localRowOffsets_def.hpp
@@ -44,11 +44,15 @@
 /// \brief Definition of function for getting local row offsets from a
 ///   Tpetra::RowGraph.
 
+#include "TpetraCore_config.h"
 #include "Tpetra_CrsGraph.hpp"
 #include "Tpetra_RowGraph.hpp"
 #include "Tpetra_Details_computeOffsets.hpp"
 #include "Tpetra_Details_getEntryOnHost.hpp"
 #include "Kokkos_Core.hpp"
+
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+// This file can be deleted when deprecated code is removed
 
 namespace Tpetra {
 namespace Details {
@@ -163,6 +167,7 @@ localRowOffsets (const RowGraph<LO, GO, NT>& G)
 //
 // Must be expanded from within the Tpetra namespace!
 //
+
 #define TPETRA_DETAILS_LOCALROWOFFSETS_INSTANT(LO, GO, NT) \
 namespace Details { \
 namespace Impl { \
@@ -181,5 +186,11 @@ localRowOffsetsFromFillCompleteCrsGraph (const CrsGraph<LO, GO, NT>& G); \
 template LocalRowOffsetsResult<NT> \
 localRowOffsets (const RowGraph<LO, GO, NT>& A); \
 }
+
+#else  // !TPETRA_ENABLE_DEPRECATED_CODE
+
+#define TPETRA_DETAILS_LOCALROWOFFSETS_INSTANT(LO, GO, NT)
+
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
 
 #endif // TPETRA_DETAILS_LOCALROWOFFSETS_DEF_HPP

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests_LocalAccessors.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests_LocalAccessors.cpp
@@ -132,7 +132,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(CrsMatrix, localValues, LO, GO, Scalar, Node)
     auto map = mat->getRowMap();
     Kokkos::parallel_reduce(
       "checkHostValues", 
-      host_range_policy(0, mat->getNodeNumRows()),
+      host_range_policy(0, mat->getLocalNumRows()),
       [&] (const LO i, int &lerr) {
         GO gid = map->getGlobalElement(i);
         for (size_t j = offs[i]; j < offs[i+1]; j++) {
@@ -152,7 +152,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(CrsMatrix, localValues, LO, GO, Scalar, Node)
     auto lclMap = mat->getRowMap()->getLocalMap();
     Kokkos::parallel_reduce(
       "checkDeviceValues", 
-      dev_range_policy(0, mat->getNodeNumRows()),
+      dev_range_policy(0, mat->getLocalNumRows()),
       KOKKOS_LAMBDA (const LO i, int &lerr) {
         GO gid = lclMap.getGlobalElement(i);
         for (size_t j = offs[i]; j < offs[i+1]; j++) {
@@ -169,7 +169,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(CrsMatrix, localValues, LO, GO, Scalar, Node)
       auto view = mat->getLocalValuesDevice(Tpetra::Access::ReadWrite);
       Kokkos::parallel_for(
         "modifyValuesOnDevice", 
-        dev_range_policy(0, mat->getNodeNumEntries()),
+        dev_range_policy(0, mat->getLocalNumEntries()),
         KOKKOS_LAMBDA (const LO i) { view[i] *= 2; }
         );
     }
@@ -182,7 +182,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(CrsMatrix, localValues, LO, GO, Scalar, Node)
       auto map = mat->getRowMap();
       Kokkos::parallel_reduce(
         "checkDeviceModifiedValuesOnHost", 
-        host_range_policy(0, mat->getNodeNumRows()),
+        host_range_policy(0, mat->getLocalNumRows()),
         [&] (const LO i, int &lerr) {
           GO gid = map->getGlobalElement(i);
           for (size_t j = offs[i]; j < offs[i+1]; j++) {
@@ -200,7 +200,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(CrsMatrix, localValues, LO, GO, Scalar, Node)
       auto view = mat->getLocalValuesHost(Tpetra::Access::ReadWrite);
       Kokkos::parallel_for(
         "modifyValuesOnHost", 
-        host_range_policy(0, mat->getNodeNumEntries()),
+        host_range_policy(0, mat->getLocalNumEntries()),
         [&] (const LO i) { view[i] *= 2; }
         );
     }
@@ -212,7 +212,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(CrsMatrix, localValues, LO, GO, Scalar, Node)
       auto lclMap = mat->getRowMap()->getLocalMap();
       Kokkos::parallel_reduce(
         "checkHostModifiedValuesOnDevice", 
-        dev_range_policy(0, mat->getNodeNumRows()),
+        dev_range_policy(0, mat->getLocalNumRows()),
         KOKKOS_LAMBDA (const LO i, int &lerr) {
           GO gid = lclMap.getGlobalElement(i);
           for (size_t j = offs[i]; j < offs[i+1]; j++) {
@@ -230,7 +230,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(CrsMatrix, localValues, LO, GO, Scalar, Node)
       auto view = mat->getLocalValuesDevice(Tpetra::Access::OverwriteAll);
       Kokkos::parallel_for(
         "overwriteValuesOnDevice", 
-        dev_range_policy(0, mat->getNodeNumEntries()),
+        dev_range_policy(0, mat->getLocalNumEntries()),
         KOKKOS_LAMBDA (const LO i) { view[i] = me; }
         );
     }
@@ -240,7 +240,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(CrsMatrix, localValues, LO, GO, Scalar, Node)
       auto view = mat->getLocalValuesHost(Tpetra::Access::ReadOnly);
       Kokkos::parallel_reduce(
         "checkDeviceOverwrittenValuesOnHost", 
-        host_range_policy(0, mat->getNodeNumEntries()),
+        host_range_policy(0, mat->getLocalNumEntries()),
         [&] (const LO i, int &lerr) {
           if (view[i] != impl_scalar_t(me)) lerr++;
         },
@@ -255,7 +255,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(CrsMatrix, localValues, LO, GO, Scalar, Node)
       auto view = mat->getLocalValuesHost(Tpetra::Access::OverwriteAll);
       Kokkos::parallel_for(
         "overwriteValuesOnHost", 
-        host_range_policy(0, mat->getNodeNumEntries()),
+        host_range_policy(0, mat->getLocalNumEntries()),
         [&] (const LO i) { view[i] = np; }
         );
     }
@@ -264,7 +264,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(CrsMatrix, localValues, LO, GO, Scalar, Node)
       auto view = mat->getLocalValuesDevice(Tpetra::Access::ReadOnly);
       Kokkos::parallel_reduce(
         "checkHostOverwrittenValuesOnDevice", 
-        dev_range_policy(0, mat->getNodeNumEntries()),
+        dev_range_policy(0, mat->getLocalNumEntries()),
         KOKKOS_LAMBDA (const LO i, int &lerr) {
           if (view[i] != impl_scalar_t(np)) lerr++;
         },
@@ -298,7 +298,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(CrsMatrix, copyOrView, LO, GO, Scalar, Node)
     int incorrectMatchingValues = 0;
     Kokkos::parallel_reduce(
       "incorrectMatchingValues",
-      host_range_policy(0, origMat->getNodeNumEntries()),
+      host_range_policy(0, origMat->getLocalNumEntries()),
       [&] (const LO i, int &lerr) { if (origVals[i] == copyVals[i]) lerr++; },
       incorrectMatchingValues);
     TEST_EQUALITY(incorrectMatchingValues, 0);
@@ -316,7 +316,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(CrsMatrix, copyOrView, LO, GO, Scalar, Node)
     int incorrectDifferingValues = 0;
     Kokkos::parallel_reduce(
       "incorrectMatchingValues",
-      host_range_policy(0, origMat->getNodeNumEntries()),
+      host_range_policy(0, origMat->getLocalNumEntries()),
       [&] (const LO i, int &lerr) { if (origVals[i] != viewVals[i]) lerr++; },
       incorrectDifferingValues);
     TEST_EQUALITY(incorrectDifferingValues, 0);


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

PR #10189 merged after #10188.  This PR removes deprecations in #10189 from the new test in #10188.  

It also deprecates some code in Details namespace that will not be needed once deprecated code is removed.  Details::localRowOffsets was called only by other deprecated code.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Compiled on ascicgpu machines, sems gcc7.2 modules, with and without Tpetra deprecated code enabled.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->