### PR TITLE
KokkosKernels and Ifpack2: Add TPL support for new cusparseSpSV for KK SPTRSV with CUDA >= 11.3 

### DIFF
--- a/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
@@ -1009,6 +1009,14 @@ setMatrix (const Teuchos::RCP<const row_matrix_type>& A)
     if (Teuchos::nonnull (htsImpl_))
       htsImpl_->reset ();
   } // pointers are not the same
+
+  //NOTE (Nov-09-2022): 
+  //For Cuda >= 11.3 (using cusparseSpSV), always call compute before apply,
+  //even when matrix values are changed with the same sparsity pattern.
+  //So, force isComputed_ to FALSE here
+#if defined(KOKKOSKERNELS_ENABLE_TPL_CUSPARSE) && defined(KOKKOS_ENABLE_CUDA) && (CUDA_VERSION >= 11030)
+  isComputed_ = false;
+#endif
 }
 
 } // namespace Ifpack2

--- a/packages/ifpack2/src/Ifpack2_RILUK_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_RILUK_def.hpp
@@ -547,10 +547,17 @@ void RILUK<MatrixType>::initialize ()
     checkOrderingConsistency (*A_local_);
     L_solver_->setMatrix (L_);
     L_solver_->initialize ();
+    //NOTE (Nov-09-2022): 
+    //For Cuda >= 11.3 (using cusparseSpSV), skip trisolve computes here.
+    //Instead, call trisolve computes within RILUK compute  
+#if !defined(KOKKOSKERNELS_ENABLE_TPL_CUSPARSE) || !defined(KOKKOS_ENABLE_CUDA) || (CUDA_VERSION < 11030)
     L_solver_->compute ();//NOTE: It makes sense to do compute here because only the nonzero pattern is involved in trisolve compute
+#endif
     U_solver_->setMatrix (U_);
     U_solver_->initialize ();
+#if !defined(KOKKOSKERNELS_ENABLE_TPL_CUSPARSE) || !defined(KOKKOS_ENABLE_CUDA) || (CUDA_VERSION < 11030)
     U_solver_->compute ();//NOTE: It makes sense to do compute here because only the nonzero pattern is involved in trisolve compute
+#endif
 
     // Do not call initAllValues. compute() always calls initAllValues to
     // fill L and U with possibly new numbers. initialize() is concerned

--- a/packages/kokkos-kernels/src/sparse/KokkosSparse_sptrsv_handle.hpp
+++ b/packages/kokkos-kernels/src/sparse/KokkosSparse_sptrsv_handle.hpp
@@ -50,7 +50,7 @@
 #define KOKKOSSPARSE_SPTRSVHANDLE_HPP
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
-#include "cusparse.h"
+#include "KokkosSparse_Utils_cusparse.hpp"
 #endif
 
 #if defined(KOKKOS_ENABLE_CUDA) && 10000 < CUDA_VERSION && \
