### PR TITLE
Belos: Removes unused Failure classes inheriting from Belos::Error

### DIFF
--- a/packages/belos/src/BelosFixedPointIteration.hpp
+++ b/packages/belos/src/BelosFixedPointIteration.hpp
@@ -72,37 +72,6 @@ namespace Belos {
     {}
   };
 
-  //! @name FixedPointIteration Exceptions
-  //@{ 
-  
-  /** \brief FixedPointIterationInitFailure is thrown when the FixedPointIteration object is unable to
-   * generate an initial iterate in the FixedPointIteration::initialize() routine. 
-   *
-   * This std::exception is thrown from the FixedPointIteration::initialize() method, which is
-   * called by the user or from the FixedPointIteration::iterate() method if isInitialized()
-   * == \c false.
-   *
-   * In the case that this std::exception is thrown, 
-   * FixedPointIteration::isInitialized() will be \c false and the user will need to provide
-   * a new initial iterate to the iteration.
-   */
-  class FixedPointIterationInitFailure : public BelosError {public:
-    FixedPointIterationInitFailure(const std::string& what_arg) : BelosError(what_arg)
-    {}};
-
-  /** \brief FixedPointIterateFailure is thrown when the FixedPointIteration object is unable to
-   * compute the next iterate in the FixedPointIteration::iterate() routine. 
-   *
-   * This std::exception is thrown from the FixedPointIteration::iterate() method.
-   *
-   */
-  class FixedPointIterateFailure : public BelosError {public:
-    FixedPointIterateFailure(const std::string& what_arg) : BelosError(what_arg)
-    {}};
-  
-  //@}
-
-
 template<class ScalarType, class MV, class OP>
 class FixedPointIteration : virtual public Iteration<ScalarType,MV,OP> {
 

--- a/packages/belos/src/BelosLSQRIteration.hpp
+++ b/packages/belos/src/BelosLSQRIteration.hpp
@@ -105,21 +105,6 @@ namespace Belos {
   //! @name LSQRIteration Exceptions
   //@{ 
   
-  /** \brief LSQRIterationInitFailure is thrown when the LSQRIteration object is
-   * unable to generate an initial iterate in the initialize() routine. 
-   *
-   * This std::exception is thrown from the initialize() method, which is
-   * called by the user or from the iterate() method if isInitialized()
-   * == \c false.
-   *
-   * In the case that this std::exception is thrown, 
-   * isInitialized() will be \c false and the user will need to provide
-   * a new initial iterate to the iteration.
-   */
-class LSQRIterationInitFailure : public BelosError {public:
-      LSQRIterationInitFailure(const std::string& what_arg) : BelosError(what_arg)
-    {}};
-
   /** \brief LSQRIterateFailure is thrown when the LSQRIteration object is unable to
    * compute the next iterate in the iterate() routine. 
    *

--- a/packages/belos/src/BelosMinresIteration.hpp
+++ b/packages/belos/src/BelosMinresIteration.hpp
@@ -92,21 +92,6 @@ namespace Belos {
   //! @name MinresIteration Exceptions
   //@{ 
   
-  /** \brief MinresIterationInitFailure is thrown when the MinresIteration object is unable to
-   * generate an initial iterate in the MinresIteration::initialize() routine.
-   *
-   * This std::exception is thrown from the MinresIteration::initialize() method, which is
-   * called by the user or from the MinresIteration::iterate() method if isInitialized()
-   * == \c false.
-   *
-   * In the case that this std::exception is thrown, 
-   * MinresIteration::isInitialized() will be \c false and the user will need to provide
-   * a new initial iterate to the iteration.
-   */
-  class MinresIterationInitFailure : public BelosError {public:
-    MinresIterationInitFailure(const std::string& what_arg) : BelosError(what_arg)
-    {}};
-
   /** \brief MinresIterateFailure is thrown when the MinresIteration object is unable to
    * compute the next iterate in the MinresIteration::iterate() routine.
    *

--- a/packages/belos/src/BelosPCPGSolMgr.hpp
+++ b/packages/belos/src/BelosPCPGSolMgr.hpp
@@ -102,16 +102,6 @@ namespace Belos {
     PCPGSolMgrLAPACKFailure(const std::string& what_arg) : BelosError(what_arg)
     {}};
 
-  /** \brief PCPGSolMgrRecyclingFailure is thrown when any problem occurs in using/creating
-   * the recycling subspace.
-   *
-   * The PCPGSolMgr::solve() method throws the exception.
-   *
-   */
-  class PCPGSolMgrRecyclingFailure : public BelosError {public:
-    PCPGSolMgrRecyclingFailure(const std::string& what_arg) : BelosError(what_arg)
-    {}};
-
   //@}
 
 
@@ -902,14 +892,6 @@ ReturnType PCPGSolMgr<ScalarType,MV,OP,true>::solve() {
                                "Belos::PCPGSolMgr::solve(): Invalid return from PCPGIter::iterate().");
           } // end if
         } // end try
