### PR TITLE
Tacho : remove KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_*

### DIFF
--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Chol.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Chol.hpp
@@ -36,7 +36,7 @@ namespace Tacho {
 template <typename ArgUplo, typename ArgAlgo> struct Chol;
 
 struct CholAlgorithm {
-  using type = ActiveAlgorithm::type;
+  using type = ActiveAlgorithm<runsOnCudaOrHIP()>::type;
 };
 
 } // namespace Tacho

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_CholSupernodes_Serial.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_CholSupernodes_Serial.hpp
@@ -118,8 +118,7 @@ template <> struct CholSupernodes<Algo::Workflow::Serial> {
     const ordinal_type srcbeg = info.sid_block_colidx(sbeg).second, srcend = info.sid_block_colidx(send).second,
                        srcsize = srcend - srcbeg;
 
-    static constexpr bool runOnHost = !std::is_same_v<typename supernode_info_type::exec_space, Kokkos::DefaultExecutionSpace> 
-                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+    static constexpr bool runOnHost = run_tacho_on_host_v <typename supernode_info_type::exec_space>;
 
     // short cut to direct update
     if ((send - sbeg) == 1) {
@@ -399,8 +398,7 @@ template <> struct CholSupernodes<Algo::Workflow::Serial> {
                                                        const typename SupernodeInfoType::value_type_matrix &xB,
                                                        const ordinal_type sid) {
 
-    static constexpr bool runOnHost = !std::is_same_v<typename SupernodeInfoType::exec_space, Kokkos::DefaultExecutionSpace> 
-                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+    static constexpr bool runOnHost = run_tacho_on_host_v <typename SupernodeInfoType::exec_space>;
 
     const auto &cur = info.supernodes(sid);
     const ordinal_type sbeg = cur.sid_col_begin + 1, send = cur.sid_col_end - 1;
@@ -495,8 +493,7 @@ template <> struct CholSupernodes<Algo::Workflow::Serial> {
                                                        const typename SupernodeInfoType::value_type_matrix &xB,
                                                        const ordinal_type sid) {
 
-    static constexpr bool runOnHost = !std::is_same_v<typename SupernodeInfoType::exec_space, Kokkos::DefaultExecutionSpace> 
-                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+    static constexpr bool runOnHost = run_tacho_on_host_v <typename SupernodeInfoType::exec_space>;
 
     const auto &s = info.supernodes(sid);
 
@@ -531,8 +528,7 @@ template <> struct CholSupernodes<Algo::Workflow::Serial> {
     using value_type = typename supernode_info_type::value_type;
     using value_type_matrix = typename supernode_info_type::value_type_matrix;
 
-    static constexpr bool runOnHost = !std::is_same_v<typename supernode_info_type::exec_space, Kokkos::DefaultExecutionSpace> 
-                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+    static constexpr bool runOnHost = run_tacho_on_host_v <typename supernode_info_type::exec_space>;
 
     const auto &s = info.supernodes(sid);
 

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_CholSupernodes_Serial.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_CholSupernodes_Serial.hpp
@@ -118,6 +118,9 @@ template <> struct CholSupernodes<Algo::Workflow::Serial> {
     const ordinal_type srcbeg = info.sid_block_colidx(sbeg).second, srcend = info.sid_block_colidx(send).second,
                        srcsize = srcend - srcbeg;
 
+    static constexpr bool runOnHost = !std::is_same_v<typename supernode_info_type::exec_space, Kokkos::DefaultExecutionSpace> 
+                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+
     // short cut to direct update
     if ((send - sbeg) == 1) {
       const auto &s = info.supernodes(info.sid_block_colidx(sbeg).first);
@@ -128,35 +131,35 @@ template <> struct CholSupernodes<Algo::Workflow::Serial> {
         /* */ value_type *tgt = s.u_buf;
         const value_type *src = (value_type *)ABR.data();
 
-#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
-        // lock
-        while (Kokkos::atomic_compare_exchange(&s.lock, 0, 1))
-          TACHO_IMPL_PAUSE;
-        Kokkos::store_fence();
+        if constexpr(runOnHost) {
+          // lock
+          while (Kokkos::atomic_compare_exchange(&s.lock, 0, 1))
+            TACHO_IMPL_PAUSE;
+          Kokkos::store_fence();
 
-        for (ordinal_type j = 0; j < srcsize; ++j) {
-          const value_type *__restrict__ ss = src + j * srcsize;
-          /* */ value_type *__restrict__ tt = tgt + j * srcsize;
-          const ordinal_type iend = update_lower ? srcsize : j + 1;
-#if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
-#pragma unroll
-#endif
-          for (ordinal_type i = 0; i < iend; ++i)
-            tt[i] += ss[i];
+          for (ordinal_type j = 0; j < srcsize; ++j) {
+            const value_type *__restrict__ ss = src + j * srcsize;
+            /* */ value_type *__restrict__ tt = tgt + j * srcsize;
+            const ordinal_type iend = update_lower ? srcsize : j + 1;
+            #if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
+            #pragma unroll
+            #endif
+            for (ordinal_type i = 0; i < iend; ++i)
+              tt[i] += ss[i];
+          }
+
+          // unlock
+          s.lock = 0;
+          Kokkos::load_fence();
+        } else {
+          Kokkos::parallel_for(Kokkos::TeamThreadRange(member, srcsize), [&](const ordinal_type &j) {
+            const value_type *__restrict__ ss = src + j * srcsize;
+            /* */ value_type *__restrict__ tt = tgt + j * srcsize;
+            const ordinal_type iend = update_lower ? srcsize : j + 1;
+            Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, iend),
+                                 [&](const ordinal_type &i) { Kokkos::atomic_add(&tt[i], ss[i]); });
+          });
         }
-
-        // unlock
-        s.lock = 0;
-        Kokkos::load_fence();
-#else
-        Kokkos::parallel_for(Kokkos::TeamThreadRange(member, srcsize), [&](const ordinal_type &j) {
-          const value_type *__restrict__ ss = src + j * srcsize;
-          /* */ value_type *__restrict__ tt = tgt + j * srcsize;
-          const ordinal_type iend = update_lower ? srcsize : j + 1;
-          Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, iend),
-                               [&](const ordinal_type &i) { Kokkos::atomic_add(&tt[i], ss[i]); });
-        });
-#endif
 
         return 0;
       }
@@ -165,69 +168,69 @@ template <> struct CholSupernodes<Algo::Workflow::Serial> {
     const ordinal_type *s_colidx = sbeg < send ? &info.gid_colidx(cur.gid_col_begin + srcbeg) : NULL;
 
     // loop over target
-#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
-    ordinal_type *s2t = (ordinal_type *)buf;
-    const size_type s2tsize = srcsize * sizeof(ordinal_type);
-    TACHO_TEST_FOR_ABORT(bufsize < s2tsize, "bufsize is smaller than required s2t workspace");
+    if constexpr(runOnHost) {
+      ordinal_type *s2t = (ordinal_type *)buf;
+      const size_type s2tsize = srcsize * sizeof(ordinal_type);
+      TACHO_TEST_FOR_ABORT(bufsize < s2tsize, "bufsize is smaller than required s2t workspace");
 
-    for (ordinal_type i = sbeg; i < send; ++i) {
-      const ordinal_type tgtsid = info.sid_block_colidx(i).first;
-      const auto &s = info.supernodes(tgtsid);
-      {
-        const ordinal_type tgtbeg = info.sid_block_colidx(s.sid_col_begin).second,
-                           tgtend = info.sid_block_colidx(s.sid_col_end - 1).second, tgtsize = tgtend - tgtbeg;
+      for (ordinal_type i = sbeg; i < send; ++i) {
+        const ordinal_type tgtsid = info.sid_block_colidx(i).first;
+        const auto &s = info.supernodes(tgtsid);
+        {
+          const ordinal_type tgtbeg = info.sid_block_colidx(s.sid_col_begin).second,
+                             tgtend = info.sid_block_colidx(s.sid_col_end - 1).second, tgtsize = tgtend - tgtbeg;
 
-        const ordinal_type *t_colidx = &info.gid_colidx(s.gid_col_begin + tgtbeg);
-        for (ordinal_type k = 0, l = 0; k < srcsize; ++k) {
-          s2t[k] = -1;
-          for (; l < tgtsize && t_colidx[l] <= s_colidx[k]; ++l)
-            if (s_colidx[k] == t_colidx[l]) {
-              s2t[k] = l;
-              break;
-            }
-        }
-      }
-
-      {
-        UnmanagedViewType<value_type_matrix> U(s.u_buf, s.m, s.n);
-        UnmanagedViewType<value_type_matrix> Lp(s.l_buf, s.n, s.m);
-        const auto L = Kokkos::subview(Lp, range_type(s.m, s.n), Kokkos::ALL());
-
-        ordinal_type ijbeg = 0;
-        for (; s2t[ijbeg] == -1; ++ijbeg)
-          ;
-
-        // lock
-        while (Kokkos::atomic_compare_exchange(&s.lock, 0, 1))
-          TACHO_IMPL_PAUSE;
-        Kokkos::store_fence();
-
-        for (ordinal_type jj = ijbeg; jj < srcsize; ++jj) {
-          const ordinal_type col = s2t[jj];
-#if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
-#pragma unroll
-#endif
-          for (ordinal_type ii = ijbeg; ii < srcsize; ++ii) {
-            const ordinal_type row = s2t[ii];
-            if (row < s.m) {
-              U(row, col) += ABR(ii, jj);
-              if (update_lower && col >= s.m) {
-                L(col - s.m, row) += ABR(jj, ii);
+          const ordinal_type *t_colidx = &info.gid_colidx(s.gid_col_begin + tgtbeg);
+          for (ordinal_type k = 0, l = 0; k < srcsize; ++k) {
+            s2t[k] = -1;
+            for (; l < tgtsize && t_colidx[l] <= s_colidx[k]; ++l)
+              if (s_colidx[k] == t_colidx[l]) {
+                s2t[k] = l;
+                break;
               }
-            } else
-              break;
           }
         }
 
-        // unlock
-        s.lock = 0;
-        Kokkos::load_fence();
+        {
+          UnmanagedViewType<value_type_matrix> U(s.u_buf, s.m, s.n);
+          UnmanagedViewType<value_type_matrix> Lp(s.l_buf, s.n, s.m);
+          const auto L = Kokkos::subview(Lp, range_type(s.m, s.n), Kokkos::ALL());
+
+          ordinal_type ijbeg = 0;
+          for (; s2t[ijbeg] == -1; ++ijbeg)
+            ;
+
+          // lock
+          while (Kokkos::atomic_compare_exchange(&s.lock, 0, 1))
+            TACHO_IMPL_PAUSE;
+          Kokkos::store_fence();
+
+          for (ordinal_type jj = ijbeg; jj < srcsize; ++jj) {
+            const ordinal_type col = s2t[jj];
+            #if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
+            #pragma unroll
+            #endif
+            for (ordinal_type ii = ijbeg; ii < srcsize; ++ii) {
+              const ordinal_type row = s2t[ii];
+              if (row < s.m) {
+                U(row, col) += ABR(ii, jj);
+                if (update_lower && col >= s.m) {
+                  L(col - s.m, row) += ABR(jj, ii);
+                }
+              } else
+                break;
+            }
+          }
+
+          // unlock
+          s.lock = 0;
+          Kokkos::load_fence();
+        }
       }
-    }
-#else
-    // CUDA version
-    const size_type s2tsize = srcsize * sizeof(ordinal_type) * member.team_size();
-    TACHO_TEST_FOR_ABORT(bufsize < s2tsize, "bufsize is smaller than required s2t workspace");
+    } else {
+      // CUDA version
+      const size_type s2tsize = srcsize * sizeof(ordinal_type) * member.team_size();
+      TACHO_TEST_FOR_ABORT(bufsize < s2tsize, "bufsize is smaller than required s2t workspace");
 #if 0 // single version for testing only 
         Kokkos::single(Kokkos::PerTeam(member), [&]() {
             ordinal_type *s2t = (ordinal_type*)buf;        
@@ -273,76 +276,76 @@ template <> struct CholSupernodes<Algo::Workflow::Serial> {
             }
           });
 #else
-    Kokkos::parallel_for(Kokkos::TeamThreadRange(member, sbeg, send), [&](const ordinal_type &i) {
-      ordinal_type *s2t = ((ordinal_type *)(buf)) + member.team_rank() * srcsize;
-      const auto &s = info.supernodes(info.sid_block_colidx(i).first);
-      {
-        const ordinal_type tgtbeg = info.sid_block_colidx(s.sid_col_begin).second,
-                           tgtend = info.sid_block_colidx(s.sid_col_end - 1).second, tgtsize = tgtend - tgtbeg;
+      Kokkos::parallel_for(Kokkos::TeamThreadRange(member, sbeg, send), [&](const ordinal_type &i) {
+        ordinal_type *s2t = ((ordinal_type *)(buf)) + member.team_rank() * srcsize;
+        const auto &s = info.supernodes(info.sid_block_colidx(i).first);
+        {
+          const ordinal_type tgtbeg = info.sid_block_colidx(s.sid_col_begin).second,
+                             tgtend = info.sid_block_colidx(s.sid_col_end - 1).second, tgtsize = tgtend - tgtbeg;
 
-        const ordinal_type *t_colidx = &info.gid_colidx(s.gid_col_begin + tgtbeg);
-        // for (ordinal_type k=0,l=0;k<srcsize;++k) {
-        //   s2t[k] = -1;
-        //   for (;l<tgtsize && t_colidx[l] <= s_colidx[k];++l)
-        //     if (s_colidx[k] == t_colidx[l]) {
-        //       s2t[k] = l;
-        //       break;
-        //     }
-        // }
-        Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, srcsize), [&](const ordinal_type &k) {
-          s2t[k] = -1;
-          auto found = lower_bound(&t_colidx[0], &t_colidx[tgtsize - 1], s_colidx[k],
-                                   [](ordinal_type left, ordinal_type right) { return left < right; });
-          if (s_colidx[k] == *found) {
-            s2t[k] = found - t_colidx;
-          }
-        });
-      }
-      {
-        UnmanagedViewType<value_type_matrix> U(s.u_buf, s.m, s.n);
-        UnmanagedViewType<value_type_matrix> Lp(s.l_buf, s.n, s.m);
-        const auto L = Kokkos::subview(Lp, range_type(s.m, s.n), Kokkos::ALL());
+          const ordinal_type *t_colidx = &info.gid_colidx(s.gid_col_begin + tgtbeg);
+          // for (ordinal_type k=0,l=0;k<srcsize;++k) {
+          //   s2t[k] = -1;
+          //   for (;l<tgtsize && t_colidx[l] <= s_colidx[k];++l)
+          //     if (s_colidx[k] == t_colidx[l]) {
+          //       s2t[k] = l;
+          //       break;
+          //     }
+          // }
+          Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, srcsize), [&](const ordinal_type &k) {
+            s2t[k] = -1;
+            auto found = lower_bound(&t_colidx[0], &t_colidx[tgtsize - 1], s_colidx[k],
+                                     [](ordinal_type left, ordinal_type right) { return left < right; });
+            if (s_colidx[k] == *found) {
+              s2t[k] = found - t_colidx;
+            }
+          });
+        }
+        {
+          UnmanagedViewType<value_type_matrix> U(s.u_buf, s.m, s.n);
+          UnmanagedViewType<value_type_matrix> Lp(s.l_buf, s.n, s.m);
+          const auto L = Kokkos::subview(Lp, range_type(s.m, s.n), Kokkos::ALL());
 
-        ordinal_type ijbeg = 0;
-        for (; s2t[ijbeg] == -1; ++ijbeg)
-          ;
+          ordinal_type ijbeg = 0;
+          for (; s2t[ijbeg] == -1; ++ijbeg)
+            ;
 
-        Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, ijbeg, srcsize), [&](const ordinal_type &ii) {
-          const ordinal_type row = s2t[ii];
-          if (row < s.m) {
-            for (ordinal_type jj = ijbeg; jj < srcsize; ++jj) {
-              const ordinal_type col = s2t[jj];
-              Kokkos::atomic_add(&U(row, col), ABR(ii, jj));
-              if (update_lower && col >= s.m) {
-                Kokkos::atomic_add(&L(col - s.m, row), ABR(jj, ii));
+          Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, ijbeg, srcsize), [&](const ordinal_type &ii) {
+            const ordinal_type row = s2t[ii];
+            if (row < s.m) {
+              for (ordinal_type jj = ijbeg; jj < srcsize; ++jj) {
+                const ordinal_type col = s2t[jj];
+                Kokkos::atomic_add(&U(row, col), ABR(ii, jj));
+                if (update_lower && col >= s.m) {
+                  Kokkos::atomic_add(&L(col - s.m, row), ABR(jj, ii));
+                }
               }
             }
-          }
-        });
-        // Kokkos::parallel_for
-        //   (Kokkos::ThreadVectorRange(member, srcsize-ijbeg), [&](const ordinal_type &jjj) {
-        //     const ordinal_type jj = jjj + ijbeg;
-        //     for (ordinal_type ii=ijbeg;ii<srcsize;++ii) {
-        //       const ordinal_type row = s2t[ii];
-        //       if (row < s.m)
-        //         Kokkos::atomic_add(&A(row, s2t[jj]), ABR(ii, jj));
-        //       else
-        //         break;
-        //     }
-        //   });
-        // const ordinal_type cnt = srcsize-ijbeg;
-        // Kokkos::parallel_for
-        //   (Kokkos::ThreadVectorRange(member, cnt*cnt), [&](const ordinal_type &idx) {
-        //     const ordinal_type ii = idx%cnt + ijbeg;
-        //     const ordinal_type jj = idx/cnt + ijbeg;
-        //     const ordinal_type row = s2t[ii];
-        //     const ordinal_type col = s2t[jj];
-        //     if (row < s.m) Kokkos::atomic_add(&A(row, s2t[jj]), ABR(ii, jj));
-        //   });
-      }
-    });
+          });
+          // Kokkos::parallel_for
+          //   (Kokkos::ThreadVectorRange(member, srcsize-ijbeg), [&](const ordinal_type &jjj) {
+          //     const ordinal_type jj = jjj + ijbeg;
+          //     for (ordinal_type ii=ijbeg;ii<srcsize;++ii) {
+          //       const ordinal_type row = s2t[ii];
+          //       if (row < s.m)
+          //         Kokkos::atomic_add(&A(row, s2t[jj]), ABR(ii, jj));
+          //       else
+          //         break;
+          //     }
+          //   });
+          // const ordinal_type cnt = srcsize-ijbeg;
+          // Kokkos::parallel_for
+          //   (Kokkos::ThreadVectorRange(member, cnt*cnt), [&](const ordinal_type &idx) {
+          //     const ordinal_type ii = idx%cnt + ijbeg;
+          //     const ordinal_type jj = idx/cnt + ijbeg;
+          //     const ordinal_type row = s2t[ii];
+          //     const ordinal_type col = s2t[jj];
+          //     if (row < s.m) Kokkos::atomic_add(&A(row, s2t[jj]), ABR(ii, jj));
+          //   });
+        }
+      });
 #endif
-#endif
+    }
     return 0;
   }
 
@@ -395,46 +398,50 @@ template <> struct CholSupernodes<Algo::Workflow::Serial> {
   KOKKOS_INLINE_FUNCTION static int update_solve_lower(MemberType &member, const SupernodeInfoType &info,
                                                        const typename SupernodeInfoType::value_type_matrix &xB,
                                                        const ordinal_type sid) {
+
+    static constexpr bool runOnHost = !std::is_same_v<typename SupernodeInfoType::exec_space, Kokkos::DefaultExecutionSpace> 
+                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+
     const auto &cur = info.supernodes(sid);
     const ordinal_type sbeg = cur.sid_col_begin + 1, send = cur.sid_col_end - 1;
 
     const ordinal_type m = xB.extent(0), n = xB.extent(1);
     TACHO_TEST_FOR_ABORT(m != (cur.n - cur.m), "# of rows in xB does not match to super blocksize in sid");
 
-#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
-    for (ordinal_type i = sbeg, is = 0; i < send; ++i) {
-      const ordinal_type tbeg = info.sid_block_colidx(i).second, tend = info.sid_block_colidx(i + 1).second;
-
-      // lock
-      const auto &s = info.supernodes(info.sid_block_colidx(i).first);
-      while (Kokkos::atomic_compare_exchange(&s.lock, 0, 1))
-        TACHO_IMPL_PAUSE;
-      Kokkos::store_fence();
-
-      // both src and tgt increase index
-      for (ordinal_type it = tbeg; it < tend; ++it, ++is) {
-        const ordinal_type row = info.gid_colidx(cur.gid_col_begin + it);
-        for (ordinal_type j = 0; j < n; ++j)
-          info.x(row, j) += xB(is, j);
-      }
-
-      // unlock
-      s.lock = 0;
-      Kokkos::load_fence();
-    }
-#else
-    Kokkos::single(Kokkos::PerTeam(member), [&]() {
+    if constexpr(runOnHost) {
       for (ordinal_type i = sbeg, is = 0; i < send; ++i) {
         const ordinal_type tbeg = info.sid_block_colidx(i).second, tend = info.sid_block_colidx(i + 1).second;
 
+        // lock
+        const auto &s = info.supernodes(info.sid_block_colidx(i).first);
+        while (Kokkos::atomic_compare_exchange(&s.lock, 0, 1))
+          TACHO_IMPL_PAUSE;
+        Kokkos::store_fence();
+
+        // both src and tgt increase index
         for (ordinal_type it = tbeg; it < tend; ++it, ++is) {
           const ordinal_type row = info.gid_colidx(cur.gid_col_begin + it);
           for (ordinal_type j = 0; j < n; ++j)
-            Kokkos::atomic_add(&info.x(row, j), xB(is, j));
+            info.x(row, j) += xB(is, j);
         }
+
+        // unlock
+        s.lock = 0;
+        Kokkos::load_fence();
       }
-    });
-#endif
+    } else {
+      Kokkos::single(Kokkos::PerTeam(member), [&]() {
+        for (ordinal_type i = sbeg, is = 0; i < send; ++i) {
+          const ordinal_type tbeg = info.sid_block_colidx(i).second, tend = info.sid_block_colidx(i + 1).second;
+
+          for (ordinal_type it = tbeg; it < tend; ++it, ++is) {
+            const ordinal_type row = info.gid_colidx(cur.gid_col_begin + it);
+            for (ordinal_type j = 0; j < n; ++j)
+              Kokkos::atomic_add(&info.x(row, j), xB(is, j));
+          }
+        }
+      });
+    }
     return 0;
   }
 
@@ -488,26 +495,29 @@ template <> struct CholSupernodes<Algo::Workflow::Serial> {
                                                        const typename SupernodeInfoType::value_type_matrix &xB,
                                                        const ordinal_type sid) {
 
+    static constexpr bool runOnHost = !std::is_same_v<typename SupernodeInfoType::exec_space, Kokkos::DefaultExecutionSpace> 
+                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+
     const auto &s = info.supernodes(sid);
 
     const ordinal_type m = xB.extent(0), n = xB.extent(1);
     TACHO_TEST_FOR_ABORT(m != (s.n - s.m), "# of rows in xB does not match to super blocksize in sid");
 
     const ordinal_type goffset = s.gid_col_begin + s.m;
-#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
-    for (ordinal_type j = 0; j < n; ++j)
-      for (ordinal_type i = 0; i < m; ++i) {
-        const ordinal_type row = info.gid_colidx(i + goffset);
-        xB(i, j) = info.x(row, j);
-      }
-#else
-    Kokkos::parallel_for(Kokkos::TeamThreadRange(member, n), [&](const ordinal_type &j) {
-      Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, m), [&](const ordinal_type &i) {
-        const ordinal_type row = info.gid_colidx(i + goffset);
-        xB(i, j) = info.x(row, j);
+    if constexpr(runOnHost) {
+      for (ordinal_type j = 0; j < n; ++j)
+        for (ordinal_type i = 0; i < m; ++i) {
+          const ordinal_type row = info.gid_colidx(i + goffset);
+          xB(i, j) = info.x(row, j);
+        }
+    } else {
+      Kokkos::parallel_for(Kokkos::TeamThreadRange(member, n), [&](const ordinal_type &j) {
+        Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, m), [&](const ordinal_type &i) {
+          const ordinal_type row = info.gid_colidx(i + goffset);
+          xB(i, j) = info.x(row, j);
+        });
       });
-    });
-#endif
+    }
 
     return 0;
   }
@@ -521,6 +531,9 @@ template <> struct CholSupernodes<Algo::Workflow::Serial> {
     using value_type = typename supernode_info_type::value_type;
     using value_type_matrix = typename supernode_info_type::value_type_matrix;
 
+    static constexpr bool runOnHost = !std::is_same_v<typename supernode_info_type::exec_space, Kokkos::DefaultExecutionSpace> 
+                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+
     const auto &s = info.supernodes(sid);
 
     if (final) {
@@ -531,11 +544,13 @@ template <> struct CholSupernodes<Algo::Workflow::Serial> {
 
     {
       const ordinal_type n = s.n - s.m;
-#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
-      const size_type bufsize_required = n * (n + 1) * sizeof(value_type);
-#else
-      const size_type bufsize_required = n * (n + member.team_size()) * sizeof(value_type);
-#endif
+
+      size_type bufsize_required;
+      if constexpr(runOnHost)
+        bufsize_required = n * (n + 1) * sizeof(value_type);
+      else
+        bufsize_required = n * (n + member.team_size()) * sizeof(value_type);
+
       TACHO_TEST_FOR_ABORT(bufsize < bufsize_required, "bufsize is smaller than required");
 
       UnmanagedViewType<value_type_matrix> ABR((value_type *)buf, n, n);

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_CholSupernodes_SerialPanel.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_CholSupernodes_SerialPanel.hpp
@@ -106,8 +106,7 @@ template <> struct CholSupernodes<Algo::Workflow::SerialPanel> {
     typedef typename supernode_info_type::value_type value_type;
     typedef typename supernode_info_type::value_type_matrix value_type_matrix;
 
-    static constexpr bool runOnHost = !std::is_same_v<typename supernode_info_type::exec_space, Kokkos::DefaultExecutionSpace>
-                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+    static constexpr bool runOnHost = run_tacho_on_host_v<typename supernode_info_type::exec_space>;
 
     // algorithm choice
     using HerkAlgoType = typename HerkAlgorithm::type;
@@ -361,8 +360,7 @@ template <> struct CholSupernodes<Algo::Workflow::SerialPanel> {
 
     typedef typename supernode_info_type::value_type value_type;
 
-    static constexpr bool runOnHost = !std::is_same_v<typename supernode_info_type::exec_space, Kokkos::DefaultExecutionSpace>
-                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+    static constexpr bool runOnHost = run_tacho_on_host_v<typename supernode_info_type::exec_space>;
 
     const auto &s = info.supernodes(sid);
 

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_CholSupernodes_SerialPanel.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_CholSupernodes_SerialPanel.hpp
@@ -106,14 +106,16 @@ template <> struct CholSupernodes<Algo::Workflow::SerialPanel> {
     typedef typename supernode_info_type::value_type value_type;
     typedef typename supernode_info_type::value_type_matrix value_type_matrix;
 
+    static constexpr bool runOnHost = !std::is_same_v<typename supernode_info_type::exec_space, Kokkos::DefaultExecutionSpace>
+                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+
     // algorithm choice
     using HerkAlgoType = typename HerkAlgorithm::type;
     using GemmAlgoType = typename GemmAlgorithm::type;
 
-#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
-#else
-    member.team_barrier();
-#endif
+    if constexpr(!runOnHost) {
+      member.team_barrier();
+    }
     // get current supernode
     const auto &cur = info.supernodes(sid);
 
@@ -128,14 +130,14 @@ template <> struct CholSupernodes<Algo::Workflow::SerialPanel> {
       const ordinal_type srcbeg = info.sid_block_colidx(sbeg).second, srcend = info.sid_block_colidx(send).second,
                          srcsize = srcend - srcbeg;
 
-#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
-      TACHO_TEST_FOR_ABORT(bufsize < size_type(srcsize * sizeof(ordinal_type) + nn * nb * sizeof(value_type)),
-                           "bufsize is smaller than required workspace");
-#else
-      TACHO_TEST_FOR_ABORT(
-          bufsize < size_type(srcsize * sizeof(ordinal_type) * member.team_size() + nn * nb * sizeof(value_type)),
-          "bufsize is smaller than required workspace");
-#endif
+      if constexpr(runOnHost) {
+        TACHO_TEST_FOR_ABORT(bufsize < size_type(srcsize * sizeof(ordinal_type) + nn * nb * sizeof(value_type)),
+                             "bufsize is smaller than required workspace");
+      } else {
+        TACHO_TEST_FOR_ABORT(
+            bufsize < size_type(srcsize * sizeof(ordinal_type) * member.team_size() + nn * nb * sizeof(value_type)),
+            "bufsize is smaller than required workspace");
+      }
 
       UnmanagedViewType<value_type_matrix> ABL(cur.buf + m * m, m, nn);
       UnmanagedViewType<value_type_matrix> ATR(ABL.data() + offn * m, m, nb);
@@ -159,193 +161,193 @@ template <> struct CholSupernodes<Algo::Workflow::SerialPanel> {
           /* */ value_type *tgt = s.buf;
           const value_type *src = (value_type *)ABR.data();
 
-#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
-          switch (info.front_update_mode) {
-          case 1: {
-            for (ordinal_type js = 0; js < nb; ++js) {
-              const ordinal_type jt = js + offn;
-              const value_type *__restrict__ ss = src + js * srcsize;
-              /* */ value_type *__restrict__ tt = tgt + jt * srcsize;
+          if constexpr(runOnHost) {
+            switch (info.front_update_mode) {
+            case 1: {
+              for (ordinal_type js = 0; js < nb; ++js) {
+                const ordinal_type jt = js + offn;
+                const value_type *__restrict__ ss = src + js * srcsize;
+                /* */ value_type *__restrict__ tt = tgt + jt * srcsize;
 #if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
 #pragma unroll
 #endif
-              for (ordinal_type i = 0; i <= jt; ++i)
-                Kokkos::atomic_fetch_add(&tt[i], ss[i]);
+                for (ordinal_type i = 0; i <= jt; ++i)
+                  Kokkos::atomic_fetch_add(&tt[i], ss[i]);
+              }
+              break;
             }
-            break;
-          }
-          case 0: {
-            // lock
-            while (Kokkos::atomic_compare_exchange(&s.lock, 0, 1))
-              TACHO_IMPL_PAUSE;
-            Kokkos::store_fence();
+            case 0: {
+              // lock
+              while (Kokkos::atomic_compare_exchange(&s.lock, 0, 1))
+                TACHO_IMPL_PAUSE;
+              Kokkos::store_fence();
 
-            for (ordinal_type js = 0; js < nb; ++js) {
-              const ordinal_type jt = js + offn;
-              const value_type *__restrict__ ss = src + js * srcsize;
-              /* */ value_type *__restrict__ tt = tgt + jt * srcsize;
+              for (ordinal_type js = 0; js < nb; ++js) {
+                const ordinal_type jt = js + offn;
+                const value_type *__restrict__ ss = src + js * srcsize;
+                /* */ value_type *__restrict__ tt = tgt + jt * srcsize;
 #if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
 #pragma unroll
 #endif
-              for (ordinal_type i = 0; i <= jt; ++i)
-                tt[i] += ss[i];
-            }
+                for (ordinal_type i = 0; i <= jt; ++i)
+                  tt[i] += ss[i];
+              }
 
-            // unlock
-            s.lock = 0;
-            Kokkos::load_fence();
-            break;
+              // unlock
+              s.lock = 0;
+              Kokkos::load_fence();
+              break;
+            }
+            }
+          } else {
+            Kokkos::parallel_for(Kokkos::TeamThreadRange(member, nb), [&](const ordinal_type &js) {
+              const ordinal_type jt = js + offn;
+              const value_type *__restrict__ ss = src + js * srcsize;
+              /* */ value_type *__restrict__ tt = tgt + jt * srcsize;
+              Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, jt + 1),
+                                   [&](const ordinal_type &i) { Kokkos::atomic_fetch_add(&tt[i], ss[i]); });
+            });
           }
-          }
-#else
-          Kokkos::parallel_for(Kokkos::TeamThreadRange(member, nb), [&](const ordinal_type &js) {
-            const ordinal_type jt = js + offn;
-            const value_type *__restrict__ ss = src + js * srcsize;
-            /* */ value_type *__restrict__ tt = tgt + jt * srcsize;
-            Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, jt + 1),
-                                 [&](const ordinal_type &i) { Kokkos::atomic_fetch_add(&tt[i], ss[i]); });
-          });
-#endif
 
           return 0;
         }
       }
 
-#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
-      // loop over target
-      const ordinal_type *s_colidx = sbeg < send ? &info.gid_colidx(cur.gid_col_begin + srcbeg) : NULL;
-      for (ordinal_type i = sbeg; i < send; ++i) {
-        ordinal_type *s2t = (ordinal_type *)ptr;
-        const auto &s = info.supernodes(info.sid_block_colidx(i).first);
-        {
-          const ordinal_type tgtbeg = info.sid_block_colidx(s.sid_col_begin).second,
-                             tgtend = info.sid_block_colidx(s.sid_col_end - 1).second, tgtsize = tgtend - tgtbeg;
+      if constexpr(runOnHost) {
+        // loop over target
+        const ordinal_type *s_colidx = sbeg < send ? &info.gid_colidx(cur.gid_col_begin + srcbeg) : NULL;
+        for (ordinal_type i = sbeg; i < send; ++i) {
+          ordinal_type *s2t = (ordinal_type *)ptr;
+          const auto &s = info.supernodes(info.sid_block_colidx(i).first);
+          {
+            const ordinal_type tgtbeg = info.sid_block_colidx(s.sid_col_begin).second,
+                               tgtend = info.sid_block_colidx(s.sid_col_end - 1).second, tgtsize = tgtend - tgtbeg;
 
-          const ordinal_type *t_colidx = &info.gid_colidx(s.gid_col_begin + tgtbeg);
-          for (ordinal_type k = 0, l = 0; k < nn; ++k) {
-            s2t[k] = -1;
-            for (; l < tgtsize && t_colidx[l] <= s_colidx[k]; ++l)
-              if (s_colidx[k] == t_colidx[l]) {
-                s2t[k] = l;
-                break;
-              }
-          }
-        }
-
-        {
-          UnmanagedViewType<value_type_matrix> A(s.u_buf, s.m, s.n);
-
-          ordinal_type ijbeg = 0;
-          for (; s2t[ijbeg] == -1; ++ijbeg)
-            ;
-
-          // lock
-          switch (info.front_update_mode) {
-          case 1: {
-            for (ordinal_type jj = max(ijbeg, offn); jj < nn; ++jj) {
-              const ordinal_type js = jj - offn;
-#if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
-#pragma unroll
-#endif
-              for (ordinal_type ii = ijbeg; ii < nn; ++ii) {
-                const ordinal_type row = s2t[ii];
-                if (row < s.m)
-                  Kokkos::atomic_fetch_add(&A(row, s2t[jj]), ABR(ii, js));
-                else
+            const ordinal_type *t_colidx = &info.gid_colidx(s.gid_col_begin + tgtbeg);
+            for (ordinal_type k = 0, l = 0; k < nn; ++k) {
+              s2t[k] = -1;
+              for (; l < tgtsize && t_colidx[l] <= s_colidx[k]; ++l)
+                if (s_colidx[k] == t_colidx[l]) {
+                  s2t[k] = l;
                   break;
-              }
+                }
             }
-            break;
           }
-          case 0: {
-            while (Kokkos::atomic_compare_exchange(&s.lock, 0, 1))
-              TACHO_IMPL_PAUSE;
-            Kokkos::store_fence();
 
-            for (ordinal_type jj = max(ijbeg, offn); jj < nn; ++jj) {
-              const ordinal_type js = jj - offn;
-#if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
-#pragma unroll
-#endif
-              for (ordinal_type ii = ijbeg; ii < nn; ++ii) {
-                const ordinal_type row = s2t[ii];
-                if (row < s.m)
-                  A(row, s2t[jj]) += ABR(ii, js);
-                else
-                  break;
-              }
-            }
-            // unlock
-            s.lock = 0;
-            Kokkos::load_fence();
-            break;
-          }
-          }
-        }
-      }
-#else
-#if 1
-      const ordinal_type *s_colidx = sbeg < send ? &info.gid_colidx(cur.gid_col_begin + srcbeg) : NULL;
-      Kokkos::parallel_for(Kokkos::TeamThreadRange(member, sbeg, send), [&](const ordinal_type &i) {
-        ordinal_type *s2t = (((ordinal_type *)ptr) + (member.team_rank() * nn));
-        const auto &s = info.supernodes(info.sid_block_colidx(i).first);
-        {
-          const ordinal_type tgtbeg = info.sid_block_colidx(s.sid_col_begin).second,
-                             tgtend = info.sid_block_colidx(s.sid_col_end - 1).second, tgtsize = tgtend - tgtbeg;
+          {
+            UnmanagedViewType<value_type_matrix> A(s.u_buf, s.m, s.n);
 
-          const ordinal_type *t_colidx = &info.gid_colidx(s.gid_col_begin + tgtbeg);
-          Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, nn), [&](const ordinal_type &k) {
-            s2t[k] = -1;
-            auto found = lower_bound(&t_colidx[0], &t_colidx[tgtsize - 1], s_colidx[k],
-                                     [](ordinal_type left, ordinal_type right) { return left < right; });
-            if (s_colidx[k] == *found) {
-              s2t[k] = found - t_colidx;
-            }
-          });
-        }
+            ordinal_type ijbeg = 0;
+            for (; s2t[ijbeg] == -1; ++ijbeg)
+              ;
 
-        {
-          UnmanagedViewType<value_type_matrix> A(s.u_buf, s.m, s.n);
-
-          ordinal_type ijbeg = 0;
-          for (; s2t[ijbeg] == -1; ++ijbeg)
-            ;
-
-          Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, nn - ijbeg), [&](const ordinal_type &iii) {
-            const ordinal_type ii = ijbeg + iii;
-            const ordinal_type row = s2t[ii];
-            if (row < s.m)
+            // lock
+            switch (info.front_update_mode) {
+            case 1: {
               for (ordinal_type jj = max(ijbeg, offn); jj < nn; ++jj) {
                 const ordinal_type js = jj - offn;
-                Kokkos::atomic_add(&A(row, s2t[jj]), ABR(ii, js));
+#if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
+#pragma unroll
+#endif
+                for (ordinal_type ii = ijbeg; ii < nn; ++ii) {
+                  const ordinal_type row = s2t[ii];
+                  if (row < s.m)
+                    Kokkos::atomic_fetch_add(&A(row, s2t[jj]), ABR(ii, js));
+                  else
+                    break;
+                }
               }
-          });
-          // for (ordinal_type jj=max(ijbeg,offn);jj<nn;++jj) {
-          //   const ordinal_type js = jj - offn;
-          //   Kokkos::parallel_for
-          //     (Kokkos::ThreadVectorRange(member, nn - ijbeg), [&](const ordinal_type &iii) {
-          //       const ordinal_type ii = iii + ijbeg;
-          //       const ordinal_type row = s2t[ii];
-          //       if (row < s.m) Kokkos::atomic_fetch_add(&A(row, s2t[jj]), ABR(ii, js));
-          //     });
-          // }
-          // const ordinal_type ijtmp = max(ijbeg,offn);
-          // Kokkos::parallel_for
-          //   (Kokkos::ThreadVectorRange(member, nn - ijtmp), [&](const ordinal_type &jjj) {
-          //     const ordinal_type jj = jjj + ijtmp;
-          //     const ordinal_type js = jj - offn;
-          //     for (ordinal_type ii=ijbeg;ii<nn;++ii) {
-          //       const ordinal_type row = s2t[ii];
-          //       if (row < s.m)
-          //         Kokkos::atomic_fetch_add(&A(row, s2t[jj]), ABR(ii, js));
-          //       else
-          //         break;
-          //     }
-          //   });
+              break;
+            }
+            case 0: {
+              while (Kokkos::atomic_compare_exchange(&s.lock, 0, 1))
+                TACHO_IMPL_PAUSE;
+              Kokkos::store_fence();
+
+              for (ordinal_type jj = max(ijbeg, offn); jj < nn; ++jj) {
+                const ordinal_type js = jj - offn;
+#if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
+#pragma unroll
+#endif
+                for (ordinal_type ii = ijbeg; ii < nn; ++ii) {
+                  const ordinal_type row = s2t[ii];
+                  if (row < s.m)
+                    A(row, s2t[jj]) += ABR(ii, js);
+                  else
+                    break;
+                }
+              }
+              // unlock
+              s.lock = 0;
+              Kokkos::load_fence();
+              break;
+            }
+            }
+          }
         }
-      });
+      } else {
+#if 1
+        const ordinal_type *s_colidx = sbeg < send ? &info.gid_colidx(cur.gid_col_begin + srcbeg) : NULL;
+        Kokkos::parallel_for(Kokkos::TeamThreadRange(member, sbeg, send), [&](const ordinal_type &i) {
+          ordinal_type *s2t = (((ordinal_type *)ptr) + (member.team_rank() * nn));
+          const auto &s = info.supernodes(info.sid_block_colidx(i).first);
+          {
+            const ordinal_type tgtbeg = info.sid_block_colidx(s.sid_col_begin).second,
+                               tgtend = info.sid_block_colidx(s.sid_col_end - 1).second, tgtsize = tgtend - tgtbeg;
+
+            const ordinal_type *t_colidx = &info.gid_colidx(s.gid_col_begin + tgtbeg);
+            Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, nn), [&](const ordinal_type &k) {
+              s2t[k] = -1;
+              auto found = lower_bound(&t_colidx[0], &t_colidx[tgtsize - 1], s_colidx[k],
+                                       [](ordinal_type left, ordinal_type right) { return left < right; });
+              if (s_colidx[k] == *found) {
+                s2t[k] = found - t_colidx;
+              }
+            });
+          }
+
+          {
+            UnmanagedViewType<value_type_matrix> A(s.u_buf, s.m, s.n);
+
+            ordinal_type ijbeg = 0;
+            for (; s2t[ijbeg] == -1; ++ijbeg)
+              ;
+
+            Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, nn - ijbeg), [&](const ordinal_type &iii) {
+              const ordinal_type ii = ijbeg + iii;
+              const ordinal_type row = s2t[ii];
+              if (row < s.m)
+                for (ordinal_type jj = max(ijbeg, offn); jj < nn; ++jj) {
+                  const ordinal_type js = jj - offn;
+                  Kokkos::atomic_add(&A(row, s2t[jj]), ABR(ii, js));
+                }
+            });
+            // for (ordinal_type jj=max(ijbeg,offn);jj<nn;++jj) {
+            //   const ordinal_type js = jj - offn;
+            //   Kokkos::parallel_for
+            //     (Kokkos::ThreadVectorRange(member, nn - ijbeg), [&](const ordinal_type &iii) {
+            //       const ordinal_type ii = iii + ijbeg;
+            //       const ordinal_type row = s2t[ii];
+            //       if (row < s.m) Kokkos::atomic_fetch_add(&A(row, s2t[jj]), ABR(ii, js));
+            //     });
+            // }
+            // const ordinal_type ijtmp = max(ijbeg,offn);
+            // Kokkos::parallel_for
+            //   (Kokkos::ThreadVectorRange(member, nn - ijtmp), [&](const ordinal_type &jjj) {
+            //     const ordinal_type jj = jjj + ijtmp;
+            //     const ordinal_type js = jj - offn;
+            //     for (ordinal_type ii=ijbeg;ii<nn;++ii) {
+            //       const ordinal_type row = s2t[ii];
+            //       if (row < s.m)
+            //         Kokkos::atomic_fetch_add(&A(row, s2t[jj]), ABR(ii, js));
+            //       else
+            //         break;
+            //     }
+            //   });
+          }
+        });
 #endif
-#endif
+      }
     }
     return 0;
   }
