### PR TITLE
Amesos2: Use ternary in conditionals involving is_contiguous.

### DIFF
--- a/packages/amesos2/src/Amesos2_Basker_def.hpp
+++ b/packages/amesos2/src/Amesos2_Basker_def.hpp
@@ -128,7 +128,7 @@ Basker<Matrix,Vector>::numericFactorization_impl()
       std::cout << "rowind_ : " << rowind_.toString() << std::endl;
       std::cout << "colptr_ : " << colptr_.toString() << std::endl;
   #endif
-     
+
       basker_dtype * pBaskerValues = function_map::convert_scalar(host_nzvals_view_.data());
       info = basker.factor(this->globalNumRows_, this->globalNumCols_, this->globalNumNonZeros_, host_col_ptr_view_.data(), host_rows_view_.data(), pBaskerValues);
 
@@ -192,24 +192,18 @@ Basker<Matrix,Vector>::solve_impl(
         host_solve_array_t>::do_get(do_not_initialize_data, X, xValues_, as<size_t>(ld_rhs));
     }
     else {
-      if ( is_contiguous_ == true ) {
-        Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
-          host_solve_array_t>::do_get(initialize_data, B, bValues_, as<size_t>(ld_rhs), ROOTED, this->rowIndexBase_);
-      }
-      else {
-        Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
-          host_solve_array_t>::do_get(initialize_data, B, bValues_, as<size_t>(ld_rhs), CONTIGUOUS_AND_ROOTED, this->rowIndexBase_);
-      }
+      Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
+        host_solve_array_t>::do_get(initialize_data, B, bValues_,
+          as<size_t>(ld_rhs),
+          (is_contiguous_ == true) ? ROOTED : CONTIGUOUS_AND_ROOTED,
+          this->rowIndexBase_);
 
       // See Amesos2_Tacho_def.hpp for notes on why we 'get' x here.
-      if ( is_contiguous_ == true ) {
-        bDidAssignX = Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
-          host_solve_array_t>::do_get(do_not_initialize_data, X, xValues_, as<size_t>(ld_rhs), ROOTED, this->rowIndexBase_);
-      }
-      else {
-        bDidAssignX = Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
-          host_solve_array_t>::do_get(do_not_initialize_data, X, xValues_, as<size_t>(ld_rhs), CONTIGUOUS_AND_ROOTED, this->rowIndexBase_);
-      }
+      bDidAssignX = Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
+        host_solve_array_t>::do_get(do_not_initialize_data, X, xValues_,
+        as<size_t>(ld_rhs),
+        (is_contiguous_ == true) ? ROOTED : CONTIGUOUS_AND_ROOTED,
+        this->rowIndexBase_);
     }
   }
 
@@ -239,18 +233,11 @@ Basker<Matrix,Vector>::solve_impl(
 #ifdef HAVE_AMESOS2_TIMERS
     Teuchos::TimeMonitor redistTimer(this->timers_.vecRedistTime_);
 #endif
-    if ( is_contiguous_ == true ) {
-      Util::put_1d_data_helper_kokkos_view<
-        MultiVecAdapter<Vector>,host_solve_array_t>::do_put(X, xValues_,
-            as<size_t>(ld_rhs),
-            ROOTED);
-    }
-    else {
-      Util::put_1d_data_helper_kokkos_view<
-        MultiVecAdapter<Vector>,host_solve_array_t>::do_put(X, xValues_,
-            as<size_t>(ld_rhs),
-            CONTIGUOUS_AND_ROOTED);
-    }
+
+    Util::put_1d_data_helper_kokkos_view<MultiVecAdapter<Vector>,
+      host_solve_array_t>::do_put(X, xValues_,
+        as<size_t>(ld_rhs),
+        (is_contiguous_ == true) ? ROOTED : CONTIGUOUS_AND_ROOTED);
   }
 
   return(ierr);
@@ -330,18 +317,13 @@ Basker<Matrix,Vector>::loadA_impl(EPhase current_phase)
     Teuchos::TimeMonitor mtxRedistTimer( this->timers_.mtxRedistTime_ );
   #endif
 
