### PR TITLE
aztecoo: Fix memory corruption in the AZ_pgmres function

### DIFF
--- a/packages/aztecoo/src/az_aztec.h
+++ b/packages/aztecoo/src/az_aztec.h
@@ -728,7 +728,7 @@ void PREFIX AZ_SLAIC1_F77(int * , int *, float *, float *, float *, float *,
 
   extern int AZ_adjust_N_nz_to_fit_memory(int N, int , int);
 
-  extern char *AZ_allocate(unsigned int iii);
+  extern char *AZ_allocate(size_t iii);
 
   extern char *AZ_allocate_or_free(void *ptr, unsigned int size, int action);
 
@@ -1021,7 +1021,7 @@ void PREFIX AZ_SLAIC1_F77(int * , int *, float *, float *, float *, float *,
   extern void  AZ_lower_tsolve(double x[],int  , double l[], int il[],
                                int jl[],  double y[] );
 
-  extern double *AZ_manage_memory(unsigned int size, int action, int type,
+  extern double *AZ_manage_memory(size_t size, int action, int type,
                                   char *name, int *status);
 
   extern struct AZ_MATRIX_STRUCT *AZ_matrix_create(int local);
@@ -1195,7 +1195,7 @@ void PREFIX AZ_SLAIC1_F77(int * , int *, float *, float *, float *, float *,
                                 int proc_config[], int bigN, int chunk,
                                 int input_option);
 
-  extern char *AZ_realloc(void *ptr, unsigned int size);
+  extern char *AZ_realloc(void *ptr, size_t size);
 
   extern void AZ_recover_sol_params(int instance, int **sub_options,
                                     double **sub_params, double **sub_status, AZ_MATRIX **sub_matrix,


### PR DESCRIPTION
## aztecoo: Fix memory corruption in the AZ_pgmres function

@trilinos/aztecoo

Summary of changes:

    * Correct signatures of the functions AZ_manage_memory, AZ_allocate and AZ_realloc;
    * Correct type of the size field of the mem_ptr and widget structs;
    * Correct types of some local variables;
    * Correct conversions of/to integer types.
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->

## Motivation

Issue #10334
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
N/A
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->