### PR TITLE
Amesos2_MUMPS : remove deprecated code

### DIFF
--- a/packages/amesos2/src/Amesos2_MUMPS_FunctionMap.hpp
+++ b/packages/amesos2/src/Amesos2_MUMPS_FunctionMap.hpp
@@ -86,7 +86,6 @@ namespace Amesos2
   };
 
 #ifdef HAVE_TEUCHOS_COMPLEX
-
   
   template <>
   struct FunctionMap<MUMPS,MUMPST::CMUMPS_COMPLEX>
@@ -121,7 +120,6 @@ namespace Amesos2
       MUMPST::zmumps_c(mumps_par);
     }
   };
-  
 
 #endif //complex
 } //end namespace Amesos2

--- a/packages/amesos2/src/Amesos2_MUMPS_decl.hpp
+++ b/packages/amesos2/src/Amesos2_MUMPS_decl.hpp
@@ -100,13 +100,19 @@ public:
   typedef typename super_type::global_ordinal_type      global_ordinal_type;
   typedef typename super_type::global_size_type            global_size_type;
 
-  typedef TypeMap<Amesos2::MUMPS,scalar_type>                    type_map;
+  typedef TypeMap<Amesos2::MUMPS,scalar_type>                      type_map;
 
-  typedef typename type_map::type                                  slu_type;
+  typedef typename type_map::type                                mumps_type;
   typedef typename type_map::magnitude_type                  magnitude_type;
   typedef typename type_map::MUMPS_STRUC_C                    MUMPS_STRUC_C;
 
-  typedef FunctionMap<Amesos2::MUMPS,slu_type>               function_map;
+  typedef Kokkos::DefaultHostExecutionSpace                     HostExecSpaceType;
+  typedef typename HostExecSpaceType::memory_space              HostMemSpaceType;
+
+  typedef Kokkos::View<local_ordinal_type*, HostExecSpaceType>  host_ordinal_type_view;
+  typedef Kokkos::View<mumps_type*, HostExecSpaceType>          host_value_type_view;
+
+  typedef FunctionMap<Amesos2::MUMPS,mumps_type>               function_map;
 
   MUMPS(Teuchos::RCP<const Matrix> A,
           Teuchos::RCP<Vector>       X,
@@ -209,16 +215,16 @@ private:
 
   // The following Arrays are persisting storage arrays for A, X, and B
   /// Stores the values of the nonzero entries for MUMPS
-  Teuchos::Array<slu_type> nzvals_;
+  host_value_type_view host_nzvals_view_;
   /// Stores the location in \c Ai_ and Aval_ that starts row j
-  Teuchos::Array<local_ordinal_type> rowind_;
+  host_ordinal_type_view host_rows_view_;
   /// Stores the row indices of the nonzero entries
-  Teuchos::Array<local_ordinal_type> colptr_;
+  host_ordinal_type_view host_col_ptr_view_;
 
   /// Persisting 1D store for X
-  mutable Teuchos::Array<slu_type> xvals_;  local_ordinal_type ldx_;
+  mutable Teuchos::Array<mumps_type> xvals_;  local_ordinal_type ldx_;
   /// Persisting 1D store for B
-  mutable Teuchos::Array<slu_type> bvals_;  local_ordinal_type ldb_;
+  mutable Teuchos::Array<mumps_type> bvals_;  local_ordinal_type ldb_;
 
   mutable MUMPS_STRUC_C mumps_par;
 

--- a/packages/amesos2/src/Amesos2_MUMPS_def.hpp
+++ b/packages/amesos2/src/Amesos2_MUMPS_def.hpp
@@ -75,9 +75,6 @@ namespace Amesos2
                               Teuchos::RCP<Vector>       X,
                               Teuchos::RCP<const Vector> B )
     : SolverCore<Amesos2::MUMPS,Matrix,Vector>(A, X, B)
