### PR TITLE
Revert "Add C++17 standard for GCC 7.2.0 and GCC 7.2.0 serial"

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1909,10 +1909,9 @@ use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
 
 use COMMON
 
-opt-set-cmake-var CMAKE_CXX_STANDARD                                     STRING FORCE : 17
-opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                            STRING       : --bind-to;none
-opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                         BOOL         : ON
-opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D          BOOL         : ON
+opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                            STRING     : --bind-to;none
+opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                         BOOL       : ON
+opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D          BOOL       : ON
 opt-set-cmake-var KokkosKernels_blas_serial_MPI_1_DISABLE                BOOL : ON
 opt-set-cmake-var ROL_example_PDE-OPT_helmholtz_example_02_MPI_1_DISABLE BOOL : ON
 opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-nonnull-compare -Wno-address -Wno-inline -Werror -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
@@ -1934,11 +1933,10 @@ use USE-DEPRECATED|YES
 
 use COMMON_USE-MPI|NO
 
-opt-set-cmake-var CMAKE_CXX_STANDARD             STRING FORCE : 17
-opt-set-cmake-var Trilinos_ENABLE_Fortran OFF    BOOL         : OFF
-opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE BOOL         : ON
-opt-set-cmake-var CMAKE_CXX_FLAGS                STRING : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-nonnull-compare -Wno-address -Wno-inline -Wno-unused-but-set-variable -Wno-unused-variable -Wno-unused-label -Werror -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
-opt-set-cmake-var TPL_ENABLE_ParMETIS            BOOL FORCE   : OFF
+opt-set-cmake-var Trilinos_ENABLE_Fortran OFF BOOL : OFF
+opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE BOOL : ON
+opt-set-cmake-var CMAKE_CXX_FLAGS STRING : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-nonnull-compare -Wno-address -Wno-inline -Wno-unused-but-set-variable -Wno-unused-variable -Wno-unused-label -Werror -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
+opt-set-cmake-var TPL_ENABLE_ParMETIS BOOL FORCE : OFF
 
 use RHEL7_POST
 


### PR DESCRIPTION
Reverts trilinos/Trilinos#10763

This appears to possibly be causing issues for PR #10777. We are considering temporarily reverting this commit until the issues can be dealt with.