### PR TITLE
Actions: Adding a title/label to mention utility for Ifpack2, MueLu

### DIFF
--- a/.github/workflows/title_to_mention.yml
+++ b/.github/workflows/title_to_mention.yml
@@ -18,13 +18,16 @@ jobs:
 
     steps:
     - name: Mention MueLu
-      uses: ben-z/actions-comment-on-issue@1.0.2
+      uses: peter-evans/create-or-update-comment@v2
       if: contains(github.event.label.name, 'MueLu') || contains(github.event.issue.title, 'MueLu')  
       with:
-        message: "Automatic mention of the @trilinos/muelu team"
+        issue-number: ${{ github.event.issue.number }}  
+        body: |
+          Automatic mention of the @trilinos/muelu team
     - name: Mention Ifpack2
-      uses: ben-z/actions-comment-on-issue@1.0.2
+      uses: peter-evans/create-or-update-comment@v2
       if: contains(github.event.label.name, 'Ifpack2') || contains(github.event.issue.title, 'Ifpack2')  
       with:
-        message: "Automatic mention of the @trilinos/ifpack2 team"
-        
+        issue-number: ${{ github.event.issue.number }}  
+        body: |
+          Automatic mention of the @trilinos/ifpack2 team

--- a/.github/workflows/title_to_mention.yml
+++ b/.github/workflows/title_to_mention.yml
@@ -1,0 +1,29 @@
+name: Automatically at mention package teams if the package name is in the title
+# Because evidently github won't let non-members do this.
+
+on:
+  issues:
+    types: [opened, labeled]
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+permissions:
+  contents: read
+  
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Mention MueLu
+      uses: ben-z/actions-comment-on-issue@1.0.2
+      if: contains(github.event.label.name, 'MueLu') || contains(github.event.issue.title, 'MueLu')  
+      with:
+        message: "Automatic mention of the @trilinos/muelu team"
+    - name: Mention Ifpack2
+      uses: ben-z/actions-comment-on-issue@1.0.2
+      if: contains(github.event.label.name, 'Ifpack2') || contains(github.event.issue.title, 'Ifpack2')  
+      with:
+        message: "Automatic mention of the @trilinos/ifpack2 team"
+        

--- a/.github/workflows/title_to_mention.yml
+++ b/.github/workflows/title_to_mention.yml
@@ -10,6 +10,7 @@ env:
 
 permissions:
   contents: read
+  issues: write
   
 jobs:
   comment:


### PR DESCRIPTION
Because github won't let non-team members do team mentions.


This is the "test" version of this utility, just targeting Ifpack2 and MueLu.  We can add more packages later, assuming it works.

