### PR TITLE
Intrepid2 triangle hierarchical bases

### DIFF
--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HierarchicalBasisFamily.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HierarchicalBasisFamily.hpp
@@ -51,10 +51,13 @@
 
 #include "Intrepid2_DerivedBasisFamily.hpp"
 
+#include "Intrepid2_HierarchicalBasis_HCURL_TRI.hpp"
+#include "Intrepid2_HierarchicalBasis_HDIV_TRI.hpp"
 #include "Intrepid2_IntegratedLegendreBasis_HGRAD_LINE.hpp"
 #include "Intrepid2_IntegratedLegendreBasis_HGRAD_TRI.hpp"
 #include "Intrepid2_IntegratedLegendreBasis_HGRAD_TET.hpp"
 #include "Intrepid2_LegendreBasis_HVOL_LINE.hpp"
+#include "Intrepid2_LegendreBasis_HVOL_TRI.hpp"
 
 namespace Intrepid2 {
   
@@ -78,9 +81,9 @@ namespace Intrepid2 {
   public:
     // we will fill these in as we implement them
     using HGRAD = IntegratedLegendreBasis_HGRAD_TRI<DeviceType,OutputScalar,PointScalar,defineVertexFunctions>;
-    using HCURL = dummyBasis<DeviceType,OutputScalar,PointScalar>;
-    using HDIV  = dummyBasis<DeviceType,OutputScalar,PointScalar>;
-    using HVOL  = dummyBasis<DeviceType,OutputScalar,PointScalar>;
+    using HCURL = HierarchicalBasis_HCURL_TRI<DeviceType,OutputScalar,PointScalar,defineVertexFunctions>; // last template argument: useCGBasis; corresponds with defineVertexFunctions.
+    using HDIV  = HierarchicalBasis_HDIV_TRI<DeviceType,OutputScalar,PointScalar,defineVertexFunctions>; // last template argument: useCGBasis; corresponds with defineVertexFunctions.
+    using HVOL  = LegendreBasis_HVOL_TRI<DeviceType,OutputScalar,PointScalar>;
   };
   
   template<typename DeviceType,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HierarchicalBasis_HCURL_TRI.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HierarchicalBasis_HCURL_TRI.hpp
@@ -568,8 +568,8 @@ namespace Intrepid2
       getSubCellRefBasis(const ordinal_type subCellDim, const ordinal_type subCellOrd) const override{
       if(subCellDim == 1) {
         return Teuchos::rcp(new
-            IntegratedLegendreBasis_HGRAD_LINE<DeviceType,OutputScalar,PointScalar>
-                    (this->basisDegree_));
+            IntegratedLegendreBasis_HVOL_LINE<DeviceType,OutputScalar,PointScalar>
+                    (this->basisDegree_-1));
       }
       INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
     }

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HierarchicalBasis_HCURL_TRI.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HierarchicalBasis_HCURL_TRI.hpp
@@ -41,13 +41,13 @@
 // ************************************************************************
 // @HEADER
 
-/** \file   Intrepid2_IntegratedLegendreBasis_HGRAD_TRI.hpp
-    \brief  H(grad) basis on the triangle based on integrated Legendre polynomials.
+/** \file   Intrepid2_HierarchicalBasis_HCURL_TRI.hpp
+    \brief  H(curl) basis on the triangle using a construction involving Legendre and integrated Jacobi polynomials.
     \author Created by N.V. Roberts.
  */
 
-#ifndef Intrepid2_IntegratedLegendreBasis_HGRAD_TRI_h
-#define Intrepid2_IntegratedLegendreBasis_HGRAD_TRI_h
+#ifndef Intrepid2_HierarchicalBasis_HCURL_TRI_h
+#define Intrepid2_HierarchicalBasis_HCURL_TRI_h
 
 #include <Kokkos_View.hpp>
 #include <Kokkos_DynRankView.hpp>
@@ -61,14 +61,14 @@
 
 namespace Intrepid2
 {
-  /** \class  Intrepid2::Hierarchical_HGRAD_TRI_Functor
-      \brief  Functor for computing values for the IntegratedLegendreBasis_HGRAD_TRI class.
+  /** \class  Intrepid2::Hierarchical_HCURL_TRI_Functor
+      \brief  Functor for computing values for the HierarchicalBasis_HCURL_TRI class.
    
-   This functor is not intended for use outside of IntegratedLegendreBasis_HGRAD_TRI.
+   This functor is not intended for use outside of HierarchicalBasis_HCURL_TRI.
   */
   template<class DeviceType, class OutputScalar, class PointScalar,
            class OutputFieldType, class InputPointsType>
-  struct Hierarchical_HGRAD_TRI_Functor
+  struct Hierarchical_HCURL_TRI_Functor
   {
     using ExecutionSpace     = typename DeviceType::execution_space;
     using ScratchSpace       = typename ExecutionSpace::scratch_memory_space;
@@ -84,26 +84,30 @@ namespace Intrepid2
     InputPointsType  inputPoints_; // P,D
     
     int polyOrder_;
-    bool defineVertexFunctions_;
     int numFields_, numPoints_;
     
     size_t fad_size_output_;
     
-    static const int numVertices = 3;
-    static const int numEdges    = 3;
+    static const int numVertices     = 3;
+    static const int numEdges        = 3;
+    static const int numFaceFamilies = 2;
     const int edge_start_[numEdges] = {0,1,0}; // edge i is from edge_start_[i] to edge_end_[i]
     const int edge_end_[numEdges]   = {1,2,2}; // edge i is from edge_start_[i] to edge_end_[i]
+    const int face_family_start_[numFaceFamilies]  = {0,1};
+    const int face_family_middle_[numFaceFamilies] = {1,2};
+    const int face_family_end_   [numFaceFamilies] = {2,0};
     
-    Hierarchical_HGRAD_TRI_Functor(EOperator opType, OutputFieldType output, InputPointsType inputPoints,
-                                    int polyOrder, bool defineVertexFunctions)
+    Hierarchical_HCURL_TRI_Functor(EOperator opType, OutputFieldType output, InputPointsType inputPoints, int polyOrder)
     : opType_(opType), output_(output), inputPoints_(inputPoints),
-      polyOrder_(polyOrder), defineVertexFunctions_(defineVertexFunctions),
+      polyOrder_(polyOrder),
       fad_size_output_(getScalarDimensionForView(output))
     {
       numFields_ = output.extent_int(0);
       numPoints_ = output.extent_int(1);
+      const int expectedCardinality = 3 * polyOrder_ + polyOrder_ * (polyOrder-1);
+      
       INTREPID2_TEST_FOR_EXCEPTION(numPoints_ != inputPoints.extent_int(0), std::invalid_argument, "point counts need to match!");
-      INTREPID2_TEST_FOR_EXCEPTION(numFields_ != (polyOrder_+1)*(polyOrder_+2)/2, std::invalid_argument, "output field size does not match basis cardinality");
+      INTREPID2_TEST_FOR_EXCEPTION(numFields_ != expectedCardinality, std::invalid_argument, "output field size does not match basis cardinality");
     }
     
     KOKKOS_INLINE_FUNCTION
@@ -112,16 +116,16 @@ namespace Intrepid2
       auto pointOrdinal = teamMember.league_rank();
       OutputScratchView edge_field_values_at_point, jacobi_values_at_point, other_values_at_point, other_values2_at_point;
       if (fad_size_output_ > 0) {
-        edge_field_values_at_point = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1, fad_size_output_);
-        jacobi_values_at_point     = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1, fad_size_output_);
-        other_values_at_point      = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1, fad_size_output_);
-        other_values2_at_point     = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1, fad_size_output_);
+        edge_field_values_at_point = OutputScratchView(teamMember.team_shmem(), polyOrder_, fad_size_output_);
+        jacobi_values_at_point     = OutputScratchView(teamMember.team_shmem(), polyOrder_, fad_size_output_);
+        other_values_at_point      = OutputScratchView(teamMember.team_shmem(), polyOrder_, fad_size_output_);
+        other_values2_at_point     = OutputScratchView(teamMember.team_shmem(), polyOrder_, fad_size_output_);
       }
       else {
-        edge_field_values_at_point = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1);
-        jacobi_values_at_point     = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1);
-        other_values_at_point      = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1);
-        other_values2_at_point     = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1);
+        edge_field_values_at_point = OutputScratchView(teamMember.team_shmem(), polyOrder_);
+        jacobi_values_at_point     = OutputScratchView(teamMember.team_shmem(), polyOrder_);
+        other_values_at_point      = OutputScratchView(teamMember.team_shmem(), polyOrder_);
+        other_values2_at_point     = OutputScratchView(teamMember.team_shmem(), polyOrder_);
       }
       
       const auto & x = inputPoints_(pointOrdinal,0);
@@ -132,36 +136,32 @@ namespace Intrepid2
       const PointScalar lambda_dx[3] = {-1., 1., 0.};
       const PointScalar lambda_dy[3] = {-1., 0., 1.};
       
