### PR TITLE
MueLu: reenable libmuelu-adapters.a

### DIFF
--- a/packages/muelu/adapters/CMakeLists.txt
+++ b/packages/muelu/adapters/CMakeLists.txt
@@ -211,16 +211,17 @@ APPEND_GLOB(HEADERS ${DIR}/*.hpp)
 APPEND_GLOB(SOURCES ${DIR}/*.cpp)
 
 IF ("${SOURCES}" STREQUAL "")
-  MESSAGE(STATUS "no adapters enabled, skipping generation of the muelu-adapters library")
-ELSE()
-  TRIBITS_ADD_LIBRARY(
-    muelu-adapters
-    HEADERS ${HEADERS}
-    SOURCES ${SOURCES}
-    DEPLIBS muelu
-    ADDED_LIB_TARGET_NAME_OUT MUELU_ADAPTERS_LIBNAME
-    )
+  # always include at least one file in the adapters library.
+  SET_AND_INC_DIRS(DIR ${CMAKE_CURRENT_SOURCE_DIR})
+  APPEND_GLOB(SOURCES ${DIR}/muelu-trivial-adapter.cpp)
 ENDIF()
+TRIBITS_ADD_LIBRARY(
+  muelu-adapters
+  HEADERS ${HEADERS}
+  SOURCES ${SOURCES}
+  DEPLIBS muelu
+  ADDED_LIB_TARGET_NAME_OUT MUELU_ADAPTERS_LIBNAME
+  )
 
 # Set linker language explicitly for CUDA builds.
 set_target_properties(

--- a/packages/muelu/adapters/muelu-trivial-adapter.cpp
+++ b/packages/muelu/adapters/muelu-trivial-adapter.cpp
@@ -43,6 +43,7 @@
 // ***********************************************************************
 //
 // @HEADER
-// MacOs 'ar' utility doesn't work on empty library.
+// If no adapters are enabled, this file will be archived so that the library
+// is not empty.
 
-void libmuelu_adapters() {}
+void muelu_trivial_adapter() {}


### PR DESCRIPTION
If no adapters are enabled, add the object file "muelu-trivial-adapter" to libmuelu-adapters.a.  In this way, TRIBITS_ADD_LIBRARY will always be invoked and install necessary header files.

Addresses #11192.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/muelu 
## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->
Supercedes #11180, which was an incorrect fix.


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Reproduced problem locally, confirmed that this PR fixes.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->