### PR TITLE
STK: Fix compiling with SYCL

### DIFF
--- a/packages/stk/stk_ngp_test/stk_ngp_test/GlobalReporter.cpp
+++ b/packages/stk/stk_ngp_test/stk_ngp_test/GlobalReporter.cpp
@@ -34,12 +34,16 @@ sycl::ext::oneapi::experimental::device_global<
 
 NGP_TEST_INLINE ReporterBase*& getDeviceReporterOnDevice()
 {
-  KOKKOS_IF_ON_DEVICE((
 #ifndef KOKKOS_ENABLE_SYCL
+  KOKKOS_IF_ON_DEVICE((
     __device__ static ReporterBase* deviceReporterOnDevice = nullptr;
-#endif
     return deviceReporterOnDevice;
   ))
+#else
+  KOKKOS_IF_ON_DEVICE((
+    return deviceReporterOnDevice;
+  ))
+#endif
   KOKKOS_IF_ON_HOST((
     static ReporterBase* deviceReporterOnDevice = nullptr;
     return deviceReporterOnDevice;

--- a/packages/stk/stk_ngp_test/stk_ngp_test/GlobalReporter.cpp
+++ b/packages/stk/stk_ngp_test/stk_ngp_test/GlobalReporter.cpp
@@ -22,10 +22,22 @@ ReporterBase*& getDeviceReporterOnHost()
   return deviceReporterOnHost;
 }
 
+#ifdef KOKKOS_ENABLE_SYCL
+namespace{
+sycl::ext::oneapi::experimental::device_global<
+    ReporterBase*,
+    decltype(sycl::ext::oneapi::experimental::properties(
+        sycl::ext::oneapi::experimental::device_image_scope))>
+  deviceReporterOnDevice;
+}
+#endif
+
 NGP_TEST_INLINE ReporterBase*& getDeviceReporterOnDevice()
 {
   KOKKOS_IF_ON_DEVICE((
+#ifndef KOKKOS_ENABLE_SYCL
     __device__ static ReporterBase* deviceReporterOnDevice = nullptr;
+#endif
     return deviceReporterOnDevice;
   ))
   KOKKOS_IF_ON_HOST((

--- a/packages/stk/stk_util/stk_util/ngp/NgpSpaces.hpp
+++ b/packages/stk/stk_util/stk_util/ngp/NgpSpaces.hpp
@@ -39,57 +39,15 @@
 namespace stk {
 namespace ngp {
 
-#ifdef KOKKOS_ENABLE_CUDA
-using ExecSpace = Kokkos::Cuda;
-#elif defined(KOKKOS_ENABLE_HIP)
-using ExecSpace = Kokkos::Experimental::HIP;
-#elif defined(KOKKOS_ENABLE_OPENMP)
-using ExecSpace = Kokkos::OpenMP;
-#else
-using ExecSpace = Kokkos::Serial;
-#endif
+using ExecSpace = Kokkos::DefaultExecutionSpace;
 
-#ifdef KOKKOS_ENABLE_CUDA
-using HostExecSpace = Kokkos::Serial;
-#elif defined(KOKKOS_ENABLE_HIP)
-using HostExecSpace = Kokkos::Serial;
-#elif defined(KOKKOS_ENABLE_OPENMP)
-using HostExecSpace = Kokkos::OpenMP;
-#else
-using HostExecSpace = Kokkos::Serial;
-#endif
+using HostExecSpace = Kokkos::DefaultHostExecutionSpace;
 
-#ifdef KOKKOS_ENABLE_CUDA
-using MemSpace = Kokkos::CudaSpace;
-#elif defined(KOKKOS_ENABLE_HIP)
-using MemSpace = Kokkos::Experimental::HIPSpace;
-#elif defined(KOKKOS_ENABLE_OPENMP)
-using MemSpace = Kokkos::OpenMP;
-#else
-using MemSpace = Kokkos::HostSpace;
-#endif
+using MemSpace = ExecSpace::memory_space;
 
-#ifdef KOKKOS_ENABLE_CUDA
-#ifdef KOKKOS_ENABLE_CUDA_UVM
-using UVMMemSpace = Kokkos::CudaUVMSpace;
-#else
-using UVMMemSpace = Kokkos::CudaHostPinnedSpace;
-#endif
-#elif defined(KOKKOS_ENABLE_HIP)
-using UVMMemSpace = Kokkos::Experimental::HIPHostPinnedSpace;
-#elif defined(KOKKOS_ENABLE_OPENMP)
-using UVMMemSpace = Kokkos::OpenMP;
-#else
-using UVMMemSpace = Kokkos::HostSpace;
-#endif
+using UVMMemSpace = Kokkos::SharedSpace;
 
-#ifdef KOKKOS_ENABLE_CUDA
-using HostPinnedSpace = Kokkos::CudaHostPinnedSpace;
-#elif defined(KOKKOS_ENABLE_HIP)
-using HostPinnedSpace = Kokkos::Experimental::HIPHostPinnedSpace;
-#else
-using HostPinnedSpace = MemSpace;
-#endif
+using HostPinnedSpace = Kokkos::SharedHostPinnedSpace;
 
 #ifdef KOKKOS_ENABLE_HIP
 template <typename ExecutionSpace>

--- a/packages/stk/stk_util/stk_util/ngp/NgpSpaces.hpp
+++ b/packages/stk/stk_util/stk_util/ngp/NgpSpaces.hpp
@@ -66,6 +66,7 @@ using UVMMemSpace = Kokkos::HostSpace;
 #ifdef KOKKOS_HAS_SHARED_SPACE
 using HostPinnedSpace = Kokkos::SharedHostPinnedSpace;
 #else
+#ifdef KOKKOS_ENABLE_CUDA
 using HostPinnedSpace = Kokkos::CudaHostPinnedSpace;
 #elif defined(KOKKOS_ENABLE_HIP)
 using HostPinnedSpace = Kokkos::Experimental::HIPHostPinnedSpace;

--- a/packages/stk/stk_util/stk_util/ngp/NgpSpaces.hpp
+++ b/packages/stk/stk_util/stk_util/ngp/NgpSpaces.hpp
@@ -45,9 +45,34 @@ using HostExecSpace = Kokkos::DefaultHostExecutionSpace;
 
 using MemSpace = ExecSpace::memory_space;
 
+#ifdef KOKKOS_HAS_SHARED_SPACE
 using UVMMemSpace = Kokkos::SharedSpace;
+#else
+#ifdef KOKKOS_ENABLE_CUDA
+#ifdef KOKKOS_ENABLE_CUDA_UVM
+using UVMMemSpace = Kokkos::CudaUVMSpace;
+#else
+using UVMMemSpace = Kokkos::CudaHostPinnedSpace;
+#endif
+#elif defined(KOKKOS_ENABLE_HIP)
+using UVMMemSpace = Kokkos::Experimental::HIPHostPinnedSpace;
+#elif defined(KOKKOS_ENABLE_OPENMP)
+using UVMMemSpace = Kokkos::OpenMP;
+#else
+using UVMMemSpace = Kokkos::HostSpace;
+#endif
+#endif
 
+#ifdef KOKKOS_HAS_SHARED_SPACE
 using HostPinnedSpace = Kokkos::SharedHostPinnedSpace;
+#else
+using HostPinnedSpace = Kokkos::CudaHostPinnedSpace;
+#elif defined(KOKKOS_ENABLE_HIP)
+using HostPinnedSpace = Kokkos::Experimental::HIPHostPinnedSpace;
+#else
+using HostPinnedSpace = MemSpace;
+#endif
+#endif
 
 #ifdef KOKKOS_ENABLE_HIP
 template <typename ExecutionSpace>


### PR DESCRIPTION
@trilinos/stk

## Motivation
This pull request fixes compiling `Trilinos with `STK` using `Kokkos`' SYCL` backend for support of `Intel` GPUs needed by ATDM.

## Testing
Compiling `Trilinos` with `STK` with `Kokkos`' `SYCL` backend.