### PR TITLE
Panzer: make epetra optional in stk adapters and mini-em

### DIFF
--- a/packages/panzer/adapters-stk/example/CurlLaplacianExample/CMakeLists.txt
+++ b/packages/panzer/adapters-stk/example/CurlLaplacianExample/CMakeLists.txt
@@ -10,19 +10,31 @@ TRIBITS_ADD_EXECUTABLE(
   SOURCES ${ASSEMBLY_EXAMPLE_SOURCES}
   )
 
-TRIBITS_ADD_ADVANCED_TEST(
-  CurlLaplacianExample
-  EXCLUDE_IF_NOT_TRUE ${${PARENT_PACKAGE_NAME}_ADD_EXPENSIVE_CUDA_TESTS}
-  TEST_0 EXEC CurlLaplacianExample
-    ARGS --use-epetra --output-filename="base-curl-test-"
-    PASS_REGULAR_EXPRESSION "ALL PASSED: Epetra"
-    NUM_MPI_PROCS 4
-  TEST_1 EXEC CurlLaplacianExample
-    ARGS --use-tpetra --output-filename="base-curl-test-"
-    PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
-    NUM_MPI_PROCS 4
-  COMM mpi
-  )
+IF(PANZER_HAVE_EPETRA)
+  TRIBITS_ADD_ADVANCED_TEST(
+    CurlLaplacianExample
+    EXCLUDE_IF_NOT_TRUE ${${PARENT_PACKAGE_NAME}_ADD_EXPENSIVE_CUDA_TESTS}
+    TEST_0 EXEC CurlLaplacianExample
+      ARGS --use-epetra --output-filename="base-curl-test-"
+      PASS_REGULAR_EXPRESSION "ALL PASSED: Epetra"
+      NUM_MPI_PROCS 4
+    TEST_1 EXEC CurlLaplacianExample
+      ARGS --use-tpetra --output-filename="base-curl-test-"
+      PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
+      NUM_MPI_PROCS 4
+    COMM mpi
+    )
+ELSE(PANZER_HAVE_EPETRA)
+  TRIBITS_ADD_ADVANCED_TEST(
+    CurlLaplacianExample
+    EXCLUDE_IF_NOT_TRUE ${${PARENT_PACKAGE_NAME}_ADD_EXPENSIVE_CUDA_TESTS}
+    TEST_0 EXEC CurlLaplacianExample
+      ARGS --use-tpetra --output-filename="base-curl-test-"
+      PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
+      NUM_MPI_PROCS 4
+    COMM mpi
+    )
+ENDIF(PANZER_HAVE_EPETRA)
 
 FOREACH( ORDER 1 2 3 4 )
   TRIBITS_ADD_ADVANCED_TEST(

--- a/packages/panzer/adapters-stk/example/MixedCurlLaplacianExample/CMakeLists.txt
+++ b/packages/panzer/adapters-stk/example/MixedCurlLaplacianExample/CMakeLists.txt
@@ -10,19 +10,31 @@ TRIBITS_ADD_EXECUTABLE(
   SOURCES ${ASSEMBLY_EXAMPLE_SOURCES}
   )
 
-TRIBITS_ADD_ADVANCED_TEST(
-  MixedCurlLaplacianExample
-  EXCLUDE_IF_NOT_TRUE ${${PARENT_PACKAGE_NAME}_ADD_EXPENSIVE_CUDA_TESTS}
-  TEST_0 EXEC MixedCurlLaplacianExample
-    ARGS --use-epetra --output-filename="base-curl-test-"
-    PASS_REGULAR_EXPRESSION "ALL PASSED: Epetra"
-    NUM_MPI_PROCS 4
-  TEST_1 EXEC MixedCurlLaplacianExample
-    ARGS --use-tpetra --output-filename="base-curl-test-"
-    PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
-    NUM_MPI_PROCS 4
-  COMM mpi
-  )
+IF(PANZER_HAVE_EPETRA)
+  TRIBITS_ADD_ADVANCED_TEST(
+    MixedCurlLaplacianExample
+    EXCLUDE_IF_NOT_TRUE ${${PARENT_PACKAGE_NAME}_ADD_EXPENSIVE_CUDA_TESTS}
+    TEST_0 EXEC MixedCurlLaplacianExample
+      ARGS --use-epetra --output-filename="base-curl-test-"
+      PASS_REGULAR_EXPRESSION "ALL PASSED: Epetra"
+      NUM_MPI_PROCS 4
+    TEST_1 EXEC MixedCurlLaplacianExample
+      ARGS --use-tpetra --output-filename="base-curl-test-"
+      PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
+      NUM_MPI_PROCS 4
+    COMM mpi
+    )
+ELSE(PANZER_HAVE_EPETRA)
+  TRIBITS_ADD_ADVANCED_TEST(
+    MixedCurlLaplacianExample
+    EXCLUDE_IF_NOT_TRUE ${${PARENT_PACKAGE_NAME}_ADD_EXPENSIVE_CUDA_TESTS}
+    TEST_0 EXEC MixedCurlLaplacianExample
+      ARGS --use-tpetra --output-filename="base-curl-test-"
+      PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
+      NUM_MPI_PROCS 4
+    COMM mpi
+    )
+ENDIF(PANZER_HAVE_EPETRA)
 
 FOREACH( ORDER 1 2 )
   TRIBITS_ADD_ADVANCED_TEST(

--- a/packages/panzer/adapters-stk/example/MixedPoissonExample/CMakeLists.txt
+++ b/packages/panzer/adapters-stk/example/MixedPoissonExample/CMakeLists.txt
@@ -10,19 +10,31 @@ TRIBITS_ADD_EXECUTABLE(
   SOURCES ${ASSEMBLY_EXAMPLE_SOURCES}
   )
 
-TRIBITS_ADD_ADVANCED_TEST(
-  MixedPoissonExample
-  EXCLUDE_IF_NOT_TRUE ${PARENT_PACKAGE_NAME}_ADD_EXPENSIVE_CUDA_TESTS
-  TEST_0 EXEC MixedPoissonExample
-    ARGS --use-epetra --x-elements=5 --y-elements=5 --z-elements=5 --output-filename="base_mixed_poisson_epetra_"
-    PASS_REGULAR_EXPRESSION "ALL PASSED: Epetra"
-    NUM_MPI_PROCS 4
-  TEST_1 EXEC MixedPoissonExample
-    ARGS --use-tpetra --x-elements=5 --y-elements=5 --z-elements=5 --output-filename="base_mixed_poisson_tpetra_"
-    PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
-    NUM_MPI_PROCS 4
-  COMM mpi
+IF (PANZER_HAVE_EPETRA)
+  TRIBITS_ADD_ADVANCED_TEST(
+    MixedPoissonExample
+    EXCLUDE_IF_NOT_TRUE ${PARENT_PACKAGE_NAME}_ADD_EXPENSIVE_CUDA_TESTS
+    TEST_0 EXEC MixedPoissonExample
+      ARGS --use-epetra --x-elements=5 --y-elements=5 --z-elements=5 --output-filename="base_mixed_poisson_epetra_"
+      PASS_REGULAR_EXPRESSION "ALL PASSED: Epetra"
+      NUM_MPI_PROCS 4
+    TEST_1 EXEC MixedPoissonExample
+      ARGS --use-tpetra --x-elements=5 --y-elements=5 --z-elements=5 --output-filename="base_mixed_poisson_tpetra_"
+      PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
+      NUM_MPI_PROCS 4
+    COMM mpi
   )
+ELSE (PANZER_HAVE_EPETRA)
+  TRIBITS_ADD_ADVANCED_TEST(
+    MixedPoissonExample
+    EXCLUDE_IF_NOT_TRUE ${PARENT_PACKAGE_NAME}_ADD_EXPENSIVE_CUDA_TESTS
+    TEST_0 EXEC MixedPoissonExample
+      ARGS --use-tpetra --x-elements=5 --y-elements=5 --z-elements=5 --output-filename="base_mixed_poisson_tpetra_"
+      PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
+      NUM_MPI_PROCS 4
+    COMM mpi
+  )
+ENDIF (PANZER_HAVE_EPETRA)
 
 ## basis order 1-3
 FOREACH( ORDER 1 2 3)

--- a/packages/panzer/adapters-stk/src/Panzer_STK_ParameterListCallbackBlocked.cpp
+++ b/packages/panzer/adapters-stk/src/Panzer_STK_ParameterListCallbackBlocked.cpp
@@ -104,9 +104,11 @@ bool ParameterListCallbackBlocked::handlesRequest(const Teko::RequestMesg & rm)
      if(pl->isType<std::string>("Coordinates")){
        field = pl->get<std::string>("Coordinates");
      }
+#ifdef PANZER_HAVE_EPETRA
      if(pl->isType<std::string>("Coordinates-Epetra")){
        field = pl->get<std::string>("Coordinates-Epetra");
      }
+#endif
 
      return isHandled;
    }
@@ -141,10 +143,13 @@ void ParameterListCallbackBlocked::preRequest(const Teko::RequestMesg & rm)
     block = blocked_ugi_->getFieldBlock(blocked_ugi_->getFieldNum(field));
 
   // Empty...  Nothing to do.
+#ifdef PANZER_HAVE_EPETRA
   if (rm.getParameterList()->isType<std::string>("Coordinates-Epetra")) {
     buildArrayToVectorEpetra(block, field, useAux);
     buildCoordinatesEpetra(field, useAux);
-  } else {
+  } else
+#endif
+  {
     buildArrayToVectorTpetra(block, field, useAux);
     buildCoordinatesTpetra(field, useAux);
   }
@@ -166,9 +171,11 @@ void ParameterListCallbackBlocked::setFieldByKey(const std::string & key,const s
       pl.set<double*>(key,z);
    } else if(key == "Coordinates") {
      pl.set<Teuchos::RCP<Tpetra::MultiVector<double,int,panzer::GlobalOrdinal,panzer::TpetraNodeType> > >(key,coordsVecTp_);
+#ifdef PANZER_HAVE_EPETRA
    } else if(key == "Coordinates-Epetra") {
       pl.set<Teuchos::RCP<Epetra_MultiVector> >("Coordinates",coordsVecEp_);
       // pl.remove("Coordinates-Epetra");
+#endif
    }
    else
       TEUCHOS_TEST_FOR_EXCEPTION(true,std::runtime_error,
@@ -187,6 +194,7 @@ void ParameterListCallbackBlocked::buildArrayToVectorTpetra(int block,const std:
    }
 }
 
+#ifdef PANZER_HAVE_EPETRA
 void ParameterListCallbackBlocked::buildArrayToVectorEpetra(int block,const std::string & field, const bool useAux)
 {
    if(arrayToVectorEpetra_[field]==Teuchos::null) {
@@ -198,6 +206,7 @@ void ParameterListCallbackBlocked::buildArrayToVectorEpetra(int block,const std:
       arrayToVectorEpetra_[field] = Teuchos::rcp(new panzer::ArrayToFieldVectorEpetra(ugi));
    }
 }
+#endif
 
 void ParameterListCallbackBlocked::buildCoordinatesTpetra(const std::string & field, const bool useAux)
 {
@@ -256,6 +265,7 @@ void ParameterListCallbackBlocked::buildCoordinatesTpetra(const std::string & fi
    }
 }
 
+#ifdef PANZER_HAVE_EPETRA
 void ParameterListCallbackBlocked::buildCoordinatesEpetra(const std::string & field, const bool useAux)
 {
    std::map<std::string,Kokkos::DynRankView<double,PHX::Device> > data;
@@ -293,6 +303,7 @@ void ParameterListCallbackBlocked::buildCoordinatesEpetra(const std::string & fi
 
    coordsVecEp_ = arrayToVectorEpetra_[field]->template getDataVector<double>(field,data);
 }
+#endif
 
 std::string ParameterListCallbackBlocked::
 getHandledField(const Teuchos::ParameterList & pl) const
@@ -302,11 +313,16 @@ getHandledField(const Teuchos::ParameterList & pl) const
     return pl.get<std::string>("x-coordinates");
   else if(pl.isType<std::string>("Coordinates"))
     return pl.get<std::string>("Coordinates");
+#ifdef PANZER_HAVE_EPETRA
   else if(pl.isType<std::string>("Coordinates-Epetra"))
     return pl.get<std::string>("Coordinates-Epetra");
+#endif
   else
+#ifdef PANZER_HAVE_EPETRA
     TEUCHOS_TEST_FOR_EXCEPTION(true,std::logic_error,"Neither x-coordinates nor Coordinates or Coordinates-Epetra field provided.");
-
+#else
+    TEUCHOS_TEST_FOR_EXCEPTION(true,std::logic_error,"Neither x-coordinates or Coordinates field provided.");
+#endif
 }
 
 const std::vector<double> & ParameterListCallbackBlocked::

--- a/packages/panzer/adapters-stk/src/Panzer_STK_ParameterListCallbackBlocked.hpp
+++ b/packages/panzer/adapters-stk/src/Panzer_STK_ParameterListCallbackBlocked.hpp
@@ -53,7 +53,9 @@
 
 #include "Panzer_STKConnManager.hpp"
 #include "Panzer_GlobalIndexer_Utilities.hpp"
+#ifdef PANZER_HAVE_EPETRA
 #include "Panzer_GlobalIndexer_EpetraUtilities.hpp"
+#endif
 #include "Panzer_BlockedDOFManager.hpp"
 
 #include <vector>
@@ -102,9 +104,12 @@ private:
   }
 
   void buildArrayToVectorTpetra(int block,const std::string & field, const bool useAux = false);
-  void buildArrayToVectorEpetra(int block,const std::string & field, const bool useAux = false);
   void buildCoordinatesTpetra(const std::string & field, const bool useAux = false);
+
+#ifdef PANZER_HAVE_EPETRA
+  void buildArrayToVectorEpetra(int block,const std::string & field, const bool useAux = false);
   void buildCoordinatesEpetra(const std::string & field, const bool useAux = false);
+#endif
 
   // this method assumes handlesRequest(rm)==true
   std::string getHandledField(const Teuchos::ParameterList & pl) const;
@@ -133,10 +138,14 @@ private:
   std::map<std::string,std::vector<double> > zcoords_;
 
   mutable std::map<std::string,Teuchos::RCP<const panzer::ArrayToFieldVector> > arrayToVectorTpetra_;
+#ifdef PANZER_HAVE_EPETRA
   mutable std::map<std::string,Teuchos::RCP<const panzer::ArrayToFieldVectorEpetra> > arrayToVectorEpetra_;
+#endif
 
   Teuchos::RCP<Tpetra::MultiVector<double,int,panzer::GlobalOrdinal,panzer::TpetraNodeType> > coordsVecTp_;
+#ifdef PANZER_HAVE_EPETRA
   Teuchos::RCP<Epetra_MultiVector> coordsVecEp_;
+#endif
 
   bool returnTpetraObjects_;
 };

--- a/packages/panzer/mini-em/example/BlockPrec/main.cpp
+++ b/packages/panzer/mini-em/example/BlockPrec/main.cpp
@@ -23,8 +23,10 @@
 #include "Panzer_String_Utilities.hpp"
 #include "Panzer_TpetraLinearObjContainer.hpp"
 #include "Panzer_BlockedTpetraLinearObjFactory.hpp"
+#ifdef PANZER_HAVE_EPETRA
 #include "Panzer_EpetraLinearObjContainer.hpp"
 #include "Panzer_BlockedEpetraLinearObjFactory.hpp"
+#endif
 #include "Panzer_ElementBlockIdToPhysicsIdMap.hpp"
 #include "Panzer_DOFManagerFactory.hpp"
 #include "Panzer_BlockedDOFManagerFactory.hpp"
@@ -1055,10 +1057,12 @@ int main(int argc,char * argv[]){
       typedef typename panzer::BlockedTpetraLinearObjFactory<panzer::Traits,double,int,panzer::GlobalOrdinal> blockedLinObjFactory;
       retVal = main_<double,int,panzer::GlobalOrdinal,blockedLinObjFactory,true>(clp, argc, argv);
 //    }
+#ifdef PANZER_HAVE_EPETRA
   } else if (linAlgebra == linAlgEpetra) {
     // TEUCHOS_ASSERT(!useComplex);
     typedef typename panzer::BlockedEpetraLinearObjFactory<panzer::Traits,int> blockedLinObjFactory;
     retVal = main_<double,int,int,blockedLinObjFactory,false>(clp, argc, argv);
+#endif
   } else
     TEUCHOS_ASSERT(false);
 

--- a/packages/panzer/mini-em/src/eqn_sets/MiniEM_AuxiliaryEquationSet_MassMatrix_impl.hpp
+++ b/packages/panzer/mini-em/src/eqn_sets/MiniEM_AuxiliaryEquationSet_MassMatrix_impl.hpp
@@ -21,7 +21,9 @@
 #include "Panzer_Constant.hpp"
 #include "Panzer_BlockedDOFManager.hpp"
 #include "Panzer_BlockedTpetraLinearObjFactory.hpp"
+#ifdef PANZER_HAVE_EPETRA
 #include "Panzer_BlockedEpetraLinearObjFactory.hpp"
+#endif
 #include "Panzer_ReorderADValues_Evaluator.hpp"
 #include "Panzer_LOCPair_GlobalEvaluationData.hpp"
 
@@ -165,14 +167,18 @@ buildAndRegisterScatterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
    typedef panzer::Traits::Jacobian EvalT;
 
    typedef double Scalar;
+#ifdef PANZER_HAVE_EPETRA
    typedef int LocalOrdinalEpetra;
+#endif
    typedef int LocalOrdinalTpetra;
    typedef panzer::GlobalOrdinal GlobalOrdinalTpetra;
 
    typedef typename panzer::BlockedTpetraLinearObjFactory<panzer::Traits,Scalar,LocalOrdinalTpetra,GlobalOrdinalTpetra> blockedTpetraLinObjFactory;
    typedef typename panzer::TpetraLinearObjFactory<panzer::Traits,Scalar,LocalOrdinalTpetra,GlobalOrdinalTpetra> tpetraLinObjFactory;
+#ifdef PANZER_HAVE_EPETRA
    typedef typename panzer::BlockedEpetraLinearObjFactory<panzer::Traits,LocalOrdinalEpetra> blockedEpetraLinObjFactory;
    typedef typename panzer::BlockedEpetraLinearObjFactory<panzer::Traits,LocalOrdinalEpetra> epetraLinObjFactory;
+#endif
 
    std::string fieldStr = (*this->m_dof_names)[0];
    const std::string residualField = "AUX_MASS_RESIDUAL_"+opLabel+dof_name;
@@ -186,8 +192,10 @@ buildAndRegisterScatterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
    // must be able to cast to a block linear object factory
    Teuchos::RCP<const blockedTpetraLinObjFactory> tblof
       = Teuchos::rcp_dynamic_cast<const blockedTpetraLinObjFactory>(Teuchos::rcpFromRef(lof));
+#ifdef PANZER_HAVE_EPETRA
    Teuchos::RCP<const blockedEpetraLinObjFactory> eblof
       = Teuchos::rcp_dynamic_cast<const blockedEpetraLinObjFactory>(Teuchos::rcpFromRef(lof));
+#endif
 
    if(tblof != Teuchos::null) {
      Teuchos::RCP<const panzer::BlockedDOFManager> blockedDOFMngr = tblof->getGlobalIndexer();
@@ -220,7 +228,7 @@ buildAndRegisterScatterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
 
         fm.registerEvaluator<EvalT>(op);
      }
-
+#ifdef PANZER_HAVE_EPETRA
    } else if(eblof != Teuchos::null) {
      Teuchos::RCP<const panzer::BlockedDOFManager> blockedDOFMngr = eblof->getGlobalIndexer();
      TEUCHOS_ASSERT(blockedDOFMngr!=Teuchos::null);
@@ -252,6 +260,7 @@ buildAndRegisterScatterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
 
         fm.registerEvaluator<EvalT>(op);
      }
