### PR TITLE
Ifpack2: Speed up DatabaseSchwarz::Compute

### DIFF
--- a/packages/ifpack2/src/Ifpack2_DatabaseSchwarz_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_DatabaseSchwarz_def.hpp
@@ -527,6 +527,9 @@ void DatabaseSchwarz<MatrixType>::compute()
               DenseMatRCP database_candidate = DatabaseMatrices_[idatabase];
               abserror += Teuchos::ScalarTraits<typename row_matrix_type::scalar_type>::magnitude((*patch_matrix)(irow,icol)-(*database_candidate)(irow,icol));
             }
+            // break out early if we finish a row and the error is already too high
+            if(abserror > Teuchos::as<typename Teuchos::ScalarTraits<typename row_matrix_type::scalar_type>::magnitudeType>(PatchTolerance_))
+              break;
           }
 
           // check if this error is acceptable; if so, mark the match and break


### PR DESCRIPTION
@trilinos/ifpack2 @cgcgcg

This speeds up the `Compute()` phase of `DatabaseSchwarz` by at least 8%-10% based on 1M DOF runs I was testing on Attaway thanks to a comment made by @rstumin earlier today.

This breaks out of the compression check loop if the accumulated difference already exceeds the tolerance, which helps immensely, especially as the patch size increases. There should be almost no performance hit because even the most basic branch prediction will handle this in an efficient manner.