### PR TITLE
Tpetra, Galeri, Xpetra, MueLu: Changes in preparation for hierarchical matrix work

### DIFF
--- a/packages/galeri/src-xpetra/Galeri_XpetraParameters.hpp
+++ b/packages/galeri/src-xpetra/Galeri_XpetraParameters.hpp
@@ -128,7 +128,7 @@ namespace Galeri {
           nz = pL.get<GO>("nz");
 
         GO numGlobalElements = -1;
-        if (matrixType == "Laplace1D" || matrixType == "Helmholtz1D")
+        if (matrixType == "Laplace1D" || matrixType == "Helmholtz1D" || matrixType == "Identity")
           numGlobalElements = nx;
 
         else if (matrixType == "Laplace2D"    ||

--- a/packages/muelu/src/MueCentral/MueLu_Hierarchy_def.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_Hierarchy_def.hpp
@@ -1234,7 +1234,8 @@ namespace MueLu {
       std::vector<Xpetra::global_size_t> nnzPerLevel;
       std::vector<Xpetra::global_size_t> rowsPerLevel;
       std::vector<int>                   numProcsPerLevel;
-      bool aborted = false;
+      bool someOpsNotMatrices = false;
+      const Xpetra::global_size_t INVALID = Teuchos::OrdinalTraits<Xpetra::global_size_t>::invalid();
       for (int i = 0; i < numLevels; i++) {
         TEUCHOS_TEST_FOR_EXCEPTION(!(Levels_[i]->IsAvailable("A")) , Exceptions::RuntimeError,
                                    "Operator A is not available on level " << i);
@@ -1245,19 +1246,22 @@ namespace MueLu {
 
         RCP<Matrix> Am = rcp_dynamic_cast<Matrix>(A);
         if (Am.is_null()) {
-          GetOStream(Warnings0) << "Some level operators are not matrices, statistics calculation aborted" << std::endl;
-          aborted = true;
-          break;
+          someOpsNotMatrices = true;
+          nnzPerLevel     .push_back(INVALID);
+          rowsPerLevel    .push_back(A->getDomainMap()->getGlobalNumElements());
+          numProcsPerLevel.push_back(A->getDomainMap()->getComm()->getSize());
+        } else {
+          LO storageblocksize=Am->GetStorageBlockSize();
+          Xpetra::global_size_t nnz = Am->getGlobalNumEntries()*storageblocksize*storageblocksize;
+          nnzPerLevel     .push_back(nnz);
+          rowsPerLevel    .push_back(Am->getGlobalNumRows()*storageblocksize);
+          numProcsPerLevel.push_back(Am->getRowMap()->getComm()->getSize());
         }
-
-        LO storageblocksize=Am->GetStorageBlockSize();
-        Xpetra::global_size_t nnz = Am->getGlobalNumEntries()*storageblocksize*storageblocksize;
-        nnzPerLevel     .push_back(nnz);
-        rowsPerLevel    .push_back(Am->getGlobalNumRows()*storageblocksize);
-        numProcsPerLevel.push_back(Am->getRowMap()->getComm()->getSize());
       }
+      if (someOpsNotMatrices)
+        GetOStream(Warnings0) << "Some level operators are not matrices, statistics calculation are incomplete" << std::endl;
 
-      if (!aborted) {
+      {
         std::string label = Levels_[0]->getObjectLabel();
         std::ostringstream oss;
         oss << std::setfill(' ');
@@ -1267,8 +1271,11 @@ namespace MueLu {
         if (verbLevel & Parameters1)
           oss << "Scalar              = " << Teuchos::ScalarTraits<Scalar>::name() << std::endl;
         oss << "Number of levels    = " << numLevels << std::endl;
-        oss << "Operator complexity = " << std::setprecision(2) << std::setiosflags(std::ios::fixed)
-            << GetOperatorComplexity() << std::endl;
+        oss << "Operator complexity = " << std::setprecision(2) << std::setiosflags(std::ios::fixed);
+        if (!someOpsNotMatrices)
+          oss << GetOperatorComplexity() << std::endl;
+        else
+          oss << "not available (Some operators in hierarchy are not matrices.)" << std::endl;
 
         if(smoother_comp!=-1.0) {
           oss << "Smoother complexity = " << std::setprecision(2) << std::setiosflags(std::ios::fixed)
@@ -1291,7 +1298,12 @@ namespace MueLu {
 
         Xpetra::global_size_t tt = rowsPerLevel[0];
         int rowspacer = 2; while (tt != 0) { tt /= 10; rowspacer++; }
-        tt = nnzPerLevel[0];
+        for (size_t i = 0; i < nnzPerLevel.size(); ++i) {
+          tt = nnzPerLevel[i];
+          if (tt != INVALID)
+            break;
+          tt = 100;  // This will get used if all levels are operators.
+        }
         int nnzspacer = 2; while (tt != 0) { tt /= 10; nnzspacer++; }
         tt = numProcsPerLevel[0];
         int npspacer = 2;  while (tt != 0) { tt /= 10; npspacer++; }
@@ -1299,9 +1311,15 @@ namespace MueLu {
         for (size_t i = 0; i < nnzPerLevel.size(); ++i) {
           oss << "  " << i << "  ";
           oss << std::setw(rowspacer) << rowsPerLevel[i];
-          oss << std::setw(nnzspacer) << nnzPerLevel[i];
-          oss << std::setprecision(2) << std::setiosflags(std::ios::fixed);
-          oss << std::setw(9) << as<double>(nnzPerLevel[i]) / rowsPerLevel[i];
+          if (nnzPerLevel[i] != INVALID) {
+            oss << std::setw(nnzspacer) << nnzPerLevel[i];
+            oss << std::setprecision(2) << std::setiosflags(std::ios::fixed);
+            oss << std::setw(9) << as<double>(nnzPerLevel[i]) / rowsPerLevel[i];
+          } else {
+            oss << std::setw(nnzspacer) << "Operator";
+            oss << std::setprecision(2) << std::setiosflags(std::ios::fixed);
+            oss << std::setw(9) << "     ";
+          }
           if (i) oss << std::setw(9) << as<double>(rowsPerLevel[i-1])/rowsPerLevel[i];
           else   oss << std::setw(9) << "     ";
           oss << "    " << std::setw(npspacer) << numProcsPerLevel[i] << std::endl;

--- a/packages/muelu/test/interface/CreateOperator.cpp
+++ b/packages/muelu/test/interface/CreateOperator.cpp
@@ -314,7 +314,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib lib, int arg
 # endif
 #endif
     }
-    clp.setOption("kokkosRefactor", "noKokkosRefactor", &useKokkos, "use kokkos refactor");
+    clp.setOption("useKokkosRefactor", "noKokkosRefactor", &useKokkos, "use kokkos refactor");
 
     switch (clp.parse(argc, argv)) {
       case Teuchos::CommandLineProcessor::PARSE_HELP_PRINTED:        return EXIT_SUCCESS;

--- a/packages/muelu/test/interface/default/Output/MLaux_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLaux_tpetra.gold
@@ -61,6 +61,8 @@ Computing Ac (MueLu::RebalanceAcFactory)
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 smoother -> 
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/MLcoarse1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLcoarse1_tpetra.gold
@@ -1,4 +1,5 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
 smoother -> 
@@ -6,6 +7,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 Build (MueLu::TentativePFactory)
@@ -42,6 +44,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 Build (MueLu::TentativePFactory)
@@ -80,6 +83,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
 Prolongator smoothing (MueLu::SaPFactory)
 Build (MueLu::TentativePFactory)
@@ -116,6 +120,8 @@ Max coarse size (<= 1000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 smoother -> 
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/MLcoarse2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLcoarse2_tpetra.gold
@@ -1,4 +1,5 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
 smoother -> 
@@ -6,6 +7,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 Build (MueLu::TentativePFactory)
@@ -42,6 +44,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 Build (MueLu::TentativePFactory)
@@ -80,6 +83,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
 Prolongator smoothing (MueLu::SaPFactory)
 Build (MueLu::TentativePFactory)
@@ -118,6 +122,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 4
 Prolongator smoothing (MueLu::SaPFactory)
 Build (MueLu::TentativePFactory)
@@ -156,6 +161,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 5
 Prolongator smoothing (MueLu::SaPFactory)
 Build (MueLu::TentativePFactory)
@@ -192,6 +198,8 @@ Max coarse size (<= 100) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 smoother -> 
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/MLcoarse3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLcoarse3_tpetra.gold
@@ -1,4 +1,5 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
 smoother -> 
@@ -6,6 +7,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 Build (MueLu::TentativePFactory)
@@ -42,6 +44,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 Build (MueLu::TentativePFactory)
@@ -80,6 +83,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
 Prolongator smoothing (MueLu::SaPFactory)
 Build (MueLu::TentativePFactory)
@@ -118,6 +122,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 4
 Prolongator smoothing (MueLu::SaPFactory)
 Build (MueLu::TentativePFactory)
@@ -154,6 +159,8 @@ Max coarse size (<= 128) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 smoother -> 
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/MLcoarse5_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLcoarse5_tpetra.gold
@@ -1,4 +1,5 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
 smoother -> 
@@ -6,6 +7,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 Build (MueLu::TentativePFactory)
@@ -42,6 +44,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 Build (MueLu::TentativePFactory)
@@ -78,6 +81,8 @@ Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 postsmoother -> 
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/MLpgamg1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLpgamg1_tpetra.gold
@@ -1,4 +1,5 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
 smoother -> 
@@ -6,6 +7,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
 Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
 Build (MueLu::TentativePFactory)
@@ -41,6 +43,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
 Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
 Build (MueLu::TentativePFactory)
@@ -78,6 +81,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
 Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
 Build (MueLu::TentativePFactory)
@@ -115,6 +119,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 4
 Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
 Build (MueLu::TentativePFactory)
@@ -150,6 +155,8 @@ Max coarse size (<= 128) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 smoother -> 
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/MLrepartitioning1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLrepartitioning1_tpetra.gold
@@ -280,6 +280,8 @@ Max coarse size (<= 100) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 smoother -> 
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/MLrepartitioning2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLrepartitioning2_tpetra.gold
@@ -224,6 +224,8 @@ Computing Ac (MueLu::RebalanceAcFactory)
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 smoother -> 
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/MLrepartitioning3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLrepartitioning3_tpetra.gold
@@ -224,6 +224,8 @@ Computing Ac (MueLu::RebalanceAcFactory)
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 smoother -> 
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/MLsmoother1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLsmoother1_tpetra.gold
@@ -1,4 +1,5 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
 smoother -> 
@@ -6,6 +7,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 Build (MueLu::TentativePFactory)
@@ -42,6 +44,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 Build (MueLu::TentativePFactory)
@@ -80,6 +83,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
 Prolongator smoothing (MueLu::SaPFactory)
 Build (MueLu::TentativePFactory)
@@ -118,6 +122,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 4
 Prolongator smoothing (MueLu::SaPFactory)
 Build (MueLu::TentativePFactory)
@@ -154,6 +159,8 @@ Max coarse size (<= 128) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 smoother -> 
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/MLsmoother2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLsmoother2_tpetra.gold
@@ -1,4 +1,5 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
 presmoother -> 
@@ -6,6 +7,7 @@ presmoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 Build (MueLu::TentativePFactory)
@@ -42,6 +44,7 @@ presmoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 Build (MueLu::TentativePFactory)
@@ -80,6 +83,7 @@ presmoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
 Prolongator smoothing (MueLu::SaPFactory)
 Build (MueLu::TentativePFactory)
@@ -118,6 +122,7 @@ presmoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 4
 Prolongator smoothing (MueLu::SaPFactory)
 Build (MueLu::TentativePFactory)
@@ -154,6 +159,8 @@ Max coarse size (<= 128) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 smoother -> 
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/MLsmoother3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLsmoother3_tpetra.gold
@@ -1,4 +1,5 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
 postsmoother -> 
@@ -6,6 +7,7 @@ postsmoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 Build (MueLu::TentativePFactory)
@@ -42,6 +44,7 @@ postsmoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 Build (MueLu::TentativePFactory)
@@ -80,6 +83,7 @@ postsmoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
 Prolongator smoothing (MueLu::SaPFactory)
 Build (MueLu::TentativePFactory)
@@ -118,6 +122,7 @@ postsmoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 4
 Prolongator smoothing (MueLu::SaPFactory)
 Build (MueLu::TentativePFactory)
@@ -154,6 +159,8 @@ Max coarse size (<= 128) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 smoother -> 
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/MLsmoother4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLsmoother4_tpetra.gold
@@ -1,4 +1,5 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
 smoother -> 
@@ -6,6 +7,7 @@ smoother ->
  chebyshev: ratio eigenvalue = 20
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  chebyshev: boost factor = 1.1   [unused]
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 Build (MueLu::TentativePFactory)
@@ -42,6 +44,7 @@ smoother ->
  chebyshev: ratio eigenvalue = 20
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  chebyshev: boost factor = 1.1   [unused]
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 Build (MueLu::TentativePFactory)
@@ -80,6 +83,7 @@ smoother ->
  chebyshev: ratio eigenvalue = 20
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  chebyshev: boost factor = 1.1   [unused]
+
 Level 3
 Prolongator smoothing (MueLu::SaPFactory)
 Build (MueLu::TentativePFactory)
@@ -118,6 +122,7 @@ smoother ->
  chebyshev: ratio eigenvalue = 20
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  chebyshev: boost factor = 1.1   [unused]
+
 Level 4
 Prolongator smoothing (MueLu::SaPFactory)
 Build (MueLu::TentativePFactory)
@@ -154,6 +159,8 @@ Max coarse size (<= 128) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 smoother -> 
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/MLunsmoothed1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLunsmoothed1_tpetra.gold
@@ -1,4 +1,5 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
 smoother -> 
@@ -6,6 +7,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
 Build (MueLu::TentativePFactory)
 Build (MueLu::UncoupledAggregationFactory)
@@ -38,6 +40,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
 Build (MueLu::TentativePFactory)
 Build (MueLu::UncoupledAggregationFactory)
@@ -72,6 +75,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
 Build (MueLu::TentativePFactory)
 Build (MueLu::UncoupledAggregationFactory)
@@ -106,6 +110,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 4
 Build (MueLu::TentativePFactory)
 Build (MueLu::UncoupledAggregationFactory)
@@ -138,6 +143,8 @@ Max coarse size (<= 128) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 smoother -> 
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/aggregatequalities_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/aggregatequalities_tpetra.gold
@@ -1,10 +1,12 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
 smoother -> 
  relaxation: type = Symmetric Gauss-Seidel
  relaxation: sweeps = 1
  relaxation: damping factor = 1
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -49,6 +51,7 @@ smoother ->
  relaxation: type = Symmetric Gauss-Seidel
  relaxation: sweeps = 1
  relaxation: damping factor = 1
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -91,6 +94,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/aggregation1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/aggregation1_tpetra.gold
@@ -74,6 +74,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/aggregation2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/aggregation2_tpetra.gold
@@ -70,6 +70,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/aggregation3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/aggregation3_tpetra.gold
@@ -80,6 +80,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/aggregation4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/aggregation4_tpetra.gold
@@ -86,6 +86,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/aggregation5_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/aggregation5_np4_tpetra.gold
@@ -1,10 +1,12 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
 smoother -> 
  relaxation: type = Symmetric Gauss-Seidel
  relaxation: sweeps = 1
  relaxation: damping factor = 1
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -37,6 +39,7 @@ smoother ->
  relaxation: type = Symmetric Gauss-Seidel
  relaxation: sweeps = 1
  relaxation: damping factor = 1
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -67,6 +70,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/aggregation5_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/aggregation5_tpetra.gold
@@ -1,10 +1,12 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
 smoother -> 
  relaxation: type = Symmetric Gauss-Seidel
  relaxation: sweeps = 1
  relaxation: damping factor = 1
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -37,6 +39,7 @@ smoother ->
  relaxation: type = Symmetric Gauss-Seidel
  relaxation: sweeps = 1
  relaxation: damping factor = 1
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -67,6 +70,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/coarse1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/coarse1_tpetra.gold
@@ -109,6 +109,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 1000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/default_e3d_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/default_e3d_tpetra.gold
@@ -1,9 +1,11 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
 smoother -> 
  chebyshev: ratio eigenvalue = 20
  chebyshev: boost factor = 1.1   [unused]
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -37,6 +39,7 @@ Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
 smoother -> 
  chebyshev: ratio eigenvalue = 20
  chebyshev: boost factor = 1.1   [unused]
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -69,6 +72,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/default_mhd_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/default_mhd_np4_tpetra.gold
@@ -74,6 +74,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/default_mhd_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/default_mhd_tpetra.gold
@@ -1,4 +1,5 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = SCHWARZ})
 smoother -> 
@@ -11,6 +12,7 @@ smoother ->
   fact: absolute threshold = 0   [unused]
   fact: relative threshold = 1   [unused]
   fact: relax value = 0   [unused]
+
 Level 1
 Build (MueLu::TentativePFactory)
 Build (MueLu::UncoupledAggregationFactory)
@@ -45,6 +47,7 @@ smoother ->
   fact: absolute threshold = 0   [unused]
   fact: relative threshold = 1   [unused]
   fact: relax value = 0   [unused]
+
 Level 2
 Build (MueLu::TentativePFactory)
 Build (MueLu::UncoupledAggregationFactory)
@@ -71,6 +74,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/default_p2d_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/default_p2d_tpetra.gold
@@ -1,9 +1,11 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
 smoother -> 
  chebyshev: ratio eigenvalue = 20
  chebyshev: boost factor = 1.1   [unused]
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -37,6 +39,7 @@ Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
 smoother -> 
  chebyshev: ratio eigenvalue = 20
  chebyshev: boost factor = 1.1   [unused]
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -69,6 +72,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/default_p3d_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/default_p3d_tpetra.gold
@@ -1,9 +1,11 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
 smoother -> 
  chebyshev: ratio eigenvalue = 20
  chebyshev: boost factor = 1.1   [unused]
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -37,6 +39,7 @@ Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
 smoother -> 
  chebyshev: ratio eigenvalue = 20
  chebyshev: boost factor = 1.1   [unused]
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -69,6 +72,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/default_pg_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/default_pg_np4_tpetra.gold
@@ -66,6 +66,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/default_pg_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/default_pg_tpetra.gold
@@ -66,6 +66,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/driver_drekar1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar1_np4_tpetra.gold
@@ -206,3 +206,5 @@ Computing Ac (MueLu::RebalanceAcFactory)
 Max coarse size (<= 1000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]

--- a/packages/muelu/test/interface/default/Output/driver_drekar1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar1_tpetra.gold
@@ -181,6 +181,8 @@ Computing Ac (MueLu::RebalanceAcFactory)
 Max coarse size (<= 1000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/driver_drekar2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar2_np4_tpetra.gold
@@ -212,3 +212,5 @@ Computing Ac (MueLu::RebalanceAcFactory)
 Max coarse size (<= 1000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]

--- a/packages/muelu/test/interface/default/Output/driver_drekar2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar2_tpetra.gold
@@ -187,6 +187,8 @@ Computing Ac (MueLu::RebalanceAcFactory)
 Max coarse size (<= 1000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/emin1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/emin1_tpetra.gold
@@ -80,6 +80,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/emin2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/emin2_tpetra.gold
@@ -84,6 +84,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/emin3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/emin3_tpetra.gold
@@ -84,6 +84,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/empty_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/empty_tpetra.gold
@@ -1,10 +1,12 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
 smoother -> 
  relaxation: type = Symmetric Gauss-Seidel
  relaxation: sweeps = 1
  relaxation: damping factor = 1
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -39,6 +41,7 @@ smoother ->
  relaxation: type = Symmetric Gauss-Seidel
  relaxation: sweeps = 1
  relaxation: damping factor = 1
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -71,6 +74,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/notay_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/notay_tpetra.gold
@@ -1,10 +1,12 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
 smoother -> 
  relaxation: type = Symmetric Gauss-Seidel
  relaxation: sweeps = 1
  relaxation: damping factor = 1
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -57,6 +59,8 @@ matrixmatrix: kernel params ->
  [empty list]
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/operator_solve_1_np1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_1_np1_tpetra.gold
@@ -1,10 +1,12 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
 smoother -> 
  relaxation: type = Symmetric Gauss-Seidel
  relaxation: sweeps = 1
  relaxation: damping factor = 1
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -39,6 +41,7 @@ smoother ->
  relaxation: type = Symmetric Gauss-Seidel
  relaxation: sweeps = 1
  relaxation: damping factor = 1
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -73,6 +76,7 @@ smoother ->
  relaxation: type = Symmetric Gauss-Seidel
  relaxation: sweeps = 1
  relaxation: damping factor = 1
+
 Level 3
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -105,6 +109,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 100) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/operator_solve_1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_1_np4_tpetra.gold
@@ -1,10 +1,12 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
 smoother -> 
  relaxation: type = Symmetric Gauss-Seidel
  relaxation: sweeps = 1
  relaxation: damping factor = 1
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -39,6 +41,7 @@ smoother ->
  relaxation: type = Symmetric Gauss-Seidel
  relaxation: sweeps = 1
  relaxation: damping factor = 1
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -73,6 +76,7 @@ smoother ->
  relaxation: type = Symmetric Gauss-Seidel
  relaxation: sweeps = 1
  relaxation: damping factor = 1
+
 Level 3
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -105,6 +109,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 100) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/operator_solve_5_np1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_5_np1_tpetra.gold
@@ -1,10 +1,12 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
 smoother -> 
  relaxation: type = Symmetric Gauss-Seidel
  relaxation: sweeps = 1
  relaxation: damping factor = 1
+
 Level 1
 Computing Ac (MueLu::RAPFactory)
 matrixmatrix: kernel params -> 
@@ -14,6 +16,7 @@ smoother ->
  relaxation: type = Symmetric Gauss-Seidel
  relaxation: sweeps = 1
  relaxation: damping factor = 1
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -46,6 +49,7 @@ smoother ->
  relaxation: type = Symmetric Gauss-Seidel
  relaxation: sweeps = 1
  relaxation: damping factor = 1
+
 Level 3
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -78,6 +82,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 100) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/operator_solve_5_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_5_np4_tpetra.gold
@@ -1,10 +1,12 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
 smoother -> 
  relaxation: type = Symmetric Gauss-Seidel
  relaxation: sweeps = 1
  relaxation: damping factor = 1
+
 Level 1
 Computing Ac (MueLu::RAPFactory)
 matrixmatrix: kernel params -> 
@@ -14,6 +16,7 @@ smoother ->
  relaxation: type = Symmetric Gauss-Seidel
  relaxation: sweeps = 1
  relaxation: damping factor = 1
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -46,6 +49,7 @@ smoother ->
  relaxation: type = Symmetric Gauss-Seidel
  relaxation: sweeps = 1
  relaxation: damping factor = 1
+
 Level 3
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -78,6 +82,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 100) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/operator_solve_6_np1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_6_np1_tpetra.gold
@@ -1,10 +1,12 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
 smoother -> 
  relaxation: type = Symmetric Gauss-Seidel
  relaxation: sweeps = 1
  relaxation: damping factor = 1
+
 Level 1
 Transpose P (MueLu::TransPFactory)
 matrixmatrix: kernel params -> 
@@ -18,6 +20,7 @@ smoother ->
  relaxation: type = Symmetric Gauss-Seidel
  relaxation: sweeps = 1
  relaxation: damping factor = 1
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -51,6 +54,7 @@ smoother ->
  relaxation: type = Symmetric Gauss-Seidel
  relaxation: sweeps = 1
  relaxation: damping factor = 1
+
 Level 3
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -83,6 +87,8 @@ matrixmatrix: kernel params ->
  [empty list]
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/operator_solve_6_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_6_np4_tpetra.gold
@@ -1,10 +1,12 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
 smoother -> 
  relaxation: type = Symmetric Gauss-Seidel
  relaxation: sweeps = 1
  relaxation: damping factor = 1
+
 Level 1
 Transpose P (MueLu::TransPFactory)
 matrixmatrix: kernel params -> 
@@ -18,6 +20,7 @@ smoother ->
  relaxation: type = Symmetric Gauss-Seidel
  relaxation: sweeps = 1
  relaxation: damping factor = 1
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -51,6 +54,7 @@ smoother ->
  relaxation: type = Symmetric Gauss-Seidel
  relaxation: sweeps = 1
  relaxation: damping factor = 1
+
 Level 3
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -83,6 +87,8 @@ matrixmatrix: kernel params ->
  [empty list]
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/operator_solve_7_np1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_7_np1_tpetra.gold
@@ -1,10 +1,12 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
 smoother -> 
  relaxation: type = Symmetric Gauss-Seidel
  relaxation: sweeps = 1
  relaxation: damping factor = 1
+
 Level 1
 Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 1
@@ -12,6 +14,8 @@ matrixmatrix: kernel params ->
  [empty list]
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/operator_solve_7_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_7_np4_tpetra.gold
@@ -1,10 +1,12 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
 smoother -> 
  relaxation: type = Symmetric Gauss-Seidel
  relaxation: sweeps = 1
  relaxation: damping factor = 1
+
 Level 1
 Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 1
@@ -12,6 +14,8 @@ matrixmatrix: kernel params ->
  [empty list]
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/pg1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/pg1_tpetra.gold
@@ -70,6 +70,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/pg2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/pg2_tpetra.gold
@@ -70,6 +70,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/repartition1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition1_np4_tpetra.gold
@@ -125,3 +125,5 @@ Smoother (level 2) post : no smoother
 
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]

--- a/packages/muelu/test/interface/default/Output/repartition1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition1_tpetra.gold
@@ -104,6 +104,8 @@ Computing Ac (MueLu::RebalanceAcFactory)
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/repartition3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition3_np4_tpetra.gold
@@ -107,6 +107,8 @@ Replacing maps with a subcommunicator
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/repartition3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition3_tpetra.gold
@@ -106,6 +106,8 @@ Computing Ac (MueLu::RebalanceAcFactory)
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/repartition4_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition4_np4_tpetra.gold
@@ -114,6 +114,8 @@ repartition: use subcommunicators = 0
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/repartition4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition4_tpetra.gold
@@ -114,6 +114,8 @@ repartition: use subcommunicators = 0   [unused]
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/reuse-RAP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RAP-1_np4_tpetra.gold
@@ -164,3 +164,5 @@ Smoother (level 2) post : no smoother
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 keep smoother data = 1
 presmoother -> 
+ Amesos2 -> 
+  [empty list]

--- a/packages/muelu/test/interface/default/Output/reuse-RAP-1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RAP-1_tpetra.gold
@@ -111,6 +111,8 @@ Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 keep smoother data = 1
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/reuse-RAP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RAP-2_np4_tpetra.gold
@@ -154,3 +154,5 @@ Smoother (level 2) post : no smoother
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 keep smoother data = 1
 presmoother -> 
+ Amesos2 -> 
+  [empty list]

--- a/packages/muelu/test/interface/default/Output/reuse-RAP-2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RAP-2_tpetra.gold
@@ -99,6 +99,8 @@ Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 keep smoother data = 1
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/reuse-RP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RP-2_np4_tpetra.gold
@@ -191,6 +191,8 @@ Smoother (level 2) post : no smoother
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 keep smoother data = 1
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 Build (MueLu::RebalanceTransferFactory)
 Using original prolongator
 repartition: rebalance P and R = 0
@@ -210,3 +212,5 @@ Replacing maps with a subcommunicator
 Setup Smoother (<Direct> solver interface)
 keep smoother data = 1
 presmoother -> 
+ Amesos2 -> 
+  [empty list]

--- a/packages/muelu/test/interface/default/Output/reuse-RP-2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RP-2_tpetra.gold
@@ -99,6 +99,8 @@ Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 keep smoother data = 1
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -172,6 +174,8 @@ matrixmatrix: kernel params ->
 Setup Smoother (<Direct> solver interface)
 keep smoother data = 1
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/reuse-S-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-S-1_np4_tpetra.gold
@@ -259,6 +259,8 @@ Smoother (level 2) post : no smoother
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 keep smoother data = 1
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 Build (MueLu::RebalanceTransferFactory)
 Build (MueLu::RepartitionFactory)
 Computing Ac (MueLu::RAPFactory)
@@ -290,3 +292,5 @@ Replacing maps with a subcommunicator
 Setup Smoother (<Direct> solver interface)
 keep smoother data = 1
 presmoother -> 
+ Amesos2 -> 
+  [empty list]

--- a/packages/muelu/test/interface/default/Output/reuse-S-1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-S-1_tpetra.gold
@@ -111,6 +111,8 @@ Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 keep smoother data = 1
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -244,6 +246,8 @@ Computing Ac (MueLu::RebalanceAcFactory)
 Setup Smoother (<Direct> solver interface)
 keep smoother data = 1
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/reuse-full-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-full-1_np4_tpetra.gold
@@ -158,3 +158,5 @@ Smoother (level 2) post : no smoother
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 keep smoother data = 1
 presmoother -> 
+ Amesos2 -> 
+  [empty list]

--- a/packages/muelu/test/interface/default/Output/reuse-full-1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-full-1_tpetra.gold
@@ -111,6 +111,8 @@ Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 keep smoother data = 1
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/reuse-none_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-none_np4_tpetra.gold
@@ -250,6 +250,8 @@ Smoother (level 2) post : no smoother
 
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 Build (MueLu::RebalanceTransferFactory)
 Build (MueLu::RepartitionFactory)
 Computing Ac (MueLu::RAPFactory)
@@ -280,3 +282,5 @@ Computing Ac (MueLu::RebalanceAcFactory)
 Replacing maps with a subcommunicator
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]

--- a/packages/muelu/test/interface/default/Output/reuse-none_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-none_tpetra.gold
@@ -104,6 +104,8 @@ Computing Ac (MueLu::RebalanceAcFactory)
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -230,6 +232,8 @@ type = Restriction
 Computing Ac (MueLu::RebalanceAcFactory)
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/reuse-tP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-1_np4_tpetra.gold
@@ -237,6 +237,8 @@ Smoother (level 2) post : no smoother
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 keep smoother data = 1
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 Reusing previous AP data
@@ -266,3 +268,5 @@ Replacing maps with a subcommunicator
 Setup Smoother (<Direct> solver interface)
 keep smoother data = 1
 presmoother -> 
+ Amesos2 -> 
+  [empty list]

--- a/packages/muelu/test/interface/default/Output/reuse-tP-1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-1_tpetra.gold
@@ -111,6 +111,8 @@ Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 keep smoother data = 1
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -218,6 +220,8 @@ matrixmatrix: kernel params ->
 Setup Smoother (<Direct> solver interface)
 keep smoother data = 1
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/reuse-tP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-2_np4_tpetra.gold
@@ -252,6 +252,8 @@ Smoother (level 2) post : no smoother
 
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 Build (MueLu::RebalanceTransferFactory)
 Build (MueLu::RepartitionFactory)
 Computing Ac (MueLu::RAPFactory)
@@ -284,3 +286,5 @@ Computing Ac (MueLu::RebalanceAcFactory)
 Replacing maps with a subcommunicator
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]

--- a/packages/muelu/test/interface/default/Output/reuse-tP-2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-2_tpetra.gold
@@ -113,6 +113,8 @@ Computing Ac (MueLu::RebalanceAcFactory)
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -232,6 +234,8 @@ type = Restriction
 Computing Ac (MueLu::RebalanceAcFactory)
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/reuse-tP-3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-3_np4_tpetra.gold
@@ -247,6 +247,8 @@ Smoother (level 2) post : no smoother
 
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 Build (MueLu::RebalanceTransferFactory)
 Build (MueLu::RepartitionFactory)
 Computing Ac (MueLu::RAPFactory)
@@ -279,3 +281,5 @@ Computing Ac (MueLu::RebalanceAcFactory)
 Replacing maps with a subcommunicator
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]

--- a/packages/muelu/test/interface/default/Output/reuse-tP-3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-3_tpetra.gold
@@ -109,6 +109,8 @@ Computing Ac (MueLu::RebalanceAcFactory)
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -227,6 +229,8 @@ type = Restriction
 Computing Ac (MueLu::RebalanceAcFactory)
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/smoother10_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother10_tpetra.gold
@@ -1,8 +1,10 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
 smoother -> 
  relaxation: sweeps = 3
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -35,6 +37,7 @@ matrixmatrix: kernel params ->
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
 smoother -> 
  relaxation: sweeps = 3
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -67,6 +70,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/smoother11_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother11_tpetra.gold
@@ -1,4 +1,5 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
 smoother -> 
@@ -6,6 +7,7 @@ smoother ->
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
 smoother -> 
  relaxation: sweeps = 0
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -41,6 +43,7 @@ smoother ->
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
 smoother -> 
  relaxation: sweeps = 0
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -73,6 +76,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/smoother12_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother12_tpetra.gold
@@ -1,9 +1,11 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
 smoother -> 
  chebyshev: ratio eigenvalue = 2
  chebyshev: boost factor = 1.1   [unused]
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -37,6 +39,7 @@ Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
 smoother -> 
  chebyshev: ratio eigenvalue = 5
  chebyshev: boost factor = 1.1   [unused]
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -70,6 +73,7 @@ Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
 smoother -> 
  chebyshev: ratio eigenvalue = 4
  chebyshev: boost factor = 1.1   [unused]
+
 Level 3
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -103,6 +107,7 @@ Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
 smoother -> 
  chebyshev: ratio eigenvalue = 2.99461
  chebyshev: boost factor = 1.1   [unused]
+
 Level 4
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -136,6 +141,7 @@ Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
 smoother -> 
  chebyshev: ratio eigenvalue = 2.99194
  chebyshev: boost factor = 1.1   [unused]
+
 Level 5
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -168,6 +174,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 100) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/smoother13_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother13_tpetra.gold
@@ -1,4 +1,5 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
 smoother -> 
@@ -7,6 +8,7 @@ smoother ->
 Setup Smoother (MueLu::Ifpack2Smoother{type = RILUK})
 smoother -> 
  [empty list]
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -43,6 +45,7 @@ smoother ->
 Setup Smoother (MueLu::Ifpack2Smoother{type = RILUK})
 smoother -> 
  [empty list]
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -75,6 +78,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/smoother1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother1_tpetra.gold
@@ -1,10 +1,12 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
 smoother -> 
  relaxation: type = Symmetric Gauss-Seidel
  relaxation: sweeps = 1
  relaxation: damping factor = 1
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -39,6 +41,7 @@ smoother ->
  relaxation: type = Symmetric Gauss-Seidel
  relaxation: sweeps = 1
  relaxation: damping factor = 1
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -71,6 +74,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/smoother2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother2_tpetra.gold
@@ -1,10 +1,12 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
 smoother -> 
  relaxation: type = Symmetric Gauss-Seidel
  relaxation: sweeps = 1
  relaxation: damping factor = 1
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -39,6 +41,7 @@ smoother ->
  relaxation: type = Symmetric Gauss-Seidel
  relaxation: sweeps = 1
  relaxation: damping factor = 1
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -71,6 +74,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/smoother3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother3_tpetra.gold
@@ -1,10 +1,12 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
 smoother -> 
  relaxation: type = Symmetric Gauss-Seidel
  relaxation: sweeps = 1
  relaxation: damping factor = 1
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -39,6 +41,7 @@ smoother ->
  relaxation: type = Symmetric Gauss-Seidel
  relaxation: sweeps = 1
  relaxation: damping factor = 1
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -71,6 +74,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/smoother4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother4_tpetra.gold
@@ -1,5 +1,7 @@
 Clearing old data (if any)
+
 Level 0
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -29,6 +31,7 @@ matrixmatrix: kernel params ->
 Computing Ac (MueLu::RAPFactory)
 matrixmatrix: kernel params -> 
  [empty list]
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -61,6 +64,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/smoother5_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother5_tpetra.gold
@@ -1,9 +1,11 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
 smoother -> 
  chebyshev: ratio eigenvalue = 20
  chebyshev: boost factor = 1.1   [unused]
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -37,6 +39,7 @@ Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
 smoother -> 
  chebyshev: ratio eigenvalue = 20
  chebyshev: boost factor = 1.1   [unused]
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -69,6 +72,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/smoother6_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother6_tpetra.gold
@@ -1,8 +1,10 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
 smoother -> 
  [empty list]
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -35,6 +37,7 @@ matrixmatrix: kernel params ->
 Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
 smoother -> 
  [empty list]
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -67,6 +70,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/smoother9_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother9_tpetra.gold
@@ -1,4 +1,5 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
 smoother -> 
@@ -7,6 +8,7 @@ smoother ->
 Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
 smoother -> 
  [empty list]
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -43,6 +45,7 @@ smoother ->
 Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
 smoother -> 
  [empty list]
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -75,6 +78,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/sync1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/sync1_tpetra.gold
@@ -1,10 +1,12 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
 smoother -> 
  relaxation: type = Symmetric Gauss-Seidel
  relaxation: sweeps = 1
  relaxation: damping factor = 1
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -39,6 +41,7 @@ smoother ->
  relaxation: type = Symmetric Gauss-Seidel
  relaxation: sweeps = 1
  relaxation: damping factor = 1
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -71,6 +74,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/transpose1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose1_tpetra.gold
@@ -1,10 +1,12 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
 smoother -> 
  relaxation: type = Symmetric Gauss-Seidel
  relaxation: sweeps = 1
  relaxation: damping factor = 1
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -37,6 +39,7 @@ smoother ->
  relaxation: type = Symmetric Gauss-Seidel
  relaxation: sweeps = 1
  relaxation: damping factor = 1
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -67,6 +70,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/transpose2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose2_np4_tpetra.gold
@@ -115,3 +115,5 @@ Smoother (level 2) post : no smoother
 
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]

--- a/packages/muelu/test/interface/default/Output/transpose2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose2_tpetra.gold
@@ -94,6 +94,8 @@ Computing Ac (MueLu::RebalanceAcFactory)
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/transpose3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose3_np4_tpetra.gold
@@ -117,3 +117,5 @@ Smoother (level 2) post : no smoother
 
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]

--- a/packages/muelu/test/interface/default/Output/transpose3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose3_tpetra.gold
@@ -96,6 +96,8 @@ Computing Ac (MueLu::RebalanceAcFactory)
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/default/Output/unsmoothed1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/unsmoothed1_tpetra.gold
@@ -1,10 +1,12 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
 smoother -> 
  relaxation: type = Symmetric Gauss-Seidel
  relaxation: sweeps = 1
  relaxation: damping factor = 1
+
 Level 1
 Build (MueLu::TentativePFactory)
 Build (MueLu::UncoupledAggregationFactory)
@@ -35,6 +37,7 @@ smoother ->
  relaxation: type = Symmetric Gauss-Seidel
  relaxation: sweeps = 1
  relaxation: damping factor = 1
+
 Level 2
 Build (MueLu::TentativePFactory)
 Build (MueLu::UncoupledAggregationFactory)
@@ -63,6 +66,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/MLaux_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLaux_tpetra.gold
@@ -63,6 +63,8 @@ Computing Ac (MueLu::RebalanceAcFactory)
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 smoother -> 
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse1_tpetra.gold
@@ -1,4 +1,5 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
 smoother -> 
@@ -6,6 +7,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::TentativePFactory_kokkos)
@@ -43,6 +45,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::TentativePFactory_kokkos)
@@ -82,6 +85,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
 Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::TentativePFactory_kokkos)