+#endif
    } else
      TEUCHOS_ASSERT(false);
 

--- a/packages/panzer/mini-em/src/eqn_sets/MiniEM_AuxiliaryEquationSet_ProjectedSchurComplement_impl.hpp
+++ b/packages/panzer/mini-em/src/eqn_sets/MiniEM_AuxiliaryEquationSet_ProjectedSchurComplement_impl.hpp
@@ -22,7 +22,9 @@
 #include "Panzer_Constant.hpp"
 #include "Panzer_BlockedDOFManager.hpp"
 #include "Panzer_BlockedTpetraLinearObjFactory.hpp"
+#ifdef PANZER_HAVE_EPETRA
 #include "Panzer_BlockedEpetraLinearObjFactory.hpp"
+#endif
 #include "Panzer_ReorderADValues_Evaluator.hpp"
 #include "Panzer_LOCPair_GlobalEvaluationData.hpp"
 
@@ -167,14 +169,18 @@ buildAndRegisterScatterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
    typedef panzer::Traits::Jacobian EvalT;
 
    typedef double Scalar;
+#ifdef PANZER_HAVE_EPETRA
    typedef int LocalOrdinalEpetra;
+#endif
    typedef int LocalOrdinalTpetra;
    typedef panzer::GlobalOrdinal GlobalOrdinalTpetra;
 
    typedef typename panzer::BlockedTpetraLinearObjFactory<panzer::Traits,Scalar,LocalOrdinalTpetra,GlobalOrdinalTpetra> blockedTpetraLinObjFactory;
    typedef typename panzer::TpetraLinearObjFactory<panzer::Traits,Scalar,LocalOrdinalTpetra,GlobalOrdinalTpetra> tpetraLinObjFactory;
