### PR TITLE
add OpenMP to a recent clang build using the llvm OpenMP runtime (not GCC)

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1788,6 +1788,22 @@ use RHEL7_TEST_DISABLES|CLANG
 
 use RHEL7_POST
 
+[rhel7_sems-clang-11.0.1-openmpi-1.10.1-openmp_debug_static_no-kokkos-arch_asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
+use rhel7_sems-clang-11.0.1-openmpi-1.10.1-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
+
+opt-set-cmake-var Ifpack2_LocalSparseTriangularSolver_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Ifpack2_LocalSparseTriangularSolver2_DISABLE BOOL FORCE : ON
+opt-set-cmake-var PanzerAdaptersSTK_MixedPoissonExample_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Trilinos_ENABLE_PanzerAdaptersSTK BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_PanzerDofMgr BOOL FORCE : OFF
+
+opt-set-cmake-var Trilinos_ENABLE_ALL_FORWARD_DEP_PACKAGES BOOL FORCE : ON
+opt-set-cmake-var Trilinos_ENABLE_TESTS BOOL FORCE : ON
+opt-set-cmake-var Trilinos_ENABLE_Kokkos BOOL FORCE : ON
+opt-set-cmake-var TPL_ENABLE_Matio BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_OpenMP BOOL FORCE : ON
+opt-set-cmake-var Kokkos_ENABLE_OPENMP BOOL FORCE : ON
+
 [rhel7_sems-clang-11.0.1-openmpi-1.10.1-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
 #uses sems-archive modules
 use rhel7_sems-clang-11.0.1-openmpi-1.10.1-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1791,18 +1791,23 @@ use RHEL7_POST
 [rhel7_sems-clang-11.0.1-openmpi-1.10.1-openmp_debug_static_no-kokkos-arch_asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
 use rhel7_sems-clang-11.0.1-openmpi-1.10.1-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 
+opt-set-cmake-var Trilinos_ENABLE_OpenMP BOOL FORCE : ON
+opt-set-cmake-var Kokkos_ENABLE_OPENMP BOOL FORCE : ON
+
+[rhel7_sems-clang-11.0.1-openmpi-1.10.1-openmp_debug_static_no-kokkos-arch_asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
+use rhel7_sems-clang-11.0.1-openmpi-1.10.1-openmp_debug_static_no-kokkos-arch_asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
+use PACKAGE-ENABLES|ALL
+
 # opt-set-cmake-var Ifpack2_LocalSparseTriangularSolver_DISABLE BOOL FORCE : ON
 # opt-set-cmake-var Ifpack2_LocalSparseTriangularSolver2_DISABLE BOOL FORCE : ON
 # opt-set-cmake-var PanzerAdaptersSTK_MixedPoissonExample_DISABLE BOOL FORCE : ON
 # opt-set-cmake-var Trilinos_ENABLE_PanzerAdaptersSTK BOOL FORCE : OFF
 # opt-set-cmake-var Trilinos_ENABLE_PanzerDofMgr BOOL FORCE : OFF
 
-opt-set-cmake-var Trilinos_ENABLE_ALL_FORWARD_DEP_PACKAGES BOOL FORCE : ON
-opt-set-cmake-var Trilinos_ENABLE_TESTS BOOL FORCE : ON
-opt-set-cmake-var Trilinos_ENABLE_Kokkos BOOL FORCE : ON
-opt-set-cmake-var TPL_ENABLE_Matio BOOL FORCE : OFF
-opt-set-cmake-var Trilinos_ENABLE_OpenMP BOOL FORCE : ON
-opt-set-cmake-var Kokkos_ENABLE_OPENMP BOOL FORCE : ON
+# opt-set-cmake-var Trilinos_ENABLE_ALL_FORWARD_DEP_PACKAGES BOOL FORCE : ON
+# opt-set-cmake-var Trilinos_ENABLE_TESTS BOOL FORCE : ON
+# opt-set-cmake-var Trilinos_ENABLE_Kokkos BOOL FORCE : ON
+# opt-set-cmake-var TPL_ENABLE_Matio BOOL FORCE : OFF
 
 [rhel7_sems-clang-11.0.1-openmpi-1.10.1-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
 #uses sems-archive modules

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1791,11 +1791,11 @@ use RHEL7_POST
 [rhel7_sems-clang-11.0.1-openmpi-1.10.1-openmp_debug_static_no-kokkos-arch_asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
 use rhel7_sems-clang-11.0.1-openmpi-1.10.1-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 
-opt-set-cmake-var Ifpack2_LocalSparseTriangularSolver_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Ifpack2_LocalSparseTriangularSolver2_DISABLE BOOL FORCE : ON
-opt-set-cmake-var PanzerAdaptersSTK_MixedPoissonExample_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Trilinos_ENABLE_PanzerAdaptersSTK BOOL FORCE : OFF
-opt-set-cmake-var Trilinos_ENABLE_PanzerDofMgr BOOL FORCE : OFF
+# opt-set-cmake-var Ifpack2_LocalSparseTriangularSolver_DISABLE BOOL FORCE : ON
+# opt-set-cmake-var Ifpack2_LocalSparseTriangularSolver2_DISABLE BOOL FORCE : ON
+# opt-set-cmake-var PanzerAdaptersSTK_MixedPoissonExample_DISABLE BOOL FORCE : ON
+# opt-set-cmake-var Trilinos_ENABLE_PanzerAdaptersSTK BOOL FORCE : OFF
+# opt-set-cmake-var Trilinos_ENABLE_PanzerDofMgr BOOL FORCE : OFF
 
 opt-set-cmake-var Trilinos_ENABLE_ALL_FORWARD_DEP_PACKAGES BOOL FORCE : ON
 opt-set-cmake-var Trilinos_ENABLE_TESTS BOOL FORCE : ON

--- a/packages/framework/ini-files/supported-envs.ini
+++ b/packages/framework/ini-files/supported-envs.ini
@@ -151,6 +151,7 @@ sems-v2-gnu-8.3.0-serial:
 sems-gnu-8.3.0-openmpi-1.10.7-serial:
 cxx-20-sems-gnu-8.3.0-openmpi-1.10.7-serial:
 sems-gnu-8.3.0-openmpi-1.10.7-openmp:
+sems-clang-11.0.1-openmpi-1.10.1-openmp:
 sems-clang-11.0.1-openmpi-1.10.1-serial:
     clang-11.0.1
 sems-clang-11.0.1-openmpi-1.10.7-serial:


### PR DESCRIPTION
At a testbed meeting, it was suggested that we add OpenMP to a recent clang build using the llvm OpenMP runtime (not GCC). This will help prepare Trilinos for future architectures.

The SEMS clang supports OpenMP, so you just need to enable OpenMP (how do you do that in general: Trilinos_ENABLE_OPENMP or Kokkos_ENABLE_OPENMP?)

@trilinos/framework 

https://sems-atlassian-son.sandia.gov/jira/browse/TRILFRAME-1