### PR TITLE
Upgrade to CMake 3.23 (#10355)

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -21,7 +21,7 @@ features and options are available and how to use them, see the document:
 Requirements
 ============
 
-* CMake 3.17.1 or newer
+* CMake 3.23.0 or newer
 * C and C++ compiler
 * Optionally a Fortran compiler
 * Optionally an installation of MPI


### PR DESCRIPTION
I missed this when I upgraded the minimum CMake version `cmake_minimum_required()` in `Trilinos/CMakeLists.txt`.

Should hopefully be the last of #10355.
