### PR TITLE
Xpetra: Set HAVE_XPETRA_EPETRAEXT=OFF when no Epetra support

### DIFF
--- a/packages/xpetra/CMakeLists.txt
+++ b/packages/xpetra/CMakeLists.txt
@@ -88,8 +88,10 @@ ELSE()
   SET(${PACKAGE_NAME}_Epetra_NO_32BIT_GLOBAL_INDICES_DEFAULT ON)
   SET(${PACKAGE_NAME}_Epetra_NO_64BIT_GLOBAL_INDICES_DEFAULT ON)
 
-  # Make sure EpetraExt is turned off
+  MESSAGE(" - NOTE: Setting Xpetra_ENABLE_EpetraExt=OFF since"
+    " Xpetra_ENABLE_Epetra='${Xpetra_ENABLE_Epetra}'" )
   DUAL_SCOPE_SET(${PACKAGE_NAME}_ENABLE_EpetraExt OFF)
+  DUAL_SCOPE_SET(HAVE_XPETRA_EPETRAEXT OFF)
 ENDIF()
 
 #


### PR DESCRIPTION
CC: @cgcgcg 

## Description
    
This fixes an Albany Trilinos build configuration issue that resulted in a broken Trilinos build.  When you overide an optional package enable like Xpetra_ENABLE_EpetraExt=OFF that was ON, you also need to set the related macro name var HAVE_XPETRA_EPETRAEXT=OFF (which TriBITS automatically sets by default before processing the packages) which is used in the generation of the Package's <Package>_Config.h file.

I was able to reproduce the reported build error reported by @cgcgcg before this change and verified that it fixed the build of Xpetra after this change.
