### PR TITLE
Framework: Enable shadow warnings everywhere we use -Wall

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1457,6 +1457,53 @@ opt-set-cmake-var Zoltan_ENABLE_Scotch BOOL FORCE : OFF
 [CUDA11-RUN-SERIAL-TESTS]
 opt-set-cmake-var KokkosKernels_batched_dla_cuda_MPI_1_SET_RUN_SERIAL BOOL FORCE : ON
 
+[GCC_PACKAGE_SPECIFIC_WARNING_FLAGS]
+opt-set-cmake-var Amesos_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var Amesos2_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+#opt-set-cmake-var Anasazi_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+opt-set-cmake-var Belos_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var Compadre_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var Domi_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var Epetra_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var EpetraExt_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var FEI_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var Galeri_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var Ifpack_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror -Wno-error=shadow
+opt-set-cmake-var Ifpack2_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var Intrepid_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var Intrepid2_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror -Wno-error=shadow
+opt-set-cmake-var Isorropia_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+#opt-set-cmake-var Kokkos_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+#opt-set-cmake-var KokkosKernels_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+opt-set-cmake-var ML_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var Moertel_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+#opt-set-cmake-var MueLu_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+opt-set-cmake-var NOX_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var Pamgen_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+#opt-set-cmake-var Panzer_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+opt-set-cmake-var Phalanx_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var Pike_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+opt-set-cmake-var Piro_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var ROL_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var Sacado_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+#opt-set-cmake-var SEACAS_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+opt-set-cmake-var Shards_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var ShyLU_Node_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var STK_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var Stokhos_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var Stratimikos_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var Teko_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var Tempus_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+#opt-set-cmake-var Teuchos_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+opt-set-cmake-var Tpetra_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var TrilinosCouplings_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+#opt-set-cmake-var Triutils_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+opt-set-cmake-var Zoltan_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+#opt-set-cmake-var Zoltan2_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+
+
+
+
 # Full configurations intended to be loaded.
 
 [rhel7_sems-gnu-7.2.0-anaconda3-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_pr-framework]
@@ -1538,10 +1585,12 @@ opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                         BOOL   
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D          BOOL         : ON
 opt-set-cmake-var KokkosKernels_blas_serial_MPI_1_DISABLE                BOOL         : ON
 opt-set-cmake-var ROL_example_PDE-OPT_helmholtz_example_02_MPI_1_DISABLE BOOL         : ON
-opt-set-cmake-var CMAKE_CXX_FLAGS                                        STRING       : -Wall -Wshadow -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-nonnull-compare -Wno-address -Wno-inline -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
+opt-set-cmake-var CMAKE_CXX_FLAGS                                        STRING       : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-nonnull-compare -Wno-address -Wno-inline -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
 
 # Test failures as of 11-28-22
 opt-set-cmake-var ROL_example_PDE-OPT_navier-stokes_example_01_MPI_4_DISABLE BOOL : ON
+
+use GCC_PACKAGE_SPECIFIC_WARNING_FLAGS
 
 use RHEL7_POST
 
@@ -1567,8 +1616,10 @@ use COMMON_USE-MPI|NO
 opt-set-cmake-var CMAKE_CXX_STANDARD             STRING FORCE : 17
 opt-set-cmake-var Trilinos_ENABLE_Fortran OFF    BOOL         : OFF
 opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE BOOL         : ON
-opt-set-cmake-var CMAKE_CXX_FLAGS                STRING       : -Wall -Wshadow -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-nonnull-compare -Wno-address -Wno-inline -Wno-unused-but-set-variable -Wno-unused-variable -Wno-unused-label -Werror -Wno-error=shadow -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
+opt-set-cmake-var CMAKE_CXX_FLAGS                STRING       : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-nonnull-compare -Wno-address -Wno-inline -Wno-unused-but-set-variable -Wno-unused-variable -Wno-unused-label -Werror -Werror=shadow -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
 opt-set-cmake-var TPL_ENABLE_ParMETIS            BOOL FORCE   : OFF
