### PR TITLE
Stokhos: support for custom types in `Sacado::MP::Vector`

### DIFF
--- a/packages/stokhos/src/sacado/kokkos/Stokhos_DynamicStorage.hpp
+++ b/packages/stokhos/src/sacado/kokkos/Stokhos_DynamicStorage.hpp
@@ -498,20 +498,7 @@ namespace Stokhos {
 
 }
 
-namespace Sacado {
-  template <typename ordinal_t, typename value_t, typename device_t>
-  struct StringName< Stokhos::DynamicStorage<ordinal_t,
-                                             value_t,
-                                             device_t> > {
-    static std::string eval() {
-      std::stringstream ss;
-      ss << "Stokhos::DynamicStorage<"
-         << StringName<ordinal_t>::eval() << ","
-         << StringName<value_t>::eval() << ","
-         << StringName<device_t>::eval() << ">";
-      return ss.str();
-    }
-  };
-}
+#include "Stokhos_StorageHelpers.hpp"
+STOKHOS_STORAGE_HELPER_STRINGNAME_DYNAMIC(DynamicStorage)
 
 #endif // STOKHOS_DYNAMIC_STORAGE_HPP

--- a/packages/stokhos/src/sacado/kokkos/Stokhos_DynamicStridedStorage.hpp
+++ b/packages/stokhos/src/sacado/kokkos/Stokhos_DynamicStridedStorage.hpp
@@ -463,20 +463,7 @@ namespace Stokhos {
 
 }
 
-namespace Sacado {
-  template <typename ordinal_t, typename value_t, typename device_t>
-  struct StringName< Stokhos::DynamicStridedStorage<ordinal_t,
-                                                    value_t,
-                                                    device_t> > {
-    static std::string eval() {
-      std::stringstream ss;
-      ss << "Stokhos::DynamicStridedStorage<"
-         << StringName<ordinal_t>::eval() << ","
-         << StringName<value_t>::eval() << ","
-         << StringName<device_t>::eval() << ">";
-      return ss.str();
-    }
-  };
-}
+#include "Stokhos_StorageHelpers.hpp"
+STOKHOS_STORAGE_HELPER_STRINGNAME_DYNAMIC(DynamicStridedStorage)
 
 #endif // STOKHOS_DYNAMIC_STORAGE_HPP

--- a/packages/stokhos/src/sacado/kokkos/Stokhos_DynamicThreadedStorage.hpp
+++ b/packages/stokhos/src/sacado/kokkos/Stokhos_DynamicThreadedStorage.hpp
@@ -56,21 +56,8 @@ namespace Stokhos {
 
 }
 
-namespace Sacado {
-  template <typename ordinal_t, typename value_t, typename device_t>
-  struct StringName< Stokhos::DynamicThreadedStorage<ordinal_t,
-                                                     value_t,
-                                                     device_t> > {
-    static std::string eval() {
-      std::stringstream ss;
-      ss << "Stokhos::DynamicThreadedStorage<"
-         << StringName<ordinal_t>::eval() << ","
-         << StringName<value_t>::eval() << ","
-         << StringName<device_t>::eval() << ">";
-      return ss.str();
-    }
-  };
-}
+#include "Stokhos_StorageHelpers.hpp"
+STOKHOS_STORAGE_HELPER_STRINGNAME_DYNAMIC(DynamicThreadedStorage)
 
 // No Host specialization
 

--- a/packages/stokhos/src/sacado/kokkos/Stokhos_StaticFixedStorage.hpp
+++ b/packages/stokhos/src/sacado/kokkos/Stokhos_StaticFixedStorage.hpp
@@ -522,22 +522,7 @@ namespace Stokhos {
 
 }
 
-namespace Sacado {
-  template <typename ordinal_t, typename value_t, int Num, typename device_t>
-  struct StringName< Stokhos::StaticFixedStorage<ordinal_t,
-                                                 value_t,
-                                                 Num,
-                                                 device_t> > {
-    static std::string eval() {
-      std::stringstream ss;
-      ss << "Stokhos::StaticFixedStorage<"
-         << StringName<ordinal_t>::eval() << ","
-         << StringName<value_t>::eval() << ","
-         << Num << ","
-         << StringName<device_t>::eval() << ">";
-      return ss.str();
-    }
-  };
-}
+#include "Stokhos_StorageHelpers.hpp"
+STOKHOS_STORAGE_HELPER_STRINGNAME_STATIC(StaticFixedStorage)
 
 #endif // STOKHOS_STATIC_FIXED_STORAGE_HPP

--- a/packages/stokhos/src/sacado/kokkos/Stokhos_StaticStorage.hpp
+++ b/packages/stokhos/src/sacado/kokkos/Stokhos_StaticStorage.hpp
@@ -287,22 +287,7 @@ namespace Stokhos {
 
 }
 
-namespace Sacado {
-  template <typename ordinal_t, typename value_t, int Num, typename device_t>
-  struct StringName< Stokhos::StaticStorage<ordinal_t,
-                                            value_t,
-                                            Num,
-                                            device_t> > {
-    static std::string eval() {
-      std::stringstream ss;
-      ss << "Stokhos::StaticStorage<"
-         << StringName<ordinal_t>::eval() << ","
-         << StringName<value_t>::eval() << ","
-         << Num << ","
-         << StringName<device_t>::eval() << ">";
-      return ss.str();
-    }
-  };
-}
+#include "Stokhos_StorageHelpers.hpp"
+STOKHOS_STORAGE_HELPER_STRINGNAME_STATIC(StaticStorage)
 
 #endif // STOKHOS_STATIC_STORAGE_HPP

--- a/packages/stokhos/src/sacado/kokkos/Stokhos_StorageHelpers.hpp
+++ b/packages/stokhos/src/sacado/kokkos/Stokhos_StorageHelpers.hpp
@@ -1,0 +1,46 @@
+#ifndef STOKHOS_STORAGE_HELPERS_HPP
+#define STOKHOS_STORAGE_HELPERS_HPP
+
+#define STOKHOS_STORAGE_HELPER_STRINGNAME_DYNAMIC(__storagename__)     \
+  namespace Sacado                                                     \
+  {                                                                    \
+    template <typename ordinal_t, typename value_t, typename device_t> \
+    struct StringName<Stokhos::__storagename__<ordinal_t,              \
+                                               value_t,                \
+                                               device_t>>              \
+    {                                                                  \
+      static std::string eval()                                        \
+      {                                                                \
+        std::stringstream ss;                                          \
+        ss << "Stokhos::" #__storagename__ "<"                         \
+           << StringName<ordinal_t>::eval() << ","                     \
+           << StringName<value_t>::eval() << ","                       \
+           << StringName<device_t>::eval() << ">";                     \
+        return ss.str();                                               \
+      }                                                                \
+    };                                                                 \
+  }
+
+#define STOKHOS_STORAGE_HELPER_STRINGNAME_STATIC(__storagename__)                   \
+    namespace Sacado                                                                \
+    {                                                                               \
+        template <typename ordinal_t, typename value_t, int Num, typename device_t> \
+        struct StringName<Stokhos::__storagename__<ordinal_t,                       \
+                                                   value_t,                         \
+                                                   Num,                             \
+                                                   device_t>>                       \
+        {                                                                           \
+            static std::string eval()                                               \
+            {                                                                       \
+                std::stringstream ss;                                               \
+                ss << "Stokhos::" #__storagename__ "<"                              \
+                   << StringName<ordinal_t>::eval() << ","                          \
+                   << StringName<value_t>::eval() << ","                            \
+                   << Num << ","                                                    \
+                   << StringName<device_t>::eval() << ">";                          \
+                return ss.str();                                                    \
+            }                                                                       \
+        };                                                                          \
+    }
+
+#endif // STOKHOS_STORAGE_HELPERS_HPP

--- a/packages/stokhos/src/sacado/kokkos/vector/Sacado_MP_Vector_ops.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/Sacado_MP_Vector_ops.hpp
@@ -115,7 +115,7 @@ namespace Sacado {
 }
 */
 
