### PR TITLE
Sacado:  Fix memory leaks in Rad when using DFad nested scalar type.

### DIFF
--- a/packages/sacado/example/trad_dfad_example.cpp
+++ b/packages/sacado/example/trad_dfad_example.cpp
@@ -138,6 +138,12 @@ int main(int argc, char **argv)
 	    << std::setw(w) << d2rdbda_ad << " (AD) Error = " << std::setw(w) 
 	    << d2rdadb - d2rdbda_ad << std::endl;
 
+  // Free Rad's memory to avoid memory leaks.  The zero_out() call is
+  // necessary to destroy dynamically allocated DFad arrays (which are
+  // stored outside of Rad's memory management).
+  Sacado::Rad::ADcontext< Sacado::Fad::DFad<double> >::zero_out();
+  Sacado::Rad::ADcontext< Sacado::Fad::DFad<double> >::free_all();
+
   double tol = 1.0e-14;
   if (std::fabs(r - r_ad)             < tol &&
       std::fabs(drda - drda_ad)       < tol &&

--- a/packages/sacado/example/trad_example.cpp
+++ b/packages/sacado/example/trad_example.cpp
@@ -90,6 +90,9 @@ int main(int argc, char **argv)
   double drda_ad = arad.adj();  // dr/da
   double drdb_ad = brad.adj();  // dr/db
 
+  // Free Rad's memory to avoid memory leaks
+  Sacado::Rad::ADcontext< double >::free_all();
+
   // Print the results
   int p = 4;
   int w = p+7;


### PR DESCRIPTION
Rad does its own memory management, but doesn't know anything about it when its nested scalar type is also dynamically allocated, which was causing massive memory leaks when using, e.g., Rad< DFad<double> >.  The only way to fix this without a major overhaul in Rad is to ask the user to call a new function to zero out all of Rad's internally stored data, which as a side-effect will deallocate DFad derivative arrays.  Also added this new function to the trad-dfad example.

For issue #7741.