### PR TITLE
Zoltan2: Refactor Adapters API

### DIFF
--- a/packages/zoltan2/core/src/input/Zoltan2_Adapter.hpp
+++ b/packages/zoltan2/core/src/input/Zoltan2_Adapter.hpp
@@ -50,12 +50,17 @@
 #ifndef _ZOLTAN2_ADAPTER_HPP_
 #define _ZOLTAN2_ADAPTER_HPP_
 
+#include "Kokkos_StaticCrsGraph.hpp"
 #include <Kokkos_Core.hpp>
 #include <Zoltan2_Standards.hpp>
 #include <Zoltan2_InputTraits.hpp>
 #include <Zoltan2_PartitioningSolution.hpp>
+#include <fstream>
 
 namespace Zoltan2 {
+
+//template<typename Adapter>
+//class PartitioningSolution;
 
 /*! \brief An enum to identify general types of adapters.
  *
@@ -80,7 +85,7 @@ enum BaseAdapterType {
 
 class BaseAdapterRoot {
 public:
-  virtual ~BaseAdapterRoot() {}; // required virtual declaration
+  virtual ~BaseAdapterRoot() = default; // required virtual declaration
 
   /*! \brief Returns the number of objects on this process
    *
@@ -101,22 +106,43 @@ template <typename User>
   class BaseAdapter : public BaseAdapterRoot {
 
 public:
-  typedef typename InputTraits<User>::lno_t lno_t;
-  typedef typename InputTraits<User>::gno_t gno_t;
-  typedef typename InputTraits<User>::scalar_t scalar_t;
-  typedef typename InputTraits<User>::node_t node_t;
-  typedef typename InputTraits<User>::part_t part_t;
-  typedef typename InputTraits<User>::offset_t offset_t;
+  using lno_t = typename InputTraits<User>::lno_t;
+  using gno_t = typename InputTraits<User>::gno_t;
+  using scalar_t = typename InputTraits<User>::scalar_t;
+  using node_t = typename InputTraits<User>::node_t;
+  using part_t = typename InputTraits<User>::part_t;
+  using offset_t = typename InputTraits<User>::offset_t;
+  using host_t = typename Kokkos::HostSpace::memory_space;
+  using device_t = typename node_t::device_type;
+
+  using ConstIdsDeviceView = Kokkos::View<const gno_t *, device_t>;
+  using ConstIdsHostView = typename ConstIdsDeviceView::HostMirror;
+//  using ConstIdsHostView = typename Kokkos::View<const gno_t *, Kokkos::HostSpace>;
+
+  using IdsDeviceView = Kokkos::View<gno_t *, device_t>;
+  using IdsHostView = typename IdsDeviceView::HostMirror;
+
+  using ConstOffsetsDeviceView = Kokkos::View<const offset_t *, device_t>;
+  using ConstOffsetsHostView = typename ConstOffsetsDeviceView::HostMirror;
+
+  using offsetsDeviceView = Kokkos::View<offset_t *, device_t>;
+  using offsetsHostView = typename offsetsDeviceView::HostMirror;
+
+  using ConstScalarsDeviceView = Kokkos::View<const scalar_t *, device_t>;
+  using ConstScalarsHostView = typename ConstScalarsDeviceView::HostMirror;
+
+  using scalarsDeviceView = Kokkos::View<scalar_t *, device_t>;
+  using scalarsHostView = typename scalarsDeviceView::HostMirror;
+
+  using WeightsDeviceView = Kokkos::View<scalar_t **, device_t>;
+  using WeightsHostView = typename WeightsDeviceView::HostMirror;
 
   /*! \brief Returns the type of adapter.
    */
   virtual enum BaseAdapterType adapterType() const = 0;
 
-  /*! \brief Destructor
-   */
-  virtual ~BaseAdapter() {};
-
   /*! \brief Provide a pointer to this process' identifiers.
+      \deprecated Use \b getIDsHostView instead.
       \param ids will on return point to the list of the global Ids for
         this process.
    */
@@ -124,32 +150,47 @@ public:
     // If adapter does not define getIDsView, getIDsKokkosView is called.
     // If adapter does not define getIDsKokkosView, getIDsView is called.
     // Allows forward and backwards compatibility.
-    Kokkos::View<const gno_t *, typename node_t::device_type> kokkosIds;
+    ConstIdsDeviceView kokkosIds;
     getIDsKokkosView(kokkosIds);
+    //deep_copy(?)
     ids = kokkosIds.data();
   }
 
   /*! \brief Provide a Kokkos view to this process' identifiers.
+      \deprecated Use \b getIDsDeviceView instead.
       \param ids will on return point to the list of the global Ids for
         this process.
    */
-  virtual void getIDsKokkosView(Kokkos::View<const gno_t *,
-    typename node_t::device_type> &ids) const {
+  virtual void getIDsKokkosView(ConstIdsDeviceView &ids) const {
     // If adapter does not define getIDsView, getIDsKokkosView is called.
     // If adapter does not define getIDsKokkosView, getIDsView is called.
     // Allows forward and backwards compatibility.
     const gno_t * ptr_ids;
     getIDsView(ptr_ids);
 
-    typedef Kokkos::View<gno_t *, typename node_t::device_type> view_t;
-    view_t non_const_ids = view_t("ptr_ids", getLocalNumIDs());
-
+    auto non_const_ids = IdsDeviceView("ptr_ids", getLocalNumIDs());
     auto host_ids = Kokkos::create_mirror_view(non_const_ids);
     for(size_t i = 0; i < this->getLocalNumIDs(); ++i) {
        host_ids(i) = ptr_ids[i];
     }
     Kokkos::deep_copy(non_const_ids, host_ids);
     ids = non_const_ids;
+  }
+
+  /*! \brief Provide a Kokkos view (Host side) to this process' identifiers.
+      \param hostIds will on return point to the list of the global Ids for
+        this process.
+   */
+  virtual void getIDsHostView(ConstIdsHostView& hostIds) const {
+    Z2_THROW_NOT_IMPLEMENTED
+  }
+
+  /*! \brief Provide a Kokkos view (Device side) to this process' identifiers.
+      \param deviceIds will on return point to the list of the global Ids for
+        this process.
+   */
+  virtual void getIDsDeviceView(ConstIdsDeviceView &deviceIds) const {
+    Z2_THROW_NOT_IMPLEMENTED
   }
 
   ///*! \brief Provide pointer to a weight array with stride.
@@ -166,9 +207,9 @@ public:
     // If adapter does not define getWeightsView, getWeightsKokkosView is called.
     // If adapter does not define getWeightsKokkosView, getWeightsView is called.
     // Allows forward and backwards compatibility.
-    Kokkos::View<scalar_t **, typename node_t::device_type> kokkos_wgts_2d;
+    Kokkos::View<scalar_t **, device_t> kokkos_wgts_2d;
     getWeightsKokkosView(kokkos_wgts_2d);
-    Kokkos::View<scalar_t *, typename node_t::device_type> kokkos_wgts;
+    Kokkos::View<scalar_t *, device_t> kokkos_wgts;
     wgt = Kokkos::subview(kokkos_wgts_2d, Kokkos::ALL, idx).data();
     stride = 1;
   }
