### PR TITLE
Intrepid2: fix for #10714

### DIFF
--- a/packages/intrepid2/src/Orientation/Intrepid2_OrientationTools.hpp
+++ b/packages/intrepid2/src/Orientation/Intrepid2_OrientationTools.hpp
@@ -256,19 +256,6 @@ namespace Intrepid2 {
                                   const unsigned cellTopoKey,
                                   const ordinal_type cellOrt);
 
-      /** \brief  Computes the determinant of the jacobian of the parameterization maps of 1- and 2-subcells with orientation.
-
-          \param  jacobianDet     [out] - pointer to scalar containing the determinant of the jacobian of the orientation map
-          \param  cellTopoKey     [in]  - key of the cell topology of the parameterized domain (1- and 2-subcells)
-          \param  cellOrt         [in]  - cell orientation number (zero is aligned with shards default configuration
-      */
-      template<typename pointType>
-      KOKKOS_INLINE_FUNCTION
-      static void
-      getJacobianDetOfOrientationMap(pointType* jacobianDet,
-                             const unsigned cellTopoKey,
-                             const ordinal_type cellOrt);
-
 
       /** \brief  Computes the (oriented) subCell tangents
           \param  tangents        [out] - rank-2 (scD,D), tangents of the subcell. scD: subCell dimension, D: parent cell dimension

--- a/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefCoeffMatrix_HVOL.hpp
+++ b/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefCoeffMatrix_HVOL.hpp
@@ -176,8 +176,14 @@ getCoeffMatrix_HVOL(OutputViewType &output, /// this is device view
   
   auto cellTagToOrdinal = cellBasis.getAllDofOrdinal();
 
-  double jacDet;
-  Intrepid2::Impl::OrientationTools::getJacobianDetOfOrientationMap(&jacDet,cellBaseKey,cellOrt);
+  Kokkos::DynRankView<value_type,host_device_type> jac("jacobian",cellDim,cellDim);
+  Intrepid2::Impl::OrientationTools::getJacobianOfOrientationMap(jac,cellBaseKey,cellOrt);
+  value_type jacDet(0);
+  if(cellDim == 2) {
+    jacDet = jac(0,0)*jac(1,1)-jac(0,1)*jac(1,0);
+  } else { //celldim == 1
+    jacDet = jac(0,0);
+  }
 
   for (ordinal_type i=0;i<cardinality;++i) {
     const ordinal_type ic = cellTagToOrdinal(cellDim, 0, i);

--- a/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefModifyPoints.hpp
+++ b/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefModifyPoints.hpp
@@ -370,47 +370,6 @@ namespace Intrepid2 {
     }
 
 
-
-    template<typename pointType>
-    KOKKOS_INLINE_FUNCTION
-    void
-    OrientationTools::
-    getJacobianDetOfOrientationMap(pointType* jacobianDet,
-                           const unsigned cellTopoKey,
-                           const ordinal_type cellOrt) {
-      Kokkos::View<pointType**> jacobian;
-      switch (cellTopoKey) {
-      case shards::Line<>::key :
-      {
-        jacobian = Kokkos::View<pointType**>(jacobianDet,1,1);
-        getLineJacobian(jacobian, cellOrt);
-        break;
-      }
-      case shards::Triangle<>::key :
-      {
-          pointType jac[4] = {};
-          jacobian = Kokkos::View<pointType**>(jac,2,2);
-          getTriangleJacobian(jacobian, cellOrt);
-          *jacobianDet = jacobian(0,0)*jacobian(1,1)-jacobian(0,1)*jacobian(1,0);
-        break;
-      }
-      case shards::Quadrilateral<>::key :
-      {
-          pointType jac[4] = {};
-          jacobian = Kokkos::View<pointType**>(jac,2,2);
-          getQuadrilateralJacobian(jacobian, cellOrt);
-          *jacobianDet = jacobian(0,0)*jacobian(1,1)-jacobian(0,1)*jacobian(1,0);
-        break;
-      }
-      default: {
-        INTREPID2_TEST_FOR_ABORT( true,
-                                    ">>> ERROR (Intrepid2::OrientationTools::mapToModifiedReference): " \
-                                    "Invalid cell topology key." );
-        break;
-      }
-      }
-    }
-
     template<typename TanViewType, typename ParamViewType>
     KOKKOS_INLINE_FUNCTION
     void


### PR DESCRIPTION
A view was created without specifying the default space, creating issues when not using UVM.
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/intrepid2

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Fixes #10714 
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->