### PR TITLE
SEACAS: Remove uses of fmt in include files

### DIFF
--- a/packages/seacas/libraries/ioss/src/Ioss_StructuredBlock.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_StructuredBlock.h
@@ -1,4 +1,4 @@
-// Copyright(C) 1999-2022 National Technology & Engineering Solutions
+// Copyright(C) 1999-2023 National Technology & Engineering Solutions
 // of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
 // NTESS, the U.S. Government retains certain rights in this software.
 //
@@ -16,7 +16,6 @@
 #include <Ioss_ZoneConnectivity.h>
 #include <array>
 #include <cassert>
-#include <fmt/ostream.h>
 #include <string>
 
 #if defined(SEACAS_HAVE_CGNS) && !defined(BUILT_IN_SIERRA)
@@ -362,11 +361,4 @@ namespace Ioss {
     }
   };
 } // namespace Ioss
-
-#if FMT_VERSION >= 90000
-namespace fmt {
-  template <> struct formatter<Ioss::BoundaryCondition> : ostream_formatter
-  {
-  };
-} // namespace fmt
 #endif

--- a/packages/seacas/libraries/ioss/src/Ioss_StructuredBlock.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_StructuredBlock.h
@@ -361,4 +361,3 @@ namespace Ioss {
     }
   };
 } // namespace Ioss
-#endif

--- a/packages/seacas/libraries/ioss/src/Ioss_ZoneConnectivity.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_ZoneConnectivity.h
@@ -147,4 +147,3 @@ namespace Ioss {
 
   IOSS_EXPORT std::ostream &operator<<(std::ostream &os, const ZoneConnectivity &zgc);
 } // namespace Ioss
-#endif

--- a/packages/seacas/libraries/ioss/src/Ioss_ZoneConnectivity.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_ZoneConnectivity.h
@@ -1,4 +1,4 @@
-// Copyright(C) 1999-2022 National Technology & Engineering Solutions
+// Copyright(C) 1999-2023 National Technology & Engineering Solutions
 // of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
 // NTESS, the U.S. Government retains certain rights in this software.
 //
@@ -11,7 +11,6 @@
 #include <Ioss_CodeTypes.h>
 #include <array>
 #include <cassert>
-#include <fmt/ostream.h>
 #include <string>
 
 #if defined(SEACAS_HAVE_CGNS) && !defined(BUILT_IN_SIERRA)
@@ -148,11 +147,4 @@ namespace Ioss {
 
   IOSS_EXPORT std::ostream &operator<<(std::ostream &os, const ZoneConnectivity &zgc);
 } // namespace Ioss
-
-#if FMT_VERSION >= 90000
-namespace fmt {
-  template <> struct formatter<Ioss::ZoneConnectivity> : ostream_formatter
-  {
-  };
-} // namespace fmt
 #endif

--- a/packages/seacas/libraries/ioss/src/heartbeat/Iohb_DatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/heartbeat/Iohb_DatabaseIO.C
@@ -5,13 +5,14 @@
 // See packages/seacas/LICENSE for details
 
 #include <Ioss_CodeTypes.h>
-#include <heartbeat/Iohb_DatabaseIO.h>
-
+#include <Ioss_Utils.h>
 #include <cassert>
 #include <cstddef>
 #include <ctime>
-#include <fmt/ostream.h>
 #include <fstream>
+#include <heartbeat/Iohb_DatabaseIO.h>
+#include <heartbeat/Iohb_Layout.h>
+#include <iostream>
 #include <string>
 
 #include <vector>
@@ -20,6 +21,7 @@
 #include "Ioss_DatabaseIO.h"
 #include "Ioss_EntityType.h"
 #include "Ioss_Field.h"
+#include "Ioss_FileInfo.h"
 #include "Ioss_IOFactory.h"
 #include "Ioss_ParallelUtils.h"
 #include "Ioss_Property.h"
@@ -27,7 +29,6 @@
 #include "Ioss_State.h"
 #include "Ioss_Utils.h"
 #include "Ioss_VariableType.h"
