### PR TITLE
Phalanx: Array of Views acceptance test.

### DIFF
--- a/packages/phalanx/src/Phalanx_KokkosViewOfViews.hpp
+++ b/packages/phalanx/src/Phalanx_KokkosViewOfViews.hpp
@@ -302,11 +302,10 @@ namespace PHX {
     template<typename... Extents>
     ViewOfViews3(const std::string name,Extents... extents)
       : view_host_(name,extents...),
-        view_host_unmanaged_(name,extents...),
         view_device_(name,extents...),
         device_view_is_synced_(false),
         is_initialized_(true)
-    {}
+    { view_host_unmanaged_ = Kokkos::create_mirror_view(Kokkos::HostSpace(),view_device_); }
 
     ViewOfViews3()
       : device_view_is_synced_(false),
@@ -326,8 +325,8 @@ namespace PHX {
     void initialize(const std::string name,Extents... extents)
     {
       view_host_ = typename OuterViewType::HostMirror(name,extents...);
-      view_host_unmanaged_ = typename OuterViewType::HostMirror(name,extents...);
       view_device_ = OuterViewType(name,extents...);
+      view_host_unmanaged_ = Kokkos::create_mirror_view(Kokkos::HostSpace(),view_device_);
       device_view_is_synced_ = false;
       is_initialized_ = true;
     }

--- a/packages/phalanx/test/ViewOfViews/tPhalanxViewOfViews.cpp
+++ b/packages/phalanx/test/ViewOfViews/tPhalanxViewOfViews.cpp
@@ -123,6 +123,58 @@ TEUCHOS_UNIT_TEST(PhalanxViewOfViews,NewImpl) {
 
 }
 
+TEUCHOS_UNIT_TEST(PhalanxViewOfViews,ViewOfView3) {
+
+  const int num_cells = 10;
+  const int num_pts = 8;
+  const int num_equations = 32;
+
+  Kokkos::View<double***,mem_t> a("a",num_cells,num_pts,num_equations);
+  Kokkos::View<double***,mem_t> b("b",num_cells,num_pts,num_equations);
+  Kokkos::View<double***,mem_t> c("c",num_cells,num_pts,num_equations);
+  Kokkos::View<double***,mem_t> d("d",num_cells,num_pts,num_equations);
+
+  Kokkos::deep_copy(a,2.0);
+  Kokkos::deep_copy(b,3.0);
+  Kokkos::deep_copy(c,4.0);
+
+  {
+    using InnerView = Kokkos::View<double***,mem_t>;
+    constexpr int OuterViewRank = 2;
+    PHX::ViewOfViews3<OuterViewRank,InnerView,mem_t> v_of_v("outer host",2,2);
+
+    v_of_v.addView(a,0,0);
+    v_of_v.addView(b,0,1);
+    v_of_v.addView(c,1,0);
+    v_of_v.addView(d,1,1);
+
+    v_of_v.syncHostToDevice();
+
+    {
+      auto v_dev = v_of_v.getViewDevice();
+      auto policy = Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0,0,0},{num_cells,num_pts,num_equations});
+      Kokkos::parallel_for("view of view test",policy,KOKKOS_LAMBDA (const int cell,const int pt, const int eq) {
+        v_dev(1,1)(cell,pt,eq) = v_dev(0,0)(cell,pt,eq) + v_dev(0,1)(cell,pt,eq) + v_dev(1,0)(cell,pt,eq);
+      });
+    }
+
+    // Uncomment the line below to prove the ViewOfViews prevents
+    // device views from outliving host view. This line will cause a
+    // Kokkos::abort() and error message since v_dev above is still in
+    // scope when the ViewOfViews is destoryed.
+    // v_of_v = PHX::ViewOfViews<OuterViewRank,InnerView,mem_t>("outer host",2,2);
+  }
+
+  auto d_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),d);
+
+  const auto tol = std::numeric_limits<double>::epsilon() * 100.0;
+  for (int cell=0; cell < num_cells; ++cell)
+    for (int pt=0; pt < num_pts; ++pt)
+      for (int eq=0; eq < num_equations; ++eq) {
+        TEST_FLOATING_EQUALITY(d_host(cell,pt,eq),9.0,tol);
+      }
+}
+
 // ********************************
 // Demonstrates an alternative path for ViewOfViews that uses a user
 // defined wrapper and the assignment operator on device to disable

