### PR TITLE
Ifpack2: Use Kokkos::Experimental::partition_space instead of cudaStream

### DIFF
--- a/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
@@ -553,10 +553,6 @@ namespace Ifpack2 {
 
       local_ordinal_type_1d_view dm2cm; // permutation
 
-#if defined(KOKKOS_ENABLE_CUDA)
-      //using cuda_stream_1d_std_vector = std::vector<cudaStream_t>;
-      //cuda_stream_1d_std_vector stream;    
-#endif
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
       using exec_instance_1d_std_vector = std::vector<execution_space>;
       exec_instance_1d_std_vector exec_instances;  
@@ -669,15 +665,9 @@ namespace Ifpack2 {
 
       void createExecutionSpaceInstances() {
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
-        const local_ordinal_type num_streams = 8;
+        //The following line creates 8 streams:
         exec_instances =
           Kokkos::Experimental::partition_space(execution_space(), 1, 1, 1, 1, 1, 1, 1, 1);
-#endif
-      }
-
-      void destroyExecutionSpaceInstances() {
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
-        //exec_instances.clear();
 #endif
       }
 
@@ -701,10 +691,6 @@ namespace Ifpack2 {
         createMpiRequests(import);
         createSendRecvIDs(import);
         createExecutionSpaceInstances();
-      }
-
-      ~AsyncableImport() {
-        destroyExecutionSpaceInstances();
       }
 
       void createDataBuffer(const local_ordinal_type &num_vectors) {

--- a/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
@@ -554,11 +554,12 @@ namespace Ifpack2 {
       local_ordinal_type_1d_view dm2cm; // permutation
 
 #if defined(KOKKOS_ENABLE_CUDA)
-      using cuda_stream_1d_std_vector = std::vector<cudaStream_t>;
-      cuda_stream_1d_std_vector stream;
-
+      //using cuda_stream_1d_std_vector = std::vector<cudaStream_t>;
+      //cuda_stream_1d_std_vector stream;    
+#endif
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
       using exec_instance_1d_std_vector = std::vector<execution_space>;
-      exec_instance_1d_std_vector exec_instances;      
+      exec_instance_1d_std_vector exec_instances;  
 #endif
 
       // for cuda
@@ -659,7 +660,7 @@ namespace Ifpack2 {
           const auto pid_send_value = pids.send[i];
           for (local_ordinal_type j=0,jend=epids.size();j<jend;++j)
             if (epids[j] == pid_send_value) lids_send_host[cnt++] = elids[j];
-#if !defined(__CUDA_ARCH__)
+#if !defined(__HIP_DEVICE_COMPILE__) && !defined(__CUDA_ARCH__)
           TEUCHOS_ASSERT(static_cast<size_t>(cnt) == offset_host.send[i+1]);
 #endif
         }
@@ -667,30 +668,16 @@ namespace Ifpack2 {
       }
 
       void createExecutionSpaceInstances() {
-#if defined(KOKKOS_ENABLE_CUDA)
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
         const local_ordinal_type num_streams = 8;
-        {
-          stream.clear();
-          stream.resize(num_streams);
-          exec_instances.clear();
-          exec_instances.resize(num_streams);
-          for (local_ordinal_type i=0;i<num_streams;++i) {
-            KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamCreateWithFlags(&stream[i], cudaStreamNonBlocking));
-            ExecutionSpaceFactory<execution_space>::createInstance(stream[i], exec_instances[i]);
-          }
-        }
+        exec_instances =
+          Kokkos::Experimental::partition_space(execution_space(), 1, 1, 1, 1, 1, 1, 1, 1);
 #endif
       }
 
       void destroyExecutionSpaceInstances() {
-#if defined(KOKKOS_ENABLE_CUDA)
-        {
-          const local_ordinal_type num_streams = stream.size();
-          for (local_ordinal_type i=0;i<num_streams;++i)
-            KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamDestroy(stream[i]));
-        }
-        stream.clear();
-        exec_instances.clear();
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
+        //exec_instances.clear();
 #endif
       }
 
@@ -750,7 +737,7 @@ namespace Ifpack2 {
       // - cuda only with kokkos develop branch
       // ======================================================================
 
-#if defined(KOKKOS_ENABLE_CUDA) 
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
       template<typename PackTag>
       static
       void copy(const local_ordinal_type_1d_view &lids_,
@@ -925,8 +912,8 @@ namespace Ifpack2 {
             });
 #endif
         } else {
-#if defined(__CUDA_ARCH__)
-          TEUCHOS_TEST_FOR_EXCEPT_MSG(true, "Error: CUDA should not see this code");
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+          TEUCHOS_TEST_FOR_EXCEPT_MSG(true, "Error: device compiler should not see this code");
 #else
           {
             const Kokkos::RangePolicy<execution_space> policy(0, idiff*num_vectors);
@@ -1010,7 +997,7 @@ namespace Ifpack2 {
       /// front interface
       ///
       void asyncSendRecv(const impl_scalar_type_2d_view_tpetra &mv) {
-#if defined(KOKKOS_ENABLE_CUDA)
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
 #if defined(IFPACK2_BLOCKTRIDICONTAINER_USE_EXEC_SPACE_INSTANCES)
         asyncSendRecvVar1(mv);
 #else
@@ -1021,7 +1008,7 @@ namespace Ifpack2 {
 #endif
       }
       void syncRecv() {
-#if defined(KOKKOS_ENABLE_CUDA)
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
 #if defined(IFPACK2_BLOCKTRIDICONTAINER_USE_EXEC_SPACE_INSTANCES)
         syncRecvVar1();
 #else
@@ -1601,7 +1588,7 @@ namespace Ifpack2 {
         const auto dommap = g.getDomainMap();
         TEUCHOS_ASSERT( !(rowmap.is_null() || colmap.is_null() || dommap.is_null()));
 
-#if !defined(__CUDA_ARCH__)
+#if !defined(__CUDA_ARCH__) && !defined(__HIP_DEVICE_COMPILE__)
         const Kokkos::RangePolicy<host_execution_space> policy(0,nrows);
         Kokkos::parallel_for
           ("performSymbolicPhase::RangePolicy::col2row",
@@ -2569,7 +2556,7 @@ namespace Ifpack2 {
 
       // copy to multivectors : damping factor and Y_scalar_multivector
       Unmanaged<impl_scalar_type_2d_view_tpetra> Y_scalar_multivector;
-#if defined(__CUDA_ARCH__)
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
       AtomicUnmanaged<impl_scalar_type_1d_view> Z_scalar_vector;
 #else
       /* */ Unmanaged<impl_scalar_type_1d_view> Z_scalar_vector;


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/ifpack2 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

This PR updates the Block Tridiagonal Solver to use `Kokkos::Experimental::partition_space` instead of `cudaStream`.
This PR has been tested on V100 and MI250.
The performance on V100 are the same as the ones of the previous implementation.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->