### PR TITLE
Disable randomly failing Tpetra test (#10847), remove FORCE from all test disables (#10870)

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -2353,6 +2353,9 @@ use SEMS_COMMON_CUDA_11
 use RHEL7_SEMS_CUDA_UVM_OFF_DISABLES
 use RHEL7_POST
 
+# Additional rhel7_sems-cuda-11.4.2, no-uvm test disables
+opt-set-cmake-var TpetraTSQR_SequentialTsqr_noncontiguousCacheBlocks_MPI_1_DISABLE BOOL : ON
+
 [rhel7_sems-cuda-11.4.2-sems-gnu-10.1.0-sems-openmpi-4.0.5_release_static_Volta70_no-asan_complex_no-fpic_mpi_pt_no-rdc_uvm_deprecated-on_no-package-enables]
 use RHEL7_SEMS_COMPILER|CUDA
 use NODE-TYPE|CUDA

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -2354,6 +2354,7 @@ use RHEL7_SEMS_CUDA_UVM_OFF_DISABLES
 use RHEL7_POST
 
 # Additional rhel7_sems-cuda-11.4.2, no-uvm test disables
+opt-set-cmake-var TpetraTSQR_SequentialTsqr_contiguousCacheBlocks_MPI_1_DISABLE BOOL : ON
 opt-set-cmake-var TpetraTSQR_SequentialTsqr_noncontiguousCacheBlocks_MPI_1_DISABLE BOOL : ON
 
 [rhel7_sems-cuda-11.4.2-sems-gnu-10.1.0-sems-openmpi-4.0.5_release_static_Volta70_no-asan_complex_no-fpic_mpi_pt_no-rdc_uvm_deprecated-on_no-package-enables]

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1628,144 +1628,144 @@ opt-set-cmake-var Trilinos_ENABLE_TrilinosCouplings BOOL FORCE : OFF
 opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HierarchicalBases_Hierarchical_Basis_Tests_MPI_1_SET_RUN_SERIAL BOOL FORCE : ON
 
 # Test Disables
-opt-set-cmake-var Adelus_vector_random_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Adelus_vector_random_MPI_2_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Adelus_vector_random_MPI_3_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Adelus_vector_random_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Amesos_Test_Detailed_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Amesos_Test_LAPACK_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Amesos_compare_solvers_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Anasazi_Epetra_IRTR_auxtest_0_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Anasazi_Epetra_IRTR_auxtest_1_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Anasazi_Epetra_IRTR_auxtest_2_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Anasazi_Epetra_IRTR_auxtest_3_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Anasazi_Epetra_IRTR_auxtest_4_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Anasazi_Epetra_LOBPCG_auxtest_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Anasazi_Epetra_LOBPCG_solvertest_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Belos_bl_fgmres_hb_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Belos_bl_pgmres_hb_0_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var EpetraExt_inout_test_LL_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var EpetraExt_inout_test_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var FEI_lagrange_20quad_old_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Ifpack2_BlockTriDiContainerUnitAndPerfTests_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Ifpack_Container_LL_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Ifpack_Container_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_DeRHAM_TET_FEM_test_01_Serial_DOUBLE_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_DeRHAM_TRI_FEM_test_01_Serial_DOUBLE_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HCURL_TET_In_FEM_test_01_CUDA_DFAD_DFAD_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HCURL_TET_In_FEM_test_01_CUDA_DOUBLE_DOUBLE_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HCURL_TET_In_FEM_test_01_CUDA_SFAD_SFAD_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HCURL_TET_In_FEM_test_01_CUDA_SLFAD_DFAD_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HCURL_TET_In_FEM_test_01_CUDA_SLFAD_DOUBLE_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HCURL_TET_In_FEM_test_01_Serial_DFAD_DFAD_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HCURL_TET_In_FEM_test_01_Serial_DOUBLE_DOUBLE_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HCURL_TET_In_FEM_test_01_Serial_SFAD_SFAD_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HCURL_TET_In_FEM_test_01_Serial_SLFAD_DFAD_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HCURL_TET_In_FEM_test_01_Serial_SLFAD_DOUBLE_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HDIV_TET_In_FEM_test_01_CUDA_DFAD_DFAD_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HDIV_TET_In_FEM_test_01_CUDA_DOUBLE_DOUBLE_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HDIV_TET_In_FEM_test_01_CUDA_SFAD_SFAD_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HDIV_TET_In_FEM_test_01_CUDA_SLFAD_DFAD_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HDIV_TET_In_FEM_test_01_CUDA_SLFAD_DOUBLE_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HDIV_TET_In_FEM_test_01_Serial_DFAD_DFAD_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HDIV_TET_In_FEM_test_01_Serial_DOUBLE_DOUBLE_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HDIV_TET_In_FEM_test_01_Serial_SFAD_SFAD_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HDIV_TET_In_FEM_test_01_Serial_SLFAD_DFAD_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HDIV_TET_In_FEM_test_01_Serial_SLFAD_DOUBLE_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HGRAD_TRI_Cn_FEM_test_01_CUDA_DFAD_DFAD_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HGRAD_TRI_Cn_FEM_test_01_CUDA_DOUBLE_DOUBLE_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HGRAD_TRI_Cn_FEM_test_01_CUDA_SFAD_SFAD_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HGRAD_TRI_Cn_FEM_test_01_CUDA_SLFAD_DFAD_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HGRAD_TRI_Cn_FEM_test_01_CUDA_SLFAD_DOUBLE_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HGRAD_TRI_Cn_FEM_test_01_Serial_DFAD_DFAD_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HGRAD_TRI_Cn_FEM_test_01_Serial_DOUBLE_DOUBLE_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HGRAD_TRI_Cn_FEM_test_01_Serial_SFAD_SFAD_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HGRAD_TRI_Cn_FEM_test_01_Serial_SLFAD_DFAD_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HGRAD_TRI_Cn_FEM_test_01_Serial_SLFAD_DOUBLE_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HVOL_TRI_Cn_FEM_test_01_CUDA_DFAD_DFAD_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HVOL_TRI_Cn_FEM_test_01_CUDA_DOUBLE_DOUBLE_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HVOL_TRI_Cn_FEM_test_01_CUDA_SFAD_SFAD_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HVOL_TRI_Cn_FEM_test_01_CUDA_SLFAD_DFAD_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HVOL_TRI_Cn_FEM_test_01_CUDA_SLFAD_DOUBLE_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HVOL_TRI_Cn_FEM_test_01_Serial_DFAD_DFAD_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HVOL_TRI_Cn_FEM_test_01_Serial_DOUBLE_DOUBLE_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HVOL_TRI_Cn_FEM_test_01_Serial_SFAD_SFAD_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HVOL_TRI_Cn_FEM_test_01_Serial_SLFAD_DFAD_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HVOL_TRI_Cn_FEM_test_01_Serial_SLFAD_DOUBLE_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_MonolithicExecutable_Intrepid2_Tests_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Orientation_test_orientation_HEX_Serial_DOUBLE_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Orientation_test_orientation_HEX_newBasis_Serial_DOUBLE_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Orientation_test_orientation_TET_Serial_DOUBLE_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Projection_test_DeRham_commutativity_TET_CUDA_DOUBLE_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Projection_test_DeRham_commutativity_TET_Serial_DOUBLE_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Projection_test_convergence_TET_CUDA_DOUBLE_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Projection_test_convergence_TET_Serial_DOUBLE_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Projection_test_interpolation_projection_HEX_CUDA_DOUBLE_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Projection_test_interpolation_projection_HEX_Serial_DOUBLE_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Projection_test_interpolation_projection_TET_CUDA_DOUBLE_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Projection_test_interpolation_projection_TET_Serial_DOUBLE_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid_test_Discretization_Basis_HCURL_HEX_In_FEM_Test_02_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid_test_Discretization_Basis_HCURL_TET_In_FEM_Test_02_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid_test_Discretization_Basis_HDIV_HEX_In_FEM_Test_02_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid_test_Discretization_Basis_HDIV_QUAD_In_FEM_Test_02_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid_test_Discretization_Basis_HDIV_TET_In_FEM_Test_02_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid_test_Discretization_Basis_HDIV_TRI_In_FEM_Test_02_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid_test_Discretization_Basis_HGRAD_HEX_Cn_FEM_Test_02_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid_test_Discretization_Basis_HGRAD_LINE_Hermite_FEM_Test_01_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid_test_Discretization_Basis_HGRAD_LINE_Hermite_FEM_Test_02_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid_test_Discretization_Basis_HGRAD_TET_Cn_FEM_Test_02_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid_test_Discretization_Basis_HGRAD_TRI_Cn_FEM_ORTH_Test_02_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid_test_Discretization_Basis_HGRAD_TRI_Cn_FEM_Test_01_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid_test_Discretization_Basis_HGRAD_TRI_Cn_FEM_Test_02_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var KokkosKernels_blas_serial_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var MiniTensor_test_Test_01_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var MiniTensor_test_Test_02_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var MueLu_Maxwell3D-Tpetra_2_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var MueLu_ParameterListInterpreterTpetra_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var MueLu_ReitzingerPFactory_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var MueLu_UnitTestsIntrepid2Tpetra_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var PanzerAdaptersSTK_MixedCurlLaplacianExample-ConvTest-Tri-Order-1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var PanzerAdaptersSTK_MixedPoissonExample-ConvTest-Hex-Order-3_DISABLE BOOL FORCE : ON
-opt-set-cmake-var PanzerAdaptersSTK_PoissonInterfaceExample_3d_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var PanzerAdaptersSTK_main_driver_energy-ss-blocked-tp_DISABLE BOOL FORCE : ON
-opt-set-cmake-var PanzerDofMgr_Test_FE_Assembly_HEX_MPI_2_DISABLE BOOL FORCE : ON
-opt-set-cmake-var PanzerMiniEM_MiniEM-BlockPrec_Augmentation_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var PanzerMiniEM_MiniEM-BlockPrec_RefMaxwell_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Piro_AnalysisDriverTpetra_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Piro_ThyraSolverTpetra_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var ROL_example_PDE-OPT_0ld_adv-diff-react_example_01_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var ROL_example_PDE-OPT_0ld_adv-diff-react_example_02_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var ROL_example_PDE-OPT_0ld_poisson_example_01_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var ROL_example_PDE-OPT_0ld_stefan-boltzmann_example_03_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var ROL_example_PDE-OPT_navier-stokes_example_01_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var ROL_example_PDE-OPT_navier-stokes_example_02_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var ROL_example_PDE-OPT_nonlinear-elliptic_example_01_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var ROL_example_PDE-OPT_nonlinear-elliptic_example_02_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var ROL_example_PDE-OPT_obstacle_example_01_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var ROL_example_PDE-OPT_poisson-boltzmann_example_01_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var ROL_example_PDE-OPT_topo-opt_poisson_example_01_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var ROL_example_poisson-inversion_example_01_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var ROL_test_elementwise_TpetraMultiVector_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var ROL_test_function_sketching_Interface_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var SEACASIoss_exodus32_to_exodus32_DISABLE BOOL FORCE : ON
-opt-set-cmake-var SEACASIoss_exodus_fpp_serialize_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Stratimikos_test_amesos_thyra_driver_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Stratimikos_test_single_amesos2_tpetra_solver_driver_KLU2_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Teko_testdriver_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var TeuchosNumerics_BLAS_test_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var ThyraTpetraAdapters_Simple2DTpetraModelEvaluatorUnitTests_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var ThyraTpetraAdapters_TpetraThyraWrappersUnitTests_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var ThyraTpetraAdapters_TpetraThyraWrappersUnitTests_serial_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var TpetraTSQR_FullTsqr_Accuracy_5000rows_100cols_Sequential_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var TrilinosCouplings_Example_Maxwell_MueLu_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var TrilinosCouplings_Example_Maxwell_MueLu_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Zoltan2_fix4785_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Pliris_vector_random_MPI_3_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Pliris_vector_random_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Projection_test_DeRham_commutativity_HEX_CUDA_DOUBLE_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Projection_test_DeRham_commutativity_QUAD_CUDA_DOUBLE_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_Projection_test_DeRham_commutativity_TRI_CUDA_DOUBLE_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Adelus_vector_random_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Adelus_vector_random_MPI_2_DISABLE BOOL : ON
+opt-set-cmake-var Adelus_vector_random_MPI_3_DISABLE BOOL : ON
+opt-set-cmake-var Adelus_vector_random_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var Amesos_Test_Detailed_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var Amesos_Test_LAPACK_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var Amesos_compare_solvers_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var Anasazi_Epetra_IRTR_auxtest_0_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var Anasazi_Epetra_IRTR_auxtest_1_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var Anasazi_Epetra_IRTR_auxtest_2_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var Anasazi_Epetra_IRTR_auxtest_3_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var Anasazi_Epetra_IRTR_auxtest_4_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var Anasazi_Epetra_LOBPCG_auxtest_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var Anasazi_Epetra_LOBPCG_solvertest_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var Belos_bl_fgmres_hb_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var Belos_bl_pgmres_hb_0_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var EpetraExt_inout_test_LL_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var EpetraExt_inout_test_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var FEI_lagrange_20quad_old_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Ifpack2_BlockTriDiContainerUnitAndPerfTests_DISABLE BOOL : ON
+opt-set-cmake-var Ifpack_Container_LL_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var Ifpack_Container_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_DeRHAM_TET_FEM_test_01_Serial_DOUBLE_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_DeRHAM_TRI_FEM_test_01_Serial_DOUBLE_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HCURL_TET_In_FEM_test_01_CUDA_DFAD_DFAD_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HCURL_TET_In_FEM_test_01_CUDA_DOUBLE_DOUBLE_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HCURL_TET_In_FEM_test_01_CUDA_SFAD_SFAD_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HCURL_TET_In_FEM_test_01_CUDA_SLFAD_DFAD_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HCURL_TET_In_FEM_test_01_CUDA_SLFAD_DOUBLE_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HCURL_TET_In_FEM_test_01_Serial_DFAD_DFAD_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HCURL_TET_In_FEM_test_01_Serial_DOUBLE_DOUBLE_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HCURL_TET_In_FEM_test_01_Serial_SFAD_SFAD_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HCURL_TET_In_FEM_test_01_Serial_SLFAD_DFAD_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HCURL_TET_In_FEM_test_01_Serial_SLFAD_DOUBLE_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HDIV_TET_In_FEM_test_01_CUDA_DFAD_DFAD_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HDIV_TET_In_FEM_test_01_CUDA_DOUBLE_DOUBLE_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HDIV_TET_In_FEM_test_01_CUDA_SFAD_SFAD_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HDIV_TET_In_FEM_test_01_CUDA_SLFAD_DFAD_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HDIV_TET_In_FEM_test_01_CUDA_SLFAD_DOUBLE_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HDIV_TET_In_FEM_test_01_Serial_DFAD_DFAD_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HDIV_TET_In_FEM_test_01_Serial_DOUBLE_DOUBLE_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HDIV_TET_In_FEM_test_01_Serial_SFAD_SFAD_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HDIV_TET_In_FEM_test_01_Serial_SLFAD_DFAD_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HDIV_TET_In_FEM_test_01_Serial_SLFAD_DOUBLE_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HGRAD_TRI_Cn_FEM_test_01_CUDA_DFAD_DFAD_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HGRAD_TRI_Cn_FEM_test_01_CUDA_DOUBLE_DOUBLE_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HGRAD_TRI_Cn_FEM_test_01_CUDA_SFAD_SFAD_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HGRAD_TRI_Cn_FEM_test_01_CUDA_SLFAD_DFAD_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HGRAD_TRI_Cn_FEM_test_01_CUDA_SLFAD_DOUBLE_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HGRAD_TRI_Cn_FEM_test_01_Serial_DFAD_DFAD_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HGRAD_TRI_Cn_FEM_test_01_Serial_DOUBLE_DOUBLE_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HGRAD_TRI_Cn_FEM_test_01_Serial_SFAD_SFAD_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HGRAD_TRI_Cn_FEM_test_01_Serial_SLFAD_DFAD_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HGRAD_TRI_Cn_FEM_test_01_Serial_SLFAD_DOUBLE_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HVOL_TRI_Cn_FEM_test_01_CUDA_DFAD_DFAD_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HVOL_TRI_Cn_FEM_test_01_CUDA_DOUBLE_DOUBLE_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HVOL_TRI_Cn_FEM_test_01_CUDA_SFAD_SFAD_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HVOL_TRI_Cn_FEM_test_01_CUDA_SLFAD_DFAD_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HVOL_TRI_Cn_FEM_test_01_CUDA_SLFAD_DOUBLE_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HVOL_TRI_Cn_FEM_test_01_Serial_DFAD_DFAD_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HVOL_TRI_Cn_FEM_test_01_Serial_DOUBLE_DOUBLE_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HVOL_TRI_Cn_FEM_test_01_Serial_SFAD_SFAD_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HVOL_TRI_Cn_FEM_test_01_Serial_SLFAD_DFAD_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HVOL_TRI_Cn_FEM_test_01_Serial_SLFAD_DOUBLE_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_MonolithicExecutable_Intrepid2_Tests_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Orientation_test_orientation_HEX_Serial_DOUBLE_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Orientation_test_orientation_HEX_newBasis_Serial_DOUBLE_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Orientation_test_orientation_TET_Serial_DOUBLE_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Projection_test_DeRham_commutativity_TET_CUDA_DOUBLE_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Projection_test_DeRham_commutativity_TET_Serial_DOUBLE_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Projection_test_convergence_TET_CUDA_DOUBLE_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Projection_test_convergence_TET_Serial_DOUBLE_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Projection_test_interpolation_projection_HEX_CUDA_DOUBLE_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Projection_test_interpolation_projection_HEX_Serial_DOUBLE_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Projection_test_interpolation_projection_TET_CUDA_DOUBLE_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Projection_test_interpolation_projection_TET_Serial_DOUBLE_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid_test_Discretization_Basis_HCURL_HEX_In_FEM_Test_02_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid_test_Discretization_Basis_HCURL_TET_In_FEM_Test_02_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid_test_Discretization_Basis_HDIV_HEX_In_FEM_Test_02_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid_test_Discretization_Basis_HDIV_QUAD_In_FEM_Test_02_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid_test_Discretization_Basis_HDIV_TET_In_FEM_Test_02_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid_test_Discretization_Basis_HDIV_TRI_In_FEM_Test_02_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid_test_Discretization_Basis_HGRAD_HEX_Cn_FEM_Test_02_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid_test_Discretization_Basis_HGRAD_LINE_Hermite_FEM_Test_01_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid_test_Discretization_Basis_HGRAD_LINE_Hermite_FEM_Test_02_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid_test_Discretization_Basis_HGRAD_TET_Cn_FEM_Test_02_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid_test_Discretization_Basis_HGRAD_TRI_Cn_FEM_ORTH_Test_02_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid_test_Discretization_Basis_HGRAD_TRI_Cn_FEM_Test_01_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid_test_Discretization_Basis_HGRAD_TRI_Cn_FEM_Test_02_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var KokkosKernels_blas_serial_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var MiniTensor_test_Test_01_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var MiniTensor_test_Test_02_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var MueLu_Maxwell3D-Tpetra_2_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var MueLu_ParameterListInterpreterTpetra_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var MueLu_ReitzingerPFactory_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var MueLu_UnitTestsIntrepid2Tpetra_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-4_DISABLE BOOL : ON
+opt-set-cmake-var PanzerAdaptersSTK_MixedCurlLaplacianExample-ConvTest-Tri-Order-1_DISABLE BOOL : ON
+opt-set-cmake-var PanzerAdaptersSTK_MixedPoissonExample-ConvTest-Hex-Order-3_DISABLE BOOL : ON
+opt-set-cmake-var PanzerAdaptersSTK_PoissonInterfaceExample_3d_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var PanzerAdaptersSTK_main_driver_energy-ss-blocked-tp_DISABLE BOOL : ON
+opt-set-cmake-var PanzerDofMgr_Test_FE_Assembly_HEX_MPI_2_DISABLE BOOL : ON
+opt-set-cmake-var PanzerMiniEM_MiniEM-BlockPrec_Augmentation_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var PanzerMiniEM_MiniEM-BlockPrec_RefMaxwell_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var Piro_AnalysisDriverTpetra_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var Piro_ThyraSolverTpetra_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var ROL_example_PDE-OPT_0ld_adv-diff-react_example_01_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var ROL_example_PDE-OPT_0ld_adv-diff-react_example_02_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var ROL_example_PDE-OPT_0ld_poisson_example_01_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var ROL_example_PDE-OPT_0ld_stefan-boltzmann_example_03_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var ROL_example_PDE-OPT_navier-stokes_example_01_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var ROL_example_PDE-OPT_navier-stokes_example_02_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var ROL_example_PDE-OPT_nonlinear-elliptic_example_01_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var ROL_example_PDE-OPT_nonlinear-elliptic_example_02_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var ROL_example_PDE-OPT_obstacle_example_01_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var ROL_example_PDE-OPT_poisson-boltzmann_example_01_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var ROL_example_PDE-OPT_topo-opt_poisson_example_01_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var ROL_example_poisson-inversion_example_01_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var ROL_test_elementwise_TpetraMultiVector_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var ROL_test_function_sketching_Interface_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var SEACASIoss_exodus32_to_exodus32_DISABLE BOOL : ON
+opt-set-cmake-var SEACASIoss_exodus_fpp_serialize_DISABLE BOOL : ON
+opt-set-cmake-var Stratimikos_test_amesos_thyra_driver_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Stratimikos_test_single_amesos2_tpetra_solver_driver_KLU2_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Teko_testdriver_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var TeuchosNumerics_BLAS_test_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var ThyraTpetraAdapters_Simple2DTpetraModelEvaluatorUnitTests_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var ThyraTpetraAdapters_TpetraThyraWrappersUnitTests_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var ThyraTpetraAdapters_TpetraThyraWrappersUnitTests_serial_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var TpetraTSQR_FullTsqr_Accuracy_5000rows_100cols_Sequential_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var TrilinosCouplings_Example_Maxwell_MueLu_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var TrilinosCouplings_Example_Maxwell_MueLu_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var Zoltan2_fix4785_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var Pliris_vector_random_MPI_3_DISABLE BOOL : ON
+opt-set-cmake-var Pliris_vector_random_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Projection_test_DeRham_commutativity_HEX_CUDA_DOUBLE_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Projection_test_DeRham_commutativity_QUAD_CUDA_DOUBLE_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Projection_test_DeRham_commutativity_TRI_CUDA_DOUBLE_MPI_1_DISABLE BOOL : ON
 
 [WEAVER_COMMON_CUDA_10.1.105]
 # Not a SEMS machine, but we can overwrite SEMS-specific configuration
@@ -2285,9 +2285,9 @@ use RHEL7_TEST_DISABLES|INTEL
 
 # Per Jim's and Henry's request in our 4-27-22 stand-up, disable these zoltan tests.
 # On 4-20-22, these tests started failing in intel-17. See https://github.com/trilinos/Trilinos/pull/10464#issuecomment-1111308760.
-opt-set-cmake-var Zoltan_ch_7944_parmetis_parallel_DISABLE   BOOL FORCE : ON
-opt-set-cmake-var Zoltan_ch_simple_parmetis_parallel_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Zoltan_ch_simple_scotch_parallel_DISABLE   BOOL FORCE : ON
+opt-set-cmake-var Zoltan_ch_7944_parmetis_parallel_DISABLE BOOL : ON
+opt-set-cmake-var Zoltan_ch_simple_parmetis_parallel_DISABLE BOOL : ON
+opt-set-cmake-var Zoltan_ch_simple_scotch_parallel_DISABLE BOOL : ON
 
 use RHEL7_POST
 
@@ -2325,14 +2325,14 @@ use RHEL7_TEST_DISABLES|INTEL
 
 # Additional intel-19 test disables
 opt-set-cmake-var Phalanx_dynamic_data_layout_MPI_1_DISABLE BOOL : ON
-opt-set-cmake-var Zoltan2_Partitioning1_EWeights_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Zoltan2_Partitioning1_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Zoltan2_Partitioning1_OneProc_EWeights_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Zoltan2_Partitioning1_OneProc_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Zoltan2_Partitioning1_OneProc_VWeights_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Zoltan2_Partitioning1_VWeights_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Zoltan2_pamgenMeshAdapterTest_scotch_MPI_4_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Zoltan2_scotch_example_MPI_4_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Zoltan2_Partitioning1_EWeights_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var Zoltan2_Partitioning1_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var Zoltan2_Partitioning1_OneProc_EWeights_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var Zoltan2_Partitioning1_OneProc_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var Zoltan2_Partitioning1_OneProc_VWeights_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var Zoltan2_Partitioning1_VWeights_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var Zoltan2_pamgenMeshAdapterTest_scotch_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var Zoltan2_scotch_example_MPI_4_DISABLE BOOL : ON
 
 use RHEL7_POST
 


### PR DESCRIPTION
CC: @trilinos/tpetra

### Internal Issues

* [TRILINOSHD-168](https://sems-atlassian-son.sandia.gov/jira/servicedesk/customer/portal/7/TRILINOSHD-168)

### Description

This PR disables the randomly failing tests `TpetraTSQR_SequentialTsqr_[non]contiguousCacheBlocks_MPI_1` that is taking out all kinds of PR iterations (see #10847).  The PR also removes 'FORCE' from all test disables (see #10870).

### How was this tested?

Using the scripts:

**load-env-and-cmake-frag-file.sh:**
```
export TRILINOS_DIR=/fgs/rabartl/Trilinos.base/Trilinos
FULL_BUILD_NAME=rhel7_sems-cuda-11.4.2-sems-gnu-10.1.0-sems-openmpi-4.0.5_release_static_Volta70_no-asan_complex_no-fpic_mpi_pt_no-rdc_no-uvm_deprecated-on_no-package-enables

if [[ -e GenConfigSettings.cmake ]] ; then
  echo "Remvoing existing file GenConfigSettings.cmake ..."
  rm GenConfigSettings.cmake
fi

export WORKSPACE=$TRILINOS_DIR/..

source $TRILINOS_DIR/packages/framework/GenConfig/gen-config.sh \
--cmake-fragment GenConfigSettings.cmake \
$FULL_BUILD_NAME \
--force \
$TRILINOS_DIR

unset FULL_BUILD_NAME
unset WORKSPACE

# NOTE Above, it is an undocumented requirment that the env vars TRILINOS_DIR
# and WORKSPACE be set!
```

and:

**do-configure:**
```
if [[ -e CMakeCache.txt ]] ; then
  echo "Removing CMakeCache.txt ..."
  rm CMakeCache.txt
fi
if [[ -d CMakeFiles ]] ; then
  echo "Removing CMakeFiles ..."
  rm -r CMakeFiles
fi
cmake \
-G Ninja \
-C GenConfigSettings.cmake \
-D Trilinos_ENABLE_ALL_FORWARD_DEP_PACKAGES=OFF \
-D Trilinos_ENABLE_TESTS=ON \
-D Trilinos_TRACE_ADD_TEST=ON \
"$@" \
$TRILINOS_DIR
```

I configured on 'ascicgpu17' with:

```
$ ssh ascicgpu17

$ cd /fgs/rabartl/Trilinos.base/BUILDS/PR/rhel7_sems-cuda-11.4.2/

$ . load-env-and-cmake-frag-file.sh

$ time ./do-configure -DTrilinos_ENABLE_Tpetra=ON &> configure.out

real    0m55.633s
user    0m22.293s
sys     0m19.367s
```

and the configure output showed:

```
$ grep TpetraTSQR_SequentialTsqr_ configure.out 
-- TpetraTSQR_SequentialTsqr_contiguousCacheBlocks_MPI_1: NOT added test because TpetraTSQR_SequentialTsqr_contiguousCacheBlocks_MPI_1_DISABLE='ON'!
-- TpetraTSQR_SequentialTsqr_noncontiguousCacheBlocks_MPI_1: NOT added test because TpetraTSQR_SequentialTsqr_noncontiguousCacheBlocks_MPI_1_DISABLE='ON'!
```
