### PR TITLE
Zoltan2:  allow coloring to work when Kokkos CUDA enabled but Trilinos CUDA not enabled

### DIFF
--- a/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
@@ -475,6 +475,9 @@ namespace Tpetra {
                                             device_type>;
     using wrapped_dual_view_type = Details::WrappedDualView<dual_view_type>;
 
+    using host_view_type = typename dual_view_type::t_host;
+    using device_view_type = typename dual_view_type::t_dev;
+
     //@}
     //! @name Constructors and destructor
     //@{

--- a/packages/zoltan2/core/src/algorithms/color/Zoltan2_AlgHybrid2GL.hpp
+++ b/packages/zoltan2/core/src/algorithms/color/Zoltan2_AlgHybrid2GL.hpp
@@ -1360,9 +1360,11 @@ class AlgTwoGhostLayer : public Algorithm<Adapter> {
       //get the color view from the FEMultiVector
       auto femvColors = femv->getLocalViewDevice(Tpetra::Access::ReadWrite);
       auto femv_colors = subview(femvColors, Kokkos::ALL, 0);
-      Kokkos::parallel_for(n_ghosts, KOKKOS_LAMBDA(const int& i){
-        ghost_colors(i) = femv_colors(i+n_local);
-      });
+      Kokkos::parallel_for("get femv colors",
+        Kokkos::RangePolicy<execution_space, int>(0,n_ghosts),
+        KOKKOS_LAMBDA(const int& i){
+          ghost_colors(i) = femv_colors(i+n_local);
+        });
       Kokkos::fence();
       
       double temp = timer();
@@ -1455,9 +1457,11 @@ class AlgTwoGhostLayer : public Algorithm<Adapter> {
 	//the recoloring does not have enough information to color
 	//ghosts correctly, so we set the colors to what they were before
 	//to avoid consistency issues.
-	Kokkos::parallel_for(n_ghosts, KOKKOS_LAMBDA(const int& i){
-          femv_colors(i+n_local) = ghost_colors(i);
-        });
+        Kokkos::parallel_for("set femv colors",
+          Kokkos::RangePolicy<execution_space, int>(0,n_ghosts),
+          KOKKOS_LAMBDA(const int& i){
+            femv_colors(i+n_local) = ghost_colors(i);
+          });
         Kokkos::fence();
         
 	//send views are up-to-date, they were copied after conflict detection.
@@ -1482,9 +1486,11 @@ class AlgTwoGhostLayer : public Algorithm<Adapter> {
 	//remove consistency issues.
         femvColors = femv->getLocalViewDevice(Tpetra::Access::ReadWrite);
         femv_colors = subview(femvColors, Kokkos::ALL, 0);
-        Kokkos::parallel_for(n_ghosts, KOKKOS_LAMBDA(const int& i){
-          ghost_colors(i) = femv_colors(i+n_local);
-        });
+        Kokkos::parallel_for("get femv colors 2",
+          Kokkos::RangePolicy<execution_space, int>(0,n_ghosts),
+          KOKKOS_LAMBDA(const int& i){
+            ghost_colors(i) = femv_colors(i+n_local);
+          });
         Kokkos::fence();
         
 

--- a/packages/zoltan2/core/src/algorithms/color/Zoltan2_AlgHybrid2GL.hpp
+++ b/packages/zoltan2/core/src/algorithms/color/Zoltan2_AlgHybrid2GL.hpp
@@ -50,11 +50,11 @@ class AlgTwoGhostLayer : public Algorithm<Adapter> {
     using map_t = Tpetra::Map<lno_t,gno_t>;
     using femv_scalar_t = int;
     using femv_t = Tpetra::FEMultiVector<femv_scalar_t, lno_t, gno_t>; 
-    using device_type = Tpetra::Map<>::device_type;
-    using execution_space = Tpetra::Map<>::execution_space;
-    using memory_space = Tpetra::Map<>::memory_space;
-    using host_exec = typename Kokkos::View<device_type>::HostMirror::execution_space;
-    using host_mem = typename Kokkos::View<device_type>::HostMirror::memory_space;
+    using device_type = typename femv_t::device_type;
+    using execution_space = typename device_type::execution_space;
+    using memory_space = typename device_type::memory_space;
+    using host_exec = typename femv_t::host_view_type::device_type::execution_space;
+    using host_mem = typename femv_t::host_view_type::device_type::memory_space;
 
     double timer(){
       struct timeval tp;

--- a/packages/zoltan2/core/src/algorithms/color/Zoltan2_AlgHybridD1-2GL.hpp
+++ b/packages/zoltan2/core/src/algorithms/color/Zoltan2_AlgHybridD1-2GL.hpp
@@ -47,11 +47,11 @@ class AlgDistance1TwoGhostLayer : public AlgTwoGhostLayer<Adapter> {
     using map_t = Tpetra::Map<lno_t,gno_t>;
     using femv_scalar_t = int;
     using femv_t = Tpetra::FEMultiVector<femv_scalar_t, lno_t, gno_t>;
-    using device_type = Tpetra::Map<>::device_type;
-    using execution_space = Tpetra::Map<>::execution_space;
-    using memory_space = Tpetra::Map<>::memory_space;
-    using host_exec = typename Kokkos::View<device_type>::HostMirror::execution_space;
-    using host_mem = typename Kokkos::View<device_type>::HostMirror::memory_space;
+    using device_type = typename femv_t::device_type;
+    using execution_space = typename device_type::execution_space;
+    using memory_space = typename device_type::memory_space;
+    using host_exec = typename femv_t::host_view_type::device_type::execution_space;
+    using host_mem = typename femv_t::host_view_type::device_type::memory_space;
 
   private:
    

--- a/packages/zoltan2/core/src/algorithms/color/Zoltan2_AlgHybridD1-2GL.hpp
+++ b/packages/zoltan2/core/src/algorithms/color/Zoltan2_AlgHybridD1-2GL.hpp
@@ -312,7 +312,9 @@ class AlgDistance1TwoGhostLayer : public AlgTwoGhostLayer<Adapter> {
                                                 device_type,
                                                 Kokkos::MemoryTraits<Kokkos::Atomic>> verts_to_send_size_atomic){
 
-      Kokkos::parallel_for(n_local, KOKKOS_LAMBDA(const int& i){
+      Kokkos::parallel_for("constructBoundary",
+        Kokkos::RangePolicy<execution_space, int>(0,n_local), 
+        KOKKOS_LAMBDA(const int& i){
         for(offset_t j = dist_offsets_dev(i); j < dist_offsets_dev(i+1); j++){
           if((size_t)dist_adjs_dev(j) >= n_local){
             verts_to_send_view(verts_to_send_size_atomic(0)++) = i;

--- a/packages/zoltan2/core/src/algorithms/color/Zoltan2_AlgHybridD1.hpp
+++ b/packages/zoltan2/core/src/algorithms/color/Zoltan2_AlgHybridD1.hpp
@@ -50,11 +50,11 @@ class AlgDistance1 : public Algorithm<Adapter>
     using map_t = Tpetra::Map<lno_t, gno_t>;
     using femv_scalar_t = int;
     using femv_t = Tpetra::FEMultiVector<femv_scalar_t, lno_t, gno_t>;
-    using device_type = Tpetra::Map<>::device_type;
-    using execution_space = Tpetra::Map<>::execution_space;
-    using memory_space = Tpetra::Map<>::memory_space;
-    using host_exec = typename Kokkos::View<device_type>::HostMirror::execution_space;
-    using host_mem = typename Kokkos::View<device_type>::HostMirror::memory_space;
+    using device_type = typename femv_t::device_type;
+    using execution_space = typename device_type::execution_space;
+    using memory_space = typename device_type::memory_space;
+    using host_exec = typename femv_t::host_view_type::device_type::execution_space;
+    using host_mem = typename femv_t::host_view_type::device_type::memory_space;
     double timer() {
       struct timeval tp;
       gettimeofday(&tp, NULL);

--- a/packages/zoltan2/core/src/algorithms/color/Zoltan2_AlgHybridD1.hpp
+++ b/packages/zoltan2/core/src/algorithms/color/Zoltan2_AlgHybridD1.hpp
@@ -699,9 +699,11 @@ class AlgDistance1 : public Algorithm<Adapter>
       
       //list of vertices to send to remote processes
       Kokkos::View<lno_t*, device_type> verts_to_send_view("verts to send",boundary_size);
-      Kokkos::parallel_for(boundary_size, KOKKOS_LAMBDA(const int& i){
-        verts_to_send_view(i) = -1;
-      });
+      Kokkos::parallel_for("init verts_to_send_view", 
+        Kokkos::RangePolicy<execution_space, int>(0,boundary_size),
+        KOKKOS_LAMBDA(const int& i){
+          verts_to_send_view(i) = -1;
+        });
       
       //size information for the list of vertices to send. Also includes an atomic copy
       Kokkos::View<size_t*, device_type> verts_to_send_size("verts to send size",1);
@@ -715,14 +717,16 @@ class AlgDistance1 : public Algorithm<Adapter>
       if(verbose)std::cout<<comm->getRank()<<": Done creating send views, initializing...\n";
       if(verbose)std::cout<<comm->getRank()<<": boundary_size = "<<boundary_size<<" verts_to_send_size_atomic(0) = "<<verts_to_send_size_atomic(0)<<"\n";
       //initially the verts to send include all boundary vertices.
-      Kokkos::parallel_for("Initialize verts_to_send",nVtx, KOKKOS_LAMBDA(const int&i){
-        for(offset_t j = dist_offsets(i); j < dist_offsets(i+1); j++){
-	  if((size_t)dist_adjs(j) >= nVtx){
-	    verts_to_send_view(verts_to_send_size_atomic(0)++) = i;
-	    break;
-	  }
-	} 
-      });
+      Kokkos::parallel_for("Initialize verts_to_send",
+        Kokkos::RangePolicy<execution_space, int>(0,nVtx),
+        KOKKOS_LAMBDA(const int&i){
+          for(offset_t j = dist_offsets(i); j < dist_offsets(i+1); j++){
+	    if((size_t)dist_adjs(j) >= nVtx){
+	      verts_to_send_view(verts_to_send_size_atomic(0)++) = i;
+	      break;
+	    }
+	  } 
+        });
       Kokkos::fence();
       
       
@@ -776,9 +780,11 @@ class AlgDistance1 : public Algorithm<Adapter>
         Kokkos::View<int**, Kokkos::LayoutLeft, device_type> femvColors =
 	  femv->template getLocalView<device_type>(Tpetra::Access::ReadWrite); // Partial write
         Kokkos::View<int*, device_type> femv_colors = subview(femvColors, Kokkos::ALL, 0);
-        Kokkos::parallel_for(rand.size()-nVtx,KOKKOS_LAMBDA(const int& i){
-          ghost_colors(i) = femv_colors(i+nVtx);
-        });
+        Kokkos::parallel_for("get colors from femv",
+          Kokkos::RangePolicy<execution_space, int>(0,rand.size()-nVtx),
+          KOKKOS_LAMBDA(const int& i){
+            ghost_colors(i) = femv_colors(i+nVtx);
+          });
 	Kokkos::fence();
 	//detect conflicts on the device, uncolor conflicts consistently.
         double temp = timer();
@@ -867,9 +873,11 @@ class AlgDistance1 : public Algorithm<Adapter>
         recoloringSize_host(0) = 0;
         Kokkos::deep_copy(recoloringSize,recoloringSize_host);
 
-        Kokkos::parallel_for(rand.size()-nVtx, KOKKOS_LAMBDA(const int& i){
-          femv_colors(i+nVtx) = ghost_colors(i);
-        });
+        Kokkos::parallel_for("set femv colors",
+          Kokkos::RangePolicy<execution_space, int>(0,rand.size()-nVtx), 
+          KOKKOS_LAMBDA(const int& i){
+            femv_colors(i+nVtx) = ghost_colors(i);
+          });
         Kokkos::fence();
         //communicate
         Kokkos::deep_copy(verts_to_send_host, verts_to_send_view);
@@ -900,9 +908,11 @@ class AlgDistance1 : public Algorithm<Adapter>
 	
         femvColors = femv->getLocalViewDevice(Tpetra::Access::ReadWrite);
         femv_colors = subview(femvColors, Kokkos::ALL, 0);
-        Kokkos::parallel_for(rand.size()-nVtx, KOKKOS_LAMBDA(const int& i){
-          ghost_colors(i) = femv_colors(i+nVtx);
-        });
+        Kokkos::parallel_for("get femv colors 2",
+          Kokkos::RangePolicy<execution_space, int>(0,rand.size()-nVtx),
+          KOKKOS_LAMBDA(const int& i){
+            ghost_colors(i) = femv_colors(i+nVtx);
+          });
         Kokkos::fence();
 	verts_to_send_size_host(0) = 0;
 	deep_copy(verts_to_send_size, verts_to_send_size_host);

--- a/packages/zoltan2/core/src/algorithms/color/Zoltan2_AlgHybridD2.hpp
+++ b/packages/zoltan2/core/src/algorithms/color/Zoltan2_AlgHybridD2.hpp
@@ -51,11 +51,12 @@ class AlgDistance2 : public AlgTwoGhostLayer<Adapter> {
     using map_t = Tpetra::Map<lno_t,gno_t>;
     using femv_scalar_t = int;
     using femv_t = Tpetra::FEMultiVector<femv_scalar_t, lno_t, gno_t>; 
-    using device_type = Tpetra::Map<>::device_type;
-    using execution_space = Tpetra::Map<>::execution_space;
-    using memory_space = Tpetra::Map<>::memory_space;
-    using host_exec = typename Kokkos::View<device_type>::HostMirror::execution_space;
-    using host_mem = typename Kokkos::View<device_type>::HostMirror::memory_space;
+    using device_type = typename femv_t::device_type;
+    using execution_space = typename device_type::execution_space;
+    using memory_space = typename device_type::memory_space;
+    using host_exec = typename femv_t::host_view_type::device_type::execution_space;
+    using host_mem = typename femv_t::host_view_type::device_type::memory_space;
+
   private:
 
     //This is both the serial and parallel local coloring.

--- a/packages/zoltan2/core/src/algorithms/color/Zoltan2_AlgHybridD2.hpp
+++ b/packages/zoltan2/core/src/algorithms/color/Zoltan2_AlgHybridD2.hpp
@@ -411,7 +411,9 @@ class AlgDistance2 : public AlgTwoGhostLayer<Adapter> {
     Kokkos::deep_copy(boundary_verts, boundary_verts_host);
 
     //initialize the list of verts to send
-    Kokkos::parallel_for(n_local, KOKKOS_LAMBDA(const int& i){
+    Kokkos::parallel_for("init verts to send", 
+      Kokkos::RangePolicy<execution_space, int>(0,n_local),
+      KOKKOS_LAMBDA(const int& i){
       for(offset_t j = dist_offsets_dev(i); j < dist_offsets_dev(i+1); j++){
         if((size_t)dist_adjs_dev(j) >= n_local){
           verts_to_send_view(verts_to_send_size_atomic(0)++) = i;

--- a/packages/zoltan2/core/src/algorithms/color/Zoltan2_AlgHybridPD2.hpp
+++ b/packages/zoltan2/core/src/algorithms/color/Zoltan2_AlgHybridPD2.hpp
@@ -51,11 +51,12 @@ class AlgPartialDistance2 : public AlgTwoGhostLayer<Adapter> {
     using map_t = Tpetra::Map<lno_t,gno_t>;
     using femv_scalar_t = int;
     using femv_t = Tpetra::FEMultiVector<femv_scalar_t, lno_t, gno_t>; 
-    using device_type = Tpetra::Map<>::device_type;
-    using execution_space = Tpetra::Map<>::execution_space;
-    using memory_space = Tpetra::Map<>::memory_space;
-    using host_exec = typename Kokkos::View<device_type>::HostMirror::execution_space;
-    using host_mem = typename Kokkos::View<device_type>::HostMirror::memory_space;      
+    using device_type = typename femv_t::device_type;
+    using execution_space = typename device_type::execution_space;
+    using memory_space = typename device_type::memory_space;
+    using host_exec = typename femv_t::host_view_type::device_type::execution_space;
+    using host_mem = typename femv_t::host_view_type::device_type::memory_space;
+
   private:
     //serial and parallel local partial distance-2 coloring function 
     template<class ExecutionSpace, typename MemorySpace>

--- a/packages/zoltan2/core/src/algorithms/color/Zoltan2_AlgHybridPD2.hpp
+++ b/packages/zoltan2/core/src/algorithms/color/Zoltan2_AlgHybridPD2.hpp
@@ -372,7 +372,9 @@ class AlgPartialDistance2 : public AlgTwoGhostLayer<Adapter> {
       Kokkos::deep_copy(boundary_verts, boundary_verts_host);
       
       //initialize the verts_to_send views
-      Kokkos::parallel_for(n_local, KOKKOS_LAMBDA(const int& i){
+      Kokkos::parallel_for("init verts to send",
+       Kokkos::RangePolicy<execution_space, int>(0,n_local),
+       KOKKOS_LAMBDA(const int& i){
        for(offset_t j = dist_offsets_dev(i); j < dist_offsets_dev(i+1); j++){
         if((size_t)dist_adjs_dev(j) >= n_local){
           verts_to_send_view(verts_to_send_size_atomic(0)++) = i;


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/zoltan2 @ndellingwood 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
In #10238, compilation errors were seen when Kokkos_ENABLE_CUDA=ON but TPL_ENABLE_CUDA=OFF.
This PR fixes the compilation errors and the subsequent memory access errors that arose in this configuration.
Data types for views were made consistent, and a Kokkos::RangePolicy was added to every parallel_for.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
@ndellingwood 

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Tested on weaver and ascicgpu using cmake configuration in #10238.
Tested on ascicgpu with TPL_ENABLE_CUDA=ON.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->