### PR TITLE
Epetra: sprintf -> snprintf in Epetra_Object.h

### DIFF
--- a/packages/epetra/src/Epetra_Object.h
+++ b/packages/epetra/src/Epetra_Object.h
@@ -144,18 +144,18 @@ class EPETRA_LIB_DLL_EXPORT Epetra_Object {
  protected:
   std::string toString(const int& x) const {
      char s[100];
-     sprintf(s, "%d", x);
+     snprintf(s, sizeof(s), "%d", x);
      return std::string(s);
 }
   std::string toString(const long long& x) const {
      char s[100];
-     sprintf(s, "%lld", x);
+     snprintf(s, sizeof(s), "%lld", x);
      return std::string(s);
 }
 
   std::string toString(const double& x) const {
      char s[100];
-     sprintf(s, "%g", x);
+     snprintf(s, sizeof(s), "%g", x);
      return std::string(s);
 }
 


### PR DESCRIPTION
@trilinos/epetra 

@trilinos/epetra

`sprintf` is deprecated in macOS 13, and issues warnings like this during the build:

```
warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
```

`snprintf` has been available since c++11 and is a suitable replacement in this circumstance.