+
+use GCC_PACKAGE_SPECIFIC_WARNING_FLAGS
 
 use RHEL7_POST
 
@@ -1596,7 +1647,9 @@ opt-set-cmake-var Tpetra_INST_SERIAL                            BOOL FORCE : ON
 opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                BOOL       : ON
 opt-set-cmake-var CMAKE_CXX_EXTENSIONS                          BOOL       : OFF
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D BOOL       : ON
-opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING     : -fno-strict-aliasing -Wall -Wshadow -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-inline -Wno-nonnull-compare -Wno-address -Werror -Wno-error=shadow -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
+opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING     : -fno-strict-aliasing -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-inline -Wno-nonnull-compare -Wno-address -Werror -Werror=shadow -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
+
+use GCC_PACKAGE_SPECIFIC_WARNING_FLAGS
 
 use RHEL7_POST
 
@@ -1622,7 +1675,9 @@ opt-set-cmake-var CMAKE_CXX_EXTENSIONS                          BOOL       : OFF
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D BOOL       : ON
 opt-set-cmake-var Trilinos_ENABLE_Moertel                       BOOL       : OFF
 opt-set-cmake-var Trilinos_ENABLE_ShyLU_DDBDDC                  BOOL       : OFF
-opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING     : -fno-strict-aliasing -Wall -Wshadow -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-inline -Wno-nonnull-compare -Wno-address -Werror -Wno-error=shadow -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
+opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING     : -fno-strict-aliasing -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-inline -Wno-nonnull-compare -Wno-address -Werror -Werror=shadow -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
+
+use GCC_PACKAGE_SPECIFIC_WARNING_FLAGS
 
 use RHEL7_POST
 
@@ -1645,7 +1700,9 @@ opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING       : -
 opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                BOOL         : ON
 opt-set-cmake-var CMAKE_CXX_EXTENSIONS                          BOOL         : OFF
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D BOOL         : ON
-opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING       : -fno-strict-aliasing -Wall -Wshadow -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-inline -Wno-nonnull-compare -Wno-address -Werror -Wno-error=shadow -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
+opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING       : -fno-strict-aliasing -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-inline -Wno-nonnull-compare -Wno-address -Werror -Werror=shadow -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
+
+use GCC_PACKAGE_SPECIFIC_WARNING_FLAGS
 
 use RHEL7_POST
 
@@ -1709,7 +1766,7 @@ opt-set-cmake-var Trilinos_ENABLE_STKBalance BOOL FORCE : OFF
 
 opt-set-cmake-var CMAKE_CXX_STANDARD STRING FORCE : 14
 opt-set-cmake-var Zoltan_ENABLE_Scotch BOOL FORCE : OFF
-opt-set-cmake-var CMAKE_CXX_FLAGS STRING : -fPIC -Wall -Wshadow -Warray-bounds -Wchar-subscripts -Wcomment -Wenum-compare -Wformat -Wuninitialized -Wmaybe-uninitialized -Wmain -Wnarrowing -Wnonnull -Wparentheses -Wpointer-sign -Wreorder -Wreturn-type -Wsign-compare -Wsequence-point -Wtrigraphs -Wunused-function -Wunused-but-set-variable -Wunused-variable -Wwrite-strings
+opt-set-cmake-var CMAKE_CXX_FLAGS STRING : -fPIC -Wall -Warray-bounds -Wchar-subscripts -Wcomment -Wenum-compare -Wformat -Wuninitialized -Wmaybe-uninitialized -Wmain -Wnarrowing -Wnonnull -Wparentheses -Wpointer-sign -Wreorder -Wreturn-type -Wsign-compare -Wsequence-point -Wtrigraphs -Wunused-function -Wunused-but-set-variable -Wunused-variable -Wwrite-strings
 
 use RHEL7_TEST_DISABLES|INTEL
 
