### PR TITLE
amesos2: update umfpack wrapper for Tpetra deprecated code changes

### DIFF
--- a/packages/amesos2/src/Amesos2_Umfpack_decl.hpp
+++ b/packages/amesos2/src/Amesos2_Umfpack_decl.hpp
@@ -91,6 +91,11 @@ public:
 
   typedef FunctionMap<Amesos2::Umfpack,umfpack_type>           function_map;
 
+  typedef Kokkos::DefaultHostExecutionSpace              HostExecSpaceType;
+  typedef Kokkos::View<int*, HostExecSpaceType>          host_size_type_array;
+  typedef Kokkos::View<int*, HostExecSpaceType>          host_ordinal_type_array;
+  typedef Kokkos::View<umfpack_type*, HostExecSpaceType> host_value_type_array;
+
   /// \name Constructor/Destructor methods
   //@{
 
@@ -197,14 +202,15 @@ private:
     double Control[UMFPACK_CONTROL];
   } data_;
 
-  // The following Arrays are persisting storage arrays for A, X, and B
+  // The following Kokkos::View's are persisting storage for A's CCS arrays
   /// Stores the values of the nonzero entries for Umfpack
-  Teuchos::Array<umfpack_type> nzvals_;
+  host_value_type_array nzvals_view_;
   /// Stores the location in \c Ai_ and Aval_ that starts row j
-  Teuchos::Array<int> rowind_;
+  host_ordinal_type_array rowind_view_;
   /// Stores the row indices of the nonzero entries
-  Teuchos::Array<int> colptr_;
+  host_size_type_array colptr_view_;
 
+  // The following Arrays are persisting storage arrays for X, and B
   /// Persisting 1D store for X
   Teuchos::Array<umfpack_type> xvals_;  int ldx_;
   /// Persisting 1D store for B


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/amesos2 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Update umfpack wrapper for compatibility with tpetra when deprecated code is disabled
Followed similar pattern to that of #10232 and naming conventions of that PR and #7503

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
Related to #10153 
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
Tested locally before changes with tpetra deprecated code on/off as baseline, retested the same cases after tests changes

Configuration:
```bash

cmake \
\
-D CMAKE_INSTALL_PREFIX:PATH="${INSTALL_LOCATION}" \
-D CMAKE_CXX_FLAGS:STRING="-g" \
-D CMAKE_MAKE_PROGRAM:STRING="make" \
-D CMAKE_BUILD_TYPE:STRING=RELEASE \
-D CMAKE_VERBOSE_MAKEFILE:BOOL=TRUE \
-D BUILD_SHARED_LIBS:BOOL=OFF \
-D Trilinos_VERBOSE_CONFIGURE:BOOL=OFF \
\
-D TPL_ENABLE_MPI:BOOL=ON \
  -D CMAKE_CXX_COMPILER:FILEPATH="`which mpicxx`" \
  -D CMAKE_C_COMPILER:FILEPATH="`which mpicc`" \
  -D CMAKE_Fortran_COMPILER:FILEPATH="`which mpifort`" \
\
-D TPL_ENABLE_BLAS:STRING=ON \
  -D BLAS_LIBRARY_DIRS:FILEPATH=${BLAS_PATH}/lib \
  -D BLAS_LIBRARY_NAMES:STRING="openblas" \
-D TPL_ENABLE_LAPACK:STRING=ON \
  -D LAPACK_INCLUDE_DIRS:FILEPATH="${LAPACK_PATH}/include" \
  -D LAPACK_LIBRARY_DIRS:FILEPATH=${LAPACK_PATH}/lib \
  -D LAPACK_LIBRARY_NAMES:STRING="openblas" \
-D TPL_ENABLE_UMFPACK:STRING=ON \
  -D UMFPACK_INCLUDE_DIRS:PATH="${SS_PATH}/include" \
  -D UMFPACK_LIBRARY_DIRS:PATH="${SS_PATH}/lib" \
  -D UMFPACK_LIBRARY_NAMES:STRING="umfpack;suitesparseconfig;amd" \
\
-D Trilinos_ENABLE_EXAMPLES:BOOL=OFF \
-D Trilinos_ENABLE_TESTS:BOOL=OFF \
-D Trilinos_ENABLE_COMPLEX_DOUBLE:BOOL=ON \
-D Trilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=OFF \
-D Trilinos_ENABLE_EXPLICIT_INSTANTIATION:BOOL=ON \
\
-D Trilinos_ENABLE_OpenMP:BOOL=OFF \
-D Trilinos_ENABLE_Kokkos:BOOL=ON \
  -D Kokkos_ENABLE_OPENMP:BOOL=OFF \
  -D Kokkos_ENABLE_SERIAL:BOOL=ON \
  -D Kokkos_ENABLE_EXAMPLES:BOOL=OFF \
  -D Kokkos_ENABLE_TESTS:BOOL=OFF \
-D Trilinos_ENABLE_Epetra:BOOL=ON \
  -D Epetra_ENABLE_EXAMPLES:BOOL=OFF \
  -D Epetra_ENABLE_TESTS:BOOL=OFF \
-D Trilinos_ENABLE_EpetraExt:BOOL=ON \
  -D EpetraExt_ENABLE_EXAMPLES:BOOL=OFF \
  -D EpetraExt_ENABLE_TESTS:BOOL=OFF \
-D Trilinos_ENABLE_Tpetra:BOOL=ON \
  -D Tpetra_ENABLE_EXAMPLES:BOOL=OFF \
  -D Tpetra_ENABLE_TESTS:BOOL=OFF \
  -D Tpetra_INST_SERIAL:BOOL=ON \
-D Trilinos_ENABLE_Amesos2:BOOL=ON \
  -D Amesos2_ENABLE_EXAMPLES:BOOL=ON \
  -D Amesos2_ENABLE_TESTS:BOOL=ON \
  -D Amesos2_ENABLE_KLU2:BOOL=ON \
  -D Amesos2_ENABLE_Basker:BOOL=ON \
  -D Amesos2_ENABLE_UMFPACK:BOOL=ON \
-D Tpetra_ENABLE_DEPRECATED_CODE=OFF \
${TRILINOS_DIR}
```

<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->