+#ifdef PANZER_HAVE_EPETRA
    typedef typename panzer::BlockedEpetraLinearObjFactory<panzer::Traits,LocalOrdinalEpetra> blockedEpetraLinObjFactory;
    typedef typename panzer::BlockedEpetraLinearObjFactory<panzer::Traits,LocalOrdinalEpetra> epetraLinObjFactory;
+#endif
 
    std::string fieldStr = (*this->m_dof_names)[0];
    const std::string residualField = "AUX_PROJECTEDSCHURCOMPLEMENT_RESIDUAL_"+dof_name;
@@ -188,8 +194,10 @@ buildAndRegisterScatterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
    // must be able to cast to a block linear object factory
    Teuchos::RCP<const blockedTpetraLinObjFactory> tblof
       = Teuchos::rcp_dynamic_cast<const blockedTpetraLinObjFactory>(Teuchos::rcpFromRef(lof));
+#ifdef PANZER_HAVE_EPETRA
    Teuchos::RCP<const blockedEpetraLinObjFactory> eblof
       = Teuchos::rcp_dynamic_cast<const blockedEpetraLinObjFactory>(Teuchos::rcpFromRef(lof));
+#endif
 
    if(tblof != Teuchos::null) {
      Teuchos::RCP<const panzer::BlockedDOFManager> blockedDOFMngr = tblof->getGlobalIndexer();
@@ -223,6 +231,7 @@ buildAndRegisterScatterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
         fm.registerEvaluator<EvalT>(op);
      }
 
