### PR TITLE
MueLu: Fix matrix-free for GO!=long long

### DIFF
--- a/packages/muelu/research/graham/mf_example_01.cpp
+++ b/packages/muelu/research/graham/mf_example_01.cpp
@@ -446,10 +446,10 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib lib, int arg
   const int num_procs = comm->getSize();
   {
     // Necessary typedefs
-    using SC = double;
-    using LO = int;
-    using GO = long long;
-    using NO = Tpetra::MultiVector<>::node_type;
+    using SC = Scalar;
+    using LO = LocalOrdinal;
+    using GO = GlobalOrdinal;
+    using NO = Node;
     //using map_type = Xpetra::Map<>; // unused
     using MV = Xpetra::MultiVector<SC,LO,GO,NO>;
 


### PR DESCRIPTION
@trilinos/muelu @cgcgcg 

When I swapped over the main routine to use the testing template instantiation framework, I forgot to swap the typedefs over as well, so builds with GO!=long long were failing. Related to #11660.