### PR TITLE
Tpetra: add BlockCrsMatrix::importAndFillComplete

### DIFF
--- a/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_decl.hpp
@@ -50,6 +50,20 @@
 
 namespace Tpetra {
 
+template<class BlockCrsMatrixType>
+Teuchos::RCP<BlockCrsMatrixType>
+importAndFillCompleteBlockCrsMatrix (const Teuchos::RCP<const BlockCrsMatrixType>& sourceMatrix,
+                                     const Import<typename BlockCrsMatrixType::local_ordinal_type,
+                                                  typename BlockCrsMatrixType::global_ordinal_type,
+                                                  typename BlockCrsMatrixType::node_type>& importer,
+                                     const Teuchos::RCP<const Map<typename BlockCrsMatrixType::local_ordinal_type,
+                                                                  typename BlockCrsMatrixType::global_ordinal_type,
+                                                                  typename BlockCrsMatrixType::node_type> >& domainMap = Teuchos::null,
+                                     const Teuchos::RCP<const Map<typename BlockCrsMatrixType::local_ordinal_type,
+                                                                  typename BlockCrsMatrixType::global_ordinal_type,
+                                                                  typename BlockCrsMatrixType::node_type> >& rangeMap = Teuchos::null,
+                                     const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
+
 /// \class BlockCrsMatrix
 /// \brief Sparse matrix whose entries are small dense square blocks,
 ///   all of the same dimensions.
@@ -377,6 +391,13 @@ public:
               Teuchos::ETransp mode = Teuchos::NO_TRANS,
               const Scalar alpha = Teuchos::ScalarTraits<Scalar>::one (),
               const Scalar beta = Teuchos::ScalarTraits<Scalar>::zero ());
+
+  void
+  importAndFillComplete (Teuchos::RCP<BlockCrsMatrix<Scalar, LO, GO, Node> >& destMatrix,
+                         const Import<LO, GO, Node>& importer,
+                         const Teuchos::RCP<const map_type>& domainMap,
+                         const Teuchos::RCP<const map_type>& rangeMap,
+                         const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null) const;
 
   /// \brief Replace values at the given (mesh, i.e., block) column
   ///   indices, in the given (mesh, i.e., block) row.
@@ -1195,7 +1216,41 @@ public:
   virtual typename ::Tpetra::RowMatrix<Scalar, LO, GO, Node>::mag_type
   getFrobeniusNorm () const override;
   //@}
+
+  // Friend declaration for nonmember function.
+  template<class BlockCrsMatrixType>
+  friend Teuchos::RCP<BlockCrsMatrixType>
+  Tpetra::importAndFillCompleteBlockCrsMatrix (const Teuchos::RCP<const BlockCrsMatrixType>& sourceMatrix,
+                                               const Import<typename BlockCrsMatrixType::local_ordinal_type,
+                                                            typename BlockCrsMatrixType::global_ordinal_type,
+                                                            typename BlockCrsMatrixType::node_type>& importer,
+                                               const Teuchos::RCP<const Map<typename BlockCrsMatrixType::local_ordinal_type,
+                                                                            typename BlockCrsMatrixType::global_ordinal_type,
+                                                                            typename BlockCrsMatrixType::node_type> >& domainMap,
+                                               const Teuchos::RCP<const Map<typename BlockCrsMatrixType::local_ordinal_type,
+                                                                            typename BlockCrsMatrixType::global_ordinal_type,
+                                                                            typename BlockCrsMatrixType::node_type> >& rangeMap,
+                                               const Teuchos::RCP<Teuchos::ParameterList>& params);
 };
+
+template<class BlockCrsMatrixType>
+Teuchos::RCP<BlockCrsMatrixType>
+importAndFillCompleteBlockCrsMatrix (const Teuchos::RCP<const BlockCrsMatrixType>& sourceMatrix,
+                                     const Import<typename BlockCrsMatrixType::local_ordinal_type,
+                                                  typename BlockCrsMatrixType::global_ordinal_type,
+                                                  typename BlockCrsMatrixType::node_type>& importer,
+                                     const Teuchos::RCP<const Map<typename BlockCrsMatrixType::local_ordinal_type,
+                                                                  typename BlockCrsMatrixType::global_ordinal_type,
+                                                                  typename BlockCrsMatrixType::node_type> >& domainMap,
+                                     const Teuchos::RCP<const Map<typename BlockCrsMatrixType::local_ordinal_type,
+                                                                  typename BlockCrsMatrixType::global_ordinal_type,
+                                                                  typename BlockCrsMatrixType::node_type> >& rangeMap,
+                                     const Teuchos::RCP<Teuchos::ParameterList>& params)
+{
+  Teuchos::RCP<BlockCrsMatrixType> destMatrix;
+  sourceMatrix->importAndFillComplete (destMatrix, importer, domainMap, rangeMap, params);
+  return destMatrix;
+}
 
 } // namespace Tpetra
 

