### PR TITLE
tpetra: add missing fences for async deep_copy use

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_DistributorActor.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorActor.hpp
@@ -488,6 +488,8 @@ void DistributorActor::doPosts(const DistributorPlan& plan,
           packOffset(sendArray, exports, sendArrayOffset, plan.getIndicesTo()[j]*numPackets, numPackets);
           sendArrayOffset += numPackets;
         }
+        typename ExpView::execution_space().fence();
+
         ImpView tmpSend =
           subview_offset(sendArray, size_t(0), plan.getLengthsTo()[p]*numPackets);
 
@@ -847,6 +849,8 @@ void DistributorActor::doPosts(const DistributorPlan& plan,
               indicesOffsets[j], numExportPacketsPerLID[j]);
           sendArrayOffset += numExportPacketsPerLID[j];
         }
+        typename ExpView::execution_space().fence();
+
         if (numPacketsTo_p > 0) {
           ImpView tmpSend =
             subview_offset(sendArray, size_t(0), numPacketsTo_p);


### PR DESCRIPTION
Adding missing fences following async deep_copy calls to ensure copy completes before handoff to send This resolves a test failure in TpetraCore_Issue1454 with Cuda-Aware MPI in cuda/11.4.2 builds without UVM

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra

## Motivation

Resolve test failure
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->



## Testing

Tested with cuda/11.4.2, uvm off, and Cuda-Aware MPI (sems modules)

<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->