### PR TITLE
Tpetra: execution space instances in MultiVector packAndPrepare

### DIFF
--- a/packages/stokhos/src/sacado/kokkos/pce/tpetra/Tpetra_KokkosRefactor_Details_MultiVectorDistObjectKernels_UQ_PCE.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/tpetra/Tpetra_KokkosRefactor_Details_MultiVectorDistObjectKernels_UQ_PCE.hpp
@@ -95,9 +95,10 @@ namespace Details {
     static void pack(const DstView& dst,
                      const SrcView& src,
                      const IdxView& idx,
-                     size_t col) {
+                     size_t col,
+                     const execution_space &space) {
       Kokkos::parallel_for(
-        Kokkos::MPVectorWorkConfig<execution_space>( idx.size(), BlockSize ),
+        Kokkos::MPVectorWorkConfig<execution_space>( space, idx.size(), BlockSize ),
         PackArraySingleColumn(dst,src,idx,col) );
     }
   };
@@ -145,9 +146,10 @@ namespace Details {
     static void pack(const DstView& dst,
                      const SrcView& src,
                      const IdxView& idx,
-                     size_t numCols) {
+                     size_t numCols,
+                     const execution_space &space) {
       Kokkos::parallel_for(
-        Kokkos::MPVectorWorkConfig<execution_space>( idx.size(), BlockSize ),
+        Kokkos::MPVectorWorkConfig<execution_space>( space, idx.size(), BlockSize ),
         PackArrayMultiColumn(dst,src,idx,numCols) );
     }
   };
@@ -199,9 +201,10 @@ namespace Details {
                      const SrcView& src,
                      const IdxView& idx,
                      const ColView& col,
-                     size_t numCols) {
+                     size_t numCols,
+                     const execution_space &space) {
       Kokkos::parallel_for(
-        Kokkos::MPVectorWorkConfig<execution_space>( idx.size(), BlockSize ),
+        Kokkos::MPVectorWorkConfig<execution_space>( space, idx.size(), BlockSize ),
         PackArrayMultiColumnVariableStride(dst,src,idx,col,numCols) );
     }
   };

--- a/packages/stokhos/src/sacado/kokkos/vector/Kokkos_Parallel_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/Kokkos_Parallel_MP_Vector.hpp
@@ -61,16 +61,26 @@ struct MPVectorWorkConfig {
   typedef ExecSpace          execution_space ;
   typedef Tag                work_tag ;
 
+  execution_space space_;
   size_t range;
   size_t team;
   size_t shared;
 
+
+  /*! \brief in the provided execution space instance */
+  MPVectorWorkConfig( const execution_space &space,
+                      const size_t range_,
+                      const size_t team_,
+                      const size_t shared_ = 0 ) :
+    space_(space), range(range_), team(team_), shared(shared_) {}
+
+  /*! \brief in the default execution space instance */
   MPVectorWorkConfig( const size_t range_,
                       const size_t team_,
                       const size_t shared_ = 0 ) :
-    range(range_), team(team_), shared(shared_) {}
+    MPVectorWorkConfig(execution_space(), range_, team_, shared_) {}
 
-  ExecSpace space() const { return ExecSpace(); }
+  ExecSpace space() const { return space_; }
 };
 
 namespace Impl {

--- a/packages/stokhos/src/sacado/kokkos/vector/tpetra/Tpetra_KokkosRefactor_Details_MultiVectorDistObjectKernels_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/tpetra/Tpetra_KokkosRefactor_Details_MultiVectorDistObjectKernels_MP_Vector.hpp
@@ -92,10 +92,11 @@ namespace Details {
     static void pack(const DstView& dst,
                      const SrcView& src,
                      const IdxView& idx,
-                     size_t col) {
+                     size_t col,
+                     const execution_space &space) {
       Kokkos::parallel_for(
         Kokkos::MPVectorWorkConfig<execution_space>(
-          idx.size(), Kokkos::dimension_scalar(dst) ),
+          space, idx.size(), Kokkos::dimension_scalar(dst) ),
         PackArraySingleColumn(dst,src,idx,col) );
     }
   };
