### PR TITLE
Address a real defect, use GenConfig without generated symlink version tracking, improve maintainability, improve readability of STDOUT

### DIFF
--- a/.gitdist.default
+++ b/.gitdist.default
@@ -7,12 +7,6 @@ package/optika
 packages/mesquite
 packages/xSDKTrilinos
 packages/framework/GenConfig
-packages/framework/GenConfig/deps/SetEnvironment
-packages/framework/GenConfig/deps/DetermineSystem
-packages/framework/GenConfig/deps/KeywordParser
-packages/framework/GenConfig/deps/LoadEnv
-packages/framework/GenConfig/deps/SetProgramOptions
-packages/framework/GenConfig/deps/ConfigParserEnhanced
 packages/framework/son-ini-files
 packages/framework/srn-ini-files
 TriBITS

--- a/packages/framework/get_dependencies.sh
+++ b/packages/framework/get_dependencies.sh
@@ -3,7 +3,7 @@ ini_file_option=$1
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
 
 # Data that needs to be updated when GenConfig changes!
-genconfig_sha1=b47cbdb1145a9d13f5bc8d4e7e691bab1dcdb60d
+genconfig_sha1=924a08af66f0a0573b5dd1128179731489339aec
 
 # The following code contains no changing data
 

--- a/packages/framework/get_dependencies.sh
+++ b/packages/framework/get_dependencies.sh
@@ -53,12 +53,13 @@ if [[ "$ini_file_option" == "--srn" ]] ; then
   tril_genconfig_clone_or_update_repo \
     git@cee-gitlab.sandia.gov:trilinos-project/srn-ini-files.git \
     srn-ini-files
-fi
-
-if [[ "$ini_file_option" == "--son" ]] ; then
+elif [[ "$ini_file_option" == "--son" ]] ; then
   tril_genconfig_clone_or_update_repo \
     git@gitlab-ex.sandia.gov:trilinos-project/son-ini-files.git \
     son-ini-files
+elif [[ "$ini_file_option" != "" ]] ; then
+  echo "ERROR: Option '${ini_file_option}' not allowed! Must select '--son', '--srn' or ''."
+  exit 1
 fi
 
 # Set up symlinks to the desired *.ini files

