### PR TITLE
Enable ccache for SRN PR testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,11 @@ if(CCACHE_PROGRAM)
         set(CMAKE_XCODE_ATTRIBUTE_CXX        "${CMAKE_BINARY_DIR}/launch-cxx")
         set(CMAKE_XCODE_ATTRIBUTE_LD         "${CMAKE_BINARY_DIR}/launch-c")
         set(CMAKE_XCODE_ATTRIBUTE_LDPLUSPLUS "${CMAKE_BINARY_DIR}/launch-cxx")
+    elseif(CMAKE_GENERATOR STREQUAL "Ninja")
+        set(CMAKE_GENERATOR "Unix Makefiles")
+        # Support Unix Makefiles and Ninja
+        set(CMAKE_C_COMPILER_LAUNCHER   "${CMAKE_BINARY_DIR}/launch-c")
+        set(CMAKE_CXX_COMPILER_LAUNCHER "${CMAKE_BINARY_DIR}/launch-cxx")
     else()
         # Support Unix Makefiles and Ninja
         set(CMAKE_C_COMPILER_LAUNCHER   "${CMAKE_BINARY_DIR}/launch-c")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ if(CCACHE_PROGRAM)
         set(CMAKE_CXX_COMPILER_LAUNCHER "${CMAKE_BINARY_DIR}/launch-cxx")
     endif()
 else()
-    message(WARNING "ccache requested but not found")
+    message(FATAL_ERROR "ccache requested but not found")
 endif()
 endif()
 

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -296,7 +296,7 @@
 #------------------------------------------------------------------------------
 
 [COMMON]
-opt-set-cmake-var CMAKE_GENERATOR STRING : Ninja
+opt-set-cmake-var CMAKE_GENERATOR STRING : "Unix Makefiles"
 #opt-set-cmake-var Trilinos_ENABLE_BUILD_STATS BOOL : ON
 
 # LINK_JOBS_LIMIT only has an affect when CMAKE_GENERATOR=Ninja, default to 2

--- a/packages/framework/pr_tools/PullRequestLinuxDriver.sh
+++ b/packages/framework/pr_tools/PullRequestLinuxDriver.sh
@@ -8,6 +8,21 @@ source ${SCRIPTPATH:?}/common.bash
 on_weaver=$(echo "$@" | grep '\-\-on_weaver' &> /dev/null && echo "1")
 on_ats2=$(echo "$@" | grep '\-\-on_ats2' &> /dev/null && echo "1")
 
+# Configure ccache via environment variables
+function configure_ccache() {
+    print_banner "Configuring ccache"
+
+    # Identify the path to the trilinos repository root
+    REPO_ROOT=`readlink -f ${SCRIPTPATH:?}/../..`
+    test -d ${REPO_ROOT:?}/.git || REPO_ROOT=`readlink -f ${WORKSPACE:?}/Trilinos`
+
+    envvar_set_or_create CCACHE_NODISABLE true
+    envvar_set_or_create CCACHE_DIR '/fgs/trilinos/ccache/cache'
+    envvar_set_or_create CCACHE_BASEDIR "$REPO_ROOT"
+    envvar_set_or_create CCACHE_NOHARDLINK true
+    envvar_set_or_create CCACHE_UMASK 077
+    envvar_set_or_create CCACHE_MAXSIZE 100G
+}
 
 # Load the right version of Git / Python based on a regex
 # match to the Jenkins job name.
