### PR TITLE
MueLu: Change schur complement inverse data type

### DIFF
--- a/packages/muelu/src/Misc/MueLu_InverseApproximationFactory_decl.hpp
+++ b/packages/muelu/src/Misc/MueLu_InverseApproximationFactory_decl.hpp
@@ -112,11 +112,7 @@ namespace MueLu {
     //@{
 
     //! Constructor.
-    InverseApproximationFactory() { }
-
-    //! Destructor.
-    virtual ~InverseApproximationFactory() { }
-    //@}
+    InverseApproximationFactory() = default;
 
     //! Input
     //@{

--- a/packages/muelu/src/Misc/MueLu_SchurComplementFactory_decl.hpp
+++ b/packages/muelu/src/Misc/MueLu_SchurComplementFactory_decl.hpp
@@ -121,11 +121,7 @@ namespace MueLu {
     //@{
 
     //! Constructor.
-    SchurComplementFactory() { }
-
-    //! Destructor.
-    virtual ~SchurComplementFactory() { }
-    //@}
+    SchurComplementFactory() = default;
 
     //! Input
     //@{
@@ -146,8 +142,8 @@ namespace MueLu {
 
 
   private:
-
-    RCP<Matrix> ComputeSchurComplement(RCP<BlockedCrsMatrix>& bA, RCP<Vector>& Ainv) const;
+    //! Schur complement calculation method.
+    RCP<Matrix> ComputeSchurComplement(RCP<BlockedCrsMatrix>& bA, RCP<Matrix>& Ainv) const;
 
   }; // class SchurComplementFactory
 

--- a/packages/muelu/test/unit_tests/InverseApproximationFactory.cpp
+++ b/packages/muelu/test/unit_tests/InverseApproximationFactory.cpp
@@ -90,12 +90,16 @@ namespace MueLuTests {
       // generate Schur complement operator
       invapproxFact->Build(level);
 
-      RCP<Vector> Ainv = level.Get<RCP<Vector> >("Ainv", invapproxFact.get());
+      RCP<Matrix> Ainv = level.Get<RCP<Matrix> >("Ainv", invapproxFact.get());
       TEST_EQUALITY(Ainv.is_null(), false);
-      TEST_EQUALITY(Ainv->getMap()->getMinGlobalIndex(), comm->getRank() * int(n/comm->getSize()));
-      TEST_EQUALITY(Ainv->getMap()->getMaxGlobalIndex(), comm->getRank() * int(n/comm->getSize()) + int(n/comm->getSize()-1));
+      TEST_EQUALITY(Ainv->getRangeMap()->getMinGlobalIndex(), comm->getRank() * int(n/comm->getSize()));
+      TEST_EQUALITY(Ainv->getRangeMap()->getMaxGlobalIndex(), comm->getRank() * int(n/comm->getSize()) + int(n/comm->getSize()-1));
+      TEST_EQUALITY(Ainv->getDomainMap()->getMinGlobalIndex(), comm->getRank() * int(n/comm->getSize()));
+      TEST_EQUALITY(Ainv->getDomainMap()->getMaxGlobalIndex(), comm->getRank() * int(n/comm->getSize()) + int(n/comm->getSize()-1));
 
-      Teuchos::ArrayRCP<const Scalar> AinvData = Ainv->getData(0);
+      const RCP<Vector> AinvDiagonal = VectorFactory::Build(Ainv->getRangeMap(), true);
+      Ainv->getLocalDiagCopy(*AinvDiagonal);
+      Teuchos::ArrayRCP<const Scalar> AinvData = AinvDiagonal->getData(0);
       bool bCheck = true;
       for(int i=0; i<int(n/comm->getSize()); i++) if(AinvData[i] != Teuchos::as<Scalar>(0.5)) bCheck = false;
       TEST_EQUALITY(bCheck, true);
@@ -119,12 +123,16 @@ namespace MueLuTests {
       // generate Schur complement operator
       invapproxFact->Build(level);
 
-      RCP<Vector> Ainv = level.Get<RCP<Vector> >("Ainv", invapproxFact.get());
+      RCP<Matrix> Ainv = level.Get<RCP<Matrix> >("Ainv", invapproxFact.get());
       TEST_EQUALITY(Ainv.is_null(), false);
-      TEST_EQUALITY(Ainv->getMap()->getMinGlobalIndex(), comm->getRank() * int(n*n/comm->getSize()));
-      TEST_EQUALITY(Ainv->getMap()->getMaxGlobalIndex(), comm->getRank() * int(n*n/comm->getSize()) + int(n*n/comm->getSize()-1));
+      TEST_EQUALITY(Ainv->getRangeMap()->getMinGlobalIndex(), comm->getRank() * int(n*n/comm->getSize()));
+      TEST_EQUALITY(Ainv->getRangeMap()->getMaxGlobalIndex(), comm->getRank() * int(n*n/comm->getSize()) + int(n*n/comm->getSize()-1));
+      TEST_EQUALITY(Ainv->getDomainMap()->getMinGlobalIndex(), comm->getRank() * int(n*n/comm->getSize()));
+      TEST_EQUALITY(Ainv->getDomainMap()->getMaxGlobalIndex(), comm->getRank() * int(n*n/comm->getSize()) + int(n*n/comm->getSize()-1));
 
-      Teuchos::ArrayRCP<const Scalar> AinvData = Ainv->getData(0);
+      const RCP<Vector> AinvDiagonal = VectorFactory::Build(Ainv->getRangeMap(), true);
+      Ainv->getLocalDiagCopy(*AinvDiagonal);
+      Teuchos::ArrayRCP<const Scalar> AinvData = AinvDiagonal->getData(0);
       bool bCheck = true;
       for(int i=0; i<int(n*n/comm->getSize()); i++) if(AinvData[i] != Teuchos::as<Scalar>(0.25)) bCheck = false;
       TEST_EQUALITY(bCheck, true);
@@ -161,12 +169,16 @@ namespace MueLuTests {
       // generate Schur complement operator
       invapproxFact->Build(level);
 
-      RCP<Vector> Ainv = level.Get<RCP<Vector> >("Ainv", invapproxFact.get());
+      RCP<Matrix> Ainv = level.Get<RCP<Matrix> >("Ainv", invapproxFact.get());
       TEST_EQUALITY(Ainv.is_null(), false);
-      TEST_EQUALITY(Ainv->getMap()->getMinGlobalIndex(), comm->getRank() * int(n/comm->getSize()));
-      TEST_EQUALITY(Ainv->getMap()->getMaxGlobalIndex(), comm->getRank() * int(n/comm->getSize()) + int(n/comm->getSize()-1));
+      TEST_EQUALITY(Ainv->getRangeMap()->getMinGlobalIndex(), comm->getRank() * int(n/comm->getSize()));
+      TEST_EQUALITY(Ainv->getRangeMap()->getMaxGlobalIndex(), comm->getRank() * int(n/comm->getSize()) + int(n/comm->getSize()-1));
+      TEST_EQUALITY(Ainv->getDomainMap()->getMinGlobalIndex(), comm->getRank() * int(n/comm->getSize()));
+      TEST_EQUALITY(Ainv->getDomainMap()->getMaxGlobalIndex(), comm->getRank() * int(n/comm->getSize()) + int(n/comm->getSize()-1));
 
-      Teuchos::ArrayRCP<const Scalar> AinvData = Ainv->getData(0);
+      const RCP<Vector> AinvDiagonal = VectorFactory::Build(Ainv->getRangeMap(), true);
+      Ainv->getLocalDiagCopy(*AinvDiagonal);
+      Teuchos::ArrayRCP<const Scalar> AinvData = AinvDiagonal->getData(0);
       bool bCheck = false;
       for(int i=0; i<int(n/comm->getSize()); i++)
         if(std::abs(AinvData[i] - Teuchos::as<Scalar>(0.66666666667)) < std::abs(Teuchos::as<Scalar>(1e-8)) ||
@@ -193,12 +205,16 @@ namespace MueLuTests {
       // generate Schur complement operator
       invapproxFact->Build(level);
 
-      RCP<Vector> Ainv = level.Get<RCP<Vector> >("Ainv", invapproxFact.get());
+      RCP<Matrix> Ainv = level.Get<RCP<Matrix> >("Ainv", invapproxFact.get());
       TEST_EQUALITY(Ainv.is_null(), false);
-      TEST_EQUALITY(Ainv->getMap()->getMinGlobalIndex(), comm->getRank() * int(n*n/comm->getSize()));
-      TEST_EQUALITY(Ainv->getMap()->getMaxGlobalIndex(), comm->getRank() * int(n*n/comm->getSize()) + int(n*n/comm->getSize()-1));
+      TEST_EQUALITY(Ainv->getRangeMap()->getMinGlobalIndex(), comm->getRank() * int(n*n/comm->getSize()));
+      TEST_EQUALITY(Ainv->getRangeMap()->getMaxGlobalIndex(), comm->getRank() * int(n*n/comm->getSize()) + int(n*n/comm->getSize()-1));
+      TEST_EQUALITY(Ainv->getDomainMap()->getMinGlobalIndex(), comm->getRank() * int(n*n/comm->getSize()));
+      TEST_EQUALITY(Ainv->getDomainMap()->getMaxGlobalIndex(), comm->getRank() * int(n*n/comm->getSize()) + int(n*n/comm->getSize()-1));
 
-      Teuchos::ArrayRCP<const Scalar> AinvData = Ainv->getData(0);
+      const RCP<Vector> AinvDiagonal = VectorFactory::Build(Ainv->getRangeMap(), true);
+      Ainv->getLocalDiagCopy(*AinvDiagonal);
+      Teuchos::ArrayRCP<const Scalar> AinvData = AinvDiagonal->getData(0);
       bool bCheck = false;
       for(int i=0; i<int(n*n/comm->getSize()); i++)
         if(std::abs(AinvData[i] - Teuchos::as<Scalar>(0.166667)) < std::abs(Teuchos::as<Scalar>(1e-6)) ||

--- a/packages/xpetra/src/BlockedCrsMatrix/Xpetra_BlockedCrsMatrix.hpp
+++ b/packages/xpetra/src/BlockedCrsMatrix/Xpetra_BlockedCrsMatrix.hpp
@@ -88,6 +88,10 @@
 */
 namespace Xpetra {
 
+#ifdef HAVE_XPETRA_THYRA
+  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node> class ThyraUtils;
+#endif
+
   typedef std::string viewLabel_t;
 
   template <class Scalar,

--- a/packages/xpetra/sup/Utils/Xpetra_MatrixMatrix.hpp
+++ b/packages/xpetra/sup/Utils/Xpetra_MatrixMatrix.hpp
@@ -548,6 +548,19 @@ Note: this class is not in the Xpetra_UseShortNames.hpp
             if (crmat1.is_null() || crmat2.is_null())
               continue;
 
+            // try unwrapping 1x1 blocked matrix
+            {
+              auto unwrap1 = Teuchos::rcp_dynamic_cast<BlockedCrsMatrix>(crmat1);
+              auto unwrap2 = Teuchos::rcp_dynamic_cast<BlockedCrsMatrix>(crmat2);
+
+              if(unwrap1.is_null() != unwrap2.is_null())  {
+                if(unwrap1 != Teuchos::null && unwrap1->Rows() == 1 && unwrap1->Cols() == 1)
+                  crmat1 = unwrap1->getCrsMatrix();
+                if(unwrap2 != Teuchos::null && unwrap2->Rows() == 1 && unwrap2->Cols() == 1)
+                  crmat2 = unwrap2->getCrsMatrix();
+              }
+            }
+
             RCP<CrsMatrixWrap> crop1 = Teuchos::rcp_dynamic_cast<CrsMatrixWrap>(crmat1);
             RCP<CrsMatrixWrap> crop2 = Teuchos::rcp_dynamic_cast<CrsMatrixWrap>(crmat2);
             TEUCHOS_TEST_FOR_EXCEPTION(crop1.is_null() != crop2.is_null(), Xpetra::Exceptions::RuntimeError,
@@ -1217,6 +1230,19 @@ Note: this class is not in the Xpetra_UseShortNames.hpp
             if (crmat1.is_null() || crmat2.is_null())
               continue;
 
+            // try unwrapping 1x1 blocked matrix
+            {
+              auto unwrap1 = Teuchos::rcp_dynamic_cast<BlockedCrsMatrix>(crmat1);
+              auto unwrap2 = Teuchos::rcp_dynamic_cast<BlockedCrsMatrix>(crmat2);
+
+              if(unwrap1.is_null() != unwrap2.is_null())  {
+                if(unwrap1 != Teuchos::null && unwrap1->Rows() == 1 && unwrap1->Cols() == 1)
+                  crmat1 = unwrap1->getCrsMatrix();
+                if(unwrap2 != Teuchos::null && unwrap2->Rows() == 1 && unwrap2->Cols() == 1)
+                  crmat2 = unwrap2->getCrsMatrix();
+              }
+            }
+
             RCP<CrsMatrixWrap> crop1 = Teuchos::rcp_dynamic_cast<CrsMatrixWrap>(crmat1);
             RCP<CrsMatrixWrap> crop2 = Teuchos::rcp_dynamic_cast<CrsMatrixWrap>(crmat2);
             TEUCHOS_TEST_FOR_EXCEPTION(crop1.is_null() != crop2.is_null(), Xpetra::Exceptions::RuntimeError,
@@ -1803,6 +1829,19 @@ Note: this class is not in the Xpetra_UseShortNames.hpp
 
             if (crmat1.is_null() || crmat2.is_null())
               continue;
+
+            // try unwrapping 1x1 blocked matrix
+            {
+              auto unwrap1 = Teuchos::rcp_dynamic_cast<BlockedCrsMatrix>(crmat1);
+              auto unwrap2 = Teuchos::rcp_dynamic_cast<BlockedCrsMatrix>(crmat2);
+
+              if(unwrap1.is_null() != unwrap2.is_null())  {
+                if(unwrap1 != Teuchos::null && unwrap1->Rows() == 1 && unwrap1->Cols() == 1)
+                  crmat1 = unwrap1->getCrsMatrix();
+                if(unwrap2 != Teuchos::null && unwrap2->Rows() == 1 && unwrap2->Cols() == 1)
+                  crmat2 = unwrap2->getCrsMatrix();
+              }
+            }
 
             RCP<CrsMatrixWrap> crop1 = Teuchos::rcp_dynamic_cast<CrsMatrixWrap>(crmat1);
             RCP<CrsMatrixWrap> crop2 = Teuchos::rcp_dynamic_cast<CrsMatrixWrap>(crmat2);

--- a/packages/xpetra/sup/Utils/Xpetra_ThyraUtils.hpp
+++ b/packages/xpetra/sup/Utils/Xpetra_ThyraUtils.hpp
@@ -64,6 +64,7 @@
 #include "Xpetra_Map.hpp"
 #include "Xpetra_BlockedMap.hpp"
 #include "Xpetra_BlockedMultiVector.hpp"
+#include "Xpetra_BlockedCrsMatrix.hpp"
 #include "Xpetra_MapUtils.hpp"
 #include "Xpetra_StridedMap.hpp"
 #include "Xpetra_StridedMapFactory.hpp"

--- a/packages/xpetra/test/BlockedCrsMatrix/BlockedCrsMatrix_UnitTests.cpp
+++ b/packages/xpetra/test/BlockedCrsMatrix/BlockedCrsMatrix_UnitTests.cpp
@@ -2862,6 +2862,81 @@ TEUCHOS_UNIT_TEST_TEMPLATE_6_DECL( BlockedCrsMatrix, ConstructFromMapExtractor, 
   TEST_ASSERT(!blockMatrix.is_null());
 }
 
+TEUCHOS_UNIT_TEST_TEMPLATE_6_DECL( BlockedCrsMatrix, ConstructFromBlockedVector, M, MA, Scalar, LO, GO, Node )
+{
+  using Teuchos::Array;
+  using Teuchos::ArrayView;
+  using Teuchos::RCP;
+  using Teuchos::rcp;
+
+  using BlockedCrsMatrix = Xpetra::BlockedCrsMatrix<Scalar,LO,GO,Node>;
+  using BlockedMap = Xpetra::BlockedMap<LO,GO,Node>;
+  using Map = Xpetra::Map<LO,GO,Node>;
+  using MapFactory = Xpetra::MapFactory<LO,GO,Node>;
+  using MapUtils = Xpetra::MapUtils<LO,GO,Node>;
+
+  RCP<const Teuchos::Comm<int> > comm = getDefaultComm();
+
+  M testMap(1, 0, comm);
+  Xpetra::UnderlyingLib lib = testMap.lib();
+
+  const GO gNumElementsPerBlock = 29;
+  Array<GO> gidsOne;
+
+  RCP<const Map> map1 = MapFactory::Build(lib, gNumElementsPerBlock, Teuchos::ScalarTraits<GO>::zero(), comm);
+
+  TEST_ASSERT(!map1.is_null());
+  TEST_EQUALITY_CONST(map1->getGlobalNumElements(), gNumElementsPerBlock);
+
+  ArrayView<const GO> myGIDs1 = map1->getLocalElementList();
+  Array<GO> myGIDs2;
+  for (const auto& gid1 : myGIDs1)
+    myGIDs2.push_back(gid1 + gNumElementsPerBlock);
+  RCP<const Map> map2 = MapFactory::Build(lib, gNumElementsPerBlock, myGIDs2, Teuchos::ScalarTraits<GO>::zero(), comm);
+
+  TEST_ASSERT(!map2.is_null());
+  TEST_EQUALITY_CONST(map2->getGlobalNumElements(), gNumElementsPerBlock);
+
+  std::vector<RCP<const Map>> maps;
+  maps.push_back(map1);
+  maps.push_back(map2);
+  RCP<const Map> fullMap = MapUtils::concatenateMaps(maps);
+  RCP<const BlockedMap> blockedMap = rcp(new BlockedMap(fullMap, maps));
+
+  TEST_ASSERT(!blockedMap.is_null());
+  TEST_EQUALITY(blockedMap->getNumMaps(), 2);
+
+  const RCP<Xpetra::Vector<Scalar, LO, GO, Node> > vec = Xpetra::VectorFactory<Scalar, LO, GO, Node>::Build(blockedMap);
+  vec->randomize();
+
+  RCP<Xpetra::BlockedVector<Scalar,LO,GO,Node> > blockVec =
+          Teuchos::rcp_dynamic_cast<Xpetra::BlockedVector<Scalar,LO,GO,Node> >(vec);
+  TEST_ASSERT(!blockVec.is_null());
+
+  RCP<Xpetra::Matrix<Scalar,LO,GO,Node> > matrix = Xpetra::MatrixFactory<Scalar,LO,GO,Node>::Build(vec.getConst());
+  TEST_ASSERT(!matrix.is_null());
+
+  RCP<Xpetra::BlockedCrsMatrix<Scalar,LO,GO,Node> > blockMatrix =
+          Teuchos::rcp_dynamic_cast<Xpetra::BlockedCrsMatrix<Scalar,LO,GO,Node> >(matrix);
+  TEST_ASSERT(!blockMatrix.is_null());
+
+  const RCP<Xpetra::Vector<Scalar, LO, GO, Node> > diagonal = Xpetra::VectorFactory<Scalar, LO, GO, Node>::Build(blockedMap);
+  blockMatrix->getLocalDiagCopy(*diagonal);
+  TEST_ASSERT(!diagonal.is_null());
+
+  RCP<Xpetra::BlockedVector<Scalar,LO,GO,Node> > blockDiagonal =
+          Teuchos::rcp_dynamic_cast<Xpetra::BlockedVector<Scalar,LO,GO,Node> >(diagonal);
+  TEST_ASSERT(!blockDiagonal.is_null());
+
+  TEST_EQUALITY(gNumElementsPerBlock, blockMatrix->getMatrix(0,0)->getGlobalNumEntries());
+  TEST_FLOATING_EQUALITY(blockVec->getMultiVector(0)->getVector(0)->norm2(), blockDiagonal->getMultiVector(0)->getVector(0)->norm2(), Teuchos::as<Scalar>(1e-12));
+  TEST_FLOATING_EQUALITY(blockVec->getMultiVector(1)->getVector(0)->norm2(), blockDiagonal->getMultiVector(1)->getVector(0)->norm2(), Teuchos::as<Scalar>(1e-12));
+  TEST_EQUALITY(gNumElementsPerBlock, blockMatrix->getMatrix(1,1)->getGlobalNumEntries());
+  TEST_FLOATING_EQUALITY(blockVec->getMultiVector(0)->getVector(0)->norm2(), blockMatrix->getMatrix(0,0)->getFrobeniusNorm(), Teuchos::as<Scalar>(1e-12));
+  TEST_FLOATING_EQUALITY(blockVec->getMultiVector(1)->getVector(0)->norm2(), blockMatrix->getMatrix(1,1)->getFrobeniusNorm(), Teuchos::as<Scalar>(1e-12));
+  TEST_FLOATING_EQUALITY(blockVec->norm2(), blockDiagonal->norm2(), Teuchos::as<Scalar>(1e-12));
+  TEST_FLOATING_EQUALITY(blockVec->norm2(), blockMatrix->getFrobeniusNorm(), Teuchos::as<Scalar>(1e-12));
+}
 
 // simple test for matrix-matrix multiplication for a 2x2 blocked matrix with a 2x1 blocked matrix
 TEUCHOS_UNIT_TEST_TEMPLATE_6_DECL( BlockedCrsMatrix, EpetraMatrixMatrixMult2x1,  M, MA, Scalar, LO, GO, Node )
@@ -3010,7 +3085,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_6_DECL( BlockedCrsMatrix, EpetraMatrixMatrixMult2x1, 
     TEUCHOS_UNIT_TEST_TEMPLATE_6_INSTANT( BlockedCrsMatrix, MatrixMatrixMult, M##LO##GO##N , MA##S##LO##GO##N, S, LO, GO, N ) \
     TEUCHOS_UNIT_TEST_TEMPLATE_6_INSTANT( BlockedCrsMatrix, BlockedOperatorApply, M##LO##GO##N , MA##S##LO##GO##N, S, LO, GO, N ) \
     TEUCHOS_UNIT_TEST_TEMPLATE_6_INSTANT( BlockedCrsMatrix, ConstructFromBlockedMap, M##LO##GO##N , MA##S##LO##GO##N, S, LO, GO, N ) \
-    TEUCHOS_UNIT_TEST_TEMPLATE_6_INSTANT( BlockedCrsMatrix, ConstructFromMapExtractor, M##LO##GO##N , MA##S##LO##GO##N, S, LO, GO, N )
+    TEUCHOS_UNIT_TEST_TEMPLATE_6_INSTANT( BlockedCrsMatrix, ConstructFromMapExtractor, M##LO##GO##N , MA##S##LO##GO##N, S, LO, GO, N ) \
+    TEUCHOS_UNIT_TEST_TEMPLATE_6_INSTANT( BlockedCrsMatrix, ConstructFromBlockedVector, M##LO##GO##N , MA##S##LO##GO##N, S, LO, GO, N )
 
 // List of tests which run only with Tpetra
 #define XP_TPETRA_MATRIX_INSTANT(S,LO,GO,N) \

--- a/packages/xpetra/test/BlockedCrsMatrix/BlockedCrsMatrix_UnitTests.cpp
+++ b/packages/xpetra/test/BlockedCrsMatrix/BlockedCrsMatrix_UnitTests.cpp
@@ -2875,6 +2875,9 @@ TEUCHOS_UNIT_TEST_TEMPLATE_6_DECL( BlockedCrsMatrix, ConstructFromBlockedVector,
   using MapFactory = Xpetra::MapFactory<LO,GO,Node>;
   using MapUtils = Xpetra::MapUtils<LO,GO,Node>;
 
+  using STS = Teuchos::ScalarTraits<Scalar>;
+  typedef typename STS::magnitudeType MT;
+
   RCP<const Teuchos::Comm<int> > comm = getDefaultComm();
 
   M testMap(1, 0, comm);
@@ -2928,14 +2931,16 @@ TEUCHOS_UNIT_TEST_TEMPLATE_6_DECL( BlockedCrsMatrix, ConstructFromBlockedVector,
           Teuchos::rcp_dynamic_cast<Xpetra::BlockedVector<Scalar,LO,GO,Node> >(diagonal);
   TEST_ASSERT(!blockDiagonal.is_null());
 
+  const MT tol = 1e-12;
+
   TEST_EQUALITY(gNumElementsPerBlock, blockMatrix->getMatrix(0,0)->getGlobalNumEntries());
-  TEST_FLOATING_EQUALITY(blockVec->getMultiVector(0)->getVector(0)->norm2(), blockDiagonal->getMultiVector(0)->getVector(0)->norm2(), Teuchos::as<Scalar>(1e-12));
-  TEST_FLOATING_EQUALITY(blockVec->getMultiVector(1)->getVector(0)->norm2(), blockDiagonal->getMultiVector(1)->getVector(0)->norm2(), Teuchos::as<Scalar>(1e-12));
+  TEST_FLOATING_EQUALITY(blockVec->getMultiVector(0)->getVector(0)->norm2(), blockDiagonal->getMultiVector(0)->getVector(0)->norm2(), tol);
+  TEST_FLOATING_EQUALITY(blockVec->getMultiVector(1)->getVector(0)->norm2(), blockDiagonal->getMultiVector(1)->getVector(0)->norm2(), tol);
   TEST_EQUALITY(gNumElementsPerBlock, blockMatrix->getMatrix(1,1)->getGlobalNumEntries());
-  TEST_FLOATING_EQUALITY(blockVec->getMultiVector(0)->getVector(0)->norm2(), blockMatrix->getMatrix(0,0)->getFrobeniusNorm(), Teuchos::as<Scalar>(1e-12));
-  TEST_FLOATING_EQUALITY(blockVec->getMultiVector(1)->getVector(0)->norm2(), blockMatrix->getMatrix(1,1)->getFrobeniusNorm(), Teuchos::as<Scalar>(1e-12));
-  TEST_FLOATING_EQUALITY(blockVec->norm2(), blockDiagonal->norm2(), Teuchos::as<Scalar>(1e-12));
-  TEST_FLOATING_EQUALITY(blockVec->norm2(), blockMatrix->getFrobeniusNorm(), Teuchos::as<Scalar>(1e-12));
+  TEST_FLOATING_EQUALITY(blockVec->getMultiVector(0)->getVector(0)->norm2(), blockMatrix->getMatrix(0,0)->getFrobeniusNorm(), tol);
+  TEST_FLOATING_EQUALITY(blockVec->getMultiVector(1)->getVector(0)->norm2(), blockMatrix->getMatrix(1,1)->getFrobeniusNorm(), tol);
+  TEST_FLOATING_EQUALITY(blockVec->norm2(), blockDiagonal->norm2(), tol);
+  TEST_FLOATING_EQUALITY(blockVec->norm2(), blockMatrix->getFrobeniusNorm(), tol);
 }
 
 // simple test for matrix-matrix multiplication for a 2x2 blocked matrix with a 2x1 blocked matrix

--- a/packages/xpetra/test/CrsMatrix/CrsMatrix_UnitTests.cpp
+++ b/packages/xpetra/test/CrsMatrix/CrsMatrix_UnitTests.cpp
@@ -104,8 +104,10 @@ namespace {
 
   TEUCHOS_UNIT_TEST_TEMPLATE_5_DECL( CrsMatrix, Constructor_Vector, M, Scalar, LO, GO, Node )
   {
-    typedef Xpetra::Map<LO, GO, Node> MapClass;
-    typedef Xpetra::MapFactory<LO, GO, Node> MapFactoryClass;
+    using MapClass = Xpetra::Map<LO, GO, Node>;
+    using MapFactoryClass = Xpetra::MapFactory<LO, GO, Node>;
+    using STS = Teuchos::ScalarTraits<Scalar>;
+    typedef typename STS::magnitudeType MT;
 
     // get a comm and node
     RCP<const Teuchos::Comm<int> > comm = getDefaultComm();
@@ -114,19 +116,23 @@ namespace {
     Xpetra::UnderlyingLib lib = testMap.lib();
 
     // generate problem
-    LO nEle = 63;
+    const LO nEle = 63;
     const RCP<const MapClass> map = MapFactoryClass::Build(lib, nEle, 0, comm);
 
     const RCP<Xpetra::Vector<Scalar, LO, GO, Node> > vec = Xpetra::VectorFactory<Scalar, LO, GO, Node>::Build(map);
     vec->randomize();
     RCP<Xpetra::Matrix<Scalar,LO,GO,Node> > mat = Xpetra::MatrixFactory<Scalar,LO,GO,Node>::Build(vec.getConst());
+
+    const MT tol = 1e-12;
+
     TEST_ASSERT(!mat.is_null());
     TEST_EQUALITY(nEle, mat->getGlobalNumEntries());
-    TEST_FLOATING_EQUALITY(vec->norm2(), mat->getFrobeniusNorm(), Teuchos::as<Scalar>(1e-12));
+    TEST_FLOATING_EQUALITY(vec->norm2(), mat->getFrobeniusNorm(), tol);
 
     const RCP<Xpetra::Vector<Scalar, LO, GO, Node> > diagonal = Xpetra::VectorFactory<Scalar, LO, GO, Node>::Build(map);
+
     mat->getLocalDiagCopy(*diagonal);
-    TEST_FLOATING_EQUALITY(vec->norm2(), diagonal->norm2(), Teuchos::as<Scalar>(1e-12));
+    TEST_FLOATING_EQUALITY(vec->norm2(), diagonal->norm2(), tol);
   }
 
   TEUCHOS_UNIT_TEST_TEMPLATE_5_DECL( CrsMatrix, Apply, M, Scalar, LO, GO, Node )


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/muelu

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
For future modifications to the inverse approximation factory it makes sense to
change the inverse data type from a vector to a matrix. This of course has small 
drawbacks regarding performance of the schur complement factory (one additional matrix-matrix multiplication,
instead of a matrix-vector one), but gives greater flexibility on how an inverse is approximated.

- Changing the datatype of the inverse from a vector to a matrix
- Add a blocked version to the matrix constructor for diagonal matrices initialized by a vector

I had some issues regarding the blocked unit tests, due to data type incompatibilities (CrsMatrix / BlockedCrsMatrix) and therefore included some kind of unwrapping check inside the blocked matrix multiplication. Maybe there's a better way to do it, but the changes worked nicely for me.

## Related Issues
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:
-->
* Related to #10437

## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
AMG for block matrices with schur complement

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
-  modified the inverse appoximation factory unit testing to work with the data type change


Joined work with @mayrmt