### PR TITLE
Tpetra: Reduce device-to-host memcpy calls in non-uvm builds

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -2143,6 +2143,16 @@ public:
                        typename row_ptrs_device_view_type::host_mirror_space(),
                        dview);
     }
+
+    // There are common cases where both packed and unpacked views are set to the same array.
+    // Doing this in a single call can reduce dataspace on host, and reduce runtime by
+    // removing a deep_copy from device to host.
+
+    void setRowPtrs(const row_ptrs_device_view_type &dview) {
+      setRowPtrsUnpacked(dview);
+      rowPtrsPacked_dev_ = rowPtrsUnpacked_dev_;
+      rowPtrsPacked_host_ = rowPtrsUnpacked_host_;
+    }
     
     //TODO:  Make private -- matrix shouldn't access directly the guts of graph
   

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -683,8 +683,7 @@ namespace Tpetra {
 
     lclIndsPacked_wdv = local_inds_wdv_type(k_local_graph_.entries);
     lclIndsUnpacked_wdv = lclIndsPacked_wdv;
-    this->setRowPtrsUnpacked(k_local_graph_.row_map);
-    this->setRowPtrsPacked(k_local_graph_.row_map);
+    this->setRowPtrs(k_local_graph_.row_map);
 
     set_need_sync_host_uvm_access(); // lclGraph_ potentially still in a kernel
 
@@ -730,8 +729,7 @@ namespace Tpetra {
 
     lclIndsPacked_wdv = local_inds_wdv_type(lclGraph.entries);
     lclIndsUnpacked_wdv = lclIndsPacked_wdv;
-    setRowPtrsUnpacked(lclGraph.row_map);
-    setRowPtrsPacked(lclGraph.row_map);
+    setRowPtrs(lclGraph.row_map);
 
     set_need_sync_host_uvm_access(); // lclGraph_ potentially still in a kernel
 
@@ -2664,6 +2662,8 @@ namespace Tpetra {
   setAllIndices (const typename local_graph_device_type::row_map_type& rowPointers,
                  const typename local_graph_device_type::entries_type::non_const_type& columnIndices)
   {
+    using ProfilingRegion=Details::ProfilingRegion;
+    ProfilingRegion region ("Tpetra::CrsGraph::setAllIndices");
     const char tfecfFuncName[] = "setAllIndices: ";
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
       ! hasColMap () || getColMap ().is_null (), std::runtime_error,
@@ -2754,8 +2754,7 @@ namespace Tpetra {
     noRedundancies_      = true;
     lclIndsPacked_wdv= local_inds_wdv_type(columnIndices);
     lclIndsUnpacked_wdv          = lclIndsPacked_wdv;
-    setRowPtrsUnpacked(rowPointers);
-    setRowPtrsPacked(rowPointers);
+    setRowPtrs(rowPointers);
 
     set_need_sync_host_uvm_access(); // columnIndices and rowPointers potentially still in a kernel
 
@@ -3652,11 +3651,16 @@ namespace Tpetra {
         }
       }
       // Build the local graph.
-      setRowPtrsPacked(ptr_d_const);
+      if (requestOptimizedStorage)
+        setRowPtrs(ptr_d_const);
+      else
+        setRowPtrsPacked(ptr_d_const);
       lclIndsPacked_wdv = local_inds_wdv_type(ind_d);
     }
     else { // We don't have to pack, so just set the pointers.
-      setRowPtrsPacked(rowPtrsUnpacked_dev_);
+      // Note: The setRowPtrsPacked call has an aditional memcpy to host that we want to avoid
+      rowPtrsPacked_dev_ = rowPtrsUnpacked_dev_;
+      rowPtrsPacked_host_ = rowPtrsUnpacked_host_;
       lclIndsPacked_wdv = lclIndsUnpacked_wdv; 
 
       if (debug_) {
@@ -3708,7 +3712,6 @@ namespace Tpetra {
       k_numRowEntries_ = row_entries_type ();
 
       // Keep the new 1-D packed allocations.
-      setRowPtrsUnpacked(rowPtrsPacked_dev_);
       lclIndsUnpacked_wdv = lclIndsPacked_wdv;
 
       storageStatus_ = Details::STORAGE_1D_PACKED;

--- a/packages/tpetra/core/src/Tpetra_Details_WrappedDualView.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_WrappedDualView.hpp
@@ -167,11 +167,14 @@ public:
     t_host hostView;
     if(deviceView.use_count() != 0)
     {
-      hostView = Kokkos::create_mirror_view_and_copy(
+      hostView = Kokkos::create_mirror_view(
+          Kokkos::WithoutInitializing,
           typename t_host::memory_space(),
           deviceView);
     }
     originalDualView = DualViewType(deviceView, hostView);
+    originalDualView.clear_sync_state();
+    originalDualView.modify_device();
     dualView = originalDualView;
   }
 

--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -217,14 +217,7 @@ namespace { // (anonymous)
          << ".  Please report this bug to the Tpetra developers.");
     }
 
-    dual_view_type dv (d_view, Kokkos::create_mirror_view (d_view));
-    // Whether or not the user cares about the initial contents of the
-    // MultiVector, the device and host views are out of sync.  We
-    // prefer to work in device memory.  The way to ensure this
-    // happens is to mark the device view as modified.
-    dv.modify_device ();
-
-    return wrapped_dual_view_type(dv);
+    return wrapped_dual_view_type(d_view);
   }
 
   // Convert 1-D Teuchos::ArrayView to an unmanaged 1-D host Kokkos::View.

--- a/packages/tpetra/core/test/Block/BlockMultiVector.cpp
+++ b/packages/tpetra/core/test/Block/BlockMultiVector.cpp
@@ -428,7 +428,7 @@ namespace {
     {
       auto X_overlap =
         X.getLocalBlockHost (meshMap.getLocalElement (meshMap.getMinGlobalIndex ()), 
-                         colToModify, Tpetra::Access::OverwriteAll);
+                         colToModify, Tpetra::Access::ReadWrite);
       TEST_ASSERT( X_overlap.data () != NULL );
       TEST_EQUALITY_CONST( static_cast<size_t> (X_overlap.extent (0)),
                            static_cast<size_t> (blockSize) );
@@ -466,6 +466,7 @@ namespace {
              localMeshRow < meshMap.getMaxLocalIndex (); ++localMeshRow) {
           auto Y_cur = Y.getLocalBlockHost (localMeshRow, col,
                                         Tpetra::Access::ReadOnly);
+
           if (col != colToModify) {
             TEST_ASSERT( equal (Y_cur, zeroLittleVector) &&
                          equal (zeroLittleVector, Y_cur) );


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
This results in a decent (up to 3x) performance improvement on non-UVM builds for CUDA/ROCm for problems with large matrices (e.g. >1 GB). Changes include:
- WrappedDualView initialization from device view no longer initializes host dataspace using the device data.
- CrsGraph/CrsMatrix have duplicate calls to copy the same row ptrs view from device to host 5-6 times in a row. This is now reduced to 1 time for trivial constructions (i.e. packed == unpacked).

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->