### PR TITLE
Kokkos::Impl::is_view -> Kokkos::is_view

### DIFF
--- a/packages/adelus/src/BlasWrapper_copy.hpp
+++ b/packages/adelus/src/BlasWrapper_copy.hpp
@@ -64,9 +64,9 @@ template<class XMV, class YMV>
 void
 copy (const XMV& X, const YMV& Y)
 {
-  static_assert (Kokkos::Impl::is_view<XMV>::value, "BlasWrapper::copy: "
+  static_assert (Kokkos::is_view<XMV>::value, "BlasWrapper::copy: "
                  "X is not a Kokkos::View.");
-  static_assert (Kokkos::Impl::is_view<YMV>::value, "BlasWrapper::copy: "
+  static_assert (Kokkos::is_view<YMV>::value, "BlasWrapper::copy: "
                  "Y is not a Kokkos::View.");
   static_assert (std::is_same<typename YMV::value_type,
                  typename YMV::non_const_value_type>::value,

--- a/packages/ifpack2/src/Ifpack2_Details_Chebyshev_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Chebyshev_def.hpp
@@ -192,7 +192,7 @@ namespace { // (anonymous)
 template<class OneDViewType,
          class LocalOrdinal = typename OneDViewType::size_type>
 class PositivizeVector {
-  static_assert (Kokkos::Impl::is_view<OneDViewType>::value,
+  static_assert (Kokkos::is_view<OneDViewType>::value,
                  "OneDViewType must be a 1-D Kokkos::View.");
   static_assert (static_cast<int> (OneDViewType::rank) == 1,
                  "This functor only works with a 1-D View.");

--- a/packages/ifpack2/src/Ifpack2_Experimental_RBILUK_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Experimental_RBILUK_def.hpp
@@ -441,7 +441,7 @@ namespace { // (anonymous)
 // possibly unmanaged) to their managed versions.
 template<class LittleBlockType>
 struct GetManagedView {
-  static_assert (Kokkos::Impl::is_view<LittleBlockType>::value,
+  static_assert (Kokkos::is_view<LittleBlockType>::value,
                  "LittleBlockType must be a Kokkos::View.");
   typedef Kokkos::View<typename LittleBlockType::non_const_data_type,
                        typename LittleBlockType::array_layout,

--- a/packages/teuchos/kokkoscomm/src/Kokkos_TeuchosCommAdapters.hpp
+++ b/packages/teuchos/kokkoscomm/src/Kokkos_TeuchosCommAdapters.hpp
@@ -61,7 +61,7 @@ namespace Teuchos {
 
 //! Variant of send() that takes a tag (and restores the correct order of arguments).
 template<typename Ordinal, class ViewType>
-typename std::enable_if<(Kokkos::Impl::is_view<ViewType>::value)>::type
+typename std::enable_if<(Kokkos::is_view<ViewType>::value)>::type
 send (const ViewType& sendBuffer,
       const Ordinal count,
       const int destRank,
@@ -73,7 +73,7 @@ send (const ViewType& sendBuffer,
 
 //! Variant of ssend() that takes a tag (and restores the correct order of arguments).
 template<typename Ordinal, class ViewType>
-typename std::enable_if<(Kokkos::Impl::is_view<ViewType>::value)>::type
+typename std::enable_if<(Kokkos::is_view<ViewType>::value)>::type
 ssend (const ViewType& sendBuffer,
        const Ordinal count,
        const int destRank,
@@ -85,7 +85,7 @@ ssend (const ViewType& sendBuffer,
 
 //! Variant of readySend() that accepts a message tag.
 template<typename Ordinal, class ViewType>
-typename std::enable_if<(Kokkos::Impl::is_view<ViewType>::value)>::type
+typename std::enable_if<(Kokkos::is_view<ViewType>::value)>::type
 readySend (const ViewType& sendBuffer,
            const Ordinal count,
            const int destRank,
@@ -97,7 +97,7 @@ readySend (const ViewType& sendBuffer,
 
 //! Variant of isend() that takes a tag (and restores the correct order of arguments).
 template<typename Ordinal, class ViewType>
-typename std::enable_if<(Kokkos::Impl::is_view<ViewType>::value),RCP<CommRequest<Ordinal> >>::type
+typename std::enable_if<(Kokkos::is_view<ViewType>::value),RCP<CommRequest<Ordinal> >>::type
 isend (const ViewType& sendBuffer,
        const int destRank,
        const int tag,
@@ -111,7 +111,7 @@ isend (const ViewType& sendBuffer,
 
 //! Variant of ireceive that takes a tag argument (and restores the correct order of arguments).
 template<typename Ordinal, class ViewType>
-typename std::enable_if<(Kokkos::Impl::is_view<ViewType>::value),RCP<CommRequest<Ordinal> >>::type
+typename std::enable_if<(Kokkos::is_view<ViewType>::value),RCP<CommRequest<Ordinal> >>::type
 ireceive (const ViewType& recvBuffer,
           const int sourceRank,
           const int tag,
@@ -123,7 +123,7 @@ ireceive (const ViewType& recvBuffer,
 
 
 template<typename Ordinal, typename SendViewType, typename RecvViewType>
-typename std::enable_if<(Kokkos::Impl::is_view<SendViewType>::value && Kokkos::Impl::is_view<RecvViewType>::value)>::type
+typename std::enable_if<(Kokkos::is_view<SendViewType>::value && Kokkos::is_view<RecvViewType>::value)>::type
 reduceAll (const SendViewType& sendBuf,
            const RecvViewType& recvBuf,
            const EReductionType reductionType,
@@ -169,7 +169,7 @@ reduceAll (const SendViewType& sendBuf,
 template<typename Ordinal, typename Serializer,
          class SendViewType,
          class RecvViewType>
-typename std::enable_if<(Kokkos::Impl::is_view<SendViewType>::value && Kokkos::Impl::is_view<RecvViewType>::value)>::type
+typename std::enable_if<(Kokkos::is_view<SendViewType>::value && Kokkos::is_view<RecvViewType>::value)>::type
 reduceAll(const Comm<Ordinal>& comm,
           const Serializer& serializer,
           const EReductionType reductType,
@@ -210,7 +210,7 @@ reduceAll(const Comm<Ordinal>& comm,
 
 template<typename Ordinal,
          class ViewType>
-typename std::enable_if<(Kokkos::Impl::is_view<ViewType>::value)>::type
+typename std::enable_if<(Kokkos::is_view<ViewType>::value)>::type
 broadcast(const Comm<Ordinal>& comm,
                const int rootRank,
                const Ordinal count,
@@ -222,7 +222,7 @@ broadcast(const Comm<Ordinal>& comm,
 template<typename Ordinal,
          class ViewType,
          typename Serializer>
-typename std::enable_if<(Kokkos::Impl::is_view<ViewType>::value)>::type
+typename std::enable_if<(Kokkos::is_view<ViewType>::value)>::type
 broadcast(const Comm<Ordinal>& comm,
                const Serializer& serializer,
                const int rootRank,

--- a/packages/teuchos/kokkoscompat/src/KokkosCompat_View.hpp
+++ b/packages/teuchos/kokkoscompat/src/KokkosCompat_View.hpp
@@ -128,7 +128,7 @@ namespace Kokkos {
     template <class ViewType>
     ViewType
     create_view (const std::string& label, size_t size) {
-      static_assert(Kokkos::Impl::is_view<ViewType>::value==true,"Kokkos::Compat::create_view() called with non-view argument.");
+      static_assert(Kokkos::is_view<ViewType>::value==true,"Kokkos::Compat::create_view() called with non-view argument.");
       static_assert(ViewType::Rank==1,"Kokkos::Compat::create_view() called with non-rank-1 view argument.");
       return ViewType (label, size);
     }
@@ -210,7 +210,7 @@ namespace Kokkos {
                    const Ordinal begin,
                    const Ordinal end)
     {
-      static_assert(Kokkos::Impl::is_view<ViewType>::value==true,"Kokkos::Compat::subview_range() called with non-view argument.");
+      static_assert(Kokkos::is_view<ViewType>::value==true,"Kokkos::Compat::subview_range() called with non-view argument.");
       static_assert(ViewType::Rank==1,"Kokkos::Compat::subview_range() called with non-rank-1 view argument.");
       return Kokkos::subview (view, std::make_pair (begin, end));
     }
@@ -221,7 +221,7 @@ namespace Kokkos {
                     const Ordinal offset,
                     const Ordinal size)
     {
-      static_assert(Kokkos::Impl::is_view<ViewType>::value==true,"Kokkos::Compat::subview_offset() called with non-view argument.");
+      static_assert(Kokkos::is_view<ViewType>::value==true,"Kokkos::Compat::subview_offset() called with non-view argument.");
       static_assert(ViewType::Rank==1,"Kokkos::Compat::subview_offset() called with non-rank-1 view argument.");
       return Kokkos::subview (view, std::make_pair (offset, offset+size));
     }
@@ -235,8 +235,8 @@ namespace Kokkos {
                      const Ordinal src_begin,
                      const Ordinal src_end)
     {
-      static_assert(Kokkos::Impl::is_view<DstViewType>::value==true,"Kokkos::Compat::deep_copy_range() called with non-view argument.");
-      static_assert(Kokkos::Impl::is_view<SrcViewType>::value==true,"Kokkos::Compat::deep_copy_range() called with non-view argument.");
+      static_assert(Kokkos::is_view<DstViewType>::value==true,"Kokkos::Compat::deep_copy_range() called with non-view argument.");
+      static_assert(Kokkos::is_view<SrcViewType>::value==true,"Kokkos::Compat::deep_copy_range() called with non-view argument.");
       static_assert(DstViewType::Rank==1 && SrcViewType::Rank==1,"Kokkos::Compat::deep_copy_range() called with non-rank-1 view argument.");
       const Ordinal size = src_end - src_begin;
       const Ordinal dst_end = dst_begin + size;
@@ -256,8 +256,8 @@ namespace Kokkos {
                       const Ordinal src_offset,
                       const Ordinal size)
     {
-      static_assert(Kokkos::Impl::is_view<DstViewType>::value==true,"Kokkos::Compat::deep_copy_offset() called with non-view argument.");
-      static_assert(Kokkos::Impl::is_view<SrcViewType>::value==true,"Kokkos::Compat::deep_copy_offset() called with non-view argument.");
+      static_assert(Kokkos::is_view<DstViewType>::value==true,"Kokkos::Compat::deep_copy_offset() called with non-view argument.");
+      static_assert(Kokkos::is_view<SrcViewType>::value==true,"Kokkos::Compat::deep_copy_offset() called with non-view argument.");
       static_assert(DstViewType::Rank==1 && SrcViewType::Rank==1,"Kokkos::Compat::deep_copy_offset() called with non-rank-1 view argument.");
       const Ordinal dst_end = dst_offset + size;
       const Ordinal src_end = src_offset + size;
@@ -271,7 +271,7 @@ namespace Kokkos {
     template <class ViewType>
     typename ViewType::const_type
     create_const_view(const ViewType& view) {
-      static_assert(Kokkos::Impl::is_view<ViewType>::value==true,"Kokkos::Compat::create_const_view() called with non-view argument.");
+      static_assert(Kokkos::is_view<ViewType>::value==true,"Kokkos::Compat::create_const_view() called with non-view argument.");
       return view;
     }
 

--- a/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_def.hpp
@@ -145,11 +145,11 @@ namespace Impl {
            bool  IsBuiltInType>
   class BcrsApplyNoTransFunctor {
   private:
-    static_assert (Kokkos::Impl::is_view<MatrixValuesType>::value,
+    static_assert (Kokkos::is_view<MatrixValuesType>::value,
                    "MatrixValuesType must be a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<OutVecType>::value,
+    static_assert (Kokkos::is_view<OutVecType>::value,
                    "OutVecType must be a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<InVecType>::value,
+    static_assert (Kokkos::is_view<InVecType>::value,
                    "InVecType must be a Kokkos::View.");
     static_assert (std::is_same<MatrixValuesType,
                    typename MatrixValuesType::const_type>::value,
@@ -297,11 +297,11 @@ namespace Impl {
                                 OutVecType,
                                 true> {
   private:
-    static_assert (Kokkos::Impl::is_view<MatrixValuesType>::value,
+    static_assert (Kokkos::is_view<MatrixValuesType>::value,
                    "MatrixValuesType must be a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<OutVecType>::value,
+    static_assert (Kokkos::is_view<OutVecType>::value,
                    "OutVecType must be a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<InVecType>::value,
+    static_assert (Kokkos::is_view<InVecType>::value,
                    "InVecType must be a Kokkos::View.");
     static_assert (std::is_same<MatrixValuesType,
                    typename MatrixValuesType::const_type>::value,
@@ -475,11 +475,11 @@ namespace Impl {
                          const OutMultiVecType& Y
                          )
   {
-    static_assert (Kokkos::Impl::is_view<MatrixValuesType>::value,
+    static_assert (Kokkos::is_view<MatrixValuesType>::value,
                    "MatrixValuesType must be a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<OutMultiVecType>::value,
+    static_assert (Kokkos::is_view<OutMultiVecType>::value,
                    "OutMultiVecType must be a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<InMultiVecType>::value,
+    static_assert (Kokkos::is_view<InMultiVecType>::value,
                    "InMultiVecType must be a Kokkos::View.");
     static_assert (static_cast<int> (MatrixValuesType::rank) == 1,
                    "MatrixValuesType must be a rank-1 Kokkos::View.");

--- a/packages/tpetra/core/src/Tpetra_BlockMultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockMultiVector_def.hpp
@@ -773,9 +773,9 @@ blockJacobiUpdate (const ViewY& Y,
                    const ViewZ& Z,
                    const Scalar& beta)
 {
-  static_assert (Kokkos::Impl::is_view<ViewY>::value, "Y must be a Kokkos::View.");
-  static_assert (Kokkos::Impl::is_view<ViewD>::value, "D must be a Kokkos::View.");
-  static_assert (Kokkos::Impl::is_view<ViewZ>::value, "Z must be a Kokkos::View.");
+  static_assert (Kokkos::is_view<ViewY>::value, "Y must be a Kokkos::View.");
+  static_assert (Kokkos::is_view<ViewD>::value, "D must be a Kokkos::View.");
+  static_assert (Kokkos::is_view<ViewZ>::value, "Z must be a Kokkos::View.");
   static_assert (static_cast<int> (ViewY::rank) == static_cast<int> (ViewZ::rank),
                  "Y and Z must have the same rank.");
   static_assert (static_cast<int> (ViewD::rank) == 3, "D must have rank 3.");

--- a/packages/tpetra/core/src/Tpetra_Details_DistributorActor.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorActor.hpp
@@ -52,7 +52,7 @@ namespace Tpetra {
 namespace Details {
 
 template <class View1, class View2>
-constexpr bool areKokkosViews = Kokkos::Impl::is_view<View1>::value && Kokkos::Impl::is_view<View2>::value;
+constexpr bool areKokkosViews = Kokkos::is_view<View1>::value && Kokkos::is_view<View2>::value;
 
 class DistributorActor {
 

--- a/packages/tpetra/core/src/Tpetra_Details_computeOffsets.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_computeOffsets.hpp
@@ -246,9 +246,9 @@ computeOffsetsFromCounts (const ExecutionSpace& execSpace,
 {
   static_assert (Kokkos::is_execution_space<ExecutionSpace>::value,
                  "ExecutionSpace must be a Kokkos execution space.");
-  static_assert (Kokkos::Impl::is_view<OffsetsViewType>::value,
+  static_assert (Kokkos::is_view<OffsetsViewType>::value,
                  "OffsetsViewType (the type of ptr) must be a Kokkos::View.");
-  static_assert (Kokkos::Impl::is_view<CountsViewType>::value,
+  static_assert (Kokkos::is_view<CountsViewType>::value,
                  "CountsViewType (the type of counts) must be a Kokkos::View.");
   static_assert (std::is_same<typename OffsetsViewType::value_type,
                    typename OffsetsViewType::non_const_value_type>::value,
@@ -359,7 +359,7 @@ typename OffsetsViewType::non_const_value_type
 computeOffsetsFromConstantCount (const OffsetsViewType& ptr,
                                  const CountType count)
 {
-  static_assert (Kokkos::Impl::is_view<OffsetsViewType>::value,
+  static_assert (Kokkos::is_view<OffsetsViewType>::value,
                  "ptr must be a Kokkos::View.");
   static_assert (std::is_same<typename OffsetsViewType::value_type,
                    typename OffsetsViewType::non_const_value_type>::value,

--- a/packages/tpetra/core/src/Tpetra_Details_copyConvert.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_copyConvert.hpp
@@ -356,9 +356,9 @@ void
 copyConvert (const OutputViewType& dst,
              const InputViewType& src)
 {
-  static_assert (Kokkos::Impl::is_view<OutputViewType>::value,
+  static_assert (Kokkos::is_view<OutputViewType>::value,
                  "OutputViewType must be a Kokkos::View.");
-  static_assert (Kokkos::Impl::is_view<InputViewType>::value,
+  static_assert (Kokkos::is_view<InputViewType>::value,
                  "InputViewType must be a Kokkos::View.");
   static_assert (std::is_same<typename OutputViewType::value_type,
                    typename OutputViewType::non_const_value_type>::value,

--- a/packages/tpetra/core/src/Tpetra_Details_copyOffsets.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_copyOffsets.hpp
@@ -529,9 +529,9 @@ template<class OutputViewType, class InputViewType>
 void
 copyOffsets (const OutputViewType& dst, const InputViewType& src)
 {
-  static_assert (Kokkos::Impl::is_view<OutputViewType>::value,
+  static_assert (Kokkos::is_view<OutputViewType>::value,
                  "OutputViewType (the type of dst) must be a Kokkos::View.");
-  static_assert (Kokkos::Impl::is_view<InputViewType>::value,
+  static_assert (Kokkos::is_view<InputViewType>::value,
                  "InputViewType (the type of src) must be a Kokkos::View.");
   static_assert (std::is_same<typename OutputViewType::value_type,
                    typename OutputViewType::non_const_value_type>::value,

--- a/packages/tpetra/core/src/Tpetra_Details_getDiagCopyWithoutOffsets_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_getDiagCopyWithoutOffsets_decl.hpp
@@ -184,7 +184,7 @@ getDiagCopyWithoutOffsets (const DiagType& D,
                            const LocalMapType& colMap,
                            const CrsMatrixType& A)
 {
-  static_assert (Kokkos::Impl::is_view<DiagType>::value,
+  static_assert (Kokkos::is_view<DiagType>::value,
                  "DiagType must be a Kokkos::View.");
   static_assert (static_cast<int> (DiagType::rank) == 1,
                  "DiagType must be a 1-D Kokkos::View.");

--- a/packages/tpetra/core/src/Tpetra_Details_getGraphDiagOffsets_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_getGraphDiagOffsets_decl.hpp
@@ -133,11 +133,11 @@ getGraphDiagOffsets (const DiagOffsetsType& diagOffsets,
                      const LclColIndsType& ind,
                      const bool isSorted)
 {
-  static_assert (Kokkos::Impl::is_view<DiagOffsetsType>::value,
+  static_assert (Kokkos::is_view<DiagOffsetsType>::value,
                  "DiagOffsetsType (the type of diagOffsets) must be a Kokkos::View.");
-  static_assert (Kokkos::Impl::is_view<RowOffsetsType>::value,
+  static_assert (Kokkos::is_view<RowOffsetsType>::value,
                  "RowOffsetsType (the type of ptr) must be a Kokkos::View.");
-  static_assert (Kokkos::Impl::is_view<LclColIndsType>::value,
+  static_assert (Kokkos::is_view<LclColIndsType>::value,
                  "LclColIndsType (the type of ind) must be a Kokkos::View.");
   static_assert (static_cast<int> (DiagOffsetsType::rank) == 1,
                  "DiagOffsetsType (the type of diagOffsets) must be a rank-1 Kokkos::View.");

--- a/packages/tpetra/core/src/Tpetra_Details_iallreduce.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_iallreduce.hpp
@@ -305,9 +305,9 @@ iallreduce (const InputViewType& sendbuf,
             const ::Teuchos::EReductionType op,
             const ::Teuchos::Comm<int>& comm)
 {
-  static_assert (Kokkos::Impl::is_view<InputViewType>::value,
+  static_assert (Kokkos::is_view<InputViewType>::value,
                  "InputViewType must be a Kokkos::View specialization.");
-  static_assert (Kokkos::Impl::is_view<OutputViewType>::value,
+  static_assert (Kokkos::is_view<OutputViewType>::value,
                  "OutputViewType must be a Kokkos::View specialization.");
   constexpr int rank = static_cast<int> (OutputViewType::rank);
   static_assert (static_cast<int> (InputViewType::rank) == rank,

--- a/packages/tpetra/core/src/Tpetra_Details_lclDot.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_lclDot.hpp
@@ -77,12 +77,12 @@ lclDot (const RV& dotsOut,
   const char prefix[] = "Tpetra::MultiVector::lclDotImpl: ";
 #endif // HAVE_TPETRA_DEBUG
 
-  static_assert (Kokkos::Impl::is_view<RV>::value,
+  static_assert (Kokkos::is_view<RV>::value,
                  "Tpetra::MultiVector::lclDotImpl: "
                  "The first argument dotsOut is not a Kokkos::View.");
   static_assert (RV::rank == 1, "Tpetra::MultiVector::lclDotImpl: "
                  "The first argument dotsOut must have rank 1.");
-  static_assert (Kokkos::Impl::is_view<XMV>::value,
+  static_assert (Kokkos::is_view<XMV>::value,
                  "Tpetra::MultiVector::lclDotImpl: The type of the 2nd and "
                  "3rd arguments (X_lcl and Y_lcl) is not a Kokkos::View.");
   static_assert (XMV::rank == 2, "Tpetra::MultiVector::lclDotImpl: "

--- a/packages/tpetra/core/src/Tpetra_Details_normImpl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_normImpl.hpp
@@ -122,7 +122,7 @@ lclNormImpl (const RV& normsOut,
   static_assert (static_cast<int> (RV::Rank) == 1,
                  "Tpetra::MultiVector::lclNormImpl: "
                  "The first argument normsOut must have rank 1.");
-  static_assert (Kokkos::Impl::is_view<XMV>::value,
+  static_assert (Kokkos::is_view<XMV>::value,
                  "Tpetra::MultiVector::lclNormImpl: "
                  "The second argument X is not a Kokkos::View.");
   static_assert (static_cast<int> (XMV::Rank) == 2,

--- a/packages/tpetra/core/src/Tpetra_Details_packCrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_packCrsGraph_def.hpp
@@ -114,23 +114,23 @@ public:
   static_assert (std::is_same<typename CountsViewType::device_type::execution_space,
                    typename device_type::execution_space>::value,
                  "OutputOffsetsViewType and CountsViewType must have the same execution space.");
-  static_assert (Kokkos::Impl::is_view<OutputOffsetsViewType>::value,
+  static_assert (Kokkos::is_view<OutputOffsetsViewType>::value,
                  "OutputOffsetsViewType must be a Kokkos::View.");
   static_assert (std::is_same<typename OutputOffsetsViewType::value_type, output_offset_type>::value,
                  "OutputOffsetsViewType must be a nonconst Kokkos::View.");
   static_assert (std::is_integral<output_offset_type>::value,
                  "The type of each entry of OutputOffsetsViewType must be a built-in integer type.");
-  static_assert (Kokkos::Impl::is_view<CountsViewType>::value,
+  static_assert (Kokkos::is_view<CountsViewType>::value,
                  "CountsViewType must be a Kokkos::View.");
   static_assert (std::is_same<typename CountsViewType::value_type, output_offset_type>::value,
                  "CountsViewType must be a nonconst Kokkos::View.");
   static_assert (std::is_integral<count_type>::value,
                  "The type of each entry of CountsViewType must be a built-in integer type.");
-  static_assert (Kokkos::Impl::is_view<InputOffsetsViewType>::value,
+  static_assert (Kokkos::is_view<InputOffsetsViewType>::value,
                  "InputOffsetsViewType must be a Kokkos::View.");
   static_assert (std::is_integral<input_offset_type>::value,
                  "The type of each entry of InputOffsetsViewType must be a built-in integer type.");
-  static_assert (Kokkos::Impl::is_view<InputLocalRowIndicesViewType>::value,
+  static_assert (Kokkos::is_view<InputLocalRowIndicesViewType>::value,
                  "InputLocalRowIndicesViewType must be a Kokkos::View.");
   static_assert (std::is_integral<local_row_index_type>::value,
                  "The type of each entry of InputLocalRowIndicesViewType must be a built-in integer type.");

--- a/packages/tpetra/core/src/Tpetra_Details_packCrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_packCrsMatrix_def.hpp
@@ -118,23 +118,23 @@ public:
   static_assert (std::is_same<typename CountsViewType::device_type::execution_space,
                    typename device_type::execution_space>::value,
                  "OutputOffsetsViewType and CountsViewType must have the same execution space.");
-  static_assert (Kokkos::Impl::is_view<OutputOffsetsViewType>::value,
+  static_assert (Kokkos::is_view<OutputOffsetsViewType>::value,
                  "OutputOffsetsViewType must be a Kokkos::View.");
   static_assert (std::is_same<typename OutputOffsetsViewType::value_type, output_offset_type>::value,
                  "OutputOffsetsViewType must be a nonconst Kokkos::View.");
   static_assert (std::is_integral<output_offset_type>::value,
                  "The type of each entry of OutputOffsetsViewType must be a built-in integer type.");
-  static_assert (Kokkos::Impl::is_view<CountsViewType>::value,
+  static_assert (Kokkos::is_view<CountsViewType>::value,
                  "CountsViewType must be a Kokkos::View.");
   static_assert (std::is_same<typename CountsViewType::value_type, output_offset_type>::value,
                  "CountsViewType must be a nonconst Kokkos::View.");
   static_assert (std::is_integral<count_type>::value,
                  "The type of each entry of CountsViewType must be a built-in integer type.");
-  static_assert (Kokkos::Impl::is_view<InputOffsetsViewType>::value,
+  static_assert (Kokkos::is_view<InputOffsetsViewType>::value,
                  "InputOffsetsViewType must be a Kokkos::View.");
   static_assert (std::is_integral<input_offset_type>::value,
                  "The type of each entry of InputOffsetsViewType must be a built-in integer type.");
-  static_assert (Kokkos::Impl::is_view<InputLocalRowIndicesViewType>::value,
+  static_assert (Kokkos::is_view<InputLocalRowIndicesViewType>::value,
                  "InputLocalRowIndicesViewType must be a Kokkos::View.");
   static_assert (std::is_integral<local_row_index_type>::value,
                  "The type of each entry of InputLocalRowIndicesViewType must be a built-in integer type.");

--- a/packages/tpetra/core/src/Tpetra_Distributor.hpp
+++ b/packages/tpetra/core/src/Tpetra_Distributor.hpp
@@ -597,7 +597,7 @@ namespace Tpetra {
     ///   accomodate the data exported (sent) to us.  On exit,
     ///   contains the values exported to us.
     template <class ExpView, class ImpView>
-    typename std::enable_if<(Kokkos::Impl::is_view<ExpView>::value && Kokkos::Impl::is_view<ImpView>::value)>::type
+    typename std::enable_if<(Kokkos::is_view<ExpView>::value && Kokkos::is_view<ImpView>::value)>::type
     doPostsAndWaits (
       const ExpView &exports,
       size_t numPackets,
@@ -625,7 +625,7 @@ namespace Tpetra {
     /// \param numImportPacketsPerLID [in] The number of packets for
     ///   each import LID (i.e., each LID to be received).
     template <class ExpView, class ImpView>
-    typename std::enable_if<(Kokkos::Impl::is_view<ExpView>::value && Kokkos::Impl::is_view<ImpView>::value)>::type
+    typename std::enable_if<(Kokkos::is_view<ExpView>::value && Kokkos::is_view<ImpView>::value)>::type
     doPostsAndWaits (const ExpView &exports,
                      const Teuchos::ArrayView<const size_t>& numExportPacketsPerLID,
                      const ImpView &imports,
@@ -656,7 +656,7 @@ namespace Tpetra {
     ///   completion of \c doWaits(), this buffer contains the values
     ///   exported to us.
     template <class ExpView, class ImpView>
-    typename std::enable_if<(Kokkos::Impl::is_view<ExpView>::value && Kokkos::Impl::is_view<ImpView>::value)>::type
+    typename std::enable_if<(Kokkos::is_view<ExpView>::value && Kokkos::is_view<ImpView>::value)>::type
     doPosts (const ExpView &exports,
              size_t numPackets,
              const ImpView &imports);
@@ -680,7 +680,7 @@ namespace Tpetra {
     /// \param numImportPacketsPerLID [in] Same as in the
     ///   four-argument version of doPostsAndWaits().
     template <class ExpView, class ImpView>
-    typename std::enable_if<(Kokkos::Impl::is_view<ExpView>::value && Kokkos::Impl::is_view<ImpView>::value)>::type
+    typename std::enable_if<(Kokkos::is_view<ExpView>::value && Kokkos::is_view<ImpView>::value)>::type
     doPosts (const ExpView &exports,
              const Teuchos::ArrayView<const size_t>& numExportPacketsPerLID,
              const ImpView &imports,
@@ -691,7 +691,7 @@ namespace Tpetra {
     /// This method takes the same arguments as the three-argument
     /// version of doPostsAndWaits().
     template <class ExpView, class ImpView>
-    typename std::enable_if<(Kokkos::Impl::is_view<ExpView>::value && Kokkos::Impl::is_view<ImpView>::value)>::type
+    typename std::enable_if<(Kokkos::is_view<ExpView>::value && Kokkos::is_view<ImpView>::value)>::type
     doReversePostsAndWaits (const ExpView &exports,
                             size_t numPackets,
                             const ImpView &imports);
@@ -701,7 +701,7 @@ namespace Tpetra {
     /// This method takes the same arguments as the four-argument
     /// version of doPostsAndWaits().
     template <class ExpView, class ImpView>
-    typename std::enable_if<(Kokkos::Impl::is_view<ExpView>::value && Kokkos::Impl::is_view<ImpView>::value)>::type
+    typename std::enable_if<(Kokkos::is_view<ExpView>::value && Kokkos::is_view<ImpView>::value)>::type
     doReversePostsAndWaits (const ExpView &exports,
                             const Teuchos::ArrayView<const size_t>& numExportPacketsPerLID,
                             const ImpView &imports,
@@ -712,7 +712,7 @@ namespace Tpetra {
     /// This method takes the same arguments as the three-argument
     /// version of doPosts().
     template <class ExpView, class ImpView>
-    typename std::enable_if<(Kokkos::Impl::is_view<ExpView>::value && Kokkos::Impl::is_view<ImpView>::value)>::type
+    typename std::enable_if<(Kokkos::is_view<ExpView>::value && Kokkos::is_view<ImpView>::value)>::type
     doReversePosts (const ExpView &exports,
                     size_t numPackets,
                     const ImpView &imports);
@@ -722,7 +722,7 @@ namespace Tpetra {
     /// This method takes the same arguments as the four-argument
     /// version of doPosts().
     template <class ExpView, class ImpView>
-    typename std::enable_if<(Kokkos::Impl::is_view<ExpView>::value && Kokkos::Impl::is_view<ImpView>::value)>::type
+    typename std::enable_if<(Kokkos::is_view<ExpView>::value && Kokkos::is_view<ImpView>::value)>::type
     doReversePosts (const ExpView &exports,
                     const Teuchos::ArrayView<const size_t>& numExportPacketsPerLID,
                     const ImpView &imports,
@@ -1030,7 +1030,7 @@ namespace Tpetra {
 #endif
 
   template <class ExpView, class ImpView>
-  typename std::enable_if<(Kokkos::Impl::is_view<ExpView>::value && Kokkos::Impl::is_view<ImpView>::value)>::type
+  typename std::enable_if<(Kokkos::is_view<ExpView>::value && Kokkos::is_view<ImpView>::value)>::type
   Distributor::
   doPostsAndWaits (const ExpView& exports,
                    size_t numPackets,
@@ -1040,7 +1040,7 @@ namespace Tpetra {
   }
 
   template <class ExpView, class ImpView>
-  typename std::enable_if<(Kokkos::Impl::is_view<ExpView>::value && Kokkos::Impl::is_view<ImpView>::value)>::type
+  typename std::enable_if<(Kokkos::is_view<ExpView>::value && Kokkos::is_view<ImpView>::value)>::type
   Distributor::
   doPostsAndWaits(const ExpView& exports,
                   const Teuchos::ArrayView<const size_t>& numExportPacketsPerLID,
@@ -1052,7 +1052,7 @@ namespace Tpetra {
 
 
   template <class ExpView, class ImpView>
-  typename std::enable_if<(Kokkos::Impl::is_view<ExpView>::value && Kokkos::Impl::is_view<ImpView>::value)>::type
+  typename std::enable_if<(Kokkos::is_view<ExpView>::value && Kokkos::is_view<ImpView>::value)>::type
   Distributor::
   doPosts (const ExpView &exports,
            size_t numPackets,
@@ -1062,7 +1062,7 @@ namespace Tpetra {
   }
 
   template <class ExpView, class ImpView>
-  typename std::enable_if<(Kokkos::Impl::is_view<ExpView>::value && Kokkos::Impl::is_view<ImpView>::value)>::type
+  typename std::enable_if<(Kokkos::is_view<ExpView>::value && Kokkos::is_view<ImpView>::value)>::type
   Distributor::
   doPosts (const ExpView &exports,
            const Teuchos::ArrayView<const size_t>& numExportPacketsPerLID,
@@ -1073,7 +1073,7 @@ namespace Tpetra {
   }
 
   template <class ExpView, class ImpView>
-  typename std::enable_if<(Kokkos::Impl::is_view<ExpView>::value && Kokkos::Impl::is_view<ImpView>::value)>::type
+  typename std::enable_if<(Kokkos::is_view<ExpView>::value && Kokkos::is_view<ImpView>::value)>::type
   Distributor::
   doReversePostsAndWaits (const ExpView& exports,
                           size_t numPackets,
@@ -1084,7 +1084,7 @@ namespace Tpetra {
   }
 
   template <class ExpView, class ImpView>
-  typename std::enable_if<(Kokkos::Impl::is_view<ExpView>::value && Kokkos::Impl::is_view<ImpView>::value)>::type
+  typename std::enable_if<(Kokkos::is_view<ExpView>::value && Kokkos::is_view<ImpView>::value)>::type
   Distributor::
   doReversePostsAndWaits (const ExpView& exports,
                           const Teuchos::ArrayView<const size_t>& numExportPacketsPerLID,
@@ -1097,7 +1097,7 @@ namespace Tpetra {
   }
 
   template <class ExpView, class ImpView>
-  typename std::enable_if<(Kokkos::Impl::is_view<ExpView>::value && Kokkos::Impl::is_view<ImpView>::value)>::type
+  typename std::enable_if<(Kokkos::is_view<ExpView>::value && Kokkos::is_view<ImpView>::value)>::type
   Distributor::
   doReversePosts (const ExpView &exports,
                   size_t numPackets,
@@ -1115,7 +1115,7 @@ namespace Tpetra {
   }
 
   template <class ExpView, class ImpView>
-  typename std::enable_if<(Kokkos::Impl::is_view<ExpView>::value && Kokkos::Impl::is_view<ImpView>::value)>::type
+  typename std::enable_if<(Kokkos::is_view<ExpView>::value && Kokkos::is_view<ImpView>::value)>::type
   Distributor::
   doReversePosts (const ExpView &exports,
                   const Teuchos::ArrayView<const size_t>& numExportPacketsPerLID,

--- a/packages/tpetra/core/src/kokkos_refactor/Tpetra_KokkosRefactor_Details_MultiVectorDistObjectKernels.hpp
+++ b/packages/tpetra/core/src/kokkos_refactor/Tpetra_KokkosRefactor_Details_MultiVectorDistObjectKernels.hpp
@@ -166,11 +166,11 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
             typename Enabled = void>
   class PackArraySingleColumnWithBoundsCheck {
   private:
-    static_assert (Kokkos::Impl::is_view<DstView>::value,
+    static_assert (Kokkos::is_view<DstView>::value,
                    "DstView must be a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<SrcView>::value,
+    static_assert (Kokkos::is_view<SrcView>::value,
                    "SrcView must be a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<IdxView>::value,
+    static_assert (Kokkos::is_view<IdxView>::value,
                    "IdxView must be a Kokkos::View.");
     static_assert (static_cast<int> (DstView::rank) == 1,
                    "DstView must be a rank-1 Kokkos::View.");
@@ -287,11 +287,11 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
                             const size_t col,
                             const bool debug = true)
   {
-    static_assert (Kokkos::Impl::is_view<DstView>::value,
+    static_assert (Kokkos::is_view<DstView>::value,
                    "DstView must be a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<SrcView>::value,
+    static_assert (Kokkos::is_view<SrcView>::value,
                    "SrcView must be a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<IdxView>::value,
+    static_assert (Kokkos::is_view<IdxView>::value,
                    "IdxView must be a Kokkos::View.");
     static_assert (static_cast<int> (DstView::rank) == 1,
                    "DstView must be a rank-1 Kokkos::View.");
@@ -465,11 +465,11 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
                            const size_t numCols,
                            const bool debug = true)
   {
-    static_assert (Kokkos::Impl::is_view<DstView>::value,
+    static_assert (Kokkos::is_view<DstView>::value,
                    "DstView must be a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<SrcView>::value,
+    static_assert (Kokkos::is_view<SrcView>::value,
                    "SrcView must be a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<IdxView>::value,
+    static_assert (Kokkos::is_view<IdxView>::value,
                    "IdxView must be a Kokkos::View.");
     static_assert (static_cast<int> (DstView::rank) == 1,
                    "DstView must be a rank-1 Kokkos::View.");
@@ -712,13 +712,13 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
                                            const size_t numCols,
                                            const bool debug = true)
   {
-    static_assert (Kokkos::Impl::is_view<DstView>::value,
+    static_assert (Kokkos::is_view<DstView>::value,
                    "DstView must be a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<SrcView>::value,
+    static_assert (Kokkos::is_view<SrcView>::value,
                    "SrcView must be a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<IdxView>::value,
+    static_assert (Kokkos::is_view<IdxView>::value,
                    "IdxView must be a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<ColView>::value,
+    static_assert (Kokkos::is_view<ColView>::value,
                    "ColView must be a Kokkos::View.");
     static_assert (static_cast<int> (DstView::rank) == 1,
                    "DstView must be a rank-1 Kokkos::View.");
@@ -811,11 +811,11 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
             typename Enabled = void>
   class UnpackArrayMultiColumn {
   private:
-    static_assert (Kokkos::Impl::is_view<DstView>::value,
+    static_assert (Kokkos::is_view<DstView>::value,
                    "DstView must be a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<SrcView>::value,
+    static_assert (Kokkos::is_view<SrcView>::value,
                    "SrcView must be a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<IdxView>::value,
+    static_assert (Kokkos::is_view<IdxView>::value,
                    "IdxView must be a Kokkos::View.");
     static_assert (static_cast<int> (DstView::rank) == 2,
                    "DstView must be a rank-2 Kokkos::View.");
@@ -902,11 +902,11 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
             typename Enabled = void>
   class UnpackArrayMultiColumnWithBoundsCheck {
   private:
-    static_assert (Kokkos::Impl::is_view<DstView>::value,
+    static_assert (Kokkos::is_view<DstView>::value,
                    "DstView must be a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<SrcView>::value,
+    static_assert (Kokkos::is_view<SrcView>::value,
                    "SrcView must be a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<IdxView>::value,
+    static_assert (Kokkos::is_view<IdxView>::value,
                    "IdxView must be a Kokkos::View.");
     static_assert (static_cast<int> (DstView::rank) == 2,
                    "DstView must be a rank-2 Kokkos::View.");
@@ -1071,11 +1071,11 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
                              const bool use_atomic_updates,
                              const bool debug)
   {
-    static_assert (Kokkos::Impl::is_view<DstView>::value,
+    static_assert (Kokkos::is_view<DstView>::value,
                    "DstView must be a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<SrcView>::value,
+    static_assert (Kokkos::is_view<SrcView>::value,
                    "SrcView must be a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<IdxView>::value,
+    static_assert (Kokkos::is_view<IdxView>::value,
                    "IdxView must be a Kokkos::View.");
     static_assert (static_cast<int> (DstView::rank) == 2,
                    "DstView must be a rank-2 Kokkos::View.");
@@ -1107,13 +1107,13 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
             typename Enabled = void>
   class UnpackArrayMultiColumnVariableStride {
   private:
-    static_assert (Kokkos::Impl::is_view<DstView>::value,
+    static_assert (Kokkos::is_view<DstView>::value,
                    "DstView must be a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<SrcView>::value,
+    static_assert (Kokkos::is_view<SrcView>::value,
                    "SrcView must be a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<IdxView>::value,
+    static_assert (Kokkos::is_view<IdxView>::value,
                    "IdxView must be a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<ColView>::value,
+    static_assert (Kokkos::is_view<ColView>::value,
                    "ColView must be a Kokkos::View.");
     static_assert (static_cast<int> (DstView::rank) == 2,
                    "DstView must be a rank-2 Kokkos::View.");
@@ -1209,13 +1209,13 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
             typename Enabled = void>
   class UnpackArrayMultiColumnVariableStrideWithBoundsCheck {
   private:
-    static_assert (Kokkos::Impl::is_view<DstView>::value,
+    static_assert (Kokkos::is_view<DstView>::value,
                    "DstView must be a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<SrcView>::value,
+    static_assert (Kokkos::is_view<SrcView>::value,
                    "SrcView must be a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<IdxView>::value,
+    static_assert (Kokkos::is_view<IdxView>::value,
                    "IdxView must be a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<ColView>::value,
+    static_assert (Kokkos::is_view<ColView>::value,
                    "ColView must be a Kokkos::View.");
     static_assert (static_cast<int> (DstView::rank) == 2,
                    "DstView must be a rank-2 Kokkos::View.");
@@ -1445,13 +1445,13 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
                                              const bool use_atomic_updates,
                                              const bool debug)
   {
-    static_assert (Kokkos::Impl::is_view<DstView>::value,
+    static_assert (Kokkos::is_view<DstView>::value,
                    "DstView must be a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<SrcView>::value,
+    static_assert (Kokkos::is_view<SrcView>::value,
                    "SrcView must be a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<IdxView>::value,
+    static_assert (Kokkos::is_view<IdxView>::value,
                    "IdxView must be a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_view<ColView>::value,
+    static_assert (Kokkos::is_view<ColView>::value,
                    "ColView must be a Kokkos::View.");
     static_assert (static_cast<int> (DstView::rank) == 2,
                    "DstView must be a rank-2 Kokkos::View.");

--- a/packages/tpetra/core/test/CrsMatrix/assembleElement.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/assembleElement.cpp
@@ -83,11 +83,11 @@ namespace TpetraTest {
       checkInputIndices_ (checkInputIndices),
       result_ ("result")
     {
-      static_assert (Kokkos::Impl::is_view<VectorViewType>::value,
+      static_assert (Kokkos::is_view<VectorViewType>::value,
                      "VectorViewType must be a Kokkos::View specialization.");
-      static_assert (Kokkos::Impl::is_view<RhsViewType>::value,
+      static_assert (Kokkos::is_view<RhsViewType>::value,
                      "RhsViewType must be a Kokkos::View specialization.");
-      static_assert (Kokkos::Impl::is_view<LhsViewType>::value,
+      static_assert (Kokkos::is_view<LhsViewType>::value,
                      "LhsViewType must be a Kokkos::View specialization.");
       static_assert (static_cast<int> (RhsViewType::rank) == 1,
                      "RhsViewType must be a rank-1 Kokkos::View.");
@@ -161,11 +161,11 @@ namespace { // (anonymous)
 #endif // KOKKOS_ENABLE_SERIAL
                                             const bool checkInputIndices = true)
   {
-    static_assert (Kokkos::Impl::is_view<VectorViewType>::value,
+    static_assert (Kokkos::is_view<VectorViewType>::value,
                    "VectorViewType must be a Kokkos::View specialization.");
-    static_assert (Kokkos::Impl::is_view<RhsViewType>::value,
+    static_assert (Kokkos::is_view<RhsViewType>::value,
                    "RhsViewType must be a Kokkos::View specialization.");
-    static_assert (Kokkos::Impl::is_view<LhsViewType>::value,
+    static_assert (Kokkos::is_view<LhsViewType>::value,
                    "LhsViewType must be a Kokkos::View specialization.");
     static_assert (static_cast<int> (RhsViewType::rank) == 1,
                    "RhsViewType must be a rank-1 Kokkos::View.");

--- a/packages/tpetra/core/test/MultiVector/Issue364.cpp
+++ b/packages/tpetra/core/test/MultiVector/Issue364.cpp
@@ -51,7 +51,7 @@ namespace TpetraTest {
 
 template<class ViewType>
 class VectorsEqual {
-  static_assert (Kokkos::Impl::is_view<ViewType>::value,
+  static_assert (Kokkos::is_view<ViewType>::value,
                  "ViewType must be a Kokkos::View specialization.");
   static_assert (static_cast<int> (ViewType::rank) == 1,
                  "ViewType must be a 1-D Kokkos::View.");
@@ -101,7 +101,7 @@ private:
 
 template<class ViewType>
 class NegateAllEntries {
-  static_assert (Kokkos::Impl::is_view<ViewType>::value,
+  static_assert (Kokkos::is_view<ViewType>::value,
                  "ViewType must be a Kokkos::View specialization.");
   static_assert (static_cast<int> (ViewType::rank) == 1,
                  "ViewType must be a 1-D Kokkos::View.");
@@ -135,7 +135,7 @@ namespace { // (anonymous)
   bool
   vectorsEqual (const ViewType& x, const ViewType& y)
   {
-    static_assert (Kokkos::Impl::is_view<ViewType>::value,
+    static_assert (Kokkos::is_view<ViewType>::value,
                    "ViewType must be a Kokkos::View specialization.");
     static_assert (static_cast<int> (ViewType::rank) == 1,
                    "ViewType must be a 1-D Kokkos::View.");
@@ -146,7 +146,7 @@ namespace { // (anonymous)
   void
   negateAllEntries (const ViewType& x)
   {
-    static_assert (Kokkos::Impl::is_view<ViewType>::value,
+    static_assert (Kokkos::is_view<ViewType>::value,
                    "ViewType must be a Kokkos::View specialization.");
     static_assert (static_cast<int> (ViewType::rank) == 1,
                    "ViewType must be a 1-D Kokkos::View.");


### PR DESCRIPTION
Other packages should not use functionality in the `Kokkos::Impl` namespace (with few exceptions).
Kokkos::is_view has existed for some time already as a replacement for `Kokkos::Impl::is_view`.
This pull request replaces all occurrences other than those in `packages/kokkos*`.

@trilinos/adelus
@trilinos/ifpack2
@trilinos/teuchos
@trilinos/tpetra

## Motivation
We don't promise backward compatibility for `Kokkos::Impl` and `Kokkos::Impl::is_view` will be deprecated in the upcoming Kokkos release.