-    if ( is_contiguous_ == true ) {
-      Util::get_ccs_helper_kokkos_view<
-        MatrixAdapter<Matrix>,host_value_type_array,host_ordinal_type_array,host_ordinal_type_array>
-        ::do_get(this->matrixA_.ptr(), host_nzvals_view_, host_rows_view_, host_col_ptr_view_,
-            nnz_ret, ROOTED, ARBITRARY, this->rowIndexBase_);
-    }
-    else {
-      Util::get_ccs_helper_kokkos_view<
-        MatrixAdapter<Matrix>,host_value_type_array,host_ordinal_type_array,host_ordinal_type_array>
-        ::do_get(this->matrixA_.ptr(), host_nzvals_view_, host_rows_view_, host_col_ptr_view_,
-            nnz_ret, CONTIGUOUS_AND_ROOTED, ARBITRARY, this->rowIndexBase_);
-    }
+    Util::get_ccs_helper_kokkos_view<
+      MatrixAdapter<Matrix>,host_value_type_array,host_ordinal_type_array,host_ordinal_type_array>
+      ::do_get(this->matrixA_.ptr(),
+        host_nzvals_view_, host_rows_view_, host_col_ptr_view_, nnz_ret,
+        (is_contiguous_ == true) ? ROOTED : CONTIGUOUS_AND_ROOTED,
+        ARBITRARY,
+        this->rowIndexBase_);
   }
 
   if( this->root_ ){

--- a/packages/amesos2/src/Amesos2_Cholmod_def.hpp
+++ b/packages/amesos2/src/Amesos2_Cholmod_def.hpp
@@ -500,48 +500,31 @@ Cholmod<Matrix,Vector>::loadA_impl(EPhase current_phase)
 
     if(use_cholmod_int_type_) {
       int nnz_ret = 0;
-      if ( is_contiguous_ == true ) {
-        Util::get_ccs_helper_kokkos_view<
-          MatrixAdapter<Matrix>,host_value_type_array,host_ordinal_int_type_array,
-            host_size_int_type_array>::do_get(this->matrixA_.ptr(),
-              host_nzvals_view_, host_rows_int_view_,
-              host_col_ptr_int_view_, nnz_ret, ROOTED,
-              ARBITRARY,
-              this->rowIndexBase_);
-      }
-      else {
-        Util::get_ccs_helper_kokkos_view<
-          MatrixAdapter<Matrix>,host_value_type_array,host_ordinal_int_type_array,
-            host_size_int_type_array>::do_get(this->matrixA_.ptr(),
-              host_nzvals_view_, host_rows_int_view_,
-              host_col_ptr_int_view_, nnz_ret, CONTIGUOUS_AND_ROOTED,
-              ARBITRARY,
-              this->rowIndexBase_);
-      }
+      Util::get_ccs_helper_kokkos_view<
+        MatrixAdapter<Matrix>,host_value_type_array,host_ordinal_int_type_array,
+          host_size_int_type_array>::do_get(this->matrixA_.ptr(),
+            host_nzvals_view_, host_rows_int_view_,
+            host_col_ptr_int_view_, nnz_ret,
+            (is_contiguous_ == true) ? ROOTED : CONTIGUOUS_AND_ROOTED,
+            ARBITRARY,
+            this->rowIndexBase_);
+
       TEUCHOS_TEST_FOR_EXCEPTION(nnz_ret != Teuchos::as<long>(this->globalNumNonZeros_),
                std::runtime_error,
                "Did not get the expected number of non-zero vals");
     }
     else {
       long nnz_ret = 0;
-      if ( is_contiguous_ == true ) {
-        Util::get_ccs_helper_kokkos_view<
-          MatrixAdapter<Matrix>,host_value_type_array,host_ordinal_long_type_array,
-            host_size_long_type_array>::do_get(this->matrixA_.ptr(),
-              host_nzvals_view_, host_rows_long_view_,
-              host_col_ptr_long_view_, nnz_ret, ROOTED,
-              ARBITRARY,
-              this->rowIndexBase_);
-      }
-      else {
-        Util::get_ccs_helper_kokkos_view<
-          MatrixAdapter<Matrix>,host_value_type_array,host_ordinal_long_type_array,
-            host_size_long_type_array>::do_get(this->matrixA_.ptr(),
-              host_nzvals_view_, host_rows_long_view_,
-              host_col_ptr_long_view_, nnz_ret, CONTIGUOUS_AND_ROOTED,
-              ARBITRARY,
-              this->rowIndexBase_);
-      }
+
+      Util::get_ccs_helper_kokkos_view<
+        MatrixAdapter<Matrix>,host_value_type_array,host_ordinal_long_type_array,
+          host_size_long_type_array>::do_get(this->matrixA_.ptr(),
+            host_nzvals_view_, host_rows_long_view_,
+            host_col_ptr_long_view_, nnz_ret,
+            (is_contiguous_ == true) ? ROOTED : CONTIGUOUS_AND_ROOTED,
+            ARBITRARY,
+            this->rowIndexBase_);
+
       TEUCHOS_TEST_FOR_EXCEPTION(nnz_ret != Teuchos::as<long>(this->globalNumNonZeros_),
                std::runtime_error,
                "Did not get the expected number of non-zero vals");

--- a/packages/amesos2/src/Amesos2_KLU2_def.hpp
+++ b/packages/amesos2/src/Amesos2_KLU2_def.hpp
@@ -254,32 +254,19 @@ KLU2<Matrix,Vector>::solve_impl(
         host_solve_array_t>::do_get(do_not_initialize_data, X, xValues_, as<size_t>(ld_rhs));
     }
     else {
-      if ( is_contiguous_ == true ) {
-        bDidAssignB = Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
-          host_solve_array_t>::do_get(initialize_data, B, bValues_,
-              as<size_t>(ld_rhs),
-              ROOTED, this->rowIndexBase_);
-      }
-      else {
-        bDidAssignB = Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
-          host_solve_array_t>::do_get(initialize_data, B, bValues_,
-              as<size_t>(ld_rhs),
-              CONTIGUOUS_AND_ROOTED, this->rowIndexBase_);
-      }
+
+      bDidAssignB = Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
+        host_solve_array_t>::do_get(initialize_data, B, bValues_,
+          as<size_t>(ld_rhs),
+          (is_contiguous_ == true) ? ROOTED : CONTIGUOUS_AND_ROOTED,
+          this->rowIndexBase_);
 
       // see Amesos2_Tacho_def.hpp for an explanation of why we 'get' X
-      if ( is_contiguous_ == true ) {
-        bDidAssignX = Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
-          host_solve_array_t>::do_get(do_not_initialize_data, X, xValues_,
-              as<size_t>(ld_rhs),
-              ROOTED, this->rowIndexBase_);
-      }
-      else {
-        bDidAssignX = Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
-          host_solve_array_t>::do_get(do_not_initialize_data, X, xValues_,
-              as<size_t>(ld_rhs),
-              CONTIGUOUS_AND_ROOTED, this->rowIndexBase_);
-      }
+      bDidAssignX = Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
+        host_solve_array_t>::do_get(do_not_initialize_data, X, xValues_,
+          as<size_t>(ld_rhs),
+          (is_contiguous_ == true) ? ROOTED : CONTIGUOUS_AND_ROOTED,
+          this->rowIndexBase_);
 
       // klu_tsolve is going to put the solution x into the input b.
       // Copy b to x then solve in x.
@@ -393,18 +380,12 @@ KLU2<Matrix,Vector>::solve_impl(
     Teuchos::TimeMonitor redistTimer( this->timers_.vecRedistTime_ );
 #endif
 
-    if ( is_contiguous_ == true ) {
-      Util::put_1d_data_helper_kokkos_view<
-        MultiVecAdapter<Vector>,host_solve_array_t>::do_put(X, xValues_,
-            as<size_t>(ld_rhs),
-            ROOTED, this->rowIndexBase_);
-    }
-    else {
-      Util::put_1d_data_helper_kokkos_view<
-        MultiVecAdapter<Vector>,host_solve_array_t>::do_put(X, xValues_,
-            as<size_t>(ld_rhs),
-            CONTIGUOUS_AND_ROOTED, this->rowIndexBase_);
-    }
+    Util::put_1d_data_helper_kokkos_view<
+      MultiVecAdapter<Vector>,host_solve_array_t>::do_put(X, xValues_,
+        as<size_t>(ld_rhs),
+        (is_contiguous_ == true) ? ROOTED : CONTIGUOUS_AND_ROOTED,
+        this->rowIndexBase_);
+
   }
 
   return(ierr);
@@ -491,7 +472,7 @@ KLU2<Matrix,Vector>::loadA_impl(EPhase current_phase)
   if ( single_proc_optimization() ) {
     // Do nothing in this case - Crs raw pointers will be used
   }
-  else 
+  else
   {
 
 #ifdef HAVE_AMESOS2_TIMERS
@@ -514,18 +495,12 @@ KLU2<Matrix,Vector>::loadA_impl(EPhase current_phase)
     Teuchos::TimeMonitor mtxRedistTimer( this->timers_.mtxRedistTime_ );
 #endif
 
-    if ( is_contiguous_ == true ) {
-      Util::get_ccs_helper_kokkos_view<
-        MatrixAdapter<Matrix>,host_value_type_array,host_ordinal_type_array,host_ordinal_type_array>
-        ::do_get(this->matrixA_.ptr(), host_nzvals_view_, host_rows_view_, host_col_ptr_view_,
-            nnz_ret, ROOTED, ARBITRARY, this->rowIndexBase_);
-    }
-    else {
-      Util::get_ccs_helper_kokkos_view<
-        MatrixAdapter<Matrix>,host_value_type_array,host_ordinal_type_array,host_ordinal_type_array>
-        ::do_get(this->matrixA_.ptr(), host_nzvals_view_, host_rows_view_, host_col_ptr_view_,
-            nnz_ret, CONTIGUOUS_AND_ROOTED, ARBITRARY, this->rowIndexBase_);
-    }
+    Util::get_ccs_helper_kokkos_view<
+      MatrixAdapter<Matrix>,host_value_type_array,host_ordinal_type_array,host_ordinal_type_array>
+      ::do_get(this->matrixA_.ptr(), host_nzvals_view_, host_rows_view_, host_col_ptr_view_, nnz_ret,
+        (is_contiguous_ == true) ? ROOTED : CONTIGUOUS_AND_ROOTED,
+        ARBITRARY,
+        this->rowIndexBase_);
   }
 
   if( this->root_ ) {

--- a/packages/amesos2/src/Amesos2_Lapack_def.hpp
+++ b/packages/amesos2/src/Amesos2_Lapack_def.hpp
@@ -150,12 +150,10 @@ namespace Amesos2 {
 #endif
       typedef Util::get_1d_copy_helper<MultiVecAdapter<Vector>,
                                        scalar_type> copy_helper;
-      if ( is_contiguous_ == true ) {
-        copy_helper::do_get(B, rhsvals_(), as<size_t>(ld_rhs), ROOTED, 0);
-      }
-      else {
-        copy_helper::do_get(B, rhsvals_(), as<size_t>(ld_rhs), CONTIGUOUS_AND_ROOTED, 0);
-      }
+      copy_helper::do_get(B, rhsvals_(),
+        as<size_t>(ld_rhs),
+        (is_contiguous_ == true) ? ROOTED : CONTIGUOUS_AND_ROOTED,
+        0);
     }
 
     int solve_ierr         = 0;
@@ -193,18 +191,10 @@ namespace Amesos2 {
       Teuchos::TimeMonitor redistTimer( this->timers_.vecRedistTime_ );
 #endif
 
-      if ( is_contiguous_ == true ) {
-        Util::put_1d_data_helper<
-          MultiVecAdapter<Vector>,scalar_type>::do_put(X, rhsvals_(),
-              as<size_t>(ld_rhs),
-              ROOTED);
-      }
-      else {
-        Util::put_1d_data_helper<
-          MultiVecAdapter<Vector>,scalar_type>::do_put(X, rhsvals_(),
-              as<size_t>(ld_rhs),
-              CONTIGUOUS_AND_ROOTED);
-      }
+      Util::put_1d_data_helper<
+        MultiVecAdapter<Vector>,scalar_type>::do_put(X, rhsvals_(),
+          as<size_t>(ld_rhs),
+          (is_contiguous_ == true) ? ROOTED : CONTIGUOUS_AND_ROOTED);
     }
 
     return( 0 );
@@ -290,16 +280,12 @@ namespace Amesos2 {
       //        scalar_type, global_ordinal_type, global_size_type> ccs_helper;
     typedef Util::get_ccs_helper_kokkos_view<MatrixAdapter<Matrix>,
         host_value_type_array, host_ordinal_type_array, host_ordinal_type_array> ccs_helper;
-    if ( is_contiguous_ == true ) {
-      ccs_helper::do_get(this->matrixA_.ptr(),
-                         nzvals_view_, rowind_view_, colptr_view_,
-                         nnz_ret, ROOTED, ARBITRARY, this->rowIndexBase_);
-    }
-    else {
-      ccs_helper::do_get(this->matrixA_.ptr(),
-                         nzvals_view_, rowind_view_, colptr_view_,
-                         nnz_ret, CONTIGUOUS_AND_ROOTED, ARBITRARY, this->rowIndexBase_);
-    }
+
+    ccs_helper::do_get(this->matrixA_.ptr(),
+      nzvals_view_, rowind_view_, colptr_view_, nnz_ret,
+      (is_contiguous_ == true) ? ROOTED : CONTIGUOUS_AND_ROOTED,
+      ARBITRARY,
+      this->rowIndexBase_);
   }
 
     if( this->root_ ){

--- a/packages/amesos2/src/Amesos2_MUMPS_def.hpp
+++ b/packages/amesos2/src/Amesos2_MUMPS_def.hpp
@@ -244,16 +244,12 @@ namespace Amesos2
     Teuchos::TimeMonitor redistTimer( this->timers_.vecRedistTime_ );
     #endif
 
-    if ( is_contiguous_ == true ) {
-      Util::get_1d_copy_helper<MultiVecAdapter<Vector>,
-        mumps_type>::do_get(B, bvals_(),as<size_t>(ld_rhs), ROOTED, this->rowIndexBase_);
-    }
-    else {
-      Util::get_1d_copy_helper<MultiVecAdapter<Vector>,
-        mumps_type>::do_get(B, bvals_(),as<size_t>(ld_rhs), CONTIGUOUS_AND_ROOTED, this->rowIndexBase_);
-    }
+    Util::get_1d_copy_helper<MultiVecAdapter<Vector>,
+      mumps_type>::do_get(B, bvals_(),
+        as<size_t>(ld_rhs),
+        (is_contiguous_ == true) ? ROOTED : CONTIGUOUS_AND_ROOTED,
+        this->rowIndexBase_);
  
-    
     int ierr = 0; // returned error code
     mumps_par.nrhs = nrhs;
     mumps_par.lrhs = mumps_par.n;
@@ -276,18 +272,11 @@ namespace Amesos2
     Teuchos::TimeMonitor redistTimer2(this->timers_.vecRedistTime_);
     #endif
 
-    if ( is_contiguous_ == true ) {
-      Util::put_1d_data_helper<
-        MultiVecAdapter<Vector>,mumps_type>::do_put(X, bvals_(),
-            as<size_t>(ld_rhs),
-            ROOTED);
-    }
-    else {
-      Util::put_1d_data_helper<
-        MultiVecAdapter<Vector>,mumps_type>::do_put(X, bvals_(),
-            as<size_t>(ld_rhs),
-            CONTIGUOUS_AND_ROOTED);
-    }
+    Util::put_1d_data_helper<
+      MultiVecAdapter<Vector>,mumps_type>::do_put(X, bvals_(),
+        as<size_t>(ld_rhs),
+        (is_contiguous_ == true) ? ROOTED : CONTIGUOUS_AND_ROOTED);
+
     // ch: see function loadA_impl()
     MUMPS_MATRIX_LOAD_PREORDERING = false;
     return(ierr);
@@ -398,18 +387,12 @@ namespace Amesos2
         Teuchos::TimeMonitor mtxRedistTimer( this->timers_.mtxRedistTime_ );
         #endif
     
-        if ( is_contiguous_ == true ) {
-          Util::get_ccs_helper_kokkos_view<
-            MatrixAdapter<Matrix>,host_value_type_view,host_ordinal_type_view,host_ordinal_type_view>
-            ::do_get(this->matrixA_.ptr(), host_nzvals_view_, host_rows_view_, host_col_ptr_view_,
-                nnz_ret, ROOTED, ARBITRARY, this->rowIndexBase_);
-        }
-        else {
-          Util::get_ccs_helper_kokkos_view<
-            MatrixAdapter<Matrix>,host_value_type_view,host_ordinal_type_view,host_ordinal_type_view>
-            ::do_get(this->matrixA_.ptr(), host_nzvals_view_, host_rows_view_, host_col_ptr_view_,
-                nnz_ret, CONTIGUOUS_AND_ROOTED, ARBITRARY, this->rowIndexBase_);
-        }
+        Util::get_ccs_helper_kokkos_view<
+          MatrixAdapter<Matrix>,host_value_type_view,host_ordinal_type_view,host_ordinal_type_view>
+          ::do_get(this->matrixA_.ptr(), host_nzvals_view_, host_rows_view_, host_col_ptr_view_, nnz_ret
+            (is_contiguous_ == true) ? ROOTED : CONTIGUOUS_AND_ROOTED,
+            ARBITRARY,
+            this->rowIndexBase_);
   
         if( this->root_ ){
                   TEUCHOS_TEST_FOR_EXCEPTION( nnz_ret != as<local_ordinal_type>(this->globalNumNonZeros_),

--- a/packages/amesos2/src/Amesos2_PardisoMKL_def.hpp
+++ b/packages/amesos2/src/Amesos2_PardisoMKL_def.hpp
@@ -221,20 +221,12 @@ namespace Amesos2 {
       Teuchos::TimeMonitor redistTimer( this->timers_.vecRedistTime_ );
 #endif
 
-      if ( is_contiguous_ == true ) {
-        Util::get_1d_copy_helper<
-          MultiVecAdapter<Vector>,
-          solver_scalar_type>::do_get(B, bvals_(),
-              as<size_t>(ld_rhs),
-              ROOTED, this->rowIndexBase_);
-      }
-      else {
-        Util::get_1d_copy_helper<
-          MultiVecAdapter<Vector>,
-          solver_scalar_type>::do_get(B, bvals_(),
-              as<size_t>(ld_rhs),
-              CONTIGUOUS_AND_ROOTED, this->rowIndexBase_);
-      }
+      Util::get_1d_copy_helper<
+        MultiVecAdapter<Vector>,
+        solver_scalar_type>::do_get(B, bvals_(),
+          as<size_t>(ld_rhs),
+          (is_contiguous_ == true) ? ROOTED : CONTIGUOUS_AND_ROOTED,
+          this->rowIndexBase_);
     }
 
     if( this->root_ ){
@@ -269,20 +261,11 @@ namespace Amesos2 {
       Teuchos::TimeMonitor redistTimer(this->timers_.vecRedistTime_);
 #endif
 
-    if ( is_contiguous_ == true ) {
       Util::put_1d_data_helper<
       MultiVecAdapter<Vector>,
         solver_scalar_type>::do_put(X, xvals_(),
-                                    as<size_t>(ld_rhs),
-                                    ROOTED);
-    }
-    else {
-      Util::put_1d_data_helper<
-      MultiVecAdapter<Vector>,
-        solver_scalar_type>::do_put(X, xvals_(),
-                                    as<size_t>(ld_rhs),
-                                    CONTIGUOUS_AND_ROOTED);
-    }
+          as<size_t>(ld_rhs),
+          (is_contiguous_ == true) ? ROOTED : CONTIGUOUS_AND_ROOTED);
   }
 
     return( 0 );
@@ -526,23 +509,15 @@ PardisoMKL<Matrix,Vector>::loadA_impl(EPhase current_phase)
     Teuchos::TimeMonitor mtxRedistTimer( this->timers_.mtxRedistTime_ );
 #endif
 
-    if ( is_contiguous_ == true ) {
-      Util::get_crs_helper_kokkos_view<
-        MatrixAdapter<Matrix>,
-        host_value_type_array, host_ordinal_type_array, host_size_type_array>::do_get(
-            this->matrixA_.ptr(),
-            nzvals_view_, colind_view_, rowptr_view_,
-            nnz_ret, ROOTED, SORTED_INDICES, this->rowIndexBase_);
-    }
-    else {
-      Util::get_crs_helper_kokkos_view<
-        MatrixAdapter<Matrix>,
-        host_value_type_array, host_ordinal_type_array, host_size_type_array>::do_get(
-            this->matrixA_.ptr(),
-            nzvals_view_, colind_view_, rowptr_view_,
-            nnz_ret, CONTIGUOUS_AND_ROOTED, SORTED_INDICES, this->rowIndexBase_);
-    }
-}
+    Util::get_crs_helper_kokkos_view<
+      MatrixAdapter<Matrix>,
+      host_value_type_array, host_ordinal_type_array, host_size_type_array>::do_get(
+        this->matrixA_.ptr(),
+        nzvals_view_, colind_view_, rowptr_view_, nnz_ret, 
+        (is_contiguous_ == true) ? ROOTED : CONTIGUOUS_AND_ROOTED,
+        SORTED_INDICES,
+        this->rowIndexBase_);
+  }
 
   return( true );
 }

--- a/packages/amesos2/src/Amesos2_Superlu_def.hpp
+++ b/packages/amesos2/src/Amesos2_Superlu_def.hpp
@@ -993,24 +993,14 @@ Superlu<Matrix,Vector>::loadA_impl(EPhase current_phase)
                         std::runtime_error,
                         "Row and column maps have different indexbase ");
 
-    if ( is_contiguous_ == true ) {
-      Util::get_ccs_helper_kokkos_view<
-        MatrixAdapter<Matrix>,host_value_type_array,host_ordinal_type_array,
-          host_size_type_array>::do_get(this->matrixA_.ptr(),
-            host_nzvals_view_, host_rows_view_,
-            host_col_ptr_view_, nnz_ret, ROOTED,
-            ARBITRARY,
-            this->rowIndexBase_);
-    }
-    else {
-      Util::get_ccs_helper_kokkos_view<
-        MatrixAdapter<Matrix>,host_value_type_array,host_ordinal_type_array,
-          host_size_type_array>::do_get(this->matrixA_.ptr(),
-            host_nzvals_view_, host_rows_view_,
-            host_col_ptr_view_, nnz_ret, CONTIGUOUS_AND_ROOTED,
-            ARBITRARY,
-            this->rowIndexBase_);
-    }
+    Util::get_ccs_helper_kokkos_view<
+      MatrixAdapter<Matrix>,host_value_type_array,host_ordinal_type_array,
+        host_size_type_array>::do_get(this->matrixA_.ptr(),
+          host_nzvals_view_, host_rows_view_,
+          host_col_ptr_view_, nnz_ret,
+          (is_contiguous_ == true) ? ROOTED : CONTIGUOUS_AND_ROOTED,
+          ARBITRARY,
+          this->rowIndexBase_);
   }
 
   // Get the SLU data type for this type of matrix

--- a/packages/amesos2/src/Amesos2_Umfpack_def.hpp
+++ b/packages/amesos2/src/Amesos2_Umfpack_def.hpp
@@ -156,20 +156,10 @@ Umfpack<Matrix,Vector>::solve_impl(const Teuchos::Ptr<MultiVecAdapter<Vector> > 
     Teuchos::TimeMonitor mvConvTimer(this->timers_.vecConvTime_);
     Teuchos::TimeMonitor redistTimer( this->timers_.vecRedistTime_ );
 #endif
-    if ( is_contiguous_ == true ) {
-      Util::get_1d_copy_helper<MultiVecAdapter<Vector>,
-                               umfpack_type>::do_get(B, bValues(),
-                                                     as<size_t>(ld_rhs),
-                                                     ROOTED, 
-                                                     this->rowIndexBase_);
-    } 
-    else {
-      Util::get_1d_copy_helper<MultiVecAdapter<Vector>,
-                               umfpack_type>::do_get(B, bValues(),
-                                                     as<size_t>(ld_rhs),
-                                                     CONTIGUOUS_AND_ROOTED, 
-                                                     this->rowIndexBase_);
-    }
+    Util::get_1d_copy_helper<MultiVecAdapter<Vector>, umfpack_type>::do_get(B, bValues(),
+      as<size_t>(ld_rhs),
+      (is_contiguous_ == true) ? ROOTED : CONTIGUOUS_AND_ROOTED, 
+      this->rowIndexBase_);
   }
 
   int UmfpackRequest = this->control_.useTranspose_ ? UMFPACK_At : UMFPACK_A;
@@ -216,20 +206,10 @@ Umfpack<Matrix,Vector>::solve_impl(const Teuchos::Ptr<MultiVecAdapter<Vector> > 
     Teuchos::TimeMonitor redistTimer(this->timers_.vecRedistTime_);
 #endif
 
-    if ( is_contiguous_ == true ) {
-      Util::put_1d_data_helper<
-        MultiVecAdapter<Vector>,umfpack_type>::do_put(X, xValues(),
-                                                      as<size_t>(ld_rhs),
-                                                      ROOTED, 
-                                                      this->rowIndexBase_);
-    }
-    else {
-      Util::put_1d_data_helper<
-        MultiVecAdapter<Vector>,umfpack_type>::do_put(X, xValues(),
-                                                      as<size_t>(ld_rhs),
-                                                      CONTIGUOUS_AND_ROOTED, 
-                                                      this->rowIndexBase_);
-    }
+    Util::put_1d_data_helper<MultiVecAdapter<Vector>,umfpack_type>::do_put(X, xValues(),
+      as<size_t>(ld_rhs),
+      (is_contiguous_ == true) ? ROOTED : CONTIGUOUS_AND_ROOTED, 
+      this->rowIndexBase_);
   }
 
   return(ierr);
@@ -309,23 +289,12 @@ Umfpack<Matrix,Vector>::loadA_impl(EPhase current_phase)
     TEUCHOS_TEST_FOR_EXCEPTION( this->rowIndexBase_ != this->columnIndexBase_,
                         std::runtime_error,
                         "Row and column maps have different indexbase ");
-    if ( is_contiguous_ == true ) {
-      Util::get_ccs_helper_kokkos_view<MatrixAdapter<Matrix>,
-        host_value_type_array,host_ordinal_type_array, host_size_type_array>::do_get(this->matrixA_.ptr(),
-                                                          nzvals_view_, rowind_view_,
-                                                          colptr_view_, nnz_ret, 
-                                                          ROOTED,
-                                                          ARBITRARY,
-                                                          this->rowIndexBase_);
-    } else {
-      Util::get_ccs_helper_kokkos_view<MatrixAdapter<Matrix>,
-        host_value_type_array,host_ordinal_type_array, host_size_type_array>::do_get(this->matrixA_.ptr(),
-                                                          nzvals_view_, rowind_view_,
-                                                          colptr_view_, nnz_ret, 
-                                                          CONTIGUOUS_AND_ROOTED,
-                                                          ARBITRARY,
-                                                          this->rowIndexBase_);
-    }
+    Util::get_ccs_helper_kokkos_view<MatrixAdapter<Matrix>, host_value_type_array,host_ordinal_type_array,
+      host_size_type_array>::do_get(this->matrixA_.ptr(),
+        nzvals_view_, rowind_view_, colptr_view_, nnz_ret, 
+        (is_contiguous_ == true) ? ROOTED : CONTIGUOUS_AND_ROOTED,
+        ARBITRARY,
+        this->rowIndexBase_);
   }
 
   return true;


### PR DESCRIPTION
This PR uses a ternary to shorten the implementation of conditionals involving the `is_contiguous` flag in Amesos2.

@trilinos/amesos2

@ndellingwood 

## Motivation
This change seeks to help the readability of the code.

## Related Issues

* Related to #11578
