### PR TITLE
Shards: make Particle topology 0-dimensional

### DIFF
--- a/packages/shards/src/Shards_BasicTopologies.cpp
+++ b/packages/shards/src/Shards_BasicTopologies.cpp
@@ -400,14 +400,20 @@ struct Descriptor<
     };
 };
 
-template<>
+template< unsigned Number_Node , unsigned Number_Vertex>
 struct Descriptor<
-  CellTopologyTraits< 0 , 0 , 0 ,
+  CellTopologyTraits< 0 , Number_Node , Number_Vertex ,
                       TypeListEnd , TypeListEnd ,
                       TypeListEnd , TypeListEnd ,
                       TypeListEnd > >
 {
-  typedef CellTopologyTraits< 0 , 0 , 0 ,
+  // Two cases: Nodes=Vertices=0 for topo=Node, and Nodes=Vertices=1 for topo=Particle
+  static_assert (Number_Node==0 || Number_Node==1,
+      "Invalid number of nodes for 0-dimensional topology.");
+  static_assert (Number_Node==Number_Vertex,
+      "Incompatible number of nodes/vertices for 0-dimensional topology.");
+
+  typedef CellTopologyTraits< 0 , Number_Node , Number_Vertex ,
                               TypeListEnd , TypeListEnd ,
                               TypeListEnd , TypeListEnd ,
                               TypeListEnd > Traits ;
@@ -425,8 +431,8 @@ struct Descriptor<
       top.name              = name ;
       top.key               = Traits::key ;
       top.dimension         = 0 ;
-      top.vertex_count      = 0 ;
-      top.node_count        = 0 ;
+      top.vertex_count      = Number_Vertex ;
+      top.node_count        = Number_Node ;
       top.edge_count        = 0 ;
       top.side_count        = 0 ;
       top.permutation_count = 0 ;

--- a/packages/shards/src/Shards_BasicTopologies.hpp
+++ b/packages/shards/src/Shards_BasicTopologies.hpp
@@ -70,8 +70,8 @@ template<> const CellTopologyData * getCellTopologyData< Node >();
 
 //----------------------------------------------------------------------
 
-/** \brief Topological traits: Dimension = 1, Vertices = 1, Nodes = 1. */
-struct Particle : public CellTopologyTraits<1,1,1>
+/** \brief Topological traits: Dimension = 0, Vertices = 1, Nodes = 1. */
+struct Particle : public CellTopologyTraits<0,1,1>
 {
 #ifndef DOXYGEN_COMPILE
   typedef Particle base ;

--- a/packages/shards/src/Shards_CellTopologyTraits.hpp
+++ b/packages/shards/src/Shards_CellTopologyTraits.hpp
@@ -112,6 +112,7 @@ template< class ListType > struct TypeListHomogeneous ;
 //----------------------------------------------------------------------
 // Self-subcell reference
 
+// Node
 template<>
 struct SubcellTopologyTraits<0,0,0,0,0,0,TypeListEnd,TypeListEnd,
                                          TypeListEnd,TypeListEnd,
@@ -123,6 +124,19 @@ struct SubcellTopologyTraits<0,0,0,0,0,0,TypeListEnd,TypeListEnd,
   enum { homogeneity = true };
 };
 
+// Particle
+template<>
+struct SubcellTopologyTraits<0,0,0,0,1,1,TypeListEnd,TypeListEnd,
+                                         TypeListEnd,TypeListEnd,
+                                         TypeListEnd,IndexList<> >
+{
+  typedef CellTopologyTraits<0,1,1> topology ;
+  enum { count = 1 };
+  enum { node = 0 };  // A Particle has 1 node, and NodeIndex (3rd tmpl arg) is 0, so it's valid
+  enum { homogeneity = true };
+};
+
+// Line
 template< unsigned NodeIndex ,
           unsigned NV , unsigned NN ,
           class EList , class EMaps ,
@@ -136,6 +150,7 @@ struct SubcellTopologyTraits<1,0,NodeIndex, 1,NV,NN,EList,EMaps,FList,FMaps,PMap
   enum { homogeneity = true };
 };
 
+// Face
 template< unsigned NodeIndex ,
           unsigned NV , unsigned NN ,
           class EList , class EMaps ,
@@ -149,6 +164,7 @@ struct SubcellTopologyTraits<2,0,NodeIndex, 2,NV,NN,EList,EMaps,FList,FMaps,PMap
   enum { homogeneity = true };
 };
 
+// Volume
 template< unsigned NodeIndex ,
           unsigned NV , unsigned NN ,
           class EList , class EMaps ,


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/shards 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The fact that a Particle was 1-dimensional created issues when using it as a "cell" topology in Panzer's dof manager stack. Although no Finite Elements can be defined on a Particle, being able to use it allows to avoid treating special cases everywhere, and keep a uniform code.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
Will considerably help Albany to switch to Panzer::DOFManager class(es).

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
No additional tests required. Shards existing tests already cover Particle.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->