### PR TITLE
Frosch : symbolic / compute setups

### DIFF
--- a/packages/shylu/shylu_dd/frosch/src/CoarseSpaces/FROSch_CoarseSpace_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/CoarseSpaces/FROSch_CoarseSpace_def.hpp
@@ -238,7 +238,7 @@ namespace FROSch {
 
             // count number of nonzeros per row
             UN numLocalRows = rowMap->getLocalNumElements();
-            rowptr_type Rowptr ("Rowptr", numLocalRows+1);
+            rowptr_type Rowptr (Kokkos::ViewAllocateWithoutInitializing("Rowptr"), numLocalRows+1);
             Kokkos::deep_copy(Rowptr, 0);
             Kokkos::parallel_for(
                 "FROSch_CoarseSpace::countGlobalBasisMatrix", policy_row,
@@ -268,8 +268,8 @@ namespace FROSch {
               (1+numLocalRows, Rowptr);
 
             // fill into the local matrix
-            indices_type Indices ("Indices", nnz);
-            values_type  Values  ("Values",  nnz);
+            indices_type Indices (Kokkos::ViewAllocateWithoutInitializing("Indices"), nnz);
+            values_type  Values  (Kokkos::ViewAllocateWithoutInitializing("Values"),  nnz);
             auto AssembledBasisLocalMap = AssembledBasisMap_->getLocalMap();
             Kokkos::parallel_for(
                 "FROSch_CoarseSpace::fillGlobalBasisMatrix", policy_row,

--- a/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_AlgebraicOverlappingOperator_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_AlgebraicOverlappingOperator_def.hpp
@@ -322,8 +322,11 @@ namespace FROSch {
             FROSCH_DETAILTIMER_START_LEVELID(AlgebraicOverlappin_extractLocalSubdomainMatrix_SymbolicTime,"AlgebraicOverlappinOperator::extractLocalSubdomainMatrix_Symbolic");
             // buid sudomain matrix
             this->subdomainMatrix_ = MatrixFactory<SC,LO,GO,NO>::Build(this->OverlappingMap_, this->OverlappingMatrix_->getGlobalMaxNumRowEntries());
-            this->subdomainScatter_ = ImportFactory<LO,GO,NO>::Build(this->OverlappingMatrix_->getRowMap(), this->OverlappingMap_);
-            this->subdomainMatrix_->doImport(*(this->OverlappingMatrix_), *(this->subdomainScatter_), ADD);
+            RCP<Import<LO,GO,NO> > scatter = ImportFactory<LO,GO,NO>::Build(this->OverlappingMatrix_->getRowMap(), this->OverlappingMap_);
+            this->subdomainMatrix_->doImport(*(this->OverlappingMatrix_), *scatter, ADD);
+
+            // Used to Map original K_ to overlapping suubdomainMatrix
+            this->subdomainScatter_ = ImportFactory<LO,GO,NO>::Build(this->K_->getRowMap(), this->OverlappingMap_);
 
             // build local subdomain matrix
             RCP<const Comm<LO> > SerialComm = rcp(new MpiComm<LO>(MPI_COMM_SELF));

--- a/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_AlgebraicOverlappingOperator_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_AlgebraicOverlappingOperator_def.hpp
@@ -294,7 +294,7 @@ namespace FROSch {
         FROSCH_DETAILTIMER_START_LEVELID(updateLocalOverlappingMatricesTime,"AlgebraicOverlappingOperator::updateLocalOverlappingMatrices");
         if (this->ExtractLocalSubdomainMatrix_Symbolic_Done_) {
             // using original K_ as input
-            ExtractLocalSubdomainMatrix_Compute(this->K_, this->subdomainMatrix_, this->localSubdomainMatrix_);
+            ExtractLocalSubdomainMatrix_Compute(this->subdomainScatter_, this->K_, this->subdomainMatrix_, this->localSubdomainMatrix_);
             this->OverlappingMatrix_ = this->localSubdomainMatrix_.getConst();
         } else {
             if (this->IsComputed_) {
@@ -322,8 +322,8 @@ namespace FROSch {
             FROSCH_DETAILTIMER_START_LEVELID(AlgebraicOverlappin_extractLocalSubdomainMatrix_SymbolicTime,"AlgebraicOverlappinOperator::extractLocalSubdomainMatrix_Symbolic");
             // buid sudomain matrix
             this->subdomainMatrix_ = MatrixFactory<SC,LO,GO,NO>::Build(this->OverlappingMap_, this->OverlappingMatrix_->getGlobalMaxNumRowEntries());
-            RCP<Import<LO,GO,NO> > scatter = ImportFactory<LO,GO,NO>::Build(this->OverlappingMatrix_->getRowMap(), this->OverlappingMap_);
-            this->subdomainMatrix_->doImport(*(this->OverlappingMatrix_), *scatter, ADD);
+            this->subdomainScatter_ = ImportFactory<LO,GO,NO>::Build(this->OverlappingMatrix_->getRowMap(), this->OverlappingMap_);
+            this->subdomainMatrix_->doImport(*(this->OverlappingMatrix_), *(this->subdomainScatter_), ADD);
 
             // build local subdomain matrix
             RCP<const Comm<LO> > SerialComm = rcp(new MpiComm<LO>(MPI_COMM_SELF));

--- a/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_CoarseOperator_decl.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_CoarseOperator_decl.hpp
@@ -204,6 +204,7 @@ namespace FROSch {
         bool coarseExtractLocalSubdomainMatrix_Symbolic_Done_ = false;
         XMatrixPtr coarseSubdomainMatrix_;
         XMatrixPtr coarseLocalSubdomainMatrix_;
+        XImportPtr coarseScatter_;
 
         // Temp Vectors for apply()
         mutable XMultiVectorPtr XTmp_;

--- a/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_HarmonicCoarseOperator_decl.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_HarmonicCoarseOperator_decl.hpp
@@ -154,6 +154,122 @@ namespace FROSch {
             UN          j_out;
             SCView      data_out;
         };
+
+
+        struct ScaleTag {};
+        struct CountNnzTag {};
+        struct TotalNnzTag {};
+        struct FillNzEntriesTag {};
+        template<class indicesView, class SCView, class localRowMapType, class localMVBasisType, class RowptrType, class IndicesType, class ValuesType>
+        struct detectLinearDependenciesFunctor
+        {
+            using Real = typename Teuchos::ScalarTraits<SC>::magnitudeType;
+            using STS = Kokkos::ArithTraits<SC>;
+            using RTS = Kokkos::ArithTraits<Real>;
+
+            UN numRows;
+            UN numCols;
+            SCView scale;
+            localMVBasisType localMVBasis;
+
+            SC tresholdDropping;
+            indicesView indicesGammaDofsAll;
+            localRowMapType localRowMap;
+            localRowMapType localRepeatedMap;
+
+            RowptrType  Rowptr;
+            IndicesType Indices;
+            ValuesType  Values;
+
+            // Constructor for ScaleTag
+            detectLinearDependenciesFunctor(UN numRows_, UN numCols_, SCView scale_, localMVBasisType localMVBasis_) :
+            numRows (numRows_),
+            numCols (numCols_),
+            scale (scale_),
+            localMVBasis (localMVBasis_)
+            {}
+
+            // Constructor for CountNnzTag
+            detectLinearDependenciesFunctor(UN numRows_, UN numCols_, localMVBasisType localMVBasis_, SC tresholdDropping_, 
+                                            indicesView indicesGammaDofsAll_, localRowMapType localRowMap_, localRowMapType localRepeatedMap_,
+                                            RowptrType Rowptr_) :
+            numRows (numRows_),
+            numCols (numCols_),
+            scale (),
+            localMVBasis (localMVBasis_),
+            tresholdDropping (tresholdDropping_),
+            indicesGammaDofsAll (indicesGammaDofsAll_),
+            localRowMap (localRowMap_),
+            localRepeatedMap (localRepeatedMap_),
+            Rowptr (Rowptr_)
+            {}
+
+            // Constructor for FillNzEntriesTag
+            detectLinearDependenciesFunctor(UN numRows_, UN numCols_, SCView scale_, localMVBasisType localMVBasis_,
+                                            SC tresholdDropping_, indicesView indicesGammaDofsAll_,
+                                            localRowMapType localRowMap_, localRowMapType localRepeatedMap_,
+                                            RowptrType Rowptr_, IndicesType Indices_, ValuesType Values_) :
+            numRows (numRows_),
+            numCols (numCols_),
+            scale (scale_),
+            localMVBasis (localMVBasis_),
+            tresholdDropping (tresholdDropping_),
+            indicesGammaDofsAll (indicesGammaDofsAll_),
+            localRowMap (localRowMap_),
+            localRepeatedMap (localRepeatedMap_),
+            Rowptr (Rowptr_),
+            Indices (Indices_),
+            Values (Values_)
+            {}
+
+            KOKKOS_INLINE_FUNCTION
+            void operator()(const ScaleTag &, const int j) const {
+                scale(j) = STS::zero();
+                for (UN i = 0; i < numRows; i++) {
+                    scale(j) += localMVBasis(i,j)*localMVBasis(i,j);
+                }
+                scale(j) = RTS::one()/RTS::sqrt(STS::abs(scale(j)));
+            }
+
+            KOKKOS_INLINE_FUNCTION
+            void operator()(const CountNnzTag &, const int i) const {
+                LO rowID = indicesGammaDofsAll[i];
+                GO iGlobal = localRepeatedMap.getGlobalElement(rowID);
+                LO iLocal = localRowMap.getLocalElement(iGlobal);
+                if (iLocal!=-1) { // This should prevent duplicate entries on the interface
+                    for (UN j=0; j<numCols; j++) {
+                        SC valueTmp=localMVBasis(i,j);
+                        if (fabs(valueTmp)>tresholdDropping) {
+                            Rowptr(iLocal+1) ++;
+                        }
+                    }
+                }
+            }
+
+
+            KOKKOS_INLINE_FUNCTION
+            void operator()(const TotalNnzTag&, const size_t i, UN &lsum) const {
+                 lsum += Rowptr[i];
+            }
+
+            KOKKOS_INLINE_FUNCTION
+            void operator()(const FillNzEntriesTag &, const int i) const {
+                LO rowID = indicesGammaDofsAll[i];
+                GO iGlobal = localRepeatedMap.getGlobalElement(rowID);
+                LO iLocal = localRowMap.getLocalElement(iGlobal);
+                if (iLocal!=-1) { // This should prevent duplicate entries on the interface
+                    UN nnz_i = Rowptr(iLocal);
+                    for (UN j=0; j<numCols; j++) {
+                        SC valueTmp=localMVBasis(i,j);
+                        if (fabs(valueTmp)>tresholdDropping) {
+                            Indices(nnz_i) = j; //localBasisMap.getGlobalElement(j);
+                            Values(nnz_i) = valueTmp*scale(j);
+                            nnz_i ++;
+                        }
+                    }
+                }
+            }
+        };
         #endif
 
     protected:

--- a/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_SchwarzOperator_decl.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_SchwarzOperator_decl.hpp
@@ -236,6 +236,7 @@ namespace FROSch {
         bool ExtractLocalSubdomainMatrix_Symbolic_Done_ = false;
         XMatrixPtr subdomainMatrix_;
         XMatrixPtr localSubdomainMatrix_;
+        XImportPtr subdomainScatter_;
 
         bool Verbose_ = false;
 

--- a/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_SumOperator_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_SumOperator_def.hpp
@@ -118,7 +118,9 @@ namespace FROSch {
     {
         FROSCH_TIMER_START_LEVELID(applyTime,"SumOperator::apply");
         if (OperatorVector_.size()>0) {
-            if (XTmp_.is_null()) XTmp_ = MultiVectorFactory<SC,LO,GO,NO>::Build(x.getMap(),x.getNumVectors());
+            if (XTmp_.is_null() || XTmp_->getNumVectors() != x.getNumVectors()) {
+                XTmp_ = MultiVectorFactory<SC,LO,GO,NO>::Build(x.getMap(),x.getNumVectors());
+            }
             *XTmp_ = x; // Das brauche ich für den Fall das x=y
             UN itmp = 0;
             for (UN i=0; i<OperatorVector_.size(); i++) {

--- a/packages/shylu/shylu_dd/frosch/src/SchwarzPreconditioners/FROSch_GDSWPreconditioner_decl.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SchwarzPreconditioners/FROSch_GDSWPreconditioner_decl.hpp
@@ -82,6 +82,7 @@ namespace FROSch {
         using GOVecPtr                  = typename SchwarzPreconditioner<SC,LO,GO,NO>::GOVecPtr;
 
     public:
+        using AlgebraicOverlappingPreconditioner<SC,LO,GO,NO>::initialize;
 
         GDSWPreconditioner(ConstXMatrixPtr k,
                            ParameterListPtr parameterList);

--- a/packages/shylu/shylu_dd/frosch/src/SchwarzPreconditioners/FROSch_RGDSWPreconditioner_decl.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SchwarzPreconditioners/FROSch_RGDSWPreconditioner_decl.hpp
@@ -81,6 +81,7 @@ namespace FROSch {
         using GOVecPtr                  = typename SchwarzPreconditioner<SC,LO,GO,NO>::GOVecPtr;
 
     public:
+        using AlgebraicOverlappingPreconditioner<SC,LO,GO,NO>::initialize;
 
         RGDSWPreconditioner(ConstXMatrixPtr k,
                             ParameterListPtr parameterList);

--- a/packages/shylu/shylu_dd/frosch/src/SchwarzPreconditioners/FROSch_TwoLevelPreconditioner_decl.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SchwarzPreconditioners/FROSch_TwoLevelPreconditioner_decl.hpp
@@ -83,6 +83,7 @@ namespace FROSch {
         using GOVecPtr                          = typename SchwarzPreconditioner<SC,LO,GO,NO>::GOVecPtr;
 
     public:
+        using OneLevelPreconditioner<SC,LO,GO,NO>::initialize;
 
         TwoLevelPreconditioner(ConstXMatrixPtr k,
                                ParameterListPtr parameterList);

--- a/packages/shylu/shylu_dd/frosch/src/SolverInterfaces/FROSch_Amesos2SolverTpetra_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SolverInterfaces/FROSch_Amesos2SolverTpetra_def.hpp
@@ -91,7 +91,9 @@ namespace FROSch {
         FROSCH_ASSERT(xTpetraMultiVectorX,"FROSch::Amesos2SolverTpetra: dynamic_cast failed.");
         TMultiVectorPtr tpetraMultiVectorX = xTpetraMultiVectorX->getTpetra_MultiVector();
 
-        if (Y_.is_null()) Y_ = XMultiVectorFactory::Build(y.getMap(),x.getNumVectors());
+        if (Y_.is_null() || Y_->getNumVectors() != x.getNumVectors()) {
+            Y_ = XMultiVectorFactory::Build(y.getMap(),x.getNumVectors());
+        }
         const TpetraMultiVector<SC,LO,GO,NO> * xTpetraMultiVectorY = dynamic_cast<const TpetraMultiVector<SC,LO,GO,NO> *>(Y_.get());
         FROSCH_ASSERT(xTpetraMultiVectorY,"FROSch::Amesos2SolverTpetra: dynamic_cast failed.");
         TMultiVectorPtr tpetraMultiVectorY = xTpetraMultiVectorY->getTpetra_MultiVector();

--- a/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_ExtractSubmatrices_decl.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_ExtractSubmatrices_decl.hpp
@@ -72,6 +72,12 @@ namespace FROSch {
     void ExtractLocalSubdomainMatrix_Compute(RCP<const Matrix<SC,LO,GO,NO> > globalMatrix,
                                              RCP<      Matrix<SC,LO,GO,NO> > subdomainMatrix,
                                              RCP<      Matrix<SC,LO,GO,NO> > repeatedMatrix);
+
+    template <class SC,class LO,class GO,class NO>
+    void ExtractLocalSubdomainMatrix_Compute(RCP<      Import<LO,GO,NO> >    scatter,
+                                             RCP<const Matrix<SC,LO,GO,NO> > globalMatrix,
+                                             RCP<      Matrix<SC,LO,GO,NO> > subdomainMatrix,
+                                             RCP<      Matrix<SC,LO,GO,NO> > repeatedMatrix);
     // ----------------------------------------------------------- //
 
     template <class SC,class LO,class GO,class NO>

--- a/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_ExtractSubmatrices_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_ExtractSubmatrices_def.hpp
@@ -123,11 +123,20 @@ namespace FROSch {
                                              RCP<      Matrix<SC,LO,GO,NO> > subdomainMatrix,
                                              RCP<      Matrix<SC,LO,GO,NO> > localSubdomainMatrix)
     {
+        RCP<Import<LO,GO,NO> > scatter = ImportFactory<LO,GO,NO>::Build(globalMatrix->getRowMap(), subdomainMatrix->getRowMap());
+        ExtractLocalSubdomainMatrix_Compute(scatter, globalMatrix, subdomainMatrix, localSubdomainMatrix);
+    }
+
+    template <class SC,class LO,class GO,class NO>
+    void ExtractLocalSubdomainMatrix_Compute(RCP<      Import<LO,GO,NO> >    scatter,
+                                             RCP<const Matrix<SC,LO,GO,NO> > globalMatrix,
+                                             RCP<      Matrix<SC,LO,GO,NO> > subdomainMatrix,
+                                             RCP<      Matrix<SC,LO,GO,NO> > localSubdomainMatrix)
+    {
         FROSCH_DETAILTIMER_START(extractLocalSubdomainMatrixTime_compute, "ExtractLocalSubdomainMatrix_Compute");
         const SC zero = ScalarTraits<SC>::zero();
         auto subdomainRowMap = subdomainMatrix->getRowMap();
 
-        RCP<Import<LO,GO,NO> > scatter = ImportFactory<LO,GO,NO>::Build(globalMatrix->getRowMap(),subdomainRowMap);
         subdomainMatrix->setAllToScalar(zero);
         subdomainMatrix->resumeFill();
         subdomainMatrix->doImport(*globalMatrix, *scatter, ADD);
@@ -314,10 +323,10 @@ namespace FROSch {
             UN numRowsI = indI.size();
             UN numRowsJ = indJ.size();
 
-            rowptr_type RowptrII ("RowptrII", numRowsI+1);
-            rowptr_type RowptrIJ ("RowptrIJ", numRowsI+1);
-            rowptr_type RowptrJI ("RowptrJI", numRowsJ+1);
-            rowptr_type RowptrJJ ("RowptrJJ", numRowsJ+1);
+            rowptr_type RowptrII (Kokkos::ViewAllocateWithoutInitializing("RowptrII"), numRowsI+1);
+            rowptr_type RowptrIJ (Kokkos::ViewAllocateWithoutInitializing("RowptrIJ"), numRowsI+1);
+            rowptr_type RowptrJI (Kokkos::ViewAllocateWithoutInitializing("RowptrJI"), numRowsJ+1);
+            rowptr_type RowptrJJ (Kokkos::ViewAllocateWithoutInitializing("RowptrJJ"), numRowsJ+1);
 
             // count nnz on each blocks
             Kokkos::deep_copy(RowptrII, 0);
@@ -388,17 +397,17 @@ namespace FROSch {
                 (1+numRowsJ, RowptrJJ);
 
             // allocate kII block
-            indices_type IndicesII ("IndicesII", nnzII);
-            values_type  ValuesII  ("ValuesII",  nnzII);
+            indices_type IndicesII (Kokkos::ViewAllocateWithoutInitializing("IndicesII"), nnzII);
+            values_type  ValuesII  (Kokkos::ViewAllocateWithoutInitializing("ValuesII"),  nnzII);
             // allocate kIJ block
-            indices_type IndicesIJ ("IndicesIJ", nnzIJ);
-            values_type  ValuesIJ  ("ValuesIJ",  nnzIJ);
+            indices_type IndicesIJ (Kokkos::ViewAllocateWithoutInitializing("IndicesIJ"), nnzIJ);
+            values_type  ValuesIJ  (Kokkos::ViewAllocateWithoutInitializing("ValuesIJ"),  nnzIJ);
             // allocate kJI block
-            indices_type IndicesJI ("IndicesJI", nnzJI);
-            values_type  ValuesJI  ("ValuesJI",  nnzJI);
+            indices_type IndicesJI (Kokkos::ViewAllocateWithoutInitializing("IndicesJI"), nnzJI);
+            values_type  ValuesJI  (Kokkos::ViewAllocateWithoutInitializing("ValuesJI"),  nnzJI);
             // allocate kJJ block
-            indices_type IndicesJJ ("IndicesJJ", nnzJJ);
-            values_type  ValuesJJ  ("ValuesJJ",  nnzJJ);
+            indices_type IndicesJJ (Kokkos::ViewAllocateWithoutInitializing("IndicesJJ"), nnzJJ);
+            values_type  ValuesJJ  (Kokkos::ViewAllocateWithoutInitializing("ValuesJJ"),  nnzJJ);
 
             // fill in all the blocks
             Kokkos::parallel_for(


### PR DESCRIPTION

@trilinos/shylu 

## Motivation

This PR moves some symbolic codes from the numerical phase of FROSch to the symbolic:
- Symbolic factorization of K_{I,I}

