### PR TITLE
Actions: Cleanup to the automentioner

### DIFF
--- a/.github/workflows/title_to_mention.yml
+++ b/.github/workflows/title_to_mention.yml
@@ -19,14 +19,14 @@ jobs:
     steps:
     - name: Mention MueLu
       uses: peter-evans/create-or-update-comment@v2
-      if: contains(github.event.label.name, 'MueLu') || contains(github.event.issue.title, 'MueLu')  
+      if: (contains(github.event.action, 'labeled') && contains(github.event.label.name, 'MueLu')) || (contains(github.event.action, 'opened') && contains(github.event.issue.title, 'MueLu'))  
       with:
         issue-number: ${{ github.event.issue.number }}  
         body: |
           Automatic mention of the @trilinos/muelu team
     - name: Mention Ifpack2
       uses: peter-evans/create-or-update-comment@v2
-      if: contains(github.event.label.name, 'Ifpack2') || contains(github.event.issue.title, 'Ifpack2')  
+      if: (contains(github.event.action, 'labeled') && contains(github.event.label.name, 'Ifpack2')) || (contains(github.event.action, 'opened') && contains(github.event.issue.title, 'Ifpack2'))
       with:
         issue-number: ${{ github.event.issue.number }}  
         body: |


### PR DESCRIPTION
This should dramatically cut down on the mentions.

In the current version, it would check the title *and* the label every time a label was added.  Now it will only check the title on open.

