### PR TITLE
Disable pseudo package ShyLU in ATS-2 builds (#10865)

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -939,6 +939,7 @@ opt-set-cmake-var Trilinos_ENABLE_STKTransfer BOOL FORCE : ON
 opt-set-cmake-var Trilinos_ENABLE_STKUnit_tests BOOL FORCE : ON
 opt-set-cmake-var Trilinos_ENABLE_STKUtil BOOL FORCE : ON
 opt-set-cmake-var Trilinos_ENABLE_ShyLU_NodeTacho BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_ShyLU BOOL FORCE : OFF
 opt-set-cmake-var Trilinos_ENABLE_Xpetra BOOL FORCE :
 opt-set-cmake-var Trilinos_ENABLE_Zoltan2 BOOL FORCE :
 opt-set-cmake-var Trilinos_ENABLE_Zoltan2Core BOOL FORCE :


### PR DESCRIPTION
Addresses #10865 

See commit log for details

### How was this tested?

Using the scripts:

**load-env-and-cmake-frag-file.sh:**
```
export TRILINOS_DIR=/fgs/rabartl/Trilinos.base/Trilinos
FULL_BUILD_NAME=rhel7_sems-cuda-11.4.2-sems-gnu-10.1.0-sems-openmpi-4.0.5_release_static_Volta70_no-asan_complex_no-fpic_mpi_pt_no-rdc_no-uvm_deprecated-on_no-package-enables

if [[ -e GenConfigSettings.cmake ]] ; then
  echo "Remvoing existing file GenConfigSettings.cmake ..."
  rm GenConfigSettings.cmake
fi

export WORKSPACE=$TRILINOS_DIR/..

source $TRILINOS_DIR/packages/framework/GenConfig/gen-config.sh \
--cmake-fragment GenConfigSettings.cmake \
$FULL_BUILD_NAME \
--force \
$TRILINOS_DIR

unset FULL_BUILD_NAME
unset WORKSPACE

# NOTE Above, it is an undocumented requirment that the env vars TRILINOS_DIR
# and WORKSPACE be set!
```

and:

**do-configure:**
```
if [[ -e CMakeCache.txt ]] ; then
  echo "Removing CMakeCache.txt ..."
  rm CMakeCache.txt
fi
if [[ -d CMakeFiles ]] ; then
  echo "Removing CMakeFiles ..."
  rm -r CMakeFiles
fi
cmake \
-G Ninja \
-C GenConfigSettings.cmake \
-D Trilinos_ENABLE_ALL_FORWARD_DEP_PACKAGES=OFF \
-D Trilinos_ENABLE_TESTS=ON \
-D Trilinos_TRACE_ADD_TEST=ON \
"$@" \
$TRILINOS_DIR
```

I configured on 'ascicgpu17' with:

```
$ ssh ascicgpu17

$ cd /fgs/rabartl/Trilinos.base/BUILDS/PR/rhel7_sems-cuda-11.4.2/

$ . load-env-and-cmake-frag-file.sh

$ time ./do-configure -DTrilinos_ENABLE_KokkosKernels=ON -DTrilinos_ENABLE_ALL_FORWARD_DEP_PACKAGES=ON \
  &> configure.out

real    1m34.260s
user    0m37.558s
sys     0m30.927s
```

The configure output shows:

* `Final set of non-enabled packages:  ... ShyLU_DD ShyLU  ... 21`

* `Final set of non-enabled SE packages:  ... ShyLU_DDFROSch ShyLU_DDCore ShyLU_DDCommon ShyLU_DD ShyLU ... 55`

With the disable of the ShyLU package, the error reported in #10865) should be fixed.
 