### PR TITLE
FEI: temporarily disable failing unit tests

### DIFF
--- a/packages/fei/unit_tests_base/CMakeLists.txt
+++ b/packages/fei/unit_tests_base/CMakeLists.txt
@@ -10,42 +10,47 @@ TRIBITS_CONFIGURE_FILE(${PACKAGE_NAME}_config.h)
 
 SET(SOURCES "")
 
-FILE(GLOB SOURCES *.cpp)
+FILE(GLOB SOURCES_ALL *.cpp)
 
-TRIBITS_ADD_EXECUTABLE_AND_TEST(
-    fei_ubase
-    SOURCES ${SOURCES}
-    ARGS "--teuchos-suppress-startup-banner"
-    COMM serial mpi
-    NUM_MPI_PROCS 1
-    TESTONLYLIBS fei_test_utils
-   STANDARD_PASS_OUTPUT
-  )
+# Temporarily disable tests. non-zero return codes on mpi processes
+# other than rank 0 are causing trouble with test harness. See #11530
+# One of the broken tests is fei_UBase_set_shared_ids.cpp.  There
+# could be others as well.
 
-TRIBITS_ADD_TEST(
-    fei_ubase
-    NAME fei_ubase
-    ARGS "--teuchos-suppress-startup-banner"
-    COMM serial mpi
-    NUM_MPI_PROCS 2
-   STANDARD_PASS_OUTPUT
-  )
+#TRIBITS_ADD_EXECUTABLE_AND_TEST(
+#    fei_ubase
+#    SOURCES ${SOURCES}
+#    ARGS "--teuchos-suppress-startup-banner"
+#    COMM serial mpi
+#    NUM_MPI_PROCS 1
+#    TESTONLYLIBS fei_test_utils
+#   STANDARD_PASS_OUTPUT
+#  )
 
-TRIBITS_ADD_TEST(
-    fei_ubase
-    NAME fei_ubase
-    ARGS "--teuchos-suppress-startup-banner"
-    COMM serial mpi
-    NUM_MPI_PROCS 3
-   STANDARD_PASS_OUTPUT
-  )
+#TRIBITS_ADD_TEST(
+#    fei_ubase
+#    NAME fei_ubase
+#    ARGS "--teuchos-suppress-startup-banner"
+#    COMM serial mpi
+#    NUM_MPI_PROCS 2
+#   STANDARD_PASS_OUTPUT
+#  )
 
-TRIBITS_ADD_TEST(
-    fei_ubase
-    NAME fei_ubase
-    ARGS "--teuchos-suppress-startup-banner"
-    COMM serial mpi
-    NUM_MPI_PROCS 4
-   STANDARD_PASS_OUTPUT
-  )
+#TRIBITS_ADD_TEST(
+#    fei_ubase
+#    NAME fei_ubase
+#    ARGS "--teuchos-suppress-startup-banner"
+#    COMM serial mpi
+#    NUM_MPI_PROCS 3
+#   STANDARD_PASS_OUTPUT
+#  )
+
+#TRIBITS_ADD_TEST(
+#    fei_ubase
+#    NAME fei_ubase
+#    ARGS "--teuchos-suppress-startup-banner"
+#    COMM serial mpi
+#    NUM_MPI_PROCS 4
+#   STANDARD_PASS_OUTPUT
+#  )
 

--- a/packages/fei/unit_tests_base/fei_ubase.cpp
+++ b/packages/fei/unit_tests_base/fei_ubase.cpp
@@ -47,5 +47,6 @@ specific unit test suites.
 int main( int argc, char* argv[] )
 {
   Teuchos::GlobalMPISession mpiSession(&argc, &argv);
+  Teuchos::UnitTestRepository::setGloballyReduceTestResult(true);
   return Teuchos::UnitTestRepository::runUnitTestsFromMain(argc, argv);
 }


### PR DESCRIPTION
## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
temporary disable of unit test causing an issue in #11530 

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->