### PR TITLE
KokkosKernels/Tpetra: Restore numVecs=1 BLAS path

### DIFF
--- a/packages/kokkos-kernels/src/blas/KokkosBlas1_nrm2w.hpp
+++ b/packages/kokkos-kernels/src/blas/KokkosBlas1_nrm2w.hpp
@@ -76,7 +76,8 @@ nrm2w(const XVector& x, const XVector& w) {
       typename XVector::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >
       XVector_Internal;
 
-  typedef Kokkos::View<mag_type, Kokkos::LayoutLeft, Kokkos::HostSpace,
+  typedef Kokkos::View<mag_type, typename XVector_Internal::array_layout,
+                       Kokkos::HostSpace,
                        Kokkos::MemoryTraits<Kokkos::Unmanaged> >
       RVector_Internal;
 
@@ -134,20 +135,21 @@ void nrm2w(const RV& R, const XMV& X, const XMV& W,
     KokkosKernels::Impl::throw_runtime_exception(os.str());
   }
 
+  using UnifiedXLayout =
+      typename KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout;
+  using UnifiedRVLayout =
+      typename KokkosKernels::Impl::GetUnifiedLayoutPreferring<
+          RV, UnifiedXLayout>::array_layout;
+
   // Create unmanaged versions of the input Views.  RV and XMV may be
   // rank 1 or rank 2.
-  typedef Kokkos::View<
-      typename std::conditional<RV::rank == 0,
-                                typename RV::non_const_value_type,
-                                typename RV::non_const_value_type*>::type,
-      typename KokkosKernels::Impl::GetUnifiedLayout<RV>::array_layout,
-      typename RV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >
+  typedef Kokkos::View<typename RV::non_const_data_type, UnifiedRVLayout,
+                       typename RV::device_type,
+                       Kokkos::MemoryTraits<Kokkos::Unmanaged> >
       RV_Internal;
-  typedef Kokkos::View<
-      typename std::conditional<XMV::rank == 1, typename XMV::const_value_type*,
-                                typename XMV::const_value_type**>::type,
-      typename KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout,
-      typename XMV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >
+  typedef Kokkos::View<typename XMV::const_data_type, UnifiedXLayout,
+                       typename XMV::device_type,
+                       Kokkos::MemoryTraits<Kokkos::Unmanaged> >
       XMV_Internal;
 
   RV_Internal R_internal  = R;

--- a/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_dot_mv_impl.hpp
+++ b/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_dot_mv_impl.hpp
@@ -131,7 +131,8 @@ void MV_Dot_Invoke(
   }
   // Zero out the result vector
   Kokkos::deep_copy(
-      r, Kokkos::ArithTraits<typename RV::non_const_value_type>::zero());
+      execution_space(), r,
+      Kokkos::ArithTraits<typename RV::non_const_value_type>::zero());
   size_type teamsPerDot;
   KokkosBlas::Impl::multipleReductionWorkDistribution<execution_space,
                                                       size_type>(
@@ -156,7 +157,7 @@ void MV_Dot_Invoke(
           Kokkos::view_alloc(Kokkos::WithoutInitializing, "Dot_MV temp result"),
           r.extent(0));
   MV_Dot_Invoke<decltype(tempResult), XV, YV, size_type>(tempResult, x, y);
-  Kokkos::deep_copy(r, tempResult);
+  Kokkos::deep_copy(typename XV::execution_space(), r, tempResult);
 }
 
 }  // namespace Impl

--- a/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_nrm1_impl.hpp
+++ b/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_nrm1_impl.hpp
@@ -170,7 +170,8 @@ void MV_Nrm1_Invoke(
   }
   // Zero out the result vector
   Kokkos::deep_copy(
-      r, Kokkos::ArithTraits<typename RV::non_const_value_type>::zero());
+      execution_space(), r,
+      Kokkos::ArithTraits<typename RV::non_const_value_type>::zero());
   size_type teamsPerVec;
   KokkosBlas::Impl::multipleReductionWorkDistribution<execution_space,
                                                       size_type>(
@@ -195,7 +196,7 @@ void MV_Nrm1_Invoke(
           Kokkos::view_alloc(Kokkos::WithoutInitializing, "Nrm1 temp result"),
           r.extent(0));
   MV_Nrm1_Invoke<decltype(tempResult), XV, size_type>(tempResult, x);
-  Kokkos::deep_copy(r, tempResult);
+  Kokkos::deep_copy(typename XV::execution_space(), r, tempResult);
 }
 
 }  // namespace Impl

--- a/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_nrm1_spec.hpp
+++ b/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_nrm1_spec.hpp
@@ -200,12 +200,23 @@ struct Nrm1<RV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
                                       : "KokkosBlas::nrm1[noETI]");
     const size_type numRows = X.extent(0);
     const size_type numCols = X.extent(1);
-    if (numRows < static_cast<size_type>(INT_MAX) &&
-        numRows * numCols < static_cast<size_type>(INT_MAX)) {
-      MV_Nrm1_Invoke<RV, XMV, int>(R, X);
+    if (numCols == Kokkos::ArithTraits<size_type>::one()) {
+      auto R0 = Kokkos::subview(R, 0);
+      auto X0 = Kokkos::subview(X, Kokkos::ALL(), 0);
+      if (numRows < static_cast<size_type>(INT_MAX)) {
+        V_Nrm1_Invoke<decltype(R0), decltype(X0), int>(R0, X0);
+      } else {
+        typedef std::int64_t index_type;
+        V_Nrm1_Invoke<decltype(R0), decltype(X0), index_type>(R0, X0);
+      }
     } else {
-      typedef std::int64_t index_type;
-      MV_Nrm1_Invoke<RV, XMV, index_type>(R, X);
+      if (numRows < static_cast<size_type>(INT_MAX) &&
+          numRows * numCols < static_cast<size_type>(INT_MAX)) {
+        MV_Nrm1_Invoke<RV, XMV, int>(R, X);
+      } else {
+        typedef std::int64_t index_type;
+        MV_Nrm1_Invoke<RV, XMV, index_type>(R, X);
+      }
     }
     Kokkos::Profiling::popRegion();
   }

--- a/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_nrm2_impl.hpp
+++ b/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_nrm2_impl.hpp
@@ -200,7 +200,8 @@ void MV_Nrm2_Invoke(
   }
   // Zero out the result vector
   Kokkos::deep_copy(
-      r, Kokkos::ArithTraits<typename RV::non_const_value_type>::zero());
+      execution_space(), r,
+      Kokkos::ArithTraits<typename RV::non_const_value_type>::zero());
   size_type teamsPerVec;
   KokkosBlas::Impl::multipleReductionWorkDistribution<execution_space,
                                                       size_type>(
@@ -230,7 +231,7 @@ void MV_Nrm2_Invoke(
           Kokkos::view_alloc(Kokkos::WithoutInitializing, "Nrm2 temp result"),
           r.extent(0));
   MV_Nrm2_Invoke<decltype(tempResult), XV, size_type>(tempResult, x, take_sqrt);
-  Kokkos::deep_copy(r, tempResult);
+  Kokkos::deep_copy(typename XV::execution_space(), r, tempResult);
 }
 
 }  // namespace Impl

