### PR TITLE
Ifpack2: Make the Chebyshev power method consistent with itself

### DIFF
--- a/packages/ifpack2/doc/UsersGuide/options.tex
+++ b/packages/ifpack2/doc/UsersGuide/options.tex
@@ -380,6 +380,11 @@ The following parameters are used in the Chebyshev method:
     {bool}
     {\false}
     {The \texttt{apply} call will optionally return the norm of the residual.}
+\ccc{chebyshev: compute spectral radius}
+    {bool}
+    {\true}
+    {The power method will compute the spectral radius if true. If false, it will
+     instead compute the dominant eigenvalue (these differ by absolute value).}
 \ccc{eigen-analysis: type}
     {string}
     {"power-method"}

--- a/packages/ifpack2/src/Ifpack2_Details_Chebyshev_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Chebyshev_decl.hpp
@@ -239,6 +239,9 @@ public:
   ///   always use the zero vector(s) as the initial guess(es).  If
   ///   false, then apply() will use X on input as the initial
   ///   guess(es).
+  /// - "chebyshev: compute spectral radius" (\c bool): If true, the
+  ///   power method will compute the spectral radius of the operator.
+  ///   If false, it will compute the dominant eigenvalue.
   ///
   /// Parameters that govern backwards compatibility:
   /// - "chebyshev: textbook algorithm" (\c bool): If true, use the
@@ -508,6 +511,9 @@ private:
 
   //! Whether apply() will compute and return the max residual norm.
   bool computeMaxResNorm_;
+
+  //! Whether the power method will compute the spectral radius or the dominant eigenvalue.
+  bool computeSpectralRadius_;
 
   /// If true, the ChebyshevKernel operator will not to use a fused kernel
   /// and insead use native blas/SpMV operators

--- a/packages/ifpack2/src/Ifpack2_Details_Chebyshev_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Chebyshev_def.hpp
@@ -306,6 +306,7 @@ Chebyshev (Teuchos::RCP<const row_matrix_type> A) :
   assumeMatrixUnchanged_ (false),
   textbookAlgorithm_ (false),
   computeMaxResNorm_ (false),