@@ -108,6 +108,8 @@ class SPTRSVHandle {
   typedef typename nnz_row_view_t::HostMirror host_nnz_row_view_t;
   typedef typename Kokkos::View<int *, HandlePersistentMemorySpace>
       int_row_view_t;
+  typedef typename Kokkos::View<int64_t *, HandlePersistentMemorySpace>
+      int64_row_view_t;
   // typedef typename row_lno_persistent_work_view_t::HostMirror
   // row_lno_persistent_work_host_view_t; //Host view type
   typedef typename Kokkos::View<
@@ -154,6 +156,46 @@ class SPTRSVHandle {
       mtx_scalar_view_t;
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
+#if (CUDA_VERSION >= 11030)
+  struct cuSparseHandleType {
+    cusparseHandle_t handle;
+    cusparseOperation_t transpose;
+    cusparseSpMatDescr_t matDescr;
+    cusparseDnVecDescr_t vecBDescr, vecBDescr_dummy;
+    cusparseDnVecDescr_t vecXDescr, vecXDescr_dummy;
+    cusparseSpSVDescr_t spsvDescr;
+    void *pBuffer{nullptr};
+
+    cuSparseHandleType(bool transpose_, bool is_lower) {
+      KOKKOS_CUSPARSE_SAFE_CALL(cusparseCreate(&handle));
+
+      KOKKOS_CUSPARSE_SAFE_CALL(
+          cusparseSetPointerMode(handle, CUSPARSE_POINTER_MODE_HOST));
+
+      if (transpose_) {
+        transpose = CUSPARSE_OPERATION_TRANSPOSE;
+      } else {
+        transpose = CUSPARSE_OPERATION_NON_TRANSPOSE;
+      }
+
+      KOKKOS_CUSPARSE_SAFE_CALL(cusparseSpSV_createDescr(&spsvDescr));
+    }
+
+    ~cuSparseHandleType() {
+      if (pBuffer != nullptr) {
+        KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(pBuffer));
+        pBuffer = nullptr;
+      }
+      KOKKOS_CUSPARSE_SAFE_CALL(cusparseDestroySpMat(matDescr));
+      KOKKOS_CUSPARSE_SAFE_CALL(cusparseDestroyDnVec(vecBDescr));
+      KOKKOS_CUSPARSE_SAFE_CALL(cusparseDestroyDnVec(vecBDescr_dummy));
+      KOKKOS_CUSPARSE_SAFE_CALL(cusparseDestroyDnVec(vecXDescr));
+      KOKKOS_CUSPARSE_SAFE_CALL(cusparseDestroyDnVec(vecXDescr_dummy));
+      KOKKOS_CUSPARSE_SAFE_CALL(cusparseSpSV_destroyDescr(spsvDescr));
+      KOKKOS_CUSPARSE_SAFE_CALL(cusparseDestroy(handle));
+    }
+  };
+#else  // CUDA_VERSION < 11030
   struct cuSparseHandleType {
     cusparseHandle_t handle;
     cusparseOperation_t transpose;
@@ -202,6 +244,7 @@ class SPTRSVHandle {
       cusparseDestroy(handle);
     }
   };
+#endif
 
   typedef cuSparseHandleType SPTRSVcuSparseHandleType;
 #endif
@@ -337,6 +380,7 @@ class SPTRSVHandle {
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
   SPTRSVcuSparseHandleType *cuSPARSEHandle;
   int_row_view_t tmp_int_rowmap;
+  int64_row_view_t tmp_int64_rowmap;
 #endif
 
 #ifdef KOKKOSKERNELS_ENABLE_SUPERNODAL_SPTRSV
@@ -443,7 +487,8 @@ class SPTRSVHandle {
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
         ,
         cuSPARSEHandle(nullptr),
-        tmp_int_rowmap()
+        tmp_int_rowmap(),
+        tmp_int64_rowmap()
 #endif
 #ifdef KOKKOSKERNELS_ENABLE_SUPERNODAL_SPTRSV
         ,
@@ -851,6 +896,18 @@ class SPTRSVHandle {
   }
   int_row_view_t get_int_rowmap_view() { return tmp_int_rowmap; }
   int *get_int_rowmap_ptr() { return tmp_int_rowmap.data(); }
+
+  void allocate_tmp_int64_rowmap(size_type N) {
+    tmp_int64_rowmap = int64_row_view_t(
+        Kokkos::view_alloc(Kokkos::WithoutInitializing, "tmp_int64_rowmap"), N);
+  }
+  template <typename RowViewType>
+  int64_t *get_int64_rowmap_ptr_copy(const RowViewType &rowmap) {
+    Kokkos::deep_copy(tmp_int64_rowmap, rowmap);
+    Kokkos::fence();
+    return tmp_int64_rowmap.data();
+  }
+  int64_t *get_int64_rowmap_ptr() { return tmp_int64_rowmap.data(); }
 #endif
 
   bool algm_requires_symb_lvlsched() const {

--- a/packages/kokkos-kernels/src/sparse/impl/KokkosSparse_sptrsv_cuSPARSE_impl.hpp
+++ b/packages/kokkos-kernels/src/sparse/impl/KokkosSparse_sptrsv_cuSPARSE_impl.hpp
@@ -45,9 +45,8 @@
 #ifndef _KOKKOSSPTRSVCUSPARSE_HPP
 #define _KOKKOSSPTRSVCUSPARSE_HPP
 
-#ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
-#include "cusparse.h"
-#endif
+#include "KokkosSparse_Utils_cusparse.hpp"
+
 namespace KokkosSparse {
 namespace Impl {
 
@@ -60,6 +59,116 @@ void sptrsvcuSPARSE_symbolic(KernelHandle* sptrsv_handle,
                              ain_nonzero_index_view_type entries,
                              ain_values_scalar_view_type values, bool trans) {
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
+#if (CUDA_VERSION >= 11030)
+  typedef typename KernelHandle::nnz_lno_t idx_type;
+  typedef typename KernelHandle::size_type size_type;
+  typedef typename KernelHandle::scalar_t scalar_type;
+  typedef typename KernelHandle::memory_space memory_space;
+  typedef typename KernelHandle::nnz_scalar_view_t nnz_scalar_view_t;
+
+  const bool is_cuda_space =
+      std::is_same<memory_space, Kokkos::CudaSpace>::value ||
+      std::is_same<memory_space, Kokkos::CudaUVMSpace>::value ||
+      std::is_same<memory_space, Kokkos::CudaHostPinnedSpace>::value;
+
+  const bool is_idx_type_supported = std::is_same<idx_type, int>::value ||
+                                     std::is_same<idx_type, int64_t>::value;
+
+  if (!is_cuda_space) {
+    throw std::runtime_error(
+        "KokkosKernels sptrsvcuSPARSE_symbolic: MEMORY IS NOT ALLOCATED IN GPU "
+        "DEVICE for CUSPARSE\n");
+  } else if (!is_idx_type_supported) {
+    throw std::runtime_error(
+        "CUSPARSE requires local ordinals to be integer (32 bits or 64 "
+        "bits).\n");
+  } else {
+    bool is_lower = sptrsv_handle->is_lower_tri();
+    sptrsv_handle->create_cuSPARSE_Handle(trans, is_lower);
+
+    typename KernelHandle::SPTRSVcuSparseHandleType* h =
+        sptrsv_handle->get_cuSparseHandle();
+
+    int64_t nnz = static_cast<int64_t>(entries.extent(0));
+    size_t pBufferSize;
+    void* rm;
+    // NOTE (Oct-29-2022):
+    // cusparseCreateCsr only supports the same sizes (either 32 bits or 64
+    // bits) for row_map_type and entries_type
+    if (std::is_same<idx_type, int>::value) {
+      if (!std::is_same<size_type, int>::value) {
+        sptrsv_handle->allocate_tmp_int_rowmap(row_map.extent(0));
+        rm = (void*)sptrsv_handle->get_int_rowmap_ptr_copy(row_map);
+      } else {
+        rm = (void*)row_map.data();
+      }
+    } else {  // idx_type has 64 bits
+      if (!std::is_same<size_type, int64_t>::value) {
+        sptrsv_handle->allocate_tmp_int64_rowmap(row_map.extent(0));
+        rm = (void*)sptrsv_handle->get_int64_rowmap_ptr_copy(row_map);
+      } else {
+        rm = (void*)row_map.data();
+      }
+    }
+    const scalar_type alpha = scalar_type(1.0);
+
+    cusparseIndexType_t cudaCsrRowMapType =
+        cusparse_index_type_t_from<idx_type>();
+    cusparseIndexType_t cudaCsrColIndType =
+        cusparse_index_type_t_from<idx_type>();
+    cudaDataType cudaValueType = cuda_data_type_from<scalar_type>();
+
+    // Create sparse matrix in CSR format
+    KOKKOS_CUSPARSE_SAFE_CALL(cusparseCreateCsr(
+        &(h->matDescr), static_cast<int64_t>(nrows),
+        static_cast<int64_t>(nrows), nnz, rm, (void*)entries.data(),
+        (void*)values.data(), cudaCsrRowMapType, cudaCsrColIndType,
+        CUSPARSE_INDEX_BASE_ZERO, cudaValueType));
+
+    // Create dummy dense vector B (RHS)
+    nnz_scalar_view_t b_dummy("b_dummy", nrows);
+    KOKKOS_CUSPARSE_SAFE_CALL(
+        cusparseCreateDnVec(&(h->vecBDescr_dummy), static_cast<int64_t>(nrows),
+                            b_dummy.data(), cudaValueType));
+
+    // Create dummy dense vector X (LHS)
+    nnz_scalar_view_t x_dummy("x_dummy", nrows);
+    KOKKOS_CUSPARSE_SAFE_CALL(
+        cusparseCreateDnVec(&(h->vecXDescr_dummy), static_cast<int64_t>(nrows),
+                            x_dummy.data(), cudaValueType));
+
+    // Specify Lower|Upper fill mode
+    if (is_lower) {
+      cusparseFillMode_t fillmode = CUSPARSE_FILL_MODE_LOWER;
+      KOKKOS_CUSPARSE_SAFE_CALL(cusparseSpMatSetAttribute(
+          h->matDescr, CUSPARSE_SPMAT_FILL_MODE, &fillmode, sizeof(fillmode)));
+    } else {
+      cusparseFillMode_t fillmode = CUSPARSE_FILL_MODE_UPPER;
+      KOKKOS_CUSPARSE_SAFE_CALL(cusparseSpMatSetAttribute(
+          h->matDescr, CUSPARSE_SPMAT_FILL_MODE, &fillmode, sizeof(fillmode)));
+    }
+
+    // Specify Unit|Non-Unit diagonal type.
+    cusparseDiagType_t diagtype = CUSPARSE_DIAG_TYPE_NON_UNIT;
+    KOKKOS_CUSPARSE_SAFE_CALL(cusparseSpMatSetAttribute(
+        h->matDescr, CUSPARSE_SPMAT_DIAG_TYPE, &diagtype, sizeof(diagtype)));
+
+    // Allocate an external buffer for analysis
+    KOKKOS_CUSPARSE_SAFE_CALL(cusparseSpSV_bufferSize(
+        h->handle, h->transpose, &alpha, h->matDescr, h->vecBDescr_dummy,
+        h->vecXDescr_dummy, cudaValueType, CUSPARSE_SPSV_ALG_DEFAULT,
+        h->spsvDescr, &pBufferSize));
+
+    // pBuffer returned by cudaMalloc is automatically aligned to 128 bytes.
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMalloc((void**)&(h->pBuffer), pBufferSize));
+
+    // Run analysis
+    KOKKOS_CUSPARSE_SAFE_CALL(cusparseSpSV_analysis(
+        h->handle, h->transpose, &alpha, h->matDescr, h->vecBDescr_dummy,
+        h->vecXDescr_dummy, cudaValueType, CUSPARSE_SPSV_ALG_DEFAULT,
+        h->spsvDescr, h->pBuffer));
+  }
+#else  // CUDA_VERSION < 11030
   typedef typename KernelHandle::nnz_lno_t idx_type;
   typedef typename KernelHandle::size_type size_type;
   typedef typename KernelHandle::scalar_t scalar_type;
@@ -137,7 +246,7 @@ void sptrsvcuSPARSE_symbolic(KernelHandle* sptrsv_handle,
 
       if (CUSPARSE_STATUS_SUCCESS != status)
         std::cout << "analysis status error name " << (status) << std::endl;
-    } else if (std::is_same<scalar_type, Kokkos::complex<double>>::value) {
+    } else if (std::is_same<scalar_type, Kokkos::complex<double> >::value) {
       cusparseZcsrsv2_bufferSize(h->handle, h->transpose, nrows, nnz, h->descr,
                                  (cuDoubleComplex*)vals, (int*)rm, (int*)ent,
                                  h->info, &pBufferSize);
@@ -156,7 +265,7 @@ void sptrsvcuSPARSE_symbolic(KernelHandle* sptrsv_handle,
 
       if (CUSPARSE_STATUS_SUCCESS != status)
         std::cout << "analysis status error name " << (status) << std::endl;
-    } else if (std::is_same<scalar_type, Kokkos::complex<float>>::value) {
+    } else if (std::is_same<scalar_type, Kokkos::complex<float> >::value) {
       cusparseCcsrsv2_bufferSize(h->handle, h->transpose, nrows, nnz, h->descr,
                                  (cuComplex*)vals, (int*)rm, (int*)ent, h->info,
                                  &pBufferSize);
@@ -182,6 +291,7 @@ void sptrsvcuSPARSE_symbolic(KernelHandle* sptrsv_handle,
     throw std::runtime_error(
         "CUSPARSE requires local ordinals to be integer.\n");
   }
+#endif
 #else
   (void)sptrsv_handle;
   (void)nrows;
@@ -207,6 +317,52 @@ void sptrsvcuSPARSE_solve(KernelHandle* sptrsv_handle,
                           x_values_scalar_view_type lhs, bool /*trans*/
 ) {
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
+#if (CUDA_VERSION >= 11030)
+  typedef typename KernelHandle::nnz_lno_t idx_type;
+  typedef typename KernelHandle::size_type size_type;
+  typedef typename KernelHandle::scalar_t scalar_type;
+  typedef typename KernelHandle::memory_space memory_space;
+
+  const bool is_cuda_space =
+      std::is_same<memory_space, Kokkos::CudaSpace>::value ||
+      std::is_same<memory_space, Kokkos::CudaUVMSpace>::value ||
+      std::is_same<memory_space, Kokkos::CudaHostPinnedSpace>::value;
+
+  const bool is_idx_type_supported = std::is_same<idx_type, int>::value ||
+                                     std::is_same<idx_type, int64_t>::value;
+
+  if (!is_cuda_space) {
+    throw std::runtime_error(
+        "KokkosKernels sptrsvcuSPARSE_solve: MEMORY IS NOT ALLOCATED IN GPU "
+        "DEVICE for CUSPARSE\n");
+  } else if (!is_idx_type_supported) {
+    throw std::runtime_error(
+        "CUSPARSE requires local ordinals to be integer (32 bits or 64 "
+        "bits).\n");
+  } else {
+    typename KernelHandle::SPTRSVcuSparseHandleType* h =
+        sptrsv_handle->get_cuSparseHandle();
+
+    const scalar_type alpha = scalar_type(1.0);
+
+    cudaDataType cudaValueType = cuda_data_type_from<scalar_type>();
+
+    // Create dense vector B (RHS)
+    KOKKOS_CUSPARSE_SAFE_CALL(
+        cusparseCreateDnVec(&(h->vecBDescr), static_cast<int64_t>(nrows),
+                            (void*)rhs.data(), cudaValueType));
+
+    // Create dense vector X (LHS)
+    KOKKOS_CUSPARSE_SAFE_CALL(
+        cusparseCreateDnVec(&(h->vecXDescr), static_cast<int64_t>(nrows),
+                            (void*)lhs.data(), cudaValueType));
+
+    // Solve
+    KOKKOS_CUSPARSE_SAFE_CALL(cusparseSpSV_solve(
+        h->handle, h->transpose, &alpha, h->matDescr, h->vecBDescr,
+        h->vecXDescr, cudaValueType, CUSPARSE_SPSV_ALG_DEFAULT, h->spsvDescr));
+  }
+#else  // CUDA_VERSION < 11030
   typedef typename KernelHandle::nnz_lno_t idx_type;
   typedef typename KernelHandle::size_type size_type;
   typedef typename KernelHandle::scalar_t scalar_type;
@@ -253,7 +409,7 @@ void sptrsvcuSPARSE_solve(KernelHandle* sptrsv_handle,
 
       if (CUSPARSE_STATUS_SUCCESS != status)
         std::cout << "solve status error name " << (status) << std::endl;
-    } else if (std::is_same<scalar_type, Kokkos::complex<double>>::value) {
+    } else if (std::is_same<scalar_type, Kokkos::complex<double> >::value) {
       cuDoubleComplex cualpha;
       cualpha.x = 1.0;
       cualpha.y = 0.0;
@@ -264,7 +420,7 @@ void sptrsvcuSPARSE_solve(KernelHandle* sptrsv_handle,
 
       if (CUSPARSE_STATUS_SUCCESS != status)
         std::cout << "solve status error name " << (status) << std::endl;
-    } else if (std::is_same<scalar_type, Kokkos::complex<float>>::value) {
+    } else if (std::is_same<scalar_type, Kokkos::complex<float> >::value) {
       cuComplex cualpha;
       cualpha.x = 1.0;
       cualpha.y = 0.0;
@@ -283,6 +439,7 @@ void sptrsvcuSPARSE_solve(KernelHandle* sptrsv_handle,
     throw std::runtime_error(
         "CUSPARSE requires local ordinals to be integer.\n");
   }
+#endif
 #else
   (void)sptrsv_handle;
   (void)nrows;


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/kokkos-kernels @trilinos/ifpack2 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
This PR matches changes in kokkos-kernels kokkos/kokkos-kernels#1574
  - use new ```cusparseSpSV``` for SPTRSV when cuSPARSE enabled with CUDA >= 11.3
  - for CUDA < 11.2, still use the deprecated APIs ``cusparseXcsrsv2_analysis``` + ```cusparseXcsrsv2_solve```

I also made necessary changes in Ifpack2 RILUK for 
  - calling trisolve compute every time L and U values got updated when using ```cusparseSpSV```
  - workaround in RILUK apply for ```cusparseSpSV``` not supporting in-place computation

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->