### PR TITLE
MueLu: Correct uses of MUELU_HAVE_* macros

### DIFF
--- a/packages/muelu/src/Graph/Containers/MueLu_Zoltan2GraphAdapter.hpp
+++ b/packages/muelu/src/Graph/Containers/MueLu_Zoltan2GraphAdapter.hpp
@@ -454,6 +454,6 @@ template <typename User, typename UserCoord>
 }  //namespace MueLu
 
 
-#endif// MUELU_HAVE_ZOLTAN2
+#endif // HAVE_MUELU_ZOLTAN2
   
 #endif

--- a/packages/muelu/test/unit_tests/GenericRFactory.cpp
+++ b/packages/muelu/test/unit_tests/GenericRFactory.cpp
@@ -89,10 +89,10 @@ namespace MueLuTests {
     #include <MueLu_UseShortNames.hpp>
     MUELU_TESTING_SET_OSTREAM;
     MUELU_TESTING_LIMIT_SCOPE(Scalar,GlobalOrdinal,Node);
-#   if !defined(MUELU_HAVE_IFPACK)
+#   if !defined(HAVE_MUELU_IFPACK)
     MUELU_TESTING_DO_NOT_TEST(Xpetra::UseEpetra, "Ifpack");
 #   endif
-#   if !defined(MUELU_HAVE_IFPACK2)
+#   if !defined(HAVE_MUELU_IFPACK2)
     MUELU_TESTING_DO_NOT_TEST(Xpetra::UseTpetra, "Ifpack2");
 #   endif
     out << "version: " << MueLu::Version() << std::endl;
@@ -224,10 +224,10 @@ namespace MueLuTests {
     #include <MueLu_UseShortNames.hpp>
     MUELU_TESTING_SET_OSTREAM;
     MUELU_TESTING_LIMIT_SCOPE(Scalar,GlobalOrdinal,Node);
-#   if !defined(MUELU_HAVE_IFPACK)
+#   if !defined(HAVE_MUELU_IFPACK)
     MUELU_TESTING_DO_NOT_TEST(Xpetra::UseEpetra, "Ifpack");
 #   endif
-#   if !defined(MUELU_HAVE_IFPACK2)
+#   if !defined(HAVE_MUELU_IFPACK2)
     MUELU_TESTING_DO_NOT_TEST(Xpetra::UseTpetra, "Ifpack2");
 #   endif
     out << "version: " << MueLu::Version() << std::endl;

--- a/packages/muelu/test/unit_tests/GenericRFactory.cpp
+++ b/packages/muelu/test/unit_tests/GenericRFactory.cpp
@@ -57,6 +57,7 @@
 #include <Xpetra_MultiVectorFactory.hpp>
 #include <Xpetra_VectorFactory.hpp>
 #include <Xpetra_MatrixMatrix.hpp>
+#include <Xpetra_CrsGraph.hpp>
 
 #include <MueLu_TestHelpers.hpp>
 #include <MueLu_Utilities.hpp>
@@ -145,8 +146,6 @@ namespace MueLuTests {
     smootherParamList.set("relaxation: damping factor", (SC) 1.0);
     RCP<SmootherPrototype> smooProto = rcp( new TrilinosSmoother("RELAXATION", smootherParamList) );
     RCP<SmootherFactory> SmooFact = rcp( new SmootherFactory(smooProto) );
-    //Acfact->setVerbLevel(Teuchos::VERB_HIGH);
-
     RCP<SmootherFactory> coarseSolveFact = rcp(new SmootherFactory(smooProto, Teuchos::null));
 
     FactoryManager M;
@@ -171,6 +170,10 @@ namespace MueLuTests {
     TEST_EQUALITY(coarseLevel->IsAvailable("PostSmoother"), true);
     TEST_EQUALITY(coarseLevel2->IsAvailable("PreSmoother"), true);
     TEST_EQUALITY(coarseLevel2->IsAvailable("PostSmoother"), false);
+
+    // GH: we need to compute global constants in order to check getGlobalNumEntries
+    Teuchos::rcp_const_cast<CrsGraph>(P1->getCrsGraph())->computeGlobalConstants();
+    Teuchos::rcp_const_cast<CrsGraph>(P2->getCrsGraph())->computeGlobalConstants();
 
     // test some basic multgrid data
     TEST_EQUALITY(P1->getGlobalNumEntries(), R1->getGlobalNumEntries());

--- a/packages/muelu/test/unit_tests/Repartition.cpp
+++ b/packages/muelu/test/unit_tests/Repartition.cpp
@@ -906,10 +906,10 @@ namespace MueLuTests {
 #   include <MueLu_UseShortNames.hpp>
     MUELU_TESTING_SET_OSTREAM;
     MUELU_TESTING_LIMIT_SCOPE(Scalar,GlobalOrdinal,Node);
-#   if !defined(MUELU_HAVE_AMESOS) || !defined(MUELU_HAVE_IFPACK)
+#   if !defined(HAVE_MUELU_AMESOS) || !defined(HAVE_MUELU_IFPACK)
     MUELU_TESTING_DO_NOT_TEST(Xpetra::UseEpetra, "Amesos, Ifpack");
 #   endif
-#   if !defined(MUELU_HAVE_AMESOS2) || !defined(MUELU_HAVE_IFPACK2)
+#   if !defined(HAVE_MUELU_AMESOS2) || !defined(HAVE_MUELU_IFPACK2)
     MUELU_TESTING_DO_NOT_TEST(Xpetra::UseTpetra, "Amesos2, Ifpack2");
 #   endif
 
@@ -1019,10 +1019,10 @@ namespace MueLuTests {
     MUELU_TESTING_SET_OSTREAM;
 
     MUELU_TESTING_LIMIT_SCOPE(Scalar,GlobalOrdinal,Node);
-#   if !defined(MUELU_HAVE_AMESOS) || !defined(MUELU_HAVE_IFPACK)
+#   if !defined(HAVE_MUELU_AMESOS) || !defined(HAVE_MUELU_IFPACK)
     MUELU_TESTING_DO_NOT_TEST(Xpetra::UseEpetra, "Amesos, Ifpack");
 #   endif
-#   if !defined(MUELU_HAVE_AMESOS2) || !defined(MUELU_HAVE_IFPACK2)
+#   if !defined(HAVE_MUELU_AMESOS2) || !defined(HAVE_MUELU_IFPACK2)
     MUELU_TESTING_DO_NOT_TEST(Xpetra::UseTpetra, "Amesos2, Ifpack2");
 #   endif
    

--- a/packages/muelu/test/unit_tests/TentativePFactory.cpp
+++ b/packages/muelu/test/unit_tests/TentativePFactory.cpp
@@ -538,10 +538,10 @@ namespace MueLuTests {
 #   include "MueLu_UseShortNames.hpp"
     MUELU_TESTING_SET_OSTREAM;
     MUELU_TESTING_LIMIT_SCOPE(Scalar,GlobalOrdinal,Node);
-#   if !defined(MUELU_HAVE_IFPACK)
+#   if !defined(HAVE_MUELU_IFPACK)
     MUELU_TESTING_DO_NOT_TEST(Xpetra::UseEpetra, "Ifpack");
 #   endif
-#   if !defined(MUELU_HAVE_IFPACK2)
+#   if !defined(HAVE_MUELU_IFPACK2)
     MUELU_TESTING_DO_NOT_TEST(Xpetra::UseTpetra, "Ifpack2");
 #   endif
 


### PR DESCRIPTION
@trilinos/muelu 

`MUELU_HAVE_*` is not correct, but `HAVE_MUELU_*` is correct :)

Closes #11843.