-      const int num1DEdgeFunctions = polyOrder_ - 1;
+      const int num1DEdgeFunctions = polyOrder_; // per edge
       
       switch (opType_)
       {
         case OPERATOR_VALUE:
         {
-          // vertex functions come first, according to vertex ordering: (0,0), (1,0), (0,1)
-          for (int vertexOrdinal=0; vertexOrdinal<numVertices; vertexOrdinal++)
-          {
-            output_(vertexOrdinal,pointOrdinal) = lambda[vertexOrdinal];
-          }
-          if (!defineVertexFunctions_)
-          {
-            // "DG" basis case
-            // here, we overwrite the first vertex function with 1:
-            output_(0,pointOrdinal) = 1.0;
-          }
-          
           // edge functions
-          int fieldOrdinalOffset = 3;
+          int fieldOrdinalOffset = 0;
           for (int edgeOrdinal=0; edgeOrdinal<numEdges; edgeOrdinal++)
           {
-            const auto & s0 = lambda[edge_start_[edgeOrdinal]];
-            const auto & s1 = lambda[  edge_end_[edgeOrdinal]];
+            const auto & s0    = lambda   [edge_start_[edgeOrdinal]];
+            const auto & s0_dx = lambda_dx[edge_start_[edgeOrdinal]];
+            const auto & s0_dy = lambda_dy[edge_start_[edgeOrdinal]];
             
-            Polynomials::shiftedScaledIntegratedLegendreValues(edge_field_values_at_point, polyOrder_, PointScalar(s1), PointScalar(s0+s1));
+            const auto & s1    = lambda   [  edge_end_[edgeOrdinal]];
+            const auto & s1_dx = lambda_dx[  edge_end_[edgeOrdinal]];
+            const auto & s1_dy = lambda_dy[  edge_end_[edgeOrdinal]];
+            
+            Polynomials::shiftedScaledLegendreValues(edge_field_values_at_point, polyOrder_-1, PointScalar(s1), PointScalar(s0+s1));
             for (int edgeFunctionOrdinal=0; edgeFunctionOrdinal<num1DEdgeFunctions; edgeFunctionOrdinal++)
             {
-              // the first two integrated legendre functions are essentially the vertex functions; hence the +2 on on the RHS here:
-              output_(edgeFunctionOrdinal+fieldOrdinalOffset,pointOrdinal) = edge_field_values_at_point(edgeFunctionOrdinal+2);
+              const auto & legendreValue = edge_field_values_at_point(edgeFunctionOrdinal);
+              const PointScalar xWeight = s0 * s1_dx - s1 * s0_dx;
+              const PointScalar yWeight = s0 * s1_dy - s1 * s0_dy;
+              output_(edgeFunctionOrdinal+fieldOrdinalOffset,pointOrdinal,0) = legendreValue * xWeight;
+              output_(edgeFunctionOrdinal+fieldOrdinalOffset,pointOrdinal,1) = legendreValue * yWeight;
             }
             fieldOrdinalOffset += num1DEdgeFunctions;
           }
@@ -171,68 +171,49 @@ namespace Intrepid2
             // these functions multiply the edge functions from the 01 edge by integrated Jacobi functions, appropriately scaled
             const double jacobiScaling = 1.0; // s0 + s1 + s2
             
-            const int max_ij_sum = polyOrder_;
-            const int min_i = 2;
-            const int min_j = 1;
-            const int min_ij_sum = min_i + min_j;
-            for (int ij_sum = min_ij_sum; ij_sum <= max_ij_sum; ij_sum++)
+            const int max_ij_sum = polyOrder_ - 1;
+            
+            // following ESEAS, we interleave the face families.  This groups all the face dofs of a given degree together.
+            const int faceFieldOrdinalOffset = fieldOrdinalOffset;
+            for (int familyOrdinal=1; familyOrdinal<=2; familyOrdinal++)
             {
-              for (int i=min_i; i<=ij_sum-min_j; i++)
+              int fieldOrdinal = faceFieldOrdinalOffset + familyOrdinal - 1;
+              const auto &s2 = lambda[ face_family_end_[familyOrdinal-1]];
+              for (int ij_sum=1; ij_sum <= max_ij_sum; ij_sum++)
               {
-                const int j = ij_sum - i;
-                const int edgeBasisOrdinal = i+numVertices-2; // i+1: where the value of the edge function is stored in output_
-                const auto & edgeValue = output_(edgeBasisOrdinal,pointOrdinal);
-                const double alpha = i*2.0;
-                
-                Polynomials::shiftedScaledIntegratedJacobiValues(jacobi_values_at_point, alpha, polyOrder_-2, lambda[2], jacobiScaling);
-                const auto & jacobiValue = jacobi_values_at_point(j);
-                output_(fieldOrdinalOffset,pointOrdinal) = edgeValue * jacobiValue;
-                fieldOrdinalOffset++;
+                for (int i=0; i<ij_sum; i++)
+                {
+                  const int j = ij_sum - i; // j >= 1
+                  // family 1 involves edge functions from edge (0,1) (edgeOrdinal 0); family 2 involves functions from edge (1,2) (edgeOrdinal 1)
+                  const int edgeBasisOrdinal = i + (familyOrdinal-1)*num1DEdgeFunctions;
+                  const auto & edgeValue_x = output_(edgeBasisOrdinal,pointOrdinal,0);
+                  const auto & edgeValue_y = output_(edgeBasisOrdinal,pointOrdinal,1);
+                  const double alpha = i*2.0 + 1;
+                  
+                  Polynomials::shiftedScaledIntegratedJacobiValues(jacobi_values_at_point, alpha, polyOrder_-1, s2, jacobiScaling);
+                  const auto & jacobiValue = jacobi_values_at_point(j);
+                  output_(fieldOrdinal,pointOrdinal,0) = edgeValue_x * jacobiValue;
+                  output_(fieldOrdinal,pointOrdinal,1) = edgeValue_y * jacobiValue;
+                  
+                  fieldOrdinal += 2; // 2 because there are two face families, and we interleave them.
+                }
               }
             }
           }
         } // end OPERATOR_VALUE
           break;