@@ -119,6 +123,8 @@ Max coarse size (<= 1000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 smoother -> 
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse2_tpetra.gold
@@ -1,4 +1,5 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
 smoother -> 
@@ -6,6 +7,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::TentativePFactory_kokkos)
@@ -43,6 +45,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::TentativePFactory_kokkos)
@@ -82,6 +85,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
 Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::TentativePFactory_kokkos)
@@ -121,6 +125,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 4
 Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::TentativePFactory_kokkos)
@@ -160,6 +165,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 5
 Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::TentativePFactory_kokkos)
@@ -197,6 +203,8 @@ Max coarse size (<= 100) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 smoother -> 
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse3_tpetra.gold
@@ -1,4 +1,5 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
 smoother -> 
@@ -6,6 +7,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::TentativePFactory_kokkos)
@@ -43,6 +45,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::TentativePFactory_kokkos)
@@ -82,6 +85,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
 Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::TentativePFactory_kokkos)
@@ -121,6 +125,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 4
 Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::TentativePFactory_kokkos)
@@ -158,6 +163,8 @@ Max coarse size (<= 128) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 smoother -> 
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse5_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse5_tpetra.gold
@@ -1,4 +1,5 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
 smoother -> 
@@ -6,6 +7,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::TentativePFactory_kokkos)
@@ -43,6 +45,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::TentativePFactory_kokkos)
@@ -80,6 +83,8 @@ Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 postsmoother -> 
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/MLpgamg1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLpgamg1_tpetra.gold
@@ -1,4 +1,5 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
 smoother -> 
