### PR TITLE
MueLu: Fix use of dependent template name in MueLu_Hierarchy_def.hpp

### DIFF
--- a/packages/muelu/src/MueCentral/MueLu_Hierarchy_def.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_Hierarchy_def.hpp
@@ -517,7 +517,7 @@ namespace MueLu {
 
         if (!setLastLevelviaMaxCoarseSize) {
           if   (Levels_[nextLevelID-1]->IsAvailable("P"))  {
-            if (Levels_[nextLevelID-1]->Get<RCP<Matrix> >("P") == Teuchos::null)   actualNumLevels = nextLevelID-1;
+            if (Levels_[nextLevelID-1]->template Get<RCP<Matrix> >("P") == Teuchos::null)   actualNumLevels = nextLevelID-1;
           }
           else actualNumLevels = nextLevelID-1;
         }
@@ -531,7 +531,7 @@ namespace MueLu {
          if (coarseFact.is_null())
            coarseFact = rcp(new TopSmootherFactory(coarseLevelManager, "CoarseSolver"));
          Levels_[nextLevelID-2]->Request(*coarseFact);
-         if ( !(Levels_[nextLevelID-2]->Get<RCP<Matrix> >("A").is_null() ))
+         if ( !(Levels_[nextLevelID-2]->template Get<RCP<Matrix> >("A").is_null() ))
            coarseFact->Build( *(Levels_[nextLevelID-2]));
          Levels_[nextLevelID-2]->Release(*coarseFact);
        }


### PR DESCRIPTION
@trilinos/muelu 
@jhux2 

Closes #11590 and fixes errors with Clang 9.