### PR TITLE
Intrepid2 CellGeometry node-based constructor may take (C,N,D) containers for indexing

### DIFF
--- a/packages/intrepid2/src/Cell/Intrepid2_CellGeometry.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellGeometry.hpp
@@ -169,10 +169,10 @@ namespace Intrepid2
                  SubdivisionStrategy subdivisionStrategy = NO_SUBDIVISION,
                  HypercubeNodeOrdering nodeOrdering = HYPERCUBE_NODE_ORDER_TENSOR);
     
-    /** \brief  Node-based constructor for straight-edged geometry.
+    /** \brief  Node-based constructor for straight-edged geometry. 
         \param [in] cellTopo - the cell topology for all cells.
         \param [in] cellToNodes - (C,LN) container specifying the global index of the local node.
-        \param [in] nodes - (GN,D) container specifying the coordinate weight for the global node in the specified dimension.
+        \param [in] nodes - (GN,D) container specifying the coordinate weight for the global node in the specified dimension; if cellToNodes is not allocated, this must be a (C,N,D) container
         \param [in] claimAffine - whether to assume (without checking) that the mapping from reference space is affine.  (If claimAffine is false, we check whether the cell topology is simplicial, and if so, set the affine_ member variable to true.)
         \param [in] nodeOrdering - applicable for hypercube cell topologies; specifies whether to use the order used by Shards (and lowest-order Intrepid2 bases), or the one used by higher-order Intrepid2 bases.
     */

--- a/packages/intrepid2/src/Cell/Intrepid2_CellGeometryDef.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellGeometryDef.hpp
@@ -513,9 +513,19 @@ namespace Intrepid2
   cellToNodes_(cellToNodes),
   nodes_(nodes)
   {
-    numCells_ = cellToNodes.extent_int(0);
-    numNodesPerCell_ = cellToNodes.extent_int(1);
-    INTREPID2_TEST_FOR_EXCEPTION_DEVICE_SAFE(numNodesPerCell_ != cellTopo.getNodeCount(), std::invalid_argument, "cellToNodes.extent(1) does not match the cell topology node count");
+    if(cellToNodes.is_allocated())
+    {
+      numCells_ = cellToNodes.extent_int(0);
+      numNodesPerCell_ = cellToNodes.extent_int(1);
+      INTREPID2_TEST_FOR_EXCEPTION_DEVICE_SAFE(numNodesPerCell_ != cellTopo.getNodeCount(), std::invalid_argument, "cellToNodes.extent(1) does not match the cell topology node count");
+    }
+    else
+    {
+      numCells_ = nodes.extent_int(0);
+      numNodesPerCell_ = nodes.extent_int(1);
+      INTREPID2_TEST_FOR_EXCEPTION_DEVICE_SAFE(numNodesPerCell_ != cellTopo.getNodeCount(), std::invalid_argument, "nodes.extent(1) does not match the cell topology node count");
+    }
+    
   
     if (!claimAffine)
     {


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/intrepid2 
@CamelliaDPG 

## Motivation
The `Intrepid2::CellGeometry` class allows `cellToNodes_` to be unallocated. In which case, `nodes_` is expected to be a `(C,N,D)` container for mesh nodes. One of the ways such a `(C,N,D)` container is commonly obtained is through `panzer_stk::STK_Interface.getElementVertices()`, so this also makes it slightly easier to pair with a `panzer_stk::STK_Interface` mesh.

The node-based constructor for straight-edge geometry previously checked the extents of `cellToNodes` to set the number of `numCells_` and `numNodesPerCell_` and vertices per cell. This updates it to check the allocation of `cellToNodes` first and then set `numCells_` and `numNodesPerCell_` using either the `cellToNodes` or `nodes`, accordingly.

## Testing
I tested this in an external code I'm using and my assembled matrix stayed the same after I switched it to use sum factorization with a `CellGeometry` constructed from the `STK_Interface` nodes.

I added a *very minimal* test to check if this constructor works when passed a `(C,N,D)` nodes container for the unit hexahedron with tensor ordering, but I didn't build it with tests turned on since I used it for linking against external codes, so I'm really just hoping to throw it at the autotester for testing. :crossed_fingers: 