### PR TITLE
Piro: fix tests for cuda 11 builds

### DIFF
--- a/packages/nox/src/NOX_Multiphysics_Solver_Generic.H
+++ b/packages/nox/src/NOX_Multiphysics_Solver_Generic.H
@@ -127,14 +127,16 @@ public:
     const Teuchos::RCP<NOX::StatusTest::Generic>& tests,
     const Teuchos::RCP<Teuchos::ParameterList>& params) = 0;
 
-  //! reset methods inherited from NOX::Solver::Generic and needed here to avoid hiding this overloaded virtual method
+  //! reset methods inherited from NOX::Solver::Generic are needed here to avoid hiding this overloaded virtual method
+
+  virtual void reset() = 0;
 
   virtual void
   reset(const NOX::Abstract::Vector& initialGuess) = 0;
 
   virtual void
   reset(const NOX::Abstract::Vector& initialGuess,
-    const Teuchos::RCP<NOX::StatusTest::Generic>& tests) = 0;
+        const Teuchos::RCP<NOX::StatusTest::Generic>& tests) = 0;
 
 };
 } // namespace Solver

--- a/packages/nox/src/NOX_Multiphysics_Solver_Manager.C
+++ b/packages/nox/src/NOX_Multiphysics_Solver_Manager.C
@@ -153,7 +153,7 @@ void NOX::Multiphysics::Solver::Manager::deprecated(const std::string& oldName, 
        << std::endl;
 }
 
-NOX::StatusTest::StatusType NOX::Multiphysics::Solver::Manager::getStatus()
+NOX::StatusTest::StatusType NOX::Multiphysics::Solver::Manager::getStatus() const
 {
   checkNullPtr("getStatus");
   return cplPtr->getStatus();

--- a/packages/nox/src/NOX_Multiphysics_Solver_Manager.H
+++ b/packages/nox/src/NOX_Multiphysics_Solver_Manager.H
@@ -120,7 +120,7 @@ public:
                  const Teuchos::RCP<NOX::StatusTest::Generic>& tests);
   virtual void reset(const NOX::Abstract::Vector& initialGuess);
   virtual void reset();
-  virtual NOX::StatusTest::StatusType getStatus();
+  virtual NOX::StatusTest::StatusType getStatus() const;
   virtual NOX::StatusTest::StatusType step();
   virtual NOX::StatusTest::StatusType solve();
   virtual const NOX::Abstract::Group& getSolutionGroup() const;

--- a/packages/nox/src/NOX_Solver_Generic.H
+++ b/packages/nox/src/NOX_Solver_Generic.H
@@ -119,7 +119,7 @@ public:
 
   //! Resets the solver, sets a new status test, and sets a new initial guess.
   virtual void reset(const NOX::Abstract::Vector& initial_guess,
-             const Teuchos::RCP<NOX::StatusTest::Generic>& test) = 0;
+                     const Teuchos::RCP<NOX::StatusTest::Generic>& test) = 0;
 
   //! Do one nonlinear step in the iteration sequence and return status.
   virtual NOX::StatusTest::StatusType step() = 0;


### PR DESCRIPTION
## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Two tests were failing cuda 11 builds. Had to fix the lifetimes of temporary local views of tpetra views.

Fixes #11169 

## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
Fixes failing tests.

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
Covered under tests:
```
    Piro_ThyraSolverTpetra_MPI_4
    Piro_AnalysisDriverTpetra_MPI_4
```

