### PR TITLE
NOX: Fix missing initialization of variables in NOX::Solver::TensorBased

### DIFF
--- a/packages/nox/src/NOX_Solver_TensorBased.C
+++ b/packages/nox/src/NOX_Solver_TensorBased.C
@@ -80,7 +80,11 @@ TensorBased(const Teuchos::RCP<NOX::Abstract::Group>& xGrp,
   tmpVecPtr(xGrp->getX().clone(ShapeCopy)), // create via clone
   residualVecPtr(xGrp->getX().clone(ShapeCopy)), // create via clone
   testPtr(t),
-  paramsPtr(p)
+  paramsPtr(p),
+  linearParamsPtr(0),
+  beta(0.),
+  sTinvJF(0.),
+  sTinvJa(0.)
 {
   reset(xGrp, t, p);
 }


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/rppawlo@sandia.gov

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
This fix is required in order to avoid conditional execution of coded based on not initialized variables which could lead to random failures. For example adding the following code in a user program causes the NOX solver to fail:

void* operator new(size_t n)
{
   void* p = malloc(n);
   memset(p, 0xFF, n);
   return p;
}

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
That modified version of Trilinos has been tested inside the free open source software MBDyn developed by the Politecnico di Milano.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
All tests have been executed using trilinos release 12.14.1-3. However, there should be no difference compared to the development branch.
Below you can find the output from valgrind executing the test problem:

==11214== Conditional jump or move depends on uninitialised value(s)
==11214==    at 0x1A5E4FD: NOX::Solver::TensorBased::computeCurvilinearStep(NOX::Abstract::Vector&, NOX::Abstract::Group const&, NOX::Solver::Generic const&, double&) (in /home/reinhard/install/mbdyn-build-trilinos/mbdyn/mbdyn)
==11214==    by 0x1A5ECA5: NOX::Solver::TensorBased::performLinesearch(NOX::Abstract::Group&, double&, NOX::Abstract::Vector const&, NOX::Solver::Generic const&) (in /home/reinhard/install/mbdyn-build-trilinos/mbdyn/mbdyn)
==11214==    by 0x1A616B9: NOX::Solver::TensorBased::step() (in /home/reinhard/install/mbdyn-build-trilinos/mbdyn/mbdyn)
==11214==    by 0xDF38E9: NoxNonlinearSolver::Solve(NonlinearProblem const*, Solver*, int, double const&, int&, double&, double const&, double&) (noxsolver.cc:300)
==11214==    by 0xCFD0E3: DerivativeSolver::Advance(Solver*, double, double, StepIntegrator::StepChange, std::deque<MyVectorHandler*, std::allocator<MyVectorHandler*> >&, std::deque<MyVectorHandler*, std::allocator<MyVectorHandler*> >&, MyVectorHandler*, MyVectorHandler*, int&, double&, double&) (stepsol.cc:351)
==11214==    by 0xCF5951: Solver::Prepare() (solver.cc:879)
==11214==    by 0xCE366D: Solver::Run() (solver.cc:1672)
==11214==    by 0xCAA70C: RunMBDyn (mbdyn.cc:1498)
==11214==    by 0xCAA70C: mbdyn_program(mbdyn_proc_t&, int, char**, int&) (mbdyn.cc:942)
==11214==    by 0xC85CDA: main (mbdyn.cc:1168)
==11214== 
==11214== Conditional jump or move depends on uninitialised value(s)
==11214==    at 0x1A5E521: NOX::Solver::TensorBased::computeCurvilinearStep(NOX::Abstract::Vector&, NOX::Abstract::Group const&, NOX::Solver::Generic const&, double&) (in /home/reinhard/install/mbdyn-build-trilinos/mbdyn/mbdyn)
==11214==    by 0x1A5ECA5: NOX::Solver::TensorBased::performLinesearch(NOX::Abstract::Group&, double&, NOX::Abstract::Vector const&, NOX::Solver::Generic const&) (in /home/reinhard/install/mbdyn-build-trilinos/mbdyn/mbdyn)
==11214==    by 0x1A616B9: NOX::Solver::TensorBased::step() (in /home/reinhard/install/mbdyn-build-trilinos/mbdyn/mbdyn)
==11214==    by 0xDF38E9: NoxNonlinearSolver::Solve(NonlinearProblem const*, Solver*, int, double const&, int&, double&, double const&, double&) (noxsolver.cc:300)
==11214==    by 0xCFD0E3: DerivativeSolver::Advance(Solver*, double, double, StepIntegrator::StepChange, std::deque<MyVectorHandler*, std::allocator<MyVectorHandler*> >&, std::deque<MyVectorHandler*, std::allocator<MyVectorHandler*> >&, MyVectorHandler*, MyVectorHandler*, int&, double&, double&) (stepsol.cc:351)
==11214==    by 0xCF5951: Solver::Prepare() (solver.cc:879)
==11214==    by 0xCE366D: Solver::Run() (solver.cc:1672)
==11214==    by 0xCAA70C: RunMBDyn (mbdyn.cc:1498)
==11214==    by 0xCAA70C: mbdyn_program(mbdyn_proc_t&, int, char**, int&) (mbdyn.cc:942)
==11214==    by 0xC85CDA: main (mbdyn.cc:1168)
==11214== 
==11214== Conditional jump or move depends on uninitialised value(s)
==11214==    at 0x1A5E533: NOX::Solver::TensorBased::computeCurvilinearStep(NOX::Abstract::Vector&, NOX::Abstract::Group const&, NOX::Solver::Generic const&, double&) (in /home/reinhard/install/mbdyn-build-trilinos/mbdyn/mbdyn)
==11214==    by 0x1A5ECA5: NOX::Solver::TensorBased::performLinesearch(NOX::Abstract::Group&, double&, NOX::Abstract::Vector const&, NOX::Solver::Generic const&) (in /home/reinhard/install/mbdyn-build-trilinos/mbdyn/mbdyn)
==11214==    by 0x1A616B9: NOX::Solver::TensorBased::step() (in /home/reinhard/install/mbdyn-build-trilinos/mbdyn/mbdyn)
==11214==    by 0xDF38E9: NoxNonlinearSolver::Solve(NonlinearProblem const*, Solver*, int, double const&, int&, double&, double const&, double&) (noxsolver.cc:300)
==11214==    by 0xCFD0E3: DerivativeSolver::Advance(Solver*, double, double, StepIntegrator::StepChange, std::deque<MyVectorHandler*, std::allocator<MyVectorHandler*> >&, std::deque<MyVectorHandler*, std::allocator<MyVectorHandler*> >&, MyVectorHandler*, MyVectorHandler*, int&, double&, double&) (stepsol.cc:351)
==11214==    by 0xCF5951: Solver::Prepare() (solver.cc:879)
==11214==    by 0xCE366D: Solver::Run() (solver.cc:1672)
==11214==    by 0xCAA70C: RunMBDyn (mbdyn.cc:1498)
==11214==    by 0xCAA70C: mbdyn_program(mbdyn_proc_t&, int, char**, int&) (mbdyn.cc:942)
==11214==    by 0xC85CDA: main (mbdyn.cc:1168)