--- a/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_def.hpp
@@ -2773,10 +2773,10 @@ public:
     {
       using policy_type = Kokkos::TeamPolicy<host_exec>;
       size_t scratch_per_row = sizeof(GO) * maxRowNumEnt + sizeof (LO) * maxRowNumEnt + numBytesPerValue * maxRowNumScalarEnt
-        + 2 * sizeof(GO) // Yeah, this is a fudge factor
+        + 2 * sizeof(GO); // Yeah, this is a fudge factor
 
       const auto policy = policy_type (numImportLIDs, 1, 1)     
-        .set_scratch_size (0, Kokkos::PerTeam (scratch_size_per_row);
+        .set_scratch_size (0, Kokkos::PerTeam (scratch_per_row));
       using host_scratch_space = typename host_exec::scratch_memory_space;
       
       using pair_type = Kokkos::pair<size_t, size_t>;

--- a/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_def.hpp
@@ -2772,23 +2772,26 @@ public:
     errorDuringUnpack () = 0;
     {
       using policy_type = Kokkos::TeamPolicy<host_exec>;
-      const auto policy = policy_type (numImportLIDs, 1, 1)
-        .set_scratch_size (0, Kokkos::PerTeam (sizeof (GO) * maxRowNumEnt +
-                                               sizeof (LO) * maxRowNumEnt +
-                                               numBytesPerValue * maxRowNumScalarEnt));
-      using host_scratch_space = typename host_exec::scratch_memory_space;
+      size_t scratch_per_row = sizeof(GO) * maxRowNumEnt + sizeof (LO) * maxRowNumEnt + numBytesPerValue * maxRowNumScalarEnt
+        + 2 * sizeof(GO) // Yeah, this is a fudge factor
 
+      const auto policy = policy_type (numImportLIDs, 1, 1)     
+        .set_scratch_size (0, Kokkos::PerTeam (scratch_size_per_row);
+      using host_scratch_space = typename host_exec::scratch_memory_space;
+      
       using pair_type = Kokkos::pair<size_t, size_t>;
       Kokkos::parallel_for
         ("Tpetra::BlockCrsMatrix::unpackAndCombine: unpack", policy,
          [=] (const typename policy_type::member_type& member) {
           const size_t i = member.league_rank();
+          //          char * view_start_char = scratch_pad.data() + i*scratch_per_row;
           Kokkos::View<GO*, host_scratch_space> gblColInds
             (member.team_scratch (0), maxRowNumEnt);
           Kokkos::View<LO*, host_scratch_space> lclColInds
             (member.team_scratch (0), maxRowNumEnt);
           Kokkos::View<impl_scalar_type*, host_scratch_space> vals
             (member.team_scratch (0), maxRowNumScalarEnt);
+          
 
           const size_t offval = offset(i);
           const LO lclRow = importLIDsHost(i);

--- a/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_def.hpp
@@ -2784,7 +2784,6 @@ public:
         ("Tpetra::BlockCrsMatrix::unpackAndCombine: unpack", policy,
          [=] (const typename policy_type::member_type& member) {
           const size_t i = member.league_rank();
-          //          char * view_start_char = scratch_pad.data() + i*scratch_per_row;
           Kokkos::View<GO*, host_scratch_space> gblColInds
             (member.team_scratch (0), maxRowNumEnt);
           Kokkos::View<LO*, host_scratch_space> lclColInds

--- a/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_def.hpp
@@ -2772,25 +2772,19 @@ public:
     errorDuringUnpack () = 0;
     {
       using policy_type = Kokkos::TeamPolicy<host_exec>;
-      const auto policy = policy_type (numImportLIDs, 1, 1)
-        .set_scratch_size (0, Kokkos::PerTeam (sizeof (GO) * maxRowNumEnt +
-                                               sizeof (LO) * maxRowNumEnt +
-                                               numBytesPerValue * maxRowNumScalarEnt));
-
-
-      using host_scratch_space = typename host_exec::scratch_memory_space;
+      const auto policy = policy_type (numImportLIDs, 1, 1);
       using pair_type = Kokkos::pair<size_t, size_t>;
       Kokkos::parallel_for
         ("Tpetra::BlockCrsMatrix::unpackAndCombine: unpack", policy,
          [=] (const typename policy_type::member_type& member) {
           const size_t i = member.league_rank();
 
-          Kokkos::View<GO*, host_scratch_space> gblColInds
-            (member.team_scratch (0), maxRowNumEnt);
-          Kokkos::View<LO*, host_scratch_space> lclColInds
-            (member.team_scratch (0), maxRowNumEnt);
-          Kokkos::View<impl_scalar_type*, host_scratch_space> vals
-            (member.team_scratch (0), maxRowNumScalarEnt);
+          Kokkos::View<GO*, host_exec> gblColInds
+            ("", maxRowNumEnt);
+          Kokkos::View<LO*, host_exec> lclColInds
+            ("", maxRowNumEnt);
+          Kokkos::View<impl_scalar_type*, host_exec> vals
+            ("", maxRowNumScalarEnt);
 
           const size_t offval = offset(i);
           const LO lclRow = importLIDsHost(i);

--- a/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_def.hpp
@@ -2512,15 +2512,6 @@ public:
         const auto policy =
           policy_type(numExportLIDs, 1, 1)
           .set_scratch_size(0, Kokkos::PerTeam(sizeof(GO)*maxRowLength));
-
-        const int myRank = this->graph_.getRowMap ()->getComm ()->getRank ();
-        std::cout << std::endl << std::endl
-                  << "proc" << myRank
-                  << " packAndPrepare"
-                  << " - scratchsize " << sizeof(GO)*maxRowLength
-                  << std::endl << std::endl;
-
-
         Kokkos::parallel_for
           (policy,
            [=](const typename policy_type::member_type &member) {
@@ -2696,7 +2687,6 @@ public:
         PackTraits<impl_scalar_type>::packValueCount
         (val_host.extent (0) ? val_host(0) : impl_scalar_type ());
     }
-
     const size_t maxRowNumEnt = graph_.getLocalMaxNumRowEntries ();
     const size_t maxRowNumScalarEnt = maxRowNumEnt * blockSize * blockSize;
 
@@ -2787,14 +2777,6 @@ public:
                                                sizeof (LO) * maxRowNumEnt +
                                                numBytesPerValue * maxRowNumScalarEnt));
 
-       const int myRank = this->graph_.getRowMap ()->getComm ()->getRank ();
-       std::cout << std::endl << std::endl
-                 << "proc" << myRank
-                 << " unpackAndCombine"
-                 << " - scratchsize " << sizeof (GO) * maxRowNumEnt +
-                                         sizeof (LO) * maxRowNumEnt +
-                                         numBytesPerValue * maxRowNumScalarEnt
-                 << std::endl << std::endl;
 
       using host_scratch_space = typename host_exec::scratch_memory_space;
       using pair_type = Kokkos::pair<size_t, size_t>;

--- a/packages/tpetra/core/test/Block/BlockCrsMatrix.cpp
+++ b/packages/tpetra/core/test/Block/BlockCrsMatrix.cpp
@@ -61,6 +61,7 @@ namespace {
   using Teuchos::reduceAll;
   using Teuchos::RCP;
   using Teuchos::rcp;
+  using Teuchos::ScalarTraits;
   using std::endl;
   typedef Tpetra::global_size_t GST;
 
@@ -1524,6 +1525,505 @@ namespace {
     TEST_EQUALITY_CONST( gblSuccess, 1 );
   }
 
+  // Test that two graphs are same.
+  template<class Graph>
+  bool graphs_are_same(const Graph& G1, const Graph& G2)
+  {
+    typedef typename Graph::local_ordinal_type LO;
+
+    int my_rank = G1.getRowMap()->getComm()->getRank();
+
+    // Make sure each graph is fill complete before checking other properties
+    if (! G1.isFillComplete()) {
+      if (my_rank == 0)
+        std::cerr << "Error: Graph 1 is not fill complete!" << std::endl;
+      return false;
+    }
+    if (! G2.isFillComplete()) {
+      if (my_rank == 0)
+        std::cerr << "Error: Graph 2 is not fill complete!" << std::endl;
+      return false;
+    }
+
+    int errors = 0;
+
+    if (! G1.getRowMap()->isSameAs(*G2.getRowMap())) {
+      if (my_rank == 0)
+        std::cerr << "Error: Graph 1's row map is different than Graph 2's" << std::endl;
+      errors++;
+    }
+    if (! G1.getDomainMap()->isSameAs(*G2.getDomainMap())) {
+      if (my_rank == 0)
+        std::cerr << "Error: Graph 1's domain map is different than Graph 2's" << std::endl;
+      errors++;
+    }
+    if (! G1.getRangeMap()->isSameAs(*G2.getRangeMap())) {
+      if (my_rank == 0)
+        std::cerr << "Error: Graph 1's range map is different than Graph 2's" << std::endl;
+      errors++;
+    }
+    if (G1.getLocalNumEntries() != G2.getLocalNumEntries()) {
+      std::cerr << "Error: Graph 1 does not have the same number of entries as Graph 2 on Process "
+           << my_rank << std::endl;
+      errors++;
+    }
+
+    if (errors != 0) return false;
+
+    for (LO i=0; i<static_cast<LO>(G1.getLocalNumRows()); i++) {
+      typename Graph::local_inds_host_view_type V1, V2;
+      G1.getLocalRowView(i, V1);
+      G2.getLocalRowView(i, V2);
+      if (V1.size() != V2.size()) {
+        std::cerr << "Error: Graph 1 and Graph 2 have different number of entries in local row "
+             << i << " on Process " << my_rank << std::endl;
+        errors++;
+        continue;
+      }
+      int jerr = 0;
+      for (LO j=0; j<static_cast<LO>(V1.size()); j++) {
+        if (V1[j] != V2[j])
+          jerr++;
+      }
+      if (jerr != 0) {
+        std::cerr << "Error: One or more entries in row " << i << " on Process " << my_rank
+             << " Graphs 1 and 2 are not the same" << std::endl;
+        errors++;
+        continue;
+      }
+    }
+
+    return (errors == 0);
+
+  }
+
+  // Test that two matrices' rows have the same entries.
+  template<class BlockCrsMatrixType>
+  bool matrices_are_same(const RCP<BlockCrsMatrixType>& A1,
+                         const RCP<BlockCrsMatrixType>& A2)
+  {
+    // Loop through A1 and make sure each row has the same
+    // entries as A2.  In the fully general case, the
+    // redistribution may have added together values, resulting in
+    // small rounding errors.  This is why we use an error tolerance
+    // (with a little bit of wiggle room).
+
+    int my_rank = A1->getRowMap()->getComm()->getRank();
+
+    using LO = typename BlockCrsMatrixType::local_ordinal_type;
+    using Scalar = typename BlockCrsMatrixType::scalar_type;
+    using lids_type = typename BlockCrsMatrixType::local_inds_host_view_type;
+    using vals_type = typename BlockCrsMatrixType::values_host_view_type;
+
+    using ST = ScalarTraits<Scalar>;
+    using magnitude_type = typename ST::magnitudeType;
+    const magnitude_type tol =
+       Teuchos::as<magnitude_type> (10) * ScalarTraits<magnitude_type>::eps ();
+
+    const LO blocksize = A1->getBlockSize();
+    // Verify the blocksizes are identical
+    if (blocksize != A2->getBlockSize()) {
+      if (my_rank==0) std::cerr << "Error: Blocksizes are not the same!" << std::endl;
+      return false;
+    }
+
+    // Verify the maps are identical
+    bool maps_same = A1->getRowMap()->isSameAs(*(A2->getRowMap()));
+    if (!maps_same) {
+      if (my_rank==0) std::cerr << "Error: RowMaps are not the same!" << std::endl;
+      return false;
+    }
+
+    // Verify the graphs are identical
+    bool graphs_same = graphs_are_same(A1->getCrsGraph(), A2->getCrsGraph());
+    if (!graphs_same) {
+      if (my_rank==0) std::cerr << "Error: Graphs are not the same!" << std::endl;
+      return false;
+    }
+
+    lids_type A1RowInds;
+    vals_type A1RowVals;
+    lids_type A2RowInds;
+    vals_type A2RowVals;
+    for (LO localrow = A1->getRowMap()->getMinLocalIndex();
+        localrow <= A1->getRowMap()->getMaxLocalIndex();
+        ++localrow)
+    {
+      size_t A1NumEntries = A1->getNumEntriesInLocalRow (localrow);
+      size_t A2NumEntries = A1->getNumEntriesInLocalRow (localrow);
+
+      // Verify the same number of entries in each row
+      if (A1NumEntries != A2NumEntries) {
+        if (my_rank==0) std::cerr << "Error: Matrices have different number of entries in at least one row!" << std::endl;
+        return false;
+      }
+
+      A1->getLocalRowView (localrow, A1RowInds, A1RowVals);
+      A2->getLocalRowView (localrow, A2RowInds, A2RowVals);
+
+      // Verify the same number of values in each row
+      if (A1RowVals.extent(0) != A2RowVals.extent(0)) {
+        if (my_rank==0) std::cerr << "Error: Matrices have different number of entries in at least one row!" << std::endl;
+        return false;
+      }
+
+      typedef typename Array<Scalar>::size_type size_type;
+      for (size_type k = 0; k < static_cast<size_type> (A1NumEntries); ++k) {
+        // Verify the same column indices
+        if(A1RowInds[k]!=A2RowInds[k]) {
+          if (my_rank==0) std::cerr << "Error: Matrices have different column indices!" << std::endl;
+          return false;
+        }
+      }
+
+      for (size_t val=0; val<A1RowVals.extent(0); ++val) {
+        // Verify the same matrix values
+        const magnitude_type rel_err = ST::magnitude(A1RowVals[val] - A2RowVals[val]);
+        if(rel_err > tol) {
+          if (my_rank==0) std::cerr << "Error: Matrices have different values!" << std::endl;
+          return false;
+        }
+      }
+    }
+
+    return true;
+  }
+
+  // Build lower diag matrix for test
+  template<class BlockCrsMatrixType>
+  void build_lower_diag_matrix (const RCP<BlockCrsMatrixType>& A) {
+
+    using LO = typename BlockCrsMatrixType::local_ordinal_type;
+    using GO = typename BlockCrsMatrixType::global_ordinal_type;
+    using Scalar = typename BlockCrsMatrixType::scalar_type;
+
+    const typename BlockCrsMatrixType::map_type row_map = *(A->getRowMap());
+    const typename BlockCrsMatrixType::map_type col_map = *(A->getColMap());
+
+    int my_rank = row_map.getComm()->getRank();
+
+    if(A->getBlockSize() != 3) {
+      if (my_rank==0) std::cerr << "Error: A->getBlockSize != 3!" << std::endl;
+      return;
+    }
+    const int blocksize = 3;
+
+    for (LO localrow = row_map.getMinLocalIndex();
+         localrow <= row_map.getMaxLocalIndex();
+         ++localrow) {
+
+      const GO globalrow = row_map.getGlobalElement(localrow);
+
+      if (globalrow == 0) {
+
+        LO local_col_indices[1];
+        local_col_indices[0] = col_map.getLocalElement(0);
+
+        Scalar values[blocksize*blocksize];
+        for (size_t b=0; b<blocksize*blocksize; ++b) {
+          values[b] = 10*(globalrow+1);
+        }
+        A->replaceLocalValues(localrow,
+                              local_col_indices,
+                              values,
+                              1);
+      }
+      else if (globalrow == 1) {
+
+        LO local_col_indices[2];
+        local_col_indices[0] = col_map.getLocalElement(0);
+        local_col_indices[1] = col_map.getLocalElement(1);
+
+        Scalar values[2*blocksize*blocksize];
+        for (GO globalcol=0; globalcol<2; ++globalcol) {
+          int start = globalcol*blocksize*blocksize;
+          for (size_t b=0; b<blocksize*blocksize; ++b) {
+            values[start+b] = 10*(globalrow+1)+globalcol;
+          }
+        }
+        A->replaceLocalValues(localrow,
+                              local_col_indices,
+                              values,
+                              2);
+      } else {
+
+        LO local_col_indices[3];
+        local_col_indices[0] = col_map.getLocalElement(globalrow-2);
+        local_col_indices[1] = col_map.getLocalElement(globalrow-1);
+        local_col_indices[2] = col_map.getLocalElement(globalrow);
+
+        Scalar values[3*blocksize*blocksize];
+        int local_indx = 0;
+        for (GO globalcol=globalrow-2; globalcol<=globalrow; ++globalcol) {
+          int start = local_indx*blocksize*blocksize;
+          for (size_t b=0; b<blocksize*blocksize; ++b) {
+            values[start+b] = 10*(globalrow+1)+globalcol;
+          }
+          ++local_indx;
+        }
+        A->replaceLocalValues(localrow,
+                              local_col_indices,
+                              values,
+                              3);
+      }
+    }
+
+    return;
+  }
+
+  // Test BlockCrsMatrix importAndFillComplete
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( BlockCrsMatrix, importAndFillComplete, Scalar, LO, GO, Node )
+  {
+    using Tpetra::Details::gathervPrint;
+    typedef Tpetra::BlockCrsMatrix<Scalar, LO, GO, Node> block_crs_type;
+    typedef Tpetra::CrsGraph<LO, GO, Node> crs_graph_type;
+    typedef Tpetra::Map<LO, GO, Node> map_type;
+    typedef Tpetra::Import<LO, GO, Node> import_type;
+    using Teuchos::REDUCE_MAX;
+
+    std::ostringstream err;
+    int lclErr = 0;
+    int gblErr = 0;
+
+    out << "Testing Tpetra::BlockCrsMatrix importAndFillComplete" << endl;
+    Teuchos::OSTab tab0 (out);
+
+    RCP<const Comm<int> > comm = getDefaultComm ();
+    const int myRank = comm->getRank ();
+    const int numRanks = comm->getSize();
+    const GST INVALID = Teuchos::OrdinalTraits<GST>::invalid ();
+
+    out << "1st test: Import a diagonal BlockCrsMatrix from a source row Map "
+           "that has all indices on Process 0, to a target row Map that is "
+           "uniformly distributed over processes. Blocksize=3." << endl;
+    try {
+      Teuchos::OSTab tab1 (out);
+
+      const GO indexBase = 0;
+      const LO tgt_num_local_elements = 2;
+      const LO src_num_local_elements = (myRank == 0) ?
+        static_cast<LO> (numRanks*tgt_num_local_elements) :
+        static_cast<LO> (0);
+
+      const int blocksize = 3;
+
+      // Create row Maps for the source and target
+      RCP<const map_type> src_map =
+        rcp (new map_type (INVALID,
+                           src_num_local_elements,
+                           indexBase, comm));
+      RCP<const map_type> tgt_map =
+        rcp (new map_type (INVALID,
+                           tgt_num_local_elements,
+                           indexBase, comm));
+
+      // Build src graph.
+      Teuchos::RCP<crs_graph_type> src_graph =
+        Teuchos::rcp (new crs_graph_type (src_map, 1));
+      for (LO localrow = src_map->getMinLocalIndex();
+           localrow<=src_map->getMaxLocalIndex(); 
+           ++localrow) {
+
+        const GO globalrow = src_map->getGlobalElement(localrow);
+        GO globalcol[1];
+        globalcol[0] = globalrow;
+        
+        src_graph->insertGlobalIndices(globalrow, 1, globalcol);
+      }
+      src_graph->fillComplete();
+
+      // Build src matrix. Simple block diagonal matrix with A(b,b) = [b*b*row,...,+b*b].
+      RCP<block_crs_type> src_mat =
+        rcp (new block_crs_type (*src_graph, blocksize)); 
+      if (src_num_local_elements != 0) {
+        for (LO localrow = src_map->getMinLocalIndex();
+             localrow <= src_map->getMaxLocalIndex();
+             ++localrow) {
+          const GO globalrow = src_map->getGlobalElement(localrow);
+          LO col_indices[1];  Scalar values[blocksize*blocksize];
+          col_indices[0] = localrow; 
+          for (size_t b=0; b<blocksize*blocksize; ++b) {
+            values[b] = blocksize*blocksize*globalrow + b;
+          }
+          const LO actual_num_replaces = src_mat->replaceLocalValues(localrow,
+                                                                     col_indices,
+                                                                     values,
+                                                                     1);
+          TEST_EQUALITY_CONST(actual_num_replaces, 1);
+        }
+      }
+
+      // Create the importer
+      import_type importer (src_map, tgt_map);
+
+      // Call importAndFillComplete to get the tgt matrix
+      RCP<block_crs_type> tgt_mat =
+        Tpetra::importAndFillCompleteBlockCrsMatrix<block_crs_type> (src_mat, importer);
+     
+      // Manually build the tgt matrix and test that it matches the returned matrix
+
+      // Build tgt graph.
+      Teuchos::RCP<crs_graph_type> tgt_graph_for_testing =
+        Teuchos::rcp (new crs_graph_type (tgt_map, 1));
+      for (LO localrow = tgt_map->getMinLocalIndex();
+           localrow<=tgt_map->getMaxLocalIndex();
+           ++localrow) {
+
+        const GO globalrow = tgt_map->getGlobalElement(localrow);
+        GO globalcol[1];
+        globalcol[0] = globalrow;
+
+        tgt_graph_for_testing->insertGlobalIndices(globalrow, 1, globalcol);
+      }
+      tgt_graph_for_testing->fillComplete();
+
+      // Build tgt matrix
+      RCP<block_crs_type> tgt_mat_for_testing =
+        rcp (new block_crs_type (*tgt_graph_for_testing, blocksize));
+      for (LO localrow = tgt_map->getMinLocalIndex();
+           localrow <= tgt_map->getMaxLocalIndex();
+           ++localrow) {
+        const GO globalrow = tgt_map->getGlobalElement(localrow);
+        LO col_indices[1];  Scalar values[blocksize*blocksize];
+        col_indices[0] = localrow;
+        for (size_t b=0; b<blocksize*blocksize; ++b) {
+          values[b] = blocksize*blocksize*globalrow + b;
+        }
+        const LO actual_num_replaces = tgt_mat_for_testing->replaceLocalValues(localrow,
+                                                                               col_indices,
+                                                                               values,
+                                                                               1);
+        TEST_EQUALITY_CONST(actual_num_replaces, 1);
+      }
+
+      // Test that matrices are identical
+      bool matrices_match = matrices_are_same<block_crs_type>(tgt_mat, tgt_mat_for_testing);
+      TEST_ASSERT(matrices_match);
+     }
+     catch (std::exception& e) { // end of the first test
+       err << "Proc " << myRank << ": " << e.what () << endl;
+       lclErr = 1;
+     }
+
+     reduceAll<int, int> (*comm, REDUCE_MAX, lclErr, outArg (gblErr));
+     TEST_EQUALITY_CONST( gblErr, 0 );
+     if (gblErr != 0) {
+       Tpetra::Details::gathervPrint (out, err.str (), *comm);
+       out << "Above test failed; aborting further tests" << endl;
+       return;
+     }
+
+     //auto out_to_screen = Teuchos::getFancyOStream (Teuchos::rcpFromRef (std::cout));
+
+     out << "2nd test: Import a lower triangular BlockCrsMatrix from a source row Map "
+            "where even processors have 1 element and odd processors have 3 elements, "
+            "to a target row Map where each processor have 2 elements. Blocksize=3." << endl;
+     try {
+       Teuchos::OSTab tab1 (out);
+
+       // This test only makes sense for even number of ranks
+       if (numRanks % 2 != 0) {
+         return;
+       }
+
+       const GO indexBase = 0;
+       LO src_num_local_elements;
+       if (myRank % 2 == 0) src_num_local_elements = 1;
+       else                 src_num_local_elements = 3;
+       LO tgt_num_local_elements = 2;
+       const int blocksize = 3;
+
+       // Create row Maps for the source and target
+       RCP<const map_type> src_map =
+         rcp (new map_type (INVALID,
+                            src_num_local_elements,
+                            indexBase, comm));
+       RCP<const map_type> tgt_map =
+         rcp (new map_type (INVALID,
+                            tgt_num_local_elements,
+                            indexBase, comm));
+       //src_map->describe(*out_to_screen, Teuchos::VERB_EXTREME);
+       //tgt_map->describe(*out_to_screen, Teuchos::VERB_EXTREME);
+
+       // Build src graph. Allow for up to 2 off-diagonal entries.
+       Teuchos::RCP<crs_graph_type> src_graph =
+         Teuchos::rcp (new crs_graph_type (src_map, 3));
+       {
+         Array<GO> cols(3);
+         for (GO globalrow = src_map->getMinGlobalIndex ();
+              globalrow <= src_map->getMaxGlobalIndex (); ++globalrow) {
+           if      (globalrow==0) cols.resize(1);
+           else if (globalrow==1) cols.resize(2);
+           else                   cols.resize(3);
+           for (GO col = 0; col < cols.size(); ++col) {
+             cols[col] = globalrow - col;
+           }
+           src_graph->insertGlobalIndices (globalrow, cols());
+         }
+         src_graph->fillComplete();
+         //src_graph->describe(*out_to_screen, Teuchos::VERB_EXTREME);
+       }
+
+       // Build src matrix. Simple block lower-diagonal matrix with
+       // A(b1,b2) = [(b1)+10*(b2+1)].
+       RCP<block_crs_type> src_mat =
+         rcp (new block_crs_type (*src_graph, blocksize));
+       build_lower_diag_matrix<block_crs_type>(src_mat);
+       //src_mat->describe(*out_to_screen, Teuchos::VERB_EXTREME);
+
+       // Create the importer
+       import_type importer (src_map, tgt_map);
+
+       // Call importAndFillComplete to get the tgt matrix
+       RCP<block_crs_type> tgt_mat =
+         Tpetra::importAndFillCompleteBlockCrsMatrix<block_crs_type> (src_mat, importer);
+       //tgt_mat->describe(*out_to_screen, Teuchos::VERB_EXTREME);
+
+       // Manually build the tgt matrix and test that it matches the returned matrix
+
+       // Build tgt graph.
+       Teuchos::RCP<crs_graph_type> tgt_graph_for_testing =
+         Teuchos::rcp (new crs_graph_type (tgt_map, 3));
+       {
+         Array<GO> cols(3);
+         for (GO globalrow = tgt_map->getMinGlobalIndex ();
+              globalrow <= tgt_map->getMaxGlobalIndex (); ++globalrow) {
+           if      (globalrow==0) cols.resize(1);
+           else if (globalrow==1) cols.resize(2);
+           else                   cols.resize(3);
+           for (GO col = 0; col < cols.size(); ++col) {
+             cols[col] = globalrow - col;
+           }
+           tgt_graph_for_testing->insertGlobalIndices (globalrow, cols());
+         }
+         tgt_graph_for_testing->fillComplete();
+         //tgt_graph_for_testing->describe(*out_to_screen, Teuchos::VERB_EXTREME);
+       }
+
+       // Build tgt matrix
+       RCP<block_crs_type> tgt_mat_for_testing =
+         rcp (new block_crs_type (*tgt_graph_for_testing, blocksize));
+       build_lower_diag_matrix<block_crs_type>(tgt_mat_for_testing);
+       //tgt_mat_for_testing->describe(*out_to_screen, Teuchos::VERB_EXTREME);
+
+       // Test that matrices are identical
+       bool matrices_match = matrices_are_same<block_crs_type>(tgt_mat, tgt_mat_for_testing);
+       TEST_ASSERT(matrices_match);
+      }
+      catch (std::exception& e) { // end of the first test
+        err << "Proc " << myRank << ": " << e.what () << endl;
+        lclErr = 1;
+      }
+
+      reduceAll<int, int> (*comm, REDUCE_MAX, lclErr, outArg (gblErr));
+      TEST_EQUALITY_CONST( gblErr, 0 );
+      if (gblErr != 0) {
+        Tpetra::Details::gathervPrint (out, err.str (), *comm);
+        out << "Above test failed; aborting further tests" << endl;
+        return;
+      }
+   }
+
   // Test BlockCrsMatrix Export for different graphs with different
   // row Maps.  This tests packAndPrepare and unpackAndCombine.
   TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( BlockCrsMatrix, ExportDiffRowMaps, Scalar, LO, GO, Node )
@@ -2307,6 +2807,7 @@ namespace {
   TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( BlockCrsMatrix, getLocalDiagCopy, SCALAR, LO, GO, NODE ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( BlockCrsMatrix, SetAllToScalar, SCALAR, LO, GO, NODE ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( BlockCrsMatrix, ImportCopy, SCALAR, LO, GO, NODE ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( BlockCrsMatrix, importAndFillComplete, SCALAR, LO, GO, NODE ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( BlockCrsMatrix, ExportDiffRowMaps, SCALAR, LO, GO, NODE ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( BlockCrsMatrix, point2block, SCALAR, LO, GO, NODE ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( BlockCrsMatrix, block2point, SCALAR, LO, GO, NODE )

--- a/packages/tpetra/core/test/Block/BlockCrsMatrix.cpp
+++ b/packages/tpetra/core/test/Block/BlockCrsMatrix.cpp
@@ -1793,118 +1793,6 @@ namespace {
     const int numRanks = comm->getSize();
     const GST INVALID = Teuchos::OrdinalTraits<GST>::invalid ();
 
-    //auto out_to_screen = Teuchos::getFancyOStream (Teuchos::rcpFromRef (std::cout));
-
-    if (myRank==0) std::cout << "TEST LOWER DIAG" << std::endl;
-    out << "2nd test: Import a lower triangular BlockCrsMatrix from a source row Map "
-           "where even processors have 1 element and odd processors have 3 elements, "
-           "to a target row Map where each processor have 2 elements. Blocksize=3." << endl;
-    try {
-      Teuchos::OSTab tab1 (out);
-
-      // This test only makes sense for even number of ranks
-      if (numRanks % 2 != 0) {
-        return;
-      }
-
-      const GO indexBase = 0;
-      LO src_num_local_elements;
-      if (myRank % 2 == 0) src_num_local_elements = 1;
-      else                 src_num_local_elements = 3;
-      LO tgt_num_local_elements = 2;
-      const int blocksize = 3;
-
-      // Create row Maps for the source and target
-      RCP<const map_type> src_map =
-        rcp (new map_type (INVALID,
-                           src_num_local_elements,
-                           indexBase, comm));
-      RCP<const map_type> tgt_map =
-        rcp (new map_type (INVALID,
-                           tgt_num_local_elements,
-                           indexBase, comm));
-      //src_map->describe(*out_to_screen, Teuchos::VERB_EXTREME);
-      //tgt_map->describe(*out_to_screen, Teuchos::VERB_EXTREME);
-
-      // Build src graph. Allow for up to 2 off-diagonal entries.
-      Teuchos::RCP<crs_graph_type> src_graph =
-        Teuchos::rcp (new crs_graph_type (src_map, 3));
-      {
-        Array<GO> cols(3);
-        for (GO globalrow = src_map->getMinGlobalIndex ();
-             globalrow <= src_map->getMaxGlobalIndex (); ++globalrow) {
-          if      (globalrow==0) cols.resize(1);
-          else if (globalrow==1) cols.resize(2);
-          else                   cols.resize(3);
-          for (GO col = 0; col < cols.size(); ++col) {
-            cols[col] = globalrow - col;
-          }
-          src_graph->insertGlobalIndices (globalrow, cols());
-        }
-        src_graph->fillComplete();
-        //src_graph->describe(*out_to_screen, Teuchos::VERB_EXTREME);
-      }
-
-      // Build src matrix. Simple block lower-diagonal matrix with
-      // A(b1,b2) = [(b1)+10*(b2+1)].
-      RCP<block_crs_type> src_mat =
-        rcp (new block_crs_type (*src_graph, blocksize));
-      build_lower_diag_matrix<block_crs_type>(src_mat);
-      //src_mat->describe(*out_to_screen, Teuchos::VERB_EXTREME);
-
-      // Create the importer
-      import_type importer (src_map, tgt_map);
-
-      // Call importAndFillComplete to get the tgt matrix
-      RCP<block_crs_type> tgt_mat =
-        Tpetra::importAndFillCompleteBlockCrsMatrix<block_crs_type> (src_mat, importer);
-      //tgt_mat->describe(*out_to_screen, Teuchos::VERB_EXTREME);
-
-      // Manually build the tgt matrix and test that it matches the returned matrix
-
-      // Build tgt graph.
-      Teuchos::RCP<crs_graph_type> tgt_graph_for_testing =
-        Teuchos::rcp (new crs_graph_type (tgt_map, 3));
-      {
-        Array<GO> cols(3);
-        for (GO globalrow = tgt_map->getMinGlobalIndex ();
-             globalrow <= tgt_map->getMaxGlobalIndex (); ++globalrow) {
-          if      (globalrow==0) cols.resize(1);
-          else if (globalrow==1) cols.resize(2);
-          else                   cols.resize(3);
-          for (GO col = 0; col < cols.size(); ++col) {
-            cols[col] = globalrow - col;
-          }
-          tgt_graph_for_testing->insertGlobalIndices (globalrow, cols());
-        }
-        tgt_graph_for_testing->fillComplete();
-        //tgt_graph_for_testing->describe(*out_to_screen, Teuchos::VERB_EXTREME);
-      }
-
-      // Build tgt matrix
-      RCP<block_crs_type> tgt_mat_for_testing =
-        rcp (new block_crs_type (*tgt_graph_for_testing, blocksize));
-      build_lower_diag_matrix<block_crs_type>(tgt_mat_for_testing);
-      //tgt_mat_for_testing->describe(*out_to_screen, Teuchos::VERB_EXTREME);
-
-      // Test that matrices are identical
-      bool matrices_match = matrices_are_same<block_crs_type>(tgt_mat, tgt_mat_for_testing);
-      TEST_ASSERT(matrices_match);
-     }
-     catch (std::exception& e) { // end of the first test
-       err << "Proc " << myRank << ": " << e.what () << endl;
-       lclErr = 1;
-     }
-
-     reduceAll<int, int> (*comm, REDUCE_MAX, lclErr, outArg (gblErr));
-     TEST_EQUALITY_CONST( gblErr, 0 );
-     if (gblErr != 0) {
-       Tpetra::Details::gathervPrint (out, err.str (), *comm);
-       out << "Above test failed; aborting further tests" << endl;
-       return;
-     }
-
-    if (myRank==0) std::cout << "TEST DIAG" << std::endl;
     out << "1st test: Import a diagonal BlockCrsMatrix from a source row Map "
            "that has all indices on Process 0, to a target row Map that is "
            "uniformly distributed over processes. Blocksize=3." << endl;
@@ -2024,6 +1912,114 @@ namespace {
        out << "Above test failed; aborting further tests" << endl;
        return;
      }
+
+     out << "2nd test: Import a lower triangular BlockCrsMatrix from a source row Map "
+            "where even processors have 1 element and odd processors have 3 elements, "
+            "to a target row Map where each processor have 2 elements. Blocksize=3." << endl;
+     try {
+       Teuchos::OSTab tab1 (out);
+
+       // This test only makes sense for even number of ranks
+       if (numRanks % 2 != 0) {
+         return;
+       }
+
+       const GO indexBase = 0;
+       LO src_num_local_elements;
+       if (myRank % 2 == 0) src_num_local_elements = 1;
+       else                 src_num_local_elements = 3;
+       LO tgt_num_local_elements = 2;
+       const int blocksize = 3;
+
+       // Create row Maps for the source and target
+       RCP<const map_type> src_map =
+         rcp (new map_type (INVALID,
+                            src_num_local_elements,
+                            indexBase, comm));
+       RCP<const map_type> tgt_map =
+         rcp (new map_type (INVALID,
+                            tgt_num_local_elements,
+                            indexBase, comm));
+       //src_map->describe(out, Teuchos::VERB_EXTREME);
+       //tgt_map->describe(out, Teuchos::VERB_EXTREME);
+
+       // Build src graph. Allow for up to 2 off-diagonal entries.
+       Teuchos::RCP<crs_graph_type> src_graph =
+         Teuchos::rcp (new crs_graph_type (src_map, 3));
+       {
+         Array<GO> cols(3);
+         for (GO globalrow = src_map->getMinGlobalIndex ();
+              globalrow <= src_map->getMaxGlobalIndex (); ++globalrow) {
+           if      (globalrow==0) cols.resize(1);
+           else if (globalrow==1) cols.resize(2);
+           else                   cols.resize(3);
+           for (GO col = 0; col < cols.size(); ++col) {
+             cols[col] = globalrow - col;
+           }
+           src_graph->insertGlobalIndices (globalrow, cols());
+         }
+         src_graph->fillComplete();
+         //src_graph->describe(out, Teuchos::VERB_EXTREME);
+       }
+
+       // Build src matrix. Simple block lower-diagonal matrix with
+       // A(b1,b2) = [(b1)+10*(b2+1)].
+       RCP<block_crs_type> src_mat =
+         rcp (new block_crs_type (*src_graph, blocksize));
+       build_lower_diag_matrix<block_crs_type>(src_mat);
+       //src_mat->describe(out, Teuchos::VERB_EXTREME);
+
+       // Create the importer
+       import_type importer (src_map, tgt_map);
+
+       // Call importAndFillComplete to get the tgt matrix
+       RCP<block_crs_type> tgt_mat =
+         Tpetra::importAndFillCompleteBlockCrsMatrix<block_crs_type> (src_mat, importer);
+       //tgt_mat->describe(out, Teuchos::VERB_EXTREME);
+
+       // Manually build the tgt matrix and test that it matches the returned matrix
+
+       // Build tgt graph.
+       Teuchos::RCP<crs_graph_type> tgt_graph_for_testing =
+         Teuchos::rcp (new crs_graph_type (tgt_map, 3));
+       {
+         Array<GO> cols(3);
+         for (GO globalrow = tgt_map->getMinGlobalIndex ();
+              globalrow <= tgt_map->getMaxGlobalIndex (); ++globalrow) {
+           if      (globalrow==0) cols.resize(1);
+           else if (globalrow==1) cols.resize(2);
+           else                   cols.resize(3);
+           for (GO col = 0; col < cols.size(); ++col) {
+             cols[col] = globalrow - col;
+           }
+           tgt_graph_for_testing->insertGlobalIndices (globalrow, cols());
+         }
+         tgt_graph_for_testing->fillComplete();
+         //tgt_graph_for_testing->describe(out, Teuchos::VERB_EXTREME);
+       }
+
+       // Build tgt matrix
+       RCP<block_crs_type> tgt_mat_for_testing =
+         rcp (new block_crs_type (*tgt_graph_for_testing, blocksize));
+       build_lower_diag_matrix<block_crs_type>(tgt_mat_for_testing);
+       //tgt_mat_for_testing->describe(out, Teuchos::VERB_EXTREME);
+
+       // Test that matrices are identical
+       bool matrices_match = matrices_are_same<block_crs_type>(tgt_mat, tgt_mat_for_testing);
+       TEST_ASSERT(matrices_match);
+      }
+      catch (std::exception& e) { // end of the first test
+        err << "Proc " << myRank << ": " << e.what () << endl;
+        lclErr = 1;
+      }
+
+      reduceAll<int, int> (*comm, REDUCE_MAX, lclErr, outArg (gblErr));
+      TEST_EQUALITY_CONST( gblErr, 0 );
+      if (gblErr != 0) {
+        Tpetra::Details::gathervPrint (out, err.str (), *comm);
+        out << "Above test failed; aborting further tests" << endl;
+        return;
+      }
    }
 
   // Test BlockCrsMatrix Export for different graphs with different


### PR DESCRIPTION
Adds a `BlockCrsMatrix::importAndFillComplete()` function.

## Motivation
BlockCrsMatrix does not currently have a Matrix-Matrix multiple. This import function is necessary for that.

## Issue
#10748

## Testing
Test added

## Stakeholder feedback
@csiefer: "This is good!"


