### PR TITLE
Fix 10294

### DIFF
--- a/packages/intrepid2/src/Cell/Intrepid2_CellGeometryDef.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellGeometryDef.hpp
@@ -866,11 +866,11 @@ namespace Intrepid2
       // then there are as many distinct orientations possible as there are there are cells per grid cell
       // fill cellNodesHost with sample nodes from grid cell 0
       const int numSubdivisions = numCellsPerGridCell(subdivisionStrategy_); // can be up to 6
-      const int gridCellOrdinal = 0;
       
 #if defined(INTREPID2_COMPILE_DEVICE_CODE)
       /// do not compile host only code with device
 #else
+      const int gridCellOrdinal = 0;
       auto hostPolicy = Kokkos::MDRangePolicy<HostExecSpace,Kokkos::Rank<2>>({0,0},{numSubdivisions,nodesPerCell});
       Kokkos::parallel_for("fill cellNodesHost", hostPolicy,
                            [this,gridCellOrdinal,cellNodesHost] (const int &subdivisionOrdinal, const int &nodeInCell) {

--- a/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefHGRAD.hpp
+++ b/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefHGRAD.hpp
@@ -556,10 +556,9 @@ ProjectionTools<DeviceType>::getHGradBasisCoeffs(BasisCoeffsViewType basisCoeffs
     WorkArrayViewType w_("w",numCells, edgeCardinality);
 
     auto edgeDofs = Kokkos::subview(tagToOrdinal, edgeDim, ie, Kokkos::ALL());
-    auto edgeDofsHost = Kokkos::subview(cellBasis->getAllDofOrdinal(), edgeDim, ie, Kokkos::ALL());
 
     ElemSystem edgeSystem("edgeSystem", false);
-    edgeSystem.solve(basisCoeffs, edgeMassMat_, edgeRhsMat_, t_, w_, edgeDofsHost, edgeCardinality);
+    edgeSystem.solve(basisCoeffs, edgeMassMat_, edgeRhsMat_, t_, w_, edgeDofs, edgeCardinality);
 
     Kokkos::parallel_for("Compute Dofs ", Kokkos::RangePolicy<ExecSpaceType, int> (0, edgeCardinality),
         KOKKOS_LAMBDA (const size_t i) {
@@ -656,9 +655,9 @@ ProjectionTools<DeviceType>::getHGradBasisCoeffs(BasisCoeffsViewType basisCoeffs
     ScalarViewType t_("t",numCells, numElemDofs);
     WorkArrayViewType w_("w",numCells, numElemDofs);
 
-    auto cellDofsHost = Kokkos::subview(cellBasis->getAllDofOrdinal(), dim, 0, Kokkos::ALL());
+    auto cellDofs = Kokkos::subview(tagToOrdinal, dim, 0, Kokkos::ALL());
     ElemSystem cellSystem("cellSystem", true);
-    cellSystem.solve(basisCoeffs, cellMassMat_, cellRhsMat_, t_, w_, cellDofsHost, numElemDofs);
+    cellSystem.solve(basisCoeffs, cellMassMat_, cellRhsMat_, t_, w_, cellDofs, numElemDofs);
   }
 }
 }

--- a/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefHGRAD.hpp
+++ b/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefHGRAD.hpp
@@ -556,9 +556,10 @@ ProjectionTools<DeviceType>::getHGradBasisCoeffs(BasisCoeffsViewType basisCoeffs
     WorkArrayViewType w_("w",numCells, edgeCardinality);
 
     auto edgeDofs = Kokkos::subview(tagToOrdinal, edgeDim, ie, Kokkos::ALL());
+    auto edgeDofsHost = Kokkos::subview(cellBasis->getAllDofOrdinal(), edgeDim, ie, Kokkos::ALL());
 
     ElemSystem edgeSystem("edgeSystem", false);
-    edgeSystem.solve(basisCoeffs, edgeMassMat_, edgeRhsMat_, t_, w_, edgeDofs, edgeCardinality);
+    edgeSystem.solve(basisCoeffs, edgeMassMat_, edgeRhsMat_, t_, w_, edgeDofsHost, edgeCardinality);
 
     Kokkos::parallel_for("Compute Dofs ", Kokkos::RangePolicy<ExecSpaceType, int> (0, edgeCardinality),
         KOKKOS_LAMBDA (const size_t i) {
@@ -655,9 +656,9 @@ ProjectionTools<DeviceType>::getHGradBasisCoeffs(BasisCoeffsViewType basisCoeffs
     ScalarViewType t_("t",numCells, numElemDofs);
     WorkArrayViewType w_("w",numCells, numElemDofs);
 
-    auto cellDofs = Kokkos::subview(tagToOrdinal, dim, 0, Kokkos::ALL());
+    auto cellDofsHost = Kokkos::subview(cellBasis->getAllDofOrdinal(), dim, 0, Kokkos::ALL());
     ElemSystem cellSystem("cellSystem", true);
-    cellSystem.solve(basisCoeffs, cellMassMat_, cellRhsMat_, t_, w_, cellDofs, numElemDofs);
+    cellSystem.solve(basisCoeffs, cellMassMat_, cellRhsMat_, t_, w_, cellDofsHost, numElemDofs);
   }
 }
 }


### PR DESCRIPTION
@trilinos/intrepid2

## Motivation
See #10294.  Some of the ProjectionTools code relied on UVM, some of it in subtle ways: certain `create_mirror_view_and_copy()` calls were failing here with an error indicating that a temporary allocation would be required to do the copy.  In this PR, I replace those with a two-stage copy: device subview to device view, followed by device view to host.

Closes #10294.

## Testing
Have confirmed that all MonolithicExecutable tests pass under CUDA when built without KokkosKernels and with `Kokkos_ENABLE_CUDA_UVM=OFF` (tried this on Weaver).