@@ -1820,7 +1877,7 @@ opt-set-cmake-var SuperLU_LIBRARY_DIRS STRING FORCE : ${SUPERLU_LIB|ENV}
 
 #CXX Settings
 opt-set-cmake-var CMAKE_CXX_STANDARD STRING FORCE : 17
-opt-set-cmake-var CMAKE_CXX_FLAGS STRING : -fPIC -Wall -Wshadow -Warray-bounds -Wchar-subscripts -Wcomment -Wenum-compare -Wformat -Wuninitialized -Wmaybe-uninitialized -Wmain -Wnarrowing -Wnonnull -Wparentheses -Wreorder -Wreturn-type -Wsign-compare -Wsequence-point -Wtrigraphs -Wunused-function -Wunused-but-set-variable -Wunused-variable -Wwrite-strings
+opt-set-cmake-var CMAKE_CXX_FLAGS STRING : -fPIC -Wall -Warray-bounds -Wchar-subscripts -Wcomment -Wenum-compare -Wformat -Wuninitialized -Wmaybe-uninitialized -Wmain -Wnarrowing -Wnonnull -Wparentheses -Wreorder -Wreturn-type -Wsign-compare -Wsequence-point -Wtrigraphs -Wunused-function -Wunused-but-set-variable -Wunused-variable -Wwrite-strings
 
 #Package Options
 opt-set-cmake-var EpetraExt_ENABLE_HDF5 BOOL FORCE : OFF

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1493,7 +1493,7 @@ opt-set-cmake-var STK_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=sha
 opt-set-cmake-var Stokhos_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var Stratimikos_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var Teko_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Tempus_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+opt-set-cmake-var Tempus_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror -Wno-error=shadow
 #opt-set-cmake-var Teuchos_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
 opt-set-cmake-var Tpetra_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var TrilinosCouplings_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1485,9 +1485,7 @@ opt-set-cmake-var ShyLU_Node_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-er
 opt-set-cmake-var STK_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var Stokhos_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var Stratimikos_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Teko_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var Tempus_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
-opt-set-cmake-var Tpetra_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var TrilinosCouplings_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var Zoltan_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1501,7 +1501,12 @@ opt-set-cmake-var TrilinosCouplings_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} 
 opt-set-cmake-var Zoltan_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 #opt-set-cmake-var Zoltan2_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
 
-
+[GCC_OPENMP_PACKAGE_SPECIFIC_WARNING_FLAGS]
+use GCC_PACKAGE_SPECIFIC_WARNING_FLAGS
+opt-set-cmake-var Panzer_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var Percept_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var Pliris_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var ShyLU_DD_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 
 
 # Full configurations intended to be loaded.
@@ -1649,7 +1654,7 @@ opt-set-cmake-var CMAKE_CXX_EXTENSIONS                          BOOL       : OFF
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D BOOL       : ON
 opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING     : -fno-strict-aliasing -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-inline -Wno-nonnull-compare -Wno-address -Werror -Werror=shadow -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
 
-use GCC_PACKAGE_SPECIFIC_WARNING_FLAGS
+use GCC_OPENMP_PACKAGE_SPECIFIC_WARNING_FLAGS
 
 use RHEL7_POST
 
@@ -1677,7 +1682,7 @@ opt-set-cmake-var Trilinos_ENABLE_Moertel                       BOOL       : OFF
 opt-set-cmake-var Trilinos_ENABLE_ShyLU_DDBDDC                  BOOL       : OFF
 opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING     : -fno-strict-aliasing -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-inline -Wno-nonnull-compare -Wno-address -Werror -Werror=shadow -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
 
-use GCC_PACKAGE_SPECIFIC_WARNING_FLAGS
+use GCC_OPENMP_PACKAGE_SPECIFIC_WARNING_FLAGS
 
 use RHEL7_POST
 
