### PR TITLE
Panzer: allow users to scale the output exodus fields

### DIFF
--- a/packages/panzer/adapters-stk/src/Panzer_STK_IOClosureModel_Factory.cpp
+++ b/packages/panzer/adapters-stk/src/Panzer_STK_IOClosureModel_Factory.cpp
@@ -81,6 +81,13 @@ buildClosureModels(const std::string& model_id,
 
      int worksetsize = ir->dl_scalar->extent(0);
 
+     // see if there's a scaling parameter object
+     Teuchos::RCP<std::map<std::string,double>> varScaleFactors;
+     if (user_data.isParameter("Variable Scale Factors Map"))
+     {
+       varScaleFactors = user_data.get<Teuchos::RCP<std::map<std::string,double>>>("Variable Scale Factors Map");
+     }
+
      // if a requested field is found then add in cell avg quantity evaluator
      BlockIdToFields::const_iterator cellAvgItr = blockIdToCellAvgFields_.find(block_id);
      if(cellAvgItr!=blockIdToCellAvgFields_.end() ) {
@@ -92,6 +99,7 @@ buildClosureModels(const std::string& model_id,
         pl.set("IR",ir);
         pl.set("Field Names",fieldNames);
         pl.set("Scatter Name", block_id+"_Cell_Avg_Fields");
+        pl.set("Variable Scale Factors Map", varScaleFactors);
         Teuchos::RCP<PHX::Evaluator<panzer::Traits> > eval
             = Teuchos::rcp(new panzer_stk::ScatterCellAvgQuantity<panzer::Traits::Residual,panzer::Traits>(pl));
         fm.registerEvaluator<panzer::Traits::Residual>(eval);
@@ -113,6 +121,7 @@ buildClosureModels(const std::string& model_id,
         pl.set("IR",ir);
         pl.set("Field Names",fieldNames);
         pl.set("Scatter Name", block_id+"_Cell_Avg_Vectors");
+        pl.set("Variable Scale Factors Map", varScaleFactors);
         Teuchos::RCP<PHX::Evaluator<panzer::Traits> > eval
             = Teuchos::rcp(new panzer_stk::ScatterCellAvgVector<panzer::Traits::Residual,panzer::Traits>(pl));
         fm.registerEvaluator<panzer::Traits::Residual>(eval);

--- a/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterCellAvgQuantity_decl.hpp
+++ b/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterCellAvgQuantity_decl.hpp
@@ -96,6 +96,12 @@ class ScatterCellAvgQuantity
   typedef panzer_stk::STK_Interface::SolutionFieldType VariableField; // this is weird, but the correct thing
 
   std::size_t numValues_;
+
+  // map of variable-name to scale-factors to be applied upon output. if
+  // this is empty then no variable scaling will be performed. this
+  // should be passed in as an object via the teuchos parameter list in
+  // the ctor with the parameter name "Variable Scale Factors Map".
+  Teuchos::RCP<std::map<std::string,double>> varScaleFactors_;
  
   std::vector< PHX::MDField<const ScalarT,panzer::Cell,panzer::Point> > scatterFields_;
   Teuchos::RCP<STK_Interface> mesh_;

--- a/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterCellAvgVector_decl.hpp
+++ b/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterCellAvgVector_decl.hpp
@@ -99,6 +99,12 @@ class ScatterCellAvgVector
   
   std::size_t numValues_;
  
+  // map of variable-name to scale-factors to be applied upon output. if
+  // this is empty then no variable scaling will be performed. this
+  // should be passed in as an object via the teuchos parameter list in
+  // the ctor with the parameter name "Variable Scale Factors Map".
+  Teuchos::RCP<std::map<std::string,double>> varScaleFactors_;
+
   std::vector< PHX::MDField<const ScalarT,panzer::Cell,panzer::Point,panzer::Dim> > scatterFields_;
   Teuchos::RCP<STK_Interface> mesh_;
 

--- a/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterCellAvgVector_impl.hpp
+++ b/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterCellAvgVector_impl.hpp
@@ -71,6 +71,9 @@ ScatterCellAvgVector(
 
   std::string scatterName = p.get<std::string>("Scatter Name");
 
+  if (p.isParameter("Variable Scale Factors Map"))
+    varScaleFactors_ = p.get<Teuchos::RCP<std::map<std::string,double>>>("Variable Scale Factors Map");
+
   const std::vector<std::string> & names =
     *(p.get< Teuchos::RCP< std::vector<std::string> > >("Field Names"));
 
@@ -147,7 +150,16 @@ evaluateFields(
          average(i,0) /= numPoints;
       }
 
-      mesh_->setCellFieldData(fieldName+d_mod[dim],blockId,localCellIds,average.get_view());
+      double scalef = 1.0;
+
+      if (!varScaleFactors_.is_null())
+      {
+        std::map<std::string,double> *tmp_sfs = varScaleFactors_.get();
+        if(tmp_sfs->find(fieldName) != tmp_sfs->end())
+          scalef = (*tmp_sfs)[fieldName];
+      }
+
+      mesh_->setCellFieldData(fieldName+d_mod[dim],blockId,localCellIds,average.get_view(),scalef);
 
     }
   }

--- a/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterCellQuantity_decl.hpp
+++ b/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterCellQuantity_decl.hpp
@@ -95,6 +95,12 @@ class ScatterCellQuantity
   std::vector< PHX::MDField<const ScalarT,panzer::Cell> > scatterFields_;
   Teuchos::RCP<STK_Interface> mesh_;
 
+  // map of variable-name to scale-factors to be applied upon output. if
+  // this is empty then no variable scaling will be performed. this
+  // should be passed in as an object via the teuchos parameter list in
+  // the ctor with the parameter name "Variable Scale Factors Map".
+  Teuchos::RCP<std::map<std::string,double>> varScaleFactors_;
+ 
 }; // end of class ScatterCellQuantity
 
 

--- a/packages/panzer/adapters-stk/src/responses/Panzer_STK_ResponseEvaluatorFactory_SolutionWriter_impl.hpp
+++ b/packages/panzer/adapters-stk/src/responses/Panzer_STK_ResponseEvaluatorFactory_SolutionWriter_impl.hpp
@@ -313,6 +313,7 @@ void ResponseEvaluatorFactory_SolutionWriter<EvalT>::
 scaleField(const std::string & fieldName,double fieldScalar)
 {
   fieldToScalar_[fieldName] = fieldScalar;
+  scaledFieldsHash_.insert(fieldName);
 }
 
 template <typename EvalT>


### PR DESCRIPTION
@trilinos/panzer

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Allow the user to scale the output exodus fields.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->