### PR TITLE
Kokkos-Kernels:  Disable compile-time check on supported scalar types for cuSPARSE

### DIFF
--- a/packages/kokkos-kernels/src/sparse/KokkosSparse_Utils_cusparse.hpp
+++ b/packages/kokkos-kernels/src/sparse/KokkosSparse_Utils_cusparse.hpp
@@ -116,9 +116,12 @@ inline void cusparse_internal_safe_call(cusparseStatus_t cusparseStatus,
 
 template <typename T>
 cudaDataType cuda_data_type_from() {
+  // Note:  compile-time failure is disabled to allow for packages such as
+  // Ifpack2 to more easily support scalar types that cuSPARSE may not.
+
   // compile-time failure with a nice message if called on an unsupported type
-  static_assert(!std::is_same<T, T>::value,
-                "cuSparse TPL does not support scalar type");
+  //static_assert(!std::is_same<T, T>::value,
+  //                "cuSparse TPL does not support scalar type");
   // static_assert(false, ...) is allowed to error even if the code is not
   // instantiated. obfuscate the predicate Despite this function being
   // uncompilable, the compiler may decide that a return statement is missing,


### PR DESCRIPTION
This change removes the compile-time static-assert on valid scalar types for the cuSPARSE TPL.  The run-time check is still there, and this mimics the behavior for the interface to the older (CUDA-10) cuSPARSE interface.  Making this a compiler error makes it very difficult for packages such as Ifpack2 to support scalar types that cuSPARSE might not, since it can't even instantiate Kokkos-Kernels when cuSPARSE is eanbled and fixes several compiler errors when Ifpack2 is instantiated on Stokhos scalar types.

For issue #11297.
