### PR TITLE
panzer: use Kokkos::ScopeGuard in periodic_32bit_int_limit.cpp test

### DIFF
--- a/packages/panzer/adapters-stk/test/periodic_bcs/periodic_32bit_int_limit.cpp
+++ b/packages/panzer/adapters-stk/test/periodic_bcs/periodic_32bit_int_limit.cpp
@@ -40,7 +40,7 @@ TEUCHOS_UNIT_TEST(periodic_bcs, 32_bit_int_limit)
   setenv("IOSS_PROPERTIES", "DECOMPOSITION_METHOD=rib", 1);
 
   Teuchos::RCP<Teuchos::MpiComm<int>> Comm = Teuchos::rcp( new Teuchos::MpiComm<int>(MPI_COMM_WORLD) );
-  Kokkos::initialize();
+  Kokkos::ScopeGuard();
 
   using topo_RCP = Teuchos::RCP<const shards::CellTopology>;
   using basis_RCP = Teuchos::RCP<Intrepid2::Basis<PHX::Device::execution_space,double,double>>;
@@ -181,6 +181,4 @@ TEUCHOS_UNIT_TEST(periodic_bcs, 32_bit_int_limit)
       }
     }
   }
-
-  Kokkos::finalize();
 }


### PR DESCRIPTION
Replace Kokkos::initialize/finalize with ScopeGuard to prevent future
test failures with kokkos@3.7.00 of the form:
0. periodic_bcs_32_bit_int_limit_UnitTest ... Calling OpenMP::initialize after OpenMP::finalize is illegal

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/panzer @rppawlo 

## Motivation
Prevent runtime failures of the test with OpenMP backend with future kokkos@3.7.00 release of the form:
```
Calling OpenMP::initialize after OpenMP::finalize is illegal
```

Use of ScopeGuard helps allow order of initialize and finalize to be handled appropriately

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Locally tested on weaver testbed with kokkos and kokkos-kernels' develop branches via source override
**Configure**:
```bash
export ATDM_CONFIG_REGISTER_CUSTOM_CONFIG_DIR=$TRILINOS_PATH/cmake/std/atdm/contributed/weaver
source $TRILINOS_PATH/cmake/std/atdm/load-env.sh weaver-gnu-7.2.0-openmp-release-debug
export ATDM_CONFIG_USE_NINJA=OFF
module list
cmake \
-G"Unix Makefiles" \
-DTrilinos_CONFIGURE_OPTIONS_FILE:STRING=cmake/std/atdm/ATDMDevEnv.cmake \
-DCMAKE_INSTALL_PREFIX=$PWD/install \
-DCMAKE_CXX_STANDARD="14" \
  -DKokkos_SOURCE_DIR_OVERRIDE:STRING=kokkos \
  -DKokkosKernels_SOURCE_DIR_OVERRIDE:STRING=kokkos-kernels \
-DTrilinos_ENABLE_ALL_PACKAGES=ON \
-DTrilinos_ENABLE_TESTS=OFF \
-DPanzer_ENABLE_TESTS=ON \
-DTrilinos_ENABLE_SEACAS=ON \
-DAmesos2_ENABLE_SuperLU=OFF \
-DTPL_ENABLE_SuperLUDist=OFF \
-DTPL_ENABLE_ParMETIS=OFF \
$TRILINOS_PATH
```

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->