+  computeSpectralRadius_(true),
   ckUseNativeSpMV_(false),
   debug_ (false)
 {

--- a/packages/ifpack2/src/Ifpack2_Details_Chebyshev_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Chebyshev_def.hpp
@@ -338,6 +338,7 @@ Chebyshev (Teuchos::RCP<const row_matrix_type> A,
   assumeMatrixUnchanged_ (false),
   textbookAlgorithm_ (false),
   computeMaxResNorm_ (false),
+  computeSpectralRadius_(true),
   ckUseNativeSpMV_(false),
   debug_ (false)
 {
@@ -384,6 +385,7 @@ setParameters (Teuchos::ParameterList& plist)
   const bool defaultAssumeMatrixUnchanged = false;
   const bool defaultTextbookAlgorithm = false;
   const bool defaultComputeMaxResNorm = false;
+  const bool defaultComputeSpectralRadius = true;
   const bool defaultCkUseNativeSpMV = false;
   const bool defaultDebug = false;
 
@@ -406,6 +408,7 @@ setParameters (Teuchos::ParameterList& plist)
   bool assumeMatrixUnchanged = defaultAssumeMatrixUnchanged;
   bool textbookAlgorithm = defaultTextbookAlgorithm;
   bool computeMaxResNorm = defaultComputeMaxResNorm;
+  bool computeSpectralRadius = defaultComputeSpectralRadius;
   bool ckUseNativeSpMV = defaultCkUseNativeSpMV;
   bool debug = defaultDebug;
 
@@ -640,6 +643,9 @@ setParameters (Teuchos::ParameterList& plist)
   if (plist.isParameter ("chebyshev: compute max residual norm")) {
     computeMaxResNorm = plist.get<bool> ("chebyshev: compute max residual norm");
   }
+  if (plist.isParameter ("chebyshev: compute spectral radius")) {
+    computeSpectralRadius = plist.get<bool> ("chebyshev: compute spectral radius");
+  }
 
   // Test for Ifpack parameters that we won't ever implement here.
   // Be careful to use the one-argument version of get(), since the
@@ -694,6 +700,7 @@ setParameters (Teuchos::ParameterList& plist)
   assumeMatrixUnchanged_ = assumeMatrixUnchanged;
   textbookAlgorithm_ = textbookAlgorithm;
   computeMaxResNorm_ = computeMaxResNorm;
+  computeSpectralRadius_ = computeSpectralRadius;
   ckUseNativeSpMV_ = ckUseNativeSpMV;
   debug_ = debug;
 
@@ -895,7 +902,8 @@ Chebyshev<ScalarType, MV>::compute ()
       
       Teuchos::RCP<Teuchos::FancyOStream> stream = (debug_ ? out_ : Teuchos::null);
       computedLambdaMax = PowerMethod::powerMethodWithInitGuess (*A_, *D_, eigMaxIters_, x, y, 
-                                                                 eigRelTolerance_, eigNormalizationFreq_, stream);
+                                                                 eigRelTolerance_, eigNormalizationFreq_, stream,
+                                                                 computeSpectralRadius_);
     }
     else
       computedLambdaMax = cgMethod (*A_, *D_, eigMaxIters_);

--- a/packages/ifpack2/src/Ifpack2_PowerMethod.hpp
+++ b/packages/ifpack2/src/Ifpack2_PowerMethod.hpp
@@ -169,13 +169,13 @@ powerMethodWithInitGuess(const OperatorType& A,
   if(y.is_null())
     y = Teuchos::rcp(new V(A.getRangeMap()));
 
-  // GH 04 Nov 2022: The previous implementation of the power method was incorrect.
-  // It computed x->norm2() inside the loop, but returned x^T*Ax. This returned horribly
-  // incorrect answers in certain cases, such as the Cheby_belos test, which has two 
-  // largest eigenvalues of 12.5839 and -10.6639. The power method iteration history 
-  // would appear to converge to something between 10 and 12, but the result would 
-  // return something between -10 and 12 instead. These have now been split into two
-  // routes which will behave consistently to themselves.
+  // GH 04 Nov 2022: The previous implementation of the power method was inconsistent with itself.
+  // It computed x->norm2() inside the loop, but returned x^T*Ax.
+  // This returned horribly incorrect estimates for Chebyshev spectral radius in certain 
+  // cases, such as the Cheby_belos test, which has two dominant eigenvalues of 12.5839, -10.6639.
+  // In such case, the power method iteration history would appear to converge to something
+  // between 10 and 12, but the resulting spectral radius estimate was sometimes negative.
+  // These have now been split into two routes which behave consistently with themselves.
   if(computeSpectralRadius) {
     // In this route, the update is as follows:
     // y=A*x, x = Dinv*y, lambda = norm(x), x = x/lambda

--- a/packages/ifpack2/src/Ifpack2_PowerMethod.hpp
+++ b/packages/ifpack2/src/Ifpack2_PowerMethod.hpp
@@ -113,8 +113,9 @@ private:
 /// \param tolerance [in] The relative eigenvalue tolerance. (default: 1e-7)
 /// \param eigNormalizationFreq [in] The frequency of normalization. (default: 1)
 /// \param out [in] The stream to send verbose output to. (default: null)
-/// \param computeSpectralRadius [in] Compute and return \f$\|D^{-1}Ax\|_2\f$ 
-/// if true, compute and return \f$x^TD^{-1}Ax\f$ if false. (default: true)
+/// \param computeSpectralRadius [in] Compute the absolute value of the dominant
+/// eigenvalue of \f$D^{-1}A\f$ if true. Compute the dominant eigenvalue of 
+/// \f$D^{-1}A\f$ if false. (default: true)
 ///
 /// \return Estimate of the maximum eigenvalue of A*D_inv.
 template<class OperatorType, class V>
@@ -342,8 +343,9 @@ computeInitialGuessForPowerMethod (V& x, const bool nonnegativeRealParts)
 /// \param tolerance [in] The relative eigenvalue tolerance. (default: 1e-7)
 /// \param eigNormalizationFreq [in] The frequency of normalization. (default: 1)
 /// \param out [in] The stream to send verbose output to. (default: null)
-/// \param computeSpectralRadius [in] Compute and return \f$\|D^{-1}Ax\|_2\f$ 
-/// if true, compute and return \f$x^TD^{-1}Ax\f$ if false. (default: true)
+/// \param computeSpectralRadius [in] Compute the absolute value of the dominant
+/// eigenvalue of \f$D^{-1}A\f$ if true. Compute the dominant eigenvalue of 
+/// \f$D^{-1}A\f$ if false. (default: true)
 ///
 /// \return Estimate of the maximum eigenvalue of A*D_inv.
 template<class OperatorType, class V>

--- a/packages/ifpack2/src/Ifpack2_PowerMethod.hpp
+++ b/packages/ifpack2/src/Ifpack2_PowerMethod.hpp
@@ -86,7 +86,7 @@ public:
     typedef Kokkos::Details::ArithTraits<IST> STS;
     typedef Kokkos::Details::ArithTraits<typename STS::mag_type> STM;
 
-    if (STS::real (x_(i)) < STM::zero ()) {
+    if(STS::real (x_(i)) < STM::zero ()) {
       x_(i) = -x_(i);
     }
   }
@@ -113,18 +113,21 @@ private:
 /// \param tolerance [in] The relative eigenvalue tolerance. (default: 1e-7)
 /// \param eigNormalizationFreq [in] The frequency of normalization. (default: 1)
 /// \param out [in] The stream to send verbose output to. (default: null)
+/// \param computeSpectralRadius [in] Compute and return \f$\|D^{-1}Ax\|_2\f$ 
+/// if true, compute and return \f$x^TD^{-1}Ax\f$ if false. (default: true)
 ///
 /// \return Estimate of the maximum eigenvalue of A*D_inv.
 template<class OperatorType, class V>
 typename V::scalar_type
-powerMethodWithInitGuess (const OperatorType& A,
-                          const V& D_inv,
-                          const int numIters,
-                          Teuchos::RCP<V> x,
-                          Teuchos::RCP<V> y,
-                          const typename Teuchos::ScalarTraits<typename V::scalar_type>::magnitudeType tolerance = 1e-7,
-                          const int eigNormalizationFreq = 1,
-                          Teuchos::RCP<Teuchos::FancyOStream> out = Teuchos::null)
+powerMethodWithInitGuess(const OperatorType& A,
+                         const V& D_inv,
+                         const int numIters,
+                         Teuchos::RCP<V> x,
+                         Teuchos::RCP<V> y,
+                         const typename Teuchos::ScalarTraits<typename V::scalar_type>::magnitudeType tolerance = 1e-7,
+                         const int eigNormalizationFreq = 1,
+                         Teuchos::RCP<Teuchos::FancyOStream> out = Teuchos::null,
+                         const bool computeSpectralRadius = true)
 {
   typedef typename V::scalar_type ST;
   typedef Teuchos::ScalarTraits<typename V::scalar_type> STS;
@@ -133,7 +136,7 @@ powerMethodWithInitGuess (const OperatorType& A,
   bool verbose = (out != Teuchos::null);
 
   using std::endl;
-  if (verbose) {
+  if(verbose) {
     *out << " powerMethodWithInitGuess:" << endl;
   }
 
@@ -143,7 +146,7 @@ powerMethodWithInitGuess (const OperatorType& A,
   ST lambdaMaxOld = one;
   ST norm;
 
-  norm = x->norm2 ();
+  norm = x->norm2();
   TEUCHOS_TEST_FOR_EXCEPTION
     (norm == zero, std::runtime_error,
      "Ifpack2::PowerMethod::powerMethodWithInitGuess: The initial guess "
@@ -152,70 +155,142 @@ powerMethodWithInitGuess (const OperatorType& A,
      "compute the initial guess), or because the norm2 method has a "
      "bug.  The first is not impossible, but unlikely.");
 
-  if (verbose) {
-    *out << "  Original norm1(x): " << x->norm1 ()
+  if(verbose) {
+    *out << "  Original norm1(x): " << x->norm1()
           << ", norm2(x): " << norm << endl;
   }
 
-  x->scale (one / norm);
+  x->scale(one / norm);
 
-  if (verbose) {
-    *out << "  norm1(x.scale(one/norm)): " << x->norm1 () << endl;
+  if(verbose) {
+    *out << "  norm1(x.scale(one/norm)): " << x->norm1() << endl;
   }
 
   if(y.is_null())
-    y = Teuchos::rcp(new V(A.getRangeMap ()));
+    y = Teuchos::rcp(new V(A.getRangeMap()));
 
-  for (int iter = 0; iter < numIters-1; ++iter) {
-    if (verbose) {
-      *out << "  Iteration " << iter << endl;
+  // GH 04 Nov 2022: The previous implementation of the power method was incorrect.
+  // It computed x->norm2() inside the loop, but returned x^T*Ax. This returned horribly
+  // incorrect answers in certain cases, such as the Cheby_belos test, which has two 
+  // largest eigenvalues of 12.5839 and -10.6639. The power method iteration history 
+  // would appear to converge to something between 10 and 12, but the result would 
+  // return something between -10 and 12 instead. These have now been split into two
+  // routes which will behave consistently to themselves.
+  if(computeSpectralRadius) {
+    // In this route, the update is as follows:
+    // y=A*x, x = Dinv*y, lambda = norm(x), x = x/lambda
+    if(verbose) {
+      *out << "  PowerMethod using spectral radius route" << endl;
     }
-    A.apply (*x, *y);
-    x->elementWiseMultiply (STS::one(), D_inv, *y, STS::zero());
-
-    if (((iter+1) % eigNormalizationFreq == 0) && (iter < numIters-2)) {
-      norm = x->norm2 ();
-      if (norm == zero) { // Return something reasonable.
-        if (verbose) {
-          *out << "   norm is zero; returning zero" << endl;
-          *out << "   Power method terminated after "<< iter << " iterations." << endl;
-        }
-        return zero;
-      } else {
-        lambdaMaxOld = lambdaMax;
-        lambdaMax = pow(norm, Teuchos::ScalarTraits<MT>::one() / eigNormalizationFreq);
-        if (Teuchos::ScalarTraits<ST>::magnitude(lambdaMax-lambdaMaxOld) < tolerance * Teuchos::ScalarTraits<ST>::magnitude(lambdaMax)) {
-          if (verbose) {
-            *out << "  lambdaMax: " << lambdaMax << endl;
-            *out << "  Power method terminated after "<< iter << " iterations." << endl;
-          }
-          return lambdaMax;
-        } else if (verbose) {
-          *out << "  lambdaMaxOld: " << lambdaMaxOld << endl;
-          *out << "  lambdaMax: " << lambdaMax << endl;
-          *out << "  |lambdaMax-lambdaMaxOld|/|lambdaMax|: " << Teuchos::ScalarTraits<ST>::magnitude(lambdaMax-lambdaMaxOld)/Teuchos::ScalarTraits<ST>::magnitude(lambdaMax) << endl;
-        }
+    for(int iter = 0; iter < numIters-1; ++iter) {
+      if(verbose) {
+        *out << "  Iteration " << iter << endl;
       }
-      x->scale (one / norm);
+      A.apply(*x, *y);
+      x->elementWiseMultiply(STS::one(), D_inv, *y, STS::zero());
+
+      if(((iter+1) % eigNormalizationFreq == 0) && (iter < numIters-2)) {
+        norm = x->norm2();
+        if(norm == zero) { // Return something reasonable.
+          if(verbose) {
+            *out << "   norm is zero; returning zero" << endl;
+            *out << "   Power method terminated after "<< iter << " iterations." << endl;
+          }
+          return zero;
+        } else {
+          lambdaMaxOld = lambdaMax;
+          lambdaMax = pow(norm, Teuchos::ScalarTraits<MT>::one() / eigNormalizationFreq);
+          if(Teuchos::ScalarTraits<ST>::magnitude(lambdaMax-lambdaMaxOld) < tolerance * Teuchos::ScalarTraits<ST>::magnitude(lambdaMax)) {
+            if(verbose) {
+              *out << "  lambdaMax: " << lambdaMax << endl;
+              *out << "  Power method terminated after "<< iter << " iterations." << endl;
+            }
+            return lambdaMax;
+          } else if(verbose) {
+            *out << "  lambdaMaxOld: " << lambdaMaxOld << endl;
+            *out << "  lambdaMax: " << lambdaMax << endl;
+            *out << "  |lambdaMax-lambdaMaxOld|/|lambdaMax|: " << Teuchos::ScalarTraits<ST>::magnitude(lambdaMax-lambdaMaxOld)/Teuchos::ScalarTraits<ST>::magnitude(lambdaMax) << endl;
+          }
+        }
+        x->scale(one / norm);
+      }
     }
-  }
-  if (verbose) {
-    *out << "  lambdaMax: " << lambdaMax << endl;
+    if(verbose) {
+      *out << "  lambdaMax: " << lambdaMax << endl;
+    }
+
+    norm = x->norm2();
+    if(norm == zero) { // Return something reasonable.
+      if(verbose) {
+        *out << "   norm is zero; returning zero" << endl;
+        *out << "   Power method terminated after "<< numIters << " iterations." << endl;
+      }
+      return zero;
+    }
+    x->scale(one / norm);
+    A.apply(*x, *y);
+    y->elementWiseMultiply(STS::one(), D_inv, *y, STS::zero());
+    lambdaMax = y->norm2();
+  } else {
+    // In this route, the update is as follows:
+    // y=A*x, y = Dinv*y, lambda = x->dot(y), x = y/lambda
+    if(verbose) {
+      *out << "  PowerMethod using largest eigenvalue route" << endl;
+    }
+    for (int iter = 0; iter < numIters-1; ++iter) {
+      if(verbose) {
+        *out << "  Iteration " << iter << endl;
+      }
+      A.apply(*x, *y);
+      y->elementWiseMultiply(STS::one(), D_inv, *y, STS::zero());
+
+      if(((iter+1) % eigNormalizationFreq == 0) && (iter < numIters-2)) {
+        norm = x->dot(*y);
+        if(norm == zero) { // Return something reasonable.
+          if(verbose) {
+            *out << "   norm is zero; returning zero" << endl;
+            *out << "   Power method terminated after "<< iter << " iterations." << endl;
+          }
+          return zero;
+        } else {
+          lambdaMaxOld = lambdaMax;
+          lambdaMax = pow(norm, Teuchos::ScalarTraits<MT>::one() / eigNormalizationFreq);
+          if(Teuchos::ScalarTraits<ST>::magnitude(lambdaMax-lambdaMaxOld) < tolerance * Teuchos::ScalarTraits<ST>::magnitude(lambdaMax)) {
+            if(verbose) {
+              *out << "  lambdaMax: " << lambdaMax << endl;
+              *out << "  Power method terminated after "<< iter << " iterations." << endl;
+            }
+            return lambdaMax;
+          } else if(verbose) {
+            *out << "  lambdaMaxOld: " << lambdaMaxOld << endl;
+            *out << "  lambdaMax: " << lambdaMax << endl;
+            *out << "  |lambdaMax-lambdaMaxOld|/|lambdaMax|: " << Teuchos::ScalarTraits<ST>::magnitude(lambdaMax-lambdaMaxOld)/Teuchos::ScalarTraits<ST>::magnitude(lambdaMax) << endl;
+          }
+        }
+        x->swap(*y);
+        norm = x->norm2();
+        x->scale(one / norm);
+      }
+    }
+    if(verbose) {
+      *out << "  lambdaMax: " << lambdaMax << endl;
+    }
+
+    norm = x->norm2();
+    if(norm == zero) { // Return something reasonable.
+      if(verbose) {
+        *out << "   norm is zero; returning zero" << endl;
+        *out << "   Power method terminated after "<< numIters << " iterations." << endl;
+      }
+      return zero;
+    }
+    x->scale(one / norm);
+    A.apply(*x, *y);
+    y->elementWiseMultiply(STS::one(), D_inv, *y, STS::zero());
+    lambdaMax = y->dot(*x);
   }
 
-  norm = x->norm2 ();
-  if (norm == zero) { // Return something reasonable.
-    if (verbose) {
-      *out << "   norm is zero; returning zero" << endl;
-      *out << "   Power method terminated after "<< numIters << " iterations." << endl;
-    }
-    return zero;
-  }
-  x->scale (one / norm);
-  A.apply (*x, *y);
-  y->elementWiseMultiply (STS::one(), D_inv, *y, STS::zero());
-  lambdaMax = y->dot (*x);
-  if (verbose) {
+  if(verbose) {
     *out << "  lambdaMax: " << lambdaMax << endl;
     *out << "  Power method terminated after "<< numIters << " iterations." << endl;
   }
@@ -244,7 +319,7 @@ computeInitialGuessForPowerMethod (V& x, const bool nonnegativeRealParts)
 
   x.randomize ();
 
-  if (nonnegativeRealParts) {
+  if(nonnegativeRealParts) {
     auto x_lcl = x.getLocalViewDevice (Tpetra::Access::ReadWrite);
     auto x_lcl_1d = Kokkos::subview (x_lcl, Kokkos::ALL (), 0);
 
@@ -267,24 +342,27 @@ computeInitialGuessForPowerMethod (V& x, const bool nonnegativeRealParts)
 /// \param tolerance [in] The relative eigenvalue tolerance. (default: 1e-7)
 /// \param eigNormalizationFreq [in] The frequency of normalization. (default: 1)
 /// \param out [in] The stream to send verbose output to. (default: null)
+/// \param computeSpectralRadius [in] Compute and return \f$\|D^{-1}Ax\|_2\f$ 
+/// if true, compute and return \f$x^TD^{-1}Ax\f$ if false. (default: true)
 ///
 /// \return Estimate of the maximum eigenvalue of A*D_inv.
 template<class OperatorType, class V>
 typename V::scalar_type
-powerMethod (const OperatorType& A,
-             const V& D_inv, 
-             const int numIters,
-             Teuchos::RCP<V> y,
-             const typename Teuchos::ScalarTraits<typename V::scalar_type>::magnitudeType tolerance = 1e-7,
-             const int eigNormalizationFreq = 1,
-             Teuchos::RCP<Teuchos::FancyOStream> out = Teuchos::null)
+powerMethod(const OperatorType& A,
+            const V& D_inv, 
+            const int numIters,
+            Teuchos::RCP<V> y,
+            const typename Teuchos::ScalarTraits<typename V::scalar_type>::magnitudeType tolerance = 1e-7,
+            const int eigNormalizationFreq = 1,
+            Teuchos::RCP<Teuchos::FancyOStream> out = Teuchos::null,
+            const bool computeSpectralRadius = true)
 {
   typedef typename V::scalar_type ST;
   typedef Teuchos::ScalarTraits<typename V::scalar_type> STS;
 
   bool verbose = (out != Teuchos::null);
 
-  if (verbose) {
+  if(verbose) {
     *out << "powerMethod:" << std::endl;
   }
 
@@ -296,7 +374,7 @@ powerMethod (const OperatorType& A,
   // entries nonnegative.
   computeInitialGuessForPowerMethod (*x, false);
 
-  ST lambdaMax = powerMethodWithInitGuess (A, D_inv, numIters, x, y, tolerance, eigNormalizationFreq, out);
+  ST lambdaMax = powerMethodWithInitGuess (A, D_inv, numIters, x, y, tolerance, eigNormalizationFreq, out, computeSpectralRadius);
 
   // mfh 07 Jan 2015: Taking the real part here is only a concession
   // to the compiler, so that this can build with ScalarType =
@@ -305,8 +383,8 @@ powerMethod (const OperatorType& A,
   // do would be what Belos does, which is provide a partial
   // specialization for ScalarType = std::complex<T> with a stub
   // implementation (that builds, but whose constructor throws).
-  if (STS::real (lambdaMax) < STS::real (zero)) {
-    if (verbose) {
+  if(STS::real (lambdaMax) < STS::real (zero)) {
+    if(verbose) {
       *out << "real(lambdaMax) = " << STS::real (lambdaMax) << " < 0; "
         "try again with a different random initial guess" << std::endl;
     }
@@ -318,7 +396,7 @@ powerMethod (const OperatorType& A,
     // For the second pass, make all the entries of the initial guess
     // vector have nonnegative real parts.
     computeInitialGuessForPowerMethod (*x, true);
-    lambdaMax = powerMethodWithInitGuess (A, D_inv, numIters, x, y, tolerance, eigNormalizationFreq, out);
+    lambdaMax = powerMethodWithInitGuess (A, D_inv, numIters, x, y, tolerance, eigNormalizationFreq, out, computeSpectralRadius);
   }
   return lambdaMax;
 }

--- a/packages/ifpack2/src/Ifpack2_PowerMethod.hpp
+++ b/packages/ifpack2/src/Ifpack2_PowerMethod.hpp
@@ -235,6 +235,7 @@ powerMethodWithInitGuess(const OperatorType& A,
   } else {
     // In this route, the update is as follows:
     // y=A*x, y = Dinv*y, lambda = x->dot(y), x = y/lambda
+    ST xDinvAx = norm;
     if(verbose) {
       *out << "  PowerMethod using largest eigenvalue route" << endl;
     }
@@ -246,16 +247,16 @@ powerMethodWithInitGuess(const OperatorType& A,
       y->elementWiseMultiply(STS::one(), D_inv, *y, STS::zero());
 
       if(((iter+1) % eigNormalizationFreq == 0) && (iter < numIters-2)) {
-        norm = x->dot(*y);
-        if(norm == zero) { // Return something reasonable.
+        xDinvAx = x->dot(*y);
+        if(xDinvAx == zero) { // Return something reasonable.
           if(verbose) {
-            *out << "   norm is zero; returning zero" << endl;
+            *out << "   xDinvAx is zero; returning zero" << endl;
             *out << "   Power method terminated after "<< iter << " iterations." << endl;
           }
           return zero;
         } else {
           lambdaMaxOld = lambdaMax;
-          lambdaMax = pow(norm, Teuchos::ScalarTraits<MT>::one() / eigNormalizationFreq);
+          lambdaMax = pow(xDinvAx, Teuchos::ScalarTraits<MT>::one() / eigNormalizationFreq);
           if(Teuchos::ScalarTraits<ST>::magnitude(lambdaMax-lambdaMaxOld) < tolerance * Teuchos::ScalarTraits<ST>::magnitude(lambdaMax)) {
             if(verbose) {
               *out << "  lambdaMax: " << lambdaMax << endl;

--- a/packages/ifpack2/test/belos/CMakeLists.txt
+++ b/packages/ifpack2/test/belos/CMakeLists.txt
@@ -49,6 +49,7 @@ TRIBITS_COPY_FILES_TO_BINARY_DIR(Ifpack2BelosCopyFiles
   test_MTGS_calore1_mm.xml
   test_RILUK_calore1_mm.xml 
   test_Cheby_calore1_mm.xml
+  test_Cheby_calore1_nospectralradius_mm.xml
   test_FILU_calore1_mm.xml
   test_FILU_calore1_mm_sptrsv.xml
   test_FIC_calore1_mm.xml
@@ -707,6 +708,17 @@ TRIBITS_ADD_TEST(
   tif_belos
   NAME Cheby_belos
   ARGS "--xml_file=test_Cheby_calore1_mm.xml"
+  COMM serial mpi
+  NUM_MPI_PROCS 1
+  STANDARD_PASS_OUTPUT
+)
+
+# GH 04 Nov 2022: Test the non-spectral
+# radius route of the power method for robustness
+TRIBITS_ADD_TEST(
+  tif_belos
+  NAME Cheby_belos_nospectralradius
+  ARGS "--xml_file=test_Cheby_calore1_nospectralradius_mm.xml"
   COMM serial mpi
   NUM_MPI_PROCS 1
   STANDARD_PASS_OUTPUT

--- a/packages/ifpack2/test/belos/test_Cheby_calore1_nospectralradius_mm.xml
+++ b/packages/ifpack2/test/belos/test_Cheby_calore1_nospectralradius_mm.xml
@@ -10,7 +10,8 @@
   <Parameter name="Ifpack2::Preconditioner" type="string" value="CHEBYSHEV"/>
   <ParameterList name="Ifpack2">
     <Parameter name="chebyshev: degree" type="int" value="3"/>
-    <Parameter name="chebyshev: eigenvalue max iterations" type="int" value="10"/>
+    <Parameter name="chebyshev: compute spectral radius" type="bool" value="false"/>
+    <Parameter name="chebyshev: eigenvalue max iterations" type="int" value="30"/>
   </ParameterList>
 
   <Parameter name="expectNumIters" type="int" value="32"/>


### PR DESCRIPTION
@trilinos/ifpack2 

I was able to reproduce the Ifpack2 Cheby test failure reported in #11204 on my machine, and thanks to help from @cgcgcg after banging our heads together for a bit, we realized this is a strange combination of several things.
1. $D^{-1}A$ for this problem ( $A$ is in `calore1.mtx`) has two dominant eigenvalues, 12.5839 and -10.6639.
2. The power method uses a random initial guess with a default of 10 iterations.
3. The loop computing `lambdaMax` is computed using $\\|D^{-1}Ax\\|_2$, but the final computation after the loop instead uses $x^T D^{-1}A x$.

There are all sorts of strange things that can happen. For this particular example, the eigenvalue history when using `<Parameter name="debug" type="bool" value="true"/>` will look like it's converging to something in the range of 10-12 because it uses `norm2()` inside the power method iteration. However, the final estimate after breaking out of the loop is computed using $x^T A x$, which means if the vector still has a large component pointing in the direction of the negative eigenvalue, the final estimate in the history will suddenly be way off (anywhere between -10.6639 and 12.5839 basically).

This splits the power method into two routes: spectral radius (computing $\\|D^{-1}Ax\\|$) and dominant eigenvalue (computing $x^TD^{-1}Ax$), and adds it as an option to Chebyshev to test code coverage. Realistically, one shouldn't use `computeSpectralRadius=false` unless debugging a nasty matrix like the one that caused us so much trouble :)