+#ifdef PANZER_HAVE_EPETRA
    } else if(eblof != Teuchos::null) {
      Teuchos::RCP<const panzer::BlockedDOFManager> blockedDOFMngr = eblof->getGlobalIndexer();
      TEUCHOS_ASSERT(blockedDOFMngr!=Teuchos::null);
@@ -254,6 +263,7 @@ buildAndRegisterScatterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
 
         fm.registerEvaluator<EvalT>(op);
      }
+#endif
    } else
      TEUCHOS_ASSERT(false);
 

--- a/packages/panzer/mini-em/src/eqn_sets/MiniEM_AuxiliaryEquationSet_SchurComplement_impl.hpp
+++ b/packages/panzer/mini-em/src/eqn_sets/MiniEM_AuxiliaryEquationSet_SchurComplement_impl.hpp
@@ -14,6 +14,7 @@
 #include "Panzer_BasisIRLayout.hpp"
 
 // include evaluators here
+#include "PanzerAdaptersSTK_config.hpp"
 #include "Panzer_Integrator_BasisTimesVector.hpp"
 #include "Panzer_Integrator_BasisTimesTensorTimesVector.hpp"
 #include "Panzer_Integrator_CurlBasisDotVector.hpp"
@@ -22,7 +23,9 @@
 #include "Panzer_Constant.hpp"
 #include "Panzer_BlockedDOFManager.hpp"
 #include "Panzer_BlockedTpetraLinearObjFactory.hpp"
+#ifdef PANZER_HAVE_EPETRA
 #include "Panzer_BlockedEpetraLinearObjFactory.hpp"
+#endif
 #include "Panzer_ReorderADValues_Evaluator.hpp"
 #include "Panzer_LOCPair_GlobalEvaluationData.hpp"
 
@@ -184,14 +187,18 @@ buildAndRegisterScatterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
    typedef panzer::Traits::Jacobian EvalT;
 
    typedef double Scalar;
+#ifdef PANZER_HAVE_EPETRA
    typedef int LocalOrdinalEpetra;
+#endif
    typedef int LocalOrdinalTpetra;
    typedef panzer::GlobalOrdinal GlobalOrdinalTpetra;
 
    typedef typename panzer::BlockedTpetraLinearObjFactory<panzer::Traits,Scalar,LocalOrdinalTpetra,GlobalOrdinalTpetra> blockedTpetraLinObjFactory;
    typedef typename panzer::TpetraLinearObjFactory<panzer::Traits,Scalar,LocalOrdinalTpetra,GlobalOrdinalTpetra> tpetraLinObjFactory;
+#ifdef PANZER_HAVE_EPETRA
    typedef typename panzer::BlockedEpetraLinearObjFactory<panzer::Traits,LocalOrdinalEpetra> blockedEpetraLinObjFactory;
    typedef typename panzer::BlockedEpetraLinearObjFactory<panzer::Traits,LocalOrdinalEpetra> epetraLinObjFactory;
+#endif
 
    std::string fieldStr = (*this->m_dof_names)[0];
    const std::string residualField = "AUX_SCHURCOMPLEMENT_RESIDUAL_"+dof_name;
@@ -205,8 +212,10 @@ buildAndRegisterScatterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
    // must be able to cast to a block linear object factory
    Teuchos::RCP<const blockedTpetraLinObjFactory> tblof
       = Teuchos::rcp_dynamic_cast<const blockedTpetraLinObjFactory>(Teuchos::rcpFromRef(lof));
+#ifdef PANZER_HAVE_EPETRA
    Teuchos::RCP<const blockedEpetraLinObjFactory> eblof
       = Teuchos::rcp_dynamic_cast<const blockedEpetraLinObjFactory>(Teuchos::rcpFromRef(lof));
+#endif
 
    if(tblof != Teuchos::null) {
      Teuchos::RCP<const panzer::BlockedDOFManager> blockedDOFMngr = tblof->getGlobalIndexer();
@@ -239,7 +248,7 @@ buildAndRegisterScatterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
 
         fm.registerEvaluator<EvalT>(op);
      }
-
+#ifdef PANZER_HAVE_EPETRA
    } else if(eblof != Teuchos::null) {
      Teuchos::RCP<const panzer::BlockedDOFManager> blockedDOFMngr = eblof->getGlobalIndexer();
      TEUCHOS_ASSERT(blockedDOFMngr!=Teuchos::null);
@@ -271,6 +280,7 @@ buildAndRegisterScatterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
 
         fm.registerEvaluator<EvalT>(op);
      }
+#endif
    } else
      TEUCHOS_ASSERT(false);
 

--- a/packages/panzer/mini-em/src/eqn_sets/MiniEM_AuxiliaryEquationSet_WeakGradient_impl.hpp
+++ b/packages/panzer/mini-em/src/eqn_sets/MiniEM_AuxiliaryEquationSet_WeakGradient_impl.hpp
@@ -18,7 +18,9 @@
 #include "Panzer_Sum.hpp"
 #include "Panzer_Constant.hpp"
 #include "Panzer_BlockedDOFManager.hpp"
+#ifdef PANZER_HAVE_EPETRA
 #include "Panzer_BlockedEpetraLinearObjFactory.hpp"
+#endif
 #include "Panzer_BlockedTpetraLinearObjFactory.hpp"
 #include "Panzer_TpetraLinearObjFactory.hpp"
 #include "Panzer_ReorderADValues_Evaluator.hpp"
@@ -125,14 +127,18 @@ buildAndRegisterScatterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
    typedef panzer::Traits::Jacobian EvalT;
 
    typedef double Scalar;
+#ifdef PANZER_HAVE_EPETRA
    typedef int LocalOrdinalEpetra;
+#endif
    typedef int LocalOrdinalTpetra;
    typedef panzer::GlobalOrdinal GlobalOrdinalTpetra;
 
    typedef typename panzer::BlockedTpetraLinearObjFactory<panzer::Traits,Scalar,LocalOrdinalTpetra,GlobalOrdinalTpetra> blockedTpetraLinObjFactory;
    typedef typename panzer::TpetraLinearObjFactory<panzer::Traits,Scalar,LocalOrdinalTpetra,GlobalOrdinalTpetra> tpetraLinObjFactory;
+#ifdef PANZER_HAVE_EPETRA
    typedef typename panzer::BlockedEpetraLinearObjFactory<panzer::Traits,LocalOrdinalEpetra> blockedEpetraLinObjFactory;
    typedef typename panzer::BlockedEpetraLinearObjFactory<panzer::Traits,LocalOrdinalEpetra> epetraLinObjFactory;
+#endif
 
    std::string fieldStr = (*this->m_dof_names)[0];
    int pFieldNum;
@@ -149,8 +155,10 @@ buildAndRegisterScatterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
    // must be able to cast to a block linear object factory
    Teuchos::RCP<const blockedTpetraLinObjFactory> tblof
       = Teuchos::rcp_dynamic_cast<const blockedTpetraLinObjFactory>(Teuchos::rcpFromRef(lof));
