### PR TITLE
teuchos(fix): add missing move constructors for Teuchos::any and Teuchos::ParameterEntry

### DIFF
--- a/packages/teuchos/parameterlist/src/Teuchos_ParameterEntry.cpp
+++ b/packages/teuchos/parameterlist/src/Teuchos_ParameterEntry.cpp
@@ -74,6 +74,27 @@ ParameterEntry& ParameterEntry::operator=(const ParameterEntry& source)
   return *this;
 }
 
+ParameterEntry::ParameterEntry(ParameterEntry&& other)
+  : val_(std::move(other.val_)),
+    isUsed_(other.isUsed_),
+    isDefault_(other.isDefault_),
+    docString_(std::move(other.docString_)),
+    validator_(std::move(other.validator_))
+{}
+
+ParameterEntry& ParameterEntry::operator=(ParameterEntry&& other)
+{
+  if(this != &other)
+  {
+    this->val_ = std::move(other.val_);
+    this->isUsed_ = other.isUsed_;
+    this->isDefault_ = other.isDefault_;
+    this->docString_ = std::move(other.docString_);
+    this->validator_ = std::move(other.validator_);
+  }
+  return *this;
+}
+
 void ParameterEntry::setAnyValue(
   const any &value_in, bool isDefault_in
   )
@@ -114,7 +135,7 @@ ParameterList& ParameterEntry::setList(
 
 bool ParameterEntry::isList() const
 {
-  return ( val_.empty() ? false : val_.type() == typeid(ParameterList) );
+  return ( !val_.has_value() ? false : val_.type() == typeid(ParameterList) );
 }
 
 std::ostream& ParameterEntry::leftshift(std::ostream& os, bool printFlags) const

--- a/packages/teuchos/parameterlist/src/Teuchos_ParameterEntry.hpp
+++ b/packages/teuchos/parameterlist/src/Teuchos_ParameterEntry.hpp
@@ -85,10 +85,13 @@ public:
   //! Copy constructor
   ParameterEntry(const ParameterEntry& source);
 
+  //! Move constructor.
+  ParameterEntry(ParameterEntry&& other);
+
   //! Templated constructor
   template<typename T>
   explicit ParameterEntry(
-    T value, bool isDefault = false, bool isList = false,
+    T&& value, bool isDefault = false, bool isList = false,
     const std::string &docString = "",
     RCP<const ParameterEntryValidator> const& validator = null
     );
@@ -100,6 +103,9 @@ public:
 
   //! Replace the current parameter entry with \c source.
   ParameterEntry& operator=(const ParameterEntry& source);
+
+  //! Move-assignment operator.
+  ParameterEntry& operator=(ParameterEntry&&);
 
   /*! \brief Templated set method that uses the input value type to determine the type of parameter.  
       
@@ -313,13 +319,13 @@ inline std::ostream& operator<<(std::ostream& os, const ParameterEntry& e)
 template<typename T>
 inline
 ParameterEntry::ParameterEntry(
-  T value_in,
+  T&& value_in,
   bool isDefault_in,
   bool /*isList_in*/, // 2007/11/26: rabartl: ToDo: This arg is ignored and should be removed!
   const std::string &docString_in,
   RCP<const ParameterEntryValidator> const& validator_in
   )
-  : val_(value_in),
+  : val_(std::forward<T>(value_in)),
     isUsed_(false),
     isDefault_(isDefault_in),
     docString_(docString_in),

--- a/packages/teuchos/parameterlist/src/Teuchos_ParameterEntry.hpp
+++ b/packages/teuchos/parameterlist/src/Teuchos_ParameterEntry.hpp
@@ -88,8 +88,8 @@ public:
   //! Move constructor.
   ParameterEntry(ParameterEntry&& other);
 
