### PR TITLE
amesos2: update shylubasker for removed deprecated code

### DIFF
--- a/packages/amesos2/src/Amesos2_ShyLUBasker.cpp
+++ b/packages/amesos2/src/Amesos2_ShyLUBasker.cpp
@@ -41,21 +41,19 @@
 //
 // @HEADER
 #include "Amesos2_config.h"
+#include "Amesos2_ShyLUBasker_decl.hpp"
 
 #ifdef HAVE_AMESOS2_EXPLICIT_INSTANTIATION
 
-#include "Amesos2_ShyLUBasker_decl.hpp"
 #include "Amesos2_ShyLUBasker_def.hpp"
 #include "Amesos2_ExplicitInstantiationHelpers.hpp"
 #include "TpetraCore_ETIHelperMacros.h"
-
 
 namespace Amesos2 {
 
 #ifdef HAVE_AMESOS2_EPETRA
   AMESOS2_SOLVER_EPETRA_INST(ShyLUBasker);
 #endif
-}
 
 #define AMESOS2_SHYLUBASKER_LOCAL_INSTANT(S,LO,GO,N) \
   template class Amesos2::ShyLUBasker<Tpetra::CrsMatrix<S, LO, GO, N>, \
@@ -65,4 +63,7 @@ TPETRA_ETI_MANGLING_TYPEDEFS()
 
 TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR(AMESOS2_SHYLUBASKER_LOCAL_INSTANT)
 
+#define AMESOS2_KOKKOS_IMPL_SOLVER_NAME ShyLUBasker
+#include "Amesos2_Kokkos_Impl.hpp"
+}
 #endif  // HAVE_AMESOS2_EXPLICIT_INSTANTIATION

