### PR TITLE
Fix ML test build failure

### DIFF
--- a/packages/ml/test/MultiLevelPreconditioner_Sym/MultiLevelPreconditioner_Sym.cpp
+++ b/packages/ml/test/MultiLevelPreconditioner_Sym/MultiLevelPreconditioner_Sym.cpp
@@ -1,7 +1,11 @@
 #ifndef HAVE_CONFIG_H
 #define HAVE_CONFIG_H
 #endif
-#include <malloc.h>
+#ifdef __APPLE__
+#include <stdlib.h> // C++ standard does not include malloc.h, and Apple platforms don't support this.
+#else
+#include <malloc.h> // icc (at least) does not define mallinfo() from stdlib.h.
+#endif
 #include <cstdio>
 #include "ml_config.h"
 


### PR DESCRIPTION
On Apple clang builds of ML tests, I see errors relating to the include of `malloc.h`.  This one-line PR replaces this with `stdlib.h` in `packages/ml/test/MultiLevelPreconditioner_Sym/MultiLevelPreconditioner_Sym.cpp`, which I believe is the standard thing to include, and which resolves it for me.