### PR TITLE
Zoltan2: fix inverse permutation logic

### DIFF
--- a/packages/zoltan2/core/src/problems/Zoltan2_OrderingSolution.hpp
+++ b/packages/zoltan2/core/src/problems/Zoltan2_OrderingSolution.hpp
@@ -184,7 +184,7 @@ public:
       for(size_t i=0; i<perm_size_; i++) {
         invperm_[perm_[i]] = i;
       }
-      havePerm_ = true;
+      haveInverse_ = true;
     }
     else {
       // TODO: throw exception


### PR DESCRIPTION
Set ``haveInverse_`` to true after computing the reverse permutation of an OrderingSolution. This looks like it might have been a copy-paste bug, since the functions computePerm and computeInverse are identical except for having "perm" and "inverse" swapped.


<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/zoltan2 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
``haveInverse_`` should be set to true after computing the reverse permutation. ``havePerm_`` is already true since it's in an ``if(havePerm_)`` branch.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->