--- a/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_nrm2_spec.hpp
+++ b/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_nrm2_spec.hpp
@@ -200,12 +200,24 @@ struct Nrm2<RV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
 
     const size_type numRows = X.extent(0);
     const size_type numCols = X.extent(1);
-    if (numRows < static_cast<size_type>(INT_MAX) &&
-        numRows * numCols < static_cast<size_type>(INT_MAX)) {
-      MV_Nrm2_Invoke<RV, XMV, int>(R, X, take_sqrt);
+    if (numCols == Kokkos::ArithTraits<size_type>::one()) {
+      auto R0 = Kokkos::subview(R, 0);
+      auto X0 = Kokkos::subview(X, Kokkos::ALL(), 0);
+      if (numRows < static_cast<size_type>(INT_MAX)) {
+        V_Nrm2_Invoke<decltype(R0), decltype(X0), int>(R0, X0, take_sqrt);
+      } else {
+        typedef std::int64_t index_type;
+        V_Nrm2_Invoke<decltype(R0), decltype(X0), index_type>(R0, X0,
+                                                              take_sqrt);
+      }
     } else {
-      typedef std::int64_t index_type;
-      MV_Nrm2_Invoke<RV, XMV, index_type>(R, X, take_sqrt);
+      if (numRows < static_cast<size_type>(INT_MAX) &&
+          numRows * numCols < static_cast<size_type>(INT_MAX)) {
+        MV_Nrm2_Invoke<RV, XMV, int>(R, X, take_sqrt);
+      } else {
+        typedef std::int64_t index_type;
+        MV_Nrm2_Invoke<RV, XMV, index_type>(R, X, take_sqrt);
+      }
     }
     Kokkos::Profiling::popRegion();
   }

--- a/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_nrm2w_impl.hpp
+++ b/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_nrm2w_impl.hpp
@@ -199,7 +199,8 @@ void MV_Nrm2w_Invoke(
   }
   // Zero out the result vector
   Kokkos::deep_copy(
-      r, Kokkos::ArithTraits<typename RV::non_const_value_type>::zero());
+      execution_space(), r,
+      Kokkos::ArithTraits<typename RV::non_const_value_type>::zero());
   size_type teamsPerVec;
   KokkosBlas::Impl::multipleReductionWorkDistribution<execution_space,
                                                       size_type>(
@@ -230,7 +231,7 @@ void MV_Nrm2w_Invoke(
           r.extent(0));
   MV_Nrm2w_Invoke<decltype(tempResult), XV, size_type>(tempResult, x, w,
                                                        take_sqrt);
-  Kokkos::deep_copy(r, tempResult);
+  Kokkos::deep_copy(typename XV::execution_space(), r, tempResult);
 }
 
 }  // namespace Impl

--- a/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_nrm2w_spec.hpp
+++ b/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_nrm2w_spec.hpp
@@ -201,12 +201,25 @@ struct Nrm2w<RV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
 
     const size_type numRows = X.extent(0);
     const size_type numCols = X.extent(1);
-    if (numRows < static_cast<size_type>(INT_MAX) &&
-        numRows * numCols < static_cast<size_type>(INT_MAX)) {
-      MV_Nrm2w_Invoke<RV, XMV, int>(R, X, W, take_sqrt);
+    if (numCols == 1) {
+      auto R0 = Kokkos::subview(R, 0);
+      auto X0 = Kokkos::subview(X, Kokkos::ALL(), 0);
+      auto W0 = Kokkos::subview(W, Kokkos::ALL(), 0);
+      if (numRows < static_cast<size_type>(INT_MAX)) {
+        V_Nrm2w_Invoke<decltype(R0), decltype(X0), int>(R0, X0, W0, take_sqrt);
+      } else {
+        typedef std::int64_t index_type;
+        V_Nrm2w_Invoke<decltype(R0), decltype(X0), index_type>(R0, X0, W0,
+                                                               take_sqrt);
+      }
     } else {
-      typedef std::int64_t index_type;
-      MV_Nrm2w_Invoke<RV, XMV, index_type>(R, X, W, take_sqrt);
+      if (numRows < static_cast<size_type>(INT_MAX) &&
+          numRows * numCols < static_cast<size_type>(INT_MAX)) {
+        MV_Nrm2w_Invoke<RV, XMV, int>(R, X, W, take_sqrt);
+      } else {
+        typedef std::int64_t index_type;
+        MV_Nrm2w_Invoke<RV, XMV, index_type>(R, X, W, take_sqrt);
+      }
     }
     Kokkos::Profiling::popRegion();
   }

--- a/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_sum_impl.hpp
+++ b/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_sum_impl.hpp
@@ -162,7 +162,8 @@ void MV_Sum_Invoke(
   }
   // Zero out the result vector
   Kokkos::deep_copy(
-      r, Kokkos::ArithTraits<typename RV::non_const_value_type>::zero());
+      execution_space(), r,
+      Kokkos::ArithTraits<typename RV::non_const_value_type>::zero());
   size_type teamsPerVec;
   KokkosBlas::Impl::multipleReductionWorkDistribution<execution_space,
                                                       size_type>(
@@ -187,7 +188,7 @@ void MV_Sum_Invoke(
           Kokkos::view_alloc(Kokkos::WithoutInitializing, "Sum temp result"),
           r.extent(0));
   MV_Sum_Invoke<decltype(tempResult), XV, size_type>(tempResult, x);
-  Kokkos::deep_copy(r, tempResult);
+  Kokkos::deep_copy(typename XV::execution_space(), r, tempResult);
 }
 
 }  // namespace Impl

--- a/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_sum_spec.hpp
+++ b/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_sum_spec.hpp
@@ -197,12 +197,23 @@ struct Sum<RV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
 
     const size_type numRows = X.extent(0);
     const size_type numCols = X.extent(1);
-    if (numRows < static_cast<size_type>(INT_MAX) &&
-        numRows * numCols < static_cast<size_type>(INT_MAX)) {
-      MV_Sum_Invoke<RV, XMV, int>(R, X);
+    if (numCols == Kokkos::ArithTraits<size_type>::one()) {
+      auto R0 = Kokkos::subview(R, 0);
+      auto X0 = Kokkos::subview(X, Kokkos::ALL(), 0);
+      if (numRows < static_cast<size_type>(INT_MAX)) {
+        V_Sum_Invoke<decltype(R0), decltype(X0), int>(R0, X0);
+      } else {
+        typedef std::int64_t index_type;
+        V_Sum_Invoke<decltype(R0), decltype(X0), index_type>(R0, X0);
+      }
     } else {
-      typedef std::int64_t index_type;
-      MV_Sum_Invoke<RV, XMV, index_type>(R, X);
+      if (numRows < static_cast<size_type>(INT_MAX) &&
+          numRows * numCols < static_cast<size_type>(INT_MAX)) {
+        MV_Sum_Invoke<RV, XMV, int>(R, X);
+      } else {
+        typedef std::int64_t index_type;
+        MV_Sum_Invoke<RV, XMV, index_type>(R, X);
+      }
     }
     Kokkos::Profiling::popRegion();
   }

