### PR TITLE
Framework: Add nightly build with Epetra stack disabled

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -912,13 +912,18 @@ opt-set-cmake-var Trilinos_ENABLE_Zoltan2Core BOOL : ON
 [PACKAGE-ENABLES|ALL-NO-EPETRA]
 opt-set-cmake-var Trilinos_ENABLE_ALL_PACKAGES BOOL : ON
 opt-set-cmake-var Trilinos_ENABLE_Amesos BOOL : OFF
+opt-set-cmake-var Trilinos_ENABLE_Domi BOOL : OFF
 opt-set-cmake-var Trilinos_ENABLE_Epetra BOOL : OFF
 opt-set-cmake-var Trilinos_ENABLE_EpetraExt BOOL : OFF
 opt-set-cmake-var Trilinos_ENABLE_FEI BOOL : OFF
 opt-set-cmake-var Trilinos_ENABLE_Ifpack BOOL : OFF
 opt-set-cmake-var Trilinos_ENABLE_Intrepid BOOL : OFF
+opt-set-cmake-var Trilinos_ENABLE_Komplex BOOL : OFF
+opt-set-cmake-var Trilinos_ENABLE_Moertel BOOL : OFF
 opt-set-cmake-var Trilinos_ENABLE_ML BOOL : OFF
-opt-set-cmake-var Trilinos_ENABLE_ThyraEpetraExtAdapters BOOL : OFF
+opt-set-cmake-var Trilinos_ENABLE_Piro BOOL : OFF
+opt-set-cmake-var Trilinos_ENABLE_Rythmos BOOL : OFF
+opt-set-cmake-var Trilinos_ENABLE_TriKota BOOL : OFF
 
 [PACKAGE-ENABLES|NO-PACKAGE-ENABLES]
 # Nothing to do here.
@@ -1660,6 +1665,11 @@ use RHEL7_POST
 #uses sems-archive modules
 use rhel7_sems-gnu-8.3.0-openmpi-1.10.1-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 use PACKAGE-ENABLES|ALL
+
+[rhel7_sems-gnu-8.3.0-openmpi-1.10.1-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all-no-epetra]
+#uses sems-archive modules
+use rhel7_sems-gnu-8.3.0-openmpi-1.10.1-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
+use PACKAGE-ENABLES|ALL-NO-EPETRA
 
 [rhel7_sems-gnu-8.3.0-openmpi-1.10.1-serial_debug-coverage_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
 #uses sems-archive modules

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -911,8 +911,13 @@ opt-set-cmake-var Trilinos_ENABLE_Zoltan2Core BOOL : ON
 
 [PACKAGE-ENABLES|ALL-NO-EPETRA]
 opt-set-cmake-var Trilinos_ENABLE_ALL_PACKAGES BOOL : ON
+opt-set-cmake-var Trilinos_ENABLE_Amesos BOOL : OFF
 opt-set-cmake-var Trilinos_ENABLE_Epetra BOOL : OFF
 opt-set-cmake-var Trilinos_ENABLE_EpetraExt BOOL : OFF
+opt-set-cmake-var Trilinos_ENABLE_FEI BOOL : OFF
+opt-set-cmake-var Trilinos_ENABLE_Ifpack BOOL : OFF
+opt-set-cmake-var Trilinos_ENABLE_Intrepid BOOL : OFF
+opt-set-cmake-var Trilinos_ENABLE_ML BOOL : OFF
 opt-set-cmake-var Trilinos_ENABLE_ThyraEpetraExtAdapters BOOL : OFF
 
 [PACKAGE-ENABLES|NO-PACKAGE-ENABLES]

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -909,6 +909,11 @@ opt-set-cmake-var Trilinos_ENABLE_Zoltan BOOL : ON
 opt-set-cmake-var Trilinos_ENABLE_Zoltan2 BOOL : ON
 opt-set-cmake-var Trilinos_ENABLE_Zoltan2Core BOOL : ON
 
+[PACKAGE-ENABLES|ALL-NO-EPETRA]
+opt-set-cmake-var Trilinos_ENABLE_ALL_PACKAGES BOOL : ON
+opt-set-cmake-var Trilinos_ENABLE_Epetra BOOL : OFF
+opt-set-cmake-var Trilinos_ENABLE_EpetraExt BOOL : OFF
+opt-set-cmake-var Trilinos_ENABLE_ThyraEpetraExtAdapters BOOL : OFF
 
 [PACKAGE-ENABLES|NO-PACKAGE-ENABLES]
 # Nothing to do here.
@@ -1686,6 +1691,11 @@ use RHEL7_POST
 #uses sems-archive modules
 use rhel7_sems-gnu-8.3.0-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 use PACKAGE-ENABLES|ALL
+
+[rhel7_sems-gnu-8.3.0-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_all-no-epetra]
+#uses sems-archive modules
+use rhel7_sems-gnu-8.3.0-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
+use PACKAGE-ENABLES|ALL-NO-EPETRA
 
 [rhel7_sems-gnu-8.3.0-openmpi-1.10.1-openmp_release-debug_static_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_pr]
 #uses sems-archive modules

--- a/packages/framework/ini-files/supported-config-flags.ini
+++ b/packages/framework/ini-files/supported-config-flags.ini
@@ -251,3 +251,4 @@ package-enables:  SELECT_MANY
     pr-serial    # reduced set of serial config enables
     pr-framework # reduced set of framework config enables
     pr-framework-atdm # combo of pr, pr-framework, and atdm enables
+    all-no-epetra # all packages, with Epetra stack disabled


### PR DESCRIPTION
@trilinos/framework 

## Motivation
To guarantee quality with Trilinos even if legacy (Epetra) stack components are disabled.  To this end, adding a nightly test line to evaluate build/test status with said stack disabled.

## Additional Information
The following packages from the Epetra stack are explicitly disabled for any new `ALL-NO-EPETRA` build:

- Amesos
- Domi
- Epetra
- EpetraExt
- FEI
- Ifpack
- Intrepid
- Komplex
- Moertel
- ML
- Piro
- Rythmos
- TriKota

The two new builds added to nightly runs are `rhel7_sems-gnu-8.3.0-openmpi-1.10.1-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all-no-epetra` and `rhel7_sems-gnu-8.3.0-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_all-no-epetra`.


This PR resolves JIRA ticket, TRILFRAME-545.