### PR TITLE
doxygen: improvements for amesos2, intrepid2 and kokkos

### DIFF
--- a/packages/amesos2/doc/Doxyfile
+++ b/packages/amesos2/doc/Doxyfile
@@ -617,7 +617,7 @@ TAGFILES               =
 # When a file name is specified after GENERATE_TAGFILE, doxygen will create
 # a tag file that is based on the input files it reads.
 
-GENERATE_TAGFILE       = ../src/amesos2.tag 
+GENERATE_TAGFILE       = ../../common/tag_files/amesos2.tag
 
 # If the ALLEXTERNALS tag is set to YES all external classes will be listed
 # in the class index. If set to NO only the inherited external classes

--- a/packages/intrepid2/doc/Doxyfile
+++ b/packages/intrepid2/doc/Doxyfile
@@ -1102,7 +1102,7 @@ TAGFILES               =
 # When a file name is specified after GENERATE_TAGFILE, doxygen will create 
 # a tag file that is based on the input files it reads.
 
-GENERATE_TAGFILE       = 
+GENERATE_TAGFILE       = ../../common/tag_files/intrepid2.tag
 
 # If the ALLEXTERNALS tag is set to YES all external classes will be listed 
 # in the class index. If set to NO only the inherited external classes 


### PR DESCRIPTION
@trilinos/<teamName>

## Motivation

We want to have better links from our Doxygen documentation to Trilinos.
For that sake, we use tag files.

As of now, we are able to use tag file of `Tpetra`, mainly. As we use Doxygen with the "fail if any warning occurs" option, the other tag files (when available) lead to errors.

## Description

This PR will:
* Change `amesos2` tag file location. Indeed, it is not in https://docs.trilinos.org/dev/packages/common/tag_files/ as I think it should.
* Generate a tag file for `intrepid2`

## Related Issues

Similar to:
* https://github.com/trilinos/Trilinos/issues/10511
