### PR TITLE
Framework: Enable shadowing errors in more fixed packages

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1516,7 +1516,6 @@ opt-set-cmake-var KokkosKernels_batched_dla_cuda_MPI_1_SET_RUN_SERIAL BOOL FORCE
 opt-set-cmake-var Amesos_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var Amesos2_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var Belos_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Compadre_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var Domi_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var Epetra_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var EpetraExt_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow


### PR DESCRIPTION
Comapdre fixed shadowing warnings, so enable them as errors now to prevent recurrences.

User Support Ticket(s) or Story Referenced: #11497

@trilinos/compadre 

## Motivation
Want to prevent future shadowing warnings.