### PR TITLE
Add missing include of Tpetra_CrsMatrix.hpp (#11730)

### DIFF
--- a/packages/stratimikos/src/Stratimikos_LinearSolverBuilder_def.hpp
+++ b/packages/stratimikos/src/Stratimikos_LinearSolverBuilder_def.hpp
@@ -68,6 +68,7 @@
 #endif
 #ifdef HAVE_STRATIMIKOS_IFPACK2
 #  include "Thyra_Ifpack2PreconditionerFactory.hpp"
+#  include "Tpetra_CrsMatrix.hpp"
 #endif
 #ifdef HAVE_STRATIMIKOS_ML
 #  include "Thyra_MLPreconditionerFactory.hpp"


### PR DESCRIPTION
CC: @alanw0, @rppawlo, @csiefer2, @hpacella 

## Description

This fixes a build error for a configuration reported by @alanw0 for a build related to STK for a particular set of optional package builds.  (There was no GitHub Issue created for this error.)

This is related to the changes in PR:

* #11739 

which is part of:

* #11730 

I was able to reproduce the build error:

```
In file included from /ascldap/users/rabartl/Trilinos.base2/Trilinos/packages/stratimikos/src/Stratimikos_LinearSolverBuilder.cpp:46:
/ascldap/users/rabartl/Trilinos.base2/Trilinos/packages/stratimikos/src/Stratimikos_LinearSolverBuilder_def.hpp:620:41: error: use of undeclared identifier 'Tpetra'
    Thyra::Ifpack2PreconditionerFactory<Tpetra::CrsMatrix<Scalar>>>(),
                                        ^
/ascldap/users/rabartl/Trilinos.base2/Trilinos/packages/stratimikos/src/Stratimikos_LinearSolverBuilder_def.hpp:620:59: error: unexpected type name 'Scalar': expected expression
    Thyra::Ifpack2PreconditionerFactory<Tpetra::CrsMatrix<Scalar>>>(),
                                                          ^
/ascldap/users/rabartl/Trilinos.base2/Trilinos/packages/stratimikos/src/Stratimikos_LinearSolverBuilder_def.hpp:620:69: error: expected expression
    Thyra::Ifpack2PreconditionerFactory<Tpetra::CrsMatrix<Scalar>>>(),
                                                                    ^
3 errors generated.
```

using a modified configure script provided by @alanw0 in an email.  This was for the `clang-11.0.1` GenConfig PR build configuration set up by:

* https://gitlab-ex.sandia.gov/rabartl/run_trilinos_pr_builds

where only the 'do-configure' script was replaced with the `do-configure.stk` adapted from @alanw0's script:

<details>

<summary><b>do-configure.stk</b> (click to expand)</summary>

```
cuda_on_or_off=OFF
not_cuda=ON

./do-configure.base \
-D Trilinos_ENABLE_ALL_FORWARD_DEP_PACKAGES=OFF \
-DTrilinos_ENABLE_EXPLICIT_INSTANTIATION:BOOL=ON \
-DTrilinos_ENABLE_TESTS:BOOL=ON \
-DTrilinos_ENABLE_ALL_OPTIONAL_PACKAGES=OFF \
-DTrilinos_ALLOW_NO_PACKAGES:BOOL=OFF \
-DTrilinos_ASSERT_DEFINED_DEPENDENCIES=OFF \
-DTPL_ENABLE_MPI=ON \
-DTrilinos_ENABLE_Tpetra:BOOL=ON \
-DTpetraCore_ENABLE_TESTS:BOOL=OFF \
-DTpetra_ENABLE_DEPRECATED_CODE:BOOL=ON \
-DTrilinos_ENABLE_Zoltan2:BOOL=ON \
-DZoltan2_ENABLE_ParMETIS:BOOL=ON \
-DTrilinos_ENABLE_Pamgen:BOOL=ON \
-DTrilinos_ENABLE_Percept:BOOL=ON \
-DTrilinos_ENABLE_Panzer:BOOL=${not_cuda} \
-DTrilinos_ENABLE_PanzerAdaptersSTK:BOOL=${not_cuda} \
-DPanzer_ENABLE_TESTS:BOOL=${not_cuda} \
-DPanzer_STK_ENABLE_TESTS:BOOL=${not_cuda} \
-DTrilinos_ENABLE_TrilinosCouplings:BOOL=${not_cuda} \
-DTPL_ENABLE_CUDA:BOOL=${cuda_on_or_off} \
-DKokkos_ENABLE_CUDA:BOOL=${cuda_on_or_off} \
-DKokkos_ENABLE_CUDA_UVM:BOOL=${cuda_on_or_off} \
-DKokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE:BOOL=OFF \
-DKokkos_ARCH_VOLTA70=${cuda_on_or_off} \
-DTpetra_ENABLE_CUDA:BOOL=${cuda_on_or_off} \
-DTrilinos_ENABLE_KokkosKernels:BOOL=ON \
-DTrilinos_ENABLE_Zoltan:BOOL=ON \
-DTrilinos_ENABLE_Fortran:BOOL=ON \
-DSTK_ENABLE_TESTS:BOOL=ON \
-DTrilinos_ENABLE_STK:BOOL=ON \
-DTrilinos_ENABLE_STKMiddle_mesh:BOOL=ON \
-DTrilinos_ENABLE_Gtest:BOOL=ON \
-DTrilinos_ENABLE_SEACASExodus:BOOL=ON \
-DTrilinos_ENABLE_SEACASIoss:BOOL=ON \
-DTPL_ENABLE_CDT=OFF \
"$@"

#-DCMAKE_CXX_STANDARD:STRING=17 \
#-DCMAKE_CXX_FLAGS:STRING="-DNOT_HAVE_STK_SEACASAPREPRO_LIB -Werror=dangling-else" \
#-DNetCDF_LIBRARIES="-lnetcdf -lpnetcdf -lhdf5_hl -lhdf5 -ldl" \
#-DTPL_ENABLE_CDT:BOOL=ON \
#-DCDT_INCLUDE_DIRS="/fgs/william/CDT/install/include" \
#-DCDT_ROOT="/fgs/william/CDT/install" \
#-DTPL_ENABLE_Netcdf:BOOL=ON \
#-DTPL_Netcdf_Enables_Netcdf4:BOOL=ON \
#-DTPL_Netcdf_Enables_Pnetcdf:BOOL=ON \
#-DTPL_ENABLE_Zlib:BOOL=ON \
#-DTPL_ENABLE_ParMETIS:BOOL=ON \
#-DTPL_ENABLE_Pnetcdf:BOOL=ON \
#-DTPL_ENABLE_HDF5:BOOL=ON \
#-DCMAKE_EXE_LINKER_FLAGS="${cmake_exe_linker_flags}" \
```

</details>

The above resulted in the following set of enabled and non-enabled pacakges:

* **Final set of enabled top-level packages:**  Gtest Kokkos Teuchos KokkosKernels RTOp Sacado Zoltan Shards Tpetra Thyra Xpetra Galeri Pamgen Zoltan2Core Belos SEACAS Anasazi Ifpack2 Stratimikos Teko Intrepid Intrepid2 STK Percept Phalanx NOX MueLu Zoltan2 Rythmos Piro Panzer TrilinosCouplings 32

* **Final set of enabled packages:**  Gtest KokkosCore KokkosContainers KokkosAlgorithms Kokkos TeuchosCore TeuchosParser TeuchosParameterList TeuchosComm TeuchosNumerics TeuchosRemainder TeuchosKokkosCompat TeuchosKokkosComm Teuchos KokkosKernels RTOp Sacado Zoltan Shards TpetraTSQR TpetraCore Tpetra ThyraCore ThyraTpetraAdapters Thyra Xpetra Galeri Pamgen Zoltan2Core Belos SEACASExodus SEACASNemesis SEACASIoss SEACAS Anasazi Ifpack2 Stratimikos Teko Intrepid Intrepid2 STKUtil STKCoupling STKMath STKSimd STKNGP_TEST STKTopology STKMesh STKIO STKSearch STKTransfer STKTools STKBalance STKUnit_test_utils STKSearchUtil STKUnit_tests STKDoc_tests STKExprEval STKEmend STK Percept Phalanx NOX MueLu Zoltan2 Rythmos Piro PanzerCore PanzerDofMgr PanzerDiscFE PanzerAdaptersSTK PanzerMiniEM Panzer TrilinosCouplings 73

* **Final set of non-enabled top-level packages:**  TrilinosFrameworkTests TrilinosATDMConfigTests MiniTensor Epetra Triutils EpetraExt TrilinosSS Domi Isorropia Pliris AztecOO Amesos Ifpack ML ShyLU_Node Amesos2 Komplex FEI TriKota Compadre Krino Moertel Zoltan2Sphynx ShyLU_DD ShyLU Tempus Stokhos ROL PyTrilinos NewPackage Adelus Pike TrilinosBuildStats TrilinosInstallTests 34

* **Final set of non-enabled packages:**  TrilinosFrameworkTests TrilinosATDMConfigTests KokkosSimd MiniTensor Epetra Triutils EpetraExt TrilinosSS Domi ThyraEpetraAdapters ThyraEpetraExtAdapters Isorropia Pliris AztecOO Amesos Ifpack ML ShyLU_NodeHTS ShyLU_NodeTacho ShyLU_NodeBasker ShyLU_NodeFastILU ShyLU_Node Amesos2 SEACASExodus_for SEACASExoIIv2for32 SEACASChaco SEACASAprepro_lib SEACASSupes SEACASSuplib SEACASSuplibC SEACASSuplibCpp SEACASSVDI SEACASPLT SEACASAlgebra SEACASAprepro SEACASBlot SEACASConjoin SEACASEjoin SEACASEpu SEACASCpup SEACASExo2mat SEACASExodiff SEACASExomatlab SEACASExotxt SEACASExo_format SEACASEx1ex2v2 SEACASExotec2 SEACASFastq SEACASGjoin SEACASGen3D SEACASGenshell SEACASGrepos SEACASExplore SEACASMapvarlib SEACASMapvar SEACASMapvar-kd SEACASMat2exo SEACASNas2exo SEACASZellij SEACASNemslice SEACASNemspread SEACASNumbers SEACASSlice SEACASTxtexo SEACASEx2ex1v2 Komplex FEI TriKota Compadre STKMiddle_mesh Krino Moertel Zoltan2Sphynx ShyLU_DDFROSch ShyLU_DDCore ShyLU_DDCommon ShyLU_DD ShyLU Tempus Stokhos ROL PanzerExprEval PyTrilinos NewPackage Adelus PikeBlackBox PikeImplicit Pike TrilinosBuildStats TrilinosInstallTests 90

* **Final set of enabled top-level external packages/TPLs:**  Pthread MPI BLAS LAPACK Boost Scotch ParMETIS Zlib HDF5 Netcdf SuperLU BoostLib DLlib 13

* **Final set of enabled external packages/TPLs:**  Pthread MPI BLAS LAPACK Boost Scotch ParMETIS Zlib HDF5 Netcdf SuperLU BoostLib DLlib 13

* **Final set of non-enabled top-level external packages/TPLs:**  MKL yaml-cpp Peano CUDA CUBLAS CUSOLVER CUSPARSE Thrust Cusp ROCBLAS ROCSPARSE TBB HWLOC QTHREAD BinUtils ARPREC QD OVIS gpcd DataWarp METIS MTMETIS PuLP TopoManager LibTopoMap PaToH CppUnit ADOLC ADIC TVMET MF ExodusII Nemesis XDMF CGNS Pnetcdf ADIOS2 Faodel Cereal Catalyst2 y12m SuperLUDist SuperLUMT Cholmod UMFPACK MA28 AMD CSparse HYPRE PETSC BLACS SCALAPACK MUMPS STRUMPACK PARDISO_MKL PARDISO Oski TAUCS ForUQTK Dakota HIPS MATLAB CASK SPARSKIT QT gtest BoostAlbLib OpenNURBS Portals CrayPortals Gemini InfiniBand BGPDCMF BGQPAMI Pablo HPCToolkit Clp GLPK qpOASES Matio PAPI MATLABLib Eigen X11 Lemon GLM quadmath CAMAL RTlib AmgX VTune TASMANIAN ArrayFireCPU SimMesh SimModel SimParasolid SimAcis SimField Valgrind QUO ViennaCL Avatar mlpack pebbl MAGMASparse Check SARMA CDT mpi_advance 109

* **Final set of non-enabled external packages/TPLs:**  MKL yaml-cpp Peano CUDA CUBLAS CUSOLVER CUSPARSE Thrust Cusp ROCBLAS ROCSPARSE TBB HWLOC QTHREAD BinUtils ARPREC QD OVIS gpcd DataWarp METIS MTMETIS PuLP TopoManager LibTopoMap PaToH CppUnit ADOLC ADIC TVMET MF ExodusII Nemesis XDMF CGNS Pnetcdf ADIOS2 Faodel Cereal Catalyst2 y12m SuperLUDist SuperLUMT Cholmod UMFPACK MA28 AMD CSparse HYPRE PETSC BLACS SCALAPACK MUMPS STRUMPACK PARDISO_MKL PARDISO Oski TAUCS ForUQTK Dakota HIPS MATLAB CASK SPARSKIT QT gtest BoostAlbLib OpenNURBS Portals CrayPortals Gemini InfiniBand BGPDCMF BGQPAMI Pablo HPCToolkit Clp GLPK qpOASES Matio PAPI MATLABLib Eigen X11 Lemon GLM quadmath CAMAL RTlib AmgX VTune TASMANIAN ArrayFireCPU SimMesh SimModel SimParasolid SimAcis SimField Valgrind QUO ViennaCL Avatar mlpack pebbl MAGMASparse Check SARMA CDT mpi_advance 109


## Testing

This PR branch fixed the build error shown above and the complete local build finished and all of the enabled tests run with test results:

```
98% tests passed, 8 tests failed out of 438

Subproject Time Summary:
KokkosKernels        =  62.57 sec*proc (17 tests)
Panzer               = 1705.44 sec*proc (164 tests)
SEACAS               =  18.32 sec*proc (15 tests)
STK                  =  76.77 sec*proc (22 tests)
Tpetra               =  19.40 sec*proc (13 tests)
TrilinosCouplings    =   0.89 sec*proc (2 tests)
Zoltan               = 121.91 sec*proc (26 tests)
Zoltan2              = 242.95 sec*proc (179 tests)

Total Test time (real) = 163.42 sec

The following tests FAILED:
        424 - PanzerMiniEM_MiniEM-BlockPrec_RefMaxwell_MPI_1 (Failed)
        425 - PanzerMiniEM_MiniEM-BlockPrec_RefMaxwell_MPI_4 (Failed)
        426 - PanzerMiniEM_MiniEM-BlockPrec_RefMaxwell_reuse_MPI_1 (Failed)
        427 - PanzerMiniEM_MiniEM-BlockPrec_RefMaxwell_reuse_MPI_4 (Failed)
        428 - PanzerMiniEM_MiniEM-BlockPrec_RefMaxwell2D_MPI_4 (Failed)
        429 - PanzerMiniEM_MiniEM-BlockPrec_MueLu_highOrder_0_MPI_4 (Failed)
        430 - PanzerMiniEM_MiniEM-BlockPrec_MueLu_highOrder_1_MPI_4 (Failed)
        437 - TrilinosCouplings_Example_Maxwell_Tpetra_MueLu_MPI_1 (Failed)
Errors while running CTest
```

NOTE: The above `PanzerMiniEM_MiniEM-BlockPrec_XXX` tests failed due to the error:

```
1:   *** THROWN EXCEPTION ***
1:   /ascldap/users/rabartl/Trilinos.base2/Trilinos/packages/muelu/src/Smoothers/MueLu_DirectSolver_def.hpp:177:
1:   
1:   Throw number = 1
1:   
1:   Throw test that evaluated to true: sEpetra_.is_null() && sTpetra_.is_null() && sBelos_.is_null() && sStratimikos_.is_null() && sRefMaxwell_.is_null()
1:   
1:   Could not enable any direct solver:
1:   Belos was disabled due to an error:
1:   Belos does not provide the smoother 'KLU'.Stratimikos was disabled due to an error:
1:   Stratimikos does not provide the smoother 'KLU'.RefMaxwell was disabled due to an error:
1:   RefMaxwellSmoother does not provide the smoother 'KLU'.
1:   ************************
1:   Teko: "buildInverse" could not construct the inverse operator using "Teko::AutoClone<mini_em::FullMaxwellPreconditionerFactory, mini_em::FullMaxwellPreconditionerFactory>"
1:   
1:   *** THROWN EXCEPTION ***
1:   std::exception
1:   ************************
```

The test `TrilinosCouplings_Example_Maxwell_Tpetra_MueLu_MPI_1 ` failed with the error:

```
1: Reading parameter list from the XML file "Maxwell.xml" ...
1: 
1: terminate called after throwing an instance of 'std::runtime_error'
1:   what():  /ascldap/users/rabartl/Trilinos.base2/Trilinos/packages/teuchos/parameterlist/src/Teuchos_FileInputStream.cpp:53:
1: 
1: Throw number = 1
1: 
1: Throw test that evaluated to true: file_ == NULL
1: 
1: FileInputStream ctor failed to open file: Maxwell.xml
```

Since this is a non-standard configuration of Trilinos, it is not surprising there are failing tests.  (It is just not possible to test every permutation.)
