### PR TITLE
NOX: fix doxygen documentation for MT linesearch

### DIFF
--- a/packages/nox/src/NOX_LineSearch_MoreThuente.H
+++ b/packages/nox/src/NOX_LineSearch_MoreThuente.H
@@ -138,11 +138,11 @@ namespace LineSearch {
   <B> Implementation </B> <br>
   This line search can be called via NOX::LineSearch::Manager.
 
-  This line search is used if "More'-Thuente2" is the "Method" in the
+  This line search is used if "More'-Thuente" is the "Method" in the
   "Line Search" sublist. (See NOX::LineSearch::Manager for details.)
 
   The following parameters can be specified for this line search in
-  the "More'-Thuente2" sublist of the "Line Search" sublist:
+  the "More'-Thuente" sublist of the "Line Search" sublist:
 
   - "Sufficient Decrease Condition" - Choice to use for the sufficient decrease condition. Options are "Ared/Pred" or "Armijo-Goldstein" (defaults to "Armijo-Goldstein").<br>
   1. "Armijo-Goldstein" conditions: \f$ f(x_{n-1}+ \lambda s) \le f(x_{n-1}) +\alpha \lambda f'(x_{n-1}) \f$ <br>


### PR DESCRIPTION
## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Fix error in doxygen documentation for More'-Thuente line search.

Closes #1520 

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
N/A

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->