### PR TITLE
Stokhos: Provide algorithm and math overloads for Sacado::MP::Vector

### DIFF
--- a/packages/stokhos/src/sacado/kokkos/vector/Sacado_MP_Vector_ops.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/Sacado_MP_Vector_ops.hpp
@@ -195,6 +195,14 @@ namespace Sacado {                                                      \
                                                                         \
       return expr_t(expr.derived());                                    \
     }                                                                   \
+                                                                        \
+    template <typename T>                                               \
+    KOKKOS_INLINE_FUNCTION                                              \
+    OP< Vector<T> >                                                     \
+    OPNAME (const Vector<T>& vector)                                    \
+    {                                                                   \
+      return OP< Vector<T> >(vector);                                   \
+    }                                                                   \
   }                                                                     \
                                                                         \
   template <typename T>                                                 \
@@ -522,6 +530,15 @@ namespace Sacado {                                                      \
                                                                         \
       return expr_t(expr.derived(), c);                                 \
     }                                                                   \
+                                                                        \
+    template <typename T>                                               \
+    KOKKOS_INLINE_FUNCTION                                              \
+    OP< Vector<T>, Vector<T> >                                          \
+    OPNAME (const Vector<T>& vector1,                                   \
+            const Vector<T>& vector2)                                   \
+    {                                                                   \
+      return {vector1, vector2};                                        \
+    }                                                                   \
   }                                                                     \
                                                                         \
   template <typename T1, typename T2>                                   \
@@ -756,6 +773,15 @@ namespace Sacado {                                                      \
       typedef OP< typename Expr<T>::derived_type, ConstT > expr_t;      \
                                                                         \
       return expr_t(expr.derived(), c);                                 \
+    }                                                                   \
+                                                                        \
+    template <typename T>                                               \
+    KOKKOS_INLINE_FUNCTION                                              \
+    OP< Vector<T>, Vector<T> >                                          \
+    OPNAME (const Vector<T>& vector1,                                   \
+            const Vector<T>& vector2)                                   \
+    {                                                                   \
+      return {vector1, vector2};                                        \
     }                                                                   \
   }                                                                     \
                                                                         \


### PR DESCRIPTION
@trilinos/stokhos

## Motivation
https://github.com/kokkos/kokkos/issues/5216.](https://github.com/kokkos/kokkos/pull/5170 promoted, among others, `Kokkos::Experimental::max` to `Kokkos::max`. This caused `Stokhos_SacadoMPVectorUnitTest_MPI_1` to fail since now the `Kokkos` function was selected in overload resolution for the unqualified `max()` call. Note that this was already happening for `Experimental` backends, like `HIP` before, since then `Kokkos::Experimental::max` was selected. This pull request fixes this by providing a better overload for `Vector` that doesn't require implicit conversion from `Expr`.

The last paragraph in https://github.com/trilinos/Trilinos/issues/10740#issuecomment-1180885529 might be related.

## Related Issues

* Closes https://github.com/kokkos/kokkos/issues/5216

## Testing
Compiling and running the failing unit test with the `Serial` backend.