### PR TITLE
Piro: enable some tests in Epetra-free build

### DIFF
--- a/packages/piro/CMakeLists.txt
+++ b/packages/piro/CMakeLists.txt
@@ -37,11 +37,7 @@ ENDIF()
 #
 
 ADD_SUBDIRECTORY(src)
-
-# All tests are based on Epetra, currently
-IF ( Piro_ENABLE_Epetra)
-  TRIBITS_ADD_TEST_DIRECTORIES(test)
-ENDIF ()
+TRIBITS_ADD_TEST_DIRECTORIES(test)
 
 #
 # D) Do standard postprocessing

--- a/packages/piro/test/CMakeLists.txt
+++ b/packages/piro/test/CMakeLists.txt
@@ -5,275 +5,53 @@ LINK_DIRECTORIES(${PACKAGE_BINARY_DIR}/../TriKota/Dakota/install/lib/)
 # Required for Dakota
 ADD_DEFINITIONS(${TRIKOTA_DAKOTA_DEFINITIONS})
 
-TRIBITS_ADD_EXECUTABLE_AND_TEST(
-  UnitTests
-  SOURCES
-    Piro_UnitTests.cpp
-    ${TEUCHOS_STD_UNIT_TEST_MAIN}
-    MockModelEval_A.cpp
-    MockModelEval_A.hpp
-    MockModelEval_C.cpp
-    MockModelEval_C.hpp
-    MockModelEval_D.cpp
-    MockModelEval_D.hpp
-  NUM_MPI_PROCS 1
-  STANDARD_PASS_OUTPUT
-  )
-
-TRIBITS_ADD_EXECUTABLE_AND_TEST(
-  Epetra_MatrixFreeOperator_UnitTests
-  SOURCES
-    Piro_Epetra_MatrixFreeOperator_UnitTests.cpp
-    ${TEUCHOS_STD_UNIT_TEST_MAIN}
-    Piro_Test_EpetraSupport.hpp
-    MockModelEval_A.hpp
-    MockModelEval_A.cpp
-  NUM_MPI_PROCS 1-4
-  STANDARD_PASS_OUTPUT
-  )
-
-TRIBITS_ADD_EXECUTABLE_AND_TEST(
-  MatrixFreeDecorator_UnitTests
-  SOURCES
-    Piro_MatrixFreeDecorator_UnitTests.cpp
-    ${TEUCHOS_STD_UNIT_TEST_MAIN}
-    Piro_Test_ThyraSupport.hpp
-    MockModelEval_A.hpp
-    MockModelEval_A.cpp
-  NUM_MPI_PROCS 1-4
-  STANDARD_PASS_OUTPUT
-  )
-
-TRIBITS_ADD_EXECUTABLE_AND_TEST(
-  EvalModel
-  SOURCES
-  Main_EvalModel.cpp
-  MockModelEval_A.cpp
-  MockModelEval_A.hpp
-  NUM_MPI_PROCS 1-4
-  ARGS -v
-  PASS_REGULAR_EXPRESSION "TEST PASSED"
-  )
-
 IF (Piro_ENABLE_NOX)
-#  TRIBITS_ADD_EXECUTABLE_AND_TEST(
-#    EpetraSolver
-#    SOURCES
-#    Main_EpetraSolver.cpp
-#    MockModelEval_A.cpp
-#    MockModelEval_A.hpp
-#    SaveEigenData_Epetra.cpp
-#    SaveEigenData_Epetra.hpp
-#    NUM_MPI_PROCS 1-4
-#    ARGS -v
-#    PASS_REGULAR_EXPRESSION "TEST PASSED"
-#  )
-
-  TRIBITS_ADD_EXECUTABLE_AND_TEST(
-    ThyraSolver
-    SOURCES
-    Main_ThyraSolver.cpp
-    MockModelEval_A.cpp
-    MockModelEval_A.hpp
-    NUM_MPI_PROCS 1-4
-    ARGS -v
-    PASS_REGULAR_EXPRESSION "TEST PASSED"
-    ADDED_EXE_TARGET_NAME_OUT ThyraSolver_NAME
-  )
-
   TRIBITS_ADD_EXECUTABLE_AND_TEST(
     ThyraSolverTpetra
-    EXCLUDE_IF_NOT_TRUE ${PACKAGE_NAME}_ENABLE_ROL
     EXCLUDE_IF_NOT_TRUE ${PACKAGE_NAME}_ENABLE_Ifpack2
     SOURCES
-      Main_ThyraSolver_Tpetra.cpp
-      MockModelEval_A_Tpetra.cpp
-      MockModelEval_A_Tpetra.hpp
+    Main_ThyraSolver_Tpetra.cpp
+    MockModelEval_A_Tpetra.cpp
+    MockModelEval_A_Tpetra.hpp
     NUM_MPI_PROCS 1-4
     ARGS -v
     PASS_REGULAR_EXPRESSION "TEST PASSED"
     ADDED_EXE_TARGET_NAME_OUT ThyraSolver_NAME
     ADDED_TESTS_NAMES_OUT ThyraSolverTpetra_NAME
   )
-
-  TRIBITS_ADD_EXECUTABLE_AND_TEST(
-    AnalysisDriver
-    SOURCES
-    Main_AnalysisDriver.cpp
-    MockModelEval_A.cpp
-    MockModelEval_A.hpp
-    ObserveSolution_Epetra.hpp
-    NUM_MPI_PROCS 1-4
-    ARGS -v
-    PASS_REGULAR_EXPRESSION "TEST PASSED"
-  )
   
