### PR TITLE
MueLu: speed up amalgamation

### DIFF
--- a/packages/muelu/src/Graph/MatrixTransformation/MueLu_AmalgamationFactory_def.hpp
+++ b/packages/muelu/src/Graph/MatrixTransformation/MueLu_AmalgamationFactory_def.hpp
@@ -158,12 +158,12 @@ namespace MueLu {
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void AmalgamationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::AmalgamateMap(const Map& sourceMap, const Matrix& A, RCP<const Map>& amalgamatedMap, Array<LO>& translation) {
     typedef typename ArrayView<const GO>::size_type size_type;
-    typedef std::map<GO,size_type> container;
+    typedef std::unordered_map<GO,size_type> container;
 
     GO                      indexBase = sourceMap.getIndexBase();
     ArrayView<const GO>     elementAList = sourceMap.getLocalElementList();
     size_type               numElements  = elementAList.size();
-    container               filter; // TODO:  replace std::set with an object having faster lookup/insert, hashtable for instance
+    container               filter;
 
     GO offset = 0;
     LO blkSize = A.GetFixedBlockSize();

--- a/packages/muelu/test/unit_tests/AmalgamationFactory.cpp
+++ b/packages/muelu/test/unit_tests/AmalgamationFactory.cpp
@@ -99,10 +99,42 @@ namespace MueLuTests {
     }
   } // DOFGid2NodeId
 
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(AmalgamationFactory, AmalgamateMap, Scalar, LocalOrdinal, GlobalOrdinal, Node)
+  {
+    // Test static method AmalgamationFactory::AmalgamateMap().
+#   include <MueLu_UseShortNames.hpp>
+    MUELU_TESTING_SET_OSTREAM;
+    MUELU_TESTING_LIMIT_SCOPE(Scalar,GlobalOrdinal,Node);
+    out << "Test static method AmalgamationFactory::AmalgamateMap()." << std::endl;
+
+    RCP<const Teuchos::Comm<int> > comm = TestHelpers::Parameters::getDefaultComm();
+    Xpetra::UnderlyingLib lib = MueLuTests::TestHelpers::Parameters::getLib();
+
+    const GlobalOrdinal nx = 32;
+    Teuchos::ParameterList matrixList;
+    matrixList.set("nx", nx);
+    matrixList.set("matrixType","Laplace1D");
+    RCP<Matrix> Op = TestHelpers::TestFactory<Scalar, LO, GO, NO>::BuildMatrix(matrixList,TestHelpers::Parameters::getLib());
+    LO blkSize=2;
+    Op->SetFixedBlockSize(blkSize);
+    RCP<Array<LO> > theRowTranslation = rcp(new Array<LO>);
+    RCP<Array<LO> > theColTranslation = rcp(new Array<LO>);
+    RCP<const Map> uniqueMap, nonUniqueMap;
+
+    AmalgamationFactory::AmalgamateMap(*(Op->getRowMap()), *Op, uniqueMap, *theRowTranslation);
+
+    Teuchos::ArrayView<const GO> localEltList = uniqueMap->getLocalElementList();
+    for (int j=0; j<uniqueMap->getLocalNumElements(); j++) {
+      TEST_EQUALITY(uniqueMap->getLocalElement(localEltList[j]),j);
+    }
+
+  } // AmalgamateMap
+
 
   # define MUELU_ETI_GROUP(Scalar, LO, GO, Node) \
     TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(AmalgamationFactory, Constructor, Scalar, LO, GO, Node) \
-    TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(AmalgamationFactory, DOFGid2NodeId, Scalar, LO, GO, Node)
+    TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(AmalgamationFactory, DOFGid2NodeId, Scalar, LO, GO, Node) \
+    TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(AmalgamationFactory, AmalgamateMap, Scalar, LO, GO, Node)
 
 # include <MueLu_ETI_4arg.hpp>
 


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/muelu 
## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Switch the amalgamation factory to use `std::unordered_map` rather than `std::map`.  This will hopefully speed up the amalgamation process.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
Awaiting feedback from @pohm01.

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
This PR includes a test.  For a large-enough matrix (4m rows), I observed that `unordered_map` was observably faster.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->