-    , nzvals_()                   // initialize to empty arrays
-    , rowind_()
-    , colptr_()
     , is_contiguous_(true)
   {
 
@@ -211,13 +208,6 @@ namespace Amesos2
           #ifdef HAVE_AMESOS2_TIMERS
           Teuchos::TimeMonitor numFactTimer(this->timers_.numFactTime_);
           #endif
-          
-          #ifdef HAVE_AMESOS2_VERBOSE_DEBUG
-          std::cout << "MUMPS:: Before numeric factorization" << std::endl;
-          std::cout << "nzvals_ : " << nzvals_.toString() << std::endl;
-          std::cout << "rowind_ : " << rowind_.toString() << std::endl;
-          std::cout << "colptr_ : " << colptr_.toString() << std::endl;
-          #endif
         }
       }
     mumps_par.job = 2;
@@ -254,11 +244,11 @@ namespace Amesos2
 
     if ( is_contiguous_ == true ) {
       Util::get_1d_copy_helper<MultiVecAdapter<Vector>,
-        slu_type>::do_get(B, bvals_(),as<size_t>(ld_rhs), ROOTED, this->rowIndexBase_);
+        mumps_type>::do_get(B, bvals_(),as<size_t>(ld_rhs), ROOTED, this->rowIndexBase_);
     }
     else {
       Util::get_1d_copy_helper<MultiVecAdapter<Vector>,
-        slu_type>::do_get(B, bvals_(),as<size_t>(ld_rhs), CONTIGUOUS_AND_ROOTED, this->rowIndexBase_);
+        mumps_type>::do_get(B, bvals_(),as<size_t>(ld_rhs), CONTIGUOUS_AND_ROOTED, this->rowIndexBase_);
     }
  
     