@@ -140,9 +141,10 @@ namespace Details {
     static void pack(const DstView& dst,
                      const SrcView& src,
                      const IdxView& idx,
-                     size_t numCols) {
+                     size_t numCols,
+                     const execution_space &space) {
       Kokkos::parallel_for(
-        Kokkos::MPVectorWorkConfig<execution_space>( idx.size(), Kokkos::dimension_scalar(dst) ),
+        Kokkos::MPVectorWorkConfig<execution_space>(space, idx.size(), Kokkos::dimension_scalar(dst) ),
         PackArrayMultiColumn(dst,src,idx,numCols) );
     }
   };
@@ -191,10 +193,11 @@ namespace Details {
                      const SrcView& src,
                      const IdxView& idx,
                      const ColView& col,
-                     size_t numCols) {
+                     size_t numCols,
+                     const execution_space &space) {
       Kokkos::parallel_for(
         Kokkos::MPVectorWorkConfig<execution_space>(
-          idx.size(), Kokkos::dimension_scalar(dst) ),
+          space, idx.size(), Kokkos::dimension_scalar(dst) ),
         PackArrayMultiColumnVariableStride(dst,src,idx,col,numCols) );
     }
   };

--- a/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_decl.hpp
@@ -754,6 +754,13 @@ protected:
      buffer_device_type>& permuteFromLIDs,
    const CombineMode CM) override;
 
+  // clang-format on
+  using dist_object_type::packAndPrepare; ///< DistObject overloads
+                                          ///< packAndPrepare. Explicitly use
+                                          ///< DistObject's packAndPrepare for
+                                          ///< anything we don't override
+                                          // clang-format off
+
   virtual void
   packAndPrepare
   (const SrcDistObject& sourceObj,

--- a/packages/tpetra/core/src/Tpetra_BlockMultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockMultiVector_decl.hpp
@@ -550,6 +550,13 @@ protected:
      buffer_device_type>& permuteFromLIDs,
    const CombineMode CM);
 
+  // clang-format on
+  using dist_object_type::packAndPrepare; ///< DistObject overloads
+                                          ///< packAndPrepare. Explicitly use
+                                          ///< DistObject's packAndPrepare for
+                                          ///< anything we don't override
+                                          // clang-format off
+
   virtual void
   packAndPrepare
   (const SrcDistObject& source,

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -1226,6 +1226,13 @@ public:
       Kokkos::DualView<size_t*, buffer_device_type> numPacketsPerLID,
       size_t& constantNumPackets) override;
 
+  // clang-format on
+  using dist_object_type::packAndPrepare; ///< DistObject overloads
+                                          ///< packAndPrepare. Explicitly use
+                                          ///< DistObject's packAndPrepare for
+                                          ///< anything we don't override
+  // clang-format off
+
     virtual void
     pack (const Teuchos::ArrayView<const local_ordinal_type>& exportLIDs,
           Teuchos::Array<global_ordinal_type>& exports,

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -3004,6 +3004,13 @@ public:
      Kokkos::DualView<size_t*, buffer_device_type> numPacketsPerLID,
      size_t& constantNumPackets) override;
 
+  // clang-format on
+  using dist_object_type::packAndPrepare; ///< DistObject overloads
+                                          ///< packAndPrepare. Explicitly use
+                                          ///< DistObject's packAndPrepare for
+                                          ///< anything we don't override
+                                          // clang-format off
+
   private:
     /// \brief Unpack the imported column indices and values, and
     ///   combine into matrix.

