### PR TITLE
FROSch: Propagate changes for Scalar!=double to FROSch

### DIFF
--- a/packages/shylu/shylu_dd/frosch/src/Adapters/Stratimikos_FROSch_decl.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/Adapters/Stratimikos_FROSch_decl.hpp
@@ -45,7 +45,7 @@
 #include <ShyLU_DDFROSch_config.h>
 
 #ifdef HAVE_SHYLU_DDFROSCH_STRATIMIKOS
-#include "Stratimikos_DefaultLinearSolverBuilder.hpp"
+#include "Stratimikos_LinearSolverBuilder.hpp"
 
 #include "Teuchos_RCP.hpp"
 #include "Teuchos_ParameterList.hpp"
@@ -68,10 +68,17 @@ namespace Stratimikos {
     using namespace Teuchos;
     using namespace Thyra;
 
-    template <typename LO = int,
+    template <typename LO,
+              typename GO,
+              typename NO>
+    void enableFROSch(LinearSolverBuilder<double>& builder,
+                      const string& stratName = "FROSch");
+
+    template <typename SC = double,
+              typename LO = int,
               typename GO = int,
               typename NO = KokkosClassic::DefaultNode::DefaultNodeType>
-    void enableFROSch(DefaultLinearSolverBuilder& builder,
+    void enableFROSch(LinearSolverBuilder<SC>& builder,
                       const string& stratName = "FROSch");
 } // namespace Stratimikos
 

--- a/packages/shylu/shylu_dd/frosch/src/Adapters/Stratimikos_FROSch_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/Adapters/Stratimikos_FROSch_def.hpp
@@ -49,25 +49,41 @@
 
 namespace Stratimikos {
 
-    using namespace std;
-    using namespace Teuchos;
-    using namespace Thyra;
+  using namespace std;
+  using namespace Teuchos;
+  using namespace Thyra;
 
-    template <typename LO,typename GO,typename NO>
-    void enableFROSch (DefaultLinearSolverBuilder& builder,
-                       const string& stratName)
-    {
-        const RCP<const ParameterList> precValidParams = sublist(builder.getValidParameters(), "Preconditioner Types");
+  template <typename LO,typename GO,typename NO>
+  void enableFROSch (LinearSolverBuilder<double>& builder,
+                     const string& stratName)
+  {
+    const RCP<const ParameterList> precValidParams = sublist(builder.getValidParameters(), "Preconditioner Types");
 
-        TEUCHOS_TEST_FOR_EXCEPTION(precValidParams->isParameter(stratName), logic_error,
-                                   "Stratimikos::enableFROSch cannot add \"" + stratName +"\" because it is already included in builder!");
+    TEUCHOS_TEST_FOR_EXCEPTION(precValidParams->isParameter(stratName), logic_error,
+                               "Stratimikos::enableFROSch cannot add \"" + stratName +"\" because it is already included in builder!");
 
-        using Base = PreconditionerFactoryBase<double>;
-        if (!stratName.compare("FROSch")) {
-            using Impl = FROSchFactory<double, LO, GO, NO>;
-            builder.setPreconditioningStrategyFactory(abstractFactoryStd<Base, Impl>(), stratName);
-        }
+    using Base = PreconditionerFactoryBase<double>;
+    if (!stratName.compare("FROSch")) {
+      using Impl = FROSchFactory<double, LO, GO, NO>;
+      builder.setPreconditioningStrategyFactory(abstractFactoryStd<Base, Impl>(), stratName);
     }
+  }
+
+  template <typename SC, typename LO,typename GO,typename NO>
+  void enableFROSch (LinearSolverBuilder<SC>& builder,
+                     const string& stratName)
+  {
+    const RCP<const ParameterList> precValidParams = sublist(builder.getValidParameters(), "Preconditioner Types");
+
+    TEUCHOS_TEST_FOR_EXCEPTION(precValidParams->isParameter(stratName), logic_error,
+                               "Stratimikos::enableFROSch cannot add \"" + stratName +"\" because it is already included in builder!");
+
+    using Base = PreconditionerFactoryBase<SC>;
+    if (!stratName.compare("FROSch")) {
+      using Impl = FROSchFactory<SC, LO, GO, NO>;
+      builder.setPreconditioningStrategyFactory(abstractFactoryStd<Base, Impl>(), stratName);
+    }
+  }
 
 } // namespace Stratimikos
 

--- a/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_CoarseOperator_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_CoarseOperator_def.hpp
@@ -901,6 +901,7 @@ namespace FROSch {
         GO global,sum,numRanks;
         LO local,minVal,maxVal;
         SC avg;
+        const SC ZERO = Teuchos::ScalarTraits<SC>::zero();
 
         global = coarseMapUnique->getMaxAllGlobalIndex();
         if (coarseMapUnique->lib()==UseEpetra || coarseMapUnique->getGlobalNumElements()>0) {
@@ -909,7 +910,7 @@ namespace FROSch {
 
         local = (LO) max((LO) coarseMapUnique->getLocalNumElements(),(LO) 0);
         reduceAll(*this->MpiComm_,REDUCE_SUM,GO(local),ptr(&sum));
-        avg = max(sum/SC(this->MpiComm_->getSize()),0.0);
+        avg = max(sum/SC(this->MpiComm_->getSize()),ZERO);
         reduceAll(*this->MpiComm_,REDUCE_MIN,local,ptr(&minVal));
         reduceAll(*this->MpiComm_,REDUCE_MAX,local,ptr(&maxVal));
 
@@ -954,7 +955,7 @@ namespace FROSch {
             local = (LO) max((LO) GatheringMaps_[i]->getLocalNumElements(),(LO) 0);
             reduceAll(*this->MpiComm_,REDUCE_SUM,GO(local),ptr(&sum));
             reduceAll(*this->MpiComm_,REDUCE_SUM,GO(GatheringMaps_[i]->getLocalNumElements()>0),ptr(&numRanks));
-            avg = max(sum/SC(numRanks),0.0);
+            avg = max(sum/SC(numRanks),ZERO);
             reduceAll(*this->MpiComm_,REDUCE_MIN,(GatheringMaps_[i]->getLocalNumElements()>0 ? local : numeric_limits<LO>::max()),ptr(&minVal));
             reduceAll(*this->MpiComm_,REDUCE_MAX,local,ptr(&maxVal));
 

--- a/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_OverlappingOperator_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_OverlappingOperator_def.hpp
@@ -96,7 +96,7 @@ namespace FROSch {
         }
         // AH 11/28/2018: replaceMap does not update the GlobalNumRows. Therefore, we have to create a new MultiVector on the serial Communicator. In Epetra, we can prevent to copy the MultiVector.
         if (XTmp_->getMap()->lib() == UseEpetra) {
-#ifdef HAVE_XPETRA_EPETRA
+#ifdef HAVE_SHYLU_DDFROSCH_EPETRA
             if (XOverlapTmp_.is_null()) XOverlapTmp_ = MultiVectorFactory<SC,LO,GO,NO>::Build(OverlappingMap_,x.getNumVectors());
             XOverlapTmp_->doImport(*XTmp_,*Scatter_,INSERT);
             const RCP<const EpetraMultiVectorT<GO,NO> > xEpetraMultiVectorXOverlapTmp = rcp_dynamic_cast<const EpetraMultiVectorT<GO,NO> >(XOverlapTmp_);

--- a/packages/shylu/shylu_dd/frosch/src/SolverInterfaces/FROSch_ThyraPreconditioner_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SolverInterfaces/FROSch_ThyraPreconditioner_def.hpp
@@ -119,8 +119,8 @@ namespace FROSch {
         const CrsMatrixWrap<SC,LO,GO,NO>& crsOp = dynamic_cast<const CrsMatrixWrap<SC,LO,GO,NO>&>(*this->K_);
         RCP<const Thyra::LinearOpBase<SC> > thyraOp = ThyraUtils<SC,LO,GO,NO>::toThyra(crsOp.getCrsMatrix());
 
-        DefaultLinearSolverBuilder linearSolverBuilder;
-        enableFROSch<LO,GO,NO>(linearSolverBuilder);
+        LinearSolverBuilder<SC> linearSolverBuilder;
+        enableFROSch<SC,LO,GO,NO>(linearSolverBuilder);
         linearSolverBuilder.setParameterList(sublist(this->ParameterList_,"ThyraPreconditioner"));
 
         PreconditionerFactoryBasePtr thyraFactory = linearSolverBuilder.createPreconditioningStrategy("");

--- a/packages/shylu/shylu_dd/frosch/src/SolverInterfaces/FROSch_ThyraSolver_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SolverInterfaces/FROSch_ThyraSolver_def.hpp
@@ -92,7 +92,7 @@ namespace FROSch {
             default: FROSCH_ASSERT(false,"FROSch::ThyraPreconditionerTpetra: mode unknown.");
         }
 
-        SolveStatus<double> status = solve<double>(*ThyraSolver_,tMode,*xThyra,YT_.ptr());
+        SolveStatus<SC> status = solve<SC>(*ThyraSolver_,tMode,*xThyra,YT_.ptr());
 
         // It seems that we have to convert the Thyra vector back to Xpetra. Is there a cheaper/more elegant way?
         // Same for ThyraPreconditioner
@@ -122,8 +122,8 @@ namespace FROSch {
         const CrsMatrixWrap<SC,LO,GO,NO>& crsOp = dynamic_cast<const CrsMatrixWrap<SC,LO,GO,NO>&>(*this->K_);
         RCP<const Thyra::LinearOpBase<SC> > thyraOp = ThyraUtils<SC,LO,GO,NO>::toThyra(crsOp.getCrsMatrix());
 
-        DefaultLinearSolverBuilder linearSolverBuilder;
-        enableFROSch<LO,GO,NO>(linearSolverBuilder);
+        LinearSolverBuilder<SC> linearSolverBuilder;
+        enableFROSch<SC,LO,GO,NO>(linearSolverBuilder);
         linearSolverBuilder.setParameterList(sublist(this->ParameterList_,"ThyraSolver"));
 
         LinearOpWithSolveFactoryBasePtr thyraFactory = linearSolverBuilder.createLinearSolveStrategy("");

--- a/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_SubdomainSolver_decl.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_SubdomainSolver_decl.hpp
@@ -80,7 +80,7 @@
 #endif
 
 #ifdef HAVE_SHYLU_DDFROSCH_THYRA
-#include "Stratimikos_DefaultLinearSolverBuilder.hpp"
+#include "Stratimikos_LinearSolverBuilder.hpp"
 #ifdef HAVE_SHYLU_DDFROSCH_IFPACK2
 #include "Teuchos_AbstractFactoryStd.hpp"
 #include "Thyra_Ifpack2PreconditionerFactory.hpp"

--- a/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_SubdomainSolver_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_SubdomainSolver_def.hpp
@@ -196,9 +196,9 @@ namespace FROSch {
             const CrsMatrixWrap<SC,LO,GO,NO>& crsOp = dynamic_cast<const CrsMatrixWrap<SC,LO,GO,NO>&>(*K_);
             RCP<const Thyra::LinearOpBase<SC> > thyraOp = ThyraUtils<SC,LO,GO,NO>::toThyra(crsOp.getCrsMatrix());
 
-            Stratimikos::DefaultLinearSolverBuilder linearSolverBuilder;
+            Stratimikos::LinearSolverBuilder<SC> linearSolverBuilder;
 #ifdef HAVE_SHYLU_DDFROSCH_IFPACK2
-            linearSolverBuilder.setPreconditioningStrategyFactory(abstractFactoryStd<Thyra::PreconditionerFactoryBase<double>,Thyra::Ifpack2PreconditionerFactory<TCrsMatrix> >(),"Ifpack2");
+            linearSolverBuilder.setPreconditioningStrategyFactory(abstractFactoryStd<Thyra::PreconditionerFactoryBase<SC>,Thyra::Ifpack2PreconditionerFactory<TCrsMatrix> >(),"Ifpack2");
 #endif
 
             ParameterListPtr parameterList = sublist(ParameterList_,"Thyra");
@@ -580,7 +580,7 @@ namespace FROSch {
             YTmp_ = rcp(new Xpetra::TpetraMultiVector<SC,LO,GO,NO>(yTmpTpMultVec));
             TEUCHOS_TEST_FOR_EXCEPT(is_null(YTmp_));
 
-            Thyra::SolveStatus<double> status = Thyra::solve<double>(*LOWS_, Thyra::NOTRANS, *thyraX, ThyraYTmp_.ptr());
+            Thyra::SolveStatus<SC> status = Thyra::solve<SC>(*LOWS_, Thyra::NOTRANS, *thyraX, ThyraYTmp_.ptr());
             y = *YTmp_;
 
             /*

--- a/packages/shylu/shylu_dd/frosch/test/Overlap/main.cpp
+++ b/packages/shylu/shylu_dd/frosch/test/Overlap/main.cpp
@@ -361,8 +361,8 @@ int main(int argc, char *argv[])
         }
 
         Comm->barrier(); if (Comm->getRank()==0) cout << "###################################\n# Stratimikos LinearSolverBuilder #\n###################################\n" << endl;
-        Stratimikos::DefaultLinearSolverBuilder linearSolverBuilder;
-        Stratimikos::enableFROSch<LO,GO,NO>(linearSolverBuilder);
+        Stratimikos::LinearSolverBuilder<SC> linearSolverBuilder;
+        Stratimikos::enableFROSch<SC,LO,GO,NO>(linearSolverBuilder);
         linearSolverBuilder.setParameterList(parameterList);
 
         Comm->barrier(); if (Comm->getRank()==0) cout << "######################\n# Thyra PrepForSolve #\n######################\n" << endl;
@@ -379,8 +379,8 @@ int main(int argc, char *argv[])
         linearOpWithSolve(*lowsFactory, K_thyra);
 
         Comm->barrier(); if (Comm->getRank()==0) cout << "\n#########\n# Solve #\n#########" << endl;
-        SolveStatus<double> status =
-        solve<double>(*lows, Thyra::NOTRANS, *thyraB, thyraX.ptr());
+        SolveStatus<SC> status =
+        solve<SC>(*lows, Thyra::NOTRANS, *thyraB, thyraX.ptr());
 
         Comm->barrier(); if (Comm->getRank()==0) cout << "\n#############\n# Finished! #\n#############" << endl;
     }

--- a/packages/shylu/shylu_dd/frosch/test/Thyra_Xpetra_Elasticity/main.cpp
+++ b/packages/shylu/shylu_dd/frosch/test/Thyra_Xpetra_Elasticity/main.cpp
@@ -250,8 +250,8 @@ int main(int argc, char *argv[])
         }
 
         Comm->barrier(); if (Comm->getRank()==0) cout << "###################################\n# Stratimikos LinearSolverBuilder #\n###################################\n" << endl;
-        Stratimikos::DefaultLinearSolverBuilder linearSolverBuilder;
-        Stratimikos::enableFROSch<LO,GO,NO>(linearSolverBuilder);
+        Stratimikos::LinearSolverBuilder<SC> linearSolverBuilder;
+        Stratimikos::enableFROSch<SC,LO,GO,NO>(linearSolverBuilder);
         linearSolverBuilder.setParameterList(parameterList);
 
         Comm->barrier(); if (Comm->getRank()==0) cout << "######################\n# Thyra PrepForSolve #\n######################\n" << endl;
@@ -268,8 +268,8 @@ int main(int argc, char *argv[])
         linearOpWithSolve(*lowsFactory, K_thyra);
 
         Comm->barrier(); if (Comm->getRank()==0) cout << "\n#########\n# Solve #\n#########" << endl;
-        SolveStatus<double> status =
-        solve<double>(*lows, Thyra::NOTRANS, *thyraB, thyraX.ptr());
+        SolveStatus<SC> status =
+        solve<SC>(*lows, Thyra::NOTRANS, *thyraB, thyraX.ptr());
 
         Comm->barrier(); if (Comm->getRank()==0) cout << "\n#############\n# Finished! #\n#############" << endl;
     }

--- a/packages/shylu/shylu_dd/frosch/test/Thyra_Xpetra_Laplace/main.cpp
+++ b/packages/shylu/shylu_dd/frosch/test/Thyra_Xpetra_Laplace/main.cpp
@@ -361,7 +361,7 @@ int main(int argc, char *argv[])
         }
 
         Comm->barrier(); if (Comm->getRank()==0) cout << "###################################\n# Stratimikos LinearSolverBuilder #\n###################################\n" << endl;
-        Stratimikos::DefaultLinearSolverBuilder linearSolverBuilder;
+        Stratimikos::LinearSolverBuilder<SC> linearSolverBuilder;
         Stratimikos::enableFROSch<LO,GO,NO>(linearSolverBuilder);
         linearSolverBuilder.setParameterList(parameterList);
 
@@ -379,8 +379,8 @@ int main(int argc, char *argv[])
         linearOpWithSolve(*lowsFactory, K_thyra);
 
         Comm->barrier(); if (Comm->getRank()==0) cout << "\n#########\n# Solve #\n#########" << endl;
-        SolveStatus<double> status =
-        solve<double>(*lows, Thyra::NOTRANS, *thyraB, thyraX.ptr());
+        SolveStatus<SC> status =
+        solve<SC>(*lows, Thyra::NOTRANS, *thyraB, thyraX.ptr());
 
         Comm->barrier(); if (Comm->getRank()==0) cout << "\n#############\n# Finished! #\n#############" << endl;
     }

--- a/packages/shylu/shylu_dd/frosch/test/Thyra_Xpetra_Stokes_HDF5/main.cpp
+++ b/packages/shylu/shylu_dd/frosch/test/Thyra_Xpetra_Stokes_HDF5/main.cpp
@@ -287,8 +287,8 @@ int main(int argc, char *argv[])
         }
 
         Comm->barrier(); if (Comm->getRank()==0) cout << "###################################\n# Stratimikos LinearSolverBuilder #\n###################################\n" << endl;
-        Stratimikos::DefaultLinearSolverBuilder linearSolverBuilder;
-        Stratimikos::enableFROSch<LO,GO,NO>(linearSolverBuilder);
+        Stratimikos::LinearSolverBuilder<SC> linearSolverBuilder;
+        Stratimikos::enableFROSch<SC,LO,GO,NO>(linearSolverBuilder);
         linearSolverBuilder.setParameterList(parameterList);
 
         Comm->barrier(); if (Comm->getRank()==0) cout << "######################\n# Thyra PrepForSolve #\n######################\n" << endl;
@@ -305,8 +305,8 @@ int main(int argc, char *argv[])
         linearOpWithSolve(*lowsFactory, K_thyra);
 
         Comm->barrier(); if (Comm->getRank()==0) cout << "\n#########\n# Solve #\n#########" << endl;
-        SolveStatus<double> status =
-        solve<double>(*lows, Thyra::NOTRANS, *thyraB, thyraX.ptr());
+        SolveStatus<SC> status =
+        solve<SC>(*lows, Thyra::NOTRANS, *thyraB, thyraX.ptr());
 
         Comm->barrier(); if (Comm->getRank()==0) cout << "\n#############\n# Finished! #\n#############" << endl;
     }


### PR DESCRIPTION
@trilinos/shylu 

## Motivation
Enable use of Scalar types != double in FROSch by using the Stratimikos interfaces for general scalar type.

## Testing
In my local testing I changed one of the tests that is hard-coded to double to float, and it still passed. I also had to disable Epetra for that. Otherwise I was getting build errors. 