@@ -6,6 +7,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
 Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
 Build (MueLu::TentativePFactory_kokkos)
@@ -42,6 +44,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
 Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
 Build (MueLu::TentativePFactory_kokkos)
@@ -80,6 +83,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
 Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
 Build (MueLu::TentativePFactory_kokkos)
@@ -118,6 +122,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 4
 Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
 Build (MueLu::TentativePFactory_kokkos)
@@ -154,6 +159,8 @@ Max coarse size (<= 128) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 smoother -> 
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/MLrepartitioning1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLrepartitioning1_tpetra.gold
@@ -285,6 +285,8 @@ Max coarse size (<= 100) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 smoother -> 
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/MLrepartitioning2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLrepartitioning2_tpetra.gold
@@ -228,6 +228,8 @@ Computing Ac (MueLu::RebalanceAcFactory)
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 smoother -> 
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/MLrepartitioning3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLrepartitioning3_tpetra.gold
@@ -228,6 +228,8 @@ Computing Ac (MueLu::RebalanceAcFactory)
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 smoother -> 
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother1_tpetra.gold
@@ -1,4 +1,5 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
 smoother -> 
@@ -6,6 +7,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::TentativePFactory_kokkos)
@@ -43,6 +45,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::TentativePFactory_kokkos)
@@ -82,6 +85,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
 Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::TentativePFactory_kokkos)
