### PR TITLE
Tpetra: Additions to get performance data from Distributor unit test

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_DistributorActor.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorActor.hpp
@@ -375,8 +375,8 @@ void DistributorActor::doPosts(const DistributorPlan& plan,
         size_t sendArrayOffset = 0;
         size_t j = plan.getStartsTo()[p];
         for (size_t k = 0; k < plan.getLengthsTo()[p]; ++k, ++j) {
-          deep_copy_offset(sendArray, exports, sendArrayOffset,
-              plan.getIndicesTo()[j]*numPackets, numPackets);
+          deep_copy_offset(sendArray, exports, sendArrayOffset, plan.getIndicesTo()[j]*numPackets, numPackets);
+          //memcpy(sendArray.data()+sendArrayOffset, exports.data()+plan.getIndicesTo()[j]*numPackets, numPackets*sizeof(Packet));
           sendArrayOffset += numPackets;
         }
         ImpView tmpSend =
@@ -394,8 +394,8 @@ void DistributorActor::doPosts(const DistributorPlan& plan,
 
     if (plan.hasSelfMessage()) {
       for (size_t k = 0; k < plan.getLengthsTo()[selfNum]; ++k) {
-        deep_copy_offset(imports, exports, selfReceiveOffset,
-            plan.getIndicesTo()[selfIndex]*numPackets, numPackets);
+        deep_copy_offset(imports, exports, selfReceiveOffset, plan.getIndicesTo()[selfIndex]*numPackets, numPackets);
+        //memcpy(imports.data()+selfReceiveOffset, exports.data()+plan.getIndicesTo()[selfIndex]*numPackets, numPackets*sizeof(Packet));
         ++selfIndex;
         selfReceiveOffset += numPackets;
       }

--- a/packages/tpetra/core/src/Tpetra_Details_DistributorActor.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorActor.hpp
@@ -376,7 +376,6 @@ void DistributorActor::doPosts(const DistributorPlan& plan,
         size_t j = plan.getStartsTo()[p];
         for (size_t k = 0; k < plan.getLengthsTo()[p]; ++k, ++j) {
           deep_copy_offset(sendArray, exports, sendArrayOffset, plan.getIndicesTo()[j]*numPackets, numPackets);
-          //memcpy(sendArray.data()+sendArrayOffset, exports.data()+plan.getIndicesTo()[j]*numPackets, numPackets*sizeof(Packet));
           sendArrayOffset += numPackets;
         }
         ImpView tmpSend =
@@ -395,7 +394,6 @@ void DistributorActor::doPosts(const DistributorPlan& plan,
     if (plan.hasSelfMessage()) {
       for (size_t k = 0; k < plan.getLengthsTo()[selfNum]; ++k) {
         deep_copy_offset(imports, exports, selfReceiveOffset, plan.getIndicesTo()[selfIndex]*numPackets, numPackets);
-        //memcpy(imports.data()+selfReceiveOffset, exports.data()+plan.getIndicesTo()[selfIndex]*numPackets, numPackets*sizeof(Packet));
         ++selfIndex;
         selfReceiveOffset += numPackets;
       }


### PR DESCRIPTION
@trilinos/tpetra 

## Motivation
Adds a command line arg and a loop so we can run the "doPostsNonContig" test several times and get performance data on the slow path of the 3-arg doPostsAndWaits.

## Testing
This is itself a test.