### PR TITLE
Stokhos: Fixing #10388

### DIFF
--- a/packages/stokhos/src/sacado/kokkos/vector/Sacado_MP_Vector_ops.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/Sacado_MP_Vector_ops.hpp
@@ -43,7 +43,12 @@
 #include <ostream>      // for std::ostream
 
 #ifdef __CUDACC__
-#include <math_functions.h>
+    #include <cuda_runtime_api.h>
+    // including math functions via math_functions.h is deprecated in cuda version >= 10.0
+    // the deprecation warning indicates to use cuda_runtime_api.h instead
+    #if CUDART_VERSION < 10000
+        #include <math_functions.h>
+    #endif
 #endif
 
 /*


### PR DESCRIPTION
@trilinos/stokhos

This patches solves #10388: Stokhos: avoid deprecation warnings when compiling with cuda >= 10.0