### PR TITLE
Teuchos: Add a constructor to Teuchos::RCP

### DIFF
--- a/packages/teuchos/core/src/Teuchos_RCP.hpp
+++ b/packages/teuchos/core/src/Teuchos_RCP.hpp
@@ -300,6 +300,15 @@ RCP<T>::RCP(const RCP<T2>& r_ptr)
 
 
 template<class T>
+template<class T2>
+inline
+RCP<T>::RCP(const RCP<T2>& r_ptr, T* ptr)
+  : ptr_(ptr), 
+    node_(r_ptr.access_private_node())
+{}
+
+
+template<class T>
 inline
 RCP<T>::~RCP()
 {}

--- a/packages/teuchos/core/src/Teuchos_RCPDecl.hpp
+++ b/packages/teuchos/core/src/Teuchos_RCPDecl.hpp
@@ -546,6 +546,11 @@ public:
   template<class T2>
   inline RCP(const RCP<T2>& r_ptr);
 
+  /** \brief Construct from another <tt>RCP<T2></tt> and from a raw pointer.
+   */
+  template<class T2>
+  inline RCP(const RCP<T2>& r_ptr, T* ptr);
+
   /** \brief Removes a reference to a dynamically allocated object and possibly deletes
    * the object if owned.
    *

--- a/packages/teuchos/core/src/Teuchos_RCPDecl.hpp
+++ b/packages/teuchos/core/src/Teuchos_RCPDecl.hpp
@@ -546,7 +546,14 @@ public:
   template<class T2>
   inline RCP(const RCP<T2>& r_ptr);
 
-  /** \brief Construct from another <tt>RCP<T2></tt> and from a raw pointer.
+  /** \brief Aliasing constructor: Construct using the ownership of a <tt>RCP<T2></tt> and from a raw pointer.
+   * 
+   * Constructs a <tt>RCP<T></tt> which shares ownership information with the initial 
+   * value of r_ptr, but holds an unrelated and unmanaged pointer ptr.
+   * 
+   * This constructor corresponds to the constructor 
+   * template< class Y > shared_ptr( const shared_ptr<Y>& r, element_type* ptr ) noexcept;
+   * of the std::shared_ptr.
    */
   template<class T2>
   inline RCP(const RCP<T2>& r_ptr, T* ptr);

--- a/packages/teuchos/core/test/MemoryManagement/RCP_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/RCP_UnitTests.cpp
@@ -1116,6 +1116,23 @@ TEUCHOS_UNIT_TEST( RCP, Fix_createRCPWithBadDealloc )
 }
 
 
+/**
+ * @test Test the aliasing constructor.
+ */
+TEUCHOS_UNIT_TEST( RCP, aliasing_constructor )
+{
+  Teuchos::RCP<A> a_rcp = Teuchos::make_rcp<A>(1,2);
+  Teuchos::RCP<A> b_rcp = Teuchos::make_rcp<A>(2,3);
+  Teuchos::RCP<A> c_rcp(a_rcp, b_rcp.get());
+
+  TEST_ASSERT(Teuchos::nonnull(c_rcp));
+  TEST_EQUALITY_CONST(c_rcp.get(), b_rcp.get());
+  TEST_EQUALITY(c_rcp->A_g(), b_rcp->A_g());
+  TEST_EQUALITY(c_rcp->A_f(), b_rcp->A_f());
+  TEST_ASSERT( c_rcp.shares_resource(a_rcp) );
+}
+
+
 //
 // Test RCP/boost::shared_ptr covnersions
 //


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/teuchos 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

`Teuchos::RCP` is currently missing one constructor of the `std::shared_ptr` ([constructor (8) here](http://en.cppreference.com/w/cpp/memory/shared_ptr/shared_ptr)) used for instance by pybind11 with multiple inheritance  https://github.com/pybind/pybind11/issues/1306 .

This PR adds the extra constructor.


<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->