### PR TITLE
stokhos/tpetra/teuchos/intrepid2: Fix warnings

### DIFF
--- a/packages/intrepid2/src/Discretization/Integration/Intrepid2_CubatureDirect.hpp
+++ b/packages/intrepid2/src/Discretization/Integration/Intrepid2_CubatureDirect.hpp
@@ -233,6 +233,13 @@ namespace Intrepid2 {
         dimension_(b.dimension_),
         cubatureData_(b.cubatureData_) {}
 
+    CubatureDirect& operator=(const CubatureDirect &b) {
+        this->degree_       = b.degree_;
+        this->dimension_    = b.dimension_;
+        this->cubatureData_ = b.cubatureData_;
+        return *this;
+    } 
+    
     CubatureDirect(const ordinal_type degree,
                    const ordinal_type dimension) 
     : degree_(degree),

--- a/packages/stokhos/src/sacado/kokkos/vector/Stokhos_MP_Vector_MaskTraits.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/Stokhos_MP_Vector_MaskTraits.hpp
@@ -511,25 +511,31 @@ public:
 
 private:
     bool data[size];
-    
+
 public:
     KOKKOS_INLINE_FUNCTION Mask(){
         for(std::size_t i=0; i<size; ++i)
             this->set(i,false);
     }
-    
+
     KOKKOS_INLINE_FUNCTION Mask(bool a){
         for(std::size_t i=0; i<size; ++i)
             this->set(i,a);
     }
-    
+
     KOKKOS_INLINE_FUNCTION Mask(const Mask &a){
         for(std::size_t i=0; i<size; ++i)
             data[i] = a.data[i];
     }
-    
+
+    KOKKOS_INLINE_FUNCTION Mask& operator=(const Mask &a){
+        for(std::size_t i=0; i<size; ++i)
+            this->data[i] = a.data[i];
+        return *this;
+    }
+
     KOKKOS_INLINE_FUNCTION std::size_t getSize() const {return size;}
-    
+
     KOKKOS_INLINE_FUNCTION bool operator> (double v)
     {
         double sum = 0;
@@ -547,7 +553,7 @@ public:
 
         return sum < v*size;
     }
-    
+
     KOKKOS_INLINE_FUNCTION bool operator>= (double v)
     {
         double sum = 0;

--- a/packages/stokhos/src/sacado/kokkos/vector/Stokhos_MP_Vector_MaskTraits.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/Stokhos_MP_Vector_MaskTraits.hpp
@@ -699,7 +699,7 @@ public:
     }
 };
 
