### PR TITLE
Panzer: remove hard-coded 3d dim in ElemFieldPattern method

### DIFF
--- a/packages/panzer/dof-mgr/src/Panzer_ElemFieldPattern.cpp
+++ b/packages/panzer/dof-mgr/src/Panzer_ElemFieldPattern.cpp
@@ -71,7 +71,7 @@ int ElemFieldPattern::getSubcellCount(int dim) const
 
 const std::vector<int> & ElemFieldPattern::getSubcellIndices(int dim,int cellIndex) const
 {
-   if(dim==3)
+   if(dim==getDimension())
       return ElemIndices_[cellIndex];
    
    // only Elems

--- a/packages/panzer/dof-mgr/test/field_pattern/CMakeLists.txt
+++ b/packages/panzer/dof-mgr/test/field_pattern/CMakeLists.txt
@@ -26,3 +26,9 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   SOURCES tFieldAggPattern_DG.cpp ${UNIT_TEST_DRIVER}
   COMM serial mpi
   )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  tEntityFieldPattern
+  SOURCES tEntityFieldPattern.cpp ${UNIT_TEST_DRIVER}
+  COMM serial mpi
+  )

--- a/packages/panzer/dof-mgr/test/field_pattern/tEntityFieldPattern.cpp
+++ b/packages/panzer/dof-mgr/test/field_pattern/tEntityFieldPattern.cpp
@@ -1,0 +1,222 @@
+// @HEADER
+// ***********************************************************************
+//
+//           Panzer: A partial differential equation assembly
+//       engine for strongly coupled complex multiphysics systems
+//                 Copyright (2011) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Roger P. Pawlowski (rppawlo@sandia.gov) and
+// Eric C. Cyr (eccyr@sandia.gov)
+// ***********************************************************************
+// @HEADER
+
+#include <Teuchos_ConfigDefs.hpp>
+#include <Teuchos_UnitTestHarness.hpp>
+#include <Teuchos_RCP.hpp>
+#include <Teuchos_TimeMonitor.hpp>
+
+#include <string>
+#include <iostream>
+
+#include "Panzer_NodalFieldPattern.hpp"
+#include "Panzer_EdgeFieldPattern.hpp"
+#include "Panzer_FaceFieldPattern.hpp"
+#include "Panzer_ElemFieldPattern.hpp"
+
+using Teuchos::rcp;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::RCP;
+using Teuchos::rcpFromRef;
+
+namespace panzer {
+
+  std::string note = "***   NOTE: UNIT TEST BASED ON SEPT 2010   ***\n"
+    "***   INTREPID AND SHARDS Trilinos-dev     ***\n"
+    "***   DOXYGEN WEBSITE                      ***\n";
+
+  // Nodal FP
+  TEUCHOS_UNIT_TEST(tEntityFieldPattern, node)
+  {
+    using namespace shards;
+    out << note << std::endl;
+
+    auto hexa = CellTopology(getCellTopologyData<Hexahedron<8>>());
+    auto tria = CellTopology(getCellTopologyData<Triangle<6>>());
+    auto line = CellTopology(getCellTopologyData<Line<2>>());
+
+    NodalFieldPattern fp_hexa (hexa);
+    NodalFieldPattern fp_tria (tria);
+    NodalFieldPattern fp_line (line);
+
+    TEST_ASSERT (fp_hexa.getDimension()==3);
+    TEST_ASSERT (fp_tria.getDimension()==2);
+    TEST_ASSERT (fp_line.getDimension()==1);
+
+    // Nodes
+    TEST_ASSERT (fp_hexa.getSubcellIndices(0,0).size()==1);
+    TEST_ASSERT (fp_tria.getSubcellIndices(0,0).size()==1);
+    TEST_ASSERT (fp_line.getSubcellIndices(0,0).size()==1);
+
+    // Edges
+    TEST_ASSERT (fp_hexa.getSubcellIndices(1,0).size()==0);
+    TEST_ASSERT (fp_tria.getSubcellIndices(1,0).size()==0);
+    TEST_ASSERT (fp_line.getSubcellIndices(1,0).size()==0);
+
+    // Faces
+    TEST_ASSERT (fp_hexa.getSubcellIndices(2,0).size()==0);
+    TEST_ASSERT (fp_tria.getSubcellIndices(2,0).size()==0);
+    TEST_ASSERT (fp_line.getSubcellIndices(2,0).size()==0);
+
+    // Volumes
+    TEST_ASSERT (fp_hexa.getSubcellIndices(3,0).size()==0);
+    TEST_ASSERT (fp_tria.getSubcellIndices(3,0).size()==0);
+    TEST_ASSERT (fp_line.getSubcellIndices(3,0).size()==0);
+  }
+
+  // Edge FP
+  TEUCHOS_UNIT_TEST(tEntityFieldPattern, edge)
+  {
+    using namespace shards;
+    out << note << std::endl;
+
+    auto hexa = CellTopology(getCellTopologyData<Hexahedron<8>>());
+    auto tria = CellTopology(getCellTopologyData<Triangle<6>>());
+    auto line = CellTopology(getCellTopologyData<Line<2>>());
+
+    EdgeFieldPattern fp_hexa (hexa);
+    EdgeFieldPattern fp_tria (tria);
+    EdgeFieldPattern fp_line (line);
+
+    TEST_ASSERT (fp_hexa.getDimension()==3);
+    TEST_ASSERT (fp_tria.getDimension()==2);
+    TEST_ASSERT (fp_line.getDimension()==1);
+
+    // Nodes
+    TEST_ASSERT (fp_hexa.getSubcellIndices(0,0).size()==0);
+    TEST_ASSERT (fp_tria.getSubcellIndices(0,0).size()==0);
+    TEST_ASSERT (fp_line.getSubcellIndices(0,0).size()==0);
+
+    // Edges
+    TEST_ASSERT (fp_hexa.getSubcellIndices(1,0).size()==1);
+    TEST_ASSERT (fp_tria.getSubcellIndices(1,0).size()==1);
+    TEST_ASSERT (fp_line.getSubcellIndices(1,0).size()==1);
+
+    // Faces
+    TEST_ASSERT (fp_hexa.getSubcellIndices(2,0).size()==0);
+    TEST_ASSERT (fp_tria.getSubcellIndices(2,0).size()==0);
+    TEST_ASSERT (fp_line.getSubcellIndices(2,0).size()==0);
+
+    // Volumes
+    TEST_ASSERT (fp_hexa.getSubcellIndices(3,0).size()==0);
+    TEST_ASSERT (fp_tria.getSubcellIndices(3,0).size()==0);
+    TEST_ASSERT (fp_line.getSubcellIndices(3,0).size()==0);
+  }
+
+  // Face FP
+  TEUCHOS_UNIT_TEST(tEntityFieldPattern, face)
+  {
+    using namespace shards;
+    out << note << std::endl;
+
+    auto hexa = CellTopology(getCellTopologyData<Hexahedron<8>>());
+    auto tria = CellTopology(getCellTopologyData<Triangle<6>>());
+    auto line = CellTopology(getCellTopologyData<Line<2>>());
+
+    FaceFieldPattern fp_hexa (hexa);
+    FaceFieldPattern fp_tria (tria);
+    FaceFieldPattern fp_line (line);
+
+    TEST_ASSERT (fp_hexa.getDimension()==3);
+    TEST_ASSERT (fp_tria.getDimension()==2);
+    TEST_ASSERT (fp_line.getDimension()==1);
+
+    // Nodes
+    TEST_ASSERT (fp_hexa.getSubcellIndices(0,0).size()==0);
+    TEST_ASSERT (fp_tria.getSubcellIndices(0,0).size()==0);
+    TEST_ASSERT (fp_line.getSubcellIndices(0,0).size()==0);
+
+    // Edges
+    TEST_ASSERT (fp_hexa.getSubcellIndices(1,0).size()==0);
+    TEST_ASSERT (fp_tria.getSubcellIndices(1,0).size()==0);
+    TEST_ASSERT (fp_line.getSubcellIndices(1,0).size()==0);
+
+    // Faces
+    TEST_ASSERT (fp_hexa.getSubcellIndices(2,0).size()==1);
+    TEST_ASSERT (fp_tria.getSubcellIndices(2,0).size()==1);
+    TEST_ASSERT (fp_line.getSubcellIndices(2,0).size()==1);
+
+    // Volumes
+    TEST_ASSERT (fp_hexa.getSubcellIndices(3,0).size()==0);
+    TEST_ASSERT (fp_tria.getSubcellIndices(3,0).size()==0);
+    TEST_ASSERT (fp_line.getSubcellIndices(3,0).size()==0);
+  }
+
+  // Elem FP
+  TEUCHOS_UNIT_TEST(tEntityFieldPattern, elem)
+  {
+    using namespace shards;
+    out << note << std::endl;
+
+    auto hexa = CellTopology(getCellTopologyData<Hexahedron<8>>());
+    auto tria = CellTopology(getCellTopologyData<Triangle<6>>());
+    auto line = CellTopology(getCellTopologyData<Line<2>>());
+
+    ElemFieldPattern fp_hexa (hexa);
+    ElemFieldPattern fp_tria (tria);
+    ElemFieldPattern fp_line (line);
+
+    TEST_ASSERT (fp_hexa.getDimension()==3);
+    TEST_ASSERT (fp_tria.getDimension()==2);
+    TEST_ASSERT (fp_line.getDimension()==1);
+
+    // Nodes
+    TEST_ASSERT (fp_hexa.getSubcellIndices(0,0).size()==0);
+    TEST_ASSERT (fp_tria.getSubcellIndices(0,0).size()==0);
+    TEST_ASSERT (fp_line.getSubcellIndices(0,0).size()==0);
+
+    // Edges
+    TEST_ASSERT (fp_hexa.getSubcellIndices(1,0).size()==0);
+    TEST_ASSERT (fp_tria.getSubcellIndices(1,0).size()==0);
+    TEST_ASSERT (fp_line.getSubcellIndices(1,0).size()==1); // Edge==Element
+
+    // Faces
+    TEST_ASSERT (fp_hexa.getSubcellIndices(2,0).size()==0);
+    TEST_ASSERT (fp_tria.getSubcellIndices(2,0).size()==1); // Face==Element
+    TEST_ASSERT (fp_line.getSubcellIndices(2,0).size()==0);
+
+    // Volumes
+    TEST_ASSERT (fp_hexa.getSubcellIndices(3,0).size()==1);
+    TEST_ASSERT (fp_tria.getSubcellIndices(3,0).size()==0);
+    TEST_ASSERT (fp_line.getSubcellIndices(3,0).size()==0);
+  }
+}


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/panzer 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The class `ElemFieldPattern` was hard-coding `3` in one of its method, as the value for element dimension. This PR changes the check to use `getDimension()`, so that it works for Elem fields in meshes of arbitrary dimension. The behavior is unchanged if the mesh dimension is 3.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
In Albany, we are checking `getSubcellIndices(dim,0).size()` (for `dim=0,...,getDimensions()`), to determine if the field in the mesh is a NODE or ELEM field. With the current master, on (n<=2)-dimensional elements, ElemFieldPattern shows no dofs for all `dim`. Things would work correctly if we used a `FaceFieldPattern`, but it'smore concise to always use `ElemFieldPatter` for fields that have one value per cell, regardless of mesh dimension.

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Added a unit test to verify indices counts for basic patterns (Nodal,Edge,Face,Elem).
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->