### PR TITLE
Make changes under packages/framework/ trigger enable of all packages (#10881)

### DIFF
--- a/commonTools/framework/ProjectCiFileChangeLogic.py
+++ b/commonTools/framework/ProjectCiFileChangeLogic.py
@@ -7,7 +7,7 @@ class ProjectCiFileChangeLogic:
     modifiedFileFullPathArray = modifiedFileFullPath.split('/')
     lenPathArray = len(modifiedFileFullPathArray)
 
-    if lenPathArray==1:
+    if lenPathArray==1:  # Base project directory
       # Files directly under <projectDir>/
       if modifiedFileFullPathArray[0] == "CMakeLists.txt":
         return True
@@ -79,6 +79,12 @@ class ProjectCiFileChangeLogic:
         # All other *.cmake files under any subdir of cmake/ should trigger
         # a global rebuild to be safe.
        return True
-    # Any other files not already covered abvoe should not trigger a global
+    elif lenPathArray >= 2 and modifiedFileFullPathArray[0] == 'packages' and \
+      modifiedFileFullPathArray[1] == 'framework' \
+      :
+      # Changes under packages/framework/ likely impact the GenConfig PR build
+      # configurations and therefore to be safe, everything needs to be tested.
+      return True
+    # Any other files not already covered above should *not* trigger a global
     # build
     return False

--- a/commonTools/framework/ProjectCiFileChangeLogic.py
+++ b/commonTools/framework/ProjectCiFileChangeLogic.py
@@ -1,13 +1,12 @@
-#
 # Specialized logic for what file changes should trigger a global build in CI
-# testing where testing should only occur package impacted by the change.
+# testing where testing should only involve packages impacted by the change.
 #
-
 class ProjectCiFileChangeLogic:
 
   def isGlobalBuildFileRequiringGlobalRebuild(self, modifiedFileFullPath):
     modifiedFileFullPathArray = modifiedFileFullPath.split('/')
     lenPathArray = len(modifiedFileFullPathArray)
+
     if lenPathArray==1:
       # Files directly under <projectDir>/
       if modifiedFileFullPathArray[0] == "CMakeLists.txt":
@@ -54,7 +53,6 @@ class ProjectCiFileChangeLogic:
         # cmake/TPLs/.  Any TPL file modules that change really needs to
         # trigger a global build to be safe
         return True
-
       elif modifiedFileFullPathArray[1] == 'ctest':
         # cmake/ctest/
         if lenPathArray==3:

--- a/commonTools/framework/ProjectCiFileChangeLogic_UnitTests.py
+++ b/commonTools/framework/ProjectCiFileChangeLogic_UnitTests.py
@@ -110,6 +110,12 @@ class test_TribitsExampleProject_ProjectCiFileChangeLogic(unittest.TestCase):
   def test_doc(self):
     self.check('doc/anything', False)
 
+  def test_packages_something(self):
+    self.check('packages/something', False)
+
+  def test_packages_framework(self):
+    self.check('packages/framework/something', True)
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/commonTools/framework/get-changed-trilinos-packages.sh
+++ b/commonTools/framework/get-changed-trilinos-packages.sh
@@ -9,7 +9,7 @@
 # and then generates a CMake fragment file <package-enables-cmake-out> which
 # provides the set of enables of Trilinos packages needed to test the changed
 # files and optionally also a <package-subproject-list-out> CMake fragment
-# file provides a 'set(CTEST_LABELS_FOR_SUBPROJECTS ...)' statment which
+# file provides a 'set(CTEST_LABELS_FOR_SUBPROJECTS ...)' statement which
 # provides the list of subprojects (TriBITS packages) to display on CDash.
 #
 # For example, to generate a file for the set of enables to test changes in
@@ -138,7 +138,7 @@ echo "***"
 echo
 
 echo
-echo "A) Generate the Trilinos Packages definition and depencencies XML file"
+echo "A) Generate the Trilinos Packages definition and dependencies XML file"
 echo
 
 generate_trilinos_package_dependencies_xml_file


### PR DESCRIPTION
### Description:

These changes can break the PR build and/or tests in any Trilinos package so, to be safe, everything needs to be enabled when changing files under this directory (see #10881).

### Testing

I tested this locally by using the local commits:

```
$ git log-short --name-status HEAD --not github/develop 
f5ecd341e85 "REMOVE ME: Change a file under packages/framework/"
Author: Roscoe A. Bartlett <rabartl@sandia.gov>
Date:   Fri Sep 23 08:28:33 2022 -0600 (5 minutes ago)

M       packages/framework/get_dependencies.sh

0bc59ef04ee "Make changes under packages/framework/ trigger enable of all packages (#10881)"
Author: Roscoe A. Bartlett <rabartl@sandia.gov>
Date:   Fri Sep 23 08:24:00 2022 -0600 (10 minutes ago)

M       commonTools/framework/ProjectCiFileChangeLogic.py
M       commonTools/framework/ProjectCiFileChangeLogic_UnitTests.py

e034f024a7c "Minor typo and format fixes (#10881)"
Author: Roscoe A. Bartlett <rabartl@sandia.gov>
Date:   Fri Sep 23 08:16:58 2022 -0600 (17 minutes ago)

M       commonTools/framework/ProjectCiFileChangeLogic.py
M       commonTools/framework/get-changed-trilinos-packages.sh
```

And then I ran the updated command:

```
$ cd Trilinos/

$ ./commonTools/framework/get-changed-trilinos-packages.sh github/develop HEAD \
  enablePackages.cmake subprojectsList.cmake
```

which gave the file `enablePackages.cmake`:

```
MACRO(PR_ENABLE_BOOL  VAR_NAME  VAR_VAL)
  MESSAGE("-- Setting ${VAR_NAME} = ${VAR_VAL}")
  SET(${VAR_NAME} ${VAR_VAL} CACHE BOOL "Set in enablePackages.cmake")
ENDMACRO()

PR_ENABLE_BOOL(Trilinos_ENABLE_TrilinosFrameworkTests ON)
PR_ENABLE_BOOL(Trilinos_ENABLE_ALL_PACKAGES ON)
```


