### PR TITLE
sacado: move shfl out of Experimental namespace for Hip

### DIFF
--- a/packages/sacado/src/new_design/Sacado_Fad_Exp_Atomic.hpp
+++ b/packages/sacado/src/new_design/Sacado_Fad_Exp_Atomic.hpp
@@ -263,7 +263,7 @@ namespace Sacado {
           while (go) {
             if (threadIdx.x == 0)
               go = !desul::Impl::lock_address_hip((void*)dest_val, scope);
-            go = Kokkos::Experimental::shfl(go, 0, blockDim.x);
+            go = Kokkos::shfl(go, 0, blockDim.x);
           }
           desul::atomic_thread_fence(desul::MemoryOrderAcquire(), scope);
           return_type return_val = op.apply(*dest, val);
@@ -309,7 +309,7 @@ namespace Sacado {
           while (go) {
             if (threadIdx.x == 0)
               go = !desul::Impl::lock_address_hip((void*)dest_val, scope);
-            go = Kokkos::Experimental::shfl(go, 0, blockDim.x);
+            go = Kokkos::shfl(go, 0, blockDim.x);
           }
           desul::atomic_thread_fence(desul::MemoryOrderAcquire(), scope);
           return_type return_val = *dest;


### PR DESCRIPTION
The shfl operations were moved out of the Experimental namespace for Hip with the 4.0 release PR #11600, this update is to resolve compilation errors with the Hip backend

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/sacado 


## Motivation
Resolve compilation errors with Hip backend and rocm compilers
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->



<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->