### PR TITLE
Automatically assign all GPUs on machine to tester

### DIFF
--- a/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationStandard.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationStandard.py
@@ -11,7 +11,6 @@ from . import TrilinosPRConfigurationBase
 from gen_config import GenConfig
 from pathlib import Path
 from .sysinfo import gpu_utils
-from .jenkinsenv import TrilinosJenkinsEnv
 
 
 class TrilinosPRConfigurationStandard(TrilinosPRConfigurationBase):
@@ -78,19 +77,14 @@ class TrilinosPRConfigurationStandard(TrilinosPRConfigurationBase):
              ]
 
         if gpu_utils.has_nvidia_gpus():
-            print("REMARK: I see that I am running on a machine that has NVidia GPUs; I will attempt to write a GPU resource file for use by ctest")
+            self.message("-- REMARK: I see that I am running on a machine that has NVidia GPUs; I will attempt to write a GPU resource file for use by ctest")
             resource_spec_file = os.path.join(self.arg_build_dir, "ctest_resources.json")
-            jobname = TrilinosJenkinsEnv.job_base_name
-            if jobname.startswith("Trilinos_autotester_driver_inst"):
-                my_autotester_id = jobname.split("_")[-1]
-                try:
-                    my_autotester_id = int(my_autotester_id)
-                except Exception:
-                    print(f"WARNING: Could not identify an index from last job base name field {my_autotester_id}")
-                gpu_utils.write_ctest_gpu_resource_file(filename=resource_spec_file, gpu_indices=[my_autotester_id], slots_per_gpu=2)
-                cmd.append(f"-DCTEST_RESOURCE_SPEC_FILE:FILEPATH={resource_spec_file}")
-            else:
-                print(f"REMARK: I am only capable of assigning GPU resources from a very specific autotester job (titled 'Trilinos_autotester_driver_inst_X'), and this job was named '{jobname}', so I will not create a resource file")
+            slots_per_gpu = 2
+            gpu_indices = gpu_utils.list_nvidia_gpus()
+            self.message(f"-- REMARK: Using {slots_per_gpu} slots per GPU")
+            self.message(f"-- REMARK: Using GPUs {gpu_indices}")
+            gpu_utils.write_ctest_gpu_resource_file(filename=resource_spec_file, gpu_indices=gpu_indices, slots_per_gpu=slots_per_gpu)
+            cmd.append(f"-DCTEST_RESOURCE_SPEC_FILE:FILEPATH={resource_spec_file}")
 
         self.message( "--- ctest version:")
         if not self.args.dry_run:

--- a/packages/framework/pr_tools/trilinosprhelpers/sysinfo/gpu_utils.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/sysinfo/gpu_utils.py
@@ -18,7 +18,7 @@ def _nvidia_smi():
 def list_nvidia_gpus():
     gpu_ids = []
     try:
-        gpu_ids = [x for x in range(0, len(_nvidia_smi()))]
+        gpu_ids = [str(x) for x in range(0, len(_nvidia_smi()))]
     except Exception as e:
         raise RuntimeError("Failed to acquire list of gpus: {0}".format(str(e)))
     return gpu_ids

--- a/packages/framework/pr_tools/trilinosprhelpers/sysinfo/gpu_utils.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/sysinfo/gpu_utils.py
@@ -17,7 +17,7 @@ def _nvidia_smi():
 def list_nvidia_gpus():
     gpu_ids = []
     try:
-        gpu_ids = [x for x in range(0, len(_nvidia_smi.splitlines()))]
+        gpu_ids = [x for x in range(0, len(_nvidia_smi().splitlines()))]
     except Exception as e:
         raise RuntimeError("Failed to acquire list of gpus: {0}".format(str(e)))
     return gpu_ids

--- a/packages/framework/pr_tools/trilinosprhelpers/sysinfo/gpu_utils.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/sysinfo/gpu_utils.py
@@ -11,13 +11,14 @@ def has_nvidia_gpus():
 def _nvidia_smi():
     if which('nvidia-smi'):
         with open(os.devnull) as errout:
-            return subprocess.check_output('nvidia-smi --list-gpus', stderr=errout, shell=True)
+            return subprocess.check_output('nvidia-smi --list-gpus', stderr=errout, shell=True).splitlines()
+    return []
 
 
 def list_nvidia_gpus():
     gpu_ids = []
     try:
-        gpu_ids = [x for x in range(0, len(_nvidia_smi().splitlines()))]
+        gpu_ids = [x for x in range(0, len(_nvidia_smi()))]
     except Exception as e:
         raise RuntimeError("Failed to acquire list of gpus: {0}".format(str(e)))
     return gpu_ids

--- a/packages/framework/pr_tools/trilinosprhelpers/sysinfo/gpu_utils.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/sysinfo/gpu_utils.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+import json
+import os
+import subprocess
+from argparse import ArgumentParser
+from shutil import which
+
+
+def has_nvidia_gpus():
+    gpu_ids = []
+    if which('nvidia-smi'):
+        try:
+            with open(os.devnull) as errout:
+                gpu_ids = [str(x) for x in range(0, len(subprocess.check_output('nvidia-smi --list-gpus', stderr=errout, shell=True).splitlines()))]
+        except Exception as e:
+            raise RuntimeError("Failed to acquire list of gpus: {0}".format(str(e)))
+    return gpu_ids != []
+
+
+def write_ctest_gpu_resource_file(filename, gpu_indices, slots_per_gpu=1):
+    content = {
+        "version": {
+            "major": 1,
+            "minor": 0
+        },
+        "local": [
+            {
+                "gpus": [{"id": x, "slots": 1} for x in gpu_indices]
+            }
+        ]
+    }
+    with open(filename, 'w') as outf:
+        json.dump(content, outf)

