### PR TITLE
Implements the achievedTol interface for the GmresPolySolMgr

### DIFF
--- a/packages/belos/src/BelosGmresPolySolMgr.hpp
+++ b/packages/belos/src/BelosGmresPolySolMgr.hpp
@@ -152,9 +152,9 @@ template<class ScalarType, class MV, class OP>
 class GmresPolySolMgr : public SolverManager<ScalarType,MV,OP> {
 private:
 
-  typedef MultiVecTraits<ScalarType,MV> MVT;
-  typedef Teuchos::ScalarTraits<ScalarType> STS;
   typedef typename Teuchos::ScalarTraits<ScalarType>::magnitudeType MagnitudeType;
+
+  typedef Teuchos::ScalarTraits<MagnitudeType> MTS;
   typedef Belos::GmresPolyOp<ScalarType,MV,OP> gmres_poly_t;
   typedef Belos::GmresPolyMv<ScalarType,MV>    gmres_poly_mv_t;
 
@@ -216,6 +216,26 @@ public:
   /*! \brief Get a parameter list containing the current parameters for this object.
    */
   Teuchos::RCP<const Teuchos::ParameterList> getCurrentParameters() const override { return params_; }
+
+  /*! \brief Tolerance achieved by the last \c solve() invocation.
+    
+     This is the maximum over all right-hand sides' achieved
+     convergence tolerances, and is set whether or not the solve
+     actually managed to achieve the desired convergence tolerance.
+    
+     \warning This solver manager may be use as either a polynomial
+       preconditioned iterative method or a polynomial preconditioner.
+       In the later case, where a static polynomial is being applied
+       through each call to solve(), there is not an outer solve that 
+       can provide the achieved tolerance.
+     \warning This result may not be meaningful if there was a loss
+       of accuracy during the outer solve.  You should first call \c
+       isLOADetected() to check for a loss of accuracy during the
+       last solve.
+  */
+    MagnitudeType achievedTol() const override {
+      return achievedTol_;
+    }
 
   /*! \brief Return the timers for this object.
    *
@@ -331,7 +351,7 @@ private:
 #endif
 
   // Current solver values.
-  MagnitudeType polyTol_;
+  MagnitudeType polyTol_, achievedTol_;
   int maxDegree_, numIters_;
   int verbosity_;
   bool hasOuterSolver_;
@@ -363,6 +383,7 @@ template<class ScalarType, class MV, class OP>
 GmresPolySolMgr<ScalarType,MV,OP>::GmresPolySolMgr () :
   outputStream_ (Teuchos::rcp(outputStream_default_,false)),
   polyTol_ (DefaultSolverParameters::polyTol),
+  achievedTol_(MTS::zero()),
   maxDegree_ (maxDegree_default_),
   numIters_ (0),
   verbosity_ (verbosity_default_),
@@ -689,6 +710,7 @@ ReturnType GmresPolySolMgr<ScalarType,MV,OP>::solve ()
     ret = solver->solve();
     numIters_ = solver->getNumIters();
     loaDetected_ = solver->isLOADetected();
+    achievedTol_ = solver->achievedTol();
 
   } // if (hasOuterSolver_ && maxDegree_)
   else if (hasOuterSolver_) {
@@ -704,12 +726,14 @@ ReturnType GmresPolySolMgr<ScalarType,MV,OP>::solve ()
     ret = solver->solve();
     numIters_ = solver->getNumIters();
     loaDetected_ = solver->isLOADetected();
+    achievedTol_ = solver->achievedTol();
 
   }
   else if (maxDegree_) {
 
     // Apply the polynomial to the current linear system
     poly_Op_->ApplyPoly( *problem_->getRHS(), *problem_->getLHS() );
+    achievedTol_ = MTS::one();
 
   }
 

--- a/packages/belos/test/BlockGmres/test_hybrid_gmres_complex_hb.cpp
+++ b/packages/belos/test/BlockGmres/test_hybrid_gmres_complex_hb.cpp
@@ -249,8 +249,9 @@ int main(int argc, char *argv[]) {
     //
     Belos::ReturnType ret = solver->solve();
     //
-    // Compute actual residuals.
+    std::cout << "Belos::GmresPolySolMgr returned achievedTol: " << solver->achievedTol() << std::endl << std::endl;
     //
+    // Compute actual residuals.
     RCP<MyMultiVec<ST> > temp = rcp( new MyMultiVec<ST>(dim,numrhs) );
     OPT::Apply( *A, *soln, *temp );
     MVT::MvAddMv( one, *rhs, -one, *temp, *temp );


### PR DESCRIPTION

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/belos 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

A user request has been received for the Gmres polynomial preconditioned
solver to return the achieved tolerance from the outer iterative method.
This is best done through the achievedTol() method in the abstract solver
manager interface, that is utilized by most of the iterative methods.
This commit implements that function call and includes a test of that call
to ensure it works.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
OSX GCC11 Serial

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->