### PR TITLE
Panzer: Use HGRAD_*_Cn instead of HGrad_*_C2

### DIFF
--- a/packages/panzer/disc-fe/src/Panzer_IntrepidBasisFactory.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_IntrepidBasisFactory.hpp
@@ -57,19 +57,15 @@
 #include "Shards_CellTopology.hpp"
 
 #include "Intrepid2_HGRAD_QUAD_C1_FEM.hpp"
-#include "Intrepid2_HGRAD_QUAD_C2_FEM.hpp"
 #include "Intrepid2_HGRAD_QUAD_Cn_FEM.hpp"
 
 #include "Intrepid2_HGRAD_HEX_C1_FEM.hpp"
-#include "Intrepid2_HGRAD_HEX_C2_FEM.hpp"
 #include "Intrepid2_HGRAD_HEX_Cn_FEM.hpp"
 
 #include "Intrepid2_HGRAD_TET_C1_FEM.hpp"
-#include "Intrepid2_HGRAD_TET_C2_FEM.hpp"
 #include "Intrepid2_HGRAD_TET_Cn_FEM.hpp"
 
 #include "Intrepid2_HGRAD_TRI_C1_FEM.hpp"
-#include "Intrepid2_HGRAD_TRI_C2_FEM.hpp"
 #include "Intrepid2_HGRAD_TRI_Cn_FEM.hpp"
 
 #include "Intrepid2_HGRAD_LINE_C1_FEM.hpp"
