### PR TITLE
panzer: check for error finding element block specified for response evaluation

### DIFF
--- a/packages/panzer/disc-fe/src/responses/Panzer_ResponseLibrary_impl.hpp
+++ b/packages/panzer/disc-fe/src/responses/Panzer_ResponseLibrary_impl.hpp
@@ -466,7 +466,11 @@ buildResponseEvaluators(
      }
 
      // we must find at least one physics block
-     // TEUCHOS_ASSERT(!failure);
+     TEUCHOS_TEST_FOR_EXCEPTION(
+        failure, std::runtime_error,
+        "panzer::ResponseLibrary::buildResponseEvaluators: "
+        << "No physics blocks found for element block '" << wd.getElementBlock() << "'!"
+    )
      if(!failure)
        requiredWorksetDesc.push_back(wd);
    }


### PR DESCRIPTION

@trilinos/panzer
@rppawlo 

If an element block specified for evaluation of a response is not a valid element block, then the current behavior is that no error is thrown and that element block is essentially ignored. For drekar, I would like to have an exception thrown if the input file contains a response with an invalid element block. The change here will have the desired effect and does not cause any errors in current drekar tests or the panzer tests when I ran them. @rppawlo Do you think this change will cause any issues for other codes, or is this ok?
