### PR TITLE
Panzer: remove use of deprecated stk and kokkos code

### DIFF
--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_ExodusReaderFactory.cpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_ExodusReaderFactory.cpp
@@ -75,7 +75,7 @@ int getMeshDimension(const std::string & meshStr,
   meshData.property_add(Ioss::Property("LOWER_CASE_VARIABLE_NAMES", false));
   meshData.add_mesh_database(meshStr, fileTypeToIOSSType(typeStr), stk::io::READ_MESH);
   meshData.create_input_mesh();
-  return Teuchos::as<int>(meshData.meta_data_rcp()->spatial_dimension());
+  return Teuchos::as<int>(meshData.meta_data_ptr()->spatial_dimension());
 }
 
 std::string fileTypeToIOSSType(const std::string & fileType)
@@ -158,12 +158,12 @@ Teuchos::RCP<STK_Interface> STK_ExodusReaderFactory::buildUncommitedMesh(stk::Pa
    meshData->add_mesh_database(fileName_, fileTypeToIOSSType(fileType_), stk::io::READ_MESH);
 
    meshData->create_input_mesh();
-   RCP<stk::mesh::MetaData> metaData = meshData->meta_data_rcp();
+   RCP<stk::mesh::MetaData> metaData = Teuchos::rcp(meshData->meta_data_ptr());
 
    RCP<STK_Interface> mesh = rcp(new STK_Interface(metaData));
    mesh->initializeFromMetaData();
    mesh->instantiateBulkData(parallelMach);
-   meshData->set_bulk_data(mesh->getBulkData());
+   meshData->set_bulk_data(Teuchos::get_shared_ptr(mesh->getBulkData()));
 
    // read in other transient fields, these will be useful later when
    // trying to read other fields for use in solve

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.cpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.cpp
@@ -690,7 +690,7 @@ setupExodusFile(const std::string& filename,
 
   ParallelMachine comm = *mpiComm_->getRawMpiComm();
   meshData_ = rcp(new StkMeshIoBroker(comm));
-  meshData_->set_bulk_data(bulkData_);
+  meshData_->set_bulk_data(Teuchos::get_shared_ptr(bulkData_));
   Ioss::PropertyManager props;
   props.add(Ioss::Property("LOWER_CASE_VARIABLE_NAMES", "FALSE"));
   if (append) {

--- a/packages/panzer/adapters-stk/test/stk_interface_test/tPamgenMeshFactory.cpp
+++ b/packages/panzer/adapters-stk/test/stk_interface_test/tPamgenMeshFactory.cpp
@@ -88,9 +88,9 @@ TEUCHOS_UNIT_TEST(tPamgenFactory, acceptance)
     RCP<stk::io::StkMeshIoBroker> broker = rcp(new stk::io::StkMeshIoBroker(MPI_COMM_WORLD));
     broker->add_mesh_database("pamgen_test.gen", "pamgen", stk::io::READ_MESH);
     broker->create_input_mesh();
-    metaData = broker->meta_data_rcp();
+    metaData = Teuchos::rcp(broker->meta_data_ptr());
     bulkData = Teuchos::rcp(new stk::mesh::BulkData(*metaData,MPI_COMM_WORLD));
-    broker->set_bulk_data(bulkData);
+    broker->set_bulk_data(Teuchos::get_shared_ptr(bulkData));
     broker->add_all_mesh_fields_as_input_fields();
     broker->populate_bulk_data();
 
@@ -135,7 +135,7 @@ TEUCHOS_UNIT_TEST(tPamgenFactory, acceptance)
   {
     out << "\nWriting output file." << std::endl;
     RCP<stk::io::StkMeshIoBroker> broker = rcp(new stk::io::StkMeshIoBroker(MPI_COMM_WORLD));
-    broker->set_bulk_data(bulkData);
+    broker->set_bulk_data(Teuchos::get_shared_ptr(bulkData));
     auto meshIndex_ = broker->create_output_mesh(output_exodus_file_name,stk::io::PURPOSE_UNKNOWN);
 
     const stk::mesh::FieldVector& fields = metaData->get_fields();
@@ -170,9 +170,9 @@ TEUCHOS_UNIT_TEST(tPamgenFactory, acceptance)
     RCP<stk::io::StkMeshIoBroker> broker = rcp(new stk::io::StkMeshIoBroker(MPI_COMM_WORLD));
     broker->add_mesh_database(output_exodus_file_name, "exodus", stk::io::READ_MESH);
     broker->create_input_mesh();
-    metaData = broker->meta_data_rcp();
+    metaData = Teuchos::rcp(broker->meta_data_ptr());
     bulkData = Teuchos::rcp(new stk::mesh::BulkData(*metaData,MPI_COMM_WORLD));
-    broker->set_bulk_data(bulkData);
+    broker->set_bulk_data(Teuchos::get_shared_ptr(bulkData));
     broker->add_all_mesh_fields_as_input_fields();
     broker->populate_bulk_data();
 

--- a/packages/panzer/dof-mgr/test/fe_assembly/test_fe_projection.hpp
+++ b/packages/panzer/dof-mgr/test/fe_assembly/test_fe_projection.hpp
@@ -151,7 +151,7 @@ template<typename ValueType, typename DeviceSpaceType>
 int feProjection(int argc, char *argv[]) {
 
   typedef typename
-      Kokkos::Impl::is_space<DeviceSpaceType>::host_mirror_space::execution_space HostSpaceType ;
+      Kokkos::Impl::HostMirror<DeviceSpaceType>::Space::execution_space HostSpaceType ;
   typedef Kokkos::DynRankView<ValueType,DeviceSpaceType> DynRankView;
   typedef Kokkos::DynRankView<ValueType,HostSpaceType> DynRankViewHost;
 
@@ -639,7 +639,7 @@ int feProjection(int argc, char *argv[]) {
             auto it = mapL2Proj.find(gid);
             if (it==mapL2Proj.end())
               mapL2Proj.insert(std::make_pair(gid,basisCoeffsL2ProjHost(elemId, nodeId)));
-            else if(abs(it->second-basisCoeffsL2ProjHost(elemId, nodeId))>1e-10) {
+            else if(std::abs(it->second-basisCoeffsL2ProjHost(elemId, nodeId))>1e-10) {
               std::cout << "ERROR: DoFs shared by cells are not consistent \n"
                   "basisL2Proj(" << gid << "):" << it->second << " " << basisCoeffsL2ProjHost(elemId, nodeId) <<std::endl;
               errorFlag++;


### PR DESCRIPTION
## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Deprecated warnings from changes to stk and kokkos prevent trilinos sync to empire due to warnings as error builds.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->
EMPIRE 2282

## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
Fixes the sync

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
N/A

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->