### PR TITLE
Teuchos: Fix parallel XML reader to correctly handle special characters

### DIFF
--- a/packages/teuchos/comm/test/ParameterList/ParameterList_UnitTest_Parallel.cpp
+++ b/packages/teuchos/comm/test/ParameterList/ParameterList_UnitTest_Parallel.cpp
@@ -158,6 +158,18 @@ TEUCHOS_UNIT_TEST( Teuchos_ParameterList, rawUpdateAndBroadcastNoOverWrite ) {
 
 }
 
+TEUCHOS_UNIT_TEST( Teuchos_ParameterList, xmlUpdateAndBroadcastSpecialChars ) {
+  const RCP<const Comm<int> > comm = DefaultComm<int>::getComm();
+  // Test that the special characters '&' and '<' are correctly translated from '&amp;' and '&lt;'
+  std::string inputFile="inputSpecialChars.xml";
+  ParameterList A;
+  updateParametersFromXmlFileAndBroadcast(inputFile, outArg(A), *comm);
+  out << "A = " << A;
+  TEST_ASSERT( A.begin() != A.end() ); // Avoid false positive from empty lists
+
+  TEST_EQUALITY( A.get<std::string>("sigma"), "if (x >= 0.0 && y >= 0.0 && x <= 0.5 && y <= 0.5)" );
+}
+
 } // namespace Teuchos
 
 

--- a/packages/teuchos/comm/test/ParameterList/inputSpecialChars.xml
+++ b/packages/teuchos/comm/test/ParameterList/inputSpecialChars.xml
@@ -1,0 +1,5 @@
+<ParameterList name="MueLu">
+
+  <Parameter        name="sigma" type="string"   value="if (x >= 0.0 &amp;&amp; y >= 0.0 &amp;&amp; x &lt;= 0.5 &amp;&amp; y &lt;= 0.5)"/>
+
+</ParameterList>

--- a/packages/teuchos/parameterlist/src/Teuchos_XMLObjectImplem.cpp
+++ b/packages/teuchos/parameterlist/src/Teuchos_XMLObjectImplem.cpp
@@ -210,7 +210,7 @@ std::string XMLObjectImplem::toString() const
   std::string rtn;
   if (content_.length()==0 && children_.length()==0)
   {
-    rtn = terminatedHeader() + "\n";
+    rtn = terminatedHeader(true) + "\n";
   }
   else
   {


### PR DESCRIPTION
@trilinos/teuchos 

## Motivation
Fixes parallel reading XML input decks with special characters in them:
```
<Parameter name="sigma" type="string" value="if (x >= 0.0 &amp;&amp; y >= 0.0 &amp;&amp; x &lt;= 0.5 &amp;&amp; y &lt;= 0.5)"/>
```