### PR TITLE
Piro: use implicitly defined adjoint model evaluator for transient sensitivities

### DIFF
--- a/packages/piro/src/Piro_TempusSolver_Def.hpp
+++ b/packages/piro/src/Piro_TempusSolver_Def.hpp
@@ -345,14 +345,8 @@ void Piro::TempusSolver<Scalar>::initialize(
     }
     
     //Create Piro::TempusIntegrator
-    //Throw an error if adjointModel_ is null
-    if ((adjointModel_ == Teuchos::null) && (sens_method_ == ADJOINT)) {
-      TEUCHOS_TEST_FOR_EXCEPTION(
-          true,
-          Teuchos::Exceptions::InvalidParameter,
-          "\n Error! Piro::TempusSolver: adjoint ModelEvaluator passed in is null!\n");
-    }
-    piroTempusIntegrator_ = (sens_method_ == ADJOINT) ?
+    //if adjointModel_ is null and the problem requires adjoints, Tempus will create and implicitly defined adjoint model.
+    piroTempusIntegrator_ = Teuchos::nonnull(adjointModel_) ?  
                             Teuchos::rcp(new Piro::TempusIntegrator<Scalar>(tempusPL, model_, adjointModel_, sens_method_)) :
                             Teuchos::rcp(new Piro::TempusIntegrator<Scalar>(tempusPL, model_, sens_method_));
     this->setPiroTempusIntegrator(piroTempusIntegrator_);  

--- a/packages/piro/test/Piro_TempusSolver_AdjointSensitivitySinCosUnitTests.cpp
+++ b/packages/piro/test/Piro_TempusSolver_AdjointSensitivitySinCosUnitTests.cpp
@@ -80,7 +80,7 @@ namespace Thyra {
 // Floating point tolerance
 const double tol = 1.0e-8;
 
-void test_sincos_asa(Teuchos::FancyOStream &out, bool &success)
+void test_sincos_asa(Teuchos::FancyOStream &out, bool &success, bool explicitAdjointME)
 {
   const std::string sens_method_string = "Adjoint";
   std::string soln_outfile_name; 
@@ -120,8 +120,9 @@ void test_sincos_asa(Teuchos::FancyOStream &out, bool &success)
     RCP<SinCosModel> model = Teuchos::rcp(new SinCosModel(scm_pl));
 
     //Set up adjoint model for adjoint sensivitities 
-    RCP<SinCosModelAdjoint> adjoint_model =
-      Teuchos::rcp(new SinCosModelAdjoint(scm_pl));
+    RCP<SinCosModelAdjoint> adjoint_model = explicitAdjointME ? 
+      Teuchos::rcp(new SinCosModelAdjoint(scm_pl)) :
+      Teuchos::null;
 
     dt /= 2;
 
@@ -343,9 +344,14 @@ void test_sincos_asa(Teuchos::FancyOStream &out, bool &success)
 
 }
 
-TEUCHOS_UNIT_TEST(Piro_TempusSolver, SinCos_AdjointSensitivities)
+TEUCHOS_UNIT_TEST(Piro_TempusSolver, SinCos_AdjointSensitivities_ExplicitAdjointModel)
 {
-  test_sincos_asa(out, success);
+  test_sincos_asa(out, success, true);
+}
+
+TEUCHOS_UNIT_TEST(Piro_TempusSolver, SinCos_AdjointSensitivities_ImplicitAdjointModel)
+{
+  test_sincos_asa(out, success, false);
 }
 
 #endif /* HAVE_PIRO_TEMPUS */


### PR DESCRIPTION
This PR allows using Tempus implicitly defined adjoint model evaluator when the user provided adjoint model is null. 

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/piro

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
Added test case to exercise use of implicitly defined adjoint model evaluator.
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->