### PR TITLE
Panzer: Fixing orientations in lazy evaluation path

### DIFF
--- a/packages/panzer/disc-fe/src/Panzer_BasisValues2.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_BasisValues2.hpp
@@ -288,7 +288,7 @@ namespace panzer {
     int num_orientations_cells_;
 
     // Orientations object
-    Teuchos::RCP<const OrientationsInterface>   orientations_;
+    std::vector<Intrepid2::Orientation>   orientations_;
 
     /// Used to check if arrays have been cached
     mutable bool basis_ref_scalar_evaluated_;
@@ -358,7 +358,7 @@ namespace panzer {
 
     /// Set the orientations object for applying orientations using the lazy evaluation path - required for certain bases
     void
-    setOrientations(const Teuchos::RCP<const OrientationsInterface> & orientations,
+    setOrientations(const std::vector<Intrepid2::Orientation> & orientations,
                     const int num_orientations_cells = -1);
 
     /// Set the cubature weights (weighted measure) for the basis values object - required to get weighted basis objects

--- a/packages/panzer/disc-fe/src/Panzer_BasisValues2_impl.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_BasisValues2_impl.hpp
@@ -210,8 +210,8 @@ evaluateValues(const PHX::MDField<Scalar,IP,Dim> & cub_points,
   if(elmtspace == PureBasis::HDIV and compute_derivatives)
     getDivVectorBasis(false,true,true);
 
-  // Orientations have been applied only if this pointer is valid
-  orientations_applied_ = orientations_ != Teuchos::null;
+  // Orientations have been applied if the number of them is greater than zero
+  orientations_applied_ = (orientations_.size()>0);
 }
 
 template <typename Scalar>
@@ -263,8 +263,8 @@ evaluateValues(const PHX::MDField<Scalar,IP,Dim> & cub_points,
     getBasisCoordinates(true,true);
   }
 
-  // Orientations have been applied only if this pointer is valid
-  orientations_applied_ = orientations_ != Teuchos::null;
+  // Orientations have been applied if the number of them is greater than zero
+  orientations_applied_ = (orientations_.size()>0);
 }
 
 template <typename Scalar>
@@ -324,9 +324,8 @@ evaluateValues(const PHX::MDField<Scalar,Cell,IP,Dim> & cub_points,
     getBasisCoordinates(true,true);
   }
 
-  // Orientations have been applied only if this pointer is valid
-  orientations_applied_ = orientations_ != Teuchos::null;
-
+  // Orientations have been applied if the number of them is greater than zero
+  orientations_applied_ = (orientations_.size()>0);
 }
 
 template <typename Scalar>
@@ -655,16 +654,15 @@ setupUniform(const Teuchos::RCP<const panzer::BasisIRLayout> &  basis,
 template <typename Scalar>
 void
 BasisValues2<Scalar>::
-setOrientations(const Teuchos::RCP<const OrientationsInterface> & orientations,
+setOrientations(const std::vector<Intrepid2::Orientation> & orientations,
                 const int num_orientations_cells)
 {
   if(num_orientations_cells < 0)
     num_orientations_cells_ = num_evaluate_cells_;
   else
     num_orientations_cells_ = num_orientations_cells;
-  if(orientations == Teuchos::null){
+  if(orientations.size() == 0){
     orientations_applied_ = false;
-    orientations_ = Teuchos::null;
     // Normally we would reset arrays here, but it seems to causes a lot of problems
   } else {
     orientations_ = orientations;
@@ -1055,7 +1053,6 @@ getBasisValues(const bool weighted,
   const int num_dim    = basis_layout->dimension();
 
   if(weighted){
-
     TEUCHOS_ASSERT(cubature_weights_.size() > 0);
 
     // Get the basis_scalar values - do not cache
@@ -1181,8 +1178,8 @@ getBasisValues(const bool weighted,
     // the two construction paths in panzer. Unification should help
     // fix the logic.
 
-    if(orientations_ != Teuchos::null)
-      applyOrientationsImpl<Scalar>(num_orientations_cells_, tmp_basis_scalar.get_view(), *orientations_->getOrientations(), *intrepid_basis);
+    if(orientations_.size() > 0)
+      applyOrientationsImpl<Scalar>(num_orientations_cells_, tmp_basis_scalar.get_view(), orientations_, *intrepid_basis);
 
     // Store for later if cache is enabled
     PANZER_CACHE_DATA(basis_scalar);
@@ -1364,8 +1361,8 @@ getVectorBasisValues(const bool weighted,
       }
     }
 
-    if(orientations_ != Teuchos::null)
-      applyOrientationsImpl<Scalar>(num_orientations_cells_, tmp_basis_vector.get_view(), *orientations_->getOrientations(), *intrepid_basis);
+    if(orientations_.size() > 0)
+      applyOrientationsImpl<Scalar>(num_orientations_cells_, tmp_basis_vector.get_view(), orientations_, *intrepid_basis);
 
     // Store for later if cache is enabled
     PANZER_CACHE_DATA(basis_vector);
@@ -1511,8 +1508,8 @@ getGradBasisValues(const bool weighted,
       }
     }
 
-    if(orientations_ != Teuchos::null)
-      applyOrientationsImpl<Scalar>(num_orientations_cells_, tmp_grad_basis.get_view(), *orientations_->getOrientations(), *intrepid_basis);
+    if(orientations_.size() > 0)
+      applyOrientationsImpl<Scalar>(num_orientations_cells_, tmp_grad_basis.get_view(), orientations_, *intrepid_basis);
 
     // Store for later if cache is enabled
     PANZER_CACHE_DATA(grad_basis);
@@ -1656,8 +1653,8 @@ getCurl2DVectorBasis(const bool weighted,
       }
     }
 
-    if(orientations_ != Teuchos::null)
-      applyOrientationsImpl<Scalar>(num_orientations_cells_, tmp_curl_basis_scalar.get_view(), *orientations_->getOrientations(), *intrepid_basis);
+    if(orientations_.size() > 0)
+      applyOrientationsImpl<Scalar>(num_orientations_cells_, tmp_curl_basis_scalar.get_view(), orientations_, *intrepid_basis);
 
     // Store for later if cache is enabled
     PANZER_CACHE_DATA(curl_basis_scalar);
@@ -1804,8 +1801,8 @@ getCurlVectorBasis(const bool weighted,
       }
     }
 
-    if(orientations_ != Teuchos::null)
-      applyOrientationsImpl<Scalar>(num_orientations_cells_, tmp_curl_basis_vector.get_view(), *orientations_->getOrientations(), *intrepid_basis);
+    if(orientations_.size() > 0)
+      applyOrientationsImpl<Scalar>(num_orientations_cells_, tmp_curl_basis_vector.get_view(), orientations_, *intrepid_basis);
 
     // Store for later if cache is enabled
     PANZER_CACHE_DATA(curl_basis_vector);
@@ -1942,8 +1939,8 @@ getDivVectorBasis(const bool weighted,
       }
     }
 
-    if(orientations_ != Teuchos::null)
-      applyOrientationsImpl<Scalar>(num_orientations_cells_, tmp_div_basis.get_view(), *orientations_->getOrientations(), *intrepid_basis);
+    if(orientations_.size() > 0)
+      applyOrientationsImpl<Scalar>(num_orientations_cells_, tmp_div_basis.get_view(), orientations_, *intrepid_basis);
 
     // Store for later if cache is enabled
     PANZER_CACHE_DATA(div_basis);


### PR DESCRIPTION
The orientations were not properly applied when different worksets
were used on a processor. This was because the orientations vector
was not subindexed to the workset cells. So always the same
cells on the processor were used for defining orientations. This
resulted in failed interpolation schemes.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/<teamName>

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->