### PR TITLE
Teuchos: sprintf -> snprintf in Teuchos_Utils.cpp

### DIFF
--- a/packages/teuchos/core/src/Teuchos_Utils.cpp
+++ b/packages/teuchos/core/src/Teuchos_Utils.cpp
@@ -83,28 +83,28 @@ std::string Utils::trimWhiteSpace( const std::string& str )
 std::string Utils::toString(const int& x)
 {
 	char s[100];
-	std::sprintf(s, "%d", x);
+	std::snprintf(s, sizeof(s), "%d", x);
 	return std::string(s);
 }
 
 std::string Utils::toString(const long long& x)
 {
 	char s[100];
-	std::sprintf(s, "%lld", x);
+	std::snprintf(s, sizeof(s), "%lld", x);
 	return std::string(s);
 }
 
 std::string Utils::toString(const unsigned int& x)
 {
 	char s[100];
-	std::sprintf(s, "%d", x);
+	std::snprintf(s, sizeof(s), "%d", x);
 	return std::string(s);
 }
 
 std::string Utils::toString(const double& x)
 {
 	char s[100];
-	std::sprintf(s, "%g", x);
+	std::snprintf(s, sizeof(s), "%g", x);
 	return std::string(s);
 }
 


### PR DESCRIPTION
@trilinos/teuchos 

`sprintf` is deprecated in macOS 13, and issues warnings like this during the build:

```
.../Trilinos/packages/teuchos/core/src/Teuchos_Utils.cpp:107:7: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
        std::sprintf(s, "%g", x);
```

`snprintf` has been available since c++11 and is a suitable replacement in this circumstance.