### PR TITLE
Tpetra: work around subview of managed view slowdown

### DIFF
--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_TotalElementLoop.hpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_TotalElementLoop.hpp
@@ -569,14 +569,19 @@ namespace TpetraExamples
     
       timerElementLoopMemory = Teuchos::null;
       RCP<TimeMonitor> timerElementLoopMatrix = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("3.3) ElementLoop  (Matrix)")));
+
+      // Work around subview of managed views being slower than unmanaged
+      auto all_element_rhs_unmanaged = makeUnmanaged(all_element_rhs);
+      auto all_element_matrix_unmanaged = makeUnmanaged(all_element_matrix);
+      auto all_lcids_unmanaged = makeUnmanaged(all_lcids);
     
       // Loop over owned elements:
       Kokkos::parallel_for(Kokkos::RangePolicy<execution_space>(0, numOwnedElements),KOKKOS_LAMBDA(const size_t& element_gidx) {
           // Get subviews
           pair_type location_pair = pair_type(nperel*element_gidx,nperel*(element_gidx+1));
-          auto element_rhs    = Kokkos::subview(all_element_rhs,location_pair);
-          auto element_matrix = Kokkos::subview(all_element_matrix,location_pair,alln);
-          auto element_lcids  = Kokkos::subview(all_lcids,location_pair);
+          auto element_rhs    = Kokkos::subview(all_element_rhs_unmanaged,location_pair);
+          auto element_matrix = Kokkos::subview(all_element_matrix_unmanaged,location_pair,alln);
+          auto element_lcids  = Kokkos::subview(all_lcids_unmanaged,location_pair);
       
           // Get the contributions for the current element
           ReferenceQuad4(element_matrix);
@@ -610,9 +615,9 @@ namespace TpetraExamples
       Kokkos::parallel_for(Kokkos::RangePolicy<execution_space>(0, numGhostElements),KOKKOS_LAMBDA(const size_t& element_gidx) {
           // Get subviews
           pair_type location_pair = pair_type(nperel*element_gidx,nperel*(element_gidx+1));
-          auto element_rhs    = Kokkos::subview(all_element_rhs,location_pair);
-          auto element_matrix = Kokkos::subview(all_element_matrix,location_pair,alln);
-          auto element_lcids  = Kokkos::subview(all_lcids,location_pair);
+          auto element_rhs    = Kokkos::subview(all_element_rhs_unmanaged,location_pair);
+          auto element_matrix = Kokkos::subview(all_element_matrix_unmanaged,location_pair,alln);
+          auto element_lcids  = Kokkos::subview(all_lcids_unmanaged,location_pair);
 
           // Get the contributions for the current element
           ReferenceQuad4(element_matrix);

--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_utility.hpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_utility.hpp
@@ -48,6 +48,13 @@
 
 namespace TpetraExamples {
 
+template<typename V>
+Kokkos::View<typename V::data_type, typename V::array_layout, typename V::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>>
+makeUnmanaged(const V& v)
+{
+  return v;
+}
+
 // Return a pointer (RCP is like std::shared_ptr) to an output
 // stream.  It prints on Process 0 of the given MPI communicator,
 // but ignores all output on other MPI processes.


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Works around performance regression in Kokkos 3.7.0 where taking a ``Kokkos::subview`` of a **managed** view inside a kernel (executing on Serial execution space) is slower than with **unmanaged**. This caused the ``3.2) ElementLoop (Matrix)`` component of the FEM assembly performance test to get about 50% slower (from ~8s to ~12s) on the Intel compiler, CTS-1 build. 
https://github.com/kokkos/kokkos/issues/5581 was about this, and I put a non-Tpetra standalone reproducer there. A fix was proposed and put in Kokkos develop which resolved the slowdown for the reproducer and which seemed to fix this Tpetra issue as well. However, recently I was not able to reproduce this fixing the Tpetra issue. So this workaround uses unmanaged views explicitly to speed ``subview`` back up.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
Built and ran the ``Tpetra FE Assembly 1 ranks`` performance test on Eclipse (CTS-1), using the same configuration as the nightly performance testing. Sub-timer ``3.2) ElementLoop (Matrix)`` went back down to about 8 seconds, instead of 12 seconds (as it had been since Kokkos 3.7.0 was integrated).
```
================================================================================
=  FECrsMatrix Insert Global Indices (Static Profile; Kokkos Assembly)
================================================================================

X) Global: 53.2551 [1]
|   1) ElementLoop  (Graph): 15.1318 [1]
|   2) FillComplete (Graph): 17.1369 [1]
|   3.1) ElementLoop  (Memory): 9.32157 [1]
|   3.2) ElementLoop  (Matrix): 8.462 [1]
|   4) FillComplete (Matrix): 6.4077e-05 [1]
|   5) GlobalAssemble (RHS): 3.891e-06 [1]
|   Remainder: 3.20281
End Result: TEST PASSED
```

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->