### PR TITLE
TrilinosCouplings:  Get FENL running again.

### DIFF
--- a/packages/stokhos/src/sacado/kokkos/pce/tpetra/Stokhos_Tpetra_UQ_PCE.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/tpetra/Stokhos_Tpetra_UQ_PCE.hpp
@@ -329,9 +329,9 @@ namespace Kokkos {
       // be the host View?  However, this is what I found when I
       // changed these lines not to call deprecated code, so I'm
       // leaving it.
-      return dimension_scalar(mv.getLocalViewDevice(Tpetra::Access::ReadOnly));
+      return dimension_scalar(mv.getLocalViewHost(Tpetra::Access::ReadOnly));
     }
-    return dimension_scalar(mv.getLocalViewHost(Tpetra::Access::ReadOnly));
+    return dimension_scalar(mv.getLocalViewDevice(Tpetra::Access::ReadOnly));
   }
 
   template <class S, class L, class G, class N>
@@ -342,9 +342,9 @@ namespace Kokkos {
       // be the host View?  However, this is what I found when I
       // changed these lines not to call deprecated code, so I'm
       // leaving it.
-      return dimension_scalar(v.getLocalViewDevice(Tpetra::Access::ReadOnly));
+      return dimension_scalar(v.getLocalViewHost(Tpetra::Access::ReadOnly));
     }
-    return dimension_scalar(v.getLocalViewHost(Tpetra::Access::ReadOnly));
+    return dimension_scalar(v.getLocalViewDevice(Tpetra::Access::ReadOnly));
   }
 }
 

--- a/packages/trilinoscouplings/examples/fenl/CMakeLists.txt
+++ b/packages/trilinoscouplings/examples/fenl/CMakeLists.txt
@@ -1,4 +1,4 @@
-IF (TrilinosCouplings_ENABLE_Tpetra AND Tpetra_Have_Kokkos_Refactor)
+IF (TrilinosCouplings_ENABLE_Tpetra)
 
   TRIBITS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR})
   TRIBITS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
@@ -52,7 +52,7 @@ IF (TrilinosCouplings_ENABLE_Tpetra AND Tpetra_Have_Kokkos_Refactor)
           fenl_ensemble
           NAME "fenl_ensemble_8x8x8_belos_muelu"
           COMM serial mpi
-          NUM_MPI_PROCS 4
+          #NUM_MPI_PROCS 4
           ARGS "--fixture=8x8x8 --belos --muelu --ensemble=${Stokhos_ETI_Default_Ensemble_Size} --print-its --unit-test --test-mean=2.0599472 --test-std-dev=8.9771555e-3"
           PASS_REGULAR_EXPRESSION "Test Passed"
           )
@@ -73,7 +73,7 @@ IF (TrilinosCouplings_ENABLE_Tpetra AND Tpetra_Have_Kokkos_Refactor)
           fenl_pce
           NAME "fenl_pce_8x8x8_belos_muelu_mean_based"
           COMM serial mpi
-          NUM_MPI_PROCS 4
+          #NUM_MPI_PROCS 4
           ARGS "--fixture=8x8x8 --belos --muelu --mean-based --print-its --unit-test --test-mean=2.0599472 --test-std-dev=8.9771555e-3"
           PASS_REGULAR_EXPRESSION "Test Passed"
           )

--- a/packages/trilinoscouplings/examples/fenl/SampleGrouping.hpp
+++ b/packages/trilinoscouplings/examples/fenl/SampleGrouping.hpp
@@ -244,7 +244,7 @@ public:
     }
 
     KOKKOS_INLINE_FUNCTION
-    void join (volatile value_type dst, const volatile value_type src) const
+    void join (value_type dst, const value_type src) const
     {
       if (src[0] > dst[0])
         dst[0] = src[0];

--- a/packages/trilinoscouplings/examples/fenl/fenl_functors.hpp
+++ b/packages/trilinoscouplings/examples/fenl/fenl_functors.hpp
@@ -367,7 +367,7 @@ public:
   void init( unsigned & update ) const { update = 0 ; }
 
   KOKKOS_INLINE_FUNCTION
-  void join( volatile unsigned & update , const volatile unsigned & input ) const { update += input ; }
+  void join( unsigned & update , const unsigned & input ) const { update += input ; }
 
   //------------------------------------
 };