@@ -286,13 +276,13 @@ namespace Amesos2
 
     if ( is_contiguous_ == true ) {
       Util::put_1d_data_helper<
-        MultiVecAdapter<Vector>,slu_type>::do_put(X, bvals_(),
+        MultiVecAdapter<Vector>,mumps_type>::do_put(X, bvals_(),
             as<size_t>(ld_rhs),
             ROOTED);
     }
     else {
       Util::put_1d_data_helper<
-        MultiVecAdapter<Vector>,slu_type>::do_put(X, bvals_(),
+        MultiVecAdapter<Vector>,mumps_type>::do_put(X, bvals_(),
             as<size_t>(ld_rhs),
             CONTIGUOUS_AND_ROOTED);
     }
@@ -395,9 +385,9 @@ namespace Amesos2
       {
         // Only the root image needs storage allocated
         if( !MUMPS_MATRIX_LOAD && this->root_ ){
-          nzvals_.resize(this->globalNumNonZeros_);
-          rowind_.resize(this->globalNumNonZeros_);
-          colptr_.resize(this->globalNumCols_ + 1);
+          Kokkos::resize(host_nzvals_view_, this->globalNumNonZeros_);
+          Kokkos::resize(host_rows_view_, this->globalNumNonZeros_);
+          Kokkos::resize(host_col_ptr_view_, this->globalNumRows_ + 1);
         }
   
         local_ordinal_type nnz_ret = 0;
@@ -407,15 +397,15 @@ namespace Amesos2
         #endif
     
         if ( is_contiguous_ == true ) {
-          Util::get_ccs_helper<
-            MatrixAdapter<Matrix>,slu_type,local_ordinal_type,local_ordinal_type>
-            ::do_get(this->matrixA_.ptr(), nzvals_(), rowind_(), colptr_(),
+          Util::get_ccs_helper_kokkos_view<
+            MatrixAdapter<Matrix>,host_value_type_view,host_ordinal_type_view,host_ordinal_type_view>
+            ::do_get(this->matrixA_.ptr(), host_nzvals_view_, host_rows_view_, host_col_ptr_view_,
                 nnz_ret, ROOTED, ARBITRARY, this->rowIndexBase_);
         }
         else {
-          Util::get_ccs_helper<
-            MatrixAdapter<Matrix>,slu_type,local_ordinal_type,local_ordinal_type>
-            ::do_get(this->matrixA_.ptr(), nzvals_(), rowind_(), colptr_(),
+          Util::get_ccs_helper_kokkos_view<
+            MatrixAdapter<Matrix>,host_value_type_view,host_ordinal_type_view,host_ordinal_type_view>
+            ::do_get(this->matrixA_.ptr(), host_nzvals_view_, host_rows_view_, host_col_ptr_view_,
                 nnz_ret, CONTIGUOUS_AND_ROOTED, ARBITRARY, this->rowIndexBase_);
         }
   
@@ -470,25 +460,25 @@ namespace Amesos2
     
     for(i = 0; i < (local_ordinal_type)this->globalNumCols_; i++)
       {
-        for( j = colptr_[i]; j < colptr_[i+1]-1; j++)
+        for( j = host_col_ptr_view_(i); j < host_col_ptr_view_(i+1)-1; j++)
           {
             mumps_par.jcn[tri_count] = (MUMPS_INT)i+1; //Fortran index
-            mumps_par.irn[tri_count] = (MUMPS_INT)rowind_[j]+1; //Fortran index
-            mumps_par.a[tri_count] = nzvals_[j];
+            mumps_par.irn[tri_count] = (MUMPS_INT)host_rows_view_(j)+1; //Fortran index
+            mumps_par.a[tri_count] = host_nzvals_view_(j);
             
             tri_count++;
           }
         
-        j = colptr_[i+1]-1;
+        j = host_col_ptr_view_(i+1)-1;
         mumps_par.jcn[tri_count] = (MUMPS_INT)i+1; //Fortran index
-        mumps_par.irn[tri_count] = (MUMPS_INT)rowind_[j]+1; //Fortran index
-        mumps_par.a[tri_count] = nzvals_[j];
+        mumps_par.irn[tri_count] = (MUMPS_INT)host_rows_view_(j)+1; //Fortran index
+        mumps_par.a[tri_count] = host_nzvals_view_(j);
 
         tri_count++;
         
-        if(rowind_[j] > max_local_ordinal)
+        if(host_rows_view_(j) > max_local_ordinal)
           {
-            max_local_ordinal = rowind_[j];
+            max_local_ordinal = host_rows_view_(j);
           }
       }
     TEUCHOS_TEST_FOR_EXCEPTION(std::numeric_limits<MUMPS_INT>::max() <= max_local_ordinal,


### PR DESCRIPTION
@trilinos/amesos2 

## Motivation

This PR updates Amesos2_MUMPS code to remove the deprecated codes.

## Related Issues

* https://github.com/trilinos/Trilinos/issues/11813

## Testing
```
    Start 1: Amesos2_KLU2_UnitTests_MPI_2
1/7 Test #1: Amesos2_KLU2_UnitTests_MPI_2 .........................   Passed    1.50 sec
    Start 2: Amesos2_KLU2_Solver_Test_MPI_2
2/7 Test #2: Amesos2_KLU2_Solver_Test_MPI_2 .......................   Passed    1.79 sec
    Start 3: Amesos2_LAPACK_Solver_Test_MPI_4
3/7 Test #3: Amesos2_LAPACK_Solver_Test_MPI_4 .....................   Passed    1.60 sec
    Start 4: Amesos2_MUMPS_UnitTests_MPI_4
4/7 Test #4: Amesos2_MUMPS_UnitTests_MPI_4 ........................   Passed    1.55 sec
    Start 5: Amesos2_SolverFactory_UnitTests_MPI_4
5/7 Test #5: Amesos2_SolverFactory_UnitTests_MPI_4 ................   Passed    1.57 sec
    Start 6: Amesos2_Tpetra_MultiVector_Adapter_UnitTests_MPI_4
6/7 Test #6: Amesos2_Tpetra_MultiVector_Adapter_UnitTests_MPI_4 ...   Passed    1.77 sec
    Start 7: Amesos2_Tpetra_CrsMatrix_Adapter_UnitTests_MPI_4
7/7 Test #7: Amesos2_Tpetra_CrsMatrix_Adapter_UnitTests_MPI_4 .....   Passed    2.12 sec

100% tests passed, 0 tests failed out of 7

Label Time Summary:
Amesos2    =  41.02 sec*proc (7 tests)

Total Test time (real) =  11.95 sec
```