### PR TITLE
Amesos2-IR & ShyLU-Basker fixes

### DIFF
--- a/packages/amesos2/src/Amesos2_Control.cpp
+++ b/packages/amesos2/src/Amesos2_Control.cpp
@@ -97,7 +97,7 @@ void Control::setControlParameters(
   if( parameterList->isType<bool>("Iterative refinement") ){
     useIterRefine_ = parameterList->get<bool>("Iterative refinement");
   }
-  if( parameterList->isType<bool>("Number of iterative refinements") ){
+  if( parameterList->isType<int>("Number of iterative refinements") ){
     maxNumIterRefines_ = parameterList->get<int>("Number of iterative refinements");
   }
   if( parameterList->isType<bool>("Verboes for iterative refinement") ){

--- a/packages/shylu/shylu_node/basker/src/shylubasker_def.hpp
+++ b/packages/shylu/shylu_node/basker/src/shylubasker_def.hpp
@@ -925,10 +925,11 @@ namespace BaskerNS
           }
         }
 
-        #ifdef AMD_ON_D
+        #define SHYLU_BASKER_AMD_ON_D
+        #ifdef SHYLU_BASKER_AMD_ON_D
         // --------------------------------------------
         // reset the small D blocks
-        if (btf_top_tabs_offset > 0) {
+        if (btf_top_tabs_offset  > 0) {
           Int d_last = btf_top_tabs_offset;
           Int ncol = btf_tabs(d_last);
 
@@ -942,13 +943,15 @@ namespace BaskerNS
             permute_row(BTF_E, order_blk_amd_d);
           }
 
-          // revert BLK_MWM ordering
-          auto order_blk_mwm_d = Kokkos::subview(order_blk_mwm_inv, 
-                                                 range_type (0, ncol));
-          permute_row(BTF_D, order_blk_mwm_d);
-          if (BTF_E.ncol > 0) {
-            // Apply MWM perm to cols
-            permute_row(BTF_E, order_blk_mwm_d);
+          if (Options.blk_matching != 0) {
+            // revert BLK_MWM ordering
+            auto order_blk_mwm_d = Kokkos::subview(order_blk_mwm_inv, 
+                                                   range_type (0, ncol));
+            permute_row(BTF_D, order_blk_mwm_d);
+            if (BTF_E.ncol > 0) {
+              // Apply MWM perm to cols
+              permute_row(BTF_E, order_blk_mwm_d);
+            }
           }
         }
         #endif
@@ -1100,7 +1103,7 @@ namespace BaskerNS
         numeric_col_iperm_array(i) = i;
       }
 
-      #ifdef AMD_ON_D
+      #ifdef SHYLU_BASKER_AMD_ON_D
       if (btf_top_tabs_offset > 0) {
         Kokkos::Timer mwm_amd_perm_timer;
         Int d_last = btf_top_tabs_offset;
@@ -1116,7 +1119,7 @@ namespace BaskerNS
         }
 
         // ----------------------------------------------------------------------------------------------
-        // recompute MWM and AMD on each block of C
+        // recompute MWM and AMD on each block of D
         INT_1DARRAY blk_nnz;
         INT_1DARRAY blk_work;
         btf_blk_mwm_amd(0, d_last, BTF_D,


### PR DESCRIPTION

@trilinos/amesos2, @trilinos/shylu 

## Motivation
- Fixes the iterative refinements in Amesos2
- Improve performance of ShyLU-Basker with MWM (by applying AMD ordering on block D)


## Testing
Tested using test matrices from Xyce