-    TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  TRIBITS_ADD_EXECUTABLE_AND_TEST(
     AnalysisDriverTpetra
     EXCLUDE_IF_NOT_TRUE ${PACKAGE_NAME}_ENABLE_ROL
+    EXCLUDE_IF_NOT_TRUE ${PACKAGE_NAME}_ENABLE_Teko
     EXCLUDE_IF_NOT_TRUE ${PACKAGE_NAME}_ENABLE_Ifpack2
     SOURCES
-      Main_AnalysisDriver_Tpetra.cpp
-      MockModelEval_A_Tpetra.cpp
-      MockModelEval_A_Tpetra.hpp
-      MockModelEval_B_Tpetra.cpp
-      MockModelEval_B_Tpetra.hpp
+    Main_AnalysisDriver_Tpetra.cpp
+    MockModelEval_A_Tpetra.cpp
+    MockModelEval_A_Tpetra.hpp
+    MockModelEval_B_Tpetra.cpp
+    MockModelEval_B_Tpetra.hpp
     NUM_MPI_PROCS 1-4
     ARGS -v
     PASS_REGULAR_EXPRESSION "TEST PASSED"
     ADDED_TESTS_NAMES_OUT AnalysisDriverTpetra_NAME 
   )
-
-  TRIBITS_ADD_EXECUTABLE_AND_TEST(
-    SecondOrderIntegrator
-    SOURCES
-    Main_SecondOrderIntegrator.cpp
-    MockModelEval_B.cpp
-    MockModelEval_B.hpp
-    ObserveSolution_Epetra.hpp
-    NUM_MPI_PROCS 1
-    ARGS -v
-    PASS_REGULAR_EXPRESSION "TEST PASSED"
-  )
-
-  TRIBITS_ADD_EXECUTABLE_AND_TEST(
-    NOXSolver_UnitTests
-    SOURCES
-    Piro_NOXSolver_UnitTests.cpp
-    ${TEUCHOS_STD_UNIT_TEST_MAIN}
-    MockModelEval_A.cpp
-    MockModelEval_A.hpp
-    Piro_Test_ThyraSupport.hpp
-    Piro_Test_WeakenedModelEvaluator.hpp
-    Piro_Test_MockObserver.hpp
-    NUM_MPI_PROCS 1-4
-    STANDARD_PASS_OUTPUT
-  )
-
-  TRIBITS_ADD_EXECUTABLE_AND_TEST(
-    LOCASolver_UnitTests
-    SOURCES
-    Piro_LOCASolver_UnitTests.cpp
-    ${TEUCHOS_STD_UNIT_TEST_MAIN}
-    MockModelEval_A.cpp
-    MockModelEval_A.hpp
-    Piro_Test_ThyraSupport.hpp
-    NUM_MPI_PROCS 1-4
-    STANDARD_PASS_OUTPUT
-  )
-
-  IF (ThyraSolver_NAME)
-   SET(ThyraSolver_EXENAME ThyraSolver)
+  
+  IF (ThyraSolverTpetra_NAME)
+    SET(ThyraSolverTpetra_EXENAME ThyraSolverTpetra)
   ELSE()
-   SET(ThyraSolver_EXENAME)
+    SET(ThyraSolverTpetra_EXENAME)
   ENDIF()
 
   IF (AnalysisDriverTpetra_NAME)
-   SET(AnalysisDriverTpetra_EXENAME AnalysisDriverTpetra)
+    SET(AnalysisDriverTpetra_EXENAME AnalysisDriverTpetra)
   ELSE()
-   SET(AnalysisDriverTpetra_EXENAME)
+    SET(AnalysisDriverTpetra_EXENAME)
   ENDIF()
 
