### PR TITLE
Teuchos: StackedTimer Watchr documentation, date override

### DIFF
--- a/packages/teuchos/comm/src/Teuchos_StackedTimer.hpp
+++ b/packages/teuchos/comm/src/Teuchos_StackedTimer.hpp
@@ -728,7 +728,12 @@ public:
    * so that Watchr knows it is a different data series than runs of the same test from other builds.
    *
    * If \c $WATCHR_BUILD_NAME is not set or is empty, the filename is just \c name_$DATESTAMP.xml .
-   * DATESTAMP is calculated from the current UTC time, in the format YYYY_MM_DD.
+   * DATESTAMP is normally calculated from the current UTC time, in the format YYYY_MM_DD. DATESTAMP
+   * can be overridden by setting $WATCHR_BUILD_DATE to a date (also in YYYY_MM_DD format).
+   *
+   * Optionally, the environment variable \c $TRILINOS_GIT_SHA can be set to the Git revision hash. This
+   * is added to the performance report as metadata, and will appear in Watchr when mousing over a data point.
+   * Only the first 10 characters are output.
    *
    * In the filename, all spaces in will be replaced by underscores.
    *


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/teuchos 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
- In doxygen for ``StackedTimer::reportWatchrXML()``, document the optional ``TRILINOS_GIT_SHA`` environment variable (just a comment change)
- Add a new variable ``WATCHR_BUILD_DATE`` to override the build date in the report filename and the XML header of the report. If unset, the date is just when the build happened (this is the current behavior). This lets us run on a Trilinos version from the past, and have the date on the report match the date of the version.

This is needed because some recent performance dashboard data was generated from incorrect builds and needs to be regenerated.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
Tested by running a performance test and outputting Watchr reports - once with the default date (today), and once with the date overridden. This created two separate reports with the correct names and contents.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->