### PR TITLE
Tpetra: Remove informational output from passing tests

### DIFF
--- a/packages/tpetra/core/test/MultiVector/Bug7745.cpp
+++ b/packages/tpetra/core/test/MultiVector/Bug7745.cpp
@@ -81,7 +81,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7745, DefaultToDefault, Scalar,LO,GO,Node)
   Teuchos::RCP<const map_t> defaultMap = 
            rcp(new map_t(nGlobalEntries, 0, comm));
 
-  std::cout << me << " DEFAULT MAP" << std::endl;
   defaultMap->describe(foo, Teuchos::VERB_EXTREME);
 
   // Create vectors; see what the result is with CombineMode=ADD
@@ -97,7 +96,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7745, DefaultToDefault, Scalar,LO,GO,Node)
   Tpetra::Export<LO,GO,Node> defaultToDefault(defaultMap, defaultMap);
   defaultVecTgt.doExport(defaultVecSrc, defaultToDefault, Tpetra::ADD_ASSIGN);
 
-  std::cout << me << " DEFAULT TO DEFAULT " << std::endl;
   defaultVecTgt.describe(foo, Teuchos::VERB_EXTREME);
 
   // Check result; all vector entries should be tgtScalar + srcScalar
@@ -143,7 +141,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7745, CyclicToDefault, Scalar,LO,GO,Node)
   Teuchos::RCP<const map_t> defaultMap = 
            rcp(new map_t(nGlobalEntries, 0, comm));
 
-  std::cout << me << " DEFAULT MAP" << std::endl;
   defaultMap->describe(foo, Teuchos::VERB_EXTREME);
 
   // One-to-one cyclic map:  deal out entries like cards
@@ -160,7 +157,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7745, CyclicToDefault, Scalar,LO,GO,Node)
   Teuchos::RCP<const map_t> cyclicMap = 
            rcp(new map_t(dummy, myEntries(0,nMyEntries), 0, comm));
 
-  std::cout << me << " CYCLIC MAP" << std::endl;
   cyclicMap->describe(foo, Teuchos::VERB_EXTREME);
 
   // Create vectors; see what the result is with CombineMode=ADD
@@ -176,7 +172,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7745, CyclicToDefault, Scalar,LO,GO,Node)
   Tpetra::Export<LO,GO,Node> cyclicToDefault(cyclicMap, defaultMap);
   defaultVecTgt.doExport(cyclicVecSrc, cyclicToDefault, Tpetra::ADD_ASSIGN);
 
-  std::cout << me << " CYCLIC TO DEFAULT " << std::endl;
   defaultVecTgt.describe(foo, Teuchos::VERB_EXTREME);
 
   // Check result
@@ -224,7 +219,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7745, OverlapToDefault, Scalar,LO,GO,Node)
     Teuchos::RCP<const map_t> defaultMap = 
              rcp(new map_t(nGlobalEntries, 0, comm));
 
-    std::cout << me << " DEFAULT MAP" << std::endl;
     defaultMap->describe(foo, Teuchos::VERB_EXTREME);
 
     // Overlap map; some entries are stored on two procs
@@ -242,7 +236,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7745, OverlapToDefault, Scalar,LO,GO,Node)
     Teuchos::RCP<const map_t> overlapMap = 
              rcp(new map_t(dummy, myEntries(0,nMyEntries), 0, comm));
   
-    std::cout << me << " OVERLAP MAP" << std::endl;
     overlapMap->describe(foo, Teuchos::VERB_EXTREME);
 
     // Create vectors; see what the result is with CombineMode=ADD
@@ -258,7 +251,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7745, OverlapToDefault, Scalar,LO,GO,Node)
     Tpetra::Export<LO,GO,Node> overlapToDefault(overlapMap, defaultMap);
     defaultVecTgt.doExport(overlapVecSrc, overlapToDefault, Tpetra::ADD_ASSIGN);
 
-    std::cout << me << " OVERLAP TO DEFAULT " << std::endl;
     defaultVecTgt.describe(foo, Teuchos::VERB_EXTREME);
 
     auto data = defaultVecTgt.getLocalViewHost(Tpetra::Access::ReadOnly);
