### PR TITLE
Stokhos: Moves KokkosContainers from an optional to a required dependency

### DIFF
--- a/packages/stokhos/cmake/Dependencies.cmake
+++ b/packages/stokhos/cmake/Dependencies.cmake
@@ -1,5 +1,5 @@
-SET(LIB_REQUIRED_DEP_PACKAGES Teuchos KokkosCore)
-SET(LIB_OPTIONAL_DEP_PACKAGES EpetraExt Ifpack ML TriKota Anasazi Sacado NOX Isorropia KokkosKernels TeuchosKokkosComm KokkosAlgorithms KokkosContainers Tpetra Ifpack2 MueLu Belos Amesos2 Thyra Xpetra)
+SET(LIB_REQUIRED_DEP_PACKAGES Teuchos KokkosCore KokkosContainers)
+SET(LIB_OPTIONAL_DEP_PACKAGES EpetraExt Ifpack ML TriKota Anasazi Sacado NOX Isorropia KokkosKernels TeuchosKokkosComm KokkosAlgorithms Tpetra Ifpack2 MueLu Belos Amesos2 Thyra Xpetra)
 SET(TEST_REQUIRED_DEP_PACKAGES)
 SET(TEST_OPTIONAL_DEP_PACKAGES AztecOO Stratimikos Zoltan KokkosContainers)
 SET(LIB_REQUIRED_DEP_TPLS)


### PR DESCRIPTION
The Kokkos_StaticCrsGraph.hpp file is included in several files in stokhos/src/kokkos, which is in the KokkosContainers subpackage. That is an optional dependency in the Dependencies.cmake file, so those headers are not installed if optional dependencies are not included.  The result is a build failure in Xyce because, when Stokhos is enabled, that header is not found.  By moving KokkosContainers to a required dependency, this build failure goes away.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/<teamName>

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->