@@ -1702,7 +1707,7 @@ opt-set-cmake-var CMAKE_CXX_EXTENSIONS                          BOOL         : O
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D BOOL         : ON
 opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING       : -fno-strict-aliasing -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-inline -Wno-nonnull-compare -Wno-address -Werror -Werror=shadow -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
 
-use GCC_PACKAGE_SPECIFIC_WARNING_FLAGS
+use GCC_OPENMP_PACKAGE_SPECIFIC_WARNING_FLAGS
 
 use RHEL7_POST
 

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1538,7 +1538,7 @@ opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                         BOOL   
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D          BOOL         : ON
 opt-set-cmake-var KokkosKernels_blas_serial_MPI_1_DISABLE                BOOL         : ON
 opt-set-cmake-var ROL_example_PDE-OPT_helmholtz_example_02_MPI_1_DISABLE BOOL         : ON
-opt-set-cmake-var CMAKE_CXX_FLAGS                                        STRING       : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-nonnull-compare -Wno-address -Wno-inline -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
+opt-set-cmake-var CMAKE_CXX_FLAGS                                        STRING       : -Wall -Werror=shadow -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-nonnull-compare -Wno-address -Wno-inline -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
 
 # Test failures as of 11-28-22
 opt-set-cmake-var ROL_example_PDE-OPT_navier-stokes_example_01_MPI_4_DISABLE BOOL : ON
@@ -1567,7 +1567,7 @@ use COMMON_USE-MPI|NO
 opt-set-cmake-var CMAKE_CXX_STANDARD             STRING FORCE : 17
 opt-set-cmake-var Trilinos_ENABLE_Fortran OFF    BOOL         : OFF
 opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE BOOL         : ON
-opt-set-cmake-var CMAKE_CXX_FLAGS                STRING       : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-nonnull-compare -Wno-address -Wno-inline -Wno-unused-but-set-variable -Wno-unused-variable -Wno-unused-label -Werror -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
+opt-set-cmake-var CMAKE_CXX_FLAGS                STRING       : -Wall -Werror=shadow -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-nonnull-compare -Wno-address -Wno-inline -Wno-unused-but-set-variable -Wno-unused-variable -Wno-unused-label -Werror -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
 opt-set-cmake-var TPL_ENABLE_ParMETIS            BOOL FORCE   : OFF
 
 use RHEL7_POST
@@ -1596,7 +1596,7 @@ opt-set-cmake-var Tpetra_INST_SERIAL                            BOOL FORCE : ON
 opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                BOOL       : ON
 opt-set-cmake-var CMAKE_CXX_EXTENSIONS                          BOOL       : OFF
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D BOOL       : ON
-opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING     : -fno-strict-aliasing -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-inline -Wno-nonnull-compare -Wno-address -Werror -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
+opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING     : -fno-strict-aliasing -Wall -Werror=shadow -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-inline -Wno-nonnull-compare -Wno-address -Werror -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
 
 use RHEL7_POST
 
@@ -1622,7 +1622,7 @@ opt-set-cmake-var CMAKE_CXX_EXTENSIONS                          BOOL       : OFF
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D BOOL       : ON
 opt-set-cmake-var Trilinos_ENABLE_Moertel                       BOOL       : OFF
 opt-set-cmake-var Trilinos_ENABLE_ShyLU_DDBDDC                  BOOL       : OFF
-opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING     : -fno-strict-aliasing -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-inline -Wno-nonnull-compare -Wno-address -Werror -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
+opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING     : -fno-strict-aliasing -Wall -Werror=shadow -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-inline -Wno-nonnull-compare -Wno-address -Werror -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
 
 use RHEL7_POST
 
@@ -1645,7 +1645,7 @@ opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING       : -
 opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                BOOL         : ON
 opt-set-cmake-var CMAKE_CXX_EXTENSIONS                          BOOL         : OFF
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D BOOL         : ON
-opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING       : -fno-strict-aliasing -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-inline -Wno-nonnull-compare -Wno-address -Werror -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
+opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING       : -fno-strict-aliasing -Wall -Werror=shadow -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-inline -Wno-nonnull-compare -Wno-address -Werror -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
 
 use RHEL7_POST
 
