### PR TITLE
Amesos2 : adds iterative refinement example (plus ShyLU-Basker singularity-check fix)

### DIFF
--- a/packages/amesos2/example/CMakeLists.txt
+++ b/packages/amesos2/example/CMakeLists.txt
@@ -69,11 +69,15 @@ TRIBITS_ADD_EXECUTABLE(
   SOURCES quick_solve.cpp
   )
 
- TRIBITS_ADD_EXECUTABLE(
-   SimpleSolveFileExample
+TRIBITS_ADD_EXECUTABLE(
+  SimpleSolveFileExample
   SOURCES SimpleSolve_File.cpp
- )
+  )
 
+TRIBITS_ADD_EXECUTABLE(
+  SimpleSolveIRExample
+  SOURCES SimpleSolve_IR.cpp
+  )
 
 IF (${PACKAGE_NAME}_ENABLE_Epetra AND ${PACKAGE_NAME}_ENABLE_EpetraExt)
   TRIBITS_ADD_EXECUTABLE(

--- a/packages/amesos2/example/SimpleSolve_IR.cpp
+++ b/packages/amesos2/example/SimpleSolve_IR.cpp
@@ -1,0 +1,179 @@
+// @HEADER
+//
+// ***********************************************************************
+//
+//           Amesos2: Templated Direct Sparse Solver Package
+//                  Copyright 2011 Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ***********************************************************************
+//
+// @HEADER
+
+#include <Teuchos_ScalarTraits.hpp>
+#include <Teuchos_RCP.hpp>
+#include <Teuchos_oblackholestream.hpp>
+#include <Teuchos_VerboseObject.hpp>
+#include <Teuchos_CommandLineProcessor.hpp>
+
+#include <Tpetra_Core.hpp>
+#include <Tpetra_Map.hpp>
+#include <Tpetra_MultiVector.hpp>
+#include <Tpetra_CrsMatrix.hpp>
+
+// I/O for Matrix-Market files
+#include <MatrixMarket_Tpetra.hpp>
+#include <Tpetra_Import.hpp>
+
+#include "Amesos2.hpp"
+#include "Amesos2_Version.hpp"
+
+
+int main(int argc, char *argv[]) {
+  Tpetra::ScopeGuard tpetraScope(&argc,&argv);
+
+  typedef double Scalar;
+  typedef Tpetra::Map<>::local_ordinal_type LO;
+  typedef Tpetra::Map<>::global_ordinal_type GO;
+
+  typedef Tpetra::CrsMatrix<Scalar,LO,GO> MAT;
+  typedef Tpetra::MultiVector<Scalar,LO,GO> MV;
+
+  using Tpetra::global_size_t;
+  using Tpetra::Map;
+  using Tpetra::Import;
+  using Teuchos::RCP;
+  using Teuchos::rcp;
+
+
+  //
+  // Get the default communicator
+  //
+  Teuchos::RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm();
+  int myRank = comm->getRank();
+
+  Teuchos::oblackholestream blackhole;
+
+  bool printTiming   = false;
+  bool equil         = false;
+  bool tinyPivot     = true;
+  bool solveIR       = false;
+  int  numIRs        = 5;
+  bool verboseIR     = true;
+  bool verbose       = true;
+  std::string solverName("SuperLUDist");
+  std::string filename("arc130.mtx");
+  std::string rhsFilename("");
+  Teuchos::CommandLineProcessor cmdp(false,true);
+  cmdp.setOption("verbose","quiet",&verbose,"Print messages and results.");
+  cmdp.setOption("equil","noEquil",&equil,"Use Equil.");
+  cmdp.setOption("tinyPivot","noTinyPivot",&tinyPivot,"Replace tiny pivot.");
+  cmdp.setOption("solveIR","noSolveIR",&solveIR,"Solve with IR.");
+  cmdp.setOption("solver",&solverName,"Solver name");
+  cmdp.setOption("filename",&filename,"Filename for Matrix-Market test matrix.");
+  cmdp.setOption("rhsFilename",&rhsFilename,"Filename for RHS.");
+  cmdp.setOption("print-timing","no-print-timing",&printTiming,"Print solver timing statistics");
+  if (cmdp.parse(argc,argv) != Teuchos::CommandLineProcessor::PARSE_SUCCESSFUL) {
+    return -1;
+  }
+
+  std::ostream& out = ( (verbose && myRank == 0) ? std::cout : blackhole );
+  RCP<Teuchos::FancyOStream> fos = Teuchos::fancyOStream(Teuchos::rcpFromRef(out));
+
+  // Say hello
+  out << myRank << " : " << Amesos2::version() << std::endl << std::endl;
+
+  RCP<MAT> A = Tpetra::MatrixMarket::Reader<MAT>::readSparseFile(filename, comm);
+  out << std::endl << A->description() << std::endl << std::endl;
+
+  // get the maps
+  RCP<const Map<LO,GO> > dmnmap = A->getDomainMap();
+  RCP<const Map<LO,GO> > rngmap = A->getRangeMap();
+
+  const size_t numVectors = 1;
+  RCP<MV> Xhat = rcp(new MV(rngmap,numVectors));
+  RCP<MV> X = rcp(new MV(rngmap,numVectors));
+  Xhat->putScalar(1.0);
+
+  // Create random X
+  X->randomize();
+
+  // Create B
+  RCP<MV> B = rcp(new MV(rngmap,numVectors));
+  if (rhsFilename != "") {
+    typedef Tpetra::MatrixMarket::Reader<Tpetra::CrsMatrix<Scalar>> reader_type;
+    B = reader_type::readDenseFile (rhsFilename, comm, rngmap, false, false);
+  } else {
+    A->apply (*Xhat, *B);
+    //B->putScalar(1.0);
+  }
+
+  // Constructor from Factory
+  RCP<Amesos2::Solver<MAT,MV> > solver;
+  solver = Amesos2::create<MAT,MV>(solverName, A, X, B);
+  Teuchos::ParameterList amesos2_params("Amesos2");
+  if (solverName == "SuperLUDist") {
+    auto superlu_params = Teuchos::sublist(Teuchos::rcpFromRef(amesos2_params), "SuperLU_DIST");
+    superlu_params->set("Equil", equil);
+    superlu_params->set("ReplaceTinyPivot", tinyPivot);
+  }
+  if (solveIR) {
+    amesos2_params.set("Iterative refinement", true);
+    amesos2_params.set("Number of iterative refinements", numIRs);
+    amesos2_params.set("Verboes for iterative refinement", verboseIR);
+  }
+  solver->setParameters( Teuchos::rcpFromRef(amesos2_params) );
+  solver->symbolicFactorization().numericFactorization().solve();
+
+  if (verbose) {
+    using mag_type = MV::mag_type;
+    MV R (B->getMap (), B->getNumVectors ());
+    Teuchos::Array<mag_type> B_norms (B->getNumVectors ());
+    Teuchos::Array<mag_type> R_norms (R.getNumVectors ());
+    B->norm2 (B_norms ());
+    A->apply (*X, R);
+    R.update (1.0, *B, -1.0);
+    R.norm2 (R_norms ());
+    out << "normR = " << R_norms[0] << " / " << B_norms[0] << " = " << R_norms[0]/B_norms[0] << std::endl;
+  }
+
+  if( printTiming ){
+    // Print some timing statistics
+    solver->printTiming(*fos);
+  }
+  Teuchos::TimeMonitor::summarize();
+
+  // We are done.
+  return 0;
+}

--- a/packages/shylu/shylu_node/basker/src/shylubasker_nfactor_blk.hpp
+++ b/packages/shylu/shylu_node/basker/src/shylubasker_nfactor_blk.hpp
@@ -487,7 +487,7 @@ namespace BaskerNS
                << "  norm(A)   = " << normA_blk << " (block)"  << endl
                << "  replace_zero_pivot = " << (Options.replace_zero_pivot ? " true " : "false" ) << endl;
           if (Options.replace_tiny_pivot && normA_blk > abs(zero) && maxindex != BASKER_MAX_IDX) {
-            cout << "  + replace zero pivot with " << normA_blk * sqrt(eps) << endl;
+            cout << "  + replace tiny pivot with " << normA_blk * sqrt(eps) << endl;
           } else if (Options.replace_zero_pivot && normA_blk > abs(zero) && maxindex != BASKER_MAX_IDX) {
             cout << "  - replace zero pivot with " << normA_blk * eps << endl;
           }

--- a/packages/shylu/shylu_node/basker/src/shylubasker_order_btf.hpp
+++ b/packages/shylu/shylu_node/basker/src/shylubasker_order_btf.hpp
@@ -214,6 +214,10 @@ namespace BaskerNS
     #endif
     int blk_mwm_info = btf_blk_mwm_amd(M, order_blk_mwm_array, order_blk_amd_array, btf_blk_nnz, btf_blk_work);
     if (blk_mwm_info != BASKER_SUCCESS) {
+      if(Options.verbose == BASKER_TRUE)
+      {
+        printf("Basker: error btf_blk_mwm_amd returned %d \n", (int)blk_mwm_info);
+      }
       return blk_mwm_info;
     }
     #if 0 //debug
@@ -258,26 +262,12 @@ namespace BaskerNS
       {
         printf("Basker find BTF: apply BLK AMD\n");
       }
-      /*printf(" B = [\n" );
-      for(Int j = 0; j < M.ncol; j++) {
-        for(Int k = M.col_ptr[j]; k < M.col_ptr[j+1]; k++) {
-          printf("%d %d %.16e\n", M.row_idx[k], j, M.val[k]);
-        }
-      }
-      printf("];\n");*/
+      //M.print_matrix("B.dat");
 
       // > apply AMD to cols & rows
       permute_col_store_valperms(M, order_blk_amd_array, vals_order_blk_amd_array); //NDE: col-order M & Track movement
       permute_row(M, order_blk_amd_array);
-
-      /*printf(" T = [\n" );
-      for(Int j = 0; j < M.ncol; j++) {
-        for(Int k = M.col_ptr[j]; k < M.col_ptr[j+1]; k++) {
-          //std::cout << M.row_idx[k] << " " << j << " " << M.val[k] << std::endl;
-          printf("%d %d %.16e\n", M.row_idx[k], j, M.val[k]);
-        }
-      }
-      printf("];\n");*/
+      //M.print_matrix("T.dat");
 
       #ifdef BASKER_TIMER
       order_time = timer_order.seconds();
@@ -314,54 +304,12 @@ namespace BaskerNS
     std::cout << " >>> Basker order : partition time    : " << order_time << std::endl;
     timer_order.reset();
     #endif
-    /*printf(" M = [\n" );
-    for(Int j = 0; j < M.ncol; j++) {
-      for(Int k = M.col_ptr[j]; k < M.col_ptr[j+1]; k++) {
-        printf("%d %d %.16e\n", M.row_idx[k], j, M.val[k]);
-      }
-    }
-    printf("];\n"); fflush(stdout);
-
-    printf(" A = [\n" );
-    for(Int j = 0; j < BTF_A.ncol; j++) {
-      for(Int k = BTF_A.col_ptr[j]; k < BTF_A.col_ptr[j+1]; k++) {
-        printf("%d %d %.16e\n", BTF_A.row_idx[k], j, BTF_A.val[k]);
-      }
-    }
-    printf("];\n"); fflush(stdout);
-
-    printf(" D = [\n" );
-    for(Int j = 0; j < BTF_D.ncol; j++) {
-      for(Int k = BTF_D.col_ptr[j]; k < BTF_D.col_ptr[j+1]; k++) {
-        printf("%d %d %.16e\n", BTF_D.row_idx[k], j, BTF_D.val[k]);
-      }
-    }
-    printf("];\n"); fflush(stdout);
-
-    printf(" E = [\n" );
-    for(Int j = 0; j < BTF_E.ncol; j++) {
-      for(Int k = BTF_E.col_ptr[j]; k < BTF_E.col_ptr[j+1]; k++) {
-        printf("%d %d %.16e\n", BTF_E.row_idx[k], j, BTF_E.val[k]);
-      }
-    }
-    printf("];\n"); fflush(stdout);
-
-    printf(" C = [\n" );
-    for(Int j = 0; j < BTF_C.ncol; j++) {
-      for(Int k = BTF_C.col_ptr[j]; k < BTF_C.col_ptr[j+1]; k++) {
-        printf("%d %d %.16e\n", BTF_C.row_idx[k], j, BTF_C.val[k]);
-      }
-    }
-    printf("];\n"); fflush(stdout);
-
-    printf(" B = [\n" );
-    for(Int j = 0; j < BTF_B.ncol; j++) {
-      for(Int k = BTF_B.col_ptr[j]; k < BTF_B.col_ptr[j+1]; k++) {
-        printf("%d %d %.16e\n", BTF_B.row_idx[k], j, BTF_B.val[k]);
-      }
-    }
-    printf("];\n"); fflush(stdout);*/
-
+    //M.print_matrix("M.dat");
+    //BTF_A.print_matrix("A.dat");
+    //BTF_D.print_matrix("D.dat");
+    //BTF_E.print_matrix("E.dat");
+    //BTF_C.print_matrix("C.dat");
+    //BTF_B.print_matrix("B.dat");
 
 
     //================================================================
@@ -709,11 +657,11 @@ namespace BaskerNS
         Options.run_nd_on_leaves = BASKER_FALSE;
       }
       #endif