-        case OPERATOR_GRAD:
-        case OPERATOR_D1:
+        case OPERATOR_CURL:
         {
-          // vertex functions
-          if (defineVertexFunctions_)
-          {
-            // standard, "CG" basis case
-            // first vertex function is 1-x-y
-            output_(0,pointOrdinal,0) = -1.0;
-            output_(0,pointOrdinal,1) = -1.0;
-          }
-          else
-          {
-            // "DG" basis case
-            // here, the first "vertex" function is 1, so the derivative is 0:
-            output_(0,pointOrdinal,0) = 0.0;
-            output_(0,pointOrdinal,1) = 0.0;
-          }
-          // second vertex function is x
-          output_(1,pointOrdinal,0) = 1.0;
-          output_(1,pointOrdinal,1) = 0.0;
-          // third vertex function is y
-          output_(2,pointOrdinal,0) = 0.0;
-          output_(2,pointOrdinal,1) = 1.0;
-          
           // edge functions
-          int fieldOrdinalOffset = 3;
+          int fieldOrdinalOffset = 0;
           /*
-           Per Fuentes et al. (see Appendix E.1, E.2), the edge functions, defined for i ≥ 2, are
-             [L_i](s0,s1) = L_i(s1; s0+s1)
-           and have gradients:
-             grad [L_i](s0,s1) = [P_{i-1}](s0,s1) grad s1 + [R_{i-1}](s0,s1) grad (s0 + s1)
-           where
-             [R_{i-1}](s0,s1) = R_{i-1}(s1; s0+s1) = d/dt L_{i}(s0; s0+s1)
-           The P_i we have implemented in shiftedScaledLegendreValues, while d/dt L_{i+1} is
-           implemented in shiftedScaledIntegratedLegendreValues_dt.
+           Per Fuentes et al. (see Appendix E.1, E.2), the curls of the edge functions, are
+             (i+2) * [P_i](s0,s1) * (grad s0 \times grad s1)
+           The P_i we have implemented in shiftedScaledLegendreValues.
            */
           // rename the scratch memory to match our usage here:
-          auto & P_i_minus_1 = edge_field_values_at_point;
-          auto & L_i_dt      = jacobi_values_at_point;
+          auto & P_i      = edge_field_values_at_point;
+          auto & L_2ip1_j = jacobi_values_at_point;
           for (int edgeOrdinal=0; edgeOrdinal<numEdges; edgeOrdinal++)
           {
             const auto & s0 = lambda[edge_start_[edgeOrdinal]];
@@ -243,83 +224,91 @@ namespace Intrepid2
             const auto & s1_dx = lambda_dx[  edge_end_[edgeOrdinal]];
             const auto & s1_dy = lambda_dy[  edge_end_[edgeOrdinal]];
             
-            Polynomials::shiftedScaledLegendreValues             (P_i_minus_1, polyOrder_-1, PointScalar(s1), PointScalar(s0+s1));
-            Polynomials::shiftedScaledIntegratedLegendreValues_dt(L_i_dt,      polyOrder_,   PointScalar(s1), PointScalar(s0+s1));
-            for (int edgeFunctionOrdinal=0; edgeFunctionOrdinal<num1DEdgeFunctions; edgeFunctionOrdinal++)
+            const OutputScalar grad_s0_cross_grad_s1 = s0_dx * s1_dy - s1_dx * s0_dy;
+            
+            Polynomials::shiftedScaledLegendreValues(P_i, polyOrder_-1, PointScalar(s1), PointScalar(s0+s1));
+            for (int i=0; i<num1DEdgeFunctions; i++)
             {
-              // the first two (integrated) Legendre functions are essentially the vertex functions; hence the +2 here:
-              const int i = edgeFunctionOrdinal+2;
-              output_(edgeFunctionOrdinal+fieldOrdinalOffset,pointOrdinal,0) = P_i_minus_1(i-1) * s1_dx + L_i_dt(i) * (s1_dx + s0_dx);
-              output_(edgeFunctionOrdinal+fieldOrdinalOffset,pointOrdinal,1) = P_i_minus_1(i-1) * s1_dy + L_i_dt(i) * (s1_dy + s0_dy);
+              output_(i+fieldOrdinalOffset,pointOrdinal) = (i+2) * P_i(i) * grad_s0_cross_grad_s1;
             }
             fieldOrdinalOffset += num1DEdgeFunctions;
           }
           
           /*
-           Fuentes et al give the face functions as phi_{ij}, with gradient:
-             grad phi_{ij}(s0,s1,s2) = [L^{2i}_j](s0+s1,s2) grad [L_i](s0,s1) + [L_i](s0,s1) grad [L^{2i}_j](s0+s1,s2)
+           Fuentes et al give the face functions as E^f_{ij}, with curl:
+             [L^{2i+1}_j](s0+s1,s2) curl(E^E_i(s0,s1)) + grad[L^(2i+1)_j](s0+s1,s2) \times E^E_i(s0,s1)
            where:
-           - grad [L_i](s0,s1) is the edge function gradient we computed above
-           - [L_i](s0,s1) is the edge function which we have implemented above (in OPERATOR_VALUE)
-           - L^{2i}_j is a Jacobi polynomial with:
-               [L^{2i}_j](s0,s1) = L^{2i}_j(s1;s0+s1)
-             and the gradient for j ≥ 1 is
-               grad [L^{2i}_j](s0,s1) = [P^{2i}_{j-1}](s0,s1) grad s1 + [R^{2i}_{j-1}(s0,s1)] grad (s0 + s1)
-           Here,
-             [P^{2i}_{j-1}](s0,s1) = P^{2i}_{j-1}(s1,s0+s1)
-           and
-             [R^{2i}_{j-1}(s0,s1)] = d/dt L^{2i}_j(s1,s0+s1)
-           We have implemented P^{alpha}_{j} as shiftedScaledJacobiValues,
-           and d/dt L^{alpha}_{j} as shiftedScaledIntegratedJacobiValues_dt.
+           - E^E_i is the ith edge function on the edge s0 to s1
+           - L^{2i+1}_j is an shifted, scaled integrated Jacobi polynomial.
+           - For family 1, s0s1s2 = 012
+           - For family 2, s0s1s2 = 120
+           - Note that grad[L^(2i+1)_j](s0+s1,s2) is computed as [P^{2i+1}_{j-1}](s0+s1,s2) (grad s2) + [R^{2i+1}_{j-1}] grad (s0+s1+s2),
+             but for triangles (s0+s1+s2) is always 1, so that the grad (s0+s1+s2) is 0.
+           - Here,
+               [P^{2i+1}_{j-1}](s0,s1) = P^{2i+1}_{j-1}(s1,s0+s1)
+             and
+               [R^{2i+1}_{j-1}(s0,s1)] = d/dt L^{2i+1}_j(s1,s0+s1)
+             We have implemented P^{alpha}_{j} as shiftedScaledJacobiValues,
+             and d/dt L^{alpha}_{j} as shiftedScaledIntegratedJacobiValues_dt.
            */
           // rename the scratch memory to match our usage here:
-          auto & P_2i_j_minus_1 = edge_field_values_at_point;
-          auto & L_2i_j_dt      = jacobi_values_at_point;
-          auto & L_i            = other_values_at_point;
-          auto & L_2i_j         = other_values2_at_point;
+          auto & P_2ip1_j    = other_values_at_point;
+          
+          // following ESEAS, we interleave the face families.  This groups all the face dofs of a given degree together.
+          const int faceFieldOrdinalOffset = fieldOrdinalOffset;
+          for (int familyOrdinal=1; familyOrdinal<=2; familyOrdinal++)
           {
-            // face functions multiply the edge functions from the 01 edge by integrated Jacobi functions, appropriately scaled
+            int fieldOrdinal = faceFieldOrdinalOffset + familyOrdinal - 1;
+            
+            const auto &s0_index = face_family_start_ [familyOrdinal-1];
+            const auto &s1_index = face_family_middle_[familyOrdinal-1];
+            const auto &s2_index = face_family_end_   [familyOrdinal-1];
+            const auto &s0 = lambda[s0_index];
+            const auto &s1 = lambda[s1_index];
+            const auto &s2 = lambda[s2_index];
             const double jacobiScaling = 1.0; // s0 + s1 + s2
-
-            const int max_ij_sum = polyOrder_;
-            const int min_i = 2;
-            const int min_j = 1;
-            const int min_ij_sum = min_i + min_j;
-            for (int ij_sum = min_ij_sum; ij_sum <= max_ij_sum; ij_sum++)
+            
+            const auto & s0_dx = lambda_dx[s0_index];
+            const auto & s0_dy = lambda_dy[s0_index];
+            const auto & s1_dx = lambda_dx[s1_index];
+            const auto & s1_dy = lambda_dy[s1_index];
+            const auto & s2_dx = lambda_dx[s2_index];
+            const auto & s2_dy = lambda_dy[s2_index];
+            
+            const OutputScalar grad_s0_cross_grad_s1 = s0_dx * s1_dy - s1_dx * s0_dy;
+            
+            Polynomials::shiftedScaledLegendreValues (P_i, polyOrder_-1, PointScalar(s1), PointScalar(s0+s1));
+            // [L^{2i+1}_j](s0+s1,s2) curl(E^E_i(s0,s1)) + grad[L^(2i+1)_j](s0+s1,s2) \times E^E_i(s0,s1)
+            // grad[L^(2i+1)_j](s0+s1,s2) \times E^E_i(s0,s1)
+//                - Note that grad[L^(2i+1)_j](s0+s1,s2) is computed as [P^{2i+1}_{j-1}](s0+s1,s2) (grad s2) + [R^{2i+1}_{j-1}] grad (s0+s1+s2),
+            const PointScalar xEdgeWeight = s0 * s1_dx - s1 * s0_dx;
+            const PointScalar yEdgeWeight = s0 * s1_dy - s1 * s0_dy;
+            OutputScalar grad_s2_cross_xy_edgeWeight = s2_dx * yEdgeWeight - xEdgeWeight * s2_dy;
+            
+            const int max_ij_sum = polyOrder_ - 1;
+            for (int ij_sum=1; ij_sum <= max_ij_sum; ij_sum++)
             {
-              for (int i=min_i; i<=ij_sum-min_j; i++)
+              for (int i=0; i<ij_sum; i++)
               {
-                const int j = ij_sum - i;
-                // the edge function here is for edge 01, in the first set of edge functions.
-                const int edgeBasisOrdinal = i+numVertices-2; // i+1: where the value of the edge function is stored in output_
-                const auto & grad_L_i_dx = output_(edgeBasisOrdinal,pointOrdinal,0);
-                const auto & grad_L_i_dy = output_(edgeBasisOrdinal,pointOrdinal,1);
+                const int j = ij_sum - i; // j >= 1
+                const OutputScalar edgeCurl = (i+2.) * P_i(i) * grad_s0_cross_grad_s1;
+              
+                const double alpha = i*2.0 + 1;
                 
-                const double alpha = i*2.0;
-
-                Polynomials::shiftedScaledIntegratedLegendreValues (L_i, polyOrder_, lambda[1], lambda[0]+lambda[1]);
-                Polynomials::shiftedScaledIntegratedJacobiValues_dt(L_2i_j_dt, alpha, polyOrder_, lambda[2], jacobiScaling);
-                Polynomials::shiftedScaledIntegratedJacobiValues   (   L_2i_j, alpha, polyOrder_, lambda[2], jacobiScaling);
-                Polynomials::shiftedScaledJacobiValues(P_2i_j_minus_1, alpha, polyOrder_-1, lambda[2], jacobiScaling);
+                Polynomials::shiftedScaledJacobiValues(P_2ip1_j, alpha, polyOrder_-1, PointScalar(s2), jacobiScaling);
+                Polynomials::shiftedScaledIntegratedJacobiValues(L_2ip1_j, alpha, polyOrder_-1, s2, jacobiScaling);
+              
+                const PointScalar & edgeValue = P_i(i);
+                output_(fieldOrdinal,pointOrdinal) = L_2ip1_j(j) * edgeCurl + P_2ip1_j(j-1) * edgeValue * grad_s2_cross_xy_edgeWeight;
                 
-                const auto & s0_dx = lambda_dx[0];
-                const auto & s0_dy = lambda_dy[0];
-                const auto & s1_dx = lambda_dx[1];
-                const auto & s1_dy = lambda_dy[1];
-                const auto & s2_dx = lambda_dx[2];
-                const auto & s2_dy = lambda_dy[2];
-                
-                const OutputScalar basisValue_dx = L_2i_j(j) * grad_L_i_dx + L_i(i) * (P_2i_j_minus_1(j-1) * s2_dx + L_2i_j_dt(j) * (s0_dx + s1_dx + s2_dx));
-                const OutputScalar basisValue_dy = L_2i_j(j) * grad_L_i_dy + L_i(i) * (P_2i_j_minus_1(j-1) * s2_dy + L_2i_j_dt(j) * (s0_dy + s1_dy + s2_dy));
-                
-                output_(fieldOrdinalOffset,pointOrdinal,0) = basisValue_dx;
-                output_(fieldOrdinalOffset,pointOrdinal,1) = basisValue_dy;
-                fieldOrdinalOffset++;
+                fieldOrdinal += 2; // 2 because there are two face families, and we interleave them.
               }
             }
           }
         }
           break;
+        case OPERATOR_GRAD:
+        case OPERATOR_D1:
         case OPERATOR_D2:
         case OPERATOR_D3:
         case OPERATOR_D4:
@@ -330,7 +319,7 @@ namespace Intrepid2
         case OPERATOR_D9:
         case OPERATOR_D10:
           INTREPID2_TEST_FOR_ABORT( true,
-                                   ">>> ERROR: (Intrepid2::Basis_HGRAD_TRI_Cn_FEM_ORTH::OrthPolynomialTri) Computing of second and higher-order derivatives is not currently supported");
+                                   ">>> ERROR: (Intrepid2::Hierarchical_HCURL_TRI_Functor) Unsupported differential operator");
         default:
           // unsupported operator type
           device_assert(false);
@@ -353,10 +342,8 @@ namespace Intrepid2
     }
   };
   
-  /** \class  Intrepid2::IntegratedLegendreBasis_HGRAD_TRI
-      \brief  Basis defining integrated Legendre basis on the line, a polynomial subspace of H(grad) on the line: extension to triangle using Jacobi blending functions.
-
-              For mathematical details of the construction, see:
+  /** \class  Intrepid2::HierarchicalBasis_HCURL_TRI
+      \brief  For mathematical details of the construction, see:
    
                Federico Fuentes, Brendan Keith, Leszek Demkowicz, Sriram Nagaraj.
                "Orientation embedded high order shape functions for the exact sequence elements of all shapes."
@@ -372,8 +359,8 @@ namespace Intrepid2
   template<typename DeviceType,
            typename OutputScalar = double,
            typename PointScalar  = double,
-           bool defineVertexFunctions = true>            // if defineVertexFunctions is true, first three basis functions are 1-x-y, x, and y.  Otherwise, they are 1, x, and y.
-  class IntegratedLegendreBasis_HGRAD_TRI
+           bool useCGBasis = true> // if useCGBasis is false, all basis functions will be associated with the interior
+  class HierarchicalBasis_HCURL_TRI
   : public Basis<DeviceType,OutputScalar,PointScalar>
   {
   public:
@@ -390,80 +377,62 @@ namespace Intrepid2
 
   protected:
     int polyOrder_; // the maximum order of the polynomial
-    EPointType pointType_;
   public:
     /** \brief  Constructor.
         \param [in] polyOrder - the polynomial order of the basis.
-     
-     The basis will have polyOrder + 1 members.
-     
-     If defineVertexFunctions is false, then all basis functions are identified with the interior of the line element, and the first two basis functions are 1 and x.
-     
-     If defineVertexFunctions is true, then the first two basis functions are 1-x and x, and these are identified with the left and right vertices of the cell.
-     
+        \param [in] pointType - point type for nodal basis.  Ignored here (irrelevant for hierarchical/modal basis).
      */
