### PR TITLE
Geminga: Disable Intrepid2 tests on CUDA

### DIFF
--- a/cmake/ctest/drivers/geminga/TrilinosCTestDriverCore.geminga.gcc-cuda.cmake
+++ b/cmake/ctest/drivers/geminga/TrilinosCTestDriverCore.geminga.gcc-cuda.cmake
@@ -130,6 +130,8 @@ MACRO(TRILINOS_SYSTEM_SPECIFIC_CTEST_DRIVER)
           "-DKokkos_ARCH_KEPLER35:BOOL=ON"
           "-DTrilinos_ENABLE_Epetra:BOOL=OFF"
           "-DTrilinos_ENABLE_ShyLU_Node:BOOL=OFF"
+          # Intrepid2 tests make Geminga hang
+          "-DIntrepid2_ENABLE_TESTS:BOOL=OFF"
 
       ### MISC ###
       "-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON"


### PR DESCRIPTION
@trilinos/muelu 

Geminga gets somehow stuck on them, and the only other way to fix appears to be a reboot.

