### PR TITLE
Amesos2: Add row permutation option to SuperLU_dist

### DIFF
--- a/packages/amesos2/src/Amesos2_SolverCore_def.hpp
+++ b/packages/amesos2/src/Amesos2_SolverCore_def.hpp
@@ -108,9 +108,11 @@ SolverCore<ConcreteSolver,Matrix,Vector>::preOrdering()
 
   loadA(PREORDERING);
 
-  static_cast<solver_type*>(this)->preOrdering_impl();
-  ++status_.numPreOrder_;
-  status_.last_phase_ = PREORDERING;
+  int error_code = static_cast<solver_type*>(this)->preOrdering_impl();
+  if (error_code == EXIT_SUCCESS){
+    ++status_.numPreOrder_;
+    status_.last_phase_ = PREORDERING;
+  }
 
   return *this;
 }
@@ -131,9 +133,11 @@ SolverCore<ConcreteSolver,Matrix,Vector>::symbolicFactorization()
     loadA(SYMBFACT);
   }
 
-  static_cast<solver_type*>(this)->symbolicFactorization_impl();
-  ++status_.numSymbolicFact_;
-  status_.last_phase_ = SYMBFACT;
+  int error_code = static_cast<solver_type*>(this)->symbolicFactorization_impl();
+  if (error_code == EXIT_SUCCESS){
+    ++status_.numSymbolicFact_;
+    status_.last_phase_ = SYMBFACT;
+  }
 
   return *this;
 }
@@ -154,9 +158,11 @@ SolverCore<ConcreteSolver,Matrix,Vector>::numericFactorization()
     loadA(NUMFACT);
   }
 
-  static_cast<solver_type*>(this)->numericFactorization_impl();
-  ++status_.numNumericFact_;
-  status_.last_phase_ = NUMFACT;
+  int error_code = static_cast<solver_type*>(this)->numericFactorization_impl();
+  if (error_code == EXIT_SUCCESS){
+    ++status_.numNumericFact_;
+    status_.last_phase_ = NUMFACT;
+  }
 
   return *this;
 }
@@ -217,9 +223,11 @@ SolverCore<ConcreteSolver,Matrix,Vector>::solve(const Teuchos::Ptr<Vector> X,
     const_cast<type&>(*this).numericFactorization();
   }
 
-  static_cast<const solver_type*>(this)->solve_impl(Teuchos::outArg(*x), Teuchos::ptrInArg(*b));
-  ++status_.numSolve_;
-  status_.last_phase_ = SOLVE;
+  int error_code = static_cast<const solver_type*>(this)->solve_impl(Teuchos::outArg(*x), Teuchos::ptrInArg(*b));
+  if (error_code == EXIT_SUCCESS){
+    ++status_.numSolve_;
+    status_.last_phase_ = SOLVE;
+  }
 }
 
 template <template <class,class> class ConcreteSolver, class Matrix, class Vector >

--- a/packages/amesos2/src/Amesos2_Superludist_FunctionMap.hpp
+++ b/packages/amesos2/src/Amesos2_Superludist_FunctionMap.hpp
@@ -525,6 +525,12 @@ namespace Amesos2 {
     {
       SLUD::D::dSolveFinalize(options, solve_struct);
     }
+
+    static int ldperm_dist(int job, int n, SLUD::int_t nnz, SLUD::int_t colptr[], SLUD::int_t adjncy[],
+            double nzval[], SLUD::int_t *perm, double u[], double v[])
+    {
+      return SLUD::D::dldperm_dist(job, n, nnz, colptr, adjncy, nzval, perm, u, v);
+    }
   };
 
 
@@ -785,6 +791,12 @@ namespace Amesos2 {
 			      type_map::SOLVEstruct_t* solve_struct)
     {
       SLUD::Z::zSolveFinalize(options, solve_struct);
+    }
+
+    static int ldperm_dist(int job, int n, SLUD::int_t nnz, SLUD::int_t colptr[], SLUD::int_t adjncy[],
+            SLUD::Z::doublecomplex nzval[], SLUD::int_t *perm, double u[], double v[])
+    {
+      return SLUD::Z::zldperm_dist(job, n, nnz, colptr, adjncy, nzval, perm, u, v);
     }
   };
 #endif	// HAVE_TEUCHOS_COMPLEX

