### PR TITLE
Tpetra: device version of sort_and_merge_crs

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -8599,7 +8599,7 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       Teuchos::TimeMonitor MMrc(*TimeMonitor::getNewTimer(prefix + std::string("TAFC sortCrsEntries")));
 #endif
       // Just to be safe we always static cast the Scalar pointer
-      // to the undelying impl_scalar type.
+      // to the underlying impl_scalar type.
       typename row_ptrs_host_view_type::non_const_type            CSR_rowptr_host(CSR_rowptr.getRawPtr(), CSR_rowptr.size());
       typename nonconst_local_inds_host_view_type::non_const_type CSR_colind_LID_host(CSR_colind_LID.getRawPtr(), CSR_colind_LID.size());
       typename nonconst_values_host_view_type::non_const_type     CSR_vals_host(reinterpret_cast<impl_scalar_type*>(CSR_vals.getRawPtr()), CSR_vals.size());

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -8613,12 +8613,43 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 #ifdef HAVE_TPETRA_MMM_TIMINGS
       Teuchos::TimeMonitor MMrc(*TimeMonitor::getNewTimer(prefix + std::string("TAFC sortAndMergeCrsEntries")));
 #endif
-      Import_Util::sortAndMergeCrsEntries (CSR_rowptr (),
-                                           CSR_colind_LID (),
-                                           CSR_vals ());
+      // Just to be safe we always static cast the Scalar pointer
+      // to the undelying impl_scalar type.
+      typename row_ptrs_host_view_type::non_const_type            CSR_rowptr_host(CSR_rowptr.getRawPtr(), CSR_rowptr.size());
+      typename nonconst_local_inds_host_view_type::non_const_type CSR_colind_LID_host(CSR_colind_LID.getRawPtr(), CSR_colind_LID.size());
+      typename nonconst_values_host_view_type::non_const_type     CSR_vals_host(reinterpret_cast<impl_scalar_type*>(CSR_vals.getRawPtr()), CSR_vals.size());
+
+      typename row_ptrs_device_view_type::non_const_type   CSR_rowptr_dev("rowmap", CSR_rowptr.size());
+      typename local_inds_device_view_type::non_const_type CSR_colind_LID_dev("colind", CSR_colind_LID.size());
+      typename values_device_view_type::non_const_type     CSR_vals_dev("values", CSR_vals.size());
+
+      Kokkos::deep_copy(CSR_rowptr_dev, CSR_rowptr_host);
+      Kokkos::deep_copy(CSR_colind_LID_dev, CSR_colind_LID_host);
+      Kokkos::deep_copy(CSR_vals_dev, CSR_vals_host);
+
+      Import_Util::sortAndMergeCrsEntries (CSR_rowptr_dev,
+                                           CSR_colind_LID_dev,
+                                           CSR_vals_dev);
+
+      // Resize before deep_copy to have matching extents
+      // between host and device or we will run into trouble...
+      if(CSR_colind_LID_host.extent(0) != CSR_colind_LID_dev.extent(0)) {
+	Kokkos::resize(CSR_colind_LID_host, CSR_colind_LID_dev.extent(0));
+	Kokkos::resize(CSR_vals_host, CSR_vals_dev.extent(0));
+      }
+
+      Kokkos::deep_copy(CSR_rowptr_host, CSR_rowptr_dev);
+      Kokkos::deep_copy(CSR_colind_LID_host, CSR_colind_LID_dev);
+      Kokkos::deep_copy(CSR_vals_host, CSR_vals_dev);
+
       if (CSR_rowptr[N] != mynnz) {
         CSR_colind_LID.resize (CSR_rowptr[N]);
         CSR_vals.resize (CSR_rowptr[N]);
+      }
+
+      for(int entryIdx = 0; entryIdx < CSR_colind_LID_host.extent_int(0); ++entryIdx) {
+	CSR_colind_LID[entryIdx] = CSR_colind_LID_host(entryIdx);
+	CSR_vals[entryIdx] = CSR_vals_host(entryIdx);
       }
     }
     else {

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -8598,9 +8598,28 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 #ifdef HAVE_TPETRA_MMM_TIMINGS
       Teuchos::TimeMonitor MMrc(*TimeMonitor::getNewTimer(prefix + std::string("TAFC sortCrsEntries")));
 #endif
-      Import_Util::sortCrsEntries (CSR_rowptr (),
-                                   CSR_colind_LID (),
-                                   CSR_vals ());
+      // Just to be safe we always static cast the Scalar pointer
+      // to the undelying impl_scalar type.
+      typename row_ptrs_host_view_type::non_const_type            CSR_rowptr_host(CSR_rowptr.getRawPtr(), CSR_rowptr.size());
+      typename nonconst_local_inds_host_view_type::non_const_type CSR_colind_LID_host(CSR_colind_LID.getRawPtr(), CSR_colind_LID.size());
+      typename nonconst_values_host_view_type::non_const_type     CSR_vals_host(reinterpret_cast<impl_scalar_type*>(CSR_vals.getRawPtr()), CSR_vals.size());
+
+      typename row_ptrs_device_view_type::non_const_type   CSR_rowptr_dev("rowmap", CSR_rowptr.size());
+      typename local_inds_device_view_type::non_const_type CSR_colind_LID_dev("colind", CSR_colind_LID.size());
+      typename values_device_view_type::non_const_type     CSR_vals_dev("values", CSR_vals.size());
+
+      Kokkos::deep_copy(CSR_rowptr_dev, CSR_rowptr_host);
+      Kokkos::deep_copy(CSR_colind_LID_dev, CSR_colind_LID_host);
+      Kokkos::deep_copy(CSR_vals_dev, CSR_vals_host);
+
+      Import_Util::sortCrsEntries (CSR_rowptr_dev,
+                                   CSR_colind_LID_dev,
+                                   CSR_vals_dev);
+
+      // Copy back to host so that ArrayRCPs are updated
+      Kokkos::deep_copy(CSR_rowptr_host, CSR_rowptr_dev);
+      Kokkos::deep_copy(CSR_colind_LID_host, CSR_colind_LID_dev);
+      Kokkos::deep_copy(CSR_vals_host, CSR_vals_dev);
     }
     else if ((! reverseMode && xferAsExport != nullptr) ||
              (reverseMode && xferAsImport != nullptr)) {
@@ -8638,19 +8657,24 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 	Kokkos::resize(CSR_vals_host, CSR_vals_dev.extent(0));
       }
 
