### PR TITLE
rol: remove volatile from join in ROL_TpetraBoundConstraint.hpp

### DIFF
--- a/packages/rol/adapters/tpetra/src/function/ROL_TpetraBoundConstraint.hpp
+++ b/packages/rol/adapters/tpetra/src/function/ROL_TpetraBoundConstraint.hpp
@@ -86,8 +86,8 @@ namespace ROL {
             }
 
             KOKKOS_INLINE_FUNCTION
-            void join(volatile Real &globalMin,
-                      const volatile Real &localMin) const {
+            void join(Real &globalMin,
+                      const Real &localMin) const {
                 if(localMin<globalMin) {
                     globalMin = localMin;
                 }
@@ -122,8 +122,8 @@ namespace ROL {
             }
 
             KOKKOS_INLINE_FUNCTION
-            void join(volatile int &globalFeasible,
-                      const volatile int &localFeasible) const {
+            void join(int &globalFeasible,
+                      const int &localFeasible) const {
                 globalFeasible *= localFeasible;
             }
 


### PR DESCRIPTION
Compatibility update following kokkos@3.7
See kokkos/kokkos#4077 kokkos/kokkos#5194

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/rol 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
A couple more removal of volatile from join in ROL_TpetraBoundConstraint.hpp. This should be the last PR with cleanup (I didn't catch this in previous PR)

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

