### PR TITLE
Ifpack2: add comm barriers separating perf regions

### DIFF
--- a/packages/ifpack2/test/belos/build_precond.hpp
+++ b/packages/ifpack2/test/belos/build_precond.hpp
@@ -64,7 +64,8 @@ build_precond (Teuchos::ParameterList& test_params,
   Teuchos::Time timer_init("Init preconditioner");
   Teuchos::Time timer("Compute preconditioner");
   Teuchos::Time timer2("Compute preconditioner (reuse)");
-  const int myRank = A->getRowMap ()->getComm ()->getRank ();
+  auto comm = A->getRowMap ()->getComm ();
+  const int myRank = comm->getRank ();
 
   RCP<FancyOStream> out = getFancyOStream (rcpFromRef (cout));
 
@@ -89,12 +90,14 @@ build_precond (Teuchos::ParameterList& test_params,
   if (myRank == 0) {
     *out << "Configuring, initializing, and computing Ifpack2 preconditioner" << endl;
   }
+  comm->barrier();
   {
     OSTab tab (*out);
     prec->setParameters (tif_params);
     {
       Teuchos::TimeMonitor timeMon (timer_init);
       prec->initialize ();
+      comm->barrier();
     }
      if (myRank == 0) {
       *out << "Time Init: " << timer_init.totalElapsedTime() << endl;
@@ -102,6 +105,7 @@ build_precond (Teuchos::ParameterList& test_params,
     {
       Teuchos::TimeMonitor timeMon (timer);
       prec->compute ();
+      comm->barrier();
     }
     if (myRank == 0) {
       *out << "Finished computing Ifpack2 preconditioner" << endl;
@@ -113,6 +117,7 @@ build_precond (Teuchos::ParameterList& test_params,
 	{
 	  Teuchos::TimeMonitor timeMon (timer2);
 	  prec->compute ();
+          comm->barrier();
 	}
 	if (myRank == 0) {
 	  *out << "Finished recomputing Ifpack2 preconditioner" 


### PR DESCRIPTION
In Ifpack2_tif_belos (performance test driver), add comm/MPI barriers around the preconditioner initialize and compute. For e.g. RILUK, the init/compute on each rank runs independently, and also can vary a lot between ranks. Processes that finished earlier would enter a different TimeMonitor block and wait a long time at collectives, so that waiting time would appear under the other timer. This caused the StackedTimer output to be misleading. With these barriers, the preconditioner setup is now timed as the max over all processors so any bottlenecks there will show up clearly in the StackedTimer.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/ifpack2 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Needed to set up Belos+Ifpack2 performance testing on SierraTF problems.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->