### PR TITLE
add congfig for clang 11 sems v2 build

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1748,6 +1748,11 @@ use RHEL7_POST
 
 opt-set-cmake-var CMAKE_CXX_STANDARD STRING FORCE : 17
 
+[rhel7_sems-clang-11.0.1-openmpi-1.10.1-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
+#uses sems-archive modules
+use rhel7_sems-clang-11.0.1-openmpi-1.10.1-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
+use PACKAGE-ENABLES|ALL
+
 [rhel7_sems-clang-11.0.1-openmpi-1.10.7-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
 # uses sems-v2 modules
 use RHEL7_SEMS_COMPILER|CLANG

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -383,6 +383,9 @@ opt-set-cmake-var TPL_LAPACK_LIBRARIES STRING : ${LAPACK_LIBRARIES|ENV}
 
 [COMMON_SPACK_TPLS]
 use COMMON
+opt-set-cmake-var TPL_ENABLE_ParMETIS BOOL FORCE : OFF
+opt-set-cmake-var TPL_ENABLE_Scotch BOOL FORCE : OFF
+
 # BLAS & LAPACK
 opt-set-cmake-var TPL_BLAS_LIBRARIES STRING FORCE : -L${BLAS_ROOT|ENV}/lib;-lblas;-lgfortran;-lgomp
 opt-set-cmake-var TPL_BLAS_LIBRARY_DIRS STRING FORCE : ${BLAS_ROOT|ENV}/lib
@@ -411,12 +414,14 @@ opt-set-cmake-var ParMETIS_INCLUDE_DIRS PATH FORCE : ${PARMETIS_INC|ENV}
 opt-set-cmake-var ParMETIS_INCLUDE_DIRS STRING FORCE : ${PARMETIS_INC|ENV}
 opt-set-cmake-var ParMETIS_LIBRARY_DIRS PATH FORCE : ${PARMETIS_LIB|ENV}
 opt-set-cmake-var ParMETIS_LIBRARY_DIRS STRING FORCE : ${PARMETIS_LIB|ENV}
+opt-set-cmake-var TPL_ParMETIS_LIBRARIES STRING FORCE : ${PARMETIS_LIB|ENV}/libparmetis.so
 
 # Scotch
 opt-set-cmake-var Scotch_INCLUDE_DIRS STRING FORCE : ${SCOTCH_INC|ENV}
 opt-set-cmake-var Scotch_LIBRARY_DIRS PATH FORCE : ${SCOTCH_LIB|ENV}
 opt-set-cmake-var Scotch_LIBRARY_DIRS STRING FORCE : ${SCOTCH_LIB|ENV}
 opt-set-cmake-var TPL_Scotch_INCLUDE_DIRS PATH FORCE : ${SCOTCH_INC|ENV}
+opt-set-cmake-var TPL_Scotch_LIBRARIES STRING FORCE : ${SCOTCH_LIB|ENV}/libscotch.so
 
 # SuperLU
 opt-set-cmake-var SuperLU_INCLUDE_DIRS PATH FORCE : ${SUPERLU_INC|ENV}
@@ -1510,6 +1515,7 @@ opt-set-cmake-var KokkosKernels_batched_dla_cuda_MPI_1_SET_RUN_SERIAL BOOL FORCE
 # Full configurations intended to be loaded.
 
 [rhel7_sems-gnu-7.2.0-anaconda3-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_pr-framework]
+#uses sems-archive modules
 use RHEL7_SEMS_COMPILER|GNU
 use NODE-TYPE|SERIAL
 use BUILD-TYPE|DEBUG
@@ -1568,6 +1574,7 @@ opt-set-cmake-var CMAKE_CXX_STANDARD          STRING FORCE : 17
 use RHEL7_POST
 
 [rhel7_sems-gnu-8.3.0-openmpi-1.10.1-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
+#uses sems-archive modules
 use RHEL7_SEMS_COMPILER|GNU
 use NODE-TYPE|SERIAL
 use BUILD-TYPE|DEBUG
@@ -1596,15 +1603,18 @@ opt-set-cmake-var ROL_example_PDE-OPT_navier-stokes_example_01_MPI_4_DISABLE BOO
 use RHEL7_POST
 
 [rhel7_sems-gnu-8.3.0-openmpi-1.10.1-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
+#uses sems-archive modules
 use rhel7_sems-gnu-8.3.0-openmpi-1.10.1-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 use PACKAGE-ENABLES|ALL
 
 [rhel7_sems-gnu-8.3.0-openmpi-1.10.1-serial_debug-coverage_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
+#uses sems-archive modules
 use rhel7_sems-gnu-8.3.0-openmpi-1.10.1-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 use BUILD-TYPE|DEBUG-COVERAGE-GNU
 use PACKAGE-ENABLES|ALL
 
 [rhel7_sems-gnu-8.3.0-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
+#uses sems-archive modules
 use RHEL7_SEMS_COMPILER|GNU
 use NODE-TYPE|SERIAL
 use BUILD-TYPE|RELEASE-DEBUG
@@ -1628,10 +1638,12 @@ opt-set-cmake-var TPL_ENABLE_ParMETIS            BOOL FORCE   : OFF
 use RHEL7_POST
 
 [rhel7_sems-gnu-8.3.0-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
+#uses sems-archive modules
 use rhel7_sems-gnu-8.3.0-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 use PACKAGE-ENABLES|ALL
 
 [rhel7_sems-gnu-8.3.0-openmpi-1.10.1-openmp_release-debug_static_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_pr]
+#uses sems-archive modules
 use RHEL7_SEMS_COMPILER|GNU
 use NODE-TYPE|OPENMP-NO-SERIAL
 use BUILD-TYPE|RELEASE-DEBUG
@@ -1656,6 +1668,7 @@ opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING     : -fn
 use RHEL7_POST
 
 [rhel7_sems-gnu-8.3.0-openmpi-1.10.1-openmp_release-debug_static_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-off_pr]
+#uses sems-archive modules
 use RHEL7_SEMS_COMPILER|GNU
 use NODE-TYPE|OPENMP
 use BUILD-TYPE|RELEASE-DEBUG
@@ -1682,6 +1695,7 @@ opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING     : -fn
 use RHEL7_POST
 
 [rhel7_sems-gnu-8.3.0-openmpi-1.10.1-openmp_release-debug_static_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
+#uses sems-archive modules
 use RHEL7_SEMS_COMPILER|GNU
 use NODE-TYPE|OPENMP
 use BUILD-TYPE|RELEASE-DEBUG
@@ -1705,10 +1719,12 @@ opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING       : -
 use RHEL7_POST
 
 [rhel7_sems-gnu-8.3.0-openmpi-1.10.1-openmp_release-debug_static_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
+#uses sems-archive modules
 use rhel7_sems-gnu-8.3.0-openmpi-1.10.1-openmp_release-debug_static_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 use PACKAGE-ENABLES|ALL
 
 [rhel7_sems-clang-11.0.1-openmpi-1.10.1-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
+#uses sems-archive modules
 use RHEL7_SEMS_COMPILER|CLANG
 use NODE-TYPE|SERIAL
 use BUILD-TYPE|RELEASE-DEBUG
@@ -1732,11 +1748,38 @@ use RHEL7_POST
 
 opt-set-cmake-var CMAKE_CXX_STANDARD STRING FORCE : 17
 
-[rhel7_sems-clang-11.0.1-openmpi-1.10.1-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
-use rhel7_sems-clang-11.0.1-openmpi-1.10.1-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
+[rhel7_sems-clang-11.0.1-openmpi-1.10.7-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
+# uses sems-v2 modules
+use RHEL7_SEMS_COMPILER|CLANG
+use NODE-TYPE|SERIAL
+use BUILD-TYPE|RELEASE-DEBUG
+use RHEL7_SEMS_V2_LIB-TYPE|SHARED
+use KOKKOS-ARCH|NO-KOKKOS-ARCH
+use RHEL7_SEMS_USE-ASAN|NO_USE-FPIC|NO_USE-MPI|YES_USE-PT|NO
+use USE-COMPLEX|NO
+use USE-RDC|NO
+use USE-UVM|NO
+use USE-DEPRECATED|YES
+use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
+
+use COMMON_SPACK_TPLS
+
+opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING     : --bind-to;none
+opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D BOOL       : ON
+
+use RHEL7_TEST_DISABLES|CLANG
+
+use RHEL7_POST
+
+opt-set-cmake-var CMAKE_CXX_STANDARD STRING FORCE : 17
+
+[rhel7_sems-clang-11.0.1-openmpi-1.10.7-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
+# uses sems-v2 modules
+use rhel7_sems-clang-11.0.1-openmpi-1.10.7-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 use PACKAGE-ENABLES|ALL
 
 [rhel7_sems-intel-19.0.5-mpich-3.2-serial_release-debug_static_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
+# JFRYE which modules is this using?
 use RHEL7_SEMS_COMPILER|INTEL
 use NODE-TYPE|SERIAL
 use BUILD-TYPE|RELEASE-DEBUG
@@ -1782,6 +1825,7 @@ opt-set-cmake-var Zoltan2_scotch_example_MPI_4_DISABLE BOOL : ON
 use RHEL7_POST
 
 [rhel7_sems-intel-2021.3-sems-openmpi-4.0.5_release-debug_shared_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
+# uses sems-v2 modules
 use RHEL7_SEMS_COMPILER|INTEL
 use BUILD-TYPE|RELEASE-DEBUG
 use RHEL7_SEMS_LIB-TYPE|SHARED
@@ -1812,10 +1856,12 @@ opt-set-cmake-var Zoltan_ch_simple_scotch_parallel_DISABLE BOOL FORCE   : ON
 opt-set-cmake-var Epetra_Directory_test_LL_MPI_1_DISABLE BOOL FORCE     : ON
 
 [rhel7_sems-intel-2021.3-sems-openmpi-4.0.5_release-debug_shared_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
+# uses sems-v2 modules
 use rhel7_sems-intel-2021.3-sems-openmpi-4.0.5_release-debug_shared_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 use PACKAGE-ENABLES|ALL
 
 [rhel7_sems-cuda-11.4.2-sems-gnu-10.1.0-sems-openmpi-4.0.5_release_static_Volta70_no-asan_complex_no-fpic_mpi_pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
+# uses sems-v2 modules
 use RHEL7_SEMS_COMPILER|CUDA
 use NODE-TYPE|CUDA
 use BUILD-TYPE|RELEASE
@@ -1909,10 +1955,12 @@ use RHEL7_POST
 use CUDA11-RUN-SERIAL-TESTS
 
 [rhel7_sems-cuda-11.4.2-sems-gnu-10.1.0-sems-openmpi-4.0.5_release_static_Volta70_no-asan_complex_no-fpic_mpi_pt_no-rdc_no-uvm_deprecated-on_all]
+# uses sems-v2 modules
 use rhel7_sems-cuda-11.4.2-sems-gnu-10.1.0-sems-openmpi-4.0.5_release_static_Volta70_no-asan_complex_no-fpic_mpi_pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 use PACKAGE-ENABLES|ALL
 
 [rhel7_sems-cuda-11.4.2-sems-gnu-10.1.0-sems-openmpi-4.0.5_release_static_Volta70_no-asan_complex_no-fpic_mpi_pt_no-rdc_uvm_deprecated-on_no-package-enables]
+# uses sems-v2 modules
 use RHEL7_SEMS_COMPILER|CUDA
 use NODE-TYPE|CUDA
 use BUILD-TYPE|RELEASE
@@ -1930,6 +1978,7 @@ use RHEL7_POST
 use CUDA11-RUN-SERIAL-TESTS
 
 [rhel7_sems-cuda-11.4.2-sems-gnu-10.1.0-sems-openmpi-4.0.5_release_static_Volta70_no-asan_complex_no-fpic_mpi_pt_rdc_uvm_deprecated-on_all]
+# uses sems-v2 modules
 use rhel7_sems-cuda-11.4.2-sems-gnu-10.1.0-sems-openmpi-4.0.5_release_static_Volta70_no-asan_complex_no-fpic_mpi_pt_no-rdc_uvm_deprecated-on_no-package-enables
 use NODE-TYPE|CUDA_USE-RDC|YES_USE-PT|YES
 use USE-RDC|YES
@@ -1939,6 +1988,7 @@ opt-set-cmake-var Trilinos_CUDA_NUM_GPUS STRING : 4
 opt-set-cmake-var Trilinos_CUDA_SLOTS_PER_GPU STRING : 2
 
 [rhel7_ascdo-gnu-10.3.0-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
+# uses asc-do modules
 use NODE-TYPE|SERIAL
 use BUILD-TYPE|DEBUG
 use RHEL7_SEMS_LIB-TYPE|SHARED
@@ -1966,10 +2016,12 @@ opt-set-cmake-var TPL_ENABLE_Netcdf  BOOL   : OFF
 opt-set-cmake-var Trilinos_ENABLE_PyTrilinos BOOL : OFF
 
 [rhel7_ascdo-gnu-10.3.0-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
+# uses asc-do modules
 use rhel7_ascdo-gnu-10.3.0-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 use PACKAGE-ENABLES|ALL
 
 [rhel7_ascdo-gnu-10.3.0-openmp_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
+# uses asc-do modules
 use NODE-TYPE|OPENMP
 use BUILD-TYPE|DEBUG
 use RHEL7_SEMS_LIB-TYPE|SHARED
@@ -1999,10 +2051,12 @@ opt-set-cmake-var Trilinos_ENABLE_PyTrilinos BOOL : OFF
 opt-set-cmake-var CMAKE_GENERATOR STRING : Ninja
 
 [rhel7_ascdo-gnu-10.3.0-openmp_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
+# uses asc-do modules
 use rhel7_ascdo-gnu-10.3.0-openmp_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 use PACKAGE-ENABLES|ALL
 
 [rhel7_ascdo-gnu-10.3.0-openmpi-4.1.4-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
+# uses asc-do modules
 use NODE-TYPE|SERIAL
 use BUILD-TYPE|DEBUG
 use RHEL7_SEMS_LIB-TYPE|SHARED
@@ -2032,11 +2086,13 @@ opt-set-cmake-var TPL_ENABLE_Netcdf  BOOL   : OFF
 opt-set-cmake-var CMAKE_GENERATOR STRING : Ninja
 
 [rhel7_ascdo-gnu-10.3.0-openmpi-4.1.4-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
+# uses asc-do modules
 use rhel7_ascdo-gnu-10.3.0-openmpi-4.1.4-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 use PACKAGE-ENABLES|ALL
 
 
 [rhel7_ascdo-gnu-12.1.0-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
+# uses asc-do modules
 use NODE-TYPE|SERIAL
 use BUILD-TYPE|DEBUG
 use RHEL7_SEMS_LIB-TYPE|SHARED
@@ -2064,10 +2120,12 @@ opt-set-cmake-var TPL_ENABLE_Netcdf  BOOL   : OFF
 opt-set-cmake-var Trilinos_ENABLE_PyTrilinos BOOL : OFF
 
 [rhel7_ascdo-gnu-12.1.0-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
+# uses asc-do modules
 use rhel7_ascdo-gnu-12.1.0-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 use PACKAGE-ENABLES|ALL
 
 [rhel7_ascdo-gnu-12.1.0-openmp_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
+# uses asc-do modules
 use NODE-TYPE|OPENMP
 use BUILD-TYPE|DEBUG
 use RHEL7_SEMS_LIB-TYPE|SHARED
@@ -2097,10 +2155,12 @@ opt-set-cmake-var Trilinos_ENABLE_PyTrilinos BOOL : OFF
 opt-set-cmake-var CMAKE_GENERATOR STRING : Ninja
 
 [rhel7_ascdo-gnu-12.1.0-openmp_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
+# uses asc-do modules
 use rhel7_ascdo-gnu-12.1.0-openmp_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 use PACKAGE-ENABLES|ALL
 
 [rhel7_ascdo-gnu-12.1.0-openmpi-4.1.4-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
+# uses asc-do modules
 use NODE-TYPE|SERIAL
 use BUILD-TYPE|DEBUG
 use RHEL7_SEMS_LIB-TYPE|SHARED
@@ -2126,12 +2186,14 @@ opt-set-cmake-var ROL_example_PDE-OPT_navier-stokes_example_01_MPI_4_DISABLE BOO
 use RHEL7_POST
 
 [rhel7_ascdo-gnu-12.1.0-openmpi-4.1.4-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
+# uses asc-do modules
 use rhel7_ascdo-gnu-12.1.0-openmpi-4.1.4-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 use PACKAGE-ENABLES|ALL
 
 
 ####### under Testing #######
 [rhel7_sems-gnu-8.3.0-openmpi-1.10.7-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
+# uses sems-v2 modules
 use RHEL7_SEMS_COMPILER|GNU
 use NODE-TYPE|SERIAL
 use BUILD-TYPE|DEBUG
@@ -2160,10 +2222,12 @@ opt-set-cmake-var TPL_ENABLE_Netcdf  BOOL   : OFF
 opt-set-cmake-var Trilinos_ENABLE_PyTrilinos BOOL : OFF
 
 [rhel7_sems-gnu-8.3.0-openmpi-1.10.7-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
+# uses sems-v2 modules
 use rhel7_sems-gnu-8.3.0-openmpi-1.10.7-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 use PACKAGE-ENABLES|ALL
 
 [rhel7_sems-v2-gnu-8.3.0-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
+# uses sems-v2 modules
 use RHEL7_SEMS_COMPILER|GNU
 
 use NODE-TYPE|SERIAL
@@ -2191,10 +2255,12 @@ opt-set-cmake-var TPL_ENABLE_ParMETIS            BOOL FORCE   : OFF
 use RHEL7_POST
 
 [rhel7_sems-v2-gnu-8.3.0-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
+# uses sems-v2 modules
 use rhel7_sems-v2-gnu-8.3.0-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 use PACKAGE-ENABLES|ALL
 
 [rhel7_sems-gnu-8.3.0-openmpi-1.10.7-openmp_release-debug_static_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_pr]
+# uses sems-v2 modules
 use RHEL7_SEMS_COMPILER|GNU
 use NODE-TYPE|OPENMP-NO-SERIAL
 use BUILD-TYPE|RELEASE-DEBUG
@@ -2223,6 +2289,7 @@ opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING     : -fn
 use RHEL7_POST
 
 [rhel7_sems-gnu-8.3.0-openmpi-1.10.7-openmp_release-debug_static_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-off_pr]
+# uses sems-v2 modules
 use RHEL7_SEMS_COMPILER|GNU
 use NODE-TYPE|OPENMP
 use BUILD-TYPE|RELEASE-DEBUG
@@ -2253,6 +2320,7 @@ opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING     : -fn
 use RHEL7_POST
 
 [rhel7_sems-gnu-8.3.0-openmpi-1.10.7-openmp_release-debug_static_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
+# uses sems-v2 modules
 use RHEL7_SEMS_COMPILER|GNU
 use NODE-TYPE|OPENMP
 use BUILD-TYPE|RELEASE-DEBUG
@@ -2281,5 +2349,6 @@ use RHEL7_POST
 
 
 [rhel7_sems-gnu-8.3.0-openmpi-1.10.7-openmp_release-debug_static_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
+# uses sems-v2 modules
 use rhel7_sems-gnu-8.3.0-openmpi-1.10.7-openmp_release-debug_static_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 use PACKAGE-ENABLES|ALL

--- a/packages/framework/ini-files/supported-envs.ini
+++ b/packages/framework/ini-files/supported-envs.ini
@@ -152,6 +152,7 @@ sems-gnu-8.3.0-openmpi-1.10.7-serial:
 sems-gnu-8.3.0-openmpi-1.10.7-openmp:
 sems-clang-11.0.1-openmpi-1.10.1-serial:
     clang-11.0.1
+sems-clang-11.0.1-openmpi-1.10.7-serial:
 sems-intel-19.0.5-mpich-3.2-serial:
     intel-19.0.5
 sems-cuda-11.4.2-sems-gnu-10.1.0-sems-openmpi-4.0.5:


### PR DESCRIPTION
@trilinos/framework 

## Motivation
Add clang-11 configuration to the ini PR/MM files that uses the sems v2 tpls.  This will greatly improve the usability of rhe ini files by reducing our dependence on two systems

## Testing
see these results on cdash which show builds passing all tests using the PR/MM infrastructure on nightly builds

https://trilinos-cdash.sandia.gov/index.php?project=Trilinos&filtercount=4&showfilters=1&filtercombine=and&field1=groupname&compare1=61&value1=Nightly&field2=buildstarttime&compare2=83&value2=2023-01-18&field3=buildstarttime&compare3=84&value3=2023-01-20&field4=buildname&compare4=63&value4=sems-v2

