### PR TITLE
Remove redundant subview from `DistributorActor::doPosts`

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_DistributorActor.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorActor.hpp
@@ -334,10 +334,7 @@ void DistributorActor::doPosts(const DistributorPlan& plan,
             exports, plan.getStartsTo()[p]*numPackets, plan.getLengthsTo()[p]*numPackets);
 
         if (sendType == Details::DISTRIBUTOR_ISEND) {
-          exports_view_type tmpSendBuf =
-            subview_offset (exports, plan.getStartsTo()[p] * numPackets,
-                plan.getLengthsTo()[p] * numPackets);
-          requests_.push_back (isend<int> (tmpSendBuf, plan.getProcsTo()[p],
+          requests_.push_back (isend<int> (tmpSend, plan.getProcsTo()[p],
                 mpiTag_, *plan.getComm()));
         }
         else {  // DISTRIBUTOR_SEND


### PR DESCRIPTION
Fixes https://github.com/trilinos/Trilinos/issues/11302

`tmpSendBuf` is identical to `tmpSend` which is already in-scope, created a few lines above.