### PR TITLE
Framework: Use default C++ standard for PR/MM testing

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1493,7 +1493,6 @@ opt-set-cmake-var SuperLU_INCLUDE_DIRS STRING FORCE : ${SUPERLU_INC|ENV}
 opt-set-cmake-var SuperLU_LIBRARY_DIRS STRING FORCE : ${SUPERLU_LIB|ENV}
 
 #CXX Settings
-opt-set-cmake-var CMAKE_CXX_STANDARD STRING FORCE : 14
 opt-set-cmake-var CMAKE_CXX_FLAGS STRING : -fPIC -Wall -Warray-bounds -Wchar-subscripts -Wcomment -Wenum-compare -Wformat -Wuninitialized -Wmaybe-uninitialized -Wmain -Wnarrowing -Wnonnull -Wparentheses -Wreorder -Wreturn-type -Wsign-compare -Wsequence-point -Wtrigraphs -Wunused-function -Wunused-but-set-variable -Wunused-variable -Wwrite-strings
 
 #Package Options
@@ -1609,8 +1608,6 @@ opt-set-cmake-var TPL_ENABLE_Scotch   BOOL FORCE : OFF
 # No build stats for Python-only PR (#7376)
 opt-set-cmake-var Trilinos_ENABLE_BUILD_STATS BOOL FORCE   : OFF
 
