### PR TITLE
belos: add missing parameter to getValidParameters in GmresPolySolMgr

### DIFF
--- a/packages/belos/src/BelosGmresPolySolMgr.hpp
+++ b/packages/belos/src/BelosGmresPolySolMgr.hpp
@@ -433,6 +433,8 @@ GmresPolySolMgr<ScalarType,MV,OP>::getValidParameters() const
       "The maximum degree allowed for any GMRES polynomial.");
     pl->set("Outer Solver", static_cast<const char *>(outerSolverType_default_),
       "The outer solver that this polynomial is used to precondition.");
+    pl->set("Outer Solver Params", Teuchos::ParameterList(),
+      "Parameter list for the outer solver.");
     pl->set("Verbosity", static_cast<int>(verbosity_default_),
       "What type(s) of solver information should be outputted\n"
       "to the output stream.");
@@ -464,7 +466,7 @@ setParameters (const Teuchos::RCP<Teuchos::ParameterList>& params)
     params_ = Teuchos::parameterList (*getValidParameters ());
   }
   else {
-    params->validateParameters (*getValidParameters ());
+    params->validateParameters (*getValidParameters (),0);
   }
 
   // Check which Gmres polynomial to use


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/belos
@jennloe 

## Motivation
In trying to use the `BelosGmresPolySolMgr` object in Sierra/Aria, it was uncovered that the "Outer Solver Param" argument was not in the set of valid arguments provided. This was causing the object to throw when trying to give non-default outer solver parameters,

## Stakeholder Feedback


## Testing
Tested by running this change through the testing infrastructure.
