### PR TITLE
Teko: Fix warnings and test

### DIFF
--- a/packages/teko/tests/CMakeLists.txt
+++ b/packages/teko/tests/CMakeLists.txt
@@ -58,8 +58,8 @@ SET(UNIT_TEST_DRIVER
 # For parallel tests, use 4 MPI procs when OpenMP not enabled; use 2 MPI procs, 2 threads when OpenMP enabled
 IF(DEFINED Kokkos_ENABLE_OPENMP)
   IF(Kokkos_ENABLE_OPENMP)
-    SET(SERIAL_ARGS_STRING "--kokkos-threads=1")
-    SET(PARALLEL_ARGS_STRING "--kokkos-threads=2")
+    SET(SERIAL_ARGS_STRING "--kokkos-num-threads=1")
+    SET(PARALLEL_ARGS_STRING "--kokkos-num-threads=2")
     SET(CUSTOM_MPI_PROCS "2")
   ELSE()
     SET(SERIAL_ARGS_STRING "")

--- a/packages/teko/tests/src/tLSCIntegrationTest_tpetra.cpp
+++ b/packages/teko/tests/src/tLSCIntegrationTest_tpetra.cpp
@@ -346,8 +346,8 @@ bool tLSCIntegrationTest_tpetra::test_plConstruction(int verbosity,std::ostream 
 
    ParameterList pl;
    pl.set("Inverse Type", "Amesos");
-   pl.set("Inverse Velocity Type", "Ifpack");
-   pl.set("Inverse Pressure Type", "Ifpack");
+   pl.set("Inverse Velocity Type", "Ifpack2");
+   pl.set("Inverse Pressure Type", "Ifpack2");
    pl.set("Ignore Boundary Rows",true);
    pl.set("Use LDU",true);
 


### PR DESCRIPTION
@trilinos/teko 

## Motivation
- Flag `--kokkos-threads` is deprecated, use `--kokkos-num-threads` instead.
- Fix testdriver_tpetra test that failed when Epetra is disabled.

