### PR TITLE
Tpetra: Fix wrong execution space in CrsGraph

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -378,7 +378,8 @@ namespace Tpetra {
     nc_view_type numAllocPerRowOut ("Tpetra::CrsGraph::numAllocPerRow",
                                     lclNumRows);
     // DEEP_COPY REVIEW - HOST-TO-HOSTMIRROR
-    Kokkos::deep_copy (execution_space(), numAllocPerRowOut, numAllocPerRowIn);
+    using exec_space = typename nc_view_type::execution_space;
+    Kokkos::deep_copy (exec_space(), numAllocPerRowOut, numAllocPerRowIn);
     k_numAllocPerRow_ = numAllocPerRowOut;
 
     resumeFill (params);
@@ -512,7 +513,8 @@ namespace Tpetra {
     nc_view_type numAllocPerRowOut ("Tpetra::CrsGraph::numAllocPerRow",
                                     lclNumRows);
     // DEEP_COPY REVIEW - HOST-TO-HOSTMIRROR
-    Kokkos::deep_copy (execution_space(), numAllocPerRowOut, numAllocPerRowIn);
+    using exec_space = typename nc_view_type::execution_space;
+    Kokkos::deep_copy (exec_space(), numAllocPerRowOut, numAllocPerRowIn);
     k_numAllocPerRow_ = numAllocPerRowOut;
 
     resumeFill (params);


### PR DESCRIPTION
@trilinos/tpetra 

## Motivation
Broken in #11422. Changing back to what it was while avoiding shadow warnings.