### PR TITLE
README: Update the README to point users to the Trilinos package owners wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ unique design feature of Trilinos is its focus on packages.
 
 - [Trilinos Configure, Build, Test, and Install Reference Guide](https://trilinos.org/docs/files/TrilinosBuildReference.html)
 
+- To ensure appropriate parties receive your issues, please direct issues by mentioning the
+  [Trilinos package owners](https://github.com/trilinos/Trilinos/wiki/Trilinos-Package-Owners).
+  External users may not mention Github teams, but may mention individual owners instead.
+
 - For help with a particular package, see the website and accompanying
   documentation for that package. Links to these can be found down the
   right side of any page on the website and at [the package website](https://trilinos.github.io/packages.html).


### PR DESCRIPTION
This is one of many things that may help external users reach package owners. It relies on the wiki page being as up-to-date as possible, which isn't much of a limitation, as it is easy to edit the wiki.

This helps external users mention the correct parties because external users may not mention teams for a project.