### PR TITLE
Belos/Thyra: Remove extra fences after Tpetra multiply in Belos and Thyra interfaces.

### DIFF
--- a/packages/belos/tpetra/src/BelosMultiVecTraits_Tpetra.hpp
+++ b/packages/belos/tpetra/src/BelosMultiVecTraits_Tpetra.hpp
@@ -409,12 +409,6 @@ namespace Belos {
         mv.multiply (Teuchos::NO_TRANS, Teuchos::NO_TRANS,
                      alpha, A, B_mv, beta);
       }
-      Kokkos::fence();  // Belos with Thyra's MvTimesMatAddMv allowed failures
-                        // when fence was not applied after mv.multiply; 
-                        // adding the fence fixed the tests in Thyra.  
-                        // Out of an abundance of caution (and with blessing 
-                        // from @hkthorn), we add the fence here as well.  
-                        // #8821 KDD
     }
 
     /// \brief <tt>mv := alpha*A + beta*B</tt>

--- a/packages/thyra/adapters/tpetra/src/Thyra_TpetraMultiVector_def.hpp
+++ b/packages/thyra/adapters/tpetra/src/Thyra_TpetraMultiVector_def.hpp
@@ -605,7 +605,6 @@ void TpetraMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>::euclideanApply(
     }
 
     Y_tpetra->multiply(trans, Teuchos::NO_TRANS, alpha, *tpetraMultiVector_.getConstObj(), *X_tpetra, beta);
-    Kokkos::fence();
   } else {
     SpmdMultiVectorDefaultBase<Scalar>::euclideanApply(M_trans, X, Y, alpha, beta);
   }

--- a/packages/thyra/adapters/tpetra/src/Thyra_TpetraVector_def.hpp
+++ b/packages/thyra/adapters/tpetra/src/Thyra_TpetraVector_def.hpp
@@ -499,7 +499,6 @@ void TpetraVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>::applyImpl(
     }
 
     Y_tpetra->multiply(trans, Teuchos::NO_TRANS, alpha, *tpetraVector_.getConstObj(), *X_tpetra, beta);
-    Kokkos::fence();
   } else {
     VectorDefaultBase<Scalar>::applyImpl(M_trans, X, Y, alpha, beta);
   }


### PR DESCRIPTION
@trilinos/belos @trilinos/thyra 
@trilinos/tpetra 

## Motivation
Sierra developers had complained about slow performance from "extra Kokkos::fences" in Belos/Tpetra, so I went digging. 
The only fence in the Belos-Tpetra (non-Thyra) interface was the one after tpetra's mv.multiply in the `MvTimesMatAddMv` interface in the Belos-Tpetra adapter.  That fence came with this note indicating it might be extraneous: "Belos with Thyra's MvTimesMatAddMv allowed failures when fence was not applied after mv.multiply; adding the fence fixed the tests in Thyra. Out of an abundance of caution (and with blessing from @hkthorn), we add the fence here as well. #8821 KDD "

This fence, and corresponding fences in the Thyra-Belos interface, were added in this commit: https://github.com/trilinos/Trilinos/commit/340a16cfbe34bdae79412253c10efa4c1b31b9d1

#8821 was a GIANT PR that refactored Tpetra::MultiVector to remove UVM from Tpetra. Even at the time (see PR discussion around March 5, 2021), there seemed to be some doubt as to whether these fences were a correct fix:
<img width="904" alt="image" src="https://user-images.githubusercontent.com/28164775/188521957-7ced654c-91b4-42d9-ba64-f0c598411a15.png">
<img width="912" alt="image" src="https://user-images.githubusercontent.com/28164775/188521971-b79d9a44-a9cb-44f5-8b5e-d076df3aa5a5.png">

However, these doubts seem to have been forgotten in the midst of many, many changes, and they were merged with the PR. 

After recent discussions with @brian-kelley (email thread, 8/1/22), it seems that the fence in the Belos adapter is no longer needed (if it ever was necessary):
"Kyungjoo is right, the function in Belos shouldn't have a fence. After the last round of deprecated removal, there is no way to access data from a Tpetra::MultiVector without triggering the lazy sync he's talking about. A failure caused by concurrent host and device access of UVM could still happen if something holds a raw pointer to data, though."

With @hkthorn, we decided that the Belos fence could be removed, pending all tests pass. [Per @hkthorn's memory, it seems that the failing tests (requiring the fences in Thyra) were from NOX?]

From my understanding, it seems that the corresponding Thyra fences should also be unnecessary?
Thus, for now, I am removing all three fences.  We will run the PR tester to see if the tests now pass without them. 

Please comment below if my understanding is wrong, or if you can spot another reason that these fences are really necessary.  Thanks!

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->