### PR TITLE
MueLu: Fixing random test fail in #11019

### DIFF
--- a/packages/muelu/test/unit_tests/ParameterList/ParameterListInterpreter/Comparison1.xml
+++ b/packages/muelu/test/unit_tests/ParameterList/ParameterListInterpreter/Comparison1.xml
@@ -18,6 +18,10 @@
     <Parameter        name="smoother: type"                       type="string"  value="RELAXATION"/>
     <Parameter        name="coarse: type"                         type="string"  value="RELAXATION"/>
 
+
+    <!-- This is a comparison test, so we really need deterministic aggregation -->
+    <Parameter        name="aggregation: deterministic"            type="bool"    value="true"/>
+
     <!-- end of default values -->
 
     <!-- ===========  REPARTITIONING  =========== -->


### PR DESCRIPTION
Issue: #11019
Tests: This
Stakeholder feedback:n/a


Root cause was a comparison test which used non-deterministic aggregation on OpenMP.  Oops.  We probably shouldn't have our default OpenMP aggregation algorithm be non-deterministic, but that's a discussion for another time.