### PR TITLE
Stokhos:  Loosen tolerance to resolve failures on Intel19 + C++17

### DIFF
--- a/packages/stokhos/test/UnitTest/Stokhos_HermiteBasisUnitTest.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_HermiteBasisUnitTest.cpp
@@ -61,7 +61,7 @@ namespace HermiteBasisUnitTest {
     OrdinalType p;
     Stokhos::HermiteBasis<OrdinalType,ValueType> basis;
     
-    UnitTestSetup() : rtol(1e-12), atol(1e-4), p(10), basis(p) {}
+    UnitTestSetup() : rtol(1e-12), atol(1e-3), p(10), basis(p) {}
     
   };
 


### PR DESCRIPTION
For issue #11045
