### PR TITLE
Tacho - change hip stream destruction order.

### DIFF
--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
@@ -627,12 +627,9 @@ public:
 
   virtual ~NumericToolsLevelSet() {
 #if defined(KOKKOS_ENABLE_CUDA)
-    // destroy previously created streams
-    for (ordinal_type i = 0; i < _nstreams; ++i) {
-      _status = cudaStreamDestroy(_streams[i]);
-      checkDeviceStatus("cudaStreamDestroy");
-    }
-    _streams.clear();
+    /// kokkos execution space may fence and it uses the wrapped stream when it is deallocated   
+    /// on cuda, deallocting streams first does not cause any errors while hip generates errors.
+    /// here, we just follow the consistent destruction process as hip does.
     _exec_instances.clear();
 
     if (_is_cusolver_dn_created) {
@@ -643,8 +640,15 @@ public:
       _status = cublasDestroy(_handle_blas);
       checkDeviceBlasStatus("cublasDestroy");
     }
+
+    for (ordinal_type i = 0; i < _nstreams; ++i) {
+      _status = cudaStreamDestroy(_streams[i]);
+      checkDeviceStatus("cudaStreamDestroy");
+    }
+    _streams.clear();
 #endif
 #if defined(KOKKOS_ENABLE_HIP)
+    /// kokkos execution space may fence and it uses the wrapped stream when it is deallocated   
     _exec_instances.clear();
 
     if (_is_rocblas_created) {

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
@@ -645,18 +645,18 @@ public:
     }
 #endif
 #if defined(KOKKOS_ENABLE_HIP)
-    // destroy previously created streams
-    for (ordinal_type i = 0; i < _nstreams; ++i) {
-      _status = hipStreamDestroy(_streams[i]);
-      checkDeviceStatus("cudaStreamDestroy");
-    }
-    _streams.clear();
     _exec_instances.clear();
 
     if (_is_rocblas_created) {
       _status = rocblas_destroy_handle(_handle_blas);
       checkDeviceLapackStatus("rocblasDestroy");
     }
+
+    for (ordinal_type i = 0; i < _nstreams; ++i) {
+      _status = hipStreamDestroy(_streams[i]);
+      checkDeviceStatus("cudaStreamDestroy");
+    }
+    _streams.clear();
 #endif
   }
 


### PR DESCRIPTION
## Motivation

hip stream is used when kokkos execution space instances are destroyed. so, the stream should be defalcated afterward. cuda stream does not have this problem even if the stream is deleted first. for consistency, cuda destruction order is also changed.


## Test

Tested on caraway03 with ROCM 5.2
