### PR TITLE
KokkosKernels: fix MIS2 agg determinism, valgrind

### DIFF
--- a/packages/kokkos-kernels/src/graph/impl/KokkosGraph_Distance1Color_impl.hpp
+++ b/packages/kokkos-kernels/src/graph/impl/KokkosGraph_Distance1Color_impl.hpp
@@ -2299,8 +2299,7 @@ class GraphColor_EB : public GraphColor<HandleType, in_row_index_view_type_,
     color_temp_work_view_type color_ban(
         Kokkos::view_alloc(Kokkos::WithoutInitializing, "color_ban"), this->nv);
     color_temp_work_view_type tentative_color_ban(
-        Kokkos::view_alloc(Kokkos::WithoutInitializing, "tentative_color_ban"),
-        this->nv);  // views are initialized with zero
+        "tentative_color_ban", this->nv);  // views are initialized with zero
     // allocate memory for vertex color set shifts.
     nnz_lno_temp_work_view_t color_set("color_set",
                                        this->nv);  // initialized with zero.

--- a/packages/kokkos-kernels/src/graph/impl/KokkosGraph_Distance2MIS_impl.hpp
+++ b/packages/kokkos-kernels/src/graph/impl/KokkosGraph_Distance2MIS_impl.hpp
@@ -1117,7 +1117,8 @@ struct D2_MIS_Aggregation {
           if (neiAgg == agg) connect++;
         }
         connectivities_(i) = connect;
-      }
+      } else
+        connectivities_(i) = 0;
     }
 
     lno_t numVerts_;
@@ -1224,9 +1225,9 @@ struct D2_MIS_Aggregation {
     // neighboring aggregate.
     labels_t labelsOld("old", numVerts);
     Kokkos::deep_copy(labelsOld, labels);
-    labels_t connectivities("connect", numVerts);
-    labels_t aggSizes(
-        Kokkos::ViewAllocateWithoutInitializing("Phase3 Agg Sizes"), numAggs);
+    labels_t connectivities(Kokkos::ViewAllocateWithoutInitializing("connect"),
+        numVerts);
+    labels_t aggSizes("Phase3 Agg Sizes", numAggs);
     Kokkos::parallel_for(
         range_pol(0, numVerts),
         SizeAndConnectivityFunctor(numVerts, rowmap, entries, labels,


### PR DESCRIPTION
Patch in KokkosKernels #1528 and #1530. 1528 fixed MIS2 aggregation being possibly non-deterministic, and fixed valgrind conditional on uninitialized value warnings. 1530 fixed valgrind warnings in EB D1 coloring.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/kokkos-kernels 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Fixes https://github.com/kokkos/kokkos-kernels/issues/1646 .

The MIS2 changes are a re-application of #11017 . Fixes non-determinism (a real bug) and also valgrind uninitialized value warnings.
The D1 EB changes have been in KokkosKernels develop for a while, but never in Trilinos. There didn't seem to be an actual bug here, but patching this will help make the nightly geminga build with valgrind run cleanly.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->