### PR TITLE
Tpetra: fix tests with both Cuda & OpenMP

### DIFF
--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_ExtraKernels_def.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_ExtraKernels_def.hpp
@@ -109,7 +109,7 @@ void mult_A_B_newmatrix_LowThreadGustavsonKernel(CrsMatrixStruct<Scalar, LocalOr
 
   // Lots and lots of typedefs
   typedef typename Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Tpetra::KokkosCompat::KokkosOpenMPWrapperNode>::local_matrix_device_type KCRS;
-  //  typedef typename KCRS::device_type device_t;
+  typedef typename KCRS::device_type device_t;
   typedef typename KCRS::StaticCrsGraphType graph_t;
   typedef typename graph_t::row_map_type::non_const_type lno_view_t;
   typedef typename graph_t::row_map_type::const_type c_lno_view_t;
@@ -182,8 +182,8 @@ void mult_A_B_newmatrix_LowThreadGustavsonKernel(CrsMatrixStruct<Scalar, LocalOr
   lno_nnz_view_t thread_total_nnz("thread_total_nnz",thread_max+1);
 
   // Thread-local memory
-  Kokkos::View<u_lno_nnz_view_t*> tl_colind("top_colind",thread_max);
-  Kokkos::View<u_scalar_view_t*> tl_values("top_values",thread_max);
+  Kokkos::View<u_lno_nnz_view_t*, device_t> tl_colind("top_colind",thread_max);
+  Kokkos::View<u_scalar_view_t*, device_t> tl_values("top_values",thread_max);
 
   double thread_chunk = (double)(m) / thread_max;
 
@@ -479,7 +479,7 @@ void jacobi_A_B_newmatrix_LowThreadGustavsonKernel(Scalar omega,
   // Lots and lots of typedefs
   typedef typename Tpetra::KokkosCompat::KokkosOpenMPWrapperNode Node;
   typedef typename Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>::local_matrix_device_type KCRS;
-  //  typedef typename KCRS::device_type device_t;
+  typedef typename KCRS::device_type device_t;
   typedef typename KCRS::StaticCrsGraphType graph_t;
   typedef typename graph_t::row_map_type::non_const_type lno_view_t;
   typedef typename graph_t::row_map_type::const_type c_lno_view_t;
@@ -559,8 +559,8 @@ void jacobi_A_B_newmatrix_LowThreadGustavsonKernel(Scalar omega,
   lno_nnz_view_t thread_total_nnz("thread_total_nnz",thread_max+1);
 
   // Thread-local memory
-  Kokkos::View<u_lno_nnz_view_t*> tl_colind("top_colind",thread_max);
-  Kokkos::View<u_scalar_view_t*> tl_values("top_values",thread_max);
+  Kokkos::View<u_lno_nnz_view_t*, device_t> tl_colind("top_colind",thread_max);
+  Kokkos::View<u_scalar_view_t*, device_t> tl_values("top_values",thread_max);
 
   double thread_chunk = (double)(m) / thread_max;
 
@@ -1137,8 +1137,8 @@ static inline void mult_R_A_P_newmatrix_LowThreadGustavsonKernel(CrsMatrixStruct
         // ("orig") or P_remote ("Import").
 
         // Thread-local memory
-        Kokkos::View<u_lno_nnz_view_t*> tl_colind("top_colind", thread_max);
-        Kokkos::View<u_scalar_view_t*> tl_values("top_values", thread_max);
+        Kokkos::View<u_lno_nnz_view_t*, device_t> tl_colind("top_colind", thread_max);
+        Kokkos::View<u_scalar_view_t*, device_t> tl_values("top_values", thread_max);
 
         // For each row of R
         Kokkos::parallel_for("MMM::RAP::NewMatrix::LTG::ThreadLocal",range_type(0, thread_max).set_chunk_size(1),[=](const size_t tid)

--- a/packages/tpetra/core/src/CMakeLists.txt
+++ b/packages/tpetra/core/src/CMakeLists.txt
@@ -937,5 +937,5 @@ SET_PROPERTY(
 # / from this directory, or to / from the 'impl' subdirectory.  That ensures
 # that running "make" will also rerun CMake in order to regenerate Makefiles.
 #
-# Here's another change, another, and another and yet another.
+# Here's another change, another, and another
 #

--- a/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_def.hpp
@@ -2609,6 +2609,9 @@ public:
         const auto policy =
           policy_type(numExportLIDs, 1, 1)
           .set_scratch_size(0, Kokkos::PerTeam(sizeof(GO)*maxRowLength));
+        // The following parallel_for needs const access to the local values of src.
+        // (the local graph is also accessed on host, but this does not use WDVs).
+        getValuesHost();
         Kokkos::parallel_for
           (policy,
            [=](const typename policy_type::member_type &member) {
@@ -2877,6 +2880,9 @@ public:
       using host_scratch_space = typename host_exec::scratch_memory_space;
       
       using pair_type = Kokkos::pair<size_t, size_t>;
+
+      //The following parallel_for modifies values on host while unpacking.
+      getValuesHostNonConst();
       Kokkos::parallel_for
         ("Tpetra::BlockCrsMatrix::unpackAndCombine: unpack", policy,
          [=] (const typename policy_type::member_type& member) {

--- a/packages/tpetra/core/src/Tpetra_Details_WrappedDualView.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_WrappedDualView.hpp
@@ -119,7 +119,8 @@ sync_device(DualViewType dualView) { }
 
 }
 
-
+/// \brief A wrapper around Kokkos::DualView to safely manage data
+///        that might be replicated between host and device.
 template <typename DualViewType>
 class WrappedDualView {
 public:
@@ -587,27 +588,31 @@ private:
     return Kokkos::subview(view,offset0,offset1);
   }
 
-
   bool memoryIsAliased() const {
     return deviceMemoryIsHostAccessible && dualView.h_view.data() == dualView.d_view.data();
   }
 
+  /// \brief needsSyncPath tells us whether we need the "sync path" where we (potentially) fence,
+  ///        check use counts and take care of sync/modify for the underlying DualView.
+  ///
+  /// The logic is this:
+  /// 1. If in a host-parallel region, then never take the sync path.
+  /// 2. For non-GPU architectures where the host/device pointers are aliased
+  ///    we don't need the "sync path."
+  /// 3. For GPUs, we always need the "sync path" in two cases: first, if we're using a memory space
+  ///    shared between host and device (e.g. CudaUVMSpace), where we need to make sure
+  ///    to fence before reading memory on host. And second, if the host/device pointers are aliased.
+  ///
+  /// Avoiding the "sync path" speeds up calculations on architectures where we can
+  /// avoid it (e.g. SerialNode) by not not touching the modify flags.
+  ///
+  /// Note for the future: Memory spaces that can be addressed on both host and device
+  /// that don't otherwise have an intrinsic fencing mechanism will need to trigger the
+  /// "sync path"
   bool needsSyncPath() const {
-    // needsSyncPath tells us whether we need the "sync path" where we (potentially) fence,
-    // check use counts and take care of sync/modify for the underlying DualView
-    //
-    // The logic is this:
-    // 1) For non-CUDA archtectures where there the host/device pointers are aliased
-    // we don't need the "sync path."
-    // 2) For CUDA, we always need the "sync path" if we're using the CudaUVMSpace (we need to make sure
-    // to fence before reading memory on host) OR if the host/device pointers are aliased.
-    //
-    // Avoiding the "sync path" speeds up calculations on architectures where we can
-    // avoid it (e.g. SerialNode) by not not touching the modify flags.
-    //
-    // Note for the future: Memory spaces that can be addressed on both host and device
-    // that don't otherwise have an intrinsic fencing mechanism will need to trigger the
-    // "sync path"
+
+    if(Kokkos::DefaultHostExecutionSpace().in_parallel())
+      return false;
 
 #ifdef KOKKOS_ENABLE_CUDA
     return std::is_same<typename t_dev::memory_space,Kokkos::CudaUVMSpace>::value || !memoryIsAliased();


### PR DESCRIPTION
Fix all Tpetra tests in a build with both Cuda and OpenMP nodes enabled.

Most issues were caused by non-thread-safe WrappedDualView functions being used in host-parallel kernels. Fixed this by disabling the WrappedDualView "sync path" parallel kernels. As a side effect this reduces a bit of overhead by skipping the reference-count checks.

In SpGEMM-Jacobi, the issues were just that the Kokkos default device was being used for temporary views, so it was trying to use e.g. CudaSpace views inside an OpenMP kernel. Fixed by using the Node's device type for those views.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Fixes some actual bugs - non-thread-safe WrappedDualView functions were being used inside parallel kernels.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
See #10569 - getting this configuration to work was requested by @romintomasetti 

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
Yes, all changes are tested (the original issue was because Tpetra tests were failing in this configuration).
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->