### PR TITLE
documentation(html) : add timestamp to html doc

### DIFF
--- a/packages/common/Doxyfile
+++ b/packages/common/Doxyfile
@@ -115,6 +115,7 @@ IGNORE_PREFIX          =
 GENERATE_HTML          = YES
 HTML_OUTPUT            = html
 HTML_FILE_EXTENSION    = .html
+HTML_TIMESTAMP         = YES
 #HTML_HEADER            = ../../common/header.html
 #HTML_FOOTER            = ../../common/footer.html
 #HTML_STYLESHEET        = ../../common/styles.css


### PR DESCRIPTION
## Motivation

Currently, the online Doxygen documentation's title is "version of the day". Without neither the commit SHA nor the generation timestamp, it is hard to determine for what version of Trilinos the documentation is.

This PR adds the generation timestamp to the bottom of the HTLM documentation page (see also https://doxygen.nl/manual/config.html#cfg_html_timestamp).

## Related Issues

* https://github.com/trilinos/Trilinos/issues/10511