### PR TITLE
Overload Kokkos::Impl::as_view_of_rank_n for Sacado/Stokhos scalar types

### DIFF
--- a/packages/kokkos/containers/src/Kokkos_DynRankView.hpp
+++ b/packages/kokkos/containers/src/Kokkos_DynRankView.hpp
@@ -1701,7 +1701,11 @@ namespace Impl {
    underlying memory, to facilitate implementation of deep_copy() and
    other routines that are defined on View */
 template <unsigned N, typename T, typename... Args>
-KOKKOS_FUNCTION auto as_view_of_rank_n(DynRankView<T, Args...> v) {
+KOKKOS_FUNCTION auto as_view_of_rank_n(
+    DynRankView<T, Args...> v,
+    typename std::enable_if<std::is_same<
+        typename ViewTraits<T, Args...>::specialize, void>::value>::type* =
+        nullptr) {
   if (v.rank() != N) {
     KOKKOS_IF_ON_HOST(
         const std::string message =

--- a/packages/kokkos/core/src/Kokkos_View.hpp
+++ b/packages/kokkos/core/src/Kokkos_View.hpp
@@ -1754,7 +1754,10 @@ struct RankDataType<ValueType, 0> {
 };
 
 template <unsigned N, typename... Args>
-KOKKOS_FUNCTION std::enable_if_t<N == View<Args...>::Rank, View<Args...>>
+KOKKOS_FUNCTION std::enable_if_t<
+    N == View<Args...>::Rank &&
+        std::is_same<typename ViewTraits<Args...>::specialize, void>::value,
+    View<Args...>>
 as_view_of_rank_n(View<Args...> v) {
   return v;
 }
@@ -1762,8 +1765,9 @@ as_view_of_rank_n(View<Args...> v) {
 // Placeholder implementation to compile generic code for DynRankView; should
 // never be called
 template <unsigned N, typename T, typename... Args>
-std::enable_if_t<
-    N != View<T, Args...>::Rank,
+KOKKOS_FUNCTION std::enable_if_t<
+    N != View<T, Args...>::Rank &&
+        std::is_same<typename ViewTraits<T, Args...>::specialize, void>::value,
     View<typename RankDataType<typename View<T, Args...>::value_type, N>::type,
          Args...>>
 as_view_of_rank_n(View<T, Args...>) {

--- a/packages/kokkos/core/src/Kokkos_View.hpp
+++ b/packages/kokkos/core/src/Kokkos_View.hpp
@@ -1765,7 +1765,7 @@ as_view_of_rank_n(View<Args...> v) {
 // Placeholder implementation to compile generic code for DynRankView; should
 // never be called
 template <unsigned N, typename T, typename... Args>
-KOKKOS_FUNCTION std::enable_if_t<
+std::enable_if_t<
     N != View<T, Args...>::Rank &&
         std::is_same<typename ViewTraits<T, Args...>::specialize, void>::value,
     View<typename RankDataType<typename View<T, Args...>::value_type, N>::type,

--- a/packages/sacado/src/KokkosExp_View_Fad.hpp
+++ b/packages/sacado/src/KokkosExp_View_Fad.hpp
@@ -654,7 +654,7 @@ as_view_of_rank_n(View<Args...> v) {
 // Placeholder implementation to compile generic code for DynRankView; should
 // never be called
 template <unsigned N, typename T, typename... Args>
-KOKKOS_FUNCTION std::enable_if_t<
+std::enable_if_t<
     N != View<T, Args...>::Rank &&
         (std::is_same<typename ViewTraits<T, Args...>::specialize,
                       Kokkos::Impl::ViewSpecializeSacadoFad>::value ||

--- a/packages/sacado/src/KokkosExp_View_Fad.hpp
+++ b/packages/sacado/src/KokkosExp_View_Fad.hpp
@@ -637,6 +637,39 @@ create_mirror_view_and_copy(
   return mirror;
 }
 
+namespace Impl {
+
+template <unsigned N, typename... Args>
+KOKKOS_FUNCTION std::enable_if_t<
+    N == View<Args...>::Rank &&
+    (std::is_same<typename ViewTraits<Args...>::specialize,
+                  Kokkos::Impl::ViewSpecializeSacadoFad>::value ||
+     std::is_same<typename ViewTraits<Args...>::specialize,
+                  Kokkos::Impl::ViewSpecializeSacadoFadContiguous>::value),
+    View<Args...>>
+as_view_of_rank_n(View<Args...> v) {
+  return v;
+}
+
+// Placeholder implementation to compile generic code for DynRankView; should
+// never be called
+template <unsigned N, typename T, typename... Args>
+KOKKOS_FUNCTION std::enable_if_t<
+    N != View<T, Args...>::Rank &&
+        (std::is_same<typename ViewTraits<T, Args...>::specialize,
+                      Kokkos::Impl::ViewSpecializeSacadoFad>::value ||
+         std::is_same<typename ViewTraits<T, Args...>::specialize,
+                      Kokkos::Impl::ViewSpecializeSacadoFadContiguous>::value),
+    View<typename RankDataType<typename View<T, Args...>::value_type, N>::type,
+         Args...>>
+as_view_of_rank_n(View<T, Args...>) {
+  Kokkos::Impl::throw_runtime_exception(
+      "Trying to get at a View of the wrong rank");
+  return {};
+}
+
+}
+
 } // namespace Kokkos
 
 //----------------------------------------------------------------------------

--- a/packages/sacado/src/Kokkos_View_Fad_Fwd.hpp
+++ b/packages/sacado/src/Kokkos_View_Fad_Fwd.hpp
@@ -196,6 +196,33 @@ create_mirror_view_and_copy(
         !Impl::MirrorViewType<Space, T, P...>::is_same_memspace>::type* =
         nullptr);
 
+namespace Impl {
+
+template <unsigned N, typename... Args>
+KOKKOS_FUNCTION std::enable_if_t<
+    N == View<Args...>::Rank &&
+    (std::is_same<typename ViewTraits<Args...>::specialize,
+                  Kokkos::Impl::ViewSpecializeSacadoFad>::value ||
+     std::is_same<typename ViewTraits<Args...>::specialize,
+                  Kokkos::Impl::ViewSpecializeSacadoFadContiguous>::value),
+    View<Args...>>
+as_view_of_rank_n(View<Args...> v);
+
+// Placeholder implementation to compile generic code for DynRankView; should
+// never be called
+template <unsigned N, typename T, typename... Args>
+KOKKOS_FUNCTION std::enable_if_t<
+    N != View<T, Args...>::Rank &&
+        (std::is_same<typename ViewTraits<T, Args...>::specialize,
+                      Kokkos::Impl::ViewSpecializeSacadoFad>::value ||
+         std::is_same<typename ViewTraits<T, Args...>::specialize,
+                      Kokkos::Impl::ViewSpecializeSacadoFadContiguous>::value),
+    View<typename RankDataType<typename View<T, Args...>::value_type, N>::type,
+         Args...>>
+as_view_of_rank_n(View<T, Args...>);
+
+}
+
 } // namespace Kokkos
 
 #endif // defined(HAVE_SACADO_VIEW_SPEC) && !defined(SACADO_DISABLE_FAD_VIEW_SPEC)

--- a/packages/sacado/src/Kokkos_View_Fad_Fwd.hpp
+++ b/packages/sacado/src/Kokkos_View_Fad_Fwd.hpp
@@ -211,7 +211,7 @@ as_view_of_rank_n(View<Args...> v);
 // Placeholder implementation to compile generic code for DynRankView; should
 // never be called
 template <unsigned N, typename T, typename... Args>
-KOKKOS_FUNCTION std::enable_if_t<
+std::enable_if_t<
     N != View<T, Args...>::Rank &&
         (std::is_same<typename ViewTraits<T, Args...>::specialize,
                       Kokkos::Impl::ViewSpecializeSacadoFad>::value ||

--- a/packages/stokhos/src/sacado/kokkos/pce/KokkosExp_View_UQ_PCE_Contiguous.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/KokkosExp_View_UQ_PCE_Contiguous.hpp
@@ -700,7 +700,7 @@ as_view_of_rank_n(View<Args...> v) {
 // Placeholder implementation to compile generic code for DynRankView; should
 // never be called
 template <unsigned N, typename T, typename... Args>
-KOKKOS_FUNCTION std::enable_if_t<
+std::enable_if_t<
     N != View<T, Args...>::Rank &&
         std::is_same<typename ViewTraits<T, Args...>::specialize,
                      Kokkos::Experimental::Impl::ViewPCEContiguous>::value,

--- a/packages/stokhos/src/sacado/kokkos/pce/KokkosExp_View_UQ_PCE_Contiguous.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/KokkosExp_View_UQ_PCE_Contiguous.hpp
@@ -685,6 +685,35 @@ void deep_copy( const View<DT,DP...> & dst ,
   Kokkos::fence();
 }
 
+namespace Impl {
+
+template <unsigned N, typename... Args>
+KOKKOS_FUNCTION std::enable_if_t<
+    N == View<Args...>::Rank &&
+    std::is_same<typename ViewTraits<Args...>::specialize,
+                 Kokkos::Experimental::Impl::ViewPCEContiguous>::value,
+    View<Args...>>
+as_view_of_rank_n(View<Args...> v) {
+  return v;
+}
+
+// Placeholder implementation to compile generic code for DynRankView; should
+// never be called
+template <unsigned N, typename T, typename... Args>
+KOKKOS_FUNCTION std::enable_if_t<
+    N != View<T, Args...>::Rank &&
+        std::is_same<typename ViewTraits<T, Args...>::specialize,
+                     Kokkos::Experimental::Impl::ViewPCEContiguous>::value,
+    View<typename RankDataType<typename View<T, Args...>::value_type, N>::type,
+         Args...>>
+as_view_of_rank_n(View<T, Args...>) {
+  Kokkos::Impl::throw_runtime_exception(
+      "Trying to get at a View of the wrong rank");
+  return {};
+}
+
+}
+
 }
 
 //----------------------------------------------------------------------------

--- a/packages/stokhos/src/sacado/kokkos/pce/Kokkos_View_UQ_PCE_Fwd.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/Kokkos_View_UQ_PCE_Fwd.hpp
@@ -258,7 +258,7 @@ as_view_of_rank_n(View<Args...> v);
 // Placeholder implementation to compile generic code for DynRankView; should
 // never be called
 template <unsigned N, typename T, typename... Args>
-KOKKOS_FUNCTION std::enable_if_t<
+std::enable_if_t<
     N != View<T, Args...>::Rank &&
         std::is_same<typename ViewTraits<T, Args...>::specialize,
                      Kokkos::Experimental::Impl::ViewPCEContiguous>::value,

--- a/packages/stokhos/src/sacado/kokkos/pce/Kokkos_View_UQ_PCE_Fwd.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/Kokkos_View_UQ_PCE_Fwd.hpp
@@ -245,6 +245,29 @@ void deep_copy( const ExecSpace &,
               , Kokkos::Experimental::Impl::ViewPCEContiguous >::value
                   )>::type * = 0 );
 
+namespace Impl {
+
+template <unsigned N, typename... Args>
+KOKKOS_FUNCTION std::enable_if_t<
+    N == View<Args...>::Rank &&
+    std::is_same<typename ViewTraits<Args...>::specialize,
+                 Kokkos::Experimental::Impl::ViewPCEContiguous>::value,
+    View<Args...>>
+as_view_of_rank_n(View<Args...> v);
+
+// Placeholder implementation to compile generic code for DynRankView; should
+// never be called
+template <unsigned N, typename T, typename... Args>
+KOKKOS_FUNCTION std::enable_if_t<
+    N != View<T, Args...>::Rank &&
+        std::is_same<typename ViewTraits<T, Args...>::specialize,
+                     Kokkos::Experimental::Impl::ViewPCEContiguous>::value,
+    View<typename RankDataType<typename View<T, Args...>::value_type, N>::type,
+         Args...>>
+as_view_of_rank_n(View<T, Args...>);
+
+}
+
 } // namespace Kokkos
 
 #endif /* #ifndef KOKKOS_VIEW_UQ_PCE_FWD_HPP */

--- a/packages/stokhos/src/sacado/kokkos/vector/KokkosExp_View_MP_Vector_Contiguous.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/KokkosExp_View_MP_Vector_Contiguous.hpp
@@ -474,7 +474,7 @@ as_view_of_rank_n(View<Args...> v) {
 // Placeholder implementation to compile generic code for DynRankView; should
 // never be called
 template <unsigned N, typename T, typename... Args>
-KOKKOS_FUNCTION std::enable_if_t<
+std::enable_if_t<
     N != View<T, Args...>::Rank &&
         std::is_same<typename ViewTraits<T, Args...>::specialize,
                      Kokkos::Experimental::Impl::ViewMPVectorContiguous>::value,

--- a/packages/stokhos/src/sacado/kokkos/vector/KokkosExp_View_MP_Vector_Contiguous.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/KokkosExp_View_MP_Vector_Contiguous.hpp
@@ -459,6 +459,35 @@ void deep_copy( const View<DT,DP...> & dst ,
   Kokkos::fence();
 }
 
+namespace Impl {
+
+template <unsigned N, typename... Args>
+KOKKOS_FUNCTION std::enable_if_t<
+    N == View<Args...>::Rank &&
+    std::is_same<typename ViewTraits<Args...>::specialize,
+                 Kokkos::Experimental::Impl::ViewMPVectorContiguous>::value,
+    View<Args...>>
+as_view_of_rank_n(View<Args...> v) {
+  return v;
+}
+
+// Placeholder implementation to compile generic code for DynRankView; should
+// never be called
+template <unsigned N, typename T, typename... Args>
+KOKKOS_FUNCTION std::enable_if_t<
+    N != View<T, Args...>::Rank &&
+        std::is_same<typename ViewTraits<T, Args...>::specialize,
+                     Kokkos::Experimental::Impl::ViewMPVectorContiguous>::value,
+    View<typename RankDataType<typename View<T, Args...>::value_type, N>::type,
+         Args...>>
+as_view_of_rank_n(View<T, Args...>) {
+  Kokkos::Impl::throw_runtime_exception(
+      "Trying to get at a View of the wrong rank");
+  return {};
+}
+
+}
+
 }
 
 namespace Kokkos {

--- a/packages/stokhos/src/sacado/kokkos/vector/Kokkos_View_MP_Vector_Fwd.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/Kokkos_View_MP_Vector_Fwd.hpp
@@ -260,7 +260,7 @@ as_view_of_rank_n(View<Args...> v);
 // Placeholder implementation to compile generic code for DynRankView; should
 // never be called
 template <unsigned N, typename T, typename... Args>
-KOKKOS_FUNCTION std::enable_if_t<
+std::enable_if_t<
     N != View<T, Args...>::Rank &&
         std::is_same<typename ViewTraits<T, Args...>::specialize,
                      Kokkos::Experimental::Impl::ViewMPVectorContiguous>::value,

--- a/packages/stokhos/src/sacado/kokkos/vector/Kokkos_View_MP_Vector_Fwd.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/Kokkos_View_MP_Vector_Fwd.hpp
@@ -247,6 +247,29 @@ void deep_copy( const ExecSpace &,
               , Kokkos::Experimental::Impl::ViewMPVectorContiguous >::value
     )>::type * = 0 );
 
+namespace Impl {
+
+template <unsigned N, typename... Args>
+KOKKOS_FUNCTION std::enable_if_t<
+    N == View<Args...>::Rank &&
+    std::is_same<typename ViewTraits<Args...>::specialize,
+                 Kokkos::Experimental::Impl::ViewMPVectorContiguous>::value,
+    View<Args...>>
+as_view_of_rank_n(View<Args...> v);
+
+// Placeholder implementation to compile generic code for DynRankView; should
+// never be called
+template <unsigned N, typename T, typename... Args>
+KOKKOS_FUNCTION std::enable_if_t<
+    N != View<T, Args...>::Rank &&
+        std::is_same<typename ViewTraits<T, Args...>::specialize,
+                     Kokkos::Experimental::Impl::ViewMPVectorContiguous>::value,
+    View<typename RankDataType<typename View<T, Args...>::value_type, N>::type,
+         Args...>>
+as_view_of_rank_n(View<T, Args...>);
+
+}
+
 } // namespace Kokkos
 
 #endif /* #ifndef KOKKOS_VIEW_MP_VECTOR_FWD_HPP */


### PR DESCRIPTION
This pulls in the changes from Kokkos PR [5491](https://github.com/kokkos/kokkos/pull/5491) to allow as_view_of_rank_n to be overloaded for Sacado and Stokhos, and implements the necessary overloads for these packages.  This fixes issue #11018 which was causing problems in Albany.