@@ -321,7 +313,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7745, OddEvenToSerial, Scalar,LO,GO,Node)
   Teuchos::RCP<const map_t> oddEvenMap = 
            rcp(new map_t(dummy, myEntries(0,nMyEntries), 0, comm));
 
-  std::cout << me << " ODDEVEN MAP" << std::endl;
   oddEvenMap->describe(foo, Teuchos::VERB_EXTREME);
 
   // Map with all entries on one processor
@@ -331,7 +322,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7745, OddEvenToSerial, Scalar,LO,GO,Node)
   Teuchos::RCP<const map_t> serialMap = 
            rcp(new map_t(dummy, nSerialEntries, 0, comm));
 
-  std::cout << me << " SERIAL MAP" << std::endl;
   serialMap->describe(foo, Teuchos::VERB_EXTREME);
 
   // Create vectors; see what the result is with CombineMode=ADD
@@ -347,7 +337,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7745, OddEvenToSerial, Scalar,LO,GO,Node)
   Tpetra::Export<LO,GO,Node> oddEvenToSerial(oddEvenMap, serialMap);
   serialVecTgt.doExport(oddEvenVecSrc, oddEvenToSerial, Tpetra::ADD_ASSIGN);
 
-  std::cout << me << " ODDEVEN TO SERIAL " << std::endl;
   serialVecTgt.describe(foo, Teuchos::VERB_EXTREME);
 
   // Check result
@@ -399,7 +388,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7745, SupersetToDefault, Scalar,LO,GO,Node)
     Teuchos::RCP<const map_t> defaultMap = 
              rcp(new map_t(nGlobalEntries, 0, comm));
 
-    std::cout << me << " DEFAULT MAP" << std::endl;
     defaultMap->describe(foo, Teuchos::VERB_EXTREME);
 
     // Superset map; some entries are stored on two procs
@@ -417,7 +405,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7745, SupersetToDefault, Scalar,LO,GO,Node)
     Teuchos::RCP<const map_t> supersetMap =
              rcp(new map_t(dummy, myEntries(0,nMyEntries), 0, comm));
   
-    std::cout << me << " SUPERSET MAP" << std::endl;
     supersetMap->describe(foo, Teuchos::VERB_EXTREME);
 
     // Create vectors; see what the result is with CombineMode=ADD
@@ -434,7 +421,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7745, SupersetToDefault, Scalar,LO,GO,Node)
     defaultVecTgt.doExport(supersetVecSrc, supersetToDefault,
                            Tpetra::ADD_ASSIGN);
 
-    std::cout << me << " SUPERSET TO DEFAULT " << std::endl;
     defaultVecTgt.describe(foo, Teuchos::VERB_EXTREME);
 
     auto data = defaultVecTgt.getLocalViewHost(Tpetra::Access::ReadOnly);
@@ -482,7 +468,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7745, NoSamesToDefault, Scalar,LO,GO,Node)
     Teuchos::RCP<const map_t> defaultMap = 
              rcp(new map_t(nGlobalEntries, 0, comm));
 
-    std::cout << me << " DEFAULT MAP" << std::endl;
     defaultMap->describe(foo, Teuchos::VERB_EXTREME);
 
     // Map with no sames or permutes
@@ -497,7 +482,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7745, NoSamesToDefault, Scalar,LO,GO,Node)
     Teuchos::RCP<const map_t> noSamesMap = 
              rcp(new map_t(dummy, myEntries(0,nMyEntries), 0, comm));
   
-    std::cout << me << " NOSAMES MAP" << std::endl;
     noSamesMap->describe(foo, Teuchos::VERB_EXTREME);
 
     // Create vectors; see what the result is with CombineMode=ADD
@@ -513,7 +497,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7745, NoSamesToDefault, Scalar,LO,GO,Node)
     Tpetra::Export<LO,GO,Node> noSamesToDefault(noSamesMap, defaultMap);
     defaultVecTgt.doExport(noSamesVecSrc, noSamesToDefault, Tpetra::ADD_ASSIGN);
 
-    std::cout << me << " NOSAMES TO DEFAULT " << std::endl;
     defaultVecTgt.describe(foo, Teuchos::VERB_EXTREME);
 
     auto data = defaultVecTgt.getLocalViewHost(Tpetra::Access::ReadOnly);

