### PR TITLE
Tpetra: Deprecate Distributor's useDistinctTags option

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.cpp
@@ -890,7 +890,9 @@ void DistributorPlan::setParameterList(const Teuchos::RCP<Teuchos::ParameterList
 #endif
     const Details::EDistributorSendType sendType =
       getIntegralValue<Details::EDistributorSendType> (*plist, "Send type");
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
     const bool useDistinctTags = plist->get<bool> ("Use distinct tags");
+#endif
 
 #ifdef TPETRA_ENABLE_DEPRECATED_CODE
     {
@@ -929,8 +931,8 @@ void DistributorPlan::setParameterList(const Teuchos::RCP<Teuchos::ParameterList
 #endif
 #ifdef TPETRA_ENABLE_DEPRECATED_CODE
     barrierBetweenRecvSend_ = barrierBetween;
-#endif
     useDistinctTags_ = useDistinctTags;
+#endif
 
     // ParameterListAcceptor semantics require pointer identity of the
     // sublist passed to setParameterList(), so we save the pointer.
@@ -963,8 +965,8 @@ DistributorPlan::getValidParameters() const
 
 #ifdef TPETRA_ENABLE_DEPRECATED_CODE
   const bool barrierBetween = Details::barrierBetween_default;
-#endif
   const bool useDistinctTags = Details::useDistinctTags_default;
+#endif
 
   Array<std::string> sendTypes = distributorSendTypes ();
   const std::string defaultSendType ("Send");
@@ -991,9 +993,11 @@ DistributorPlan::getValidParameters() const
   setStringToIntegralParameter<Details::EDistributorSendType> ("Send type",
       defaultSendType, "When using MPI, the variant of send to use in "
       "do[Reverse]Posts()", sendTypes(), sendTypeEnums(), plist.getRawPtr());
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
   plist->set ("Use distinct tags", useDistinctTags, "Whether to use distinct "
       "MPI message tags for different code paths.  Highly recommended"
       " to avoid message collisions.");
+#endif
   plist->set ("Timer Label","","Label for Time Monitor output");
 
 #ifdef TPETRA_ENABLE_DEPRECATED_CODE

--- a/packages/tpetra/core/src/Tpetra_Distributor.cpp
+++ b/packages/tpetra/core/src/Tpetra_Distributor.cpp
@@ -195,8 +195,8 @@ namespace Tpetra {
 
 #ifdef TPETRA_ENABLE_DEPRECATED_CODE
     const bool barrierBetween = Details::barrierBetween_default;
-#endif
     const bool useDistinctTags = Details::useDistinctTags_default;
+#endif
     const bool debug = tpetraDistributorDebugDefault;
 
     Array<std::string> sendTypes = distributorSendTypes ();
@@ -223,9 +223,11 @@ namespace Tpetra {
     setStringToIntegralParameter<Details::EDistributorSendType> ("Send type",
       defaultSendType, "When using MPI, the variant of send to use in "
       "do[Reverse]Posts()", sendTypes(), sendTypeEnums(), plist.getRawPtr());
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
     plist->set ("Use distinct tags", useDistinctTags, "Whether to use distinct "
                 "MPI message tags for different code paths.  Highly recommended"
                 " to avoid message collisions.");
+#endif
     plist->set ("Debug", debug, "Whether to print copious debugging output on "
                 "all processes.");
     plist->set ("Timer Label","","Label for Time Monitor output");
@@ -343,9 +345,9 @@ namespace Tpetra {
 #ifdef TPETRA_ENABLE_DEPRECATED_CODE
         << ", Barrier between receives and sends: "
         << (plan_.barrierBetweenRecvSend() ? "true" : "false")
-#endif
         << ", Use distinct tags: "
         << (plan_.useDistinctTags() ? "true" : "false")
+#endif
         << ", Debug: " << (verbose_ ? "true" : "false")
         << "}}";
     return out.str ();
@@ -460,9 +462,9 @@ namespace Tpetra {
 #ifdef TPETRA_ENABLE_DEPRECATED_CODE
             << "\"Barrier between receives and sends\": "
             << (plan_.barrierBetweenRecvSend() ? "true" : "false") << endl
-#endif
             << "\"Use distinct tags\": "
             << (plan_.useDistinctTags() ? "true" : "false") << endl
+#endif
             << "\"Debug\": " << (verbose_ ? "true" : "false") << endl;
       }
     } // if myRank == 0


### PR DESCRIPTION
@trilinos/tpetra 

## Motivation

Since the default is to use distinct tags for each code path,
this deprecation effectively is taking away the option for users
to ask Distributor to always use the same tag.

The more robust strategy of giving one unique tag per DistributorActor
should make useDistinctTags unnecessary.  Deprecating the option to
pass it in the parameter list lets us change it as needed later.

## Related Issues

* Related to #10308

## Testing
Manually tested a Tpetra build with deprecated code off on GCC 7.2.0, and did not see any failing tests.