### PR TITLE
Tpetra: fix uninitialized const ref complaints from clang 14 compiler

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_DistributorActor.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorActor.hpp
@@ -272,7 +272,7 @@ void DistributorActor::doPosts(const DistributorPlan& plan,
     Teuchos::RCP<const Teuchos::MpiComm<int> > mpiComm = Teuchos::rcp_dynamic_cast<const Teuchos::MpiComm<int> >(comm);
     Teuchos::RCP<const Teuchos::OpaqueWrapper<MPI_Comm> > rawComm = mpiComm->getRawMpiComm();
     using T = typename exports_view_type::non_const_value_type;
-    T t;
+    T t{};
     MPI_Datatype rawType = ::Tpetra::Details::MpiTypeTraits<T>::getType (t);
     const int err = MPI_Alltoallv(exports.data(), sendcounts.data(), sdispls.data(), rawType,
                                   imports.data(), recvcounts.data(), rdispls.data(), rawType,
@@ -604,7 +604,7 @@ void DistributorActor::doPosts(const DistributorPlan& plan,
     Teuchos::RCP<const Teuchos::MpiComm<int> > mpiComm = Teuchos::rcp_dynamic_cast<const Teuchos::MpiComm<int> >(comm);
     Teuchos::RCP<const Teuchos::OpaqueWrapper<MPI_Comm> > rawComm = mpiComm->getRawMpiComm();
     using T = typename exports_view_type::non_const_value_type;
-    T t;
+    T t{};
     MPI_Datatype rawType = ::Tpetra::Details::MpiTypeTraits<T>::getType (t);
     const int err = MPI_Alltoallv(exports.data(), sendcounts.data(), sdispls.data(), rawType,
                                   imports.data(), recvcounts.data(), rdispls.data(), rawType,


### PR DESCRIPTION
@trilinos/tpetra @jhux2 

## Motivation
Fix an uninitialized dummy variable used passed as a const reference—detected in Tpetra template instantiations, in clang builds in Sierra.