### PR TITLE
Stokhos: Make sure deep_copy uses contiguous layouts where intended

### DIFF
--- a/packages/stokhos/src/sacado/kokkos/pce/KokkosExp_View_UQ_PCE_Contiguous.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/KokkosExp_View_UQ_PCE_Contiguous.hpp
@@ -548,11 +548,17 @@ void deep_copy( const ExecSpace &,
     else {
 
       typedef View< typename src_type::non_const_data_type ,
-                    typename src_type::execution_space::array_layout ,
+                    std::conditional_t<std::is_same<typename src_type::array_layout,
+                                                    Kokkos::LayoutStride>::value,
+                                       Kokkos::LayoutRight,
+                                       typename src_type::array_layout>,
                     typename src_type::execution_space > tmp_src_type;
       typedef typename tmp_src_type::array_type tmp_src_array_type;
       typedef View< typename dst_type::non_const_data_type ,
-                    typename dst_type::execution_space::array_layout ,
+                    std::conditional_t<std::is_same<typename dst_type::array_layout,
+                                                    Kokkos::LayoutStride>::value,
+                                       Kokkos::LayoutRight,
+                                       typename dst_type::array_layout>,
                     typename dst_type::execution_space > tmp_dst_type;
       typedef typename tmp_dst_type::array_type tmp_dst_array_type;
 

--- a/packages/stokhos/src/sacado/kokkos/pce/KokkosExp_View_UQ_PCE_Contiguous.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/KokkosExp_View_UQ_PCE_Contiguous.hpp
@@ -548,11 +548,11 @@ void deep_copy( const ExecSpace &,
     else {
 
       typedef View< typename src_type::non_const_data_type ,
-                    typename src_type::array_layout ,
+                    typename src_type::execution_space::array_layout ,
                     typename src_type::execution_space > tmp_src_type;
       typedef typename tmp_src_type::array_type tmp_src_array_type;
       typedef View< typename dst_type::non_const_data_type ,
-                    typename dst_type::array_layout ,
+                    typename dst_type::execution_space::array_layout ,
                     typename dst_type::execution_space > tmp_dst_type;
       typedef typename tmp_dst_type::array_type tmp_dst_array_type;
 


### PR DESCRIPTION
@trilinos/stokhos @etphipp

## Motivation
https://github.com/kokkos/kokkos/pull/5209 added a check for the layout to be used in Kokkos::View constructors to be constructible from just extents. The only standard layout for which this property doesn't hold is `LayoutStride`. The cases fixed below mean to create a contiguous representation of a given `View` in case the View is not contiguous in memory but the newly created Views just copy the layout from the old ones which makes the new Views also non-contiguous in memory in case of `LayoutStride`. In the end, the new `View` is initialized only from extents which again doesn't do the right thing for `LayoutStride` since its constructor expects extents and strides alternating.
The proposed fix is to just take the preferred layout of the associated execution space which is either `LayoutLeft` or `LayoutRight` and in particular constructible from extents only.

## Related Issues

Fixes https://github.com/kokkos/kokkos/issues/5243.

## Testing
Compiling and running all Stokhos tests with the `Serial` backend and `Kokkos` `develop`.