### PR TITLE
MueLu: Guard repartition option in hierarchy write unit test by HAVE_MUELU_ZOLTAN2

### DIFF
--- a/packages/muelu/test/unit_tests/Hierarchy.cpp
+++ b/packages/muelu/test/unit_tests/Hierarchy.cpp
@@ -1567,7 +1567,7 @@ namespace MueLuTests {
     RCP<RealValuedMultiVector> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<SC,LO,GO,Map,RealValuedMultiVector>("1D", A->getRowMap(), galeriList);
 
     Teuchos::ParameterList paramList;
-#ifdef HAVE_MPI
+#if defined(HAVE_MPI) && defined(HAVE_MUELU_ZOLTAN2)
     paramList.set("repartition: enable", true);
     paramList.set("repartition: start level", 1);
     paramList.set("repartition: min rows per proc", 6);


### PR DESCRIPTION
Closes #11773.

@trilinos/muelu 
I have no clue if this will even be noticed by testing since I assume testing enables the majority of packages, but I think this is the best way to fix the test on builds without Zoltan2.