### PR TITLE
ShyLU Basker : 

### DIFF
--- a/packages/shylu/shylu_node/basker/src/shylubasker_order_btf.hpp
+++ b/packages/shylu/shylu_node/basker/src/shylubasker_order_btf.hpp
@@ -709,6 +709,12 @@ namespace BaskerNS
         Options.run_nd_on_leaves = BASKER_FALSE;
       }
       #endif
+      if (Options.replace_tiny_pivot == BASKER_TRUE) {
+        if(Options.verbose == BASKER_TRUE) {
+          printf("Basker: turning off replace-tiny-pivot option since one block (to identify singular matrix)\n");
+        }
+        Options.replace_tiny_pivot = BASKER_FALSE;
+      }
       return 0;
     }
 

--- a/packages/shylu/shylu_node/basker/src/shylubasker_order_btf.hpp
+++ b/packages/shylu/shylu_node/basker/src/shylubasker_order_btf.hpp
@@ -704,7 +704,7 @@ namespace BaskerNS
       #if !defined (HAVE_SHYLU_NODEBASKER_METIS) & !defined(HAVE_SHYLU_NODEBASKER_SCOTCH)
       if (Options.run_nd_on_leaves == BASKER_TRUE) {
         if(Options.verbose == BASKER_TRUE) {
-          printf("Basker: turning ND on leaves since no METIS nor SCOTCH (hence sequential)\n");
+          printf("Basker: turning off ND-on-leaves option since no METIS nor SCOTCH (hence sequential)\n");
         }
         Options.run_nd_on_leaves = BASKER_FALSE;
       }

--- a/packages/shylu/shylu_node/basker/src/shylubasker_order_btf.hpp
+++ b/packages/shylu/shylu_node/basker/src/shylubasker_order_btf.hpp
@@ -700,13 +700,15 @@ namespace BaskerNS
       printf("Basker: break_into_parts2 - short circuit for single block case\n");
     #endif
       BTF_A = A;
-      //Options.btf = BASKER_FALSE; // NDE: how is this handled???
-      //if (A.nrow < Options.btf_large) {
-      //  btf_tabs_offset = 0;
-      //} else {
-      //  btf_tabs_offset = 1;
-      //}
       btf_tabs_offset = 1;
+      #if !defined (HAVE_SHYLU_NODEBASKER_METIS) & !defined(HAVE_SHYLU_NODEBASKER_SCOTCH)
+      if (Options.run_nd_on_leaves == BASKER_TRUE) {
+        if(Options.verbose == BASKER_TRUE) {
+          printf("Basker: turning ND on leaves since no METIS nor SCOTCH (hence sequential)\n");
+        }
+        Options.run_nd_on_leaves = BASKER_FALSE;
+      }
+      #endif
       return 0;
     }
 
@@ -725,7 +727,8 @@ namespace BaskerNS
     Int scol_top          = 0;      // starting column of the BTF_A bloc
     Int scol              = M.ncol; // starting column of the BTF_C blocks (end of BTF_A block)
     Int blk_idx           = nblks;  // start at lower right corner block, move left and up the diagonal
-    #if 0 // use Metis on a large block even with one thread
+    #if !defined (HAVE_SHYLU_NODEBASKER_METIS) & !defined(HAVE_SHYLU_NODEBASKER_SCOTCH)
+    // use Metis on a large block even with one thread
     if (num_threads == 1) {
       // Short circuit for single thread = no big block A
       scol = 0;

--- a/packages/shylu/shylu_node/basker/test/CMakeLists.txt
+++ b/packages/shylu/shylu_node/basker/test/CMakeLists.txt
@@ -6,10 +6,12 @@ IF(Kokkos_ENABLE_OPENMP)
         SOURCES simple_test_check.cpp
      )
 
-    TRIBITS_ADD_EXECUTABLE(
+    TRIBITS_ADD_EXECUTABLE_AND_TEST(
         singular_matrix_check
         NOEXEPREFIX
         SOURCES singular_matrix_check.cpp
+        NUM_MPI_PROCS 1
+        FAIL_REGULAR_EXPRESSION "  FAILED  "
      )
 
     TRIBITS_ADD_EXECUTABLE(

--- a/packages/shylu/shylu_node/basker/test/singular_matrix_check.cpp
+++ b/packages/shylu/shylu_node/basker/test/singular_matrix_check.cpp
@@ -15,6 +15,7 @@ int main(int argc, char* argv[])
   Int m = 2;
   Int n = 2;
   Int nnz = 4;
+  int error = 0;
 
   Kokkos::InitArguments init_args;
   const Int nthreads = 1;
@@ -74,14 +75,22 @@ int main(int argc, char* argv[])
       std::cout << "Setting Threads:" << nthreads << std::endl;
 
       double stime = myTime();
-      int error = mybasker.Symbolic(m,n,nnz,col_ptr,row_idx,val);
+      error = mybasker.Symbolic(m,n,nnz,col_ptr,row_idx,val);
       std::cout << "Done with Symbolic"
                 << "\nError code: " << error
                 << "\nTime: " 
         	      << totalTime(stime, myTime()) << std::endl;
 
       double ftime = myTime();
-      error = mybasker.Factor(m,n,nnz,col_ptr,row_idx,val);
+      try
+      {
+        error = mybasker.Factor(m,n,nnz,col_ptr,row_idx,val);
+      }
+      catch (std::runtime_error& e)
+      {
+        std::cout << " ** Factor threw exception **" << std::endl;
+        error = 1;
+      }
       std::cout << "Done with Factor"
                 << "\nError code: " << error
                 << "\nTime: " 
@@ -132,5 +141,5 @@ int main(int argc, char* argv[])
   }
   Kokkos::finalize();
 
-
+  return (error == 0 ? 1 : 0);
 } //end main


### PR DESCRIPTION

@trilinos/shylu 

## Motivation
This PR fixes a couple of issues that @hkthorn reported in ShyLU-Basker

- It should not throw exception "need Metis or Scotch" when running with one thread
- "replace tiny pivot" option is turned off when we only have one block (to identify singular matrix)


## Testing

We added `singular_matrix_check` to ctest.

## Additional Information

We also removed some commented-out code.