-#include <heartbeat/Iohb_Layout.h>
 
 namespace Ioss {
   class CommSet;
@@ -184,7 +185,7 @@ namespace Iohb {
 
         if (new_this->logStream == nullptr) {
           std::ostringstream errmsg;
-          fmt::print(errmsg, "ERROR: Could not create heartbeat file '{}'\n", get_filename());
+          errmsg << "ERROR: Could not create heartbeat file '" << get_filename() << "'\n";
           IOSS_ERROR(errmsg);
         }
       }
@@ -326,16 +327,15 @@ namespace Iohb {
     if (legend_ != nullptr) {
       if (fileFormat == Iohb::Format::SPYHIS) {
         time_t calendar_time = time(nullptr);
-        // ctime include \n; the legend is output twice for SPYHIS.
-        fmt::print(*logStream, "% Sierra SPYHIS Output {}{}\n", ctime(&calendar_time),
-                   legend_->layout()); // ctime includes \n
+        *logStream << "% Sierra SPYHIS Output " << ctime(&calendar_time);
+        *logStream << *legend_ << '\n'; // Legend output twice for SPYHIS
       }
 
-      fmt::print(*logStream, "{}\n", legend_->layout());
+      *logStream << *legend_ << '\n';
       legend_.reset();
     }
 
-    fmt::print(*logStream, "{}\n", layout_->layout());
+    *logStream << *layout_ << '\n';
     layout_.reset();
 
     // Flush the buffer to disk...
@@ -387,7 +387,7 @@ namespace Iohb {
           layout.add_literal(" ");
           layout.add_literal(*reinterpret_cast<std::string *>(data));
           if (logStream != nullptr) {
-            fmt::print(*logStream, "{}\n", layout.layout());
+            *logStream << layout << '\n';
           }
         }
         else {
@@ -397,7 +397,7 @@ namespace Iohb {
       else {
         if (layout_ == nullptr) {
           std::ostringstream errmsg;
-          fmt::print(errmsg, "INTERNAL ERROR: Unexpected nullptr layout.\n");
+          errmsg << "INTERNAL ERROR: Unexpected nullptr layout.\n";
           IOSS_ERROR(errmsg);
         }
         if (field.get_type() == Ioss::Field::INTEGER) {

--- a/packages/seacas/libraries/ioss/src/heartbeat/Iohb_DatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/heartbeat/Iohb_DatabaseIO.C
@@ -1,4 +1,4 @@
-// Copyright(C) 1999-2022 National Technology & Engineering Solutions
+// Copyright(C) 1999-2023 National Technology & Engineering Solutions
 // of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
 // NTESS, the U.S. Government retains certain rights in this software.
 //
@@ -422,8 +422,7 @@ namespace Iohb {
     }
     else {
       std::ostringstream errmsg;
-      fmt::print(errmsg,
-                 "ERROR: Can not handle non-TRANSIENT or non-REDUCTION fields on regions.\n");
+      errmsg << "ERROR: Can not handle non-TRANSIENT or non-REDUCTION fields on regions.\n";
       IOSS_ERROR(errmsg);
     }
     return num_to_get;

--- a/packages/seacas/libraries/ioss/src/heartbeat/Iohb_Layout.C
+++ b/packages/seacas/libraries/ioss/src/heartbeat/Iohb_Layout.C
@@ -16,11 +16,28 @@ namespace Iohb {
 
   Layout::~Layout() = default;
 
-  void Layout::add_literal(const std::string &label) { fmt::print(layout_, "{}", label); }
+  std::ostream &operator<<(std::ostream &o, Layout &lo)
+  {
+    o << lo.layout_.str();
+    return o;
+  }
+
+  void Layout::add_literal(const std::string &label) { layout_ << label; }
 
   void Layout::add_legend(const std::string &label)
   {
-    fmt::print(layout_, "{}{:>{}}", legendStarted ? separator_ : "", label, fieldWidth_);
-    legendStarted = true;
+    if (legendStarted && !separator_.empty()) {
+      layout_ << separator_;
+    }
+    else {
+      legendStarted = true;
+    }
+
+    if (fieldWidth_ != 0) {
+      layout_ << std::setw(fieldWidth_) << label;
+    }
+    else {
+      layout_ << label;
+    }
   }
 } // namespace Iohb


### PR DESCRIPTION
SEACAS uses the lib{fmt} library for output, but that library is not yet a Trilinos TPL, so external packages using Trilinos are not required to have the lib{fmt} include files available.

SEACAS in Trilinos uses lib{fmt} as a header-only library and there is an embedded version in SEACAS/Trilinos.

This commit removes all fmt-related includes from header files so applications using Trilinos do not need to have the fmt include files.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/seacas 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->