### PR TITLE
Revert "Add C++17 standard for Clang 10.0.0 PR build"

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -2135,9 +2135,8 @@ use COMMON
 # ../../Trilinos/build/CMakeCache.txt mismatch Trilinos_ENABLE_Zoltan2Core=ON -> Trilinos_ENABLE_Zoltan2Core=
 # ../../Trilinos/build/CMakeCache.txt mismatch Trilinos_ENABLE_Zoltan2Sphynx=ON -> Trilinos_ENABLE_Zoltan2Sphynx=
 
-opt-set-cmake-var CMAKE_CXX_STANDARD                            STRING FORCE : 17
-opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING       : --bind-to;none
-opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D BOOL         : ON
+opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING     : --bind-to;none
+opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D BOOL       : ON
 
 use RHEL7_TEST_DISABLES|CLANG
 


### PR DESCRIPTION
Reverts trilinos/Trilinos#10762

We have been experiencing some odd results in this build since this change was applied. Specifically, large numbers of tests are usually not run, and a few are failing. I am submitting this PR to test if reverting this change would potentially clear up those issues or not. This does not seem obviously tied to the issues we are seeing, but it is relatively simple to check.