### PR TITLE
Stokhos:  allow explicit conversions of ensembles to integral types

### DIFF
--- a/packages/stokhos/src/sacado/kokkos/vector/Sacado_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/Sacado_MP_Vector.hpp
@@ -291,6 +291,7 @@ namespace Sacado {
       // Allow explicit casting to integral types, since we don't have an
       // integral ensemble type.
       template <typename T, typename Enabled = typename std::enable_if<std::is_integral<T>::value>::type>
+      KOKKOS_INLINE_FUNCTION
       explicit operator T() const { return static_cast<T>(val()); }
 
       //! Initialize coefficients to value

--- a/packages/stokhos/src/sacado/kokkos/vector/Sacado_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/Sacado_MP_Vector.hpp
@@ -288,6 +288,11 @@ namespace Sacado {
       KOKKOS_DEFAULTED_FUNCTION
       ~Vector() = default;
 
+      // Allow explicit casting to integral types, since we don't have an
+      // integral ensemble type.
+      template <typename T, typename Enabled = typename std::enable_if<std::is_integral<T>::value>::type>
+      explicit operator T() const { return static_cast<T>(val()); }
+
       //! Initialize coefficients to value
       KOKKOS_INLINE_FUNCTION
       void init(const value_type& v) { s.init(v); }

--- a/packages/stokhos/src/sacado/kokkos/vector/Sacado_MP_Vector_SFS.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/Sacado_MP_Vector_SFS.hpp
@@ -175,6 +175,11 @@ namespace Sacado {
       KOKKOS_INLINE_FUNCTION
       ~Vector() {}
 
+      // Allow explicit casting to integral types, since we don't have an
+      // integral ensemble type.
+      template <typename T, typename Enabled = typename std::enable_if<std::is_integral<T>::value>::type>
+      explicit operator T() const { return static_cast<T>(val()); }
+
       //! Initialize coefficients to value
       KOKKOS_INLINE_FUNCTION
       void init(const value_type& v) { s.init(v); }

--- a/packages/stokhos/src/sacado/kokkos/vector/Sacado_MP_Vector_SFS.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/Sacado_MP_Vector_SFS.hpp
@@ -178,6 +178,7 @@ namespace Sacado {
       // Allow explicit casting to integral types, since we don't have an
       // integral ensemble type.
       template <typename T, typename Enabled = typename std::enable_if<std::is_integral<T>::value>::type>
+      KOKKOS_INLINE_FUNCTION
       explicit operator T() const { return static_cast<T>(val()); }
 
       //! Initialize coefficients to value


### PR DESCRIPTION
Allows, e.g., static_cast<int>(x) where x is an ensemble, since this is something Kokkos-Kernels does.  Elsewhere in Trilinos we have relied on Teuchos::as<>, but Kokkos-Kernels can't rely on that.

@jhux2 