+#ifdef PANZER_HAVE_EPETRA
    Teuchos::RCP<const blockedEpetraLinObjFactory> eblof
       = Teuchos::rcp_dynamic_cast<const blockedEpetraLinObjFactory>(Teuchos::rcpFromRef(lof));
+#endif
 
    if(tblof != Teuchos::null) {
 
@@ -191,7 +199,7 @@ buildAndRegisterScatterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
 
        fm.registerEvaluator<EvalT>(op);
      }
-
+#ifdef PANZER_HAVE_EPETRA
    } else if(eblof != Teuchos::null) {
      Teuchos::RCP<const panzer::BlockedDOFManager> blockedDOFMngr;
      Teuchos::RCP<panzer::GlobalIndexer> rowUgi;
@@ -230,6 +238,7 @@ buildAndRegisterScatterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
 
        fm.registerEvaluator<EvalT>(op);
      }
+#endif
    } else
      TEUCHOS_ASSERT(false);
 

--- a/packages/panzer/mini-em/src/solvers/MiniEM_DiscreteCurl.hpp
+++ b/packages/panzer/mini-em/src/solvers/MiniEM_DiscreteCurl.hpp
@@ -6,7 +6,9 @@
 #include "Panzer_IntrepidBasisFactory.hpp"
 #include "Intrepid2_OrientationTools.hpp"
 #include "Intrepid2_LagrangianInterpolation.hpp"
+#ifdef PANZER_HAVE_EPETRA
 #include "Thyra_EpetraThyraWrappers.hpp"