@@ -121,6 +125,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 4
 Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::TentativePFactory_kokkos)
@@ -158,6 +163,8 @@ Max coarse size (<= 128) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 smoother -> 
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother2_tpetra.gold
@@ -1,4 +1,5 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
 presmoother -> 
@@ -6,6 +7,7 @@ presmoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::TentativePFactory_kokkos)
@@ -43,6 +45,7 @@ presmoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::TentativePFactory_kokkos)
@@ -82,6 +85,7 @@ presmoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
 Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::TentativePFactory_kokkos)
@@ -121,6 +125,7 @@ presmoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 4
 Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::TentativePFactory_kokkos)
@@ -158,6 +163,8 @@ Max coarse size (<= 128) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 smoother -> 
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother3_tpetra.gold
@@ -1,4 +1,5 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
 postsmoother -> 
@@ -6,6 +7,7 @@ postsmoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::TentativePFactory_kokkos)
@@ -43,6 +45,7 @@ postsmoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::TentativePFactory_kokkos)
@@ -82,6 +85,7 @@ postsmoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
 Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::TentativePFactory_kokkos)
@@ -121,6 +125,7 @@ postsmoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 4
 Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::TentativePFactory_kokkos)
@@ -158,6 +163,8 @@ Max coarse size (<= 128) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 smoother -> 
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother4_tpetra.gold
@@ -1,4 +1,5 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
 smoother -> 
