### PR TITLE
Tpetra: address Cuda 10 compiler bug

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_unpackCrsMatrixAndCombine_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_unpackCrsMatrixAndCombine_def.hpp
@@ -345,9 +345,11 @@ struct UnpackCrsMatrixAndCombineFunctor {
     }
 
     constexpr bool matrix_has_sorted_rows = true; // see #6282
+    //Note BMK 6-22: this lambda must use capture-by-value [=] and not capture-by-ref [&].
+    //By ref triggers compiler bug in CUDA 10.
     Kokkos::parallel_for(
       Kokkos::TeamThreadRange(team_member, num_entries_in_batch),
-      [&](const LO& j)
+      [=](const LO& j)
       {
         size_t distance = 0;
 


### PR DESCRIPTION
Change TeamThread lambda to use capture-by-value [=] explicitly. Semantically all Kokkos nested loop bodies must capture by value, but we often just make sure captures aren't modified and use [&] to avoid extra copies. In this case, using [&] triggered an NVCC internal compiler error that evaded PR testing. See nightly build error in https://testing.sandia.gov/cdash/viewBuildError.php?buildid=11137806

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

Compiler bug in #10724

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:
-->
## Related Issues

* Closes #10724
* Blocks 
* Is blocked by 
* Follows #10697 (changes in this PR triggered the internal compiler error) 
* Precedes 
* Related to 
* Part of 
* Composed of 


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

@csiefer2 says: "As the stakeholder, I approve this fix"

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->