### PR TITLE
Only add Krino tests when tests are enabled (TriBITSPub/TriBITS#299)

### DIFF
--- a/packages/krino/krino/CMakeLists.txt
+++ b/packages/krino/krino/CMakeLists.txt
@@ -4,7 +4,7 @@ add_subdirectory(adaptivity_interface)
 add_subdirectory(region)
 add_subdirectory(rebalance_utils)
 add_subdirectory(parser)
-add_subdirectory(unit_tests)
+tribits_add_test_directories(unit_tests)
 
 SET(SOURCES_MAIN Apps_krino.cpp)
 


### PR DESCRIPTION
This is needed to successfully build and install Trilinos and then build SPARC when enabling all ATDM Trilinos packages with the new TriBITS 'master' branch.

See the commit log message for details on why this is needed.

For details on the build errors this fixes, see [internal tribitsrefactoring#6](https://cee-gitlab.sandia.gov/rabartl/tribitsrefactoring/-/issues/6#note_2442260).