--- a/packages/tpetra/core/src/Tpetra_DistObject_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_DistObject_decl.hpp
@@ -797,7 +797,8 @@ namespace Tpetra {
 
     void doPackAndPrepare(const SrcDistObject& src,
                           const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& exportLIDs,
-                          size_t& constantNumPackets);
+                          size_t& constantNumPackets,
+                          const execution_space &space);
 
     void doUnpackAndCombine(const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& remoteLIDs,
                             size_t constantNumPackets,
@@ -906,6 +907,19 @@ namespace Tpetra {
                     Kokkos::DualView<size_t*,
                       buffer_device_type> numPacketsPerLID,
                     size_t& constantNumPackets);
+
+    /*! \brief Same as packAndPrepare, but in an execution space instance
+    */
+    virtual void
+    packAndPrepare (const SrcDistObject& source,
+                    const Kokkos::DualView<const local_ordinal_type*,
+                      buffer_device_type>& exportLIDs,
+                    Kokkos::DualView<packet_type*,
+                      buffer_device_type>& exports,
+                    Kokkos::DualView<size_t*,
+                      buffer_device_type> numPacketsPerLID,
+                    size_t& constantNumPackets,
+                    const execution_space &space);
 
     /// \brief Perform any unpacking and combining after
     ///   communication.

--- a/packages/tpetra/core/src/Tpetra_DistObject_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_DistObject_def.hpp
@@ -1772,15 +1772,6 @@ void DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::unpackAndCombine(
 // clang-format off
 
 template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
-void DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::unpackAndCombine(
-    const Kokkos::DualView<const local_ordinal_type *, buffer_device_type>
-        & /* importLIDs */,
-    Kokkos::DualView<packet_type *, buffer_device_type> /* imports */,
-    Kokkos::DualView<size_t *, buffer_device_type> /* numPacketsPerLID */,
-    const size_t /* constantNumPackets */,
-    const CombineMode /* combineMode */) {}
-
-template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
 void DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::print(
     std::ostream &os) const {
   using std::endl;

--- a/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
@@ -2355,7 +2355,22 @@ namespace Tpetra {
      Kokkos::DualView<
        size_t*,
        buffer_device_type> /* numPacketsPerLID */,
-     size_t& constantNumPackets);
+     size_t& constantNumPackets,
+     const execution_space &space) override;
+
+    virtual void
+    packAndPrepare
+    (const SrcDistObject& sourceObj,
+     const Kokkos::DualView<
+       const local_ordinal_type*,
+       buffer_device_type>& exportLIDs,
+     Kokkos::DualView<
+       impl_scalar_type*,
+       buffer_device_type>& exports,
+     Kokkos::DualView<
+       size_t*,
+       buffer_device_type> /* numPacketsPerLID */,
+     size_t& constantNumPackets) override;
 
     virtual void
     unpackAndCombine

--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -1489,7 +1489,8 @@ namespace Tpetra {
    const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& exportLIDs,
    Kokkos::DualView<impl_scalar_type*, buffer_device_type>& exports,
    Kokkos::DualView<size_t*, buffer_device_type> /* numExportPacketsPerLID */,
-   size_t& constantNumPackets)
+   size_t& constantNumPackets,
+   const execution_space &space)
   {
     using ::Tpetra::Details::Behavior;
     using ::Tpetra::Details::ProfilingRegion;
@@ -1643,7 +1644,8 @@ namespace Tpetra {
                                     src_dev,
                                     exportLIDs.view_device (),
                                     0,
-                                    debugCheckIndices);
+                                    debugCheckIndices,
+                                    space);
         }
       }
       else {
@@ -1667,7 +1669,8 @@ namespace Tpetra {
                                     src_dev,
                                     exportLIDs.view_device (),
                                     sourceMV.whichVectors_[0],
-                                    debugCheckIndices);
+                                    debugCheckIndices,
+                                    space);
         }
       }
     }
@@ -1693,7 +1696,8 @@ namespace Tpetra {
                                    src_dev,
                                    exportLIDs.view_device (),
                                    numCols,
-                                   debugCheckIndices);
+                                   debugCheckIndices,
+                                   space);
         }
       }
       else {
@@ -1730,7 +1734,7 @@ namespace Tpetra {
              exportLIDs.view_device (),
              getKokkosViewDeepCopy<DES> (whichVecs),
              numCols,
-             debugCheckIndices);
+             debugCheckIndices, space);
         }
       }
     }
@@ -1743,6 +1747,19 @@ namespace Tpetra {
 
   }
 
+// clang-format on
+  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+  void
+  MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
+  packAndPrepare
+  (const SrcDistObject& sourceObj,
+   const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& exportLIDs,
+   Kokkos::DualView<impl_scalar_type*, buffer_device_type>& exports,
+   Kokkos::DualView<size_t*, buffer_device_type> numExportPacketsPerLID,
+   size_t& constantNumPackets) {
+     packAndPrepare(sourceObj, exportLIDs, exports, numExportPacketsPerLID, constantNumPackets, execution_space());    
+   }
+// clang-format off
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   template <class NO>

