### PR TITLE
Amesos2_MUMPS : fix compilation with complex scalar type

### DIFF
--- a/packages/amesos2/src/Amesos2_MUMPS_TypeMap.hpp
+++ b/packages/amesos2/src/Amesos2_MUMPS_TypeMap.hpp
@@ -116,7 +116,7 @@ template <class, class> class MUMPS;
   struct TypeMap<MUMPS,std::complex<float> >
   {
     typedef MUMPST::CMUMPS_COMPLEX type;
-    typedef MUMPST::CMUMPS_COMPLEX  magnitude_type;
+    typedef float                  magnitude_type;
     typedef MUMPST::CMUMPS_STRUC_C MUMPS_STRUC_C;
   };
     
@@ -124,7 +124,7 @@ template <class, class> class MUMPS;
   struct TypeMap<MUMPS,std::complex<double> >
   {
     typedef MUMPST::ZMUMPS_COMPLEX type;
-    typedef MUMPST::ZMUMPS_COMPLEX   magnitude_type;
+    typedef double                 magnitude_type;
     typedef MUMPST::ZMUMPS_STRUC_C MUMPS_STRUC_C; 
   };
   
@@ -132,7 +132,7 @@ template <class, class> class MUMPS;
   struct TypeMap<MUMPS, MUMPST::CMUMPS_COMPLEX>
   {
     typedef MUMPST::CMUMPS_COMPLEX type;
-    typedef MUMPST::CMUMPS_COMPLEX magnitude_type;
+    typedef float                  magnitude_type;
     typedef MUMPST::CMUMPS_STRUC_C MUMPS_STRUC_C;
   };
   
@@ -140,7 +140,7 @@ template <class, class> class MUMPS;
   struct TypeMap<MUMPS, MUMPST::ZMUMPS_COMPLEX>
   {
     typedef MUMPST::ZMUMPS_COMPLEX type;
-    typedef MUMPST::ZMUMPS_COMPLEX magnitude_type;
+    typedef double                 magnitude_type;
     typedef MUMPST::ZMUMPS_STRUC_C MUMPS_STRUC_C;
   };
   

--- a/packages/amesos2/src/Amesos2_MUMPS_decl.hpp
+++ b/packages/amesos2/src/Amesos2_MUMPS_decl.hpp
@@ -112,8 +112,6 @@ public:
   typedef Kokkos::View<local_ordinal_type*, HostExecSpaceType>  host_ordinal_type_view;
   typedef Kokkos::View<mumps_type*, HostExecSpaceType>          host_value_type_view;
 
-  typedef FunctionMap<Amesos2::MUMPS,mumps_type>               function_map;
-
   MUMPS(Teuchos::RCP<const Matrix> A,
           Teuchos::RCP<Vector>       X,
           Teuchos::RCP<const Vector> B);

--- a/packages/amesos2/src/Amesos2_MUMPS_def.hpp
+++ b/packages/amesos2/src/Amesos2_MUMPS_def.hpp
@@ -153,6 +153,8 @@ namespace Amesos2
   MUMPS<Matrix,Vector>::~MUMPS( )
   {
     /* Clean up the struc*/
+    typedef FunctionMap<MUMPS,scalar_type> function_map;
+
     if(MUMPS_STRUCT == true)
       {
         free(mumps_par.a);
@@ -443,7 +445,7 @@ namespace Amesos2
       MUMPS_STRUCT = true;
       mumps_par.n =  this->globalNumCols_;
       mumps_par.nz = this->globalNumNonZeros_;
-      mumps_par.a = (magnitude_type*)malloc(mumps_par.nz * sizeof(magnitude_type));
+      mumps_par.a = (mumps_type*)malloc(mumps_par.nz * sizeof(mumps_type));
       mumps_par.irn = (MUMPS_INT*)malloc(mumps_par.nz *sizeof(MUMPS_INT));
       mumps_par.jcn = (MUMPS_INT*)malloc(mumps_par.nz * sizeof(MUMPS_INT));
     }


### PR DESCRIPTION

@trilinos/amesos2 

## Motivation

This PR fixed errors compiling Amesos2::MUMPS with complex scalar type

## Related Issues

https://github.com/trilinos/Trilinos/issues/10667

## Testing

```
    Start 1: Amesos2_KLU2_UnitTests_MPI_2
1/7 Test #1: Amesos2_KLU2_UnitTests_MPI_2 .........................   Passed    1.68 sec
    Start 2: Amesos2_KLU2_Solver_Test_MPI_2
2/7 Test #2: Amesos2_KLU2_Solver_Test_MPI_2 .......................   Passed    2.09 sec
    Start 3: Amesos2_LAPACK_Solver_Test_MPI_4
3/7 Test #3: Amesos2_LAPACK_Solver_Test_MPI_4 .....................   Passed    1.62 sec
    Start 4: Amesos2_MUMPS_UnitTests_MPI_4
4/7 Test #4: Amesos2_MUMPS_UnitTests_MPI_4 ........................   Passed    2.07 sec
    Start 5: Amesos2_SolverFactory_UnitTests_MPI_4
5/7 Test #5: Amesos2_SolverFactory_UnitTests_MPI_4 ................   Passed    1.65 sec
    Start 6: Amesos2_Tpetra_MultiVector_Adapter_UnitTests_MPI_4
6/7 Test #6: Amesos2_Tpetra_MultiVector_Adapter_UnitTests_MPI_4 ...   Passed    1.74 sec
    Start 7: Amesos2_Tpetra_CrsMatrix_Adapter_UnitTests_MPI_4
7/7 Test #7: Amesos2_Tpetra_CrsMatrix_Adapter_UnitTests_MPI_4 .....   Passed    1.85 sec

100% tests passed, 0 tests failed out of 7

Label Time Summary:
Amesos2    =  43.27 sec*proc (7 tests)

Total Test time (real) =  12.75 sec
```