### PR TITLE
Tpetra: Add `Tpetra::Details::Spaces`, `...::Slot`, and `...::User`

### DIFF
--- a/packages/tpetra/.clang-format
+++ b/packages/tpetra/.clang-format
@@ -1,0 +1,121 @@
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:   
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:   
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories: 
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IncludeIsMainRegex: '(Test)?$'
+IndentCaseLabels: false
+IndentPPDirectives: None
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Right
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+StatementMacros: 
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseTab:          Never
+...
+

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -52,6 +52,7 @@
 #include "Tpetra_CrsGraph.hpp"
 #include "Tpetra_Vector.hpp"
 #include "Tpetra_Details_PackTraits.hpp" // unused here, could delete
+#include "Tpetra_Details_ExecutionSpacesUser.hpp"
 #include "KokkosSparse_Utils.hpp"
 #include "KokkosSparse_CrsMatrix.hpp"
 #include "Teuchos_DataAccess.hpp"
@@ -424,7 +425,8 @@ namespace Tpetra {
             class Node>
   class CrsMatrix :
     public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
-    public DistObject<char, LocalOrdinal, GlobalOrdinal, Node>
+    public DistObject<char, LocalOrdinal, GlobalOrdinal, Node>,
+    public Details::Spaces::User
   {
   // clang-format on
 private:

--- a/packages/tpetra/core/src/Tpetra_Details_Behavior.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Behavior.cpp
@@ -571,6 +571,16 @@ bool Behavior::overlapCommunicationAndComputation ()
     (value_, initialized_, envVarName, defaultValue);
 }
 
+size_t Behavior::spacesIdWarnLimit ()
+{
+  constexpr char envVarName[] = "TPETRA_SPACES_ID_WARN_LIMT";
+  constexpr size_t defaultValue(16);
+
+  static size_t value_ = defaultValue;
+  static bool initialized_ = false;
+  return idempotentlyGetEnvironmentVariableAsSize
+    (value_, initialized_, envVarName, defaultValue);
+}
 
 bool Behavior::timeKokkosDeepCopy() 
 {

--- a/packages/tpetra/core/src/Tpetra_Details_Behavior.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Behavior.hpp
@@ -275,14 +275,18 @@ public:
   /// <tt>TPETRA_OVERLAP</tt> environment variable.
   static bool overlapCommunicationAndComputation();
 
-
   /// \brief Add Teuchos timers for all host calls to Kokkos::deep_copy().
   /// This is especially useful for identifying host/device data transfers
   ///
   /// This is disabled by default.  You may control this at run time via the
   /// <tt>TPETRA_TIME_KOKKOS_DEEP_COPY</tt> environment variable.
   static bool timeKokkosDeepCopy();
-
+  
+  /// \brief Warn if more than this many Kokkos spaces are accessed.
+  ///
+  /// This is disabled by default.  You may control this at run time via the
+  /// <tt>TPETRA_SPACE_ID_WARN_LIMIT</tt> environment variable.
+  static size_t spacesIdWarnLimit();
 };
 
 } // namespace Details

--- a/packages/tpetra/core/src/Tpetra_Details_ExecutionSpaces.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_ExecutionSpaces.cpp
@@ -1,0 +1,65 @@
+#include "Tpetra_Details_ExecutionSpaces.hpp"
+
+#include <sstream>
+#include <vector>
+
+namespace Tpetra {
+namespace Details {
+namespace Spaces {
+
+#if defined(KOKKOS_ENABLE_CUDA)
+// cuda has default stream priority 0
+CudaInfo::CudaInfo() : initialized_(false), mediumPrio_(0) {}
+#endif
+
+void lazy_init() {
+#if defined(KOKKOS_ENABLE_CUDA)
+  if (!cudaInfo.initialized_) {
+    cudaInfo.initialized_ = true;
+    CUDA_RUNTIME(cudaEventCreateWithFlags(&cudaInfo.execSpaceWaitEvent_,
+                                          cudaEventDisableTiming));
+    CUDA_RUNTIME(cudaDeviceGetStreamPriorityRange(&cudaInfo.lowPrio_,
+                                                  &cudaInfo.highPrio_));
+
+    // We expect
+    //   medium priority should be 0
+    //   lower numbers to be higher priorities
+    //   low is at least as good as medium
+    //   medium is at least as good as high
+    if (!(cudaInfo.lowPrio_ >= cudaInfo.mediumPrio_ &&
+          cudaInfo.mediumPrio_ >= cudaInfo.highPrio_)) {
+      std::stringstream ss;
+      ss << "CUDA stream priority does not follow assumptions."
+         << " low=" << cudaInfo.lowPrio_ << " medium=" << cudaInfo.mediumPrio_
+         << " high=" << cudaInfo.highPrio_
+         << " Please report this to the Tpetra developers.";
+      throw std::runtime_error(ss.str());
+    }
+  }
+#endif
+}
+
+/* -----------------------------
+    Space Management Singletons
+   -----------------------------*/
+
+#if defined(KOKKOS_ENABLE_CUDA)
+/*extern*/ InstanceLifetimeManager<Kokkos::Cuda> cudaSpaces;
+/*extern*/ CudaInfo cudaInfo;
+#endif
+#ifdef KOKKOS_ENABLE_SERIAL
+/*extern*/ InstanceLifetimeManager<Kokkos::Serial> serialSpaces;
+#endif
+#ifdef KOKKOS_ENABLE_OPENMP
+/*extern*/ InstanceLifetimeManager<Kokkos::OpenMP> openMPSpaces;
+#endif
+#ifdef KOKKOS_ENABLE_HIP
+/*extern*/ InstanceLifetimeManager<Kokkos::HIP> HIPSpaces;
+#endif
+#ifdef KOKKOS_ENABLE_SYCL
+/*extern*/ InstanceLifetimeManager<Kokkos::SYCL> SYCLSpaces;
+#endif
+
+} // namespace Spaces
+} // namespace Details
+} // namespace Tpetra

