### PR TITLE
Tpetra: fix #11820

### DIFF
--- a/packages/tpetra/core/src/CMakeLists.txt
+++ b/packages/tpetra/core/src/CMakeLists.txt
@@ -937,4 +937,4 @@ SET_PROPERTY(
 # / from this directory, or to / from the 'impl' subdirectory.  That ensures
 # that running "make" will also rerun CMake in order to regenerate Makefiles.
 #
-# Here's another change, another, and another
+# Here's another change, another, and another 

--- a/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_def.hpp
@@ -2612,6 +2612,7 @@ public:
         // The following parallel_for needs const access to the local values of src.
         // (the local graph is also accessed on host, but this does not use WDVs).
         getValuesHost();
+        Details::disableWDVTracking();
         Kokkos::parallel_for
           (policy,
            [=](const typename policy_type::member_type &member) {
@@ -2659,6 +2660,7 @@ public:
               }
             }
           }); // for each LID (of a row) to send
+        Details::enableWDVTracking();
       }
     } // if totalNumEntries > 0
 
@@ -2883,6 +2885,7 @@ public:
 
       //The following parallel_for modifies values on host while unpacking.
       getValuesHostNonConst();
+      Details::disableWDVTracking();
       Kokkos::parallel_for
         ("Tpetra::BlockCrsMatrix::unpackAndCombine: unpack", policy,
          [=] (const typename policy_type::member_type& member) {
@@ -2999,6 +3002,7 @@ public:
             return;
           }
         }); // for each import LID i
+      Details::enableWDVTracking();
     }
 
     if (errorDuringUnpack () != 0) {

--- a/packages/tpetra/core/src/Tpetra_Details_WrappedDualView.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_WrappedDualView.cpp
@@ -1,0 +1,62 @@
+// @HEADER
+// ***********************************************************************
+//
+//          Tpetra: Templated Linear Algebra Services Package
+//                 Copyright (2008) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// ************************************************************************
+// @HEADER
+
+#include "Tpetra_Details_WrappedDualView.hpp"
+
+namespace Tpetra {
+namespace Details {
+
+bool wdvTrackingEnabled = true;
+
+void enableWDVTracking()
+{
+  if(wdvTrackingEnabled)
+    throw std::runtime_error("WrappedDualView refcount tracking is already enabled!");
+  wdvTrackingEnabled = true;
+}
+
+void disableWDVTracking()
+{
+  if(!wdvTrackingEnabled)
+    throw std::runtime_error("WrappedDualView refcount tracking is already disabled!");
+  wdvTrackingEnabled = false;
+}
+
+} // namespace Details
+} // namespace Tpetra


### PR DESCRIPTION
In #11679, the WDV "sync path" was disabled when in a host-parallel region. However, it turns out that ``Serial::in_parallel()`` always returns false, so ``Kokkos::parallel`` kernels running on Serial would still suffer the overhead of WDV tracking. This brings back the explicit enable/disable of WDV tracking. This means a few more lines of boilerplate, but it fixes perf regression #11820, and as a bonus makes the fillComplete in FEAssembly perf test 20% faster than before #11679.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Fix major performance regression
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:
-->
## Related Issues

* Closes #11820 
* Blocks 
* Is blocked by 
* Follows #11679 
* Precedes 
* Related to 
* Part of 
* Composed of 



## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->