### PR TITLE
Piro: Const Issue In getValidTempusParameters

### DIFF
--- a/packages/piro/src/Piro_TempusSolverForwardOnly.hpp
+++ b/packages/piro/src/Piro_TempusSolverForwardOnly.hpp
@@ -40,8 +40,8 @@
 // ************************************************************************
 // @HEADER
 
-#ifndef PIRO_TEMPUSSOLVERMIMIC_H
-#define PIRO_TEMPUSSOLVERMIMIC_H
+#ifndef PIRO_TEMPUSSOLVERFORWARDONLY_H
+#define PIRO_TEMPUSSOLVERFORWARDONLY_H
 
 #include "Piro_ConfigDefs.hpp"
 #include "Thyra_ResponseOnlyModelEvaluatorBase.hpp"
@@ -65,7 +65,7 @@
 namespace Piro {
 
 /** \brief Thyra-based Model Evaluator for Tempus solves
- *  that mimics Piro_TempusSolverForwardOnly.hpp.
+ *  that mimics forward only in Piro_RythmosSolver.hpp.
  */
 template <typename Scalar>
 class TempusSolverForwardOnly

--- a/packages/piro/src/Piro_TempusSolverForwardOnly_Def.hpp
+++ b/packages/piro/src/Piro_TempusSolverForwardOnly_Def.hpp
@@ -543,14 +543,12 @@ template <typename Scalar>
 Teuchos::RCP<const Teuchos::ParameterList>
 Piro::TempusSolverForwardOnly<Scalar>::getValidTempusParameters() const
 {
-  Teuchos::RCP<Teuchos::ParameterList> validPL;
-  if (fwdStateIntegrator != Teuchos::null) {
-    validPL = fwdStateIntegrator->getValidParameters();
-  } else {
-    auto integrator =Teuchos::rcp(new Tempus::IntegratorBasic<Scalar>());
-    validPL = integrator->getValidParameters();
+  if (fwdStateIntegrator == Teuchos::null) {
+    auto integrator = Teuchos::rcp(new Tempus::IntegratorBasic<Scalar>());
+    return integrator->getValidParameters();
   }
-  return validPL;
+
+  return fwdStateIntegrator->getValidParameters();
 }
 
 template <typename Scalar>


### PR DESCRIPTION
Fix a const issue in getValidTempusParameters() and make guard variable consistent.

@trilinos/tempus 

## Motivation
This would not compiler for @glhenni and was clearly an issue.  Not sure why it slipped through the testing?!

* Closes #10281 

## Stakeholder Feedback
Will check back with @glhenni that this fixes his build failure.

## Testing
Not sure why this slipped through the testing.