-  TRIBITS_COPY_FILES_TO_BINARY_DIR(copyTestInputFiles
-    DEST_FILES   input_Solve_NOX_1.xml
-                 input_Solve_NOX_2.xml
-                 input_Solve_NOX_3.xml
-                 input_Solve_NOX_4.xml
-		 input_Solve_NOX_Adjoint.xml
-                 input_Solve_LOCA_1.xml
-                 input_Solve_Rythmos_1.xml
-                 input_Solve_Rythmos_1new.xml
-                 input_Solve_Rythmos_2.xml
-                 input_Solve_RythmosSolver_2.xml
-                 input_Solve_VV.xml
-                 input_Solve_TR.xml
-                 input_Solve_NB.xml
-          input_Analysis_Dakota.xml dak.in
-          input_Analysis_ROL_Tpetra.xml
-          input_Analysis_ROL_ReducedSpace_NOXSolver_Tpetra.xml
-          input_Analysis_ROL_ReducedSpace_Tpetra.xml
-          input_Analysis_ROL_FullSpace_Tpetra.xml
-          input_Analysis_ROL_AdjointSensitivities_Tpetra.xml
-          input_Analysis_ROL_AdjointSensitivities_ReducedSpace_NOXSolver_Tpetra.xml
-          input_Analysis_ROL_AdjointSensitivities_FullSpace_Tpetra.xml
-          input_Solve_RythmosMatrixFree_Fails.xml
-	  input_SGSolve.xml
-	  input_problem1.xml input_problem2.xml input_coupled.xml
-	  input_problem1_sg.xml input_problem2_sg.xml input_coupled_sg.xml
-	  input_SGAnalysis.xml dakota_sg.in dakota_sg_target.txt
-          input_Tempus_BackwardEuler_SinCos.xml 
-    SOURCE_DIR   ${PACKAGE_SOURCE_DIR}/test
-    SOURCE_PREFIX "_"
-    EXEDEPS ${ThyraSolver_EXENAME} AnalysisDriver ${AnalysisDriverTpetra_EXENAME} UnitTests NOXSolver_UnitTests
-  )
-
-ENDIF()
-
-IF (Piro_ENABLE_Rythmos)
-  TRIBITS_ADD_EXECUTABLE_AND_TEST(
-    RythmosSolver_UnitTests
-    SOURCES
-    Piro_RythmosSolver_UnitTests.cpp
-    ${TEUCHOS_STD_UNIT_TEST_MAIN}
-    Piro_Test_ThyraSupport.hpp
-    MockModelEval_A.hpp
-    MockModelEval_A.cpp
-    NUM_MPI_PROCS 1-4
-    STANDARD_PASS_OUTPUT
-  )
-
-  TRIBITS_ADD_EXECUTABLE_AND_TEST(
-    Epetra_RythmosSolver_UnitTests
-    SOURCES
-    Piro_Epetra_RythmosSolver_UnitTests.cpp
-    ${TEUCHOS_STD_UNIT_TEST_MAIN}
-    Piro_Test_EpetraSupport.hpp
-    MockModelEval_A.hpp
-    MockModelEval_A.cpp
-    NUM_MPI_PROCS 1-4
-    STANDARD_PASS_OUTPUT
-  )
-ENDIF (Piro_ENABLE_Rythmos)
+ENDIF(Piro_ENABLE_NOX)
 
 IF (Piro_ENABLE_Tempus)
-  TRIBITS_ADD_EXECUTABLE_AND_TEST(
-    TempusSolver_UnitTests
-    SOURCES
-    Piro_TempusSolver_UnitTests.cpp
-    ${TEUCHOS_STD_UNIT_TEST_MAIN}
-    Piro_Test_ThyraSupport.hpp
-    MockModelEval_A.hpp
-    MockModelEval_A.cpp
-    NUM_MPI_PROCS 1-4
-    STANDARD_PASS_OUTPUT
-  )
-  TRIBITS_ADD_EXECUTABLE_AND_TEST(
-    TempusSolverForwardOnly_UnitTests
-    SOURCES
-    Piro_TempusSolverForwardOnly_UnitTests.cpp
-    ${TEUCHOS_STD_UNIT_TEST_MAIN}
-    Piro_Test_ThyraSupport.hpp
-    MockModelEval_A.hpp
-    MockModelEval_A.cpp
-    NUM_MPI_PROCS 1-4
-    STANDARD_PASS_OUTPUT
-  )
-  TRIBITS_ADD_EXECUTABLE_AND_TEST(
-    TempusSolver_SensitivityUnitTests
-    SOURCES
-    Piro_TempusSolver_SensitivityUnitTests.cpp
-    ${TEUCHOS_STD_UNIT_TEST_MAIN}
-    Piro_Test_ThyraSupport.hpp
-    MockModelEval_A.hpp
-    MockModelEval_A.cpp
-    NUM_MPI_PROCS 1
-    STANDARD_PASS_OUTPUT
-  )
-  TRIBITS_ADD_TEST(
-    TempusSolver_SensitivityUnitTests
-    NUM_MPI_PROCS 4
-    STANDARD_PASS_OUTPUT
-  )
   TRIBITS_ADD_EXECUTABLE_AND_TEST(
     TempusSolver_SensitivitySinCosUnitTests
     SOURCES
@@ -285,6 +63,7 @@ IF (Piro_ENABLE_Tempus)
     NUM_MPI_PROCS 1-4
     STANDARD_PASS_OUTPUT
   )
+
   TRIBITS_ADD_EXECUTABLE_AND_TEST(
     TempusSolver_AdjointSensitivitySinCosUnitTests
     SOURCES
@@ -296,4 +75,247 @@ IF (Piro_ENABLE_Tempus)
     NUM_MPI_PROCS 1-4
     STANDARD_PASS_OUTPUT
   )
+
 ENDIF (Piro_ENABLE_Tempus)
