### PR TITLE
Tpetra: execution space instances in MultiVector unpackAndCombine

### DIFF
--- a/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_decl.hpp
@@ -37,6 +37,7 @@
 // ************************************************************************
 // @HEADER
 
+// clang-format off
 #ifndef TPETRA_BLOCKCRSMATRIX_DECL_HPP
 #define TPETRA_BLOCKCRSMATRIX_DECL_HPP
 
@@ -763,6 +764,13 @@ protected:
    Kokkos::DualView<size_t*,
      buffer_device_type> numPacketsPerLID,
    size_t& constantNumPackets) override;
+
+  // clang-format on
+  using dist_object_type::unpackAndCombine; ///< DistObject has overloaded
+                                            ///< unpackAndCombine, use the
+                                            ///< DistObject's implementation for
+                                            ///< anything we don't override.
+                                            // clang-format off
 
   virtual void
   unpackAndCombine

--- a/packages/tpetra/core/src/Tpetra_BlockMultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockMultiVector_decl.hpp
@@ -37,6 +37,7 @@
 // ************************************************************************
 // @HEADER
 
+// clang-format off
 #ifndef TPETRA_BLOCKMULTIVECTOR_DECL_HPP
 #define TPETRA_BLOCKMULTIVECTOR_DECL_HPP
 
@@ -559,6 +560,13 @@ protected:
    Kokkos::DualView<size_t*,
      buffer_device_type> numPacketsPerLID,
    size_t& constantNumPackets);
+
+  // clang-format on
+  using dist_object_type::unpackAndCombine; ///< DistObject has overloaded
+                                            ///< unpackAndCombine, use the
+                                            ///< DistObject's implementation for
+                                            ///< anything we don't override.
+                                            // clang-format off
 
   virtual void
   unpackAndCombine

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -37,6 +37,7 @@
 // ************************************************************************
 // @HEADER
 
+// clang-format off
 #ifndef TPETRA_CRSGRAPH_DECL_HPP
 #define TPETRA_CRSGRAPH_DECL_HPP
 
@@ -1245,6 +1246,13 @@ public:
                        Kokkos::DualView<size_t*,
                          buffer_device_type> numPacketsPerLID,
                        size_t& constantNumPackets) const;
+
+  // clang-format on
+  using dist_object_type::unpackAndCombine; ///< DistObject has overloaded
+                                            ///< unpackAndCombine, use the
+                                            ///< DistObject's implementation for
+                                            ///< anything we don't override.
+  // clang-format off
 
     virtual void
     unpackAndCombine

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -37,6 +37,7 @@
 // ************************************************************************
 // @HEADER
 
+// clang-format off
 #ifndef TPETRA_CRSMATRIX_DECL_HPP
 #define TPETRA_CRSMATRIX_DECL_HPP
 
@@ -425,6 +426,14 @@ namespace Tpetra {
     public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
     public DistObject<char, LocalOrdinal, GlobalOrdinal, Node>
   {
+  // clang-format on
+private:
+  using dist_object_type =
+      DistObject<char, LocalOrdinal, GlobalOrdinal,
+                 Node>; ///< Type of the DistObject specialization from which
+                        ///< this class inherits.
+  // clang-format off
+
   public:
     //! @name Typedefs
     //@{
@@ -3037,6 +3046,13 @@ public:
      const size_t constantNumPackets,
      const CombineMode CM) override;
 
+  // clang-format on
+  using dist_object_type::unpackAndCombine; ///< DistObject has overloaded
+                                            ///< unpackAndCombine, use the
+                                            ///< DistObject's implementation for
+                                            ///< anything we don't override.
+                                            // clang-format off
+
     /// \brief Pack this object's data for an Import or Export.
     ///
     /// \warning To be called only by the packAndPrepare method of
@@ -3705,9 +3721,6 @@ public:
                             const Teuchos::ArrayView<const impl_scalar_type>& newRowVals,
                             const ELocalGlobal lg,
                             const ELocalGlobal I);
-
-    //! Type of the DistObject specialization from which this class inherits.
-    typedef DistObject<char, LocalOrdinal, GlobalOrdinal, Node> dist_object_type;
 
   protected:
     // useful typedefs

--- a/packages/tpetra/core/src/Tpetra_DistObject_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_DistObject_decl.hpp
@@ -801,7 +801,8 @@ namespace Tpetra {
 
     void doUnpackAndCombine(const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& remoteLIDs,
                             size_t constantNumPackets,
-                            CombineMode CM);
+                            CombineMode CM,
+                            const execution_space &space);
 
     /// \name Methods implemented by subclasses and used by doTransfer().
     ///