@@ -6,6 +7,7 @@ smoother ->
  chebyshev: ratio eigenvalue = 20
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  chebyshev: boost factor = 1.1   [unused]
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::TentativePFactory_kokkos)
@@ -43,6 +45,7 @@ smoother ->
  chebyshev: ratio eigenvalue = 20
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  chebyshev: boost factor = 1.1   [unused]
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::TentativePFactory_kokkos)
@@ -82,6 +85,7 @@ smoother ->
  chebyshev: ratio eigenvalue = 20
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  chebyshev: boost factor = 1.1   [unused]
+
 Level 3
 Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::TentativePFactory_kokkos)
@@ -121,6 +125,7 @@ smoother ->
  chebyshev: ratio eigenvalue = 20
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  chebyshev: boost factor = 1.1   [unused]
+
 Level 4
 Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::TentativePFactory_kokkos)
@@ -158,6 +163,8 @@ Max coarse size (<= 128) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 smoother -> 
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/MLunsmoothed1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLunsmoothed1_tpetra.gold
@@ -1,4 +1,5 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
 smoother -> 
@@ -6,6 +7,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
@@ -39,6 +41,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
@@ -74,6 +77,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
@@ -109,6 +113,7 @@ smoother ->
  relaxation: sweeps = 2
  relaxation: damping factor = 1
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 4
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
@@ -142,6 +147,8 @@ Max coarse size (<= 128) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 smoother -> 
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/aggregation1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/aggregation1_tpetra.gold
@@ -70,6 +70,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/aggregation3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/aggregation3_tpetra.gold
@@ -76,6 +76,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/aggregation4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/aggregation4_tpetra.gold
@@ -82,6 +82,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/coarse1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/coarse1_tpetra.gold
@@ -103,6 +103,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 1000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/default_e3d_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_e3d_tpetra.gold
@@ -68,6 +68,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/default_mhd_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_mhd_np4_tpetra.gold
@@ -74,6 +74,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/default_mhd_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_mhd_tpetra.gold
@@ -74,6 +74,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/default_p2d_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_p2d_tpetra.gold
@@ -68,6 +68,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/default_p3d_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_p3d_tpetra.gold
@@ -68,6 +68,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/default_pg_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_pg_np4_tpetra.gold
@@ -66,6 +66,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/default_pg_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_pg_tpetra.gold
@@ -66,6 +66,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar1_np4_tpetra.gold
@@ -200,3 +200,5 @@ Computing Ac (MueLu::RebalanceAcFactory)
 Max coarse size (<= 1000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar1_tpetra.gold
@@ -175,6 +175,8 @@ Computing Ac (MueLu::RebalanceAcFactory)
 Max coarse size (<= 1000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar2_np4_tpetra.gold
@@ -206,3 +206,5 @@ Computing Ac (MueLu::RebalanceAcFactory)
 Max coarse size (<= 1000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar2_tpetra.gold
@@ -181,6 +181,8 @@ Computing Ac (MueLu::RebalanceAcFactory)
 Max coarse size (<= 1000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/emin1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/emin1_tpetra.gold
@@ -76,6 +76,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/emin2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/emin2_tpetra.gold
@@ -80,6 +80,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/emin3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/emin3_tpetra.gold
@@ -80,6 +80,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/empty_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/empty_tpetra.gold
@@ -70,6 +70,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_1_np1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_1_np1_tpetra.gold
@@ -106,6 +106,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 100) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_1_np4_tpetra.gold
@@ -106,6 +106,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 100) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np1_tpetra.gold
@@ -80,6 +80,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 100) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np4_tpetra.gold
@@ -80,6 +80,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 100) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np1_tpetra.gold
@@ -85,6 +85,8 @@ matrixmatrix: kernel params ->
  [empty list]
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np4_tpetra.gold
@@ -85,6 +85,8 @@ matrixmatrix: kernel params ->
  [empty list]
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_7_np1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_7_np1_tpetra.gold
@@ -1,10 +1,12 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
 smoother -> 
  relaxation: type = Symmetric Gauss-Seidel
  relaxation: sweeps = 1
  relaxation: damping factor = 1