+#endif
 
 class CurlRequestCallback : public Teko::RequestCallback<Teko::LinearOp> {
 private:
@@ -57,7 +59,9 @@ void addDiscreteCurlToRequestHandler(
   typedef panzer::GlobalOrdinal GlobalOrdinal;
 
   typedef typename panzer::BlockedTpetraLinearObjFactory<panzer::Traits,Scalar,LocalOrdinal,GlobalOrdinal> tpetraBlockedLinObjFactory;
+#ifdef PANZER_HAVE_EPETRA
   typedef typename panzer::BlockedEpetraLinearObjFactory<panzer::Traits,LocalOrdinal> epetraBlockedLinObjFactory;
+#endif
   typedef panzer::GlobalIndexer UGI;
   typedef PHX::Device DeviceSpace;
   typedef Kokkos::HostSpace HostSpace;
@@ -70,7 +74,9 @@ void addDiscreteCurlToRequestHandler(
 
   // must be able to cast to a block linear object factory
   RCP<const tpetraBlockedLinObjFactory > tblof  = rcp_dynamic_cast<const tpetraBlockedLinObjFactory >(linObjFactory);
+#ifdef PANZER_HAVE_EPETRA
   RCP<const epetraBlockedLinObjFactory > eblof  = rcp_dynamic_cast<const epetraBlockedLinObjFactory >(linObjFactory);
+#endif
   if (tblof != Teuchos::null) {
     typedef typename panzer::BlockedTpetraLinearObjContainer<Scalar,LocalOrdinal,GlobalOrdinal> linObjContainer;
     typedef Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,panzer::TpetraNodeType> matrix;
@@ -288,6 +294,7 @@ void addDiscreteCurlToRequestHandler(
     // add curl callback to request handler
     reqHandler->addRequestCallback(Teuchos::rcp(new CurlRequestCallback(thyra_curl)));
 
+#ifdef PANZER_HAVE_EPETRA
   }  else if (eblof != Teuchos::null) {
 
     typedef typename panzer::BlockedEpetraLinearObjContainer linObjContainer;
@@ -506,7 +513,7 @@ void addDiscreteCurlToRequestHandler(
 
     // add curl callback to request handler
     reqHandler->addRequestCallback(Teuchos::rcp(new CurlRequestCallback(thyra_curl)));
-
+#endif
   } else
     TEUCHOS_ASSERT(false);
 }

--- a/packages/panzer/mini-em/src/solvers/MiniEM_DiscreteGradient.hpp
+++ b/packages/panzer/mini-em/src/solvers/MiniEM_DiscreteGradient.hpp
@@ -4,7 +4,9 @@
 #include "Panzer_LOCPair_GlobalEvaluationData.hpp"
 #include "Panzer_IntrepidOrientation.hpp"
 #include "Thyra_TpetraLinearOp.hpp"
+#ifdef PANZER_HAVE_EPETRA
 #include "Thyra_EpetraThyraWrappers.hpp"
+#endif
 #include "Tpetra_Import.hpp"
 
 class GradientRequestCallback : public Teko::RequestCallback<Teko::LinearOp> {
@@ -51,12 +53,16 @@ void addDiscreteGradientToRequestHandler(
   using Teuchos::rcp_dynamic_cast;
 
   typedef double Scalar;
+#ifdef PANZER_HAVE_EPETRA
   typedef int LocalOrdinalEpetra;
+#endif
   typedef int LocalOrdinalTpetra;
   typedef panzer::GlobalOrdinal GlobalOrdinalTpetra;
 
   typedef typename panzer::BlockedTpetraLinearObjFactory<panzer::Traits,Scalar,LocalOrdinalTpetra,GlobalOrdinalTpetra> tpetraBlockedLinObjFactory;
+#ifdef PANZER_HAVE_EPETRA
   typedef typename panzer::BlockedEpetraLinearObjFactory<panzer::Traits,LocalOrdinalEpetra> epetraBlockedLinObjFactory;
+#endif
 
   typedef PHX::Device DeviceSpace;
 
@@ -66,7 +72,9 @@ void addDiscreteGradientToRequestHandler(
       
   // must be able to cast to a block linear object factory
   RCP<const tpetraBlockedLinObjFactory > tblof  = rcp_dynamic_cast<const tpetraBlockedLinObjFactory >(linObjFactory);
+#ifdef PANZER_HAVE_EPETRA
   RCP<const epetraBlockedLinObjFactory > eblof  = rcp_dynamic_cast<const epetraBlockedLinObjFactory >(linObjFactory);
+#endif
   if (tblof != Teuchos::null) {
     typedef LocalOrdinalTpetra LocalOrdinal;
     typedef GlobalOrdinalTpetra GlobalOrdinal;
@@ -161,6 +169,7 @@ void addDiscreteGradientToRequestHandler(
 
     // add gradient callback to request handler
     reqHandler->addRequestCallback(Teuchos::rcp(new GradientRequestCallback(thyra_gradient)));
+#ifdef PANZER_HAVE_EPETRA
   } else if (eblof != Teuchos::null) {
     typedef panzer::GlobalIndexer UGI;
     typedef typename panzer::BlockedEpetraLinearObjContainer linObjContainer;
@@ -263,6 +272,7 @@ void addDiscreteGradientToRequestHandler(
 
     // add gradient callback to request handler
     reqHandler->addRequestCallback(Teuchos::rcp(new GradientRequestCallback(thyra_gradient)));
+#endif
   } else
     TEUCHOS_ASSERT(false);
   

--- a/packages/panzer/mini-em/src/solvers/MiniEM_FullMaxwellPreconditionerFactory.cpp
+++ b/packages/panzer/mini-em/src/solvers/MiniEM_FullMaxwellPreconditionerFactory.cpp
@@ -17,7 +17,9 @@
 
 #include "Thyra_TpetraLinearOp.hpp"
 #include "Panzer_NodeType.hpp"
+#ifdef PANZER_HAVE_EPETRA
 #include "Thyra_EpetraThyraWrappers.hpp"
+#endif
 #include "Panzer_LOCPair_GlobalEvaluationData.hpp"
 #include "Panzer_LinearObjContainer.hpp"
 #include "Panzer_ThyraObjContainer.hpp"
@@ -125,8 +127,8 @@ Teko::LinearOp FullMaxwellPreconditionerFactory::buildPreconditionerOperator(Tek
    }
 
    // Check whether we are using Tpetra or Epetra
-   RCP<const Thyra::EpetraLinearOp> EOp = rcp_dynamic_cast<const Thyra::EpetraLinearOp>(Q_E);
-   bool useTpetra = (EOp == Teuchos::null);
+   RCP<const Thyra::TpetraLinearOp<Scalar,LocalOrdinal,GlobalOrdinal,Node> > checkTpetra = Teuchos::rcp_dynamic_cast<const Thyra::TpetraLinearOp<Scalar,LocalOrdinal,GlobalOrdinal,Node>>(Q_E);
+   bool useTpetra = nonnull(checkTpetra);
 
    /////////////////////////////////////////////////
    // Debug and matrix dumps                      //
@@ -227,6 +229,7 @@ Teko::LinearOp FullMaxwellPreconditionerFactory::buildPreconditionerOperator(Tek
 #endif
            RCP<Tpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > Coordinates = S_E_prec_pl.get<RCP<Tpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >("Coordinates");
            S_E_prec_pl.sublist("Preconditioner Types").sublist(S_E_prec_type_).set("Coordinates",Coordinates);
+#ifdef PANZER_HAVE_EPETRA
 #ifndef PANZER_HIDE_DEPRECATED_CODE
          } else if (!useTpetra && ((S_E_prec_type_ == "MueLuRefMaxwell") || (S_E_prec_type_ == "MueLuRefMaxwell-Tpetra"))) {
 #else
@@ -234,6 +237,7 @@ Teko::LinearOp FullMaxwellPreconditionerFactory::buildPreconditionerOperator(Tek
 #endif
            RCP<Epetra_MultiVector> Coordinates = S_E_prec_pl.get<RCP<Epetra_MultiVector> >("Coordinates");
            S_E_prec_pl.sublist("Preconditioner Types").sublist(S_E_prec_type_).set("Coordinates",Coordinates);
+
          } else if (S_E_prec_type_ == "ML") {
            double* x_coordinates = S_E_prec_pl.sublist("ML Settings").get<double*>("x-coordinates");
            S_E_prec_pl.sublist("ML Settings").sublist("refmaxwell: 11list").set("x-coordinates",x_coordinates);
@@ -244,6 +248,7 @@ Teko::LinearOp FullMaxwellPreconditionerFactory::buildPreconditionerOperator(Tek
            double* z_coordinates = S_E_prec_pl.sublist("ML Settings").get<double*>("z-coordinates");
            S_E_prec_pl.sublist("ML Settings").sublist("refmaxwell: 11list").set("z-coordinates",z_coordinates);
            S_E_prec_pl.sublist("ML Settings").sublist("refmaxwell: 22list").set("z-coordinates",z_coordinates);
+#endif // PANZER_HAVE_EPETRA
          } else
            TEUCHOS_ASSERT(false);
        }
@@ -265,11 +270,15 @@ Teko::LinearOp FullMaxwellPreconditionerFactory::buildPreconditionerOperator(Tek
        {
          Teko::InverseLibrary myInvLib = invLib;
          if (S_E_prec_type_ == "ML") {
+#ifdef PANZER_HAVE_EPETRA
            RCP<const Epetra_CrsMatrix> eInvDiagQ_rho = get_Epetra_CrsMatrix(*invDiagQ_rho,get_Epetra_CrsMatrix(*Q_B)->RowMap().Comm());
            S_E_prec_pl.sublist("ML Settings").set("M0inv",eInvDiagQ_rho);
 
            S_E_prec_pl.set("Type",S_E_prec_type_);
            myInvLib.addInverse("S_E Preconditioner",S_E_prec_pl);
+#else
+           TEUCHOS_TEST_FOR_EXCEPTION(true,std::runtime_error,"ERROR: MiniEM_FullMaxwellPreconditionerFactory: ML is not supported in this build! Requires Epetra support be enabled!");
+#endif
          } else {
            S_E_prec_pl.sublist("Preconditioner Types").sublist(S_E_prec_type_).set("M0inv",invDiagQ_rho);
 
@@ -446,12 +455,16 @@ void FullMaxwellPreconditionerFactory::initializeFromParameterList(const Teuchos
      Teko::LinearOp Q_E_aux_weighted = getRequestHandler()->request<Teko::LinearOp>(Teko::RequestMesg("Mass Matrix weighted AUXILIARY_EDGE"));
      Teko::LinearOp T = getRequestHandler()->request<Teko::LinearOp>(Teko::RequestMesg("Discrete Gradient"));
      if (S_E_prec_type_ == "ML") {
+#ifdef PANZER_HAVE_EPETRA
        RCP<const Epetra_CrsMatrix> eT = get_Epetra_CrsMatrix(*T);
        RCP<const Epetra_CrsMatrix> eQ_E_aux = get_Epetra_CrsMatrix(*Q_E_aux);
        RCP<const Epetra_CrsMatrix> eQ_E_aux_weighted = get_Epetra_CrsMatrix(*Q_E_aux_weighted);
        S_E_prec_pl.sublist("ML Settings").set("D0",eT);
        S_E_prec_pl.sublist("ML Settings").set("M1",eQ_E_aux);
        S_E_prec_pl.sublist("ML Settings").set("Ms",eQ_E_aux_weighted);
+#else
+       TEUCHOS_TEST_FOR_EXCEPTION(true,std::runtime_error,"ERROR: MiniEM_FullMaxwellPreconditionerFactory: ML is not supported in this build! Requires Epetra support be enabled!");
+#endif
      } else {
        S_E_prec_pl.sublist("Preconditioner Types").sublist(S_E_prec_type_).set("D0",T);
        S_E_prec_pl.sublist("Preconditioner Types").sublist(S_E_prec_type_).set("M1",Q_E_aux);

--- a/packages/panzer/mini-em/src/solvers/MiniEM_FullMaxwellPreconditionerFactory_Augmentation.cpp
+++ b/packages/panzer/mini-em/src/solvers/MiniEM_FullMaxwellPreconditionerFactory_Augmentation.cpp
@@ -17,7 +17,6 @@
 
 #include "Thyra_TpetraLinearOp.hpp"
 #include "Panzer_NodeType.hpp"
-#include "Thyra_EpetraThyraWrappers.hpp"
 #include "Panzer_LOCPair_GlobalEvaluationData.hpp"
 #include "Panzer_LinearObjContainer.hpp"
 #include "Panzer_ThyraObjContainer.hpp"

--- a/packages/panzer/mini-em/src/solvers/MiniEM_Interpolation.hpp
+++ b/packages/panzer/mini-em/src/solvers/MiniEM_Interpolation.hpp
@@ -7,7 +7,9 @@
 #include "Panzer_IntrepidBasisFactory.hpp"
 #include "Intrepid2_OrientationTools.hpp"
 #include "Intrepid2_LagrangianInterpolation.hpp"
+#ifdef PANZER_HAVE_EPETRA
 #include "Thyra_EpetraThyraWrappers.hpp"
+#endif
 #include "MiniEM_Utils.hpp"
 #include "MiniEM_MatrixFreeInterpolationOp.hpp"
 #include "MiniEM_MatrixFreeInterpolationOp.cpp"
@@ -31,7 +33,9 @@ Teko::LinearOp buildInterpolation(const Teuchos::RCP<const panzer::LinearObjFact
   using OT  = Teuchos::OrdinalTraits<GlobalOrdinal>;
 
   typedef typename panzer::BlockedTpetraLinearObjFactory<panzer::Traits,Scalar,LocalOrdinal,GlobalOrdinal> tpetraBlockedLinObjFactory;
+#ifdef PANZER_HAVE_EPETRA
   typedef typename panzer::BlockedEpetraLinearObjFactory<panzer::Traits,LocalOrdinal> epetraBlockedLinObjFactory;
+#endif
   typedef panzer::GlobalIndexer UGI;
   typedef PHX::Device DeviceSpace;
   typedef Kokkos::HostSpace HostSpace;
@@ -42,26 +46,33 @@ Teko::LinearOp buildInterpolation(const Teuchos::RCP<const panzer::LinearObjFact
 
   // must be able to cast to a block linear object factory
   RCP<const tpetraBlockedLinObjFactory > tblof = rcp_dynamic_cast<const tpetraBlockedLinObjFactory >(linObjFactory);
+#ifdef PANZER_HAVE_EPETRA
   RCP<const epetraBlockedLinObjFactory > eblof = rcp_dynamic_cast<const epetraBlockedLinObjFactory >(linObjFactory);
+#endif
 
   typedef Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal> tp_matrix;
   typedef Tpetra::Map<LocalOrdinal,GlobalOrdinal> tp_map;
+#ifdef PANZER_HAVE_EPETRA
   typedef typename panzer::BlockedEpetraLinearObjContainer ep_linObjContainer;
   typedef Epetra_CrsMatrix ep_matrix;
   typedef Epetra_Map ep_map;
+#endif
 
   RCP<const panzer::BlockedDOFManager> blockedDOFMngr;
-  if (tblof != Teuchos::null)
+  if (tblof != Teuchos::null) {
     blockedDOFMngr = tblof->getGlobalIndexer();
-  else if (eblof != Teuchos::null) {
+#ifdef PANZER_HAVE_EPETRA
+  } else if (eblof != Teuchos::null) {
     TEUCHOS_ASSERT(false);
     // The Epetra code path works, expect for the fact that Epetra
     // does not implement the needed matrix entry insertion. We'd need
     // to handle the overwriting (instead of summing into) of already
     // existing entries by hand.
     blockedDOFMngr = eblof->getGlobalIndexer();
-  } else
+#endif
+  } else {
     TEUCHOS_ASSERT(false);
+  }
 
   // get global indexers for LO and HO dofs
   std::vector<RCP<UGI> > fieldDOFMngrs = blockedDOFMngr->getFieldDOFManagers();
@@ -90,8 +101,10 @@ Teko::LinearOp buildInterpolation(const Teuchos::RCP<const panzer::LinearObjFact
   // The operator maps from LO (domain) to HO (range)
   RCP<const tp_map> tp_rangemap, tp_domainmap, tp_rowmap, tp_colmap;
   RCP<tp_matrix> tp_interp_matrix;
+#ifdef PANZER_HAVE_EPETRA
   RCP<const ep_map> ep_rangemap, ep_domainmap, ep_rowmap, ep_colmap;
   RCP<ep_matrix> ep_interp_matrix;
+#endif
 
   RCP<Thyra::LinearOpBase<Scalar> > thyra_interp;
   if (tblof != Teuchos::null) {
@@ -144,6 +157,7 @@ Teko::LinearOp buildInterpolation(const Teuchos::RCP<const panzer::LinearObjFact
                                                                                                           Thyra::createVectorSpace<Scalar,LocalOrdinal,GlobalOrdinal>(tp_domainmap),
                                                                                                           tp_interp_matrix);
   }
+#ifdef PANZER_HAVE_EPETRA
   else if (eblof != Teuchos::null) {
     RCP<panzer::GlobalEvaluationData> dataObject
       = rcp(new panzer::LOCPair_GlobalEvaluationData(eblof,panzer::LinearObjContainer::Mat));
@@ -173,7 +187,7 @@ Teko::LinearOp buildInterpolation(const Teuchos::RCP<const panzer::LinearObjFact
                                                                                  Thyra::create_VectorSpace(ep_domainmap));
     thyra_interp = Teuchos::rcp_const_cast<Thyra::LinearOpBase<double> >(th_ep_interp);
   }
-
+#endif
 
   RCP<const panzer::ConnManager> conn = blockedDOFMngr->getConnManager();
 
@@ -310,10 +324,14 @@ Teko::LinearOp buildInterpolation(const Teuchos::RCP<const panzer::LinearObjFact
         for(size_t hoIter = 0; hoIter < hoLIDs_h.size(); ++hoIter) {
           LocalOrdinal ho_row = hoLIDs_h(hoIter);
           bool isOwned;
+#ifdef PANZER_HAVE_EPETRA
           if (tblof != Teuchos::null)
             isOwned = tp_rowmap->isNodeLocalElement(ho_row);
           else
             isOwned = ep_rowmap->MyLID(ho_row);
+#else
+          isOwned = tp_rowmap->isNodeLocalElement(ho_row);
+#endif
 
           if (isOwned) {
             // filter entries for zeros
@@ -327,11 +345,14 @@ Teko::LinearOp buildInterpolation(const Teuchos::RCP<const panzer::LinearObjFact
               }
             }
 
+#ifdef PANZER_HAVE_EPETRA
             if (tblof != Teuchos::null)
               tp_interp_matrix->insertLocalValues(ho_row, rowNNZ, values_h.data(), indices_h.data(), Tpetra::INSERT);
             else
               ep_interp_matrix->InsertMyValues(ho_row, rowNNZ, values_h.data(), indices_h.data());
-
+#else
+            tp_interp_matrix->insertLocalValues(ho_row, rowNNZ, values_h.data(), indices_h.data(), Tpetra::INSERT);
+#endif
           } //end if owned
         } //end HO LID loop
       } //end workset loop
@@ -394,8 +415,10 @@ Teko::LinearOp buildInterpolation(const Teuchos::RCP<const panzer::LinearObjFact
 #endif
 
   }
+#ifdef PANZER_HAVE_EPETRA
   else
     ep_interp_matrix->FillComplete(*ep_domainmap, *ep_rangemap);
+#endif
 
   return thyra_interp;
 }

--- a/packages/panzer/mini-em/src/solvers/MiniEM_Utils.cpp
+++ b/packages/panzer/mini-em/src/solvers/MiniEM_Utils.cpp
@@ -13,7 +13,10 @@ namespace mini_em {
     using Teuchos::rcp_dynamic_cast;
     using NT = panzer::TpetraNodeType;
     const RCP<const Thyra::TpetraLinearOp<double,int,panzer::GlobalOrdinal,NT> > tOp = rcp_dynamic_cast<const Thyra::TpetraLinearOp<double,int,panzer::GlobalOrdinal,NT> >(Teuchos::rcpFromRef(op));
+#ifdef PANZER_HAVE_EPETRA
     const RCP<const Thyra::EpetraLinearOp> eOp = rcp_dynamic_cast<const Thyra::EpetraLinearOp>(Teuchos::rcpFromRef(op));
+#endif
+
     if(tOp != Teuchos::null) {
       *Teko::getOutputStream() << "Dumping matrix \'" << s << "\'" << std::endl;
       const RCP<const Tpetra::CrsMatrix<double,int,panzer::GlobalOrdinal,NT> > crsOp = rcp_dynamic_cast<const Tpetra::CrsMatrix<double,int,panzer::GlobalOrdinal,NT> >(tOp->getConstTpetraOperator());
@@ -33,6 +36,7 @@ namespace mini_em {
         }
         *Teko::getOutputStream() << "Cannot dump operator \'" << s << "\'" << std::endl;
       }
+#ifdef PANZER_HAVE_EPETRA
     } else if (eOp != Teuchos::null) {
       *Teko::getOutputStream() << "Dumping matrix \'" << s << "\'" << std::endl;
       const RCP<const Epetra_CrsMatrix> crsOp = rcp_dynamic_cast<const Epetra_CrsMatrix>(eOp->epetra_op(),true);
@@ -41,6 +45,7 @@ namespace mini_em {
       EpetraExt::BlockMapToMatrixMarketFile(("domainmap_"+s).c_str(), crsOp->DomainMap());
       EpetraExt::BlockMapToMatrixMarketFile(("rangemap_"+s).c_str(), crsOp->RangeMap());
       EpetraExt::RowMatrixToMatrixMarketFile(s.c_str(), *crsOp);
+#endif
     } else
       TEUCHOS_ASSERT(false);
   }
@@ -53,15 +58,19 @@ namespace mini_em {
     using NT = Tpetra::Map<>::node_type;
     if (out!=Teuchos::null) {
       const RCP<const Thyra::TpetraLinearOp<double,int,panzer::GlobalOrdinal,NT> > tOp = rcp_dynamic_cast<const Thyra::TpetraLinearOp<double,int,panzer::GlobalOrdinal,NT> >(Teuchos::rcpFromRef(op));
+#ifdef PANZER_HAVE_EPETRA
       const RCP<const Thyra::EpetraLinearOp > eOp = rcp_dynamic_cast<const Thyra::EpetraLinearOp>(Teuchos::rcpFromRef(op));
+#endif
       if(tOp != Teuchos::null) {
         const RCP<const Tpetra::CrsMatrix<double,int,panzer::GlobalOrdinal,NT> > crsOp = rcp_dynamic_cast<const Tpetra::CrsMatrix<double,int,panzer::GlobalOrdinal,NT> >(tOp->getConstTpetraOperator(),true);
         *out << "\nDebug: " << s << std::endl;
         crsOp->describe(*out,Teuchos::VERB_MEDIUM);
+#ifdef PANZER_HAVE_EPETRA
       } else if (eOp != Teuchos::null) {
         const RCP<const Epetra_CrsMatrix> crsOp = rcp_dynamic_cast<const Epetra_CrsMatrix>(eOp->epetra_op(),true);
         *out << "\nDebug: " << s << std::endl;
         // crsOp->describe(*out,Teuchos::VERB_MEDIUM);
+#endif
       } else
         TEUCHOS_ASSERT(false);
     }
@@ -83,7 +92,7 @@ namespace mini_em {
     return crsOp;
   }
 
-
+#ifdef PANZER_HAVE_EPETRA
   Teuchos::RCP<const Epetra_CrsMatrix> get_Epetra_CrsMatrix(const Thyra::LinearOpBase<double> & op) {
     using Teuchos::RCP;
     using Teuchos::rcp_dynamic_cast;
@@ -113,6 +122,7 @@ namespace mini_em {
     crsMatrix->FillComplete();
     return crsMatrix;
   }
+#endif
 
   template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   Teuchos::RCP<Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> >
@@ -132,6 +142,7 @@ namespace mini_em {
     return identityMatrix;
   }
 
+#ifdef PANZER_HAVE_EPETRA
   Teuchos::RCP<const Epetra_CrsMatrix>
   getIdentityMatrixEpetra (const Epetra_Map& rowMap,
                            double scaling)
@@ -146,6 +157,7 @@ namespace mini_em {
     identityMatrix->FillComplete();
     return identityMatrix;
   }
+#endif
 
   Teko::LinearOp getIdentityMatrix(const Teko::LinearOp& op, double scaling)
   {
@@ -154,7 +166,9 @@ namespace mini_em {
     using Node = panzer::TpetraNodeType;
 
     const RCP<const Thyra::TpetraLinearOp<double,int,panzer::GlobalOrdinal,Node> > tOp = rcp_dynamic_cast<const Thyra::TpetraLinearOp<double,int,panzer::GlobalOrdinal,Node> >(op);
+#ifdef PANZER_HAVE_EPETRA
     const RCP<const Thyra::EpetraLinearOp> eOp = rcp_dynamic_cast<const Thyra::EpetraLinearOp>(op);
+#endif
     if(tOp != Teuchos::null) {
       using Scalar = double;
       using LocalOrdinal = int;
@@ -167,6 +181,7 @@ namespace mini_em {
                                                                                            Teko::domainSpace(op),
                                                                                            tpId);
       return thyId;
+#ifdef PANZER_HAVE_EPETRA
     } else if (eOp != Teuchos::null) {
       const RCP<const Epetra_CrsMatrix> crsOp = rcp_dynamic_cast<const Epetra_CrsMatrix>(eOp->epetra_op(),true);
       auto epMap = crsOp->RowMap();
@@ -180,6 +195,7 @@ namespace mini_em {
                                                                                    Teko::domainSpace(op));
       // return Teuchos::rcp_const_cast<Thyra::LinearOpBase<double> >(thyConst);
       return thyConst;
+#endif
     } else
       TEUCHOS_ASSERT(false);
   }

--- a/packages/panzer/mini-em/src/solvers/MiniEM_Utils.hpp
+++ b/packages/panzer/mini-em/src/solvers/MiniEM_Utils.hpp
@@ -1,20 +1,22 @@
 #ifndef _MiniEM_Utils_hpp_
 #define _MiniEM_Utils_hpp_
 
+#include "PanzerAdaptersSTK_config.hpp"
 #include "Teuchos_RCP.hpp"
 #include "Teko_TpetraHelpers.hpp"
 #include "Teko_TpetraOperatorWrapper.hpp"
 #include "Thyra_TpetraLinearOp.hpp"
-#include "Thyra_EpetraLinearOp.hpp"
 #include "MatrixMarket_Tpetra.hpp"
 #include "Panzer_NodeType.hpp"
+#ifdef PANZER_HAVE_EPETRA
+#include "Thyra_EpetraLinearOp.hpp"
 #include "EpetraExt_RowMatrixOut.h"
 #include "EpetraExt_BlockMapOut.h"
 #include "Epetra_CombineMode.h"
 #include "Epetra_Comm.h"
 #include "Epetra_CrsMatrix.h"
 #include "Thyra_EpetraThyraWrappers.hpp"
-#include "Panzer_NodeType.hpp"
+#endif
 #include "Panzer_LOCPair_GlobalEvaluationData.hpp"
 #include "Panzer_LinearObjContainer.hpp"
 #include "Panzer_ThyraObjContainer.hpp"
@@ -32,9 +34,11 @@ namespace mini_em {
   template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node=Tpetra::Map<>::node_type>
   Teuchos::RCP<const Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > get_Tpetra_CrsMatrix(const Thyra::LinearOpBase<double> & op);
 
+#ifdef PANZER_HAVE_EPETRA
   Teuchos::RCP<const Epetra_CrsMatrix> get_Epetra_CrsMatrix(const Thyra::LinearOpBase<double> & op);
 
   Teuchos::RCP<const Epetra_CrsMatrix> get_Epetra_CrsMatrix(const Thyra::DiagonalLinearOpBase<double> & op, const Epetra_Comm& comm);
+#endif
 
   Teko::LinearOp getIdentityMatrix(const Teko::LinearOp& op, double scaling);
 


### PR DESCRIPTION
## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
make epetra stack optional for panzer

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
N/A
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->