@@ -359,6 +361,9 @@ template <> struct CholSupernodes<Algo::Workflow::SerialPanel> {
 
     typedef typename supernode_info_type::value_type value_type;
 
+    static constexpr bool runOnHost = !std::is_same_v<typename supernode_info_type::exec_space, Kokkos::DefaultExecutionSpace>
+                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+
     const auto &s = info.supernodes(sid);
 
     if (final) {
@@ -369,11 +374,13 @@ template <> struct CholSupernodes<Algo::Workflow::SerialPanel> {
 
     {
       const ordinal_type n = s.n - s.m;
-#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
-      const size_type bufsize_required = n * (min(np, n) + 1) * sizeof(value_type);
-#else
-      const size_type bufsize_required = n * (min(np, n) + member.team_size()) * sizeof(value_type);
-#endif
+
+      size_type bufsize_required;
+      if constexpr(runOnHost)
+        bufsize_required = n * (min(np, n) + 1) * sizeof(value_type);
+      else
+        bufsize_required = n * (min(np, n) + member.team_size()) * sizeof(value_type);
+
       TACHO_TEST_FOR_ABORT(bufsize < bufsize_required, "bufsize is smaller than required");
 
       CholSupernodes<Algo::Workflow::SerialPanel>::factorize(member, info, sid);

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Chol_External.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Chol_External.hpp
@@ -32,8 +32,7 @@ namespace Tacho {
 template <typename ArgUplo> struct Chol<ArgUplo, Algo::External> {
   template <typename ViewTypeA> inline static int invoke(const ViewTypeA &A) {
 
-    static constexpr bool runOnHost = !std::is_same_v<typename ViewTypeA::execution_space, Kokkos::DefaultExecutionSpace>
-                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+    static constexpr bool runOnHost = run_tacho_on_host_v<typename ViewTypeA::execution_space>;
 
     if constexpr(runOnHost) {
       typedef typename ViewTypeA::non_const_value_type value_type;
@@ -55,8 +54,7 @@ template <typename ArgUplo> struct Chol<ArgUplo, Algo::External> {
   template <typename MemberType, typename ViewTypeA>
   KOKKOS_INLINE_FUNCTION static int invoke(MemberType &member, const ViewTypeA &A) {
 
-    static constexpr bool runOnHost = !std::is_same_v<typename ViewTypeA::execution_space, Kokkos::DefaultExecutionSpace>
-                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+    static constexpr bool runOnHost = run_tacho_on_host_v<typename ViewTypeA::execution_space>;
 
     if constexpr(runOnHost) {
       int r_val = 0;

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Chol_External.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Chol_External.hpp
@@ -31,36 +31,44 @@ namespace Tacho {
 /// ===========
 template <typename ArgUplo> struct Chol<ArgUplo, Algo::External> {
   template <typename ViewTypeA> inline static int invoke(const ViewTypeA &A) {
-#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
-    typedef typename ViewTypeA::non_const_value_type value_type;
-    static_assert(ViewTypeA::rank == 2, "A is not rank 2 view.");
 
-    int r_val = 0;
-    const ordinal_type m = A.extent(0);
-    if (m > 0) {
-      Lapack<value_type>::potrf(ArgUplo::param, m, A.data(), A.stride_1(), &r_val);
-      TACHO_TEST_FOR_EXCEPTION(r_val, std::runtime_error, "LAPACK (potrf) returns non-zero error code.");
+    static constexpr bool runOnHost = !std::is_same_v<typename ViewTypeA::execution_space, Kokkos::DefaultExecutionSpace>
+                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+
+    if constexpr(runOnHost) {
+      typedef typename ViewTypeA::non_const_value_type value_type;
+      static_assert(ViewTypeA::rank == 2, "A is not rank 2 view.");
+
+      int r_val = 0;
+      const ordinal_type m = A.extent(0);
+      if (m > 0) {
+        Lapack<value_type>::potrf(ArgUplo::param, m, A.data(), A.stride_1(), &r_val);
+        TACHO_TEST_FOR_EXCEPTION(r_val, std::runtime_error, "LAPACK (potrf) returns non-zero error code.");
+      }
+      return r_val;
+    } else {
+      TACHO_TEST_FOR_ABORT(true, ">> This function is only allowed in host space.");
+      return -1;
     }
-    return r_val;
-#else
-    TACHO_TEST_FOR_ABORT(true, ">> This function is only allowed in host space.");
-    return -1;
-#endif
   }
 
   template <typename MemberType, typename ViewTypeA>
   KOKKOS_INLINE_FUNCTION static int invoke(MemberType &member, const ViewTypeA &A) {
-#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
-    int r_val = 0;
-    // Kokkos::single(Kokkos::PerTeam(member), [&]() {
-    r_val = invoke(A);
-    TACHO_TEST_FOR_EXCEPTION(r_val, std::runtime_error, "LAPACK (potrf) returns non-zero error code.");
-    //});
-    return r_val;
-#else
-    TACHO_TEST_FOR_ABORT(true, ">> This function is only allowed in host space.");
-    return 0;
-#endif
+
+    static constexpr bool runOnHost = !std::is_same_v<typename ViewTypeA::execution_space, Kokkos::DefaultExecutionSpace>
+                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+
+    if constexpr(runOnHost) {
+      int r_val = 0;
+      // Kokkos::single(Kokkos::PerTeam(member), [&]() {
+      r_val = invoke(A);
+      TACHO_TEST_FOR_EXCEPTION(r_val, std::runtime_error, "LAPACK (potrf) returns non-zero error code.");
+      //});
+      return r_val;
+    } else {
+      TACHO_TEST_FOR_ABORT(true, ">> This function is only allowed in host space.");
+      return 0;
+    }
   }
 };
 } // namespace Tacho

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Gemm.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Gemm.hpp
@@ -35,7 +35,7 @@ namespace Tacho {
 template <typename ArgTransA, typename ArgTransB, typename ArgAlgo> struct Gemm;
 
 struct GemmAlgorithm {
-  using type = ActiveAlgorithm::type;
+  using type = ActiveAlgorithm<runsOnCudaOrHIP()>::type;
 };
 
 } // namespace Tacho

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_GemmTriangular_External.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_GemmTriangular_External.hpp
@@ -32,8 +32,7 @@ template <> struct GemmTriangular<Trans::Transpose, Trans::NoTranspose, Uplo::Up
   inline static int invoke(const ScalarType alpha, const ViewTypeA &A, const ViewTypeB &B, const ScalarType beta,
                            const ViewTypeC &C) {
 
-    static constexpr bool runOnHost = !std::is_same_v<typename ViewTypeA::execution_space, Kokkos::DefaultExecutionSpace>
-                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+    static constexpr bool runOnHost = run_tacho_on_host_v<typename ViewTypeA::execution_space>;
 
     if constexpr(runOnHost) {
       typedef typename ViewTypeA::non_const_value_type value_type;
@@ -74,8 +73,7 @@ template <> struct GemmTriangular<Trans::Transpose, Trans::NoTranspose, Uplo::Up
   KOKKOS_INLINE_FUNCTION static int invoke(MemberType &member, const ScalarType alpha, const ViewTypeA &A,
                                            const ViewTypeB &B, const ScalarType beta, const ViewTypeC &C) {
 
-    static constexpr bool runOnHost = !std::is_same_v<typename ViewTypeA::execution_space, Kokkos::DefaultExecutionSpace>
-                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+    static constexpr bool runOnHost = run_tacho_on_host_v<typename ViewTypeA::execution_space>;
 
     if constexpr(runOnHost) {
       // Kokkos::single(Kokkos::PerTeam(member), [&]() {

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_GemmTriangular_External.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_GemmTriangular_External.hpp
@@ -31,51 +31,59 @@ template <> struct GemmTriangular<Trans::Transpose, Trans::NoTranspose, Uplo::Up
   template <typename ScalarType, typename ViewTypeA, typename ViewTypeB, typename ViewTypeC>
   inline static int invoke(const ScalarType alpha, const ViewTypeA &A, const ViewTypeB &B, const ScalarType beta,
                            const ViewTypeC &C) {
-#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
-    typedef typename ViewTypeA::non_const_value_type value_type;
-    typedef typename ViewTypeB::non_const_value_type value_type_b;
-    typedef typename ViewTypeC::non_const_value_type value_type_c;
 
-    static_assert(ViewTypeA::rank == 2, "A is not rank 2 view.");
-    static_assert(ViewTypeB::rank == 2, "B is not rank 2 view.");
-    static_assert(ViewTypeC::rank == 2, "C is not rank 2 view.");
+    static constexpr bool runOnHost = !std::is_same_v<typename ViewTypeA::execution_space, Kokkos::DefaultExecutionSpace>
+                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
 
-    static_assert(std::is_same<value_type, value_type_b>::value && std::is_same<value_type_b, value_type_c>::value,
-                  "A, B and C do not have the same value type.");
+    if constexpr(runOnHost) {
+      typedef typename ViewTypeA::non_const_value_type value_type;
+      typedef typename ViewTypeB::non_const_value_type value_type_b;
+      typedef typename ViewTypeC::non_const_value_type value_type_c;
 
-    const ordinal_type m = C.extent(0), n = C.extent(1), k = B.extent(0);
+      static_assert(ViewTypeA::rank == 2, "A is not rank 2 view.");
+      static_assert(ViewTypeB::rank == 2, "B is not rank 2 view.");
+      static_assert(ViewTypeC::rank == 2, "C is not rank 2 view.");
 
-    if (m > 0 && n > 0 && k > 0) {
-      if (m == n) {
-        const ordinal_type b = 32;
-        value_type *aptr = A.data(), *bptr = B.data(), *cptr = C.data();
-        const int as1 = A.stride_1(), bs1 = B.stride_1(), cs1 = C.stride_1();
-        for (ordinal_type i = 0; i < m; i += b) {
-          const ordinal_type m2 = i + b, mm = (m2 > m ? m : m2), nn = mm - i;
-          value_type *aaptr = aptr, *bbptr = bptr + i * bs1, *ccptr = cptr + i * cs1;
-          Blas<value_type>::gemm(Trans::Transpose::param, Trans::NoTranspose::param, mm, nn, k, value_type(alpha),
-                                 aaptr, as1, bbptr, bs1, value_type(beta), ccptr, cs1);
+      static_assert(std::is_same<value_type, value_type_b>::value && std::is_same<value_type_b, value_type_c>::value,
+                    "A, B and C do not have the same value type.");
+
+      const ordinal_type m = C.extent(0), n = C.extent(1), k = B.extent(0);
+
+      if (m > 0 && n > 0 && k > 0) {
+        if (m == n) {
+          const ordinal_type b = 32;
+          value_type *aptr = A.data(), *bptr = B.data(), *cptr = C.data();
+          const int as1 = A.stride_1(), bs1 = B.stride_1(), cs1 = C.stride_1();
+          for (ordinal_type i = 0; i < m; i += b) {
+            const ordinal_type m2 = i + b, mm = (m2 > m ? m : m2), nn = mm - i;
+            value_type *aaptr = aptr, *bbptr = bptr + i * bs1, *ccptr = cptr + i * cs1;
+            Blas<value_type>::gemm(Trans::Transpose::param, Trans::NoTranspose::param, mm, nn, k, value_type(alpha),
+                                   aaptr, as1, bbptr, bs1, value_type(beta), ccptr, cs1);
+          }
+        } else {
+          TACHO_TEST_FOR_ABORT(true, "C is not a square matrix");
         }
-      } else {
-        TACHO_TEST_FOR_ABORT(true, "C is not a square matrix");
       }
+    } else {
+      TACHO_TEST_FOR_ABORT(true, ">> This function is only allowed in host space.");
     }
-#else
-    TACHO_TEST_FOR_ABORT(true, ">> This function is only allowed in host space.");
-#endif
     return 0;
   }
 
   template <typename MemberType, typename ScalarType, typename ViewTypeA, typename ViewTypeB, typename ViewTypeC>
   KOKKOS_INLINE_FUNCTION static int invoke(MemberType &member, const ScalarType alpha, const ViewTypeA &A,
                                            const ViewTypeB &B, const ScalarType beta, const ViewTypeC &C) {
-#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
-    // Kokkos::single(Kokkos::PerTeam(member), [&]() {
-    invoke(alpha, A, B, beta, C);
-    //});
-#else
-    TACHO_TEST_FOR_ABORT(true, ">> This function is only allowed in host space.");
-#endif
+
+    static constexpr bool runOnHost = !std::is_same_v<typename ViewTypeA::execution_space, Kokkos::DefaultExecutionSpace>
+                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+
+    if constexpr(runOnHost) {
+      // Kokkos::single(Kokkos::PerTeam(member), [&]() {
+      invoke(alpha, A, B, beta, C);
+      //});
+    } else {
+      TACHO_TEST_FOR_ABORT(true, ">> This function is only allowed in host space.");
+    }
     return 0;
   }
 };

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Gemm_External.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Gemm_External.hpp
@@ -32,8 +32,7 @@ template <typename ArgTransA, typename ArgTransB> struct Gemm<ArgTransA, ArgTran
   inline static int invoke(const ScalarType alpha, const ViewTypeA &A, const ViewTypeB &B, const ScalarType beta,
                            const ViewTypeC &C) {
 
-    static constexpr bool runOnHost = !std::is_same_v<typename ViewTypeA::execution_space, Kokkos::DefaultExecutionSpace>
-                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+    static constexpr bool runOnHost = run_tacho_on_host_v<typename ViewTypeA::execution_space>;
 
     if constexpr(runOnHost) {
       typedef typename ViewTypeA::non_const_value_type value_type;
@@ -64,8 +63,7 @@ template <typename ArgTransA, typename ArgTransB> struct Gemm<ArgTransA, ArgTran
   KOKKOS_INLINE_FUNCTION static int invoke(MemberType &member, const ScalarType alpha, const ViewTypeA &A,
                                            const ViewTypeB &B, const ScalarType beta, const ViewTypeC &C) {
 
-    static constexpr bool runOnHost = !std::is_same_v<typename ViewTypeA::execution_space, Kokkos::DefaultExecutionSpace>
-                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+    static constexpr bool runOnHost = run_tacho_on_host_v<typename ViewTypeA::execution_space>;
 
     if constexpr(runOnHost) {
       // Kokkos::single(Kokkos::PerTeam(member), [&]() {

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Gemm_External.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Gemm_External.hpp
@@ -31,41 +31,49 @@ template <typename ArgTransA, typename ArgTransB> struct Gemm<ArgTransA, ArgTran
   template <typename ScalarType, typename ViewTypeA, typename ViewTypeB, typename ViewTypeC>
   inline static int invoke(const ScalarType alpha, const ViewTypeA &A, const ViewTypeB &B, const ScalarType beta,
                            const ViewTypeC &C) {
-#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
-    typedef typename ViewTypeA::non_const_value_type value_type;
-    typedef typename ViewTypeB::non_const_value_type value_type_b;
-    typedef typename ViewTypeC::non_const_value_type value_type_c;
 
-    static_assert(ViewTypeA::rank == 2, "A is not rank 2 view.");
-    static_assert(ViewTypeB::rank == 2, "B is not rank 2 view.");
-    static_assert(ViewTypeC::rank == 2, "C is not rank 2 view.");
+    static constexpr bool runOnHost = !std::is_same_v<typename ViewTypeA::execution_space, Kokkos::DefaultExecutionSpace>
+                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
 
-    static_assert(std::is_same<value_type, value_type_b>::value && std::is_same<value_type_b, value_type_c>::value,
-                  "A, B and C do not have the same value type.");
+    if constexpr(runOnHost) {
+      typedef typename ViewTypeA::non_const_value_type value_type;
+      typedef typename ViewTypeB::non_const_value_type value_type_b;
+      typedef typename ViewTypeC::non_const_value_type value_type_c;
 
-    const ordinal_type m = C.extent(0), n = C.extent(1),
-                       k = (std::is_same<ArgTransB, Trans::NoTranspose>::value ? B.extent(0) : B.extent(1));
+      static_assert(ViewTypeA::rank == 2, "A is not rank 2 view.");
+      static_assert(ViewTypeB::rank == 2, "B is not rank 2 view.");
+      static_assert(ViewTypeC::rank == 2, "C is not rank 2 view.");
 
-    if (m > 0 && n > 0 && k > 0) {
-      Blas<value_type>::gemm(ArgTransA::param, ArgTransB::param, m, n, k, value_type(alpha), A.data(), A.stride_1(),
-                             B.data(), B.stride_1(), value_type(beta), C.data(), C.stride_1());
+      static_assert(std::is_same<value_type, value_type_b>::value && std::is_same<value_type_b, value_type_c>::value,
+                    "A, B and C do not have the same value type.");
+
+      const ordinal_type m = C.extent(0), n = C.extent(1),
+                         k = (std::is_same<ArgTransB, Trans::NoTranspose>::value ? B.extent(0) : B.extent(1));
+
+      if (m > 0 && n > 0 && k > 0) {
+        Blas<value_type>::gemm(ArgTransA::param, ArgTransB::param, m, n, k, value_type(alpha), A.data(), A.stride_1(),
+                               B.data(), B.stride_1(), value_type(beta), C.data(), C.stride_1());
+      }
+    } else {
+      TACHO_TEST_FOR_ABORT(true, ">> This function is only allowed in host space.");
     }
-#else
-    TACHO_TEST_FOR_ABORT(true, ">> This function is only allowed in host space.");
-#endif
     return 0;
   }
 
   template <typename MemberType, typename ScalarType, typename ViewTypeA, typename ViewTypeB, typename ViewTypeC>
   KOKKOS_INLINE_FUNCTION static int invoke(MemberType &member, const ScalarType alpha, const ViewTypeA &A,
                                            const ViewTypeB &B, const ScalarType beta, const ViewTypeC &C) {
-#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
-    // Kokkos::single(Kokkos::PerTeam(member), [&]() {
-    invoke(alpha, A, B, beta, C);
-    //});
-#else
-    TACHO_TEST_FOR_ABORT(true, ">> This function is only allowed in host space.");
-#endif
+
+    static constexpr bool runOnHost = !std::is_same_v<typename ViewTypeA::execution_space, Kokkos::DefaultExecutionSpace>
+                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+
+    if constexpr(runOnHost) {
+      // Kokkos::single(Kokkos::PerTeam(member), [&]() {
+      invoke(alpha, A, B, beta, C);
+      //});
+    } else {
+      TACHO_TEST_FOR_ABORT(true, ">> This function is only allowed in host space.");
+    }
     return 0;
   }
 };

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Gemv.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Gemv.hpp
@@ -35,7 +35,7 @@ namespace Tacho {
 template <typename ArgTrans, typename ArgAlgo> struct Gemv;
 
 struct GemvAlgorithm {
-  using type = ActiveAlgorithm::type;
+  using type = ActiveAlgorithm<runsOnCudaOrHIP()>::type;
 };
 
 } // namespace Tacho

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Gemv_External.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Gemv_External.hpp
@@ -32,8 +32,7 @@ template <typename ArgTrans> struct Gemv<ArgTrans, Algo::External> {
   inline static int invoke(const ScalarType alpha, const ViewTypeA &A, const ViewTypeB &B, const ScalarType beta,
                            const ViewTypeC &C) {
 
-    static constexpr bool runOnHost = !std::is_same_v<typename ViewTypeA::execution_space, Kokkos::DefaultExecutionSpace>
-                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+    static constexpr bool runOnHost = run_tacho_on_host_v<typename ViewTypeA::execution_space>;
 
     if constexpr(runOnHost) {
       typedef typename ViewTypeA::non_const_value_type value_type;
@@ -70,8 +69,7 @@ template <typename ArgTrans> struct Gemv<ArgTrans, Algo::External> {
   KOKKOS_INLINE_FUNCTION static int invoke(MemberType &member, const ScalarType alpha, const ViewTypeA &A,
                                            const ViewTypeB &B, const ScalarType beta, const ViewTypeC &C) {
 
-    static constexpr bool runOnHost = !std::is_same_v<typename ViewTypeA::execution_space, Kokkos::DefaultExecutionSpace>
-                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+    static constexpr bool runOnHost = run_tacho_on_host_v<typename ViewTypeA::execution_space>;
 
     if constexpr(runOnHost) {
       // Kokkos::single(Kokkos::PerTeam(member), [&]() {

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Gemv_External.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Gemv_External.hpp
@@ -31,47 +31,55 @@ template <typename ArgTrans> struct Gemv<ArgTrans, Algo::External> {
   template <typename ScalarType, typename ViewTypeA, typename ViewTypeB, typename ViewTypeC>
   inline static int invoke(const ScalarType alpha, const ViewTypeA &A, const ViewTypeB &B, const ScalarType beta,
                            const ViewTypeC &C) {
-#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
-    typedef typename ViewTypeA::non_const_value_type value_type;
-    typedef typename ViewTypeB::non_const_value_type value_type_b;
-    typedef typename ViewTypeC::non_const_value_type value_type_c;
 
-    static_assert(ViewTypeA::rank == 2, "A is not rank 2 view.");
-    static_assert(ViewTypeB::rank == 2, "B is not rank 2 view.");
-    static_assert(ViewTypeC::rank == 2, "C is not rank 2 view.");
+    static constexpr bool runOnHost = !std::is_same_v<typename ViewTypeA::execution_space, Kokkos::DefaultExecutionSpace>
+                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
 
-    static_assert(std::is_same<value_type, value_type_b>::value && std::is_same<value_type_b, value_type_c>::value,
-                  "A, B and C do not have the same value type.");
+    if constexpr(runOnHost) {
+      typedef typename ViewTypeA::non_const_value_type value_type;
+      typedef typename ViewTypeB::non_const_value_type value_type_b;
+      typedef typename ViewTypeC::non_const_value_type value_type_c;
 
-    const ordinal_type m = C.extent(0), n = C.extent(1);
+      static_assert(ViewTypeA::rank == 2, "A is not rank 2 view.");
+      static_assert(ViewTypeB::rank == 2, "B is not rank 2 view.");
+      static_assert(ViewTypeC::rank == 2, "C is not rank 2 view.");
 
-    if (m > 0 && n > 0) {
-      if (n == 1) {
-        const int mm = A.extent(0), nn = A.extent(1);
-        Blas<value_type>::gemv(ArgTrans::param, mm, nn, value_type(alpha), A.data(), A.stride_1(), B.data(),
-                               B.stride_0(), value_type(beta), C.data(), C.stride_0());
-      } else {
-        const int mm = C.extent(0), nn = C.extent(1), kk = B.extent(0);
-        Blas<value_type>::gemm(ArgTrans::param, Trans::NoTranspose::param, mm, nn, kk, value_type(alpha), A.data(),
-                               A.stride_1(), B.data(), B.stride_1(), value_type(beta), C.data(), C.stride_1());
+      static_assert(std::is_same<value_type, value_type_b>::value && std::is_same<value_type_b, value_type_c>::value,
+                    "A, B and C do not have the same value type.");
+
+      const ordinal_type m = C.extent(0), n = C.extent(1);
+
+      if (m > 0 && n > 0) {
+        if (n == 1) {
+          const int mm = A.extent(0), nn = A.extent(1);
+          Blas<value_type>::gemv(ArgTrans::param, mm, nn, value_type(alpha), A.data(), A.stride_1(), B.data(),
+                                 B.stride_0(), value_type(beta), C.data(), C.stride_0());
+        } else {
+          const int mm = C.extent(0), nn = C.extent(1), kk = B.extent(0);
+          Blas<value_type>::gemm(ArgTrans::param, Trans::NoTranspose::param, mm, nn, kk, value_type(alpha), A.data(),
+                                 A.stride_1(), B.data(), B.stride_1(), value_type(beta), C.data(), C.stride_1());
+        }
       }
+    } else {
+      TACHO_TEST_FOR_ABORT(true, ">> This function is only allowed in host space.");
     }
-#else
-    TACHO_TEST_FOR_ABORT(true, ">> This function is only allowed in host space.");
-#endif
     return 0;
   }
 
   template <typename MemberType, typename ScalarType, typename ViewTypeA, typename ViewTypeB, typename ViewTypeC>
   KOKKOS_INLINE_FUNCTION static int invoke(MemberType &member, const ScalarType alpha, const ViewTypeA &A,
                                            const ViewTypeB &B, const ScalarType beta, const ViewTypeC &C) {
-#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
-    // Kokkos::single(Kokkos::PerTeam(member), [&]() {
-    invoke(alpha, A, B, beta, C);
-    //});
-#else
-    TACHO_TEST_FOR_ABORT(true, ">> This function is only allowed in host space.");
-#endif
+
+    static constexpr bool runOnHost = !std::is_same_v<typename ViewTypeA::execution_space, Kokkos::DefaultExecutionSpace>
+                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+
+    if constexpr(runOnHost) {
+      // Kokkos::single(Kokkos::PerTeam(member), [&]() {
+      invoke(alpha, A, B, beta, C);
+      //});
+    } else {
+      TACHO_TEST_FOR_ABORT(true, ">> This function is only allowed in host space.");
+    }
     return 0;
   }
 };

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Herk.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Herk.hpp
@@ -35,7 +35,7 @@ namespace Tacho {
 template <typename ArgUplo, typename ArgTrans, typename ArgAlgo> struct Herk;
 
 struct HerkAlgorithm {
-  using type = ActiveAlgorithm::type;
+  using type = ActiveAlgorithm<runsOnCudaOrHIP()>::type;
 };
 
 } // namespace Tacho

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Herk_External.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Herk_External.hpp
@@ -30,37 +30,45 @@ namespace Tacho {
 template <typename ArgUplo, typename ArgTrans> struct Herk<ArgUplo, ArgTrans, Algo::External> {
   template <typename ScalarType, typename ViewTypeA, typename ViewTypeC>
   inline static int invoke(const ScalarType alpha, const ViewTypeA &A, const ScalarType beta, const ViewTypeC &C) {
-#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
-    typedef typename ViewTypeA::non_const_value_type value_type;
-    typedef typename ViewTypeC::non_const_value_type value_type_c;
 
-    static_assert(ViewTypeA::rank == 2, "A is not rank 2 view.");
-    static_assert(ViewTypeC::rank == 2, "B is not rank 2 view.");
+    static constexpr bool runOnHost = !std::is_same_v<typename ViewTypeA::execution_space, Kokkos::DefaultExecutionSpace>
+                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
 
-    static_assert(std::is_same<value_type, value_type_c>::value, "A and C do not have the same value type.");
+    if constexpr(runOnHost) {
+      typedef typename ViewTypeA::non_const_value_type value_type;
+      typedef typename ViewTypeC::non_const_value_type value_type_c;
 
-    const ordinal_type n = C.extent(0),
-                       k = (std::is_same<ArgTrans, Trans::NoTranspose>::value ? A.extent(1) : A.extent(0));
-    if (n > 0 && k > 0) {
-      Blas<value_type>::herk(ArgUplo::param, ArgTrans::param, n, k, value_type(alpha), A.data(), A.stride_1(),
-                             value_type(beta), C.data(), C.stride_1());
+      static_assert(ViewTypeA::rank == 2, "A is not rank 2 view.");
+      static_assert(ViewTypeC::rank == 2, "B is not rank 2 view.");
+
+      static_assert(std::is_same<value_type, value_type_c>::value, "A and C do not have the same value type.");
+
+      const ordinal_type n = C.extent(0),
+                         k = (std::is_same<ArgTrans, Trans::NoTranspose>::value ? A.extent(1) : A.extent(0));
+      if (n > 0 && k > 0) {
+        Blas<value_type>::herk(ArgUplo::param, ArgTrans::param, n, k, value_type(alpha), A.data(), A.stride_1(),
+                               value_type(beta), C.data(), C.stride_1());
+      }
+    } else {
+      TACHO_TEST_FOR_ABORT(true, ">> This function is only allowed in host space.");
     }
-#else
-    TACHO_TEST_FOR_ABORT(true, ">> This function is only allowed in host space.");
-#endif
     return 0;
   }
 
   template <typename MemberType, typename ScalarType, typename ViewTypeA, typename ViewTypeC>
   KOKKOS_INLINE_FUNCTION static int invoke(MemberType &member, const ScalarType alpha, const ViewTypeA &A,
                                            const ScalarType beta, const ViewTypeC &C) {
-#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
-    // Kokkos::single(Kokkos::PerTeam(member), [&]() {
-    invoke(alpha, A, beta, C);
-    //});
-#else
-    TACHO_TEST_FOR_ABORT(true, ">> This function is only allowed in host space.");
-#endif
+
+    static constexpr bool runOnHost = !std::is_same_v<typename ViewTypeA::execution_space, Kokkos::DefaultExecutionSpace>
+                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+
+    if constexpr(runOnHost) {
+      // Kokkos::single(Kokkos::PerTeam(member), [&]() {
+      invoke(alpha, A, beta, C);
+      //});
+    } else {
+      TACHO_TEST_FOR_ABORT(true, ">> This function is only allowed in host space.");
+    }
     return 0;
   }
 };

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Herk_External.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Herk_External.hpp
@@ -31,8 +31,7 @@ template <typename ArgUplo, typename ArgTrans> struct Herk<ArgUplo, ArgTrans, Al
   template <typename ScalarType, typename ViewTypeA, typename ViewTypeC>
   inline static int invoke(const ScalarType alpha, const ViewTypeA &A, const ScalarType beta, const ViewTypeC &C) {
 
-    static constexpr bool runOnHost = !std::is_same_v<typename ViewTypeA::execution_space, Kokkos::DefaultExecutionSpace>
-                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+    static constexpr bool runOnHost = run_tacho_on_host_v<typename ViewTypeA::execution_space>;
 
     if constexpr(runOnHost) {
       typedef typename ViewTypeA::non_const_value_type value_type;
@@ -59,8 +58,7 @@ template <typename ArgUplo, typename ArgTrans> struct Herk<ArgUplo, ArgTrans, Al
   KOKKOS_INLINE_FUNCTION static int invoke(MemberType &member, const ScalarType alpha, const ViewTypeA &A,
                                            const ScalarType beta, const ViewTypeC &C) {
 
-    static constexpr bool runOnHost = !std::is_same_v<typename ViewTypeA::execution_space, Kokkos::DefaultExecutionSpace>
-                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+    static constexpr bool runOnHost = run_tacho_on_host_v<typename ViewTypeA::execution_space>;
 
     if constexpr(runOnHost) {
       // Kokkos::single(Kokkos::PerTeam(member), [&]() {

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_LDL.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_LDL.hpp
@@ -36,7 +36,7 @@ namespace Tacho {
 template <typename ArgUplo, typename ArgAlgo> struct LDL;
 
 struct LDL_Algorithm {
-  using type = ActiveAlgorithm::type;
+  using type = ActiveAlgorithm<runsOnCudaOrHIP()>::type;
 };
 
 } // namespace Tacho

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_LDL_External.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_LDL_External.hpp
@@ -34,8 +34,7 @@ template <> struct LDL<Uplo::Lower, Algo::External> {
   inline static int invoke(const ViewTypeA &A, const ViewTypeP &P, const ViewTypeW &W) {
     int r_val = 0;
 
-    static constexpr bool runOnHost = !std::is_same_v<typename ViewTypeA::execution_space, Kokkos::DefaultExecutionSpace>
-                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+    static constexpr bool runOnHost = run_tacho_on_host_v<typename ViewTypeA::execution_space>;
 
     if constexpr(runOnHost) {
       typedef typename ViewTypeA::non_const_value_type value_type;
@@ -62,8 +61,7 @@ template <> struct LDL<Uplo::Lower, Algo::External> {
   KOKKOS_INLINE_FUNCTION static int invoke(MemberType &member, const ViewTypeA &A, const ViewTypeP &P,
                                            const ViewTypeW &W) {
 
-    static constexpr bool runOnHost = !std::is_same_v<typename ViewTypeA::execution_space, Kokkos::DefaultExecutionSpace>
-                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+    static constexpr bool runOnHost = run_tacho_on_host_v<typename ViewTypeA::execution_space>;
 
     if constexpr(runOnHost) {
       int r_val = 0;
@@ -78,8 +76,7 @@ template <> struct LDL<Uplo::Lower, Algo::External> {
   inline static int modify(const ViewTypeA &A, const ViewTypeP &P, const ViewTypeD &D) {
     int r_val = 0;
 
-    static constexpr bool runOnHost = !std::is_same_v<typename ViewTypeA::execution_space, Kokkos::DefaultExecutionSpace>
-                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+    static constexpr bool runOnHost = run_tacho_on_host_v<typename ViewTypeA::execution_space>;
 
     if constexpr(runOnHost) {
       typedef typename ViewTypeA::non_const_value_type value_type;
@@ -166,8 +163,7 @@ template <> struct LDL<Uplo::Lower, Algo::External> {
   KOKKOS_INLINE_FUNCTION static int modify(MemberType &member, const ViewTypeA &A, const ViewTypeP &P,
                                            const ViewTypeD &D) {
 
-    static constexpr bool runOnHost = !std::is_same_v<typename ViewTypeA::execution_space, Kokkos::DefaultExecutionSpace>
-                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+    static constexpr bool runOnHost = run_tacho_on_host_v<typename ViewTypeA::execution_space>;
 
     if constexpr(runOnHost) {
       int r_val = 0;

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_LDL_External.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_LDL_External.hpp
@@ -33,133 +33,149 @@ template <> struct LDL<Uplo::Lower, Algo::External> {
   template <typename ViewTypeA, typename ViewTypeP, typename ViewTypeW>
   inline static int invoke(const ViewTypeA &A, const ViewTypeP &P, const ViewTypeW &W) {
     int r_val = 0;
-#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
-    typedef typename ViewTypeA::non_const_value_type value_type;
 
-    static_assert(ViewTypeA::rank == 2, "A is not rank 2 view.");
-    static_assert(ViewTypeP::rank == 1, "P is not rank 1 view.");
-    static_assert(ViewTypeW::rank == 1, "W is not rank 1 view.");
+    static constexpr bool runOnHost = !std::is_same_v<typename ViewTypeA::execution_space, Kokkos::DefaultExecutionSpace>
+                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
 
-    TACHO_TEST_FOR_EXCEPTION(P.extent(0) < 4 * A.extent(0), std::runtime_error, "P should be 4*A.extent(0) .");
+    if constexpr(runOnHost) {
+      typedef typename ViewTypeA::non_const_value_type value_type;
 
-    const ordinal_type m = A.extent(0);
-    if (m > 0) {
-      /// factorize LDL
-      Lapack<value_type>::sytrf('L', m, A.data(), A.stride_1(), P.data(), W.data(), W.extent(0), &r_val);
-      TACHO_TEST_FOR_EXCEPTION(r_val, std::runtime_error, "LAPACK (sytrf) returns non-zero error code.");
+      static_assert(ViewTypeA::rank == 2, "A is not rank 2 view.");
+      static_assert(ViewTypeP::rank == 1, "P is not rank 1 view.");
+      static_assert(ViewTypeW::rank == 1, "W is not rank 1 view.");
+
+      TACHO_TEST_FOR_EXCEPTION(P.extent(0) < 4 * A.extent(0), std::runtime_error, "P should be 4*A.extent(0) .");
+
+      const ordinal_type m = A.extent(0);
+      if (m > 0) {
+        /// factorize LDL
+        Lapack<value_type>::sytrf('L', m, A.data(), A.stride_1(), P.data(), W.data(), W.extent(0), &r_val);
+        TACHO_TEST_FOR_EXCEPTION(r_val, std::runtime_error, "LAPACK (sytrf) returns non-zero error code.");
+      }
+    } else {
+      TACHO_TEST_FOR_ABORT(true, ">> This function is only allowed in host space.");
     }
-#else
-    TACHO_TEST_FOR_ABORT(true, ">> This function is only allowed in host space.");
-#endif
     return r_val;
   }
 
   template <typename MemberType, typename ViewTypeA, typename ViewTypeP, typename ViewTypeW>
   KOKKOS_INLINE_FUNCTION static int invoke(MemberType &member, const ViewTypeA &A, const ViewTypeP &P,
                                            const ViewTypeW &W) {
-#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
-    int r_val = 0;
-    r_val = invoke(A, P, W);
-    return r_val;
-#else
-    TACHO_TEST_FOR_ABORT(true, ">> This function is only allowed in host space.");
-#endif
+
+    static constexpr bool runOnHost = !std::is_same_v<typename ViewTypeA::execution_space, Kokkos::DefaultExecutionSpace>
+                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+
+    if constexpr(runOnHost) {
+      int r_val = 0;
+      r_val = invoke(A, P, W);
+      return r_val;
+    } else {
+      TACHO_TEST_FOR_ABORT(true, ">> This function is only allowed in host space.");
+    }
   }
 
   template <typename ViewTypeA, typename ViewTypeP, typename ViewTypeD>
   inline static int modify(const ViewTypeA &A, const ViewTypeP &P, const ViewTypeD &D) {
     int r_val = 0;
-#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
-    typedef typename ViewTypeA::non_const_value_type value_type;
 
-    static_assert(ViewTypeA::rank == 2, "A is not rank 2 view.");
-    static_assert(ViewTypeP::rank == 1, "P is not rank 1 view.");
-    static_assert(ViewTypeD::rank == 2, "D is not rank 2 view.");
+    static constexpr bool runOnHost = !std::is_same_v<typename ViewTypeA::execution_space, Kokkos::DefaultExecutionSpace>
+                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
 
-    TACHO_TEST_FOR_EXCEPTION(D.extent(0) < A.extent(0), std::runtime_error, "D extent(0) is smaller than A extent(0).");
-    TACHO_TEST_FOR_EXCEPTION(D.extent(1) != 2, std::runtime_error, "D is supposed to store 2x2 blocks .");
-    TACHO_TEST_FOR_EXCEPTION(P.extent(0) < 4 * A.extent(0), std::runtime_error, "P should be 4*A.extent(0) .");
+    if constexpr(runOnHost) {
+      typedef typename ViewTypeA::non_const_value_type value_type;
 
-    const ordinal_type m = A.extent(0);
-    if (m > 0) {
-      value_type *__restrict__ Aptr = A.data();
-      ordinal_type *__restrict__ ipiv = P.data(), *__restrict__ fpiv = ipiv + m, *__restrict__ perm = fpiv + m,
-                                 *__restrict__ peri = perm + m;
+      static_assert(ViewTypeA::rank == 2, "A is not rank 2 view.");
+      static_assert(ViewTypeP::rank == 1, "P is not rank 1 view.");
+      static_assert(ViewTypeD::rank == 2, "D is not rank 2 view.");
 
-      const value_type one(1), zero(0);
-      for (ordinal_type i = 0; i < m; ++i)
-        perm[i] = i;
-      for (ordinal_type i = 0; i < m; ++i) {
-        if (ipiv[i] < 0) {
-          {
-            // first pivot
-            ipiv[i] = 0; /// invalidate this pivot
-            fpiv[i] = 0;
+      TACHO_TEST_FOR_EXCEPTION(D.extent(0) < A.extent(0), std::runtime_error, "D extent(0) is smaller than A extent(0).");
+      TACHO_TEST_FOR_EXCEPTION(D.extent(1) != 2, std::runtime_error, "D is supposed to store 2x2 blocks .");
+      TACHO_TEST_FOR_EXCEPTION(P.extent(0) < 4 * A.extent(0), std::runtime_error, "P should be 4*A.extent(0) .");
 
-            D(i, 0) = A(i, i);
-            D(i, 1) = A(i + 1, i); /// symmetric
-            A(i, i) = one;
-          }
-          {
-            // second pivot
-            i++;
-            const ordinal_type fla_pivot = -ipiv[i] - i - 1;
+      const ordinal_type m = A.extent(0);
+      if (m > 0) {
+        value_type *__restrict__ Aptr = A.data();
+        ordinal_type *__restrict__ ipiv = P.data(), *__restrict__ fpiv = ipiv + m, *__restrict__ perm = fpiv + m,
+                                   *__restrict__ peri = perm + m;
+
+        const value_type one(1), zero(0);
+        for (ordinal_type i = 0; i < m; ++i)
+          perm[i] = i;
+        for (ordinal_type i = 0; i < m; ++i) {
+          if (ipiv[i] < 0) {
+            {
+              // first pivot
+              ipiv[i] = 0; /// invalidate this pivot
+              fpiv[i] = 0;
+
+              D(i, 0) = A(i, i);
+              D(i, 1) = A(i + 1, i); /// symmetric
+              A(i, i) = one;
+            }
+            {
+              // second pivot
+              i++;
+              const ordinal_type fla_pivot = -ipiv[i] - i - 1;
+              fpiv[i] = fla_pivot;
+              if (fla_pivot) {
+                value_type *__restrict__ src = Aptr + i;
+                value_type *__restrict__ tgt = src + fla_pivot;
+                for (ordinal_type j = 0; j < (i - 1); ++j) {
+                  const ordinal_type idx = j * m;
+                  swap(src[idx], tgt[idx]);
+                }
+              }
+
+              D(i, 0) = A(i, i - 1);
+              D(i, 1) = A(i, i);
+              A(i, i - 1) = zero;
+              A(i, i) = one;
+            }
+          } else {
+            const ordinal_type fla_pivot = ipiv[i] - i - 1;
             fpiv[i] = fla_pivot;
             if (fla_pivot) {
-              value_type *__restrict__ src = Aptr + i;
-              value_type *__restrict__ tgt = src + fla_pivot;
-              for (ordinal_type j = 0; j < (i - 1); ++j) {
+              value_type *src = Aptr + i;
+              value_type *tgt = src + fla_pivot;
+              for (ordinal_type j = 0; j < i; ++j) {
                 const ordinal_type idx = j * m;
                 swap(src[idx], tgt[idx]);
               }
             }
 
-            D(i, 0) = A(i, i - 1);
-            D(i, 1) = A(i, i);
-            A(i, i - 1) = zero;
+            D(i, 0) = A(i, i);
             A(i, i) = one;
           }
-        } else {
-          const ordinal_type fla_pivot = ipiv[i] - i - 1;
-          fpiv[i] = fla_pivot;
-          if (fla_pivot) {
-            value_type *src = Aptr + i;
-            value_type *tgt = src + fla_pivot;
-            for (ordinal_type j = 0; j < i; ++j) {
-              const ordinal_type idx = j * m;
-              swap(src[idx], tgt[idx]);
-            }
+
+          /// apply pivots to perm vector
+          if (fpiv[i]) {
+            const ordinal_type pidx = i + fpiv[i];
+            swap(perm[i], perm[pidx]);
           }
-
-          D(i, 0) = A(i, i);
-          A(i, i) = one;
         }
-
-        /// apply pivots to perm vector
-        if (fpiv[i]) {
-          const ordinal_type pidx = i + fpiv[i];
-          swap(perm[i], perm[pidx]);
-        }
+        for (ordinal_type i = 0; i < m; ++i)
+          peri[perm[i]] = i;
       }
-      for (ordinal_type i = 0; i < m; ++i)
-        peri[perm[i]] = i;
+    } else {
+      TACHO_TEST_FOR_ABORT(true, ">> This function is only allowed in host space.");
     }
-#else
-    TACHO_TEST_FOR_ABORT(true, ">> This function is only allowed in host space.");
-#endif
     return r_val;
   }
 
   template <typename MemberType, typename ViewTypeA, typename ViewTypeP, typename ViewTypeD>
   KOKKOS_INLINE_FUNCTION static int modify(MemberType &member, const ViewTypeA &A, const ViewTypeP &P,
                                            const ViewTypeD &D) {
-#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
-    int r_val = 0;
-    r_val = modify(A, P, D);
-    return r_val;
-#else
-    TACHO_TEST_FOR_ABORT(true, ">> This function is only allowed in host space.");
-#endif
+
+    static constexpr bool runOnHost = !std::is_same_v<typename ViewTypeA::execution_space, Kokkos::DefaultExecutionSpace>
+                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+
+    if constexpr(runOnHost) {
+      int r_val = 0;
+      r_val = modify(A, P, D);
+      return r_val;
+    } else {
+      TACHO_TEST_FOR_ABORT(true, ">> This function is only allowed in host space.");
+    }
   }
 };
 

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_LU.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_LU.hpp
@@ -36,7 +36,7 @@ namespace Tacho {
 template <typename ArgAlgo> struct LU;
 
 struct LU_Algorithm {
-  using type = ActiveAlgorithm::type;
+  using type = ActiveAlgorithm<runsOnCudaOrHIP()>::type;
 };
 
 } // namespace Tacho

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_LU_External.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_LU_External.hpp
@@ -32,80 +32,97 @@ namespace Tacho {
 template <> struct LU<Algo::External> {
   template <typename ViewTypeA, typename ViewTypeP> inline static int invoke(const ViewTypeA &A, const ViewTypeP &P) {
     int r_val = 0;
-#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
-    typedef typename ViewTypeA::non_const_value_type value_type;
 
-    static_assert(ViewTypeA::rank == 2, "A is not rank 2 view.");
-    static_assert(ViewTypeP::rank == 1, "P is not rank 1 view.");
+    static constexpr bool runOnHost = !std::is_same_v<typename ViewTypeA::execution_space, Kokkos::DefaultExecutionSpace>
+                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
 
-    TACHO_TEST_FOR_EXCEPTION(P.extent(0) < 4 * A.extent(0), std::runtime_error, "P should be 4*A.extent(0) .");
+    if constexpr(runOnHost) {
+      typedef typename ViewTypeA::non_const_value_type value_type;
 
-    const ordinal_type m = A.extent(0), n = A.extent(1);
-    if (m > 0 && n > 0) {
-      /// factorize LU
-      Lapack<value_type>::getrf(m, n, A.data(), A.stride_1(), P.data(), &r_val);
-      TACHO_TEST_FOR_EXCEPTION(r_val, std::runtime_error, "LAPACK (getrf) returns non-zero error code.");
+      static_assert(ViewTypeA::rank == 2, "A is not rank 2 view.");
+      static_assert(ViewTypeP::rank == 1, "P is not rank 1 view.");
+
+      TACHO_TEST_FOR_EXCEPTION(P.extent(0) < 4 * A.extent(0), std::runtime_error, "P should be 4*A.extent(0) .");
+
+      const ordinal_type m = A.extent(0), n = A.extent(1);
+      if (m > 0 && n > 0) {
+        /// factorize LU
+        Lapack<value_type>::getrf(m, n, A.data(), A.stride_1(), P.data(), &r_val);
+        TACHO_TEST_FOR_EXCEPTION(r_val, std::runtime_error, "LAPACK (getrf) returns non-zero error code.");
+      }
+    } else {
+      TACHO_TEST_FOR_ABORT(true, ">> This function is only allowed in host space.");
     }
-#else
-    TACHO_TEST_FOR_ABORT(true, ">> This function is only allowed in host space.");
-#endif
     return r_val;
   }
 
   template <typename MemberType, typename ViewTypeA, typename ViewTypeP>
   KOKKOS_INLINE_FUNCTION static int invoke(MemberType &member, const ViewTypeA &A, const ViewTypeP &P) {
-#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
-    int r_val = 0;
-    r_val = invoke(A, P);
-    return r_val;
-#else
-    TACHO_TEST_FOR_ABORT(true, ">> This function is only allowed in host space.");
-#endif
+
+    static constexpr bool runOnHost = !std::is_same_v<typename ViewTypeA::execution_space, Kokkos::DefaultExecutionSpace>
+                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+
+    if constexpr(runOnHost) {
+      int r_val = 0;
+      r_val = invoke(A, P);
+      return r_val;
+    } else {
+      TACHO_TEST_FOR_ABORT(true, ">> This function is only allowed in host space.");
+    }
   }
 
   template <typename ViewTypeP> inline static int modify(const ordinal_type m, const ViewTypeP &P) {
+
+    static constexpr bool runOnHost = !std::is_same_v<typename ViewTypeP::execution_space, Kokkos::DefaultExecutionSpace>
+                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+
     int r_val = 0;
-#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
-    static_assert(ViewTypeP::rank == 1, "P is not rank 1 view.");
 
-    TACHO_TEST_FOR_EXCEPTION(int(P.extent(0)) < 4 * m, std::runtime_error, "P should be 4*m.");
+    if constexpr(runOnHost) {
+      static_assert(ViewTypeP::rank == 1, "P is not rank 1 view.");
 
-    if (m > 0) {
-      ordinal_type *__restrict__ ipiv = P.data();
-      ordinal_type *__restrict__ fpiv = ipiv + m;
-      ordinal_type *__restrict__ perm = fpiv + m;
-      ordinal_type *__restrict__ peri = perm + m;
+      TACHO_TEST_FOR_EXCEPTION(int(P.extent(0)) < 4 * m, std::runtime_error, "P should be 4*m.");
 
-      for (ordinal_type i = 0; i < m; ++i)
-        perm[i] = i;
-      for (ordinal_type i = 0; i < m; ++i) {
-        const ordinal_type fla_pivot = ipiv[i] - i - 1;
-        fpiv[i] = fla_pivot;
+      if (m > 0) {
+        ordinal_type *__restrict__ ipiv = P.data();
+        ordinal_type *__restrict__ fpiv = ipiv + m;
+        ordinal_type *__restrict__ perm = fpiv + m;
+        ordinal_type *__restrict__ peri = perm + m;
 
-        /// apply pivots to perm vector
-        if (fpiv[i]) {
-          const ordinal_type pidx = i + fpiv[i];
-          swap(perm[i], perm[pidx]);
+        for (ordinal_type i = 0; i < m; ++i)
+          perm[i] = i;
+        for (ordinal_type i = 0; i < m; ++i) {
+          const ordinal_type fla_pivot = ipiv[i] - i - 1;
+          fpiv[i] = fla_pivot;
+
+          /// apply pivots to perm vector
+          if (fpiv[i]) {
+            const ordinal_type pidx = i + fpiv[i];
+            swap(perm[i], perm[pidx]);
+          }
         }
+        for (ordinal_type i = 0; i < m; ++i)
+          peri[perm[i]] = i;
       }
-      for (ordinal_type i = 0; i < m; ++i)
-        peri[perm[i]] = i;
+    } else {
+      TACHO_TEST_FOR_ABORT(true, ">> This function is only allowed in host space.");
     }
-#else
-    TACHO_TEST_FOR_ABORT(true, ">> This function is only allowed in host space.");
-#endif
     return r_val;
   }
 
   template <typename MemberType, typename ViewTypeP>
   KOKKOS_INLINE_FUNCTION static int modify(MemberType &member, ordinal_type m, const ViewTypeP &P) {
-#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
-    int r_val = 0;
-    r_val = modify(m, P);
-    return r_val;
-#else
-    TACHO_TEST_FOR_ABORT(true, ">> This function is only allowed in host space.");
-#endif
+
+    static constexpr bool runOnHost = !std::is_same_v<typename ViewTypeP::execution_space, Kokkos::DefaultExecutionSpace>
+                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+
+    if constexpr(runOnHost) {
+      int r_val = 0;
+      r_val = modify(m, P);
+      return r_val;
+    } else {
+      TACHO_TEST_FOR_ABORT(true, ">> This function is only allowed in host space.");
+    }
   }
 };
 

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_LU_External.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_LU_External.hpp
@@ -33,8 +33,7 @@ template <> struct LU<Algo::External> {
   template <typename ViewTypeA, typename ViewTypeP> inline static int invoke(const ViewTypeA &A, const ViewTypeP &P) {
     int r_val = 0;
 
-    static constexpr bool runOnHost = !std::is_same_v<typename ViewTypeA::execution_space, Kokkos::DefaultExecutionSpace>
-                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+    static constexpr bool runOnHost = run_tacho_on_host_v<typename ViewTypeA::execution_space>;
 
     if constexpr(runOnHost) {
       typedef typename ViewTypeA::non_const_value_type value_type;
@@ -59,8 +58,7 @@ template <> struct LU<Algo::External> {
   template <typename MemberType, typename ViewTypeA, typename ViewTypeP>
   KOKKOS_INLINE_FUNCTION static int invoke(MemberType &member, const ViewTypeA &A, const ViewTypeP &P) {
 
-    static constexpr bool runOnHost = !std::is_same_v<typename ViewTypeA::execution_space, Kokkos::DefaultExecutionSpace>
-                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+    static constexpr bool runOnHost = run_tacho_on_host_v<typename ViewTypeA::execution_space>;
 
     if constexpr(runOnHost) {
       int r_val = 0;
@@ -73,8 +71,7 @@ template <> struct LU<Algo::External> {
 
   template <typename ViewTypeP> inline static int modify(const ordinal_type m, const ViewTypeP &P) {
 
-    static constexpr bool runOnHost = !std::is_same_v<typename ViewTypeP::execution_space, Kokkos::DefaultExecutionSpace>
-                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+    static constexpr bool runOnHost = run_tacho_on_host_v<typename ViewTypeP::execution_space>;
 
     int r_val = 0;
 
@@ -113,8 +110,7 @@ template <> struct LU<Algo::External> {
   template <typename MemberType, typename ViewTypeP>
   KOKKOS_INLINE_FUNCTION static int modify(MemberType &member, ordinal_type m, const ViewTypeP &P) {
 
-    static constexpr bool runOnHost = !std::is_same_v<typename ViewTypeP::execution_space, Kokkos::DefaultExecutionSpace>
-                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+    static constexpr bool runOnHost = run_tacho_on_host_v<typename ViewTypeP::execution_space>;
 
     if constexpr(runOnHost) {
       int r_val = 0;

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_TeamFunctor_FactorizeChol.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_TeamFunctor_FactorizeChol.hpp
@@ -186,6 +186,10 @@ public:
   template <typename MemberType>
   KOKKOS_INLINE_FUNCTION void update(MemberType &member, const supernode_type &cur,
                                      const value_type_matrix &ABR) const {
+
+    static constexpr bool runOnHost = !std::is_same_v<typename value_type_matrix::execution_space, Kokkos::DefaultExecutionSpace>
+                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+
     const auto info = _info;
     value_type *buf = ABR.data() + ABR.span();
     const ordinal_type sbeg = cur.sid_col_begin + 1, send = cur.sid_col_end - 1;
@@ -250,25 +254,25 @@ public:
             for (; s2t[ijbeg] == -1; ++ijbeg)
               ;
 
-#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
-            for (ordinal_type iii = 0; iii < (srcsize - ijbeg); ++iii) {
-              const ordinal_type ii = ijbeg + iii;
-              const ordinal_type row = s2t[ii];
-              if (row < s.m) {
-                for (ordinal_type jj = ijbeg; jj < srcsize; ++jj)
-                  Kokkos::atomic_add(&A(row, s2t[jj]), ABR(ii, jj));
+            if constexpr(runOnHost) {
+              for (ordinal_type iii = 0; iii < (srcsize - ijbeg); ++iii) {
+                const ordinal_type ii = ijbeg + iii;
+                const ordinal_type row = s2t[ii];
+                if (row < s.m) {
+                  for (ordinal_type jj = ijbeg; jj < srcsize; ++jj)
+                    Kokkos::atomic_add(&A(row, s2t[jj]), ABR(ii, jj));
+                }
               }
+            } else {
+              Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, srcsize - ijbeg), [&](const ordinal_type &iii) {
+                const ordinal_type ii = ijbeg + iii;
+                const ordinal_type row = s2t[ii];
+                if (row < s.m) {
+                  for (ordinal_type jj = ijbeg; jj < srcsize; ++jj)
+                    Kokkos::atomic_add(&A(row, s2t[jj]), ABR(ii, jj));
+                }
+              });
             }
-#else
-            Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, srcsize - ijbeg), [&](const ordinal_type &iii) {
-              const ordinal_type ii = ijbeg + iii;
-              const ordinal_type row = s2t[ii];
-              if (row < s.m) {
-                for (ordinal_type jj = ijbeg; jj < srcsize; ++jj)
-                  Kokkos::atomic_add(&A(row, s2t[jj]), ABR(ii, jj));
-              }
-            });
-#endif
           }
         });
     return;

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_TeamFunctor_FactorizeChol.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_TeamFunctor_FactorizeChol.hpp
@@ -187,8 +187,7 @@ public:
   KOKKOS_INLINE_FUNCTION void update(MemberType &member, const supernode_type &cur,
                                      const value_type_matrix &ABR) const {
 
-    static constexpr bool runOnHost = !std::is_same_v<typename value_type_matrix::execution_space, Kokkos::DefaultExecutionSpace>
-                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+    static constexpr bool runOnHost = run_tacho_on_host_v<typename value_type_matrix::execution_space>;
 
     const auto info = _info;
     value_type *buf = ABR.data() + ABR.span();

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_TeamFunctor_FactorizeLDL.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_TeamFunctor_FactorizeLDL.hpp
@@ -235,8 +235,7 @@ public:
   KOKKOS_INLINE_FUNCTION void update(MemberType &member, const supernode_type &cur,
                                      const value_type_matrix &ABR) const {
 
-    static constexpr bool runOnHost = !std::is_same_v<typename value_type_matrix::execution_space, Kokkos::DefaultExecutionSpace>
-                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+    static constexpr bool runOnHost = run_tacho_on_host_v<typename value_type_matrix::execution_space>;
 
     const auto info = _info;
     value_type *buf = ABR.data() + ABR.span();

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_TeamFunctor_FactorizeLDL.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_TeamFunctor_FactorizeLDL.hpp
@@ -234,6 +234,10 @@ public:
   template <typename MemberType>
   KOKKOS_INLINE_FUNCTION void update(MemberType &member, const supernode_type &cur,
                                      const value_type_matrix &ABR) const {
+
+    static constexpr bool runOnHost = !std::is_same_v<typename value_type_matrix::execution_space, Kokkos::DefaultExecutionSpace>
+                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+
     const auto info = _info;
     value_type *buf = ABR.data() + ABR.span();
     const ordinal_type sbeg = cur.sid_col_begin + 1, send = cur.sid_col_end - 1;
@@ -298,25 +302,25 @@ public:
             for (; s2t[ijbeg] == -1; ++ijbeg)
               ;
 
-#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
-            for (ordinal_type iii = 0; iii < (srcsize - ijbeg); ++iii) {
-              const ordinal_type ii = ijbeg + iii;
-              const ordinal_type row = s2t[ii];
-              if (row < s.m) {
-                for (ordinal_type jj = ijbeg; jj < srcsize; ++jj)
-                  Kokkos::atomic_add(&A(row, s2t[jj]), ABR(ii, jj));
+            if constexpr(runOnHost) {
+              for (ordinal_type iii = 0; iii < (srcsize - ijbeg); ++iii) {
+                const ordinal_type ii = ijbeg + iii;
+                const ordinal_type row = s2t[ii];
+                if (row < s.m) {
+                  for (ordinal_type jj = ijbeg; jj < srcsize; ++jj)
+                    Kokkos::atomic_add(&A(row, s2t[jj]), ABR(ii, jj));
+                }
               }
+            } else {
+              Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, srcsize - ijbeg), [&](const ordinal_type &iii) {
+                const ordinal_type ii = ijbeg + iii;
+                const ordinal_type row = s2t[ii];
+                if (row < s.m) {
+                  for (ordinal_type jj = ijbeg; jj < srcsize; ++jj)
+                    Kokkos::atomic_add(&A(row, s2t[jj]), ABR(ii, jj));
+                }
+              });
             }
-#else
-            Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, srcsize - ijbeg), [&](const ordinal_type &iii) {
-              const ordinal_type ii = ijbeg + iii;
-              const ordinal_type row = s2t[ii];
-              if (row < s.m) {
-                for (ordinal_type jj = ijbeg; jj < srcsize; ++jj)
-                  Kokkos::atomic_add(&A(row, s2t[jj]), ABR(ii, jj));
-              }
-            });
-#endif
           }
         });
     return;

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_TeamFunctor_FactorizeLU.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_TeamFunctor_FactorizeLU.hpp
@@ -223,8 +223,7 @@ public:
   KOKKOS_INLINE_FUNCTION void update(MemberType &member, const supernode_type &cur,
                                      const value_type_matrix &ABR) const {
 
-    static constexpr bool runOnHost = !std::is_same_v<typename value_type_matrix::execution_space, Kokkos::DefaultExecutionSpace>
-                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+    static constexpr bool runOnHost = run_tacho_on_host_v<typename value_type_matrix::execution_space>;
 
     const auto info = _info;
     value_type *buf = ABR.data() + ABR.span();

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_TeamFunctor_FactorizeLU.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_TeamFunctor_FactorizeLU.hpp
@@ -222,6 +222,10 @@ public:
   template <typename MemberType>
   KOKKOS_INLINE_FUNCTION void update(MemberType &member, const supernode_type &cur,
                                      const value_type_matrix &ABR) const {
+
+    static constexpr bool runOnHost = !std::is_same_v<typename value_type_matrix::execution_space, Kokkos::DefaultExecutionSpace>
+                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+
     const auto info = _info;
     value_type *buf = ABR.data() + ABR.span();
     const ordinal_type sbeg = cur.sid_col_begin + 1, send = cur.sid_col_end - 1;
@@ -288,33 +292,33 @@ public:
             for (; s2t[ijbeg] == -1; ++ijbeg)
               ;
 
-#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
-            for (ordinal_type ii = ijbeg; ii < srcsize; ++ii) {
-              const ordinal_type row = s2t[ii];
-              if (row < s.m) {
-                for (ordinal_type jj = ijbeg; jj < srcsize; ++jj) {
-                  const ordinal_type col = s2t[jj];
-                  Kokkos::atomic_add(&U(row, col), ABR(ii, jj));
-                  if (col >= s.m) {
-                    Kokkos::atomic_add(&L(col - s.m, row), ABR(jj, ii));
+            if constexpr(runOnHost) {
+              for (ordinal_type ii = ijbeg; ii < srcsize; ++ii) {
+                const ordinal_type row = s2t[ii];
+                if (row < s.m) {
+                  for (ordinal_type jj = ijbeg; jj < srcsize; ++jj) {
+                    const ordinal_type col = s2t[jj];
+                    Kokkos::atomic_add(&U(row, col), ABR(ii, jj));
+                    if (col >= s.m) {
+                      Kokkos::atomic_add(&L(col - s.m, row), ABR(jj, ii));
+                    }
                   }
                 }
               }
+            } else {
+              Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, ijbeg, srcsize), [&](const ordinal_type &ii) {
+                const ordinal_type row = s2t[ii];
+                if (row < s.m) {
+                  for (ordinal_type jj = ijbeg; jj < srcsize; ++jj) {
+                    const ordinal_type col = s2t[jj];
+                    Kokkos::atomic_add(&U(row, col), ABR(ii, jj));
+                    if (col >= s.m) {
+                      Kokkos::atomic_add(&L(col - s.m, row), ABR(jj, ii));
+                    }
+                  }
+                }
+              });
             }
-#else
-            Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, ijbeg, srcsize), [&](const ordinal_type &ii) {
-              const ordinal_type row = s2t[ii];
-              if (row < s.m) {
-                for (ordinal_type jj = ijbeg; jj < srcsize; ++jj) {
-                  const ordinal_type col = s2t[jj];
-                  Kokkos::atomic_add(&U(row, col), ABR(ii, jj));
-                  if (col >= s.m) {
-                    Kokkos::atomic_add(&L(col - s.m, row), ABR(jj, ii));
-                  }
-                }
-              }
-            });
-#endif
           }
         });
     return;

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Trsm.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Trsm.hpp
@@ -34,7 +34,7 @@ namespace Tacho {
 template <typename ArgSide, typename ArgUplo, typename ArgTrans, typename ArgAlgo> struct Trsm;
 
 struct TrsmAlgorithm {
-  using type = ActiveAlgorithm::type;
+  using type = ActiveAlgorithm<runsOnCudaOrHIP()>::type;
 };
 
 } // namespace Tacho

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Trsm_External.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Trsm_External.hpp
@@ -32,37 +32,45 @@ struct Trsm<ArgSide, ArgUplo, ArgTransA, Algo::External> {
 
   template <typename DiagType, typename ScalarType, typename ViewTypeA, typename ViewTypeB>
   inline static int invoke(const DiagType diagA, const ScalarType alpha, const ViewTypeA &A, const ViewTypeB &B) {
-#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
-    typedef typename ViewTypeA::non_const_value_type value_type;
-    typedef typename ViewTypeB::non_const_value_type value_type_b;
 
-    static_assert(ViewTypeA::rank == 2, "A is not rank 2 view.");
-    static_assert(ViewTypeB::rank == 2, "B is not rank 2 view.");
+    static constexpr bool runOnHost = !std::is_same_v<typename ViewTypeA::execution_space, Kokkos::DefaultExecutionSpace>
+                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
 
-    static_assert(std::is_same<value_type, value_type_b>::value, "A and B do not have the same value type.");
+    if constexpr(runOnHost) {
+      typedef typename ViewTypeA::non_const_value_type value_type;
+      typedef typename ViewTypeB::non_const_value_type value_type_b;
 
-    const ordinal_type m = B.extent(0);
-    const ordinal_type n = B.extent(1);
+      static_assert(ViewTypeA::rank == 2, "A is not rank 2 view.");
+      static_assert(ViewTypeB::rank == 2, "B is not rank 2 view.");
 
-    if (m > 0 && n > 0)
-      Blas<value_type>::trsm(ArgSide::param, ArgUplo::param, ArgTransA::param, diagA.param, m, n, value_type(alpha),
-                             A.data(), A.stride_1(), B.data(), B.stride_1());
-#else
-    TACHO_TEST_FOR_ABORT(true, "This function is only allowed in host space.");
-#endif
+      static_assert(std::is_same<value_type, value_type_b>::value, "A and B do not have the same value type.");
+
+      const ordinal_type m = B.extent(0);
+      const ordinal_type n = B.extent(1);
+
+      if (m > 0 && n > 0)
+        Blas<value_type>::trsm(ArgSide::param, ArgUplo::param, ArgTransA::param, diagA.param, m, n, value_type(alpha),
+                               A.data(), A.stride_1(), B.data(), B.stride_1());
+    } else {
+      TACHO_TEST_FOR_ABORT(true, "This function is only allowed in host space.");
+    }
     return 0;
   }
 
   template <typename MemberType, typename DiagType, typename ScalarType, typename ViewTypeA, typename ViewTypeB>
   KOKKOS_INLINE_FUNCTION static int invoke(MemberType &member, const DiagType diagA, const ScalarType alpha,
                                            const ViewTypeA &A, const ViewTypeB &B) {
-#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
-    // Kokkos::single(Kokkos::PerTeam(member), [&]() {
-    invoke(diagA, alpha, A, B);
-    //});
-#else
-    TACHO_TEST_FOR_ABORT(true, "This function is only allowed in host space.");
-#endif
+
+    static constexpr bool runOnHost = !std::is_same_v<typename ViewTypeA::execution_space, Kokkos::DefaultExecutionSpace>
+                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+
+    if constexpr(runOnHost) {
+      // Kokkos::single(Kokkos::PerTeam(member), [&]() {
+      invoke(diagA, alpha, A, B);
+      //});
+    } else {
+      TACHO_TEST_FOR_ABORT(true, "This function is only allowed in host space.");
+    }
     return 0;
   }
 };

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Trsm_External.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Trsm_External.hpp
@@ -33,8 +33,7 @@ struct Trsm<ArgSide, ArgUplo, ArgTransA, Algo::External> {
   template <typename DiagType, typename ScalarType, typename ViewTypeA, typename ViewTypeB>
   inline static int invoke(const DiagType diagA, const ScalarType alpha, const ViewTypeA &A, const ViewTypeB &B) {
 
-    static constexpr bool runOnHost = !std::is_same_v<typename ViewTypeA::execution_space, Kokkos::DefaultExecutionSpace>
-                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+    static constexpr bool runOnHost = run_tacho_on_host_v<typename ViewTypeA::execution_space>;
 
     if constexpr(runOnHost) {
       typedef typename ViewTypeA::non_const_value_type value_type;
@@ -61,8 +60,7 @@ struct Trsm<ArgSide, ArgUplo, ArgTransA, Algo::External> {
   KOKKOS_INLINE_FUNCTION static int invoke(MemberType &member, const DiagType diagA, const ScalarType alpha,
                                            const ViewTypeA &A, const ViewTypeB &B) {
 
-    static constexpr bool runOnHost = !std::is_same_v<typename ViewTypeA::execution_space, Kokkos::DefaultExecutionSpace>
-                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+    static constexpr bool runOnHost = run_tacho_on_host_v<typename ViewTypeA::execution_space>;
 
     if constexpr(runOnHost) {
       // Kokkos::single(Kokkos::PerTeam(member), [&]() {

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Trsv.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Trsv.hpp
@@ -34,7 +34,7 @@ namespace Tacho {
 template <typename ArgUplo, typename ArgTrans, typename ArgAlgo> struct Trsv;
 
 struct TrsvAlgorithm {
-  using type = ActiveAlgorithm::type;
+  using type = ActiveAlgorithm<runsOnCudaOrHIP()>::type;
 };
 
 } // namespace Tacho

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Trsv_External.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Trsv_External.hpp
@@ -31,8 +31,7 @@ template <typename ArgUplo, typename ArgTransA> struct Trsv<ArgUplo, ArgTransA, 
   template <typename DiagType, typename ViewTypeA, typename ViewTypeB>
   inline static int invoke(const DiagType diagA, const ViewTypeA &A, const ViewTypeB &B) {
 
-    static constexpr bool runOnHost = !std::is_same_v<typename ViewTypeA::execution_space, Kokkos::DefaultExecutionSpace>
-                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+    static constexpr bool runOnHost = run_tacho_on_host_v<typename ViewTypeA::execution_space>;
 
     if constexpr(runOnHost) {
       typedef typename ViewTypeA::non_const_value_type value_type;
@@ -64,8 +63,7 @@ template <typename ArgUplo, typename ArgTransA> struct Trsv<ArgUplo, ArgTransA, 
   KOKKOS_INLINE_FUNCTION static int invoke(MemberType &member, const DiagType diagA, const ViewTypeA &A,
                                            const ViewTypeB &B) {
 
-    static constexpr bool runOnHost = !std::is_same_v<typename ViewTypeA::execution_space, Kokkos::DefaultExecutionSpace>
-                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+    static constexpr bool runOnHost = run_tacho_on_host_v<typename ViewTypeA::execution_space>;
 
     if constexpr(runOnHost) {
       // Kokkos::single(Kokkos::PerTeam(member), [&]() {

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Trsv_External.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Trsv_External.hpp
@@ -30,42 +30,50 @@ namespace Tacho {
 template <typename ArgUplo, typename ArgTransA> struct Trsv<ArgUplo, ArgTransA, Algo::External> {
   template <typename DiagType, typename ViewTypeA, typename ViewTypeB>
   inline static int invoke(const DiagType diagA, const ViewTypeA &A, const ViewTypeB &B) {
-#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
-    typedef typename ViewTypeA::non_const_value_type value_type;
-    typedef typename ViewTypeB::non_const_value_type value_type_b;
 
-    static_assert(ViewTypeA::rank == 2, "A is not rank 2 view.");
-    static_assert(ViewTypeB::rank == 2, "B is not rank 2 view.");
+    static constexpr bool runOnHost = !std::is_same_v<typename ViewTypeA::execution_space, Kokkos::DefaultExecutionSpace>
+                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
 
-    static_assert(std::is_same<value_type, value_type_b>::value, "A and B do not have the same value type.");
+    if constexpr(runOnHost) {
+      typedef typename ViewTypeA::non_const_value_type value_type;
+      typedef typename ViewTypeB::non_const_value_type value_type_b;
 
-    const ordinal_type m = B.extent(0), n = B.extent(1);
+      static_assert(ViewTypeA::rank == 2, "A is not rank 2 view.");
+      static_assert(ViewTypeB::rank == 2, "B is not rank 2 view.");
 
-    if (m > 0 && n > 0) {
-      if (n == 1) {
-        Blas<value_type>::trsv(ArgUplo::param, ArgTransA::param, diagA.param, m, A.data(), A.stride_1(), B.data(),
-                               B.stride_0());
-      } else {
-        Blas<value_type>::trsm(Side::Left::param, ArgUplo::param, ArgTransA::param, diagA.param, m, n, value_type(1),
-                               A.data(), A.stride_1(), B.data(), B.stride_1());
+      static_assert(std::is_same<value_type, value_type_b>::value, "A and B do not have the same value type.");
+
+      const ordinal_type m = B.extent(0), n = B.extent(1);
+
+      if (m > 0 && n > 0) {
+        if (n == 1) {
+          Blas<value_type>::trsv(ArgUplo::param, ArgTransA::param, diagA.param, m, A.data(), A.stride_1(), B.data(),
+                                 B.stride_0());
+        } else {
+          Blas<value_type>::trsm(Side::Left::param, ArgUplo::param, ArgTransA::param, diagA.param, m, n, value_type(1),
+                                 A.data(), A.stride_1(), B.data(), B.stride_1());
+        }
       }
+    } else {
+      TACHO_TEST_FOR_ABORT(true, "This function is only allowed in host space.");
     }
-#else
-    TACHO_TEST_FOR_ABORT(true, "This function is only allowed in host space.");
-#endif
     return 0;
   }
 
   template <typename MemberType, typename DiagType, typename ViewTypeA, typename ViewTypeB>
   KOKKOS_INLINE_FUNCTION static int invoke(MemberType &member, const DiagType diagA, const ViewTypeA &A,
                                            const ViewTypeB &B) {
-#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
-    // Kokkos::single(Kokkos::PerTeam(member), [&]() {
-    invoke(diagA, A, B);
-    //});
-#else
-    TACHO_TEST_FOR_ABORT(true, "This function is only allowed in host space.");
-#endif
+
+    static constexpr bool runOnHost = !std::is_same_v<typename ViewTypeA::execution_space, Kokkos::DefaultExecutionSpace>
+                                    || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
+
+    if constexpr(runOnHost) {
+      // Kokkos::single(Kokkos::PerTeam(member), [&]() {
+      invoke(diagA, A, B);
+      //});
+    } else {
+      TACHO_TEST_FOR_ABORT(true, "This function is only allowed in host space.");
+    }
     return 0;
   }
 };

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Util.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Util.hpp
@@ -77,6 +77,9 @@ const char *Version();
 #define MSG_INVALID_TEMPLATE_ARGS "Invaid template arguments"
 #define MSG_INVALID_INPUT "Invaid input arguments"
 #define MSG_NOT_IMPLEMENTED "Not yet implemented"
+template <class ExecutionSpace>
+inline constexpr bool run_tacho_on_host_v = !std::is_same_v<ExecutionSpace, Kokkos::DefaultExecutionSpace>
+                                          || std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
 
 #define TACHO_TEST_FOR_ABORT(ierr, msg)                                                                                \
   if ((ierr) != 0) {                                                                                                   \


### PR DESCRIPTION
@trilinos/shylu 

## Motivation

This PR removes the deprecated `KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_*` in Tacho

## Related Issues

* Closes https://github.com/trilinos/Trilinos/issues/11508

## Testing

Being tested on Weaver with CUDA & Host builds