### PR TITLE
Tpetra: ETI for import_and_extract_views

### DIFF
--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
@@ -3408,7 +3408,15 @@ template \
                      const Teuchos::RCP<const Map<LO, GO , NODE > >& rangeMap, \
                      const Teuchos::RCP<Teuchos::ParameterList>& params); \
 \
-  template struct MMdetails::AddKernels<SCALAR, LO, GO, NODE>;
+  template struct MMdetails::AddKernels<SCALAR, LO, GO, NODE>; \
+\
+  template void MMdetails::import_and_extract_views<SCALAR, LO, GO, NODE>(const CrsMatrix<SCALAR, LO, GO, NODE>& M, \
+                                                                          Teuchos::RCP<const Map<LO, GO, NODE> > targetMap, \
+                                                                          CrsMatrixStruct<SCALAR, LO, GO, NODE>& Mview, \
+                                                                          Teuchos::RCP<const Import<LO,GO, NODE> > prototypeImporter, \
+                                                                          bool userAssertsThereAreNoRemotes, \
+                                                                          const std::string& label, \
+                                                                          const Teuchos::RCP<Teuchos::ParameterList>& params);
 
 } //End namespace Tpetra
 


### PR DESCRIPTION
@trilinos/tpetra 

## Motivation
Issue #10416 appears to be caused by `import_and_extract_views` not being ETI'd. `import_and_extract_views` is used in a MueLu's ImportPerformance test. 