### PR TITLE
NOX: fix exit status of 1DfemStratimikos test

### DIFF
--- a/packages/nox/test/epetra/1Dfem/1DfemStratimikos.C
+++ b/packages/nox/test/epetra/1Dfem/1DfemStratimikos.C
@@ -332,6 +332,8 @@ int main(int argc, char *argv[])
     if (const_cast<Teuchos::ParameterList&>(solver->getList()).sublist("Output").get("Nonlinear Iterations", 0) != 10)
       status = 3;
 
+    success = status==0;
+
     // Summarize test results
     if (status == 0)
       printing.out() << "Test passed!" << std::endl;


### PR DESCRIPTION

`success` is initialized to `false` and only changed if `TEUCHOS_STANDARD_CATCH_STATEMENTS()` catches.  `success` should be set based on the solver status.  The other versions of the 1DfemStratimikos tests already do this.

@trilinos/nox

Discovered while investigating MPI exit hangs discussed in https://github.com/trilinos/Trilinos/issues/11530

Related to https://github.com/trilinos/Trilinos/issues/11530
