### PR TITLE
Tpetra: (local map) device default constructor fix for #11186

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_def.hpp
@@ -542,43 +542,12 @@ private:
 
 template<class KeyType, class ValueType, class DeviceType>
 FixedHashTable<KeyType, ValueType, DeviceType>::
-FixedHashTable () :
-  minKey_ (::Kokkos::Details::ArithTraits<KeyType>::max ()),
-  maxKey_ (::Kokkos::Details::ArithTraits<KeyType>::is_integer ?
-           ::Kokkos::Details::ArithTraits<KeyType>::min () :
-           -::Kokkos::Details::ArithTraits<KeyType>::max ()),
-  minVal_ (::Kokkos::Details::ArithTraits<ValueType>::max ()),
-  maxVal_ (::Kokkos::Details::ArithTraits<ValueType>::is_integer ?
-           ::Kokkos::Details::ArithTraits<ValueType>::min () :
-           -::Kokkos::Details::ArithTraits<ValueType>::max ()),
-  firstContigKey_ (::Kokkos::Details::ArithTraits<KeyType>::max ()),
-  lastContigKey_ (::Kokkos::Details::ArithTraits<KeyType>::is_integer ?
-                  ::Kokkos::Details::ArithTraits<KeyType>::min () :
-                  -::Kokkos::Details::ArithTraits<KeyType>::max ()),
-  contiguousValues_ (true), // trivially
-  checkedForDuplicateKeys_ (true), // it's an empty table; no need to check
-  hasDuplicateKeys_ (false)
-{
-}
-
-template<class KeyType, class ValueType, class DeviceType>
-FixedHashTable<KeyType, ValueType, DeviceType>::
 FixedHashTable (const keys_type& keys) :
-  minKey_ (::Kokkos::Details::ArithTraits<KeyType>::max ()), // to be set in init()
-  maxKey_ (::Kokkos::Details::ArithTraits<KeyType>::is_integer ?
-           ::Kokkos::Details::ArithTraits<KeyType>::min () :
-           -::Kokkos::Details::ArithTraits<KeyType>::max ()), // to be set in init()
   minVal_ (0),
   maxVal_ (keys.size () == 0 ?
            static_cast<ValueType> (0) :
            static_cast<ValueType> (keys.size () - 1)),
