### PR TITLE
Eliminate nvidia warnings

### DIFF
--- a/packages/seacas/libraries/ioss/src/Ioss_SmartAssert.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_SmartAssert.C
@@ -1,4 +1,4 @@
-// Copyright(C) 1999-2020 National Technology & Engineering Solutions
+// Copyright(C) 1999-2020, 2023 National Technology & Engineering Solutions
 // of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
 // NTESS, the U.S. Government retains certain rights in this software.
 //
@@ -30,12 +30,6 @@ namespace {
   // information about the stream we write to, in case
   // we're using the default logger
   stream_holder default_logger_info;
-
-  // initializes the SMART_ASSERT library
-  struct assert_initializer
-  {
-    assert_initializer() { Ioss::Private::init_assert(); }
-  } init;
 } // anonymous namespace
 
 namespace Ioss {

--- a/packages/seacas/libraries/ioss/src/main/cgns_decomp.C
+++ b/packages/seacas/libraries/ioss/src/main/cgns_decomp.C
@@ -223,7 +223,7 @@ namespace {
 } // namespace
 namespace {
   std::string codename;
-  std::string version = "0.97";
+  //  std::string version = "0.97";
 
   void cleanup(std::vector<Iocgns::StructuredZoneData *> &zones)
   {

--- a/packages/seacas/libraries/ioss/src/main/sphgen.C
+++ b/packages/seacas/libraries/ioss/src/main/sphgen.C
@@ -1,4 +1,4 @@
-// Copyright(C) 1999-2022 National Technology & Engineering Solutions
+// Copyright(C) 1999-2023 National Technology & Engineering Solutions
 // of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
 // NTESS, the U.S. Government retains certain rights in this software.
 //
@@ -34,9 +34,6 @@
 // ========================================================================
 
 namespace {
-  // Data space shared by most field input/output routines...
-  std::vector<char> data;
-
   struct Globals
   {
     std::string working_directory{};

--- a/packages/seacas/libraries/ioss/src/utest/Utst_map.C
+++ b/packages/seacas/libraries/ioss/src/utest/Utst_map.C
@@ -1,4 +1,4 @@
-// Copyright(C) 1999-2022 National Technology & Engineering Solutions
+// Copyright(C) 1999-2023 National Technology & Engineering Solutions
 // of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
 // NTESS, the U.S. Government retains certain rights in this software.
 //
@@ -7,6 +7,7 @@
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #define DOCTEST_CONFIG_NO_SHORT_MACRO_NAMES
 #define DOCTEST_CONFIG_SUPER_FAST_ASSERTS
+#define DOCTEST_CONFIG_NO_MULTITHREADING
 #include <doctest.h>
 
 #include <Ioss_CodeTypes.h>

--- a/packages/seacas/libraries/ioss/src/utest/Utst_structured_decomp.C
+++ b/packages/seacas/libraries/ioss/src/utest/Utst_structured_decomp.C
@@ -1,4 +1,4 @@
-// Copyright(C) 1999-2022 National Technology & Engineering Solutions
+// Copyright(C) 1999-2023 National Technology & Engineering Solutions
 // of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
 // NTESS, the U.S. Government retains certain rights in this software.
 //
@@ -7,6 +7,7 @@
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #define DOCTEST_CONFIG_NO_SHORT_MACRO_NAMES
 #define DOCTEST_CONFIG_SUPER_FAST_ASSERTS
+#define DOCTEST_CONFIG_NO_MULTITHREADING
 #include <doctest.h>
 
 #include <Ioss_ZoneConnectivity.h>

--- a/packages/seacas/libraries/ioss/src/utest/Utst_structured_decomp_rocket.C
+++ b/packages/seacas/libraries/ioss/src/utest/Utst_structured_decomp_rocket.C
@@ -5,6 +5,9 @@
 // See packages/seacas/LICENSE for details
 
 #include "Utst_structured_decomp.h"
+#define DOCTEST_CONFIG_NO_SHORT_MACRO_NAMES
+#define DOCTEST_CONFIG_SUPER_FAST_ASSERTS
+#define DOCTEST_CONFIG_NO_MULTITHREADING
 #include <doctest.h>
 
 // Disable these tests on NVCC. It tries to optimize and takes forever to build...

--- a/packages/seacas/libraries/ioss/src/utest/Utst_utils.C
+++ b/packages/seacas/libraries/ioss/src/utest/Utst_utils.C
@@ -1,4 +1,4 @@
-// Copyright(C) 1999-2022 National Technology & Engineering Solutions
+// Copyright(C) 1999-2023 National Technology & Engineering Solutions
 // of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
 // NTESS, the U.S. Government retains certain rights in this software.
 //
@@ -7,6 +7,7 @@
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #define DOCTEST_CONFIG_NO_SHORT_MACRO_NAMES
 #define DOCTEST_CONFIG_SUPER_FAST_ASSERTS
+#define DOCTEST_CONFIG_NO_MULTITHREADING
 #include <doctest.h>
 
 #include <Ioss_CodeTypes.h>


### PR DESCRIPTION
This should get rid of the warnings showing up during the nvidia builds.

@trilinos/seacas 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->