### PR TITLE
Fix Stokhos tests/examples for CUDA w/o UVM and newer CUDA toolkits

### DIFF
--- a/packages/stokhos/example/epetra/twoD_diffusion_ME.cpp
+++ b/packages/stokhos/example/epetra/twoD_diffusion_ME.cpp
@@ -52,7 +52,7 @@ namespace {
   struct KL_Diffusion_Func {
     double mean;
     mutable Teuchos::Array<double> point;
-    Teuchos::RCP< Stokhos::KL::ExponentialRandomField<double> > rf;
+    Teuchos::RCP< Stokhos::KL::ExponentialRandomField<double, Kokkos::DefaultHostExecutionSpace> > rf;
 
     KL_Diffusion_Func(double xyLeft, double xyRight,
                       double mean_, double std_dev,
@@ -75,7 +75,7 @@ namespace {
       rfParams.set("Correlation Lengths", correlation_length);
 
       rf =
-        Teuchos::rcp(new Stokhos::KL::ExponentialRandomField<double>(rfParams));
+        Teuchos::rcp(new Stokhos::KL::ExponentialRandomField<double, Kokkos::DefaultHostExecutionSpace>(rfParams));
     }
 
     ~KL_Diffusion_Func() {

--- a/packages/stokhos/src/kokkos/Cuda/Stokhos_Cuda_CrsMatrix.hpp
+++ b/packages/stokhos/src/kokkos/Cuda/Stokhos_Cuda_CrsMatrix.hpp
@@ -123,6 +123,45 @@ public:
     const int n = A.graph.row_map.extent(0) - 1 ;
     const int nz = A.graph.entries.extent(0);
 
+#if CUSPARSE_VERSION >= 10300
+    using offset_type = typename matrix_type::graph_type::size_type;
+    using entry_type  = typename matrix_type::graph_type::data_type;
+    const cusparseIndexType_t myCusparseOffsetType =
+      sizeof(offset_type) == 4 ? CUSPARSE_INDEX_32I : CUSPARSE_INDEX_64I;
+    const cusparseIndexType_t myCusparseEntryType =
+      sizeof(entry_type) == 4 ? CUSPARSE_INDEX_32I : CUSPARSE_INDEX_64I;
+    cusparseSpMatDescr_t A_cusparse;
+    cusparseCreateCsr(
+      &A_cusparse, n, n, nz,
+      (void*)A.graph.row_map.data(), (void*)A.graph.entries.data(),
+      (void*)A.values.data(), myCusparseOffsetType, myCusparseEntryType,
+      CUSPARSE_INDEX_BASE_ZERO, CUDA_R_32F);
+    cusparseDnVecDescr_t x_cusparse, y_cusparse;
+    cusparseCreateDnVec(&x_cusparse, n, (void*)x.data(), CUDA_R_32F);
+    cusparseCreateDnVec(&y_cusparse, n, (void*)y.data(), CUDA_R_32F);
+    size_t bufferSize = 0;
+    void* dBuffer     = NULL;
+    cusparseSpMV_bufferSize(
+      s.handle, CUSPARSE_OPERATION_NON_TRANSPOSE, &alpha, A_cusparse,
+      x_cusparse, &beta, y_cusparse, CUDA_R_32F, CUSPARSE_MV_ALG_DEFAULT,
+      &bufferSize);
+    cudaMalloc(&dBuffer, bufferSize);
+    cusparseStatus_t status =
+      cusparseSpMV(s.handle ,
+                   CUSPARSE_OPERATION_NON_TRANSPOSE ,
+                   &alpha ,
+                   A_cusparse ,
+                   x_cusparse ,
+                   &beta ,
+                   y_cusparse ,
+                   CUDA_R_32F ,
+                   CUSPARSE_MV_ALG_DEFAULT ,
+                   dBuffer );
+    cudaFree(dBuffer);
+    cusparseDestroyDnVec(x_cusparse);
+    cusparseDestroyDnVec(y_cusparse);
+    cusparseDestroySpMat(A_cusparse);
+#else
     cusparseStatus_t status =
       cusparseScsrmv( s.handle ,
                       CUSPARSE_OPERATION_NON_TRANSPOSE ,
@@ -135,6 +174,7 @@ public:
                       x.data() ,
                       &beta ,
                       y.data() );
+#endif
 
     if ( CUSPARSE_STATUS_SUCCESS != status ) {
       throw std::runtime_error( std::string("ERROR - cusparseScsrmv " ) );
@@ -167,6 +207,45 @@ public:
     const int n = A.graph.row_map.extent(0) - 1 ;
     const int nz = A.graph.entries.extent(0);
 
+#if CUSPARSE_VERSION >= 10300
+    using offset_type = typename matrix_type::graph_type::size_type;
+    using entry_type  = typename matrix_type::graph_type::data_type;
+    const cusparseIndexType_t myCusparseOffsetType =
+      sizeof(offset_type) == 4 ? CUSPARSE_INDEX_32I : CUSPARSE_INDEX_64I;
+    const cusparseIndexType_t myCusparseEntryType =
+      sizeof(entry_type) == 4 ? CUSPARSE_INDEX_32I : CUSPARSE_INDEX_64I;
+    cusparseSpMatDescr_t A_cusparse;
+    cusparseCreateCsr(
+      &A_cusparse, n, n, nz,
+      (void*)A.graph.row_map.data(), (void*)A.graph.entries.data(),
+      (void*)A.values.data(), myCusparseOffsetType, myCusparseEntryType,
+      CUSPARSE_INDEX_BASE_ZERO, CUDA_R_64F);
+    cusparseDnVecDescr_t x_cusparse, y_cusparse;
+    cusparseCreateDnVec(&x_cusparse, n, (void*)x.data(), CUDA_R_64F);
+    cusparseCreateDnVec(&y_cusparse, n, (void*)y.data(), CUDA_R_64F);
+    size_t bufferSize = 0;
+    void* dBuffer     = NULL;
+    cusparseSpMV_bufferSize(
+      s.handle, CUSPARSE_OPERATION_NON_TRANSPOSE, &alpha, A_cusparse,
+      x_cusparse, &beta, y_cusparse, CUDA_R_64F, CUSPARSE_MV_ALG_DEFAULT,
+      &bufferSize);
+    cudaMalloc(&dBuffer, bufferSize);
+    cusparseStatus_t status =
+      cusparseSpMV(s.handle ,
+                   CUSPARSE_OPERATION_NON_TRANSPOSE ,
+                   &alpha ,
+                   A_cusparse ,
+                   x_cusparse ,
+                   &beta ,
+                   y_cusparse ,
+                   CUDA_R_64F ,
+                   CUSPARSE_MV_ALG_DEFAULT ,
+                   dBuffer );
+    cudaFree(dBuffer);
+    cusparseDestroyDnVec(x_cusparse);
+    cusparseDestroyDnVec(y_cusparse);
+    cusparseDestroySpMat(A_cusparse);
+#else
     cusparseStatus_t status =
       cusparseDcsrmv( s.handle ,
                       CUSPARSE_OPERATION_NON_TRANSPOSE ,
@@ -179,6 +258,7 @@ public:
                       x.data() ,
                       &beta ,
                       y.data() );
+#endif
 
     if ( CUSPARSE_STATUS_SUCCESS != status ) {
       throw std::runtime_error( std::string("ERROR - cusparseDcsrmv " ) );
@@ -227,6 +307,51 @@ public:
     }
 
     // Sparse matrix-times-multivector
+#if CUSPARSE_VERSION >= 10300
+    using offset_type = typename matrix_type::graph_type::size_type;
+    using entry_type  = typename matrix_type::graph_type::data_type;
+    const cusparseIndexType_t myCusparseOffsetType =
+      sizeof(offset_type) == 4 ? CUSPARSE_INDEX_32I : CUSPARSE_INDEX_64I;
+    const cusparseIndexType_t myCusparseEntryType =
+      sizeof(entry_type) == 4 ? CUSPARSE_INDEX_32I : CUSPARSE_INDEX_64I;
+    cusparseSpMatDescr_t A_cusparse;
+    cusparseCreateCsr(
+      &A_cusparse, n, n, nz,
+      (void*)A.graph.row_map.data(), (void*)A.graph.entries.data(),
+      (void*)A.values.data(), myCusparseOffsetType, myCusparseEntryType,
+      CUSPARSE_INDEX_BASE_ZERO, CUDA_R_32F);
+    cusparseDnMatDescr_t x_cusparse, y_cusparse;
+    cusparseCreateDnMat(
+      &x_cusparse, n, ncol, n,
+      (void*)xx.data(), CUDA_R_32F, CUSPARSE_ORDER_COL);
+    cusparseCreateDnMat(
+      &y_cusparse, n, ncol, n,
+      (void*)yy.data(), CUDA_R_32F, CUSPARSE_ORDER_COL);
+    size_t bufferSize = 0;
+    void* dBuffer     = NULL;
+    cusparseSpMM_bufferSize(
+      s.handle, CUSPARSE_OPERATION_NON_TRANSPOSE,
+      CUSPARSE_OPERATION_NON_TRANSPOSE, &alpha, A_cusparse,
+      x_cusparse, &beta, y_cusparse, CUDA_R_32F, CUSPARSE_MM_ALG_DEFAULT,
+      &bufferSize);
+    cudaMalloc(&dBuffer, bufferSize);
+    cusparseStatus_t status =
+      cusparseSpMM(s.handle ,
+                   CUSPARSE_OPERATION_NON_TRANSPOSE ,
+                   CUSPARSE_OPERATION_NON_TRANSPOSE ,
+                   &alpha ,
+                   A_cusparse ,
+                   x_cusparse ,
+                   &beta ,
+                   y_cusparse ,
+                   CUDA_R_32F ,
+                   CUSPARSE_MM_ALG_DEFAULT ,
+                   dBuffer );
+    cudaFree(dBuffer);
+    cusparseDestroyDnMat(x_cusparse);
+    cusparseDestroyDnMat(y_cusparse);
+    cusparseDestroySpMat(A_cusparse);
+#else
     cusparseStatus_t status =
       cusparseScsrmm( s.handle ,
                       CUSPARSE_OPERATION_NON_TRANSPOSE ,
@@ -241,6 +366,7 @@ public:
                       &beta ,
                       yy.data() ,
                       n );
+#endif
 
     if ( CUSPARSE_STATUS_SUCCESS != status ) {
       throw std::runtime_error( std::string("ERROR - cusparseDcsrmv " ) );
@@ -396,6 +522,51 @@ public:
     }
 
     // Sparse matrix-times-multivector
+#if CUSPARSE_VERSION >= 10300
+    using offset_type = typename matrix_type::graph_type::size_type;
+    using entry_type  = typename matrix_type::graph_type::data_type;
+    const cusparseIndexType_t myCusparseOffsetType =
+      sizeof(offset_type) == 4 ? CUSPARSE_INDEX_32I : CUSPARSE_INDEX_64I;
+    const cusparseIndexType_t myCusparseEntryType =
+      sizeof(entry_type) == 4 ? CUSPARSE_INDEX_32I : CUSPARSE_INDEX_64I;
+    cusparseSpMatDescr_t A_cusparse;
+    cusparseCreateCsr(
+      &A_cusparse, n, n, nz,
+      (void*)A.graph.row_map.data(), (void*)A.graph.entries.data(),
+      (void*)A.values.data(), myCusparseOffsetType, myCusparseEntryType,
+      CUSPARSE_INDEX_BASE_ZERO, CUDA_R_64F);
+    cusparseDnMatDescr_t x_cusparse, y_cusparse;
+    cusparseCreateDnMat(
+      &x_cusparse, n, ncol, n,
+      (void*)xx.data(), CUDA_R_64F, CUSPARSE_ORDER_COL);
+    cusparseCreateDnMat(
+      &y_cusparse, n, ncol, n,
+      (void*)yy.data(), CUDA_R_64F, CUSPARSE_ORDER_COL);
+    size_t bufferSize = 0;
+    void* dBuffer     = NULL;
+    cusparseSpMM_bufferSize(
+      s.handle, CUSPARSE_OPERATION_NON_TRANSPOSE,
+      CUSPARSE_OPERATION_NON_TRANSPOSE, &alpha, A_cusparse,
+      x_cusparse, &beta, y_cusparse, CUDA_R_64F, CUSPARSE_MM_ALG_DEFAULT,
+      &bufferSize);
+    cudaMalloc(&dBuffer, bufferSize);
+    cusparseStatus_t status =
+      cusparseSpMM(s.handle ,
+                   CUSPARSE_OPERATION_NON_TRANSPOSE ,
+                   CUSPARSE_OPERATION_NON_TRANSPOSE ,
+                   &alpha ,
+                   A_cusparse ,
+                   x_cusparse ,
+                   &beta ,
+                   y_cusparse ,
+                   CUDA_R_64F ,
+                   CUSPARSE_MM_ALG_DEFAULT ,
+                   dBuffer );
+    cudaFree(dBuffer);
+    cusparseDestroyDnMat(x_cusparse);
+    cusparseDestroyDnMat(y_cusparse);
+    cusparseDestroySpMat(A_cusparse);
+#else
     cusparseStatus_t status =
       cusparseDcsrmm( s.handle ,
                       CUSPARSE_OPERATION_NON_TRANSPOSE ,
@@ -410,6 +581,7 @@ public:
                       &beta ,
                       yy.data() ,
                       n );
+#endif
 
     if ( CUSPARSE_STATUS_SUCCESS != status ) {
       throw std::runtime_error( std::string("ERROR - cusparseDcsrmv " ) );
@@ -454,6 +626,51 @@ public:
     const size_t ncol = x.extent(1);
 
     // Sparse matrix-times-multivector
+#if CUSPARSE_VERSION >= 10300
+    using offset_type = typename matrix_type::graph_type::size_type;
+    using entry_type  = typename matrix_type::graph_type::data_type;
+    const cusparseIndexType_t myCusparseOffsetType =
+      sizeof(offset_type) == 4 ? CUSPARSE_INDEX_32I : CUSPARSE_INDEX_64I;
+    const cusparseIndexType_t myCusparseEntryType =
+      sizeof(entry_type) == 4 ? CUSPARSE_INDEX_32I : CUSPARSE_INDEX_64I;
+    cusparseSpMatDescr_t A_cusparse;
+    cusparseCreateCsr(
+      &A_cusparse, n, n, nz,
+      (void*)A.graph.row_map.data(), (void*)A.graph.entries.data(),
+      (void*)A.values.data(), myCusparseOffsetType, myCusparseEntryType,
+      CUSPARSE_INDEX_BASE_ZERO, CUDA_R_32F);
+    cusparseDnMatDescr_t x_cusparse, y_cusparse;
+    cusparseCreateDnMat(
+      &x_cusparse, n, ncol, x.stride(1),
+      (void*)x.data(), CUDA_R_32F, CUSPARSE_ORDER_COL);
+    cusparseCreateDnMat(
+      &y_cusparse, n, ncol, y.stride(1),
+      (void*)y.data(), CUDA_R_32F, CUSPARSE_ORDER_COL);
+    size_t bufferSize = 0;
+    void* dBuffer     = NULL;
+    cusparseSpMM_bufferSize(
+      s.handle, CUSPARSE_OPERATION_NON_TRANSPOSE,
+      CUSPARSE_OPERATION_NON_TRANSPOSE, &alpha, A_cusparse,
+      x_cusparse, &beta, y_cusparse, CUDA_R_32F, CUSPARSE_MM_ALG_DEFAULT,
+      &bufferSize);
+    cudaMalloc(&dBuffer, bufferSize);
+    cusparseStatus_t status =
+      cusparseSpMM(s.handle ,
+                   CUSPARSE_OPERATION_NON_TRANSPOSE ,
+                   CUSPARSE_OPERATION_NON_TRANSPOSE ,
+                   &alpha ,
+                   A_cusparse ,
+                   x_cusparse ,
+                   &beta ,
+                   y_cusparse ,
+                   CUDA_R_32F ,
+                   CUSPARSE_MM_ALG_DEFAULT ,
+                   dBuffer );
+    cudaFree(dBuffer);
+    cusparseDestroyDnMat(x_cusparse);
+    cusparseDestroyDnMat(y_cusparse);
+    cusparseDestroySpMat(A_cusparse);
+#else
     cusparseStatus_t status =
       cusparseScsrmm( s.handle ,
                       CUSPARSE_OPERATION_NON_TRANSPOSE ,
@@ -468,6 +685,7 @@ public:
                       &beta ,
                       y.data() ,
                       n );
+#endif
 
     if ( CUSPARSE_STATUS_SUCCESS != status ) {
       throw std::runtime_error( std::string("ERROR - cusparseDcsrmv " ) );
@@ -502,6 +720,51 @@ public:
     const size_t ncol = x.extent(1);
 
     // Sparse matrix-times-multivector
+#if CUSPARSE_VERSION >= 10300
+    using offset_type = typename matrix_type::graph_type::size_type;
+    using entry_type  = typename matrix_type::graph_type::data_type;
+    const cusparseIndexType_t myCusparseOffsetType =
+      sizeof(offset_type) == 4 ? CUSPARSE_INDEX_32I : CUSPARSE_INDEX_64I;
+    const cusparseIndexType_t myCusparseEntryType =
+      sizeof(entry_type) == 4 ? CUSPARSE_INDEX_32I : CUSPARSE_INDEX_64I;
+    cusparseSpMatDescr_t A_cusparse;
+    cusparseCreateCsr(
+      &A_cusparse, n, n, nz,
+      (void*)A.graph.row_map.data(), (void*)A.graph.entries.data(),
+      (void*)A.values.data(), myCusparseOffsetType, myCusparseEntryType,
+      CUSPARSE_INDEX_BASE_ZERO, CUDA_R_64F);
+    cusparseDnMatDescr_t x_cusparse, y_cusparse;
+    cusparseCreateDnMat(
+      &x_cusparse, n, ncol, x.stride(1),
+      (void*)x.data(), CUDA_R_64F, CUSPARSE_ORDER_COL);
+    cusparseCreateDnMat(
+      &y_cusparse, n, ncol, y.stride(1),
+      (void*)y.data(), CUDA_R_64F, CUSPARSE_ORDER_COL);
+    size_t bufferSize = 0;
+    void* dBuffer     = NULL;
+    cusparseSpMM_bufferSize(
+      s.handle, CUSPARSE_OPERATION_NON_TRANSPOSE,
+      CUSPARSE_OPERATION_NON_TRANSPOSE, &alpha, A_cusparse,
+      x_cusparse, &beta, y_cusparse, CUDA_R_64F, CUSPARSE_MM_ALG_DEFAULT,
+      &bufferSize);
+    cudaMalloc(&dBuffer, bufferSize);
+    cusparseStatus_t status =
+      cusparseSpMM(s.handle ,
+                   CUSPARSE_OPERATION_NON_TRANSPOSE ,
+                   CUSPARSE_OPERATION_NON_TRANSPOSE ,
+                   &alpha ,
+                   A_cusparse ,
+                   x_cusparse ,
+                   &beta ,
+                   y_cusparse ,
+                   CUDA_R_64F ,
+                   CUSPARSE_MM_ALG_DEFAULT ,
+                   dBuffer );
+    cudaFree(dBuffer);
+    cusparseDestroyDnMat(x_cusparse);
+    cusparseDestroyDnMat(y_cusparse);
+    cusparseDestroySpMat(A_cusparse);
+#else
     cusparseStatus_t status =
       cusparseDcsrmm( s.handle ,
                       CUSPARSE_OPERATION_NON_TRANSPOSE ,
@@ -516,6 +779,7 @@ public:
                       &beta ,
                       y.data() ,
                       n );
+#endif
 
     if ( CUSPARSE_STATUS_SUCCESS != status ) {
       throw std::runtime_error( std::string("ERROR - cusparseDcsrmv " ) );
@@ -637,6 +901,51 @@ public:
     }
 
     // Sparse matrix-times-multivector
+#if CUSPARSE_VERSION >= 10300
+    using offset_type = typename matrix_type::graph_type::size_type;
+    using entry_type  = typename matrix_type::graph_type::data_type;
+    const cusparseIndexType_t myCusparseOffsetType =
+      sizeof(offset_type) == 4 ? CUSPARSE_INDEX_32I : CUSPARSE_INDEX_64I;
+    const cusparseIndexType_t myCusparseEntryType =
+      sizeof(entry_type) == 4 ? CUSPARSE_INDEX_32I : CUSPARSE_INDEX_64I;
+    cusparseSpMatDescr_t A_cusparse;
+    cusparseCreateCsr(
+      &A_cusparse, n, n, nz,
+      (void*)A.graph.row_map.data(), (void*)A.graph.entries.data(),
+      (void*)A.values.data(), myCusparseOffsetType, myCusparseEntryType,
+      CUSPARSE_INDEX_BASE_ZERO, CUDA_R_32F);
+    cusparseDnMatDescr_t x_cusparse, y_cusparse;
+    cusparseCreateDnMat(
+      &x_cusparse, n, ncol, n,
+      (void*)xx.data(), CUDA_R_32F, CUSPARSE_ORDER_COL);
+    cusparseCreateDnMat(
+      &y_cusparse, n, ncol, n,
+      (void*)yy.data(), CUDA_R_32F, CUSPARSE_ORDER_COL);
+    size_t bufferSize = 0;
+    void* dBuffer     = NULL;
+    cusparseSpMM_bufferSize(
+      s.handle, CUSPARSE_OPERATION_NON_TRANSPOSE,
+      CUSPARSE_OPERATION_NON_TRANSPOSE, &alpha, A_cusparse,
+      x_cusparse, &beta, y_cusparse, CUDA_R_32F, CUSPARSE_MM_ALG_DEFAULT,
+      &bufferSize);
+    cudaMalloc(&dBuffer, bufferSize);
+    cusparseStatus_t status =
+      cusparseSpMM(s.handle ,
+                   CUSPARSE_OPERATION_NON_TRANSPOSE ,
+                   CUSPARSE_OPERATION_NON_TRANSPOSE ,
+                   &alpha ,
+                   A_cusparse ,
+                   x_cusparse ,
+                   &beta ,
+                   y_cusparse ,
+                   CUDA_R_32F ,
+                   CUSPARSE_MM_ALG_DEFAULT ,
+                   dBuffer );
+    cudaFree(dBuffer);
+    cusparseDestroyDnMat(x_cusparse);
+    cusparseDestroyDnMat(y_cusparse);
+    cusparseDestroySpMat(A_cusparse);
+#else
     cusparseStatus_t status =
       cusparseScsrmm( s.handle ,
                       CUSPARSE_OPERATION_NON_TRANSPOSE ,
@@ -651,6 +960,7 @@ public:
                       &beta ,
                       yy.data() ,
                       n );
+#endif
 
     if ( CUSPARSE_STATUS_SUCCESS != status ) {
       throw std::runtime_error( std::string("ERROR - cusparseDcsrmv " ) );
@@ -702,6 +1012,51 @@ public:
     }
 
     // Sparse matrix-times-multivector
+#if CUSPARSE_VERSION >= 10300
+    using offset_type = typename matrix_type::graph_type::size_type;
+    using entry_type  = typename matrix_type::graph_type::data_type;
+    const cusparseIndexType_t myCusparseOffsetType =
+      sizeof(offset_type) == 4 ? CUSPARSE_INDEX_32I : CUSPARSE_INDEX_64I;
+    const cusparseIndexType_t myCusparseEntryType =
+      sizeof(entry_type) == 4 ? CUSPARSE_INDEX_32I : CUSPARSE_INDEX_64I;
+    cusparseSpMatDescr_t A_cusparse;
+    cusparseCreateCsr(
+      &A_cusparse, n, n, nz,
+      (void*)A.graph.row_map.data(), (void*)A.graph.entries.data(),
+      (void*)A.values.data(), myCusparseOffsetType, myCusparseEntryType,
+      CUSPARSE_INDEX_BASE_ZERO, CUDA_R_64F);
+    cusparseDnMatDescr_t x_cusparse, y_cusparse;
+    cusparseCreateDnMat(
+      &x_cusparse, n, ncol, n,
+      (void*)xx.data(), CUDA_R_64F, CUSPARSE_ORDER_COL);
+    cusparseCreateDnMat(
+      &y_cusparse, n, ncol, n,
+      (void*)yy.data(), CUDA_R_64F, CUSPARSE_ORDER_COL);
+    size_t bufferSize = 0;
+    void* dBuffer     = NULL;
+    cusparseSpMM_bufferSize(
+      s.handle, CUSPARSE_OPERATION_NON_TRANSPOSE,
+      CUSPARSE_OPERATION_NON_TRANSPOSE, &alpha, A_cusparse,
+      x_cusparse, &beta, y_cusparse, CUDA_R_64F, CUSPARSE_MM_ALG_DEFAULT,
+      &bufferSize);
+    cudaMalloc(&dBuffer, bufferSize);
+    cusparseStatus_t status =
+      cusparseSpMM(s.handle ,
+                   CUSPARSE_OPERATION_NON_TRANSPOSE ,
+                   CUSPARSE_OPERATION_NON_TRANSPOSE ,
+                   &alpha ,
+                   A_cusparse ,
+                   x_cusparse ,
+                   &beta ,
+                   y_cusparse ,
+                   CUDA_R_64F ,
+                   CUSPARSE_MM_ALG_DEFAULT ,
+                   dBuffer );
+    cudaFree(dBuffer);
+    cusparseDestroyDnMat(x_cusparse);
+    cusparseDestroyDnMat(y_cusparse);
+    cusparseDestroySpMat(A_cusparse);
+#else
     cusparseStatus_t status =
       cusparseDcsrmm( s.handle ,
                       CUSPARSE_OPERATION_NON_TRANSPOSE ,
@@ -716,6 +1071,7 @@ public:
                       &beta ,
                       yy.data() ,
                       n );
+#endif
 
     if ( CUSPARSE_STATUS_SUCCESS != status ) {
       throw std::runtime_error( std::string("ERROR - cusparseDcsrmv " ) );

--- a/packages/stokhos/src/sacado/kokkos/Stokhos_Tpetra_Utilities.hpp
+++ b/packages/stokhos/src/sacado/kokkos/Stokhos_Tpetra_Utilities.hpp
@@ -241,18 +241,10 @@ namespace Stokhos {
     using Teuchos::RCP;
     using Teuchos::rcp;
     typedef Tpetra::CrsMatrix<Scalar,LO,GO,N> MatrixType;
-    typedef Tpetra::Map<LO,GO,N> Map;
-
     typedef typename MatrixType::local_matrix_device_type KokkosMatrixType;
-
-    typedef typename KokkosMatrixType::StaticCrsGraphType KokkosGraphType;
     typedef typename KokkosMatrixType::values_type KokkosMatrixValuesType;
 
-    RCP< const Map > rmap = A.getRowMap();
-    RCP< const Map > cmap = A.getColMap();
-
     KokkosMatrixType kokkos_matrix = A.getLocalMatrixDevice();
-    KokkosGraphType kokkos_graph = kokkos_matrix.graph;
     KokkosMatrixValuesType matrix_values = kokkos_matrix.values;
     const size_t ncols = kokkos_matrix.numCols();
     typedef GetMeanValsFunc <KokkosMatrixValuesType > MeanFunc;
@@ -263,10 +255,9 @@ namespace Stokhos {
     // From here on we are assuming that
     // KokkosMeanMatrixValuesType == KokkosMatrixValuestype
 
-    KokkosMatrixType mean_kokkos_matrix(
-      "mean-matrix", ncols, mean_matrix_values, kokkos_graph);
     RCP < MatrixType > mean_matrix =
-      rcp( new MatrixType(rmap, cmap, mean_kokkos_matrix) );
+      rcp( new MatrixType(A.getCrsGraph(), mean_matrix_values) );
+    mean_matrix->fillComplete();
     return mean_matrix;
   }
 
@@ -279,19 +270,11 @@ namespace Stokhos {
     typedef typename Scalar::value_type BaseScalar;
     typedef Tpetra::CrsMatrix<Scalar,LO,GO,N> MatrixType;
     typedef Tpetra::CrsMatrix<BaseScalar,LO,GO,N> ScalarMatrixType;
-    typedef Tpetra::Map<LO,GO,N> Map;
-
     typedef typename MatrixType::local_matrix_device_type KokkosMatrixType;
     typedef typename ScalarMatrixType::local_matrix_device_type ScalarKokkosMatrixType;
-
-    typedef typename KokkosMatrixType::StaticCrsGraphType KokkosGraphType;
     typedef typename KokkosMatrixType::values_type KokkosMatrixValuesType;
 
-    RCP< const Map > rmap = A.getRowMap();
-    RCP< const Map > cmap = A.getColMap();
-
     KokkosMatrixType kokkos_matrix = A.getLocalMatrixDevice();
-    KokkosGraphType kokkos_graph = kokkos_matrix.graph;
     KokkosMatrixValuesType matrix_values = kokkos_matrix.values;
     const size_t ncols = kokkos_matrix.numCols();
     typedef GetScalarMeanValsFunc <KokkosMatrixValuesType > MeanFunc;
@@ -302,10 +285,9 @@ namespace Stokhos {
     // From here on we are assuming that
     // KokkosMeanMatrixValuesType == ScalarKokkosMatrixValuesType
 
-    ScalarKokkosMatrixType mean_kokkos_matrix(
-      "mean-matrix", ncols, mean_matrix_values, kokkos_graph);
     RCP < ScalarMatrixType > mean_matrix =
-      rcp( new ScalarMatrixType(rmap, cmap, mean_kokkos_matrix) );
+      rcp( new ScalarMatrixType(A.getCrsGraph(), mean_matrix_values) );
+    mean_matrix->fillComplete();
     return mean_matrix;
   }
 
@@ -550,18 +532,24 @@ namespace Stokhos {
           Y_s->getNumVectors() != Y.getNumVectors()*pce_size)
         Y_s = Teuchos::rcp(new scalar_mv_type(Y.getMap(),
                                               Y.getNumVectors()*pce_size));
-      auto xv_s = X_s->getLocalViewDevice(Tpetra::Access::ReadWrite);
-      auto yv_s = Y_s->getLocalViewDevice(Tpetra::Access::ReadWrite);
       base_scalar_type alpha_s = alpha.fastAccessCoeff(0);
       base_scalar_type beta_s = beta.fastAccessCoeff(0);
 
-      copy_pce_to_scalar(xv_s, xv);
-      if (beta_s != 0.0)
-        copy_pce_to_scalar(yv_s, yv);
+      {
+        auto xv_s = X_s->getLocalViewDevice(Tpetra::Access::ReadWrite);
+        auto yv_s = Y_s->getLocalViewDevice(Tpetra::Access::ReadWrite);
+
+        copy_pce_to_scalar(xv_s, xv);
+        if (beta_s != 0.0)
+          copy_pce_to_scalar(yv_s, yv);
+      }
 
       mb_op->apply(*X_s, *Y_s, mode, alpha_s, beta_s);
 
-      copy_scalar_to_pce(yv, yv_s);
+      {
+        auto yv_s = Y_s->getLocalViewDevice(Tpetra::Access::ReadOnly);
+        copy_scalar_to_pce(yv, yv_s);
+      }
     }
 
     virtual bool hasTransposeApply() const {

--- a/packages/stokhos/src/sacado/kokkos/pce/amesos2/Amesos2_Solver_UQ_PCE.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/amesos2/Amesos2_Solver_UQ_PCE.hpp
@@ -113,13 +113,15 @@ namespace Amesos2 {
       const Teuchos::RCP<const Vector>& B_) :
       A(A_), X(X_), B(B_) {
       cijk = get_pce_cijk(A, X, B);
+      const size_t pce_size =
+        Kokkos::dimension_scalar(A->getLocalMatrixDevice().values);
       flat_graph =
         Stokhos::create_flat_pce_graph(*(A->getCrsGraph()),
                                        cijk,
                                        flat_X_map,
                                        flat_B_map,
                                        cijk_graph,
-                                       Kokkos::dimension_scalar(A->getLocalMatrixDevice().values));
+                                       pce_size);
       if (A != Teuchos::null)
         flat_A = Stokhos::create_flat_matrix(*A, flat_graph, cijk_graph, cijk);
       if (X != Teuchos::null)

--- a/packages/stokhos/src/sacado/kokkos/pce/belos/Belos_TpetraAdapter_UQ_PCE.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/belos/Belos_TpetraAdapter_UQ_PCE.hpp
@@ -373,7 +373,12 @@ namespace Belos {
       typedef Kokkos::View<dot_type*, Kokkos::LayoutLeft, execution_space> b_1d_view_type;
       b_1d_view_type B_1d_view_dev(Kokkos::ViewAllocateWithoutInitializing("B"), numRowsB*numColsB);
       b_view_type B_view_dev( B_1d_view_dev.data(), numRowsB, numColsB);
-      Kokkos::deep_copy(B_view_dev, B_view_host);
+      //Kokkos::deep_copy(B_view_dev, B_view_host);
+      // Device-to-host copies requires dest to be contiguous, which
+      // C_view_host may not be.  So do 1 column at a time.
+      for (int j=0; j<numColsB; ++j)
+        Kokkos::deep_copy(Kokkos::subview(B_view_dev,Kokkos::ALL,j),
+                          Kokkos::subview(B_view_host,Kokkos::ALL,j));
 
       // Do local multiply
       {
@@ -498,8 +503,14 @@ namespace Belos {
       }
       // reduce across processors -- could check for RDMA
       RCP<const Comm<int> > pcomm = A.getMap()->getComm ();
-      if (pcomm->getSize () == 1)
-        Kokkos::deep_copy(C_view_host, C_view_dev);
+      if (pcomm->getSize () == 1) {
+        //Kokkos::deep_copy(C_view_host, C_view_dev);
+        // Device-to-host copies requires dest to be contiguous, which
+        // C_view_host may not be.  So do 1 column at a time.
+        for (int j=0; j<numColsC; ++j)
+          Kokkos::deep_copy(Kokkos::subview(C_view_host,Kokkos::ALL,j),
+                            Kokkos::subview(C_view_dev,Kokkos::ALL,j));
+      }
       else {
         typedef Kokkos::View<dot_type*, Kokkos::LayoutLeft, Kokkos::HostSpace> c_1d_host_view_type;
         c_1d_host_view_type C_1d_view_tmp(Kokkos::ViewAllocateWithoutInitializing("C_tmp"), strideC*numColsC);

--- a/packages/stokhos/src/sacado/kokkos/pce/belos/Belos_TpetraAdapter_UQ_PCE.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/belos/Belos_TpetraAdapter_UQ_PCE.hpp
@@ -516,10 +516,11 @@ namespace Belos {
         c_1d_host_view_type C_1d_view_tmp(Kokkos::ViewAllocateWithoutInitializing("C_tmp"), strideC*numColsC);
         c_host_view_type C_view_tmp( C_1d_view_tmp.data(),
                                      strideC, numColsC);
-        Kokkos::deep_copy(Kokkos::subview(C_view_tmp,
-                                          Kokkos::pair<int,int>(0, numRowsC),
-                                          Kokkos::pair<int,int>(0, numColsC)),
-                          C_view_dev);
+        for (int j=0; j<numColsC; ++j)
+          Kokkos::deep_copy(Kokkos::subview(C_view_tmp,
+                                            Kokkos::pair<int,int>(0, numRowsC),
+                                            j),
+                            Kokkos::subview(C_view_dev, Kokkos::ALL, j));
         reduceAll<int> (*pcomm, REDUCE_SUM, strideC*numColsC,
                         C_view_tmp.data(),
                         C_view_host.data());

--- a/packages/stokhos/src/sacado/kokkos/pce/tpetra/Stokhos_Tpetra_Utilities_UQ_PCE.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/tpetra/Stokhos_Tpetra_Utilities_UQ_PCE.hpp
@@ -57,7 +57,7 @@ namespace Stokhos {
             typename CijkType>
   Teuchos::RCP< Tpetra::CrsGraph<LocalOrdinal,GlobalOrdinal,
                                  Kokkos::Compat::KokkosDeviceWrapperNode<Device> > >
-  create_cijk_crs_graph(const CijkType& cijk,
+  create_cijk_crs_graph(const CijkType& cijk_dev,
                         const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
                         const size_t matrix_pce_size) {
     using Teuchos::RCP;
@@ -66,6 +66,11 @@ namespace Stokhos {
     typedef Kokkos::Compat::KokkosDeviceWrapperNode<Device> Node;
     typedef Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> Map;
     typedef Tpetra::CrsGraph<LocalOrdinal,GlobalOrdinal,Node> Graph;
+
+    // Code below accesses cijk entries on the host, so make sure it is
+    // accessible there
+    auto cijk = create_mirror_view(cijk_dev);
+    deep_copy(cijk, cijk_dev);
 
     const size_t pce_sz = cijk.dimension();
     RCP<const Map> map =
@@ -177,6 +182,7 @@ namespace Stokhos {
     for (LocalOrdinal outer_row=0; outer_row < num_outer_rows; outer_row++) {
 
       // Get outer columns for this outer row
+      Kokkos::fence();
       graph.getLocalRowView(outer_row, outer_cols);
       const LocalOrdinal num_outer_cols = outer_cols.size();
 
@@ -187,6 +193,7 @@ namespace Stokhos {
         const LocalOrdinal flat_row = outer_row*block_size + inner_row;
 
         // Get inner columns for this inner row
+        Kokkos::fence();
         cijk_graph->getLocalRowView(inner_row, inner_cols);
         const LocalOrdinal num_inner_cols = inner_cols.size();
 

--- a/packages/stokhos/src/sacado/kokkos/pce/tpetra/Stokhos_Tpetra_Utilities_UQ_PCE.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/tpetra/Stokhos_Tpetra_Utilities_UQ_PCE.hpp
@@ -441,7 +441,7 @@ namespace Stokhos {
                             LocalOrdinal,GlobalOrdinal,Kokkos::Compat::KokkosDeviceWrapperNode<Device> >& mat,
     const Teuchos::RCP<const Tpetra::CrsGraph<LocalOrdinal,GlobalOrdinal,Kokkos::Compat::KokkosDeviceWrapperNode<Device> > >& flat_graph,
     const Teuchos::RCP<const Tpetra::CrsGraph<LocalOrdinal,GlobalOrdinal,Kokkos::Compat::KokkosDeviceWrapperNode<Device> > >& cijk_graph,
-    const CijkType& cijk) {
+    const CijkType& cijk_dev) {
     using Teuchos::ArrayView;
     using Teuchos::Array;
     using Teuchos::RCP;
@@ -452,6 +452,11 @@ namespace Stokhos {
     typedef typename Storage::value_type BaseScalar;
     typedef Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> Matrix;
     typedef Tpetra::CrsMatrix<BaseScalar,LocalOrdinal,GlobalOrdinal,Node> FlatMatrix;
+
+    // Code below accesses cijk entries on the host, so make sure it is
+    // accessible there
+    auto cijk = create_mirror_view(cijk_dev);
+    deep_copy(cijk, cijk_dev);
 
     const LocalOrdinal block_size = cijk.dimension();
     const LocalOrdinal matrix_pce_size =

--- a/packages/stokhos/test/UnitTest/CMakeLists.txt
+++ b/packages/stokhos/test/UnitTest/CMakeLists.txt
@@ -499,6 +499,8 @@ IF(Stokhos_ENABLE_Sacado)
           )
       ENDIF()
 
+      message("Stokhos_ENABLE_Tpetra = ${Stokhos_ENABLE_Tpetra}")
+      message("HAVE_TPETRA_CUDA = ${HAVE_TPETRA_CUDA}")
       IF (Stokhos_ENABLE_Tpetra)
 
         IF (HAVE_TPETRA_PTHREAD)
@@ -537,6 +539,7 @@ IF(Stokhos_ENABLE_Sacado)
         ENDIF()
 
         IF (HAVE_TPETRA_CUDA)
+          message("enabling TpetraCrsMatrixUQPCEUnitTest_Cuda")
           TRIBITS_ADD_EXECUTABLE_AND_TEST(
             TpetraCrsMatrixUQPCEUnitTest_Cuda
             SOURCES Stokhos_TpetraCrsMatrixUQPCEUnitTest.hpp

--- a/packages/stokhos/test/UnitTest/Stokhos_TpetraCrsMatrixMPVectorUnitTest.hpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_TpetraCrsMatrixMPVectorUnitTest.hpp
@@ -2474,6 +2474,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
   //             Teuchos::VERB_EXTREME);
 
   // Check -- For a*y'' = b, correct answer is y = 0.5 *(b/a) * x * (x-1)
+  solver = Teuchos::null; // Delete solver to eliminate live device views of x
   typedef Teuchos::ScalarTraits<BaseScalar> ST;
   typename ST::magnitudeType tol = 1e-9;
   auto x_view = x->getLocalViewHost(Tpetra::Access::ReadOnly);

--- a/packages/stokhos/test/UnitTest/Stokhos_TpetraCrsMatrixUQPCEUnitTest.hpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_TpetraCrsMatrixUQPCEUnitTest.hpp
@@ -1038,13 +1038,15 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
 
   // Fill vector
   RCP<Tpetra_Vector> x = Tpetra::createVector<Scalar>(map);
-  ArrayRCP<Scalar> x_view = x->get1dViewNonConst();
-  for (size_t i=0; i<num_my_row; ++i) {
-    const GlobalOrdinal row = myGIDs[i];
-    for (LocalOrdinal j=0; j<pce_size; ++j)
-      val.fastAccessCoeff(j) = generate_vector_coefficient<BaseScalar,size_t>(
-        nrow, pce_size, row, j);
-    x_view[i] = val;
+  {
+    ArrayRCP<Scalar> x_view = x->get1dViewNonConst();
+    for (size_t i=0; i<num_my_row; ++i) {
+      const GlobalOrdinal row = myGIDs[i];
+      for (LocalOrdinal j=0; j<pce_size; ++j)
+        val.fastAccessCoeff(j) = generate_vector_coefficient<BaseScalar,size_t>(
+          nrow, pce_size, row, j);
+      x_view[i] = val;
+    }
   }
 
   // Multiply

--- a/packages/stokhos/test/UnitTest/Stokhos_TpetraCrsMatrixUQPCEUnitTest.hpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_TpetraCrsMatrixUQPCEUnitTest.hpp
@@ -91,7 +91,8 @@
 // Use "scalar" version of mean-based preconditioner (i.e., a preconditioner
 // with double as the scalar type).  This is currently necessary to get the
 // MueLu tests to pass on OpenMP and Cuda due to various kernels that don't
-// work with the PCE scalar type.
+// work with the PCE scalar type.  Also required for RILUK test on Cuda
+// without UVM (since factorization occurs on the host).
 #define USE_SCALAR_MEAN_BASED_PREC 1
 
 template <typename scalar, typename ordinal>
@@ -1078,28 +1079,30 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
 
   // Multiply with flattened matix
   RCP<Tpetra_Vector> y2 = Tpetra::createVector<Scalar>(map);
-  RCP<Flat_Tpetra_Vector> flat_x =
-    Stokhos::create_flat_vector_view(*x, flat_x_map);
-  RCP<Flat_Tpetra_Vector> flat_y =
-    Stokhos::create_flat_vector_view(*y2, flat_y_map);
-  flat_matrix->apply(*flat_x, *flat_y);
+  {
+    RCP<Flat_Tpetra_Vector> flat_x =
+      Stokhos::create_flat_vector_view(*x, flat_x_map);
+    RCP<Flat_Tpetra_Vector> flat_y =
+      Stokhos::create_flat_vector_view(*y2, flat_y_map);
+    flat_matrix->apply(*flat_x, *flat_y);
 
-  /*
-  cijk_graph->describe(*(Teuchos::fancyOStream(rcp(&std::cout,false))),
-                       Teuchos::VERB_EXTREME);
+    /*
+    cijk_graph->describe(*(Teuchos::fancyOStream(rcp(&std::cout,false))),
+                         Teuchos::VERB_EXTREME);
 
-  flat_graph->describe(*(Teuchos::fancyOStream(rcp(&std::cout,false))),
-                       Teuchos::VERB_EXTREME);
+    flat_graph->describe(*(Teuchos::fancyOStream(rcp(&std::cout,false))),
+                         Teuchos::VERB_EXTREME);
 
-  flat_matrix->describe(*(Teuchos::fancyOStream(rcp(&std::cout,false))),
-                        Teuchos::VERB_EXTREME);
+    flat_matrix->describe(*(Teuchos::fancyOStream(rcp(&std::cout,false))),
+                          Teuchos::VERB_EXTREME);
 
-  flat_x->describe(*(Teuchos::fancyOStream(rcp(&std::cout,false))),
-                   Teuchos::VERB_EXTREME);
+    flat_x->describe(*(Teuchos::fancyOStream(rcp(&std::cout,false))),
+                     Teuchos::VERB_EXTREME);
 
-  flat_y->describe(*(Teuchos::fancyOStream(rcp(&std::cout,false))),
-                   Teuchos::VERB_EXTREME);
-  */
+    flat_y->describe(*(Teuchos::fancyOStream(rcp(&std::cout,false))),
+                     Teuchos::VERB_EXTREME);
+    */
+  }
 
   // Check
   BaseScalar tol = 1.0e-14;
@@ -1208,18 +1211,20 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
 
   // Fill RHS vector
   RCP<Tpetra_Vector> b = Tpetra::createVector<Scalar>(map);
-  ArrayRCP<Scalar> b_view = b->get1dViewNonConst();
-  Scalar b_val(cijk);
-  for (LocalOrdinal j=0; j<pce_size; ++j) {
-    b_val.fastAccessCoeff(j) =
-      BaseScalar(2.0) - BaseScalar(1.0) / BaseScalar(j+1);
-  }
-  for (size_t i=0; i<num_my_row; ++i) {
-    const GlobalOrdinal row = myGIDs[i];
-    if (row == 0 || row == nrow-1)
-      b_view[i] = Scalar(0.0);
-    else
-      b_view[i] = b_val * (h*h);
+  {
+    ArrayRCP<Scalar> b_view = b->get1dViewNonConst();
+    Scalar b_val(cijk);
+    for (LocalOrdinal j=0; j<pce_size; ++j) {
+      b_val.fastAccessCoeff(j) =
+        BaseScalar(2.0) - BaseScalar(1.0) / BaseScalar(j+1);
+    }
+    for (size_t i=0; i<num_my_row; ++i) {
+      const GlobalOrdinal row = myGIDs[i];
+      if (row == 0 || row == nrow-1)
+        b_view[i] = Scalar(0.0);
+      else
+        b_view[i] = b_val * (h*h);
+    }
   }
 
   // b->describe(*(Teuchos::fancyOStream(rcp(&std::cout,false))),
@@ -1251,13 +1256,15 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
   RCP<Flat_Tpetra_CrsMatrix> flat_matrix =
     Stokhos::create_flat_matrix(*matrix, flat_graph, cijk_graph, cijk);
   RCP<Tpetra_Vector> x2 = Tpetra::createVector<Scalar>(map);
-  RCP<Flat_Tpetra_Vector> flat_x =
-    Stokhos::create_flat_vector_view(*x2, flat_x_map);
-  RCP<Flat_Tpetra_Vector> flat_b =
-    Stokhos::create_flat_vector_view(*b, flat_b_map);
-  bool solved_flat = Stokhos::CG_Solve(*flat_matrix, *flat_x, *flat_b,
-                                       tol, max_its, out.getOStream().get());
-  TEST_EQUALITY_CONST( solved_flat, true );
+  {
+    RCP<Flat_Tpetra_Vector> flat_x =
+      Stokhos::create_flat_vector_view(*x2, flat_x_map);
+    RCP<Flat_Tpetra_Vector> flat_b =
+      Stokhos::create_flat_vector_view(*b, flat_b_map);
+    bool solved_flat = Stokhos::CG_Solve(*flat_matrix, *flat_x, *flat_b,
+                                         tol, max_its, out.getOStream().get());
+    TEST_EQUALITY_CONST( solved_flat, true );
+  }
 
   btol = 500*btol;
   ArrayRCP<Scalar> x_view = x->get1dViewNonConst();
@@ -1379,45 +1386,22 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
 
   // Fill RHS vector
   RCP<Tpetra_Vector> b = Tpetra::createVector<Scalar>(map);
-  ArrayRCP<Scalar> b_view = b->get1dViewNonConst();
-  Scalar b_val(cijk);
-  for (LocalOrdinal j=0; j<pce_size; ++j) {
-    b_val.fastAccessCoeff(j) =
-      BaseScalar(2.0) - BaseScalar(1.0) / BaseScalar(j+1);
-  }
-  for (size_t i=0; i<num_my_row; ++i) {
-    const GlobalOrdinal row = myGIDs[i];
-    if (row == 0 || row == nrow-1)
-      b_view[i] = Scalar(0.0);
-    else
-      b_view[i] = b_val * (h*h);
+  {
+    ArrayRCP<Scalar> b_view = b->get1dViewNonConst();
+    Scalar b_val(cijk);
+    for (LocalOrdinal j=0; j<pce_size; ++j) {
+      b_val.fastAccessCoeff(j) =
+        BaseScalar(2.0) - BaseScalar(1.0) / BaseScalar(j+1);
+    }
+    for (size_t i=0; i<num_my_row; ++i) {
+      const GlobalOrdinal row = myGIDs[i];
+      if (row == 0 || row == nrow-1)
+        b_view[i] = Scalar(0.0);
+      else
+        b_view[i] = b_val * (h*h);
+    }
   }
 
-  // Create preconditioner
-  typedef Tpetra::Operator<Scalar,LocalOrdinal,GlobalOrdinal,Node> OP;
-  RCP<ParameterList> muelu_params =
-    getParametersFromXmlFile("muelu_cheby.xml");
-#if USE_SCALAR_MEAN_BASED_PREC
-  typedef Tpetra::Operator<BaseScalar,LocalOrdinal,GlobalOrdinal,Node> Scalar_OP;
-  typedef Tpetra::CrsMatrix<BaseScalar,LocalOrdinal,GlobalOrdinal,Node> Scalar_Tpetra_CrsMatrix;
-  RCP<Scalar_Tpetra_CrsMatrix> mean_matrix =
-    Stokhos::build_mean_scalar_matrix(*matrix);
-  RCP<Scalar_OP> mean_matrix_op = mean_matrix;
-  RCP<Scalar_OP> M_s =
-    MueLu::CreateTpetraPreconditioner<BaseScalar,LocalOrdinal,GlobalOrdinal,Node>(mean_matrix_op, *muelu_params);
-  RCP<OP> M = rcp(new Stokhos::MeanBasedTpetraOperator<Scalar,LocalOrdinal,GlobalOrdinal,Node>(M_s));
-#else
-  Cijk mean_cijk =
-    Stokhos::create_mean_based_product_tensor<typename Storage::execution_space,typename Storage::ordinal_type,BaseScalar>();
-  Kokkos::setGlobalCijkTensor(mean_cijk);
-  RCP<Tpetra_CrsMatrix> mean_matrix = Stokhos::build_mean_matrix(*matrix);
-  RCP<OP> mean_matrix_op = mean_matrix;
-  RCP<OP> M =
-    MueLu::CreateTpetraPreconditioner<Scalar,LocalOrdinal,GlobalOrdinal,Node>(mean_matrix_op, *muelu_params);
-  Kokkos::setGlobalCijkTensor(cijk);
-#endif
-
-  // Solve
   RCP<Tpetra_Vector> x = Tpetra::createVector<Scalar>(map);
   typedef Kokkos::Details::ArithTraits<BaseScalar> BST;
   typedef typename BST::mag_type base_mag_type;
@@ -1425,36 +1409,65 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
   base_mag_type btol = 1e-9;
   mag_type tol = btol;
   int max_its = 1000;
-  bool solved = Stokhos::PCG_Solve(*matrix, *x, *b, *M, tol, max_its,
+  {
+    // Create preconditioner
+    typedef Tpetra::Operator<Scalar,LocalOrdinal,GlobalOrdinal,Node> OP;
+    RCP<ParameterList> muelu_params =
+      getParametersFromXmlFile("muelu_cheby.xml");
+#if USE_SCALAR_MEAN_BASED_PREC
+    typedef Tpetra::Operator<BaseScalar,LocalOrdinal,GlobalOrdinal,Node> Scalar_OP;
+    typedef Tpetra::CrsMatrix<BaseScalar,LocalOrdinal,GlobalOrdinal,Node> Scalar_Tpetra_CrsMatrix;
+    RCP<Scalar_Tpetra_CrsMatrix> mean_matrix =
+      Stokhos::build_mean_scalar_matrix(*matrix);
+    RCP<Scalar_OP> mean_matrix_op = mean_matrix;
+    RCP<Scalar_OP> M_s =
+      MueLu::CreateTpetraPreconditioner<BaseScalar,LocalOrdinal,GlobalOrdinal,Node>(mean_matrix_op, *muelu_params);
+    RCP<OP> M = rcp(new Stokhos::MeanBasedTpetraOperator<Scalar,LocalOrdinal,GlobalOrdinal,Node>(M_s));
+#else
+    Cijk mean_cijk =
+      Stokhos::create_mean_based_product_tensor<typename Storage::execution_space,typename Storage::ordinal_type,BaseScalar>();
+    Kokkos::setGlobalCijkTensor(mean_cijk);
+    RCP<Tpetra_CrsMatrix> mean_matrix = Stokhos::build_mean_matrix(*matrix);
+    RCP<OP> mean_matrix_op = mean_matrix;
+    RCP<OP> M =
+      MueLu::CreateTpetraPreconditioner<Scalar,LocalOrdinal,GlobalOrdinal,Node>(mean_matrix_op, *muelu_params);
+    Kokkos::setGlobalCijkTensor(cijk);
+#endif
+
+    // Solve
+    bool solved = Stokhos::PCG_Solve(*matrix, *x, *b, *M, tol, max_its,
                                    out.getOStream().get());
-  TEST_EQUALITY_CONST( solved, true );
+    TEST_EQUALITY_CONST( solved, true );
+  }
 
   // x->describe(*(Teuchos::fancyOStream(rcp(&std::cout,false))),
   //             Teuchos::VERB_EXTREME);
 
   // Check by solving flattened system
-   typedef Tpetra::Vector<BaseScalar,LocalOrdinal,GlobalOrdinal,Node> Flat_Tpetra_Vector;
-  typedef Tpetra::CrsMatrix<BaseScalar,LocalOrdinal,GlobalOrdinal,Node> Flat_Tpetra_CrsMatrix;
-  RCP<const Tpetra_Map> flat_x_map, flat_b_map;
-  RCP<const Tpetra_CrsGraph> flat_graph, cijk_graph;
-  flat_graph =
-    Stokhos::create_flat_pce_graph(*graph, cijk, flat_x_map, flat_b_map,
-                                   cijk_graph, pce_size);
-  RCP<Flat_Tpetra_CrsMatrix> flat_matrix =
-    Stokhos::create_flat_matrix(*matrix, flat_graph, cijk_graph, cijk);
   RCP<Tpetra_Vector> x2 = Tpetra::createVector<Scalar>(map);
-  RCP<Flat_Tpetra_Vector> flat_x =
-    Stokhos::create_flat_vector_view(*x2, flat_x_map);
-  RCP<Flat_Tpetra_Vector> flat_b =
-    Stokhos::create_flat_vector_view(*b, flat_b_map);
-  // typedef Tpetra::Operator<BaseScalar,LocalOrdinal,GlobalOrdinal,Node> FlatPrec;
-  // RCP<FlatPrec> flat_M =
-  //   MueLu::CreateTpetraPreconditioner<BaseScalar,LocalOrdinal,GlobalOrdinal,Node>(flat_matrix, *muelu_params);
-  // bool solved_flat = Stokhos::PCG_Solve(*flat_matrix, *flat_x, *flat_b, *flat_M,
-  //                                      tol, max_its, out.getOStream().get());
-  bool solved_flat = Stokhos::CG_Solve(*flat_matrix, *flat_x, *flat_b,
-                                       tol, max_its, out.getOStream().get());
-  TEST_EQUALITY_CONST( solved_flat, true );
+  {
+    typedef Tpetra::Vector<BaseScalar,LocalOrdinal,GlobalOrdinal,Node> Flat_Tpetra_Vector;
+    typedef Tpetra::CrsMatrix<BaseScalar,LocalOrdinal,GlobalOrdinal,Node> Flat_Tpetra_CrsMatrix;
+    RCP<const Tpetra_Map> flat_x_map, flat_b_map;
+    RCP<const Tpetra_CrsGraph> flat_graph, cijk_graph;
+    flat_graph =
+      Stokhos::create_flat_pce_graph(*graph, cijk, flat_x_map, flat_b_map,
+                                     cijk_graph, pce_size);
+    RCP<Flat_Tpetra_CrsMatrix> flat_matrix =
+      Stokhos::create_flat_matrix(*matrix, flat_graph, cijk_graph, cijk);
+    RCP<Flat_Tpetra_Vector> flat_x =
+      Stokhos::create_flat_vector_view(*x2, flat_x_map);
+    RCP<Flat_Tpetra_Vector> flat_b =
+      Stokhos::create_flat_vector_view(*b, flat_b_map);
+    // typedef Tpetra::Operator<BaseScalar,LocalOrdinal,GlobalOrdinal,Node> FlatPrec;
+    // RCP<FlatPrec> flat_M =
+    //   MueLu::CreateTpetraPreconditioner<BaseScalar,LocalOrdinal,GlobalOrdinal,Node>(flat_matrix, *muelu_params);
+    // bool solved_flat = Stokhos::PCG_Solve(*flat_matrix, *flat_x, *flat_b, *flat_M,
+    //                                      tol, max_its, out.getOStream().get());
+    bool solved_flat = Stokhos::CG_Solve(*flat_matrix, *flat_x, *flat_b,
+                                         tol, max_its, out.getOStream().get());
+    TEST_EQUALITY_CONST( solved_flat, true );
+  }
 
   btol = 500*btol;
   ArrayRCP<Scalar> x_view = x->get1dViewNonConst();
@@ -1567,9 +1580,11 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
 
   // Fill RHS vector
   RCP<Tpetra_Vector> b = Tpetra::createVector<Scalar>(map);
-  ArrayRCP<Scalar> b_view = b->get1dViewNonConst();
-  for (size_t i=0; i<num_my_row; ++i) {
-    b_view[i] = Scalar(1.0);
+  {
+    ArrayRCP<Scalar> b_view = b->get1dViewNonConst();
+    for (size_t i=0; i<num_my_row; ++i) {
+      b_view[i] = Scalar(1.0);
+    }
   }
 
   // Solve
@@ -1610,21 +1625,23 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
   RCP<Flat_Tpetra_CrsMatrix> flat_matrix =
     Stokhos::create_flat_matrix(*matrix, flat_graph, cijk_graph, cijk);
   RCP<Tpetra_Vector> x2 = Tpetra::createVector<Scalar>(map);
-  RCP<Flat_Tpetra_Vector> flat_x =
-    Stokhos::create_flat_vector_view(*x2, flat_x_map);
-  RCP<Flat_Tpetra_Vector> flat_b =
-    Stokhos::create_flat_vector_view(*b, flat_b_map);
-  typedef Tpetra::MultiVector<BaseScalar,LocalOrdinal,GlobalOrdinal,Node> FMV;
-  typedef Tpetra::Operator<BaseScalar,LocalOrdinal,GlobalOrdinal,Node> FOP;
-  typedef Belos::LinearProblem<BelosScalar,FMV,FOP> FBLinProb;
-  RCP< FBLinProb > flat_problem =
-    rcp(new FBLinProb(flat_matrix, flat_x, flat_b));
-  RCP<Belos::SolverManager<BelosScalar,FMV,FOP> > flat_solver =
-    rcp(new Belos::PseudoBlockGmresSolMgr<BelosScalar,FMV,FOP>(flat_problem,
+  {
+    RCP<Flat_Tpetra_Vector> flat_x =
+      Stokhos::create_flat_vector_view(*x2, flat_x_map);
+    RCP<Flat_Tpetra_Vector> flat_b =
+      Stokhos::create_flat_vector_view(*b, flat_b_map);
+    typedef Tpetra::MultiVector<BaseScalar,LocalOrdinal,GlobalOrdinal,Node> FMV;
+    typedef Tpetra::Operator<BaseScalar,LocalOrdinal,GlobalOrdinal,Node> FOP;
+    typedef Belos::LinearProblem<BelosScalar,FMV,FOP> FBLinProb;
+    RCP< FBLinProb > flat_problem =
+      rcp(new FBLinProb(flat_matrix, flat_x, flat_b));
+    RCP<Belos::SolverManager<BelosScalar,FMV,FOP> > flat_solver =
+      rcp(new Belos::PseudoBlockGmresSolMgr<BelosScalar,FMV,FOP>(flat_problem,
                                                                belosParams));
-  flat_problem->setProblem();
-  Belos::ReturnType flat_ret = flat_solver->solve();
-  TEST_EQUALITY_CONST( flat_ret, Belos::Converged );
+    flat_problem->setProblem();
+    Belos::ReturnType flat_ret = flat_solver->solve();
+    TEST_EQUALITY_CONST( flat_ret, Belos::Converged );
+  }
 
   typename ST::magnitudeType btol = 100*tol;
   ArrayRCP<Scalar> x_view = x->get1dViewNonConst();
@@ -1738,75 +1755,91 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
   }
   matrix->fillComplete();
 
-  // Create mean matrix for preconditioning
-  RCP<Tpetra_CrsMatrix> mean_matrix = Stokhos::build_mean_matrix(*matrix);
-
   // Fill RHS vector
   RCP<Tpetra_Vector> b = Tpetra::createVector<Scalar>(map);
-  ArrayRCP<Scalar> b_view = b->get1dViewNonConst();
-  for (size_t i=0; i<num_my_row; ++i) {
-    b_view[i] = Scalar(1.0);
+  {
+    ArrayRCP<Scalar> b_view = b->get1dViewNonConst();
+    for (size_t i=0; i<num_my_row; ++i) {
+      b_view[i] = Scalar(1.0);
+    }
   }
 
-  // Create preconditioner
-  typedef Ifpack2::Preconditioner<Scalar,LocalOrdinal,GlobalOrdinal,Node> Prec;
-  Ifpack2::Factory factory;
-  RCP<Prec> M = factory.create<Tpetra_CrsMatrix>("RILUK", mean_matrix);
-  M->initialize();
-  M->compute();
-
-  // Solve
-  typedef Teuchos::ScalarTraits<BaseScalar> ST;
-  typedef BaseScalar BelosScalar;
-  typedef Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> MV;
-  typedef Tpetra::Operator<Scalar,LocalOrdinal,GlobalOrdinal,Node> OP;
-  typedef Belos::LinearProblem<BelosScalar,MV,OP> BLinProb;
   RCP<Tpetra_Vector> x = Tpetra::createVector<Scalar>(map);
-  RCP< BLinProb > problem = rcp(new BLinProb(matrix, x, b));
-  problem->setRightPrec(M);
-  problem->setProblem();
   RCP<ParameterList> belosParams = rcp(new ParameterList);
+  typedef BaseScalar BelosScalar;
+  typedef Teuchos::ScalarTraits<BaseScalar> ST;
   typename ST::magnitudeType tol = 1e-9;
-  belosParams->set("Flexible Gmres", false);
-  belosParams->set("Num Blocks", 100);
-  belosParams->set("Convergence Tolerance", BelosScalar(tol));
-  belosParams->set("Maximum Iterations", 100);
-  belosParams->set("Verbosity", 33);
-  belosParams->set("Output Style", 1);
-  belosParams->set("Output Frequency", 1);
-  belosParams->set("Output Stream", out.getOStream());
-  //belosParams->set("Orthogonalization", "TSQR");
-  RCP<Belos::SolverManager<BelosScalar,MV,OP> > solver =
-    rcp(new Belos::PseudoBlockGmresSolMgr<BelosScalar,MV,OP>(problem, belosParams));
-  Belos::ReturnType ret = solver->solve();
-  TEST_EQUALITY_CONST( ret, Belos::Converged );
+  {
+    typedef Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> MV;
+    typedef Tpetra::Operator<Scalar,LocalOrdinal,GlobalOrdinal,Node> OP;
+    typedef Belos::LinearProblem<BelosScalar,MV,OP> BLinProb;
+
+#if USE_SCALAR_MEAN_BASED_PREC
+    typedef Tpetra::CrsMatrix<BaseScalar,LocalOrdinal,GlobalOrdinal,Node> Scalar_Tpetra_CrsMatrix;
+    RCP<Scalar_Tpetra_CrsMatrix> mean_matrix =
+      Stokhos::build_mean_scalar_matrix(*matrix);
+    typedef Ifpack2::Preconditioner<BaseScalar,LocalOrdinal,GlobalOrdinal,Node> Scalar_Prec;
+    Ifpack2::Factory factory;
+    RCP<Scalar_Prec> M_s = factory.create<Scalar_Tpetra_CrsMatrix>("RILUK", mean_matrix);
+    M_s->initialize();
+    M_s->compute();
+    RCP<OP> M = rcp(new Stokhos::MeanBasedTpetraOperator<Scalar,LocalOrdinal,GlobalOrdinal,Node>(M_s));
+#else
+    RCP<Tpetra_CrsMatrix> mean_matrix = Stokhos::build_mean_matrix(*matrix);
+    typedef Ifpack2::Preconditioner<Scalar,LocalOrdinal,GlobalOrdinal,Node> Prec;
+    Ifpack2::Factory factory;
+    RCP<Prec> M = factory.create<Tpetra_CrsMatrix>("RILUK", mean_matrix);
+    M->initialize();
+    M->compute();
+#endif
+
+    // Solve
+    RCP< BLinProb > problem = rcp(new BLinProb(matrix, x, b));
+    problem->setRightPrec(M);
+    problem->setProblem();
+    belosParams->set("Flexible Gmres", false);
+    belosParams->set("Num Blocks", 100);
+    belosParams->set("Convergence Tolerance", BelosScalar(tol));
+    belosParams->set("Maximum Iterations", 100);
+    belosParams->set("Verbosity", 33);
+    belosParams->set("Output Style", 1);
+    belosParams->set("Output Frequency", 1);
+    belosParams->set("Output Stream", out.getOStream());
+    //belosParams->set("Orthogonalization", "TSQR");
+    RCP<Belos::SolverManager<BelosScalar,MV,OP> > solver =
+      rcp(new Belos::PseudoBlockGmresSolMgr<BelosScalar,MV,OP>(problem, belosParams));
+    Belos::ReturnType ret = solver->solve();
+    TEST_EQUALITY_CONST( ret, Belos::Converged );
+  }
 
   // Check by solving flattened system
-  typedef Tpetra::Vector<BaseScalar,LocalOrdinal,GlobalOrdinal,Node> Flat_Tpetra_Vector;
-  typedef Tpetra::CrsMatrix<BaseScalar,LocalOrdinal,GlobalOrdinal,Node> Flat_Tpetra_CrsMatrix;
-  RCP<const Tpetra_Map> flat_x_map, flat_b_map;
-  RCP<const Tpetra_CrsGraph> flat_graph, cijk_graph;
-  flat_graph =
-    Stokhos::create_flat_pce_graph(*graph, cijk, flat_x_map, flat_b_map,
-                                   cijk_graph, pce_size);
-  RCP<Flat_Tpetra_CrsMatrix> flat_matrix =
-    Stokhos::create_flat_matrix(*matrix, flat_graph, cijk_graph, cijk);
   RCP<Tpetra_Vector> x2 = Tpetra::createVector<Scalar>(map);
-  RCP<Flat_Tpetra_Vector> flat_x =
-    Stokhos::create_flat_vector_view(*x2, flat_x_map);
-  RCP<Flat_Tpetra_Vector> flat_b =
-    Stokhos::create_flat_vector_view(*b, flat_b_map);
-  typedef Tpetra::MultiVector<BaseScalar,LocalOrdinal,GlobalOrdinal,Node> FMV;
-  typedef Tpetra::Operator<BaseScalar,LocalOrdinal,GlobalOrdinal,Node> FOP;
-  typedef Belos::LinearProblem<BelosScalar,FMV,FOP> FBLinProb;
-  RCP< FBLinProb > flat_problem =
-    rcp(new FBLinProb(flat_matrix, flat_x, flat_b));
-  RCP<Belos::SolverManager<BelosScalar,FMV,FOP> > flat_solver =
-    rcp(new Belos::PseudoBlockGmresSolMgr<BelosScalar,FMV,FOP>(flat_problem,
-                                                               belosParams));
-  flat_problem->setProblem();
-  Belos::ReturnType flat_ret = flat_solver->solve();
-  TEST_EQUALITY_CONST( flat_ret, Belos::Converged );
+  {
+    typedef Tpetra::Vector<BaseScalar,LocalOrdinal,GlobalOrdinal,Node> Flat_Tpetra_Vector;
+    typedef Tpetra::CrsMatrix<BaseScalar,LocalOrdinal,GlobalOrdinal,Node> Flat_Tpetra_CrsMatrix;
+    RCP<const Tpetra_Map> flat_x_map, flat_b_map;
+    RCP<const Tpetra_CrsGraph> flat_graph, cijk_graph;
+    flat_graph =
+      Stokhos::create_flat_pce_graph(*graph, cijk, flat_x_map, flat_b_map,
+                                     cijk_graph, pce_size);
+    RCP<Flat_Tpetra_CrsMatrix> flat_matrix =
+      Stokhos::create_flat_matrix(*matrix, flat_graph, cijk_graph, cijk);
+    RCP<Flat_Tpetra_Vector> flat_x =
+      Stokhos::create_flat_vector_view(*x2, flat_x_map);
+    RCP<Flat_Tpetra_Vector> flat_b =
+      Stokhos::create_flat_vector_view(*b, flat_b_map);
+    typedef Tpetra::MultiVector<BaseScalar,LocalOrdinal,GlobalOrdinal,Node> FMV;
+    typedef Tpetra::Operator<BaseScalar,LocalOrdinal,GlobalOrdinal,Node> FOP;
+    typedef Belos::LinearProblem<BelosScalar,FMV,FOP> FBLinProb;
+    RCP< FBLinProb > flat_problem =
+      rcp(new FBLinProb(flat_matrix, flat_x, flat_b));
+    RCP<Belos::SolverManager<BelosScalar,FMV,FOP> > flat_solver =
+      rcp(new Belos::PseudoBlockGmresSolMgr<BelosScalar,FMV,FOP>(flat_problem,
+                                                                 belosParams));
+    flat_problem->setProblem();
+    Belos::ReturnType flat_ret = flat_solver->solve();
+    TEST_EQUALITY_CONST( flat_ret, Belos::Converged );
+  }
 
   typename ST::magnitudeType btol = 100*tol;
   ArrayRCP<Scalar> x_view = x->get1dViewNonConst();
@@ -1935,18 +1968,20 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
 
   // Fill RHS vector
   RCP<Tpetra_Vector> b = Tpetra::createVector<Scalar>(map);
-  ArrayRCP<Scalar> b_view = b->get1dViewNonConst();
-  Scalar b_val(cijk);
-  for (LocalOrdinal j=0; j<pce_size; ++j) {
-    b_val.fastAccessCoeff(j) =
-      BaseScalar(2.0) - BaseScalar(1.0) / BaseScalar(j+1);
-  }
-  for (size_t i=0; i<num_my_row; ++i) {
-    const GlobalOrdinal row = myGIDs[i];
-    if (row == 0 || row == nrow-1)
-      b_view[i] = Scalar(0.0);
-    else
-      b_view[i] = b_val * (h*h);
+  {
+    ArrayRCP<Scalar> b_view = b->get1dViewNonConst();
+    Scalar b_val(cijk);
+    for (LocalOrdinal j=0; j<pce_size; ++j) {
+      b_val.fastAccessCoeff(j) =
+        BaseScalar(2.0) - BaseScalar(1.0) / BaseScalar(j+1);
+    }
+    for (size_t i=0; i<num_my_row; ++i) {
+      const GlobalOrdinal row = myGIDs[i];
+      if (row == 0 || row == nrow-1)
+        b_view[i] = Scalar(0.0);
+      else
+        b_view[i] = b_val * (h*h);
+    }
   }
 
   // Create preconditioner
@@ -2013,24 +2048,26 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
   RCP<Flat_Tpetra_CrsMatrix> flat_matrix =
     Stokhos::create_flat_matrix(*matrix, flat_graph, cijk_graph, cijk);
   RCP<Tpetra_Vector> x2 = Tpetra::createVector<Scalar>(map);
-  RCP<Flat_Tpetra_Vector> flat_x =
-    Stokhos::create_flat_vector_view(*x2, flat_x_map);
-  RCP<Flat_Tpetra_Vector> flat_b =
-    Stokhos::create_flat_vector_view(*b, flat_b_map);
-  typedef Tpetra::MultiVector<BaseScalar,LocalOrdinal,GlobalOrdinal,Node> FMV;
-  typedef Tpetra::Operator<BaseScalar,LocalOrdinal,GlobalOrdinal,Node> FOP;
-  typedef Belos::LinearProblem<BelosScalar,FMV,FOP> FBLinProb;
-  RCP< FBLinProb > flat_problem =
-    rcp(new FBLinProb(flat_matrix, flat_x, flat_b));
-  RCP<Belos::SolverManager<BelosScalar,FMV,FOP> > flat_solver =
-    rcp(new Belos::PseudoBlockGmresSolMgr<BelosScalar,FMV,FOP>(flat_problem,
-                                                               belosParams));
-  // RCP<Belos::SolverManager<BelosScalar,FMV,FOP> > flat_solver =
-  //   rcp(new Belos::PseudoBlockCGSolMgr<BelosScalar,FMV,FOP>(flat_problem,
-  //                                                           belosParams));
-  flat_problem->setProblem();
-  Belos::ReturnType flat_ret = flat_solver->solve();
-  TEST_EQUALITY_CONST( flat_ret, Belos::Converged );
+  {
+    RCP<Flat_Tpetra_Vector> flat_x =
+      Stokhos::create_flat_vector_view(*x2, flat_x_map);
+    RCP<Flat_Tpetra_Vector> flat_b =
+      Stokhos::create_flat_vector_view(*b, flat_b_map);
+    typedef Tpetra::MultiVector<BaseScalar,LocalOrdinal,GlobalOrdinal,Node> FMV;
+    typedef Tpetra::Operator<BaseScalar,LocalOrdinal,GlobalOrdinal,Node> FOP;
+    typedef Belos::LinearProblem<BelosScalar,FMV,FOP> FBLinProb;
+    RCP< FBLinProb > flat_problem =
+      rcp(new FBLinProb(flat_matrix, flat_x, flat_b));
+    RCP<Belos::SolverManager<BelosScalar,FMV,FOP> > flat_solver =
+      rcp(new Belos::PseudoBlockGmresSolMgr<BelosScalar,FMV,FOP>(flat_problem,
+                                                                 belosParams));
+    // RCP<Belos::SolverManager<BelosScalar,FMV,FOP> > flat_solver =
+    //   rcp(new Belos::PseudoBlockCGSolMgr<BelosScalar,FMV,FOP>(flat_problem,
+    //                                                           belosParams));
+    flat_problem->setProblem();
+    Belos::ReturnType flat_ret = flat_solver->solve();
+    TEST_EQUALITY_CONST( flat_ret, Belos::Converged );
+  }
 
   typename ST::magnitudeType btol = 100*tol;
   ArrayRCP<Scalar> x_view = x->get1dViewNonConst();
@@ -2156,18 +2193,20 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
 
   // Fill RHS vector
   RCP<Tpetra_Vector> b = Tpetra::createVector<Scalar>(map);
-  ArrayRCP<Scalar> b_view = b->get1dViewNonConst();
-  Scalar b_val(cijk);
-  for (LocalOrdinal j=0; j<pce_size; ++j) {
-    b_val.fastAccessCoeff(j) =
-      BaseScalar(2.0) - BaseScalar(1.0) / BaseScalar(j+1);
-  }
-  for (size_t i=0; i<num_my_row; ++i) {
-    const GlobalOrdinal row = myGIDs[i];
-    if (row == 0 || row == nrow-1)
-      b_view[i] = Scalar(0.0);
-    else
-      b_view[i] = b_val * (h*h);
+  {
+    ArrayRCP<Scalar> b_view = b->get1dViewNonConst();
+    Scalar b_val(cijk);
+    for (LocalOrdinal j=0; j<pce_size; ++j) {
+      b_val.fastAccessCoeff(j) =
+        BaseScalar(2.0) - BaseScalar(1.0) / BaseScalar(j+1);
+    }
+    for (size_t i=0; i<num_my_row; ++i) {
+      const GlobalOrdinal row = myGIDs[i];
+      if (row == 0 || row == nrow-1)
+        b_view[i] = Scalar(0.0);
+      else
+        b_view[i] = b_val * (h*h);
+    }
   }
 
   // Solve
@@ -2196,10 +2235,11 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
   return;
 #endif
   out << "Solving linear system with " << solver_name << std::endl;
-  RCP<Solver> solver = Amesos2::create<Tpetra_CrsMatrix,Tpetra_MultiVector>(
-    solver_name, matrix, x, b);
-  solver->solve();
-
+  {
+    RCP<Solver> solver = Amesos2::create<Tpetra_CrsMatrix,Tpetra_MultiVector>(
+      solver_name, matrix, x, b);
+    solver->solve();
+  }
   // x->describe(*(Teuchos::fancyOStream(rcp(&std::cout,false))),
   //             Teuchos::VERB_EXTREME);
 
@@ -2215,15 +2255,17 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
   RCP<Flat_Tpetra_CrsMatrix> flat_matrix =
     Stokhos::create_flat_matrix(*matrix, flat_graph, cijk_graph, cijk);
   RCP<Tpetra_Vector> x2 = Tpetra::createVector<Scalar>(map);
-  RCP<Flat_Tpetra_Vector> flat_x =
-    Stokhos::create_flat_vector_view(*x2, flat_x_map);
-  RCP<Flat_Tpetra_Vector> flat_b =
-    Stokhos::create_flat_vector_view(*b, flat_b_map);
-  typedef Amesos2::Solver<Flat_Tpetra_CrsMatrix,Flat_Tpetra_MultiVector> Flat_Solver;
-  RCP<Flat_Solver> flat_solver =
-    Amesos2::create<Flat_Tpetra_CrsMatrix,Flat_Tpetra_MultiVector>(
-      solver_name, flat_matrix, flat_x, flat_b);
-  flat_solver->solve();
+  {
+    RCP<Flat_Tpetra_Vector> flat_x =
+      Stokhos::create_flat_vector_view(*x2, flat_x_map);
+    RCP<Flat_Tpetra_Vector> flat_b =
+      Stokhos::create_flat_vector_view(*b, flat_b_map);
+    typedef Amesos2::Solver<Flat_Tpetra_CrsMatrix,Flat_Tpetra_MultiVector> Flat_Solver;
+    RCP<Flat_Solver> flat_solver =
+      Amesos2::create<Flat_Tpetra_CrsMatrix,Flat_Tpetra_MultiVector>(
+        solver_name, flat_matrix, flat_x, flat_b);
+    flat_solver->solve();
+  }
 
   typedef Kokkos::Details::ArithTraits<BaseScalar> ST;
   typename ST::mag_type btol = 1e-12;


### PR DESCRIPTION
This fixes the Stokhos tests and examples to work on CUDA with UVM disabled in Kokkos (for issue #10884) as well as to work with cuSPARSE in newer versions of the CUDA toolkit (for issue #11084).

Thanks to @csiefer2 for help with diagnosing the numerous Tpetra active host/device errors that were the source of most of the trouble with UVM disabled.