-      if (Options.replace_tiny_pivot == BASKER_TRUE) {
+      if (Options.replace_zero_pivot == BASKER_TRUE) {
         if(Options.verbose == BASKER_TRUE) {
-          printf("Basker: turning off replace-tiny-pivot option since one block (to identify singular matrix)\n");
+          printf("Basker: turning off replace-zero-pivot option since one block (to identify singular matrix)\n");
         }
-        Options.replace_tiny_pivot = BASKER_FALSE;
+        Options.replace_zero_pivot = BASKER_FALSE;
       }
       return 0;
     }


### PR DESCRIPTION

@trilinos/shylu @trilinos/amesos2 

## Motivation

- Amesos2 : this PR adds an example of using iterative refinements
- ShyLU-Basker : this PR also fixes the singularity detection when BTF has only one block (by turning the replace-zero-pivot flag off)

## Testing

```
    Start 1: ShyLU_NodeBasker_singular_matrix_check
1/6 Test #1: ShyLU_NodeBasker_singular_matrix_check .............   Passed    0.02 sec
    Start 2: ShyLU_NodeBasker_basker_test_1
2/6 Test #2: ShyLU_NodeBasker_basker_test_1 .....................   Passed    1.03 sec
    Start 3: ShyLU_NodeBasker_basker_amesos_test_1
3/6 Test #3: ShyLU_NodeBasker_basker_amesos_test_1 ..............   Passed    0.72 sec
    Start 4: ShyLU_NodeBasker_basker_test_4
4/6 Test #4: ShyLU_NodeBasker_basker_test_4 .....................   Passed    1.32 sec
    Start 5: ShyLU_NodeBasker_basker_amesos2_test_4
5/6 Test #5: ShyLU_NodeBasker_basker_amesos2_test_4 .............   Passed    0.77 sec
    Start 6: ShyLU_NodeBasker_basker_amesos2_coverage_test_14
6/6 Test #6: ShyLU_NodeBasker_basker_amesos2_coverage_test_14 ...   Passed    0.03 sec

100% tests passed, 0 tests failed out of 6
```