### PR TITLE
Framework: Update versions to reflect 14.0 release

### DIFF
--- a/Version.cmake
+++ b/Version.cmake
@@ -59,10 +59,10 @@
 # for release mode and set the version.
 #
 
-SET(Trilinos_VERSION 13.5)
-SET(Trilinos_MAJOR_VERSION 13)
-SET(Trilinos_MAJOR_MINOR_VERSION 130500)
-SET(Trilinos_VERSION_STRING "13.5 (Dev)")
+SET(Trilinos_VERSION 14.1)
+SET(Trilinos_MAJOR_VERSION 14)
+SET(Trilinos_MAJOR_MINOR_VERSION 140100)
+SET(Trilinos_VERSION_STRING "14.1 (Dev)")
 SET(Trilinos_ENABLE_DEVELOPMENT_MODE_DEFAULT ON) # Change to 'OFF' for a release
 
 # Used by testing scripts and should not be used elsewhere

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1999,7 +1999,6 @@ opt-set-cmake-var Tpetra_INST_SERIAL BOOL FORCE : ON
 opt-set-cmake-var Zoltan_ENABLE_Scotch BOOL FORCE : OFF
 
 # Test failures as of 11-28-22
-#opt-set-cmake-var MiniTensor_test_Test_01_MPI_1_DISABLE BOOL : ON
 opt-set-cmake-var PanzerAdaptersSTK_tQuad8ToQuad4Factory_MPI_2_DISABLE BOOL : ON
 opt-set-cmake-var PanzerAdaptersSTK_tQuadraticToLinearMeshFactory_MPI_2_DISABLE BOOL : ON
 opt-set-cmake-var Pliris_vector_random_MPI_3_DISABLE BOOL : ON
@@ -2011,6 +2010,8 @@ opt-set-cmake-var ROL_example_PDE-OPT_obstacle_example_01_MPI_4_DISABLE BOOL : O
 opt-set-cmake-var ROL_example_PDE-OPT_topo-opt_poisson_example_01_MPI_4_DISABLE BOOL : ON
 opt-set-cmake-var ROL_test_elementwise_TpetraMultiVector_MPI_4_DISABLE BOOL : ON
 opt-set-cmake-var STKUnit_tests_stk_mesh_unit_tests_MPI_4_DISABLE BOOL : ON
+# This was failing fairly reliably and Nate said it should be okay to disable (https://github.com/trilinos/Trilinos/issues/11678)
+opt-set-cmake-var KokkosCore_UnitTest_CudaTimingBased_MPI_1_DISABLE BOOL : ON
 
 use RHEL7_POST
 


### PR DESCRIPTION
@trilinos/framework 

## Motivation
Once Trilinos 14.0 is released, want develop/master to reflect that 14.0 was the most recent release.

## Related Issues
Wait for #11644 to be merged first.