@@ -1709,7 +1709,7 @@ opt-set-cmake-var Trilinos_ENABLE_STKBalance BOOL FORCE : OFF
 
 opt-set-cmake-var CMAKE_CXX_STANDARD STRING FORCE : 14
 opt-set-cmake-var Zoltan_ENABLE_Scotch BOOL FORCE : OFF
-opt-set-cmake-var CMAKE_CXX_FLAGS STRING : -fPIC -Wall -Warray-bounds -Wchar-subscripts -Wcomment -Wenum-compare -Wformat -Wuninitialized -Wmaybe-uninitialized -Wmain -Wnarrowing -Wnonnull -Wparentheses -Wpointer-sign -Wreorder -Wreturn-type -Wsign-compare -Wsequence-point -Wtrigraphs -Wunused-function -Wunused-but-set-variable -Wunused-variable -Wwrite-strings
+opt-set-cmake-var CMAKE_CXX_FLAGS STRING : -fPIC -Wall -Werror=shadow -Warray-bounds -Wchar-subscripts -Wcomment -Wenum-compare -Wformat -Wuninitialized -Wmaybe-uninitialized -Wmain -Wnarrowing -Wnonnull -Wparentheses -Wpointer-sign -Wreorder -Wreturn-type -Wsign-compare -Wsequence-point -Wtrigraphs -Wunused-function -Wunused-but-set-variable -Wunused-variable -Wwrite-strings
 
 use RHEL7_TEST_DISABLES|INTEL
 
@@ -1820,7 +1820,7 @@ opt-set-cmake-var SuperLU_LIBRARY_DIRS STRING FORCE : ${SUPERLU_LIB|ENV}
 
 #CXX Settings
 opt-set-cmake-var CMAKE_CXX_STANDARD STRING FORCE : 17
-opt-set-cmake-var CMAKE_CXX_FLAGS STRING : -fPIC -Wall -Warray-bounds -Wchar-subscripts -Wcomment -Wenum-compare -Wformat -Wuninitialized -Wmaybe-uninitialized -Wmain -Wnarrowing -Wnonnull -Wparentheses -Wreorder -Wreturn-type -Wsign-compare -Wsequence-point -Wtrigraphs -Wunused-function -Wunused-but-set-variable -Wunused-variable -Wwrite-strings
+opt-set-cmake-var CMAKE_CXX_FLAGS STRING : -fPIC -Wall -Werror=shadow -Warray-bounds -Wchar-subscripts -Wcomment -Wenum-compare -Wformat -Wuninitialized -Wmaybe-uninitialized -Wmain -Wnarrowing -Wnonnull -Wparentheses -Wreorder -Wreturn-type -Wsign-compare -Wsequence-point -Wtrigraphs -Wunused-function -Wunused-but-set-variable -Wunused-variable -Wwrite-strings
 
 #Package Options
 opt-set-cmake-var EpetraExt_ENABLE_HDF5 BOOL FORCE : OFF

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1486,7 +1486,7 @@ opt-set-cmake-var STK_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=sha
 opt-set-cmake-var Stokhos_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var Stratimikos_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var Teko_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Tempus_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror -Wno-error=shadow
+opt-set-cmake-var Tempus_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
 opt-set-cmake-var Tpetra_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var TrilinosCouplings_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var Zoltan_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1460,7 +1460,6 @@ opt-set-cmake-var KokkosKernels_batched_dla_cuda_MPI_1_SET_RUN_SERIAL BOOL FORCE
 [GCC_PACKAGE_SPECIFIC_WARNING_FLAGS]
 opt-set-cmake-var Amesos_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var Amesos2_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-#opt-set-cmake-var Anasazi_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
 opt-set-cmake-var Belos_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var Compadre_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var Domi_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