-template<typename scalar> KOKKOS_INLINE_FUNCTION std::ostream &operator<<(std::ostream &os, const Mask<scalar>& m) {
+template<typename scalar> std::ostream &operator<<(std::ostream &os, const Mask<scalar>& m) {
     os << "[ ";
     for(std::size_t i=0; i<m.getSize(); ++i)
         os << m.get(i) << " ";

--- a/packages/teuchos/core/src/Teuchos_UnitTestHelpers.hpp
+++ b/packages/teuchos/core/src/Teuchos_UnitTestHelpers.hpp
@@ -87,9 +87,9 @@ see Teuchos_LocalTestingHelpers.hpp and Teuchos_TestingHelpers.hpp.
     TEST_GROUP##_##TEST_NAME##_UnitTest() \
       : Teuchos::UnitTestBase( #TEST_GROUP, #TEST_NAME ) \
     {} \
-    virtual void runUnitTestImpl( Teuchos::FancyOStream &out, bool &success ) const; \
-    virtual std::string unitTestFile() const { return __FILE__; } \
-    virtual long int unitTestFileLineNumber() const { return __LINE__; } \
+    virtual void runUnitTestImpl( Teuchos::FancyOStream &out, bool &success ) const override; \
+    virtual std::string unitTestFile() const override { return __FILE__; } \
+    virtual long int unitTestFileLineNumber() const override { return __LINE__; } \
   }; \
   \
   TEST_GROUP##_##TEST_NAME##_UnitTest \

--- a/packages/tpetra/core/inout/MatrixMarket_TpetraNew.hpp
+++ b/packages/tpetra/core/inout/MatrixMarket_TpetraNew.hpp
@@ -581,8 +581,10 @@ readBinary(
       // The header in the binary file contains only numVertices and numEdges
       unsigned int nv = 0;
       unsigned long long ne = 0;
-      fread(&nv, sizeof(unsigned int), 1, fp);
-      fread(&ne, sizeof(unsigned long long), 1, fp);
+      if (fread(&nv, sizeof(unsigned int), 1, fp) != 1)
+           throw std::runtime_error("Error: bad number of read values.");
+      if (fread(&ne, sizeof(unsigned long long), 1, fp) != 1)
+           throw std::runtime_error("Error: bad number of read values.");
       dim[0] = nv;
       dim[1] = dim[0];
       dim[2] = ne;
@@ -812,9 +814,12 @@ readPerProcessBinary(
   // The header in each per-process file:  globalNumRows globalNumCols localNumNonzeros
   unsigned int globalNumRows = 0, globalNumCols = 0;
   unsigned long long localNumNonzeros = 0;
-  fread(&globalNumRows, sizeof(unsigned int), 1, fp);
-  fread(&globalNumCols, sizeof(unsigned int), 1, fp);
-  fread(&localNumNonzeros, sizeof(unsigned long long), 1, fp);
+  if (fread(&globalNumRows, sizeof(unsigned int), 1, fp) != 1)
+    throw std::runtime_error("Error: bad number of read values.");
+  if (fread(&globalNumCols, sizeof(unsigned int), 1, fp) != 1)
+    throw std::runtime_error("Error: bad number of read values.");
+  if (fread(&localNumNonzeros, sizeof(unsigned long long), 1, fp) != 1)
+    throw std::runtime_error("Error: bad number of read values.");
  
   nRow = static_cast<size_t>(globalNumRows);
   nCol = static_cast<size_t>(globalNumCols);


### PR DESCRIPTION
@trilinos/stokhos
@trilinos/tpetra
@trilinos/teuchos
@trilinos/intrepid2

## Motivation
Following issue #11247, we now compile our PDE code using Trilinos as a regular include, rather than as a system include. This allows us to see and solve more compiler warnings in our PDE code.  

When we compile our PDE code in this way, we also see compiler warnings that seem to be related to Trilinos itself.  For some of those compiler warnings, there seem to be rather straightforward fixes, which we would like to propose as a PR:

- The fix around line 531 in `packages/stokhos/src/sacado/kokkos/vector/Stokhos_MP_Vector_MaskTraits.hpp` solves a warning about deprecated implicit generation of a copy constructor.

```
error: implicitly-declared 'constexpr Mask<Sacado::MP::Vector<Stokhos::StaticFixedStorage<int, double, 2, Kokkos::OpenMP> > >& Mask<Sacado::MP::Vector<Stokhos::StaticFixedStorage<int, double, 2, Kokkos::OpenMP> > >::operator=(const Mask<Sacado::MP::Vector<Stokhos::StaticFixedStorage<int, double, 2, Kokkos::OpenMP> > >&)' is deprecated [-Werror=deprecated-copy]
In file included from /opt/Trilinos/GNU-OpenMP/include/Sacado_MP_Vector.hpp:2028,
    from /opt/Trilinos/GNU-OpenMP/include/Stokhos_Sacado_Kokkos_MP_Vector.hpp:61,
```

- The fix around line 700 in `packages/stokhos/src/sacado/kokkos/vector/Stokhos_MP_Vector_MaskTraits.hpp` solves a __host__ __device__ warning in cuda about the stream operator not being available on device.

```
packages/stokhos/src/sacado/kokkos/vector/Stokhos_MP_Vector_MaskTraits.hpp(699): warning #20011-D: calling a __host__ function("std::basic_ostream<char, T1>  &  ::std::operator <<<    ::std::char_traits<char> > (    ::std::basic_ostream<char, T1>  &, const char *)") from a __host__ __device__ function("operator <<< ::Sacado::MP::Vector< ::Stokhos::StaticFixedStorage<int, double, (int)16, ::Kokkos::Cuda> > > ") is not allowed
```

- The fix around line 90 in `packages/teuchos/core/src/Teuchos_UnitTestHelpers.hpp b/packages/teuchos/core/src/Teuchos_UnitTestHelpers.hpp` solves a warning about overriding functions not being declared override.

```
/opt/Trilinos/GNU-OpenMP/include/Teuchos_UnitTestHelpers.hpp:90:18: error: 'virtual void ComplexSupport_complex_comparison_UnitTest::runUnitTestImpl(Teuchos::FancyOStream&, bool&) const' can be marked override [-Werror=suggest-override]
   90 |     virtual void runUnitTestImpl( Teuchos::FancyOStream &out, bool &success ) const  \
```

- The fixes around lines 584 and 815 in `packages/tpetra/core/inout/MatrixMarket_TpetraNew.hpp` solve warnings about the result of a call not being used.

```
packages/tpetra/core/inout/MatrixMarket_TpetraNew.hpp(584): warning #1650-D: result of call is not used
packages/tpetra/core/inout/MatrixMarket_TpetraNew.hpp(585): warning #1650-D: result of call is not used
packages/tpetra/core/inout/MatrixMarket_TpetraNew.hpp(815): warning #1650-D: result of call is not used
packages/tpetra/core/inout/MatrixMarket_TpetraNew.hpp(816): warning #1650-D: result of call is not used
packages/tpetra/core/inout/MatrixMarket_TpetraNew.hpp(817): warning #1650-D: result of call is not used
```

- The fix arount line 233 in `packages/intrepid2/src/Discretization/Integration/Intrepid2_CubatureDirect.hpp` solves a warning about deprecated implicit generation of a copy constructor.

```
Intrepid2_CubatureTensor.hpp:224:21: error: implicitly-declared 'Intrepid2::CubatureDirect<Kokkos::OpenMP, double, double>& Intrepid2::CubatureDirect<Kokkos::OpenMP, double, double>::operator=(const Intrepid2::CubatureDirect<Kokkos::OpenMP, double, double>&)' is deprecated [-Werror=deprecated-copy]
```

## Related Issues

#11247

## Testing
These changes are tested by various existing tests in Trilinos.