### PR TITLE
Tpetra TSQR: fix lwork in LAPACK tester

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -2428,10 +2428,6 @@ opt-set-cmake-var Zoltan_ENABLE_Scotch BOOL FORCE : OFF
 use RHEL7_SEMS_CUDA_UVM_OFF_DISABLES
 use RHEL7_POST
 
-# Additional rhel7_sems-cuda-11.4.2, no-uvm test disables
-opt-set-cmake-var TpetraTSQR_SequentialTsqr_contiguousCacheBlocks_MPI_1_DISABLE BOOL : ON
-opt-set-cmake-var TpetraTSQR_SequentialTsqr_noncontiguousCacheBlocks_MPI_1_DISABLE BOOL : ON
-
 use CUDA11-RUN-SERIAL-TESTS
 
 [rhel7_sems-cuda-11.4.2-sems-gnu-10.1.0-sems-openmpi-4.0.5_release_static_Volta70_no-asan_complex_no-fpic_mpi_pt_no-rdc_uvm_deprecated-on_no-package-enables]


### PR DESCRIPTION
In TSQR's LAPACK wrappers, ``compute_QR`` and ``compute_explicit_Q`` each have their own function to compute the work length (lwork). Since the TSQR test reuses the same work array for both computations, its length needs to be the max of the two lworks. Not just the lwork for ``compute_QR`` since it might be too small to do the explicit Q.

There is already a function ``lworkQueryLapackQr`` to do this max, but it can't be used with cuSOLVER because ``cusolverDnXorgqr_bufferSize`` needs the actual A/tau pointers.

Fixes #10847.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
The actual bug was just in the test.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->