@@ -1469,24 +1468,18 @@ opt-set-cmake-var EpetraExt_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-err
 opt-set-cmake-var FEI_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var Galeri_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var Ifpack_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror -Wno-error=shadow
-opt-set-cmake-var Ifpack2_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var Intrepid_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var Intrepid2_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror -Wno-error=shadow
 opt-set-cmake-var Isorropia_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-#opt-set-cmake-var Kokkos_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
-#opt-set-cmake-var KokkosKernels_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
 opt-set-cmake-var ML_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var Moertel_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-#opt-set-cmake-var MueLu_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
 opt-set-cmake-var NOX_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var Pamgen_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-#opt-set-cmake-var Panzer_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
 opt-set-cmake-var Phalanx_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var Pike_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
 opt-set-cmake-var Piro_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var ROL_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var Sacado_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-#opt-set-cmake-var SEACAS_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
 opt-set-cmake-var Shards_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var ShyLU_Node_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var STK_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
@@ -1494,12 +1487,9 @@ opt-set-cmake-var Stokhos_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error
 opt-set-cmake-var Stratimikos_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var Teko_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var Tempus_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror -Wno-error=shadow
-#opt-set-cmake-var Teuchos_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
 opt-set-cmake-var Tpetra_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var TrilinosCouplings_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-#opt-set-cmake-var Triutils_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
 opt-set-cmake-var Zoltan_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-#opt-set-cmake-var Zoltan2_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
 
 [GCC_OPENMP_PACKAGE_SPECIFIC_WARNING_FLAGS]
 use GCC_PACKAGE_SPECIFIC_WARNING_FLAGS

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1538,7 +1538,7 @@ opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                         BOOL   
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D          BOOL         : ON
 opt-set-cmake-var KokkosKernels_blas_serial_MPI_1_DISABLE                BOOL         : ON
 opt-set-cmake-var ROL_example_PDE-OPT_helmholtz_example_02_MPI_1_DISABLE BOOL         : ON
-opt-set-cmake-var CMAKE_CXX_FLAGS                                        STRING       : -Wall -Werror=shadow -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-nonnull-compare -Wno-address -Wno-inline -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
+opt-set-cmake-var CMAKE_CXX_FLAGS                                        STRING       : -Wall -Wshadow -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-nonnull-compare -Wno-address -Wno-inline -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
 
 # Test failures as of 11-28-22
 opt-set-cmake-var ROL_example_PDE-OPT_navier-stokes_example_01_MPI_4_DISABLE BOOL : ON
@@ -1567,7 +1567,7 @@ use COMMON_USE-MPI|NO
 opt-set-cmake-var CMAKE_CXX_STANDARD             STRING FORCE : 17
 opt-set-cmake-var Trilinos_ENABLE_Fortran OFF    BOOL         : OFF
 opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE BOOL         : ON
-opt-set-cmake-var CMAKE_CXX_FLAGS                STRING       : -Wall -Werror=shadow -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-nonnull-compare -Wno-address -Wno-inline -Wno-unused-but-set-variable -Wno-unused-variable -Wno-unused-label -Werror -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
+opt-set-cmake-var CMAKE_CXX_FLAGS                STRING       : -Wall -Wshadow -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-nonnull-compare -Wno-address -Wno-inline -Wno-unused-but-set-variable -Wno-unused-variable -Wno-unused-label -Werror -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
 opt-set-cmake-var TPL_ENABLE_ParMETIS            BOOL FORCE   : OFF
 
 use RHEL7_POST
@@ -1596,7 +1596,7 @@ opt-set-cmake-var Tpetra_INST_SERIAL                            BOOL FORCE : ON
 opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                BOOL       : ON
 opt-set-cmake-var CMAKE_CXX_EXTENSIONS                          BOOL       : OFF
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D BOOL       : ON
-opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING     : -fno-strict-aliasing -Wall -Werror=shadow -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-inline -Wno-nonnull-compare -Wno-address -Werror -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
+opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING     : -fno-strict-aliasing -Wall -Wshadow -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-inline -Wno-nonnull-compare -Wno-address -Werror -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
 
 use RHEL7_POST
 