--- a/packages/tpetra/core/test/MultiVector/Bug7745.cpp
+++ b/packages/tpetra/core/test/MultiVector/Bug7745.cpp
@@ -81,8 +81,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7745, DefaultToDefault, Scalar,LO,GO,Node)
   Teuchos::RCP<const map_t> defaultMap = 
            rcp(new map_t(nGlobalEntries, 0, comm));
 
-  defaultMap->describe(foo, Teuchos::VERB_EXTREME);
-
   // Create vectors; see what the result is with CombineMode=ADD
 
   vector_t defaultVecTgt(defaultMap);
@@ -95,8 +93,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7745, DefaultToDefault, Scalar,LO,GO,Node)
 
   Tpetra::Export<LO,GO,Node> defaultToDefault(defaultMap, defaultMap);
   defaultVecTgt.doExport(defaultVecSrc, defaultToDefault, Tpetra::ADD_ASSIGN);
-
-  defaultVecTgt.describe(foo, Teuchos::VERB_EXTREME);
 
   // Check result; all vector entries should be tgtScalar + srcScalar
   auto data = defaultVecTgt.getLocalViewHost(Tpetra::Access::ReadOnly);
@@ -141,8 +137,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7745, CyclicToDefault, Scalar,LO,GO,Node)
   Teuchos::RCP<const map_t> defaultMap = 
            rcp(new map_t(nGlobalEntries, 0, comm));
 
-  defaultMap->describe(foo, Teuchos::VERB_EXTREME);
-
   // One-to-one cyclic map:  deal out entries like cards
 
   int nMyEntries = 0;
@@ -156,23 +150,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7745, CyclicToDefault, Scalar,LO,GO,Node)
           Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid();
   Teuchos::RCP<const map_t> cyclicMap = 
            rcp(new map_t(dummy, myEntries(0,nMyEntries), 0, comm));
-
-  cyclicMap->describe(foo, Teuchos::VERB_EXTREME);
-
-  // Create vectors; see what the result is with CombineMode=ADD
-
-  vector_t defaultVecTgt(defaultMap);
-  defaultVecTgt.putScalar(tgtScalar);
-
-  vector_t cyclicVecSrc(cyclicMap);
-  cyclicVecSrc.putScalar(srcScalar);
-
-  // Export Cyclic-to-default
-
-  Tpetra::Export<LO,GO,Node> cyclicToDefault(cyclicMap, defaultMap);
-  defaultVecTgt.doExport(cyclicVecSrc, cyclicToDefault, Tpetra::ADD_ASSIGN);
-
-  defaultVecTgt.describe(foo, Teuchos::VERB_EXTREME);
 
   // Check result
 
@@ -219,8 +196,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7745, OverlapToDefault, Scalar,LO,GO,Node)
     Teuchos::RCP<const map_t> defaultMap = 
              rcp(new map_t(nGlobalEntries, 0, comm));
 
-    defaultMap->describe(foo, Teuchos::VERB_EXTREME);
-
     // Overlap map; some entries are stored on two procs
     int nMyEntries = 0;
     for (size_t i = 0; i < defaultMap->getLocalNumElements()/2; i++) {
@@ -235,8 +210,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7745, OverlapToDefault, Scalar,LO,GO,Node)
             Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid();
     Teuchos::RCP<const map_t> overlapMap = 
              rcp(new map_t(dummy, myEntries(0,nMyEntries), 0, comm));
-  
-    overlapMap->describe(foo, Teuchos::VERB_EXTREME);
 
     // Create vectors; see what the result is with CombineMode=ADD
 
@@ -250,8 +223,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7745, OverlapToDefault, Scalar,LO,GO,Node)
 
     Tpetra::Export<LO,GO,Node> overlapToDefault(overlapMap, defaultMap);
     defaultVecTgt.doExport(overlapVecSrc, overlapToDefault, Tpetra::ADD_ASSIGN);
