### PR TITLE
Teuchos: use reinterpret_cast instead of invalid implicit cast for co…

### DIFF
--- a/packages/teuchos/numerics/src/Teuchos_LAPACK.cpp
+++ b/packages/teuchos/numerics/src/Teuchos_LAPACK.cpp
@@ -115,6 +115,12 @@ namespace Teuchos
 {
   // BEGIN INT, FLOAT SPECIALIZATION IMPLEMENTATION //
 
+  std::complex<float> convert_Fortran_complex_to_CXX_complex(_Complex float val)
+  {
+    return reinterpret_cast<std::complex<float>&>(val);
+    // NOTE: The above is guaranteed to be okay given the C99 and C++11 standards
+  }
+
   void LAPACK<int, float>::PTTRF(const int& n, float* d, float* e, int* info) const
   { SPTTRF_F77(&n,d,e,info); }
 
@@ -523,7 +529,11 @@ namespace Teuchos
 
   // BEGIN INT, DOUBLE SPECIALIZATION IMPLEMENTATION //
 
-
+  std::complex<double> convert_Fortran_complex_to_CXX_complex(_Complex double val)
+  {
+    return reinterpret_cast<std::complex<double>&>(val);
+    // NOTE: The above is guaranteed to be okay given the C99 and C++11 standards
+  }
 
   void LAPACK<int, double>::PTTRF(const int& n, double* d, double* e, int* info) const
   { DPTTRF_F77(&n,d,e,info); }

--- a/packages/teuchos/numerics/src/Teuchos_LAPACK.cpp
+++ b/packages/teuchos/numerics/src/Teuchos_LAPACK.cpp
@@ -1360,7 +1360,8 @@ namespace Teuchos
 #ifdef HAVE_TEUCHOS_LAPACKLARND
   std::complex<float> LAPACK<int, std::complex<float> >::LARND( const int& idist, int* seed ) const
   {
-    return(CLARND_F77(&idist, seed));
+    auto val = CLARND_F77(&idist, seed);
+    return(reinterpret_cast<std::complex<float>&>(val));
   }
 #endif
 
@@ -1782,7 +1783,8 @@ namespace Teuchos
 #ifdef HAVE_TEUCHOS_LAPACKLARND
   std::complex<double> LAPACK<int, std::complex<double> >::LARND( const int& idist, int* seed ) const
   {
-    return(ZLARND_F77(&idist, seed));
+    auto val = ZLARND_F77(&idist, seed);
+    return(reinterpret_cast<std::complex<double>&>(val));
   }
 #endif
 

--- a/packages/teuchos/numerics/src/Teuchos_LAPACK.cpp
+++ b/packages/teuchos/numerics/src/Teuchos_LAPACK.cpp
@@ -1360,8 +1360,7 @@ namespace Teuchos
 #ifdef HAVE_TEUCHOS_LAPACKLARND
   std::complex<float> LAPACK<int, std::complex<float> >::LARND( const int& idist, int* seed ) const
   {
-    auto val = CLARND_F77(&idist, seed);
-    return(reinterpret_cast<std::complex<float>&>(val));
+    return(convert_Fortran_complex_to_CXX_complex(CLARND_F77(&idist, seed)));
   }
 #endif
 
@@ -1783,8 +1782,7 @@ namespace Teuchos
 #ifdef HAVE_TEUCHOS_LAPACKLARND
   std::complex<double> LAPACK<int, std::complex<double> >::LARND( const int& idist, int* seed ) const
   {
-    auto val = ZLARND_F77(&idist, seed);
-    return(reinterpret_cast<std::complex<double>&>(val));
+    return(convert_Fortran_complex_to_CXX_complex(ZLARND_F77(&idist, seed)));
   }
 #endif
 

--- a/packages/teuchos/numerics/src/Teuchos_LAPACK.hpp
+++ b/packages/teuchos/numerics/src/Teuchos_LAPACK.hpp
@@ -92,17 +92,9 @@ namespace Teuchos
     static inline T notDefined() { return T::LAPACK_routine_not_defined_for_this_type(); }
   };
 
-  std::complex<double> convert_Fortran_complex_to_CXX_complex(_Complex double val)
-  {
-    return reinterpret_cast<std::complex<double>&>(val);
-    // NOTE: The above is guaranteed to be okay given the C99 and C++11 standards
-  }
+  std::complex<double> convert_Fortran_complex_to_CXX_complex(_Complex double val);
 
-  std::complex<float> convert_Fortran_complex_to_CXX_complex(_Complex float val)
-  {
-    return reinterpret_cast<std::complex<float>&>(val);
-    // NOTE: The above is guaranteed to be okay given the C99 and C++11 standards
-  }
+  std::complex<float> convert_Fortran_complex_to_CXX_complex(_Complex float val);
 
   template<typename OrdinalType, typename ScalarType>
   class LAPACK

--- a/packages/teuchos/numerics/src/Teuchos_LAPACK.hpp
+++ b/packages/teuchos/numerics/src/Teuchos_LAPACK.hpp
@@ -92,6 +92,18 @@ namespace Teuchos
     static inline T notDefined() { return T::LAPACK_routine_not_defined_for_this_type(); }
   };
 
+  std::complex<double> convert_Fortran_complex_to_CXX_complex(_Complex double val)
+  {
+    return reinterpret_cast<std::complex<double>&>(val);
+    // NOTE: The above is guaranteed to be okay given the C99 and C++11 standards
+  }
+
+  std::complex<float> convert_Fortran_complex_to_CXX_complex(_Complex float val)
+  {
+    return reinterpret_cast<std::complex<float>&>(val);
+    // NOTE: The above is guaranteed to be okay given the C99 and C++11 standards
+  }
+
   template<typename OrdinalType, typename ScalarType>
   class LAPACK
   {


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/teuchos 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

Function `LAPACK<int, std::complex<float> >::LARND` in Teuchos_LAPACK.cpp relies on an implicit cast from the return type of `CLARND_F77` or `ZLARND_F77` to `std::complex<float>` and `std::complex<double>`, respectively.

These implicit casts are not in the C++ standards and fail with apple-clang on mac. Usually a user wouldn't see this because the functions are guarded by

```C
#ifdef HAVE_TEUCHOS_LAPACKLARND
```

which is never satisfied by `lapack` provided through XCode.

However, using openblas for the Lapack distribution will evoke this problem.

This PR addresses this through a `reinterpret_cast`.