### PR TITLE
Add developer friendly script for reproducing GenConfig builds (#10867)

### DIFF
--- a/packages/framework/load-gen-config-env.sh
+++ b/packages/framework/load-gen-config-env.sh
@@ -1,0 +1,81 @@
+#
+# Source this script to load a GenConfig env and generate the CMake fragment file
+#
+# Usage:
+#
+#   cd <any-build-dir>/
+#
+#   source <trilinosDir>/packages/framework/load-gen-config-env.sh \
+#     <full-build-name>
+#
+# where:
+#
+#   <full-build-name>: Full build name taken off a Trilinos PR comment or CDash
+#                      (minus the PR prefix 'PR-<prnum>-test-' and the Jenkins build
+#                      ID suffix '-<jobid>' at the end)
+#
+# This has the following effect:
+#
+#   * Runs a new bash shell
+#   * Loads the correct env matching (modules and env vars)
+#   * Writes a cmake fragment file GenConfigSettings.cmake
+#   * Sets the env var TRILINOS_DIR and any other needed vars
+#
+# Once in the new shell, just (re)configure and (re)build with:
+#
+#   rm -rf CMake*
+#
+#   cmake -C GenConfigSettings.cmake \
+#     -D Trilinos_ENABLE_ALL_FORWARD_DEP_PACKAGES=OFF \
+#     -D Trilinos_ENABLE_TESTS=ON \
+#     -D Trilinos_ENABLE_<pkg1>=ON \
+#     [other options] \
+#     $TRILINOS_DIR
+#
+#   make
+#
+# When finished building, running tests, etc., exist the new shell by typing
+# 'exit[RETURN]'.
+#
+
+# Assert this script is sourced, not run!
+if [ "${BASH_SOURCE[0]}" == "${0}" ] ; then
+  echo "This script '${0}' is being called.  Instead, it must be sourced!"
+  exit 1
+fi
+
+# Get the base dir for the sourced script
+SCRIPT_BASE_DIR=$(readlink -f \
+  $(echo $BASH_SOURCE | sed "s/\(.*\)\/.*\.sh/\1/g"))
+
+# Get the build name
+if [ "$1" == "" ] ; then
+  echo "Error, the first argument must be the build name!"
+  return
+fi
+FULL_BUILD_NAME=$1
+
+export TRILINOS_DIR=$(realpath $SCRIPT_BASE_DIR/../..)
+
+export WORKSPACE=$(realpath $TRILINOS_DIR/..)  # Needed for some platforms
+
+if [[ -e GenConfigSettings.cmake ]] ; then
+  echo "Removing existing file GenConfigSettings.cmake ..."
+  rm GenConfigSettings.cmake
+fi
+
+# Run new shell, set env, generate fragment file
+source $TRILINOS_DIR/packages/framework/GenConfig/gen-config.sh \
+--cmake-fragment GenConfigSettings.cmake \
+$FULL_BUILD_NAME \
+--force \
+$TRILINOS_DIR
+
+# NOTE: The above command will not complete until the user types 'exit' after
+# doing the configure, build, testing, etc.
+
+unset FULL_BUILD_NAME
+unset WORKSPACE
+
+# NOTE Above, it is an undocumented requirement that the env vars TRILINOS_DIR
+# and WORKSPACE be set.

--- a/packages/framework/load-gen-config-env.sh
+++ b/packages/framework/load-gen-config-env.sh
@@ -6,7 +6,7 @@
 #   cd <any-build-dir>/
 #
 #   source <trilinosDir>/packages/framework/load-gen-config-env.sh \
-#     <full-build-name>
+#     <full-build-name> [--ci-mode]
 #
 # where:
 #
@@ -16,7 +16,7 @@
 #
 # This has the following effect:
 #
-#   * Runs a new bash shell
+#   * Runs a new bash shell (unless pasing in --ci-mode)
 #   * Loads the correct env matching (modules and env vars)
 #   * Writes a cmake fragment file GenConfigSettings.cmake
 #   * Sets the env var TRILINOS_DIR and any other needed vars
@@ -35,7 +35,7 @@
 #   make
 #
 # When finished building, running tests, etc., exist the new shell by typing
-# 'exit[RETURN]'.
+# 'exit[RETURN]' (unless pasing in --ci-mode).
 #
 
 # Assert this script is sourced, not run!
@@ -53,7 +53,7 @@ if [ "$1" == "" ] ; then
   echo "Error, the first argument must be the build name!"
   return
 fi
-FULL_BUILD_NAME=$1
+FULL_BUILD_NAME=$1 ; shift
 
 export TRILINOS_DIR=$(realpath $SCRIPT_BASE_DIR/../..)
 
@@ -69,10 +69,12 @@ source $TRILINOS_DIR/packages/framework/GenConfig/gen-config.sh \
 --cmake-fragment GenConfigSettings.cmake \
 $FULL_BUILD_NAME \
 --force \
+"$@" \
 $TRILINOS_DIR
 
 # NOTE: The above command will not complete until the user types 'exit' after
-# doing the configure, build, testing, etc.
+# doing the configure, build, testing, etc. (unless --ci-mode is passed
+# through).
 
 unset FULL_BUILD_NAME
 unset WORKSPACE

--- a/packages/framework/load-gen-config-env.sh
+++ b/packages/framework/load-gen-config-env.sh
@@ -16,7 +16,7 @@
 #
 # This has the following effect:
 #
-#   * Runs a new bash shell (unless pasing in --ci-mode)
+#   * Runs a new bash shell (unless passing in --ci-mode)
 #   * Loads the correct env matching (modules and env vars)
 #   * Writes a cmake fragment file GenConfigSettings.cmake
 #   * Sets the env var TRILINOS_DIR and any other needed vars
@@ -35,7 +35,7 @@
 #   make
 #
 # When finished building, running tests, etc., exist the new shell by typing
-# 'exit[RETURN]' (unless pasing in --ci-mode).
+# 'exit[RETURN]' (unless passing in --ci-mode).
 #
 
 # Assert this script is sourced, not run!


### PR DESCRIPTION
CC: @trilinos/framework, @e10harvey, @rppawlo, @jhux2, @csiefer2, @srbdev 

### Internal Issues

* [TRILINOSHD-180](https://sems-atlassian-son.sandia.gov/jira/servicedesk/customer/portal/7/TRILINOSHD-180)

### Description

As per #10867, this provides as small wrapper script that I have developed to make it easier and more robust to reproduce Trilinos PR builds using the new GenConfig system.  Script is super easy to use (as documented at the top of the script):

```
$ cd <any-build-dir>/

$ source <trilinosDir>/packages/framework/load-gen-config-env.sh \
    <full-build-name> [--ci-mode]

$ rm -rf CMake*

$ cmake -C GenConfigSettings.cmake \
    -D Trilinos_ENABLE_ALL_FORWARD_DEP_PACKAGES=OFF \
    -D Trilinos_ENABLE_TESTS=ON \
    -D Trilinos_ENABLE_<pkg1>=ON \
    [other options] \
    $TRILINOS_DIR

$  make
```

where `--ci-mode` needs to be passed in if running this in a driver script.  Easy as pie.

This script solves a number of problems:

* Does not require you to have to pass in the Trilinos source dir again since the script knows it is in Trilinos.
* Sets the `TRILINOS_DIR` env var (which needs to be set on some platforms but is not documented that it is needed)
* Sets the `WORKSPACE` env var (which needs to be set at least for the cuda-11 builds but is not documented that it is needed).
* Add the `--force` option which seems to be needed when running on various machines.

Without these things, you can't reproduce PR builds on the various supported platforms (unless you are running in a Trilinos Framework Jenkins build).

### How was this tested?

I tested this through a throw-away-integration-test-branch [10807-kokkos-kernels-cublas-titb](https://github.com/bartlettroscoe/Trilinos/tree/10807-kokkos-kernels-cublas-titb) as part of trying to reproduce some build errors as documented in https://github.com/trilinos/Trilinos/issues/10836#issuecomment-1216017031.
