### PR TITLE
Panzer: Epetra deprecation

### DIFF
--- a/packages/panzer/adapters-stk/src/Panzer_STK_ModelEvaluatorFactory.hpp
+++ b/packages/panzer/adapters-stk/src/Panzer_STK_ModelEvaluatorFactory.hpp
@@ -63,12 +63,14 @@
 #include "Panzer_EquationSet_Factory.hpp"
 #include "Panzer_BCStrategy_Factory.hpp"
 #include "Panzer_ClosureModel_Factory_TemplateManager.hpp"
-#include "Panzer_ModelEvaluator_Epetra.hpp"
 #include "Panzer_ModelEvaluator.hpp"
 
 #include "Panzer_NodeType.hpp"
 
+#ifdef PANZER_HAVE_EPETRA_STACK
+#include "Panzer_ModelEvaluator_Epetra.hpp"
 #include "Thyra_EpetraModelEvaluator.hpp"
+#endif
 
 #ifdef PANZER_HAVE_TEKO
 #include "Teko_RequestHandler.hpp"
@@ -360,6 +362,7 @@ addResponse(const std::string & responseName,const std::vector<panzer::WorksetDe
 {
   typedef panzer::ModelEvaluator<double> PanzerME;
 
+#ifdef PANZER_HAVE_EPETRA_STACK
   Teuchos::RCP<Thyra::EpetraModelEvaluator> thyra_ep_me = Teuchos::rcp_dynamic_cast<Thyra::EpetraModelEvaluator>(m_physics_me);
   Teuchos::RCP<PanzerME> panzer_me = Teuchos::rcp_dynamic_cast<PanzerME>(m_physics_me);
 
@@ -373,6 +376,12 @@ addResponse(const std::string & responseName,const std::vector<panzer::WorksetDe
   else if(panzer_me!=Teuchos::null && thyra_ep_me==Teuchos::null) {
     return panzer_me->addResponse(responseName,wkstDesc,builder);
   }
+#else
+  Teuchos::RCP<PanzerME> panzer_me = Teuchos::rcp_dynamic_cast<PanzerME>(m_physics_me);
+  if(panzer_me!=Teuchos::null) {
+    return panzer_me->addResponse(responseName,wkstDesc,builder);
+  }
+#endif
 
   TEUCHOS_ASSERT(false);
   return -1;


### PR DESCRIPTION
@trilinos/panzer 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Found some use of Epetra in the ModelEvaluator that is not protected by ifdef. Broke the build of empire unit testing when epetra is disabled.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
Fixes issue for EMPIRE

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
N/A

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->