### PR TITLE
Compadre: Do not define `KOKKOS_*` macros, add `COMPADRE_` prefix

### DIFF
--- a/packages/compadre/src/Compadre_KokkosParser.cpp
+++ b/packages/compadre/src/Compadre_KokkosParser.cpp
@@ -5,7 +5,7 @@ using namespace Compadre;
 // for InitArguments, pass them directly in to Kokkos
 KokkosParser::KokkosParser(KokkosInitArguments args, bool print_status) {
     this->ksg = !Kokkos::is_initialized()
-#ifdef KOKKOS_GREATEREQUAL_3_7
+#ifdef COMPADRE_KOKKOS_GREATEREQUAL_3_7
                 && !Kokkos::is_finalized()
 #endif
                 ?
@@ -16,7 +16,7 @@ KokkosParser::KokkosParser(KokkosInitArguments args, bool print_status) {
 // for command line arguments, pass them directly in to Kokkos
 KokkosParser::KokkosParser(int narg, char* args[], bool print_status) {
     this->ksg = !Kokkos::is_initialized()
-#ifdef KOKKOS_GREATEREQUAL_3_7
+#ifdef COMPADRE_KOKKOS_GREATEREQUAL_3_7
                 && !Kokkos::is_finalized()
 #endif
                 ?
@@ -33,7 +33,7 @@ KokkosParser::KokkosParser(std::vector<std::string> stdvec_args, bool print_stat
     int narg = (int)stdvec_args.size();
 
     this->ksg = !Kokkos::is_initialized()
-#ifdef KOKKOS_GREATEREQUAL_3_7
+#ifdef COMPADRE_KOKKOS_GREATEREQUAL_3_7
                 && !Kokkos::is_finalized()
 #endif
                 ?

--- a/packages/compadre/src/Compadre_Typedefs.hpp
+++ b/packages/compadre/src/Compadre_Typedefs.hpp
@@ -102,14 +102,14 @@ typedef typename pool_type::generator_type generator_type;
 // KOKKOS_VERSION / 100 % 100 is the minor version
 // KOKKOS_VERSION / 10000 is the major version
 #ifdef KOKKOS_VERSION
-  #define KOKKOS_VERSION_MAJOR KOKKOS_VERSION / 10000
-  #define KOKKOS_VERSION_MINOR KOKKOS_VERSION / 100 % 100 
-  #if KOKKOS_VERSION_MAJOR  < 4
-    #if KOKKOS_VERSION_MINOR >= 7
+  #define COMPADRE_KOKKOS_VERSION_MAJOR KOKKOS_VERSION / 10000
+  #define COMPADRE_KOKKOS_VERSION_MINOR KOKKOS_VERSION / 100 % 100
+  #if COMPADRE_KOKKOS_VERSION_MAJOR < 4
+    #if COMPADRE_KOKKOS_VERSION_MINOR >= 7
         using KokkosInitArguments = Kokkos::InitializationSettings;
-        #define KOKKOS_GREATEREQUAL_3_7
+        #define COMPADRE_KOKKOS_GREATEREQUAL_3_7
         constexpr char KOKKOS_THREADS_ARG[] = "--kokkos-num-threads";
-    #elif KOKKOS_VERSION_MINOR < 7
+    #elif COMPADRE_KOKKOS_VERSION_MINOR < 7
         using KokkosInitArguments = Kokkos::InitArguments;
         constexpr char KOKKOS_THREADS_ARG[] = "--kokkos-threads";
     #endif


### PR DESCRIPTION
See https://kokkos.github.io/kokkos-core-wiki/ProgrammingGuide/Compatibility.html#user-defined-macros-compatibility

@kuberry