### PR TITLE
Phalanx: rename include guard that used KOKKOS_ prefix

### DIFF
--- a/packages/phalanx/src/Phalanx_KokkosViewFactoryFunctor.hpp
+++ b/packages/phalanx/src/Phalanx_KokkosViewFactoryFunctor.hpp
@@ -1,5 +1,5 @@
-#ifndef KOKKOS_VIEW_FACTORY_FUNCTOR_HPP
-#define KOKKOS_VIEW_FACTORY_FUNCTOR_HPP
+#ifndef PHALANX_KOKKOS_VIEW_FACTORY_FUNCTOR_HPP
+#define PHALANX_KOKKOS_VIEW_FACTORY_FUNCTOR_HPP
 
 #include "Phalanx_KokkosDeviceTypes.hpp"
 #include "Phalanx_KokkosViewFactory.hpp"


### PR DESCRIPTION
## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Fix phalanx include guard that was prefixed with "KOKKOS_" as mentioned in #10715 

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
This code change is tested by almost all unit tests in phalanx. It is used by the FieldManager class.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->