### PR TITLE
TrilinosSS: include <omp.h> (Fix #11867)

### DIFF
--- a/packages/common/auxiliarySoftware/SuiteSparse/src/KLU/Include/trilinos_klu_internal.h
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/KLU/Include/trilinos_klu_internal.h
@@ -37,6 +37,10 @@
 #include <stdlib.h>
 #include <math.h>
 
+#ifdef TRILINOSSS_HAVE_OMP
+#include <omp.h>
+#endif
+
 #undef ASSERT
 #ifndef NDEBUG
 #define ASSERT(a) assert(a)


### PR DESCRIPTION
When using OpenMP directly in the KLU wrapper, include omp.h. Previously, this relied on omp.h being included somewhere else (like through Kokkos) but this doesn't always work.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/amesos2

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Fixes build errors. KLU wrapper made OpenMP calls without having included omp.h.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:
-->

## Related Issues

* Closes #11867
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
See thread on #11867 
## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
Not a code behavior change
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->