### PR TITLE
Amesos2 : Update Pardiso interface for deprecated codes

### DIFF
--- a/packages/amesos2/src/Amesos2_PardisoMKL_TypeMap.hpp
+++ b/packages/amesos2/src/Amesos2_PardisoMKL_TypeMap.hpp
@@ -66,15 +66,16 @@
 #endif
 
 #include "Amesos2_TypeMap.hpp"
+#ifdef _MKL_TYPES_H_
+  #undef _MKL_TYPES_H_
+  #define PARDISOMKL_PREVIOUS_MKL_TYPES_H
+#endif
 
 namespace Amesos2{
   namespace PMKL {
     //Update JDB 6.25.15
     //MKL has changed _INTEGER_t to deprecated
     //MKL has changed _INTEGER_t to define from typedef 
-  #ifdef _MKL_TYPES_H_
-    #undef _MKL_TYPES_H_
-  #endif
     #include <mkl_types.h>
   #ifdef __MKL_DSS_H
     #undef __MKL_DSS_H
@@ -285,4 +286,8 @@ namespace Amesos2 {
 
 } // end namespace Amesos
 
+#ifndef PARDISOMKL_PREVIOUS_MKL_TYPES_H
+  // first time including mkl_types.h
+  #undef _MKL_TYPES_H_
+#endif
 #endif  // AMESOS2_PARDISOMKL_TYPEMAP_HPP

--- a/packages/amesos2/src/Amesos2_PardisoMKL_decl.hpp
+++ b/packages/amesos2/src/Amesos2_PardisoMKL_decl.hpp
@@ -115,6 +115,10 @@ namespace Amesos2 {
      */
     typedef FunctionMap<Amesos2::PardisoMKL,int_t>                  function_map;
 
+    typedef Kokkos::DefaultHostExecutionSpace HostExecSpaceType;
+    typedef Kokkos::View<int_t*,              HostExecSpaceType>    host_size_type_array;
+    typedef Kokkos::View<int_t*,              HostExecSpaceType>    host_ordinal_type_array;
+    typedef Kokkos::View<solver_scalar_type*, HostExecSpaceType>    host_value_type_array;
 
     /// \name Constructor/Destructor methods
     //@{
@@ -271,11 +275,11 @@ namespace Amesos2 {
      */
 
     /// Stores the values of the nonzero entries for PardisoMKL
-    Teuchos::Array<solver_scalar_type> nzvals_;
+    host_value_type_array nzvals_view_;
     /// Stores the location in \c Ai_ and Aval_ that starts row j
-    Teuchos::Array<int_t> colind_;
+    host_ordinal_type_array colind_view_;
     /// Stores the row indices of the nonzero entries
-    Teuchos::Array<int_t> rowptr_;
+    host_size_type_array rowptr_view_;
     /// Persisting, contiguous, 1D store for X
     mutable Teuchos::Array<solver_scalar_type> xvals_;
     /// Persisting, contiguous, 1D store for B

--- a/packages/amesos2/src/Amesos2_PardisoMKL_def.hpp
+++ b/packages/amesos2/src/Amesos2_PardisoMKL_def.hpp
@@ -75,9 +75,6 @@ namespace Amesos2 {
                                         Teuchos::RCP<Vector>       X,
                                         Teuchos::RCP<const Vector> B)
     : SolverCore<Amesos2::PardisoMKL,Matrix,Vector>(A, X, B) // instantiate superclass
-    , nzvals_()
-    , colind_()
-    , rowptr_()
     , n_(Teuchos::as<int_t>(this->globalNumRows_))
     , perm_(this->globalNumRows_)
     , nrhs_(0)
@@ -122,8 +119,8 @@ namespace Amesos2 {
       int_t phase = -1;         // release all internal solver memory
       function_map::pardiso( pt_, const_cast<int_t*>(&maxfct_),
                              const_cast<int_t*>(&mnum_), &mtype_, &phase, &n_,
-                             nzvals_.getRawPtr(), rowptr_.getRawPtr(),
-                             colind_.getRawPtr(), perm_.getRawPtr(), &nrhs_, iparm_,
+                             nzvals_view_.data(), rowptr_view_.data(),
+                             colind_view_.data(), perm_.getRawPtr(), &nrhs_, iparm_,
                              const_cast<int_t*>(&msglvl_), &bdummy, &xdummy, &error );
     }
 
@@ -158,8 +155,8 @@ namespace Amesos2 {
 
       function_map::pardiso( pt_, const_cast<int_t*>(&maxfct_),
                              const_cast<int_t*>(&mnum_), &mtype_, &phase, &n_,
-                             nzvals_.getRawPtr(), rowptr_.getRawPtr(),
-                             colind_.getRawPtr(), perm_.getRawPtr(), &nrhs_, iparm_,
+                             nzvals_view_.data(), rowptr_view_.data(),
+                             colind_view_.data(), perm_.getRawPtr(), &nrhs_, iparm_,
                              const_cast<int_t*>(&msglvl_), &bdummy, &xdummy, &error );
     }
 
@@ -190,8 +187,8 @@ namespace Amesos2 {
 
       function_map::pardiso( pt_, const_cast<int_t*>(&maxfct_),
                              const_cast<int_t*>(&mnum_), &mtype_, &phase, &n_,
-                             nzvals_.getRawPtr(), rowptr_.getRawPtr(),
-                             colind_.getRawPtr(), perm_.getRawPtr(), &nrhs_, iparm_,
+                             nzvals_view_.data(), rowptr_view_.data(),
+                             colind_view_.data(), perm_.getRawPtr(), &nrhs_, iparm_,
                              const_cast<int_t*>(&msglvl_), &bdummy, &xdummy, &error );
     }
 
@@ -253,9 +250,9 @@ namespace Amesos2 {
                              const_cast<int_t*>(&mtype_),
                              const_cast<int_t*>(&phase),
                              const_cast<int_t*>(&n_),
-                             const_cast<solver_scalar_type*>(nzvals_.getRawPtr()),
-                             const_cast<int_t*>(rowptr_.getRawPtr()),
-                             const_cast<int_t*>(colind_.getRawPtr()),
+                             const_cast<solver_scalar_type*>(nzvals_view_.data()),
+                             const_cast<int_t*>(rowptr_view_.data()),
+                             const_cast<int_t*>(colind_view_.data()),
                              const_cast<int_t*>(perm_.getRawPtr()),
                              &nrhs_,
                              const_cast<int_t*>(iparm_),
@@ -518,9 +515,9 @@ PardisoMKL<Matrix,Vector>::loadA_impl(EPhase current_phase)
   if( current_phase == PREORDERING ) return( false );
 
   if( this->root_ ){
-    nzvals_.resize(this->globalNumNonZeros_);
-    colind_.resize(this->globalNumNonZeros_);
-    rowptr_.resize(this->globalNumRows_ + 1);
+    Kokkos::resize(nzvals_view_, this->globalNumNonZeros_);
+    Kokkos::resize(colind_view_, this->globalNumNonZeros_);
+    Kokkos::resize(rowptr_view_, this->globalNumRows_ + 1);
   }
 
   int_t nnz_ret = 0;
@@ -530,19 +527,19 @@ PardisoMKL<Matrix,Vector>::loadA_impl(EPhase current_phase)
 #endif
 
     if ( is_contiguous_ == true ) {
-      Util::get_crs_helper<
+      Util::get_crs_helper_kokkos_view<
         MatrixAdapter<Matrix>,
-        solver_scalar_type,
-        int_t,int_t>::do_get(this->matrixA_.ptr(),
-            nzvals_(), colind_(), rowptr_(),
+        host_value_type_array, host_ordinal_type_array, host_size_type_array>::do_get(
+            this->matrixA_.ptr(),
+            nzvals_view_, colind_view_, rowptr_view_,
             nnz_ret, ROOTED, SORTED_INDICES, this->rowIndexBase_);
     }
     else {
-      Util::get_crs_helper<
+      Util::get_crs_helper_kokkos_view<
         MatrixAdapter<Matrix>,
-        solver_scalar_type,
-        int_t,int_t>::do_get(this->matrixA_.ptr(),
-            nzvals_(), colind_(), rowptr_(),
+        host_value_type_array, host_ordinal_type_array, host_size_type_array>::do_get(
+            this->matrixA_.ptr(),
+            nzvals_view_, colind_view_, rowptr_view_,
             nnz_ret, CONTIGUOUS_AND_ROOTED, SORTED_INDICES, this->rowIndexBase_);
     }
 }


### PR DESCRIPTION

@trilinos/amesos2 

## Motivation

This PR updates Amesos2 interface to Pardiso for the deprecated codes that have been removed.

## Testing

On Blake using `intel/compilers/20.2.254`:
```
Test project /ascldap/users/iyamaza/github/basker/forks/trilinos-build-intel/packages/amesos2/test/solvers
    Start 1: Amesos2_Pardiso_MKL_Solver_Test
1/2 Test #1: Amesos2_Pardiso_MKL_Solver_Test ...   Passed    0.05 sec
    Start 2: Amesos2_SolverFactory_UnitTests
2/2 Test #2: Amesos2_SolverFactory_UnitTests ...   Passed    0.15 sec

100% tests passed, 0 tests failed out of 2
```