### PR TITLE
Intrepid2 :: Projection doesn't always need orientations

### DIFF
--- a/packages/intrepid2/src/Projection/Intrepid2_ProjectionTools.hpp
+++ b/packages/intrepid2/src/Projection/Intrepid2_ProjectionTools.hpp
@@ -630,7 +630,7 @@ public:
     projStruct.createL2ProjectionStruct(dstBasis, srcBasis->getDegree());
 
     ordinal_type numPoints = projStruct.getNumTargetEvalPoints();
-    ordinal_type numCells = cellOrientations.extent(0);
+    ordinal_type numCells = srcCoeffs.extent(0);
     ordinal_type dim = srcBasis->getBaseCellTopology().getDimension();
     ordinal_type srcBasisCardinality = srcBasis->getCardinality();
     ordinal_type fieldDimension = (srcBasis->getFunctionSpace() == Intrepid2::FUNCTION_SPACE_HCURL || srcBasis->getFunctionSpace() == Intrepid2::FUNCTION_SPACE_HDIV) ? dim : 1;


### PR DESCRIPTION
In my testing of the new wrappers introduced in #11698 I found that if `orts` is an empty array, the projection operation thinks `ncells = 0` and nothing occurs.
I'm proposing this simple fix which should allow for an empty `orts` array.
The use case is for nodal bases where one may not need to compute the orientations.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/<teamName>

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->