### PR TITLE
Ifpack2: fix wrapped dualview error

### DIFF
--- a/packages/ifpack2/src/Ifpack2_BlockRelaxation_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockRelaxation_def.hpp
@@ -707,6 +707,8 @@ initialize ()
           Teuchos::ArrayRCP<scalar_type> nonOverLapWArray = nonOverLapW.getDataNonConst(0);
           nonOverLapW.putScalar(STS::zero ());
           for (int ii = 0; ii < (int) theImport->getSourceMap()->getLocalNumElements(); ii++)  nonOverLapWArray[ii] = w_ptr[ii];
+          nonOverLapWArray = Teuchos::null;
+          w_ptr = Teuchos::null;
           nonOverLapW.doExport (*W_,         *theImport, Tpetra::ADD);
           W_->doImport(         nonOverLapW, *theImport, Tpetra::INSERT);
         }

--- a/packages/trilinoscouplings/examples/scaling/TrilinosCouplings_TpetraIntrepidHybridPoisson2DExample.cpp
+++ b/packages/trilinoscouplings/examples/scaling/TrilinosCouplings_TpetraIntrepidHybridPoisson2DExample.cpp
@@ -210,6 +210,8 @@ makeMatrixAndRightHandSide (Teuchos::RCP<sparse_matrix_type>& A,
   (void) verbose;
   (void) debug;
 
+  Tpetra::global_size_t INVALID_GO = Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid();
+
   //
   // mfh 19 Apr 2012: If you want to change the template parameters of
   // these typedefs, modify the typedefs (ST, LO, GO, Node) near the
@@ -627,7 +629,7 @@ makeMatrixAndRightHandSide (Teuchos::RCP<sparse_matrix_type>& A,
     coordArray[0] = coordXArray;
     coordArray[1] = coordYArray;
     coordArray[2] = coordZArray;
-    globalMapG = rcp (new map_type (-1, ownedGIDs (), 0, comm));
+    globalMapG = rcp (new map_type (INVALID_GO, ownedGIDs (), 0, comm));
   }
 
   /**********************************************************************************/
@@ -648,7 +650,7 @@ makeMatrixAndRightHandSide (Teuchos::RCP<sparse_matrix_type>& A,
     }
 
     //Generate overlapped Map for nodes.
-    overlappedMapG = rcp (new map_type (-1, overlappedGIDs (), 0, comm));
+    overlappedMapG = rcp (new map_type (INVALID_GO, overlappedGIDs (), 0, comm));
 
     // Build Tpetra Export from overlapped to owned Map.
     exporter = rcp (new export_type (overlappedMapG, globalMapG));

--- a/packages/trilinoscouplings/examples/scaling/TrilinosCouplings_TpetraIntrepidHybridPoisson3DExample.cpp
+++ b/packages/trilinoscouplings/examples/scaling/TrilinosCouplings_TpetraIntrepidHybridPoisson3DExample.cpp
@@ -210,6 +210,8 @@ makeMatrixAndRightHandSide (Teuchos::RCP<sparse_matrix_type>& A,
   (void) verbose;
   (void) debug;
 
+  Tpetra::global_size_t INVALID_GO = Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid();
+
   //
   // mfh 19 Apr 2012: If you want to change the template parameters of
   // these typedefs, modify the typedefs (ST, LO, GO, Node) near the
@@ -629,7 +631,7 @@ makeMatrixAndRightHandSide (Teuchos::RCP<sparse_matrix_type>& A,
     coordArray[0] = coordXArray;
     coordArray[1] = coordYArray;
     coordArray[2] = coordZArray;
-    globalMapG = rcp (new map_type (-1, ownedGIDs (), 0, comm));
+    globalMapG = rcp (new map_type (INVALID_GO, ownedGIDs (), 0, comm));
   }
 
   /**********************************************************************************/
@@ -650,7 +652,7 @@ makeMatrixAndRightHandSide (Teuchos::RCP<sparse_matrix_type>& A,
     }
 
     //Generate overlapped Map for nodes.
-    overlappedMapG = rcp (new map_type (-1, overlappedGIDs (), 0, comm));
+    overlappedMapG = rcp (new map_type (INVALID_GO, overlappedGIDs (), 0, comm));
 
     // Build Tpetra Export from overlapped to owned Map.
     exporter = rcp (new export_type (overlappedMapG, globalMapG));

--- a/packages/trilinoscouplings/examples/scaling/TrilinosCouplings_TpetraIntrepidStructuredPoissonExample.cpp
+++ b/packages/trilinoscouplings/examples/scaling/TrilinosCouplings_TpetraIntrepidStructuredPoissonExample.cpp
@@ -210,6 +210,8 @@ makeMatrixAndRightHandSide (Teuchos::RCP<sparse_matrix_type>& A,
   (void) verbose;
   (void) debug;
 
+  Tpetra::global_size_t INVALID_GO = Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid();
+
   //
   // mfh 19 Apr 2012: If you want to change the template parameters of
   // these typedefs, modify the typedefs (ST, LO, GO, Node) near the
@@ -621,7 +623,7 @@ makeMatrixAndRightHandSide (Teuchos::RCP<sparse_matrix_type>& A,
         ++oidx;
       }
     }
-    globalMapG = rcp (new map_type (-1, ownedGIDs (), 0, comm));
+    globalMapG = rcp (new map_type (INVALID_GO, ownedGIDs (), 0, comm));
   }
 
   /**********************************************************************************/
@@ -642,7 +644,7 @@ makeMatrixAndRightHandSide (Teuchos::RCP<sparse_matrix_type>& A,
     }
 
     //Generate overlapped Map for nodes.
-    overlappedMapG = rcp (new map_type (-1, overlappedGIDs (), 0, comm));
+    overlappedMapG = rcp (new map_type (INVALID_GO, overlappedGIDs (), 0, comm));
 
     // Build Tpetra Export from overlapped to owned Map.
     exporter = rcp (new export_type (overlappedMapG, globalMapG));

--- a/packages/trilinoscouplings/examples/scaling/example_Poisson_NoFE_Tpetra.cpp
+++ b/packages/trilinoscouplings/examples/scaling/example_Poisson_NoFE_Tpetra.cpp
@@ -281,6 +281,7 @@ int main(int argc, char *argv[]) {
   const int numProcs = CommT->getSize();
 
   int MyPID = CommT->getRank();
+  Tpetra::global_size_t INVALID_GO = Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid();
 
 
   //Check number of arguments
@@ -716,7 +717,7 @@ int main(int argc, char *argv[]) {
     {
     TimeMonitor timerBuildGlobalMaps1L(*timerBuildGlobalMaps1);
     //Generate Tpetra map for nodes
-    globalMapGT = rcp(new Map(-1, ownedGIDs(), 0, CommT));
+    globalMapGT = rcp(new Map(INVALID_GO, ownedGIDs(), 0, CommT));
     }
     }
 
@@ -742,7 +743,7 @@ int main(int argc, char *argv[]) {
     {
     TimeMonitor timerBuildOverlapMaps1L(*timerBuildOverlapMaps1);
     //Generate Tpetra map for nodes
-    overlappedMapGT = rcp(new Map(-1, overlappedGIDs(), 0, CommT));
+    overlappedMapGT = rcp(new Map(INVALID_GO, overlappedGIDs(), 0, CommT));
     }
     //build Tpetra Export/Import
     RCP<Teuchos::Time> timerBuildOverlapMaps2 = TimeMonitor::getNewTimer("Build overlapped maps: exporterT");
@@ -1255,9 +1256,9 @@ int main(int argc, char *argv[]) {
       gl_StiffMatrixT->getLocalRowCopy(i, indices, values, NumEntries);
       //Matrix.ExtractMyRowView(i,numEntries,vals,cols);
       for (size_t j=0; j < NumEntries; j++){
-	//Teuchos::ArrayRCP<const int> myColsToZeroj = myColsToZeroT->getData();
-	if (myColsToZeroArrayRCP[indices(j)] == 1)
-	  values(j) = 0.0;
+        //Teuchos::ArrayRCP<const int> myColsToZeroj = myColsToZeroT->getData();
+        if (myColsToZeroArrayRCP[indices(j)] == 1)
+          values(j) = 0.0;
       }
       gl_StiffMatrixT->replaceLocalValues(i, indices, values);
     }/*end for*/
@@ -1271,9 +1272,9 @@ int main(int argc, char *argv[]) {
       int globalRow = gl_StiffMatrixT->getRowMap()->getGlobalElement(BCNodes[i]);
       int localCol = gl_StiffMatrixT->getColMap()->getLocalElement(globalRow);
       for (size_t j = 0; j<NumEntries; j++){
-	values(j) = 0.0;
-	if (indices(j) == localCol)
-	  values(j) = 1.0;
+        values(j) = 0.0;
+        if (indices(j) == localCol)
+          values(j) = 1.0;
       }
       gl_StiffMatrixT->replaceLocalValues(BCNodes[i], indices, values);
    }


### PR DESCRIPTION
Fixes simultaneous host/device access in Ifpack2 block relaxation as seen in proposed PR test using CUDA 11.4.2 ([dashboard link](https://trilinos-cdash.sandia.gov/build/609006)).
Also eliminates some sign-change compiler warnings in some TrilinosCouplings examples.
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/ifpack2 @trilinos/trilinoscouplings @trilinos/muelu 
## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Part of standing up new PR test using CUDA 11.4.2, as described in #11239 and https://sems-atlassian-son.sandia.gov/jira/browse/TRILFRAME-491.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
N/A

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
I reproduced the MueLu/Ifpack2 block relaxation test errors locally and verified that this PR allows the tests to complete successfully.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->