-opt-set-cmake-var CMAKE_CXX_STANDARD          STRING FORCE : 17
-
 use RHEL7_POST
 
 [rhel7_sems-gnu-8.3.0-openmpi-1.10.1-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
@@ -1629,7 +1626,6 @@ use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
 
 use COMMON
 
-opt-set-cmake-var CMAKE_CXX_STANDARD                                     STRING FORCE : 17
 opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                            STRING       : --bind-to;none
 opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                         BOOL         : ON
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D          BOOL         : ON
@@ -1671,7 +1667,6 @@ use USE-DEPRECATED|YES
 
 use COMMON_USE-MPI|NO
 
-opt-set-cmake-var CMAKE_CXX_STANDARD             STRING FORCE : 17
 opt-set-cmake-var Trilinos_ENABLE_Fortran OFF    BOOL         : OFF
 opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE BOOL         : ON
 opt-set-cmake-var CMAKE_CXX_FLAGS                STRING       : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-nonnull-compare -Wno-address -Wno-inline -Wno-unused-but-set-variable -Wno-unused-variable -Wno-unused-label -Werror -Werror=shadow -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
@@ -1701,7 +1696,6 @@ use USE-DEPRECATED|YES
 
 use COMMON
 
-opt-set-cmake-var CMAKE_CXX_STANDARD STRING FORCE : 17
 opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING     : --bind-to;none
 opt-set-cmake-var Tpetra_INST_SERIAL                            BOOL FORCE : ON
 opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                BOOL       : ON
@@ -1728,7 +1722,6 @@ use USE-DEPRECATED|NO
 
 use COMMON
 
-opt-set-cmake-var CMAKE_CXX_STANDARD STRING FORCE : 17
 opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING     : --bind-to;none
 opt-set-cmake-var Tpetra_INST_SERIAL                            BOOL FORCE : ON
 opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                BOOL       : ON
@@ -1757,7 +1750,6 @@ use USE-DEPRECATED|YES
 use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
 use COMMON
 
-opt-set-cmake-var CMAKE_CXX_STANDARD                            STRING FORCE : 17
 opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING       : --bind-to;none
 opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                BOOL         : ON
 opt-set-cmake-var CMAKE_CXX_EXTENSIONS                          BOOL         : OFF
@@ -1796,8 +1788,6 @@ use RHEL7_TEST_DISABLES|CLANG
 
 use RHEL7_POST
 
-opt-set-cmake-var CMAKE_CXX_STANDARD STRING FORCE : 17
-
 [rhel7_sems-clang-11.0.1-openmpi-1.10.1-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
 #uses sems-archive modules
 use rhel7_sems-clang-11.0.1-openmpi-1.10.1-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
@@ -1825,8 +1815,6 @@ opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D BOOL       : ON
 use RHEL7_TEST_DISABLES|CLANG
 
 use RHEL7_POST
-
-opt-set-cmake-var CMAKE_CXX_STANDARD STRING FORCE : 17
 
 [rhel7_sems-clang-11.0.1-openmpi-1.10.7-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
 # uses sems-v2 modules
@@ -1860,7 +1848,6 @@ opt-set-cmake-var Trilinos_ENABLE_STKBalance BOOL FORCE : OFF
 # opt-set-cmake-var Trilinos_ENABLE_Zoltan2Core BOOL FORCE : OFF
 # opt-set-cmake-var Trilinos_ENABLE_Zoltan2Sphynx BOOL FORCE : OFF
 
-opt-set-cmake-var CMAKE_CXX_STANDARD STRING FORCE : 14
 opt-set-cmake-var Zoltan_ENABLE_Scotch BOOL FORCE : OFF
 opt-set-cmake-var CMAKE_CXX_FLAGS STRING : -fPIC -Wall -Warray-bounds -Wchar-subscripts -Wcomment -Wenum-compare -Wformat -Wuninitialized -Wmaybe-uninitialized -Wmain -Wnarrowing -Wnonnull -Wparentheses -Wpointer-sign -Wreorder -Wreturn-type -Wsign-compare -Wsequence-point -Wtrigraphs -Wunused-function -Wunused-but-set-variable -Wunused-variable -Wwrite-strings
 
@@ -1895,8 +1882,6 @@ use USE-UVM|NO
 use USE-DEPRECATED|YES
 use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
 use COMMON
-
-opt-set-cmake-var CMAKE_CXX_STANDARD STRING : 17
 
 opt-set-cmake-var TPL_Netcdf_LIBRARIES STRING FORCE : -L${NETCDF_C_LIB|ENV}/lib;${NETCDF_C_LIB|ENV}/libnetcdf.so;${PARALLEL_NETCDF_LIB|ENV}/libpnetcdf.a
 opt-set-cmake-var TPL_HDF5_LIBRARIES STRING FORCE : ${HDF5_LIB|ENV}/libhdf5_hl.so;${HDF5_LIB|ENV}/libhdf5.a;${ZLIB_LIB|ENV}/libz.a;-ldl
@@ -1975,7 +1960,6 @@ opt-set-cmake-var SuperLU_INCLUDE_DIRS STRING FORCE : ${SUPERLU_INC|ENV}
 opt-set-cmake-var SuperLU_LIBRARY_DIRS STRING FORCE : ${SUPERLU_LIB|ENV}
 
 #CXX Settings
-opt-set-cmake-var CMAKE_CXX_STANDARD STRING FORCE : 17
 opt-set-cmake-var CMAKE_CXX_FLAGS STRING : -fPIC -Wall -Warray-bounds -Wchar-subscripts -Wcomment -Wenum-compare -Wformat -Wuninitialized -Wmaybe-uninitialized -Wmain -Wnarrowing -Wnonnull -Wparentheses -Wreorder -Wreturn-type -Wsign-compare -Wsequence-point -Wtrigraphs -Wunused-function -Wunused-but-set-variable -Wunused-variable -Wwrite-strings
 
 #Package Options
@@ -2058,7 +2042,6 @@ use USE-UVM|NO
 use USE-DEPRECATED|YES
 use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
 
-opt-set-cmake-var CMAKE_CXX_STANDARD STRING        : 17
 opt-set-cmake-var Trilinos_ENABLE_TESTS BOOL FORCE : ON
 
 # There is no netcdf available via ascdo
@@ -2091,7 +2074,6 @@ use USE-UVM|NO
 use USE-DEPRECATED|YES
 use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
 
-opt-set-cmake-var CMAKE_CXX_STANDARD STRING        : 17
 opt-set-cmake-var Trilinos_ENABLE_TESTS BOOL FORCE : ON
 
 # There is no netcdf available via ascdo
@@ -2126,7 +2108,6 @@ use USE-UVM|NO
 use USE-DEPRECATED|YES
 use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
 
-opt-set-cmake-var CMAKE_CXX_STANDARD STRING        : 17
 opt-set-cmake-var Trilinos_ENABLE_TESTS BOOL FORCE : ON
 
 # There is no netcdf available via ascdo
@@ -2162,7 +2143,6 @@ use USE-UVM|NO
 use USE-DEPRECATED|YES
 use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
 
-opt-set-cmake-var CMAKE_CXX_STANDARD STRING        : 17
 opt-set-cmake-var Trilinos_ENABLE_TESTS BOOL FORCE : ON
 
 # There is no netcdf available via ascdo
@@ -2195,7 +2175,6 @@ use USE-UVM|NO
 use USE-DEPRECATED|YES
 use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
 
-opt-set-cmake-var CMAKE_CXX_STANDARD STRING        : 17
 opt-set-cmake-var Trilinos_ENABLE_TESTS BOOL FORCE : ON
 
 # There is no netcdf available via ascdo
@@ -2227,7 +2206,6 @@ use USE-MPI|YES
 use USE-PT|NO
 use COMMON_SPACK_TPLS
 
-opt-set-cmake-var CMAKE_CXX_STANDARD                                     STRING FORCE : 17
 opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                            STRING       : --bind-to;none
 opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                         BOOL         : ON
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D          BOOL         : ON
@@ -2266,7 +2244,6 @@ use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
 
 use COMMON_SPACK_TPLS
 
-opt-set-cmake-var CMAKE_CXX_STANDARD                                     STRING FORCE : 17
 opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                            STRING       : --bind-to;none
 opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                         BOOL         : ON
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D          BOOL         : ON
@@ -2301,7 +2278,6 @@ use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
 
 use COMMON_SPACK_TPLS
 
-opt-set-cmake-var CMAKE_CXX_STANDARD             STRING FORCE : 17
 opt-set-cmake-var Trilinos_ENABLE_Fortran OFF    BOOL         : OFF
 opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE BOOL         : ON
 opt-set-cmake-var CMAKE_CXX_FLAGS                STRING       : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-nonnull-compare -Wno-address -Wno-inline -Wno-unused-but-set-variable -Wno-unused-variable -Wno-unused-label -Werror -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
@@ -2335,7 +2311,6 @@ use PACKAGE-ENABLES|PR
 
 use COMMON_SPACK_TPLS
 
-opt-set-cmake-var CMAKE_CXX_STANDARD STRING FORCE : 17
 opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING     : --bind-to;none
 opt-set-cmake-var Tpetra_INST_SERIAL                            BOOL FORCE : ON
 opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                BOOL       : ON
@@ -2364,7 +2339,6 @@ use PACKAGE-ENABLES|PR
 
 use COMMON_SPACK_TPLS
 
-opt-set-cmake-var CMAKE_CXX_STANDARD STRING FORCE : 17
 opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING     : --bind-to;none
 opt-set-cmake-var Tpetra_INST_SERIAL                            BOOL FORCE : ON
 opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                BOOL       : ON
@@ -2394,7 +2368,6 @@ use USE-DEPRECATED|YES
 use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
 
 use COMMON_SPACK_TPLS
-opt-set-cmake-var CMAKE_CXX_STANDARD                            STRING FORCE : 17
 opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING       : --bind-to;none
 opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                BOOL         : ON
 opt-set-cmake-var CMAKE_CXX_EXTENSIONS                          BOOL         : OFF


### PR DESCRIPTION
@trilinos/framework

## Motivation
We want to use the default C++ standard for most testing, unless we're in the process of advancing standards.  In particular, some of the build configs were still set to C++14 which caused the nightly RDC build to fail.