--- a/packages/amesos2/src/Amesos2_Superludist_decl.hpp
+++ b/packages/amesos2/src/Amesos2_Superludist_decl.hpp
@@ -144,6 +144,14 @@ public:
 private:
 
   /**
+   * \brief Compute the row permutation for option LargeDiag-MC64.
+   *
+   * SuperLU_DIST supports several forms of row permutations.  Refer
+   * to \ref slu_mt_options for the available \c RowPerm options.
+   */
+  void computeRowPermutationLargeDiagMC64(SLUD::SuperMatrix& GA);
+
+  /**
    * \brief Performs pre-ordering on the matrix to increase efficiency.
    *
    * SuperLU_DIST supports several forms of column permutations.  Refer
@@ -326,6 +334,7 @@ private:
   /// \c true if this processor is in SuperLU_DISTS's 2D process grid
   bool in_grid_;
   bool same_symbolic_;
+  bool force_symbfact_;
   mutable bool same_solve_struct_; // may be modified in solve_impl, but still `logically const'
 
   /// Maps rows of the matrix to processors in the SuperLU_DIST processor grid

--- a/packages/amesos2/src/Amesos2_Superludist_decl.hpp
+++ b/packages/amesos2/src/Amesos2_Superludist_decl.hpp
@@ -308,6 +308,7 @@ private:
     SLUD::DiagScale_t equed;    ///< Whether/what kind of equilibration to use/has been used
     bool rowequ, colequ;        ///< whether row/col equilibration has been applied to AC
     magnitude_type rowcnd, colcnd, amax;
+    int largediag_mc64_job;     // job id for LargeDiag_MC64 row permutation
   } data_;
 
   // The following Arrays are persisting storage arrays for A, X, and B

--- a/packages/amesos2/src/Amesos2_Superludist_def.hpp
+++ b/packages/amesos2/src/Amesos2_Superludist_def.hpp
@@ -797,12 +797,13 @@ namespace Amesos2 {
       data_.options.ColPerm = getIntegralValue<SLUD::colperm_t>(*parameterList, "ColPerm");
     }
 
-    if( parameterList->isParameter("IterRefine") ){
-      RCP<const ParameterEntryValidator> iter_refine_validator = valid_params->getEntry("IterRefine").validator();
-      parameterList->getEntry("IterRefine").setValidator(iter_refine_validator);
-
-      data_.options.IterRefine = getIntegralValue<SLUD::IterRefine_t>(*parameterList, "IterRefine");
-    }
+    // TODO: Uncomment when supported
+    // if( parameterList->isParameter("IterRefine") ){
+    //   RCP<const ParameterEntryValidator> iter_refine_validator = valid_params->getEntry("IterRefine").validator();
+    //   parameterList->getEntry("IterRefine").setValidator(iter_refine_validator);
+    //   data_.options.IterRefine = getIntegralValue<SLUD::IterRefine_t>(*parameterList, "IterRefine");
+    // }
+    data_.options.IterRefine = SLUD::NOREFINE;
 
     bool replace_tiny = parameterList->get<bool>("ReplaceTinyPivot", true);
     data_.options.ReplaceTinyPivot = replace_tiny ? SLUD::YES : SLUD::NO;
@@ -848,18 +849,18 @@ namespace Amesos2 {
                                                   tuple<SLUD::trans_t>(SLUD::NOTRANS),
                                                   pl.getRawPtr());
 
-      // Equilibration
-      pl->set("Equil", true, "Whether to equilibrate the system before solve");
+      // Equillbration
+      pl->set("Equil", false, "Whether to equilibrate the system before solve");
 
-      // Iterative refinement
-      setStringToIntegralParameter<SLUD::IterRefine_t>("IterRefine", "NOREFINE",
-                                                    "Type of iterative refinement to use",
-                                                    tuple<string>("NOREFINE", "SLU_DOUBLE"),
-                                                    tuple<string>("Do not use iterative refinement",
-                                                                  "Do double iterative refinement"),
-                                                    tuple<SLUD::IterRefine_t>(SLUD::NOREFINE,
-                                                                              SLUD::SLU_DOUBLE),
-                                                    pl.getRawPtr());
+      // TODO: uncomment when supported
+      // setStringToIntegralParameter<SLUD::IterRefine_t>("IterRefine", "NOREFINE",
+      //                                                     "Type of iterative refinement to use",
+      //                                                     tuple<string>("NOREFINE", "DOUBLE"),
+      //                                                     tuple<string>("Do not use iterative refinement",
+      //                                                                   "Do double iterative refinement"),
+      //                                                     tuple<SLUD::IterRefine_t>(SLUD::NOREFINE,
+      //                                                                               SLUD::DOUBLE),
+      //                                                     pl.getRawPtr());
 
       // Tiny pivot handling
       pl->set("ReplaceTinyPivot", true,

--- a/packages/amesos2/src/Amesos2_Superludist_def.hpp
+++ b/packages/amesos2/src/Amesos2_Superludist_def.hpp
@@ -867,7 +867,7 @@ namespace Amesos2 {
               "Specifies whether to replace tiny diagonals during LU factorization");
 
       // Row permutation
-      setStringToIntegralParameter<SLUD::rowperm_t>("RowPerm", "LargeDiag_MC64",
+      setStringToIntegralParameter<SLUD::rowperm_t>("RowPerm", "NOROWPERM",
                                                     "Specifies how to permute the rows of the "
                                                     "matrix for sparsity preservation",
                                                     tuple<string>("NOROWPERM", "LargeDiag_MC64"),


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/amesos2

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Currently the `SuperLU_dist` interface of `Amesos2` allows no row permutation as pre-ordering method. For certain type of matrices a row pre-ordering is a necessary step to be able to factorize the matrix without running into errors. This adds the `LargeDiag_MC64` row permutation option, even though it might be a sequential bottleneck in the algorithm.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes #11469
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
Enhancing the `SuperLU_dist` interface of `Amesos2`

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->

## Additional Information
<!--- 
Anything else we need to know in evaluating this merge request?
 -->
Joint work with @vryy and @mayrmt 

See also #11469.