+
 Level 1
 Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 1
@@ -12,6 +14,8 @@ matrixmatrix: kernel params ->
  [empty list]
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_7_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_7_np4_tpetra.gold
@@ -1,10 +1,12 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
 smoother -> 
  relaxation: type = Symmetric Gauss-Seidel
  relaxation: sweeps = 1
  relaxation: damping factor = 1
+
 Level 1
 Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 1
@@ -12,6 +14,8 @@ matrixmatrix: kernel params ->
  [empty list]
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/pg1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/pg1_tpetra.gold
@@ -70,6 +70,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/pg2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/pg2_tpetra.gold
@@ -70,6 +70,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/repartition1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition1_np4_tpetra.gold
@@ -121,3 +121,5 @@ Smoother (level 2) post : no smoother
 
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]

--- a/packages/muelu/test/interface/kokkos/Output/repartition1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition1_tpetra.gold
@@ -100,6 +100,8 @@ Computing Ac (MueLu::RebalanceAcFactory)
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/repartition3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition3_np4_tpetra.gold
@@ -103,6 +103,8 @@ Replacing maps with a subcommunicator
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/repartition3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition3_tpetra.gold
@@ -102,6 +102,8 @@ Computing Ac (MueLu::RebalanceAcFactory)
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/repartition4_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition4_np4_tpetra.gold
@@ -110,6 +110,8 @@ repartition: use subcommunicators = 0
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/repartition4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition4_tpetra.gold
@@ -110,6 +110,8 @@ repartition: use subcommunicators = 0   [unused]
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_np4_tpetra.gold
@@ -160,3 +160,5 @@ Smoother (level 2) post : no smoother
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 keep smoother data = 1
 presmoother -> 
