### PR TITLE
Adelus: Fix to allow permute view value type rather than int

### DIFF
--- a/packages/adelus/src/Adelus_factor.hpp
+++ b/packages/adelus/src/Adelus_factor.hpp
@@ -81,7 +81,7 @@ template<class HandleType,
          class ZDView,
          class ViewType1D,
          class ViewType2D,
-         class ViewIntType1D>
+         class PViewType>
 inline
 void factor(HandleType& ahandle,           // handle containg metadata
             ZDView&     ZV,                // matrix and rhs
@@ -89,20 +89,21 @@ void factor(HandleType& ahandle,           // handle containg metadata
             ViewType2D& row1_view,         // diagonal row
             ViewType1D& row2_view,         // pivot row
             ViewType1D& row3_view,         // temporary vector for rows
-            ViewIntType1D& pivot_vec_view, // vector storing list of pivot rows
+            PViewType&  pivot_vec_view,    // vector storing list of pivot rows
             int         nrhs,              // total num of RHS (note: set to 0 if factoring matrix only)
             int         my_rhs)            // num of RHS I own (note: set to 0 if factoring matrix only)
 {
-  typedef typename ZDView::value_type value_type;
+  using value_type = typename ZDView::value_type;
+  using pival_type = typename PViewType::value_type;
 #ifdef PRINT_STATUS
-  typedef typename ZDView::device_type::execution_space execution_space;
-  typedef typename ZDView::device_type::memory_space memory_space;
+  using execution_space = typename ZDView::device_type::execution_space;
+  using memory_space    = typename ZDView::device_type::memory_space;
 #endif
 #ifdef ADELUS_HOST_PINNED_MEM_MPI
 #if defined(KOKKOS_ENABLE_CUDA)
-  typedef Kokkos::View<value_type*, Kokkos::LayoutLeft, Kokkos::CudaHostPinnedSpace> View1DHostPinnType;//CudaHostPinnedSpace
+  using View1DHostPinnType = Kokkos::View<value_type*, Kokkos::LayoutLeft, Kokkos::CudaHostPinnedSpace>;//CudaHostPinnedSpace
 #elif defined(KOKKOS_ENABLE_HIP)
-  typedef Kokkos::View<value_type*, Kokkos::LayoutLeft, Kokkos::Experimental::HIPHostPinnedSpace> View1DHostPinnType;//HIPHostPinnedSpace
+  using View1DHostPinnType = Kokkos::View<value_type*, Kokkos::LayoutLeft, Kokkos::Experimental::HIPHostPinnedSpace>;//HIPHostPinnedSpace
 #endif
 #endif
 
@@ -349,7 +350,7 @@ void factor(HandleType& ahandle,           // handle containg metadata
       xpivmsgtime += (MPI_Wtime()-t1);
 #endif
 
-      pivot_vec_view(sav_pivot_vec_i) = pivot.row;
+      pivot_vec_view(sav_pivot_vec_i) = static_cast<pival_type>(pivot.row);
       gpivot_row = pivot.row;
       pivot_mag = abs(pivot.entry);
       if (pivot_mag == 0.0) {

--- a/packages/adelus/src/Adelus_perm_rhs.hpp
+++ b/packages/adelus/src/Adelus_perm_rhs.hpp
@@ -107,7 +107,7 @@ namespace Adelus {
       k_row=k%nprocs_col;
 
       if (ahandle.get_my_rhs() > 0) {
-        if (myrow==k_row) pivot_row = permute(k/nprocs_col);
+        if (myrow==k_row) pivot_row = static_cast<int>(permute(k/nprocs_col));
         MPI_Bcast(&pivot_row,1,MPI_INT,k_row,col_comm);
         int pivot_row_pid = pivot_row%nprocs_col;
 


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/adelus

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
This PR adds some changes to allow the permute view value type to be other than ```int``` type for the ```Adelus::Factor``` and ```Adelus::Solve``` interfaces

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Tests are performed on Lassen and Weaver, and are confirmed by @jdkotul .
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->