--- a/packages/kokkos-kernels/unit_test/blas/Test_Blas.hpp
+++ b/packages/kokkos-kernels/unit_test/blas/Test_Blas.hpp
@@ -15,6 +15,8 @@
 #include "Test_Blas1_nrm1.hpp"
 #include "Test_Blas1_nrm2_squared.hpp"
 #include "Test_Blas1_nrm2.hpp"
+#include "Test_Blas1_nrm2w_squared.hpp"
+#include "Test_Blas1_nrm2w.hpp"
 #include "Test_Blas1_nrminf.hpp"
 #include "Test_Blas1_reciprocal.hpp"
 #include "Test_Blas1_scal.hpp"

--- a/packages/kokkos-kernels/unit_test/blas/Test_Blas1_dot.hpp
+++ b/packages/kokkos-kernels/unit_test/blas/Test_Blas1_dot.hpp
@@ -196,6 +196,7 @@ int test_dot_mv() {
   Test::impl_test_dot_mv<view_type_a_ll, view_type_b_ll, Device>(0, 5);
   Test::impl_test_dot_mv<view_type_a_ll, view_type_b_ll, Device>(13, 5);
   Test::impl_test_dot_mv<view_type_a_ll, view_type_b_ll, Device>(1024, 5);
+  Test::impl_test_dot_mv<view_type_a_ll, view_type_b_ll, Device>(789, 1);
   // Test::impl_test_dot_mv<view_type_a_ll, view_type_b_ll, Device>(132231,5);
 #endif
 
@@ -207,6 +208,7 @@ int test_dot_mv() {
   Test::impl_test_dot_mv<view_type_a_lr, view_type_b_lr, Device>(0, 5);
   Test::impl_test_dot_mv<view_type_a_lr, view_type_b_lr, Device>(13, 5);
   Test::impl_test_dot_mv<view_type_a_lr, view_type_b_lr, Device>(1024, 5);
+  Test::impl_test_dot_mv<view_type_a_lr, view_type_b_lr, Device>(789, 1);
   // Test::impl_test_dot_mv<view_type_a_lr, view_type_b_lr, Device>(132231,5);
 #endif
 
@@ -218,6 +220,7 @@ int test_dot_mv() {
   Test::impl_test_dot_mv<view_type_a_ls, view_type_b_ls, Device>(0, 5);
   Test::impl_test_dot_mv<view_type_a_ls, view_type_b_ls, Device>(13, 5);
   Test::impl_test_dot_mv<view_type_a_ls, view_type_b_ls, Device>(1024, 5);
+  Test::impl_test_dot_mv<view_type_a_ls, view_type_b_ls, Device>(789, 1);
   // Test::impl_test_dot_mv<view_type_a_ls, view_type_b_ls, Device>(132231,5);
 #endif
 

--- a/packages/kokkos-kernels/unit_test/blas/Test_Blas1_nrm1.hpp
+++ b/packages/kokkos-kernels/unit_test/blas/Test_Blas1_nrm1.hpp
@@ -149,6 +149,7 @@ int test_nrm1_mv() {
   Test::impl_test_nrm1_mv<view_type_a_ll, Device>(0, 5);
   Test::impl_test_nrm1_mv<view_type_a_ll, Device>(13, 5);
   Test::impl_test_nrm1_mv<view_type_a_ll, Device>(1024, 5);
+  Test::impl_test_nrm1_mv<view_type_a_ll, Device>(789, 1);
   Test::impl_test_nrm1_mv<view_type_a_ll, Device>(132231, 5);
 #endif
 
@@ -159,6 +160,7 @@ int test_nrm1_mv() {
   Test::impl_test_nrm1_mv<view_type_a_lr, Device>(0, 5);
   Test::impl_test_nrm1_mv<view_type_a_lr, Device>(13, 5);
   Test::impl_test_nrm1_mv<view_type_a_lr, Device>(1024, 5);
+  Test::impl_test_nrm1_mv<view_type_a_lr, Device>(789, 1);
   Test::impl_test_nrm1_mv<view_type_a_lr, Device>(132231, 5);
 #endif
 
@@ -169,6 +171,7 @@ int test_nrm1_mv() {
   Test::impl_test_nrm1_mv<view_type_a_ls, Device>(0, 5);
   Test::impl_test_nrm1_mv<view_type_a_ls, Device>(13, 5);
   Test::impl_test_nrm1_mv<view_type_a_ls, Device>(1024, 5);
+  Test::impl_test_nrm1_mv<view_type_a_ls, Device>(789, 1);
   Test::impl_test_nrm1_mv<view_type_a_ls, Device>(132231, 5);
 #endif
 

--- a/packages/kokkos-kernels/unit_test/blas/Test_Blas1_nrm2_squared.hpp
+++ b/packages/kokkos-kernels/unit_test/blas/Test_Blas1_nrm2_squared.hpp
@@ -160,6 +160,7 @@ int test_nrm2_squared_mv() {
   Test::impl_test_nrm2_squared_mv<view_type_a_ll, Device>(0, 5);
   Test::impl_test_nrm2_squared_mv<view_type_a_ll, Device>(13, 5);
   Test::impl_test_nrm2_squared_mv<view_type_a_ll, Device>(1024, 5);
+  Test::impl_test_nrm2_squared_mv<view_type_a_ll, Device>(789, 1);
   // Test::impl_test_nrm2_squared_mv<view_type_a_ll, Device>(132231,5);
 #endif
 
@@ -170,6 +171,7 @@ int test_nrm2_squared_mv() {
   Test::impl_test_nrm2_squared_mv<view_type_a_lr, Device>(0, 5);
   Test::impl_test_nrm2_squared_mv<view_type_a_lr, Device>(13, 5);
   Test::impl_test_nrm2_squared_mv<view_type_a_lr, Device>(1024, 5);
+  Test::impl_test_nrm2_squared_mv<view_type_a_lr, Device>(789, 1);
   // Test::impl_test_nrm2_squared_mv<view_type_a_lr, Device>(132231,5);
 #endif
 
@@ -180,6 +182,7 @@ int test_nrm2_squared_mv() {
   Test::impl_test_nrm2_squared_mv<view_type_a_ls, Device>(0, 5);
   Test::impl_test_nrm2_squared_mv<view_type_a_ls, Device>(13, 5);
   Test::impl_test_nrm2_squared_mv<view_type_a_ls, Device>(1024, 5);
+  Test::impl_test_nrm2_squared_mv<view_type_a_ls, Device>(789, 1);
   // Test::impl_test_nrm2_squared_mv<view_type_a_ls, Device>(132231,5);
 #endif
 

--- a/packages/kokkos-kernels/unit_test/blas/Test_Blas1_nrm2w.hpp
+++ b/packages/kokkos-kernels/unit_test/blas/Test_Blas1_nrm2w.hpp
@@ -1,18 +1,20 @@
 #include <gtest/gtest.h>
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Random.hpp>
-#include <KokkosBlas1_nrm2.hpp>
+#include <KokkosBlas1_nrm2w.hpp>
 #include <KokkosKernels_TestUtils.hpp>
 
 namespace Test {
 template <class ViewTypeA, class Device>
-void impl_test_nrm2(int N) {
+void impl_test_nrm2w(int N) {
   typedef typename ViewTypeA::value_type ScalarA;
-  typedef Kokkos::Details::ArithTraits<ScalarA> AT;
+  typedef Kokkos::ArithTraits<ScalarA> AT;
 
   ViewTypeA a("A", N);
+  ViewTypeA w("W", N);
 
   typename ViewTypeA::HostMirror h_a = Kokkos::create_mirror_view(a);
+  typename ViewTypeA::HostMirror h_w = Kokkos::create_mirror_view(w);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
@@ -20,42 +22,45 @@ void impl_test_nrm2(int N) {
   ScalarA randStart, randEnd;
   Test::getRandomBounds(1.0, randStart, randEnd);
   Kokkos::fill_random(a, rand_pool, randStart, randEnd);
+  Kokkos::fill_random(w, rand_pool, randStart, randEnd);
 
   Kokkos::deep_copy(h_a, a);
+  Kokkos::deep_copy(h_w, w);
 
-  typename ViewTypeA::const_type c_a = a;
   double eps = std::is_same<ScalarA, float>::value ? 2 * 1e-5 : 1e-7;
 
   typename AT::mag_type expected_result = 0;
   for (int i = 0; i < N; i++) {
-    expected_result += AT::abs(h_a(i)) * AT::abs(h_a(i));
+    typename AT::mag_type term = AT::abs(h_a(i)) / AT::abs(h_w(i));
+    expected_result += term * term;
   }
-  expected_result = Kokkos::Details::ArithTraits<typename AT::mag_type>::sqrt(
-      expected_result);
+  expected_result =
+      Kokkos::ArithTraits<typename AT::mag_type>::sqrt(expected_result);
 
-  typename AT::mag_type nonconst_result = KokkosBlas::nrm2(a);
+  typename AT::mag_type nonconst_result = KokkosBlas::nrm2w(a, w);
   EXPECT_NEAR_KK(nonconst_result, expected_result, eps * expected_result);
-
-  typename AT::mag_type const_result = KokkosBlas::nrm2(c_a);
-  EXPECT_NEAR_KK(const_result, expected_result, eps * expected_result);
 }
 
 template <class ViewTypeA, class Device>
-void impl_test_nrm2_mv(int N, int K) {
+void impl_test_nrm2w_mv(int N, int K) {
   typedef typename ViewTypeA::value_type ScalarA;
-  typedef Kokkos::Details::ArithTraits<ScalarA> AT;
+  typedef Kokkos::ArithTraits<ScalarA> AT;
 
   typedef multivector_layout_adapter<ViewTypeA> vfA_type;
 
   typename vfA_type::BaseType b_a("A", N, K);
+  typename vfA_type::BaseType b_w("W", N, K);
 
   ViewTypeA a = vfA_type::view(b_a);
+  ViewTypeA w = vfA_type::view(b_w);
 
   typedef multivector_layout_adapter<typename ViewTypeA::HostMirror> h_vfA_type;
 
   typename h_vfA_type::BaseType h_b_a = Kokkos::create_mirror_view(b_a);
+  typename h_vfA_type::BaseType h_b_w = Kokkos::create_mirror_view(b_w);
 
   typename ViewTypeA::HostMirror h_a = h_vfA_type::view(h_b_a);
+  typename ViewTypeA::HostMirror h_w = h_vfA_type::view(h_b_w);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
@@ -63,37 +68,32 @@ void impl_test_nrm2_mv(int N, int K) {
   ScalarA randStart, randEnd;
   Test::getRandomBounds(1.0, randStart, randEnd);
   Kokkos::fill_random(b_a, rand_pool, randStart, randEnd);
+  Kokkos::fill_random(b_w, rand_pool, randStart, randEnd);
 
   Kokkos::deep_copy(h_b_a, b_a);
-
-  typename ViewTypeA::const_type c_a = a;
+  Kokkos::deep_copy(h_b_w, b_w);
 
   typename AT::mag_type* expected_result = new typename AT::mag_type[K];
   for (int j = 0; j < K; j++) {
     expected_result[j] = typename AT::mag_type();
     for (int i = 0; i < N; i++) {
-      expected_result[j] += AT::abs(h_a(i, j)) * AT::abs(h_a(i, j));
+      typename AT::mag_type term = AT::abs(h_a(i, j)) / AT::abs(h_w(i, j));
+      expected_result[j] += term * term;
     }
     expected_result[j] =
-        Kokkos::Details::ArithTraits<typename AT::mag_type>::sqrt(
-            expected_result[j]);
+        Kokkos::ArithTraits<typename AT::mag_type>::sqrt(expected_result[j]);
   }
 
   double eps = std::is_same<ScalarA, float>::value ? 2 * 1e-5 : 1e-7;
 
-  Kokkos::View<typename AT::mag_type*, Kokkos::HostSpace> r("Dot::Result", K);
+  Kokkos::View<typename AT::mag_type*, Device> r("Dot::Result", K);
+  KokkosBlas::nrm2w(r, a, w);
+  auto r_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), r);
 
-  KokkosBlas::nrm2(r, a);
   for (int k = 0; k < K; k++) {
-    typename AT::mag_type nonconst_result = r(k);
+    typename AT::mag_type nonconst_result = r_host(k);
     EXPECT_NEAR_KK(nonconst_result, expected_result[k],
                    eps * expected_result[k]);
-  }
-
-  KokkosBlas::nrm2(r, c_a);
-  for (int k = 0; k < K; k++) {
-    typename AT::mag_type const_result = r(k);
-    EXPECT_NEAR_KK(const_result, expected_result[k], eps * expected_result[k]);
   }
 
   delete[] expected_result;
@@ -101,14 +101,14 @@ void impl_test_nrm2_mv(int N, int K) {
 }  // namespace Test
 
 template <class ScalarA, class Device>
-int test_nrm2() {
+int test_nrm2w() {
 #if defined(KOKKOSKERNELS_INST_LAYOUTLEFT) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&      \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
   typedef Kokkos::View<ScalarA*, Kokkos::LayoutLeft, Device> view_type_a_ll;
-  Test::impl_test_nrm2<view_type_a_ll, Device>(0);
-  Test::impl_test_nrm2<view_type_a_ll, Device>(13);
-  Test::impl_test_nrm2<view_type_a_ll, Device>(1024);
+  Test::impl_test_nrm2w<view_type_a_ll, Device>(0);
+  Test::impl_test_nrm2w<view_type_a_ll, Device>(13);
+  Test::impl_test_nrm2w<view_type_a_ll, Device>(1024);
   // Test::impl_test_nrm2<view_type_a_ll, Device>(132231);
 #endif
 
@@ -116,9 +116,9 @@ int test_nrm2() {
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&       \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
   typedef Kokkos::View<ScalarA*, Kokkos::LayoutRight, Device> view_type_a_lr;
-  Test::impl_test_nrm2<view_type_a_lr, Device>(0);
-  Test::impl_test_nrm2<view_type_a_lr, Device>(13);
-  Test::impl_test_nrm2<view_type_a_lr, Device>(1024);
+  Test::impl_test_nrm2w<view_type_a_lr, Device>(0);
+  Test::impl_test_nrm2w<view_type_a_lr, Device>(13);
+  Test::impl_test_nrm2w<view_type_a_lr, Device>(1024);
   // Test::impl_test_nrm2<view_type_a_lr, Device>(132231);
 #endif
 
@@ -126,9 +126,9 @@ int test_nrm2() {
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
   typedef Kokkos::View<ScalarA*, Kokkos::LayoutStride, Device> view_type_a_ls;
-  Test::impl_test_nrm2<view_type_a_ls, Device>(0);
-  Test::impl_test_nrm2<view_type_a_ls, Device>(13);
-  Test::impl_test_nrm2<view_type_a_ls, Device>(1024);
+  Test::impl_test_nrm2w<view_type_a_ls, Device>(0);
+  Test::impl_test_nrm2w<view_type_a_ls, Device>(13);
+  Test::impl_test_nrm2w<view_type_a_ls, Device>(1024);
   // Test::impl_test_nrm2<view_type_a_ls, Device>(132231);
 #endif
 
@@ -136,38 +136,38 @@ int test_nrm2() {
 }
 
 template <class ScalarA, class Device>
-int test_nrm2_mv() {
+int test_nrm2w_mv() {
 #if defined(KOKKOSKERNELS_INST_LAYOUTLEFT) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&      \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
   typedef Kokkos::View<ScalarA**, Kokkos::LayoutLeft, Device> view_type_a_ll;
-  Test::impl_test_nrm2_mv<view_type_a_ll, Device>(0, 5);
-  Test::impl_test_nrm2_mv<view_type_a_ll, Device>(13, 5);
-  Test::impl_test_nrm2_mv<view_type_a_ll, Device>(1024, 5);
-  Test::impl_test_nrm2_mv<view_type_a_ll, Device>(789, 1);
-  // Test::impl_test_nrm2_mv<view_type_a_ll, Device>(132231,5);
+  Test::impl_test_nrm2w_mv<view_type_a_ll, Device>(0, 5);
+  Test::impl_test_nrm2w_mv<view_type_a_ll, Device>(13, 5);
+  Test::impl_test_nrm2w_mv<view_type_a_ll, Device>(1024, 5);
+  Test::impl_test_nrm2w_mv<view_type_a_ll, Device>(789, 1);
+  // Test::impl_test_nrm2w_mv<view_type_a_ll, Device>(132231,5);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&       \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
   typedef Kokkos::View<ScalarA**, Kokkos::LayoutRight, Device> view_type_a_lr;
-  Test::impl_test_nrm2_mv<view_type_a_lr, Device>(0, 5);
-  Test::impl_test_nrm2_mv<view_type_a_lr, Device>(13, 5);
-  Test::impl_test_nrm2_mv<view_type_a_lr, Device>(1024, 5);
-  Test::impl_test_nrm2_mv<view_type_a_lr, Device>(789, 1);
-  // Test::impl_test_nrm2_mv<view_type_a_lr, Device>(132231,5);
+  Test::impl_test_nrm2w_mv<view_type_a_lr, Device>(0, 5);
+  Test::impl_test_nrm2w_mv<view_type_a_lr, Device>(13, 5);
+  Test::impl_test_nrm2w_mv<view_type_a_lr, Device>(1024, 5);
+  Test::impl_test_nrm2w_mv<view_type_a_lr, Device>(789, 1);
+  // Test::impl_test_nrm2w_mv<view_type_a_lr, Device>(132231,5);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
   typedef Kokkos::View<ScalarA**, Kokkos::LayoutStride, Device> view_type_a_ls;
-  Test::impl_test_nrm2_mv<view_type_a_ls, Device>(0, 5);
-  Test::impl_test_nrm2_mv<view_type_a_ls, Device>(13, 5);
-  Test::impl_test_nrm2_mv<view_type_a_ls, Device>(1024, 5);
-  Test::impl_test_nrm2_mv<view_type_a_ls, Device>(789, 1);
-  // Test::impl_test_nrm2_mv<view_type_a_ls, Device>(132231,5);
+  Test::impl_test_nrm2w_mv<view_type_a_ls, Device>(0, 5);
+  Test::impl_test_nrm2w_mv<view_type_a_ls, Device>(13, 5);
+  Test::impl_test_nrm2w_mv<view_type_a_ls, Device>(1024, 5);
+  Test::impl_test_nrm2w_mv<view_type_a_ls, Device>(789, 1);
+  // Test::impl_test_nrm2w_mv<view_type_a_ls, Device>(132231,5);
 #endif
 
   return 1;
@@ -176,14 +176,14 @@ int test_nrm2_mv() {
 #if defined(KOKKOSKERNELS_INST_FLOAT) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) && \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-TEST_F(TestCategory, nrm2_float) {
-  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2_float");
-  test_nrm2<float, TestExecSpace>();
+TEST_F(TestCategory, nrm2w_float) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2w_float");
+  test_nrm2w<float, TestExecSpace>();
   Kokkos::Profiling::popRegion();
 }
-TEST_F(TestCategory, nrm2_mv_float) {
-  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2_mv_float");
-  test_nrm2_mv<float, TestExecSpace>();
+TEST_F(TestCategory, nrm2w_mv_float) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2w_mv_float");
+  test_nrm2w_mv<float, TestExecSpace>();
   Kokkos::Profiling::popRegion();
 }
 #endif
@@ -191,14 +191,14 @@ TEST_F(TestCategory, nrm2_mv_float) {
 #if defined(KOKKOSKERNELS_INST_DOUBLE) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&  \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-TEST_F(TestCategory, nrm2_double) {
-  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2_double");
-  test_nrm2<double, TestExecSpace>();
+TEST_F(TestCategory, nrm2w_double) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2w_double");
+  test_nrm2w<double, TestExecSpace>();
   Kokkos::Profiling::popRegion();
 }
-TEST_F(TestCategory, nrm2_mv_double) {
-  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2_mv_double");
-  test_nrm2_mv<double, TestExecSpace>();
+TEST_F(TestCategory, nrm2w_mv_double) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2w_mv_double");
+  test_nrm2w_mv<double, TestExecSpace>();
   Kokkos::Profiling::popRegion();
 }
 #endif
@@ -206,14 +206,14 @@ TEST_F(TestCategory, nrm2_mv_double) {
 #if defined(KOKKOSKERNELS_INST_COMPLEX_DOUBLE) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&          \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-TEST_F(TestCategory, nrm2_complex_double) {
-  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2_complex_double");
-  test_nrm2<Kokkos::complex<double>, TestExecSpace>();
+TEST_F(TestCategory, nrm2w_complex_double) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2w_complex_double");
+  test_nrm2w<Kokkos::complex<double>, TestExecSpace>();
   Kokkos::Profiling::popRegion();
 }
-TEST_F(TestCategory, nrm2_mv_complex_double) {
-  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2_mv_complex_double");
-  test_nrm2_mv<Kokkos::complex<double>, TestExecSpace>();
+TEST_F(TestCategory, nrm2w_mv_complex_double) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2w_mv_complex_double");
+  test_nrm2w_mv<Kokkos::complex<double>, TestExecSpace>();
   Kokkos::Profiling::popRegion();
 }
 #endif
@@ -221,14 +221,14 @@ TEST_F(TestCategory, nrm2_mv_complex_double) {
 #if defined(KOKKOSKERNELS_INST_INT) ||   \
     (!defined(KOKKOSKERNELS_ETI_ONLY) && \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-TEST_F(TestCategory, nrm2_int) {
-  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2_int");
-  test_nrm2<int, TestExecSpace>();
+TEST_F(TestCategory, nrm2w_int) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2w_int");
+  test_nrm2w<int, TestExecSpace>();
   Kokkos::Profiling::popRegion();
 }
-TEST_F(TestCategory, nrm2_mv_int) {
-  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2_mv_int");
-  test_nrm2_mv<int, TestExecSpace>();
+TEST_F(TestCategory, nrm2w_mv_int) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2w_mv_int");
+  test_nrm2w_mv<int, TestExecSpace>();
   Kokkos::Profiling::popRegion();
 }
 #endif

--- a/packages/kokkos-kernels/unit_test/blas/Test_Blas1_nrm2w_squared.hpp
+++ b/packages/kokkos-kernels/unit_test/blas/Test_Blas1_nrm2w_squared.hpp
@@ -1,18 +1,20 @@
 #include <gtest/gtest.h>
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Random.hpp>
-#include <KokkosBlas1_nrm2.hpp>
+#include <KokkosBlas1_nrm2w_squared.hpp>
 #include <KokkosKernels_TestUtils.hpp>
 
 namespace Test {
 template <class ViewTypeA, class Device>
-void impl_test_nrm2(int N) {
+void impl_test_nrm2w_squared(int N) {
   typedef typename ViewTypeA::value_type ScalarA;
-  typedef Kokkos::Details::ArithTraits<ScalarA> AT;
+  typedef Kokkos::ArithTraits<ScalarA> AT;
 
   ViewTypeA a("A", N);
+  ViewTypeA w("W", N);
 
   typename ViewTypeA::HostMirror h_a = Kokkos::create_mirror_view(a);
+  typename ViewTypeA::HostMirror h_w = Kokkos::create_mirror_view(w);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
@@ -20,42 +22,43 @@ void impl_test_nrm2(int N) {
   ScalarA randStart, randEnd;
   Test::getRandomBounds(1.0, randStart, randEnd);
   Kokkos::fill_random(a, rand_pool, randStart, randEnd);
+  Kokkos::fill_random(w, rand_pool, randStart, randEnd);
 
   Kokkos::deep_copy(h_a, a);
+  Kokkos::deep_copy(h_w, w);
 
-  typename ViewTypeA::const_type c_a = a;
   double eps = std::is_same<ScalarA, float>::value ? 2 * 1e-5 : 1e-7;
 
   typename AT::mag_type expected_result = 0;
   for (int i = 0; i < N; i++) {
-    expected_result += AT::abs(h_a(i)) * AT::abs(h_a(i));
+    typename AT::mag_type term = AT::abs(h_a(i)) / AT::abs(h_w(i));
+    expected_result += term * term;
   }
-  expected_result = Kokkos::Details::ArithTraits<typename AT::mag_type>::sqrt(
-      expected_result);
 
-  typename AT::mag_type nonconst_result = KokkosBlas::nrm2(a);
+  typename AT::mag_type nonconst_result = KokkosBlas::nrm2w_squared(a, w);
   EXPECT_NEAR_KK(nonconst_result, expected_result, eps * expected_result);
-
-  typename AT::mag_type const_result = KokkosBlas::nrm2(c_a);
-  EXPECT_NEAR_KK(const_result, expected_result, eps * expected_result);
 }
 
 template <class ViewTypeA, class Device>
-void impl_test_nrm2_mv(int N, int K) {
+void impl_test_nrm2w_squared_mv(int N, int K) {
   typedef typename ViewTypeA::value_type ScalarA;
-  typedef Kokkos::Details::ArithTraits<ScalarA> AT;
+  typedef Kokkos::ArithTraits<ScalarA> AT;
 
   typedef multivector_layout_adapter<ViewTypeA> vfA_type;
 
   typename vfA_type::BaseType b_a("A", N, K);
+  typename vfA_type::BaseType b_w("W", N, K);
 
   ViewTypeA a = vfA_type::view(b_a);
+  ViewTypeA w = vfA_type::view(b_w);
 
   typedef multivector_layout_adapter<typename ViewTypeA::HostMirror> h_vfA_type;
 
   typename h_vfA_type::BaseType h_b_a = Kokkos::create_mirror_view(b_a);
+  typename h_vfA_type::BaseType h_b_w = Kokkos::create_mirror_view(b_w);
 
   typename ViewTypeA::HostMirror h_a = h_vfA_type::view(h_b_a);
+  typename ViewTypeA::HostMirror h_w = h_vfA_type::view(h_b_w);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
@@ -63,37 +66,30 @@ void impl_test_nrm2_mv(int N, int K) {
   ScalarA randStart, randEnd;
   Test::getRandomBounds(1.0, randStart, randEnd);
   Kokkos::fill_random(b_a, rand_pool, randStart, randEnd);
+  Kokkos::fill_random(b_w, rand_pool, randStart, randEnd);
 
   Kokkos::deep_copy(h_b_a, b_a);
-
-  typename ViewTypeA::const_type c_a = a;
+  Kokkos::deep_copy(h_b_w, b_w);
 
   typename AT::mag_type* expected_result = new typename AT::mag_type[K];
   for (int j = 0; j < K; j++) {
     expected_result[j] = typename AT::mag_type();
     for (int i = 0; i < N; i++) {
-      expected_result[j] += AT::abs(h_a(i, j)) * AT::abs(h_a(i, j));
+      typename AT::mag_type term = AT::abs(h_a(i, j)) / AT::abs(h_w(i, j));
+      expected_result[j] += term * term;
     }
-    expected_result[j] =
-        Kokkos::Details::ArithTraits<typename AT::mag_type>::sqrt(
-            expected_result[j]);
   }
 
   double eps = std::is_same<ScalarA, float>::value ? 2 * 1e-5 : 1e-7;
 
-  Kokkos::View<typename AT::mag_type*, Kokkos::HostSpace> r("Dot::Result", K);
+  Kokkos::View<typename AT::mag_type*, Device> r("Dot::Result", K);
+  KokkosBlas::nrm2w_squared(r, a, w);
+  auto r_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), r);
 
-  KokkosBlas::nrm2(r, a);
   for (int k = 0; k < K; k++) {
-    typename AT::mag_type nonconst_result = r(k);
+    typename AT::mag_type nonconst_result = r_host(k);
     EXPECT_NEAR_KK(nonconst_result, expected_result[k],
                    eps * expected_result[k]);
-  }
-
-  KokkosBlas::nrm2(r, c_a);
-  for (int k = 0; k < K; k++) {
-    typename AT::mag_type const_result = r(k);
-    EXPECT_NEAR_KK(const_result, expected_result[k], eps * expected_result[k]);
   }
 
   delete[] expected_result;
@@ -101,14 +97,14 @@ void impl_test_nrm2_mv(int N, int K) {
 }  // namespace Test
 
 template <class ScalarA, class Device>
-int test_nrm2() {
+int test_nrm2w_squared() {
 #if defined(KOKKOSKERNELS_INST_LAYOUTLEFT) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&      \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
   typedef Kokkos::View<ScalarA*, Kokkos::LayoutLeft, Device> view_type_a_ll;
-  Test::impl_test_nrm2<view_type_a_ll, Device>(0);
-  Test::impl_test_nrm2<view_type_a_ll, Device>(13);
-  Test::impl_test_nrm2<view_type_a_ll, Device>(1024);
+  Test::impl_test_nrm2w_squared<view_type_a_ll, Device>(0);
+  Test::impl_test_nrm2w_squared<view_type_a_ll, Device>(13);
+  Test::impl_test_nrm2w_squared<view_type_a_ll, Device>(1024);
   // Test::impl_test_nrm2<view_type_a_ll, Device>(132231);
 #endif
 
@@ -116,9 +112,9 @@ int test_nrm2() {
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&       \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
   typedef Kokkos::View<ScalarA*, Kokkos::LayoutRight, Device> view_type_a_lr;
-  Test::impl_test_nrm2<view_type_a_lr, Device>(0);
-  Test::impl_test_nrm2<view_type_a_lr, Device>(13);
-  Test::impl_test_nrm2<view_type_a_lr, Device>(1024);
+  Test::impl_test_nrm2w_squared<view_type_a_lr, Device>(0);
+  Test::impl_test_nrm2w_squared<view_type_a_lr, Device>(13);
+  Test::impl_test_nrm2w_squared<view_type_a_lr, Device>(1024);
   // Test::impl_test_nrm2<view_type_a_lr, Device>(132231);
 #endif
 
@@ -126,9 +122,9 @@ int test_nrm2() {
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
   typedef Kokkos::View<ScalarA*, Kokkos::LayoutStride, Device> view_type_a_ls;
-  Test::impl_test_nrm2<view_type_a_ls, Device>(0);
-  Test::impl_test_nrm2<view_type_a_ls, Device>(13);
-  Test::impl_test_nrm2<view_type_a_ls, Device>(1024);
+  Test::impl_test_nrm2w_squared<view_type_a_ls, Device>(0);
+  Test::impl_test_nrm2w_squared<view_type_a_ls, Device>(13);
+  Test::impl_test_nrm2w_squared<view_type_a_ls, Device>(1024);
   // Test::impl_test_nrm2<view_type_a_ls, Device>(132231);
 #endif
 
@@ -136,38 +132,38 @@ int test_nrm2() {
 }
 
 template <class ScalarA, class Device>
-int test_nrm2_mv() {
+int test_nrm2w_squared_mv() {
 #if defined(KOKKOSKERNELS_INST_LAYOUTLEFT) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&      \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
   typedef Kokkos::View<ScalarA**, Kokkos::LayoutLeft, Device> view_type_a_ll;
-  Test::impl_test_nrm2_mv<view_type_a_ll, Device>(0, 5);
-  Test::impl_test_nrm2_mv<view_type_a_ll, Device>(13, 5);
-  Test::impl_test_nrm2_mv<view_type_a_ll, Device>(1024, 5);
-  Test::impl_test_nrm2_mv<view_type_a_ll, Device>(789, 1);
-  // Test::impl_test_nrm2_mv<view_type_a_ll, Device>(132231,5);
+  Test::impl_test_nrm2w_squared_mv<view_type_a_ll, Device>(0, 5);
+  Test::impl_test_nrm2w_squared_mv<view_type_a_ll, Device>(13, 5);
+  Test::impl_test_nrm2w_squared_mv<view_type_a_ll, Device>(1024, 5);
+  Test::impl_test_nrm2w_squared_mv<view_type_a_ll, Device>(789, 1);
+  // Test::impl_test_nrm2w_squared_mv<view_type_a_ll, Device>(132231,5);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&       \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
   typedef Kokkos::View<ScalarA**, Kokkos::LayoutRight, Device> view_type_a_lr;
-  Test::impl_test_nrm2_mv<view_type_a_lr, Device>(0, 5);
-  Test::impl_test_nrm2_mv<view_type_a_lr, Device>(13, 5);
-  Test::impl_test_nrm2_mv<view_type_a_lr, Device>(1024, 5);
-  Test::impl_test_nrm2_mv<view_type_a_lr, Device>(789, 1);
-  // Test::impl_test_nrm2_mv<view_type_a_lr, Device>(132231,5);
+  Test::impl_test_nrm2w_squared_mv<view_type_a_lr, Device>(0, 5);
+  Test::impl_test_nrm2w_squared_mv<view_type_a_lr, Device>(13, 5);
+  Test::impl_test_nrm2w_squared_mv<view_type_a_lr, Device>(1024, 5);
+  Test::impl_test_nrm2w_squared_mv<view_type_a_lr, Device>(789, 1);
+  // Test::impl_test_nrm2w_squared_mv<view_type_a_lr, Device>(132231,5);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
   typedef Kokkos::View<ScalarA**, Kokkos::LayoutStride, Device> view_type_a_ls;
-  Test::impl_test_nrm2_mv<view_type_a_ls, Device>(0, 5);
-  Test::impl_test_nrm2_mv<view_type_a_ls, Device>(13, 5);
-  Test::impl_test_nrm2_mv<view_type_a_ls, Device>(1024, 5);
-  Test::impl_test_nrm2_mv<view_type_a_ls, Device>(789, 1);
-  // Test::impl_test_nrm2_mv<view_type_a_ls, Device>(132231,5);
+  Test::impl_test_nrm2w_squared_mv<view_type_a_ls, Device>(0, 5);
+  Test::impl_test_nrm2w_squared_mv<view_type_a_ls, Device>(13, 5);
+  Test::impl_test_nrm2w_squared_mv<view_type_a_ls, Device>(1024, 5);
+  Test::impl_test_nrm2w_squared_mv<view_type_a_ls, Device>(789, 1);
+  // Test::impl_test_nrm2w_squared_mv<view_type_a_ls, Device>(132231,5);
 #endif
 
   return 1;
@@ -176,14 +172,14 @@ int test_nrm2_mv() {
 #if defined(KOKKOSKERNELS_INST_FLOAT) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) && \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-TEST_F(TestCategory, nrm2_float) {
-  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2_float");
-  test_nrm2<float, TestExecSpace>();
+TEST_F(TestCategory, nrm2w_squared_float) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2w_squared_float");
+  test_nrm2w_squared<float, TestExecSpace>();
   Kokkos::Profiling::popRegion();
 }
-TEST_F(TestCategory, nrm2_mv_float) {
-  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2_mv_float");
-  test_nrm2_mv<float, TestExecSpace>();
+TEST_F(TestCategory, nrm2w_squared_mv_float) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2w_squared_mv_float");
+  test_nrm2w_squared_mv<float, TestExecSpace>();
   Kokkos::Profiling::popRegion();
 }
 #endif
@@ -191,14 +187,14 @@ TEST_F(TestCategory, nrm2_mv_float) {
 #if defined(KOKKOSKERNELS_INST_DOUBLE) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&  \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-TEST_F(TestCategory, nrm2_double) {
-  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2_double");
-  test_nrm2<double, TestExecSpace>();
+TEST_F(TestCategory, nrm2w_squared_double) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2w_squared_double");
+  test_nrm2w_squared<double, TestExecSpace>();
   Kokkos::Profiling::popRegion();
 }
-TEST_F(TestCategory, nrm2_mv_double) {
-  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2_mv_double");
-  test_nrm2_mv<double, TestExecSpace>();
+TEST_F(TestCategory, nrm2w_squared_mv_double) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2w_squared_mv_double");
+  test_nrm2w_squared_mv<double, TestExecSpace>();
   Kokkos::Profiling::popRegion();
 }
 #endif
@@ -206,14 +202,16 @@ TEST_F(TestCategory, nrm2_mv_double) {
 #if defined(KOKKOSKERNELS_INST_COMPLEX_DOUBLE) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&          \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-TEST_F(TestCategory, nrm2_complex_double) {
-  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2_complex_double");
-  test_nrm2<Kokkos::complex<double>, TestExecSpace>();
+TEST_F(TestCategory, nrm2w_squared_complex_double) {
+  Kokkos::Profiling::pushRegion(
+      "KokkosBlas::Test::nrm2w_squared_complex_double");
+  test_nrm2w_squared<Kokkos::complex<double>, TestExecSpace>();
   Kokkos::Profiling::popRegion();
 }
-TEST_F(TestCategory, nrm2_mv_complex_double) {
-  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2_mv_complex_double");
-  test_nrm2_mv<Kokkos::complex<double>, TestExecSpace>();
+TEST_F(TestCategory, nrm2w_squared_mv_complex_double) {
+  Kokkos::Profiling::pushRegion(
+      "KokkosBlas::Test::nrm2w_squared_mv_complex_double");
+  test_nrm2w_squared_mv<Kokkos::complex<double>, TestExecSpace>();
   Kokkos::Profiling::popRegion();
 }
 #endif
@@ -221,14 +219,14 @@ TEST_F(TestCategory, nrm2_mv_complex_double) {
 #if defined(KOKKOSKERNELS_INST_INT) ||   \
     (!defined(KOKKOSKERNELS_ETI_ONLY) && \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-TEST_F(TestCategory, nrm2_int) {
-  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2_int");
-  test_nrm2<int, TestExecSpace>();
+TEST_F(TestCategory, nrm2w_squared_int) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2w_squared_int");
+  test_nrm2w_squared<int, TestExecSpace>();
   Kokkos::Profiling::popRegion();
 }
-TEST_F(TestCategory, nrm2_mv_int) {
-  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2_mv_int");
-  test_nrm2_mv<int, TestExecSpace>();
+TEST_F(TestCategory, nrm2w_squared_mv_int) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2w_squared_mv_int");
+  test_nrm2w_squared_mv<int, TestExecSpace>();
   Kokkos::Profiling::popRegion();
 }
 #endif

--- a/packages/kokkos-kernels/unit_test/blas/Test_Blas1_sum.hpp
+++ b/packages/kokkos-kernels/unit_test/blas/Test_Blas1_sum.hpp
@@ -133,6 +133,7 @@ int test_sum_mv() {
   Test::impl_test_sum_mv<view_type_a_ll, Device>(0, 5);
   Test::impl_test_sum_mv<view_type_a_ll, Device>(13, 5);
   Test::impl_test_sum_mv<view_type_a_ll, Device>(1024, 5);
+  Test::impl_test_sum_mv<view_type_a_ll, Device>(789, 1);
   // Test::impl_test_sum_mv<view_type_a_ll, Device>(132231,5);
 #endif
 
@@ -143,6 +144,7 @@ int test_sum_mv() {
   Test::impl_test_sum_mv<view_type_a_lr, Device>(0, 5);
   Test::impl_test_sum_mv<view_type_a_lr, Device>(13, 5);
   Test::impl_test_sum_mv<view_type_a_lr, Device>(1024, 5);
+  Test::impl_test_sum_mv<view_type_a_lr, Device>(789, 1);
   // Test::impl_test_sum_mv<view_type_a_lr, Device>(132231,5);
 #endif
 
@@ -153,6 +155,7 @@ int test_sum_mv() {
   Test::impl_test_sum_mv<view_type_a_ls, Device>(0, 5);
   Test::impl_test_sum_mv<view_type_a_ls, Device>(13, 5);
   Test::impl_test_sum_mv<view_type_a_ls, Device>(1024, 5);
+  Test::impl_test_sum_mv<view_type_a_ls, Device>(789, 1);
   // Test::impl_test_sum_mv<view_type_a_ls, Device>(132231,5);
 #endif
 

--- a/packages/tpetra/core/src/Tpetra_Details_normImpl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_normImpl.hpp
@@ -151,37 +151,18 @@ lclNormImpl (const RV& normsOut,
   }
   else { // lclNumRows != 0
     if (constantStride) {
-      if (X.extent(1) == 1) {
-        auto normsOut_0d = Kokkos::subview (normsOut, 0);
-        auto X_1d = Kokkos::subview (X, Kokkos::ALL(), 0);
-        if (whichNorm == NORM_INF) {
-          KokkosBlas::nrminf (normsOut_0d, X_1d);
-        }
-        else if (whichNorm == NORM_ONE) {
-          KokkosBlas::nrm1 (normsOut_0d, X_1d);
-        }
-        else if (whichNorm == NORM_TWO) {
-          KokkosBlas::nrm2_squared (normsOut_0d, X_1d);
-        }
-        else {
-          TEUCHOS_TEST_FOR_EXCEPTION
-            (true, std::logic_error, "Should never get here!");
-        }
+      if (whichNorm == NORM_INF) {
+        KokkosBlas::nrminf (normsOut, X);
+      }
+      else if (whichNorm == NORM_ONE) {
+        KokkosBlas::nrm1 (normsOut, X);
+      }
+      else if (whichNorm == NORM_TWO) {
+        KokkosBlas::nrm2_squared (normsOut, X);
       }
       else {
-        if (whichNorm == NORM_INF) {
-          KokkosBlas::nrminf (normsOut, X);
-        }
-        else if (whichNorm == NORM_ONE) {
-          KokkosBlas::nrm1 (normsOut, X);
-        }
-        else if (whichNorm == NORM_TWO) {
-          KokkosBlas::nrm2_squared (normsOut, X);
-        }
-        else {
-          TEUCHOS_TEST_FOR_EXCEPTION
-            (true, std::logic_error, "Should never get here!");
-        }
+        TEUCHOS_TEST_FOR_EXCEPTION
+          (true, std::logic_error, "Should never get here!");
       }
     }
     else { // not constant stride


### PR DESCRIPTION
This patches in Kokkos Kernels PR #1354, which restores the special
path in BLAS-1 MV reduction-like kernels for when there is only one
column. This path just calls the single-column kernel, which is a simple
parallel_reduce. This path existed before but I accidentally removed it.
This also reverts #10415 since Tpetra won't need to intercept the special path
if Kokkos Kernels is taking care of it.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/kokkos-kernels 
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
For multivectors (rank-2 views) with a single column, the single-column kernels use a simple parallel_reduce and get much better performance than the general multivector kernel. This restores the single-column path for all the BLAS-1 reduction-like kernels.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:
-->
## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows #10415
* Precedes 
* Related to #10463
* Part of 
* Composed of 


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
This expands KokkosKernel's BLAS-1 tests - now the rank-2 interface is tested with Nx1 vectors, and the weighted 2-norm kernels ``nrm2w`` and ``nrm2w_squared`` are tested (they weren't before).
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->