+      // Copy back to host so we can later pass it to ArrayRCPs
       Kokkos::deep_copy(CSR_rowptr_host, CSR_rowptr_dev);
       Kokkos::deep_copy(CSR_colind_LID_host, CSR_colind_LID_dev);
       Kokkos::deep_copy(CSR_vals_host, CSR_vals_dev);
 
+      // First resize the ArrayRCPs correctly so meta data
+      // matches actual data and avoid suprizes down the road
       if (CSR_rowptr[N] != mynnz) {
         CSR_colind_LID.resize (CSR_rowptr[N]);
         CSR_vals.resize (CSR_rowptr[N]);
       }
 
-      for(int entryIdx = 0; entryIdx < CSR_colind_LID_host.extent_int(0); ++entryIdx) {
-	CSR_colind_LID[entryIdx] = CSR_colind_LID_host(entryIdx);
-	CSR_vals[entryIdx] = CSR_vals_host(entryIdx);
-      }
+      // Do the actual data copy, after this the matrix local
+      // data should be correctly defined.
+      typename nonconst_local_inds_host_view_type::non_const_type tmp_CSR_colind_LID_host(CSR_colind_LID.getRawPtr(), CSR_colind_LID.size());
+      typename nonconst_values_host_view_type::non_const_type     tmp_CSR_vals_host(reinterpret_cast<impl_scalar_type*>(CSR_vals.getRawPtr()), CSR_vals.size());
+      Kokkos::deep_copy(tmp_CSR_colind_LID_host, CSR_colind_LID_host);
+      Kokkos::deep_copy(tmp_CSR_vals_host, CSR_vals_host);
     }
     else {
       TEUCHOS_TEST_FOR_EXCEPTION(


### PR DESCRIPTION
This should increase the speed of MueLu by a nice amount on GPU platforms : )

@trilinos/tpetra 

## Motivation
There is no reason to not perform the sort and merge of csr entries on device.
This code should increase the performance of Tpetra and MueLu on GPU architectures.

## Related Issues

* Closes #11696 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to #11689 
* Part of 
* Composed of 


## Stakeholder Feedback


## Testing
Tested on Crusher