### PR TITLE
Apply Trilinos changes to accept updated TriBITS (TriBITSPub/TriBITS#299)

### DIFF
--- a/packages/sacado/test/GTestSuite/CMakeLists.txt
+++ b/packages/sacado/test/GTestSuite/CMakeLists.txt
@@ -5,6 +5,8 @@ SET(gtest_disable_pthreads ON CACHE BOOL "Disable uses of pthreads in gtest")
 
 # Configure googletest
 add_subdirectory(googletest)
+set_target_properties(sacado-gtest gtest_main PROPERTIES
+  TRIBITS_TESTONLY_LIB TRUE)
 
 INCLUDE_DIRECTORIES(${PACKAGE_SOURCE_DIR}/Fad)
 INCLUDE_DIRECTORIES(${PACKAGE_SOURCE_DIR}/test/utils)


### PR DESCRIPTION
This applies the only change to Trilinos needed to accept the updated version of TriBITS.  This is the only commit from PR #9978 needed to allow building Trilinos with updated versions of TriBITS 'master'.

I am creating this PR because we can't merge PR #9978 due to a break in backward compatibility with the move to modern CMake (see [here](https://github.com/bartlettroscoe/Trilinos/blob/3281be9b5af148f16d9f507519d3e06b916b675c/RELEASE_NOTES#L7-L73)).  This will allow building Trilinos 'develop' against external TriBITS versions by just setting `Trilinos_TRIBITS_DIR` at configure time.  That is critical for testing updated versions of TriBITS.