@@ -1237,7 +1237,8 @@ public:
   {
     Teuchos::Array<scalar_type> response(value_count, 0.0);
     //Kokkos::parallel_reduce( fixture.elem_count() , *this , response );
-    Kokkos::parallel_reduce( solution.extent(0) , *this , &response[0] );
+    Kokkos::View<scalar_type*, Kokkos::HostSpace> resp_view(&response[0], value_count);
+    Kokkos::parallel_reduce( solution.extent(0) , *this , resp_view );
     return response[0];
   }
 
@@ -1245,7 +1246,8 @@ public:
   {
     Teuchos::Array<scalar_type> response(value_count, 0.0);
     //Kokkos::parallel_reduce( fixture.elem_count() , *this , response );
-    Kokkos::parallel_reduce( solution.extent(0) , *this , &response[0] );
+    Kokkos::View<scalar_type*, Kokkos::HostSpace> resp_view(&response[0], value_count);
+    Kokkos::parallel_reduce( solution.extent(0) , *this , resp_view );
     return response;
   }
 
@@ -1377,8 +1379,8 @@ public:
   }
 
   KOKKOS_INLINE_FUNCTION
-  void join( volatile value_type response ,
-             volatile const value_type input ) const {
+  void join( value_type response ,
+             const value_type input ) const {
      for (unsigned j=0; j<value_count; ++j)
        response[j] += input[j] ;
   }

--- a/packages/trilinoscouplings/examples/fenl/fenl_functors_pce.hpp
+++ b/packages/trilinoscouplings/examples/fenl/fenl_functors_pce.hpp
@@ -75,7 +75,8 @@ public:
   typedef typename vector_type::value_type scalar_type ;
 
   // Hack to get parallel_reduce to work
-  typedef typename Kokkos::IntrinsicScalarType<vector_type>::type value_type[] ;
+  typedef typename Kokkos::IntrinsicScalarType<vector_type>::type reduce_scalar_type;
+  typedef reduce_scalar_type value_type[] ;
   typedef typename Kokkos::CijkType<vector_type>::type cijk_type ;
 
   typedef Kokkos::Example::HexElement_Data< fixture_type::ElemNode > element_data_type ;
@@ -130,7 +131,8 @@ public:
   {
     scalar_type response(cijk, value_count);
     //Kokkos::parallel_reduce( fixture.elem_count() , *this , response.coeff() );
-    Kokkos::parallel_reduce( solution.extent(0) , *this , response.coeff() );
+    Kokkos::View<reduce_scalar_type*, Kokkos::HostSpace> resp_view(response.coeff(), value_count);
+    Kokkos::parallel_reduce( solution.extent(0) , *this , resp_view );
     return response;
   }
 
@@ -270,8 +272,8 @@ public:
   }
 
   KOKKOS_INLINE_FUNCTION
-  void join( volatile value_type  response ,
-             volatile const value_type input ) const
+  void join( value_type  response ,
+             const value_type input ) const
   {
     for (unsigned i=0; i<value_count; ++i)
       response[i] += input[i] ;
@@ -757,7 +759,7 @@ public:
     , jacobian( arg_jacobian )
     , scalar_solution( "scalar_solution", solution.extent(0) )
     , scalar_residual( "scalar_residual", residual.extent(0) )
-    , scalar_jacobian( "scalar_jacobian", jacobian.graph )
+    , scalar_jacobian( "scalar_jacobian", jacobian.graph, maximum_entry(jacobian.graph) + 1 )
     , scalar_diffusion_coefficient( arg_coeff_function.m_mean,
                                     arg_coeff_function.m_variance,
                                     arg_coeff_function.m_corr_len,

--- a/packages/trilinoscouplings/examples/fenl/fenl_impl.hpp
+++ b/packages/trilinoscouplings/examples/fenl/fenl_impl.hpp
@@ -253,7 +253,7 @@ public:
     , g_nodal_residual( RowMap, 1 )
     , g_nodal_delta(    RowMap, 1 )
     , g_nodal_solution_no_overlap (g_nodal_solution, RowMap)
-    , g_jacobian( RowMap, ColMap, LocalMatrixType( "jacobian" , mesh_to_graph.graph ) )
+    , g_jacobian( RowMap, ColMap, LocalMatrixType( "jacobian" , mesh_to_graph.graph , maximum_entry(mesh_to_graph.graph) + 1 ) )
     , perf()
     , num_sensitivities(num_sens)
     {


### PR DESCRIPTION
FENL hasn't been built since the Tpetra Kokkos Refactor macro was removed from Tpetra but not FENL.  This gets the code running again with updates to Kokkos.