### PR TITLE
common.bash: remove missing "color" command

### DIFF
--- a/packages/framework/pr_tools/common.bash
+++ b/packages/framework/pr_tools/common.bash
@@ -73,9 +73,9 @@ function execute_command()
         local _runtime=$((_stop-_start))
 
         if [ $err -ne 0 ]; then
-            message_std "PRDriver> " "${red}FAILED $(color 100)(${_runtime} s)${normal}"
+            message_std "PRDriver> " "${red}FAILED ${normal}(${_runtime} s)"
         else
-            message_std "PRDriver> " "${green}OK $(color 100)(${_runtime} s)${normal}"
+            message_std "PRDriver> " "${green}OK ${normal}(${_runtime} s)"
         fi
     else
         message_std "PRDriver> " "${red}ERROR: command '${command:?}' is not executable"

--- a/packages/framework/pr_tools/common.bash
+++ b/packages/framework/pr_tools/common.bash
@@ -302,7 +302,7 @@ function get_python_packages() {
     )
     message_std "PRDriver> " ""
     # ${pip_exe:?} install --user ${pip_args[@]}
-    execute_command "${pip_exe:?} install --user ${pip_args[@]}"
+    ${pip_exe:?} install --user "${pip_args[@]}"
 }
 
 


### PR DESCRIPTION
Early exit from the execute_command() function due to a missing "color" command leads to weird behavior in our CI scripts.  Remove the "color" command and restore the coloring by using the "${normal}" variable instead.
