### PR TITLE
Panzer: remove kokko scope guard from unit test

### DIFF
--- a/packages/panzer/adapters-stk/test/periodic_bcs/periodic_32bit_int_limit.cpp
+++ b/packages/panzer/adapters-stk/test/periodic_bcs/periodic_32bit_int_limit.cpp
@@ -40,8 +40,6 @@ TEUCHOS_UNIT_TEST(periodic_bcs, 32_bit_int_limit)
   setenv("IOSS_PROPERTIES", "DECOMPOSITION_METHOD=rib", 1);
 
   Teuchos::RCP<Teuchos::MpiComm<int>> Comm = Teuchos::rcp( new Teuchos::MpiComm<int>(MPI_COMM_WORLD) );
-  if (!Kokkos::is_initialized())
-    Kokkos::ScopeGuard();
 
   using topo_RCP = Teuchos::RCP<const shards::CellTopology>;
   using basis_RCP = Teuchos::RCP<Intrepid2::Basis<PHX::Device::execution_space,double,double>>;


### PR DESCRIPTION
## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
remove use of scope guard in unit test. kokkos is already initialized in the global mpi session object

Closes #11856 

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->