### PR TITLE
Fix Compadre typedef for Kokkos >= 4.0.0

### DIFF
--- a/packages/compadre/src/Compadre_Typedefs.hpp
+++ b/packages/compadre/src/Compadre_Typedefs.hpp
@@ -103,7 +103,7 @@ typedef typename pool_type::generator_type generator_type;
 // KOKKOS_VERSION / 10000 is the major version
 #ifdef KOKKOS_VERSION
   #define COMPADRE_KOKKOS_VERSION_MAJOR KOKKOS_VERSION / 10000
-  #define COMPADRE_KOKKOS_VERSION_MINOR KOKKOS_VERSION / 100 % 100
+  #define COMPADRE_KOKKOS_VERSION_MINOR KOKKOS_VERSION / 100 % 100 
   #if COMPADRE_KOKKOS_VERSION_MAJOR < 4
     #if COMPADRE_KOKKOS_VERSION_MINOR >= 7
         using KokkosInitArguments = Kokkos::InitializationSettings;
@@ -113,6 +113,10 @@ typedef typename pool_type::generator_type generator_type;
         using KokkosInitArguments = Kokkos::InitArguments;
         constexpr char KOKKOS_THREADS_ARG[] = "--kokkos-threads";
     #endif
+  #elif COMPADRE_KOKKOS_VERSION_MAJOR >= 4
+      using KokkosInitArguments = Kokkos::InitializationSettings;
+      #define COMPADRE_KOKKOS_GREATEREQUAL_3_7
+      constexpr char KOKKOS_THREADS_ARG[] = "--kokkos-num-threads";
   #endif
 #else // older version
   using KokkosInitArguments = Kokkos::InitArguments;


### PR DESCRIPTION
Fixes an omission in the `COMPADRE_KOKKOS_VERSION_MAJOR` when >= 4.

Thank you @ndellingwood!