### PR TITLE
Intrepid2: Update TensorData.setFirstComponentExtentInDimension0 to modify extents_[0]

### DIFF
--- a/packages/intrepid2/src/Shared/Intrepid2_TensorData.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_TensorData.hpp
@@ -563,6 +563,7 @@ namespace Intrepid2
     {
       INTREPID2_TEST_FOR_EXCEPTION(!separateFirstComponent_ && (numTensorComponents_ != 1), std::invalid_argument, "setFirstComponentExtent() is only allowed when separateFirstComponent_ is true, or there is only one component");
       tensorComponents_[0].setExtent(0,newExtent);
+      extents_[0] = newExtent;
     }
   };
 }


### PR DESCRIPTION
@trilinos/intrepid2 

In the sum factorization case where the remaining number of elements is smaller than the workset size, this routine is usually called to resize the data. This sets the member variable for the extents so that any subsequent queries to `extent(0)` will return a size that is consistent with the underlying data.
