### PR TITLE
Tpetra: Remove HAVE_TPETRA_THROW_EFFICIENCY_WARNINGS

### DIFF
--- a/packages/tpetra/core/CMakeLists.txt
+++ b/packages/tpetra/core/CMakeLists.txt
@@ -131,13 +131,6 @@ TRIBITS_ADD_OPTION_AND_DEFINE(
   )
 
 TRIBITS_ADD_OPTION_AND_DEFINE(
-  Tpetra_THROW_Efficiency_Warnings
-  HAVE_TPETRA_THROW_EFFICIENCY_WARNINGS
-  "Enable exception throwing for Tpetra efficiency warnings."
-  ${Tpetra_THROW_Warnings}
-  )
-
-TRIBITS_ADD_OPTION_AND_DEFINE(
   Tpetra_PRINT_Efficiency_Warnings
   HAVE_TPETRA_PRINT_EFFICIENCY_WARNINGS
   "Enable printing of Tpetra efficiency warnings."

--- a/packages/tpetra/core/cmake/TpetraCore_config.h.in
+++ b/packages/tpetra/core/cmake/TpetraCore_config.h.in
@@ -43,9 +43,6 @@
 /* Define if want to build tpetra-print_warnings */
 #cmakedefine HAVE_TPETRA_PRINT_WARNINGS
 
-/* Define if want to build tpetra-throw_efficiency_warnings */
-#cmakedefine HAVE_TPETRA_THROW_EFFICIENCY_WARNINGS
-
 /* Define if want to build tpetra-print_efficiency_warnings */
 #cmakedefine HAVE_TPETRA_PRINT_EFFICIENCY_WARNINGS
 

--- a/packages/tpetra/core/src/Tpetra_ConfigDefs.hpp
+++ b/packages/tpetra/core/src/Tpetra_ConfigDefs.hpp
@@ -52,12 +52,6 @@ namespace Tpetra {
 }
 
 // these make some of the macros in Tpetra_Util.hpp much easier to describe
-#ifdef HAVE_TPETRA_THROW_EFFICIENCY_WARNINGS
-  #define TPETRA_THROWS_EFFICIENCY_WARNINGS 1
-#else
-  #define TPETRA_THROWS_EFFICIENCY_WARNINGS 0
-#endif
-
 #ifdef HAVE_TPETRA_PRINT_EFFICIENCY_WARNINGS
   #define TPETRA_PRINTS_EFFICIENCY_WARNINGS 1
 #else

--- a/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.cpp
@@ -139,7 +139,6 @@ size_t DistributorPlan::createFromSends(const Teuchos::ArrayView<const int>& exp
   // However, if they do not provide an efficient pattern, we will
   // warn them if one of the following compile-time options has been
   // set:
-  //   * HAVE_TPETRA_THROW_EFFICIENCY_WARNINGS
   //   * HAVE_TPETRA_PRINT_EFFICIENCY_WARNINGS
   //
   // If the data are contiguous, then we can post the sends in situ
@@ -201,13 +200,13 @@ size_t DistributorPlan::createFromSends(const Teuchos::ArrayView<const int>& exp
     }
   }
 
-#if defined(HAVE_TPETRA_THROW_EFFICIENCY_WARNINGS) || defined(HAVE_TPETRA_PRINT_EFFICIENCY_WARNINGS)
+#if defined(HAVE_TPETRA_PRINT_EFFICIENCY_WARNINGS)
   {
     int global_needSendBuff;
     reduceAll<int, int> (*comm_, REDUCE_MAX, needSendBuff,
         outArg (global_needSendBuff));
     TPETRA_EFFICIENCY_WARNING(
-        global_needSendBuff != 0, std::runtime_error,
+        global_needSendBuff != 0,
         "::createFromSends: Grouping export IDs together by process rank often "
         "improves performance.");
   }

--- a/packages/tpetra/core/src/Tpetra_Util.hpp
+++ b/packages/tpetra/core/src/Tpetra_Util.hpp
@@ -63,15 +63,11 @@
 #include <ostream>
 #include <sstream>
 
-#if defined(HAVE_TPETRA_THROW_EFFICIENCY_WARNINGS) || defined(HAVE_TPETRA_PRINT_EFFICIENCY_WARNINGS)
+#if defined(HAVE_TPETRA_PRINT_EFFICIENCY_WARNINGS)
 /// \brief Print or throw an efficency warning.
 ///
 /// This macro is only for use by Tpetra developers.  It is only to be
 /// used in the implementation of a Tpetra class' instance method.
-///
-/// If HAVE_TPETRA_THROW_EFFICIENCY_WARNINGS is defined, throw an
-/// exception of type Exception, whose exception message will include
-/// \c msg (along with other useful information).
 ///
 /// If HAVE_TPETRA_PRINT_EFFICIENCY_WARNINGS is defined, print the
 /// given message to std::cerr, along with other useful information.
@@ -86,18 +82,13 @@
 /// throw_exception_test: Boolean expression to evaluate.  If true,
 /// this macro will trigger the efficiency warning.  The test will be
 /// evaluated at most once.  Nevertheless, the test should not have
-/// side effects, since it will not be evaluated at all if neither
-/// HAVE_TPETRA_THROW_EFFICIENCY_WARNINGS nor
-/// HAVE_TPETRA_PRINT_EFFICIENCY_WARNINGS are defined.
-///
-/// Exception: The type of exception to throw, if throw_exception_test
-/// evaluates to true and TPETRA_THROWS_EFFICIENCY_WARNINGS is
-/// defined.  The Exception should be a subclass of std::exception.
+/// side effects, since it will not be evaluated at all if
+/// HAVE_TPETRA_PRINT_EFFICIENCY_WARNINGS is defined.
 ///
 /// msg: The message to include in the warning.  The warning also
 /// includes the name of the class, and other useful information.
 ///
-#define TPETRA_EFFICIENCY_WARNING(throw_exception_test,Exception,msg)  \
+#define TPETRA_EFFICIENCY_WARNING(throw_exception_test,msg)  \
 { \
   const bool tpetraEfficiencyWarningTest = (throw_exception_test); \
   if (tpetraEfficiencyWarningTest) { \
@@ -109,7 +100,6 @@
     if (TPETRA_PRINTS_EFFICIENCY_WARNINGS && tpetraEfficiencyWarningTest) { \
       std::cerr << err << std::endl; \
     } \
-    TEUCHOS_TEST_FOR_EXCEPTION(TPETRA_THROWS_EFFICIENCY_WARNINGS && tpetraEfficiencyWarningTest, Exception, err); \
   } \
 }
 #else
@@ -117,10 +107,6 @@
 ///
 /// This macro is only for use by Tpetra developers.  It is only to be
 /// used in the implementation of a Tpetra class' instance method.
-///
-/// If HAVE_TPETRA_THROW_EFFICIENCY_WARNINGS is defined, throw an
-/// exception of type Exception, whose exception message will include
-/// \c msg (along with other useful information).
 ///
 /// If HAVE_TPETRA_PRINT_EFFICIENCY_WARNINGS is defined, print the
 /// given message to std::cerr, along with other useful information.
@@ -136,17 +122,12 @@
 /// this macro will trigger the efficiency warning.  The test will be
 /// evaluated at most once.  Nevertheless, the test should not have
 /// side effects, since it will not be evaluated at all if neither
-/// HAVE_TPETRA_THROW_EFFICIENCY_WARNINGS nor
-/// HAVE_TPETRA_PRINT_EFFICIENCY_WARNINGS are defined.
-///
-/// Exception: The type of exception to throw, if throw_exception_test
-/// evaluates to true and TPETRA_THROWS_EFFICIENCY_WARNINGS is
-/// defined.  The Exception should be a subclass of std::exception.
+/// HAVE_TPETRA_PRINT_EFFICIENCY_WARNINGS is defined.
 ///
 /// msg: The message to include in the warning.  The warning also
 /// includes the name of the class, and other useful information.
 ///
-#define TPETRA_EFFICIENCY_WARNING(throw_exception_test,Exception,msg)
+#define TPETRA_EFFICIENCY_WARNING(throw_exception_test,msg)
 #endif
 
 // handle an abuse warning, according to HAVE_TPETRA_THROW_ABUSE_WARNINGS and HAVE_TPETRA_PRINT_ABUSE_WARNINGS

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests.cpp
@@ -116,10 +116,6 @@ namespace { // (anonymous)
       MV mv(map,1);
       zero = rcp( new MAT(map,0) );
       TEST_THROW(zero->apply(mv,mv), std::runtime_error);
-#   if defined(HAVE_TPETRA_THROW_EFFICIENCY_WARNINGS)
-      // throw exception because we required increased allocation
-      TEST_THROW(zero->insertGlobalValues(map->getMinGlobalIndex(),tuple<GO>(0),tuple<Scalar>(ST::one())), std::runtime_error);
-#   endif
       zero->fillComplete();
     }
     STD_TESTS((*zero));

--- a/packages/tpetra/core/test/Distributor/Distributor_UnitTests.cpp
+++ b/packages/tpetra/core/test/Distributor/Distributor_UnitTests.cpp
@@ -276,9 +276,6 @@ namespace {
     myOut << "Create Distributor from sends (mix of contiguous and noncontiguous)" << endl;
 
     Distributor distributor(comm);
-#ifdef HAVE_TPETRA_THROW_EFFICIENCY_WARNINGS
-    TEST_THROW( distributor.createFromSends(exportImageIDs), std::runtime_error );
-#else
     TEST_NOTHROW( numImports = distributor.createFromSends(exportImageIDs) );
 
     myOut << "Test the resulting Distributor" << endl;
@@ -632,9 +629,6 @@ namespace {
     myOut << "Create Distributor from noncontiguous sends" << endl;
 
     Distributor distributor(comm);
-#ifdef HAVE_TPETRA_THROW_EFFICIENCY_WARNINGS
-    TEST_THROW( distributor.createFromSends(exportImageIDs), std::runtime_error );
-#else
     numImports = distributor.createFromSends(exportImageIDs);
 
     myOut << "Test the resulting Distributor" << endl;
@@ -846,9 +840,6 @@ namespace {
         }
       }
       Distributor distributor(comm);
-#ifdef HAVE_TPETRA_THROW_EFFICIENCY_WARNINGS
-      TEST_THROW( numRemoteIDs = distributor.createFromSends(exportImageIDs), std::runtime_error );
-#else
       numRemoteIDs = distributor.createFromSends(exportImageIDs);
 
       // Make sure that Distributor output doesn't cause a hang.

--- a/packages/tpetra/core/test/Distributor/Distributor_UnitTests.cpp
+++ b/packages/tpetra/core/test/Distributor/Distributor_UnitTests.cpp
@@ -662,7 +662,6 @@ namespace {
         TEST_EQUALITY_CONST( lenTo[i],   2);
       }
     }
-#endif
 
     myOut << "Make sure that Distributor output doesn't cause a hang" << endl;
     distributor.describe (out, Teuchos::VERB_EXTREME);
@@ -895,7 +894,6 @@ namespace {
       }
       // check the values
       TEST_COMPARE_ARRAYS(expectedImports,imports);
-#endif
       // All procs fail if any proc fails
       int globalSuccess_int = -1;
       reduceAll( *comm, REDUCE_SUM, success ? 0 : 1, outArg(globalSuccess_int) );

--- a/packages/tpetra/core/test/Distributor/Distributor_UnitTests.cpp
+++ b/packages/tpetra/core/test/Distributor/Distributor_UnitTests.cpp
@@ -305,7 +305,6 @@ namespace {
         TEST_EQUALITY_CONST( lenTo[i],   2);
       }
     }
-#endif
 
     myOut << "Make sure that Distributor output doesn't cause a hang" << endl;
     distributor.describe (out, Teuchos::VERB_EXTREME);


### PR DESCRIPTION
Tpetra: Remove HAVE_TPETRA_THROW_EFFICIENCY_WARNINGS macros and associated code

Closes: #11005