### PR TITLE
Framework: Change CDash settings for nightly jobs

### DIFF
--- a/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
@@ -437,7 +437,10 @@ class TrilinosPRConfigurationBase(object):
 
         PR-<PR Number>-test-<Jenkins Job Name>-<Job Number">
         """
-        output = "PR-{}-test-{}-{}".format(self.arg_pullrequest_number, self.arg_pr_genconfig_job_name, self.arg_jenkins_job_number)
+        if self.arg_pullrequest_cdash_track == "Pull Request":
+            output = "PR-{}-test-{}-{}".format(self.arg_pullrequest_number, self.arg_pr_genconfig_job_name, self.arg_jenkins_job_number)
+        else:
+            output = self.arg_pr_genconfig_job_name            
         return output
 
 

--- a/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
@@ -444,6 +444,18 @@ class TrilinosPRConfigurationBase(object):
         return output
 
 
+    @property
+    def dashboard_model(self):
+        """
+        Generate the dashboard model for CDash
+
+        Nightly, Continuous, Experimental
+        """
+        if self.arg_pullrequest_cdash_track == "Pull Request":
+            return "Experimental"
+        return "Nightly"
+
+
     # --------------------
     # M E T H O D S
     # --------------------

--- a/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationInstallation.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationInstallation.py
@@ -63,7 +63,7 @@ class TrilinosPRConfigurationInstallation(TrilinosPRConfigurationBase):
                       '-Dbuild_name={}'.format(self.pullrequest_build_name),
                       '-Dskip_by_parts_submit=OFF',
                       '-Dskip_update_step=ON',
-                      '-Ddashboard_model=Experimental',
+                      '-Ddashboard_model={self.dashboard_model}',
                       '-Ddashboard_track={}'.format(self.arg_pullrequest_cdash_track),
                       '-DPARALLEL_LEVEL={}'.format(self.concurrency_build),
                       '-DTEST_PARALLEL_LEVEL={}'.format(self.concurrency_test),

--- a/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationInstallation.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationInstallation.py
@@ -63,7 +63,7 @@ class TrilinosPRConfigurationInstallation(TrilinosPRConfigurationBase):
                       '-Dbuild_name={}'.format(self.pullrequest_build_name),
                       '-Dskip_by_parts_submit=OFF',
                       '-Dskip_update_step=ON',
-                      '-Ddashboard_model={self.dashboard_model}',
+                      f'-Ddashboard_model={self.dashboard_model}',
                       '-Ddashboard_track={}'.format(self.arg_pullrequest_cdash_track),
                       '-DPARALLEL_LEVEL={}'.format(self.concurrency_build),
                       '-DTEST_PARALLEL_LEVEL={}'.format(self.concurrency_test),

--- a/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationStandard.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationStandard.py
@@ -65,7 +65,7 @@ class TrilinosPRConfigurationStandard(TrilinosPRConfigurationBase):
                f"-Dbuild_name:STRING={self.pullrequest_build_name}",
                 "-Dskip_by_parts_submit:BOOL=OFF",
                 "-Dskip_update_step:BOOL=ON",
-                "-Ddashboard_model:STRING='Experimental'",
+                "-Ddashboard_model:STRING='{self.dashboard_model}'",
                f"-Ddashboard_track:STRING='{self.arg_pullrequest_cdash_track}'",
                f"-DPARALLEL_LEVEL:STRING={self.concurrency_build}",
                f"-DTEST_PARALLEL_LEVEL:STRING={self.concurrency_test}",

--- a/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationStandard.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationStandard.py
@@ -65,7 +65,7 @@ class TrilinosPRConfigurationStandard(TrilinosPRConfigurationBase):
                f"-Dbuild_name:STRING={self.pullrequest_build_name}",
                 "-Dskip_by_parts_submit:BOOL=OFF",
                 "-Dskip_update_step:BOOL=ON",
-                "-Ddashboard_model:STRING='{self.dashboard_model}'",
+               f"-Ddashboard_model:STRING='{self.dashboard_model}'",
                f"-Ddashboard_track:STRING='{self.arg_pullrequest_cdash_track}'",
                f"-DPARALLEL_LEVEL:STRING={self.concurrency_build}",
                f"-DTEST_PARALLEL_LEVEL:STRING={self.concurrency_test}",

--- a/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationBase.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationBase.py
@@ -367,7 +367,7 @@ class TrilinosPRConfigurationTest(unittest.TestCase):
     def test_TrilinosPRConfigurationBaseBuildNameGCC720(self):
         args = self.dummy_args_gcc_720()
         pr_config = trilinosprhelpers.TrilinosPRConfigurationBase(args)
-        build_name = pr_config. pullrequest_build_name
+        build_name = pr_config.pullrequest_build_name
         print("--- build_name = {}".format(build_name))
         expected_build_name = "PR-{}-test-{}-{}".format(args.pullrequest_number, args.genconfig_build_name, args.jenkins_job_number)
         self.assertEqual(build_name, expected_build_name)
@@ -376,10 +376,28 @@ class TrilinosPRConfigurationTest(unittest.TestCase):
     def test_TrilinosPRConfigurationBaseBuildNameNonPRTrack(self):
         args = self.dummy_args_non_pr_track()
         pr_config = trilinosprhelpers.TrilinosPRConfigurationBase(args)
-        build_name = pr_config. pullrequest_build_name
+        build_name = pr_config.pullrequest_build_name
         print("--- build_name = {}".format(build_name))
         expected_build_name = args.genconfig_build_name
         self.assertEqual(build_name, expected_build_name)
+
+
+    def test_TrilinosPRConfigurationBaseDashboardModelPRTrack(self):
+        args = self.dummy_args()
+        pr_config = trilinosprhelpers.TrilinosPRConfigurationBase(args)
+        dashboard_model = pr_config.dashboard_model
+        print("--- dashboard_model = {}".format(dashboard_model))
+        expected_dashboard_model = "Experimental"
+        self.assertEqual(dashboard_model, expected_dashboard_model)
+
+
+    def test_TrilinosPRConfigurationBaseDashboardModelNonPRTrack(self):
+        args = self.dummy_args_non_pr_track()
+        pr_config = trilinosprhelpers.TrilinosPRConfigurationBase(args)
+        dashboard_model = pr_config.dashboard_model
+        print("--- dashboard_model = {}".format(dashboard_model))
+        expected_dashboard_model = "Nightly"
+        self.assertEqual(dashboard_model, expected_dashboard_model)
 
 
     def test_TrilinosPRConfigurationBasePackageEnablesPython3(self):

--- a/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationBase.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationBase.py
@@ -261,6 +261,12 @@ class TrilinosPRConfigurationTest(unittest.TestCase):
         return args
 
 
+    def dummy_args_non_pr_track(self):
+        args = copy.deepcopy(self.dummy_args())
+        args.pullrequest_cdash_track = "some_random_track"
+        return args
+
+
     def dummy_args_master_pass(self):
         """
         Modify arguments to test a develop->master with a valid
