### PR TITLE
Ifpack2: fix Schwarz+FastILU sort skipping

### DIFF
--- a/packages/ifpack2/src/Ifpack2_Details_Filu_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Filu_def.hpp
@@ -47,6 +47,7 @@
 
 #include "Ifpack2_Details_Filu_decl.hpp"
 #include "Ifpack2_Details_CrsArrays.hpp"
+#include "Ifpack2_Details_getCrsMatrix.hpp"
 #include <Kokkos_Timer.hpp>
 #include <shylu_fastilu.hpp>
 
@@ -102,7 +103,7 @@ initLocalPrec()
   typedef Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> TCrsMatrix;
   auto nRows = this->mat_->getLocalNumRows();
   auto& p = this->params_;
-  auto matCrs = Teuchos::rcp_dynamic_cast<const TCrsMatrix>(this->mat_);
+  auto matCrs = Ifpack2::Details::getCrsMatrix(this->mat_);
 
   bool skipSortMatrix = matCrs && matCrs->getCrsGraph()->isSorted() &&
                        !p.use_metis;

--- a/packages/ifpack2/src/Ifpack2_Details_Filu_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Filu_def.hpp
@@ -105,7 +105,7 @@ initLocalPrec()
   auto& p = this->params_;
   auto matCrs = Ifpack2::Details::getCrsMatrix(this->mat_);
 
-  bool skipSortMatrix = matCrs && matCrs->getCrsGraph()->isSorted() &&
+  bool skipSortMatrix = !matCrs.is_null() && matCrs->getCrsGraph()->isSorted() &&
                        !p.use_metis;
   localPrec_ = Teuchos::rcp(new LocalFILU(skipSortMatrix, this->localRowPtrs_, this->localColInds_, this->localValues_, nRows, p.sptrsv_algo,
                                           p.nFact, p.nTrisol, p.level, p.omega, p.shift, p.guessFlag ? 1 : 0, p.blockSizeILU, p.blockSize));

--- a/packages/muelu/src/Utils/MueLu_Utilities_kokkos_def.hpp
+++ b/packages/muelu/src/Utils/MueLu_Utilities_kokkos_def.hpp
@@ -361,8 +361,8 @@ namespace MueLu {
 
                              boundaryNodes(row) = true;
                              if (length > 2) {
-                               decltype(length) colID;
-                               for (colID = 0; colID < length; colID++)
+                               decltype(length) colID = 0;
+                               for (; colID < length; colID++)
                                  if ((rowView.colidx(colID) != row) &&
                                      (ATS::magnitude(rowView.value(colID)) > tol)) {
                                    if (!boundaryNodes(row))


### PR DESCRIPTION
The AdditiveSchwarzFilter gets passed in directly as the FastILU input matrix, so a dynamic cast to CrsMatrix isn't what we want. Use getCrsMatrix helper instead to extract the filtered&sorted CrsMatrix when using AdditiveSchwarzFilter.

Now, the sort skipping path added in #10736 is taken correctly when calling AdditiveSchwarz with FastILU as inner solver.
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/ifpack2 
@vbrunini 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
Tested by running Ifpack2+Belos driver with this configuration, and checking which path is taken:
```
<ParameterList name="test_params">
  <Parameter name="mm_file"     type="string" value="/ascldap/users/bmkelle/MatrixCollection/Laplace3D_100.mtx"/>

  <Parameter name="solver_type" type="string" value="Block Gmres"/>
  <ParameterList name="Belos">
    <Parameter name="Num Blocks" type="int" value="40"/>
    <Parameter name="Verbosity" type="int" value="33"/>
    <Parameter name="Output Style" type="int" value="1"/>
    <Parameter name="Output Frequency" type="int" value="1"/>
  </ParameterList>

  <Parameter name="Ifpack2::Preconditioner" type="string" value="SCHWARZ"/>
  <ParameterList name="Ifpack2">
    <Parameter name="schwarz: overlap level" type="int" value="0"/>
    <Parameter name="schwarz: combine mode" type="string" value="ZERO"/>
    <Parameter name="schwarz: use reordering" type="bool" value="true"/>
    <Parameter name="subdomain solver name" type="string" value="FAST_ILU"/>
    <ParameterList name="subdomain solver parameters">
      <Parameter name="metis" type="bool" value="false"/>
      <Parameter name="sweeps" type="int" value="10"/>
      <Parameter name="damping factor" type="double" value="0.2"/>
      <Parameter name="triangular solve type" type="string" value="StandardHost"/>
      <Parameter name="level" type="int" value="3"/>
    </ParameterList>
  </ParameterList>
</ParameterList>
```
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->