### PR TITLE
Blas complex cast fix

### DIFF
--- a/packages/teuchos/numerics/src/Teuchos_BLAS.cpp
+++ b/packages/teuchos/numerics/src/Teuchos_BLAS.cpp
@@ -333,7 +333,8 @@ namespace Teuchos {
     CDOT_F77(&z, &n, x, &incx, y, &incy);
     return z;
 #elif defined(HAVE_TEUCHOS_BLASFLOAT)
-    return CDOT_F77(&n, x, &incx, y, &incy);
+    Teuchos_Complex_float_type_name z = CDOT_F77(&n, x, &incx, y, &incy);
+    return TEUCHOS_BLAS_CONVERT_COMPLEX_FORTRAN_TO_CXX(float, z);
 #else // Wow, you just plain don't have this routine.
     // mfh 01 Feb 2013: See www.netlib.org/blas/cdotc.f.
     // I've enhanced this by accumulating in double precision.
@@ -512,7 +513,8 @@ namespace Teuchos {
 
 #  endif // defined(HAVE_FIXABLE_COMPLEX_BLAS_PROBLEM)
 #else
-    return ZDOT_F77(&n, x, &incx, y, &incy);
+    Teuchos_Complex_double_type_name z = ZDOT_F77(&n, x, &incx, y, &incy);
+    return TEUCHOS_BLAS_CONVERT_COMPLEX_FORTRAN_TO_CXX(double, z);
 #endif
   }
 

--- a/packages/teuchos/numerics/src/Teuchos_BLAS_wrappers.hpp
+++ b/packages/teuchos/numerics/src/Teuchos_BLAS_wrappers.hpp
@@ -166,6 +166,9 @@
 #define CHERK_F77   F77_BLAS_MANGLE(cherk,CHERK)
 #define CTRMM_F77   F77_BLAS_MANGLE(ctrmm,CTRMM)
 #define CTRSM_F77   F77_BLAS_MANGLE(ctrsm,CTRSM)
+#define TEUCHOS_BLAS_CONVERT_COMPLEX_FORTRAN_TO_CXX(TYPE, Z) \
+   reinterpret_cast<std::complex<TYPE>&>(Z);
+// NOTE: The above is guaranteed to be okay given the C99 and C++11 standards
 
 #endif /* HAVE_TEUCHOS_COMPLEX */
 

--- a/packages/teuchos/numerics/src/Teuchos_LAPACK.cpp
+++ b/packages/teuchos/numerics/src/Teuchos_LAPACK.cpp
@@ -115,12 +115,6 @@ namespace Teuchos
 {
   // BEGIN INT, FLOAT SPECIALIZATION IMPLEMENTATION //
 
-  std::complex<float> convert_Fortran_complex_to_CXX_complex(_Complex float val)
-  {
-    return reinterpret_cast<std::complex<float>&>(val);
-    // NOTE: The above is guaranteed to be okay given the C99 and C++11 standards
-  }
-
   void LAPACK<int, float>::PTTRF(const int& n, float* d, float* e, int* info) const
   { SPTTRF_F77(&n,d,e,info); }
 
@@ -485,12 +479,6 @@ namespace Teuchos
   // END INT, FLOAT SPECIALIZATION IMPLEMENTATION //
 
   // BEGIN INT, DOUBLE SPECIALIZATION IMPLEMENTATION //
-
-  std::complex<double> convert_Fortran_complex_to_CXX_complex(_Complex double val)
-  {
-    return reinterpret_cast<std::complex<double>&>(val);
-    // NOTE: The above is guaranteed to be okay given the C99 and C++11 standards
-  }
 
   void LAPACK<int, double>::PTTRF(const int& n, double* d, double* e, int* info) const
   { DPTTRF_F77(&n,d,e,info); }
@@ -1287,7 +1275,8 @@ namespace Teuchos
 #ifdef HAVE_TEUCHOS_LAPACKLARND
   std::complex<float> LAPACK<int, std::complex<float> >::LARND( const int& idist, int* seed ) const
   {
-    return(convert_Fortran_complex_to_CXX_complex(CLARND_F77(&idist, seed)));
+    float _Complex z = CLARND_F77(&idist, seed);
+    return TEUCHOS_LAPACK_CONVERT_COMPLEX_FORTRAN_TO_CXX(float, z);
   }
 #endif
 
@@ -1695,7 +1684,8 @@ namespace Teuchos
 #ifdef HAVE_TEUCHOS_LAPACKLARND
   std::complex<double> LAPACK<int, std::complex<double> >::LARND( const int& idist, int* seed ) const
   {
-    return(convert_Fortran_complex_to_CXX_complex(ZLARND_F77(&idist, seed)));
+    double _Complex z = ZLARND_F77(&idist, seed);
+    return TEUCHOS_LAPACK_CONVERT_COMPLEX_FORTRAN_TO_CXX(double, z);
   }
 #endif
 

--- a/packages/teuchos/numerics/src/Teuchos_LAPACK.hpp
+++ b/packages/teuchos/numerics/src/Teuchos_LAPACK.hpp
@@ -92,10 +92,6 @@ namespace Teuchos
     static inline T notDefined() { return T::LAPACK_routine_not_defined_for_this_type(); }
   };
 
-  std::complex<double> convert_Fortran_complex_to_CXX_complex(_Complex double val);
-
-  std::complex<float> convert_Fortran_complex_to_CXX_complex(_Complex float val);
-
   template<typename OrdinalType, typename ScalarType>
   class LAPACK
   {

--- a/packages/teuchos/numerics/src/Teuchos_LAPACK_wrappers.hpp
+++ b/packages/teuchos/numerics/src/Teuchos_LAPACK_wrappers.hpp
@@ -215,6 +215,9 @@
 #define ZLARND_F77  F77_BLAS_MANGLE(zlarnd,ZLARND)
 #define ZLARNV_F77  F77_BLAS_MANGLE(zlarnv,ZLARNV)
 #define ZGEQP3_F77  F77_BLAS_MANGLE(zgeqp3,ZGEQP3)
+#define TEUCHOS_LAPACK_CONVERT_COMPLEX_FORTRAN_TO_CXX(TYPE, Z) \
+   reinterpret_cast<std::complex<TYPE>&>(Z);
+// NOTE: The above is guaranteed to be okay given the C99 and C++11 standards
 
 #endif /* HAVE_TEUCHOS_COMPLEX */
 


### PR DESCRIPTION
Commit:
2425baf8 packages/teuchos/numerics/src/Teuchos_BLAS_wrappers.hpp (James Elliott         2022-09-12 15:33:51 -0700 269)

breaks `apple-clang` builds of Teuchos numerics when combined with `openblas`.

The reason is an illegal cast from `float _Complex` to `std::complex<float>` and `double _Complex` to `std::complex<double>`.

```sh
[ 48%] Building CXX object packages/teuchos/numerics/src/CMakeFiles/teuchosnumerics.dir/Teuchos_BLAS.cpp.o
/Users/pakuber/Compadre/Trilinos-new/packages/teuchos/numerics/src/Teuchos_BLAS.cpp:336:12: error: implicit conversion from '_Complex float' to 'float' is not permitted in C++
    return CDOT_F77(&n, x, &incx, y, &incy);
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/pakuber/Compadre/Trilinos-new/packages/teuchos/numerics/src/Teuchos_BLAS_wrappers.hpp:155:21: note: expanded from macro 'CDOT_F77'
#define CDOT_F77    F77_BLAS_MANGLE(cdotc,CDOTC)
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/pakuber/Compadre/Trilinos-new/build/packages/teuchos/core/src/Teuchos_config.h:10:37: note: expanded from macro 'F77_BLAS_MANGLE'
 #define F77_BLAS_MANGLE(name,NAME) name ## _
                                    ^~~~~~~~~
<scratch space>:11:1: note: expanded from here
cdotc_
^~~~~~
/Users/pakuber/Compadre/Trilinos-new/packages/teuchos/numerics/src/Teuchos_BLAS.cpp:515:12: error: implicit conversion from '_Complex double' to 'double' is not permitted in C++
    return ZDOT_F77(&n, x, &incx, y, &incy);
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/pakuber/Compadre/Trilinos-new/packages/teuchos/numerics/src/Teuchos_BLAS_wrappers.hpp:112:21: note: expanded from macro 'ZDOT_F77'
#define ZDOT_F77    F77_BLAS_MANGLE(zdotc,ZDOTC)
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/pakuber/Compadre/Trilinos-new/build/packages/teuchos/core/src/Teuchos_config.h:10:37: note: expanded from macro 'F77_BLAS_MANGLE'
 #define F77_BLAS_MANGLE(name,NAME) name ## _
                                    ^~~~~~~~~
<scratch space>:30:1: note: expanded from here
zdotc_
^~~~~~
2 errors generated.
make[2]: *** [packages/teuchos/numerics/src/CMakeFiles/teuchosnumerics.dir/Teuchos_BLAS.cpp.o] Error 1
make[1]: *** [packages/teuchos/numerics/src/CMakeFiles/teuchosnumerics.dir/all] Error 2
make: *** [all] Error 2
```

CMake configuration that reproduces issue:
```cmake
cmake \
-DCMAKE_Fortran_COMPILER:STRING=/opt/homebrew/bin/gfortran-12 \
-DTrilinos_VERBOSE_CONFIGURE:BOOL=OFF \
-DBUILD_SHARED_LIBS:BOOL=ON \
-DCMAKE_CXX_STANDARD:STRING=17 \
-DTrilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=OFF \
-DTrilinos_ENABLE_ALL_PACKAGES:BOOL=OFF \
-DTrilinos_ENABLE_CXX11:BOOL=ON \
-DTrilinos_ENABLE_DEBUG:BOOL=OFF \
-DTrilinos_ENABLE_EXAMPLES:BOOL=OFF \
-DTrilinos_ENABLE_SECONDARY_TESTED_CODE:BOOL=ON \
-DTrilinos_ENABLE_TESTS:BOOL=OFF \
-DTrilinos_ENABLE_Fortran:BOOL=ON \
-DTrilinos_ENABLE_OpenMP:BOOL=OFF \
-DTrilinos_ENABLE_EXPLICIT_INSTANTIATION:BOOL=ON \
-DTrilinos_ENABLE_Epetra:BOOL=ON \
-DTrilinos_ENABLE_Kokkos:BOOL=ON \
-DTrilinos_ENABLE_Tpetra:BOOL=ON \
-DTPL_ENABLE_MPI:BOOL=ON \
-DTeuchos_ENABLE_COMPLEX:BOOL=ON \
-DTeuchos_ENABLE_FLOAT:BOOL=OFF \
-DTpetra_INST_OPENMP:BOOL=OFF \
-DTpetra_INST_DOUBLE:BOOL=ON \
-DTpetra_INST_COMPLEX_DOUBLE:BOOL=ON \
-DTpetra_INST_COMPLEX_FLOAT:BOOL=OFF \
-DTpetra_INST_FLOAT:BOOL=OFF \
-DTpetra_INST_SERIAL:BOOL=ON \
-DTpetra_INST_INT_INT:BOOL=OFF \
-DTpetra_INST_INT_LONG:BOOL=OFF \
-DTpetra_INST_INT_LONG_LONG:BOOL=ON \
-DKokkos_ENABLE_OPENMP:BOOL=OFF \
-DCMAKE_MACOSX_RPATH:BOOL=ON \
-DTPL_ENABLE_BLAS:BOOL=ON \
-DBLAS_ROOT=/Users/pakuber/Compadre/Trilinos-new/build/OpenBLAS/build/install/ \
-DBLAS_INCLUDE_DIRS=/Users/pakuber/Compadre/Trilinos-new/build/OpenBLAS/build/install/include \
-DBLAS_LIBRARY_DIRS=/Users/pakuber/Compadre/Trilinos-new/build/OpenBLAS/build/install/lib \
-DTPL_ENABLE_LAPACK:BOOL=ON \
-DLAPACK_INCLUDE_DIRS=/Users/pakuber/Compadre/Trilinos-new/build/OpenBLAS/build/install/include \
-DLAPACK_LIBRARY_DIRS=/Users/pakuber/Compadre/Trilinos-new/build/OpenBLAS/build/install/lib \
-DLAPACK_LIBRARY_NAMES:STRING=openblas \
-DBLAS_LIBRARY_NAMES:STRING=openblas \
..
```
@trilinos/teuchos 

This PR fixes the illegal casts.