### PR TITLE
Ifpack+Ifpack2: Fix Hypre interfaces

### DIFF
--- a/packages/ifpack/src/Ifpack_Hypre.h
+++ b/packages/ifpack/src/Ifpack_Hypre.h
@@ -216,6 +216,18 @@ public:
    */
     int SetParameter(Hypre_Chooser chooser, int (*pt2Func)(HYPRE_Solver, double, int), double parameter1, int parameter2);
 
+    //! Set a parameter that takes an int then a double.
+    /*!
+    \param chooser (In) -A Hypre_Chooser enumerated type set to Solver or Preconditioner, whatever the parameter is setting for.
+    \param *pt2Func (In) -The function that sets the parameter. It must set parameters for the type of solver or preconditioner that was created.
+      An example is if the solver is BoomerAMG, the function to set relaxation weight for a given level would be &HYPRE_BoomerAMGSetLevelRelaxWt
+    \param parameter1 (In) -The int parameter being set.
+    \param parameter2 (In) - The double parameter being set.
+
+    \return Integer error code, set to 0 if successful.
+   */
+    int SetParameter(Hypre_Chooser chooser, int (*pt2Func)(HYPRE_Solver, int, double), int parameter1, double parameter2);
+
     //! Set a parameter that takes two int parameters.
     /*!
     \param chooser (In) -A Hypre_Chooser enumerated type set to Solver or Preconditioner, whatever the parameter is setting for.

--- a/packages/ifpack/utils/parseHypre.py
+++ b/packages/ifpack/utils/parseHypre.py
@@ -16,7 +16,8 @@ outputFile = argv[2]
 
 functionInt = re.compile(r'\s*HYPRE_Int\s+(HYPRE_[a-zA-Z]+Set[a-zA-Z]+)\s*\(\s*HYPRE_Solver\s*solver\s*,\s*HYPRE_Int\s*[^\s*]+\s*\)')
 functionDouble = re.compile(r'\s*HYPRE_Int\s+(HYPRE_[a-zA-Z]+Set[a-zA-Z]+)\s*\(\s*HYPRE_Solver\s*solver\s*,\s*HYPRE_Real\s*[^\s*]+\s*\)')
-functionDoubleInt = re.compile(r'\s*HYPRE_Int\s+(HYPRE_[a-zA-Z]+Set[a-zA-Z]+)\s*\(\s*HYPRE_Solver\s*solver\s*,\s*HYPRE_Int\s*[^\s*]+\s*,\s*HYPRE_Real\s*[^\s*]+\s*\)')
+functionDoubleInt = re.compile(r'\s*HYPRE_Int\s+(HYPRE_[a-zA-Z]+Set[a-zA-Z]+)\s*\(\s*HYPRE_Solver\s*solver\s*,\s*HYPRE_Real\s*[^\s*]+\s*,\s*HYPRE_Int\s*[^\s*]+\s*\)')
+functionIntDouble = re.compile(r'\s*HYPRE_Int\s+(HYPRE_[a-zA-Z]+Set[a-zA-Z]+)\s*\(\s*HYPRE_Solver\s*solver\s*,\s*HYPRE_Int\s*[^\s*]+\s*,\s*HYPRE_Real\s*[^\s*]+\s*\)')
 functionIntInt = re.compile(r'\s*HYPRE_Int\s+(HYPRE_[a-zA-Z]+Set[a-zA-Z]+)\s*\(\s*HYPRE_Solver\s*solver\s*,\s*HYPRE_Int\s*[^\s*]+\s*,\s*HYPRE_Int\s*[^\s*]+\s*\)')
 functionIntStar = re.compile(r'\s*HYPRE_Int\s+(HYPRE_[a-zA-Z]+Set[a-zA-Z]+)\s*\(\s*HYPRE_Solver\s*solver\s*,\s*HYPRE_Int\s*\*[^\s*]+\s*\)')
 functionDoubleStar = re.compile(r'\s*HYPRE_Int\s+(HYPRE_[a-zA-Z]+Set[a-zA-Z]+)\s*\(\s*HYPRE_Solver\s*solver\s*,\s*HYPRE_Real\s*\*[^\s*]+\s*\)')
@@ -59,6 +60,12 @@ with open(outputFile, 'w') as out:
     m = list(set(m))
     fs = ['  {{\"{func}\", &{func}}}'.format(func=func) if not func in skip else '//  {{\"{func}\", &{func}}}'.format(func=func) for func in m]
     out.write("const std::map<std::string, double_int_func> FunctionParameter::hypreMapDoubleIntFunc_ = {{\n{}}};".format(',\n'.join(fs)))
+
+    out.write('\n\n')
+    m = functionIntDouble.findall(s)
+    m = list(set(m))
+    fs = ['  {{\"{func}\", &{func}}}'.format(func=func) if not func in skip else '//  {{\"{func}\", &{func}}}'.format(func=func) for func in m]
+    out.write("const std::map<std::string, int_double_func> FunctionParameter::hypreMapIntDoubleFunc_ = {{\n{}}};".format(',\n'.join(fs)))
 
     out.write('\n\n')
     m = functionIntInt.findall(s)

--- a/packages/ifpack2/src/Ifpack2_Hypre_FunctionParameters.hpp
+++ b/packages/ifpack2/src/Ifpack2_Hypre_FunctionParameters.hpp
@@ -99,6 +99,7 @@ typedef struct hypre_ParVector_struct hypre_ParVector;
 typedef HYPRE_Int (*int_func)(HYPRE_Solver, HYPRE_Int);
 typedef HYPRE_Int (*double_func)(HYPRE_Solver, double);
 typedef HYPRE_Int (*double_int_func)(HYPRE_Solver, double, HYPRE_Int);
+typedef HYPRE_Int (*int_double_func)(HYPRE_Solver, HYPRE_Int, double);
 typedef HYPRE_Int (*int_int_func)(HYPRE_Solver, HYPRE_Int, HYPRE_Int);
 typedef HYPRE_Int (*int_star_func)(HYPRE_Solver, HYPRE_Int*);
 typedef HYPRE_Int (*int_star_star_func)(HYPRE_Solver, HYPRE_Int**);
@@ -150,6 +151,14 @@ namespace Ifpack2 {
       double_int_func_(funct),
       int_param1_(param2),
       double_param1_(param1) {}
+
+    //! Single int, single double constructor.
+    FunctionParameter(Hypre_Chooser chooser, int_double_func funct, HYPRE_Int param1, double param2):
+      chooser_(chooser),
+      option_(10),
+      int_double_func_(funct),
+      int_param1_(param1),
+      double_param1_(param2) {}
 
     FunctionParameter(Hypre_Chooser chooser, std::string funct_name, double param1, HYPRE_Int param2):
       chooser_(chooser),
@@ -290,6 +299,8 @@ namespace Ifpack2 {
           return int_int_int_double_int_int_func_(solver, int_param1_, int_param2_, int_param3_, double_param1_, int_param4_, int_param5_);
         } else if (option_ == 9) {
           return char_star_func_(solver, char_star_param_);
+        } else if (option_ == 10) {
+          return int_double_func_(solver, int_param1_, double_param1_);
         } else {
           IFPACK2_CHK_ERR(-2);
         }
@@ -314,6 +325,8 @@ namespace Ifpack2 {
           return int_int_int_double_int_int_func_(precond, int_param1_, int_param2_, int_param3_, double_param1_, int_param4_, int_param5_);
         } else if (option_ == 9) {
           return char_star_func_(solver, char_star_param_);
+        } else if (option_ == 10) {
+          return int_double_func_(precond, int_param1_, double_param1_);
         } else {
           IFPACK2_CHK_ERR(-2);
         }
@@ -343,6 +356,7 @@ namespace Ifpack2 {
     int_func int_func_;
     double_func double_func_;
     double_int_func double_int_func_;
+    int_double_func int_double_func_;
     int_int_func int_int_func_;
     int_star_func int_star_func_;
     double_star_func double_star_func_;
@@ -365,6 +379,7 @@ namespace Ifpack2 {
     static const std::map<std::string, int_func> hypreMapIntFunc_;
     static const std::map<std::string, double_func> hypreMapDoubleFunc_;
     static const std::map<std::string, double_int_func> hypreMapDoubleIntFunc_;
+    static const std::map<std::string, int_double_func> hypreMapIntDoubleFunc_;
     static const std::map<std::string, int_int_func> hypreMapIntIntFunc_;
     static const std::map<std::string, int_star_func> hypreMapIntStarFunc_;
     static const std::map<std::string, double_star_func> hypreMapDoubleStarFunc_;

--- a/packages/ifpack2/src/Ifpack2_Hypre_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_Hypre_decl.hpp
@@ -295,6 +295,18 @@ public:
    */
     int SetParameter(Hypre_Chooser chooser, global_ordinal_type (*pt2Func)(HYPRE_Solver, double, global_ordinal_type), double parameter1, global_ordinal_type parameter2);
 