--- a/packages/tpetra/core/src/kokkos_refactor/Tpetra_KokkosRefactor_Details_MultiVectorDistObjectKernels.hpp
+++ b/packages/tpetra/core/src/kokkos_refactor/Tpetra_KokkosRefactor_Details_MultiVectorDistObjectKernels.hpp
@@ -148,12 +148,13 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
     pack (const DstView& dst,
           const SrcView& src,
           const IdxView& idx,
-          const size_t col)
+          const size_t col,
+          const execution_space &space)
     {
       typedef Kokkos::RangePolicy<execution_space, size_type> range_type;
       Kokkos::parallel_for
         ("Tpetra::MultiVector pack one col",
-         range_type (0, idx.size ()),
+         range_type (space, 0, idx.size ()),
          PackArraySingleColumn (dst, src, idx, col));
     }
   };
@@ -179,6 +180,9 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
                    "IdxView must be a rank-1 Kokkos::View.");
     static_assert (std::is_integral<SizeType>::value,
                    "SizeType must be a built-in integer type.");
+
+    using execution_space = typename DstView::execution_space;
+
   public:
     typedef SizeType size_type;
     using value_type = size_t;
@@ -188,6 +192,7 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
     SrcView src;
     IdxView idx;
     size_type col;
+    execution_space space;
 
   public:
     PackArraySingleColumnWithBoundsCheck (const DstView& dst_,
@@ -226,16 +231,16 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
     pack (const DstView& dst,
           const SrcView& src,
           const IdxView& idx,
-          const size_type col)
+          const size_type col,
+          const execution_space &space)
     {
-      typedef typename DstView::execution_space execution_space;
       typedef Kokkos::RangePolicy<execution_space, size_type> range_type;
       typedef typename IdxView::non_const_value_type index_type;
 
       size_t errorCount = 0;
       Kokkos::parallel_reduce
         ("Tpetra::MultiVector pack one col debug only",
-         range_type (0, idx.size ()),
+         range_type (space, 0, idx.size ()),
          PackArraySingleColumnWithBoundsCheck (dst, src, idx, col),
          errorCount);
 
@@ -286,7 +291,8 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
                             const SrcView& src,
                             const IdxView& idx,
                             const size_t col,
-                            const bool debug = true)
+                            const bool debug,
+                            const typename DstView::execution_space &space)
   {
     static_assert (Kokkos::is_view<DstView>::value,
                    "DstView must be a Kokkos::View.");
@@ -301,20 +307,45 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
     static_assert (static_cast<int> (IdxView::rank) == 1,
                    "IdxView must be a rank-1 Kokkos::View.");
 
+    using execution_space = typename DstView::execution_space;
+
+    static_assert (Kokkos::SpaceAccessibility<execution_space,
+                     typename DstView::memory_space>::accessible,
+                   "DstView not accessible from execution space");
+    static_assert (Kokkos::SpaceAccessibility<execution_space,
+                     typename SrcView::memory_space>::accessible,
+                   "SrcView not accessible from execution space");
+    static_assert (Kokkos::SpaceAccessibility<execution_space,
+                     typename IdxView::memory_space>::accessible,
+                   "IdxView not accessible from execution space");
+
     if (debug) {
       typedef PackArraySingleColumnWithBoundsCheck<DstView,SrcView,IdxView> impl_type;
-      impl_type::pack (dst, src, idx, col);
+      impl_type::pack (dst, src, idx, col, space);
     }
     else {
       typedef PackArraySingleColumn<DstView,SrcView,IdxView> impl_type;
-      impl_type::pack (dst, src, idx, col);
+      impl_type::pack (dst, src, idx, col, space);
     }
+  }
+
+ /*! \brief pack_array_single_column in the default execution space
+  */
+  template <typename DstView, typename SrcView, typename IdxView>
+  void
+  pack_array_single_column (const DstView& dst,
+                            const SrcView& src,
+                            const IdxView& idx,
+                            const size_t col,
+                            const bool debug = true)
+  {
+    pack_array_single_column(dst, src, idx, col, debug, typename DstView::execution_space());
   }
 
   template <typename DstView, typename SrcView, typename IdxView,
             typename Enabled = void>
   struct PackArrayMultiColumn {
-    typedef typename DstView::execution_space execution_space;
+    using execution_space = typename DstView::execution_space;
     typedef typename execution_space::size_type size_type;
 
     DstView dst;
@@ -340,11 +371,12 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
     static void pack(const DstView& dst,
                      const SrcView& src,
                      const IdxView& idx,
-                     size_t numCols) {
+                     size_t numCols,
+                     const execution_space &space) {
       typedef Kokkos::RangePolicy<execution_space, size_type> range_type;
       Kokkos::parallel_for
         ("Tpetra::MultiVector pack multicol const stride",
-         range_type (0, idx.size ()),
+         range_type (space, 0, idx.size ()),
          PackArrayMultiColumn (dst, src, idx, numCols));
     }
   };
