### PR TITLE
MiniEM: Speed up assembly of discrete ops

### DIFF
--- a/packages/panzer/mini-em/src/solvers/MiniEM_DiscreteCurl.hpp
+++ b/packages/panzer/mini-em/src/solvers/MiniEM_DiscreteCurl.hpp
@@ -57,8 +57,9 @@ void addDiscreteCurlToRequestHandler(
   typedef typename panzer::BlockedEpetraLinearObjFactory<panzer::Traits,LocalOrdinal> epetraBlockedLinObjFactory;
   typedef panzer::GlobalIndexer UGI;
   typedef PHX::Device DeviceSpace;
-  typedef Intrepid2::OrientationTools<DeviceSpace> ots;
-  typedef Intrepid2::Experimental::LagrangianInterpolation<DeviceSpace> li;
+  typedef Kokkos::HostSpace HostSpace;
+  typedef Intrepid2::OrientationTools<HostSpace> ots;
+  typedef Intrepid2::Experimental::LagrangianInterpolation<HostSpace> li;
 
   // use "B_face" and "E_edge" as the DOFs
   std::string face_basis_name = "B_face";
@@ -132,28 +133,29 @@ void addDiscreteCurlToRequestHandler(
 
     // allocate some view
     Kokkos::DynRankView<double,DeviceSpace> dofCoords("dofCoords", 1, hdivCardinality, dim);
-    Kokkos::DynRankView<double,DeviceSpace> basisCoeffsLI("basisCoeffsLI", 1, hcurlCardinality, hdivCardinality);
-    typename Kokkos::DynRankView<Intrepid2::Orientation,DeviceSpace>::HostMirror elemOrts("elemOrts", 1);
-    typename Kokkos::DynRankView<GlobalOrdinal, DeviceSpace>::HostMirror elemNodes("elemNodes", 1, numElemVertices);
-    typename Kokkos::DynRankView<int, DeviceSpace>::HostMirror fOrt("fOrt", hdivCardinality);
-    typename Kokkos::DynRankView<double, DeviceSpace>::HostMirror ortJacobian("ortJacobian", 2, 2);
+    Kokkos::DynRankView<double,HostSpace> basisCoeffsLI("basisCoeffsLI", 1, hcurlCardinality, hdivCardinality);
+    typename Kokkos::DynRankView<Intrepid2::Orientation,HostSpace>::HostMirror elemOrts("elemOrts", 1);
+    typename Kokkos::DynRankView<GlobalOrdinal, HostSpace>::HostMirror elemNodes("elemNodes", 1, numElemVertices);
+    typename Kokkos::DynRankView<int, HostSpace>::HostMirror fOrt("fOrt", hdivCardinality);
+    typename Kokkos::DynRankView<double, HostSpace>::HostMirror ortJacobian("ortJacobian", 2, 2);
 
     // the ranks of these depend on dimension
-    Kokkos::DynRankView<double,DeviceSpace> dofCoeffs;
+    Kokkos::DynRankView<double,HostSpace>   dofCoeffs;
     Kokkos::DynRankView<double,DeviceSpace> refDofCoeffs;
-    Kokkos::DynRankView<double,DeviceSpace> curlAtDofCoordsNonOriented;
-    Kokkos::DynRankView<double,DeviceSpace> curlAtDofCoords;
+    Kokkos::DynRankView<double,DeviceSpace> curlAtDofCoordsNonOriented_d;
+    Kokkos::DynRankView<double,HostSpace>   curlAtDofCoords;
     if(dim==3){
-      dofCoeffs                  = Kokkos::DynRankView<double,DeviceSpace>("dofCoeffs", 1, hdivCardinality,dim);
-      refDofCoeffs               = Kokkos::DynRankView<double,DeviceSpace>("refDofCoeffs", hdivCardinality,dim);
-      curlAtDofCoordsNonOriented = Kokkos::DynRankView<double,DeviceSpace>("curlAtDofCoordsNonOriented", 1, hcurlCardinality, hdivCardinality, dim);
-      curlAtDofCoords            = Kokkos::DynRankView<double,DeviceSpace>("curlAtDofCoords", 1, hcurlCardinality, hdivCardinality, dim);
+      dofCoeffs                    = Kokkos::DynRankView<double,HostSpace>("dofCoeffs", 1, hdivCardinality,dim);
+      refDofCoeffs                 = Kokkos::DynRankView<double,DeviceSpace>("refDofCoeffs", hdivCardinality,dim);
+      curlAtDofCoordsNonOriented_d = Kokkos::DynRankView<double,DeviceSpace>("curlAtDofCoordsNonOriented", 1, hcurlCardinality, hdivCardinality, dim);
+      curlAtDofCoords              = Kokkos::DynRankView<double,HostSpace>("curlAtDofCoords", 1, hcurlCardinality, hdivCardinality, dim);
     } else {
-      dofCoeffs                  = Kokkos::DynRankView<double,DeviceSpace>("dofCoeffs", 1, hdivCardinality);
-      refDofCoeffs               = Kokkos::DynRankView<double,DeviceSpace>("refDofCoeffs", hdivCardinality);
-      curlAtDofCoordsNonOriented = Kokkos::DynRankView<double,DeviceSpace>("curlAtDofCoordsNonOriented", 1, hcurlCardinality, hdivCardinality);
-      curlAtDofCoords            = Kokkos::DynRankView<double,DeviceSpace>("curlAtDofCoords", 1, hcurlCardinality, hdivCardinality);
+      dofCoeffs                    = Kokkos::DynRankView<double,HostSpace>("dofCoeffs", 1, hdivCardinality);
+      refDofCoeffs                 = Kokkos::DynRankView<double,DeviceSpace>("refDofCoeffs", hdivCardinality);
+      curlAtDofCoordsNonOriented_d = Kokkos::DynRankView<double,DeviceSpace>("curlAtDofCoordsNonOriented", 1, hcurlCardinality, hdivCardinality);
+      curlAtDofCoords              = Kokkos::DynRankView<double,HostSpace>("curlAtDofCoords", 1, hcurlCardinality, hdivCardinality);
     }
+    auto curlAtDofCoordsNonOriented = Kokkos::create_mirror_view(curlAtDofCoordsNonOriented_d);
     face_basis->getDofCoeffs(refDofCoeffs);
     auto dofCoeffs_h = Kokkos::create_mirror_view(dofCoeffs);
     auto refDofCoeffs_h = Kokkos::create_mirror_view(refDofCoeffs);
@@ -173,10 +175,22 @@ void addDiscreteCurlToRequestHandler(
     }
 
     // compute curls at dof coords
-    edge_basis->getValues(Kokkos::subview(curlAtDofCoordsNonOriented, 0, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(dofCoords, 0, Kokkos::ALL(), Kokkos::ALL()), Intrepid2::OPERATOR_CURL);
+    edge_basis->getValues(Kokkos::subview(curlAtDofCoordsNonOriented_d, 0, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()),
+                          Kokkos::subview(dofCoords, 0, Kokkos::ALL(), Kokkos::ALL()), Intrepid2::OPERATOR_CURL);
+    Kokkos::deep_copy(curlAtDofCoordsNonOriented, curlAtDofCoordsNonOriented_d);
 
     // create the global curl matrix
     RCP<matrix> curl_matrix = rcp(new matrix(rowmap,colmap,basisCoeffsLI.extent(1)));
+
+    // get IDs for edges and faces
+    auto fLIDs_k = face_ugi->getLIDs();
+    auto fLIDs = Kokkos::create_mirror_view(fLIDs_k);
+    Kokkos::deep_copy(DeviceSpace::execution_space(), fLIDs, fLIDs_k);
+    auto eLIDs_k = edge_ugi->getLIDs();
+    auto eLIDs = Kokkos::create_mirror_view(eLIDs_k);
+    Kokkos::deep_copy(DeviceSpace::execution_space(), eLIDs, eLIDs_k);
+
+    std::vector<int> edges_on_face(hcurlCardinality,-1);
 
     // loop over element blocks
     std::vector<std::string> elementBlockIds;
@@ -187,10 +201,10 @@ void addDiscreteCurlToRequestHandler(
       std::vector<int> elementIds = edge_ugi->getElementBlock(elementBlockIds[blockIter]);
       for(std::size_t elemIter = 0; elemIter < elementIds.size(); ++elemIter){
 
+        int element = elementIds[elemIter];
+
         // get element orientations
-
-        auto node_ids = node_conn->getConnectivity(elementIds[elemIter]);
-
+        auto node_ids = node_conn->getConnectivity(element);
         for(int i = 0; i < numElemVertices; i++)
           elemNodes(0,i) = node_ids[i];
 
@@ -207,67 +221,57 @@ void addDiscreteCurlToRequestHandler(
           }
         }
 
-	Kokkos::deep_copy(dofCoeffs, dofCoeffs_h);
         //orient basis
-	Kokkos::DynRankView<Intrepid2::Orientation,DeviceSpace> elemOrts_d("elemOrts_d", 1);
-	Kokkos::deep_copy(elemOrts_d, elemOrts);
         ots::modifyBasisByOrientation(curlAtDofCoords,
                                       curlAtDofCoordsNonOriented,
-                                      elemOrts_d,
+                                      elemOrts,
                                       edge_basis.get());
 
         //get basis coefficients (dofs)
         for(int curlIter=0; curlIter<hcurlCardinality; curlIter++)
-          li::getBasisCoeffs(Kokkos::subview(basisCoeffsLI,Kokkos::ALL(),curlIter,Kokkos::ALL()), Kokkos::subview(curlAtDofCoords,Kokkos::ALL(),curlIter,Kokkos::ALL(),Kokkos::ALL()), dofCoeffs);
-	auto basisCoeffsLI_h = Kokkos::create_mirror_view(basisCoeffsLI);
-	Kokkos::deep_copy(basisCoeffsLI_h, basisCoeffsLI);
-
-        // get IDs for edges and faces
-        std::vector<GlobalOrdinal> fGIDs;
-        face_ugi->getElementGIDs(elementIds[elemIter],fGIDs);
-        std::vector<GlobalOrdinal> eGIDs;
-        edge_ugi->getElementGIDs(elementIds[elemIter],eGIDs);
-        auto eLIDs_k = edge_ugi->getElementLIDs(elementIds[elemIter]);
-        auto fLIDs_k = face_ugi->getElementLIDs(elementIds[elemIter]);
-	auto eLIDs = Kokkos::create_mirror_view(eLIDs_k);
-	auto fLIDs = Kokkos::create_mirror_view(fLIDs_k);
-	Kokkos::deep_copy(eLIDs, eLIDs_k);
-	Kokkos::deep_copy(fLIDs, fLIDs_k);
-
-        // need to know which faces are owned by this proc
-        std::vector<bool> isOwned(fGIDs.size());
-        for (size_t face=0; face < fGIDs.size(); ++face)
-          isOwned[face] = (rowmap->isNodeGlobalElement(fGIDs[face]));
+          li::getBasisCoeffs(Kokkos::subview(basisCoeffsLI,Kokkos::ALL(),curlIter,Kokkos::ALL()),
+                             Kokkos::subview(curlAtDofCoords,Kokkos::ALL(),curlIter,Kokkos::ALL(),Kokkos::ALL()),
+                             dofCoeffs_h);
 
         // loop over faces
-        for(std::size_t fIter = 0; fIter < fLIDs.size(); ++fIter){
+        for(std::size_t fIter = 0; fIter < fLIDs.extent(1); ++fIter){
+
+          LocalOrdinal fLID = fLIDs(element,fIter);
 
           // get a list of edges on the face
-          std::vector<int> edges_on_face(hcurlCardinality,-1);
           if(dim==3)
             edge_fieldPattern->getSubcellClosureIndices(2,fIter,edges_on_face);
           else
             for(int i = 0; i < hcurlCardinality; i++)
               edges_on_face[i] = i;
 
+          const bool isOwned = rowmap->isNodeLocalElement(fLID);
+
           // if owned
-          if(isOwned[fIter] && curl_matrix->getNumEntriesInLocalRow(fLIDs[fIter]) < 1){
+          if(isOwned && curl_matrix->getNumEntriesInLocalRow(fLID) < 1){
 
             // get values from reference incidence matrix
             std::vector<Scalar> values(hcurlCardinality,0.0);
             for(int curlIter=0; curlIter<hcurlCardinality; curlIter++){
               // only add entries for edges on the face
-              auto it = std::find(edges_on_face.begin(), edges_on_face.end(), curlIter);
-              if(it!=edges_on_face.end()){
+              bool edge_is_on_face = false;
+              for (int i = 0; i < hcurlCardinality; i++) {
+                if (edges_on_face[i] == curlIter) {
+                  edge_is_on_face = true;
+                  break;
+                }
+              }
+              if(edge_is_on_face) {
                 // normalize the values
-                if(std::abs(basisCoeffsLI_h(0,curlIter,fIter)) > 1.0e-10)
-                  values[curlIter] = basisCoeffsLI_h(0,curlIter,fIter)*area_scaling;
+                if(std::abs(basisCoeffsLI(0,curlIter,fIter)) > 1.0e-10)
+                  values[curlIter] = basisCoeffsLI(0,curlIter,fIter)*area_scaling;
               }
             }
 
             // insert values in matrix
-            curl_matrix->insertLocalValues(fLIDs[fIter], values.size(), &values[0], &eLIDs[0]);
-            TEUCHOS_ASSERT_EQUALITY(curl_matrix->getNumEntriesInLocalRow(fLIDs[fIter]),values.size());
+            auto indices = Kokkos::subview(eLIDs, element, Kokkos::ALL());
+            curl_matrix->insertLocalValues(fLID, values.size(), &values[0], &indices[0]);
+            TEUCHOS_ASSERT_EQUALITY(curl_matrix->getNumEntriesInLocalRow(fLID),values.size());
 
           }//end if owned
         }//end face loop

--- a/packages/panzer/mini-em/src/solvers/MiniEM_DiscreteGradient.hpp
+++ b/packages/panzer/mini-em/src/solvers/MiniEM_DiscreteGradient.hpp
@@ -55,6 +55,8 @@ void addDiscreteGradientToRequestHandler(
   typedef typename panzer::BlockedTpetraLinearObjFactory<panzer::Traits,Scalar,LocalOrdinalTpetra,GlobalOrdinalTpetra> tpetraBlockedLinObjFactory;
   typedef typename panzer::BlockedEpetraLinearObjFactory<panzer::Traits,LocalOrdinalEpetra> epetraBlockedLinObjFactory;
 
+  typedef PHX::Device DeviceSpace;
+
   // use "AUXILIARY_EDGE" and "AUXILIARY_NODE" as the DOFs
   std::string edge_basis_name  = "AUXILIARY_EDGE";
   std::string nodal_basis_name = "AUXILIARY_NODE";
@@ -105,36 +107,32 @@ void addDiscreteGradientToRequestHandler(
     std::vector<std::string> elementBlockIds;
     blockedDOFMngr->getElementBlockIds(elementBlockIds);
     std::vector<bool> insertedEdges(rowmap->getNodeNumElements(),false);
+    auto eLIDs_k = eUgi->getLIDs();
+    auto nLIDs_k = nUgi->getLIDs();
+    auto eLIDs = Kokkos::create_mirror_view(eLIDs_k);
+    auto nLIDs = Kokkos::create_mirror_view(nLIDs_k);
+    Kokkos::deep_copy(DeviceSpace::execution_space(), eLIDs, eLIDs_k);
+    Kokkos::deep_copy(DeviceSpace::execution_space(), nLIDs, nLIDs_k);
+
     for(std::size_t blockIter = 0; blockIter < elementBlockIds.size(); ++blockIter) {
 
       // loop over elements
       std::vector<int> elementIds = blockedDOFMngr->getElementBlock(elementBlockIds[blockIter]);
       for(std::size_t elemIter = 0; elemIter < elementIds.size(); ++elemIter){
+
+        int element = elementIds[elemIter];
  
-        // get IDs for edges and nodes
-        std::vector<GlobalOrdinal> eGIDs;
-        eUgi->getElementGIDs(elementIds[elemIter],eGIDs);
-        std::vector<GlobalOrdinal> nGIDs;
-        nUgi->getElementGIDs(elementIds[elemIter],nGIDs);
-        auto eLIDs_k = eUgi->getElementLIDs(elementIds[elemIter]);
-        auto nLIDs_k = nUgi->getElementLIDs(elementIds[elemIter]);
-	auto eLIDs = Kokkos::create_mirror_view(eLIDs_k);
-	auto nLIDs = Kokkos::create_mirror_view(nLIDs_k);
-	Kokkos::deep_copy(eLIDs, eLIDs_k);
-	Kokkos::deep_copy(nLIDs, nLIDs_k);
-
-        std::vector<bool> isOwned;
-        eUgi->ownedIndices(eGIDs,isOwned);
-
         // get element orientations
         std::vector<int> eFieldOffsets = blockedDOFMngr->getGIDFieldOffsets(elementBlockIds[blockIter],eFieldNum);
         std::vector<int> ort(eFieldOffsets.size(),0);
-        orientations[elementIds[elemIter]].getEdgeOrientation(&ort[0], eFieldOffsets.size());
+        orientations[element].getEdgeOrientation(&ort[0], eFieldOffsets.size());
 
         // loop over edges
         for(std::size_t eIter = 0; eIter < eFieldOffsets.size(); ++eIter){
 
-          if(isOwned[eIter] && !insertedEdges[eLIDs[eIter]]){
+          const bool isOwned = rowmap->isNodeLocalElement(eLIDs(element,eIter));
+
+          if(isOwned && !insertedEdges[eLIDs(element, eIter)]){
 
             int headIndex = cell_topology.getNodeMap(1, eIter, 0);
             int tailIndex = cell_topology.getNodeMap(1, eIter, 1);
@@ -145,9 +143,9 @@ void addDiscreteGradientToRequestHandler(
               {values[0] *= -1.0; values[1] *= -1.0;}
  
             // get LIDs associated with nodes
-            int indices[2] = {nLIDs[tailIndex],nLIDs[headIndex]};
-            grad_matrix->insertLocalValues(eLIDs[eIter], 2, values, indices);
-            insertedEdges[eLIDs[eIter]] = true;
+            int indices[2] = {nLIDs(element,tailIndex),nLIDs(element,headIndex)};
+            grad_matrix->insertLocalValues(eLIDs(element,eIter), 2, values, indices);
+            insertedEdges[eLIDs(element,eIter)] = true;
           }//end if
         }//end edge loop
       }//end element loop


### PR DESCRIPTION
@trilinos/panzer 

- DiscreteCurl: Don't copy back and forth between host and device and launch tiny kernels, just stay on host.
- DiscreteGradient: Do not use `ownedIndices`.