+ Amesos2 -> 
+  [empty list]

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_tpetra.gold
@@ -107,6 +107,8 @@ Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 keep smoother data = 1
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_np4_tpetra.gold
@@ -150,3 +150,5 @@ Smoother (level 2) post : no smoother
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 keep smoother data = 1
 presmoother -> 
+ Amesos2 -> 
+  [empty list]

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_tpetra.gold
@@ -95,6 +95,8 @@ Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 keep smoother data = 1
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_np4_tpetra.gold
@@ -187,6 +187,8 @@ Smoother (level 2) post : no smoother
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 keep smoother data = 1
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 Build (MueLu::RebalanceTransferFactory)
 Using original prolongator
 repartition: rebalance P and R = 0
@@ -206,3 +208,5 @@ Replacing maps with a subcommunicator
 Setup Smoother (<Direct> solver interface)
 keep smoother data = 1
 presmoother -> 
+ Amesos2 -> 
+  [empty list]

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_tpetra.gold
@@ -95,6 +95,8 @@ Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 keep smoother data = 1
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -168,6 +170,8 @@ matrixmatrix: kernel params ->
 Setup Smoother (<Direct> solver interface)
 keep smoother data = 1
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/reuse-S-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-S-1_np4_tpetra.gold
@@ -251,6 +251,8 @@ Smoother (level 2) post : no smoother
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 keep smoother data = 1
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 Build (MueLu::RebalanceTransferFactory)
 Build (MueLu::RepartitionFactory)
 Computing Ac (MueLu::RAPFactory)
@@ -282,3 +284,5 @@ Replacing maps with a subcommunicator
 Setup Smoother (<Direct> solver interface)
 keep smoother data = 1
 presmoother -> 
+ Amesos2 -> 
+  [empty list]

--- a/packages/muelu/test/interface/kokkos/Output/reuse-S-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-S-1_tpetra.gold
@@ -107,6 +107,8 @@ Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 keep smoother data = 1
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -236,6 +238,8 @@ Computing Ac (MueLu::RebalanceAcFactory)
 Setup Smoother (<Direct> solver interface)
 keep smoother data = 1
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/reuse-full-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-full-1_np4_tpetra.gold
@@ -154,3 +154,5 @@ Smoother (level 2) post : no smoother
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 keep smoother data = 1
 presmoother -> 
+ Amesos2 -> 
+  [empty list]

--- a/packages/muelu/test/interface/kokkos/Output/reuse-full-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-full-1_tpetra.gold
@@ -107,6 +107,8 @@ Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 keep smoother data = 1
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/reuse-none_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-none_np4_tpetra.gold
@@ -242,6 +242,8 @@ Smoother (level 2) post : no smoother
 
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 Build (MueLu::RebalanceTransferFactory)
 Build (MueLu::RepartitionFactory)
 Computing Ac (MueLu::RAPFactory)
@@ -272,3 +274,5 @@ Computing Ac (MueLu::RebalanceAcFactory)
 Replacing maps with a subcommunicator
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]

--- a/packages/muelu/test/interface/kokkos/Output/reuse-none_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-none_tpetra.gold
@@ -100,6 +100,8 @@ Computing Ac (MueLu::RebalanceAcFactory)
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -222,6 +224,8 @@ type = Restriction
 Computing Ac (MueLu::RebalanceAcFactory)
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_np4_tpetra.gold
@@ -225,6 +225,8 @@ Smoother (level 2) post : no smoother
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 keep smoother data = 1
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory_kokkos)
 matrixmatrix: kernel params -> 
@@ -253,3 +255,5 @@ Replacing maps with a subcommunicator
 Setup Smoother (<Direct> solver interface)
 keep smoother data = 1
 presmoother -> 
+ Amesos2 -> 
+  [empty list]

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_tpetra.gold
@@ -107,6 +107,8 @@ Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 keep smoother data = 1
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -206,6 +208,8 @@ matrixmatrix: kernel params ->
 Setup Smoother (<Direct> solver interface)
 keep smoother data = 1
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_np4_tpetra.gold
@@ -243,6 +243,8 @@ Smoother (level 2) post : no smoother
 
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 Build (MueLu::RebalanceTransferFactory)
 Build (MueLu::RepartitionFactory)
 Computing Ac (MueLu::RAPFactory)
