### PR TITLE
SEACAS: Add optional TPLs used by Seacas

### DIFF
--- a/TPLsList.cmake
+++ b/TPLsList.cmake
@@ -77,6 +77,7 @@ TRIBITS_REPOSITORY_DEFINE_TPLS(
   Scotch          "cmake/TPLs/"    ST
   OVIS            "cmake/TPLs/"    ST
   gpcd            "cmake/TPLs/"    ST
+  DataWarp        "cmake/TPLs/"    SS
   METIS           "cmake/TPLs/"    TS
   MTMETIS         "cmake/TPLs/"    EX
   ParMETIS        "cmake/TPLs/"    PT
@@ -97,7 +98,10 @@ TRIBITS_REPOSITORY_DEFINE_TPLS(
   CGNS            "${${PROJECT_NAME}_TRIBITS_DIR}/common_tpls/"  PT
   Pnetcdf         "${${PROJECT_NAME}_TRIBITS_DIR}/common_tpls/"  PT
   Netcdf          "${${PROJECT_NAME}_TRIBITS_DIR}/common_tpls/"  PT
-  ADIOS2          "packages/seacas/cmake/tpls/"    EX
+  ADIOS2          "${PROJECT_SOURCE_DIR}/packages/seacas/cmake/tpls/"    EX
+  Faodel          "${PROJECT_SOURCE_DIR}/packages/seacas/cmake/tpls/"    SS
+  Cereal          "${PROJECT_SOURCE_DIR}/packages/seacas/cmake/tpls/"    SS
+  Catalyst2       "${PROJECT_SOURCE_DIR}/packages/seacas/cmake/tpls/"    EX
   y12m            "cmake/TPLs/"    ST
   SuperLUDist     "cmake/TPLs/"    ST
   SuperLUMT	  "cmake/TPLs/"	   ST


### PR DESCRIPTION
Added a few optional TPLs that can be used with the SEACAS IOSS library to provide additional capabilities.  These include:

* DataWarp -- Cray's burst buffer library
* Faodel -- a collection of data management tools that Sandia is developing to improve how datasets migrate between memory and storage resources in a distributed system.
* Cereal -- used by Faodel for serialization
* Catalyst2 -- Embedded visualization capability

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/seacas

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

## Related Issues

* Related to #11154 


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->