### PR TITLE
Testing on Geminga: Do not disable Kokkos in Epetra build

### DIFF
--- a/cmake/ctest/drivers/geminga/ctest_linux_nightly_serial_debug_muelu_epetra_geminga.cmake
+++ b/cmake/ctest/drivers/geminga/ctest_linux_nightly_serial_debug_muelu_epetra_geminga.cmake
@@ -76,7 +76,6 @@ SET(Trilinos_PACKAGES MueLu Xpetra)
 
 SET(EXTRA_CONFIGURE_OPTIONS
   "-DTrilinos_ENABLE_DEPENDENCY_UNIT_TESTS=OFF"
-  "-DTrilinos_ENABLE_Kokkos=OFF"
   "-DTrilinos_ENABLE_Tpetra=OFF"
   "-DTrilinos_ENABLE_ML=OFF"
   "-DTPL_ENABLE_SuperLU=ON"


### PR DESCRIPTION
@trilinos/muelu 

## Motivation
Kokkos is a required MueLu dependency.
