### PR TITLE
TrilinosCouplings:  Remove usage of TriKota from FENL

### DIFF
--- a/packages/trilinoscouplings/cmake/Dependencies.cmake
+++ b/packages/trilinoscouplings/cmake/Dependencies.cmake
@@ -1,7 +1,7 @@
 SET(LIB_REQUIRED_DEP_PACKAGES)
 SET(LIB_OPTIONAL_DEP_PACKAGES Amesos AztecOO Belos EpetraExt Ifpack Isorropia ML MueLu NOX Stokhos Zoltan)
 SET(TEST_REQUIRED_DEP_PACKAGES)
-SET(TEST_OPTIONAL_DEP_PACKAGES Amesos AvatarT AztecOO Epetra EpetraExt Ifpack Ifpack2 Intrepid Intrepid2 Isorropia Kokkos KokkosKernels ML MueLu MueLu Pamgen SEACASExodus SEACASNemesis Sacado STKIO STKMesh Stokhos Stratimikos Teko TeuchosKokkosComm TeuchosKokkosCompat Tpetra TriKota Zoltan)
+SET(TEST_OPTIONAL_DEP_PACKAGES Amesos AvatarT AztecOO Epetra EpetraExt Ifpack Ifpack2 Intrepid Intrepid2 Isorropia Kokkos KokkosKernels ML MueLu MueLu Pamgen SEACASExodus SEACASNemesis Sacado STKIO STKMesh Stokhos Stratimikos Teko TeuchosKokkosComm TeuchosKokkosCompat Tpetra Zoltan)
 SET(LIB_REQUIRED_DEP_TPLS)
 SET(LIB_OPTIONAL_DEP_TPLS)
 SET(TEST_REQUIRED_DEP_TPLS)

--- a/packages/trilinoscouplings/examples/fenl/fenl_utils.cpp
+++ b/packages/trilinoscouplings/examples/fenl/fenl_utils.cpp
@@ -40,11 +40,10 @@ clp_return_type parse_cmdline( int argc , char ** argv, CMD & cmdline,
     GROUPING_TASMANIAN_SURROGATE };
   const char *grouping_names[] = { "natural", "max-anisotropy", "mortan-z", "tasmanian-surrogate" };
 
-  const int num_sampling_types = 5;
+  const int num_sampling_types = 4;
   const SamplingType sampling_values[] = {
-    SAMPLING_STOKHOS, SAMPLING_DAKOTA, SAMPLING_TASMANIAN, SAMPLING_FILE,
-    SAMPLING_VPS };
-  const char *sampling_names[] = { "stokhos", "dakota", "tasmanian", "file", "vps" };
+    SAMPLING_STOKHOS, SAMPLING_TASMANIAN, SAMPLING_FILE, SAMPLING_VPS };
+  const char *sampling_names[] = { "stokhos", "tasmanian", "file", "vps" };
 
   clp.setOption("serial", "no-serial",     &cmdline.USE_SERIAL, "use the serial device");
   clp.setOption("threads",                 &cmdline.USE_THREADS, "number of pthreads threads");


### PR DESCRIPTION
I could have replaced this with the Dakota TPL, but that would still need to be maintained, and it is unclear if this code even still works, so I decided to just remove it completely.

@ccober6