### PR TITLE
Tpetra: Adding support for Kokkos::deep_copy tracking via Teuchos timers

### DIFF
--- a/packages/muelu/test/unit_tests/MueLu_Test_ETI.hpp
+++ b/packages/muelu/test/unit_tests/MueLu_Test_ETI.hpp
@@ -128,7 +128,7 @@ bool Automatic_Test_ETI(int argc, char *argv[]) {
 #endif
 
 #ifdef HAVE_MUELU_TPETRA
-    bool timedeepcopy = true;   clp.setOption("timedeepcopy", "notimedeepcopy", &timedeepcopy, "instrument Kokkos::deep_copy() with Teuchos timers.  This can also be done with by setting the environment variable TPETRA_TIME_KOKKOS_DEEP_COPY=ON");
+    bool timedeepcopy = false;   clp.setOption("timedeepcopy", "notimedeepcopy", &timedeepcopy, "instrument Kokkos::deep_copy() with Teuchos timers.  This can also be done with by setting the environment variable TPETRA_TIME_KOKKOS_DEEP_COPY=ON");
 #endif
     Xpetra::Parameters xpetraParameters(clp);
 

--- a/packages/muelu/test/unit_tests/MueLu_Test_ETI.hpp
+++ b/packages/muelu/test/unit_tests/MueLu_Test_ETI.hpp
@@ -61,6 +61,7 @@
 
 #if defined(HAVE_MUELU_TPETRA)
 #include <TpetraCore_config.h>
+#include <Tpetra_Details_DeepCopyTeuchosTimerInjection.hpp>
 #endif
 
 #include <KokkosKernels_config.h>
@@ -125,6 +126,10 @@ bool Automatic_Test_ETI(int argc, char *argv[]) {
 #ifdef HAVE_TEUCHOS_STACKTRACE
     bool stacktrace = true;     clp.setOption("stacktrace", "nostacktrace", &stacktrace, "display stacktrace");
 #endif
+
+#ifdef HAVE_MUELU_TPETRA
+    bool timedeepcopy = true;   clp.setOption("timedeepcopy", "notimedeepcopy", &timedeepcopy, "instrument Kokkos::deep_copy() with Teuchos timers.  This can also be done with by setting the environment variable TPETRA_TIME_KOKKOS_DEEP_COPY=ON");
+#endif
     Xpetra::Parameters xpetraParameters(clp);
 
     clp.recogniseAllOptions(false);
@@ -134,6 +139,11 @@ bool Automatic_Test_ETI(int argc, char *argv[]) {
       case Teuchos::CommandLineProcessor::PARSE_SUCCESSFUL:
       case Teuchos::CommandLineProcessor::PARSE_HELP_PRINTED:         break;
     }
+
+#ifdef HAVE_MUELU_TPETRA
+    if(timedeepcopy)
+      Tpetra::Details::AddKokkosDeepCopyToTimeMonitor(true);
+#endif
 
 #ifdef HAVE_TEUCHOS_STACKTRACE
     if (stacktrace)

--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_main.cpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_main.cpp
@@ -49,7 +49,7 @@
 #include "Teuchos_FancyOStream.hpp"
 #include "Teuchos_TimeMonitor.hpp"
 #include "Teuchos_StackedTimer.hpp"
-
+#include "Tpetra_Details_DeepCopyTeuchosTimerInjection.hpp"
 #include "fem_assembly_commandLineOpts.hpp"
 #include "fem_assembly_typedefs.hpp"
 #include "fem_assembly_MeshDatabase.hpp"
@@ -104,6 +104,9 @@ int main (int argc, char *argv[])
     timer = rcp(new StackedTimer("X) Global", false));
     TimeMonitor::setStackedTimer(timer);
   }
+
+  // Force timing of the Kokkos::deep_copy calls
+  Tpetra::Details::AddKokkosDeepCopyToTimeMonitor(true);
 
   // Entry point
   if(opts.execInsertGlobalIndicesFE && executeInsertGlobalIndicesFESP(comm, opts))

--- a/packages/tpetra/core/src/CMakeLists.txt
+++ b/packages/tpetra/core/src/CMakeLists.txt
@@ -938,4 +938,3 @@ SET_PROPERTY(
 # that running "make" will also rerun CMake in order to regenerate Makefiles.
 #
 # Here's another change, another, and another
-#

--- a/packages/tpetra/core/src/Tpetra_Core.cpp
+++ b/packages/tpetra/core/src/Tpetra_Core.cpp
@@ -47,6 +47,7 @@
 
 #include <Kokkos_Core.hpp>
 #include "Tpetra_Details_checkLaunchBlocking.hpp"
+#include "Tpetra_Details_DeepCopyTeuchosTimerInjection.hpp"
 
 namespace Tpetra {
 
@@ -240,6 +241,9 @@ namespace Tpetra {
       const int myRank = 0;
 #endif // defined(HAVE_TPETRACORE_MPI)
       initKokkosIfNeeded (argc, argv, myRank);
+
+      // Add Kokkos::deep_copy() to the TimeMonitor if the environment says so
+      Tpetra::Details::AddKokkosDeepCopyToTimeMonitor();
     }
     tpetraIsInitialized_ = true;
   }
@@ -258,6 +262,9 @@ namespace Tpetra {
       const int myRank = 0;
 #endif // defined(HAVE_TPETRACORE_MPI)
       initKokkosIfNeeded (argc, argv, myRank);
+
+      // Add Kokkos::deep_copy() to the TimeMonitor if the environment says so
+      Tpetra::Details::AddKokkosDeepCopyToTimeMonitor();
     }
     tpetraIsInitialized_ = true;
 
@@ -300,6 +307,9 @@ namespace Tpetra {
       // MPI_Comm_rank without first checking MPI_Finalized.
       const int myRank = comm->getRank ();
       initKokkosIfNeeded (argc, argv, myRank);
+
+      // Add Kokkos::deep_copy() to the TimeMonitor if the environment says so
+      Tpetra::Details::AddKokkosDeepCopyToTimeMonitor();
     }
     tpetraIsInitialized_ = true;
     wrappedDefaultComm_ = comm;

--- a/packages/tpetra/core/src/Tpetra_Details_Behavior.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Behavior.cpp
@@ -572,6 +572,19 @@ bool Behavior::overlapCommunicationAndComputation ()
 }
 
 
+bool Behavior::timeKokkosDeepCopy() 
+{
+  constexpr char envVarName[] = "TPETRA_TIME_KOKKOS_DEEP_COPY";
+  constexpr bool defaultValue(false);
+
+  static bool value_ = defaultValue;
+  static bool initialized_ = false;
+  return idempotentlyGetEnvironmentVariableAsBool
+    (value_, initialized_, envVarName, defaultValue);
+
+}    
+
+
 } // namespace Details
 } // namespace Tpetra
 

