### PR TITLE
Amesos2 : trying to fix issues with including MKL headers..

### DIFF
--- a/packages/amesos2/src/Amesos2_PardisoMKL_TypeMap.hpp
+++ b/packages/amesos2/src/Amesos2_PardisoMKL_TypeMap.hpp
@@ -60,27 +60,27 @@
 #include <complex>
 #endif
 
+#include <mkl_types.h>
+#include <mkl_dss.h>
+
 #include <Teuchos_as.hpp>
 #ifdef HAVE_TEUCHOS_COMPLEX
 #include <Teuchos_SerializationTraits.hpp>
 #endif
 
 #include "Amesos2_TypeMap.hpp"
-#ifdef _MKL_TYPES_H_
-  #undef _MKL_TYPES_H_
-  #define PARDISOMKL_PREVIOUS_MKL_TYPES_H
-#endif
 
 namespace Amesos2{
   namespace PMKL {
+    #undef _MKL_TYPES_H_
+    #include <mkl_types.h>
+
+    #undef __MKL_DSS_H
+    #include <mkl_dss.h>
+
     //Update JDB 6.25.15
     //MKL has changed _INTEGER_t to deprecated
     //MKL has changed _INTEGER_t to define from typedef 
-    #include <mkl_types.h>
-  #ifdef __MKL_DSS_H
-    #undef __MKL_DSS_H
-  #endif
-    #include <mkl_dss.h>
     #undef _INTEGER_t
     typedef MKL_INT _INTEGER_t;
   } // end namespace PMKL
@@ -286,8 +286,4 @@ namespace Amesos2 {
 
 } // end namespace Amesos
 
-#ifndef PARDISOMKL_PREVIOUS_MKL_TYPES_H
-  // first time including mkl_types.h
-  #undef _MKL_TYPES_H_
-#endif
 #endif  // AMESOS2_PARDISOMKL_TYPEMAP_HPP


### PR DESCRIPTION

@trilinos/amesos2 

## Motivation

This PR is trying to fix the issues with including MKL header files from Amesos2 PardisoMKL.

## Testing

Tested PardisoMKL with and without MKL TPL.
