### PR TITLE
Tpetra:  Use a consistent MPI tag for DistributorActor

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_DistributorActor.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorActor.cpp
@@ -42,14 +42,17 @@
 namespace Tpetra {
 namespace Details {
 
-  DistributorActor::DistributorActor() {
+  DistributorActor::DistributorActor()
+    : mpiTag_(getNewMpiTag())
+  {
 #ifdef HAVE_TPETRA_DISTRIBUTOR_TIMINGS
     makeTimers();
 #endif // HAVE_TPETRA_DISTRIBUTOR_TIMINGS
   }
 
   DistributorActor::DistributorActor(const DistributorActor& otherActor)
-    : requests_(otherActor.requests_)
+    : mpiTag_(otherActor.mpiTag_),
+      requests_(otherActor.requests_)
   {
 #ifdef HAVE_TPETRA_DISTRIBUTOR_TIMINGS
     makeTimers();

--- a/packages/tpetra/core/src/Tpetra_Details_DistributorActor.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorActor.cpp
@@ -43,7 +43,7 @@ namespace Tpetra {
 namespace Details {
 
   DistributorActor::DistributorActor()
-    : mpiTag_(getNewMpiTag())
+    : mpiTag_(1)
   {
 #ifdef HAVE_TPETRA_DISTRIBUTOR_TIMINGS
     makeTimers();

--- a/packages/tpetra/core/src/Tpetra_Details_DistributorActor.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorActor.hpp
@@ -94,7 +94,7 @@ public:
 
 private:
   int getNewMpiTag() {
-    return 0;
+    return 1;
   }
 
   int mpiTag_;
@@ -204,7 +204,7 @@ void DistributorActor::doPosts(const DistributorPlan& plan,
   // (getIndicesTo().is_null()) and others might take the "slow" path for
   // the same doPosts() call, so the path tag must be the same for
   // both.
-  const int pathTag = 0;
+  const int pathTag = 1;
   const int tag = plan.getTag(pathTag);
 
 #ifdef HAVE_TPETRA_DEBUG
@@ -482,7 +482,7 @@ void DistributorActor::doPosts(const DistributorPlan& plan,
   // (plan.getIndicesTo().is_null()) and others might take the "slow" path for
   // the same doPosts() call, so the path tag must be the same for
   // both.
-  const int pathTag = 1;
+  const int pathTag = 2;
   const int tag = plan.getTag(pathTag);
 
 #ifdef HAVE_TPETRA_DEBUG

--- a/packages/tpetra/core/src/Tpetra_Details_DistributorActor.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorActor.hpp
@@ -91,6 +91,12 @@ public:
   bool isReady() const;
 
 private:
+  int getNewMpiTag() {
+    return 0;
+  }
+
+  int mpiTag_;
+
   Teuchos::Array<Teuchos::RCP<Teuchos::CommRequest<int>>> requests_;
 
 #ifdef HAVE_TPETRA_DISTRIBUTOR_TIMINGS

--- a/packages/tpetra/core/src/Tpetra_Details_DistributorActor.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorActor.hpp
@@ -93,10 +93,6 @@ public:
   bool isReady() const;
 
 private:
-  int getNewMpiTag() {
-    return 1;
-  }
-
   int mpiTag_;
 
   Teuchos::Array<Teuchos::RCP<Teuchos::CommRequest<int>>> requests_;

--- a/packages/tpetra/core/src/Tpetra_Details_DistributorActor.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorActor.hpp
@@ -48,6 +48,8 @@
 #include "Teuchos_RCP.hpp"
 #include "Teuchos_Time.hpp"
 
+#include "Kokkos_TeuchosCommAdapters.hpp"
+
 namespace Tpetra {
 namespace Details {
 

--- a/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.cpp
@@ -644,7 +644,7 @@ void DistributorPlan::computeReceives()
   const int numProcs = comm_->getSize();
 
   // MPI tag for nonblocking receives and blocking sends in this method.
-  const int pathTag = 2;
+  const int pathTag = 0;
   const int tag = getTag(pathTag);
 
   // toProcsFromMe[i] == the number of messages sent by this process

--- a/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.cpp
@@ -86,7 +86,6 @@ DistributorPlan::DistributorPlan(Teuchos::RCP<const Teuchos::Comm<int>> comm)
     howInitialized_(DISTRIBUTOR_NOT_INITIALIZED),
     reversePlan_(Teuchos::null),
     sendType_(DISTRIBUTOR_SEND),
-    useDistinctTags_(useDistinctTags_default),
     sendMessageToSelf_(false),
     numSendsToOtherProcs_(0),
     maxSendLength_(0),
@@ -99,7 +98,6 @@ DistributorPlan::DistributorPlan(const DistributorPlan& otherPlan)
     howInitialized_(DISTRIBUTOR_INITIALIZED_BY_COPY),
     reversePlan_(otherPlan.reversePlan_),
     sendType_(otherPlan.sendType_),
-    useDistinctTags_(otherPlan.useDistinctTags_),
     sendMessageToSelf_(otherPlan.sendMessageToSelf_),
     numSendsToOtherProcs_(otherPlan.numSendsToOtherProcs_),
     procIdsToSendTo_(otherPlan.procIdsToSendTo_),
@@ -616,7 +614,6 @@ void DistributorPlan::createReversePlan() const
   reversePlan_->procsFrom_ = procIdsToSendTo_;
   reversePlan_->startsFrom_ = startsTo_;
   reversePlan_->indicesFrom_ = indicesTo_;
-  reversePlan_->useDistinctTags_ = useDistinctTags_;
 }
 
 void DistributorPlan::computeReceives()
@@ -639,12 +636,7 @@ void DistributorPlan::computeReceives()
   const int myRank = comm_->getRank();
   const int numProcs = comm_->getSize();
 
-  // MPI tag for nonblocking receives and blocking sends in this method.
-  // Note that useDistinctTags_ is deprecated.  After deprecation cycle is complete, we should just
-  // use 0 here (although it's highly unlikely the Actor's communication will conflict with this
-  // communication, we still avoid the use of tag 0 in Actor, so the hardcoded 0 is in fact still
-  // unique with respect to the Actor code paths)
-  const int tag = useDistinctTags_ ? 0 : comm_->getTag();
+  const int mpiTag = 0;
 
   // toProcsFromMe[i] == the number of messages sent by this process
   // to process i.  The data in numSendsToOtherProcs_, procIdsToSendTo_, and lengthsTo_
@@ -786,7 +778,7 @@ void DistributorPlan::computeReceives()
     lengthsFromBuffers[i].resize (1);
     lengthsFromBuffers[i][0] = as<size_t> (0);
     requests[i] = ireceive<int, size_t> (lengthsFromBuffers[i], anySourceProc,
-        tag, *comm_);
+        mpiTag, *comm_);
   }
 
   // Post the sends: Tell each process to which we are sending how
@@ -803,7 +795,7 @@ void DistributorPlan::computeReceives()
       // this communication pattern will send that process
       // lengthsTo_[i] blocks of packets.
       const size_t* const lengthsTo_i = &lengthsTo_[i];
-      send<int, size_t> (lengthsTo_i, 1, as<int> (procIdsToSendTo_[i]), tag, *comm_);
+      send<int, size_t> (lengthsTo_i, 1, as<int> (procIdsToSendTo_[i]), mpiTag, *comm_);
     }
     else {
       // We don't need a send in the self-message case.  If this

--- a/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.cpp
@@ -115,10 +115,6 @@ DistributorPlan::DistributorPlan(const DistributorPlan& otherPlan)
     indicesFrom_(otherPlan.indicesFrom_)
 { }
 
-int DistributorPlan::getTag(const int pathTag) const {
-  return useDistinctTags_ ? pathTag : comm_->getTag();
-}
-
 size_t DistributorPlan::createFromSends(const Teuchos::ArrayView<const int>& exportProcIDs) {
   using Teuchos::outArg;
   using Teuchos::REDUCE_MAX;
@@ -644,8 +640,11 @@ void DistributorPlan::computeReceives()
   const int numProcs = comm_->getSize();
 
   // MPI tag for nonblocking receives and blocking sends in this method.
-  const int pathTag = 0;
-  const int tag = getTag(pathTag);
+  // Note that useDistinctTags_ is deprecated.  After deprecation cycle is complete, we should just
+  // use 0 here (although it's highly unlikely the Actor's communication will conflict with this
+  // communication, we still avoid the use of tag 0 in Actor, so the hardcoded 0 is in fact still
+  // unique with respect to the Actor code paths)
+  const int tag = useDistinctTags_ ? 0 : comm_->getTag();
 
   // toProcsFromMe[i] == the number of messages sent by this process
   // to process i.  The data in numSendsToOtherProcs_, procIdsToSendTo_, and lengthsTo_

--- a/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.hpp
@@ -104,12 +104,6 @@ public:
   DistributorPlan(Teuchos::RCP<const Teuchos::Comm<int>> comm);
   DistributorPlan(const DistributorPlan& otherPlan);
 
-  //! Get the tag to use for receives and sends.
-  ///
-  /// See useDistinctTags_.  This is called in doPosts() (both
-  /// variants) and computeReceives().
-  int getTag(const int pathTag) const;
-
   size_t createFromSends(const Teuchos::ArrayView<const int>& exportProcIDs);
   void createFromRecvs(const Teuchos::ArrayView<const int>& remoteProcIDs);
   void createFromSendsAndRecvs(const Teuchos::ArrayView<const int>& exportProcIDs,

--- a/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.hpp
@@ -49,10 +49,6 @@
 namespace Tpetra {
 namespace Details {
 
-namespace {
-  const bool useDistinctTags_default = true;
-}
-
 /// \brief The type of MPI send that Distributor should use.
 ///
 /// This is an implementation detail of Distributor.  Please do
@@ -115,7 +111,6 @@ public:
 
   Teuchos::RCP<const Teuchos::Comm<int>> getComm() const { return comm_; }
   EDistributorSendType getSendType() const { return sendType_; }
-  bool useDistinctTags() const { return useDistinctTags_; }
   size_t getNumReceives() const { return numReceives_; }
   size_t getNumSends() const { return numSendsToOtherProcs_; }
   bool hasSelfMessage() const { return sendMessageToSelf_; }
@@ -153,19 +148,6 @@ private:
   //! @name Parameters read in from the Teuchos::ParameterList
   //@{
   EDistributorSendType sendType_;
-
-  /// \brief Whether to use different tags for different code paths.
-  ///
-  /// There are currently three code paths in Distributor that post
-  /// receives and sends:
-  ///
-  /// 1. Three-argument variant of doPosts()
-  /// 2. Four-argument variant of doPosts()
-  /// 3. computeReceives()
-  ///
-  /// If this option is true, Distributor will use a distinct
-  /// message tag for each of these paths.
-  bool useDistinctTags_;
   //@}
 
   bool sendMessageToSelf_;


### PR DESCRIPTION
@trilinos/tpetra 

## Motivation
Clean up MPI tagging in DistributorActor, and remove last vestiges of the deprecated useDistinctTags option.  Enable a "unique tag per Actor" strategy to be easily implemented if necessary.  Clarify what the actual tag values are and how to set them.

## Testing
Existing Tpetra tests that use Distributor directly and indirectly continue to pass.