### PR TITLE
Teko fix return of temporary address

### DIFF
--- a/packages/teko/src/Epetra/Teko_EpetraHelpers.cpp
+++ b/packages/teko/src/Epetra/Teko_EpetraHelpers.cpp
@@ -232,7 +232,9 @@ void zeroMultiVectorRowIndices(Epetra_MultiVector & mv,const std::vector<int> & 
 ZeroedOperator::ZeroedOperator(const std::vector<int> & zeroIndices,
                                const Teuchos::RCP<const Epetra_Operator> & op)
    : zeroIndices_(zeroIndices), epetraOp_(op)
-{ }
+{
+   label_ = "zeroed( "+std::string(epetraOp_->Label())+" )";
+}
 
 //! Perform a matrix-vector product with certain rows zeroed out
 int ZeroedOperator::Apply(const Epetra_MultiVector& X, Epetra_MultiVector& Y) const

--- a/packages/teko/src/Epetra/Teko_EpetraHelpers.hpp
+++ b/packages/teko/src/Epetra/Teko_EpetraHelpers.hpp
@@ -163,8 +163,7 @@ public:
    double NormInf() const { return -1.0; }
 
    //!
-   const char* Label() const
-   {return ("zeroed( "+std::string(epetraOp_->Label())+" )").c_str(); }
+   const char* Label() const {return label_.c_str();}
 
    //!
    bool UseTranspose() const {return false;}
@@ -186,6 +185,7 @@ public:
 protected:
    std::vector<int> zeroIndices_;
    const Teuchos::RCP<const Epetra_Operator> epetraOp_;
+   std::string label_;
 };
 
 } // end namespace Epetra


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/teko 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
const char * function returns address to temporary variable
```make
/trilinos/packages/teko/src/Epetra/Teko_EpetraHelpers.hpp:167:12: warning: returning address of local temporary object [-Wreturn-stack-address]
   {return ("zeroed( "+std::string(epetraOp_->Label())+" )").c_str(); }
```

This PR adds a `label_` std::string that is set at construction (all info needed is there at that time) and the c_str() is then returned for label. This is consistent with `/trilinos/packages/teko/src/Epetra/Teko_EpetraOperatorWrapper.hpp`