### PR TITLE
Add NVIDIA warnings-as-errors build to nightly testing

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -2281,9 +2281,11 @@ use rhel7_sems-cuda-11.4.2-sems-gnu-10.1.0-sems-openmpi-4.0.5_release_static_Vol
 use NODE-TYPE|CUDA_USE-RDC|YES_USE-PT|YES
 use USE-RDC|YES
 use PACKAGE-ENABLES|ALL
-opt-set-cmake-var Trilinos_AUTOGENERATE_TEST_RESOURCE_FILE BOOL : ON
-opt-set-cmake-var Trilinos_CUDA_NUM_GPUS STRING : 4
-opt-set-cmake-var Trilinos_CUDA_SLOTS_PER_GPU STRING : 2
+
+opt-set-cmake-var Trilinos_AUTOGENERATE_TEST_RESOURCE_FILE BOOL   : ON
+opt-set-cmake-var Trilinos_CUDA_NUM_GPUS                   STRING : 4
+opt-set-cmake-var Trilinos_CUDA_SLOTS_PER_GPU              STRING : 2
+opt-set-cmake-var CMAKE_CXX_FLAGS                          STRING : -Wall -Wunused-parameter -Wshadow -pedantic -Wsign-compare -Wtype-limits -Wuninitialized
 
 # This is temporarily disabled because it seems to be particularly sensitive to the spack-built
 #  MPI issue (TRILFRAME-552)

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -2285,7 +2285,7 @@ use PACKAGE-ENABLES|ALL
 opt-set-cmake-var Trilinos_AUTOGENERATE_TEST_RESOURCE_FILE BOOL   : ON
 opt-set-cmake-var Trilinos_CUDA_NUM_GPUS                   STRING : 4
 opt-set-cmake-var Trilinos_CUDA_SLOTS_PER_GPU              STRING : 2
-opt-set-cmake-var CMAKE_CXX_FLAGS                          STRING : -Wall -Wunused-parameter -Wshadow -pedantic -Wsign-compare -Wtype-limits -Wuninitialized
+opt-set-cmake-var CMAKE_CXX_FLAGS                          STRING : -Wall -Wunused-parameter -Werror=unused-parameter -Wshadow -Werror=shadow -pedantic -Werror=pedantic -Werror=sign-compare -Werror=sign-compare -Wtype-limits -Werror=type-limits -Wuninitialized -Werror=uninitialized
 
 # This is temporarily disabled because it seems to be particularly sensitive to the spack-built
 #  MPI issue (TRILFRAME-552)

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -2285,7 +2285,7 @@ use PACKAGE-ENABLES|ALL
 opt-set-cmake-var Trilinos_AUTOGENERATE_TEST_RESOURCE_FILE BOOL   : ON
 opt-set-cmake-var Trilinos_CUDA_NUM_GPUS                   STRING : 4
 opt-set-cmake-var Trilinos_CUDA_SLOTS_PER_GPU              STRING : 2
-opt-set-cmake-var CMAKE_CXX_FLAGS                          STRING : -Wall -Wunused-parameter -Werror=unused-parameter -Wshadow -Werror=shadow -pedantic -Werror=pedantic -Werror=sign-compare -Werror=sign-compare -Wtype-limits -Werror=type-limits -Wuninitialized -Werror=uninitialized
+opt-set-cmake-var CMAKE_CXX_FLAGS                          STRING FORCE : -Wall -Wunused-parameter -Werror=unused-parameter -Wshadow -Werror=shadow -pedantic -Werror=pedantic -Werror=sign-compare -Werror=sign-compare -Wtype-limits -Werror=type-limits -Wuninitialized -Werror=uninitialized
 
 # This is temporarily disabled because it seems to be particularly sensitive to the spack-built
 #  MPI issue (TRILFRAME-552)


### PR DESCRIPTION
@trilinos/framework 

## Motivation
Clean up NVIDA warnings in Trilinos, as requested by @crtrott . See TRILFRAME-396 for more details.

## Related Issues

* Follows #7346 
