### PR TITLE
MueLu LowPrecisionFactory: Fix for other combos of enables Scalar types

### DIFF
--- a/packages/muelu/src/Misc/MueLu_LowPrecisionFactory_decl.hpp
+++ b/packages/muelu/src/Misc/MueLu_LowPrecisionFactory_decl.hpp
@@ -102,6 +102,95 @@ namespace MueLu {
 
   }; //class LowPrecisionFactory
 
+
+#if defined(HAVE_TPETRA_INST_DOUBLE) && defined(HAVE_TPETRA_INST_FLOAT)
+  template <class LocalOrdinal, class GlobalOrdinal, class Node>
+  class LowPrecisionFactory<double,LocalOrdinal,GlobalOrdinal,Node> : public SingleLevelFactoryBase {
+    typedef double Scalar;
+#undef MUELU_LOWPRECISIONFACTORY_SHORT
+#include "MueLu_UseShortNames.hpp"
+
+  public:
+
+    //! @name Constructors/Destructors.
+    //@{
+
+    LowPrecisionFactory() { }
+
+    //! Destructor.
+    virtual ~LowPrecisionFactory() { }
+
+    RCP<const ParameterList> GetValidParameterList() const;
+
+    //@}
+
+    //! Input
+    //@{
+
+    void DeclareInput(Level& currentLevel) const;
+
+    //@}
+
+    //! @name Build methods.
+    //@{
+
+    /*!
+      @brief Build method.
+
+      Converts a matrix to half precision operators and returns it in <tt>currentLevel</tt>.
+      */
+    void Build(Level& currentLevel) const;
+
+    //@}
+
+  }; //class LowPrecisionFactory
+#endif
+
+
+#if defined(HAVE_TPETRA_INST_COMPLEX_DOUBLE) && defined(HAVE_TPETRA_INST_COMPLEX_FLOAT)
+  template <class LocalOrdinal, class GlobalOrdinal, class Node>
+  class LowPrecisionFactory<std::complex<double>,LocalOrdinal,GlobalOrdinal,Node> : public SingleLevelFactoryBase {
+    typedef std::complex<double> Scalar;
+#undef MUELU_LOWPRECISIONFACTORY_SHORT
+#include "MueLu_UseShortNames.hpp"
+
+  public:
+
+    //! @name Constructors/Destructors.
+    //@{
+
+    LowPrecisionFactory() { }
+
+    //! Destructor.
+    virtual ~LowPrecisionFactory() { }
+
+    RCP<const ParameterList> GetValidParameterList() const;
+
+    //@}
+
+    //! Input
+    //@{
+
+    void DeclareInput(Level& currentLevel) const;
+
+    //@}
+
+    //! @name Build methods.
+    //@{
+
+    /*!
+      @brief Build method.
+
+      Converts a matrix to half precision operators and returns it in <tt>currentLevel</tt>.
+      */
+    void Build(Level& currentLevel) const;
+
+    //@}
+
+  }; //class LowPrecisionFactory
+#endif
+
+
 } //namespace MueLu
 
 #define MUELU_LOWPRECISIONFACTORY_SHORT

