### PR TITLE
Adds getEigenEstimates() method and changes positive-definite error

### DIFF
--- a/packages/belos/epetra/test/BlockCG/test_pseudo_pcg_hb.cpp
+++ b/packages/belos/epetra/test/BlockCG/test_pseudo_pcg_hb.cpp
@@ -243,6 +243,13 @@ int main(int argc, char *argv[]) {
         if (actRes > tol) badRes = true;
       }
       std::cout<<std::endl<<"Condition Estimate: " << solver->getConditionEstimate() << std::endl;
+
+      auto ee = solver->getEigenEstimates();
+      std::cout << std::endl << "Eigen estimates:\n" << ee.size() << " " << ee << std::endl;
+      for (int i=0; i < ee.size(); i++) {
+        std::cout << " " << ee[i];
+        if (i > 0 && (i % 10 == 0)) std::cout << std::endl;
+      }
     }
 
     success = ret==Belos::Converged && !badRes;

--- a/packages/belos/src/BelosCGIter.hpp
+++ b/packages/belos/src/BelosCGIter.hpp
@@ -497,9 +497,11 @@ class CGIter : virtual public CGIteration<ScalarType,MV,OP> {
       alpha[0] = rHz[0] / pAp[0];
       
       // Check that alpha is a positive number!
-      if(assertPositiveDefiniteness_)
-        TEUCHOS_TEST_FOR_EXCEPTION( SCT::real(alpha[0]) <= zero, CGIterateFailure,
+      if(assertPositiveDefiniteness_) {
+        TEUCHOS_TEST_FOR_EXCEPTION( SCT::real(alpha[0]) <= zero, CGPositiveDefiniteFailure,
                                     "Belos::CGIter::iterate(): non-positive value for p^H*A*p encountered!" );
+      }
+
       //
       // Update the solution vector x := x + alpha * P_
       //

--- a/packages/belos/src/BelosCGIteration.hpp
+++ b/packages/belos/src/BelosCGIteration.hpp
@@ -106,7 +106,16 @@ namespace Belos {
   class CGIterateFailure : public BelosError {public:
     CGIterateFailure(const std::string& what_arg) : BelosError(what_arg)
     {}};
-  
+
+  /** \brief CGPositiveDefiniteFailure is thrown when the the CG 'alpha = p^H*A*P' value
+   * is less than zero, indicating a breakdown in the computation due to roundoff or
+   * a non-positive-definite matrix.
+   *
+   */
+  class CGPositiveDefiniteFailure : public CGIterateFailure {public:
+    CGPositiveDefiniteFailure(const std::string& what_arg) : CGIterateFailure(what_arg)
+    {}};
+
   /** \brief CGIterationOrthoFailure is thrown when the CGIteration object is unable to
    * compute independent direction vectors in the CGIteration::iterate() routine. 
    *

--- a/packages/belos/src/BelosCGSingleRedIter.hpp
+++ b/packages/belos/src/BelosCGSingleRedIter.hpp
@@ -502,7 +502,7 @@ class CGSingleRedIter : virtual public CGIteration<ScalarType,MV,OP> {
     alpha = rHz_ / delta;
 
     // Check that alpha is a positive number!
-    TEUCHOS_TEST_FOR_EXCEPTION( SCT::real(alpha) <= zero, CGIterateFailure,
+    TEUCHOS_TEST_FOR_EXCEPTION( SCT::real(alpha) <= zero, CGPositiveDefiniteFailure,
       "Belos::CGSingleRedIter::iterate(): non-positive value for p^H*A*p encountered!" );
  
     ////////////////////////////////////////////////////////////////
@@ -563,7 +563,7 @@ class CGSingleRedIter : virtual public CGIteration<ScalarType,MV,OP> {
         alpha = rHz_ / (delta - (beta*rHz_ / alpha));
         //
         // Check that alpha is a positive number!
-        TEUCHOS_TEST_FOR_EXCEPTION( SCT::real(alpha) <= zero, CGIterateFailure,
+        TEUCHOS_TEST_FOR_EXCEPTION( SCT::real(alpha) <= zero, CGPositiveDefiniteFailure,
                                     "Belos::CGSingleRedIter::iterate(): non-positive value for p^H*A*p encountered!" );
 
         //
@@ -628,7 +628,7 @@ class CGSingleRedIter : virtual public CGIteration<ScalarType,MV,OP> {
         alpha = rHz_ / (delta - (beta*rHz_ / alpha));
         //
         // Check that alpha is a positive number!
-        TEUCHOS_TEST_FOR_EXCEPTION( SCT::real(alpha) <= zero, CGIterateFailure,
+        TEUCHOS_TEST_FOR_EXCEPTION( SCT::real(alpha) <= zero, CGPositiveDefiniteFailure,
                                     "Belos::CGSingleRedIter::iterate(): non-positive value for p^H*A*p encountered!" );
 
         //

--- a/packages/belos/src/BelosPseudoBlockCGIter.hpp
+++ b/packages/belos/src/BelosPseudoBlockCGIter.hpp
@@ -435,7 +435,7 @@ namespace Belos {
     if ( assertPositiveDefiniteness_ )
         for (i=0; i<numRHS_; ++i)
             TEUCHOS_TEST_FOR_EXCEPTION( SCT::real(rHz[i]) < zero,
-                                CGIterateFailure,
+                                CGPositiveDefiniteFailure,
                                 "Belos::PseudoBlockCGIter::iterate(): negative value for r^H*M*r encountered!" );
 
     ////////////////////////////////////////////////////////////////
@@ -456,7 +456,7 @@ namespace Belos {
         if ( assertPositiveDefiniteness_ )
             // Check that pAp[i] is a positive number!
             TEUCHOS_TEST_FOR_EXCEPTION( SCT::real(pAp[i]) <= zero,
-                                CGIterateFailure,
+                                CGPositiveDefiniteFailure,
                                 "Belos::PseudoBlockCGIter::iterate(): non-positive value for p^H*A*p encountered!" );
 
         alpha(i,i) = rHz[i] / pAp[i];
@@ -500,7 +500,7 @@ namespace Belos {
       if ( assertPositiveDefiniteness_ )
           for (i=0; i<numRHS_; ++i)
               TEUCHOS_TEST_FOR_EXCEPTION( SCT::real(rHz[i]) < zero,
-                                  CGIterateFailure,
+                                  CGPositiveDefiniteFailure,
                                   "Belos::PseudoBlockCGIter::iterate(): negative value for r^H*M*r encountered!" );
       //
       // Update the search directions.
@@ -513,7 +513,7 @@ namespace Belos {
       }
 
       // Condition estimate (if needed)
-      if (doCondEst_) {
+      if (doCondEst_ && (iter_ - 1) < diag_.size()) {
         if (iter_ > 1) {
           diag_[iter_-1]    = Teuchos::ScalarTraits<ScalarType>::real((beta_old_ * beta_old_ * pAp_old_ + pAp[0]) / rHz_old[0]);
           offdiag_[iter_-2] = -Teuchos::ScalarTraits<ScalarType>::real(beta_old_ * pAp_old_ / (sqrt( rHz_old[0] * rHz_old2_)));

--- a/packages/belos/src/BelosPseudoBlockStochasticCGIter.hpp
+++ b/packages/belos/src/BelosPseudoBlockStochasticCGIter.hpp
@@ -448,7 +448,7 @@ namespace Belos {
     if ( assertPositiveDefiniteness_ )
         for (i=0; i<numRHS_; ++i)
             TEUCHOS_TEST_FOR_EXCEPTION( SCT::real(rHz[i]) < zero,
-                                CGIterateFailure,
+                                CGPositiveDefiniteFailure,
                                 "Belos::PseudoBlockStochasticCGIter::iterate(): negative value for r^H*M*r encountered!" );
 
     ////////////////////////////////////////////////////////////////
@@ -471,7 +471,7 @@ namespace Belos {
         if ( assertPositiveDefiniteness_ )
             // Check that pAp[i] is a positive number!
             TEUCHOS_TEST_FOR_EXCEPTION( SCT::real(pAp[i]) <= zero,
-                                CGIterateFailure,
+                                CGPositiveDefiniteFailure,
                                 "Belos::PseudoBlockStochasticCGIter::iterate(): non-positive value for p^H*A*p encountered!" );
 
         alpha(i,i) = rHz[i] / pAp[i];
@@ -522,7 +522,7 @@ namespace Belos {
       if ( assertPositiveDefiniteness_ )
           for (i=0; i<numRHS_; ++i)
               TEUCHOS_TEST_FOR_EXCEPTION( SCT::real(rHz[i]) < zero,
-                                  CGIterateFailure,
+                                  CGPositiveDefiniteFailure,
                                   "Belos::PseudoBlockStochasticCGIter::iterate(): negative value for r^H*M*r encountered!" );
       //
       // Update the search directions.

--- a/packages/belos/tpetra/test/BlockCG/test_pseudo_bl_cg_hb.cpp
+++ b/packages/belos/tpetra/test/BlockCG/test_pseudo_bl_cg_hb.cpp
@@ -224,8 +224,15 @@ int main(int argc, char *argv[]) {
       if (actRes > tol) badRes = true;
     }
 
-    if (proc_verbose)
+    if (proc_verbose) {
       std::cout<<std::endl<<"Condition Estimate: " << SCT::real(solver.getConditionEstimate()) << std::endl;
+      auto ee = solver.getEigenEstimates();
+      std::cout << std::endl << "Eigen estimates:\n" << ee.size() << " " << ee << std::endl;
+      for (int i=0; i < ee.size(); i++) {
+        std::cout << " " << ee[i];
+        if (i > 0 && (i % 10 == 0)) std::cout << std::endl;
+      }
+    }
 
     success = (ret==Belos::Converged && !badRes);
 


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/belos

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The getEigenEstimates() method returns all the eigenvalues computed
by LAPACK during the condition estimate computation.  The condition
estimate code is only provided by the pseudo-block CG solver at this
time.  There are Epetra and Tpetra tests updated to call this method.

A new CGPositiveDefiniteFailure error class created to enable users
to trap iteration errors that are specifically due to the positive
definiteness checks in the CG solvers.  Any CG iteration that uses
the errors provided in the BelosCGIteration header have been changed
to throw this new error.  The error inherits from the CGIterateFailure
class to address backwards compatibility.

This commit addresses the user request in this issue:

https://github.com/trilinos/Trilinos/issues/10446

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes https://github.com/trilinos/Trilinos/issues/10446
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
These changes were provided by the stakeholder Steve Kennon, reviewed, and modified before integration.

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
OSX GCC11 serial and CLANG parallel

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->