### PR TITLE
Intrepid2: rename basis function Intrepid2_HVOL_C0_FEM

### DIFF
--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_C0_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_C0_FEM.hpp
@@ -130,6 +130,9 @@ namespace Intrepid2 {
            typename outputValueType = double,
            typename pointValueType = double>
   class Basis_HVOL_C0_FEM : public Basis<DeviceType,outputValueType,pointValueType> {
+    
+    std::string basisName_;
+
   public:
     using OrdinalTypeArray1DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
     using OrdinalTypeArray2DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
@@ -201,7 +204,7 @@ namespace Intrepid2 {
 
     virtual
     const char* getName() const override {
-      return "Intrepid2_HVOL_C0_FEM";
+      return basisName_.c_str();
     }
 
     virtual HostBasisPtr<outputValueType,pointValueType>

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_C0_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_C0_FEMDef.hpp
@@ -140,6 +140,10 @@ namespace Intrepid2 {
     this->basisType_         = Intrepid2::BASIS_FEM_DEFAULT;
     this->basisCoordinates_  = Intrepid2::COORDINATES_CARTESIAN;
     this->functionSpace_     = FUNCTION_SPACE_HVOL;
+    
+    basisName_ = "Intrepid2_HVOL_";
+    basisName_ += cellTopo.getName();
+    basisName_ += "_C0_FEM";
 
     // initialize tags
     {


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/Intrepid2

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Orientation tools require basis functions to have unique names.
`Intrepid2_HVOL_C0_FEM` basis function has the same name independently of the basis topology, which create issues in 2d `HCurl` and `HDiv` boundary projections. 
Fixing this by including the topology name into the basis name, e.g. 
`Intrepid2_HVOL_Line_2_C0_FEM`
`Intrepid2_HVOL_Quad_4_C0_FEM`
In this way basis functions with different topologies have different names, which is required by orientations.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->