### PR TITLE
PIRO: fix bug with ostream

### DIFF
--- a/packages/piro/src/Piro_PerformAnalysis.cpp
+++ b/packages/piro/src/Piro_PerformAnalysis.cpp
@@ -683,7 +683,7 @@ Piro::PerformROLAnalysis(
 #else
   (void)piroModel;
   (void)p;
-  RCP<Teuchos::FancyOStream> out = Teuchos::VerboseObjectBase::getDefaultOStream();
+  out = Teuchos::VerboseObjectBase::getDefaultOStream();
   *out << "ERROR: Trilinos/Piro was not configured to include ROL analysis."
        << "\nYou must enable ROL." << endl;
   return 0;  // should not fail tests


### PR DESCRIPTION
@mperego 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Recent change to piro is causing compile failures on all empire builds. The error is in an ifdef that apparently is not exercised by PR builds but is used by empire.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
N/A
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->