### PR TITLE
Device version of MP vector constructor with initialiser list.

### DIFF
--- a/packages/stokhos/test/UnitTest/Stokhos_SacadoMPVectorUnitTest_MaskTraits.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_SacadoMPVectorUnitTest_MaskTraits.cpp
@@ -568,7 +568,7 @@ TEUCHOS_UNIT_TEST( MP_Vector_MaskTraits, Mask_div)
     typedef Stokhos::StaticFixedStorage<int,double,ensemble_size,execution_space> storage_type;
     typedef Sacado::MP::Vector<storage_type> scalar;    
 
-    scalar a2 = {0.,2.};
+    scalar a2 = {0.,2.,2.,2.,2.,2.,2.,2.};
     std::cout << a2 << std::endl;
 
     scalar a = (scalar) 1.;


### PR DESCRIPTION
@trilinos/stokhos

## Related Issues

Closes #11337.  

## Testing

These changes are tested in `Stokhos_SacadoMPVectorUnitTest_MPI_1` and `Stokhos_SacadoMPVectorUnitTestMaskTraits_MPI_1`.