@@ -275,3 +277,5 @@ Computing Ac (MueLu::RebalanceAcFactory)
 Replacing maps with a subcommunicator
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_tpetra.gold
@@ -109,6 +109,8 @@ Computing Ac (MueLu::RebalanceAcFactory)
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -223,6 +225,8 @@ type = Restriction
 Computing Ac (MueLu::RebalanceAcFactory)
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_np4_tpetra.gold
@@ -237,6 +237,8 @@ Smoother (level 2) post : no smoother
 
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 Build (MueLu::RebalanceTransferFactory)
 Build (MueLu::RepartitionFactory)
 Computing Ac (MueLu::RAPFactory)
@@ -269,3 +271,5 @@ Computing Ac (MueLu::RebalanceAcFactory)
 Replacing maps with a subcommunicator
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_tpetra.gold
@@ -105,6 +105,8 @@ Computing Ac (MueLu::RebalanceAcFactory)
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -217,6 +219,8 @@ type = Restriction
 Computing Ac (MueLu::RebalanceAcFactory)
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/smoother10_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother10_tpetra.gold
@@ -66,6 +66,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/smoother11_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother11_tpetra.gold
@@ -72,6 +72,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/smoother12_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother12_tpetra.gold
@@ -164,6 +164,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 100) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/smoother13_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother13_tpetra.gold
@@ -74,6 +74,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/smoother1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother1_tpetra.gold
@@ -70,6 +70,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/smoother2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother2_tpetra.gold
@@ -70,6 +70,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/smoother3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother3_tpetra.gold
@@ -70,6 +70,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/smoother4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother4_tpetra.gold
@@ -60,6 +60,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/smoother5_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother5_tpetra.gold
@@ -68,6 +68,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/smoother6_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother6_tpetra.gold
@@ -66,6 +66,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/smoother9_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother9_tpetra.gold
@@ -74,6 +74,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/sync1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/sync1_tpetra.gold
@@ -70,6 +70,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/transpose1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose1_tpetra.gold
@@ -66,6 +66,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/transpose2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose2_np4_tpetra.gold
@@ -111,3 +111,5 @@ Smoother (level 2) post : no smoother
 
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]

--- a/packages/muelu/test/interface/kokkos/Output/transpose2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose2_tpetra.gold
@@ -90,6 +90,8 @@ Computing Ac (MueLu::RebalanceAcFactory)
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/transpose3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose3_np4_tpetra.gold
@@ -113,3 +113,5 @@ Smoother (level 2) post : no smoother
 
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]

--- a/packages/muelu/test/interface/kokkos/Output/transpose3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose3_tpetra.gold
@@ -92,6 +92,8 @@ Computing Ac (MueLu::RebalanceAcFactory)
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/unsmoothed1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/unsmoothed1_tpetra.gold
@@ -66,6 +66,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/unsmoothed2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/unsmoothed2_tpetra.gold
@@ -68,6 +68,8 @@ matrixmatrix: kernel params ->
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
 presmoother -> 
+ Amesos2 -> 
+  [empty list]
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/scaling/MatrixLoad.hpp
+++ b/packages/muelu/test/scaling/MatrixLoad.hpp
@@ -118,7 +118,7 @@ void MatrixLoad(Teuchos::RCP<const Teuchos::Comm<int> > &comm,  Xpetra::Underlyi
     // Create map and coordinates
     // In the future, we hope to be able to first create a Galeri problem, and then request map and coordinates from it
     // At the moment, however, things are fragile as we hope that the Problem uses same map and coordinates inside
-    if (matrixType == "Laplace1D") {
+    if (matrixType == "Laplace1D" || matrixType == "Identity") {
       map = Galeri::Xpetra::CreateMap<LO, GO, Node>(xpetraParameters.GetLib(), "Cartesian1D", comm, galeriList);
       coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<real_type,LO,GO,Map,RealValuedMultiVector>("1D", map, galeriList);
 

--- a/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.cpp
@@ -55,6 +55,9 @@ DistributorSendTypeEnumToString (EDistributorSendType sendType)
   else if (sendType == DISTRIBUTOR_SEND) {
     return "Send";
   }
+  else if (sendType == DISTRIBUTOR_ALLTOALL) {
+    return "Alltoall";
+  }
   else {
     TEUCHOS_TEST_FOR_EXCEPTION(true, std::invalid_argument, "Invalid "
       "EDistributorSendType enum value " << sendType << ".");
@@ -894,6 +897,7 @@ Teuchos::Array<std::string> distributorSendTypes()
   Teuchos::Array<std::string> sendTypes;
   sendTypes.push_back ("Isend");
   sendTypes.push_back ("Send");
+  sendTypes.push_back ("Alltoall");
   return sendTypes;
 }
 
@@ -911,6 +915,7 @@ DistributorPlan::getValidParameters() const
   Array<Details::EDistributorSendType> sendTypeEnums;
   sendTypeEnums.push_back (Details::DISTRIBUTOR_ISEND);
   sendTypeEnums.push_back (Details::DISTRIBUTOR_SEND);
+  sendTypeEnums.push_back (Details::DISTRIBUTOR_ALLTOALL);
 
   RCP<ParameterList> plist = parameterList ("Tpetra::Distributor");
 

--- a/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.hpp
@@ -55,7 +55,8 @@ namespace Details {
 /// not rely on these values in your code.
 enum EDistributorSendType {
   DISTRIBUTOR_ISEND, // Use MPI_Isend (Teuchos::isend)
-  DISTRIBUTOR_SEND   // Use MPI_Send (Teuchos::send)
+  DISTRIBUTOR_SEND,  // Use MPI_Send (Teuchos::send)
+  DISTRIBUTOR_ALLTOALL // Use MPI_Alltoall
 };
 
 /// \brief Convert an EDistributorSendType enum value to a string.

--- a/packages/tpetra/core/src/Tpetra_Distributor.cpp
+++ b/packages/tpetra/core/src/Tpetra_Distributor.cpp
@@ -61,6 +61,7 @@ namespace Tpetra {
     Teuchos::Array<std::string> sendTypes;
     sendTypes.push_back ("Isend");
     sendTypes.push_back ("Send");
+    sendTypes.push_back ("Alltoall");
     return sendTypes;
   }
 
@@ -194,6 +195,7 @@ namespace Tpetra {
     Array<Details::EDistributorSendType> sendTypeEnums;
     sendTypeEnums.push_back (Details::DISTRIBUTOR_ISEND);
     sendTypeEnums.push_back (Details::DISTRIBUTOR_SEND);
+    sendTypeEnums.push_back (Details::DISTRIBUTOR_ALLTOALL);
 
     RCP<ParameterList> plist = parameterList ("Tpetra::Distributor");
     setStringToIntegralParameter<Details::EDistributorSendType> ("Send type",

--- a/packages/tpetra/core/test/ImportExport2/CMakeLists.txt
+++ b/packages/tpetra/core/test/ImportExport2/CMakeLists.txt
@@ -22,6 +22,15 @@ TRIBITS_ADD_TEST(
   STANDARD_PASS_OUTPUT
   )
 
+TRIBITS_ADD_TEST(
+  ImportExport2_UnitTests
+  NAME ImportExport2_UnitTests_Alltoall
+  COMM serial mpi
+  ARGS "--distributor-send-type=Alltoall --globally-reduce-test-result --output-show-proc-rank --output-to-root-rank-only=-1"
+  STANDARD_PASS_OUTPUT
+  )
+
+
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   AsyncTransfer_UnitTests
   SOURCES


### PR DESCRIPTION
@trilinos/tpetra @trilinos/galeri @trilinos/xpetra @trilinos/muelu 

## Motivation
- Tpetra: Add an "Alltoall" send type and test it. Question: Is it ok to use `MPI_Alltoallv` directly, or should it be added to Teuchos?
- MueLu: Allow passing parameters to Amesos2 coarse solver, print information about non-matrix operators in multigrid summary.
- Galeri, MueLu: Allow to run "Identity" matrix problem. Can be useful for testing edge cases.