-    IntegratedLegendreBasis_HGRAD_TRI(int polyOrder, const EPointType pointType=POINTTYPE_DEFAULT)
+    HierarchicalBasis_HCURL_TRI(int polyOrder, const EPointType pointType=POINTTYPE_DEFAULT)
     :
-    polyOrder_(polyOrder),
-    pointType_(pointType)
+    polyOrder_(polyOrder)
     {
-      INTREPID2_TEST_FOR_EXCEPTION(pointType!=POINTTYPE_DEFAULT,std::invalid_argument,"PointType not supported");
-
-      this->basisCardinality_  = ((polyOrder+2) * (polyOrder+1)) / 2;
+      const int numEdgeFunctions = polyOrder * 3;
+      const int numFaceFunctions = polyOrder * (polyOrder-1);  // two families, each with p*(p-1)/2 functions
+      this->basisCardinality_  = numEdgeFunctions + numFaceFunctions;
       this->basisDegree_       = polyOrder;
       this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Triangle<> >() );
       this->basisType_         = BASIS_FEM_HIERARCHICAL;
       this->basisCoordinates_  = COORDINATES_CARTESIAN;
-      this->functionSpace_     = FUNCTION_SPACE_HGRAD;
+      this->functionSpace_     = FUNCTION_SPACE_HCURL;
       
       const int degreeLength = 1;
-      this->fieldOrdinalPolynomialDegree_ = OrdinalTypeArray2DHost("Integrated Legendre H(grad) triangle polynomial degree lookup", this->basisCardinality_, degreeLength);
+      this->fieldOrdinalPolynomialDegree_ = OrdinalTypeArray2DHost("Hierarchical H(curl) triangle polynomial degree lookup", this->basisCardinality_, degreeLength);
       
       int fieldOrdinalOffset = 0;
       // **** vertex functions **** //
-      const int numVertices = this->basisCellTopology_.getVertexCount();
-      const int numFunctionsPerVertex = 1;
-      const int numVertexFunctions = numVertices * numFunctionsPerVertex;
-      for (int i=0; i<numVertexFunctions; i++)
-      {
-        // for H(grad) on triangle, if defineVertexFunctions is false, first three basis members are linear
-        // if not, then the only difference is that the first member is constant
-        this->fieldOrdinalPolynomialDegree_(i,0) = 1;
-      }
-      if (!defineVertexFunctions)
-      {
-        this->fieldOrdinalPolynomialDegree_(0,0) = 0;
-      }
-      fieldOrdinalOffset += numVertexFunctions;
+      // no vertex functions in H(curl)
       
       // **** edge functions **** //
-      const int numFunctionsPerEdge = polyOrder - 1; // bubble functions: all but the vertices
+      const int numFunctionsPerEdge = polyOrder; // p functions associated with each edge
       const int numEdges            = this->basisCellTopology_.getEdgeCount();
       for (int edgeOrdinal=0; edgeOrdinal<numEdges; edgeOrdinal++)
       {
         for (int i=0; i<numFunctionsPerEdge; i++)
         {
-          this->fieldOrdinalPolynomialDegree_(i+fieldOrdinalOffset,0) = i+2; // vertex functions are 1st order; edge functions start at order 2
+          this->fieldOrdinalPolynomialDegree_(i+fieldOrdinalOffset,0) = i+1; // the multiplicands involving the gradients of the vertex functions are first degree polynomials; hence the +1 (the remaining multiplicands are order i = 0,…,p-1).
         }
         fieldOrdinalOffset += numFunctionsPerEdge;
       }
+      INTREPID2_TEST_FOR_EXCEPTION(fieldOrdinalOffset != numEdgeFunctions, std::invalid_argument, "Internal error: basis enumeration is incorrect");
       
       // **** face functions **** //
-      const int max_ij_sum = polyOrder;
-      const int min_i = 2;
-      const int min_j = 1;
-      const int min_ij_sum = min_i + min_j;
-      for (int ij_sum = min_ij_sum; ij_sum <= max_ij_sum; ij_sum++)
+      const int max_ij_sum = polyOrder-1;
+      const int faceFieldOrdinalOffset = fieldOrdinalOffset;
+      for (int faceFamilyOrdinal=1; faceFamilyOrdinal<=2; faceFamilyOrdinal++)
       {
-        for (int i=min_i; i<=ij_sum-min_j; i++)
+        // following ESEAS, we interleave the face families.  This groups all the face dofs of a given degree together.
+        int fieldOrdinal = faceFieldOrdinalOffset + faceFamilyOrdinal - 1;
+        for (int ij_sum=1; ij_sum <= max_ij_sum; ij_sum++)
         {
-          const int j = ij_sum - i;
-          this->fieldOrdinalPolynomialDegree_(fieldOrdinalOffset,0) = i+j;
-          fieldOrdinalOffset++;
+          for (int i=0; i<ij_sum; i++)
+          {
+            this->fieldOrdinalPolynomialDegree_(fieldOrdinal,0) = ij_sum+1;
+            fieldOrdinal += 2; // 2 because there are two face families, and we interleave them.
+          }
         }
+        fieldOrdinalOffset = fieldOrdinal - 1; // due to the interleaving increment, we've gone two past the last face ordinal.  Set offset to be one past.
       }
-      const int numFaces = 1;
-      const int numFunctionsPerFace = ((polyOrder-1)*(polyOrder-2))/2;
+
       INTREPID2_TEST_FOR_EXCEPTION(fieldOrdinalOffset != this->basisCardinality_, std::invalid_argument, "Internal error: basis enumeration is incorrect");
       
       // initialize tags
@@ -477,22 +446,11 @@ namespace Intrepid2
         const ordinal_type posDfOrd = 2;        // position in the tag, counting from 0, of DoF ordinal relative to the subcell
         
         OrdinalTypeArray1DHost tagView("tag view", cardinality*tagSize);
-        const int vertexDim = 0, edgeDim = 1, faceDim = 2;
+        const ordinal_type edgeDim = 1, faceDim = 2;
 
-        if (defineVertexFunctions) {
+        if (useCGBasis) {
           {
             int tagNumber = 0;
-            for (int vertexOrdinal=0; vertexOrdinal<numVertices; vertexOrdinal++)
-            {
-              for (int functionOrdinal=0; functionOrdinal<numFunctionsPerVertex; functionOrdinal++)
-              {
-                tagView(tagNumber*tagSize+0) = vertexDim;             // vertex dimension
-                tagView(tagNumber*tagSize+1) = vertexOrdinal;         // vertex id
-                tagView(tagNumber*tagSize+2) = functionOrdinal;       // local dof id
-                tagView(tagNumber*tagSize+3) = numFunctionsPerVertex; // total number of dofs in this vertex
-                tagNumber++;
-              }
-            }
             for (int edgeOrdinal=0; edgeOrdinal<numEdges; edgeOrdinal++)
             {
               for (int functionOrdinal=0; functionOrdinal<numFunctionsPerEdge; functionOrdinal++)
@@ -504,6 +462,8 @@ namespace Intrepid2
                 tagNumber++;
               }
             }
+            const int numFunctionsPerFace = numFaceFunctions; // just one face in the triangle
+            const int numFaces = 1;
             for (int faceOrdinal=0; faceOrdinal<numFaces; faceOrdinal++)
             {
               for (int functionOrdinal=0; functionOrdinal<numFunctionsPerFace; functionOrdinal++)
@@ -516,7 +476,10 @@ namespace Intrepid2
               }
             }
           }
