### PR TITLE
Framework: Use spack TPLs for Intel

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1881,7 +1881,7 @@ use RHEL7_POST
 
 [rhel7_sems-intel-2021.3-sems-openmpi-4.0.5_release-debug_shared_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
 # uses sems-v2 modules
-use RHEL7_SEMS_COMPILER|INTEL
+use RHEL7_COMPILER|INTEL
 use BUILD-TYPE|RELEASE-DEBUG
 use RHEL7_SEMS_LIB-TYPE|SHARED
 use KOKKOS-ARCH|NO-KOKKOS-ARCH
@@ -1894,7 +1894,7 @@ use USE-RDC|NO
 use USE-UVM|NO
 use USE-DEPRECATED|YES
 use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
-use COMMON
+use COMMON_SPACK_TPLS
 
 opt-set-cmake-var CMAKE_CXX_STANDARD STRING : 17
 


### PR DESCRIPTION
@trilinos/framework 

## Motivation
Want Intel builds re-enabled, and the existing configuration is a bit wonky with the move from sems-dev to sems modules.  I tested this with the new environment specs, and it built correctly for me.  Note that MKL is not enabled, since there were some more errors, but I figure it's better to get the Intel build back and iterate later to get MKL in use again.