@@ -1622,7 +1622,7 @@ opt-set-cmake-var CMAKE_CXX_EXTENSIONS                          BOOL       : OFF
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D BOOL       : ON
 opt-set-cmake-var Trilinos_ENABLE_Moertel                       BOOL       : OFF
 opt-set-cmake-var Trilinos_ENABLE_ShyLU_DDBDDC                  BOOL       : OFF
-opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING     : -fno-strict-aliasing -Wall -Werror=shadow -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-inline -Wno-nonnull-compare -Wno-address -Werror -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
+opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING     : -fno-strict-aliasing -Wall -Wshadow -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-inline -Wno-nonnull-compare -Wno-address -Werror -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
 
 use RHEL7_POST
 
@@ -1645,7 +1645,7 @@ opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING       : -
 opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                BOOL         : ON
 opt-set-cmake-var CMAKE_CXX_EXTENSIONS                          BOOL         : OFF
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D BOOL         : ON
-opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING       : -fno-strict-aliasing -Wall -Werror=shadow -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-inline -Wno-nonnull-compare -Wno-address -Werror -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
+opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING       : -fno-strict-aliasing -Wall -Wshadow -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-inline -Wno-nonnull-compare -Wno-address -Werror -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
 
 use RHEL7_POST
 
@@ -1709,7 +1709,7 @@ opt-set-cmake-var Trilinos_ENABLE_STKBalance BOOL FORCE : OFF
 
 opt-set-cmake-var CMAKE_CXX_STANDARD STRING FORCE : 14
 opt-set-cmake-var Zoltan_ENABLE_Scotch BOOL FORCE : OFF
-opt-set-cmake-var CMAKE_CXX_FLAGS STRING : -fPIC -Wall -Werror=shadow -Warray-bounds -Wchar-subscripts -Wcomment -Wenum-compare -Wformat -Wuninitialized -Wmaybe-uninitialized -Wmain -Wnarrowing -Wnonnull -Wparentheses -Wpointer-sign -Wreorder -Wreturn-type -Wsign-compare -Wsequence-point -Wtrigraphs -Wunused-function -Wunused-but-set-variable -Wunused-variable -Wwrite-strings
+opt-set-cmake-var CMAKE_CXX_FLAGS STRING : -fPIC -Wall -Wshadow -Warray-bounds -Wchar-subscripts -Wcomment -Wenum-compare -Wformat -Wuninitialized -Wmaybe-uninitialized -Wmain -Wnarrowing -Wnonnull -Wparentheses -Wpointer-sign -Wreorder -Wreturn-type -Wsign-compare -Wsequence-point -Wtrigraphs -Wunused-function -Wunused-but-set-variable -Wunused-variable -Wwrite-strings
 
 use RHEL7_TEST_DISABLES|INTEL
 
@@ -1820,7 +1820,7 @@ opt-set-cmake-var SuperLU_LIBRARY_DIRS STRING FORCE : ${SUPERLU_LIB|ENV}
 
 #CXX Settings
 opt-set-cmake-var CMAKE_CXX_STANDARD STRING FORCE : 17
