### PR TITLE
packages/framework: Try to override dynamic package enables

### DIFF
--- a/packages/framework/pr_tools/pullrequest-specs.ini
+++ b/packages/framework/pr_tools/pullrequest-specs.ini
@@ -11,7 +11,7 @@
 # - `package_subproject_list.cmake` and
 #
 # Instead of using the TriBiTS tool to determine changes.
-python-3: TrilinosFrameworkTests
+Trilinos_PR_python3: TrilinosFrameworkTests
 Trilinos-pullrequest-gcc-8.3.0-installation-testing A: Teuchos
 Trilinos-pullrequest-gcc-8.3.0-installation-testing B: Tpetra
 #

--- a/packages/framework/pr_tools/trilinosprhelpers/unittests/pullrequest-specs.ini
+++ b/packages/framework/pr_tools/trilinosprhelpers/unittests/pullrequest-specs.ini
@@ -11,7 +11,7 @@
 # - `package_subproject_list.cmake` and
 #
 # Instead of using the TriBiTS tool to determine changes.
-python-3: TrilinosFrameworkTests
+Trilinos_PR_python3: TrilinosFrameworkTests
 Trilinos-pullrequest-gcc-8.3.0-installation-testing A: Teuchos
 Trilinos-pullrequest-gcc-8.3.0-installation-testing B: Tpetra
 #

--- a/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationBase.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationBase.py
@@ -250,8 +250,8 @@ class TrilinosPRConfigurationTest(unittest.TestCase):
         Generate dummy command line arguments
         """
         args = copy.deepcopy(self.dummy_args())
-        args.pullrequest_build_name = "python-3"
-        args.genconfig_build_name = "python-3"
+        args.pullrequest_build_name = "Trilinos_PR_python3"
+        args.genconfig_build_name = "Trilinos_PR_python3"
         return args
 
 

--- a/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationStandard.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationStandard.py
@@ -236,7 +236,7 @@ class TrilinosPRConfigurationStandardTest(TestCase):
         - Change args to enable dry_run mode.
         """
         args = self.dummy_args()
-        args.pullrequest_build_name = "python-3"
+        args.pullrequest_build_name = "Trilinos_PR_python3"
         pr_config = trilinosprhelpers.TrilinosPRConfigurationStandard(args)
 
         # prepare step


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/framework

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The new Trilinos_PR_python3 build is not overriding the dynamic set of package enables causing mass PR failures as reported in #10622.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->
#10622 and everyone with PRs touching anything outside of `packages/framework`


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Replaying the failing pipeline reported via https://trilinos-cdash.sandia.gov/index.php?project=Trilinos&parentid=183234&filtercount=1&showfilters=1&field1=buildstarttime&compare1=84&value1=NOW&filtercombine=and with these changes on top of the #10614 source branch. [Here are those pipeline results on cdash](https://trilinos-cdash.sandia.gov/index.php?project=Trilinos&display=project&filtercount=3&showfilters=1&filtercombine=and&field1=site&compare1=61&value1=ascic158&field2=buildname&compare2=61&value2=PR-test-issue10622-test-rhel7_sems-gnu-7.2.0-anaconda3-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_pr-framework-51&field3=buildstamp&compare3=61&value3=20220615-1648-Experimental).

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->