### PR TITLE
Panzer: move dirichlet residual face basis computation to device

### DIFF
--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Dirichlet_Residual_FaceBasis_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Dirichlet_Residual_FaceBasis_impl.hpp
@@ -149,9 +149,11 @@ evaluateFields(
 
     const WorksetDetails & details = workset;
 
-    int faceOrts[6] = {};
-    for(index_t c=0;c<workset.num_cells;c++) {
+    Kokkos::parallel_for("panzer::DirichletRsidual_FaceBasis::evalauteFields",
+                         workset.num_cells,
+                         KOKKOS_LAMBDA(const index_t c) {
       const auto ort = orientations->at(details.cell_local_ids[c]);
+      Intrepid2::ordinal_type faceOrts[6] = {};
       ort.getFaceOrientation(faceOrts, numFaces); 
 
       // vertex count represent rotation count before it flips
@@ -162,7 +164,7 @@ evaluateFields(
           residual(c,b) += (dof(c,b,d)-value(c,b,d))*faceNormal(c,b,d);
         residual(c,b) *= ortVal;
       } 
-    }
+    });
   }
 }
 


### PR DESCRIPTION
@trilinos/panzer

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Allows for kernel to be run UVM free.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->