### PR TITLE
Anasazi: Minor cleanup to address build warnings and memory leaks

### DIFF
--- a/packages/anasazi/epetra/util/ModeLaplace/ModeLaplace1DQ1.cpp
+++ b/packages/anasazi/epetra/util/ModeLaplace/ModeLaplace1DQ1.cpp
@@ -464,6 +464,9 @@ int ModeLaplace1DQ1::eigenCheck(const Epetra_MultiVector &Q, double *lambda,
   // if smallest == true, nMax is the rightmost value in continuous that we matched against
   // if smallest == false, nMax is the leftmost value in continuous that we matched against
 
+  // Clean up.
+  delete [] lambdasorted;
+
   // Define the exact discrete eigenvectors
   int localSize = Map->NumMyElements();
   double *vQ = new (std::nothrow) double[(nMax+2)*localSize];

--- a/packages/anasazi/src/AnasaziFactory.hpp
+++ b/packages/anasazi/src/AnasaziFactory.hpp
@@ -111,6 +111,8 @@ public:
     else
       TEUCHOS_TEST_FOR_EXCEPTION(true, std::invalid_argument,
         "Anasazi::Factory::create: Invalid solver type \"" << solverType << "\".");
+
+    return Teuchos::null;
   }
 
   template<class MV, class OP>
@@ -152,6 +154,8 @@ public:
     else
       TEUCHOS_TEST_FOR_EXCEPTION( true, std::invalid_argument,
         "Anasazi::Factory::create: Invalid solverType type \"" << solverType << "\".");
+
+    return Teuchos::null;
   }
 
   //! Specialize create for BasicEigenproblem type.

--- a/packages/anasazi/thyra/example/MVOPTester/CMakeLists.txt
+++ b/packages/anasazi/thyra/example/MVOPTester/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-IF (Anasazi_ENABLE_Epetra)
+IF(${PACKAGE_NAME}_ENABLE_Epetra AND ${PACKAGE_NAME}_ENABLE_ThyraEpetraAdapters)
 TRIBITS_ADD_EXECUTABLE(
   Thyra_MVOPTester_example
   SOURCES MVOPTesterEx.cpp

--- a/packages/anasazi/thyra/test/MVOPTester/CMakeLists.txt
+++ b/packages/anasazi/thyra/test/MVOPTester/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 
-IF(Anasazi_ENABLE_Epetra)
+IF(${PACKAGE_NAME}_ENABLE_Epetra AND ${PACKAGE_NAME}_ENABLE_ThyraEpetraAdapters)
   TRIBITS_ADD_EXECUTABLE_AND_TEST(
     MVOPTesterThyra_test
     SOURCES cxx_main.cpp


### PR DESCRIPTION

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/anasazi 

## Motivation
The new dashboard for memory leaks in Trilinos has identified an issue in the Anasazi utiltity that generates test problems for the eigensolver.

https://trilinos-cdash.sandia.gov/index.php?project=Trilinos#!/%23DynamicAnalysis

While checking this issue, I noticed a build warning in the solver factory and potential issues in building the Thyra examples and tests.

This commit addresses all these minor issues.
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
OSX GCC12 / RHEL7 Intel 19.x

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->