### PR TITLE
Deprecation fixes

### DIFF
--- a/packages/amesos2/src/Amesos2_EpetraMultiVecAdapter_def.hpp
+++ b/packages/amesos2/src/Amesos2_EpetraMultiVecAdapter_def.hpp
@@ -279,7 +279,7 @@ void MultiVecAdapter<Epetra_MultiVector>::get1dCopy_kokkos_view_host(
     // First make a host view
     host_view = Kokkos::View<scalar_t**, Kokkos::LayoutLeft, Kokkos::HostSpace>(
       Kokkos::ViewAllocateWithoutInitializing("get1dCopy_kokkos_view"),
-      distribution_map->getNodeNumElements(), num_vecs);
+      distribution_map->getLocalNumElements(), num_vecs);
 
     // Optimization for ROOTED and single MPI process
     if ( num_vecs == 1 && this->mv_->Comm().MyPID() == 0 && this->mv_->Comm().NumProc() == 1 ) {

--- a/packages/amesos2/src/Amesos2_MatrixAdapter_def.hpp
+++ b/packages/amesos2/src/Amesos2_MatrixAdapter_def.hpp
@@ -509,7 +509,7 @@ namespace Amesos2 {
     // compatibility, but things are working fine now.
 
     RCP<const Tpetra::Map<local_ordinal_t,global_ordinal_t,node_t> > rmap = get_mat->getRowMap();
-    ArrayView<const global_ordinal_t> node_elements = rmap->getNodeElementList();
+    ArrayView<const global_ordinal_t> node_elements = rmap->getLocalElementList();
     //if( node_elements.size() == 0 ) return; // no more contribution
     typename ArrayView<const global_ordinal_t>::iterator row_it, row_end;
     row_end = node_elements.end();

--- a/packages/amesos2/src/Amesos2_Util.hpp
+++ b/packages/amesos2/src/Amesos2_Util.hpp
@@ -1072,7 +1072,7 @@ namespace Amesos2 {
       using Teuchos::as;
 
       Teuchos::Array<GO> elements_tmp;
-      elements_tmp = map.getNodeElementList();
+      elements_tmp = map.getLocalElementList();
       int num_my_elements = elements_tmp.size();
       Teuchos::Array<int> my_global_elements(num_my_elements);
       for (int i = 0; i < num_my_elements; ++i){

--- a/packages/ifpack2/src/Ifpack2_Hypre_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Hypre_def.hpp
@@ -416,16 +416,16 @@ int Hypre<MatrixType>::SetDiscreteGradient(Teuchos::RCP<const crs_matrix_type> G
 
   std::vector<GO> new_indices(G->getLocalMaxNumRowEntries());
   for(LO i = 0; i < (LO)G->getLocalNumRows(); i++){
-    Teuchos::ArrayView<const SC> values;
-    Teuchos::ArrayView<const LO> indices;
+    typename crs_matrix_type::values_host_view_type     values;
+    typename crs_matrix_type::local_inds_host_view_type indices;
     G->getLocalRowView(i, indices, values);
-    for(LO j = 0; j < (LO) indices.size(); j++){
-      new_indices[j] = GloballyContiguousNodeColMap_->getGlobalElement(indices[j]);
+    for(LO j = 0; j < (LO) indices.extent(0); j++){
+      new_indices[j] = GloballyContiguousNodeColMap_->getGlobalElement(indices(j));
     }
     GO GlobalRow[1];
-    GO numEntries = (GO) indices.size();
+    GO numEntries = (GO) indices.extent(0);
     GlobalRow[0] = GloballyContiguousRowMap_->getGlobalElement(i);
-    IFPACK2_CHK_ERR(HYPRE_IJMatrixSetValues(HypreG_, 1, &numEntries, GlobalRow, new_indices.data(), values.getRawPtr()));
+    IFPACK2_CHK_ERR(HYPRE_IJMatrixSetValues(HypreG_, 1, &numEntries, GlobalRow, new_indices.data(), values.data()));
   }
   IFPACK2_CHK_ERR(HYPRE_IJMatrixAssemble(HypreG_));
   IFPACK2_CHK_ERR(HYPRE_IJMatrixGetObject(HypreG_, (void**)&ParMatrixG_));
@@ -892,16 +892,16 @@ int Hypre<MatrixType>::CopyTpetraToHypre(){
 
   std::vector<GO> new_indices(Matrix->getLocalMaxNumRowEntries());
   for(LO i = 0; i < (LO) Matrix->getLocalNumRows(); i++){
-    Teuchos::ArrayView<const SC> values;
-    Teuchos::ArrayView<const LO> indices;
+    typename crs_matrix_type::values_host_view_type     values;
+    typename crs_matrix_type::local_inds_host_view_type indices;
     Matrix->getLocalRowView(i, indices, values);
-    for(LO j = 0; j < (LO)indices.size(); j++){
-      new_indices[j] = GloballyContiguousColMap_->getGlobalElement(indices[j]);
+    for(LO j = 0; j < (LO)indices.extent(0); j++){
+      new_indices[j] = GloballyContiguousColMap_->getGlobalElement(indices(j));
     }
     GO GlobalRow[1];
-    GO numEntries = (GO) indices.size();
+    GO numEntries = (GO) indices.extent(0);
     GlobalRow[0] = GloballyContiguousRowMap_->getGlobalElement(i);    
-    IFPACK2_CHK_ERR(HYPRE_IJMatrixSetValues(HypreA_, 1, &numEntries, GlobalRow, new_indices.data(), values.getRawPtr()));
+    IFPACK2_CHK_ERR(HYPRE_IJMatrixSetValues(HypreA_, 1, &numEntries, GlobalRow, new_indices.data(), values.data()));
   }
   IFPACK2_CHK_ERR(HYPRE_IJMatrixAssemble(HypreA_));
   IFPACK2_CHK_ERR(HYPRE_IJMatrixGetObject(HypreA_, (void**)&ParMatrix_));

--- a/packages/muelu/example/advanced/memory/Tpetra1DLaplace.cpp
+++ b/packages/muelu/example/advanced/memory/Tpetra1DLaplace.cpp
@@ -94,8 +94,8 @@ int main(int argc, char *argv[]) {
     RCP<const Map> map =
       rcp (new Map (static_cast<Tpetra::global_size_t> (numGlobalElements),
                     indexBase, comm));
-    const size_t numMyElements = map->getNodeNumElements();
-    Teuchos::ArrayView<const GO> myGlobalElements = map->getNodeElementList();
+    const size_t numMyElements = map->getLocalNumElements();
+    Teuchos::ArrayView<const GO> myGlobalElements = map->getLocalElementList();
 
     MemoryUsageStart("Tpetra");
     PrintMemoryUsage("Initial memory usage", "tpetra-init.heap");

--- a/packages/muelu/research/caglusa/main.cpp
+++ b/packages/muelu/research/caglusa/main.cpp
@@ -222,7 +222,7 @@ namespace Tpetra {
 
       // construct identity on clusterCoeffMap_
       RCP<matrix_type> identity = rcp(new matrix_type(clusterCoeffMap_, 1));
-      Teuchos::ArrayView<const GlobalOrdinal> gblRows = clusterCoeffMap_->getNodeElementList ();
+      Teuchos::ArrayView<const GlobalOrdinal> gblRows = clusterCoeffMap_->getLocalElementList ();
       for (auto it = gblRows.begin (); it != gblRows.end (); ++it) {
         Teuchos::Array<GlobalOrdinal> col (1, *it);
         Teuchos::Array<Scalar> val (1, one);
@@ -284,12 +284,12 @@ namespace Tpetra {
       return nearField_->getGlobalNumCols();
     }
 
-    size_t getNodeNumRows() const {
-      return nearField_->getNodeNumRows();
+    size_t getLocalNumRows() const {
+      return nearField_->getLocalNumRows();
     }
 
-    size_t getNodeNumCols() const {
-      return nearField_->getNodeNumCols();
+    size_t getLocalNumCols() const {
+      return nearField_->getLocalNumCols();
     }
 
     GlobalOrdinal getIndexBase() const {
@@ -300,8 +300,8 @@ namespace Tpetra {
       return nearField_->getGlobalNumEntries();
     }
 
-    size_t getNodeNumEntries() const {
-      return nearField_->getNodeNumEntries();
+    size_t getLocalNumEntries() const {
+      return nearField_->getLocalNumEntries();
     }
 
     size_t getNumEntriesInGlobalRow (GlobalOrdinal globalRow) const {
@@ -316,7 +316,7 @@ namespace Tpetra {
       throw MueLu::Exceptions::RuntimeError("Not implemented.");
     }
 
-    size_t getNodeMaxNumRowEntries () const {
+    size_t getLocalMaxNumRowEntries () const {
       throw MueLu::Exceptions::RuntimeError("Not implemented.");
     }
 

--- a/packages/muelu/research/q2q1/Q2Q1.cpp
+++ b/packages/muelu/research/q2q1/Q2Q1.cpp
@@ -344,7 +344,7 @@ int main(int argc, char *argv[]) {
     // simply reading the data again. Normally, this would be supplied by Eric
     // Cyr and would be Teko operators.
 
-    int numElem = A12->getRangeMap()->getNodeNumElements() + A21->getRangeMap()->getNodeNumElements();
+    int numElem = A12->getRangeMap()->getLocalNumElements() + A21->getRangeMap()->getLocalNumElements();
     RCP<const tMap> fullMap = Utilities::Map2TpetraMap(*(MapFactory::createUniformContigMap(Xpetra::UseTpetra, numElem, comm)));
 
     RCP<tOperator> A;

--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_kokkos_def.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_kokkos_def.hpp
@@ -981,8 +981,8 @@ namespace MueLu {
     auto rowLocalMap = rowMap.getLocalMap();
     auto colLocalMap = colMap.getLocalMap();
 
-    const size_t numRows = rowLocalMap.getNodeNumElements();
-    const size_t numCols = colLocalMap.getNodeNumElements();
+    const size_t numRows = rowLocalMap.getLocalNumElements();
+    const size_t numCols = colLocalMap.getLocalNumElements();
 
     if (numCols < numRows)
       return false;

--- a/packages/muelu/src/Utils/MueLu_Utilities_decl.hpp
+++ b/packages/muelu/src/Utils/MueLu_Utilities_decl.hpp
@@ -691,7 +691,7 @@ namespace MueLu {
         const RCP<const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> > domainMap = tpOp.getDomainMap();
         const RCP<const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> > rangeMap  = tpOp.getRangeMap();
 
-        size_t maxRowSize = tpOp.getNodeMaxNumRowEntries();
+        size_t maxRowSize = tpOp.getLocalMaxNumRowEntries();
         if (maxRowSize == Teuchos::as<size_t>(-1)) // hasn't been determined yet
           maxRowSize = 20;
 
@@ -702,7 +702,7 @@ namespace MueLu {
         if (Op.isLocallyIndexed() == true) {
 	  typename Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::local_inds_host_view_type cols;
 	  typename Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::values_host_view_type vals;
-          for (size_t i = 0; i < rowMap->getNodeNumElements(); ++i) {
+          for (size_t i = 0; i < rowMap->getLocalNumElements(); ++i) {
             tpOp.getLocalRowView(i, cols, vals);
             size_t nnz = tpOp.getNumEntriesInLocalRow(i);
             if (nnz > maxRowSize) {
@@ -723,7 +723,7 @@ namespace MueLu {
 	  typename Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::local_inds_host_view_type cols;
 	  typename Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::values_host_view_type vals;
 
-          for (size_t i = 0; i < rowMap->getNodeNumElements(); ++i) {
+          for (size_t i = 0; i < rowMap->getLocalNumElements(); ++i) {
             GlobalOrdinal gid = rowMap->getGlobalElement(i);
             tpOp.getGlobalRowView(gid, cols, vals);
             size_t nnz = tpOp.getNumEntriesInGlobalRow(gid);

--- a/packages/muelu/src/Utils/MueLu_Utilities_kokkos_decl.hpp
+++ b/packages/muelu/src/Utils/MueLu_Utilities_kokkos_decl.hpp
@@ -511,7 +511,7 @@ namespace MueLu {
         const RCP<const Tpetra::Map<LO,GO,NO> > domainMap = tpOp.getDomainMap();
         const RCP<const Tpetra::Map<LO,GO,NO> > rangeMap  = tpOp.getRangeMap();
 
-        size_t maxRowSize = tpOp.getNodeMaxNumRowEntries();
+        size_t maxRowSize = tpOp.getLocalMaxNumRowEntries();
         if (maxRowSize == Teuchos::as<size_t>(-1)) // hasn't been determined yet
           maxRowSize = 20;
 
@@ -523,7 +523,7 @@ namespace MueLu {
 	  typename Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::local_inds_host_view_type cols;
 	  typename Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::values_host_view_type vals;
 
-          for (size_t i = 0; i < rowMap->getNodeNumElements(); ++i) {
+          for (size_t i = 0; i < rowMap->getLocalNumElements(); ++i) {
             tpOp.getLocalRowView(i, cols, vals);
             size_t nnz = tpOp.getNumEntriesInLocalRow(i);
             if (nnz > maxRowSize) {
@@ -544,7 +544,7 @@ namespace MueLu {
           typename Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::global_inds_host_view_type cols;
           typename Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::values_host_view_type vals;
 
-          for (size_t i = 0; i < rowMap->getNodeNumElements(); ++i) {
+          for (size_t i = 0; i < rowMap->getLocalNumElements(); ++i) {
             GO gid = rowMap->getGlobalElement(i);
             tpOp.getGlobalRowView(gid, cols, vals);
             size_t nnz = tpOp.getNumEntriesInGlobalRow(gid);

--- a/packages/muelu/test/meshtying/MeshTyingBlocked_SimpleSmoother.cpp
+++ b/packages/muelu/test/meshtying/MeshTyingBlocked_SimpleSmoother.cpp
@@ -111,9 +111,9 @@ int main(int argc, char *argv[])
   // Construct the blocked map in Thyra mode
   RCP<const tpetra_map_type> primalNodeMap = Tpetra::createUniformContigMapWithNode<LocalOrdinal, GlobalOrdinal, Node>(globalPrimalNumNodes, comm);
   const GO indexBase = primalNodeMap->getIndexBase();
-  ArrayView<const GO> myPrimalNodes = primalNodeMap->getNodeElementList();
+  ArrayView<const GO> myPrimalNodes = primalNodeMap->getLocalElementList();
 
-  const size_t numMyPrimalNodes = primalNodeMap->getNodeNumElements();
+  const size_t numMyPrimalNodes = primalNodeMap->getLocalNumElements();
   const size_t numMyPrimalDofs = numMyPrimalNodes * nPrimalDofsPerNode;
 
   Array<GO> myPrimalDofs(numMyPrimalDofs);

--- a/packages/muelu/test/scaling/CMakeLists.txt
+++ b/packages/muelu/test/scaling/CMakeLists.txt
@@ -197,7 +197,7 @@ IF (${PACKAGE_NAME}_HAVE_EPETRA_SOLVER_STACK AND (NOT Xpetra_INT_LONG_LONG))
       NUM_MPI_PROCS 4
       COMM mpi # HAVE_MPI required
       )
-    
+
 
     TRIBITS_ADD_TEST(
       Driver
@@ -431,7 +431,7 @@ IF (${PACKAGE_NAME}_HAVE_TPETRA_SOLVER_STACK)
   MUELU_ADD_SERIAL_AND_MPI_TEST(
       Driver
       NAME "CalcRotations"
-      ARGS "--linAlgebra=Tpetra --xml=comp_rotations.xml  --matrixType=Elasticity3D --nx=40 --ny=40 --nz=4 --its=100 --belosType='gmres' --tol=1.0e-8  --muelu-computed-nullspace"  
+      ARGS "--linAlgebra=Tpetra --xml=comp_rotations.xml  --matrixType=Elasticity3D --nx=40 --ny=40 --nz=4 --its=100 --belosType='gmres' --tol=1.0e-8  --muelu-computed-nullspace"
       NUM_MPI_PROCS 4
       COMM serial mpi
       )
@@ -591,15 +591,11 @@ IF (${PACKAGE_NAME}_ENABLE_Experimental AND ${PACKAGE_NAME}_ENABLE_Tpetra)
       COMM serial mpi
       )
 
-  ENDIF()
-ENDIF()
-
-
-# remove this from Experimental it requires Galeri + Tpetra
-IF (${PACKAGE_NAME}_ENABLE_Tpetra)
-  TRIBITS_ADD_EXECUTABLE(
-    MatvecKernelDriver
-    SOURCES MatvecKernelDriver.cpp
-    COMM serial mpi
+    TRIBITS_ADD_EXECUTABLE(
+      MatvecKernelDriver
+      SOURCES MatvecKernelDriver.cpp
+      COMM serial mpi
     )
+
+  ENDIF()
 ENDIF()

--- a/packages/muelu/test/scaling/MMKernelDriver.cpp
+++ b/packages/muelu/test/scaling/MMKernelDriver.cpp
@@ -649,9 +649,9 @@ void Multiply_KokkosKernels(const Xpetra::Matrix<Scalar,LocalOrdinal,GlobalOrdin
     typename lno_view_t::const_value_type,typename lno_nnz_view_t::const_value_type, typename scalar_view_t::const_value_type,
       typename device_t::execution_space, typename device_t::memory_space,typename device_t::memory_space > KernelHandle;
     KokkosSparse::SPGEMMAlgorithm alg_enum = KokkosSparse::StringToSPGEMMAlgorithm(algorithm_name);
-    typename KernelHandle::nnz_lno_t AnumRows = Au->getNodeNumRows();
-    typename KernelHandle::nnz_lno_t BnumRows = Bu->getNodeNumRows();
-    typename KernelHandle::nnz_lno_t BnumCols = Bu->getNodeNumCols();
+    typename KernelHandle::nnz_lno_t AnumRows = Au->getLocalNumRows();
+    typename KernelHandle::nnz_lno_t BnumRows = Bu->getLocalNumRows();
+    typename KernelHandle::nnz_lno_t BnumCols = Bu->getLocalNumCols();
 
     // **********************************
     // Multiply

--- a/packages/muelu/test/unit_tests_kokkos/Utilities_kokkos.cpp
+++ b/packages/muelu/test/unit_tests_kokkos/Utilities_kokkos.cpp
@@ -565,7 +565,7 @@ namespace MueLuTests
     {
       TEST_EQUALITY(xpetraMat.getGlobalNumRows(), tpetraMat.getGlobalNumRows());
       TEST_EQUALITY(xpetraMat.getGlobalNumCols(), tpetraMat.getGlobalNumCols());
-      TEST_EQUALITY(xpetraMat.getNodeNumRows(), tpetraMat.getNodeNumRows());
+      TEST_EQUALITY(xpetraMat.getNodeNumRows(), tpetraMat.getLocalNumRows());
       TEST_EQUALITY(xpetraMat.getGlobalNumEntries(), tpetraMat.getGlobalNumEntries());
     };
 

--- a/packages/teko/src/Teko_Utilities.cpp
+++ b/packages/teko/src/Teko_Utilities.cpp
@@ -238,7 +238,7 @@ RCP<Tpetra::CrsMatrix<ST,LO,GO,NT> > buildGraphLaplacian(int dim,ST * coords,con
    auto rowData = typename Tpetra::CrsMatrix<ST,LO,GO,NT>::nonconst_values_host_view_type(Kokkos::ViewAllocateWithoutInitializing("rowIndices"),stencil.getGlobalMaxNumRowEntries()+1);
 
    // loop over all the rows
-   for(LO j=0;j< (LO) gl->getNodeNumRows();j++) {
+   for(LO j=0;j< (LO) gl->getLocalNumRows();j++) {
       GO row = gl->getRowMap()->getGlobalElement(j);
       ST diagValue = 0.0;
       GO diagInd = -1;
@@ -376,7 +376,7 @@ RCP<Tpetra::CrsMatrix<ST,LO,GO,NT> > buildGraphLaplacian(ST * x,ST * y,ST * z,GO
    auto rowData = typename Tpetra::CrsMatrix<ST,LO,GO,NT>::nonconst_values_host_view_type(Kokkos::ViewAllocateWithoutInitializing("rowIndices"),stencil.getGlobalMaxNumRowEntries()+1);
 
    // loop over all the rows
-   for(LO j=0;j<(LO) gl->getNodeNumRows();j++) {
+   for(LO j=0;j<(LO) gl->getLocalNumRows();j++) {
       GO row = gl->getRowMap()->getGlobalElement(j);
       ST diagValue = 0.0;
       GO diagInd = -1;
@@ -696,7 +696,7 @@ ModifiableLinearOp getAbsRowSumMatrix(const LinearOp & op)
 
      // compute absolute value row sum
      diag.putScalar(0.0);
-     for(LO i=0;i<(LO) tCrsOp->getNodeNumRows();i++) {
+     for(LO i=0;i<(LO) tCrsOp->getLocalNumRows();i++) {
         LO numEntries = tCrsOp->getNumEntriesInLocalRow (i); 
         typename Tpetra::CrsMatrix<ST,LO,GO,NT>::local_inds_host_view_type indices;
         typename Tpetra::CrsMatrix<ST,LO,GO,NT>::values_host_view_type values;
@@ -755,7 +755,7 @@ ModifiableLinearOp getAbsRowSumInvMatrix(const LinearOp & op)
 
      // compute absolute value row sum
      diag.putScalar(0.0);
-     for(LO i=0;i<(LO) tCrsOp->getNodeNumRows();i++) {
+     for(LO i=0;i<(LO) tCrsOp->getLocalNumRows();i++) {
         LO numEntries = tCrsOp->getNumEntriesInLocalRow (i);
         typename Tpetra::CrsMatrix<ST,LO,GO,NT>::local_inds_host_view_type indices;
         typename Tpetra::CrsMatrix<ST,LO,GO,NT>::values_host_view_type values;
@@ -2122,7 +2122,7 @@ double infNorm(const LinearOp & op)
 
     // compute absolute value row sum
     diag.putScalar(0.0);
-    for(LO i=0;i<(LO) tCrsOp->getNodeNumRows();i++) {
+    for(LO i=0;i<(LO) tCrsOp->getLocalNumRows();i++) {
        LO numEntries = tCrsOp->getNumEntriesInLocalRow (i);
        typename Tpetra::CrsMatrix<ST,LO,GO,NT>::local_inds_host_view_type indices;
        typename Tpetra::CrsMatrix<ST,LO,GO,NT>::values_host_view_type values;

--- a/packages/teko/src/Tpetra/Teko_BlockingTpetra.cpp
+++ b/packages/teko/src/Tpetra/Teko_BlockingTpetra.cpp
@@ -205,7 +205,7 @@ RCP<Tpetra::Vector<GO,LO,GO,NT> > getSubBlockColumnGIDs(const Tpetra::CrsMatrix<
 
    // fill index vector for rows
    Tpetra::Vector<GO,LO,GO,NT> rIndex(A.getRowMap(),true);
-   for(size_t i=0;i<A.getNodeNumRows();i++) {
+   for(size_t i=0;i<A.getLocalNumRows();i++) {
       // LID is need to get to contiguous map
       LO lid = blkGIDMap->getLocalElement(A.getRowMap()->getGlobalElement(i)); // this LID makes me nervous
       if(lid>-1)
@@ -240,8 +240,8 @@ RCP<Tpetra::CrsMatrix<ST,LO,GO,NT> > buildSubBlock(int i,int j,const RCP<const T
 
 
    // get entry information
-   LO numMyRows = rowMap->getNodeNumElements();
-   LO maxNumEntries = A->getNodeMaxNumRowEntries();
+   LO numMyRows = rowMap->getLocalNumElements();
+   LO maxNumEntries = A->getLocalMaxNumRowEntries();
 
    // for extraction
    auto indices = typename Tpetra::CrsMatrix<ST,LO,GO,NT>::nonconst_local_inds_host_view_type(Kokkos::ViewAllocateWithoutInitializing("rowIndices"),maxNumEntries);
@@ -340,8 +340,8 @@ void rebuildSubBlock(int i,int j,const RCP<const Tpetra::CrsMatrix<ST,LO,GO,NT> 
    mat.setAllToScalar(0.0);
 
    // get entry information
-   LO numMyRows = rowMap.getNodeNumElements();
-   LO maxNumEntries = A->getNodeMaxNumRowEntries();
+   LO numMyRows = rowMap.getLocalNumElements();
+   LO maxNumEntries = A->getLocalMaxNumRowEntries();
 
    // for extraction
    auto indices = typename Tpetra::CrsMatrix<ST,LO,GO,NT>::nonconst_local_inds_host_view_type(Kokkos::ViewAllocateWithoutInitializing("rowIndices"),maxNumEntries);

--- a/packages/teko/src/Tpetra/Teko_InterlacedTpetra.cpp
+++ b/packages/teko/src/Tpetra/Teko_InterlacedTpetra.cpp
@@ -74,7 +74,7 @@ void buildSubMaps(GO numGlobals,int numVars,const Teuchos::Comm<int> & comm,std:
 void buildSubMaps(const Tpetra::Map<LO,GO,NT> & globalMap,const std::vector<int> & vars,const Teuchos::Comm<int> & comm,
                   std::vector<std::pair<int,Teuchos::RCP<Tpetra::Map<LO,GO,NT> > > > & subMaps)
 {
-   buildSubMaps(globalMap.getGlobalNumElements(),globalMap.getNodeNumElements(),globalMap.getMinGlobalIndex(),
+   buildSubMaps(globalMap.getGlobalNumElements(),globalMap.getLocalNumElements(),globalMap.getMinGlobalIndex(),
                 vars,comm,subMaps);
 }
 
@@ -93,7 +93,7 @@ void buildSubMaps(GO numGlobals,const std::vector<int> & vars,const Teuchos::Com
 
    Tpetra::Map<LO,GO,NT> sampleMap(numGlobals/numGlobalVars,0,rcpFromRef(comm));
 
-   buildSubMaps(numGlobals,numGlobalVars*sampleMap.getNodeNumElements(),numGlobalVars*sampleMap.getMinGlobalIndex(),vars,comm,subMaps);
+   buildSubMaps(numGlobals,numGlobalVars*sampleMap.getLocalNumElements(),numGlobalVars*sampleMap.getMinGlobalIndex(),vars,comm,subMaps);
 }
 
 // build maps to make other conversions
@@ -240,7 +240,7 @@ RCP<Tpetra::CrsMatrix<ST,LO,GO,NT> > buildSubBlock(int i,int j,const RCP<const T
    localA.doImport(*A,import,Tpetra::INSERT);
 
    // get entry information
-   LO numMyRows = rowMap.getNodeNumElements();
+   LO numMyRows = rowMap.getLocalNumElements();
    LO maxNumEntries = A->getGlobalMaxNumRowEntries();
 
    // for extraction
@@ -379,7 +379,7 @@ void rebuildSubBlock(int i,int j,const RCP<const Tpetra::CrsMatrix<ST,LO,GO,NT> 
    mat.setAllToScalar(0.0);
 
    // get entry information
-   LO numMyRows = rowMap.getNodeNumElements();
+   LO numMyRows = rowMap.getLocalNumElements();
    GO maxNumEntries = A->getGlobalMaxNumRowEntries();
 
    // for extraction

--- a/packages/teko/src/Tpetra/Teko_TpetraHelpers.cpp
+++ b/packages/teko/src/Tpetra/Teko_TpetraHelpers.cpp
@@ -175,7 +175,7 @@ void identityRowIndices(const Tpetra::Map<LO,GO,NT> & rowMap, const Tpetra::CrsM
    std::vector<GO> indices(maxSz);
 
    // loop over elements owned by this processor
-   for(size_t i=0;i<rowMap.getNodeNumElements();i++) {
+   for(size_t i=0;i<rowMap.getLocalNumElements();i++) {
       bool rowIsIdentity = true;
       GO rowGID = rowMap.getGlobalElement(i);
 

--- a/packages/thyra/adapters/tpetra/src/Thyra_TpetraLinearOp_def.hpp
+++ b/packages/thyra/adapters/tpetra/src/Thyra_TpetraLinearOp_def.hpp
@@ -410,7 +410,7 @@ void TpetraLinearOp<Scalar,LocalOrdinal,GlobalOrdinal,Node>::getRowStatImpl(
     TEUCHOS_ASSERT(tCrsMatrix->getRowMap()->isSameAs(*tCrsMatrix->getRangeMap()));
     TEUCHOS_ASSERT(tCrsMatrix->getRowMap()->isSameAs(*tRowSumVec->getMap()));
 
-    size_t numMyRows = tCrsMatrix->getNodeNumRows();
+    size_t numMyRows = tCrsMatrix->getLocalNumRows();
 
     using crs_t = Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
     typename crs_t::local_inds_host_view_type indices;

--- a/packages/thyra/adapters/tpetra/src/Thyra_TpetraVectorSpace_def.hpp
+++ b/packages/thyra/adapters/tpetra/src/Thyra_TpetraVectorSpace_def.hpp
@@ -256,7 +256,7 @@ bool TpetraVectorSpace<Scalar,LocalOrdinal,GlobalOrdinal,Node>::hasInCoreView(
   const Ordinal l_localOffset = this->localOffset();
 
   const Ordinal myLocalSubDim = tpetraMap_.is_null () ?
-    static_cast<Ordinal> (0) : tpetraMap_->getNodeNumElements ();
+    static_cast<Ordinal> (0) : tpetraMap_->getLocalNumElements ();
 
   return ( l_localOffset<=rng.lbound() && rng.ubound()<l_localOffset+myLocalSubDim );
 }
@@ -291,7 +291,7 @@ template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 Ordinal TpetraVectorSpace<Scalar,LocalOrdinal,GlobalOrdinal,Node>::localSubDim() const
 {
   return tpetraMap_.is_null () ? static_cast<Ordinal> (0) :
-    static_cast<Ordinal> (tpetraMap_->getNodeNumElements ());
+    static_cast<Ordinal> (tpetraMap_->getLocalNumElements ());
 }
 
 // private

--- a/packages/thyra/adapters/tpetra/test/TpetraThyraWrappers_UnitTests.cpp
+++ b/packages/thyra/adapters/tpetra/test/TpetraThyraWrappers_UnitTests.cpp
@@ -114,10 +114,10 @@ createTriDiagonalTpetraOperator(const int numLocalRows)
 
   RCP<const Tpetra::Map<> > map = createTpetraMap(numLocalRows);
 
-  const size_t numMyElements = map->getNodeNumElements();
+  const size_t numMyElements = map->getLocalNumElements();
   const global_size_t numGlobalElements = map->getGlobalNumElements();
 
-  ArrayView<const GO> myGlobalElements = map->getNodeElementList();
+  ArrayView<const GO> myGlobalElements = map->getLocalElementList();
 
   // Create an OTeger vector numNz that is used to build the Petra Matrix.
   // numNz[i] is the Number of OFF-DIAGONAL term for the ith global equation

--- a/packages/xpetra/src/CrsGraph/Xpetra_TpetraCrsGraph_def.hpp
+++ b/packages/xpetra/src/CrsGraph/Xpetra_TpetraCrsGraph_def.hpp
@@ -244,11 +244,11 @@ global_size_t TpetraCrsGraph<LocalOrdinal,GlobalOrdinal,Node>::getGlobalNumCols(
 
 template<class LocalOrdinal, class GlobalOrdinal, class Node>
 size_t TpetraCrsGraph<LocalOrdinal,GlobalOrdinal,Node>::getNodeNumRows() const
-{ XPETRA_MONITOR("TpetraCrsGraph::getNodeNumRows"); return graph_->getNodeNumRows(); }
+{ XPETRA_MONITOR("TpetraCrsGraph::getNodeNumRows"); return graph_->getLocalNumRows(); }
 
 template<class LocalOrdinal, class GlobalOrdinal, class Node>
 size_t TpetraCrsGraph<LocalOrdinal,GlobalOrdinal,Node>::getNodeNumCols() const
-{ XPETRA_MONITOR("TpetraCrsGraph::getNodeNumCols"); return graph_->getNodeNumCols(); }
+{ XPETRA_MONITOR("TpetraCrsGraph::getNodeNumCols"); return graph_->getLocalNumCols(); }
 
 template<class LocalOrdinal, class GlobalOrdinal, class Node>
 GlobalOrdinal TpetraCrsGraph<LocalOrdinal,GlobalOrdinal,Node>::getIndexBase() const
@@ -260,7 +260,7 @@ global_size_t TpetraCrsGraph<LocalOrdinal,GlobalOrdinal,Node>::getGlobalNumEntri
 
 template<class LocalOrdinal, class GlobalOrdinal, class Node>
 size_t TpetraCrsGraph<LocalOrdinal,GlobalOrdinal,Node>::getNodeNumEntries() const
-{ XPETRA_MONITOR("TpetraCrsGraph::getNodeNumEntries"); return graph_->getNodeNumEntries(); }
+{ XPETRA_MONITOR("TpetraCrsGraph::getNodeNumEntries"); return graph_->getLocalNumEntries(); }
 
 template<class LocalOrdinal, class GlobalOrdinal, class Node>
 size_t TpetraCrsGraph<LocalOrdinal,GlobalOrdinal,Node>::getNumEntriesInGlobalRow(GlobalOrdinal globalRow) const
@@ -284,7 +284,7 @@ size_t TpetraCrsGraph<LocalOrdinal,GlobalOrdinal,Node>::getGlobalMaxNumRowEntrie
 
 template<class LocalOrdinal, class GlobalOrdinal, class Node>
 size_t TpetraCrsGraph<LocalOrdinal,GlobalOrdinal,Node>::getNodeMaxNumRowEntries() const
-{ XPETRA_MONITOR("TpetraCrsGraph::getNodeMaxNumRowEntries"); return graph_->getNodeMaxNumRowEntries(); }
+{ XPETRA_MONITOR("TpetraCrsGraph::getNodeMaxNumRowEntries"); return graph_->getLocalMaxNumRowEntries(); }
 
 template<class LocalOrdinal, class GlobalOrdinal, class Node>
 bool TpetraCrsGraph<LocalOrdinal,GlobalOrdinal,Node>::hasColMap() const

--- a/packages/xpetra/src/CrsMatrix/Xpetra_TpetraBlockCrsMatrix_def.hpp
+++ b/packages/xpetra/src/CrsMatrix/Xpetra_TpetraBlockCrsMatrix_def.hpp
@@ -399,14 +399,14 @@ namespace Xpetra {
     size_t 
     TpetraBlockCrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>::
     getNodeNumRows() const
-    { XPETRA_MONITOR("TpetraBlockCrsMatrix::getNodeNumRows"); return mtx_->getNodeNumRows(); }
+    { XPETRA_MONITOR("TpetraBlockCrsMatrix::getNodeNumRows"); return mtx_->getLocalNumRows(); }
 
 
     template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
     size_t 
     TpetraBlockCrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>::
     getNodeNumCols() const
-    { XPETRA_MONITOR("TpetraBlockCrsMatrix::getNodeNumCols"); return mtx_->getNodeNumCols(); }
+    { XPETRA_MONITOR("TpetraBlockCrsMatrix::getNodeNumCols"); return mtx_->getLocalNumCols(); }
 
 
     template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
@@ -420,7 +420,7 @@ namespace Xpetra {
     size_t 
     TpetraBlockCrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>::
     getNodeNumEntries() const
-    { XPETRA_MONITOR("TpetraBlockCrsMatrix::getNodeNumEntries"); return mtx_->getNodeNumEntries(); }
+    { XPETRA_MONITOR("TpetraBlockCrsMatrix::getNodeNumEntries"); return mtx_->getLocalNumEntries(); }
 
 
     template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
@@ -444,7 +444,7 @@ namespace Xpetra {
 
     template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
     size_t TpetraBlockCrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>::getNodeMaxNumRowEntries() const
-    { XPETRA_MONITOR("TpetraBlockCrsMatrix::getNodeMaxNumRowEntries"); return mtx_->getNodeMaxNumRowEntries(); }
+    { XPETRA_MONITOR("TpetraBlockCrsMatrix::getNodeMaxNumRowEntries"); return mtx_->getLocalMaxNumRowEntries(); }
 
 
     template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
@@ -654,7 +654,7 @@ namespace Xpetra {
     {
         XPETRA_MONITOR("TpetraBlockCrsMatrix::getLocalDiagOffsets");
 
-        const size_t lclNumRows = mtx_->getGraph()->getNodeNumRows();
+        const size_t lclNumRows = mtx_->getGraph()->getLocalNumRows();
         if (static_cast<size_t>(offsets.size()) < lclNumRows) 
         {
             offsets.resize(lclNumRows);

--- a/packages/xpetra/src/CrsMatrix/Xpetra_TpetraCrsMatrix_def.hpp
+++ b/packages/xpetra/src/CrsMatrix/Xpetra_TpetraCrsMatrix_def.hpp
@@ -311,16 +311,16 @@ namespace Xpetra {
     global_size_t TpetraCrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>::getGlobalNumCols() const { XPETRA_MONITOR("TpetraCrsMatrix::getGlobalNumCols"); return mtx_->getGlobalNumCols(); }
 
     template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-    size_t TpetraCrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>::getNodeNumRows() const { XPETRA_MONITOR("TpetraCrsMatrix::getNodeNumRows"); return mtx_->getNodeNumRows(); }
+    size_t TpetraCrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>::getNodeNumRows() const { XPETRA_MONITOR("TpetraCrsMatrix::getNodeNumRows"); return mtx_->getLocalNumRows(); }
 
     template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-    size_t TpetraCrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>::getNodeNumCols() const { XPETRA_MONITOR("TpetraCrsMatrix::getNodeNumCols"); return mtx_->getNodeNumCols(); }
+    size_t TpetraCrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>::getNodeNumCols() const { XPETRA_MONITOR("TpetraCrsMatrix::getNodeNumCols"); return mtx_->getLocalNumCols(); }
 
     template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
     global_size_t TpetraCrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>::getGlobalNumEntries() const { XPETRA_MONITOR("TpetraCrsMatrix::getGlobalNumEntries"); return mtx_->getGlobalNumEntries(); }
 
     template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-    size_t TpetraCrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>::getNodeNumEntries() const { XPETRA_MONITOR("TpetraCrsMatrix::getNodeNumEntries"); return mtx_->getNodeNumEntries(); }
+    size_t TpetraCrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>::getNodeNumEntries() const { XPETRA_MONITOR("TpetraCrsMatrix::getNodeNumEntries"); return mtx_->getLocalNumEntries(); }
 
     template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
     size_t TpetraCrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>::getNumEntriesInLocalRow(LocalOrdinal localRow) const { XPETRA_MONITOR("TpetraCrsMatrix::getNumEntriesInLocalRow"); return mtx_->getNumEntriesInLocalRow(localRow); }
@@ -332,7 +332,7 @@ namespace Xpetra {
     size_t TpetraCrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>::getGlobalMaxNumRowEntries() const { XPETRA_MONITOR("TpetraCrsMatrix::getGlobalMaxNumRowEntries"); return mtx_->getGlobalMaxNumRowEntries(); }
 
     template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-    size_t TpetraCrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>::getNodeMaxNumRowEntries() const { XPETRA_MONITOR("TpetraCrsMatrix::getNodeMaxNumRowEntries"); return mtx_->getNodeMaxNumRowEntries(); }
+    size_t TpetraCrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>::getNodeMaxNumRowEntries() const { XPETRA_MONITOR("TpetraCrsMatrix::getNodeMaxNumRowEntries"); return mtx_->getLocalMaxNumRowEntries(); }
 
     template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
     bool TpetraCrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>::isLocallyIndexed() const { XPETRA_MONITOR("TpetraCrsMatrix::isLocallyIndexed"); return mtx_->isLocallyIndexed(); }

--- a/packages/xpetra/src/Map/Xpetra_TpetraMap_def.hpp
+++ b/packages/xpetra/src/Map/Xpetra_TpetraMap_def.hpp
@@ -133,7 +133,7 @@ global_size_t TpetraMap<LocalOrdinal,GlobalOrdinal,Node>::getGlobalNumElements()
 
 template<class LocalOrdinal, class GlobalOrdinal, class Node>
 size_t TpetraMap<LocalOrdinal,GlobalOrdinal,Node>::getNodeNumElements() const
-{ XPETRA_MONITOR("TpetraMap::getNodeNumElements"); return map_->getNodeNumElements(); }
+{ XPETRA_MONITOR("TpetraMap::getNodeNumElements"); return map_->getLocalNumElements(); }
 
 template<class LocalOrdinal, class GlobalOrdinal, class Node>
 GlobalOrdinal TpetraMap<LocalOrdinal,GlobalOrdinal,Node>::getIndexBase() const
@@ -181,7 +181,7 @@ LookupStatus TpetraMap<LocalOrdinal,GlobalOrdinal,Node>::getRemoteIndexList(cons
 
 template<class LocalOrdinal, class GlobalOrdinal, class Node>
 Teuchos::ArrayView< const GlobalOrdinal > TpetraMap<LocalOrdinal,GlobalOrdinal,Node>::getNodeElementList() const
-{ XPETRA_MONITOR("TpetraMap::getNodeElementList"); return map_->getNodeElementList(); }
+{ XPETRA_MONITOR("TpetraMap::getNodeElementList"); return map_->getLocalElementList(); }
 
 template<class LocalOrdinal, class GlobalOrdinal, class Node>
 bool TpetraMap<LocalOrdinal,GlobalOrdinal,Node>::isNodeLocalElement(LocalOrdinal localIndex) const

--- a/packages/xpetra/sup/Utils/Xpetra_MatrixMatrix.hpp
+++ b/packages/xpetra/sup/Utils/Xpetra_MatrixMatrix.hpp
@@ -258,7 +258,7 @@ Note: this class is not in the Xpetra_UseShortNames.hpp
           Bprime = Tpetra::importAndFillCompleteCrsMatrix<tcrs_matrix_type>(Bprime, *import, Aprime->getDomainMap(), Aprime->getRangeMap());
         }
         //Count the entries to allocate for C in each local row.
-        LO numLocalRows = Aprime->getNodeNumRows();
+        LO numLocalRows = Aprime->getLocalNumRows();
         Array<size_t> allocPerRow(numLocalRows);
         //0 is always the minimum LID
         for(LO i = 0; i < numLocalRows; i++)

--- a/packages/xpetra/test/Map/Map_UnitTests.cpp
+++ b/packages/xpetra/test/Map/Map_UnitTests.cpp
@@ -580,7 +580,7 @@ namespace {
       M m(numDofsPerProc*numProcs, 0/*indexBase*/, comm);
       auto localMap = m.getLocalMap();
 
-      TEST_EQUALITY(localMap.getNodeNumElements(), numDofsPerProc);
+      TEST_EQUALITY(localMap.getLocalNumElements(), numDofsPerProc);
       for (int i = 0; i < numDofsPerProc; i++) {
         // localMap.getGlobalElement is device only
         GO globalElement;
@@ -606,7 +606,7 @@ namespace {
       M m(INVALID, elementList, indexBase, comm);
       auto localMap = m.getLocalMap();
 
-      TEST_EQUALITY(localMap.getNodeNumElements(), numDofsPerProc);
+      TEST_EQUALITY(localMap.getLocalNumElements(), numDofsPerProc);
       for (int i = 0; i < numDofsPerProc; i++) {
         // localMap.getGlobalElement is device only
         GO globalElement;
@@ -632,7 +632,7 @@ namespace {
       M m(INVALID, elementList, indexBase, comm);
       auto localMap = m.getLocalMap();
 
-      TEST_EQUALITY(localMap.getNodeNumElements(), numDofsPerProc);
+      TEST_EQUALITY(localMap.getLocalNumElements(), numDofsPerProc);
       for (int i = 0; i < numDofsPerProc; i++) {
         // localMap.getGlobalElement is device only
         GO globalElement;


### PR DESCRIPTION
@trilinos/xpetra @trilinos/ifpack2 @trilinos/amesos2 @trilinos/teko @trilinos/thyra @trilinos/muelu 

## Motivation
Replace use of deprecated Tpetra methods "getNode*".

Should address #10255.