### PR TITLE
TRILFRAME-23: Add nightly coverage build

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1530,7 +1530,7 @@ use RHEL7_POST
 [rhel7_sems-gnu-8.3.0-openmpi-1.10.1-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
 use RHEL7_SEMS_COMPILER|GNU
 use NODE-TYPE|SERIAL
-use BUILD-TYPE|DEBUG-COVERAGE-GNU
+use BUILD-TYPE|DEBUG
 use RHEL7_SEMS_LIB-TYPE|SHARED
 use KOKKOS-ARCH|NO-KOKKOS-ARCH
 use RHEL7_SEMS_USE-ASAN|NO_USE-FPIC|NO_USE-MPI|YES_USE-PT|NO
@@ -1557,6 +1557,11 @@ use RHEL7_POST
 
 [rhel7_sems-gnu-8.3.0-openmpi-1.10.1-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
 use rhel7_sems-gnu-8.3.0-openmpi-1.10.1-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
+use PACKAGE-ENABLES|ALL
+
+[rhel7_sems-gnu-8.3.0-openmpi-1.10.1-serial_debug-coverage_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
+use rhel7_sems-gnu-8.3.0-openmpi-1.10.1-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
+use BUILD-TYPE|DEBUG-COVERAGE-GNU
 use PACKAGE-ENABLES|ALL
 
 [rhel7_sems-gnu-8.3.0-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -425,6 +425,12 @@ opt-set-cmake-var Trilinos_ENABLE_STKBalance BOOL FORCE : OFF
 #    `supported-config-flags.ini`.
 #------------------------------------------------------------------------------
 
+#
+# COVERAGE
+#
+
+[COVERAGE]
+opt-set-cmake-var CMAKE_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} --coverage -O0
 
 
 #
@@ -438,6 +444,10 @@ opt-set-cmake-var Trilinos_ENABLE_DEBUG            BOOL   : ON
 # coreKokkos_Array.hpp:152:57: error: array subscript is below array bounds [-Werror=array-bounds]
 opt-set-cmake-var Kokkos_ENABLE_DEBUG_BOUNDS_CHECK BOOL   : OFF
 opt-set-cmake-var Kokkos_ENABLE_DEBUG              BOOL   : ON
+
+[BUILD-TYPE|DEBUG-COVERAGE-GNU]
+use BUILD-TYPE|DEBUG
+use COVERAGE
 
 [BUILD-TYPE|RELEASE]
 opt-set-cmake-var CMAKE_BUILD_TYPE                 STRING : RELEASE
@@ -647,13 +657,13 @@ opt-set-cmake-var Kokkos_ENABLE_SERIAL BOOL       : OFF
 #
 
 [USE-ASAN|YES]
-opt-set-cmake-var CMAKE_CXX_FLAGS           STRING : ${CMAKE_CXX_FLAGS|CMAKE} -g -O1 -fsanitize=address -fno-omit-frame-pointer
+opt-set-cmake-var CMAKE_CXX_FLAGS           STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -g -O1 -fsanitize=address -fno-omit-frame-pointer
 # WARNING: the CMAKE var expansion will fail here if it hasn't been already defined to something
 #          that isn't a CMAKE var in a previously loaded section if generating BASH output.
 #          This is because BASH has no idea what the CMAKE vars are...
 #          This will work fine if generating a CMake fragment file.
-opt-set-cmake-var CMAKE_EXE_LINKER_FLAGS    STRING : -ldl -fsanitize=address ${CMAKE_EXE_LINKER_FLAGS|CMAKE}
-opt-set-cmake-var Trilinos_EXTRA_LINK_FLAGS STRING : -ldl -fsanitize=address ${Trilinos_EXTRA_LINK_FLAGS|CMAKE}
+opt-set-cmake-var CMAKE_EXE_LINKER_FLAGS    STRING FORCE : -ldl -fsanitize=address ${CMAKE_EXE_LINKER_FLAGS|CMAKE}
+opt-set-cmake-var Trilinos_EXTRA_LINK_FLAGS STRING FORCE : -ldl -fsanitize=address ${Trilinos_EXTRA_LINK_FLAGS|CMAKE}
 
 
 [USE-ASAN|NO]
@@ -768,7 +778,6 @@ opt-set-cmake-var Xpetra_ENABLE_DEPRECATED_CODE  BOOL : OFF
 
 [USE-DEPRECATED|YES]
 # Nothing to do here
-
 
 
 #
@@ -963,34 +972,34 @@ opt-set-cmake-var Amesos2_SolverFactory_UnitTests_MPI_4_DISABLE BOOL : ON
 opt-set-cmake-var Amesos2_SuperLU_DIST_Solver_Test_MPI_4_DISABLE BOOL : ON
 opt-set-cmake-var Stratimikos_test_single_amesos2_tpetra_solver_driver_SuperLU_DIST_MPI_1_DISABLE BOOL : ON
 
-#opt-set-cmake-var Anasazi_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
-#opt-set-cmake-var Belos_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
-#opt-set-cmake-var Domi_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
-#opt-set-cmake-var Epetra_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
-#opt-set-cmake-var EpetraExt_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
-#opt-set-cmake-var FEI_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
-#opt-set-cmake-var Ifpack_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
-#opt-set-cmake-var Ifpack2_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
-opt-set-cmake-var Intrepid2_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
-#opt-set-cmake-var Kokkos_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
-#opt-set-cmake-var KokkosKernels_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
-#opt-set-cmake-var ML_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
-#opt-set-cmake-var MueLu_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
-#opt-set-cmake-var NOX_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
-#opt-set-cmake-var Panzer_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
-#opt-set-cmake-var Phalanx_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
-opt-set-cmake-var Pike_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
-#opt-set-cmake-var Piro_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
-#opt-set-cmake-var ROL_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
-#opt-set-cmake-var Sacado_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
-#opt-set-cmake-var SEACAS_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
-#opt-set-cmake-var Shards_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
-#opt-set-cmake-var Stokhos_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
-opt-set-cmake-var Tempus_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
-#opt-set-cmake-var Teuchos_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
-#opt-set-cmake-var Tpetra_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
-#opt-set-cmake-var Triutils_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
-#opt-set-cmake-var Zoltan2_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+#opt-set-cmake-var Anasazi_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+#opt-set-cmake-var Belos_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+#opt-set-cmake-var Domi_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+#opt-set-cmake-var Epetra_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+#opt-set-cmake-var EpetraExt_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+#opt-set-cmake-var FEI_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+#opt-set-cmake-var Ifpack_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+#opt-set-cmake-var Ifpack2_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+opt-set-cmake-var Intrepid2_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+#opt-set-cmake-var Kokkos_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+#opt-set-cmake-var KokkosKernels_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+#opt-set-cmake-var ML_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+#opt-set-cmake-var MueLu_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+#opt-set-cmake-var NOX_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+#opt-set-cmake-var Panzer_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+#opt-set-cmake-var Phalanx_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+opt-set-cmake-var Pike_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+#opt-set-cmake-var Piro_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+#opt-set-cmake-var ROL_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+#opt-set-cmake-var Sacado_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+#opt-set-cmake-var SEACAS_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+#opt-set-cmake-var Shards_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+#opt-set-cmake-var Stokhos_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+opt-set-cmake-var Tempus_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+#opt-set-cmake-var Teuchos_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+#opt-set-cmake-var Tpetra_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+#opt-set-cmake-var Triutils_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+#opt-set-cmake-var Zoltan2_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
 
 [RHEL7_TEST_DISABLES|INTEL-19]
 use RHEL7_TEST_DISABLES|INTEL
@@ -1521,7 +1530,7 @@ use RHEL7_POST
 [rhel7_sems-gnu-8.3.0-openmpi-1.10.1-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
 use RHEL7_SEMS_COMPILER|GNU
 use NODE-TYPE|SERIAL
-use BUILD-TYPE|DEBUG
+use BUILD-TYPE|DEBUG-COVERAGE-GNU
 use RHEL7_SEMS_LIB-TYPE|SHARED
 use KOKKOS-ARCH|NO-KOKKOS-ARCH
 use RHEL7_SEMS_USE-ASAN|NO_USE-FPIC|NO_USE-MPI|YES_USE-PT|NO
@@ -1539,7 +1548,7 @@ opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                         BOOL   
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D          BOOL         : ON
 opt-set-cmake-var KokkosKernels_blas_serial_MPI_1_DISABLE                BOOL         : ON
 opt-set-cmake-var ROL_example_PDE-OPT_helmholtz_example_02_MPI_1_DISABLE BOOL         : ON
-opt-set-cmake-var CMAKE_CXX_FLAGS                                        STRING       : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-nonnull-compare -Wno-address -Wno-inline -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
+opt-set-cmake-var CMAKE_CXX_FLAGS                                        STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-nonnull-compare -Wno-address -Wno-inline -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
 
 # Test failures as of 11-28-22
 opt-set-cmake-var ROL_example_PDE-OPT_navier-stokes_example_01_MPI_4_DISABLE BOOL : ON

--- a/packages/framework/ini-files/supported-config-flags.ini
+++ b/packages/framework/ini-files/supported-config-flags.ini
@@ -134,6 +134,9 @@ build-type:  SELECT_ONE
     # The following option means a release build with debug checking turned on.
     release-debug
 
+    # The following option means a debug build with coverage turned on.
+    debug-coverage
+
 # What kind of libraries to build.
 lib-type:  SELECT_ONE
     static


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/framework

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Prototype code coverage collection via a nightly build:
  - Added the `debug-coverage` option and `rhel7_sems-gnu-8.3.0-openmpi-1.10.1-serial_debug-coverage_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all`
  - See accompanying ctest changes.

Fixed appending `opt-set-cmake-var` commands. CMake cache variables are sticky. If appending in config-specs.ini, use the `FORCE` option. This applies to raw CMake as well.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Manually via our pipeline scripts (pending). See TRILFRAME-23.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->