@@ -358,6 +390,7 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
   public:
     using size_type = SizeType;
     using value_type = size_t;
+    using execution_space = typename DstView::execution_space;
 
   private:
     DstView dst;
@@ -405,16 +438,16 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
     pack (const DstView& dst,
           const SrcView& src,
           const IdxView& idx,
-          const size_type numCols)
+          const size_type numCols,
+          const execution_space &space)
     {
-      typedef typename DstView::execution_space execution_space;
       typedef Kokkos::RangePolicy<execution_space, size_type> range_type;
       typedef typename IdxView::non_const_value_type index_type;
 
       size_t errorCount = 0;
       Kokkos::parallel_reduce
         ("Tpetra::MultiVector pack multicol const stride debug only",
-         range_type (0, idx.size ()),
+         range_type (space, 0, idx.size ()),
          PackArrayMultiColumnWithBoundsCheck (dst, src, idx, numCols),
          errorCount);
       if (errorCount != 0) {
@@ -466,7 +499,8 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
                            const SrcView& src,
                            const IdxView& idx,
                            const size_t numCols,
-                           const bool debug = true)
+                           const bool debug,
+                           const typename DstView::execution_space &space)
   {
     static_assert (Kokkos::is_view<DstView>::value,
                    "DstView must be a Kokkos::View.");
@@ -481,21 +515,45 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
     static_assert (static_cast<int> (IdxView::rank) == 1,
                    "IdxView must be a rank-1 Kokkos::View.");
 
+    using execution_space = typename DstView::execution_space;
+
+    static_assert (Kokkos::SpaceAccessibility<execution_space,
+                     typename DstView::memory_space>::accessible,
+                   "DstView not accessible from execution space");
+    static_assert (Kokkos::SpaceAccessibility<execution_space,
+                     typename SrcView::memory_space>::accessible,
+                   "SrcView not accessible from execution space");
+    static_assert (Kokkos::SpaceAccessibility<execution_space,
+                     typename IdxView::memory_space>::accessible,
+                   "IdxView not accessible from execution space");
+
     if (debug) {
       typedef PackArrayMultiColumnWithBoundsCheck<DstView,
         SrcView, IdxView> impl_type;
-      impl_type::pack (dst, src, idx, numCols);
+      impl_type::pack (dst, src, idx, numCols, space);
     }
     else {
       typedef PackArrayMultiColumn<DstView, SrcView, IdxView> impl_type;
-      impl_type::pack (dst, src, idx, numCols);
+      impl_type::pack (dst, src, idx, numCols, space);
     }
+  }
+
+  template <typename DstView,
+            typename SrcView,
+            typename IdxView>
+  void
+  pack_array_multi_column (const DstView& dst,
+                           const SrcView& src,
+                           const IdxView& idx,
+                           const size_t numCols,
+                           const bool debug = true) {
+    pack_array_multi_column(dst, src, idx, numCols, debug, typename DstView::execution_space());
   }
 
   template <typename DstView, typename SrcView, typename IdxView,
             typename ColView, typename Enabled = void>
   struct PackArrayMultiColumnVariableStride {
-    typedef typename DstView::execution_space execution_space;
+    using execution_space = typename DstView::execution_space;
     typedef typename execution_space::size_type size_type;
 
     DstView dst;
@@ -524,11 +582,12 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
                      const SrcView& src,
                      const IdxView& idx,
                      const ColView& col,
-                     size_t numCols) {
+                     size_t numCols,
+                     const execution_space &space) {
       typedef Kokkos::RangePolicy<execution_space, size_type> range_type;
       Kokkos::parallel_for
         ("Tpetra::MultiVector pack multicol var stride",
-         range_type (0, idx.size ()),
+         range_type (space, 0, idx.size ()),
          PackArrayMultiColumnVariableStride (dst, src, idx, col, numCols));
     }
   };
