### PR TITLE
Panzer: fix Poisson interface test

### DIFF
--- a/packages/panzer/adapters-stk/example/PoissonInterfaceTpetra/main.cpp
+++ b/packages/panzer/adapters-stk/example/PoissonInterfaceTpetra/main.cpp
@@ -871,8 +871,6 @@ int main (int argc, char* argv[])
     status = -1;
   }
 
-  Kokkos::finalize();
-
   return status;
 }
 


### PR DESCRIPTION
## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The Poisson interface test was failing the trilinos sync in empire. Kokkos::finalize was being called twice (in the dtor of GlobalMPISession and then again at the end of main). ctest was always declaring this test a success based o screen output ("TEST PASSED") even though kokkos was throwing an exception for calling finalize at the very end of main. 

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->