### PR TITLE
Epetra: Throw if CrsGraph indices are negative

### DIFF
--- a/packages/epetra/src/Epetra_CrsGraph.cpp
+++ b/packages/epetra/src/Epetra_CrsGraph.cpp
@@ -1817,9 +1817,9 @@ int Epetra_CrsGraph::MakeIndicesLocal(const Epetra_BlockMap& domainMap, const Ep
       for(int j = 0; j < NumIndices; j++) {
       int GID = ColIndices[j];
       int LID = colmap.LID(GID);
-      if(LID != -1)
+      if(LID > -1)
         ColIndices[j] = LID;
-      else
+      else // GH: if an index is negative, it's a sign of an error or overflow
         throw ReportError("Internal error in FillComplete ",-1);
       }
     }
@@ -1848,9 +1848,9 @@ int Epetra_CrsGraph::MakeIndicesLocal(const Epetra_BlockMap& domainMap, const Ep
       for(int j = 0; j < NumIndices; j++) {
       long long GID = ColIndices[j];
       int LID = colmap.LID(GID);
-      if(LID != -1)
+      if(LID > -1)
         intColIndices[j] = LID;
-      else
+      else // GH: if an index is negative, it's a sign of an error or overflow
         throw ReportError("Internal error in FillComplete ",-1);
       }
     }


### PR DESCRIPTION
@trilinos/epetra

Epetra's CrsGraph previously only checked if an LID was valid with `if(LID != -1)`, which did not cover the case where local indices overflow, as seen in #10249. This addresses it by instead defining `LID > -1` to be valid, so it will now throw on overflows.

Closes #10249.