### PR TITLE
Thyra: ThyraCore depends on Thyra

### DIFF
--- a/packages/thyra/core/cmake/Dependencies.cmake
+++ b/packages/thyra/core/cmake/Dependencies.cmake
@@ -1,4 +1,4 @@
 TRIBITS_PACKAGE_DEFINE_DEPENDENCIES(
   LIB_REQUIRED_PACKAGES TeuchosCore TeuchosParameterList TeuchosComm TeuchosNumerics
-    RTOp
+    RTOp Thyra
   )


### PR DESCRIPTION
@trilinos/thyra @bartlettroscoe 

While trimming down Trilinos package enables and removing the Epetra stack to build MrHyDE (which uses Trilinos as a library), I ran into a strange scenario where it was possible to enable Thyra but other packages wouldn't detect it.

In my case, it was possible to trigger ThyraCore to enable via downstream packages like Panzer, but it did not immediately enable Thyra. Therefore packages such as MueLu would undef HAVE_THYRA macros because `-- NOT setting MueLu_ENABLE_Thyra=ON since Thyra is NOT enabled at this point!`, and then try to build the Stratimikos adapters anyway, which would fail because HAVE_THYRA was false. This fixes the Trilinos build issue.

## Testing
Here's the relevant list of Trilinos packages I was using for my configure:
```
  -D Trilinos_ENABLE_EXPLICIT_INSTANTIATION:BOOL=ON \
  -D Trilinos_ENABLE_INSTALL_CMAKE_CONFIG_FILES:BOOL=ON \
  -D Trilinos_SKIP_FORTRANCINTERFACE_VERIFY_TEST:BOOL=ON \
  -D Trilinos_ENABLE_EXAMPLES:BOOL=OFF \
  -D Trilinos_ENABLE_TESTS:BOOL=OFF \
  -D Trilinos_ENABLE_ALL_PACKAGES:BOOL=OFF \
  -D Trilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=OFF \
  -D Trilinos_ENABLE_Amesos2:BOOL=ON \
  -D Trilinos_ENABLE_Belos:BOOL=ON \
  -D Trilinos_ENABLE_Compadre:BOOL=ON \
  -D Trilinos_ENABLE_Epetra:BOOL=OFF \
  -D Trilinos_ENABLE_MueLu:BOOL=ON \
  -D Trilinos_ENABLE_Pamgen:BOOL=ON \
  -D Trilinos_ENABLE_Panzer:BOOL=ON \
    -D Panzer_ENABLE_PanzerAdaptersSTK:BOOL=ON \
    -D Panzer_ENABLE_TESTS:BOOL=OFF \
    -D Panzer_ENABLE_EXAMPLES:BOOL=OFF \
    -D Panzer_ENABLE_EXPLICIT_INSTANTIATION:BOOL=ON \
  -D Trilinos_ENABLE_ROL:BOOL=ON \
  -D Trilinos_ENABLE_SEACAS:BOOL=ON \
    -D SEACASExodus_ENABLE_MPI:BOOL=OFF \
  -D Trilinos_ENABLE_Shards:BOOL=ON \
  -D Trilinos_ENABLE_STK:BOOL=ON \
    -D STK_ENABLE_TESTS:BOOL=OFF \
  -D Trilinos_ENABLE_Teko:BOOL=OFF \
  -D Trilinos_ENABLE_Teuchos:BOOL=ON \
```

The build corresponding to this package list failed previously, and now it does not fail.