### PR TITLE
Remove CUDA_LAUNCH_BLOCKING from testing

### DIFF
--- a/packages/framework/pr_tools/trilinosprhelpers/unittests/environment-specs.ini
+++ b/packages/framework/pr_tools/trilinosprhelpers/unittests/environment-specs.ini
@@ -357,7 +357,6 @@ use RHEL7_SEMS-SERIAL
 use RHEL7_PRE
 module-load  sems-gcc                        : 7.2.0
 module-load  sems-cuda                       : 10.1
-envvar-set   CUDA_LAUNCH_BLOCKING            : 1
 envvar-set   CUDA_MANAGED_FORCE_DEVICE_ALLOC : 1
 envvar-set   KOKKOS_NUM_DEVICES              : 2
 use MPI-COMPILER-VARS


### PR DESCRIPTION
Not needed for testing, and confusing for people trying to ensure that CUDA_LAUNCH_BLOCKING is not set anymore.

User Support Ticket(s) or Story Referenced: TRILINOSHD-227

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/framework 

## Motivation
Real variables should not be used in capability testing, for pretty much this exact reason (Roger was concerned that it may have been used "for real").