### PR TITLE
Tpetra: Fix CMake test for default ordinal type

### DIFF
--- a/packages/tpetra/CMakeLists.txt
+++ b/packages/tpetra/CMakeLists.txt
@@ -684,7 +684,7 @@ MESSAGE(STATUS "Tpetra: Tpetra_INST_INT_LONG is disabled by default.")
 
 # IF anything other than long long is defined and enabled, and long long isn't defined then we disable long long
 IF( (    (    DEFINED Tpetra_INST_INT_INT           AND Tpetra_INST_INT_INT)
-     OR  (    DEFINED Tpetra_INST_INT_LONG          AND Tpetra_INST_INT_UNSIGNED_LONG)
+     OR  (    DEFINED Tpetra_INST_INT_LONG          AND Tpetra_INST_INT_LONG)
      OR  (    DEFINED Tpetra_INST_INT_UNSIGNED      AND Tpetra_INST_INT_UNSIGNED)
      OR  (    DEFINED Tpetra_INST_INT_UNSIGNED_LONG AND Tpetra_INST_INT_UNSIGNED_LONG))
      AND (NOT DEFINED Tpetra_INST_INT_LONG_LONG) )


### PR DESCRIPTION
@trilinos/tpetra

The `CMakeLists.txt` was testing for

```
DEFINED Tpetra_INST_INT_LONG AND Tpetra_INST_INT_UNSIGNED_LONG
```

instead of

```
DEFINED Tpetra_INST_INT_LONG AND Tpetra_INST_INT_LONG
```

which resulted in `-DTpetra_INST_INT_LONG=ON` requiring the explicit `-DTpetra_INST_INT_LONG_LONG=OFF` to prevent the build failing from two ordinal types being specified.
