### PR TITLE
Intrepid2: add getHostBasis() implementation to HGrad Basis classes

### DIFF
--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C2_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C2_FEM.hpp
@@ -291,6 +291,10 @@ namespace Intrepid2 {
       return "Intrepid2_HGRAD_HEX_C2_FEM";
     }
 
+    BasisPtr<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>
+    getHostBasis() const override{
+      return Teuchos::rcp(new Basis_HGRAD_HEX_C2_FEM<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>());
+    }
   };
 }// namespace Intrepid2
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_C1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_C1_FEM.hpp
@@ -227,6 +227,11 @@ namespace Intrepid2 {
       return "Intrepid2_HGRAD_LINE_C1_FEM";
     }
 
+    BasisPtr<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>
+    getHostBasis() const override{
+      return Teuchos::rcp(new Basis_HGRAD_LINE_C1_FEM<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>());
+    }
+
   };
 
 }// namespace Intrepid2

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_C2_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_C2_FEM.hpp
@@ -248,6 +248,10 @@ namespace Intrepid2 {
       return "Intrepid2_HGRAD_QUAD_C2_FEM";
     }
 
+    BasisPtr<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>
+    getHostBasis() const override{
+      return Teuchos::rcp(new Basis_HGRAD_QUAD_C2_FEM<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>());
+    }  
   };
 }// namespace Intrepid2
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_C2_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_C2_FEM.hpp
@@ -248,6 +248,10 @@ namespace Intrepid2 {
       return "Intrepid2_HGRAD_TET_C2_FEM";
     }
 
+    BasisPtr<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>
+    getHostBasis() const override{
+      return Teuchos::rcp(new Basis_HGRAD_TET_C2_FEM<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>());
+    }
   };
 }// namespace Intrepid2
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_C2_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_C2_FEM.hpp
@@ -237,6 +237,10 @@ namespace Intrepid2 {
       return "Intrepid2_HGRAD_TRI_C2_FEM";
     }
 
+    BasisPtr<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>
+    getHostBasis() const override{
+      return Teuchos::rcp(new Basis_HGRAD_TRI_C2_FEM<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>());
+    }  
   };
 
 }// namespace Intrepid2

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_WEDGE_C1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_WEDGE_C1_FEM.hpp
@@ -234,6 +234,10 @@ namespace Intrepid2 {
       return "Intrepid2_HGRAD_WEDGE_C1_FEM";
     }
 
+    BasisPtr<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>
+    getHostBasis() const override{
+      return Teuchos::rcp(new Basis_HGRAD_WEDGE_C1_FEM<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>());
+    }
   };
 }// namespace Intrepid2
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_WEDGE_C2_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_WEDGE_C2_FEM.hpp
@@ -267,6 +267,10 @@ namespace Intrepid2 {
       return "Intrepid2_HGRAD_WEDGE_C2_FEM";
     }
 
+    BasisPtr<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>
+    getHostBasis() const override{
+      return Teuchos::rcp(new Basis_HGRAD_WEDGE_C2_FEM<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>());
+    }
   };
 
 }// namespace Intrepid2


### PR DESCRIPTION

Following the pattern found in the other basis classes, this PR adds a getHostBasis() implementation to:

- Basis_HGRAD_HEX_C2_FEM
- Basis_HGRAD_LINE_C1_FEM
- Basis_HGRAD_QUAD_C2_FEM
- Basis_HGRAD_TET_C2_FEM
- Basis_HGRAD_TRI_C2_FEM
- Basis_HGRAD_WEDGE_C1_FEM
- Basis_HGRAD_WEDGE_C2_FEM

@trilinos/intrepid2 

## Related Issues

* Closes #10701 
