### PR TITLE
Cleanup warnings and refactor deprecated code

### DIFF
--- a/packages/aztecoo/src/az_gmres_condnum.c
+++ b/packages/aztecoo/src/az_gmres_condnum.c
@@ -832,7 +832,7 @@ static void dgeev_interface(double **H, int n,
 	    &ldvl, vr, &ldvr, work, &lwork, &info);
   
   for( i=0 ; i<n ; i++ )
-    if( abs(Er[i])>largest_inv_A2 ) largest_inv_A2 = abs(Er[i]);
+    if( fabs(Er[i])>largest_inv_A2 ) largest_inv_A2 = fabs(Er[i]);
   
   largest_inv_A2 = sqrt(largest_inv_A2);
 

--- a/packages/aztecoo/src/az_scaling.c
+++ b/packages/aztecoo/src/az_scaling.c
@@ -1376,10 +1376,10 @@ void AZ_sym_diagonal_scaling(int action, AZ_MATRIX *Amat,
 
   /* rescale right hand side and solution */
 
-  if ( (action == AZ_SCALE_RHS) ) {
+  if (action == AZ_SCALE_RHS) {
        for (irow = 0; irow < N; irow++) b[irow] *= sc_vec[irow];
   }
-  if ( action == AZ_INVSCALE_RHS)  {
+  if (action == AZ_INVSCALE_RHS)  {
        for (irow = 0; irow < N; irow++) b[irow] /= sc_vec[irow];
   }
   if (action == AZ_SCALE_MAT_RHS_SOL) {
@@ -1626,10 +1626,10 @@ void AZ_sym_row_sum_scaling(int action, AZ_MATRIX *Amat,
     } /* VBR */
   }
 
-  if ( (action == AZ_SCALE_RHS) ) {
+  if (action == AZ_SCALE_RHS) {
        for (row = 0; row < N; row++) b[row] *= sc_vec[row];
   }
-  if ( action == AZ_INVSCALE_RHS)  {
+  if (action == AZ_INVSCALE_RHS)  {
        for (row = 0; row < N; row++) b[row] /= sc_vec[row];
   }
   if (action == AZ_SCALE_MAT_RHS_SOL) {
@@ -1934,10 +1934,10 @@ void AZ_equil_scaling(int action, AZ_MATRIX *Amat,
     free((void *) colsum);
   }
 
-  if ( (action == AZ_SCALE_RHS) ) {
+  if (action == AZ_SCALE_RHS) {
        for (row = 0; row < N; row++) b[row] *= sc_vec[row];
   }
-  if ( action == AZ_INVSCALE_RHS)  {
+  if (action == AZ_INVSCALE_RHS)  {
        for (row = 0; row < N; row++) b[row] /= sc_vec[row];
   }
   if (action == AZ_SCALE_MAT_RHS_SOL) {

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_SolverManagerBase.hpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_SolverManagerBase.hpp
@@ -198,7 +198,7 @@ public:
     return lastSolverOutput_.converged ? Belos::Converged : Belos::Unconverged;
   }
 
-  typename Teuchos::ScalarTraits<SC>::magnitudeType achievedTol() const {
+  typename Teuchos::ScalarTraits<SC>::magnitudeType achievedTol() const override {
     using STS = Teuchos::ScalarTraits<SC>;
     using real_type = typename STS::magnitudeType;
     const SC one = STS::one ();

--- a/packages/epetraext/src/coloring/EpetraExt_MapColoring.cpp
+++ b/packages/epetraext/src/coloring/EpetraExt_MapColoring.cpp
@@ -59,6 +59,7 @@
 #include <vector>
 #include <set>
 #include <map>
+#include <random>
 
 using std::vector;
 using std::set;
@@ -199,7 +200,9 @@ Toperator( OriginalTypeRef orig  )
       for( int i = 0; i < nCols; ++i )
         rowOrder[ i ] = i;
 #ifndef TFLOP
-      std::random_shuffle( rowOrder.begin(), rowOrder.end() );
+      std::random_device rd;
+      std::mt19937 g(rd());
+      std::shuffle( rowOrder.begin(), rowOrder.end(), g );
 #endif
     }
 
@@ -609,7 +612,9 @@ Toperator( OriginalTypeRef orig  )
       for( int i = 0; i < nRows; ++i )
         rowOrder[i] = i;
 #ifdef TFLOP
-      random_shuffle( rowOrder.begin(), rowOrder.end() );
+      std::random_device rd;
+      std::mt19937 g(rd());
+      std::shuffle( rowOrder.begin(), rowOrder.end(), g );
 #endif
     }
 

--- a/packages/ml/src/Operator/ml_op_utils.c
+++ b/packages/ml/src/Operator/ml_op_utils.c
@@ -2095,8 +2095,8 @@ void ML_Operator_ReportStatistics(ML_Operator *mat, char *appendlabel,
     which limits.h did not exist.  In any case, I decided to leave the
     line of code alone.
     */
-    minStencil = ML_gmin_int( (proc_active ? mat->min_nz_per_row : 1e11), comm);
-    minproc = ML_gmax_int( (minStencil == mat->min_nz_per_row ? mypid:0), comm);
+    minStencil = ML_gmin_int(proc_active ? mat->min_nz_per_row : (int)1e11, comm);
+    minproc = ML_gmax_int(minStencil == mat->min_nz_per_row ? mypid:0, comm);
     t1 = NglobNonzeros/((double) Nglobrows);
     if (mypid == 0) {
       printf("%s: max stencil size (pid %d) \t= %d\n",

--- a/packages/ml/src/Operator/ml_rap_utils.c
+++ b/packages/ml/src/Operator/ml_rap_utils.c
@@ -323,7 +323,7 @@ void ML_get_matrix_row(ML_Operator *input_matrix, int N_requested_rows,
       *values  = t2;
    }
 
-   if ( (input_matrix->getrow->use_loc_glob_map == ML_YES)) {
+   if (input_matrix->getrow->use_loc_glob_map == ML_YES) {
       mapper       = input_matrix->getrow->loc_glob_map;
       for (i = 0; i < row_lengths[0]; i++)
          (*columns)[i+index] = mapper[(*columns)[index+i]];
@@ -413,7 +413,7 @@ void ML_get_matrow_VBR(ML_Operator *input_matrix, int N_requested_rows,
       *val_ptr++  = *val_start++;
    }
 
-   if ( (input_matrix->getrow->use_loc_glob_map == ML_YES)) {
+   if (input_matrix->getrow->use_loc_glob_map == ML_YES) {
       col_size = matrix->cpntr[1]-matrix->cpntr[0];
 /*mapper       = input_matrix->getrow->loc_glob_map;*/
       for (i = 0; i < row_lengths[0]; i++)
@@ -503,7 +503,7 @@ void ML_get_matrow_CSR(ML_Operator *input_matrix, int N_requested_rows,
       *val_ptr++  = *val++;
    }
 
-   if ( (input_matrix->getrow->use_loc_glob_map == ML_YES)) {
+   if (input_matrix->getrow->use_loc_glob_map == ML_YES) {
       mapper       = input_matrix->getrow->loc_glob_map;
       for (i = 0; i < row_lengths[0]; i++)
          (*columns)[i+index] = mapper[(*columns)[index+i]];
@@ -581,7 +581,7 @@ void ML_get_row_CSR_norow_map(ML_Operator *input_matrix, int N_requested_rows,
       *val_ptr++  = *val++;
    }
 
-   if ( (input_matrix->getrow->use_loc_glob_map == ML_YES)) {
+   if (input_matrix->getrow->use_loc_glob_map == ML_YES) {
       mapper       = input_matrix->getrow->loc_glob_map;
       for (i = 0; i < row_lengths[0]; i++)
          (*columns)[i+index] = mapper[(*columns)[index+i]];

--- a/packages/stratimikos/adapters/belos/src/Thyra_BelosTpetrasSolverAdapter.hpp
+++ b/packages/stratimikos/adapters/belos/src/Thyra_BelosTpetrasSolverAdapter.hpp
@@ -76,7 +76,7 @@ namespace Thyra {
     BelosTpetraKrylov() = default;
 
     //! clone for Inverted Injection (DII)
-    virtual Teuchos::RCP<Belos::SolverManager<SC, MV, OP> > clone () const = 0;
+    virtual Teuchos::RCP<Belos::SolverManager<SC, MV, OP> > clone () const override = 0;
 
     //! set/get problem
     void setProblem( const Teuchos::RCP<Belos::LinearProblem<SC, MV, OP> > &problem ) override {

--- a/packages/zoltan/src/lb/lb_init.c
+++ b/packages/zoltan/src/lb/lb_init.c
@@ -125,7 +125,7 @@ void Zoltan_LB_Init(struct Zoltan_LB_Struct *lb, int num_proc)
 size_t Zoltan_LB_Serialize_Size(struct Zoltan_Struct const *zz) 
 {
   size_t bufSize = 0;
-  struct Zoltan_LB_Struct *lb = &(zz->LB);
+  const struct Zoltan_LB_Struct *lb = &(zz->LB);
 
   /* Copy 12 integers from zz->LB */
   bufSize += 12 * sizeof(int);
@@ -158,7 +158,7 @@ size_t Zoltan_LB_Serialize_Size(struct Zoltan_Struct const *zz)
 void Zoltan_LB_Serialize(struct Zoltan_Struct const *zz, char **buf)
 {
   char *bufptr = *buf;
-  struct Zoltan_LB_Struct *lb = &(zz->LB);
+  const struct Zoltan_LB_Struct *lb = &(zz->LB);
 
   /* Copy 12 integers; if add more, update Zoltan_LB_Serialize_Size */
   int *intptr = (int *) bufptr;

--- a/packages/zoltan/src/params/free_params.c
+++ b/packages/zoltan/src/params/free_params.c
@@ -117,6 +117,8 @@ int Zoltan_Serialize_Params(struct Zoltan_Struct const *from, char **buf)
     param = param->next;
   }
   *buf = bufptr;
+
+  return ZOLTAN_OK;
 }
 
 int Zoltan_Deserialize_Params(struct Zoltan_Struct *to, char **buf)
@@ -137,6 +139,8 @@ int Zoltan_Deserialize_Params(struct Zoltan_Struct *to, char **buf)
     bufptr += 2 * MAX_PARAM_STRING_LEN;
   }
   *buf = bufptr;
+
+  return ZOLTAN_OK;
 }
 
 int Zoltan_Copy_Params(PARAM_LIST **to, PARAM_LIST const *from)


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/aztecoo 
@trilinos/zoltan 
@trilinos/belos 
@trilinos/epetraext 
@trilinos/ml 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Clean up a number of warnings and deprecated code:

```make
/Users/pakuber/Compadre/trilinos/packages/zoltan/src/lb/lb_init.c:128:28: warning: initializing 'struct Zoltan_LB_Struct *' with an expression of type 'const struct Zoltan_LB_Struct *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
[ 31%] Building C object packages/aztecoo/src/CMakeFiles/aztecoo.dir/az_matvec_mult.c.o
/Users/pakuber/Compadre/trilinos/packages/aztecoo/src/az_gmres_condnum.c:835:9: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
    if( abs(Er[i])>largest_inv_A2 ) largest_inv_A2 = abs(Er[i]);
vi:1379:16: warning: equality comparison with extraneous parentheses [-Wparentheses-equality]
  if ( (action == AZ_SCALE_RHS) ) {
/Users/pakuber/Compadre/trilinos/packages/aztecoo/src/az_scaling.c:1629:16: warning: equality comparison with extraneous parentheses [-Wparentheses-equality]
  if ( (action == AZ_SCALE_RHS) ) {
/Users/pakuber/Compadre/trilinos/packages/aztecoo/src/az_scaling.c:1937:16: warning: equality comparison with extraneous parentheses [-Wparentheses-equality]
  if ( (action == AZ_SCALE_RHS) ) {
[ 34%] Linking CXX executable ThyraCore_DefaultBlockedTriangularLinearOpWithSolveUnitTests.exe
/Users/pakuber/Compadre/trilinos/packages/epetraext/src/coloring/EpetraExt_MapColoring.cpp:202:12: warning: 'random_shuffle<std::__wrap_iter<int *>>' is deprecated [-Wdeprecated-declarations]
      std::random_shuffle( rowOrder.begin(), rowOrder.end() );
[ 52%] Building C object packages/ml/src/CMakeFiles/ml.dir/Utils/ml_rbm.c.o
/Users/pakuber/Compadre/trilinos/packages/ml/src/Operator/ml_op_utils.c:2098:68: warning: implicit conversion of out of range value from 'double' to 'int' is undefined [-Wliteral-conversion]
    minStencil = ML_gmin_int( (proc_active ? mat->min_nz_per_row : 1e11), comm);
[ 53%] Building C object packages/ml/src/CMakeFiles/ml.dir/Utils/ml_twogrid_analysis.c.o
/Users/pakuber/Compadre/trilinos/packages/ml/src/Operator/ml_rap_utils.c:326:49: warning: equality comparison with extraneous parentheses [-Wparentheses-equality]
   if ( (input_matrix->getrow->use_loc_glob_map == ML_YES)) {
[ 63%] Building CXX object packages/belos/tpetra/src/CMakeFiles/belostpetra.dir/solvers/Belos_Tpetra_PseudoBlockGmres.cpp.o
In file included from /Users/pakuber/Compadre/trilinos/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresSingleReduce.cpp:46:
In file included from /Users/pakuber/Compadre/trilinos/packages/belos/tpetra/src/solvers/Belos_Tpetra_SolverManager.hpp:44:
/Users/pakuber/Compadre/trilinos/packages/belos/tpetra/src/solvers/Belos_Tpetra_SolverManagerBase.hpp:201:53: warning: 'achievedTol' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  typename Teuchos::ScalarTraits<SC>::magnitudeType achievedTol() const {
```
Replaced `std::random_shuffle` consistent with `https://en.cppreference.com/w/cpp/algorithm/random_shuffle`.