@@ -364,6 +370,15 @@ class TrilinosPRConfigurationTest(unittest.TestCase):
         build_name = pr_config. pullrequest_build_name
         print("--- build_name = {}".format(build_name))
         expected_build_name = "PR-{}-test-{}-{}".format(args.pullrequest_number, args.genconfig_build_name, args.jenkins_job_number)
+        self.assertEqual(build_name, expected_build_name)
+
+
+    def test_TrilinosPRConfigurationBaseBuildNameNonPRTrack(self):
+        args = self.dummy_args_non_pr_track()
+        pr_config = trilinosprhelpers.TrilinosPRConfigurationBase(args)
+        build_name = pr_config. pullrequest_build_name
+        print("--- build_name = {}".format(build_name))
+        expected_build_name = args.genconfig_build_name
         self.assertEqual(build_name, expected_build_name)
 
 


### PR DESCRIPTION
I want nightly CDash jobs to work the way that CDash expects.  So, make the build name for nightly jobs be the same, and 
set the model to nightly.  For this, "nightly jobs" means "any job not in the track 'Pull Request'".

Long-term we probably do not want to use the PR framework for nightly builds (doesn't make a whole lot of sense), but since we do at the moment, this change helps us move towards more sensible output.

@trilinos/framework 

## Motivation
This will enable the historical graphs and other analysis of night-to-night runs on CDash.