### PR TITLE
Panzer: release local views to avoid tpetra throw

### DIFF
--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_PeriodicBC_Matcher.cpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_PeriodicBC_Matcher.cpp
@@ -93,10 +93,12 @@ getGlobalPairing(const std::vector<std::size_t> & locallyRequiredIds,
 
    // this is what to distribute
    Tpetra::Vector<GO,LO,GO,NODE> providedVector(providedMap);
-   auto pvHost = providedVector.getLocalViewHost(Tpetra::Access::OverwriteAll);
-   for(std::size_t i=0;i<locallyMatchedIds.size();i++) 
-     pvHost(i,0) = locallyMatchedIds[i].second;
-   
+   {
+     auto pvHost = providedVector.getLocalViewHost(Tpetra::Access::OverwriteAll);
+     for(std::size_t i=0;i<locallyMatchedIds.size();i++)
+       pvHost(i,0) = locallyMatchedIds[i].second;
+   }
+
    Tpetra::Vector<GO,LO,GO,NODE> requiredVector(requiredMap);
    requiredVector.doImport(providedVector,importer,Tpetra::INSERT);
    
@@ -279,15 +281,17 @@ getSideIdsAndCoords(const STK_Interface & mesh,
    RCP<Tpetra::MultiVector<double,LO,GO,NODE>> localCoordVec_ = rcp(new Tpetra::MultiVector<double,LO,GO,NODE>(idMap_,physicalDim));
 
    // copy local Ids and coords into Tpetra vectors
-   auto lidHost = localIdVec_->getLocalViewHost(Tpetra::Access::OverwriteAll);
-   auto lcoordHost = localCoordVec_->getLocalViewHost(Tpetra::Access::OverwriteAll);
-   for(std::size_t n=0;n<local_side_ids.size();n++) {
-      std::size_t nodeId = local_side_ids[n];
-      Teuchos::Tuple<double,3> & coords = local_side_coords[n];
+   {
+     auto lidHost = localIdVec_->getLocalViewHost(Tpetra::Access::OverwriteAll);
+     auto lcoordHost = localCoordVec_->getLocalViewHost(Tpetra::Access::OverwriteAll);
+     for(std::size_t n=0;n<local_side_ids.size();n++) {
+       std::size_t nodeId = local_side_ids[n];
+       Teuchos::Tuple<double,3> & coords = local_side_coords[n];
 
-      lidHost(n,0) = static_cast<GO>(nodeId);
-      for(unsigned d=0;d<physicalDim;d++)
-        lcoordHost(n,d) = coords[d];
+       lidHost(n,0) = static_cast<GO>(nodeId);
+       for(unsigned d=0;d<physicalDim;d++)
+         lcoordHost(n,d) = coords[d];
+     }
    }
 
    // fully distribute epetra vector across all processors 


### PR DESCRIPTION


## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Seeing tpetra throws in periodic bc. Thought we had all of these out of the code, but running at scale on cuda has revealed some new ones. Tpetra switches execution spaces based on problem size for some operations (and whether cuda aware mpi is enabled), so this only occurs if on cuda with a big enough problem. Not sure how to test this without adding special flags to tpetra to exercise the path for small problem sizes.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
Fixes empire's issue.

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->