### PR TITLE
ML: sprintf -> snprintf

### DIFF
--- a/packages/ml/src/Utils/ml_MultiLevelPreconditioner.cpp
+++ b/packages/ml/src/Utils/ml_MultiLevelPreconditioner.cpp
@@ -3730,7 +3730,7 @@ int ML_Epetra::MultiLevelPreconditioner::SetSmoothingDamping()
   int PSmSweeps = List_.get("aggregation: smoothing sweeps", 1);
   char aggListName[80];
   for (int i=0; i<MaxLevels_; i++) {
-    sprintf(aggListName,"aggregation: list (level %d)",LevelID_[i]);
+    snprintf(aggListName, sizeof(aggListName), "aggregation: list (level %d)",LevelID_[i]);
     ParameterList &aggList = List_.sublist(aggListName);
     int MyPSmSweeps = aggList.get("aggregation: smoothing sweeps",PSmSweeps);
     ML_Aggregate_Set_DampingSweeps(agg_,MyPSmSweeps,LevelID_[i]);


### PR DESCRIPTION
@trilinos/ml 

This was issuing a warning in one of my builds

See https://github.com/trilinos/Trilinos/issues/11881 for discussion of why `snprintf` may be preferable to`sprintf` in this context.