--- a/packages/framework/get_dependencies.sh
+++ b/packages/framework/get_dependencies.sh
@@ -24,6 +24,8 @@ function tril_genconfig_clone_or_update_repo() {
 
   if [[ ! -z ${head_sha} ]]; then
     git checkout -f ${head_sha}
+  else
+    git merge @{u} # (FF) merge tip if tracking branch
   fi
 
   if [[ "${has_submodules}" == "has-submodules" ]] ; then

--- a/packages/framework/get_dependencies.sh
+++ b/packages/framework/get_dependencies.sh
@@ -22,11 +22,11 @@ function tril_genconfig_clone_or_update_repo() {
   echo
 
   if [[ -d ${sub_dir} ]] ; then
-    echo "${sub_dir}: Fetching remote repo"
+    echo "STATUS: ${sub_dir}: Fetching remote repo"
     cd ${sub_dir}
     git fetch
   else
-    echo "${sub_dir}: Cloning from '${git_url}'"
+    echo "STATUS: ${sub_dir}: Cloning from '${git_url}'"
     git clone ${git_url} ${sub_dir}
     cd ${sub_dir}
   fi
@@ -34,13 +34,13 @@ function tril_genconfig_clone_or_update_repo() {
   if [[ ! -z ${head_sha} ]]; then
     git checkout -f ${head_sha}
   else
-    echo "${sub_dir}: Merging tip of remote tracking branch"
+    echo "STATUS: ${sub_dir}: Merging tip of remote tracking branch"
     git merge @{u}
   fi
 
   if [[ "${has_submodules}" == "has-submodules" ]] ; then
     echo
-    echo "${sub_dir}: Update submodules"
+    echo "STATUS: ${sub_dir}: Update submodules"
     git submodule update --force --init --recursive
     cd - > /dev/null
   elif [[ "${has_submodules}" != "" ]] ; then
@@ -74,15 +74,15 @@ fi
 echo
 cd ${script_dir}/GenConfig/deps/LoadEnv/ini_files
 if [[ -d ${script_dir}/srn-ini-files ]] && [[ "$ini_file_option" == "--srn" ]]; then
-    echo "Link files from srn-ini-files"
+    echo "STATUS: Link files from srn-ini-files"
     ln -sf ${script_dir}/srn-ini-files/trilinos/framework/environment-specs.ini
     ln -sf ${script_dir}/srn-ini-files/trilinos/framework/supported-systems.ini
 elif [[ -d ${script_dir}/son-ini-files ]] && [[ "$ini_file_option" == "--son" ]]; then
-    echo "Link files from son-ini-files"
+    echo "STATUS: Link files from son-ini-files"
     ln -sf ${script_dir}/son-ini-files/trilinos/framework/environment-specs.ini
     ln -sf ${script_dir}/son-ini-files/trilinos/framework/supported-systems.ini
 else
-    echo "Link files from ini-files"
+    echo "STATUS: Link files from ini-files"
     [ -e ${script_dir}/ini-files/environment-specs.ini ] && ln -sf ${script_dir}/ini-files/environment-specs.ini
     [ -e ${script_dir}/ini-files/supported-systems.ini ] && ln -sf ${script_dir}/ini-files/supported-systems.ini
 fi
@@ -96,15 +96,15 @@ ln -sf ${script_dir}/ini-files/supported-config-flags.ini
 # Print summary of ini file settings
 cd ${script_dir}
 echo
-echo "You selected the following LoadEnv ini files:"
+echo "INFO: You selected the following LoadEnv ini files:"
 echo
 find GenConfig/deps/LoadEnv/ini_files -type l -exec ls -lta {} \;
 echo
-echo "You selected the following GenConfig ini files:"
+echo "INFO: You selected the following GenConfig ini files:"
 echo
 find  GenConfig/ini_files -type l -exec ls -lta {} \;
 echo
-echo "If these symlinks do not point to the desired ini files, please re-run:"
+echo "INFO: If these symlinks do not point to the desired ini files, please re-run:"
 echo
 echo "    $0 [--son|--srn]"
 popd > /dev/null

--- a/packages/framework/get_dependencies.sh
+++ b/packages/framework/get_dependencies.sh
@@ -2,6 +2,11 @@
 ini_file_option=$1
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
 
+# Data that needs to be updated when GenConfig changes!
+genconfig_sha1=b47cbdb1145a9d13f5bc8d4e7e691bab1dcdb60d
+
+# The following code contains no changing data
+
 pushd $PWD
 
 cd ${script_dir}
@@ -42,7 +47,7 @@ function tril_genconfig_clone_or_update_repo() {
 
 tril_genconfig_clone_or_update_repo \
   git@gitlab-ex.sandia.gov:trilinos-devops-consolidation/code/GenConfig.git \
-  GenConfig  has-submodules b47cbdb1145a9d13f5bc8d4e7e691bab1dcdb60d
+  GenConfig  has-submodules ${genconfig_sha1}
 
 if [[ "$ini_file_option" == "--srn" ]] ; then
   tril_genconfig_clone_or_update_repo \

--- a/packages/framework/get_dependencies.sh
+++ b/packages/framework/get_dependencies.sh
@@ -7,11 +7,12 @@ pushd $PWD
 cd ${script_dir}
 
 function tril_genconfig_clone_or_update_repo() {
-  pushd $PWD
   git_url=$1
   sub_dir=$2
   has_submodules=$3
   head_sha=$4
+
+  pushd $PWD
 
   if [[ -e ${sub_dir} ]] ; then
     cd ${sub_dir}


### PR DESCRIPTION
Final tweaks to GenConfig repo handling following on from PR #10620.  This is the same branch as PR https://github.com/bartlettroscoe/Trilinos/pull/7 but with a new name and pushed to the main Trilinos GitHub repo.

It is important to merge this PR ASAP,  otherwise, the srn-ini-files and son-ini-files repos will not be getting updated after their initial clone (see commit https://github.com/trilinos/Trilinos/commit/bc80cdf57d5256c96f3f51a0b18f239c520b46da).  See the individual commit log messages for details about other changes.

NOTE: [stacked  PR](https://blog.logrocket.com/using-stacked-pull-requests-in-github/) https://github.com/bartlettroscoe/Trilinos/pull/7 was meant to be merged to the PR branch  for #10620 before merging #10620.  A new PR has to be created to allow changing the target branch to the main repo 'develop' branch.