--- a/packages/phalanx/test/ViewOfViews/tPhalanxViewOfViews.cpp
+++ b/packages/phalanx/test/ViewOfViews/tPhalanxViewOfViews.cpp
@@ -123,7 +123,63 @@ TEUCHOS_UNIT_TEST(PhalanxViewOfViews,NewImpl) {
 
 }
 
-TEUCHOS_UNIT_TEST(PhalanxViewOfViews,ViewOfView3) {
+TEUCHOS_UNIT_TEST(PhalanxViewOfViews,ViewOfView3_EmptyCtor) {
+
+  const int num_cells = 10;
+  const int num_pts = 8;
+  const int num_equations = 32;
+
+  Kokkos::View<double***,mem_t> a("a",num_cells,num_pts,num_equations);
+  Kokkos::View<double***,mem_t> b("b",num_cells,num_pts,num_equations);
+  Kokkos::View<double***,mem_t> c("c",num_cells,num_pts,num_equations);
+  Kokkos::View<double***,mem_t> d("d",num_cells,num_pts,num_equations);
+
+  Kokkos::deep_copy(a,2.0);
+  Kokkos::deep_copy(b,3.0);
+  Kokkos::deep_copy(c,4.0);
+
+  {
+    using InnerView = Kokkos::View<double***,mem_t>;
+    constexpr int OuterViewRank = 2;
+    PHX::ViewOfViews3<OuterViewRank,InnerView,mem_t> v_of_v;
+
+    TEST_ASSERT(!v_of_v.is_initialized());
+    v_of_v.initialize("outer host",2,2);
+    TEST_ASSERT(v_of_v.is_initialized());
+
+    v_of_v.addView(a,0,0);
+    v_of_v.addView(b,0,1);
+    v_of_v.addView(c,1,0);
+    v_of_v.addView(d,1,1);
+
+    v_of_v.syncHostToDevice();
+
+    {
+      auto v_dev = v_of_v.getViewDevice();
+      auto policy = Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0,0,0},{num_cells,num_pts,num_equations});
+      Kokkos::parallel_for("view of view test",policy,KOKKOS_LAMBDA (const int cell,const int pt, const int eq) {
+        v_dev(1,1)(cell,pt,eq) = v_dev(0,0)(cell,pt,eq) + v_dev(0,1)(cell,pt,eq) + v_dev(1,0)(cell,pt,eq);
+      });
+    }
+
+    // Uncomment the line below to prove the ViewOfViews prevents
+    // device views from outliving host view. This line will cause a
+    // Kokkos::abort() and error message since v_dev above is still in
+    // scope when the ViewOfViews is destoryed.
+    // v_of_v = PHX::ViewOfViews<OuterViewRank,InnerView,mem_t>("outer host",2,2);
+  }
+
+  auto d_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),d);
+
+  const auto tol = std::numeric_limits<double>::epsilon() * 100.0;
+  for (int cell=0; cell < num_cells; ++cell)
+    for (int pt=0; pt < num_pts; ++pt)
+      for (int eq=0; eq < num_equations; ++eq) {
+        TEST_FLOATING_EQUALITY(d_host(cell,pt,eq),9.0,tol);
+      }
+}
+
+TEUCHOS_UNIT_TEST(PhalanxViewOfViews,ViewOfView3_TwoArgCtor) {
 
   const int num_cells = 10;
   const int num_pts = 8;
@@ -142,6 +198,8 @@ TEUCHOS_UNIT_TEST(PhalanxViewOfViews,ViewOfView3) {
     using InnerView = Kokkos::View<double***,mem_t>;
     constexpr int OuterViewRank = 2;
     PHX::ViewOfViews3<OuterViewRank,InnerView,mem_t> v_of_v("outer host",2,2);
+
+    TEST_ASSERT(v_of_v.is_initialized());
 
     v_of_v.addView(a,0,0);
     v_of_v.addView(b,0,1);


### PR DESCRIPTION
## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Another use case for v-of-v construction to protect. In this case the outer view is a Kokkos:Array

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
New test added to ViewOfViews tests
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->