--- a/packages/tpetra/core/src/Tpetra_Details_ExecutionSpaces.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_ExecutionSpaces.cpp
@@ -16,10 +16,10 @@ void lazy_init() {
 #if defined(KOKKOS_ENABLE_CUDA)
   if (!cudaInfo.initialized_) {
     cudaInfo.initialized_ = true;
-    CUDA_RUNTIME(cudaEventCreateWithFlags(&cudaInfo.execSpaceWaitEvent_,
-                                          cudaEventDisableTiming));
-    CUDA_RUNTIME(cudaDeviceGetStreamPriorityRange(&cudaInfo.lowPrio_,
-                                                  &cudaInfo.highPrio_));
+    TPETRA_DETAILS_SPACES_CUDA_RUNTIME(cudaEventCreateWithFlags(
+        &cudaInfo.execSpaceWaitEvent_, cudaEventDisableTiming));
+    TPETRA_DETAILS_SPACES_CUDA_RUNTIME(cudaDeviceGetStreamPriorityRange(
+        &cudaInfo.lowPrio_, &cudaInfo.highPrio_));
 
     // We expect
     //   medium priority should be 0

--- a/packages/tpetra/core/src/Tpetra_Details_ExecutionSpaces.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_ExecutionSpaces.hpp
@@ -61,7 +61,7 @@ inline void success_or_throw(cudaError_t err, const char *file,
     throw std::runtime_error(ss.str());
   }
 }
-#define CUDA_RUNTIME(x)                                                        \
+#define TPETRA_DETAILS_SPACES_CUDA_RUNTIME(x)                                  \
   Tpetra::Details::Spaces::success_or_throw((x), __FILE__, __LINE__)
 #endif // KOKKOS_ENABLE_CUDA
 
@@ -169,7 +169,7 @@ Kokkos::Cuda make_instance() {
   default:
     throw std::runtime_error("unexpected static Tpetra Space priority");
   }
-  CUDA_RUNTIME(
+  TPETRA_DETAILS_SPACES_CUDA_RUNTIME(
       cudaStreamCreateWithPriority(&stream, cudaStreamNonBlocking, prio));
   return Kokkos::Cuda(stream, true /*Kokkos will manage this stream*/);
 }
@@ -423,9 +423,9 @@ void exec_space_wait(const char *msg, const S1 &waitee, const S2 &waiter) {
     even if it overwrites the state of a shared event this means we only need
     one event even if many exec_space_waits are in flight at the same time
     */
-    CUDA_RUNTIME(
+    TPETRA_DETAILS_SPACES_CUDA_RUNTIME(
         cudaEventRecord(cudaInfo.execSpaceWaitEvent_, waitee.cuda_stream()));
-    CUDA_RUNTIME(cudaStreamWaitEvent(
+    TPETRA_DETAILS_SPACES_CUDA_RUNTIME(cudaStreamWaitEvent(
         waiter.cuda_stream(), cudaInfo.execSpaceWaitEvent_, 0 /*flags*/));
   }
 }

--- a/packages/tpetra/core/src/Tpetra_Details_ExecutionSpaces.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_ExecutionSpaces.hpp
@@ -1,5 +1,5 @@
-#ifndef TPETRA_DETAILS_SPACES_HPP
-#define TPETRA_DETAILS_SPACES_HPP
+#ifndef TPETRA_DETAILS_EXECUTIONSPACES_HPP
+#define TPETRA_DETAILS_EXECUTIONSPACES_HPP
 
 #include <iostream>
 #include <sstream>
@@ -473,4 +473,4 @@ is_gpu_exec_space<Kokkos::Experimental::SYCL>() {
 
 #undef TPETRA_DETAILS_SPACES_THROW
 
-#endif // TPETRA_DETAILS_SPACES_HPP
+#endif // TPETRA_DETAILS_EXECUTIONSPACES_HPP

--- a/packages/tpetra/core/src/Tpetra_Details_ExecutionSpaces.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_ExecutionSpaces.hpp
@@ -1,0 +1,476 @@
+#ifndef TPETRA_DETAILS_SPACES_HPP
+#define TPETRA_DETAILS_SPACES_HPP
+
+#include <iostream>
+#include <sstream>
+#include <vector>
+
+#include <Kokkos_Core.hpp>
+
+#include <Teuchos_RCP.hpp>
+
+#include "Tpetra_Details_Behavior.hpp"
+#include "Tpetra_Details_Profiling.hpp"
+
+/*! \file
+
+Interface for Tpetra's managed Kokkos execution spaces
+This facility strives to provide:
+1. Caching previously-constructed spaces so they can be used on-demand in parts
+of Tpetra
+2. Spaces of different priorities where supported
+3. Fast sync of spaces where supported
+
+For each Kokkos backend, there is a singleton instance manager.
+This singleton manages the lifetime of all instances for that Kokkos backend.
+These singletons are not meant to be accessed directly, but through
+top-level functions in this file.
+
+*/
+
+#define TPETRA_DETAILS_SPACES_THROW(x)                                         \
+  {                                                                            \
+    std::stringstream ss;                                                      \
+    ss << __FILE__ << ":" << __LINE__ << ": " << x;                            \
+    throw std::runtime_error(ss.str());                                        \
+  }
+
+namespace Tpetra {
+namespace Details {
+namespace Spaces {
+
+/*! \brief Priority interface for Tpetra's managed execution spaces
+
+    Priority is best-effort. low <= medium <= high, but it may be the case that
+   priority levels are equivalent.
+*/
+enum class Priority {
+  low = 0,
+  medium = 1,
+  high = 2,
+  NUM_LEVELS = 3 // not to be used as a priority
+};
+
+#if defined(KOKKOS_ENABLE_CUDA)
+inline void success_or_throw(cudaError_t err, const char *file,
+                             const int line) {
+  if (err != cudaSuccess) {
+    std::stringstream ss;
+    ss << file << ":" << line << ": ";
+    ss << cudaGetErrorString(err);
+    throw std::runtime_error(ss.str());
+  }
+}
+#define CUDA_RUNTIME(x)                                                        \
+  Tpetra::Details::Spaces::success_or_throw((x), __FILE__, __LINE__)
+#endif // KOKKOS_ENABLE_CUDA
+
+/*! \brief Should be called by all functions in the Tpetra::Details::Spaces
+   namespace
+
+    * Prepares resources for Kokkos::CUDA exec space instance sync
+    * Maps Tpetra::Priority to CUDA stream priorities
+*/
+void lazy_init();
+
+#if defined(KOKKOS_ENABLE_CUDA)
+struct CudaInfo {
+  bool initialized_;
+  int lowPrio_;
+  int mediumPrio_; // same as CUDA default
+  int highPrio_;
+  cudaEvent_t execSpaceWaitEvent_; // see exec_space_wait
+
+  CudaInfo();
+  ~CudaInfo() = default; // execSpaceWaitEvent_ cleaned up by CUDA deinit
+  CudaInfo(const CudaInfo &other) = delete;
+  CudaInfo(CudaInfo &&other) = delete;
+};
+extern CudaInfo cudaInfo;
+#endif // KOKKOS_ENABLE_CUDA
+
+// Tpetra's managed spaces
+#if defined(KOKKOS_ENABLE_CUDA)
+template <typename Space>
+using IsCuda = std::enable_if_t<std::is_same_v<Space, Kokkos::Cuda>, bool>;
+template <typename Space>
+using NotCuda = std::enable_if_t<!std::is_same_v<Space, Kokkos::Cuda>, bool>;
+template <typename S1, typename S2>
+using BothCuda = std::enable_if_t<
+    std::is_same_v<S1, Kokkos::Cuda> && std::is_same_v<S2, Kokkos::Cuda>, bool>;
+template <typename S1, typename S2>
+using NotBothCuda = std::enable_if_t<!std::is_same_v<S1, Kokkos::Cuda> ||
+                                         !std::is_same_v<S2, Kokkos::Cuda>,
+                                     bool>;
+#endif // KOKKOS_ENABLE_CUDA
+
+#if defined(KOKKOS_ENABLE_SERIAL)
+///\brief IsSerial<Space> is a type if Space is Kokkos::Serial
+template <typename Space>
+using IsSerial = std::enable_if_t<std::is_same_v<Space, Kokkos::Serial>, bool>;
+#endif // KOKKOS_ENABLE_SERIAL
+
+#if defined(KOKKOS_ENABLE_OPENMP)
+///\brief IsOpenMP<Space> is a type if Space is Kokkos::OpenMP
+template <typename Space>
+using IsOpenMP = std::enable_if_t<std::is_same_v<Space, Kokkos::OpenMP>, bool>;
+#endif // KOKKOS_ENABLE_OPENMP
+
+#if defined(KOKKOS_ENABLE_HIP)
+///\brief IsHIP<Space> is a type if Space is Kokkos::HIP
+template <typename Space>
+using IsHIP = std::enable_if_t<std::is_same_v<Space, Kokkos::HIP>, bool>;
+#endif // KOKKOS_ENABLE_HIP
+
+#if defined(KOKKOS_ENABLE_SYCL)
+///\brief IsSYCL<Space> is a type if Space is Kokkos::SYCL
+template <typename Space>
+using IsSYCL = std::enable_if_t<std::is_same_v<Space, Kokkos::SYCL>, bool>;
+#endif // KOKKOS_ENABLE_SYCL
+
+/*! \brief Construct a Kokkos execution space instance with the following
+   priority
+
+    If priority is not supported, returns the default space instance
+*/
+template <typename ExecSpace, Priority priority = Priority::medium
+#if defined(KOKKOS_ENABLE_CUDA)
+          ,
+          NotCuda<ExecSpace> = true
+#endif // KOKKOS_ENABLE_CUDA
+          >
+ExecSpace make_instance() {
+  return ExecSpace();
+}
+
+/*! \brief Construct a Kokkos::Cuda execution space instance with the requested
+   priority
+
+    This creates a stream with the requested priority, and attaches it to a new
+   space
+*/
+#if defined(KOKKOS_ENABLE_CUDA)
+template <typename ExecSpace, Priority priority = Priority::medium,
+          IsCuda<ExecSpace> = true>
+Kokkos::Cuda make_instance() {
+  lazy_init(); // CUDA priorities
+  cudaStream_t stream;
+  int prio;
+  switch (priority) {
+  case Priority::high:
+    prio = cudaInfo.highPrio_;
+    break;
+  case Priority::medium:
+    prio = cudaInfo.mediumPrio_;
+    break;
+  case Priority::low:
+    prio = cudaInfo.lowPrio_;
+    break;
+  default:
+    throw std::runtime_error("unexpected static Tpetra Space priority");
+  }
+  CUDA_RUNTIME(
+      cudaStreamCreateWithPriority(&stream, cudaStreamNonBlocking, prio));
+  return Kokkos::Cuda(stream, true /*Kokkos will manage this stream*/);
+}
+#endif // KOKKOS_ENABLE_CUDA
+
+/*! \brief Construct a Kokkos execution space instance with the requested
+   priority \tparam ExecSpace the type of Kokkos execution space to produce
+    \param prio The Tpetra::Details::Spaces::Priority of the execution space to
+   produce
+*/
+template <typename ExecSpace> ExecSpace make_instance(const Priority &prio) {
+  switch (prio) {
+  case Priority::high:
+    return make_instance<ExecSpace, Priority::high>();
+  case Priority::medium:
+    return make_instance<ExecSpace, Priority::medium>();
+  case Priority::low:
+    return make_instance<ExecSpace, Priority::low>();
+  default:
+    throw std::runtime_error("unexpected dynamic Tpetra Space priority");
+  }
+}
+
+/*! \brief Provides reusable Kokkos execution space instances
+    \tparam ExecSpace the type of Kokkos execution space to manage
+
+    Holds a weak RCP to exec space instances, but provides strong RCPs to
+   callers. Callers in Tpetra can use this to quickly get an execution space
+   instance on-demand.
+
+
+    When all strong RCP holders go away, the referenced instance will also go
+   away. This prevents the spaces from living longer than Kokkos.
+*/
+template <typename ExecSpace> class InstanceLifetimeManager {
+public:
+  using execution_space = ExecSpace;
+  using rcp_type = Teuchos::RCP<const execution_space>;
+
+  /*! \brief Retrieve a strong `Teuchos::RCP<const ExecSpace>` to instance `i`
+
+      \tparam priority the Spaces::Details::Priority of the provided instance
+      \param i Which execution space instance to provide (default =
+     Tpetra::Details::Spaces::Priority::medium)
+  */
+  template <Priority priority = Priority::medium>
+  rcp_type space_instance(int i = 0) {
+    Tpetra::Details::ProfilingRegion region(
+        "Tpetra::Details::Spaces::space_instance");
+
+    constexpr int p = static_cast<int>(priority);
+    static_assert(p < sizeof(instances) / sizeof(instances[0]),
+                  "Spaces::Priority enum error");
+
+    if (i < 0) {
+      TPETRA_DETAILS_SPACES_THROW("requested instance id " << i << " (< 0)");
+    }
+    if (size_t(i) >= Tpetra::Details::Behavior::spacesIdWarnLimit()) {
+      TPETRA_DETAILS_SPACES_THROW(
+          "requested instance id "
+          << i << " (>= " << Tpetra::Details::Behavior::spacesIdWarnLimit()
+          << ") set by TPETRA_SPACES_ID_WARN_LIMT");
+    }
+
+    // make sure we can store an exec space at index i for priority
+    // not sure what happens in RCP(), so let's explicitly make it null
+    while (size_t(i) >= instances[p].size()) {
+      instances[p].push_back(Teuchos::ENull());
+    }
+
+    /* no exec space instance i of priority p exists.
+       It may have never existed, or all Tpetra objects referencing it have been
+       destructed.
+
+       Create a new RCP<ExecSpace> and internally store a weak
+       reference, so this space will be destructed when all strong references to
+       it are gone, but we can still refer to it as long as it lives to prevent
+       recreating
+    */
+    if (instances[p][i].is_null() || !instances[p][i].is_valid_ptr()) {
+
+      // create a strong RCP to a space
+      rcp_type r = Teuchos::RCP<const execution_space>(
+          new ExecSpace(make_instance<ExecSpace, priority>()));
+
+      // store a weak RCP to the space
+      instances[p][i] = r.create_weak();
+
+      return r; // allow strong rcp to escape so internal weak one does not
+                // immediately go away
+    }
+
+    auto r = instances[p][i].create_strong();
+    return r;
+  }
+
+  /*! \brief Issue a warning if any Tpetra-managed execution space instances
+   * survive to the end of static lifetime
+   */
+  ~InstanceLifetimeManager() {
+    for (int i = 0; i < static_cast<int>(Spaces::Priority::NUM_LEVELS); ++i) {
+      for (const rcp_type &rcp : instances[i]) {
+        if (rcp.is_valid_ptr() && !rcp.is_null()) {
+          // avoid throwing in dtor
+          std::cerr << __FILE__ << ":" << __LINE__
+                    << " execution space instance survived to "
+                       "~InstanceLifetimeManager. strong_count() = "
+                    << rcp.strong_count()
+                    << ". Did a Tpetra object live past Kokkos::finalize()?"
+                    << std::endl;
+        }
+      }
+    }
+  }
+
+private:
+  // one vector of instances for each priority level
+  std::vector<rcp_type>
+      instances[static_cast<int>(Spaces::Priority::NUM_LEVELS)];
+};
+
+#if defined(KOKKOS_ENABLE_CUDA)
+extern InstanceLifetimeManager<Kokkos::Cuda> cudaSpaces;
+#endif
+#if defined(KOKKOS_ENABLE_SERIAL)
+extern InstanceLifetimeManager<Kokkos::Serial> serialSpaces;
+#endif
+#if defined(KOKKOS_ENABLE_OPENMP)
+extern InstanceLifetimeManager<Kokkos::OpenMP> openMPSpaces;
+#endif
+#if defined(KOKKOS_ENABLE_HIP)
+extern InstanceLifetimeManager<Kokkos::HIP> HIPSpaces;
+#endif
+#if defined(KOKKOS_ENABLE_SYCL)
+extern InstanceLifetimeManager<Kokkos::SYCL> SYCLSpaces;
+#endif
+
+#if defined(KOKKOS_ENABLE_CUDA)
+
+/*! \brief get a strong Teuchos::RCP to Tpetra-managed Kokkos::Cuda instance \c
+ * i
+ */
+template <typename ExecSpace, Priority priority = Priority::medium,
+          IsCuda<ExecSpace> = true>
+Teuchos::RCP<const ExecSpace> space_instance(int i = 0) {
+  return cudaSpaces.space_instance<priority>(i);
+}
+#endif
+
+#if defined(KOKKOS_ENABLE_SERIAL)
+/*! \brief get a strong Teuchos::RCP to Tpetra-managed Kokkos::Serial instance
+ * \c i
+ */
+template <typename ExecSpace, Priority priority = Priority::medium,
+          IsSerial<ExecSpace> = true>
+Teuchos::RCP<const ExecSpace> space_instance(int i = 0) {
+  return serialSpaces.space_instance<priority>(i);
+}
+#endif
+
+#if defined(KOKKOS_ENABLE_OPENMP)
+/*! \brief get a strong Teuchos::RCP to Tpetra-managed Kokkos::OpenMP instance
+ * \c i
+ */
+template <typename ExecSpace, Priority priority = Priority::medium,
+          IsOpenMP<ExecSpace> = true>
+Teuchos::RCP<const ExecSpace> space_instance(int i = 0) {
+  return openMPSpaces.space_instance<priority>(i);
+}
+#endif
+
+#if defined(KOKKOS_ENABLE_HIP)
+/*! \brief get a strong Teuchos::RCP to Tpetra-managed Kokkos::HIP instance \c i
+ */
+template <typename ExecSpace, Priority priority = Priority::medium,
+          IsHIP<ExecSpace> = true>
+Teuchos::RCP<const ExecSpace> space_instance(int i = 0) {
+  return HIPSpaces.space_instance<priority>(i);
+}
+#endif
+#if defined(KOKKOS_ENABLE_SYCL)
+/*! \brief get a strong Teuchos::RCP to Tpetra-managed Kokkos::SYCL instance \c
+ * i
+ */
+template <typename ExecSpace, Priority priority = Priority::medium,
+          IsSYCL<ExecSpace> = true>
+Teuchos::RCP<const ExecSpace> space_instance(int i = 0) {
+  return SYCLSpaces.space_instance<priority>(i);
+}
+#endif
+
+/*! \brief get a strong Teuchos::RCP to Tpetra-managed Kokkos execution space
+   instance \c i \param priority the priority of the execution space instance
+    \tparam ExecSpace the type of Execution
+    \returns a strong RCP<ExecSpace>
+*/
+template <typename ExecSpace>
+Teuchos::RCP<const ExecSpace> space_instance(const Priority &priority,
+                                             int i = 0) {
+  switch (priority) {
+  case Priority::high:
+    return space_instance<ExecSpace, Priority::high>(i);
+  case Priority::medium:
+    return space_instance<ExecSpace, Priority::medium>(i);
+  case Priority::low:
+    return space_instance<ExecSpace, Priority::low>(i);
+  default:
+    throw std::runtime_error(
+        "unexpected dynamic Tpetra Space priority in space_instance");
+  }
+}
+
+/*! \brief cause future work submitted to waiter to wait for the current work in
+  waitee to finish
+
+  \tparam S1 the type of waitee
+  \tparam S2 the type of waiter
+  \param msg
+  \param waitee Future work submitted to this stream will wait for work in \c
+  waiter to finish \param waiter Future work submitted to \c waitee will wait
+  for work in this stream to finish
+
+  For Kokkos::Cuda execution spaces, this function may return immediately (i.e.,
+  without synchronizing the host).
+*/
+template <typename S1, typename S2
+#if defined(KOKKOS_ENABLE_CUDA)
+          ,
+          NotBothCuda<S1, S2> = true
+#endif
+          >
+void exec_space_wait(const char *msg, const S1 &waitee, const S2 & /*waiter*/) {
+  Tpetra::Details::ProfilingRegion r(
+      "Tpetra::Details::Spaces::exec_space_wait");
+  lazy_init();
+  waitee.fence(msg);
+}
+
+#if defined(KOKKOS_ENABLE_CUDA)
+template <typename S1, typename S2, BothCuda<S1, S2> = true>
+void exec_space_wait(const char *msg, const S1 &waitee, const S2 &waiter) {
+  Tpetra::Details::ProfilingRegion r(
+      "Tpetra::Details::Spaces::exec_space_wait");
+  lazy_init();
+
+  // if they are the same instance, no sync needed
+  if (waitee.impl_instance_id() !=
+      waiter
+          .impl_instance_id()) { // TODO: use instance operator== once available
+    /* cudaStreamWaitEvent is not affected by later calls to cudaEventRecord,
+    even if it overwrites the state of a shared event this means we only need
+    one event even if many exec_space_waits are in flight at the same time
+    */
+    CUDA_RUNTIME(
+        cudaEventRecord(cudaInfo.execSpaceWaitEvent_, waitee.cuda_stream()));
+    CUDA_RUNTIME(cudaStreamWaitEvent(
+        waiter.cuda_stream(), cudaInfo.execSpaceWaitEvent_, 0 /*flags*/));
+  }
+}
+#endif
+
+template <typename S1, typename S2>
+void exec_space_wait(const S1 &waitee, const S2 &waiter) {
+  Tpetra::Details::ProfilingRegion r(
+      "Tpetra::Details::Spaces::exec_space_wait");
+  lazy_init();
+  exec_space_wait("anonymous", waitee, waiter);
+}
+
+template <typename ExecutionSpace>
+constexpr KOKKOS_INLINE_FUNCTION bool is_gpu_exec_space() {
+  return false;
+}
+
+#if defined(KOKKOS_ENABLE_CUDA)
+template <>
+constexpr KOKKOS_INLINE_FUNCTION bool is_gpu_exec_space<Kokkos::Cuda>() {
+  return true;
+}
+#endif
+
+#if defined(KOKKOS_ENABLE_HIP)
+template <>
+constexpr KOKKOS_INLINE_FUNCTION bool
+is_gpu_exec_space<Kokkos::Experimental::HIP>() {
+  return true;
+}
+#endif
+
+#if defined(KOKKOS_ENABLE_SYCL)
+template <>
+constexpr KOKKOS_INLINE_FUNCTION bool
+is_gpu_exec_space<Kokkos::Experimental::SYCL>() {
+  return true;
+}
+#endif
+
+} // namespace Spaces
+} // namespace Details
+} // namespace Tpetra
+
+#undef TPETRA_DETAILS_SPACES_THROW
+
+#endif // TPETRA_DETAILS_SPACES_HPP

--- a/packages/tpetra/core/src/Tpetra_Details_ExecutionSpacesSlot.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_ExecutionSpacesSlot.hpp
@@ -1,0 +1,93 @@
+#ifndef TPETRA_DETAILS_EXEUTIONSPACESSLOT_HPP
+#define TPETRA_DETAILS_EXEUTIONSPACESSLOT_HPP
+
+#include <iostream>
+#include <sstream>
+#include <vector>
+
+#include "Teuchos_RCP.hpp"
+#include "Tpetra_Details_Behavior.hpp"
+#include "Tpetra_Details_ExecutionSpaces.hpp"
+#include <Kokkos_Core.hpp>
+
+namespace Tpetra {
+namespace Details {
+namespace Spaces {
+
+/**
+ * @brief Lazily acquires and stores Kokkos Execution Spaces
+ *
+ * @tparam ExecSpace the type of the execution space to be wrapped.
+ */
+template <typename ExecSpace> class Slot {
+public:
+  using execution_space = ExecSpace;
+
+  /**
+   * @brief Default constructor that creates instances for each possible space
+   * priority level.
+   */
+  Slot() {
+    for (int i = 0; i < static_cast<int>(Spaces::Priority::NUM_LEVELS); ++i) {
+      // retrieve an RCP from the global instance manager
+      instances_[i] = Spaces::space_instance<execution_space>(
+          static_cast<Spaces::Priority>(i));
+    }
+  }
+
+  /**
+   * @brief Get a specific execution space instance based on the given priority
+   * level.
+   *
+   * @tparam priority the priority level of the desired execution space
+   * instance. Default value is medium.
+   * @return Teuchos::RCP<const execution_space> a smart pointer to a const
+   * execution_space object.
+   * @note This template method is used to get the execution space instance
+   * based on the template parameter priority.
+   */
+  template <Spaces::Priority priority = Spaces::Priority::medium>
+  Teuchos::RCP<const execution_space> space_instance() const {
+    return instances_[static_cast<int>(priority)];
+  }
+
+  /**
+   * @brief Get a specific execution space instance based on the given priority
+   * level.
+   *
+   * @param priority the priority level of the desired execution space instance.
+   * @return Teuchos::RCP<const execution_space> a smart pointer to a const
+   * execution_space object.
+   * @note This non-template method is used to get the execution space instance
+   * based on the runtime parameter priority. It returns the corresponding
+   * execution space instance by calling the corresponding template method.
+   * Throws a runtime error if the given priority is not valid.
+   */
+  Teuchos::RCP<const execution_space>
+  space_instance(const Spaces::Priority &priority) const {
+    switch (priority) {
+    case Spaces::Priority::high:
+      return space_instance<Spaces::Priority::high>();
+    case Spaces::Priority::medium:
+      return space_instance<Spaces::Priority::medium>();
+    case Spaces::Priority::low:
+      return space_instance<Spaces::Priority::low>();
+    default:
+      throw std::runtime_error("unexpected Tpetra Space priority");
+    }
+  }
+
+private:
+  /**
+   * @brief Array that contains instances of different execution space
+   * prioritized by priority levels.
+   */
+  Teuchos::RCP<const execution_space>
+      instances_[static_cast<int>(Spaces::Priority::NUM_LEVELS)];
+}; // Slot
+
+} // namespace Spaces
+} // namespace Details
+} // namespace Tpetra
+
+#endif // TPETRA_DETAILS_EXEUTIONSPACESSLOT_HPP

--- a/packages/tpetra/core/src/Tpetra_Details_ExecutionSpacesUser.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_ExecutionSpacesUser.hpp
@@ -1,0 +1,137 @@
+#ifndef TPETRA_DETAILS_EXECUTIONSPACESUSER_HPP
+#define TPETRA_DETAILS_EXECUTIONSPACESUSER_HPP
+
+#include <iostream>
+#include <sstream>
+#include <vector>
+
+#include <Kokkos_Core.hpp>
+
+#include "Teuchos_RCP.hpp"
+
+#include "Tpetra_Details_ExecutionSpacesSlot.hpp"
+
+namespace Tpetra {
+namespace Details {
+namespace Spaces {
+
+/*! @brief A class can inherit from this if it wants to use Tpetra managed
+ * spaces
+
+   Adds a Tpetra::Details::SpaceSlot for each enabled Kokkos execution space,
+   and provides a ::space_instance() member function that class members can
+   call to retrieve the owned spaces, if they want to use them.
+ */
+class User {
+public:
+#ifdef KOKKOS_ENABLE_CUDA
+
+  /**
+   * @brief Returns a const smart pointer to an execution space instance.
+   *
+   * @tparam ExecSpace the execution space type
+   * @tparam priority the execution space priority, default value: medium
+   *
+   * @return a const smart pointer to an execution space instance
+   */
+  template <typename ExecSpace,
+            Spaces::Priority priority = Spaces::Priority::medium,
+            Spaces::IsCuda<ExecSpace> = true>
+  Teuchos::RCP<const ExecSpace> space_instance() const {
+    return cudaSlot.space_instance<priority>();
+  }
+
+  /**
+   * @brief Returns a const smart pointer to an execution space instance with a
+   * specific priority.
+   *
+   * @tparam ExecSpace the execution space type
+   * @param priority the execution space priority
+   *
+   * @return a const smart pointer to an execution space instance
+   */
+  template <typename ExecSpace, Spaces::IsCuda<ExecSpace> = true>
+  Teuchos::RCP<const ExecSpace>
+  space_instance(const Spaces::Priority &priority) const {
+    return cudaSlot.space_instance(priority);
+  }
+#endif // KOKKOS_ENABLE_CUDA
+
+#ifdef KOKKOS_ENABLE_SERIAL
+  template <typename ExecSpace,
+            Spaces::Priority priority = Spaces::Priority::medium,
+            Spaces::IsSerial<ExecSpace> = true>
+  Teuchos::RCP<const ExecSpace> space_instance() const {
+    return serialSlot.space_instance<priority>();
+  }
+  template <typename ExecSpace, Spaces::IsSerial<ExecSpace> = true>
+  Teuchos::RCP<const ExecSpace>
+  space_instance(const Spaces::Priority &priority) const {
+    return serialSlot.space_instance(priority);
+  }
+#endif // KOKKOS_ENABLE_SERIAL
+
+#ifdef KOKKOS_ENABLE_OPENMP
+  template <typename ExecSpace,
+            Spaces::Priority priority = Spaces::Priority::medium,
+            Spaces::IsOpenMP<ExecSpace> = true>
+  Teuchos::RCP<const ExecSpace> space_instance() const {
+    return openMPSlot.space_instance<priority>();
+  }
+  template <typename ExecSpace, Spaces::IsOpenMP<ExecSpace> = true>
+  Teuchos::RCP<const ExecSpace>
+  space_instance(const Spaces::Priority &priority) const {
+    return openMPSlot.space_instance(priority);
+  }
+#endif // KOKKOS_ENABLE_OPENMP
+
+#ifdef KOKKOS_ENABLE_HIP
+  template <typename ExecSpace,
+            Spaces::Priority priority = Spaces::Priority::medium,
+            Spaces::IsHIP<ExecSpace> = true>
+  Teuchos::RCP<const ExecSpace> space_instance() const {
+    return HIPSlot.space_instance<priority>();
+  }
+  template <typename ExecSpace, Spaces::IsHIP<ExecSpace> = true>
+  Teuchos::RCP<const ExecSpace>
+  space_instance(const Spaces::Priority &priority) const {
+    return HIPSlot.space_instance(priority);
+  }
+#endif // KOKKOS_ENABLE_HIP
+
+#ifdef KOKKOS_ENABLE_SYCL
+  template <typename ExecSpace,
+            Spaces::Priority priority = Spaces::Priority::medium,
+            Spaces::IsSYCL<ExecSpace> = true>
+  Teuchos::RCP<const ExecSpace> space_instance() const {
+    return SYCLSlot.space_instance<priority>();
+  }
+  template <typename ExecSpace, Spaces::IsSYCL<ExecSpace> = true>
+  Teuchos::RCP<const ExecSpace>
+  space_instance(const Spaces::Priority &priority) const {
+    return SYCLSlot.space_instance(priority);
+  }
+#endif // KOKKOS_ENABLE_SYCL
+
+#ifdef KOKKOS_ENABLE_SERIAL
+  Slot<Kokkos::Serial> serialSlot;
+#endif
+#ifdef KOKKOS_ENABLE_OPENMP
+  Slot<Kokkos::OpenMP> openMPSlot;
+#endif
+#ifdef KOKKOS_ENABLE_CUDA
+  Slot<Kokkos::Cuda> cudaSlot;
+#endif
+#ifdef KOKKOS_ENABLE_HIP
+  Slot<Kokkos::HIP> HIPSlot;
+#endif
+#ifdef KOKKOS_ENABLE_SYCL
+  Slot<Kokkos::SYCL> SYCLSlot;
+#endif
+
+}; // User
+} // namespace Spaces
+} // namespace Details
+} // namespace Tpetra
+
+#endif // TPETRA_DETAILS_EXECUTIONSPACESUSER_HPP

--- a/packages/tpetra/core/test/CMakeLists.txt
+++ b/packages/tpetra/core/test/CMakeLists.txt
@@ -31,6 +31,7 @@ ADD_SUBDIRECTORIES(
   Operator
   PerformanceCGSolve
   Sort
+  Spaces
   Utils
   RowMatrixTransposer
   Tsqr

--- a/packages/tpetra/core/test/Spaces/CMakeLists.txt
+++ b/packages/tpetra/core/test/Spaces/CMakeLists.txt
@@ -1,0 +1,18 @@
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  Spaces
+  SOURCES
+    Spaces.cpp
+  COMM serial mpi
+  NUM_MPI_PROCS 1
+  STANDARD_PASS_OUTPUT
+)
+
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  SpaceUser
+  SOURCES
+    SpaceUser.cpp
+  COMM serial mpi
+  NUM_MPI_PROCS 1
+  STANDARD_PASS_OUTPUT
+)

--- a/packages/tpetra/core/test/Spaces/SpaceUser.cpp
+++ b/packages/tpetra/core/test/Spaces/SpaceUser.cpp
@@ -1,0 +1,142 @@
+/*
+// @HEADER
+// ***********************************************************************
+//
+//          Tpetra: Templated Linear Algebra Services Package
+//                 Copyright (2008) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+*/
+
+#include <Teuchos_UnitTestHarness.hpp>
+
+#include <Tpetra_Core.hpp>
+#include <Tpetra_Details_ExecutionSpacesUser.hpp>
+
+/*! \file SpaceUser.cpp 
+    \brief Make sure SpaceUser compiles and doesn't crash
+*/
+
+namespace { // (anonymous)
+
+template <typename ExecSpace> struct S : public Tpetra::Details::Spaces::User {
+
+  static constexpr size_t B = size_t(1024) * size_t(1024) * size_t(1024);
+
+  void priority() const {
+    auto e1 =
+        space_instance<ExecSpace, Tpetra::Details::Spaces::Priority::low>();
+    auto e2 =
+        space_instance<ExecSpace, Tpetra::Details::Spaces::Priority::medium>();
+    auto e3 =
+        space_instance<ExecSpace, Tpetra::Details::Spaces::Priority::high>();
+    auto e4 = space_instance<ExecSpace>(Tpetra::Details::Spaces::Priority::low);
+    auto e5 =
+        space_instance<ExecSpace>(Tpetra::Details::Spaces::Priority::medium);
+    auto e6 =
+        space_instance<ExecSpace>(Tpetra::Details::Spaces::Priority::high);
+  }
+
+  // request the same instance 1B times should be pretty quick
+  void reuse() const {
+    for (size_t i = 0; i < B; ++i) {
+      auto e1 =
+          space_instance<ExecSpace, Tpetra::Details::Spaces::Priority::low>();
+    }
+  }
+
+}; // S
+
+template <typename ExecutionSpace>
+void test_priority(bool &success, Teuchos::FancyOStream &out) {
+  S<ExecutionSpace>().priority();
+  success = true;
+}
+
+template <typename ExecutionSpace>
+void test_reuse(bool &success, Teuchos::FancyOStream &out) {
+  S<ExecutionSpace>().reuse();
+  success = true;
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+  Tpetra::ScopeGuard sg(&argc, &argv);
+
+  bool success = false;
+  auto out = Teuchos::fancyOStream (Teuchos::rcpFromRef (std::cout));
+  *out << "Test SpaceUser" << std::endl;
+
+#if defined(KOKKOS_ENABLE_SERIAL)
+  test_priority<Kokkos::Serial>(success, *out);
+  test_reuse<Kokkos::Serial>(success, *out);
+#endif
+
+#if defined(KOKKOS_ENABLE_OPENMP)
+  test_priority<Kokkos::OpenMP>(success, *out);
+  test_reuse<Kokkos::OpenMP>(success, *out);
+#endif
+
+#if defined(KOKKOS_ENABLE_THREADS)
+  test_priority<Kokkos::Threads>(success, *out);
+  test_reuse<Kokkos::Threads>(success, *out);
+#endif
+
+#if defined(KOKKOS_ENABLE_CUDA)
+  test_priority<Kokkos::Cuda>(success, *out);
+  test_reuse<Kokkos::Cuda>(success, *out);
+#endif
+
+#if defined(KOKKOS_ENABLE_HIP)
+  test_priority<Kokkos::HIP>(success, *out);
+  test_reuse<Kokkos::HIP>(success, *out);
+#endif
+
+#if defined(KOKKOS_ENABLE_SYCL)
+  test_priority<Kokkos::SYCL>(success, *out);
+  test_reuse<Kokkos::SYCL>(success, *out);
+#endif
+
+  if (success) {
+    std::cout << std::endl << "End Result: TEST PASSED" << std::endl;
+  } else {
+    std::cout << std::endl << "End Result: TEST FAILED" << std::endl;
+  }
+  
+  Teuchos::OSTab tab1(out);
+  return 0;
+}

--- a/packages/tpetra/core/test/Spaces/Spaces.cpp
+++ b/packages/tpetra/core/test/Spaces/Spaces.cpp
@@ -1,0 +1,231 @@
+/*
+// @HEADER
+// ***********************************************************************
+//
+//          Tpetra: Templated Linear Algebra Services Package
+//                 Copyright (2008) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+*/
+
+#include <Teuchos_UnitTestHarness.hpp>
+
+#include <Tpetra_Core.hpp>
+#include <Tpetra_Details_ExecutionSpaces.hpp>
+
+/*! \file Spaces.cpp 
+    \brief Make sure Tpetra::Details::Spaces interfaces compile and don't crash
+*/
+
+namespace { // (anonymous)
+
+template <typename ExecutionSpace>
+void test_exec_space_wait(bool &success, Teuchos::FancyOStream &out) {
+  ExecutionSpace e1, e2;
+  Tpetra::Details::Spaces::exec_space_wait(e1, e2);
+  Tpetra::Details::Spaces::exec_space_wait("test_exec_space_wait", e1, e2);
+
+  success = true;
+}
+
+template <typename ExecutionSpace>
+void test_make_instance(bool &success, Teuchos::FancyOStream &out) {
+
+  using Priority = Tpetra::Details::Spaces::Priority;
+  {
+    ExecutionSpace e1 =
+        Tpetra::Details::Spaces::make_instance<ExecutionSpace>();
+    ExecutionSpace e2 =
+        Tpetra::Details::Spaces::make_instance<ExecutionSpace, Priority::low>();
+    ExecutionSpace e3 =
+        Tpetra::Details::Spaces::make_instance<ExecutionSpace,
+                                               Priority::medium>();
+    ExecutionSpace e4 =
+        Tpetra::Details::Spaces::make_instance<ExecutionSpace,
+                                               Priority::high>();
+  }
+  {
+    ExecutionSpace e1 =
+        Tpetra::Details::Spaces::make_instance<ExecutionSpace>(Priority::low);
+    ExecutionSpace e2 = Tpetra::Details::Spaces::make_instance<ExecutionSpace>(
+        Priority::medium);
+    ExecutionSpace e3 =
+        Tpetra::Details::Spaces::make_instance<ExecutionSpace>(Priority::high);
+  }
+
+  success = true;
+}
+
+template <typename ExecutionSpace>
+void test_space_instance(bool &success, Teuchos::FancyOStream &out) {
+  using Priority = Tpetra::Details::Spaces::Priority;
+
+  // unnumbered spaces are the same
+  {
+    Teuchos::RCP<const ExecutionSpace> e1 =
+        Tpetra::Details::Spaces::space_instance<ExecutionSpace>();
+    Teuchos::RCP<const ExecutionSpace> e2 =
+        Tpetra::Details::Spaces::space_instance<ExecutionSpace>();
+    TEUCHOS_TEST_EQUALITY(e1, e2, out, success);
+  }
+
+  // unnumbered space is the same as 0
+  {
+    Teuchos::RCP<const ExecutionSpace> e1 =
+        Tpetra::Details::Spaces::space_instance<ExecutionSpace>();
+    Teuchos::RCP<const ExecutionSpace> e2 =
+        Tpetra::Details::Spaces::space_instance<ExecutionSpace>(0);
+    TEUCHOS_TEST_EQUALITY(e1, e2, out, success);
+  }
+
+  // construct priorities (no relationship with each other defined yet)
+  {
+    Teuchos::RCP<const ExecutionSpace> e1 =
+        Tpetra::Details::Spaces::space_instance<ExecutionSpace,
+                                                Priority::low>();
+    Teuchos::RCP<const ExecutionSpace> e2 =
+        Tpetra::Details::Spaces::space_instance<ExecutionSpace,
+                                                Priority::medium>();
+    Teuchos::RCP<const ExecutionSpace> e3 =
+        Tpetra::Details::Spaces::space_instance<ExecutionSpace,
+                                                Priority::high>();
+  }
+  {
+    Teuchos::RCP<const ExecutionSpace> e1 =
+        Tpetra::Details::Spaces::space_instance<ExecutionSpace, Priority::low>(
+            0);
+    Teuchos::RCP<const ExecutionSpace> e2 =
+        Tpetra::Details::Spaces::space_instance<ExecutionSpace,
+                                                Priority::medium>(2);
+    Teuchos::RCP<const ExecutionSpace> e3 =
+        Tpetra::Details::Spaces::space_instance<ExecutionSpace, Priority::high>(
+            10);
+  }
+
+  {
+    Teuchos::RCP<const ExecutionSpace> e1 =
+        Tpetra::Details::Spaces::space_instance<ExecutionSpace>(Priority::low);
+    Teuchos::RCP<const ExecutionSpace> e2 =
+        Tpetra::Details::Spaces::space_instance<ExecutionSpace>(
+            Priority::medium);
+    Teuchos::RCP<const ExecutionSpace> e3 =
+        Tpetra::Details::Spaces::space_instance<ExecutionSpace>(Priority::high);
+  }
+
+  {
+    Teuchos::RCP<const ExecutionSpace> e1 =
+        Tpetra::Details::Spaces::space_instance<ExecutionSpace>(Priority::low,
+                                                                0);
+    Teuchos::RCP<const ExecutionSpace> e2 =
+        Tpetra::Details::Spaces::space_instance<ExecutionSpace>(
+            Priority::medium, 2);
+    Teuchos::RCP<const ExecutionSpace> e3 =
+        Tpetra::Details::Spaces::space_instance<ExecutionSpace>(Priority::high,
+                                                                10);
+  }
+
+  success = true;
+}
+
+template <typename ExecutionSpace, bool expected>
+void test_is_gpu_exec_space(bool &success, Teuchos::FancyOStream &out) {
+  TEUCHOS_TEST_EQUALITY(
+      expected, Tpetra::Details::Spaces::is_gpu_exec_space<ExecutionSpace>(),
+      out, success);
+}
+
+
+
+} // namespace
+
+int main(int argc, char **argv) {
+  Tpetra::ScopeGuard sg(&argc, &argv);
+
+  bool success = false;
+  auto out = Teuchos::fancyOStream (Teuchos::rcpFromRef (std::cout));
+  *out << "Test spaces" << std::endl;
+
+#if defined(KOKKOS_ENABLE_SERIAL)
+  test_exec_space_wait<Kokkos::Serial>(success, *out);
+  test_make_instance<Kokkos::Serial>(success, *out);
+  test_space_instance<Kokkos::Serial>(success, *out);
+  test_is_gpu_exec_space<Kokkos::Serial, false>(success, *out);
+#endif
+
+#if defined(KOKKOS_ENABLE_OPENMP)
+  test_exec_space_wait<Kokkos::OpenMP>(success, *out);
+  test_make_instance<Kokkos::OpenMP>(success, *out);
+  test_space_instance<Kokkos::OpenMP>(success, *out);
+  test_is_gpu_exec_space<Kokkos::OpenMP, false>(success, *out);
+#endif
+
+#if defined(KOKKOS_ENABLE_THREADS)
+  test_exec_space_wait<Kokkos::Threads>(success, *out);
+  test_make_instance<Kokkos::Threads>(success, *out);
+  test_space_instance<Kokkos::Threads>(success, *out);
+  test_is_gpu_exec_space<Kokkos::Threads, false>(success, *out);
+#endif
+
+#if defined(KOKKOS_ENABLE_CUDA)
+  test_exec_space_wait<Kokkos::Cuda>(success, *out);
+  test_make_instance<Kokkos::Cuda>(success, *out);
+  test_space_instance<Kokkos::Cuda>(success, *out);
+  test_is_gpu_exec_space<Kokkos::Cuda, true>(success, *out);
+#endif
+
+#if defined(KOKKOS_ENABLE_HIP)
+  test_exec_space_wait<Kokkos::HIP>(success, *out);
+  test_make_instance<Kokkos::HIP>(success, *out);
+  test_space_instance<Kokkos::HIP>(success, *out);
+  test_is_gpu_exec_space<Kokkos::HIP, true>(success, *out);
+#endif
+
+#if defined(KOKKOS_ENABLE_SYCL)
+  test_exec_space_wait<Kokkos::SYCL>(success, *out);
+  test_make_instance<Kokkos::SYCL>(success, *out);
+  test_space_instance<Kokkos::SYCL>(success, *out);
+  test_is_gpu_exec_space<Kokkos::SYCL, true>(success, *out);
+#endif
+
+  if (success) {
+    std::cout << std::endl << "End Result: TEST PASSED" << std::endl;
+  } else {
+    std::cout << std::endl << "End Result: TEST FAILED" << std::endl;
+  }
+  
+  Teuchos::OSTab tab1(out);
+  return 0;
+}


### PR DESCRIPTION
@trilinos/tpetra

## Summary
Adds `Tpetra::Details::ExecutionSpaces` namespace with a variety of free functions to create and cache Kokkos execution space instances. In this PR, only `Kokkos::Cuda` execution space instances are special-cased for performance, but all backends are supported.

Adds `Tpetra::Details::ExecutionSpaces::User` which a Tpetra object can inherit from, which provides a couple utility functions to access execution space instances and scope those instances to the lifetime of the object.

Makes `Tpetra::CrsMatrix` a `Tpetra::Details::ExecutionSpaces::User` but since `Tpetra::CrsMatrix` is otherwise unchanged, has no impact on its behavior.

Adds a `.clang-format` file generated by clang-format-8 in the LLVM style (`clang-format-8 --style=LLVM --dump-config`) for a consistent format for future Tpetra code

## Motivation
Needed to manage execution space instances and priorities in communication-computation overlap: https://github.com/trilinos/Trilinos/pull/10926




