### PR TITLE
Adelus: Do not use `Kokkos::Impl::throw_runtime_exception`

### DIFF
--- a/packages/adelus/src/Adelus_factor.hpp
+++ b/packages/adelus/src/Adelus_factor.hpp
@@ -48,6 +48,7 @@
 #define __ADELUS_FACTOR_HPP__
 
 #include <math.h>
+#include <stdexcept>
 #include <stdio.h>
 #include <stdlib.h>
 #include <mpi.h>
@@ -358,7 +359,7 @@ void factor(HandleType& ahandle,           // handle containg metadata
         //return; 
         std::ostringstream os;
         os << "Adelus::factor: rank " << me << " error -- zero pivot found in column "<< j;
-        Kokkos::Impl::throw_runtime_exception (os.str ());
+        throw std::runtime_error (os.str ());
       }
 
       // divide everything including the diagonal by the pivot entry

--- a/packages/adelus/src/BlasWrapper_copy.hpp
+++ b/packages/adelus/src/BlasWrapper_copy.hpp
@@ -47,6 +47,8 @@
 #ifndef BLASWRAPPER_COPY_HPP_
 #define BLASWRAPPER_COPY_HPP_
 
+#include <stdexcept>
+
 #include<BlasWrapper_copy_spec.hpp>
 #include<KokkosKernels_helpers.hpp>
 
@@ -85,7 +87,7 @@ copy (const XMV& X, const YMV& Y)
     os << "BlasWrapper::copy (MV): Dimensions of Y and X do not match: "
        << "Y: " << Y.extent(0) << " x " << Y.extent(1)
        << ", X: " << X.extent(0) << " x " << X.extent(1);
-    Kokkos::Impl::throw_runtime_exception (os.str ());
+    throw std::runtime_error (os.str ());
   }
 
   // Create unmanaged versions of the input Views.  RMV and XMV may be


### PR DESCRIPTION
It is not legal to use `Kokkos::Impl::throw_runtime_exception()`.
Throw `std::runtime_error` instead.

adelus @srajama1