-#define MP_UNARYOP_MACRO(OPNAME,OP,OPER)                                \
+#define MP_UNARYOP_MACRO(OPNAME,OP,OPER,USING_OP)                       \
 namespace Sacado {                                                      \
   namespace MP {                                                        \
                                                                         \
@@ -150,22 +150,26 @@ namespace Sacado {                                                      \
                                                                         \
       KOKKOS_INLINE_FUNCTION                                            \
       value_type val() const {                                          \
+        USING_OP                                                        \
         return OPER(expr.val());                                        \
       }                                                                 \
                                                                         \
       KOKKOS_INLINE_FUNCTION                                            \
       value_type coeff(int i) const {                                   \
+        USING_OP                                                        \
         return OPER(expr.coeff(i));                                     \
       }                                                                 \
                                                                         \
       KOKKOS_INLINE_FUNCTION                                            \
       value_type fastAccessCoeff(int i) const {                         \
+        USING_OP                                                        \
         return OPER(expr.fastAccessCoeff(i));                           \
       }                                                                 \
                                                                         \
       template <int i>                                                  \
       KOKKOS_INLINE_FUNCTION                                            \
       value_type getCoeff() const {                                     \
+        USING_OP                                                        \
         return OPER(expr.template getCoeff<i>());                       \
       }                                                                 \
                                                                         \
@@ -216,28 +220,28 @@ namespace Sacado {                                                      \
   };                                                                    \
 }
 
-MP_UNARYOP_MACRO(operator+, UnaryPlusOp, +)
-MP_UNARYOP_MACRO(operator-, UnaryMinusOp, -)
-MP_UNARYOP_MACRO(exp, ExpOp, std::exp)
-MP_UNARYOP_MACRO(log, LogOp, std::log)
-MP_UNARYOP_MACRO(log10, Log10Op, std::log10)
-MP_UNARYOP_MACRO(sqrt, SqrtOp, std::sqrt)
-MP_UNARYOP_MACRO(cbrt, CbrtOp, std::cbrt)
-MP_UNARYOP_MACRO(cos, CosOp, std::cos)
-MP_UNARYOP_MACRO(sin, SinOp, std::sin)
-MP_UNARYOP_MACRO(tan, TanOp, std::tan)
-MP_UNARYOP_MACRO(acos, ACosOp, std::acos)
-MP_UNARYOP_MACRO(asin, ASinOp, std::asin)
-MP_UNARYOP_MACRO(atan, ATanOp, std::atan)
-MP_UNARYOP_MACRO(cosh, CoshOp, std::cosh)
-MP_UNARYOP_MACRO(sinh, SinhOp, std::sinh)
-MP_UNARYOP_MACRO(tanh, TanhOp, std::tanh)
-MP_UNARYOP_MACRO(acosh, ACoshOp, std::acosh)
-MP_UNARYOP_MACRO(asinh, ASinhOp, std::asinh)
-MP_UNARYOP_MACRO(atanh, ATanhOp, std::atanh)
-MP_UNARYOP_MACRO(abs, AbsOp, std::abs)
-MP_UNARYOP_MACRO(fabs, FAbsOp, std::fabs)
-MP_UNARYOP_MACRO(ceil, CeilOp, std::ceil)
+MP_UNARYOP_MACRO(operator+, UnaryPlusOp , +    , )
+MP_UNARYOP_MACRO(operator-, UnaryMinusOp, -    , )
+MP_UNARYOP_MACRO(exp      , ExpOp       , exp  , using std::exp;)
+MP_UNARYOP_MACRO(log      , LogOp       , log  , using std::log;)
+MP_UNARYOP_MACRO(log10    , Log10Op     , log10, using std::log10;)
+MP_UNARYOP_MACRO(sqrt     , SqrtOp      , sqrt , using std::sqrt;)
+MP_UNARYOP_MACRO(cbrt     , CbrtOp      , cbrt , using std::cbrt;)
+MP_UNARYOP_MACRO(cos      , CosOp       , cos  , using std::cos;)
+MP_UNARYOP_MACRO(sin      , SinOp       , sin  , using std::sin;)
+MP_UNARYOP_MACRO(tan      , TanOp       , tan  , using std::tan;)
+MP_UNARYOP_MACRO(acos     , ACosOp      , acos , using std::acos;)
+MP_UNARYOP_MACRO(asin     , ASinOp      , asin , using std::asin;)
+MP_UNARYOP_MACRO(atan     , ATanOp      , atan , using std::atan;)
+MP_UNARYOP_MACRO(cosh     , CoshOp      , cosh , using std::cosh;)
+MP_UNARYOP_MACRO(sinh     , SinhOp      , sinh , using std::sinh;)
+MP_UNARYOP_MACRO(tanh     , TanhOp      , tanh , using std::tanh;)
+MP_UNARYOP_MACRO(acosh    , ACoshOp     , acosh, using std::acosh;)
+MP_UNARYOP_MACRO(asinh    , ASinhOp     , asinh, using std::asinh;)
+MP_UNARYOP_MACRO(atanh    , ATanhOp     , atanh, using std::atanh;)
+MP_UNARYOP_MACRO(abs      , AbsOp       , abs  , using std::abs;)
+MP_UNARYOP_MACRO(fabs     , FAbsOp      , fabs , using std::fabs;)
+MP_UNARYOP_MACRO(ceil     , CeilOp      , ceil , using std::ceil;)
 
 #undef MP_UNARYOP_MACRO
 
@@ -559,7 +563,7 @@ MP_BINARYOP_MACRO(operator/, DivisionOp, /)
 
 #undef MP_BINARYOP_MACRO
 
-#define MP_BINARYOP_MACRO(OPNAME,OP,OPER)                               \
+#define MP_BINARYOP_MACRO(OPNAME,OP,OPER,USING_OP)                      \
 namespace Sacado {                                                      \
   namespace MP {                                                        \
                                                                         \
@@ -600,22 +604,26 @@ namespace Sacado {                                                      \
                                                                         \
       KOKKOS_INLINE_FUNCTION                                            \
       value_type val() const {                                          \
+        USING_OP                                                        \
         return OPER(expr1.val(), expr2.val());                          \
       }                                                                 \
                                                                         \
       KOKKOS_INLINE_FUNCTION                                            \
       value_type coeff(int i) const {                                   \
+        USING_OP                                                        \
         return OPER(expr1.coeff(i), expr2.coeff(i));                    \
       }                                                                 \
                                                                         \
       KOKKOS_INLINE_FUNCTION                                            \
       value_type fastAccessCoeff(int i) const {                         \
+        USING_OP                                                        \
         return OPER(expr1.fastAccessCoeff(i), expr2.fastAccessCoeff(i)); \
       }                                                                 \
                                                                         \
       template <int i>                                                  \
       KOKKOS_INLINE_FUNCTION                                            \
       value_type getCoeff() const {                                     \
+        USING_OP                                                        \
         return OPER(expr1.template getCoeff<i>(),                       \
                     expr2.template getCoeff<i>());                      \
       }                                                                 \
@@ -658,22 +666,26 @@ namespace Sacado {                                                      \
                                                                         \
       KOKKOS_INLINE_FUNCTION                                            \
       value_type val() const {                                          \
+        USING_OP                                                        \
         return OPER(expr1.val(), c);                                    \
       }                                                                 \
                                                                         \
       KOKKOS_INLINE_FUNCTION                                            \
       value_type coeff(int i) const {                                   \
+        USING_OP                                                        \
         return OPER(expr1.coeff(i), c);                                 \
       }                                                                 \
                                                                         \
       KOKKOS_INLINE_FUNCTION                                            \
       value_type fastAccessCoeff(int i) const {                         \
+        USING_OP                                                        \
         return OPER(expr1.fastAccessCoeff(i), c);                       \
       }                                                                 \
                                                                         \
       template <int i>                                                  \
         KOKKOS_INLINE_FUNCTION                                          \
       value_type getCoeff() const {                                     \
+        USING_OP                                                        \
         return OPER(expr1.template getCoeff<i>(), c);                   \
       }                                                                 \
                                                                         \
@@ -714,22 +726,26 @@ namespace Sacado {                                                      \
                                                                         \
       KOKKOS_INLINE_FUNCTION                                            \
       value_type val() const {                                          \
+        USING_OP                                                        \
         return OPER(c, expr2.val());                                    \
       }                                                                 \
                                                                         \
       KOKKOS_INLINE_FUNCTION                                            \
       value_type coeff(int i) const {                                   \
+        USING_OP                                                        \
         return OPER(c, expr2.coeff(i));                                 \
       }                                                                 \
                                                                         \
       KOKKOS_INLINE_FUNCTION                                            \
       value_type fastAccessCoeff(int i) const {                         \
+        USING_OP                                                        \
         return OPER(c, expr2.fastAccessCoeff(i));                       \
       }                                                                 \
                                                                         \
       template <int i>                                                  \
       KOKKOS_INLINE_FUNCTION                                            \
       value_type getCoeff() const {                                     \
+        USING_OP                                                        \
         return OPER(c, expr2.template getCoeff<i>());                   \
       }                                                                 \
                                                                         \
@@ -796,14 +812,14 @@ namespace Sacado {                                                      \
   };                                                                    \
 }
 
-MP_BINARYOP_MACRO(atan2, Atan2Op, std::atan2)
-MP_BINARYOP_MACRO(pow, PowerOp, std::pow)
+MP_BINARYOP_MACRO(atan2, Atan2Op, atan2, using std::atan2;)
+MP_BINARYOP_MACRO(pow  , PowerOp, pow  , using std::pow;  )
 #ifdef __CUDACC__
-MP_BINARYOP_MACRO(max, MaxOp, ::max)
-MP_BINARYOP_MACRO(min, MinOp, ::min)
+MP_BINARYOP_MACRO(max, MaxOp, ::max, using std::max;)
+MP_BINARYOP_MACRO(min, MinOp, ::min, using std::min;)
 #else
-MP_BINARYOP_MACRO(max, MaxOp, std::max)
-MP_BINARYOP_MACRO(min, MinOp, std::min)
+MP_BINARYOP_MACRO(max, MaxOp, max, using std::max;)
+MP_BINARYOP_MACRO(min, MinOp, min, using std::min;)
 #endif
 
 #undef MP_BINARYOP_MACRO

--- a/packages/stokhos/test/UnitTest/CMakeLists.txt
+++ b/packages/stokhos/test/UnitTest/CMakeLists.txt
@@ -1,5 +1,16 @@
 ASSERT_DEFINED(PACKAGE_SOURCE_DIR CMAKE_CURRENT_SOURCE_DIR)
 
+# Unit test static library containing 'int main' that initializes:
+#   - Teuchos MPI Comm
+#   - Kokkos
+TRIBITS_ADD_LIBRARY(
+  Stokhos_UnitTestBaseLib
+  TESTONLY
+  STATIC
+  SOURCES 
+      Stokhos_UnitTestBase.cpp
+)
+
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   LegendreBasisUnitTest
   SOURCES Stokhos_LegendreBasisUnitTest.cpp
@@ -154,6 +165,7 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   ExponentialRandomFieldUnitTest
   SOURCES Stokhos_ExponentialRandomFieldUnitTest.cpp
+  TESTONLYLIBS Stokhos_UnitTestBaseLib
   COMM serial mpi
   STANDARD_PASS_OUTPUT
   NUM_MPI_PROCS 1
@@ -380,6 +392,7 @@ IF(Stokhos_ENABLE_Sacado)
     TRIBITS_ADD_EXECUTABLE_AND_TEST(
       SacadoUQPCEUnitTest
       SOURCES Stokhos_SacadoUQPCEUnitTest.cpp
+      TESTONLYLIBS Stokhos_UnitTestBaseLib
       COMM serial mpi
       STANDARD_PASS_OUTPUT
       NUM_MPI_PROCS 1
@@ -388,6 +401,7 @@ IF(Stokhos_ENABLE_Sacado)
     TRIBITS_ADD_EXECUTABLE_AND_TEST(
       SacadoUQPCESerializationTests
       SOURCES Stokhos_SacadoUQPCESerializationTests.cpp ${UTILS_SOURCES}
+      TESTONLYLIBS Stokhos_UnitTestBaseLib
       ARGS
       COMM serial mpi
       NUM_MPI_PROCS 1
@@ -397,6 +411,7 @@ IF(Stokhos_ENABLE_Sacado)
     TRIBITS_ADD_EXECUTABLE_AND_TEST(
       SacadoUQPCECommTests
       SOURCES Stokhos_SacadoUQPCECommTests.cpp ${UTILS_SOURCES}
+      TESTONLYLIBS Stokhos_UnitTestBaseLib
       ARGS
       COMM serial mpi
       NUM_MPI_PROCS 1
@@ -420,6 +435,7 @@ IF(Stokhos_ENABLE_Sacado)
         KokkosViewUQPCEUnitTest_Serial
         SOURCES Stokhos_KokkosViewUQPCEUnitTest.hpp
                 Stokhos_KokkosViewUQPCEUnitTest_Serial.cpp
+        TESTONLYLIBS Stokhos_UnitTestBaseLib
         COMM serial mpi
         STANDARD_PASS_OUTPUT
         NUM_MPI_PROCS 1
@@ -469,6 +485,7 @@ IF(Stokhos_ENABLE_Sacado)
           KokkosCrsMatrixUQPCEUnitTest_Serial
           SOURCES Stokhos_KokkosCrsMatrixUQPCEUnitTest.hpp
                   Stokhos_KokkosCrsMatrixUQPCEUnitTest_Serial.cpp
+          TESTONLYLIBS Stokhos_UnitTestBaseLib
           COMM serial mpi
           STANDARD_PASS_OUTPUT
           NUM_MPI_PROCS 1
@@ -558,6 +575,7 @@ IF(Stokhos_ENABLE_Sacado)
     TRIBITS_ADD_EXECUTABLE_AND_TEST(
       SacadoMPVectorUnitTest
       SOURCES Stokhos_SacadoMPVectorUnitTest.cpp
+      TESTONLYLIBS Stokhos_UnitTestBaseLib
       COMM serial mpi
       STANDARD_PASS_OUTPUT
       NUM_MPI_PROCS 1
@@ -566,6 +584,7 @@ IF(Stokhos_ENABLE_Sacado)
     TRIBITS_ADD_EXECUTABLE_AND_TEST(
       SacadoMPVectorUnitTestMaskTraits
       SOURCES Stokhos_SacadoMPVectorUnitTest_MaskTraits.cpp
+      TESTONLYLIBS Stokhos_UnitTestBaseLib
       COMM serial mpi
       STANDARD_PASS_OUTPUT
       NUM_MPI_PROCS 1
@@ -606,6 +625,7 @@ IF(Stokhos_ENABLE_Sacado)
         KokkosViewMPVectorUnitTest_Serial
         SOURCES Stokhos_KokkosViewMPVectorUnitTest.hpp
                 Stokhos_KokkosViewMPVectorUnitTest_Serial.cpp
+        TESTONLYLIBS Stokhos_UnitTestBaseLib
         COMM serial mpi
         STANDARD_PASS_OUTPUT
         NUM_MPI_PROCS 1
@@ -665,6 +685,7 @@ IF(Stokhos_ENABLE_Sacado)
           KokkosCrsMatrixMPVectorUnitTest_Serial
           SOURCES Stokhos_KokkosCrsMatrixMPVectorUnitTest.hpp
                   Stokhos_KokkosCrsMatrixMPVectorUnitTest_Serial.cpp
+          TESTONLYLIBS Stokhos_UnitTestBaseLib
           COMM serial mpi
           STANDARD_PASS_OUTPUT
           NUM_MPI_PROCS 1
@@ -674,6 +695,7 @@ IF(Stokhos_ENABLE_Sacado)
           KokkosViewFadMPVectorUnitTest_Serial
           SOURCES Stokhos_KokkosViewFadMPVectorUnitTest.hpp
                   Stokhos_KokkosViewFadMPVectorUnitTest_Serial.cpp
+          TESTONLYLIBS Stokhos_UnitTestBaseLib
           COMM serial mpi
           STANDARD_PASS_OUTPUT
           NUM_MPI_PROCS 1

--- a/packages/stokhos/test/UnitTest/Stokhos_ExponentialRandomFieldUnitTest.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_ExponentialRandomFieldUnitTest.cpp
@@ -341,11 +341,3 @@ namespace ExponentialRandomFieldUnitTest {
   }
 
 }
-
-int main( int argc, char* argv[] ) {
-  Teuchos::GlobalMPISession mpiSession(&argc, &argv);
-  Kokkos::initialize();
-  int ret = Teuchos::UnitTestRepository::runUnitTestsFromMain(argc, argv);
-  Kokkos::finalize();
-  return ret;
-}

--- a/packages/stokhos/test/UnitTest/Stokhos_KokkosCrsMatrixMPVectorUnitTest_Serial.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_KokkosCrsMatrixMPVectorUnitTest_Serial.cpp
@@ -112,18 +112,3 @@ TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL(
   CRS_MATRIX_MP_VECTOR_MULTIPLY_TESTS_STORAGE_OP( DS, KokkosMultiply )
 
 CRS_MATRIX_MP_VECTOR_MULTIPLY_TESTS_ORDINAL_SCALAR_DEVICE(int, double, Serial)
-
-int main( int argc, char* argv[] ) {
-  Teuchos::GlobalMPISession mpiSession(&argc, &argv);
-
-  // Initialize serial
-  Kokkos::initialize();
-
-  // Run tests
-  int ret = Teuchos::UnitTestRepository::runUnitTestsFromMain(argc, argv);
-
-  // Finish up
-  Kokkos::finalize();
-
-  return ret;
-}

--- a/packages/stokhos/test/UnitTest/Stokhos_KokkosCrsMatrixUQPCEUnitTest_Serial.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_KokkosCrsMatrixUQPCEUnitTest_Serial.cpp
@@ -50,18 +50,3 @@
 // Instantiate test for Serial device
 using Kokkos::Serial;
 CRSMATRIX_UQ_PCE_TESTS_DEVICE( Serial )
-
-int main( int argc, char* argv[] ) {
-  Teuchos::GlobalMPISession mpiSession(&argc, &argv);
-
-  // Initialize serial
-  Kokkos::initialize();
-
-  // Run tests
-  int ret = Teuchos::UnitTestRepository::runUnitTestsFromMain(argc, argv);
-
-  // Finish up
-  Kokkos::finalize();
-
-  return ret;
-}

--- a/packages/stokhos/test/UnitTest/Stokhos_KokkosViewFadMPVectorUnitTest_Serial.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_KokkosViewFadMPVectorUnitTest_Serial.cpp
@@ -50,18 +50,3 @@
 // Instantiate test for Serial device
 using Kokkos::Serial;
 VIEW_FAD_MP_VECTOR_TESTS_DEVICE( Serial )
-
-int main( int argc, char* argv[] ) {
-  Teuchos::GlobalMPISession mpiSession(&argc, &argv);
-
-  // Initialize serial
-  Kokkos::initialize();
-
-  // Run tests
-  int ret = Teuchos::UnitTestRepository::runUnitTestsFromMain(argc, argv);
-
-  // Finish up
-  Kokkos::finalize();
-
-  return ret;
-}

--- a/packages/stokhos/test/UnitTest/Stokhos_KokkosViewMPVectorUnitTest_Serial.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_KokkosViewMPVectorUnitTest_Serial.cpp
@@ -50,18 +50,3 @@
 // Instantiate test for Serial device
 using Kokkos::Serial;
 VIEW_MP_VECTOR_TESTS_DEVICE( Serial )
-
-int main( int argc, char* argv[] ) {
-  Teuchos::GlobalMPISession mpiSession(&argc, &argv);
-
-  // Initialize serial
-  Kokkos::initialize();
-
-  // Run tests
-  int ret = Teuchos::UnitTestRepository::runUnitTestsFromMain(argc, argv);
-
-  // Finish up
-  Kokkos::finalize();
-
-  return ret;
-}

--- a/packages/stokhos/test/UnitTest/Stokhos_KokkosViewUQPCEUnitTest_Serial.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_KokkosViewUQPCEUnitTest_Serial.cpp
@@ -50,18 +50,3 @@
 // Instantiate test for Serial device
 using Kokkos::Serial;
 VIEW_UQ_PCE_TESTS_DEVICE( Serial )
-
-int main( int argc, char* argv[] ) {
-  Teuchos::GlobalMPISession mpiSession(&argc, &argv);
-
-  // Initialize serial
-  Kokkos::initialize();
-
-  // Run tests
-  int ret = Teuchos::UnitTestRepository::runUnitTestsFromMain(argc, argv);
-
-  // Finish up
-  Kokkos::finalize();
-
-  return ret;
-}

--- a/packages/stokhos/test/UnitTest/Stokhos_SacadoMPVectorUnitTest.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_SacadoMPVectorUnitTest.cpp
@@ -48,7 +48,6 @@
 #include "Stokhos_UnitTestHelpers.hpp"
 
 #include "Kokkos_Core.hpp"
-#include "Kokkos_ArithTraits.hpp"
 #include "Kokkos_Complex.hpp"
 
 //

--- a/packages/stokhos/test/UnitTest/Stokhos_SacadoMPVectorUnitTest.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_SacadoMPVectorUnitTest.cpp
@@ -47,7 +47,9 @@
 #include "Stokhos_Sacado_Kokkos_MP_Vector.hpp"
 #include "Stokhos_UnitTestHelpers.hpp"
 
-#include <Kokkos_Core.hpp>
+#include "Kokkos_Core.hpp"
+#include "Kokkos_ArithTraits.hpp"
+#include "Kokkos_Complex.hpp"
 
 //
 // Currently this doesn't test:
@@ -61,12 +63,13 @@ template <typename VectorType>
 struct UnitTestSetup {
 
   typedef VectorType vec_type;
+  typedef typename vec_type::value_type value_type;
 
   double rtol, atol;
   double crtol, catol;
   int sz;
   vec_type x, y, cx;
-  double a;
+  value_type a;
 
   UnitTestSetup() {
     rtol = 1e-4;
@@ -88,38 +91,51 @@ struct UnitTestSetup {
   }
 };
 
-#define UNARY_UNIT_TEST(VEC, OP, OPNAME)                                \
-  TEUCHOS_UNIT_TEST( VEC, OPNAME) {                                     \
+/**
+ * @def UNARY_UNIT_TEST
+ * Common series of test for any unary operator.
+ */
+#define UNARY_UNIT_TEST(VEC, SCALAR_T, OP, OPNAME, USING_OP)            \
+  TEUCHOS_UNIT_TEST( VEC##_##SCALAR_T, OPNAME) {                        \
     UTS setup;                                                          \
     UTS::vec_type u = OP(setup.x);                                      \
     UTS::vec_type v(setup.sz, 0.0);                                     \
     for (int i=0; i<setup.sz; i++)                                      \
+    {                                                                   \
+      USING_OP                                                          \
       v.fastAccessCoeff(i) = OP(setup.x.fastAccessCoeff(i));            \
+    }                                                                   \
     success = compareVecs(u, "u",v, "v",                                \
                           setup.rtol, setup.atol, out);                 \
   }                                                                     \
-  TEUCHOS_UNIT_TEST( VEC, OPNAME##_const) {                             \
+  TEUCHOS_UNIT_TEST( VEC##_##SCALAR_T, OPNAME##_const) {                \
     UTS setup;                                                          \
     UTS::vec_type u = OP(setup.cx);                                     \
     UTS::vec_type v(1, 0.0);                                            \
     for (int i=0; i<v.size(); i++)                                      \
+    {                                                                   \
+    USING_OP                                                            \
       v.fastAccessCoeff(i) = OP(setup.cx.fastAccessCoeff(0));           \
+    }                                                                   \
     success = compareVecs(u, "u",v, "v",                                \
                           setup.rtol, setup.atol, out);                 \
   }                                                                     \
-  TEUCHOS_UNIT_TEST( VEC, OPNAME##_resize) {                            \
+  TEUCHOS_UNIT_TEST( VEC##_##SCALAR_T, OPNAME##_resize) {               \
     UTS setup;                                                          \
     UTS::vec_type u;                                                    \
     u = OP(setup.x);                                                    \
     UTS::vec_type v(setup.sz, 0.0);                                     \
     for (int i=0; i<setup.sz; i++)                                      \
+    {                                                                   \
+    USING_OP                                                            \
       v.fastAccessCoeff(i) = OP(setup.x.fastAccessCoeff(i));            \
+    }                                                                   \
     success = compareVecs(u, "u",v, "v",                                \
                           setup.rtol, setup.atol, out);                 \
   }
 
-#define BINARY_UNIT_TEST(VEC, OP, OPNAME)                               \
-  TEUCHOS_UNIT_TEST( VEC, OPNAME) {                                     \
+#define BINARY_UNIT_TEST(VEC, SCALAR_T, OP, OPNAME)                     \
+  TEUCHOS_UNIT_TEST( VEC##_##SCALAR_T, OPNAME) {                        \
     UTS setup;                                                          \
     UTS::vec_type u = setup.x OP setup.y;                               \
     UTS::vec_type v(setup.sz, 0.0);                                     \
@@ -129,7 +145,7 @@ struct UnitTestSetup {
     success = compareVecs(u, "u",v, "v",                                \
                           setup.rtol, setup.atol, out);                 \
   }                                                                     \
-  TEUCHOS_UNIT_TEST( VEC, OPNAME##_left_const) {                        \
+  TEUCHOS_UNIT_TEST( VEC##_##SCALAR_T, OPNAME##_left_const) {           \
     UTS setup;                                                          \
     UTS::vec_type u = setup.a OP setup.y;                               \
     UTS::vec_type v(setup.sz, 0.0);                                     \
@@ -138,7 +154,7 @@ struct UnitTestSetup {
     success = compareVecs(u, "u",v, "v",                                \
                           setup.rtol, setup.atol, out);                 \
   }                                                                     \
-  TEUCHOS_UNIT_TEST( VEC, OPNAME##_right_const) {                       \
+  TEUCHOS_UNIT_TEST( VEC##_##SCALAR_T, OPNAME##_right_const) {          \
     UTS setup;                                                          \
     UTS::vec_type u = setup.x OP setup.a ;                              \
     UTS::vec_type v(setup.sz, 0.0);                                     \
@@ -148,7 +164,7 @@ struct UnitTestSetup {
     success = compareVecs(u, "u",v, "v",                                \
                           setup.rtol, setup.atol, out);                 \
   }                                                                     \
-  TEUCHOS_UNIT_TEST( VEC, OPNAME##_both_const) {                        \
+  TEUCHOS_UNIT_TEST( VEC##_##SCALAR_T, OPNAME##_both_const) {           \
     UTS setup;                                                          \
     UTS::vec_type u = setup.cx OP setup.cx;                             \
     UTS::vec_type v(1, 0.0);                                            \
@@ -158,7 +174,7 @@ struct UnitTestSetup {
     success = compareVecs(u, "u",v, "v",                                \
                           setup.rtol, setup.atol, out);                 \
   }                                                                     \
-  TEUCHOS_UNIT_TEST( VEC, OPNAME##_left_const2) {                       \
+  TEUCHOS_UNIT_TEST( VEC##_##SCALAR_T, OPNAME##_left_const2) {          \
     UTS setup;                                                          \
     UTS::vec_type u = setup.cx OP setup.x;                              \
     UTS::vec_type v(setup.sz, 0.0);                                     \
@@ -168,7 +184,7 @@ struct UnitTestSetup {
     success = compareVecs(u, "u",v, "v",                                \
                           setup.rtol, setup.atol, out);                 \
   }                                                                     \
-  TEUCHOS_UNIT_TEST( VEC, OPNAME##_right_const2) {                      \
+  TEUCHOS_UNIT_TEST( VEC##_##SCALAR_T, OPNAME##_right_const2) {         \
     UTS setup;                                                          \
     UTS::vec_type u = setup.x OP setup.cx;                              \
     UTS::vec_type v(setup.sz, 0.0);                                     \
@@ -178,7 +194,7 @@ struct UnitTestSetup {
     success = compareVecs(u, "u",v, "v",                                \
                           setup.rtol, setup.atol, out);                 \
   }                                                                     \
-  TEUCHOS_UNIT_TEST( VEC, OPNAME##_resize) {                            \
+  TEUCHOS_UNIT_TEST( VEC##_##SCALAR_T, OPNAME##_resize) {               \
     UTS setup;                                                          \
     UTS::vec_type u;                                                    \
     u = setup.x OP setup.y;                                             \
@@ -189,7 +205,7 @@ struct UnitTestSetup {
     success = compareVecs(u, "u",v, "v",                                \
                           setup.rtol, setup.atol, out);                 \
   }                                                                     \
-  TEUCHOS_UNIT_TEST( VEC, OPNAME##_left_const_resize) {                 \
+  TEUCHOS_UNIT_TEST( VEC##_##SCALAR_T, OPNAME##_left_const_resize) {    \
     UTS setup;                                                          \
     UTS::vec_type u;                                                    \
     u = setup.a OP setup.y;                                             \
@@ -200,7 +216,7 @@ struct UnitTestSetup {
     success = compareVecs(u, "u",v, "v",                                \
                           setup.rtol, setup.atol, out);                 \
   }                                                                     \
-  TEUCHOS_UNIT_TEST( VEC, OPNAME##_right_const_resize) {                \
+  TEUCHOS_UNIT_TEST( VEC##_##SCALAR_T, OPNAME##_right_const_resize) {   \
     UTS setup;                                                          \
     UTS::vec_type u;                                                    \
     u = setup.x OP setup.a;                                             \
@@ -212,103 +228,130 @@ struct UnitTestSetup {
                           setup.rtol, setup.atol, out);                 \
   }
 
-#define BINARYFUNC_UNIT_TEST(VEC, OP, SOP, OPNAME)                      \
-  TEUCHOS_UNIT_TEST( VEC, OPNAME) {                                     \
+#define BINARYFUNC_UNIT_TEST(VEC, SCALAR_T, OP, SOP, USING_SOP, OPNAME) \
+  TEUCHOS_UNIT_TEST( VEC##_##SCALAR_T, OPNAME) {                        \
     UTS setup;                                                          \
     UTS::vec_type u = OP(setup.x,setup.y);                              \
     UTS::vec_type v(setup.sz, 0.0);                                     \
     for (int i=0; i<setup.sz; i++)                                      \
+    {                                                                   \
+      USING_SOP                                                         \
       v.fastAccessCoeff(i) = SOP(setup.x.fastAccessCoeff(i),            \
                                 setup.y.fastAccessCoeff(i));            \
+    }                                                                   \
     success = compareVecs(u, "u",v, "v",                                \
                           setup.rtol, setup.atol, out);                 \
   }                                                                     \
-  TEUCHOS_UNIT_TEST( VEC, OPNAME##_left_const) {                        \
+  TEUCHOS_UNIT_TEST( VEC##_##SCALAR_T, OPNAME##_left_const) {           \
     UTS setup;                                                          \
     UTS::vec_type u = OP(setup.a,setup.y);                              \
     UTS::vec_type v(setup.sz, 0.0);                                     \
     for (int i=0; i<setup.sz; i++)                                      \
+    {                                                                   \
+      USING_SOP                                                         \
       v.fastAccessCoeff(i) = SOP(setup.a,                               \
                                 setup.y.fastAccessCoeff(i));            \
+    }                                                                   \
     success = compareVecs(u, "u",v, "v",                                \
                           setup.rtol, setup.atol, out);                 \
   }                                                                     \
-  TEUCHOS_UNIT_TEST( VEC, OPNAME##_right_const) {                       \
+  TEUCHOS_UNIT_TEST( VEC##_##SCALAR_T, OPNAME##_right_const) {          \
     UTS setup;                                                          \
     UTS::vec_type u = OP(setup.x,setup.a);                              \
     UTS::vec_type v(setup.sz, 0.0);                                     \
     for (int i=0; i<setup.sz; i++)                                      \
+    {                                                                   \
+      USING_SOP                                                         \
       v.fastAccessCoeff(i) = SOP(setup.x.fastAccessCoeff(i),            \
                                 setup.a);                               \
+    }                                                                   \
     success = compareVecs(u, "u",v, "v",                                \
                           setup.rtol, setup.atol, out);                 \
   }                                                                     \
-  TEUCHOS_UNIT_TEST( VEC, OPNAME##_both_const) {                        \
+  TEUCHOS_UNIT_TEST( VEC##_##SCALAR_T, OPNAME##_both_const) {           \
     UTS setup;                                                          \
     UTS::vec_type u = OP(setup.cx,setup.cx);                            \
     UTS::vec_type v(1, 0.0);                                            \
     for (int i=0; i<v.size(); i++)                                      \
+    {                                                                   \
+      USING_SOP                                                         \
       v.fastAccessCoeff(i) = SOP(setup.cx.fastAccessCoeff(0),           \
                                  setup.cx.fastAccessCoeff(0));          \
+    }                                                                   \
     success = compareVecs(u, "u",v, "v",                                \
                           setup.rtol, setup.atol, out);                 \
   }                                                                     \
-  TEUCHOS_UNIT_TEST( VEC, OPNAME##_left_const2) {                       \
+  TEUCHOS_UNIT_TEST( VEC##_##SCALAR_T, OPNAME##_left_const2) {          \
     UTS setup;                                                          \
     UTS::vec_type u = OP(setup.cx,setup.x);                             \
     UTS::vec_type v(setup.sz, 0.0);                                     \
     for (int i=0; i<setup.sz; i++)                                      \
+    {                                                                   \
+      USING_SOP                                                         \
       v.fastAccessCoeff(i) = SOP(setup.cx.fastAccessCoeff(0),           \
                                 setup.x.fastAccessCoeff(i));            \
+    }                                                                   \
     success = compareVecs(u, "u",v, "v",                                \
                           setup.rtol, setup.atol, out);                 \
   }                                                                     \
-  TEUCHOS_UNIT_TEST( VEC, OPNAME##_right_const2) {                      \
+  TEUCHOS_UNIT_TEST( VEC##_##SCALAR_T, OPNAME##_right_const2) {         \
     UTS setup;                                                          \
     UTS::vec_type u = OP(setup.x,setup.cx);                             \
     UTS::vec_type v(setup.sz, 0.0);                                     \
     for (int i=0; i<setup.sz; i++)                                      \
+    {                                                                   \
+      USING_SOP                                                         \
       v.fastAccessCoeff(i) = SOP(setup.x.fastAccessCoeff(i),            \
                                 setup.cx.fastAccessCoeff(0));           \
+    }                                                                   \
     success = compareVecs(u, "u",v, "v",                                \
                           setup.rtol, setup.atol, out);                 \
   }                                                                     \
-  TEUCHOS_UNIT_TEST( VEC, OPNAME##_resize) {                            \
+  TEUCHOS_UNIT_TEST( VEC##_##SCALAR_T, OPNAME##_resize) {               \
     UTS setup;                                                          \
     UTS::vec_type u;                                                    \
     u = OP(setup.x,setup.y);                                            \
     UTS::vec_type v(setup.sz, 0.0);                                     \
     for (int i=0; i<setup.sz; i++)                                      \
+    {                                                                   \
+      USING_SOP                                                         \
       v.fastAccessCoeff(i) = SOP(setup.x.fastAccessCoeff(i),            \
                                 setup.y.fastAccessCoeff(i));            \
+    }                                                                   \
     success = compareVecs(u, "u",v, "v",                                \
                           setup.rtol, setup.atol, out);                 \
   }                                                                     \
-  TEUCHOS_UNIT_TEST( VEC, OPNAME##_left_const_resize) {                 \
+  TEUCHOS_UNIT_TEST( VEC##_##SCALAR_T, OPNAME##_left_const_resize) {    \
     UTS setup;                                                          \
     UTS::vec_type u;                                                    \
     u = OP(setup.a,setup.y);                                            \
     UTS::vec_type v(setup.sz, 0.0);                                     \
     for (int i=0; i<setup.sz; i++)                                      \
+    {                                                                   \
+      USING_SOP                                                         \
       v.fastAccessCoeff(i) = SOP(setup.a,                               \
                                 setup.y.fastAccessCoeff(i));            \
+    }                                                                   \
     success = compareVecs(u, "u",v, "v",                                \
                           setup.rtol, setup.atol, out);                 \
   }                                                                     \
-  TEUCHOS_UNIT_TEST( VEC, OPNAME##_right_const_resize) {                \
+  TEUCHOS_UNIT_TEST( VEC##_##SCALAR_T, OPNAME##_right_const_resize) {   \
     UTS setup;                                                          \
     UTS::vec_type u;                                                    \
     u = OP(setup.x,setup.a);                                            \
     UTS::vec_type v(setup.sz, 0.0);                                     \
     for (int i=0; i<setup.sz; i++)                                      \
+    {                                                                   \
+      USING_SOP                                                         \
       v.fastAccessCoeff(i) = SOP(setup.x.fastAccessCoeff(i),            \
                                 setup.a);                               \
+    }                                                                   \
     success = compareVecs(u, "u",v, "v",                                \
                           setup.rtol, setup.atol, out);                 \
   }
 
-#define OPASSIGN_UNIT_TEST(VEC, OP, OPNAME)                             \
-  TEUCHOS_UNIT_TEST( VEC, OPNAME) {                                     \
+#define OPASSIGN_UNIT_TEST(VEC, SCALAR_T, OP, OPNAME)                   \
+  TEUCHOS_UNIT_TEST( VEC##_##SCALAR_T, OPNAME) {                        \
     UTS setup;                                                          \
     UTS::vec_type u = std::sin(setup.x);                                \
     UTS::vec_type v = std::sin(setup.x);                                \
@@ -318,7 +361,7 @@ struct UnitTestSetup {
     success = compareVecs(u, "u",v, "v",                                \
                           setup.rtol, setup.atol, out);                 \
   }                                                                     \
-  TEUCHOS_UNIT_TEST( VEC, OPNAME##_const) {                             \
+  TEUCHOS_UNIT_TEST( VEC##_##SCALAR_T, OPNAME##_const) {                \
     UTS setup;                                                          \
     UTS::vec_type u = std::sin(setup.x);                                \
     UTS::vec_type v = std::sin(setup.x);                                \
@@ -328,7 +371,7 @@ struct UnitTestSetup {
     success = compareVecs(u, "u",v, "v",                                \
                           setup.rtol, setup.atol, out);                 \
   }                                                                     \
-  TEUCHOS_UNIT_TEST( VEC, OPNAME##_const2) {                            \
+  TEUCHOS_UNIT_TEST( VEC##_##SCALAR_T, OPNAME##_const2) {               \
     UTS setup;                                                          \
     UTS::vec_type u = std::sin(setup.x);                                \
     UTS::vec_type v = std::sin(setup.x);                                \
@@ -338,7 +381,7 @@ struct UnitTestSetup {
     success = compareVecs(u, "u",v, "v",                                \
                           setup.rtol, setup.atol, out);                 \
   }                                                                     \
-  TEUCHOS_UNIT_TEST( VEC, OPNAME##_resize) {                            \
+  TEUCHOS_UNIT_TEST( VEC##_##SCALAR_T, OPNAME##_resize) {               \
     UTS setup;                                                          \
     UTS::vec_type u = setup.a;                                          \
     UTS::vec_type v(setup.sz, 0.0);                                     \
@@ -351,8 +394,8 @@ struct UnitTestSetup {
                           setup.rtol, setup.atol, out);                 \
   }
 
-#define SAXPY_UNIT_TEST(VEC)                                            \
-  TEUCHOS_UNIT_TEST( VEC, saxpy) {                                      \
+#define SAXPY_UNIT_TEST(VEC, SCALAR_T)                                  \
+  TEUCHOS_UNIT_TEST( VEC##_##SCALAR_T, saxpy) {                         \
     UTS setup;                                                          \
     UTS::vec_type u = std::sin(setup.x);                                \
     UTS::vec_type v = std::sin(setup.x);                                \
@@ -363,7 +406,7 @@ struct UnitTestSetup {
     success = compareVecs(u, "u",v, "v",                                \
                           setup.rtol, setup.atol, out);                 \
   }                                                                     \
-  TEUCHOS_UNIT_TEST( VEC, saxpy_resize) {                               \
+  TEUCHOS_UNIT_TEST( VEC##_##SCALAR_T, saxpy_resize) {                  \
     UTS setup;                                                          \
     UTS::vec_type u = setup.cx;                                         \
     UTS::vec_type v(setup.sz, 0.0);                                     \
@@ -374,7 +417,7 @@ struct UnitTestSetup {
     success = compareVecs(u, "u",v, "v",                                \
                           setup.rtol, setup.atol, out);                 \
   }                                                                     \
-  TEUCHOS_UNIT_TEST( VEC, saxpy_const) {                                \
+  TEUCHOS_UNIT_TEST( VEC##_##SCALAR_T, saxpy_const) {                   \
     UTS setup;                                                          \
     UTS::vec_type u = std::sin(setup.x);                                \
     UTS::vec_type v = std::sin(setup.x);                                \
@@ -385,7 +428,7 @@ struct UnitTestSetup {
     success = compareVecs(u, "u",v, "v",                                \
                           setup.rtol, setup.atol, out);                 \
   }                                                                     \
-  TEUCHOS_UNIT_TEST( VEC, saxpy_const2) {                               \
+  TEUCHOS_UNIT_TEST( VEC##_##SCALAR_T, saxpy_const2) {                  \
     UTS setup;                                                          \
     UTS::vec_type u = std::sin(setup.x);                                \
     UTS::vec_type v = std::sin(setup.x);                                \
@@ -397,8 +440,8 @@ struct UnitTestSetup {
                           setup.rtol, setup.atol, out);                 \
   }
 
-#define TERNARY_UNIT_TEST(VEC)                                          \
-  TEUCHOS_UNIT_TEST( VEC, ternay) {                                     \
+#define TERNARY_UNIT_TEST(VEC, SCALAR_T)                                \
+  TEUCHOS_UNIT_TEST( VEC##_##SCALAR_T, ternay) {                        \
     UTS setup;                                                          \
     UTS::vec_type u = std::sin(setup.x);                                \
     UTS::vec_type v = -std::sin(setup.x);                               \
@@ -407,46 +450,45 @@ struct UnitTestSetup {
                           setup.rtol, setup.atol, out);                 \
   }
 
-#define VECTOR_UNIT_TESTS(VEC)                                  \
-  UNARY_UNIT_TEST(VEC, +, UnaryPlus)                            \
-  UNARY_UNIT_TEST(VEC, -, UnaryMinus)                           \
-  UNARY_UNIT_TEST(VEC, std::exp, Exp)                           \
-  UNARY_UNIT_TEST(VEC, std::log, Log)                           \
-  UNARY_UNIT_TEST(VEC, std::log10, Log10)                       \
-  UNARY_UNIT_TEST(VEC, std::sqrt, Sqrt)                         \
-  UNARY_UNIT_TEST(VEC, std::cbrt, Cbrt)                         \
-  UNARY_UNIT_TEST(VEC, std::sin, Sin)                           \
-  UNARY_UNIT_TEST(VEC, std::cos, Cos)                           \
-  UNARY_UNIT_TEST(VEC, std::tan, Tan)                           \
-  UNARY_UNIT_TEST(VEC, std::sinh, Sinh)                         \
-  UNARY_UNIT_TEST(VEC, std::cosh, Cosh)                         \
-  UNARY_UNIT_TEST(VEC, std::tanh, Tanh)                         \
-  UNARY_UNIT_TEST(VEC, std::asin, ASin)                         \
-  UNARY_UNIT_TEST(VEC, std::acos, ACos)                         \
-  UNARY_UNIT_TEST(VEC, std::atan, ATan)                         \
-  UNARY_UNIT_TEST(VEC, std::asinh, ASinh)                       \
-  UNARY_UNIT_TEST(VEC, std::acosh, ACosh)                       \
-  UNARY_UNIT_TEST(VEC, std::atanh, ATanh)                       \
+/**
+ * Default series of tests to perform for any type.
+ * The set of operators should make sense for both real and complex types.
+ */
+#define VECTOR_UNIT_TESTS_ANY_TYPE(VEC,SCALAR_T)                        \
+  UNARY_UNIT_TEST(VEC, SCALAR_T, +    , UnaryPlus ,)                    \
+  UNARY_UNIT_TEST(VEC, SCALAR_T, -    , UnaryMinus,)                    \
+  UNARY_UNIT_TEST(VEC, SCALAR_T, exp  , Exp       , using std::exp;  )  \
+  UNARY_UNIT_TEST(VEC, SCALAR_T, log  , Log       , using std::log;  )  \
+  UNARY_UNIT_TEST(VEC, SCALAR_T, log10, Log10     , using std::log10;)  \
+  UNARY_UNIT_TEST(VEC, SCALAR_T, sqrt , Sqrt      , using std::sqrt; )  \
+  UNARY_UNIT_TEST(VEC, SCALAR_T, sin  , Sin       , using std::sin;  )  \
+  UNARY_UNIT_TEST(VEC, SCALAR_T, cos  , Cos       , using std::cos;  )  \
+  UNARY_UNIT_TEST(VEC, SCALAR_T, tan  , Tan       , using std::tan;  )  \
+  UNARY_UNIT_TEST(VEC, SCALAR_T, sinh , Sinh      , using std::sinh; )  \
+  UNARY_UNIT_TEST(VEC, SCALAR_T, cosh , Cosh      , using std::cosh; )  \
+  UNARY_UNIT_TEST(VEC, SCALAR_T, tanh , Tanh      , using std::tanh; )  \
+  UNARY_UNIT_TEST(VEC, SCALAR_T, asin , ASin      , using std::asin; )  \
+  UNARY_UNIT_TEST(VEC, SCALAR_T, acos , ACos      , using std::acos; )  \
+  UNARY_UNIT_TEST(VEC, SCALAR_T, atan , ATan      , using std::atan; )  \
+  UNARY_UNIT_TEST(VEC, SCALAR_T, asinh, ASinh     , using std::asinh;)  \
+  UNARY_UNIT_TEST(VEC, SCALAR_T, acosh, ACosh     , using std::acosh;)  \
+  UNARY_UNIT_TEST(VEC, SCALAR_T, atanh, ATanh     , using std::atanh;)  \
                                                                 \
-  BINARY_UNIT_TEST(VEC, +, Plus)                                \
-  BINARY_UNIT_TEST(VEC, -, Minus)                               \
-  BINARY_UNIT_TEST(VEC, *, Times)                               \
-  BINARY_UNIT_TEST(VEC, /, Divide)                              \
+  BINARY_UNIT_TEST(VEC, SCALAR_T, +, Plus)                              \
+  BINARY_UNIT_TEST(VEC, SCALAR_T, -, Minus)                             \
+  BINARY_UNIT_TEST(VEC, SCALAR_T, *, Times)                             \
+  BINARY_UNIT_TEST(VEC, SCALAR_T, /, Divide)                            \
                                                                 \
-  BINARYFUNC_UNIT_TEST(VEC, atan2, std::atan2, ATan2)           \
-  BINARYFUNC_UNIT_TEST(VEC, pow, std::pow, Pow)                 \
-  BINARYFUNC_UNIT_TEST(VEC, max, std::max, Max)                 \
-  BINARYFUNC_UNIT_TEST(VEC, min, std::min, Min)                 \
+  BINARYFUNC_UNIT_TEST(VEC, SCALAR_T, pow, pow, using std::pow;, Pow)   \
                                                                 \
-  OPASSIGN_UNIT_TEST(VEC, +=, PlusEqual)                        \
-  OPASSIGN_UNIT_TEST(VEC, -=, MinusEqual)                       \
-  OPASSIGN_UNIT_TEST(VEC, *=, TimesEqual)                       \
-  OPASSIGN_UNIT_TEST(VEC, /=, DivideEqual)                      \
+  OPASSIGN_UNIT_TEST(VEC, SCALAR_T, +=, PlusEqual)                      \
+  OPASSIGN_UNIT_TEST(VEC, SCALAR_T, -=, MinusEqual)                     \
+  OPASSIGN_UNIT_TEST(VEC, SCALAR_T, *=, TimesEqual)                     \
+  OPASSIGN_UNIT_TEST(VEC, SCALAR_T, /=, DivideEqual)                    \
                                                                 \
-  SAXPY_UNIT_TEST(VEC)                                          \
-  TERNARY_UNIT_TEST(VEC)                                        \
+  SAXPY_UNIT_TEST(VEC, SCALAR_T)                                        \
                                                                 \
-  TEUCHOS_UNIT_TEST( VEC, initializer_list_copy ) {                     \
+  TEUCHOS_UNIT_TEST( VEC##_##SCALAR_T, initializer_list_copy ) {        \
     UTS setup;                                                          \
     UTS::vec_type u = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 };       \
     UTS::vec_type v(setup.sz, 0.0);                                     \
@@ -455,7 +497,7 @@ struct UnitTestSetup {
     success = compareVecs(u, "u", v, "v",                               \
                           setup.rtol, setup.atol, out);                 \
   }                                                                     \
-  TEUCHOS_UNIT_TEST( VEC, initializer_list_assign ) {                   \
+  TEUCHOS_UNIT_TEST( VEC##_##SCALAR_T, initializer_list_assign ) {      \
     UTS setup;                                                          \
     UTS::vec_type u;                                                    \
     u = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 };                     \
@@ -465,7 +507,7 @@ struct UnitTestSetup {
     success = compareVecs(u, "u", v, "v",                               \
                           setup.rtol, setup.atol, out);                 \
   }                                                                     \
-  TEUCHOS_UNIT_TEST( VEC, range_based_for ) {                           \
+  TEUCHOS_UNIT_TEST( VEC##_##SCALAR_T, range_based_for ) {              \
     UTS setup;                                                          \
     UTS::vec_type u(setup.sz, 0.0);                                     \
     for (auto& z : u) { z = 3.0; }                                      \
@@ -474,52 +516,90 @@ struct UnitTestSetup {
                           setup.rtol, setup.atol, out);                 \
   }
 
-namespace DynamicVecTest {
-  typedef Kokkos::DefaultExecutionSpace execution_space;
-  typedef Stokhos::DynamicStorage<int,double,execution_space> storage_type;
-  typedef Sacado::MP::Vector<storage_type> vec_type;
-  typedef UnitTestSetup<vec_type> UTS;
-  VECTOR_UNIT_TESTS(DynamicVector)
+/**
+ * Series of tests to run for complex type.
+ * It will run the series of tests for any type.
+ */
+#define VECTOR_UNIT_TESTS_COMPLEX_TYPE(VEC,SCALAR_T)                               \
+  /* Run the series of tests for any type. */                                      \
+  VECTOR_UNIT_TESTS_ANY_TYPE(VEC,SCALAR_T)
+
+/**
+ * Series of tests to run for real type.
+ * It will run the series of tests for any type, as well as tests that don't work or
+ * don't make sense for complex type.
+ */
+#define VECTOR_UNIT_TESTS_REAL_TYPE(VEC,SCALAR_T)                                  \
+  /* Run the series of tests for any type. */                                      \
+  VECTOR_UNIT_TESTS_ANY_TYPE(VEC,SCALAR_T)                                         \
+  /* Operator cbrt not supported for complex type but supported for real type. */  \
+  UNARY_UNIT_TEST(VEC, SCALAR_T, cbrt , Cbrt, using std::cbrt;)                    \
+  /* Operator atan2 not supported for complex type but supported for real type. */ \
+  BINARYFUNC_UNIT_TEST(VEC, SCALAR_T, atan2, atan2, using std::atan2;, ATan2)      \
+  /* Operators min and max are not supported for complex type. */                  \
+  BINARYFUNC_UNIT_TEST(VEC, SCALAR_T, max  , max  , using std::max  ;, Max)        \
+  BINARYFUNC_UNIT_TEST(VEC, SCALAR_T, min  , min  , using std::min  ;, Min)        \
+  /* Ternary test uses 'operator<' that is not defined for complex type. */        \
+  TERNARY_UNIT_TEST(VEC, SCALAR_T)
+
+/**
+ * Common test structure for dynamic storage.
+ */
+#define TEST_DYNAMIC_STORAGE(__storage_type__,__vec_type__,__scalar_type__,__macro_for_tests__)\
+  typedef Kokkos::DefaultExecutionSpace execution_space;                                       \
+  typedef Stokhos::__storage_type__<int,__scalar_type__,execution_space> storage_type;         \
+  typedef Sacado::MP::Vector<storage_type> vec_type;                                           \
+  typedef UnitTestSetup<vec_type> UTS;                                                         \
+  __macro_for_tests__(__vec_type__,__scalar_type__)
+
+namespace DynamicVecTest
+{
+  TEST_DYNAMIC_STORAGE(DynamicStorage, DynamicVector, double, VECTOR_UNIT_TESTS_REAL_TYPE)
 }
 
-namespace DynamicStridedVecTest {
-  typedef Kokkos::DefaultExecutionSpace execution_space;
-  typedef Stokhos::DynamicStridedStorage<int,double,execution_space> storage_type;
-  typedef Sacado::MP::Vector<storage_type> vec_type;
-  typedef UnitTestSetup<vec_type> UTS;
-  VECTOR_UNIT_TESTS(DynamicStridedVector)
+namespace DynamicStridedVecTest
+{
+  TEST_DYNAMIC_STORAGE(DynamicStridedStorage, DynamicStridedVector, double, VECTOR_UNIT_TESTS_REAL_TYPE)
 }
 
-namespace StaticVecTest {
-  typedef Kokkos::DefaultExecutionSpace execution_space;
-  typedef Stokhos::StaticStorage<int,double,8,execution_space> storage_type;
-  typedef Sacado::MP::Vector<storage_type> vec_type;
-  typedef UnitTestSetup<vec_type> UTS;
-  VECTOR_UNIT_TESTS(StaticVector)
+/**
+ * Common test structure for static storage.
+ */
+#define TEST_STATIC_STORAGE(__storage_type__,__vec_type__,__scalar_type__,__scalar_type_name__,__storage_size__,__macro_for_tests__) \
+    typedef ::Kokkos::DefaultExecutionSpace execution_space;                                                                         \
+    typedef ::Stokhos::__storage_type__<int,__scalar_type__,__storage_size__,execution_space> storage_type;                          \
+    typedef ::Sacado::MP::Vector<storage_type> vec_type;                                                                             \
+    typedef UnitTestSetup<vec_type> UTS;                                                                                             \
+    __macro_for_tests__(__vec_type__,__scalar_type_name__)
+
+namespace StaticVecTest
+{
+  TEST_STATIC_STORAGE(StaticStorage, StaticVector, double, double, 8, VECTOR_UNIT_TESTS_REAL_TYPE)
 }
 
-namespace StaticFixedVecTest {
-  typedef Kokkos::DefaultExecutionSpace execution_space;
-  typedef Stokhos::StaticFixedStorage<int,double,8,execution_space> storage_type;
-  typedef Sacado::MP::Vector<storage_type> vec_type;
-  typedef UnitTestSetup<vec_type> UTS;
-  VECTOR_UNIT_TESTS(StaticFixedVector)
+namespace StaticFixedVecTest
+{
+  namespace Double        {TEST_STATIC_STORAGE(StaticFixedStorage, StaticFixedVector,                   double ,                double, 8, VECTOR_UNIT_TESTS_REAL_TYPE   )}
+
+// Skip std::complex when compiling with CUDA, because std::complex isn't supported in that case.
+// Note that even though the tests aren't run on the device, nvcc still complains that __device__ code functions are called
+// from __host__ code (or vice versa).
+#if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_HIP)
+  namespace Complex_std   {TEST_STATIC_STORAGE(StaticFixedStorage, StaticFixedVector,   std   ::complex<double>,    std_complex_double, 8, VECTOR_UNIT_TESTS_COMPLEX_TYPE)}
+#endif
+
+  // Always test for Kokkos::complex because it is always shipped as part of Kokkos, whatever the space.
+  namespace Complex_Kokkos{TEST_STATIC_STORAGE(StaticFixedStorage, StaticFixedVector, ::Kokkos::complex<double>, kokkos_complex_double, 8, VECTOR_UNIT_TESTS_COMPLEX_TYPE)}
 }
 
 int main( int argc, char* argv[] ) {
   Teuchos::GlobalMPISession mpiSession(&argc, &argv);
 
-  Kokkos::initialize();
-//  Kokkos::HostSpace::execution_space::initialize();
-//  if (!Kokkos::DefaultExecutionSpace::is_initialized())
-//    Kokkos::DefaultExecutionSpace::initialize();
+  Kokkos::initialize(argc,argv);
 
   int res = Teuchos::UnitTestRepository::runUnitTestsFromMain(argc, argv);
 
   Kokkos::finalize();
-//  Kokkos::HostSpace::execution_space::finalize();
-//  if (Kokkos::DefaultExecutionSpace::is_initialized())
-//    Kokkos::DefaultExecutionSpace::finalize();
 
   return res;
 }

--- a/packages/stokhos/test/UnitTest/Stokhos_SacadoMPVectorUnitTest.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_SacadoMPVectorUnitTest.cpp
@@ -591,15 +591,3 @@ namespace StaticFixedVecTest
   // Always test for Kokkos::complex because it is always shipped as part of Kokkos, whatever the space.
   namespace Complex_Kokkos{TEST_STATIC_STORAGE(StaticFixedStorage, StaticFixedVector, ::Kokkos::complex<double>, kokkos_complex_double, 8, VECTOR_UNIT_TESTS_COMPLEX_TYPE)}
 }
-
-int main( int argc, char* argv[] ) {
-  Teuchos::GlobalMPISession mpiSession(&argc, &argv);
-
-  Kokkos::initialize(argc,argv);
-
-  int res = Teuchos::UnitTestRepository::runUnitTestsFromMain(argc, argv);
-
-  Kokkos::finalize();
-
-  return res;
-}

--- a/packages/stokhos/test/UnitTest/Stokhos_SacadoMPVectorUnitTest_MaskTraits.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_SacadoMPVectorUnitTest_MaskTraits.cpp
@@ -612,21 +612,3 @@ TEUCHOS_UNIT_TEST( MP_Vector_MaskTraits, Mask_div)
     TEST_EQUALITY(b,-1.);
 
 }
-
-int main( int argc, char* argv[] ) {
-  Teuchos::GlobalMPISession mpiSession(&argc, &argv);
-
-  Kokkos::initialize();
-//  Kokkos::HostSpace::execution_space::initialize();
-//  if (!Kokkos::DefaultExecutionSpace::is_initialized())
-//    Kokkos::DefaultExecutionSpace::initialize();
-
-  int res = Teuchos::UnitTestRepository::runUnitTestsFromMain(argc, argv);
-
-  Kokkos::finalize();
-//  Kokkos::HostSpace::execution_space::finalize();
-//  if (Kokkos::DefaultExecutionSpace::is_initialized())
-//    Kokkos::DefaultExecutionSpace::finalize();
-
-  return res;
-}

--- a/packages/stokhos/test/UnitTest/Stokhos_SacadoUQPCECommTests.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_SacadoUQPCECommTests.cpp
@@ -714,21 +714,3 @@ TEUCHOS_UNIT_TEST( UQ_PCE_Comm, FadPCE_SendReceive ) {
   else
     success = true;
 }
-
-int main( int argc, char* argv[] ) {
-  Teuchos::GlobalMPISession mpiSession(&argc, &argv);
-
-  Kokkos::initialize();
-//  Kokkos::HostSpace::execution_space::initialize();
-//  if (!Kokkos::DefaultExecutionSpace::is_initialized())
-//    Kokkos::DefaultExecutionSpace::initialize();
-
-  int res = Teuchos::UnitTestRepository::runUnitTestsFromMain(argc, argv);
-
-  Kokkos::finalize();
-//  Kokkos::HostSpace::execution_space::finalize();
-//  if (Kokkos::DefaultExecutionSpace::is_initialized())
-//    Kokkos::DefaultExecutionSpace::finalize();
-
-  return res;
-}

--- a/packages/stokhos/test/UnitTest/Stokhos_SacadoUQPCESerializationTests.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_SacadoUQPCESerializationTests.cpp
@@ -380,21 +380,3 @@ TEUCHOS_UNIT_TEST( UQ_PCE_Serialization, FadPCEEmptyAll ) {
       x, *setup.fad_pce_serializer,
       std::string("UQ::PCE") + " Nested Empty All", out);
 }
-
-int main( int argc, char* argv[] ) {
-  Teuchos::GlobalMPISession mpiSession(&argc, &argv);
-
-  Kokkos::initialize();
-//  Kokkos::HostSpace::execution_space::initialize();
-//  if (!Kokkos::DefaultExecutionSpace::is_initialized())
-//    Kokkos::DefaultExecutionSpace::initialize();
-
-  int res = Teuchos::UnitTestRepository::runUnitTestsFromMain(argc, argv);
-
-  Kokkos::finalize();
-//  Kokkos::HostSpace::execution_space::finalize();
-//  if (Kokkos::DefaultExecutionSpace::is_initialized())
-//    Kokkos::DefaultExecutionSpace::finalize();
-
-  return res;
-}

--- a/packages/stokhos/test/UnitTest/Stokhos_SacadoUQPCEUnitTest.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_SacadoUQPCEUnitTest.cpp
@@ -417,21 +417,3 @@ namespace SacadoPCEUnitTest {
                           setup.rtol, setup.atol, out);
   }
 }
-
-int main( int argc, char* argv[] ) {
-  Teuchos::GlobalMPISession mpiSession(&argc, &argv);
-
-  Kokkos::initialize();
-//  Kokkos::HostSpace::execution_space::initialize();
-//  if (!Kokkos::DefaultExecutionSpace::is_initialized())
-//    Kokkos::DefaultExecutionSpace::initialize();
-
-  int res = Teuchos::UnitTestRepository::runUnitTestsFromMain(argc, argv);
-
-  Kokkos::finalize();
-//  Kokkos::HostSpace::execution_space::finalize();
-//  if (Kokkos::DefaultExecutionSpace::is_initialized())
-//    Kokkos::DefaultExecutionSpace::finalize();
-
-  return res;
-}

--- a/packages/stokhos/test/UnitTest/Stokhos_UnitTestBase.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_UnitTestBase.cpp
@@ -1,0 +1,26 @@
+#include "Teuchos_GlobalMPISession.hpp"
+#include "Kokkos_Core.hpp"
+#include "Teuchos_UnitTestRepository.hpp"
+
+/**
+ * Initialize both Teuchos MPI Comm and Kokkos.
+ * Run the tests and return test suite result code.
+ */
+int main( int argc, char* argv[] )
+{
+    Teuchos::GlobalMPISession mpiSession(&argc, &argv);
+
+    // Initialize Kokkos
+    Kokkos::initialize(argc,argv);
+
+    // For unit tests to reduce the result when MPI is used
+    Teuchos::UnitTestRepository::setGloballyReduceTestResult(true);
+
+    // Run all registered unit tests
+    int res = Teuchos::UnitTestRepository::runUnitTestsFromMain(argc, argv);
+
+    // Finalize Kokkos
+    Kokkos::finalize();
+
+    return res;
+}

--- a/packages/stokhos/test/UnitTest/Stokhos_UnitTestHelpers.hpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_UnitTestHelpers.hpp
@@ -42,6 +42,7 @@
 #ifndef STOKHOS_UNIT_TEST_HELPERS_HPP
 #define STOKHOS_UNIT_TEST_HELPERS_HPP
 
+#include "Kokkos_ArithTraits.hpp"
 #include "Stokhos_OrthogPolyApprox.hpp"
 #include "Stokhos_ProductBasis.hpp"
 #include "Stokhos_Sparse3Tensor.hpp"
@@ -127,6 +128,11 @@ namespace Stokhos {
                    const ValueType& rel_tol, const ValueType& abs_tol,
                    Teuchos::FancyOStream& out)
   {
+    using value_t_1 = typename VectorType1::value_type;
+    using value_t_2 = typename VectorType2::value_type;
+    static_assert(std::is_same<value_t_1,value_t_2>::value,"Inconsistent types.");
+    using KAT = typename Kokkos::ArithTraits<value_t_1>;
+
     bool success = true;
 
     out << "Comparing " << a1_name << " == " << a2_name << " ... ";
@@ -142,10 +148,10 @@ namespace Stokhos {
 
     // Compare elements
     for( int i = 0; i < n; ++i ) {
-      ValueType err = std::abs(a1.coeff(i) - a2.coeff(i));
+      ValueType err = KAT::abs(a1.coeff(i) - a2.coeff(i));
       ValueType tol =
-        abs_tol + rel_tol*std::max(std::abs(a1.fastAccessCoeff(i)),
-                                   std::abs(a2.fastAccessCoeff(i)));
+        abs_tol + rel_tol*std::max(KAT::abs(a1.fastAccessCoeff(i)),
+                                   KAT::abs(a2.fastAccessCoeff(i)));
       if (err  > tol) {
         out
           <<"\nError, relErr("<<a1_name<<"["<<i<<"],"

--- a/packages/stokhos/test/UnitTest/Stokhos_UnitTestHelpers.hpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_UnitTestHelpers.hpp
@@ -42,7 +42,6 @@
 #ifndef STOKHOS_UNIT_TEST_HELPERS_HPP
 #define STOKHOS_UNIT_TEST_HELPERS_HPP
 
-#include "Kokkos_ArithTraits.hpp"
 #include "Stokhos_OrthogPolyApprox.hpp"
 #include "Stokhos_ProductBasis.hpp"
 #include "Stokhos_Sparse3Tensor.hpp"
@@ -131,7 +130,6 @@ namespace Stokhos {
     using value_t_1 = typename VectorType1::value_type;
     using value_t_2 = typename VectorType2::value_type;
     static_assert(std::is_same<value_t_1,value_t_2>::value,"Inconsistent types.");
-    using KAT = typename Kokkos::ArithTraits<value_t_1>;
 
     bool success = true;
 
@@ -148,10 +146,10 @@ namespace Stokhos {
 
     // Compare elements
     for( int i = 0; i < n; ++i ) {
-      ValueType err = KAT::abs(a1.coeff(i) - a2.coeff(i));
+      ValueType err = abs(a1.coeff(i) - a2.coeff(i));
       ValueType tol =
-        abs_tol + rel_tol*std::max(KAT::abs(a1.fastAccessCoeff(i)),
-                                   KAT::abs(a2.fastAccessCoeff(i)));
+        abs_tol + rel_tol*std::max(abs(a1.fastAccessCoeff(i)),
+                                   abs(a2.fastAccessCoeff(i)));
       if (err  > tol) {
         out
           <<"\nError, relErr("<<a1_name<<"["<<i<<"],"


### PR DESCRIPTION
@trilinos/Stokhos
@etphipp

## What's new in this PR ?

Stokhos is now able to perform basic mathematical operations with ensembles of `std::complex` and `Kokkos::Complex`.

The main fix brought by this PR is the addition of `using std::matop` in the macros of `packages/stokhos/src/sacado/kokkos/vector/Sacado_MP_Vector_ops.hpp`. This brings a behavior that is similar to `packages/sacado/src/Sacado_Fad_Ops.hpp` for instance.

Moreover, the test `packages/stokhos/test/UnitTest/Stokhos_SacadoMPVectorUnitTest.cpp` has been adapted to ensure that `Kokkos::Complex` now works with ensembles.

This PR was already discussed and reviewed in [uliegecsm/Trilinos/1.](https://github.com/uliegecsm/Trilinos/pull/1)

## Side quests

As a side quest, I also added a `Stokhos_UnitBaseTestLib` (static) that contains the `int main(...)` entrypoint. Only the tests that were strictly following the sequence `MPI - Kokkos::init - Test - Kokkos::finalize - return` now link to this *test only* library.

## Notes

This PR needed:
* https://github.com/kokkos/kokkos/pull/5009.