-        } else {
+        }
+        else
+        {
+          // DG basis: all functions are associated with interior
           for (ordinal_type i=0;i<cardinality;++i) {
             tagView(i*tagSize+0) = faceDim;     // face dimension
             tagView(i*tagSize+1) = 0;           // face id
@@ -543,7 +506,7 @@ namespace Intrepid2
      \return the name of the basis
      */
     const char* getName() const override {
-      return "Intrepid2_IntegratedLegendreBasis_HGRAD_TRI";
+      return "Intrepid2_HierarchicalBasis_HCURL_TRI";
     }
     
     /** \brief True if orientation is required
@@ -580,9 +543,9 @@ namespace Intrepid2
     {
       auto numPoints = inputPoints.extent_int(0);
       
-      using FunctorType = Hierarchical_HGRAD_TRI_Functor<DeviceType, OutputScalar, PointScalar, OutputViewType, PointViewType>;
+      using FunctorType = Hierarchical_HCURL_TRI_Functor<DeviceType, OutputScalar, PointScalar, OutputViewType, PointViewType>;
       
-      FunctorType functor(operatorType, outputValues, inputPoints, polyOrder_, defineVertexFunctions);
+      FunctorType functor(operatorType, outputValues, inputPoints, polyOrder_);
       
       const int outputVectorSize = getVectorSizeForHierarchicalParallelism<OutputScalar>();
       const int pointVectorSize  = getVectorSizeForHierarchicalParallelism<PointScalar>();
@@ -590,7 +553,7 @@ namespace Intrepid2
       const int teamSize = 1; // because of the way the basis functions are computed, we don't have a second level of parallelism...
 
       auto policy = Kokkos::TeamPolicy<ExecutionSpace>(numPoints,teamSize,vectorSize);
-      Kokkos::parallel_for( policy , functor, "Hierarchical_HGRAD_TRI_Functor");
+      Kokkos::parallel_for( policy , functor, "Hierarchical_HCURL_TRI_Functor");
     }
 
     /** \brief returns the basis associated to a subCell.
@@ -618,10 +581,10 @@ namespace Intrepid2
     virtual BasisPtr<typename Kokkos::HostSpace::device_type, OutputScalar, PointScalar>
     getHostBasis() const override {
       using HostDeviceType = typename Kokkos::HostSpace::device_type;
-      using HostBasisType  = IntegratedLegendreBasis_HGRAD_TRI<HostDeviceType, OutputScalar, PointScalar, defineVertexFunctions>;
-      return Teuchos::rcp( new HostBasisType(polyOrder_, pointType_) );
+      using HostBasisType  = HierarchicalBasis_HCURL_TRI<HostDeviceType, OutputScalar, PointScalar, useCGBasis>;
+      return Teuchos::rcp( new HostBasisType(polyOrder_) );
     }
   };
 } // end namespace Intrepid2
 
-#endif /* Intrepid2_IntegratedLegendreBasis_HGRAD_TRI_h */
+#endif /* Intrepid2_HierarchicalBasis_HCURL_TRI_h */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HierarchicalBasis_HDIV_TRI.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HierarchicalBasis_HDIV_TRI.hpp
@@ -1,0 +1,186 @@
+// @HEADER
+// ************************************************************************
+//
+//                           Intrepid2 Package
+//                 Copyright (2007) Sandia Corporation
+//
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Kyungjoo Kim  (kyukim@sandia.gov),
+//                    Mauro Perego  (mperego@sandia.gov), or
+//                    Nate Roberts  (nvrober@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+
+/** \file   Intrepid2_HierarchicalBasis_HDIV_TRI.hpp
+    \brief  H(div) basis on the triangle using a construction involving Legendre and integrated Jacobi polynomials.
+    \author Created by N.V. Roberts.
+ 
+ The H(div) basis in 2D is a rotation of the H(curl) basis.  That is how this is implemented, in terms of the H(curl) basis.
+ */
+
+#ifndef Intrepid2_HierarchicalBasis_HDIV_TRI_h
+#define Intrepid2_HierarchicalBasis_HDIV_TRI_h
+
+#include <Kokkos_View.hpp>
+#include <Kokkos_DynRankView.hpp>
+
+#include <Intrepid2_config.h>
+
+#include "Intrepid2_Basis.hpp"
+#include "Intrepid2_HierarchicalBasis_HCURL_TRI.hpp"
+#include "Intrepid2_Polynomials.hpp"
+#include "Intrepid2_Utils.hpp"
+
+namespace Intrepid2
+{
+  
+  /** \class  Intrepid2::HierarchicalBasis_HDIV_TRI
+      \brief  For mathematical details of the construction, see:
+   
+               Federico Fuentes, Brendan Keith, Leszek Demkowicz, Sriram Nagaraj.
+               "Orientation embedded high order shape functions for the exact sequence elements of all shapes."
+               Computers & Mathematics with Applications, Volume 70, Issue 4, 2015, Pages 353-458, ISSN 0898-1221.
+               https://doi.org/10.1016/j.camwa.2015.04.027.
+  */
+  template<typename DeviceType,
+           typename OutputScalar = double,
+           typename PointScalar  = double,
+           bool useCGBasis = true> // if useCGBasis is false, all basis functions will be associated with the interior
+  class HierarchicalBasis_HDIV_TRI
+  : public HierarchicalBasis_HCURL_TRI<DeviceType,OutputScalar,PointScalar,useCGBasis>
+  {
+  public:
+    using CurlBasis = HierarchicalBasis_HCURL_TRI<DeviceType,OutputScalar,PointScalar,useCGBasis>;
+    
+    using BasisBase = Basis<DeviceType,OutputScalar,PointScalar>;
+
+    using typename BasisBase::OrdinalTypeArray1DHost;
+    using typename BasisBase::OrdinalTypeArray2DHost;
+
+    using typename BasisBase::OutputViewType;
+    using typename BasisBase::PointViewType;
+    using typename BasisBase::ScalarViewType;
+
+    using typename BasisBase::ExecutionSpace;
+
+  public:
+    /** \brief  Constructor.
+        \param [in] polyOrder - the polynomial order of the basis.
+        \param [in] pointType - point type for nodal basis.  Ignored here (irrelevant for hierarchical/modal basis).
+     */
+    HierarchicalBasis_HDIV_TRI(int polyOrder, const EPointType pointType=POINTTYPE_DEFAULT)
+    :
+    CurlBasis(polyOrder,pointType)
+    {
+      this->functionSpace_ = FUNCTION_SPACE_HDIV; // CurlBasis will set the other Basis member variables correctly…
+    }
+    
+    /** \brief  Returns basis name
+     
+     \return the name of the basis
+     */
+    const char* getName() const override {
+      return "Intrepid2_HierarchicalBasis_HDIV_TRI";
+    }
+    
+    /** \brief True if orientation is required
+    */
+    virtual bool requireOrientation() const override {
+      return (this->getDegree() > 2);
+    }
+
+    // since the getValues() below only overrides the FEM variant, we specify that
+    // we use the base class's getValues(), which implements the FVD variant by throwing an exception.
+    // (It's an error to use the FVD variant on this basis.)
+    using BasisBase::getValues;
+    
+    /** \brief  Evaluation of a FEM basis on a <strong>reference cell</strong>.
+
+        Returns values of <var>operatorType</var> acting on FEM basis functions for a set of
+        points in the <strong>reference cell</strong> for which the basis is defined.
+
+        \param  outputValues      [out] - variable rank array with the basis values
+        \param  inputPoints       [in]  - rank-2 array (P,D) with the evaluation points
+        \param  operatorType      [in]  - the operator acting on the basis functions
+
+        \remark For rank and dimension specifications of the output array see Section
+        \ref basis_md_array_sec.  Dimensions of <var>ArrayScalar</var> arguments are checked
+        at runtime if HAVE_INTREPID2_DEBUG is defined.
+
+        \remark A FEM basis spans a COMPLETE or INCOMPLETE polynomial space on the reference cell
+        which is a smooth function space. Thus, all operator types that are meaningful for the
+        approximated function space are admissible. When the order of the operator exceeds the
+        degree of the basis, the output array is filled with the appropriate number of zeros.
+    */
+    virtual void getValues( OutputViewType outputValues, const PointViewType inputPoints,
+                           const EOperator operatorType = OPERATOR_VALUE ) const override
+    {
+      // H(div) functions are a rotation of the corresponding H(curl) functions
+      if (operatorType == OPERATOR_DIV)
+      {
+        this->CurlBasis::getValues(outputValues, inputPoints, OPERATOR_CURL);
+      }
+      else if (operatorType == OPERATOR_VALUE)
+      {
+        this->CurlBasis::getValues(outputValues, inputPoints, OPERATOR_VALUE);
+        
+        const ordinal_type numFields = outputValues.extent_int(0);
+        const ordinal_type numPoints = outputValues.extent_int(1);
+        
+        using ExecutionSpace = typename DeviceType::execution_space;
+        auto policy = Kokkos::MDRangePolicy<ExecutionSpace,Kokkos::Rank<2>>(Kokkos::Array<int,2>{0,0},Kokkos::Array<int,2>{numFields,numPoints});
+        
+        // multiply by [[0 1] [-1 0]]
+        Kokkos::parallel_for("apply rotation to H(curl) values", policy,
+        KOKKOS_LAMBDA (const int &fieldOrdinal, const int &pointOrdinal) {
+          const auto tempValue = outputValues(fieldOrdinal,pointOrdinal,0);
+          outputValues(fieldOrdinal,pointOrdinal,0) = outputValues(fieldOrdinal,pointOrdinal,1);
+          outputValues(fieldOrdinal,pointOrdinal,1) = -tempValue;
+        });
+      }
+    }
+
+    /** \brief Creates and returns a Basis object whose DeviceType template argument is Kokkos::HostSpace::device_type, but is otherwise identical to this.
+     
+        \return Pointer to the new Basis object.
+     */
+    virtual BasisPtr<typename Kokkos::HostSpace::device_type, OutputScalar, PointScalar>
+    getHostBasis() const override {
+      using HostDeviceType = typename Kokkos::HostSpace::device_type;
+      using HostBasisType  = HierarchicalBasis_HDIV_TRI<HostDeviceType, OutputScalar, PointScalar, useCGBasis>;
+      return Teuchos::rcp( new HostBasisType(this->CurlBasis::polyOrder_) );
+    }
+  };
+} // end namespace Intrepid2
+
+#endif /* Intrepid2_HierarchicalBasis_HDIV_TRI_h */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_IntegratedLegendreBasis_HGRAD_TET.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_IntegratedLegendreBasis_HGRAD_TET.hpp
@@ -205,7 +205,7 @@ namespace Intrepid2
               using Kokkos::subview;
               using Kokkos::ALL;
               auto jacobi_alpha = subview(jacobi_values1_at_point, alphaOrdinal, ALL);
-              Polynomials::integratedJacobiValues(jacobi_alpha, alpha, polyOrder_-2, s2, jacobiScaling);
+              Polynomials::shiftedScaledIntegratedJacobiValues(jacobi_alpha, alpha, polyOrder_-2, s2, jacobiScaling);
             }
             
             const int edgeOrdinal = face_ordinal_of_first_edge[faceOrdinal];
@@ -238,7 +238,7 @@ namespace Intrepid2
             using Kokkos::subview;
             using Kokkos::ALL;
             auto jacobi_alpha = subview(jacobi_values1_at_point, alphaOrdinal, ALL);
-            Polynomials::integratedJacobiValues(jacobi_alpha, alpha, polyOrder_-3, lambda[3], jacobiScaling);
+            Polynomials::shiftedScaledIntegratedJacobiValues(jacobi_alpha, alpha, polyOrder_-3, lambda[3], jacobiScaling);
           }
           const int min_i  = 2;
           const int min_j  = 1;
@@ -358,7 +358,7 @@ namespace Intrepid2
            and
              [R^{2i}_{j-1}(s0,s1)] = d/dt L^{2i}_j(s1,s0+s1)
            We have implemented P^{alpha}_{j} as shiftedScaledJacobiValues,
-           and d/dt L^{alpha}_{j} as integratedJacobiValues_dt.
+           and d/dt L^{alpha}_{j} as shiftedScaledIntegratedJacobiValues_dt.
            */
           // rename the scratch memory to match our usage here:
           auto & L_i            = legendre_values2_at_point;
@@ -385,8 +385,8 @@ namespace Intrepid2
               auto L_2i_j_dt_alpha      = subview(L_2i_j_dt,      alphaOrdinal, ALL);
               auto L_2i_j_alpha         = subview(L_2i_j,         alphaOrdinal, ALL);
               auto P_2i_j_minus_1_alpha = subview(P_2i_j_minus_1, alphaOrdinal, ALL);
