### PR TITLE
Phalanx: remove cuda compiler warnings and add test for new use case …

### DIFF
--- a/packages/phalanx/src/Phalanx_KokkosViewOfViews.hpp
+++ b/packages/phalanx/src/Phalanx_KokkosViewOfViews.hpp
@@ -323,12 +323,17 @@ namespace PHX {
         check_use_count_(true)
     {}
 
+    // Making this a kokkos function eliminates cuda compiler warnings
+    // in objects that contain ViewOfViews3 that are copied to device.
+    KOKKOS_INLINE_FUNCTION
     ~ViewOfViews3()
     {
       // Make sure there is not another object pointing to device view
       // since the host view will delete the inner views on exit.
-      if ( check_use_count_ && (view_device_.impl_track().use_count() != use_count_) )
-        Kokkos::abort("\n ERROR - PHX::ViewOfViews - please free all instances of device ViewOfView \n before deleting the host ViewOfView!\n\n");
+      KOKKOS_IF_ON_HOST((
+        if ( check_use_count_ && (view_device_.impl_track().use_count() != use_count_) )
+          Kokkos::abort("\n ERROR - PHX::ViewOfViews - please free all instances of device ViewOfView \n before deleting the host ViewOfView!\n\n");
+      ))
     }
 
     /// Enable safety check in dtor for external references.

--- a/packages/phalanx/test/Kokkos/CMakeLists.txt
+++ b/packages/phalanx/test/Kokkos/CMakeLists.txt
@@ -41,3 +41,10 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   TESTONLYLIBS phalanx_unit_test_main phalanx_test_utilities
   NUM_MPI_PROCS 1
   )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  tKokkosClassOnDevice
+  SOURCES tKokkosClassOnDevice.cpp
+  TESTONLYLIBS phalanx_unit_test_main phalanx_test_utilities
+  NUM_MPI_PROCS 1
+  )

--- a/packages/phalanx/test/Kokkos/tKokkosClassOnDevice.cpp
+++ b/packages/phalanx/test/Kokkos/tKokkosClassOnDevice.cpp
@@ -1,0 +1,108 @@
+#include "Kokkos_Core.hpp"
+#include "Kokkos_View.hpp"
+
+#include "Teuchos_Assert.hpp"
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Phalanx_KokkosViewOfViews.hpp"
+
+template<typename T,int dim>
+class Vector {
+  T values_[dim];
+public:
+
+  template<typename INDEX_I>
+  KOKKOS_INLINE_FUNCTION
+  T& operator[](const INDEX_I& index){return values_[index];}
+
+  template<typename INDEX_I>
+  KOKKOS_INLINE_FUNCTION
+  const T& operator[](const INDEX_I& index)const{return values_[index];}
+
+  template<typename INDEX_I>
+  KOKKOS_INLINE_FUNCTION
+  volatile T& operator[](const INDEX_I& index)volatile{return values_[index];}
+
+  template<typename INDEX_I>
+  KOKKOS_INLINE_FUNCTION
+  const volatile T& operator[](const INDEX_I& index)const volatile{return values_[index];}
+};
+
+class MyClass {
+  Kokkos::View<double*> a_;
+  double b_[3];
+  Kokkos::View<double*> c_;
+  Vector<double,3> d_;
+  // To test for cuda warnings when MyClass is lambda captured to
+  // device
+  PHX::ViewOfViews3<1,Kokkos::View<double*>> e_;
+
+public:
+  MyClass() :
+    a_("a",3),
+    c_("c",3)
+  {
+    Kokkos::deep_copy(a_,1.0);
+    b_[0] = 1.0;
+    b_[1] = 2.0;
+    b_[2] = 3.0;
+    Kokkos::deep_copy(c_,2.0);
+    d_[0] = 1.0;
+    d_[1] = 2.0;
+    d_[2] = 3.0;
+  }
+
+  void KOKKOS_FUNCTION checkInternalMethod1() const
+  { this->callInternalMethod1(); }
+
+  void KOKKOS_FUNCTION
+  callInternalMethod1() const
+  {
+    printf("b_[0]=%f\n",b_[0]);
+    printf("b_[1]=%f\n",b_[1]);
+    printf("b_[2]=%f\n",b_[2]);
+    a_(0)=b_[0];
+    a_(1)=b_[1];
+    a_(2)=b_[2];
+  }
+
+  void KOKKOS_FUNCTION checkInternalMethod2() const
+  { this->callInternalMethod2(); }
+
+  void KOKKOS_FUNCTION
+  callInternalMethod2() const
+  {
+    a_(0)=c_(0);
+    a_(1)=c_(1);
+    a_(2)=c_(2);
+  }
+
+  void KOKKOS_FUNCTION checkInternalMethod3() const
+  { this->callInternalMethod3(); }
+
+  void KOKKOS_FUNCTION
+  callInternalMethod3() const
+  {
+    a_(0)=d_[0];
+    a_(1)=d_[1];
+    a_(2)=d_[2];
+  }
+};
+
+TEUCHOS_UNIT_TEST(KokkosClassOnDevice, One)
+{
+  MyClass my_class;
+
+  Kokkos::parallel_for("test 1",1,KOKKOS_LAMBDA (const int ) {
+      my_class.checkInternalMethod1();
+  });
+
+  Kokkos::parallel_for("test 2",1,KOKKOS_LAMBDA (const int ) {
+      my_class.checkInternalMethod2();
+  });
+
+  Kokkos::parallel_for("test 3",1,KOKKOS_LAMBDA (const int ) {
+      my_class.checkInternalMethod3();
+  });
+  
+  Kokkos::fence();
+}


### PR DESCRIPTION
## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
seeing lots of warnings in an application code for VoV3 dtor. This fixes the warnings.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
Warnings are gone.

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Added new test tKokkosClassOnDevice.cpp

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->