### PR TITLE
packages/framework:

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -297,7 +297,7 @@
 
 [COMMON]
 opt-set-cmake-var CMAKE_GENERATOR STRING : Ninja
-opt-set-cmake-var Trilinos_ENABLE_BUILD_STATS BOOL : ON
+#opt-set-cmake-var Trilinos_ENABLE_BUILD_STATS BOOL : ON
 
 # LINK_JOBS_LIMIT only has an affect when CMAKE_GENERATOR=Ninja, default to 2
 opt-set-cmake-var Trilinos_PARALLEL_LINK_JOBS_LIMIT STRING : 2

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -296,6 +296,9 @@
 #------------------------------------------------------------------------------
 
 [COMMON]
+opt-set-cmake-var CMAKE_GENERATOR STRING : Ninja
+opt-set-cmake-var Trilinos_ENABLE_BUILD_STATS BOOL : ON
+
 # LINK_JOBS_LIMIT only has an affect when CMAKE_GENERATOR=Ninja, default to 2
 opt-set-cmake-var Trilinos_PARALLEL_LINK_JOBS_LIMIT STRING : 2
 
@@ -862,7 +865,7 @@ opt-set-cmake-var Trilinos_ENABLE_Zoltan2Core BOOL : ON
 
 [NODE-TYPE|CUDA_USE-RDC|YES_USE-PT|YES]
 # LINK_JOBS_LIMIT only has an affect when CMAKE_GENERATOR=Ninja
-opt-set-cmake-var Trilinos_PARALLEL_LINK_JOBS_LIMIT STRING FORCE : 10
+opt-set-cmake-var Trilinos_PARALLEL_LINK_JOBS_LIMIT STRING FORCE : 32
 
 [NODE-TYPE|CUDA_USE-RDC|YES_USE-PT|NO]
 # LINK_JOBS_LIMIT only has an affect when CMAKE_GENERATOR=Ninja

--- a/packages/framework/pr_tools/LaunchDriver.py
+++ b/packages/framework/pr_tools/LaunchDriver.py
@@ -50,10 +50,7 @@ def get_launch_cmd(build_name : str, system : str):
   Returns:
       str: The command used to launch the driver.
   """
-  if system == "weaver" or system == "ats2":
-    cmd = "bsub -Is -J " + build_name + " -W 12:00"
-  else:
-    cmd = ""
+  cmd = ""
 
   return cmd + " "
 

--- a/packages/framework/pr_tools/LaunchDriver.py
+++ b/packages/framework/pr_tools/LaunchDriver.py
@@ -29,16 +29,13 @@ def get_launch_env(build_name : str, system : str):
   """
   Gets the launch environment based on the detected system.
   This is an early environment that's required for running the driver.
-  
+
   Returns:
       str: The environment used to launch the driver.
   """
   env = ""
   if "_rdc" in build_name:
-      env += " TRILINOS_MAX_CORES=10"
-
-  if system == "weaver" or system == "ats2":
-      env += " Trilinos_CTEST_DO_ALL_AT_ONCE=TRUE"
+      env += " TRILINOS_MAX_CORES=96"
 
   if env == "":
       return ""
@@ -49,14 +46,14 @@ def get_launch_env(build_name : str, system : str):
 def get_launch_cmd(build_name : str, system : str):
   """
   Gets the launch command based on the detected system.
-  
+
   Returns:
       str: The command used to launch the driver.
   """
   if system == "weaver" or system == "ats2":
     cmd = "bsub -Is -J " + build_name + " -W 12:00"
   else:
-    cmd = ""  
+    cmd = ""
 
   return cmd + " "
 
@@ -64,10 +61,10 @@ def get_launch_cmd(build_name : str, system : str):
 def get_driver_args(system : str):
   """
   Gets the driver arguments based on the detected system.
-  
+
   Returns:
       str: The arguments passed to the driver.
-  """  
+  """
   return " " + "--on_" + system
 
 
@@ -112,4 +109,3 @@ def main(argv):
 
 if __name__ == "__main__":
     main(sys.argv[1 :])
-

--- a/packages/framework/pr_tools/unittests/test_LaunchDriver.py
+++ b/packages/framework/pr_tools/unittests/test_LaunchDriver.py
@@ -27,34 +27,19 @@ class Test_LaunchDriver(unittest.TestCase):
 
     ## Test LaunchDriver methods
     def testUnitGetLaunchEnv(self):
-      env = ld.get_launch_env(self.build_name, "weaver")
-      self.assertEqual(env, "env Trilinos_CTEST_DO_ALL_AT_ONCE=TRUE ")
-
-      env = ld.get_launch_env(self.build_name, "ats2")
-      self.assertEqual(env, "env Trilinos_CTEST_DO_ALL_AT_ONCE=TRUE ")
-
-      env = ld.get_launch_env(self.build_name+"_rdc", "weaver")
-      self.assertEqual(env, "env TRILINOS_MAX_CORES=10 Trilinos_CTEST_DO_ALL_AT_ONCE=TRUE ")
+      env = ld.get_launch_env(self.build_name+"_rdc", "dne")
+      self.assertEqual(env, "env TRILINOS_MAX_CORES=96 ")
 
       env = ld.get_launch_env(self.build_name, "dne")
       self.assertEqual(env, "")
 
 
     def testUnitGetLaunchCmd(self):
-      cmd = ld.get_launch_cmd(self.build_name, "weaver")
-      self.assertEqual(cmd, "bsub -Is -J " + self.build_name + " -W 12:00 ")
-
-      cmd = ld.get_launch_cmd(self.build_name, "ats2")
-      self.assertEqual(cmd, "bsub -Is -J " + self.build_name + " -W 12:00 ")
-
       cmd = ld.get_launch_cmd(self.build_name, "dne")
       self.assertEqual(cmd, " ")
 
 
     def testUnitGetDriverArgs(self):
-      args = ld.get_driver_args("ats2")
-      self.assertEqual(args, " --on_ats2")
-
       args = ld.get_driver_args("dne1")
       self.assertEqual(args, " --on_dne1")
 


### PR DESCRIPTION
  - Increase parallel levels for rdc build
  - Always use build stats and the ninja generator

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Increase parallel build levels for the cuda 11 rdc build in an effort to get nightly rdc results posted every 24 hours.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Tested via:
```
source ../packages/framework/GenConfig/gen-config.sh --ci-mode --cmake-fragment frag.cmake rhel7_sems-cuda-11.4.2-sems-gnu-10.1.0-sems-openmpi-4.0.5_release_static_Volta70_no-asan_complex_no-fpic_mpi_pt_rdc_uvm_deprecated-on_all ..
```

## Additional Information
<!--- 
Anything else we need to know in evaluating this merge request?
 -->
Enable build stats for all PR and MM builds.
Select Ninja generator for all PR and MM builds since that is what PR testing scripts are using already. It is confusing that Unix Makefiles are used when running GenConfig outside of PR testing.