-              Polynomials::integratedJacobiValues_dt(L_2i_j_dt_alpha,      alpha, polyOrder_-2, s2, jacobiScaling);
-              Polynomials::integratedJacobiValues   (L_2i_j_alpha,         alpha, polyOrder_-2, s2, jacobiScaling);
+              Polynomials::shiftedScaledIntegratedJacobiValues_dt(L_2i_j_dt_alpha,      alpha, polyOrder_-2, s2, jacobiScaling);
+              Polynomials::shiftedScaledIntegratedJacobiValues   (L_2i_j_alpha,         alpha, polyOrder_-2, s2, jacobiScaling);
               Polynomials::shiftedScaledJacobiValues(P_2i_j_minus_1_alpha, alpha, polyOrder_-1, s2, jacobiScaling);
             }
             
@@ -473,7 +473,7 @@ namespace Intrepid2
               using Kokkos::subview;
               using Kokkos::ALL;
               auto jacobi_alpha = subview(jacobi_values3_at_point, alphaOrdinal, ALL);
-              Polynomials::integratedJacobiValues(jacobi_alpha, alpha, polyOrder_-2, s2, jacobiScaling);
+              Polynomials::shiftedScaledIntegratedJacobiValues(jacobi_alpha, alpha, polyOrder_-2, s2, jacobiScaling);
             }
           }
           
@@ -489,8 +489,8 @@ namespace Intrepid2
             // values for interior functions:
             auto L = subview(L_alpha, alphaOrdinal, ALL);
             auto P = subview(P_alpha, alphaOrdinal, ALL);
-            Polynomials::integratedJacobiValues   (L, alpha, polyOrder_-3, lambda[3], jacobiScaling);
-            Polynomials::shiftedScaledJacobiValues(P, alpha, polyOrder_-3, lambda[3], jacobiScaling);
+            Polynomials::shiftedScaledIntegratedJacobiValues(L, alpha, polyOrder_-3, lambda[3], jacobiScaling);
+            Polynomials::shiftedScaledJacobiValues          (P, alpha, polyOrder_-3, lambda[3], jacobiScaling);
           }
           
           const int min_i  = 2;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_LegendreBasis_HVOL_TRI.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_LegendreBasis_HVOL_TRI.hpp
@@ -1,0 +1,368 @@
+// @HEADER
+// ************************************************************************
+//
+//                           Intrepid2 Package
+//                 Copyright (2007) Sandia Corporation
+//
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Kyungjoo Kim  (kyukim@sandia.gov),
+//                    Mauro Perego  (mperego@sandia.gov), or
+//                    Nate Roberts  (nvrober@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+
+/** \file   Intrepid2_LegendreBasis_HVOL_TRI.hpp
+    \brief  H(vol) basis on the triangle based on integrated Legendre polynomials.
+    \author Created by N.V. Roberts.
+ */
+
+#ifndef Intrepid2_LegendreBasis_HVOL_TRI_h
+#define Intrepid2_LegendreBasis_HVOL_TRI_h
+
+#include <Kokkos_View.hpp>
+#include <Kokkos_DynRankView.hpp>
+
+#include <Intrepid2_config.h>
+
+#include "Intrepid2_Basis.hpp"
+#include "Intrepid2_IntegratedLegendreBasis_HGRAD_LINE.hpp"
+#include "Intrepid2_Polynomials.hpp"
+#include "Intrepid2_Utils.hpp"
+
+namespace Intrepid2
+{
+  /** \class  Intrepid2::Hierarchical_HVOL_TRI_Functor
+      \brief  Functor for computing values for the LegendreBasis_HVOL_TRI class.
+   
+   This functor is not intended for use outside of LegendreBasis_HVOL_TRI.
+  */
+  template<class DeviceType, class OutputScalar, class PointScalar,
+           class OutputFieldType, class InputPointsType>
+  struct Hierarchical_HVOL_TRI_Functor
+  {
+    using ExecutionSpace     = typename DeviceType::execution_space;
+    using ScratchSpace       = typename ExecutionSpace::scratch_memory_space;
+    using OutputScratchView  = Kokkos::View<OutputScalar*,ScratchSpace,Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+    using PointScratchView   = Kokkos::View<PointScalar*, ScratchSpace,Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+    
+    using TeamPolicy = Kokkos::TeamPolicy<ExecutionSpace>;
+    using TeamMember = typename TeamPolicy::member_type;
+    
+    EOperator opType_;
+    
+    OutputFieldType  output_;      // F,P
+    InputPointsType  inputPoints_; // P,D
+    
+    int polyOrder_;
+    int numFields_, numPoints_;
+    
+    size_t fad_size_output_;
+    
+    static const int numVertices = 3;
+    static const int numEdges    = 3;
+    const int edge_start_[numEdges] = {0,1,0}; // edge i is from edge_start_[i] to edge_end_[i]
+    const int edge_end_[numEdges]   = {1,2,2}; // edge i is from edge_start_[i] to edge_end_[i]
+    
+    Hierarchical_HVOL_TRI_Functor(EOperator opType, OutputFieldType output, InputPointsType inputPoints, int polyOrder)
+    : opType_(opType), output_(output), inputPoints_(inputPoints),
+      polyOrder_(polyOrder),
+      fad_size_output_(getScalarDimensionForView(output))
+    {
+      numFields_ = output.extent_int(0);
+      numPoints_ = output.extent_int(1);
+      INTREPID2_TEST_FOR_EXCEPTION(numPoints_ != inputPoints.extent_int(0), std::invalid_argument, "point counts need to match!");
+      INTREPID2_TEST_FOR_EXCEPTION(numFields_ != (polyOrder_+1)*(polyOrder_+2)/2, std::invalid_argument, "output field size does not match basis cardinality");
+    }
+    
+    KOKKOS_INLINE_FUNCTION
+    void operator()( const TeamMember & teamMember ) const
+    {
+      auto pointOrdinal = teamMember.league_rank();
+      OutputScratchView legendre_field_values_at_point, jacobi_values_at_point;
+      if (fad_size_output_ > 0) {
+        legendre_field_values_at_point = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1, fad_size_output_);
+        jacobi_values_at_point         = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1, fad_size_output_);
+      }
+      else {
+        legendre_field_values_at_point = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1);
+        jacobi_values_at_point         = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1);
+      }
+      
+      const auto & x = inputPoints_(pointOrdinal,0);
+      const auto & y = inputPoints_(pointOrdinal,1);
+      
+      // write as barycentric coordinates:
+      const PointScalar lambda[3]    = {1. - x - y, x, y};
+      
+      switch (opType_)
+      {
+        case OPERATOR_VALUE:
+        {
+          // face functions
+          {
+            const PointScalar tLegendre = lambda[0] + lambda[1];
+            Polynomials::shiftedScaledLegendreValues(legendre_field_values_at_point, polyOrder_, lambda[1], tLegendre);
+
+            int fieldOrdinalOffset = 0;
+            const int max_ij_sum = polyOrder_;
+            for (int ij_sum=0; ij_sum<=max_ij_sum; ij_sum++)
+            {
+              for (int i=0; i<=ij_sum; i++)
+              {
+                const int j = ij_sum - i;
+                const auto & legendreValue = legendre_field_values_at_point(i);
+                const double alpha = i*2.0+1;
+                
+                const PointScalar tJacobi = 1.0;// lambda[0] + lambda[1] + lambda[2];
+                Polynomials::shiftedScaledJacobiValues(jacobi_values_at_point, alpha, polyOrder_, lambda[2], tJacobi);
+                
+                const auto & jacobiValue = jacobi_values_at_point(j);
+                output_(fieldOrdinalOffset,pointOrdinal) = legendreValue * jacobiValue;
+                fieldOrdinalOffset++;
+              }
+            }
+          }
+        } // end OPERATOR_VALUE
+          break;
+        default:
+          // unsupported operator type
+          device_assert(false);
+      }
+    }
+    
+    // Provide the shared memory capacity.
+    // This function takes the team_size as an argument,
+    // which allows team_size-dependent allocations.
+    size_t team_shmem_size (int team_size) const
+    {
+      // TODO: edit this to match scratch that we actually need.  (What's here is copied from H^1 basis on triangles…)
+      // we will use shared memory to create a fast buffer for basis computations
+      size_t shmem_size = 0;
+      if (fad_size_output_ > 0)
+        shmem_size += 2 * OutputScratchView::shmem_size(polyOrder_ + 1, fad_size_output_);
+      else
+        shmem_size += 2 * OutputScratchView::shmem_size(polyOrder_ + 1);
+      
+      return shmem_size;
+    }
+  };
+  
+  /** \class  Intrepid2::LegendreBasis_HVOL_TRI
+      \brief  Basis defining Legendre basis on the line, a polynomial subspace of H(vol) on the line: extension to triangle using Jacobi blending function.
+
+              For mathematical details of the construction, see:
+   
+               Federico Fuentes, Brendan Keith, Leszek Demkowicz, Sriram Nagaraj.
+               "Orientation embedded high order shape functions for the exact sequence elements of all shapes."
+               Computers & Mathematics with Applications, Volume 70, Issue 4, 2015, Pages 353-458, ISSN 0898-1221.
+               https://doi.org/10.1016/j.camwa.2015.04.027.
+  */
+  template<typename DeviceType,
+           typename OutputScalar = double,
+           typename PointScalar  = double>
+  class LegendreBasis_HVOL_TRI
+  : public Basis<DeviceType,OutputScalar,PointScalar>
+  {
+  public:
+    using BasisBase = Basis<DeviceType,OutputScalar,PointScalar>;
+
+    using typename BasisBase::OrdinalTypeArray1DHost;
+    using typename BasisBase::OrdinalTypeArray2DHost;
+
+    using typename BasisBase::OutputViewType;
+    using typename BasisBase::PointViewType;
+    using typename BasisBase::ScalarViewType;
+
+    using typename BasisBase::ExecutionSpace;
+
+  protected:
+    int polyOrder_; // the maximum order of the polynomial
+    EPointType pointType_;
+  public:
+    /** \brief  Constructor.
+        \param [in] polyOrder - the polynomial order of the basis.
+     
+     The basis will have (polyOrder + 1)*(polyOrder + 2) / 2 members, and is in a discrete exact sequence that begins with the integrated Legendre basis of order polyOrder + 1.
+     
+     */
+    LegendreBasis_HVOL_TRI(int polyOrder, const EPointType pointType=POINTTYPE_DEFAULT)
+    :
+    polyOrder_(polyOrder),
+    pointType_(pointType)
+    {
+      INTREPID2_TEST_FOR_EXCEPTION(pointType!=POINTTYPE_DEFAULT,std::invalid_argument,"PointType not supported");
+
+      this->basisCardinality_  = ((polyOrder+2) * (polyOrder+1)) / 2;
+      this->basisDegree_       = polyOrder;
+      this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Triangle<> >() );
+      this->basisType_         = BASIS_FEM_HIERARCHICAL;
+      this->basisCoordinates_  = COORDINATES_CARTESIAN;
+      this->functionSpace_     = FUNCTION_SPACE_HVOL;
+      
+      const int degreeLength = 1;
+      this->fieldOrdinalPolynomialDegree_ = OrdinalTypeArray2DHost("Integrated Legendre H(vol) triangle polynomial degree lookup", this->basisCardinality_, degreeLength);
+      
+      int fieldOrdinalOffset = 0;
+      // **** face functions **** //
+      const int max_ij_sum = polyOrder;
+      for (int ij_sum=0; ij_sum<=max_ij_sum; ij_sum++)
+      {
+        for (int i=0; i<=ij_sum; i++)
+        {
+          const int j = ij_sum - i;
+          this->fieldOrdinalPolynomialDegree_(fieldOrdinalOffset,0) = i+j;
+          fieldOrdinalOffset++;
+        }
+      }
+      INTREPID2_TEST_FOR_EXCEPTION(fieldOrdinalOffset != this->basisCardinality_, std::invalid_argument, "Internal error: basis enumeration is incorrect");
+      
+      // initialize tags
+      {
+        const auto & cardinality = this->basisCardinality_;
+        
+        // Basis-dependent initializations
+        const ordinal_type tagSize  = 4;        // size of DoF tag, i.e., number of fields in the tag
+        const ordinal_type posScDim = 0;        // position in the tag, counting from 0, of the subcell dim
+        const ordinal_type posScOrd = 1;        // position in the tag, counting from 0, of the subcell ordinal
+        const ordinal_type posDfOrd = 2;        // position in the tag, counting from 0, of DoF ordinal relative to the subcell
+        
+        OrdinalTypeArray1DHost tagView("tag view", cardinality*tagSize);
+        const int faceDim = 2;
+
+        for (ordinal_type i=0;i<cardinality;++i) {
+          tagView(i*tagSize+0) = faceDim;     // face dimension
+          tagView(i*tagSize+1) = 0;           // face id
+          tagView(i*tagSize+2) = i;           // local dof id
+          tagView(i*tagSize+3) = cardinality; // total number of dofs on this face
+        }
+        
+        // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
+        // tags are constructed on host
+        this->setOrdinalTagData(this->tagToOrdinal_,
+                                this->ordinalToTag_,
+                                tagView,
+                                this->basisCardinality_,
+                                tagSize,
+                                posScDim,
+                                posScOrd,
+                                posDfOrd);
+      }
+    }
+    
+    /** \brief  Returns basis name
+     
+     \return the name of the basis
+     */
+    const char* getName() const override {
+      return "Intrepid2_LegendreBasis_HVOL_TRI";
+    }
+    
+    /** \brief True if orientation is required
+    */
+    virtual bool requireOrientation() const override {
+      return (this->getDegree() > 2);
+    }
+
+    // since the getValues() below only overrides the FEM variant, we specify that
+    // we use the base class's getValues(), which implements the FVD variant by throwing an exception.
+    // (It's an error to use the FVD variant on this basis.)
+    using BasisBase::getValues;
+    
+    /** \brief  Evaluation of a FEM basis on a <strong>reference cell</strong>.
+
+        Returns values of <var>operatorType</var> acting on FEM basis functions for a set of
+        points in the <strong>reference cell</strong> for which the basis is defined.
+
+        \param  outputValues      [out] - variable rank array with the basis values
+        \param  inputPoints       [in]  - rank-2 array (P,D) with the evaluation points
+        \param  operatorType      [in]  - the operator acting on the basis functions
+
+        \remark For rank and dimension specifications of the output array see Section
+        \ref basis_md_array_sec.  Dimensions of <var>ArrayScalar</var> arguments are checked
+        at runtime if HAVE_INTREPID2_DEBUG is defined.
+
+        \remark A FEM basis spans a COMPLETE or INCOMPLETE polynomial space on the reference cell
+        which is a smooth function space. Thus, all operator types that are meaningful for the
+        approximated function space are admissible. When the order of the operator exceeds the
+        degree of the basis, the output array is filled with the appropriate number of zeros.
+    */
+    virtual void getValues( OutputViewType outputValues, const PointViewType inputPoints,
+                           const EOperator operatorType = OPERATOR_VALUE ) const override
+    {
+      auto numPoints = inputPoints.extent_int(0);
+      
+      using FunctorType = Hierarchical_HVOL_TRI_Functor<DeviceType, OutputScalar, PointScalar, OutputViewType, PointViewType>;
+      
+      FunctorType functor(operatorType, outputValues, inputPoints, polyOrder_);
+      
+      const int outputVectorSize = getVectorSizeForHierarchicalParallelism<OutputScalar>();
+      const int pointVectorSize  = getVectorSizeForHierarchicalParallelism<PointScalar>();
+      const int vectorSize = std::max(outputVectorSize,pointVectorSize);
+      const int teamSize = 1; // because of the way the basis functions are computed, we don't have a second level of parallelism...
+
+      auto policy = Kokkos::TeamPolicy<ExecutionSpace>(numPoints,teamSize,vectorSize);
+      Kokkos::parallel_for( policy , functor, "Hierarchical_HVOL_TRI_Functor");
+    }
+
+    /** \brief returns the basis associated to a subCell.
+
+        The bases of the subCell are the restriction to the subCell
+        of the bases of the parent cell.
+        \param [in] subCellDim - dimension of subCell
+        \param [in] subCellOrd - position of the subCell among of the subCells having the same dimension
+        \return pointer to the subCell basis of dimension subCellDim and position subCellOrd
+     */
+    BasisPtr<DeviceType,OutputScalar,PointScalar>
+      getSubCellRefBasis(const ordinal_type subCellDim, const ordinal_type subCellOrd) const override{
+      if(subCellDim == 1) {
+        return Teuchos::rcp(new
+            IntegratedLegendreBasis_HGRAD_LINE<DeviceType,OutputScalar,PointScalar>
+                    (this->basisDegree_));
+      }
+      INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
+    }
+
+    /** \brief Creates and returns a Basis object whose DeviceType template argument is Kokkos::HostSpace::device_type, but is otherwise identical to this.
+     
+        \return Pointer to the new Basis object.
+     */
+    virtual BasisPtr<typename Kokkos::HostSpace::device_type, OutputScalar, PointScalar>
+    getHostBasis() const override {
+      using HostDeviceType = typename Kokkos::HostSpace::device_type;
+      using HostBasisType  = LegendreBasis_HVOL_TRI<HostDeviceType, OutputScalar, PointScalar>;
+      return Teuchos::rcp( new HostBasisType(polyOrder_, pointType_) );
+    }
+  };
+} // end namespace Intrepid2
+
+#endif /* Intrepid2_LegendreBasis_HVOL_TRI_h */

