### PR TITLE
Ifpack2: Add implementation of fourth-kind chebyshev polynomial smoothers

### DIFF
--- a/packages/ifpack2/doc/UsersGuide/ifpack2guide.bib
+++ b/packages/ifpack2/doc/UsersGuide/ifpack2guide.bib
@@ -179,3 +179,9 @@
   year        = {2005},
   number      = {SAND-0662},
 }
+@article{Lottes2022,
+  title={Optimal polynomial smoothers for multigrid V-cycles},
+  author={Lottes, James},
+  journal={arXiv preprint arXiv:2202.08830},
+  year={2022}
+}

--- a/packages/ifpack2/doc/UsersGuide/options.tex
+++ b/packages/ifpack2/doc/UsersGuide/options.tex
@@ -376,7 +376,7 @@ The following parameters are used in the Chebyshev method:
     % {bool}
     % {\false}
     % {If true, use the textbook variant; otherwise, use the \ifpack{} variant.}
-\ccc{chebyshev: kind}
+\ccc{chebyshev: algorithm}
     {string}
     {"first"}
     {The algorithm for the Chebyshev polynomial. Currently supports

--- a/packages/ifpack2/doc/UsersGuide/options.tex
+++ b/packages/ifpack2/doc/UsersGuide/options.tex
@@ -376,6 +376,22 @@ The following parameters are used in the Chebyshev method:
     % {bool}
     % {\false}
     % {If true, use the textbook variant; otherwise, use the \ifpack{} variant.}
+\ccc{chebyshev: kind}
+    {string}
+    {"first"}
+    {The algorithm for the Chebyshev polynomial. Currently supports
+     the default \ifpack{} variant, otherwise known as the first-kind ("first") Chebyshev polynomials.
+     Chebyshev smoothing via the fourth-kind ("fourth") and optimized fourth-kind ("opt_fourth")
+     are also implemented as in ~\cite{Lottes2022}.
+     Note that these latter two algorithms do not require the ad-hoc minimum eigenvalue estimate
+     as the standard \ifpack{} algorithm ("first").
+     The textbook algorithm ("textbook") as described in ~\cite{Saad2003} is also available.
+     However, the "first", "fourth", and "opt_fourth" kinds are preferred.
+     Currently supported: "first", "fourth", "opt_fourth", and "textbook".
+     Generally, the "fourth" and "opt_fourth" provide better smoothing properties
+     when employing the Chebyshev polynomials as multigrid smoothers, especially at orders
+     greater than or equal to 3.
+    }
 \ccc{chebyshev: compute max residual norm}
     {bool}
     {\false}

--- a/packages/ifpack2/src/Ifpack2_Details_Chebyshev_Weights.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Chebyshev_Weights.hpp
@@ -1,0 +1,305 @@
+/*
+//@HEADER
+// ***********************************************************************
+//
+//       Ifpack2: Templated Object-Oriented Algebraic Preconditioner Package
+//                 Copyright (2009) Sandia Corporation
+//
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ***********************************************************************
+//@HEADER
+*/
+
+#ifndef IFPACK2_DETAILS_CHEBYSHEV_WEIGHTS_HPP
+#define IFPACK2_DETAILS_CHEBYSHEV_WEIGHTS_HPP
+
+#include <stdexcept>
+#include <vector>
+#include "Teuchos_StandardParameterEntryValidators.hpp"
+
+/// \file Ifpack2_Details_Chebyshev_Weights.hpp
+/// \brief Definition of Chebyshev implementation
+/// \author Malachi Phillips
+///
+/// This file is meant for Ifpack2 developers only, not for users.
+/// It defines the weights needed for fourth kind Chebyshev polynomials
+/// with optimal weights. See: https://arxiv.org/pdf/2202.08830.pdf for details.
+
+
+namespace Ifpack2 {
+namespace Details {
+
+  /// \brief Generate optimal weights for using the fourth kind Chebyshev polynomials
+  ///   see:
+  ///    https://arxiv.org/pdf/2202.08830.pdf
+  ///   for details.
+  ///
+  /// \pre 0 < numIters <= 16 -- this is an arbitrary distinction,
+  ///      but the weights are currently hard-coded from the
+  ///      MATLAB scripts from https://arxiv.org/pdf/2202.08830.pdf.
+  ///
+  /// \param numIters [in] Number of Chebyshev iterations.
+  template<typename ScalarType>
+  std::vector<ScalarType>
+  optimalWeightsImpl (const int numIters)
+  {
+    if (numIters == 0){
+      return {};
+    }
+    if (numIters == 1){
+      return {
+          1.12500000000000,
+      };
+    }
+
+    if (numIters == 2){
+      return {
+          1.02387287570313,
+          1.26408905371085,
+      };
+    }
+
+    if (numIters == 3){
+      return {
+          1.00842544782028,
+          1.08867839208730,
+          1.33753125909618,
+      };
+    }
+
+    if (numIters == 4){
+      return {
+          1.00391310427285,
+          1.04035811188593,
+          1.14863498546254,
+          1.38268869241000,
+      };
+    }
+
+    if (numIters == 5){
+      return {
+          1.00212930146164,
+          1.02173711549260,
+          1.07872433192603,
+          1.19810065292663,
+          1.41322542791682,
+      };
+    }
+
+    if (numIters == 6){
+      return {
+          1.00128517255940,
+          1.01304293035233,
+          1.04678215124113,
+          1.11616489419675,
+          1.23829020218444,
+          1.43524297106744,
+      };
+    }
+
+    if (numIters == 7){
+      return {
+          1.00083464397912,
+          1.00843949430122,
+          1.03008707768713,
+          1.07408384092003,
+          1.15036186707366,
+          1.27116474046139,
+          1.45186658649364,
+      };
+    }
+
+    if (numIters == 8){
+      return {
+          1.00057246631197,
+          1.00577427662415,
+          1.02050187922941,
+          1.05019803444565,
+          1.10115572984941,
+          1.18086042806856,
+          1.29838585382576,
+          1.46486073151099,
+      };
+    }
+
+    if (numIters == 9){
+      return {
+          1.00040960072832,
+          1.00412439506106,
+          1.01460212148266,
+          1.03561113626671,
+          1.07139972529194,
+          1.12688273710962,
+          1.20785219140729,
+          1.32121930716746,
+          1.47529642820699,
+      };
+    }
+
+    if (numIters == 10){
+      return {
+          1.00030312229652,
+          1.00304840660796,
+          1.01077022715387,
+          1.02619011597640,
+          1.05231724933755,
+          1.09255743207549,
+          1.15083376663972,
+          1.23172250870894,
+          1.34060802024460,
+          1.48386124407011,
+      };
+    }
+
+    if (numIters == 11){
+      return {
+          1.00023058595209,
+          1.00231675024028,
+          1.00817245396304,
+          1.01982986566342,
+          1.03950210235324,
+          1.06965042700541,
+          1.11305754295742,
+          1.17290876275564,
+          1.25288300576792,
+          1.35725579919519,
+          1.49101672564139,
+      };
+    }
+
+    if (numIters == 12){
+      return {
+          1.00017947200828,
+          1.00180189139619,
+          1.00634861907307,
+          1.01537864566306,
+          1.03056942830760,
+          1.05376019693943,
+          1.08699862592072,
+          1.13259183097913,
+          1.19316273358172,
+          1.27171293675110,
+          1.37169337969799,
+          1.49708418575562,
+      };
+    }
+
+    if (numIters == 13){
+      return {
+          1.00014241921559,
+          1.00142906932629,
+          1.00503028986298,
+          1.01216910518495,
+          1.02414874342792,
+          1.04238158880820,
+          1.06842008128700,
+          1.10399010936759,
+          1.15102748242645,
+          1.21171811910125,
+          1.28854264865128,
+          1.38432619380991,
+          1.50229418757368,
+      };
+    }
+
+    if (numIters == 14){
+      return {
+          1.00011490538261,
+          1.00115246376914,
+          1.00405357333264,
+          1.00979590573153,
+          1.01941300472994,
+          1.03401425035436,
+          1.05480599606629,
+          1.08311420301813,
+          1.12040891660892,
+          1.16833095655446,
+          1.22872122288238,
+          1.30365305707817,
+          1.39546814053678,
+          1.50681646209583,
+      };
+    }
+
+    if (numIters == 15){
+      return {
+          1.00009404750752,
+          1.00094291696343,
+          1.00331449056444,
+          1.00800294833816,
+          1.01584236259140,
+          1.02772083317705,
+          1.04459535422831,
+          1.06750761206125,
+          1.09760092545889,
+          1.13613855366157,
+          1.18452361426236,
+          1.24432087304475,
+          1.31728069083392,
+          1.40536543893560,
+          1.51077872501845,
+      };
+    }
+
+    if (numIters == 16){
+      return {
+          1.00007794828179,
+          1.00078126847253,
+          1.00274487974401,
+          1.00662291017015,
+          1.01309858836971,
+          1.02289448329337,
+          1.03678321409983,
+          1.05559875719896,
+          1.08024848405560,
+          1.11172607131497,
+          1.15112543431072,
+          1.19965584614973,
+          1.25865841744946,
+          1.32962412656664,
+          1.41421360695576,
+          1.51427891730346,
+      };
+    }
+
+    TEUCHOS_TEST_FOR_EXCEPTION(
+      true, std::runtime_error, "Ifpack2::Details::optimalWeightsImpl::"
+        "Requested Chebyshev iterations exceeds maximum of 16."
+      );
+  }
+
+} // namespace Details
+} // namespace Ifpack2
+
+#endif // IFPACK2_DETAILS_CHEBYSHEV_WEIGHTS_HPP

--- a/packages/ifpack2/src/Ifpack2_Details_Chebyshev_Weights.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Chebyshev_Weights.hpp
@@ -65,32 +65,32 @@ namespace Details {
   ///    https://arxiv.org/pdf/2202.08830.pdf
   ///   for details.
   ///
-  /// \pre 0 < numIters <= 16 -- this is an arbitrary distinction,
+  /// \pre 0 < chebyOrder <= 16 -- this is an arbitrary distinction,
   ///      but the weights are currently hard-coded from the
   ///      MATLAB scripts from https://arxiv.org/pdf/2202.08830.pdf.
   ///
-  /// \param numIters [in] Number of Chebyshev iterations.
+  /// \param chebyOrder [in] Number of Chebyshev iterations.
   template<typename ScalarType>
   std::vector<ScalarType>
-  optimalWeightsImpl (const int numIters)
+  optimalWeightsImpl (const int chebyOrder)
   {
-    if (numIters == 0){
+    if (chebyOrder == 0){
       return {};
     }
-    if (numIters == 1){
+    if (chebyOrder == 1){
       return {
           1.12500000000000,
       };
     }
 
-    if (numIters == 2){
+    if (chebyOrder == 2){
       return {
           1.02387287570313,
           1.26408905371085,
       };
     }
 
-    if (numIters == 3){
+    if (chebyOrder == 3){
       return {
           1.00842544782028,
           1.08867839208730,
@@ -98,7 +98,7 @@ namespace Details {
       };
     }
 
-    if (numIters == 4){
+    if (chebyOrder == 4){
       return {
           1.00391310427285,
           1.04035811188593,
@@ -107,7 +107,7 @@ namespace Details {
       };
     }
 
-    if (numIters == 5){
+    if (chebyOrder == 5){
       return {
           1.00212930146164,
           1.02173711549260,
@@ -117,7 +117,7 @@ namespace Details {
       };
     }
 
-    if (numIters == 6){
+    if (chebyOrder == 6){
       return {
           1.00128517255940,
           1.01304293035233,
@@ -128,7 +128,7 @@ namespace Details {
       };
     }
 
-    if (numIters == 7){
+    if (chebyOrder == 7){
       return {
           1.00083464397912,
           1.00843949430122,
@@ -140,7 +140,7 @@ namespace Details {
       };
     }
 
-    if (numIters == 8){
+    if (chebyOrder == 8){
       return {
           1.00057246631197,
           1.00577427662415,
@@ -153,7 +153,7 @@ namespace Details {
       };
     }
 
-    if (numIters == 9){
+    if (chebyOrder == 9){
       return {
           1.00040960072832,
           1.00412439506106,
@@ -167,7 +167,7 @@ namespace Details {
       };
     }
 
-    if (numIters == 10){
+    if (chebyOrder == 10){
       return {
           1.00030312229652,
           1.00304840660796,
@@ -182,7 +182,7 @@ namespace Details {
       };
     }
 
-    if (numIters == 11){
+    if (chebyOrder == 11){
       return {
           1.00023058595209,
           1.00231675024028,
@@ -198,7 +198,7 @@ namespace Details {
       };
     }
 
-    if (numIters == 12){
+    if (chebyOrder == 12){
       return {
           1.00017947200828,
           1.00180189139619,
@@ -215,7 +215,7 @@ namespace Details {
       };
     }
 
-    if (numIters == 13){
+    if (chebyOrder == 13){
       return {
           1.00014241921559,
           1.00142906932629,
@@ -233,7 +233,7 @@ namespace Details {
       };
     }
 
-    if (numIters == 14){
+    if (chebyOrder == 14){
       return {
           1.00011490538261,
           1.00115246376914,
@@ -252,7 +252,7 @@ namespace Details {
       };
     }
 
-    if (numIters == 15){
+    if (chebyOrder == 15){
       return {
           1.00009404750752,
           1.00094291696343,
@@ -272,7 +272,7 @@ namespace Details {
       };
     }
 
-    if (numIters == 16){
+    if (chebyOrder == 16){
       return {
           1.00007794828179,
           1.00078126847253,
@@ -295,7 +295,7 @@ namespace Details {
 
     TEUCHOS_TEST_FOR_EXCEPTION(
       true, std::runtime_error, "Ifpack2::Details::optimalWeightsImpl::"
-        "Requested Chebyshev iterations exceeds maximum of 16."
+        "Requested Chebyshev order exceeds maximum of 16."
       );
   }
 

--- a/packages/ifpack2/src/Ifpack2_Details_Chebyshev_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Chebyshev_decl.hpp
@@ -510,7 +510,7 @@ private:
   bool assumeMatrixUnchanged_;
 
   //! Chebyshev type
-  std::string chebyshevKind_;
+  std::string chebyshevAlgorithm_;
 
   //! Whether apply() will compute and return the max residual norm.
   bool computeMaxResNorm_;

--- a/packages/ifpack2/src/Ifpack2_Details_Chebyshev_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Chebyshev_decl.hpp
@@ -76,6 +76,7 @@ class ChebyshevKernel; // forward declaration
 /// <ol>
 /// <li> A direct imitation of Ifpack's implementation </li>
 /// <li> A textbook version of the algorithm </li>
+/// <li> Chebyshev polynomials of the 4th kind, using optimal coefficients </li>
 /// </ol>
 ///
 /// All implemented variants use the diagonal of the matrix to
@@ -88,7 +89,9 @@ class ChebyshevKernel; // forward declaration
 /// Linear Systems," 2nd edition.  Experiments show that the Ifpack
 /// imitation is much less sensitive to the eigenvalue bounds than the
 /// textbook version, so users should prefer it.  (In fact, it is the
-/// default.)
+/// default.) Variant #3 is an experimental implementation of Chebyshev
+/// polynomials of the 4th kind with optimal coefficients,
+/// from https://arxiv.org/pdf/2202.08830.pdf.
 ///
 /// We require that the matrix A be real valued and symmetric positive
 /// definite.  If users could provide the ellipse parameters ("d" and
@@ -509,6 +512,9 @@ private:
   //! Whether to use the textbook version of the algorithm.
   bool textbookAlgorithm_;
 
+  //! Whether to use Chebyshev polynomials of the 4th kind with optimal weights.
+  bool fourthKindAlgorithm_;
+
   //! Whether apply() will compute and return the max residual norm.
   bool computeMaxResNorm_;
 
@@ -633,6 +639,34 @@ private:
                      const ST lambdaMin,
                      const ST eigRatio,
                      const V& D_inv) const;
+
+  /// \brief Solve AX=B for X with Chebyshev iteration with left
+  ///   diagonal scaling, using the fourth kind Chebyshev polynomials
+  ///   with optimal weights, see:
+  ///    https://arxiv.org/pdf/2202.08830.pdf
+  ///   for details.
+  ///
+  /// \pre A must be real-valued and symmetric positive definite.
+  /// \pre numIters <= 16 -- this is an arbitrary distinction,
+  ///      but the weights are currently hard-coded from the
+  ///      MATLAB scripts from https://arxiv.org/pdf/2202.08830.pdf.
+  /// \pre 0 < lambdaMax
+  /// \pre All entries of D_inv are positive.
+  ///
+  /// \param A [in] The matrix A in the linear system to solve.
+  /// \param B [in] Right-hand side(s) in the linear system to solve.
+  /// \param X [in] Initial guess(es) for the linear system to solve.
+  /// \param numIters [in] Number of Chebyshev iterations.
+  /// \param lambdaMax [in] Estimate of max eigenvalue of A.
+  /// \param D_inv [in] Vector of diagonal entries of A.  It must have
+  ///   the same distribution as B.
+  void
+  fourthKindApplyImpl (const op_type& A,
+                       const MV& B,
+                       MV& X,
+                       const int numIters,
+                       const ST lambdaMax,
+                       const V& D_inv) const;
 
   /// \brief Solve AX=B for X with Chebyshev iteration with left
   ///   diagonal scaling, imitating Ifpack's implementation.

--- a/packages/ifpack2/src/Ifpack2_Details_Chebyshev_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Chebyshev_decl.hpp
@@ -646,7 +646,7 @@ private:
 
   /// \brief Solve AX=B for X with Chebyshev iteration with left
   ///   diagonal scaling, using the fourth kind Chebyshev polynomials
-  ///   with optimal weights, see:
+  ///   (optionally) with optimal weights, see:
   ///    https://arxiv.org/pdf/2202.08830.pdf
   ///   for details.
   ///

--- a/packages/ifpack2/src/Ifpack2_Details_Chebyshev_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Chebyshev_decl.hpp
@@ -515,6 +515,10 @@ private:
   //! Whether to use Chebyshev polynomials of the 4th kind with optimal weights.
   bool fourthKindAlgorithm_;
 
+  //! Whether to use optimal weights for the Chebyshev polynomial.
+  //  Only applicable when using the Chebyshev polynomials of the 4th kind.
+  bool useOptimalWeights_;
+
   //! Whether apply() will compute and return the max residual norm.
   bool computeMaxResNorm_;
 

--- a/packages/ifpack2/src/Ifpack2_Details_Chebyshev_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Chebyshev_decl.hpp
@@ -663,7 +663,7 @@ private:
                        MV& X,
                        const int numIters,
                        const ST lambdaMax,
-                       const V& D_inv) const;
+                       const V& D_inv);
 
   /// \brief Solve AX=B for X with Chebyshev iteration with left
   ///   diagonal scaling, imitating Ifpack's implementation.

--- a/packages/ifpack2/src/Ifpack2_Details_Chebyshev_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Chebyshev_decl.hpp
@@ -644,7 +644,8 @@ private:
   ///   for details.
   ///
   /// \pre A must be real-valued and symmetric positive definite.
-  /// \pre numIters <= 16 -- this is an arbitrary distinction,
+  /// \pre numIters <= 16 if using the opt. 4th-kind Chebyshev smoothers
+  ///      -- this is an arbitrary distinction,
   ///      but the weights are currently hard-coded from the
   ///      MATLAB scripts from https://arxiv.org/pdf/2202.08830.pdf.
   /// \pre 0 < lambdaMax

--- a/packages/ifpack2/src/Ifpack2_Details_Chebyshev_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Chebyshev_decl.hpp
@@ -509,15 +509,8 @@ private:
   /// which we have not yet computed before.
   bool assumeMatrixUnchanged_;
 
-  //! Whether to use the textbook version of the algorithm.
-  bool textbookAlgorithm_;
-
-  //! Whether to use Chebyshev polynomials of the 4th kind with optimal weights.
-  bool fourthKindAlgorithm_;
-
-  //! Whether to use optimal weights for the Chebyshev polynomial.
-  //  Only applicable when using the Chebyshev polynomials of the 4th kind.
-  bool useOptimalWeights_;
+  //! Chebyshev type
+  std::string chebyshevKind_;
 
   //! Whether apply() will compute and return the max residual norm.
   bool computeMaxResNorm_;

--- a/packages/ifpack2/src/Ifpack2_Details_Chebyshev_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Chebyshev_def.hpp
@@ -650,11 +650,17 @@ setParameters (Teuchos::ParameterList& plist)
       "Ifpack2::Chebyshev: Ifpack2 only supports \"first\", \"textbook\", \"fourth\", and \"opt_fourth\", for \"chebyshev: kind\".");
   }
 
-#ifndef IFPACK2_ENABLE_DEPRECATED_CODE
-  if (plist.isParameter ("chebyshev: textbook algorithm")) {
-    const bool textbookAlgorithm = plist.get<bool> ("chebyshev: textbook algorithm");
-    if(textbookAlgorithm){
-      chebyshevKind = "textbook";
+#ifdef IFPACK2_ENABLE_DEPRECATED_CODE
+  // to preserve behavior with previous input decks, only read "chebyshev:textbook algorithm" setting
+  // if a user has not specified "chebyshev: kind"
+  if (!plist.isParameter ("chebyshev: kind")) {
+    if (plist.isParameter ("chebyshev: textbook algorithm")) {
+      const bool textbookAlgorithm = plist.get<bool> ("chebyshev: textbook algorithm");
+      if(textbookAlgorithm){
+        chebyshevKind = "textbook";
+      } else {
+        chebyshevKind = "first";
+      }
     }
   }
 #endif

--- a/packages/ifpack2/src/Ifpack2_Details_Chebyshev_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Chebyshev_def.hpp
@@ -1666,7 +1666,8 @@ description () const {
       << ", lambdaMax: " << lambdaMaxForApply_
       << ", alpha: " << eigRatioForApply_
       << ", lambdaMin: " << lambdaMinForApply_
-      << ", boost factor: " << boostFactor_;
+      << ", boost factor: " << boostFactor_
+      << ", algorithm: " << chebyshevAlgorithm_;
   if (!userInvDiag_.is_null())
     oss << ", diagonal: user-supplied";
   oss << "}";

--- a/packages/ifpack2/src/Ifpack2_Details_Chebyshev_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Chebyshev_def.hpp
@@ -1329,7 +1329,7 @@ fourthKindApplyImpl (const op_type& A,
                      const V& D_inv) const
 {
   // standard 4th kind Chebyshev smoother has \beta_i := 1
-  std::vector<ScalarType> betas(numIters, 1.0)
+  std::vector<ScalarType> betas(numIters, 1.0);
   if(useOptimalWeights_){
     betas = optimalWeightsImpl<ScalarType>(numIters);
   }
@@ -1337,6 +1337,7 @@ fourthKindApplyImpl (const op_type& A,
   const ST zero = Teuchos::as<ST> (0);
   const ST one = Teuchos::as<ST> (1);
   const ST mone = Teuchos::as<ST> (-1);
+  const ST invEig = 1.0 / (lambdaMax * boostFactor_);
 
   if (zeroStartingSolution_) {
     X.putScalar (zero);
@@ -1355,7 +1356,7 @@ fourthKindApplyImpl (const op_type& A,
 
   for (int i = 0; i < numIters; ++i) {
     const ST zScale = (2.0 * i - 1.0) / (2.0 * i + 3.0);
-    const ST rScale = (8.0 * i + 4.0) / (2.0 * i + 3.0) / lambdaMax;
+    const ST rScale = (8.0 * i + 4.0) / (2.0 * i + 3.0) * invEig;
 
     solve (P, D_inv, R); // P = D_inv * R, that is, D \ R.
 
@@ -1365,7 +1366,7 @@ fourthKindApplyImpl (const op_type& A,
     // X = X + betas[i] * Z
     X.update(betas[i], Z, one);
 
-    // R = R - A*Z (not really the residual!)
+    // R = R - A*Z
     A.apply(Z, P);
 
     R.update(mone, P, one);

--- a/packages/ifpack2/src/Ifpack2_Details_Chebyshev_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Chebyshev_def.hpp
@@ -1337,9 +1337,6 @@ fourthKindApplyImpl (const op_type& A,
     betas = optimalWeightsImpl<ScalarType>(numIters);
   }
 
-  const ST zero = Teuchos::as<ST> (0);
-  const ST one = Teuchos::as<ST> (1);
-  const ST mone = Teuchos::as<ST> (-1);
   const ST invEig = 1.0 / (lambdaMax * boostFactor_);
 
   // Fetch cached temporary (multi)vector.
@@ -1347,8 +1344,7 @@ fourthKindApplyImpl (const op_type& A,
   MV& Z = *Z_ptr;
   
   // Store 4th-kind result (needed as temporary for bootstrapping opt. 4th-kind Chebyshev)
-  Teuchos::RCP<MV> X4_ptr = makeTempMultiVector (B);
-  MV& X4 = *X4_ptr;
+  MV X4 (B.getMap (), B.getNumVectors (), false);
   
   // Special case for the first iteration.
   if (! zeroStartingSolution_) {
@@ -1363,7 +1359,7 @@ fourthKindApplyImpl (const op_type& A,
     // Z := (4/3 * invEig)*D_inv*(B-A*X4)
     // X4 := X4 + Z
     ck_->compute (Z, 4.0/3.0 * invEig, const_cast<V&> (D_inv),
-                   const_cast<MV&> (B), X4, zero);
+                   const_cast<MV&> (B), X4, STS::zero());
 
     // X := X + beta[0] * Z
     X.update (betas[0], Z, STS::one());

--- a/packages/ifpack2/src/Ifpack2_Details_Chebyshev_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Chebyshev_def.hpp
@@ -1342,9 +1342,8 @@ fourthKindApplyImpl (const op_type& A,
   }
 
   for (int i = 0; i < numIters; ++i) {
-    const auto index = i+1;
-    const ST zScale = (2 * index - 3) / (2 * index + 1);
-    const ST rScale = (8 * index - 4.0) / (2 * index + 1) / lambdaMax;
+    const ST zScale = (2.0 * i - 1.0) / (2.0 * i + 3.0);
+    const ST rScale = (8.0 * i + 4.0) / (2.0 * i + 3.0) / lambdaMax;
 
     solve (P, D_inv, R); // P = D_inv * R, that is, D \ R.
 

--- a/packages/ifpack2/src/Ifpack2_Details_Chebyshev_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Chebyshev_def.hpp
@@ -307,6 +307,7 @@ Chebyshev (Teuchos::RCP<const row_matrix_type> A) :
   assumeMatrixUnchanged_ (false),
   textbookAlgorithm_ (false),
   fourthKindAlgorithm_ (false),
+  useOptimalWeights_ (false),
   computeMaxResNorm_ (false),
   computeSpectralRadius_(true),
   ckUseNativeSpMV_(false),
@@ -341,6 +342,7 @@ Chebyshev (Teuchos::RCP<const row_matrix_type> A,
   assumeMatrixUnchanged_ (false),
   textbookAlgorithm_ (false),
   fourthKindAlgorithm_ (false),
+  useOptimalWeights_ (false),
   computeMaxResNorm_ (false),
   computeSpectralRadius_(true),
   ckUseNativeSpMV_(false),
@@ -389,6 +391,7 @@ setParameters (Teuchos::ParameterList& plist)
   const bool defaultAssumeMatrixUnchanged = false;
   const bool defaultTextbookAlgorithm = false;
   const bool defaultFourthKindAlgorithm = false;
+  const bool defaultUseOptimalWeights = false;
   const bool defaultComputeMaxResNorm = false;
   const bool defaultComputeSpectralRadius = true;
   const bool defaultCkUseNativeSpMV = false;
@@ -413,6 +416,7 @@ setParameters (Teuchos::ParameterList& plist)
   bool assumeMatrixUnchanged = defaultAssumeMatrixUnchanged;
   bool textbookAlgorithm = defaultTextbookAlgorithm;
   bool fourthKindAlgorithm = defaultFourthKindAlgorithm;
+  bool useOptimalWeights = defaultUseOptimalWeights;
   bool computeMaxResNorm = defaultComputeMaxResNorm;
   bool computeSpectralRadius = defaultComputeSpectralRadius;
   bool ckUseNativeSpMV = defaultCkUseNativeSpMV;
@@ -649,6 +653,9 @@ setParameters (Teuchos::ParameterList& plist)
   if (plist.isParameter ("chebyshev: fourth kind algorithm")) {
     fourthKindAlgorithm = plist.get<bool> ("chebyshev: fourth kind algorithm");
   }
+  if (plist.isParameter ("chebyshev: use optimal weights")) {
+    useOptimalWeights = plist.get<bool> ("chebyshev: use optimal weights");
+  }
   if (plist.isParameter ("chebyshev: compute max residual norm")) {
     computeMaxResNorm = plist.get<bool> ("chebyshev: compute max residual norm");
   }
@@ -709,6 +716,7 @@ setParameters (Teuchos::ParameterList& plist)
   assumeMatrixUnchanged_ = assumeMatrixUnchanged;
   textbookAlgorithm_ = textbookAlgorithm;
   fourthKindAlgorithm_ = fourthKindAlgorithm;
+  useOptimalWeights_ = useOptimalWeights;
   computeMaxResNorm_ = computeMaxResNorm;
   computeSpectralRadius_ = computeSpectralRadius;
   ckUseNativeSpMV_ = ckUseNativeSpMV;
@@ -1321,6 +1329,11 @@ fourthKindApplyImpl (const op_type& A,
                      const V& D_inv) const
 {
   const auto betas = optimalWeightsImpl<ScalarType>(numIters);
+
+  // standard 4th kind Chebyshev smoother has \beta_i := 1
+  if(!useOptimalWeights_){
+    std::fill(betas.begin(), betas.end(), 1.0);
+  }
 
   const ST zero = Teuchos::as<ST> (0);
   const ST one = Teuchos::as<ST> (1);

--- a/packages/ifpack2/src/Ifpack2_Details_Chebyshev_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Chebyshev_def.hpp
@@ -1328,7 +1328,7 @@ fourthKindApplyImpl (const op_type& A,
                      const ST lambdaMax,
                      const V& D_inv) const
 {
-  const auto betas = optimalWeightsImpl<ScalarType>(numIters);
+  auto betas = optimalWeightsImpl<ScalarType>(numIters);
 
   // standard 4th kind Chebyshev smoother has \beta_i := 1
   if(!useOptimalWeights_){

--- a/packages/ifpack2/src/Ifpack2_Details_Chebyshev_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Chebyshev_def.hpp
@@ -1328,11 +1328,10 @@ fourthKindApplyImpl (const op_type& A,
                      const ST lambdaMax,
                      const V& D_inv) const
 {
-  auto betas = optimalWeightsImpl<ScalarType>(numIters);
-
   // standard 4th kind Chebyshev smoother has \beta_i := 1
-  if(!useOptimalWeights_){
-    std::fill(betas.begin(), betas.end(), 1.0);
+  std::vector<ScalarType> betas(numIters, 1.0)
+  if(useOptimalWeights_){
+    betas = optimalWeightsImpl<ScalarType>(numIters);
   }
 
   const ST zero = Teuchos::as<ST> (0);

--- a/packages/ifpack2/src/Ifpack2_Details_Chebyshev_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Chebyshev_def.hpp
@@ -639,21 +639,21 @@ setParameters (Teuchos::ParameterList& plist)
 
   // We don't want to fill these parameters in, because they shouldn't
   // be visible to Ifpack2::Chebyshev users.
-  if (plist.isParameter ("chebyshev: kind")) {
-    chebyshevKind = plist.get<std::string> ("chebyshev: kind");
+  if (plist.isParameter ("chebyshev: algorithm")) {
+    chebyshevKind = plist.get<std::string> ("chebyshev: algorithm");
     TEUCHOS_TEST_FOR_EXCEPTION(
       chebyshevKind != "first" &&
       chebyshevKind != "textbook" &&
       chebyshevKind != "fourth" &&
       chebyshevKind != "opt_fourth",
       std::invalid_argument,
-      "Ifpack2::Chebyshev: Ifpack2 only supports \"first\", \"textbook\", \"fourth\", and \"opt_fourth\", for \"chebyshev: kind\".");
+      "Ifpack2::Chebyshev: Ifpack2 only supports \"first\", \"textbook\", \"fourth\", and \"opt_fourth\", for \"chebyshev: algorithm\".");
   }
 
 #ifdef IFPACK2_ENABLE_DEPRECATED_CODE
   // to preserve behavior with previous input decks, only read "chebyshev:textbook algorithm" setting
-  // if a user has not specified "chebyshev: kind"
-  if (!plist.isParameter ("chebyshev: kind")) {
+  // if a user has not specified "chebyshev: algorithm"
+  if (!plist.isParameter ("chebyshev: algorithm")) {
     if (plist.isParameter ("chebyshev: textbook algorithm")) {
       const bool textbookAlgorithm = plist.get<bool> ("chebyshev: textbook algorithm");
       if(textbookAlgorithm){

--- a/packages/ifpack2/src/Ifpack2_Details_Chebyshev_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Chebyshev_def.hpp
@@ -1787,6 +1787,8 @@ describe (Teuchos::FancyOStream& out,
           << "zeroStartingSolution_: " << zeroStartingSolution_ << endl
           << "assumeMatrixUnchanged_: " << assumeMatrixUnchanged_ << endl
           << "textbookAlgorithm_: " << textbookAlgorithm_ << endl
+          << "fourthKindAlgorithm_: " << fourthKindAlgorithm_ << endl
+          << "useOptimalWeights_: " << useOptimalWeights_ << endl
           << "computeMaxResNorm_: " << computeMaxResNorm_ << endl;
     }
   } // print user parameters

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestChebyshev2.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestChebyshev2.cpp
@@ -498,7 +498,7 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
 
   // Run Ifpack2's 4th-kind Chebyshev.
   x.putScalar (zero); // Reset the initial guess(es).
-  params.set ("chebyshev: kind", "fourth");
+  params.set ("chebyshev: algorithm", "fourth");
   ifpack2FourthCheby.setParameters (params);
   ifpack2FourthCheby.initialize ();
   ifpack2FourthCheby.compute ();
@@ -510,7 +510,7 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
 
   // Run our custom version of Chebyshev.
   x.putScalar (zero); // Reset the initial guess(es).
-  params.set ("chebyshev: kind", "textbook");
+  params.set ("chebyshev: algorithm", "textbook");
   myCheby.setParameters (params);
   myCheby.compute ();
   (void) myCheby.apply (b, x);
@@ -537,7 +537,7 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
   ////////////////////////////////////////////////////////////////////
 
   // Reset parameters.
-  params.set ("chebyshev: kind", "first");
+  params.set ("chebyshev: algorithm", "first");
   params.set ("chebyshev: min eigenvalue", lambdaMin);
   params.set ("chebyshev: ratio eigenvalue", eigRatio);
 
@@ -553,7 +553,7 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
 
   // Run 4th-kind Chebyshev
   x.putScalar (zero); // Reset the initial guess(es).
-  params.set ("chebyshev: kind", "fourth");
+  params.set ("chebyshev: algorithm", "fourth");
   ifpack2FourthCheby.setParameters (params);
   ifpack2FourthCheby.compute ();
   ifpack2FourthCheby.apply (b, x);
@@ -564,7 +564,7 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
 
   // Run our custom version of Chebyshev.
   x.putScalar (zero); // Reset the initial guess(es).
-  params.set ("chebyshev: kind", "textbook");
+  params.set ("chebyshev: algorithm", "textbook");
   myCheby.setParameters (params);
   myCheby.compute ();
   (void) myCheby.apply (b, x);
@@ -586,7 +586,7 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
       << "- CG:                         " << maxResNormCg / maxInitResNorm << endl;
 
   // Reset parameters.
-  params.set ("chebyshev: kind", "first");
+  params.set ("chebyshev: algorithm", "first");
   // ParameterList is NOT a delta.  That is, if we remove these
   // parameters from the list, setParameters() will use default
   // values, rather than letting the current settings remain.
@@ -617,7 +617,7 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
   
   // Run Ifpack2's 4th-kind Chebyshev.
   x.putScalar (zero); // Reset the initial guess(es).
-  params.set ("chebyshev: kind", "fourth");
+  params.set ("chebyshev: algorithm", "fourth");
   ifpack2FourthCheby.setParameters (params);
   ifpack2FourthCheby.initialize ();
   ifpack2FourthCheby.compute ();
@@ -629,7 +629,7 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
 
   // Run our custom version of Chebyshev.
   x.putScalar (zero); // Reset the initial guess(es).
-  params.set ("chebyshev: kind", "textbook");
+  params.set ("chebyshev: algorithm", "textbook");
   myCheby.setParameters (params);
   myCheby.compute ();
   (void) myCheby.apply (b, x);
@@ -651,7 +651,7 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
       << "- CG:                         " << maxResNormCg / maxInitResNorm << endl;
 
   // Reset parameters.
-  params.set ("chebyshev: kind", "first");
+  params.set ("chebyshev: algorithm", "first");
 
   ////////////////////////////////////////////////////////////////////
   // Test 4: set lambdaMax exactly, and set eigRatio = 30 (Ifpack's
@@ -675,7 +675,7 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
 
   // Run Ifpack2's 4th-kind Chebyshev.
   x.putScalar (zero); // Reset the initial guess(es).
-  params.set ("chebyshev: kind", "fourth");
+  params.set ("chebyshev: algorithm", "fourth");
   ifpack2FourthCheby.setParameters (params);
   ifpack2FourthCheby.initialize ();
   ifpack2FourthCheby.compute ();
@@ -687,7 +687,7 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
 
   // Run our custom version of Chebyshev.
   x.putScalar (zero); // Reset the initial guess(es).
-  params.set ("chebyshev: kind", "textbook");
+  params.set ("chebyshev: algorithm", "textbook");
   myCheby.setParameters (params);
   myCheby.compute ();
   (void) myCheby.apply (b, x);
@@ -709,7 +709,7 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
       << "- CG:                         " << maxResNormCg / maxInitResNorm << endl;
 
   // Reset parameters to their original values.
-  params.set ("chebyshev: kind", "first");
+  params.set ("chebyshev: algorithm", "first");
   params.remove ("chebyshev: ratio eigenvalue", false);
   eigRatio = lambdaMax / lambdaMin;
 
@@ -734,7 +734,7 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
 
   // Run Ifpack2's 4th-kind Chebyshev.
   x.putScalar (zero); // Reset the initial guess(es).
-  params.set ("chebyshev: kind", "fourth");
+  params.set ("chebyshev: algorithm", "fourth");
   ifpack2FourthCheby.setParameters (params);
   ifpack2FourthCheby.initialize ();
   ifpack2FourthCheby.compute ();
@@ -746,7 +746,7 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
 
   // Run our custom version of Chebyshev.
   x.putScalar (zero); // Reset the initial guess(es).
-  params.set ("chebyshev: kind", "textbook");
+  params.set ("chebyshev: algorithm", "textbook");
   myCheby.setParameters (params);
   myCheby.compute ();
   (void) myCheby.apply (b, x);
@@ -772,7 +772,7 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
   myCheby.print (os2);
 
   // Reset parameters.
-  params.set ("chebyshev: kind", "first");
+  params.set ("chebyshev: algorithm", "first");
 
   ////////////////////////////////////////////////////////////////////
   // Test 6: Clear lambdaMax, lambdaMin, and eigRatio.  Let the
@@ -798,7 +798,7 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
 
   // Run Ifpack2's 4th-kind Chebyshev.
   x.putScalar (zero); // Reset the initial guess(es).
-  params.set ("chebyshev: kind", "fourth");
+  params.set ("chebyshev: algorithm", "fourth");
   ifpack2FourthCheby.setParameters (params);
   ifpack2FourthCheby.initialize ();
   ifpack2FourthCheby.compute ();
@@ -810,7 +810,7 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
 
   // Run our custom version of Chebyshev.
   x.putScalar (zero); // Reset the initial guess(es).
-  params.set ("chebyshev: kind", "textbook");
+  params.set ("chebyshev: algorithm", "textbook");
   myCheby.setParameters (params);
   myCheby.compute ();
   (void) myCheby.apply (b, x);

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestChebyshev2.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestChebyshev2.cpp
@@ -498,7 +498,7 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
 
   // Run Ifpack2's 4th-kind Chebyshev.
   x.putScalar (zero); // Reset the initial guess(es).
-  params.set ("chebyshev: fourth kind algorithm", true);
+  params.set ("chebyshev: kind", "fourth");
   ifpack2FourthCheby.setParameters (params);
   ifpack2FourthCheby.initialize ();
   ifpack2FourthCheby.compute ();
@@ -510,8 +510,7 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
 
   // Run our custom version of Chebyshev.
   x.putScalar (zero); // Reset the initial guess(es).
-  params.set ("chebyshev: fourth kind algorithm", false);
-  params.set ("chebyshev: textbook algorithm", true);
+  params.set ("chebyshev: kind", "textbook");
   myCheby.setParameters (params);
   myCheby.compute ();
   (void) myCheby.apply (b, x);
@@ -538,8 +537,7 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
   ////////////////////////////////////////////////////////////////////
 
   // Reset parameters.
-  params.set ("chebyshev: fourth kind algorithm", false);
-  params.set ("chebyshev: textbook algorithm", false);
+  params.set ("chebyshev: kind", "first");
   params.set ("chebyshev: min eigenvalue", lambdaMin);
   params.set ("chebyshev: ratio eigenvalue", eigRatio);
 
@@ -555,7 +553,7 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
 
   // Run 4th-kind Chebyshev
   x.putScalar (zero); // Reset the initial guess(es).
-  params.set ("chebyshev: fourth kind algorithm", true);
+  params.set ("chebyshev: kind", "fourth");
   ifpack2FourthCheby.setParameters (params);
   ifpack2FourthCheby.compute ();
   ifpack2FourthCheby.apply (b, x);
@@ -566,8 +564,7 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
 
   // Run our custom version of Chebyshev.
   x.putScalar (zero); // Reset the initial guess(es).
-  params.set ("chebyshev: fourth kind algorithm", false);
-  params.set ("chebyshev: textbook algorithm", true);
+  params.set ("chebyshev: kind", "textbook");
   myCheby.setParameters (params);
   myCheby.compute ();
   (void) myCheby.apply (b, x);
@@ -589,7 +586,7 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
       << "- CG:                         " << maxResNormCg / maxInitResNorm << endl;
 
   // Reset parameters.
-  params.set ("chebyshev: textbook algorithm", false);
+  params.set ("chebyshev: kind", "first");
   // ParameterList is NOT a delta.  That is, if we remove these
   // parameters from the list, setParameters() will use default
   // values, rather than letting the current settings remain.
@@ -620,7 +617,7 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
   
   // Run Ifpack2's 4th-kind Chebyshev.
   x.putScalar (zero); // Reset the initial guess(es).
-  params.set ("chebyshev: fourth kind algorithm", true);
+  params.set ("chebyshev: kind", "fourth");
   ifpack2FourthCheby.setParameters (params);
   ifpack2FourthCheby.initialize ();
   ifpack2FourthCheby.compute ();
@@ -632,8 +629,7 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
 
   // Run our custom version of Chebyshev.
   x.putScalar (zero); // Reset the initial guess(es).
-  params.set ("chebyshev: fourth kind algorithm", false);
-  params.set ("chebyshev: textbook algorithm", true);
+  params.set ("chebyshev: kind", "textbook");
   myCheby.setParameters (params);
   myCheby.compute ();
   (void) myCheby.apply (b, x);
@@ -655,8 +651,7 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
       << "- CG:                         " << maxResNormCg / maxInitResNorm << endl;
 
   // Reset parameters.
-  params.set ("chebyshev: textbook algorithm", false);
-  params.set ("chebyshev: fourth kind algorithm", false);
+  params.set ("chebyshev: kind", "first");
 
   ////////////////////////////////////////////////////////////////////
   // Test 4: set lambdaMax exactly, and set eigRatio = 30 (Ifpack's
@@ -680,7 +675,7 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
 
   // Run Ifpack2's 4th-kind Chebyshev.
   x.putScalar (zero); // Reset the initial guess(es).
-  params.set ("chebyshev: fourth kind algorithm", true);
+  params.set ("chebyshev: kind", "fourth");
   ifpack2FourthCheby.setParameters (params);
   ifpack2FourthCheby.initialize ();
   ifpack2FourthCheby.compute ();
@@ -692,8 +687,7 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
 
   // Run our custom version of Chebyshev.
   x.putScalar (zero); // Reset the initial guess(es).
-  params.set ("chebyshev: fourth kind algorithm", false);
-  params.set ("chebyshev: textbook algorithm", true);
+  params.set ("chebyshev: kind", "textbook");
   myCheby.setParameters (params);
   myCheby.compute ();
   (void) myCheby.apply (b, x);
@@ -715,8 +709,7 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
       << "- CG:                         " << maxResNormCg / maxInitResNorm << endl;
 
   // Reset parameters to their original values.
-  params.set ("chebyshev: fourth kind algorithm", false);
-  params.set ("chebyshev: textbook algorithm", false);
+  params.set ("chebyshev: kind", "first");
   params.remove ("chebyshev: ratio eigenvalue", false);
   eigRatio = lambdaMax / lambdaMin;
 
@@ -741,7 +734,7 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
 
   // Run Ifpack2's 4th-kind Chebyshev.
   x.putScalar (zero); // Reset the initial guess(es).
-  params.set ("chebyshev: fourth kind algorithm", true);
+  params.set ("chebyshev: kind", "fourth");
   ifpack2FourthCheby.setParameters (params);
   ifpack2FourthCheby.initialize ();
   ifpack2FourthCheby.compute ();
@@ -753,8 +746,7 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
 
   // Run our custom version of Chebyshev.
   x.putScalar (zero); // Reset the initial guess(es).
-  params.set ("chebyshev: fourth kind algorithm", false);
-  params.set ("chebyshev: textbook algorithm", true);
+  params.set ("chebyshev: kind", "textbook");
   myCheby.setParameters (params);
   myCheby.compute ();
   (void) myCheby.apply (b, x);
@@ -780,8 +772,7 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
   myCheby.print (os2);
 
   // Reset parameters.
-  params.set ("chebyshev: fourth kind algorithm", false);
-  params.set ("chebyshev: textbook algorithm", false);
+  params.set ("chebyshev: kind", "first");
 
   ////////////////////////////////////////////////////////////////////
   // Test 6: Clear lambdaMax, lambdaMin, and eigRatio.  Let the
@@ -807,7 +798,7 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
 
   // Run Ifpack2's 4th-kind Chebyshev.
   x.putScalar (zero); // Reset the initial guess(es).
-  params.set ("chebyshev: fourth kind algorithm", true);
+  params.set ("chebyshev: kind", "fourth");
   ifpack2FourthCheby.setParameters (params);
   ifpack2FourthCheby.initialize ();
   ifpack2FourthCheby.compute ();
@@ -819,8 +810,7 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
 
   // Run our custom version of Chebyshev.
   x.putScalar (zero); // Reset the initial guess(es).
-  params.set ("chebyshev: fourth kind algorithm", false);
-  params.set ("chebyshev: textbook algorithm", true);
+  params.set ("chebyshev: kind", "textbook");
   myCheby.setParameters (params);
   myCheby.compute ();
   (void) myCheby.apply (b, x);

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestChebyshev2.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestChebyshev2.cpp
@@ -849,7 +849,7 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
   if (numEigIters >= 15) {
     const MT tol = Teuchos::as<MT> (1.0e-4);
     // Avoid division by zero when computing relative accuracy.
-    const MT relDiff = maxResNormTextbook == zero ?
+    MT relDiff = maxResNormTextbook == zero ?
       STS::magnitude (maxResNormIfpack2 - maxResNormTextbook) :
       STS::magnitude (maxResNormIfpack2 - maxResNormTextbook) / maxResNormTextbook;
     TEUCHOS_TEST_FOR_EXCEPTION(

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestChebyshev2.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestChebyshev2.cpp
@@ -469,13 +469,17 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
   params.set ("chebyshev: degree", numIters);
   params.set ("chebyshev: max eigenvalue", lambdaMax);
 
-  // Create the operators: Ifpack2, textbook Chebyshev, and custom CG.
+  // Create the operators: Ifpack2, 4th-kind Chebyshev, textbook Chebyshev, and custom CG.
   prec_type ifpack2Cheby (A);
   Ifpack2::Details::Chebyshev<ST, MV> myCheby (A);
+
+  prec_type ifpack2FourthCheby (A);
+  Ifpack2::Details::Chebyshev<ST, MV> myFourthKindCheby (A);
+
   CG<ST, MV, crs_matrix_type> cg (A);
 
   // Residual 2-norms for comparison.
-  MT maxResNormIfpack2, maxResNormTextbook, maxResNormCg;
+  MT maxResNormIfpack2, maxResNormFourthKind, maxResNormTextbook, maxResNormCg;
 
   ////////////////////////////////////////////////////////////////////
   // Test 1: set lambdaMax exactly, use default values of eigRatio and
@@ -492,8 +496,21 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
   r.norm2 (norms ());
   maxResNormIfpack2 = *std::max_element (norms.begin (), norms.end ());
 
+  // Run Ifpack2's 4th-kind Chebyshev.
+  x.putScalar (zero); // Reset the initial guess(es).
+  params.set ("chebyshev: fourth kind algorithm", true);
+  ifpack2FourthCheby.setParameters (params);
+  ifpack2FourthCheby.initialize ();
+  ifpack2FourthCheby.compute ();
+  ifpack2FourthCheby.apply (b, x);
+  r = b;
+  A->apply (x, r, Teuchos::NO_TRANS, -one, one);
+  r.norm2 (norms ());
+  maxResNormFourthKind = *std::max_element (norms.begin (), norms.end ());
+
   // Run our custom version of Chebyshev.
   x.putScalar (zero); // Reset the initial guess(es).
+  params.set ("chebyshev: fourth kind algorithm", false);
   params.set ("chebyshev: textbook algorithm", true);
   myCheby.setParameters (params);
   myCheby.compute ();
@@ -511,6 +528,7 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
   os2 << "Results with lambdaMax = " << lambdaMax
       << ", default lambdaMin and eigRatio:" << endl
       << "- Ifpack2::Chebyshev:         " << maxResNormIfpack2 / maxInitResNorm << endl
+      << "- 4th-kind Chebyshev:         " << maxResNormFourthKind / maxInitResNorm << endl
       << "- Textbook Chebyshev:         " << maxResNormTextbook / maxInitResNorm << endl
       << "- CG:                         " << maxResNormCg / maxInitResNorm << endl;
 
@@ -520,6 +538,7 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
   ////////////////////////////////////////////////////////////////////
 
   // Reset parameters.
+  params.set ("chebyshev: fourth kind algorithm", false);
   params.set ("chebyshev: textbook algorithm", false);
   params.set ("chebyshev: min eigenvalue", lambdaMin);
   params.set ("chebyshev: ratio eigenvalue", eigRatio);
@@ -534,8 +553,20 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
   r.norm2 (norms ());
   maxResNormIfpack2 = *std::max_element (norms.begin (), norms.end ());
 
+  // Run 4th-kind Chebyshev
+  x.putScalar (zero); // Reset the initial guess(es).
+  params.set ("chebyshev: fourth kind algorithm", true);
+  ifpack2FourthCheby.setParameters (params);
+  ifpack2FourthCheby.compute ();
+  ifpack2FourthCheby.apply (b, x);
+  r = b;
+  A->apply (x, r, Teuchos::NO_TRANS, -one, one);
+  r.norm2 (norms ());
+  maxResNormFourthKind = *std::max_element (norms.begin (), norms.end ());
+
   // Run our custom version of Chebyshev.
   x.putScalar (zero); // Reset the initial guess(es).
+  params.set ("chebyshev: fourth kind algorithm", false);
   params.set ("chebyshev: textbook algorithm", true);
   myCheby.setParameters (params);
   myCheby.compute ();
@@ -553,6 +584,7 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
   os2 << "Results with lambdaMax = " << lambdaMax
       << ", lambdaMin = " << lambdaMin << ", eigRatio = " << eigRatio << endl
       << "- Ifpack2::Chebyshev:         " << maxResNormIfpack2 / maxInitResNorm << endl
+      << "- 4th-kind Chebyshev:         " << maxResNormFourthKind / maxInitResNorm << endl
       << "- Textbook Chebyshev:         " << maxResNormTextbook / maxInitResNorm << endl
       << "- CG:                         " << maxResNormCg / maxInitResNorm << endl;
 
@@ -585,9 +617,22 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
   A->apply (x, r, Teuchos::NO_TRANS, -one, one);
   r.norm2 (norms ());
   maxResNormIfpack2 = *std::max_element (norms.begin (), norms.end ());
+  
+  // Run Ifpack2's 4th-kind Chebyshev.
+  x.putScalar (zero); // Reset the initial guess(es).
+  params.set ("chebyshev: fourth kind algorithm", true);
+  ifpack2FourthCheby.setParameters (params);
+  ifpack2FourthCheby.initialize ();
+  ifpack2FourthCheby.compute ();
+  ifpack2FourthCheby.apply (b, x);
+  r = b;
+  A->apply (x, r, Teuchos::NO_TRANS, -one, one);
+  r.norm2 (norms ());
+  maxResNormFourthKind = *std::max_element (norms.begin (), norms.end ());
 
   // Run our custom version of Chebyshev.
   x.putScalar (zero); // Reset the initial guess(es).
+  params.set ("chebyshev: fourth kind algorithm", false);
   params.set ("chebyshev: textbook algorithm", true);
   myCheby.setParameters (params);
   myCheby.compute ();
@@ -605,11 +650,13 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
   os2 << "Results with lambdaMax = " << lambdaMax
       << ", default lambdaMin, eigRatio = " << eigRatio << endl
       << "- Ifpack2::Chebyshev:         " << maxResNormIfpack2 / maxInitResNorm << endl
+      << "- 4th-kind Chebyshev:         " << maxResNormFourthKind / maxInitResNorm << endl
       << "- Textbook Chebyshev:         " << maxResNormTextbook / maxInitResNorm << endl
       << "- CG:                         " << maxResNormCg / maxInitResNorm << endl;
 
   // Reset parameters.
   params.set ("chebyshev: textbook algorithm", false);
+  params.set ("chebyshev: fourth kind algorithm", false);
 
   ////////////////////////////////////////////////////////////////////
   // Test 4: set lambdaMax exactly, and set eigRatio = 30 (Ifpack's
@@ -631,8 +678,21 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
   r.norm2 (norms ());
   maxResNormIfpack2 = *std::max_element (norms.begin (), norms.end ());
 
+  // Run Ifpack2's 4th-kind Chebyshev.
+  x.putScalar (zero); // Reset the initial guess(es).
+  params.set ("chebyshev: fourth kind algorithm", true);
+  ifpack2FourthCheby.setParameters (params);
+  ifpack2FourthCheby.initialize ();
+  ifpack2FourthCheby.compute ();
+  ifpack2FourthCheby.apply (b, x);
+  r = b;
+  A->apply (x, r, Teuchos::NO_TRANS, -one, one);
+  r.norm2 (norms ());
+  maxResNormFourthKind = *std::max_element (norms.begin (), norms.end ());
+
   // Run our custom version of Chebyshev.
   x.putScalar (zero); // Reset the initial guess(es).
+  params.set ("chebyshev: fourth kind algorithm", false);
   params.set ("chebyshev: textbook algorithm", true);
   myCheby.setParameters (params);
   myCheby.compute ();
@@ -650,10 +710,12 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
   os2 << "Results with lambdaMax = " << lambdaMax
       << ", default lambdaMin, eigRatio = " << eigRatio << endl
       << "- Ifpack2::Chebyshev:         " << maxResNormIfpack2 / maxInitResNorm << endl
+      << "- 4th-kind Chebyshev:         " << maxResNormFourthKind / maxInitResNorm << endl
       << "- Textbook Chebyshev:         " << maxResNormTextbook / maxInitResNorm << endl
       << "- CG:                         " << maxResNormCg / maxInitResNorm << endl;
 
   // Reset parameters to their original values.
+  params.set ("chebyshev: fourth kind algorithm", false);
   params.set ("chebyshev: textbook algorithm", false);
   params.remove ("chebyshev: ratio eigenvalue", false);
   eigRatio = lambdaMax / lambdaMin;
@@ -677,8 +739,21 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
   r.norm2 (norms ());
   maxResNormIfpack2 = *std::max_element (norms.begin (), norms.end ());
 
+  // Run Ifpack2's 4th-kind Chebyshev.
+  x.putScalar (zero); // Reset the initial guess(es).
+  params.set ("chebyshev: fourth kind algorithm", true);
+  ifpack2FourthCheby.setParameters (params);
+  ifpack2FourthCheby.initialize ();
+  ifpack2FourthCheby.compute ();
+  ifpack2FourthCheby.apply (b, x);
+  r = b;
+  A->apply (x, r, Teuchos::NO_TRANS, -one, one);
+  r.norm2 (norms ());
+  maxResNormFourthKind = *std::max_element (norms.begin (), norms.end ());
+
   // Run our custom version of Chebyshev.
   x.putScalar (zero); // Reset the initial guess(es).
+  params.set ("chebyshev: fourth kind algorithm", false);
   params.set ("chebyshev: textbook algorithm", true);
   myCheby.setParameters (params);
   myCheby.compute ();
@@ -696,6 +771,7 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
   os2 << "Results with default lambdaMax, lambdaMin, and eigRatio, "
     "with numEigIters = " << numEigIters << ":" << endl
       << "- Ifpack2::Chebyshev:         " << maxResNormIfpack2 / maxInitResNorm << endl
+      << "- 4th-kind Chebyshev:         " << maxResNormFourthKind / maxInitResNorm << endl
       << "- Textbook Chebyshev:         " << maxResNormTextbook / maxInitResNorm << endl
       << "- CG:                         " << maxResNormCg / maxInitResNorm << endl;
 
@@ -704,6 +780,7 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
   myCheby.print (os2);
 
   // Reset parameters.
+  params.set ("chebyshev: fourth kind algorithm", false);
   params.set ("chebyshev: textbook algorithm", false);
 
   ////////////////////////////////////////////////////////////////////
@@ -728,8 +805,21 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
   r.norm2 (norms ());
   maxResNormIfpack2 = *std::max_element (norms.begin (), norms.end ());
 
+  // Run Ifpack2's 4th-kind Chebyshev.
+  x.putScalar (zero); // Reset the initial guess(es).
+  params.set ("chebyshev: fourth kind algorithm", true);
+  ifpack2FourthCheby.setParameters (params);
+  ifpack2FourthCheby.initialize ();
+  ifpack2FourthCheby.compute ();
+  ifpack2FourthCheby.apply (b, x);
+  r = b;
+  A->apply (x, r, Teuchos::NO_TRANS, -one, one);
+  r.norm2 (norms ());
+  maxResNormFourthKind = *std::max_element (norms.begin (), norms.end ());
+
   // Run our custom version of Chebyshev.
   x.putScalar (zero); // Reset the initial guess(es).
+  params.set ("chebyshev: fourth kind algorithm", false);
   params.set ("chebyshev: textbook algorithm", true);
   myCheby.setParameters (params);
   myCheby.compute ();
@@ -747,11 +837,12 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
   os2 << "Results with default lambdaMax, lambdaMin, and eigRatio, "
     "with numEigIters = " << numEigIters << ":" << endl
       << "- Ifpack2::Chebyshev:         " << maxResNormIfpack2 / maxInitResNorm << endl
+      << "- 4th-kind Chebyshev:         " << maxResNormFourthKind / maxInitResNorm << endl
       << "- Textbook Chebyshev:         " << maxResNormTextbook / maxInitResNorm << endl
       << "- CG:                         " << maxResNormCg / maxInitResNorm << endl;
 
   // For this case, if there are enough eigenanalysis iterations,
-  // Ifpack2 should do quite a bit better than the textbook version of
+  // Ifpack2 (with standard and 4th-kind polynomials) should do quite a bit better than the textbook version of
   // the algorithm.  We'll be generous and say that it does "no worse"
   // than the textbook version.  We give "wiggle room" of four digits
   // for defining "no worse than."
@@ -768,6 +859,17 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
       << lambdaMax << " and default lambdaMin and eigRatio, Ifpack2::Chebyshev "
       "does quite a bit worse than the textbook version of the algorithm.  The "
       "former has a max relative residual norm of " << maxResNormIfpack2 << ", "
+      "and the latter of " << maxResNormTextbook << ".");
+    relDiff = maxResNormTextbook == zero ?
+      STS::magnitude (maxResNormFourthKind - maxResNormTextbook) :
+      STS::magnitude (maxResNormFourthKind - maxResNormTextbook) / maxResNormTextbook;
+    TEUCHOS_TEST_FOR_EXCEPTION(
+      maxResNormFourthKind > maxResNormTextbook && relDiff > tol,
+      std::runtime_error,
+      "After " << numIters << " iterations of Chebyshev, with lambdaMax = "
+      << lambdaMax << " and default lambdaMin and eigRatio, 4th-kind Ifpack2::Chebyshev "
+      "does quite a bit worse than the textbook version of the algorithm.  The "
+      "former has a max relative residual norm of " << maxResNormFourthKind << ", "
       "and the latter of " << maxResNormTextbook << ".");
   }
 

--- a/packages/muelu/test/interface/default/Output/MLsmoother4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLsmoother4_tpetra.gold
@@ -1,4 +1,5 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
 smoother -> 
@@ -6,6 +7,7 @@ smoother ->
  chebyshev: ratio eigenvalue = 20
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  chebyshev: boost factor = 1.1   [unused]
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 Build (MueLu::TentativePFactory)
@@ -42,6 +44,7 @@ smoother ->
  chebyshev: ratio eigenvalue = 20
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  chebyshev: boost factor = 1.1   [unused]
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 Build (MueLu::TentativePFactory)
@@ -80,6 +83,7 @@ smoother ->
  chebyshev: ratio eigenvalue = 20
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  chebyshev: boost factor = 1.1   [unused]
+
 Level 3
 Prolongator smoothing (MueLu::SaPFactory)
 Build (MueLu::TentativePFactory)
@@ -118,6 +122,7 @@ smoother ->
  chebyshev: ratio eigenvalue = 20
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  chebyshev: boost factor = 1.1   [unused]
+
 Level 4
 Prolongator smoothing (MueLu::SaPFactory)
 Build (MueLu::TentativePFactory)
@@ -170,13 +175,13 @@ level  rows  nnz    nnz/row  c ratio  procs
   3  371   1111   2.99     2.99         1  
   4  124   370    2.98     2.99         1  
 
-Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
+Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
-Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
+Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
 
-Smoother (level 2) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [1111, 1111], Global nnz: 3331}
+Smoother (level 2) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [1111, 1111], Global nnz: 3331}
 
-Smoother (level 3) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [371, 371], Global nnz: 1111}
+Smoother (level 3) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [371, 371], Global nnz: 1111}
 
 Smoother (level 4) pre  : <Direct> solver interface
 Smoother (level 4) post : no smoother

--- a/packages/muelu/test/interface/default/Output/default_e3d_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/default_e3d_tpetra.gold
@@ -1,9 +1,11 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
 smoother -> 
  chebyshev: ratio eigenvalue = 20
  chebyshev: boost factor = 1.1   [unused]
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -37,6 +39,7 @@ Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
 smoother -> 
  chebyshev: ratio eigenvalue = 20
  chebyshev: boost factor = 1.1   [unused]
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -83,9 +86,9 @@ level  rows  nnz    nnz/row  c ratio  procs
   1  3333  23319  7.00     3.00         1  
   2  1113  9999   8.98     2.99         1  
 
-Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
+Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
-Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [3333, 3333], Global nnz: 23319}
+Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [3333, 3333], Global nnz: 23319}
 
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother

--- a/packages/muelu/test/interface/default/Output/default_p2d_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/default_p2d_tpetra.gold
@@ -1,9 +1,11 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
 smoother -> 
  chebyshev: ratio eigenvalue = 20
  chebyshev: boost factor = 1.1   [unused]
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -37,6 +39,7 @@ Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
 smoother -> 
  chebyshev: ratio eigenvalue = 20
  chebyshev: boost factor = 1.1   [unused]
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -83,9 +86,9 @@ level  rows  nnz    nnz/row  c ratio  procs
   1  3333  9997   3.00     3.00         1  
   2  1111  3331   3.00     3.00         1  
 
-Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
+Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
-Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
+Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
 
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother

--- a/packages/muelu/test/interface/default/Output/default_p3d_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/default_p3d_tpetra.gold
@@ -1,9 +1,11 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
 smoother -> 
  chebyshev: ratio eigenvalue = 20
  chebyshev: boost factor = 1.1   [unused]
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -37,6 +39,7 @@ Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
 smoother -> 
  chebyshev: ratio eigenvalue = 20
  chebyshev: boost factor = 1.1   [unused]
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -83,9 +86,9 @@ level  rows  nnz    nnz/row  c ratio  procs
   1  3333  9997   3.00     3.00         1  
   2  1111  3331   3.00     3.00         1  
 
-Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
+Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
-Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
+Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
 
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother

--- a/packages/muelu/test/interface/default/Output/driver_drekar1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar1_np4_tpetra.gold
@@ -76,11 +76,11 @@ level  rows  nnz    nnz/row  c ratio  procs
   2  1111  3331   3.00     3.00         1  
   3  371   1111   2.99     2.99         1  
 
-Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
+Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
-Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [3335, 3335], Global nnz: 10015}
+Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [3335, 3335], Global nnz: 10015}
 
-Smoother (level 2) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [1111, 1111], Global nnz: 3331}
+Smoother (level 2) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [1111, 1111], Global nnz: 3331}
 
 Smoother (level 3) pre  : <Direct> solver interface
 Smoother (level 3) post : no smoother

--- a/packages/muelu/test/interface/default/Output/driver_drekar1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar1_tpetra.gold
@@ -196,11 +196,11 @@ level  rows  nnz    nnz/row  c ratio  procs
   2  1111  3331   3.00     3.00         1  
   3  371   1111   2.99     2.99         1  
 
-Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
+Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
-Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
+Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
 
-Smoother (level 2) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [1111, 1111], Global nnz: 3331}
+Smoother (level 2) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [1111, 1111], Global nnz: 3331}
 
 Smoother (level 3) pre  : <Direct> solver interface
 Smoother (level 3) post : no smoother

--- a/packages/muelu/test/interface/default/Output/driver_drekar2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar2_np4_tpetra.gold
@@ -78,11 +78,11 @@ level  rows  nnz    nnz/row  c ratio  procs
   2  1111  3331   3.00     3.00         1  
   3  371   1111   2.99     2.99         1  
 
-Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
+Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
-Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [3335, 3335], Global nnz: 10015}
+Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [3335, 3335], Global nnz: 10015}
 
-Smoother (level 2) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [1111, 1111], Global nnz: 3331}
+Smoother (level 2) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [1111, 1111], Global nnz: 3331}
 
 Smoother (level 3) pre  : <Direct> solver interface
 Smoother (level 3) post : no smoother

--- a/packages/muelu/test/interface/default/Output/driver_drekar2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar2_tpetra.gold
@@ -202,11 +202,11 @@ level  rows  nnz    nnz/row  c ratio  procs
   2  1111  3331   3.00     3.00         1  
   3  371   1111   2.99     2.99         1  
 
-Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
+Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
-Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
+Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
 
-Smoother (level 2) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [1111, 1111], Global nnz: 3331}
+Smoother (level 2) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [1111, 1111], Global nnz: 3331}
 
 Smoother (level 3) pre  : <Direct> solver interface
 Smoother (level 3) post : no smoother

--- a/packages/muelu/test/interface/default/Output/smoother12_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother12_tpetra.gold
@@ -1,9 +1,11 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
 smoother -> 
  chebyshev: ratio eigenvalue = 2
  chebyshev: boost factor = 1.1   [unused]
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -37,6 +39,7 @@ Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
 smoother -> 
  chebyshev: ratio eigenvalue = 5
  chebyshev: boost factor = 1.1   [unused]
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -70,6 +73,7 @@ Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
 smoother -> 
  chebyshev: ratio eigenvalue = 4
  chebyshev: boost factor = 1.1   [unused]
+
 Level 3
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -103,6 +107,7 @@ Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
 smoother -> 
  chebyshev: ratio eigenvalue = 2.99461
  chebyshev: boost factor = 1.1   [unused]
+
 Level 4
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -136,6 +141,7 @@ Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
 smoother -> 
  chebyshev: ratio eigenvalue = 2.99194
  chebyshev: boost factor = 1.1   [unused]
+
 Level 5
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -185,15 +191,15 @@ level  rows  nnz    nnz/row  c ratio  procs
   4  124   370    2.98     2.99         1  
   5  42    124    2.95     2.95         1  
 
-Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 2, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
+Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 2, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
-Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 5, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
+Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 5, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
 
-Smoother (level 2) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 4, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [1111, 1111], Global nnz: 3331}
+Smoother (level 2) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 4, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [1111, 1111], Global nnz: 3331}
 
-Smoother (level 3) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 2.99461, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [371, 371], Global nnz: 1111}
+Smoother (level 3) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 2.99461, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [371, 371], Global nnz: 1111}
 
-Smoother (level 4) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 2.99194, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [124, 124], Global nnz: 370}
+Smoother (level 4) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 2.99194, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [124, 124], Global nnz: 370}
 
 Smoother (level 5) pre  : <Direct> solver interface
 Smoother (level 5) post : no smoother

--- a/packages/muelu/test/interface/default/Output/smoother13_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother13_tpetra.gold
@@ -1,4 +1,5 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
 smoother -> 
@@ -7,6 +8,7 @@ smoother ->
 Setup Smoother (MueLu::Ifpack2Smoother{type = RILUK})
 smoother -> 
  [empty list]
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -43,6 +45,7 @@ smoother ->
 Setup Smoother (MueLu::Ifpack2Smoother{type = RILUK})
 smoother -> 
  [empty list]
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -89,10 +92,10 @@ level  rows  nnz    nnz/row  c ratio  procs
   1  3333  9997   3.00     3.00         1  
   2  1111  3331   3.00     3.00         1  
 
-Smoother (level 0) pre  : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
+Smoother (level 0) pre  : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 Smoother (level 0) post : "Ifpack2::RILUK": {Initialized: true, Computed: true, Level-of-fill: 0, Global matrix dimensions: [9999, 9999], Global nnz: 29995, "Ifpack2::LocalSparseTriangularSolver": {Label: "lower", Initialized: true, Computed: true, Matrix dimensions: [9999, 9999], Number of nonzeros: 9998}, "Ifpack2::LocalSparseTriangularSolver": {Label: "upper", Initialized: true, Computed: true, Matrix dimensions: [9999, 9999], Number of nonzeros: 9998}}
 
-Smoother (level 1) pre  : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
+Smoother (level 1) pre  : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
 Smoother (level 1) post : "Ifpack2::RILUK": {Initialized: true, Computed: true, Level-of-fill: 0, Global matrix dimensions: [3333, 3333], Global nnz: 9997, "Ifpack2::LocalSparseTriangularSolver": {Label: "lower", Initialized: true, Computed: true, Matrix dimensions: [3333, 3333], Number of nonzeros: 3332}, "Ifpack2::LocalSparseTriangularSolver": {Label: "upper", Initialized: true, Computed: true, Matrix dimensions: [3333, 3333], Number of nonzeros: 3332}}
 
 Smoother (level 2) pre  : <Direct> solver interface

--- a/packages/muelu/test/interface/default/Output/smoother5_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother5_tpetra.gold
@@ -1,9 +1,11 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
 smoother -> 
  chebyshev: ratio eigenvalue = 20
  chebyshev: boost factor = 1.1   [unused]
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -37,6 +39,7 @@ Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
 smoother -> 
  chebyshev: ratio eigenvalue = 20
  chebyshev: boost factor = 1.1   [unused]
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -83,9 +86,9 @@ level  rows  nnz    nnz/row  c ratio  procs
   1  3333  9997   3.00     3.00         1  
   2  1111  3331   3.00     3.00         1  
 
-Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
+Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
-Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
+Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
 
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother

--- a/packages/muelu/test/interface/default/Output/smoother9_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother9_tpetra.gold
@@ -1,4 +1,5 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
 smoother -> 
@@ -7,6 +8,7 @@ smoother ->
 Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
 smoother -> 
  [empty list]
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -43,6 +45,7 @@ smoother ->
 Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
 smoother -> 
  [empty list]
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 Matrix filtering (MueLu::FilteredAFactory)
@@ -89,10 +92,10 @@ level  rows  nnz    nnz/row  c ratio  procs
   1  3333  9997   3.00     3.00         1  
   2  1111  3331   3.00     3.00         1  
 
-Smoother (level 0) pre  : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
+Smoother (level 0) pre  : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 Smoother (level 0) post : "Ifpack2::ILUT": {Initialized: true, Computed: true, Level-of-fill: 1, absolute threshold: 0, relative threshold: 1, relaxation value: 0, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
-Smoother (level 1) pre  : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
+Smoother (level 1) pre  : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
 Smoother (level 1) post : "Ifpack2::ILUT": {Initialized: true, Computed: true, Level-of-fill: 1, absolute threshold: 0, relative threshold: 1, relaxation value: 0, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
 
 Smoother (level 2) pre  : <Direct> solver interface

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother4_tpetra.gold
@@ -1,4 +1,5 @@
 Clearing old data (if any)
+
 Level 0
 Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
 smoother -> 
@@ -6,6 +7,7 @@ smoother ->
  chebyshev: ratio eigenvalue = 20
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  chebyshev: boost factor = 1.1   [unused]
+
 Level 1
 Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::TentativePFactory_kokkos)
@@ -43,6 +45,7 @@ smoother ->
  chebyshev: ratio eigenvalue = 20
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  chebyshev: boost factor = 1.1   [unused]
+
 Level 2
 Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::TentativePFactory_kokkos)
@@ -82,6 +85,7 @@ smoother ->
  chebyshev: ratio eigenvalue = 20
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  chebyshev: boost factor = 1.1   [unused]
+
 Level 3
 Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::TentativePFactory_kokkos)
@@ -121,6 +125,7 @@ smoother ->
  chebyshev: ratio eigenvalue = 20
  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  chebyshev: boost factor = 1.1   [unused]
+
 Level 4
 Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::TentativePFactory_kokkos)
@@ -174,13 +179,13 @@ level  rows  nnz    nnz/row  c ratio  procs
   3  371   1111   2.99     2.99         1  
   4  124   370    2.98     2.99         1  
 
-Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
+Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
-Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
+Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
 
-Smoother (level 2) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [1111, 1111], Global nnz: 3331}
+Smoother (level 2) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [1111, 1111], Global nnz: 3331}
 
-Smoother (level 3) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [371, 371], Global nnz: 1111}
+Smoother (level 3) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [371, 371], Global nnz: 1111}
 
 Smoother (level 4) pre  : <Direct> solver interface
 Smoother (level 4) post : no smoother

--- a/packages/muelu/test/interface/kokkos/Output/default_e3d_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_e3d_tpetra.gold
@@ -82,9 +82,9 @@ level  rows  nnz    nnz/row  c ratio  procs
   1  3333  23319  7.00     3.00         1  
   2  1113  9999   8.98     2.99         1  
 
-Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
+Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
-Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [3333, 3333], Global nnz: 23319}
+Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [3333, 3333], Global nnz: 23319}
 
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother

--- a/packages/muelu/test/interface/kokkos/Output/default_p2d_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_p2d_tpetra.gold
@@ -82,9 +82,9 @@ level  rows  nnz    nnz/row  c ratio  procs
   1  3333  9997   3.00     3.00         1  
   2  1111  3331   3.00     3.00         1  
 
-Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
+Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
-Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
+Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
 
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother

--- a/packages/muelu/test/interface/kokkos/Output/default_p3d_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_p3d_tpetra.gold
@@ -82,9 +82,9 @@ level  rows  nnz    nnz/row  c ratio  procs
   1  3333  9997   3.00     3.00         1  
   2  1111  3331   3.00     3.00         1  
 
-Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
+Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
-Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
+Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
 
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar1_np4_tpetra.gold
@@ -74,11 +74,11 @@ level  rows  nnz    nnz/row  c ratio  procs
   2  1111  3331   3.00     3.00         1  
   3  371   1111   2.99     2.99         1  
 
-Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
+Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
-Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [3335, 3335], Global nnz: 10015}
+Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [3335, 3335], Global nnz: 10015}
 
-Smoother (level 2) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [1111, 1111], Global nnz: 3331}
+Smoother (level 2) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [1111, 1111], Global nnz: 3331}
 
 Smoother (level 3) pre  : <Direct> solver interface
 Smoother (level 3) post : no smoother

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar1_tpetra.gold
@@ -190,11 +190,11 @@ level  rows  nnz    nnz/row  c ratio  procs
   2  1111  3331   3.00     3.00         1  
   3  371   1111   2.99     2.99         1  
 
-Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
+Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
-Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
+Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
 
-Smoother (level 2) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [1111, 1111], Global nnz: 3331}
+Smoother (level 2) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [1111, 1111], Global nnz: 3331}
 
 Smoother (level 3) pre  : <Direct> solver interface
 Smoother (level 3) post : no smoother

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar2_np4_tpetra.gold
@@ -76,11 +76,11 @@ level  rows  nnz    nnz/row  c ratio  procs
   2  1111  3331   3.00     3.00         1  
   3  371   1111   2.99     2.99         1  
 
-Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
+Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
-Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [3335, 3335], Global nnz: 10015}
+Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [3335, 3335], Global nnz: 10015}
 
-Smoother (level 2) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [1111, 1111], Global nnz: 3331}
+Smoother (level 2) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [1111, 1111], Global nnz: 3331}
 
 Smoother (level 3) pre  : <Direct> solver interface
 Smoother (level 3) post : no smoother

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar2_tpetra.gold
@@ -196,11 +196,11 @@ level  rows  nnz    nnz/row  c ratio  procs
   2  1111  3331   3.00     3.00         1  
   3  371   1111   2.99     2.99         1  
 
-Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
+Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
-Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
+Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
 
-Smoother (level 2) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [1111, 1111], Global nnz: 3331}
+Smoother (level 2) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [1111, 1111], Global nnz: 3331}
 
 Smoother (level 3) pre  : <Direct> solver interface
 Smoother (level 3) post : no smoother

--- a/packages/muelu/test/interface/kokkos/Output/smoother12_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother12_tpetra.gold
@@ -181,15 +181,15 @@ level  rows  nnz    nnz/row  c ratio  procs
   4  124   370    2.98     2.99         1  
   5  42    124    2.95     2.95         1  
 
-Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 2, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
+Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 2, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
-Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 5, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
+Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 5, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
 
-Smoother (level 2) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 4, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [1111, 1111], Global nnz: 3331}
+Smoother (level 2) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 4, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [1111, 1111], Global nnz: 3331}
 
-Smoother (level 3) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 2.99461, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [371, 371], Global nnz: 1111}
+Smoother (level 3) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 2.99461, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [371, 371], Global nnz: 1111}
 
-Smoother (level 4) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 2.99194, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [124, 124], Global nnz: 370}
+Smoother (level 4) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 2.99194, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [124, 124], Global nnz: 370}
 
 Smoother (level 5) pre  : <Direct> solver interface
 Smoother (level 5) post : no smoother

--- a/packages/muelu/test/interface/kokkos/Output/smoother13_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother13_tpetra.gold
@@ -88,10 +88,10 @@ level  rows  nnz    nnz/row  c ratio  procs
   1  3333  9997   3.00     3.00         1  
   2  1111  3331   3.00     3.00         1  
 
-Smoother (level 0) pre  : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
+Smoother (level 0) pre  : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 Smoother (level 0) post : "Ifpack2::RILUK": {Initialized: true, Computed: true, Level-of-fill: 0, Global matrix dimensions: [9999, 9999], Global nnz: 29995, "Ifpack2::LocalSparseTriangularSolver": {Label: "lower", Initialized: true, Computed: true, Matrix dimensions: [9999, 9999], Number of nonzeros: 9998}, "Ifpack2::LocalSparseTriangularSolver": {Label: "upper", Initialized: true, Computed: true, Matrix dimensions: [9999, 9999], Number of nonzeros: 9998}}
 
-Smoother (level 1) pre  : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
+Smoother (level 1) pre  : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
 Smoother (level 1) post : "Ifpack2::RILUK": {Initialized: true, Computed: true, Level-of-fill: 0, Global matrix dimensions: [3333, 3333], Global nnz: 9997, "Ifpack2::LocalSparseTriangularSolver": {Label: "lower", Initialized: true, Computed: true, Matrix dimensions: [3333, 3333], Number of nonzeros: 3332}, "Ifpack2::LocalSparseTriangularSolver": {Label: "upper", Initialized: true, Computed: true, Matrix dimensions: [3333, 3333], Number of nonzeros: 3332}}
 
 Smoother (level 2) pre  : <Direct> solver interface

--- a/packages/muelu/test/interface/kokkos/Output/smoother5_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother5_tpetra.gold
@@ -82,9 +82,9 @@ level  rows  nnz    nnz/row  c ratio  procs
   1  3333  9997   3.00     3.00         1  
   2  1111  3331   3.00     3.00         1  
 
-Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
+Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
-Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
+Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
 
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother

--- a/packages/muelu/test/interface/kokkos/Output/smoother9_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother9_tpetra.gold
@@ -88,10 +88,10 @@ level  rows  nnz    nnz/row  c ratio  procs
   1  3333  9997   3.00     3.00         1  
   2  1111  3331   3.00     3.00         1  
 
-Smoother (level 0) pre  : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
+Smoother (level 0) pre  : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 Smoother (level 0) post : "Ifpack2::ILUT": {Initialized: true, Computed: true, Level-of-fill: 1, absolute threshold: 0, relative threshold: 1, relaxation value: 0, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
-Smoother (level 1) pre  : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
+Smoother (level 1) pre  : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
 Smoother (level 1) post : "Ifpack2::ILUT": {Initialized: true, Computed: true, Level-of-fill: 1, absolute threshold: 0, relative threshold: 1, relaxation value: 0, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
 
 Smoother (level 2) pre  : <Direct> solver interface


### PR DESCRIPTION
@trilinos/ifpack2
@jhux2 @csiefer2

## Motivation
#11721 

Add in fourth-kind Chebyshev polynomial smoothing, which in certain cases may outperform the first-kind Chebyshev polynomial smoothers.

## Related Issues

* Closes #11721 

## Testing
Added test coverage through `packages/ifpack2/test/unit_tests/Ifpack2_UnitTestChebyshev2.cpp`