### PR TITLE
Allow working with GenConfig repos with gitdist

### DIFF
--- a/.gitdist.default
+++ b/.gitdist.default
@@ -6,6 +6,14 @@ packages/ForTrilinos
 package/optika
 packages/mesquite
 packages/xSDKTrilinos
+packages/framework/GenConfig
+packages/framework/GenConfig/deps/SetEnvironment
+packages/framework/GenConfig/deps/DetermineSystem
+packages/framework/GenConfig/deps/KeywordParser
+packages/framework/GenConfig/deps/LoadEnv
+packages/framework/GenConfig/deps/SetProgramOptions
+packages/framework/son-ini-files
+packages/framework/srn-ini-files
 TriBITS
 TriBITS/TriBITSDoc
 kokkos


### PR DESCRIPTION
This allows using the tool gitdist to view and work with the GenConfig repos. This makes it easy to see what is going on with these various repos.

NOTE: Having this .gitdist.default file does not impact the git submodule manipulation as defined in .gitsubmodules or
packages/framework/get_dependencies.sh at all.  All it does it provide another easy way to view and work with these repos.
