### PR TITLE
Sacado:  Fix Cuda 11 error about variables being undefined in device code

### DIFF
--- a/packages/sacado/src/Kokkos_DynRankView_Fad.hpp
+++ b/packages/sacado/src/Kokkos_DynRankView_Fad.hpp
@@ -350,12 +350,12 @@ namespace Impl {
 template <unsigned> struct AssignDim7 {
   template <typename Dst>
   KOKKOS_INLINE_FUNCTION
-  static void eval(Dst& dst, const size_t& src_dim) {}
+  static void eval(Dst& dst, const size_t src_dim) {}
 };
 template <> struct AssignDim7<0u> {
   template <typename Dst>
   KOKKOS_INLINE_FUNCTION
-  static void eval(Dst& dst, const size_t& src_dim) {
+  static void eval(Dst& dst, const size_t src_dim) {
     dst.N7 = src_dim;
   }
 };


### PR DESCRIPTION
This fixes a build error with Cuda 11 in Sacado about certain variables being
undefined in device code.  The cause is taking a reference to certain
static constexpr variables, which according to this:

https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#const-variables

is not allowed in device code.  Passing by value appears to resolve it.

For issue #10342 