+
+TRIBITS_COPY_FILES_TO_BINARY_DIR(copyTestInputFiles
+  DEST_FILES   
+        input_Solve_NOX_Thyra.xml
+        input_Analysis_ROL_Tpetra.xml
+        input_Analysis_ROL_ReducedSpace_NOXSolver_Tpetra.xml
+        input_Analysis_ROL_ReducedSpace_Tpetra.xml
+        input_Analysis_ROL_FullSpace_Tpetra.xml
+        input_Analysis_ROL_AdjointSensitivities_Tpetra.xml
+        input_Analysis_ROL_AdjointSensitivities_ReducedSpace_NOXSolver_Tpetra.xml
+        input_Analysis_ROL_AdjointSensitivities_FullSpace_Tpetra.xml
+        input_Tempus_BackwardEuler_SinCos.xml 
+  SOURCE_DIR   ${PACKAGE_SOURCE_DIR}/test
+  SOURCE_PREFIX "_"
+  EXEDEPS ${ThyraSolverTpetra_EXENAME} ${AnalysisDriverTpetra_EXENAME}
+)
+
+
+IF (Piro_ENABLE_Epetra)
+
+  TRIBITS_ADD_EXECUTABLE_AND_TEST(
+    UnitTests
+    SOURCES
+    Piro_UnitTests.cpp
+    ${TEUCHOS_STD_UNIT_TEST_MAIN}
+    MockModelEval_A.cpp
+    MockModelEval_A.hpp
+    MockModelEval_C.cpp
+    MockModelEval_C.hpp
+    MockModelEval_D.cpp
+    MockModelEval_D.hpp
+    NUM_MPI_PROCS 1
+    STANDARD_PASS_OUTPUT
+  )
+
+  TRIBITS_ADD_EXECUTABLE_AND_TEST(
+    Epetra_MatrixFreeOperator_UnitTests
+    SOURCES
+    Piro_Epetra_MatrixFreeOperator_UnitTests.cpp
+    ${TEUCHOS_STD_UNIT_TEST_MAIN}
+    Piro_Test_EpetraSupport.hpp
+    MockModelEval_A.hpp
+    MockModelEval_A.cpp
+    NUM_MPI_PROCS 1-4
+    STANDARD_PASS_OUTPUT
+  )
+
+  TRIBITS_ADD_EXECUTABLE_AND_TEST(
+    MatrixFreeDecorator_UnitTests
+    SOURCES
+    Piro_MatrixFreeDecorator_UnitTests.cpp
+    ${TEUCHOS_STD_UNIT_TEST_MAIN}
+    Piro_Test_ThyraSupport.hpp
+    MockModelEval_A.hpp
+    MockModelEval_A.cpp
+    NUM_MPI_PROCS 1-4
+    STANDARD_PASS_OUTPUT
+  )
+
+  TRIBITS_ADD_EXECUTABLE_AND_TEST(
+    EvalModel
+    SOURCES
+    Main_EvalModel.cpp
+    MockModelEval_A.cpp
+    MockModelEval_A.hpp
+    NUM_MPI_PROCS 1-4
+    ARGS -v
+    PASS_REGULAR_EXPRESSION "TEST PASSED"
+  )
+
+  IF (Piro_ENABLE_NOX)
+
+    TRIBITS_ADD_EXECUTABLE_AND_TEST(
+      ThyraSolver
+      SOURCES
+      Main_ThyraSolver.cpp
+      MockModelEval_A.cpp
+      MockModelEval_A.hpp
+      NUM_MPI_PROCS 1-4
+      ARGS -v
+      PASS_REGULAR_EXPRESSION "TEST PASSED"
+      ADDED_EXE_TARGET_NAME_OUT ThyraSolver_NAME
+    )
+
+    TRIBITS_ADD_EXECUTABLE_AND_TEST(
+      AnalysisDriver
+      SOURCES
+      Main_AnalysisDriver.cpp
+      MockModelEval_A.cpp
+      MockModelEval_A.hpp
+      ObserveSolution_Epetra.hpp
+      NUM_MPI_PROCS 1-4
+      ARGS -v
+      PASS_REGULAR_EXPRESSION "TEST PASSED"
+    )
+  
+
+    TRIBITS_ADD_EXECUTABLE_AND_TEST(
+      SecondOrderIntegrator
+      SOURCES
+      Main_SecondOrderIntegrator.cpp
+      MockModelEval_B.cpp
+      MockModelEval_B.hpp
+      ObserveSolution_Epetra.hpp
+      NUM_MPI_PROCS 1
+      ARGS -v
+      PASS_REGULAR_EXPRESSION "TEST PASSED"
+    )
+
+    TRIBITS_ADD_EXECUTABLE_AND_TEST(
+      NOXSolver_UnitTests
+      SOURCES
+      Piro_NOXSolver_UnitTests.cpp
+      ${TEUCHOS_STD_UNIT_TEST_MAIN}
+      MockModelEval_A.cpp
+      MockModelEval_A.hpp
+      Piro_Test_ThyraSupport.hpp
+      Piro_Test_WeakenedModelEvaluator.hpp
+      Piro_Test_MockObserver.hpp
+      NUM_MPI_PROCS 1-4
+      STANDARD_PASS_OUTPUT
+    )
+
+    TRIBITS_ADD_EXECUTABLE_AND_TEST(
+      LOCASolver_UnitTests
+      SOURCES
+      Piro_LOCASolver_UnitTests.cpp
+      ${TEUCHOS_STD_UNIT_TEST_MAIN}
+      MockModelEval_A.cpp
+      MockModelEval_A.hpp
+      Piro_Test_ThyraSupport.hpp
+      NUM_MPI_PROCS 1-4
+      STANDARD_PASS_OUTPUT
+    )
+
+    IF (ThyraSolver_NAME)
+     SET(ThyraSolver_EXENAME ThyraSolver)
+    ELSE()
+     SET(ThyraSolver_EXENAME)
+    ENDIF()
+
+  ENDIF(Piro_ENABLE_NOX)
+
+  IF (Piro_ENABLE_Rythmos)
+    TRIBITS_ADD_EXECUTABLE_AND_TEST(
+      RythmosSolver_UnitTests
+      SOURCES
+      Piro_RythmosSolver_UnitTests.cpp
+      ${TEUCHOS_STD_UNIT_TEST_MAIN}
+      Piro_Test_ThyraSupport.hpp
+      MockModelEval_A.hpp
+      MockModelEval_A.cpp
+      NUM_MPI_PROCS 1-4
+      STANDARD_PASS_OUTPUT
+    )
+
+    TRIBITS_ADD_EXECUTABLE_AND_TEST(
+      Epetra_RythmosSolver_UnitTests
+      SOURCES
+      Piro_Epetra_RythmosSolver_UnitTests.cpp
+      ${TEUCHOS_STD_UNIT_TEST_MAIN}
+      Piro_Test_EpetraSupport.hpp
+      MockModelEval_A.hpp
+      MockModelEval_A.cpp
+      NUM_MPI_PROCS 1-4
+      STANDARD_PASS_OUTPUT
+    )
+  ENDIF (Piro_ENABLE_Rythmos)
+
+  IF (Piro_ENABLE_Tempus)
+    TRIBITS_ADD_EXECUTABLE_AND_TEST(
+      TempusSolver_UnitTests
+      SOURCES
+      Piro_TempusSolver_UnitTests.cpp
+      ${TEUCHOS_STD_UNIT_TEST_MAIN}
+      Piro_Test_ThyraSupport.hpp
+      MockModelEval_A.hpp
+      MockModelEval_A.cpp
+      NUM_MPI_PROCS 1-4
+      STANDARD_PASS_OUTPUT
+    )
+    TRIBITS_ADD_EXECUTABLE_AND_TEST(
+      TempusSolverForwardOnly_UnitTests
+      SOURCES
+      Piro_TempusSolverForwardOnly_UnitTests.cpp
+      ${TEUCHOS_STD_UNIT_TEST_MAIN}
+      Piro_Test_ThyraSupport.hpp
+      MockModelEval_A.hpp
+      MockModelEval_A.cpp
+      NUM_MPI_PROCS 1-4
+      STANDARD_PASS_OUTPUT
+    )
+    TRIBITS_ADD_EXECUTABLE_AND_TEST(
+      TempusSolver_SensitivityUnitTests
+      SOURCES
+      Piro_TempusSolver_SensitivityUnitTests.cpp
+      ${TEUCHOS_STD_UNIT_TEST_MAIN}
+      Piro_Test_ThyraSupport.hpp
+      MockModelEval_A.hpp
+      MockModelEval_A.cpp
+      NUM_MPI_PROCS 1
+      STANDARD_PASS_OUTPUT
+    )
+    TRIBITS_ADD_TEST(
+      TempusSolver_SensitivityUnitTests
+      NUM_MPI_PROCS 4
+      STANDARD_PASS_OUTPUT
+    )
+    
+  ENDIF (Piro_ENABLE_Tempus)
+
+  TRIBITS_COPY_FILES_TO_BINARY_DIR(copyEpetraTestInputFiles
+    DEST_FILES   input_Solve_NOX_1.xml
+                 input_Solve_NOX_2.xml
+                 input_Solve_NOX_3.xml                 
+		         input_Solve_NOX_Adjoint.xml
+                 input_Solve_LOCA_1.xml
+                 input_Solve_Rythmos_1.xml
+                 input_Solve_Rythmos_1new.xml
+                 input_Solve_Rythmos_2.xml
+                 input_Solve_RythmosSolver_2.xml
+                 input_Solve_VV.xml
+                 input_Solve_TR.xml
+                 input_Solve_NB.xml
+                 input_Analysis_Dakota.xml dak.in
+                 input_Solve_RythmosMatrixFree_Fails.xml
+	             input_SGSolve.xml
+	             input_problem1.xml
+	             input_problem2.xml
+	             input_coupled.xml
+	             input_problem1_sg.xml
+	             input_problem2_sg.xml
+	             input_coupled_sg.xml
+	             input_SGAnalysis.xml
+	             dakota_sg.in
+	             dakota_sg_target.txt
+    SOURCE_DIR   ${PACKAGE_SOURCE_DIR}/test
+    SOURCE_PREFIX "_"
+    EXEDEPS ${ThyraSolver_EXENAME} AnalysisDriver UnitTests NOXSolver_UnitTests
+  )
+
+ENDIF(Piro_ENABLE_Epetra)

