### PR TITLE
Add include guards for *_def.hpp file (#10507)

### DIFF
--- a/packages/stratimikos/src/Stratimikos_LinearSolverBuilder_def.hpp
+++ b/packages/stratimikos/src/Stratimikos_LinearSolverBuilder_def.hpp
@@ -39,6 +39,9 @@
 // ***********************************************************************
 // @HEADER
 
+#ifndef STRATIMIKOS_LINEARSOLVERBUILDER_DEF_HPP
+#define STRATIMIKOS_LINEARSOLVERBUILDER_DEF_HPP
+
 //#define THYRA_DEFAULT_REAL_LINEAR_SOLVER_BUILDER_DUMP
 
 #include "Stratimikos_InternalConfig.h"
@@ -625,3 +628,5 @@ void LinearSolverBuilder<Scalar>::justInTimeInitialize() const
 
 
 } // namespace Stratimikos
+
+#endif // STRATIMIKOS_LINEARSOLVERBUILDER_DEF_HPP


### PR DESCRIPTION
When this file was converted from a *.cpp file to a *_def.hpp file when Stratimikos::LinearSolverBuilder was templated in PR #10507, include guards did not get added to this file.