--- a/packages/muelu/src/Misc/MueLu_LowPrecisionFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_LowPrecisionFactory_def.hpp
@@ -84,6 +84,43 @@ namespace MueLu {
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void LowPrecisionFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(Level& currentLevel) const {
     using Teuchos::ParameterList;
+
+    const ParameterList& pL = GetParameterList();
+    std::string matrixKey = pL.get<std::string>("matrix key");
+
+    FactoryMonitor m(*this, "Converting " + matrixKey + " to half precision", currentLevel);
+
+    RCP<Matrix> A = Get< RCP<Matrix> >(currentLevel, matrixKey);
+
+    GetOStream(Warnings) << "Matrix not converted to half precision. This only works for Tpetra and when both Scalar and HalfScalar have been instantiated." << std::endl;
+    Set(currentLevel, matrixKey, A);
+  }
+
+
+#if defined(HAVE_TPETRA_INST_DOUBLE) && defined(HAVE_TPETRA_INST_FLOAT)
+  template <class LocalOrdinal, class GlobalOrdinal, class Node>
+  RCP<const ParameterList> LowPrecisionFactory<double, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+    RCP<ParameterList> validParamList = rcp(new ParameterList());
+
+    validParamList->set<std::string>("matrix key", "A", "");
+    validParamList->set< RCP<const FactoryBase> >("R", Teuchos::null, "Generating factory of the matrix A to be converted to lower precision");
+    validParamList->set< RCP<const FactoryBase> >("A", Teuchos::null, "Generating factory of the matrix A to be converted to lower precision");
+    validParamList->set< RCP<const FactoryBase> >("P", Teuchos::null, "Generating factory of the matrix A to be converted to lower precision");
+
+    return validParamList;
+  }
+
+  template <class LocalOrdinal, class GlobalOrdinal, class Node>
+  void LowPrecisionFactory<double, LocalOrdinal, GlobalOrdinal, Node>::DeclareInput(Level& currentLevel) const {
+
+    const ParameterList& pL = GetParameterList();
+    std::string matrixKey = pL.get<std::string>("matrix key");
+    Input(currentLevel, matrixKey);
+  }
+
+  template <class LocalOrdinal, class GlobalOrdinal, class Node>
+  void LowPrecisionFactory<double, LocalOrdinal, GlobalOrdinal, Node>::Build(Level& currentLevel) const {
+    using Teuchos::ParameterList;
     using HalfScalar = typename Teuchos::ScalarTraits<Scalar>::halfPrecision;
 
     const ParameterList& pL = GetParameterList();
@@ -93,7 +130,6 @@ namespace MueLu {
 
     RCP<Matrix> A = Get< RCP<Matrix> >(currentLevel, matrixKey);
 
-#if defined(HAVE_TPETRA_INST_DOUBLE) && defined(HAVE_TPETRA_INST_FLOAT)
     if ((A->getRowMap()->lib() == Xpetra::UseTpetra) && std::is_same<Scalar, double>::value) {
       auto tpA = rcp_dynamic_cast<TpetraCrsMatrix>(rcp_dynamic_cast<CrsMatrixWrap>(A)->getCrsMatrix(), true)->getTpetra_CrsMatrix();
       auto tpLowA = tpA->template convert<HalfScalar>();
@@ -103,9 +139,47 @@ namespace MueLu {
       Set(currentLevel, matrixKey, xpLowOpA);
       return;
     }
+
+    GetOStream(Warnings) << "Matrix not converted to half precision. This only works for Tpetra and when both Scalar and HalfScalar have been instantiated." << std::endl;
+    Set(currentLevel, matrixKey, A);
+  }
 #endif
-#if defined(HAVE_TPETRA_INST_DOUBLE) && defined(HAVE_TPETRA_INST_FLOAT)
-    if ((A->getRowMap()->lib() == Xpetra::UseTpetra) && std::is_same<Scalar, std::complex<double>>::value) {
+
+
+#if defined(HAVE_TPETRA_INST_COMPLEX_DOUBLE) && defined(HAVE_TPETRA_INST_COMPLEX_FLOAT)
+  template <class LocalOrdinal, class GlobalOrdinal, class Node>
+  RCP<const ParameterList> LowPrecisionFactory<std::complex<double>, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+    RCP<ParameterList> validParamList = rcp(new ParameterList());
+
+    validParamList->set<std::string>("matrix key", "A", "");
+    validParamList->set< RCP<const FactoryBase> >("R", Teuchos::null, "Generating factory of the matrix A to be converted to lower precision");
+    validParamList->set< RCP<const FactoryBase> >("A", Teuchos::null, "Generating factory of the matrix A to be converted to lower precision");
+    validParamList->set< RCP<const FactoryBase> >("P", Teuchos::null, "Generating factory of the matrix A to be converted to lower precision");
+
+    return validParamList;
+  }
+
+  template <class LocalOrdinal, class GlobalOrdinal, class Node>
+  void LowPrecisionFactory<std::complex<double>, LocalOrdinal, GlobalOrdinal, Node>::DeclareInput(Level& currentLevel) const {
+
+    const ParameterList& pL = GetParameterList();
+    std::string matrixKey = pL.get<std::string>("matrix key");
+    Input(currentLevel, matrixKey);
+  }
+
+  template <class LocalOrdinal, class GlobalOrdinal, class Node>
+  void LowPrecisionFactory<std::complex<double>, LocalOrdinal, GlobalOrdinal, Node>::Build(Level& currentLevel) const {
+    using Teuchos::ParameterList;
+    using HalfScalar = typename Teuchos::ScalarTraits<Scalar>::halfPrecision;
+
+    const ParameterList& pL = GetParameterList();
+    std::string matrixKey = pL.get<std::string>("matrix key");
+
+    FactoryMonitor m(*this, "Converting " + matrixKey + " to half precision", currentLevel);
+
+    RCP<Matrix> A = Get< RCP<Matrix> >(currentLevel, matrixKey);
+
+    if ((A->getRowMap()->lib() == Xpetra::UseTpetra) && std::is_same<Scalar, std::complex<double> >::value) {
       auto tpA = rcp_dynamic_cast<TpetraCrsMatrix>(rcp_dynamic_cast<CrsMatrixWrap>(A)->getCrsMatrix(), true)->getTpetra_CrsMatrix();
       auto tpLowA = tpA->template convert<HalfScalar>();
       auto tpLowOpA = rcp(new Tpetra::CrsMatrixMultiplyOp<Scalar,HalfScalar,LocalOrdinal,GlobalOrdinal,Node>(tpLowA));
@@ -114,11 +188,11 @@ namespace MueLu {
       Set(currentLevel, matrixKey, xpLowOpA);
       return;
     }
-#endif
 
     GetOStream(Warnings) << "Matrix not converted to half precision. This only works for Tpetra and when both Scalar and HalfScalar have been instantiated." << std::endl;
     Set(currentLevel, matrixKey, A);
   }
+#endif
 
 } //namespace MueLu
 


### PR DESCRIPTION
Enabling double, float and complex<double>, but not complex<float> resulted in linking issues.