--- a/packages/piro/test/Main_ThyraSolver_Tpetra.cpp
+++ b/packages/piro/test/Main_ThyraSolver_Tpetra.cpp
@@ -94,7 +94,7 @@ int main(int argc, char *argv[]) {
         if (doAll) {
             switch (iTest) {
                 case 0:
-                    inputFile = "input_Solve_NOX_4.xml";
+                    inputFile = "input_Solve_NOX_Thyra.xml";
                     break;
                 default:
                     std::cout << "iTest logic error " << std::endl;

--- a/packages/piro/test/_input_Analysis_ROL_AdjointSensitivities_FullSpace_Tpetra.xml
+++ b/packages/piro/test/_input_Analysis_ROL_AdjointSensitivities_FullSpace_Tpetra.xml
@@ -42,20 +42,8 @@
             <ParameterList name="NOX Stratimikos Options">
             </ParameterList>
             <ParameterList name="Stratimikos">
-              <Parameter name="Linear Solver Type" type="string" value="AztecOO" />
+              <Parameter name="Linear Solver Type" type="string" value="Belos" />
               <ParameterList name="Linear Solver Types">
-                <ParameterList name="AztecOO">
-                  <ParameterList name="Forward Solve">
-                    <ParameterList name="AztecOO Settings">
-                      <Parameter name="Aztec Solver" type="string" value="GMRES" />
-                      <Parameter name="Convergence Test" type="string" value="r0" />
-                      <Parameter name="Size of Krylov Subspace" type="int" value="200" />
-                      <Parameter name="Output Frequency" type="int" value="10" />
-                    </ParameterList>
-                    <Parameter name="Max Iterations" type="int" value="200" />
-                    <Parameter name="Tolerance" type="double" value="1e-5" />
-                  </ParameterList>
-                </ParameterList>
                 <ParameterList name="Belos">
                   <Parameter name="Solver Type" type="string" value="Block GMRES" />
                   <ParameterList name="Solver Types">
@@ -69,6 +57,9 @@
                       <Parameter name="Num Blocks" type="int" value="20" />
                       <Parameter name="Flexible Gmres" type="bool" value="0" />
                     </ParameterList>
+                  </ParameterList>
+                  <ParameterList name="VerboseObject">
+                    <Parameter name="Verbosity Level" type="string" value="low" />
                   </ParameterList>
                 </ParameterList>
               </ParameterList>

--- a/packages/piro/test/_input_Analysis_ROL_AdjointSensitivities_ReducedSpace_NOXSolver_Tpetra.xml
+++ b/packages/piro/test/_input_Analysis_ROL_AdjointSensitivities_ReducedSpace_NOXSolver_Tpetra.xml
@@ -42,20 +42,8 @@
             <ParameterList name="NOX Stratimikos Options">
             </ParameterList>
             <ParameterList name="Stratimikos">
-              <Parameter name="Linear Solver Type" type="string" value="AztecOO" />
+              <Parameter name="Linear Solver Type" type="string" value="Belos" />
               <ParameterList name="Linear Solver Types">
-                <ParameterList name="AztecOO">
-                  <ParameterList name="Forward Solve">
-                    <ParameterList name="AztecOO Settings">
-                      <Parameter name="Aztec Solver" type="string" value="GMRES" />
-                      <Parameter name="Convergence Test" type="string" value="r0" />
-                      <Parameter name="Size of Krylov Subspace" type="int" value="200" />
-                      <Parameter name="Output Frequency" type="int" value="10" />
-                    </ParameterList>
-                    <Parameter name="Max Iterations" type="int" value="200" />
-                    <Parameter name="Tolerance" type="double" value="1e-5" />
-                  </ParameterList>
-                </ParameterList>
                 <ParameterList name="Belos">
                   <Parameter name="Solver Type" type="string" value="Block GMRES" />
                   <ParameterList name="Solver Types">
@@ -69,6 +57,9 @@
                       <Parameter name="Num Blocks" type="int" value="20" />
                       <Parameter name="Flexible Gmres" type="bool" value="0" />
                     </ParameterList>
+                  </ParameterList>
+                  <ParameterList name="VerboseObject">
+                    <Parameter name="Verbosity Level" type="string" value="low" />
                   </ParameterList>
                 </ParameterList>
               </ParameterList>

--- a/packages/piro/test/_input_Analysis_ROL_AdjointSensitivities_Tpetra.xml
+++ b/packages/piro/test/_input_Analysis_ROL_AdjointSensitivities_Tpetra.xml
@@ -42,20 +42,8 @@
             <ParameterList name="NOX Stratimikos Options">
             </ParameterList>
             <ParameterList name="Stratimikos">
-              <Parameter name="Linear Solver Type" type="string" value="AztecOO" />
+              <Parameter name="Linear Solver Type" type="string" value="Belos" />
               <ParameterList name="Linear Solver Types">
-                <ParameterList name="AztecOO">
-                  <ParameterList name="Forward Solve">
-                    <ParameterList name="AztecOO Settings">
-                      <Parameter name="Aztec Solver" type="string" value="GMRES" />
-                      <Parameter name="Convergence Test" type="string" value="r0" />
-                      <Parameter name="Size of Krylov Subspace" type="int" value="200" />
-                      <Parameter name="Output Frequency" type="int" value="10" />
-                    </ParameterList>
-                    <Parameter name="Max Iterations" type="int" value="200" />
-                    <Parameter name="Tolerance" type="double" value="1e-5" />
-                  </ParameterList>
-                </ParameterList>
                 <ParameterList name="Belos">
                   <Parameter name="Solver Type" type="string" value="Block GMRES" />
                   <ParameterList name="Solver Types">
@@ -70,6 +58,9 @@
                       <Parameter name="Flexible Gmres" type="bool" value="0" />
                     </ParameterList>
                   </ParameterList>
+                  <ParameterList name="VerboseObject">
+                    <Parameter name="Verbosity Level" type="string" value="low" />
+                  </ParameterList>
                 </ParameterList>
               </ParameterList>
               <Parameter name="Preconditioner Type" type="string" value="Ifpack2" />
@@ -77,6 +68,11 @@
                 <ParameterList name="Ifpack2">
                   <Parameter name="Overlap" type="int" value="1" />
                   <Parameter name="Prec Type" type="string" value="RILUK" />
+                  <ParameterList name="Ifpack2 Settings">
+                    <Parameter name="fact: drop tolerance" type="double" value="0" />
+                    <Parameter name="fact: iluk level-of-fill" type="int" value="0" />
+                    <Parameter name="fact: level-of-fill" type="int" value="1" />
+                  </ParameterList>
                 </ParameterList>
               </ParameterList>
             </ParameterList>

--- a/packages/piro/test/_input_Analysis_ROL_FullSpace_Tpetra.xml
+++ b/packages/piro/test/_input_Analysis_ROL_FullSpace_Tpetra.xml
@@ -41,20 +41,8 @@
             <ParameterList name="NOX Stratimikos Options">
             </ParameterList>
             <ParameterList name="Stratimikos">
-              <Parameter name="Linear Solver Type" type="string" value="AztecOO" />
+              <Parameter name="Linear Solver Type" type="string" value="Belos" />
               <ParameterList name="Linear Solver Types">
-                <ParameterList name="AztecOO">
-                  <ParameterList name="Forward Solve">
-                    <ParameterList name="AztecOO Settings">
-                      <Parameter name="Aztec Solver" type="string" value="GMRES" />
-                      <Parameter name="Convergence Test" type="string" value="r0" />
-                      <Parameter name="Size of Krylov Subspace" type="int" value="200" />
-                      <Parameter name="Output Frequency" type="int" value="10" />
-                    </ParameterList>
-                    <Parameter name="Max Iterations" type="int" value="200" />
-                    <Parameter name="Tolerance" type="double" value="1e-5" />
-                  </ParameterList>
-                </ParameterList>
                 <ParameterList name="Belos">
                   <Parameter name="Solver Type" type="string" value="Block GMRES" />
                   <ParameterList name="Solver Types">
@@ -68,6 +56,9 @@
                       <Parameter name="Num Blocks" type="int" value="20" />
                       <Parameter name="Flexible Gmres" type="bool" value="0" />
                     </ParameterList>
+                  </ParameterList>
+                  <ParameterList name="VerboseObject">
+                    <Parameter name="Verbosity Level" type="string" value="low" />
                   </ParameterList>
                 </ParameterList>
               </ParameterList>

--- a/packages/piro/test/_input_Analysis_ROL_ReducedSpace_NOXSolver_Tpetra.xml
+++ b/packages/piro/test/_input_Analysis_ROL_ReducedSpace_NOXSolver_Tpetra.xml
@@ -41,20 +41,8 @@
             <ParameterList name="NOX Stratimikos Options">
             </ParameterList>
             <ParameterList name="Stratimikos">
-              <Parameter name="Linear Solver Type" type="string" value="AztecOO" />
+              <Parameter name="Linear Solver Type" type="string" value="Belos" />
               <ParameterList name="Linear Solver Types">
-                <ParameterList name="AztecOO">
-                  <ParameterList name="Forward Solve">
-                    <ParameterList name="AztecOO Settings">
-                      <Parameter name="Aztec Solver" type="string" value="GMRES" />
-                      <Parameter name="Convergence Test" type="string" value="r0" />
-                      <Parameter name="Size of Krylov Subspace" type="int" value="200" />
-                      <Parameter name="Output Frequency" type="int" value="10" />
-                    </ParameterList>
-                    <Parameter name="Max Iterations" type="int" value="200" />
-                    <Parameter name="Tolerance" type="double" value="1e-5" />
-                  </ParameterList>
-                </ParameterList>
                 <ParameterList name="Belos">
                   <Parameter name="Solver Type" type="string" value="Block GMRES" />
                   <ParameterList name="Solver Types">
@@ -68,6 +56,9 @@
                       <Parameter name="Num Blocks" type="int" value="20" />
                       <Parameter name="Flexible Gmres" type="bool" value="0" />
                     </ParameterList>
+                  </ParameterList>
+                  <ParameterList name="VerboseObject">
+                    <Parameter name="Verbosity Level" type="string" value="low" />
                   </ParameterList>
                 </ParameterList>
               </ParameterList>

--- a/packages/piro/test/_input_Analysis_ROL_ReducedSpace_Tpetra.xml
+++ b/packages/piro/test/_input_Analysis_ROL_ReducedSpace_Tpetra.xml
@@ -41,20 +41,8 @@
             <ParameterList name="NOX Stratimikos Options">
             </ParameterList>
             <ParameterList name="Stratimikos">
-              <Parameter name="Linear Solver Type" type="string" value="AztecOO" />
+              <Parameter name="Linear Solver Type" type="string" value="Belos" />
               <ParameterList name="Linear Solver Types">
-                <ParameterList name="AztecOO">
-                  <ParameterList name="Forward Solve">
-                    <ParameterList name="AztecOO Settings">
-                      <Parameter name="Aztec Solver" type="string" value="GMRES" />
-                      <Parameter name="Convergence Test" type="string" value="r0" />
-                      <Parameter name="Size of Krylov Subspace" type="int" value="200" />
-                      <Parameter name="Output Frequency" type="int" value="10" />
-                    </ParameterList>
-                    <Parameter name="Max Iterations" type="int" value="200" />
-                    <Parameter name="Tolerance" type="double" value="1e-5" />
-                  </ParameterList>
-                </ParameterList>
                 <ParameterList name="Belos">
                   <Parameter name="Solver Type" type="string" value="Block GMRES" />
                   <ParameterList name="Solver Types">
@@ -68,6 +56,9 @@
                       <Parameter name="Num Blocks" type="int" value="20" />
                       <Parameter name="Flexible Gmres" type="bool" value="0" />
                     </ParameterList>
+                  </ParameterList>
+                  <ParameterList name="VerboseObject">
+                    <Parameter name="Verbosity Level" type="string" value="low" />
                   </ParameterList>
                 </ParameterList>
               </ParameterList>

--- a/packages/piro/test/_input_Analysis_ROL_Tpetra.xml
+++ b/packages/piro/test/_input_Analysis_ROL_Tpetra.xml
@@ -41,20 +41,8 @@
             <ParameterList name="NOX Stratimikos Options">
             </ParameterList>
             <ParameterList name="Stratimikos">
-              <Parameter name="Linear Solver Type" type="string" value="AztecOO" />
+              <Parameter name="Linear Solver Type" type="string" value="Belos" />
               <ParameterList name="Linear Solver Types">
-                <ParameterList name="AztecOO">
-                  <ParameterList name="Forward Solve">
-                    <ParameterList name="AztecOO Settings">
-                      <Parameter name="Aztec Solver" type="string" value="GMRES" />
-                      <Parameter name="Convergence Test" type="string" value="r0" />
-                      <Parameter name="Size of Krylov Subspace" type="int" value="200" />
-                      <Parameter name="Output Frequency" type="int" value="10" />
-                    </ParameterList>
-                    <Parameter name="Max Iterations" type="int" value="200" />
-                    <Parameter name="Tolerance" type="double" value="1e-5" />
-                  </ParameterList>
-                </ParameterList>
                 <ParameterList name="Belos">
                   <Parameter name="Solver Type" type="string" value="Block GMRES" />
                   <ParameterList name="Solver Types">
@@ -68,6 +56,9 @@
                       <Parameter name="Num Blocks" type="int" value="20" />
                       <Parameter name="Flexible Gmres" type="bool" value="0" />
                     </ParameterList>
+                  </ParameterList>
+                  <ParameterList name="VerboseObject">
+                    <Parameter name="Verbosity Level" type="string" value="low" />
                   </ParameterList>
                 </ParameterList>
               </ParameterList>
@@ -155,7 +146,6 @@
         <Parameter name="Error File" type="string" value="dak.err" />
       </ParameterList>
       <ParameterList name="ROL">
-      
         <Parameter name="Response Vector Index" type="int" value="0" />
         <Parameter name="Parameter Vector Index" type="int" value="0" />
         <Parameter name="Print Output" type="bool" value="true" />

--- a/packages/piro/test/_input_Solve_NOX_Thyra.xml
+++ b/packages/piro/test/_input_Solve_NOX_Thyra.xml
@@ -16,20 +16,8 @@
           <ParameterList name="NOX Stratimikos Options">
           </ParameterList>
           <ParameterList name="Stratimikos">
-            <Parameter name="Linear Solver Type" type="string" value="AztecOO" />
+            <Parameter name="Linear Solver Type" type="string" value="Belos" />
             <ParameterList name="Linear Solver Types">
-              <ParameterList name="AztecOO">
-                <ParameterList name="Forward Solve">
-                  <ParameterList name="AztecOO Settings">
-                    <Parameter name="Aztec Solver" type="string" value="GMRES" />
-                    <Parameter name="Convergence Test" type="string" value="r0" />
-                    <Parameter name="Size of Krylov Subspace" type="int" value="200" />
-                    <Parameter name="Output Frequency" type="int" value="10" />
-                  </ParameterList>
-                  <Parameter name="Max Iterations" type="int" value="200" />
-                  <Parameter name="Tolerance" type="double" value="1e-5" />
-                </ParameterList>
-              </ParameterList>
               <ParameterList name="Belos">
                 <Parameter name="Solver Type" type="string" value="Block GMRES" />
                 <ParameterList name="Solver Types">
@@ -38,11 +26,14 @@
                     <Parameter name="Output Frequency" type="int" value="10" />
                     <Parameter name="Output Style" type="int" value="1" />
                     <Parameter name="Verbosity" type="int" value="33" />
-                    <Parameter name="Maximum Iterations" type="int" value="100" />
+                    <Parameter name="Maximum Iterations" type="int" value="200" />
                     <Parameter name="Block Size" type="int" value="1" />
-                    <Parameter name="Num Blocks" type="int" value="20" />
+                    <Parameter name="Num Blocks" type="int" value="4" />
                     <Parameter name="Flexible Gmres" type="bool" value="0" />
                   </ParameterList>
+                </ParameterList>
+                <ParameterList name="VerboseObject">
+                  <Parameter name="Verbosity Level" type="string" value="low" />
                 </ParameterList>
               </ParameterList>
             </ParameterList>


### PR DESCRIPTION
All Piro tests were disabled in a Epetra-free build. 
This PR enables some of them, after implementing minor changes (e.g. use Belos instead of AztecOO) when needed.
In particular it enables Thyra-based NOX unit tests, ROL-based analysis tests and the Tempus-based tests that don't depend on Epetra-based model evaluators.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/piro

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing

Tested both in a Epetra-free build and in a "standard" build.
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->