### PR TITLE
Fix for krino on vortex

### DIFF
--- a/packages/krino/krino/unit_tests/Akri_Unit_main.cpp
+++ b/packages/krino/krino/unit_tests/Akri_Unit_main.cpp
@@ -18,13 +18,13 @@
 #include <Kokkos_Core.hpp>
 
 int main(int argc, char **argv) {
-  Kokkos::ScopeGuard guard(argc, argv);
-
   sierra::Env::set_input_file_required(false);
 
   testing::InitGoogleTest(&argc, argv);
 
   krino::Startup startup__(argc, argv);
+
+  Kokkos::ScopeGuard guard(argc, argv);
 
   stk::unit_test_util::create_parallel_output(sierra::Env::parallel_rank());
 


### PR DESCRIPTION
Thanks to Evan Harvey for help diagnosing and fixing this issue.
MPI_Init must be called before any Kokkos or cuda code.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/framework 

## Motivation
Fix for krino in PR# 10365.
<!--- 
Fix for PR# 10365.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->