### PR TITLE
intrepid2: updates to compile with disable of kokkos deprecated code

### DIFF
--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HierarchicalBasis_HCURL_TET.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HierarchicalBasis_HCURL_TET.hpp
@@ -48,7 +48,6 @@
 #ifndef Intrepid2_HierarchicalBasis_HCURL_TET_h
 #define Intrepid2_HierarchicalBasis_HCURL_TET_h
 
-#include <Kokkos_View.hpp>
 #include <Kokkos_DynRankView.hpp>
 
 #include <Intrepid2_config.h>
@@ -958,7 +957,7 @@ namespace Intrepid2
       const int teamSize = 1; // because of the way the basis functions are computed, we don't have a second level of parallelism...
 
       auto policy = Kokkos::TeamPolicy<ExecutionSpace>(numPoints,teamSize,vectorSize);
-      Kokkos::parallel_for( policy , functor, "Hierarchical_HCURL_TET_Functor");
+      Kokkos::parallel_for("Hierarchical_HCURL_TET_Functor", policy , functor);
     }
 
     /** \brief returns the basis associated to a subCell.

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HierarchicalBasis_HDIV_TET.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HierarchicalBasis_HDIV_TET.hpp
@@ -48,7 +48,6 @@
 #ifndef Intrepid2_HierarchicalBasis_HDIV_TET_h
 #define Intrepid2_HierarchicalBasis_HDIV_TET_h
 
-#include <Kokkos_View.hpp>
 #include <Kokkos_DynRankView.hpp>
 
 #include <Intrepid2_config.h>
@@ -923,7 +922,7 @@ namespace Intrepid2
       const int teamSize = 1; // because of the way the basis functions are computed, we don't have a second level of parallelism...
 
       auto policy = Kokkos::TeamPolicy<ExecutionSpace>(numPoints,teamSize,vectorSize);
-      Kokkos::parallel_for( policy , functor, "Hierarchical_HDIV_TET_Functor");
+      Kokkos::parallel_for("Hierarchical_HDIV_TET_Functor", policy , functor);
     }
 
     /** \brief returns the basis associated to a subCell.

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_LegendreBasis_HVOL_TET.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_LegendreBasis_HVOL_TET.hpp
@@ -49,7 +49,6 @@
 #ifndef Intrepid2_LegendreBasis_HVOL_TET_h
 #define Intrepid2_LegendreBasis_HVOL_TET_h
 
-#include <Kokkos_View.hpp>
 #include <Kokkos_DynRankView.hpp>
 
 #include <Intrepid2_config.h>
@@ -365,7 +364,7 @@ namespace Intrepid2
       const int teamSize = 1; // because of the way the basis functions are computed, we don't have a second level of parallelism...
 
       auto policy = Kokkos::TeamPolicy<ExecutionSpace>(numPoints,teamSize,vectorSize);
-      Kokkos::parallel_for( policy , functor, "Hierarchical_HVOL_TET_Functor");
+      Kokkos::parallel_for("Hierarchical_HVOL_TET_Functor", policy , functor);
     }
 
     /** \brief Creates and returns a Basis object whose DeviceType template argument is Kokkos::HostSpace::device_type, but is otherwise identical to this.


### PR DESCRIPTION
- remove private kokkos headers
- move kernel label to first argument of parallel_for

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/intrepid2 

## Motivation
Updates to compile with disable of kokkos deprecated code
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
NA
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
Locally testing confirmed successful compilation with Kokkos' deprecated code disabled; AT for more testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->