### PR TITLE
KokkosKernels: Fix #10950

### DIFF
--- a/packages/kokkos-kernels/src/graph/impl/KokkosGraph_Distance2MIS_impl.hpp
+++ b/packages/kokkos-kernels/src/graph/impl/KokkosGraph_Distance2MIS_impl.hpp
@@ -1117,7 +1117,8 @@ struct D2_MIS_Aggregation {
           if (neiAgg == agg) connect++;
         }
         connectivities_(i) = connect;
-      }
+      } else
+        connectivities_(i) = 0;
     }
 
     lno_t numVerts_;
@@ -1224,9 +1225,9 @@ struct D2_MIS_Aggregation {
     // neighboring aggregate.
     labels_t labelsOld("old", numVerts);
     Kokkos::deep_copy(labelsOld, labels);
-    labels_t connectivities("connect", numVerts);
-    labels_t aggSizes(
-        Kokkos::ViewAllocateWithoutInitializing("Phase3 Agg Sizes"), numAggs);
+    labels_t connectivities(Kokkos::ViewAllocateWithoutInitializing("connect"),
+                            numVerts);
+    labels_t aggSizes("Phase3 Agg Sizes", numAggs);
     Kokkos::parallel_for(
         range_pol(0, numVerts),
         SizeAndConnectivityFunctor(numVerts, rowmap, entries, labels,


### PR DESCRIPTION
(Patch for KK PR #1528). Fixes bug #10950 where uninitialized memory was used in MIS-2 aggregation phase3. This didn't break the validity of the aggregation, but it did break determinism and potentially decreased the quality (size balance) of the aggregates.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/kokkos-kernels 
@trilinos/muelu 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Fixes a real bug, see description above
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:
-->
## Related Issues

* Closes #10950 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of https://github.com/kokkos/kokkos-kernels/pull/1528



## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
Bug showed up as Valgrind errors (conditional branch on uninitialized values) in the KokkosKernels graph unit tests and the MueLu Kokkos refactor unit tests.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->