### PR TITLE
Frosch : fix how MV is accessed from Kokkos execution space

### DIFF
--- a/packages/shylu/shylu_dd/frosch/src/CoarseSpaces/FROSch_CoarseSpace_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/CoarseSpaces/FROSch_CoarseSpace_def.hpp
@@ -141,8 +141,8 @@ namespace FROSch {
 
                             Kokkos::RangePolicy<execution_space> policy (0, LocalLength_i);
                             // Xpetra wrapper for Tpetra MV
-                            auto unassembledXTpetraMVector = rcp_dynamic_cast<const TpetraMultiVector<SC,LO,GO,NO>>(UnassembledSubspaceBases_[i]);
-                            auto   assembledXTpetraMVector = rcp_dynamic_cast<      TpetraMultiVector<SC,LO,GO,NO>>(AssembledBasis_);
+                            auto unassembledXTpetraMVector = rcp_dynamic_cast<const TpetraMultiVector<SC,LO,GO,NO>>(UnassembledSubspaceBases_[i], true);
+                            auto   assembledXTpetraMVector = rcp_dynamic_cast<      TpetraMultiVector<SC,LO,GO,NO>>(AssembledBasis_, true);
                             // Tpetra MV
                             auto unassembledTpetraMVector = unassembledXTpetraMVector->getTpetra_MultiVector();
                             auto   assembledTpetraMVector = assembledXTpetraMVector->getTpetra_MultiVector();

--- a/packages/shylu/shylu_dd/frosch/src/CoarseSpaces/FROSch_CoarseSpace_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/CoarseSpaces/FROSch_CoarseSpace_def.hpp
@@ -129,6 +129,7 @@ namespace FROSch {
                 #if defined(HAVE_XPETRA_KOKKOS_REFACTOR) && defined(HAVE_XPETRA_TPETRA)
                 if (AssembledBasis_->getMap()->lib() == UseTpetra) {
                     UN itmp = 0;
+                    using execution_space = typename XMap::local_map_type::execution_space;
                     for (UN i=0; i<UnassembledSubspaceBases_.size(); i++) {
                         if (!UnassembledSubspaceBases_[i].is_null()) {
                             const UN Offset_i = Offsets_[i];
@@ -138,16 +139,21 @@ namespace FROSch {
                             FROSCH_ASSERT(NumVectors_i+itmp <= AssembledBasis_->getNumVectors(),"FROSch::CoarseSpace: NumVectors_i+itmp <= AssembledBasis_->getNumVectors()");
                             FROSCH_ASSERT(LocalLength_i+Offsets_[i] <= AssembledBasis_->getLocalLength(),"FROSch::CoarseSpace: LocalLength_i+Offsets_[i] <= AssembledBasis_");
 
+                            Kokkos::RangePolicy<execution_space> policy (0, LocalLength_i);
+                            // Xpetra wrapper for Tpetra MV
+                            auto unassembledXTpetraMVector = rcp_dynamic_cast<const TpetraMultiVector<SC,LO,GO,NO>>(UnassembledSubspaceBases_[i]);
+                            auto   assembledXTpetraMVector = rcp_dynamic_cast<      TpetraMultiVector<SC,LO,GO,NO>>(AssembledBasis_);
+                            // Tpetra MV
+                            auto unassembledTpetraMVector = unassembledXTpetraMVector->getTpetra_MultiVector();
+                            auto   assembledTpetraMVector = assembledXTpetraMVector->getTpetra_MultiVector();
+                            // Views
+                            auto unassembledView = unassembledTpetraMVector->getLocalViewDevice(Tpetra::Access::ReadOnly);
+                            auto   assembledView =   assembledTpetraMVector->getLocalViewDevice(Tpetra::Access::ReadWrite);
                             for (UN j=0; j < NumVectors_i; j++) {
-                                auto unassembledSubspaceBasesData = UnassembledSubspaceBases_[i]->getData(j).getRawPtr();
-                                auto   assembledSubspaceBasesData = AssembledBasis_->getDataNonConst(itmp+j);
-
-                                using execution_space = typename XMap::local_map_type::execution_space;
-                                Kokkos::RangePolicy<execution_space> policy (0, LocalLength_i);
                                 Kokkos::parallel_for(
                                     "FROSch_CoarseSpace::assembleCoarseSpace", policy,
                                     KOKKOS_LAMBDA(const UN k) {
-                                        assembledSubspaceBasesData[k+Offset_i] = unassembledSubspaceBasesData[k];
+                                        assembledView(k+Offset_i, j) = unassembledView(k, j);
                                     });
                             }
                             itmp += NumVectors_i;

--- a/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_HarmonicCoarseOperator_decl.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_HarmonicCoarseOperator_decl.hpp
@@ -132,23 +132,25 @@ namespace FROSch {
         ConstXMapPtr computeCoarseSpace(CoarseSpacePtr coarseSpace);
 
         #if defined(HAVE_XPETRA_KOKKOS_REFACTOR) && defined(HAVE_XPETRA_TPETRA)
-        template<class GOIndView>
-        struct CopyPhiDataFunctor
+        template<class GOIndView, class ConstSCView, class SCView>
+        struct CopyPhiViewFunctor
         {
-            CopyPhiDataFunctor(SCVecPtr data_out_, ConstSCVecPtr data_in_, GOIndView indices_) :
-            data_out(data_out_),
+            CopyPhiViewFunctor(UN j_, GOIndView indices_, ConstSCView data_in_, SCView data_out_) :
+            j(j_),
+            indices (indices_),
             data_in (data_in_),
-            indices (indices_)
+            data_out(data_out_)
             {}
 
             KOKKOS_INLINE_FUNCTION
             void operator()(const int k) const {
-                data_out[indices[k]] = data_in[k];
+                data_out(indices(k), j) = data_in(k, j);
             }
 
-            SCVecPtr      data_out;
-            ConstSCVecPtr data_in;
-            GOIndView     indices;
+            UN          j;
+            GOIndView   indices;
+            ConstSCView data_in;
+            SCView      data_out;
         };
         #endif
 

--- a/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_HarmonicCoarseOperator_decl.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_HarmonicCoarseOperator_decl.hpp
@@ -135,21 +135,23 @@ namespace FROSch {
         template<class GOIndView, class ConstSCView, class SCView>
         struct CopyPhiViewFunctor
         {
-            CopyPhiViewFunctor(UN j_, GOIndView indices_, ConstSCView data_in_, SCView data_out_) :
-            j(j_),
+            CopyPhiViewFunctor(UN j_in_, GOIndView indices_, ConstSCView data_in_, UN j_out_, SCView data_out_) :
+            j_in(j_in_),
             indices (indices_),
             data_in (data_in_),
+            j_out(j_out_),
             data_out(data_out_)
             {}
 
             KOKKOS_INLINE_FUNCTION
             void operator()(const int k) const {
-                data_out(indices(k), j) = data_in(k, j);
+                data_out(indices(k), j_out) = data_in(k, j_in);
             }
 
-            UN          j;
+            UN          j_in;
             GOIndView   indices;
             ConstSCView data_in;
+            UN          j_out;
             SCView      data_out;
         };
         #endif

--- a/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_HarmonicCoarseOperator_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_HarmonicCoarseOperator_def.hpp
@@ -814,8 +814,8 @@ namespace FROSch {
                 using SCView       = typename TMVector::dual_view_type::t_dev;
                 using ConstSCView  = typename TMVector::dual_view_type::t_dev::const_type;
                 // Xpetra wrapper for Tpetra MV
-                auto mVPhiIXTpetraMVector = rcp_dynamic_cast<const xTMVector>(mVPhiI);
-                auto mVPhiXTpetraMVector = rcp_dynamic_cast<       xTMVector>(mVPhi);
+                auto mVPhiIXTpetraMVector = rcp_dynamic_cast<const xTMVector>(mVPhiI, true);
+                auto mVPhiXTpetraMVector = rcp_dynamic_cast<       xTMVector>(mVPhi, true);
                 // Tpetra MV
                 auto mVPhiITpetraMVector = mVPhiIXTpetraMVector->getTpetra_MultiVector();
                 auto mVPhiTpetraMVector = mVPhiXTpetraMVector->getTpetra_MultiVector();

--- a/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_HarmonicCoarseOperator_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_HarmonicCoarseOperator_def.hpp
@@ -525,16 +525,16 @@ namespace FROSch {
             for (UN i=0; i<AssembledInterfaceCoarseSpace_->getAssembledBasis()->getLocalLength(); i++) {
                 GOVec indices;
                 SCVec values;
-                for (UN j=0; j<AssembledInterfaceCoarseSpace_->getAssembledBasis()->getNumVectors(); j++) {
-                    valueTmp=AssembledInterfaceCoarseSpace_->getAssembledBasis()->getData(j)[i];
-                    if (fabs(valueTmp)>tresholdDropping) {
-                        indices.push_back(AssembledInterfaceCoarseSpace_->getBasisMap()->getGlobalElement(j));
-                        values.push_back(valueTmp*scale[j]);
-                    }
-                }
                 iD = repeatedMap->getGlobalElement(indicesGammaDofsAll[i]);
-
                 if (rowMap->getLocalElement(iD)!=-1) { // This should prevent duplicate entries on the interface
+                    for (UN j=0; j<AssembledInterfaceCoarseSpace_->getAssembledBasis()->getNumVectors(); j++) {
+                        valueTmp=AssembledInterfaceCoarseSpace_->getAssembledBasis()->getData(j)[i];
+                        if (fabs(valueTmp)>tresholdDropping) {
+                            indices.push_back(AssembledInterfaceCoarseSpace_->getBasisMap()->getGlobalElement(j));
+                            values.push_back(valueTmp*scale[j]);
+                        }
+                    }
+
                     phiGamma->insertGlobalValues(iD,indices(),values());
                 }
             }
@@ -819,11 +819,15 @@ namespace FROSch {
                 // Tpetra MV
                 auto mVPhiITpetraMVector = mVPhiIXTpetraMVector->getTpetra_MultiVector();
                 auto mVPhiTpetraMVector = mVPhiXTpetraMVector->getTpetra_MultiVector();
-                // View
+                // Kokkos-Kernels Views
                 auto mvPhiIView = mVPhiITpetraMVector->getLocalViewDevice(Tpetra::Access::ReadOnly);
                 auto mvPhiView = mVPhiTpetraMVector->getLocalViewDevice(Tpetra::Access::ReadWrite);
+                auto mvPhiICols = Tpetra::getMultiVectorWhichVectors(*mVPhiITpetraMVector);
+                auto mvPhiCols = Tpetra::getMultiVectorWhichVectors(*mVPhiTpetraMVector);
                 for (UN j=0; j<numLocalBlockColumns[i]; j++) {
-                    CopyPhiViewFunctor<GOIndView, ConstSCView, SCView> functor(j, indicesIDofsAllData, mvPhiIView, mvPhiView);
+                    int col_in = mVPhiITpetraMVector->isConstantStride() ? j : mvPhiICols[j];
+                    int col_out = mVPhiTpetraMVector->isConstantStride() ? j : mvPhiCols[j];
+                    CopyPhiViewFunctor<GOIndView, ConstSCView, SCView> functor(col_in, indicesIDofsAllData, mvPhiIView, col_out, mvPhiView);
                     for (UN ii=0; ii<extensionBlocks.size(); ii++) {
                         Kokkos::RangePolicy<execution_space> policy (bound[extensionBlocks[ii]], bound[extensionBlocks[ii]+1]);
                         Kokkos::parallel_for(

--- a/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_OverlappingOperator_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_OverlappingOperator_def.hpp
@@ -137,7 +137,6 @@ namespace FROSch {
                 Kokkos::RangePolicy<execution_space> policy (0, yMap->getLocalNumElements());
 
                 using xTMVector    = Xpetra::TpetraMultiVector<SC,LO,GO,NO>;
-                using TMVector     = Tpetra::MultiVector<SC,LO,GO,NO>;
                 // Xpetra wrapper for Tpetra MV
                 auto yXTpetraMVector = rcp_dynamic_cast<const xTMVector>(YOverlap_, true);
                 auto xXTpetraMVector = rcp_dynamic_cast<      xTMVector>(XTmp_, true);
@@ -147,13 +146,13 @@ namespace FROSch {
                 // View
                 auto yView = yTpetraMVector->getLocalViewDevice(Tpetra::Access::ReadOnly);
                 auto xView = xTpetraMVector->getLocalViewDevice(Tpetra::Access::ReadWrite);
-                for (UN i=0; i<y.getNumVectors(); i++) {
+                for (UN j=0; j<y.getNumVectors(); j++) {
                     Kokkos::parallel_for(
                       "FROSch_OverlappingOperator::applyLocalRestriction", policy,
-                      KOKKOS_LAMBDA(const int j) {
-                        GO gID = yLocalMap.getGlobalElement(j);
+                      KOKKOS_LAMBDA(const int i) {
+                        GO gID = yLocalMap.getGlobalElement(i);
                         LO lID = yLocalOverlapMap.getLocalElement(gID);
-                        xView(j, i) = yView(lID, i);
+                        xView(i, j) = yView(lID, j);
                       });
                 }
                 Kokkos::fence();

--- a/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_OverlappingOperator_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_OverlappingOperator_def.hpp
@@ -139,8 +139,8 @@ namespace FROSch {
                 using xTMVector    = Xpetra::TpetraMultiVector<SC,LO,GO,NO>;
                 using TMVector     = Tpetra::MultiVector<SC,LO,GO,NO>;
                 // Xpetra wrapper for Tpetra MV
-                auto yXTpetraMVector = rcp_dynamic_cast<const xTMVector>(YOverlap_);
-                auto xXTpetraMVector = rcp_dynamic_cast<      xTMVector>(XTmp_);
+                auto yXTpetraMVector = rcp_dynamic_cast<const xTMVector>(YOverlap_, true);
+                auto xXTpetraMVector = rcp_dynamic_cast<      xTMVector>(XTmp_, true);
                 // Tpetra MV
                 auto yTpetraMVector = yXTpetraMVector->getTpetra_MultiVector();
                 auto xTpetraMVector = xXTpetraMVector->getTpetra_MultiVector();


### PR DESCRIPTION
@trilinos/shylu

## Motivation

This PR uses Kokkos::View instead of Teuchos::Array for accessing local part of MultiVector

## Testing

Tested on Spock (not sure how this was not, and still isn't, crashing on my CUDA runs)