### PR TITLE
ShyLU_Basker : improve numerical stability of threaded factorization

### DIFF
--- a/packages/amesos2/src/Amesos2_Control.cpp
+++ b/packages/amesos2/src/Amesos2_Control.cpp
@@ -94,6 +94,16 @@ void Control::setControlParameters(
     useTranspose_ = parameterList->get<bool>("Transpose");
   }
 
+  if( parameterList->isType<bool>("Iterative refinement") ){
+    useIterRefine_ = parameterList->get<bool>("Iterative refinement");
+  }
+  if( parameterList->isType<bool>("Number of iterative refinements") ){
+    maxNumIterRefines_ = parameterList->get<int>("Number of iterative refinements");
+  }
+  if( parameterList->isType<bool>("Verboes for iterative refinement") ){
+    verboseIterRefine_ = parameterList->get<bool>("Verboes for iterative refinement");
+  }
+
   // Add this value to all diagonal elements which are structurally
   // non-zero. No change is made to non-zero structure of the matrix.
   if( parameterList->isParameter("AddToDiag") ){

--- a/packages/amesos2/src/Amesos2_Control.hpp
+++ b/packages/amesos2/src/Amesos2_Control.hpp
@@ -63,6 +63,9 @@ struct Control {
     : verbose_(0)
     , debug_(0)
     , useTranspose_(false)
+    , useIterRefine_(false)
+    , maxNumIterRefines_(2)
+    , verboseIterRefine_(false)
     , addToDiag_("0.0")
     , addZeroToDiag_(false)
     , matrixProperty_(0)
@@ -92,6 +95,14 @@ struct Control {
   /// When solving, use A^T instead of A
   bool useTranspose_;
 
+  /// When solving, use iterative refinement
+  bool useIterRefine_;
+
+  /// How many iterative refinements to perform
+  int maxNumIterRefines_;
+
+  /// Verbosity for iterative refinement
+  bool verboseIterRefine_;
 
   /**
    * \brief Add this value to the diagonal.

--- a/packages/amesos2/src/Amesos2_EpetraMultiVecAdapter_decl.hpp
+++ b/packages/amesos2/src/Amesos2_EpetraMultiVecAdapter_decl.hpp
@@ -115,6 +115,8 @@ namespace Amesos2 {
     bool isGloballyIndexed() const;
 
 
+    Teuchos::RCP<Epetra_MultiVector> clone() const;
+
     /**
      * \brief Get a Tpetra::Map that describes this MultiVector
      *

--- a/packages/amesos2/src/Amesos2_EpetraMultiVecAdapter_def.hpp
+++ b/packages/amesos2/src/Amesos2_EpetraMultiVecAdapter_def.hpp
@@ -80,6 +80,15 @@ MultiVecAdapter<Epetra_MultiVector>::MultiVecAdapter(const Teuchos::RCP<multivec
 }
   
 
+Teuchos::RCP<Epetra_MultiVector>
+MultiVecAdapter<Epetra_MultiVector>::clone() const
+{
+  Teuchos::RCP<Epetra_MultiVector> Y (new Epetra_MultiVector(*mv_map_, mv_->NumVectors(), false));
+  return Y;
+}
+
+
+
 bool MultiVecAdapter<Epetra_MultiVector>::isLocallyIndexed() const
 {
   return !mv_->DistributedGlobal();

--- a/packages/amesos2/src/Amesos2_KokkosMultiVecAdapter_decl.hpp
+++ b/packages/amesos2/src/Amesos2_KokkosMultiVecAdapter_decl.hpp
@@ -179,6 +179,9 @@ namespace Amesos2 {
     /// Return pointer to vector when number of vectors == 1 and single MPI process
     Scalar * getMVPointer_impl() const;
 
+
+    Teuchos::RCP<multivec_t> clone() const;
+
     /**
      * \brief Copies the multivector's data into the user-provided vector.
      *

--- a/packages/amesos2/src/Amesos2_KokkosMultiVecAdapter_def.hpp
+++ b/packages/amesos2/src/Amesos2_KokkosMultiVecAdapter_def.hpp
@@ -67,6 +67,16 @@ namespace Amesos2 {
   {}
 
   template <typename Scalar, typename ExecutionSpace >
+  Teuchos::RCP< Kokkos::View<Scalar**, Kokkos::LayoutLeft, ExecutionSpace> >
+   MultiVecAdapter<
+    Kokkos::View<Scalar**, Kokkos::LayoutLeft, ExecutionSpace> >::clone() const
+  {
+    using MV = Kokkos::View<Scalar**, Kokkos::LayoutLeft, ExecutionSpace>;
+    MV Y("clonedY", mv_->extent(0), mv_->extent(1));
+    return Teuchos::rcp( &Y );
+  }
+
+  template <typename Scalar, typename ExecutionSpace >
   Scalar *
   MultiVecAdapter<
     Kokkos::View<Scalar**, Kokkos::LayoutLeft, ExecutionSpace> >::getMVPointer_impl() const

--- a/packages/amesos2/src/Amesos2_MultiVecAdapter_decl.hpp
+++ b/packages/amesos2/src/Amesos2_MultiVecAdapter_decl.hpp
@@ -175,6 +175,7 @@ namespace Amesos2 {
   template <class MV>
   struct MultiVecAdapter {};
 
+
   /** \brief Factory creation method for MultiVecAdapters
    *
    * Developers should favor this method for creating Amesos2

--- a/packages/amesos2/src/Amesos2_SolverCore_decl.hpp
+++ b/packages/amesos2/src/Amesos2_SolverCore_decl.hpp
@@ -232,13 +232,22 @@ namespace Amesos2 {
      * \sa preOrdering(), symbolicFactorization(), and numericFactorization()
      */
     void solve();
-
-
     void solve(const Teuchos::Ptr<Vector> X, const Teuchos::Ptr<const Vector> B) const;
-
-
     void solve(Vector* X, const Vector* B) const;
-  
+
+    static const int defaultNumIters = 2;
+    int solve_ir(const Teuchos::Ptr<Vector> X, const Teuchos::Ptr<const Vector> B, const Teuchos::Ptr<Vector> R, const Teuchos::Ptr<Vector> E,
+                 const int maxNumIters = defaultNumIters,
+                 const bool verbose = false) const;
+    int solve_ir(Vector* X, const Vector* B, Vector* R, Vector* E,
+                 const int maxNumIters = defaultNumIters,
+                 const bool verbose = false) const;
+    int solve_ir(const Teuchos::Ptr<Vector> R, const Teuchos::Ptr<Vector> E,
+                 const int maxNumIters = defaultNumIters,
+                 const bool verbose = false);
+    int solve_ir(Vector* R, Vector* E,
+                 const int maxNumIters = defaultNumIters,
+                 const bool verbose = false);
 
     //@}  End Mathematical Functions group
 
@@ -485,7 +494,6 @@ namespace Amesos2 {
 
     /// Index base of column map of \c matrixA_
     global_size_type columnIndexBase_;
-
 
     /// Holds status information about a solver
     mutable Status status_;

--- a/packages/amesos2/src/Amesos2_SolverCore_decl.hpp
+++ b/packages/amesos2/src/Amesos2_SolverCore_decl.hpp
@@ -235,19 +235,11 @@ namespace Amesos2 {
     void solve(const Teuchos::Ptr<Vector> X, const Teuchos::Ptr<const Vector> B) const;
     void solve(Vector* X, const Vector* B) const;
 
-    static const int defaultNumIters = 2;
-    int solve_ir(const Teuchos::Ptr<Vector> X, const Teuchos::Ptr<const Vector> B, const Teuchos::Ptr<Vector> R, const Teuchos::Ptr<Vector> E,
-                 const int maxNumIters = defaultNumIters,
-                 const bool verbose = false) const;
-    int solve_ir(Vector* X, const Vector* B, Vector* R, Vector* E,
-                 const int maxNumIters = defaultNumIters,
-                 const bool verbose = false) const;
-    int solve_ir(const Teuchos::Ptr<Vector> R, const Teuchos::Ptr<Vector> E,
-                 const int maxNumIters = defaultNumIters,
-                 const bool verbose = false);
-    int solve_ir(Vector* R, Vector* E,
-                 const int maxNumIters = defaultNumIters,
-                 const bool verbose = false);
+    int solve_ir(const Teuchos::Ptr<Vector> X, const Teuchos::Ptr<const Vector> B,
+                 const int maxNumIters, const bool verbose) const;
+    int solve_ir(Vector* X, const Vector* B,
+                 const int maxNumIters, const bool verbose) const;
+    int solve_ir(const int maxNumIters, const bool verbose);
 
     //@}  End Mathematical Functions group
 

--- a/packages/amesos2/src/Amesos2_SolverCore_def.hpp
+++ b/packages/amesos2/src/Amesos2_SolverCore_def.hpp
@@ -283,9 +283,18 @@ SolverCore<ConcreteSolver,Matrix,Vector>::solve_ir(const Teuchos::Ptr<      Vect
   // get local matriix
   host_crsmat_t crsmat;
   host_graph_t static_graph;
-  host_row_map_t rowmap_view("rowptr", 1+nrows);
-  host_colinds_t colind_view("colind", nnz);
-  host_values_t  values_view("nzvals", nnz);
+  host_row_map_t rowmap_view;
+  host_colinds_t colind_view;
+  host_values_t  values_view;
+  if (this->root_) {
+    Kokkos::resize(rowmap_view, 1+nrows);
+    Kokkos::resize(colind_view, nnz);
+    Kokkos::resize(values_view, nnz);
+  } else {
+    Kokkos::resize(rowmap_view, 1);
+    Kokkos::resize(colind_view, 0);
+    Kokkos::resize(values_view, 0);
+  }
 
   int nnz_ret = 0;
   Util::get_crs_helper_kokkos_view<

--- a/packages/amesos2/src/Amesos2_SolverCore_def.hpp
+++ b/packages/amesos2/src/Amesos2_SolverCore_def.hpp
@@ -283,21 +283,16 @@ SolverCore<ConcreteSolver,Matrix,Vector>::solve_ir(const Teuchos::Ptr<      Vect
   // get local matriix
   host_crsmat_t crsmat;
   host_graph_t static_graph;
-  host_row_map_t rowmap_view;
-  host_colinds_t colind_view;
-  host_values_t  values_view;
-  if (this->root_) {
-    rowmap_view = host_row_map_t("rowptr", 1+nrows);
-    colind_view = host_colinds_t("colind", nnz);
-    values_view = host_values_t("nzvals", nnz);
-  }
+  host_row_map_t rowmap_view("rowptr", 1+nrows);
+  host_colinds_t colind_view("colind", nnz);
+  host_values_t  values_view("nzvals", nnz);
 
   int nnz_ret = 0;
   Util::get_crs_helper_kokkos_view<
     MatrixAdapter<Matrix>, host_values_t, host_colinds_t, host_row_map_t>::do_get(
       this->matrixA_.ptr(),
       values_view, colind_view, rowmap_view,
-      nnz_ret, ROOTED, SORTED_INDICES, this->rowIndexBase_);
+      nnz_ret, ROOTED, ARBITRARY, this->rowIndexBase_);
 
   if (this->root_) {
     static_graph = host_graph_t(colind_view, rowmap_view);

--- a/packages/amesos2/src/Amesos2_SolverCore_def.hpp
+++ b/packages/amesos2/src/Amesos2_SolverCore_def.hpp
@@ -608,8 +608,8 @@ SolverCore<ConcreteSolver,Matrix,Vector>::describe(
     Util::printLine(out);
     out << this->description() << std::endl << std::endl;
 
-    out << p << "Matrix has " << globalNumRows_ << "rows"
-        << " and " << globalNumNonZeros_ << "nonzeros"
+    out << p << "Matrix has " << globalNumRows_ << " rows"
+        << " and " << globalNumNonZeros_ << " nonzeros"
         << std::endl;
     if( vl == VERB_MEDIUM || vl == VERB_HIGH || vl == VERB_EXTREME ){
       out << p << "Nonzero elements per row = "

--- a/packages/amesos2/src/Amesos2_Solver_decl.hpp
+++ b/packages/amesos2/src/Amesos2_Solver_decl.hpp
@@ -166,39 +166,6 @@ namespace Amesos2 {
      */
     virtual void solve(Vector* X, const Vector* B) const = 0;
 
-
-    /** \brief Solve \f$ A X = B\f$ using iterative refinements.
-     */
-    static const int defaultNumIters = 2;
-    virtual int solve_ir(const Teuchos::Ptr<Vector> X,
-                         const Teuchos::Ptr<const Vector> B,
-                         const Teuchos::Ptr<Vector> R,
-                         const Teuchos::Ptr<Vector> E,
-                         const int maxNumIters = 2,
-                         const bool verbose = false) const {
-      TEUCHOS_TEST_FOR_EXCEPTION(1, std::runtime_error, "Amesos2::Solver::solve_ir not supported.");
-      return 0;
-    }
-    virtual int solve_ir(Vector* X, const Vector* B, Vector* R, Vector* E,
-                         const int maxNumIters = defaultNumIters,
-                         const bool verbose = false) const {
-      TEUCHOS_TEST_FOR_EXCEPTION(1, std::runtime_error, "Amesos2::Solver::solve_ir not supported.");
-      return 0;
-    }
-    virtual int solve_ir(const Teuchos::Ptr<Vector> R,
-                         const Teuchos::Ptr<Vector> E,
-                         const int maxNumIters = defaultNumIters,
-                         const bool verbose = false) const {
-      TEUCHOS_TEST_FOR_EXCEPTION(1, std::runtime_error, "Amesos2::Solver::solve_ir not supported.");
-      return 0;
-    }
-    virtual int solve_ir(Vector* R, Vector* E,
-                         const int maxNumIters = defaultNumIters,
-                         const bool verbose = false) const {
-      TEUCHOS_TEST_FOR_EXCEPTION(1, std::runtime_error, "Amesos2::Solver::solve_ir not supported.");
-      return 0;
-    }
-
     //@} End Mathematical Functions
 
     /** \name Parameter Methods

--- a/packages/amesos2/src/Amesos2_Solver_decl.hpp
+++ b/packages/amesos2/src/Amesos2_Solver_decl.hpp
@@ -168,6 +168,24 @@ namespace Amesos2 {
 
     //@} End Mathematical Functions
 
+    static const int defaultNumIters = 2;
+    virtual int solve_ir(const Teuchos::Ptr<Vector> X,
+                         const Teuchos::Ptr<const Vector> B,
+                         const Teuchos::Ptr<Vector> R,
+                         const Teuchos::Ptr<Vector> E,
+                         const int maxNumIters = defaultNumIters,
+                         const bool verbose = false) const = 0;
+    virtual int solve_ir(Vector* X, const Vector* B, Vector* R, Vector* E,
+                         const int maxNumIters = defaultNumIters,
+                         const bool verbose = false) const = 0;
+    virtual int solve_ir(const Teuchos::Ptr<Vector> R,
+                         const Teuchos::Ptr<Vector> E,
+                         const int maxNumIters = defaultNumIters,
+                         const bool verbose = false) = 0;
+    virtual int solve_ir(Vector* R, Vector* E,
+                         const int maxNumIters = defaultNumIters,
+                         const bool verbose = false) = 0;
+
 
     /** \name Parameter Methods
      * @{

--- a/packages/amesos2/src/Amesos2_Solver_decl.hpp
+++ b/packages/amesos2/src/Amesos2_Solver_decl.hpp
@@ -166,26 +166,40 @@ namespace Amesos2 {
      */
     virtual void solve(Vector* X, const Vector* B) const = 0;
 
-    //@} End Mathematical Functions
 
+    /** \brief Solve \f$ A X = B\f$ using iterative refinements.
+     */
     static const int defaultNumIters = 2;
     virtual int solve_ir(const Teuchos::Ptr<Vector> X,
                          const Teuchos::Ptr<const Vector> B,
                          const Teuchos::Ptr<Vector> R,
                          const Teuchos::Ptr<Vector> E,
-                         const int maxNumIters = defaultNumIters,
-                         const bool verbose = false) const = 0;
+                         const int maxNumIters = 2,
+                         const bool verbose = false) const {
+      TEUCHOS_TEST_FOR_EXCEPTION(1, std::runtime_error, "Amesos2::Solver::solve_ir not supported.");
+      return 0;
+    }
     virtual int solve_ir(Vector* X, const Vector* B, Vector* R, Vector* E,
                          const int maxNumIters = defaultNumIters,
-                         const bool verbose = false) const = 0;
+                         const bool verbose = false) const {
+      TEUCHOS_TEST_FOR_EXCEPTION(1, std::runtime_error, "Amesos2::Solver::solve_ir not supported.");
+      return 0;
+    }
     virtual int solve_ir(const Teuchos::Ptr<Vector> R,
                          const Teuchos::Ptr<Vector> E,
                          const int maxNumIters = defaultNumIters,
-                         const bool verbose = false) = 0;
+                         const bool verbose = false) const {
+      TEUCHOS_TEST_FOR_EXCEPTION(1, std::runtime_error, "Amesos2::Solver::solve_ir not supported.");
+      return 0;
+    }
     virtual int solve_ir(Vector* R, Vector* E,
                          const int maxNumIters = defaultNumIters,
-                         const bool verbose = false) = 0;
+                         const bool verbose = false) const {
+      TEUCHOS_TEST_FOR_EXCEPTION(1, std::runtime_error, "Amesos2::Solver::solve_ir not supported.");
+      return 0;
+    }
 
+    //@} End Mathematical Functions
 
     /** \name Parameter Methods
      * @{

--- a/packages/amesos2/src/Amesos2_TpetraMultiVecAdapter_decl.hpp
+++ b/packages/amesos2/src/Amesos2_TpetraMultiVecAdapter_decl.hpp
@@ -205,6 +205,12 @@ namespace Amesos2 {
     typename multivec_t::impl_scalar_type * getMVPointer_impl() const;
 
     /**
+     * \brief Clone the multivector
+     */ 
+    Teuchos::RCP<multivec_t>
+    clone() const;
+
+    /**
      * \brief Copies the multivector's data into the user-provided vector.
      *
      *  Each vector of the multivector is placed \c lda apart in the

--- a/packages/amesos2/src/Amesos2_TpetraMultiVecAdapter_def.hpp
+++ b/packages/amesos2/src/Amesos2_TpetraMultiVecAdapter_def.hpp
@@ -71,6 +71,23 @@ namespace Amesos2 {
   : mv_(m)
   {}
 
+  template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, class Node >
+  Teuchos::RCP<
+    MultiVector<Scalar,
+                LocalOrdinal,
+                GlobalOrdinal,
+                Node> >
+  MultiVecAdapter<
+    MultiVector<Scalar,
+                LocalOrdinal,
+                GlobalOrdinal,
+                Node> >::clone() const
+  {
+      using MV = MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>;
+      Teuchos::RCP<MV> Y (new MV (mv_->getMap(), mv_->getNumVectors(), false));
+      Y->setCopyOrView (Teuchos::View);
+      return Y;
+  }
 
   template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, class Node >
   typename MultiVecAdapter<

--- a/packages/amesos2/test/solvers/KLU2_UnitTests.cpp
+++ b/packages/amesos2/test/solvers/KLU2_UnitTests.cpp
@@ -394,9 +394,11 @@ namespace {
 
     A->apply(*X,*B);            // no transpose
 
+    bool verbose = false;
     Xhat->randomize();
-    Xhat->describe(*(getDefaultOStream()), Teuchos::VERB_EXTREME);
-
+    if (verbose) {
+      Xhat->describe(*(getDefaultOStream()), Teuchos::VERB_EXTREME);
+    }
 
     // Solve A*Xhat = B for Xhat using the KLU2 solver with iterative refinement
     RCP<Amesos2::Solver<MAT,MV> > solver
@@ -404,16 +406,17 @@ namespace {
 
     Teuchos::ParameterList amesos2_params("Amesos2");
     amesos2_params.set("Iterative refinement", true);
-    amesos2_params.set("Verboes for iterative refinement", true);
+    amesos2_params.set("Verboes for iterative refinement", verbose);
     solver->setParameters( rcpFromRef(amesos2_params) );
 
     solver->symbolicFactorization();
     solver->numericFactorization();
     solver->solve();
-
-    Xhat->describe(*(getDefaultOStream()), Teuchos::VERB_EXTREME);
-    X->describe(*(getDefaultOStream()), Teuchos::VERB_EXTREME);
-    B->describe(*(getDefaultOStream()), Teuchos::VERB_EXTREME);
+    if (verbose) {
+      Xhat->describe(*(getDefaultOStream()), Teuchos::VERB_EXTREME);
+      X->describe(*(getDefaultOStream()), Teuchos::VERB_EXTREME);
+      B->describe(*(getDefaultOStream()), Teuchos::VERB_EXTREME);
+    }
 
     // Check result of solve
     Array<Mag> xhatnorms(numVecs), xnorms(numVecs);

--- a/packages/amesos2/test/solvers/KLU2_UnitTests.cpp
+++ b/packages/amesos2/test/solvers/KLU2_UnitTests.cpp
@@ -365,6 +365,63 @@ namespace {
     TEST_COMPARE_FLOATING_ARRAYS( xhatnorms, xnorms, 0.005 );
   }
 
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( KLU2, SolveIR, SCALAR, LO, GO )
+  {
+    typedef CrsMatrix<SCALAR,LO,GO,Node> MAT;
+    typedef ScalarTraits<SCALAR> ST;
+    typedef MultiVector<SCALAR,LO,GO,Node> MV;
+    typedef typename ST::magnitudeType Mag;
+    //typedef ScalarTraits<Mag> MT;
+    const size_t numVecs = 1;
+
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
+
+
+    RCP<MAT> A =
+      Tpetra::MatrixMarket::Reader<MAT>::readSparseFile("../matrices/amesos2_test_mat1.mtx",comm);
+
+
+    RCP<const Map<LO,GO,Node> > dmnmap = A->getDomainMap();
+    RCP<const Map<LO,GO,Node> > rngmap = A->getRangeMap();
+
+    RCP<MV> X = rcp(new MV(dmnmap,numVecs));
+    RCP<MV> B = rcp(new MV(rngmap,numVecs));
+    RCP<MV> Xhat = rcp(new MV(dmnmap,numVecs));
+    X->setObjectLabel("X");
+    B->setObjectLabel("B");
+    Xhat->setObjectLabel("Xhat");
+    X->randomize();
+
+    A->apply(*X,*B);            // no transpose
+
+    Xhat->randomize();
+    Xhat->describe(*(getDefaultOStream()), Teuchos::VERB_EXTREME);
+
+
+    // Solve A*Xhat = B for Xhat using the KLU2 solver with iterative refinement
+    RCP<Amesos2::Solver<MAT,MV> > solver
+      = Amesos2::create<MAT,MV>("KLU2", A, Xhat, B );
+
+    Teuchos::ParameterList amesos2_params("Amesos2");
+    amesos2_params.set("Iterative refinement", true);
+    amesos2_params.set("Verboes for iterative refinement", true);
+    solver->setParameters( rcpFromRef(amesos2_params) );
+
+    solver->symbolicFactorization();
+    solver->numericFactorization();
+    solver->solve();
+
+    Xhat->describe(*(getDefaultOStream()), Teuchos::VERB_EXTREME);
+    X->describe(*(getDefaultOStream()), Teuchos::VERB_EXTREME);
+    B->describe(*(getDefaultOStream()), Teuchos::VERB_EXTREME);
+
+    // Check result of solve
+    Array<Mag> xhatnorms(numVecs), xnorms(numVecs);
+    Xhat->norm2(xhatnorms());
+    X->norm2(xnorms());
+    TEST_COMPARE_FLOATING_ARRAYS( xhatnorms, xnorms, 0.005 );
+  }
+
   TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( KLU2, SolveTrans, SCALAR, LO, GO )
   {
     typedef CrsMatrix<SCALAR,LO,GO,Node> MAT;
@@ -800,6 +857,7 @@ namespace {
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( KLU2, NumericFactorization, SCALAR, LO, GO ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( KLU2, NumericFactorizationNullThrows, SCALAR, LO, GO ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( KLU2, Solve, SCALAR, LO, GO ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( KLU2, SolveIR, SCALAR, LO, GO ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( KLU2, SolveTrans, SCALAR, LO, GO ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( KLU2, NonContigGID, SCALAR, LO, GO )
 

--- a/packages/amesos2/test/solvers/ShyLUBasker_UnitTests.cpp
+++ b/packages/amesos2/test/solvers/ShyLUBasker_UnitTests.cpp
@@ -115,16 +115,6 @@ namespace {
   // Where to look for input files
   string filedir;
 
-  TEUCHOS_STATIC_SETUP()
-  {
-    Teuchos::CommandLineProcessor &clp = Teuchos::UnitTestRepository::getCLP();
-    clp.setOption("filedir",&filedir,"Directory of matrix files.");
-    clp.addOutputSetupOptions(true);
-    clp.setOption("test-mpi", "test-serial", &testMpi,
-                  "Test MPI by default or force serial test.  In a serial build,"
-                  " this option is ignored and a serial comm is always used." );
-  }
-
   RCP<const Comm<int> > getDefaultComm()
   {
     RCP<const Comm<int> > ret;
@@ -139,6 +129,25 @@ namespace {
   RCP<FancyOStream> getDefaultOStream()
   {
     return( VerboseObjectBase::getDefaultOStream() );
+  }
+
+  TEUCHOS_STATIC_SETUP()
+  {
+    Teuchos::CommandLineProcessor &clp = Teuchos::UnitTestRepository::getCLP();
+    clp.setOption("filedir",&filedir,"Directory of matrix files.");
+    clp.addOutputSetupOptions(true);
+    clp.setOption("test-mpi", "test-serial", &testMpi,
+                  "Test MPI by default or force serial test.  In a serial build,"
+                  " this option is ignored and a serial comm is always used." );
+
+    auto out = getDefaultOStream();
+    auto comm = getDefaultComm();
+    auto numRanks = comm->getSize();
+    auto myRank = comm->getRank();
+    if (myRank == 0) {
+      using std::endl;
+      *out << endl << "TEUCHOS_STATIC_SETUP with " << numRanks << " MPI processes" << endl << endl;
+    }
   }
 
 
@@ -161,8 +170,7 @@ namespace {
 
     const global_size_t INVALID = OrdinalTraits<global_size_t>::invalid();
     RCP<const Comm<int> > comm = getDefaultComm();
-    //const size_t numprocs = comm->getSize();
-    const size_t rank     = comm->getRank();
+    const size_t rank = comm->getRank();
     // create a Map
     const size_t numLocal = 10;
     RCP<Map<LO,GO,Node> > map = rcp( new Map<LO,GO,Node>(INVALID,numLocal,0,comm) );
@@ -209,8 +217,7 @@ namespace {
 
     const global_size_t INVALID = OrdinalTraits<global_size_t>::invalid();
     RCP<const Comm<int> > comm = getDefaultComm();
-    //const size_t numprocs = comm->getSize();
-    const size_t rank     = comm->getRank();
+    const size_t rank = comm->getRank();
     // create a Map
     const size_t numLocal = 10;
     RCP<Map<LO,GO,Node> > map = rcp( new Map<LO,GO,Node>(INVALID,numLocal,0,comm) );
@@ -244,8 +251,7 @@ namespace {
 
     const global_size_t INVALID = OrdinalTraits<global_size_t>::invalid();
     RCP<const Comm<int> > comm = getDefaultComm();
-    //const size_t numprocs = comm->getSize();
-    const size_t rank     = comm->getRank();
+    const size_t rank = comm->getRank();
     // create a Map
     const size_t numLocal = 10;
     RCP<Map<LO,GO,Node> > map = rcp( new Map<LO,GO,Node>(INVALID,numLocal,0,comm) );
@@ -331,9 +337,9 @@ namespace {
     A->apply(*X,*B);            // no transpose
 
     Xhat->randomize();
-    Xhat->describe(*(getDefaultOStream()), Teuchos::VERB_EXTREME);
-    X->describe(*(getDefaultOStream()), Teuchos::VERB_EXTREME);
-    B->describe(*(getDefaultOStream()), Teuchos::VERB_EXTREME);
+    //Xhat->describe(*(getDefaultOStream()), Teuchos::VERB_EXTREME);
+    //X->describe(*(getDefaultOStream()), Teuchos::VERB_EXTREME);
+    //B->describe(*(getDefaultOStream()), Teuchos::VERB_EXTREME);
 
 
     // Solve A*Xhat = B for Xhat using the Bakser solver
@@ -346,9 +352,9 @@ namespace {
     solver->numericFactorization();
     solver->solve();
 
-    Xhat->describe(*(getDefaultOStream()), Teuchos::VERB_EXTREME);
-    X->describe(*(getDefaultOStream()), Teuchos::VERB_EXTREME);
-    B->describe(*(getDefaultOStream()), Teuchos::VERB_EXTREME);
+    //Xhat->describe(*(getDefaultOStream()), Teuchos::VERB_EXTREME);
+    //X->describe(*(getDefaultOStream()), Teuchos::VERB_EXTREME);
+    //B->describe(*(getDefaultOStream()), Teuchos::VERB_EXTREME);
 
     // Check result of solve
     Array<Mag> xhatnorms(numVecs), xnorms(numVecs);

--- a/packages/shylu/shylu_node/basker/src/shylubasker_decl.hpp
+++ b/packages/shylu/shylu_node/basker/src/shylubasker_decl.hpp
@@ -17,6 +17,7 @@
 #else
 #include <omp.h>
 #endif
+#include "Teuchos_ScalarTraits.hpp"
 
 //System Includes
 #include <iostream>
@@ -716,12 +717,6 @@ namespace BaskerNS
     int t_col_barrier(Int kid);
 
     BASKER_INLINE
-    int t_col_copy_atomic(Int kid, Int team_leader, Int lvl, Int l, Int k);
-
-    BASKER_INLINE
-    int t_n_col_copy_atomic(Int kid, Int team_leader, Int lvl, Int l, Int k);
-    
-    BASKER_INLINE
     int t_dense_move_offdiag_L(Int kid, 
                          Int blkcol, Int blkrow,
                          Int X_col, Int X_row,
@@ -1293,10 +1288,8 @@ namespace BaskerNS
     Int gn;
     Int gm;
 
-    //Note: In future, rename AV -> AU
-    MATRIX_VIEW_2DARRAY  AV;
-    MATRIX_VIEW_2DARRAY  AL;
-    MATRIX_2DARRAY       AVM; // view of views of 2D blocks; stores CCS of the BTF_A upper matrix 2D blocks; btf_tabs_offset blocks in BTF_A
+    // view of views of 2D blocks; stores CCS of the BTF_A upper matrix 2D blocks; btf_tabs_offset blocks in BTF_A
+    MATRIX_2DARRAY       AVM;
     MATRIX_2DARRAY       ALM;
 
     BASKER_MATRIX At;

--- a/packages/shylu/shylu_node/basker/src/shylubasker_decl.hpp
+++ b/packages/shylu/shylu_node/basker/src/shylubasker_decl.hpp
@@ -17,7 +17,6 @@
 #else
 #include <omp.h>
 #endif
-#include "Teuchos_ScalarTraits.hpp"
 
 //System Includes
 #include <iostream>

--- a/packages/shylu/shylu_node/basker/src/shylubasker_def.hpp
+++ b/packages/shylu/shylu_node/basker/src/shylubasker_def.hpp
@@ -91,8 +91,6 @@ namespace BaskerNS
     BTF_E.Finalize();
    
     //finalize array of 2d matrics
-    FREE_MATRIX_VIEW_2DARRAY(AV, tree.nblks);
-    FREE_MATRIX_VIEW_2DARRAY(AL, tree.nblks);
     FREE_MATRIX_2DARRAY(AVM, tree.nblks);
     FREE_MATRIX_2DARRAY(ALM, tree.nblks);
     
@@ -748,55 +746,11 @@ namespace BaskerNS
       fclose(fp);
       printf("];\n");
     }*/
-    /*printf(" AA = [\n" );
-    if (BTF_A.nrow > 0 && BTF_A.ncol > 0) {
-      for(Int j = 0; j < BTF_A.ncol; j++) {
-        for(Int k = BTF_A.col_ptr[j]; k < BTF_A.col_ptr[j+1]; k++) {
-          printf("%d %d %e\n", BTF_A.row_idx[k], j, BTF_A.val[k]);
-        }
-      }
-    }
-    printf("];\n");*/
-
-    /*printf(" BB = [\n" );
-    if (BTF_B.nrow > 0 && BTF_B.ncol > 0) {
-      for(Int j = 0; j < BTF_B.ncol; j++) {
-        for(Int k = BTF_B.col_ptr[j]; k < BTF_B.col_ptr[j+1]; k++) {
-          printf("%d %d %e\n", BTF_B.row_idx[k], j, BTF_B.val[k]);
-        }
-      }
-    }
-    printf("];\n");
-
-    printf(" CC = [\n" );
-    if (BTF_C.nrow > 0 && BTF_C.ncol > 0) {
-      for(Int j = 0; j < BTF_C.ncol; j++) {
-        for(Int k = BTF_C.col_ptr[j]; k < BTF_C.col_ptr[j+1]; k++) {
-          printf("%d %d %e\n", BTF_C.row_idx[k], j, BTF_C.val[k]);
-        }
-      }
-    }
-    printf("];\n");
-
-    printf(" DD = [\n" );
-    if (BTF_D.nrow > 0 && BTF_D.ncol > 0) {
-      for(Int j = 0; j < BTF_D.ncol; j++) {
-        for(Int k = BTF_D.col_ptr[j]; k < BTF_D.col_ptr[j+1]; k++) {
-          printf("%d %d %e\n", BTF_D.row_idx[k], j, BTF_D.val[k]);
-        }
-      }
-    }
-    printf("];\n");
-
-    printf(" EE = [\n" );
-    if (BTF_E.nrow > 0 && BTF_E.ncol > 0) {
-      for(Int j = 0; j < BTF_E.ncol; j++) {
-        for(Int k = BTF_E.col_ptr[j]; k < BTF_E.col_ptr[j+1]; k++) {
-          printf("%d %d %e\n", BTF_E.row_idx[k], j, BTF_E.val[k]);
-        }
-      }
-    }
-    printf("];\n");*/
+    //BTF_A.print_matrix("AA.dat");
+    //BTF_B.print_matrix("BB.dat");
+    //BTF_C.print_matrix("CC.dat");
+    //BTF_D.print_matrix("DD.dat");
+    //BTF_E.print_matrix("EE.dat");
 
     using range_type = Kokkos::pair<int, int>;
     if (Options.static_delayed_pivot != 0 || Options.blk_matching != 0) {
@@ -811,15 +765,7 @@ namespace BaskerNS
         // to revert BLK_MWM ordering
         for (Int k = 0; k < (Int)ncol; k++) order_blk_mwm_inv(k) = k;
         permute_inv(order_blk_mwm_inv, order_blk_mwm_array, ncol);
-
-        /*printf("\n before reverting\n" );
-        printf(" A = [\n" );
-        for(Int j = 0; j < BTF_A.ncol; j++) {
-          for(Int k = BTF_A.col_ptr[j]; k < BTF_A.col_ptr[j+1]; k++) {
-           printf("%d %d %.16e\n", BTF_A.row_idx[k], j, BTF_A.val[k]);
-          }
-        }
-        printf("];\n");*/
+        //BTF_A.print_matrix("A.dat");
 
         // --------------------------------------------
         // reset the large A block
@@ -1093,57 +1039,14 @@ namespace BaskerNS
     }
     printf("];\n");*/
 
-    /*printf(" A_ = [\n" );
-    if (BTF_A.nrow > 0 && BTF_A.ncol > 0) {
-      for(Int j = 0; j < BTF_A.ncol; j++) {
-        for(Int k = BTF_A.col_ptr[j]; k < BTF_A.col_ptr[j+1]; k++) {
-          printf("%d %d %e\n", BTF_A.row_idx[k], j, BTF_A.val[k]);
-        }
-      }
-    }
-    printf("];\n");*/
+    //BTF_A.print_matrix("A_.dat");
+    //BTF_B.print_matrix("B_.dat");
+    //BTF_C.print_matrix("C_.dat");
+    //BTF_D.print_matrix("D_.dat");
+    //BTF_E.print_matrix("E_.dat");
 
-    /*printf(" B_ = [\n" );
-    if (BTF_B.nrow > 0 && BTF_B.ncol > 0) {
-      for(Int j = 0; j < BTF_B.ncol; j++) {
-        for(Int k = BTF_B.col_ptr[j]; k < BTF_B.col_ptr[j+1]; k++) {
-          printf("%d %d %e\n", BTF_B.row_idx[k], j, BTF_B.val[k]);
-        }
-      }
-    }
-    printf("];\n");
 
-    printf(" C_ = [\n" );
-    if (BTF_C.nrow > 0 && BTF_C.ncol > 0) {
-      for(Int j = 0; j < BTF_C.ncol; j++) {
-        for(Int k = BTF_C.col_ptr[j]; k < BTF_C.col_ptr[j+1]; k++) {
-          printf("%d %d %e\n", BTF_C.row_idx[k], j, BTF_C.val[k]);
-        }
-      }
-    }
-    printf("];\n");
-
-    printf(" D_ = [\n" );
-    if (BTF_D.nrow > 0 && BTF_D.ncol > 0) {
-      for(Int j = 0; j < BTF_D.ncol; j++) {
-        for(Int k = BTF_D.col_ptr[j]; k < BTF_D.col_ptr[j+1]; k++) {
-          printf("%d %d %e\n", BTF_D.row_idx[k], j, BTF_D.val[k]);
-        }
-      }
-    }
-    printf("];\n");
-
-    printf(" E_ = [\n" );
-    if (BTF_E.nrow > 0 && BTF_E.ncol > 0) {
-      for(Int j = 0; j < BTF_E.ncol; j++) {
-        for(Int k = BTF_E.col_ptr[j]; k < BTF_E.col_ptr[j+1]; k++) {
-          printf("%d %d %e\n", BTF_E.row_idx[k], j, BTF_E.val[k]);
-        }
-      }
-    }
-    printf("];\n");*/
-
-    if (Options.replace_tiny_pivot && BTF_A.nnz > 0) {
+    if ((Options.replace_zero_pivot || Options.replace_tiny_pivot) && BTF_A.nnz > 0) {
       // to compute one-norm of global A and BTF_A
       Kokkos::Timer normA_timer;
       using STS = Teuchos::ScalarTraits<Entry>;
@@ -1191,8 +1094,8 @@ namespace BaskerNS
       for (Int i = 0; i < (Int)A.nrow; i++) {
         order_blk_mwm_array(i) = i;
         order_blk_amd_array(i) = i;
-        scale_row_array(i) = one;
-        scale_col_array(i) = one;
+        scale_row_array(i) = abs(one);
+        scale_col_array(i) = abs(one);
 
         numeric_row_iperm_array(i) = i;
         numeric_col_iperm_array(i) = i;
@@ -1837,53 +1740,6 @@ namespace BaskerNS
       //for (Int i = 0; i < (Int)BTF_A.ncol; i++) {
       //  printf( " + nd(%d)=%d camd(%d)=%d\n",i,part_tree.permtab(i), i,order_csym_array(i));
       //}
-      /*printf("After everything:\n");
-      printf(" qA = [\n" );
-      if (BTF_A.nrow > 0 && BTF_A.ncol > 0) {
-        for(Int j = 0; j < BTF_A.ncol; j++) {
-          for(Int k = BTF_A.col_ptr[j]; k < BTF_A.col_ptr[j+1]; k++) {
-            printf("%d %d %e\n", BTF_A.row_idx[k], j, BTF_A.val[k]);
-          }
-        }
-      }
-      printf("];\n");
-      printf(" qB = [\n" );
-      if (BTF_B.nrow > 0 && BTF_B.ncol > 0) {
-        for(Int j = 0; j < BTF_B.ncol; j++) {
-          for(Int k = BTF_B.col_ptr[j]; k < BTF_B.col_ptr[j+1]; k++) {
-            printf("%d %d %e\n", BTF_B.row_idx[k], j, BTF_B.val[k]);
-          }
-        }
-      }
-      printf("];\n");
-      printf(" qC = [\n" );
-      if (BTF_C.nrow > 0 && BTF_C.ncol > 0) {
-        for(Int j = 0; j < BTF_C.ncol; j++) {
-          for(Int k = BTF_C.col_ptr[j]; k < BTF_C.col_ptr[j+1]; k++) {
-            printf("%d %d %e\n", BTF_C.row_idx[k], j, BTF_C.val[k]);
-          }
-        }
-      }
-      printf("];\n");
-      printf(" qD = [\n" );
-      if (BTF_D.nrow > 0 && BTF_D.ncol > 0) {
-        for(Int j = 0; j < BTF_D.ncol; j++) {
-          for(Int k = BTF_D.col_ptr[j]; k < BTF_D.col_ptr[j+1]; k++) {
-            printf("%d %d %e\n", BTF_D.row_idx[k], j, BTF_D.val[k]);
-          }
-        }
-      }
-      printf("];\n");
-      printf(" qE = [\n" );
-      if (BTF_E.nrow > 0 && BTF_E.ncol > 0) {
-        for(Int j = 0; j < BTF_E.ncol; j++) {
-          for(Int k = BTF_E.col_ptr[j]; k < BTF_E.col_ptr[j+1]; k++) {
-            printf("%d %d %e\n", BTF_E.row_idx[k], j, BTF_E.val[k]);
-          }
-        }
-      }
-      printf("];\n");*/
-
 
       // compose row permute
       //printf( " > ND and CSYMAMD in numeric setup\n" );
@@ -1915,11 +1771,122 @@ namespace BaskerNS
       permute_with_workspace(numeric_col_iperm_array, order_blk_amd_array, ncol);
       //for (int i = 0; i < ncol; i++) printf( " %d: %d %d\n",i, numeric_row_iperm_array(i),numeric_col_iperm_array(i) );
     }
-    else if(Options.verbose == BASKER_TRUE) {
-      std::cout << " No MWM on diagonal blocks " << std::endl;
+    else {
+      if(Options.verbose == BASKER_TRUE) {
+        std::cout << " No MWM on diagonal blocks " << std::endl;
+      }
+      //BTF_A.print_matrix("A1.dat");
+      if (Options.matrix_scaling != 0)
+      {
+        using STS = Teuchos::ScalarTraits<Entry>;
+        using Real = typename STS::magnitudeType;
+        const Real one (1.0);
+        const Real eps = Teuchos::ScalarTraits<Entry>::eps ();
+        const Real normA = BTF_A.anorm;
+
+        Int scol_top = btf_tabs[btf_top_tabs_offset];
+
+        ////////////////////
+        // row and column scale A
+        if (Options.matrix_scaling == 1) {
+          // find diagonal scaling factors 
+          for(Int j = 0; j < BTF_A.ncol; j++) {
+            Int col = scol_top+j;
+            scale_row_array[col] = one;
+            scale_col_array[col] = one;
+            for(Int k = BTF_A.col_ptr[j]; k < BTF_A.col_ptr[j+1]; k++) {
+              if (BTF_A.row_idx[k] == j) {
+                Entry ajj = abs(BTF_A.val[k]);
+                if (abs(ajj) <= eps*normA) {
+                  ajj = eps*normA;
+                }
+                scale_row_array[col] = one / sqrt(ajj);
+                scale_col_array[col] = one / sqrt(ajj);
+              }
+            }
+          }
+
+          // scale matrix with symmetric diagonal scale
+          for(Int j = 0; j < BTF_A.ncol; j++) {
+            Int col = scol_top+j;
+            for(Int k = BTF_A.col_ptr[j]; k < BTF_A.col_ptr[j+1]; k++) {
+              Int row = scol_top+BTF_A.row_idx[k];
+              BTF_A.val[k] *= scale_col_array[col];
+              BTF_A.val[k] *= scale_row_array[row];
+            }
+          }
+        } else {
+          // find max non-zero entry on row
+          for(Int j = 0; j < BTF_A.ncol; j++) {
+            for(Int k = BTF_A.col_ptr[j]; k < BTF_A.col_ptr[j+1]; k++) {
+              Int row = scol_top+BTF_A.row_idx[k];
+              if (abs(scale_row_array[row]) < abs(BTF_A.val[k])) {
+                scale_row_array[row] = abs(BTF_A.val[k]);
+              }
+            }
+          }
+          for(Int i = 0; i < BTF_A.ncol; i++) {
+            Int row = scol_top+i;
+            if (abs(scale_row_array[row]) <= eps*normA) {
+              scale_row_array[row] = eps*normA;
+            }
+            scale_row_array[row] = one / scale_row_array[row];
+          }
+
+          // scale matrix with row scale
+          for(Int j = 0; j < BTF_A.ncol; j++) {
+            for(Int k = BTF_A.col_ptr[j]; k < BTF_A.col_ptr[j+1]; k++) {
+              Int row = scol_top+BTF_A.row_idx[k];
+              BTF_A.val[k] *= scale_row_array[row];
+            }
+          }
+
+          // find max non-zero entry on col, scale matrix
+          for(Int j = 0; j < BTF_A.ncol; j++) {
+            // find max entry
+            Int col = scol_top+j;
+            for(Int k = BTF_A.col_ptr[j]; k < BTF_A.col_ptr[j+1]; k++) {
+              if (abs(scale_col_array[col]) < abs(BTF_A.val[k])) {
+                scale_col_array[col] = abs(BTF_A.val[k]);
+              }
+            }
+            if (abs(scale_col_array[col]) <= eps*normA) {
+              scale_col_array[col] = eps*normA;
+            }
+            // scale
+            scale_col_array[col] = one / scale_col_array[col];
+            for(Int k = BTF_A.col_ptr[j]; k < BTF_A.col_ptr[j+1]; k++) {
+              BTF_A.val[k] *= scale_col_array[col];
+            }
+          }
+        }
+
+        ////////////////////
+        // row-scale B
+        for(Int j = 0; j < BTF_B.ncol; j++) {
+          for(Int k = BTF_B.col_ptr[j]; k < BTF_B.col_ptr[j+1]; k++) {
+            Int row = scol_top+BTF_B.row_idx[k];
+            BTF_B.val[k] *= scale_row_array[row];
+          }
+        }
+        ////////////////////
+        // col-scale E
+        for(Int j = 0; j < BTF_E.ncol; j++) {
+          Int col = scol_top+j;
+          for(Int k = BTF_E.col_ptr[j]; k < BTF_E.col_ptr[j+1]; k++) {
+            BTF_E.val[k] *= scale_col_array[col];
+          }
+        }
+      }
+      //BTF_A.print_matrix("A2.dat");
     }
     reset_error();
 
+    //BTF_A.print_matrix("qA.dat");
+    //BTF_B.print_matrix("qB.dat");
+    //BTF_C.print_matrix("qC.dat");
+    //BTF_D.print_matrix("qD.dat");
+    //BTF_E.print_matrix("qE.dat");
 
     #ifdef BASKER_DEBUG_DIAG
     // Look for zeros on the diagonal - an Option / parameter list option should be used to enable this

--- a/packages/shylu/shylu_node/basker/src/shylubasker_def.hpp
+++ b/packages/shylu/shylu_node/basker/src/shylubasker_def.hpp
@@ -765,7 +765,6 @@ namespace BaskerNS
         // to revert BLK_MWM ordering
         for (Int k = 0; k < (Int)ncol; k++) order_blk_mwm_inv(k) = k;
         permute_inv(order_blk_mwm_inv, order_blk_mwm_array, ncol);
-        //BTF_A.print_matrix("A.dat");
 
         // --------------------------------------------
         // reset the large A block
@@ -1775,7 +1774,6 @@ namespace BaskerNS
       if(Options.verbose == BASKER_TRUE) {
         std::cout << " No MWM on diagonal blocks " << std::endl;
       }
-      //BTF_A.print_matrix("A1.dat");
       if (Options.matrix_scaling != 0)
       {
         using STS = Teuchos::ScalarTraits<Entry>;
@@ -1878,15 +1876,8 @@ namespace BaskerNS
           }
         }
       }
-      //BTF_A.print_matrix("A2.dat");
     }
     reset_error();
-
-    //BTF_A.print_matrix("qA.dat");
-    //BTF_B.print_matrix("qB.dat");
-    //BTF_C.print_matrix("qC.dat");
-    //BTF_D.print_matrix("qD.dat");
-    //BTF_E.print_matrix("qE.dat");
 
     #ifdef BASKER_DEBUG_DIAG
     // Look for zeros on the diagonal - an Option / parameter list option should be used to enable this

--- a/packages/shylu/shylu_node/basker/src/shylubasker_matrix_decl.hpp
+++ b/packages/shylu/shylu_node/basker/src/shylubasker_matrix_decl.hpp
@@ -119,6 +119,8 @@ namespace BaskerNS
     BASKER_INLINE
     void print();
 
+    BASKER_INLINE
+    void print_matrix(const char *filename);
 
     //Note: These need to be reordered to make better use of 
     //Class size.

--- a/packages/shylu/shylu_node/basker/src/shylubasker_matrix_def.hpp
+++ b/packages/shylu/shylu_node/basker/src/shylubasker_matrix_def.hpp
@@ -552,9 +552,6 @@ namespace BaskerNS
 
     anorm = abs(zero);
     Int temp_count = 0;
-    //char filename[200];
-    //sprintf(filename,"ALM%d_%d_%d.dat",kid,nrow,ncol);
-    //FILE *fp = fopen(filename,"w");
     for(Int k = scol; k < scol+ncol; ++k)
     {
       //note col_ptr[k-scol] contains the starting index (by find_2D_convert)
@@ -562,37 +559,17 @@ namespace BaskerNS
       if(col_ptr(k-scol) == BASKER_MAX_IDX)
       {
         col_ptr(k-scol) = temp_count;
-        /*if (kid == 1) {
-          printf("continue called, k: %d  \n", k);
-        }*/
         continue;
       }
 
-      /*if (kid == 1)
-      {
-        printf(" kid=%d: col_ptr(%d-%d) = %d, M.col_ptr(%d) = %d\n", kid,k,scol,col_ptr(k-scol), k+1,M.col_ptr(k+1));
-      }*/
       Mag anorm_k (0.0);
       for(Int i = col_ptr(k-scol); i < M.col_ptr(k+1); i++)
       {
         Int j = M.row_idx(i);
-        /*if (nrow == 289 && ncol == 100)
-        {
-          printf( " > row_idx[%d] = %d, val[%d] = %e (%d + %d) with k = %d+%d\n",i,j, i,M.val(i), srow,nrow, scol,k );
-        }*/
         if(j >= srow+nrow)
         {
-          // skip lower-off diagonal blocks for U
-          /*if (kid == 3)
-          {
-            printf("break called, k: %d  \n", k);
-          }*/
           break;
         }
-        //printf("writing row_dix: %d i: %d  val: %d nnz: %d srow: %d nrow: %d \n",
-        //	   temp_count, i, j, nnz, 
-        //	   srow, nrow);
-        //BASKER_ASSERT(temp_count < nnz, "2DConvert, too many values");
 
         if(j < srow)
         {
@@ -610,30 +587,18 @@ namespace BaskerNS
           sprintf(error_msg, " ERROR: j is less than srow (j=%d, srow=%d, kid=%d)",(int)j,(int)srow,(int)kid);
           BASKER_ASSERT(0 == 1, error_msg);
         }
-        /*if (kid == 0) 
-        {
-          fprintf(fp, " %d %d, %.16e\n", j-srow, k-scol, M.val(i));
-        }*/
         if (keep_zeros || M.val(i) != zero)
         {
           row_idx(temp_count) = j-srow;
           val(temp_count) = M.val(i);
-          /*if (nrow == 289 && ncol == 100) {
-            printf( " (%d %e) k=%d nnz = %d\n",j-srow,M.val(i),k-scol,temp_count );
-          }*/
 
           anorm_k += abs(M.val(i));
           temp_count++;
         }
       }
       anorm = (anorm > anorm_k ? anorm : anorm_k);
-      /*if (kid == 1) 
-      {
-        printf( " %d: col_ptr(%d) = %d\n",kid,k-scol,temp_count );
-      }*/
       col_ptr(k-scol) = temp_count;
     }
-    //fclose(fp);
 
     //NO!!1
     //Slide over the col counts

--- a/packages/shylu/shylu_node/basker/src/shylubasker_matrix_def.hpp
+++ b/packages/shylu/shylu_node/basker/src/shylubasker_matrix_def.hpp
@@ -552,6 +552,9 @@ namespace BaskerNS
 
     anorm = abs(zero);
     Int temp_count = 0;
+    //char filename[200];
+    //sprintf(filename,"ALM%d_%d_%d.dat",kid,nrow,ncol);
+    //FILE *fp = fopen(filename,"w");
     for(Int k = scol; k < scol+ncol; ++k)
     {
       //note col_ptr[k-scol] contains the starting index (by find_2D_convert)
@@ -607,9 +610,9 @@ namespace BaskerNS
           sprintf(error_msg, " ERROR: j is less than srow (j=%d, srow=%d, kid=%d)",(int)j,(int)srow,(int)kid);
           BASKER_ASSERT(0 == 1, error_msg);
         }
-        /*if (kid == 1) 
+        /*if (kid == 0) 
         {
-          printf( " %d:%d:%d: %d %d, %e\n",kid,i,temp_count,j-srow,k,M.val(i) );
+          fprintf(fp, " %d %d, %.16e\n", j-srow, k-scol, M.val(i));
         }*/
         if (keep_zeros || M.val(i) != zero)
         {
@@ -630,6 +633,7 @@ namespace BaskerNS
       }*/
       col_ptr(k-scol) = temp_count;
     }
+    //fclose(fp);
 
     //NO!!1
     //Slide over the col counts
@@ -691,7 +695,21 @@ namespace BaskerNS
     std::cout << "\n END PRINT " << std::endl;
 
   }//end print()
-
+  
+  template <class Int, class Entry, class Exe_Space>
+  BASKER_INLINE
+  void BaskerMatrix<Int,Entry,Exe_Space>::print_matrix(const char *filename)
+  {
+    FILE *fp = fopen(filename, "w");
+    if (nrow > 0 && ncol > 0) {
+      for(Int j = 0; j < ncol; j++) {
+        for(Int k = col_ptr[j]; k < col_ptr[j+1]; k++) {
+          fprintf(fp,"%d %d %.16e\n", (int)row_idx[k], (int)j, val[k]);
+        }
+      }
+    }
+    fclose(fp);
+  }
 }//end namespace basker
 
 #endif //end BASKER_MATRIX_DEF_HPP

--- a/packages/shylu/shylu_node/basker/src/shylubasker_nfactor_blk.hpp
+++ b/packages/shylu/shylu_node/basker/src/shylubasker_nfactor_blk.hpp
@@ -136,6 +136,9 @@ namespace BaskerNS
     using Mag = typename STS::magnitudeType;
     const Entry zero (0.0);
     const Entry one (1.0);
+    const Mag eps = STS::eps ();
+    const Mag normA     = BTF_A.gnorm;
+    const Mag normA_blk = BTF_A.anorm;
 
     Int b = S[0][kid]; //Which blk from schedule
     BASKER_MATRIX &L   = LL(b)(0);
@@ -243,17 +246,16 @@ namespace BaskerNS
     }
     //#define MY_DEBUG_BASKER
     #ifdef MY_DEBUG_BASKER
-    #define debug_kid 2
-    if (kid == debug_kid) {
-      printf( " t_nfactor_blk(kid = %d, %dx%d): wsize=%d\n",kid,M.nrow,M.ncol,ws_size );
-      printf( " D = [\n" );
-      for(Int k = 0; k < M.ncol; ++k) {
-        for( i = M.col_ptr(k); i < M.col_ptr(k+1); ++i) {
-          printf( "%d %d %d %.16e\n", i, M.row_idx(i), k, M.val(i));
-        }
-      }
-      printf( "];\n" );
+    #define debug_kid 1
+    {
+      //printf( " t_nfactor_blk(kid = %d, %dx%d): wsize=%d\n",kid,M.nrow,M.ncol,ws_size );
+      char filename[200];
+      sprintf(filename,"D_%d.dat",kid);
+      M.print_matrix(filename);
     }
+    char filename[200];
+    sprintf(filename,"t_nfactor_blk_%d_%d.dat",kid,M.ncol);
+    FILE *fp = fopen(filename,"w");
     #endif
 
     // initialize perm vector
@@ -435,8 +437,12 @@ namespace BaskerNS
         }
       }//for (i = top; i < ws_size)
       #ifdef MY_DEBUG_BASKER
-      if (kid == debug_kid) {
-        printf( " thread-%d > k=%d maxindex=%d pivot=%e maxv=%e, diag=%e diagj=%d tol=%e (nopivot=%d)\n", kid, k, maxindex, pivot, maxv, digv,digj, Options.pivot_tol,Options.no_pivot);
+      //if (kid == debug_kid)
+      {
+        const Mag eps = STS::eps ();
+        const Mag normA_blk = BTF_A.anorm;
+        fprintf(fp, " thread-%d > k=%d maxindex=%d pivot=%e maxv=%e, diag=%e diagj=%d tol=%e eps*normA=%e*%e=%e (nopivot=%d)\n", 
+                kid, k, maxindex, pivot, maxv, digv,digj, Options.pivot_tol,eps,normA_blk,eps*normA_blk,Options.no_pivot);
         fflush(stdout);
       }
       #endif
@@ -467,24 +473,23 @@ namespace BaskerNS
       ucnt = ws_size - top - lcnt +1;
       if((maxindex == BASKER_MAX_IDX) || (pivot == zero) )
       {
-        const Mag eps = STS::eps ();
-        const Mag normA     = BTF_A.gnorm;
-        const Mag normA_blk = BTF_A.anorm;
         if (Options.verbose == BASKER_TRUE)
         {
           cout << endl << endl;
           cout << "---------------------------" << endl;
           cout << "  thread-" << kid 
-               << " Error: Dom Matrix, k = " << k
+               << " Error: Dom Matrix(" << b << "), k = " << k
                << " ( " << M.nrow << " x " << M.ncol << " )"
                << " with nnz = " << M.nnz
                << " is singular"
                << endl;
           cout << "  norm(A)   = " << normA     << " (global)" << endl
                << "  norm(A)   = " << normA_blk << " (block)"  << endl
-               << "  replace_tiny_pivot = " << (Options.replace_tiny_pivot ? " true " : "false" ) << endl;
+               << "  replace_zero_pivot = " << (Options.replace_zero_pivot ? " true " : "false" ) << endl;
           if (Options.replace_tiny_pivot && normA_blk > abs(zero) && maxindex != BASKER_MAX_IDX) {
-            cout << "  replace tiny pivot with " << normA_blk * eps << endl;
+            cout << "  + replace zero pivot with " << normA_blk * sqrt(eps) << endl;
+          } else if (Options.replace_zero_pivot && normA_blk > abs(zero) && maxindex != BASKER_MAX_IDX) {
+            cout << "  - replace zero pivot with " << normA_blk * eps << endl;
           }
           cout << "  Ptr       = " << M.col_ptr(k) 
                            << " " << M.col_ptr(k+1)-1 << endl;
@@ -497,22 +502,20 @@ namespace BaskerNS
                << "---------------------------" << endl;
           /*if (kid == 0)
           {
-            printf( " D = [\n" );
-            for(Int k = 0; k < M.ncol; ++k) {
-              for( i = M.col_ptr(k); i < M.col_ptr(k+1); ++i) {
-                printf( "%d %d %d %e\n", i, M.row_idx(i), k, M.val(i));
-              }
-            }
-            printf( "];\n" );
+            M.print_matrix("D.dat");
           }*/
         }
+
         if (Options.replace_tiny_pivot && normA_blk > abs(zero) && maxindex != BASKER_MAX_IDX) {
+          pivot = normA_blk * sqrt(eps);
+          X(maxindex) = pivot;
+          npivots ++;
+        } else if (Options.replace_zero_pivot && normA_blk > abs(zero) && maxindex != BASKER_MAX_IDX) {
           pivot = normA_blk * eps;
           X(maxindex) = pivot;
           npivots ++;
         } else {
           // replace-tiny-pivot not requested, or the current column is structurally empty after elimination
-          // TODO: should we "add" tiny pivot to diagonal?    
           thread_array(kid).error_type =
             BASKER_ERROR_SINGULAR;
           thread_array(kid).error_blk    = b;
@@ -520,17 +523,36 @@ namespace BaskerNS
           thread_array(kid).error_info   = k;
           return BASKER_ERROR;
         }
+      } else if (Options.replace_tiny_pivot && normA_blk > abs(zero) && abs(pivot) < normA_blk * sqrt(eps)) {
+        if (Options.verbose == BASKER_TRUE)
+        {
+          cout << endl << endl;
+          cout << "---------------------------" << endl;
+          cout << "  thread-" << kid 
+               << " Dom Matrix(" << b << "), k = " << k
+               << " ( " << M.nrow << " x " << M.ncol << " )"
+               << " with nnz = " << M.nnz
+               << " : replace tiny pivot( " << pivot << " -> "
+               << (STS::real(pivot) >= abs(zero) ? normA_blk * sqrt(eps) : -normA_blk * sqrt(eps))
+               << endl;
+          cout << "---------------------------" << endl;
+        }
+        if (STS::real(pivot) >= abs(zero)) {
+          pivot = normA_blk * sqrt(eps);
+        } else {
+          pivot = -normA_blk * sqrt(eps);
+        }
+        X(maxindex) = pivot;
+        npivots ++;
       }
-      /*else if (abs(pivot) < BTF_A.gnorm*sqrt(eps)) {
-        cout << " tiny but not zero : " << abs(pivot) << " vs " << BTF_A.gnorm << " * " << sqrt(eps) << " = " << BTF_A.gnorm*sqrt(eps) << endl;
-      }*/
+
       // store pivot
       gperm(maxindex+brow_g) = k+brow_g;
       gpermi(k+brow_g) = maxindex + brow_g;
       #ifdef MY_DEBUG_BASKER
-      if (kid == debug_kid)
+      //if (kid == debug_kid)
       {
-        printf( " + %d: gperm(%d + %d) = %d\n",kid,maxindex,brow_g,k+brow_g );
+        fprintf(fp, " + %d: gperm(%d + %d) = %d\n",kid,maxindex,brow_g,k+brow_g );
       }
       #endif
 
@@ -860,22 +882,22 @@ namespace BaskerNS
     #endif
 
     #ifdef MY_DEBUG_BASKER
-    if (kid == debug_kid) {
-      //print_factor(L,U);
-      printf("L=[\n");
+    fclose(fp);
+    {
+      char filename[200];
+      sprintf(filename,"P_%d.dat",kid);
+      FILE *fp = fopen(filename, "w");
       for (int j = 0; j < L.ncol; j++) {
-        for (int k = L.col_ptr[j]; k < L.col_ptr[j+1]; k++) {
-          printf( "%d %d %e\n",(int)L.row_idx[k],j,L.val[k]);
-        }
+        fprintf(fp,"%d %d\n",gperm(j+brow_g)-brow_g,gpermi(j+brow_g)-brow_g);
       }
-      printf("];\n");
-      printf("U=[\n");
-      for (int j = 0; j < U.ncol; j++) {
-        for (int k = U.col_ptr[j]; k < U.col_ptr[j+1]; k++) {
-          printf( "%d %d %e\n",(int)U.row_idx[k],j,U.val[k]);
-        }
-      }
-      printf("];\n");
+      fclose(fp);
+
+      // D(P(:,2), :) = L(P(:,2), :) * U
+      sprintf(filename,"L_%d.dat",kid);
+      L.print_matrix(filename);
+
+      sprintf(filename,"U_%d.dat",kid);
+      U.print_matrix(filename);
     }
     #endif
 
@@ -1424,12 +1446,13 @@ namespace BaskerNS
           //do this in a dense way
           //#pragma ivdep (may be slower)
           //printf( " gperm(%d+%d) = %d, scol=%d, %d:%d\n",(int)j,(int)brow,(int)t, (int)L.scol, (int)L.col_ptr(t-local_offset)+1,(int)pend );
+          //if (kid == 1) printf( " t_back_solve(%d):\n",t-local_offset );
           for(Int p = L.col_ptr(t-local_offset)+1; p < pend; ++p)
           {
             const Int row_idx = L.row_idx(p);
             const Entry update_val = L.val(p)*xj;
 
-            //printf( " %d: row_idx=%d\n",(int)p,(int)row_idx );
+            //if (kid == 1) printf( " %d: x(row_idx=%d) = %e - %e*%e = %e\n",(int)p,(int)row_idx, X(row_idx),xj,L.val(p),X(row_idx)-update_val );
             X(row_idx) -= update_val;
             flops += 2;
           }//end for() over each nnz in the column

--- a/packages/shylu/shylu_node/basker/src/shylubasker_nfactor_blk.hpp
+++ b/packages/shylu/shylu_node/basker/src/shylubasker_nfactor_blk.hpp
@@ -1445,14 +1445,11 @@ namespace BaskerNS
           //What we want to think about is how to 
           //do this in a dense way
           //#pragma ivdep (may be slower)
-          //printf( " gperm(%d+%d) = %d, scol=%d, %d:%d\n",(int)j,(int)brow,(int)t, (int)L.scol, (int)L.col_ptr(t-local_offset)+1,(int)pend );
-          //if (kid == 1) printf( " t_back_solve(%d):\n",t-local_offset );
           for(Int p = L.col_ptr(t-local_offset)+1; p < pend; ++p)
           {
             const Int row_idx = L.row_idx(p);
             const Entry update_val = L.val(p)*xj;
 
-            //if (kid == 1) printf( " %d: x(row_idx=%d) = %e - %e*%e = %e\n",(int)p,(int)row_idx, X(row_idx),xj,L.val(p),X(row_idx)-update_val );
             X(row_idx) -= update_val;
             flops += 2;
           }//end for() over each nnz in the column

--- a/packages/shylu/shylu_node/basker/src/shylubasker_nfactor_diag.hpp
+++ b/packages/shylu/shylu_node/basker/src/shylubasker_nfactor_diag.hpp
@@ -427,7 +427,7 @@ namespace BaskerNS
 
     // compute one-norm of diagonal block, if needed
     Mag normA_blk = Mag (0.0);
-    if (Options.replace_tiny_pivot) {
+    if (Options.replace_zero_pivot) {
       for (j = btf_tabs(c); j < btf_tabs(c+1); ++j) {
         Mag anorm_j = Mag(0.0);
         for (i = M.col_ptr(j-bcol); i < M.col_ptr(j-bcol+1); ++i) {
@@ -686,12 +686,12 @@ namespace BaskerNS
           cout << "MaxIndex: " << maxindex 
             << " pivot " 
             << pivot << endl;
-          if (Options.replace_tiny_pivot && normA_blk > abs(zero) && maxindex != BASKER_MAX_IDX) {
-            cout << "  replace tiny pivot with " << normA_blk * eps
+          if (Options.replace_zero_pivot && normA_blk > abs(zero) && maxindex != BASKER_MAX_IDX) {
+            cout << "  replace zero pivot with " << normA_blk * eps
                  << " (normA = " << normA << ", normA_blk = " << normA_blk << ", eps = " << eps << ")" << endl;
           } else {
-            if (!Options.replace_tiny_pivot) {
-              cout << " replace_tiny_pivot disabled, ";
+            if (!Options.replace_zero_pivot) {
+              cout << " replace_zero_pivot disabled, ";
             }
             if (normA_blk <= abs(zero)) {
               cout << " empty block, ";
@@ -702,7 +702,7 @@ namespace BaskerNS
             cout << endl;
           }
         }
-        if (Options.replace_tiny_pivot && normA_blk > abs(zero) && maxindex != BASKER_MAX_IDX) {
+        if (Options.replace_zero_pivot && normA_blk > abs(zero) && maxindex != BASKER_MAX_IDX) {
           pivot = normA_blk * eps;
           X(maxindex) = pivot;
         } else {

--- a/packages/shylu/shylu_node/basker/src/shylubasker_order.hpp
+++ b/packages/shylu/shylu_node/basker/src/shylubasker_order.hpp
@@ -255,14 +255,7 @@ static int basker_sort_matrix_col(const void *arg1, const void *arg2)
       vals_perm_composition(i) = i;
     }
     permute_inv(vals_perm_composition, vals_crs_transpose, A.nnz);
-
-    /*printf( " a=[\n" );
-    for(Int j = 0; j < A.ncol; j++) {
-      for(Int k = A.col_ptr[j]; k < A.col_ptr[j+1]; k++) {
-        printf( "%d %d %e\n", A.row_idx[k], j, A.val[k]);
-      }
-    }
-    printf( "];\n" );*/
+    //A.print_matrix("a.dat");
 
     //--------------------------------------------------
     // 0: Basker, 1: trilinos, 2: MC64
@@ -279,13 +272,7 @@ static int basker_sort_matrix_col(const void *arg1, const void *arg2)
     /*printf( " matchP=[\n" );
     for (int i = 0; i < A.ncol; i++) printf( "%d\n", order_match_array(i));
     printf( "];\n" );
-    printf( " c=[\n" );
-    for(Int j = 0; j < A.ncol; j++) {
-      for(Int k = A.col_ptr[j]; k < A.col_ptr[j+1]; k++) {
-        printf( "%d %d %e\n", A.row_idx[k], j, A.val[k]);
-      }
-    }
-    printf( "];\n" );*/
+    A.print_matrix("c.dat");*/
 
 
     #ifdef BASKER_TIMER
@@ -590,19 +577,20 @@ static int basker_sort_matrix_col(const void *arg1, const void *arg2)
 
     if (option < 0) {
       // no matching
+      match_flag = BASKER_FALSE;
       if(Options.verbose == BASKER_TRUE) {
         std::cout << " ++ calling NO matching ++ " << std::endl;
       }
-      match_flag = BASKER_FALSE;
+      if (Options.matrix_scaling != 0) {
+        if(Options.verbose == BASKER_TRUE) {
+          std::cout << " ++ allocate matrix sscaling ++ " << std::endl;
+        }
+        MALLOC_ENTRY_1DARRAY (scale_row_array, A.nrow);
+        MALLOC_ENTRY_1DARRAY (scale_col_array, A.nrow);
+      }
     } else {
       match_flag = BASKER_TRUE;
-      /*printf( " A = [\n" );
-      for(Int j = 0; j < A.ncol; j++) {
-        for(Int k = A.col_ptr[j]; k < A.col_ptr[j+1]; k++) {
-          printf( " %d %d %e\n", A.row_idx[k],j,A.val[k]);
-        }
-      }
-      printf("];\n");*/
+      //A.print_matrix("A.dat");
 
       Entry one(1.0);
       int num_match = min(A.nrow, A.ncol);
@@ -687,13 +675,7 @@ static int basker_sort_matrix_col(const void *arg1, const void *arg2)
       }
       //printf( " match_array\n" );
       //for(Int j = 0; j < A.ncol; j++) printf( " > %d\n",order_match_array(j) );
-      /*printf( " B = [\n" );
-      for(Int j = 0; j < A.ncol; j++) {
-        for(Int k = A.col_ptr[j]; k < A.col_ptr[j+1]; k++) {
-          printf( " %d %d %e\n", A.row_idx[k],j,A.val[k]);
-        }
-      }
-      printf("];\n");*/
+      //A.print_matrix("B.dat");
       if(num_match < min(A.nrow, A.ncol)) {
         if(Options.verbose == BASKER_TRUE) {
           std::cout << " ++ Num of matches returned " << num_match
@@ -819,15 +801,8 @@ static int basker_sort_matrix_col(const void *arg1, const void *arg2)
     //currently finds ND and permute BTF_A
     //Would like to change so finds permuation, 
     //and move into 2D-Structure
-    /*printf(" in apply_scotch_partition\n" );
-    printf(" T = [\n" );
-    for(Int j = 0; j < BTF_A.ncol; j++) {
-      for(Int k = BTF_A.col_ptr[j]; k < BTF_A.col_ptr[j+1]; k++) {
-        printf("%d %d %e\n", BTF_A.row_idx[k], j, BTF_A.val[k]);
-      }
-    }
-    printf("];\n");*/
-
+    //printf(" in apply_scotch_partition\n" );
+    //AAT.print_matrix("T.dat");
     BASKER_MATRIX AAT;
     if(Options.symmetric == BASKER_TRUE) {
       AAT = BTF_A;
@@ -835,13 +810,7 @@ static int basker_sort_matrix_col(const void *arg1, const void *arg2)
       // compute AAT here
       AplusAT(BTF_A, AAT, keep_zeros);
     }
-    /*printf(" AAT = [\n" );
-    for(Int j = 0; j < AAT.ncol; j++) {
-      for(Int k = AAT.col_ptr[j]; k < AAT.col_ptr[j+1]; k++) {
-        printf("%d %d\n", AAT.row_idx[k], j);
-      }
-    }
-    printf("];\n");*/
+    //AAT.print_matrix("AAT_.dat");
     #ifdef BASKER_TIMER
     double apat_time = scotch_timer.seconds();
     std::cout << " ++ Basker apply_scotch : ++ AplusAT  : nnz = " << BTF_A.nnz << " -> " << AAT.nnz
@@ -852,13 +821,7 @@ static int basker_sort_matrix_col(const void *arg1, const void *arg2)
 
     // tree is prepped; permutation then applied to BTF_A
     /*printf(" Before permute:\n" );
-    printf(" A1 = [\n" );
-    for(Int j = 0; j < BTF_A.ncol; j++) {
-      for(Int k = BTF_A.col_ptr[j]; k < BTF_A.col_ptr[j+1]; k++) {
-        printf("%d %d %e\n", BTF_A.row_idx[k], j, BTF_A.val(k));
-      }
-    }
-    printf("];\n");*/
+    BTF_A.print_matrix("A1.dat");*/
     int info_scotch = 0;
     if (compute_nd) {
       if (Options.symmetric == BASKER_TRUE) {
@@ -871,15 +834,10 @@ static int basker_sort_matrix_col(const void *arg1, const void *arg2)
       permute_row(BTF_A, part_tree.permtab);
       permute_col(BTF_A, part_tree.permtab);
     }
-    /*printf(" After permute:\n" );
-    for(Int j = 0; j < AAT.ncol; j++) printf( " %d %d %d\n",j,part_tree.permtab(j),part_tree.ipermtab(j) );
-    printf(" A2 = [\n" );
-    for(Int j = 0; j < BTF_A.ncol; j++) {
-      for(Int k = BTF_A.col_ptr[j]; k < BTF_A.col_ptr[j+1]; k++) {
-        printf("%d %d %e\n", BTF_A.row_idx[k], j, BTF_A.val(k));
-      }
-    }
-    printf("];\n");*/
+    //printf(" After permute:\n" );
+    //for(Int j = 0; j < AAT.ncol; j++) printf( " %d %d %d\n",j,part_tree.permtab(j),part_tree.ipermtab(j) );
+    //BTF_A.print_matrix("A2.dat");
+
     if (info_scotch != BASKER_SUCCESS || !apply_nd) {
       if(Options.verbose == BASKER_TRUE) {
         std::cout << " > scotch_partition returned info = " << info_scotch << " with apply_nd = " << apply_nd << std::endl;
@@ -922,20 +880,8 @@ static int basker_sort_matrix_col(const void *arg1, const void *arg2)
       printf("%d\n",part_tree.permtab(j) );
     }
     printf("];\n");
-    printf(" ppT = [\n" );
-    for(Int j = 0; j < BTF_A.ncol; j++) {
-      for(Int k = BTF_A.col_ptr[j]; k < BTF_A.col_ptr[j+1]; k++) {
-        printf("%d %d %e\n", BTF_A.row_idx[k], j, BTF_A.val[k]);
-      }
-    }
-    printf("];\n");
-    printf(" AAT = [\n" );
-    for(Int j = 0; j < AAT.ncol; j++) {
-      for(Int k = AAT.col_ptr[j]; k < AAT.col_ptr[j+1]; k++) {
-        printf("%d %d\n", AAT.row_idx[k], j);
-      }
-    }
-    printf("];\n");*/
+    BTF_A.print_matrix("pA.dat");
+    AAT.print_matrix("AAT.dat");*/
 
     //need to do a col perm on BTF_E and a row perm on BTF_B too
     if (BTF_E.ncol > 0) {
@@ -949,6 +895,7 @@ static int basker_sort_matrix_col(const void *arg1, const void *arg2)
     {
       permute_row(BTF_B, part_tree.permtab);
     }
+    //BTF_A.print_matrix("pT.dat");
 
     //--------------------------------------------------------------
     //4. Init tree structure
@@ -968,7 +915,7 @@ static int basker_sort_matrix_col(const void *arg1, const void *arg2)
     //5. Constrained symamd on A
     //Init for Constrained symamd on A
     bool run_nd_on_leaves  = Options.run_nd_on_leaves;
-    bool run_amd_on_leaves = false; //Options.run_amd_on_leaves;
+    bool run_amd_on_leaves = Options.run_amd_on_leaves;
     //if (Options.amd_dom && Options.static_delayed_pivot == 0)
     if (Options.amd_dom && (!run_nd_on_leaves && !run_amd_on_leaves)) // still compute csymamd in symbolic for delayed pivot (to reduce cost of setup in numeric)
     {
@@ -1059,14 +1006,10 @@ static int basker_sort_matrix_col(const void *arg1, const void *arg2)
     //sort_matrix_store_valperms(BTF_A, vals_order_ndbtfa_array);
     permute_row(BTF_A, order_csym_array);
 
-    /*printf(" After cAMD\n");
-    printf(" ppT = [\n" );
-    for(Int j = 0; j < BTF_A.ncol; j++) {
-      for(Int k = BTF_A.col_ptr[j]; k < BTF_A.col_ptr[j+1]; k++) {
-        printf("%d %d %e\n", (int)BTF_A.row_idx[k], (int)j, BTF_A.val[k]);
-      }
-    }
-    printf("];\n");*/
+    //printf("pp=[");
+    //for(Int j = 0; j < BTF_A.ncol; j++) printf("%d\n",order_csym_array(j));
+    //printf("]\n");
+    //BTF_A.print_matrix("ppT.dat");
 
     // ----------------------------------------------
     // sort matrix(BTF_A);
@@ -1086,15 +1029,6 @@ static int basker_sort_matrix_col(const void *arg1, const void *arg2)
               << " ( " << sortA_time1 << " )" << std::endl;
     scotch_timer.reset();
     #endif
-    /*printf( " After sort(A)\n" );
-    for (Int j = 0; j < BTF_A.nnz; j++) printf( " + vals_ndbtfa(%d) = %d\n",j,vals_order_ndbtfa_array(j) );
-    printf(" ppT = [\n" );
-    for(Int j = 0; j < BTF_A.ncol; j++) {
-      for(Int k = BTF_A.col_ptr[j]; k < BTF_A.col_ptr[j+1]; k++) {
-        printf("%d %d %e\n", BTF_A.row_idx[k], j, BTF_A.val[k]);
-      }
-    }
-    printf("];\n");*/
 
     if (BTF_E.ncol > 0) {
       //permute_col(BTF_E, order_csym_array);

--- a/packages/shylu/shylu_node/basker/src/shylubasker_order_btf.hpp
+++ b/packages/shylu/shylu_node/basker/src/shylubasker_order_btf.hpp
@@ -759,12 +759,10 @@ namespace BaskerNS
       //	   ((double)1/num_threads) +
       //	   ((double)BASKER_BTF_IMBALANCE));
       #if 0 // forcing to have the big A bloock for debug
-      //Int break_size = 0;
-      //Int break_size = 5;
-      Int break_size = 10;
-      //Int break_size = 100;
-      //Int break_size = 500000;
-      printf( " > debug: break_size = %d\n",break_size );
+      double break_work_size = 0.0;
+      //double break_block_size = 0.0;
+      double break_block_size = 10.0;
+      printf( " > debug: break_size = %f, %f\n",break_work_size,break_block_size );
       #else
       // A block if it is larger than work esitimate assigned to one thread
       double break_fact = 0.7;

--- a/packages/shylu/shylu_node/basker/src/shylubasker_order_scotch.hpp
+++ b/packages/shylu/shylu_node/basker/src/shylubasker_order_scotch.hpp
@@ -269,11 +269,13 @@ namespace BaskerNS
         /*for (Int i = 0; i < num_doms; i++) {
           printf( " post[%d] = %d, ipost[%d]=%d\n",i,post_order(i),i,post_iorder(i) );
         }*/
-        /*printf( " M = [\n" );
+        //printf( " M = [\n" );
+        /*FILE *fp = fopen("A.dat","w");
         for(Int i = 0; i < M.nrow; i++) {
-          for(Int k = M.col_ptr(i); k < M.col_ptr(i+1); k++) printf( "%d %d\n",i,M.row_idx(k) );
+          for(Int k = M.col_ptr(i); k < M.col_ptr(i+1); k++) fprintf(fp, "%d %d\n",i,M.row_idx(k) );
         }
-        printf( "];\n" );*/
+        fclose(fp);*/
+        //printf( "];\n" );
 
         // initial partition
         sg.cblk = 1;
@@ -332,6 +334,15 @@ namespace BaskerNS
           METIS_NodeNDP(metis_size, &(metis_rowptr(0)), &(metis_colidx(0)), vwgt,
                         num_leaves, options, &(metis_perm_k(0)), &(metis_iperm_k(0)), &(metis_sep_sizes(0)));
           time_metis += timer_metis.seconds();
+          #if 0
+          // debug: merging all the subdomains into one domain
+          //metis_sep_sizes(0) = metis_size;
+          //for (int i=1; i < 2*num_leaves-1; i++) metis_sep_sizes(i) = 0;
+
+          // debug: merging the first two subdomains
+          //metis_sep_sizes(0) += metis_sep_sizes(1);
+          //metis_sep_sizes(1) = 0;
+          #endif
           //for (int i=0; i < 2*num_leaves-1; i++) printf( " > size[%d] = %d\n",i,metis_sep_sizes(i) );
           for(Int i = 0; i < metis_size; i++) {
             sg.peritab[i] = metis_perm_k[i];
@@ -1138,12 +1149,14 @@ namespace BaskerNS
     }
 
     //printf( " + permtab, peritab\n" );
+    //FILE *fp = fopen("permtab_p.dat","w");
     for(Int i = 0; i < M.nrow; i++)
     {
       BT.permtab[i] = sg.permtab[i];
       BT.ipermtab[i] = sg.peritab[i];
-      //printf( " + %d, %d\n",BT.permtab[i],BT.ipermtab[i] );
+      //fprintf(fp, " %d, %d\n",BT.permtab[i],BT.ipermtab[i] );
     }
+    //fclose(fp);
 
     //Used for recursing easier
     BT.treetab[BT.nblks-1]   = BT.nblks;

--- a/packages/shylu/shylu_node/basker/src/shylubasker_order_scotch.hpp
+++ b/packages/shylu/shylu_node/basker/src/shylubasker_order_scotch.hpp
@@ -357,8 +357,8 @@ namespace BaskerNS
             }
 
             if (level_k < num_levels) {
-              Int num_leaves = pow(2.0, (double)(level_k));       // number of leaves at this level
-              for (Int leaf_id = 0; leaf_id < num_leaves; leaf_id++) {
+              Int num_leaves_k = pow(2.0, (double)(level_k));       // number of leaves at this level
+              for (Int leaf_id = 0; leaf_id < num_leaves_k; leaf_id++) {
                 Int dom_id = 2 * leaf_id + first_leaf1;
                 Int dom_id1 = dom_id;     // id of left-child after bisection
                 Int dom_id2 = dom_id + 1; // id of right-child after bisection

--- a/packages/shylu/shylu_node/basker/src/shylubasker_order_scotch.hpp
+++ b/packages/shylu/shylu_node/basker/src/shylubasker_order_scotch.hpp
@@ -269,13 +269,7 @@ namespace BaskerNS
         /*for (Int i = 0; i < num_doms; i++) {
           printf( " post[%d] = %d, ipost[%d]=%d\n",i,post_order(i),i,post_iorder(i) );
         }*/
-        //printf( " M = [\n" );
-        /*FILE *fp = fopen("A.dat","w");
-        for(Int i = 0; i < M.nrow; i++) {
-          for(Int k = M.col_ptr(i); k < M.col_ptr(i+1); k++) fprintf(fp, "%d %d\n",i,M.row_idx(k) );
-        }
-        fclose(fp);*/
-        //printf( "];\n" );
+        //M.print_matrix("A.dat");
 
         // initial partition
         sg.cblk = 1;

--- a/packages/shylu/shylu_node/basker/src/shylubasker_sfactor.hpp
+++ b/packages/shylu/shylu_node/basker/src/shylubasker_sfactor.hpp
@@ -2216,14 +2216,13 @@ printf( " col_count:: view \n" );
   {
     if(option == 0)
     {
-      Int t_nnz = 0;
-      Int temp = 0;
+      const Int Int_MAX = std::numeric_limits<Int>::max();
 
+      Int t_nnz = 0;
       for(Int i = 0; i < M.ncol; i++)
       {
-        temp = t_nnz + ST.col_counts[i];
-        if (temp > t_nnz) {
-          t_nnz = temp;
+        if (t_nnz <= Int_MAX - ST.col_counts[i]) {
+          t_nnz += ST.col_counts[i];
         } else {
           // let's just hope it is enough, if overflow
           break;
@@ -2235,7 +2234,7 @@ printf( " col_count:: view \n" );
 
       //double nnz_shoulder = 1.05;
       double fill_factor = BASKER_DOM_NNZ_OVER+Options.user_fill; // used to boost fill estimate
-      temp = fill_factor*t_nnz;
+      Int temp = fill_factor*t_nnz;
       if (temp > t_nnz) {
         M.nnz = temp;
       } else {
@@ -2247,10 +2246,9 @@ printf( " col_count:: view \n" );
       t_nnz = 0;
       #endif
 
-      temp = global_nnz + t_nnz;
-      if (temp > global_nnz) {
+      if (global_nnz <= Int_MAX-t_nnz) {
         // let's just hope it is enough, if overflow
-        global_nnz = temp;
+        global_nnz += t_nnz;
       }
       if(Options.verbose == BASKER_TRUE)
       {
@@ -2273,13 +2271,13 @@ printf( " col_count:: view \n" );
   {
     if(option == 0)
     {
+      const Int Int_MAX = std::numeric_limits<Int>::max();
+
       Int t_nnz = 0; 
-      Int temp = 0;
       for(Int i = 0; i < M.ncol; i++)
       {
-        temp = t_nnz + ST.U_col_counts[i];
-        if (temp > t_nnz) {
-          t_nnz = temp;
+        if (t_nnz <= Int_MAX-ST.U_col_counts[i]) {
+          t_nnz += ST.U_col_counts[i];
         } else {
           // let's just hope it is enough, if overflow
           break;
@@ -2291,16 +2289,15 @@ printf( " col_count:: view \n" );
       #endif
 
       //double fill_factor = 1.05;
-      temp = fill_factor*t_nnz;
+      Int temp = fill_factor*t_nnz;
       if (temp >= t_nnz) {
         M.nnz = temp;
       } else {
         M.nnz = t_nnz;
       }
-      temp = global_nnz + t_nnz;
-      if (temp > global_nnz) {
+      if (global_nnz <= Int_MAX-t_nnz) {
         // let's just hope it is enough, if overflow
-        global_nnz = temp;
+        global_nnz += t_nnz;
       }
       #if 0
       printf( " debug: set U.nnz = 0 to force realloc\n" );
@@ -2328,14 +2325,13 @@ printf( " col_count:: view \n" );
   {
     if(option == 0)
     {
-      Int t_nnz = 0; 
-      Int temp = 0;
+      const Int Int_MAX = std::numeric_limits<Int>::max();
 
+      Int t_nnz = 0; 
       for(Int i = 0; i < M.nrow; i++)
       {
-        temp = t_nnz + ST.L_row_counts[i];
-        if (temp > t_nnz) {
-          t_nnz = temp;
+        if (t_nnz <= Int_MAX-ST.L_row_counts[i]) {
+          t_nnz += ST.L_row_counts[i];
         } else {
           // let's just hope it is enough, if overflow
           break;
@@ -2348,7 +2344,7 @@ printf( " col_count:: view \n" );
 
       // double fill_factor = 2.05;
       double old_nnz = M.nnz;
-      temp = fill_factor*t_nnz;
+      Int temp = fill_factor*t_nnz;
       if (temp >= t_nnz) {
         M.nnz = temp;
       } else {
@@ -2359,10 +2355,9 @@ printf( " col_count:: view \n" );
       M.nnz = 0;
       t_nnz = 0;
       #endif
-      temp = global_nnz + t_nnz;
-      if (temp > global_nnz) {
+      if (global_nnz <= Int_MAX-t_nnz) {
         // let's just hope it is enough, if overflow
-        global_nnz = temp;
+        global_nnz += t_nnz;
       }
       if(Options.verbose == BASKER_TRUE)
       {
@@ -2389,17 +2384,16 @@ printf( " col_count:: view \n" );
       printf("S_assign_nnz: %ld  \n", M.nnz);
       #endif
 
-      Int temp = global_nnz + M.nnz;
-      if (temp > global_nnz) {
+      const Int Int_MAX = std::numeric_limits<Int>::max();
+      if (global_nnz <= Int_MAX-M.nnz) {
         // let's just hope it is enough, if overflow
-        global_nnz = temp;
+        global_nnz += M.nnz;
       }
       if(Options.verbose == BASKER_TRUE)
       {
         printf("S_assign elbow global_nnz = %ld, M.nnz = %ld + 2\n", (long)global_nnz, (long)M.nnz);
       }
-      temp = M.nnz + 2;
-      if (temp > M.nnz) {
+      if (M.nnz <= Int_MAX - 2) {
         M.nnz += 2;
       }
     }

--- a/packages/shylu/shylu_node/basker/src/shylubasker_structs.hpp
+++ b/packages/shylu/shylu_node/basker/src/shylubasker_structs.hpp
@@ -765,6 +765,9 @@ namespace BaskerNS
       btf_matching = 2;
       min_block_size = 0; // no merging blocks
 
+      // Matrix scaling
+      matrix_scaling = 0;
+
       //BTF Ordering Options
       btf             = BASKER_TRUE;
       btf_max_percent = BASKER_BTF_MAX_PERCENT;
@@ -790,7 +793,8 @@ namespace BaskerNS
 
       //Prune (if not pruned, check for numerical cancelatin)
       prune = BASKER_FALSE;
-      replace_tiny_pivot = BASKER_TRUE;
+      replace_zero_pivot = BASKER_TRUE;
+      replace_tiny_pivot = BASKER_FALSE;
 
       //BTF Options
       btf_prune_size = (Int)BASKER_BTF_PRUNE_SIZE;
@@ -836,8 +840,11 @@ namespace BaskerNS
     int btf_matching; // carbinality matching before BTF (Symbolic):                0 = none, 1 = Basker, or 2 = Trilinos (default) (3 = MC64 if enable)
     int blk_matching; // max weight matching on each of diagonal blocks (Numeric):  0 = none (default), or 1 = Basker (2 = MC64 if enable)
     Int min_block_size; // min size of blocks
+    // matrix scaling
+    int matrix_scaling; // 0 = no scaling, 1 = symmetric diagonal scaling, 2 = non-symm row-max, and then col-max scaling
 
     // Replace tiny pivott
+    BASKER_BOOL replace_zero_pivot;
     BASKER_BOOL replace_tiny_pivot;
 
     // Option to apply MWM at numeric through "delayed" pivot

--- a/packages/shylu/shylu_node/basker/src/shylubasker_tree.hpp
+++ b/packages/shylu/shylu_node/basker/src/shylubasker_tree.hpp
@@ -29,7 +29,7 @@ namespace BaskerNS
 
     //Copy into our tree_struct
     part_tree.basic_convert(A.nrow, perm, nblks, parts,
-			    row_tabs, col_tabs, treetab);
+                            row_tabs, col_tabs, treetab);
 
     int result = 0;
     if(options == 0) //default case (based on threads)
@@ -143,7 +143,7 @@ namespace BaskerNS
     
     #ifdef BASKER_DEBUG_TREE
     printf("Start, nparts: %d nblks: %d \n",
-	   parts, nblks);
+           parts, nblks);
     #endif
 
 
@@ -152,21 +152,21 @@ namespace BaskerNS
     #ifdef BASKER_DEBUG_TREE
     printf("nblks: %d parts: %d \n", nblks, parts);
     printf("log: %f %f %f \n", 
-	   log(nblks+1), log(parts), log(num_threads));
+           log(nblks+1), log(parts), log(num_threads));
     #endif
 
     Int maxlvls = round(
-			log((double)num_threads)/
-			log((double)parts));
+                        log((double)num_threads)/
+                        log((double)parts));
 
     Int treelvls = round(
-			 log((double)(nblks+1))/
-			 log((double)parts)) - 1;
+                         log((double)(nblks+1))/
+                         log((double)parts)) - 1;
 
 
     //Int treelvls = ((((double)log(nblks+1))/((double)log(parts))) - 1.0);
     //Int treelvls = (((double)log((double)(nblks+1)))/
-    //		    ((double)log((double)parts))) ;
+    //                    ((double)log((double)parts))) ;
     //Int treelvls = crazy_temp -1;
 
     //Number of blocks now is parts^lvl+1 - 1
@@ -174,7 +174,7 @@ namespace BaskerNS
     
     #ifdef BASKER_DEBUG_TREE
     printf("maxlvl: %d treelvl: %d newnblks: %d \n",
-	   maxlvls, treelvls, newnblks);
+           maxlvls, treelvls, newnblks);
     #endif
 
     if(newnblks < nblks)
@@ -209,7 +209,7 @@ namespace BaskerNS
     init_value(temp_row_tabs, tree.nblks+1, (Int)0);
     
     rec_tabs(0, tree.nlvls, treelvls, tree.nblks, old_pos,
-	     &new_pos, col_tabs, row_tabs, treetab,
+             &new_pos, col_tabs, row_tabs, treetab,
        temp_col_tabs, temp_row_tabs, temp_tree);
 
     for(Int i=0; i < tree.nblks+1; i++)
@@ -661,9 +661,9 @@ namespace BaskerNS
     //Set Values
     #ifdef BASKER_DEBUG_TREE
     printf("Rec Tabs, new_pos: %d old_pos %d\n", 
-    	   *new_pos, old_pos);
+               *new_pos, old_pos);
     printf("Rec Tabs, oldc: %d oldr: %d mynum %d \n",
-    	   old_col[old_pos], old_row[old_pos], mynum);
+               old_col[old_pos], old_row[old_pos], mynum);
     #endif
 
     new_col[*new_pos]  = old_col[old_pos];
@@ -844,25 +844,11 @@ namespace BaskerNS
       #endif
       for(Int j=i; j != -flat.ncol; j=tree.treetab[j])
       {
-        //MATRIX_VIEW_1DARRAY &Utemp = AV[j];
-        //MATRIX_VIEW_1DARRAY &Ltemp = AL[i];
-
         MATRIX_1DARRAY &UMtemp = AVM[j];
         MATRIX_1DARRAY &LMtemp = ALM[i];
 
         MATRIX_1DARRAY &LUtemp = LU[j];
         MATRIX_1DARRAY &LLtemp = LL[i];
-
-        //Init AU
-        #ifdef MY_DEBUG
-        printf( " AV (%d)(%d).set_shape(%dx%d)\n",j,U_view_count[j], tree.col_tabs[i+1]-tree.col_tabs[i],tree.col_tabs[j+1]-tree.col_tabs[j] );
-        #endif
-        /*Utemp[U_view_count[j]].init(&(flat), 
-            tree.col_tabs[i], 
-            (tree.col_tabs[i+1]-tree.col_tabs[i]),
-            tree.col_tabs[j], 
-            (tree.col_tabs[j+1]-tree.col_tabs[j])
-            );*/
 
         #ifdef MY_DEBUG
         printf( " AVM(%d)(%d).set_shape(%dx%d)\n",j,U_view_count[j], tree.col_tabs[i+1]-tree.col_tabs[i],tree.col_tabs[j+1]-tree.col_tabs[j] );
@@ -886,20 +872,9 @@ namespace BaskerNS
             (tree.col_tabs[i+1]-tree.col_tabs[i]),
             tree.col_tabs[j], 
             (tree.col_tabs[j+1]-tree.col_tabs[j])
-            );	
+            );        
 
         U_view_count[j] = U_view_count[j]+1;
-
-        //Init AL
-        #ifdef MY_DEBUG
-        printf( " AL (%d)(%d).set_shape(%dx%d)\n",i,L_view_count[i], tree.col_tabs[j+1]-tree.col_tabs[j],tree.col_tabs[i+1]-tree.col_tabs[i] );
-        #endif
-        /*Ltemp[L_view_count[i]].init(&(flat),
-            tree.col_tabs[j],
-            (tree.col_tabs[j+1]-tree.col_tabs[j]),
-            tree.col_tabs[i],
-            (tree.col_tabs[i+1] - tree.col_tabs[i])
-            );*/
 
         #ifdef MY_DEBUG
         printf( " ALM(%d)(%d).set_shape(%dx%d)\n",i,L_view_count[i], tree.col_tabs[j+1]-tree.col_tabs[j],tree.col_tabs[i+1]-tree.col_tabs[i] );
@@ -1160,7 +1135,7 @@ namespace BaskerNS
           }
         }
         start_col = BASKER_FALSE;
-      }//over each row	
+      }//over each row        
     }//over each colunm
 
   }//end find_2d_convert()
@@ -1285,7 +1260,7 @@ namespace BaskerNS
 
       if(btf_tabs_offset != 0)
       {
-        permute_col(BTF_B, order_c_csym_array);	
+        permute_col(BTF_B, order_c_csym_array);        
         sort_matrix(BTF_B);
       }
     }

--- a/packages/shylu/shylu_node/basker/src/shylubasker_tree.hpp
+++ b/packages/shylu/shylu_node/basker/src/shylubasker_tree.hpp
@@ -741,6 +741,10 @@ namespace BaskerNS
   }//end update_lpinv_tree
 
 
+  // ALM : strictly-lower triangular blocks (no diagonal blocks)
+  //  LL : -> L-factor
+  // AVM :          upper triangular blocks (with diagonal blocks)
+  //  LU : -> U-factor
   template <class Int, class Entry, class Exe_Space>
   BASKER_INLINE
   void Basker<Int,Entry, Exe_Space>::matrix_to_views_2D
@@ -797,14 +801,9 @@ namespace BaskerNS
 
     //Malloc  AU and AL views, and needed space
     BASKER_ASSERT(nblks > 0, "tree nblks 99");
-    MALLOC_MATRIX_VIEW_2DARRAY(AV, nblks);
-    MALLOC_MATRIX_VIEW_2DARRAY(AL, nblks);
-
     //Malloc AU and AL, matrix
     MALLOC_MATRIX_2DARRAY(AVM, nblks);
     MALLOC_MATRIX_2DARRAY(ALM, nblks);
-    
-
     //Malloc LU and LL matrix ARRAYs
     MALLOC_MATRIX_2DARRAY(LU, nblks);
     MALLOC_MATRIX_2DARRAY(LL, nblks);
@@ -817,8 +816,6 @@ namespace BaskerNS
       Int U_view_size = (U_view_count(i) > 0 ? U_view_count(i) : 1);
       if (U_view_size > 0)
       {
-        //BASKER_ASSERT(U_view_count(i)>0, "tree uvc");
-        MALLOC_MATRIX_VIEW_1DARRAY(AV(i), U_view_size);
         MALLOC_MATRIX_1DARRAY(AVM(i),     U_view_size);
         MALLOC_MATRIX_1DARRAY(LU(i),      U_view_size);
       }
@@ -827,8 +824,6 @@ namespace BaskerNS
       Int L_view_size = (L_view_count(i) > 0 ? L_view_count(i): 1);
       if (L_view_size > 0) 
       {
-        //BASKER_ASSERT(L_view_count(i)>0, "tree lvc");
-        MALLOC_MATRIX_VIEW_1DARRAY(AL(i), L_view_size);
         MALLOC_MATRIX_1DARRAY(ALM(i),     L_view_size);
         MALLOC_MATRIX_1DARRAY(LL(i),      L_view_size);
       }
@@ -849,8 +844,8 @@ namespace BaskerNS
       #endif
       for(Int j=i; j != -flat.ncol; j=tree.treetab[j])
       {
-        MATRIX_VIEW_1DARRAY &Utemp = AV[j];
-        MATRIX_VIEW_1DARRAY &Ltemp = AL[i];
+        //MATRIX_VIEW_1DARRAY &Utemp = AV[j];
+        //MATRIX_VIEW_1DARRAY &Ltemp = AL[i];
 
         MATRIX_1DARRAY &UMtemp = AVM[j];
         MATRIX_1DARRAY &LMtemp = ALM[i];
@@ -860,14 +855,14 @@ namespace BaskerNS
 
         //Init AU
         #ifdef MY_DEBUG
-        printf( " AV(%d)(%d).set_shape(%dx%d)\n",j,U_view_count[j], tree.col_tabs[i+1]-tree.col_tabs[i],tree.col_tabs[j+1]-tree.col_tabs[j] );
+        printf( " AV (%d)(%d).set_shape(%dx%d)\n",j,U_view_count[j], tree.col_tabs[i+1]-tree.col_tabs[i],tree.col_tabs[j+1]-tree.col_tabs[j] );
         #endif
-        Utemp[U_view_count[j]].init(&(flat), 
+        /*Utemp[U_view_count[j]].init(&(flat), 
             tree.col_tabs[i], 
             (tree.col_tabs[i+1]-tree.col_tabs[i]),
             tree.col_tabs[j], 
             (tree.col_tabs[j+1]-tree.col_tabs[j])
-            );
+            );*/
 
         #ifdef MY_DEBUG
         printf( " AVM(%d)(%d).set_shape(%dx%d)\n",j,U_view_count[j], tree.col_tabs[i+1]-tree.col_tabs[i],tree.col_tabs[j+1]-tree.col_tabs[j] );
@@ -883,6 +878,9 @@ namespace BaskerNS
         }
 
         //Int LU
+        #ifdef MY_DEBUG
+        printf( " LU (%d)(%d).set_shape(%dx%d)\n",j,U_view_count[j], tree.col_tabs[i+1]-tree.col_tabs[i],tree.col_tabs[j+1]-tree.col_tabs[j] );
+        #endif
         LUtemp[U_view_count[j]].set_shape(
             tree.col_tabs[i], 
             (tree.col_tabs[i+1]-tree.col_tabs[i]),
@@ -893,12 +891,15 @@ namespace BaskerNS
         U_view_count[j] = U_view_count[j]+1;
 
         //Init AL
-        Ltemp[L_view_count[i]].init(&(flat),
+        #ifdef MY_DEBUG
+        printf( " AL (%d)(%d).set_shape(%dx%d)\n",i,L_view_count[i], tree.col_tabs[j+1]-tree.col_tabs[j],tree.col_tabs[i+1]-tree.col_tabs[i] );
+        #endif
+        /*Ltemp[L_view_count[i]].init(&(flat),
             tree.col_tabs[j],
             (tree.col_tabs[j+1]-tree.col_tabs[j]),
             tree.col_tabs[i],
             (tree.col_tabs[i+1] - tree.col_tabs[i])
-            );
+            );*/
 
         #ifdef MY_DEBUG
         printf( " ALM(%d)(%d).set_shape(%dx%d)\n",i,L_view_count[i], tree.col_tabs[j+1]-tree.col_tabs[j],tree.col_tabs[i+1]-tree.col_tabs[i] );
@@ -914,15 +915,15 @@ namespace BaskerNS
         }
 
         //Init LL
+        #ifdef MY_DEBUG
+        printf( " LL (%d)(%d).set_shape(%dx%d)\n",i,L_view_count[i], tree.col_tabs[j+1]-tree.col_tabs[j],tree.col_tabs[i+1]-tree.col_tabs[i] );
+        #endif
         LLtemp[L_view_count[i]].set_shape(
             tree.col_tabs[j],
             (tree.col_tabs[j+1]-tree.col_tabs[j]),
             tree.col_tabs[i],
             (tree.col_tabs[i+1] - tree.col_tabs[i])
             );
-        #ifdef MY_DEBUG
-        printf( " LL(%d)(%d).set_shape(%dx%d)\n",i,L_view_count[i], tree.col_tabs[j+1]-tree.col_tabs[j],tree.col_tabs[i+1]-tree.col_tabs[i] );
-        #endif
 
         L_view_count[i] = L_view_count[i]+1;
 
@@ -1028,12 +1029,7 @@ namespace BaskerNS
     printf( "\n >> find_2D_convert (%d x %d) <<\n\n",M.nrow,M.ncol );
     for (Int k = 0; k <= tree.nblks; k++) printf( "  row_tabs[%d] = %d\n",k,tree.row_tabs(k));
     for (Int k = 0; k <  tree.nblks; k++) printf( "   LU_size[%d] = %d\n",k,LU_size(k));
-    printf( "M = [\n" );
-    for(Int k = 0; k < M.ncol; ++k) {
-      for(Int i = M.col_ptr(k); i < M.col_ptr(k+1); i++)
-        printf( " %d %d %e\n", M.row_idx(i),k, M.val(i) );
-    }
-    printf("];\n");
+    M.print_matrix("M.dat");
     #endif
     for(Int k = 0; k < M.ncol; ++k)
     {

--- a/packages/shylu/shylu_node/basker/src/shylubasker_util.hpp
+++ b/packages/shylu/shylu_node/basker/src/shylubasker_util.hpp
@@ -595,6 +595,8 @@ namespace BaskerNS
   }//end t_init_factor()
 
 
+  // ALM : strictly-lower triangular blocks (no diagonal blocks)
+  // AVM :          upper triangular blocks (with diagonal blocks)
   template <class Int, class Entry, class Exe_Space>
   BASKER_INLINE
   void Basker<Int, Entry, Exe_Space>::t_init_2DA
@@ -603,22 +605,11 @@ namespace BaskerNS
   )
   {
     /*if (kid == 1) {
-      printf(" BTF_A_2D = [\n" );
-      for(Int j = 0; j < BTF_A.ncol; j++) {
-        for(Int k = BTF_A.col_ptr[j]; k < BTF_A.col_ptr[j+1]; k++) {
-          printf("%d %d %e\n", BTF_A.row_idx[k], j, BTF_A.val[k]);
-        }
-      }
-      printf("];\n");
-      printf(" A_2D = [\n" );
-      for(Int j = 0; j < A.ncol; j++) {
-        for(Int k = A.col_ptr[j]; k < A.col_ptr[j+1]; k++) {
-          printf("%d %d %e\n", A.row_idx[k], j, A.val[k]);
-        }
-      }
-      printf("];\n");
+      BTF_A.print_matrix("BTF_A_2D.dat");
+          A.print_matrix(    "A_2D.dat");
     }*/
-    // extract strictly Lower blockks into ALM
+    //if (kid == 0) printf( " >> t_init_2DA <<\n" );
+    // extract strictly Lower blocks into ALM
     // (blocks in strictly lower part, diagonal blocks are in AVM)
     for(Int lvl = 0; lvl < tree.nlvls+1; lvl++)
     {
@@ -640,18 +631,12 @@ namespace BaskerNS
             printf(" > kid=%d, lvl=%d: convert2D ALM(%d, %d) with (%dx%d and nnz=%d from %d,%d)\n", kid, lvl, b, row,
                    ALM(b)(row).nrow,ALM(b)(row).ncol, ALM(b)(row).nnz, ALM(b)(row).srow,ALM(b)(row).scol);
             printf("[\n");
-            for(Int j = 0; j < BTF_A.ncol; j++) {
-              for(Int k = BTF_A.col_ptr[j]; k < BTF_A.col_ptr[j+1]; k++) {
-                printf("%d %d %e\n", BTF_A.row_idx[k], j, BTF_A.val[k]);
-              }
-            }
-            printf("];\n");
           }*/
           if(Options.btf == BASKER_FALSE)
           {
             #ifdef BASKER_DEBUG_INIT
-            printf("ALM alloc: b=%d row=%d kid=%d btf=%d\n",
-                    b, row, kid, Options.btf);
+            printf("ALM(%d,%d: %dx%d) alloc with A: kid=%d btf=%d\n",
+                    b, row, ALM(b)(row).nrow, ALM(b)(row).ncol, kid, Options.btf);
             #endif
             ALM(b)(row).convert2D(A, alloc, kid);
           }
@@ -659,8 +644,8 @@ namespace BaskerNS
           {
             //printf("Using BTF AL \n");
             #ifdef BASKER_DEBUG_INIT
-            printf("ALM alloc (btf): b=%d row=%d kid=%d \n",
-                   b, row, kid);
+            printf("ALM(%d,%d, %dx%d) alloc (btf) with BTF_A: kid=%d \n",
+                   b, row, ALM(b)(row).nrow, ALM(b)(row).ncol, kid);
             #endif
             ALM(b)(row).convert2D(BTF_A, alloc, kid);
           }


### PR DESCRIPTION
@trilinos/shylu 

## Motivation

This PR contains options to improve the stability of ShyLU_Basker threaded factorization

- Iterative-refinement in Amesos2
     - gather vectors on rank-0 and performs iterative-refinements (using solver-specific `solve`) 
     - stops when reaching `maxNumIters` or the solution did not change much (the norm of the correction is less than eps*norm(initial computed solution)) 
     - available through parameter `Iterative refinement` but only for solvers inheriting `SolverCore`
- threaded nested-dissection factorization within ShyLU_Basker
     - matrix-scaling, either symmetric diagonal scaling, or non-symmetric row-max and then col-max
     - replace tiny pivots, which are less than tol, with tol, where tol = sqrt(eps) ||A||

