### PR TITLE
Phalanx: static_assert that inner view in a view-of-views is unmanaged

### DIFF
--- a/packages/phalanx/src/Phalanx_KokkosViewOfViews.hpp
+++ b/packages/phalanx/src/Phalanx_KokkosViewOfViews.hpp
@@ -56,7 +56,11 @@ namespace PHX {
       : view_host_(name,extents...),
         view_device_(name,extents...),
         device_view_is_synced_(false)
-    {}
+    {
+      // Inner view must be unmanaged if the outerview is not using UVM!
+      static_assert(InnerViewType::memory_traits::is_unmanaged,
+                    "ERROR: PHX::ViewOfViews - Inner view must be unmanaged!");
+    }
 
     ~ViewOfViews()
     {


### PR DESCRIPTION
safety check

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Enforces that inners views are unmanaged - needed when UVM is disabled.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
covered by view of views unit test

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->