-        catch (const PCPGIterOrthoFailure &e) {
-
-          // Check to see if the most recent solution yielded convergence.
-          sTest_->checkStatus( &*pcpg_iter );
-          if (convTest_->getStatus() != Passed)
-            isConverged = false;
-          break;
-        }
         catch (const std::exception &e) {
           printer_->stream(Errors) << "Error! Caught exception in PCPGIter::iterate() at iteration "
                                    << pcpg_iter->getNumIters() << std::endl

--- a/packages/belos/src/BelosPseudoBlockCGSolMgr.hpp
+++ b/packages/belos/src/BelosPseudoBlockCGSolMgr.hpp
@@ -96,16 +96,6 @@ namespace Belos {
     PseudoBlockCGSolMgrLinearProblemFailure(const std::string& what_arg) : BelosError(what_arg)
     {}};
 
-  /** \brief PseudoBlockCGSolMgrOrthoFailure is thrown when the orthogonalization manager is
-   * unable to generate orthonormal columns from the initial basis vectors.
-   *
-   * This std::exception is thrown from the PseudoBlockCGSolMgr::solve() method.
-   *
-   */
-  class PseudoBlockCGSolMgrOrthoFailure : public BelosError {public:
-    PseudoBlockCGSolMgrOrthoFailure(const std::string& what_arg) : BelosError(what_arg)
-    {}};
-
 
   // Partial specialization for unsupported ScalarType types.
   // This contains a stub implementation.

--- a/packages/belos/src/BelosPseudoBlockGmresIter.hpp
+++ b/packages/belos/src/BelosPseudoBlockGmresIter.hpp
@@ -122,22 +122,6 @@ namespace Belos {
   //! @name PseudoBlockGmresIter Exceptions
   //@{ 
   
-  /** \brief PseudoBlockGmresIterInitFailure is thrown when the PseudoBlockGmresIter object is unable to
-   * generate an initial iterate in the PseudoBlockGmresIter::initialize() routine. 
-   *
-   * This std::exception is thrown from the PseudoBlockGmresIter::initialize() method, which is
-   * called by the user or from the PseudoBlockGmresIter::iterate() method if isInitialized()
-   * == \c false.
-   *
-   * In the case that this std::exception is thrown, 
-   * PseudoBlockGmresIter::isInitialized() will be \c false and the user will need to provide
-   * a new initial iterate to the iteration.
-   *
-   */
-  class PseudoBlockGmresIterInitFailure : public BelosError {public:
-    PseudoBlockGmresIterInitFailure(const std::string& what_arg) : BelosError(what_arg)
-    {}};
-  
   /** \brief PseudoBlockGmresIterOrthoFailure is thrown when the orthogonalization manager is
    * unable to generate orthonormal columns from the new basis vectors.
    *

--- a/packages/belos/src/BelosPseudoBlockTFQMRIter.hpp
+++ b/packages/belos/src/BelosPseudoBlockTFQMRIter.hpp
@@ -110,38 +110,6 @@ namespace Belos {
     {}
   };
 
-  
-  //! @name PseudoBlockTFQMRIter Exceptions
-  //@{
-  
-  /** \brief PseudoBlockTFQMRIterInitFailure is thrown when the PseudoBlockTFQMRIter object is unable to
-   * generate an initial iterate in the PseudoBlockTFQMRIter::initialize() routine.
-   *
-   * This std::exception is thrown from the PseudoBlockTFQMRIter::initialize() method, which is
-   * called by the user or from the PseudoBlockTFQMRIter::iterate() method if isInitialized()
-   * == \c false.
-   *
-   * In the case that this std::exception is thrown,
-   * PseudoBlockTFQMRIter::isInitialized() will be \c false and the user will need to provide
-   * a new initial iterate to the iteration.
-   */
-  class PseudoBlockTFQMRIterInitFailure : public BelosError {public:
-    PseudoBlockTFQMRIterInitFailure(const std::string& what_arg) : BelosError(what_arg)
-    {}};
-  
-  /** \brief PseudoBlockTFQMRIterateFailure is thrown when the PseudoBlockTFQMRIter object is unable to
-   * compute the next iterate in the PseudoBlockTFQMRIter::iterate() routine.
-   *
-   * This std::exception is thrown from the PseudoBlockTFQMRIter::iterate() method.
-   *
-   */
-  class PseudoBlockTFQMRIterateFailure : public BelosError {public:
-    PseudoBlockTFQMRIterateFailure(const std::string& what_arg) : BelosError(what_arg)
-    {}};
-  
-  //@}
-
-
   template <class ScalarType, class MV, class OP>
   class PseudoBlockTFQMRIter : public Iteration<ScalarType,MV,OP> { 
   public:

--- a/packages/belos/src/BelosRCGSolMgr.hpp
+++ b/packages/belos/src/BelosRCGSolMgr.hpp
@@ -128,16 +128,6 @@ namespace Belos {
     RCGSolMgrLAPACKFailure(const std::string& what_arg) : BelosError(what_arg)
     {}};
 
-  /** \brief RCGSolMgrRecyclingFailure is thrown when any problem occurs in using/creating
-   * the recycling subspace.
-   *
-   * This exception is thrown from the RCGSolMgr::solve() method.
-   *
-   */
-  class RCGSolMgrRecyclingFailure : public BelosError {public:
-    RCGSolMgrRecyclingFailure(const std::string& what_arg) : BelosError(what_arg)
-    {}};
-
   //@}
 
 

--- a/packages/belos/src/BelosTFQMRIter.hpp
+++ b/packages/belos/src/BelosTFQMRIter.hpp
@@ -110,21 +110,6 @@ namespace Belos {
   //! @name TFQMRIter Exceptions
   //@{
   
-  /** \brief TFQMRIterInitFailure is thrown when the TFQMRIter object is unable to
-   * generate an initial iterate in the TFQMRIter::initialize() routine.
-   *
-   * This std::exception is thrown from the TFQMRIter::initialize() method, which is
-   * called by the user or from the TFQMRIter::iterate() method if isInitialized()
-   * == \c false.
-   *
-   * In the case that this std::exception is thrown,
-   * TFQMRIter::isInitialized() will be \c false and the user will need to provide
-   * a new initial iterate to the iteration.
-   */
-  class TFQMRIterInitFailure : public BelosError {public:
-    TFQMRIterInitFailure(const std::string& what_arg) : BelosError(what_arg)
-    {}};
-  
   /** \brief TFQMRIterateFailure is thrown when the TFQMRIter object is unable to
    * compute the next iterate in the TFQMRIter::iterate() routine.
    *


### PR DESCRIPTION

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/belos 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

There are many Failure classes that are defined in the iteration
classes and solver managers that are not used.  Many of these are
the result of general code copying during the development of new
solvers.  However, if they are not being used, they should be
removed to improve the general clarity of the code.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Mac OSX GCC11 serial and CLANG parallel

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->