### PR TITLE
STK: Field redeclaration with increased number of states, increases the number of states.

### DIFF
--- a/packages/stk/stk_mesh/stk_mesh/baseImpl/FieldRepository.cpp
+++ b/packages/stk/stk_mesh/stk_mesh/baseImpl/FieldRepository.cpp
@@ -42,6 +42,7 @@
 #include "stk_mesh/base/MetaData.hpp"
 #include "stk_mesh/base/FieldState.hpp"  // for ::MaximumFieldStates, etc
 #include "stk_util/util/ReportHandler.hpp"  // for ThrowErrorMsgIf
+#include <iostream>
 
 namespace stk { namespace mesh { class Part; } }
 
@@ -71,7 +72,7 @@ std::string print_field_type(const DataTraits                  & arg_traits ,
 
 // Check for compatibility:
 // 1) Scalar type must match
-// 2) Number of states must match
+// 2) Number of states must be nonzero
 // 3) Dimension must be different by at most one rank,
 //    where the tags match for the smaller rank.
 void
@@ -81,10 +82,9 @@ FieldRepository::verify_field_type(const FieldBase                   & arg_field
                                    const shards::ArrayDimTag * const * arg_dim_tags,
                                    unsigned                            arg_num_states) const
 {
-
   const bool ok_traits = arg_traits.is_void || &arg_traits == &arg_field.data_traits();
 
-  const bool ok_number_states = not arg_num_states || arg_num_states == arg_field.number_of_states();
+  const bool ok_number_states = arg_num_states != 0;
 
   if (m_meta.is_using_simple_fields()) {
     const bool has_extra_template_parameters = (arg_field.m_field_rank > 0);
@@ -96,7 +96,7 @@ FieldRepository::verify_field_type(const FieldBase                   & arg_field
                     "\" , #states = " << arg_field.number_of_states() << " ]" <<
                     " Expected field info = " <<
                     print_field_type(arg_traits, arg_rank, arg_dim_tags) <<
-                    "[ #states = " << arg_num_states << " ]");
+                    "[ #states > 0 ]");
   }
   else {
     bool ok_dimension = ! arg_rank || arg_rank     == arg_field.field_array_rank() ||
@@ -116,7 +116,7 @@ FieldRepository::verify_field_type(const FieldBase                   & arg_field
                     "\" , #states = " << arg_field.number_of_states() << " ]" <<
                     " Expected field info = " <<
                     print_field_type(arg_traits, arg_rank, arg_dim_tags) <<
-                    "[ #states = " << arg_num_states << " ]");
+                    "[ #states > 0 ]");
   }
 }
 

--- a/packages/stk/stk_mesh/stk_mesh/baseImpl/FieldRepository.cpp
+++ b/packages/stk/stk_mesh/stk_mesh/baseImpl/FieldRepository.cpp
@@ -42,7 +42,6 @@
 #include "stk_mesh/base/MetaData.hpp"
 #include "stk_mesh/base/FieldState.hpp"  // for ::MaximumFieldStates, etc
 #include "stk_util/util/ReportHandler.hpp"  // for ThrowErrorMsgIf
-#include <iostream>
 
 namespace stk { namespace mesh { class Part; } }
 

--- a/packages/stk/stk_unit_tests/stk_mesh/UnitTestField.cpp
+++ b/packages/stk/stk_unit_tests/stk_mesh/UnitTestField.cpp
@@ -80,6 +80,28 @@ namespace {
 const stk::topology::rank_t NODE_RANK = stk::topology::NODE_RANK;
 using stk::unit_test_util::build_mesh;
 
+TEST(UnitTestField, testFieldStates)
+{
+  stk::ParallelMachine pm = MPI_COMM_SELF;
+
+  typedef stk::mesh::Field<double> rank_one_field;
+  const std::string name1("test_field_1");
+  const std::string name2("test_field_2");
+  const int spatial_dimension = 3;
+  std::shared_ptr<stk::mesh::BulkData> bulkPtr = build_mesh(spatial_dimension, pm);
+  stk::mesh::MetaData& meta_data = bulkPtr->mesh_meta_data();
+
+  // Redeclaration with fewer number of states.
+  rank_one_field* field1_v1 = &meta_data.declare_field<double>(stk::topology::ELEMENT_RANK, name1, 2);
+  rank_one_field* field1_v2 = &meta_data.declare_field<double>(stk::topology::ELEMENT_RANK, name1, 1);
+  EXPECT_EQ(field1_v1, field1_v2);
+
+  // Redeclaration with greater number of states.
+  rank_one_field* field2_v1 = &meta_data.declare_field<double>(stk::topology::ELEMENT_RANK, name2, 1);
+  rank_one_field* field2_v2 = &meta_data.declare_field<double>(stk::topology::ELEMENT_RANK, name2, 2);
+  EXPECT_EQ(field2_v1, field2_v2);
+}
+
 TEST(UnitTestField, testFieldMaxSize)
 {
   stk::ParallelMachine pm = MPI_COMM_SELF ;


### PR DESCRIPTION
@trilinos/stk
@alanw0 

## Motivation
Hi Alan,

STK currently forbids the redeclaration of a field with a different number of states. The attached modifications, on the other hand, alter STK such that the redeclaration of a field with a larger number of states increases the number of states. Similarly, the redeclaration of a field with fewer states leaves the current number of states intact. The motivation for this change can be seen from a simple example:

Consider the same paradigm as Nalu-wind, where different algorithms declare their required fields to isolate an algorithm's requirements with that algorithm. If, for example, one algorithm requires a "node_coordinates" field with two states (as is often needed for second-order time-stepping schemes), then every other algorithm that attempts to declare the "node_coordinates" field with one state will need to be modified, lest STK throw an error. If field states are to be treated as "the memory of the field," which consists of the last N values of said field, then increasing the number of states will have no impact on algorithms that require fewer states.

I will note that this change is incompatible with the view of states as being cyclic since increasing the number of states would cause algorithms that assume a certain cycle width to break. I leave it up to you to decide if field states rotating cyclically after calling update_field_data_states was a feature or merely an implementation detail about how shifting the states was performed. Otherwise, the attached modifications should have no impact on existing code.

## Testing
I added a test for this feature to UnitTestField.cpp, but I'll copy it here:
```
TEST(UnitTestField, testFieldStates)
{
  stk::ParallelMachine pm = MPI_COMM_SELF;

  typedef stk::mesh::Field<double> rank_one_field;
  const std::string name1("test_field_1");
  const std::string name2("test_field_2");
  const int spatial_dimension = 3;
  std::shared_ptr<stk::mesh::BulkData> bulkPtr = build_mesh(spatial_dimension, pm);
  stk::mesh::MetaData& meta_data = bulkPtr->mesh_meta_data();

  // Redeclaration with fewer number of states.
  rank_one_field* field1_v1 = &meta_data.declare_field<double>(stk::topology::ELEMENT_RANK, name1, 2);
  rank_one_field* field1_v2 = &meta_data.declare_field<double>(stk::topology::ELEMENT_RANK, name1, 1);
  EXPECT_EQ(field1_v1, field1_v2);

  // Redeclaration with greater number of states.
  rank_one_field* field2_v1 = &meta_data.declare_field<double>(stk::topology::ELEMENT_RANK, name2, 1);
  rank_one_field* field2_v2 = &meta_data.declare_field<double>(stk::topology::ELEMENT_RANK, name2, 2);
  EXPECT_EQ(field2_v1, field2_v2);
}
```