### PR TITLE
Cmake: Remove Epetra stack from Rocketman testing

### DIFF
--- a/cmake/ctest/drivers/rocketman/ctest_linux_experimental_mpi_release_avatar_rocketman.cmake
+++ b/cmake/ctest/drivers/rocketman/ctest_linux_experimental_mpi_release_avatar_rocketman.cmake
@@ -75,6 +75,7 @@ SET(CTEST_TEST_TIMEOUT 14400) # twice the default value, for valgrind
 SET(CTEST_DO_MEMORY_TESTING FALSE)
 
 SET(Trilinos_PACKAGES TrilinosCouplings MueLu )
+SET(Trilinos_EXCLUDE_PACKAGES Epetra Domi PyTrilinos Moertel)
 
 # If true, this option yields faster builds. In that case, however, it won't disable any upstream package that fails to compile.
 SET(Trilinos_CTEST_DO_ALL_AT_ONCE TRUE)

--- a/cmake/ctest/drivers/rocketman/ctest_linux_nightly_mpi_release_muelu_rocketman.cmake
+++ b/cmake/ctest/drivers/rocketman/ctest_linux_nightly_mpi_release_muelu_rocketman.cmake
@@ -75,6 +75,7 @@ SET(CTEST_TEST_TIMEOUT 14400) # twice the default value, for valgrind
 SET(CTEST_DO_MEMORY_TESTING FALSE)
 
 SET(Trilinos_PACKAGES MueLu Xpetra Amesos2)
+SET(Trilinos_EXCLUDE_PACKAGES Epetra Domi PyTrilinos Moertel)
 
 # If true, this option yields faster builds. In that case, however, it won't disable any upstream package that fails to compile.
 SET(Trilinos_CTEST_DO_ALL_AT_ONCE TRUE)


### PR DESCRIPTION
@cgcgcg 

Rocketman nightlies are struggling to build Ifpack1 and Amesos1 due to errors related to SuperLU. These builds really don't need the Epetra stack, and I'd rather just see if the build succeeds without the Epetra stack as opposed to troubleshooting an issue that may potentially require me to rebuild SuperLU.