### PR TITLE
Ifpack2&MueLu: Block Relaxation fixes

### DIFF
--- a/packages/ifpack2/src/Ifpack2_BlockRelaxation_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockRelaxation_decl.hpp
@@ -123,6 +123,13 @@ public:
   typedef Tpetra::Import<local_ordinal_type, global_ordinal_type, node_type> import_type;
 
 private:
+
+  /// \brief Variant of setParameters() that takes a nonconst Teuchos::ParameterList.
+  ///
+  /// This variant fills in default values for any valid parameters
+  /// that are not in the input list.
+  void setParametersImpl(Teuchos::ParameterList& params);
+
   void computeImporter() const;
 
   //! \name Internal typedefs (handy for brevity and code clarity)

--- a/packages/ifpack2/src/Ifpack2_BlockRelaxation_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockRelaxation_def.hpp
@@ -176,8 +176,27 @@ getValidParameters () const
 template<class MatrixType,class ContainerType>
 void
 BlockRelaxation<MatrixType,ContainerType>::
-setParameters (const Teuchos::ParameterList& List)
+setParameters (const Teuchos::ParameterList& pl)
 {
+  // CAG: Copied form Relaxation
+  // FIXME (aprokop 18 Oct 2013) Casting away const is bad here.
+  // but otherwise, we will get [unused] in pl
+  this->setParametersImpl(const_cast<Teuchos::ParameterList&>(pl));
+}
+
+template<class MatrixType,class ContainerType>
+void
+BlockRelaxation<MatrixType,ContainerType>::
+setParametersImpl (Teuchos::ParameterList& List)
+{
+  if (List.isType<double>("relaxation: damping factor")) {
+    // Make sure that ST=complex can run with a damping factor that is
+    // a double.
+    scalar_type df = List.get<double>("relaxation: damping factor");
+    List.remove("relaxation: damping factor");
+    List.set("relaxation: damping factor",df);
+  }
+
   // Note that the validation process does not change List.
   Teuchos::RCP<const Teuchos::ParameterList> validparams;
   validparams = this->getValidParameters();

--- a/packages/muelu/test/scaling/CMakeLists.txt
+++ b/packages/muelu/test/scaling/CMakeLists.txt
@@ -459,7 +459,7 @@ IF (${PACKAGE_NAME}_HAVE_TPETRA_SOLVER_STACK)
   MUELU_ADD_SERIAL_AND_MPI_TEST(
       Driver
       NAME "CalcRotations"
-      ARGS "--linAlgebra=Tpetra --xml=comp_rotations.xml  --matrixType=Elasticity3D --nx=40 --ny=40 --nz=4 --its=100 --belosType='gmres' --tol=1.0e-8  --muelu-computed-nullspace"
+      ARGS "--linAlgebra=Tpetra --xml=comp_rotations.xml  --matrixType=Elasticity3D --nx=40 --ny=40 --nz=4 --its=100 --belosType=gmres --tol=1.0e-8  --muelu-computed-nullspace"
       NUM_MPI_PROCS 4
       COMM serial mpi
       )

--- a/packages/muelu/test/scaling/Driver.cpp
+++ b/packages/muelu/test/scaling/Driver.cpp
@@ -505,7 +505,10 @@ MueLu::MueLu_AMGX_initialize_plugins();
         comm->barrier();
       }
       catch(const std::exception& e) {
-        out2<<"MueLu_Driver: solver crashed w/ message:"<<e.what()<<std::endl;
+        if (isDriver)
+          out2<<"MueLu_Driver: solver crashed w/ message:"<<e.what()<<std::endl;
+        else
+          throw;
       }
 
 


### PR DESCRIPTION
@trilinos/ifpack2 @trilinos/muelu 

## Motivation
- Don't catch exceptions in the MueLu driver unless we run several input decks. This avoids getting passing tests with failing input decks.
- Fix a bug in Ifpack2::BlockRelaxation for singletons.