--- a/packages/framework/pr_tools/trilinosprhelpers/sysinfo/unittests/test_gpu_utils.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/sysinfo/unittests/test_gpu_utils.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+# -*- coding: utf-8; mode: python; py-indent-offset: 4; py-continuation-offset: 4 -*-
+"""
+"""
+from __future__ import print_function
+
+from unittest import TestCase
+
+try:                                    # pragma: no cover
+    import unittest.mock as mock        # pragma: no cover
+    from unittest.mock import patch
+except:                                 # pragma: no cover
+    import mock                         # pragma: no cover
+    from mock import patch
+
+import trilinosprhelpers.sysinfo as sysinfo
+
+
+#==============================================================================
+#
+#                         M O C K   H E L P E R S
+#
+#==============================================================================
+
+def mock_nvidia_smi():
+    return """GPU 0: Tesla V100S-PCIE-32GB (UUID: GPU-somehash1)
+GPU 1: Tesla V100S-PCIE-32GB (UUID: GPU-somehash2)
+GPU 2: Tesla V100S-PCIE-32GB (UUID: GPU-somehash3)
+GPU 3: Tesla V100S-PCIE-32GB (UUID: GPU-somehash4)"""
+
+
+#==============================================================================
+#
+#                                T E S T S
+#
+#==============================================================================
+
+class GpuUtilsTest(TestCase):
+    """
+    Tests for gpu_utils.
+    """
+    def setUp(self):
+        self.maxDiff = None
+
+    def test_list_nvidia_gpus(self):
+        """
+        Test that sane output from nvidia-smi yields a sane list of gpu indices.
+        """
+        print("")
+        with patch("trilinosprhelpers.sysinfo.gpu_utils._nvidia_smi", side_effect=mock_nvidia_smi):
+            ret = sysinfo.gpu_utils.list_nvidia_gpus()
+        self.assertEqual([0, 1, 2, 3], ret)
+
+    def test_has_nvidia_gpus(self):
+        """
+        Test that sane output from nvidia-smi yields positive for system possessing NVidia GPUs.
+        """
+        print("")
+        with patch("trilinosprhelpers.sysinfo.gpu_utils._nvidia_smi", side_effect=mock_nvidia_smi):
+            ret = sysinfo.gpu_utils.has_nvidia_gpus()
+        self.assertTrue(ret)

--- a/packages/framework/pr_tools/trilinosprhelpers/sysinfo/unittests/test_gpu_utils.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/sysinfo/unittests/test_gpu_utils.py
@@ -54,7 +54,7 @@ class GpuUtilsTest(TestCase):
         print("")
         with patch("trilinosprhelpers.sysinfo.gpu_utils._nvidia_smi", side_effect=mock_nvidia_smi):
             ret = sysinfo.gpu_utils.list_nvidia_gpus()
-        self.assertEqual([0, 1, 2, 3], ret)
+        self.assertEqual(["0", "1", "2", "3"], ret)
 
     def test_has_nvidia_gpus(self):
         """

--- a/packages/framework/pr_tools/trilinosprhelpers/sysinfo/unittests/test_gpu_utils.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/sysinfo/unittests/test_gpu_utils.py
@@ -4,6 +4,8 @@
 """
 from __future__ import print_function
 
+import os
+
 from unittest import TestCase
 
 try:                                    # pragma: no cover
@@ -27,6 +29,9 @@ def mock_nvidia_smi():
 GPU 1: Tesla V100S-PCIE-32GB (UUID: GPU-somehash2)
 GPU 2: Tesla V100S-PCIE-32GB (UUID: GPU-somehash3)
 GPU 3: Tesla V100S-PCIE-32GB (UUID: GPU-somehash4)"""
+
+def mock_which(thing_to_find):
+    return os.path.join(os.getcwd(), thing_to_find)
 
 
 #==============================================================================
@@ -59,3 +64,12 @@ class GpuUtilsTest(TestCase):
         with patch("trilinosprhelpers.sysinfo.gpu_utils._nvidia_smi", side_effect=mock_nvidia_smi):
             ret = sysinfo.gpu_utils.has_nvidia_gpus()
         self.assertTrue(ret)
+
+    def test_nvidia_smi_output_without_smi(self):
+        """
+        Test that without nvidia-smi available the smi interface returns an empty list of output.
+        """
+        print("")
+        with patch("trilinosprhelpers.sysinfo.gpu_utils.which", side_effect=mock_which):
+            ret = sysinfo.gpu_utils._nvidia_smi()
+        self.assertEqual([], ret)


### PR DESCRIPTION
Scan a machine for NVidia GPUs, and if found, assign them all to the ctest instance with 2 slots each.

This will be coupled with some rearrangement of the PR pool such that each GPU machine only runs one GPU PR at a time, and nothing else.

@trilinos/framework 

## Motivation
Want more robust test results, and faster ones too.  Seeing repeated flaky testing on the GPU PR runs and suspect it's due to multiple autotester instances using the same GPU.  I've monitored this and there can be as many as 8 MPI ranks communicating with GPU 0, but all of the others are always idle.

## Related Issues
#11361 

## Testing
Framework unit tests