### PR TITLE
Intrepid2 - compiling on hip compiler

### DIFF
--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_QUAD_I1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_QUAD_I1_FEMDef.hpp
@@ -209,7 +209,7 @@ namespace Intrepid2 {
                                  1, 3, 0, 1 };
 
       // when exec space is device, this wrapping relies on uvm.
-      //Kokkos::View<ordinal_type[16], typename DT::execution_space> tagView(tags);
+      //Kokkos::View<ordinal_type[16], DT> tagView(tags);
       OrdinalTypeArray1DHost tagView(&tags[0], 16);
 
       // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_HEX_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_HEX_In_FEMDef.hpp
@@ -336,8 +336,8 @@ namespace Intrepid2 {
       cardLine = lineBasis.getCardinality(),
       cardBubble = bubbleBasis.getCardinality();
 
-    this->vinvLine_   = Kokkos::DynRankView<typename ScalarViewType::value_type,typename DT::execution_space>("Hcurl::Hex::In::vinvLine", cardLine, cardLine);
-    this->vinvBubble_ = Kokkos::DynRankView<typename ScalarViewType::value_type,typename DT::execution_space>("Hcurl::Hex::In::vinvBubble", cardBubble, cardBubble);
+    this->vinvLine_   = Kokkos::DynRankView<typename ScalarViewType::value_type,DT>("Hcurl::Hex::In::vinvLine", cardLine, cardLine);
+    this->vinvBubble_ = Kokkos::DynRankView<typename ScalarViewType::value_type,DT>("Hcurl::Hex::In::vinvBubble", cardBubble, cardBubble);
 
     lineBasis.getVandermondeInverse(this->vinvLine_);
     bubbleBasis.getVandermondeInverse(this->vinvBubble_);
@@ -482,7 +482,7 @@ namespace Intrepid2 {
     Kokkos::DynRankView<typename ScalarViewType::value_type,typename DT::execution_space::array_layout,Kokkos::HostSpace>
       dofCoeffsHost("dofCoeffsHost", this->basisCardinality_, this->basisCellTopology_.getDimension());
 
-    Kokkos::DynRankView<typename ScalarViewType::value_type,typename DT::execution_space>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,DT>
       dofCoordsLine("dofCoordsLine", cardLine, 1),
       dofCoordsBubble("dofCoordsBubble", cardBubble, 1);
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_QUAD_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_QUAD_In_FEMDef.hpp
@@ -259,8 +259,8 @@ namespace Intrepid2 {
       cardLine = lineBasis.getCardinality(),
       cardBubble = bubbleBasis.getCardinality();
 
-    this->vinvLine_   = Kokkos::DynRankView<typename ScalarViewType::value_type,typename DT::execution_space>("Hdiv::Quad::In::vinvLine", cardLine, cardLine);
-    this->vinvBubble_ = Kokkos::DynRankView<typename ScalarViewType::value_type,typename DT::execution_space>("Hdiv::Quad::In::vinvBubble", cardBubble, cardBubble);
+    this->vinvLine_   = Kokkos::DynRankView<typename ScalarViewType::value_type,DT>("Hdiv::Quad::In::vinvLine", cardLine, cardLine);
+    this->vinvBubble_ = Kokkos::DynRankView<typename ScalarViewType::value_type,DT>("Hdiv::Quad::In::vinvBubble", cardBubble, cardBubble);
 
     lineBasis.getVandermondeInverse(this->vinvLine_);
     bubbleBasis.getVandermondeInverse(this->vinvBubble_);
@@ -372,7 +372,7 @@ namespace Intrepid2 {
     Kokkos::DynRankView<typename ScalarViewType::value_type,typename DT::execution_space::array_layout,Kokkos::HostSpace>
       dofCoeffsHost("dofCoeffsHost", this->basisCardinality_, this->basisCellTopology_.getDimension());
 
-    Kokkos::DynRankView<typename ScalarViewType::value_type,typename DT::execution_space>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,DT>
       dofCoordsLine("dofCoordsLine", cardLine, 1),
       dofCoordsBubble("dofCoordsBubble", cardBubble, 1);
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_HEX_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_HEX_Cn_FEMDef.hpp
@@ -266,7 +266,7 @@ namespace Intrepid2 {
     const auto cardLine = lineBasis.getCardinality();
 
     this->pointType_         = pointType;
-    this->vinv_ = Kokkos::DynRankView<typename ScalarViewType::value_type,typename DT::execution_space>("HVOL::HEX::Cn::vinv", cardLine, cardLine);
+    this->vinv_ = Kokkos::DynRankView<typename ScalarViewType::value_type,DT>("HVOL::HEX::Cn::vinv", cardLine, cardLine);
     lineBasis.getVandermondeInverse(this->vinv_);
     
     this->basisCardinality_  = cardLine*cardLine*cardLine;
@@ -325,7 +325,7 @@ namespace Intrepid2 {
     Kokkos::DynRankView<typename ScalarViewType::value_type,typename DT::execution_space::array_layout,Kokkos::HostSpace>
       dofCoordsHost("dofCoordsHost", this->basisCardinality_, this->basisCellTopology_.getDimension());
 
-    Kokkos::DynRankView<typename ScalarViewType::value_type,typename DT::execution_space>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,DT>
       dofCoordsLine("dofCoordsLine", cardLine, 1);
 
     lineBasis.getDofCoords(dofCoordsLine);

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_QUAD_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_QUAD_Cn_FEMDef.hpp
@@ -239,7 +239,7 @@ namespace Intrepid2 {
     const auto cardLine = lineBasis.getCardinality();
     
     this->pointType_ = pointType;
-    this->vinv_ = Kokkos::DynRankView<typename ScalarViewType::value_type,typename DT::execution_space>("HVOL::Quad::Cn::vinv", cardLine, cardLine);
+    this->vinv_ = Kokkos::DynRankView<typename ScalarViewType::value_type,DT>("HVOL::Quad::Cn::vinv", cardLine, cardLine);
     lineBasis.getVandermondeInverse(this->vinv_);
 
     this->basisCardinality_  = cardLine*cardLine;
@@ -295,7 +295,7 @@ namespace Intrepid2 {
     Kokkos::DynRankView<typename ScalarViewType::value_type,typename DT::execution_space::array_layout,Kokkos::HostSpace>
       dofCoordsHost("dofCoordsHost", this->basisCardinality_, this->basisCellTopology_.getDimension());
 
-    Kokkos::DynRankView<typename ScalarViewType::value_type,typename DT::execution_space>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,DT>
       dofCoordsLine("dofCoordsLine", cardLine, 1);
 
     lineBasis.getDofCoords(dofCoordsLine);

--- a/packages/intrepid2/src/Shared/Intrepid2_TestUtils.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_TestUtils.hpp
@@ -71,7 +71,7 @@ namespace Intrepid2
 #if defined(KOKKOS_ENABLE_CUDA)
   using DefaultTestDeviceType = Kokkos::Device<Kokkos::Cuda,Kokkos::CudaSpace>;
 #elif defined(KOKKOS_ENABLE_HIP)
-  using DefaultTestDeviceType = Kokkos::Device<Kokkos::HIP,Kokkos::HIPSpace>;
+  using DefaultTestDeviceType = Kokkos::Device<Kokkos::Experimental::HIP,Kokkos::Experimental::HIPSpace>;
 #else
   using DefaultTestDeviceType = typename Kokkos::DefaultExecutionSpace::device_type;
 #endif

--- a/packages/intrepid2/unit-test/CMakeLists.txt
+++ b/packages/intrepid2/unit-test/CMakeLists.txt
@@ -3,10 +3,7 @@ ADD_SUBDIRECTORY(Shared)
 ADD_SUBDIRECTORY(Cell)
 ADD_SUBDIRECTORY(Orientation)
 ADD_SUBDIRECTORY(Projection)
-
-IF(NOT Kokkos_ENABLE_HIP)
-  ADD_SUBDIRECTORY(MonolithicExecutable)
-ENDIF()
+ADD_SUBDIRECTORY(MonolithicExecutable)
 
 ADD_SUBDIRECTORY(performance)
 

--- a/packages/intrepid2/unit-test/CMakeLists.txt
+++ b/packages/intrepid2/unit-test/CMakeLists.txt
@@ -3,7 +3,10 @@ ADD_SUBDIRECTORY(Shared)
 ADD_SUBDIRECTORY(Cell)
 ADD_SUBDIRECTORY(Orientation)
 ADD_SUBDIRECTORY(Projection)
-ADD_SUBDIRECTORY(MonolithicExecutable)
+
+IF(NOT Kokkos_ENABLE_HIP)
+  ADD_SUBDIRECTORY(MonolithicExecutable)
+ENDIF()
 
 ADD_SUBDIRECTORY(performance)
 

--- a/packages/intrepid2/unit-test/MonolithicExecutable/StructuredIntegrationTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/StructuredIntegrationTests.cpp
@@ -97,9 +97,13 @@ void integrate_baseline(Data<Scalar,DeviceType> integrals, const TransformedVect
   INTREPID2_TEST_FOR_EXCEPTION_DEVICE_SAFE(vectorDataLeft.spaceDim() != vectorDataRight.spaceDim(), std::invalid_argument, "vectorDataLeft and vectorDataRight must agree on the spatial dimension");
   
   INTREPID2_TEST_FOR_EXCEPTION_DEVICE_SAFE(vectorDataRight.extent_int(2) != vectorDataLeft.extent_int(2), std::invalid_argument, "vectorData point dimensions must match");
+  /// hip compiler does not like std::to_string mixed
+  // INTREPID2_TEST_FOR_EXCEPTION_DEVICE_SAFE(cellMeasures.extent_int(1) != vectorDataLeft.extent_int(2), std::invalid_argument,
+  //                                          "cellMeasures point dimension (" + std::to_string(cellMeasures.extent_int(1)) +
+  //                                          ") must match vectorData point dimension (" + std::to_string(vectorDataLeft.extent_int(2)) + ")");
+  
   INTREPID2_TEST_FOR_EXCEPTION_DEVICE_SAFE(cellMeasures.extent_int(1) != vectorDataLeft.extent_int(2), std::invalid_argument,
-                                           "cellMeasures point dimension (" + std::to_string(cellMeasures.extent_int(1)) +
-                                           ") must match vectorData point dimension (" + std::to_string(vectorDataLeft.extent_int(2)) + ")");
+                                           "cellMeasures point dimension must match vectorData point dimension");
   
 //  printFunctor4(vectorDataLeft, std::cout, "vectorDataLeft");
 //  printFunctor2(cellMeasures, std::cout, "cellMeasures");

--- a/packages/intrepid2/unit-test/MonolithicExecutable/StructuredIntegrationTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/StructuredIntegrationTests.cpp
@@ -97,13 +97,9 @@ void integrate_baseline(Data<Scalar,DeviceType> integrals, const TransformedVect
   INTREPID2_TEST_FOR_EXCEPTION_DEVICE_SAFE(vectorDataLeft.spaceDim() != vectorDataRight.spaceDim(), std::invalid_argument, "vectorDataLeft and vectorDataRight must agree on the spatial dimension");
   
   INTREPID2_TEST_FOR_EXCEPTION_DEVICE_SAFE(vectorDataRight.extent_int(2) != vectorDataLeft.extent_int(2), std::invalid_argument, "vectorData point dimensions must match");
-  /// hip compiler does not like std::to_string mixed
-  // INTREPID2_TEST_FOR_EXCEPTION_DEVICE_SAFE(cellMeasures.extent_int(1) != vectorDataLeft.extent_int(2), std::invalid_argument,
-  //                                          "cellMeasures point dimension (" + std::to_string(cellMeasures.extent_int(1)) +
-  //                                          ") must match vectorData point dimension (" + std::to_string(vectorDataLeft.extent_int(2)) + ")");
-  
   INTREPID2_TEST_FOR_EXCEPTION_DEVICE_SAFE(cellMeasures.extent_int(1) != vectorDataLeft.extent_int(2), std::invalid_argument,
-                                           "cellMeasures point dimension must match vectorData point dimension");
+                                           std::string("cellMeasures point dimension (" + std::to_string(cellMeasures.extent_int(1)) +
+                                                       ") must match vectorData point dimension (" + std::to_string(vectorDataLeft.extent_int(2)) + ")").c_str());
   
 //  printFunctor4(vectorDataLeft, std::cout, "vectorDataLeft");
 //  printFunctor2(cellMeasures, std::cout, "cellMeasures");

--- a/packages/sacado/src/Sacado.hpp
+++ b/packages/sacado/src/Sacado.hpp
@@ -67,7 +67,7 @@
 #include "Sacado_ELRCacheFad_DFadTraits.hpp"
 #include "Sacado_ELRCacheFad_SFadTraits.hpp"
 #include "Sacado_ELRCacheFad_SLFadTraits.hpp"
-#ifndef __CUDACC__
+#if !defined(__CUDACC__) && !defined(__HIPCC__ )
 #include "Sacado_Fad_DVFadTraits.hpp"
 #include "Sacado_LFad_LogicalSparseTraits.hpp"
 #include "Sacado_ScalarFlopCounterTraits.hpp"

--- a/packages/sacado/src/Sacado_DynamicArrayTraits.hpp
+++ b/packages/sacado/src/Sacado_DynamicArrayTraits.hpp
@@ -721,7 +721,7 @@ namespace Sacado {
     SACADO_INLINE_FUNCTION
     static void copy(const T* src, T* dest, int sz) {
       if (sz > 0 && dest != NULL && src != NULL)
-#ifdef __CUDACC__
+#if defined( __CUDACC__) || defined(__HIPCC__ )
         for (int i=0; i<sz; ++i)
           dest[i] = src[i];
 #else

--- a/packages/sacado/src/Sacado_StaticArrayTraits.hpp
+++ b/packages/sacado/src/Sacado_StaticArrayTraits.hpp
@@ -68,7 +68,7 @@ namespace Sacado {
     SACADO_INLINE_FUNCTION
     static void copy(const T* src, T* dest, int sz) {
       if (sz > 0)
-#ifdef __CUDACC__
+#if defined( __CUDACC__) || defined(__HIPCC__ )
         for (int i=0; i<sz; ++i)
           dest[i] = src[i];
 #else


### PR DESCRIPTION
## Motivation

Testing the code in compiling with AMD and hip compiler.

## Stakeholder Feedback

@rppawlo I confirmed that the all unit tests in Intrepid2 pass on caraway. Current Intrepid2 unit test may not cover all SACADO use case though. 

## Additional Information

@CamelliaDPG The hip compiler gets an error while compiling your test.
```
/ascldap/users/kyukim/Work/lib/trilinos/kyukim/packages/intrepid2/unit-test/MonolithicExecutable/StructuredIn\
tegrationTests.cpp:101:44: error: cannot pass non-trivial object of type 'basic_string<char>' to variadic fun\
ction; expected type from format string was 'char *' [-Wnon-pod-varargs]
                                           "cellMeasures point dimension (" + std::to_string(cellMeasures.ext\
ent_int(1)) +
                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\
~~~~~~~~~~~~~
``` 
Currently I fix this issue by removing the ``std::to_string`` and simplifying the error message.