@@ -955,6 +956,16 @@ namespace Tpetra {
                       const size_t constantNumPackets,
                       const CombineMode combineMode);
 
+    virtual void
+    unpackAndCombine (const Kokkos::DualView<const local_ordinal_type*,
+                        buffer_device_type>& importLIDs,
+                      Kokkos::DualView<packet_type*,
+                        buffer_device_type> imports,
+                      Kokkos::DualView<size_t*,
+                        buffer_device_type> numPacketsPerLID,
+                      const size_t constantNumPackets,
+                      const CombineMode combineMode,
+                      const execution_space &space);
 
     //! The Map over which this object is distributed.
     Teuchos::RCP<const map_type> map_;

--- a/packages/tpetra/core/src/Tpetra_DistObject_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_DistObject_def.hpp
@@ -1335,7 +1335,7 @@ namespace Tpetra {
           os << *prefix << "8. unpackAndCombine - remoteLIDs " << remoteLIDs.extent(0) << ", constantNumPackets " << constantNumPackets << endl;
           std::cerr << os.str ();
         }
-        doUnpackAndCombine(remoteLIDs, constantNumPackets, CM);
+        doUnpackAndCombine(remoteLIDs, constantNumPackets, CM, execution_space());
       } // if (needCommunication)
     } // if (CM != ZERO)
 
@@ -1618,14 +1618,15 @@ namespace Tpetra {
   DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
   doUnpackAndCombine(const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& remoteLIDs,
                      size_t constantNumPackets,
-                     CombineMode CM)
+                     CombineMode CM,
+                     const execution_space &space)
   {
     using Details::ProfilingRegion;
     using std::endl;
     const bool debug = Details::Behavior::debug("DistObject");
 
     ProfilingRegion region_uc
-      ("Tpetra::DistObject::doTransferNew::unpackAndCombine");
+      ("Tpetra::DistObject::doUnpackAndCombine");
 #ifdef HAVE_TPETRA_TRANSFER_TIMERS
     // FIXME (mfh 04 Feb 2019) Deprecate Teuchos::TimeMonitor in
     // favor of Kokkos profiling.
@@ -1638,15 +1639,15 @@ namespace Tpetra {
       try {
         this->unpackAndCombine (remoteLIDs, this->imports_,
             this->numImportPacketsPerLID_,
-            constantNumPackets, CM);
+            constantNumPackets, CM, space);
         lclSuccess = true;
       }
       catch (std::exception& e) {
-        lclErrStrm << "unpackAndCombine threw an exception: "
+        lclErrStrm << "doUnpackAndCombine threw an exception: "
           << endl << e.what();
       }
       catch (...) {
-        lclErrStrm << "unpackAndCombine threw an exception "
+        lclErrStrm << "doUnpackAndCombine threw an exception "
           "not a subclass of std::exception.";
       }
       const char gblErrMsgHeader[] = "Tpetra::DistObject "
@@ -1660,7 +1661,7 @@ namespace Tpetra {
     else {
       this->unpackAndCombine (remoteLIDs, this->imports_,
           this->numImportPacketsPerLID_,
-          constantNumPackets, CM);
+          constantNumPackets, CM, space);
     }
   }
 
@@ -1695,6 +1696,34 @@ namespace Tpetra {
      buffer_device_type>,
    size_t&)
   {}
+
+  template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
+  void
+  DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
+  unpackAndCombine
+  (const Kokkos::DualView<
+     const local_ordinal_type*,
+     buffer_device_type>& importLIDs,
+   Kokkos::DualView<
+     packet_type*,
+     buffer_device_type> imports,
+   Kokkos::DualView<
+     size_t*,
+     buffer_device_type> numPacketsPerLID,
+   const size_t constantNumPackets,
+   const CombineMode combineMode,
+   const execution_space &space)
+  {
+    /*
+    we're here if the derived class doesn't know how to do this in an
+    execution space instance, so just do it in the default instance
+    after appropriate sync 
+    */
+    
+    execution_space().fence(); //TODO: Details::Spaces::exec_space_wait(space, execution_space());
+    unpackAndCombine(importLIDs, imports, numPacketsPerLID, constantNumPackets, combineMode); // default instance
+    space.fence(); //TODO: Details::Spaces::exec_space_wait(execution_space(), space);
+  }
 
   template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
   void