-  firstContigKey_ (::Kokkos::Details::ArithTraits<KeyType>::max ()),
-  lastContigKey_ (::Kokkos::Details::ArithTraits<KeyType>::is_integer ?
-                  ::Kokkos::Details::ArithTraits<KeyType>::min () :
-                  -::Kokkos::Details::ArithTraits<KeyType>::max ()),
-  contiguousValues_ (true),
-  checkedForDuplicateKeys_ (false),
-  hasDuplicateKeys_ (false) // to revise in hasDuplicateKeys()
+  checkedForDuplicateKeys_ (false)
 {
   const ValueType startingValue = static_cast<ValueType> (0);
   const KeyType initMinKey = this->minKey_;
@@ -590,21 +559,11 @@ FixedHashTable (const keys_type& keys) :
 template<class KeyType, class ValueType, class DeviceType>
 FixedHashTable<KeyType, ValueType, DeviceType>::
 FixedHashTable (const Teuchos::ArrayView<const KeyType>& keys) :
-  minKey_ (::Kokkos::Details::ArithTraits<KeyType>::max ()), // to be set in init()
-  maxKey_ (::Kokkos::Details::ArithTraits<KeyType>::is_integer ?
-           ::Kokkos::Details::ArithTraits<KeyType>::min () :
-           -::Kokkos::Details::ArithTraits<KeyType>::max ()), // to be set in init()
   minVal_ (0),
   maxVal_ (keys.size () == 0 ?
            static_cast<ValueType> (0) :
            static_cast<ValueType> (keys.size () - 1)),
-  firstContigKey_ (::Kokkos::Details::ArithTraits<KeyType>::max ()),
-  lastContigKey_ (::Kokkos::Details::ArithTraits<KeyType>::is_integer ?
-                  ::Kokkos::Details::ArithTraits<KeyType>::min () :
-                  -::Kokkos::Details::ArithTraits<KeyType>::max ()),
-  contiguousValues_ (true),
-  checkedForDuplicateKeys_ (false),
-  hasDuplicateKeys_ (false) // to revise in hasDuplicateKeys()
+  checkedForDuplicateKeys_ (false)
 {
   typedef typename keys_type::non_const_type nonconst_keys_type;
 
@@ -629,21 +588,11 @@ template<class KeyType, class ValueType, class DeviceType>
 FixedHashTable<KeyType, ValueType, DeviceType>::
 FixedHashTable (const Teuchos::ArrayView<const KeyType>& keys,
                 const ValueType startingValue) :
-  minKey_ (::Kokkos::Details::ArithTraits<KeyType>::max ()),
-  maxKey_ (::Kokkos::Details::ArithTraits<KeyType>::is_integer ?
-           ::Kokkos::Details::ArithTraits<KeyType>::min () :
-           -::Kokkos::Details::ArithTraits<KeyType>::max ()),
   minVal_ (startingValue),
   maxVal_ (keys.size () == 0 ?
            startingValue :
            static_cast<ValueType> (startingValue + keys.size () - 1)),
-  firstContigKey_ (::Kokkos::Details::ArithTraits<KeyType>::max ()),
-  lastContigKey_ (::Kokkos::Details::ArithTraits<KeyType>::is_integer ?
-                  ::Kokkos::Details::ArithTraits<KeyType>::min () :
-                  -::Kokkos::Details::ArithTraits<KeyType>::max ()),
-  contiguousValues_ (true),
-  checkedForDuplicateKeys_ (false),
-  hasDuplicateKeys_ (false) // to revise in hasDuplicateKeys()
+  checkedForDuplicateKeys_ (false)
 {
   typedef typename keys_type::non_const_type nonconst_keys_type;
 
@@ -686,19 +635,13 @@ FixedHashTable (const keys_type& keys,
                 const KeyType firstContigKey,
                 const KeyType lastContigKey,
                 const ValueType startingValue) :
-  minKey_ (::Kokkos::Details::ArithTraits<KeyType>::max ()),
-  maxKey_ (::Kokkos::Details::ArithTraits<KeyType>::is_integer ?
-           ::Kokkos::Details::ArithTraits<KeyType>::min () :
-           -::Kokkos::Details::ArithTraits<KeyType>::max ()),
   minVal_ (startingValue),
   maxVal_ (keys.size () == 0 ?
            startingValue :
            static_cast<ValueType> (startingValue + keys.size () - 1)),
   firstContigKey_ (firstContigKey),
   lastContigKey_ (lastContigKey),
-  contiguousValues_ (true),
-  checkedForDuplicateKeys_ (false),
-  hasDuplicateKeys_ (false) // to revise in hasDuplicateKeys()
+  checkedForDuplicateKeys_ (false)
 {
   const KeyType initMinKey = ::Kokkos::Details::ArithTraits<KeyType>::max ();
   // min() for a floating-point type returns the minimum _positive_
@@ -726,19 +669,13 @@ FixedHashTable (const Teuchos::ArrayView<const KeyType>& keys,
                 const KeyType firstContigKey,
                 const KeyType lastContigKey,
                 const ValueType startingValue) :
-  minKey_ (::Kokkos::Details::ArithTraits<KeyType>::max ()),
-  maxKey_ (::Kokkos::Details::ArithTraits<KeyType>::is_integer ?
-           ::Kokkos::Details::ArithTraits<KeyType>::min () :
-           -::Kokkos::Details::ArithTraits<KeyType>::max ()),
   minVal_ (startingValue),
   maxVal_ (keys.size () == 0 ?
            startingValue :
            static_cast<ValueType> (startingValue + keys.size () - 1)),
   firstContigKey_ (firstContigKey),
   lastContigKey_ (lastContigKey),
-  contiguousValues_ (true),
-  checkedForDuplicateKeys_ (false),
-  hasDuplicateKeys_ (false) // to revise in hasDuplicateKeys()
+  checkedForDuplicateKeys_ (false)
 {
   typedef typename keys_type::non_const_type nonconst_keys_type;
 
@@ -777,21 +714,11 @@ template<class KeyType, class ValueType, class DeviceType>
 FixedHashTable<KeyType, ValueType, DeviceType>::
 FixedHashTable (const keys_type& keys,
                 const ValueType startingValue) :
-  minKey_ (::Kokkos::Details::ArithTraits<KeyType>::max ()),
-  maxKey_ (::Kokkos::Details::ArithTraits<KeyType>::is_integer ?
-           ::Kokkos::Details::ArithTraits<KeyType>::min () :
-           -::Kokkos::Details::ArithTraits<KeyType>::max ()),
   minVal_ (startingValue),
   maxVal_ (keys.size () == 0 ?
            startingValue :
            static_cast<ValueType> (startingValue + keys.size () - 1)),
-  firstContigKey_ (::Kokkos::Details::ArithTraits<KeyType>::max ()),
-  lastContigKey_ (::Kokkos::Details::ArithTraits<KeyType>::is_integer ?
-                  ::Kokkos::Details::ArithTraits<KeyType>::min () :
-                  -::Kokkos::Details::ArithTraits<KeyType>::max ()),
-  contiguousValues_ (true),
-  checkedForDuplicateKeys_ (false),
-  hasDuplicateKeys_ (false) // to revise in hasDuplicateKeys()
+  checkedForDuplicateKeys_ (false)
 {
   const KeyType initMinKey = ::Kokkos::Details::ArithTraits<KeyType>::max ();
   // min() for a floating-point type returns the minimum _positive_
@@ -817,21 +744,8 @@ template<class KeyType, class ValueType, class DeviceType>
 FixedHashTable<KeyType, ValueType, DeviceType>::
 FixedHashTable (const Teuchos::ArrayView<const KeyType>& keys,
                 const Teuchos::ArrayView<const ValueType>& vals) :
-  minKey_ (::Kokkos::Details::ArithTraits<KeyType>::max ()),
-  maxKey_ (::Kokkos::Details::ArithTraits<KeyType>::is_integer ?
-           ::Kokkos::Details::ArithTraits<KeyType>::min () :
-           -::Kokkos::Details::ArithTraits<KeyType>::max ()),
-  minVal_ (::Kokkos::Details::ArithTraits<ValueType>::max ()),
-  maxVal_ (::Kokkos::Details::ArithTraits<ValueType>::is_integer ?
-           ::Kokkos::Details::ArithTraits<ValueType>::min () :
-           -::Kokkos::Details::ArithTraits<ValueType>::max ()),
-  firstContigKey_ (::Kokkos::Details::ArithTraits<KeyType>::max ()),
-  lastContigKey_ (::Kokkos::Details::ArithTraits<KeyType>::is_integer ?
-                  ::Kokkos::Details::ArithTraits<KeyType>::min () :
-                  -::Kokkos::Details::ArithTraits<KeyType>::max ()),
   contiguousValues_ (false),
-  checkedForDuplicateKeys_ (false),
-  hasDuplicateKeys_ (false) // to revise in hasDuplicateKeys()
+  checkedForDuplicateKeys_ (false)
 {
   // mfh 01 May 2015: I don't trust that
   // Teuchos::ArrayView::getRawPtr() returns NULL when the size is 0,

--- a/packages/tpetra/core/src/Tpetra_Details_LocalMap.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_LocalMap.hpp
@@ -94,15 +94,9 @@ public:
   using no_uvm_device_type = device_type;
 #endif
 
-  LocalMap () :
-    indexBase_ (0),
-    myMinGid_ (Tpetra::Details::OrdinalTraits<GlobalOrdinal>::invalid ()),
-    myMaxGid_ (Tpetra::Details::OrdinalTraits<GlobalOrdinal>::invalid ()),
-    firstContiguousGid_ (Tpetra::Details::OrdinalTraits<GlobalOrdinal>::invalid ()),
-    lastContiguousGid_ (Tpetra::Details::OrdinalTraits<GlobalOrdinal>::invalid ()),
-    numLocalElements_ (0),
-    contiguous_ (false)
-  {}
+  //! Default constructor.
+  KOKKOS_DEFAULTED_FUNCTION LocalMap() = default;
+
   LocalMap (const ::Tpetra::Details::FixedHashTable<GlobalOrdinal, LocalOrdinal, no_uvm_device_type>& glMap,
             const ::Kokkos::View<const GlobalOrdinal*, ::Kokkos::LayoutLeft, no_uvm_device_type>& lgMap,
             const GlobalOrdinal indexBase,
@@ -222,13 +216,13 @@ private:
   /// copying from the default to the nondefault layout.
   ::Kokkos::View<const GlobalOrdinal*, ::Kokkos::LayoutLeft, no_uvm_device_type> lgMap_;
 
-  GlobalOrdinal indexBase_;
-  GlobalOrdinal myMinGid_;
-  GlobalOrdinal myMaxGid_;
-  GlobalOrdinal firstContiguousGid_;
-  GlobalOrdinal lastContiguousGid_;
-  LocalOrdinal numLocalElements_;
-  bool contiguous_;
+  GlobalOrdinal indexBase_          = 0;
+  GlobalOrdinal myMinGid_           = Tpetra::Details::OrdinalTraits<GlobalOrdinal>::invalid();
+  GlobalOrdinal myMaxGid_           = Tpetra::Details::OrdinalTraits<GlobalOrdinal>::invalid();
+  GlobalOrdinal firstContiguousGid_ = Tpetra::Details::OrdinalTraits<GlobalOrdinal>::invalid();
+  GlobalOrdinal lastContiguousGid_  = Tpetra::Details::OrdinalTraits<GlobalOrdinal>::invalid();
+  LocalOrdinal numLocalElements_    = 0;
+  bool contiguous_                  = false;
 };
 
 } // namespace Details

--- a/packages/tpetra/core/test/Map/Map_LocalMap.cpp
+++ b/packages/tpetra/core/test/Map/Map_LocalMap.cpp
@@ -322,6 +322,27 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( LocalMap, Noncontig, LO, GO, NT )
   }
 }
 
+/**
+ * @test This test ensures that the fix brought by trilinos/Trilinos#11218 is tested.
+ *
+ * Mainly, it creates a dual view of local maps, assigns on the host view and syncs.
+ * Without the fix from trilinos/Trilinos#11218, the assignment would crash at runtime
+ * when running with Cuda UVM.
+ */
+TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( LocalMap, KokkosView, LO, GO, NT )
+{
+    using execution_space = typename NT::execution_space;
+    using map_t           = Tpetra::Map<LO, GO, NT>;
+    using local_map_t     = typename map_t::local_map_type;
+    using dual_view_t     = Kokkos::DualView<local_map_t*, execution_space>;
+
+    dual_view_t my_dual_view("test view with local maps",1);
+
+    my_dual_view.h_view(0) = local_map_t();
+
+    my_dual_view.sync_device();
+}
+
 //
 // INSTANTIATIONS
 //
@@ -329,7 +350,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( LocalMap, Noncontig, LO, GO, NT )
 #define UNIT_TEST_GROUP( LO, GO, NT ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( LocalMap, UniformContig, LO, GO, NT ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( LocalMap, NonuniformContig, LO, GO, NT ) \
-  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( LocalMap, Noncontig, LO, GO, NT )
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( LocalMap, Noncontig, LO, GO, NT ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( LocalMap, KokkosView, LO, GO, NT )
 
   TPETRA_ETI_MANGLING_TYPEDEFS()
 


### PR DESCRIPTION
@trilinos/Tpetra

Suggested reviewer: @brian-kelley 

## Motivation

`Tpetra::Details::LocalMap` and `Tpetra::Details::FixedHashTable` had no device default constructor, leading to issues when using them in a `Kokkos::DualView` with `cuda uvm`. See related issue for more information.

## Related Issues

* Related to #11186

## Testing

We tested the patch for both `cuda` and `rocm`.