### PR TITLE
STK: Replace deprecated Kokkos::create_mirror_view overload

### DIFF
--- a/packages/stk/stk_mesh/stk_mesh/base/DeviceField.hpp
+++ b/packages/stk/stk_mesh/stk_mesh/base/DeviceField.hpp
@@ -474,7 +474,7 @@ private:
 
     newDeviceSelectedBucketOffset = UnsignedViewType(Kokkos::view_alloc(Kokkos::WithoutInitializing, hostField->name() + "_bucket_offset"),
                                                      allBuckets.size());
-    newHostSelectedBucketOffset = Kokkos::create_mirror_view(Kokkos::HostSpace(), newDeviceSelectedBucketOffset, Kokkos::WithoutInitializing);
+    newHostSelectedBucketOffset = Kokkos::create_mirror_view(Kokkos::WithoutInitializing, Kokkos::HostSpace(), newDeviceSelectedBucketOffset);
 
     for(unsigned i = 0; i < allBuckets.size(); i++) {
       if(selector(*allBuckets[i])) {

--- a/packages/stk/stk_mesh/stk_mesh/base/DeviceMesh.cpp
+++ b/packages/stk/stk_mesh/stk_mesh/base/DeviceMesh.cpp
@@ -48,7 +48,7 @@ void DeviceBucket::initialize_bucket_attributes(const stk::mesh::Bucket &bucket)
 void DeviceBucket::allocate(const stk::mesh::Bucket &bucket)
 {
   nodeOffsets = OrdinalViewType(Kokkos::view_alloc(Kokkos::WithoutInitializing, "NodeOffsets"), bucket.size()+1);
-  hostNodeOffsets = Kokkos::create_mirror_view(Kokkos::HostSpace(), nodeOffsets, Kokkos::WithoutInitializing);
+  hostNodeOffsets = Kokkos::create_mirror_view(Kokkos::WithoutInitializing, Kokkos::HostSpace(), nodeOffsets);
 
   unsigned maxNodesPerEntity = bucketTopology.num_nodes();
   unsigned totalNumNodes = bucketTopology.num_nodes()*bucketCapacity;
@@ -64,17 +64,17 @@ void DeviceBucket::allocate(const stk::mesh::Bucket &bucket)
   const stk::mesh::PartVector& parts = bucket.supersets();
 
   entities = EntityViewType(Kokkos::view_alloc(Kokkos::WithoutInitializing, "BucketEntities"), bucketCapacity);
-  hostEntities = Kokkos::create_mirror_view(Kokkos::HostSpace(), entities, Kokkos::WithoutInitializing);
+  hostEntities = Kokkos::create_mirror_view(Kokkos::WithoutInitializing, Kokkos::HostSpace(), entities);
 
   nodeConnectivity = BucketConnectivityType(Kokkos::view_alloc(Kokkos::WithoutInitializing, "BucketConnectivity"), totalNumNodes);
-  hostNodeConnectivity = Kokkos::create_mirror_view(Kokkos::HostSpace(), nodeConnectivity, Kokkos::WithoutInitializing);
+  hostNodeConnectivity = Kokkos::create_mirror_view(Kokkos::WithoutInitializing, Kokkos::HostSpace(), nodeConnectivity);
 
   nodeOrdinals = OrdinalViewType(Kokkos::view_alloc(Kokkos::WithoutInitializing, "NodeOrdinals"),
                                  static_cast<size_t>(maxNodesPerEntity));
-  hostNodeOrdinals = Kokkos::create_mirror_view(Kokkos::HostSpace(), nodeOrdinals, Kokkos::WithoutInitializing);
+  hostNodeOrdinals = Kokkos::create_mirror_view(Kokkos::WithoutInitializing, Kokkos::HostSpace(), nodeOrdinals);
 
   partOrdinals = PartOrdinalViewType(Kokkos::view_alloc(Kokkos::WithoutInitializing, "PartOrdinals"), parts.size());
-  hostPartOrdinals = Kokkos::create_mirror_view(Kokkos::HostSpace(), partOrdinals, Kokkos::WithoutInitializing);
+  hostPartOrdinals = Kokkos::create_mirror_view(Kokkos::WithoutInitializing, Kokkos::HostSpace(), partOrdinals);
 }
 
 void DeviceBucket::initialize_from_host(const stk::mesh::Bucket &bucket)
@@ -107,7 +107,7 @@ void DeviceBucket::update_from_host(const stk::mesh::Bucket &bucket)
 
   if (bucketSize+1 != hostNodeOffsets.size()) {
     nodeOffsets = OrdinalViewType(Kokkos::view_alloc(Kokkos::WithoutInitializing, "NodeOffsets"), bucketSize+1);
-    hostNodeOffsets = Kokkos::create_mirror_view(Kokkos::HostSpace(), nodeOffsets, Kokkos::WithoutInitializing);
+    hostNodeOffsets = Kokkos::create_mirror_view(Kokkos::WithoutInitializing, Kokkos::HostSpace(), nodeOffsets);
   }
 
   unsigned totalNumNodes = bucket.topology().num_nodes()*bucketCapacity;
@@ -123,13 +123,13 @@ void DeviceBucket::update_from_host(const stk::mesh::Bucket &bucket)
 
   if (totalNumNodes != hostNodeConnectivity.size()) {
     nodeConnectivity = BucketConnectivityType(Kokkos::view_alloc(Kokkos::WithoutInitializing, "BucketConnectivity"), totalNumNodes);
-    hostNodeConnectivity = Kokkos::create_mirror_view(Kokkos::HostSpace(), nodeConnectivity, Kokkos::WithoutInitializing);
+    hostNodeConnectivity = Kokkos::create_mirror_view(Kokkos::WithoutInitializing, Kokkos::HostSpace(), nodeConnectivity);
   }
 
   if (maxNodesPerEntity != hostNodeOrdinals.size()) {
     nodeOrdinals = OrdinalViewType(Kokkos::view_alloc(Kokkos::WithoutInitializing, "NodeOrdinals"),
                                    static_cast<size_t>(maxNodesPerEntity));
-    hostNodeOrdinals = Kokkos::create_mirror_view(Kokkos::HostSpace(), nodeOrdinals, Kokkos::WithoutInitializing);
+    hostNodeOrdinals = Kokkos::create_mirror_view(Kokkos::WithoutInitializing, Kokkos::HostSpace(), nodeOrdinals);
     for (unsigned i = 0; i < maxNodesPerEntity; ++i) {
       hostNodeOrdinals(i) = static_cast<stk::mesh::ConnectivityOrdinal>(i);
     }
@@ -243,7 +243,7 @@ inline void reallocate_views(DEVICE_VIEW & deviceView, HOST_VIEW & hostView, siz
   if (needGrowth || needShrink) {
     const size_t newSize = requiredSize + static_cast<size_t>(resizeFactor*requiredSize);
     deviceView = DEVICE_VIEW(Kokkos::view_alloc(Kokkos::WithoutInitializing, deviceView.label()), newSize);
-    hostView = Kokkos::create_mirror_view(Kokkos::HostSpace(), deviceView, Kokkos::WithoutInitializing);
+    hostView = Kokkos::create_mirror_view(Kokkos::WithoutInitializing, Kokkos::HostSpace(), deviceView);
   }
 }
 

--- a/packages/stk/stk_util/stk_util/util/StkNgpVector.hpp
+++ b/packages/stk/stk_util/stk_util/util/StkNgpVector.hpp
@@ -50,7 +50,7 @@ public:
     NgpVector() : NgpVector(get_default_name())
     {
     }
-    NgpVector(const std::string &n, size_t s) : mSize(s), deviceVals(Kokkos::view_alloc(Kokkos::WithoutInitializing, n), mSize), hostVals(Kokkos::create_mirror_view(HostSpace(), deviceVals, Kokkos::WithoutInitializing))
+    NgpVector(const std::string &n, size_t s) : mSize(s), deviceVals(Kokkos::view_alloc(Kokkos::WithoutInitializing, n), mSize), hostVals(Kokkos::create_mirror_view(Kokkos::WithoutInitializing, HostSpace(), deviceVals))
     {
     }
     NgpVector(size_t s) : NgpVector(get_default_name(), s)


### PR DESCRIPTION
In the upcoming Kokkos release, the syntax for `Kokkos::create_mirror_view` without initializing the new `Kokkos::View` slightly changes. The overload taking `Kokkos::WithoutInitializing` as last argument is deprecated in favor of an overload taking `Kokkos::WithoutInitializing` as first argument to be conforming to other library functions that take `Kokkos::WithoutInitializing` as an argument, see https://github.com/kokkos/kokkos/pull/4486.
It seems `STK` is the only package using this overload in `Trilinos` at the moment.

The pull request currently targets the `kokkos-promotion` branch. I don't have a strong opinion if it should be merged into that one or if it should be retargeted for the `develop` branch after `kokkos-promotion` has been merged.

@trilinos/stk
@ndellingwood 

## Related Issues

* Follows #10253
* Related to #9905