### PR TITLE
Amesos2: fix build with HIP, complex enabled

### DIFF
--- a/packages/amesos2/src/Amesos2_Lapack_decl.hpp
+++ b/packages/amesos2/src/Amesos2_Lapack_decl.hpp
@@ -96,12 +96,15 @@ namespace Amesos2 {
     typedef typename super_type::global_ordinal_type              global_ordinal_type;
     typedef typename super_type::global_size_type                    global_size_type;
 
+    // Version of scalar type that can be used in Kokkos device code
+    typedef typename MatrixTraits<Matrix>::impl_scalar_type          impl_scalar_type;
+
     typedef typename Teuchos::ScalarTraits<scalar_type>::magnitudeType magnitude_type;
 
     typedef Kokkos::DefaultHostExecutionSpace              HostExecSpaceType;
     typedef Kokkos::View<int*, HostExecSpaceType>          host_size_type_array;
     typedef Kokkos::View<int*, HostExecSpaceType>          host_ordinal_type_array;
-    typedef Kokkos::View<scalar_type*, HostExecSpaceType> host_value_type_array;
+    typedef Kokkos::View<impl_scalar_type*, HostExecSpaceType>  host_value_type_array;
 
     /// \name Constructor/Destructor methods
     //@{ 

--- a/packages/amesos2/src/Amesos2_MatrixTraits.hpp
+++ b/packages/amesos2/src/Amesos2_MatrixTraits.hpp
@@ -85,6 +85,7 @@ namespace Amesos2 {
     typedef Node node_t;
 
     typedef Tpetra::RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>  matrix_type;
+    typedef typename matrix_type::impl_scalar_type                    impl_scalar_type;
 
     typedef typename matrix_type::nonconst_global_inds_host_view_type global_host_idx_type;
     typedef typename matrix_type::nonconst_values_host_view_type      global_host_val_type;
@@ -107,6 +108,7 @@ namespace Amesos2 {
     typedef Node node_t;
 
     typedef Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>  matrix_type;
+    typedef typename matrix_type::impl_scalar_type                    impl_scalar_type;
 
     typedef typename matrix_type::nonconst_global_inds_host_view_type global_host_idx_type;
     typedef typename matrix_type::nonconst_values_host_view_type      global_host_val_type;
@@ -127,6 +129,7 @@ namespace Amesos2 {
     typedef LocalOrdinal global_size_t;
 
     typedef KokkosSparse::CrsMatrix<Scalar, LocalOrdinal, DeviceType>  matrix_type;
+    typedef Scalar impl_scalar_type;
     typedef Tpetra::Map<>::node_type node_t;
 
     typedef typename matrix_type::HostMirror::index_type  global_host_idx_type;
@@ -140,6 +143,7 @@ namespace Amesos2 {
   template <>
   struct MatrixTraits<Epetra_RowMatrix> {
     typedef double scalar_t;
+    typedef double impl_scalar_type;
     typedef int local_ordinal_t;
     typedef Tpetra::Map<>::global_ordinal_type global_ordinal_t;
     typedef Tpetra::Map<>::node_type node_t;
@@ -159,6 +163,7 @@ namespace Amesos2 {
   template <>
   struct MatrixTraits<Epetra_CrsMatrix> {
     typedef double scalar_t;
+    typedef double impl_scalar_type;
     typedef int local_ordinal_t;
     typedef Tpetra::Map<>::global_ordinal_type global_ordinal_t;
     typedef Tpetra::Map<>::node_type node_t;
@@ -188,6 +193,7 @@ namespace Amesos2 {
   template <>
   struct MatrixTraits<Epetra_VbrMatrix> {
     typedef double scalar_t;
+    typedef double impl_scalar_type;
     typedef int local_ordinal_t;
     typedef Tpetra::Map<>::global_ordinal_type global_ordinal_t;
     typedef Tpetra::Map<>::node_type node_t;


### PR DESCRIPTION
Fix build errors caused by host functions (conversion between std::complex and Kokkos::complex) being called in device code (some copy/conversion functor in Kokkos_CopyViews.hpp). Even though the copy in question was only ever executed on host, the functor body was getting compiled for both host and device.

The fix was to just add a typedef ``Amesos2::MatrixTraits<Matrix>::impl_scalar_type``, and use that as the value type for views in ``Amesos2::Lapack``. 
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/amesos2 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Allows amesos2 to build cleanly when HIP and complex are enabled. This issue was reported directly by a Sandia user of Trilinos and I was able to replicate it easily on Caraway (edit: this was before I saw the issues about it)

Note: only hipcc seems to treat "calling host from host/device" as an error by default - on Cuda/nvcc it's just a warning. These changes also fix the warnings on Cuda.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:
-->
## Related Issues

* Closes #11711 #11690
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 



## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
Covered by Amesos2_LAPACK_Solver_Test_MPI_4
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->