### PR TITLE
Clean up ATDM builds for CMake upgrade (#10355)

### DIFF
--- a/cmake/ctest/drivers/atdm/cee-rhel7/drivers/Trilinos-atdm-cee-rhel7_mini-no-mpi_clang-9.0.1_serial_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/cee-rhel7/drivers/Trilinos-atdm-cee-rhel7_mini-no-mpi_clang-9.0.1_serial_static_opt.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 export Trilinos_TRACK=SparcATDM
-$WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cee-rhel7/local-driver.sh
+echo "Build Trilinos-atdm-cee-rhel7_mini-no-mpi_clang-9.0.1_serial_static_opt has been disabled (see #10355)"
+#$WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cee-rhel7/local-driver.sh

--- a/cmake/ctest/drivers/atdm/cee-rhel7/drivers/Trilinos-atdm-cee-rhel7_mini-no-mpi_cuda-10.1.243_gnu-7.2.0_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/cee-rhel7/drivers/Trilinos-atdm-cee-rhel7_mini-no-mpi_cuda-10.1.243_gnu-7.2.0_static_opt.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 export Trilinos_TRACK=SparcATDM
-$WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cee-rhel7/local-driver.sh
+echo "The build Trilinos-atdm-cee-rhel7_mini-no-mpi_cuda-10.1.243_gnu-7.2.0_static_opt has been diabled (see #10355)"
+#$WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cee-rhel7/local-driver.sh

--- a/cmake/ctest/drivers/atdm/cee-rhel7/drivers/Trilinos-atdm-cee-rhel7_mini-no-mpi_gnu-7.2.0_serial_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/cee-rhel7/drivers/Trilinos-atdm-cee-rhel7_mini-no-mpi_gnu-7.2.0_serial_static_opt.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 export Trilinos_TRACK=SparcATDM
-$WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cee-rhel7/local-driver.sh
+echo "The build Trilinos-atdm-cee-rhel7_mini-no-mpi_gnu-7.2.0_serial_static_opt has been disabled (see #10355)"
+#$WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cee-rhel7/local-driver.sh

--- a/cmake/ctest/drivers/atdm/tlcc2/drivers/Trilinos-atdm-tlcc2-intel-debug-openmp.sh
+++ b/cmake/ctest/drivers/atdm/tlcc2/drivers/Trilinos-atdm-tlcc2-intel-debug-openmp.sh
@@ -8,4 +8,5 @@ if [ "${Trilinos_TRACK}" == "" ] ; then
   export Trilinos_TRACK=SecondaryATDM
 fi
 
-$WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/tlcc2/local-driver.sh
+echo "Build Trilinos-atdm-tlcc2-intel-debug-openmp has been disabled (see #10355)"
+#$WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/tlcc2/local-driver.sh

--- a/cmake/ctest/drivers/atdm/tlcc2/drivers/Trilinos-atdm-tlcc2-intel-opt-openmp.sh
+++ b/cmake/ctest/drivers/atdm/tlcc2/drivers/Trilinos-atdm-tlcc2-intel-opt-openmp.sh
@@ -3,4 +3,6 @@
 if [ "${Trilinos_TRACK}" == "" ] ; then
   export Trilinos_TRACK=PrimaryATDM
 fi
-$WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/tlcc2/local-driver.sh
+
+echo "Build Trilinos-atdm-tlcc2-intel-opt-openmp has been disabled (see #10355)"
+#$WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/tlcc2/local-driver.sh

--- a/cmake/ctest/drivers/atdm/van1-tx2/drivers/Trilinos-atdm-van1-tx2_arm-20.0_openmpi-4.0.2_openmp_static_dbg.sh
+++ b/cmake/ctest/drivers/atdm/van1-tx2/drivers/Trilinos-atdm-van1-tx2_arm-20.0_openmpi-4.0.2_openmp_static_dbg.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-#export SALLOC_CTEST_TIME_LIMIT_MINUTES=1:00:00
-
-if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=SecondaryATDM
-fi
-
-$WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/van1-tx2/local-driver.sh

--- a/cmake/ctest/drivers/atdm/van1-tx2/drivers/Trilinos-atdm-van1-tx2_arm-20.0_openmpi-4.0.2_openmp_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/van1-tx2/drivers/Trilinos-atdm-van1-tx2_arm-20.0_openmpi-4.0.2_openmp_static_opt.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-#export SALLOC_CTEST_TIME_LIMIT_MINUTES=1:00:00
-
-if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=SecondaryATDM
-fi
-
-$WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/van1-tx2/local-driver.sh

--- a/cmake/ctest/drivers/atdm/van1-tx2/drivers/Trilinos-atdm-van1-tx2_arm-20.1_openmpi-4.0.3_openmp_static_dbg.sh
+++ b/cmake/ctest/drivers/atdm/van1-tx2/drivers/Trilinos-atdm-van1-tx2_arm-20.1_openmpi-4.0.3_openmp_static_dbg.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-#export SALLOC_CTEST_TIME_LIMIT_MINUTES=1:00:00
-
-if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=SecondaryATDM
-fi
-
-$WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/van1-tx2/local-driver.sh

--- a/cmake/ctest/drivers/atdm/van1-tx2/drivers/Trilinos-atdm-van1-tx2_arm-20.1_openmpi-4.0.3_openmp_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/van1-tx2/drivers/Trilinos-atdm-van1-tx2_arm-20.1_openmpi-4.0.3_openmp_static_opt.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-#export SALLOC_CTEST_TIME_LIMIT_MINUTES=1:00:00
-
-if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=PrimaryATDM
-fi
-
-$WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/van1-tx2/local-driver.sh

--- a/cmake/ctest/drivers/atdm/van1-tx2/drivers/Trilinos-atdm-van1-tx2_arm-20.1_openmpi-4.0.5_openmp_static_dbg.sh
+++ b/cmake/ctest/drivers/atdm/van1-tx2/drivers/Trilinos-atdm-van1-tx2_arm-20.1_openmpi-4.0.5_openmp_static_dbg.sh
@@ -6,4 +6,7 @@ if [ "${Trilinos_TRACK}" == "" ] ; then
   export Trilinos_TRACK=Specialized
 fi
 
+# Disabling tests, see #10355
+export CTEST_DO_TEST=OFF
+
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/van1-tx2/local-driver.sh

--- a/cmake/ctest/drivers/atdm/van1-tx2/drivers/Trilinos-atdm-van1-tx2_arm-20.1_openmpi-4.0.5_openmp_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/van1-tx2/drivers/Trilinos-atdm-van1-tx2_arm-20.1_openmpi-4.0.5_openmp_static_opt.sh
@@ -6,4 +6,7 @@ if [ "${Trilinos_TRACK}" == "" ] ; then
   export Trilinos_TRACK=PrimaryATDM
 fi
 
+# Disabling tests, see #10355
+export CTEST_DO_TEST=OFF
+
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/van1-tx2/local-driver.sh

--- a/cmake/std/atdm/ATDMDisables.cmake
+++ b/cmake/std/atdm/ATDMDisables.cmake
@@ -50,6 +50,7 @@ SET(ATDM_SE_PACKAGE_DISABLES
   PyTrilinos
   TrilinosCouplings
   Pike
+  TrilinosInstallTests
   )
 
 IF (NOT ATDM_ENABLE_SPARC_SETTINGS)


### PR DESCRIPTION
Disabled builds and tests that have failed for all recorded history on CDash (see https://github.com/trilinos/Trilinos/issues/10355#issuecomment-1303693318).

See individual commits for details.
