### PR TITLE
SEACAS: Make getline termios symbols unique across uses

### DIFF
--- a/packages/seacas/libraries/aprepro_lib/apr_getline_int.c
+++ b/packages/seacas/libraries/aprepro_lib/apr_getline_int.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1991, 1992, 1993, 2020, 2021, 2022 by Chris Thewalt (thewalt@ce.berkeley.edu)
+ * Copyright (C) 1991, 1992, 1993, 2020, 2021, 2022, 2023 by Chris Thewalt (thewalt@ce.berkeley.edu)
  *
  * Permission to use, copy, modify, and distribute this software
  * for any purpose and without fee is hereby granted, provided
@@ -39,7 +39,7 @@
 #endif
 
 #include <termios.h>
-struct termios new_termios, old_termios;
+struct termios ap_new_termios, ap_old_termios;
 #endif
 
 /********************* C library headers ********************************/
@@ -126,21 +126,21 @@ static char *copy_string(char *dest, char const *source, long int elements)
 static void ap_gl_char_init(void) /* turn off input echo */
 {
 #ifdef __unix__
-  tcgetattr(0, &old_termios);
-  new_termios = old_termios;
-  new_termios.c_iflag &= ~(BRKINT | ISTRIP | IXON | IXOFF);
-  new_termios.c_iflag |= (IGNBRK | IGNPAR);
-  new_termios.c_lflag &= ~(ICANON | ISIG | IEXTEN | ECHO);
-  new_termios.c_cc[VMIN]  = 1;
-  new_termios.c_cc[VTIME] = 0;
-  tcsetattr(0, TCSANOW, &new_termios);
+  tcgetattr(0, &ap_old_termios);
+  ap_new_termios = ap_old_termios;
+  ap_new_termios.c_iflag &= ~(BRKINT | ISTRIP | IXON | IXOFF);
+  ap_new_termios.c_iflag |= (IGNBRK | IGNPAR);
+  ap_new_termios.c_lflag &= ~(ICANON | ISIG | IEXTEN | ECHO);
+  ap_new_termios.c_cc[VMIN]  = 1;
+  ap_new_termios.c_cc[VTIME] = 0;
+  tcsetattr(0, TCSANOW, &ap_new_termios);
 #endif /* __unix__ */
 }
 
 static void ap_gl_char_cleanup(void) /* undo effects of ap_gl_char_init */
 {
 #ifdef __unix__
-  tcsetattr(0, TCSANOW, &old_termios);
+  tcsetattr(0, TCSANOW, &ap_old_termios);
 #endif /* __unix__ */
 }
 

--- a/packages/seacas/libraries/ioss/src/Ioss_Getline.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Getline.C
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (C) 1991, 1992, 1993, 2021, 2022 by Chris Thewalt (thewalt@ce.berkeley.edu)
+ * Copyright (C) 1991, 1992, 1993, 2021, 2022, 2023 by Chris Thewalt (thewalt@ce.berkeley.edu)
  *
  * Permission to use, copy, modify, and distribute this software
  * for any purpose and without fee is hereby granted, provided
@@ -39,7 +39,7 @@
 #endif
 
 #include <termios.h>
-struct termios new_termios, old_termios;
+struct termios io_new_termios, io_old_termios;
 #endif
 
 /********************* C library headers ********************************/
@@ -128,21 +128,21 @@ namespace {
   void io_gl_char_init(void) /* turn off input echo */
   {
 #ifdef __unix__
-    tcgetattr(0, &old_termios);
-    new_termios = old_termios;
-    new_termios.c_iflag &= ~(BRKINT | ISTRIP | IXON | IXOFF);
-    new_termios.c_iflag |= (IGNBRK | IGNPAR);
-    new_termios.c_lflag &= ~(ICANON | ISIG | IEXTEN | ECHO);
-    new_termios.c_cc[VMIN]  = 1;
-    new_termios.c_cc[VTIME] = 0;
-    tcsetattr(0, TCSANOW, &new_termios);
+    tcgetattr(0, &io_old_termios);
+    io_new_termios = io_old_termios;
+    io_new_termios.c_iflag &= ~(BRKINT | ISTRIP | IXON | IXOFF);
+    io_new_termios.c_iflag |= (IGNBRK | IGNPAR);
+    io_new_termios.c_lflag &= ~(ICANON | ISIG | IEXTEN | ECHO);
+    io_new_termios.c_cc[VMIN]  = 1;
+    io_new_termios.c_cc[VTIME] = 0;
+    tcsetattr(0, TCSANOW, &io_new_termios);
 #endif /* __unix__ */
   }
 
   void io_gl_char_cleanup(void) /* undo effects of io_gl_char_init */
   {
 #ifdef __unix__
-    tcsetattr(0, TCSANOW, &old_termios);
+    tcsetattr(0, TCSANOW, &io_old_termios);
 #endif /* __unix__ */
   }
 } // namespace

--- a/packages/seacas/libraries/supes/ext_lib/getline_int.c
+++ b/packages/seacas/libraries/supes/ext_lib/getline_int.c
@@ -1,6 +1,6 @@
 
 /*
- * Copyright(C) 1999-2022 National Technology & Engineering Solutions
+ * Copyright(C) 1999-2023 National Technology & Engineering Solutions
  * of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
  * NTESS, the U.S. Government retains certain rights in this software.
  *
@@ -31,7 +31,7 @@
 #endif
 
 #include <termios.h>
-struct termios new_termios, old_termios;
+struct termios gl_new_termios, gl_old_termios;
 #endif
 
 /********************* C library headers ********************************/
@@ -114,21 +114,21 @@ static char *copy_string(char *dest, char const *source, long int elements)
 static void gl_char_init(void) /* turn off input echo */
 {
 #ifdef __unix__
-  tcgetattr(0, &old_termios);
-  new_termios = old_termios;
-  new_termios.c_iflag &= ~(BRKINT | ISTRIP | IXON | IXOFF);
-  new_termios.c_iflag |= (IGNBRK | IGNPAR);
-  new_termios.c_lflag &= ~(ICANON | ISIG | IEXTEN | ECHO);
-  new_termios.c_cc[VMIN]  = 1;
-  new_termios.c_cc[VTIME] = 0;
-  tcsetattr(0, TCSANOW, &new_termios);
+  tcgetattr(0, &gl_old_termios);
+  gl_new_termios = gl_old_termios;
+  gl_new_termios.c_iflag &= ~(BRKINT | ISTRIP | IXON | IXOFF);
+  gl_new_termios.c_iflag |= (IGNBRK | IGNPAR);
+  gl_new_termios.c_lflag &= ~(ICANON | ISIG | IEXTEN | ECHO);
+  gl_new_termios.c_cc[VMIN]  = 1;
+  gl_new_termios.c_cc[VTIME] = 0;
+  tcsetattr(0, TCSANOW, &gl_new_termios);
 #endif /* __unix__ */
 }
 
 static void gl_char_cleanup(void) /* undo effects of gl_char_init */
 {
 #ifdef __unix__
-  tcsetattr(0, TCSANOW, &old_termios);
+  tcsetattr(0, TCSANOW, &gl_old_termios);
 #endif /* __unix__ */
 }
 


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/seacas 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Aprepro, suplib, and IOSS all contain an embedded getline function that defined a `new_termios` and `old_termios` global symbol which could cause conflicts on some platforms.  Changed each instance to a new name that is unique for each use.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->