### PR TITLE
Framework: Setup PR build for Clang 11.0.1

### DIFF
--- a/cmake/std/PullRequestLinuxClang11.0.1TestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxClang11.0.1TestingSettings.cmake
@@ -1,0 +1,39 @@
+# This file contains the options needed to both run the pull request testing
+# for Trilinos for the Linux Clang 11.0.1 pull request testing builds, and to reproduce
+# the errors reported by those builds. Prior to using this this file, the
+# appropriate set of SEMS modules must be loaded and accessible through the
+# SEMS NFS mount. (See the sems/PullRequest*TestingEnv.sh files.)
+
+# Usage: cmake -C PullRequestLinuxClang11.0.1TestingSettings.cmake
+
+# Misc options typically added by CI testing mode in TriBITS
+
+# Use the below option only when submitting to the dashboard
+#set (CTEST_USE_LAUNCHERS ON CACHE BOOL "Set by default for PR testing")
+
+#set (TPL_ENABLE_Netcdf OFF CACHE BOOL "Turn off for Clang")
+
+#set (TPL_Netcdf_LIBRARIES "-L$ENV{SEMS_NETCDF_ROOT}/lib;-L$ENV{SEMS_HDF5_ROOT}/lib;$ENV{SEMS_NETCDF_ROOT}/lib/libnetcdf.a;$ENV{SEMS_NETCDF_ROOT}/lib/libpnetcdf.a;$ENV{SEMS_HDF5_ROOT}/lib/libhdf5_hl.a;$ENV{SEMS_HDF5_ROOT}/lib/libhdf5.a;-lz;-ldl;-lcurl" CACHE STRING "Set by default for CUDA PR testing")
+
+set (MPI_EXEC_PRE_NUMPROCS_FLAGS "--bind-to;none" CACHE STRING "Set by default for PR testing")
+# NOTE: The above is a workaround for the problem of having threads on MPI
+# ranks bind to the same cores (see #2422).
+
+# Disable just one Teko sub-unit test that fails with openmpi 1.10 (#2712)
+set (Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D ON CACHE BOOL "Temporarily disabled in PR testing")
+
+# Disable three ShyLu_DD tests - see #2691
+set (ShyLU_DDFROSch_test_frosch_laplacian_epetra_2d_gdsw_MPI_4_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
+set (ShyLU_DDFROSch_test_frosch_laplacian_epetra_2d_rgdsw_MPI_4_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
+set (ShyLU_DDFROSch_test_frosch_interfacesets_2D_MPI_4_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
+
+include("${CMAKE_CURRENT_LIST_DIR}/PullRequestLinuxCommonTestingSettings.cmake")
+
+#Disable for clang
+set(FEI_elemDOF_Aztec_MPI_2_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
+set(FEI_lagrange_20quad_old_MPI_2_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
+set(FEI_lagrange_20quad_old_MPI_4_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
+set(FEI_multifield_vbr_az_MPI_2_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
+set(FEI_multifield_vbr_az_MPI_3_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
+set(ROL_example_PinT_parabolic-control_example_01_MPI_1_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
+set(Rythmos_StepperBuilder_UnitTest_MPI_1_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")

--- a/cmake/std/PullRequestLinuxClang11.0.1TestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxClang11.0.1TestingSettings.cmake
@@ -19,21 +19,7 @@ set (MPI_EXEC_PRE_NUMPROCS_FLAGS "--bind-to;none" CACHE STRING "Set by default f
 # NOTE: The above is a workaround for the problem of having threads on MPI
 # ranks bind to the same cores (see #2422).
 
-# Disable just one Teko sub-unit test that fails with openmpi 1.10 (#2712)
-set (Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D ON CACHE BOOL "Temporarily disabled in PR testing")
-
-# Disable three ShyLu_DD tests - see #2691
-set (ShyLU_DDFROSch_test_frosch_laplacian_epetra_2d_gdsw_MPI_4_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
-set (ShyLU_DDFROSch_test_frosch_laplacian_epetra_2d_rgdsw_MPI_4_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
-set (ShyLU_DDFROSch_test_frosch_interfacesets_2D_MPI_4_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
-
 include("${CMAKE_CURRENT_LIST_DIR}/PullRequestLinuxCommonTestingSettings.cmake")
 
-#Disable for clang
-set(FEI_elemDOF_Aztec_MPI_2_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
-set(FEI_lagrange_20quad_old_MPI_2_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
-set(FEI_lagrange_20quad_old_MPI_4_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
-set(FEI_multifield_vbr_az_MPI_2_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
-set(FEI_multifield_vbr_az_MPI_3_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
-set(ROL_example_PinT_parabolic-control_example_01_MPI_1_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
-set(Rythmos_StepperBuilder_UnitTest_MPI_1_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
+#Disable failing test in new Clang 11.0.1 build
+set(Zoltan_ch_simple_parmetis_parallel_DISABLE ON CACHE BOOL "Disabled in PR testing")

--- a/cmake/std/pr_config/pullrequest.ini
+++ b/cmake/std/pr_config/pullrequest.ini
@@ -346,28 +346,15 @@ module-load sems-archive-scotch: 6.0.3/nopthread_64bit_parallel
 module-load sems-archive-superlu: 4.3/base
 module-load sems-archive-cmake: 3.17.1
 module-load sems-archive-ninja_fortran: 1.10.0
+setenv OMP_NUM_THREADS: 2
 
 
 
 [Trilinos_pullrequest_clang_11.0.1]
-module-load sems-git            : 2.11.1
+module-purge:
 module-load sems-clang          : 11.0.1
-module-load sems-openmpi        : 4.0.5
-use SIERRA-PYTHON-3.6.3:
-module-load sems-boost          : 1.69.0
-module-load sems-zlib           : 1.2.11
-module-load sems-hdf5           : 1.10.7
-module-load sems-netcdf-c       : 4.7.3
-module-load sems-netcdf-cxx     : 4.2
-module-load sems-netcdf-fortran : 4.5.3
-module-load sems-parallel-netcdf: 1.12.1
-module-load sems-metis-int64    : 5.1.0
-module-load sems-parmetis-int64 : 4.0.3
-module-load sems-scotch-int64   : 6.0.3
-module-load sems-superlu        : 4.3
-module-load sems-cmake          : 3.18.4
 module-load sems-ninja          : 1.10.1
-setenv OMP_NUM_THREADS: 2
+use SEMS-DEFAULT:
 
 
 

--- a/cmake/std/pr_config/pullrequest.ini
+++ b/cmake/std/pr_config/pullrequest.ini
@@ -83,6 +83,8 @@
 Trilinos_pullrequest_clang_7.0.1:      PullRequestLinuxClang7.0.1TestingSettings.cmake
 Trilinos_pullrequest_clang_9.0.0:      PullRequestLinuxClang9.0.0TestingSettings.cmake
 Trilinos_pullrequest_clang_10.0.0:     PullRequestLinuxClang10.0.0TestingSettings.cmake
+Trilinos_pullrequest_clang_11.0.1:     PullRequestLinuxClang11.0.1TestingSettings.cmake
+
 
 # CUDA Testing
 Trilinos_pullrequest_cuda_9.2:         PullRequestLinuxCuda9.2TestingSettings.cmake
@@ -344,6 +346,27 @@ module-load sems-archive-scotch: 6.0.3/nopthread_64bit_parallel
 module-load sems-archive-superlu: 4.3/base
 module-load sems-archive-cmake: 3.17.1
 module-load sems-archive-ninja_fortran: 1.10.0
+
+
+
+[Trilinos_pullrequest_clang_11.0.1]
+module-load sems-git            : 2.11.1
+module-load sems-clang          : 11.0.1
+module-load sems-openmpi        : 4.0.5
+use SIERRA-PYTHON-3.6.3:
+module-load sems-boost          : 1.69.0
+module-load sems-zlib           : 1.2.11
+module-load sems-hdf5           : 1.10.7
+module-load sems-netcdf-c       : 4.7.3
+module-load sems-netcdf-cxx     : 4.2
+module-load sems-netcdf-fortran : 4.5.3
+module-load sems-parallel-netcdf: 1.12.1
+module-load sems-metis-int64    : 5.1.0
+module-load sems-parmetis-int64 : 4.0.3
+module-load sems-scotch-int64   : 6.0.3
+module-load sems-superlu        : 4.3
+module-load sems-cmake          : 3.18.4
+module-load sems-ninja          : 1.10.1
 setenv OMP_NUM_THREADS: 2
 
 

--- a/cmake/std/pr_config/pullrequest.ini
+++ b/cmake/std/pr_config/pullrequest.ini
@@ -190,7 +190,8 @@ setenv OMP_NUM_THREADS    : 2
 [SEMS-DEFAULT]
 module-load sems-git            : 2.11.1
 module-load sems-openmpi        : 4.0.5
-module-load sems-boost          : 1.74.0
+# boost/1.74.0 not available for Intel
+module-load sems-boost          : 1.70.0
 module-load sems-zlib           : 1.2.11
 module-load sems-hdf5           : 1.10.7
 module-load sems-netcdf-c       : 4.7.3

--- a/cmake/std/sems/PullRequestClang11.0.1TestingEnv.sh
+++ b/cmake/std/sems/PullRequestClang11.0.1TestingEnv.sh
@@ -1,0 +1,35 @@
+
+# This script can be used to load the appropriate environment for the
+# Clang 10.0.0 Pull Request testing build on a Linux machine that has access to
+# the SEMS NFS mount.
+
+# usage: $ source PullRequestClang10.0.0TestingEnv.sh
+
+# After the environment is no longer needed, it can be purged using
+# $ module purge
+# or Trilinos/cmake/unload_sems_dev_env.sh
+
+module purge
+
+source /projects/sems/modulefiles/utils/sems-modules-init.sh
+
+module load sems-clang/11.0.1
+module load sems-ninja/1.10.1
+
+module load sems-git/2.11.1
+module load sems-openmpi/4.0.5
+module load sems-boost/1.70.0
+module load sems-zlib/1.2.11
+module load sems-hdf5/1.10.7
+module load sems-netcdf-c/4.7.3
+module load sems-netcdf-cxx/4.2
+module load sems-netcdf-fortran/4.5.3
+module load sems-parallel-netcdf/1.12.1
+module load sems-metis-int64/5.1.0
+module load sems-parmetis-int64/4.0.3
+module load sems-scotch-int64/6.0.3
+module load sems-superlu/4.3
+module load sems-cmake/3.18.4
+
+# add the OpenMP environment variable we need
+export OMP_NUM_THREADS=2


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/framework

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Setup a new build that uses Clang 11.0.1.
This is setup for the current PR system. It will need to be migrated to the new MM system.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

<!--- 
## Stakeholder Feedback

If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

- Test ran through with one failing test: Zoltan_ch_simple_parmetis_parallel
  In the following commit, I disabled that test. @trilinos/zoltan
- There were also 11 tests that _were_ disabled in the Clang 7, 9, & 10 builds. I removed those test disables to determine their current status. It appears they will run successfully now. So, those disables have been left out of this build. See commit 131b4b04fc2c79cfad33fa64b7456365d118db10.

[CDash](https://testing.sandia.gov/cdash/index.php?project=Trilinos&display=project&filtercount=3&showfilters=1&filtercombine=and&field1=buildname&compare1=63&value1=clang11&field2=buildstamp&compare2=63&value2=Experimental&field3=buildstarttime&compare3=83&value3=2022-05-14)

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->