### PR TITLE
Framework: Ignore warnings in pytest tests

### DIFF
--- a/commonTools/framework/CMakeLists.txt
+++ b/commonTools/framework/CMakeLists.txt
@@ -62,7 +62,7 @@ TRIBITS_ADD_ADVANCED_TEST( PullRequestLinuxDriver_UnitTests
         ARGS pr_python_test_driver.sh ${PYTHON_EXECUTABLE} ${PYTHON_PIP_EXECUTABLE}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../packages/framework/pr_tools
         SKIP_CLEAN_WORKING_DIRECTORY
-        PASS_REGULAR_EXPRESSION "=+ [0-9]+ passed in"
+        PASS_REGULAR_EXPRESSION "=+ [0-9]+ passed"
         #ALWAYS_FAIL_ON_NONZERO_RETURN
 )
 # Note: pytest output looks like this:


### PR DESCRIPTION
Can revisit this later, but a new deprecated code warning is blocking PRs now (and manual inspection reveals that it's due to code coverage).  I changed the regex to be a little bit less restrictive (warnings show up after the test passes, so this should allow them to be there).

User Support Ticket(s) or Story Referenced: N/A

@trilinos/framework 

## Motivation
Framework test warnings (and manifested as failures) are blocking all PRs.

## Related Issues
#11435 