@@ -180,14 +221,13 @@ public:
   // *   This function should not be called if getNumWeightsPerID is zero.
   // */
   virtual void getWeightsKokkosView(Kokkos::View<scalar_t **,
-    typename node_t::device_type> & wgt) const {
+    device_t> & wgt) const {
     // If adapter does not define getWeightsKokkosView, getWeightsView is called.
     // If adapter does not define getWeightsView, getWeightsKokkosView is called.
     // Allows forward and backwards compatibility.
-    wgt = Kokkos::View<scalar_t **, typename node_t::device_type>(
+    wgt = Kokkos::View<scalar_t **, device_t>(
       "wgts", getLocalNumIDs(), getNumWeightsPerID());
-    typename Kokkos::View<scalar_t **, typename node_t::device_type>::HostMirror
-      host_wgt = Kokkos::create_mirror_view(wgt);
+    auto host_wgt = Kokkos::create_mirror_view(wgt);
     for(int j = 0; j < this->getNumWeightsPerID(); ++j) {
       const scalar_t * ptr_wgts;
       int stride;
@@ -200,6 +240,20 @@ public:
     Kokkos::deep_copy(wgt, host_wgt);
   }
 
+  /*! \brief Provide a Kokkos view (Host side) of the weights.
+      \param hostWgts on return a Kokkos view of the weights for this idx
+   */
+  virtual void getWeightsHostView(WeightsHostView& hostWgts) const {
+    Z2_THROW_NOT_IMPLEMENTED
+  }
+
+  /*! \brief Provide a Kokkos view (Device side) of the weights.
+      \param deviceWgts on return a Kokkos view of the weights for this idx
+   */
+  virtual void getWeightsDeviceView(WeightsDeviceView& deviceWgts) const {
+    Z2_THROW_NOT_IMPLEMENTED
+  }
+
   /*! \brief Provide pointer to an array containing the input part
    *         assignment for each ID.
    *         The input part information may be used for re-partitioning
@@ -209,10 +263,18 @@ public:
    *         the rank
    *    \param inputPart on return a pointer to input part numbers
    */
-  void getPartsView(const part_t *&inputPart) const {
+  virtual void getPartsView(const part_t *&inputPart) const {
     // Default behavior:  return NULL for inputPart array;
     // assume input part == rank
     inputPart = NULL;
+  }
+
+  virtual void getPartsHostView(Kokkos::View<part_t*, host_t> &inputPart) const {
+    Z2_THROW_NOT_IMPLEMENTED
+  }
+
+  virtual void getPartsDeviceView(Kokkos::View<part_t*, device_t> &inputPart) const {
+    Z2_THROW_NOT_IMPLEMENTED
   }
 
   /*! \brief Apply a PartitioningSolution to an input.
@@ -250,13 +312,25 @@ protected:
 
 };
 
-template <typename User>
-class AdapterWithCoords : public BaseAdapter<User>
+template <typename User> class AdapterWithCoords : public BaseAdapter<User>
 {
+  using scalar_t = typename BaseAdapter<User>::scalar_t;
+  using device_t = typename BaseAdapter<User>::node_t::device_type;
+  using host_t = typename Kokkos::HostSpace::memory_space;
+  template <typename space>
+  using coords_t = Kokkos::View<scalar_t **, Kokkos::LayoutLeft, space>;
+
 public:
-  virtual void getCoordinatesView(const typename BaseAdapter<User>::scalar_t *&coords, int &stride, int coordDim) const = 0;
-  virtual void getCoordinatesKokkosView(
-    Kokkos::View<typename BaseAdapter<User>::scalar_t **, Kokkos::LayoutLeft, typename BaseAdapter<User>::node_t::device_type> &elements) const = 0;
+  virtual void getCoordinatesView(const scalar_t *&coords, int &stride,
+                                  int coordDim) const = 0;
+  virtual void getCoordinatesKokkosView(coords_t<device_t> &elements) const = 0;
+
+  virtual void getCoordinatesHostView(coords_t<host_t> &) const {
+    Z2_THROW_NOT_IMPLEMENTED
+  }
+  virtual void getCoordinatesDeviceView(coords_t<device_t> &elements) const {
+    Z2_THROW_NOT_IMPLEMENTED
+  }
 };
 
 // Forward declare

--- a/packages/zoltan2/core/src/input/Zoltan2_GraphAdapter.hpp
+++ b/packages/zoltan2/core/src/input/Zoltan2_GraphAdapter.hpp
@@ -98,16 +98,16 @@ enum GraphEntityType {
 template <typename User, typename UserCoord=User>
   class GraphAdapter : public AdapterWithCoordsWrapper<User, UserCoord> {
 private:
-  enum GraphEntityType primaryEntityType; // Entity (vertex or edge) to
+  enum GraphEntityType primaryEntityType_; // Entity (vertex or edge) to
                                           // be partitioned, ordered,
                                           // colored, matched, etc.
-  enum GraphEntityType adjacencyEntityType; // Entity (edge or vertex)
+  enum GraphEntityType adjacencyEntityType_; // Entity (edge or vertex)
                                             // describing adjacencies;
                                             // typically opposite of
-                                            // primaryEntityType.
+                                            // primaryEntityType_.
   VectorAdapter<UserCoord> *coordinateInput_;  // A VectorAdapter containing
                                                // coordinates of the objects
-                                               // with primaryEntityType;
+                                               // with primaryEntityType_;
                                                // optional.
   bool haveCoordinateInput_;                   // Flag indicating whether
                                                // coordinateInput_ is provided.
@@ -127,13 +127,9 @@ public:
 
   enum BaseAdapterType adapterType() const override {return GraphAdapterType;}
 
-  /*! \brief Destructor
-   */
-  virtual ~GraphAdapter() {};
-
   // Default GraphEntityType is GRAPH_VERTEX.
-  GraphAdapter() : primaryEntityType(GRAPH_VERTEX),
-                   adjacencyEntityType(GRAPH_EDGE),
+  GraphAdapter() : primaryEntityType_(GRAPH_VERTEX),
+                   adjacencyEntityType_(GRAPH_EDGE),
                    coordinateInput_(),
                    haveCoordinateInput_(false) {}
 
@@ -212,9 +208,9 @@ public:
 
 
   /*! \brief Allow user to provide additional data that contains coordinate
-   *         info associated with the MatrixAdapter's primaryEntityType.
+   *         info associated with the MatrixAdapter's primaryEntityType_.
    *         Associated data must have the same parallel distribution and
-   *         ordering of entries as the primaryEntityType.
+   *         ordering of entries as the primaryEntityType_.
    *
    *  \param coordData is a pointer to a VectorAdapter with the user's
    *         coordinate data.
@@ -245,22 +241,22 @@ public:
    *  Valid values are GRAPH_VERTEX or GRAPH_EDGE.
    */
   inline enum GraphEntityType getPrimaryEntityType() const {
-    return this->primaryEntityType;
+    return this->primaryEntityType_;
   }
 
   /*! \brief Sets the primary entity type.  Called by algorithm based on
    *  parameter value in parameter list from application.
-   *  Also sets to adjacencyEntityType to something reasonable:  opposite of
-   *  primaryEntityType.
+   *  Also sets to adjacencyEntityType_ to something reasonable:  opposite of
+   *  primaryEntityType_.
    */
   void setPrimaryEntityType(std::string typestr) {
     if (typestr == "vertex") {
-      this->primaryEntityType = GRAPH_VERTEX;
-      this->adjacencyEntityType = GRAPH_EDGE;
+      this->primaryEntityType_ = GRAPH_VERTEX;
+      this->adjacencyEntityType_ = GRAPH_EDGE;
     }
     else if (typestr == "edge") {
-      this->primaryEntityType = GRAPH_EDGE;
-      this->adjacencyEntityType = GRAPH_VERTEX;
+      this->primaryEntityType_ = GRAPH_EDGE;
+      this->adjacencyEntityType_ = GRAPH_VERTEX;
     }
     else {
       std::ostringstream emsg;
@@ -276,22 +272,22 @@ public:
    *  Valid values are GRAPH_VERTEX or GRAPH_EDGE.
    */
   inline enum GraphEntityType getAdjacencyEntityType() const {
-    return this->adjacencyEntityType;
+    return this->adjacencyEntityType_;
   }
 
   /*! \brief Sets the adjacency entity type.  Called by algorithm based on
    *  parameter value in parameter list from application.
-   *  Also sets to primaryEntityType to something reasonable:  opposite of
-   *  adjacencyEntityType.
+   *  Also sets to primaryEntityType_ to something reasonable:  opposite of
+   *  adjacencyEntityType_.
    */
   void setAdjacencyEntityType(std::string typestr) {
     if (typestr == "vertex") {
-      this->adjacencyEntityType = GRAPH_VERTEX;
-      this->primaryEntityType = GRAPH_EDGE;
+      this->adjacencyEntityType_ = GRAPH_VERTEX;
+      this->primaryEntityType_ = GRAPH_EDGE;
     }
     else if (typestr == "edge") {
-      this->adjacencyEntityType = GRAPH_EDGE;
-      this->primaryEntityType = GRAPH_VERTEX;
+      this->adjacencyEntityType_ = GRAPH_EDGE;
+      this->primaryEntityType_ = GRAPH_VERTEX;
     }
     else {
       std::ostringstream emsg;

--- a/packages/zoltan2/core/src/input/Zoltan2_IdentifierAdapter.hpp
+++ b/packages/zoltan2/core/src/input/Zoltan2_IdentifierAdapter.hpp
@@ -108,10 +108,6 @@ public:
   typedef IdentifierAdapter<User> base_adapter_t;
 #endif
 
-  /*! \brief Destructor
-   */
-  virtual ~IdentifierAdapter() {};
-
   enum BaseAdapterType adapterType() const {return IdentifierAdapterType;}
 };
 

--- a/packages/zoltan2/core/src/input/Zoltan2_MatrixAdapter.hpp
+++ b/packages/zoltan2/core/src/input/Zoltan2_MatrixAdapter.hpp
@@ -112,15 +112,15 @@ private:
 public:
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
-  typedef typename InputTraits<User>::scalar_t scalar_t;
-  typedef typename InputTraits<User>::lno_t    lno_t;
-  typedef typename InputTraits<User>::gno_t    gno_t;
-  typedef typename InputTraits<User>::part_t   part_t;
-  typedef typename InputTraits<User>::node_t   node_t;
-  typedef typename InputTraits<User>::offset_t offset_t;
-  typedef User user_t;
-  typedef UserCoord userCoord_t;
-  typedef MatrixAdapter<User,UserCoord> base_adapter_t;
+  using scalar_t = typename InputTraits<User>::scalar_t;
+  using lno_t = typename InputTraits<User>::lno_t;
+  using gno_t = typename InputTraits<User>::gno_t;
+  using part_t = typename InputTraits<User>::part_t;
+  using node_t = typename InputTraits<User>::node_t;
+  using offset_t = typename InputTraits<User>::offset_t;
+  using user_t = User;
+  using userCoord_t = UserCoord;
+  using base_adapter_t = MatrixAdapter<User,UserCoord>;
 #endif
 
   enum BaseAdapterType adapterType() const override {return MatrixAdapterType;}
@@ -129,10 +129,6 @@ public:
   MatrixAdapter() : primaryEntityType_(MATRIX_ROW),
                     coordinateInput_(),
                     haveCoordinateInput_(false) {}
-
-  /*! \brief Destructor
-   */
-  virtual ~MatrixAdapter(){}
 
   /*! \brief Returns the number of rows on this process.
    */
@@ -164,6 +160,16 @@ public:
     Z2_THROW_NOT_IMPLEMENTED
   }
 
+  virtual void getRowIDsHostView(typename BaseAdapter<User>::ConstIdsHostView& rowIds) const
+  {
+    Z2_THROW_NOT_IMPLEMENTED
+  }
+
+  virtual void getRowIDsDeviceView(typename BaseAdapter<User>::ConstIdsDeviceView& rowIds) const
+  {
+    Z2_THROW_NOT_IMPLEMENTED
+  }
+
   /*! \brief Sets pointers to this process' matrix entries using
              compressed sparse row (CRS) format.
              All matrix adapters must implement either getCRSView or
@@ -182,6 +188,19 @@ public:
     colIds = ArrayRCP<const gno_t>();
     Z2_THROW_NOT_IMPLEMENTED
   }
+
+  virtual void getCRSHostView(typename BaseAdapter<User>::ConstOffsetsHostView& offsets,
+                              typename BaseAdapter<User>::ConstIdsHostView& colIds) const
+  {
+      Z2_THROW_NOT_IMPLEMENTED
+  }
+
+  virtual void getCRSDeviceView(typename BaseAdapter<User>::ConstOffsetsDeviceView& offsets,
+                                typename BaseAdapter<User>::ConstIdsDeviceView& colIds) const
+  {
+      Z2_THROW_NOT_IMPLEMENTED
+  }
+
 
   /*! \brief Sets pointers to this process' matrix entries
              and their values using
@@ -208,6 +227,21 @@ public:
     Z2_THROW_NOT_IMPLEMENTED
   }
 
+  virtual void getCRSHostView(typename BaseAdapter<User>::ConstOffsetsHostView& offsets,
+                              typename BaseAdapter<User>::ConstIdsHostView& colIds,
+                              typename BaseAdapter<User>::ConstScalarsHostView& values) const
+  {
+      Z2_THROW_NOT_IMPLEMENTED
+  }
+
+  virtual void getCRSDeviceView(typename BaseAdapter<User>::ConstOffsetsDeviceView& offsets,
+                                typename BaseAdapter<User>::ConstIdsDeviceView& colIds,
+                                typename BaseAdapter<User>::ConstScalarsDeviceView& values) const
+  {
+      Z2_THROW_NOT_IMPLEMENTED
+  }
+
+
   /*! \brief Returns the number of weights per row (0 or greater).
       Row weights may be used when partitioning matrix rows.
    */
@@ -226,6 +260,16 @@ public:
     weights = NULL;
     stride = 0;
     Z2_THROW_NOT_IMPLEMENTED
+  }
+
+  virtual void getRowWeightsHostView(typename BaseAdapter<User>::WeightsHostView& weights) const
+  {
+      Z2_THROW_NOT_IMPLEMENTED
+  }
+
+  virtual void getRowWeightsDeviceView(typename BaseAdapter<User>::WeightsDeviceView& weights) const
+  {
+      Z2_THROW_NOT_IMPLEMENTED
   }
 
   /*! \brief Indicate whether row weight with index idx should be the
@@ -249,6 +293,16 @@ public:
   virtual void getColumnIDsView(const gno_t *&colIds) const
   {
     colIds = NULL;
+    Z2_THROW_NOT_IMPLEMENTED
+  }
+
+  virtual void getColumnIDsHostView(typename BaseAdapter<User>::ConstIdsHostView& colIds) const
+  {
+    Z2_THROW_NOT_IMPLEMENTED
+  }
+
+  virtual void getColumnIDsDeviceView(typename BaseAdapter<User>::ConstIdsDeviceView& colIds) const
+  {
     Z2_THROW_NOT_IMPLEMENTED
   }
 
@@ -315,6 +369,16 @@ public:
     weights = NULL;
     stride = 0;
     Z2_THROW_NOT_IMPLEMENTED
+  }
+
+  virtual void getColumnWeightsHostView(typename BaseAdapter<User>::WeightsHostView& weights) const
+  {
+      Z2_THROW_NOT_IMPLEMENTED
+  }
+
+  virtual void getColumnWeightsDeviceView(typename BaseAdapter<User>::WeightsDeviceView& weights) const
+  {
+      Z2_THROW_NOT_IMPLEMENTED
   }
 
   /*! \brief Indicate whether column weight with index idx should be the
@@ -431,6 +495,50 @@ public:
     }
   }
 
+  void getIDsHostView(typename BaseAdapter<User>::ConstIdsHostView& ids) const override {
+    switch (getPrimaryEntityType()) {
+    case MATRIX_ROW:
+      getRowIDsHostView(ids);
+      break;
+    case MATRIX_COLUMN:
+      getColumnIDsHostView(ids);
+      break;
+    case MATRIX_NONZERO: {
+      // TODO:  Need getNonzeroIDsHostView?  What is a Nonzero ID?
+      // TODO:  std::pair<gno_t, gno_t>?
+      std::ostringstream emsg;
+      emsg << __FILE__ << "," << __LINE__
+           << " error:  getIDsView not yet supported for matrix nonzeros."
+           << std::endl;
+      throw std::runtime_error(emsg.str());
+      }
+    default:   // Shouldn't reach default; just making compiler happy
+      break;
+    }
+  }
+
+  void getIDsDeviceView(typename BaseAdapter<User>::ConstIdsDeviceView& ids) const override {
+    switch (getPrimaryEntityType()) {
+    case MATRIX_ROW:
+      getRowIDsDeviceView(ids);
+      break;
+    case MATRIX_COLUMN:
+      getColumnIDsDeviceView(ids);
+      break;
+    case MATRIX_NONZERO: {
+      // TODO:  Need getNonzeroIDsDeviceView?  What is a Nonzero ID?
+      // TODO:  std::pair<gno_t, gno_t>?
+      std::ostringstream emsg;
+      emsg << __FILE__ << "," << __LINE__
+           << " error:  getIDsView not yet supported for matrix nonzeros."
+           << std::endl;
+      throw std::runtime_error(emsg.str());
+      }
+    default:   // Shouldn't reach default; just making compiler happy
+      break;
+    }
+  }
+
   int getNumWeightsPerID() const override
   {
     switch (getPrimaryEntityType()) {
@@ -468,6 +576,50 @@ public:
       break;
     }
   }
+
+  virtual void getWeightsHostView(typename BaseAdapter<User>::WeightsHostView& hostWgts) const {
+      switch (getPrimaryEntityType()) {
+      case MATRIX_ROW:
+        getRowWeightsHostView(hostWgts);
+        break;
+      case MATRIX_COLUMN:
+        getColumnWeightsHostView(hostWgts);
+        break;
+      case MATRIX_NONZERO:
+        {
+        // TODO:  Need getNonzeroWeightsView with Nonzeros as primary object?
+        // TODO:  That is, get Nonzeros' weights based on some nonzero ID?
+        std::ostringstream emsg;
+        emsg << __FILE__ << "," << __LINE__
+             << " error:  getWeightsView not yet supported for matrix nonzeros."
+             << std::endl;
+        throw std::runtime_error(emsg.str());
+        }
+      default:   // Shouldn't reach default; just making compiler happy
+        break;
+      }  }
+
+  virtual void getWeightsDeviceView(typename BaseAdapter<User>::WeightsDeviceView& deviceWgts) const {
+      switch (getPrimaryEntityType()) {
+      case MATRIX_ROW:
+        getRowWeightsDeviceView(deviceWgts);
+        break;
+      case MATRIX_COLUMN:
+        getColumnWeightsDeviceView(deviceWgts);
+        break;
+      case MATRIX_NONZERO:
+        {
+        // TODO:  Need getNonzeroWeightsView with Nonzeros as primary object?
+        // TODO:  That is, get Nonzeros' weights based on some nonzero ID?
+        std::ostringstream emsg;
+        emsg << __FILE__ << "," << __LINE__
+             << " error:  getWeightsView not yet supported for matrix nonzeros."
+             << std::endl;
+        throw std::runtime_error(emsg.str());
+        }
+      default:   // Shouldn't reach default; just making compiler happy
+        break;
+      }  }
 
   bool useDegreeAsWeight(int idx) const
   {

--- a/packages/zoltan2/core/src/input/Zoltan2_MeshAdapter.hpp
+++ b/packages/zoltan2/core/src/input/Zoltan2_MeshAdapter.hpp
@@ -138,10 +138,6 @@ public:
 
   enum BaseAdapterType adapterType() const override {return MeshAdapterType;}
 
-  /*! \brief Destructor
-   */
-  virtual ~MeshAdapter() {};
-
   // Default MeshEntityType is MESH_REGION with MESH_FACE-based adjacencies and
   // second adjacencies and coordinates
   MeshAdapter() : primaryEntityType(MESH_REGION),

--- a/packages/zoltan2/core/src/input/Zoltan2_TpetraRowGraphAdapter.hpp
+++ b/packages/zoltan2/core/src/input/Zoltan2_TpetraRowGraphAdapter.hpp
@@ -94,10 +94,6 @@ public:
   typedef UserCoord userCoord_t;
 #endif
 
-  /*! \brief Destructor
-   */
-  ~TpetraRowGraphAdapter() { }
-
   /*! \brief Constructor for graph with no weights or coordinates.
    *  \param ingraph the  Tpetra::RowGraph
    *  \param numVtxWeights  the number of weights per vertex (default = 0)

--- a/packages/zoltan2/core/src/input/Zoltan2_TpetraRowMatrixAdapter.hpp
+++ b/packages/zoltan2/core/src/input/Zoltan2_TpetraRowMatrixAdapter.hpp
@@ -51,8 +51,8 @@
 #define _ZOLTAN2_TPETRAROWMATRIXADAPTER_HPP_
 
 #include <Zoltan2_MatrixAdapter.hpp>
-#include <Zoltan2_StridedData.hpp>
 #include <Zoltan2_PartitioningHelpers.hpp>
+#include <Zoltan2_StridedData.hpp>
 
 #include <Tpetra_RowMatrix.hpp>
 
@@ -72,32 +72,30 @@ namespace Zoltan2 {
 
 */
 
-template <typename User, typename UserCoord=User>
-  class TpetraRowMatrixAdapter : public MatrixAdapter<User,UserCoord> {
+template <typename User, typename UserCoord = User>
+class TpetraRowMatrixAdapter : public MatrixAdapter<User, UserCoord> {
 public:
-
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
-  typedef typename InputTraits<User>::scalar_t scalar_t;
-  typedef typename InputTraits<User>::offset_t offset_t;
-  typedef typename InputTraits<User>::lno_t    lno_t;
-  typedef typename InputTraits<User>::gno_t    gno_t;
-  typedef typename InputTraits<User>::part_t   part_t;
-  typedef typename InputTraits<User>::node_t   node_t;
-  typedef User user_t;
-  typedef UserCoord userCoord_t;
+  using scalar_t = typename InputTraits<User>::scalar_t;
+  using offset_t = typename InputTraits<User>::offset_t;
+  using lno_t = typename InputTraits<User>::lno_t;
+  using gno_t = typename InputTraits<User>::gno_t;
+  using part_t = typename InputTraits<User>::part_t;
+  using node_t = typename InputTraits<User>::node_t;
+  using device_t = typename node_t::device_type;
+  using host_t = typename Kokkos::HostSpace::memory_space;
+  using user_t = User;
+  using userCoord_t = UserCoord;
 #endif
-
-  /*! \brief Destructor
-   */
-  ~TpetraRowMatrixAdapter() { }
 
   /*! \brief Constructor
    *    \param inmatrix The user's Tpetra RowMatrix object
-   *    \param nWeightsPerRow If row weights will be provided in setRowWeights(),
-   *        the set \c nWeightsPerRow to the number of weights per row.
+   *    \param nWeightsPerRow If row weights will be provided in
+   * setRowWeights(), the set \c nWeightsPerRow to the number of weights per
+   * row.
    */
   TpetraRowMatrixAdapter(const RCP<const User> &inmatrix,
-                         int nWeightsPerRow=0);
+                         int nWeightsPerRow = 0);
 
   /*! \brief Specify a weight for each entity of the primaryEntityType.
    *    \param weightVal A pointer to the weights for this index.
@@ -112,12 +110,13 @@ public:
    */
 
   void setWeights(const scalar_t *weightVal, int stride, int idx = 0);
+  void setWeights(Kokkos::View<scalar_t **, device_t> &weights);
 
   /*! \brief Specify a weight for each row.
    *    \param weightVal A pointer to the weights for this index.
-   *    \stride          A stride to be used in reading the values.  The
-   *        index \c idx weight for row \k should be found at
-   *        <tt>weightVal[k*stride]</tt>.
+   *    \param stride    A stride to be used in reading the values.
+   *                     The index \c idx weight for row \k should be found at
+   *                     <tt>weightVal[k*stride]</tt>.
    *    \param idx  A value between zero and one less that the \c nWeightsPerRow
    *                  argument to the constructor.
    *
@@ -129,6 +128,7 @@ public:
    */
 
   void setRowWeights(const scalar_t *weightVal, int stride, int idx = 0);
+  void setRowWeights(Kokkos::View<scalar_t **, device_t> &weights);
 
   /*! \brief Specify an index for which the weight should be
               the degree of the entity
@@ -148,85 +148,153 @@ public:
   // The MatrixAdapter interface.
   ////////////////////////////////////////////////////
 
-  size_t getLocalNumRows() const {
-    return matrix_->getLocalNumRows();
-  }
+  size_t getLocalNumRows() const { return matrix_->getLocalNumRows(); }
 
-  size_t getLocalNumColumns() const {
-    return matrix_->getLocalNumCols();
-  }
+  size_t getLocalNumColumns() const { return matrix_->getLocalNumCols(); }
 
-  size_t getLocalNumEntries() const {
-    return matrix_->getLocalNumEntries();
-  }
+  size_t getLocalNumEntries() const { return matrix_->getLocalNumEntries(); }
 
   bool CRSViewAvailable() const { return true; }
 
-  void getRowIDsView(const gno_t *&rowIds) const
-  {
+  void getRowIDsView(const gno_t *&rowIds) const override {
     ArrayView<const gno_t> rowView = rowMap_->getLocalElementList();
     rowIds = rowView.getRawPtr();
   }
 
-  void getCRSView(ArrayRCP<const offset_t> &offsets, ArrayRCP<const gno_t> &colIds) const
-  {
+  void getRowIDsHostView(
+      typename BaseAdapter<User>::ConstIdsHostView &rowIds) const override {
+    auto kRowIds = rowMap_->getMyGlobalIndices();
+    auto hostRowIds = Kokkos::create_mirror_view(kRowIds);
+    Kokkos::deep_copy(hostRowIds, kRowIds);
+    rowIds = hostRowIds;
+  }
+
+  void getRowIDsDeviceView(
+      typename BaseAdapter<User>::ConstIdsDeviceView &rowIds) const override {
+    using device_type = typename node_t::device_type;
+    auto rowIdsDevice = Kokkos::create_mirror_view_and_copy(
+        device_type(), rowMap_->getMyGlobalIndices());
+    rowIds = rowIdsDevice;
+  }
+
+  void getCRSView(ArrayRCP<const offset_t> &offsets,
+                  ArrayRCP<const gno_t> &colIds) const {
     offsets = offset_;
     colIds = columnIds_;
   }
 
+  void getCRSHostView(
+      typename BaseAdapter<User>::ConstOffsetsHostView &offsets,
+      typename BaseAdapter<User>::ConstIdsHostView &colIds) const override {
+    auto hostOffsets = Kokkos::create_mirror_view(kOffset_);
+    Kokkos::deep_copy(hostOffsets, kOffset_);
+    offsets = hostOffsets;
+
+    auto hostColIds = Kokkos::create_mirror_view(kColumnIds_);
+    Kokkos::deep_copy(hostColIds, kColumnIds_);
+    colIds = hostColIds;
+  }
+
+  void getCRSDeviceView(
+      typename BaseAdapter<User>::ConstOffsetsDeviceView &offsets,
+      typename BaseAdapter<User>::ConstIdsDeviceView &colIds) const override {
+    offsets = kOffset_;
+    colIds = kColumnIds_;
+  }
+
   void getCRSView(ArrayRCP<const offset_t> &offsets,
                   ArrayRCP<const gno_t> &colIds,
-                  ArrayRCP<const scalar_t> &values) const
-  {
+                  ArrayRCP<const scalar_t> &values) const {
     offsets = offset_;
     colIds = columnIds_;
     values = values_;
   }
 
+  void getCRSHostView(
+      typename BaseAdapter<User>::ConstOffsetsHostView &offsets,
+      typename BaseAdapter<User>::ConstIdsHostView &colIds,
+      typename BaseAdapter<User>::ConstScalarsHostView &values) const override {
+    auto hostOffsets = Kokkos::create_mirror_view(kOffset_);
+    Kokkos::deep_copy(hostOffsets, kOffset_);
+    offsets = hostOffsets;
+
+    auto hostColIds = Kokkos::create_mirror_view(kColumnIds_);
+    Kokkos::deep_copy(hostColIds, kColumnIds_);
+    colIds = hostColIds;
+
+    auto hostValues = Kokkos::create_mirror_view(kValues_);
+    Kokkos::deep_copy(hostValues, kValues_);
+    values = hostValues;
+  }
+
+  void
+  getCRSDeviceView(typename BaseAdapter<User>::ConstOffsetsDeviceView &offsets,
+                   typename BaseAdapter<User>::ConstIdsDeviceView &colIds,
+                   typename BaseAdapter<User>::ConstScalarsDeviceView &values)
+      const override {
+    offsets = kOffset_;
+    colIds = kColumnIds_;
+    values = kValues_;
+  }
 
   int getNumWeightsPerRow() const { return nWeightsPerRow_; }
 
   void getRowWeightsView(const scalar_t *&weights, int &stride,
-                           int idx = 0) const
-  {
-    if(idx<0 || idx >= nWeightsPerRow_)
-    {
+                         int idx = 0) const {
+    if (idx < 0 || idx >= nWeightsPerRow_) {
       std::ostringstream emsg;
-      emsg << __FILE__ << ":" << __LINE__
-           << "  Invalid row weight index " << idx << std::endl;
+      emsg << __FILE__ << ":" << __LINE__ << "  Invalid row weight index "
+           << idx << std::endl;
       throw std::runtime_error(emsg.str());
     }
-
 
     size_t length;
     rowWeights_[idx].getStridedList(length, weights, stride);
   }
 
-  bool useNumNonzerosAsRowWeight(int idx) const { return numNzWeight_[idx];}
+  void getRowWeightsHostView(
+      typename BaseAdapter<User>::WeightsHostView &weights) const {
+    auto hostWeight = Kokkos::create_mirror_view(kRowWeights_);
+    Kokkos::deep_copy(hostWeight, kRowWeights_);
+    weights = hostWeight;
+  }
+
+  void getRowWeightsDeviceView(
+      typename BaseAdapter<User>::WeightsDeviceView &weights) const {
+    weights = kRowWeights_;
+  }
+
+  bool useNumNonzerosAsRowWeight(int idx) const { return numNzWeight_[idx]; }
 
   template <typename Adapter>
-    void applyPartitioningSolution(const User &in, User *&out,
-         const PartitioningSolution<Adapter> &solution) const;
+  void applyPartitioningSolution(
+      const User &in, User *&out,
+      const PartitioningSolution<Adapter> &solution) const;
 
   template <typename Adapter>
-    void applyPartitioningSolution(const User &in, RCP<User> &out,
-         const PartitioningSolution<Adapter> &solution) const;
+  void applyPartitioningSolution(
+      const User &in, RCP<User> &out,
+      const PartitioningSolution<Adapter> &solution) const;
 
 private:
-
+  // Old Non Kokkos type
   RCP<const User> matrix_;
-  RCP<const Tpetra::Map<lno_t, gno_t, node_t> > rowMap_;
-  RCP<const Tpetra::Map<lno_t, gno_t, node_t> > colMap_;
+  RCP<const Tpetra::Map<lno_t, gno_t, node_t>> rowMap_;
+  RCP<const Tpetra::Map<lno_t, gno_t, node_t>> colMap_;
   ArrayRCP<offset_t> offset_;
-  ArrayRCP<gno_t> columnIds_;  // TODO:  KDD Is it necessary to copy and store
-  ArrayRCP<scalar_t> values_;  // TODO:  the matrix here?  Would prefer views.
+  ArrayRCP<gno_t> columnIds_; // TODO:  KDD Is it necessary to copy and store
+  ArrayRCP<scalar_t> values_; // TODO:  the matrix here?  Would prefer views.
+  ArrayRCP<StridedData<lno_t, scalar_t>> rowWeights_;
+
+  // New Kokkos Type
+  Kokkos::View<offset_t *, device_t> kOffset_;
+  Kokkos::View<gno_t *, device_t> kColumnIds_;
+  Kokkos::View<scalar_t *, device_t> kValues_;
+  Kokkos::View<scalar_t **, device_t> kRowWeights_;
+  Kokkos::View<bool *, host_t> numNzWeight_;
 
   int nWeightsPerRow_;
-  ArrayRCP<StridedData<lno_t, scalar_t> > rowWeights_;
-  ArrayRCP<bool> numNzWeight_;
-
   bool mayHaveDiagonalEntries;
-
   RCP<User> doMigration(const User &from, size_t numLocalRows,
                         const gno_t *myNewRows) const;
 };
@@ -236,14 +304,12 @@ private:
 /////////////////////////////////////////////////////////////////
 
 template <typename User, typename UserCoord>
-  TpetraRowMatrixAdapter<User,UserCoord>::TpetraRowMatrixAdapter(
-    const RCP<const User> &inmatrix, int nWeightsPerRow):
-      matrix_(inmatrix), rowMap_(), colMap_(),
-      offset_(), columnIds_(),
-      nWeightsPerRow_(nWeightsPerRow), rowWeights_(), numNzWeight_(),
-      mayHaveDiagonalEntries(true)
-{
-  typedef StridedData<lno_t,scalar_t> input_t;
+TpetraRowMatrixAdapter<User, UserCoord>::TpetraRowMatrixAdapter(
+    const RCP<const User> &inmatrix, int nWeightsPerRow)
+    : matrix_(inmatrix), rowMap_(), colMap_(), offset_(), columnIds_(),
+      nWeightsPerRow_(nWeightsPerRow), rowWeights_(),
+      mayHaveDiagonalEntries(true) {
+  typedef StridedData<lno_t, scalar_t> input_t;
 
   rowMap_ = matrix_->getRowMap();
   colMap_ = matrix_->getColMap();
@@ -251,40 +317,69 @@ template <typename User, typename UserCoord>
   size_t nrows = matrix_->getLocalNumRows();
   size_t nnz = matrix_->getLocalNumEntries();
   size_t maxnumentries =
-         matrix_->getLocalMaxNumRowEntries(); // Diff from CrsMatrix
+      matrix_->getLocalMaxNumRowEntries(); // Diff from CrsMatrix
 
-  offset_.resize(nrows+1, 0);
+  offset_.resize(nrows + 1, 0);
   columnIds_.resize(nnz);
   values_.resize(nnz);
-  typename User::nonconst_local_inds_host_view_type  indices("indices", maxnumentries);
-  typename User::nonconst_values_host_view_type  nzs("nzs", maxnumentries);
+  typename User::nonconst_local_inds_host_view_type indices("indices",
+                                                            maxnumentries);
+  typename User::nonconst_values_host_view_type nzs("nzs", maxnumentries);
+
+  kOffset_ = Kokkos::View<offset_t *, device_t>(
+      Kokkos::ViewAllocateWithoutInitializing("offset_"), nrows + 1);
+  auto kOffsetHost = Kokkos::create_mirror_view(kOffset_);
+
+  kColumnIds_ = Kokkos::View<gno_t *, device_t>(
+      Kokkos::ViewAllocateWithoutInitializing("columIds_"), nnz);
+  auto kColumnIdsHost = Kokkos::create_mirror_view(kColumnIds_);
+
+  kValues_ = Kokkos::View<scalar_t *, device_t>(
+      Kokkos::ViewAllocateWithoutInitializing("values_"), nnz);
+  auto kValuesHost = Kokkos::create_mirror_view(kValues_);
+
+  kRowWeights_ = Kokkos::View<scalar_t **, device_t>(
+      Kokkos::ViewAllocateWithoutInitializing("rowWeights_"), nWeightsPerRow_,
+      nWeightsPerRow_ * nrows);
 
   lno_t next = 0;
-  for (size_t i=0; i < nrows; i++){
+  kOffsetHost(0) = 0;
+  for (size_t i = 0; i < nrows; i++) {
     lno_t row = i;
     matrix_->getLocalRowCopy(row, indices, nzs, nnz); // Diff from CrsMatrix
-    for (size_t j=0; j < nnz; j++){
-      values_[next] = nzs[j];
+    for (size_t j = 0; j < nnz; j++) {
+      auto cNzs = nzs[j];
+      values_[next] = cNzs;
+      kValuesHost(next) = cNzs;
       // TODO - this will be slow
       //   Is it possible that global columns ids might be stored in order?
-      columnIds_[next++] = colMap_->getGlobalElement(indices[j]);
+      auto colMapGId = colMap_->getGlobalElement(indices[j]);
+      kColumnIdsHost(next) = colMapGId;
+      columnIds_[next++] = colMapGId;
     }
-    offset_[i+1] = offset_[i] + nnz;
+    auto nextOffset = offset_[i] + nnz;
+    offset_[i + 1] = nextOffset;
+    kOffsetHost(i + 1) = nextOffset;
   }
 
-  if (nWeightsPerRow_ > 0){
-    rowWeights_ = arcp(new input_t [nWeightsPerRow_], 0, nWeightsPerRow_, true);
-    numNzWeight_ = arcp(new bool [nWeightsPerRow_], 0, nWeightsPerRow_, true);
-    for (int i=0; i < nWeightsPerRow_; i++)
-      numNzWeight_[i] = false;
+  Kokkos::deep_copy(kValues_, kValuesHost);
+  Kokkos::deep_copy(kOffset_, kOffsetHost);
+  Kokkos::deep_copy(kColumnIds_, kColumnIdsHost);
+
+  if (nWeightsPerRow_ > 0) {
+    rowWeights_ = arcp(new input_t[nWeightsPerRow_], 0, nWeightsPerRow_, true);
+    numNzWeight_ =
+        Kokkos::View<bool *, host_t>("numNzWeight_", nWeightsPerRow_);
+    for (size_t i = 0; i < numNzWeight_.extent(0); ++i) {
+      numNzWeight_(i) = false;
+    }
   }
 }
 
 ////////////////////////////////////////////////////////////////////////////
 template <typename User, typename UserCoord>
-  void TpetraRowMatrixAdapter<User,UserCoord>::setWeights(
-    const scalar_t *weightVal, int stride, int idx)
-{
+void TpetraRowMatrixAdapter<User, UserCoord>::setWeights(
+    const scalar_t *weightVal, int stride, int idx) {
   if (this->getPrimaryEntityType() == MATRIX_ROW)
     setRowWeights(weightVal, stride, idx);
   else {
@@ -292,36 +387,63 @@ template <typename User, typename UserCoord>
     std::ostringstream emsg;
     emsg << __FILE__ << "," << __LINE__
          << " error:  setWeights not yet supported for"
-         << " columns or nonzeros."
-         << std::endl;
+         << " columns or nonzeros." << std::endl;
     throw std::runtime_error(emsg.str());
   }
 }
 
 ////////////////////////////////////////////////////////////////////////////
 template <typename User, typename UserCoord>
-  void TpetraRowMatrixAdapter<User,UserCoord>::setRowWeights(
-    const scalar_t *weightVal, int stride, int idx)
-{
-  typedef StridedData<lno_t,scalar_t> input_t;
-  if(idx<0 || idx >= nWeightsPerRow_)
-  {
-      std::ostringstream emsg;
-      emsg << __FILE__ << ":" << __LINE__
-           << "  Invalid row weight index " << idx << std::endl;
-      throw std::runtime_error(emsg.str());
+void TpetraRowMatrixAdapter<User, UserCoord>::setWeights(
+    Kokkos::View<scalar_t **, device_t> &weights) {
+  if (this->getPrimaryEntityType() == MATRIX_ROW)
+    setRowWeights(weights);
+  else {
+    // TODO:  Need to allow weights for columns and/or nonzeros
+    std::ostringstream emsg;
+    emsg << __FILE__ << "," << __LINE__
+         << " error:  setWeights not yet supported for"
+         << " columns or nonzeros." << std::endl;
+    throw std::runtime_error(emsg.str());
   }
-
-  size_t nvtx = getLocalNumRows();
-  ArrayRCP<const scalar_t> weightV(weightVal, 0, nvtx*stride, false);
-  rowWeights_[idx] = input_t(weightV, stride);
 }
 
 ////////////////////////////////////////////////////////////////////////////
 template <typename User, typename UserCoord>
-  void TpetraRowMatrixAdapter<User,UserCoord>::setWeightIsDegree(
-    int idx)
-{
+void TpetraRowMatrixAdapter<User, UserCoord>::setRowWeights(
+    const scalar_t *weightVal, int stride, int idx) {
+  typedef StridedData<lno_t, scalar_t> input_t;
+  if (idx < 0 || idx >= nWeightsPerRow_) {
+    std::ostringstream emsg;
+    emsg << __FILE__ << ":" << __LINE__ << "  Invalid row weight index " << idx
+         << std::endl;
+    throw std::runtime_error(emsg.str());
+  }
+
+  size_t nvtx = getLocalNumRows();
+  ArrayRCP<const scalar_t> weightV(weightVal, 0, nvtx * stride, false);
+  rowWeights_[idx] = input_t(weightV, stride);
+
+  // JD-TODO: Check if correct
+  auto kRowWeightsHost = Kokkos::create_mirror_view(kRowWeights_);
+  Kokkos::deep_copy(kRowWeightsHost, kRowWeights_);
+  for (size_t i = 0; i < nvtx; ++i) {
+    kRowWeightsHost(idx, i) = weightV[i];
+  }
+
+  Kokkos::deep_copy(kRowWeights_, kRowWeightsHost);
+}
+
+////////////////////////////////////////////////////////////////////////////
+template <typename User, typename UserCoord>
+void TpetraRowMatrixAdapter<User, UserCoord>::setRowWeights(
+    Kokkos::View<scalar_t **, device_t> &weights) {
+  kRowWeights_ = weights;
+}
+
+////////////////////////////////////////////////////////////////////////////
+template <typename User, typename UserCoord>
+void TpetraRowMatrixAdapter<User, UserCoord>::setWeightIsDegree(int idx) {
   if (this->getPrimaryEntityType() == MATRIX_ROW)
     setRowWeightIsNumberOfNonZeros(idx);
   else {
@@ -336,35 +458,32 @@ template <typename User, typename UserCoord>
 
 ////////////////////////////////////////////////////////////////////////////
 template <typename User, typename UserCoord>
-  void TpetraRowMatrixAdapter<User,UserCoord>::setRowWeightIsNumberOfNonZeros(
-    int idx)
-{
-  if(idx<0 || idx >= nWeightsPerRow_)
-  {
-      std::ostringstream emsg;
-      emsg << __FILE__ << ":" << __LINE__
-           << "  Invalid row weight index " << idx << std::endl;
-      throw std::runtime_error(emsg.str());
+void TpetraRowMatrixAdapter<User, UserCoord>::setRowWeightIsNumberOfNonZeros(
+    int idx) {
+  if (idx < 0 || idx >= nWeightsPerRow_) {
+    std::ostringstream emsg;
+    emsg << __FILE__ << ":" << __LINE__ << "  Invalid row weight index " << idx
+         << std::endl;
+    throw std::runtime_error(emsg.str());
   }
 
-
-  numNzWeight_[idx] = true;
+  numNzWeight_(idx) = true;
 }
 
 ////////////////////////////////////////////////////////////////////////////
 template <typename User, typename UserCoord>
-  template <typename Adapter>
-    void TpetraRowMatrixAdapter<User,UserCoord>::applyPartitioningSolution(
-      const User &in, User *&out,
-      const PartitioningSolution<Adapter> &solution) const
-{
+template <typename Adapter>
+void TpetraRowMatrixAdapter<User, UserCoord>::applyPartitioningSolution(
+    const User &in, User *&out,
+    const PartitioningSolution<Adapter> &solution) const {
   // Get an import list (rows to be received)
   size_t numNewRows;
   ArrayRCP<gno_t> importList;
-  try{
-    numNewRows = Zoltan2::getImportList<Adapter,
-                                        TpetraRowMatrixAdapter<User,UserCoord> >
-                                       (solution, this, importList);
+  try {
+    numNewRows =
+        Zoltan2::getImportList<Adapter,
+                               TpetraRowMatrixAdapter<User, UserCoord>>(
+            solution, this, importList);
   }
   Z2_FORWARD_EXCEPTIONS;
 
@@ -376,18 +495,18 @@ template <typename User, typename UserCoord>
 
 ////////////////////////////////////////////////////////////////////////////
 template <typename User, typename UserCoord>
-  template <typename Adapter>
-    void TpetraRowMatrixAdapter<User,UserCoord>::applyPartitioningSolution(
-      const User &in, RCP<User> &out,
-      const PartitioningSolution<Adapter> &solution) const
-{
+template <typename Adapter>
+void TpetraRowMatrixAdapter<User, UserCoord>::applyPartitioningSolution(
+    const User &in, RCP<User> &out,
+    const PartitioningSolution<Adapter> &solution) const {
   // Get an import list (rows to be received)
   size_t numNewRows;
   ArrayRCP<gno_t> importList;
-  try{
-    numNewRows = Zoltan2::getImportList<Adapter,
-                                        TpetraRowMatrixAdapter<User,UserCoord> >
-                                       (solution, this, importList);
+  try {
+    numNewRows =
+        Zoltan2::getImportList<Adapter,
+                               TpetraRowMatrixAdapter<User, UserCoord>>(
+            solution, this, importList);
   }
   Z2_FORWARD_EXCEPTIONS;
 
@@ -395,15 +514,10 @@ template <typename User, typename UserCoord>
   out = doMigration(in, numNewRows, importList.getRawPtr());
 }
 
-
 ////////////////////////////////////////////////////////////////////////////
-template < typename User, typename UserCoord>
-RCP<User> TpetraRowMatrixAdapter<User,UserCoord>::doMigration(
-  const User &from,
-  size_t numLocalRows,
-  const gno_t *myNewRows
-) const
-{
+template <typename User, typename UserCoord>
+RCP<User> TpetraRowMatrixAdapter<User, UserCoord>::doMigration(
+    const User &from, size_t numLocalRows, const gno_t *myNewRows) const {
   typedef Tpetra::Map<lno_t, gno_t, node_t> map_t;
   typedef Tpetra::CrsMatrix<scalar_t, lno_t, gno_t, node_t> tcrsmatrix_t;
 
@@ -418,7 +532,7 @@ RCP<User> TpetraRowMatrixAdapter<User,UserCoord>::doMigration(
   // approach it might be clearer what's going on here
   const tcrsmatrix_t *pCrsMatrix = dynamic_cast<const tcrsmatrix_t *>(&from);
 
-  if(!pCrsMatrix) {
+  if (!pCrsMatrix) {
     throw std::logic_error("TpetraRowMatrixAdapter cannot migrate data for "
                            "your RowMatrix; it can migrate data only for "
                            "Tpetra::CrsMatrix.  "
@@ -433,7 +547,7 @@ RCP<User> TpetraRowMatrixAdapter<User,UserCoord>::doMigration(
 
   // target map
   ArrayView<const gno_t> rowList(myNewRows, numLocalRows);
-  const RCP<const Teuchos::Comm<int> > &comm = from.getComm();
+  const RCP<const Teuchos::Comm<int>> &comm = from.getComm();
   RCP<const map_t> tmap = rcp(new map_t(numGlobalRows, rowList, base, comm));
 
   // importer
@@ -462,25 +576,24 @@ RCP<User> TpetraRowMatrixAdapter<User,UserCoord>::doMigration(
 
   // number of non zeros in my new rows
   typedef Tpetra::Vector<scalar_t, lno_t, gno_t, node_t> vector_t;
-  vector_t numOld(smap);  // TODO These vectors should have scalar=size_t,
-  vector_t numNew(tmap);  // but ETI does not yet support that.
-  for (int lid=0; lid < oldNumElts; lid++){
+  vector_t numOld(smap); // TODO These vectors should have scalar=size_t,
+  vector_t numNew(tmap); // but ETI does not yet support that.
+  for (int lid = 0; lid < oldNumElts; lid++) {
     numOld.replaceGlobalValue(smap->getGlobalElement(lid),
-      scalar_t(from.getNumEntriesInLocalRow(lid)));
+                              scalar_t(from.getNumEntriesInLocalRow(lid)));
   }
   numNew.doImport(numOld, importer, Tpetra::INSERT);
 
   // TODO Could skip this copy if could declare vector with scalar=size_t.
   ArrayRCP<size_t> nnz(newNumElts);
-  if (newNumElts > 0){
+  if (newNumElts > 0) {
     ArrayRCP<scalar_t> ptr = numNew.getDataNonConst(0);
-    for (int lid=0; lid < newNumElts; lid++){
+    for (int lid = 0; lid < newNumElts; lid++) {
       nnz[lid] = static_cast<size_t>(ptr[lid]);
     }
   }
 
-  RCP<tcrsmatrix_t> M =
-    rcp(new tcrsmatrix_t(tmap, nnz()));
+  RCP<tcrsmatrix_t> M = rcp(new tcrsmatrix_t(tmap, nnz()));
 
   M->doImport(from, importer, Tpetra::INSERT);
   M->fillComplete();
@@ -489,6 +602,6 @@ RCP<User> TpetraRowMatrixAdapter<User,UserCoord>::doMigration(
   return Teuchos::rcp_dynamic_cast<User>(M);
 }
 
-}  //namespace Zoltan2
+} // namespace Zoltan2
 
-#endif
+#endif // _ZOLTAN2_TPETRAROWMATRIXADAPTER_HPP_

--- a/packages/zoltan2/core/src/input/Zoltan2_VectorAdapter.hpp
+++ b/packages/zoltan2/core/src/input/Zoltan2_VectorAdapter.hpp
@@ -110,10 +110,6 @@ public:
   typedef VectorAdapter<User> base_adapter_t;
 #endif
 
-  /*! \brief Destructor
-   */
-  virtual ~VectorAdapter() {};
-
   ////////////////////////////////////////////////////
   // The Adapter interface.
   ////////////////////////////////////////////////////

--- a/packages/zoltan2/core/src/input/Zoltan2_XpetraCrsGraphAdapter.hpp
+++ b/packages/zoltan2/core/src/input/Zoltan2_XpetraCrsGraphAdapter.hpp
@@ -97,10 +97,6 @@ public:
   typedef UserCoord userCoord_t;
 #endif
 
-  /*! \brief Destructor
-   */
-  ~XpetraCrsGraphAdapter() { }
-
   /*! \brief Constructor for graph with no weights or coordinates.
    *  \param ingraph the Epetra_CrsGraph, Tpetra::CrsGraph or Xpetra::CrsGraph
    *  \param numVtxWeights  the number of weights per vertex (default = 0)
@@ -110,7 +106,7 @@ public:
    * one does because the user is obviously a Trilinos user.
    */
 
-  XpetraCrsGraphAdapter(const RCP<const User> &ingraph, 
+  XpetraCrsGraphAdapter(const RCP<const User> &ingraph,
                         int nVtxWeights=0, int nEdgeWeights=0);
 
   /*! \brief Provide a pointer to weights for the primary entity type.
@@ -118,7 +114,7 @@ public:
    *    \param stride    A stride for the \c val array.  If \stride is
    *             \c k, then val[n * k] is the weight for the
    *             \c n th entity for index \idx.
-   *    \param idx A number from 0 to one less than 
+   *    \param idx A number from 0 to one less than
    *          weight idx specified in the constructor.
    *
    *  The order of the weights should match the order that
@@ -132,7 +128,7 @@ public:
    *    \param stride    A stride for the \c val array.  If \stride is
    *             \c k, then val[n * k] is the weight for the
    *             \c n th vertex for index \idx.
-   *    \param idx A number from 0 to one less than 
+   *    \param idx A number from 0 to one less than
    *          number of vertex weights specified in the constructor.
    *
    *  The order of the vertex weights should match the order that
@@ -146,14 +142,14 @@ public:
 
   /*! \brief Specify an index for which the weight should be
               the degree of the entity
-   *    \param idx Zoltan2 will use the entity's 
+   *    \param idx Zoltan2 will use the entity's
    *         degree as the entity weight for index \c idx.
    */
   void setWeightIsDegree(int idx);
 
   /*! \brief Specify an index for which the vertex weight should be
               the degree of the vertex
-   *    \param idx Zoltan2 will use the vertex's 
+   *    \param idx Zoltan2 will use the vertex's
    *         degree as the vertex weight for index \c idx.
    */
   void setVertexWeightIsDegree(int idx);
@@ -183,11 +179,11 @@ public:
   void setEdgeWeights(const scalar_t *val, int stride, int idx);
 
   /*! \brief Access to Xpetra-wrapped user's graph.
-   */ 
+   */
   RCP<const xgraph_t> getXpetraGraph() const { return graph_; }
 
-  /*! \brief Access to user's graph 
-   */ 
+  /*! \brief Access to user's graph
+   */
   RCP<const User> getUserGraph() const { return ingraph_; }
 
   ////////////////////////////////////////////////////
@@ -198,11 +194,11 @@ public:
   // The GraphAdapter interface.
   ////////////////////////////////////////////////////
 
-  // TODO:  Assuming rows == objects; 
+  // TODO:  Assuming rows == objects;
   // TODO:  Need to add option for columns or nonzeros?
   size_t getLocalNumVertices() const { return graph_->getLocalNumRows(); }
 
-  void getVertexIDsView(const gno_t *&ids) const 
+  void getVertexIDsView(const gno_t *&ids) const
   {
     ids = NULL;
     if (getLocalNumVertices())
@@ -227,7 +223,7 @@ public:
       std::ostringstream emsg;
       emsg << __FILE__ << ":" << __LINE__
            << "  Invalid vertex weight index " << idx << std::endl;
-      throw std::runtime_error(emsg.str()); 
+      throw std::runtime_error(emsg.str());
     }
 
 
@@ -246,7 +242,7 @@ public:
       std::ostringstream emsg;
       emsg << __FILE__ << ":" << __LINE__
            << "  Invalid edge weight index " << idx << std::endl;
-      throw std::runtime_error(emsg.str()); 
+      throw std::runtime_error(emsg.str());
     }
 
 
@@ -347,7 +343,7 @@ template <typename User, typename UserCoord>
   adjids_ = arcp(adjids, 0, nedges, true);
 
   if (nWeightsPerVertex_ > 0) {
-    vertexWeights_ = 
+    vertexWeights_ =
           arcp(new input_t[nWeightsPerVertex_], 0, nWeightsPerVertex_, true);
     vertexDegreeWeight_ =
           arcp(new bool[nWeightsPerVertex_], 0, nWeightsPerVertex_, true);
@@ -366,7 +362,7 @@ template <typename User, typename UserCoord>
 {
   if (this->getPrimaryEntityType() == GRAPH_VERTEX)
     setVertexWeights(weightVal, stride, idx);
-  else 
+  else
     setEdgeWeights(weightVal, stride, idx);
 }
 
@@ -382,7 +378,7 @@ template <typename User, typename UserCoord>
       std::ostringstream emsg;
       emsg << __FILE__ << ":" << __LINE__
            << "  Invalid vertex weight index " << idx << std::endl;
-      throw std::runtime_error(emsg.str()); 
+      throw std::runtime_error(emsg.str());
   }
 
   size_t nvtx = getLocalNumVertices();
@@ -416,7 +412,7 @@ template <typename User, typename UserCoord>
       std::ostringstream emsg;
       emsg << __FILE__ << ":" << __LINE__
            << "  Invalid vertex weight index " << idx << std::endl;
-      throw std::runtime_error(emsg.str()); 
+      throw std::runtime_error(emsg.str());
   }
 
   vertexDegreeWeight_[idx] = true;
@@ -434,7 +430,7 @@ template <typename User, typename UserCoord>
       std::ostringstream emsg;
       emsg << __FILE__ << ":" << __LINE__
            << "  Invalid edge weight index " << idx << std::endl;
-      throw std::runtime_error(emsg.str()); 
+      throw std::runtime_error(emsg.str());
   }
 
   size_t nedges = getLocalNumEdges();
@@ -446,7 +442,7 @@ template <typename User, typename UserCoord>
 template <typename User, typename UserCoord>
   template<typename Adapter>
     void XpetraCrsGraphAdapter<User,UserCoord>::applyPartitioningSolution(
-      const User &in, User *&out, 
+      const User &in, User *&out,
       const PartitioningSolution<Adapter> &solution) const
 {
   // Get an import list (rows to be received)
@@ -454,7 +450,7 @@ template <typename User, typename UserCoord>
   ArrayRCP<gno_t> importList;
   try{
     numNewVtx = Zoltan2::getImportList<Adapter,
-                                       XpetraCrsGraphAdapter<User,UserCoord> > 
+                                       XpetraCrsGraphAdapter<User,UserCoord> >
                                       (solution, this, importList);
   }
   Z2_FORWARD_EXCEPTIONS;
@@ -465,12 +461,12 @@ template <typename User, typename UserCoord>
   out = outPtr.get();
   outPtr.release();
 }
-  
+
 ////////////////////////////////////////////////////////////////////////////
 template <typename User, typename UserCoord>
   template<typename Adapter>
     void XpetraCrsGraphAdapter<User,UserCoord>::applyPartitioningSolution(
-      const User &in, RCP<User> &out, 
+      const User &in, RCP<User> &out,
       const PartitioningSolution<Adapter> &solution) const
 {
   // Get an import list (rows to be received)
@@ -478,7 +474,7 @@ template <typename User, typename UserCoord>
   ArrayRCP<gno_t> importList;
   try{
     numNewVtx = Zoltan2::getImportList<Adapter,
-                                       XpetraCrsGraphAdapter<User,UserCoord> > 
+                                       XpetraCrsGraphAdapter<User,UserCoord> >
                                       (solution, this, importList);
   }
   Z2_FORWARD_EXCEPTIONS;
@@ -489,5 +485,5 @@ template <typename User, typename UserCoord>
 }
 
 }  //namespace Zoltan2
-  
+
 #endif

--- a/packages/zoltan2/core/src/input/Zoltan2_XpetraCrsMatrixAdapter.hpp
+++ b/packages/zoltan2/core/src/input/Zoltan2_XpetraCrsMatrixAdapter.hpp
@@ -98,12 +98,8 @@ public:
   typedef UserCoord userCoord_t;
 #endif
 
-  /*! \brief Destructor
-   */
-  ~XpetraCrsMatrixAdapter() { }
-
-  /*! \brief Constructor   
-   *    \param inmatrix The users Epetra, Tpetra, or Xpetra CrsMatrix object 
+  /*! \brief Constructor
+   *    \param inmatrix The users Epetra, Tpetra, or Xpetra CrsMatrix object
    *    \param nWeightsPerRow If row weights will be provided in setRowWeights(),
    *        the set \c nWeightsPerRow to the number of weights per row.
    */
@@ -115,10 +111,10 @@ public:
    *    \stride          A stride to be used in reading the values.  The
    *        index \c idx weight for entity \k should be found at
    *        <tt>weightVal[k*stride]</tt>.
-   *    \param idx  A value between zero and one less that the \c nWeightsPerRow 
+   *    \param idx  A value between zero and one less that the \c nWeightsPerRow
    *                  argument to the constructor.
    *
-   * The order of weights should correspond to the order of the primary 
+   * The order of weights should correspond to the order of the primary
    * entity type; see, e.g.,  setRowWeights below.
    */
 
@@ -129,7 +125,7 @@ public:
    *    \stride          A stride to be used in reading the values.  The
    *        index \c idx weight for row \k should be found at
    *        <tt>weightVal[k*stride]</tt>.
-   *    \param idx  A value between zero and one less that the \c nWeightsPerRow 
+   *    \param idx  A value between zero and one less that the \c nWeightsPerRow
    *                  argument to the constructor.
    *
    * The order of weights should correspond to the order of rows
@@ -143,7 +139,7 @@ public:
 
   /*! \brief Specify an index for which the weight should be
               the degree of the entity
-   *    \param idx Zoltan2 will use the entity's 
+   *    \param idx Zoltan2 will use the entity's
    *         degree as the entity weight for index \c idx.
    */
   void setWeightIsDegree(int idx);
@@ -159,11 +155,11 @@ public:
   // The MatrixAdapter interface.
   ////////////////////////////////////////////////////
 
-  size_t getLocalNumRows() const { 
+  size_t getLocalNumRows() const {
     return matrix_->getLocalNumRows();
   }
 
-  size_t getLocalNumColumns() const { 
+  size_t getLocalNumColumns() const {
     return matrix_->getLocalNumCols();
   }
 
@@ -173,7 +169,7 @@ public:
 
   bool CRSViewAvailable() const { return true; }
 
-  void getRowIDsView(const gno_t *&rowIds) const 
+  void getRowIDsView(const gno_t *&rowIds) const
   {
     ArrayView<const gno_t> rowView = rowMap_->getLocalElementList();
     rowIds = rowView.getRawPtr();
@@ -208,7 +204,7 @@ public:
       std::ostringstream emsg;
       emsg << __FILE__ << ":" << __LINE__
            << "  Invalid row weight index " << idx << std::endl;
-      throw std::runtime_error(emsg.str()); 
+      throw std::runtime_error(emsg.str());
     }
 
     size_t length;
@@ -314,7 +310,7 @@ template <typename User, typename UserCoord>
       std::ostringstream emsg;
       emsg << __FILE__ << ":" << __LINE__
            << "  Invalid row weight index " << idx << std::endl;
-      throw std::runtime_error(emsg.str()); 
+      throw std::runtime_error(emsg.str());
   }
 
   size_t nvtx = getLocalNumRows();
@@ -349,7 +345,7 @@ template <typename User, typename UserCoord>
       std::ostringstream emsg;
       emsg << __FILE__ << ":" << __LINE__
            << "  Invalid row weight index " << idx << std::endl;
-      throw std::runtime_error(emsg.str()); 
+      throw std::runtime_error(emsg.str());
   }
 
 
@@ -360,9 +356,9 @@ template <typename User, typename UserCoord>
 template <typename User, typename UserCoord>
   template <typename Adapter>
     void XpetraCrsMatrixAdapter<User,UserCoord>::applyPartitioningSolution(
-      const User &in, User *&out, 
+      const User &in, User *&out,
       const PartitioningSolution<Adapter> &solution) const
-{ 
+{
   // Get an import list (rows to be received)
   size_t numNewRows;
   ArrayRCP<gno_t> importList;
@@ -384,9 +380,9 @@ template <typename User, typename UserCoord>
 template <typename User, typename UserCoord>
   template <typename Adapter>
     void XpetraCrsMatrixAdapter<User,UserCoord>::applyPartitioningSolution(
-      const User &in, RCP<User> &out, 
+      const User &in, RCP<User> &out,
       const PartitioningSolution<Adapter> &solution) const
-{ 
+{
   // Get an import list (rows to be received)
   size_t numNewRows;
   ArrayRCP<gno_t> importList;
@@ -403,5 +399,5 @@ template <typename User, typename UserCoord>
 }
 
 }  //namespace Zoltan2
-  
+
 #endif

--- a/packages/zoltan2/core/src/input/Zoltan2_XpetraMultiVectorAdapter.hpp
+++ b/packages/zoltan2/core/src/input/Zoltan2_XpetraMultiVectorAdapter.hpp
@@ -97,10 +97,6 @@ public:
     scalar_t, lno_t, gno_t, node_t> xt_mvector_t;
 #endif
 
-  /*! \brief Destructor
-   */
-  ~XpetraMultiVectorAdapter() { }
-
   /*! \brief Constructor
    *
    *  \param invector  the user's Xpetra, Tpetra or Epetra MultiVector object
@@ -177,7 +173,7 @@ public:
         std::ostringstream emsg;
         emsg << __FILE__ << ":" << __LINE__
              << "  Invalid weight index " << idx << std::endl;
-        throw std::runtime_error(emsg.str()); 
+        throw std::runtime_error(emsg.str());
     }
 
     size_t length;

--- a/packages/zoltan2/test/core/unit/CMakeLists.txt
+++ b/packages/zoltan2/test/core/unit/CMakeLists.txt
@@ -98,7 +98,7 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   PASS_REGULAR_EXPRESSION "PASS"
   FAIL_REGULAR_EXPRESSION "FAIL"
   )
- 
+
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   BasicIdentifierInput
   SOURCES input/BasicIdentifierInput.cpp
@@ -157,10 +157,10 @@ TRIBITS_COPY_FILES_TO_BINARY_DIR(copy_files_for_scorec_unit_tests
 )
 
 ENDIF()
- 
+
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   TpetraRowMatrixInput
-  SOURCES input/TpetraRowMatrixInput.cpp 
+  SOURCES input/TpetraRowMatrixInput.cpp
   NUM_MPI_PROCS 4
   COMM serial mpi
   PASS_REGULAR_EXPRESSION "PASS"
@@ -178,25 +178,25 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
 
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   XpetraTraits
-  SOURCES input/XpetraTraits.cpp 
+  SOURCES input/XpetraTraits.cpp
   NUM_MPI_PROCS 4
   COMM serial mpi
   PASS_REGULAR_EXPRESSION "PASS"
   FAIL_REGULAR_EXPRESSION "FAIL"
   )
- 
+
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   XpetraCrsMatrixInput
-  SOURCES input/XpetraCrsMatrixInput.cpp 
+  SOURCES input/XpetraCrsMatrixInput.cpp
   NUM_MPI_PROCS 4
   COMM serial mpi
   PASS_REGULAR_EXPRESSION "PASS"
   FAIL_REGULAR_EXPRESSION "FAIL"
   )
- 
+
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   XpetraCrsGraphInput
-  SOURCES input/XpetraCrsGraphInput.cpp 
+  SOURCES input/XpetraCrsGraphInput.cpp
   NUM_MPI_PROCS 4
   COMM serial mpi
   PASS_REGULAR_EXPRESSION "PASS"
@@ -205,7 +205,7 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
 
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   XpetraVectorInput
-  SOURCES input/XpetraVectorInput.cpp 
+  SOURCES input/XpetraVectorInput.cpp
   NUM_MPI_PROCS 4
   COMM serial mpi
   PASS_REGULAR_EXPRESSION "PASS"
@@ -214,7 +214,7 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
 
 TRIBITS_ADD_EXECUTABLE(
   XpetraMultiVectorInput
-  SOURCES input/XpetraMultiVectorInput.cpp 
+  SOURCES input/XpetraMultiVectorInput.cpp
   COMM serial mpi
   )
 
@@ -251,7 +251,7 @@ TRIBITS_ADD_TEST(
 #
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   GraphModel
-  SOURCES models/GraphModel.cpp 
+  SOURCES models/GraphModel.cpp
   NUM_MPI_PROCS 4
   COMM serial mpi
   PASS_REGULAR_EXPRESSION "PASS"
@@ -274,7 +274,7 @@ ENDIF()
 IF (${PROJECT_NAME}_ENABLE_Pamgen)
   TRIBITS_ADD_EXECUTABLE_AND_TEST(
     GraphModel2ndAdjsFromAdjs
-    SOURCES models/GraphModel2ndAdjsFromAdjs.cpp 
+    SOURCES models/GraphModel2ndAdjsFromAdjs.cpp
     NUM_MPI_PROCS 4
     COMM serial mpi
     PASS_REGULAR_EXPRESSION "PASS"
@@ -294,6 +294,15 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   CoordinateModel
   SOURCES models/CoordinateModel.cpp
+  NUM_MPI_PROCS 4
+  COMM serial mpi
+  PASS_REGULAR_EXPRESSION "PASS"
+  FAIL_REGULAR_EXPRESSION "FAIL"
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  MatrixAdapter
+  SOURCES input/MatrixAdapter.cpp
   NUM_MPI_PROCS 4
   COMM serial mpi
   PASS_REGULAR_EXPRESSION "PASS"
@@ -339,7 +348,7 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
 
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   Metric
-  SOURCES util/Metric.cpp 
+  SOURCES util/Metric.cpp
   NUM_MPI_PROCS 4
   COMM serial mpi
   PASS_REGULAR_EXPRESSION "PASS"
@@ -348,7 +357,7 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
 
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   TPLTraits
-  SOURCES util/TPLTraits.cpp 
+  SOURCES util/TPLTraits.cpp
   NUM_MPI_PROCS 4
   COMM serial mpi
   PASS_REGULAR_EXPRESSION "PASS"

--- a/packages/zoltan2/test/core/unit/input/MatrixAdapter.cpp
+++ b/packages/zoltan2/test/core/unit/input/MatrixAdapter.cpp
@@ -1,0 +1,332 @@
+// @HEADER
+//
+// ***********************************************************************
+//
+//   Zoltan2: A package of combinatorial algorithms for scientific computing
+//                  Copyright 2012 Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Karen Devine      (kddevin@sandia.gov)
+//                    Erik Boman        (egboman@sandia.gov)
+//                    Siva Rajamanickam (srajama@sandia.gov)
+//
+// ***********************************************************************
+//
+// @HEADER
+//
+// Testing of GraphAdapter built from Xpetra matrix input adapters.
+//
+
+/*! \brief Test of GraphAdapter interface.
+ *
+ */
+
+#include "Kokkos_StaticCrsGraph.hpp"
+#include "Kokkos_UnorderedMap.hpp"
+#include <Zoltan2_BasicVectorAdapter.hpp>
+#include <Zoltan2_InputTraits.hpp>
+#include <Zoltan2_TestHelpers.hpp>
+#include <Zoltan2_TpetraRowMatrixAdapter.hpp>
+#include <Zoltan2_XpetraCrsMatrixAdapter.hpp>
+
+#include <bitset>
+#include <iostream>
+#include <string>
+
+#include <Teuchos_ArrayView.hpp>
+#include <Teuchos_Comm.hpp>
+#include <Teuchos_DefaultComm.hpp>
+#include <Teuchos_TestingHelpers.hpp>
+
+using Teuchos::ArrayView;
+using Teuchos::Comm;
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+
+using simpleUser_t = Zoltan2::BasicUserTypes<zscalar_t, zlno_t, zgno_t>;
+
+using tcrsMatrix_t = Tpetra::CrsMatrix<zscalar_t, zlno_t, zgno_t, znode_t>;
+using trowMatrix_t = Tpetra::RowMatrix<zscalar_t, zlno_t, zgno_t, znode_t>;
+using tmap_t = Tpetra::Map<zlno_t, zgno_t, znode_t>;
+
+using simpleVAdapter_t = Zoltan2::BasicVectorAdapter<simpleUser_t>;
+using baseMAdapter_t = Zoltan2::MatrixAdapter<tcrsMatrix_t, simpleUser_t>;
+using tRowMAdapter_t = typename Zoltan2::TpetraRowMatrixAdapter<trowMatrix_t, simpleUser_t>;
+using zoffset_t = typename baseMAdapter_t::offset_t;
+
+/////////////////////////////////////////////////////////////////////////////
+int main(int narg, char *arg[]) {
+  Tpetra::ScopeGuard tscope(&narg, &arg);
+  Teuchos::RCP<const Teuchos::Comm<int>> comm = Tpetra::getDefaultComm();
+
+  int rank = comm->getRank();
+
+  int nVtxWeights = 5;
+  int nnzWgtIdx = -1;
+  std::string fname("simple");
+
+  if (rank == 0)
+    std::cout << "TESTING base case (global)" << std::endl;
+
+  // Input generator
+  UserInputForTests *uinput;
+
+  uinput = new UserInputForTests(testDataFilePath, fname, comm, true);
+
+  RCP<tcrsMatrix_t> M = uinput->getUITpetraCrsMatrix();
+  RCP<trowMatrix_t> trM = rcp_dynamic_cast<trowMatrix_t>(M);
+  RCP<const trowMatrix_t> ctrM = rcp_const_cast<const trowMatrix_t>(trM);
+  zlno_t nLocalRows = M->getLocalNumRows();
+
+  // Weights:
+  zscalar_t **rowWeights = NULL;
+  Zoltan2::BaseAdapter<trowMatrix_t>::WeightsDeviceView kRowWeights(
+      Kokkos::ViewAllocateWithoutInitializing("kRowWeights"), nVtxWeights,
+      nLocalRows);
+
+  auto kRowWeightsHost = Kokkos::create_mirror_view(kRowWeights);
+
+  if (nVtxWeights > 0) {
+    rowWeights = new zscalar_t *[nVtxWeights];
+    for (int i = 0; i < nVtxWeights; i++) {
+      if (nnzWgtIdx == i) {
+        rowWeights[i] = NULL;
+        kRowWeightsHost(i, 0) = 0;
+      } else {
+        rowWeights[i] = new zscalar_t[nLocalRows];
+        for (zlno_t j = 0; j < nLocalRows; j++) {
+          rowWeights[i][j] = 200000 * i + j;
+          kRowWeightsHost(i, j) = 200000 * i + j;
+        }
+      }
+    }
+  }
+
+  Kokkos::deep_copy(kRowWeights, kRowWeightsHost);
+
+  tRowMAdapter_t tmi(ctrM, nVtxWeights);
+  for (int i = 0; i < nVtxWeights; i++) {
+    tmi.setWeights(rowWeights[i], 1, i);
+  }
+  tmi.setRowWeights(kRowWeights);
+
+  simpleVAdapter_t *via = NULL;
+
+  // Set up some fake input
+  zscalar_t **coords = NULL;
+  int coordDim = 3;
+
+  if (coordDim > 0) {
+    coords = new zscalar_t *[coordDim];
+    for (int i = 0; i < coordDim; i++) {
+      coords[i] = new zscalar_t[nLocalRows];
+      for (zlno_t j = 0; j < nLocalRows; j++) {
+        coords[i][j] = 100000 * i + j;
+      }
+    }
+  }
+
+  zgno_t *gids = NULL;
+  if (coordDim > 0) {
+    gids = new zgno_t[nLocalRows];
+    for (zlno_t i = 0; i < nLocalRows; i++)
+      gids[i] = M->getRowMap()->getGlobalElement(i);
+    via = new simpleVAdapter_t(nLocalRows, gids, coords[0],
+                               (coordDim > 1 ? coords[1] : NULL),
+                               (coordDim > 2 ? coords[2] : NULL), 1, 1, 1);
+    tmi.setCoordinateInput(via);
+  }
+
+  // TEST of getIDsView, getIDsKokkosView, getRowIDsView, getRowIDsHostView and
+  // getRowIDsDeviceView
+
+  const zgno_t *ids;
+  const zgno_t *rowIds;
+  Zoltan2::BaseAdapter<simpleUser_t>::ConstIdsDeviceView kIds;
+  Zoltan2::BaseAdapter<simpleUser_t>::ConstIdsHostView kHostIds;
+  Zoltan2::BaseAdapter<simpleUser_t>::ConstIdsDeviceView kDeviceIds;
+
+  tmi.getIDsView(ids);
+  tmi.getRowIDsView(rowIds);
+  tmi.getIDsKokkosView(kIds);
+  auto kIdsHost = Kokkos::create_mirror_view(kIds);
+  Kokkos::deep_copy(kIdsHost, kIds);
+
+  tmi.getRowIDsHostView(kHostIds);
+  tmi.getRowIDsDeviceView(kDeviceIds);
+
+  auto kDeviceIdsHost = Kokkos::create_mirror_view(kDeviceIds);
+  Kokkos::deep_copy(kDeviceIdsHost, kDeviceIds);
+
+  bool success = true;
+  for (size_t i = 0; i < tmi.getLocalNumIDs(); ++i) {
+    TEUCHOS_TEST_EQUALITY(ids[i], kIdsHost(i), std::cout, success);
+    TEUCHOS_TEST_EQUALITY(ids[i], rowIds[i], std::cout, success);
+    TEUCHOS_TEST_EQUALITY(kIdsHost(i), kHostIds(i), std::cout, success);
+    TEUCHOS_TEST_EQUALITY(kIdsHost(i), kDeviceIdsHost(i), std::cout, success);
+  }
+  TEST_FAIL_AND_EXIT(*comm, success, "ids != vertexIds != kIds", 1)
+
+  // TEST of getCRSView, getCRSHostView and getCRSDeviceView
+  //  const zoffset_t *offsets;
+  ArrayRCP<const zoffset_t> offsets;
+  ArrayRCP<const zgno_t> colIds;
+  Zoltan2::BaseAdapter<trowMatrix_t>::ConstOffsetsHostView kHostOffsets;
+  Zoltan2::BaseAdapter<trowMatrix_t>::ConstIdsHostView kHostColIds;
+  Zoltan2::BaseAdapter<trowMatrix_t>::ConstOffsetsDeviceView kDeviceOffsets;
+  Zoltan2::BaseAdapter<trowMatrix_t>::ConstIdsDeviceView kDeviceColIds;
+  tmi.getCRSView(offsets, colIds);
+  tmi.getCRSHostView(kHostOffsets, kHostColIds);
+  tmi.getCRSDeviceView(kDeviceOffsets, kDeviceColIds);
+
+  auto kDeviceColIdsHost = Kokkos::create_mirror_view(kDeviceColIds);
+  Kokkos::deep_copy(kDeviceColIdsHost, kDeviceColIds);
+
+  auto kDeviceOffsetsHost = Kokkos::create_mirror_view(kDeviceOffsets);
+  Kokkos::deep_copy(kDeviceOffsetsHost, kDeviceOffsets);
+
+  for (int i = 0; success && i < colIds.size(); i++) {
+    TEUCHOS_TEST_EQUALITY(colIds[i], kHostColIds(i), std::cout, success);
+    TEUCHOS_TEST_EQUALITY(colIds[i], kDeviceColIdsHost(i), std::cout, success);
+  }
+  TEST_FAIL_AND_EXIT(*comm, success, "colIds != kHostColIds != kDeviceColIds",
+                     1)
+
+  for (int i = 0; success && i < offsets.size(); i++) {
+    TEUCHOS_TEST_EQUALITY(offsets[i], kHostOffsets(i), std::cout, success);
+    TEUCHOS_TEST_EQUALITY(offsets[i], kDeviceOffsetsHost(i), std::cout,
+                          success);
+  }
+  TEST_FAIL_AND_EXIT(*comm, success,
+                     "offsets != kHostOffsets != kDeviceOffsets", 1)
+
+  ArrayRCP<const zscalar_t> values;
+  Zoltan2::BaseAdapter<trowMatrix_t>::ConstScalarsHostView kHostValues;
+  Zoltan2::BaseAdapter<trowMatrix_t>::ConstScalarsDeviceView kDeviceValues;
+
+  tmi.getCRSView(offsets, colIds, values);
+  tmi.getCRSHostView(kHostOffsets, kHostColIds, kHostValues);
+  tmi.getCRSDeviceView(kDeviceOffsets, kDeviceColIds, kDeviceValues);
+  auto kDeviceValuesHost = Kokkos::create_mirror_view(kDeviceValues);
+  Kokkos::deep_copy(kDeviceValuesHost, kDeviceValues);
+
+  for (int i = 0; success && i < colIds.size(); i++) {
+    TEUCHOS_TEST_EQUALITY(colIds[i], kHostColIds(i), std::cout, success);
+    TEUCHOS_TEST_EQUALITY(colIds[i], kDeviceColIdsHost(i), std::cout, success);
+  }
+  TEST_FAIL_AND_EXIT(*comm, success, "colIds != kHostColIds != kDeviceColIds",
+                     1)
+
+  for (int i = 0; success && i < offsets.size(); i++) {
+    TEUCHOS_TEST_EQUALITY(offsets[i], kHostOffsets(i), std::cout, success);
+    TEUCHOS_TEST_EQUALITY(offsets[i], kDeviceOffsetsHost(i), std::cout,
+                          success);
+  }
+  TEST_FAIL_AND_EXIT(*comm, success,
+                     "offsets != kHostOffsets != kDeviceOffsets", 1)
+
+  for (int i = 0; success && i < values.size(); i++) {
+    TEUCHOS_TEST_EQUALITY(values[i], kHostValues(i), std::cout, success);
+    TEUCHOS_TEST_EQUALITY(values[i], kDeviceValuesHost(i), std::cout, success);
+  }
+  TEST_FAIL_AND_EXIT(*comm, success, "values != kHostValues != kDeviceValues",
+                     1)
+
+  // TEST of getRowWeightsView, getRowWeightsHostView and
+  // getRowWeightsDeviceView
+  for (int w = 0; success && w < nVtxWeights; w++) {
+    const zscalar_t *wgts;
+    Zoltan2::BaseAdapter<trowMatrix_t>::WeightsHostView kHostWgts;
+    Zoltan2::BaseAdapter<trowMatrix_t>::WeightsDeviceView kDeviceWgts;
+
+    Kokkos::View<zscalar_t **, typename znode_t::device_type> wkgts;
+    int stride;
+    tmi.getRowWeightsView(wgts, stride, w);
+    tmi.getRowWeightsHostView(kHostWgts);
+    tmi.getRowWeightsDeviceView(kDeviceWgts);
+
+    auto kDeviceWgtsHost = Kokkos::create_mirror_view(kDeviceWgts);
+    Kokkos::deep_copy(kDeviceWgtsHost, kDeviceWgts);
+
+    for (zlno_t i = 0; success && i < nLocalRows; ++i) {
+      TEUCHOS_TEST_EQUALITY(wgts[stride * i], kHostWgts(w, i), std::cout,
+                            success);
+      TEUCHOS_TEST_EQUALITY(wgts[stride * i], kDeviceWgtsHost(w, i), std::cout,
+                            success);
+    }
+  }
+  TEST_FAIL_AND_EXIT(*comm, success, "wgts != vwgts != wkgts", 1)
+
+  // TEST of useNumNonzerosAsRowWeight, useNumNonzerosAsRowWeightHost and
+  // useNumNonzerosAsRowWeightDevice
+  // for (int w = 0; success && w < nVtxWeights; w++) {
+  //   TEUCHOS_TEST_EQUALITY(tmi.useNumNonzerosAsRowWeight(w),
+  //                         tmi.useNumNonzerosAsRowWeightHost(w), std::cout,
+  //                         success);
+  //   TEUCHOS_TEST_EQUALITY(tmi.useNumNonzerosAsRowWeight(w),
+  //                         tmi.useNumNonzerosAsRowWeightDevice(w), std::cout,
+  //                         success);
+  // }
+  // TEST_FAIL_AND_EXIT(
+  //     *comm, success,
+  //     "useNumNonzerosAsRowWeight != useNumNonzerosAsRowWeightHost != "
+  //     "useNumNonzerosAsRowWeightDevice",
+  //     1)
+
+  // clean
+  if (nVtxWeights > 0) {
+    for (int i = 0; i < nVtxWeights; i++) {
+      if (rowWeights[i])
+        delete[] rowWeights[i];
+    }
+    delete[] rowWeights;
+  }
+
+  if (coordDim > 0) {
+    delete via;
+    delete[] gids;
+    for (int i = 0; i < coordDim; i++) {
+      if (coords[i])
+        delete[] coords[i];
+    }
+    delete[] coords;
+  }
+
+  delete uinput;
+
+  if (rank == 0)
+    std::cout << "PASS" << std::endl;
+
+  return 0;
+}

--- a/packages/zoltan2/test/core/unit/input/TpetraRowMatrixInput.cpp
+++ b/packages/zoltan2/test/core/unit/input/TpetraRowMatrixInput.cpp
@@ -43,7 +43,7 @@
 //
 // @HEADER
 //
-// Basic testing of Zoltan2::TpetraRowMatrixAdapter 
+// Basic testing of Zoltan2::TpetraRowMatrixAdapter
 
 /*! \file TpetraRowMatrixInput.cpp
  *  \brief Test of Zoltan2::TpetraRowMatrixAdapter class.
@@ -177,7 +177,7 @@ int main(int narg, char *arg[])
 
   size_t nrows = trM->getLocalNumRows();
 
-  // To test migration in the input adapter we need a Solution object. 
+  // To test migration in the input adapter we need a Solution object.
 
   RCP<const Zoltan2::Environment> env = rcp(new Zoltan2::Environment(comm));
 
@@ -196,14 +196,14 @@ int main(int narg, char *arg[])
 
   /////////////////////////////////////////////////////////////
   // User object is Tpetra::RowMatrix
-  if (!gfail){ 
+  if (!gfail){
     if (rank==0)
       std::cout << "Input adapter for Tpetra::RowMatrix" << std::endl;
-    
+
     RCP<const ztrowmatrix_t> ctrM = rcp_const_cast<const ztrowmatrix_t>(
                                    rcp_dynamic_cast<ztrowmatrix_t>(tM));
     RCP<adapter_t> trMInput;
-  
+
     try {
       trMInput = rcp(new adapter_t(ctrM));
     }
@@ -212,11 +212,11 @@ int main(int narg, char *arg[])
       std::cout << e.what() << std::endl;
     }
     TEST_FAIL_AND_EXIT(*comm, aok, "TpetraRowMatrixAdapter ", 1);
-  
+
     fail = verifyInputAdapter<ztrowmatrix_t>(*trMInput, *trM);
-  
+
     gfail = globalFail(*comm, fail);
-  
+
     if (!gfail){
       ztrowmatrix_t *mMigrate = NULL;
       try{
@@ -229,9 +229,9 @@ int main(int narg, char *arg[])
       }
 
       gfail = globalFail(*comm, fail);
-  
+
       if (!gfail){
-        RCP<const ztrowmatrix_t> cnewM = 
+        RCP<const ztrowmatrix_t> cnewM =
                                  rcp_const_cast<const ztrowmatrix_t>(newM);
         RCP<adapter_t> newInput;
         try{
@@ -242,10 +242,10 @@ int main(int narg, char *arg[])
           std::cout << e.what() << std::endl;
         }
         TEST_FAIL_AND_EXIT(*comm, aok, "TpetraRowMatrixAdapter 2 ", 1);
-  
+
         if (rank==0){
-          std::cout << 
-           "Input adapter for Tpetra::RowMatrix migrated to proc 0" << 
+          std::cout <<
+           "Input adapter for Tpetra::RowMatrix migrated to proc 0" <<
            std::endl;
         }
         fail = verifyInputAdapter<ztrowmatrix_t>(*newInput, *newM);


### PR DESCRIPTION
Changes:
- Cleanup some parts of Zoltan2 code (mostly Adapters)
- Add new API for Adapters that return Host/Device Kokkos::View for `get` methods (`getIds`, `getWeights` etc.)
- Deprecate (?) the old API (raw pointers/Teuchos Arrays)