@@ -543,6 +602,7 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
   public:
     using size_type = SizeType;
     using value_type = size_t;
+    using execution_space = typename DstView::execution_space;
 
   private:
     DstView dst;
@@ -600,9 +660,9 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
           const SrcView& src,
           const IdxView& idx,
           const ColView& col,
-          const size_type numCols)
+          const size_type numCols,
+          const execution_space &space)
     {
-      using execution_space = typename DstView::execution_space;
       using range_type = Kokkos::RangePolicy<execution_space, size_type>;
       using row_index_type = typename IdxView::non_const_value_type;
       using col_index_type = typename ColView::non_const_value_type;
@@ -610,7 +670,7 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
       size_t errorCount = 0;
       Kokkos::parallel_reduce
         ("Tpetra::MultiVector pack multicol var stride debug only",
-         range_type (0, idx.size ()),
+         range_type (space, 0, idx.size ()),
          PackArrayMultiColumnVariableStrideWithBoundsCheck (dst, src, idx,
                                                             col, numCols),
          errorCount);
@@ -717,7 +777,8 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
                                            const IdxView& idx,
                                            const ColView& col,
                                            const size_t numCols,
-                                           const bool debug = true)
+                                           const bool debug,
+                                           const typename DstView::execution_space &space)
   {
     static_assert (Kokkos::is_view<DstView>::value,
                    "DstView must be a Kokkos::View.");
@@ -736,16 +797,43 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
     static_assert (static_cast<int> (ColView::rank) == 1,
                    "ColView must be a rank-1 Kokkos::View.");
 
+    using execution_space = typename DstView::execution_space;
+
+    static_assert (Kokkos::SpaceAccessibility<execution_space,
+                     typename DstView::memory_space>::accessible,
+                   "DstView not accessible from execution space");
+    static_assert (Kokkos::SpaceAccessibility<execution_space,
+                     typename SrcView::memory_space>::accessible,
+                   "SrcView not accessible from execution space");
+    static_assert (Kokkos::SpaceAccessibility<execution_space,
+                     typename IdxView::memory_space>::accessible,
+                   "IdxView not accessible from execution space");
+
     if (debug) {
       typedef PackArrayMultiColumnVariableStrideWithBoundsCheck<DstView,
         SrcView, IdxView, ColView> impl_type;
-      impl_type::pack (dst, src, idx, col, numCols);
+      impl_type::pack (dst, src, idx, col, numCols, space);
     }
     else {
       typedef PackArrayMultiColumnVariableStride<DstView,
         SrcView, IdxView, ColView> impl_type;
-      impl_type::pack (dst, src, idx, col, numCols);
+      impl_type::pack (dst, src, idx, col, numCols, space);
     }
+  }
+
+  template <typename DstView,
+            typename SrcView,
+            typename IdxView,
+            typename ColView>
+  void
+  pack_array_multi_column_variable_stride (const DstView& dst,
+                                           const SrcView& src,
+                                           const IdxView& idx,
+                                           const ColView& col,
+                                           const size_t numCols,
+                                           const bool debug = true) {
+    pack_array_multi_column_variable_stride(dst, src, idx, col, numCols, debug,
+      typename DstView::execution_space());
   }
 
   // Tag types to indicate whether to use atomic updates in the


### PR DESCRIPTION
@trilinos/tpetra
@trilinos/stokhos 

## Motivation
Needed before execution-space instance enabled import/export for SpMV communication-computation overlap: https://github.com/trilinos/Trilinos/pull/10926