-opt-set-cmake-var CMAKE_CXX_FLAGS STRING : -fPIC -Wall -Werror=shadow -Warray-bounds -Wchar-subscripts -Wcomment -Wenum-compare -Wformat -Wuninitialized -Wmaybe-uninitialized -Wmain -Wnarrowing -Wnonnull -Wparentheses -Wreorder -Wreturn-type -Wsign-compare -Wsequence-point -Wtrigraphs -Wunused-function -Wunused-but-set-variable -Wunused-variable -Wwrite-strings
+opt-set-cmake-var CMAKE_CXX_FLAGS STRING : -fPIC -Wall -Wshadow -Warray-bounds -Wchar-subscripts -Wcomment -Wenum-compare -Wformat -Wuninitialized -Wmaybe-uninitialized -Wmain -Wnarrowing -Wnonnull -Wparentheses -Wreorder -Wreturn-type -Wsign-compare -Wsequence-point -Wtrigraphs -Wunused-function -Wunused-but-set-variable -Wunused-variable -Wwrite-strings
 
 #Package Options
 opt-set-cmake-var EpetraExt_ENABLE_HDF5 BOOL FORCE : OFF

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1567,7 +1567,7 @@ use COMMON_USE-MPI|NO
 opt-set-cmake-var CMAKE_CXX_STANDARD             STRING FORCE : 17
 opt-set-cmake-var Trilinos_ENABLE_Fortran OFF    BOOL         : OFF
 opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE BOOL         : ON
-opt-set-cmake-var CMAKE_CXX_FLAGS                STRING       : -Wall -Wshadow -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-nonnull-compare -Wno-address -Wno-inline -Wno-unused-but-set-variable -Wno-unused-variable -Wno-unused-label -Werror -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
+opt-set-cmake-var CMAKE_CXX_FLAGS                STRING       : -Wall -Wshadow -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-nonnull-compare -Wno-address -Wno-inline -Wno-unused-but-set-variable -Wno-unused-variable -Wno-unused-label -Werror -Wno-error=shadow -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
 opt-set-cmake-var TPL_ENABLE_ParMETIS            BOOL FORCE   : OFF
 
 use RHEL7_POST
@@ -1596,7 +1596,7 @@ opt-set-cmake-var Tpetra_INST_SERIAL                            BOOL FORCE : ON
 opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                BOOL       : ON
 opt-set-cmake-var CMAKE_CXX_EXTENSIONS                          BOOL       : OFF
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D BOOL       : ON
-opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING     : -fno-strict-aliasing -Wall -Wshadow -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-inline -Wno-nonnull-compare -Wno-address -Werror -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
+opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING     : -fno-strict-aliasing -Wall -Wshadow -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-inline -Wno-nonnull-compare -Wno-address -Werror -Wno-error=shadow -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
 
 use RHEL7_POST
 
@@ -1622,7 +1622,7 @@ opt-set-cmake-var CMAKE_CXX_EXTENSIONS                          BOOL       : OFF
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D BOOL       : ON
 opt-set-cmake-var Trilinos_ENABLE_Moertel                       BOOL       : OFF
 opt-set-cmake-var Trilinos_ENABLE_ShyLU_DDBDDC                  BOOL       : OFF
-opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING     : -fno-strict-aliasing -Wall -Wshadow -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-inline -Wno-nonnull-compare -Wno-address -Werror -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
+opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING     : -fno-strict-aliasing -Wall -Wshadow -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-inline -Wno-nonnull-compare -Wno-address -Werror -Wno-error=shadow -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
 
 use RHEL7_POST
 
@@ -1645,7 +1645,7 @@ opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING       : -
 opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                BOOL         : ON
 opt-set-cmake-var CMAKE_CXX_EXTENSIONS                          BOOL         : OFF
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D BOOL         : ON
-opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING       : -fno-strict-aliasing -Wall -Wshadow -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-inline -Wno-nonnull-compare -Wno-address -Werror -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
+opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING       : -fno-strict-aliasing -Wall -Wshadow -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-inline -Wno-nonnull-compare -Wno-address -Werror -Wno-error=shadow -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
 
 use RHEL7_POST
 


### PR DESCRIPTION
SIERRA builds with shadowing warnings/errors and in the past has been hit with shadowing warnings from Trilinos.  Turn on shadowing errors in Trilinos to try and keep everything cleaner.

User Support Ticket(s) or Story Referenced: [TRILFRAME-376](https://sems-atlassian-son.sandia.gov/jira/browse/TRILFRAME-376)


@trilinos/framework 