### PR TITLE
ShyLU FastILU : add an option to use Kokkos-Kernels SpMV for FastSpTRSV

### DIFF
--- a/packages/ifpack2/test/belos/belos_solve.cpp
+++ b/packages/ifpack2/test/belos/belos_solve.cpp
@@ -240,7 +240,11 @@ int main (int argc, char* argv[])
     {
       stackedTimer->stopBaseTimer();
       StackedTimer::OutputOptions options;
+      options.num_histogram=3;
       options.print_warnings = false;
+      options.output_histogram = true;
+      options.output_fraction=true;
+      options.output_minmax = true;
       stackedTimer->report(std::cout, comm, options);
       auto xmlOut = stackedTimer->reportWatchrXML(problem_name, comm);
       if(comm->getRank() == 0)


### PR DESCRIPTION

@trilinos/shylu 

## Motivation

This PR adds an option to use Kokkos-Kernels SpMV for FastSpTRSV, which should improves the solve time.

## Testing

Tested on Weaver host build.