-
-    defaultVecTgt.describe(foo, Teuchos::VERB_EXTREME);
 
     auto data = defaultVecTgt.getLocalViewHost(Tpetra::Access::ReadOnly);
     for (size_t i = 0; i < defaultVecTgt.getLocalLength()/2; i++) {
@@ -313,16 +284,12 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7745, OddEvenToSerial, Scalar,LO,GO,Node)
   Teuchos::RCP<const map_t> oddEvenMap = 
            rcp(new map_t(dummy, myEntries(0,nMyEntries), 0, comm));
 
-  oddEvenMap->describe(foo, Teuchos::VERB_EXTREME);
-
   // Map with all entries on one processor
 
   dummy = Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid();
   size_t nSerialEntries = (me == 0 ? nGlobalEntries : 0);
   Teuchos::RCP<const map_t> serialMap = 
            rcp(new map_t(dummy, nSerialEntries, 0, comm));
-
-  serialMap->describe(foo, Teuchos::VERB_EXTREME);
 
   // Create vectors; see what the result is with CombineMode=ADD
 
@@ -336,8 +303,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7745, OddEvenToSerial, Scalar,LO,GO,Node)
 
   Tpetra::Export<LO,GO,Node> oddEvenToSerial(oddEvenMap, serialMap);
   serialVecTgt.doExport(oddEvenVecSrc, oddEvenToSerial, Tpetra::ADD_ASSIGN);
-
-  serialVecTgt.describe(foo, Teuchos::VERB_EXTREME);
 
   // Check result
 
@@ -388,8 +353,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7745, SupersetToDefault, Scalar,LO,GO,Node)
     Teuchos::RCP<const map_t> defaultMap = 
              rcp(new map_t(nGlobalEntries, 0, comm));
 
-    defaultMap->describe(foo, Teuchos::VERB_EXTREME);
-
     // Superset map; some entries are stored on two procs
     int nMyEntries = 0;
     for (size_t i = 0; i < defaultMap->getLocalNumElements(); i++) {
@@ -404,8 +367,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7745, SupersetToDefault, Scalar,LO,GO,Node)
             Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid();
     Teuchos::RCP<const map_t> supersetMap =
              rcp(new map_t(dummy, myEntries(0,nMyEntries), 0, comm));
-  
-    supersetMap->describe(foo, Teuchos::VERB_EXTREME);
 
     // Create vectors; see what the result is with CombineMode=ADD
 
@@ -420,8 +381,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7745, SupersetToDefault, Scalar,LO,GO,Node)
     Tpetra::Export<LO,GO,Node> supersetToDefault(supersetMap, defaultMap);
     defaultVecTgt.doExport(supersetVecSrc, supersetToDefault,
                            Tpetra::ADD_ASSIGN);
-
-    defaultVecTgt.describe(foo, Teuchos::VERB_EXTREME);
 
     auto data = defaultVecTgt.getLocalViewHost(Tpetra::Access::ReadOnly);
     for (size_t i = 0; i < defaultVecTgt.getLocalLength()/2; i++)
@@ -468,8 +427,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7745, NoSamesToDefault, Scalar,LO,GO,Node)
     Teuchos::RCP<const map_t> defaultMap = 
              rcp(new map_t(nGlobalEntries, 0, comm));
 
-    defaultMap->describe(foo, Teuchos::VERB_EXTREME);
-
     // Map with no sames or permutes
     int nMyEntries = 0;
     for (size_t i = 0; i < defaultMap->getLocalNumElements(); i++) {
@@ -481,8 +438,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7745, NoSamesToDefault, Scalar,LO,GO,Node)
             Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid();
     Teuchos::RCP<const map_t> noSamesMap = 
              rcp(new map_t(dummy, myEntries(0,nMyEntries), 0, comm));
-  
-    noSamesMap->describe(foo, Teuchos::VERB_EXTREME);
 
     // Create vectors; see what the result is with CombineMode=ADD
 
@@ -496,8 +451,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7745, NoSamesToDefault, Scalar,LO,GO,Node)
 
     Tpetra::Export<LO,GO,Node> noSamesToDefault(noSamesMap, defaultMap);
     defaultVecTgt.doExport(noSamesVecSrc, noSamesToDefault, Tpetra::ADD_ASSIGN);
