### PR TITLE
FastILU : metis-chec & skip-sort options

### DIFF
--- a/packages/ifpack2/src/Ifpack2_Details_FastILU_Base_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_FastILU_Base_def.hpp
@@ -116,13 +116,15 @@ apply (const Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> &X,
   }
   //zero out applyTime_ now, because the calls to applyLocalPrec() will add to it
   applyTime_ = 0;
-  int nvecs = X.getNumVectors();
+  int  nvecs = X.getNumVectors();
+  auto nrowsX = X.getLocalLength();
+  auto nrowsY = Y.getLocalLength();
   if(nvecs == 1)
   {
     auto x2d = X.getLocalViewDevice(Tpetra::Access::ReadOnly);
     auto y2d = Y.getLocalViewDevice(Tpetra::Access::ReadWrite);
-    ImplScalarArray x1d (const_cast<ImplScalar*>(x2d.data()), x1d.extent(0));
-    ImplScalarArray y1d (const_cast<ImplScalar*>(y2d.data()), y1d.extent(0));
+    ImplScalarArray x1d (const_cast<ImplScalar*>(x2d.data()), nrowsX);
+    ImplScalarArray y1d (const_cast<ImplScalar*>(y2d.data()), nrowsY);
 
     applyLocalPrec(x1d, y1d);
   }
@@ -135,8 +137,8 @@ apply (const Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> &X,
     {
       auto xColView1d = Kokkos::subview(x2d, Kokkos::ALL(), i);
       auto yColView1d = Kokkos::subview(y2d, Kokkos::ALL(), i);
-      ImplScalarArray x1d (const_cast<ImplScalar*>(xColView1d.data()), xColView1d.extent(0));
-      ImplScalarArray y1d (const_cast<ImplScalar*>(yColView1d.data()), yColView1d.extent(0));
+      ImplScalarArray x1d (const_cast<ImplScalar*>(xColView1d.data()), nrowsX);
+      ImplScalarArray y1d (const_cast<ImplScalar*>(yColView1d.data()), nrowsY);
 
       applyLocalPrec(x1d, y1d);
     }

--- a/packages/ifpack2/src/Ifpack2_Details_FastILU_Base_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_FastILU_Base_def.hpp
@@ -179,64 +179,65 @@ initialize()
     }
     Teuchos::TimeMonitor timeMonMetis (*timerMetis);
     #ifdef HAVE_IFPACK2_METIS
-    // reorder will convert both graph and perm/iperm to the internal METIS integer type
     idx_t nrows = localRowPtrsHost_.size() - 1;
