### PR TITLE
MueLu: Add ComputeNodesInAggregate for Aggregates_kokkos

### DIFF
--- a/packages/muelu/src/Graph/Containers/MueLu_Aggregates_def.hpp
+++ b/packages/muelu/src/Graph/Containers/MueLu_Aggregates_def.hpp
@@ -191,12 +191,12 @@ namespace MueLu {
     for(LO i=0; i<numNodes; i++) {
       LO aggregate = vertex2AggId[i];
       if(aggregate !=INVALID) {
-	aggNodes[aggCurr[aggregate]] = i;
-	aggCurr[aggregate]++;
+        aggNodes[aggCurr[aggregate]] = i;
+        aggCurr[aggregate]++;
       }
       else {
-	unaggregated[currNumUnaggregated] = i;
-	currNumUnaggregated++;
+        unaggregated[currNumUnaggregated] = i;
+        currNumUnaggregated++;
       }
     }
     unaggregated.resize(currNumUnaggregated);

--- a/packages/muelu/src/Graph/Containers/MueLu_Aggregates_kokkos_decl.hpp
+++ b/packages/muelu/src/Graph/Containers/MueLu_Aggregates_kokkos_decl.hpp
@@ -116,6 +116,7 @@ namespace MueLu {
     using node_type           = Kokkos::Compat::KokkosDeviceWrapperNode<DeviceType>;
     using device_type         = DeviceType;
     using range_type          = Kokkos::RangePolicy<local_ordinal_type, execution_space>;
+    using LO_view             = Kokkos::View<local_ordinal_type*, device_type>;
 
     using aggregates_sizes_type = Kokkos::View<LocalOrdinal*, device_type>;
 
@@ -258,6 +259,12 @@ namespace MueLu {
     typename aggregates_sizes_type::const_type ComputeAggregateSizes(bool forceRecompute = false) const;
 
     local_graph_type GetGraph() const;
+
+    /*! @brief Generates a compressed list of nodes in each aggregate, where
+      the entries in aggNodes[aggPtr[i]] up to aggNodes[aggPtr[i+1]-1] contain the nodes in aggregate i.
+      unaggregated contains the list of nodes which are, for whatever reason, not aggregated (e.g. Dirichlet)
+     */
+    void ComputeNodesInAggregate(LO_view & aggPtr, LO_view & aggNodes, LO_view & unaggregated) const;
 
     //! @name Overridden from Teuchos::Describable
     //@{

--- a/packages/muelu/test/unit_tests_kokkos/Aggregates_kokkos.cpp
+++ b/packages/muelu/test/unit_tests_kokkos/Aggregates_kokkos.cpp
@@ -614,15 +614,15 @@ namespace MueLuTests {
     // Check ComputeNodesInAggregate
     typename Aggregates_kokkos::LO_view aggPtr, aggNodes, unaggregated;
     aggregates->ComputeNodesInAggregate(aggPtr, aggNodes, unaggregated);
-    TEST_EQUALITY(aggPtr.extent(0), numAggs+1);
-    // TEST_EQUALITY(unaggregated.extent(0), 0); // 1 unaggregated node in the MPI_4 case
+    TEST_EQUALITY(aggPtr.extent_int(0), numAggs+1);
+    // TEST_EQUALITY(unaggregated.extent_int(0), 0); // 1 unaggregated node in the MPI_4 case
     
     // test aggPtr(i)+aggSizes(i)=aggPtr(i+1)
     typename Aggregates_kokkos::LO_view::HostMirror aggPtr_h = Kokkos::create_mirror_view(aggPtr);
     typename Aggregates_kokkos::aggregates_sizes_type::HostMirror aggSizes_h = Kokkos::create_mirror_view(aggSizes);
     Kokkos::deep_copy(aggPtr_h, aggPtr);
     Kokkos::deep_copy(aggSizes_h, aggSizes);
-    for(LO i=0; i<aggSizes_h.extent(0); ++i)
+    for(LO i=0; i<aggSizes_h.extent_int(0); ++i)
       TEST_EQUALITY(aggPtr_h(i)+aggSizes_h(i), aggPtr_h(i+1));
 
   } //UncoupledPhase3

--- a/packages/muelu/test/unit_tests_kokkos/Aggregates_kokkos.cpp
+++ b/packages/muelu/test/unit_tests_kokkos/Aggregates_kokkos.cpp
@@ -611,6 +611,20 @@ namespace MueLuTests {
                             }, numBadAggregates);
     TEST_EQUALITY(numBadAggregates, 0);
 
+    // Check ComputeNodesInAggregate
+    typename Aggregates_kokkos::LO_view aggPtr, aggNodes, unaggregated;
+    aggregates->ComputeNodesInAggregate(aggPtr, aggNodes, unaggregated);
+    TEST_EQUALITY(aggPtr.extent(0), numAggs+1);
+    // TEST_EQUALITY(unaggregated.extent(0), 0); // 1 unaggregated node in the MPI_4 case
+    
+    // test aggPtr(i)+aggSizes(i)=aggPtr(i+1)
+    typename Aggregates_kokkos::LO_view::HostMirror aggPtr_h = Kokkos::create_mirror_view(aggPtr);
+    typename Aggregates_kokkos::aggregates_sizes_type::HostMirror aggSizes_h = Kokkos::create_mirror_view(aggSizes);
+    Kokkos::deep_copy(aggPtr_h, aggPtr);
+    Kokkos::deep_copy(aggSizes_h, aggSizes);
+    for(LO i=0; i<aggSizes_h.extent(0); ++i)
+      TEST_EQUALITY(aggPtr_h(i)+aggSizes_h(i), aggPtr_h(i+1));
+
   } //UncoupledPhase3
 
   TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Aggregates_kokkos, AllowDroppingToCreateAdditionalDirichletRows, Scalar, LocalOrdinal, GlobalOrdinal, Node)


### PR DESCRIPTION
@trilinos/muelu 

## Motivation
This addresses an inconsistency between `Aggregates` and `Aggregates_kokkos`. As an added bonus, this enables matrix-free restriction grid transfers. With how non-parallel the algorithm is, I think I can see why nobody did this before 🙂 

I have a couple bits of tidying to do before the final test, but I figured I'd open this now anyway. Mainly I'm really trying to figure out if the main couple loops can be turned into some more parallel-friendly algorithm. Otherwise I'll just copy everything to host and do the serial thing.