### PR TITLE
Tpetra: Permanent fix for #11655

### DIFF
--- a/packages/kokkos-kernels/sparse/src/KokkosSparse_spgemm_symbolic.hpp
+++ b/packages/kokkos-kernels/sparse/src/KokkosSparse_spgemm_symbolic.hpp
@@ -140,26 +140,15 @@ void spgemm_symbolic(KernelHandle *handle,
   // Verify that graphs A and B are sorted.
   // This test is designed to be as efficient as possible, but still skip
   // it in a release build.
-  //
-  // Temporary fix for Trilinos issue #11655: Only perform this check if a TPL
-  // is to be called. The KokkosKernels (non-TPL) implementation does not
-  // actually require sorted indices yet. And Tpetra uses size_type = size_t, so
-  // it will (currently) not be calling a TPL path.
 #ifndef NDEBUG
-  if constexpr (KokkosSparse::Impl::spgemm_symbolic_tpl_spec_avail<
-                    const_handle_type, Internal_alno_row_view_t_,
-                    Internal_alno_nnz_view_t_, Internal_blno_row_view_t_,
-                    Internal_blno_nnz_view_t_,
-                    Internal_clno_row_view_t_>::value) {
-    if (!KokkosSparse::Impl::isCrsGraphSorted(const_a_r, const_a_l))
-      throw std::runtime_error(
-          "KokkosSparse::spgemm_symbolic: entries of A are not sorted within "
-          "rows. May use KokkosSparse::sort_crs_matrix to sort it.");
-    if (!KokkosSparse::Impl::isCrsGraphSorted(const_b_r, const_b_l))
-      throw std::runtime_error(
-          "KokkosSparse::spgemm_symbolic: entries of B are not sorted within "
-          "rows. May use KokkosSparse::sort_crs_matrix to sort it.");
-  }
+  if (!KokkosSparse::Impl::isCrsGraphSorted(const_a_r, const_a_l))
+    throw std::runtime_error(
+        "KokkosSparse::spgemm_symbolic: entries of A are not sorted within "
+        "rows. May use KokkosSparse::sort_crs_matrix to sort it.");
+  if (!KokkosSparse::Impl::isCrsGraphSorted(const_b_r, const_b_l))
+    throw std::runtime_error(
+        "KokkosSparse::spgemm_symbolic: entries of B are not sorted within "
+        "rows. May use KokkosSparse::sort_crs_matrix to sort it.");
 #endif
 
   auto algo = tmp_handle.get_spgemm_handle()->get_algorithm_type();

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
@@ -3523,6 +3523,8 @@ merge_matrices(CrsMatrixStruct<Scalar, LocalOrdinal, GlobalOrdinal, Node>& Aview
       });
 
     KCRS newmat("CrsMatrix",merge_numrows,mergedNodeNumCols,merge_nnz,Mvalues,Mrowptr,Mcolind);
+    if(!KokkosSparse::isCrsGraphSorted(Mrowptr, Mcolind))
+      KokkosSparse::sort_crs_matrix(newmat);
     return newmat;
   }
   else {
@@ -3631,6 +3633,8 @@ merge_matrices(BlockCrsMatrixStruct<Scalar, LocalOrdinal, GlobalOrdinal, Node>& 
 
     // Build and return merged KokkosSparse matrix
     KBCRS newmat("CrsMatrix",merge_numrows,mergedNodeNumCols,merge_nnz,Mvalues,Mrowptr,Mcolind, blocksize);
+    if(!KokkosSparse::isCrsGraphSorted(Mrowptr, Mcolind))
+      KokkosSparse::sort_bsr_matrix(newmat);
     return newmat;
   }
   else {


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra
@trilinos/kokkos-kernels 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Permanent fix for #11655, where Tpetra was passing unsorted matrices to KokkosKernels SpGEMM and triggering debug checks. Revert the workaround in KokkosKernels (#11663).
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
@rppawlo With these changes, all MiniEM tests are still passing with OpenMP+Debug. I would be surprised if EMPIRE still runs into the issue, but could you please check (either before or after this merges)?
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->