--- a/packages/tpetra/core/src/Tpetra_Details_Behavior.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Behavior.hpp
@@ -276,6 +276,13 @@ public:
   static bool overlapCommunicationAndComputation();
 
 
+  /// \brief Add Teuchos timers for all host calls to Kokkos::deep_copy().
+  /// This is especially useful for identifying host/device data transfers
+  ///
+  /// This is disabled by default.  You may control this at run time via the
+  /// <tt>TPETRA_TIME_KOKKOS_DEEP_COPY</tt> environment variable.
+  static bool timeKokkosDeepCopy();
+
 };
 
 } // namespace Details

--- a/packages/tpetra/core/src/Tpetra_Details_DeepCopyTeuchosTimerInjection.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DeepCopyTeuchosTimerInjection.cpp
@@ -1,0 +1,121 @@
+/*
+// @HEADER
+// ***********************************************************************
+//
+//          Tpetra: Templated Linear Algebra Services Package
+//                 Copyright (2008) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// ************************************************************************
+// @HEADER
+*/
+#include "Tpetra_Details_DeepCopyTeuchosTimerInjection.hpp"
+#include "TpetraCore_config.h"
+#include "Tpetra_Details_Behavior.hpp"
+#include "Kokkos_Core.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_Time.hpp"
+#include "Teuchos_RCP.hpp"
+#ifdef HAVE_TEUCHOS_ADD_TIME_MONITOR_TO_STACKED_TIMER
+#include "Teuchos_StackedTimer.hpp"
+#include <sstream>
+#endif
+#include <string>
+
+namespace Tpetra {
+namespace Details {
+
+  namespace DeepCopyTimerInjection {
+    Teuchos::RCP<Teuchos::Time> timer_;
+    bool initialized_ = false;
+
+    void kokkosp_begin_deep_copy(Kokkos::Tools::SpaceHandle dst_handle, const char* dst_name, const void* dst_ptr,                                 
+                                 Kokkos::Tools::SpaceHandle src_handle, const char* src_name, const void* src_ptr,
+                                 uint64_t size) {      
+      if(timer_ != Teuchos::null)
+        std::cout << "WARNING: Kokkos::deep_copy() started within another Kokkos::deep_copy().  Timers will be in error"<<std::endl;
+
+      timer_ = Teuchos::TimeMonitor::getNewTimer(std::string("Kokkos::deep_copy [")+src_handle.name+"=>"+dst_handle.name+"]");
+      timer_->start();
+      timer_->incrementNumCalls();
+#ifdef HAVE_TEUCHOS_ADD_TIME_MONITOR_TO_STACKED_TIMER
+      const auto stackedTimer = Teuchos::TimeMonitor::getStackedTimer();
+      if (nonnull(stackedTimer))
+        stackedTimer->start(timer_->name());
+#endif
+    }
+
+    void kokkosp_end_deep_copy() {
+      if (timer_ != Teuchos::null) {
+        timer_->stop();
+#ifdef HAVE_TEUCHOS_ADD_TIME_MONITOR_TO_STACKED_TIMER
+        try {
+          const auto stackedTimer = Teuchos::TimeMonitor::getStackedTimer();
+          if (nonnull(stackedTimer))
+            stackedTimer->stop(timer_->name());
+        }
+        catch (std::runtime_error&) {
+          std::ostringstream warning;
+          warning <<
+            "\n*********************************************************************\n"
+            "WARNING: Overlapping timers detected!\n"
+            "A TimeMonitor timer was stopped before a nested subtimer was\n"
+            "stopped. This is not allowed by the StackedTimer. This corner case\n"
+            "typically occurs if the TimeMonitor is stored in an RCP and the RCP is\n"
+            "assigned to a new timer. To disable this warning, either fix the\n"
+            "ordering of timer creation and destuction or disable the StackedTimer\n";
+          std::cout << warning.str() << std::endl;
+          Teuchos::TimeMonitor::setStackedTimer(Teuchos::null);
+        }
+#endif
+      }
+      
+      timer_ = Teuchos::null;
+    }
+  }// end DeepCopyTimerInjection
+
+
+
+  void AddKokkosDeepCopyToTimeMonitor(bool force) {
+    if (!DeepCopyTimerInjection::initialized_) {
+      if (force || Tpetra::Details::Behavior::timeKokkosDeepCopy()) {
+        Kokkos::Tools::Experimental::set_begin_deep_copy_callback(DeepCopyTimerInjection::kokkosp_begin_deep_copy);
+        Kokkos::Tools::Experimental::set_end_deep_copy_callback(DeepCopyTimerInjection::kokkosp_end_deep_copy);
+        DeepCopyTimerInjection::initialized_=true;
+      }
+    }
+  }
+
+
+} // namespace Details
+} // namespace Tpetra
+


### PR DESCRIPTION
Issue: #11767
Tests: Added to FEM Assembly
Stakeholder feedback: F2F discussions w/ Glusa.


You can do this in one of three ways:
1. Specifically call a function to turn it on
2. Use a command-line argument via the MueLu ETI Helper
3. Use the  TPETRA_TIME_KOKKOS_DEEP_COPY environment variable.

Kokkos Profiling hooks FTW