### PR TITLE
auxiliarySoftware/SuiteSparse: update naming of EMPTY macro

### DIFF
--- a/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Include/trilinos_amd_internal.h
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Include/trilinos_amd_internal.h
@@ -101,8 +101,8 @@
 #undef MIN
 #endif
 
-#ifdef EMPTY
-#undef EMPTY
+#ifdef TRILINOS_AMD_EMPTY
+#undef TRILINOS_AMD_EMPTY
 #endif
 
 #ifdef GLOBAL
@@ -114,12 +114,12 @@
 #endif
 
 /* FLIP is a "negation about -1", and is used to mark an integer i that is
- * normally non-negative.  FLIP (EMPTY) is EMPTY.  FLIP of a number > EMPTY
+ * normally non-negative.  FLIP (TRILINOS_AMD_EMPTY) is TRILINOS_AMD_EMPTY.  FLIP of a number > TRILINOS_AMD_EMPTY
  * is negative, and FLIP of a number < EMTPY is positive.  FLIP (FLIP (i)) = i
- * for all integers i.  UNFLIP (i) is >= EMPTY. */
-#define EMPTY (-1)
+ * for all integers i.  UNFLIP (i) is >= TRILINOS_AMD_EMPTY. */
+#define TRILINOS_AMD_EMPTY (-1)
 #define FLIP(i) (-(i)-2)
-#define UNFLIP(i) ((i < EMPTY) ? FLIP (i) : (i))
+#define UNFLIP(i) ((i < TRILINOS_AMD_EMPTY) ? FLIP (i) : (i))
 
 /* for integer MAX/MIN, or for doubles when we don't care how NaN's behave: */
 #define MAX(a,b) (((a) > (b)) ? (a) : (b))
@@ -141,7 +141,7 @@
 #define FALSE (0)
 #define PRIVATE static
 #define GLOBAL
-#define EMPTY (-1)
+#define TRILINOS_AMD_EMPTY (-1)
 
 /* Note that Linux's gcc 2.96 defines NULL as ((void *) 0), but other */
 /* compilers (even gcc 2.95.2 on Solaris) define NULL as 0 or (0).  We */

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Source/trilinos_amd_1.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Source/trilinos_amd_1.c
@@ -81,7 +81,7 @@ GLOBAL void TRILINOS_AMD_1
     ASSERT (iwlen >= pfree + n) ;
 
 #ifndef NDEBUG
-    for (p = 0 ; p < iwlen ; p++) Iw [p] = EMPTY ;
+    for (p = 0 ; p < iwlen ; p++) Iw [p] = TRILINOS_AMD_EMPTY ;
 #endif
 
     for (k = 0 ; k < n ; k++)

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Source/trilinos_amd_2.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Source/trilinos_amd_2.c
@@ -252,7 +252,7 @@ GLOBAL void TRILINOS_AMD_2
  *	    as (-(j)-2).  Row j has the same pattern as row i.  Note that j
  *	    might later be absorbed into another supervariable j2, in which
  *	    case Pe [i] is still FLIP (j), and Pe [j] = FLIP (j2) which is
- *	    < EMPTY, where EMPTY is defined as (-1) in amd_internal.h.
+ *	    < TRILINOS_AMD_EMPTY, where TRILINOS_AMD_EMPTY is defined as (-1) in amd_internal.h.
  *
  *	Unabsorbed element e:  the index into Iw of the description of element
  *	    e, if e has not yet been absorbed by a subsequent element.  Element
@@ -262,18 +262,18 @@ GLOBAL void TRILINOS_AMD_2
  *	Absorbed element e:  if element e is absorbed into element e2, then
  *	    Pe [e] = FLIP (e2).  This occurs when the pattern of e (which we
  *	    refer to as Le) is found to be a subset of the pattern of e2 (that
- *	    is, Le2).  In this case, Pe [i] < EMPTY.  If element e is "null"
- *	    (it has no nonzeros outside its pivot block), then Pe [e] = EMPTY,
+ *	    is, Le2).  In this case, Pe [i] < TRILINOS_AMD_EMPTY.  If element e is "null"
+ *	    (it has no nonzeros outside its pivot block), then Pe [e] = TRILINOS_AMD_EMPTY,
  *	    and e is the root of an assembly subtree (or the whole tree if
  *	    there is just one such root).
  *
- *	Dense variable i:  if i is "dense", then Pe [i] = EMPTY.
+ *	Dense variable i:  if i is "dense", then Pe [i] = TRILINOS_AMD_EMPTY.
  *
  *	On output, Pe holds the assembly tree/forest, which implicitly
  *	represents a pivot order with identical fill-in as the actual order
  *	(via a depth-first search of the tree), as follows.  If Nv [i] > 0,
  *	then i represents a node in the assembly tree, and the parent of i is
- *	Pe [i], or EMPTY if i is a root.  If Nv [i] = 0, then (i, Pe [i])
+ *	Pe [i], or TRILINOS_AMD_EMPTY if i is a root.  If Nv [i] = 0, then (i, Pe [i])
  *	represents an edge in a subtree, the root of which is a node in the
  *	assembly tree.  Note that i refers to a row/column in the original
  *	matrix, not the permuted matrix.
@@ -358,16 +358,16 @@ GLOBAL void TRILINOS_AMD_2
  *	execution, Elen [i] is the number of elements in the list for
  *	supervariable i.  When e becomes an element, Elen [e] = FLIP (esize) is
  *	set, where esize is the size of the element (the number of pivots, plus
- *	the number of nonpivotal entries).  Thus Elen [e] < EMPTY.
- *	Elen (i) = EMPTY set when variable i becomes nonprincipal.
+ *	the number of nonpivotal entries).  Thus Elen [e] < TRILINOS_AMD_EMPTY.
+ *	Elen (i) = TRILINOS_AMD_EMPTY set when variable i becomes nonprincipal.
  *
- *	For variables, Elen (i) >= EMPTY holds until just before the
+ *	For variables, Elen (i) >= TRILINOS_AMD_EMPTY holds until just before the
  *	postordering and permutation vectors are computed.  For elements,
- *	Elen [e] < EMPTY holds.
+ *	Elen [e] < TRILINOS_AMD_EMPTY holds.
  *
  *	On output, Elen [i] is the degree of the row/column in the Cholesky
  *	factorization of the permuted matrix, corresponding to the original row
- *	i, if i is a super row/column.  It is equal to EMPTY if i is
+ *	i, if i is a super row/column.  It is equal to TRILINOS_AMD_EMPTY if i is
  *	non-principal.  Note that i refers to a row/column in the original
  *	matrix, not the permuted matrix.
  *
@@ -376,7 +376,7 @@ GLOBAL void TRILINOS_AMD_2
  *	which is instead returned in the Next array in this C version,
  *	described below).
  *
- * Last: In a degree list, Last [i] is the supervariable preceding i, or EMPTY
+ * Last: In a degree list, Last [i] is the supervariable preceding i, or TRILINOS_AMD_EMPTY
  *	if i is the head of the list.  In a hash bucket, Last [i] is the hash
  *	key for i.
  *
@@ -388,7 +388,7 @@ GLOBAL void TRILINOS_AMD_2
  *	i = Last [k], then row i is the kth pivot row (where k ranges from 0 to
  *	n-1).  Row Last [k] of A is the kth row in the permuted matrix, PAP'.
  *
- * Next: Next [i] is the supervariable following i in a link list, or EMPTY if
+ * Next: Next [i] is the supervariable following i in a link list, or TRILINOS_AMD_EMPTY if
  *	i is the last in the list.  Used for two kinds of lists:  degree lists
  *	and hash buckets (a supervariable can be in only one kind of list at a
  *	time).
@@ -419,16 +419,16 @@ GLOBAL void TRILINOS_AMD_2
  *	Head [deg] is the first supervariable in a degree list.  All
  *	supervariables i in a degree list Head [deg] have the same approximate
  *	degree, namely, deg = Degree [i].  If the list Head [deg] is empty then
- *	Head [deg] = EMPTY.
+ *	Head [deg] = TRILINOS_AMD_EMPTY.
  *
  *	During supervariable detection Head [hash] also serves as a pointer to
  *	a hash bucket.  If Head [hash] >= 0, there is a degree list of degree
  *	hash.  The hash bucket head pointer is Last [Head [hash]].  If
- *	Head [hash] = EMPTY, then the degree list and hash bucket are both
- *	empty.  If Head [hash] < EMPTY, then the degree list is empty, and
+ *	Head [hash] = TRILINOS_AMD_EMPTY, then the degree list and hash bucket are both
+ *	empty.  If Head [hash] < TRILINOS_AMD_EMPTY, then the degree list is empty, and
  *	FLIP (Head [hash]) is the head of the hash bucket.  After supervariable
  *	detection is complete, all hash buckets are empty, and the
- *	(Last [Head [hash]] = EMPTY) condition is restored for the non-empty
+ *	(Last [Head [hash]] = TRILINOS_AMD_EMPTY) condition is restored for the non-empty
  *	degree lists.
  *
  * W:  An integer array of size n.  The flag array W determines the status of
@@ -574,7 +574,7 @@ GLOBAL void TRILINOS_AMD_2
     nms_lu = 0 ;
     nms_ldl = 0 ;
     dmax = 1 ;
-    me = EMPTY ;
+    me = TRILINOS_AMD_EMPTY ;
 
     mindeg = 0 ;
     ncmpa = 0 ;
@@ -609,11 +609,11 @@ GLOBAL void TRILINOS_AMD_2
 
     for (i = 0 ; i < n ; i++)
     {
-	Last [i] = EMPTY ;
-	Head [i] = EMPTY ;
-	Next [i] = EMPTY ;
+	Last [i] = TRILINOS_AMD_EMPTY ;
+	Head [i] = TRILINOS_AMD_EMPTY ;
+	Next [i] = TRILINOS_AMD_EMPTY ;
 	/* if separate Hhead array is used for hash buckets: *
-	Hhead [i] = EMPTY ;
+	Hhead [i] = TRILINOS_AMD_EMPTY ;
 	*/
 	Nv [i] = 1 ;
 	W [i] = 1 ;
@@ -653,7 +653,7 @@ GLOBAL void TRILINOS_AMD_2
 
 	    Elen [i] = FLIP (1) ;
 	    nel++ ;
-	    Pe [i] = EMPTY ;
+	    Pe [i] = TRILINOS_AMD_EMPTY ;
 	    W [i] = 0 ;
 
 	}
@@ -670,9 +670,9 @@ GLOBAL void TRILINOS_AMD_2
 	    TRILINOS_AMD_DEBUG1 (("Dense node "ID" degree "ID"\n", i, deg)) ;
 	    ndense++ ;
 	    Nv [i] = 0 ;		/* do not postorder this node */
-	    Elen [i] = EMPTY ;
+	    Elen [i] = TRILINOS_AMD_EMPTY ;
 	    nel++ ;
-	    Pe [i] = EMPTY ;
+	    Pe [i] = TRILINOS_AMD_EMPTY ;
 
 	}
 	else
@@ -683,8 +683,8 @@ GLOBAL void TRILINOS_AMD_2
 	     * ------------------------------------------------------------- */
 
 	    inext = Head [deg] ;
-	    ASSERT (inext >= EMPTY && inext < n) ;
-	    if (inext != EMPTY) Last [inext] = i ;
+	    ASSERT (inext >= TRILINOS_AMD_EMPTY && inext < n) ;
+	    if (inext != TRILINOS_AMD_EMPTY) Last [inext] = i ;
 	    Next [i] = inext ;
 	    Head [deg] = i ;
 
@@ -719,7 +719,7 @@ GLOBAL void TRILINOS_AMD_2
 	for (deg = mindeg ; deg < n ; deg++)
 	{
 	    me = Head [deg] ;
-	    if (me != EMPTY) break ;
+	    if (me != TRILINOS_AMD_EMPTY) break ;
 	}
 	mindeg = deg ;
 	ASSERT (me >= 0 && me < n) ;
@@ -730,8 +730,8 @@ GLOBAL void TRILINOS_AMD_2
 	/* ----------------------------------------------------------------- */
 
 	inext = Next [me] ;
-	ASSERT (inext >= EMPTY && inext < n) ;
-	if (inext != EMPTY) Last [inext] = EMPTY ;
+	ASSERT (inext >= TRILINOS_AMD_EMPTY && inext < n) ;
+	if (inext != TRILINOS_AMD_EMPTY) Last [inext] = TRILINOS_AMD_EMPTY ;
 	Head [deg] = inext ;
 
 	/* ----------------------------------------------------------------- */
@@ -795,10 +795,10 @@ GLOBAL void TRILINOS_AMD_2
 
 		    ilast = Last [i] ;
 		    inext = Next [i] ;
-		    ASSERT (ilast >= EMPTY && ilast < n) ;
-		    ASSERT (inext >= EMPTY && inext < n) ;
-		    if (inext != EMPTY) Last [inext] = ilast ;
-		    if (ilast != EMPTY)
+		    ASSERT (ilast >= TRILINOS_AMD_EMPTY && ilast < n) ;
+		    ASSERT (inext >= TRILINOS_AMD_EMPTY && inext < n) ;
+		    if (inext != TRILINOS_AMD_EMPTY) Last [inext] = ilast ;
+		    if (ilast != TRILINOS_AMD_EMPTY)
 		    {
 			Next [ilast] = inext ;
 		    }
@@ -841,7 +841,7 @@ GLOBAL void TRILINOS_AMD_2
 		    pj = Pe [e] ;
 		    ln = Len [e] ;
 		    TRILINOS_AMD_DEBUG2 (("Search element e "ID" in me "ID"\n", e,me)) ;
-		    ASSERT (Elen [e] < EMPTY && W [e] > 0 && pj >= 0) ;
+		    ASSERT (Elen [e] < TRILINOS_AMD_EMPTY && W [e] > 0 && pj >= 0) ;
 		}
 		ASSERT (ln >= 0 && (ln == 0 || (pj >= 0 && pj < iwlen))) ;
 
@@ -855,7 +855,7 @@ GLOBAL void TRILINOS_AMD_2
 		for (knt2 = 1 ; knt2 <= ln ; knt2++)
 		{
 		    i = Iw [pj++] ;
-		    ASSERT (i >= 0 && i < n && (i == me || Elen [i] >= EMPTY));
+		    ASSERT (i >= 0 && i < n && (i == me || Elen [i] >= TRILINOS_AMD_EMPTY));
 		    nvi = Nv [i] ;
 		    TRILINOS_AMD_DEBUG2 ((": "ID" "ID" "ID" "ID"\n",
 				i, Elen [i], Nv [i], wflg)) ;
@@ -880,11 +880,11 @@ GLOBAL void TRILINOS_AMD_2
 			    Pe [me] = p ;
 			    Len [me] -= knt1 ;
 			    /* check if nothing left of supervariable me */
-			    if (Len [me] == 0) Pe [me] = EMPTY ;
+			    if (Len [me] == 0) Pe [me] = TRILINOS_AMD_EMPTY ;
 			    Pe [e] = pj ;
 			    Len [e] = ln - knt2 ;
 			    /* nothing left of element e */
-			    if (Len [e] == 0) Pe [e] = EMPTY ;
+			    if (Len [e] == 0) Pe [e] = TRILINOS_AMD_EMPTY ;
 
 			    ncmpa++ ;	/* one more garbage collection */
 
@@ -954,10 +954,10 @@ GLOBAL void TRILINOS_AMD_2
 
 			ilast = Last [i] ;
 			inext = Next [i] ;
-			ASSERT (ilast >= EMPTY && ilast < n) ;
-			ASSERT (inext >= EMPTY && inext < n) ;
-			if (inext != EMPTY) Last [inext] = ilast ;
-			if (ilast != EMPTY)
+			ASSERT (ilast >= TRILINOS_AMD_EMPTY && ilast < n) ;
+			ASSERT (inext >= TRILINOS_AMD_EMPTY && inext < n) ;
+			if (inext != TRILINOS_AMD_EMPTY) Last [inext] = ilast ;
+			if (ilast != TRILINOS_AMD_EMPTY)
 			{
 			    Next [ilast] = inext ;
 			}
@@ -1219,7 +1219,7 @@ GLOBAL void TRILINOS_AMD_2
 		nvpiv += nvi ;
 		nel += nvi ;
 		Nv [i] = 0 ;
-		Elen [i] = EMPTY ;
+		Elen [i] = TRILINOS_AMD_EMPTY ;
 
 	    }
 	    else
@@ -1260,7 +1260,7 @@ GLOBAL void TRILINOS_AMD_2
 
 		/* if the Hhead array is not used: */
 		j = Head [hash] ;
-		if (j <= EMPTY)
+		if (j <= TRILINOS_AMD_EMPTY)
 		{
 		    /* degree list is empty, hash head is FLIP (j) */
 		    Next [i] = FLIP (j) ;
@@ -1321,33 +1321,33 @@ GLOBAL void TRILINOS_AMD_2
 
 		/* if Hhead array is not used: */
 		j = Head [hash] ;
-		if (j == EMPTY)
+		if (j == TRILINOS_AMD_EMPTY)
 		{
 		    /* hash bucket and degree list are both empty */
-		    i = EMPTY ;
+		    i = TRILINOS_AMD_EMPTY ;
 		}
-		else if (j < EMPTY)
+		else if (j < TRILINOS_AMD_EMPTY)
 		{
 		    /* degree list is empty */
 		    i = FLIP (j) ;
-		    Head [hash] = EMPTY ;
+		    Head [hash] = TRILINOS_AMD_EMPTY ;
 		}
 		else
 		{
 		    /* degree list is not empty, restore Last [j] of head j */
 		    i = Last [j] ;
-		    Last [j] = EMPTY ;
+		    Last [j] = TRILINOS_AMD_EMPTY ;
 		}
 
 		/* if separate Hhead array is used: *
 		i = Hhead [hash] ;
-		Hhead [hash] = EMPTY ;
+		Hhead [hash] = TRILINOS_AMD_EMPTY ;
 		*/
 
-		ASSERT (i >= EMPTY && i < n) ;
+		ASSERT (i >= TRILINOS_AMD_EMPTY && i < n) ;
 		TRILINOS_AMD_DEBUG2 (("----i "ID" hash "ID"\n", i, hash)) ;
 
-		while (i != EMPTY && Next [i] != EMPTY)
+		while (i != TRILINOS_AMD_EMPTY && Next [i] != TRILINOS_AMD_EMPTY)
 		{
 
 		    /* -----------------------------------------------------
@@ -1373,9 +1373,9 @@ GLOBAL void TRILINOS_AMD_2
 
 		    jlast = i ;
 		    j = Next [i] ;
-		    ASSERT (j >= EMPTY && j < n) ;
+		    ASSERT (j >= TRILINOS_AMD_EMPTY && j < n) ;
 
-		    while (j != EMPTY)
+		    while (j != TRILINOS_AMD_EMPTY)
 		    {
 			/* ------------------------------------------------- */
 			/* check if j and i have identical nonzero pattern */
@@ -1406,7 +1406,7 @@ GLOBAL void TRILINOS_AMD_2
 			    /* are the number of variables in i and j: */
 			    Nv [i] += Nv [j] ;
 			    Nv [j] = 0 ;
-			    Elen [j] = EMPTY ;
+			    Elen [j] = TRILINOS_AMD_EMPTY ;
 			    /* delete j from hash bucket */
 			    ASSERT (j != Next [j]) ;
 			    j = Next [j] ;
@@ -1420,7 +1420,7 @@ GLOBAL void TRILINOS_AMD_2
 			    ASSERT (j != Next [j]) ;
 			    j = Next [j] ;
 			}
-			ASSERT (j >= EMPTY && j < n) ;
+			ASSERT (j >= TRILINOS_AMD_EMPTY && j < n) ;
 		    }
 
 		    /* -----------------------------------------------------
@@ -1430,7 +1430,7 @@ GLOBAL void TRILINOS_AMD_2
 
 		    wflg++ ;
 		    i = Next [i] ;
-		    ASSERT (i >= EMPTY && i < n) ;
+		    ASSERT (i >= TRILINOS_AMD_EMPTY && i < n) ;
 
 		}
 	    }
@@ -1468,10 +1468,10 @@ GLOBAL void TRILINOS_AMD_2
 		/* --------------------------------------------------------- */
 
 		inext = Head [deg] ;
-		ASSERT (inext >= EMPTY && inext < n) ;
-		if (inext != EMPTY) Last [inext] = i ;
+		ASSERT (inext >= TRILINOS_AMD_EMPTY && inext < n) ;
+		if (inext != TRILINOS_AMD_EMPTY) Last [inext] = i ;
 		Next [i] = inext ;
-		Last [i] = EMPTY ;
+		Last [i] = TRILINOS_AMD_EMPTY ;
 		Head [deg] = i ;
 
 		/* --------------------------------------------------------- */
@@ -1503,7 +1503,7 @@ GLOBAL void TRILINOS_AMD_2
 	{
 	    /* there is nothing left of the current pivot element */
 	    /* it is a root of the assembly tree */
-	    Pe [me] = EMPTY ;
+	    Pe [me] = TRILINOS_AMD_EMPTY ;
 	    W [me] = 0 ;
 	}
 	if (elenme != 0)
@@ -1610,13 +1610,13 @@ GLOBAL void TRILINOS_AMD_2
  * Variables at this point:
  *
  * Pe: holds the elimination tree.  The parent of j is FLIP (Pe [j]),
- *	or EMPTY if j is a root.  The tree holds both elements and
+ *	or TRILINOS_AMD_EMPTY if j is a root.  The tree holds both elements and
  *	non-principal (unordered) variables absorbed into them.
  *	Dense variables are non-principal and unordered.
  *
  * Elen: holds the size of each element, including the diagonal part.
  *	FLIP (Elen [e]) > 0 if e is an element.  For unordered
- *	variables i, Elen [i] is EMPTY.
+ *	variables i, Elen [i] is TRILINOS_AMD_EMPTY.
  *
  * Nv: Nv [e] > 0 is the number of pivots represented by the element e.
  *	For unordered variables i, Nv [i] is zero.
@@ -1642,15 +1642,15 @@ GLOBAL void TRILINOS_AMD_2
 	Elen [i] = FLIP (Elen [i]) ;
     }
 
-/* Now the parent of j is Pe [j], or EMPTY if j is a root.  Elen [e] > 0
- * is the size of element e.  Elen [i] is EMPTY for unordered variable i. */
+/* Now the parent of j is Pe [j], or TRILINOS_AMD_EMPTY if j is a root.  Elen [e] > 0
+ * is the size of element e.  Elen [i] is TRILINOS_AMD_EMPTY for unordered variable i. */
 
 #ifndef NDEBUG
     TRILINOS_AMD_DEBUG2 (("\nTree:\n")) ;
     for (i = 0 ; i < n ; i++)
     {
 	TRILINOS_AMD_DEBUG2 ((" "ID" parent: "ID"   ", i, Pe [i])) ;
-	ASSERT (Pe [i] >= EMPTY && Pe [i] < n) ;
+	ASSERT (Pe [i] >= TRILINOS_AMD_EMPTY && Pe [i] < n) ;
 	if (Nv [i] > 0)
 	{
 	    /* this is an element */
@@ -1679,7 +1679,7 @@ GLOBAL void TRILINOS_AMD_2
 	    j = Pe [i] ;
 	    cnt = 0 ;
 	    TRILINOS_AMD_DEBUG3 (("  j: "ID"\n", j)) ;
-	    if (j == EMPTY)
+	    if (j == TRILINOS_AMD_EMPTY)
 	    {
 		TRILINOS_AMD_DEBUG3 (("	i is a dense variable\n")) ;
 	    }
@@ -1719,9 +1719,9 @@ GLOBAL void TRILINOS_AMD_2
 
 	    TRILINOS_AMD_DEBUG1 (("Path compression, i unordered: "ID"\n", i)) ;
 	    j = Pe [i] ;
-	    ASSERT (j >= EMPTY && j < n) ;
+	    ASSERT (j >= TRILINOS_AMD_EMPTY && j < n) ;
 	    TRILINOS_AMD_DEBUG3 (("	j: "ID"\n", j)) ;
-	    if (j == EMPTY)
+	    if (j == TRILINOS_AMD_EMPTY)
 	    {
 		/* Skip a dense variable.  It has no parent. */
 		TRILINOS_AMD_DEBUG3 (("      i is a dense variable\n")) ;
@@ -1777,14 +1777,14 @@ GLOBAL void TRILINOS_AMD_2
 
     for (k = 0 ; k < n ; k++)
     {
-	Head [k] = EMPTY ;
-	Next [k] = EMPTY ;
+	Head [k] = TRILINOS_AMD_EMPTY ;
+	Next [k] = TRILINOS_AMD_EMPTY ;
     }
     for (e = 0 ; e < n ; e++)
     {
 	k = W [e] ;
-	ASSERT ((k == EMPTY) == (Nv [e] == 0)) ;
-	if (k != EMPTY)
+	ASSERT ((k == TRILINOS_AMD_EMPTY) == (Nv [e] == 0)) ;
+	if (k != TRILINOS_AMD_EMPTY)
 	{
 	    ASSERT (k >= 0 && k < n) ;
 	    Head [k] = e ;
@@ -1797,7 +1797,7 @@ GLOBAL void TRILINOS_AMD_2
     for (k = 0 ; k < n ; k++)
     {
 	e = Head [k] ;
-	if (e == EMPTY) break ;
+	if (e == TRILINOS_AMD_EMPTY) break ;
 	ASSERT (e >= 0 && e < n && Nv [e] > 0) ;
 	Next [e] = nel ;
 	nel += Nv [e] ;
@@ -1810,14 +1810,14 @@ GLOBAL void TRILINOS_AMD_2
 	if (Nv [i] == 0)
 	{
 	    e = Pe [i] ;
-	    ASSERT (e >= EMPTY && e < n) ;
-	    if (e != EMPTY)
+	    ASSERT (e >= TRILINOS_AMD_EMPTY && e < n) ;
+	    if (e != TRILINOS_AMD_EMPTY)
 	    {
 		/* This is an unordered variable that was merged
 		 * into element e via supernode detection or mass
 		 * elimination of i when e became the pivot element.
 		 * Place i in order just before e. */
-		ASSERT (Next [i] == EMPTY && Nv [e] > 0) ;
+		ASSERT (Next [i] == TRILINOS_AMD_EMPTY && Nv [e] > 0) ;
 		Next [i] = Next [e] ;
 		Next [e]++ ;
 	    }

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Source/trilinos_amd_aat.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Source/trilinos_amd_aat.c
@@ -34,7 +34,7 @@ GLOBAL size_t TRILINOS_AMD_aat	/* returns nz in A+A' */
 
 #ifndef NDEBUG
     TRILINOS_AMD_debug_init ("AMD AAT") ;
-    for (k = 0 ; k < n ; k++) Tp [k] = EMPTY ;
+    for (k = 0 ; k < n ; k++) Tp [k] = TRILINOS_AMD_EMPTY ;
     ASSERT (TRILINOS_AMD_valid (n, n, Ap, Ai) == TRILINOS_AMD_OK) ;
 #endif
 
@@ -43,7 +43,7 @@ GLOBAL size_t TRILINOS_AMD_aat	/* returns nz in A+A' */
 	/* clear the Info array, if it exists */
 	for (i = 0 ; i < TRILINOS_AMD_INFO ; i++)
 	{
-	    Info [i] = EMPTY ;
+	    Info [i] = TRILINOS_AMD_EMPTY ;
 	}
 	Info [TRILINOS_AMD_STATUS] = TRILINOS_AMD_OK ;
     }
@@ -91,7 +91,7 @@ GLOBAL size_t TRILINOS_AMD_aat	/* returns nz in A+A' */
 	    }
 	    /* scan lower triangular part of A, in column j until reaching
 	     * row k.  Start where last scan left off. */
-	    ASSERT (Tp [j] != EMPTY) ;
+	    ASSERT (Tp [j] != TRILINOS_AMD_EMPTY) ;
 	    ASSERT (Ap [j] <= Tp [j] && Tp [j] <= Ap [j+1]) ;
 	    pj2 = Ap [j+1] ;
 	    for (pj = Tp [j] ; pj < pj2 ; )

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Source/trilinos_amd_dump.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Source/trilinos_amd_dump.c
@@ -85,20 +85,20 @@ GLOBAL void TRILINOS_AMD_dump (
 	len = Len [i] ;
 	w = W [i] ;
 
-	if (elen >= EMPTY)
+	if (elen >= TRILINOS_AMD_EMPTY)
 	{
 	    if (nv == 0)
 	    {
 		TRILINOS_AMD_DEBUG3 (("\nI "ID": nonprincipal:    ", i)) ;
-		ASSERT (elen == EMPTY) ;
-		if (pe == EMPTY)
+		ASSERT (elen == TRILINOS_AMD_EMPTY) ;
+		if (pe == TRILINOS_AMD_EMPTY)
 		{
 		    TRILINOS_AMD_DEBUG3 ((" dense node\n")) ;
 		    ASSERT (w == 1) ;
 		}
 		else
 		{
-		    ASSERT (pe < EMPTY) ;
+		    ASSERT (pe < TRILINOS_AMD_EMPTY) ;
 		    TRILINOS_AMD_DEBUG3 ((" i "ID" -> parent "ID"\n", i, FLIP (Pe[i])));
 		}
 	    }
@@ -158,10 +158,10 @@ GLOBAL void TRILINOS_AMD_dump (
 	cnt = 0 ;
 	for (deg = 0 ; deg < n ; deg++)
 	{
-	    if (Head [deg] == EMPTY) continue ;
-	    ilast = EMPTY ;
+	    if (Head [deg] == TRILINOS_AMD_EMPTY) continue ;
+	    ilast = TRILINOS_AMD_EMPTY ;
 	    TRILINOS_AMD_DEBUG3 ((ID": \n", deg)) ;
-	    for (i = Head [deg] ; i != EMPTY ; i = Next [i])
+	    for (i = Head [deg] ; i != TRILINOS_AMD_EMPTY ; i = Next [i])
 	    {
 		TRILINOS_AMD_DEBUG3 (("   "ID" : next "ID" last "ID" deg "ID"\n",
 		    i, Next [i], Last [i], Degree [i])) ;

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Source/trilinos_amd_l1.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Source/trilinos_amd_l1.c
@@ -84,7 +84,7 @@ GLOBAL void TRILINOS_AMD_1
     ASSERT (iwlen >= pfree + n) ;
 
 #ifndef NDEBUG
-    for (p = 0 ; p < iwlen ; p++) Iw [p] = EMPTY ;
+    for (p = 0 ; p < iwlen ; p++) Iw [p] = TRILINOS_AMD_EMPTY ;
 #endif
 
     for (k = 0 ; k < n ; k++)

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Source/trilinos_amd_l2.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Source/trilinos_amd_l2.c
@@ -255,7 +255,7 @@ GLOBAL void TRILINOS_AMD_2
  *	    as (-(j)-2).  Row j has the same pattern as row i.  Note that j
  *	    might later be absorbed into another supervariable j2, in which
  *	    case Pe [i] is still FLIP (j), and Pe [j] = FLIP (j2) which is
- *	    < EMPTY, where EMPTY is defined as (-1) in amd_internal.h.
+ *	    < TRILINOS_AMD_EMPTY, where TRILINOS_AMD_EMPTY is defined as (-1) in amd_internal.h.
  *
  *	Unabsorbed element e:  the index into Iw of the description of element
  *	    e, if e has not yet been absorbed by a subsequent element.  Element
@@ -265,18 +265,18 @@ GLOBAL void TRILINOS_AMD_2
  *	Absorbed element e:  if element e is absorbed into element e2, then
  *	    Pe [e] = FLIP (e2).  This occurs when the pattern of e (which we
  *	    refer to as Le) is found to be a subset of the pattern of e2 (that
- *	    is, Le2).  In this case, Pe [i] < EMPTY.  If element e is "null"
- *	    (it has no nonzeros outside its pivot block), then Pe [e] = EMPTY,
+ *	    is, Le2).  In this case, Pe [i] < TRILINOS_AMD_EMPTY.  If element e is "null"
+ *	    (it has no nonzeros outside its pivot block), then Pe [e] = TRILINOS_AMD_EMPTY,
  *	    and e is the root of an assembly subtree (or the whole tree if
  *	    there is just one such root).
  *
- *	Dense variable i:  if i is "dense", then Pe [i] = EMPTY.
+ *	Dense variable i:  if i is "dense", then Pe [i] = TRILINOS_AMD_EMPTY.
  *
  *	On output, Pe holds the assembly tree/forest, which implicitly
  *	represents a pivot order with identical fill-in as the actual order
  *	(via a depth-first search of the tree), as follows.  If Nv [i] > 0,
  *	then i represents a node in the assembly tree, and the parent of i is
- *	Pe [i], or EMPTY if i is a root.  If Nv [i] = 0, then (i, Pe [i])
+ *	Pe [i], or TRILINOS_AMD_EMPTY if i is a root.  If Nv [i] = 0, then (i, Pe [i])
  *	represents an edge in a subtree, the root of which is a node in the
  *	assembly tree.  Note that i refers to a row/column in the original
  *	matrix, not the permuted matrix.
@@ -361,16 +361,16 @@ GLOBAL void TRILINOS_AMD_2
  *	execution, Elen [i] is the number of elements in the list for
  *	supervariable i.  When e becomes an element, Elen [e] = FLIP (esize) is
  *	set, where esize is the size of the element (the number of pivots, plus
- *	the number of nonpivotal entries).  Thus Elen [e] < EMPTY.
- *	Elen (i) = EMPTY set when variable i becomes nonprincipal.
+ *	the number of nonpivotal entries).  Thus Elen [e] < TRILINOS_AMD_EMPTY.
+ *	Elen (i) = TRILINOS_AMD_EMPTY set when variable i becomes nonprincipal.
  *
- *	For variables, Elen (i) >= EMPTY holds until just before the
+ *	For variables, Elen (i) >= TRILINOS_AMD_EMPTY holds until just before the
  *	postordering and permutation vectors are computed.  For elements,
- *	Elen [e] < EMPTY holds.
+ *	Elen [e] < TRILINOS_AMD_EMPTY holds.
  *
  *	On output, Elen [i] is the degree of the row/column in the Cholesky
  *	factorization of the permuted matrix, corresponding to the original row
- *	i, if i is a super row/column.  It is equal to EMPTY if i is
+ *	i, if i is a super row/column.  It is equal to TRILINOS_AMD_EMPTY if i is
  *	non-principal.  Note that i refers to a row/column in the original
  *	matrix, not the permuted matrix.
  *
@@ -379,7 +379,7 @@ GLOBAL void TRILINOS_AMD_2
  *	which is instead returned in the Next array in this C version,
  *	described below).
  *
- * Last: In a degree list, Last [i] is the supervariable preceding i, or EMPTY
+ * Last: In a degree list, Last [i] is the supervariable preceding i, or TRILINOS_AMD_EMPTY
  *	if i is the head of the list.  In a hash bucket, Last [i] is the hash
  *	key for i.
  *
@@ -391,7 +391,7 @@ GLOBAL void TRILINOS_AMD_2
  *	i = Last [k], then row i is the kth pivot row (where k ranges from 0 to
  *	n-1).  Row Last [k] of A is the kth row in the permuted matrix, PAP'.
  *
- * Next: Next [i] is the supervariable following i in a link list, or EMPTY if
+ * Next: Next [i] is the supervariable following i in a link list, or TRILINOS_AMD_EMPTY if
  *	i is the last in the list.  Used for two kinds of lists:  degree lists
  *	and hash buckets (a supervariable can be in only one kind of list at a
  *	time).
@@ -422,16 +422,16 @@ GLOBAL void TRILINOS_AMD_2
  *	Head [deg] is the first supervariable in a degree list.  All
  *	supervariables i in a degree list Head [deg] have the same approximate
  *	degree, namely, deg = Degree [i].  If the list Head [deg] is empty then
- *	Head [deg] = EMPTY.
+ *	Head [deg] = TRILINOS_AMD_EMPTY.
  *
  *	During supervariable detection Head [hash] also serves as a pointer to
  *	a hash bucket.  If Head [hash] >= 0, there is a degree list of degree
  *	hash.  The hash bucket head pointer is Last [Head [hash]].  If
- *	Head [hash] = EMPTY, then the degree list and hash bucket are both
- *	empty.  If Head [hash] < EMPTY, then the degree list is empty, and
+ *	Head [hash] = TRILINOS_AMD_EMPTY, then the degree list and hash bucket are both
+ *	empty.  If Head [hash] < TRILINOS_AMD_EMPTY, then the degree list is empty, and
  *	FLIP (Head [hash]) is the head of the hash bucket.  After supervariable
  *	detection is complete, all hash buckets are empty, and the
- *	(Last [Head [hash]] = EMPTY) condition is restored for the non-empty
+ *	(Last [Head [hash]] = TRILINOS_AMD_EMPTY) condition is restored for the non-empty
  *	degree lists.
  *
  * W:  An integer array of size n.  The flag array W determines the status of
@@ -577,7 +577,7 @@ GLOBAL void TRILINOS_AMD_2
     nms_lu = 0 ;
     nms_ldl = 0 ;
     dmax = 1 ;
-    me = EMPTY ;
+    me = TRILINOS_AMD_EMPTY ;
 
     mindeg = 0 ;
     ncmpa = 0 ;
@@ -612,11 +612,11 @@ GLOBAL void TRILINOS_AMD_2
 
     for (i = 0 ; i < n ; i++)
     {
-	Last [i] = EMPTY ;
-	Head [i] = EMPTY ;
-	Next [i] = EMPTY ;
+	Last [i] = TRILINOS_AMD_EMPTY ;
+	Head [i] = TRILINOS_AMD_EMPTY ;
+	Next [i] = TRILINOS_AMD_EMPTY ;
 	/* if separate Hhead array is used for hash buckets: *
-	Hhead [i] = EMPTY ;
+	Hhead [i] = TRILINOS_AMD_EMPTY ;
 	*/
 	Nv [i] = 1 ;
 	W [i] = 1 ;
@@ -656,7 +656,7 @@ GLOBAL void TRILINOS_AMD_2
 
 	    Elen [i] = FLIP (1) ;
 	    nel++ ;
-	    Pe [i] = EMPTY ;
+	    Pe [i] = TRILINOS_AMD_EMPTY ;
 	    W [i] = 0 ;
 
 	}
@@ -673,9 +673,9 @@ GLOBAL void TRILINOS_AMD_2
 	    TRILINOS_AMD_DEBUG1 (("Dense node "ID" degree "ID"\n", i, deg)) ;
 	    ndense++ ;
 	    Nv [i] = 0 ;		/* do not postorder this node */
-	    Elen [i] = EMPTY ;
+	    Elen [i] = TRILINOS_AMD_EMPTY ;
 	    nel++ ;
-	    Pe [i] = EMPTY ;
+	    Pe [i] = TRILINOS_AMD_EMPTY ;
 
 	}
 	else
@@ -686,8 +686,8 @@ GLOBAL void TRILINOS_AMD_2
 	     * ------------------------------------------------------------- */
 
 	    inext = Head [deg] ;
-	    ASSERT (inext >= EMPTY && inext < n) ;
-	    if (inext != EMPTY) Last [inext] = i ;
+	    ASSERT (inext >= TRILINOS_AMD_EMPTY && inext < n) ;
+	    if (inext != TRILINOS_AMD_EMPTY) Last [inext] = i ;
 	    Next [i] = inext ;
 	    Head [deg] = i ;
 
@@ -722,7 +722,7 @@ GLOBAL void TRILINOS_AMD_2
 	for (deg = mindeg ; deg < n ; deg++)
 	{
 	    me = Head [deg] ;
-	    if (me != EMPTY) break ;
+	    if (me != TRILINOS_AMD_EMPTY) break ;
 	}
 	mindeg = deg ;
 	ASSERT (me >= 0 && me < n) ;
@@ -733,8 +733,8 @@ GLOBAL void TRILINOS_AMD_2
 	/* ----------------------------------------------------------------- */
 
 	inext = Next [me] ;
-	ASSERT (inext >= EMPTY && inext < n) ;
-	if (inext != EMPTY) Last [inext] = EMPTY ;
+	ASSERT (inext >= TRILINOS_AMD_EMPTY && inext < n) ;
+	if (inext != TRILINOS_AMD_EMPTY) Last [inext] = TRILINOS_AMD_EMPTY ;
 	Head [deg] = inext ;
 
 	/* ----------------------------------------------------------------- */
@@ -798,10 +798,10 @@ GLOBAL void TRILINOS_AMD_2
 
 		    ilast = Last [i] ;
 		    inext = Next [i] ;
-		    ASSERT (ilast >= EMPTY && ilast < n) ;
-		    ASSERT (inext >= EMPTY && inext < n) ;
-		    if (inext != EMPTY) Last [inext] = ilast ;
-		    if (ilast != EMPTY)
+		    ASSERT (ilast >= TRILINOS_AMD_EMPTY && ilast < n) ;
+		    ASSERT (inext >= TRILINOS_AMD_EMPTY && inext < n) ;
+		    if (inext != TRILINOS_AMD_EMPTY) Last [inext] = ilast ;
+		    if (ilast != TRILINOS_AMD_EMPTY)
 		    {
 			Next [ilast] = inext ;
 		    }
@@ -844,7 +844,7 @@ GLOBAL void TRILINOS_AMD_2
 		    pj = Pe [e] ;
 		    ln = Len [e] ;
 		    TRILINOS_AMD_DEBUG2 (("Search element e "ID" in me "ID"\n", e,me)) ;
-		    ASSERT (Elen [e] < EMPTY && W [e] > 0 && pj >= 0) ;
+		    ASSERT (Elen [e] < TRILINOS_AMD_EMPTY && W [e] > 0 && pj >= 0) ;
 		}
 		ASSERT (ln >= 0 && (ln == 0 || (pj >= 0 && pj < iwlen))) ;
 
@@ -858,7 +858,7 @@ GLOBAL void TRILINOS_AMD_2
 		for (knt2 = 1 ; knt2 <= ln ; knt2++)
 		{
 		    i = Iw [pj++] ;
-		    ASSERT (i >= 0 && i < n && (i == me || Elen [i] >= EMPTY));
+		    ASSERT (i >= 0 && i < n && (i == me || Elen [i] >= TRILINOS_AMD_EMPTY));
 		    nvi = Nv [i] ;
 		    TRILINOS_AMD_DEBUG2 ((": "ID" "ID" "ID" "ID"\n",
 				i, Elen [i], Nv [i], wflg)) ;
@@ -883,11 +883,11 @@ GLOBAL void TRILINOS_AMD_2
 			    Pe [me] = p ;
 			    Len [me] -= knt1 ;
 			    /* check if nothing left of supervariable me */
-			    if (Len [me] == 0) Pe [me] = EMPTY ;
+			    if (Len [me] == 0) Pe [me] = TRILINOS_AMD_EMPTY ;
 			    Pe [e] = pj ;
 			    Len [e] = ln - knt2 ;
 			    /* nothing left of element e */
-			    if (Len [e] == 0) Pe [e] = EMPTY ;
+			    if (Len [e] == 0) Pe [e] = TRILINOS_AMD_EMPTY ;
 
 			    ncmpa++ ;	/* one more garbage collection */
 
@@ -957,10 +957,10 @@ GLOBAL void TRILINOS_AMD_2
 
 			ilast = Last [i] ;
 			inext = Next [i] ;
-			ASSERT (ilast >= EMPTY && ilast < n) ;
-			ASSERT (inext >= EMPTY && inext < n) ;
-			if (inext != EMPTY) Last [inext] = ilast ;
-			if (ilast != EMPTY)
+			ASSERT (ilast >= TRILINOS_AMD_EMPTY && ilast < n) ;
+			ASSERT (inext >= TRILINOS_AMD_EMPTY && inext < n) ;
+			if (inext != TRILINOS_AMD_EMPTY) Last [inext] = ilast ;
+			if (ilast != TRILINOS_AMD_EMPTY)
 			{
 			    Next [ilast] = inext ;
 			}
@@ -1222,7 +1222,7 @@ GLOBAL void TRILINOS_AMD_2
 		nvpiv += nvi ;
 		nel += nvi ;
 		Nv [i] = 0 ;
-		Elen [i] = EMPTY ;
+		Elen [i] = TRILINOS_AMD_EMPTY ;
 
 	    }
 	    else
@@ -1263,7 +1263,7 @@ GLOBAL void TRILINOS_AMD_2
 
 		/* if the Hhead array is not used: */
 		j = Head [hash] ;
-		if (j <= EMPTY)
+		if (j <= TRILINOS_AMD_EMPTY)
 		{
 		    /* degree list is empty, hash head is FLIP (j) */
 		    Next [i] = FLIP (j) ;
@@ -1324,33 +1324,33 @@ GLOBAL void TRILINOS_AMD_2
 
 		/* if Hhead array is not used: */
 		j = Head [hash] ;
-		if (j == EMPTY)
+		if (j == TRILINOS_AMD_EMPTY)
 		{
 		    /* hash bucket and degree list are both empty */
-		    i = EMPTY ;
+		    i = TRILINOS_AMD_EMPTY ;
 		}
-		else if (j < EMPTY)
+		else if (j < TRILINOS_AMD_EMPTY)
 		{
 		    /* degree list is empty */
 		    i = FLIP (j) ;
-		    Head [hash] = EMPTY ;
+		    Head [hash] = TRILINOS_AMD_EMPTY ;
 		}
 		else
 		{
 		    /* degree list is not empty, restore Last [j] of head j */
 		    i = Last [j] ;
-		    Last [j] = EMPTY ;
+		    Last [j] = TRILINOS_AMD_EMPTY ;
 		}
 
 		/* if separate Hhead array is used: *
 		i = Hhead [hash] ;
-		Hhead [hash] = EMPTY ;
+		Hhead [hash] = TRILINOS_AMD_EMPTY ;
 		*/
 
-		ASSERT (i >= EMPTY && i < n) ;
+		ASSERT (i >= TRILINOS_AMD_EMPTY && i < n) ;
 		TRILINOS_AMD_DEBUG2 (("----i "ID" hash "ID"\n", i, hash)) ;
 
-		while (i != EMPTY && Next [i] != EMPTY)
+		while (i != TRILINOS_AMD_EMPTY && Next [i] != TRILINOS_AMD_EMPTY)
 		{
 
 		    /* -----------------------------------------------------
@@ -1376,9 +1376,9 @@ GLOBAL void TRILINOS_AMD_2
 
 		    jlast = i ;
 		    j = Next [i] ;
-		    ASSERT (j >= EMPTY && j < n) ;
+		    ASSERT (j >= TRILINOS_AMD_EMPTY && j < n) ;
 
-		    while (j != EMPTY)
+		    while (j != TRILINOS_AMD_EMPTY)
 		    {
 			/* ------------------------------------------------- */
 			/* check if j and i have identical nonzero pattern */
@@ -1409,7 +1409,7 @@ GLOBAL void TRILINOS_AMD_2
 			    /* are the number of variables in i and j: */
 			    Nv [i] += Nv [j] ;
 			    Nv [j] = 0 ;
-			    Elen [j] = EMPTY ;
+			    Elen [j] = TRILINOS_AMD_EMPTY ;
 			    /* delete j from hash bucket */
 			    ASSERT (j != Next [j]) ;
 			    j = Next [j] ;
@@ -1423,7 +1423,7 @@ GLOBAL void TRILINOS_AMD_2
 			    ASSERT (j != Next [j]) ;
 			    j = Next [j] ;
 			}
-			ASSERT (j >= EMPTY && j < n) ;
+			ASSERT (j >= TRILINOS_AMD_EMPTY && j < n) ;
 		    }
 
 		    /* -----------------------------------------------------
@@ -1433,7 +1433,7 @@ GLOBAL void TRILINOS_AMD_2
 
 		    wflg++ ;
 		    i = Next [i] ;
-		    ASSERT (i >= EMPTY && i < n) ;
+		    ASSERT (i >= TRILINOS_AMD_EMPTY && i < n) ;
 
 		}
 	    }
@@ -1471,10 +1471,10 @@ GLOBAL void TRILINOS_AMD_2
 		/* --------------------------------------------------------- */
 
 		inext = Head [deg] ;
-		ASSERT (inext >= EMPTY && inext < n) ;
-		if (inext != EMPTY) Last [inext] = i ;
+		ASSERT (inext >= TRILINOS_AMD_EMPTY && inext < n) ;
+		if (inext != TRILINOS_AMD_EMPTY) Last [inext] = i ;
 		Next [i] = inext ;
-		Last [i] = EMPTY ;
+		Last [i] = TRILINOS_AMD_EMPTY ;
 		Head [deg] = i ;
 
 		/* --------------------------------------------------------- */
@@ -1506,7 +1506,7 @@ GLOBAL void TRILINOS_AMD_2
 	{
 	    /* there is nothing left of the current pivot element */
 	    /* it is a root of the assembly tree */
-	    Pe [me] = EMPTY ;
+	    Pe [me] = TRILINOS_AMD_EMPTY ;
 	    W [me] = 0 ;
 	}
 	if (elenme != 0)
@@ -1613,13 +1613,13 @@ GLOBAL void TRILINOS_AMD_2
  * Variables at this point:
  *
  * Pe: holds the elimination tree.  The parent of j is FLIP (Pe [j]),
- *	or EMPTY if j is a root.  The tree holds both elements and
+ *	or TRILINOS_AMD_EMPTY if j is a root.  The tree holds both elements and
  *	non-principal (unordered) variables absorbed into them.
  *	Dense variables are non-principal and unordered.
  *
  * Elen: holds the size of each element, including the diagonal part.
  *	FLIP (Elen [e]) > 0 if e is an element.  For unordered
- *	variables i, Elen [i] is EMPTY.
+ *	variables i, Elen [i] is TRILINOS_AMD_EMPTY.
  *
  * Nv: Nv [e] > 0 is the number of pivots represented by the element e.
  *	For unordered variables i, Nv [i] is zero.
@@ -1645,15 +1645,15 @@ GLOBAL void TRILINOS_AMD_2
 	Elen [i] = FLIP (Elen [i]) ;
     }
 
-/* Now the parent of j is Pe [j], or EMPTY if j is a root.  Elen [e] > 0
- * is the size of element e.  Elen [i] is EMPTY for unordered variable i. */
+/* Now the parent of j is Pe [j], or TRILINOS_AMD_EMPTY if j is a root.  Elen [e] > 0
+ * is the size of element e.  Elen [i] is TRILINOS_AMD_EMPTY for unordered variable i. */
 
 #ifndef NDEBUG
     TRILINOS_AMD_DEBUG2 (("\nTree:\n")) ;
     for (i = 0 ; i < n ; i++)
     {
 	TRILINOS_AMD_DEBUG2 ((" "ID" parent: "ID"   ", i, Pe [i])) ;
-	ASSERT (Pe [i] >= EMPTY && Pe [i] < n) ;
+	ASSERT (Pe [i] >= TRILINOS_AMD_EMPTY && Pe [i] < n) ;
 	if (Nv [i] > 0)
 	{
 	    /* this is an element */
@@ -1682,7 +1682,7 @@ GLOBAL void TRILINOS_AMD_2
 	    j = Pe [i] ;
 	    cnt = 0 ;
 	    TRILINOS_AMD_DEBUG3 (("  j: "ID"\n", j)) ;
-	    if (j == EMPTY)
+	    if (j == TRILINOS_AMD_EMPTY)
 	    {
 		TRILINOS_AMD_DEBUG3 (("	i is a dense variable\n")) ;
 	    }
@@ -1722,9 +1722,9 @@ GLOBAL void TRILINOS_AMD_2
 
 	    TRILINOS_AMD_DEBUG1 (("Path compression, i unordered: "ID"\n", i)) ;
 	    j = Pe [i] ;
-	    ASSERT (j >= EMPTY && j < n) ;
+	    ASSERT (j >= TRILINOS_AMD_EMPTY && j < n) ;
 	    TRILINOS_AMD_DEBUG3 (("	j: "ID"\n", j)) ;
-	    if (j == EMPTY)
+	    if (j == TRILINOS_AMD_EMPTY)
 	    {
 		/* Skip a dense variable.  It has no parent. */
 		TRILINOS_AMD_DEBUG3 (("      i is a dense variable\n")) ;
@@ -1780,14 +1780,14 @@ GLOBAL void TRILINOS_AMD_2
 
     for (k = 0 ; k < n ; k++)
     {
-	Head [k] = EMPTY ;
-	Next [k] = EMPTY ;
+	Head [k] = TRILINOS_AMD_EMPTY ;
+	Next [k] = TRILINOS_AMD_EMPTY ;
     }
     for (e = 0 ; e < n ; e++)
     {
 	k = W [e] ;
-	ASSERT ((k == EMPTY) == (Nv [e] == 0)) ;
-	if (k != EMPTY)
+	ASSERT ((k == TRILINOS_AMD_EMPTY) == (Nv [e] == 0)) ;
+	if (k != TRILINOS_AMD_EMPTY)
 	{
 	    ASSERT (k >= 0 && k < n) ;
 	    Head [k] = e ;
@@ -1800,7 +1800,7 @@ GLOBAL void TRILINOS_AMD_2
     for (k = 0 ; k < n ; k++)
     {
 	e = Head [k] ;
-	if (e == EMPTY) break ;
+	if (e == TRILINOS_AMD_EMPTY) break ;
 	ASSERT (e >= 0 && e < n && Nv [e] > 0) ;
 	Next [e] = nel ;
 	nel += Nv [e] ;
@@ -1813,14 +1813,14 @@ GLOBAL void TRILINOS_AMD_2
 	if (Nv [i] == 0)
 	{
 	    e = Pe [i] ;
-	    ASSERT (e >= EMPTY && e < n) ;
-	    if (e != EMPTY)
+	    ASSERT (e >= TRILINOS_AMD_EMPTY && e < n) ;
+	    if (e != TRILINOS_AMD_EMPTY)
 	    {
 		/* This is an unordered variable that was merged
 		 * into element e via supernode detection or mass
 		 * elimination of i when e became the pivot element.
 		 * Place i in order just before e. */
-		ASSERT (Next [i] == EMPTY && Nv [e] > 0) ;
+		ASSERT (Next [i] == TRILINOS_AMD_EMPTY && Nv [e] > 0) ;
 		Next [i] = Next [e] ;
 		Next [e]++ ;
 	    }

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Source/trilinos_amd_l_aat.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Source/trilinos_amd_l_aat.c
@@ -37,7 +37,7 @@ GLOBAL size_t TRILINOS_AMD_aat	/* returns nz in A+A' */
 
 #ifndef NDEBUG
     TRILINOS_AMD_debug_init ("AMD AAT") ;
-    for (k = 0 ; k < n ; k++) Tp [k] = EMPTY ;
+    for (k = 0 ; k < n ; k++) Tp [k] = TRILINOS_AMD_EMPTY ;
     ASSERT (TRILINOS_AMD_valid (n, n, Ap, Ai) == TRILINOS_AMD_OK) ;
 #endif
 
@@ -46,7 +46,7 @@ GLOBAL size_t TRILINOS_AMD_aat	/* returns nz in A+A' */
 	/* clear the Info array, if it exists */
 	for (i = 0 ; i < TRILINOS_AMD_INFO ; i++)
 	{
-	    Info [i] = EMPTY ;
+	    Info [i] = TRILINOS_AMD_EMPTY ;
 	}
 	Info [TRILINOS_AMD_STATUS] = TRILINOS_AMD_OK ;
     }
@@ -94,7 +94,7 @@ GLOBAL size_t TRILINOS_AMD_aat	/* returns nz in A+A' */
 	    }
 	    /* scan lower triangular part of A, in column j until reaching
 	     * row k.  Start where last scan left off. */
-	    ASSERT (Tp [j] != EMPTY) ;
+	    ASSERT (Tp [j] != TRILINOS_AMD_EMPTY) ;
 	    ASSERT (Ap [j] <= Tp [j] && Tp [j] <= Ap [j+1]) ;
 	    pj2 = Ap [j+1] ;
 	    for (pj = Tp [j] ; pj < pj2 ; )

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Source/trilinos_amd_l_order.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Source/trilinos_amd_l_order.c
@@ -46,7 +46,7 @@ GLOBAL Int TRILINOS_AMD_order
     {
 	for (i = 0 ; i < TRILINOS_AMD_INFO ; i++)
 	{
-	    Info [i] = EMPTY ;
+	    Info [i] = TRILINOS_AMD_EMPTY ;
 	}
 	Info [TRILINOS_AMD_N] = n ;
 	Info [TRILINOS_AMD_STATUS] = TRILINOS_AMD_OK ;

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Source/trilinos_amd_l_post_tree.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Source/trilinos_amd_l_post_tree.c
@@ -47,7 +47,7 @@ GLOBAL Int TRILINOS_AMD_post_tree
 
     /* this is simple, but can caouse stack overflow if nn is large */
     i = root ;
-    for (f = Child [i] ; f != EMPTY ; f = Sibling [f])
+    for (f = Child [i] ; f != TRILINOS_AMD_EMPTY ; f = Sibling [f])
     {
 	k = TRILINOS_AMD_post_tree (f, k, Child, Sibling, Order, Stack, nn) ;
     }
@@ -71,13 +71,13 @@ GLOBAL Int TRILINOS_AMD_post_tree
 	TRILINOS_AMD_DEBUG1 (("head of stack "ID" \n", i)) ;
 	ASSERT (i >= 0 && i < nn) ;
 
-	if (Child [i] != EMPTY)
+	if (Child [i] != TRILINOS_AMD_EMPTY)
 	{
 	    /* the children of i are not yet ordered */
 	    /* push each child onto the stack in reverse order */
 	    /* so that small ones at the head of the list get popped first */
 	    /* and the biggest one at the end of the list gets popped last */
-	    for (f = Child [i] ; f != EMPTY ; f = Sibling [f])
+	    for (f = Child [i] ; f != TRILINOS_AMD_EMPTY ; f = Sibling [f])
 	    {
 		head++ ;
 		ASSERT (head < nn) ;
@@ -85,7 +85,7 @@ GLOBAL Int TRILINOS_AMD_post_tree
 	    }
 	    h = head ;
 	    ASSERT (head < nn) ;
-	    for (f = Child [i] ; f != EMPTY ; f = Sibling [f])
+	    for (f = Child [i] ; f != TRILINOS_AMD_EMPTY ; f = Sibling [f])
 	    {
 		ASSERT (h > 0) ;
 		Stack [h--] = f ;
@@ -95,7 +95,7 @@ GLOBAL Int TRILINOS_AMD_post_tree
 	    ASSERT (Stack [h] == i) ;
 
 	    /* delete child list so that i gets ordered next time we see it */
-	    Child [i] = EMPTY ;
+	    Child [i] = TRILINOS_AMD_EMPTY ;
 	}
 	else
 	{

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Source/trilinos_amd_l_postorder.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Source/trilinos_amd_l_postorder.c
@@ -20,7 +20,7 @@ GLOBAL void TRILINOS_AMD_postorder
 (
     /* inputs, not modified on output: */
     Int nn,		/* nodes are in the range 0..nn-1 */
-    Int Parent [ ],	/* Parent [j] is the parent of j, or EMPTY if root */
+    Int Parent [ ],	/* Parent [j] is the parent of j, or TRILINOS_AMD_EMPTY if root */
     Int Nv [ ],		/* Nv [j] > 0 number of pivots represented by node j,
 			 * or zero if j is not a node. */
     Int Fsize [ ],	/* Fsize [j]: size of node j */
@@ -38,8 +38,8 @@ GLOBAL void TRILINOS_AMD_postorder
 
     for (j = 0 ; j < nn ; j++)
     {
-	Child [j] = EMPTY ;
-	Sibling [j] = EMPTY ;
+	Child [j] = TRILINOS_AMD_EMPTY ;
+	Sibling [j] = TRILINOS_AMD_EMPTY ;
     }
 
     /* --------------------------------------------------------------------- */
@@ -52,7 +52,7 @@ GLOBAL void TRILINOS_AMD_postorder
 	{
 	    /* this is an element */
 	    parent = Parent [j] ;
-	    if (parent != EMPTY)
+	    if (parent != TRILINOS_AMD_EMPTY)
 	    {
 		/* place the element in link list of the children its parent */
 		/* bigger elements will tend to be at the end of the list */
@@ -78,7 +78,7 @@ GLOBAL void TRILINOS_AMD_postorder
 		/* dump the link list of children */
 		nchild = 0 ;
 		TRILINOS_AMD_DEBUG1 (("    Children: ")) ;
-		for (ff = Child [j] ; ff != EMPTY ; ff = Sibling [ff])
+		for (ff = Child [j] ; ff != TRILINOS_AMD_EMPTY ; ff = Sibling [ff])
 		{
 		    TRILINOS_AMD_DEBUG1 ((ID" ", ff)) ;
 		    ASSERT (Parent [ff] == j) ;
@@ -87,7 +87,7 @@ GLOBAL void TRILINOS_AMD_postorder
 		}
 		TRILINOS_AMD_DEBUG1 (("\n")) ;
 		parent = Parent [j] ;
-		if (parent != EMPTY)
+		if (parent != TRILINOS_AMD_EMPTY)
 		{
 		    ASSERT (Nv [parent] > 0) ;
 		}
@@ -105,14 +105,14 @@ GLOBAL void TRILINOS_AMD_postorder
 
     for (i = 0 ; i < nn ; i++)
     {
-	if (Nv [i] > 0 && Child [i] != EMPTY)
+	if (Nv [i] > 0 && Child [i] != TRILINOS_AMD_EMPTY)
 	{
 
 #ifndef NDEBUG
 	    Int nchild ;
 	    TRILINOS_AMD_DEBUG1 (("Before partial sort, element "ID"\n", i)) ;
 	    nchild = 0 ;
-	    for (f = Child [i] ; f != EMPTY ; f = Sibling [f])
+	    for (f = Child [i] ; f != TRILINOS_AMD_EMPTY ; f = Sibling [f])
 	    {
 		ASSERT (f >= 0 && f < nn) ;
 		TRILINOS_AMD_DEBUG1 (("      f: "ID"  size: "ID"\n", f, Fsize [f])) ;
@@ -122,11 +122,11 @@ GLOBAL void TRILINOS_AMD_postorder
 #endif
 
 	    /* find the biggest element in the child list */
-	    fprev = EMPTY ;
-	    maxfrsize = EMPTY ;
-	    bigfprev = EMPTY ;
-	    bigf = EMPTY ;
-	    for (f = Child [i] ; f != EMPTY ; f = Sibling [f])
+	    fprev = TRILINOS_AMD_EMPTY ;
+	    maxfrsize = TRILINOS_AMD_EMPTY ;
+	    bigfprev = TRILINOS_AMD_EMPTY ;
+	    bigf = TRILINOS_AMD_EMPTY ;
+	    for (f = Child [i] ; f != TRILINOS_AMD_EMPTY ; f = Sibling [f])
 	    {
 		ASSERT (f >= 0 && f < nn) ;
 		frsize = Fsize [f] ;
@@ -139,18 +139,18 @@ GLOBAL void TRILINOS_AMD_postorder
 		}
 		fprev = f ;
 	    }
-	    ASSERT (bigf != EMPTY) ;
+	    ASSERT (bigf != TRILINOS_AMD_EMPTY) ;
 
 	    fnext = Sibling [bigf] ;
 
 	    TRILINOS_AMD_DEBUG1 (("bigf "ID" maxfrsize "ID" bigfprev "ID" fnext "ID
 		" fprev " ID"\n", bigf, maxfrsize, bigfprev, fnext, fprev)) ;
 
-	    if (fnext != EMPTY)
+	    if (fnext != TRILINOS_AMD_EMPTY)
 	    {
-		/* if fnext is EMPTY then bigf is already at the end of list */
+		/* if fnext is TRILINOS_AMD_EMPTY then bigf is already at the end of list */
 
-		if (bigfprev == EMPTY)
+		if (bigfprev == TRILINOS_AMD_EMPTY)
 		{
 		    /* delete bigf from the element of the list */
 		    Child [i] = fnext ;
@@ -162,16 +162,16 @@ GLOBAL void TRILINOS_AMD_postorder
 		}
 
 		/* put bigf at the end of the list */
-		Sibling [bigf] = EMPTY ;
-		ASSERT (Child [i] != EMPTY) ;
+		Sibling [bigf] = TRILINOS_AMD_EMPTY ;
+		ASSERT (Child [i] != TRILINOS_AMD_EMPTY) ;
 		ASSERT (fprev != bigf) ;
-		ASSERT (fprev != EMPTY) ;
+		ASSERT (fprev != TRILINOS_AMD_EMPTY) ;
 		Sibling [fprev] = bigf ;
 	    }
 
 #ifndef NDEBUG
 	    TRILINOS_AMD_DEBUG1 (("After partial sort, element "ID"\n", i)) ;
-	    for (f = Child [i] ; f != EMPTY ; f = Sibling [f])
+	    for (f = Child [i] ; f != TRILINOS_AMD_EMPTY ; f = Sibling [f])
 	    {
 		ASSERT (f >= 0 && f < nn) ;
 		TRILINOS_AMD_DEBUG1 (("        "ID"  "ID"\n", f, Fsize [f])) ;
@@ -190,14 +190,14 @@ GLOBAL void TRILINOS_AMD_postorder
 
     for (i = 0 ; i < nn ; i++)
     {
-	Order [i] = EMPTY ;
+	Order [i] = TRILINOS_AMD_EMPTY ;
     }
 
     k = 0 ;
 
     for (i = 0 ; i < nn ; i++)
     {
-	if (Parent [i] == EMPTY && Nv [i] > 0)
+	if (Parent [i] == TRILINOS_AMD_EMPTY && Nv [i] > 0)
 	{
 	    TRILINOS_AMD_DEBUG1 (("Root of assembly tree "ID"\n", i)) ;
 	    k = TRILINOS_AMD_post_tree (i, k, Child, Sibling, Order, Stack

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Source/trilinos_amd_l_preprocess.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Source/trilinos_amd_l_preprocess.c
@@ -60,7 +60,7 @@ GLOBAL void TRILINOS_AMD_preprocess
     for (i = 0 ; i < n ; i++)
     {
 	W [i] = 0 ;		/* # of nonzeros in row i (excl duplicates) */
-	Flag [i] = EMPTY ;	/* Flag [i] = j if i appears in column j */
+	Flag [i] = TRILINOS_AMD_EMPTY ;	/* Flag [i] = j if i appears in column j */
     }
     for (j = 0 ; j < n ; j++)
     {
@@ -89,7 +89,7 @@ GLOBAL void TRILINOS_AMD_preprocess
     for (i = 0 ; i < n ; i++)
     {
 	W [i] = Rp [i] ;
-	Flag [i] = EMPTY ;
+	Flag [i] = TRILINOS_AMD_EMPTY ;
     }
 
     /* --------------------------------------------------------------------- */

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Source/trilinos_amd_l_valid.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Source/trilinos_amd_l_valid.c
@@ -72,7 +72,7 @@ GLOBAL Int TRILINOS_AMD_valid
 	    TRILINOS_AMD_DEBUG0 (("column "ID" pointer bad\n", j)) ;
 	    return (TRILINOS_AMD_INVALID) ;
 	}
-	ilast = EMPTY ;
+	ilast = TRILINOS_AMD_EMPTY ;
 	for (p = p1 ; p < p2 ; p++)
 	{
 	    i = Ai [p] ;

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Source/trilinos_amd_order.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Source/trilinos_amd_order.c
@@ -43,7 +43,7 @@ GLOBAL Int TRILINOS_AMD_order
     {
 	for (i = 0 ; i < TRILINOS_AMD_INFO ; i++)
 	{
-	    Info [i] = EMPTY ;
+	    Info [i] = TRILINOS_AMD_EMPTY ;
 	}
 	Info [TRILINOS_AMD_N] = n ;
 	Info [TRILINOS_AMD_STATUS] = TRILINOS_AMD_OK ;

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Source/trilinos_amd_post_tree.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Source/trilinos_amd_post_tree.c
@@ -44,7 +44,7 @@ GLOBAL Int TRILINOS_AMD_post_tree
 
     /* this is simple, but can caouse stack overflow if nn is large */
     i = root ;
-    for (f = Child [i] ; f != EMPTY ; f = Sibling [f])
+    for (f = Child [i] ; f != TRILINOS_AMD_EMPTY ; f = Sibling [f])
     {
 	k = TRILINOS_AMD_post_tree (f, k, Child, Sibling, Order, Stack, nn) ;
     }
@@ -68,13 +68,13 @@ GLOBAL Int TRILINOS_AMD_post_tree
 	TRILINOS_AMD_DEBUG1 (("head of stack "ID" \n", i)) ;
 	ASSERT (i >= 0 && i < nn) ;
 
-	if (Child [i] != EMPTY)
+	if (Child [i] != TRILINOS_AMD_EMPTY)
 	{
 	    /* the children of i are not yet ordered */
 	    /* push each child onto the stack in reverse order */
 	    /* so that small ones at the head of the list get popped first */
 	    /* and the biggest one at the end of the list gets popped last */
-	    for (f = Child [i] ; f != EMPTY ; f = Sibling [f])
+	    for (f = Child [i] ; f != TRILINOS_AMD_EMPTY ; f = Sibling [f])
 	    {
 		head++ ;
 		ASSERT (head < nn) ;
@@ -82,7 +82,7 @@ GLOBAL Int TRILINOS_AMD_post_tree
 	    }
 	    h = head ;
 	    ASSERT (head < nn) ;
-	    for (f = Child [i] ; f != EMPTY ; f = Sibling [f])
+	    for (f = Child [i] ; f != TRILINOS_AMD_EMPTY ; f = Sibling [f])
 	    {
 		ASSERT (h > 0) ;
 		Stack [h--] = f ;
@@ -92,7 +92,7 @@ GLOBAL Int TRILINOS_AMD_post_tree
 	    ASSERT (Stack [h] == i) ;
 
 	    /* delete child list so that i gets ordered next time we see it */
-	    Child [i] = EMPTY ;
+	    Child [i] = TRILINOS_AMD_EMPTY ;
 	}
 	else
 	{

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Source/trilinos_amd_postorder.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Source/trilinos_amd_postorder.c
@@ -17,7 +17,7 @@ GLOBAL void TRILINOS_AMD_postorder
 (
     /* inputs, not modified on output: */
     Int nn,		/* nodes are in the range 0..nn-1 */
-    Int Parent [ ],	/* Parent [j] is the parent of j, or EMPTY if root */
+    Int Parent [ ],	/* Parent [j] is the parent of j, or TRILINOS_AMD_EMPTY if root */
     Int Nv [ ],		/* Nv [j] > 0 number of pivots represented by node j,
 			 * or zero if j is not a node. */
     Int Fsize [ ],	/* Fsize [j]: size of node j */
@@ -35,8 +35,8 @@ GLOBAL void TRILINOS_AMD_postorder
 
     for (j = 0 ; j < nn ; j++)
     {
-	Child [j] = EMPTY ;
-	Sibling [j] = EMPTY ;
+	Child [j] = TRILINOS_AMD_EMPTY ;
+	Sibling [j] = TRILINOS_AMD_EMPTY ;
     }
 
     /* --------------------------------------------------------------------- */
@@ -49,7 +49,7 @@ GLOBAL void TRILINOS_AMD_postorder
 	{
 	    /* this is an element */
 	    parent = Parent [j] ;
-	    if (parent != EMPTY)
+	    if (parent != TRILINOS_AMD_EMPTY)
 	    {
 		/* place the element in link list of the children its parent */
 		/* bigger elements will tend to be at the end of the list */
@@ -75,7 +75,7 @@ GLOBAL void TRILINOS_AMD_postorder
 		/* dump the link list of children */
 		nchild = 0 ;
 		TRILINOS_AMD_DEBUG1 (("    Children: ")) ;
-		for (ff = Child [j] ; ff != EMPTY ; ff = Sibling [ff])
+		for (ff = Child [j] ; ff != TRILINOS_AMD_EMPTY ; ff = Sibling [ff])
 		{
 		    TRILINOS_AMD_DEBUG1 ((ID" ", ff)) ;
 		    ASSERT (Parent [ff] == j) ;
@@ -84,7 +84,7 @@ GLOBAL void TRILINOS_AMD_postorder
 		}
 		TRILINOS_AMD_DEBUG1 (("\n")) ;
 		parent = Parent [j] ;
-		if (parent != EMPTY)
+		if (parent != TRILINOS_AMD_EMPTY)
 		{
 		    ASSERT (Nv [parent] > 0) ;
 		}
@@ -102,14 +102,14 @@ GLOBAL void TRILINOS_AMD_postorder
 
     for (i = 0 ; i < nn ; i++)
     {
-	if (Nv [i] > 0 && Child [i] != EMPTY)
+	if (Nv [i] > 0 && Child [i] != TRILINOS_AMD_EMPTY)
 	{
 
 #ifndef NDEBUG
 	    Int nchild ;
 	    TRILINOS_AMD_DEBUG1 (("Before partial sort, element "ID"\n", i)) ;
 	    nchild = 0 ;
-	    for (f = Child [i] ; f != EMPTY ; f = Sibling [f])
+	    for (f = Child [i] ; f != TRILINOS_AMD_EMPTY ; f = Sibling [f])
 	    {
 		ASSERT (f >= 0 && f < nn) ;
 		TRILINOS_AMD_DEBUG1 (("      f: "ID"  size: "ID"\n", f, Fsize [f])) ;
@@ -119,11 +119,11 @@ GLOBAL void TRILINOS_AMD_postorder
 #endif
 
 	    /* find the biggest element in the child list */
-	    fprev = EMPTY ;
-	    maxfrsize = EMPTY ;
-	    bigfprev = EMPTY ;
-	    bigf = EMPTY ;
-	    for (f = Child [i] ; f != EMPTY ; f = Sibling [f])
+	    fprev = TRILINOS_AMD_EMPTY ;
+	    maxfrsize = TRILINOS_AMD_EMPTY ;
+	    bigfprev = TRILINOS_AMD_EMPTY ;
+	    bigf = TRILINOS_AMD_EMPTY ;
+	    for (f = Child [i] ; f != TRILINOS_AMD_EMPTY ; f = Sibling [f])
 	    {
 		ASSERT (f >= 0 && f < nn) ;
 		frsize = Fsize [f] ;
@@ -136,18 +136,18 @@ GLOBAL void TRILINOS_AMD_postorder
 		}
 		fprev = f ;
 	    }
-	    ASSERT (bigf != EMPTY) ;
+	    ASSERT (bigf != TRILINOS_AMD_EMPTY) ;
 
 	    fnext = Sibling [bigf] ;
 
 	    TRILINOS_AMD_DEBUG1 (("bigf "ID" maxfrsize "ID" bigfprev "ID" fnext "ID
 		" fprev " ID"\n", bigf, maxfrsize, bigfprev, fnext, fprev)) ;
 
-	    if (fnext != EMPTY)
+	    if (fnext != TRILINOS_AMD_EMPTY)
 	    {
-		/* if fnext is EMPTY then bigf is already at the end of list */
+		/* if fnext is TRILINOS_AMD_EMPTY then bigf is already at the end of list */
 
-		if (bigfprev == EMPTY)
+		if (bigfprev == TRILINOS_AMD_EMPTY)
 		{
 		    /* delete bigf from the element of the list */
 		    Child [i] = fnext ;
@@ -159,16 +159,16 @@ GLOBAL void TRILINOS_AMD_postorder
 		}
 
 		/* put bigf at the end of the list */
-		Sibling [bigf] = EMPTY ;
-		ASSERT (Child [i] != EMPTY) ;
+		Sibling [bigf] = TRILINOS_AMD_EMPTY ;
+		ASSERT (Child [i] != TRILINOS_AMD_EMPTY) ;
 		ASSERT (fprev != bigf) ;
-		ASSERT (fprev != EMPTY) ;
+		ASSERT (fprev != TRILINOS_AMD_EMPTY) ;
 		Sibling [fprev] = bigf ;
 	    }
 
 #ifndef NDEBUG
 	    TRILINOS_AMD_DEBUG1 (("After partial sort, element "ID"\n", i)) ;
-	    for (f = Child [i] ; f != EMPTY ; f = Sibling [f])
+	    for (f = Child [i] ; f != TRILINOS_AMD_EMPTY ; f = Sibling [f])
 	    {
 		ASSERT (f >= 0 && f < nn) ;
 		TRILINOS_AMD_DEBUG1 (("        "ID"  "ID"\n", f, Fsize [f])) ;
@@ -187,14 +187,14 @@ GLOBAL void TRILINOS_AMD_postorder
 
     for (i = 0 ; i < nn ; i++)
     {
-	Order [i] = EMPTY ;
+	Order [i] = TRILINOS_AMD_EMPTY ;
     }
 
     k = 0 ;
 
     for (i = 0 ; i < nn ; i++)
     {
-	if (Parent [i] == EMPTY && Nv [i] > 0)
+	if (Parent [i] == TRILINOS_AMD_EMPTY && Nv [i] > 0)
 	{
 	    TRILINOS_AMD_DEBUG1 (("Root of assembly tree "ID"\n", i)) ;
 	    k = TRILINOS_AMD_post_tree (i, k, Child, Sibling, Order, Stack

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Source/trilinos_amd_preprocess.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Source/trilinos_amd_preprocess.c
@@ -57,7 +57,7 @@ GLOBAL void TRILINOS_AMD_preprocess
     for (i = 0 ; i < n ; i++)
     {
 	W [i] = 0 ;		/* # of nonzeros in row i (excl duplicates) */
-	Flag [i] = EMPTY ;	/* Flag [i] = j if i appears in column j */
+	Flag [i] = TRILINOS_AMD_EMPTY ;	/* Flag [i] = j if i appears in column j */
     }
     for (j = 0 ; j < n ; j++)
     {
@@ -86,7 +86,7 @@ GLOBAL void TRILINOS_AMD_preprocess
     for (i = 0 ; i < n ; i++)
     {
 	W [i] = Rp [i] ;
-	Flag [i] = EMPTY ;
+	Flag [i] = TRILINOS_AMD_EMPTY ;
     }
 
     /* --------------------------------------------------------------------- */

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Source/trilinos_amd_valid.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Source/trilinos_amd_valid.c
@@ -69,7 +69,7 @@ GLOBAL Int TRILINOS_AMD_valid
 	    TRILINOS_AMD_DEBUG0 (("column "ID" pointer bad\n", j)) ;
 	    return (TRILINOS_AMD_INVALID) ;
 	}
-	ilast = EMPTY ;
+	ilast = TRILINOS_AMD_EMPTY ;
 	for (p = p1 ; p < p2 ; p++)
 	{
 	    i = Ai [p] ;

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/BTF/Include/trilinos_btf_internal.h
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/BTF/Include/trilinos_btf_internal.h
@@ -58,7 +58,7 @@
 
 #define TRUE 1
 #define FALSE 0
-#define EMPTY (-1)
+#define TRILINOS_BTF_EMPTY (-1)
 #define MIN(a,b) (((a) < (b)) ?  (a) : (b))
 
 #endif

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/BTF/Source/trilinos_btf_l_maxtrans.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/BTF/Source/trilinos_btf_l_maxtrans.c
@@ -168,7 +168,7 @@ static Int trilinos_augment
 
     /* start a DFS to find a match for column k */
     found = FALSE ;
-    i = EMPTY ;
+    i = TRILINOS_BTF_EMPTY ;
     head = 0 ;
     Jstack [0] = k ;
     ASSERT (Flag [k] != k) ;
@@ -193,7 +193,7 @@ static Int trilinos_augment
 	    for (p = Cheap [j] ; p < pend && !found ; p++)
 	    {
 		i = Ai [p] ;
-		found = (Match [i] == EMPTY) ;
+		found = (Match [i] == TRILINOS_BTF_EMPTY) ;
 	    }
 	    Cheap [j] = p ;
 
@@ -217,7 +217,7 @@ static Int trilinos_augment
 	if (quick && *work > maxwork)
 	{
 	    /* too much work has been performed; abort the search */
-	    return (EMPTY) ;
+	    return (TRILINOS_BTF_EMPTY) ;
 	}
 
 	/* ------------------------------------------------------------------ */
@@ -236,7 +236,7 @@ static Int trilinos_augment
 	{
 	    i = Ai [p] ;
 	    j2 = Match [i] ;
-	    ASSERT (j2 != EMPTY) ;
+	    ASSERT (j2 != TRILINOS_BTF_EMPTY) ;
 	    if (Flag [j2] != k)
 	    {
 		/* Node j2 is not yet visited, start a depth-first search on
@@ -335,13 +335,13 @@ Int TRILINOS_BTF(maxtrans)   /* returns # of columns in the matching */
     for (j = 0 ; j < ncol ; j++)
     {
 	Cheap [j] = Ap [j] ;
-	Flag [j] = EMPTY ; 
+	Flag [j] = TRILINOS_BTF_EMPTY ; 
     }
 
     /* all rows and columns are currently unmatched */
     for (i = 0 ; i < nrow ; i++)
     {
-	Match [i] = EMPTY ;
+	Match [i] = TRILINOS_BTF_EMPTY ;
     }
 
     if (maxwork > 0)
@@ -366,7 +366,7 @@ Int TRILINOS_BTF(maxtrans)   /* returns # of columns in the matching */
 	    /* we found it.  Match [i] = k for some row i has been done. */
 	    nmatch++ ;
 	}
-	else if (result == EMPTY)
+	else if (result == TRILINOS_BTF_EMPTY)
 	{
 	    /* augment gave up because of too much work, and no match found */
 	    work_limit_reached = TRUE ;
@@ -378,12 +378,12 @@ Int TRILINOS_BTF(maxtrans)   /* returns # of columns in the matching */
     /* ---------------------------------------------------------------------- */
 
     /* At this point, row i is matched to j = Match [i] if j >= 0.  i is an
-     * unmatched row if Match [i] == EMPTY. */
+     * unmatched row if Match [i] == TRILINOS_BTF_EMPTY. */
 
     if (work_limit_reached)
     {
 	/* return -1 if the work limit of maxwork*nnz(A) was reached */
-	*work = EMPTY ;
+	*work = TRILINOS_BTF_EMPTY ;
     }
 
     return (nmatch) ;

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/BTF/Source/trilinos_btf_l_order.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/BTF/Source/trilinos_btf_l_order.c
@@ -88,7 +88,7 @@ Int TRILINOS_BTF(order)	    /* returns number of blocks found */
 	for (i = 0 ; i < n ; i++)
 	{
 	    j = Q [i] ;
-	    if (j != EMPTY)
+	    if (j != TRILINOS_BTF_EMPTY)
 	    {
 		/* row i and column j are matched to each other */
 		Flag [j] = 1 ;
@@ -110,7 +110,7 @@ Int TRILINOS_BTF(order)	    /* returns number of blocks found */
 	/* make an assignment for each unmatched row */
 	for (i = 0 ; i < n ; i++)
 	{
-	    if (Q [i] == EMPTY && nbadcol > 0)
+	    if (Q [i] == TRILINOS_BTF_EMPTY && nbadcol > 0)
 	    {
 		/* get an unmatched column j */
 		j = Work [--nbadcol] ;

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/BTF/Source/trilinos_btf_l_strongcomp.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/BTF/Source/trilinos_btf_l_strongcomp.c
@@ -102,7 +102,7 @@ static void trilinos_dfs
     Int timestamp = *p_timestamp ;
 
     /* ---------------------------------------------------------------------- */
-    /* start a DFS at node j (same as the recursive call dfs (EMPTY, j)) */
+    /* start a DFS at node j (same as the recursive call dfs (TRILINOS_BTF_EMPTY, j)) */
     /* ---------------------------------------------------------------------- */
 
     chead = 0 ;		    /* component stack is empty */
@@ -155,8 +155,8 @@ static void trilinos_dfs
 		/* Push i onto the stack and immediately break
 		 * so we can recurse on node i. */
 		Jstack [++jhead] = i ;
-		ASSERT (Time [i] == EMPTY) ;
-		ASSERT (Low [i] == EMPTY) ;
+		ASSERT (Time [i] == TRILINOS_BTF_EMPTY) ;
+		ASSERT (Low [i] == TRILINOS_BTF_EMPTY) ;
 		/* break here to do what the recursive call dfs (j,i) does */
 		break ;
 	    }
@@ -305,7 +305,7 @@ static void trilinos_dfs
 	nblocks++ ;	/* one more block has been found */
     }
     /* update Low [parent] */
-    if (parent != EMPTY)
+    if (parent != TRILINOS_BTF_EMPTY)
     {
 	/* Note that this could be done with Low[j] = MIN(Low[j],Low[i]) just
 	 * after the dfs (j,i) statement above, and then parent would not have
@@ -374,7 +374,7 @@ Int TRILINOS_BTF(strongcomp) /* recursive version - same as above except for Wor
     Q = Q_in ;
     P = P_in ;
     R = R_in ;
-    chead = EMPTY ;
+    chead = TRILINOS_BTF_EMPTY ;
 #endif
 
     /* ---------------------------------------------------------------------- */
@@ -418,13 +418,13 @@ Int TRILINOS_BTF(strongcomp) /* recursive version - same as above except for Wor
     for (j = 0 ; j < n ; j++)
     {
 	Flag [j] = UNVISITED ;
-	Low [j] = EMPTY ;
-	Time [j] = EMPTY ;
+	Low [j] = TRILINOS_BTF_EMPTY ;
+	Time [j] = TRILINOS_BTF_EMPTY ;
 #ifndef NDEBUG
-	Cstack [j] = EMPTY ;
+	Cstack [j] = TRILINOS_BTF_EMPTY ;
 #ifndef RECURSIVE
-	Jstack [j] = EMPTY ;
-	Pstack [j] = EMPTY ;
+	Jstack [j] = TRILINOS_BTF_EMPTY ;
+	Pstack [j] = TRILINOS_BTF_EMPTY ;
 #endif
 #endif
     }
@@ -448,9 +448,9 @@ Int TRILINOS_BTF(strongcomp) /* recursive version - same as above except for Wor
 		    Cstack, Jstack, Pstack) ;
 #else
 	    /* recursive dfs (for illustration only) */
-	    ASSERT (chead == EMPTY) ;
-	    trilinos_dfs (EMPTY, j) ;
-	    ASSERT (chead == EMPTY) ;
+	    ASSERT (chead == TRILINOS_BTF_EMPTY) ;
+	    trilinos_dfs (TRILINOS_BTF_EMPTY, j) ;
+	    ASSERT (chead == TRILINOS_BTF_EMPTY) ;
 #endif
 	}
     }
@@ -492,7 +492,7 @@ Int TRILINOS_BTF(strongcomp) /* recursive version - same as above except for Wor
 #ifndef NDEBUG
     for (k = 0 ; k < n ; k++)
     {
-	P [k] = EMPTY ;
+	P [k] = TRILINOS_BTF_EMPTY ;
     }
 #endif
 
@@ -505,7 +505,7 @@ Int TRILINOS_BTF(strongcomp) /* recursive version - same as above except for Wor
 #ifndef NDEBUG
     for (k = 0 ; k < n ; k++)
     {
-	ASSERT (P [k] != EMPTY) ;
+	ASSERT (P [k] != TRILINOS_BTF_EMPTY) ;
     }
 #endif
 

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/BTF/Source/trilinos_btf_maxtrans.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/BTF/Source/trilinos_btf_maxtrans.c
@@ -165,7 +165,7 @@ static Int trilinos_augment
 
     /* start a DFS to find a match for column k */
     found = FALSE ;
-    i = EMPTY ;
+    i = TRILINOS_BTF_EMPTY ;
     head = 0 ;
     Jstack [0] = k ;
     ASSERT (Flag [k] != k) ;
@@ -190,7 +190,7 @@ static Int trilinos_augment
 	    for (p = Cheap [j] ; p < pend && !found ; p++)
 	    {
 		i = Ai [p] ;
-		found = (Match [i] == EMPTY) ;
+		found = (Match [i] == TRILINOS_BTF_EMPTY) ;
 	    }
 	    Cheap [j] = p ;
 
@@ -214,7 +214,7 @@ static Int trilinos_augment
 	if (quick && *work > maxwork)
 	{
 	    /* too much work has been performed; abort the search */
-	    return (EMPTY) ;
+	    return (TRILINOS_BTF_EMPTY) ;
 	}
 
 	/* ------------------------------------------------------------------ */
@@ -233,7 +233,7 @@ static Int trilinos_augment
 	{
 	    i = Ai [p] ;
 	    j2 = Match [i] ;
-	    ASSERT (j2 != EMPTY) ;
+	    ASSERT (j2 != TRILINOS_BTF_EMPTY) ;
 	    if (Flag [j2] != k)
 	    {
 		/* Node j2 is not yet visited, start a depth-first search on
@@ -332,13 +332,13 @@ Int TRILINOS_BTF(maxtrans)   /* returns # of columns in the matching */
     for (j = 0 ; j < ncol ; j++)
     {
 	Cheap [j] = Ap [j] ;
-	Flag [j] = EMPTY ; 
+	Flag [j] = TRILINOS_BTF_EMPTY ; 
     }
 
     /* all rows and columns are currently unmatched */
     for (i = 0 ; i < nrow ; i++)
     {
-	Match [i] = EMPTY ;
+	Match [i] = TRILINOS_BTF_EMPTY ;
     }
 
     if (maxwork > 0)
@@ -363,7 +363,7 @@ Int TRILINOS_BTF(maxtrans)   /* returns # of columns in the matching */
 	    /* we found it.  Match [i] = k for some row i has been done. */
 	    nmatch++ ;
 	}
-	else if (result == EMPTY)
+	else if (result == TRILINOS_BTF_EMPTY)
 	{
 	    /* augment gave up because of too much work, and no match found */
 	    work_limit_reached = TRUE ;
@@ -375,12 +375,12 @@ Int TRILINOS_BTF(maxtrans)   /* returns # of columns in the matching */
     /* ---------------------------------------------------------------------- */
 
     /* At this point, row i is matched to j = Match [i] if j >= 0.  i is an
-     * unmatched row if Match [i] == EMPTY. */
+     * unmatched row if Match [i] == TRILINOS_BTF_EMPTY. */
 
     if (work_limit_reached)
     {
 	/* return -1 if the work limit of maxwork*nnz(A) was reached */
-	*work = EMPTY ;
+	*work = TRILINOS_BTF_EMPTY ;
     }
 
     return (nmatch) ;

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/BTF/Source/trilinos_btf_order.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/BTF/Source/trilinos_btf_order.c
@@ -85,7 +85,7 @@ Int TRILINOS_BTF(order)	    /* returns number of blocks found */
 	for (i = 0 ; i < n ; i++)
 	{
 	    j = Q [i] ;
-	    if (j != EMPTY)
+	    if (j != TRILINOS_BTF_EMPTY)
 	    {
 		/* row i and column j are matched to each other */
 		Flag [j] = 1 ;
@@ -107,7 +107,7 @@ Int TRILINOS_BTF(order)	    /* returns number of blocks found */
 	/* make an assignment for each unmatched row */
 	for (i = 0 ; i < n ; i++)
 	{
-	    if (Q [i] == EMPTY && nbadcol > 0)
+	    if (Q [i] == TRILINOS_BTF_EMPTY && nbadcol > 0)
 	    {
 		/* get an unmatched column j */
 		j = Work [--nbadcol] ;

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/BTF/Source/trilinos_btf_strongcomp.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/BTF/Source/trilinos_btf_strongcomp.c
@@ -99,7 +99,7 @@ static void trilinos_dfs
     Int timestamp = *p_timestamp ;
 
     /* ---------------------------------------------------------------------- */
-    /* start a DFS at node j (same as the recursive call dfs (EMPTY, j)) */
+    /* start a DFS at node j (same as the recursive call dfs (TRILINOS_BTF_EMPTY, j)) */
     /* ---------------------------------------------------------------------- */
 
     chead = 0 ;		    /* component stack is empty */
@@ -152,8 +152,8 @@ static void trilinos_dfs
 		/* Push i onto the stack and immediately break
 		 * so we can recurse on node i. */
 		Jstack [++jhead] = i ;
-		ASSERT (Time [i] == EMPTY) ;
-		ASSERT (Low [i] == EMPTY) ;
+		ASSERT (Time [i] == TRILINOS_BTF_EMPTY) ;
+		ASSERT (Low [i] == TRILINOS_BTF_EMPTY) ;
 		/* break here to do what the recursive call dfs (j,i) does */
 		break ;
 	    }
@@ -302,7 +302,7 @@ static void trilinos_dfs
 	nblocks++ ;	/* one more block has been found */
     }
     /* update Low [parent] */
-    if (parent != EMPTY)
+    if (parent != TRILINOS_BTF_EMPTY)
     {
 	/* Note that this could be done with Low[j] = MIN(Low[j],Low[i]) just
 	 * after the dfs (j,i) statement above, and then parent would not have
@@ -371,7 +371,7 @@ Int TRILINOS_BTF(strongcomp) /* recursive version - same as above except for Wor
     Q = Q_in ;
     P = P_in ;
     R = R_in ;
-    chead = EMPTY ;
+    chead = TRILINOS_BTF_EMPTY ;
 #endif
 
     /* ---------------------------------------------------------------------- */
@@ -415,13 +415,13 @@ Int TRILINOS_BTF(strongcomp) /* recursive version - same as above except for Wor
     for (j = 0 ; j < n ; j++)
     {
 	Flag [j] = UNVISITED ;
-	Low [j] = EMPTY ;
-	Time [j] = EMPTY ;
+	Low [j] = TRILINOS_BTF_EMPTY ;
+	Time [j] = TRILINOS_BTF_EMPTY ;
 #ifndef NDEBUG
-	Cstack [j] = EMPTY ;
+	Cstack [j] = TRILINOS_BTF_EMPTY ;
 #ifndef RECURSIVE
-	Jstack [j] = EMPTY ;
-	Pstack [j] = EMPTY ;
+	Jstack [j] = TRILINOS_BTF_EMPTY ;
+	Pstack [j] = TRILINOS_BTF_EMPTY ;
 #endif
 #endif
     }
@@ -445,9 +445,9 @@ Int TRILINOS_BTF(strongcomp) /* recursive version - same as above except for Wor
 		    Cstack, Jstack, Pstack) ;
 #else
 	    /* recursive dfs (for illustration only) */
-	    ASSERT (chead == EMPTY) ;
-	    trilinos_dfs (EMPTY, j) ;
-	    ASSERT (chead == EMPTY) ;
+	    ASSERT (chead == TRILINOS_BTF_EMPTY) ;
+	    trilinos_dfs (TRILINOS_BTF_EMPTY, j) ;
+	    ASSERT (chead == TRILINOS_BTF_EMPTY) ;
 #endif
 	}
     }
@@ -489,7 +489,7 @@ Int TRILINOS_BTF(strongcomp) /* recursive version - same as above except for Wor
 #ifndef NDEBUG
     for (k = 0 ; k < n ; k++)
     {
-	P [k] = EMPTY ;
+	P [k] = TRILINOS_BTF_EMPTY ;
     }
 #endif
 
@@ -502,7 +502,7 @@ Int TRILINOS_BTF(strongcomp) /* recursive version - same as above except for Wor
 #ifndef NDEBUG
     for (k = 0 ; k < n ; k++)
     {
-	ASSERT (P [k] != EMPTY) ;
+	ASSERT (P [k] != TRILINOS_BTF_EMPTY) ;
     }
 #endif
 

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CAMD/Include/trilinos_camd_internal.h
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CAMD/Include/trilinos_camd_internal.h
@@ -102,8 +102,8 @@
 #undef MIN
 #endif
 
-#ifdef EMPTY
-#undef EMPTY
+#ifdef TRILINOS_CAMD_EMPTY
+#undef TRILINOS_CAMD_EMPTY
 #endif
 
 #ifdef GLOBAL
@@ -115,12 +115,12 @@
 #endif
 
 /* FLIP is a "negation about -1", and is used to mark an integer i that is
- * normally non-negative.  FLIP (EMPTY) is EMPTY.  FLIP of a number > EMPTY
+ * normally non-negative.  FLIP (TRILINOS_CAMD_EMPTY) is TRILINOS_CAMD_EMPTY.  FLIP of a number > TRILINOS_CAMD_EMPTY
  * is negative, and FLIP of a number < EMTPY is positive.  FLIP (FLIP (i)) = i
- * for all integers i.  UNFLIP (i) is >= EMPTY. */
-#define EMPTY (-1)
+ * for all integers i.  UNFLIP (i) is >= TRILINOS_CAMD_EMPTY. */
+#define TRILINOS_CAMD_EMPTY (-1)
 #define FLIP(i) (-(i)-2)
-#define UNFLIP(i) ((i < EMPTY) ? FLIP (i) : (i))
+#define UNFLIP(i) ((i < TRILINOS_CAMD_EMPTY) ? FLIP (i) : (i))
 
 /* for integer MAX/MIN, or for doubles when we don't care how NaN's behave: */
 #define MAX(a,b) (((a) > (b)) ? (a) : (b))
@@ -142,7 +142,7 @@
 #define FALSE (0)
 #define PRIVATE static
 #define GLOBAL
-#define EMPTY (-1)
+#define TRILINOS_CAMD_EMPTY (-1)
 
 /* Note that Linux's gcc 2.96 defines NULL as ((void *) 0), but other */
 /* compilers (even gcc 2.95.2 on Solaris) define NULL as 0 or (0).  We */

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CAMD/Source/trilinos_camd_1.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CAMD/Source/trilinos_camd_1.c
@@ -84,7 +84,7 @@ GLOBAL void TRILINOS_CAMD_1
     ASSERT (iwlen >= pfree + n) ;
 
 #ifndef NDEBUG
-    for (p = 0 ; p < iwlen ; p++) Iw [p] = EMPTY ;
+    for (p = 0 ; p < iwlen ; p++) Iw [p] = TRILINOS_CAMD_EMPTY ;
 #endif
 
     for (k = 0 ; k < n ; k++)

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CAMD/Source/trilinos_camd_2.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CAMD/Source/trilinos_camd_2.c
@@ -278,7 +278,7 @@ GLOBAL void TRILINOS_CAMD_2
  *	    as (-(j)-2).  Row j has the same pattern as row i.  Note that j
  *	    might later be absorbed into another supervariable j2, in which
  *	    case Pe [i] is still FLIP (j), and Pe [j] = FLIP (j2) which is
- *	    < EMPTY, where EMPTY is defined as (-1) in camd_internal.h.
+ *	    < TRILINOS_CAMD_EMPTY, where TRILINOS_CAMD_EMPTY is defined as (-1) in camd_internal.h.
  *
  *	Unabsorbed element e:  the index into Iw of the description of element
  *	    e, if e has not yet been absorbed by a subsequent element.  Element
@@ -288,8 +288,8 @@ GLOBAL void TRILINOS_CAMD_2
  *	Absorbed element e:  if element e is absorbed into element e2, then
  *	    Pe [e] = FLIP (e2).  This occurs when the pattern of e (which we
  *	    refer to as Le) is found to be a subset of the pattern of e2 (that
- *	    is, Le2).  In this case, Pe [i] < EMPTY.  If element e is "null"
- *	    (it has no nonzeros outside its pivot block), then Pe [e] = EMPTY,
+ *	    is, Le2).  In this case, Pe [i] < TRILINOS_CAMD_EMPTY.  If element e is "null"
+ *	    (it has no nonzeros outside its pivot block), then Pe [e] = TRILINOS_CAMD_EMPTY,
  *	    and e is the root of an assembly subtree (or the whole tree if
  *	    there is just one such root).
  *
@@ -300,7 +300,7 @@ GLOBAL void TRILINOS_CAMD_2
  *	represents a pivot order with identical fill-in as the actual order
  *	(via a depth-first search of the tree), as follows.  If Nv [i] > 0,
  *	then i represents a node in the assembly tree, and the parent of i is
- *	Pe [i], or EMPTY if i is a root.  If Nv [i] = 0, then (i, Pe [i])
+ *	Pe [i], or TRILINOS_CAMD_EMPTY if i is a root.  If Nv [i] = 0, then (i, Pe [i])
  *	represents an edge in a subtree, the root of which is a node in the
  *	assembly tree.  Note that i refers to a row/column in the original
  *	matrix, not the permuted matrix.
@@ -390,16 +390,16 @@ GLOBAL void TRILINOS_CAMD_2
  *	execution, Elen [i] is the number of elements in the list for
  *	supervariable i.  When e becomes an element, Elen [e] = FLIP (esize) is
  *	set, where esize is the size of the element (the number of pivots, plus
- *	the number of nonpivotal entries).  Thus Elen [e] < EMPTY.
- *	Elen (i) = EMPTY set when variable i becomes nonprincipal.
+ *	the number of nonpivotal entries).  Thus Elen [e] < TRILINOS_CAMD_EMPTY.
+ *	Elen (i) = TRILINOS_CAMD_EMPTY set when variable i becomes nonprincipal.
  *
- *	For variables, Elen (i) >= EMPTY holds until just before the
+ *	For variables, Elen (i) >= TRILINOS_CAMD_EMPTY holds until just before the
  *	postordering and permutation vectors are computed.  For elements,
- *	Elen [e] < EMPTY holds.
+ *	Elen [e] < TRILINOS_CAMD_EMPTY holds.
  *
  *	On output, Elen [i] is the degree of the row/column in the Cholesky
  *	factorization of the permuted matrix, corresponding to the original row
- *	i, if i is a super row/column.  It is equal to EMPTY if i is
+ *	i, if i is a super row/column.  It is equal to TRILINOS_CAMD_EMPTY if i is
  *	non-principal.  Note that i refers to a row/column in the original
  *	matrix, not the permuted matrix.
  *
@@ -408,7 +408,7 @@ GLOBAL void TRILINOS_CAMD_2
  *	which is instead returned in the Next array in this C version,
  *	described below).
  *
- * Last: In a degree list, Last [i] is the supervariable preceding i, or EMPTY
+ * Last: In a degree list, Last [i] is the supervariable preceding i, or TRILINOS_CAMD_EMPTY
  *	if i is the head of the list.  In a hash bucket, Last [i] is the hash
  *	key for i.
  *
@@ -420,7 +420,7 @@ GLOBAL void TRILINOS_CAMD_2
  *	i = Last [k], then row i is the kth pivot row (where k ranges from 0 to
  *	n-1).  Row Last [k] of A is the kth row in the permuted matrix, PAP'.
  *
- * Next: Next [i] is the supervariable following i in a link list, or EMPTY if
+ * Next: Next [i] is the supervariable following i in a link list, or TRILINOS_CAMD_EMPTY if
  *	i is the last in the list.  Used for two kinds of lists:  degree lists
  *	and hash buckets (a supervariable can be in only one kind of list at a
  *	time).
@@ -451,16 +451,16 @@ GLOBAL void TRILINOS_CAMD_2
  *	Head [deg] is the first supervariable in a degree list.  All
  *	supervariables i in a degree list Head [deg] have the same approximate
  *	degree, namely, deg = Degree [i].  If the list Head [deg] is empty then
- *	Head [deg] = EMPTY.
+ *	Head [deg] = TRILINOS_CAMD_EMPTY.
  *
  *	During supervariable detection Head [hash] also serves as a pointer to
  *	a hash bucket.  If Head [hash] >= 0, there is a degree list of degree
  *	hash.  The hash bucket head pointer is Last [Head [hash]].  If
- *	Head [hash] = EMPTY, then the degree list and hash bucket are both
- *	empty.  If Head [hash] < EMPTY, then the degree list is empty, and
+ *	Head [hash] = TRILINOS_CAMD_EMPTY, then the degree list and hash bucket are both
+ *	empty.  If Head [hash] < TRILINOS_CAMD_EMPTY, then the degree list is empty, and
  *	FLIP (Head [hash]) is the head of the hash bucket.  After supervariable
  *	detection is complete, all hash buckets are empty, and the
- *	(Last [Head [hash]] = EMPTY) condition is restored for the non-empty
+ *	(Last [Head [hash]] = TRILINOS_CAMD_EMPTY) condition is restored for the non-empty
  *	degree lists.
  *
  *      Head also workes as a temporary workspace in post ordering with dense
@@ -631,7 +631,7 @@ GLOBAL void TRILINOS_CAMD_2
     nms_lu = 0 ;
     nms_ldl = 0 ;
     dmax = 1 ;
-    me = EMPTY ;
+    me = TRILINOS_CAMD_EMPTY ;
 
     mindeg = 0 ;
     ncmpa = 0 ;
@@ -734,18 +734,18 @@ GLOBAL void TRILINOS_CAMD_2
 
     for (i = 0 ; i < n ; i++)
     {
-	Last [i] = EMPTY ;
-	Head [i] = EMPTY ;
-	Next [i] = EMPTY ;
+	Last [i] = TRILINOS_CAMD_EMPTY ;
+	Head [i] = TRILINOS_CAMD_EMPTY ;
+	Next [i] = TRILINOS_CAMD_EMPTY ;
 	/* if separate Hhead array is used for hash buckets: *
-	Hhead [i] = EMPTY ;
+	Hhead [i] = TRILINOS_CAMD_EMPTY ;
 	*/
 	Nv [i] = 1 ;
 	W [i] = 1 ;
 	Elen [i] = 0 ;
 	Degree [i] = Len [i] ;
     }
-    Head [n] = EMPTY ;
+    Head [n] = TRILINOS_CAMD_EMPTY ;
 
     /* initialize wflg */
     wbig = Int_MAX - n ;
@@ -787,7 +787,7 @@ GLOBAL void TRILINOS_CAMD_2
 	    }
 	    Pe [i] = FLIP (n) ;
 	    Nv [i] = 0 ;		/* do not postorder this node */
-	    Elen [i] = EMPTY ;
+	    Elen [i] = TRILINOS_CAMD_EMPTY ;
 	    nel++ ;
 	}
     }
@@ -829,12 +829,12 @@ GLOBAL void TRILINOS_CAMD_2
 		     * ------------------------------------------------------ */
 
 		    inext = Head [deg] ;
-		    ASSERT (inext >= EMPTY && inext < n) ;
-		    if (inext != EMPTY) Last [inext] = i ;
+		    ASSERT (inext >= TRILINOS_CAMD_EMPTY && inext < n) ;
+		    if (inext != TRILINOS_CAMD_EMPTY) Last [inext] = i ;
 		    Next [i] = inext ;
 		    Head [deg] = i ;
 		    degreeListCounter++ ;
-		    Last [i] = EMPTY ;
+		    Last [i] = TRILINOS_CAMD_EMPTY ;
 		    mindeg = MIN (mindeg, deg) ;
 		}
 	    }
@@ -861,7 +861,7 @@ GLOBAL void TRILINOS_CAMD_2
 	for (deg = mindeg ; deg < n ; deg++)
 	{
 	    me = Head [deg] ;
-	    if (me != EMPTY) break ;
+	    if (me != TRILINOS_CAMD_EMPTY) break ;
 	}
 	mindeg = deg ;
 	ASSERT (me >= 0 && me < n) ;
@@ -872,8 +872,8 @@ GLOBAL void TRILINOS_CAMD_2
 	/* ----------------------------------------------------------------- */
 
 	inext = Next [me] ;
-	ASSERT (inext >= EMPTY && inext < n) ;
-	if (inext != EMPTY) Last [inext] = EMPTY ;
+	ASSERT (inext >= TRILINOS_CAMD_EMPTY && inext < n) ;
+	if (inext != TRILINOS_CAMD_EMPTY) Last [inext] = TRILINOS_CAMD_EMPTY ;
 	Head [deg] = inext ;
 	degreeListCounter-- ;
 
@@ -941,10 +941,10 @@ GLOBAL void TRILINOS_CAMD_2
 		    {
 			ilast = Last [i] ;
 			inext = Next [i] ;
-			ASSERT (ilast >= EMPTY && ilast < n) ;
-			ASSERT (inext >= EMPTY && inext < n) ;
-			if (inext != EMPTY) Last [inext] = ilast ;
-			if (ilast != EMPTY)
+			ASSERT (ilast >= TRILINOS_CAMD_EMPTY && ilast < n) ;
+			ASSERT (inext >= TRILINOS_CAMD_EMPTY && inext < n) ;
+			if (inext != TRILINOS_CAMD_EMPTY) Last [inext] = ilast ;
+			if (ilast != TRILINOS_CAMD_EMPTY)
 			{
 			    Next [ilast] = inext ;
 			}
@@ -989,7 +989,7 @@ GLOBAL void TRILINOS_CAMD_2
 		    pj = Pe [e] ;
 		    ln = Len [e] ;
 		    TRILINOS_CAMD_DEBUG2 (("Search element e "ID" in me "ID"\n", e,me)) ;
-		    ASSERT (Elen [e] < EMPTY && W [e] > 0 && pj >= 0) ;
+		    ASSERT (Elen [e] < TRILINOS_CAMD_EMPTY && W [e] > 0 && pj >= 0) ;
 		}
 		ASSERT (ln >= 0 && (ln == 0 || (pj >= 0 && pj < iwlen))) ;
 
@@ -1003,7 +1003,7 @@ GLOBAL void TRILINOS_CAMD_2
 		for (knt2 = 1 ; knt2 <= ln ; knt2++)
 		{
 		    i = Iw [pj++] ;
-		    ASSERT (i >= 0 && i < n && (i == me || Elen [i] >= EMPTY));
+		    ASSERT (i >= 0 && i < n && (i == me || Elen [i] >= TRILINOS_CAMD_EMPTY));
 		    nvi = Nv [i] ;
 		    TRILINOS_CAMD_DEBUG2 ((": "ID" "ID" "ID" "ID"\n",
 				i, Elen [i], Nv [i], wflg)) ;
@@ -1028,11 +1028,11 @@ GLOBAL void TRILINOS_CAMD_2
 			    Pe [me] = p ;
 			    Len [me] -= knt1 ;
 			    /* check if nothing left of supervariable me */
-			    if (Len [me] == 0) Pe [me] = EMPTY ;
+			    if (Len [me] == 0) Pe [me] = TRILINOS_CAMD_EMPTY ;
 			    Pe [e] = pj ;
 			    Len [e] = ln - knt2 ;
 			    /* nothing left of element e */
-			    if (Len [e] == 0) Pe [e] = EMPTY ;
+			    if (Len [e] == 0) Pe [e] = TRILINOS_CAMD_EMPTY ;
 
 			    ncmpa++ ;	/* one more garbage collection */
 
@@ -1104,10 +1104,10 @@ GLOBAL void TRILINOS_CAMD_2
 			{
 			    ilast = Last [i] ;
 			    inext = Next [i] ;
-			    ASSERT (ilast >= EMPTY && ilast < n) ;
-			    ASSERT (inext >= EMPTY && inext < n) ;
-			    if (inext != EMPTY) Last [inext] = ilast ;
-			    if (ilast != EMPTY)
+			    ASSERT (ilast >= TRILINOS_CAMD_EMPTY && ilast < n) ;
+			    ASSERT (inext >= TRILINOS_CAMD_EMPTY && inext < n) ;
+			    if (inext != TRILINOS_CAMD_EMPTY) Last [inext] = ilast ;
+			    if (ilast != TRILINOS_CAMD_EMPTY)
 			    {
 				Next [ilast] = inext ;
 			    }
@@ -1138,7 +1138,7 @@ GLOBAL void TRILINOS_CAMD_2
 		    {
 			/* make element a root; kill it if not in same bucket */
 			TRILINOS_CAMD_DEBUG1 (("2 Element "ID" => "ID"\n", e, me)) ;
-			Pe [e] = EMPTY ;
+			Pe [e] = TRILINOS_CAMD_EMPTY ;
 			W [e] = 0 ;
 		    }
 		}
@@ -1299,7 +1299,7 @@ GLOBAL void TRILINOS_CAMD_2
 				TRILINOS_CAMD_DEBUG1 (("2 Element "ID" =>"ID" (aggr)\n",
 					e, me)) ;
 				ASSERT (dext == 0) ;
-				Pe [e] = EMPTY ;
+				Pe [e] = TRILINOS_CAMD_EMPTY ;
 				W [e] = 0 ;
 			    }
 			}
@@ -1397,7 +1397,7 @@ GLOBAL void TRILINOS_CAMD_2
 		nvpiv += nvi ;
 		nel += nvi ;
 		Nv [i] = 0 ;
-		Elen [i] = EMPTY ;
+		Elen [i] = TRILINOS_CAMD_EMPTY ;
 
 	    }
 	    else
@@ -1438,7 +1438,7 @@ GLOBAL void TRILINOS_CAMD_2
 
 		/* if the Hhead array is not used: */
 		j = Head [hash] ;
-		if (j <= EMPTY)
+		if (j <= TRILINOS_CAMD_EMPTY)
 		{
 		    /* degree list is empty, hash head is FLIP (j) */
 		    Next [i] = FLIP (j) ;
@@ -1502,33 +1502,33 @@ GLOBAL void TRILINOS_CAMD_2
 
 		/* if Hhead array is not used: */
 		j = Head [hash] ;
-		if (j == EMPTY)
+		if (j == TRILINOS_CAMD_EMPTY)
 		{
 		    /* hash bucket and degree list are both empty */
-		    i = EMPTY ;
+		    i = TRILINOS_CAMD_EMPTY ;
 		}
-		else if (j < EMPTY)
+		else if (j < TRILINOS_CAMD_EMPTY)
 		{
 		    /* degree list is empty */
 		    i = FLIP (j) ;
-		    Head [hash] = EMPTY ;
+		    Head [hash] = TRILINOS_CAMD_EMPTY ;
 		}
 		else
 		{
 		    /* degree list is not empty, restore Last [j] of head j */
 		    i = Last [j] ;
-		    Last [j] = EMPTY ;
+		    Last [j] = TRILINOS_CAMD_EMPTY ;
 		}
 
 		/* if separate Hhead array is used: *
 		i = Hhead [hash] ;
-		Hhead [hash] = EMPTY ;
+		Hhead [hash] = TRILINOS_CAMD_EMPTY ;
 		*/
 
-		ASSERT (i >= EMPTY && i < n) ;
+		ASSERT (i >= TRILINOS_CAMD_EMPTY && i < n) ;
 		TRILINOS_CAMD_DEBUG2 (("----i "ID" hash "ID"\n", i, hash)) ;
 
-		while (i != EMPTY && Next [i] != EMPTY)
+		while (i != TRILINOS_CAMD_EMPTY && Next [i] != TRILINOS_CAMD_EMPTY)
 		{
 
 		    /* -----------------------------------------------------
@@ -1554,9 +1554,9 @@ GLOBAL void TRILINOS_CAMD_2
 
 		    jlast = i ;
 		    j = Next [i] ;
-		    ASSERT (j >= EMPTY && j < n) ;
+		    ASSERT (j >= TRILINOS_CAMD_EMPTY && j < n) ;
 
-		    while (j != EMPTY)
+		    while (j != TRILINOS_CAMD_EMPTY)
 		    {
 			/* ------------------------------------------------- */
 			/* check if j and i have identical nonzero pattern */
@@ -1590,7 +1590,7 @@ GLOBAL void TRILINOS_CAMD_2
 			    /* are the number of variables in i and j: */
 			    Nv [i] += Nv [j] ;
 			    Nv [j] = 0 ;
-			    Elen [j] = EMPTY ;
+			    Elen [j] = TRILINOS_CAMD_EMPTY ;
 			    /* delete j from hash bucket */
 			    ASSERT (j != Next [j]) ;
 			    j = Next [j] ;
@@ -1604,7 +1604,7 @@ GLOBAL void TRILINOS_CAMD_2
 			    ASSERT (j != Next [j]) ;
 			    j = Next [j] ;
 			}
-			ASSERT (j >= EMPTY && j < n) ;
+			ASSERT (j >= TRILINOS_CAMD_EMPTY && j < n) ;
 		    }
 
 		    /* -----------------------------------------------------
@@ -1614,7 +1614,7 @@ GLOBAL void TRILINOS_CAMD_2
 
 		    wflg++ ;
 		    i = Next [i] ;
-		    ASSERT (i >= EMPTY && i < n) ;
+		    ASSERT (i >= TRILINOS_CAMD_EMPTY && i < n) ;
 
 		}
 	    }
@@ -1654,10 +1654,10 @@ GLOBAL void TRILINOS_CAMD_2
 		if (IsInCurrentSet (C, i, curC))
 		{
 		    inext = Head [deg] ;
-		    ASSERT (inext >= EMPTY && inext < n) ;
-		    if (inext != EMPTY) Last [inext] = i ;
+		    ASSERT (inext >= TRILINOS_CAMD_EMPTY && inext < n) ;
+		    if (inext != TRILINOS_CAMD_EMPTY) Last [inext] = i ;
 		    Next [i] = inext ;
-		    Last [i] = EMPTY ;
+		    Last [i] = TRILINOS_CAMD_EMPTY ;
 		    Head [deg] = i ;
 		    degreeListCounter++ ;
 		}
@@ -1690,7 +1690,7 @@ GLOBAL void TRILINOS_CAMD_2
 	{
 	    /* there is nothing left of the current pivot element */
 	    /* it is a root of the assembly tree */
-	    Pe [me] = EMPTY ;
+	    Pe [me] = TRILINOS_CAMD_EMPTY ;
 	    W [me] = 0 ;
 	}
 	if (elenme != 0)
@@ -1801,15 +1801,15 @@ GLOBAL void TRILINOS_CAMD_2
  * Variables at this point:
  *
  * Pe: holds the elimination tree.  The parent of j is FLIP (Pe [j]),
- *	or EMPTY if j is a root.  The tree holds both elements and
+ *	or TRILINOS_CAMD_EMPTY if j is a root.  The tree holds both elements and
  *	non-principal (unordered) variables absorbed into them.
  *	Dense and empty variables are non-principal and unordered.  They are
  *	all represented by the fictitious node n (that is, Pe [i] = FLIP (n)
- *      and Elen [i] = EMPTY if i is a dense or empty node).
+ *      and Elen [i] = TRILINOS_CAMD_EMPTY if i is a dense or empty node).
  *
  * Elen: holds the size of each element, including the diagonal part.
  *	FLIP (Elen [e]) > 0 if e is an element.  For unordered
- *	variables i, Elen [i] is EMPTY.
+ *	variables i, Elen [i] is TRILINOS_CAMD_EMPTY.
  *
  * Nv: Nv [e] > 0 is the number of pivots represented by the element e.
  *	For unordered variables i, Nv [i] is zero.
@@ -1842,7 +1842,7 @@ GLOBAL void TRILINOS_CAMD_2
 	Elen [i] = FLIP (Elen [i]) ;
     }
 
-    /* Now, Pe [j] is the parent of j, or EMPTY if j is a root.
+    /* Now, Pe [j] is the parent of j, or TRILINOS_CAMD_EMPTY if j is a root.
      * Pe [j] = n if j is a dense/empty node */
 
     /* place all variables in the list of children of their parents */
@@ -1858,7 +1858,7 @@ GLOBAL void TRILINOS_CAMD_2
     for (e = n-1 ; e >= 0 ; e--)
     {
 	if (Nv [e] <= 0) continue ;	    /* skip if e is a variable */
-	if (Pe [e] == EMPTY) continue ;	    /* skip if e is a root */
+	if (Pe [e] == TRILINOS_CAMD_EMPTY) continue ;	    /* skip if e is a root */
 	Next [e] = Head [Pe [e]] ;	    /* place e in list of its parent */
 	Head [Pe [e]] = e ;
     }
@@ -1882,7 +1882,7 @@ GLOBAL void TRILINOS_CAMD_2
     {
 	j = BucketSet [i] ;
 	ASSERT (j >= 0 && j < n) ;
-	if (Pe [j] == EMPTY)
+	if (Pe [j] == TRILINOS_CAMD_EMPTY)
 	{
 	    k = TRILINOS_CAMD_postorder (j, k, n, Head, Next, Perm, W) ;
 	}
@@ -1919,12 +1919,12 @@ GLOBAL void TRILINOS_CAMD_2
 		Bucket [c] = 0 ;
 	    }
 	    i = 0 ;
-	    for (j = Head [n] ; j != EMPTY ; j = Next [j])
+	    for (j = Head [n] ; j != TRILINOS_CAMD_EMPTY ; j = Next [j])
 	    {
 		TRILINOS_CAMD_DEBUG1 (("Dense/empty node: "ID" : "ID" "ID"\n", j,
 		    Pe [j], Elen [j])) ;
 		fflush (stdout) ;
-		ASSERT (Pe [j] == n && Elen [j] == EMPTY) ;
+		ASSERT (Pe [j] == n && Elen [j] == TRILINOS_CAMD_EMPTY) ;
 		i++ ;
 		Bucket [C [j]]++ ;
 	    }
@@ -1943,7 +1943,7 @@ GLOBAL void TRILINOS_CAMD_2
 
 	    /* place dense/empty nodes in BucketSet, in constraint order,
 	     * ties in natural order */
-	    for (j = Head [n] ; j != EMPTY ; j = Next [j])
+	    for (j = Head [n] ; j != TRILINOS_CAMD_EMPTY ; j = Next [j])
 	    {
 		BucketSet [Bucket [C [j]]++] = j ;
 	    }

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CAMD/Source/trilinos_camd_aat.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CAMD/Source/trilinos_camd_aat.c
@@ -34,7 +34,7 @@ GLOBAL size_t TRILINOS_CAMD_aat	/* returns nz in A+A' */
 
 #ifndef NDEBUG
     TRILINOS_CAMD_debug_init ("CAMD AAT") ;
-    for (k = 0 ; k < n ; k++) Tp [k] = EMPTY ;
+    for (k = 0 ; k < n ; k++) Tp [k] = TRILINOS_CAMD_EMPTY ;
     ASSERT (TRILINOS_CAMD_valid (n, n, Ap, Ai) == TRILINOS_CAMD_OK) ;
 #endif
 
@@ -43,7 +43,7 @@ GLOBAL size_t TRILINOS_CAMD_aat	/* returns nz in A+A' */
 	/* clear the Info array, if it exists */
 	for (i = 0 ; i < TRILINOS_CAMD_INFO ; i++)
 	{
-	    Info [i] = EMPTY ;
+	    Info [i] = TRILINOS_CAMD_EMPTY ;
 	}
 	Info [TRILINOS_CAMD_STATUS] = TRILINOS_CAMD_OK ;
     }
@@ -91,7 +91,7 @@ GLOBAL size_t TRILINOS_CAMD_aat	/* returns nz in A+A' */
 	    }
 	    /* scan lower triangular part of A, in column j until reaching
 	     * row k.  Start where last scan left off. */
-	    ASSERT (Tp [j] != EMPTY) ;
+	    ASSERT (Tp [j] != TRILINOS_CAMD_EMPTY) ;
 	    ASSERT (Ap [j] <= Tp [j] && Tp [j] <= Ap [j+1]) ;
 	    pj2 = Ap [j+1] ;
 	    for (pj = Tp [j] ; pj < pj2 ; )

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CAMD/Source/trilinos_camd_dump.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CAMD/Source/trilinos_camd_dump.c
@@ -88,12 +88,12 @@ GLOBAL void TRILINOS_CAMD_dump (
 	len = Len [i] ;
 	w = W [i] ;
 
-	if (elen >= EMPTY)
+	if (elen >= TRILINOS_CAMD_EMPTY)
 	{
 	    if (nv == 0)
 	    {
 		TRILINOS_CAMD_DEBUG4 (("\nI "ID": nonprincipal:    ", i)) ;
-		ASSERT (elen == EMPTY) ;
+		ASSERT (elen == TRILINOS_CAMD_EMPTY) ;
 		if (pe == FLIP(n))
 		{
 		    TRILINOS_CAMD_DEBUG4 ((" dense node\n")) ;
@@ -101,7 +101,7 @@ GLOBAL void TRILINOS_CAMD_dump (
 		}
 		else
 		{
-		    ASSERT (pe < EMPTY) ;
+		    ASSERT (pe < TRILINOS_CAMD_EMPTY) ;
 		    TRILINOS_CAMD_DEBUG4 ((" i "ID" -> parent "ID"\n", i, FLIP (Pe[i])));
 		}
 	    }
@@ -162,10 +162,10 @@ GLOBAL void TRILINOS_CAMD_dump (
 	cnt = 0 ;
 	for (deg = 0 ; deg < n ; deg++)
 	{
-	    if (Head [deg] == EMPTY) continue ;
-	    ilast = EMPTY ;
+	    if (Head [deg] == TRILINOS_CAMD_EMPTY) continue ;
+	    ilast = TRILINOS_CAMD_EMPTY ;
 	    TRILINOS_CAMD_DEBUG4 ((ID": \n", deg)) ;
-	    for (i = Head [deg] ; i != EMPTY ; i = Next [i])
+	    for (i = Head [deg] ; i != TRILINOS_CAMD_EMPTY ; i = Next [i])
 	    {
 		TRILINOS_CAMD_DEBUG4 (("   "ID" : next "ID" last "ID" deg "ID"\n",
 		    i, Next [i], Last [i], Degree [i])) ;

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CAMD/Source/trilinos_camd_l2.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CAMD/Source/trilinos_camd_l2.c
@@ -281,7 +281,7 @@ GLOBAL void TRILINOS_CAMD_2
  *	    as (-(j)-2).  Row j has the same pattern as row i.  Note that j
  *	    might later be absorbed into another supervariable j2, in which
  *	    case Pe [i] is still FLIP (j), and Pe [j] = FLIP (j2) which is
- *	    < EMPTY, where EMPTY is defined as (-1) in camd_internal.h.
+ *	    < TRILINOS_CAMD_EMPTY, where TRILINOS_CAMD_EMPTY is defined as (-1) in camd_internal.h.
  *
  *	Unabsorbed element e:  the index into Iw of the description of element
  *	    e, if e has not yet been absorbed by a subsequent element.  Element
@@ -291,8 +291,8 @@ GLOBAL void TRILINOS_CAMD_2
  *	Absorbed element e:  if element e is absorbed into element e2, then
  *	    Pe [e] = FLIP (e2).  This occurs when the pattern of e (which we
  *	    refer to as Le) is found to be a subset of the pattern of e2 (that
- *	    is, Le2).  In this case, Pe [i] < EMPTY.  If element e is "null"
- *	    (it has no nonzeros outside its pivot block), then Pe [e] = EMPTY,
+ *	    is, Le2).  In this case, Pe [i] < TRILINOS_CAMD_EMPTY.  If element e is "null"
+ *	    (it has no nonzeros outside its pivot block), then Pe [e] = TRILINOS_CAMD_EMPTY,
  *	    and e is the root of an assembly subtree (or the whole tree if
  *	    there is just one such root).
  *
@@ -303,7 +303,7 @@ GLOBAL void TRILINOS_CAMD_2
  *	represents a pivot order with identical fill-in as the actual order
  *	(via a depth-first search of the tree), as follows.  If Nv [i] > 0,
  *	then i represents a node in the assembly tree, and the parent of i is
- *	Pe [i], or EMPTY if i is a root.  If Nv [i] = 0, then (i, Pe [i])
+ *	Pe [i], or TRILINOS_CAMD_EMPTY if i is a root.  If Nv [i] = 0, then (i, Pe [i])
  *	represents an edge in a subtree, the root of which is a node in the
  *	assembly tree.  Note that i refers to a row/column in the original
  *	matrix, not the permuted matrix.
@@ -393,16 +393,16 @@ GLOBAL void TRILINOS_CAMD_2
  *	execution, Elen [i] is the number of elements in the list for
  *	supervariable i.  When e becomes an element, Elen [e] = FLIP (esize) is
  *	set, where esize is the size of the element (the number of pivots, plus
- *	the number of nonpivotal entries).  Thus Elen [e] < EMPTY.
- *	Elen (i) = EMPTY set when variable i becomes nonprincipal.
+ *	the number of nonpivotal entries).  Thus Elen [e] < TRILINOS_CAMD_EMPTY.
+ *	Elen (i) = TRILINOS_CAMD_EMPTY set when variable i becomes nonprincipal.
  *
- *	For variables, Elen (i) >= EMPTY holds until just before the
+ *	For variables, Elen (i) >= TRILINOS_CAMD_EMPTY holds until just before the
  *	postordering and permutation vectors are computed.  For elements,
- *	Elen [e] < EMPTY holds.
+ *	Elen [e] < TRILINOS_CAMD_EMPTY holds.
  *
  *	On output, Elen [i] is the degree of the row/column in the Cholesky
  *	factorization of the permuted matrix, corresponding to the original row
- *	i, if i is a super row/column.  It is equal to EMPTY if i is
+ *	i, if i is a super row/column.  It is equal to TRILINOS_CAMD_EMPTY if i is
  *	non-principal.  Note that i refers to a row/column in the original
  *	matrix, not the permuted matrix.
  *
@@ -411,7 +411,7 @@ GLOBAL void TRILINOS_CAMD_2
  *	which is instead returned in the Next array in this C version,
  *	described below).
  *
- * Last: In a degree list, Last [i] is the supervariable preceding i, or EMPTY
+ * Last: In a degree list, Last [i] is the supervariable preceding i, or TRILINOS_CAMD_EMPTY
  *	if i is the head of the list.  In a hash bucket, Last [i] is the hash
  *	key for i.
  *
@@ -423,7 +423,7 @@ GLOBAL void TRILINOS_CAMD_2
  *	i = Last [k], then row i is the kth pivot row (where k ranges from 0 to
  *	n-1).  Row Last [k] of A is the kth row in the permuted matrix, PAP'.
  *
- * Next: Next [i] is the supervariable following i in a link list, or EMPTY if
+ * Next: Next [i] is the supervariable following i in a link list, or TRILINOS_CAMD_EMPTY if
  *	i is the last in the list.  Used for two kinds of lists:  degree lists
  *	and hash buckets (a supervariable can be in only one kind of list at a
  *	time).
@@ -454,16 +454,16 @@ GLOBAL void TRILINOS_CAMD_2
  *	Head [deg] is the first supervariable in a degree list.  All
  *	supervariables i in a degree list Head [deg] have the same approximate
  *	degree, namely, deg = Degree [i].  If the list Head [deg] is empty then
- *	Head [deg] = EMPTY.
+ *	Head [deg] = TRILINOS_CAMD_EMPTY.
  *
  *	During supervariable detection Head [hash] also serves as a pointer to
  *	a hash bucket.  If Head [hash] >= 0, there is a degree list of degree
  *	hash.  The hash bucket head pointer is Last [Head [hash]].  If
- *	Head [hash] = EMPTY, then the degree list and hash bucket are both
- *	empty.  If Head [hash] < EMPTY, then the degree list is empty, and
+ *	Head [hash] = TRILINOS_CAMD_EMPTY, then the degree list and hash bucket are both
+ *	empty.  If Head [hash] < TRILINOS_CAMD_EMPTY, then the degree list is empty, and
  *	FLIP (Head [hash]) is the head of the hash bucket.  After supervariable
  *	detection is complete, all hash buckets are empty, and the
- *	(Last [Head [hash]] = EMPTY) condition is restored for the non-empty
+ *	(Last [Head [hash]] = TRILINOS_CAMD_EMPTY) condition is restored for the non-empty
  *	degree lists.
  *
  *      Head also workes as a temporary workspace in post ordering with dense
@@ -634,7 +634,7 @@ GLOBAL void TRILINOS_CAMD_2
     nms_lu = 0 ;
     nms_ldl = 0 ;
     dmax = 1 ;
-    me = EMPTY ;
+    me = TRILINOS_CAMD_EMPTY ;
 
     mindeg = 0 ;
     ncmpa = 0 ;
@@ -737,18 +737,18 @@ GLOBAL void TRILINOS_CAMD_2
 
     for (i = 0 ; i < n ; i++)
     {
-	Last [i] = EMPTY ;
-	Head [i] = EMPTY ;
-	Next [i] = EMPTY ;
+	Last [i] = TRILINOS_CAMD_EMPTY ;
+	Head [i] = TRILINOS_CAMD_EMPTY ;
+	Next [i] = TRILINOS_CAMD_EMPTY ;
 	/* if separate Hhead array is used for hash buckets: *
-	Hhead [i] = EMPTY ;
+	Hhead [i] = TRILINOS_CAMD_EMPTY ;
 	*/
 	Nv [i] = 1 ;
 	W [i] = 1 ;
 	Elen [i] = 0 ;
 	Degree [i] = Len [i] ;
     }
-    Head [n] = EMPTY ;
+    Head [n] = TRILINOS_CAMD_EMPTY ;
 
     /* initialize wflg */
     wbig = Int_MAX - n ;
@@ -790,7 +790,7 @@ GLOBAL void TRILINOS_CAMD_2
 	    }
 	    Pe [i] = FLIP (n) ;
 	    Nv [i] = 0 ;		/* do not postorder this node */
-	    Elen [i] = EMPTY ;
+	    Elen [i] = TRILINOS_CAMD_EMPTY ;
 	    nel++ ;
 	}
     }
@@ -832,12 +832,12 @@ GLOBAL void TRILINOS_CAMD_2
 		     * ------------------------------------------------------ */
 
 		    inext = Head [deg] ;
-		    ASSERT (inext >= EMPTY && inext < n) ;
-		    if (inext != EMPTY) Last [inext] = i ;
+		    ASSERT (inext >= TRILINOS_CAMD_EMPTY && inext < n) ;
+		    if (inext != TRILINOS_CAMD_EMPTY) Last [inext] = i ;
 		    Next [i] = inext ;
 		    Head [deg] = i ;
 		    degreeListCounter++ ;
-		    Last [i] = EMPTY ;
+		    Last [i] = TRILINOS_CAMD_EMPTY ;
 		    mindeg = MIN (mindeg, deg) ;
 		}
 	    }
@@ -864,7 +864,7 @@ GLOBAL void TRILINOS_CAMD_2
 	for (deg = mindeg ; deg < n ; deg++)
 	{
 	    me = Head [deg] ;
-	    if (me != EMPTY) break ;
+	    if (me != TRILINOS_CAMD_EMPTY) break ;
 	}
 	mindeg = deg ;
 	ASSERT (me >= 0 && me < n) ;
@@ -875,8 +875,8 @@ GLOBAL void TRILINOS_CAMD_2
 	/* ----------------------------------------------------------------- */
 
 	inext = Next [me] ;
-	ASSERT (inext >= EMPTY && inext < n) ;
-	if (inext != EMPTY) Last [inext] = EMPTY ;
+	ASSERT (inext >= TRILINOS_CAMD_EMPTY && inext < n) ;
+	if (inext != TRILINOS_CAMD_EMPTY) Last [inext] = TRILINOS_CAMD_EMPTY ;
 	Head [deg] = inext ;
 	degreeListCounter-- ;
 
@@ -944,10 +944,10 @@ GLOBAL void TRILINOS_CAMD_2
 		    {
 			ilast = Last [i] ;
 			inext = Next [i] ;
-			ASSERT (ilast >= EMPTY && ilast < n) ;
-			ASSERT (inext >= EMPTY && inext < n) ;
-			if (inext != EMPTY) Last [inext] = ilast ;
-			if (ilast != EMPTY)
+			ASSERT (ilast >= TRILINOS_CAMD_EMPTY && ilast < n) ;
+			ASSERT (inext >= TRILINOS_CAMD_EMPTY && inext < n) ;
+			if (inext != TRILINOS_CAMD_EMPTY) Last [inext] = ilast ;
+			if (ilast != TRILINOS_CAMD_EMPTY)
 			{
 			    Next [ilast] = inext ;
 			}
@@ -992,7 +992,7 @@ GLOBAL void TRILINOS_CAMD_2
 		    pj = Pe [e] ;
 		    ln = Len [e] ;
 		    TRILINOS_CAMD_DEBUG2 (("Search element e "ID" in me "ID"\n", e,me)) ;
-		    ASSERT (Elen [e] < EMPTY && W [e] > 0 && pj >= 0) ;
+		    ASSERT (Elen [e] < TRILINOS_CAMD_EMPTY && W [e] > 0 && pj >= 0) ;
 		}
 		ASSERT (ln >= 0 && (ln == 0 || (pj >= 0 && pj < iwlen))) ;
 
@@ -1006,7 +1006,7 @@ GLOBAL void TRILINOS_CAMD_2
 		for (knt2 = 1 ; knt2 <= ln ; knt2++)
 		{
 		    i = Iw [pj++] ;
-		    ASSERT (i >= 0 && i < n && (i == me || Elen [i] >= EMPTY));
+		    ASSERT (i >= 0 && i < n && (i == me || Elen [i] >= TRILINOS_CAMD_EMPTY));
 		    nvi = Nv [i] ;
 		    TRILINOS_CAMD_DEBUG2 ((": "ID" "ID" "ID" "ID"\n",
 				i, Elen [i], Nv [i], wflg)) ;
@@ -1031,11 +1031,11 @@ GLOBAL void TRILINOS_CAMD_2
 			    Pe [me] = p ;
 			    Len [me] -= knt1 ;
 			    /* check if nothing left of supervariable me */
-			    if (Len [me] == 0) Pe [me] = EMPTY ;
+			    if (Len [me] == 0) Pe [me] = TRILINOS_CAMD_EMPTY ;
 			    Pe [e] = pj ;
 			    Len [e] = ln - knt2 ;
 			    /* nothing left of element e */
-			    if (Len [e] == 0) Pe [e] = EMPTY ;
+			    if (Len [e] == 0) Pe [e] = TRILINOS_CAMD_EMPTY ;
 
 			    ncmpa++ ;	/* one more garbage collection */
 
@@ -1107,10 +1107,10 @@ GLOBAL void TRILINOS_CAMD_2
 			{
 			    ilast = Last [i] ;
 			    inext = Next [i] ;
-			    ASSERT (ilast >= EMPTY && ilast < n) ;
-			    ASSERT (inext >= EMPTY && inext < n) ;
-			    if (inext != EMPTY) Last [inext] = ilast ;
-			    if (ilast != EMPTY)
+			    ASSERT (ilast >= TRILINOS_CAMD_EMPTY && ilast < n) ;
+			    ASSERT (inext >= TRILINOS_CAMD_EMPTY && inext < n) ;
+			    if (inext != TRILINOS_CAMD_EMPTY) Last [inext] = ilast ;
+			    if (ilast != TRILINOS_CAMD_EMPTY)
 			    {
 				Next [ilast] = inext ;
 			    }
@@ -1141,7 +1141,7 @@ GLOBAL void TRILINOS_CAMD_2
 		    {
 			/* make element a root; kill it if not in same bucket */
 			TRILINOS_CAMD_DEBUG1 (("2 Element "ID" => "ID"\n", e, me)) ;
-			Pe [e] = EMPTY ;
+			Pe [e] = TRILINOS_CAMD_EMPTY ;
 			W [e] = 0 ;
 		    }
 		}
@@ -1302,7 +1302,7 @@ GLOBAL void TRILINOS_CAMD_2
 				TRILINOS_CAMD_DEBUG1 (("2 Element "ID" =>"ID" (aggr)\n",
 					e, me)) ;
 				ASSERT (dext == 0) ;
-				Pe [e] = EMPTY ;
+				Pe [e] = TRILINOS_CAMD_EMPTY ;
 				W [e] = 0 ;
 			    }
 			}
@@ -1400,7 +1400,7 @@ GLOBAL void TRILINOS_CAMD_2
 		nvpiv += nvi ;
 		nel += nvi ;
 		Nv [i] = 0 ;
-		Elen [i] = EMPTY ;
+		Elen [i] = TRILINOS_CAMD_EMPTY ;
 
 	    }
 	    else
@@ -1441,7 +1441,7 @@ GLOBAL void TRILINOS_CAMD_2
 
 		/* if the Hhead array is not used: */
 		j = Head [hash] ;
-		if (j <= EMPTY)
+		if (j <= TRILINOS_CAMD_EMPTY)
 		{
 		    /* degree list is empty, hash head is FLIP (j) */
 		    Next [i] = FLIP (j) ;
@@ -1505,33 +1505,33 @@ GLOBAL void TRILINOS_CAMD_2
 
 		/* if Hhead array is not used: */
 		j = Head [hash] ;
-		if (j == EMPTY)
+		if (j == TRILINOS_CAMD_EMPTY)
 		{
 		    /* hash bucket and degree list are both empty */
-		    i = EMPTY ;
+		    i = TRILINOS_CAMD_EMPTY ;
 		}
-		else if (j < EMPTY)
+		else if (j < TRILINOS_CAMD_EMPTY)
 		{
 		    /* degree list is empty */
 		    i = FLIP (j) ;
-		    Head [hash] = EMPTY ;
+		    Head [hash] = TRILINOS_CAMD_EMPTY ;
 		}
 		else
 		{
 		    /* degree list is not empty, restore Last [j] of head j */
 		    i = Last [j] ;
-		    Last [j] = EMPTY ;
+		    Last [j] = TRILINOS_CAMD_EMPTY ;
 		}
 
 		/* if separate Hhead array is used: *
 		i = Hhead [hash] ;
-		Hhead [hash] = EMPTY ;
+		Hhead [hash] = TRILINOS_CAMD_EMPTY ;
 		*/
 
-		ASSERT (i >= EMPTY && i < n) ;
+		ASSERT (i >= TRILINOS_CAMD_EMPTY && i < n) ;
 		TRILINOS_CAMD_DEBUG2 (("----i "ID" hash "ID"\n", i, hash)) ;
 
-		while (i != EMPTY && Next [i] != EMPTY)
+		while (i != TRILINOS_CAMD_EMPTY && Next [i] != TRILINOS_CAMD_EMPTY)
 		{
 
 		    /* -----------------------------------------------------
@@ -1557,9 +1557,9 @@ GLOBAL void TRILINOS_CAMD_2
 
 		    jlast = i ;
 		    j = Next [i] ;
-		    ASSERT (j >= EMPTY && j < n) ;
+		    ASSERT (j >= TRILINOS_CAMD_EMPTY && j < n) ;
 
-		    while (j != EMPTY)
+		    while (j != TRILINOS_CAMD_EMPTY)
 		    {
 			/* ------------------------------------------------- */
 			/* check if j and i have identical nonzero pattern */
@@ -1593,7 +1593,7 @@ GLOBAL void TRILINOS_CAMD_2
 			    /* are the number of variables in i and j: */
 			    Nv [i] += Nv [j] ;
 			    Nv [j] = 0 ;
-			    Elen [j] = EMPTY ;
+			    Elen [j] = TRILINOS_CAMD_EMPTY ;
 			    /* delete j from hash bucket */
 			    ASSERT (j != Next [j]) ;
 			    j = Next [j] ;
@@ -1607,7 +1607,7 @@ GLOBAL void TRILINOS_CAMD_2
 			    ASSERT (j != Next [j]) ;
 			    j = Next [j] ;
 			}
-			ASSERT (j >= EMPTY && j < n) ;
+			ASSERT (j >= TRILINOS_CAMD_EMPTY && j < n) ;
 		    }
 
 		    /* -----------------------------------------------------
@@ -1617,7 +1617,7 @@ GLOBAL void TRILINOS_CAMD_2
 
 		    wflg++ ;
 		    i = Next [i] ;
-		    ASSERT (i >= EMPTY && i < n) ;
+		    ASSERT (i >= TRILINOS_CAMD_EMPTY && i < n) ;
 
 		}
 	    }
@@ -1657,10 +1657,10 @@ GLOBAL void TRILINOS_CAMD_2
 		if (IsInCurrentSet (C, i, curC))
 		{
 		    inext = Head [deg] ;
-		    ASSERT (inext >= EMPTY && inext < n) ;
-		    if (inext != EMPTY) Last [inext] = i ;
+		    ASSERT (inext >= TRILINOS_CAMD_EMPTY && inext < n) ;
+		    if (inext != TRILINOS_CAMD_EMPTY) Last [inext] = i ;
 		    Next [i] = inext ;
-		    Last [i] = EMPTY ;
+		    Last [i] = TRILINOS_CAMD_EMPTY ;
 		    Head [deg] = i ;
 		    degreeListCounter++ ;
 		}
@@ -1693,7 +1693,7 @@ GLOBAL void TRILINOS_CAMD_2
 	{
 	    /* there is nothing left of the current pivot element */
 	    /* it is a root of the assembly tree */
-	    Pe [me] = EMPTY ;
+	    Pe [me] = TRILINOS_CAMD_EMPTY ;
 	    W [me] = 0 ;
 	}
 	if (elenme != 0)
@@ -1804,15 +1804,15 @@ GLOBAL void TRILINOS_CAMD_2
  * Variables at this point:
  *
  * Pe: holds the elimination tree.  The parent of j is FLIP (Pe [j]),
- *	or EMPTY if j is a root.  The tree holds both elements and
+ *	or TRILINOS_CAMD_EMPTY if j is a root.  The tree holds both elements and
  *	non-principal (unordered) variables absorbed into them.
  *	Dense and empty variables are non-principal and unordered.  They are
  *	all represented by the fictitious node n (that is, Pe [i] = FLIP (n)
- *      and Elen [i] = EMPTY if i is a dense or empty node).
+ *      and Elen [i] = TRILINOS_CAMD_EMPTY if i is a dense or empty node).
  *
  * Elen: holds the size of each element, including the diagonal part.
  *	FLIP (Elen [e]) > 0 if e is an element.  For unordered
- *	variables i, Elen [i] is EMPTY.
+ *	variables i, Elen [i] is TRILINOS_CAMD_EMPTY.
  *
  * Nv: Nv [e] > 0 is the number of pivots represented by the element e.
  *	For unordered variables i, Nv [i] is zero.
@@ -1845,7 +1845,7 @@ GLOBAL void TRILINOS_CAMD_2
 	Elen [i] = FLIP (Elen [i]) ;
     }
 
-    /* Now, Pe [j] is the parent of j, or EMPTY if j is a root.
+    /* Now, Pe [j] is the parent of j, or TRILINOS_CAMD_EMPTY if j is a root.
      * Pe [j] = n if j is a dense/empty node */
 
     /* place all variables in the list of children of their parents */
@@ -1861,7 +1861,7 @@ GLOBAL void TRILINOS_CAMD_2
     for (e = n-1 ; e >= 0 ; e--)
     {
 	if (Nv [e] <= 0) continue ;	    /* skip if e is a variable */
-	if (Pe [e] == EMPTY) continue ;	    /* skip if e is a root */
+	if (Pe [e] == TRILINOS_CAMD_EMPTY) continue ;	    /* skip if e is a root */
 	Next [e] = Head [Pe [e]] ;	    /* place e in list of its parent */
 	Head [Pe [e]] = e ;
     }
@@ -1885,7 +1885,7 @@ GLOBAL void TRILINOS_CAMD_2
     {
 	j = BucketSet [i] ;
 	ASSERT (j >= 0 && j < n) ;
-	if (Pe [j] == EMPTY)
+	if (Pe [j] == TRILINOS_CAMD_EMPTY)
 	{
 	    k = TRILINOS_CAMD_postorder (j, k, n, Head, Next, Perm, W) ;
 	}
@@ -1922,12 +1922,12 @@ GLOBAL void TRILINOS_CAMD_2
 		Bucket [c] = 0 ;
 	    }
 	    i = 0 ;
-	    for (j = Head [n] ; j != EMPTY ; j = Next [j])
+	    for (j = Head [n] ; j != TRILINOS_CAMD_EMPTY ; j = Next [j])
 	    {
 		TRILINOS_CAMD_DEBUG1 (("Dense/empty node: "ID" : "ID" "ID"\n", j,
 		    Pe [j], Elen [j])) ;
 		fflush (stdout) ;
-		ASSERT (Pe [j] == n && Elen [j] == EMPTY) ;
+		ASSERT (Pe [j] == n && Elen [j] == TRILINOS_CAMD_EMPTY) ;
 		i++ ;
 		Bucket [C [j]]++ ;
 	    }
@@ -1946,7 +1946,7 @@ GLOBAL void TRILINOS_CAMD_2
 
 	    /* place dense/empty nodes in BucketSet, in constraint order,
 	     * ties in natural order */
-	    for (j = Head [n] ; j != EMPTY ; j = Next [j])
+	    for (j = Head [n] ; j != TRILINOS_CAMD_EMPTY ; j = Next [j])
 	    {
 		BucketSet [Bucket [C [j]]++] = j ;
 	    }

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CAMD/Source/trilinos_camd_order.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CAMD/Source/trilinos_camd_order.c
@@ -44,7 +44,7 @@ GLOBAL Int TRILINOS_CAMD_order
     {
 	for (i = 0 ; i < TRILINOS_CAMD_INFO ; i++)
 	{
-	    Info [i] = EMPTY ;
+	    Info [i] = TRILINOS_CAMD_EMPTY ;
 	}
 	Info [TRILINOS_CAMD_N] = n ;
 	Info [TRILINOS_CAMD_STATUS] = TRILINOS_CAMD_OK ;

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CAMD/Source/trilinos_camd_preprocess.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CAMD/Source/trilinos_camd_preprocess.c
@@ -57,7 +57,7 @@ GLOBAL void TRILINOS_CAMD_preprocess
     for (i = 0 ; i < n ; i++)
     {
 	W [i] = 0 ;		/* # of nonzeros in row i (excl duplicates) */
-	Flag [i] = EMPTY ;	/* Flag [i] = j if i appears in column j */
+	Flag [i] = TRILINOS_CAMD_EMPTY ;	/* Flag [i] = j if i appears in column j */
     }
     for (j = 0 ; j < n ; j++)
     {
@@ -86,7 +86,7 @@ GLOBAL void TRILINOS_CAMD_preprocess
     for (i = 0 ; i < n ; i++)
     {
 	W [i] = Rp [i] ;
-	Flag [i] = EMPTY ;
+	Flag [i] = TRILINOS_CAMD_EMPTY ;
     }
 
     /* --------------------------------------------------------------------- */

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CAMD/Source/trilinos_camd_valid.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CAMD/Source/trilinos_camd_valid.c
@@ -64,7 +64,7 @@ GLOBAL Int TRILINOS_CAMD_valid
 	    TRILINOS_CAMD_DEBUG0 (("column "ID" pointer bad\n", j)) ;
 	    return (TRILINOS_CAMD_INVALID) ;
 	}
-	ilast = EMPTY ;
+	ilast = TRILINOS_CAMD_EMPTY ;
 	for (p = p1 ; p < p2 ; p++)
 	{
 	    i = Ai [p] ;

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CCOLAMD/Source/trilinos_ccolamd.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CCOLAMD/Source/trilinos_ccolamd.c
@@ -751,7 +751,7 @@ typedef struct Trilinos_CColamd_Row_struct
 /* === basic definitions ==================================================== */
 /* ========================================================================== */
 
-#define EMPTY (-1)
+#define TRILINOS_CCOLAMD_EMPTY (-1)
 #define MAX(a,b) (((a) > (b)) ? (a) : (b))
 #define MIN(a,b) (((a) < (b)) ? (a) : (b))
 
@@ -1552,7 +1552,7 @@ PUBLIC Int TRILINOS_CCOLAMD_2	    /* returns TRUE if successful, FALSE otherwise
     Int Front_cols [ ],		/* link list of pivot columns for each front */
     Int *p_nfr,			/* total number of frontal matrices */
     Int InFront [ ],		/* InFront [row] = f if the original row was
-				 * absorbed into front f.  EMPTY if the row was
+				 * absorbed into front f.  TRILINOS_CCOLAMD_EMPTY if the row was
 				 * empty, dense, or not absorbed.  This array
 				 * has size n_row+1 */
     Int cmember [ ]		/* constraint set of A */
@@ -1830,8 +1830,8 @@ PUBLIC Int TRILINOS_CCOLAMD_2	    /* returns TRUE if successful, FALSE otherwise
     	Front_npivcol [col] = 0 ;
     	Front_nrows [col] = 0 ;
     	Front_ncols [col] = 0 ;
-    	Front_parent [col] = EMPTY ;
-    	Front_cols [col] = EMPTY ;
+    	Front_parent [col] = TRILINOS_CCOLAMD_EMPTY ;
+    	Front_cols [col] = TRILINOS_CCOLAMD_EMPTY ;
     }
 
     /* === Initialize scores, kill dense rows/columns ======================= */
@@ -1890,7 +1890,7 @@ PUBLIC Int TRILINOS_CCOLAMD_2	    /* returns TRUE if successful, FALSE otherwise
     for (i = 0 ; i < nfr ; i++)
     {
         parent = Front_parent [i] ;
-        if (parent != EMPTY)
+        if (parent != TRILINOS_CCOLAMD_EMPTY)
         {
             Front_parent [i] = Front_order [parent] ;
         }
@@ -1900,8 +1900,8 @@ PUBLIC Int TRILINOS_CCOLAMD_2	    /* returns TRUE if successful, FALSE otherwise
     for (row = 0 ; row < n_row ; row++)
     {
         i = InFront [row] ;
-        ASSERT (i >= EMPTY && i < nfr) ;
-        if (i != EMPTY)
+        ASSERT (i >= TRILINOS_CCOLAMD_EMPTY && i < nfr) ;
+        if (i != TRILINOS_CCOLAMD_EMPTY)
         {
             InFront [row] = Front_order [i] ;
         }
@@ -1914,7 +1914,7 @@ PUBLIC Int TRILINOS_CCOLAMD_2	    /* returns TRUE if successful, FALSE otherwise
     /* use A [0..n_col-1] as inverse permutation */
     for (i = 0 ; i < n_col ; i++)
     {
-        A [i] = EMPTY ;
+        A [i] = TRILINOS_CCOLAMD_EMPTY ;
     }
 
     k = 0 ;
@@ -1932,12 +1932,12 @@ PUBLIC Int TRILINOS_CCOLAMD_2	    /* returns TRUE if successful, FALSE otherwise
         }
         set1 = set2 ;
 
-        for (col = Front_cols [i] ; col != EMPTY ; col = Col [col].nextcol)
+        for (col = Front_cols [i] ; col != TRILINOS_CCOLAMD_EMPTY ; col = Col [col].nextcol)
         {
             ASSERT (col >= 0 && col < n_col) ;
             DEBUG1 (("trilinos_ccolamd output ordering: k "ID" col "ID"\n", k, col)) ;
             p [k] = col ;
-            ASSERT (A [col] == EMPTY) ;
+            ASSERT (A [col] == TRILINOS_CCOLAMD_EMPTY) ;
 
 	    cs = CMEMBER (col) ;
             ASSERT (k >= cset_start [cs] && k < cset_start [cs+1]) ;
@@ -1953,7 +1953,7 @@ PUBLIC Int TRILINOS_CCOLAMD_2	    /* returns TRUE if successful, FALSE otherwise
     {
         for (col = 0 ; col < n_col ; col++)
         {
-            if (A [col] == EMPTY)
+            if (A [col] == TRILINOS_CCOLAMD_EMPTY)
             {
                 k = Col [col].shared2.order ;
 		cs = CMEMBER (col) ;
@@ -2084,9 +2084,9 @@ PRIVATE Int init_rows_cols	/* returns TRUE if OK, or FALSE otherwise */
 
 	Col [col].shared1.thickness = 1 ;
 	Col [col].shared2.score = 0 ;
-	Col [col].shared3.prev = EMPTY ;
-	Col [col].shared4.degree_next = EMPTY ;
-        Col [col].nextcol = EMPTY ;
+	Col [col].shared3.prev = TRILINOS_CCOLAMD_EMPTY ;
+	Col [col].shared4.degree_next = TRILINOS_CCOLAMD_EMPTY ;
+        Col [col].nextcol = TRILINOS_CCOLAMD_EMPTY ;
         Col [col].lastcol = col ;
     }
 
@@ -2101,7 +2101,7 @@ PRIVATE Int init_rows_cols	/* returns TRUE if OK, or FALSE otherwise */
 	Row [row].length = 0 ;
 	Row [row].shared2.mark = -1 ;
         Row [row].thickness = 1 ;
-        Row [row].front = EMPTY ;
+        Row [row].front = TRILINOS_CCOLAMD_EMPTY ;
     }
 
     for (col = 0 ; col < n_col ; col++)
@@ -2541,7 +2541,7 @@ PRIVATE void init_scoring
     /* clear the hash buckets */
     for (c = 0 ; c <= n_col ; c++)
     {
-	head [c] = EMPTY ;
+	head [c] = TRILINOS_CCOLAMD_EMPTY ;
     }
 
 #ifndef NDEBUG
@@ -2667,7 +2667,7 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 
     for (row = 0 ; row < n_row ; row++)
     {
-        InFront [row] = EMPTY ;
+        InFront [row] = TRILINOS_CCOLAMD_EMPTY ;
     }
 
     /* === Order the columns ================================================ */
@@ -2678,12 +2678,12 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 	/* make sure degree list isn't empty */
 	ASSERT (min_score >= 0) ;
 	ASSERT (min_score <= n_col) ;
-	ASSERT (head [min_score] >= EMPTY) ;
+	ASSERT (head [min_score] >= TRILINOS_CCOLAMD_EMPTY) ;
 
 #ifndef NDEBUG
 	for (debug_d = 0 ; debug_d < min_score ; debug_d++)
 	{
-	    ASSERT (head [debug_d] == EMPTY) ;
+	    ASSERT (head [debug_d] == TRILINOS_CCOLAMD_EMPTY) ;
 	}
 #endif
 
@@ -2708,7 +2708,7 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 #ifndef NDEBUG
 	    for (col = 0 ; col <= n_col ; col++)
 	    {
-	        ASSERT (head [col] == EMPTY) ;
+	        ASSERT (head [col] == TRILINOS_CCOLAMD_EMPTY) ;
 	    }
 #endif
 
@@ -2724,7 +2724,7 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 		{
 		    DEBUG1 (("Column "ID" is dead\n", col)) ;
 		    /* count dense and null columns */
-		    if (Col [col].shared2.order != EMPTY)
+		    if (Col [col].shared2.order != TRILINOS_CCOLAMD_EMPTY)
 		    {
 			deadcol++ ;
 		    }
@@ -2741,16 +2741,16 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 		ASSERT (min_score <= n_col) ;
 		ASSERT (score >= 0) ;
 		ASSERT (score <= n_col) ;
-		ASSERT (head [score] >= EMPTY) ;
+		ASSERT (head [score] >= TRILINOS_CCOLAMD_EMPTY) ;
 
 		/* now add this column to dList at proper score location */
 		next_col = head [score] ;
-		Col [col].shared3.prev = EMPTY ;
+		Col [col].shared3.prev = TRILINOS_CCOLAMD_EMPTY ;
 		Col [col].shared4.degree_next = next_col ;
 
 		/* if there already was a column with the same score, set its */
 		/* previous pointer to this new column */
-		if (next_col != EMPTY)
+		if (next_col != TRILINOS_CCOLAMD_EMPTY)
 		{
 		    Col [next_col].shared3.prev = col ;
 		}
@@ -2786,7 +2786,7 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 
 	/* === Select pivot column, and order it ============================ */
 
-	while (head [min_score] == EMPTY && min_score < n_col)
+	while (head [min_score] == TRILINOS_CCOLAMD_EMPTY && min_score < n_col)
 	{
 	    min_score++ ;
 	}
@@ -2796,9 +2796,9 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 	ASSERT (pivot_col >= 0 && pivot_col <= n_col) ;
 	next_col = Col [pivot_col].shared4.degree_next ;
 	head [min_score] = next_col ;
-	if (next_col != EMPTY)
+	if (next_col != TRILINOS_CCOLAMD_EMPTY)
 	{
-	    Col [next_col].shared3.prev = EMPTY ;
+	    Col [next_col].shared3.prev = TRILINOS_CCOLAMD_EMPTY ;
 	}
 
 	ASSERT (COL_IS_ALIVE (pivot_col)) ;
@@ -2914,7 +2914,7 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 	    ASSERT (row >= 0 && row < n_row) ;
             if (ROW_IS_ALIVE (row))
             {
-                if (Row [row].front != EMPTY)
+                if (Row [row].front != TRILINOS_CCOLAMD_EMPTY)
                 {
                     /* This row represents a frontal matrix. */
                     /* Row [row].front is a child of current front */
@@ -2947,7 +2947,7 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 	else
 	{
 	    /* there is no pivot row, since it is of zero length */
-	    pivot_row = EMPTY ;
+	    pivot_row = TRILINOS_CCOLAMD_EMPTY ;
 	    ASSERT (pivot_row_length == 0) ;
 	}
 	ASSERT (Col [pivot_col].length > 0 || pivot_row_length == 0) ;
@@ -3007,8 +3007,8 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 			cur_score, prev_col, next_col)) ;
 		ASSERT (cur_score >= 0) ;
 		ASSERT (cur_score <= n_col) ;
-		ASSERT (cur_score >= EMPTY) ;
-		if (prev_col == EMPTY)
+		ASSERT (cur_score >= TRILINOS_CCOLAMD_EMPTY) ;
+		if (prev_col == TRILINOS_CCOLAMD_EMPTY)
 		{
 		    head [cur_score] = next_col ;
 		}
@@ -3016,7 +3016,7 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 		{
 		    Col [prev_col].shared4.degree_next = next_col ;
 		}
-		if (next_col != EMPTY)
+		if (next_col != TRILINOS_CCOLAMD_EMPTY)
 		{
 		    Col [next_col].shared3.prev = prev_col ;
 		}
@@ -3052,7 +3052,7 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 		{
 		    DEBUG3 (("aggressive absorption. Row: "ID"\n", row)) ;
 
-                    if (Row [row].front != EMPTY)
+                    if (Row [row].front != TRILINOS_CCOLAMD_EMPTY)
                     {
                         /* Row [row].front is a child of current front. */
                         child = Row [row].front ;
@@ -3176,7 +3176,7 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 		ASSERT (((Int) hash) <= n_col) ;
 
 		head_column = head [hash] ;
-		if (head_column > EMPTY)
+		if (head_column > TRILINOS_CCOLAMD_EMPTY)
 		{
 		    /* degree list "hash" is non-empty, use prev (shared3) of */
 		    /* first column in degree list as head of hash bucket */
@@ -3280,11 +3280,11 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 		ASSERT (min_score <= n_col) ;
 		ASSERT (cur_score >= 0) ;
 		ASSERT (cur_score <= n_col) ;
-		ASSERT (head [cur_score] >= EMPTY) ;
+		ASSERT (head [cur_score] >= TRILINOS_CCOLAMD_EMPTY) ;
 		next_col = head [cur_score] ;
 		Col [col].shared4.degree_next = next_col ;
-		Col [col].shared3.prev = EMPTY ;
-		if (next_col != EMPTY)
+		Col [col].shared3.prev = TRILINOS_CCOLAMD_EMPTY ;
+		if (next_col != TRILINOS_CCOLAMD_EMPTY)
 		{
 		    Col [next_col].shared3.prev = col ;
 		}
@@ -3294,8 +3294,8 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 	    }
 	    else
 	    {
-		Col [col].shared4.degree_next = EMPTY ;
-		Col [col].shared3.prev = EMPTY ;
+		Col [col].shared4.degree_next = TRILINOS_CCOLAMD_EMPTY ;
+		Col [col].shared3.prev = TRILINOS_CCOLAMD_EMPTY ;
 	    }
 	}
 
@@ -3316,7 +3316,7 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 	/* all cols */
 	Front_ncols [nfr] = pivot_col_thickness + pivot_row_degree ;
 
-	Front_parent [nfr] = EMPTY ;
+	Front_parent [nfr] = TRILINOS_CCOLAMD_EMPTY ;
 
 	pivot_row_thickness -= pivot_col_thickness ;
 	DEBUG1 (("Front "ID" Pivot_row_thickness after pivot cols elim: "ID"\n",
@@ -3346,7 +3346,7 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 		 Front_npivcol [nfr], Front_nrows [nfr], Front_ncols [nfr])) ;
 	DEBUG1 ((" cols:[ ")) ;
 	debug_d = 0 ;
-	for (col = Front_cols [nfr] ; col != EMPTY ; col = Col [col].nextcol)
+	for (col = Front_cols [nfr] ; col != TRILINOS_CCOLAMD_EMPTY ; col = Col [col].nextcol)
 	{
 		DEBUG1 ((" "ID, col)) ;
 		ASSERT (col >= 0 && col < n_col) ;
@@ -3453,7 +3453,7 @@ PRIVATE void detect_super_cols
 	/* === Get the first column in this hash bucket ===================== */
 
 	head_column = head [hash] ;
-	if (head_column > EMPTY)
+	if (head_column > TRILINOS_CCOLAMD_EMPTY)
 	{
 	    first_col = Col [head_column].shared3.headhash ;
 	}
@@ -3464,7 +3464,7 @@ PRIVATE void detect_super_cols
 
 	/* === Consider each column in the hash bucket ====================== */
 
-	for (super_c = first_col ; super_c != EMPTY ;
+	for (super_c = first_col ; super_c != TRILINOS_CCOLAMD_EMPTY ;
 	    super_c = Col [super_c].shared4.hash_next)
 	{
 	    ASSERT (COL_IS_ALIVE (super_c)) ;
@@ -3477,7 +3477,7 @@ PRIVATE void detect_super_cols
 	    /* === Compare super_c with all columns after it ================ */
 
 	    for (c = Col [super_c].shared4.hash_next ;
-		 c != EMPTY ; c = Col [c].shared4.hash_next)
+		 c != TRILINOS_CCOLAMD_EMPTY ; c = Col [c].shared4.hash_next)
 	    {
 		ASSERT (c != super_c) ;
 		ASSERT (COL_IS_ALIVE (c)) ;
@@ -3526,7 +3526,7 @@ PRIVATE void detect_super_cols
 		Col [c].shared1.parent = super_c ;
 		KILL_NON_PRINCIPAL_COL (c) ;
 		/* order c later, in order_children() */
-		Col [c].shared2.order = EMPTY ;
+		Col [c].shared2.order = TRILINOS_CCOLAMD_EMPTY ;
 		/* remove c from hash bucket */
 		Col [prev_c].shared4.hash_next = Col [c].shared4.hash_next ;
 
@@ -3545,15 +3545,15 @@ PRIVATE void detect_super_cols
 
 	/* === Empty this hash bucket ======================================= */
 
-	if (head_column > EMPTY)
+	if (head_column > TRILINOS_CCOLAMD_EMPTY)
 	{
 	    /* corresponding degree list "hash" is not empty */
-	    Col [head_column].shared3.headhash = EMPTY ;
+	    Col [head_column].shared3.headhash = TRILINOS_CCOLAMD_EMPTY ;
 	}
 	else
 	{
 	    /* corresponding degree list "hash" is empty */
-	    head [hash] = EMPTY ;
+	    head [hash] = TRILINOS_CCOLAMD_EMPTY ;
 	}
     }
 }
@@ -3900,8 +3900,8 @@ GLOBAL void TRILINOS_CCOLAMD_apply_order
     for (i = 0 ; i < nn ; i++)
     {
 	k = Order [i] ;
-	ASSERT (k >= EMPTY && k < nfr) ;
-	if (k != EMPTY)
+	ASSERT (k >= TRILINOS_CCOLAMD_EMPTY && k < nfr) ;
+	if (k != TRILINOS_CCOLAMD_EMPTY)
 	{
 	    Temp [k] = Front [i] ;
 	}
@@ -3937,7 +3937,7 @@ GLOBAL void TRILINOS_CCOLAMD_fsize
 
     for (j = 0 ; j < nn ; j++)
     {
-	Fsize [j] = EMPTY ;
+	Fsize [j] = TRILINOS_CCOLAMD_EMPTY ;
     }
 
     /* ---------------------------------------------------------------------- */
@@ -3961,7 +3961,7 @@ GLOBAL void TRILINOS_CCOLAMD_fsize
 		j, Npiv [j], frsize, parent)) ;
 	    Fsize [j] = MAX (Fsize [j], frsize) ;
 	    DEBUG1 (("Fsize [j = "ID"] = "ID"\n", j, Fsize [j])) ;
-	    if (parent != EMPTY)
+	    if (parent != TRILINOS_CCOLAMD_EMPTY)
 	    {
 		/* find the maximum frontsize of self and children */
 		ASSERT (Npiv [parent] > 0) ;
@@ -3986,7 +3986,7 @@ GLOBAL void TRILINOS_CCOLAMD_postorder
 (
     /* inputs, not modified on output: */
     Int nn,		/* nodes are in the range 0..nn-1 */
-    Int Parent [ ],	/* Parent [j] is the parent of j, or EMPTY if root */
+    Int Parent [ ],	/* Parent [j] is the parent of j, or TRILINOS_CCOLAMD_EMPTY if root */
     Int Nv [ ],		/* Nv [j] > 0 number of pivots represented by node j,
 			 * or zero if j is not a node. */
     Int Fsize [ ],	/* Fsize [j]: size of node j */
@@ -4008,8 +4008,8 @@ GLOBAL void TRILINOS_CCOLAMD_postorder
 
     for (j = 0 ; j < nn ; j++)
     {
-	Child [j] = EMPTY ;
-	Sibling [j] = EMPTY ;
+	Child [j] = TRILINOS_CCOLAMD_EMPTY ;
+	Sibling [j] = TRILINOS_CCOLAMD_EMPTY ;
     }
 
     /* --------------------------------------------------------------------- */
@@ -4022,7 +4022,7 @@ GLOBAL void TRILINOS_CCOLAMD_postorder
 	{
 	    /* this is an element */
 	    parent = Parent [j] ;
-	    if (parent != EMPTY)
+	    if (parent != TRILINOS_CCOLAMD_EMPTY)
 	    {
 		/* place the element in link list of the children its parent */
 		/* bigger elements will tend to be at the end of the list */
@@ -4051,7 +4051,7 @@ GLOBAL void TRILINOS_CCOLAMD_postorder
 		/* dump the link list of children */
 		nchild = 0 ;
 		DEBUG1 (("    Children: ")) ;
-		for (ff = Child [j] ; ff != EMPTY ; ff = Sibling [ff])
+		for (ff = Child [j] ; ff != TRILINOS_CCOLAMD_EMPTY ; ff = Sibling [ff])
 		{
 		    DEBUG1 ((ID" ", ff)) ;
 		    nchild++ ;
@@ -4071,14 +4071,14 @@ GLOBAL void TRILINOS_CCOLAMD_postorder
 
     for (i = 0 ; i < nn ; i++)
     {
-	if (Nv [i] > 0 && Child [i] != EMPTY)
+	if (Nv [i] > 0 && Child [i] != TRILINOS_CCOLAMD_EMPTY)
 	{
 
 #ifndef NDEBUG
 	    Int nchild ;
 	    DEBUG1 (("Before partial sort, element "ID"\n", i)) ;
 	    nchild = 0 ;
-	    for (f = Child [i] ; f != EMPTY ; f = Sibling [f])
+	    for (f = Child [i] ; f != TRILINOS_CCOLAMD_EMPTY ; f = Sibling [f])
 	    {
 		DEBUG1 (("      f: "ID"  size: "ID"\n", f, Fsize [f])) ;
 		nchild++ ;
@@ -4086,11 +4086,11 @@ GLOBAL void TRILINOS_CCOLAMD_postorder
 #endif
 
 	    /* find the biggest element in the child list */
-	    fprev = EMPTY ;
-	    maxfrsize = EMPTY ;
-	    bigfprev = EMPTY ;
-	    bigf = EMPTY ;
-	    for (f = Child [i] ; f != EMPTY ; f = Sibling [f])
+	    fprev = TRILINOS_CCOLAMD_EMPTY ;
+	    maxfrsize = TRILINOS_CCOLAMD_EMPTY ;
+	    bigfprev = TRILINOS_CCOLAMD_EMPTY ;
+	    bigf = TRILINOS_CCOLAMD_EMPTY ;
+	    for (f = Child [i] ; f != TRILINOS_CCOLAMD_EMPTY ; f = Sibling [f])
 	    {
 		frsize = Fsize [f] ;
 		if (frsize >= maxfrsize)
@@ -4108,11 +4108,11 @@ GLOBAL void TRILINOS_CCOLAMD_postorder
 	    DEBUG1 (("bigf "ID" maxfrsize "ID" bigfprev "ID" fnext "ID
 		" fprev " ID"\n", bigf, maxfrsize, bigfprev, fnext, fprev)) ;
 
-	    if (fnext != EMPTY)
+	    if (fnext != TRILINOS_CCOLAMD_EMPTY)
 	    {
-		/* if fnext is EMPTY then bigf is already at the end of list */
+		/* if fnext is TRILINOS_CCOLAMD_EMPTY then bigf is already at the end of list */
 
-		if (bigfprev == EMPTY)
+		if (bigfprev == TRILINOS_CCOLAMD_EMPTY)
 		{
 		    /* delete bigf from the element of the list */
 		    Child [i] = fnext ;
@@ -4124,13 +4124,13 @@ GLOBAL void TRILINOS_CCOLAMD_postorder
 		}
 
 		/* put bigf at the end of the list */
-		Sibling [bigf] = EMPTY ;
+		Sibling [bigf] = TRILINOS_CCOLAMD_EMPTY ;
 		Sibling [fprev] = bigf ;
 	    }
 
 #ifndef NDEBUG
 	    DEBUG1 (("After partial sort, element "ID"\n", i)) ;
-	    for (f = Child [i] ; f != EMPTY ; f = Sibling [f])
+	    for (f = Child [i] ; f != TRILINOS_CCOLAMD_EMPTY ; f = Sibling [f])
 	    {
 		DEBUG1 (("        "ID"  "ID"\n", f, Fsize [f])) ;
 		nchild-- ;
@@ -4145,14 +4145,14 @@ GLOBAL void TRILINOS_CCOLAMD_postorder
 
     for (i = 0 ; i < nn ; i++)
     {
-	Order [i] = EMPTY ;
+	Order [i] = TRILINOS_CCOLAMD_EMPTY ;
     }
 
     k = 0 ;
 
     for (i = 0 ; i < nn ; i++)
     {
-	if ((Parent [i] == EMPTY
+	if ((Parent [i] == TRILINOS_CCOLAMD_EMPTY
 	    || (CMEMBER (Front_cols [Parent [i]]) != CMEMBER (Front_cols [i])))
 	    && Nv [i] > 0)
 	{
@@ -4197,7 +4197,7 @@ GLOBAL Int TRILINOS_CCOLAMD_post_tree
 
     /* this is simple, but can cause stack overflow if nn is large */
     i = root ;
-    for (f = Child [i] ; f != EMPTY ; f = Sibling [f])
+    for (f = Child [i] ; f != TRILINOS_CCOLAMD_EMPTY ; f = Sibling [f])
     {
 	k = TRILINOS_CCOLAMD_post_tree (f, k, Child, Sibling, Order, Stack, nn) ;
     }
@@ -4219,18 +4219,18 @@ GLOBAL Int TRILINOS_CCOLAMD_post_tree
 	i = Stack [head] ;
 	DEBUG1 (("head of stack "ID" \n", i)) ;
 
-	if (Child [i] != EMPTY)
+	if (Child [i] != TRILINOS_CCOLAMD_EMPTY)
 	{
 	    /* the children of i are not yet ordered */
 	    /* push each child onto the stack in reverse order */
 	    /* so that small ones at the head of the list get popped first */
 	    /* and the biggest one at the end of the list gets popped last */
-	    for (f = Child [i] ; f != EMPTY ; f = Sibling [f])
+	    for (f = Child [i] ; f != TRILINOS_CCOLAMD_EMPTY ; f = Sibling [f])
 	    {
 		head++ ;
 	    }
 	    h = head ;
-	    for (f = Child [i] ; f != EMPTY ; f = Sibling [f])
+	    for (f = Child [i] ; f != TRILINOS_CCOLAMD_EMPTY ; f = Sibling [f])
 	    {
 		ASSERT (h > 0) ;
 		Stack [h--] = f ;
@@ -4239,7 +4239,7 @@ GLOBAL Int TRILINOS_CCOLAMD_post_tree
 	    ASSERT (Stack [h] == i) ;
 
 	    /* delete child list so that i gets ordered next time we see it */
-	    Child [i] = EMPTY ;
+	    Child [i] = TRILINOS_CCOLAMD_EMPTY ;
 	}
 	else
 	{
@@ -4409,13 +4409,13 @@ PRIVATE void debug_deg_lists
     for (deg = 0 ; deg <= n_col ; deg++)
     {
 	col = head [deg] ;
-	if (col == EMPTY)
+	if (col == TRILINOS_CCOLAMD_EMPTY)
 	{
 	    continue ;
 	}
 	DEBUG4 (("%d:", deg)) ;
-	ASSERT (Col [col].shared3.prev == EMPTY) ;
-	while (col != EMPTY)
+	ASSERT (Col [col].shared3.prev == TRILINOS_CCOLAMD_EMPTY) ;
+	while (col != TRILINOS_CCOLAMD_EMPTY)
 	{
 	    DEBUG4 ((" "ID"", col)) ;
 	    have += Col [col].shared1.thickness ;
@@ -4570,7 +4570,7 @@ PRIVATE void dump_super
 
     DEBUG1 ((" =[ ")) ;
     ncols = 0 ;
-    for (col = super_c ; col != EMPTY ; col = Col [col].nextcol)
+    for (col = super_c ; col != TRILINOS_CCOLAMD_EMPTY ; col = Col [col].nextcol)
     {
         DEBUG1 ((" "ID, col)) ;
         ASSERT (col >= 0 && col < n_col) ;
@@ -4578,7 +4578,7 @@ PRIVATE void dump_super
         {
             ASSERT (COL_IS_DEAD (col)) ;
         }
-        if (Col [col].nextcol == EMPTY)
+        if (Col [col].nextcol == TRILINOS_CCOLAMD_EMPTY)
         {
             ASSERT (col == Col [super_c].lastcol) ;
         }

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CCOLAMD/Source/trilinos_ccolamd_l.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CCOLAMD/Source/trilinos_ccolamd_l.c
@@ -754,7 +754,7 @@ typedef struct Trilinos_CColamd_Row_struct
 /* === basic definitions ==================================================== */
 /* ========================================================================== */
 
-#define EMPTY (-1)
+#define TRILINOS_CCOLAMDL_EMPTY (-1)
 #define MAX(a,b) (((a) > (b)) ? (a) : (b))
 #define MIN(a,b) (((a) < (b)) ? (a) : (b))
 
@@ -1555,7 +1555,7 @@ PUBLIC Int TRILINOS_CCOLAMD_2	    /* returns TRUE if successful, FALSE otherwise
     Int Front_cols [ ],		/* link list of pivot columns for each front */
     Int *p_nfr,			/* total number of frontal matrices */
     Int InFront [ ],		/* InFront [row] = f if the original row was
-				 * absorbed into front f.  EMPTY if the row was
+				 * absorbed into front f.  TRILINOS_CCOLAMDL_EMPTY if the row was
 				 * empty, dense, or not absorbed.  This array
 				 * has size n_row+1 */
     Int cmember [ ]		/* constraint set of A */
@@ -1833,8 +1833,8 @@ PUBLIC Int TRILINOS_CCOLAMD_2	    /* returns TRUE if successful, FALSE otherwise
     	Front_npivcol [col] = 0 ;
     	Front_nrows [col] = 0 ;
     	Front_ncols [col] = 0 ;
-    	Front_parent [col] = EMPTY ;
-    	Front_cols [col] = EMPTY ;
+    	Front_parent [col] = TRILINOS_CCOLAMDL_EMPTY ;
+    	Front_cols [col] = TRILINOS_CCOLAMDL_EMPTY ;
     }
 
     /* === Initialize scores, kill dense rows/columns ======================= */
@@ -1893,7 +1893,7 @@ PUBLIC Int TRILINOS_CCOLAMD_2	    /* returns TRUE if successful, FALSE otherwise
     for (i = 0 ; i < nfr ; i++)
     {
         parent = Front_parent [i] ;
-        if (parent != EMPTY)
+        if (parent != TRILINOS_CCOLAMDL_EMPTY)
         {
             Front_parent [i] = Front_order [parent] ;
         }
@@ -1903,8 +1903,8 @@ PUBLIC Int TRILINOS_CCOLAMD_2	    /* returns TRUE if successful, FALSE otherwise
     for (row = 0 ; row < n_row ; row++)
     {
         i = InFront [row] ;
-        ASSERT (i >= EMPTY && i < nfr) ;
-        if (i != EMPTY)
+        ASSERT (i >= TRILINOS_CCOLAMDL_EMPTY && i < nfr) ;
+        if (i != TRILINOS_CCOLAMDL_EMPTY)
         {
             InFront [row] = Front_order [i] ;
         }
@@ -1917,7 +1917,7 @@ PUBLIC Int TRILINOS_CCOLAMD_2	    /* returns TRUE if successful, FALSE otherwise
     /* use A [0..n_col-1] as inverse permutation */
     for (i = 0 ; i < n_col ; i++)
     {
-        A [i] = EMPTY ;
+        A [i] = TRILINOS_CCOLAMDL_EMPTY ;
     }
 
     k = 0 ;
@@ -1935,12 +1935,12 @@ PUBLIC Int TRILINOS_CCOLAMD_2	    /* returns TRUE if successful, FALSE otherwise
         }
         set1 = set2 ;
 
-        for (col = Front_cols [i] ; col != EMPTY ; col = Col [col].nextcol)
+        for (col = Front_cols [i] ; col != TRILINOS_CCOLAMDL_EMPTY ; col = Col [col].nextcol)
         {
             ASSERT (col >= 0 && col < n_col) ;
             DEBUG1 (("trilinos_ccolamd output ordering: k "ID" col "ID"\n", k, col)) ;
             p [k] = col ;
-            ASSERT (A [col] == EMPTY) ;
+            ASSERT (A [col] == TRILINOS_CCOLAMDL_EMPTY) ;
 
 	    cs = CMEMBER (col) ;
             ASSERT (k >= cset_start [cs] && k < cset_start [cs+1]) ;
@@ -1956,7 +1956,7 @@ PUBLIC Int TRILINOS_CCOLAMD_2	    /* returns TRUE if successful, FALSE otherwise
     {
         for (col = 0 ; col < n_col ; col++)
         {
-            if (A [col] == EMPTY)
+            if (A [col] == TRILINOS_CCOLAMDL_EMPTY)
             {
                 k = Col [col].shared2.order ;
 		cs = CMEMBER (col) ;
@@ -2087,9 +2087,9 @@ PRIVATE Int init_rows_cols	/* returns TRUE if OK, or FALSE otherwise */
 
 	Col [col].shared1.thickness = 1 ;
 	Col [col].shared2.score = 0 ;
-	Col [col].shared3.prev = EMPTY ;
-	Col [col].shared4.degree_next = EMPTY ;
-        Col [col].nextcol = EMPTY ;
+	Col [col].shared3.prev = TRILINOS_CCOLAMDL_EMPTY ;
+	Col [col].shared4.degree_next = TRILINOS_CCOLAMDL_EMPTY ;
+        Col [col].nextcol = TRILINOS_CCOLAMDL_EMPTY ;
         Col [col].lastcol = col ;
     }
 
@@ -2104,7 +2104,7 @@ PRIVATE Int init_rows_cols	/* returns TRUE if OK, or FALSE otherwise */
 	Row [row].length = 0 ;
 	Row [row].shared2.mark = -1 ;
         Row [row].thickness = 1 ;
-        Row [row].front = EMPTY ;
+        Row [row].front = TRILINOS_CCOLAMDL_EMPTY ;
     }
 
     for (col = 0 ; col < n_col ; col++)
@@ -2544,7 +2544,7 @@ PRIVATE void init_scoring
     /* clear the hash buckets */
     for (c = 0 ; c <= n_col ; c++)
     {
-	head [c] = EMPTY ;
+	head [c] = TRILINOS_CCOLAMDL_EMPTY ;
     }
 
 #ifndef NDEBUG
@@ -2670,7 +2670,7 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 
     for (row = 0 ; row < n_row ; row++)
     {
-        InFront [row] = EMPTY ;
+        InFront [row] = TRILINOS_CCOLAMDL_EMPTY ;
     }
 
     /* === Order the columns ================================================ */
@@ -2681,12 +2681,12 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 	/* make sure degree list isn't empty */
 	ASSERT (min_score >= 0) ;
 	ASSERT (min_score <= n_col) ;
-	ASSERT (head [min_score] >= EMPTY) ;
+	ASSERT (head [min_score] >= TRILINOS_CCOLAMDL_EMPTY) ;
 
 #ifndef NDEBUG
 	for (debug_d = 0 ; debug_d < min_score ; debug_d++)
 	{
-	    ASSERT (head [debug_d] == EMPTY) ;
+	    ASSERT (head [debug_d] == TRILINOS_CCOLAMDL_EMPTY) ;
 	}
 #endif
 
@@ -2711,7 +2711,7 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 #ifndef NDEBUG
 	    for (col = 0 ; col <= n_col ; col++)
 	    {
-	        ASSERT (head [col] == EMPTY) ;
+	        ASSERT (head [col] == TRILINOS_CCOLAMDL_EMPTY) ;
 	    }
 #endif
 
@@ -2727,7 +2727,7 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 		{
 		    DEBUG1 (("Column "ID" is dead\n", col)) ;
 		    /* count dense and null columns */
-		    if (Col [col].shared2.order != EMPTY)
+		    if (Col [col].shared2.order != TRILINOS_CCOLAMDL_EMPTY)
 		    {
 			deadcol++ ;
 		    }
@@ -2744,16 +2744,16 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 		ASSERT (min_score <= n_col) ;
 		ASSERT (score >= 0) ;
 		ASSERT (score <= n_col) ;
-		ASSERT (head [score] >= EMPTY) ;
+		ASSERT (head [score] >= TRILINOS_CCOLAMDL_EMPTY) ;
 
 		/* now add this column to dList at proper score location */
 		next_col = head [score] ;
-		Col [col].shared3.prev = EMPTY ;
+		Col [col].shared3.prev = TRILINOS_CCOLAMDL_EMPTY ;
 		Col [col].shared4.degree_next = next_col ;
 
 		/* if there already was a column with the same score, set its */
 		/* previous pointer to this new column */
-		if (next_col != EMPTY)
+		if (next_col != TRILINOS_CCOLAMDL_EMPTY)
 		{
 		    Col [next_col].shared3.prev = col ;
 		}
@@ -2789,7 +2789,7 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 
 	/* === Select pivot column, and order it ============================ */
 
-	while (head [min_score] == EMPTY && min_score < n_col)
+	while (head [min_score] == TRILINOS_CCOLAMDL_EMPTY && min_score < n_col)
 	{
 	    min_score++ ;
 	}
@@ -2799,9 +2799,9 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 	ASSERT (pivot_col >= 0 && pivot_col <= n_col) ;
 	next_col = Col [pivot_col].shared4.degree_next ;
 	head [min_score] = next_col ;
-	if (next_col != EMPTY)
+	if (next_col != TRILINOS_CCOLAMDL_EMPTY)
 	{
-	    Col [next_col].shared3.prev = EMPTY ;
+	    Col [next_col].shared3.prev = TRILINOS_CCOLAMDL_EMPTY ;
 	}
 
 	ASSERT (COL_IS_ALIVE (pivot_col)) ;
@@ -2917,7 +2917,7 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 	    ASSERT (row >= 0 && row < n_row) ;
             if (ROW_IS_ALIVE (row))
             {
-                if (Row [row].front != EMPTY)
+                if (Row [row].front != TRILINOS_CCOLAMDL_EMPTY)
                 {
                     /* This row represents a frontal matrix. */
                     /* Row [row].front is a child of current front */
@@ -2950,7 +2950,7 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 	else
 	{
 	    /* there is no pivot row, since it is of zero length */
-	    pivot_row = EMPTY ;
+	    pivot_row = TRILINOS_CCOLAMDL_EMPTY ;
 	    ASSERT (pivot_row_length == 0) ;
 	}
 	ASSERT (Col [pivot_col].length > 0 || pivot_row_length == 0) ;
@@ -3010,8 +3010,8 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 			cur_score, prev_col, next_col)) ;
 		ASSERT (cur_score >= 0) ;
 		ASSERT (cur_score <= n_col) ;
-		ASSERT (cur_score >= EMPTY) ;
-		if (prev_col == EMPTY)
+		ASSERT (cur_score >= TRILINOS_CCOLAMDL_EMPTY) ;
+		if (prev_col == TRILINOS_CCOLAMDL_EMPTY)
 		{
 		    head [cur_score] = next_col ;
 		}
@@ -3019,7 +3019,7 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 		{
 		    Col [prev_col].shared4.degree_next = next_col ;
 		}
-		if (next_col != EMPTY)
+		if (next_col != TRILINOS_CCOLAMDL_EMPTY)
 		{
 		    Col [next_col].shared3.prev = prev_col ;
 		}
@@ -3055,7 +3055,7 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 		{
 		    DEBUG3 (("aggressive absorption. Row: "ID"\n", row)) ;
 
-                    if (Row [row].front != EMPTY)
+                    if (Row [row].front != TRILINOS_CCOLAMDL_EMPTY)
                     {
                         /* Row [row].front is a child of current front. */
                         child = Row [row].front ;
@@ -3179,7 +3179,7 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 		ASSERT (((Int) hash) <= n_col) ;
 
 		head_column = head [hash] ;
-		if (head_column > EMPTY)
+		if (head_column > TRILINOS_CCOLAMDL_EMPTY)
 		{
 		    /* degree list "hash" is non-empty, use prev (shared3) of */
 		    /* first column in degree list as head of hash bucket */
@@ -3283,11 +3283,11 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 		ASSERT (min_score <= n_col) ;
 		ASSERT (cur_score >= 0) ;
 		ASSERT (cur_score <= n_col) ;
-		ASSERT (head [cur_score] >= EMPTY) ;
+		ASSERT (head [cur_score] >= TRILINOS_CCOLAMDL_EMPTY) ;
 		next_col = head [cur_score] ;
 		Col [col].shared4.degree_next = next_col ;
-		Col [col].shared3.prev = EMPTY ;
-		if (next_col != EMPTY)
+		Col [col].shared3.prev = TRILINOS_CCOLAMDL_EMPTY ;
+		if (next_col != TRILINOS_CCOLAMDL_EMPTY)
 		{
 		    Col [next_col].shared3.prev = col ;
 		}
@@ -3297,8 +3297,8 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 	    }
 	    else
 	    {
-		Col [col].shared4.degree_next = EMPTY ;
-		Col [col].shared3.prev = EMPTY ;
+		Col [col].shared4.degree_next = TRILINOS_CCOLAMDL_EMPTY ;
+		Col [col].shared3.prev = TRILINOS_CCOLAMDL_EMPTY ;
 	    }
 	}
 
@@ -3319,7 +3319,7 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 	/* all cols */
 	Front_ncols [nfr] = pivot_col_thickness + pivot_row_degree ;
 
-	Front_parent [nfr] = EMPTY ;
+	Front_parent [nfr] = TRILINOS_CCOLAMDL_EMPTY ;
 
 	pivot_row_thickness -= pivot_col_thickness ;
 	DEBUG1 (("Front "ID" Pivot_row_thickness after pivot cols elim: "ID"\n",
@@ -3349,7 +3349,7 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 		 Front_npivcol [nfr], Front_nrows [nfr], Front_ncols [nfr])) ;
 	DEBUG1 ((" cols:[ ")) ;
 	debug_d = 0 ;
-	for (col = Front_cols [nfr] ; col != EMPTY ; col = Col [col].nextcol)
+	for (col = Front_cols [nfr] ; col != TRILINOS_CCOLAMDL_EMPTY ; col = Col [col].nextcol)
 	{
 		DEBUG1 ((" "ID, col)) ;
 		ASSERT (col >= 0 && col < n_col) ;
@@ -3456,7 +3456,7 @@ PRIVATE void detect_super_cols
 	/* === Get the first column in this hash bucket ===================== */
 
 	head_column = head [hash] ;
-	if (head_column > EMPTY)
+	if (head_column > TRILINOS_CCOLAMDL_EMPTY)
 	{
 	    first_col = Col [head_column].shared3.headhash ;
 	}
@@ -3467,7 +3467,7 @@ PRIVATE void detect_super_cols
 
 	/* === Consider each column in the hash bucket ====================== */
 
-	for (super_c = first_col ; super_c != EMPTY ;
+	for (super_c = first_col ; super_c != TRILINOS_CCOLAMDL_EMPTY ;
 	    super_c = Col [super_c].shared4.hash_next)
 	{
 	    ASSERT (COL_IS_ALIVE (super_c)) ;
@@ -3480,7 +3480,7 @@ PRIVATE void detect_super_cols
 	    /* === Compare super_c with all columns after it ================ */
 
 	    for (c = Col [super_c].shared4.hash_next ;
-		 c != EMPTY ; c = Col [c].shared4.hash_next)
+		 c != TRILINOS_CCOLAMDL_EMPTY ; c = Col [c].shared4.hash_next)
 	    {
 		ASSERT (c != super_c) ;
 		ASSERT (COL_IS_ALIVE (c)) ;
@@ -3529,7 +3529,7 @@ PRIVATE void detect_super_cols
 		Col [c].shared1.parent = super_c ;
 		KILL_NON_PRINCIPAL_COL (c) ;
 		/* order c later, in order_children() */
-		Col [c].shared2.order = EMPTY ;
+		Col [c].shared2.order = TRILINOS_CCOLAMDL_EMPTY ;
 		/* remove c from hash bucket */
 		Col [prev_c].shared4.hash_next = Col [c].shared4.hash_next ;
 
@@ -3548,15 +3548,15 @@ PRIVATE void detect_super_cols
 
 	/* === Empty this hash bucket ======================================= */
 
-	if (head_column > EMPTY)
+	if (head_column > TRILINOS_CCOLAMDL_EMPTY)
 	{
 	    /* corresponding degree list "hash" is not empty */
-	    Col [head_column].shared3.headhash = EMPTY ;
+	    Col [head_column].shared3.headhash = TRILINOS_CCOLAMDL_EMPTY ;
 	}
 	else
 	{
 	    /* corresponding degree list "hash" is empty */
-	    head [hash] = EMPTY ;
+	    head [hash] = TRILINOS_CCOLAMDL_EMPTY ;
 	}
     }
 }
@@ -3903,8 +3903,8 @@ GLOBAL void TRILINOS_CCOLAMD_apply_order
     for (i = 0 ; i < nn ; i++)
     {
 	k = Order [i] ;
-	ASSERT (k >= EMPTY && k < nfr) ;
-	if (k != EMPTY)
+	ASSERT (k >= TRILINOS_CCOLAMDL_EMPTY && k < nfr) ;
+	if (k != TRILINOS_CCOLAMDL_EMPTY)
 	{
 	    Temp [k] = Front [i] ;
 	}
@@ -3940,7 +3940,7 @@ GLOBAL void TRILINOS_CCOLAMD_fsize
 
     for (j = 0 ; j < nn ; j++)
     {
-	Fsize [j] = EMPTY ;
+	Fsize [j] = TRILINOS_CCOLAMDL_EMPTY ;
     }
 
     /* ---------------------------------------------------------------------- */
@@ -3964,7 +3964,7 @@ GLOBAL void TRILINOS_CCOLAMD_fsize
 		j, Npiv [j], frsize, parent)) ;
 	    Fsize [j] = MAX (Fsize [j], frsize) ;
 	    DEBUG1 (("Fsize [j = "ID"] = "ID"\n", j, Fsize [j])) ;
-	    if (parent != EMPTY)
+	    if (parent != TRILINOS_CCOLAMDL_EMPTY)
 	    {
 		/* find the maximum frontsize of self and children */
 		ASSERT (Npiv [parent] > 0) ;
@@ -3989,7 +3989,7 @@ GLOBAL void TRILINOS_CCOLAMD_postorder
 (
     /* inputs, not modified on output: */
     Int nn,		/* nodes are in the range 0..nn-1 */
-    Int Parent [ ],	/* Parent [j] is the parent of j, or EMPTY if root */
+    Int Parent [ ],	/* Parent [j] is the parent of j, or TRILINOS_CCOLAMDL_EMPTY if root */
     Int Nv [ ],		/* Nv [j] > 0 number of pivots represented by node j,
 			 * or zero if j is not a node. */
     Int Fsize [ ],	/* Fsize [j]: size of node j */
@@ -4011,8 +4011,8 @@ GLOBAL void TRILINOS_CCOLAMD_postorder
 
     for (j = 0 ; j < nn ; j++)
     {
-	Child [j] = EMPTY ;
-	Sibling [j] = EMPTY ;
+	Child [j] = TRILINOS_CCOLAMDL_EMPTY ;
+	Sibling [j] = TRILINOS_CCOLAMDL_EMPTY ;
     }
 
     /* --------------------------------------------------------------------- */
@@ -4025,7 +4025,7 @@ GLOBAL void TRILINOS_CCOLAMD_postorder
 	{
 	    /* this is an element */
 	    parent = Parent [j] ;
-	    if (parent != EMPTY)
+	    if (parent != TRILINOS_CCOLAMDL_EMPTY)
 	    {
 		/* place the element in link list of the children its parent */
 		/* bigger elements will tend to be at the end of the list */
@@ -4054,7 +4054,7 @@ GLOBAL void TRILINOS_CCOLAMD_postorder
 		/* dump the link list of children */
 		nchild = 0 ;
 		DEBUG1 (("    Children: ")) ;
-		for (ff = Child [j] ; ff != EMPTY ; ff = Sibling [ff])
+		for (ff = Child [j] ; ff != TRILINOS_CCOLAMDL_EMPTY ; ff = Sibling [ff])
 		{
 		    DEBUG1 ((ID" ", ff)) ;
 		    nchild++ ;
@@ -4074,14 +4074,14 @@ GLOBAL void TRILINOS_CCOLAMD_postorder
 
     for (i = 0 ; i < nn ; i++)
     {
-	if (Nv [i] > 0 && Child [i] != EMPTY)
+	if (Nv [i] > 0 && Child [i] != TRILINOS_CCOLAMDL_EMPTY)
 	{
 
 #ifndef NDEBUG
 	    Int nchild ;
 	    DEBUG1 (("Before partial sort, element "ID"\n", i)) ;
 	    nchild = 0 ;
-	    for (f = Child [i] ; f != EMPTY ; f = Sibling [f])
+	    for (f = Child [i] ; f != TRILINOS_CCOLAMDL_EMPTY ; f = Sibling [f])
 	    {
 		DEBUG1 (("      f: "ID"  size: "ID"\n", f, Fsize [f])) ;
 		nchild++ ;
@@ -4089,11 +4089,11 @@ GLOBAL void TRILINOS_CCOLAMD_postorder
 #endif
 
 	    /* find the biggest element in the child list */
-	    fprev = EMPTY ;
-	    maxfrsize = EMPTY ;
-	    bigfprev = EMPTY ;
-	    bigf = EMPTY ;
-	    for (f = Child [i] ; f != EMPTY ; f = Sibling [f])
+	    fprev = TRILINOS_CCOLAMDL_EMPTY ;
+	    maxfrsize = TRILINOS_CCOLAMDL_EMPTY ;
+	    bigfprev = TRILINOS_CCOLAMDL_EMPTY ;
+	    bigf = TRILINOS_CCOLAMDL_EMPTY ;
+	    for (f = Child [i] ; f != TRILINOS_CCOLAMDL_EMPTY ; f = Sibling [f])
 	    {
 		frsize = Fsize [f] ;
 		if (frsize >= maxfrsize)
@@ -4111,11 +4111,11 @@ GLOBAL void TRILINOS_CCOLAMD_postorder
 	    DEBUG1 (("bigf "ID" maxfrsize "ID" bigfprev "ID" fnext "ID
 		" fprev " ID"\n", bigf, maxfrsize, bigfprev, fnext, fprev)) ;
 
-	    if (fnext != EMPTY)
+	    if (fnext != TRILINOS_CCOLAMDL_EMPTY)
 	    {
-		/* if fnext is EMPTY then bigf is already at the end of list */
+		/* if fnext is TRILINOS_CCOLAMDL_EMPTY then bigf is already at the end of list */
 
-		if (bigfprev == EMPTY)
+		if (bigfprev == TRILINOS_CCOLAMDL_EMPTY)
 		{
 		    /* delete bigf from the element of the list */
 		    Child [i] = fnext ;
@@ -4127,13 +4127,13 @@ GLOBAL void TRILINOS_CCOLAMD_postorder
 		}
 
 		/* put bigf at the end of the list */
-		Sibling [bigf] = EMPTY ;
+		Sibling [bigf] = TRILINOS_CCOLAMDL_EMPTY ;
 		Sibling [fprev] = bigf ;
 	    }
 
 #ifndef NDEBUG
 	    DEBUG1 (("After partial sort, element "ID"\n", i)) ;
-	    for (f = Child [i] ; f != EMPTY ; f = Sibling [f])
+	    for (f = Child [i] ; f != TRILINOS_CCOLAMDL_EMPTY ; f = Sibling [f])
 	    {
 		DEBUG1 (("        "ID"  "ID"\n", f, Fsize [f])) ;
 		nchild-- ;
@@ -4148,14 +4148,14 @@ GLOBAL void TRILINOS_CCOLAMD_postorder
 
     for (i = 0 ; i < nn ; i++)
     {
-	Order [i] = EMPTY ;
+	Order [i] = TRILINOS_CCOLAMDL_EMPTY ;
     }
 
     k = 0 ;
 
     for (i = 0 ; i < nn ; i++)
     {
-	if ((Parent [i] == EMPTY
+	if ((Parent [i] == TRILINOS_CCOLAMDL_EMPTY
 	    || (CMEMBER (Front_cols [Parent [i]]) != CMEMBER (Front_cols [i])))
 	    && Nv [i] > 0)
 	{
@@ -4200,7 +4200,7 @@ GLOBAL Int TRILINOS_CCOLAMD_post_tree
 
     /* this is simple, but can cause stack overflow if nn is large */
     i = root ;
-    for (f = Child [i] ; f != EMPTY ; f = Sibling [f])
+    for (f = Child [i] ; f != TRILINOS_CCOLAMDL_EMPTY ; f = Sibling [f])
     {
 	k = TRILINOS_CCOLAMD_post_tree (f, k, Child, Sibling, Order, Stack, nn) ;
     }
@@ -4222,18 +4222,18 @@ GLOBAL Int TRILINOS_CCOLAMD_post_tree
 	i = Stack [head] ;
 	DEBUG1 (("head of stack "ID" \n", i)) ;
 
-	if (Child [i] != EMPTY)
+	if (Child [i] != TRILINOS_CCOLAMDL_EMPTY)
 	{
 	    /* the children of i are not yet ordered */
 	    /* push each child onto the stack in reverse order */
 	    /* so that small ones at the head of the list get popped first */
 	    /* and the biggest one at the end of the list gets popped last */
-	    for (f = Child [i] ; f != EMPTY ; f = Sibling [f])
+	    for (f = Child [i] ; f != TRILINOS_CCOLAMDL_EMPTY ; f = Sibling [f])
 	    {
 		head++ ;
 	    }
 	    h = head ;
-	    for (f = Child [i] ; f != EMPTY ; f = Sibling [f])
+	    for (f = Child [i] ; f != TRILINOS_CCOLAMDL_EMPTY ; f = Sibling [f])
 	    {
 		ASSERT (h > 0) ;
 		Stack [h--] = f ;
@@ -4242,7 +4242,7 @@ GLOBAL Int TRILINOS_CCOLAMD_post_tree
 	    ASSERT (Stack [h] == i) ;
 
 	    /* delete child list so that i gets ordered next time we see it */
-	    Child [i] = EMPTY ;
+	    Child [i] = TRILINOS_CCOLAMDL_EMPTY ;
 	}
 	else
 	{
@@ -4412,13 +4412,13 @@ PRIVATE void debug_deg_lists
     for (deg = 0 ; deg <= n_col ; deg++)
     {
 	col = head [deg] ;
-	if (col == EMPTY)
+	if (col == TRILINOS_CCOLAMDL_EMPTY)
 	{
 	    continue ;
 	}
 	DEBUG4 (("%d:", deg)) ;
-	ASSERT (Col [col].shared3.prev == EMPTY) ;
-	while (col != EMPTY)
+	ASSERT (Col [col].shared3.prev == TRILINOS_CCOLAMDL_EMPTY) ;
+	while (col != TRILINOS_CCOLAMDL_EMPTY)
 	{
 	    DEBUG4 ((" "ID"", col)) ;
 	    have += Col [col].shared1.thickness ;
@@ -4573,7 +4573,7 @@ PRIVATE void dump_super
 
     DEBUG1 ((" =[ ")) ;
     ncols = 0 ;
-    for (col = super_c ; col != EMPTY ; col = Col [col].nextcol)
+    for (col = super_c ; col != TRILINOS_CCOLAMDL_EMPTY ; col = Col [col].nextcol)
     {
         DEBUG1 ((" "ID, col)) ;
         ASSERT (col >= 0 && col < n_col) ;
@@ -4581,7 +4581,7 @@ PRIVATE void dump_super
         {
             ASSERT (COL_IS_DEAD (col)) ;
         }
-        if (Col [col].nextcol == EMPTY)
+        if (Col [col].nextcol == TRILINOS_CCOLAMDL_EMPTY)
         {
             ASSERT (col == Col [super_c].lastcol) ;
         }

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Check/amesos_cholmod_check.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Check/amesos_cholmod_check.c
@@ -270,13 +270,13 @@ static int check_common
     P3 ("    sizeof(BLAS_INT): %d (integer used in the BLAS)\n",
 	    (int) sizeof (BLAS_INT)) ;
 
-    if (Common->fl != EMPTY)
+    if (Common->fl != TRILINOS_CHOLMOD_EMPTY)
     {
 	P2 ("%s", "  Results from most recent analysis:\n") ;
 	P2 ("    Cholesky flop count: %.5g\n", Common->fl) ;
 	P2 ("    Nonzeros in L:       %.5g\n", Common->lnz) ;
     }
-    if (Common->modfl != EMPTY)
+    if (Common->modfl != TRILINOS_CHOLMOD_EMPTY)
     {
 	P2 ("    Update/downdate flop count: %.5g\n", Common->modfl) ;
     }
@@ -428,8 +428,8 @@ static int check_common
 	    }
 	}
 
-	if (fl  != EMPTY) P3 ("        flop count: %.5g\n", fl) ;
-	if (lnz != EMPTY) P3 ("        nnz(L):     %.5g\n", lnz) ;
+	if (fl  != TRILINOS_CHOLMOD_EMPTY) P3 ("        flop count: %.5g\n", fl) ;
+	if (lnz != TRILINOS_CHOLMOD_EMPTY) P3 ("        nnz(L):     %.5g\n", lnz) ;
     }
 
     /* backup AMD results, if any */
@@ -439,8 +439,8 @@ static int check_common
 	P3 ("%s", "AMD (or TRILINOS_COLAMD if factorizing AA')\n") ;
 	fl = Common->method [nmethods].fl ;
 	lnz = Common->method [nmethods].lnz ;
-	if (fl  != EMPTY) P3 ("        AMD flop count: %.5g\n", fl) ;
-	if (lnz != EMPTY) P3 ("        AMD nnz(L):     %.5g\n", lnz) ;
+	if (fl  != TRILINOS_CHOLMOD_EMPTY) P3 ("        AMD flop count: %.5g\n", fl) ;
+	if (lnz != TRILINOS_CHOLMOD_EMPTY) P3 ("        AMD nnz(L):     %.5g\n", lnz) ;
     }
 
     /* ---------------------------------------------------------------------- */
@@ -535,7 +535,7 @@ static int check_common
 	}
 	for (i = 0 ; i <= nrow ; i++)
 	{
-	    if (Head [i] != EMPTY)
+	    if (Head [i] != TRILINOS_CHOLMOD_EMPTY)
 	    {
 		PRINT0 (("Head ["ID"] = "ID",\n", i, Head [i])) ;
 		ERR ("workspace corrupted (Head)") ;
@@ -759,7 +759,7 @@ static UF_long check_sparse
 	}
 	for (i = 0 ; i < nrow ; i++)
 	{
-	    Wi [i] = EMPTY ;
+	    Wi [i] = TRILINOS_CHOLMOD_EMPTY ;
 	}
     }
 
@@ -805,7 +805,7 @@ static UF_long check_sparse
 	{
 	    ERR ("nz invalid") ;
 	}
-	ilast = EMPTY ;
+	ilast = TRILINOS_CHOLMOD_EMPTY ;
 
 	for ( ; p < pend ; p++)
 	{
@@ -1333,7 +1333,7 @@ int CHOLMOD(print_perm)
 /* ========================================================================== */
 
 /* Ensure that Parent is a valid elimination tree of nodes 0 to n-1.
- * If j is a root of the tree then Parent [j] is EMPTY (-1).
+ * If j is a root of the tree then Parent [j] is TRILINOS_CHOLMOD_EMPTY (-1).
  *
  * NOTE: this check will fail if applied to the component tree (CParent) in
  * cholmod_nested_dissection, unless it has been postordered and renumbered.
@@ -1381,7 +1381,7 @@ static int check_parent
 	p = Parent [j] ;
 	P4 ("  "I8":", j) ;
 	P4 (" "ID"\n", p) ;
-	if (!(p == EMPTY || p > j))
+	if (!(p == TRILINOS_CHOLMOD_EMPTY || p > j))
 	{
 	    ERR ("invalid") ;
 	}
@@ -1729,7 +1729,7 @@ static int check_factor
 	head = n+1 ;
 	tail = n ;
 	j = head ;
-	jprev = EMPTY ;
+	jprev = TRILINOS_CHOLMOD_EMPTY ;
 	count = 0 ;
 	for ( ; ; )
 	{
@@ -1753,7 +1753,7 @@ static int check_factor
 	    jprev = j ;
 	    j = jnext ;
 	}
-	if (Lnext [tail] != EMPTY || count != n+2)
+	if (Lnext [tail] != TRILINOS_CHOLMOD_EMPTY || count != n+2)
 	{
 	    ERR ("invalid link list") ;
 	}
@@ -1807,7 +1807,7 @@ static int check_factor
 	    {
 		ERR ("invalid: L->x missing") ;
 	    }
-	    if (Ls [0] == EMPTY)
+	    if (Ls [0] == TRILINOS_CHOLMOD_EMPTY)
 	    {
 		ERR ("invalid: L->s not defined") ;
 	    }
@@ -1816,7 +1816,7 @@ static int check_factor
 	else
 	{
 	    /* symbolic supernodal factor, but only if it has been computed */
-	    examine_super = (Ls [0] != EMPTY) ;
+	    examine_super = (Ls [0] != TRILINOS_CHOLMOD_EMPTY) ;
 	}
 
 	if (examine_super)
@@ -2199,7 +2199,7 @@ void CHOLMOD(dump_init) (char *s, cholmod_common *Common)
 /* === cholmod_dump_sparse ================================================== */
 /* ========================================================================== */
 
-UF_long CHOLMOD(dump_sparse)	/* returns nnz (diag (A)) or EMPTY if error */
+UF_long CHOLMOD(dump_sparse)	/* returns nnz (diag (A)) or TRILINOS_CHOLMOD_EMPTY if error */
 (
     cholmod_sparse *A,
     char *name,
@@ -2221,7 +2221,7 @@ UF_long CHOLMOD(dump_sparse)	/* returns nnz (diag (A)) or EMPTY if error */
     Wi = malloc (MAX (1, A->nrow) * sizeof (Int)) ;
     ok = check_sparse (Wi, CHOLMOD(dump), name, A, &nnzdiag, Common) ;
     if (Wi != NULL) free (Wi) ;
-    return (ok ? nnzdiag : EMPTY) ;
+    return (ok ? nnzdiag : TRILINOS_CHOLMOD_EMPTY) ;
 }
 
 
@@ -2602,7 +2602,7 @@ int CHOLMOD(dump_work) (int flag, int head, UF_long wsize,
     {
 	for (k = 0 ; k < nrow ; k++)
 	{
-	    if (Head [k] != EMPTY)
+	    if (Head [k] != TRILINOS_CHOLMOD_EMPTY)
 	    {
 		PRINT0 (("Head invalid, Head ["ID"] = "ID"\n", k, Head [k])) ;
 		ASSERT (0) ;

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Cholesky/amesos_cholmod_amd.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Cholesky/amesos_cholmod_amd.c
@@ -205,7 +205,7 @@ int CHOLMOD(amd)
     CHOLMOD(free_sparse) (&C, Common) ;
     for (j = 0 ; j <= n ; j++)
     {
-	Head [j] = EMPTY ;
+	Head [j] = TRILINOS_CHOLMOD_EMPTY ;
     }
     return (TRUE) ;
 }

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Cholesky/amesos_cholmod_analyze.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Cholesky/amesos_cholmod_analyze.c
@@ -406,7 +406,7 @@ cholmod_factor *CHOLMOD(analyze_p)
     RETURN_IF_XTYPE_INVALID (A, CHOLMOD_PATTERN, CHOLMOD_ZOMPLEX, NULL) ;
     Common->status = CHOLMOD_OK ;
     status = CHOLMOD_OK ;
-    Common->selected = EMPTY ;
+    Common->selected = TRILINOS_CHOLMOD_EMPTY ;
     Common->called_nd = FALSE ;
 
     /* ---------------------------------------------------------------------- */
@@ -421,7 +421,7 @@ cholmod_factor *CHOLMOD(analyze_p)
     /* set the default strategy */
     /* ---------------------------------------------------------------------- */
 
-    lnz_best = (double) EMPTY ;
+    lnz_best = (double) TRILINOS_CHOLMOD_EMPTY ;
     skip_best = FALSE ;
     nmethods = MIN (Common->nmethods, CHOLMOD_MAXMETHODS) ;
     nmethods = MAX (0, nmethods) ;
@@ -516,7 +516,7 @@ cholmod_factor *CHOLMOD(analyze_p)
     }
     Lperm = L->Perm ;
     Lcolcount = L->ColCount ;
-    Common->anz = EMPTY ;
+    Common->anz = TRILINOS_CHOLMOD_EMPTY ;
 
     /* ---------------------------------------------------------------------- */
     /* try all the requested ordering options and backup to AMD if needed */
@@ -532,14 +532,14 @@ cholmod_factor *CHOLMOD(analyze_p)
 	/* determine the method to try */
 	/* ------------------------------------------------------------------ */
 
-	Common->fl = EMPTY ;
-	Common->lnz = EMPTY ;
+	Common->fl = TRILINOS_CHOLMOD_EMPTY ;
+	Common->lnz = TRILINOS_CHOLMOD_EMPTY ;
 	skip_analysis = FALSE ;
 
 	if (method == nmethods)
 	{
 	    /* All methods failed: backup to AMD */
-	    if (Common->selected == EMPTY && !default_strategy)
+	    if (Common->selected == TRILINOS_CHOLMOD_EMPTY && !default_strategy)
 	    {
 		PRINT1 (("All methods requested failed: backup to AMD\n")) ;
 		ordering = CHOLMOD_AMD ;
@@ -712,7 +712,7 @@ cholmod_factor *CHOLMOD(analyze_p)
 	/* ------------------------------------------------------------------ */
 
 	/* fl.pt. compare, but lnz can never be NaN */
-	if (Common->selected == EMPTY || Common->lnz < lnz_best)
+	if (Common->selected == TRILINOS_CHOLMOD_EMPTY || Common->lnz < lnz_best)
 	{
 	    Common->selected = method ;
 	    PRINT1 (("this is best so far, method "ID"\n", method)) ;
@@ -768,7 +768,7 @@ cholmod_factor *CHOLMOD(analyze_p)
     /* return if no ordering method succeeded */
     /* ---------------------------------------------------------------------- */
 
-    if (Common->selected == EMPTY)
+    if (Common->selected == TRILINOS_CHOLMOD_EMPTY)
     {
 	/* All methods failed.  
 	 * If two or more methods failed, they may have failed for different
@@ -842,7 +842,7 @@ cholmod_factor *CHOLMOD(analyze_p)
 	    {
 		oldchild = Post [newchild] ;
 		oldparent = Lparent [oldchild] ;
-		newparent = (oldparent == EMPTY) ? EMPTY : InvPost [oldparent] ;
+		newparent = (oldparent == TRILINOS_CHOLMOD_EMPTY) ? TRILINOS_CHOLMOD_EMPTY : InvPost [oldparent] ;
 		Wi [newchild] = newparent ;
 	    }
 	    for (k = 0 ; k < n ; k++)

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Cholesky/amesos_cholmod_etree.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Cholesky/amesos_cholmod_etree.c
@@ -65,7 +65,7 @@ static void amesos_update_etree
 	}
 	/* perform path compression */
 	Ancestor [k] = i ;
-	if (a == EMPTY)
+	if (a == TRILINOS_CHOLMOD_EMPTY)
 	{
 	    /* final ancestor undefined; this is a new edge in the tree */
 	    Parent [k] = i ;
@@ -144,8 +144,8 @@ int CHOLMOD(etree)
 
     for (j = 0 ; j < ncol ; j++)
     {
-	Parent [j] = EMPTY ;
-	Ancestor [j] = EMPTY ;
+	Parent [j] = TRILINOS_CHOLMOD_EMPTY ;
+	Ancestor [j] = TRILINOS_CHOLMOD_EMPTY ;
     }
 
     /* ---------------------------------------------------------------------- */
@@ -185,7 +185,7 @@ int CHOLMOD(etree)
 	Prev = Iwork + ncol ;	/* size nrow (i/i/l) */
 	for (i = 0 ; i < nrow ; i++)
 	{
-	    Prev [i] = EMPTY ;
+	    Prev [i] = TRILINOS_CHOLMOD_EMPTY ;
 	}
 	for (j = 0 ; j < ncol ; j++)
 	{
@@ -201,7 +201,7 @@ int CHOLMOD(etree)
 		 * (jprev,j) are considered, where jprev<j */
 		i = Ai [p] ;
 		jprev = Prev [i] ;
-		if (jprev != EMPTY)
+		if (jprev != TRILINOS_CHOLMOD_EMPTY)
 		{
 		    amesos_update_etree (jprev, j, Parent, Ancestor) ;
 		}

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Cholesky/amesos_cholmod_l_amd.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Cholesky/amesos_cholmod_l_amd.c
@@ -208,7 +208,7 @@ int CHOLMOD(amd)
     CHOLMOD(free_sparse) (&C, Common) ;
     for (j = 0 ; j <= n ; j++)
     {
-	Head [j] = EMPTY ;
+	Head [j] = TRILINOS_CHOLMOD_EMPTY ;
     }
     return (TRUE) ;
 }

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Cholesky/amesos_cholmod_l_analyze.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Cholesky/amesos_cholmod_l_analyze.c
@@ -409,7 +409,7 @@ cholmod_factor *CHOLMOD(analyze_p)
     RETURN_IF_XTYPE_INVALID (A, CHOLMOD_PATTERN, CHOLMOD_ZOMPLEX, NULL) ;
     Common->status = CHOLMOD_OK ;
     status = CHOLMOD_OK ;
-    Common->selected = EMPTY ;
+    Common->selected = TRILINOS_CHOLMOD_EMPTY ;
     Common->called_nd = FALSE ;
 
     /* ---------------------------------------------------------------------- */
@@ -424,7 +424,7 @@ cholmod_factor *CHOLMOD(analyze_p)
     /* set the default strategy */
     /* ---------------------------------------------------------------------- */
 
-    lnz_best = (double) EMPTY ;
+    lnz_best = (double) TRILINOS_CHOLMOD_EMPTY ;
     skip_best = FALSE ;
     nmethods = MIN (Common->nmethods, CHOLMOD_MAXMETHODS) ;
     nmethods = MAX (0, nmethods) ;
@@ -519,7 +519,7 @@ cholmod_factor *CHOLMOD(analyze_p)
     }
     Lperm = L->Perm ;
     Lcolcount = L->ColCount ;
-    Common->anz = EMPTY ;
+    Common->anz = TRILINOS_CHOLMOD_EMPTY ;
 
     /* ---------------------------------------------------------------------- */
     /* try all the requested ordering options and backup to AMD if needed */
@@ -535,14 +535,14 @@ cholmod_factor *CHOLMOD(analyze_p)
 	/* determine the method to try */
 	/* ------------------------------------------------------------------ */
 
-	Common->fl = EMPTY ;
-	Common->lnz = EMPTY ;
+	Common->fl = TRILINOS_CHOLMOD_EMPTY ;
+	Common->lnz = TRILINOS_CHOLMOD_EMPTY ;
 	skip_analysis = FALSE ;
 
 	if (method == nmethods)
 	{
 	    /* All methods failed: backup to AMD */
-	    if (Common->selected == EMPTY && !default_strategy)
+	    if (Common->selected == TRILINOS_CHOLMOD_EMPTY && !default_strategy)
 	    {
 		PRINT1 (("All methods requested failed: backup to AMD\n")) ;
 		ordering = CHOLMOD_AMD ;
@@ -715,7 +715,7 @@ cholmod_factor *CHOLMOD(analyze_p)
 	/* ------------------------------------------------------------------ */
 
 	/* fl.pt. compare, but lnz can never be NaN */
-	if (Common->selected == EMPTY || Common->lnz < lnz_best)
+	if (Common->selected == TRILINOS_CHOLMOD_EMPTY || Common->lnz < lnz_best)
 	{
 	    Common->selected = method ;
 	    PRINT1 (("this is best so far, method "ID"\n", method)) ;
@@ -771,7 +771,7 @@ cholmod_factor *CHOLMOD(analyze_p)
     /* return if no ordering method succeeded */
     /* ---------------------------------------------------------------------- */
 
-    if (Common->selected == EMPTY)
+    if (Common->selected == TRILINOS_CHOLMOD_EMPTY)
     {
 	/* All methods failed.  
 	 * If two or more methods failed, they may have failed for different
@@ -845,7 +845,7 @@ cholmod_factor *CHOLMOD(analyze_p)
 	    {
 		oldchild = Post [newchild] ;
 		oldparent = Lparent [oldchild] ;
-		newparent = (oldparent == EMPTY) ? EMPTY : InvPost [oldparent] ;
+		newparent = (oldparent == TRILINOS_CHOLMOD_EMPTY) ? TRILINOS_CHOLMOD_EMPTY : InvPost [oldparent] ;
 		Wi [newchild] = newparent ;
 	    }
 	    for (k = 0 ; k < n ; k++)

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Cholesky/amesos_cholmod_l_etree.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Cholesky/amesos_cholmod_l_etree.c
@@ -68,7 +68,7 @@ static void amesos_update_etree
 	}
 	/* perform path compression */
 	Ancestor [k] = i ;
-	if (a == EMPTY)
+	if (a == TRILINOS_CHOLMOD_EMPTY)
 	{
 	    /* final ancestor undefined; this is a new edge in the tree */
 	    Parent [k] = i ;
@@ -147,8 +147,8 @@ int CHOLMOD(etree)
 
     for (j = 0 ; j < ncol ; j++)
     {
-	Parent [j] = EMPTY ;
-	Ancestor [j] = EMPTY ;
+	Parent [j] = TRILINOS_CHOLMOD_EMPTY ;
+	Ancestor [j] = TRILINOS_CHOLMOD_EMPTY ;
     }
 
     /* ---------------------------------------------------------------------- */
@@ -188,7 +188,7 @@ int CHOLMOD(etree)
 	Prev = Iwork + ncol ;	/* size nrow (i/i/l) */
 	for (i = 0 ; i < nrow ; i++)
 	{
-	    Prev [i] = EMPTY ;
+	    Prev [i] = TRILINOS_CHOLMOD_EMPTY ;
 	}
 	for (j = 0 ; j < ncol ; j++)
 	{
@@ -204,7 +204,7 @@ int CHOLMOD(etree)
 		 * (jprev,j) are considered, where jprev<j */
 		i = Ai [p] ;
 		jprev = Prev [i] ;
-		if (jprev != EMPTY)
+		if (jprev != TRILINOS_CHOLMOD_EMPTY)
 		{
 		    amesos_update_etree (jprev, j, Parent, Ancestor) ;
 		}

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Cholesky/amesos_cholmod_l_postorder.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Cholesky/amesos_cholmod_l_postorder.c
@@ -43,20 +43,20 @@ static Int trilinos_dfs			/* return the new value of k */
     Int p,		/* start a DFS at node p */
     Int k,		/* start the node numbering at k */
     Int Post [ ],	/* Post ordering, modified on output */
-    Int Head [ ],	/* Head [p] = youngest child of p; EMPTY on output */
+    Int Head [ ],	/* Head [p] = youngest child of p; TRILINOS_CHOLMOD_EMPTY on output */
     Int Next [ ],	/* Next [j] = sibling of j; unmodified */
     Int Pstack [ ]	/* unused */
 )
 {
     Int j ;
     /* start a DFS at each child of node p */
-    for (j = Head [p] ; j != EMPTY ; j = Next [j])
+    for (j = Head [p] ; j != TRILINOS_CHOLMOD_EMPTY ; j = Next [j])
     {
 	/* start a DFS at child node j */
 	k = trilinos_dfs (j, k, Post, Head, Next, Pstack) ;
     }
     Post [k++] = p ;	/* order node p as the kth node */
-    Head [p] = EMPTY ;	/* link list p no longer needed */
+    Head [p] = TRILINOS_CHOLMOD_EMPTY ;	/* link list p no longer needed */
     return (k) ;	/* the next node will be numbered k */
 }
 
@@ -69,7 +69,7 @@ static Int trilinos_dfs		/* return the new value of k */
     Int p,		/* start the DFS at a root node p */
     Int k,		/* start the node numbering at k */
     Int Post [ ],	/* Post ordering, modified on output */
-    Int Head [ ],	/* Head [p] = youngest child of p; EMPTY on output */
+    Int Head [ ],	/* Head [p] = youngest child of p; TRILINOS_CHOLMOD_EMPTY on output */
     Int Next [ ],	/* Next [j] = sibling of j; unmodified */
     Int Pstack [ ]	/* workspace of size n, undefined on input or output */
 )
@@ -86,7 +86,7 @@ static Int trilinos_dfs		/* return the new value of k */
 	/* grab the node p from top of the stack and get its youngest child j */
 	p = Pstack [phead] ;
 	j = Head [p] ;
-	if (j == EMPTY)
+	if (j == TRILINOS_CHOLMOD_EMPTY)
 	{
 	    /* all children of p ordered.  remove p from stack and order it */
 	    phead-- ;
@@ -113,18 +113,18 @@ static Int trilinos_dfs		/* return the new value of k */
  * from cholmod_etree) or a component tree (from cholmod_nested_dissection).
  *
  * An elimination tree is a complete tree of n nodes with Parent [j] > j or
- * Parent [j] = EMPTY if j is a root.  On output Post [0..n-1] is a complete
+ * Parent [j] = TRILINOS_CHOLMOD_EMPTY if j is a root.  On output Post [0..n-1] is a complete
  * permutation vector.
  *
  * A component tree is a subset of 0..n-1.  Parent [j] = -2 if node j is not
- * in the component tree.  Parent [j] = EMPTY if j is a root of the component
+ * in the component tree.  Parent [j] = TRILINOS_CHOLMOD_EMPTY if j is a root of the component
  * tree, and Parent [j] is in the range 0 to n-1 if j is in the component
  * tree but not a root.  On output, Post [k] is defined only for nodes in
  * the component tree.  Post [k] = j if node j is the kth node in the
  * postordered component tree, where k is in the range 0 to the number of
  * components minus 1.
  *
- * Node j is ignored and not included in the postorder if Parent [j] < EMPTY.
+ * Node j is ignored and not included in the postorder if Parent [j] < TRILINOS_CHOLMOD_EMPTY.
  *
  * As a result, check_parent (Parent, n,...) may fail on input, since
  * cholmod_check_parent assumes Parent is an elimination tree.  Similarly,
@@ -163,9 +163,9 @@ UF_long CHOLMOD(postorder)	/* return # of nodes postordered */
     /* check inputs */
     /* ---------------------------------------------------------------------- */
 
-    RETURN_IF_NULL_COMMON (EMPTY) ;
-    RETURN_IF_NULL (Parent, EMPTY) ;
-    RETURN_IF_NULL (Post, EMPTY) ;
+    RETURN_IF_NULL_COMMON (TRILINOS_CHOLMOD_EMPTY) ;
+    RETURN_IF_NULL (Parent, TRILINOS_CHOLMOD_EMPTY) ;
+    RETURN_IF_NULL (Post, TRILINOS_CHOLMOD_EMPTY) ;
     Common->status = CHOLMOD_OK ;
 
     /* ---------------------------------------------------------------------- */
@@ -177,13 +177,13 @@ UF_long CHOLMOD(postorder)	/* return # of nodes postordered */
     if (!ok)
     {
 	ERROR (CHOLMOD_TOO_LARGE, "problem too large") ;
-	return (EMPTY) ;
+	return (TRILINOS_CHOLMOD_EMPTY) ;
     }
 
     CHOLMOD(allocate_work) (n, s, 0, Common) ;
     if (Common->status < CHOLMOD_OK)
     {
-	return (EMPTY) ;
+	return (TRILINOS_CHOLMOD_EMPTY) ;
     }
     ASSERT (CHOLMOD(dump_work) (TRUE, TRUE, 0, Common)) ;
 
@@ -191,7 +191,7 @@ UF_long CHOLMOD(postorder)	/* return # of nodes postordered */
     /* get inputs */
     /* ---------------------------------------------------------------------- */
 
-    Head  = Common->Head ;	/* size n+1, initially all EMPTY */
+    Head  = Common->Head ;	/* size n+1, initially all TRILINOS_CHOLMOD_EMPTY */
     Iwork = Common->Iwork ;
     Next  = Iwork ;		/* size n (i/i/l) */
     Pstack = Iwork + n ;	/* size n (i/i/l) */
@@ -232,7 +232,7 @@ UF_long CHOLMOD(postorder)	/* return # of nodes postordered */
 
 	for (w = 0 ; w < ((Int) n) ; w++)
 	{
-	    Whead [w] = EMPTY ;
+	    Whead [w] = TRILINOS_CHOLMOD_EMPTY ;
 	}
 	/* do in forward order, so nodes that ties are ordered by node index */
 	for (j = 0 ; j < ((Int) n) ; j++)
@@ -252,7 +252,7 @@ UF_long CHOLMOD(postorder)	/* return # of nodes postordered */
 	/* traverse weight buckets, placing each node in its parent's list */
 	for (w = n-1 ; w >= 0 ; w--)
 	{
-	    for (j = Whead [w] ; j != EMPTY ; j = nextj)
+	    for (j = Whead [w] ; j != TRILINOS_CHOLMOD_EMPTY ; j = nextj)
 	    {
 		nextj = Next [j] ;
 		/* put node j in the link list of its parent */
@@ -275,17 +275,17 @@ UF_long CHOLMOD(postorder)	/* return # of nodes postordered */
     k = 0 ;
     for (j = 0 ; j < ((Int) n) ; j++)
     {
-	if (Parent [j] == EMPTY)
+	if (Parent [j] == TRILINOS_CHOLMOD_EMPTY)
 	{
 	    /* j is the root of a tree; start a DFS here */
 	    k = trilinos_dfs (j, k, Post, Head, Next, Pstack) ;
 	}
     }
 
-    /* this would normally be EMPTY already, unless Parent is invalid */
+    /* this would normally be TRILINOS_CHOLMOD_EMPTY already, unless Parent is invalid */
     for (j = 0 ; j < ((Int) n) ; j++)
     {
-	Head [j] = EMPTY ;
+	Head [j] = TRILINOS_CHOLMOD_EMPTY ;
     }
 
     PRINT1 (("postordered "ID" nodes\n", k)) ;

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Cholesky/amesos_cholmod_l_rowcolcounts.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Cholesky/amesos_cholmod_l_rowcolcounts.c
@@ -75,7 +75,7 @@ static int amesos_initialize_node  /* initial work for kth node in postordered e
     p = Post [k] ;
     /* adjust the weight if p is not a root of the etree */
     parent = Parent [p] ;
-    if (parent != EMPTY)
+    if (parent != TRILINOS_CHOLMOD_EMPTY)
     {
 	ColCount [parent]-- ;
     }
@@ -123,7 +123,7 @@ static void amesos_process_edge
 	/* p is a leaf of the subtree of u */
 	ColCount [p]++ ;
 	prevleaf = PrevLeaf [u] ;
-	if (prevleaf == EMPTY)
+	if (prevleaf == TRILINOS_CHOLMOD_EMPTY)
 	{
 	    /* p is the first leaf of subtree of u; RowCount will be incremented
 	     * by the length of the path in the etree from p up to u. */
@@ -177,7 +177,7 @@ static void amesos_finalize_node    /* compute UNION (p, Parent [p]) */
 {
     /* all nodes in the SetParent tree rooted at p now have as their final
      * root the node Parent [p].  This computes UNION (p, Parent [p]) */
-    if (Parent [p] != EMPTY)
+    if (Parent [p] != TRILINOS_CHOLMOD_EMPTY)
     {
 	SetParent [p] = Parent [p] ;
     }
@@ -294,7 +294,7 @@ int CHOLMOD(rowcolcounts)
 
     for (i = 0 ; i < nrow ; i++)
     {
-	First [i] = EMPTY ;
+	First [i] = TRILINOS_CHOLMOD_EMPTY ;
     }
 
     /* postorder traversal of the etree */
@@ -303,19 +303,19 @@ int CHOLMOD(rowcolcounts)
 	/* node i of the etree is the kth node in the postordered etree */
 	i = Post [k] ;
 
-	/* i is a leaf if First [i] is still EMPTY */
+	/* i is a leaf if First [i] is still TRILINOS_CHOLMOD_EMPTY */
 	/* ColCount [i] starts at 1 if i is a leaf, zero otherwise */
-	ColCount [i] = (First [i] == EMPTY) ? 1 : 0 ;
+	ColCount [i] = (First [i] == TRILINOS_CHOLMOD_EMPTY) ? 1 : 0 ;
 
 	/* traverse the path from node i to the root, stopping if we find a
 	 * node r whose First [r] is already defined. */
 	len = 0 ;
-	for (r = i ; (r != EMPTY) && (First [r] == EMPTY) ; r = Parent [r])
+	for (r = i ; (r != TRILINOS_CHOLMOD_EMPTY) && (First [r] == TRILINOS_CHOLMOD_EMPTY) ; r = Parent [r])
 	{
 	    First [r] = k ;
 	    len++ ;
 	}
-	if (r == EMPTY)
+	if (r == TRILINOS_CHOLMOD_EMPTY)
 	{
 	    /* we hit a root node, the level of which is zero */
 	    len-- ;
@@ -367,7 +367,7 @@ int CHOLMOD(rowcolcounts)
 		    return (FALSE) ;
 		}
 		/* flag column j as having been seen */
-		Anext [j] = EMPTY ;
+		Anext [j] = TRILINOS_CHOLMOD_EMPTY ;
 	    }
 	    /* fset is now valid */
 	    ASSERT (CHOLMOD(dump_perm) (fset, nf, ncol, "fset", Common)) ;
@@ -416,8 +416,8 @@ int CHOLMOD(rowcolcounts)
     }
     for (i = 0 ; i < nrow ; i++)
     {
-	PrevLeaf [i] = EMPTY ;
-	PrevNbr [i] = EMPTY ;
+	PrevLeaf [i] = TRILINOS_CHOLMOD_EMPTY ;
+	PrevNbr [i] = TRILINOS_CHOLMOD_EMPTY ;
 	SetParent [i] = i ;	/* every node is in its own set, by itself */
     }
 
@@ -467,7 +467,7 @@ int CHOLMOD(rowcolcounts)
 	    inode = amesos_initialize_node (k, Post, Parent, ColCount, PrevNbr) ;
 
 	    /* for all cols j whose first postordered row is k: */
-	    for (j = Head [k] ; j != EMPTY ; j = Anext [j])
+	    for (j = Head [k] ; j != TRILINOS_CHOLMOD_EMPTY ; j = Anext [j])
 	    {
 		/* k is the first postordered row in column j of A */
 		/* for all rows i in column j: */
@@ -487,7 +487,7 @@ int CHOLMOD(rowcolcounts)
 		}
 	    }
 	    /* clear link list k */
-	    Head [k] = EMPTY ;
+	    Head [k] = TRILINOS_CHOLMOD_EMPTY ;
 	    /* update SetParent: UNION (inode, Parent [inode]) */
 	    amesos_finalize_node (inode, Parent, SetParent) ;
 	}
@@ -500,7 +500,7 @@ int CHOLMOD(rowcolcounts)
     for (j = 0 ; j < nrow ; j++)
     {
 	parent = Parent [j] ;
-	if (parent != EMPTY)
+	if (parent != TRILINOS_CHOLMOD_EMPTY)
 	{
 	    /* add the ColCount of j to its parent */
 	    ColCount [parent] += ColCount [j] ;
@@ -511,7 +511,7 @@ int CHOLMOD(rowcolcounts)
     /* clear workspace */
     /* ---------------------------------------------------------------------- */
 
-    Common->mark = EMPTY ;
+    Common->mark = TRILINOS_CHOLMOD_EMPTY ;
     CHOLMOD(clear_flag) (Common) ;
     ASSERT (CHOLMOD(dump_work) (TRUE, TRUE, 0, Common)) ;
 

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Cholesky/amesos_cholmod_postorder.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Cholesky/amesos_cholmod_postorder.c
@@ -40,20 +40,20 @@ static Int trilinos_dfs			/* return the new value of k */
     Int p,		/* start a DFS at node p */
     Int k,		/* start the node numbering at k */
     Int Post [ ],	/* Post ordering, modified on output */
-    Int Head [ ],	/* Head [p] = youngest child of p; EMPTY on output */
+    Int Head [ ],	/* Head [p] = youngest child of p; TRILINOS_CHOLMOD_EMPTY on output */
     Int Next [ ],	/* Next [j] = sibling of j; unmodified */
     Int Pstack [ ]	/* unused */
 )
 {
     Int j ;
     /* start a DFS at each child of node p */
-    for (j = Head [p] ; j != EMPTY ; j = Next [j])
+    for (j = Head [p] ; j != TRILINOS_CHOLMOD_EMPTY ; j = Next [j])
     {
 	/* start a DFS at child node j */
 	k = trilinos_dfs (j, k, Post, Head, Next, Pstack) ;
     }
     Post [k++] = p ;	/* order node p as the kth node */
-    Head [p] = EMPTY ;	/* link list p no longer needed */
+    Head [p] = TRILINOS_CHOLMOD_EMPTY ;	/* link list p no longer needed */
     return (k) ;	/* the next node will be numbered k */
 }
 
@@ -66,7 +66,7 @@ static Int trilinos_dfs		/* return the new value of k */
     Int p,		/* start the DFS at a root node p */
     Int k,		/* start the node numbering at k */
     Int Post [ ],	/* Post ordering, modified on output */
-    Int Head [ ],	/* Head [p] = youngest child of p; EMPTY on output */
+    Int Head [ ],	/* Head [p] = youngest child of p; TRILINOS_CHOLMOD_EMPTY on output */
     Int Next [ ],	/* Next [j] = sibling of j; unmodified */
     Int Pstack [ ]	/* workspace of size n, undefined on input or output */
 )
@@ -83,7 +83,7 @@ static Int trilinos_dfs		/* return the new value of k */
 	/* grab the node p from top of the stack and get its youngest child j */
 	p = Pstack [phead] ;
 	j = Head [p] ;
-	if (j == EMPTY)
+	if (j == TRILINOS_CHOLMOD_EMPTY)
 	{
 	    /* all children of p ordered.  remove p from stack and order it */
 	    phead-- ;
@@ -110,18 +110,18 @@ static Int trilinos_dfs		/* return the new value of k */
  * from cholmod_etree) or a component tree (from cholmod_nested_dissection).
  *
  * An elimination tree is a complete tree of n nodes with Parent [j] > j or
- * Parent [j] = EMPTY if j is a root.  On output Post [0..n-1] is a complete
+ * Parent [j] = TRILINOS_CHOLMOD_EMPTY if j is a root.  On output Post [0..n-1] is a complete
  * permutation vector.
  *
  * A component tree is a subset of 0..n-1.  Parent [j] = -2 if node j is not
- * in the component tree.  Parent [j] = EMPTY if j is a root of the component
+ * in the component tree.  Parent [j] = TRILINOS_CHOLMOD_EMPTY if j is a root of the component
  * tree, and Parent [j] is in the range 0 to n-1 if j is in the component
  * tree but not a root.  On output, Post [k] is defined only for nodes in
  * the component tree.  Post [k] = j if node j is the kth node in the
  * postordered component tree, where k is in the range 0 to the number of
  * components minus 1.
  *
- * Node j is ignored and not included in the postorder if Parent [j] < EMPTY.
+ * Node j is ignored and not included in the postorder if Parent [j] < TRILINOS_CHOLMOD_EMPTY.
  *
  * As a result, check_parent (Parent, n,...) may fail on input, since
  * cholmod_check_parent assumes Parent is an elimination tree.  Similarly,
@@ -160,9 +160,9 @@ UF_long CHOLMOD(postorder)	/* return # of nodes postordered */
     /* check inputs */
     /* ---------------------------------------------------------------------- */
 
-    RETURN_IF_NULL_COMMON (EMPTY) ;
-    RETURN_IF_NULL (Parent, EMPTY) ;
-    RETURN_IF_NULL (Post, EMPTY) ;
+    RETURN_IF_NULL_COMMON (TRILINOS_CHOLMOD_EMPTY) ;
+    RETURN_IF_NULL (Parent, TRILINOS_CHOLMOD_EMPTY) ;
+    RETURN_IF_NULL (Post, TRILINOS_CHOLMOD_EMPTY) ;
     Common->status = CHOLMOD_OK ;
 
     /* ---------------------------------------------------------------------- */
@@ -174,13 +174,13 @@ UF_long CHOLMOD(postorder)	/* return # of nodes postordered */
     if (!ok)
     {
 	ERROR (CHOLMOD_TOO_LARGE, "problem too large") ;
-	return (EMPTY) ;
+	return (TRILINOS_CHOLMOD_EMPTY) ;
     }
 
     CHOLMOD(allocate_work) (n, s, 0, Common) ;
     if (Common->status < CHOLMOD_OK)
     {
-	return (EMPTY) ;
+	return (TRILINOS_CHOLMOD_EMPTY) ;
     }
     ASSERT (CHOLMOD(dump_work) (TRUE, TRUE, 0, Common)) ;
 
@@ -188,7 +188,7 @@ UF_long CHOLMOD(postorder)	/* return # of nodes postordered */
     /* get inputs */
     /* ---------------------------------------------------------------------- */
 
-    Head  = Common->Head ;	/* size n+1, initially all EMPTY */
+    Head  = Common->Head ;	/* size n+1, initially all TRILINOS_CHOLMOD_EMPTY */
     Iwork = Common->Iwork ;
     Next  = Iwork ;		/* size n (i/i/l) */
     Pstack = Iwork + n ;	/* size n (i/i/l) */
@@ -229,7 +229,7 @@ UF_long CHOLMOD(postorder)	/* return # of nodes postordered */
 
 	for (w = 0 ; w < ((Int) n) ; w++)
 	{
-	    Whead [w] = EMPTY ;
+	    Whead [w] = TRILINOS_CHOLMOD_EMPTY ;
 	}
 	/* do in forward order, so nodes that ties are ordered by node index */
 	for (j = 0 ; j < ((Int) n) ; j++)
@@ -249,7 +249,7 @@ UF_long CHOLMOD(postorder)	/* return # of nodes postordered */
 	/* traverse weight buckets, placing each node in its parent's list */
 	for (w = n-1 ; w >= 0 ; w--)
 	{
-	    for (j = Whead [w] ; j != EMPTY ; j = nextj)
+	    for (j = Whead [w] ; j != TRILINOS_CHOLMOD_EMPTY ; j = nextj)
 	    {
 		nextj = Next [j] ;
 		/* put node j in the link list of its parent */
@@ -272,17 +272,17 @@ UF_long CHOLMOD(postorder)	/* return # of nodes postordered */
     k = 0 ;
     for (j = 0 ; j < ((Int) n) ; j++)
     {
-	if (Parent [j] == EMPTY)
+	if (Parent [j] == TRILINOS_CHOLMOD_EMPTY)
 	{
 	    /* j is the root of a tree; start a DFS here */
 	    k = trilinos_dfs (j, k, Post, Head, Next, Pstack) ;
 	}
     }
 
-    /* this would normally be EMPTY already, unless Parent is invalid */
+    /* this would normally be TRILINOS_CHOLMOD_EMPTY already, unless Parent is invalid */
     for (j = 0 ; j < ((Int) n) ; j++)
     {
-	Head [j] = EMPTY ;
+	Head [j] = TRILINOS_CHOLMOD_EMPTY ;
     }
 
     PRINT1 (("postordered "ID" nodes\n", k)) ;

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Cholesky/amesos_cholmod_rcond.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Cholesky/amesos_cholmod_rcond.c
@@ -82,9 +82,9 @@ double CHOLMOD(rcond)	    /* return min(diag(L)) / max(diag(L)) */
     /* check inputs */
     /* ---------------------------------------------------------------------- */
 
-    RETURN_IF_NULL_COMMON (EMPTY) ;
-    RETURN_IF_NULL (L, EMPTY) ;
-    RETURN_IF_XTYPE_INVALID (L, CHOLMOD_REAL, CHOLMOD_ZOMPLEX, EMPTY) ;
+    RETURN_IF_NULL_COMMON (TRILINOS_CHOLMOD_EMPTY) ;
+    RETURN_IF_NULL (L, TRILINOS_CHOLMOD_EMPTY) ;
+    RETURN_IF_XTYPE_INVALID (L, CHOLMOD_REAL, CHOLMOD_ZOMPLEX, TRILINOS_CHOLMOD_EMPTY) ;
     Common->status = CHOLMOD_OK ;
 
     /* ---------------------------------------------------------------------- */

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Cholesky/amesos_cholmod_resymbol.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Cholesky/amesos_cholmod_resymbol.c
@@ -350,7 +350,7 @@ int CHOLMOD(resymbol_noperm)
     Anext = Iwork + 2*((size_t) nrow) ;	/* size ncol (i/i/l), unsym. only */
     for (j = 0 ; j < nrow ; j++)
     {
-	Link [j] = EMPTY ;
+	Link [j] = TRILINOS_CHOLMOD_EMPTY ;
     }
 
     /* use Lnz in L itself */
@@ -387,7 +387,7 @@ int CHOLMOD(resymbol_noperm)
 		    return (FALSE) ;
 		}
 		/* flag column j as having been seen */
-		Anext [j] = EMPTY ;
+		Anext [j] = TRILINOS_CHOLMOD_EMPTY ;
 	    }
 	    /* the fset is now valid */
 	    ASSERT (CHOLMOD(dump_perm) (fset, nf, ncol, "fset", Common)) ;
@@ -463,7 +463,7 @@ int CHOLMOD(resymbol_noperm)
 	else
 	{
 	    /* for each column j whos first row index is in row k */
-	    for (j = Head [k] ; j != EMPTY ; j = Anext [j])
+	    for (j = Head [k] ; j != TRILINOS_CHOLMOD_EMPTY ; j = Anext [j])
 	    {
 		/* merge column j of A into Flag */
 		PRINT1 (("	---- A column "ID"\n", j)) ;
@@ -480,7 +480,7 @@ int CHOLMOD(resymbol_noperm)
 		}
 	    }
 	    /* clear the kth link list */
-	    Head [k] = EMPTY ;
+	    Head [k] = TRILINOS_CHOLMOD_EMPTY ;
 	}
 
 	/* ------------------------------------------------------------------ */
@@ -488,7 +488,7 @@ int CHOLMOD(resymbol_noperm)
 	/* ------------------------------------------------------------------ */
 
 	/* for each column j of L whose parent is k */
-	for (j = Link [k] ; j != EMPTY ; j = Link [j])
+	for (j = Link [k] ; j != TRILINOS_CHOLMOD_EMPTY ; j = Link [j])
 	{
 	    /* merge column j of L into Flag */
 	    PRINT1 (("	---- L column "ID"\n", k)) ;
@@ -563,12 +563,12 @@ int CHOLMOD(resymbol_noperm)
 	ASSERT (Lnz [k] > 0) ;
 
 	/* parent is the first entry in the column after the diagonal */
-	parent = (Lnz [k] > 1) ? (Li [Lp [k] + 1]) : EMPTY ;
+	parent = (Lnz [k] > 1) ? (Li [Lp [k] + 1]) : TRILINOS_CHOLMOD_EMPTY ;
 
 	PRINT1 (("parent ("ID") = "ID"\n", k, parent)) ;
-	ASSERT ((parent > k && parent < nrow) || (parent == EMPTY)) ;
+	ASSERT ((parent > k && parent < nrow) || (parent == TRILINOS_CHOLMOD_EMPTY)) ;
 
-	if (parent != EMPTY)
+	if (parent != TRILINOS_CHOLMOD_EMPTY)
 	{
 	    Link [k] = Link [parent] ;
 	    Link [parent] = k ;

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Cholesky/amesos_cholmod_rowcolcounts.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Cholesky/amesos_cholmod_rowcolcounts.c
@@ -72,7 +72,7 @@ static int amesos_initialize_node  /* initial work for kth node in postordered e
     p = Post [k] ;
     /* adjust the weight if p is not a root of the etree */
     parent = Parent [p] ;
-    if (parent != EMPTY)
+    if (parent != TRILINOS_CHOLMOD_EMPTY)
     {
 	ColCount [parent]-- ;
     }
@@ -120,7 +120,7 @@ static void amesos_process_edge
 	/* p is a leaf of the subtree of u */
 	ColCount [p]++ ;
 	prevleaf = PrevLeaf [u] ;
-	if (prevleaf == EMPTY)
+	if (prevleaf == TRILINOS_CHOLMOD_EMPTY)
 	{
 	    /* p is the first leaf of subtree of u; RowCount will be incremented
 	     * by the length of the path in the etree from p up to u. */
@@ -174,7 +174,7 @@ static void amesos_finalize_node    /* compute UNION (p, Parent [p]) */
 {
     /* all nodes in the SetParent tree rooted at p now have as their final
      * root the node Parent [p].  This computes UNION (p, Parent [p]) */
-    if (Parent [p] != EMPTY)
+    if (Parent [p] != TRILINOS_CHOLMOD_EMPTY)
     {
 	SetParent [p] = Parent [p] ;
     }
@@ -291,7 +291,7 @@ int CHOLMOD(rowcolcounts)
 
     for (i = 0 ; i < nrow ; i++)
     {
-	First [i] = EMPTY ;
+	First [i] = TRILINOS_CHOLMOD_EMPTY ;
     }
 
     /* postorder traversal of the etree */
@@ -300,19 +300,19 @@ int CHOLMOD(rowcolcounts)
 	/* node i of the etree is the kth node in the postordered etree */
 	i = Post [k] ;
 
-	/* i is a leaf if First [i] is still EMPTY */
+	/* i is a leaf if First [i] is still TRILINOS_CHOLMOD_EMPTY */
 	/* ColCount [i] starts at 1 if i is a leaf, zero otherwise */
-	ColCount [i] = (First [i] == EMPTY) ? 1 : 0 ;
+	ColCount [i] = (First [i] == TRILINOS_CHOLMOD_EMPTY) ? 1 : 0 ;
 
 	/* traverse the path from node i to the root, stopping if we find a
 	 * node r whose First [r] is already defined. */
 	len = 0 ;
-	for (r = i ; (r != EMPTY) && (First [r] == EMPTY) ; r = Parent [r])
+	for (r = i ; (r != TRILINOS_CHOLMOD_EMPTY) && (First [r] == TRILINOS_CHOLMOD_EMPTY) ; r = Parent [r])
 	{
 	    First [r] = k ;
 	    len++ ;
 	}
-	if (r == EMPTY)
+	if (r == TRILINOS_CHOLMOD_EMPTY)
 	{
 	    /* we hit a root node, the level of which is zero */
 	    len-- ;
@@ -364,7 +364,7 @@ int CHOLMOD(rowcolcounts)
 		    return (FALSE) ;
 		}
 		/* flag column j as having been seen */
-		Anext [j] = EMPTY ;
+		Anext [j] = TRILINOS_CHOLMOD_EMPTY ;
 	    }
 	    /* fset is now valid */
 	    ASSERT (CHOLMOD(dump_perm) (fset, nf, ncol, "fset", Common)) ;
@@ -413,8 +413,8 @@ int CHOLMOD(rowcolcounts)
     }
     for (i = 0 ; i < nrow ; i++)
     {
-	PrevLeaf [i] = EMPTY ;
-	PrevNbr [i] = EMPTY ;
+	PrevLeaf [i] = TRILINOS_CHOLMOD_EMPTY ;
+	PrevNbr [i] = TRILINOS_CHOLMOD_EMPTY ;
 	SetParent [i] = i ;	/* every node is in its own set, by itself */
     }
 
@@ -464,7 +464,7 @@ int CHOLMOD(rowcolcounts)
 	    inode = amesos_initialize_node (k, Post, Parent, ColCount, PrevNbr) ;
 
 	    /* for all cols j whose first postordered row is k: */
-	    for (j = Head [k] ; j != EMPTY ; j = Anext [j])
+	    for (j = Head [k] ; j != TRILINOS_CHOLMOD_EMPTY ; j = Anext [j])
 	    {
 		/* k is the first postordered row in column j of A */
 		/* for all rows i in column j: */
@@ -484,7 +484,7 @@ int CHOLMOD(rowcolcounts)
 		}
 	    }
 	    /* clear link list k */
-	    Head [k] = EMPTY ;
+	    Head [k] = TRILINOS_CHOLMOD_EMPTY ;
 	    /* update SetParent: UNION (inode, Parent [inode]) */
 	    amesos_finalize_node (inode, Parent, SetParent) ;
 	}
@@ -497,7 +497,7 @@ int CHOLMOD(rowcolcounts)
     for (j = 0 ; j < nrow ; j++)
     {
 	parent = Parent [j] ;
-	if (parent != EMPTY)
+	if (parent != TRILINOS_CHOLMOD_EMPTY)
 	{
 	    /* add the ColCount of j to its parent */
 	    ColCount [parent] += ColCount [j] ;
@@ -508,7 +508,7 @@ int CHOLMOD(rowcolcounts)
     /* clear workspace */
     /* ---------------------------------------------------------------------- */
 
-    Common->mark = EMPTY ;
+    Common->mark = TRILINOS_CHOLMOD_EMPTY ;
     CHOLMOD(clear_flag) (Common) ;
     ASSERT (CHOLMOD(dump_work) (TRUE, TRUE, 0, Common)) ;
 

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Cholesky/amesos_cholmod_rowfac.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Cholesky/amesos_cholmod_rowfac.c
@@ -125,7 +125,7 @@
  *
  * PARENT(i) is a macro the defines how the etree is accessed.  It is either:
  *	#define PARENT(i) Parent [i]
- *	#define PARENT(i) (Lnz [i] > 1) ? (Li [Lp [i] + 1]) : EMPTY
+ *	#define PARENT(i) (Lnz [i] > 1) ? (Li [Lp [i] + 1]) : TRILINOS_CHOLMOD_EMPTY
  */
 
 #define SUBTREE \
@@ -137,7 +137,7 @@
 	    /* scatter the column of A, or A*A' into Wx and Wz */ \
 	    SCATTER ; \
 	    /* start at node i and traverse up the subtree, stop at node k */ \
-	    for (len = 0 ; i < k && i != EMPTY && Flag [i] < mark ; i = parent) \
+	    for (len = 0 ; i < k && i != TRILINOS_CHOLMOD_EMPTY && Flag [i] < mark ; i = parent) \
 	    { \
 		/* L(k,i) is nonzero, and seen for the first time */ \
 		Stack [len++] = i ;	    /* place i on the stack */ \
@@ -464,7 +464,7 @@ int CHOLMOD(row_lsubtree)
     Flag [k] = mark ;		/* do not include diagonal entry in Stack */
 
 #define SCATTER			/* do not scatter numerical values */
-#define PARENT(i) (Lnz [i] > 1) ? (Li [Lp [i] + 1]) : EMPTY
+#define PARENT(i) (Lnz [i] > 1) ? (Li [Lp [i] + 1]) : TRILINOS_CHOLMOD_EMPTY
 
     if (stype != 0)
     {

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Cholesky/amesos_t_cholmod_rowfac.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Cholesky/amesos_t_cholmod_rowfac.c
@@ -185,7 +185,7 @@ static int TEMPLATE (cholmod_rowfac)
 	Flag [k] = mark ;	/* do not include diagonal entry in Stack */
 
 	/* use Li [Lp [i]+1] for etree */
-#define PARENT(i) (Lnz [i] > 1) ? (Li [Lp [i] + 1]) : EMPTY
+#define PARENT(i) (Lnz [i] > 1) ? (Li [Lp [i] + 1]) : TRILINOS_CHOLMOD_EMPTY
 
 	if (stype > 0)
 	{

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Core/amesos_cholmod_add.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Core/amesos_cholmod_add.c
@@ -205,7 +205,7 @@ cholmod_sparse *CHOLMOD(add)
 	    {
 		continue ;
 	    }
-	    Flag [i] = EMPTY ;
+	    Flag [i] = TRILINOS_CHOLMOD_EMPTY ;
 	    Ci [nz] = i ;
 	    if (values)
 	    {

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Core/amesos_cholmod_change_factor.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Core/amesos_cholmod_change_factor.c
@@ -178,8 +178,8 @@ static void natural_list (cholmod_factor *L)
     head = n+1 ;
     tail = n ;
     Lnext [head] = 0 ;
-    Lprev [head] = EMPTY ;
-    Lnext [tail] = EMPTY ;
+    Lprev [head] = TRILINOS_CHOLMOD_EMPTY ;
+    Lnext [tail] = TRILINOS_CHOLMOD_EMPTY ;
     Lprev [tail] = n-1 ;
     for (j = 0 ; j < n ; j++)
     {
@@ -305,7 +305,7 @@ static int simplicial_symbolic_to_super_symbolic
     L->pi = Lpi ;
     L->px = Lpx ;
     L->s  = Ls ;
-    Ls [0] = EMPTY ;	    /* supernodal pattern undefined */
+    Ls [0] = TRILINOS_CHOLMOD_EMPTY ;	    /* supernodal pattern undefined */
 
     L->is_super = TRUE ;
     L->is_ll = TRUE ;	    /* supernodal LDL' not supported */

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Core/amesos_cholmod_common.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Core/amesos_cholmod_common.c
@@ -131,7 +131,7 @@ int CHOLMOD(start)
      * overwritten with NULL. */
 
     Common->nrow = 0 ;
-    Common->mark = EMPTY ;
+    Common->mark = TRILINOS_CHOLMOD_EMPTY ;
     Common->xworksize = 0 ;
     Common->iworksize = 0 ;
     Common->Flag = NULL ;
@@ -145,11 +145,11 @@ int CHOLMOD(start)
     /* ---------------------------------------------------------------------- */
 
     /* fl and lnz are computed in cholmod_analyze and cholmod_rowcolcounts */
-    Common->fl = EMPTY ;
-    Common->lnz = EMPTY ;
+    Common->fl = TRILINOS_CHOLMOD_EMPTY ;
+    Common->lnz = TRILINOS_CHOLMOD_EMPTY ;
 
     /* modfl is computed in cholmod_updown, cholmod_rowadd, and cholmod_rowdel*/
-    Common->modfl = EMPTY ;
+    Common->modfl = TRILINOS_CHOLMOD_EMPTY ;
 
     /* all routines use status as their error-report code */
     Common->status = CHOLMOD_OK ;
@@ -162,7 +162,7 @@ int CHOLMOD(start)
     Common->nrealloc_factor = 0 ;
     Common->ndbounds_hit = 0 ;
     Common->rowfacfl = 0 ;
-    Common->aatfl = EMPTY ;
+    Common->aatfl = TRILINOS_CHOLMOD_EMPTY ;
 
     /* Common->called_nd is TRUE if cholmod_analyze called or NESDIS */
     Common->called_nd = FALSE ;
@@ -275,8 +275,8 @@ int CHOLMOD(defaults)
 	Common->method [i].nd_oksep = 1.0 ;	/* sep ok if < oksep*n */
 
 	/* statistics for each method are not yet computed */
-	Common->method [i].fl = EMPTY ;
-	Common->method [i].lnz = EMPTY ;
+	Common->method [i].fl = TRILINOS_CHOLMOD_EMPTY ;
+	Common->method [i].lnz = TRILINOS_CHOLMOD_EMPTY ;
     }
 
     Common->postorder = TRUE ;	/* follow ordering with weighted postorder */
@@ -408,12 +408,12 @@ int CHOLMOD(allocate_work)
 	}
 
 	/* initialize Flag and Head */
-	Common->mark = EMPTY ;
+	Common->mark = TRILINOS_CHOLMOD_EMPTY ;
 	CHOLMOD(clear_flag) (Common) ;
 	Head = Common->Head ;
 	for (i = 0 ; i <= (Int) (nrow) ; i++)
 	{
-	    Head [i] = EMPTY ;
+	    Head [i] = TRILINOS_CHOLMOD_EMPTY ;
 	}
     }
 
@@ -550,7 +550,7 @@ UF_long CHOLMOD(clear_flag)
 	PRINT2 (("reset Flag: mark %ld\n", Common->mark)) ;
 	for (i = 0 ; i < nrow ; i++)
 	{
-	    Flag [i] = EMPTY ;
+	    Flag [i] = TRILINOS_CHOLMOD_EMPTY ;
 	}
 	Common->mark = 0 ;
     }

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Core/amesos_cholmod_l_add.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Core/amesos_cholmod_l_add.c
@@ -208,7 +208,7 @@ cholmod_sparse *CHOLMOD(add)
 	    {
 		continue ;
 	    }
-	    Flag [i] = EMPTY ;
+	    Flag [i] = TRILINOS_CHOLMOD_EMPTY ;
 	    Ci [nz] = i ;
 	    if (values)
 	    {

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Core/amesos_cholmod_l_change_factor.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Core/amesos_cholmod_l_change_factor.c
@@ -181,8 +181,8 @@ static void natural_list (cholmod_factor *L)
     head = n+1 ;
     tail = n ;
     Lnext [head] = 0 ;
-    Lprev [head] = EMPTY ;
-    Lnext [tail] = EMPTY ;
+    Lprev [head] = TRILINOS_CHOLMOD_EMPTY ;
+    Lnext [tail] = TRILINOS_CHOLMOD_EMPTY ;
     Lprev [tail] = n-1 ;
     for (j = 0 ; j < n ; j++)
     {
@@ -308,7 +308,7 @@ static int simplicial_symbolic_to_super_symbolic
     L->pi = Lpi ;
     L->px = Lpx ;
     L->s  = Ls ;
-    Ls [0] = EMPTY ;	    /* supernodal pattern undefined */
+    Ls [0] = TRILINOS_CHOLMOD_EMPTY ;	    /* supernodal pattern undefined */
 
     L->is_super = TRUE ;
     L->is_ll = TRUE ;	    /* supernodal LDL' not supported */

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Core/amesos_cholmod_l_common.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Core/amesos_cholmod_l_common.c
@@ -134,7 +134,7 @@ int CHOLMOD(start)
      * overwritten with NULL. */
 
     Common->nrow = 0 ;
-    Common->mark = EMPTY ;
+    Common->mark = TRILINOS_CHOLMOD_EMPTY ;
     Common->xworksize = 0 ;
     Common->iworksize = 0 ;
     Common->Flag = NULL ;
@@ -148,11 +148,11 @@ int CHOLMOD(start)
     /* ---------------------------------------------------------------------- */
 
     /* fl and lnz are computed in cholmod_analyze and cholmod_rowcolcounts */
-    Common->fl = EMPTY ;
-    Common->lnz = EMPTY ;
+    Common->fl = TRILINOS_CHOLMOD_EMPTY ;
+    Common->lnz = TRILINOS_CHOLMOD_EMPTY ;
 
     /* modfl is computed in cholmod_updown, cholmod_rowadd, and cholmod_rowdel*/
-    Common->modfl = EMPTY ;
+    Common->modfl = TRILINOS_CHOLMOD_EMPTY ;
 
     /* all routines use status as their error-report code */
     Common->status = CHOLMOD_OK ;
@@ -165,7 +165,7 @@ int CHOLMOD(start)
     Common->nrealloc_factor = 0 ;
     Common->ndbounds_hit = 0 ;
     Common->rowfacfl = 0 ;
-    Common->aatfl = EMPTY ;
+    Common->aatfl = TRILINOS_CHOLMOD_EMPTY ;
 
     /* Common->called_nd is TRUE if cholmod_analyze called or NESDIS */
     Common->called_nd = FALSE ;
@@ -278,8 +278,8 @@ int CHOLMOD(defaults)
 	Common->method [i].nd_oksep = 1.0 ;	/* sep ok if < oksep*n */
 
 	/* statistics for each method are not yet computed */
-	Common->method [i].fl = EMPTY ;
-	Common->method [i].lnz = EMPTY ;
+	Common->method [i].fl = TRILINOS_CHOLMOD_EMPTY ;
+	Common->method [i].lnz = TRILINOS_CHOLMOD_EMPTY ;
     }
 
     Common->postorder = TRUE ;	/* follow ordering with weighted postorder */
@@ -411,12 +411,12 @@ int CHOLMOD(allocate_work)
 	}
 
 	/* initialize Flag and Head */
-	Common->mark = EMPTY ;
+	Common->mark = TRILINOS_CHOLMOD_EMPTY ;
 	CHOLMOD(clear_flag) (Common) ;
 	Head = Common->Head ;
 	for (i = 0 ; i <= (Int) (nrow) ; i++)
 	{
-	    Head [i] = EMPTY ;
+	    Head [i] = TRILINOS_CHOLMOD_EMPTY ;
 	}
     }
 
@@ -553,7 +553,7 @@ UF_long CHOLMOD(clear_flag)
 	PRINT2 (("reset Flag: mark %ld\n", Common->mark)) ;
 	for (i = 0 ; i < nrow ; i++)
 	{
-	    Flag [i] = EMPTY ;
+	    Flag [i] = TRILINOS_CHOLMOD_EMPTY ;
 	}
 	Common->mark = 0 ;
     }

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Core/amesos_cholmod_l_sparse.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Core/amesos_cholmod_l_sparse.c
@@ -433,9 +433,9 @@ UF_long CHOLMOD(nnz)
     /* get inputs */
     /* ---------------------------------------------------------------------- */
 
-    RETURN_IF_NULL_COMMON (EMPTY) ;
-    RETURN_IF_NULL (A, EMPTY) ;
-    RETURN_IF_XTYPE_INVALID (A, CHOLMOD_PATTERN, CHOLMOD_ZOMPLEX, EMPTY) ;
+    RETURN_IF_NULL_COMMON (TRILINOS_CHOLMOD_EMPTY) ;
+    RETURN_IF_NULL (A, TRILINOS_CHOLMOD_EMPTY) ;
+    RETURN_IF_XTYPE_INVALID (A, CHOLMOD_PATTERN, CHOLMOD_ZOMPLEX, TRILINOS_CHOLMOD_EMPTY) ;
     Common->status = CHOLMOD_OK ;
 
     /* ---------------------------------------------------------------------- */
@@ -446,13 +446,13 @@ UF_long CHOLMOD(nnz)
     if (A->packed)
     {
 	Ap = A->p ;
-	RETURN_IF_NULL (Ap, EMPTY) ;
+	RETURN_IF_NULL (Ap, TRILINOS_CHOLMOD_EMPTY) ;
 	nz = Ap [ncol] ;
     }
     else
     {
 	Anz = A->nz ;
-	RETURN_IF_NULL (Anz, EMPTY) ;
+	RETURN_IF_NULL (Anz, TRILINOS_CHOLMOD_EMPTY) ;
 	nz = 0 ;
 	for (j = 0 ; j < ncol ; j++)
 	{

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Core/amesos_cholmod_l_transpose.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Core/amesos_cholmod_l_transpose.c
@@ -289,7 +289,7 @@ int CHOLMOD(transpose_unsym)
 	Wi [i] = 0 ;
     }
 
-    jlast = EMPTY ;
+    jlast = TRILINOS_CHOLMOD_EMPTY ;
     Fsorted = TRUE ;
 
     if (use_fset)
@@ -569,12 +569,12 @@ int CHOLMOD(transpose_sym)
     {
 	for (i = 0 ; i < n ; i++)
 	{
-	    Pinv [i] = EMPTY ;
+	    Pinv [i] = TRILINOS_CHOLMOD_EMPTY ;
 	}
 	for (k = 0 ; k < n ; k++)
 	{
 	    i = Perm [k] ;
-	    if (i < 0 || i > n || Pinv [i] != EMPTY)
+	    if (i < 0 || i > n || Pinv [i] != TRILINOS_CHOLMOD_EMPTY)
 	    {
 		ERROR (CHOLMOD_INVALID, "invalid permutation") ;
 		return (FALSE) ;

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Core/amesos_cholmod_sparse.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Core/amesos_cholmod_sparse.c
@@ -430,9 +430,9 @@ UF_long CHOLMOD(nnz)
     /* get inputs */
     /* ---------------------------------------------------------------------- */
 
-    RETURN_IF_NULL_COMMON (EMPTY) ;
-    RETURN_IF_NULL (A, EMPTY) ;
-    RETURN_IF_XTYPE_INVALID (A, CHOLMOD_PATTERN, CHOLMOD_ZOMPLEX, EMPTY) ;
+    RETURN_IF_NULL_COMMON (TRILINOS_CHOLMOD_EMPTY) ;
+    RETURN_IF_NULL (A, TRILINOS_CHOLMOD_EMPTY) ;
+    RETURN_IF_XTYPE_INVALID (A, CHOLMOD_PATTERN, CHOLMOD_ZOMPLEX, TRILINOS_CHOLMOD_EMPTY) ;
     Common->status = CHOLMOD_OK ;
 
     /* ---------------------------------------------------------------------- */
@@ -443,13 +443,13 @@ UF_long CHOLMOD(nnz)
     if (A->packed)
     {
 	Ap = A->p ;
-	RETURN_IF_NULL (Ap, EMPTY) ;
+	RETURN_IF_NULL (Ap, TRILINOS_CHOLMOD_EMPTY) ;
 	nz = Ap [ncol] ;
     }
     else
     {
 	Anz = A->nz ;
-	RETURN_IF_NULL (Anz, EMPTY) ;
+	RETURN_IF_NULL (Anz, TRILINOS_CHOLMOD_EMPTY) ;
 	nz = 0 ;
 	for (j = 0 ; j < ncol ; j++)
 	{

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Core/amesos_cholmod_transpose.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Core/amesos_cholmod_transpose.c
@@ -286,7 +286,7 @@ int CHOLMOD(transpose_unsym)
 	Wi [i] = 0 ;
     }
 
-    jlast = EMPTY ;
+    jlast = TRILINOS_CHOLMOD_EMPTY ;
     Fsorted = TRUE ;
 
     if (use_fset)
@@ -566,12 +566,12 @@ int CHOLMOD(transpose_sym)
     {
 	for (i = 0 ; i < n ; i++)
 	{
-	    Pinv [i] = EMPTY ;
+	    Pinv [i] = TRILINOS_CHOLMOD_EMPTY ;
 	}
 	for (k = 0 ; k < n ; k++)
 	{
 	    i = Perm [k] ;
-	    if (i < 0 || i > n || Pinv [i] != EMPTY)
+	    if (i < 0 || i > n || Pinv [i] != TRILINOS_CHOLMOD_EMPTY)
 	    {
 		ERROR (CHOLMOD_INVALID, "invalid permutation") ;
 		return (FALSE) ;

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Core/amesos_t_cholmod_triplet.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Core/amesos_t_cholmod_triplet.c
@@ -124,7 +124,7 @@ static size_t TEMPLATE (cholmod_triplet_to_sparse)
     /* use Wj (i/l/l) of size ncol to keep track of duplicates in each row [ */
     for (j = 0 ; j < ncol ; j++)
     {
-	Wj [j] = EMPTY ;
+	Wj [j] = TRILINOS_CHOLMOD_EMPTY ;
     }
 
     anz = 0 ;

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Include/amesos_cholmod_core.h
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Include/amesos_cholmod_core.h
@@ -832,7 +832,7 @@ typedef struct cholmod_common_struct
 			 * calls to cholmod rouines (Flag [i] < mark) */
 
     void *Head ;	/* size nrow+1, an integer array. Kept cleared between
-			 * calls to cholmod routines (Head [i] = EMPTY) */
+			 * calls to cholmod routines (Head [i] = TRILINOS_CHOLMOD_EMPTY) */
 
     void *Xwork ; 	/* a double array.  Its size varies.  It is nrow for
 			 * most routines (cholmod_rowfac, cholmod_add,
@@ -1014,7 +1014,7 @@ int amesos_cholmod_l_free_work (cholmod_common *) ;
     Common->mark++ ; \
     if (Common->mark <= 0) \
     { \
-        Common->mark = EMPTY ; \
+        Common->mark = TRILINOS_CHOLMOD_EMPTY ; \
         CHOLMOD (clear_flag) (Common) ; \
     } \
 }

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Include/amesos_cholmod_internal.h
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Include/amesos_cholmod_internal.h
@@ -84,12 +84,12 @@
 #endif
 
 /* FLIP is a "negation about -1", and is used to mark an integer i that is
- * normally non-negative.  FLIP (EMPTY) is EMPTY.  FLIP of a number > EMPTY
+ * normally non-negative.  FLIP (TRILINOS_CHOLMOD_EMPTY) is TRILINOS_CHOLMOD_EMPTY.  FLIP of a number > TRILINOS_CHOLMOD_EMPTY
  * is negative, and FLIP of a number < EMTPY is positive.  FLIP (FLIP (i)) = i
- * for all integers i.  UNFLIP (i) is >= EMPTY. */
-#define EMPTY (-1)
+ * for all integers i.  UNFLIP (i) is >= TRILINOS_CHOLMOD_EMPTY. */
+#define TRILINOS_CHOLMOD_EMPTY (-1)
 #define FLIP(i) (-(i)-2)
-#define UNFLIP(i) (((i) < EMPTY) ? FLIP (i) : (i))
+#define UNFLIP(i) (((i) < TRILINOS_CHOLMOD_EMPTY) ? FLIP (i) : (i))
 
 /* MAX and MIN are not safe to use for NaN's */
 #define MAX(a,b) (((a) > (b)) ? (a) : (b))

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Include/amesos_cholmod_partition.h
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Include/amesos_cholmod_partition.h
@@ -60,7 +60,7 @@ UF_long amesos_cholmod_nested_dissection	/* returns # of components */
     /* ---- output --- */
     int *Perm,		/* size A->nrow, output permutation */
     int *CParent,	/* size A->nrow.  On output, CParent [c] is the parent
-			 * of component c, or EMPTY if c is a root, and where
+			 * of component c, or TRILINOS_CHOLMOD_EMPTY if c is a root, and where
 			 * c is in the range 0 to # of components minus 1 */
     int *Cmember,	/* size A->nrow.  Cmember [j] = c if node j of A is
 			 * in component c */

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Partition/amesos_cholmod_camd.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Partition/amesos_cholmod_camd.c
@@ -219,7 +219,7 @@ int CHOLMOD(camd)
     CHOLMOD(free_sparse) (&C, Common) ;
     for (j = 0 ; j <= n ; j++)
     {
-	Head [j] = EMPTY ;
+	Head [j] = TRILINOS_CHOLMOD_EMPTY ;
     }
     CHOLMOD(free) (n+1, 3*sizeof (Int), Work3n, Common) ;
     return (TRUE) ;

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Partition/amesos_cholmod_csymamd.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Partition/amesos_cholmod_csymamd.c
@@ -133,7 +133,7 @@ int CHOLMOD(csymamd)
     Head = Common->Head ;
     for (i = 0 ; i <= nrow ; i++)
     {
-	Head [i] = EMPTY ;
+	Head [i] = TRILINOS_CHOLMOD_EMPTY ;
     }
 
     return (ok) ;

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Partition/amesos_cholmod_l_camd.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Partition/amesos_cholmod_l_camd.c
@@ -222,7 +222,7 @@ int CHOLMOD(camd)
     CHOLMOD(free_sparse) (&C, Common) ;
     for (j = 0 ; j <= n ; j++)
     {
-	Head [j] = EMPTY ;
+	Head [j] = TRILINOS_CHOLMOD_EMPTY ;
     }
     CHOLMOD(free) (n+1, 3*sizeof (Int), Work3n, Common) ;
     return (TRUE) ;

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Partition/amesos_cholmod_l_csymamd.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Partition/amesos_cholmod_l_csymamd.c
@@ -136,7 +136,7 @@ int CHOLMOD(csymamd)
     Head = Common->Head ;
     for (i = 0 ; i <= nrow ; i++)
     {
-	Head [i] = EMPTY ;
+	Head [i] = TRILINOS_CHOLMOD_EMPTY ;
     }
 
     return (ok) ;

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Partition/amesos_cholmod_l_metis.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Partition/amesos_cholmod_l_metis.c
@@ -224,18 +224,18 @@ UF_long CHOLMOD(metis_bisector)	/* returns separator size */
     /* check inputs */
     /* ---------------------------------------------------------------------- */
 
-    RETURN_IF_NULL_COMMON (EMPTY) ;
-    RETURN_IF_NULL (A, EMPTY) ;
-    RETURN_IF_NULL (Anw, EMPTY) ;
-    RETURN_IF_NULL (Aew, EMPTY) ;
-    RETURN_IF_NULL (Partition, EMPTY) ;
-    RETURN_IF_XTYPE_INVALID (A, CHOLMOD_PATTERN, CHOLMOD_ZOMPLEX, EMPTY) ;
+    RETURN_IF_NULL_COMMON (TRILINOS_CHOLMOD_EMPTY) ;
+    RETURN_IF_NULL (A, TRILINOS_CHOLMOD_EMPTY) ;
+    RETURN_IF_NULL (Anw, TRILINOS_CHOLMOD_EMPTY) ;
+    RETURN_IF_NULL (Aew, TRILINOS_CHOLMOD_EMPTY) ;
+    RETURN_IF_NULL (Partition, TRILINOS_CHOLMOD_EMPTY) ;
+    RETURN_IF_XTYPE_INVALID (A, CHOLMOD_PATTERN, CHOLMOD_ZOMPLEX, TRILINOS_CHOLMOD_EMPTY) ;
     if (A->stype || A->nrow != A->ncol)
     {
 	/* A must be square, with both upper and lower parts present */
 	ERROR (CHOLMOD_INVALID, "matrix must be square, symmetric,"
 		" and with both upper/lower parts present") ;
-	return (EMPTY) ;
+	return (TRILINOS_CHOLMOD_EMPTY) ;
     }
     Common->status = CHOLMOD_OK ;
 
@@ -266,7 +266,7 @@ UF_long CHOLMOD(metis_bisector)	/* returns separator size */
     if (sizeof (Int) > sizeof (idxtype) && MAX (n,nz) > INT_MAX / sizeof (int))
     {
 	/* CHOLMOD's matrix is too large for METIS */
-	return (EMPTY) ;
+	return (TRILINOS_CHOLMOD_EMPTY) ;
     }
 #endif
 
@@ -314,7 +314,7 @@ UF_long CHOLMOD(metis_bisector)	/* returns separator size */
 	    CHOLMOD(free) (n1, sizeof (idxtype), Mp,    Common) ;
 	    CHOLMOD(free) (n,  sizeof (idxtype), Mnw,   Common) ;
 	    CHOLMOD(free) (n,  sizeof (idxtype), Mpart, Common) ;
-	    return (EMPTY) ;
+	    return (TRILINOS_CHOLMOD_EMPTY) ;
 	}
 	for (p = 0 ; p < nz ; p++)
 	{
@@ -349,7 +349,7 @@ UF_long CHOLMOD(metis_bisector)	/* returns separator size */
 	    CHOLMOD(free) (n,  sizeof (idxtype), Mnw,   Common) ;
 	    CHOLMOD(free) (n,  sizeof (idxtype), Mpart, Common) ;
 	}
-	return (EMPTY) ;
+	return (TRILINOS_CHOLMOD_EMPTY) ;
     }
 
     /* ---------------------------------------------------------------------- */

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Partition/amesos_cholmod_l_nesdis.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Partition/amesos_cholmod_l_nesdis.c
@@ -202,10 +202,10 @@ static UF_long partition    /* size of separator or -1 if failure */
 	    hash = Hash [j] ;
 	    ASSERT (hash >= 0 && hash < csize) ;
 	    head = Hhead [hash] ;
-	    if (head > EMPTY)
+	    if (head > TRILINOS_CHOLMOD_EMPTY)
 	    {
 		/* hash bucket for this hash key is empty. */
-		head = EMPTY ;
+		head = TRILINOS_CHOLMOD_EMPTY ;
 	    }
 	    else
 	    {
@@ -218,7 +218,7 @@ static UF_long partition    /* size of separator or -1 if failure */
 	     * bucket. */
 	    Hhead [hash] = FLIP (j) ;
 	    Next [j] = head ;
-	    ASSERT (head >= EMPTY && head < n) ;
+	    ASSERT (head >= TRILINOS_CHOLMOD_EMPTY && head < n) ;
 	}
 
 #ifndef NDEBUG
@@ -228,13 +228,13 @@ static UF_long partition    /* size of separator or -1 if failure */
 	    hash = Hash [k] ;
 	    ASSERT (hash >= 0 && hash < csize) ;
 	    head = Hhead [hash] ;
-	    ASSERT (head < EMPTY) ;	/* hash bucket not empty */
+	    ASSERT (head < TRILINOS_CHOLMOD_EMPTY) ;	/* hash bucket not empty */
 	    j = FLIP (head) ;
 	    ASSERT (j >= 0 && j < n) ;
 	    if (j == k)
 	    {
 		PRINT2 (("hash "ID": ", hash)) ;
-		for ( ; j != EMPTY ; j = Next [j])
+		for ( ; j != TRILINOS_CHOLMOD_EMPTY ; j = Next [j])
 		{
 		    PRINT3 ((" "ID"", j)) ;
 		    ASSERT (j >= 0 && j < n) ;
@@ -268,7 +268,7 @@ static UF_long partition    /* size of separator or -1 if failure */
 
 	for (i = 0 ; i < n ; i++)
 	{
-	    Cmap [i] = EMPTY ;
+	    Cmap [i] = TRILINOS_CHOLMOD_EMPTY ;
 	}
 
 	for (k = 0 ; k < n ; k++)
@@ -282,14 +282,14 @@ static UF_long partition    /* size of separator or -1 if failure */
 		continue ;
 	    }
 	    head = Hhead [hash] ;
-	    ASSERT (head < EMPTY || head == 1) ;
+	    ASSERT (head < TRILINOS_CHOLMOD_EMPTY || head == 1) ;
 	    if (head == 1)
 	    {
 		/* hash bucket is already empty */
 		continue ;
 	    }
 	    PRINT2 (("\n--------------------hash "ID":\n", hash)) ;
-	    for (j = FLIP (head) ; j != EMPTY && Next[j] > EMPTY ; j = Next [j])
+	    for (j = FLIP (head) ; j != TRILINOS_CHOLMOD_EMPTY && Next[j] > TRILINOS_CHOLMOD_EMPTY ; j = Next [j])
 	    {
 		/* compare j with all nodes i following it in hash bucket */
 		ASSERT (j >= 0 && j < n && Hash [j] == hash) ;
@@ -300,7 +300,7 @@ static UF_long partition    /* size of separator or -1 if failure */
 		DEBUG (for (i = 0 ; i < n ; i++) ASSERT (!Cmap_MARKED (i))) ;
 		DEBUG (pruned = FALSE) ;
 		ilast = j ;
-		for (i = Next [j] ; i != EMPTY ; i = Next [i])
+		for (i = Next [j] ; i != TRILINOS_CHOLMOD_EMPTY ; i = Next [i])
 		{
 		    ASSERT (i >= 0 && i < n && Hash [i] == hash && i != j) ;
 		    pi = Cp [i] ;
@@ -411,11 +411,11 @@ static UF_long partition    /* size of separator or -1 if failure */
 
 	/* Cmap [j] = k if node j is alive and the kth node of compressed graph.
 	 * The mapping is done monotonically (that is, k <= j) to simplify the
-	 * uncompression later on.  Cmap [j] = EMPTY if node j is dead. */
+	 * uncompression later on.  Cmap [j] = TRILINOS_CHOLMOD_EMPTY if node j is dead. */
 
 	for (j = 0 ; j < n ; j++)
 	{
-	    Cmap [j] = EMPTY ;
+	    Cmap [j] = TRILINOS_CHOLMOD_EMPTY ;
 	}
 	k = 0 ;
 	for (j = 0 ; j < n ; j++)
@@ -452,8 +452,8 @@ static UF_long partition    /* size of separator or -1 if failure */
 		    i = Ci [p] ;
 		    ASSERT (i >= 0 && i < n && i != j) ;
 		    i = Cmap [i] ;
-		    ASSERT (i >= EMPTY && i < cn && i != k) ;
-		    if (i > EMPTY)
+		    ASSERT (i >= TRILINOS_CHOLMOD_EMPTY && i < cn && i != k) ;
+		    if (i > TRILINOS_CHOLMOD_EMPTY)
 		    {
 			ASSERT (pdest <= p) ;
 			Ci [pdest++] = i ;
@@ -516,12 +516,12 @@ static UF_long partition    /* size of separator or -1 if failure */
 	{
 	    /* do this in reverse order so that Cnw can be expanded in place */
 	    k = Cmap [j] ;
-	    ASSERT (k >= EMPTY && k < n) ;
-	    if (k > EMPTY)
+	    ASSERT (k >= TRILINOS_CHOLMOD_EMPTY && k < n) ;
+	    if (k > TRILINOS_CHOLMOD_EMPTY)
 	    {
 		/* node k in compressed graph and is node j in full graph */
 		ASSERT (k <= j) ;
-		ASSERT (Hash [j] >= EMPTY) ;
+		ASSERT (Hash [j] >= TRILINOS_CHOLMOD_EMPTY) ;
 		Part [j] = Part [k] ;
 		Cnw [j] = Cnw [k] ;
 	    }
@@ -529,19 +529,19 @@ static UF_long partition    /* size of separator or -1 if failure */
 	    {
 		/* node j is a dead node */
 		Cnw [j] = 0 ;
-		DEBUG (Part [j] = EMPTY) ;
-		ASSERT (Hash [j] < EMPTY) ;
+		DEBUG (Part [j] = TRILINOS_CHOLMOD_EMPTY) ;
+		ASSERT (Hash [j] < TRILINOS_CHOLMOD_EMPTY) ;
 	    }
 	}
 
 	/* find the components for the dead nodes */
 	for (i = 0 ; i < n ; i++)
 	{
-	    if (Hash [i] < EMPTY)
+	    if (Hash [i] < TRILINOS_CHOLMOD_EMPTY)
 	    {
 		/* node i has been absorbed into node j */
 		j = FLIP (Hash [i]) ;
-		ASSERT (Part [i] == EMPTY && j >= 0 && j < n && Cnw [i] == 0) ;
+		ASSERT (Part [i] == TRILINOS_CHOLMOD_EMPTY && j >= 0 && j < n && Cnw [i] == 0) ;
 		Part [i] = Part [j] ;
 	    }
 	    ASSERT (Part [i] >= 0 && Part [i] <= 2) ;
@@ -551,7 +551,7 @@ static UF_long partition    /* size of separator or -1 if failure */
 	PRINT2 (("Part: ")) ;
 	for (cnt = 0, j = 0 ; j < n ; j++)
 	{
-	    ASSERT (Part [j] != EMPTY) ;
+	    ASSERT (Part [j] != TRILINOS_CHOLMOD_EMPTY) ;
 	    PRINT2 ((""ID" ", Part [j])) ;
 	    if (Part [j] == 2) cnt += Cnw [j] ;
 	}
@@ -577,14 +577,14 @@ static UF_long partition    /* size of separator or -1 if failure */
 /* === clear_flag =========================================================== */
 /* ========================================================================== */
 
-/* A node j has been removed from the graph if Flag [j] < EMPTY.
- * If Flag [j] >= EMPTY && Flag [j] < mark, then node j is alive but unmarked.
+/* A node j has been removed from the graph if Flag [j] < TRILINOS_CHOLMOD_EMPTY.
+ * If Flag [j] >= TRILINOS_CHOLMOD_EMPTY && Flag [j] < mark, then node j is alive but unmarked.
  * Flag [j] == mark means that node j is alive and marked.  Incrementing mark
  * means that all nodes are either (still) dead, or live but unmarked.
  *
  * On output, Common->mark < Common->Flag [i] for all i from 0 to Common->nrow.
  * This is the same output condition as cholmod_clear_flag, except that this
- * routine maintains the Flag [i] < EMPTY condition as well, if that condition
+ * routine maintains the Flag [i] < TRILINOS_CHOLMOD_EMPTY condition as well, if that condition
  * was true on input.
  *
  * workspace: Flag (nrow)
@@ -603,13 +603,13 @@ static UF_long clear_flag (cholmod_common *Common)
 	Flag = Common->Flag ;
 	for (i = 0 ; i < nrow ; i++)
 	{
-	    /* if Flag [i] < EMPTY, leave it alone */
-	    if (Flag [i] >= EMPTY)
+	    /* if Flag [i] < TRILINOS_CHOLMOD_EMPTY, leave it alone */
+	    if (Flag [i] >= TRILINOS_CHOLMOD_EMPTY)
 	    {
-		Flag [i] = EMPTY ;
+		Flag [i] = TRILINOS_CHOLMOD_EMPTY ;
 	    }
 	}
-	/* now Flag [i] <= EMPTY for all i */
+	/* now Flag [i] <= TRILINOS_CHOLMOD_EMPTY for all i */
 	Common->mark = 0 ;
     }
     return (Common->mark) ;
@@ -625,7 +625,7 @@ static UF_long clear_flag (cholmod_common *Common)
  * is NULL, then it is assumed to be the identity mapping
  * (Map [0..cn-1] = 0..cn-1).
  *
- * A node j does not appear in B if it has been ordered (Flag [j] < EMPTY,
+ * A node j does not appear in B if it has been ordered (Flag [j] < TRILINOS_CHOLMOD_EMPTY,
  * which means that j has been ordered and is "deleted" from B).
  *
  * If the size of a component is large, it is placed on the component stack,
@@ -652,7 +652,7 @@ static void find_components
     cholmod_sparse *B,
     Int Map [ ],	    /* size n, only Map [0..cn-1] used */
     Int cn,		    /* # of nodes in C */
-    Int cnode,		    /* root node of component C, or EMPTY if C is the
+    Int cnode,		    /* root node of component C, or TRILINOS_CHOLMOD_EMPTY if C is the
 			     * entire graph B */
 
     Int Part [ ],	    /* size cn, optional */
@@ -663,7 +663,7 @@ static void find_components
 
     Int CParent [ ],	    /* CParent [i] = j if component with repnode j is
 			     * the parent of the component with repnode i.
-			     * CParent [i] = EMPTY if the component with
+			     * CParent [i] = TRILINOS_CHOLMOD_EMPTY if the component with
 			     * repnode i is a root of the separator tree.
 			     * CParent [i] is -2 if i is not a repnode. */
     Int Cstack [ ],	    /* component stack for nested dissection */
@@ -686,13 +686,13 @@ static void find_components
 
     PRINT2 (("find components: cn %d\n", cn)) ;
     Flag = Common->Flag ;	    /* size n */
-    Common->mark = EMPTY ;	    /* force initialization of Flag array */
-    mark = clear_flag (Common) ;    /* clear Flag but preserve Flag [i]<EMPTY */
+    Common->mark = TRILINOS_CHOLMOD_EMPTY ;	    /* force initialization of Flag array */
+    mark = clear_flag (Common) ;    /* clear Flag but preserve Flag [i]<TRILINOS_CHOLMOD_EMPTY */
     Bp = B->p ;
     Bi = B->i ;
     n = B->nrow ;
-    ASSERT (cnode >= EMPTY && cnode < n) ;
-    ASSERT (IMPLIES (cnode >= 0, Flag [cnode] < EMPTY)) ;
+    ASSERT (cnode >= TRILINOS_CHOLMOD_EMPTY && cnode < n) ;
+    ASSERT (IMPLIES (cnode >= 0, Flag [cnode] < TRILINOS_CHOLMOD_EMPTY)) ;
 
     /* get ordering parameters */
     nd_components = Common->method [Common->current].nd_components ;
@@ -714,12 +714,12 @@ static void find_components
 	for (cj = 0 ; cj < cn ; cj++)
 	{
 	    /* get node snode, which is node cj of C.  It might already be in
-	     * the separator of C (and thus ordered, with Flag [snode] < EMPTY)
+	     * the separator of C (and thus ordered, with Flag [snode] < TRILINOS_CHOLMOD_EMPTY)
 	     */
 	    snode = (Map == NULL) ? (cj) : (Map [cj]) ;
 	    ASSERT (snode >= 0 && snode < n) ;
 
-	    if (Flag [snode] >= EMPTY && Flag [snode] < mark
+	    if (Flag [snode] >= TRILINOS_CHOLMOD_EMPTY && Flag [snode] < mark
 		    && ((Part == NULL) || Part [cj] == part))
 	    {
 
@@ -729,7 +729,7 @@ static void find_components
 
 		/* node snode is the repnode of a connected component S, the
 		 * parent of which is cnode, the repnode of C.  If cnode is
-		 * EMPTY then C is the original graph B. */
+		 * TRILINOS_CHOLMOD_EMPTY then C is the original graph B. */
 		PRINT2 (("----------:::snode "ID" cnode "ID"\n", snode, cnode));
 
 		ASSERT (CParent [snode] == -2) ;
@@ -765,7 +765,7 @@ static void find_components
 		    for (p = pstart ; p < pend ; p++)
 		    {
 			i = Bi [p] ;
-			if (i != j && Flag [i] >= EMPTY)
+			if (i != j && Flag [i] >= TRILINOS_CHOLMOD_EMPTY)
 			{
 			    /* node is still in the graph */
 			    Bi [pdest++] = i ;
@@ -800,7 +800,7 @@ static void find_components
 	}
     }
 
-    /* clear Flag array, but preserve Flag [i] < EMPTY */
+    /* clear Flag array, but preserve Flag [i] < TRILINOS_CHOLMOD_EMPTY */
     clear_flag (Common) ;
 }
 
@@ -843,10 +843,10 @@ UF_long CHOLMOD(bisect)	/* returns # of nodes in separator */
     /* check inputs */
     /* ---------------------------------------------------------------------- */
 
-    RETURN_IF_NULL_COMMON (EMPTY) ;
-    RETURN_IF_NULL (A, EMPTY) ;
-    RETURN_IF_NULL (Partition, EMPTY) ;
-    RETURN_IF_XTYPE_INVALID (A, CHOLMOD_PATTERN, CHOLMOD_ZOMPLEX, EMPTY) ;
+    RETURN_IF_NULL_COMMON (TRILINOS_CHOLMOD_EMPTY) ;
+    RETURN_IF_NULL (A, TRILINOS_CHOLMOD_EMPTY) ;
+    RETURN_IF_NULL (Partition, TRILINOS_CHOLMOD_EMPTY) ;
+    RETURN_IF_XTYPE_INVALID (A, CHOLMOD_PATTERN, CHOLMOD_ZOMPLEX, TRILINOS_CHOLMOD_EMPTY) ;
     Common->status = CHOLMOD_OK ;
 
     /* ---------------------------------------------------------------------- */
@@ -868,13 +868,13 @@ UF_long CHOLMOD(bisect)	/* returns # of nodes in separator */
     if (!ok)
     {
 	ERROR (CHOLMOD_TOO_LARGE, "problem too large") ;
-	return (EMPTY) ;
+	return (TRILINOS_CHOLMOD_EMPTY) ;
     }
 
     CHOLMOD(allocate_work) (n, s, 0, Common) ;
     if (Common->status < CHOLMOD_OK)
     {
-	return (EMPTY) ;
+	return (TRILINOS_CHOLMOD_EMPTY) ;
     }
     ASSERT (CHOLMOD(dump_work) (TRUE, TRUE, 0, Common)) ;
 
@@ -907,7 +907,7 @@ UF_long CHOLMOD(bisect)	/* returns # of nodes in separator */
 
     if (Common->status < CHOLMOD_OK)
     {
-	return (EMPTY) ;
+	return (TRILINOS_CHOLMOD_EMPTY) ;
     }
     Bp = B->p ;
     Bi = B->i ;
@@ -951,7 +951,7 @@ UF_long CHOLMOD(bisect)	/* returns # of nodes in separator */
 	/* out of memory */
 	CHOLMOD(free_sparse) (&B, Common) ;
 	CHOLMOD(free) (csize, sizeof (Int), Bew, Common) ;
-	return (EMPTY) ;
+	return (TRILINOS_CHOLMOD_EMPTY) ;
     }
 
     /* graph has unit node and edge weights */
@@ -984,7 +984,7 @@ UF_long CHOLMOD(bisect)	/* returns # of nodes in separator */
 
     B->ncol = n ;   /* restore size for memory usage statistics */
     CHOLMOD(free_sparse) (&B, Common) ;
-    Common->mark = EMPTY ;
+    Common->mark = TRILINOS_CHOLMOD_EMPTY ;
     CHOLMOD(clear_flag) (Common) ;
     CHOLMOD(free) (csize, sizeof (Int), Bew, Common) ;
     return (sepsize) ;
@@ -1023,7 +1023,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
     /* ---- output --- */
     Int *Perm,		/* size A->nrow, output permutation */
     Int *CParent,	/* size A->nrow.  On output, CParent [c] is the parent
-			 * of component c, or EMPTY if c is a root, and where
+			 * of component c, or TRILINOS_CHOLMOD_EMPTY if c is a root, and where
 			 * c is in the range 0 to # of components minus 1 */
     Int *Cmember,	/* size A->nrow.  Cmember [j] = c if node j of A is
 			 * in component c */
@@ -1039,7 +1039,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
     Int n, bnz, top, i, j, k, cnode, cdense, p, cj, cn, ci, cnz, mark, c, uncol,
 	sepsize, parent, ncomponents, threshold, ndense, pstart, pdest, pend,
 	nd_compress, nd_camd, csize, jnext, nd_small, total_weight,
-	nchild, child = EMPTY ;
+	nchild, child = TRILINOS_CHOLMOD_EMPTY ;
     cholmod_sparse *B, *C ;
     size_t s ;
     int ok = TRUE ;
@@ -1049,12 +1049,12 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
     /* get inputs */
     /* ---------------------------------------------------------------------- */
 
-    RETURN_IF_NULL_COMMON (EMPTY) ;
-    RETURN_IF_NULL (A, EMPTY) ;
-    RETURN_IF_NULL (Perm, EMPTY) ;
-    RETURN_IF_NULL (CParent, EMPTY) ;
-    RETURN_IF_NULL (Cmember, EMPTY) ;
-    RETURN_IF_XTYPE_INVALID (A, CHOLMOD_PATTERN, CHOLMOD_ZOMPLEX, EMPTY) ;
+    RETURN_IF_NULL_COMMON (TRILINOS_CHOLMOD_EMPTY) ;
+    RETURN_IF_NULL (A, TRILINOS_CHOLMOD_EMPTY) ;
+    RETURN_IF_NULL (Perm, TRILINOS_CHOLMOD_EMPTY) ;
+    RETURN_IF_NULL (CParent, TRILINOS_CHOLMOD_EMPTY) ;
+    RETURN_IF_NULL (Cmember, TRILINOS_CHOLMOD_EMPTY) ;
+    RETURN_IF_XTYPE_INVALID (A, CHOLMOD_PATTERN, CHOLMOD_ZOMPLEX, TRILINOS_CHOLMOD_EMPTY) ;
     Common->status = CHOLMOD_OK ;
 
     /* ---------------------------------------------------------------------- */
@@ -1098,13 +1098,13 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
     if (!ok)
     {
 	ERROR (CHOLMOD_TOO_LARGE, "problem too large") ;
-	return (EMPTY) ;
+	return (TRILINOS_CHOLMOD_EMPTY) ;
     }
 
     CHOLMOD(allocate_work) (n, s, 0, Common) ;
     if (Common->status < CHOLMOD_OK)
     {
-	return (EMPTY) ;
+	return (TRILINOS_CHOLMOD_EMPTY) ;
     }
     ASSERT (CHOLMOD(dump_work) (TRUE, TRUE, 0, Common)) ;
 
@@ -1131,7 +1131,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 
     if (Common->status < CHOLMOD_OK)
     {
-	return (EMPTY) ;
+	return (TRILINOS_CHOLMOD_EMPTY) ;
     }
 
     /* ---------------------------------------------------------------------- */
@@ -1157,7 +1157,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
     if (Common->status < CHOLMOD_OK)
     {
 	CHOLMOD(free) (3*n, sizeof (Int), Work3n, Common) ;
-	return (EMPTY) ;
+	return (TRILINOS_CHOLMOD_EMPTY) ;
     }
     Bp = B->p ;
     Bi = B->i ;
@@ -1171,7 +1171,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
     /* ---------------------------------------------------------------------- */
 
     /* all nodes start out unmarked and unordered (Type 4, see below) */
-    Common->mark = EMPTY ;
+    Common->mark = TRILINOS_CHOLMOD_EMPTY ;
     CHOLMOD(clear_flag) (Common) ;
     ASSERT (Flag == Common->Flag) ;
     ASSERT (CHOLMOD(dump_work) (TRUE, TRUE, 0, Common)) ;
@@ -1194,8 +1194,8 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 	threshold = MIN (n, threshold) ;
     }
     ndense = 0 ;
-    cnode = EMPTY ;
-    cdense = EMPTY ;
+    cnode = TRILINOS_CHOLMOD_EMPTY ;
+    cdense = TRILINOS_CHOLMOD_EMPTY ;
 
     for (j = 0 ; j < n ; j++)
     {
@@ -1205,13 +1205,13 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 	    /* node j is dense, prune it from B */
 	    PRINT2 (("j is dense %d\n", j)) ;
 	    ndense++ ;
-	    if (cnode == EMPTY)
+	    if (cnode == TRILINOS_CHOLMOD_EMPTY)
 	    {
 		/* first dense node found becomes root of this component,
 		 * which contains all of the dense nodes found here */
 		cdense = j ;
 		cnode = j ;
-		CParent [cnode] = EMPTY ;
+		CParent [cnode] = TRILINOS_CHOLMOD_EMPTY ;
 	    }
 	    Flag [j] = FLIP (cnode) ;
 	}
@@ -1229,10 +1229,10 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 	    Perm [k] = k ;
 	    Cmember [k] = 0 ;
 	}
-	CParent [0] = EMPTY ;
+	CParent [0] = TRILINOS_CHOLMOD_EMPTY ;
 	CHOLMOD(free_sparse) (&B, Common) ;
 	CHOLMOD(free) (3*n, sizeof (Int), Work3n, Common) ;
-	Common->mark = EMPTY ;
+	Common->mark = TRILINOS_CHOLMOD_EMPTY ;
 	CHOLMOD(clear_flag) (Common) ;
 	return (1) ;
     }
@@ -1249,10 +1249,10 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 	CHOLMOD(free_sparse) (&B, Common) ;
 	CHOLMOD(free) (csize, sizeof (Int), Cew, Common) ;
 	CHOLMOD(free) (3*n, sizeof (Int), Work3n, Common) ;
-	Common->mark = EMPTY ;
+	Common->mark = TRILINOS_CHOLMOD_EMPTY ;
 	CHOLMOD(clear_flag) (Common) ;
 	PRINT2 (("out of memory for C, etc\n")) ;
-	return (EMPTY) ;
+	return (TRILINOS_CHOLMOD_EMPTY) ;
     }
 
     Cp = C->p ;
@@ -1269,7 +1269,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
     }
 
     /* push the initial connnected components of B onto the Cstack */
-    top = EMPTY ;	/* Cstack is empty */
+    top = TRILINOS_CHOLMOD_EMPTY ;	/* Cstack is empty */
     /* workspace: Flag (nrow), Iwork (nrow); use Imap as workspace for Queue [*/
     find_components (B, NULL, n, cnode, NULL,
 	    Bnz, CParent, Cstack, &top, Imap, Common) ;
@@ -1287,7 +1287,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 	/* clear the Flag array, but do not modify negative entries in Flag  */
 	mark = clear_flag (Common) ;
 
-	DEBUG (for (i = 0 ; i < n ; i++) Imap [i] = EMPTY) ;
+	DEBUG (for (i = 0 ; i < n ; i++) Imap [i] = TRILINOS_CHOLMOD_EMPTY) ;
 
 	/* ------------------------------------------------------------------ */
 	/* get node(s) from the top of the Cstack */
@@ -1298,9 +1298,9 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 	 * each connected component is to be ordered separately (nd_components
 	 * is TRUE), then this while loop iterates just once. */
 
-	cnode = EMPTY ;
+	cnode = TRILINOS_CHOLMOD_EMPTY ;
 	cn = 0 ;
-	while (cnode == EMPTY)
+	while (cnode == TRILINOS_CHOLMOD_EMPTY)
 	{
 	    i = Cstack [top--] ;
 
@@ -1311,7 +1311,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 		cnode = i ;
 	    }
 
-	    ASSERT (i >= 0 && i < n && Flag [i] >= EMPTY) ;
+	    ASSERT (i >= 0 && i < n && Flag [i] >= TRILINOS_CHOLMOD_EMPTY) ;
 
 	    /* place i in the queue and mark it */
 	    Map [cn] = i ;
@@ -1320,37 +1320,37 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 	    cn++ ;
 	}
 
-	ASSERT (cnode != EMPTY) ;
+	ASSERT (cnode != TRILINOS_CHOLMOD_EMPTY) ;
 
 	/* During ordering, there are five kinds of nodes in the graph of B,
 	 * based on Flag [j] and CParent [j] for nodes j = 0 to n-1:
 	 *
 	 * Type 0: If cnode is a repnode of an unordered component, then
-	 * CParent [cnode] is in the range EMPTY to n-1 and
-	 * Flag [cnode] >= EMPTY.  This is a "live" node.
+	 * CParent [cnode] is in the range TRILINOS_CHOLMOD_EMPTY to n-1 and
+	 * Flag [cnode] >= TRILINOS_CHOLMOD_EMPTY.  This is a "live" node.
 	 *
 	 * Type 1: If cnode is a repnode of an ordered separator component,
-	 * then Flag [cnode] < EMPTY and FLAG [cnode] = FLIP (cnode).
-	 * CParent [cnode] is in the range EMPTY to n-1.  cnode is a root of
-	 * the separator tree if CParent [cnode] == EMPTY.  This node is dead.
+	 * then Flag [cnode] < TRILINOS_CHOLMOD_EMPTY and FLAG [cnode] = FLIP (cnode).
+	 * CParent [cnode] is in the range TRILINOS_CHOLMOD_EMPTY to n-1.  cnode is a root of
+	 * the separator tree if CParent [cnode] == TRILINOS_CHOLMOD_EMPTY.  This node is dead.
 	 *
 	 * Type 2: If node j isn't a repnode, has not been absorbed via
 	 * graph compression into another node, but is in an ordered separator
 	 * component, then cnode = FLIP (Flag [j]) gives the repnode of the
 	 * component that contains j and CParent [j]  is -2.  This node is dead.
-	 * Note that Flag [j] < EMPTY.
+	 * Note that Flag [j] < TRILINOS_CHOLMOD_EMPTY.
 	 *
 	 * Type 3: If node i has been absorbed via graph compression into some
 	 * other node j = FLIP (Flag [i]) where j is not a repnode.
 	 * CParent [j] is -2.  Node i may or may not be in an ordered
-	 * component.  This node is dead.  Note that Flag [j] < EMPTY.
+	 * component.  This node is dead.  Note that Flag [j] < TRILINOS_CHOLMOD_EMPTY.
 	 *
 	 * Type 4: If node j is "live" (not in an ordered component, and not
-	 * absorbed into any other node), then Flag [j] >= EMPTY.
+	 * absorbed into any other node), then Flag [j] >= TRILINOS_CHOLMOD_EMPTY.
 	 *
 	 * Only "live" nodes (of type 0 or 4) are placed in a subgraph to be
-	 * partitioned.  Node j is alive if Flag [j] >= EMPTY, and dead if
-	 * Flag [j] < EMPTY.
+	 * partitioned.  Node j is alive if Flag [j] >= TRILINOS_CHOLMOD_EMPTY, and dead if
+	 * Flag [j] < TRILINOS_CHOLMOD_EMPTY.
 	 */
 
 	/* ------------------------------------------------------------------ */
@@ -1383,7 +1383,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 	    {
 		i = Bi [p] ;
 		/* prune diagonal entries and dead edges from B */
-		if (i != j && Flag [i] >= EMPTY)
+		if (i != j && Flag [i] >= TRILINOS_CHOLMOD_EMPTY)
 		{
 		    /* live node i is in the current component */
 		    Bi [pdest++] = i ;
@@ -1423,7 +1423,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 	    PRINT2 (("----------------------------C column cj: "ID" j: "ID"\n",
 		cj, j)) ;
 	    ASSERT (j >= 0 && j < n) ;
-	    ASSERT (Flag [j] >= EMPTY) ;
+	    ASSERT (Flag [j] >= TRILINOS_CHOLMOD_EMPTY) ;
 	    for (p = Cp [cj] ; p < Cp [cj+1] ; p++)
 	    {
 		ci = Ci [p] ;
@@ -1431,7 +1431,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 		PRINT3 (("ci: "ID" i: "ID"\n", ci, i)) ;
 		ASSERT (ci != cj && ci >= 0 && ci < cn) ;
 		ASSERT (i != j && i >= 0 && i < n) ;
-		ASSERT (Flag [i] >= EMPTY) ;
+		ASSERT (Flag [i] >= TRILINOS_CHOLMOD_EMPTY) ;
 	    }
 	}
 #endif
@@ -1475,9 +1475,9 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 		CHOLMOD(free_sparse) (&B, Common) ;
 		CHOLMOD(free) (csize, sizeof (Int), Cew, Common) ;
 		CHOLMOD(free) (3*n, sizeof (Int), Work3n, Common) ;
-		Common->mark = EMPTY ;
+		Common->mark = TRILINOS_CHOLMOD_EMPTY ;
 		CHOLMOD(clear_flag) (Common) ;
-		return (EMPTY) ;
+		return (TRILINOS_CHOLMOD_EMPTY) ;
 	    }
 
 	    /* -------------------------------------------------------------- */
@@ -1486,7 +1486,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 
 	    for (ci = 0 ; ci < cn ; ci++)
 	    {
-		if (Hash [ci] < EMPTY)
+		if (Hash [ci] < TRILINOS_CHOLMOD_EMPTY)
 		{
 		    /* ci is dead in C, having been absorbed into cj */
 		    cj = FLIP (Hash [ci]) ;
@@ -1542,7 +1542,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 		PRINT2 (("      node cj: "ID" j: "ID" ordered\n", cj, j)) ;
 	    }
 	    ASSERT (Flag [cnode] == FLIP (cnode)) ;
-	    ASSERT (cnode != EMPTY && Flag [cnode] < EMPTY) ;
+	    ASSERT (cnode != TRILINOS_CHOLMOD_EMPTY && Flag [cnode] < TRILINOS_CHOLMOD_EMPTY) ;
 	    PRINT0 (("discarded\n")) ;
 
 	}
@@ -1554,9 +1554,9 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 	     * to be non-empty. */
 	    PRINT0 (("sepsize not tiny: "ID"\n", sepsize)) ;
 	    parent = CParent [cnode] ;
-	    ASSERT (parent >= EMPTY && parent < n) ;
+	    ASSERT (parent >= TRILINOS_CHOLMOD_EMPTY && parent < n) ;
 	    CParent [cnode] = -2 ;
-	    cnode = EMPTY ;
+	    cnode = TRILINOS_CHOLMOD_EMPTY ;
 	    for (cj = 0 ; cj < cn ; cj++)
 	    {
 		j = Map [cj] ;
@@ -1565,7 +1565,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 		    /* All nodes in the separator become part of a component
 		     * whose repnode is cnode */
 		    PRINT2 (("node cj: "ID" j: "ID" ordered\n", cj, j)) ;
-		    if (cnode == EMPTY)
+		    if (cnode == TRILINOS_CHOLMOD_EMPTY)
 		    {
 			PRINT2(("------------new cnode: cj "ID" j "ID"\n",
 				    cj, j)) ;
@@ -1579,7 +1579,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 				cj, j)) ;
 		}
 	    }
-	    ASSERT (cnode != EMPTY && Flag [cnode] < EMPTY) ;
+	    ASSERT (cnode != TRILINOS_CHOLMOD_EMPTY && Flag [cnode] < TRILINOS_CHOLMOD_EMPTY) ;
 	    ASSERT (CParent [cnode] == -2) ;
 	    CParent [cnode] = parent ;
 
@@ -1620,7 +1620,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 	}
 	cnode = j ;
 	ASSERT (cnode >= 0 && cnode < n) ;
-	ASSERT (CParent [cnode] >= EMPTY && CParent [cnode] < n) ;
+	ASSERT (CParent [cnode] >= TRILINOS_CHOLMOD_EMPTY && CParent [cnode] < n) ;
 	PRINT2 (("i "ID" is in component with cnode "ID"\n", i, cnode)) ;
 	ASSERT (Flag [cnode] == FLIP (cnode)) ;
 
@@ -1647,7 +1647,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
     for (j = 0 ; j < n ; j++)
     {
 	PRINT2 (("j %d CParent %d  ", j, CParent [j])) ;
-	if (CParent [j] >= EMPTY && CParent [j] < n)
+	if (CParent [j] >= TRILINOS_CHOLMOD_EMPTY && CParent [j] < n)
 	{
 	    /* case 1: j is a repnode of a component */
 	    cnode = j ;
@@ -1659,7 +1659,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 	    cnode = FLIP (Flag [j]) ;
 	    PRINT2 ((" repnode is %d\n", cnode)) ;
 	    ASSERT (cnode >= 0 && cnode < n) ;
-	    ASSERT (CParent [cnode] >= EMPTY && CParent [cnode] < n) ;
+	    ASSERT (CParent [cnode] >= TRILINOS_CHOLMOD_EMPTY && CParent [cnode] < n) ;
 	}
 	ASSERT (Flag [cnode] == FLIP (cnode)) ;
 	/* case 3 no longer holds */
@@ -1687,7 +1687,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 
     if (ndense > 0)
     {
-	ASSERT (CParent [cdense] == EMPTY) ;	/* cdense has no parent */
+	ASSERT (CParent [cdense] == TRILINOS_CHOLMOD_EMPTY) ;	/* cdense has no parent */
 	/* find the children of cdense */
 	nchild = 0 ;
 	for (j = 0 ; j < n ; j++)
@@ -1703,7 +1703,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 	    /* the cdense node has just one child; merge the two nodes */
 	    PRINT1 (("root has one child\n")) ;
 	    CParent [cdense] = -2 ;		/* cdense is deleted */
-	    CParent [child] = EMPTY ;		/* child becomes a root */
+	    CParent [child] = TRILINOS_CHOLMOD_EMPTY ;		/* child becomes a root */
 	    for (j = 0 ; j < n ; j++)
 	    {
 		if (Flag [j] == FLIP (cdense))
@@ -1734,7 +1734,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 
     /* use Iwork [0..n-1] as workspace for Ipost ( */
     Ipost = Iwork ;
-    DEBUG (for (j = 0 ; j < n ; j++) Ipost [j] = EMPTY) ;
+    DEBUG (for (j = 0 ; j < n ; j++) Ipost [j] = TRILINOS_CHOLMOD_EMPTY) ;
 
     /* compute inverse postorder */
     for (c = 0 ; c < ncomponents ; c++)
@@ -1742,7 +1742,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 	cnode = Post [c] ;
 	ASSERT (cnode >= 0 && cnode < n) ;
 	Ipost [cnode] = c ;
-	ASSERT (Head [c] == EMPTY) ;
+	ASSERT (Head [c] == TRILINOS_CHOLMOD_EMPTY) ;
     }
 
     /* adjust the parent array */
@@ -1751,7 +1751,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
     for (c = 0 ; c < ncomponents ; c++)
     {
 	parent = CParent [Post [c]] ;
-	NewParent [c] = (parent == EMPTY) ? EMPTY : (Ipost [parent]) ;
+	NewParent [c] = (parent == TRILINOS_CHOLMOD_EMPTY) ? TRILINOS_CHOLMOD_EMPTY : (Ipost [parent]) ;
     }
     for (c = 0 ; c < ncomponents ; c++)
     {
@@ -1770,7 +1770,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
     }
     for (c = 0 ; c < ncomponents ; c++)
     {
-	if (CParent [c] != EMPTY) Cmember [CParent [c]]++ ;
+	if (CParent [c] != TRILINOS_CHOLMOD_EMPTY) Cmember [CParent [c]]++ ;
     }
     for (c = 0 ; c < ncomponents ; c++)
     {
@@ -1803,7 +1803,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
     /* clear the Flag array */
     /* ---------------------------------------------------------------------- */
 
-    Common->mark = EMPTY ;
+    Common->mark = TRILINOS_CHOLMOD_EMPTY ;
     CHOLMOD(clear_flag) (Common) ;
     ASSERT (CHOLMOD(dump_work) (TRUE, TRUE, 0, Common)) ;
 
@@ -1830,7 +1830,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 	    if (Common->status < CHOLMOD_OK)
 	    {
 		PRINT0 (("make symmetric failed\n")) ;
-		return (EMPTY) ;
+		return (TRILINOS_CHOLMOD_EMPTY) ;
 	    }
 	    ASSERT ((Int) (B->nrow) == n && (Int) (B->ncol) == n) ;
 	    PRINT2 (("nested dissection (2)\n")) ;
@@ -1850,7 +1850,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 	    {
 		/* failed */
 		PRINT0 (("camd/csymamd failed\n")) ;
-		return (EMPTY) ;
+		return (TRILINOS_CHOLMOD_EMPTY) ;
 	    }
 	}
 	else
@@ -1861,7 +1861,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 	    {
 		/* trilinos_ccolamd failed */
 		PRINT2 (("trilinos_ccolamd failed\n")) ;
-		return (EMPTY) ;
+		return (TRILINOS_CHOLMOD_EMPTY) ;
 	    }
 	}
 
@@ -1898,11 +1898,11 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 	k = 0 ;
 	for (c = 0 ; c < ncomponents ; c++)
 	{
-	    for (j = Head [c] ; j != EMPTY ; j = Next [j])
+	    for (j = Head [c] ; j != TRILINOS_CHOLMOD_EMPTY ; j = Next [j])
 	    {
 		Perm [k++] = j ;
 	    }
-	    Head [c] = EMPTY ;
+	    Head [c] = TRILINOS_CHOLMOD_EMPTY ;
 	}
 	ASSERT (k == n) ;
 
@@ -1958,13 +1958,13 @@ UF_long CHOLMOD(collapse_septree)
     /* get inputs */
     /* ---------------------------------------------------------------------- */
 
-    RETURN_IF_NULL_COMMON (EMPTY) ;
-    RETURN_IF_NULL (CParent, EMPTY) ;
-    RETURN_IF_NULL (Cmember, EMPTY) ;
+    RETURN_IF_NULL_COMMON (TRILINOS_CHOLMOD_EMPTY) ;
+    RETURN_IF_NULL (CParent, TRILINOS_CHOLMOD_EMPTY) ;
+    RETURN_IF_NULL (Cmember, TRILINOS_CHOLMOD_EMPTY) ;
     if (n < ncomponents)
     {
 	ERROR (CHOLMOD_INVALID, "invalid separator tree") ;
-	return (EMPTY) ;
+	return (TRILINOS_CHOLMOD_EMPTY) ;
     }
     Common->status = CHOLMOD_OK ;
     nc = ncomponents ;
@@ -1987,12 +1987,12 @@ UF_long CHOLMOD(collapse_septree)
     if (!ok)
     {
 	ERROR (CHOLMOD_TOO_LARGE, "problem too large") ;
-	return (EMPTY) ;
+	return (TRILINOS_CHOLMOD_EMPTY) ;
     }
     CHOLMOD(allocate_work) (0, s, 0, Common) ;
     if (Common->status < CHOLMOD_OK)
     {
-	return (EMPTY) ;
+	return (TRILINOS_CHOLMOD_EMPTY) ;
     }
     W = Common->Iwork ;
     Count    = W ; W += ncomponents ;	    /* size ncomponents */
@@ -2005,11 +2005,11 @@ UF_long CHOLMOD(collapse_septree)
 
     for (c = 0 ; c < nc ; c++)
     {
-	First [c] = EMPTY ;
+	First [c] = TRILINOS_CHOLMOD_EMPTY ;
     }
     for (k = 0 ; k < nc ; k++)
     {
-	for (c = k ; c != EMPTY && First [c] == -1 ; c = CParent [c])
+	for (c = k ; c != TRILINOS_CHOLMOD_EMPTY && First [c] == -1 ; c = CParent [c])
 	{
 	    ASSERT (c >= 0 && c < nc) ;
 	    First [c] = k ;
@@ -2046,8 +2046,8 @@ UF_long CHOLMOD(collapse_septree)
     {
 	/* add the subtree of the child, c, into the count of its parent */
 	parent = CParent [c] ;
-	ASSERT (parent >= EMPTY && parent < nc) ;
-	if (parent != EMPTY)
+	ASSERT (parent >= TRILINOS_CHOLMOD_EMPTY && parent < nc) ;
+	if (parent != TRILINOS_CHOLMOD_EMPTY)
 	{
 	    Csubtree [parent] += Csubtree [c] ;
 	}
@@ -2056,7 +2056,7 @@ UF_long CHOLMOD(collapse_septree)
 #ifndef NDEBUG
     /* the sum of the roots should be n */
     j = 0 ;
-    for (c = 0 ; c < nc ; c++) if (CParent [c] == EMPTY) j += Csubtree [c] ;
+    for (c = 0 ; c < nc ; c++) if (CParent [c] == TRILINOS_CHOLMOD_EMPTY) j += Csubtree [c] ;
     ASSERT (j == (Int) n) ;
 #endif
 
@@ -2108,7 +2108,7 @@ UF_long CHOLMOD(collapse_septree)
 	for (c = 0 ; c < nc ; c++)
 	{
 	    Map [c] = nc_new ;
-	    if (CParent [c] >= EMPTY)
+	    if (CParent [c] >= TRILINOS_CHOLMOD_EMPTY)
 	    {
 		/* node c is alive, and becomes node Map[c] in the new tree.
 		 * Increment nc_new for the next node c. */
@@ -2120,10 +2120,10 @@ UF_long CHOLMOD(collapse_septree)
 	for (c = 0 ; c < nc ; c++)
 	{
 	    parent = CParent [c] ;
-	    if (parent >= EMPTY)
+	    if (parent >= TRILINOS_CHOLMOD_EMPTY)
 	    {
 		/* node c is alive */
-		CParent [Map [c]] = (parent == EMPTY) ? EMPTY : Map [parent] ;
+		CParent [Map [c]] = (parent == TRILINOS_CHOLMOD_EMPTY) ? TRILINOS_CHOLMOD_EMPTY : Map [parent] ;
 	    }
 	}
 	for (j = 0 ; j < (Int) n ; j++)

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Partition/amesos_cholmod_metis.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Partition/amesos_cholmod_metis.c
@@ -221,18 +221,18 @@ UF_long CHOLMOD(metis_bisector)	/* returns separator size */
     /* check inputs */
     /* ---------------------------------------------------------------------- */
 
-    RETURN_IF_NULL_COMMON (EMPTY) ;
-    RETURN_IF_NULL (A, EMPTY) ;
-    RETURN_IF_NULL (Anw, EMPTY) ;
-    RETURN_IF_NULL (Aew, EMPTY) ;
-    RETURN_IF_NULL (Partition, EMPTY) ;
-    RETURN_IF_XTYPE_INVALID (A, CHOLMOD_PATTERN, CHOLMOD_ZOMPLEX, EMPTY) ;
+    RETURN_IF_NULL_COMMON (TRILINOS_CHOLMOD_EMPTY) ;
+    RETURN_IF_NULL (A, TRILINOS_CHOLMOD_EMPTY) ;
+    RETURN_IF_NULL (Anw, TRILINOS_CHOLMOD_EMPTY) ;
+    RETURN_IF_NULL (Aew, TRILINOS_CHOLMOD_EMPTY) ;
+    RETURN_IF_NULL (Partition, TRILINOS_CHOLMOD_EMPTY) ;
+    RETURN_IF_XTYPE_INVALID (A, CHOLMOD_PATTERN, CHOLMOD_ZOMPLEX, TRILINOS_CHOLMOD_EMPTY) ;
     if (A->stype || A->nrow != A->ncol)
     {
 	/* A must be square, with both upper and lower parts present */
 	ERROR (CHOLMOD_INVALID, "matrix must be square, symmetric,"
 		" and with both upper/lower parts present") ;
-	return (EMPTY) ;
+	return (TRILINOS_CHOLMOD_EMPTY) ;
     }
     Common->status = CHOLMOD_OK ;
 
@@ -263,7 +263,7 @@ UF_long CHOLMOD(metis_bisector)	/* returns separator size */
     if (sizeof (Int) > sizeof (idxtype) && MAX (n,nz) > INT_MAX / sizeof (int))
     {
 	/* CHOLMOD's matrix is too large for METIS */
-	return (EMPTY) ;
+	return (TRILINOS_CHOLMOD_EMPTY) ;
     }
 #endif
 
@@ -311,7 +311,7 @@ UF_long CHOLMOD(metis_bisector)	/* returns separator size */
 	    CHOLMOD(free) (n1, sizeof (idxtype), Mp,    Common) ;
 	    CHOLMOD(free) (n,  sizeof (idxtype), Mnw,   Common) ;
 	    CHOLMOD(free) (n,  sizeof (idxtype), Mpart, Common) ;
-	    return (EMPTY) ;
+	    return (TRILINOS_CHOLMOD_EMPTY) ;
 	}
 	for (p = 0 ; p < nz ; p++)
 	{
@@ -346,7 +346,7 @@ UF_long CHOLMOD(metis_bisector)	/* returns separator size */
 	    CHOLMOD(free) (n,  sizeof (idxtype), Mnw,   Common) ;
 	    CHOLMOD(free) (n,  sizeof (idxtype), Mpart, Common) ;
 	}
-	return (EMPTY) ;
+	return (TRILINOS_CHOLMOD_EMPTY) ;
     }
 
     /* ---------------------------------------------------------------------- */

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Partition/amesos_cholmod_nesdis.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Partition/amesos_cholmod_nesdis.c
@@ -199,10 +199,10 @@ static UF_long partition    /* size of separator or -1 if failure */
 	    hash = Hash [j] ;
 	    ASSERT (hash >= 0 && hash < csize) ;
 	    head = Hhead [hash] ;
-	    if (head > EMPTY)
+	    if (head > TRILINOS_CHOLMOD_EMPTY)
 	    {
 		/* hash bucket for this hash key is empty. */
-		head = EMPTY ;
+		head = TRILINOS_CHOLMOD_EMPTY ;
 	    }
 	    else
 	    {
@@ -215,7 +215,7 @@ static UF_long partition    /* size of separator or -1 if failure */
 	     * bucket. */
 	    Hhead [hash] = FLIP (j) ;
 	    Next [j] = head ;
-	    ASSERT (head >= EMPTY && head < n) ;
+	    ASSERT (head >= TRILINOS_CHOLMOD_EMPTY && head < n) ;
 	}
 
 #ifndef NDEBUG
@@ -225,13 +225,13 @@ static UF_long partition    /* size of separator or -1 if failure */
 	    hash = Hash [k] ;
 	    ASSERT (hash >= 0 && hash < csize) ;
 	    head = Hhead [hash] ;
-	    ASSERT (head < EMPTY) ;	/* hash bucket not empty */
+	    ASSERT (head < TRILINOS_CHOLMOD_EMPTY) ;	/* hash bucket not empty */
 	    j = FLIP (head) ;
 	    ASSERT (j >= 0 && j < n) ;
 	    if (j == k)
 	    {
 		PRINT2 (("hash "ID": ", hash)) ;
-		for ( ; j != EMPTY ; j = Next [j])
+		for ( ; j != TRILINOS_CHOLMOD_EMPTY ; j = Next [j])
 		{
 		    PRINT3 ((" "ID"", j)) ;
 		    ASSERT (j >= 0 && j < n) ;
@@ -265,7 +265,7 @@ static UF_long partition    /* size of separator or -1 if failure */
 
 	for (i = 0 ; i < n ; i++)
 	{
-	    Cmap [i] = EMPTY ;
+	    Cmap [i] = TRILINOS_CHOLMOD_EMPTY ;
 	}
 
 	for (k = 0 ; k < n ; k++)
@@ -279,14 +279,14 @@ static UF_long partition    /* size of separator or -1 if failure */
 		continue ;
 	    }
 	    head = Hhead [hash] ;
-	    ASSERT (head < EMPTY || head == 1) ;
+	    ASSERT (head < TRILINOS_CHOLMOD_EMPTY || head == 1) ;
 	    if (head == 1)
 	    {
 		/* hash bucket is already empty */
 		continue ;
 	    }
 	    PRINT2 (("\n--------------------hash "ID":\n", hash)) ;
-	    for (j = FLIP (head) ; j != EMPTY && Next[j] > EMPTY ; j = Next [j])
+	    for (j = FLIP (head) ; j != TRILINOS_CHOLMOD_EMPTY && Next[j] > TRILINOS_CHOLMOD_EMPTY ; j = Next [j])
 	    {
 		/* compare j with all nodes i following it in hash bucket */
 		ASSERT (j >= 0 && j < n && Hash [j] == hash) ;
@@ -297,7 +297,7 @@ static UF_long partition    /* size of separator or -1 if failure */
 		DEBUG (for (i = 0 ; i < n ; i++) ASSERT (!Cmap_MARKED (i))) ;
 		DEBUG (pruned = FALSE) ;
 		ilast = j ;
-		for (i = Next [j] ; i != EMPTY ; i = Next [i])
+		for (i = Next [j] ; i != TRILINOS_CHOLMOD_EMPTY ; i = Next [i])
 		{
 		    ASSERT (i >= 0 && i < n && Hash [i] == hash && i != j) ;
 		    pi = Cp [i] ;
@@ -408,11 +408,11 @@ static UF_long partition    /* size of separator or -1 if failure */
 
 	/* Cmap [j] = k if node j is alive and the kth node of compressed graph.
 	 * The mapping is done monotonically (that is, k <= j) to simplify the
-	 * uncompression later on.  Cmap [j] = EMPTY if node j is dead. */
+	 * uncompression later on.  Cmap [j] = TRILINOS_CHOLMOD_EMPTY if node j is dead. */
 
 	for (j = 0 ; j < n ; j++)
 	{
-	    Cmap [j] = EMPTY ;
+	    Cmap [j] = TRILINOS_CHOLMOD_EMPTY ;
 	}
 	k = 0 ;
 	for (j = 0 ; j < n ; j++)
@@ -449,8 +449,8 @@ static UF_long partition    /* size of separator or -1 if failure */
 		    i = Ci [p] ;
 		    ASSERT (i >= 0 && i < n && i != j) ;
 		    i = Cmap [i] ;
-		    ASSERT (i >= EMPTY && i < cn && i != k) ;
-		    if (i > EMPTY)
+		    ASSERT (i >= TRILINOS_CHOLMOD_EMPTY && i < cn && i != k) ;
+		    if (i > TRILINOS_CHOLMOD_EMPTY)
 		    {
 			ASSERT (pdest <= p) ;
 			Ci [pdest++] = i ;
@@ -513,12 +513,12 @@ static UF_long partition    /* size of separator or -1 if failure */
 	{
 	    /* do this in reverse order so that Cnw can be expanded in place */
 	    k = Cmap [j] ;
-	    ASSERT (k >= EMPTY && k < n) ;
-	    if (k > EMPTY)
+	    ASSERT (k >= TRILINOS_CHOLMOD_EMPTY && k < n) ;
+	    if (k > TRILINOS_CHOLMOD_EMPTY)
 	    {
 		/* node k in compressed graph and is node j in full graph */
 		ASSERT (k <= j) ;
-		ASSERT (Hash [j] >= EMPTY) ;
+		ASSERT (Hash [j] >= TRILINOS_CHOLMOD_EMPTY) ;
 		Part [j] = Part [k] ;
 		Cnw [j] = Cnw [k] ;
 	    }
@@ -526,19 +526,19 @@ static UF_long partition    /* size of separator or -1 if failure */
 	    {
 		/* node j is a dead node */
 		Cnw [j] = 0 ;
-		DEBUG (Part [j] = EMPTY) ;
-		ASSERT (Hash [j] < EMPTY) ;
+		DEBUG (Part [j] = TRILINOS_CHOLMOD_EMPTY) ;
+		ASSERT (Hash [j] < TRILINOS_CHOLMOD_EMPTY) ;
 	    }
 	}
 
 	/* find the components for the dead nodes */
 	for (i = 0 ; i < n ; i++)
 	{
-	    if (Hash [i] < EMPTY)
+	    if (Hash [i] < TRILINOS_CHOLMOD_EMPTY)
 	    {
 		/* node i has been absorbed into node j */
 		j = FLIP (Hash [i]) ;
-		ASSERT (Part [i] == EMPTY && j >= 0 && j < n && Cnw [i] == 0) ;
+		ASSERT (Part [i] == TRILINOS_CHOLMOD_EMPTY && j >= 0 && j < n && Cnw [i] == 0) ;
 		Part [i] = Part [j] ;
 	    }
 	    ASSERT (Part [i] >= 0 && Part [i] <= 2) ;
@@ -548,7 +548,7 @@ static UF_long partition    /* size of separator or -1 if failure */
 	PRINT2 (("Part: ")) ;
 	for (cnt = 0, j = 0 ; j < n ; j++)
 	{
-	    ASSERT (Part [j] != EMPTY) ;
+	    ASSERT (Part [j] != TRILINOS_CHOLMOD_EMPTY) ;
 	    PRINT2 ((""ID" ", Part [j])) ;
 	    if (Part [j] == 2) cnt += Cnw [j] ;
 	}
@@ -574,14 +574,14 @@ static UF_long partition    /* size of separator or -1 if failure */
 /* === clear_flag =========================================================== */
 /* ========================================================================== */
 
-/* A node j has been removed from the graph if Flag [j] < EMPTY.
- * If Flag [j] >= EMPTY && Flag [j] < mark, then node j is alive but unmarked.
+/* A node j has been removed from the graph if Flag [j] < TRILINOS_CHOLMOD_EMPTY.
+ * If Flag [j] >= TRILINOS_CHOLMOD_EMPTY && Flag [j] < mark, then node j is alive but unmarked.
  * Flag [j] == mark means that node j is alive and marked.  Incrementing mark
  * means that all nodes are either (still) dead, or live but unmarked.
  *
  * On output, Common->mark < Common->Flag [i] for all i from 0 to Common->nrow.
  * This is the same output condition as cholmod_clear_flag, except that this
- * routine maintains the Flag [i] < EMPTY condition as well, if that condition
+ * routine maintains the Flag [i] < TRILINOS_CHOLMOD_EMPTY condition as well, if that condition
  * was true on input.
  *
  * workspace: Flag (nrow)
@@ -600,13 +600,13 @@ static UF_long clear_flag (cholmod_common *Common)
 	Flag = Common->Flag ;
 	for (i = 0 ; i < nrow ; i++)
 	{
-	    /* if Flag [i] < EMPTY, leave it alone */
-	    if (Flag [i] >= EMPTY)
+	    /* if Flag [i] < TRILINOS_CHOLMOD_EMPTY, leave it alone */
+	    if (Flag [i] >= TRILINOS_CHOLMOD_EMPTY)
 	    {
-		Flag [i] = EMPTY ;
+		Flag [i] = TRILINOS_CHOLMOD_EMPTY ;
 	    }
 	}
-	/* now Flag [i] <= EMPTY for all i */
+	/* now Flag [i] <= TRILINOS_CHOLMOD_EMPTY for all i */
 	Common->mark = 0 ;
     }
     return (Common->mark) ;
@@ -622,7 +622,7 @@ static UF_long clear_flag (cholmod_common *Common)
  * is NULL, then it is assumed to be the identity mapping
  * (Map [0..cn-1] = 0..cn-1).
  *
- * A node j does not appear in B if it has been ordered (Flag [j] < EMPTY,
+ * A node j does not appear in B if it has been ordered (Flag [j] < TRILINOS_CHOLMOD_EMPTY,
  * which means that j has been ordered and is "deleted" from B).
  *
  * If the size of a component is large, it is placed on the component stack,
@@ -649,7 +649,7 @@ static void find_components
     cholmod_sparse *B,
     Int Map [ ],	    /* size n, only Map [0..cn-1] used */
     Int cn,		    /* # of nodes in C */
-    Int cnode,		    /* root node of component C, or EMPTY if C is the
+    Int cnode,		    /* root node of component C, or TRILINOS_CHOLMOD_EMPTY if C is the
 			     * entire graph B */
 
     Int Part [ ],	    /* size cn, optional */
@@ -660,7 +660,7 @@ static void find_components
 
     Int CParent [ ],	    /* CParent [i] = j if component with repnode j is
 			     * the parent of the component with repnode i.
-			     * CParent [i] = EMPTY if the component with
+			     * CParent [i] = TRILINOS_CHOLMOD_EMPTY if the component with
 			     * repnode i is a root of the separator tree.
 			     * CParent [i] is -2 if i is not a repnode. */
     Int Cstack [ ],	    /* component stack for nested dissection */
@@ -683,13 +683,13 @@ static void find_components
 
     PRINT2 (("find components: cn %d\n", cn)) ;
     Flag = Common->Flag ;	    /* size n */
-    Common->mark = EMPTY ;	    /* force initialization of Flag array */
-    mark = clear_flag (Common) ;    /* clear Flag but preserve Flag [i]<EMPTY */
+    Common->mark = TRILINOS_CHOLMOD_EMPTY ;	    /* force initialization of Flag array */
+    mark = clear_flag (Common) ;    /* clear Flag but preserve Flag [i]<TRILINOS_CHOLMOD_EMPTY */
     Bp = B->p ;
     Bi = B->i ;
     n = B->nrow ;
-    ASSERT (cnode >= EMPTY && cnode < n) ;
-    ASSERT (IMPLIES (cnode >= 0, Flag [cnode] < EMPTY)) ;
+    ASSERT (cnode >= TRILINOS_CHOLMOD_EMPTY && cnode < n) ;
+    ASSERT (IMPLIES (cnode >= 0, Flag [cnode] < TRILINOS_CHOLMOD_EMPTY)) ;
 
     /* get ordering parameters */
     nd_components = Common->method [Common->current].nd_components ;
@@ -711,12 +711,12 @@ static void find_components
 	for (cj = 0 ; cj < cn ; cj++)
 	{
 	    /* get node snode, which is node cj of C.  It might already be in
-	     * the separator of C (and thus ordered, with Flag [snode] < EMPTY)
+	     * the separator of C (and thus ordered, with Flag [snode] < TRILINOS_CHOLMOD_EMPTY)
 	     */
 	    snode = (Map == NULL) ? (cj) : (Map [cj]) ;
 	    ASSERT (snode >= 0 && snode < n) ;
 
-	    if (Flag [snode] >= EMPTY && Flag [snode] < mark
+	    if (Flag [snode] >= TRILINOS_CHOLMOD_EMPTY && Flag [snode] < mark
 		    && ((Part == NULL) || Part [cj] == part))
 	    {
 
@@ -726,7 +726,7 @@ static void find_components
 
 		/* node snode is the repnode of a connected component S, the
 		 * parent of which is cnode, the repnode of C.  If cnode is
-		 * EMPTY then C is the original graph B. */
+		 * TRILINOS_CHOLMOD_EMPTY then C is the original graph B. */
 		PRINT2 (("----------:::snode "ID" cnode "ID"\n", snode, cnode));
 
 		ASSERT (CParent [snode] == -2) ;
@@ -762,7 +762,7 @@ static void find_components
 		    for (p = pstart ; p < pend ; p++)
 		    {
 			i = Bi [p] ;
-			if (i != j && Flag [i] >= EMPTY)
+			if (i != j && Flag [i] >= TRILINOS_CHOLMOD_EMPTY)
 			{
 			    /* node is still in the graph */
 			    Bi [pdest++] = i ;
@@ -797,7 +797,7 @@ static void find_components
 	}
     }
 
-    /* clear Flag array, but preserve Flag [i] < EMPTY */
+    /* clear Flag array, but preserve Flag [i] < TRILINOS_CHOLMOD_EMPTY */
     clear_flag (Common) ;
 }
 
@@ -840,10 +840,10 @@ UF_long CHOLMOD(bisect)	/* returns # of nodes in separator */
     /* check inputs */
     /* ---------------------------------------------------------------------- */
 
-    RETURN_IF_NULL_COMMON (EMPTY) ;
-    RETURN_IF_NULL (A, EMPTY) ;
-    RETURN_IF_NULL (Partition, EMPTY) ;
-    RETURN_IF_XTYPE_INVALID (A, CHOLMOD_PATTERN, CHOLMOD_ZOMPLEX, EMPTY) ;
+    RETURN_IF_NULL_COMMON (TRILINOS_CHOLMOD_EMPTY) ;
+    RETURN_IF_NULL (A, TRILINOS_CHOLMOD_EMPTY) ;
+    RETURN_IF_NULL (Partition, TRILINOS_CHOLMOD_EMPTY) ;
+    RETURN_IF_XTYPE_INVALID (A, CHOLMOD_PATTERN, CHOLMOD_ZOMPLEX, TRILINOS_CHOLMOD_EMPTY) ;
     Common->status = CHOLMOD_OK ;
 
     /* ---------------------------------------------------------------------- */
@@ -865,13 +865,13 @@ UF_long CHOLMOD(bisect)	/* returns # of nodes in separator */
     if (!ok)
     {
 	ERROR (CHOLMOD_TOO_LARGE, "problem too large") ;
-	return (EMPTY) ;
+	return (TRILINOS_CHOLMOD_EMPTY) ;
     }
 
     CHOLMOD(allocate_work) (n, s, 0, Common) ;
     if (Common->status < CHOLMOD_OK)
     {
-	return (EMPTY) ;
+	return (TRILINOS_CHOLMOD_EMPTY) ;
     }
     ASSERT (CHOLMOD(dump_work) (TRUE, TRUE, 0, Common)) ;
 
@@ -904,7 +904,7 @@ UF_long CHOLMOD(bisect)	/* returns # of nodes in separator */
 
     if (Common->status < CHOLMOD_OK)
     {
-	return (EMPTY) ;
+	return (TRILINOS_CHOLMOD_EMPTY) ;
     }
     Bp = B->p ;
     Bi = B->i ;
@@ -948,7 +948,7 @@ UF_long CHOLMOD(bisect)	/* returns # of nodes in separator */
 	/* out of memory */
 	CHOLMOD(free_sparse) (&B, Common) ;
 	CHOLMOD(free) (csize, sizeof (Int), Bew, Common) ;
-	return (EMPTY) ;
+	return (TRILINOS_CHOLMOD_EMPTY) ;
     }
 
     /* graph has unit node and edge weights */
@@ -981,7 +981,7 @@ UF_long CHOLMOD(bisect)	/* returns # of nodes in separator */
 
     B->ncol = n ;   /* restore size for memory usage statistics */
     CHOLMOD(free_sparse) (&B, Common) ;
-    Common->mark = EMPTY ;
+    Common->mark = TRILINOS_CHOLMOD_EMPTY ;
     CHOLMOD(clear_flag) (Common) ;
     CHOLMOD(free) (csize, sizeof (Int), Bew, Common) ;
     return (sepsize) ;
@@ -1020,7 +1020,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
     /* ---- output --- */
     Int *Perm,		/* size A->nrow, output permutation */
     Int *CParent,	/* size A->nrow.  On output, CParent [c] is the parent
-			 * of component c, or EMPTY if c is a root, and where
+			 * of component c, or TRILINOS_CHOLMOD_EMPTY if c is a root, and where
 			 * c is in the range 0 to # of components minus 1 */
     Int *Cmember,	/* size A->nrow.  Cmember [j] = c if node j of A is
 			 * in component c */
@@ -1036,7 +1036,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
     Int n, bnz, top, i, j, k, cnode, cdense, p, cj, cn, ci, cnz, mark, c, uncol,
 	sepsize, parent, ncomponents, threshold, ndense, pstart, pdest, pend,
 	nd_compress, nd_camd, csize, jnext, nd_small, total_weight,
-	nchild, child = EMPTY ;
+	nchild, child = TRILINOS_CHOLMOD_EMPTY ;
     cholmod_sparse *B, *C ;
     size_t s ;
     int ok = TRUE ;
@@ -1046,12 +1046,12 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
     /* get inputs */
     /* ---------------------------------------------------------------------- */
 
-    RETURN_IF_NULL_COMMON (EMPTY) ;
-    RETURN_IF_NULL (A, EMPTY) ;
-    RETURN_IF_NULL (Perm, EMPTY) ;
-    RETURN_IF_NULL (CParent, EMPTY) ;
-    RETURN_IF_NULL (Cmember, EMPTY) ;
-    RETURN_IF_XTYPE_INVALID (A, CHOLMOD_PATTERN, CHOLMOD_ZOMPLEX, EMPTY) ;
+    RETURN_IF_NULL_COMMON (TRILINOS_CHOLMOD_EMPTY) ;
+    RETURN_IF_NULL (A, TRILINOS_CHOLMOD_EMPTY) ;
+    RETURN_IF_NULL (Perm, TRILINOS_CHOLMOD_EMPTY) ;
+    RETURN_IF_NULL (CParent, TRILINOS_CHOLMOD_EMPTY) ;
+    RETURN_IF_NULL (Cmember, TRILINOS_CHOLMOD_EMPTY) ;
+    RETURN_IF_XTYPE_INVALID (A, CHOLMOD_PATTERN, CHOLMOD_ZOMPLEX, TRILINOS_CHOLMOD_EMPTY) ;
     Common->status = CHOLMOD_OK ;
 
     /* ---------------------------------------------------------------------- */
@@ -1095,13 +1095,13 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
     if (!ok)
     {
 	ERROR (CHOLMOD_TOO_LARGE, "problem too large") ;
-	return (EMPTY) ;
+	return (TRILINOS_CHOLMOD_EMPTY) ;
     }
 
     CHOLMOD(allocate_work) (n, s, 0, Common) ;
     if (Common->status < CHOLMOD_OK)
     {
-	return (EMPTY) ;
+	return (TRILINOS_CHOLMOD_EMPTY) ;
     }
     ASSERT (CHOLMOD(dump_work) (TRUE, TRUE, 0, Common)) ;
 
@@ -1128,7 +1128,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 
     if (Common->status < CHOLMOD_OK)
     {
-	return (EMPTY) ;
+	return (TRILINOS_CHOLMOD_EMPTY) ;
     }
 
     /* ---------------------------------------------------------------------- */
@@ -1154,7 +1154,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
     if (Common->status < CHOLMOD_OK)
     {
 	CHOLMOD(free) (3*n, sizeof (Int), Work3n, Common) ;
-	return (EMPTY) ;
+	return (TRILINOS_CHOLMOD_EMPTY) ;
     }
     Bp = B->p ;
     Bi = B->i ;
@@ -1168,7 +1168,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
     /* ---------------------------------------------------------------------- */
 
     /* all nodes start out unmarked and unordered (Type 4, see below) */
-    Common->mark = EMPTY ;
+    Common->mark = TRILINOS_CHOLMOD_EMPTY ;
     CHOLMOD(clear_flag) (Common) ;
     ASSERT (Flag == Common->Flag) ;
     ASSERT (CHOLMOD(dump_work) (TRUE, TRUE, 0, Common)) ;
@@ -1191,8 +1191,8 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 	threshold = MIN (n, threshold) ;
     }
     ndense = 0 ;
-    cnode = EMPTY ;
-    cdense = EMPTY ;
+    cnode = TRILINOS_CHOLMOD_EMPTY ;
+    cdense = TRILINOS_CHOLMOD_EMPTY ;
 
     for (j = 0 ; j < n ; j++)
     {
@@ -1202,13 +1202,13 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 	    /* node j is dense, prune it from B */
 	    PRINT2 (("j is dense %d\n", j)) ;
 	    ndense++ ;
-	    if (cnode == EMPTY)
+	    if (cnode == TRILINOS_CHOLMOD_EMPTY)
 	    {
 		/* first dense node found becomes root of this component,
 		 * which contains all of the dense nodes found here */
 		cdense = j ;
 		cnode = j ;
-		CParent [cnode] = EMPTY ;
+		CParent [cnode] = TRILINOS_CHOLMOD_EMPTY ;
 	    }
 	    Flag [j] = FLIP (cnode) ;
 	}
@@ -1226,10 +1226,10 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 	    Perm [k] = k ;
 	    Cmember [k] = 0 ;
 	}
-	CParent [0] = EMPTY ;
+	CParent [0] = TRILINOS_CHOLMOD_EMPTY ;
 	CHOLMOD(free_sparse) (&B, Common) ;
 	CHOLMOD(free) (3*n, sizeof (Int), Work3n, Common) ;
-	Common->mark = EMPTY ;
+	Common->mark = TRILINOS_CHOLMOD_EMPTY ;
 	CHOLMOD(clear_flag) (Common) ;
 	return (1) ;
     }
@@ -1246,10 +1246,10 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 	CHOLMOD(free_sparse) (&B, Common) ;
 	CHOLMOD(free) (csize, sizeof (Int), Cew, Common) ;
 	CHOLMOD(free) (3*n, sizeof (Int), Work3n, Common) ;
-	Common->mark = EMPTY ;
+	Common->mark = TRILINOS_CHOLMOD_EMPTY ;
 	CHOLMOD(clear_flag) (Common) ;
 	PRINT2 (("out of memory for C, etc\n")) ;
-	return (EMPTY) ;
+	return (TRILINOS_CHOLMOD_EMPTY) ;
     }
 
     Cp = C->p ;
@@ -1266,7 +1266,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
     }
 
     /* push the initial connnected components of B onto the Cstack */
-    top = EMPTY ;	/* Cstack is empty */
+    top = TRILINOS_CHOLMOD_EMPTY ;	/* Cstack is empty */
     /* workspace: Flag (nrow), Iwork (nrow); use Imap as workspace for Queue [*/
     find_components (B, NULL, n, cnode, NULL,
 	    Bnz, CParent, Cstack, &top, Imap, Common) ;
@@ -1284,7 +1284,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 	/* clear the Flag array, but do not modify negative entries in Flag  */
 	mark = clear_flag (Common) ;
 
-	DEBUG (for (i = 0 ; i < n ; i++) Imap [i] = EMPTY) ;
+	DEBUG (for (i = 0 ; i < n ; i++) Imap [i] = TRILINOS_CHOLMOD_EMPTY) ;
 
 	/* ------------------------------------------------------------------ */
 	/* get node(s) from the top of the Cstack */
@@ -1295,9 +1295,9 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 	 * each connected component is to be ordered separately (nd_components
 	 * is TRUE), then this while loop iterates just once. */
 
-	cnode = EMPTY ;
+	cnode = TRILINOS_CHOLMOD_EMPTY ;
 	cn = 0 ;
-	while (cnode == EMPTY)
+	while (cnode == TRILINOS_CHOLMOD_EMPTY)
 	{
 	    i = Cstack [top--] ;
 
@@ -1308,7 +1308,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 		cnode = i ;
 	    }
 
-	    ASSERT (i >= 0 && i < n && Flag [i] >= EMPTY) ;
+	    ASSERT (i >= 0 && i < n && Flag [i] >= TRILINOS_CHOLMOD_EMPTY) ;
 
 	    /* place i in the queue and mark it */
 	    Map [cn] = i ;
@@ -1317,37 +1317,37 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 	    cn++ ;
 	}
 
-	ASSERT (cnode != EMPTY) ;
+	ASSERT (cnode != TRILINOS_CHOLMOD_EMPTY) ;
 
 	/* During ordering, there are five kinds of nodes in the graph of B,
 	 * based on Flag [j] and CParent [j] for nodes j = 0 to n-1:
 	 *
 	 * Type 0: If cnode is a repnode of an unordered component, then
-	 * CParent [cnode] is in the range EMPTY to n-1 and
-	 * Flag [cnode] >= EMPTY.  This is a "live" node.
+	 * CParent [cnode] is in the range TRILINOS_CHOLMOD_EMPTY to n-1 and
+	 * Flag [cnode] >= TRILINOS_CHOLMOD_EMPTY.  This is a "live" node.
 	 *
 	 * Type 1: If cnode is a repnode of an ordered separator component,
-	 * then Flag [cnode] < EMPTY and FLAG [cnode] = FLIP (cnode).
-	 * CParent [cnode] is in the range EMPTY to n-1.  cnode is a root of
-	 * the separator tree if CParent [cnode] == EMPTY.  This node is dead.
+	 * then Flag [cnode] < TRILINOS_CHOLMOD_EMPTY and FLAG [cnode] = FLIP (cnode).
+	 * CParent [cnode] is in the range TRILINOS_CHOLMOD_EMPTY to n-1.  cnode is a root of
+	 * the separator tree if CParent [cnode] == TRILINOS_CHOLMOD_EMPTY.  This node is dead.
 	 *
 	 * Type 2: If node j isn't a repnode, has not been absorbed via
 	 * graph compression into another node, but is in an ordered separator
 	 * component, then cnode = FLIP (Flag [j]) gives the repnode of the
 	 * component that contains j and CParent [j]  is -2.  This node is dead.
-	 * Note that Flag [j] < EMPTY.
+	 * Note that Flag [j] < TRILINOS_CHOLMOD_EMPTY.
 	 *
 	 * Type 3: If node i has been absorbed via graph compression into some
 	 * other node j = FLIP (Flag [i]) where j is not a repnode.
 	 * CParent [j] is -2.  Node i may or may not be in an ordered
-	 * component.  This node is dead.  Note that Flag [j] < EMPTY.
+	 * component.  This node is dead.  Note that Flag [j] < TRILINOS_CHOLMOD_EMPTY.
 	 *
 	 * Type 4: If node j is "live" (not in an ordered component, and not
-	 * absorbed into any other node), then Flag [j] >= EMPTY.
+	 * absorbed into any other node), then Flag [j] >= TRILINOS_CHOLMOD_EMPTY.
 	 *
 	 * Only "live" nodes (of type 0 or 4) are placed in a subgraph to be
-	 * partitioned.  Node j is alive if Flag [j] >= EMPTY, and dead if
-	 * Flag [j] < EMPTY.
+	 * partitioned.  Node j is alive if Flag [j] >= TRILINOS_CHOLMOD_EMPTY, and dead if
+	 * Flag [j] < TRILINOS_CHOLMOD_EMPTY.
 	 */
 
 	/* ------------------------------------------------------------------ */
@@ -1380,7 +1380,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 	    {
 		i = Bi [p] ;
 		/* prune diagonal entries and dead edges from B */
-		if (i != j && Flag [i] >= EMPTY)
+		if (i != j && Flag [i] >= TRILINOS_CHOLMOD_EMPTY)
 		{
 		    /* live node i is in the current component */
 		    Bi [pdest++] = i ;
@@ -1420,7 +1420,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 	    PRINT2 (("----------------------------C column cj: "ID" j: "ID"\n",
 		cj, j)) ;
 	    ASSERT (j >= 0 && j < n) ;
-	    ASSERT (Flag [j] >= EMPTY) ;
+	    ASSERT (Flag [j] >= TRILINOS_CHOLMOD_EMPTY) ;
 	    for (p = Cp [cj] ; p < Cp [cj+1] ; p++)
 	    {
 		ci = Ci [p] ;
@@ -1428,7 +1428,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 		PRINT3 (("ci: "ID" i: "ID"\n", ci, i)) ;
 		ASSERT (ci != cj && ci >= 0 && ci < cn) ;
 		ASSERT (i != j && i >= 0 && i < n) ;
-		ASSERT (Flag [i] >= EMPTY) ;
+		ASSERT (Flag [i] >= TRILINOS_CHOLMOD_EMPTY) ;
 	    }
 	}
 #endif
@@ -1472,9 +1472,9 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 		CHOLMOD(free_sparse) (&B, Common) ;
 		CHOLMOD(free) (csize, sizeof (Int), Cew, Common) ;
 		CHOLMOD(free) (3*n, sizeof (Int), Work3n, Common) ;
-		Common->mark = EMPTY ;
+		Common->mark = TRILINOS_CHOLMOD_EMPTY ;
 		CHOLMOD(clear_flag) (Common) ;
-		return (EMPTY) ;
+		return (TRILINOS_CHOLMOD_EMPTY) ;
 	    }
 
 	    /* -------------------------------------------------------------- */
@@ -1483,7 +1483,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 
 	    for (ci = 0 ; ci < cn ; ci++)
 	    {
-		if (Hash [ci] < EMPTY)
+		if (Hash [ci] < TRILINOS_CHOLMOD_EMPTY)
 		{
 		    /* ci is dead in C, having been absorbed into cj */
 		    cj = FLIP (Hash [ci]) ;
@@ -1539,7 +1539,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 		PRINT2 (("      node cj: "ID" j: "ID" ordered\n", cj, j)) ;
 	    }
 	    ASSERT (Flag [cnode] == FLIP (cnode)) ;
-	    ASSERT (cnode != EMPTY && Flag [cnode] < EMPTY) ;
+	    ASSERT (cnode != TRILINOS_CHOLMOD_EMPTY && Flag [cnode] < TRILINOS_CHOLMOD_EMPTY) ;
 	    PRINT0 (("discarded\n")) ;
 
 	}
@@ -1551,9 +1551,9 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 	     * to be non-empty. */
 	    PRINT0 (("sepsize not tiny: "ID"\n", sepsize)) ;
 	    parent = CParent [cnode] ;
-	    ASSERT (parent >= EMPTY && parent < n) ;
+	    ASSERT (parent >= TRILINOS_CHOLMOD_EMPTY && parent < n) ;
 	    CParent [cnode] = -2 ;
-	    cnode = EMPTY ;
+	    cnode = TRILINOS_CHOLMOD_EMPTY ;
 	    for (cj = 0 ; cj < cn ; cj++)
 	    {
 		j = Map [cj] ;
@@ -1562,7 +1562,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 		    /* All nodes in the separator become part of a component
 		     * whose repnode is cnode */
 		    PRINT2 (("node cj: "ID" j: "ID" ordered\n", cj, j)) ;
-		    if (cnode == EMPTY)
+		    if (cnode == TRILINOS_CHOLMOD_EMPTY)
 		    {
 			PRINT2(("------------new cnode: cj "ID" j "ID"\n",
 				    cj, j)) ;
@@ -1576,7 +1576,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 				cj, j)) ;
 		}
 	    }
-	    ASSERT (cnode != EMPTY && Flag [cnode] < EMPTY) ;
+	    ASSERT (cnode != TRILINOS_CHOLMOD_EMPTY && Flag [cnode] < TRILINOS_CHOLMOD_EMPTY) ;
 	    ASSERT (CParent [cnode] == -2) ;
 	    CParent [cnode] = parent ;
 
@@ -1617,7 +1617,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 	}
 	cnode = j ;
 	ASSERT (cnode >= 0 && cnode < n) ;
-	ASSERT (CParent [cnode] >= EMPTY && CParent [cnode] < n) ;
+	ASSERT (CParent [cnode] >= TRILINOS_CHOLMOD_EMPTY && CParent [cnode] < n) ;
 	PRINT2 (("i "ID" is in component with cnode "ID"\n", i, cnode)) ;
 	ASSERT (Flag [cnode] == FLIP (cnode)) ;
 
@@ -1644,7 +1644,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
     for (j = 0 ; j < n ; j++)
     {
 	PRINT2 (("j %d CParent %d  ", j, CParent [j])) ;
-	if (CParent [j] >= EMPTY && CParent [j] < n)
+	if (CParent [j] >= TRILINOS_CHOLMOD_EMPTY && CParent [j] < n)
 	{
 	    /* case 1: j is a repnode of a component */
 	    cnode = j ;
@@ -1656,7 +1656,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 	    cnode = FLIP (Flag [j]) ;
 	    PRINT2 ((" repnode is %d\n", cnode)) ;
 	    ASSERT (cnode >= 0 && cnode < n) ;
-	    ASSERT (CParent [cnode] >= EMPTY && CParent [cnode] < n) ;
+	    ASSERT (CParent [cnode] >= TRILINOS_CHOLMOD_EMPTY && CParent [cnode] < n) ;
 	}
 	ASSERT (Flag [cnode] == FLIP (cnode)) ;
 	/* case 3 no longer holds */
@@ -1684,7 +1684,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 
     if (ndense > 0)
     {
-	ASSERT (CParent [cdense] == EMPTY) ;	/* cdense has no parent */
+	ASSERT (CParent [cdense] == TRILINOS_CHOLMOD_EMPTY) ;	/* cdense has no parent */
 	/* find the children of cdense */
 	nchild = 0 ;
 	for (j = 0 ; j < n ; j++)
@@ -1700,7 +1700,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 	    /* the cdense node has just one child; merge the two nodes */
 	    PRINT1 (("root has one child\n")) ;
 	    CParent [cdense] = -2 ;		/* cdense is deleted */
-	    CParent [child] = EMPTY ;		/* child becomes a root */
+	    CParent [child] = TRILINOS_CHOLMOD_EMPTY ;		/* child becomes a root */
 	    for (j = 0 ; j < n ; j++)
 	    {
 		if (Flag [j] == FLIP (cdense))
@@ -1731,7 +1731,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 
     /* use Iwork [0..n-1] as workspace for Ipost ( */
     Ipost = Iwork ;
-    DEBUG (for (j = 0 ; j < n ; j++) Ipost [j] = EMPTY) ;
+    DEBUG (for (j = 0 ; j < n ; j++) Ipost [j] = TRILINOS_CHOLMOD_EMPTY) ;
 
     /* compute inverse postorder */
     for (c = 0 ; c < ncomponents ; c++)
@@ -1739,7 +1739,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 	cnode = Post [c] ;
 	ASSERT (cnode >= 0 && cnode < n) ;
 	Ipost [cnode] = c ;
-	ASSERT (Head [c] == EMPTY) ;
+	ASSERT (Head [c] == TRILINOS_CHOLMOD_EMPTY) ;
     }
 
     /* adjust the parent array */
@@ -1748,7 +1748,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
     for (c = 0 ; c < ncomponents ; c++)
     {
 	parent = CParent [Post [c]] ;
-	NewParent [c] = (parent == EMPTY) ? EMPTY : (Ipost [parent]) ;
+	NewParent [c] = (parent == TRILINOS_CHOLMOD_EMPTY) ? TRILINOS_CHOLMOD_EMPTY : (Ipost [parent]) ;
     }
     for (c = 0 ; c < ncomponents ; c++)
     {
@@ -1767,7 +1767,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
     }
     for (c = 0 ; c < ncomponents ; c++)
     {
-	if (CParent [c] != EMPTY) Cmember [CParent [c]]++ ;
+	if (CParent [c] != TRILINOS_CHOLMOD_EMPTY) Cmember [CParent [c]]++ ;
     }
     for (c = 0 ; c < ncomponents ; c++)
     {
@@ -1800,7 +1800,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
     /* clear the Flag array */
     /* ---------------------------------------------------------------------- */
 
-    Common->mark = EMPTY ;
+    Common->mark = TRILINOS_CHOLMOD_EMPTY ;
     CHOLMOD(clear_flag) (Common) ;
     ASSERT (CHOLMOD(dump_work) (TRUE, TRUE, 0, Common)) ;
 
@@ -1827,7 +1827,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 	    if (Common->status < CHOLMOD_OK)
 	    {
 		PRINT0 (("make symmetric failed\n")) ;
-		return (EMPTY) ;
+		return (TRILINOS_CHOLMOD_EMPTY) ;
 	    }
 	    ASSERT ((Int) (B->nrow) == n && (Int) (B->ncol) == n) ;
 	    PRINT2 (("nested dissection (2)\n")) ;
@@ -1847,7 +1847,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 	    {
 		/* failed */
 		PRINT0 (("camd/csymamd failed\n")) ;
-		return (EMPTY) ;
+		return (TRILINOS_CHOLMOD_EMPTY) ;
 	    }
 	}
 	else
@@ -1858,7 +1858,7 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 	    {
 		/* trilinos_ccolamd failed */
 		PRINT2 (("trilinos_ccolamd failed\n")) ;
-		return (EMPTY) ;
+		return (TRILINOS_CHOLMOD_EMPTY) ;
 	    }
 	}
 
@@ -1895,11 +1895,11 @@ UF_long CHOLMOD(nested_dissection) /* returns # of components, or -1 if error */
 	k = 0 ;
 	for (c = 0 ; c < ncomponents ; c++)
 	{
-	    for (j = Head [c] ; j != EMPTY ; j = Next [j])
+	    for (j = Head [c] ; j != TRILINOS_CHOLMOD_EMPTY ; j = Next [j])
 	    {
 		Perm [k++] = j ;
 	    }
-	    Head [c] = EMPTY ;
+	    Head [c] = TRILINOS_CHOLMOD_EMPTY ;
 	}
 	ASSERT (k == n) ;
 
@@ -1955,13 +1955,13 @@ UF_long CHOLMOD(collapse_septree)
     /* get inputs */
     /* ---------------------------------------------------------------------- */
 
-    RETURN_IF_NULL_COMMON (EMPTY) ;
-    RETURN_IF_NULL (CParent, EMPTY) ;
-    RETURN_IF_NULL (Cmember, EMPTY) ;
+    RETURN_IF_NULL_COMMON (TRILINOS_CHOLMOD_EMPTY) ;
+    RETURN_IF_NULL (CParent, TRILINOS_CHOLMOD_EMPTY) ;
+    RETURN_IF_NULL (Cmember, TRILINOS_CHOLMOD_EMPTY) ;
     if (n < ncomponents)
     {
 	ERROR (CHOLMOD_INVALID, "invalid separator tree") ;
-	return (EMPTY) ;
+	return (TRILINOS_CHOLMOD_EMPTY) ;
     }
     Common->status = CHOLMOD_OK ;
     nc = ncomponents ;
@@ -1984,12 +1984,12 @@ UF_long CHOLMOD(collapse_septree)
     if (!ok)
     {
 	ERROR (CHOLMOD_TOO_LARGE, "problem too large") ;
-	return (EMPTY) ;
+	return (TRILINOS_CHOLMOD_EMPTY) ;
     }
     CHOLMOD(allocate_work) (0, s, 0, Common) ;
     if (Common->status < CHOLMOD_OK)
     {
-	return (EMPTY) ;
+	return (TRILINOS_CHOLMOD_EMPTY) ;
     }
     W = Common->Iwork ;
     Count    = W ; W += ncomponents ;	    /* size ncomponents */
@@ -2002,11 +2002,11 @@ UF_long CHOLMOD(collapse_septree)
 
     for (c = 0 ; c < nc ; c++)
     {
-	First [c] = EMPTY ;
+	First [c] = TRILINOS_CHOLMOD_EMPTY ;
     }
     for (k = 0 ; k < nc ; k++)
     {
-	for (c = k ; c != EMPTY && First [c] == -1 ; c = CParent [c])
+	for (c = k ; c != TRILINOS_CHOLMOD_EMPTY && First [c] == -1 ; c = CParent [c])
 	{
 	    ASSERT (c >= 0 && c < nc) ;
 	    First [c] = k ;
@@ -2043,8 +2043,8 @@ UF_long CHOLMOD(collapse_septree)
     {
 	/* add the subtree of the child, c, into the count of its parent */
 	parent = CParent [c] ;
-	ASSERT (parent >= EMPTY && parent < nc) ;
-	if (parent != EMPTY)
+	ASSERT (parent >= TRILINOS_CHOLMOD_EMPTY && parent < nc) ;
+	if (parent != TRILINOS_CHOLMOD_EMPTY)
 	{
 	    Csubtree [parent] += Csubtree [c] ;
 	}
@@ -2053,7 +2053,7 @@ UF_long CHOLMOD(collapse_septree)
 #ifndef NDEBUG
     /* the sum of the roots should be n */
     j = 0 ;
-    for (c = 0 ; c < nc ; c++) if (CParent [c] == EMPTY) j += Csubtree [c] ;
+    for (c = 0 ; c < nc ; c++) if (CParent [c] == TRILINOS_CHOLMOD_EMPTY) j += Csubtree [c] ;
     ASSERT (j == (Int) n) ;
 #endif
 
@@ -2105,7 +2105,7 @@ UF_long CHOLMOD(collapse_septree)
 	for (c = 0 ; c < nc ; c++)
 	{
 	    Map [c] = nc_new ;
-	    if (CParent [c] >= EMPTY)
+	    if (CParent [c] >= TRILINOS_CHOLMOD_EMPTY)
 	    {
 		/* node c is alive, and becomes node Map[c] in the new tree.
 		 * Increment nc_new for the next node c. */
@@ -2117,10 +2117,10 @@ UF_long CHOLMOD(collapse_septree)
 	for (c = 0 ; c < nc ; c++)
 	{
 	    parent = CParent [c] ;
-	    if (parent >= EMPTY)
+	    if (parent >= TRILINOS_CHOLMOD_EMPTY)
 	    {
 		/* node c is alive */
-		CParent [Map [c]] = (parent == EMPTY) ? EMPTY : Map [parent] ;
+		CParent [Map [c]] = (parent == TRILINOS_CHOLMOD_EMPTY) ? TRILINOS_CHOLMOD_EMPTY : Map [parent] ;
 	    }
 	}
 	for (j = 0 ; j < (Int) n ; j++)

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/COLAMD/Source/trilinos_colamd.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/COLAMD/Source/trilinos_colamd.c
@@ -802,7 +802,7 @@ typedef struct Trilinos_Colamd_Row_struct
 
 /* -------------------------------------------------------------------------- */
 
-#define EMPTY	(-1)
+#define TRILINOS_COLAMD_EMPTY	(-1)
 
 /* Row and column status */
 #define ALIVE	(0)
@@ -1719,8 +1719,8 @@ PRIVATE Int init_rows_cols	/* returns TRUE if OK, or FALSE otherwise */
 
 	Col [col].shared1.thickness = 1 ;
 	Col [col].shared2.score = 0 ;
-	Col [col].shared3.prev = EMPTY ;
-	Col [col].shared4.degree_next = EMPTY ;
+	Col [col].shared3.prev = TRILINOS_COLAMD_EMPTY ;
+	Col [col].shared4.degree_next = TRILINOS_COLAMD_EMPTY ;
     }
 
     /* p [0..n_col] no longer needed, used as "head" in subsequent routines */
@@ -2118,7 +2118,7 @@ PRIVATE void init_scoring
     /* clear the hash buckets */
     for (c = 0 ; c <= n_col ; c++)
     {
-	head [c] = EMPTY ;
+	head [c] = TRILINOS_COLAMD_EMPTY ;
     }
     min_score = n_col ;
     /* place in reverse order, so low column indices are at the front */
@@ -2139,16 +2139,16 @@ PRIVATE void init_scoring
 	    ASSERT (min_score <= n_col) ;
 	    ASSERT (score >= 0) ;
 	    ASSERT (score <= n_col) ;
-	    ASSERT (head [score] >= EMPTY) ;
+	    ASSERT (head [score] >= TRILINOS_COLAMD_EMPTY) ;
 
 	    /* now add this column to dList at proper score location */
 	    next_col = head [score] ;
-	    Col [c].shared3.prev = EMPTY ;
+	    Col [c].shared3.prev = TRILINOS_COLAMD_EMPTY ;
 	    Col [c].shared4.degree_next = next_col ;
 
 	    /* if there already was a column with the same score, set its */
 	    /* previous pointer to this new column */
-	    if (next_col != EMPTY)
+	    if (next_col != TRILINOS_COLAMD_EMPTY)
 	    {
 		Col [next_col].shared3.prev = c ;
 	    }
@@ -2278,17 +2278,17 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 	/* make sure degree list isn't empty */
 	ASSERT (min_score >= 0) ;
 	ASSERT (min_score <= n_col) ;
-	ASSERT (head [min_score] >= EMPTY) ;
+	ASSERT (head [min_score] >= TRILINOS_COLAMD_EMPTY) ;
 
 #ifndef NDEBUG
 	for (debug_d = 0 ; debug_d < min_score ; debug_d++)
 	{
-	    ASSERT (head [debug_d] == EMPTY) ;
+	    ASSERT (head [debug_d] == TRILINOS_COLAMD_EMPTY) ;
 	}
 #endif /* NDEBUG */
 
 	/* get pivot column from head of minimum degree list */
-	while (head [min_score] == EMPTY && min_score < n_col)
+	while (head [min_score] == TRILINOS_COLAMD_EMPTY && min_score < n_col)
 	{
 	    min_score++ ;
 	}
@@ -2296,9 +2296,9 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 	ASSERT (pivot_col >= 0 && pivot_col <= n_col) ;
 	next_col = Col [pivot_col].shared4.degree_next ;
 	head [min_score] = next_col ;
-	if (next_col != EMPTY)
+	if (next_col != TRILINOS_COLAMD_EMPTY)
 	{
-	    Col [next_col].shared3.prev = EMPTY ;
+	    Col [next_col].shared3.prev = TRILINOS_COLAMD_EMPTY ;
 	}
 
 	ASSERT (COL_IS_ALIVE (pivot_col)) ;
@@ -2410,7 +2410,7 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 	else
 	{
 	    /* there is no pivot row, since it is of zero length */
-	    pivot_row = EMPTY ;
+	    pivot_row = TRILINOS_COLAMD_EMPTY ;
 	    ASSERT (pivot_row_length == 0) ;
 	}
 	ASSERT (Col [pivot_col].length > 0 || pivot_row_length == 0) ;
@@ -2462,8 +2462,8 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 	    next_col = Col [col].shared4.degree_next ;
 	    ASSERT (cur_score >= 0) ;
 	    ASSERT (cur_score <= n_col) ;
-	    ASSERT (cur_score >= EMPTY) ;
-	    if (prev_col == EMPTY)
+	    ASSERT (cur_score >= TRILINOS_COLAMD_EMPTY) ;
+	    if (prev_col == TRILINOS_COLAMD_EMPTY)
 	    {
 		head [cur_score] = next_col ;
 	    }
@@ -2471,7 +2471,7 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 	    {
 		Col [prev_col].shared4.degree_next = next_col ;
 	    }
-	    if (next_col != EMPTY)
+	    if (next_col != TRILINOS_COLAMD_EMPTY)
 	    {
 		Col [next_col].shared3.prev = prev_col ;
 	    }
@@ -2598,7 +2598,7 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 		ASSERT (((Int) hash) <= n_col) ;
 
 		head_column = head [hash] ;
-		if (head_column > EMPTY)
+		if (head_column > TRILINOS_COLAMD_EMPTY)
 		{
 		    /* degree list "hash" is non-empty, use prev (shared3) of */
 		    /* first column in degree list as head of hash bucket */
@@ -2693,11 +2693,11 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 	    ASSERT (min_score <= n_col) ;
 	    ASSERT (cur_score >= 0) ;
 	    ASSERT (cur_score <= n_col) ;
-	    ASSERT (head [cur_score] >= EMPTY) ;
+	    ASSERT (head [cur_score] >= TRILINOS_COLAMD_EMPTY) ;
 	    next_col = head [cur_score] ;
 	    Col [col].shared4.degree_next = next_col ;
-	    Col [col].shared3.prev = EMPTY ;
-	    if (next_col != EMPTY)
+	    Col [col].shared3.prev = TRILINOS_COLAMD_EMPTY ;
+	    if (next_col != TRILINOS_COLAMD_EMPTY)
 	    {
 		Col [next_col].shared3.prev = col ;
 	    }
@@ -2776,7 +2776,7 @@ PRIVATE void order_children
     {
 	/* find an un-ordered non-principal column */
 	ASSERT (COL_IS_DEAD (i)) ;
-	if (!COL_IS_DEAD_PRINCIPAL (i) && Col [i].shared2.order == EMPTY)
+	if (!COL_IS_DEAD_PRINCIPAL (i) && Col [i].shared2.order == TRILINOS_COLAMD_EMPTY)
 	{
 	    parent = i ;
 	    /* once found, find its principal parent */
@@ -2793,7 +2793,7 @@ PRIVATE void order_children
 
 	    do
 	    {
-		ASSERT (Col [c].shared2.order == EMPTY) ;
+		ASSERT (Col [c].shared2.order == TRILINOS_COLAMD_EMPTY) ;
 
 		/* order this column */
 		Col [c].shared2.order = order++ ;
@@ -2806,7 +2806,7 @@ PRIVATE void order_children
 		/* continue until we hit an ordered column.  There are */
 		/* guarranteed not to be anymore unordered columns */
 		/* above an ordered column */
-	    } while (Col [c].shared2.order == EMPTY) ;
+	    } while (Col [c].shared2.order == TRILINOS_COLAMD_EMPTY) ;
 
 	    /* re-order the super_col parent to largest order for this group */
 	    Col [parent].shared2.order = order ;
@@ -2907,7 +2907,7 @@ PRIVATE void detect_super_cols
 	/* === Get the first column in this hash bucket ===================== */
 
 	head_column = head [hash] ;
-	if (head_column > EMPTY)
+	if (head_column > TRILINOS_COLAMD_EMPTY)
 	{
 	    first_col = Col [head_column].shared3.headhash ;
 	}
@@ -2918,7 +2918,7 @@ PRIVATE void detect_super_cols
 
 	/* === Consider each column in the hash bucket ====================== */
 
-	for (super_c = first_col ; super_c != EMPTY ;
+	for (super_c = first_col ; super_c != TRILINOS_COLAMD_EMPTY ;
 	    super_c = Col [super_c].shared4.hash_next)
 	{
 	    ASSERT (COL_IS_ALIVE (super_c)) ;
@@ -2931,7 +2931,7 @@ PRIVATE void detect_super_cols
 	    /* === Compare super_c with all columns after it ================ */
 
 	    for (c = Col [super_c].shared4.hash_next ;
-		 c != EMPTY ; c = Col [c].shared4.hash_next)
+		 c != TRILINOS_COLAMD_EMPTY ; c = Col [c].shared4.hash_next)
 	    {
 		ASSERT (c != super_c) ;
 		ASSERT (COL_IS_ALIVE (c)) ;
@@ -2977,7 +2977,7 @@ PRIVATE void detect_super_cols
 		Col [c].shared1.parent = super_c ;
 		KILL_NON_PRINCIPAL_COL (c) ;
 		/* order c later, in order_children() */
-		Col [c].shared2.order = EMPTY ;
+		Col [c].shared2.order = TRILINOS_COLAMD_EMPTY ;
 		/* remove c from hash bucket */
 		Col [prev_c].shared4.hash_next = Col [c].shared4.hash_next ;
 	    }
@@ -2985,15 +2985,15 @@ PRIVATE void detect_super_cols
 
 	/* === Empty this hash bucket ======================================= */
 
-	if (head_column > EMPTY)
+	if (head_column > TRILINOS_COLAMD_EMPTY)
 	{
 	    /* corresponding degree list "hash" is not empty */
-	    Col [head_column].shared3.headhash = EMPTY ;
+	    Col [head_column].shared3.headhash = TRILINOS_COLAMD_EMPTY ;
 	}
 	else
 	{
 	    /* corresponding degree list "hash" is empty */
-	    head [hash] = EMPTY ;
+	    head [hash] = TRILINOS_COLAMD_EMPTY ;
 	}
     }
 }
@@ -3444,12 +3444,12 @@ PRIVATE void debug_deg_lists
     for (deg = 0 ; deg <= n_col ; deg++)
     {
 	col = head [deg] ;
-	if (col == EMPTY)
+	if (col == TRILINOS_COLAMD_EMPTY)
 	{
 	    continue ;
 	}
 	DEBUG4 (("%d:", deg)) ;
-	while (col != EMPTY)
+	while (col != TRILINOS_COLAMD_EMPTY)
 	{
 	    DEBUG4 ((" %d", col)) ;
 	    have += Col [col].shared1.thickness ;

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/COLAMD/Source/trilinos_colamd_l.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/COLAMD/Source/trilinos_colamd_l.c
@@ -805,7 +805,7 @@ typedef struct Trilinos_Colamd_Row_struct
 
 /* -------------------------------------------------------------------------- */
 
-#define EMPTY	(-1)
+#define TRILINOS_COLAMDL_EMPTY	(-1)
 
 /* Row and column status */
 #define ALIVE	(0)
@@ -1722,8 +1722,8 @@ PRIVATE Int init_rows_cols	/* returns TRUE if OK, or FALSE otherwise */
 
 	Col [col].shared1.thickness = 1 ;
 	Col [col].shared2.score = 0 ;
-	Col [col].shared3.prev = EMPTY ;
-	Col [col].shared4.degree_next = EMPTY ;
+	Col [col].shared3.prev = TRILINOS_COLAMDL_EMPTY ;
+	Col [col].shared4.degree_next = TRILINOS_COLAMDL_EMPTY ;
     }
 
     /* p [0..n_col] no longer needed, used as "head" in subsequent routines */
@@ -2121,7 +2121,7 @@ PRIVATE void init_scoring
     /* clear the hash buckets */
     for (c = 0 ; c <= n_col ; c++)
     {
-	head [c] = EMPTY ;
+	head [c] = TRILINOS_COLAMDL_EMPTY ;
     }
     min_score = n_col ;
     /* place in reverse order, so low column indices are at the front */
@@ -2142,16 +2142,16 @@ PRIVATE void init_scoring
 	    ASSERT (min_score <= n_col) ;
 	    ASSERT (score >= 0) ;
 	    ASSERT (score <= n_col) ;
-	    ASSERT (head [score] >= EMPTY) ;
+	    ASSERT (head [score] >= TRILINOS_COLAMDL_EMPTY) ;
 
 	    /* now add this column to dList at proper score location */
 	    next_col = head [score] ;
-	    Col [c].shared3.prev = EMPTY ;
+	    Col [c].shared3.prev = TRILINOS_COLAMDL_EMPTY ;
 	    Col [c].shared4.degree_next = next_col ;
 
 	    /* if there already was a column with the same score, set its */
 	    /* previous pointer to this new column */
-	    if (next_col != EMPTY)
+	    if (next_col != TRILINOS_COLAMDL_EMPTY)
 	    {
 		Col [next_col].shared3.prev = c ;
 	    }
@@ -2281,17 +2281,17 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 	/* make sure degree list isn't empty */
 	ASSERT (min_score >= 0) ;
 	ASSERT (min_score <= n_col) ;
-	ASSERT (head [min_score] >= EMPTY) ;
+	ASSERT (head [min_score] >= TRILINOS_COLAMDL_EMPTY) ;
 
 #ifndef NDEBUG
 	for (debug_d = 0 ; debug_d < min_score ; debug_d++)
 	{
-	    ASSERT (head [debug_d] == EMPTY) ;
+	    ASSERT (head [debug_d] == TRILINOS_COLAMDL_EMPTY) ;
 	}
 #endif /* NDEBUG */
 
 	/* get pivot column from head of minimum degree list */
-	while (head [min_score] == EMPTY && min_score < n_col)
+	while (head [min_score] == TRILINOS_COLAMDL_EMPTY && min_score < n_col)
 	{
 	    min_score++ ;
 	}
@@ -2299,9 +2299,9 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 	ASSERT (pivot_col >= 0 && pivot_col <= n_col) ;
 	next_col = Col [pivot_col].shared4.degree_next ;
 	head [min_score] = next_col ;
-	if (next_col != EMPTY)
+	if (next_col != TRILINOS_COLAMDL_EMPTY)
 	{
-	    Col [next_col].shared3.prev = EMPTY ;
+	    Col [next_col].shared3.prev = TRILINOS_COLAMDL_EMPTY ;
 	}
 
 	ASSERT (COL_IS_ALIVE (pivot_col)) ;
@@ -2413,7 +2413,7 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 	else
 	{
 	    /* there is no pivot row, since it is of zero length */
-	    pivot_row = EMPTY ;
+	    pivot_row = TRILINOS_COLAMDL_EMPTY ;
 	    ASSERT (pivot_row_length == 0) ;
 	}
 	ASSERT (Col [pivot_col].length > 0 || pivot_row_length == 0) ;
@@ -2465,8 +2465,8 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 	    next_col = Col [col].shared4.degree_next ;
 	    ASSERT (cur_score >= 0) ;
 	    ASSERT (cur_score <= n_col) ;
-	    ASSERT (cur_score >= EMPTY) ;
-	    if (prev_col == EMPTY)
+	    ASSERT (cur_score >= TRILINOS_COLAMDL_EMPTY) ;
+	    if (prev_col == TRILINOS_COLAMDL_EMPTY)
 	    {
 		head [cur_score] = next_col ;
 	    }
@@ -2474,7 +2474,7 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 	    {
 		Col [prev_col].shared4.degree_next = next_col ;
 	    }
-	    if (next_col != EMPTY)
+	    if (next_col != TRILINOS_COLAMDL_EMPTY)
 	    {
 		Col [next_col].shared3.prev = prev_col ;
 	    }
@@ -2601,7 +2601,7 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 		ASSERT (((Int) hash) <= n_col) ;
 
 		head_column = head [hash] ;
-		if (head_column > EMPTY)
+		if (head_column > TRILINOS_COLAMDL_EMPTY)
 		{
 		    /* degree list "hash" is non-empty, use prev (shared3) of */
 		    /* first column in degree list as head of hash bucket */
@@ -2696,11 +2696,11 @@ PRIVATE Int find_ordering	/* return the number of garbage collections */
 	    ASSERT (min_score <= n_col) ;
 	    ASSERT (cur_score >= 0) ;
 	    ASSERT (cur_score <= n_col) ;
-	    ASSERT (head [cur_score] >= EMPTY) ;
+	    ASSERT (head [cur_score] >= TRILINOS_COLAMDL_EMPTY) ;
 	    next_col = head [cur_score] ;
 	    Col [col].shared4.degree_next = next_col ;
-	    Col [col].shared3.prev = EMPTY ;
-	    if (next_col != EMPTY)
+	    Col [col].shared3.prev = TRILINOS_COLAMDL_EMPTY ;
+	    if (next_col != TRILINOS_COLAMDL_EMPTY)
 	    {
 		Col [next_col].shared3.prev = col ;
 	    }
@@ -2779,7 +2779,7 @@ PRIVATE void order_children
     {
 	/* find an un-ordered non-principal column */
 	ASSERT (COL_IS_DEAD (i)) ;
-	if (!COL_IS_DEAD_PRINCIPAL (i) && Col [i].shared2.order == EMPTY)
+	if (!COL_IS_DEAD_PRINCIPAL (i) && Col [i].shared2.order == TRILINOS_COLAMDL_EMPTY)
 	{
 	    parent = i ;
 	    /* once found, find its principal parent */
@@ -2796,7 +2796,7 @@ PRIVATE void order_children
 
 	    do
 	    {
-		ASSERT (Col [c].shared2.order == EMPTY) ;
+		ASSERT (Col [c].shared2.order == TRILINOS_COLAMDL_EMPTY) ;
 
 		/* order this column */
 		Col [c].shared2.order = order++ ;
@@ -2809,7 +2809,7 @@ PRIVATE void order_children
 		/* continue until we hit an ordered column.  There are */
 		/* guarranteed not to be anymore unordered columns */
 		/* above an ordered column */
-	    } while (Col [c].shared2.order == EMPTY) ;
+	    } while (Col [c].shared2.order == TRILINOS_COLAMDL_EMPTY) ;
 
 	    /* re-order the super_col parent to largest order for this group */
 	    Col [parent].shared2.order = order ;
@@ -2910,7 +2910,7 @@ PRIVATE void detect_super_cols
 	/* === Get the first column in this hash bucket ===================== */
 
 	head_column = head [hash] ;
-	if (head_column > EMPTY)
+	if (head_column > TRILINOS_COLAMDL_EMPTY)
 	{
 	    first_col = Col [head_column].shared3.headhash ;
 	}
@@ -2921,7 +2921,7 @@ PRIVATE void detect_super_cols
 
 	/* === Consider each column in the hash bucket ====================== */
 
-	for (super_c = first_col ; super_c != EMPTY ;
+	for (super_c = first_col ; super_c != TRILINOS_COLAMDL_EMPTY ;
 	    super_c = Col [super_c].shared4.hash_next)
 	{
 	    ASSERT (COL_IS_ALIVE (super_c)) ;
@@ -2934,7 +2934,7 @@ PRIVATE void detect_super_cols
 	    /* === Compare super_c with all columns after it ================ */
 
 	    for (c = Col [super_c].shared4.hash_next ;
-		 c != EMPTY ; c = Col [c].shared4.hash_next)
+		 c != TRILINOS_COLAMDL_EMPTY ; c = Col [c].shared4.hash_next)
 	    {
 		ASSERT (c != super_c) ;
 		ASSERT (COL_IS_ALIVE (c)) ;
@@ -2980,7 +2980,7 @@ PRIVATE void detect_super_cols
 		Col [c].shared1.parent = super_c ;
 		KILL_NON_PRINCIPAL_COL (c) ;
 		/* order c later, in order_children() */
-		Col [c].shared2.order = EMPTY ;
+		Col [c].shared2.order = TRILINOS_COLAMDL_EMPTY ;
 		/* remove c from hash bucket */
 		Col [prev_c].shared4.hash_next = Col [c].shared4.hash_next ;
 	    }
@@ -2988,15 +2988,15 @@ PRIVATE void detect_super_cols
 
 	/* === Empty this hash bucket ======================================= */
 
-	if (head_column > EMPTY)
+	if (head_column > TRILINOS_COLAMDL_EMPTY)
 	{
 	    /* corresponding degree list "hash" is not empty */
-	    Col [head_column].shared3.headhash = EMPTY ;
+	    Col [head_column].shared3.headhash = TRILINOS_COLAMDL_EMPTY ;
 	}
 	else
 	{
 	    /* corresponding degree list "hash" is empty */
-	    head [hash] = EMPTY ;
+	    head [hash] = TRILINOS_COLAMDL_EMPTY ;
 	}
     }
 }
@@ -3447,12 +3447,12 @@ PRIVATE void debug_deg_lists
     for (deg = 0 ; deg <= n_col ; deg++)
     {
 	col = head [deg] ;
-	if (col == EMPTY)
+	if (col == TRILINOS_COLAMDL_EMPTY)
 	{
 	    continue ;
 	}
 	DEBUG4 (("%d:", deg)) ;
-	while (col != EMPTY)
+	while (col != TRILINOS_COLAMDL_EMPTY)
 	{
 	    DEBUG4 ((" %d", col)) ;
 	    have += Col [col].shared1.thickness ;

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/KLU/Include/trilinos_klu_internal.h
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/KLU/Include/trilinos_klu_internal.h
@@ -69,12 +69,12 @@
 #define MIN(a,b) (((a) < (b)) ?  (a) : (b))
 
 /* FLIP is a "negation about -1", and is used to mark an integer i that is
- * normally non-negative.  FLIP (EMPTY) is EMPTY.  FLIP of a number > EMPTY
+ * normally non-negative.  FLIP (TRILINOS_KLU_EMPTY) is TRILINOS_KLU_EMPTY.  FLIP of a number > TRILINOS_KLU_EMPTY
  * is negative, and FLIP of a number < EMTPY is positive.  FLIP (FLIP (i)) = i
- * for all integers i.  UNFLIP (i) is >= EMPTY. */
-#define EMPTY (-1)
+ * for all integers i.  UNFLIP (i) is >= TRILINOS_KLU_EMPTY. */
+#define TRILINOS_KLU_EMPTY (-1)
 #define FLIP(i) (-(i)-2)
-#define UNFLIP(i) (((i) < EMPTY) ? FLIP (i) : (i))
+#define UNFLIP(i) (((i) < TRILINOS_KLU_EMPTY) ? FLIP (i) : (i))
 
 
 size_t TRILINOS_KLU_kernel   /* final size of LU on output */

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/KLU/Source/trilinos_klu_analyze.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/KLU/Source/trilinos_klu_analyze.c
@@ -53,9 +53,9 @@ static Int analyze_worker	/* returns TRILINOS_KLU_OK or < 0 if error */
 #ifndef NDEBUG
     for (k = 0 ; k < n ; k++)
     {
-	P [k] = EMPTY ;
-	Q [k] = EMPTY ;
-	Pinv [k] = EMPTY ;
+	P [k] = TRILINOS_KLU_EMPTY ;
+	Q [k] = TRILINOS_KLU_EMPTY ;
+	Pinv [k] = TRILINOS_KLU_EMPTY ;
     }
 #endif
     for (k = 0 ; k < n ; k++)
@@ -64,13 +64,13 @@ static Int analyze_worker	/* returns TRILINOS_KLU_OK or < 0 if error */
 	Pinv [Pbtf [k]] = k ;
     }
 #ifndef NDEBUG
-    for (k = 0 ; k < n ; k++) ASSERT (Pinv [k] != EMPTY) ;
+    for (k = 0 ; k < n ; k++) ASSERT (Pinv [k] != TRILINOS_KLU_EMPTY) ;
 #endif
     nzoff = 0 ;
     lnz = 0 ;
     maxnz = 0 ;
     flops = 0 ;
-    Symbolic->symmetry = EMPTY ;	/* only computed by AMD */
+    Symbolic->symmetry = TRILINOS_KLU_EMPTY ;	/* only computed by AMD */
 
     /* ---------------------------------------------------------------------- */
     /* order each block */
@@ -92,7 +92,7 @@ static Int analyze_worker	/* returns TRILINOS_KLU_OK or < 0 if error */
 	/* construct the kth block, C */
 	/* ------------------------------------------------------------------ */
 
-	Lnz [block] = EMPTY ;
+	Lnz [block] = TRILINOS_KLU_EMPTY ;
 	pc = 0 ;
 	for (k = k1 ; k < k2 ; k++)
 	{
@@ -180,8 +180,8 @@ static Int analyze_worker	/* returns TRILINOS_KLU_OK or < 0 if error */
 	     * and Ci allocated. */
 
 	    ok = TRILINOS_COLAMD (nk, nk, Cilen, Ci, Cp, NULL, cstats) ;
-	    lnz1 = EMPTY ;
-	    flops1 = EMPTY ;
+	    lnz1 = TRILINOS_KLU_EMPTY ;
+	    flops1 = TRILINOS_KLU_EMPTY ;
 
 	    /* copy the permutation from Cp to Pblk */
 	    for (k = 0 ; k < nk ; k++)
@@ -198,7 +198,7 @@ static Int analyze_worker	/* returns TRILINOS_KLU_OK or < 0 if error */
 	    /* -------------------------------------------------------------- */
 
 	    lnz1 = (Common->user_order) (nk, Cp, Ci, Pblk, Common) ;
-	    flops1 = EMPTY ;
+	    flops1 = TRILINOS_KLU_EMPTY ;
 	    ok = (lnz1 != 0) ;
 	}
 
@@ -212,8 +212,8 @@ static Int analyze_worker	/* returns TRILINOS_KLU_OK or < 0 if error */
 	/* ------------------------------------------------------------------ */
 
 	Lnz [block] = lnz1 ;
-	lnz = (lnz == EMPTY || lnz1 == EMPTY) ? EMPTY : (lnz + lnz1) ;
-	flops = (flops == EMPTY || flops1 == EMPTY) ? EMPTY : (flops + flops1) ;
+	lnz = (lnz == TRILINOS_KLU_EMPTY || lnz1 == TRILINOS_KLU_EMPTY) ? TRILINOS_KLU_EMPTY : (lnz + lnz1) ;
+	flops = (flops == TRILINOS_KLU_EMPTY || flops1 == TRILINOS_KLU_EMPTY) ? TRILINOS_KLU_EMPTY : (flops + flops1) ;
 
 	/* ------------------------------------------------------------------ */
 	/* combine the preordering with the TRILINOS_BTF ordering */
@@ -238,10 +238,10 @@ static Int analyze_worker	/* returns TRILINOS_KLU_OK or < 0 if error */
     ASSERT (nzoff >= 0 && nzoff <= Ap [n]) ;
 
     /* return estimates of # of nonzeros in L including diagonal */
-    Symbolic->lnz = lnz ;	    /* EMPTY if TRILINOS_COLAMD used */
+    Symbolic->lnz = lnz ;	    /* TRILINOS_KLU_EMPTY if TRILINOS_COLAMD used */
     Symbolic->unz = lnz ;
     Symbolic->nzoff = nzoff ;
-    Symbolic->est_flops = flops ;   /* EMPTY if TRILINOS_COLAMD or user-ordering used */
+    Symbolic->est_flops = flops ;   /* TRILINOS_KLU_EMPTY if TRILINOS_COLAMD or user-ordering used */
     return (TRILINOS_KLU_OK) ;
 }
 
@@ -334,7 +334,7 @@ static TRILINOS_KLU_symbolic *order_and_analyze	/* returns NULL if error, or a v
     do_btf = (do_btf) ? TRUE : FALSE ;
     Symbolic->ordering = ordering ;
     Symbolic->do_btf = do_btf ;
-    Symbolic->structural_rank = EMPTY ;
+    Symbolic->structural_rank = TRILINOS_KLU_EMPTY ;
 
     /* ---------------------------------------------------------------------- */
     /* find the block triangular form (if requested) */
@@ -469,7 +469,7 @@ TRILINOS_KLU_symbolic *TRILINOS_KLU_analyze	/* returns NULL if error, or a valid
 	return (NULL) ;
     }
     Common->status = TRILINOS_KLU_OK ;
-    Common->structural_rank = EMPTY ;
+    Common->structural_rank = TRILINOS_KLU_EMPTY ;
 
     /* ---------------------------------------------------------------------- */
     /* order and analyze */

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/KLU/Source/trilinos_klu_analyze_given.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/KLU/Source/trilinos_klu_analyze_given.c
@@ -72,7 +72,7 @@ TRILINOS_KLU_symbolic *TRILINOS_KLU_alloc_symbolic
     }
     for (i = 0 ; i < n ; i++)
     {
-	P [i] = EMPTY ;
+	P [i] = TRILINOS_KLU_EMPTY ;
     }
     for (j = 0 ; j < n ; j++)
     {
@@ -316,7 +316,7 @@ TRILINOS_KLU_symbolic *TRILINOS_KLU_analyze_given	    /* returns NULL if error, 
 	    }
 
 	    /* fill-in not estimated */
-	    Lnz [block] = EMPTY ;
+	    Lnz [block] = TRILINOS_KLU_EMPTY ;
 	}
 
 	/* ------------------------------------------------------------------ */
@@ -343,7 +343,7 @@ TRILINOS_KLU_symbolic *TRILINOS_KLU_analyze_given	    /* returns NULL if error, 
 	maxblock = n ;
 	R [0] = 0 ;
 	R [1] = n ;
-	Lnz [0] = EMPTY ;
+	Lnz [0] = TRILINOS_KLU_EMPTY ;
 
 	/* ------------------------------------------------------------------ */
 	/* P = Puser, or identity if Puser is NULL */
@@ -361,8 +361,8 @@ TRILINOS_KLU_symbolic *TRILINOS_KLU_analyze_given	    /* returns NULL if error, 
 
     Symbolic->nblocks = nblocks ;
     Symbolic->maxblock = maxblock ;
-    Symbolic->lnz = EMPTY ;
-    Symbolic->unz = EMPTY ;
+    Symbolic->lnz = TRILINOS_KLU_EMPTY ;
+    Symbolic->unz = TRILINOS_KLU_EMPTY ;
     Symbolic->nzoff = nzoff ;
 
     return (Symbolic) ;

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/KLU/Source/trilinos_klu_defaults.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/KLU/Source/trilinos_klu_defaults.c
@@ -44,13 +44,13 @@ Int TRILINOS_KLU_defaults
     /* statistics */
     Common->status = TRILINOS_KLU_OK ;
     Common->nrealloc = 0 ;
-    Common->structural_rank = EMPTY ;
-    Common->numerical_rank = EMPTY ;
-    Common->noffdiag = EMPTY ;
-    Common->flops = EMPTY ;
-    Common->rcond = EMPTY ;
-    Common->condest = EMPTY ;
-    Common->rgrowth = EMPTY ;
+    Common->structural_rank = TRILINOS_KLU_EMPTY ;
+    Common->numerical_rank = TRILINOS_KLU_EMPTY ;
+    Common->noffdiag = TRILINOS_KLU_EMPTY ;
+    Common->flops = TRILINOS_KLU_EMPTY ;
+    Common->rcond = TRILINOS_KLU_EMPTY ;
+    Common->condest = TRILINOS_KLU_EMPTY ;
+    Common->rgrowth = TRILINOS_KLU_EMPTY ;
     Common->work = 0 ;		/* work done by btf_order */
 
     Common->memusage = 0 ;

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/KLU/Source/trilinos_klu_diagnostics.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/KLU/Source/trilinos_klu_diagnostics.c
@@ -432,7 +432,7 @@ Int TRILINOS_KLU_flops		/* return TRUE if successful, FALSE otherwise */
     {
 	return (FALSE) ;
     }
-    Common->flops = EMPTY ;
+    Common->flops = TRILINOS_KLU_EMPTY ;
     if (Numeric == NULL || Symbolic == NULL)
     {
 	Common->status = TRILINOS_KLU_INVALID ;

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/KLU/Source/trilinos_klu_factor.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/KLU/Source/trilinos_klu_factor.c
@@ -78,7 +78,7 @@ static void factor2
 #ifndef NDEBUG
     for (k = 0 ; k < n ; k++)
     {
-	Pinv [k] = EMPTY ;
+	Pinv [k] = TRILINOS_KLU_EMPTY ;
     }
 #endif
     for (k = 0 ; k < n ; k++)
@@ -87,7 +87,7 @@ static void factor2
 	Pinv [P [k]] = k ;
     }
 #ifndef NDEBUG
-    for (k = 0 ; k < n ; k++) ASSERT (Pinv [k] != EMPTY) ;
+    for (k = 0 ; k < n ; k++) ASSERT (Pinv [k] != TRILINOS_KLU_EMPTY) ;
 #endif
 
     lnz = 0 ;
@@ -266,7 +266,7 @@ static void factor2
 	    max_lnz_block = MAX (max_lnz_block, lnz_block) ;
 	    max_unz_block = MAX (max_unz_block, unz_block) ;
 
-	    if (Lnz [block] == EMPTY)
+	    if (Lnz [block] == TRILINOS_KLU_EMPTY)
 	    {
 		/* revise estimate for subsequent factorization */
 		Lnz [block] = MAX (lnz_block, unz_block) ;
@@ -302,7 +302,7 @@ static void factor2
 #ifndef NDEBUG
     for (k = 0 ; k < n ; k++)
     {
-	Pinv [k] = EMPTY ;
+	Pinv [k] = TRILINOS_KLU_EMPTY ;
     }
 #endif
     for (k = 0 ; k < n ; k++)
@@ -311,7 +311,7 @@ static void factor2
 	Pinv [Pnum [k]] = k ;
     }
 #ifndef NDEBUG
-    for (k = 0 ; k < n ; k++) ASSERT (Pinv [k] != EMPTY) ;
+    for (k = 0 ; k < n ; k++) ASSERT (Pinv [k] != TRILINOS_KLU_EMPTY) ;
 #endif
 
     /* permute scale factors Rs according to pivotal row order */
@@ -407,8 +407,8 @@ TRILINOS_KLU_numeric *TRILINOS_KLU_factor		/* returns NULL if error, or a valid
 	return (NULL) ;
     }
     Common->status = TRILINOS_KLU_OK ;
-    Common->numerical_rank = EMPTY ;
-    Common->singular_col = EMPTY ;
+    Common->numerical_rank = TRILINOS_KLU_EMPTY ;
+    Common->singular_col = TRILINOS_KLU_EMPTY ;
 
     /* ---------------------------------------------------------------------- */
     /* get the contents of the Symbolic object */

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/KLU/Source/trilinos_klu_kernel.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/KLU/Source/trilinos_klu_kernel.c
@@ -20,7 +20,7 @@ static Int dfs
     /* input, not modified on output: */
     Int j,		/* node at which to start the DFS */
     Int k,		/* mark value, for the Flag array */
-    Int Pinv [ ],	/* Pinv [i] = k if row i is kth pivot row, or EMPTY if
+    Int Pinv [ ],	/* Pinv [i] = k if row i is kth pivot row, or TRILINOS_KLU_EMPTY if
 			 * row i is not yet pivotal.  */
     Int Llen [ ],	/* size n, Llen [k] = # nonzeros in column k of L */
     Int Lip [ ],	/* size n, Lip [k] is position in LU of column k of L */
@@ -62,7 +62,7 @@ static Int dfs
 	    PRINTF (("[ start dfs at %d : new %d\n", j, jnew)) ;
 	    /* set Ap_pos [head] to one past the last entry in col j to scan */
 	    Ap_pos [head] =
-		(Lpend [jnew] == EMPTY) ?  Llen [jnew] : Lpend [jnew] ;
+		(Lpend [jnew] == TRILINOS_KLU_EMPTY) ?  Llen [jnew] : Lpend [jnew] ;
 	}
 
 	/* add the adjacent nodes to the recursive stack by iterating through
@@ -127,7 +127,7 @@ static Int lsolve_symbolic
     Int Ap [ ],
     Int Ai [ ],
     Int Q [ ],
-    Int Pinv [ ],	/* Pinv [i] = k if i is kth pivot row, or EMPTY if row i
+    Int Pinv [ ],	/* Pinv [i] = k if i is kth pivot row, or TRILINOS_KLU_EMPTY if row i
 			 * is not yet pivotal.  */
 
     /* workspace, not defined on input or output */
@@ -305,7 +305,7 @@ static void construct_column
 static void lsolve_numeric
 (
     /* input, not modified on output: */
-    Int Pinv [ ],	/* Pinv [i] = k if i is kth pivot row, or EMPTY if row i
+    Int Pinv [ ],	/* Pinv [i] = k if i is kth pivot row, or TRILINOS_KLU_EMPTY if row i
 			 * is not yet pivotal.  */
     Unit *LU,		/* LU factors (pattern and values) */
     Int Stack [ ],	/* stack for dfs */
@@ -365,7 +365,7 @@ static Int lpivot
     Int k,
     Int n,
 
-    Int Pinv [ ],	/* Pinv [i] = k if row i is kth pivot row, or EMPTY if
+    Int Pinv [ ],	/* Pinv [i] = k if row i is kth pivot row, or TRILINOS_KLU_EMPTY if
 			 * row i is not yet pivotal.  */
 
     Int *p_firstrow,
@@ -376,7 +376,7 @@ static Int lpivot
     double abs_pivot, xabs ;
     Int p, i, ppivrow, pdiag, pivrow, *Li, last_row_index, firstrow, len ;
 
-    pivrow = EMPTY ;
+    pivrow = TRILINOS_KLU_EMPTY ;
     if (Llen [k] == 0)
     {
 	/* matrix is structurally singular */
@@ -404,9 +404,9 @@ static Int lpivot
 	return (FALSE) ;
     }
 
-    pdiag = EMPTY ;
-    ppivrow = EMPTY ;
-    abs_pivot = EMPTY ;
+    pdiag = TRILINOS_KLU_EMPTY ;
+    ppivrow = TRILINOS_KLU_EMPTY ;
+    abs_pivot = TRILINOS_KLU_EMPTY ;
     i = Llen [k] - 1 ;
     GET_POINTER (LU, Lip, Llen, Li, Lx, k, len) ;
     last_row_index = Li [i] ;
@@ -446,7 +446,7 @@ static Int lpivot
     if (xabs > abs_pivot)
     {
         abs_pivot = xabs ;
-        ppivrow = EMPTY ;
+        ppivrow = TRILINOS_KLU_EMPTY ;
     }
 
     /* compare the diagonal with the largest entry */
@@ -455,10 +455,10 @@ static Int lpivot
 	if (xabs >= tol * abs_pivot)
 	{
     	    abs_pivot = xabs ;
-            ppivrow = EMPTY ;
+            ppivrow = TRILINOS_KLU_EMPTY ;
         }
     }
-    else if (pdiag != EMPTY)
+    else if (pdiag != TRILINOS_KLU_EMPTY)
     {
 	/* xabs = ABS (Lx [pdiag]) ;*/
 	ABS (xabs, Lx [pdiag]) ;
@@ -470,7 +470,7 @@ static Int lpivot
 	}
     }
 
-    if (ppivrow != EMPTY)
+    if (ppivrow != TRILINOS_KLU_EMPTY)
     {
         pivrow = Li [ppivrow] ;
         pivot  = Lx [ppivrow] ;
@@ -518,7 +518,7 @@ static void prune
     Int Lpend [ ],	/* Lpend [j] marks symmetric pruning point for L(:,j) */
 
     /* input: */
-    Int Pinv [ ],	/* Pinv [i] = k if row i is kth pivot row, or EMPTY if
+    Int Pinv [ ],	/* Pinv [i] = k if row i is kth pivot row, or TRILINOS_KLU_EMPTY if
 			 * row i is not yet pivotal.  */
     Int k,		/* prune using column k of U */
     Int pivrow,		/* current pivot row */
@@ -545,8 +545,8 @@ static void prune
 	j = Ui [p] ;
 	ASSERT (j < k) ;
 	PRINTF (("%d is pruned: %d. Lpend[j] %d Lip[j+1] %d\n",
-	    j, Lpend [j] != EMPTY, Lpend [j], Lip [j+1])) ;
-	if (Lpend [j] == EMPTY)
+	    j, Lpend [j] != TRILINOS_KLU_EMPTY, Lpend [j], Lip [j+1])) ;
+	if (Lpend [j] == TRILINOS_KLU_EMPTY)
 	{
 	    /* scan column j of L for the pivot row */
             GET_POINTER (LU, Lip, Llen, Li, Lx, j, llen) ;
@@ -595,7 +595,7 @@ static void prune
 		     * first part of the column of L.  Entries in
 		     * Li [0 ... Lpend [j]-1] are the only part of
 		     * column j of L that needs to be scanned in the DFS.
-		     * Lpend [j] was EMPTY; setting it >= 0 also flags
+		     * Lpend [j] was TRILINOS_KLU_EMPTY; setting it >= 0 also flags
 		     * column j as pruned. */
 		    Lpend [j] = ptail ;
 
@@ -708,8 +708,8 @@ size_t TRILINOS_KLU_kernel   /* final size of LU on output */
     {
 	/* X [k] = 0 ; */
 	CLEAR (X [k]) ;
-	Flag [k] = EMPTY ;
-	Lpend [k] = EMPTY ;	/* flag k as not pruned */
+	Flag [k] = TRILINOS_KLU_EMPTY ;
+	Lpend [k] = TRILINOS_KLU_EMPTY ;	/* flag k as not pruned */
     }
 
     /* ---------------------------------------------------------------------- */
@@ -727,7 +727,7 @@ size_t TRILINOS_KLU_kernel   /* final size of LU on output */
 
     /* P [k] = row means that UNFLIP (Pinv [row]) = k, and visa versa.
      * If row is pivotal, then Pinv [row] >= 0.  A row is initially "flipped"
-     * (Pinv [k] < EMPTY), and then marked "unflipped" when it becomes
+     * (Pinv [k] < TRILINOS_KLU_EMPTY), and then marked "unflipped" when it becomes
      * pivotal. */
 
 #ifndef NDEBUG
@@ -870,7 +870,7 @@ size_t TRILINOS_KLU_kernel   /* final size of LU on output */
 	{
 	    /* matrix is structurally or numerically singular */
 	    Common->status = TRILINOS_KLU_SINGULAR ;
-	    if (Common->numerical_rank == EMPTY)
+	    if (Common->numerical_rank == TRILINOS_KLU_EMPTY)
 	    {
 		Common->numerical_rank = k+k1 ;
 		Common->singular_col = Q [k+k1] ;

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/KLU/Source/trilinos_klu_l_analyze.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/KLU/Source/trilinos_klu_l_analyze.c
@@ -56,9 +56,9 @@ static Int analyze_worker	/* returns TRILINOS_KLU_OK or < 0 if error */
 #ifndef NDEBUG
     for (k = 0 ; k < n ; k++)
     {
-	P [k] = EMPTY ;
-	Q [k] = EMPTY ;
-	Pinv [k] = EMPTY ;
+	P [k] = TRILINOS_KLU_EMPTY ;
+	Q [k] = TRILINOS_KLU_EMPTY ;
+	Pinv [k] = TRILINOS_KLU_EMPTY ;
     }
 #endif
     for (k = 0 ; k < n ; k++)
@@ -67,13 +67,13 @@ static Int analyze_worker	/* returns TRILINOS_KLU_OK or < 0 if error */
 	Pinv [Pbtf [k]] = k ;
     }
 #ifndef NDEBUG
-    for (k = 0 ; k < n ; k++) ASSERT (Pinv [k] != EMPTY) ;
+    for (k = 0 ; k < n ; k++) ASSERT (Pinv [k] != TRILINOS_KLU_EMPTY) ;
 #endif
     nzoff = 0 ;
     lnz = 0 ;
     maxnz = 0 ;
     flops = 0 ;
-    Symbolic->symmetry = EMPTY ;	/* only computed by AMD */
+    Symbolic->symmetry = TRILINOS_KLU_EMPTY ;	/* only computed by AMD */
 
     /* ---------------------------------------------------------------------- */
     /* order each block */
@@ -95,7 +95,7 @@ static Int analyze_worker	/* returns TRILINOS_KLU_OK or < 0 if error */
 	/* construct the kth block, C */
 	/* ------------------------------------------------------------------ */
 
-	Lnz [block] = EMPTY ;
+	Lnz [block] = TRILINOS_KLU_EMPTY ;
 	pc = 0 ;
 	for (k = k1 ; k < k2 ; k++)
 	{
@@ -183,8 +183,8 @@ static Int analyze_worker	/* returns TRILINOS_KLU_OK or < 0 if error */
 	     * and Ci allocated. */
 
 	    ok = TRILINOS_COLAMD (nk, nk, Cilen, Ci, Cp, NULL, cstats) ;
-	    lnz1 = EMPTY ;
-	    flops1 = EMPTY ;
+	    lnz1 = TRILINOS_KLU_EMPTY ;
+	    flops1 = TRILINOS_KLU_EMPTY ;
 
 	    /* copy the permutation from Cp to Pblk */
 	    for (k = 0 ; k < nk ; k++)
@@ -201,7 +201,7 @@ static Int analyze_worker	/* returns TRILINOS_KLU_OK or < 0 if error */
 	    /* -------------------------------------------------------------- */
 
 	    lnz1 = (Common->user_order) (nk, Cp, Ci, Pblk, Common) ;
-	    flops1 = EMPTY ;
+	    flops1 = TRILINOS_KLU_EMPTY ;
 	    ok = (lnz1 != 0) ;
 	}
 
@@ -215,8 +215,8 @@ static Int analyze_worker	/* returns TRILINOS_KLU_OK or < 0 if error */
 	/* ------------------------------------------------------------------ */
 
 	Lnz [block] = lnz1 ;
-	lnz = (lnz == EMPTY || lnz1 == EMPTY) ? EMPTY : (lnz + lnz1) ;
-	flops = (flops == EMPTY || flops1 == EMPTY) ? EMPTY : (flops + flops1) ;
+	lnz = (lnz == TRILINOS_KLU_EMPTY || lnz1 == TRILINOS_KLU_EMPTY) ? TRILINOS_KLU_EMPTY : (lnz + lnz1) ;
+	flops = (flops == TRILINOS_KLU_EMPTY || flops1 == TRILINOS_KLU_EMPTY) ? TRILINOS_KLU_EMPTY : (flops + flops1) ;
 
 	/* ------------------------------------------------------------------ */
 	/* combine the preordering with the TRILINOS_BTF ordering */
@@ -241,10 +241,10 @@ static Int analyze_worker	/* returns TRILINOS_KLU_OK or < 0 if error */
     ASSERT (nzoff >= 0 && nzoff <= Ap [n]) ;
 
     /* return estimates of # of nonzeros in L including diagonal */
-    Symbolic->lnz = lnz ;	    /* EMPTY if TRILINOS_COLAMD used */
+    Symbolic->lnz = lnz ;	    /* TRILINOS_KLU_EMPTY if TRILINOS_COLAMD used */
     Symbolic->unz = lnz ;
     Symbolic->nzoff = nzoff ;
-    Symbolic->est_flops = flops ;   /* EMPTY if TRILINOS_COLAMD or user-ordering used */
+    Symbolic->est_flops = flops ;   /* TRILINOS_KLU_EMPTY if TRILINOS_COLAMD or user-ordering used */
     return (TRILINOS_KLU_OK) ;
 }
 
@@ -337,7 +337,7 @@ static TRILINOS_KLU_symbolic *order_and_analyze	/* returns NULL if error, or a v
     do_btf = (do_btf) ? TRUE : FALSE ;
     Symbolic->ordering = ordering ;
     Symbolic->do_btf = do_btf ;
-    Symbolic->structural_rank = EMPTY ;
+    Symbolic->structural_rank = TRILINOS_KLU_EMPTY ;
 
     /* ---------------------------------------------------------------------- */
     /* find the block triangular form (if requested) */
@@ -472,7 +472,7 @@ TRILINOS_KLU_symbolic *TRILINOS_KLU_analyze	/* returns NULL if error, or a valid
 	return (NULL) ;
     }
     Common->status = TRILINOS_KLU_OK ;
-    Common->structural_rank = EMPTY ;
+    Common->structural_rank = TRILINOS_KLU_EMPTY ;
 
     /* ---------------------------------------------------------------------- */
     /* order and analyze */

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/KLU/Source/trilinos_klu_l_analyze_given.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/KLU/Source/trilinos_klu_l_analyze_given.c
@@ -75,7 +75,7 @@ TRILINOS_KLU_symbolic *TRILINOS_KLU_alloc_symbolic
     }
     for (i = 0 ; i < n ; i++)
     {
-	P [i] = EMPTY ;
+	P [i] = TRILINOS_KLU_EMPTY ;
     }
     for (j = 0 ; j < n ; j++)
     {
@@ -319,7 +319,7 @@ TRILINOS_KLU_symbolic *TRILINOS_KLU_analyze_given	    /* returns NULL if error, 
 	    }
 
 	    /* fill-in not estimated */
-	    Lnz [block] = EMPTY ;
+	    Lnz [block] = TRILINOS_KLU_EMPTY ;
 	}
 
 	/* ------------------------------------------------------------------ */
@@ -346,7 +346,7 @@ TRILINOS_KLU_symbolic *TRILINOS_KLU_analyze_given	    /* returns NULL if error, 
 	maxblock = n ;
 	R [0] = 0 ;
 	R [1] = n ;
-	Lnz [0] = EMPTY ;
+	Lnz [0] = TRILINOS_KLU_EMPTY ;
 
 	/* ------------------------------------------------------------------ */
 	/* P = Puser, or identity if Puser is NULL */
@@ -364,8 +364,8 @@ TRILINOS_KLU_symbolic *TRILINOS_KLU_analyze_given	    /* returns NULL if error, 
 
     Symbolic->nblocks = nblocks ;
     Symbolic->maxblock = maxblock ;
-    Symbolic->lnz = EMPTY ;
-    Symbolic->unz = EMPTY ;
+    Symbolic->lnz = TRILINOS_KLU_EMPTY ;
+    Symbolic->unz = TRILINOS_KLU_EMPTY ;
     Symbolic->nzoff = nzoff ;
 
     return (Symbolic) ;

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/KLU/Source/trilinos_klu_l_defaults.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/KLU/Source/trilinos_klu_l_defaults.c
@@ -47,13 +47,13 @@ Int TRILINOS_KLU_defaults
     /* statistics */
     Common->status = TRILINOS_KLU_OK ;
     Common->nrealloc = 0 ;
-    Common->structural_rank = EMPTY ;
-    Common->numerical_rank = EMPTY ;
-    Common->noffdiag = EMPTY ;
-    Common->flops = EMPTY ;
-    Common->rcond = EMPTY ;
-    Common->condest = EMPTY ;
-    Common->rgrowth = EMPTY ;
+    Common->structural_rank = TRILINOS_KLU_EMPTY ;
+    Common->numerical_rank = TRILINOS_KLU_EMPTY ;
+    Common->noffdiag = TRILINOS_KLU_EMPTY ;
+    Common->flops = TRILINOS_KLU_EMPTY ;
+    Common->rcond = TRILINOS_KLU_EMPTY ;
+    Common->condest = TRILINOS_KLU_EMPTY ;
+    Common->rgrowth = TRILINOS_KLU_EMPTY ;
     Common->work = 0 ;		/* work done by btf_order */
 
     Common->memusage = 0 ;

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/KLU/Source/trilinos_klu_l_factor.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/KLU/Source/trilinos_klu_l_factor.c
@@ -80,7 +80,7 @@ static void factor2
 #ifndef NDEBUG
     for (k = 0 ; k < n ; k++)
     {
-	Pinv [k] = EMPTY ;
+	Pinv [k] = TRILINOS_KLU_EMPTY ;
     }
 #endif
     for (k = 0 ; k < n ; k++)
@@ -89,7 +89,7 @@ static void factor2
 	Pinv [P [k]] = k ;
     }
 #ifndef NDEBUG
-    for (k = 0 ; k < n ; k++) ASSERT (Pinv [k] != EMPTY) ;
+    for (k = 0 ; k < n ; k++) ASSERT (Pinv [k] != TRILINOS_KLU_EMPTY) ;
 #endif
 
     lnz = 0 ;
@@ -268,7 +268,7 @@ static void factor2
 	    max_lnz_block = MAX (max_lnz_block, lnz_block) ;
 	    max_unz_block = MAX (max_unz_block, unz_block) ;
 
-	    if (Lnz [block] == EMPTY)
+	    if (Lnz [block] == TRILINOS_KLU_EMPTY)
 	    {
 		/* revise estimate for subsequent factorization */
 		Lnz [block] = MAX (lnz_block, unz_block) ;
@@ -304,7 +304,7 @@ static void factor2
 #ifndef NDEBUG
     for (k = 0 ; k < n ; k++)
     {
-	Pinv [k] = EMPTY ;
+	Pinv [k] = TRILINOS_KLU_EMPTY ;
     }
 #endif
     for (k = 0 ; k < n ; k++)
@@ -313,7 +313,7 @@ static void factor2
 	Pinv [Pnum [k]] = k ;
     }
 #ifndef NDEBUG
-    for (k = 0 ; k < n ; k++) ASSERT (Pinv [k] != EMPTY) ;
+    for (k = 0 ; k < n ; k++) ASSERT (Pinv [k] != TRILINOS_KLU_EMPTY) ;
 #endif
 
     /* permute scale factors Rs according to pivotal row order */
@@ -406,8 +406,8 @@ TRILINOS_KLU_numeric *TRILINOS_KLU_factor		/* returns NULL if error, or a valid
 	return (NULL) ;
     }
     Common->status = TRILINOS_KLU_OK ;
-    Common->numerical_rank = EMPTY ;
-    Common->singular_col = EMPTY ;
+    Common->numerical_rank = TRILINOS_KLU_EMPTY ;
+    Common->singular_col = TRILINOS_KLU_EMPTY ;
 
     /* ---------------------------------------------------------------------- */
     /* get the contents of the Symbolic object */

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/KLU/Source/trilinos_klu_l_kernel.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/KLU/Source/trilinos_klu_l_kernel.c
@@ -23,7 +23,7 @@ static Int dfs
     /* input, not modified on output: */
     Int j,		/* node at which to start the DFS */
     Int k,		/* mark value, for the Flag array */
-    Int Pinv [ ],	/* Pinv [i] = k if row i is kth pivot row, or EMPTY if
+    Int Pinv [ ],	/* Pinv [i] = k if row i is kth pivot row, or TRILINOS_KLU_EMPTY if
 			 * row i is not yet pivotal.  */
     Int Llen [ ],	/* size n, Llen [k] = # nonzeros in column k of L */
     Int Lip [ ],	/* size n, Lip [k] is position in LU of column k of L */
@@ -65,7 +65,7 @@ static Int dfs
 	    PRINTF (("[ start dfs at %d : new %d\n", j, jnew)) ;
 	    /* set Ap_pos [head] to one past the last entry in col j to scan */
 	    Ap_pos [head] =
-		(Lpend [jnew] == EMPTY) ?  Llen [jnew] : Lpend [jnew] ;
+		(Lpend [jnew] == TRILINOS_KLU_EMPTY) ?  Llen [jnew] : Lpend [jnew] ;
 	}
 
 	/* add the adjacent nodes to the recursive stack by iterating through
@@ -130,7 +130,7 @@ static Int lsolve_symbolic
     Int Ap [ ],
     Int Ai [ ],
     Int Q [ ],
-    Int Pinv [ ],	/* Pinv [i] = k if i is kth pivot row, or EMPTY if row i
+    Int Pinv [ ],	/* Pinv [i] = k if i is kth pivot row, or TRILINOS_KLU_EMPTY if row i
 			 * is not yet pivotal.  */
 
     /* workspace, not defined on input or output */
@@ -308,7 +308,7 @@ static void construct_column
 static void lsolve_numeric
 (
     /* input, not modified on output: */
-    Int Pinv [ ],	/* Pinv [i] = k if i is kth pivot row, or EMPTY if row i
+    Int Pinv [ ],	/* Pinv [i] = k if i is kth pivot row, or TRILINOS_KLU_EMPTY if row i
 			 * is not yet pivotal.  */
     Unit *LU,		/* LU factors (pattern and values) */
     Int Stack [ ],	/* stack for dfs */
@@ -368,7 +368,7 @@ static Int lpivot
     Int k,
     Int n,
 
-    Int Pinv [ ],	/* Pinv [i] = k if row i is kth pivot row, or EMPTY if
+    Int Pinv [ ],	/* Pinv [i] = k if row i is kth pivot row, or TRILINOS_KLU_EMPTY if
 			 * row i is not yet pivotal.  */
 
     Int *p_firstrow,
@@ -379,7 +379,7 @@ static Int lpivot
     double abs_pivot, xabs ;
     Int p, i, ppivrow, pdiag, pivrow, *Li, last_row_index, firstrow, len ;
 
-    pivrow = EMPTY ;
+    pivrow = TRILINOS_KLU_EMPTY ;
     if (Llen [k] == 0)
     {
 	/* matrix is structurally singular */
@@ -407,9 +407,9 @@ static Int lpivot
 	return (FALSE) ;
     }
 
-    pdiag = EMPTY ;
-    ppivrow = EMPTY ;
-    abs_pivot = EMPTY ;
+    pdiag = TRILINOS_KLU_EMPTY ;
+    ppivrow = TRILINOS_KLU_EMPTY ;
+    abs_pivot = TRILINOS_KLU_EMPTY ;
     i = Llen [k] - 1 ;
     GET_POINTER (LU, Lip, Llen, Li, Lx, k, len) ;
     last_row_index = Li [i] ;
@@ -449,7 +449,7 @@ static Int lpivot
     if (xabs > abs_pivot)
     {
         abs_pivot = xabs ;
-        ppivrow = EMPTY ;
+        ppivrow = TRILINOS_KLU_EMPTY ;
     }
 
     /* compare the diagonal with the largest entry */
@@ -458,10 +458,10 @@ static Int lpivot
 	if (xabs >= tol * abs_pivot)
 	{
     	    abs_pivot = xabs ;
-            ppivrow = EMPTY ;
+            ppivrow = TRILINOS_KLU_EMPTY ;
         }
     }
-    else if (pdiag != EMPTY)
+    else if (pdiag != TRILINOS_KLU_EMPTY)
     {
 	/* xabs = ABS (Lx [pdiag]) ;*/
 	ABS (xabs, Lx [pdiag]) ;
@@ -473,7 +473,7 @@ static Int lpivot
 	}
     }
 
-    if (ppivrow != EMPTY)
+    if (ppivrow != TRILINOS_KLU_EMPTY)
     {
         pivrow = Li [ppivrow] ;
         pivot  = Lx [ppivrow] ;
@@ -521,7 +521,7 @@ static void prune
     Int Lpend [ ],	/* Lpend [j] marks symmetric pruning point for L(:,j) */
 
     /* input: */
-    Int Pinv [ ],	/* Pinv [i] = k if row i is kth pivot row, or EMPTY if
+    Int Pinv [ ],	/* Pinv [i] = k if row i is kth pivot row, or TRILINOS_KLU_EMPTY if
 			 * row i is not yet pivotal.  */
     Int k,		/* prune using column k of U */
     Int pivrow,		/* current pivot row */
@@ -548,8 +548,8 @@ static void prune
 	j = Ui [p] ;
 	ASSERT (j < k) ;
 	PRINTF (("%d is pruned: %d. Lpend[j] %d Lip[j+1] %d\n",
-	    j, Lpend [j] != EMPTY, Lpend [j], Lip [j+1])) ;
-	if (Lpend [j] == EMPTY)
+	    j, Lpend [j] != TRILINOS_KLU_EMPTY, Lpend [j], Lip [j+1])) ;
+	if (Lpend [j] == TRILINOS_KLU_EMPTY)
 	{
 	    /* scan column j of L for the pivot row */
             GET_POINTER (LU, Lip, Llen, Li, Lx, j, llen) ;
@@ -598,7 +598,7 @@ static void prune
 		     * first part of the column of L.  Entries in
 		     * Li [0 ... Lpend [j]-1] are the only part of
 		     * column j of L that needs to be scanned in the DFS.
-		     * Lpend [j] was EMPTY; setting it >= 0 also flags
+		     * Lpend [j] was TRILINOS_KLU_EMPTY; setting it >= 0 also flags
 		     * column j as pruned. */
 		    Lpend [j] = ptail ;
 
@@ -711,8 +711,8 @@ size_t TRILINOS_KLU_kernel   /* final size of LU on output */
     {
 	/* X [k] = 0 ; */
 	CLEAR (X [k]) ;
-	Flag [k] = EMPTY ;
-	Lpend [k] = EMPTY ;	/* flag k as not pruned */
+	Flag [k] = TRILINOS_KLU_EMPTY ;
+	Lpend [k] = TRILINOS_KLU_EMPTY ;	/* flag k as not pruned */
     }
 
     /* ---------------------------------------------------------------------- */
@@ -730,7 +730,7 @@ size_t TRILINOS_KLU_kernel   /* final size of LU on output */
 
     /* P [k] = row means that UNFLIP (Pinv [row]) = k, and visa versa.
      * If row is pivotal, then Pinv [row] >= 0.  A row is initially "flipped"
-     * (Pinv [k] < EMPTY), and then marked "unflipped" when it becomes
+     * (Pinv [k] < TRILINOS_KLU_EMPTY), and then marked "unflipped" when it becomes
      * pivotal. */
 
 #ifndef NDEBUG
@@ -873,7 +873,7 @@ size_t TRILINOS_KLU_kernel   /* final size of LU on output */
 	{
 	    /* matrix is structurally or numerically singular */
 	    Common->status = TRILINOS_KLU_SINGULAR ;
-	    if (Common->numerical_rank == EMPTY)
+	    if (Common->numerical_rank == TRILINOS_KLU_EMPTY)
 	    {
 		Common->numerical_rank = k+k1 ;
 		Common->singular_col = Q [k+k1] ;

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/KLU/Source/trilinos_klu_l_scale.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/KLU/Source/trilinos_klu_l_scale.c
@@ -100,7 +100,7 @@ Int TRILINOS_KLU_scale		/* return TRUE if successful, FALSE otherwise */
     {
 	for (row = 0 ; row < n ; row++)
 	{
-	    W [row] = EMPTY ;
+	    W [row] = TRILINOS_KLU_EMPTY ;
 	}
     }
 

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/KLU/Source/trilinos_klu_refactor.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/KLU/Source/trilinos_klu_refactor.c
@@ -55,8 +55,8 @@ Int TRILINOS_KLU_refactor	/* returns TRUE if successful, FALSE otherwise */
 	return (FALSE) ;
     }
 
-    Common->numerical_rank = EMPTY ;
-    Common->singular_col = EMPTY ;
+    Common->numerical_rank = TRILINOS_KLU_EMPTY ;
+    Common->singular_col = TRILINOS_KLU_EMPTY ;
 
     Az = (Entry *) Ax ;
 
@@ -252,7 +252,7 @@ Int TRILINOS_KLU_refactor	/* returns TRUE if successful, FALSE otherwise */
 		    {
 			/* matrix is numerically singular */
 			Common->status = TRILINOS_KLU_SINGULAR ;
-			if (Common->numerical_rank == EMPTY)
+			if (Common->numerical_rank == TRILINOS_KLU_EMPTY)
 			{
 			    Common->numerical_rank = k+k1 ;
 			    Common->singular_col = Q [k+k1] ;
@@ -396,7 +396,7 @@ Int TRILINOS_KLU_refactor	/* returns TRUE if successful, FALSE otherwise */
 		    {
 			/* matrix is numerically singular */
 			Common->status = TRILINOS_KLU_SINGULAR ;
-			if (Common->numerical_rank == EMPTY)
+			if (Common->numerical_rank == TRILINOS_KLU_EMPTY)
 			{
 			    Common->numerical_rank = k+k1 ;
 			    Common->singular_col = Q [k+k1] ;

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/KLU/Source/trilinos_klu_scale.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/KLU/Source/trilinos_klu_scale.c
@@ -97,7 +97,7 @@ Int TRILINOS_KLU_scale		/* return TRUE if successful, FALSE otherwise */
     {
 	for (row = 0 ; row < n ; row++)
 	{
-	    W [row] = EMPTY ;
+	    W [row] = TRILINOS_KLU_EMPTY ;
 	}
     }
 

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/PARAKLETE/Include/amesos_paraklete_decl.h
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/PARAKLETE/Include/amesos_paraklete_decl.h
@@ -25,6 +25,9 @@
 
 #include "amesos_cholmod.h"
 #include "amesos_cholmod_internal.h"
+// paraklete did not define its own EMPTY macro
+// the macro came from include of amesos_cholmod_internal.h
+// which defines the TRILINOS_CHOLMOD_EMPTY macro used through paraklete
 #include "trilinos_btf_decl.h"
 #include "trilinos_klu_decl.h"
 
@@ -144,7 +147,7 @@ typedef struct paraklete_symbolic_struct
 
     Int *Cparent ;	/* size n, but only entries 0 to ncomponents-1 used.
 			 * Cparent [c] is the parent of node c in the separator
-			 * tree, or EMPTY if c is a root. */
+			 * tree, or TRILINOS_CHOLMOD_EMPTY if c is a root. */
 
     /* ---------------------------------------------------------------------- */
     /* size-(7*ncomponents+2) memory space, in Mem_c: */

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/PARAKLETE/Source/amesos_paraklete_analyze.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/PARAKLETE/Source/amesos_paraklete_analyze.c
@@ -44,8 +44,8 @@ static Int paraklete_bcast_symbolic
     cholmod_common *cm ;
 
     cm = &(Common->cm) ;
-    n = EMPTY ;
-    ncomponents = EMPTY ;
+    n = TRILINOS_CHOLMOD_EMPTY ;
+    ncomponents = TRILINOS_CHOLMOD_EMPTY ;
 
     if (Common->myid == 0)
     {
@@ -68,7 +68,7 @@ static Int paraklete_bcast_symbolic
     MPI_Bcast (&header, 2, MPI_Int, TAG0, MPI_COMM_WORLD) ;
     n = header [0] ;
     ncomponents = header [1] ;
-    if (n == EMPTY)
+    if (n == TRILINOS_CHOLMOD_EMPTY)
     {
 	/* the analysis in the root process failed */
 	PR0 ((Common->file, "proc "ID" root analyze fails\n", Common->myid)) ;
@@ -288,7 +288,7 @@ paraklete_symbolic *amesos_paraklete_analyze
 
     /* Cperm [k] = i if row/col i of A is the kth row/col of A(p,p)
      * ncomponents = # of components in separator tree
-     * Cparent [c] is parent of c in separator tree, or EMPTY if c is a root
+     * Cparent [c] is parent of c in separator tree, or TRILINOS_CHOLMOD_EMPTY if c is a root
      * Cmember [i] = c if row/col i of A is in component c
      */
 
@@ -318,7 +318,7 @@ paraklete_symbolic *amesos_paraklete_analyze
 
 #ifndef NDEBUG
     /* check results: */
-    clast = EMPTY ;
+    clast = TRILINOS_CHOLMOD_EMPTY ;
     for (k = 0 ; k < n ; k++)
     {
 	c = Cmember [Cperm [k]] ;
@@ -440,7 +440,7 @@ paraklete_symbolic *amesos_paraklete_analyze
     /* ---------------------------------------------------------------------- */
 
     /* Nchildren [c] = the number of children of node c */
-    /* Merged [c] = node that c is merged into, or EMPTY if c is not merged */
+    /* Merged [c] = node that c is merged into, or TRILINOS_CHOLMOD_EMPTY if c is not merged */
     /* Leaves [0..nleaves-1] is a list of the leaves of the current tree */
 
     /* Note that W [0..n-1] is still in use for ColCount [0..n-1] */
@@ -451,12 +451,12 @@ paraklete_symbolic *amesos_paraklete_analyze
     for (c = 0 ; c <= ncomponents ; c++)
     {
 	Nchildren [c] = 0 ;
-	Merged [c] = EMPTY ;
+	Merged [c] = TRILINOS_CHOLMOD_EMPTY ;
     }
     for (c = 0 ; c < ncomponents ; c++)
     {
 	parent = Cparent [c] ;
-	if (parent == EMPTY)
+	if (parent == TRILINOS_CHOLMOD_EMPTY)
 	{
 	    parent = ncomponents ;
 	}
@@ -487,14 +487,14 @@ paraklete_symbolic *amesos_paraklete_analyze
 	PR1 ((Common->file, "\n------------ nleaves: "ID"\n", nleaves)) ;
 
 	/* find the lightest leaf (skip node ncomponents-1) */
-	work = EMPTY ;
-	c = EMPTY ;
-	cp = EMPTY ;
+	work = TRILINOS_CHOLMOD_EMPTY ;
+	c = TRILINOS_CHOLMOD_EMPTY ;
+	cp = TRILINOS_CHOLMOD_EMPTY ;
 	for (p = 0 ; p < nleaves ; p++)
 	{
 	    PR2 ((Common->file, "Leaf "ID" work %g\n",
 			Leaves [p], Cwork [Leaves [p]])) ;
-	    ASSERT (Merged [Leaves [p]] == EMPTY) ;
+	    ASSERT (Merged [Leaves [p]] == TRILINOS_CHOLMOD_EMPTY) ;
 	    if (Leaves [p] == ncomponents-1)
 	    {
 		/* node ncomponents-1 has no live node to its right (that is,
@@ -506,14 +506,14 @@ paraklete_symbolic *amesos_paraklete_analyze
 		 * case. */
 		continue ;
 	    }
-	    if (work == EMPTY || Cwork [Leaves [p]] < work)
+	    if (work == TRILINOS_CHOLMOD_EMPTY || Cwork [Leaves [p]] < work)
 	    {
 		c = Leaves [p] ;
 		work = Cwork [c] ;
 		cp = p ;
 	    }
 	}
-	ASSERT (c != EMPTY) ;
+	ASSERT (c != TRILINOS_CHOLMOD_EMPTY) ;
 	PR2 ((Common->file,"Lightest leaf is "ID" with work %g\n", c, Cwork [c]));
 	ASSERT (c < ncomponents-1) ;
 	ASSERT (Nchildren [c] == 0) ;
@@ -521,7 +521,7 @@ paraklete_symbolic *amesos_paraklete_analyze
 	/* find the live node to the right of this node */
 	for (cmerge = c+1 ; cmerge < ncomponents ; cmerge++)
 	{
-	    if (Merged [cmerge] == EMPTY)
+	    if (Merged [cmerge] == TRILINOS_CHOLMOD_EMPTY)
 	    {
 		break ;
 	    }
@@ -529,7 +529,7 @@ paraklete_symbolic *amesos_paraklete_analyze
 
 	/* find the parent of c */
 	parent = Cparent [c] ;
-	if (parent == EMPTY)
+	if (parent == TRILINOS_CHOLMOD_EMPTY)
 	{
 	    parent = ncomponents ;
 	}
@@ -542,7 +542,7 @@ paraklete_symbolic *amesos_paraklete_analyze
 	Merged [c] = cmerge ;
 	Leaves [cp] = Leaves [--nleaves] ;
 	Nchildren [parent]-- ;
-	ASSERT (Merged [parent] == EMPTY) ;
+	ASSERT (Merged [parent] == TRILINOS_CHOLMOD_EMPTY) ;
 
 	if (Nchildren [parent] == 0 && parent != ncomponents)
 	{
@@ -559,10 +559,10 @@ paraklete_symbolic *amesos_paraklete_analyze
     /* merge nodes that have just one child, with the one child */
     for (c = 0 ; c < ncomponents-1 ; c++)
     {
-	if (Merged [c] == EMPTY)
+	if (Merged [c] == TRILINOS_CHOLMOD_EMPTY)
 	{
 	    parent = Cparent [c] ;
-	    if (parent == EMPTY) continue ;
+	    if (parent == TRILINOS_CHOLMOD_EMPTY) continue ;
 	    if (Nchildren [parent] == 1)
 	    {
 		PR1 ((Common->file, "\nparent "ID" of c "ID" has one child\n",
@@ -573,7 +573,7 @@ paraklete_symbolic *amesos_paraklete_analyze
 		for (cc = c+1 ; cc < parent ; cc++)
 		{
 		    PR1 ((Common->file, "merge "ID" into "ID"\n", cc, parent)) ;
-		    ASSERT (Merged [cc] != EMPTY) ;
+		    ASSERT (Merged [cc] != TRILINOS_CHOLMOD_EMPTY) ;
 		    Merged [cc] = parent ;
 		}
 	    }
@@ -587,8 +587,8 @@ paraklete_symbolic *amesos_paraklete_analyze
     {
 	/* find the ultimate node that node c was merged into */
 	PR1 ((Common->file, "\nFind ultimate node for "ID"\n", c)) ;
-	for (cc = c ; Merged [cc] != EMPTY ; cc = Merged [cc]) ;
-	for (c2 = c ; Merged [c2] != EMPTY ; c2 = Merged [c2])
+	for (cc = c ; Merged [cc] != TRILINOS_CHOLMOD_EMPTY ; cc = Merged [cc]) ;
+	for (c2 = c ; Merged [c2] != TRILINOS_CHOLMOD_EMPTY ; c2 = Merged [c2])
 	{
 	    PR1 ((Common->file, "   merge "ID" into "ID"\n", c2, cc)) ;
 	    Merged [c2] = cc ;
@@ -600,7 +600,7 @@ paraklete_symbolic *amesos_paraklete_analyze
     ncomp2 = 0 ;
     for (c = 0 ; c < ncomponents ; c++)
     {
-	if (Merged [c] == EMPTY)
+	if (Merged [c] == TRILINOS_CHOLMOD_EMPTY)
 	{
 	    PR1 ((Common->file, "Live node "ID" becomes node "ID"\n", c, ncomp2)) ;
 	    NewNode [c] = ncomp2++ ;
@@ -608,7 +608,7 @@ paraklete_symbolic *amesos_paraklete_analyze
     }
     for (c = 0 ; c < ncomponents ; c++)
     {
-	if (Merged [c] != EMPTY)
+	if (Merged [c] != TRILINOS_CHOLMOD_EMPTY)
 	{
 	    NewNode [c] = NewNode [Merged [c]] ;
 	    PR1 ((Common->file, "Dead node "ID" becomes part of node "ID"\n",
@@ -628,11 +628,11 @@ paraklete_symbolic *amesos_paraklete_analyze
     Cparent2 = Nchildren ;
     for (c = 0 ; c < ncomponents ; c++)
     {
-	if (Merged [c] == EMPTY)
+	if (Merged [c] == TRILINOS_CHOLMOD_EMPTY)
 	{
 	    c2 = NewNode [c] ;
 	    parent = Cparent [c] ;
-	    parent2 = (parent == EMPTY) ? EMPTY : (NewNode [parent]) ;
+	    parent2 = (parent == TRILINOS_CHOLMOD_EMPTY) ? TRILINOS_CHOLMOD_EMPTY : (NewNode [parent]) ;
 	    Cparent2 [c2] = parent2 ;
 	}
     }
@@ -700,7 +700,7 @@ paraklete_symbolic *amesos_paraklete_analyze
     /* Cstart = start and end nodes of each component */
     /* ---------------------------------------------------------------------- */
 
-    clast = EMPTY ;
+    clast = TRILINOS_CHOLMOD_EMPTY ;
     for (k = 0 ; k < n ; k++)
     {
 	c = Cmember [Cperm [k]] ;
@@ -753,7 +753,7 @@ paraklete_symbolic *amesos_paraklete_analyze
     {
 	parent = Cparent [c] ;
 	PR1 ((Common->file, "node "ID": parent "ID"\n", c, parent)) ;
-	if (parent == EMPTY)
+	if (parent == TRILINOS_CHOLMOD_EMPTY)
 	{
 	    nroots++ ;
 	}
@@ -801,7 +801,7 @@ paraklete_symbolic *amesos_paraklete_analyze
     for (c = 0 ; c < ncomponents ; c++)
     {
 	parent = Cparent [c] ;
-	if (parent != EMPTY)
+	if (parent != TRILINOS_CHOLMOD_EMPTY)
 	{
 	    Child [Cn [parent]++] = c ;
 	}
@@ -826,7 +826,7 @@ paraklete_symbolic *amesos_paraklete_analyze
     for (c = ncomponents - 1 ; c >= 0 ; c--)
     {
 	parent = Cparent [c] ;
-	nparent = (parent == EMPTY) ? 0 : Cn [parent] ;
+	nparent = (parent == TRILINOS_CHOLMOD_EMPTY) ? 0 : Cn [parent] ;
 	Cn [c] = (Cstart [c+1] - Cstart [c]) + nparent ;
 	PR1 ((Common->file, "node "ID" Cn: "ID"\n", c, Cn [c])) ;
     }
@@ -892,7 +892,7 @@ paraklete_symbolic *amesos_paraklete_analyze
 
     for (c = 0 ; c < ncomponents ; c++)
     {
-	Sched [c] = EMPTY ;
+	Sched [c] = TRILINOS_CHOLMOD_EMPTY ;
         Lo_id [c] = -1 ;
         Hi_id [c] = -1 ;
     }
@@ -960,7 +960,7 @@ paraklete_symbolic *amesos_paraklete_analyze
 	if (nchild == 0)
 	{
 	    PR1 ((Common->file,"\nSchedule child "ID" to process "ID"\n", c, proc));
-	    for (cc = c ; cc != EMPTY && Sched [cc] == EMPTY ; cc = Cparent[cc])
+	    for (cc = c ; cc != TRILINOS_CHOLMOD_EMPTY && Sched [cc] == TRILINOS_CHOLMOD_EMPTY ; cc = Cparent[cc])
 	    {
 		PR1 ((Common->file, "  node "ID" to process "ID"\n", cc, proc)) ;
 		Sched [cc] = proc ;
@@ -986,7 +986,7 @@ paraklete_symbolic *amesos_paraklete_analyze
     {
 	PR0 ((Common->file, "    node "ID" Sched "ID" : Cparent "ID" proc "ID"\n",
 		    c, Sched [c], Cparent [c],
-		    (Cparent [c] == EMPTY) ? EMPTY : Sched [Cparent [c]])) ;
+		    (Cparent [c] == TRILINOS_CHOLMOD_EMPTY) ? TRILINOS_CHOLMOD_EMPTY : Sched [Cparent [c]])) ;
     }
 #endif
 
@@ -995,7 +995,7 @@ paraklete_symbolic *amesos_paraklete_analyze
     {
         printf ("   node "ID" on "ID" : Cparent "ID" on "ID"\n",
 		    c, Sched [c], Cparent [c],
-		    (Cparent [c] == EMPTY) ? EMPTY : Sched [Cparent [c]]) ;
+		    (Cparent [c] == TRILINOS_CHOLMOD_EMPTY) ? TRILINOS_CHOLMOD_EMPTY : Sched [Cparent [c]]) ;
     }
 #endif
 

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/PARAKLETE/Source/amesos_paraklete_btf.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/PARAKLETE/Source/amesos_paraklete_btf.c
@@ -31,8 +31,8 @@ static Int paraklete_btf_bcast_symbolic
     cm = &(Common->cm) ;
     km = &(Common->km) ;
 
-    n = EMPTY ;
-    nblocks = EMPTY ;
+    n = TRILINOS_CHOLMOD_EMPTY ;
+    nblocks = TRILINOS_CHOLMOD_EMPTY ;
 
     /* broadcast number of diagonal blocks in the TRILINOS_BTF form, or -1 if failure */
     if (Common->myid == 0)
@@ -56,7 +56,7 @@ static Int paraklete_btf_bcast_symbolic
     MPI (MPI_Bcast (&header, 2, MPI_Int, TAG0, MPI_COMM_WORLD)) ;
     n = header [0] ;
     nblocks = header [1] ;
-    if (n == EMPTY)
+    if (n == TRILINOS_CHOLMOD_EMPTY)
     {
 	return (FALSE) ;
     }

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/PARAKLETE/Source/amesos_paraklete_factorize.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/PARAKLETE/Source/amesos_paraklete_factorize.c
@@ -529,7 +529,7 @@ paraklete_numeric *amesos_paraklete_factorize
 
 	    /* find mapping of global rows/columns to node c's local indices */
 	    cj = 0 ;
-	    for (a = c ; a != EMPTY ; a = Cparent [a])
+	    for (a = c ; a != TRILINOS_CHOLMOD_EMPTY ; a = Cparent [a])
 	    {
 		PR2 ((Common->file, "ancestor "ID", for c "ID", ncomp "ID"\n",
 			a, c, ncomponents)) ;
@@ -579,7 +579,7 @@ paraklete_numeric *amesos_paraklete_factorize
 
 	    /* create columns for the ancestors of C.  These will become columns
 	     * of U2 and S for node c. */
-	    for (a = Cparent [c] ; a != EMPTY ; a = Cparent [a])
+	    for (a = Cparent [c] ; a != TRILINOS_CHOLMOD_EMPTY ; a = Cparent [a])
 	    {
 		PR2 ((Common->file, "ancestor "ID"\n", a)) ;
 		PR2 ((Common->file, "k1 "ID" k2 "ID"\n", Cstart [a], Cstart [a+1]));

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/PARAKLETE/Source/amesos_paraklete_kernel.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/PARAKLETE/Source/amesos_paraklete_kernel.c
@@ -31,7 +31,7 @@ static Int dfs		/* returns new top of output stack */
     Int npiv,
     Int j,		/* node at which to start the DFS */
     Int mark,		/* mark value for Flag */
-    Int Pinv [ ],	/* Pinv [i] = k if row i is kth pivot row, or EMPTY if
+    Int Pinv [ ],	/* Pinv [i] = k if row i is kth pivot row, or TRILINOS_CHOLMOD_EMPTY if
 			 * row i is not yet pivotal.  Only used in phase 1. */
     Int Llen [ ],
     Int Lip [ ],
@@ -77,7 +77,7 @@ static Int dfs		/* returns new top of output stack */
 	    /* first time that j has been visited */
 	    Flag [j] = mark ;
 	    /* set Pstack [head] to one past the last entry in col j to scan */
-	    Pstack [head] = (Lprune [jnew] == EMPTY) ?
+	    Pstack [head] = (Lprune [jnew] == TRILINOS_CHOLMOD_EMPTY) ?
 		(Llen [jnew]) : (Lprune [jnew]) ;
 	}
 
@@ -150,7 +150,7 @@ static void lsolve_symbolic
     Int kcol,		/* b = A (:,kcol) */
     Int Ap [ ],
     Int Ai [ ],
-    Int Pinv [ ],	/* Pinv [i] = k if i is kth pivot row, or EMPTY if row i
+    Int Pinv [ ],	/* Pinv [i] = k if i is kth pivot row, or TRILINOS_CHOLMOD_EMPTY if row i
 			 * is not yet pivotal.  In phase 2, all rows are in
 			 * their final order, and Pinv is a complete inverse
 			 * permutation. */
@@ -328,7 +328,7 @@ static void lsolve_numeric
 (
     /* input, not modified on output: */
     Int npiv,
-    Int Pinv [ ],	/* Pinv [i] = k if i is kth pivot row, or EMPTY if row i
+    Int Pinv [ ],	/* Pinv [i] = k if i is kth pivot row, or TRILINOS_CHOLMOD_EMPTY if row i
 			 * is not yet pivotal.  */
 
     /* TODO comment this */
@@ -517,10 +517,10 @@ static Int lpivot
 
     GET_COLUMN (Lip, Llen, LU, k, Li, Lx, llen) ;
 
-    pdiag = EMPTY ;
+    pdiag = TRILINOS_CHOLMOD_EMPTY ;
     abs_pivot = -1 ;
     max_entry = -1 ;
-    ppivrow = EMPTY ;
+    ppivrow = TRILINOS_CHOLMOD_EMPTY ;
 
     for (p = 0 ; p < llen ; p++)
     {
@@ -550,7 +550,7 @@ static Int lpivot
     }
 
     /* compare the diagonal with the largest entry */
-    if (pdiag != EMPTY)
+    if (pdiag != TRILINOS_CHOLMOD_EMPTY)
     {
 	x = fabs (Lx [pdiag]) ;
 	if (x >= tol_diag * max_entry)
@@ -562,22 +562,22 @@ static Int lpivot
 	else
 	{
 	    /* diagonal entry is too small, discard it */
-	    pdiag = EMPTY ;
+	    pdiag = TRILINOS_CHOLMOD_EMPTY ;
 	}
     }
 
     /* if diagonal not found or not chosen, try for an off-diagonal pivot */
-    if (pdiag == EMPTY && ppivrow != EMPTY)
+    if (pdiag == TRILINOS_CHOLMOD_EMPTY && ppivrow != TRILINOS_CHOLMOD_EMPTY)
     {
 	/* no diagonal pivot.  Try to pick the off-diagonal pivot */
 	if (abs_pivot < tol_offdiag * max_entry)
 	{
 	    /* off-diagonal pivot is too small, discard it */
-	    ppivrow = EMPTY ;
+	    ppivrow = TRILINOS_CHOLMOD_EMPTY ;
 	}
     }
 
-    pivot_found = (ppivrow != EMPTY && abs_pivot > 0) ;
+    pivot_found = (ppivrow != TRILINOS_CHOLMOD_EMPTY && abs_pivot > 0) ;
 
     if (pivot_found)
     {
@@ -645,7 +645,7 @@ static void prune
     {
 	j = Ui [p] ;
 	ASSERT (j >= 0 && j < k) ;
-	if (Lprune [j] == EMPTY)
+	if (Lprune [j] == TRILINOS_CHOLMOD_EMPTY)
 	{
 	    /* scan column j of L for the pivot row */
 	    GET_COLUMN (Lip, Llen, LU, j, Li, Lx, llen) ;
@@ -683,7 +683,7 @@ static void prune
 		     * first part of the column of L.  Entries in
 		     * Li [0 ... Lprune [j]-1] are the only part of
 		     * column j of L that needs to be scanned in the DFS.
-		     * Lprune [j] was EMPTY; setting it >= 0 also flags
+		     * Lprune [j] was TRILINOS_CHOLMOD_EMPTY; setting it >= 0 also flags
 		     * column j as pruned. */
 		    Lprune [j] = ptail ;
 		    break ;
@@ -801,8 +801,8 @@ Int amesos_paraklete_kernel
     for (k = 0 ; k < n ; k++)
     {
 	X [k] = 0 ;
-	Flag [k] = EMPTY ;	/* flag k as unmarked */
-	Lprune [k] = EMPTY ;	/* flag k as not pruned */
+	Flag [k] = TRILINOS_CHOLMOD_EMPTY ;	/* flag k as unmarked */
+	Lprune [k] = TRILINOS_CHOLMOD_EMPTY ;	/* flag k as not pruned */
     }
     mark = 0 ;
 
@@ -828,7 +828,7 @@ Int amesos_paraklete_kernel
 
     /* (P [k] = row) means that (UNFLIP (Pinv [row]) = k), and visa versa.
      * If row is pivotal, then Pinv [row] >= 0.  A row is initially "flipped"
-     * (Pinv [k] < EMPTY), and then marked "unflipped" when it becomes
+     * (Pinv [k] < TRILINOS_CHOLMOD_EMPTY), and then marked "unflipped" when it becomes
      * pivotal. */
 
     /* ---------------------------------------------------------------------- */
@@ -877,8 +877,8 @@ Int amesos_paraklete_kernel
 	/* ------------------------------------------------------------------ */
 
 	found = FALSE ;
-	diagrow = EMPTY ;
-	kcol = EMPTY ;
+	diagrow = TRILINOS_CHOLMOD_EMPTY ;
+	kcol = TRILINOS_CHOLMOD_EMPTY ;
 	while (!found && qhead != qtail)
 	{
 
@@ -1074,7 +1074,7 @@ Int amesos_paraklete_kernel
 
     for (j = 0 ; j < npiv ; j++)
     {
-	Qinv [j] = EMPTY ;
+	Qinv [j] = TRILINOS_CHOLMOD_EMPTY ;
     }
     for (k = 0 ; k < nfound ; k++)
     {
@@ -1086,7 +1086,7 @@ Int amesos_paraklete_kernel
     k = nfound ;
     for (j = 0 ; j < npiv ; j++)
     {
-	if (Qinv [j] == EMPTY)
+	if (Qinv [j] == TRILINOS_CHOLMOD_EMPTY)
 	{
 	    /* a non-pivotal column */
 	    Q [k] = j ;
@@ -1126,7 +1126,7 @@ Int amesos_paraklete_kernel
 	    }
 	}
 
-	unpruned = (Lprune [j] == EMPTY) ;
+	unpruned = (Lprune [j] == TRILINOS_CHOLMOD_EMPTY) ;
 
 	phead = (unpruned) ? 1 : (Lprune [j]) ;
 	ptail = llen ;
@@ -1385,7 +1385,7 @@ Int amesos_paraklete_kernel
 	/* if slen is odd, this entry is allocated but not accessed */
 	if (slen % 2 == 1)
 	{
-	    Si [slen] = EMPTY ;
+	    Si [slen] = TRILINOS_CHOLMOD_EMPTY ;
 	}
 
 	Slen [k - nfound] = slen ;

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/PARAKLETE/Source/amesos_paraklete_lsolve_node.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/PARAKLETE/Source/amesos_paraklete_lsolve_node.c
@@ -202,7 +202,7 @@ Int amesos_paraklete_lsolve_node
      * the contribution to the parent and ancestors */
 
     parent = Cparent [c] ;
-    if (parent != EMPTY && Sched [parent] != myid)
+    if (parent != TRILINOS_CHOLMOD_EMPTY && Sched [parent] != myid)
     {
 	MPI (MPI_Isend (X, cn, MPI_DOUBLE, Sched [parent], TAG0, MPI_COMM_WORLD,
 	    &req)) ;

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/PARAKLETE/Source/amesos_paraklete_node.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/PARAKLETE/Source/amesos_paraklete_node.c
@@ -94,7 +94,7 @@ static void paraklete_send_to_parent
     LUnode->PK_STATUS = status ;
 
     ok = TRUE ;
-    if (parent_id != EMPTY && parent_id != Common->myid)
+    if (parent_id != TRILINOS_CHOLMOD_EMPTY && parent_id != Common->myid)
     {
 	/* send header to process that owns the parent node (parent_id) */
 	PR1 ((Common->file, "proc "ID" sends header parent proc "ID"\n",
@@ -127,7 +127,7 @@ static void paraklete_send_to_parent
 	}
     }
 
-    if (!ok || parent_id == EMPTY || parent_id != Common->myid)
+    if (!ok || parent_id == TRILINOS_CHOLMOD_EMPTY || parent_id != Common->myid)
     {
 	/* free the Schur complement of node c if a failure occured, if node
 	 * c has no parent, or if the Schur complement was sent to a
@@ -198,7 +198,7 @@ Int amesos_paraklete_factorize_node
     Sched  = LUsymbolic->Sched ;
     parent = LUsymbolic->Cparent [c] ;
     myid = Common->myid ;
-    parent_id = (parent == EMPTY) ? EMPTY : Sched [parent] ;
+    parent_id = (parent == TRILINOS_CHOLMOD_EMPTY) ? TRILINOS_CHOLMOD_EMPTY : Sched [parent] ;
 
     PR0 ((Common->file, "proc "ID" at node "ID", clnz: "ID"\n", myid, c, clnz)) ;
 
@@ -660,7 +660,7 @@ Int amesos_paraklete_factorize_node
 	    LUnode->PK_NPIV - LUnode->PK_NFOUND)) ;
 
     /* TODO ensure the kernel does this */
-    cm->mark = EMPTY ;
+    cm->mark = TRILINOS_CHOLMOD_EMPTY ;
     /* CHOLMOD (clear_flag) (cm) ; */
     CHOLMOD_CLEAR_FLAG (cm) 
 

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/PARAKLETE/Source/amesos_paraklete_reanalyze.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/PARAKLETE/Source/amesos_paraklete_reanalyze.c
@@ -108,7 +108,7 @@ paraklete_symbolic *amesos_paraklete_reanalyze
     for (c = ncomponents - 1 ; c >= 0 ; c--)
     {
 	parent = Cparent [c] ;
-	nparent = (parent == EMPTY) ? 0 : Cn [parent] ;
+	nparent = (parent == TRILINOS_CHOLMOD_EMPTY) ? 0 : Cn [parent] ;
 	Cn [c] = (Cstart [c+1] - Cstart [c]) + nparent ;
 	PR1 ((Common->file, "node "ID" new Cn: "ID"\n", c, Cn [c])) ;
     }

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/PARAKLETE/Source/amesos_paraklete_usolve_node.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/PARAKLETE/Source/amesos_paraklete_usolve_node.c
@@ -63,7 +63,7 @@ Int amesos_paraklete_usolve_node
 
     PR1 ((Common->file, "Usolve node "ID" cn "ID" nfound "ID"\n", c, cn, nfound)) ;
 
-    if (parent != EMPTY && Sched [parent] != myid)
+    if (parent != TRILINOS_CHOLMOD_EMPTY && Sched [parent] != myid)
     {
 	PR1 ((Common->file, "Recving usolve from "ID", size "ID"\n", Sched [parent],
 		cn - nfound)) ;


### PR DESCRIPTION
The macro `EMPTY` is defined in multiple solvers in the auxiliarySoftware/SuiteSparse common package. This can cause issues with other software, as in #11630 for example which builds with cuda/11.4 and includes cub files that define a static variable of the same name

This PR renames the EMPTY macro defined in the following places:
* AMD/Include/trilinos_amd_internal.h
* BTF/Include/trilinos_btf_internal.h
* CAMD/Include/trilinos_camd_internal.h
* CHOLMOD/Include/amesos_cholmod_internal.h
* KLU/Include/trilinos_klu_internal.h
* CCOLAMD/Source/trilinos_ccolamd.c
* CCOLAMD/Source/trilinos_ccolamd_l.c
* COLAMD/Source/trilinos_colamd.c
* COLAMD/Source/trilinos_colamd_l.c

and updates the usage of that macro in the corresponding source code

Note: The PARAKLETE solver includes amesos_cholmod_internal.h from which it received its definition of EMPTY; in the PARAKLETE source code I renamed the use of EMPTY to follow the cholmod naming convention, TRILINOS_CHOLMOD_EMPTY

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/amesos 

## Motivation
Resolve, or prevent, possible issues with other software, such as when building with Cuda versions greater than 11.2

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->



## Testing

AT testings
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->