### PR TITLE
Amesos2_Superludist : to be consistent with SuperLU_DIST

### DIFF
--- a/packages/amesos2/src/Amesos2_Superludist_def.hpp
+++ b/packages/amesos2/src/Amesos2_Superludist_def.hpp
@@ -460,7 +460,8 @@ namespace Amesos2 {
       }
 
       // Retrieve the normI of A (required by gstrf).
-      double anorm = function_map::plangs((char *)"I", &(data_.A), &(data_.grid));
+      bool notran = (data_.options.Trans == SLUD::NOTRANS);
+      double anorm = function_map::plangs((notran ? (char *)"1" : (char *)"I"), &(data_.A), &(data_.grid));
 
       int info = 0;
       {


### PR DESCRIPTION

@trilinos/amesos2 

## Motivation

This PR adjusts Amesos2 to follow SuperLU_DIST

## Additional Information
`anorm` is used to determine tiny pivots.