-
-    defaultVecTgt.describe(foo, Teuchos::VERB_EXTREME);
 
     auto data = defaultVecTgt.getLocalViewHost(Tpetra::Access::ReadOnly);
     for (size_t i = 0; i < defaultVecTgt.getLocalLength(); i++) {

--- a/packages/tpetra/core/test/MultiVector/Bug7745.cpp
+++ b/packages/tpetra/core/test/MultiVector/Bug7745.cpp
@@ -151,6 +151,19 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug7745, CyclicToDefault, Scalar,LO,GO,Node)
   Teuchos::RCP<const map_t> cyclicMap = 
            rcp(new map_t(dummy, myEntries(0,nMyEntries), 0, comm));
 
+  // Create vectors; see what the result is with CombineMode=ADD
+
+  vector_t defaultVecTgt(defaultMap);
+  defaultVecTgt.putScalar(tgtScalar);
+
+  vector_t cyclicVecSrc(cyclicMap);
+  cyclicVecSrc.putScalar(srcScalar);
+
+  // Export Cyclic-to-default
+
+  Tpetra::Export<LO,GO,Node> cyclicToDefault(cyclicMap, defaultMap);
+  defaultVecTgt.doExport(cyclicVecSrc, cyclicToDefault, Tpetra::ADD_ASSIGN);
+
   // Check result
 
   auto data = defaultVecTgt.getLocalViewHost(Tpetra::Access::ReadOnly);

--- a/packages/tpetra/core/test/MultiVector/MultiVector_LocalViewTests.cpp
+++ b/packages/tpetra/core/test/MultiVector/MultiVector_LocalViewTests.cpp
@@ -88,9 +88,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( MultiVector, TeuchosArray, LO, GO, Scalar , N
       auto dataDevice = defaultVec.getLocalViewDevice(Tpetra::Access::ReadOnly);
     } 
     catch (...) {
-      std::cout << me 
-                << " caught exception trying to get a device view"
-                << " while holding a local view " << std::endl;
       threw = true;
     }
     ierr += (threw == shouldThrow) ? 0 : 1;
@@ -103,9 +100,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( MultiVector, TeuchosArray, LO, GO, Scalar , N
       auto dataDevice = defaultVec.getLocalViewDevice(Tpetra::Access::ReadOnly);
     } 
     catch (...) {
-      std::cout << me 
-                << " caught exception trying to get a device view"
-                << " while holding a local view " << std::endl;
       threw = true;
     }
     ierr += (threw == shouldThrow) ? 0 : 1;
@@ -118,9 +112,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( MultiVector, TeuchosArray, LO, GO, Scalar , N
       auto dataDevice = defaultVec.getLocalViewDevice(Tpetra::Access::ReadOnly);
     } 
     catch (...) {
-      std::cout << me 
-                << " caught exception trying to get a device view"
-                << " while holding a local view " << std::endl;
       threw = true;
     }
     ierr += (threw == shouldThrow) ? 0 : 1;
@@ -133,9 +124,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( MultiVector, TeuchosArray, LO, GO, Scalar , N
       auto dataDevice = defaultVec.getLocalViewDevice(Tpetra::Access::ReadOnly);
     } 
     catch (...) {
-      std::cout << me 
-                << " caught exception trying to get a device view"
-                << " while holding a local view " << std::endl;
       threw = true;
     }
     ierr += (threw == shouldThrow) ? 0 : 1;
@@ -263,7 +251,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( MultiVector, HostDeviceView, LO, GO, Scalar ,
   try {
     auto data_old = defaultVec.getLocalViewDevice(Tpetra::Access::ReadOnly);
   } catch (...) {
-    std::cout << me << " caught exception trying to get a device view while holding a local view" << std::endl;
     threw = true;
   }
 
@@ -307,7 +294,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( MultiVector, DeviceHostView, LO, GO, Scalar ,
   try {
     auto data_old = defaultVec.getLocalViewHost(Tpetra::Access::ReadOnly);
   } catch (...) {
-    std::cout << me << " caught exception trying to get a local view while holding a device view" << std::endl;
     threw = true;
   }
 


### PR DESCRIPTION
@trilinos/tpetra @bartlettroscoe 

## Motivation
Informational output is of limited utility when tests are passing, and can randomly break automated PR testing when it overlaps with and breaks up the "test passed" output.

## Related Issues

* Closes #10885 

## Testing
Update to tests to improve robustness.