### PR TITLE
MueLu: Update ExecSpace::concurrency() for the non-static case

### DIFF
--- a/packages/muelu/src/Rebalancing/MueLu_RepartitionHeuristicFactory_def.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_RepartitionHeuristicFactory_def.hpp
@@ -132,7 +132,7 @@ namespace MueLu {
 #if defined(KOKKOS_ENABLE_OPENMP)
     using execution_space = typename Node::device_type::execution_space;
     if (std::is_same<execution_space, Kokkos::OpenMP>::value)
-      thread_per_mpi_rank = execution_space::concurrency();
+      thread_per_mpi_rank = execution_space().concurrency();
 #endif
 
     if (minRowsPerThread > 0)

--- a/packages/muelu/test/scaling/JacobiKernelDriver.cpp
+++ b/packages/muelu/test/scaling/JacobiKernelDriver.cpp
@@ -477,7 +477,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
         << "========================================================" << endl;
 
 #if defined(HAVE_MUELU_TPETRA) && defined(HAVE_TPETRA_INST_OPENMP)
-    out<< "Kokkos::Compat::KokkosOpenMPWrapperNode::execution_space::concurrency() = "<<Kokkos::Compat::KokkosOpenMPWrapperNode::execution_space::concurrency()<<endl
+    out<< "Kokkos::Compat::KokkosOpenMPWrapperNode::execution_space().concurrency() = "<<Kokkos::Compat::KokkosOpenMPWrapperNode::execution_space().concurrency()<<endl
        << "========================================================" << endl;
 #endif
 

--- a/packages/muelu/test/scaling/MatvecKernelDriver.cpp
+++ b/packages/muelu/test/scaling/MatvecKernelDriver.cpp
@@ -956,7 +956,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
         << "========================================================" << endl;
 
 #if defined(HAVE_MUELU_TPETRA) && defined(HAVE_TPETRA_INST_OPENMP)
-    out<< "Kokkos::Compat::KokkosOpenMPWrapperNode::execution_space::concurrency() = "<<Kokkos::Compat::KokkosOpenMPWrapperNode::execution_space::concurrency()<<endl
+    out<< "Kokkos::Compat::KokkosOpenMPWrapperNode::execution_space().concurrency() = "<<Kokkos::Compat::KokkosOpenMPWrapperNode::execution_space().concurrency()<<endl
        << "========================================================" << endl;
 #endif
 

--- a/packages/muelu/test/scaling/TwoMatrixMMKernelDriver.cpp
+++ b/packages/muelu/test/scaling/TwoMatrixMMKernelDriver.cpp
@@ -554,7 +554,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
         << "========================================================" << endl;
 
 #if defined(HAVE_MUELU_TPETRA) && defined(HAVE_TPETRA_INST_OPENMP)
-    out<< "Kokkos::Compat::KokkosOpenMPWrapperNode::execution_space::concurrency() = "<<Kokkos::Compat::KokkosOpenMPWrapperNode::execution_space::concurrency()<<endl
+    out<< "Kokkos::Compat::KokkosOpenMPWrapperNode::execution_space().concurrency() = "<<Kokkos::Compat::KokkosOpenMPWrapperNode::execution_space().concurrency()<<endl
        << "========================================================" << endl;
 #endif
 


### PR DESCRIPTION
@trilinos/muelu 

This changes our uses of `ExecSpace::concurrency()` to `ExecSpace().concurrency()` as requested in #11331 to prepare for https://github.com/kokkos/kokkos/issues/5655.