--- a/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
@@ -2369,7 +2369,22 @@ namespace Tpetra {
        size_t*,
        buffer_device_type> /* numPacketsPerLID */,
      const size_t constantNumPackets,
-     const CombineMode CM);
+     const CombineMode CM,
+     const execution_space &space) override;
+
+    virtual void
+    unpackAndCombine
+    (const Kokkos::DualView<
+       const local_ordinal_type*,
+       buffer_device_type>& importLIDs,
+     Kokkos::DualView<
+       impl_scalar_type*,
+       buffer_device_type> imports,
+     Kokkos::DualView<
+       size_t*,
+       buffer_device_type> /* numPacketsPerLID */,
+     const size_t constantNumPackets,
+     const CombineMode CM) override;
 
   private:
 

--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -1865,7 +1865,8 @@ namespace Tpetra {
    Kokkos::DualView<impl_scalar_type*, buffer_device_type> imports,
    Kokkos::DualView<size_t*, buffer_device_type> /* numPacketsPerLID */,
    const size_t constantNumPackets,
-   const CombineMode CM)
+   const CombineMode CM,
+   const execution_space &space)
   {
     using ::Tpetra::Details::Behavior;
     using ::Tpetra::Details::ProfilingRegion;
@@ -2027,7 +2028,7 @@ namespace Tpetra {
           }
           else { // unpack on device
             auto X_d = this->getLocalViewDevice(Access::ReadWrite);
-            unpack_array_multi_column (dev_exec_space (),
+            unpack_array_multi_column (space,
                                        X_d, imports_d, importLIDs_d,
                                        op_type (), numVecs,
                                        use_atomic_updates,
@@ -2048,7 +2049,7 @@ namespace Tpetra {
           }
           else { // unpack on device
             auto X_d = this->getLocalViewDevice(Access::ReadWrite);
-            unpack_array_multi_column_variable_stride (dev_exec_space (),
+            unpack_array_multi_column_variable_stride (space,
                                                        X_d, imports_d,
                                                        importLIDs_d,
                                                        whichVecs_d,
@@ -2072,7 +2073,7 @@ namespace Tpetra {
           }
           else { // unpack on device
             auto X_d = this->getLocalViewDevice(Access::ReadWrite);
-            unpack_array_multi_column (dev_exec_space (),
+            unpack_array_multi_column (space,
                                        X_d, imports_d, importLIDs_d,
                                        op_type (), numVecs,
                                        use_atomic_updates,
@@ -2093,7 +2094,7 @@ namespace Tpetra {
           }
           else { // unpack on device
             auto X_d = this->getLocalViewDevice(Access::ReadWrite);
-            unpack_array_multi_column_variable_stride (dev_exec_space (),
+            unpack_array_multi_column_variable_stride (space,
                                                        X_d, imports_d,
                                                        importLIDs_d,
                                                        whichVecs_d,
@@ -2117,7 +2118,7 @@ namespace Tpetra {
           }
           else { // unpack on device
             auto X_d = this->getLocalViewDevice(Access::ReadWrite);
-            unpack_array_multi_column (dev_exec_space (),
+            unpack_array_multi_column (space,
                                        X_d, imports_d, importLIDs_d,
                                        op_type (), numVecs,
                                        use_atomic_updates,
@@ -2138,7 +2139,7 @@ namespace Tpetra {
           }
           else { // unpack on device
             auto X_d = this->getLocalViewDevice(Access::ReadWrite);
-            unpack_array_multi_column_variable_stride (dev_exec_space (),
+            unpack_array_multi_column_variable_stride (space,
                                                        X_d, imports_d,
                                                        importLIDs_d,
                                                        whichVecs_d,
@@ -2168,6 +2169,20 @@ namespace Tpetra {
       std::cerr << os.str ();
     }
   }
+
+  // clang-format on
+  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+  void
+  MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
+  unpackAndCombine
+  (const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& importLIDs,
+   Kokkos::DualView<impl_scalar_type*, buffer_device_type> imports,
+   Kokkos::DualView<size_t*, buffer_device_type> numPacketsPerLID,
+   const size_t constantNumPackets,
+   const CombineMode CM) {
+    unpackAndCombine(importLIDs, imports, numPacketsPerLID, constantNumPackets, CM, execution_space());
+  }
+  // clang-format off
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   size_t


### PR DESCRIPTION
@trilinos/tpetra 

## Motivation
Needed before execution-space instance enabled import/export for SpMV communication-computation overlap: https://github.com/trilinos/Trilinos/pull/10926

Replaces https://github.com/trilinos/Trilinos/pull/11736, which was made against master and got an autotest attached to it that couldn't pass