### PR TITLE
Don't unconditionally enable STK subpackages (#11205)

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -937,14 +937,6 @@ opt-set-cmake-var KokkosKernels_batched_dla_cuda_MPI_1_SET_RUN_SERIAL BOOL FORCE
 [ATS2-ENABLE-OVERRIDES]
 opt-set-cmake-var TPL_ENABLE_DLlib BOOL FORCE : ON
 opt-set-cmake-var TPL_FIND_SHARED_LIBS BOOL FORCE : ON
-opt-set-cmake-var Trilinos_ENABLE_STKIO BOOL FORCE : ON
-opt-set-cmake-var Trilinos_ENABLE_STKMesh BOOL FORCE : ON
-opt-set-cmake-var Trilinos_ENABLE_STKSearch BOOL FORCE : ON
-opt-set-cmake-var Trilinos_ENABLE_STKSimd BOOL FORCE : ON
-opt-set-cmake-var Trilinos_ENABLE_STKTopology BOOL FORCE : ON
-opt-set-cmake-var Trilinos_ENABLE_STKTransfer BOOL FORCE : ON
-opt-set-cmake-var Trilinos_ENABLE_STKUnit_tests BOOL FORCE : ON
-opt-set-cmake-var Trilinos_ENABLE_STKUtil BOOL FORCE : ON
 opt-set-cmake-var Trilinos_ENABLE_ShyLU_NodeTacho BOOL FORCE : OFF
 opt-set-cmake-var Trilinos_ENABLE_ShyLU BOOL FORCE : OFF
 opt-set-cmake-var Trilinos_ENABLE_Xpetra BOOL FORCE :


### PR DESCRIPTION
Fixes #11205 

The PR testing will show that this is working (after examining the configure output on the 'ats2' build).
