### PR TITLE
Tempus: Cleanup Validation of ParameterLists

### DIFF
--- a/packages/piro/src/Piro_TempusSolverForwardOnly_Def.hpp
+++ b/packages/piro/src/Piro_TempusSolverForwardOnly_Def.hpp
@@ -131,14 +131,13 @@ void Piro::TempusSolverForwardOnly<Scalar>::initialize(
 
   RCP<Teuchos::ParameterList> tempusPL = sublist(appParams, "Tempus", true);
 
-  // this only works if the stepper is "Forward Euler".for now just
-  // disable validation
-  // tempusPL->validateParameters(*getValidTempusParameters(),0);
-
   //
   *out << "\nD) Create the stepper and integrator for the forward problem ...\n";
   //
 
+  // Validation of Parameters in tempusPL is done through each objects
+  // "create" function, e.g., createIntegratorBasic, createStepper,
+  // and createTimeStepControl.
   fwdStateIntegrator = Tempus::createIntegratorBasic(tempusPL, in_model);
 
 

--- a/packages/tempus/src/Tempus_IntegratorBasic_decl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorBasic_decl.hpp
@@ -31,7 +31,7 @@ class IntegratorBasic : virtual public Tempus::Integrator<Scalar>
 {
 public:
 
-  /// Default constructor that requires a subsequent, ??? , setStepper, and initialize calls.
+  /// Default constructor (requires calls to setModel and setSolutionHistory for initial conditions before calling initialize() to be fully constructed).
   IntegratorBasic();
 
   /// Full constructor

--- a/packages/tempus/src/Tempus_TimeStepControlStrategyBasicVS.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategyBasicVS.hpp
@@ -296,12 +296,11 @@ createTimeStepControlStrategyBasicVS(
   if (pList == Teuchos::null || pList->numParams() == 0) return tscs;
 
   TEUCHOS_TEST_FOR_EXCEPTION(
-    pList->get<std::string>("Strategy Type", "Basic VS") != "Basic VS",
-    std::logic_error,
+    pList->get<std::string>("Strategy Type") != "Basic VS", std::logic_error,
     "Error - Strategy Type != 'Basic VS'.  (='"
     +pList->get<std::string>("Strategy Type")+"')\n");
 
-  pList->validateParametersAndSetDefaults(*tscs->getValidParameters(), 0);
+  pList->validateParametersAndSetDefaults(*tscs->getValidParameters());
 
   tscs->setAmplFactor(  pList->get<double>("Amplification Factor"));
   tscs->setReductFactor(pList->get<double>("Reduction Factor"));

--- a/packages/tempus/src/Tempus_TimeStepControlStrategyComposite.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategyComposite.hpp
@@ -193,8 +193,7 @@ createTimeStepControlStrategyComposite(
   std::vector<std::string> tscsList;
 
   TEUCHOS_TEST_FOR_EXCEPTION(
-    pList->get<std::string>("Strategy Type", "Composite") !=
-      "Composite", std::logic_error,
+    pList->get<std::string>("Strategy Type") != "Composite", std::logic_error,
     "Error - Strategy Type != 'Composite'.  (='"
     +pList->get<std::string>("Strategy Type")+"')\n");
 
@@ -227,7 +226,7 @@ createTimeStepControlStrategyComposite(
   // For each sublist name tokenized, add the TSCS
   for ( auto tscsName: tscsList) {
     RCP<ParameterList> pl =
-      Teuchos::rcp(new ParameterList(pList->sublist(tscsName)));
+      Teuchos::rcp(new ParameterList(pList->sublist(tscsName, true)));
 
     auto strategyType = pl->get<std::string>("Strategy Type", "Unknown");
     if (strategyType == "Constant") {

--- a/packages/tempus/src/Tempus_TimeStepControlStrategyConstant.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategyConstant.hpp
@@ -183,12 +183,11 @@ createTimeStepControlStrategyConstant(
   if (pList == Teuchos::null || pList->numParams() == 0) return tscs;
 
   TEUCHOS_TEST_FOR_EXCEPTION(
-    pList->get<std::string>("Strategy Type", "Constant") != "Constant",
-    std::logic_error,
+    pList->get<std::string>("Strategy Type") != "Constant", std::logic_error,
     "Error - Strategy Type != 'Constant'.  (='"
     +pList->get<std::string>("Strategy Type")+"')\n");
 
-  pList->validateParametersAndSetDefaults(*tscs->getValidParameters(), 0);
+  pList->validateParametersAndSetDefaults(*tscs->getValidParameters());
 
   tscs->setConstantTimeStep(pList->get<double>("Time Step"));
 

--- a/packages/tempus/src/Tempus_TimeStepControlStrategyIntegralController.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategyIntegralController.hpp
@@ -292,7 +292,7 @@ createTimeStepControlStrategyIntegralController(
   if (pList == Teuchos::null || pList->numParams() == 0) return tscs;
 
   TEUCHOS_TEST_FOR_EXCEPTION(
-    pList->get<std::string>("Strategy Type", "Integral Controller") !=
+    pList->get<std::string>("Strategy Type") !=
       "Integral Controller", std::logic_error,
     "Error - Strategy Type != 'Integral Controller'.  (='"
     +pList->get<std::string>("Strategy Type")+"')\n");

--- a/packages/tempus/src/Tempus_TimeStepControl_impl.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControl_impl.hpp
@@ -931,7 +931,7 @@ Teuchos::RCP<TimeStepControl<Scalar> > createTimeStepControl(
 
   if ( !pList->isParameter("Time Step Control Strategy") ) {
 
-    tsc->setTimeStepControlStrategy();  // i.e, set default Constant timestep strategy.
+    tsc->setTimeStepControlStrategy();  // i.e., set default Constant timestep strategy.
 
   } else {
 

--- a/packages/tempus/test/DIRK/Tempus_DIRKTest.cpp
+++ b/packages/tempus/test/DIRK/Tempus_DIRKTest.cpp
@@ -147,6 +147,9 @@ TEUCHOS_UNIT_TEST(DIRK, ParameterList)
         Teuchos::rcp_const_cast<Teuchos::ParameterList>(
           integrator->getStepper()->getValidParameters());
 
+      // Do not worry about "Description" as it is documentation.
+      defaultPL->remove("Description");
+
       bool pass = haveSameValuesSorted(*stepperPL, *defaultPL, true);
       if (!pass) {
         std::cout << std::endl;
@@ -165,6 +168,9 @@ TEUCHOS_UNIT_TEST(DIRK, ParameterList)
       RCP<ParameterList> defaultPL =
         Teuchos::rcp_const_cast<Teuchos::ParameterList>(
           integrator->getStepper()->getValidParameters());
+
+      // Do not worry about "Description" as it is documentation.
+      defaultPL->remove("Description");
 
       // These Steppers have 'Initial Condition Consistency = Consistent'
       // set as the default, so the ParameterList has been modified by


### PR DESCRIPTION
Validation of Parameters in ParameterLists is done through
each objects "create" function for the given ParameterList,
e.g., createIntegratorBasic, createStepper, and
createTimeStepControl.  This allows multiple sub-ParameterLists
with different names to exist (e.g., multiple integrators, and
steppers).  Only sub-ParameterLists being used will be validated.
This allows multiple sub-ParameterLists to coexist and be easily
switched between.

@trilinos/tempus 

## Motivation
Improve validation of ParameterLists.

## Related Issues

* Closes #10371 

## Stakeholder Feedback
Will have @glhenni look at this.

## Testing
Fixed existing test, which should sufficient.