### PR TITLE
Tpetra: Drop host views before apply, since apply may use the device.

### DIFF
--- a/packages/tpetra/core/inout/MatrixMarket_Tpetra.hpp
+++ b/packages/tpetra/core/inout/MatrixMarket_Tpetra.hpp
@@ -8788,8 +8788,10 @@ namespace Tpetra {
               localColsArray.push_back(curLocalCol);
             }
           }
-          //TODO Do the views eiData need to be released prior to the matvec?
 
+          // drop host views before apply
+          for (size_t i=0; i<numMVs; ++i)
+            eiData[i] = Teuchos::null;
           // probe
           A.apply(*ei,*colsA);
 
@@ -8798,6 +8800,18 @@ namespace Tpetra {
           if (myRank==0)
             globalNnz += writeColumns(os,*colsOnPid0, numMVs, importedGidsData(),
                                       globalColsArray, offsetToUseInPrinting);
+
+          // reconstruct dropped eiData
+          for (size_t i=0; i<numMVs; ++i)
+            eiData[i] = ei->getDataNonConst(i);
+          for (size_t j=0; j<numMVs; ++j ) {
+            GO curGlobalCol = minColGid + k*numMVs + j;
+            //TODO  extract the g2l map outside of this loop loop
+            LO curLocalCol = domainMap.getLocalElement(curGlobalCol);
+            if (curLocalCol != TLOT::invalid()) {
+              eiData[j][curLocalCol] = TGOT::one();
+            }
+          }
 
           //zero out the ei's
           for (size_t j=0; j<numMVs; ++j ) {
@@ -8823,8 +8837,10 @@ namespace Tpetra {
               localColsArray.push_back(curLocalCol);
             }
           }
-          //TODO Do the views eiData need to be released prior to the matvec?
 
+          // drop host views before apply
+          for (size_t i=0; i<numMVs; ++i)
+            eiData[i] = Teuchos::null;
           // probe
           A.apply(*ei,*colsA);
 
@@ -8832,6 +8848,18 @@ namespace Tpetra {
           if (myRank==0)
             globalNnz += writeColumns(os,*colsOnPid0, rem, importedGidsData(),
                                       globalColsArray, offsetToUseInPrinting);
+
+          // reconstruct dropped eiData
+          for (size_t i=0; i<numMVs; ++i)
+            eiData[i] = ei->getDataNonConst(i);
+          for (int j=0; j<rem; ++j ) {
+            GO curGlobalCol = maxColGid - rem + j + TGOT::one();
+            //TODO  extract the g2l map outside of this loop loop
+            LO curLocalCol = domainMap.getLocalElement(curGlobalCol);
+            if (curLocalCol != TLOT::invalid()) {
+              eiData[j][curLocalCol] = TGOT::one();
+            }
+          }
 
           //zero out the ei's
           for (int j=0; j<rem; ++j ) {


### PR DESCRIPTION
@trilinos/tpetra 

## Motivation
It was always improper to hold on to these host views, but SpMV with communication overlap exercises this now.

## Related Issues
Part of https://github.com/trilinos/Trilinos/pull/10926

