### PR TITLE
 Xpetra: Don't use std::binary_function 

### DIFF
--- a/packages/tpetra/core/src/Tpetra_ConfigDefs.hpp
+++ b/packages/tpetra/core/src/Tpetra_ConfigDefs.hpp
@@ -150,7 +150,7 @@ namespace Tpetra {
   /// this and other reasons not to state <tt>using namespace
   /// std;</tt> in the global namespace.
   template<class Arg1, class Arg2>
-  class project1st : public std::binary_function<Arg1, Arg2, Arg1> {
+  class project1st {
   public:
     typedef Arg1 first_argument_type;
     typedef Arg2 second_argument_type;
@@ -176,7 +176,7 @@ namespace Tpetra {
   /// this and other reasons not to state <tt>using namespace
   /// std;</tt> in the global namespace.
   template<class Arg1, class Arg2>
-  class project2nd : public std::binary_function<Arg1, Arg2, Arg2> {
+  class project2nd {
   public:
     typedef Arg1 first_argument_type;
     typedef Arg2 second_argument_type;

--- a/packages/xpetra/src/Headers/Xpetra_ConfigDefs.hpp
+++ b/packages/xpetra/src/Headers/Xpetra_ConfigDefs.hpp
@@ -242,7 +242,7 @@ namespace Xpetra {
   // Xpetra functor objects
   // inspired by SGI-specific project2nd, project1st
   template <class Arg1, class Arg2>
-  class firstArg : std::binary_function<Arg1,Arg2,Arg1> {
+  class firstArg {
   public:
     typedef Arg1 first_argument_type;
     typedef Arg2 second_argument_type;
@@ -251,7 +251,7 @@ namespace Xpetra {
   };
 
   template <class Arg1, class Arg2>
-  class secondArg : std::binary_function<Arg1,Arg2,Arg2> {
+  class secondArg {
   public:
     typedef Arg1 first_argument_type;
     typedef Arg2 second_argument_type;


### PR DESCRIPTION
@trilinos/xpetra

## Motivation
`std::binary_function` (https://en.cppreference.com/w/cpp/utility/functional/binary_function) has been deprecated since C++11 and removed in C++17. Recent compilers like `clang 16` don't include this class anymore in their STL implementation.
std::binary_function only provides aliases for `first_argument_type`, `second_argument_type`, and `result_type` which the classes in question already provide anyway.

## Related Issues

* Related to #11920

## Testing
Compiling Trilinos with Tpetra and clang-16.