### PR TITLE
Teuchos : make_rcp (#10642)

### DIFF
--- a/packages/teuchos/core/src/Teuchos_RCPDecl.hpp
+++ b/packages/teuchos/core/src/Teuchos_RCPDecl.hpp
@@ -1189,6 +1189,18 @@ embeddedObjDeallocArrayDelete(const Embedded &embedded, EPrePostDestruction preP
 template<class T> inline
 RCP<T> rcp(T* p, bool owns_mem = true);
 
+/**
+ * Allocates and constructs an object of type \c T 
+ * passing @p args to its constructor, and returns an object of type
+ * @ref Teuchos::RCP that owns and stores a pointer to it.
+ */
+template <typename T, typename ... Args>
+inline auto make_rcp(Args&& ... args)
+{
+    return Teuchos::rcp(
+        new T(std::forward<Args>(args)...)
+    );
+}
 
 /** \brief Initialize from a raw pointer with a deallocation policy.
  *

--- a/packages/teuchos/core/test/MemoryManagement/RCP_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/RCP_UnitTests.cpp
@@ -333,6 +333,26 @@ TEUCHOS_UNIT_TEST( RCP, rcpFromUndefRef )
   TEST_ASSERT(nonnull(a_rcp));
 }
 
+/**
+ * @test Test @ref Teuchos::make_rcp without constructor argument.
+ */
+TEUCHOS_UNIT_TEST( RCP, make_rcp_no_constructor_arg )
+{
+  Teuchos::RCP<A> a_rcp = Teuchos::make_rcp<A>();
+  TEST_ASSERT(Teuchos::nonnull(a_rcp));
+}
+
+/**
+ * @test Test @ref Teuchos::make_rcp with constructor arguments.
+ */
+TEUCHOS_UNIT_TEST( RCP, make_rcp )
+{
+  Teuchos::RCP<A> a_rcp = Teuchos::make_rcp<A>(1,2);
+  TEST_ASSERT(Teuchos::nonnull(a_rcp));
+  TEST_EQUALITY(a_rcp->A_g(),1);
+  TEST_EQUALITY(a_rcp->A_f(),2);
+}
+
 
 //
 // Test rcpCloneNode(...)

--- a/packages/teuchos/core/test/MemoryManagement/TestClasses.hpp
+++ b/packages/teuchos/core/test/MemoryManagement/TestClasses.hpp
@@ -93,6 +93,7 @@ class A {
 	int A_g_, A_f_;
 public:
 	A() : A_g_(A_g_return), A_f_(A_f_return) {}
+  A(const int A_g, const int A_f) : A_g_(A_g), A_f_(A_f) {}
   static Teuchos::RCP<A> create() { return Teuchos::rcp(new A); }
 	virtual ~A() TEUCHOS_NOEXCEPT_FALSE; // See below
 	virtual int A_g() { return A_g_; }


### PR DESCRIPTION
This PR addresses:
* https://github.com/trilinos/Trilinos/issues/10642

It introduces `Teuchos::make_rcp`, similar to `std::make_shared`.