### PR TITLE
Panzer: fix issue with uvm=off in Dirichlet_Residual_EdgeBasis

### DIFF
--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Dirichlet_Residual_EdgeBasis_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Dirichlet_Residual_EdgeBasis_impl.hpp
@@ -165,6 +165,7 @@ evaluateFields(
     auto value_h = Kokkos::create_mirror_view(value.get_static_view());
     Kokkos::deep_copy(dof_h, dof.get_static_view());
     Kokkos::deep_copy(value_h, value.get_static_view());
+    auto worksetJacobians_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),worksetJacobians);
     switch (subcellDim) {
     case 1: {  // 2D element Tri and Quad
       if (intrepid_basis->getDofCount(1, subcellOrd)) {
@@ -186,7 +187,7 @@ evaluateFields(
 
           for (int i=0;i<ndofsEdge;++i) {
             const int b = intrepid_basis->getDofOrdinal(1, subcellOrd, i);
-            auto J = Kokkos::create_mirror_view(Kokkos::subview(worksetJacobians, c, b, Kokkos::ALL(), Kokkos::ALL()));
+            auto J = Kokkos::subview(worksetJacobians_h, c, b, Kokkos::ALL(), Kokkos::ALL());
             Intrepid2::Kernels::Serial::matvec_product(phyEdgeTan, J, ortEdgeTan);            
             
             for(int d=0;d<cellDim;d++) {
@@ -223,7 +224,7 @@ evaluateFields(
                 edgeOrts[edgeOrd]);
 
             {
-              auto J = Kokkos::create_mirror_view(Kokkos::subview(worksetJacobians, c, b, Kokkos::ALL(), Kokkos::ALL()));
+              auto J = Kokkos::subview(worksetJacobians_h, c, b, Kokkos::ALL(), Kokkos::ALL());
               Intrepid2::Kernels::Serial::matvec_product(phyEdgeTan, J, ortEdgeTan);
               
               for(int d=0;d<dof.extent_int(2);d++) {
@@ -251,7 +252,7 @@ evaluateFields(
               faceOrts[subcellOrd]);
 
           for(int b=0;b<dof.extent_int(1);b++) {
-            auto J = Kokkos::create_mirror_view(Kokkos::subview(worksetJacobians, c, b, Kokkos::ALL(), Kokkos::ALL()));
+            auto J = Kokkos::subview(worksetJacobians, c, b, Kokkos::ALL(), Kokkos::ALL());
             Intrepid2::Kernels::Serial::matvec_product(phyFaceTanU, J, ortFaceTanU);
             Intrepid2::Kernels::Serial::matvec_product(phyFaceTanV, J, ortFaceTanV);
             


### PR DESCRIPTION
@trilinos/panzer 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
In UVM=off builds, the Dirichlet_Residual_EdgeBasis evaluator was broken. The mirror view needed a deep_copy of the values from device.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
Fixes EMPIRE solver_interface unit tests

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->