-  //! Templated constructor
-  template<typename T>
+  //! Templated constructor. @note Accepting a @ref ParameterEntry would lead to infinite recursion.
+  template <typename T, typename = std::enable_if_t< ! std::is_same_v<std::decay_t<T>, ParameterEntry>>>
   explicit ParameterEntry(
     T&& value, bool isDefault = false, bool isList = false,
     const std::string &docString = "",
@@ -316,7 +316,7 @@ inline std::ostream& operator<<(std::ostream& os, const ParameterEntry& e)
 
 // Constructor/Destructor
 
-template<typename T>
+template<typename T, typename>
 inline
 ParameterEntry::ParameterEntry(
   T&& value_in,

--- a/packages/teuchos/parameterlist/src/Teuchos_ParameterList.hpp
+++ b/packages/teuchos/parameterlist/src/Teuchos_ParameterList.hpp
@@ -316,7 +316,8 @@ public:
    * \note This is required to preserve the isDefault value when reading back
    * from XML. KL 7 August 2004 
    */
-  ParameterList& setEntry(const std::string& name, const ParameterEntry& entry);
+  template <typename U, typename = std::enable_if_t<std::is_same_v<std::decay_t<U>, ParameterEntry>>>
+  ParameterList& setEntry(const std::string& name, U&&  entry);
 
   /** \brief Recursively attach a validator to parameters of type T.
    *
@@ -1009,13 +1010,13 @@ ParameterList& ParameterList::set(
 }
 
 
+template <typename U, typename>
 inline
-ParameterList& ParameterList::setEntry(std::string const& name_in, ParameterEntry const& entry_in)
+ParameterList& ParameterList::setEntry(std::string const& name_in, U&& entry_in)
 {
-  params_.setObj(name_in, entry_in);
+  params_.setObj(name_in, std::forward<U>(entry_in));
   return *this;
 }
-
 
 template<typename T>
 void ParameterList::recursivelySetValidator(

--- a/packages/teuchos/parameterlist/src/Teuchos_YamlParser.cpp
+++ b/packages/teuchos/parameterlist/src/Teuchos_YamlParser.cpp
@@ -228,13 +228,13 @@ class Reader : public Teuchos::Reader {
       case Teuchos::YAML::PROD_DOC:
       case Teuchos::YAML::PROD_DOC2: {
         std::size_t offset = prod == Teuchos::YAML::PROD_DOC2 ? 1 : 0;
-        TEUCHOS_ASSERT(!rhs.at(offset).empty());
+        TEUCHOS_ASSERT(rhs.at(offset).has_value());
         swap(result_any, rhs.at(offset));
         TEUCHOS_ASSERT(result_any.type() == typeid(ParameterList));
         break;
       }
       case Teuchos::YAML::PROD_TOP_BMAP: {
-        TEUCHOS_ASSERT(!rhs.at(0).empty());
+        TEUCHOS_ASSERT(rhs.at(0).has_value());
         TEUCHOS_ASSERT(rhs.at(0).type() == typeid(PLPair));
         PLPair& pair = any_ref_cast<PLPair>(rhs.at(0));
         any& pair_rhs_any = pair.value.getAny(/* set isUsed = */ false);
@@ -249,7 +249,7 @@ class Reader : public Teuchos::Reader {
       }
       case Teuchos::YAML::PROD_TOP_NEXT: {
         if (rhs.at(1).type() == typeid(ParameterList)) {
-          TEUCHOS_TEST_FOR_EXCEPTION(!rhs.at(0).empty(), ParserFail,
+          TEUCHOS_TEST_FOR_EXCEPTION(rhs.at(0).has_value(), ParserFail,
               "Can't specify multiple top-level ParameterLists in one YAML file!\n");
           swap(result_any, rhs.at(1));
         } else {
@@ -388,7 +388,7 @@ class Reader : public Teuchos::Reader {
       case Teuchos::YAML::PROD_SCALAR_RAW:
       case Teuchos::YAML::PROD_MAP_SCALAR_RAW: {
         Scalar& scalar = make_any_ref<Scalar>(result_any);
-        TEUCHOS_ASSERT(!rhs.at(0).empty());
+        TEUCHOS_ASSERT(rhs.at(0).has_value());
         scalar.text = any_ref_cast<std::string>(rhs.at(0));
         scalar.text += any_ref_cast<std::string>(rhs.at(1));
         if (prod == Teuchos::YAML::PROD_MAP_SCALAR_RAW) {
@@ -531,7 +531,7 @@ class Reader : public Teuchos::Reader {
       case Teuchos::YAML::PROD_SPACE_STAR_NEXT:
       case Teuchos::YAML::PROD_SPACE_PLUS_NEXT:
       case Teuchos::YAML::PROD_BSCALAR_HEAD_NEXT: {
-        TEUCHOS_TEST_FOR_EXCEPTION(rhs.at(0).empty(), ParserFail,
+        TEUCHOS_TEST_FOR_EXCEPTION(!rhs.at(0).has_value(), ParserFail,
             "leading characters in " << prod << ": any was empty\n");
         swap(result_any, rhs.at(0));
         std::string& str = any_ref_cast<std::string>(result_any);
@@ -622,7 +622,7 @@ class Reader : public Teuchos::Reader {
   }
   void map_first_item(any& result_any, any& first_item) {
     ParameterList& list = make_any_ref<ParameterList>(result_any);
-    TEUCHOS_ASSERT(!first_item.empty());
+    TEUCHOS_ASSERT(first_item.has_value());
     PLPair& pair = any_ref_cast<PLPair>(first_item);
     safe_set_entry(list, pair.key, pair.value);
   }

--- a/packages/teuchos/parameterlist/test/ParameterList/ParameterEntry_UnitTest.cpp
+++ b/packages/teuchos/parameterlist/test/ParameterList/ParameterEntry_UnitTest.cpp
@@ -45,6 +45,46 @@
 
 namespace Teuchos {
 
+//! @test Check that the move constructor of @ref Teuchos::ParameterEntry works as expected.
+TEUCHOS_UNIT_TEST(Teuchos_ParameterEntry, move_constructor)
+{
+  ParameterEntry source(std::string("nice-entry"));
+  TEST_EQUALITY(Teuchos::any_cast<std::string>(source.getAny()),"nice-entry");
+
+  //! After the move-construct, @c source has no value (its holding a @c nullptr when looking at how @c Teuchos::any holds values).
+  ParameterEntry move_constructed(std::move(source));
+  TEST_ASSERT  (source.getAny().access_content() == nullptr);
+  TEST_EQUALITY(source.getAny().has_value(),false);
+  TEST_EQUALITY(Teuchos::any_cast<std::string>(move_constructed.getAny()),"nice-entry");
+
+  //! Same behavior is expected for the move-assign.
+  ParameterEntry move_assigned;
+  move_assigned = std::move(move_constructed);
+  TEST_EQUALITY(move_constructed.getAny().access_content(),nullptr);
+  TEST_EQUALITY(move_constructed.getAny().has_value(),false);
+  TEST_EQUALITY(Teuchos::any_cast<std::string>(move_assigned.getAny()),"nice-entry");
+}
+
+//! @test This test checks that it is possible to move-extract the value held by a parameter entry.
+TEUCHOS_UNIT_TEST(Teuchos_ParameterList, move_extract_value_from_any)
+{
+  ParameterEntry source(std::string("nice-entry"));
+
+  Teuchos::any::holder<std::string>* dyn_cast_content = dynamic_cast<Teuchos::any::holder<std::string>*>(
+    source.getAny().access_content());
+
+  TEST_EQUALITY(dyn_cast_content->held, std::string("nice-entry"));
+
+  //! Simple copy assignment from a reference to the value is still possible and leaves the parameter entry untouched.
+  std::string copy_extracted = Teuchos::any_cast<std::string>(source.getAny());
+  TEST_EQUALITY(dyn_cast_content->held, std::string("nice-entry"));
+  TEST_EQUALITY(copy_extracted        , std::string("nice-entry"));
+
+  //! Move-extract the value will make the string held by the parameter entry empty (default for @c std::string).
+  std::string move_extracted = Teuchos::any_cast<std::string>(std::move(source.getAny()));
+  TEST_EQUALITY(dyn_cast_content->held, std::string());
+  TEST_EQUALITY(move_extracted        , std::string("nice-entry"));
+}
 
 TEUCHOS_UNIT_TEST( Teuchos_ParameterEntry, testTypeFunctions )
 {

--- a/packages/teuchos/parameterlist/test/ParameterList/ParameterEntry_UnitTest.cpp
+++ b/packages/teuchos/parameterlist/test/ParameterList/ParameterEntry_UnitTest.cpp
@@ -60,7 +60,7 @@ TEUCHOS_UNIT_TEST(Teuchos_ParameterEntry, move_constructor)
   //! Same behavior is expected for the move-assign.
   ParameterEntry move_assigned;
   move_assigned = std::move(move_constructed);
-  TEST_EQUALITY(move_constructed.getAny().access_content(),nullptr);
+  TEST_ASSERT  (move_constructed.getAny().access_content() == nullptr);
   TEST_EQUALITY(move_constructed.getAny().has_value(),false);
   TEST_EQUALITY(Teuchos::any_cast<std::string>(move_assigned.getAny()),"nice-entry");
 }

--- a/packages/teuchos/parser/src/Teuchos_MathExpr.cpp
+++ b/packages/teuchos/parser/src/Teuchos_MathExpr.cpp
@@ -172,7 +172,7 @@ class CalcReader : public Reader {
     using std::swap;
     switch (prod) {
       case MathExpr::PROD_PROGRAM: {
-        TEUCHOS_TEST_FOR_EXCEPTION(rhs.at(1).empty(), ParserFail,
+        TEUCHOS_TEST_FOR_EXCEPTION(!rhs.at(1).has_value(), ParserFail,
           "Calculator needs an expression to evaluate!");
         swap(result, rhs.at(1));
         break;


### PR DESCRIPTION
@trilinos/Teuchos

## Motivation

Adding missing move semantics, see https://github.com/trilinos/Trilinos/issues/11481.

## Related Issues

* https://github.com/trilinos/Trilinos/issues/11481

## Testing

Tested for `OpenMP`, `Cuda 12`, and `ROCm 5.4`.