### PR TITLE
Use 2x4 (slots x GPUs) for RDC build

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1874,3 +1874,6 @@ use rhel7_sems-cuda-11.4.2-sems-gnu-10.1.0-sems-openmpi-4.0.5_release_static_Vol
 use NODE-TYPE|CUDA_USE-RDC|YES_USE-PT|YES
 use USE-RDC|YES
 use PACKAGE-ENABLES|ALL
+opt-set-cmake-var Trilinos_AUTOGENERATE_TEST_RESOURCE_FILE BOOL : ON
+opt-set-cmake-var Trilinos_CUDA_NUM_GPUS STRING : 4
+opt-set-cmake-var Trilinos_CUDA_SLOTS_PER_GPU STRING : 2


### PR DESCRIPTION
User Support Ticket(s) or Story Referenced: TRILFRAME-517


@trilinos/framework 

## Motivation
Want the RDC builds to use a full 4 GPU machine to get results faster from testing.