--- a/packages/intrepid2/src/Shared/Intrepid2_Polynomials.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_Polynomials.hpp
@@ -426,11 +426,11 @@ namespace Intrepid2
      
      When alpha = 0, Jacobi coincides with Legendre.
      
-     Compared with the integratedJacobiValues() below, this version uses more memory, but may require fewer floating point computations by reusing the values in jacobiValues.
+     Compared with the shiftedScaledIntegratedJacobiValues() below, this version uses more memory, but may require fewer floating point computations by reusing the values in jacobiValues.
      */
     template<typename OutputValueViewType, typename ScalarType, typename ScalarTypeForScaling>
-    KOKKOS_INLINE_FUNCTION void integratedJacobiValues(OutputValueViewType outputValues, const OutputValueViewType jacobiValues,
-                                                       double alpha, Intrepid2::ordinal_type n, ScalarType x, ScalarTypeForScaling t)
+    KOKKOS_INLINE_FUNCTION void shiftedScaledIntegratedJacobiValues(OutputValueViewType outputValues, const OutputValueViewType jacobiValues,
+                                                                    double alpha, Intrepid2::ordinal_type n, ScalarType x, ScalarTypeForScaling t)
     {
       // reduced flops version: rely on previously computed P_i
       if (n >= 0) outputValues(0) = 1.0;
@@ -466,11 +466,11 @@ namespace Intrepid2
      
      When alpha = 0, Jacobi coincides with Legendre.
      
-     Compared with the integratedJacobiValues() above, this version uses less memory, but may require more floating point computations.
+     Compared with the shiftedScaledIntegratedJacobiValues() above, this version uses less memory, but may require more floating point computations.
      */
     template<typename OutputValueViewType, typename ScalarType, typename ScalarTypeForScaling>
-    KOKKOS_INLINE_FUNCTION void integratedJacobiValues(OutputValueViewType outputValues,
-                                                       double alpha, Intrepid2::ordinal_type n, ScalarType x, ScalarTypeForScaling t)
+    KOKKOS_INLINE_FUNCTION void shiftedScaledIntegratedJacobiValues(OutputValueViewType outputValues,
+                                                                    double alpha, Intrepid2::ordinal_type n, ScalarType x, ScalarTypeForScaling t)
     {
       // memory-conserving version -- place the Jacobi values in the final output container
       shiftedScaledJacobiValues(outputValues, alpha, n, x, t);
@@ -509,8 +509,8 @@ namespace Intrepid2
      These are defined for x in [0,1].  The x derivative of integrated Jacobi is just Jacobi; the only distinction is in the index -- outputValues indices are shifted by 1 relative to shiftedScaledJacobiValues, above.
      */
     template<typename OutputValueViewType, typename ScalarType, typename ScalarTypeForScaling>
-    KOKKOS_INLINE_FUNCTION void integratedJacobiValues_dx(OutputValueViewType outputValues,
-                                                          double alpha, Intrepid2::ordinal_type n, ScalarType x, ScalarTypeForScaling t)
+    KOKKOS_INLINE_FUNCTION void shiftedScaledIntegratedJacobiValues_dx(OutputValueViewType outputValues,
+                                                                       double alpha, Intrepid2::ordinal_type n, ScalarType x, ScalarTypeForScaling t)
     {
       // rather than repeating the somewhat involved implementation of jacobiValues here,
       // call with (n-1), and then move values accordingly
@@ -539,8 +539,8 @@ namespace Intrepid2
      This implementation uses more memory than the one above, but depending on the application may save some computation, in that it can reuse previously computed jacobiValues.
      */
     template<typename OutputValueViewType, typename ScalarType, typename ScalarTypeForScaling>
-    KOKKOS_INLINE_FUNCTION void integratedJacobiValues_dt(OutputValueViewType outputValues, const OutputValueViewType jacobiValues,
-                                                          double alpha, Intrepid2::ordinal_type n, ScalarType x, ScalarTypeForScaling t)
+    KOKKOS_INLINE_FUNCTION void shiftedScaledIntegratedJacobiValues_dt(OutputValueViewType outputValues, const OutputValueViewType jacobiValues,
+                                                                       double alpha, Intrepid2::ordinal_type n, ScalarType x, ScalarTypeForScaling t)
     {
       // reduced flops version: rely on previously computed P_i
       if (n >= 0) outputValues(0) = 0.0;
@@ -564,8 +564,8 @@ namespace Intrepid2
      This implementation requires less memory than the one above, but depending on the application may require some extra computation.
      */
     template<typename OutputValueViewType, typename ScalarType, typename ScalarTypeForScaling>
-    KOKKOS_INLINE_FUNCTION void integratedJacobiValues_dt(OutputValueViewType outputValues,
-                                                          double alpha, Intrepid2::ordinal_type n, ScalarType x, ScalarTypeForScaling t)
+    KOKKOS_INLINE_FUNCTION void shiftedScaledIntegratedJacobiValues_dt(OutputValueViewType outputValues,
+                                                                       double alpha, Intrepid2::ordinal_type n, ScalarType x, ScalarTypeForScaling t)
     {
       // memory-conserving version -- place the Jacobi values in the final output container
       shiftedScaledJacobiValues(outputValues, alpha, n, x, t);

--- a/packages/intrepid2/unit-test/MonolithicExecutable/AnalyticPolynomialsMatchTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/AnalyticPolynomialsMatchTests.cpp
@@ -67,9 +67,9 @@ namespace
   Scalar integratedJacobi(Scalar x, Scalar t, double alpha, const int n, const int derivativeOrder = 0)
   {
     // ideally, we would have closed-form expressions somewhere in here, as we do for integrated Legendre below
-    // for now, though, this is just a thin wrapper around the call to Intrepid2::Polynomials::integratedJacobiValues()
+    // for now, though, this is just a thin wrapper around the call to Intrepid2::Polynomials::shiftedScaledIntegratedJacobiValues()
     auto values = getView<Scalar,Kokkos::HostSpace>("integrated Jacobi values", n+1);
-    Polynomials::integratedJacobiValues(values, alpha, n, x, t);
+    Polynomials::shiftedScaledIntegratedJacobiValues(values, alpha, n, x, t);
     return values(n);
   }
   

--- a/packages/intrepid2/unit-test/MonolithicExecutable/IntegratedJacobiTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/IntegratedJacobiTests.cpp
@@ -72,7 +72,7 @@ namespace
     // for all alpha, t, integrated jacobi should evaluate to 0 at 0.
     Kokkos::View<double*,DeviceType> integratedJacobiView("integrated jacobi values",polyOrder+1);
     
-    using Intrepid2::Polynomials::integratedJacobiValues;
+    using Intrepid2::Polynomials::shiftedScaledIntegratedJacobiValues;
     using Intrepid2::Polynomials::shiftedScaledJacobiValues;
 
     const double x = 0.0;
@@ -85,7 +85,7 @@ namespace
         auto policy = Kokkos::RangePolicy<>(ExecutionSpace(),0,1);
         Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const int dummy_index)
         {
-          integratedJacobiValues(integratedJacobiView, alpha, polyOrder, x, t);
+          shiftedScaledIntegratedJacobiValues(integratedJacobiView, alpha, polyOrder, x, t);
         });
         
         Kokkos::fence();
@@ -110,7 +110,7 @@ namespace
     const int polyOrder = 2;
     Kokkos::View<double*,DeviceType> integratedJacobiView("integrated jacobi values",polyOrder+1);
     
-    using Intrepid2::Polynomials::integratedJacobiValues;
+    using Intrepid2::Polynomials::shiftedScaledIntegratedJacobiValues;
     
     const double alpha = 0.0;
     
@@ -123,7 +123,7 @@ namespace
         auto policy = Kokkos::RangePolicy<>(ExecutionSpace(),0,1);
         Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const int dummy_index)
         {
-          integratedJacobiValues(integratedJacobiView, alpha, polyOrder, x, t);
+          shiftedScaledIntegratedJacobiValues(integratedJacobiView, alpha, polyOrder, x, t);
         });
         
         Kokkos::fence();
@@ -154,7 +154,7 @@ namespace
       {
         for (auto t : t_values)
         {
-          using Intrepid2::Polynomials::integratedJacobiValues;
+          using Intrepid2::Polynomials::shiftedScaledIntegratedJacobiValues;
           using Intrepid2::Polynomials::shiftedScaledJacobiValues;
           
           // wrap invocation in parallel_for just to ensure execution on device (for CUDA)
@@ -162,8 +162,8 @@ namespace
           Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const int dummy_index)
           {
             shiftedScaledJacobiValues(jacobiView, alpha, polyOrder, x, t);
-            integratedJacobiValues(integratedJacobiView, alpha, polyOrder, x, t);
-            integratedJacobiValues(integratedJacobiViewSecondPath, jacobiView, alpha, polyOrder, x, t);
+            shiftedScaledIntegratedJacobiValues(integratedJacobiView, alpha, polyOrder, x, t);
+            shiftedScaledIntegratedJacobiValues(integratedJacobiViewSecondPath, jacobiView, alpha, polyOrder, x, t);
           });
           
           auto integratedJacobiViewSecondPathHost = getHostCopy(integratedJacobiViewSecondPath);
@@ -201,7 +201,7 @@ namespace
       {
         for (auto t : t_values)
         {
-          using Intrepid2::Polynomials::integratedJacobiValues_dt;
+          using Intrepid2::Polynomials::shiftedScaledIntegratedJacobiValues_dt;
           using Intrepid2::Polynomials::shiftedScaledJacobiValues;
           
           // wrap invocation in parallel_for just to ensure execution on device (for CUDA)
@@ -209,8 +209,8 @@ namespace
           Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const int dummy_index)
           {
             shiftedScaledJacobiValues(jacobiView, alpha, polyOrder, x, t);
-            integratedJacobiValues_dt(integratedJacobiView_dt, alpha, polyOrder, x, t);
-            integratedJacobiValues_dt(secondPathIntegratedJacobiView_dt, jacobiView, alpha, polyOrder, x, t);
+            shiftedScaledIntegratedJacobiValues_dt(integratedJacobiView_dt, alpha, polyOrder, x, t);
+            shiftedScaledIntegratedJacobiValues_dt(secondPathIntegratedJacobiView_dt, jacobiView, alpha, polyOrder, x, t);
           });
           
           auto secondPathIntegratedJacobiView_dt_host = getHostCopy(secondPathIntegratedJacobiView_dt);

--- a/packages/intrepid2/unit-test/Projection/test_convergence_TRI.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_convergence_TRI.hpp
@@ -625,7 +625,7 @@ int ConvergenceTri(const bool verbose) {
       std::vector<basisType*> basis_set;
       basis_set.push_back(new typename  CG_NBasis::HCURL_TRI(basisDegree));
       basis_set.push_back(new typename  CG_DNBasis::HCURL_TRI(basisDegree));
-      //basis_set.push_back(new typename  CG_HBasis::HCURL_TRI(basisDegree));
+      basis_set.push_back(new typename  CG_HBasis::HCURL_TRI(basisDegree));
 
       for (auto basisPtr:basis_set) {
         auto& basis = *basisPtr;
@@ -883,7 +883,7 @@ int ConvergenceTri(const bool verbose) {
       std::vector<basisType*> basis_set;
       basis_set.push_back(new typename  CG_NBasis::HDIV_TRI(basisDegree));
       basis_set.push_back(new typename  CG_DNBasis::HDIV_TRI(basisDegree));
-      //basis_set.push_back(new typename  CG_HBasis::HDIV_TRI(basisDegree));
+      basis_set.push_back(new typename  CG_HBasis::HDIV_TRI(basisDegree));
 
       for (auto basisPtr:basis_set) {
         auto& basis = *basisPtr;
@@ -1145,7 +1145,7 @@ int ConvergenceTri(const bool verbose) {
       std::vector<basisType*> basis_set;
       basis_set.push_back(new typename  CG_NBasis::HVOL_TRI(basisDegree-1));
       basis_set.push_back(new typename  CG_DNBasis::HVOL_TRI(basisDegree-1));
-      //basis_set.push_back(new typename  CG_HBasis::HVOL_TRI(basisDegree-1));
+      basis_set.push_back(new typename  CG_HBasis::HVOL_TRI(basisDegree-1));
 
       for (auto basisPtr:basis_set) {
         auto& basis = *basisPtr;


### PR DESCRIPTION
@trilinos/intrepid2

(Accidentally closed #10628, and can't figure out how to reopen that directly, so just putting a new one up here.)

## Motivation
This PR fills in missing H(curl), H(div), and H(vol) hierarchical bases on the triangle.  It also brings the ordering of the existing H^1 basis on the triangle into agreement with the ESEAS implementation of the same basis, placing face basis functions of like polynomial degree together.

Forthcoming PRs will similarly add missing hierarchical bases on the tetrahedron, wedge, and pyramid.

## Testing
Some basic "basis equivalence" tests, which establish that the hierarchical bases span the same space as existing nodal bases, are included here.  Additionally, I have done offline comparison with the ESEAS implementation of each basis, testing up to 8th order, with excellent agreement.