### PR TITLE
PyTrilinos: Fix Tpetra bindings when compiled with -DTpetra_INST_INT_…

### DIFF
--- a/packages/PyTrilinos/cmake/PyTrilinos_config.h.in
+++ b/packages/PyTrilinos/cmake/PyTrilinos_config.h.in
@@ -123,7 +123,12 @@
 
 /* PyTrilinos ordinal types */
 
+#ifdef HAVE_TPETRA_INST_INT_LONG_LONG
 #define PYTRILINOS_GLOBAL_ORD long long
+#else
+#define PYTRILINOS_GLOBAL_ORD int
+#endif
+
 #define PYTRILINOS_LOCAL_ORD  int
 
 /**********************************************************************/

--- a/packages/PyTrilinos/src/Tpetra.i
+++ b/packages/PyTrilinos/src/Tpetra.i
@@ -1477,7 +1477,9 @@ public:
 // Concrete scalar types for Tpetra classes //
 //////////////////////////////////////////////
 %tpetra_scalars(int       , int   )
+#ifdef HAVE_TPETRA_INST_INT_LONG_LONG
 %tpetra_scalars(long long , long  )
+#endif
 %tpetra_scalars(double    , double)
 
 /////////////////////////////////////////////////////


### PR DESCRIPTION
…LONG_LONG:BOOL=OFF.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/pytrilinos
@trilinos/tpetra

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Importing PyTrilinos fails with
```
ImportError: /mnt/fvm-env/install/lib/libpytrilinos.so.13: undefined symbol: _ZNK6Tpetra3MapIixN6Kokkos6Compat23KokkosDeviceWrapperNodeINS1_6SerialENS1_9HostSpaceEEEE19getLocalElementListEv 
``` 
without this patch. 

I don't know if this is the right fix, so I would appreciate any feedback. I don't use Tpetra with PyTrilinos, and I can't compile the tests, so I have no way of actually testing this, or maybe other configurations with other `-DTpetra_INST_*` configurations that also need fixing.

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
I've been unable to compile the PyTrilinos tests:
```
[ 98%] Generating testutil.py
/bin/sh: 1: ../util/copyWithCMakeSubstitutions.py: not found
make[2]: *** [packages/PyTrilinos/test/CMakeFiles/PyTrilinos_Test_testutil.dir/build.make:73: packages/PyTrilinos/test/testutil.py] Error 127
make[1]: *** [CMakeFiles/Makefile2:16564: packages/PyTrilinos/test/CMakeFiles/PyTrilinos_Test_testutil.dir/all] Error 2
make: *** [Makefile:166: all] Error 2
```
But that does not seem to be a problem with the patch.