@@ -36,6 +51,7 @@ function bootstrap_modules() {
         execute_command_checked "module unload sems-archive-python"
         execute_command_checked "module load sems-archive-git/2.10.1"
         execute_command_checked "module load ccache"
+        configure_ccache
 
         envvar_set_or_create     PYTHON_EXE $(which python3)
     fi

--- a/packages/framework/pr_tools/PullRequestLinuxDriver.sh
+++ b/packages/framework/pr_tools/PullRequestLinuxDriver.sh
@@ -50,7 +50,7 @@ function bootstrap_modules() {
         execute_command_checked "module unload sems-archive-git"
         execute_command_checked "module unload sems-archive-python"
         execute_command_checked "module load sems-archive-git/2.10.1"
-        execute_command_checked "module load ccache"
+        execute_command_checked "module load sems-ccache"
         configure_ccache
 
         envvar_set_or_create     PYTHON_EXE $(which python3)

--- a/packages/framework/pr_tools/PullRequestLinuxDriver.sh
+++ b/packages/framework/pr_tools/PullRequestLinuxDriver.sh
@@ -24,7 +24,7 @@ function configure_ccache() {
     envvar_set_or_create CCACHE_MAXSIZE 100G
     envvar_set_or_create CCACHE_DEBUG true
 
-    message_std "PRDriver> " "$(ccache -s)"
+    message_std "PRDriver> " "$(ccache --show-stats --verbose)"
 }
 
 # Load the right version of Git / Python based on a regex

--- a/packages/framework/pr_tools/PullRequestLinuxDriver.sh
+++ b/packages/framework/pr_tools/PullRequestLinuxDriver.sh
@@ -35,6 +35,7 @@ function bootstrap_modules() {
         execute_command_checked "module unload sems-archive-git"
         execute_command_checked "module unload sems-archive-python"
         execute_command_checked "module load sems-archive-git/2.10.1"
+        execute_command_checked "module load ccache"
 
         envvar_set_or_create     PYTHON_EXE $(which python3)
     fi

--- a/packages/framework/pr_tools/PullRequestLinuxDriver.sh
+++ b/packages/framework/pr_tools/PullRequestLinuxDriver.sh
@@ -22,6 +22,9 @@ function configure_ccache() {
     envvar_set_or_create CCACHE_NOHARDLINK true
     envvar_set_or_create CCACHE_UMASK 077
     envvar_set_or_create CCACHE_MAXSIZE 100G
+    envvar_set_or_create CCACHE_DEBUG true
+
+    message_std "PRDriver> " "$(ccache -s)"
 }
 
 # Load the right version of Git / Python based on a regex

--- a/packages/framework/pr_tools/PullRequestLinuxDriverTest.py
+++ b/packages/framework/pr_tools/PullRequestLinuxDriverTest.py
@@ -225,6 +225,12 @@ def parse_args():
                                "based on number_of_available_cores / max_test_parallelism" + \
                                " Default = %(default)s")
 
+    optional.add_argument("--enable-ccache",
+                          dest="ccache_enable",
+                          action="store_true",
+                          default=False,
+                          help="Enable ccache object caching to improve build times. Default = %(default)s")
+
     optional.add_argument("--dry-run",
                           dest="dry_run",
                           action="store_true",
@@ -257,6 +263,7 @@ def parse_args():
     print("| - [R] ctest-drop-site             : {ctest_drop_site}".format(**vars(arguments)))
     print("|")
     print("| - [O] dry-run                     : {dry_run}".format(**vars(arguments)))
+    print("| - [O] enable-ccache               : {ccache_enable}".format(**vars(arguments)))
     print("| - [O] filename-packageenables     : {filename_packageenables}".format(**vars(arguments)))
     print("| - [O] max-cores-allowed           : {max_cores_allowed}".format(**vars(arguments)))
     print("| - [O] num-concurrent-tests        : {num_concurrent_tests}".format(**vars(arguments)))

--- a/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
@@ -15,7 +15,7 @@ from textwrap import dedent
 
 sys.dont_write_bytecode = True
 
-from . import sysinfo
+from .sysinfo import SysInfo
 from LoadEnv.load_env import LoadEnv
 import setenvironment
 
@@ -24,7 +24,7 @@ import setenvironment
 class TrilinosPRConfigurationBase(object):
     """
     Trilinos Pull Request configuration driver. This should be
-    treated as an Abstract Base Class because the `execute()`
+    treated as an Abstract Base Class because the `execute_test()`
     method is implemented as a stub.
 
     Note: Attributes / Properties prefixed with `arg_` come from the
@@ -45,6 +45,7 @@ class TrilinosPRConfigurationBase(object):
             variable set by Jenkins.)
         arg_pr_config_file: The config.ini file that specifies the configuration to load.
         arg_pr_jenkins_job_name: The Jenkins Job Name.
+        arg_ccache_enable: Enable ccache.
         filename_subprojects: The subprojects file.
         working_directory_ctest: Gen. working dir where TFW_testing_single_configure_prototype
             is executed from.
@@ -63,6 +64,7 @@ class TrilinosPRConfigurationBase(object):
     """
     def __init__(self, args):
         self.args                  = args
+        self.load_env_ini_file     = None
         self._config_data          = None
         self._mem_per_core         = None
         self._max_cores_allowed    = None
@@ -276,6 +278,10 @@ class TrilinosPRConfigurationBase(object):
         """
         return self.args.filename_subprojects
 
+    @property
+    def arg_ccache_enable(self):
+        """Is ccache enabled?"""
+        return self.args.ccache_enable
 
     # --------------------
     # P R O P E R T I E S
@@ -399,7 +405,7 @@ class TrilinosPRConfigurationBase(object):
         This is equvalent to running `make -j <concurrency_build>` from the command line.
         """
         if self._concurrency_build is None:
-            si = sysinfo.SysInfo()
+            si = SysInfo()
 
             self._concurrency_build = si.compute_num_usable_cores(req_mem_gb_per_core = self.arg_req_mem_per_core,
                                                                   max_cores_allowed   = self.max_cores_allowed)
@@ -444,6 +450,9 @@ class TrilinosPRConfigurationBase(object):
     # --------------------
     # M E T H O D S
     # --------------------
+
+    def get_formatted_msg(self, msg):
+        pass
 
     def message(self, text, debug_level_override=None):
         """
@@ -686,6 +695,7 @@ class TrilinosPRConfigurationBase(object):
         self.message("--- arg_build_dir               = {}".format(self.arg_build_dir))
         self.message("--- arg_ctest_driver            = {}".format(self.arg_ctest_driver))
         self.message("--- arg_ctest_drop_site         = {}".format(self.arg_ctest_drop_site))
+        self.message("--- arg_ccache_enable           = {}".format(self.arg_ccache_enable))
         self.message("")
         self.message("--- concurrency_build           = {}".format(self.concurrency_build))
         self.message("--- concurrency_test            = {}".format(self.concurrency_test))

--- a/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationBase.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationBase.py
@@ -230,6 +230,7 @@ class TrilinosPRConfigurationTest(unittest.TestCase):
             req_mem_per_core=3.0,
             max_cores_allowed=12,
             num_concurrent_tests=-1,
+            ccache_enable=False,
             dry_run=False
         )
         return output

--- a/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationInstallation.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationInstallation.py
@@ -172,6 +172,7 @@ class TrilinosPRConfigurationInstallationTest(TestCase):
             req_mem_per_core=3.0,
             max_cores_allowed=12,
             num_concurrent_tests=-1,
+            ccache_enable=False,
             dry_run = False
         )
         return output

--- a/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationStandard.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationStandard.py
@@ -169,6 +169,7 @@ class TrilinosPRConfigurationStandardTest(TestCase):
             req_mem_per_core=3.0,
             max_cores_allowed=12,
             num_concurrent_tests=-1,
+            ccache_enable=False,
             dry_run = False
         )
         return output

--- a/packages/framework/pr_tools/unittests/test_PullRequestLinuxDriverTest.py
+++ b/packages/framework/pr_tools/unittests/test_PullRequestLinuxDriverTest.py
@@ -84,6 +84,7 @@ class Test_parse_args(unittest.TestCase):
                                          req_mem_per_core=3.0,
                                          max_cores_allowed=12,
                                          num_concurrent_tests=-1,
+                                         ccache_enable=False,
                                          dry_run=False)
 
         self.default_stdout = dedent('''\
@@ -101,6 +102,7 @@ class Test_parse_args(unittest.TestCase):
                 | - [R] ctest-drop-site             : testing.sandia.gov
                 |
                 | - [O] dry-run                     : False
+                | - [O] enable-ccache               : False
                 | - [O] filename-packageenables     : ../packageEnables.cmake
                 | - [O] max-cores-allowed           : 12
                 | - [O] num-concurrent-tests        : -1
@@ -132,7 +134,8 @@ class Test_parse_args(unittest.TestCase):
                                    [--test-mode TEST_MODE]
                                    [--req-mem-per-core REQ_MEM_PER_CORE]
                                    [--max-cores-allowed MAX_CORES_ALLOWED]
-                                   [--num-concurrent-tests NUM_CONCURRENT_TESTS] [--dry-run]
+                                   [--num-concurrent-tests NUM_CONCURRENT_TESTS]
+                                   [--enable-ccache] [--dry-run]
 
                 Parse the repo and build information
 
@@ -208,6 +211,8 @@ class Test_parse_args(unittest.TestCase):
                                         tests>`. If > 0 then this value is used, otherwise the
                                         value is calculated based on number_of_available_cores
                                         / max_test_parallelism Default = -1
+                  --enable-ccache       Enable ccache object caching to improve build times.
+                                        Default = False
                   --dry-run             Enable dry-run mode. Script will run but not execute
                                         the build steps. Default = False
                 ''')
@@ -232,7 +237,8 @@ class Test_parse_args(unittest.TestCase):
                                    [--test-mode TEST_MODE]
                                    [--req-mem-per-core REQ_MEM_PER_CORE]
                                    [--max-cores-allowed MAX_CORES_ALLOWED]
-                                   [--num-concurrent-tests NUM_CONCURRENT_TESTS] [--dry-run]
+                                   [--num-concurrent-tests NUM_CONCURRENT_TESTS]
+                                   [--enable-ccache] [--dry-run]
                 programName: error: the following arguments are required: --source-repo-url, --source-branch-name, --target-repo-url, --target-branch-name, --pullrequest-build-name, --genconfig-build-name, --pullrequest-number, --jenkins-job-number
                 ''')
 


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/framework 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->


As anyone associated with Trilinos, I want the autotester to be faster.

Use ccache for PR testing.  Ideally, start with the CUDA build, since it takes the longest.

Store the cache at `/fgs/trilinos/ccache/cache`.

This is a follow-up to #11386.

https://sems-atlassian-son.sandia.gov/jira/browse/TRILFRAME-521