### PR TITLE
Ifpack2, FastILU : add an option to use KokkosKernels::sptrsv

### DIFF
--- a/packages/ifpack2/src/Ifpack2_Details_FastILU_Base_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_FastILU_Base_decl.hpp
@@ -200,6 +200,7 @@ template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
     {
       Params() {}
       Params(const Teuchos::ParameterList& pL, std::string precType);
+      bool standard_sptrsv;
       int nFact;
       int nTrisol;
       int level;

--- a/packages/ifpack2/src/Ifpack2_Details_FastILU_Base_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_FastILU_Base_def.hpp
@@ -356,6 +356,7 @@ FastILU_Base<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 Params::getDefaults()
 {
   Params p;
+  p.standard_sptrsv = false;
   p.nFact = 5;
   p.nTrisol = 1;
   p.level = 0;
@@ -388,6 +389,11 @@ Params::Params(const Teuchos::ParameterList& pL, std::string precType)
     else 
       TYPE_ERROR("sweeps", "int");
   }
+  if(pL.isParameter("standard triangular solve"))
+  {
+      standard_sptrsv = pL.get<bool>("standard triangular solve");
+  }
+
   //"triangular solve iterations" aka nTrisol
   if(pL.isParameter("triangular solve iterations"))
   {

--- a/packages/ifpack2/src/Ifpack2_Details_Fic_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Fic_def.hpp
@@ -87,9 +87,8 @@ initLocalPrec()
 {
   auto nRows = this->mat_->getLocalNumRows();
   auto& p = this->params_;
-  localPrec_ = Teuchos::rcp(new LocalFIC(this->localRowPtrs_, this->localColInds_, this->localValues_, nRows,
-        p.nFact, p.nTrisol, p.level, p.omega,
-        p.shift, p.guessFlag ? 1 : 0, p.blockSize));
+  localPrec_ = Teuchos::rcp(new LocalFIC(this->localRowPtrs_, this->localColInds_, this->localValues_, nRows, p.standard_sptrsv,
+                                         p.nFact, p.nTrisol, p.level, p.omega, p.shift, p.guessFlag ? 1 : 0, p.blockSize));
   localPrec_->initialize();
   this->initTime_ = localPrec_->getInitializeTime();
 }

--- a/packages/ifpack2/src/Ifpack2_Details_Fildl_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Fildl_def.hpp
@@ -87,9 +87,8 @@ initLocalPrec()
 {
   auto nRows = this->mat_->getLocalNumRows();
   auto& p = this->params_;
-  localPrec_ = Teuchos::rcp(new LocalFILDL(this->localRowPtrs_, this->localColInds_, this->localValues_, nRows,
-        p.nFact, p.nTrisol, p.level, p.omega,
-        p.shift, p.guessFlag ? 1 : 0, p.blockSize));
+  localPrec_ = Teuchos::rcp(new LocalFILDL(this->localRowPtrs_, this->localColInds_, this->localValues_, nRows, p.standard_sptrsv,
+                                           p.nFact, p.nTrisol, p.level, p.omega, p.shift, p.guessFlag ? 1 : 0, p.blockSize));
   localPrec_->initialize();
   this->initTime_ = localPrec_->getInitializeTime();
 }

--- a/packages/ifpack2/src/Ifpack2_Details_Filu_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Filu_def.hpp
@@ -94,9 +94,8 @@ initLocalPrec()
 {
   auto nRows = this->mat_->getLocalNumRows();
   auto& p = this->params_;
-  localPrec_ = Teuchos::rcp(new LocalFILU(this->localRowPtrs_, this->localColInds_, this->localValues_, nRows,
-        p.nFact, p.nTrisol, p.level, p.omega,
-        p.shift, p.guessFlag ? 1 : 0, p.blockSize));
+  localPrec_ = Teuchos::rcp(new LocalFILU(this->localRowPtrs_, this->localColInds_, this->localValues_, nRows, p.standard_sptrsv, 
+                                          p.nFact, p.nTrisol, p.level, p.omega, p.shift, p.guessFlag ? 1 : 0, p.blockSize));
   localPrec_->initialize();
   this->initTime_ = localPrec_->getInitializeTime();
 }

--- a/packages/ifpack2/test/belos/5w_bel_tif_FIC_sptrsv.xml
+++ b/packages/ifpack2/test/belos/5w_bel_tif_FIC_sptrsv.xml
@@ -1,0 +1,23 @@
+<ParameterList name="test_params">
+  <Parameter name="mm_file" type="string" value="5w.mtx"/>
+  <Parameter name="rhs_mm_file" type="string" value="5w.vec"/>
+
+  <Parameter name="solver_type" type="string" value="PseudoBlock Gmres"/>
+  <ParameterList name="Belos">
+    <!-- "Num Blocks" is the krylov subspace size, or iters-per-restart. -->
+    <Parameter name="Num Blocks" type="int" value="3"/>
+    <Parameter name="Verbosity" type="int" value="33"/>
+    <Parameter name="Maximum Iterations" type="int" value="300"/>
+    <Parameter name="Orthogonalization" type="string" value="ICGS"/>
+    <Parameter name="Output Style" type="int" value="1"/>
+    <Parameter name="Output Frequency" type="int" value="1"/>
+  </ParameterList>
+
+  <Parameter name="Ifpack2::Preconditioner" type="string" value="FAST_IC"/>
+  <ParameterList name="Ifpack2">
+    <Parameter name="level" type="int" value="2"/>
+    <Parameter name="standard triangular solve" type="bool" value="true"/>
+  </ParameterList>
+
+  <Parameter name="expectNumIters" type="int" value="4"/>
+</ParameterList>

--- a/packages/ifpack2/test/belos/5w_bel_tif_FILDL_sptrsv.xml
+++ b/packages/ifpack2/test/belos/5w_bel_tif_FILDL_sptrsv.xml
@@ -1,0 +1,23 @@
+<ParameterList name="test_params">
+  <Parameter name="mm_file" type="string" value="5w.mtx"/>
+  <Parameter name="rhs_mm_file" type="string" value="5w.vec"/>
+
+  <Parameter name="solver_type" type="string" value="PseudoBlock Gmres"/>
+  <ParameterList name="Belos">
+    <!-- "Num Blocks" is the krylov subspace size, or iters-per-restart. -->
+    <Parameter name="Num Blocks" type="int" value="3"/>
+    <Parameter name="Verbosity" type="int" value="33"/>
+    <Parameter name="Maximum Iterations" type="int" value="300"/>
+    <Parameter name="Orthogonalization" type="string" value="ICGS"/>
+    <Parameter name="Output Style" type="int" value="1"/>
+    <Parameter name="Output Frequency" type="int" value="1"/>
+  </ParameterList>
+
+  <Parameter name="Ifpack2::Preconditioner" type="string" value="FAST_ILDL"/>
+  <ParameterList name="Ifpack2">
+    <Parameter name="level" type="int" value="2"/>
+    <Parameter name="standard triangular solve" type="bool" value="true"/>
+  </ParameterList>
+
+  <Parameter name="expectNumIters" type="int" value="4"/>
+</ParameterList>

--- a/packages/ifpack2/test/belos/5w_bel_tif_FILU_sptrsv.xml
+++ b/packages/ifpack2/test/belos/5w_bel_tif_FILU_sptrsv.xml
@@ -1,0 +1,23 @@
+<ParameterList name="test_params">
+  <Parameter name="mm_file" type="string" value="5w.mtx"/>
+  <Parameter name="rhs_mm_file" type="string" value="5w.vec"/>
+
+  <Parameter name="solver_type" type="string" value="PseudoBlock Gmres"/>
+  <ParameterList name="Belos">
+    <!-- "Num Blocks" is the krylov subspace size, or iters-per-restart. -->
+    <Parameter name="Num Blocks" type="int" value="3"/>
+    <Parameter name="Verbosity" type="int" value="33"/>
+    <Parameter name="Maximum Iterations" type="int" value="300"/>
+    <Parameter name="Orthogonalization" type="string" value="ICGS"/>
+    <Parameter name="Output Style" type="int" value="1"/>
+    <Parameter name="Output Frequency" type="int" value="1"/>
+  </ParameterList>
+
+  <Parameter name="Ifpack2::Preconditioner" type="string" value="FAST_ILU"/>
+  <ParameterList name="Ifpack2">
+    <Parameter name="level" type="int" value="2"/>
+    <Parameter name="standard triangular solve" type="bool" value="true"/>
+  </ParameterList>
+
+  <Parameter name="expectNumIters" type="int" value="4"/>
+</ParameterList>

--- a/packages/ifpack2/test/belos/CMakeLists.txt
+++ b/packages/ifpack2/test/belos/CMakeLists.txt
@@ -50,8 +50,11 @@ TRIBITS_COPY_FILES_TO_BINARY_DIR(Ifpack2BelosCopyFiles
   test_RILUK_calore1_mm.xml 
   test_Cheby_calore1_mm.xml
   test_FILU_calore1_mm.xml
+  test_FILU_calore1_mm_sptrsv.xml
   test_FIC_calore1_mm.xml
+  test_FIC_calore1_mm_sptrsv.xml
   test_FILDL_calore1_mm.xml
+  test_FILDL_calore1_mm_sptrsv.xml
   test_Jacobi_nos1_hb.xml 
   test_2_Jacobi_nos1_hb.xml 
   test_Jacobi_gcrodr_nos1_hb.xml 
@@ -82,15 +85,21 @@ TRIBITS_COPY_FILES_TO_BINARY_DIR(Ifpack2BelosCopyFiles
   test_ILUT_tfqmr_small_sym_mm.xml
   test_tfqmr_small_sym_mm.xml
   test_FILU_tfqmr_small_sym_mm.xml
+  test_FILU_tfqmr_small_sym_mm_sptrsv.xml
   test_FIC_tfqmr_small_sym_mm.xml
+  test_FIC_tfqmr_small_sym_mm_sptrsv.xml
   test_FILDL_tfqmr_small_sym_mm.xml
+  test_FILDL_tfqmr_small_sym_mm_sptrsv.xml
   test_ILUT_tfqmr_calore1_mm.xml
   5w.mtx 
   5w.vec
   5w_bel_tif_ILUT.xml
   5w_bel_tif_FILU.xml
+  5w_bel_tif_FILU_sptrsv.xml
   5w_bel_tif_FIC.xml
+  5w_bel_tif_FIC_sptrsv.xml
   5w_bel_tif_FILDL.xml
+  5w_bel_tif_FILDL_sptrsv.xml
   5w_missing_diag.mtx 
   5w_missing_diag_ILUT.xml
   5w_bel_tif_RILUK_0.xml 
@@ -99,8 +108,11 @@ TRIBITS_COPY_FILES_TO_BINARY_DIR(Ifpack2BelosCopyFiles
   test_bordered_DIAG_small.xml 
   test_minres_bordered_DIAG_small.xml 
   test_FILU_small_sym_sing.xml
+  test_FILU_small_sym_sing_sptrsv.xml
   test_FIC_small_sym_sing.xml
+  test_FIC_small_sym_sing_sptrsv.xml
   test_FILDL_small_sym_sing.xml
+  test_FILDL_small_sym_sing_sptrsv.xml
   small_sym_sing.mtx consist_rhs.vec small_null.vec
   mueluMatrix.mtx
   mueluMatrix_rhs.mtx
@@ -413,24 +425,41 @@ ENDIF()
 IF(Tpetra_INST_DOUBLE AND Ifpack2_ENABLE_ShyLU_NodeFastILU)
   #calore1
   TRIBITS_ADD_TEST(
-    tif_belos Ifpack2BelosCopyFiles
+    tif_belos
     NAME FILU_calore1
     ARGS "--xml_file=test_FILU_calore1_mm.xml"
     COMM serial mpi
     NUM_MPI_PROCS 1
     STANDARD_PASS_OUTPUT
   )
+
   TRIBITS_ADD_TEST(
-    tif_belos Ifpack2BelosCopyFiles
+    tif_belos
+    NAME FILU_calore1_sptrsv
+    ARGS "--xml_file=test_FILU_calore1_mm_sptrsv.xml"
+    COMM serial mpi
+    NUM_MPI_PROCS 1
+    STANDARD_PASS_OUTPUT
+  )
+  TRIBITS_ADD_TEST(
+    tif_belos
     NAME FILDL_calore1
     ARGS "--xml_file=test_FILDL_calore1_mm.xml"
     COMM serial mpi
     NUM_MPI_PROCS 1
     STANDARD_PASS_OUTPUT
   )
+  TRIBITS_ADD_TEST(
+    tif_belos
+    NAME FILDL_calore1_sptrsv
+    ARGS "--xml_file=test_FILDL_calore1_mm_sptrsv.xml"
+    COMM serial mpi
+    NUM_MPI_PROCS 1
+    STANDARD_PASS_OUTPUT
+  )
   #5w
   TRIBITS_ADD_TEST(
-    tif_belos Ifpack2BelosCopyFiles
+    tif_belos
     NAME FILU_5w
     ARGS "--xml_file=5w_bel_tif_FILU.xml"
     COMM serial mpi
@@ -438,7 +467,15 @@ IF(Tpetra_INST_DOUBLE AND Ifpack2_ENABLE_ShyLU_NodeFastILU)
     STANDARD_PASS_OUTPUT
   )
   TRIBITS_ADD_TEST(
-    tif_belos Ifpack2BelosCopyFiles
+    tif_belos
+    NAME FILU_5w_sptrsv
+    ARGS "--xml_file=5w_bel_tif_FILU_sptrsv.xml"
+    COMM serial mpi
+    NUM_MPI_PROCS 1
+    STANDARD_PASS_OUTPUT
+  )
+  TRIBITS_ADD_TEST(
+    tif_belos
     NAME FIC_5w
     ARGS "--xml_file=5w_bel_tif_FIC.xml"
     COMM serial mpi
@@ -446,16 +483,32 @@ IF(Tpetra_INST_DOUBLE AND Ifpack2_ENABLE_ShyLU_NodeFastILU)
     STANDARD_PASS_OUTPUT
   )
   TRIBITS_ADD_TEST(
-    tif_belos Ifpack2BelosCopyFiles
+    tif_belos
+    NAME FIC_5w_sptrsv
+    ARGS "--xml_file=5w_bel_tif_FIC_sptrsv.xml"
+    COMM serial mpi
+    NUM_MPI_PROCS 1
+    STANDARD_PASS_OUTPUT
+  )
+  TRIBITS_ADD_TEST(
+    tif_belos
     NAME FILDL_5w
     ARGS "--xml_file=5w_bel_tif_FILDL.xml"
     COMM serial mpi
     NUM_MPI_PROCS 1
     STANDARD_PASS_OUTPUT
   )
+  TRIBITS_ADD_TEST(
+    tif_belos
+    NAME FILDL_5w_sptrsv
+    ARGS "--xml_file=5w_bel_tif_FILDL_sptrsv.xml"
+    COMM serial mpi
+    NUM_MPI_PROCS 1
+    STANDARD_PASS_OUTPUT
+  )
   #small_sym
   TRIBITS_ADD_TEST(
-    tif_belos Ifpack2BelosCopyFiles
+    tif_belos
     NAME FILU_small_sym
     ARGS "--xml_file=test_FILU_tfqmr_small_sym_mm.xml"
     COMM serial mpi
@@ -463,7 +516,15 @@ IF(Tpetra_INST_DOUBLE AND Ifpack2_ENABLE_ShyLU_NodeFastILU)
     STANDARD_PASS_OUTPUT
   )
   TRIBITS_ADD_TEST(
-    tif_belos Ifpack2BelosCopyFiles
+    tif_belos
+    NAME FILU_small_sym_sptrsv
+    ARGS "--xml_file=test_FILU_tfqmr_small_sym_mm_sptrsv.xml"
+    COMM serial mpi
+    NUM_MPI_PROCS 1
+    STANDARD_PASS_OUTPUT
+  )
+  TRIBITS_ADD_TEST(
+    tif_belos
     NAME FIC_small_sym
     ARGS "--xml_file=test_FIC_tfqmr_small_sym_mm.xml"
     COMM serial mpi
@@ -471,16 +532,32 @@ IF(Tpetra_INST_DOUBLE AND Ifpack2_ENABLE_ShyLU_NodeFastILU)
     STANDARD_PASS_OUTPUT
   )
   TRIBITS_ADD_TEST(
-    tif_belos Ifpack2BelosCopyFiles
+    tif_belos
+    NAME FIC_small_sym_sptrsv
+    ARGS "--xml_file=test_FIC_tfqmr_small_sym_mm_sptrsv.xml"
+    COMM serial mpi
+    NUM_MPI_PROCS 1
+    STANDARD_PASS_OUTPUT
+  )
+  TRIBITS_ADD_TEST(
+    tif_belos
     NAME FILDL_small_sym
     ARGS "--xml_file=test_FILDL_tfqmr_small_sym_mm.xml"
     COMM serial mpi
     NUM_MPI_PROCS 1
     STANDARD_PASS_OUTPUT
   )
+  TRIBITS_ADD_TEST(
+    tif_belos
+    NAME FILDL_small_sym_sptrsv
+    ARGS "--xml_file=test_FILDL_tfqmr_small_sym_mm_sptrsv.xml"
+    COMM serial mpi
+    NUM_MPI_PROCS 1
+    STANDARD_PASS_OUTPUT
+  )
   #small_sym_sing
   TRIBITS_ADD_TEST(
-    tif_belos Ifpack2BelosCopyFiles
+    tif_belos
     NAME FILU_small_sym_sing
     ARGS "--xml_file=test_FILU_small_sym_sing.xml"
     COMM serial mpi
@@ -488,7 +565,15 @@ IF(Tpetra_INST_DOUBLE AND Ifpack2_ENABLE_ShyLU_NodeFastILU)
     STANDARD_PASS_OUTPUT
   )
   TRIBITS_ADD_TEST(
-    tif_belos Ifpack2BelosCopyFiles
+    tif_belos
+    NAME FILU_small_sym_sing_sptrsv
+    ARGS "--xml_file=test_FILU_small_sym_sing_sptrsv.xml"
+    COMM serial mpi
+    NUM_MPI_PROCS 1
+    STANDARD_PASS_OUTPUT
+  )
+  TRIBITS_ADD_TEST(
+    tif_belos
     NAME FIC_small_sym_sing
     ARGS "--xml_file=test_FIC_small_sym_sing.xml"
     COMM serial mpi
@@ -496,9 +581,25 @@ IF(Tpetra_INST_DOUBLE AND Ifpack2_ENABLE_ShyLU_NodeFastILU)
     STANDARD_PASS_OUTPUT
   )
   TRIBITS_ADD_TEST(
-    tif_belos Ifpack2BelosCopyFiles
+    tif_belos
+    NAME FIC_small_sym_sing_sptrsv
+    ARGS "--xml_file=test_FIC_small_sym_sing_sptrsv.xml"
+    COMM serial mpi
+    NUM_MPI_PROCS 1
+    STANDARD_PASS_OUTPUT
+  )
+  TRIBITS_ADD_TEST(
+    tif_belos
     NAME FILDL_small_sym_sing
     ARGS "--xml_file=test_FILDL_small_sym_sing.xml"
+    COMM serial mpi
+    NUM_MPI_PROCS 1
+    STANDARD_PASS_OUTPUT
+  )
+  TRIBITS_ADD_TEST(
+    tif_belos
+    NAME FILDL_small_sym_sing_sptrsv
+    ARGS "--xml_file=test_FILDL_small_sym_sing_sptrsv.xml"
     COMM serial mpi
     NUM_MPI_PROCS 1
     STANDARD_PASS_OUTPUT

--- a/packages/ifpack2/test/belos/test_FIC_calore1_mm_sptrsv.xml
+++ b/packages/ifpack2/test/belos/test_FIC_calore1_mm_sptrsv.xml
@@ -1,0 +1,24 @@
+<ParameterList name="test_params">
+  <Parameter name="mm_file"     type="string" value="calore1.mtx"/>
+  <Parameter name="rhs_mm_file" type="string" value="calore1_rhs.mtx"/>
+
+  <Parameter name="solver_type" type="string" value="Block Gmres"/>
+  <ParameterList name="Belos">
+    <!-- "Num Blocks" is the krylov subspace size, or iters-per-restart. -->
+    <Parameter name="Num Blocks" type="int" value="50"/>
+    <Parameter name="Verbosity" type="int" value="33"/>
+    <Parameter name="Output Style" type="int" value="1"/>
+    <Parameter name="Output Frequency" type="int" value="1"/>
+  </ParameterList>
+
+  <Parameter name="Ifpack2::Preconditioner" type="string" value="FAST_IC"/>
+  <ParameterList name="Ifpack2">
+    <Parameter name="level" type="int" value="2"/>
+    <Parameter name="shift" type="double" value="0.2"/>
+    <Parameter name="damping factor" type="double" value="0.6"/>
+    <Parameter name="sweeps" type="int" value="5"/>
+    <Parameter name="standard triangular solve" type="bool" value="true"/>
+  </ParameterList>
+
+  <Parameter name="expectNumIters" type="int" value="12"/>
+</ParameterList>

--- a/packages/ifpack2/test/belos/test_FIC_small_sym_sing_sptrsv.xml
+++ b/packages/ifpack2/test/belos/test_FIC_small_sym_sing_sptrsv.xml
@@ -1,0 +1,25 @@
+<ParameterList name="test_params">
+  <Parameter name="mm_file" type="string" value="small_sym_sing.mtx"/>
+  <Parameter name="rhs_mm_file" type="string" value="consist_rhs.vec"/>
+  <Parameter name="nullMvec_mm_file" type="string" value="small_null.vec"/>
+
+  <Parameter name="solver_type" type="string" value="Block CG"/>
+  <ParameterList name="Belos">
+    <Parameter name="Block Size" type="int" value="1"/>
+    <Parameter name="Convergence Tolerance" type="double" value=".0001"/>
+    <Parameter name="Verbosity" type="int" value="33"/>
+    <Parameter name="Maximum Iterations" type="int" value="4"/>
+    <Parameter name="Orthogonalization" type="string" value="ICGS"/>
+    <Parameter name="Output Style" type="int" value="1"/>
+    <Parameter name="Output Frequency" type="int" value="1"/>
+  </ParameterList>
+
+  <Parameter name="Ifpack2::Preconditioner" type="string" value="FAST_IC"/>
+  <ParameterList name="Ifpack2">
+    <Parameter name="level" type="int" value="1"/>
+    <Parameter name="damping factor" type="double" value="0.9"/>
+    <Parameter name="standard triangular solve" type="bool" value="true"/>
+  </ParameterList>
+
+  <Parameter name="expectNumIters" type="int" value="4"/>
+</ParameterList>

--- a/packages/ifpack2/test/belos/test_FIC_tfqmr_small_sym_mm_sptrsv.xml
+++ b/packages/ifpack2/test/belos/test_FIC_tfqmr_small_sym_mm_sptrsv.xml
@@ -1,0 +1,19 @@
+<ParameterList name="test_params">
+  <Parameter name="mm_file" type="string" value="small_sym.mtx"/>
+
+  <Parameter name="solver_type" type="string" value="TFQMR"/>
+  <ParameterList name="Belos">
+    <Parameter name="Verbosity" type="int" value="33"/>
+    <Parameter name="Output Style" type="int" value="1"/>
+    <Parameter name="Output Frequency" type="int" value="1"/>
+  </ParameterList>
+
+  <Parameter name="Ifpack2::Preconditioner" type="string" value="FAST_IC"/>
+  <ParameterList name="Ifpack2">
+    <Parameter name="level" type="int" value="1"/>
+    <Parameter name="damping factor" type="double" value="0.9"/>
+    <Parameter name="standard triangular solve" type="bool" value="true"/>
+  </ParameterList>
+
+  <Parameter name="expectNumIters" type="int" value="1"/>
+</ParameterList>

--- a/packages/ifpack2/test/belos/test_FILDL_calore1_mm_sptrsv.xml
+++ b/packages/ifpack2/test/belos/test_FILDL_calore1_mm_sptrsv.xml
@@ -1,0 +1,23 @@
+<ParameterList name="test_params">
+  <Parameter name="mm_file"     type="string" value="calore1.mtx"/>
+  <Parameter name="rhs_mm_file" type="string" value="calore1_rhs.mtx"/>
+
+  <Parameter name="solver_type" type="string" value="Block Gmres"/>
+  <ParameterList name="Belos">
+    <!-- "Num Blocks" is the krylov subspace size, or iters-per-restart. -->
+    <Parameter name="Num Blocks" type="int" value="50"/>
+    <Parameter name="Verbosity" type="int" value="33"/>
+    <Parameter name="Output Style" type="int" value="1"/>
+    <Parameter name="Output Frequency" type="int" value="1"/>
+  </ParameterList>
+
+  <Parameter name="Ifpack2::Preconditioner" type="string" value="FAST_ILDL"/>
+  <ParameterList name="Ifpack2">
+    <Parameter name="level" type="int" value="1"/>
+    <Parameter name="damping factor" type="double" value="0.6"/>
+    <Parameter name="sweeps" type="int" value="5"/>
+    <Parameter name="standard triangular solve" type="bool" value="true"/>
+  </ParameterList>
+
+  <Parameter name="expectNumIters" type="int" value="12"/>
+</ParameterList>

--- a/packages/ifpack2/test/belos/test_FILDL_small_sym_sing_sptrsv.xml
+++ b/packages/ifpack2/test/belos/test_FILDL_small_sym_sing_sptrsv.xml
@@ -1,0 +1,25 @@
+<ParameterList name="test_params">
+  <Parameter name="mm_file" type="string" value="small_sym_sing.mtx"/>
+  <Parameter name="rhs_mm_file" type="string" value="consist_rhs.vec"/>
+  <Parameter name="nullMvec_mm_file" type="string" value="small_null.vec"/>
+
+  <Parameter name="solver_type" type="string" value="Block CG"/>
+  <ParameterList name="Belos">
+    <Parameter name="Block Size" type="int" value="1"/>
+    <Parameter name="Convergence Tolerance" type="double" value=".0001"/>
+    <Parameter name="Verbosity" type="int" value="33"/>
+    <Parameter name="Maximum Iterations" type="int" value="4"/>
+    <Parameter name="Orthogonalization" type="string" value="ICGS"/>
+    <Parameter name="Output Style" type="int" value="1"/>
+    <Parameter name="Output Frequency" type="int" value="1"/>
+  </ParameterList>
+
+  <Parameter name="Ifpack2::Preconditioner" type="string" value="FAST_ILDL"/>
+  <ParameterList name="Ifpack2">
+    <Parameter name="level" type="int" value="1"/>
+    <Parameter name="damping factor" type="double" value="0.9"/>
+    <Parameter name="standard triangular solve" type="bool" value="true"/>
+  </ParameterList>
+
+  <Parameter name="expectNumIters" type="int" value="4"/>
+</ParameterList>

--- a/packages/ifpack2/test/belos/test_FILDL_tfqmr_small_sym_mm_sptrsv.xml
+++ b/packages/ifpack2/test/belos/test_FILDL_tfqmr_small_sym_mm_sptrsv.xml
@@ -1,0 +1,19 @@
+<ParameterList name="test_params">
+  <Parameter name="mm_file" type="string" value="small_sym.mtx"/>
+
+  <Parameter name="solver_type" type="string" value="TFQMR"/>
+  <ParameterList name="Belos">
+    <Parameter name="Verbosity" type="int" value="33"/>
+    <Parameter name="Output Style" type="int" value="1"/>
+    <Parameter name="Output Frequency" type="int" value="1"/>
+  </ParameterList>
+
+  <Parameter name="Ifpack2::Preconditioner" type="string" value="FAST_ILDL"/>
+  <ParameterList name="Ifpack2">
+    <Parameter name="level" type="int" value="1"/>
+    <Parameter name="damping factor" type="double" value="0.9"/>
+    <Parameter name="standard triangular solve" type="bool" value="true"/>
+  </ParameterList>
+
+  <Parameter name="expectNumIters" type="int" value="1"/>
+</ParameterList>

--- a/packages/ifpack2/test/belos/test_FILU_calore1_mm_sptrsv.xml
+++ b/packages/ifpack2/test/belos/test_FILU_calore1_mm_sptrsv.xml
@@ -1,0 +1,23 @@
+<ParameterList name="test_params">
+  <Parameter name="mm_file"     type="string" value="calore1.mtx"/>
+  <Parameter name="rhs_mm_file" type="string" value="calore1_rhs.mtx"/>
+
+  <Parameter name="solver_type" type="string" value="Block Gmres"/>
+  <ParameterList name="Belos">
+    <!-- "Num Blocks" is the krylov subspace size, or iters-per-restart. -->
+    <Parameter name="Num Blocks" type="int" value="50"/>
+    <Parameter name="Verbosity" type="int" value="33"/>
+    <Parameter name="Output Style" type="int" value="1"/>
+    <Parameter name="Output Frequency" type="int" value="1"/>
+  </ParameterList>
+
+  <Parameter name="Ifpack2::Preconditioner" type="string" value="FAST_ILU"/>
+  <ParameterList name="Ifpack2">
+    <Parameter name="level" type="int" value="1"/>
+    <Parameter name="damping factor" type="double" value="0.6"/>
+    <Parameter name="sweeps" type="int" value="5"/>
+    <Parameter name="standard triangular solve" type="bool" value="true"/>
+  </ParameterList>
+
+  <Parameter name="expectNumIters" type="int" value="12"/>
+</ParameterList>

--- a/packages/ifpack2/test/belos/test_FILU_small_sym_sing_sptrsv.xml
+++ b/packages/ifpack2/test/belos/test_FILU_small_sym_sing_sptrsv.xml
@@ -1,0 +1,25 @@
+<ParameterList name="test_params">
+  <Parameter name="mm_file" type="string" value="small_sym_sing.mtx"/>
+  <Parameter name="rhs_mm_file" type="string" value="consist_rhs.vec"/>
+  <Parameter name="nullMvec_mm_file" type="string" value="small_null.vec"/>
+
+  <Parameter name="solver_type" type="string" value="Block CG"/>
+  <ParameterList name="Belos">
+    <Parameter name="Block Size" type="int" value="1"/>
+    <Parameter name="Convergence Tolerance" type="double" value=".0001"/>
+    <Parameter name="Verbosity" type="int" value="33"/>
+    <Parameter name="Maximum Iterations" type="int" value="4"/>
+    <Parameter name="Orthogonalization" type="string" value="ICGS"/>
+    <Parameter name="Output Style" type="int" value="1"/>
+    <Parameter name="Output Frequency" type="int" value="1"/>
+  </ParameterList>
+
+  <Parameter name="Ifpack2::Preconditioner" type="string" value="FAST_ILU"/>
+  <ParameterList name="Ifpack2">
+    <Parameter name="level" type="int" value="1"/>
+    <Parameter name="damping factor" type="double" value="0.9"/>
+    <Parameter name="standard triangular solve" type="bool" value="true"/>
+  </ParameterList>
+
+  <Parameter name="expectNumIters" type="int" value="4"/>
+</ParameterList>

--- a/packages/ifpack2/test/belos/test_FILU_tfqmr_small_sym_mm_sptrsv.xml
+++ b/packages/ifpack2/test/belos/test_FILU_tfqmr_small_sym_mm_sptrsv.xml
@@ -1,0 +1,19 @@
+<ParameterList name="test_params">
+  <Parameter name="mm_file" type="string" value="small_sym.mtx"/>
+
+  <Parameter name="solver_type" type="string" value="TFQMR"/>
+  <ParameterList name="Belos">
+    <Parameter name="Verbosity" type="int" value="33"/>
+    <Parameter name="Output Style" type="int" value="1"/>
+    <Parameter name="Output Frequency" type="int" value="1"/>
+  </ParameterList>
+
+  <Parameter name="Ifpack2::Preconditioner" type="string" value="FAST_ILU"/>
+  <ParameterList name="Ifpack2">
+    <Parameter name="level" type="int" value="1"/>
+    <Parameter name="damping factor" type="double" value="0.9"/>
+    <Parameter name="standard triangular solve" type="bool" value="true"/>
+  </ParameterList>
+
+  <Parameter name="expectNumIters" type="int" value="1"/>
+</ParameterList>

--- a/packages/shylu/shylu_node/fastilu/src/shylu_fastic.hpp
+++ b/packages/shylu/shylu_node/fastilu/src/shylu_fastic.hpp
@@ -139,15 +139,23 @@ class FastICPrec
         ScalarArray xTemp;
         ScalarArray onesVector;
 
+        //This will have the continuation initial
+        //guess if guessFlag=1
         Teuchos::RCP<FastPrec> initGuessPrec;
 
+        // forward/backwar substitution for standard SpTrsv
+        using MemSpace = typename ExecSpace::memory_space;
+        using KernelHandle = KokkosKernels::Experimental::KokkosKernelsHandle <Ordinal, Ordinal, Scalar, ExecSpace, MemSpace, MemSpace >;
+        bool standard_sptrsv;
+        KernelHandle khL;
+        KernelHandle khLt;
 
     public:
-        FastICPrec(OrdinalArray &aRowMapIn, OrdinalArray &aColIdxIn, ScalarArray &aValIn, Ordinal nRow_,
-                Ordinal nFact_, Ordinal nTrisol_, Ordinal level_, Scalar omega_, 
-                Scalar shift_, Ordinal guessFlag_, Ordinal blkSz_)
+        FastICPrec(OrdinalArray &aRowMapIn, OrdinalArray &aColIdxIn, ScalarArray &aValIn, Ordinal nRow_, bool standard_sptrsv_,
+                   Ordinal nFact_, Ordinal nTrisol_, Ordinal level_, Scalar omega_, Scalar shift_, Ordinal guessFlag_, Ordinal blkSz_)
         {
             nRows = nRow_;
+            standard_sptrsv = standard_sptrsv_;
             nFact = nFact_;
             nTrisol = nTrisol_;
             computeTime = 0.0;
@@ -180,8 +188,8 @@ class FastICPrec
 
             if (level > 0)
             {
-                initGuessPrec = Teuchos::rcp(new FastPrec(aRowMapIn, aColIdxIn, aValIn, nRow_, 3, 5, 
-                            level_ - 1, omega_, shift_, guessFlag_, blkSz_));
+                initGuessPrec = Teuchos::rcp(new FastPrec(aRowMapIn, aColIdxIn, aValIn, nRow_, standard_sptrsv, 3, 5, 
+                                                          level_-1, omega_, shift_, guessFlag_, blkSz_));
             }
 
         }
@@ -850,6 +858,28 @@ class FastICPrec
             }
             Kokkos::deep_copy(diagElemsInv, diagElemsInv_);
             transposeL();
+
+            if (standard_sptrsv) {
+                #if defined(KOKKOSKERNELS_ENABLE_TPL_CUSPARSE)
+                KokkosSparse::Experimental::SPTRSVAlgorithm algo = KokkosSparse::Experimental::SPTRSVAlgorithm::SPTRSV_CUSPARSE;
+                #else
+                KokkosSparse::Experimental::SPTRSVAlgorithm algo = KokkosSparse::Experimental::SPTRSVAlgorithm::SEQLVLSCHD_TP1;
+                #endif
+                // setup L solve
+                khL.create_sptrsv_handle(algo, nRows, true);
+                #if defined(KOKKOSKERNELS_ENABLE_TPL_CUSPARSE)
+                KokkosSparse::Experimental::sptrsv_symbolic(&khL, lRowMap, lColIdx, lVal);
+                #else
+                KokkosSparse::Experimental::sptrsv_symbolic(&khL, lRowMap, lColIdx);
+                #endif
+                // setup Lt solve
+                khLt.create_sptrsv_handle(algo, nRows, false);
+                #if defined(KOKKOSKERNELS_ENABLE_TPL_CUSPARSE)
+                KokkosSparse::Experimental::sptrsv_symbolic(&khLt, ltRowMap, ltColIdx, ltVal);
+                #else
+                KokkosSparse::Experimental::sptrsv_symbolic(&khLt, ltRowMap, ltColIdx);
+                #endif
+            }
         }
 
         void apply(ScalarArray &x, ScalarArray &y)
@@ -862,9 +892,16 @@ class FastICPrec
             ExecSpace().fence();
 
             applyD(x, xTemp);
-            applyLIC(xTemp, y);
-            //applyDD(y, xTemp);
-            applyLT(y, xTemp);
+            if (standard_sptrsv) {
+                // solve with L
+                KokkosSparse::Experimental::sptrsv_solve(&khL, lRowMap, lColIdx, lVal, xTemp, y);
+                // solve with Lt
+                KokkosSparse::Experimental::sptrsv_solve(&khLt, ltRowMap, ltColIdx, ltVal, y, xTemp);
+            } else {
+                applyLIC(xTemp, y);
+                //applyDD(y, xTemp);
+                applyLT(y, xTemp);
+            }
             applyD(xTemp, y);
 
 //            ParCopyFunctor<Ordinal, Scalar, ExecSpace> parCopyFunctor2(nRows, y, xTemp);


### PR DESCRIPTION

@trilinos/ifpack2, @trilinos/shylu 

## Motivation

This PR adds an option to use KokkosKernels::sptrsv with FastILU

## Testing

This new option has been added to ctest in ifpack2/belos

## Additional Information

It also tries removing `Arguments are being passed in but not used.  UNPARSED_ARGUMENTS =` warning in CMakeLists.txt of ifpack2/test/belos with fastilu