### PR TITLE
Ifpack2: BlockTriDi StackedTimer/Watchr support

### DIFF
--- a/packages/ifpack2/example/BlockTriDi.cpp
+++ b/packages/ifpack2/example/BlockTriDi.cpp
@@ -11,13 +11,14 @@
 #include <Teuchos_CommandLineProcessor.hpp>
 #include <Teuchos_ParameterXMLFileReader.hpp>
 #include <Teuchos_TimeMonitor.hpp>
+#include "Teuchos_StackedTimer.hpp"
 #include <Teuchos_StandardCatchMacros.hpp>
 
 namespace { // (anonymous)
 
 // Values of command-line arguments.
 struct CmdLineArgs {
-  CmdLineArgs ():blockSize(-1),numIters(10),tol(1e-12),nx(172),lpp(10){}
+  CmdLineArgs ():blockSize(-1),numIters(10),tol(1e-12),nx(172),lpp(10),useStackedTimer(false){}
 
   std::string mapFilename;
   std::string matrixFilename;
@@ -28,6 +29,8 @@ struct CmdLineArgs {
   double tol;
   int nx;
   int lpp;
+  bool useStackedTimer;
+  std::string problemName;
 };
 
 // Read in values of command-line arguments.
@@ -48,6 +51,9 @@ getCmdLineArgs (CmdLineArgs& args, int argc, char* argv[])
   cmdp.setOption ("tol", &args.tol, "Solver tolerance");
   cmdp.setOption ("nx", &args.nx, "If using inline meshing, number of nodes in the x direction per proc");
   cmdp.setOption ("lpp", &args.lpp, "If using inline meshing, number of lines per proc");
+  cmdp.setOption ("withStackedTimer", "withoutStackedTimer", &args.useStackedTimer,
+      "Whether to run with a StackedTimer and print the timer tree at the end (and try to output Watchr report)");
+  cmdp.setOption("problemName", &args.problemName, "Human-readable problem name for Watchr plot");
   auto result = cmdp.parse (argc, argv);
   return result == Teuchos::CommandLineProcessor::PARSE_SUCCESSFUL;
 }
@@ -182,6 +188,7 @@ main (int argc, char* argv[])
   using Teuchos::RCP;
   using Teuchos::rcp;
   using Teuchos::Time;
+  using Teuchos::StackedTimer;
   using std::cerr;
   using std::endl;
   typedef Tpetra::CrsMatrix<> crs_matrix_type;
@@ -203,15 +210,8 @@ main (int argc, char* argv[])
 
   Tpetra::ScopeGuard tpetraScope (&argc, &argv);
 
-  RCP<Time> totalTime = Teuchos::TimeMonitor::getNewTimer ("Total");
-  RCP<Time> precSetupTime =
-    Teuchos::TimeMonitor::getNewTimer ("Preconditioner setup");
-  RCP<Time> solveTime = Teuchos::TimeMonitor::getNewTimer ("Solve");
-
-  Teuchos::TimeMonitor totalTimeMon (*totalTime);
   RCP<const Comm<int> > comm = Tpetra::getDefaultComm ();
   bool rank0 = comm->getRank() == 0;
-
 
   // Get command-line arguments.
   CmdLineArgs args;
@@ -221,6 +221,18 @@ main (int argc, char* argv[])
     return EXIT_FAILURE;
   }
 
+  // If using StackedTimer, then do not time Galeri or matrix I/O because that will dominate the total time.
+
+  RCP<StackedTimer> stackedTimer;
+  RCP<Time> totalTime;
+  RCP<Teuchos::TimeMonitor> totalTimeMon;
+  RCP<Time> precSetupTime = Teuchos::TimeMonitor::getNewTimer ("Preconditioner setup");
+  RCP<Time> solveTime = Teuchos::TimeMonitor::getNewTimer ("Solve");
+  if(!args.useStackedTimer)
+  {
+    totalTime = Teuchos::TimeMonitor::getNewTimer ("Total");
+    totalTimeMon = rcp(new Teuchos::TimeMonitor(*totalTime));
+  }
 
   bool inline_matrix = false;
 #if defined(HAVE_IFPACK2_XPETRA)
@@ -350,6 +362,11 @@ main (int argc, char* argv[])
              << " rows with an implied block size of "<< ((double)numDomains / (double)numRows)<<std::endl;
   }
 
+  if(args.useStackedTimer)
+  {
+    stackedTimer = rcp(new StackedTimer("BlockTriDiagonalSolver"));
+    Teuchos::TimeMonitor::setStackedTimer(stackedTimer);
+  }
 
   // Initial Guess
   if(rank0) std::cout<<"Allocating initial guess..."<<std::endl;
@@ -445,8 +462,30 @@ main (int argc, char* argv[])
 
 
   // Report timings.
-  Teuchos::TimeMonitor::report (comm.ptr (), std::cout);
-  
+  if(args.useStackedTimer)
+  {
+    stackedTimer->stopBaseTimer();
+    StackedTimer::OutputOptions options;
+    options.num_histogram=3;
+    options.print_warnings = false;
+    options.output_histogram = true;
+    options.output_fraction=true;
+    options.output_minmax = true;
+    stackedTimer->report(std::cout, comm, options);
+    auto xmlOut = stackedTimer->reportWatchrXML(args.problemName, comm);
+    if(rank0)
+    {
+      if(xmlOut.length())
+        std::cout << "\nAlso created Watchr performance report " << xmlOut << '\n';
+    }
+  }
+  else
+  {
+    // Stop the "Total" timer.
+    if(!args.useStackedTimer)
+      totalTimeMon = Teuchos::null;
+    Teuchos::TimeMonitor::report (comm.ptr (), std::cout);
+  }
 
   // Test output if this doesn't crash
   bool success=true;
@@ -459,8 +498,8 @@ main (int argc, char* argv[])
   TEUCHOS_STANDARD_CATCH_STATEMENTS(verbose, std::cerr, success);
   */
 
-  
-  std::cout<<"End Result: TEST PASSED"<<std::endl;
+  comm->barrier();
+  if(rank0) std::cout<<"End Result: TEST PASSED"<<std::endl;
 
   return ( success ? EXIT_SUCCESS : EXIT_FAILURE );
 }


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/ifpack2 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Lets the Ifpack2_BlockTriDiagonalSolver be used to drive performance tests that are plotted in Watchr. Adds ``--withStackedTimer`` option to enable stacked timers, and ``--problemName="..."`` option to put a description of the matrix/problem in the Watchr plot title.

Also fix an issue in flat timer mode (``--withoutStackedTimer``) where the "Total" timer would always read 0, because it was never stopped.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
Tested by comparing new and old flat timer output, and then by running with stacked timer and outputting a Watchr report.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->