### PR TITLE
Tpetra: Use numVectors==1 specialization for local parts of norms

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_normImpl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_normImpl.hpp
@@ -151,18 +151,37 @@ lclNormImpl (const RV& normsOut,
   }
   else { // lclNumRows != 0
     if (constantStride) {
-      if (whichNorm == NORM_INF) {
-        KokkosBlas::nrminf (normsOut, X);
-      }
-      else if (whichNorm == NORM_ONE) {
-        KokkosBlas::nrm1 (normsOut, X);
-      }
-      else if (whichNorm == NORM_TWO) {
-        KokkosBlas::nrm2_squared (normsOut, X);
+      if (X.extent(1) == 1) {
+        auto normsOut_0d = Kokkos::subview (normsOut, 0);
+        auto X_1d = Kokkos::subview (X, Kokkos::ALL(), 0);
+        if (whichNorm == NORM_INF) {
+          KokkosBlas::nrminf (normsOut_0d, X_1d);
+        }
+        else if (whichNorm == NORM_ONE) {
+          KokkosBlas::nrm1 (normsOut_0d, X_1d);
+        }
+        else if (whichNorm == NORM_TWO) {
+          KokkosBlas::nrm2_squared (normsOut_0d, X_1d);
+        }
+        else {
+          TEUCHOS_TEST_FOR_EXCEPTION
+            (true, std::logic_error, "Should never get here!");
+        }
       }
       else {
-        TEUCHOS_TEST_FOR_EXCEPTION
-          (true, std::logic_error, "Should never get here!");
+        if (whichNorm == NORM_INF) {
+          KokkosBlas::nrminf (normsOut, X);
+        }
+        else if (whichNorm == NORM_ONE) {
+          KokkosBlas::nrm1 (normsOut, X);
+        }
+        else if (whichNorm == NORM_TWO) {
+          KokkosBlas::nrm2_squared (normsOut, X);
+        }
+        else {
+          TEUCHOS_TEST_FOR_EXCEPTION
+            (true, std::logic_error, "Should never get here!");
+        }
       }
     }
     else { // not constant stride


### PR DESCRIPTION
@trilinos/tpetra 

## Motivation
Use the KokkosKernels specialization for 1-vector MVs for the local parts of norms.

For a run on 32 GPUs, I see 

**Before**
```
Belos::MVT::MvNorm: 1.4864 - 3.84499% [3604] {min=1.47393, max=1.49435, std dev=0.00603344} <1, 4, 1, 1, 3, 3, 7, 3, 1, 8>
```
**After**
```
Belos::MVT::MvNorm: 0.19496 - 0.527566% [3604] {min=0.177702, max=0.205975, std dev=0.00839741} <2, 2, 2, 1, 5, 5, 0, 2, 9, 4>
```