### PR TITLE
Teuchos StackedTimer: Fix for repeated reports with different options

### DIFF
--- a/packages/teuchos/comm/src/Teuchos_StackedTimer.cpp
+++ b/packages/teuchos/comm/src/Teuchos_StackedTimer.cpp
@@ -143,6 +143,12 @@ StackedTimer::collectRemoteData(Teuchos::RCP<const Teuchos::Comm<int> > comm, co
     max_.resize(num_names);
     if ( options.output_minmax )
       sum_sq_.resize(num_names);
+    else
+      sum_sq_.resize(0);
+  } else {
+    min_.resize(0);
+    max_.resize(0);
+    sum_sq_.resize(0);
   }
 
   if (options.output_proc_minmax) {


### PR DESCRIPTION
@trilinos/teuchos 

## Motivation
This fixes segfaults when repeatedly exercising stacked timer reports with different options. This can happen when timing summaries are printed to both terminal and Watchr XML.