### PR TITLE
Seacas fix symbol clash

### DIFF
--- a/packages/seacas/libraries/aprepro_lib/apr_getline.cc
+++ b/packages/seacas/libraries/aprepro_lib/apr_getline.cc
@@ -36,9 +36,6 @@
 #ifndef __unix__
 #define __unix__ 1
 #endif
-
-#include <termios.h>
-struct termios io_new_termios, io_old_termios;
 #endif
 
 /********************* C library headers ********************************/
@@ -121,6 +118,11 @@ namespace {
 #endif
 
 namespace {
+#ifdef __unix__
+#include <termios.h>
+  struct termios io_new_termios, io_old_termios;
+#endif
+
   void gl_char_init(void) /* turn off input echo */
   {
 #ifdef __unix__

--- a/packages/seacas/libraries/ioss/src/Ioss_Getline.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Getline.C
@@ -36,9 +36,6 @@
 #ifndef __unix__
 #define __unix__ 1
 #endif
-
-#include <termios.h>
-struct termios io_new_termios, io_old_termios;
 #endif
 
 /********************* C library headers ********************************/
@@ -121,6 +118,12 @@ namespace {
 #endif
 
 namespace {
+#ifdef __unix__
+#include <termios.h>
+  struct termios io_new_termios;
+  struct termios io_old_termios;
+#endif
+
   void gl_char_init(void) /* turn off input echo */
   {
 #ifdef __unix__


### PR DESCRIPTION
Fix symbol clash with termio global variables.  Move to blank namespace.

@trilinos/seacas

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes #11601 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->