### PR TITLE
Fix typos in some docs 

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -93,7 +93,7 @@ Intermediate MPI instructions (enables a few packages)
   make -j<n> install
 
 
-Intermediate MPI instructions (enables a few packages, explict compilers)
+Intermediate MPI instructions (enables a few packages, explicit compilers)
 -------------------------------------------------------------------------
 
 ::

--- a/doc/DocumentingParameterLists/memo/SMemo_PListDoc.tex
+++ b/doc/DocumentingParameterLists/memo/SMemo_PListDoc.tex
@@ -30,7 +30,7 @@
     \from{Bill Spotz, Org 1446; Dena Vigil, Org 1441}
 
     % Fill in a subject
-    \subject{How to Document \texttt{Teuchos::ParameterList}s with collapsable HTML}
+    \subject{How to Document \texttt{Teuchos::ParameterList}s with collapsible HTML}
 
 
 

--- a/doc/DocumentingParameterLists/memo/smemo.cls
+++ b/doc/DocumentingParameterLists/memo/smemo.cls
@@ -918,7 +918,7 @@
 %    ****************************************
 %
 %  The distribution environment switches to two column mode if necessary,
-%  shrinks up the \baselineskip and \parskip, allowing disribution list
+%  shrinks up the \baselineskip and \parskip, allowing distribution list
 %  to be set in a minimal amount of space.
 
 \def\distribution#1{%
@@ -1029,8 +1029,8 @@
 % of counter CTR.  It is defined in terms of the following macros:
 %
 %  \arabic{COUNTER} : The value of COUNTER printed as an arabic numeral.
-%  \roman{COUNTER}  : Its value printed as a lower-case roman numberal.
-%  \Roman{COUNTER}  : Its value printed as an upper-case roman numberal.
+%  \roman{COUNTER}  : Its value printed as a lower-case roman numeral.
+%  \Roman{COUNTER}  : Its value printed as an upper-case roman numeral.
 %  \alph{COUNTER}   : Value of COUNTER printed as a lower-case letter:
 %                         1 = a, 2 = b, etc.
 %  \Alph{COUNTER}   : Value of COUNTER printed as an upper-case letter:

--- a/doc/build_docs.pl
+++ b/doc/build_docs.pl
@@ -3,7 +3,7 @@
 ###############################################################################
 # Trilinos/doc/build_docs.pl
 #
-# - You must run this script from this directoy!
+# - You must run this script from this directory!
 # - Run any build_docs in any doc directory
 # - Create html file with links to each set of documentation
 #

--- a/doc/build_ref/TrilinosBuildReferenceTemplate.rst
+++ b/doc/build_ref/TrilinosBuildReferenceTemplate.rst
@@ -289,7 +289,7 @@ This will do the following:
 
 * Generate wrappers ``build_stats_<op>_wrapper.sh`` for C, C++, and Fortran
   (and for static builds also ``ar``, ``randlib`` and ``ld``) in the build
-  tree that will compute statistics as a byproduct of every invocation of these
+  tree that will compute statics as a byproduct of every invocation of these
   commands.  (The wrappers create a file ``<output-file>.timing`` for every
   generated object, library and executable ``<output-file>`` file.)
 

--- a/doc/build_ref/TrilinosBuildReferenceTemplate.rst
+++ b/doc/build_ref/TrilinosBuildReferenceTemplate.rst
@@ -48,17 +48,17 @@ various Trilinos packages can be enabled using the following options:
 
   ``-DTrilinos_ENABLE_FLOAT=ON``
 
-    Enables suppport and explicit instantiations for the ``float`` scalar
+    Enables support and explicit instantiations for the ``float`` scalar
     data-type in all supported Trilinos packages.
 
   ``-DTrilinos_ENABLE_COMPLEX=ON``
 
-    Enables suppport and explicit instantiations for the ``std::complex<T>``
+    Enables support and explicit instantiations for the ``std::complex<T>``
     scalar data-type in all supported Trilinos packages.
 
   ``-DTrilinos_ENABLE_COMPLEX_FLOAT=ON``
 
-    Enables suppport and explicit instantiations for the
+    Enables support and explicit instantiations for the
     ``std::complex<float>`` scalar data-type in all supported Trilinos
     packages.  This is set to ``ON`` by default when
     ``-DTrilinos_ENABLE_FLOAT=ON`` and ``-DTrilinos_ENABLE_COMPLEX=ON`` are
@@ -66,7 +66,7 @@ various Trilinos packages can be enabled using the following options:
 
   ``-DTrilinos_ENABLE_COMPLEX_DOUBLE=ON``
 
-    Enables suppport and explicit instantiations for the
+    Enables support and explicit instantiations for the
     ``std::complex<double>`` scalar data-type in all supported Trilinos
     packages.  This is set to ``ON`` by default when
     ``-DTrilinos_ENABLE_COMPLEX=ON`` is set.
@@ -125,7 +125,7 @@ target machine.  These build-related flags are selected to create correct and
 perforamnt code and for C++ software that uses Kokkos.
 
 ============================    ======================================
-Functionality                   CMake Cache Varaible
+Functionality                   CMake Cache Variable
 ============================    ======================================
 Specify architecture            ``KOKKOS_ARCH``
 Debug builds                    ``KOKKOS_DEBUG``
@@ -218,7 +218,7 @@ Addressing problems with large builds of Trilinos
 -------------------------------------------------
 
 Trilinos is a large collection of complex software.  Depending on what gets
-enbaled when building Trlinos, one can experience build and installation
+enabled when building Trlinos, one can experience build and installation
 problems due to this large size.
 
 When running into problems like these, the first thing that should be tried is
@@ -289,7 +289,7 @@ This will do the following:
 
 * Generate wrappers ``build_stats_<op>_wrapper.sh`` for C, C++, and Fortran
   (and for static builds also ``ar``, ``randlib`` and ``ld``) in the build
-  tree that will compute statics as a byproduct of every invocation of these
+  tree that will compute statistics as a byproduct of every invocation of these
   commands.  (The wrappers create a file ``<output-file>.timing`` for every
   generated object, library and executable ``<output-file>`` file.)
 


### PR DESCRIPTION
Found via `codespell -q 3 -S ./packages,./commonTools/gtest`