+    //! Set a parameter that takes an int then a double.
+    /*!
+    \param chooser (In) -A Hypre_Chooser enumerated type set to Solver or Preconditioner, whatever the parameter is setting for.
+    \param *pt2Func (In) -The function that sets the parameter. It must set parameters for the type of solver or preconditioner that was created.
+      An example is if the solver is BoomerAMG, the function to set relaxation weight for a given level would be &HYPRE_BoomerAMGSetLevelRelaxWt
+    \param parameter1 (In) -The int parameter being set.
+    \param parameter2 (In) - The double parameter being set.
+
+    \return Integer error code, set to 0 if successful.
+   */
+    int SetParameter(Hypre_Chooser chooser, global_ordinal_type (*pt2Func)(HYPRE_Solver, global_ordinal_type, double), global_ordinal_type parameter1, double parameter2);
+
     //! Set a parameter that takes two int parameters.
     /*!
     \param chooser (In) -A Hypre_Chooser enumerated type set to Solver or Preconditioner, whatever the parameter is setting for.

--- a/packages/ifpack2/src/Ifpack2_Hypre_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Hypre_def.hpp
@@ -347,6 +347,14 @@ int Hypre<MatrixType>::SetParameter(Hypre_Chooser chooser, global_ordinal_type (
 
 //==============================================================================
 template<class MatrixType>
+int Hypre<MatrixType>::SetParameter(Hypre_Chooser chooser, global_ordinal_type (*pt2Func)(HYPRE_Solver, global_ordinal_type, double), global_ordinal_type parameter1, double parameter2){
+  RCP<FunctionParameter> temp = rcp(new FunctionParameter(chooser, pt2Func, parameter1, parameter2));
+  IFPACK2_CHK_ERR(AddFunToList(temp));
+  return 0;
+} //SetParameter() - int,double function pointer
+
+//==============================================================================
+template<class MatrixType>
 int Hypre<MatrixType>::SetParameter(Hypre_Chooser chooser, global_ordinal_type (*pt2Func)(HYPRE_Solver, global_ordinal_type, global_ordinal_type), global_ordinal_type parameter1, global_ordinal_type parameter2){
   RCP<FunctionParameter> temp = rcp(new FunctionParameter(chooser, pt2Func, parameter1, parameter2));
   IFPACK2_CHK_ERR(AddFunToList(temp));
@@ -393,7 +401,7 @@ template<class MatrixType>
 int Hypre<MatrixType>::SetDiscreteGradient(Teuchos::RCP<const crs_matrix_type> G){
   using LO = local_ordinal_type;
   using GO = global_ordinal_type;
-  using SC = scalar_type;
+  // using SC = scalar_type;
 
   // Sanity check
   if(!A_->getRowMap()->isSameAs(*G->getRowMap()))
@@ -884,7 +892,7 @@ template<class MatrixType>
 int Hypre<MatrixType>::CopyTpetraToHypre(){
   using LO = local_ordinal_type;
   using GO = global_ordinal_type;
-  using SC = scalar_type;
+  // using SC = scalar_type;
 
   Teuchos::RCP<const crs_matrix_type> Matrix = Teuchos::rcp_dynamic_cast<const crs_matrix_type>(A_);
   if(Matrix.is_null()) 

--- a/packages/ifpack2/utils/parseHypre.py
+++ b/packages/ifpack2/utils/parseHypre.py
@@ -16,7 +16,8 @@ outputFile = argv[2]
 
 functionInt = re.compile(r'\s*HYPRE_Int\s+(HYPRE_[a-zA-Z]+Set[a-zA-Z]+)\s*\(\s*HYPRE_Solver\s*solver\s*,\s*HYPRE_Int\s*[^\s*]+\s*\)')
 functionDouble = re.compile(r'\s*HYPRE_Int\s+(HYPRE_[a-zA-Z]+Set[a-zA-Z]+)\s*\(\s*HYPRE_Solver\s*solver\s*,\s*HYPRE_Real\s*[^\s*]+\s*\)')
-functionDoubleInt = re.compile(r'\s*HYPRE_Int\s+(HYPRE_[a-zA-Z]+Set[a-zA-Z]+)\s*\(\s*HYPRE_Solver\s*solver\s*,\s*HYPRE_Int\s*[^\s*]+\s*,\s*HYPRE_Real\s*[^\s*]+\s*\)')
+functionDoubleInt = re.compile(r'\s*HYPRE_Int\s+(HYPRE_[a-zA-Z]+Set[a-zA-Z]+)\s*\(\s*HYPRE_Solver\s*solver\s*,\s*HYPRE_Real\s*[^\s*]+\s*,\s*HYPRE_Int\s*[^\s*]+\s*\)')
+functionIntDouble = re.compile(r'\s*HYPRE_Int\s+(HYPRE_[a-zA-Z]+Set[a-zA-Z]+)\s*\(\s*HYPRE_Solver\s*solver\s*,\s*HYPRE_Int\s*[^\s*]+\s*,\s*HYPRE_Real\s*[^\s*]+\s*\)')
 functionIntInt = re.compile(r'\s*HYPRE_Int\s+(HYPRE_[a-zA-Z]+Set[a-zA-Z]+)\s*\(\s*HYPRE_Solver\s*solver\s*,\s*HYPRE_Int\s*[^\s*]+\s*,\s*HYPRE_Int\s*[^\s*]+\s*\)')
 functionIntStar = re.compile(r'\s*HYPRE_Int\s+(HYPRE_[a-zA-Z]+Set[a-zA-Z]+)\s*\(\s*HYPRE_Solver\s*solver\s*,\s*HYPRE_Int\s*\*[^\s*]+\s*\)')
 functionDoubleStar = re.compile(r'\s*HYPRE_Int\s+(HYPRE_[a-zA-Z]+Set[a-zA-Z]+)\s*\(\s*HYPRE_Solver\s*solver\s*,\s*HYPRE_Real\s*\*[^\s*]+\s*\)')
@@ -59,6 +60,12 @@ with open(outputFile, 'w') as out:
     m = list(set(m))
     fs = ['  {{\"{func}\", &{func}}}'.format(func=func) if not func in skip else '//  {{\"{func}\", &{func}}}'.format(func=func) for func in m]
     out.write("const std::map<std::string, double_int_func> FunctionParameter::hypreMapDoubleIntFunc_ = {{\n{}}};".format(',\n'.join(fs)))
+
+    out.write('\n\n')
+    m = functionIntDouble.findall(s)
+    m = list(set(m))
+    fs = ['  {{\"{func}\", &{func}}}'.format(func=func) if not func in skip else '//  {{\"{func}\", &{func}}}'.format(func=func) for func in m]
+    out.write("const std::map<std::string, int_double_func> FunctionParameter::hypreMapIntDoubleFunc_ = {{\n{}}};".format(',\n'.join(fs)))
 
     out.write('\n\n')
     m = functionIntInt.findall(s)


### PR DESCRIPTION
@trilinos/ifpack @trilinos/ifpack2 

## Motivation
A recent change in Hypre exposed a bug in both the Ifpack and the Ifpack2 interfaces to Hypre:
- functions with args "double, int" were treated as "int, double" but because so far there was not such function this didn't result in compile errors.

https://github.com/xsdk-project/xsdk-issues/issues/213