### PR TITLE
Tpetra: Add a fence in makeColMap and setAllToScalar

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -3426,6 +3426,8 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       using execution_space = typename device_type::execution_space;
       Kokkos::deep_copy (execution_space(), valuesUnpacked_wdv.getDeviceView(Access::OverwriteAll),
                          theAlpha);
+      // CAG: This fence was found to be required on Cuda with UVM=on.
+      Kokkos::fence();
     }
   }
 

--- a/packages/tpetra/core/src/Tpetra_Details_makeColMap_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_makeColMap_def.hpp
@@ -640,6 +640,8 @@ makeColMap (Teuchos::RCP<const Tpetra::Map<LO, GO, NT>>& colMap,
   Kokkos::deep_copy(exec_space(), localsHost, localGIDView);
   // DEEP_COPY REVIEW - DEVICE-TO-HOSTMIRROR
   Kokkos::deep_copy(exec_space(), remotesHost, remoteGIDView);
+  // CAG: This fence was found to be required on Cuda with UVM=on.
+  Kokkos::fence();
   //Finally, populate the STL structures which hold the index lists
   std::set<GO> RemoteGIDSet;
   std::vector<GO> RemoteGIDUnorderedVector;


### PR DESCRIPTION
@trilinos/tpetra 

## Motivation
Add a fence to `makeColMap`. Without it, Tpetra crashes on Cuda, UVM=on. With UVM=off it seems to work regardless.