--- a/packages/amesos2/src/Amesos2_ShyLUBasker_FunctionMap.hpp
+++ b/packages/amesos2/src/Amesos2_ShyLUBasker_FunctionMap.hpp
@@ -75,7 +75,25 @@ namespace Amesos2 {
    * \brief Pass function calls to ShyLUBasker based on data type.
 
    */
-  // TODO : Do we need the specializations for ShyLUBasker ??
+#ifdef HAVE_TEUCHOS_COMPLEX
+  template <>
+  struct FunctionMap<ShyLUBasker,Kokkos::complex<double>>
+  {
+    static std::complex<double> * convert_scalar(Kokkos::complex<double> * pData) {
+      return reinterpret_cast<std::complex<double> *>(pData);
+    }
+  };
+
+#endif // HAVE_TEUCHOS_COMPLEX
+
+  // if not specialized, then assume generic conversion is fine
+  template <typename scalar_t>
+  struct FunctionMap<ShyLUBasker,scalar_t>
+  {
+    static scalar_t * convert_scalar(scalar_t * pData) {
+      return pData; // no conversion necessary
+    }
+  };
 
 
   /* \endcond ShyLUBasker_function_specializations */

--- a/packages/amesos2/src/Amesos2_ShyLUBasker_TypeMap.hpp
+++ b/packages/amesos2/src/Amesos2_ShyLUBasker_TypeMap.hpp
@@ -67,77 +67,6 @@
 
 #include "Amesos2_TypeMap.hpp"
 
-
-#ifdef HAVE_TEUCHOS_COMPLEX
-
-/* ==================== Conversion ==================== */
-namespace Teuchos {
-
-/**
- * \defgroup slu_conversion Conversion definitions for SLU types.
- *
- * Define specializations of Teuchos::as<> for the SLU types.
- *
- * These specializations are meant to work with any complex data type that
- * implements the same interface as the STL complex type.
- *
- * @{
- */
-
-#ifndef HAVE_AMESOS2_KLU2
-
-template <>
-class ValueTypeConversionTraits<std::complex<double>, std::complex<float> >
-{
-public:
-  static std::complex<double> convert( const std::complex<float>  t )
-    {
-      std::complex<double> ret(Teuchos::as<double>(t.real()),
-                                 Teuchos::as<double>(t.imag()));
-      return( ret );
-    }
-
-  static std::complex<double> safeConvert( const std::complex<float>  t )
-    {
-      std::complex<double> ret(Teuchos::as<double>(t.real()),
-                                 Teuchos::as<double>(t.imag()));
-      return( ret );
-    }
-};
-
-
-template <>
-class ValueTypeConversionTraits<std::complex<float> , std::complex<double> >
-{
-public:
-  static std::complex<float>  convert( const std::complex<double> t )
-    {
-      float ret_r = Teuchos::as<float>( t.real() );
-      float ret_i = Teuchos::as<float>( t.imag() );
-      std::complex<float> ret (ret_r,  ret_i);
-      return (ret);
-    }
-
-  // No special checks for safe Convert
-  static std::complex<float>  safeConvert( const std::complex<double> t )
-    {
-      float ret_r = Teuchos::as<float>( t.real() );
-      float ret_i = Teuchos::as<float>( t.imag() );
-      std::complex<float> ret (ret_r,  ret_i);
-      return (ret);
-    }
-};
-
-
-#endif
-//@}  End Conversion group
-
-
-} // end namespace Teuchos
-
-#endif	// HAVE_TEUCHOS_COMPLEX
-
-
 namespace Amesos2 {
 
 template <class, class> class ShyLUBasker;
@@ -151,18 +80,15 @@ template <class, class> class ShyLUBasker;
 template <>
 struct TypeMap<ShyLUBasker,float>
 {
-  static float dtype;
+  typedef float dtype;
   typedef float type;
-  typedef float magnitude_type;
 };
-
 
 template <>
 struct TypeMap<ShyLUBasker,double>
 {
-  static double dtype;
+  typedef double dtype;
   typedef double type;
-  typedef double magnitude_type;
 };
 
 
@@ -171,20 +97,30 @@ struct TypeMap<ShyLUBasker,double>
 template <>
 struct TypeMap<ShyLUBasker,std::complex<float> >
 {
-  static std::complex<double> dtype;
-  typedef std::complex<double> type;
-  typedef double magnitude_type;
+  typedef std::complex<double> dtype;
+  typedef Kokkos::complex<double> type;
 };
-
 
 template <>
 struct TypeMap<ShyLUBasker,std::complex<double> >
 {
-  static std::complex<double> dtype;
-  typedef std::complex<double> type;
-  typedef double magnitude_type;
+  typedef std::complex<double> dtype;
+  typedef Kokkos::complex<double> type;
 };
 
+template <>
+struct TypeMap<ShyLUBasker,Kokkos::complex<float> >
+{
+  typedef std::complex<double> dtype;
+  typedef Kokkos::complex<double> type;
+};
+
+template <>
+struct TypeMap<ShyLUBasker,Kokkos::complex<double> >
+{
+  typedef std::complex<double> dtype;
+  typedef Kokkos::complex<double> type;
+};
 
 #endif  // HAVE_TEUCHOS_COMPLEX
 


### PR DESCRIPTION
Shift to usage of Kokkos::View's in place of Teuchos::Array's
Addresses issue #10743

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/amesos2

## Motivation
Update ShyluBasker compiler to compile with removal of deprecated code

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
@hkthorn this should allow Xyce to resume compiling with Trilinos' develop branch

## Testing
Configuration script (extra boiler plate pasted in for various tpls):
```bash

cmake \
\
-D CMAKE_INSTALL_PREFIX:PATH="${INSTALL_LOCATION}" \
-D CMAKE_CXX_FLAGS:STRING="-g" \
-D CMAKE_MAKE_PROGRAM:STRING="make" \
-D CMAKE_BUILD_TYPE:STRING=DEBUG \
-D CMAKE_VERBOSE_MAKEFILE:BOOL=TRUE \
-D BUILD_SHARED_LIBS:BOOL=OFF \
-D Trilinos_VERBOSE_CONFIGURE:BOOL=OFF \
\
-D TPL_ENABLE_MPI:BOOL=ON \
-D CMAKE_CXX_COMPILER:FILEPATH="`which mpicxx`" \
-D CMAKE_C_COMPILER:FILEPATH="`which mpicc`" \
-D CMAKE_Fortran_COMPILER:FILEPATH="`which mpifort`" \
\
-D TPL_ENABLE_METIS:BOOL=ON \
  -D METIS_INCLUDE_DIRS:PATH="${METIS_PATH}/include" \
  -D METIS_LIBRARY_DIRS:PATH="${METIS_PATH}/lib" \
  -D METIS_LIBRARY_NAMES:STRING="metis" \
-D TPL_ENABLE_ParMETIS:BOOL=ON \
  -D ParMETIS_INCLUDE_DIRS:PATH="${PARMETIS_PATH}/include;${METIS_PATH}/include" \
  -D ParMETIS_LIBRARY_DIRS:PATH="${PARMETIS_PATH}/lib" \
  -D ParMETIS_LIBRARY_NAMES:STRING="parmetis" \
-D TPL_ENABLE_Scotch:BOOL=ON \
  -D Scotch_INCLUDE_DIRS:PATH="${SCOTCH_PATH}/include" \
  -D Scotch_LIBRARY_DIRS:PATH="${SCOTCH_PATH}/lib" \
  -D Scotch_LIBRARY_NAMES:STRING="scotch;scotcherr" \
-D TPL_ENABLE_BLAS:STRING=ON \
  -D BLAS_LIBRARY_DIRS:FILEPATH=${BLAS_PATH}/lib \
  -D BLAS_LIBRARY_NAMES:STRING="openblas" \
-D TPL_ENABLE_LAPACK:STRING=ON \
  -D LAPACK_INCLUDE_DIRS:FILEPATH="${LAPACK_PATH}/include" \
  -D LAPACK_LIBRARY_DIRS:FILEPATH=${LAPACK_PATH}/lib \
  -D LAPACK_LIBRARY_NAMES:STRING="openblas" \
-D TPL_ENABLE_SuperLU:BOOL=OFF \
  -D SuperLU_INCLUDE_DIRS:FILEPATH="${SUPERLU_PATH}/include" \
  -D SuperLU_LIBRARY_DIRS:FILEPATH="${SUPERLU_PATH}/lib" \
  -D SuperLU_LIBRARY_NAMES:STRING="superlu" \
-D TPL_ENABLE_UMFPACK:STRING=OFF \
  -D UMFPACK_INCLUDE_DIRS:PATH="${SS_PATH}/include" \
  -D UMFPACK_LIBRARY_DIRS:PATH="${SS_PATH}/lib" \
  -D UMFPACK_LIBRARY_NAMES:STRING="umfpack;suitesparseconfig;amd" \
\
-D Trilinos_ENABLE_EXAMPLES:BOOL=OFF \
-D Trilinos_ENABLE_TESTS:BOOL=OFF \
-D Trilinos_ENABLE_COMPLEX_DOUBLE:BOOL=ON \
-D Trilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=OFF \
-D Trilinos_ENABLE_EXPLICIT_INSTANTIATION:BOOL=ON \
\
-D Trilinos_ENABLE_OpenMP:BOOL=ON \
-D Trilinos_ENABLE_Kokkos:BOOL=ON \
  -D Kokkos_ENABLE_OPENMP:BOOL=ON \
  -D Kokkos_ENABLE_SERIAL:BOOL=ON \
  -D Kokkos_ENABLE_EXAMPLES:BOOL=OFF \
  -D Kokkos_ENABLE_TESTS:BOOL=OFF \
-D Trilinos_ENABLE_Epetra:BOOL=ON \
  -D Epetra_ENABLE_EXAMPLES:BOOL=OFF \
  -D Epetra_ENABLE_TESTS:BOOL=OFF \
-D Trilinos_ENABLE_EpetraExt:BOOL=ON \
  -D EpetraExt_ENABLE_EXAMPLES:BOOL=OFF \
  -D EpetraExt_ENABLE_TESTS:BOOL=OFF \
-D Trilinos_ENABLE_Tpetra:BOOL=ON \
  -D Tpetra_ENABLE_EXAMPLES:BOOL=OFF \
  -D Tpetra_ENABLE_TESTS:BOOL=OFF \
  -D Tpetra_INST_SERIAL:BOOL=ON \
-D Trilinos_ENABLE_ShyLU_NodeBasker:BOOL=ON \
  -D ShyLU_NodeBasker_ENABLE_TESTS:BOOL=ON \
-D Trilinos_ENABLE_Amesos2:BOOL=ON \
  -D Amesos2_ENABLE_EXAMPLES:BOOL=ON \
  -D Amesos2_ENABLE_TESTS:BOOL=ON \
  -D Amesos2_ENABLE_KLU2:BOOL=ON \
  -D Amesos2_ENABLE_ShyLU_NodeBasker:BOOL=ON \
${TRILINOS_DIR}

```

Passing tests (local build, gcc/9 on MacOS):
```bash
s1067110:amesos2 ndellin$ ctest
Test project /Users/ndellin/Research/trilinos/Trilinos/Build/ShyluBaskerAmesos2-MPI/packages/amesos2
      Start  1: Amesos2_KLU2_UnitTests_MPI_2
 1/11 Test  #1: Amesos2_KLU2_UnitTests_MPI_2 .........................   Passed    3.26 sec
      Start  2: Amesos2_KLU2_Solver_Test_MPI_2
 2/11 Test  #2: Amesos2_KLU2_Solver_Test_MPI_2 .......................   Passed    1.62 sec
      Start  3: Amesos2_ShyLUBasker_UnitTests_MPI_2
 3/11 Test  #3: Amesos2_ShyLUBasker_UnitTests_MPI_2 ..................   Passed    0.39 sec
      Start  4: Amesos2_SolverFactory_UnitTests_MPI_4
 4/11 Test  #4: Amesos2_SolverFactory_UnitTests_MPI_4 ................   Passed    1.42 sec
      Start  5: Amesos2_Tpetra_MultiVector_Adapter_UnitTests_MPI_4
 5/11 Test  #5: Amesos2_Tpetra_MultiVector_Adapter_UnitTests_MPI_4 ...   Passed    0.74 sec
      Start  6: Amesos2_Tpetra_CrsMatrix_Adapter_UnitTests_MPI_4
 6/11 Test  #6: Amesos2_Tpetra_CrsMatrix_Adapter_UnitTests_MPI_4 .....   Passed    1.17 sec
      Start  7: Amesos2_Epetra_MultiVector_Adapter_UnitTests_MPI_4
 7/11 Test  #7: Amesos2_Epetra_MultiVector_Adapter_UnitTests_MPI_4 ...   Passed    0.68 sec
      Start  8: Amesos2_Epetra_RowMatrix_Adapter_UnitTests_MPI_4
 8/11 Test  #8: Amesos2_Epetra_RowMatrix_Adapter_UnitTests_MPI_4 .....   Passed    2.62 sec
      Start  9: Amesos2_CrsMatrix_Adapter_Consistency_Tests_MPI_4
 9/11 Test  #9: Amesos2_CrsMatrix_Adapter_Consistency_Tests_MPI_4 ....   Passed    2.91 sec
      Start 10: Amesos2_SimpleSolveExampleNonContigMap_MPI_2
10/11 Test #10: Amesos2_SimpleSolveExampleNonContigMap_MPI_2 .........   Passed    1.23 sec
      Start 11: Amesos2_GappedMtxGIDs-1proc_MPI_1
11/11 Test #11: Amesos2_GappedMtxGIDs-1proc_MPI_1 ....................   Passed    1.27 sec

100% tests passed, 0 tests failed out of 11

Label Time Summary:
Amesos2    =  52.36 sec*proc (11 tests)

Total Test time (real) =  17.30 sec
```

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->