### PR TITLE
Tpetra: Adding version checking for external Kokkos

### DIFF
--- a/packages/tpetra/CMakeLists.txt
+++ b/packages/tpetra/CMakeLists.txt
@@ -30,13 +30,13 @@ SET(Tpetra_SUPPORTED_KOKKOS_VERSION "4.0.0")
 # Option to allow developers to ignore incompatible Kokkos versions
 TRIBITS_ADD_OPTION_AND_DEFINE(
   Tpetra_IGNORE_KOKKOS_COMPATIBILITY
-  TPETRA_IGNORE_KOKKOS_COMPATIBILITY
+  ""
   "If true, disables the Kokkos version compatibility checking in Tpetra"
   OFF
 )
 # Kokkos version checking
 ASSERT_DEFINED (Tpetra_IGNORE_KOKKOS_COMPATIBILITY)
-IF(DEFINED TPL_ENABLE_Kokkos AND TPL_ENABLE_Kokkos)
+IF(TPL_ENABLE_Kokkos)
   # If we're using external Kokkos, we check the supported version, unless the cmake option says otherwise
   IF(DEFINED Kokkos_VERSION)
     IF(Kokkos_VERSION VERSION_EQUAL Tpetra_SUPPORTED_KOKKOS_VERSION)


### PR DESCRIPTION
Issue: #11756
Tests: Tested all use cases (internal, external ok, external not matching, external not matching with override)
Stakeholder feedback: See below


The logic here is that Tpetra is a sensible place to check Kokkos compatibility with Trilinos, since the vast majority of Trilinos users that use Kokkos also use Tpetra.  If there's a strong demand to put this somewhere at the top level, we can look into that, but that might be overkill.