### PR TITLE
Galeri: copy missing header during installation

### DIFF
--- a/packages/galeri/src-xpetra/CMakeLists.txt
+++ b/packages/galeri/src-xpetra/CMakeLists.txt
@@ -18,6 +18,7 @@ APPEND_SET(HEADERS
 
 APPEND_SET(HEADERS
   ../src-epetra/Galeri_ConfigDefs.h
+  ../src-epetra/Galeri_Exception.h
   Galeri_XpetraParameters.hpp
 
   Galeri_XpetraProblemFactory.hpp


### PR DESCRIPTION
@trilinos/galeri 
@searhein 

## Motivation

For Galeri's Xpetra portion, includes the file `galeri/src-eptra/Galeri_Exception.h` into the list of headers to be copied to the include directory during installation.

This is only a quick fix to hopefully get Galeri working for the upcoming EuroTUG 2022 meeting. A long-term solution coudl be to move the header outside of `src-epetra` to a place, that's independent of Epetra or Xpetra. See details in #10996.

## Related Issues

* Part of #10996.

## Testing

Verified on my machine.

<!--
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->