### PR TITLE
Phalanx: more v-of-v support

### DIFF
--- a/packages/phalanx/test/ViewOfViews/tPhalanxViewOfViews.cpp
+++ b/packages/phalanx/test/ViewOfViews/tPhalanxViewOfViews.cpp
@@ -81,10 +81,10 @@ TEUCHOS_UNIT_TEST(PhalanxViewOfViews,NewImpl) {
       Kokkos::deep_copy(b,3.0);
       Kokkos::deep_copy(c,4.0);
 
-      v_of_v.addView(a,0,0);
-      v_of_v.addView(b,0,1);
-      v_of_v.addView(c,1,0);
-      v_of_v.addView(d,1,1);
+      v_of_v.setView(a,0,0);
+      v_of_v.setView(b,0,1);
+      v_of_v.setView(c,1,0);
+      v_of_v.setView(d,1,1);
     }
 
     v_of_v.syncHostToDevice();


### PR DESCRIPTION
## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
add default ctor and initialization method to follow empire object construction path.
improved documentation

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->


## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Unit test for V-of-V udpated for changes.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->