@@ -151,10 +147,7 @@ namespace panzer {
     else if ( (basis_type == "HGrad") && (cell_type == "Hexahedron") && (basis_order == 1) )
       basis = Teuchos::rcp( new Intrepid2::Basis_HGRAD_HEX_C1_FEM<ExecutionSpace,OutputValueType,PointValueType> );
 
-    else if ( (basis_type == "HGrad") && (cell_type == "Hexahedron") && (basis_order == 2) )
-      basis = Teuchos::rcp( new Intrepid2::Basis_HGRAD_HEX_C2_FEM<ExecutionSpace,OutputValueType,PointValueType> );
-
-    else if ( (basis_type == "HGrad") && (cell_type == "Hexahedron") && (basis_order > 2) )
+    else if ( (basis_type == "HGrad") && (cell_type == "Hexahedron") && (basis_order > 1) )
       basis = Teuchos::rcp( new Intrepid2::Basis_HGRAD_HEX_Cn_FEM<ExecutionSpace,OutputValueType,PointValueType>(basis_order, point_type) );
     
     else if ( (basis_type == "HCurl") && (cell_type == "Hexahedron") && (basis_order == 1) )
@@ -172,10 +165,7 @@ namespace panzer {
     else if ( (basis_type == "HGrad") && (cell_type == "Tetrahedron") && (basis_order == 1) )
       basis = Teuchos::rcp( new Intrepid2::Basis_HGRAD_TET_C1_FEM<ExecutionSpace,OutputValueType,PointValueType> );
 
-    else if ( (basis_type == "HGrad") && (cell_type == "Tetrahedron") && (basis_order == 2) )
-      basis = Teuchos::rcp( new Intrepid2::Basis_HGRAD_TET_C2_FEM<ExecutionSpace,OutputValueType,PointValueType> );
-
-    else if ( (basis_type == "HGrad") && (cell_type == "Tetrahedron") && (basis_order > 2) )
+    else if ( (basis_type == "HGrad") && (cell_type == "Tetrahedron") && (basis_order > 1) )
       basis = Teuchos::rcp( new Intrepid2::Basis_HGRAD_TET_Cn_FEM<ExecutionSpace,OutputValueType,PointValueType>(basis_order, point_type) );
 
     else if ( (basis_type == "HCurl") && (cell_type == "Tetrahedron") && (basis_order == 1) )
@@ -193,10 +183,7 @@ namespace panzer {
     else if ( (basis_type == "HGrad") && (cell_type == "Quadrilateral") && (basis_order == 1) )
       basis = Teuchos::rcp( new Intrepid2::Basis_HGRAD_QUAD_C1_FEM<ExecutionSpace,OutputValueType,PointValueType> );
 
-    else if ( (basis_type == "HGrad") && (cell_type == "Quadrilateral") && (basis_order == 2) )
-      basis = Teuchos::rcp( new Intrepid2::Basis_HGRAD_QUAD_C2_FEM<ExecutionSpace,OutputValueType,PointValueType> );
-
-    else if ( (basis_type == "HGrad") && (cell_type == "Quadrilateral") && (basis_order > 2) )
+    else if ( (basis_type == "HGrad") && (cell_type == "Quadrilateral") && (basis_order > 1) )
       basis = Teuchos::rcp( new Intrepid2::Basis_HGRAD_QUAD_Cn_FEM<ExecutionSpace,OutputValueType,PointValueType>(basis_order, point_type) );
 
     else if ( (basis_type == "HCurl") && (cell_type == "Quadrilateral") && (basis_order == 1) )
@@ -214,10 +201,7 @@ namespace panzer {
     else if ( (basis_type == "HGrad") && (cell_type == "Triangle") && (basis_order == 1) )
       basis = Teuchos::rcp( new Intrepid2::Basis_HGRAD_TRI_C1_FEM<ExecutionSpace,OutputValueType,PointValueType> );
     
-    else if ( (basis_type == "HGrad") && (cell_type == "Triangle") && (basis_order == 2) )
-      basis = Teuchos::rcp( new Intrepid2::Basis_HGRAD_TRI_C2_FEM<ExecutionSpace,OutputValueType,PointValueType> );
-    
-    else if ( (basis_type == "HGrad") && (cell_type == "Triangle") && (basis_order > 2) )
+    else if ( (basis_type == "HGrad") && (cell_type == "Triangle") && (basis_order > 1) )
       basis = Teuchos::rcp( new Intrepid2::Basis_HGRAD_TRI_Cn_FEM<ExecutionSpace,OutputValueType,PointValueType>(basis_order, point_type) );
     
     else if ( (basis_type == "HCurl") && (cell_type == "Triangle") && (basis_order == 1) )
@@ -235,7 +219,7 @@ namespace panzer {
     else if ( (basis_type == "HGrad") && (cell_type == "Line") && (basis_order == 1) )
       basis = Teuchos::rcp( new Intrepid2::Basis_HGRAD_LINE_C1_FEM<ExecutionSpace,OutputValueType,PointValueType> );
 
-    else if ( (basis_type == "HGrad") && (cell_type == "Line") && (basis_order >= 2) )
+    else if ( (basis_type == "HGrad") && (cell_type == "Line") && (basis_order > 1) )
       basis = Teuchos::rcp( new Intrepid2::Basis_HGRAD_LINE_Cn_FEM<ExecutionSpace,OutputValueType,PointValueType>(basis_order, point_type) );
     
     TEUCHOS_TEST_FOR_EXCEPTION(Teuchos::is_null(basis), std::runtime_error,

--- a/packages/panzer/disc-fe/test/evaluator_tests/dof_basistobasis.cpp
+++ b/packages/panzer/disc-fe/test/evaluator_tests/dof_basistobasis.cpp
@@ -234,26 +234,26 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL(dof_pointfield,value,EvalType)
   auto t_h = Kokkos::create_mirror_view(t.get_view());
   Kokkos::deep_copy(t_h, t.get_view());
   TEST_FLOATING_EQUALITY(ScalarT(t_h(0,0)),ScalarT(s_h(0,0)),tol);
-  TEST_FLOATING_EQUALITY(ScalarT(t_h(0,1)),ScalarT(s_h(0,1)),tol);
-  TEST_FLOATING_EQUALITY(ScalarT(t_h(0,2)),ScalarT(s_h(0,2)),tol);
-  TEST_FLOATING_EQUALITY(ScalarT(t_h(0,3)),ScalarT(s_h(0,3)),tol);
+  TEST_FLOATING_EQUALITY(ScalarT(t_h(0,2)),ScalarT(s_h(0,1)),tol);
+  TEST_FLOATING_EQUALITY(ScalarT(t_h(0,8)),ScalarT(s_h(0,2)),tol);
+  TEST_FLOATING_EQUALITY(ScalarT(t_h(0,6)),ScalarT(s_h(0,3)),tol);
 
   TEST_FLOATING_EQUALITY(ScalarT(t_h(1,0)),ScalarT(s_h(1,0)),tol);
-  TEST_FLOATING_EQUALITY(ScalarT(t_h(1,1)),ScalarT(s_h(1,1)),tol);
-  TEST_FLOATING_EQUALITY(ScalarT(t_h(1,2)),ScalarT(s_h(1,2)),tol);
-  TEST_FLOATING_EQUALITY(ScalarT(t_h(1,3)),ScalarT(s_h(1,3)),tol);
+  TEST_FLOATING_EQUALITY(ScalarT(t_h(1,2)),ScalarT(s_h(1,1)),tol);
+  TEST_FLOATING_EQUALITY(ScalarT(t_h(1,8)),ScalarT(s_h(1,2)),tol);
+  TEST_FLOATING_EQUALITY(ScalarT(t_h(1,6)),ScalarT(s_h(1,3)),tol);
 
-  TEST_FLOATING_EQUALITY(ScalarT(t_h(0,4)),ScalarT(1.5),tol);
+  TEST_FLOATING_EQUALITY(ScalarT(t_h(0,1)),ScalarT(1.5),tol);
   TEST_FLOATING_EQUALITY(ScalarT(t_h(0,5)),ScalarT(2.0),tol);
-  TEST_FLOATING_EQUALITY(ScalarT(t_h(0,6)),ScalarT(1.5),tol);
-  TEST_FLOATING_EQUALITY(ScalarT(t_h(0,7)),ScalarT(1.0),tol);
-  TEST_FLOATING_EQUALITY(ScalarT(t_h(0,8)),ScalarT(1.5),tol);
+  TEST_FLOATING_EQUALITY(ScalarT(t_h(0,4)),ScalarT(1.5),tol);
+  TEST_FLOATING_EQUALITY(ScalarT(t_h(0,3)),ScalarT(1.0),tol);
+  TEST_FLOATING_EQUALITY(ScalarT(t_h(0,7)),ScalarT(1.5),tol);
 
-  TEST_FLOATING_EQUALITY(ScalarT(t_h(1,4)),ScalarT(2.5),tol);
+  TEST_FLOATING_EQUALITY(ScalarT(t_h(1,1)),ScalarT(2.5),tol);
   TEST_FLOATING_EQUALITY(ScalarT(t_h(1,5)),ScalarT(3.0),tol);
-  TEST_FLOATING_EQUALITY(ScalarT(t_h(1,6)),ScalarT(2.5),tol);
-  TEST_FLOATING_EQUALITY(ScalarT(t_h(1,7)),ScalarT(2.0),tol);
-  TEST_FLOATING_EQUALITY(ScalarT(t_h(1,8)),ScalarT(2.5),tol);
+  TEST_FLOATING_EQUALITY(ScalarT(t_h(1,4)),ScalarT(2.5),tol);
+  TEST_FLOATING_EQUALITY(ScalarT(t_h(1,3)),ScalarT(2.0),tol);
+  TEST_FLOATING_EQUALITY(ScalarT(t_h(1,7)),ScalarT(2.5),tol);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
@trilinos/panzer @trilinos/intrepid2 

## Motivation
HGRAD_*_C2 is missing some method implementations, and Intrepid2 would like to deprecate the quadratic elements in favor of n-th order elements.