### PR TITLE
Ifpack2 Relaxation: Don't check for bit-by-bit identity

### DIFF
--- a/packages/ifpack2/src/Ifpack2_Relaxation_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Relaxation_def.hpp
@@ -1325,7 +1325,7 @@ void Relaxation<MatrixType>::compute ()
         // The two diagonals should be exactly the same, so their
         // difference should be exactly zero.
         TEUCHOS_TEST_FOR_EXCEPTION
-          (err != STM::zero(), std::logic_error, methodName << ": "
+          (err > 10*STM::eps(), std::logic_error, methodName << ": "
            << "\"fast-path\" diagonal computation failed.  "
            "\\|D1 - D2\\|_inf = " << err << ".");
       }


### PR DESCRIPTION
@trilinos/ifpack2 

## Motivation
Relax a bit-by-bit error check. Should fix a failure in the chama nightly:
https://testing.sandia.gov/cdash/test/136817886