### PR TITLE
Ctest: Disabling randomly failing tests

### DIFF
--- a/cmake/std/PullRequestLinuxCommonTestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxCommonTestingSettings.cmake
@@ -60,6 +60,9 @@ set (Piro_EpetraSolver_MPI_4_DISABLE ON CACHE BOOL "Set by default for PR testin
 # Disable tests that timeout in PR testing until it can be fixed (#4614)
 set (PanzerAdaptersSTK_PoissonInterfaceExample_2d_diffsideids_MPI_1_DISABLE ON CACHE BOOL "Set by default for PR testing")
 
+# Disable tests that randomly fail in PR testing (#10412)
+set (PanzerAdaptersSTK_PoissonInterfaceTpetra_2d_diffsideids_MPI_1_DISABLE ON CACHE BOOL "Set by default for PR testing")
+
 # Disable long-failing Anazazi test until it can be fixed (#3585)
 set (Anasazi_Epetra_OrthoManagerGenTester_0_MPI_4_DISABLE ON CACHE BOOL "Set by default for PR testing")
 

--- a/cmake/std/PullRequestLinuxWeaverTestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxWeaverTestingSettings.cmake
@@ -128,6 +128,9 @@ set (KokkosCore_UnitTest_Cuda_MPI_1_EXTRA_ARGS
   "--gtest_filter=-cuda.debug_pin_um_to_host:cuda.debug_serial_execution"
   CACHE STRING "Temporary disable for CUDA PR testing")
 
+# Disable randomly failing test (#10420)
+set (Krino_krino_unit_MPI_4_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
+
 # Disable a few failing tests for initial release of Cuda 10.2.2 PR build
 set (EpetraExt_inout_test_LL_MPI_4_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
 set (EpetraExt_inout_test_MPI_4_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")

--- a/cmake/std/PullRequestLinuxWeaverUvmOffTestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxWeaverUvmOffTestingSettings.cmake
@@ -131,6 +131,9 @@ set (KokkosCore_UnitTest_Cuda_MPI_1_EXTRA_ARGS
   "--gtest_filter=-cuda.debug_pin_um_to_host:cuda.debug_serial_execution"
   CACHE STRING "Temporary disable for CUDA PR testing")
 
+# Disable randomly failing test (#10420)
+set (Krino_krino_unit_MPI_4_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
+
 # Disable a few failing tests for initial release of Cuda 10.2.2 PR build
 set (EpetraExt_inout_test_LL_MPI_4_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
 set (EpetraExt_inout_test_MPI_4_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")


### PR DESCRIPTION
Tests in Panzer and Krino are blocking PRs across the board.

Issues:#10412, #10420