-    metis_perm_  = MetisArrayHost(Kokkos::ViewAllocateWithoutInitializing("metis_perm"),  nrows);
-    metis_iperm_ = MetisArrayHost(Kokkos::ViewAllocateWithoutInitializing("metis_iperm"), nrows);
+    if (nrows > 0) {
+      // reorder will convert both graph and perm/iperm to the internal METIS integer type
+      metis_perm_  = MetisArrayHost(Kokkos::ViewAllocateWithoutInitializing("metis_perm"),  nrows);
+      metis_iperm_ = MetisArrayHost(Kokkos::ViewAllocateWithoutInitializing("metis_iperm"), nrows);
 
-    // copy ColInds to host
-    auto localColIndsHost_ = Kokkos::create_mirror(localColInds_);
-    Kokkos::deep_copy(localColIndsHost_, localColInds_);
+      // copy ColInds to host
+      auto localColIndsHost_ = Kokkos::create_mirror(localColInds_);
+      Kokkos::deep_copy(localColIndsHost_, localColInds_);
 
-    // prepare for calling metis
-    idx_t nnz = localColIndsHost_.size();
-    MetisArrayHost metis_rowptr;
-    MetisArrayHost metis_colidx;
+      // prepare for calling metis
+      idx_t nnz = localColIndsHost_.size();
+      MetisArrayHost metis_rowptr;
+      MetisArrayHost metis_colidx;
 
-    bool metis_symmetrize = true;
-    if (metis_symmetrize) {
-      // symmetrize
-      using OrdinalArrayMirror = typename OrdinalArray::host_mirror_type;
-      KokkosKernels::Impl::symmetrize_graph_symbolic_hashmap<
-        OrdinalArrayHost, OrdinalArrayMirror, MetisArrayHost, MetisArrayHost, Kokkos::HostSpace::execution_space>
-        (nrows, localRowPtrsHost_, localColIndsHost_, metis_rowptr, metis_colidx);
+      bool metis_symmetrize = true;
+      if (metis_symmetrize) {
+        // symmetrize
+        using OrdinalArrayMirror = typename OrdinalArray::host_mirror_type;
+        KokkosKernels::Impl::symmetrize_graph_symbolic_hashmap<
+          OrdinalArrayHost, OrdinalArrayMirror, MetisArrayHost, MetisArrayHost, Kokkos::HostSpace::execution_space>
+          (nrows, localRowPtrsHost_, localColIndsHost_, metis_rowptr, metis_colidx);
 
-      // remove diagonals
-      idx_t old_nnz = nnz = 0;
-      for (idx_t i = 0; i < nrows; i++) {
-        for (LocalOrdinal k = old_nnz; k < metis_rowptr(i+1); k++) {
-          if (metis_colidx(k) != i) {
-            metis_colidx(nnz) = metis_colidx(k);
-            nnz++;
+        // remove diagonals
+        idx_t old_nnz = nnz = 0;
+        for (idx_t i = 0; i < nrows; i++) {
+          for (LocalOrdinal k = old_nnz; k < metis_rowptr(i+1); k++) {
+            if (metis_colidx(k) != i) {
+              metis_colidx(nnz) = metis_colidx(k);
+              nnz++;
+            }
           }
+          old_nnz = metis_rowptr(i+1);
+          metis_rowptr(i+1) = nnz;
         }
-        old_nnz = metis_rowptr(i+1);
-        metis_rowptr(i+1) = nnz;
+      } else {
+        // copy and remove diagonals
+        metis_rowptr = MetisArrayHost(Kokkos::ViewAllocateWithoutInitializing("metis_rowptr"), nrows+1);
+        metis_colidx = MetisArrayHost(Kokkos::ViewAllocateWithoutInitializing("metis_colidx"), nnz);
+        nnz = 0;
+        metis_rowptr(0) = 0;
+        for (idx_t i = 0; i < nrows; i++) {
+          for (LocalOrdinal k = localRowPtrsHost_(i); k < localRowPtrsHost_(i+1); k++) {
+            if (localColIndsHost_(k) != i) {
+              metis_colidx(nnz) = localColIndsHost_(k);
+              nnz++;
+            }
+          }
+          metis_rowptr(i+1) = nnz;
+        }
       }
-    } else {
-      // copy and remove diagonals
-      metis_rowptr = MetisArrayHost(Kokkos::ViewAllocateWithoutInitializing("metis_rowptr"), nrows+1);
-      metis_colidx = MetisArrayHost(Kokkos::ViewAllocateWithoutInitializing("metis_colidx"), nnz);
-      nnz = 0;
-      metis_rowptr(0) = 0;
-      for (idx_t i = 0; i < nrows; i++) {
-        for (LocalOrdinal k = localRowPtrsHost_(i); k < localRowPtrsHost_(i+1); k++) {
-          if (localColIndsHost_(k) != i) {
-            metis_colidx(nnz) = localColIndsHost_(k);
-            nnz++;
-          }
-        }
-        metis_rowptr(i+1) = nnz;
+
+      // call metis
+      int info = METIS_NodeND(&nrows, metis_rowptr.data(), metis_colidx.data(),
+                              NULL, NULL, metis_perm_.data(), metis_iperm_.data());
+      if (METIS_OK != info) {
+        throw std::runtime_error(std::string("METIS_NodeND returned info = " + info));
       }
     }
-
-    // call metis
-    int info = METIS_NodeND(&nrows, metis_rowptr.data(), metis_colidx.data(),
-                            NULL, NULL, metis_perm_.data(), metis_iperm_.data());
-    if (METIS_OK != info) {
-      throw std::runtime_error(std::string("METIS_NodeND returned info = " + info));
-    }
-    //for (idx_t i = 0; i < nrows; i++) printf("%d %d\n",metis_perm_(i),metis_iperm_(i));
     #else
     throw std::runtime_error(std::string("TPL METIS is not enabled"));
     #endif

--- a/packages/ifpack2/src/Ifpack2_Details_FastILU_Base_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_FastILU_Base_def.hpp
@@ -188,7 +188,7 @@ initialize()
       metis_iperm_ = MetisArrayHost(Kokkos::ViewAllocateWithoutInitializing("metis_iperm"), nrows);
 
       // copy ColInds to host
-      auto localColIndsHost_ = Kokkos::create_mirror(localColInds_);
+      auto localColIndsHost_ = Kokkos::create_mirror_view(localColInds_);
       Kokkos::deep_copy(localColIndsHost_, localColInds_);
 
       // prepare for calling metis

--- a/packages/ifpack2/src/Ifpack2_Details_Filu_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Filu_def.hpp
@@ -101,7 +101,7 @@ initLocalPrec()
 {
   auto nRows = this->mat_->getLocalNumRows();
   auto& p = this->params_;
-  bool skipSortMatrix = false;
+  bool skipSortMatrix = !p.use_metis;
   localPrec_ = Teuchos::rcp(new LocalFILU(skipSortMatrix, this->localRowPtrs_, this->localColInds_, this->localValues_, nRows, p.sptrsv_algo,
                                           p.nFact, p.nTrisol, p.level, p.omega, p.shift, p.guessFlag ? 1 : 0, p.blockSizeILU, p.blockSize));
   #ifdef HAVE_IFPACK2_METIS

--- a/packages/ifpack2/src/Ifpack2_Details_Filu_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Filu_def.hpp
@@ -101,7 +101,8 @@ initLocalPrec()
 {
   auto nRows = this->mat_->getLocalNumRows();
   auto& p = this->params_;
-  localPrec_ = Teuchos::rcp(new LocalFILU(this->localRowPtrs_, this->localColInds_, this->localValues_, nRows, p.sptrsv_algo,
+  bool skipSortMatrix = true;
+  localPrec_ = Teuchos::rcp(new LocalFILU(skipSortMatrix, this->localRowPtrs_, this->localColInds_, this->localValues_, nRows, p.sptrsv_algo,
                                           p.nFact, p.nTrisol, p.level, p.omega, p.shift, p.guessFlag ? 1 : 0, p.blockSizeILU, p.blockSize));
   #ifdef HAVE_IFPACK2_METIS
   if (p.use_metis) {

--- a/packages/ifpack2/src/Ifpack2_Details_Filu_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Filu_def.hpp
@@ -99,9 +99,13 @@ template<typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typenam
 void Filu<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 initLocalPrec()
 {
+  typedef Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> TCrsMatrix;
   auto nRows = this->mat_->getLocalNumRows();
   auto& p = this->params_;
-  bool skipSortMatrix = !p.use_metis;
+  auto matCrs = Teuchos::rcp_dynamic_cast<const TCrsMatrix>(this->mat_);
+
+  bool skipSortMatrix = matCrs && matCrs->getCrsGraph()->isSorted() &&
+                       !p.use_metis;
   localPrec_ = Teuchos::rcp(new LocalFILU(skipSortMatrix, this->localRowPtrs_, this->localColInds_, this->localValues_, nRows, p.sptrsv_algo,
                                           p.nFact, p.nTrisol, p.level, p.omega, p.shift, p.guessFlag ? 1 : 0, p.blockSizeILU, p.blockSize));
   #ifdef HAVE_IFPACK2_METIS

--- a/packages/ifpack2/src/Ifpack2_Details_Filu_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Filu_def.hpp
@@ -101,7 +101,7 @@ initLocalPrec()
 {
   auto nRows = this->mat_->getLocalNumRows();
   auto& p = this->params_;
-  bool skipSortMatrix = true;
+  bool skipSortMatrix = false;
   localPrec_ = Teuchos::rcp(new LocalFILU(skipSortMatrix, this->localRowPtrs_, this->localColInds_, this->localValues_, nRows, p.sptrsv_algo,
                                           p.nFact, p.nTrisol, p.level, p.omega, p.shift, p.guessFlag ? 1 : 0, p.blockSizeILU, p.blockSize));
   #ifdef HAVE_IFPACK2_METIS

--- a/packages/shylu/shylu_node/fastilu/src/shylu_fastic.hpp
+++ b/packages/shylu/shylu_node/fastilu/src/shylu_fastic.hpp
@@ -171,9 +171,9 @@ class FastICPrec
             level = level_;
 
             // mirror & deep-copy the input matrix
-            aRowMapHost = Kokkos::create_mirror(aRowMapIn);
-            aColIdxHost = Kokkos::create_mirror(aColIdxIn);
-            aValHost    = Kokkos::create_mirror(aValIn);
+            aRowMapHost = Kokkos::create_mirror_view(aRowMapIn);
+            aColIdxHost = Kokkos::create_mirror_view(aColIdxIn);
+            aValHost    = Kokkos::create_mirror_view(aValIn);
             Kokkos::deep_copy(aRowMapHost, aRowMapIn);
             Kokkos::deep_copy(aColIdxHost, aColIdxIn);
             Kokkos::deep_copy(aValHost,    aValIn);
@@ -256,9 +256,9 @@ class FastICPrec
 
         void transposeL()
         {
-            auto ltRowMap_ = Kokkos::create_mirror(ltRowMap);
-            auto ltColIdx_ = Kokkos::create_mirror(ltColIdx);
-            auto ltVal_ = Kokkos::create_mirror(ltVal);
+            auto ltRowMap_ = Kokkos::create_mirror_view(ltRowMap);
+            auto ltColIdx_ = Kokkos::create_mirror_view(ltColIdx);
+            auto ltVal_ = Kokkos::create_mirror_view(ltVal);
 
             //Count the elements in each row of Lt
             auto temp = OrdinalArrayHost("temp", nRows + 1);
@@ -482,9 +482,9 @@ class FastICPrec
             aRowMap = OrdinalArray("aRowMap", nRows + 1);
             aColIdx = OrdinalArray("aColIdx", knzl + knzu);
             aRowIdx = OrdinalArray("aRowIds", knzl + knzu);
-            aRowMap_ = Kokkos::create_mirror(aRowMap);
-            aColIdx_ = Kokkos::create_mirror(aColIdx);
-            aRowIdx_ = Kokkos::create_mirror(aRowIdx);
+            aRowMap_ = Kokkos::create_mirror_view(aRowMap);
+            aColIdx_ = Kokkos::create_mirror_view(aColIdx);
+            aRowIdx_ = Kokkos::create_mirror_view(aRowIdx);
 
             Ordinal aRowPtr = 0;
             aRowMap_[0] = 0;
@@ -530,7 +530,7 @@ class FastICPrec
         void numericILU()
         {
             aVal = ScalarArray("aVal", aColIdx.extent(0));
-            aVal_ = Kokkos::create_mirror(aVal);
+            aVal_ = Kokkos::create_mirror_view(aVal);
 
             //Copy the host matrix into the initialized a;
             for (Ordinal i = 0; i < nRows; i++)
@@ -562,7 +562,7 @@ class FastICPrec
 
         void countL()
         {
-            lRowMap_ = Kokkos::create_mirror(lRowMap);
+            lRowMap_ = Kokkos::create_mirror_view(lRowMap);
 
             lRowMap_[0] = 0;
             for (Ordinal i = 0; i < nRows; i++) 
@@ -585,9 +585,9 @@ class FastICPrec
 
         void fillL()
         {
-            lVal_    = Kokkos::create_mirror(lVal);
-            lColIdx_ = Kokkos::create_mirror(lColIdx);
-            diagElems_ = Kokkos::create_mirror(diagElems);
+            lVal_    = Kokkos::create_mirror_view(lVal);
+            lColIdx_ = Kokkos::create_mirror_view(lColIdx);
+            diagElems_ = Kokkos::create_mirror_view(diagElems);
 
             Ordinal lPtr = 0; 
             for (Ordinal i = 0; i < nRows; i++) 
@@ -625,8 +625,8 @@ class FastICPrec
 
                 Kokkos::deep_copy(diagElems, gD);
 
-                auto lGColIdx_ = Kokkos::create_mirror(lGColIdx);
-                auto lGVal_ = Kokkos::create_mirror(lGVal);
+                auto lGColIdx_ = Kokkos::create_mirror_view(lGColIdx);
+                auto lGVal_ = Kokkos::create_mirror_view(lGVal);
                 Kokkos::deep_copy(lGColIdx_, lGColIdx);
                 Kokkos::deep_copy(lGVal_, lGVal);
                 for (Ordinal i = 0; i < nRows; i++) 
@@ -662,7 +662,7 @@ class FastICPrec
             //First fill Aj and extract the diagonal scaling factors
             //Use diag array to store scaling factors since
             //it gets set to the correct value by findFactorPattern anyway.
-            auto diagFact_ = Kokkos::create_mirror(diagFact);
+            auto diagFact_ = Kokkos::create_mirror_view(diagFact);
             for (int i = 0; i < nRows; i++) 
             {
                 for(int k = aRowMap_[i]; k < aRowMap_[i+1]; k++) 
@@ -818,7 +818,7 @@ class FastICPrec
 
         void setValues(ScalarArray& aValsIn)
         {
-          this->aValHost = Kokkos::create_mirror(aValsIn);
+          this->aValHost = Kokkos::create_mirror_view(aValsIn);
           Kokkos::deep_copy(this->aValHost, aValsIn);
           if(!initGuessPrec.is_null())
           {
@@ -854,7 +854,7 @@ class FastICPrec
             computeTime = t;
 
             Kokkos::deep_copy(diagElems_, diagElems);
-            diagElemsInv_ = Kokkos::create_mirror(diagElemsInv);
+            diagElemsInv_ = Kokkos::create_mirror_view(diagElemsInv);
             for (int i = 0; i < nRows; i++) 
             {
                 diagElemsInv_[i] = one/diagElems_[i];

--- a/packages/shylu/shylu_node/fastilu/src/shylu_fastildl.hpp
+++ b/packages/shylu/shylu_node/fastilu/src/shylu_fastildl.hpp
@@ -177,9 +177,9 @@ class FastILDLPrec
             level = level_;
 
             // mirror & deep-copy input matrix to host
-            aRowMapHost = Kokkos::create_mirror(aRowMapIn);
-            aColIdxHost = Kokkos::create_mirror(aColIdxIn);
-            aValHost    = Kokkos::create_mirror(aValIn);
+            aRowMapHost = Kokkos::create_mirror_view(aRowMapIn);
+            aColIdxHost = Kokkos::create_mirror_view(aColIdxIn);
+            aValHost    = Kokkos::create_mirror_view(aValIn);
             Kokkos::deep_copy(aRowMapHost, aRowMapIn);
             Kokkos::deep_copy(aColIdxHost, aColIdxIn);
             Kokkos::deep_copy(aValHost,    aValIn);
@@ -263,9 +263,9 @@ class FastILDLPrec
 
         void transposeL()
         {
-            auto ltRowMap_ = Kokkos::create_mirror(ltRowMap);
-            auto ltColIdx_ = Kokkos::create_mirror(ltColIdx);
-            auto ltVal_ = Kokkos::create_mirror(ltVal);
+            auto ltRowMap_ = Kokkos::create_mirror_view(ltRowMap);
+            auto ltColIdx_ = Kokkos::create_mirror_view(ltColIdx);
+            auto ltVal_ = Kokkos::create_mirror_view(ltVal);
 
             //Count the elements in each row of Lt
             auto temp = OrdinalArrayHost("temp", nRows + 1);
@@ -491,9 +491,9 @@ class FastILDLPrec
             aRowMap = OrdinalArray("aRowMap", nRows + 1);
             aColIdx = OrdinalArray("aColIdx", knzl + knzu);
             aRowIdx = OrdinalArray("aRowIds", knzl + knzu);
-            aRowMap_ = Kokkos::create_mirror(aRowMap);
-            aColIdx_ = Kokkos::create_mirror(aColIdx);
-            aRowIdx_ = Kokkos::create_mirror(aRowIdx);
+            aRowMap_ = Kokkos::create_mirror_view(aRowMap);
+            aColIdx_ = Kokkos::create_mirror_view(aColIdx);
+            aRowIdx_ = Kokkos::create_mirror_view(aRowIdx);
 
             Ordinal aRowPtr = 0;
             aRowMap_[0] = 0;
@@ -539,7 +539,7 @@ class FastILDLPrec
         void numericILU()
         {
             aVal = ScalarArray("aVal", aColIdx.extent(0));
-            aVal_ = Kokkos::create_mirror(aVal);
+            aVal_ = Kokkos::create_mirror_view(aVal);
 
             //Copy the host matrix into the initialized a;
             for (Ordinal i = 0; i < nRows; i++)
@@ -571,7 +571,7 @@ class FastILDLPrec
         
         void countL()
         {
-            lRowMap_ = Kokkos::create_mirror(lRowMap);
+            lRowMap_ = Kokkos::create_mirror_view(lRowMap);
 
             lRowMap_[0] = 0;
             for (Ordinal i = 0; i < nRows; i++) 
@@ -594,9 +594,9 @@ class FastILDLPrec
 
         void fillL()
         {
-            lVal_    = Kokkos::create_mirror(lVal);
-            lColIdx_ = Kokkos::create_mirror(lColIdx);
-            diagElems_ = Kokkos::create_mirror(diagElems);
+            lVal_    = Kokkos::create_mirror_view(lVal);
+            lColIdx_ = Kokkos::create_mirror_view(lColIdx);
+            diagElems_ = Kokkos::create_mirror_view(diagElems);
 
             Ordinal lPtr = 0; 
             for (Ordinal i = 0; i < nRows; i++) 
@@ -634,8 +634,8 @@ class FastILDLPrec
 
                 Kokkos::deep_copy(diagElems, gD);
 
-                auto lGColIdx_ = Kokkos::create_mirror(lGColIdx);
-                auto lGVal_ = Kokkos::create_mirror(lGVal);
+                auto lGColIdx_ = Kokkos::create_mirror_view(lGColIdx);
+                auto lGVal_ = Kokkos::create_mirror_view(lGVal);
                 Kokkos::deep_copy(lGColIdx_, lGColIdx);
                 Kokkos::deep_copy(lGVal_, lGVal);
                 for (Ordinal i = 0; i < nRows; i++) 
@@ -671,7 +671,7 @@ class FastILDLPrec
             //First fill Aj and extract the diagonal scaling factors
             //Use diag array to store scaling factors since
             //it gets set to the correct value by findFactorPattern anyway.
-            auto diagFact_ = Kokkos::create_mirror(diagFact);
+            auto diagFact_ = Kokkos::create_mirror_view(diagFact);
             for (int i = 0; i < nRows; i++) 
             {
                 for(int k = aRowMap_[i]; k < aRowMap_[i+1]; k++) 
@@ -798,7 +798,7 @@ class FastILDLPrec
 
         void setValues(ScalarArray& aValsIn)
         {
-          this->aValHost = Kokkos::create_mirror(aValsIn);
+          this->aValHost = Kokkos::create_mirror_view(aValsIn);
           Kokkos::deep_copy(this->aValHost, aValsIn);
           if(!initGuessPrec.is_null())
           {
@@ -836,7 +836,7 @@ class FastILDLPrec
             computeTime = t;
 
             Kokkos::deep_copy(diagElems_, diagElems);
-            diagElemsInv_ = Kokkos::create_mirror(diagElemsInv);
+            diagElemsInv_ = Kokkos::create_mirror_view(diagElemsInv);
             for (int i = 0; i < nRows; i++) 
             {
                 diagElemsInv_[i] = one/diagElems_[i];

--- a/packages/shylu/shylu_node/fastilu/src/shylu_fastilu.hpp
+++ b/packages/shylu/shylu_node/fastilu/src/shylu_fastilu.hpp
@@ -1106,7 +1106,7 @@ class FastILUPrec
             level = level_;
 
             // mirror & deep-copy the input matrix
-            skipSortMatrix = false;
+            skipSortMatrix = skipSortMatrix_;
             aRowMapIn = aRowMapIn_;
             aColIdxIn = aColIdxIn_;
             aValIn    = aValIn_;
@@ -1409,10 +1409,10 @@ class FastILUPrec
             }
             Kokkos::deep_copy(permMetis, permMetisHost);
             Kokkos::deep_copy(ipermMetis, ipermMetisHost);
-            if ((level > 0) && (guessFlag != 0))
-            {
-              initGuessPrec->setMetisPerm(permMetis_, ipermMetis_);
-            }
+          }
+          if ((level > 0) && (guessFlag != 0))
+          {
+            initGuessPrec->setMetisPerm(permMetis_, ipermMetis_);
           }
           useMetis = true;
         }

--- a/packages/shylu/shylu_node/fastilu/src/shylu_fastilu.hpp
+++ b/packages/shylu/shylu_node/fastilu/src/shylu_fastilu.hpp
@@ -1393,22 +1393,23 @@ class FastILUPrec
         void setMetisPerm(MetisArrayHost permMetis_, MetisArrayHost ipermMetis_)
         {
           Ordinal nRows_ = permMetis_.size();
-          permMetis = OrdinalArray("permMetis", nRows_);
-          ipermMetis = OrdinalArray("ipermMetis", nRows_);
+          if (nRows > 0) {
+            permMetis = OrdinalArray("permMetis", nRows_);
+            ipermMetis = OrdinalArray("ipermMetis", nRows_);
 
-          permMetisHost = Kokkos::create_mirror(permMetis);
-          ipermMetisHost = Kokkos::create_mirror(ipermMetis);
-          for (Ordinal i = 0; i < nRows_; i++) {
-            permMetisHost(i) = permMetis_(i);
-            ipermMetisHost(i) = ipermMetis_(i);
+            permMetisHost = Kokkos::create_mirror(permMetis);
+            ipermMetisHost = Kokkos::create_mirror(ipermMetis);
+            for (Ordinal i = 0; i < nRows_; i++) {
+              permMetisHost(i) = permMetis_(i);
+              ipermMetisHost(i) = ipermMetis_(i);
+            }
+            Kokkos::deep_copy(permMetis, permMetisHost);
+            Kokkos::deep_copy(ipermMetis, ipermMetisHost);
+            if ((level > 0) && (guessFlag != 0))
+            {
+              initGuessPrec->setMetisPerm(permMetis_, ipermMetis_);
+            }
           }
-          Kokkos::deep_copy(permMetis, permMetisHost);
-          Kokkos::deep_copy(ipermMetis, ipermMetisHost);
-          if ((level > 0) && (guessFlag != 0))
-          {
-            initGuessPrec->setMetisPerm(permMetis_, ipermMetis_);
-          }
-
           useMetis = true;
         }
 

--- a/packages/shylu/shylu_node/fastilu/src/shylu_fastilu.hpp
+++ b/packages/shylu/shylu_node/fastilu/src/shylu_fastilu.hpp
@@ -493,14 +493,14 @@ class FastILUPrec
             aRowMap = OrdinalArray("aRowMap", nRows + 1);
             aColIdx = OrdinalArray("aColIdx", knzl + knzu);
             aRowIdx = OrdinalArray("aRowIds", knzl + knzu);
-            aRowMap_ = Kokkos::create_mirror(aRowMap);
-            aColIdx_ = Kokkos::create_mirror(aColIdx);
-            aRowIdx_ = Kokkos::create_mirror(aRowIdx);
+            aRowMap_ = Kokkos::create_mirror_view(aRowMap);
+            aColIdx_ = Kokkos::create_mirror_view(aColIdx);
+            aRowIdx_ = Kokkos::create_mirror_view(aRowIdx);
 
             aLvlIdx_ = OrdinalArrayHost("aLvlIdx", knzl + knzu);
 
             aVal = ScalarArray("aVal", aColIdx.extent(0));
-            aVal_ = Kokkos::create_mirror(aVal);
+            aVal_ = Kokkos::create_mirror_view(aVal);
 
             Ordinal aRowPtr = 0;
             aRowMap_[0] = aRowPtr;
@@ -552,7 +552,7 @@ class FastILUPrec
             //Compute RowMap for L and U. 
             // > form RowMap for L
             lRowMap = OrdinalArray("lRowMap", nRows + 1);
-            lRowMap_ = Kokkos::create_mirror(lRowMap);
+            lRowMap_ = Kokkos::create_mirror_view(lRowMap);
             Ordinal nnzL = countL();
             #ifdef FASTILU_DEBUG_OUTPUT
             std::cout << "**Finished counting L" << std::endl;
@@ -561,8 +561,8 @@ class FastILUPrec
             // > form RowMap for U and Ut
             uRowMap  = OrdinalArray("uRowMap", nRows + 1);
             utRowMap = OrdinalArray("utRowMap", nRows + 1);
-            utRowMap_ = Kokkos::create_mirror(utRowMap);
-            uRowMap_  = Kokkos::create_mirror(uRowMap);
+            utRowMap_ = Kokkos::create_mirror_view(utRowMap);
+            uRowMap_  = Kokkos::create_mirror_view(uRowMap);
             Ordinal nnzU = countU();
 
             // > form RowMap for Ut
@@ -580,13 +580,13 @@ class FastILUPrec
             utVal = ScalarArray("utVal", nnzU);
 
             //Create mirror
-            lColIdx_ = Kokkos::create_mirror(lColIdx);
-            uColIdx_ = Kokkos::create_mirror(uColIdx);
-            utColIdx_ = Kokkos::create_mirror(utColIdx);
+            lColIdx_  = Kokkos::create_mirror_view(lColIdx);
+            uColIdx_  = Kokkos::create_mirror_view(uColIdx);
+            utColIdx_ = Kokkos::create_mirror_view(utColIdx);
 
-            lVal_    = Kokkos::create_mirror(lVal);
-            uVal_    = Kokkos::create_mirror(uVal);
-            utVal_    = Kokkos::create_mirror(utVal);
+            lVal_    = Kokkos::create_mirror_view(lVal);
+            uVal_    = Kokkos::create_mirror_view(uVal);
+            utVal_   = Kokkos::create_mirror_view(utVal);
             #ifdef FASTILU_INIT_TIMER
             std::cout << " Mirror : " << timer.seconds() << std::endl;
             timer.reset();
@@ -605,12 +605,12 @@ class FastILUPrec
             aRowMap = OrdinalArray("aRowMap", nRows + 1);
             aColIdx = OrdinalArray("aColIdx", nnzA);
             aRowIdx = OrdinalArray("aRowIds", nnzA);
-            aRowMap_ = Kokkos::create_mirror(aRowMap);
-            aColIdx_ = Kokkos::create_mirror(aColIdx);
-            aRowIdx_ = Kokkos::create_mirror(aRowIdx);
+            aRowMap_ = Kokkos::create_mirror_view(aRowMap);
+            aColIdx_ = Kokkos::create_mirror_view(aColIdx);
+            aRowIdx_ = Kokkos::create_mirror_view(aRowIdx);
 
             aVal = ScalarArray("aVal", nnzA);
-            aVal_ = Kokkos::create_mirror(aVal);
+            aVal_ = Kokkos::create_mirror_view(aVal);
 
             Ordinal aRowPtr = 0;
             aRowMap_[0] = aRowPtr;
@@ -643,7 +643,7 @@ class FastILUPrec
             //Now allocate memory for L and U. 
             //
             lRowMap = OrdinalArray("lRowMap", nRows + 1);
-            lRowMap_ = Kokkos::create_mirror(lRowMap);
+            lRowMap_ = Kokkos::create_mirror_view(lRowMap);
             countL();
             #ifdef FASTILU_DEBUG_OUTPUT
             std::cout << "**Finished counting L" << std::endl;
@@ -651,8 +651,8 @@ class FastILUPrec
             
             uRowMap = OrdinalArray("uRowMap", nRows + 1);
             utRowMap = OrdinalArray("utRowMap", nRows + 1);
-            utRowMap_ = Kokkos::create_mirror(utRowMap);
-            uRowMap_  = Kokkos::create_mirror(uRowMap);
+            utRowMap_ = Kokkos::create_mirror_view(utRowMap);
+            uRowMap_  = Kokkos::create_mirror_view(uRowMap);
             countU();
             #ifdef FASTILU_DEBUG_OUTPUT
             std::cout << "**Finished counting U" << std::endl;
@@ -668,13 +668,13 @@ class FastILUPrec
             utVal = ScalarArray("utVal", uRowMap_[nRows]);
 
             //Create mirror
-            lColIdx_ = Kokkos::create_mirror(lColIdx);
-            uColIdx_ = Kokkos::create_mirror(uColIdx);
-            utColIdx_ = Kokkos::create_mirror(utColIdx);
+            lColIdx_  = Kokkos::create_mirror_view(lColIdx);
+            uColIdx_  = Kokkos::create_mirror_view(uColIdx);
+            utColIdx_ = Kokkos::create_mirror_view(utColIdx);
 
-            lVal_    = Kokkos::create_mirror(lVal);
-            uVal_    = Kokkos::create_mirror(uVal);
-            utVal_   = Kokkos::create_mirror(utVal);
+            lVal_    = Kokkos::create_mirror_view(lVal);
+            uVal_    = Kokkos::create_mirror_view(uVal);
+            utVal_   = Kokkos::create_mirror_view(utVal);
         }
 
         void numericILU()
@@ -843,7 +843,7 @@ class FastILUPrec
             auto nnzU = uRowMap_[nRows];
 #if 1
             a2uMap = OrdinalArray("a2uMap", nnzU);
-            auto a2uMap_ = Kokkos::create_mirror(a2uMap);
+            auto a2uMap_ = Kokkos::create_mirror_view(a2uMap);
             for (Ordinal i = 0; i < nRows; i++) 
             {
                 for (Ordinal k = aRowMap_[i]; k < aRowMap_[i+1]; k++)
@@ -884,7 +884,7 @@ class FastILUPrec
             ExecSpace().fence();
             #else
             Kokkos::deep_copy(aVal_, aVal);
-            auto a2uMap_ = Kokkos::create_mirror(a2uMap);
+            auto a2uMap_ = Kokkos::create_mirror_view(a2uMap);
             Kokkos::deep_copy(a2uMap_, a2uMap);
             for (int k=0; k<nnzU; k++) {
                 auto pos = a2uMap_(k);
@@ -974,7 +974,7 @@ class FastILUPrec
             //First fill Aj and extract the diagonal scaling factors
             //Use diag array to store scaling factors since
             //it gets set to the correct value by findFactorPattern anyway.
-            auto diagFact_ = Kokkos::create_mirror(diagFact);
+            auto diagFact_ = Kokkos::create_mirror_view(diagFact);
             for (int i = 0; i < nRows; i++)
             {
                 for(int k = aRowMap_[i]; k < aRowMap_[i+1]; k++) 
@@ -1132,9 +1132,9 @@ class FastILUPrec
             aRowMapIn = aRowMapIn_;
             aColIdxIn = aColIdxIn_;
             aValIn    = aValIn_;
-            aRowMapHost = Kokkos::create_mirror(aRowMapIn_);
-            aColIdxHost = Kokkos::create_mirror(aColIdxIn_);
-            aValHost = Kokkos::create_mirror(aValIn_);
+            aRowMapHost = Kokkos::create_mirror_view(aRowMapIn_);
+            aColIdxHost = Kokkos::create_mirror_view(aColIdxIn_);
+            aValHost = Kokkos::create_mirror_view(aValIn_);
             Kokkos::deep_copy(aRowMapHost, aRowMapIn_);
             Kokkos::deep_copy(aColIdxHost, aColIdxIn_);
             Kokkos::deep_copy(aValHost,    aValIn_);
@@ -1423,8 +1423,8 @@ class FastILUPrec
             permMetis = OrdinalArray("permMetis", nRows_);
             ipermMetis = OrdinalArray("ipermMetis", nRows_);
 
-            permMetisHost = Kokkos::create_mirror(permMetis);
-            ipermMetisHost = Kokkos::create_mirror(ipermMetis);
+            permMetisHost = Kokkos::create_mirror_view(permMetis);
+            ipermMetisHost = Kokkos::create_mirror_view(ipermMetis);
             for (Ordinal i = 0; i < nRows_; i++) {
               permMetisHost(i) = permMetis_(i);
               ipermMetisHost(i) = ipermMetis_(i);
@@ -1574,7 +1574,7 @@ class FastILUPrec
         void setValues(ScalarArray& aValIn_)
         {
           this->aValIn = aValIn_;
-          this->aValHost = Kokkos::create_mirror(aValIn_);
+          this->aValHost = Kokkos::create_mirror_view(aValIn_);
           Kokkos::deep_copy(this->aValHost, aValIn_);
           if(!initGuessPrec.is_null())
           {
@@ -1771,8 +1771,8 @@ class FastILUPrec
                 if (sptrsv_algo == FastILU::SpTRSV::StandardHost) {
 
                     // copy x to host
-                    auto x_ = Kokkos::create_mirror(x2d);
-                    auto y_ = Kokkos::create_mirror(y2d);
+                    auto x_ = Kokkos::create_mirror_view(x2d);
+                    auto y_ = Kokkos::create_mirror_view(y2d);
                     Kokkos::deep_copy(x_, x2d);
 
                     if (doUnitDiag_TRSV) {

--- a/packages/shylu/shylu_node/fastilu/src/shylu_fastilu.hpp
+++ b/packages/shylu/shylu_node/fastilu/src/shylu_fastilu.hpp
@@ -692,7 +692,7 @@ class FastILUPrec
               ExecSpace().fence();
             }
             //Sort each row of A by ColIdx
-            if (!skipSortMatrix) {
+            if (!skipSortMatrix || useMetis) {
               KokkosKernels::sort_crs_matrix<ExecSpace, OrdinalArray, OrdinalArray, ScalarArray>(aRowMapIn, aColIdxIn, aValIn);
               ExecSpace().fence();
             }


### PR DESCRIPTION

@trilinos/shylu 

## Motivation

This PR adds a check to call Metis only with non-empty local matrix, for FastILU, and add an option to skip sorting matrix if the matrix has been already sorted.
