### PR TITLE
Xpetra: Add getLocalView implementations to EpetraInt Vector and MultiVector

### DIFF
--- a/packages/xpetra/src/MultiVector/Xpetra_MultiVector_decl.hpp
+++ b/packages/xpetra/src/MultiVector/Xpetra_MultiVector_decl.hpp
@@ -317,9 +317,9 @@ class MultiVector
     using host_execution_space = typename dual_view_type::host_mirror_space;
     using dev_execution_space  = typename dual_view_type::t_dev::execution_space;
 
-    virtual typename dual_view_type::t_host_const_um getHostLocalView (Access::ReadOnlyStruct)  const
+    virtual typename dual_view_type::t_host_const_um getHostLocalView(Access::ReadOnlyStruct)  const
     {
-      throw std::runtime_error("Dummy function getHostLocalView, should be overwritten at"+std::string(__FILE__)+":"+std::to_string(__LINE__));
+      throw std::runtime_error("Dummy function getHostLocalView(Access::ReadOnlyStruct), should be overwritten at"+std::string(__FILE__)+":"+std::to_string(__LINE__));
 #ifndef __NVCC__
       typename dual_view_type::t_host_um test;
 #endif
@@ -329,16 +329,16 @@ class MultiVector
 
     virtual typename dual_view_type::t_dev_const_um  getDeviceLocalView(Access::ReadOnlyStruct) const
     {
-      throw std::runtime_error("Dummy function getHostLocalView, should be overwritten at"+std::string(__FILE__)+":"+std::to_string(__LINE__));
+      throw std::runtime_error("Dummy function getDeviceLocalView(Access::ReadOnlyStruct), should be overwritten at"+std::string(__FILE__)+":"+std::to_string(__LINE__));
 #ifndef __NVCC__
       typename dual_view_type::t_dev_um test;
 #endif
       TEUCHOS_UNREACHABLE_RETURN(test);
     }
 
-    virtual typename dual_view_type::t_host_um getHostLocalView (Access::OverwriteAllStruct)  const
+    virtual typename dual_view_type::t_host_um getHostLocalView(Access::OverwriteAllStruct)  const
     {
-      throw std::runtime_error("Dummy function getHostLocalView, should be overwritten at"+std::string(__FILE__)+":"+std::to_string(__LINE__));
+      throw std::runtime_error("Dummy function getHostLocalView(Access::OverwriteAllStruct), should be overwritten at"+std::string(__FILE__)+":"+std::to_string(__LINE__));
 #ifndef __NVCC__
       typename dual_view_type::t_host_um test;
 #endif
@@ -348,16 +348,16 @@ class MultiVector
 
     virtual typename dual_view_type::t_dev_um  getDeviceLocalView(Access::OverwriteAllStruct) const
     {
-      throw std::runtime_error("Dummy function getHostLocalView, should be overwritten at"+std::string(__FILE__)+":"+std::to_string(__LINE__));
+      throw std::runtime_error("Dummy function getDeviceLocalView(Access::OverwriteAllStruct), should be overwritten at"+std::string(__FILE__)+":"+std::to_string(__LINE__));
 #ifndef __NVCC__
       typename dual_view_type::t_dev_um test;
 #endif
       TEUCHOS_UNREACHABLE_RETURN(test);
     }
 
-    virtual typename dual_view_type::t_host_um getHostLocalView (Access::ReadWriteStruct)  const
+    virtual typename dual_view_type::t_host_um getHostLocalView(Access::ReadWriteStruct)  const
     {
-      throw std::runtime_error("Dummy function getHostLocalView, should be overwritten at"+std::string(__FILE__)+":"+std::to_string(__LINE__));
+      throw std::runtime_error("Dummy function getHostLocalView(Access::ReadWriteStruct), should be overwritten at"+std::string(__FILE__)+":"+std::to_string(__LINE__));
 #ifndef __NVCC__
       typename dual_view_type::t_host_um test;
 #endif
@@ -367,7 +367,7 @@ class MultiVector
 
     virtual typename dual_view_type::t_dev_um  getDeviceLocalView(Access::ReadWriteStruct) const
     {
-      throw std::runtime_error("Dummy function getHostLocalView, should be overwritten at"+std::string(__FILE__)+":"+std::to_string(__LINE__));
+      throw std::runtime_error("Dummy function getDeviceLocalView(Access::ReadWriteStruct), should be overwritten at"+std::string(__FILE__)+":"+std::to_string(__LINE__));
 #ifndef __NVCC__
       typename dual_view_type::t_dev_um test;
 #endif


### PR DESCRIPTION
@trilinos/muelu @maxfirmbach 

This should resolve most of the issues related to #11806. There were missing implementations for `getDeviceLocalView` and `getHostLocalView` for `Xpetra::EpetraIntMultiVectorT` and `Xpetra::EpetraIntVectorT`, which caused the reported runtime errors. I believe these errors were introduced by #11726, as we now use `Xpetra::LOVector` and `Xpetra::LOMultiVector` types as members in the `Aggregates` class.

## Testing
I don't think anything tests the Epetra stack anymore, but I went from 67 failing MueLu tests in the supplied configuration to 34 failing MueLu tests. That sounds bad, but a lot of the tests in the supplied configuration fail with errors like:
```
11:   Error: running in Tpetra mode, but MueLu with Amesos2 was disabled during the configure stage.
11:   Please make sure that:
11:     - Amesos2 is enabled (Trilinos_ENABLE_Amesos2=ON),
11:     - Amesos2 is available for MueLu to use (MueLu_ENABLE_Amesos2=ON)
```

There are also a pile of `MueLu_Navier2DBlocked` tests that fail with the following:
```
667: p=0: *** Caught standard std::exception of type 'std::runtime_error' :
667: 
667:  Constructing View and initializing data with uninitialized execution space
```
which leads me to believe it's a simple problem with the test driver and not a larger problem.

This at least addresses the main problem, and then we'll iterate with @maxfirmbach to see if there are additional problems.