### PR TITLE
MueLu: Update ParameterListInterpreter to disable repartitioning if Zoltan/Zoltan2 are unavailable

### DIFF
--- a/packages/muelu/test/unit_tests/Hierarchy.cpp
+++ b/packages/muelu/test/unit_tests/Hierarchy.cpp
@@ -1567,11 +1567,9 @@ namespace MueLuTests {
     RCP<RealValuedMultiVector> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<SC,LO,GO,Map,RealValuedMultiVector>("1D", A->getRowMap(), galeriList);
 
     Teuchos::ParameterList paramList;
-#if defined(HAVE_MPI) && defined(HAVE_MUELU_ZOLTAN2)
     paramList.set("repartition: enable", true);
     paramList.set("repartition: start level", 1);
     paramList.set("repartition: min rows per proc", 6);
-#endif
     paramList.set("coarse: max size", 29);
     //    paramList.sublist("user data").set("Node Comm",nodeComm);
     paramList.set("verbosity", "high");


### PR DESCRIPTION
@trilinos/muelu 

This is a more appropriate resolution for #11773/#11774. The `#ifdef` logic in `ParameterListInterpreter` was a little messy, as evidenced by an `#ifdef HAVE_MPI` nested inside an `#ifdef HAVE_MPI`, which I also removed. Now the ParameterListInterpreter will turn repartitioning off and print an appropriate warning if the user does not have both MPI and Zoltan/Zoltan2.

Therefore, I don't think I need to guard repartitioning in the hierarchy test with `HAVE_MPI` or `HAVE_MUELU_ZOLTAN2` since that logic now falls on the `ParameterListInterpreter`.

Previous behavior: If the user requests repartitioning and does not have MPI, it will print a warning and turn repartitioning off. If the user requests repartitioning and has MPI enabled but does not have Zoltan2 enabled, it will attempt to switch to Zoltan and then throw and crash if Zoltan isn't available either. 
New behavior: If the user requests repartitioning and has MPI enabled but does not have Zoltan or Zoltan2 enabled, it will print a warning about Zoltan/Zoltan2 and disable repartitioning, consistent with the current behavior when MPI is unavailable.