### PR TITLE
MueLu: Remove trailing whitespace

### DIFF
--- a/packages/muelu/adapters/amgx/MueLu_AMGXOperator_decl.hpp
+++ b/packages/muelu/adapters/amgx/MueLu_AMGXOperator_decl.hpp
@@ -449,7 +449,7 @@ namespace MueLu {
 
       vectorTimer1_ = Teuchos::TimeMonitor::getNewTimer("MueLu: AMGX: transfer vectors CPU->GPU");
       vectorTimer2_ = Teuchos::TimeMonitor::getNewTimer("MueLu: AMGX: transfer vector  GPU->CPU");
-      solverTimer_  = Teuchos::TimeMonitor::getNewTimer("MueLu: AMGX: Solve (total)"); 
+      solverTimer_  = Teuchos::TimeMonitor::getNewTimer("MueLu: AMGX: Solve (total)");
     }
 
     //! Destructor.

--- a/packages/muelu/adapters/amgx/MueLu_AMGXOperator_def.hpp
+++ b/packages/muelu/adapters/amgx/MueLu_AMGXOperator_def.hpp
@@ -106,7 +106,7 @@ namespace MueLu {
           vectorTimer1_->incrementNumCalls();
         }
        
-        // Solve the system and time. 
+        // Solve the system and time.
         solverTimer_->start();
         AMGX_solver_solve(Solver_, X_, Y_);
         solverTimer_->stop();

--- a/packages/muelu/adapters/amgx/MueLu_AMGX_Setup.cpp
+++ b/packages/muelu/adapters/amgx/MueLu_AMGX_Setup.cpp
@@ -54,7 +54,7 @@ namespace MueLu {
   }
 
   void MueLu_AMGX_initialize_plugins()
-  {    
+  {
     AMGX_SAFE_CALL(AMGX_initialize_plugins());
   }
 
@@ -64,7 +64,7 @@ namespace MueLu {
   }
 
   void MueLu_AMGX_finalize_plugins()
-  {    
+  {
    AMGX_print_summary();
    AMGX_SAFE_CALL(AMGX_finalize_plugins());
   }

--- a/packages/muelu/adapters/linear_solver_factory/MueLu_Details_LinearSolverFactory_def.hpp
+++ b/packages/muelu/adapters/linear_solver_factory/MueLu_Details_LinearSolverFactory_def.hpp
@@ -270,11 +270,11 @@ private:
 
 #ifdef HAVE_MUELU_TPETRA
 template<class Scalar, class LO, class GO, class Node>
-class LinearSolver<Tpetra::MultiVector<Scalar,LO,GO,Node>, 
+class LinearSolver<Tpetra::MultiVector<Scalar,LO,GO,Node>,
                    Tpetra::Operator<Scalar,LO,GO,Node>,
                    typename Teuchos::ScalarTraits<Scalar>::magnitudeType> :
-    public Trilinos::Details::LinearSolver<Tpetra::MultiVector<Scalar,LO,GO,Node>, 
-                                           Tpetra::Operator<Scalar,LO,GO,Node>, 
+    public Trilinos::Details::LinearSolver<Tpetra::MultiVector<Scalar,LO,GO,Node>,
+                                           Tpetra::Operator<Scalar,LO,GO,Node>,
                                            typename Teuchos::ScalarTraits<Scalar>::magnitudeType>,
     virtual public Teuchos::Describable
 {

--- a/packages/muelu/doc/Tutorial/src/ScalingTestParamList.cpp
+++ b/packages/muelu/doc/Tutorial/src/ScalingTestParamList.cpp
@@ -446,7 +446,7 @@ int main(int argc, char *argv[]) {
         belosList.set("Verbosity",             Belos::Errors + Belos::Warnings + Belos::StatusTestDetails);
         belosList.set("Output Frequency",      1);
         belosList.set("Output Style",          Belos::Brief);
-        if (!scaleResidualHistory) 
+        if (!scaleResidualHistory)
           belosList.set("Implicit Residual Scaling", "None");
 
         // Create an iterative solver manager

--- a/packages/muelu/doc/Tutorial/src/xml/s1_easy_jacobi.xml
+++ b/packages/muelu/doc/Tutorial/src/xml/s1_easy_jacobi.xml
@@ -21,6 +21,6 @@
     <Parameter name="relaxation: type"  type="string" value="Jacobi"/>
     <Parameter name="relaxation: sweeps" type="int" value="1"/>
     <Parameter name="relaxation: damping factor" type="double" value="0.9"/>
-  </ParameterList>  
+  </ParameterList>
   
 </ParameterList>

--- a/packages/muelu/doc/Tutorial/src/xml/s2_adv_b.xml
+++ b/packages/muelu/doc/Tutorial/src/xml/s2_adv_b.xml
@@ -36,7 +36,7 @@
       <Parameter name="PreSmoother"           type="string" value="NoSmoother"/>
       <Parameter name="PostSmoother"          type="string" value="BackwardGaussSeidel"/>
       <Parameter name="CoarseSolver"          type="string"  value="DirectSolver"/>
-    </ParameterList>    
+    </ParameterList>
 
   </ParameterList>
 </ParameterList>

--- a/packages/muelu/doc/Tutorial/src/xml/s2_adv_c.xml
+++ b/packages/muelu/doc/Tutorial/src/xml/s2_adv_c.xml
@@ -12,7 +12,7 @@
         <Parameter name="relaxation: sweeps"                type="int"    value="5"/>
         <Parameter name="relaxation: damping factor"        type="double" value="0.6"/>
       </ParameterList>
-    </ParameterList>  
+    </ParameterList>
     
     <ParameterList name="ForwardGaussSeidel">
       <Parameter name="factory"                        type="string" value="TrilinosSmoother"/>

--- a/packages/muelu/doc/Tutorial/src/xml/s4c.xml
+++ b/packages/muelu/doc/Tutorial/src/xml/s4c.xml
@@ -17,7 +17,7 @@
       <Parameter name="aggregation: max selected neighbors" type="int"    value="0"/>
       <Parameter name="aggregation: min agg size"           type="int"    value="4"/>
       <Parameter name="Graph"                               type="string" value="myCoalesceDropFact"/>
-      <Parameter name="DofsPerNode"                         type="string" value="myCoalesceDropFact"/>      
+      <Parameter name="DofsPerNode"                         type="string" value="myCoalesceDropFact"/>
     </ParameterList>
 
     <ParameterList name="myTentativePFact">

--- a/packages/muelu/doc/Tutorial/src/xml/s5a.xml
+++ b/packages/muelu/doc/Tutorial/src/xml/s5a.xml
@@ -41,7 +41,7 @@
       <Parameter name="A"                              type="string" value="myRAPFact"/>
       <Parameter name="repartition: min rows per proc"      type="int"    value="2000"/>
       <Parameter name="repartition: max imbalance"          type="double" value="1.1"/>
-      <Parameter name="repartition: start level"            type="int"    value="1"/>    
+      <Parameter name="repartition: start level"            type="int"    value="1"/>
     </ParameterList>
     
     <ParameterList name="myIsorropiaInterface">

--- a/packages/muelu/doc/Tutorial/src/xml/s5b.xml
+++ b/packages/muelu/doc/Tutorial/src/xml/s5b.xml
@@ -40,7 +40,7 @@
       <Parameter name="factory"                             type="string" value="SaPFactory"/>
       <Parameter name="P"                                   type="string" value="PA-AMG"/>
       <Parameter name="Damping factor"                      type="double" value="1.33"/>
-    </ParameterList>    
+    </ParameterList>
     
     <ParameterList name="myRestrictorFact">
       <Parameter name="factory"                             type="string" value="TransPFactory"/>
@@ -89,7 +89,7 @@
       <Parameter name="Partition"                           type="string" value="myRepartitionInterface"/>
       <Parameter name="minRowsPerProcessor"                 type="int"    value="800"/>
       <Parameter name="nonzeroImbalance"                    type="double" value="1.1"/>
-      <Parameter name="startLevel"                          type="int"    value="1"/>  
+      <Parameter name="startLevel"                          type="int"    value="1"/>
       <Parameter name="remapPartitions"                     type="bool"   value="false"/>
     </ParameterList>
 
@@ -175,7 +175,7 @@
       <Parameter name="P"                                   type="string"   value="PA-AMG"/>
       <Parameter name="R"                                   type="string"   value="myRestrictorFact"/>
       <Parameter name="A"                                   type="string"   value="myRAPFact"/>
-      <Parameter name="CoarseSolver"                        type="string"   value="DirectSolver"/>      
+      <Parameter name="CoarseSolver"                        type="string"   value="DirectSolver"/>
       <Parameter name="Importer"                            type="string"   value="myRepartitionFact"/>
       <Parameter name="Graph"                               type="string"   value="myCoalesceDropFact"/>
     </ParameterList>

--- a/packages/muelu/example/basic/Simple.cpp
+++ b/packages/muelu/example/basic/Simple.cpp
@@ -125,7 +125,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
   std::string coordFile;                              clp.setOption("coords",                &coordFile,         "coordinates data file");
   std::string coordMapFile;                           clp.setOption("coordsmap",             &coordMapFile,      "coordinates map data file");
   std::string nullFile;                               clp.setOption("nullspace",             &nullFile,          "nullspace data file");
-  std::string materialFile;                           clp.setOption("material",              &materialFile,      "material data file");    
+  std::string materialFile;                           clp.setOption("material",              &materialFile,      "material data file");
   int         maxIts            = 200;                clp.setOption("its",                   &maxIts,            "maximum number of solver iterations");
   int         numVectors        = 1;                  clp.setOption("multivector",           &numVectors,        "number of rhs to solve simultaneously");
   bool        scaleResidualHist = true;               clp.setOption("scale", "noscale",      &scaleResidualHist, "scaled Krylov residual history");

--- a/packages/muelu/example/basic/Teko.cpp
+++ b/packages/muelu/example/basic/Teko.cpp
@@ -98,7 +98,7 @@ void GenerateDefault_2x2_Splitting(const RCP<Tpetra::CrsMatrix<SC,LO,GO,NO> >& c
                                    Teko::LinearOp & A,
                                    Teko::MultiVector & x,
                                    Teko::MultiVector & b)
-{  
+{
    typedef Tpetra::Vector<SC,LO,GO,NO>        TP_Vec;
    typedef Tpetra::CrsMatrix<SC,LO,GO,NO>     TP_Crs;
    typedef Tpetra::Operator<SC,LO,GO,NO>      TP_Op;
@@ -146,7 +146,7 @@ int extract_int(std::istringstream & iss) {
   iss >> s;
   if(s != "") {
     return stoi(s); }
-  else 
+  else
     return -1;
 }
 
@@ -167,7 +167,7 @@ std::vector<std::vector<GO> > read_block_gids(std::string partitionFile, RCP<con
   std::vector<std::vector<GO> > block_gids(num_blocks);
   auto vv = pfile->get1dView();
   for(LO i=0; i<(LO)vv.size(); i++){
-    LO block_id = vv[i];    
+    LO block_id = vv[i];
     block_gids[block_id].push_back(rowMap->getGlobalElement(i));
   }
 
@@ -201,7 +201,7 @@ template<class SC,class LO, class GO, class NO>
   int solve_thyra(RCP<Tpetra::CrsMatrix<SC,LO,GO,NO> > & crsMat, const std::string &xmlFile) {
   typedef Tpetra::CrsMatrix<SC>       TP_Crs;
   typedef Thyra::PreconditionerFactoryBase<SC>        Base;
-  typedef Thyra::Ifpack2PreconditionerFactory<TP_Crs> Impl; 
+  typedef Thyra::Ifpack2PreconditionerFactory<TP_Crs> Impl;
 
   typedef Thyra::MultiVectorBase<SC>  MV;
   typedef Thyra::LinearOpBase<SC>     OP;
@@ -296,7 +296,7 @@ template<class SC,class LO, class GO, class NO>
   // tell Stratimikos => Teko about MueLu
   RCP<Stratimikos::DefaultLinearSolverBuilder> linearSolverBuilder = Teuchos::rcp(new Stratimikos::DefaultLinearSolverBuilder);
   linearSolverBuilder->setPreconditioningStrategyFactory(Teuchos::abstractFactoryStd<Base, Impl>(), "Ifpack2");
-  Stratimikos::enableMueLu<SC,LO,GO,NO>(*linearSolverBuilder);  
+  Stratimikos::enableMueLu<SC,LO,GO,NO>(*linearSolverBuilder);
  
   /////////////////////////////////////////////////////////
   // Build the Thyra operators
@@ -444,8 +444,8 @@ int main(int argc,char * argv[])
 
      if(coordsFile!= "") {
        RCP<const TP_Map> coordsMap = rowMap;
-       if(coordsMapFile != "") 
-         coordsMap = Tpetra::MatrixMarket::Reader<TP_Crs>::readMapFile(coordsMapFile,rowMap->getComm()); 
+       if(coordsMapFile != "")
+         coordsMap = Tpetra::MatrixMarket::Reader<TP_Crs>::readMapFile(coordsMapFile,rowMap->getComm());
        coords = Tpetra::MatrixMarket::Reader<TP_Crs>::readDenseFile(coordsFile,coordsMap->getComm(),coordsMap);
      }
    }
@@ -465,9 +465,9 @@ int main(int argc,char * argv[])
    Teko::MultiVector x,b;
 
    int rv;
-   if(partitionFile == "") 
+   if(partitionFile == "")
      rv = solve_thyra(crsMat,xmlFile);
-   else 
+   else
      rv = solve_tpetra<SC,LO,GO,NO>(crsMat,rhs,coords,xmlFile,partitionFile);
    
    return rv;

--- a/packages/muelu/example/basic/stratimikos_ParameterList.xml
+++ b/packages/muelu/example/basic/stratimikos_ParameterList.xml
@@ -145,54 +145,54 @@
 
       <!-- Use the following block instead for symmetric Gauss-Seidel smoothing -->
       <!--
-       <Parameter        name="smoother: type"                       type="string"   value="RELAXATION"/> 
-       <ParameterList    name="smoother: params"> 
-         <Parameter      name="relaxation: type"                     type="string"   value="Symmetric Gauss-Seidel"/> 
-         <Parameter      name="relaxation: sweeps"                   type="int"      value="1"/> 
-       </ParameterList> 
+       <Parameter        name="smoother: type"                       type="string"   value="RELAXATION"/>
+       <ParameterList    name="smoother: params">
+         <Parameter      name="relaxation: type"                     type="string"   value="Symmetric Gauss-Seidel"/>
+         <Parameter      name="relaxation: sweeps"                   type="int"      value="1"/>
+       </ParameterList>
       -->
 
       <!-- Use the following block instead for Gauss-Seidel smoothing -->
       <!--
-       <Parameter        name="smoother: pre type"                   type="string"   value="RELAXATION"/> 
-       <ParameterList    name="smoother: pre params"> 
-         <Parameter      name="relaxation: type"                     type="string"   value="Gauss-Seidel"/> 
-         <Parameter      name="relaxation: sweeps"                   type="int"      value="1"/> 
-         <Parameter      name="relaxation: damping factor"           type="double"   value="1.0"/> 
-         <Parameter      name="relaxation: backward mode"            type="bool"     value="false"/> 
-       </ParameterList> 
-       <Parameter        name="smoother: post type"                  type="string"   value="RELAXATION"/> 
-       <ParameterList    name="smoother: post params"> 
-         <Parameter      name="relaxation: type"                     type="string"   value="Gauss-Seidel"/> 
-         <Parameter      name="relaxation: sweeps"                   type="int"      value="1"/> 
-         <Parameter      name="relaxation: damping factor"           type="double"   value="1.0"/> 
-         <Parameter      name="relaxation: backward mode"            type="bool"     value="true"/> 
-       </ParameterList> 
+       <Parameter        name="smoother: pre type"                   type="string"   value="RELAXATION"/>
+       <ParameterList    name="smoother: pre params">
+         <Parameter      name="relaxation: type"                     type="string"   value="Gauss-Seidel"/>
+         <Parameter      name="relaxation: sweeps"                   type="int"      value="1"/>
+         <Parameter      name="relaxation: damping factor"           type="double"   value="1.0"/>
+         <Parameter      name="relaxation: backward mode"            type="bool"     value="false"/>
+       </ParameterList>
+       <Parameter        name="smoother: post type"                  type="string"   value="RELAXATION"/>
+       <ParameterList    name="smoother: post params">
+         <Parameter      name="relaxation: type"                     type="string"   value="Gauss-Seidel"/>
+         <Parameter      name="relaxation: sweeps"                   type="int"      value="1"/>
+         <Parameter      name="relaxation: damping factor"           type="double"   value="1.0"/>
+         <Parameter      name="relaxation: backward mode"            type="bool"     value="true"/>
+       </ParameterList>
       -->
 
       <!-- Use the following block instead for Chebyshev smoothing -->
       <!--
-       <Parameter        name="smoother: type"                       type="string"   value="CHEBYSHEV"/> 
-       <ParameterList    name="smoother: params"> 
-         <Parameter      name="chebyshev: degree"                    type="int"      value="2"/> 
-         <Parameter      name="chebyshev: ratio eigenvalue"          type="double"   value="7"/> 
-         <Parameter      name="chebyshev: min eigenvalue"            type="double"   value="1.0"/> 
-         <Parameter      name="chebyshev: zero starting solution"    type="bool"     value="true"/> 
-       </ParameterList> 
+       <Parameter        name="smoother: type"                       type="string"   value="CHEBYSHEV"/>
+       <ParameterList    name="smoother: params">
+         <Parameter      name="chebyshev: degree"                    type="int"      value="2"/>
+         <Parameter      name="chebyshev: ratio eigenvalue"          type="double"   value="7"/>
+         <Parameter      name="chebyshev: min eigenvalue"            type="double"   value="1.0"/>
+         <Parameter      name="chebyshev: zero starting solution"    type="bool"     value="true"/>
+       </ParameterList>
       -->
 
       <!-- ===========  REPARTITIONING  =========== -->
       <!--
-       <Parameter        name="repartition: enable"                  type="bool"     value="true"/> 
-       <Parameter        name="repartition: partitioner"             type="string"   value="zoltan2"/> 
-       <Parameter        name="repartition: start level"             type="int"      value="2"/> 
-       <Parameter        name="repartition: min rows per proc"       type="int"      value="800"/> 
-       <Parameter        name="repartition: max imbalance"           type="double"   value="1.1"/> 
-       <Parameter        name="repartition: remap parts"             type="bool"     value="false"/> 
-       <Parameter        name="repartition: rebalance P and R"       type="bool"     value="false"/> 
-       <ParameterList name="repartition: params"> 
-         <Parameter name="algorithm" type="string" value="multijagged"/> 
-       </ParameterList> 
+       <Parameter        name="repartition: enable"                  type="bool"     value="true"/>
+       <Parameter        name="repartition: partitioner"             type="string"   value="zoltan2"/>
+       <Parameter        name="repartition: start level"             type="int"      value="2"/>
+       <Parameter        name="repartition: min rows per proc"       type="int"      value="800"/>
+       <Parameter        name="repartition: max imbalance"           type="double"   value="1.1"/>
+       <Parameter        name="repartition: remap parts"             type="bool"     value="false"/>
+       <Parameter        name="repartition: rebalance P and R"       type="bool"     value="false"/>
+       <ParameterList name="repartition: params">
+         <Parameter name="algorithm" type="string" value="multijagged"/>
+       </ParameterList>
       -->
 
       <!-- for runs on with OpenMP or Cuda backend, enable -->

--- a/packages/muelu/matlab/src/MueLu_MatlabSmoother_decl.hpp
+++ b/packages/muelu/matlab/src/MueLu_MatlabSmoother_decl.hpp
@@ -60,7 +60,7 @@ namespace MueLu {
 
   /*!
     @class MatlabSmoother
-    @ingroup MueMexClasses 
+    @ingroup MueMexClasses
     @brief Class that encapsulates Matlab smoothers.
 
     //   This class creates an Matlab preconditioner factory. The factory creates a smoother based on the
@@ -178,7 +178,7 @@ namespace MueLu {
     //! Matlab solve function
     std::string solveFunction_;
 
-    //! Matrix, (maybe) used in apply 
+    //! Matrix, (maybe) used in apply
     mutable RCP<Matrix> A_;
     
   }; // class MatlabSmoother
@@ -190,12 +190,12 @@ namespace MueLu {
     const ParameterList& paramList = this->GetParameterList();
 
     RCP<MatlabSmoother<Scalar, LocalOrdinal, GlobalOrdinal, Node2> > cloneSmoother =
-      rcp(new MatlabSmoother<Scalar, LocalOrdinal, GlobalOrdinal, Node2>(paramList));   
+      rcp(new MatlabSmoother<Scalar, LocalOrdinal, GlobalOrdinal, Node2>(paramList));
 
     cloneSmoother->needsSetup_    = needsSetup_;
     cloneSmoother->setupFunction_ = setupFunction_;
     cloneSmoother->solveFunction_  = solveFunction_;
-    cloneSmoother->A_             = A_;    
+    cloneSmoother->A_             = A_;
     
     for(size_t i=0; i< solveData_.size(); i++)
       cloneSmoother->solveData_->push_back(solveData_[i]);

--- a/packages/muelu/matlab/src/MueLu_SingleLevelMatlabFactory_decl.hpp
+++ b/packages/muelu/matlab/src/MueLu_SingleLevelMatlabFactory_decl.hpp
@@ -69,7 +69,7 @@
 namespace MueLu {
   /*!
     @class SingleLevelMatlabFactory
-    @ingroup MueMexClasses 
+    @ingroup MueMexClasses
     @brief Factory for interacting with Matlab
   */
   template <class Scalar = double, class LocalOrdinal = int, class GlobalOrdinal = LocalOrdinal, class Node = KokkosClassic::DefaultNode::DefaultNodeType>

--- a/packages/muelu/matlab/src/MueLu_SingleLevelMatlabFactory_def.hpp
+++ b/packages/muelu/matlab/src/MueLu_SingleLevelMatlabFactory_def.hpp
@@ -107,7 +107,7 @@ namespace MueLu {
     if(!matlabFunction.length())
       throw std::runtime_error("Invalid matlab function name");
     vector<Teuchos::RCP<MuemexArg> > mexOutput = callMatlab(matlabFunction, numProvides, InputArgs);
-    // Set output in level 
+    // Set output in level
     processProvides<Scalar, LocalOrdinal, GlobalOrdinal, Node>(mexOutput, this, providesList, currentLevel);
   }
   

--- a/packages/muelu/matlab/src/MueLu_TwoLevelMatlabFactory_decl.hpp
+++ b/packages/muelu/matlab/src/MueLu_TwoLevelMatlabFactory_decl.hpp
@@ -70,7 +70,7 @@
 namespace MueLu {
   /*!
     @class TwoLevelMatlabFactory
-    @ingroup MueMexClasses 
+    @ingroup MueMexClasses
     @brief Factory for interacting with Matlab
   */
   template <class Scalar = double, class LocalOrdinal = int, class GlobalOrdinal = LocalOrdinal, class Node = KokkosClassic::DefaultNode::DefaultNodeType>
@@ -114,7 +114,7 @@ namespace MueLu {
 
     //@{
 
-    //! List of arguments to the MATLAB function, in order.  These args must correspond to MueLu "Needs" objects for the fine level.  These must be listed before coarse needs.   
+    //! List of arguments to the MATLAB function, in order.  These args must correspond to MueLu "Needs" objects for the fine level.  These must be listed before coarse needs.
     mutable std::vector<std::string> needsFine_;
 
     //! List of arguments to the MATLAB function, in order.  These args must correspond to MueLu "Needs" objects for the coarse level.  These must be listed after fine needs.

--- a/packages/muelu/matlab/src/MueLu_TwoLevelMatlabFactory_def.hpp
+++ b/packages/muelu/matlab/src/MueLu_TwoLevelMatlabFactory_def.hpp
@@ -72,7 +72,7 @@ namespace MueLu {
     validParamList->set<std::string>("Provides"     , "" ,"A comma-separated list of objects provided on the coarse level by the TwoLevelMatlabFactory");
     validParamList->set<std::string>("Needs Fine"   , "", "A comma-separated list of objects needed on the fine level by the TwoLevelMatlabFactory");
     validParamList->set<std::string>("Needs Coarse" , "", "A comma-separated list of objects needed on the coarse level by the TwoLevelMatlabFactory");
-    validParamList->set<std::string>("Function"     , "" , "The name of the Matlab MEX function to call for Build()");    
+    validParamList->set<std::string>("Function"     , "" , "The name of the Matlab MEX function to call for Build()");
     return validParamList;
   }
 

--- a/packages/muelu/matlab/tests/CustomP/matlabParams.xml
+++ b/packages/muelu/matlab/tests/CustomP/matlabParams.xml
@@ -6,7 +6,7 @@
       <Parameter name="factory" type="string" value="UncoupledAggregationFactory"/>
     </ParameterList>
     <ParameterList name="myMatlabPtentFactory">
-      <Parameter name="factory" type="string" value="TwoLevelMatlabFactory"/> 
+      <Parameter name="factory" type="string" value="TwoLevelMatlabFactory"/>
       <Parameter name="Provides" type="string" value="P, Nullspace, OrdinalVector KeepNodes"/>
       <Parameter name="Needs Fine" type="string" value="A, OrdinalVector KeepNodes"/>
       <Parameter name="Needs Coarse" type="string" value=""/>

--- a/packages/muelu/matlab/tests/ReentrantDemo/matlabParams.xml
+++ b/packages/muelu/matlab/tests/ReentrantDemo/matlabParams.xml
@@ -3,7 +3,7 @@
 <ParameterList name="MueLu">
   <ParameterList name="Factories">
     <ParameterList name="reentrantPFactory">
-      <Parameter name="factory" type="string" value="TwoLevelMatlabFactory"/> 
+      <Parameter name="factory" type="string" value="TwoLevelMatlabFactory"/>
       <Parameter name="Provides" type="string" value="P"/>
       <Parameter name="Needs Fine" type="string" value="A"/>
       <Parameter name="Needs Coarse" type="string" value=""/>

--- a/packages/muelu/matlab/tests/UnsmoothedP/matlabParams.xml
+++ b/packages/muelu/matlab/tests/UnsmoothedP/matlabParams.xml
@@ -6,7 +6,7 @@
       <Parameter name="factory" type="string" value="UncoupledAggregationFactory"/>
     </ParameterList>
     <ParameterList name="myMatlabPtentFactory">
-      <Parameter name="factory" type="string" value="TwoLevelMatlabFactory"/> 
+      <Parameter name="factory" type="string" value="TwoLevelMatlabFactory"/>
       <Parameter name="Provides" type="string" value="P, Nullspace"/>
       <Parameter name="Needs Fine" type="string" value="Aggregates"/>
       <Parameter name="Needs Coarse" type="string" value=""/>

--- a/packages/muelu/research/max/AdditiveMG/BAP.hpp
+++ b/packages/muelu/research/max/AdditiveMG/BAP.hpp
@@ -75,7 +75,7 @@ void BAP2D(Teuchos::RCP<tpetra_matrix_type> BAP, Teuchos::RCP<tpetra_matrix_type
                 int neighbour = -1;
 	        Teuchos::ArrayRCP<const double> localBAP = BAP_shrunk->getData(color);
 
-                //The following if statements control the neighbours of a subdomain in a 2D brick partitioned mesh 
+                //The following if statements control the neighbours of a subdomain in a 2D brick partitioned mesh
 		if( coloring2D( brick_id, ndx )==color && (shifted_id)>= 0 && (shifted_id)<tpetra_prolong->getGlobalNumCols() )
 		  neighbour = (shifted_id);
 
@@ -104,7 +104,7 @@ void BAP2D(Teuchos::RCP<tpetra_matrix_type> BAP, Teuchos::RCP<tpetra_matrix_type
 			neighbour = (shifted_id+ndx+1);
 
                 //in case neighbour>=0, it means that the current MPI processor (=subdomain) has a neighbour with the color analyzed at the current for-loop iteration
-                //otherwise the current MPI processor sits on the boundary of the mesh and it has less than 8 neighbours. 
+                //otherwise the current MPI processor sits on the boundary of the mesh and it has less than 8 neighbours.
                 if(neighbour>=0)
                 {
 			for (iterator_type it = myLocalElements.begin(); it != myLocalElements.end(); ++it)
@@ -140,7 +140,7 @@ void BAP3D(Teuchos::RCP<tpetra_matrix_type> BAP, Teuchos::RCP<tpetra_matrix_type
   //INPUT: BAP_shrunk = Tpetra:MultiVector contatining the shrunk version of B_DD * A_h * Ptentative resulting from domain decomposition with coloring
   //INPUT: comm = MPI communicator (MPI_COMM_WORLD)
   //INPUT: ndx = number of domains along x-direction
-  //INPUT: ndy = number of domains along y-direction 
+  //INPUT: ndy = number of domains along y-direction
 
   Teuchos::ArrayView<const int> myLocalElements = BAP->getRowMap()->getLocalElementList();
   int mypid = comm->getRank();
@@ -154,7 +154,7 @@ void BAP3D(Teuchos::RCP<tpetra_matrix_type> BAP, Teuchos::RCP<tpetra_matrix_type
 		int neighbour = -1;
 		Teuchos::ArrayRCP<const double> localBAP = BAP_shrunk->getData(color);
 
-                //The following if statements control the neighbours of a subdomain in a 3D brick partitioned mesh 
+                //The following if statements control the neighbours of a subdomain in a 3D brick partitioned mesh
                 //Each subdomains is incorporated in a 3x3x3 cube which is sliced into 3 squares living on three different planes
                 //The neighbours of a subdomain are checked plane by plane: in total there are three planes to span
                 //
@@ -219,7 +219,7 @@ void BAP3D(Teuchos::RCP<tpetra_matrix_type> BAP, Teuchos::RCP<tpetra_matrix_type
 			neighbour = (shifted_id+ndx+1+ndx*ndy);
 
                 //in case neighbour>=0, it means that the current MPI processor (=subdomain) has a neighbour with the color analyzed at the current for-loop iteration
-                //otherwise the current MPI processor sits on the boundary of the mesh and it has less than 26 neighbours. 
+                //otherwise the current MPI processor sits on the boundary of the mesh and it has less than 26 neighbours.
                 if(neighbour>=0)
                 {
 			for (iterator_type it = myLocalElements.begin(); it != myLocalElements.end(); ++it)

--- a/packages/muelu/research/max/AdditiveMG/CreateADRMatrix.hpp
+++ b/packages/muelu/research/max/AdditiveMG/CreateADRMatrix.hpp
@@ -63,7 +63,7 @@ namespace ADR {
       ADR1DProblem(Teuchos::ParameterList& list, const Teuchos::RCP<const Map>& map) : Problem<Map,Matrix,MultiVector>(list, map) { }
       Teuchos::RCP<Matrix> BuildMatrix();
 
-		private: 
+		private:
 
 			//domain definition
 			Scalar xleft = 0.0;
@@ -156,7 +156,7 @@ namespace ADR {
 					Values [1] = Values[1] -  diff_prime( xleft + MyGlobalElements[i]*dx )/(2.0 * dx);
   
 					//Advective term
-					Values [0] = Values[0] - adv( xleft + MyGlobalElements[i]*dx )/(2.0 * dx); 
+					Values [0] = Values[0] - adv( xleft + MyGlobalElements[i]*dx )/(2.0 * dx);
 					Values [1] = Values[1] + adv( xleft + MyGlobalElements[i]*dx )/(2.0 * dx);
 
           NumEntries = 2;
@@ -169,10 +169,10 @@ namespace ADR {
         mtx->insertGlobalValues(MyGlobalElements[i], iv, av);
 
         // Put in the diagonal entry
-				//Diffusion 
+				//Diffusion
 				Scalar diag_entry = a * diff( xleft + MyGlobalElements[i]*dx )/(dx * dx);
 				//Reaction
-				diag_entry = diag_entry + reac( xleft + MyGlobalElements[i]*dx ); 
+				diag_entry = diag_entry + reac( xleft + MyGlobalElements[i]*dx );
 
         mtx->insertGlobalValues(MyGlobalElements[i],
                                 Teuchos::tuple<GlobalOrdinal>(MyGlobalElements[i]),
@@ -201,7 +201,7 @@ namespace ADR {
       ADR2DProblem(Teuchos::ParameterList& list, const Teuchos::RCP<const Map>& map) : Problem<Map,Matrix,MultiVector>(list, map) { }
       Teuchos::RCP<Matrix> BuildMatrix();
 
-		private: 
+		private:
 
 			//Function that defines the diffusion coefficient
 			inline Scalar diff( Scalar  x, Scalar y ){return 1.0 + 0.0 * x + 0.0 * y;};
@@ -274,7 +274,7 @@ namespace ADR {
 
         center = myGlobalElements[i] - indexBase;
 
-				//Determine coordinates 
+				//Determine coordinates
 				Scalar x1 = (Scalar) (center % nx) * stretchx;
 				Scalar x2 = (Scalar) (std::floor( center/nx )) * stretchy;
 
@@ -338,7 +338,7 @@ namespace ADR {
       ADR3DProblem(Teuchos::ParameterList& list, const Teuchos::RCP<const Map>& map) : Problem<Map,Matrix,MultiVector>(list, map) { }
       Teuchos::RCP<Matrix> BuildMatrix();
 
-		private: 
+		private:
 
 			//Function that defines the diffusion coefficient
 			inline Scalar diff( Scalar  x, Scalar y, Scalar z ){return 1.0 + 0.0 * x + 0.0 * y + 0.0 * z;};
@@ -424,7 +424,7 @@ namespace ADR {
 
         center = myGlobalElements[i] - indexBase;
 
-				//Determine coordinates 
+				//Determine coordinates
 				Scalar x3 = (Scalar) (std::floor( center/( nx*ny ) )) * stretchz;
 				int plane = center % (nx*ny);
 				Scalar x1 = (Scalar) (plane % nx) * stretchx;

--- a/packages/muelu/research/max/AdditiveMG/MultiplicativeBricks.cpp
+++ b/packages/muelu/research/max/AdditiveMG/MultiplicativeBricks.cpp
@@ -227,11 +227,11 @@ int main(int argc, char *argv[]) {
 
   RCP<MultiVector> coordinates;
 
-  if (problem_type == "ADR1D") 
+  if (problem_type == "ADR1D")
 	coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<scalar_type,local_ordinal_type,global_ordinal_type,Map,MultiVector>("1D", xpetraMap, matrixParameters.GetParameterList());
-  else if (problem_type == "ADR2D") 
+  else if (problem_type == "ADR2D")
 	coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<scalar_type,local_ordinal_type,global_ordinal_type,Map,MultiVector>("2D", xpetraMap, matrixParameters.GetParameterList());
-  else if (problem_type == "ADR3D") 
+  else if (problem_type == "ADR3D")
 	coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<scalar_type,local_ordinal_type,global_ordinal_type,Map,MultiVector>("3D", xpetraMap, matrixParameters.GetParameterList());
 
   RCP<ADRXpetraProblem> Pr = ADR::Xpetra::BuildProblem<scalar_type, local_ordinal_type, global_ordinal_type, Map, CrsMatrixWrap, MultiVector>(matrixParameters.GetMatrixType(), xpetraMap, matrixParameters.GetParameterList());
@@ -241,13 +241,13 @@ int main(int argc, char *argv[]) {
   RCP<const driver_map_type> map = MueLuUtilities::Map2TpetraMap(*xpetraMap);
 
  // ===================================================
- // 	Domain Decomposition Preconditioner 
+ // 	Domain Decomposition Preconditioner
  // 	===================================
 
   //Creation of the MueLu list for the DD preconditioner
   RCP<Teuchos::ParameterList> dd_list = rcp(new Teuchos::ParameterList());
   dd_list->setName("MueLu");
-  dd_list->set("verbosity", "low"); 
+  dd_list->set("verbosity", "low");
   dd_list->set("number of equations", 1);
   dd_list->set("max levels", 1);
   dd_list->set("coarse: type", "SCHWARZ"); //FOR A ONE LEVEL PRECONDITIONER THE COARSE LEVEL IS INTERPRETED AS SMOOTHING LEVEL
@@ -266,7 +266,7 @@ int main(int argc, char *argv[]) {
   RCP<muelu_tpetra_operator_type> B_DD = MueLu::CreateTpetraPreconditioner( (RCP<operator_type>)A, *dd_list );
 
  // ===================================================
- // 	Multi Grid Preconditioner 
+ // 	Multi Grid Preconditioner
  // 	===================================
  
   RCP<muelu_tpetra_operator_type> M;
@@ -325,7 +325,7 @@ for(int trial = 1; trial<=number_runs; ++trial)
     std::cout << "number of iterations with MueLu preconditioner= " << numIterations_muelu << std::endl;
     std::cout << "||Residual|| = " << normVec_muelu[0] << std::endl;
  }
-} 
+}
 
 
   #include <Teuchos_TimeMonitor.hpp>

--- a/packages/muelu/research/max/AdditiveMG/MultiplicativeStride.cpp
+++ b/packages/muelu/research/max/AdditiveMG/MultiplicativeStride.cpp
@@ -219,11 +219,11 @@ int main(int argc, char *argv[]) {
 
   RCP<MultiVector> coordinates;
 
-  if (problem_type == "ADR1D") 
+  if (problem_type == "ADR1D")
   	coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<scalar_type,local_ordinal_type,global_ordinal_type,Map,MultiVector>("1D", xpetraMap, matrixParameters.GetParameterList());
-  else if (problem_type == "ADR2D") 
+  else if (problem_type == "ADR2D")
   	coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<scalar_type,local_ordinal_type,global_ordinal_type,Map,MultiVector>("2D", xpetraMap, matrixParameters.GetParameterList());
-  else if (problem_type == "ADR3D") 
+  else if (problem_type == "ADR3D")
   	coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<scalar_type,local_ordinal_type,global_ordinal_type,Map,MultiVector>("3D", xpetraMap, matrixParameters.GetParameterList());
 
   RCP<ADRXpetraProblem> Pr = ADR::Xpetra::BuildProblem<scalar_type, local_ordinal_type, global_ordinal_type, Map, CrsMatrixWrap, MultiVector>(matrixParameters.GetMatrixType(), xpetraMap, matrixParameters.GetParameterList());

--- a/packages/muelu/research/max/AdditiveMG/Smooth_Prolongation.cpp
+++ b/packages/muelu/research/max/AdditiveMG/Smooth_Prolongation.cpp
@@ -44,7 +44,7 @@ AdditiveVariant::AdditiveFineSmoother( RCP<crs_matrix_type> A )
 	  //Creation of the MueLu list for the DD preconditioner
 	  RCP<ParameterList> dd_list = rcp(new Teuchos::ParameterList());
 	  dd_list->setName("MueLu");
-	  dd_list->set("verbosity", "low"); 
+	  dd_list->set("verbosity", "low");
 	  dd_list->set("number of equations", 1);
 	  dd_list->set("max levels", 1);
 	  dd_list->set("coarse: type", "SCHWARZ"); //FOR A ONE LEVEL PRECONDITIONER THE COARSE LEVEL IS INTERPRETED AS SMOOTHING LEVEL
@@ -75,7 +75,7 @@ AdditiveVariant::AdditiveCoarseSolver( RCP<crs_matrix_type> A )
 	  //Creation of the MueLu list for the DD preconditioner
 		RCP<ParameterList> coarse_list = rcp(new Teuchos::ParameterList());
 		coarse_list->setName("MueLu");
-		coarse_list->set("verbosity", "low"); 
+		coarse_list->set("verbosity", "low");
 		coarse_list->set("number of equations", 1);
 		coarse_list->set("max levels", 2);
 		coarse_list->set("multigrid algorithm", "unsmoothed");
@@ -91,7 +91,7 @@ AdditiveVariant::AdditiveCoarseSolver( RCP<crs_matrix_type> A )
 		coarse_list->set("repartition: min rows per proc", static_cast<int>(A->getGlobalNumRows()) );
 		coarse_list->set("repartition: max imbalance", 1.2);
 		coarse_list->set("repartition: remap parts", false);
-		coarse_list->set("coarse: type", "SCHWARZ"); 
+		coarse_list->set("coarse: type", "SCHWARZ");
 
 		//Creation of Sublist for smoother	
 	  ParameterList& coarse_smooth_sublist = coarse_list->sublist("coarse: params");
@@ -99,7 +99,7 @@ AdditiveVariant::AdditiveCoarseSolver( RCP<crs_matrix_type> A )
 		coarse_smooth_sublist.set("schwarz: combine mode", "Zero");
 		coarse_smooth_sublist.set("subdomain solver name", "RILUK");
 
-		//Creation of the sublist for the subdomain solver 
+		//Creation of the sublist for the subdomain solver
 		ParameterList& coarse_subdomain_solver = coarse_smooth_sublist.sublist("subdomain solver parameters");
 		coarse_subdomain_solver.set("fact: iluk level-of-fill", 3);
 		coarse_subdomain_solver.set("fact: absolute threshold", 0.);
@@ -119,8 +119,8 @@ AdditiveVariant::AdditiveCoarseSolver( RCP<crs_matrix_type> A )
 	
     RCP<Xpetra::MultiVector<scalar_type, local_ordinal_type, global_ordinal_type, node_type > > coords = Xpetra::toXpetra( coords_	); 	
 
-    H->GetLevel(0)->Set("A", mueluA); 
-    H->GetLevel(0)->Set("Coordinates", coords); 
+    H->GetLevel(0)->Set("A", mueluA);
+    H->GetLevel(0)->Set("Coordinates", coords);
 
     // Multigrid setup phase
     mueLuFactory.SetupHierarchy(*H);	
@@ -129,10 +129,10 @@ AdditiveVariant::AdditiveCoarseSolver( RCP<crs_matrix_type> A )
 
   	RCP<Xpetra::Matrix<scalar_type,local_ordinal_type,global_ordinal_type,node_type>> prolong, restr;
 
-  	if (L->IsAvailable("P")) 
+  	if (L->IsAvailable("P"))
     	  prolong = L->template Get< RCP<Xpetra::Matrix<scalar_type,local_ordinal_type,global_ordinal_type,node_type>> >("P");
 
-  	if (L->IsAvailable("R")) 
+  	if (L->IsAvailable("R"))
     	  restr = L->template Get< RCP<Xpetra::Matrix<scalar_type,local_ordinal_type,global_ordinal_type,node_type>> >("R");
 
 		RCP<crs_matrix_type> tpetra_prolong = MueLuUtilities::Op2NonConstTpetraCrs(prolong);
@@ -176,7 +176,7 @@ AdditiveVariant::AdditiveCoarseSolver( RCP<crs_matrix_type> A )
 
 	  GlobalComm_->barrier();
 
-	  RCP<crs_matrix_type> BAP = rcp( new crs_matrix_type( tpetra_prolong->getRowMap(), AP->getColMap(), tpetra_prolong->getGlobalNumCols() ) ); 
+	  RCP<crs_matrix_type> BAP = rcp( new crs_matrix_type( tpetra_prolong->getRowMap(), AP->getColMap(), tpetra_prolong->getGlobalNumCols() ) );
 	  Teuchos::ArrayView<const global_ordinal_type> myLocalElements = BAP->getRowMap()->getLocalElementList();
 
 	  for(int color = 0; color<3; ++color)
@@ -213,7 +213,7 @@ AdditiveVariant::AdditiveCoarseSolver( RCP<crs_matrix_type> A )
 
 	//=============================================================================================================
 
-    RCP<crs_matrix_type> Pbar = Tpetra::MatrixMatrix::add(1.0, false, *tpetra_prolong, -1.0, false, *BAP); 
+    RCP<crs_matrix_type> Pbar = Tpetra::MatrixMatrix::add(1.0, false, *tpetra_prolong, -1.0, false, *BAP);
     RCP<xpetra_matrix> mueluPbar = MueLu::TpetraCrs_To_XpetraMatrix<scalar_type,local_ordinal_type,global_ordinal_type,node_type>(Pbar);
 
     H->GetLevel(1)->Set("Pbar", mueluPbar);
@@ -233,14 +233,14 @@ void AdditiveVariant::apply( const multivector_type &r, multivector_type &Pr, Te
 
 	multivector_type r_fine(DomainMap_, 1);
 	r_fine.doImport(r, Export_fine1, Tpetra::INSERT);	
-	multivector_type B_fine_Pr(RangeMap_,1); 
+	multivector_type B_fine_Pr(RangeMap_,1);
 	B_fine_->apply(r_fine, B_fine_Pr, mode, alpha, beta);
 	multivector_type B_Pr1(r.getMap(),1);	
 	B_Pr1.doImport(B_fine_Pr, Export_fine2, Tpetra::INSERT);
 
 	multivector_type r_coarse(DomainMap_, 1);
 	r_coarse.doImport(r, Export_fine1, Tpetra::INSERT);	
-	multivector_type B_coarse_Pr(RangeMap_,1); 
+	multivector_type B_coarse_Pr(RangeMap_,1);
 	B_coarse_->apply(r_coarse, B_coarse_Pr, mode, alpha, beta);
 	multivector_type B_Pr2(r.getMap(),1);
 	B_Pr2.doImport(B_coarse_Pr, Export_fine2, Tpetra::INSERT);

--- a/packages/muelu/research/max/AdditiveMG/Smooth_Prolongation.hpp
+++ b/packages/muelu/research/max/AdditiveMG/Smooth_Prolongation.hpp
@@ -64,9 +64,9 @@ class AdditiveVariant: public operator_type{
 
 		bool hasTransposeApply()const{return false;}
 	
-		RCP< const driver_map_type > getDomainMap() const{return DomainMap_;}; 
+		RCP< const driver_map_type > getDomainMap() const{return DomainMap_;};
 
-		RCP< const driver_map_type > getRangeMap() const{return RangeMap_;}; 
+		RCP< const driver_map_type > getRangeMap() const{return RangeMap_;};
 
 	private:		
 
@@ -81,12 +81,12 @@ class AdditiveVariant: public operator_type{
 		RCP< const driver_map_type > RangeMap_;
 
 		//MueLu Preconditioner to store the smoother at the fine level
-		RCP<muelu_tpetra_operator_type>	B_fine_ = Teuchos::null; 
+		RCP<muelu_tpetra_operator_type>	B_fine_ = Teuchos::null;
 
 	  //RCP<Ifpack2::AdditiveSchwarz< row_matrix_type, precond_type > > B_DD_;
 
-		//MueLu Preconditioner to store 
-		RCP<muelu_tpetra_operator_type>	B_coarse_ = Teuchos::null; 
+		//MueLu Preconditioner to store
+		RCP<muelu_tpetra_operator_type>	B_coarse_ = Teuchos::null;
 
 		void AdditiveFineSmoother( RCP<crs_matrix_type> );
 

--- a/packages/muelu/research/max/AdditiveMG/SmoothedAdditiveBricks.cpp
+++ b/packages/muelu/research/max/AdditiveMG/SmoothedAdditiveBricks.cpp
@@ -232,11 +232,11 @@ int main(int argc, char *argv[]) {
 
   RCP<MultiVector> coordinates;
 
-  if (problem_type == "ADR1D") 
+  if (problem_type == "ADR1D")
   	coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<scalar_type,local_ordinal_type,global_ordinal_type,Map,MultiVector>("1D", xpetraMap, matrixParameters.GetParameterList());
-  else if (problem_type == "ADR2D") 
+  else if (problem_type == "ADR2D")
   	coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<scalar_type,local_ordinal_type,global_ordinal_type,Map,MultiVector>("2D", xpetraMap, matrixParameters.GetParameterList());
-  else if (problem_type == "ADR3D") 
+  else if (problem_type == "ADR3D")
   	coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<scalar_type,local_ordinal_type,global_ordinal_type,Map,MultiVector>("3D", xpetraMap, matrixParameters.GetParameterList());
 
  RCP<ADRXpetraProblem> Pr = ADR::Xpetra::BuildProblem<scalar_type, local_ordinal_type, global_ordinal_type, Map, CrsMatrixWrap, MultiVector>(matrixParameters.GetMatrixType(), xpetraMap, matrixParameters.GetParameterList());
@@ -246,13 +246,13 @@ int main(int argc, char *argv[]) {
   RCP<const driver_map_type> map = MueLuUtilities::Map2TpetraMap(*xpetraMap);
 
  // ===================================================
- // 	Domain Decomposition Preconditioner 
+ // 	Domain Decomposition Preconditioner
  // 	===================================
 
   //Creation of the MueLu list for the DD preconditioner
   RCP<Teuchos::ParameterList> dd_list = rcp(new Teuchos::ParameterList());
   dd_list->setName("MueLu");
-  dd_list->set("verbosity", "low"); 
+  dd_list->set("verbosity", "low");
   dd_list->set("number of equations", 1);
   dd_list->set("max levels", 1);
   dd_list->set("coarse: type", "SCHWARZ"); //FOR A ONE LEVEL PRECONDITIONER THE COARSE LEVEL IS INTERPRETED AS SMOOTHING LEVEL
@@ -271,7 +271,7 @@ int main(int argc, char *argv[]) {
   RCP<muelu_tpetra_operator_type> B_DD = MueLu::CreateTpetraPreconditioner( (RCP<operator_type>)A, *dd_list );
 
  // ===================================================
- // 	Multi Grid Preconditioner 
+ // 	Multi Grid Preconditioner
  // 	===================================
 
   RCP<muelu_tpetra_operator_type> M;
@@ -281,8 +281,8 @@ int main(int argc, char *argv[]) {
   RCP<MueLu::Hierarchy<scalar_type> > H = mueLuFactory.CreateHierarchy();
   H->setVerbLevel(Teuchos::VERB_HIGH);
 	
-  H->GetLevel(0)->Set("A", xpetraA); 
-  H->GetLevel(0)->Set("Coordinates", coordinates); 
+  H->GetLevel(0)->Set("A", xpetraA);
+  H->GetLevel(0)->Set("Coordinates", coordinates);
 
   // Multigrid setup phase
   mueLuFactory.SetupHierarchy(*H);	
@@ -291,10 +291,10 @@ int main(int argc, char *argv[]) {
 
   RCP<Xpetra::Matrix<scalar_type,local_ordinal_type,global_ordinal_type,node_type>> prolong, restr;
 
-  if (L->IsAvailable("P")) 
+  if (L->IsAvailable("P"))
     prolong = L->template Get< RCP<Xpetra::Matrix<scalar_type,local_ordinal_type,global_ordinal_type,node_type>> >("P");
 
-  if (L->IsAvailable("R")) 
+  if (L->IsAvailable("R"))
     restr = L->template Get< RCP<Xpetra::Matrix<scalar_type,local_ordinal_type,global_ordinal_type,node_type>> >("R");
 
   RCP<crs_matrix_type> tpetra_prolong = MueLuUtilities::Op2NonConstTpetraCrs(prolong);
@@ -398,7 +398,7 @@ int main(int argc, char *argv[]) {
   Teuchos::ArrayView<const global_ordinal_type> elementListBAP (indBAPcolMap);
   Teuchos::RCP< Tpetra::Map< local_ordinal_type, global_ordinal_type, node_type > > BAPcolMap = rcp( new Tpetra::Map< local_ordinal_type, global_ordinal_type, node_type >( static_cast<size_t>(tpetra_prolong->getGlobalNumCols()), elementListBAP, indexBase, comm ) );
 
-  RCP<crs_matrix_type> BAP = rcp( new crs_matrix_type( tpetra_prolong->getRowMap(), BAPcolMap, tpetra_prolong->getGlobalNumCols() ) ); 
+  RCP<crs_matrix_type> BAP = rcp( new crs_matrix_type( tpetra_prolong->getRowMap(), BAPcolMap, tpetra_prolong->getGlobalNumCols() ) );
   Teuchos::ArrayView<const global_ordinal_type> myLocalElements = BAP->getRowMap()->getLocalElementList();
 
 
@@ -412,7 +412,7 @@ int main(int argc, char *argv[]) {
   BAP->fillComplete( tpetra_prolong->getDomainMap(), tpetra_prolong->getRangeMap() );
 	
 //=============================================================================================================
-  RCP<crs_matrix_type> Pbar = Tpetra::MatrixMatrix::add(1.0, false, *tpetra_prolong, -1.0, false, *BAP); 
+  RCP<crs_matrix_type> Pbar = Tpetra::MatrixMatrix::add(1.0, false, *tpetra_prolong, -1.0, false, *BAP);
   mueluPbar = MueLu::TpetraCrs_To_XpetraMatrix<scalar_type,local_ordinal_type,global_ordinal_type,node_type>(Pbar);
   }
   PbarSetUp->stop();
@@ -483,7 +483,7 @@ for(int trial = 1; trial<=number_runs; ++trial)
     std::cout << "number of iterations with MueLu preconditioner= " << numIterations_muelu << std::endl;
     std::cout << "||Residual|| = " << normVec_muelu[0] << std::endl;
  }
-} 
+}
 
   Teuchos::TimeMonitor::summarize ();
 /*
@@ -507,7 +507,7 @@ for(int trial = 1; trial<=number_runs; ++trial)
   localMV[aux] = (static_cast<double>(Timers_Max[1])/CLOCKS_PER_SEC/number_runs);
   localMV = TimerFine->getDataNonConst(0);
   localMV[aux] = (static_cast<double>(Timers_Max[2])/CLOCKS_PER_SEC/number_runs);
-  localMV = TimerCoarse->getDataNonConst(0);     
+  localMV = TimerCoarse->getDataNonConst(0);
   localMV[aux] = (static_cast<double>(Timers_Max[3])/CLOCKS_PER_SEC/number_runs);
 
   Tpetra::MatrixMarket::Writer<multivector_type>::writeDenseFile("TimeRestr.mtx", TimerRestr);

--- a/packages/muelu/research/max/AdditiveMG/SmoothedAdditiveStride.cpp
+++ b/packages/muelu/research/max/AdditiveMG/SmoothedAdditiveStride.cpp
@@ -218,16 +218,16 @@ int main(int argc, char *argv[]) {
 		Teuchos::ArrayView<const global_ordinal_type> elementList (ind);
 		xpetraMap = MapFactory::Build(Xpetra::UseTpetra,matrixParameters.GetNumGlobalElements(), elementList, indexBase, comm);
    }
-   else if( comm->getSize()==1 )   
+   else if( comm->getSize()==1 )
 	xpetraMap = MapFactory::Build(Xpetra::UseTpetra, matrixParameters.GetNumGlobalElements(), indexBase, comm);
 
   RCP<MultiVector> coordinates;
 
-  if (problem_type == "ADR1D") 
+  if (problem_type == "ADR1D")
   	coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<scalar_type,local_ordinal_type,global_ordinal_type,Map,MultiVector>("1D", xpetraMap, matrixParameters.GetParameterList());
-  else if (problem_type == "ADR2D") 
+  else if (problem_type == "ADR2D")
   	coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<scalar_type,local_ordinal_type,global_ordinal_type,Map,MultiVector>("2D", xpetraMap, matrixParameters.GetParameterList());
-  else if (problem_type == "ADR3D") 
+  else if (problem_type == "ADR3D")
   	coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<scalar_type,local_ordinal_type,global_ordinal_type,Map,MultiVector>("3D", xpetraMap, matrixParameters.GetParameterList());
 
   RCP<ADRXpetraProblem> Pr = ADR::Xpetra::BuildProblem<scalar_type, local_ordinal_type, global_ordinal_type, Map, CrsMatrixWrap, MultiVector>(matrixParameters.GetMatrixType(), xpetraMap, matrixParameters.GetParameterList());
@@ -237,13 +237,13 @@ int main(int argc, char *argv[]) {
   RCP<const driver_map_type> map = MueLuUtilities::Map2TpetraMap(*xpetraMap);
 
  // ===================================================
- // 	Domain Decomposition Preconditioner 
+ // 	Domain Decomposition Preconditioner
  // 	===================================
 
   //Creation of the MueLu list for the DD preconditioner
   RCP<Teuchos::ParameterList> dd_list = rcp(new Teuchos::ParameterList());
   dd_list->setName("MueLu");
-  dd_list->set("verbosity", "low"); 
+  dd_list->set("verbosity", "low");
   dd_list->set("number of equations", 1);
   dd_list->set("max levels", 1);
   dd_list->set("coarse: type", "SCHWARZ"); //FOR A ONE LEVEL PRECONDITIONER THE COARSE LEVEL IS INTERPRETED AS SMOOTHING LEVEL
@@ -262,7 +262,7 @@ int main(int argc, char *argv[]) {
   RCP<muelu_tpetra_operator_type> B_DD = MueLu::CreateTpetraPreconditioner( (RCP<operator_type>)A, *dd_list );
 
  // ===================================================
- // 	Multi Grid Preconditioner 
+ // 	Multi Grid Preconditioner
  // 	===================================
   RCP<muelu_tpetra_operator_type> M;
 
@@ -271,8 +271,8 @@ int main(int argc, char *argv[]) {
   RCP<MueLu::Hierarchy<scalar_type> > H = mueLuFactory.CreateHierarchy();
   H->setVerbLevel(Teuchos::VERB_HIGH);
 	
-  H->GetLevel(0)->Set("A", xpetraA); 
-  H->GetLevel(0)->Set("Coordinates", coordinates); 
+  H->GetLevel(0)->Set("A", xpetraA);
+  H->GetLevel(0)->Set("Coordinates", coordinates);
 
   // Multigrid setup phase
   mueLuFactory.SetupHierarchy(*H);	
@@ -281,10 +281,10 @@ int main(int argc, char *argv[]) {
 
   RCP<Xpetra::Matrix<scalar_type,local_ordinal_type,global_ordinal_type,node_type>> prolong, restr;
 
-  if (L->IsAvailable("P")) 
+  if (L->IsAvailable("P"))
     prolong = L->template Get< RCP<Xpetra::Matrix<scalar_type,local_ordinal_type,global_ordinal_type,node_type>> >("P");
 
-  if (L->IsAvailable("R")) 
+  if (L->IsAvailable("R"))
     restr = L->template Get< RCP<Xpetra::Matrix<scalar_type,local_ordinal_type,global_ordinal_type,node_type>> >("R");
 
   RCP<crs_matrix_type> tpetra_prolong = MueLuUtilities::Op2NonConstTpetraCrs(prolong);
@@ -300,7 +300,7 @@ int main(int argc, char *argv[]) {
   typedef typename Teuchos::ArrayView<const global_ordinal_type>::const_iterator iter_type;
 
 for(int trial = 1; trial<=number_runs; ++trial)
-{ 
+{
     for(int j = 0; j<tpetra_prolong->getGlobalNumCols(); ++j)
     {
         int color = j%3;
@@ -342,7 +342,7 @@ for(int trial = 1; trial<=number_runs; ++trial)
   Teuchos::ArrayView<const global_ordinal_type> elementListBAP (indBAPcolMap);
   Teuchos::RCP< Tpetra::Map< local_ordinal_type, global_ordinal_type, node_type > > BAPcolMap = rcp( new Tpetra::Map< local_ordinal_type, global_ordinal_type, node_type >( static_cast<size_t>(tpetra_prolong->getGlobalNumCols()), elementListBAP, indexBase, comm ) );
 
-   RCP<crs_matrix_type> BAP = rcp( new crs_matrix_type( tpetra_prolong->getRowMap(), BAPcolMap, tpetra_prolong->getGlobalNumCols() ) ); 
+   RCP<crs_matrix_type> BAP = rcp( new crs_matrix_type( tpetra_prolong->getRowMap(), BAPcolMap, tpetra_prolong->getGlobalNumCols() ) );
    Teuchos::ArrayView<const global_ordinal_type> myLocalElements = BAP->getRowMap()->getLocalElementList();
 
   for(int color = 0; color<3; ++color)
@@ -378,9 +378,9 @@ for(int trial = 1; trial<=number_runs; ++trial)
   BAP->fillComplete( tpetra_prolong->getDomainMap(), tpetra_prolong->getRangeMap() );
 
   //=============================================================================================================
-  RCP<crs_matrix_type> Pbar = Tpetra::MatrixMatrix::add(1.0, false, *tpetra_prolong, -1.0, false, *BAP); 
+  RCP<crs_matrix_type> Pbar = Tpetra::MatrixMatrix::add(1.0, false, *tpetra_prolong, -1.0, false, *BAP);
   mueluPbar = MueLu::TpetraCrs_To_XpetraMatrix<scalar_type,local_ordinal_type,global_ordinal_type,node_type>(Pbar);
-  Tpetra::MatrixMarket::Writer<crs_matrix_type>::writeSparseFile("Pbar.mtx", Pbar); //Auxiliary prints introduced to generate pictures 
+  Tpetra::MatrixMarket::Writer<crs_matrix_type>::writeSparseFile("Pbar.mtx", Pbar); //Auxiliary prints introduced to generate pictures
 }
   H->GetLevel(1)->Set("Pbar", mueluPbar);
 
@@ -393,7 +393,7 @@ for(int trial = 1; trial<=number_runs; ++trial)
   Teuchos::TimeMonitor::zeroOutTimers();
   //======================================================================================================================
 
-  // Linear Solver  
+  // Linear Solver
     
   RCP<multivector_type> X_muelu = rcp(new multivector_type(map,1));
   RCP<multivector_type> B = rcp(new multivector_type(map,1));
@@ -448,7 +448,7 @@ for(int trial = 1; trial<=number_runs; ++trial)
     std::cout << "number of iterations with MueLu preconditioner= " << numIterations_muelu << std::endl;
     std::cout << "||Residual|| = " << normVec_muelu[0] << std::endl;
  }
-} 
+}
 
   Teuchos::TimeMonitor::summarize ();
 

--- a/packages/muelu/research/max/AdditiveMG/Test.cpp
+++ b/packages/muelu/research/max/AdditiveMG/Test.cpp
@@ -91,7 +91,7 @@ int main(int argc, char* argv[])
     
     Solve(Problem);
 
-    // and we compute the norm of the true residual. 
+    // and we compute the norm of the true residual.
     double ResidualNorm = ComputeNorm(Matrix, &LHS, &RHS);
 
     if (Comm.MyPID() == 0)

--- a/packages/muelu/research/max/AdditiveMG/coloring.hpp
+++ b/packages/muelu/research/max/AdditiveMG/coloring.hpp
@@ -1,12 +1,12 @@
-#include <math.h> 
+#include <math.h>
 
 
 int coloring2D(int mypid, int ndx)
 {
 
   //INPUT: mypid is the MPI id of the processor
-  //INPUT: ndx is the nuber of domains along x-direction 
-  //INPUT: ndy is the nuber of domains along y-direction 
+  //INPUT: ndx is the nuber of domains along x-direction
+  //INPUT: ndy is the nuber of domains along y-direction
   //OUTPUT: color label associated with the current MPI processor (=subdomain)
 
   //detect the row of the domain grid where the current subdomain is located
@@ -42,11 +42,11 @@ int coloring3D(int mypid, int ndx, int ndy)
 {
 
   //INPUT: mypid is the MPI id of the processor
-  //INPUT: ndx is the nuber of domains along x-direction 
-  //INPUT: ndy is the nuber of domains along y-direction 
+  //INPUT: ndx is the nuber of domains along x-direction
+  //INPUT: ndy is the nuber of domains along y-direction
   //OUTPUT: color label associated with the current MPI processor (=subdomain)
  
-  //detect the plane of the domain grid where the current subdomain resides 
+  //detect the plane of the domain grid where the current subdomain resides
   int grid_plane = std::ceil( static_cast<double>(mypid)/(ndx*ndy) );
 
   //On the given plane, find the local id of the current subdomain

--- a/packages/muelu/research/max/AdditiveMG/dd.xml
+++ b/packages/muelu/research/max/AdditiveMG/dd.xml
@@ -43,7 +43,7 @@
       <Parameter name= "fact: relax value"                type="double" value="0."/>
     </ParameterList>
   </ParameterList>
-   <!-- 
+   <!--
    <Parameter name="subdomain solver name"             type="string" value="AMESOS2"/>
    -->
   <!-- ===========  REPARTITIONING  =========== -->

--- a/packages/muelu/research/max/AdditiveMG/final_parser.xml
+++ b/packages/muelu/research/max/AdditiveMG/final_parser.xml
@@ -54,7 +54,7 @@
 	      <Parameter name= "fact: relax value"                type="double" value="0."/>
 	    </ParameterList>
 	  </ParameterList>
-	   <!-- 
+	   <!--
 	   <Parameter name="subdomain solver name"             type="string" value="AMESOS2"/>
 	   -->
 	  <!-- ===========  REPARTITIONING  =========== -->

--- a/packages/muelu/research/max/AdditiveMG/neighbours.hpp
+++ b/packages/muelu/research/max/AdditiveMG/neighbours.hpp
@@ -56,8 +56,8 @@ void neighbours2D(Teuchos::RCP<tpetra_matrix_type> tpetra_prolong, std::vector<i
 	{
                 int neighbour = -1;
 
-                //The following if statements control the neighbours of a subdomain in a 2D brick partitioned mesh 
-                //Each subdomains is incorporated in a 3x3 square which is sliced into 3 stripes 
+                //The following if statements control the neighbours of a subdomain in a 2D brick partitioned mesh
+                //Each subdomains is incorporated in a 3x3 square which is sliced into 3 stripes
                 //The neighbours of a subdomain are checked plane by plane: in total there are three planes to span
                 // In case the subdomains sit on a boundary, there are missing neighbours for a specific color
                 // (this is what the last two conditions of each if statement take care of)
@@ -119,7 +119,7 @@ void neighbours3D(Teuchos::RCP<tpetra_matrix_type> tpetra_prolong, std::vector<i
 	{
 		int neighbour = -1;
 
-                //The following if statements control the neighbours of a subdomain in a 3D brick partitioned mesh 
+                //The following if statements control the neighbours of a subdomain in a 3D brick partitioned mesh
                 //Each subdomains is incorporated in a 3x3x3 cube which is sliced into 3 squares living on three different planes
                 //The neighbours of a subdomain are checked plane by plane: in total there are three planes to span
                 // In case the subdomains sit on a boundary, there are missing neighbours for a specific color

--- a/packages/muelu/research/max/AdditiveMG/tentative.cpp
+++ b/packages/muelu/research/max/AdditiveMG/tentative.cpp
@@ -231,11 +231,11 @@ int main(int argc, char *argv[]) {
 
   RCP<MultiVector> coordinates;
 
-	if (problem_type == "ADR1D") 
+	if (problem_type == "ADR1D")
 		coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<scalar_type,local_ordinal_type,global_ordinal_type,Map,MultiVector>("1D", xpetraMap, matrixParameters.GetParameterList());
-	else if (problem_type == "ADR2D") 
+	else if (problem_type == "ADR2D")
 		coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<scalar_type,local_ordinal_type,global_ordinal_type,Map,MultiVector>("2D", xpetraMap, matrixParameters.GetParameterList());
-	else if (problem_type == "ADR3D") 
+	else if (problem_type == "ADR3D")
 		coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<scalar_type,local_ordinal_type,global_ordinal_type,Map,MultiVector>("3D", xpetraMap, matrixParameters.GetParameterList());
 
  RCP<ADRXpetraProblem> Pr = ADR::Xpetra::BuildProblem<scalar_type, local_ordinal_type, global_ordinal_type, Map, CrsMatrixWrap, MultiVector>(matrixParameters.GetMatrixType(), xpetraMap, matrixParameters.GetParameterList());
@@ -245,13 +245,13 @@ int main(int argc, char *argv[]) {
     RCP<const driver_map_type> map = MueLuUtilities::Map2TpetraMap(*xpetraMap);
 
  // ===================================================
- // 	Domain Decomposition Preconditioner 
+ // 	Domain Decomposition Preconditioner
  // 	===================================
 
     //Creation of the MueLu list for the DD preconditioner
     RCP<Teuchos::ParameterList> dd_list = rcp(new Teuchos::ParameterList());
     dd_list->setName("MueLu");
-    dd_list->set("verbosity", "low"); 
+    dd_list->set("verbosity", "low");
     dd_list->set("number of equations", 1);
     dd_list->set("max levels", 1);
     dd_list->set("coarse: type", "SCHWARZ"); //FOR A ONE LEVEL PRECONDITIONER THE COARSE LEVEL IS INTERPRETED AS SMOOTHING LEVEL
@@ -277,8 +277,8 @@ int main(int argc, char *argv[]) {
     RCP<MueLu::Hierarchy<scalar_type> > H = mueLuFactory.CreateHierarchy();
     H->setVerbLevel(Teuchos::VERB_HIGH);
 	
-    H->GetLevel(0)->Set("A", xpetraA); 
-    H->GetLevel(0)->Set("Coordinates", coordinates); 
+    H->GetLevel(0)->Set("A", xpetraA);
+    H->GetLevel(0)->Set("Coordinates", coordinates);
 
     // Multigrid setup phase
     mueLuFactory.SetupHierarchy(*H);	
@@ -287,10 +287,10 @@ int main(int argc, char *argv[]) {
 
     RCP<Xpetra::Matrix<scalar_type,local_ordinal_type,global_ordinal_type,node_type>> prolong, restr;
 
-    if (L->IsAvailable("P")) 
+    if (L->IsAvailable("P"))
       prolong = L->template Get< RCP<Xpetra::Matrix<scalar_type,local_ordinal_type,global_ordinal_type,node_type>> >("P");
 
-    if (L->IsAvailable("R")) 
+    if (L->IsAvailable("R"))
       restr = L->template Get< RCP<Xpetra::Matrix<scalar_type,local_ordinal_type,global_ordinal_type,node_type>> >("R");
 
 
@@ -389,7 +389,7 @@ for(int trial = 1; trial<=number_runs; ++trial)
 	// CREATION OF BAP
 
     RCP<multivector_type> BAP_shrunk = rcp(new multivector_type(B_DD->getRangeMap(),AP_shrunk->getNumVectors()));
-	  B_DD->apply(*AP_shrunk, *BAP_shrunk, Teuchos::NO_TRANS, Teuchos::ScalarTraits< scalar_type >::one(), Teuchos::ScalarTraits< scalar_type >::zero()); 
+	  B_DD->apply(*AP_shrunk, *BAP_shrunk, Teuchos::NO_TRANS, Teuchos::ScalarTraits< scalar_type >::one(), Teuchos::ScalarTraits< scalar_type >::zero());
     
    //Columns Map for BAP
    std::vector<int> indBAPcolMap;
@@ -403,7 +403,7 @@ for(int trial = 1; trial<=number_runs; ++trial)
    Teuchos::ArrayView<const global_ordinal_type> elementListBAP (indBAPcolMap);
    Teuchos::RCP< Tpetra::Map< local_ordinal_type, global_ordinal_type, node_type > > BAPcolMap = rcp( new Tpetra::Map< local_ordinal_type, global_ordinal_type, node_type >( static_cast<size_t>(tpetra_prolong->getGlobalNumCols()), elementListBAP, indexBase, comm ) );
 
-    RCP<crs_matrix_type> BAP = rcp( new crs_matrix_type( tpetra_prolong->getRowMap(), BAPcolMap, tpetra_prolong->getGlobalNumCols() ) ); 
+    RCP<crs_matrix_type> BAP = rcp( new crs_matrix_type( tpetra_prolong->getRowMap(), BAPcolMap, tpetra_prolong->getGlobalNumCols() ) );
     Teuchos::ArrayView<const global_ordinal_type> myLocalElements = BAP->getRowMap()->getLocalElementList();
 
 
@@ -418,7 +418,7 @@ for(int trial = 1; trial<=number_runs; ++trial)
 	
     //Tpetra::MatrixMarket::Writer<crs_matrix_type>::writeSparseFile("BAP.mtx", BAP);
 //=============================================================================================================
-  RCP<crs_matrix_type> Pbar = Tpetra::MatrixMatrix::add(1.0, false, *tpetra_prolong, -1.0, false, *BAP); 
+  RCP<crs_matrix_type> Pbar = Tpetra::MatrixMatrix::add(1.0, false, *tpetra_prolong, -1.0, false, *BAP);
   mueluPbar = MueLu::TpetraCrs_To_XpetraMatrix<scalar_type,local_ordinal_type,global_ordinal_type,node_type>(Pbar);
 }
 PbarSetUp->stop();
@@ -477,7 +477,7 @@ for(int trial = 1; trial<=number_runs; ++trial)
     std::cout << "number of iterations with MueLu preconditioner= " << numIterations_muelu << std::endl;
     std::cout << "||Residual|| = " << normVec_muelu[0] << std::endl;
  }
-} 
+}
 
   //Teuchos::TimeMonitor::summarize ();
 

--- a/packages/muelu/research/max/XpetraSplitting/Xpetra_Level_decl.hpp
+++ b/packages/muelu/research/max/XpetraSplitting/Xpetra_Level_decl.hpp
@@ -65,7 +65,7 @@ namespace Xpetra{
 		typedef MultiVector<Scalar, LocalOrdinal, GlobalOrdinal> multivector_type;
 		typedef Matrix< Scalar, LocalOrdinal, GlobalOrdinal, Node > matrix_type;
 
-		public: 
+		public:
 
 			//! Constructors/destructors
 			//@{	
@@ -80,10 +80,10 @@ namespace Xpetra{
 			//! Public methods
 			//@{
 			virtual void
-				apply (const multivector_type& X, multivector_type& Y, 
-				Teuchos::ETransp mode = Teuchos::NO_TRANS, 
-				Scalar alpha = Teuchos::ScalarTraits<Scalar>::one(), 
-				Scalar beta = Teuchos::ScalarTraits<Scalar>::zero())const{}; 
+				apply (const multivector_type& X, multivector_type& Y,
+				Teuchos::ETransp mode = Teuchos::NO_TRANS,
+				Scalar alpha = Teuchos::ScalarTraits<Scalar>::one(),
+				Scalar beta = Teuchos::ScalarTraits<Scalar>::zero())const{};
 
 			virtual bool hasTransposeApply() const { return false; }
 
@@ -100,7 +100,7 @@ namespace Xpetra{
 			//! Extract regionToAll from the level
 			Array<Array<std::tuple<GlobalOrdinal, GlobalOrdinal> > > GetRegionToAll() const;
 
-			// Extract the level ID 
+			// Extract the level ID
 			GlobalOrdinal GetLevelID() const {return levelID_;}
 
 			//! Take a region index and returns the composite index for a given mesh node
@@ -150,7 +150,7 @@ namespace Xpetra{
 			//! Region operators
 			Array<RCP<matrix_type> > regionA_;
 
-			//! Region grid transfers 
+			//! Region grid transfers
 			Array<RCP<matrix_type> > regionP_;
 			Array<RCP<matrix_type> > regionR_;
 

--- a/packages/muelu/research/tawiesn/crada/driver_fullAMG.xml
+++ b/packages/muelu/research/tawiesn/crada/driver_fullAMG.xml
@@ -39,8 +39,8 @@
       <Parameter name="CoarseMap" type="string" value="myCoarseMap1"/>
     </ParameterList>
 
-    <!-- We have to use Nullspace1 here. If "Nullspace1" is not set the 
-         Factory creates the default null space containing of constant 
+    <!-- We have to use Nullspace1 here. If "Nullspace1" is not set the
+         Factory creates the default null space containing of constant
          vectors -->
     <ParameterList name="myNspFact1">
       <Parameter name="factory" type="string" value="NullspaceFactory"/>
@@ -108,8 +108,8 @@
       <Parameter name="CoarseMap" type="string" value="myCoarseMap2"/>
     </ParameterList>
 
-    <!-- We have to use Nullspace2 here. If "Nullspace2" is not set the 
-         Factory creates the default null space containing of constant 
+    <!-- We have to use Nullspace2 here. If "Nullspace2" is not set the
+         Factory creates the default null space containing of constant
          vectors (here only one constant vector) -->
     <ParameterList name="myNspFact2">
       <Parameter name="factory" type="string" value="NullspaceFactory"/>
@@ -245,8 +245,8 @@
       <!-- factory manager for block 1 -->
       <ParameterList name="block1">
         <!-- <Parameter name="group" type="string" value="myFirstGroup"/> -->
-        <!-- It's enough to just provide the sub block matrix A_{00} needed 
-             as input for the smoother "mySmooFact1" as well as the smoother 
+        <!-- It's enough to just provide the sub block matrix A_{00} needed
+             as input for the smoother "mySmooFact1" as well as the smoother
              itself. Alternatively, one could add below strings to the
              factory group "myFirstGroup" and use it here instead of below lines -->
         <Parameter name="A" type="string" value="mySubBlockAFactory1"/>
@@ -255,8 +255,8 @@
       <!-- factory manager for block 2 -->
       <ParameterList name="block2">
         <!-- The second equation in the SIMPLE smoother is the Schur complement
-             equation that has to be solved. Therefore, provide the Schur complement 
-             operator together with the smoother. The smoother object takes the 
+             equation that has to be solved. Therefore, provide the Schur complement
+             operator together with the smoother. The smoother object takes the
              Schur complement operator as operator "A" for the internal smoothing process. -->
         <!--<Parameter name="A" type="string" value="mySchurCompFact"/>-->
         <Parameter name="A" type="string" value="mySubBlockAFactory2"/>
@@ -276,8 +276,8 @@
       <!-- factory manager for block 1 -->
       <ParameterList name="block1">
         <!-- <Parameter name="group" type="string" value="myFirstGroup"/> -->
-        <!-- It's enough to just provide the sub block matrix A_{00} needed 
-             as input for the smoother "mySmooFact1" as well as the smoother 
+        <!-- It's enough to just provide the sub block matrix A_{00} needed
+             as input for the smoother "mySmooFact1" as well as the smoother
              itself. Alternatively, one could add below strings to the
              factory group "myFirstGroup" and use it here instead of below lines -->
         <Parameter name="A" type="string" value="mySubBlockAFactory1"/>
@@ -286,8 +286,8 @@
       <!-- factory manager for block 2 -->
       <ParameterList name="block2">
         <!-- The second equation in the SIMPLE smoother is the Schur complement
-             equation that has to be solved. Therefore, provide the Schur complement 
-             operator together with the smoother. The smoother object takes the 
+             equation that has to be solved. Therefore, provide the Schur complement
+             operator together with the smoother. The smoother object takes the
              Schur complement operator as operator "A" for the internal smoothing process. -->
         <!--<Parameter name="A" type="string" value="mySchurCompFact"/>-->
         <Parameter name="A" type="string" value="mySubBlockAFactory2"/>

--- a/packages/muelu/research/tawiesn/crada/driver_fullAMG_3l_ILU_KLU.xml
+++ b/packages/muelu/research/tawiesn/crada/driver_fullAMG_3l_ILU_KLU.xml
@@ -39,8 +39,8 @@
       <Parameter name="CoarseMap" type="string" value="myCoarseMap1"/>
     </ParameterList>
 
-    <!-- We have to use Nullspace1 here. If "Nullspace1" is not set the 
-         Factory creates the default null space containing of constant 
+    <!-- We have to use Nullspace1 here. If "Nullspace1" is not set the
+         Factory creates the default null space containing of constant
          vectors -->
     <ParameterList name="myNspFact1">
       <Parameter name="factory" type="string" value="NullspaceFactory"/>
@@ -108,8 +108,8 @@
       <Parameter name="CoarseMap" type="string" value="myCoarseMap2"/>
     </ParameterList>
 
-    <!-- We have to use Nullspace2 here. If "Nullspace2" is not set the 
-         Factory creates the default null space containing of constant 
+    <!-- We have to use Nullspace2 here. If "Nullspace2" is not set the
+         Factory creates the default null space containing of constant
          vectors (here only one constant vector) -->
     <ParameterList name="myNspFact2">
       <Parameter name="factory" type="string" value="NullspaceFactory"/>
@@ -245,8 +245,8 @@
       <!-- factory manager for block 1 -->
       <ParameterList name="block1">
         <!-- <Parameter name="group" type="string" value="myFirstGroup"/> -->
-        <!-- It's enough to just provide the sub block matrix A_{00} needed 
-             as input for the smoother "mySmooFact1" as well as the smoother 
+        <!-- It's enough to just provide the sub block matrix A_{00} needed
+             as input for the smoother "mySmooFact1" as well as the smoother
              itself. Alternatively, one could add below strings to the
              factory group "myFirstGroup" and use it here instead of below lines -->
         <Parameter name="A" type="string" value="mySubBlockAFactory1"/>
@@ -255,8 +255,8 @@
       <!-- factory manager for block 2 -->
       <ParameterList name="block2">
         <!-- The second equation in the SIMPLE smoother is the Schur complement
-             equation that has to be solved. Therefore, provide the Schur complement 
-             operator together with the smoother. The smoother object takes the 
+             equation that has to be solved. Therefore, provide the Schur complement
+             operator together with the smoother. The smoother object takes the
              Schur complement operator as operator "A" for the internal smoothing process. -->
         <!--<Parameter name="A" type="string" value="mySchurCompFact"/>-->
         <Parameter name="A" type="string" value="mySubBlockAFactory2"/>
@@ -276,8 +276,8 @@
       <!-- factory manager for block 1 -->
       <ParameterList name="block1">
         <!-- <Parameter name="group" type="string" value="myFirstGroup"/> -->
-        <!-- It's enough to just provide the sub block matrix A_{00} needed 
-             as input for the smoother "mySmooFact1" as well as the smoother 
+        <!-- It's enough to just provide the sub block matrix A_{00} needed
+             as input for the smoother "mySmooFact1" as well as the smoother
              itself. Alternatively, one could add below strings to the
              factory group "myFirstGroup" and use it here instead of below lines -->
         <Parameter name="A" type="string" value="mySubBlockAFactory1"/>
@@ -286,8 +286,8 @@
       <!-- factory manager for block 2 -->
       <ParameterList name="block2">
         <!-- The second equation in the SIMPLE smoother is the Schur complement
-             equation that has to be solved. Therefore, provide the Schur complement 
-             operator together with the smoother. The smoother object takes the 
+             equation that has to be solved. Therefore, provide the Schur complement
+             operator together with the smoother. The smoother object takes the
              Schur complement operator as operator "A" for the internal smoothing process. -->
         <!--<Parameter name="A" type="string" value="mySchurCompFact"/>-->
         <Parameter name="A" type="string" value="mySubBlockAFactory2"/>

--- a/packages/muelu/research/tawiesn/crada/driver_working_cms.xml
+++ b/packages/muelu/research/tawiesn/crada/driver_working_cms.xml
@@ -39,8 +39,8 @@
       <Parameter name="CoarseMap" type="string" value="myCoarseMap1"/>
     </ParameterList>
 
-    <!-- We have to use Nullspace1 here. If "Nullspace1" is not set the 
-         Factory creates the default null space containing of constant 
+    <!-- We have to use Nullspace1 here. If "Nullspace1" is not set the
+         Factory creates the default null space containing of constant
          vectors -->
     <ParameterList name="myNspFact1">
       <Parameter name="factory" type="string" value="NullspaceFactory"/>
@@ -108,8 +108,8 @@
       <Parameter name="CoarseMap" type="string" value="myCoarseMap2"/>
     </ParameterList>
 
-    <!-- We have to use Nullspace2 here. If "Nullspace2" is not set the 
-         Factory creates the default null space containing of constant 
+    <!-- We have to use Nullspace2 here. If "Nullspace2" is not set the
+         Factory creates the default null space containing of constant
          vectors (here only one constant vector) -->
     <ParameterList name="myNspFact2">
       <Parameter name="factory" type="string" value="NullspaceFactory"/>
@@ -245,8 +245,8 @@
       <!-- factory manager for block 1 -->
       <ParameterList name="block1">
         <!-- <Parameter name="group" type="string" value="myFirstGroup"/> -->
-        <!-- It's enough to just provide the sub block matrix A_{00} needed 
-             as input for the smoother "mySmooFact1" as well as the smoother 
+        <!-- It's enough to just provide the sub block matrix A_{00} needed
+             as input for the smoother "mySmooFact1" as well as the smoother
              itself. Alternatively, one could add below strings to the
              factory group "myFirstGroup" and use it here instead of below lines -->
         <Parameter name="A" type="string" value="mySubBlockAFactory1"/>
@@ -255,8 +255,8 @@
       <!-- factory manager for block 2 -->
       <ParameterList name="block2">
         <!-- The second equation in the SIMPLE smoother is the Schur complement
-             equation that has to be solved. Therefore, provide the Schur complement 
-             operator together with the smoother. The smoother object takes the 
+             equation that has to be solved. Therefore, provide the Schur complement
+             operator together with the smoother. The smoother object takes the
              Schur complement operator as operator "A" for the internal smoothing process. -->
         <!--<Parameter name="A" type="string" value="mySchurCompFact"/>-->
         <Parameter name="A" type="string" value="mySubBlockAFactory2"/>
@@ -276,8 +276,8 @@
       <!-- factory manager for block 1 -->
       <ParameterList name="block1">
         <!-- <Parameter name="group" type="string" value="myFirstGroup"/> -->
-        <!-- It's enough to just provide the sub block matrix A_{00} needed 
-             as input for the smoother "mySmooFact1" as well as the smoother 
+        <!-- It's enough to just provide the sub block matrix A_{00} needed
+             as input for the smoother "mySmooFact1" as well as the smoother
              itself. Alternatively, one could add below strings to the
              factory group "myFirstGroup" and use it here instead of below lines -->
         <Parameter name="A" type="string" value="mySubBlockAFactory1"/>
@@ -286,8 +286,8 @@
       <!-- factory manager for block 2 -->
       <ParameterList name="block2">
         <!-- The second equation in the SIMPLE smoother is the Schur complement
-             equation that has to be solved. Therefore, provide the Schur complement 
-             operator together with the smoother. The smoother object takes the 
+             equation that has to be solved. Therefore, provide the Schur complement
+             operator together with the smoother. The smoother object takes the
              Schur complement operator as operator "A" for the internal smoothing process. -->
         <!--<Parameter name="A" type="string" value="mySchurCompFact"/>-->
         <Parameter name="A" type="string" value="mySubBlockAFactory2"/>

--- a/packages/muelu/src/Graph/BrickAggregation/MueLu_BrickAggregationFactory_decl.hpp
+++ b/packages/muelu/src/Graph/BrickAggregation/MueLu_BrickAggregationFactory_decl.hpp
@@ -159,9 +159,9 @@ namespace MueLu {
      int nx_, ny_, nz_;
     mutable
      int bx_, by_, bz_;
-    mutable 
+    mutable
      bool dirichletX_,dirichletY_,dirichletZ_;
-    mutable 
+    mutable
      int naggx_, naggy_, naggz_;
 
     mutable

--- a/packages/muelu/src/Graph/BrickAggregation/MueLu_BrickAggregationFactory_def.hpp
+++ b/packages/muelu/src/Graph/BrickAggregation/MueLu_BrickAggregationFactory_def.hpp
@@ -326,12 +326,12 @@ namespace MueLu {
     naggx_ = (nx_-2*xboost)/bx_ + ((nx_-2*xboost) % bx_ ? 1 : 0);
 
     if(nDim_ > 1)
-      naggy_ = (ny_-2*yboost)/by_ + ( (ny_-2*yboost) % by_ ? 1 : 0);      
-    else 
+      naggy_ = (ny_-2*yboost)/by_ + ( (ny_-2*yboost) % by_ ? 1 : 0);
+    else
       naggy_ = 1;
 
     if(nDim_ > 2)
-      naggz_ = (nz_-2*zboost)/bz_ + ( (nz_-2*zboost) % bz_ ? 1 : 0);   
+      naggz_ = (nz_-2*zboost)/bz_ + ( (nz_-2*zboost) % bz_ ? 1 : 0);
     else
       naggz_ = 1;
 
@@ -432,7 +432,7 @@ namespace MueLu {
 
  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void  BrickAggregationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::getIJK(LocalOrdinal LID, int &i, int &j, int &k) const {
-   i = (*xMap_)[x_[LID]]; 
+   i = (*xMap_)[x_[LID]];
    j = (nDim_>1) ? (*yMap_)[y_[LID]] : 0;
    k =  (nDim_>2) ? (*zMap_)[z_[LID]] : 0;
   }
@@ -504,7 +504,7 @@ namespace MueLu {
         RCP<const Teuchos::Comm<int> > comm = A->getRowMap()->getComm();
         MueLu_sumAll(comm, numLocalBoundaryNodes, numGlobalBoundaryNodes);
         GetOStream(Statistics1) << "Detected " << numGlobalBoundaryNodes << " Dirichlet nodes" << std::endl;
-      }      
+      }
       Set(currentLevel, "DofsPerNode", 1);
       Set(currentLevel, "Graph", graph);
       Set(currentLevel, "Filtering",false);
@@ -512,7 +512,7 @@ namespace MueLu {
     else {
       FactoryMonitor m(*this, "Generating Graph", currentLevel);
       /*** Case 2: Dropping required ***/
-      // There is at least one active dimension in which we are not coarsening.  
+      // There is at least one active dimension in which we are not coarsening.
       // Those connections need to be dropped
       bool drop_x = (bx_ == 1);
       bool drop_y = (nDim_> 1 && by_ == 1);
@@ -538,7 +538,7 @@ namespace MueLu {
 
         for(size_t cidx=rowptr[row]; cidx<rowptr[row+1]; cidx++) {
           int ic,jc,kc;
-          LO col = colind[cidx];          
+          LO col = colind[cidx];
           getIJK(col,ic,jc,kc);
 
           if( (row2 !=col) && ((drop_x && ir != ic) || (drop_y && jr != jc) || (drop_z && kr != kc) )) {
@@ -570,7 +570,7 @@ namespace MueLu {
         RCP<const Teuchos::Comm<int> > comm = A->getRowMap()->getComm();
         MueLu_sumAll(comm, numLocalBoundaryNodes, numGlobalBoundaryNodes);
         GetOStream(Statistics1) << "Detected " << numGlobalBoundaryNodes << " Dirichlet nodes" << std::endl;
-      }      
+      }
       Set(currentLevel, "DofsPerNode", 1);
       Set(currentLevel, "Graph", graph);
       Set(currentLevel, "Filtering",true);

--- a/packages/muelu/src/Graph/Containers/MueLu_Aggregates_def.hpp
+++ b/packages/muelu/src/Graph/Containers/MueLu_Aggregates_def.hpp
@@ -181,7 +181,7 @@ namespace MueLu {
     LO currNumUnaggregated=0;
 
     // Construct the "rowptr" and the counter
-    aggPtr[0] = 0; 
+    aggPtr[0] = 0;
     for(LO i=0; i<numAggs; i++) {
       aggPtr[i+1] = aggSizes[i] + aggPtr[i];
       aggCurr[i] = aggPtr[i];

--- a/packages/muelu/src/Graph/Containers/MueLu_Aggregates_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/Containers/MueLu_Aggregates_kokkos_def.hpp
@@ -182,7 +182,7 @@ namespace MueLu {
   }
   
   template <class LocalOrdinal, class GlobalOrdinal, class DeviceType>
-  void 
+  void
   Aggregates_kokkos<LocalOrdinal, GlobalOrdinal, Kokkos::Compat::KokkosDeviceWrapperNode<DeviceType> >::ComputeNodesInAggregate(LO_view & aggPtr, LO_view & aggNodes, LO_view & unaggregated) const {
     LO numAggs  = GetNumAggregates();
     LO numNodes = vertex2AggId_->getLocalLength();
@@ -212,8 +212,8 @@ namespace MueLu {
     // Preallocate unaggregated to the correct size
     LO numUnaggregated = 0;
     Kokkos::parallel_reduce("MueLu:Aggregates:ComputeNodesInAggregate:unaggregatedSize", range_type(0,numNodes),
-      KOKKOS_LAMBDA(const LO nodeIdx, LO & count) { 
-        if(vertex2AggId(nodeIdx,0)==INVALID) 
+      KOKKOS_LAMBDA(const LO nodeIdx, LO & count) {
+        if(vertex2AggId(nodeIdx,0)==INVALID)
           count++;
       }, numUnaggregated);
     unaggregated = LO_view("unaggregated",numUnaggregated);

--- a/packages/muelu/src/Graph/Containers/MueLu_Zoltan2GraphAdapter.hpp
+++ b/packages/muelu/src/Graph/Containers/MueLu_Zoltan2GraphAdapter.hpp
@@ -105,7 +105,7 @@ public:
   //! MueLu::GraphBase Compatibility Layer
   const Teuchos::RCP< const Teuchos::Comm< int > >  getComm() const { return graph_->GetComm();}
   const Teuchos::RCP< const Xpetra::Map<lno_t, gno_t, node_t> > getRowMap() const { return graph_->GetDomainMap();}
-  const RCP< const Xpetra::Map<lno_t, gno_t, node_t> > getColMap() const { 
+  const RCP< const Xpetra::Map<lno_t, gno_t, node_t> > getColMap() const {
     // For some GraphBases' this is a ColMap, in others it is a seperate map that is
     // only non-null in parallel.
     Teuchos::RCP<const Xpetra::Map<lno_t,gno_t,node_t> > map =  graph_->GetImportMap();
@@ -135,7 +135,7 @@ public:
    * one does because the user is obviously a Trilinos user.
    */
 
-   MueLuGraphBaseAdapter(const RCP<const User> &ingraph, 
+   MueLuGraphBaseAdapter(const RCP<const User> &ingraph,
                       int nVtxWeights=0, int nEdgeWeights=0);
 
   /*! \brief Provide a pointer to weights for the primary entity type.
@@ -143,7 +143,7 @@ public:
    *    \param stride    A stride for the \c val array.  If \stride is
    *             \c k, then val[n * k] is the weight for the
    *             \c n th entity for index \idx.
-   *    \param idx A number from 0 to one less than 
+   *    \param idx A number from 0 to one less than
    *          weight idx specified in the constructor.
    *
    *  The order of the weights should match the order that
@@ -157,7 +157,7 @@ public:
    *    \param stride    A stride for the \c val array.  If \stride is
    *             \c k, then val[n * k] is the weight for the
    *             \c n th vertex for index \idx.
-   *    \param idx A number from 0 to one less than 
+   *    \param idx A number from 0 to one less than
    *          number of vertex weights specified in the constructor.
    *
    *  The order of the vertex weights should match the order that
@@ -171,14 +171,14 @@ public:
 
   /*! \brief Specify an index for which the weight should be
               the degree of the entity
-   *    \param idx Zoltan2 will use the entity's 
+   *    \param idx Zoltan2 will use the entity's
    *         degree as the entity weight for index \c idx.
    */
   void setWeightIsDegree(int idx);
 
   /*! \brief Specify an index for which the vertex weight should be
               the degree of the vertex
-   *    \param idx Zoltan2 will use the vertex's 
+   *    \param idx Zoltan2 will use the vertex's
    *         degree as the vertex weight for index \c idx.
    */
   void setVertexWeightIsDegree(int idx);
@@ -208,11 +208,11 @@ public:
   void setEdgeWeights(const scalar_t *val, int stride, int idx);
 
   /*! \brief Access to Xpetra-wrapped user's graph.
-   */ 
+   */
   RCP<const xgraph_t> getXpetraGraph() const { return graph_; }
 
-  /*! \brief Access to user's graph 
-   */ 
+  /*! \brief Access to user's graph
+   */
   RCP<const User> getUserGraph() const { return ingraph_; }
 
   ////////////////////////////////////////////////////
@@ -223,11 +223,11 @@ public:
   // The GraphAdapter interface.
   ////////////////////////////////////////////////////
 
-  // TODO:  Assuming rows == objects; 
+  // TODO:  Assuming rows == objects;
   // TODO:  Need to add option for columns or nonzeros?
   size_t getLocalNumVertices() const { return getLocalNumRows(); }
 
-  void getVertexIDsView(const gno_t *&ids) const 
+  void getVertexIDsView(const gno_t *&ids) const
   {
     ids = NULL;
     if (getLocalNumVertices())
@@ -252,7 +252,7 @@ public:
       std::ostringstream emsg;
       emsg << __FILE__ << ":" << __LINE__
            << "  Invalid vertex weight index " << idx << std::endl;
-      throw std::runtime_error(emsg.str()); 
+      throw std::runtime_error(emsg.str());
     }
 
 
@@ -271,7 +271,7 @@ public:
       std::ostringstream emsg;
       emsg << __FILE__ << ":" << __LINE__
            << "  Invalid edge weight index " << idx << std::endl;
-      throw std::runtime_error(emsg.str()); 
+      throw std::runtime_error(emsg.str());
     }
 
 
@@ -356,7 +356,7 @@ template <typename User, typename UserCoord>
   }
 
   if (nWeightsPerVertex_ > 0) {
-    vertexWeights_ = 
+    vertexWeights_ =
           arcp(new input_t[nWeightsPerVertex_], 0, nWeightsPerVertex_, true);
     vertexDegreeWeight_ =
           arcp(new bool[nWeightsPerVertex_], 0, nWeightsPerVertex_, true);
@@ -374,7 +374,7 @@ template <typename User, typename UserCoord>
 {
   if (this->getPrimaryEntityType() == Zoltan2::GRAPH_VERTEX)
     setVertexWeights(weightVal, stride, idx);
-  else 
+  else
     setEdgeWeights(weightVal, stride, idx);
 }
 
@@ -390,7 +390,7 @@ template <typename User, typename UserCoord>
       std::ostringstream emsg;
       emsg << __FILE__ << ":" << __LINE__
            << "  Invalid vertex weight index " << idx << std::endl;
-      throw std::runtime_error(emsg.str()); 
+      throw std::runtime_error(emsg.str());
   }
 
   size_t nvtx = getLocalNumVertices();
@@ -424,7 +424,7 @@ template <typename User, typename UserCoord>
       std::ostringstream emsg;
       emsg << __FILE__ << ":" << __LINE__
            << "  Invalid vertex weight index " << idx << std::endl;
-      throw std::runtime_error(emsg.str()); 
+      throw std::runtime_error(emsg.str());
   }
 
   vertexDegreeWeight_[idx] = true;
@@ -442,7 +442,7 @@ template <typename User, typename UserCoord>
       std::ostringstream emsg;
       emsg << __FILE__ << ":" << __LINE__
            << "  Invalid edge weight index " << idx << std::endl;
-      throw std::runtime_error(emsg.str()); 
+      throw std::runtime_error(emsg.str());
   }
 
   size_t nedges = getLocalNumEdges();

--- a/packages/muelu/src/Graph/MatrixTransformation/MueLu_AmalgamationFactory_def.hpp
+++ b/packages/muelu/src/Graph/MatrixTransformation/MueLu_AmalgamationFactory_def.hpp
@@ -88,7 +88,7 @@ namespace MueLu {
 
        If numPDEs>1
          If matrix uses point storage, then storageblocksize=1  and fullblockssize=numPDEs.
-         If matrix uses block storage, with block size of n, then storageblocksize=n, and fullblocksize=numPDEs/n.  
+         If matrix uses block storage, with block size of n, then storageblocksize=n, and fullblocksize=numPDEs/n.
          Thus far, only storageblocksize=numPDEs and fullblocksize=1 has been tested.
     */
 

--- a/packages/muelu/src/Graph/MatrixTransformation/MueLu_AmalgamationFactory_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/MatrixTransformation/MueLu_AmalgamationFactory_kokkos_def.hpp
@@ -93,7 +93,7 @@ namespace MueLu {
 
        If numPDEs>1
          If matrix uses point storage, then storageblocksize=1  and fullblockssize=numPDEs.
-         If matrix uses block storage, with block size of n, then storageblocksize=n, and fullblocksize=numPDEs/n.  
+         If matrix uses block storage, with block size of n, then storageblocksize=n, and fullblocksize=numPDEs/n.
          Thus far, only storageblocksize=numPDEs and fullblocksize=1 has been tested.
     */
 

--- a/packages/muelu/src/Graph/MatrixTransformation/MueLu_CoalesceDropFactory_def.hpp
+++ b/packages/muelu/src/Graph/MatrixTransformation/MueLu_CoalesceDropFactory_def.hpp
@@ -163,14 +163,14 @@ namespace MueLu {
     if (pL.get<bool>("lightweight wrap") == true) {
       std::string algo = pL.get<std::string>("aggregation: drop scheme");
       if (algo == "distance laplacian" || algo == "block diagonal distance laplacian") {
-        Input(currentLevel, "Coordinates");    
+        Input(currentLevel, "Coordinates");
       }
-      if(algo == "signed classical sa") 
+      if(algo == "signed classical sa")
 	;
       else if (algo.find("block diagonal") != std::string::npos || algo.find("signed classical") != std::string::npos)  {
         Input(currentLevel, "BlockNumber");
       }
-    }     
+    }
     
   }
   
@@ -211,7 +211,7 @@ namespace MueLu {
     RCP<LocalOrdinalVector> ghostedBlockNumber;
     ArrayRCP<const LO> g_block_id;
 
-    if(algo == "distance laplacian" ) { 
+    if(algo == "distance laplacian" ) {
       // Grab the coordinates for distance laplacian
       Coords = Get< RCP<RealValuedMultiVector > >(currentLevel, "Coordinates");
       A = realA;
@@ -228,16 +228,16 @@ namespace MueLu {
         // Ghost the column block numbers if we need to
         RCP<const Import> importer = realA->getCrsGraph()->getImporter();
         if(!importer.is_null()) {
-          SubFactoryMonitor m1(*this, "Block Number import", currentLevel);      
+          SubFactoryMonitor m1(*this, "Block Number import", currentLevel);
           ghostedBlockNumber= Xpetra::VectorFactory<LO,LO,GO,NO>::Build(importer->getTargetMap());
-          ghostedBlockNumber->doImport(*BlockNumber, *importer, Xpetra::INSERT);          
-        } 
+          ghostedBlockNumber->doImport(*BlockNumber, *importer, Xpetra::INSERT);
+        }
         else {
           ghostedBlockNumber = BlockNumber;
         }
         g_block_id = ghostedBlockNumber->getData(0);
         //      }
-      if(algo == "block diagonal colored signed classical") 
+      if(algo == "block diagonal colored signed classical")
         generateColoringGraph=true;
       algo = "classical";
       A = realA;
@@ -252,7 +252,7 @@ namespace MueLu {
       // Handle the "block diagonal" filtering, and then continue onward
       use_block_algorithm = true;
       RCP<Matrix> filteredMatrix = BlockDiagonalize(currentLevel,realA,true);
-      if(algo == "block diagonal distance laplacian") {  
+      if(algo == "block diagonal distance laplacian") {
         // We now need to expand the coordinates by the interleaved blocksize
         RCP<RealValuedMultiVector> OldCoords = Get< RCP<RealValuedMultiVector > >(currentLevel, "Coordinates");
         if (OldCoords->getLocalLength() != realA->getLocalNumRows()) {
@@ -261,16 +261,16 @@ namespace MueLu {
            for(LO k=0; k<dim; k++){
              ArrayRCP<const real_type> old_vec = OldCoords->getData(k);
              ArrayRCP<real_type>       new_vec = Coords->getDataNonConst(k);
-             for(LO i=0; i <(LO)OldCoords->getLocalLength(); i++) {   
+             for(LO i=0; i <(LO)OldCoords->getLocalLength(); i++) {
                LO new_base = i*dim;
-               for(LO j=0; j<interleaved_blocksize; j++) 
+               for(LO j=0; j<interleaved_blocksize; j++)
                 new_vec[new_base + j] = old_vec[i];
              }
           }
         }
         else {
           Coords = OldCoords;
-        }  
+        }
         algo = "distance laplacian";
       }
       else if(algo == "block diagonal classical") {
@@ -296,17 +296,17 @@ namespace MueLu {
         if(dlap_weights[i] != 1.0) {
           non_unity = true;
         }
-      }  
-      if(non_unity) {        
+      }
+      if(non_unity) {
         LO blocksize = use_block_algorithm ? as<LO>(pL.get<int>("aggregation: block diagonal: interleaved blocksize")) : 1;
-        if((LO)dlap_weights.size() == dim) 
+        if((LO)dlap_weights.size() == dim)
           use_dlap_weights = SINGLE_WEIGHTS;
         else if((LO)dlap_weights.size() == blocksize * dim)
           use_dlap_weights = BLOCK_WEIGHTS;
         else  {
           TEUCHOS_TEST_FOR_EXCEPTION(1, Exceptions::RuntimeError,
                                      "length of 'aggregation: distance laplacian directional weights' must equal the coordinate dimension OR the coordinate dimension times the blocksize");
-        }        
+        }
         if (GetVerbLevel() & Statistics1)
           GetOStream(Statistics1) << "Using distance laplacian weights: "<<dlap_weights<<std::endl;
       }
@@ -410,9 +410,9 @@ namespace MueLu {
 
        If numPDEs>1
          If matrix uses point storage, then storageblocksize=1  and BlockSize=numPDEs.
-         If matrix uses block storage, with block size of n, then storageblocksize=n, and BlockSize=numPDEs/n.  
+         If matrix uses block storage, with block size of n, then storageblocksize=n, and BlockSize=numPDEs/n.
          Thus far, only storageblocksize=numPDEs and BlockSize=1 has been tested.
-      */      
+      */
       TEUCHOS_TEST_FOR_EXCEPTION(A->GetFixedBlockSize() % A->GetStorageBlockSize() != 0,Exceptions::RuntimeError,"A->GetFixedBlockSize() needs to be a multiple of A->GetStorageBlockSize()");
       const LO BlockSize = A->GetFixedBlockSize() / A->GetStorageBlockSize();
 
@@ -443,7 +443,7 @@ namespace MueLu {
           RCP<GraphBase> graph = rcp(new Graph(A->getCrsGraph(), "graph of A"));
           // Detect and record rows that correspond to Dirichlet boundary conditions
           ArrayRCP<bool > boundaryNodes = Teuchos::arcp_const_cast<bool>(MueLu::Utilities<SC,LO,GO,NO>::DetectDirichletRows(*A, dirichletThreshold));
-          if (rowSumTol > 0.) 
+          if (rowSumTol > 0.)
             Utilities::ApplyRowSumCriterion(*A, rowSumTol, boundaryNodes);
 
           graph->SetBoundaryNodeMap(boundaryNodes);
@@ -501,7 +501,7 @@ namespace MueLu {
             if(ghostedBlockNumber.is_null()) {
               if (GetVerbLevel() & Statistics1)
                 GetOStream(Statistics1) << "Applying point row sum criterion." << std::endl;
-              Utilities::ApplyRowSumCriterion(*A, rowSumTol, boundaryNodes);          
+              Utilities::ApplyRowSumCriterion(*A, rowSumTol, boundaryNodes);
             } else {
               if (GetVerbLevel() & Statistics1)
                 GetOStream(Statistics1) << "Applying block row sum criterion." << std::endl;
@@ -518,7 +518,7 @@ namespace MueLu {
             ArrayView<const SC> vals;
             A->getLocalRowView(row, indices, vals);
 
-            if(classicalAlgo == defaultAlgo) {              
+            if(classicalAlgo == defaultAlgo) {
               //FIXME the current predrop function uses the following
               //FIXME    if(std::abs(vals[k]) > std::abs(threshold_) || grow == gcid )
               //FIXME but the threshold doesn't take into account the rows' diagonal entries
@@ -528,7 +528,7 @@ namespace MueLu {
               if(useSignedClassicalRS) {
                 // Signed classical RS style
                 for (LO colID = 0; colID < Teuchos::as<LO>(nnz); colID++) {
-                  LO col = indices[colID];               
+                  LO col = indices[colID];
                   MT max_neg_aik = realThreshold * STS::real(negMaxOffDiagonal[row]);
                   MT neg_aij     = - STS::real(vals[colID]);
                   /*                  if(row==1326) printf("A(%d,%d) = %6.4e, block = (%d,%d) neg_aij = %6.4e max_neg_aik = %6.4e\n",row,col,vals[colID],
@@ -546,7 +546,7 @@ namespace MueLu {
               else if(useSignedClassicalSA) {
 		// Signed classical SA style
                 for (LO colID = 0; colID < Teuchos::as<LO>(nnz); colID++) {
-                  LO col = indices[colID];             
+                  LO col = indices[colID];
 
 		  bool is_nonpositive =  STS::real(vals[colID]) <= 0;
                   MT  aiiajj = STS::magnitude(threshold*threshold * ghostedDiagVals[col]*ghostedDiagVals[row]);  // eps^2*|a_ii|*|a_jj|
@@ -567,7 +567,7 @@ namespace MueLu {
               else {
                 // Standard abs classical
                 for (LO colID = 0; colID < Teuchos::as<LO>(nnz); colID++) {
-                  LO col = indices[colID];               
+                  LO col = indices[colID];
                   MT  aiiajj = STS::magnitude(threshold*threshold * ghostedDiagVals[col]*ghostedDiagVals[row]);  // eps^2*|a_ii|*|a_jj|
                   MT aij    = STS::magnitude(vals[colID]*vals[colID]);                                          // |a_ij|^2
                   
@@ -593,7 +593,7 @@ namespace MueLu {
 
               // find magnitudes
               for (LO colID = 0; colID < (LO)nnz; colID++) {
-                LO col = indices[colID];              
+                LO col = indices[colID];
                 if (row == col) {
                   drop_vec.emplace_back( zero, one, colID, false);
                   continue;
@@ -632,7 +632,7 @@ namespace MueLu {
                   }
                   drop_vec[i].drop = drop;
                 }
-              } else if (classicalAlgo == scaled_cut) {               
+              } else if (classicalAlgo == scaled_cut) {
                   std::sort( drop_vec.begin(), drop_vec.end()
                            , [](DropTol const& a, DropTol const& b) {
                                return a.val/a.diag > b.val/b.diag;
@@ -1190,7 +1190,7 @@ namespace MueLu {
 	  // Extra array for if we're allowing symmetrization with cutting
 	  ArrayRCP<LO> rows_stop;
 	  bool use_stop_array = threshold != STS::zero() && distanceLaplacianAlgo == scaled_cut_symmetric;
-	  if(use_stop_array) 
+	  if(use_stop_array)
 	    rows_stop.resize(numRows);
 	 
           const ArrayRCP<bool> amalgBoundaryNodes(numRows, false);
@@ -1373,7 +1373,7 @@ namespace MueLu {
 #ifdef HAVE_MUELU_DEBUG
                         if (distanceLaplacianCutVerbose) {
                           std::cout << "DJS: KEEP, N, ROW:  " << i+1 << ", " << n << ", " << row << std::endl;
-			}                        
+			}
 #endif
                       }
                     }
@@ -1428,7 +1428,7 @@ namespace MueLu {
               amalgBoundaryNodes[row] = true;
             }
 
-	    if(use_stop_array) 
+	    if(use_stop_array)
 	      rows_stop[row] = rownnz + rows[row];
 	    else
 	      rows[row+1] = realnnz;
@@ -1446,7 +1446,7 @@ namespace MueLu {
 		
 		bool found = false;
 		for(LO t_col = rows[col] ; !found && t_col  < rows_stop[col]; t_col++) {
-		  if (columns[t_col] == row) 
+		  if (columns[t_col] == row)
 		    found = true;
 		}
 		// We didn't find the transpose buddy, so let's symmetrize, unless we'd be symmetrizing
@@ -1776,15 +1776,15 @@ namespace MueLu {
 
     RCP<LocalOrdinalVector> BlockNumber = Get<RCP<LocalOrdinalVector> >(currentLevel, "BlockNumber");
     RCP<LocalOrdinalVector> ghostedBlockNumber;
-    GetOStream(Statistics1) << "Using BlockDiagonal Graph before dropping (with provided blocking)"<<std::endl;      
+    GetOStream(Statistics1) << "Using BlockDiagonal Graph before dropping (with provided blocking)"<<std::endl;
 
     // Ghost the column block numbers if we need to
     RCP<const Import> importer = A->getCrsGraph()->getImporter();
     if(!importer.is_null()) {
-      SubFactoryMonitor m1(*this, "Block Number import", currentLevel);      
+      SubFactoryMonitor m1(*this, "Block Number import", currentLevel);
       ghostedBlockNumber= Xpetra::VectorFactory<LO,LO,GO,NO>::Build(importer->getTargetMap());
       ghostedBlockNumber->doImport(*BlockNumber, *importer, Xpetra::INSERT);
-    } 
+    }
     else {
       ghostedBlockNumber = BlockNumber;
     }
@@ -1794,7 +1794,7 @@ namespace MueLu {
     Teuchos::ArrayRCP<const LO> col_block_number = ghostedBlockNumber->getData(0);
 
     // allocate space for the local graph
-    ArrayRCP<size_t> rows_mat;   
+    ArrayRCP<size_t> rows_mat;
     ArrayRCP<LO> rows_graph,columns;
     ArrayRCP<SC> values;
     RCP<CrsMatrixWrap> crs_matrix_wrap;
@@ -1865,13 +1865,13 @@ namespace MueLu {
       GetOStream(Statistics1) << std::endl;
     }
 
-    Set(currentLevel, "Filtering", true);    
+    Set(currentLevel, "Filtering", true);
 
     if(generate_matrix) {
       // NOTE: Trying to use A's Import/Export objects will cause the code to segfault back in Build() with errors on the Import
       // if you're using Epetra.  I'm not really sure why. By using the Col==Domain and Row==Range maps, we get null Import/Export objects
       // here, which is legit, because we never use them anyway.
-      crs_matrix_wrap->getCrsMatrix()->setAllValues(rows_mat,columns,values);      
+      crs_matrix_wrap->getCrsMatrix()->setAllValues(rows_mat,columns,values);
       crs_matrix_wrap->getCrsMatrix()->expertStaticFillComplete(A->getColMap(), A->getRowMap());
     }
     else {

--- a/packages/muelu/src/Graph/MatrixTransformation/MueLu_CoalesceDropFactory_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/MatrixTransformation/MueLu_CoalesceDropFactory_kokkos_def.hpp
@@ -517,9 +517,9 @@ namespace MueLu {
 
        If numPDEs>1
          If matrix uses point storage, then storageblocksize=1  and blkSize=numPDEs.
-         If matrix uses block storage, with block size of n, then storageblocksize=n, and blkSize=numPDEs/n.  
+         If matrix uses block storage, with block size of n, then storageblocksize=n, and blkSize=numPDEs/n.
          Thus far, only storageblocksize=numPDEs and blkSize=1 has been tested.
-      */      
+      */
  
     TEUCHOS_TEST_FOR_EXCEPTION(A->GetFixedBlockSize() % A->GetStorageBlockSize() != 0,Exceptions::RuntimeError,"A->GetFixedBlockSize() needs to be a multiple of A->GetStorageBlockSize()");
     LO   blkSize   = A->GetFixedBlockSize() / A->GetStorageBlockSize();

--- a/packages/muelu/src/Graph/MatrixTransformation/MueLu_SmooVecCoalesceDropFactory_decl.hpp
+++ b/packages/muelu/src/Graph/MatrixTransformation/MueLu_SmooVecCoalesceDropFactory_decl.hpp
@@ -83,16 +83,16 @@ namespace MueLu {
 
     Experimental dropping function based on taking a set of random vectors u, running
     a smoother on A u = 0, and then basing the drop decisions on "how smooth" the vectors
-    are local. Neighobring regions where the vectors are smooth can be aggregated 
-    together and so these are kept in the associated drop matrix. Areas that are 
+    are local. Neighobring regions where the vectors are smooth can be aggregated
+    together and so these are kept in the associated drop matrix. Areas that are
     not smooth should end up in different aggregates and so the A_ij representing
     these should be dropped.  This Factory can address both PDE systems and
     scalar PDEs, always creating a matrix reprsenting nodal connections as opposed
-    to dof connections. 
+    to dof connections.
 
      To enter this factor as opposed to the more standard CoalesceDropFactory() one
-     must set "aggregation: drop scheme" to "unsupported vector smoothing". In this 
-     case some of the parameter options associated with CoalesceDropFactory (e.g., 
+     must set "aggregation: drop scheme" to "unsupported vector smoothing". In this
+     case some of the parameter options associated with CoalesceDropFactory (e.g.,
      "aggregation: drop tol", "aggregation: Dirichlet threshold", "lightweight wrap")
      will cause parameter validator errors.
 
@@ -102,7 +102,7 @@ namespace MueLu {
     Parameter                  | type      | default   | master.xml | validated | requested | description
     ---------------------------|-----------|-----------|:----------:|:---------:|:---------:|------------
      A                         |Factory    | null      |            | *         | *         | Generating factory of the operator A
-     "aggregation: drop scheme"|std::string|"classical"| *          | *         | *         | Must choose "unsupported vector smoothing" 
+     "aggregation: drop scheme"|std::string|"classical"| *          | *         | *         | Must choose "unsupported vector smoothing"
      "aggregation: number of times to pre or post smooth"|int| 10|* |           | *         | Amount of pre or post smoothing invocations
      "aggregation: number of random vectors"|int| 10   |          * | *         | *         | Number of random vectors
      "aggregation: penalty parameters"|Array(double)|{12.0,-.20}| * | *         | *         | Ultimately determines how much dropping is done

--- a/packages/muelu/src/Graph/PairwiseAggregation/MueLu_NotayAggregationFactory_def.hpp
+++ b/packages/muelu/src/Graph/PairwiseAggregation/MueLu_NotayAggregationFactory_def.hpp
@@ -246,7 +246,7 @@ namespace MueLu {
         std::vector<std::vector<LO> > agg2vertex(numLocalAggregates);
         auto vertex2AggId = aggregates->GetVertex2AggId()->getData(0);
         for(LO i=0; i<(LO)numRows; i++) {
-          if(aggStat[i] != AGGREGATED) 
+          if(aggStat[i] != AGGREGATED)
             continue;
           LO agg=vertex2AggId[i];
           agg2vertex[agg].push_back(i);
@@ -269,8 +269,8 @@ namespace MueLu {
           for (LO colidx = 0; colidx < static_cast<LO>(nnz); colidx++) {
             bool found = false;
             if(indices[colidx] < numRows) {
-              for(LO j=0; j<(LO)myagg.size(); j++) 
-                if (vertex2AggId[indices[colidx]] == agg) 
+              for(LO j=0; j<(LO)myagg.size(); j++)
+                if (vertex2AggId[indices[colidx]] == agg)
                   found=true;
             }
             if(!found) {
@@ -457,7 +457,7 @@ namespace MueLu {
 	    best_idx = col;
             *out << "[" << current_idx << "] Column     UPDATED " << col << ": "
                  << "aii - si + ajj - sj = " << aii << " - " << si << " + " << ajj << " - " << sj
-                 << " = " << aii - si + ajj - sj<< ", aij = "<<aij << ", mu = " << mu << std::endl;            
+                 << " = " << aii - si + ajj - sj<< ", aij = "<<aij << ", mu = " << mu << std::endl;
 	  }
           else {
           *out << "[" << current_idx << "] Column NOT UPDATED " << col << ": "

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_UncoupledAggregationFactory_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_UncoupledAggregationFactory_def.hpp
@@ -148,8 +148,8 @@ namespace MueLu {
       }
     }
 
-    // request special data necessary for InterfaceAggregation  
-    if (pL.get<bool>("aggregation: use interface aggregation")       == true){   
+    // request special data necessary for InterfaceAggregation
+    if (pL.get<bool>("aggregation: use interface aggregation")       == true){
       if(currentLevel.GetLevelID() == 0) {
         if(currentLevel.IsAvailable("nodeOnInterface", NoFactory::get())) {
           currentLevel.DeclareInput("nodeOnInterface", NoFactory::get(), this);
@@ -224,8 +224,8 @@ namespace MueLu {
     // construct aggStat information
     std::vector<unsigned> aggStat(numRows, READY);
 
-    // interface 
-    if (pL.get<bool>("aggregation: use interface aggregation")       == true){   
+    // interface
+    if (pL.get<bool>("aggregation: use interface aggregation")       == true){
       Teuchos::Array<LO> nodeOnInterface = Get<Array<LO>>(currentLevel,"nodeOnInterface");
       for (LO i = 0; i < numRows; i++) {
         if (nodeOnInterface[i])

--- a/packages/muelu/src/Interface/FacadeClasses/def_facade_BGS2x2.xml
+++ b/packages/muelu/src/Interface/FacadeClasses/def_facade_BGS2x2.xml
@@ -29,7 +29,7 @@
       <type>int</type>
       <default>0</default>
       <description>Level of fill for ILU</description>
-    </parameter>   
+    </parameter>
     <parameter>
       <name>Block 1: relaxation: sweeps</name>
       <type>int</type>
@@ -108,9 +108,9 @@
     </parameter>
   </input-defaults>
   
-  <!-- This block may contain some decision logic for the string replacement code 
+  <!-- This block may contain some decision logic for the string replacement code
        It runs before the standard string replacement of the defaults in the default
-       parameter list  
+       parameter list
   -->
   <interpreter-logic>
     

--- a/packages/muelu/src/Interface/FacadeClasses/def_facade_Simple2x2.xml
+++ b/packages/muelu/src/Interface/FacadeClasses/def_facade_Simple2x2.xml
@@ -29,7 +29,7 @@
       <type>int</type>
       <default>0</default>
       <description>Level of fill for ILU</description>
-    </parameter>   
+    </parameter>
     <parameter>
       <name>Block 1: relaxation: sweeps</name>
       <type>int</type>
@@ -108,9 +108,9 @@
     </parameter>
   </input-defaults>
   
-  <!-- This block may contain some decision logic for the string replacement code 
+  <!-- This block may contain some decision logic for the string replacement code
        It runs before the standard string replacement of the defaults in the default
-       parameter list  
+       parameter list
   -->
   <interpreter-logic>
     

--- a/packages/muelu/src/Interface/MueLu_HierarchyManager.hpp
+++ b/packages/muelu/src/Interface/MueLu_HierarchyManager.hpp
@@ -248,12 +248,12 @@ namespace MueLu {
       }
 
       // Matrices to print
-      for(auto iter=matricesToPrint_.begin(); iter!=matricesToPrint_.end(); iter++) 
+      for(auto iter=matricesToPrint_.begin(); iter!=matricesToPrint_.end(); iter++)
         ExportDataSetKeepFlags(H,iter->second,iter->first);
 
       // Vectors, aggregates and other things that need special case handling
       ExportDataSetKeepFlags(H, nullspaceToPrint_,  "Nullspace");
-      ExportDataSetKeepFlags(H, coordinatesToPrint_,  "Coordinates");     
+      ExportDataSetKeepFlags(H, coordinatesToPrint_,  "Coordinates");
       // NOTE: Aggregates use the next level's Factory
       ExportDataSetKeepFlagsNextLevel(H, aggregatesToPrint_,  "Aggregates");
 #ifdef HAVE_MUELU_INTREPID2
@@ -261,7 +261,7 @@ namespace MueLu {
 #endif
 
       // Data to save only (these do not have a level, so we do all levels)
-      for(int i=0; i<dataToSave_.size(); i++) 
+      for(int i=0; i<dataToSave_.size(); i++)
         ExportDataSetKeepFlagsAll(H,dataToSave_[i]);
 
       int  levelID     = 0;
@@ -382,7 +382,7 @@ namespace MueLu {
     Teuchos::Array<int> elementToNodeMapsToPrint_;
 
     // Data we'll need to save, not necessarily print
-    Teuchos::Array<std::string> dataToSave_;   
+    Teuchos::Array<std::string> dataToSave_;
 
     // Matrices we'll need to print
     std::map<std::string,Teuchos::Array<int> > matricesToPrint_;

--- a/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_decl.hpp
+++ b/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_decl.hpp
@@ -236,9 +236,9 @@ namespace MueLu {
                                            int levelID, std::vector<keep_pair>& keeps) const;
     void UpdateFactoryManager_Nullspace(Teuchos::ParameterList& paramList, const Teuchos::ParameterList& defaultList, FactoryManager& manager,
                                         int levelID, std::vector<keep_pair>& keeps, RCP<Factory> & nullSpaceFactory) const;
-    void UpdateFactoryManager_BlockNumber(Teuchos::ParameterList& paramList, const Teuchos::ParameterList& defaultList, 
+    void UpdateFactoryManager_BlockNumber(Teuchos::ParameterList& paramList, const Teuchos::ParameterList& defaultList,
                                           FactoryManager& manager,int levelID, std::vector<keep_pair>& keeps) const;
-    void UpdateFactoryManager_LocalOrdinalTransfer(const std::string& VarName, const std::string& multigridAlgo, Teuchos::ParameterList& paramList, const Teuchos::ParameterList& defaultList, 
+    void UpdateFactoryManager_LocalOrdinalTransfer(const std::string& VarName, const std::string& multigridAlgo, Teuchos::ParameterList& paramList, const Teuchos::ParameterList& defaultList,
                                            FactoryManager& manager,int levelID, std::vector<keep_pair>& keeps) const;
 
     // Algorithm-specific components for UpdateFactoryManager

--- a/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
+++ b/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
@@ -322,7 +322,7 @@ namespace MueLu {
     (void)MUELU_TEST_AND_SET_VAR(paramList, "debug: graph level", int, this->graphOutputLevel_);
 
     // Generic data saving (this saves the data on all levels)
-    if(paramList.isParameter("save data")) 
+    if(paramList.isParameter("save data"))
       this->dataToSave_ = Teuchos::getArrayFromStringParameter<std::string>(paramList,"save data");
 
     // Save level data

--- a/packages/muelu/src/Misc/MueLu_AggregateQualityEstimateFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_AggregateQualityEstimateFactory_def.hpp
@@ -128,7 +128,7 @@ namespace MueLu {
     }
     if(mode == "size" || mode =="both") {
       RCP<LocalOrdinalVector> aggregate_sizes = Xpetra::VectorFactory<LO,LO,GO,NO>::Build(map);
-      ComputeAggregateSizes(A,aggregates,aggregate_sizes);      
+      ComputeAggregateSizes(A,aggregates,aggregate_sizes);
       Set(currentLevel, "AggregateSizes",aggregate_sizes);
       OutputAggSizes(currentLevel, aggregate_sizes);
     }
@@ -367,7 +367,7 @@ namespace MueLu {
         for (int i=LO_ZERO;i<aggSize;++i) {
           // NOTE: In theory, the eigenvalues should be nearly real
           //TEUCHOS_ASSERT(fabs(alpha_imag[i]) <= 1e-8*fabs(alpha_real[i])); // Eigenvalues should be nearly real
-          maxEigenVal = std::max(maxEigenVal, alpha_real[i]/beta[i]);          
+          maxEigenVal = std::max(maxEigenVal, alpha_real[i]/beta[i]);
         }
         
         (agg_qualities->getDataNonConst(0))[aggId] = (MT_ONE+MT_ONE)*maxEigenVal;
@@ -391,7 +391,7 @@ namespace MueLu {
             if (minEigenVal == MT_ZERO) minEigenVal = ev;
             else minEigenVal = std::min(minEigenVal,ev);
           }
-        }        
+        }
         if(minEigenVal == MT_ZERO)  (agg_qualities->getDataNonConst(0))[aggId] = Teuchos::ScalarTraits<MT>::rmax();
         else (agg_qualities->getDataNonConst(0))[aggId] = (MT_ONE+MT_ONE) / minEigenVal;
       }
@@ -486,7 +486,7 @@ template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
     // Iterate over each node in the aggregate
     auto data = agg_sizes->getDataNonConst(0);
     for (LO i=0; i<(LO)aggSizes.size(); i++)
-      data[i] = aggSizes[i];      
+      data[i] = aggSizes[i];
 }
 
 

--- a/packages/muelu/src/Misc/MueLu_LocalOrdinalTransferFactory_decl.hpp
+++ b/packages/muelu/src/Misc/MueLu_LocalOrdinalTransferFactory_decl.hpp
@@ -102,7 +102,7 @@ namespace MueLu {
 #undef MUELU_LOCALORDINALTRANSFERFACTORY_SHORT
 #include "MueLu_UseShortNamesOrdinal.hpp"
 
-  public:    
+  public:
     //! @name Constructors/Destructors.
     //@{
 
@@ -117,7 +117,7 @@ namespace MueLu {
        The operator associated with <tt>projectionName</tt> will be applied to the MultiVector associated with
        <tt>vectorName</tt>.
     */
-    LocalOrdinalTransferFactory(const std::string & TransferVecName, const std::string & mode): TransferVecName_(TransferVecName) { 
+    LocalOrdinalTransferFactory(const std::string & TransferVecName, const std::string & mode): TransferVecName_(TransferVecName) {
       if(mode == "classical") useAggregatesMode_ = false;
       else useAggregatesMode_ = true;
     }

--- a/packages/muelu/src/Misc/MueLu_LocalOrdinalTransferFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_LocalOrdinalTransferFactory_def.hpp
@@ -83,7 +83,7 @@ namespace MueLu {
         Input(fineLevel, TransferVecName_);
         Input(fineLevel, "CoarseMap");
 
-        if(useAggregatesMode_) 
+        if(useAggregatesMode_)
           Input(fineLevel, "Aggregates");
         else {
           Input(coarseLevel, "P Graph");
@@ -234,7 +234,7 @@ namespace MueLu {
    
     // Fill in coarse TV
     size_t error_count = 0;
-    for (LO lnode = 0; lnode < vertex2AggID.size(); lnode++) {      
+    for (LO lnode = 0; lnode < vertex2AggID.size(); lnode++) {
       if (procWinner[lnode] == myPID &&
           //lnode < vertex2AggID.size() &&
           lnode < fineData.size() && // TAW do not access off-processor data
@@ -242,7 +242,7 @@ namespace MueLu {
         if(coarseData[vertex2AggID[lnode]] == LO_INVALID)
           coarseData[vertex2AggID[lnode]] = fineData[lnode];
         if(coarseData[vertex2AggID[lnode]] != fineData[lnode])
-          error_count++;        
+          error_count++;
       }
     }
 

--- a/packages/muelu/src/Misc/MueLu_RAPFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_RAPFactory_def.hpp
@@ -286,7 +286,7 @@ namespace MueLu {
           Xpetra::TripleMatrixMultiply<SC,LO,GO,NO>::
             MultiplyRAP(*P, doTranspose, *A, !doTranspose, *P, !doTranspose, *Ac, doFillComplete,
                         doOptimizeStorage, labelstr+std::string("MueLu::R*A*P-implicit-")+levelstr.str(),
-                        RAPparams);         
+                        RAPparams);
         } else {
           RCP<Matrix> R = Get< RCP<Matrix> >(coarseLevel, "R");
           Ac = MatrixFactory::Build(R->getRowMap(), Teuchos::as<LO>(0));

--- a/packages/muelu/src/MueCentral/MueLu_MasterList.cpp
+++ b/packages/muelu/src/MueCentral/MueLu_MasterList.cpp
@@ -119,53 +119,53 @@ namespace MueLu {
     // put in auto-generated code here
 
 
-    if (name == "output filename") { ss << "<Parameter name=\"output filename\" type=\"string\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "number of equations") { ss << "<Parameter name=\"number of equations\" type=\"int\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "max levels") { ss << "<Parameter name=\"max levels\" type=\"int\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "W cycle start level") { ss << "<Parameter name=\"W cycle start level\" type=\"int\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "coarse grid correction scaling factor") { ss << "<Parameter name=\"coarse grid correction scaling factor\" type=\"double\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "fuse prolongation and update") { ss << "<Parameter name=\"fuse prolongation and update\" type=\"bool\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "number of vectors") { ss << "<Parameter name=\"number of vectors\" type=\"int\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "problem: symmetric") { ss << "<Parameter name=\"problem: symmetric\" type=\"bool\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "hierarchy label") { ss << "<Parameter name=\"hierarchy label\" type=\"string\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "aggregation: drop tol") { ss << "<Parameter name=\"aggregation: drop tol\" type=\"double\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "print initial parameters") { ss << "<Parameter name=\"print initial parameters\" type=\"bool\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "print unused parameters") { ss << "<Parameter name=\"print unused parameters\" type=\"bool\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "sa: damping factor") { ss << "<Parameter name=\"sa: damping factor\" type=\"double\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "sa: use filtered matrix") { ss << "<Parameter name=\"sa: use filtered matrix\" type=\"bool\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "sa: eigenvalue estimate num iterations") { ss << "<Parameter name=\"sa: eigenvalue estimate num iterations\" type=\"int\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "sa: use rowsumabs diagonal scaling") { ss << "<Parameter name=\"sa: use rowsumabs diagonal scaling\" type=\"bool\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "sa: enforce constraints") { ss << "<Parameter name=\"sa: enforce constraints\" type=\"bool\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "sa: max eigenvalue") { ss << "<Parameter name=\"sa: max eigenvalue\" type=\"double\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "sa: rowsumabs diagonal replacement tolerance") { ss << "<Parameter name=\"sa: rowsumabs diagonal replacement tolerance\" type=\"double\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "sa: rowsumabs use automatic diagonal tolerance") { ss << "<Parameter name=\"sa: rowsumabs use automatic diagonal tolerance\" type=\"bool\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "sa: rowsumabs diagonal replacement value") { ss << "<Parameter name=\"sa: rowsumabs diagonal replacement value\" type=\"double\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "sa: rowsumabs replace single entry row with zero") { ss << "<Parameter name=\"sa: rowsumabs replace single entry row with zero\" type=\"bool\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "pcoarsen: element") { ss << "<Parameter name=\"pcoarsen: element\" type=\"string\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "pcoarsen: schedule") { ss << "<Parameter name=\"pcoarsen: schedule\" type=\"string\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "pcoarsen: hi basis") { ss << "<Parameter name=\"pcoarsen: hi basis\" type=\"string\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "pcoarsen: lo basis") { ss << "<Parameter name=\"pcoarsen: lo basis\" type=\"string\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "smoother: neighborhood type") { ss << "<Parameter name=\"smoother: neighborhood type\" type=\"string\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "tentative: calculate qr") { ss << "<Parameter name=\"tentative: calculate qr\" type=\"bool\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "tentative: constant column sums") { ss << "<Parameter name=\"tentative: constant column sums\" type=\"bool\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "repartition: enable") { ss << "<Parameter name=\"repartition: enable\" type=\"bool\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "repartition: start level") { ss << "<Parameter name=\"repartition: start level\" type=\"int\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "repartition: use map") { ss << "<Parameter name=\"repartition: use map\" type=\"bool\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "repartition: use subcommunicators in place") { ss << "<Parameter name=\"repartition: use subcommunicators in place\" type=\"bool\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "repartition: node repartition level") { ss << "<Parameter name=\"repartition: node repartition level\" type=\"int\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "repartition: node id") { ss << "<Parameter name=\"repartition: node id\" type=\"int\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "repartition: min rows per proc") { ss << "<Parameter name=\"repartition: min rows per proc\" type=\"int\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "repartition: max imbalance") { ss << "<Parameter name=\"repartition: max imbalance\" type=\"double\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "use external multigrid package") { ss << "<Parameter name=\"use external multigrid package\" type=\"string\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "maxwell1: dump matrices") { ss << "<Parameter name=\"maxwell1: dump matrices\" type=\"bool\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "refmaxwell: mode") { ss << "<Parameter name=\"refmaxwell: mode\" type=\"string\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "refmaxwell: disable addon") { ss << "<Parameter name=\"refmaxwell: disable addon\" type=\"bool\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "refmaxwell: use as preconditioner") { ss << "<Parameter name=\"refmaxwell: use as preconditioner\" type=\"bool\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "refmaxwell: dump matrices") { ss << "<Parameter name=\"refmaxwell: dump matrices\" type=\"bool\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "refmaxwell: subsolves on subcommunicators") { ss << "<Parameter name=\"refmaxwell: subsolves on subcommunicators\" type=\"bool\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "refmaxwell: enable reuse") { ss << "<Parameter name=\"refmaxwell: enable reuse\" type=\"bool\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "refmaxwell: skip first (1,1) level") { ss << "<Parameter name=\"refmaxwell: skip first (1,1) level\" type=\"bool\" value=" << value << "/>"; return ss.str(); }      
-    if (name == "refmaxwell: normalize nullspace") { ss << "<Parameter name=\"refmaxwell: normalize nullspace\" type=\"bool\" value=" << value << "/>"; return ss.str(); }      
+    if (name == "output filename") { ss << "<Parameter name=\"output filename\" type=\"string\" value=" << value << "/>"; return ss.str(); }
+    if (name == "number of equations") { ss << "<Parameter name=\"number of equations\" type=\"int\" value=" << value << "/>"; return ss.str(); }
+    if (name == "max levels") { ss << "<Parameter name=\"max levels\" type=\"int\" value=" << value << "/>"; return ss.str(); }
+    if (name == "W cycle start level") { ss << "<Parameter name=\"W cycle start level\" type=\"int\" value=" << value << "/>"; return ss.str(); }
+    if (name == "coarse grid correction scaling factor") { ss << "<Parameter name=\"coarse grid correction scaling factor\" type=\"double\" value=" << value << "/>"; return ss.str(); }
+    if (name == "fuse prolongation and update") { ss << "<Parameter name=\"fuse prolongation and update\" type=\"bool\" value=" << value << "/>"; return ss.str(); }
+    if (name == "number of vectors") { ss << "<Parameter name=\"number of vectors\" type=\"int\" value=" << value << "/>"; return ss.str(); }
+    if (name == "problem: symmetric") { ss << "<Parameter name=\"problem: symmetric\" type=\"bool\" value=" << value << "/>"; return ss.str(); }
+    if (name == "hierarchy label") { ss << "<Parameter name=\"hierarchy label\" type=\"string\" value=" << value << "/>"; return ss.str(); }
+    if (name == "aggregation: drop tol") { ss << "<Parameter name=\"aggregation: drop tol\" type=\"double\" value=" << value << "/>"; return ss.str(); }
+    if (name == "print initial parameters") { ss << "<Parameter name=\"print initial parameters\" type=\"bool\" value=" << value << "/>"; return ss.str(); }
+    if (name == "print unused parameters") { ss << "<Parameter name=\"print unused parameters\" type=\"bool\" value=" << value << "/>"; return ss.str(); }
+    if (name == "sa: damping factor") { ss << "<Parameter name=\"sa: damping factor\" type=\"double\" value=" << value << "/>"; return ss.str(); }
+    if (name == "sa: use filtered matrix") { ss << "<Parameter name=\"sa: use filtered matrix\" type=\"bool\" value=" << value << "/>"; return ss.str(); }
+    if (name == "sa: eigenvalue estimate num iterations") { ss << "<Parameter name=\"sa: eigenvalue estimate num iterations\" type=\"int\" value=" << value << "/>"; return ss.str(); }
+    if (name == "sa: use rowsumabs diagonal scaling") { ss << "<Parameter name=\"sa: use rowsumabs diagonal scaling\" type=\"bool\" value=" << value << "/>"; return ss.str(); }
+    if (name == "sa: enforce constraints") { ss << "<Parameter name=\"sa: enforce constraints\" type=\"bool\" value=" << value << "/>"; return ss.str(); }
+    if (name == "sa: max eigenvalue") { ss << "<Parameter name=\"sa: max eigenvalue\" type=\"double\" value=" << value << "/>"; return ss.str(); }
+    if (name == "sa: rowsumabs diagonal replacement tolerance") { ss << "<Parameter name=\"sa: rowsumabs diagonal replacement tolerance\" type=\"double\" value=" << value << "/>"; return ss.str(); }
+    if (name == "sa: rowsumabs use automatic diagonal tolerance") { ss << "<Parameter name=\"sa: rowsumabs use automatic diagonal tolerance\" type=\"bool\" value=" << value << "/>"; return ss.str(); }
+    if (name == "sa: rowsumabs diagonal replacement value") { ss << "<Parameter name=\"sa: rowsumabs diagonal replacement value\" type=\"double\" value=" << value << "/>"; return ss.str(); }
+    if (name == "sa: rowsumabs replace single entry row with zero") { ss << "<Parameter name=\"sa: rowsumabs replace single entry row with zero\" type=\"bool\" value=" << value << "/>"; return ss.str(); }
+    if (name == "pcoarsen: element") { ss << "<Parameter name=\"pcoarsen: element\" type=\"string\" value=" << value << "/>"; return ss.str(); }
+    if (name == "pcoarsen: schedule") { ss << "<Parameter name=\"pcoarsen: schedule\" type=\"string\" value=" << value << "/>"; return ss.str(); }
+    if (name == "pcoarsen: hi basis") { ss << "<Parameter name=\"pcoarsen: hi basis\" type=\"string\" value=" << value << "/>"; return ss.str(); }
+    if (name == "pcoarsen: lo basis") { ss << "<Parameter name=\"pcoarsen: lo basis\" type=\"string\" value=" << value << "/>"; return ss.str(); }
+    if (name == "smoother: neighborhood type") { ss << "<Parameter name=\"smoother: neighborhood type\" type=\"string\" value=" << value << "/>"; return ss.str(); }
+    if (name == "tentative: calculate qr") { ss << "<Parameter name=\"tentative: calculate qr\" type=\"bool\" value=" << value << "/>"; return ss.str(); }
+    if (name == "tentative: constant column sums") { ss << "<Parameter name=\"tentative: constant column sums\" type=\"bool\" value=" << value << "/>"; return ss.str(); }
+    if (name == "repartition: enable") { ss << "<Parameter name=\"repartition: enable\" type=\"bool\" value=" << value << "/>"; return ss.str(); }
+    if (name == "repartition: start level") { ss << "<Parameter name=\"repartition: start level\" type=\"int\" value=" << value << "/>"; return ss.str(); }
+    if (name == "repartition: use map") { ss << "<Parameter name=\"repartition: use map\" type=\"bool\" value=" << value << "/>"; return ss.str(); }
+    if (name == "repartition: use subcommunicators in place") { ss << "<Parameter name=\"repartition: use subcommunicators in place\" type=\"bool\" value=" << value << "/>"; return ss.str(); }
+    if (name == "repartition: node repartition level") { ss << "<Parameter name=\"repartition: node repartition level\" type=\"int\" value=" << value << "/>"; return ss.str(); }
+    if (name == "repartition: node id") { ss << "<Parameter name=\"repartition: node id\" type=\"int\" value=" << value << "/>"; return ss.str(); }
+    if (name == "repartition: min rows per proc") { ss << "<Parameter name=\"repartition: min rows per proc\" type=\"int\" value=" << value << "/>"; return ss.str(); }
+    if (name == "repartition: max imbalance") { ss << "<Parameter name=\"repartition: max imbalance\" type=\"double\" value=" << value << "/>"; return ss.str(); }
+    if (name == "use external multigrid package") { ss << "<Parameter name=\"use external multigrid package\" type=\"string\" value=" << value << "/>"; return ss.str(); }
+    if (name == "maxwell1: dump matrices") { ss << "<Parameter name=\"maxwell1: dump matrices\" type=\"bool\" value=" << value << "/>"; return ss.str(); }
+    if (name == "refmaxwell: mode") { ss << "<Parameter name=\"refmaxwell: mode\" type=\"string\" value=" << value << "/>"; return ss.str(); }
+    if (name == "refmaxwell: disable addon") { ss << "<Parameter name=\"refmaxwell: disable addon\" type=\"bool\" value=" << value << "/>"; return ss.str(); }
+    if (name == "refmaxwell: use as preconditioner") { ss << "<Parameter name=\"refmaxwell: use as preconditioner\" type=\"bool\" value=" << value << "/>"; return ss.str(); }
+    if (name == "refmaxwell: dump matrices") { ss << "<Parameter name=\"refmaxwell: dump matrices\" type=\"bool\" value=" << value << "/>"; return ss.str(); }
+    if (name == "refmaxwell: subsolves on subcommunicators") { ss << "<Parameter name=\"refmaxwell: subsolves on subcommunicators\" type=\"bool\" value=" << value << "/>"; return ss.str(); }
+    if (name == "refmaxwell: enable reuse") { ss << "<Parameter name=\"refmaxwell: enable reuse\" type=\"bool\" value=" << value << "/>"; return ss.str(); }
+    if (name == "refmaxwell: skip first (1,1) level") { ss << "<Parameter name=\"refmaxwell: skip first (1,1) level\" type=\"bool\" value=" << value << "/>"; return ss.str(); }
+    if (name == "refmaxwell: normalize nullspace") { ss << "<Parameter name=\"refmaxwell: normalize nullspace\" type=\"bool\" value=" << value << "/>"; return ss.str(); }
     return "";
   }
 

--- a/packages/muelu/src/Operators/MueLu_Maxwell1_decl.hpp
+++ b/packages/muelu/src/Operators/MueLu_Maxwell1_decl.hpp
@@ -218,8 +218,8 @@ namespace MueLu {
                   MultiVector & R) const {
       using STS = Teuchos::ScalarTraits<Scalar>;
       R.update(STS::one(),B,STS::zero());
-      this->apply (X, R, Teuchos::NO_TRANS, -STS::one(), STS::one());   
-    }      
+      this->apply (X, R, Teuchos::NO_TRANS, -STS::one(), STS::one());
+    }
     
 
   private:

--- a/packages/muelu/src/Operators/MueLu_Maxwell1_def.hpp
+++ b/packages/muelu/src/Operators/MueLu_Maxwell1_def.hpp
@@ -146,7 +146,7 @@ namespace MueLu {
     defaultSmootherList.set("smoother: type", "CHEBYSHEV");
     defaultSmootherList.sublist("smoother: params").set("chebyshev: degree",2);
     defaultSmootherList.sublist("smoother: params").set("chebyshev: ratio eigenvalue",7.0);
-    defaultSmootherList.sublist("smoother: params").set("chebyshev: eigenvalue max iterations",30);    
+    defaultSmootherList.sublist("smoother: params").set("chebyshev: eigenvalue max iterations",30);
 
     // Make sure verbosity gets passed to the sublists
     std::string verbosity = list.get("verbosity","high");
@@ -165,8 +165,8 @@ namespace MueLu {
     if(list.isSublist("maxwell1: 22list"))
       precList22_     =  list.sublist("maxwell1: 22list");
     else if(list.isSublist("refmaxwell: 22list"))
-      precList22_     =  list.sublist("refmaxwell: 22list");   
-    if(mode_ == MODE_EDGE_ONLY || mode_ == MODE_STANDARD) 
+      precList22_     =  list.sublist("refmaxwell: 22list");
+    if(mode_ == MODE_EDGE_ONLY || mode_ == MODE_STANDARD)
       precList22_.set("smoother: pre or post","none");
     else if(!precList22_.isType<std::string>("Preconditioner Type") &&
        !precList22_.isType<std::string>("smoother: type") &&
@@ -180,9 +180,9 @@ namespace MueLu {
     // For the (1,1) hierarchy we'll use Hiptmair (STANDARD) or Chebyshev (EDGE_ONLY / REFMAXWELL) if
     // the user doesn't specify things
     if(list.isSublist("maxwell1: 11list"))
-      precList11_     =  list.sublist("maxwell1: 11list");   
+      precList11_     =  list.sublist("maxwell1: 11list");
     else if(list.isSublist("refmaxwell: 11list"))
-      precList11_     =  list.sublist("refmaxwell: 11list");   
+      precList11_     =  list.sublist("refmaxwell: 11list");
     if(!precList11_.isType<std::string>("Preconditioner Type") &&
        !precList11_.isType<std::string>("smoother: type") &&
        !precList11_.isType<std::string>("smoother: pre type") &&
@@ -349,7 +349,7 @@ namespace MueLu {
 
     /* Repartitioning *must* be in sync between hierarchies, but the
      only thing we need to watch here is the subcomms, since ReitzingerPFactory
-     won't look at all the other stuff */    
+     won't look at all the other stuff */
     if(precList22_.isParameter("repartition: enable")) {
       bool repartition = precList22_.get<bool>("repartition: enable");
       precList11_.set("repartition: enable",repartition);
@@ -363,7 +363,7 @@ namespace MueLu {
         
         // We do not want (1,1) and (2,2) blocks being repartitioned seperately, so we specify the map that
         // is going to be used (this is generated in ReitzingerPFactory)
-        if(precList11_.get<bool>("repartition: use subcommunicators")==true) 
+        if(precList11_.get<bool>("repartition: use subcommunicators")==true)
           precList11_.set("repartition: use subcommunicators in place",true);
       }
       else {
@@ -374,7 +374,7 @@ namespace MueLu {
         // We do not want (1,1) and (2,2) blocks being repartitioned seperately, so we specify the map that
         // is going to be used (this is generated in ReitzingerPFactory)
         precList11_.set("repartition: use subcommunicators in place",true);
-      }        
+      }
 
         
     }
@@ -411,11 +411,11 @@ namespace MueLu {
         EdgeL->Set("D0", D0_Matrix_);
       }
       else {
-        EdgeL->Set("Pnodal",NodeL->Get<RCP<Matrix> >("P"));    
+        EdgeL->Set("Pnodal",NodeL->Get<RCP<Matrix> >("P"));
         /*
-        auto P = NodeL->Get<RCP<Matrix> >("P");        
+        auto P = NodeL->Get<RCP<Matrix> >("P");
         int Pn_r = P.is_null() ? 0 : (int) P->getRangeMap()->getLocalNumElements();
-        int Pn_d = P.is_null() ? 0 : (int) P->getDomainMap()->getLocalNumElements();          
+        int Pn_d = P.is_null() ? 0 : (int) P->getDomainMap()->getLocalNumElements();
         printf("[%d] Local Level %d: Pn = %d x %d\n",SM_Matrix_->getRowMap()->getComm()->getRank(),i,Pn_r,Pn_d);
         fflush(stdout);
         */
@@ -520,11 +520,11 @@ namespace MueLu {
   template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void Maxwell1<Scalar,LocalOrdinal,GlobalOrdinal,Node>::allocateMemory(int numVectors) const {
     if(mode_ == MODE_REFMAXWELL) {
-      RCP<Teuchos::TimeMonitor> tmAlloc = getTimer("MueLu Maxwell1: Allocate MVs");      
+      RCP<Teuchos::TimeMonitor> tmAlloc = getTimer("MueLu Maxwell1: Allocate MVs");
 
       residualFine_ = MultiVectorFactory::Build(SM_Matrix_->getRangeMap(), numVectors);
      
-      if(!Hierarchy11_.is_null() && Hierarchy11_->GetNumLevels() > 1) { 
+      if(!Hierarchy11_.is_null() && Hierarchy11_->GetNumLevels() > 1) {
         RCP<Level> EdgeL = Hierarchy11_->GetLevel(1);
         RCP<Matrix> A = EdgeL->Get<RCP<Matrix> >("A");
         residual11c_ = MultiVectorFactory::Build(A->getRangeMap(), numVectors);
@@ -627,7 +627,7 @@ namespace MueLu {
     if (!allEdgesBoundary_ && X.getNumVectors() != residualFine_->getNumVectors())
       allocateMemory(X.getNumVectors());
 
-    TEUCHOS_TEST_FOR_EXCEPTION(Hierarchy11_.is_null() || Hierarchy11_->GetNumLevels() == 0, Exceptions::RuntimeError, "(1,1) Hiearchy is null.");    
+    TEUCHOS_TEST_FOR_EXCEPTION(Hierarchy11_.is_null() || Hierarchy11_->GetNumLevels() == 0, Exceptions::RuntimeError, "(1,1) Hiearchy is null.");
 
     // 1) Run fine pre-smoother using Hierarchy11
     RCP<Level> Fine = Hierarchy11_->GetLevel(0);
@@ -660,9 +660,9 @@ namespace MueLu {
     // 4) Prolong both updates back into X-vector (Need to do both the P11 null and not null cases
     {
       RCP<Teuchos::TimeMonitor> tmRes = getTimer("MueLu Maxwell1: Orolongation");
-      if(!P11_.is_null()) 
+      if(!P11_.is_null())
         P11_->apply(*update11c_,X,Teuchos::NO_TRANS,one,one);
-      if (!allNodesBoundary_) 
+      if (!allNodesBoundary_)
         D0_Matrix_->apply(*update22_,X,Teuchos::NO_TRANS,one,one);
     }
 
@@ -692,7 +692,7 @@ namespace MueLu {
     else if(mode_ == MODE_REFMAXWELL)
       applyInverseRefMaxwellAdditive(RHS,X);
     else
-      TEUCHOS_TEST_FOR_EXCEPTION(true, Exceptions::RuntimeError, "Must use mode 'standard', 'refmaxwell' or 'edge only'.");    
+      TEUCHOS_TEST_FOR_EXCEPTION(true, Exceptions::RuntimeError, "Must use mode 'standard', 'refmaxwell' or 'edge only'.");
   }
 
 
@@ -729,7 +729,7 @@ namespace MueLu {
     mode_          = MODE_STANDARD;
 
     // Default settings
-    useKokkos_=false; 
+    useKokkos_=false;
     allEdgesBoundary_=false;
     allNodesBoundary_=false;
     dump_matrices_ = false;

--- a/packages/muelu/src/Operators/MueLu_Maxwell_Utils_decl.hpp
+++ b/packages/muelu/src/Operators/MueLu_Maxwell_Utils_decl.hpp
@@ -91,11 +91,11 @@ namespace MueLu {
                                            magnitudeType rowSumTol,
 #ifdef HAVE_MUELU_KOKKOS_REFACTOR
                                            bool useKokkos_,
-                                           Kokkos::View<bool*, typename Node::device_type> & BCrowsKokkos, 
-                                           Kokkos::View<bool*, typename Node::device_type> & BCcolsKokkos,   
+                                           Kokkos::View<bool*, typename Node::device_type> & BCrowsKokkos,
+                                           Kokkos::View<bool*, typename Node::device_type> & BCcolsKokkos,
                                            Kokkos::View<bool*, typename Node::device_type> & BCdomainKokkos,
 #endif
-                                           int & BCedges, 
+                                           int & BCedges,
                                            int & BCnodes,
                                            Teuchos::ArrayRCP<bool> & BCrows,
                                            Teuchos::ArrayRCP<bool> & BCcols,

--- a/packages/muelu/src/Operators/MueLu_Maxwell_Utils_def.hpp
+++ b/packages/muelu/src/Operators/MueLu_Maxwell_Utils_def.hpp
@@ -74,11 +74,11 @@ namespace MueLu {
                                                                                          magnitudeType rowSumTol,
 #ifdef HAVE_MUELU_KOKKOS_REFACTOR
                                                                                          bool useKokkos_,
-                                                                                         Kokkos::View<bool*, typename Node::device_type> & BCrowsKokkos_, 
-                                                                                         Kokkos::View<bool*, typename Node::device_type> & BCcolsKokkos_,   
+                                                                                         Kokkos::View<bool*, typename Node::device_type> & BCrowsKokkos_,
+                                                                                         Kokkos::View<bool*, typename Node::device_type> & BCcolsKokkos_,
                                                                                          Kokkos::View<bool*, typename Node::device_type> & BCdomainKokkos_,
 #endif
-                                                                                         int & BCedges_, 
+                                                                                         int & BCedges_,
                                                                                          int & BCnodes_,
                                                                                          Teuchos::ArrayRCP<bool> & BCrows_,
                                                                                          Teuchos::ArrayRCP<bool> & BCcols_,
@@ -147,7 +147,7 @@ namespace MueLu {
                                                                                   RCP<Matrix> & D0_Matrix_,
                                                                                   RCP<Matrix> & SM_Matrix_,
                                                                                   RCP<Matrix> & M1_Matrix_,
-                                                                                  RCP<Matrix> & Ms_Matrix_) {    
+                                                                                  RCP<Matrix> & Ms_Matrix_) {
 
     bool defaultFilter = false;
 

--- a/packages/muelu/src/Operators/MueLu_RefMaxwell_decl.hpp
+++ b/packages/muelu/src/Operators/MueLu_RefMaxwell_decl.hpp
@@ -333,8 +333,8 @@ namespace MueLu {
                   MultiVector & R) const {
       using STS = Teuchos::ScalarTraits<Scalar>;
       R.update(STS::one(),B,STS::zero());
-      this->apply (X, R, Teuchos::NO_TRANS, -STS::one(), STS::one());   
-    }      
+      this->apply (X, R, Teuchos::NO_TRANS, -STS::one(), STS::one());
+    }
     
 
   private:

--- a/packages/muelu/src/Rebalancing/MueLu_RebalanceAcFactory_def.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_RebalanceAcFactory_def.hpp
@@ -89,7 +89,7 @@ namespace MueLu {
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void RebalanceAcFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(Level &/* fineLevel */, Level &coarseLevel) const {
-    FactoryMonitor m(*this, "Computing Ac", coarseLevel);    
+    FactoryMonitor m(*this, "Computing Ac", coarseLevel);
     
     const Teuchos::ParameterList & pL = GetParameterList();
     RCP<Matrix> originalAc = Get< RCP<Matrix> >(coarseLevel, "A");
@@ -106,7 +106,7 @@ namespace MueLu {
       // The "in place" still leaves a dummy matrix here.  That needs to go
       if(newMap.is_null()) originalAc = Teuchos::null;
 
-      Set(coarseLevel, "A", originalAc);      
+      Set(coarseLevel, "A", originalAc);
       return;
     }
 

--- a/packages/muelu/src/Rebalancing/MueLu_RebalanceBlockInterpolationFactory_def.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_RebalanceBlockInterpolationFactory_def.hpp
@@ -233,7 +233,7 @@ void RebalanceBlockInterpolationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Nod
 
       // rebalance coordinates
       // TAW: Note, that each sub-block manager overwrites the Coordinates. So far we only support one set of Coordinates
-      //      for a multiphysics problem (i.e., we only support volume coupled problems with the same mesh)   
+      //      for a multiphysics problem (i.e., we only support volume coupled problems with the same mesh)
       if(UseSingleSource)  {
 	RCP<xdMV> localCoords = oldCoordinates->getMultiVector(curBlockId);
 

--- a/packages/muelu/src/Rebalancing/MueLu_RepartitionBlockDiagonalFactory_def.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_RepartitionBlockDiagonalFactory_def.hpp
@@ -80,10 +80,10 @@ namespace MueLu {
     FactoryMonitor m(*this, "Build", currentLevel);
     typedef Xpetra::BlockedCrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>  BlockCrs;
 
-    RCP<Matrix> originalA = Get< RCP<Matrix> >(currentLevel, "A");    
+    RCP<Matrix> originalA = Get< RCP<Matrix> >(currentLevel, "A");
     RCP<BlockCrs> A = Teuchos::rcp_dynamic_cast<BlockCrs>(originalA);
 
-    //    RCP<BlockCrs> A = Get< RCP<BlockCrs> >(currentLevel, "A");    
+    //    RCP<BlockCrs> A = Get< RCP<BlockCrs> >(currentLevel, "A");
     TEUCHOS_TEST_FOR_EXCEPTION(A==Teuchos::null, Exceptions::BadCast, "MueLu::RepartitionBlockDiagonalFactory::Build: input matrix A is not of type BlockedCrsMatrix! error.");
 
     // Build the block diagonal

--- a/packages/muelu/src/Rebalancing/MueLu_RepartitionFactory_def.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_RepartitionFactory_def.hpp
@@ -375,7 +375,7 @@ namespace MueLu {
       SubFactoryMonitor m1(*this, "Blocking newRowMap and Importer", currentLevel);
       RCP<const BlockedMap> blockedTargetMap = MueLu::UtilitiesBase<Scalar,LocalOrdinal,GlobalOrdinal,Node>::GeneratedBlockedTargetMap(*blockedRowMap,*rowMapImporter);
 
-      // NOTE: This code qualifies as "correct but not particularly performant"  If this needs to be sped up, we can probably read data from the existing importer to 
+      // NOTE: This code qualifies as "correct but not particularly performant"  If this needs to be sped up, we can probably read data from the existing importer to
       // build sub-importers rather than generating new ones ex nihilo
       size_t numBlocks = blockedRowMap->getNumMaps();
       std::vector<RCP<const Import> > subImports(numBlocks);

--- a/packages/muelu/src/Rebalancing/MueLu_RepartitionHeuristicFactory_def.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_RepartitionHeuristicFactory_def.hpp
@@ -184,7 +184,7 @@ namespace MueLu {
     // a decision on whether to repartition. However, there is value in knowing how "close" we are to having to
     // rebalance an operator. So, it would probably be beneficial to do and report *all* tests.
 
-    // Test0: Should we do node repartitioning? 
+    // Test0: Should we do node repartitioning?
     if (currentLevel.GetLevelID() == nodeRepartLevel && map->getComm()->getSize() > 1) {
       RCP<const Teuchos::Comm<int> > NodeComm = Get< RCP<const Teuchos::Comm<int> > >(currentLevel, "Node Comm");
       TEUCHOS_TEST_FOR_EXCEPTION(NodeComm.is_null(), Exceptions::RuntimeError, "MueLu::RepartitionHeuristicFactory::Build(): NodeComm is null.");
@@ -201,9 +201,9 @@ namespace MueLu {
         Set(currentLevel, "number of partitions", numNodes);
         return;
       }
-    }  
+    }
 
-    // Test1: skip repartitioning if current level is less than the specified minimum level for repartitioning     
+    // Test1: skip repartitioning if current level is less than the specified minimum level for repartitioning
     if (currentLevel.GetLevelID() < startLevel) {
       GetOStream(Statistics1) << "Repartitioning?  NO:" <<
           "\n  current level = " << Teuchos::toString(currentLevel.GetLevelID()) <<

--- a/packages/muelu/src/Smoothers/MueLu_Ifpack2Smoother_def.hpp
+++ b/packages/muelu/src/Smoothers/MueLu_Ifpack2Smoother_def.hpp
@@ -237,7 +237,7 @@ namespace MueLu {
         RCP<TpetraCrsMatrix> At = rcp_dynamic_cast<TpetraCrsMatrix>(Acrs);
         if(At.is_null()) {
           if(!Xpetra::Helpers<Scalar,LO,GO,Node>::isTpetraBlockCrs(matA))
-            throw std::runtime_error("Ifpack2Smoother: Cannot extract CrsMatrix or BlockCrsMatrix from matrix A.");          
+            throw std::runtime_error("Ifpack2Smoother: Cannot extract CrsMatrix or BlockCrsMatrix from matrix A.");
           this->GetOStream(Statistics0) << "Ifpack2Smoother: Using (native) BlockCrsMatrix storage with blocksize "<<blocksize<<std::endl;
           paramList.remove("smoother: use blockcrsmatrix storage");
         }
@@ -283,7 +283,7 @@ namespace MueLu {
              type_ == "TRIDIRELAXATION" ||
              type_ == "TRIDIAGONAL_RELAXATION" ||
              type_ == "TRIDIAGONAL RELAXATION" ||
-             type_ == "TRIDIAGONALRELAXATION") 
+             type_ == "TRIDIAGONALRELAXATION")
       SetupBlockRelaxation(currentLevel);
 
     else if (type_ == "CHEBYSHEV")
@@ -297,10 +297,10 @@ namespace MueLu {
       TEUCHOS_TEST_FOR_EXCEPTION(true, std::invalid_argument, "'TOPOLOGICAL' smoother choice requires Intrepid2");
 #endif
     }
-    else if (type_ == "AGGREGATE") 
+    else if (type_ == "AGGREGATE")
       SetupAggregate(currentLevel);
 
-    else if (type_ == "HIPTMAIR") 
+    else if (type_ == "HIPTMAIR")
       SetupHiptmair(currentLevel);
 
     else
@@ -361,8 +361,8 @@ namespace MueLu {
         std::string partName = "partitioner: type";
         // Pretty sure no one has been using this. Unfortunately, old if
         // statement (which checked for equality with "user") prevented
-        // anyone from employing other types of Ifpack2 user partition 
-        // options. Leaving this and switching if to "vanka user" just 
+        // anyone from employing other types of Ifpack2 user partition
+        // options. Leaving this and switching if to "vanka user" just
         // in case some day someone might want to use this.
         if (subList.isParameter(partName) && subList.get<std::string>(partName) == "vanka user") {
           isBlockedMatrix = true;
@@ -436,7 +436,7 @@ namespace MueLu {
 
     if (this->IsSetup() == true) {
       this->GetOStream(Warnings0) << "MueLu::Ifpack2Smoother::SetupAggregate(): Setup() has already been called" << std::endl;
-      this->GetOStream(Warnings0) << "MueLu::Ifpack2Smoother::SetupAggregate(): reuse of this type is not available, reverting to full construction" << std::endl;    
+      this->GetOStream(Warnings0) << "MueLu::Ifpack2Smoother::SetupAggregate(): reuse of this type is not available, reverting to full construction" << std::endl;
     }
 
     this->GetOStream(Statistics0) << "Ifpack2Smoother: Using Aggregate Smoothing"<<std::endl;
@@ -456,7 +456,7 @@ namespace MueLu {
       dof_ids.resize(aggregate_ids.size() * blocksize);
       for(LO i=0; i<(LO)aggregate_ids.size(); i++) {
         for(LO j=0; j<(LO)blocksize; j++)
-          dof_ids[i*blocksize+j] = aggregate_ids[i];    
+          dof_ids[i*blocksize+j] = aggregate_ids[i];
       }
     }
     else {
@@ -792,12 +792,12 @@ namespace MueLu {
 
     if(smoother1 == "CHEBYSHEV") {
       ParameterList & list1 = paramList.sublist("hiptmair: smoother list 1");
-      //lambdaMax11 = 
+      //lambdaMax11 =
       SetupChebyshevEigenvalues(currentLevel,"A","EdgeMatrix ",list1);
     }
     if(smoother2 == "CHEBYSHEV") {
       ParameterList & list2 = paramList.sublist("hiptmair: smoother list 2");
-      //lambdaMax22 = 
+      //lambdaMax22 =
       SetupChebyshevEigenvalues(currentLevel,"A","EdgeMatrix ",list2);
     }
 
@@ -837,7 +837,7 @@ namespace MueLu {
     std::string maxEigString   = "chebyshev: max eigenvalue";
     std::string eigRatioString = "chebyshev: ratio eigenvalue";
     
-    // Get/calculate the maximum eigenvalue      
+    // Get/calculate the maximum eigenvalue
     if (paramList.isParameter(maxEigString)) {
       if (paramList.isType<double>(maxEigString))
         lambdaMax = paramList.get<double>(maxEigString);

--- a/packages/muelu/src/Smoothers/MueLu_IfpackSmoother.cpp
+++ b/packages/muelu/src/Smoothers/MueLu_IfpackSmoother.cpp
@@ -287,7 +287,7 @@ namespace MueLu {
 
     if (this->IsSetup() == true) {
       this->GetOStream(Warnings0) << "MueLu::Ifpack2moother::SetupAggregate(): Setup() has already been called" << std::endl;
-      this->GetOStream(Warnings0) << "MueLu::IfpackSmoother::SetupAggregate(): reuse of this type is not available, reverting to full construction" << std::endl;    
+      this->GetOStream(Warnings0) << "MueLu::IfpackSmoother::SetupAggregate(): reuse of this type is not available, reverting to full construction" << std::endl;
     }
 
     this->GetOStream(Statistics0) << "IfpackSmoother: Using Aggregate Smoothing"<<std::endl;
@@ -307,7 +307,7 @@ namespace MueLu {
       dof_ids.resize(aggregate_ids.size() * blocksize);
       for(LO i=0; i<(LO)aggregate_ids.size(); i++) {
         for(LO j=0; j<(LO)blocksize; j++)
-          dof_ids[i*blocksize+j] = aggregate_ids[i];    
+          dof_ids[i*blocksize+j] = aggregate_ids[i];
       }
     }
     else {

--- a/packages/muelu/src/Smoothers/MueLu_MergedSmoother_decl.hpp
+++ b/packages/muelu/src/Smoothers/MueLu_MergedSmoother_decl.hpp
@@ -51,7 +51,7 @@
 #include "MueLu_SmootherPrototype.hpp"
 
 /*! @class MergedSmoother
-    @ingroup MueLuSmootherClasses 
+    @ingroup MueLuSmootherClasses
 */
 
 namespace MueLu {

--- a/packages/muelu/src/Smoothers/MueLu_MergedSmoother_def.hpp
+++ b/packages/muelu/src/Smoothers/MueLu_MergedSmoother_def.hpp
@@ -214,7 +214,7 @@ namespace MueLu {
 
   template <class Scalar,class LocalOrdinal, class GlobalOrdinal, class Node>
   size_t MergedSmoother<Scalar,LocalOrdinal,GlobalOrdinal,Node>::
-  getNodeSmootherComplexity() const 
+  getNodeSmootherComplexity() const
   {
     // FIXME: This is a placeholder
     return Teuchos::OrdinalTraits<size_t>::invalid();

--- a/packages/muelu/src/Smoothers/MueLu_PermutingSmoother_decl.hpp
+++ b/packages/muelu/src/Smoothers/MueLu_PermutingSmoother_decl.hpp
@@ -73,7 +73,7 @@ namespace MueLu {
 
   /*!
     @class PermutingSmoother
-    @ingroup MueLuSmootherClasses 
+    @ingroup MueLuSmootherClasses
     @brief This class first calculates row- and column permutation operators and applies a smoother to the permuted linear system.
 
   */

--- a/packages/muelu/src/Smoothers/MueLu_ProjectorSmoother_decl.hpp
+++ b/packages/muelu/src/Smoothers/MueLu_ProjectorSmoother_decl.hpp
@@ -59,7 +59,7 @@ namespace MueLu {
 
   /*!
     @class ProjectorSmoother
-    @ingroup MueLuSmootherClasses 
+    @ingroup MueLuSmootherClasses
     @brief This class enables the elimination of the nullspace component of the solution through the use of projection
 
     The solution of the coarsest level system may have a significant nullspace component. We can try to eliminate it through the use of nullspaces.

--- a/packages/muelu/src/Smoothers/MueLu_SmootherBase.hpp
+++ b/packages/muelu/src/Smoothers/MueLu_SmootherBase.hpp
@@ -54,7 +54,7 @@
 namespace MueLu {
   /*!
     @class SmootherBase
-    @ingroup MueLuSmootherClasses 
+    @ingroup MueLuSmootherClasses
     @brief Base class for smoothers
 
     This has the signature for the required Apply function and contains data that is generic across all

--- a/packages/muelu/src/Smoothers/MueLu_SmootherFactoryBase.hpp
+++ b/packages/muelu/src/Smoothers/MueLu_SmootherFactoryBase.hpp
@@ -56,7 +56,7 @@ namespace MueLu {
 
   /*!
     @class Smoother factory base class.
-    @ingroup MueLuSmootherClasses 
+    @ingroup MueLuSmootherClasses
     @brief Base class for smoother factories.
 
     This interface inherits from SingleLevelFactoryBase and defines an additional Build method (BuildSmoother)

--- a/packages/muelu/src/Smoothers/MueLu_SmootherFactory_decl.hpp
+++ b/packages/muelu/src/Smoothers/MueLu_SmootherFactory_decl.hpp
@@ -60,7 +60,7 @@ namespace MueLu {
 
   /*!
     @class SmootherFactory
-    @ingroup MueLuSmootherClasses 
+    @ingroup MueLuSmootherClasses
     @brief Generic Smoother Factory for generating the smoothers of the MG hierarchy
 
     This factory is generic and can produce any kind of Smoother.

--- a/packages/muelu/src/Smoothers/MueLu_SmootherPrototype_decl.hpp
+++ b/packages/muelu/src/Smoothers/MueLu_SmootherPrototype_decl.hpp
@@ -57,7 +57,7 @@ namespace MueLu {
 
   /*!
     @class SmootherPrototype
-    @ingroup MueLuSmootherClasses 
+    @ingroup MueLuSmootherClasses
     @brief Base class for smoother prototypes
 
     A smoother prototype is a smoother which can be in two states:

--- a/packages/muelu/src/Smoothers/MueLu_StratimikosSmoother_def.hpp
+++ b/packages/muelu/src/Smoothers/MueLu_StratimikosSmoother_def.hpp
@@ -156,7 +156,7 @@ system(mystring);
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   void StratimikosSmoother<double, LocalOrdinal, GlobalOrdinal, Node>::ExperimentalDropVertConnections(RCP<Matrix> & filteredA, Level& currentLevel) {
 
-    // strip out the veritcal connections. 
+    // strip out the veritcal connections.
     //
     // There is some code, which is currently turned off (via sumDropped). That
     // makes things more complicated. I want to keep it for now, and so it is
@@ -164,10 +164,10 @@ system(mystring);
     // of the horizontal stencil by summing dropped entries appropriately.
     // However, this does not correspond to plane relexation, and so I am
     // not sure it is really justified. Anyway, the picture below
-    // gives a situation with a 15-pt stencil 
+    // gives a situation with a 15-pt stencil
     //
     //                              a
-    //                             / 
+    //                             /
     //                            /
     //                     b ----c----- d
     //                          /
@@ -188,17 +188,17 @@ system(mystring);
     //                         /
     //                        p
     // To do this, we use umap to record locations within the middle layer associated
-    // with each line ID (e.g. g corresponds to the 13th line). Then, when dropping (in a 2nd pass) we 
-    // use lineId and umap to find where dropped entries should be summed (e.g., b corresponds to the 
+    // with each line ID (e.g. g corresponds to the 13th line). Then, when dropping (in a 2nd pass) we
+    // use lineId and umap to find where dropped entries should be summed (e.g., b corresponds to the
     // 13th line and umap[13] points at location for g).
     // using TST = typename Teuchos::ScalarTraits<SC>;
 
-    bool sumDropped = false;           
+    bool sumDropped = false;
 
     LO dofsPerNode = A_->GetFixedBlockSize();
 
 
-    RCP<ParameterList> fillCompleteParams(new ParameterList);    // This code taken from Build method 
+    RCP<ParameterList> fillCompleteParams(new ParameterList);    // This code taken from Build method
     fillCompleteParams->set("No Nonlocal Changes", true);        // within MueLu_FilteredAFactory_def
     filteredA = MatrixFactory::Build(A_->getCrsGraph());
     filteredA->resumeFill();
@@ -231,7 +231,7 @@ system(mystring);
           jdof  = inds[j];
           jnode = jdof/dofsPerNode;
           jdof_offset = jdof - jnode*dofsPerNode;
-          if ( LayerId[jnode]  == LayerId[inode] ) umap[dofsPerNode*VertLineId[jnode]+jdof_offset] = j;  
+          if ( LayerId[jnode]  == LayerId[inode] ) umap[dofsPerNode*VertLineId[jnode]+jdof_offset] = j;
         }
       }
 
@@ -242,14 +242,14 @@ system(mystring);
         jdof_offset = jdof - jnode*dofsPerNode;
         if ( LayerId[jnode]  != LayerId[inode] ) {
           if (sumDropped) {
-            if (umap.find(dofsPerNode*VertLineId[jnode + jdof_offset]) != umap.end()) 
+            if (umap.find(dofsPerNode*VertLineId[jnode + jdof_offset]) != umap.end())
               vals[umap[dofsPerNode*VertLineId[jnode + jdof_offset]]] +=  vals[j];
           }
           vals[j] = ZERO;
         }
       }
     }
-    filteredA->fillComplete(fillCompleteParams);   
+    filteredA->fillComplete(fillCompleteParams);
 
   }
 

--- a/packages/muelu/src/Smoothers/MueLu_TrilinosSmoother_decl.hpp
+++ b/packages/muelu/src/Smoothers/MueLu_TrilinosSmoother_decl.hpp
@@ -78,7 +78,7 @@ namespace MueLu {
 
   /*!
     @class TrilinosSmoother
-    @ingroup MueLuSmootherClasses 
+    @ingroup MueLuSmootherClasses
     @brief Class that encapsulates external library smoothers.
 
     Autoselection of Ifpack or Ifpack2 according to the underlying linear algebra library.

--- a/packages/muelu/src/Smoothers/MueLu_TrilinosSmoother_def.hpp
+++ b/packages/muelu/src/Smoothers/MueLu_TrilinosSmoother_def.hpp
@@ -308,7 +308,7 @@ namespace MueLu {
     if(type == "BLOCK_RELAXATION" ||
        type == "BLOCK RELAXATION" ||
        type == "BLOCKRELAXATION" ||
-       // Banded       
+       // Banded
        type == "BANDED_RELAXATION" ||
        type == "BANDED RELAXATION" ||
        type == "BANDEDRELAXATION" ||

--- a/packages/muelu/src/Transfers/Classical/MueLu_ClassicalMapFactory_decl.hpp
+++ b/packages/muelu/src/Transfers/Classical/MueLu_ClassicalMapFactory_decl.hpp
@@ -131,11 +131,11 @@ namespace MueLu {
   protected:
     virtual void GenerateCoarseMap(const Map & fineMap, LO num_c_points, Teuchos::RCP<const Map> & coarseMap) const;
 
-    virtual void DoGraphColoring(const GraphBase & graph, Teuchos::ArrayRCP<LO> & myColors, LO & numColors) const;    
+    virtual void DoGraphColoring(const GraphBase & graph, Teuchos::ArrayRCP<LO> & myColors, LO & numColors) const;
 
-    virtual void DoMISNaive(const GraphBase & graph, Teuchos::ArrayRCP<LO> & myColors, LO & numColors) const;    
+    virtual void DoMISNaive(const GraphBase & graph, Teuchos::ArrayRCP<LO> & myColors, LO & numColors) const;
 
-    virtual void DoDistributedGraphColoring(RCP<const GraphBase> & graph, Teuchos::ArrayRCP<LO> & myColors, LO & numColors) const;    
+    virtual void DoDistributedGraphColoring(RCP<const GraphBase> & graph, Teuchos::ArrayRCP<LO> & myColors, LO & numColors) const;
 
   }; //class ClassicalMapFactory
 

--- a/packages/muelu/src/Transfers/Classical/MueLu_ClassicalMapFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Classical/MueLu_ClassicalMapFactory_def.hpp
@@ -113,7 +113,7 @@ namespace MueLu {
     
     const ParameterList& pL = GetParameterList();
     bool use_color_graph = pL.get<bool>("aggregation: coloring: use color graph");
-    if(use_color_graph) 
+    if(use_color_graph)
       Input(currentLevel, "Coloring Graph");
   }
 
@@ -195,16 +195,16 @@ namespace MueLu {
         // Use A's rowmap and hope it matches
         mv = Xpetra::IO<real_type, LocalOrdinal, GlobalOrdinal, Node>::ReadMultiVector(color_file,A->getRowMap());
       }
-      TEUCHOS_TEST_FOR_EXCEPTION(mv.is_null(),std::invalid_argument,"Coloring on disk cannot be read");      
+      TEUCHOS_TEST_FOR_EXCEPTION(mv.is_null(),std::invalid_argument,"Coloring on disk cannot be read");
       fc_splitting = LocalOrdinalVectorFactory::Build(A->getRowMap());
       TEUCHOS_TEST_FOR_EXCEPTION(mv->getLocalLength() != fc_splitting->getLocalLength(),std::invalid_argument,"Coloring map mismatch");
 
       // Overlay the Dirichlet Points (and copy out the rest)
       auto boundaryNodes = graph->GetBoundaryNodeMap();
       ArrayRCP<const real_type> mv_data= mv->getData(0);
-      ArrayRCP<LO> fc_data= fc_splitting->getDataNonConst(0);     
+      ArrayRCP<LO> fc_data= fc_splitting->getDataNonConst(0);
       for(LO i=0; i<(LO)fc_data.size(); i++) {
-        if(boundaryNodes[i]) 
+        if(boundaryNodes[i])
           fc_data[i] = DIRICHLET_PT;
         else
           fc_data[i] = Teuchos::as<LO>(mv_data[i]);
@@ -299,7 +299,7 @@ namespace MueLu {
     }
         
     Set(currentLevel, "FC Splitting",fc_splitting);
-    Set(currentLevel, "CoarseMap", coarseMap);    
+    Set(currentLevel, "CoarseMap", coarseMap);
    
   }
 
@@ -319,7 +319,7 @@ namespace MueLu {
                                          fineMap.getIndexBase(),
                                          stridingInfo_,
                                          fineMap.getComm(),
-                                         domainGIDOffset);  
+                                         domainGIDOffset);
   }
 
 /* ************************************************************************* */
@@ -341,7 +341,7 @@ namespace MueLu {
     kh.create_graph_coloring_handle();
     
     // Get the distance-1 graph coloring handle
-    auto coloringHandle = kh.get_graph_coloring_handle();      
+    auto coloringHandle = kh.get_graph_coloring_handle();
     
     // Set the distance-1 coloring algorithm to use
     if(pL.get<bool>("aggregation: deterministic") == true) {
@@ -382,8 +382,8 @@ namespace MueLu {
       // Assume that the graph is symmetric so row map/entries and col map/entries are the same
 
     if(graphLWK) {
-      KokkosGraph::Experimental::graph_color(&kh, 
-                                             numRows, 
+      KokkosGraph::Experimental::graph_color(&kh,
+                                             numRows,
                                              numRows, // FIXME: This should be the number of columns
                                              graphLWK->getLocalLWGraph().getRowPtrs(),
                                              graphLWK->getLocalLWGraph().getEntries(),
@@ -397,14 +397,14 @@ namespace MueLu {
       std::copy(rowptrs.begin(),rowptrs.end(),rowptrs_s.begin());
       Kokkos::View<const size_t*,Kokkos::LayoutLeft,Kokkos::HostSpace> rowptrs_v(rowptrs_s.data(),(size_t)rowptrs.size());
       Kokkos::View<const LO*,Kokkos::LayoutLeft,Kokkos::HostSpace> entries_v(entries.getRawPtr(),(size_t)entries.size());
-      KokkosGraph::Experimental::graph_color(&kh, 
-                                             numRows, 
+      KokkosGraph::Experimental::graph_color(&kh,
+                                             numRows,
                                              numRows, // FIXME: This should be the number of columns
                                              rowptrs_v,
                                              entries_v,
                                              true);
     }
-    else if(graphG) {  
+    else if(graphG) {
       // FIXME:  This is a terrible, terrible hack, based on 0-based local indexing.
       RCP<const CrsGraph> graphC = graphG->GetGraph();
       size_t numEntries = graphC->getLocalNumEntries();
@@ -412,15 +412,15 @@ namespace MueLu {
       graphC->getLocalRowView(0,indices);
       Kokkos::View<size_t*,Kokkos::LayoutLeft,Kokkos::HostSpace> rowptrs_v("rowptrs_v",graphC->getLocalNumRows()+1);
       rowptrs_v[0]=0;
-      for(LO i=0; i<(LO)graphC->getLocalNumRows()+1; i++) 
+      for(LO i=0; i<(LO)graphC->getLocalNumRows()+1; i++)
         rowptrs_v[i+1] = rowptrs_v[i] + graphC->getNumEntriesInLocalRow(i);
-      Kokkos::View<const LO*,Kokkos::LayoutLeft,Kokkos::HostSpace> entries_v(&indices[0],numEntries);    
-      KokkosGraph::Experimental::graph_color(&kh, 
-                                             numRows, 
+      Kokkos::View<const LO*,Kokkos::LayoutLeft,Kokkos::HostSpace> entries_v(&indices[0],numEntries);
+      KokkosGraph::Experimental::graph_color(&kh,
+                                             numRows,
                                              numRows, // FIXME: This should be the number of columns
                                              rowptrs_v,
                                              entries_v,
-                                             true);       
+                                             true);
     }
 
     
@@ -464,12 +464,12 @@ namespace MueLu {
       bool has_colored_neighbor=false;
       for(LO j=0; !has_colored_neighbor && j<(LO)indices.size(); j++) {
         // FIXME: This does not handle ghosting correctly
-        if(myColors[indices[j]] == MIS) 
+        if(myColors[indices[j]] == MIS)
           has_colored_neighbor=true;
       }
       if(!has_colored_neighbor)
-        myColors[row] = MIS;   
-    } 
+        myColors[row] = MIS;
+    }
     numColors=1;
   }
 
@@ -501,7 +501,7 @@ namespace MueLu {
 
     // Assign the Array RCP or Copy Out
     // FIXME:  This probably won't work if LO!=int
-    if(std::is_same<LO,int>::value) 
+    if(std::is_same<LO,int>::value)
       myColors_out = colors;
     else {
       myColors_out.resize(colors.size());
@@ -512,7 +512,7 @@ namespace MueLu {
     /*
 
     printf("CMS: numColors = %d\ncolors = ",numColors);
-    for(int i=0;i<colors.size(); i++) 
+    for(int i=0;i<colors.size(); i++)
       printf("%d ",colors[i]);
     printf("\n");
 

--- a/packages/muelu/src/Transfers/Classical/MueLu_ClassicalPFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Classical/MueLu_ClassicalPFactory_def.hpp
@@ -74,7 +74,7 @@
 //#define CMS_DEBUG
 //#define CMS_DUMP
 
-namespace { 
+namespace {
 
 template<class SC>
 int Sign(SC val) {
@@ -125,7 +125,7 @@ namespace MueLu {
   void ClassicalPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::DeclareInput(Level& fineLevel, Level& /* coarseLevel */) const {
     Input(fineLevel, "A");
     Input(fineLevel, "Graph");
-    Input(fineLevel, "DofsPerNode");    
+    Input(fineLevel, "DofsPerNode");
     //    Input(fineLevel, "UnAmalgamationInfo");
     Input(fineLevel, "CoarseMap");
     Input(fineLevel, "FC Splitting");
@@ -152,7 +152,7 @@ namespace MueLu {
     // algorithm before we start to get our Graph, DofsPerNode and UnAmalgamationInfo
 
     // We begin by getting a MIS (from a graph coloring) and then at that point we need
-    // to start generating entries for the prolongator.   
+    // to start generating entries for the prolongator.
     RCP<const Matrix>      A        = Get< RCP<Matrix> >(fineLevel, "A");
     RCP<const Map> ownedCoarseMap   = Get<RCP<const Map> >(fineLevel,"CoarseMap");
     RCP<const LocalOrdinalVector> owned_fc_splitting = Get<RCP<LocalOrdinalVector> >(fineLevel,"FC Splitting");
@@ -179,11 +179,11 @@ namespace MueLu {
     // Do we need ghosts rows of A and myPointType?
     std::string scheme = pL.get<std::string>("aggregation: classical scheme");
     bool need_ghost_rows =false;
-    if(scheme == "ext+i") 
+    if(scheme == "ext+i")
       need_ghost_rows=true;
     else if(scheme == "direct")
       need_ghost_rows=false;
-    else if(scheme == "classical modified") 
+    else if(scheme == "classical modified")
       need_ghost_rows=true;
     // NOTE: ParameterList validator will check this guy so we don't really need an "else" here
 
@@ -202,7 +202,7 @@ namespace MueLu {
       fc_splitting_nonconst->doImport(*owned_fc_splitting,*Importer,Xpetra::INSERT);
       fc_splitting = fc_splitting_nonconst;
     }
-    myPointType = fc_splitting->getData(0);      
+    myPointType = fc_splitting->getData(0);
 
 
     /* Ghost A (if needed) */
@@ -210,7 +210,7 @@ namespace MueLu {
     RCP<const LocalOrdinalVector> fc_splitting_ghost;
     ArrayRCP<const LO> myPointType_ghost;
     RCP<const Import> remoteOnlyImporter;
-    if(need_ghost_rows && !Importer.is_null()){      
+    if(need_ghost_rows && !Importer.is_null()){
       ArrayView<const LO> remoteLIDs = Importer->getRemoteLIDs();
       size_t numRemote = Importer->getNumRemoteIDs();
       Array<GO> remoteRows(numRemote);
@@ -235,14 +235,14 @@ namespace MueLu {
       // }
     }
 
-    /* Generate the ghosted Coarse map using the "Tuminaro maneuver" (if needed)*/   
+    /* Generate the ghosted Coarse map using the "Tuminaro maneuver" (if needed)*/
     RCP<const Map> coarseMap;
-    if(Importer.is_null())  
+    if(Importer.is_null())
       coarseMap = ownedCoarseMap;
     else {
       // Generate a domain vector with the coarse ID's as entries for C points
       GhostCoarseMap(*A,*Importer,myPointType,ownedCoarseMap,coarseMap);
-    }  
+    }
 
     /* Get the block number, if we need it (and ghost it) */
     RCP<LocalOrdinalVector>  BlockNumber;
@@ -250,7 +250,7 @@ namespace MueLu {
     if (drop_algo.find("block diagonal") != std::string::npos || drop_algo == "signed classical") {
       RCP<LocalOrdinalVector> OwnedBlockNumber;
       OwnedBlockNumber = Get<RCP<LocalOrdinalVector> >(fineLevel, "BlockNumber");
-      if(Importer.is_null()) 
+      if(Importer.is_null())
         BlockNumber = OwnedBlockNumber;
       else{
         BlockNumber = LocalOrdinalVectorFactory::Build(A->getColMap());
@@ -281,7 +281,7 @@ namespace MueLu {
       ArrayRCP<real_type> mv_data= mv->getDataNonConst(0);
 
       // FC Splitting
-      ArrayRCP<const LO> fc_data= fc_splitting->getData(0);      
+      ArrayRCP<const LO> fc_data= fc_splitting->getData(0);
       for(LO i=0; i<(LO)fc_data.size(); i++)
         mv_data[i] = Teuchos::as<real_type>(fc_data[i]);
       Xpetra::IO<real_type,LO,GO,NO>::Write(out_fc,*mv);
@@ -290,7 +290,7 @@ namespace MueLu {
       if(!BlockNumber.is_null()) {
         RCP<RealValuedMultiVector> mv2 = RealValuedMultiVectorFactory::Build(BlockNumber->getMap(),1);
         ArrayRCP<real_type> mv_data2= mv2->getDataNonConst(0);
-        ArrayRCP<const LO> b_data= BlockNumber->getData(0);      
+        ArrayRCP<const LO> b_data= BlockNumber->getData(0);
         for(LO i=0; i<(LO)b_data.size(); i++) {
           mv_data2[i] = Teuchos::as<real_type>(b_data[i]);
         }
@@ -309,7 +309,7 @@ namespace MueLu {
     // pcol2cpoint - Takes a LCID for P and turns in into an LCID for A.
     // cpoint2pcol - Takes a LCID for A --- if it is a C Point --- and turns in into an LCID for P.
     Array<LO> cpoint2pcol(myPointType.size(),LO_INVALID);
-    Array<LO> pcol2cpoint(coarseMap->getLocalNumElements(),LO_INVALID);   
+    Array<LO> pcol2cpoint(coarseMap->getLocalNumElements(),LO_INVALID);
     LO num_c_points = 0;
     LO num_f_points =0;
     for(LO i=0; i<(LO) myPointType.size(); i++) {
@@ -380,7 +380,7 @@ Coarsen_ClassicalModified(const Matrix & A,const RCP<const Matrix> & Aghost, con
     /* De Sterck, Falgout, Nolting and Yang. "Distance-two           */
     /* interpolation for parallel algebraic multigrid", NLAA 2008    */
     /* 15:115-139                                                    */
-    /* ============================================================= */    
+    /* ============================================================= */
     /* Definitions:                                                        */
     /* F = F-points                                                        */
     /* C = C-points                                                        */
@@ -406,10 +406,10 @@ Coarsen_ClassicalModified(const Matrix & A,const RCP<const Matrix> & Aghost, con
 
     /* Rewritten Equation (9) on p. 120                                    */
     /* \tilde{a}_ii =  (a_ij + \sum_{k\in{N_i^w \cup F_i^s\star}} a_ik     */
-    /*                                                                     */ 
-    /* f_ij = \sum_{k\in{F_i^s\setminusF_i^s*}} \frac{a_ik \bar{a}_kj}{\sum_{m\inC_i^s \bar{a}_km}}    */ 
-    /*                                                                     */ 
-    /* w_ij = \frac{1}{\tilde{a}_ii} ( a_ij + f_ij)  for all j in C_i^s    */ 
+    /*                                                                     */
+    /* f_ij = \sum_{k\in{F_i^s\setminusF_i^s*}} \frac{a_ik \bar{a}_kj}{\sum_{m\inC_i^s \bar{a}_km}}    */
+    /*                                                                     */
+    /* w_ij = \frac{1}{\tilde{a}_ii} ( a_ij + f_ij)  for all j in C_i^s    */
   
     //    const point_type F_PT = ClassicalMapFactory::F_PT;
     const point_type C_PT = ClassicalMapFactory::C_PT;
@@ -423,8 +423,8 @@ Coarsen_ClassicalModified(const Matrix & A,const RCP<const Matrix> & Aghost, con
 #endif
 
     // Get the block number if we have it.
-    ArrayRCP<const LO> block_id; 
-    if(!BlockNumber.is_null()) 
+    ArrayRCP<const LO> block_id;
+    if(!BlockNumber.is_null())
       block_id = BlockNumber->getData(0);
 
     // Initial (estimated) allocation
@@ -441,8 +441,8 @@ Coarsen_ClassicalModified(const Matrix & A,const RCP<const Matrix> & Aghost, con
     Array<LO> tmp_colind(nnz_est);
 
     // Algorithm (count+realloc)
-    // For each row, i, 
-    // - Count the number of elements in \hat{C}_j, aka [C-neighbors and C-neighbors of strong F-neighbors of i]   
+    // For each row, i,
+    // - Count the number of elements in \hat{C}_j, aka [C-neighbors and C-neighbors of strong F-neighbors of i]
     size_t ct=0;
     for(LO row=0; row < (LO) Nrows; row++) {
       size_t row_start = eis_rowptr[row];
@@ -459,12 +459,12 @@ Coarsen_ClassicalModified(const Matrix & A,const RCP<const Matrix> & Aghost, con
       else {
         // F-Points have a more complicated interpolation
 
-        // C-neighbors of row 
+        // C-neighbors of row
         A.getLocalRowView(row, indices, vals);
         for(LO j=0; j<indices.size(); j++)
           if(myPointType[indices[j]] == C_PT && edgeIsStrong[row_start + j])
             C_hat.insert(cpoint2pcol[indices[j]]);
-      }// end else 
+      }// end else
       
       // Realloc if needed
       if(ct + (size_t)C_hat.size() > (size_t)tmp_colind.size()) {
@@ -527,7 +527,7 @@ Coarsen_ClassicalModified(const Matrix & A,const RCP<const Matrix> & Aghost, con
     ArrayRCP<LO> Pghostcol_to_Pcol;
     if(!Pghost.is_null()) {
       Pghostcol_to_Pcol.resize(Pghost->getColMap()->getLocalNumElements(),LO_INVALID);
-      for(LO i=0; i<(LO) Pghost->getColMap()->getLocalNumElements(); i++) 
+      for(LO i=0; i<(LO) Pghost->getColMap()->getLocalNumElements(); i++)
         Pghostcol_to_Pcol[i] = Pgraph->getColMap()->getLocalElement(Pghost->getColMap()->getGlobalElement(i));
     }//end Pghost
 
@@ -535,31 +535,31 @@ Coarsen_ClassicalModified(const Matrix & A,const RCP<const Matrix> & Aghost, con
     ArrayRCP<LO> Aghostcol_to_Acol;
     if(!Aghost.is_null()) {
       Aghostcol_to_Acol.resize(Aghost->getColMap()->getLocalNumElements(),LO_INVALID);
-      for(LO i=0; i<(LO)Aghost->getColMap()->getLocalNumElements(); i++) 
+      for(LO i=0; i<(LO)Aghost->getColMap()->getLocalNumElements(); i++)
         Aghostcol_to_Acol[i] = A.getColMap()->getLocalElement(Aghost->getColMap()->getGlobalElement(i));
     }//end Aghost
 
 
-    // Algorithm (numeric)    
+    // Algorithm (numeric)
     for(LO i=0; i < (LO)Nrows; i++) {
       if(myPointType[i] == DIRICHLET_PT) {
         // Dirichlet points get ignored completely
-#ifdef CMS_DEBUG        
+#ifdef CMS_DEBUG
         // DEBUG
         printf("[%d] ** A(%d,:) is a Dirichlet-Point.\n",rank,i);
 #endif
       }
       else if (myPointType[i] == C_PT) {
         // C Points get a single 1 in their row
-        P_values[P_rowptr[i]] = Teuchos::ScalarTraits<SC>::one();  
-#ifdef CMS_DEBUG        
+        P_values[P_rowptr[i]] = Teuchos::ScalarTraits<SC>::one();
+#ifdef CMS_DEBUG
         // DEBUG
         printf("[%d] ** A(%d,:) is a C-Point.\n",rank,i);
 #endif
       }
       else {
         // F Points get all of the fancy stuff
-#ifdef CMS_DEBUG        
+#ifdef CMS_DEBUG
         // DEBUG
         printf("[%d] ** A(%d,:) is a F-Point.\n",rank,i);
 #endif
@@ -579,7 +579,7 @@ Coarsen_ClassicalModified(const Matrix & A,const RCP<const Matrix> & Aghost, con
 
         // Stash the hash:  Flag any strong C-points with their index into P_colind
         // NOTE:  We'll consider any points that are LO_INVALID or less than P_rowptr[i] as not strong C-points
-        for(LO j=0; j<(LO)P_indices_i.size(); j++)  { 
+        for(LO j=0; j<(LO)P_indices_i.size(); j++)  {
           Acol_to_Pcol[pcol2cpoint[P_indices_i[j]]] = P_rowptr[i] + j;
         }
 
@@ -590,10 +590,10 @@ Coarsen_ClassicalModified(const Matrix & A,const RCP<const Matrix> & Aghost, con
 #endif
         for(LO k0=0; k0<(LO)A_indices_i.size(); k0++) {
           LO k      = A_indices_i[k0];
-          SC a_ik   = A_vals_i[k0]; 
+          SC a_ik   = A_vals_i[k0];
           LO pcol_k = Acol_to_Pcol[k];
 
-          if(k == i) { 
+          if(k == i) {
             // Case A: Diagonal value (add to first denominator)
             // FIXME:  Add BlockNumber matching here
             first_denominator += a_ik;
@@ -637,19 +637,19 @@ Coarsen_ClassicalModified(const Matrix & A,const RCP<const Matrix> & Aghost, con
             printf("- A(%d,%d) is a strong F-Point\n",i,k);
 #endif
 
-            SC a_kk = SC_ZERO;              
+            SC a_kk = SC_ZERO;
             SC second_denominator = SC_ZERO;
             int sign_akk = 0;
             
             if(k < (LO)Nrows) {
-              // Grab the diagonal a_kk 
+              // Grab the diagonal a_kk
               A.getLocalRowView(k, A_indices_k, A_vals_k);
               for(LO m0=0; m0<(LO)A_indices_k.size(); m0++){
                 LO m    = A_indices_k[m0];
                 if(k == m) {
                   a_kk = A_vals_k[m0];
                   break;
-                }               
+                }
               }//end for A_indices_k
               
               // Compute the second denominator term
@@ -662,11 +662,11 @@ Coarsen_ClassicalModified(const Matrix & A,const RCP<const Matrix> & Aghost, con
                 }
               }//end for A_indices_k
 
-              // Now we have the second denominator, for this particular strong F point.  
-              // So we can now add the sum to the w_ij components for the P values 
+              // Now we have the second denominator, for this particular strong F point.
+              // So we can now add the sum to the w_ij components for the P values
               if(second_denominator != SC_ZERO) {
                 for(LO j0=0; j0<(LO)A_indices_k.size(); j0++) {
-                  LO j    = A_indices_k[j0];            
+                  LO j    = A_indices_k[j0];
                   // NOTE: Row k should be in fis_star, so I should have to check for diagonals here
                   //                  printf("Acol_to_Pcol[%d] = %d P_values.size() = %d\n",j,Acol_to_Pcol[j],(int)P_values.size());
                   if(Acol_to_Pcol[j] >=  (LO)P_rowptr[i]) {
@@ -676,7 +676,7 @@ Coarsen_ClassicalModified(const Matrix & A,const RCP<const Matrix> & Aghost, con
 #ifdef CMS_DEBUG
                     printf("- - Unscaled P(%d,A-%d) += %6.4e = %5.4e\n",i,j,a_ik * sign_akj_val / second_denominator,P_values[Acol_to_Pcol[j]]);
 #endif
-                  }                 
+                  }
                 }//end for A_indices_k
               }//end if second_denominator != 0
               else {
@@ -694,7 +694,7 @@ Coarsen_ClassicalModified(const Matrix & A,const RCP<const Matrix> & Aghost, con
               // NOTE: ColMap is not locally fitted to the RowMap
               // so we need to check GIDs here
               Aghost->getLocalRowView(kless, A_indices_k, A_vals_k);
-              GO k_g = Aghost->getRowMap()->getGlobalElement(kless);                
+              GO k_g = Aghost->getRowMap()->getGlobalElement(kless);
               for(LO m0=0; m0<(LO)A_indices_k.size(); m0++){
                 GO m_g    = Aghost->getColMap()->getGlobalElement(A_indices_k[m0]);
                 if(k_g == m_g) {
@@ -716,8 +716,8 @@ Coarsen_ClassicalModified(const Matrix & A,const RCP<const Matrix> & Aghost, con
               }//end for A_indices_k
               
               
-              // Now we have the second denominator, for this particular strong F point.  
-              // So we can now add the sum to the w_ij components for the P values 
+              // Now we have the second denominator, for this particular strong F point.
+              // So we can now add the sum to the w_ij components for the P values
               if(second_denominator != SC_ZERO) {
                 for(LO j0=0; j0<(LO)A_indices_k.size(); j0++){
                   LO jghost = A_indices_k[j0];//Aghost LCID
@@ -738,9 +738,9 @@ Coarsen_ClassicalModified(const Matrix & A,const RCP<const Matrix> & Aghost, con
 #ifdef CMS_DEBUG
                 printf("- - A(%d,%d) second denominator is zero\n",i,k);
 #endif
-                if(block_id.size() == 0 || block_id[i] == block_id[k]) 
+                if(block_id.size() == 0 || block_id[i] == block_id[k])
                   first_denominator += a_ik;
-              }//end else second_denominator != 0                           
+              }//end else second_denominator != 0
             }//end else k < Nrows
           }//end else Case A,...,E
                            
@@ -748,7 +748,7 @@ Coarsen_ClassicalModified(const Matrix & A,const RCP<const Matrix> & Aghost, con
 
         // Now, downscale by the first_denominator
         if(first_denominator != SC_ZERO) {
-          for(LO j0=0; j0<(LO)P_indices_i.size(); j0++)  { 
+          for(LO j0=0; j0<(LO)P_indices_i.size(); j0++)  {
 #ifdef CMS_DEBUG
             SC old_pij = P_vals_i[j0];
             P_vals_i[j0] /= -first_denominator;
@@ -782,7 +782,7 @@ Coarsen_Direct(const Matrix & A,const RCP<const Matrix> & Aghost, const GraphBas
     /* here.  Instead we follow:                                     */
     /* Trottenberg, Oosterlee and Schueller, Multigrid, 2001.        */
     /* with some modifications inspirted by PyAMG                    */
-    /* ============================================================= */    
+    /* ============================================================= */
     /* Definitions:                                                        */
     /* F = F-points                                                        */
     /* C = C-points                                                        */
@@ -792,11 +792,11 @@ Coarsen_Direct(const Matrix & A,const RCP<const Matrix> & Aghost, const GraphBas
     /* C_i^s = C \cap S_i [strong C-neighbors of i]                        */
     /* P_i = Set of interpolatory variables for row i [here = C_i^s]       */
 
-    /* (A.2.17) from p. 426                                                */ 
-    /* a_ij^- = {  a_ij,  if a_ij < 0                                      */ 
-    /*          {     0,  otherwise                                        */ 
-    /* a_ij^+ = {  a_ij,  if a_ij > 0                                      */ 
-    /*          {     0,  otherwise                                        */ 
+    /* (A.2.17) from p. 426                                                */
+    /* a_ij^- = {  a_ij,  if a_ij < 0                                      */
+    /*          {     0,  otherwise                                        */
+    /* a_ij^+ = {  a_ij,  if a_ij > 0                                      */
+    /*          {     0,  otherwise                                        */
     /* P_i^- =  P_i \cap {k | a_ij^- != 0 and a_ij^- = a_ij}               */
     /*          [strong C-neighbors with negative edges]                   */
     /* P_i^+ =  P_i \cap {k | a_ij^+ != 0 and a_ij^+ = a_ij}               */
@@ -811,7 +811,7 @@ Coarsen_Direct(const Matrix & A,const RCP<const Matrix> & Aghost, const GraphBas
     /* alpha_i = \frac{ \sum_{j\in N_i} a_ij^- }{ \sum_{k\in P_i} a_ik^- }                   */
     /* beta_i  = \frac{ \sum_{j\in N_i} a_ij^+ }{ \sum_{k\in P_i} a_ik^+ }                   */
     /* w_ik    = { - alpha_i (a_ik / a_ii),   if k\in P_i^-                                  */
-    /*           { -  beta_i (a_ik / a_ii),   if k\in P_i^+                                  */  
+    /*           { -  beta_i (a_ik / a_ii),   if k\in P_i^+                                  */
     /* NOTE: The text says to modify, if  P_i^+ is zero but it isn't entirely clear how that */
     /* works.  We'll follow the PyAMG implementation in a few important ways.                */
      
@@ -837,8 +837,8 @@ Coarsen_Direct(const Matrix & A,const RCP<const Matrix> & Aghost, const GraphBas
     Array<LO> tmp_colind(nnz_est);
 
     // Algorithm (count+realloc)
-    // For each row, i, 
-    // - Count the number of elements in \hat{C}_j, aka [C-neighbors and C-neighbors of strong F-neighbors of i]   
+    // For each row, i,
+    // - Count the number of elements in \hat{C}_j, aka [C-neighbors and C-neighbors of strong F-neighbors of i]
     size_t ct=0;
     for(LO row=0; row < (LO) Nrows; row++) {
       size_t row_start = eis_rowptr[row];
@@ -855,12 +855,12 @@ Coarsen_Direct(const Matrix & A,const RCP<const Matrix> & Aghost, const GraphBas
       else {
         // F-Points have a more complicated interpolation
 
-        // C-neighbors of row 
+        // C-neighbors of row
         A.getLocalRowView(row, indices, vals);
         for(LO j=0; j<indices.size(); j++)
           if(myPointType[indices[j]] == C_PT && edgeIsStrong[row_start + j])
             C_hat.insert(cpoint2pcol[indices[j]]);
-      }// end else 
+      }// end else
       
       // Realloc if needed
       if(ct + (size_t)C_hat.size() > (size_t)tmp_colind.size()) {
@@ -873,7 +873,7 @@ Coarsen_Direct(const Matrix & A,const RCP<const Matrix> & Aghost, const GraphBas
       tmp_rowptr[row+1] = tmp_rowptr[row] + C_hat.size();
     }
     // Resize down
-    tmp_colind.resize(tmp_rowptr[Nrows]);  
+    tmp_colind.resize(tmp_rowptr[Nrows]);
 
     // Allocate memory & copy
     P = rcp(new CrsMatrixWrap(A.getRowMap(), coarseColMap, 0));
@@ -899,15 +899,15 @@ printf("CMS: Allocating P w/ %d nonzeros\n",(int)tmp_rowptr[Nrows]);
     for(LO i=0; i < (LO)Nrows; i++) {
       if(myPointType[i] == DIRICHLET_PT) {
         // Dirichlet points get ignored completely
-#ifdef CMS_DEBUG        
+#ifdef CMS_DEBUG
         // DEBUG
         printf("** A(%d,:) is a Dirichlet-Point.\n",i);
 #endif
       }
       else if (myPointType[i] == C_PT) {
         // C Points get a single 1 in their row
-        P_values[P_rowptr[i]] = Teuchos::ScalarTraits<SC>::one();  
-#ifdef CMS_DEBUG        
+        P_values[P_rowptr[i]] = Teuchos::ScalarTraits<SC>::one();
+#ifdef CMS_DEBUG
         // DEBUG
         printf("** A(%d,:) is a C-Point.\n",i);
 #endif
@@ -917,7 +917,7 @@ printf("CMS: Allocating P w/ %d nonzeros\n",(int)tmp_rowptr[Nrows]);
         /* alpha_i = \frac{ \sum_{j\in N_i} a_ij^- }{ \sum_{k\in P_i} a_ik^- }                   */
         /* beta_i  = \frac{ \sum_{j\in N_i} a_ij^+ }{ \sum_{k\in P_i} a_ik^+ }                   */
         /* w_ik    = { - alpha_i (a_ik / a_ii),   if k\in P_i^-                                  */
-        /*           { -  beta_i (a_ik / a_ii),   if k\in P_i^+                                  */  
+        /*           { -  beta_i (a_ik / a_ii),   if k\in P_i^+                                  */
         ArrayView<const LO> A_indices_i, A_incides_k;
         ArrayView<const SC> A_vals_i, A_indices_k;
         A.getLocalRowView(i, A_indices_i, A_vals_i);
@@ -926,51 +926,51 @@ printf("CMS: Allocating P w/ %d nonzeros\n",(int)tmp_rowptr[Nrows]);
         ArrayView<LO> P_indices_i  = P_colind.view(P_rowptr[i],P_rowptr[i+1] - P_rowptr[i]);
         ArrayView<SC> P_vals_i     = P_values.view(P_rowptr[i],P_rowptr[i+1] - P_rowptr[i]);
         
-#ifdef CMS_DEBUG          
+#ifdef CMS_DEBUG
         // DEBUG
         {
           char mylabel[5]="FUCD";
           char sw[3]="ws";
           printf("** A(%d,:) = ",i);
-          for(LO j=0; j<(LO)A_indices_i.size(); j++){  
+          for(LO j=0; j<(LO)A_indices_i.size(); j++){
             printf("%6.4e(%d-%c%c) ",A_vals_i[j],A_indices_i[j],mylabel[1+myPointType[A_indices_i[j]]],sw[(int)edgeIsStrong[row_start+j]]);
           }
           printf("\n");
         }
-#endif        
+#endif
                       
         SC a_ii            = SC_ZERO;
         SC pos_numerator   = SC_ZERO, neg_numerator   = SC_ZERO;
         SC pos_denominator = SC_ZERO, neg_denominator = SC_ZERO;
         // Find the diagonal and compute the sum ratio
         for(LO j=0; j<(LO)A_indices_i.size(); j++) {
-          SC a_ik = A_vals_i[j]; 
+          SC a_ik = A_vals_i[j];
           LO k = A_indices_i[j];
           
           // Diagonal
-          if(i == k) { 
+          if(i == k) {
             a_ii = a_ik;
-          }          
+          }
           // Only strong C-neighbors are in the denomintor
           if(myPointType[k] == C_PT && edgeIsStrong[row_start + j]) {
             if(STS::real(a_ik) > MT_ZERO) pos_denominator += a_ik;
             else neg_denominator += a_ik;
-          }  
+          }
           
           // All neighbors are in the numerator
           // NOTE: As per PyAMG, this does not include the diagonal
           if(i != k) {
             if(STS::real(a_ik) > MT_ZERO) pos_numerator += a_ik;
             else neg_numerator += a_ik;
-          }   
+          }
         }
         SC alpha = (neg_denominator == MT_ZERO) ? SC_ZERO : (neg_numerator / neg_denominator);
         SC beta  = (pos_denominator == MT_ZERO) ? SC_ZERO : (pos_numerator / pos_denominator);
-        alpha /= -a_ii;        
+        alpha /= -a_ii;
         beta  /= -a_ii;
 
         // Loop over the entries
-        for(LO p_j=0; p_j<(LO)P_indices_i.size(); p_j++){  
+        for(LO p_j=0; p_j<(LO)P_indices_i.size(); p_j++){
           LO P_col = pcol2cpoint[P_indices_i[p_j]];
           SC a_ij = SC_ZERO;
           
@@ -987,7 +987,7 @@ printf("CMS: Allocating P w/ %d nonzeros\n",(int)tmp_rowptr[Nrows]);
           SC alpha_or_beta = (STS::real(a_ij) < 0 ) ? alpha : beta;
           printf("P(%d,%d/%d) =  - %6.4e  * %6.4e  = %6.4e\n",i,P_indices_i[p_j],pcol2cpoint[P_indices_i[p_j]],alpha_or_beta,a_ij,w_ij);
 #endif
-          P_vals_i[p_j] = w_ij;          
+          P_vals_i[p_j] = w_ij;
         }//end for A_indices_i
       }//end else C_PT
     }//end for Numrows
@@ -1008,7 +1008,7 @@ Coarsen_Ext_Plus_I(const Matrix & A,const RCP<const Matrix> & Aghost, const Grap
     /* De Sterck, Falgout, Nolting and Yang. "Distance-two           */
     /* interpolation for parallel algebraic multigrid", NLAA 2008    */
     /* 15:115-139                                                    */
-    /* ============================================================= */    
+    /* ============================================================= */
     /* Definitions:                                                        */
     /* F = F-points                                                        */
     /* C = C-points                                                        */
@@ -1036,7 +1036,7 @@ Coarsen_Ext_Plus_I(const Matrix & A,const RCP<const Matrix> & Aghost, const Grap
     /*         for j in \hat{C}_i                                          */
     
     /* Rewritten Equation (20) on p. 124 [for the lumped diagonal]                                  */
-    /* g_ik = \frac{\bar{a}_ki}{\sum{l\in \hat{C}_i\cup {i}} \bar{a}_kl                             */    
+    /* g_ik = \frac{\bar{a}_ki}{\sum{l\in \hat{C}_i\cup {i}} \bar{a}_kl                             */
     /* \tilde{a}_ii = a_ii + \sum_{n\inN_i^w\setminus \hat{C}_i} a_in + \sum_{k\inF_i^s} a_ik g_ik  */
     TEUCHOS_TEST_FOR_EXCEPTION(1,std::runtime_error,"ClassicalPFactory: Ext+i not implemented");
 
@@ -1088,7 +1088,7 @@ GenerateStrengthFlags(const Matrix & A,const GraphBase & graph, Teuchos::Array<s
       LO col = G_indices[g_idx];
       while (A_indices[a_idx] != col && a_idx < A_size) a_idx++;
       if(a_idx == A_size) {is_ok=false;break;}
-      edgeIsStrong[rowstart+a_idx] = true;      
+      edgeIsStrong[rowstart+a_idx] = true;
     }
 
     eis_rowptr[i+1] = eis_rowptr[i] + A_size;
@@ -1099,7 +1099,7 @@ GenerateStrengthFlags(const Matrix & A,const GraphBase & graph, Teuchos::Array<s
 /* ************************************************************************* */
 template <class Scalar,class LocalOrdinal, class GlobalOrdinal, class Node>
 void ClassicalPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-GhostCoarseMap(const Matrix &A, const Import & Importer, const ArrayRCP<const LO> myPointType, const RCP<const Map> & coarseMap, RCP<const Map> & coarseColMap) const {  
+GhostCoarseMap(const Matrix &A, const Import & Importer, const ArrayRCP<const LO> myPointType, const RCP<const Map> & coarseMap, RCP<const Map> & coarseColMap) const {
   const point_type C_PT = ClassicalMapFactory::C_PT;
   const GO GO_INVALID = Teuchos::OrdinalTraits<GO>::invalid();
   RCP<GlobalOrdinalVector> d_coarseIds = GlobalOrdinalVectorFactory::Build(A.getRowMap());
@@ -1120,7 +1120,7 @@ GhostCoarseMap(const Matrix &A, const Import & Importer, const ArrayRCP<const LO
   c_coarseIds->doImport(*d_coarseIds,Importer,Xpetra::INSERT);
   
   // If we assume that A is in Aztec ordering, then any subset of A's unknowns will
-  // be in Aztec ordering as well, which means we can just condense these guys down        
+  // be in Aztec ordering as well, which means we can just condense these guys down
   // Overallocate, count and view
   ArrayRCP<GO> c_data = c_coarseIds->getDataNonConst(0);
   
@@ -1144,7 +1144,7 @@ GhostCoarseMap(const Matrix &A, const Import & Importer, const ArrayRCP<const LO
                                           coarseMap->getIndexBase(),
                                           stridingInfo_,
                                           coarseMap->getComm(),
-                                          domainGIDOffset);        
+                                          domainGIDOffset);
   
 }
 

--- a/packages/muelu/src/Transfers/GeneralGeometric/MueLu_GeneralGeometricPFactory_decl.hpp
+++ b/packages/muelu/src/Transfers/GeneralGeometric/MueLu_GeneralGeometricPFactory_decl.hpp
@@ -84,7 +84,7 @@ namespace MueLu {
   | Parameter   | type    | default   | master.xml | validated | requested | description                                                                      |
   | ------------|---------|-----------|:----------:|:---------:|:---------:|----------------------------------------------------------------------------------|
   | Coarsen     | string  | -1        |            |           |           | A string that specify the coarsening rate, if it is a single character, it will  |
-  |             |         |           |            |           |           | indicate a unique coarsening rate in each direction, if it is longer, it will be | 
+  |             |         |           |            |           |           | indicate a unique coarsening rate in each direction, if it is longer, it will be |
   |             |         |           |            |           |           | processed as a vector with 3 entries, one for each spatial direction             |
   | A           | Factory | null      |            | *         | *         | Generating factory of the matrix A used during the prolongator smoothing process |
   | Nullspace   | Factory | null      |            | *         | *         | Generating factory of the nullspace. The GeneralGeometricPFactory provides       |

--- a/packages/muelu/src/Transfers/GeneralGeometric/MueLu_GeometricInterpolationPFactory_def.hpp
+++ b/packages/muelu/src/Transfers/GeneralGeometric/MueLu_GeometricInterpolationPFactory_def.hpp
@@ -87,7 +87,7 @@ namespace MueLu {
     validParamList->set<RCP<const FactoryBase> >("numDimensions",                Teuchos::null,
                                                  "Number of spacial dimensions in the problem.");
     validParamList->set<RCP<const FactoryBase> >("lCoarseNodesPerDim",           Teuchos::null,
-                                                 "Number of nodes per spatial dimension on the coarse grid.");                              
+                                                 "Number of nodes per spatial dimension on the coarse grid.");
     validParamList->set<RCP<const FactoryBase> >("structuredInterpolationOrder", Teuchos::null,
     						 "Interpolation order for constructing the prolongator.");
     validParamList->set<bool>                   ("keep coarse coords",           false, "Flag to keep coordinates for special coarse grid solve");
@@ -113,7 +113,7 @@ namespace MueLu {
       Input(fineLevel, "Coordinates");
       Input(fineLevel, "coarseCoordinatesFineMap");
       Input(fineLevel, "coarseCoordinatesMap");
-    }     
+    }
   }
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
@@ -336,14 +336,14 @@ namespace MueLu {
       P = rcp(new CrsMatrixWrap(prolongatorGraph, dummyList));
       RCP<CrsMatrix> PCrs = rcp_dynamic_cast<CrsMatrixWrap>(P)->getCrsMatrix();
       PCrs->setAllToScalar(1.0);
-      PCrs->fillComplete();          
+      PCrs->fillComplete();
 
-      // set StridingInformation of P    
+      // set StridingInformation of P
       if (A->IsView("stridedMaps") == true)
         P->CreateView("stridedMaps", A->getRowMap("stridedMaps"), stridedDomainMap);
-      else 
+      else
         P->CreateView("stridedMaps", P->getRangeMap(), stridedDomainMap);
-    }      
+    }
 
   } // BuildConstantP
 

--- a/packages/muelu/src/Transfers/Matrix-Free/MueLu_MatrixFreeTentativeP_kokkos_def.hpp
+++ b/packages/muelu/src/Transfers/Matrix-Free/MueLu_MatrixFreeTentativeP_kokkos_def.hpp
@@ -66,10 +66,10 @@ namespace MueLu {
 
   // compute Y = alpha*R*X + beta*Y
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class DeviceType>
-  void MatrixFreeTentativeP_kokkos<Scalar,LocalOrdinal,GlobalOrdinal,Kokkos::Compat::KokkosDeviceWrapperNode<DeviceType>>::apply(const MultiVector &X, 
-                                          MultiVector &Y, 
-                                          Teuchos::ETransp mode, 
-                                          Scalar alpha, 
+  void MatrixFreeTentativeP_kokkos<Scalar,LocalOrdinal,GlobalOrdinal,Kokkos::Compat::KokkosDeviceWrapperNode<DeviceType>>::apply(const MultiVector &X,
+                                          MultiVector &Y,
+                                          Teuchos::ETransp mode,
+                                          Scalar alpha,
                                           Scalar beta) const {
 
     using impl_scalar_type = typename Kokkos::ArithTraits<Scalar>::val_type;
@@ -92,7 +92,7 @@ namespace MueLu {
 
       // Step 2: Compute Y=Y+alpha*R*X
       // recall R*X is an average of X over aggregates
-      Kokkos::parallel_for("MueLu:MatrixFreeTentativeR_kokkos:apply", md_range_type({0,0},{numCols,numNodes}), 
+      Kokkos::parallel_for("MueLu:MatrixFreeTentativeR_kokkos:apply", md_range_type({0,0},{numCols,numNodes}),
         KOKKOS_LAMBDA(const int colIdx, const int NodeIdx) {
           LO aggIdx = vertex2AggIdView(NodeIdx,0);
           if(aggIdx != -1) { // depending on maps, vertex2agg
@@ -106,19 +106,19 @@ namespace MueLu {
 
       // Step 2: Compute Y=Y+alpha*P*X
       // recall P*X is essentially injection of X, but sum if a node belongs to multiple aggregates
-      Kokkos::parallel_for("MueLu:MatrixFreeTentativeP_kokkos:apply", md_range_type({0,0},{numCols,numNodes}), 
+      Kokkos::parallel_for("MueLu:MatrixFreeTentativeP_kokkos:apply", md_range_type({0,0},{numCols,numNodes}),
         KOKKOS_LAMBDA(const int colIdx, const int fineIdx) {
           LO aggIdx = vertex2AggView(fineIdx,0);
           kokkos_view_Y(fineIdx,colIdx) += implAlpha*kokkos_view_X(aggIdx,colIdx)/Kokkos::sqrt(aggSizes(aggIdx));
         });
     }
-  } 
+  }
 
   // I don't care
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class DeviceType>
   void MatrixFreeTentativeP_kokkos<Scalar,LocalOrdinal,GlobalOrdinal,Kokkos::Compat::KokkosDeviceWrapperNode<DeviceType>>::residual(const MultiVector &X, const MultiVector &B, MultiVector &R) const {
     TEUCHOS_TEST_FOR_EXCEPTION(true,Exceptions::RuntimeError,"MatrixFreeTentativeP residual would make no sense as the operator is not square!");
-  }  
+  }
 
 } //namespace MueLu
 

--- a/packages/muelu/src/Transfers/SemiCoarsen/MueLu_SemiCoarsenPFactory_decl.hpp
+++ b/packages/muelu/src/Transfers/SemiCoarsen/MueLu_SemiCoarsenPFactory_decl.hpp
@@ -144,7 +144,7 @@ namespace MueLu {
     LO FindCpts(LO const PtsPerLine, LO const CoarsenRate, LO const Thin, LO **LayerCpts) const;
     LO MakeSemiCoarsenP(LO const Ntotal, LO const nz, LO const CoarsenRate, LO const LayerId[],
                                   LO const VertLineId[], LO const DofsPerNode, RCP<Matrix>& Amat,
-                                  RCP<Matrix>& P, RCP<const Map>& coarseMap, 
+                                  RCP<Matrix>& P, RCP<const Map>& coarseMap,
                                   const RCP<MultiVector> fineNullspace, RCP<MultiVector>& coarseNullspace, RCP<Matrix>& R, bool buildRestriction, bool doLinear) const;
     void RevertToPieceWiseConstant( RCP<Matrix>& P, LO BlkSize) const;
 

--- a/packages/muelu/src/Transfers/SemiCoarsen/MueLu_SemiCoarsenPFactory_def.hpp
+++ b/packages/muelu/src/Transfers/SemiCoarsen/MueLu_SemiCoarsenPFactory_def.hpp
@@ -547,7 +547,7 @@ namespace MueLu {
 
    Xpetra::global_size_t     itemp = GNdofs/nz;
     coarseMap = StridedMapFactory::Build(rowMap->lib(),
-        NCLayers*itemp, 
+        NCLayers*itemp,
         NCLayers*NVertLines*DofsPerNode,
         0, /* index base */
         stridingInfo_,
@@ -984,13 +984,13 @@ namespace MueLu {
       for (size_t j =0; j < nnz; j++) {
         if (Teuchos::ScalarTraits<SC>::magnitude(vals[ j ]) >= Teuchos::ScalarTraits<SC>::magnitude(largestValue)) {
           if ( inds[j]%BlkSize == rowDof ) {
-            largestValue = vals[j]; 
+            largestValue = vals[j];
             largestIndex = (int) j;
           }
         }
         vals[j] = ZERO;
       }
-      if (largestIndex != -1) vals[largestIndex] = ONE; 
+      if (largestIndex != -1) vals[largestIndex] = ONE;
       else
         TEUCHOS_TEST_FOR_EXCEPTION(nnz > 0, Exceptions::RuntimeError, "no nonzero column associated with a proper dof within node.");
 

--- a/packages/muelu/src/Transfers/SemiCoarsen/MueLu_TogglePFactory_def.hpp
+++ b/packages/muelu/src/Transfers/SemiCoarsen/MueLu_TogglePFactory_def.hpp
@@ -141,13 +141,13 @@ namespace MueLu {
     prolongatorFacts_[nProlongatorFactory]->CallBuild(coarseLevel);
     P = coarseLevel.Get< RCP<Matrix> >("P", (prolongatorFacts_[nProlongatorFactory]).get());
     RCP<Matrix> R     = Teuchos::null;
-    int Rplaceholder = -1;   // Used to indicate that an R matrix has not been produced by a prolongator factory, but 
+    int Rplaceholder = -1;   // Used to indicate that an R matrix has not been produced by a prolongator factory, but
                              // that it is capable of producing one and should be invoked a 2nd time in restrictor mode
                              // (e.g. with PgPFactory).  prolongatorFacts_[Rplaceholder] is factory that can produce R
                              // matrix, which might be later invoked by  MueLu_RfromP_Or_TransP
     if (coarseLevel.IsAvailable("RfromPfactory",(prolongatorFacts_[nProlongatorFactory]).get())) {
 	 std::string strType = coarseLevel.GetTypeName("RfromPfactory", (prolongatorFacts_[nProlongatorFactory]).get());
-	 if (strType == "int") Rplaceholder = nProlongatorFactory; 
+	 if (strType == "int") Rplaceholder = nProlongatorFactory;
 	 else R = coarseLevel.Get< RCP<Matrix> >("RfromPfactory", (prolongatorFacts_[nProlongatorFactory]).get());
 	               // Need to get R (and set it below) so that TogglePFactory is given credit for creating R
     }
@@ -168,7 +168,7 @@ namespace MueLu {
     //  Three cases:
     //   1) R already computed and TogglePFactory takes credit for constructing it
     //   2) R not computed but prolongatorFacts_[Rplaceholder] can produce it
-    //   3) R not computed  and prolongator can not produce it 
+    //   3) R not computed  and prolongator can not produce it
     if (R !=  Teuchos::null) Set(coarseLevel, "RfromPfactory", R);
     else if (Rplaceholder !=  -1) Set(coarseLevel, "RfromPfactory",  Teuchos::as<int>(Rplaceholder));
     Set(coarseLevel, "Nullspace", coarseNullspace);

--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_NullspaceFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_NullspaceFactory_def.hpp
@@ -290,8 +290,8 @@ namespace MueLu {
          }
          /*
           // Scale columns to match what Galeri does. Not sure that this is necessary as the qr factorizatoin
-          // of the tentative prolongator also takes care of scaling issues. I'm leaving the code here 
-          // just in case. 
+          // of the tentative prolongator also takes care of scaling issues. I'm leaving the code here
+          // just in case.
           if ( (int) nullspaceDim > numPDEs ) {
             Teuchos::Array<typename Teuchos::ScalarTraits<Scalar>::magnitudeType> norms2(nullspaceDim);
             nullspace->norm2(norms2);

--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_ReitzingerPFactory_decl.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_ReitzingerPFactory_decl.hpp
@@ -92,7 +92,7 @@ namespace MueLu {
      A        | Factory | null |   | * | * | Generating factory of the matrix A
      P        | Factory | null |   | * | * | Generating factory of the nodal Prolongator
      D0       | Factory | null |   | * | * | Generating factory of the discrete gradient operator
-     NodeMatrix  | Factory | null |   | * | * | Generating factory of the nodal A matrix    
+     NodeMatrix  | Factory | null |   | * | * | Generating factory of the nodal A matrix
 
     The * in the @c master.xml column denotes that the parameter is defined in the @c master.xml file.<br>
     The * in the @c validated column means that the parameter is declared in the list of valid input parameters (see ReitzingerPFactory::GetValidParameters).<br>
@@ -140,7 +140,7 @@ template <class Scalar = DefaultScalar,
     //@{
 
     void Build (Level& fineLevel, Level& coarseLevel) const;
-    void BuildP(Level& fineLevel, Level& coarseLevel) const; 
+    void BuildP(Level& fineLevel, Level& coarseLevel) const;
 
     //@}
 

--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_ReitzingerPFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_ReitzingerPFactory_def.hpp
@@ -208,7 +208,7 @@ namespace MueLu {
     size_t Nn=NodeMatrix->getLocalNumRows();
 
     // Upper bound on local number of coarse edges
-    size_t max_edges = (NodeMatrix->getLocalNumEntries() + Nn +1) / 2;      
+    size_t max_edges = (NodeMatrix->getLocalNumEntries() + Nn +1) / 2;
     ArrayRCP<size_t>  D0_rowptr(Ne+1);
     ArrayRCP<LO>      D0_colind(max_edges);
     ArrayRCP<SC>      D0_values(max_edges);
@@ -308,7 +308,7 @@ namespace MueLu {
     // We're assuming that if the coarse NodeMatrix has no nodes on a rank, the coarse edge guy won't either.
     // We check that here.
     TEUCHOS_TEST_FOR_EXCEPTION( (num_coarse_edges > 0  && CoarseNodeMatrix.is_null()) ||
-                                (num_coarse_edges == 0 && !CoarseNodeMatrix.is_null()) 
+                                (num_coarse_edges == 0 && !CoarseNodeMatrix.is_null())
                                 , Exceptions::RuntimeError, "MueLu::ReitzingerPFactory: Mismatched num_coarse_edges and NodeMatrix repartition.");
     
 
@@ -318,7 +318,7 @@ namespace MueLu {
 
 
     // NOTE:  This only works because of the assumptions above
-    RCP<const Map> ownedCoarseNodeMap = Pn->getDomainMap(); 
+    RCP<const Map> ownedCoarseNodeMap = Pn->getDomainMap();
     RCP<const Map> ownedPlusSharedCoarseNodeMap  = D0_Pn->getCrsGraph()->getColMap();
 
     // Create the coarse D0
@@ -341,7 +341,7 @@ namespace MueLu {
       D0_coarse->setAllValues(ia, ja, val);
 
 #if 0
-      { 
+      {
         char fname[80];
         printf("[%d] D0: ia.size() = %d ja.size() = %d\n",MyPID,(int)ia.size(),(int)ja.size());
         printf("[%d] D0: ia  :",MyPID);
@@ -353,7 +353,7 @@ namespace MueLu {
         printf("\n[%d] D0: local ja  :",MyPID);
         for(int i=0; i<(int)ja.size(); i++)
           printf("%d ",(int)ja[i]);
-        printf("\n");        
+        printf("\n");
 
         sprintf(fname,"D0_global_ja_%d_%d.dat",MyPID,fineLevel.GetLevelID());
         FILE * f = fopen(fname,"w");
@@ -395,10 +395,10 @@ namespace MueLu {
 
       // TODO: Something like this *might* work.  But this specifically, doesn;'t
       // Pe = XMM::Multiply(*D0_Pn_nonghosted,false,*D0_coarse_m,true,dummy,out0,true,true,"(D0*Pn)*D0c'",mm_params);
-    }  
+    }
 
     /* Weed out the +/- entries */
-    { 
+    {
       SubFactoryMonitor m2(*this, "Generate Pe (post-fix)", coarseLevel);
       Pe->resumeFill();
       SC one = Teuchos::ScalarTraits<SC>::one();
@@ -449,9 +449,9 @@ namespace MueLu {
     coarseLevel.AddKeepFlag("D0",NoFactory::get(), MueLu::Final);
     coarseLevel.RemoveKeepFlag("D0",NoFactory::get(), MueLu::UserData);
    
-#if 0 
+#if 0
   {
-    int numProcs = Pe->getRowMap()->getComm()->getSize();       
+    int numProcs = Pe->getRowMap()->getComm()->getSize();
     char fname[80];
 
     sprintf(fname,"Pe_%d_%d.mat",numProcs,fineLevel.GetLevelID());  Xpetra::IO<SC,LO,GO,NO>::Write(fname,*Pe);
@@ -465,7 +465,7 @@ namespace MueLu {
 
  template <class Scalar,class LocalOrdinal, class GlobalOrdinal, class Node>
  void ReitzingerPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
- CheckCommutingProperty(const Matrix & Pe, const Matrix & D0_c, const Matrix& D0_f, const Matrix & Pn) const {   
+ CheckCommutingProperty(const Matrix & Pe, const Matrix & D0_c, const Matrix& D0_f, const Matrix & Pn) const {
    if(IsPrint(Statistics0)) {
      using XMM = Xpetra::MatrixMatrix<SC,LO,GO,NO>;
      using MT   = typename Teuchos::ScalarTraits<SC>::magnitudeType;
@@ -473,17 +473,17 @@ namespace MueLu {
      SC zero = Teuchos::ScalarTraits<SC>::zero();
 
      RCP<Matrix> dummy;
-     Teuchos::FancyOStream &out0=GetBlackHole();     
+     Teuchos::FancyOStream &out0=GetBlackHole();
      RCP<Matrix> left  = XMM::Multiply(Pe,false,D0_c,false,dummy,out0);
      RCP<Matrix> right = XMM::Multiply(D0_f,false,Pn,false,dummy,out0);
      
      // We need a non-FC matrix for the add, sadly
-     RCP<CrsMatrix> sum_c = CrsMatrixFactory::Build(left->getRowMap(),left->getLocalMaxNumRowEntries()+right->getLocalMaxNumRowEntries());    
+     RCP<CrsMatrix> sum_c = CrsMatrixFactory::Build(left->getRowMap(),left->getLocalMaxNumRowEntries()+right->getLocalMaxNumRowEntries());
      RCP<Matrix> summation = rcp(new CrsMatrixWrap(sum_c));
      XMM::TwoMatrixAdd(*left,  false, one, *summation, zero);
      XMM::TwoMatrixAdd(*right, false, -one, *summation, one);
      
-     MT norm = summation->getFrobeniusNorm();     
+     MT norm = summation->getFrobeniusNorm();
      GetOStream(Statistics0) << "CheckCommutingProperty: ||Pe D0_c - D0_f Pn || = "<<norm<<std::endl;
     
    }

--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_SaPFactory_decl.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_SaPFactory_decl.hpp
@@ -140,7 +140,7 @@ template <class Scalar = DefaultScalar,
     /*!
       @brief Enforce constraints on prolongator
 
-      Modifies the prolongator so that all entries lie between 0 and 1. It also 
+      Modifies the prolongator so that all entries lie between 0 and 1. It also
       ensures that the row sum is between 0 and 1. This option only makes
       sense in the SA constext if the tentative prolgonator does not use
       the QR factorization.

--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_SaPFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_SaPFactory_def.hpp
@@ -289,7 +289,7 @@ namespace MueLu {
 
   // Analyze the grid transfer produced by smoothed aggregation and make
   // modifications if it does not look right. In particular, if there are
-  // negative entries or entries larger than 1, modify P's rows. 
+  // negative entries or entries larger than 1, modify P's rows.
   //
   // Note: this kind of evaluation probably only makes sense if not doing QR
   // when constructing tentative P.
@@ -298,8 +298,8 @@ namespace MueLu {
   // these entries to the constraint value and modify the rest of the row
   // so that the row sum remains the same as before by adding an equal
   // amount to each remaining entry. However, if the original row sum value
-  // violates the constraints, we set the row sum back to 1 (the row sum of 
-  // tentative P). After doing the modification to a row, we need to check 
+  // violates the constraints, we set the row sum back to 1 (the row sum of
+  // tentative P). After doing the modification to a row, we need to check
   // again the entire row to make sure that the modified row does not violate
   // the constraints.
 
@@ -331,22 +331,22 @@ namespace MueLu {
 
       bool checkRow = true;
 
-      while (checkRow) { 
+      while (checkRow) {
 
         // check constraints and compute the row sum
     
         for (LO j = 0; j < indices.size(); j++)  {
-          Rsum[ j%nPDEs ] += vals[j]; 
-          if (Teuchos::ScalarTraits<SC>::real(vals[j]) < Teuchos::ScalarTraits<SC>::real(zero)) { 
-            ConstraintViolationSum[ j%nPDEs ] += vals[j]; 
+          Rsum[ j%nPDEs ] += vals[j];
+          if (Teuchos::ScalarTraits<SC>::real(vals[j]) < Teuchos::ScalarTraits<SC>::real(zero)) {
+            ConstraintViolationSum[ j%nPDEs ] += vals[j];
             vals[j] = zero;
           }
           else {
             if (Teuchos::ScalarTraits<SC>::real(vals[j]) != Teuchos::ScalarTraits<SC>::real(zero))
               (nPositive[ j%nPDEs])++;
     
-            if (Teuchos::ScalarTraits<SC>::real(vals[j]) > Teuchos::ScalarTraits<SC>::real(1.00001  )) { 
-              ConstraintViolationSum[ j%nPDEs ] += (vals[j] - one); 
+            if (Teuchos::ScalarTraits<SC>::real(vals[j]) > Teuchos::ScalarTraits<SC>::real(1.00001  )) {
+              ConstraintViolationSum[ j%nPDEs ] += (vals[j] - one);
               vals[j] = one;
             }
           }
@@ -359,14 +359,14 @@ namespace MueLu {
         for (size_t k=0; k < (size_t) nPDEs; k++) {
 
           if (Teuchos::ScalarTraits<SC>::real(Rsum[ k ]) < Teuchos::ScalarTraits<SC>::magnitude(zero)) {
-              ConstraintViolationSum[k] +=  (-Rsum[k]);  // rstumin 
+              ConstraintViolationSum[k] +=  (-Rsum[k]);  // rstumin
           }
           else if (Teuchos::ScalarTraits<SC>::real(Rsum[ k ]) > Teuchos::ScalarTraits<SC>::magnitude(1.00001)) {
               ConstraintViolationSum[k] += (one - Rsum[k]);  // rstumin
           }
         }
 
-        // check if row need modification 
+        // check if row need modification
         for (size_t k=0; k < (size_t) nPDEs; k++) {
           if (Teuchos::ScalarTraits<SC>::magnitude(ConstraintViolationSum[ k ]) != Teuchos::ScalarTraits<SC>::magnitude(zero))
              checkRow = true;
@@ -374,13 +374,13 @@ namespace MueLu {
         // modify row
         if (checkRow) {
            for (LO j = 0; j < indices.size(); j++)  {
-             if (Teuchos::ScalarTraits<SC>::real(vals[j]) > Teuchos::ScalarTraits<SC>::real(zero)) { 
+             if (Teuchos::ScalarTraits<SC>::real(vals[j]) > Teuchos::ScalarTraits<SC>::real(zero)) {
                 vals[j] += (ConstraintViolationSum[j%nPDEs]/ (as<Scalar>(nPositive[j%nPDEs])));
              }
            }
-           for (size_t k=0; k < (size_t) nPDEs; k++) ConstraintViolationSum[k] = zero; 
+           for (size_t k=0; k < (size_t) nPDEs; k++) ConstraintViolationSum[k] = zero;
         }
-        for (size_t k=0; k < (size_t) nPDEs; k++) Rsum[k] = zero; 
+        for (size_t k=0; k < (size_t) nPDEs; k++) Rsum[k] = zero;
         for (size_t k=0; k < (size_t) nPDEs; k++) nPositive[k] = 0;
       } // while (checkRow) ...
     } // for (size_t i = 0; i < as<size_t>(P->getRowMap()->getNumNodeElements()); i++) ...
@@ -392,7 +392,7 @@ namespace MueLu {
     const Scalar zero = Teuchos::ScalarTraits<Scalar>::zero();
     const Scalar one  = Teuchos::ScalarTraits<Scalar>::one();
 
-    LocalOrdinal  maxEntriesPerRow = 100; // increased later if needed 
+    LocalOrdinal  maxEntriesPerRow = 100; // increased later if needed
     Teuchos::ArrayRCP<Scalar> scalarData(3*maxEntriesPerRow);
     bool hasFeasible;
 
@@ -439,10 +439,10 @@ namespace MueLu {
 
      fixedUnsorted  on output, if a feasible solutuion exists then
                     || orig - fixedUnsorted || = min  when also
-                    leftBound <= fixedUnsorted[i] <= rghtBound for all i 
+                    leftBound <= fixedUnsorted[i] <= rghtBound for all i
                     and  sum(fixedUnsorted) = rsumTarget.
 
-                    Note: it is possible to use the same pointer for 
+                    Note: it is possible to use the same pointer for
                     fixedUnsorted and orig. In this case, orig gets
                     overwritten with the new constraint satisfying values.
  
@@ -452,77 +452,77 @@ namespace MueLu {
 */
 
 /*
-  Given a sequence of numbers    o1  ... on, fix these so that they are as 
-  close as possible to the original but satisfy bound constraints and also 
-  have the same row sum as the oi's. If we know who is going to lie on a  
-  bound, then the "best" answer (i.e., || o - f ||_2 = min)  perturbs 
-  each element that doesn't lie on a bound by the same amount. 
+  Given a sequence of numbers    o1  ... on, fix these so that they are as
+  close as possible to the original but satisfy bound constraints and also
+  have the same row sum as the oi's. If we know who is going to lie on a
+  bound, then the "best" answer (i.e., || o - f ||_2 = min)  perturbs
+  each element that doesn't lie on a bound by the same amount.
    
   We can represent the oi's by considering scattered points on a number line
 
                  |                                                   |
                  |                                                   |
-   o      o    o |  o        o     o           o       o     o       |o       o 
+   o      o    o |  o        o     o           o       o     o       |o       o
                  |                                                   |
                                                                       
                  \____/                                              \____/
                  <----                                               <----
                  delta                                               delta
 
-  Bounds are shown by vertical lines. The fi's must lie within the bounds, so 
+  Bounds are shown by vertical lines. The fi's must lie within the bounds, so
   the 3 leftmost points must be shifted to the right and the 2 rightmost must
   be shifted to the left. If these fi points are all shifted to the bounds
-  while the others remain in the same location, the row sum constraint is 
+  while the others remain in the same location, the row sum constraint is
   likely not satisfied and so more shifting is necessary.  In the figure, the f
-  rowsum is too large and so there must be more shifting to the left. 
+  rowsum is too large and so there must be more shifting to the left.
 
-  To minimize || o - f ||_2, we basically shift all "interiors" by the same 
+  To minimize || o - f ||_2, we basically shift all "interiors" by the same
   amount, denoted delta. The only trick is that some points near bounds are
   still affected by the bounds and so these points might be shifted more or less
   than delta. In the example,t he 3 rightmost points are shifted in the opposite
-  direction as delta to the bound. The 4th point is shifted by something less 
-  than delta so it does not violate the lower bound. The rightmost point is 
+  direction as delta to the bound. The 4th point is shifted by something less
+  than delta so it does not violate the lower bound. The rightmost point is
   shifted to the bound by some amount larger than delta. However, the 2nd point
-  is shifted by delta (i.e., it lies inside the two bounds). 
+  is shifted by delta (i.e., it lies inside the two bounds).
 
   If we know delta, we can figure out everything. If we know which points
   are special (not shifted by delta), we can also figure out everything.
-  The problem is these two things (delta and the special points) are 
+  The problem is these two things (delta and the special points) are
   inter-connected. An algorithm for computing follows.
 
   1) move exterior points to the bounds and compute how much the row sum is off
      (rowSumDeviation). We assume now that the new row sum is high, so interior
-     points must be shifted left. 
+     points must be shifted left.
 
   2) Mark closest point just left of the leftmost bound, closestToLeftBound,
      and compute its distance to the leftmost bound.  Mark closest point to the
      left of the rightmost bound, closestToRghtBound, and compute its distance to
-     right bound. There are two cases to consider. 
+     right bound. There are two cases to consider.
 
   3) Case 1: closestToLeftBound is closer than closestToRghtBound.
-     Assume that shifting by delta does not move closestToLeftBound past the 
-     left bound. This means that it will be shifted by delta. However, 
+     Assume that shifting by delta does not move closestToLeftBound past the
+     left bound. This means that it will be shifted by delta. However,
      closestToRghtBound will be shifted by more than delta.  So the total
-     number of points shifted by delta (|interiorToBounds|) includes 
-     closestToLeftBound up to and including the point just to the left of 
-     closestToRghtBound. So 
+     number of points shifted by delta (|interiorToBounds|) includes
+     closestToLeftBound up to and including the point just to the left of
+     closestToRghtBound. So
 
                   delta = rowSumDeviation/ |interiorToBounds| .
 
-     Recall that rowSumDeviation already accounts for the non-delta shift of 
+     Recall that rowSumDeviation already accounts for the non-delta shift of
      of closestToRightBound.  Now check whether our assumption is valid.
 
-     If delta <= closestToLeftBoundDist, assumption is true so delta can be 
+     If delta <= closestToLeftBoundDist, assumption is true so delta can be
      applied to interiorToBounds ... and we are done.
-     Else assumption is false. Shift closestToLeftBound to the left bound. 
-     Update rowSumDeviation, interiorToBounds, and identify new 
+     Else assumption is false. Shift closestToLeftBound to the left bound.
+     Update rowSumDeviation, interiorToBounds, and identify new
      closestToLeftBound. Repeat step 3).
 
      Case 2: closestToRghtBound is closer than closestToLeftBound.
-     Assume that shifting by delta does not move closestToRghtBound past right 
+     Assume that shifting by delta does not move closestToRghtBound past right
      bound. This means that it must be shifted by more than delta to right
      bound.  So the total number of points shifted by delta again includes
-     closestToLeftBound up to and including the point just to the left of 
+     closestToLeftBound up to and including the point just to the left of
      closestToRghtBound. So again compute
 
                   delta = rowSumDeviation/ |interiorToBounds| .
@@ -535,8 +535,8 @@ namespace MueLu {
 
 
   To implement, sort the oi's so things like closestToLeftBound is just index
-  into sorted array.  Updaing closestToLeftBound or closestToRghtBound requires 
-  increment by 1.  |interiorToBounds|= closestToRghtBound -  closestToLeftBound 
+  into sorted array.  Updaing closestToLeftBound or closestToRghtBound requires
+  increment by 1.  |interiorToBounds|= closestToRghtBound -  closestToLeftBound
   To handle the case when the rowsum is low (requiring right interior shifts),
   just flip the signs on data and use the left-shift code (and then flip back
   before exiting function.
@@ -546,25 +546,25 @@ namespace MueLu {
   Scalar rowSumDeviation, temp, *fixedSorted, delta;
   Scalar closestToLeftBoundDist, closestToRghtBoundDist;
   LocalOrdinal    closestToLeftBound, closestToRghtBound;
-  LocalOrdinal    *inds; 
+  LocalOrdinal    *inds;
   bool   flipped;
 
-  notFlippedLeftBound = leftBound; 
-  notFlippedRghtBound = rghtBound; 
+  notFlippedLeftBound = leftBound;
+  notFlippedRghtBound = rghtBound;
 
-  if ((Teuchos::ScalarTraits<SC>::real(rsumTarget) >= Teuchos::ScalarTraits<SC>::real(leftBound*as<Scalar>(nEntries))) && 
+  if ((Teuchos::ScalarTraits<SC>::real(rsumTarget) >= Teuchos::ScalarTraits<SC>::real(leftBound*as<Scalar>(nEntries))) &&
       (Teuchos::ScalarTraits<SC>::real(rsumTarget) <= Teuchos::ScalarTraits<SC>::real(rghtBound*as<Scalar>(nEntries))))
-    hasFeasibleSol = true; 
+    hasFeasibleSol = true;
   else {
-    hasFeasibleSol=false; 
-    return hasFeasibleSol; 
+    hasFeasibleSol=false;
+    return hasFeasibleSol;
   }
   flipped    = false;
   // compute aBigNumber to handle some corner cases where we need
   // something large so that an if statement will be false
   aBigNumber = Teuchos::ScalarTraits<SC>::zero();
   for (LocalOrdinal i = 0; i < nEntries; i++) {
-    if ( Teuchos::ScalarTraits<SC>::magnitude(orig[i]) > Teuchos::ScalarTraits<SC>::magnitude(aBigNumber)) 
+    if ( Teuchos::ScalarTraits<SC>::magnitude(orig[i]) > Teuchos::ScalarTraits<SC>::magnitude(aBigNumber))
       aBigNumber = Teuchos::ScalarTraits<SC>::magnitude(orig[i]);
   }
   aBigNumber = aBigNumber+ (Teuchos::ScalarTraits<SC>::magnitude(leftBound) + Teuchos::ScalarTraits<SC>::magnitude(rghtBound))*as<Scalar>(100.0);
@@ -573,10 +573,10 @@ namespace MueLu {
   fixedSorted = &(scalarData[nEntries]);
   inds        = (LocalOrdinal    *) &(scalarData[2*nEntries]);
 
-  for (LocalOrdinal i = 0; i < nEntries; i++) inds[i] = i; 
+  for (LocalOrdinal i = 0; i < nEntries; i++) inds[i] = i;
   for (LocalOrdinal i = 0; i < nEntries; i++) origSorted[i] = orig[i];  /* orig no longer used */
 
-  // sort so that  orig[inds] is sorted. 
+  // sort so that  orig[inds] is sorted.
   std::sort(inds, inds+nEntries,
             [origSorted](LocalOrdinal leftIndex, LocalOrdinal rightIndex)
                  { return Teuchos::ScalarTraits<SC>::real(origSorted[leftIndex]) < Teuchos::ScalarTraits<SC>::real(origSorted[rightIndex]);});
@@ -590,8 +590,8 @@ namespace MueLu {
   closestToRghtBound = closestToLeftBound;
   while ((closestToRghtBound < nEntries) && (Teuchos::ScalarTraits<SC>::real(origSorted[closestToRghtBound]) <= Teuchos::ScalarTraits<SC>::real(rghtBound))) closestToRghtBound++;
 
-  // compute distance between closestToLeftBound and the left bound and the 
-  // distance between closestToRghtBound and the right bound. 
+  // compute distance between closestToLeftBound and the left bound and the
+  // distance between closestToRghtBound and the right bound.
 
   closestToLeftBoundDist = origSorted[closestToLeftBound] - leftBound;
   if (closestToRghtBound==nEntries) closestToRghtBoundDist= aBigNumber;
@@ -600,30 +600,30 @@ namespace MueLu {
   // compute how far the rowSum is off from the target row sum taking into account
   // numbers that have been shifted to satisfy bound constraint
 
-  rowSumDeviation = leftBound*as<Scalar>(closestToLeftBound) + as<Scalar>((nEntries-closestToRghtBound))*rghtBound - rsumTarget; 
+  rowSumDeviation = leftBound*as<Scalar>(closestToLeftBound) + as<Scalar>((nEntries-closestToRghtBound))*rghtBound - rsumTarget;
   for (LocalOrdinal i=closestToLeftBound; i < closestToRghtBound; i++) rowSumDeviation += origSorted[i];
 
   // the code that follow after this if statement assumes that rowSumDeviation is positive. If this
-  // is not the case, flip the signs of everything so that rowSumDeviation is now positive. 
+  // is not the case, flip the signs of everything so that rowSumDeviation is now positive.
   // Later we will flip the data back to its original form.
   if (Teuchos::ScalarTraits<SC>::real(rowSumDeviation) < Teuchos::ScalarTraits<SC>::real(Teuchos::ScalarTraits<SC>::zero())) {
     flipped = true;
-    temp = leftBound; leftBound = -rghtBound; rghtBound = temp; 
+    temp = leftBound; leftBound = -rghtBound; rghtBound = temp;
 
     /* flip sign of origSorted and reverse ordering so that the negative version is sorted */
 
     if ((nEntries%2) == 1) origSorted[(nEntries/2)  ] =  -origSorted[(nEntries/2)  ];
     for (LocalOrdinal i=0; i < nEntries/2; i++) {
       temp=origSorted[i];
-      origSorted[i] = -origSorted[nEntries-1-i]; 
+      origSorted[i] = -origSorted[nEntries-1-i];
       origSorted[nEntries-i-1] = -temp;
     }
   
     /* reverse bounds */
 
-    LocalOrdinal itemp = closestToLeftBound; 
+    LocalOrdinal itemp = closestToLeftBound;
     closestToLeftBound = nEntries-closestToRghtBound;
-    closestToRghtBound = nEntries-itemp; 
+    closestToRghtBound = nEntries-itemp;
     closestToLeftBoundDist = origSorted[closestToLeftBound] - leftBound;
     if (closestToRghtBound==nEntries) closestToRghtBoundDist= aBigNumber;
     else                              closestToRghtBoundDist= origSorted[closestToRghtBound] - rghtBound;
@@ -640,15 +640,15 @@ namespace MueLu {
   while ((Teuchos::ScalarTraits<SC>::magnitude(rowSumDeviation) > Teuchos::ScalarTraits<SC>::magnitude(as<Scalar>(1.e-10)*rsumTarget))){ // && ( (closestToLeftBound < nEntries ) || (closestToRghtBound < nEntries))) {
    if (closestToRghtBound !=  closestToLeftBound)
         delta = rowSumDeviation/ as<Scalar>(closestToRghtBound -  closestToLeftBound);
-   else delta = aBigNumber; 
+   else delta = aBigNumber;
 
    if (Teuchos::ScalarTraits<SC>::magnitude(closestToLeftBoundDist) <= Teuchos::ScalarTraits<SC>::magnitude(closestToRghtBoundDist)) {
       if (Teuchos::ScalarTraits<SC>::magnitude(delta) <= Teuchos::ScalarTraits<SC>::magnitude(closestToLeftBoundDist)) {
-        rowSumDeviation = Teuchos::ScalarTraits<SC>::zero(); 
+        rowSumDeviation = Teuchos::ScalarTraits<SC>::zero();
         for (LocalOrdinal i = closestToLeftBound; i < closestToRghtBound ; i++) fixedSorted[i] = origSorted[i] - delta;
       }
       else {
-        rowSumDeviation = rowSumDeviation - closestToLeftBoundDist; 
+        rowSumDeviation = rowSumDeviation - closestToLeftBoundDist;
         fixedSorted[closestToLeftBound] = leftBound;
         closestToLeftBound++;
         if (closestToLeftBound < nEntries) closestToLeftBoundDist = origSorted[closestToLeftBound] - leftBound;
@@ -657,12 +657,12 @@ namespace MueLu {
    }
    else {
       if (Teuchos::ScalarTraits<SC>::magnitude(delta) <= Teuchos::ScalarTraits<SC>::magnitude(closestToRghtBoundDist)) {
-        rowSumDeviation = 0; 
+        rowSumDeviation = 0;
         for (LocalOrdinal i = closestToLeftBound; i < closestToRghtBound ; i++) fixedSorted[i] = origSorted[i] - delta;
       }
       else {
         rowSumDeviation = rowSumDeviation + closestToRghtBoundDist;
-//        if (closestToRghtBound < nEntries) { 
+//        if (closestToRghtBound < nEntries) {
           fixedSorted[closestToRghtBound] = origSorted[closestToRghtBound];
           closestToRghtBound++;
  //       }
@@ -678,7 +678,7 @@ namespace MueLu {
     if ((nEntries%2) == 1) fixedSorted[(nEntries/2)  ] =  -fixedSorted[(nEntries/2)  ];
     for (LocalOrdinal i=0; i < nEntries/2; i++) {
       temp=fixedSorted[i];
-      fixedSorted[i] = -fixedSorted[nEntries-1-i]; 
+      fixedSorted[i] = -fixedSorted[nEntries-1-i];
       fixedSorted[nEntries-i-1] = -temp;
     }
   }
@@ -691,7 +691,7 @@ namespace MueLu {
   bool sumViolation = false;
   using TST = Teuchos::ScalarTraits<SC>;
   temp = TST::zero();
-  for (LocalOrdinal i = 0; i < nEntries; i++)  { 
+  for (LocalOrdinal i = 0; i < nEntries; i++)  {
     if (TST::real(fixedUnsorted[i]) < TST::real(notFlippedLeftBound)) lowerViolation = true;
     if (TST::real(fixedUnsorted[i]) > TST::real(notFlippedRghtBound)) upperViolation = true;
     temp += fixedUnsorted[i];

--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_SaPFactory_kokkos_def.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_SaPFactory_kokkos_def.hpp
@@ -141,9 +141,9 @@ namespace MueLu {
 
     // Reuse pattern if available
     RCP<ParameterList> APparams;
-    if(pL.isSublist("matrixmatrix: kernel params")) 
+    if(pL.isSublist("matrixmatrix: kernel params"))
       APparams=rcp(new ParameterList(pL.sublist("matrixmatrix: kernel params")));
-    else 
+    else
       APparams= rcp(new ParameterList);
     if (coarseLevel.IsAvailable("AP reuse data", this)) {
       GetOStream(static_cast<MsgType>(Runtime0 | Test)) << "Reusing previous AP data" << std::endl;
@@ -253,7 +253,7 @@ namespace MueLu {
 
   // Analyze the grid transfer produced by smoothed aggregation and make
   // modifications if it does not look right. In particular, if there are
-  // negative entries or entries larger than 1, modify P's rows. 
+  // negative entries or entries larger than 1, modify P's rows.
   //
   // Note: this kind of evaluation probably only makes sense if not doing QR
   // when constructing tentative P.
@@ -262,8 +262,8 @@ namespace MueLu {
   // these entries to the constraint value and modify the rest of the row
   // so that the row sum remains the same as before by adding an equal
   // amount to each remaining entry. However, if the original row sum value
-  // violates the constraints, we set the row sum back to 1 (the row sum of 
-  // tentative P). After doing the modification to a row, we need to check 
+  // violates the constraints, we set the row sum back to 1 (the row sum of
+  // tentative P). After doing the modification to a row, we need to check
   // again the entire row to make sure that the modified row does not violate
   // the constraints.
 
@@ -300,23 +300,23 @@ struct constraintKernel {
       if (rowPtr(rowIdx + 1) == rowPtr(rowIdx)) checkRow = false;
 
 
-      while (checkRow) { 
+      while (checkRow) {
 
         // check constraints and compute the row sum
     
         for (auto entryIdx = rowPtr(rowIdx); entryIdx < rowPtr(rowIdx + 1); entryIdx++)  {
-          Rsum(rowIdx, entryIdx%nPDEs) += values(entryIdx); 
-          if (Kokkos::ArithTraits<SC>::real(values(entryIdx)) < Kokkos::ArithTraits<SC>::real(zero)) { 
+          Rsum(rowIdx, entryIdx%nPDEs) += values(entryIdx);
+          if (Kokkos::ArithTraits<SC>::real(values(entryIdx)) < Kokkos::ArithTraits<SC>::real(zero)) {
 
-            ConstraintViolationSum(rowIdx, entryIdx%nPDEs) += values(entryIdx); 
+            ConstraintViolationSum(rowIdx, entryIdx%nPDEs) += values(entryIdx);
             values(entryIdx) = zero;
           }
           else {
             if (Kokkos::ArithTraits<SC>::real(values(entryIdx)) != Kokkos::ArithTraits<SC>::real(zero))
               nPositive(rowIdx, entryIdx%nPDEs) = nPositive(rowIdx, entryIdx%nPDEs) + 1;
     
-            if (Kokkos::ArithTraits<SC>::real(values(entryIdx)) > Kokkos::ArithTraits<SC>::real(1.00001  )) { 
-              ConstraintViolationSum(rowIdx, entryIdx%nPDEs) += (values(entryIdx) - one); 
+            if (Kokkos::ArithTraits<SC>::real(values(entryIdx)) > Kokkos::ArithTraits<SC>::real(1.00001  )) {
+              ConstraintViolationSum(rowIdx, entryIdx%nPDEs) += (values(entryIdx) - one);
               values(entryIdx) =  one;
             }
           }
@@ -329,14 +329,14 @@ struct constraintKernel {
         for (size_t k=0; k < (size_t) nPDEs; k++) {
 
           if (Kokkos::ArithTraits<SC>::real(Rsum(rowIdx, k)) < Kokkos::ArithTraits<SC>::magnitude(zero)) {
-              ConstraintViolationSum(rowIdx, k) = ConstraintViolationSum(rowIdx, k) - Rsum(rowIdx, k);  // rstumin 
+              ConstraintViolationSum(rowIdx, k) = ConstraintViolationSum(rowIdx, k) - Rsum(rowIdx, k);  // rstumin
           }
           else if (Kokkos::ArithTraits<SC>::real(Rsum(rowIdx, k)) > Kokkos::ArithTraits<SC>::magnitude(1.00001)) {
               ConstraintViolationSum(rowIdx, k) = ConstraintViolationSum(rowIdx, k)+ (one - Rsum(rowIdx, k));  // rstumin
           }
         }
 
-        // check if row need modification 
+        // check if row need modification
         for (size_t k=0; k < (size_t) nPDEs; k++) {
           if (Kokkos::ArithTraits<SC>::magnitude(ConstraintViolationSum(rowIdx, k)) != Kokkos::ArithTraits<SC>::magnitude(zero))
              checkRow = true;
@@ -344,14 +344,14 @@ struct constraintKernel {
         // modify row
         if (checkRow) {
 	   for (auto entryIdx = rowPtr(rowIdx); entryIdx < rowPtr(rowIdx + 1); entryIdx++)  {
-             if (Kokkos::ArithTraits<SC>::real(values(entryIdx)) > Kokkos::ArithTraits<SC>::real(zero)) { 
+             if (Kokkos::ArithTraits<SC>::real(values(entryIdx)) > Kokkos::ArithTraits<SC>::real(zero)) {
 	       values(entryIdx) = values(entryIdx) +
 		 (ConstraintViolationSum(rowIdx, entryIdx%nPDEs)/ (Scalar (nPositive(rowIdx, entryIdx%nPDEs)) != zero ? Scalar (nPositive(rowIdx, entryIdx%nPDEs)) : one));
              }
            }
-           for (size_t k=0; k < (size_t) nPDEs; k++) ConstraintViolationSum(rowIdx, k) = zero; 
+           for (size_t k=0; k < (size_t) nPDEs; k++) ConstraintViolationSum(rowIdx, k) = zero;
         }
-        for (size_t k=0; k < (size_t) nPDEs; k++) Rsum(rowIdx, k) = zero; 
+        for (size_t k=0; k < (size_t) nPDEs; k++) Rsum(rowIdx, k) = zero;
         for (size_t k=0; k < (size_t) nPDEs; k++) nPositive(rowIdx, k) = 0;
       } // while (checkRow) ...
 
@@ -403,7 +403,7 @@ struct optimalSatisfyConstraintsForScalarPDEsKernel {
 
          SC leftBound = zero;
          SC rghtBound = one;
-         if ((KAT::real(rsumTarget) >= KAT::real(leftBound*(static_cast<SC>(nnz)))) && 
+         if ((KAT::real(rsumTarget) >= KAT::real(leftBound*(static_cast<SC>(nnz)))) &&
              (KAT::real(rsumTarget) <= KAT::real(rghtBound*(static_cast<SC>(nnz))))){ // has Feasible solution
 
            flipped    = false;
@@ -411,7 +411,7 @@ struct optimalSatisfyConstraintsForScalarPDEsKernel {
            // something large so that an if statement will be false
            aBigNumber = KAT::zero();
            for (auto entryIdx = rowPtr(rowIdx); entryIdx < rowPtr(rowIdx + 1); entryIdx++){
-             if ( KAT::magnitude( values(entryIdx) ) > KAT::magnitude(aBigNumber)) 
+             if ( KAT::magnitude( values(entryIdx) ) > KAT::magnitude(aBigNumber))
                aBigNumber = KAT::magnitude( values(entryIdx) );
            }
            aBigNumber = aBigNumber+ (KAT::magnitude(leftBound) + KAT::magnitude(rghtBound))*(100*one);
@@ -453,8 +453,8 @@ struct optimalSatisfyConstraintsForScalarPDEsKernel {
            closestToRghtBound = closestToLeftBound;
            while ((closestToRghtBound < static_cast<LO>(nnz)) && (KAT::real(origSorted(rowIdx, closestToRghtBound)) <= KAT::real(rghtBound))) closestToRghtBound++;
   
-           // compute distance between closestToLeftBound and the left bound and the 
-           // distance between closestToRghtBound and the right bound. 
+           // compute distance between closestToLeftBound and the left bound and the
+           // distance between closestToRghtBound and the right bound.
         
            closestToLeftBoundDist = origSorted(rowIdx, closestToLeftBound) - leftBound;
            if (closestToRghtBound == static_cast<LO>(nnz)) closestToRghtBoundDist= aBigNumber;
@@ -463,15 +463,15 @@ struct optimalSatisfyConstraintsForScalarPDEsKernel {
            // compute how far the rowSum is off from the target row sum taking into account
            // numbers that have been shifted to satisfy bound constraint
   
-           rowSumDeviation = leftBound*(static_cast<SC>(closestToLeftBound)) + (static_cast<SC>(nnz-closestToRghtBound))*rghtBound - rsumTarget; 
+           rowSumDeviation = leftBound*(static_cast<SC>(closestToLeftBound)) + (static_cast<SC>(nnz-closestToRghtBound))*rghtBound - rsumTarget;
            for (LO i=closestToLeftBound; i < closestToRghtBound; i++) rowSumDeviation += origSorted(rowIdx, i);
   
            // the code that follow after this if statement assumes that rowSumDeviation is positive. If this
-           // is not the case, flip the signs of everything so that rowSumDeviation is now positive. 
+           // is not the case, flip the signs of everything so that rowSumDeviation is now positive.
            // Later we will flip the data back to its original form.
            if (KAT::real(rowSumDeviation) < KAT::real(KAT::zero())) {
              flipped = true;
-             temp = leftBound; leftBound = -rghtBound; rghtBound = temp; 
+             temp = leftBound; leftBound = -rghtBound; rghtBound = temp;
          
              /* flip sign of origSorted and reverse ordering so that the negative version is sorted */
          
@@ -479,15 +479,15 @@ struct optimalSatisfyConstraintsForScalarPDEsKernel {
              if ((nnz%2) == 1) origSorted(rowIdx, (nnz/2)  ) =  -origSorted(rowIdx, (nnz/2)  );
              for (LO i=0; i < static_cast<LO>(nnz/2); i++) {
                temp=origSorted(rowIdx, i);
-               origSorted(rowIdx, i) = -origSorted(rowIdx, nnz-1-i); 
+               origSorted(rowIdx, i) = -origSorted(rowIdx, nnz-1-i);
                origSorted(rowIdx, nnz-i-1) = -temp;
              }
            
              /* reverse bounds */
          
-             LO itemp = closestToLeftBound; 
+             LO itemp = closestToLeftBound;
              closestToLeftBound = nnz-closestToRghtBound;
-             closestToRghtBound = nnz-itemp; 
+             closestToRghtBound = nnz-itemp;
              closestToLeftBoundDist = origSorted(rowIdx, closestToLeftBound) - leftBound;
              if (closestToRghtBound == static_cast<LO>(nnz)) closestToRghtBoundDist= aBigNumber;
              else                                closestToRghtBoundDist= origSorted(rowIdx, closestToRghtBound) - rghtBound;
@@ -504,7 +504,7 @@ struct optimalSatisfyConstraintsForScalarPDEsKernel {
            while ((KAT::magnitude(rowSumDeviation) > KAT::magnitude((one*1.e-10)*rsumTarget))){ // && ( (closestToLeftBound < nEntries ) || (closestToRghtBound < nEntries))) {
             if (closestToRghtBound !=  closestToLeftBound)
                  delta = rowSumDeviation/ static_cast<SC>(closestToRghtBound -  closestToLeftBound);
-            else delta = aBigNumber; 
+            else delta = aBigNumber;
          
             if (KAT::magnitude(closestToLeftBoundDist) <= KAT::magnitude(closestToRghtBoundDist)) {
                if (KAT::magnitude(delta) <= KAT::magnitude(closestToLeftBoundDist)) {
@@ -512,7 +512,7 @@ struct optimalSatisfyConstraintsForScalarPDEsKernel {
                  for (LO i = closestToLeftBound; i < closestToRghtBound ; i++) fixedSorted(rowIdx, i) = origSorted(rowIdx, i) - delta;
                }
                else {
-                 rowSumDeviation = rowSumDeviation - closestToLeftBoundDist; 
+                 rowSumDeviation = rowSumDeviation - closestToLeftBoundDist;
                  fixedSorted(rowIdx, closestToLeftBound) = leftBound;
                  closestToLeftBound++;
                  if (closestToLeftBound < static_cast<LO>(nnz)) closestToLeftBoundDist = origSorted(rowIdx, closestToLeftBound) - leftBound;
@@ -526,7 +526,7 @@ struct optimalSatisfyConstraintsForScalarPDEsKernel {
                }
                else {
                  rowSumDeviation = rowSumDeviation + closestToRghtBoundDist;
-         //        if (closestToRghtBound < nEntries) { 
+         //        if (closestToRghtBound < nEntries) {
                    fixedSorted(rowIdx, closestToRghtBound) = origSorted(rowIdx, closestToRghtBound);
                    closestToRghtBound++;
           //       }
@@ -543,7 +543,7 @@ struct optimalSatisfyConstraintsForScalarPDEsKernel {
              if ((nnz%2) == 1) fixedSorted(rowIdx, (nnz/2)  ) =  -fixedSorted(rowIdx, (nnz/2)  );
              for (LO i=0; i < static_cast<LO>(nnz/2); i++) {
                temp=fixedSorted(rowIdx, i);
-               fixedSorted(rowIdx, i) = -fixedSorted(rowIdx, nnz-1-i); 
+               fixedSorted(rowIdx, i) = -fixedSorted(rowIdx, nnz-1-i);
                fixedSorted(rowIdx, nnz-i-1) = -temp;
              }
            }

--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_ScaledNullspaceFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_ScaledNullspaceFactory_def.hpp
@@ -91,11 +91,11 @@ namespace MueLu {
         tentativeNullspace = currentLevel.Get< RCP<MultiVector> >("Nullspace", NoFactory::get());
       } else {
         // A User "Nullspace" (nspName) is not available (use factory)
-        tentativeNullspace = currentLevel.Get< RCP<MultiVector> >("Nullspace", GetFactory("Nullspace").get()); 
+        tentativeNullspace = currentLevel.Get< RCP<MultiVector> >("Nullspace", GetFactory("Nullspace").get());
 
       } // end if "Nullspace" not available
     } else {
-      tentativeNullspace = currentLevel.Get< RCP<MultiVector> >("Nullspace", GetFactory("Nullspace").get()); 
+      tentativeNullspace = currentLevel.Get< RCP<MultiVector> >("Nullspace", GetFactory("Nullspace").get());
     }
 
   
@@ -112,7 +112,7 @@ namespace MueLu {
     }
    
     GetOStream(Runtime1) << "ScaledNullspaceFactory: Generating scaled nullspace, blocksize = "<< tentativeNullspace->getNumVectors() <<std::endl;
-    nullspace = MultiVectorFactory::Build(tentativeNullspace->getMap(), tentativeNullspace->getNumVectors());  
+    nullspace = MultiVectorFactory::Build(tentativeNullspace->getMap(), tentativeNullspace->getNumVectors());
     *nullspace = *tentativeNullspace;  // Copy the tentative nullspace
     RCP<MultiVector> blockDiagonal = MultiVectorFactory::Build(A->getDomainMap(), numPDEs);
     

--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_def.hpp
@@ -280,7 +280,7 @@ namespace MueLu {
                           RCP<const Map> coarsePointMap, RCP<Matrix>& Ptentative, RCP<MultiVector>& coarseNullspace, const int levelID) const {
 #ifdef HAVE_MUELU_TPETRA
 
-    /* This routine generates a BlockCrs P for a BlockCrs A.  There are a few assumptions here, which meet the use cases we care about, but could 
+    /* This routine generates a BlockCrs P for a BlockCrs A.  There are a few assumptions here, which meet the use cases we care about, but could
        be generalized later, if we ever need to do so:
        1) Null space dimension === block size of matrix:  So no elasticity right now
        2) QR is not supported:  Under assumption #1, this shouldn't cause problems.
@@ -314,7 +314,7 @@ namespace MueLu {
                                                       Teuchos::OrdinalTraits<Xpetra::global_size_t>::invalid(),
                                                       numCoarseBlockRows,
                                                       coarsePointMap->getIndexBase(),
-                                                      coarsePointMap->getComm());    
+                                                      coarsePointMap->getComm());
     // Sanity checking
     const ParameterList& pL = GetParameterList();
     const bool &doQRStep = pL.get<bool>("tentative: calculate qr");
@@ -356,7 +356,7 @@ namespace MueLu {
     }
 
     // BlockCrs requires that we build the (block) graph first, so let's do that...
-    // NOTE: Because we're assuming that the NSDim == BlockSize, we only have one 
+    // NOTE: Because we're assuming that the NSDim == BlockSize, we only have one
     // block non-zero per row in the matrix;
     RCP<CrsGraph> BlockGraph = CrsGraphFactory::Build(rowMap,coarseBlockMap,0);
     ArrayRCP<size_t>  iaPtent;
@@ -381,7 +381,7 @@ namespace MueLu {
         const LO localRow = aggToRowMapLO[aggStart[agg]+j];
         const size_t rowStart = ia[localRow];
         ja[rowStart] = offset;
-      }      
+      }
     }
 
     // Compress storage (remove all INVALID, which happen when we skip zeros)
@@ -454,7 +454,7 @@ namespace MueLu {
 
         for (size_t r = 0; r < NSDim; r++) {
           LO localPointRow = localBlockRow*NSDim + r;
-          for (size_t c = 0; c < NSDim; c++) 
+          for (size_t c = 0; c < NSDim; c++)
             block[r*NSDim+c] = fineNS[c][localPointRow];
         }
         // NOTE: Assumes columns==aggs and are ordered sequentially

--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_kokkos_decl.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_kokkos_decl.hpp
@@ -156,7 +156,7 @@ namespace MueLu {
 
     // NOTE: All of thess should really be private, but CUDA doesn't like that
     
-    void BuildPuncoupledBlockCrs(Level& coarseLevel, RCP<Matrix> A, RCP<Aggregates_kokkos> aggregates, RCP<AmalgamationInfo_kokkos> amalgInfo, 
+    void BuildPuncoupledBlockCrs(Level& coarseLevel, RCP<Matrix> A, RCP<Aggregates_kokkos> aggregates, RCP<AmalgamationInfo_kokkos> amalgInfo,
                                  RCP<MultiVector> fineNullspace, RCP<const Map> coarseMap, RCP<Matrix>& Ptentative, RCP<MultiVector>& coarseNullspace, const int levelID) const;
 
 

--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_kokkos_def.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_kokkos_def.hpp
@@ -985,7 +985,7 @@ namespace MueLu {
                   RCP<const Map> coarsePointMap, RCP<Matrix>& Ptentative,
                   RCP<MultiVector>& coarseNullspace, const int levelID) const {
 #ifdef HAVE_MUELU_TPETRA
-  /* This routine generates a BlockCrs P for a BlockCrs A.  There are a few assumptions here, which meet the use cases we care about, but could 
+  /* This routine generates a BlockCrs P for a BlockCrs A.  There are a few assumptions here, which meet the use cases we care about, but could
        be generalized later, if we ever need to do so:
        1) Null space dimension === block size of matrix:  So no elasticity right now
        2) QR is not supported:  Under assumption #1, this shouldn't cause problems.
@@ -1032,7 +1032,7 @@ namespace MueLu {
                                                       Teuchos::OrdinalTraits<Xpetra::global_size_t>::invalid(),
                                                       numCoarseBlockRows,
                                                       coarsePointMap->getIndexBase(),
-                                                      coarsePointMap->getComm());    
+                                                      coarsePointMap->getComm());
     // Sanity checking
     const ParameterList& pL = GetParameterList();
     //    const bool &doQRStep = pL.get<bool>("tentative: calculate qr");
@@ -1080,7 +1080,7 @@ namespace MueLu {
       aggDofSizes = AggSizeType("agg_dof_sizes", numAggregates+1);
 
       Kokkos::deep_copy(Kokkos::subview(aggDofSizes, Kokkos::make_pair(static_cast<size_t>(1), numAggregates+1)), aggSizes);
-    } 
+    }
 
     // Find maximum dof size for aggregates
     // Later used to reserve enough scratch space for local QR decompositions
@@ -1148,7 +1148,7 @@ namespace MueLu {
 
     // BlockCrs requires that we build the (block) graph first, so let's do that...
 
-    // NOTE: Because we're assuming that the NSDim == BlockSize, we only have one 
+    // NOTE: Because we're assuming that the NSDim == BlockSize, we only have one
     // block non-zero per row in the matrix;
     rows_type ia(Kokkos::ViewAllocateWithoutInitializing("BlockGraph_rowptr"), numFineBlockRows+1);
     cols_type ja(Kokkos::ViewAllocateWithoutInitializing("BlockGraph_colind"), numFineBlockRows);
@@ -1190,7 +1190,7 @@ namespace MueLu {
       LO nnz=0;
       Kokkos::parallel_scan("MueLu:TentativePF:BlockCrs:compress_rows", range_type(0,numFineBlockRows),
                             KOKKOS_LAMBDA(const LO i, LO& upd, const bool& final) {
-                              if(final) 
+                              if(final)
                                 i_temp[i] = upd;
                               for (auto j = ia[i]; j < ia[i+1]; j++)
                                 if (ja[j] != INVALID)
@@ -1211,7 +1211,7 @@ namespace MueLu {
                                  j_temp[rowStart+lnnz] = ja[j];
                                  lnnz++;
                                }
-                           });     
+                           });
       
       ia = i_temp;
       ja = j_temp;
@@ -1274,7 +1274,7 @@ namespace MueLu {
 
                            // R = norm
                            for(LO j=0; j<(LO)NSDim; j++)
-                             coarseNS(offset+j,j) = one;                                                    
+                             coarseNS(offset+j,j) = one;
                          });
 
   Ptentative = P_wrap;

--- a/packages/muelu/src/Utils/MueLu_AvatarInterface.cpp
+++ b/packages/muelu/src/Utils/MueLu_AvatarInterface.cpp
@@ -45,10 +45,10 @@
 // @HEADER
 #include "MueLu_AvatarInterface.hpp"
 
-#include <string> 
-#include <fstream> 
-#include <sstream> 
-#include <vector> 
+#include <string>
+#include <fstream>
+#include <sstream>
+#include <vector>
 #include "Teuchos_Array.hpp"
 #include "Teuchos_CommHelpers.hpp"
 #include "MueLu_BaseClass.hpp"
@@ -130,7 +130,7 @@ RCP<const ParameterList> AvatarInterface::GetValidParameterList() const {
   validParamList->set<int>("avatar: good class",int_dummy,"Numeric code for class Avatar considers to be good");
 
    // Which drop tol choice heuristic to use
-  validParamList->set<int>("avatar: heuristic",int_dummy,"Numeric code for which heuristic we want to use");  
+  validParamList->set<int>("avatar: heuristic",int_dummy,"Numeric code for which heuristic we want to use");
 
   // Bounds file for extrapolation risk
   validParamList->set<Teuchos::Array<std::string> >("avatar: bounds file",ar_dummy,"Bounds file for Avatar extrapolation risk");
@@ -246,7 +246,7 @@ void AvatarInterface::UnpackMueLuMapping() {
   const Teuchos::ParameterList & mapping = params_.get<Teuchos::ParameterList>("avatar: muelu parameter mapping");
   // Each MueLu/Avatar parameter pair gets its own sublist.  These must be numerically ordered with no gap
 
-  bool done=false; 
+  bool done=false;
   int idx=0;
   int numParams = mapping.numParams();
 
@@ -256,7 +256,7 @@ void AvatarInterface::UnpackMueLuMapping() {
   avatarParameterValues_.resize(numParams);
 
   while(!done) {
-    std::stringstream ss; 
+    std::stringstream ss;
     ss << "param" << idx;
     if(mapping.isSublist(ss.str())) {
       const Teuchos::ParameterList & sublist = mapping.sublist(ss.str());
@@ -268,7 +268,7 @@ void AvatarInterface::UnpackMueLuMapping() {
       // Get the values
       //FIXME: For now we assume that all of these guys are doubles and their Avatar analogues are doubles
       mueluParameterValues_[idx]  = sublist.get<Teuchos::Array<double> >("muelu values");
-      avatarParameterValues_[idx] = sublist.get<Teuchos::Array<double> >("avatar values");            
+      avatarParameterValues_[idx] = sublist.get<Teuchos::Array<double> >("avatar values");
 
       idx++;
     }
@@ -277,7 +277,7 @@ void AvatarInterface::UnpackMueLuMapping() {
     }
   }
 
-  if(idx!=numParams) 
+  if(idx!=numParams)
     throw std::runtime_error("MueLu::AvatarInterface::UnpackMueLuMapping(): 'avatar: muelu parameter mapping' has unknown fields");
 }
 // ***********************************************************************
@@ -376,41 +376,41 @@ void AvatarInterface::SetMueLuParameters(const Teuchos::ParameterList & problemF
       const int test_data_is_a_string = 1;
       avatar_test(avatarHandle_,const_cast<char*>(testString.c_str()),test_data_is_a_string,predictions.data(),probabilities.data());
 
-    // Look at the list of acceptable combinations of options 
+    // Look at the list of acceptable combinations of options
     std::vector<int> acceptableCombos; acceptableCombos.reserve(100);
-    for(int i=0; i<num_combos; i++) {    
-      if(predictions[i] == avatarGoodClass_) acceptableCombos.push_back(i);      
+    for(int i=0; i<num_combos; i++) {
+      if(predictions[i] == avatarGoodClass_) acceptableCombos.push_back(i);
     }
     GetOStream(Runtime0)<< "MueLu::AvatarInterface: "<< acceptableCombos.size() << " acceptable option combinations found"<<std::endl;
 
     // Did we have any good combos at all?
     int chosen_option_id = 0;
-    if(acceptableCombos.size() == 0) { 
+    if(acceptableCombos.size() == 0) {
       GetOStream(Runtime0) << "WARNING: MueLu::AvatarInterface: found *no* combinations of options which it believes will perform well on this problem" <<std::endl
-                           << "         An arbitrary set of options will be chosen instead"<<std::endl;    
+                           << "         An arbitrary set of options will be chosen instead"<<std::endl;
     }
     else {
-      // If there is only one acceptable combination, use it; 
+      // If there is only one acceptable combination, use it;
       // otherwise, find the parameter choice with the highest
       // probability of success
       if(acceptableCombos.size() == 1){
 	chosen_option_id = acceptableCombos[0];
-      } 
+      }
       else {
 	switch (heuristicToUse_){
-	  case 1: 
+	  case 1:
 		chosen_option_id = hybrid(probabilities.data(), acceptableCombos);
 		break;
-	  case 2: 
+	  case 2:
 		chosen_option_id = highProb(probabilities.data(), acceptableCombos);
 		break;
-	  case 3: 
+	  case 3:
 		// Choose the first option in the list of acceptable
-		// combinations; the lowest drop tolerance among the 
+		// combinations; the lowest drop tolerance among the
 		// acceptable combinations
 		chosen_option_id = acceptableCombos[0];
 		break;
-	  case 4: 
+	  case 4:
 		chosen_option_id = lowCrash(probabilities.data(), acceptableCombos);
 		break;
 	  case 5:
@@ -429,7 +429,7 @@ void AvatarInterface::SetMueLuParameters(const Teuchos::ParameterList & problemF
     } else {
       GenerateMueLuParametersFromIndex(chosen_option_id,avatarParams);
     }
-  } 
+  }
 
   Teuchos::updateParametersAndBroadcast(outArg(avatarParams),outArg(mueluParams),*comm_,0,overwrite);
 
@@ -440,7 +440,7 @@ int AvatarInterface::checkBounds(std::string trialString, Teuchos::ArrayRCP<std:
   std::stringstream ss(trialString);
   std::vector<double> vect;
 
-  double b; 
+  double b;
   while (ss >> b)  {
     vect.push_back(b);
     if (ss.peek() == ',') ss.ignore();
@@ -450,14 +450,14 @@ int AvatarInterface::checkBounds(std::string trialString, Teuchos::ArrayRCP<std:
   std::vector<double> boundsVect;
 
   while (ssBounds >> b) {
-    boundsVect.push_back(b);    
+    boundsVect.push_back(b);
     if (ssBounds.peek() == ',') ssBounds.ignore();
   }
 
   int min_idx = (int) std::min(vect.size(),boundsVect.size()/2);
 
   bool inbounds=true;
-  for(int i=0; inbounds && i<min_idx; i++) 
+  for(int i=0; inbounds && i<min_idx; i++)
     inbounds =  boundsVect[2*i] <= vect[i] && vect[i] <= boundsVect[2*i+1];
 
   return (int) inbounds;
@@ -473,16 +473,16 @@ int AvatarInterface::hybrid(float * probabilities, std::vector<int> acceptableCo
     this_combo = acceptableCombos[x] * 3;
     diff = probabilities[this_combo] - low_crash;
      // If this parameter combination has a crash
-     // probability .2 lower than the current "best", we 
+     // probability .2 lower than the current "best", we
      // will use this drop tolerance
     if(diff < -.2){
       low_crash =  probabilities[this_combo];
       best_prob = probabilities[this_combo + 2];
       chosen_option_id = acceptableCombos[x];
-    } 
+    }
     // If this parameter combination has the same
     // or slightly lower crash probability than the
-    // current best, we compare their "GOOD" probabilities 
+    // current best, we compare their "GOOD" probabilities
     else if(diff <= 0 && probabilities[this_combo + 2] > best_prob){
       low_crash =  probabilities[this_combo];
       best_prob = probabilities[this_combo + 2];
@@ -498,11 +498,11 @@ int AvatarInterface::highProb(float * probabilities, std::vector<int> acceptable
   int chosen_option_id = acceptableCombos[0];
   for(int x=0; x<(int)acceptableCombos.size(); x++){
     this_combo = acceptableCombos[x] * 3;
-    // If this parameter combination has a higher "GOOD" 
+    // If this parameter combination has a higher "GOOD"
     // probability, use this combination
     if(probabilities[this_combo + 2] > high_prob){
       high_prob = probabilities[this_combo + 2];
-      chosen_option_id = acceptableCombos[x]; 
+      chosen_option_id = acceptableCombos[x];
     }
   }
   return chosen_option_id;
@@ -518,7 +518,7 @@ int AvatarInterface::lowCrash(float * probabilities, std::vector<int> acceptable
     // probability, use this combination
     if(probabilities[this_combo] < low_crash){
       low_crash = probabilities[this_combo];
-      chosen_option_id = acceptableCombos[x]; 
+      chosen_option_id = acceptableCombos[x];
     }
   }
   return chosen_option_id;
@@ -534,16 +534,16 @@ int AvatarInterface::weighted(float * probabilities, std::vector<int> acceptable
     this_combo = acceptableCombos[x] * 3;
     diff = probabilities[this_combo] - low_crash;
      // If this parameter combination has a crash
-     // probability .2 lower than the current "best", we 
+     // probability .2 lower than the current "best", we
      // will use this drop tolerance
     if(diff < -.2){
       low_crash =  probabilities[this_combo];
       best_prob = probabilities[this_combo + 2];
       chosen_option_id = acceptableCombos[x];
-    } 
+    }
     // If this parameter combination is within .1
     // or has a slightly lower crash probability than the
-    // current best, we compare their "GOOD" probabilities 
+    // current best, we compare their "GOOD" probabilities
     else if(diff <= .1 && probabilities[this_combo + 2] > best_prob){
       low_crash =  probabilities[this_combo];
       best_prob = probabilities[this_combo + 2];

--- a/packages/muelu/src/Utils/MueLu_AvatarInterface.hpp
+++ b/packages/muelu/src/Utils/MueLu_AvatarInterface.hpp
@@ -63,7 +63,7 @@ typedef struct Avatar_struct Avatar_handle;
 
 namespace MueLu {
 
-  /*! @class 
+  /*! @class
     Manages the interface to the Avatar machine learning library.
 
     Note only proc 0 (as defined by comm) will actually have avatar instantiated.  The options determined
@@ -93,17 +93,17 @@ namespace MueLu {
     // Clean up the handle
     void Cleanup();
 
-    // Returns 1 if the given parameters are within same 
+    // Returns 1 if the given parameters are within same
     // same domain as training data, 0 otherwise
     int checkBounds(std::string trialString, Teuchos::ArrayRCP<std::string> boundsString) const;
 
-    int hybrid(float * probabilities, std::vector<int> acceptableCombos) const; 
+    int hybrid(float * probabilities, std::vector<int> acceptableCombos) const;
 
-    int highProb(float * probabilities, std::vector<int> acceptableCombos) const; 
+    int highProb(float * probabilities, std::vector<int> acceptableCombos) const;
  
-    int lowCrash(float * probabilities, std::vector<int> acceptableCombos) const; 
+    int lowCrash(float * probabilities, std::vector<int> acceptableCombos) const;
 
-    int weighted(float * probabilities, std::vector<int> acceptableCombos) const; 
+    int weighted(float * probabilities, std::vector<int> acceptableCombos) const;
 
   private:
     // Utility functions

--- a/packages/muelu/src/Utils/MueLu_UtilitiesBase_decl.hpp
+++ b/packages/muelu/src/Utils/MueLu_UtilitiesBase_decl.hpp
@@ -375,7 +375,7 @@ namespace MueLu {
      * @ret: vector containing max_{i\not=k}(-a_ik)
     */
 
-    static Teuchos::ArrayRCP<Magnitude> GetMatrixMaxMinusOffDiagonal(const Xpetra::Matrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>& A) { 
+    static Teuchos::ArrayRCP<Magnitude> GetMatrixMaxMinusOffDiagonal(const Xpetra::Matrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>& A) {
       size_t numRows = A.getRowMap()->getLocalNumElements();
       Magnitude ZERO = Teuchos::ScalarTraits<Magnitude>::zero();
       Teuchos::ArrayRCP<Magnitude> maxvec(numRows);
@@ -388,7 +388,7 @@ namespace MueLu {
           if (Teuchos::as<size_t>(cols[j]) != i) {
             mymax = std::max(mymax,-Teuchos::ScalarTraits<Scalar>::real(vals[j]));
           }
-        }          
+        }
         maxvec[i] = mymax;
       }
       return maxvec;
@@ -411,8 +411,8 @@ namespace MueLu {
           if (Teuchos::as<size_t>(cols[j]) != i && block_id[i] == block_id[cols[j]]) {
             mymax = std::max(mymax,-Teuchos::ScalarTraits<Scalar>::real(vals[j]));
           }
-        }          
-        //        printf("A(%d,:) row_scale(block) = %6.4e\n",(int)i,mymax); 
+        }
+        //        printf("A(%d,:) row_scale(block) = %6.4e\n",(int)i,mymax);
 
         maxvec[i] = mymax;
       }
@@ -853,7 +853,7 @@ namespace MueLu {
     }
 
     /*! @brief Find non-zero values in an ArrayRCP
-      Compares the value to 2 * machine epsilon 
+      Compares the value to 2 * machine epsilon
 
       @param[in]  vals - ArrayRCP<const Scalar> of values to be tested
       @param[out] nonzeros - ArrayRCP<bool> of true/false values for whether each entry in vals is nonzero

--- a/packages/muelu/src/Utils/MueLu_Utilities_def.hpp
+++ b/packages/muelu/src/Utils/MueLu_Utilities_def.hpp
@@ -355,7 +355,7 @@ namespace MueLu {
       }
     } catch (std::bad_cast&) {
         throw Exceptions::BadCast("Cast from Xpetra::Matrix to Xpetra::CrsMatrixWrap failed");
-    }    
+    }
   }
 
 

--- a/packages/muelu/src/Utils/MueLu_Utilities_kokkos_def.hpp
+++ b/packages/muelu/src/Utils/MueLu_Utilities_kokkos_def.hpp
@@ -377,10 +377,10 @@ namespace MueLu {
       auto b_graph      = Am.getCrsGraph().getLocalGraphDevice();
       auto b_rowptr     = Am.getCrsGraph().getLocalRowPtrsDevice();
       auto values       = Am.getValuesDevice();
-      LO   numBlockRows = Am.getLocalNumRows();      
+      LO   numBlockRows = Am.getLocalNumRows();
       const LO stride   = Am.getBlockSize() * Am.getBlockSize();
 
-      Kokkos::View<bool*, typename NO::device_type> boundaryNodes(Kokkos::ViewAllocateWithoutInitializing("boundaryNodes"), numBlockRows);      
+      Kokkos::View<bool*, typename NO::device_type> boundaryNodes(Kokkos::ViewAllocateWithoutInitializing("boundaryNodes"), numBlockRows);
 
       if (count_twos_as_dirichlet)
         throw Exceptions::RuntimeError("BlockCrs does not support counting twos as Dirichlet");
@@ -409,14 +409,14 @@ namespace MueLu {
                            });
 
       return boundaryNodes;
-#else 
+#else
       throw Exceptions::RuntimeError("BlockCrs requires Tpetra");
 #endif
-    } 
+    }
     else {
       auto localMatrix = A.getLocalMatrixDevice();
       LO   numRows     = A.getLocalNumRows();
-      Kokkos::View<bool*, typename NO::device_type> boundaryNodes(Kokkos::ViewAllocateWithoutInitializing("boundaryNodes"), numRows);      
+      Kokkos::View<bool*, typename NO::device_type> boundaryNodes(Kokkos::ViewAllocateWithoutInitializing("boundaryNodes"), numRows);
 
       if (count_twos_as_dirichlet)
         Kokkos::parallel_for("MueLu:Utils::DetectDirichletRows_Twos_As_Dirichlet", range_type(0,numRows),

--- a/packages/muelu/src/Utils/MueLu_VisualizationHelpers_def.hpp
+++ b/packages/muelu/src/Utils/MueLu_VisualizationHelpers_def.hpp
@@ -165,7 +165,7 @@ namespace MueLu {
 	  pointsAndIndex[i] = std::make_pair(myVec2(xCoords[aggNodes[i]], yCoords[aggNodes[i]]),i);
 	}
 
-	// Sort by x coordinate    
+	// Sort by x coordinate
 	std::sort(pointsAndIndex.begin(),pointsAndIndex.end(),[](const MyPair &a, const MyPair &b) {
 	    return a.first.x < b.first.x || (a.first.x == b.first.x && a.first.y < b.first.y);
 	  });
@@ -185,7 +185,7 @@ namespace MueLu {
 	  vertices.push_back(aggNodes[pointsAndIndex.back().second]);
 	  geomSizes.push_back(2);
 	}
-	else {      
+	else {
 	  std::vector<int> hull(2*N);
 	  int count=0;
 	  

--- a/packages/muelu/test/maxwell/Maxwell_Reitzinger.xml
+++ b/packages/muelu/test/maxwell/Maxwell_Reitzinger.xml
@@ -11,17 +11,17 @@
     <Parameter name="smoother: type" type="string" value="HIPTMAIR"/>
     <ParameterList name="smoother: params">
       <Parameter name="hiptmair: smoother type 1" type="string" value="RELAXATION"/>
-      <Parameter name="hiptmair: smoother type 2" type="string" value="RELAXATION"/>      
+      <Parameter name="hiptmair: smoother type 2" type="string" value="RELAXATION"/>
       <ParameterList name="hiptmair: smoother list 1">
         <Parameter name="relaxation: type" type="string" value="Symmetric Gauss-Seidel"/>
         <Parameter name="relaxation: sweeps" type="int" value="1"/>
         <Parameter name="relaxation: use l1" type="bool" value="true"/>
-      </ParameterList>    
+      </ParameterList>
       <ParameterList name="hiptmair: smoother list 2">
         <Parameter name="relaxation: type" type="string" value="Symmetric Gauss-Seidel"/>
         <Parameter name="relaxation: sweeps" type="int" value="1"/>
         <Parameter name="relaxation: use l1" type="bool" value="true"/>
-      </ParameterList>    
+      </ParameterList>
     </ParameterList>
   </ParameterList>
 

--- a/packages/muelu/test/maxwell/Maxwell_Reitzinger_repart.xml
+++ b/packages/muelu/test/maxwell/Maxwell_Reitzinger_repart.xml
@@ -16,17 +16,17 @@
 
     <ParameterList name="smoother: params">
       <Parameter name="hiptmair: smoother type 1" type="string" value="RELAXATION"/>
-      <Parameter name="hiptmair: smoother type 2" type="string" value="RELAXATION"/>      
+      <Parameter name="hiptmair: smoother type 2" type="string" value="RELAXATION"/>
       <ParameterList name="hiptmair: smoother list 1">
         <Parameter name="relaxation: type" type="string" value="Symmetric Gauss-Seidel"/>
         <Parameter name="relaxation: sweeps" type="int" value="1"/>
         <Parameter name="relaxation: use l1" type="bool" value="true"/>
-      </ParameterList>    
+      </ParameterList>
       <ParameterList name="hiptmair: smoother list 2">
         <Parameter name="relaxation: type" type="string" value="Symmetric Gauss-Seidel"/>
         <Parameter name="relaxation: sweeps" type="int" value="1"/>
         <Parameter name="relaxation: use l1" type="bool" value="true"/>
-      </ParameterList>    
+      </ParameterList>
     </ParameterList>
   </ParameterList>
 

--- a/packages/muelu/test/maxwell/ReitzingerPFactory.cpp
+++ b/packages/muelu/test/maxwell/ReitzingerPFactory.cpp
@@ -78,7 +78,7 @@
 using Teuchos::RCP;
 using Teuchos::rcp;
 
-// Copy & paste from MueLu_TestHelpers.cpp 
+// Copy & paste from MueLu_TestHelpers.cpp
 namespace MueLuTests {
 
   // static members initialization of the class TestHelpers::Parameters
@@ -87,7 +87,7 @@ namespace MueLuTests {
 }
 
 template <class Scalar,class LocalOrdinal, class GlobalOrdinal, class Node>
- typename Teuchos::ScalarTraits<Scalar>::magnitudeType 
+ typename Teuchos::ScalarTraits<Scalar>::magnitudeType
 CheckCommutingProperty(MueLu::Level & nodeLevel_coarse, MueLu::Level & edgeLevel_fine, MueLu::Level & edgeLevel_coarse) {
 #include <MueLu_UseShortNames.hpp>
   RCP<Matrix> Pn = nodeLevel_coarse.Get<RCP<Matrix> >("P");
@@ -107,12 +107,12 @@ CheckCommutingProperty(MueLu::Level & nodeLevel_coarse, MueLu::Level & edgeLevel
   RCP<Matrix> right = XMM::Multiply(*D0_f,false,*Pn,false,dummy,*out0);
   
   // We need a non-FC matrix for the add, sadly
-  RCP<CrsMatrix> sum_c = CrsMatrixFactory::Build(left->getRowMap(),left->getLocalMaxNumRowEntries()+right->getLocalMaxNumRowEntries());    
+  RCP<CrsMatrix> sum_c = CrsMatrixFactory::Build(left->getRowMap(),left->getLocalMaxNumRowEntries()+right->getLocalMaxNumRowEntries());
   RCP<Matrix> summation = rcp(new CrsMatrixWrap(sum_c));
   XMM::TwoMatrixAdd(*left,  false, one, *summation, zero);
   XMM::TwoMatrixAdd(*right, false, -one, *summation, one);
   
-  MT norm = summation->getFrobeniusNorm();     
+  MT norm = summation->getFrobeniusNorm();
   return norm;
 }
 
@@ -120,8 +120,8 @@ CheckCommutingProperty(MueLu::Level & nodeLevel_coarse, MueLu::Level & edgeLevel
 
 
 template<typename Scalar,class LocalOrdinal,class GlobalOrdinal,class Node>
-void read_matrix(Xpetra::UnderlyingLib & lib,RCP<const Teuchos::Comm<int> > & comm, 
-                 RCP<Xpetra::Matrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > & SM_Matrix, 
+void read_matrix(Xpetra::UnderlyingLib & lib,RCP<const Teuchos::Comm<int> > & comm,
+                 RCP<Xpetra::Matrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > & SM_Matrix,
                  RCP<Xpetra::Matrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > & D0_Matrix,
                  RCP<Xpetra::Matrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > & Kn_Matrix,
                  RCP<Xpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::magnitudeType, LocalOrdinal, GlobalOrdinal, Node> > & coords) {
@@ -214,7 +214,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(ReitzingerPFactory, Setup2Level_Unsmoothed, Sc
   out<<"*** Setting Up Node Hierarchy *** "<<std::endl;
   {
     RCP<MueLu::Level> Finest = NodeH.GetLevel();
-    Finest->setDefaultVerbLevel(Teuchos::VERB_HIGH);  
+    Finest->setDefaultVerbLevel(Teuchos::VERB_HIGH);
     Finest->Set("A", Kn_Matrix);
 
     // Level 0
@@ -222,9 +222,9 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(ReitzingerPFactory, Setup2Level_Unsmoothed, Sc
     M0.SetKokkosRefactor(false);
     
     // Level 1 (Plain aggregation)
-    FactoryManager M1; 
+    FactoryManager M1;
     M1.SetKokkosRefactor(false);
-    Teuchos::ParameterList tp_list; 
+    Teuchos::ParameterList tp_list;
     tp_list.set("tentative: constant column sums",false);
     tp_list.set("tentative: calculate qr",false);
     RCP<TentativePFactory>        PnodalFact = rcp(new TentativePFactory());
@@ -237,18 +237,18 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(ReitzingerPFactory, Setup2Level_Unsmoothed, Sc
     r = NodeH.Setup(1, rcpFromRef(M0), rcpFromRef(M1), Teuchos::null); TEST_EQUALITY(r, true);
     RCP<Level> l0 = NodeH.GetLevel(0);
     RCP<Level> l1 = NodeH.GetLevel(1);
-  }  
+  }
 
   out<<"*** Copy Node->Edge Data *** "<<std::endl;
   // Copy Data to Edge Hierarchy
-  for(int i=0; i<NumLevels; i++) {  
+  for(int i=0; i<NumLevels; i++) {
     EdgeH.AddNewLevel();
     RCP<Level> NodeL = NodeH.GetLevel(i);
     RCP<Level> EdgeL = EdgeH.GetLevel(i);
 
     EdgeL->Set("NodeMatrix",NodeL->Get<RCP<Matrix> >("A"));
     if(i!=0) {
-      EdgeL->Set("Pnodal",NodeL->Get<RCP<Matrix> >("P"));    
+      EdgeL->Set("Pnodal",NodeL->Get<RCP<Matrix> >("P"));
 
       RCP<const Matrix> P = NodeL->Get<RCP<Matrix> >("P");
       //      Xpetra::IO<SC,LO,GO,NO>::Write("Pn.mat",*P);
@@ -267,7 +267,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(ReitzingerPFactory, Setup2Level_Unsmoothed, Sc
     M0.SetKokkosRefactor(false);
     
     // Level 1 (Plain aggregation)
-    FactoryManager M1; 
+    FactoryManager M1;
     M1.SetKokkosRefactor(false);
     RCP<ReitzingerPFactory> PedgeFact  = rcp(new ReitzingerPFactory());
     M1.SetFactory("P",PedgeFact);
@@ -290,7 +290,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(ReitzingerPFactory, Setup2Level_Unsmoothed, Sc
 
   // Check the commuting property
   using MT = typename Teuchos::ScalarTraits<SC>::magnitudeType;
-  Teuchos::Array<MT> norm(1), norm0(1);  
+  Teuchos::Array<MT> norm(1), norm0(1);
   norm0[0] = Teuchos::ScalarTraits<MT>::zero();
 
   norm[0] = CheckCommutingProperty<SC,LO,GO,NO>(*node_l1,*l0,*l1);
@@ -323,7 +323,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(ReitzingerPFactory, Setup2Level_AlphaSmoothed,
   out<<"*** Setting Up Node Hierarchy *** "<<std::endl;
   {
     RCP<MueLu::Level> Finest = NodeH.GetLevel();
-    Finest->setDefaultVerbLevel(Teuchos::VERB_HIGH);  
+    Finest->setDefaultVerbLevel(Teuchos::VERB_HIGH);
     Finest->Set("A", Kn_Matrix);
 
     // Level 0
@@ -331,9 +331,9 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(ReitzingerPFactory, Setup2Level_AlphaSmoothed,
     M0.SetKokkosRefactor(false);
     
     // Level 1 (Plain aggregation)
-    FactoryManager M1; 
+    FactoryManager M1;
     M1.SetKokkosRefactor(false);
-    Teuchos::ParameterList tp_list; 
+    Teuchos::ParameterList tp_list;
     tp_list.set("tentative: constant column sums",false);
     tp_list.set("tentative: calculate qr",false);
     RCP<TentativePFactory>        PnodalFact = rcp(new TentativePFactory());
@@ -346,18 +346,18 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(ReitzingerPFactory, Setup2Level_AlphaSmoothed,
     r = NodeH.Setup(1, rcpFromRef(M0), rcpFromRef(M1), Teuchos::null); TEST_EQUALITY(r, true);
     RCP<Level> l0 = NodeH.GetLevel(0);
     RCP<Level> l1 = NodeH.GetLevel(1);
-  }  
+  }
 
   out<<"*** Copy Node->Edge Data *** "<<std::endl;
   // Copy Data to Edge Hierarchy
-  for(int i=0; i<NumLevels; i++) {  
+  for(int i=0; i<NumLevels; i++) {
     EdgeH.AddNewLevel();
     RCP<Level> NodeL = NodeH.GetLevel(i);
     RCP<Level> EdgeL = EdgeH.GetLevel(i);
 
     EdgeL->Set("NodeMatrix",NodeL->Get<RCP<Matrix> >("A"));
     if(i!=0) {
-      EdgeL->Set("Pnodal",NodeL->Get<RCP<Matrix> >("P"));    
+      EdgeL->Set("Pnodal",NodeL->Get<RCP<Matrix> >("P"));
 
       RCP<const Matrix> P = NodeL->Get<RCP<Matrix> >("P");
       //      Xpetra::IO<SC,LO,GO,NO>::Write("Pn.mat",*P);
@@ -376,10 +376,10 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(ReitzingerPFactory, Setup2Level_AlphaSmoothed,
     M0.SetKokkosRefactor(false);
     
     // Level 1 (Smoothed Reitzinger)
-    FactoryManager M1; 
+    FactoryManager M1;
     M1.SetKokkosRefactor(false);
     RCP<ReitzingerPFactory> PedgeFact  = rcp(new ReitzingerPFactory());
-    RCP<SaPFactory> PFact = rcp(new SaPFactory());    
+    RCP<SaPFactory> PFact = rcp(new SaPFactory());
     PFact->SetFactory("P",PedgeFact);
     M1.SetFactory("Ptent",PedgeFact);
     M1.SetFactory("P",PFact);
@@ -430,7 +430,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(ReitzingerPFactory, Setup3Level_AlphaSmoothed,
   out<<"*** Setting Up Node Hierarchy *** "<<std::endl;
   {
     RCP<MueLu::Level> Finest = NodeH.GetLevel();
-    Finest->setDefaultVerbLevel(Teuchos::VERB_HIGH);  
+    Finest->setDefaultVerbLevel(Teuchos::VERB_HIGH);
     Finest->Set("A", Kn_Matrix);
     Finest->Set("Coordinates", coords);
 
@@ -442,7 +442,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(ReitzingerPFactory, Setup3Level_AlphaSmoothed,
     FactoryManager M1;
     {
       M1.SetKokkosRefactor(false);
-      Teuchos::ParameterList tp_list; 
+      Teuchos::ParameterList tp_list;
       tp_list.set("tentative: constant column sums",false);
       tp_list.set("tentative: calculate qr",false);
       RCP<TentativePFactory>        PnodalFact = rcp(new TentativePFactory());
@@ -455,7 +455,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(ReitzingerPFactory, Setup3Level_AlphaSmoothed,
     FactoryManager M2;
     {
       M2.SetKokkosRefactor(false);
-      Teuchos::ParameterList tp_list; 
+      Teuchos::ParameterList tp_list;
       tp_list.set("tentative: constant column sums",false);
       tp_list.set("tentative: calculate qr",false);
       RCP<TentativePFactory>        PnodalFact = rcp(new TentativePFactory());
@@ -471,18 +471,18 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(ReitzingerPFactory, Setup3Level_AlphaSmoothed,
     RCP<Level> l0 = NodeH.GetLevel(0);
     RCP<Level> l1 = NodeH.GetLevel(1);
     RCP<Level> l2 = NodeH.GetLevel(2);
-  }  
+  }
 
   out<<"*** Copy Node->Edge Data *** "<<std::endl;
   // Copy Data to Edge Hierarchy
-  for(int i=0; i<NumLevels; i++) {  
+  for(int i=0; i<NumLevels; i++) {
     EdgeH.AddNewLevel();
     RCP<Level> NodeL = NodeH.GetLevel(i);
     RCP<Level> EdgeL = EdgeH.GetLevel(i);
 
     EdgeL->Set("NodeMatrix",NodeL->Get<RCP<Matrix> >("A"));
     if(i!=0) {
-      EdgeL->Set("Pnodal",NodeL->Get<RCP<Matrix> >("P"));    
+      EdgeL->Set("Pnodal",NodeL->Get<RCP<Matrix> >("P"));
 
       RCP<const Matrix> P = NodeL->Get<RCP<Matrix> >("P");
       //      Xpetra::IO<SC,LO,GO,NO>::Write("Pn.mat",*P);
@@ -501,11 +501,11 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(ReitzingerPFactory, Setup3Level_AlphaSmoothed,
     M0.SetKokkosRefactor(false);
     
     // Level 1 (Smoothed Reitzinger)
-    FactoryManager M1; 
+    FactoryManager M1;
     {
       M1.SetKokkosRefactor(false);
       RCP<ReitzingerPFactory> PedgeFact1  = rcp(new ReitzingerPFactory());
-      RCP<SaPFactory> PFact = rcp(new SaPFactory());    
+      RCP<SaPFactory> PFact = rcp(new SaPFactory());
       PFact->SetFactory("P",PedgeFact1);
       M1.SetFactory("Ptent",PedgeFact1);
       M1.SetFactory("D0",PedgeFact1);
@@ -513,11 +513,11 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(ReitzingerPFactory, Setup3Level_AlphaSmoothed,
     }
 
     // Level 2 (just like level 1)
-    FactoryManager M2; 
+    FactoryManager M2;
     {
       M2.SetKokkosRefactor(false);
       RCP<ReitzingerPFactory> PedgeFact2  = rcp(new ReitzingerPFactory());
-      RCP<SaPFactory> PFact = rcp(new SaPFactory());    
+      RCP<SaPFactory> PFact = rcp(new SaPFactory());
       PFact->SetFactory("P",PedgeFact2);
       M2.SetFactory("Ptent",PedgeFact2);
       M2.SetFactory("D0",PedgeFact2);
@@ -574,7 +574,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(ReitzingerPFactory, Setup3Level_Unsmoothed, Sc
   out<<"*** Setting Up Node Hierarchy *** "<<std::endl;
   {
     RCP<MueLu::Level> Finest = NodeH.GetLevel();
-    Finest->setDefaultVerbLevel(Teuchos::VERB_HIGH);  
+    Finest->setDefaultVerbLevel(Teuchos::VERB_HIGH);
     Finest->Set("A", Kn_Matrix);
     Finest->Set("Coordinates", coords);
 
@@ -586,7 +586,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(ReitzingerPFactory, Setup3Level_Unsmoothed, Sc
     FactoryManager M1;
     {
       M1.SetKokkosRefactor(false);
-      Teuchos::ParameterList tp_list; 
+      Teuchos::ParameterList tp_list;
       tp_list.set("tentative: constant column sums",false);
       tp_list.set("tentative: calculate qr",false);
       RCP<TentativePFactory>        PnodalFact = rcp(new TentativePFactory());
@@ -599,7 +599,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(ReitzingerPFactory, Setup3Level_Unsmoothed, Sc
     FactoryManager M2;
     {
       M2.SetKokkosRefactor(false);
-      Teuchos::ParameterList tp_list; 
+      Teuchos::ParameterList tp_list;
       tp_list.set("tentative: constant column sums",false);
       tp_list.set("tentative: calculate qr",false);
       RCP<TentativePFactory>        PnodalFact = rcp(new TentativePFactory());
@@ -615,18 +615,18 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(ReitzingerPFactory, Setup3Level_Unsmoothed, Sc
     RCP<Level> l0 = NodeH.GetLevel(0);
     RCP<Level> l1 = NodeH.GetLevel(1);
     RCP<Level> l2 = NodeH.GetLevel(2);
-  }  
+  }
 
   out<<"*** Copy Node->Edge Data *** "<<std::endl;
   // Copy Data to Edge Hierarchy
-  for(int i=0; i<NumLevels; i++) {  
+  for(int i=0; i<NumLevels; i++) {
     EdgeH.AddNewLevel();
     RCP<Level> NodeL = NodeH.GetLevel(i);
     RCP<Level> EdgeL = EdgeH.GetLevel(i);
 
     EdgeL->Set("NodeMatrix",NodeL->Get<RCP<Matrix> >("A"));
     if(i!=0) {
-      EdgeL->Set("Pnodal",NodeL->Get<RCP<Matrix> >("P"));    
+      EdgeL->Set("Pnodal",NodeL->Get<RCP<Matrix> >("P"));
 
       RCP<const Matrix> P = NodeL->Get<RCP<Matrix> >("P");
       //      Xpetra::IO<SC,LO,GO,NO>::Write("Pn.mat",*P);
@@ -645,7 +645,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(ReitzingerPFactory, Setup3Level_Unsmoothed, Sc
     M0.SetKokkosRefactor(false);
     
     // Level 1 (Plain aggregation)
-    FactoryManager M1; 
+    FactoryManager M1;
     {
       M1.SetKokkosRefactor(false);
       RCP<ReitzingerPFactory> PFact  = rcp(new ReitzingerPFactory());
@@ -655,7 +655,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(ReitzingerPFactory, Setup3Level_Unsmoothed, Sc
     }
 
     // Level 2 (just like level 1)
-    FactoryManager M2; 
+    FactoryManager M2;
     {
       M2.SetKokkosRefactor(false);
       RCP<ReitzingerPFactory> PFact  = rcp(new ReitzingerPFactory());
@@ -691,7 +691,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(ReitzingerPFactory, Setup3Level_Unsmoothed, Sc
 
   // Check the commuting property
   using MT = typename Teuchos::ScalarTraits<SC>::magnitudeType;
-  Teuchos::Array<MT> norm(1), norm0(1);  
+  Teuchos::Array<MT> norm(1), norm0(1);
   norm0[0] = Teuchos::ScalarTraits<MT>::zero();
 
   norm[0] = CheckCommutingProperty<SC,LO,GO,NO>(*node_l1,*l0,*l1);

--- a/packages/muelu/test/scaling/ImportPerformance.cpp
+++ b/packages/muelu/test/scaling/ImportPerformance.cpp
@@ -482,7 +482,7 @@ int main_(Teuchos::CommandLineProcessor &clp,  Xpetra::UnderlyingLib &lib, int a
     bool        printTimings      = true;             clp.setOption("timings", "notimings",  &printTimings,      "print timings to screen");
     std::string timingsFormat     = "table-fixed";    clp.setOption("time-format",           &timingsFormat,     "timings format (table-fixed | table-scientific | yaml)");
     int         numImports        = 100;              clp.setOption("numImport",             &numImports,        "#times to test");
-    int         MM_TAFC_OptCoreCnt=3000;              clp.setOption("MM_TAFC_OptimizationCoreCount",       &MM_TAFC_OptCoreCnt, "Num Cores above which Optimized MatrixMatrix transferAndFillComplete is used"); 
+    int         MM_TAFC_OptCoreCnt=3000;              clp.setOption("MM_TAFC_OptimizationCoreCount",       &MM_TAFC_OptCoreCnt, "Num Cores above which Optimized MatrixMatrix transferAndFillComplete is used");
 
     switch (clp.parse(argc, argv)) {
         case Teuchos::CommandLineProcessor::PARSE_HELP_PRINTED:        return EXIT_SUCCESS;
@@ -494,7 +494,7 @@ int main_(Teuchos::CommandLineProcessor &clp,  Xpetra::UnderlyingLib &lib, int a
     ParameterList paramList;
     Teuchos::updateParametersFromXmlFileAndBroadcast(xmlFileName, Teuchos::Ptr<ParameterList>(&paramList), *comm);
 
-    ParameterList& mmlist = paramList.sublist("matrixmatrix: kernel params",false);  
+    ParameterList& mmlist = paramList.sublist("matrixmatrix: kernel params",false);
     int commandcc = mmlist.get("MM_TAFC_OptimizationCoreCount",MM_TAFC_OptCoreCnt);
     commandcc = paramList.get("MM_TAFC_OptimizationCoreCount",commandcc);
     paramList.remove("MM_TAFC_OptimizationCoreCount",false);
@@ -527,7 +527,7 @@ int main_(Teuchos::CommandLineProcessor &clp,  Xpetra::UnderlyingLib &lib, int a
     RCP<RealValuedMultiVector> coordinates;
     typedef typename RealValuedMultiVector::scalar_type Real;
     RCP<MultiVector> nullspace;
-    std::string matrixType = galeriParameters.GetMatrixType();  
+    std::string matrixType = galeriParameters.GetMatrixType();
   
     RCP<TimeMonitor>  globalTimeMonitor = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("Driver: S - Global Time")));
     {
@@ -594,7 +594,7 @@ int main_(Teuchos::CommandLineProcessor &clp,  Xpetra::UnderlyingLib &lib, int a
     }
 
     comm->barrier();
-    tm = Teuchos::null; 
+    tm = Teuchos::null;
     }
 
 

--- a/packages/muelu/test/scaling/JacobiKernelDriver.cpp
+++ b/packages/muelu/test/scaling/JacobiKernelDriver.cpp
@@ -180,7 +180,7 @@ void Jacobi_MKL_SPMM(const Xpetra::Matrix<Scalar,LocalOrdinal,GlobalOrdinal,Node
         DrowptrMKL[i] = i;
         if(i < n)  {
           DcolindMKL[i] = i;
-          DvalsMKL[i]   = - omega * Dvals(i,0); 
+          DvalsMKL[i]   = - omega * Dvals(i,0);
         }
     });
 
@@ -191,7 +191,7 @@ void Jacobi_MKL_SPMM(const Xpetra::Matrix<Scalar,LocalOrdinal,GlobalOrdinal,Node
     Au->getComm()->barrier();
 
     // **********************************
-    // Multiply (A*B) 
+    // Multiply (A*B)
     tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("Jacobi MKL: Multiply")));
     result = mkl_sparse_spmm(SPARSE_OPERATION_NON_TRANSPOSE, AMKL, BMKL, &XTempMKL);
     KCRS::execution_space::fence();
@@ -236,7 +236,7 @@ void Jacobi_MKL_SPMM(const Xpetra::Matrix<Scalar,LocalOrdinal,GlobalOrdinal,Node
     mkl_sparse_destroy(XTempMKL);
     mkl_sparse_destroy(YTempMKL);
 
-#else 
+#else
     std::runtime_error("ERROR: MKL wrapper can only be called with Tpetra enabled");
 #endif
 
@@ -542,7 +542,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
           #ifdef HAVE_MUELU_MKL
           C = Xpetra::MatrixFactory<SC,LO,GO,Node>::Build(A->getRowMap(),0);
           {
-            TimeMonitor t(*TimeMonitor::getNewTimer("JAC MKL: Total"));            
+            TimeMonitor t(*TimeMonitor::getNewTimer("JAC MKL: Total"));
             Jacobi_MKL_SPMM(*A,*B,*C,*D,omega);
           }
           #endif

--- a/packages/muelu/test/scaling/MatrixLoad.hpp
+++ b/packages/muelu/test/scaling/MatrixLoad.hpp
@@ -157,8 +157,8 @@ void MatrixLoad(Teuchos::RCP<const Teuchos::Comm<int> > &comm,  Xpetra::Underlyi
     A = Pr->BuildMatrix();
     nullspace = Pr->BuildNullspace();
     //  The coordinates used by Galeri here might not match the coordinates that come into this function.
-    //  In particular, they might correspond to different stretch factors. To fix this, we overwrite the 
-    //  coordinate array with those that Galeri now provides. 
+    //  In particular, they might correspond to different stretch factors. To fix this, we overwrite the
+    //  coordinate array with those that Galeri now provides.
     
 
     if(!coordinates.is_null() && (matrixType == "Elasticity2D" || matrixType == "Elasticity3D") ) {
@@ -172,7 +172,7 @@ void MatrixLoad(Teuchos::RCP<const Teuchos::Comm<int> > &comm,  Xpetra::Underlyi
       for (size_t kkk = 0; kkk < coordinates->getNumVectors(); kkk++) {
         Teuchos::ArrayRCP<real_type> old = coordinates->getDataNonConst(kkk);
         Teuchos::ArrayRCP<real_type> newvals  = newcoordinates->getDataNonConst(kkk);
-        int numCopies = newvals.size() / old.size();  
+        int numCopies = newvals.size() / old.size();
         for (int jj=0; jj < old.size(); jj++) old[jj] = newvals[numCopies*jj];
       }
     }
@@ -255,7 +255,7 @@ void MatrixLoad(Teuchos::RCP<const Teuchos::Comm<int> > &comm,  Xpetra::Underlyi
 //     2) all file entries defining blk k occur before
 //        file entries defining blk k+1.
 template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-void readUserBlks(const std::string& userBlkFileName, const std::string& smootherOrCoarse, Teuchos::ParameterList& mueluList, 
+void readUserBlks(const std::string& userBlkFileName, const std::string& smootherOrCoarse, Teuchos::ParameterList& mueluList,
                   const Teuchos::RCP<Xpetra::Matrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> >      & A) {
 
 //     userBlkFileName          MatrixMarket file defining blocks
@@ -305,11 +305,11 @@ void readUserBlks(const std::string& userBlkFileName, const std::string& smoothe
             fclose(fp);
 
             // Assign ownership of each block to one mpirank corresponding
-            // to which mpirank owns the most rows within a block. When 
-            // ties occur, highest procId wins.                           
+            // to which mpirank owns the most rows within a block. When
+            // ties occur, highest procId wins.
 
             // first, set to procId+1 if we own the largest # of rows
-            // in block.  Otherwise, set to 0.                       
+            // in block.  Otherwise, set to 0.
 
             Teuchos::ArrayRCP<int> maxOwnedRowsPerBlock(nBlks, 0);
             Teuchos::reduceAll(*comm, Teuchos::REDUCE_MAX, (LocalOrdinal) nBlks, myOwnedRowsPerBlock.getRawPtr(),maxOwnedRowsPerBlock.getRawPtr());
@@ -333,7 +333,7 @@ void readUserBlks(const std::string& userBlkFileName, const std::string& smoothe
             maxDofsInAnyBlock *= 2; // We only have an estimate as to the largest number of dofs in any block (as some dofs
             maxDofsInAnyBlock++;    // might reside on other processors. So we multiple our estimate by 2 hoping to be large
                                     // enough. Later, we check to see if things are not large enough and re-allocate space
-                                    // in this case. 
+                                    // in this case.
 
             Teuchos::Array<Teuchos::ArrayRCP<GlobalOrdinal> > blockLists(nOwned,Teuchos::null);
 
@@ -358,7 +358,7 @@ void readUserBlks(const std::string& userBlkFileName, const std::string& smoothe
                 curRow = row;
                 while ((row == curRow) && (jj <= nnzs)){
                   if (i == maxDofsInAnyBlock) {
-                    maxDofsInAnyBlock *= 2; 
+                    maxDofsInAnyBlock *= 2;
                     buffer.resize(maxDofsInAnyBlock);
                   }
                   buffer[i] = col; i++;

--- a/packages/muelu/test/scaling/MatrixMatrixMultiply.cpp
+++ b/packages/muelu/test/scaling/MatrixMatrixMultiply.cpp
@@ -103,7 +103,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib &lib, int ar
 
   RCP< const Teuchos::Comm<int> > comm = Teuchos::DefaultComm<int>::getComm();
   
-#include <MueLu_UseShortNames.hpp>   
+#include <MueLu_UseShortNames.hpp>
     Xpetra::Parameters            xpetraParameters(clp);
     int  optNmults         = 1;     clp.setOption("nmults",               &optNmults,           "number of matrix matrix multiplies to perform");
 

--- a/packages/muelu/test/scaling/MatvecKernelDriver.cpp
+++ b/packages/muelu/test/scaling/MatvecKernelDriver.cpp
@@ -117,7 +117,7 @@ void print_crs_graph(std::string name, const V1 rowptr, const V2 colind) {
   printf("\n");
 }
 
-#if defined(HAVE_MUELU_TPETRA) 
+#if defined(HAVE_MUELU_TPETRA)
 //==============================================================================
 template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void MakeContiguousMaps(const Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> & Matrix,
@@ -163,7 +163,7 @@ void MakeContiguousMaps(const Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdina
     // The domain map isn't linear, so we need a new domain map
     ContiguousDomainMap = rcp(new map_type(DomainMap->getGlobalNumElements(),
                                            DomainMap->getLocalNumElements(), 0, DomainMap->getComm()));
-    if(importer) {    
+    if(importer) {
       // If there's an importer then we can use it to get a new column map
       go_vector_type MyGIDsHYPRE(DomainMap,ContiguousDomainMap->getLocalElementList());
 
@@ -178,7 +178,7 @@ void MakeContiguousMaps(const Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdina
       // The problem has matching domain/column maps, and somehow the domain map isn't linear, so just use the new domain map
       ContiguousColumnMap = rcp(new map_type(ColumnMap->getGlobalNumElements(),ContiguousDomainMap->getLocalElementList(), 0, ColumnMap->getComm()));
     }
-  }  
+  }
 }
 
 #endif
@@ -207,13 +207,13 @@ public:
     LO Nx = (LO) X.getMap()->getLocalNumElements();
     LO Ny = (LO) Y.getMap()->getLocalNumElements();
 
-    // NOTE:  Petsc requires contiguous GIDs for the row map    
+    // NOTE:  Petsc requires contiguous GIDs for the row map
     Teuchos::RCP<const map_type> c_row_map, c_col_map, c_domain_map;
     MakeContiguousMaps(A,c_row_map,c_col_map,c_domain_map);
 
     // Note: PETSC appears to favor local indices for vector insertion
     std::vector<PetscInt> l_indices(std::max(Nx,Ny));
-    for(int i=0; i<std::max(Nx,Ny); i++) 
+    for(int i=0; i<std::max(Nx,Ny); i++)
       l_indices[i] = i;
 
     // x vector
@@ -252,22 +252,22 @@ public:
       GlobalRow[0] = c_row_map->getGlobalElement(i);
       
       MatSetValues(A_p,1,GlobalRow, numEntries, new_indices.data(), values.data(),INSERT_VALUES);
-    }                   
+    }
     MatAssemblyBegin(A_p,MAT_FINAL_ASSEMBLY);
     MatAssemblyEnd(A_p,MAT_FINAL_ASSEMBLY);
 
   }
 
-  ~Petsc_SpmV_Pack() { 
+  ~Petsc_SpmV_Pack() {
     VecDestroy(&x_p);
     VecDestroy(&y_p);
     MatDestroy(&A_p);
   }
 
-  bool spmv(const Scalar alpha, const Scalar beta) { 
+  bool spmv(const Scalar alpha, const Scalar beta) {
     int rv = MatMult(A_p,x_p,y_p);
     return (rv != 0);
-  }  
+  }
 
 private:
   Mat A_p;
@@ -353,7 +353,7 @@ public:
     HYPRE_CHK_ERR(HYPRE_IJVectorInitialize(y_ij));
     HYPRE_CHK_ERR(HYPRE_IJVectorSetValues(y_ij,Y.getLocalLength(),row_indices,Y.getDataNonConst(0).getRawPtr()));
     HYPRE_CHK_ERR(HYPRE_IJVectorAssemble(y_ij));
-    HYPRE_CHK_ERR(HYPRE_IJVectorGetObject(y_ij, (void**) &y_par));   
+    HYPRE_CHK_ERR(HYPRE_IJVectorGetObject(y_ij, (void**) &y_par));
   }
 
   ~HYPRE_SpmV_Pack() {
@@ -362,7 +362,7 @@ public:
     HYPRE_IJVectorDestroy(y_ij);
   }
 
-  bool spmv(const Scalar alpha, const Scalar beta) { 
+  bool spmv(const Scalar alpha, const Scalar beta) {
     int rv = HYPRE_ParCSRMatrixMatvec(alpha,parcsr_matrix, x_par,beta, y_par);
     return (rv != 0);
   }

--- a/packages/muelu/test/scaling/TwoMatrixMMKernelDriver.cpp
+++ b/packages/muelu/test/scaling/TwoMatrixMMKernelDriver.cpp
@@ -200,7 +200,7 @@ void MM2_MKL(const Xpetra::Matrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> &A, co
       });
     Kokkos::parallel_for(Ni+1,KOKKOS_LAMBDA(const size_t i) {
         if(i!=0) B1rowptrMKL[Nb+i] = B1rowptr[Nb-1];
-        B2rowptrMKL[Nb+i] = B2rowptr[i]; 
+        B2rowptrMKL[Nb+i] = B2rowptr[i];
       });
 
     // Reindex the column indices into C's column map
@@ -230,16 +230,16 @@ void MM2_MKL(const Xpetra::Matrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> &A, co
     tm = Teuchos::null;
     Au->getComm()->barrier();
 
-    if(algorithm_name == "MULT_ADD" ) {      
+    if(algorithm_name == "MULT_ADD" ) {
       // **********************************
-      // Multiply #1 (A*B1) 
+      // Multiply #1 (A*B1)
       tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("MM2 MKL MULT_ADD: Multiply 1")));
       result = mkl_sparse_spmm(SPARSE_OPERATION_NON_TRANSPOSE, AMKL, B1MKL, &Temp1MKL);
       KCRS::execution_space::fence();
       if(result != SPARSE_STATUS_SUCCESS) throw std::runtime_error("MKL Multiply 1 failed: "+mkl_error(result));
 
       // **********************************
-      // Multiply #2 (A*B2) 
+      // Multiply #2 (A*B2)
       tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("MM2 MKL MULT_ADD: Multiply 2")));
       result = mkl_sparse_spmm(SPARSE_OPERATION_NON_TRANSPOSE, AMKL, B1MKL, &Temp2MKL);
       KCRS::execution_space::fence();
@@ -252,7 +252,7 @@ void MM2_MKL(const Xpetra::Matrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> &A, co
       KCRS::execution_space::fence();
       if(result != SPARSE_STATUS_SUCCESS) throw std::runtime_error("MKL Add failed: "+mkl_error(result));
     }
-    else if(algorithm_name == "ADD_MULT" ) {      
+    else if(algorithm_name == "ADD_MULT" ) {
       // **********************************
       // Add B1 + B2
       tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("MM2 MKL ADD_MULT: Add")));
@@ -296,7 +296,7 @@ void MM2_MKL(const Xpetra::Matrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> &A, co
     mkl_sparse_destroy(Temp1MKL);
     if(algorithm_name == "MULT_ADD" ) mkl_sparse_destroy(Temp2MKL);
 
-#else 
+#else
     std::runtime_error("ERROR: MKL wrapper can only be called with Tpetra enabled");
 #endif
 
@@ -645,7 +645,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
          #ifdef HAVE_MUELU_MKL
           C = Xpetra::MatrixFactory<SC,LO,GO,Node>::Build(A->getRowMap(),0);
           {
-            TimeMonitor t(*TimeMonitor::getNewTimer("MM2 MKL MULT_ADD: Total"));            
+            TimeMonitor t(*TimeMonitor::getNewTimer("MM2 MKL MULT_ADD: Total"));
             MM2_MKL(*A,*B1,*B2,*C,Bcolmap,std::string("MULT_ADD"));
           }
           #endif
@@ -655,7 +655,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
          #ifdef HAVE_MUELU_MKL
           C = Xpetra::MatrixFactory<SC,LO,GO,Node>::Build(A->getRowMap(),0);
           {
-            TimeMonitor t(*TimeMonitor::getNewTimer("MM2 MKL ADD_MULT: Total"));            
+            TimeMonitor t(*TimeMonitor::getNewTimer("MM2 MKL ADD_MULT: Total"));
             MM2_MKL(*A,*B1,*B2,*C,Bcolmap,std::string("ADD_MULT"));
           }
           #endif

--- a/packages/muelu/test/scaling/anisotropic.xml
+++ b/packages/muelu/test/scaling/anisotropic.xml
@@ -1,4 +1,4 @@
-<ParameterList> 
+<ParameterList>
   <ParameterList name="Run1">
     <ParameterList name="Galeri">
       <!--  //  z3  e  z4
@@ -44,7 +44,7 @@
       <Parameter        name="aggregation: drop scheme"             type="string"   value="classical"/>
       <!-- Uncomment the next line to enable dropping of weak connections, which can help AMG convergence
            for anisotropic problems.  The exact value is problem dependent. -->
-      <Parameter        name="aggregation: drop tol"                type="double"   value="0.2"/> 
+      <Parameter        name="aggregation: drop tol"                type="double"   value="0.2"/>
       
       <!-- ===========  SMOOTHING  =========== -->
       <Parameter        name="smoother: type"                       type="string"   value="RELAXATION"/>

--- a/packages/muelu/test/scaling/elasticity3D.xml
+++ b/packages/muelu/test/scaling/elasticity3D.xml
@@ -50,7 +50,7 @@
     <Parameter name="repartition: rebalance P and R"          type="bool"     value="false"/>
     <ParameterList name="repartition: params">
        <Parameter name="algorithm" type="string" value="multijagged"/>
-    </ParameterList> 
+    </ParameterList>
     <!-- end of default values -->
 
 </ParameterList>

--- a/packages/muelu/test/scaling/recurMG.xml
+++ b/packages/muelu/test/scaling/recurMG.xml
@@ -9,7 +9,7 @@
   <Parameter name="multigrid algorithm" type="string" value="sa"/>
   <Parameter name="sa: damping factor"  type="double" value="1.33333"/>
 
-   <!-- 
+   <!--
   <Parameter name="coarse: type" type="string" value="RELAXATION"/>
   <ParameterList name="coarse: params">
     <Parameter name="relaxation: type"  type="string" value="Jacobi"/>

--- a/packages/muelu/test/scaling/scaling-noderepart.xml
+++ b/packages/muelu/test/scaling/scaling-noderepart.xml
@@ -49,7 +49,7 @@
     <Parameter name="repartition: rebalance P and R"          type="bool"     value="false"/>
     <ParameterList name="repartition: params">
        <Parameter name="algorithm" type="string" value="multijagged"/>
-    </ParameterList> 
+    </ParameterList>
     <!-- end of default values -->
 
 </ParameterList>

--- a/packages/muelu/test/scaling/scaling-with-rerun.xml
+++ b/packages/muelu/test/scaling/scaling-with-rerun.xml
@@ -12,7 +12,7 @@
       <!-- ===========  AGGREGATION  =========== -->
       <Parameter        name="aggregation: type"                    type="string"   value="uncoupled"/>
       <Parameter        name="aggregation: drop scheme"             type="string"   value="classical"/>
-      <Parameter        name="aggregation: drop tol"                type="double"   value="0.00"/>      
+      <Parameter        name="aggregation: drop tol"                type="double"   value="0.00"/>
       <!-- ===========  SMOOTHING  =========== -->
       <Parameter        name="smoother: type"                       type="string"   value="CHEBYSHEV"/>
       <ParameterList    name="smoother: params">
@@ -20,7 +20,7 @@
         <Parameter      name="chebyshev: ratio eigenvalue"          type="double"   value="7"/>
         <Parameter      name="chebyshev: min eigenvalue"            type="double"   value="1.0"/>
         <Parameter      name="chebyshev: zero starting solution"    type="bool"     value="true"/>
-      </ParameterList>      
+      </ParameterList>
       <!-- ===========  REPARTITIONING  =========== -->
       <Parameter        name="repartition: enable"                  type="bool"     value="true"/>
     </ParameterList>
@@ -39,7 +39,7 @@
       <!-- ===========  AGGREGATION  =========== -->
       <Parameter        name="aggregation: type"                    type="string"   value="uncoupled"/>
       <Parameter        name="aggregation: drop scheme"             type="string"   value="classical"/>
-      <Parameter        name="aggregation: drop tol"                type="double"   value="1e-4"/>     
+      <Parameter        name="aggregation: drop tol"                type="double"   value="1e-4"/>
       <!-- ===========  SMOOTHING  =========== -->
       <Parameter        name="smoother: type"                       type="string"   value="CHEBYSHEV"/>
       <ParameterList    name="smoother: params">
@@ -47,7 +47,7 @@
         <Parameter      name="chebyshev: ratio eigenvalue"          type="double"   value="7"/>
         <Parameter      name="chebyshev: min eigenvalue"            type="double"   value="1.0"/>
         <Parameter      name="chebyshev: zero starting solution"    type="bool"     value="true"/>
-      </ParameterList>      
+      </ParameterList>
       <!-- ===========  REPARTITIONING  =========== -->
       <Parameter        name="repartition: enable"                  type="bool"     value="true"/>
     </ParameterList>
@@ -66,7 +66,7 @@
       <!-- ===========  AGGREGATION  =========== -->
       <Parameter        name="aggregation: type"                    type="string"   value="uncoupled"/>
       <Parameter        name="aggregation: drop scheme"             type="string"   value="classical"/>
-      <Parameter        name="aggregation: drop tol"                type="double"   value="1e-3"/> 
+      <Parameter        name="aggregation: drop tol"                type="double"   value="1e-3"/>
       <!-- ===========  SMOOTHING  =========== -->
       <Parameter        name="smoother: type"                       type="string"   value="CHEBYSHEV"/>
       <ParameterList    name="smoother: params">
@@ -74,7 +74,7 @@
         <Parameter      name="chebyshev: ratio eigenvalue"          type="double"   value="7"/>
         <Parameter      name="chebyshev: min eigenvalue"            type="double"   value="1.0"/>
         <Parameter      name="chebyshev: zero starting solution"    type="bool"     value="true"/>
-      </ParameterList>      
+      </ParameterList>
       <!-- ===========  REPARTITIONING  =========== -->
       <Parameter        name="repartition: enable"                  type="bool"     value="true"/>
     </ParameterList>

--- a/packages/muelu/test/scaling/scaling-withglobalconstants.xml
+++ b/packages/muelu/test/scaling/scaling-withglobalconstants.xml
@@ -48,7 +48,7 @@
     <Parameter name="repartition: rebalance P and R"          type="bool"     value="false"/>
     <ParameterList name="repartition: params">
        <Parameter name="algorithm" type="string" value="multijagged"/>
-    </ParameterList> 
+    </ParameterList>
 
 
     <ParameterList name="matrixmatrix: kernel params">

--- a/packages/muelu/test/scaling/smooVecCoalesce.xml
+++ b/packages/muelu/test/scaling/smooVecCoalesce.xml
@@ -3,7 +3,7 @@
   <!--
     For a generic symmetric scalar problem, these are the recommended settings for MueLu.
   -->
-  <!-- Configuration of the Xpetra operator (fine level) 
+  <!-- Configuration of the Xpetra operator (fine level)
   <ParameterList name="Matrix">
     <Parameter name="number of equations"                   type="int" value="3"/>
   </ParameterList>

--- a/packages/muelu/test/toggletransfer/linPconstR_pg.xml
+++ b/packages/muelu/test/toggletransfer/linPconstR_pg.xml
@@ -142,8 +142,8 @@
       <Parameter name="Smoother"                            type="string"   value="myJacobi"/>
 
       <Parameter name="P"                                   type="string"   value="myTogglePFact1"/> <!-- TogglePFact provides the prolongator from the generating factories -->
-      <Parameter name="R"                                   type="string"   value="myRestrictorFact"/> 
-      <Parameter name="A"                                   type="string"   value="myRAPFact"/> 
+      <Parameter name="R"                                   type="string"   value="myRestrictorFact"/>
+      <Parameter name="A"                                   type="string"   value="myRAPFact"/>
       <Parameter name="Nullspace"                           type="string"   value="myTogglePFact1"/> <!-- TogglePFact provides the coarse null space from the generating factories -->
       <Parameter name="CoarseSolver"                        type="string"   value="DirectSolver"/>
     </ParameterList>

--- a/packages/muelu/test/toggletransfer/parameters_semi_tentWithR.xml
+++ b/packages/muelu/test/toggletransfer/parameters_semi_tentWithR.xml
@@ -104,8 +104,8 @@
       <Parameter name="Smoother"                            type="string"   value="myJacobi"/>
 
       <Parameter name="P"                                   type="string"   value="myTogglePFact"/> <!-- TogglePFact provides the prolongator from the generating factories -->
-      <Parameter name="R"                                   type="string"   value="myRestrictorFact"/> 
-      <Parameter name="A"                                   type="string"   value="myRAPFact"/> 
+      <Parameter name="R"                                   type="string"   value="myRestrictorFact"/>
+      <Parameter name="A"                                   type="string"   value="myRAPFact"/>
       <Parameter name="Nullspace"                           type="string"   value="myTogglePFact"/> <!-- TogglePFact provides the coarse null space from the generating factories -->
       <Parameter name="CoarseSolver"                        type="string"   value="DirectSolver"/>
     </ParameterList>

--- a/packages/muelu/test/toggletransfer/semiPsemiR_pg.xml
+++ b/packages/muelu/test/toggletransfer/semiPsemiR_pg.xml
@@ -104,8 +104,8 @@
       <Parameter name="Smoother"                            type="string"   value="myJacobi"/>
 
       <Parameter name="P"                                   type="string"   value="myTogglePFact"/> <!-- TogglePFact provides the prolongator from the generating factories -->
-      <Parameter name="R"                                   type="string"   value="myRestrictorFact"/> 
-      <Parameter name="A"                                   type="string"   value="myRAPFact"/> 
+      <Parameter name="R"                                   type="string"   value="myRestrictorFact"/>
+      <Parameter name="A"                                   type="string"   value="myRAPFact"/>
       <Parameter name="Nullspace"                           type="string"   value="myTogglePFact"/> <!-- TogglePFact provides the coarse null space from the generating factories -->
       <Parameter name="CoarseSolver"                        type="string"   value="DirectSolver"/>
     </ParameterList>

--- a/packages/muelu/test/unit_tests/AggregateQualityEstimateFactory.cpp
+++ b/packages/muelu/test/unit_tests/AggregateQualityEstimateFactory.cpp
@@ -229,10 +229,10 @@ namespace MueLuTests {
 						    AGG18_NODES};
 
     const std::vector<MT> AGG_QUALITIES = {2002., 2.002, 2670.000811,
-					       2001.9998, 4003.999998, 4.004, 
+					       2001.9998, 4003.999998, 4.004,
 					       3003.666728, 4003.999198, 4003.998397,
 					       4003.999198, 2001.999599, 4003.999198,
-					       4004.666568, 2403.067729, 4886.458381, 
+					       4004.666568, 2403.067729, 4886.458381,
 					       4003.998397, 4005.666904, 4004.665757,
 					       4004.665841};
 
@@ -378,7 +378,7 @@ namespace MueLuTests {
 
       }
 
-    }    
+    }
 
   } // Anisotropic Diffusion 2D test
 
@@ -586,7 +586,7 @@ namespace MueLuTests {
 
       }
 
-    }    
+    }
 
   } // Convection Diffusion 2D test
 
@@ -596,7 +596,7 @@ namespace MueLuTests {
   //  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(AggregateQualityEstimateFactory,AnisotropicDiffusion2D,Scalar,LO,GO,Node)
 
 
-  //  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(AggregateQualityEstimateFactory,ConvectionDiffusion2D,Scalar,LO,GO,Node) 
+  //  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(AggregateQualityEstimateFactory,ConvectionDiffusion2D,Scalar,LO,GO,Node)
 
 #include <MueLu_ETI_4arg.hpp>
 

--- a/packages/muelu/test/unit_tests/BlockedRepartition.cpp
+++ b/packages/muelu/test/unit_tests/BlockedRepartition.cpp
@@ -1207,7 +1207,7 @@ namespace MueLuTests {
   zoltan22->SetFactory("A",AR22Fact);
   zoltan22->SetFactory("number of partitions",RepHeuFact);
   zoltan22->SetFactory("Coordinates",Coord22);
-#endif 
+#endif
 
   RCP<RepartitionFactory> repart22 = rcp(new RepartitionFactory());
   repart22->SetFactory("A",AR22Fact);

--- a/packages/muelu/test/unit_tests/CoalesceDropFactory.cpp
+++ b/packages/muelu/test/unit_tests/CoalesceDropFactory.cpp
@@ -1942,7 +1942,7 @@ namespace MueLuTests {
     fineLevel.Set("Coordinates", coordinates);
 
 
-    RCP<InitialBlockNumberFactory> ibFact = rcp(new InitialBlockNumberFactory());      
+    RCP<InitialBlockNumberFactory> ibFact = rcp(new InitialBlockNumberFactory());
     Teuchos::ParameterList ibList;
     ibList.set("aggregation: block diagonal: interleaved blocksize",3);
     RCP<AmalgamationFactory> amalgFact = rcp(new AmalgamationFactory());
@@ -2037,7 +2037,7 @@ namespace MueLuTests {
     fineLevel.Set("Coordinates", coordinates);
 
 
-    RCP<InitialBlockNumberFactory> ibFact = rcp(new InitialBlockNumberFactory());      
+    RCP<InitialBlockNumberFactory> ibFact = rcp(new InitialBlockNumberFactory());
     Teuchos::ParameterList ibList;
     ibList.set("aggregation: block diagonal: interleaved blocksize",3);
     RCP<AmalgamationFactory> amalgFact = rcp(new AmalgamationFactory());
@@ -2137,7 +2137,7 @@ namespace MueLuTests {
     fineLevel.Set("Coordinates", coordinates);
 
 
-    RCP<InitialBlockNumberFactory> ibFact = rcp(new InitialBlockNumberFactory());      
+    RCP<InitialBlockNumberFactory> ibFact = rcp(new InitialBlockNumberFactory());
     Teuchos::ParameterList ibList;
     ibList.set("aggregation: block diagonal: interleaved blocksize",3);
     RCP<AmalgamationFactory> amalgFact = rcp(new AmalgamationFactory());

--- a/packages/muelu/test/unit_tests/Hierarchy.cpp
+++ b/packages/muelu/test/unit_tests/Hierarchy.cpp
@@ -807,8 +807,8 @@ namespace MueLuTests {
     RCP<const Teuchos::Comm<int> > comm = TestHelpers::Parameters::getDefaultComm();
     Teuchos::ParameterList matrixParams;
     matrixParams.set("matrixType","Laplace1D");
-    matrixParams.set("nx",(GlobalOrdinal)20);// needs to be even    
-    RCP<Matrix> A = TestHelpers::TestFactory<SC, LO, GO, NO>::BuildBlockMatrixAsPoint(matrixParams,Xpetra::UseTpetra);  
+    matrixParams.set("nx",(GlobalOrdinal)20);// needs to be even
+    RCP<Matrix> A = TestHelpers::TestFactory<SC, LO, GO, NO>::BuildBlockMatrixAsPoint(matrixParams,Xpetra::UseTpetra);
 
     // Multigrid Hierarchy
     Hierarchy H(A);
@@ -890,8 +890,8 @@ namespace MueLuTests {
     RCP<const Teuchos::Comm<int> > comm = TestHelpers::Parameters::getDefaultComm();
     Teuchos::ParameterList matrixParams;
     matrixParams.set("matrixType","Laplace1D");
-    matrixParams.set("nx",(GlobalOrdinal)100);// needs to be even    
-    RCP<Matrix> A = TestHelpers::TestFactory<SC, LO, GO, NO>::BuildBlockMatrixAsPoint(matrixParams,Xpetra::UseTpetra);  
+    matrixParams.set("nx",(GlobalOrdinal)100);// needs to be even
+    RCP<Matrix> A = TestHelpers::TestFactory<SC, LO, GO, NO>::BuildBlockMatrixAsPoint(matrixParams,Xpetra::UseTpetra);
 
     // Multigrid Hierarchy
     Hierarchy H(A);
@@ -1102,7 +1102,7 @@ namespace MueLuTests {
     GO nx = 10*comm->getSize();
     Teuchos::ParameterList galeriList, ifpack2Params;
     galeriList.set("nx", nx);
-    RCP<Matrix> A = TestHelpers::TestFactory<SC, LO, GO, NO>::BuildBlockMatrixAsPoint(galeriList,Xpetra::UseTpetra);    
+    RCP<Matrix> A = TestHelpers::TestFactory<SC, LO, GO, NO>::BuildBlockMatrixAsPoint(galeriList,Xpetra::UseTpetra);
 
     ifpack2Params.set("smoother: use blockcrsmatrix storage",true);
 
@@ -1230,7 +1230,7 @@ namespace MueLuTests {
     // Here we want no pre-smoothing on levels 0 and 1
     RCP<SmootherPrototype> noSmooProto;
     RCP<SmootherPrototype> smooProto = TestHelpers::TestFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::createSmootherPrototype("Gauss-Seidel", 2);
-    RCP<SmootherFactory>   SmooFact = rcp( new SmootherFactory(noSmooProto,smooProto) );    
+    RCP<SmootherFactory>   SmooFact = rcp( new SmootherFactory(noSmooProto,smooProto) );
     M0.SetFactory("Smoother", SmooFact);
     M1.SetFactory("Smoother", SmooFact);
 

--- a/packages/muelu/test/unit_tests/IntrepidPCoarsenFactory.cpp
+++ b/packages/muelu/test/unit_tests/IntrepidPCoarsenFactory.cpp
@@ -1325,7 +1325,7 @@ namespace MueLuTests {
         FC hi_dofCoords;
         MueLu::MueLuIntrepid::IntrepidGetP1NodeInHi<MT,typename Node::device_type>(hi,lo_node_in_hi,hi_dofCoords);
 
-        Kokkos::parallel_for("IntrepidPCoarsenFactory,BuildLoElemToNodeWithDirichlet", 
+        Kokkos::parallel_for("IntrepidPCoarsenFactory,BuildLoElemToNodeWithDirichlet",
 			     Kokkos::RangePolicy<typename Node::device_type::execution_space>(0, Nn), KOKKOS_LAMBDA (int i) {
            hi_e2n(0,i)=i;
         });
@@ -2330,7 +2330,7 @@ bool test_representative_basis(Teuchos::FancyOStream &out, const std::string & n
       FCi lo_e2n("lo_e2n",1,numLo);
 
       // Dummy elem2node map
-      Kokkos::parallel_for("IntrepidPCoarsenFactory,GenerateLoNodeInHighViaGIDs_QUAD_pn_to_p1", 
+      Kokkos::parallel_for("IntrepidPCoarsenFactory,GenerateLoNodeInHighViaGIDs_QUAD_pn_to_p1",
 			   Kokkos::RangePolicy<typename Node::device_type::execution_space>(0, numHi), KOKKOS_LAMBDA (int j) {
         hi_e2n(0,j)    = j;
       });
@@ -2405,7 +2405,7 @@ bool test_representative_basis(Teuchos::FancyOStream &out, const std::string & n
         FC hi_dofCoords;
 
         // El2node / ownership / colmap
-        Kokkos::parallel_for("IntrepidPCoarsenFactory,BuildLoElemToNodeViaRepresentatives_QUAD_pn_to_p1", 
+        Kokkos::parallel_for("IntrepidPCoarsenFactory,BuildLoElemToNodeViaRepresentatives_QUAD_pn_to_p1",
 			     Kokkos::RangePolicy<typename Node::device_type::execution_space>(0, Nn), KOKKOS_LAMBDA (int i) {
            hi_e2n(0,i)=i;
         });

--- a/packages/muelu/test/unit_tests/MueLu_TestHelpers.hpp
+++ b/packages/muelu/test/unit_tests/MueLu_TestHelpers.hpp
@@ -808,10 +808,10 @@ namespace MueLuTests {
            Teuchos::Array<GO> new_indices(1);
            Teuchos::Array<SC> new_values(1);
            old_matrix->getLocalRowView(i,old_indices,old_values);
-           for(int ii=0; ii<blocksize; ii++) {           
+           for(int ii=0; ii<blocksize; ii++) {
              GO GRID = new_map->getGlobalElement(i*blocksize+ii);
              for(LO j=0; j<(LO)old_indices.size(); j++) {
-               for(int jj=0; jj<blocksize; jj++) {           
+               for(int jj=0; jj<blocksize; jj++) {
                 new_indices[0] = old_colmap->getGlobalElement(old_indices[j]) * blocksize + jj;
                 new_values[0]  = old_values[j] * (SC)( (ii == jj && i == old_indices[j] ) ? blocksize*blocksize : 1 );
                 new_matrix->insertGlobalValues(GRID,new_indices(),new_values);
@@ -821,7 +821,7 @@ namespace MueLuTests {
          }
          new_matrix->fillComplete();
          Op = rcp(new CrsMatrixWrap(new_matrix));
-         if(new_map.is_null()) throw std::runtime_error("BuildBlockMatrixAsPoint: CrsMatrixWrap constructor failed");         
+         if(new_map.is_null()) throw std::runtime_error("BuildBlockMatrixAsPoint: CrsMatrixWrap constructor failed");
          Op->SetFixedBlockSize(blocksize);
 
          return Op;

--- a/packages/muelu/test/unit_tests/NullspaceFactory.cpp
+++ b/packages/muelu/test/unit_tests/NullspaceFactory.cpp
@@ -111,17 +111,17 @@ namespace MueLuTests {
     nspace->Build(fineLevel);
     RCP<MultiVector> nullSpace = fineLevel.Get<RCP<MultiVector> >("Nullspace",nspace.get());
 
-    ArrayRCP<real_type> xvals = coordinates->getDataNonConst(0); 
-    ArrayRCP<real_type> yvals = coordinates->getDataNonConst(1); 
-    ArrayRCP<real_type> zvals = coordinates->getDataNonConst(2); 
+    ArrayRCP<real_type> xvals = coordinates->getDataNonConst(0);
+    ArrayRCP<real_type> yvals = coordinates->getDataNonConst(1);
+    ArrayRCP<real_type> zvals = coordinates->getDataNonConst(2);
     size_t nullDim = 6;
     RCP<MultiVector> handCompNullSpace = MultiVectorFactory::Build(Op->getRowMap(), nullDim);
     handCompNullSpace->putScalar(0.0);
     {
       ArrayRCP<Scalar> nsValues;
-      nsValues = handCompNullSpace->getDataNonConst(0); for (int j = 0; j < nsValues.size(); j +=3) nsValues[j] = 1.; 
-      nsValues = handCompNullSpace->getDataNonConst(1); for (int j = 1; j < nsValues.size(); j +=3) nsValues[j] = 1.; 
-      nsValues = handCompNullSpace->getDataNonConst(2); for (int j = 2; j < nsValues.size(); j +=3) nsValues[j] = 1.; 
+      nsValues = handCompNullSpace->getDataNonConst(0); for (int j = 0; j < nsValues.size(); j +=3) nsValues[j] = 1.;
+      nsValues = handCompNullSpace->getDataNonConst(1); for (int j = 1; j < nsValues.size(); j +=3) nsValues[j] = 1.;
+      nsValues = handCompNullSpace->getDataNonConst(2); for (int j = 2; j < nsValues.size(); j +=3) nsValues[j] = 1.;
       nsValues = handCompNullSpace->getDataNonConst(3); for (int j = 0; j < nsValues.size(); j +=3) nsValues[j] = -(yvals[j/3]-.5);
                                                         for (int j = 1; j < nsValues.size(); j +=3) nsValues[j] =  (xvals[j/3]-.5);
       nsValues = handCompNullSpace->getDataNonConst(4); for (int j = 1; j < nsValues.size(); j +=3) nsValues[j] = -(zvals[j/3]-.5);
@@ -145,7 +145,7 @@ namespace MueLuTests {
   } // NullSpace test
 
 #define MUELU_ETI_GROUP(Scalar, LO, GO, Node) \
-  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(NullspaceFactory,3DElasticity,Scalar,LO,GO,Node) 
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(NullspaceFactory,3DElasticity,Scalar,LO,GO,Node)
 #include <MueLu_ETI_4arg.hpp>
 
 } // namespace MueLuTests

--- a/packages/muelu/test/unit_tests/ParameterList/ParameterListInterpreter.cpp
+++ b/packages/muelu/test/unit_tests/ParameterList/ParameterListInterpreter.cpp
@@ -113,7 +113,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(ParameterListInterpreter, BlockCrs, Scalar, Lo
       matrixParams.set("matrixType","Laplace1D");
       matrixParams.set("nx",(GlobalOrdinal)300);// needs to be even
 
-      RCP<Matrix> A = TestHelpers::TpetraTestFactory<SC, LO, GO, NO>::BuildBlockMatrix(matrixParams,Xpetra::UseTpetra);  
+      RCP<Matrix> A = TestHelpers::TpetraTestFactory<SC, LO, GO, NO>::BuildBlockMatrix(matrixParams,Xpetra::UseTpetra);
       out<<"Matrix Size (block) = "<<A->getGlobalNumRows()<<" (point) "<<A->getRangeMap()->getGlobalNumElements()<<std::endl;
       RCP<const Teuchos::Comm<int> > comm = TestHelpers::Parameters::getDefaultComm();
       
@@ -133,7 +133,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(ParameterListInterpreter, BlockCrs, Scalar, Lo
         mueluFactory.SetupHierarchy(*H);
 
         // Test to make sure all of the matrices in the Hierarchy are actually Block Matrices
-        using helpers = Xpetra::Helpers<Scalar,LocalOrdinal,GlobalOrdinal,Node>;        
+        using helpers = Xpetra::Helpers<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
         for(int j=0; j<H->GetNumLevels(); j++) {
           RCP<Level> level = H->GetLevel(j);
 
@@ -143,7 +143,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(ParameterListInterpreter, BlockCrs, Scalar, Lo
             RCP<Matrix> P = level->Get<RCP<Matrix> >("P");
             TEST_EQUALITY(helpers::isTpetraBlockCrs(P),true);
             RCP<Matrix> R = level->Get<RCP<Matrix> >("R");
-            TEST_EQUALITY(helpers::isTpetraBlockCrs(R),true);          
+            TEST_EQUALITY(helpers::isTpetraBlockCrs(R),true);
           }
         }
         
@@ -170,7 +170,7 @@ MT compare_matrices(RCP<Matrix> & Ap, RCP<Matrix> &Ab) {
 
   RCP<const CRS> Ap_t = MueLu::Utilities<SC,LO,GO,NO>::Op2TpetraCrs(Ap);
   auto Ab_t = MueLu::Utilities<SC,LO,GO,NO>::Op2TpetraBlockCrs(Ab);
-  RCP<CRS> Ab_as_point = Tpetra::convertToCrsMatrix<SC,LO,GO,NO>(*Ab_t);  
+  RCP<CRS> Ab_as_point = Tpetra::convertToCrsMatrix<SC,LO,GO,NO>(*Ab_t);
 
   RCP<CRS> diff = rcp(new CRS(Ap_t->getCrsGraph()));
   diff->setAllToScalar(zero);
@@ -195,13 +195,13 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(ParameterListInterpreter, PointCrs_vs_BlockCrs
       matrixParams.set("matrixType","Laplace1D");
       matrixParams.set("nx",(GlobalOrdinal)300);// needs to be even
       
-      RCP<Matrix> PointA = TestHelpers::TestFactory<SC, LO, GO, NO>::BuildMatrix(matrixParams,Xpetra::UseTpetra);  
+      RCP<Matrix> PointA = TestHelpers::TestFactory<SC, LO, GO, NO>::BuildMatrix(matrixParams,Xpetra::UseTpetra);
       RCP<Matrix> BlockA;
       {
         using XCRS = Xpetra::TpetraBlockCrsMatrix<SC,LO,GO,NO>;
 
         auto tA = MueLu::Utilities<SC,LO,GO,NO>::Op2TpetraCrs(PointA);
-        auto bA = Tpetra::convertToBlockCrsMatrix<SC,LO,GO,NO>(*tA,1);      
+        auto bA = Tpetra::convertToBlockCrsMatrix<SC,LO,GO,NO>(*tA,1);
         RCP<XCRS> AA   = rcp(new XCRS(bA));
         BlockA = rcp(new CrsMatrixWrap(rcp_implicit_cast<CrsMatrix>(AA)));
       }
@@ -222,13 +222,13 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(ParameterListInterpreter, PointCrs_vs_BlockCrs
         // Point Hierarchy
         ParameterListInterpreter mueluFactory1("ParameterList/ParameterListInterpreter/" + fileList[i],*comm);
         RCP<Hierarchy> PointH = mueluFactory1.CreateHierarchy();
-        PointH->GetLevel(0)->Set("A", PointA);       
+        PointH->GetLevel(0)->Set("A", PointA);
         mueluFactory1.SetupHierarchy(*PointH);
 
         // Block Hierachy
         ParameterListInterpreter mueluFactory2("ParameterList/ParameterListInterpreter/" + fileList[i],*comm);
         RCP<Hierarchy> BlockH = mueluFactory2.CreateHierarchy();
-        BlockH->GetLevel(0)->Set("A", BlockA);       
+        BlockH->GetLevel(0)->Set("A", BlockA);
         mueluFactory2.SetupHierarchy(*BlockH);
 
         // Check to see that we get the same matrices in both hierarchies
@@ -246,19 +246,19 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(ParameterListInterpreter, PointCrs_vs_BlockCrs
           RCP<Matrix> Ap = Plevel->Get<RCP<Matrix> >("A");
           RCP<Matrix> Ab = Blevel->Get<RCP<Matrix> >("A");
           MT norm = compare_matrices<Matrix,MT>(Ap,Ab);
-          TEUCHOS_TEST_COMPARE(norm,<,tol,out,success);         
+          TEUCHOS_TEST_COMPARE(norm,<,tol,out,success);
 
           // Compare P, R
           if(j>0) {
             RCP<Matrix> Pp = Plevel->Get<RCP<Matrix> >("P");
             RCP<Matrix> Pb = Blevel->Get<RCP<Matrix> >("P");
             norm = compare_matrices<Matrix,MT>(Pp,Pb);
-            TEUCHOS_TEST_COMPARE(norm,<,tol,out,success);         
+            TEUCHOS_TEST_COMPARE(norm,<,tol,out,success);
 
             RCP<Matrix> Rp = Plevel->Get<RCP<Matrix> >("R");
             RCP<Matrix> Rb = Blevel->Get<RCP<Matrix> >("R");
             norm = compare_matrices<Matrix,MT>(Rp,Rb);
-            TEUCHOS_TEST_COMPARE(norm,<,tol,out,success);         
+            TEUCHOS_TEST_COMPARE(norm,<,tol,out,success);
           }
         }
 

--- a/packages/muelu/test/unit_tests/Repartition.cpp
+++ b/packages/muelu/test/unit_tests/Repartition.cpp
@@ -1054,7 +1054,7 @@ namespace MueLuTests {
     galeriList.set("ny", ny);
     RCP<const Map> map = Galeri::Xpetra::CreateMap<LocalOrdinal, GlobalOrdinal, Node>(TestHelpers::Parameters::getLib(), "Cartesian2D", comm, galeriList);
 
-    // build coordinates 
+    // build coordinates
     RCP<mv_type_double> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<double,LocalOrdinal,GlobalOrdinal,Map,mv_type_double>("2D", map, galeriList);
 
     galeriList.set("right boundary" , "Neumann");

--- a/packages/muelu/test/unit_tests/SaPFactory.cpp
+++ b/packages/muelu/test/unit_tests/SaPFactory.cpp
@@ -329,7 +329,7 @@ namespace MueLuTests {
       Teuchos::ArrayView<const SC> vals;
       P->getLocalRowView((LO) i, indices, vals);
       size_t nnz = indices.size();
-      for (size_t j = 0; j < nnz; j++)  { 
+      for (size_t j = 0; j < nnz; j++)  {
         if (Teuchos::ScalarTraits<SC>::real(vals[j]) < Teuchos::ScalarTraits<SC>::real(zero)) lowerViolation = true;
         if (Teuchos::ScalarTraits<SC>::real(vals[j]) > Teuchos::ScalarTraits<SC>::real(one))  upperViolation = true;
         //if (STS::magnitude(vals[j]) < STS::magnitude(zero)) lowerViolation = true;

--- a/packages/muelu/test/unit_tests/ScaledNullspaceFactory.cpp
+++ b/packages/muelu/test/unit_tests/ScaledNullspaceFactory.cpp
@@ -188,7 +188,7 @@ namespace MueLuTests {
     out << "Skipping test because some required packages are not enabled (Tpetra)." << std::endl;
 #   endif
 
-  } 
+  }
 
 #  define MUELU_ETI_GROUP(SC, LO, GO, Node) \
       TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(ScaledNullspaceFactory, Test0, SC, LO, GO, Node)

--- a/packages/muelu/test/unit_tests/SemiCoarsenPFactoryWithSemiRestriction.cpp
+++ b/packages/muelu/test/unit_tests/SemiCoarsenPFactoryWithSemiRestriction.cpp
@@ -104,7 +104,7 @@ namespace MueLuTests {
     SemiCoarsenPFact->SetFactory("LineDetection_VertLineIds", LineDetectionFact);
     SemiCoarsenPFact->SetFactory("LineDetection_Layers", LineDetectionFact);
     SemiCoarsenPFact->SetFactory("CoarseNumZLayers", LineDetectionFact);
-    // seem to need two factories to avoid failing multipleCallCheck on some machines? 
+    // seem to need two factories to avoid failing multipleCallCheck on some machines?
     RCP<LineDetectionFactory> LineDetectionFact2 = rcp(new LineDetectionFactory());
     LineDetectionFact2->SetParameter("linedetection: orientation",
                                     Teuchos::ParameterEntry(std::string("vertical")));
@@ -185,7 +185,7 @@ namespace MueLuTests {
   } // NullSpace test
 
 #define MUELU_ETI_GROUP(Scalar, LO, GO, Node) \
-  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(SemiCoarsenPFactoryWithSemiRestriction,TestSemiRestrict,Scalar,LO,GO,Node) 
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(SemiCoarsenPFactoryWithSemiRestriction,TestSemiRestrict,Scalar,LO,GO,Node)
 #include <MueLu_ETI_4arg.hpp>
 
 } // namespace MueLuTests

--- a/packages/muelu/test/unit_tests/Smoothers/Ifpack2Smoother.cpp
+++ b/packages/muelu/test/unit_tests/Smoothers/Ifpack2Smoother.cpp
@@ -579,7 +579,7 @@ namespace MueLuTests {
       matrixParams.set("matrixType","Laplace1D");
       matrixParams.set("nx",(GlobalOrdinal)20);// needs to be even
 
-      RCP<Matrix> A = TestHelpers::TestFactory<SC, LO, GO, NO>::BuildBlockMatrixAsPoint(matrixParams,Xpetra::UseTpetra);     
+      RCP<Matrix> A = TestHelpers::TestFactory<SC, LO, GO, NO>::BuildBlockMatrixAsPoint(matrixParams,Xpetra::UseTpetra);
       ifpack2Params.set("smoother: use blockcrsmatrix storage",true);
       
       Ifpack2Smoother smoother("RELAXATION",ifpack2Params);
@@ -604,7 +604,7 @@ namespace MueLuTests {
       matrixParams.set("matrixType","Laplace1D");
       matrixParams.set("nx",(GlobalOrdinal)20);// needs to be even
 
-      RCP<Matrix> A = TestHelpers::TpetraTestFactory<SC, LO, GO, NO>::BuildBlockMatrix(matrixParams,Xpetra::UseTpetra);     
+      RCP<Matrix> A = TestHelpers::TpetraTestFactory<SC, LO, GO, NO>::BuildBlockMatrix(matrixParams,Xpetra::UseTpetra);
       ifpack2Params.set("smoother: use blockcrsmatrix storage",true);
       
       Ifpack2Smoother smoother("RELAXATION",ifpack2Params);

--- a/packages/muelu/test/unit_tests_kokkos/CoalesceDropFactory_kokkos.cpp
+++ b/packages/muelu/test/unit_tests_kokkos/CoalesceDropFactory_kokkos.cpp
@@ -101,7 +101,7 @@ namespace MueLuTests {
     int comm_size=comm->getSize(), comm_rank=comm->getRank();
     auto lclLWGraph = graph->getLocalLWGraph();
     Kokkos::parallel_reduce("MueLu:TentativePF:Build:compute_agg_sizes", Kokkos::RangePolicy<typename NO::execution_space, size_t> (0,1),
-			    KOKKOS_LAMBDA(const LO i, int &correct) { 
+			    KOKKOS_LAMBDA(const LO i, int &correct) {
 			      if (comm_size == 1) {
 				auto v0 = lclLWGraph.getNeighborVertices(0);
 				auto v1 = lclLWGraph.getNeighborVertices(1);
@@ -177,7 +177,7 @@ namespace MueLuTests {
     int comm_size=comm->getSize(), comm_rank=comm->getRank();
     auto lclLWGraph = graph->getLocalLWGraph();
     Kokkos::parallel_reduce("MueLu:TentativePF:Build:compute_agg_sizes", Kokkos::RangePolicy<typename NO::execution_space, size_t> (0,1),
-			    KOKKOS_LAMBDA(const LO i, int &correct) { 
+			    KOKKOS_LAMBDA(const LO i, int &correct) {
 			      if (comm_size == 1) {
 				auto v0 = lclLWGraph.getNeighborVertices(0);
 				auto v1 = lclLWGraph.getNeighborVertices(1);
@@ -255,7 +255,7 @@ namespace MueLuTests {
     int comm_size=comm->getSize(), comm_rank=comm->getRank();
     auto lclLWGraph = graph->getLocalLWGraph();
     Kokkos::parallel_reduce("MueLu:TentativePF:Build:compute_agg_sizes", Kokkos::RangePolicy<typename NO::execution_space, size_t> (0,1),
-			    KOKKOS_LAMBDA(const LO i, int &correct) { 
+			    KOKKOS_LAMBDA(const LO i, int &correct) {
 			      if (comm_size == 1 && lclLWGraph.getNeighborVertices(0).length == 1) {
 				correct = true;
 			      } else {

--- a/packages/muelu/test/unit_tests_kokkos/LWGraph_kokkos.cpp
+++ b/packages/muelu/test/unit_tests_kokkos/LWGraph_kokkos.cpp
@@ -155,7 +155,7 @@ namespace MueLuTests {
       int result=0;
       auto lclLWGraph = graph->getLocalLWGraph();
       Kokkos::parallel_reduce("MueLu:TentativePF:Build:compute_agg_sizes", Kokkos::RangePolicy<typename NO::execution_space, size_t> (0,1),
-			      KOKKOS_LAMBDA(const LO i, int &incorrect) { 
+			      KOKKOS_LAMBDA(const LO i, int &incorrect) {
 				if (lclLWGraph.GetNodeNumVertices() != numrows)
 				  incorrect++;
 				if (lclLWGraph.GetNodeNumEdges() != nument)

--- a/packages/muelu/test/unit_tests_kokkos/MatrixFree_kokkos.cpp
+++ b/packages/muelu/test/unit_tests_kokkos/MatrixFree_kokkos.cpp
@@ -383,7 +383,7 @@ namespace MueLuTests {
       TestHelpers_kokkos::TestFactory<SC,LO,GO,NO>::createTwoLevelHierarchy(fineLevel, coarseLevel);
 
       fineLevel  .SetFactoryManager(Teuchos::null);  // factory manager is not used on this test
-      coarseLevel.SetFactoryManager(Teuchos::null);  
+      coarseLevel.SetFactoryManager(Teuchos::null);
       fineLevel.Request("A");
       fineLevel.Set    ("A", A);
 

--- a/packages/muelu/test/unit_tests_kokkos/NotayAggregationFactory.cpp
+++ b/packages/muelu/test/unit_tests_kokkos/NotayAggregationFactory.cpp
@@ -450,7 +450,7 @@ namespace MueLuTests {
       TEST_EQUALITY(aggregates->AggregatesCrossProcessors(),false);
     }
 
-#endif 
+#endif
 
   } // BuildNotayAggregates2D
 

--- a/packages/muelu/test/unit_tests_kokkos/SaPFactory_kokkos.cpp
+++ b/packages/muelu/test/unit_tests_kokkos/SaPFactory_kokkos.cpp
@@ -259,7 +259,7 @@ namespace MueLuTests {
       Teuchos::ArrayView<const Scalar> vals;
       P->getLocalRowView((LocalOrdinal) j, indices, vals);
       size_t nnz = indices.size();
-      for (LO i = 0; i < (LO) nnz; i++)  { 
+      for (LO i = 0; i < (LO) nnz; i++)  {
         if (Teuchos::ScalarTraits<SC>::real(vals[i]) < Teuchos::ScalarTraits<SC>::real(zero)) lowerViolation = true;
         if (Teuchos::ScalarTraits<SC>::real(vals[i]) > Teuchos::ScalarTraits<SC>::real(one)) upperViolation = true;
       }


### PR DESCRIPTION
@trilinos/muelu 

### Motivation
While I haven't personally been affected by trailing whitespace, it's generally a good practice to avoid trailing whitespaces. Apologies in advance; please rebase if you see any conflicts related to this.

Created via `find . -type f -name "*.hpp" -exec sed -i 's/\(\S\) *$/\1/' '{}' ';'` and rerunning for cpps and xmls.