### PR TITLE
Tpetra: fixup Kokkos compatibility `ExecSpace::concurrency()` not a static member function

### DIFF
--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -2001,8 +2001,8 @@ namespace Tpetra {
 
       // This fixes GitHub Issue #4418.
       const bool use_atomic_updates = unpackOnHost ?
-        host_exec_space::concurrency () != 1 :
-        dev_exec_space::concurrency () != 1;
+        host_exec_space().concurrency () != 1 :
+        dev_exec_space().concurrency () != 1;
 
       if (printDebugOutput) {
         std::ostringstream os;


### PR DESCRIPTION
Closes #11331

@csiefer2 
@ndellingwood 