### PR TITLE
PyTrilinos: Add a cmake define for HAVE_TPETRA_INST_INT_LONG_LONG.

### DIFF
--- a/packages/PyTrilinos/cmake/PyTrilinos_config.h.in
+++ b/packages/PyTrilinos/cmake/PyTrilinos_config.h.in
@@ -116,6 +116,9 @@
 /* Define if want to build with Tpetra enabled */
 #cmakedefine HAVE_PYTRILINOS_TPETRA
 
+/* Define if want to build with Tpetra long long support enabled */
+#cmakedefine HAVE_PYTRILINOS_TPETRA_INST_INT_LONG_LONG
+
 /* Define if want to build with TriUtils enabled */
 #cmakedefine HAVE_PYTRILINOS_TRIUTILS
 
@@ -123,7 +126,7 @@
 
 /* PyTrilinos ordinal types */
 
-#ifdef HAVE_TPETRA_INST_INT_LONG_LONG
+#ifdef HAVE_PYTRILINOS_TPETRA_INST_INT_LONG_LONG
 #define PYTRILINOS_GLOBAL_ORD long long
 #else
 #define PYTRILINOS_GLOBAL_ORD int

--- a/packages/PyTrilinos/src/CMakeLists.txt
+++ b/packages/PyTrilinos/src/CMakeLists.txt
@@ -80,6 +80,12 @@ IF(PyTrilinos_ENABLE_NOX)
   ENDIF()
 ENDIF()
 
+IF(PyTrilinos_ENABLE_Tpetra)
+  IF(Tpetra_INST_INT_LONG_LONG)
+    SET(HAVE_PYTRILINOS_TPETRA_INST_INT_LONG_LONG ON)
+  ENDIF()
+ENDIF()
+
 #
 # Build the PyTrilinos configuration file
 TRIBITS_CONFIGURE_FILE(PyTrilinos_config.h)

--- a/packages/PyTrilinos/src/Tpetra.i
+++ b/packages/PyTrilinos/src/Tpetra.i
@@ -1477,7 +1477,7 @@ public:
 // Concrete scalar types for Tpetra classes //
 //////////////////////////////////////////////
 %tpetra_scalars(int       , int   )
-#ifdef HAVE_TPETRA_INST_INT_LONG_LONG
+#ifdef HAVE_PYTRILINOS_TPETRA_INST_INT_LONG_LONG
 %tpetra_scalars(long long , long  )
 #endif
 %tpetra_scalars(double    , double)


### PR DESCRIPTION
@trilinos/pytrilinos

## Related Issues

Fixes #10362
Closes #10363

## Testing

I tested the build with the configuration described in #10362 as well as the configuration that exposed the original issue.