### PR TITLE
MueLu: Fix fscanf and system warnings

### DIFF
--- a/packages/muelu/test/viz/AggExport.cpp
+++ b/packages/muelu/test/viz/AggExport.cpp
@@ -75,9 +75,12 @@ bool compare_to_gold_all_ranks(int myRank, const std::string & baseFile) {
 
   // Create a copy of outputs
   std::string cmd = "cp -f ";
-  system((cmd + baseFile + ".gold " + baseFile + ".gold_filtered").c_str());
+  int retVal;
+  retVal = system((cmd + baseFile + ".gold " + baseFile + ".gold_filtered").c_str());
+  TEUCHOS_TEST_FOR_EXCEPTION(retVal != 0, std::runtime_error, "goldfile copy failed!");
   //system((cmd + baseFile + ".out "  + baseFile + ".out_filtered").c_str());
-  system((cmd + baseFile + ".vtu "  + baseFile + ".out_filtered").c_str());
+  retVal = system((cmd + baseFile + ".vtu "  + baseFile + ".out_filtered").c_str());
+  TEUCHOS_TEST_FOR_EXCEPTION(retVal != 0, std::runtime_error, "goldfile copy failed!");
 
   // Run comparison (ignoring whitespaces)
   cmd = "diff -u -w -I\"^\\s*$\" " + baseFile + ".gold_filtered " + baseFile + ".out_filtered";


### PR DESCRIPTION
@trilinos/muelu

I saw some warnings about `fscanf` unused returns and `system` unused returns originating from `MatrixLoad.hpp` and `AggExport.cpp` like the one below. I fixed them :)
```
/home/graham/Programming/cpp/Trilinos/Trilinos-source/packages/muelu/test/scaling/MatrixLoad.hpp:295:19: warning: ignoring return value of ‘int fscanf(FILE*, const char*, ...)’, declared with attribute warn_unused_result [-Wunused-result]
  295 |             fscanf(fp,"%d %d %d\n",&nBlks, &nRows, &nnzs);
      |             ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Note: While I placed asserts at the start of the file parsing in `MatrixLoad.hpp`, I did not continue by placing asserts inside the main loops. In principle, they should be inside the loop, but I would rather not sacrifice performance on loading user input, although I have no clue how much of an impact it would have on performance anyway. Feel free to discuss if you think it's worth adding an assert in the main loop as well.
