### PR TITLE
Ifpack2: Call cuSPARSE SPTRSV if scalar type is supported by cuSPARSE

### DIFF
--- a/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
@@ -576,7 +576,8 @@ compute ()
     // Destroy existing handle and recreate in case new matrix provided - requires rerunning symbolic analysis
     kh_->destroy_sptrsv_handle();
 #if defined(KOKKOSKERNELS_ENABLE_TPL_CUSPARSE) && defined(KOKKOS_ENABLE_CUDA)
-    // CuSparse only supports int type ordinals
+    // CuSparse only supports int type ordinals 
+    // and scalar types of float, double, float complex and double complex
     if (std::is_same<Kokkos::Cuda, HandleExecSpace>::value &&
         std::is_same<int, local_ordinal_type>::value &&
        (std::is_same<scalar_type, float>::value ||

--- a/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
@@ -577,7 +577,12 @@ compute ()
     kh_->destroy_sptrsv_handle();
 #if defined(KOKKOSKERNELS_ENABLE_TPL_CUSPARSE) && defined(KOKKOS_ENABLE_CUDA)
     // CuSparse only supports int type ordinals
-    if (std::is_same<Kokkos::Cuda, HandleExecSpace>::value && std::is_same<int,local_ordinal_type >::value)
+    if (std::is_same<Kokkos::Cuda, HandleExecSpace>::value &&
+        std::is_same<int, local_ordinal_type>::value &&
+       (std::is_same<scalar_type, float>::value ||
+        std::is_same<scalar_type, double>::value ||
+        std::is_same<scalar_type, Kokkos::complex<float>>::value ||
+        std::is_same<scalar_type, Kokkos::complex<double>>::value))
     {
       kh_->create_sptrsv_handle(KokkosSparse::Experimental::SPTRSVAlgorithm::SPTRSV_CUSPARSE, numRows, is_lower_tri);
     }


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/ifpack2 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
As per the suggestion of @etphipp in #11297, this PR adds another condition of scalar types supported by cuSPARSE for Ifpack2 calling cuSPARSE SPTRSV. Otherwise, Ifpack2 calls Kokkos Kernels's SPTRSV implementation.
