### PR TITLE
Phalanx: add static assert check for vov addView indices

### DIFF
--- a/packages/phalanx/src/Phalanx_KokkosViewOfViews.hpp
+++ b/packages/phalanx/src/Phalanx_KokkosViewOfViews.hpp
@@ -364,7 +364,11 @@ namespace PHX {
     template<typename... Indices>
     void addView(InnerViewType v,Indices... i)
     {
+      static_assert(sizeof...(Indices)==OuterViewRank,
+        "Error: PHX::ViewOfViews3::addView() - the number of indices must match the outer view rank!");
+
       TEUCHOS_ASSERT(is_initialized_);
+
       // Store the managed version so it doesn't get deleted.
       view_host_(i...) = v;
       // Store a runtime unmanaged view to prevent double deletion on device


### PR DESCRIPTION
## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Add a static assert to make sure the number if indices used in VoV.addView() is the same as the outer view rank

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
Fixes issue observed in empire.

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
ViewOfViews unit test covers this.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->