### PR TITLE
Improve simpleBuildAgainstTrilinos/README.md

### DIFF
--- a/demos/simpleBuildAgainstTrilinos/README.md
+++ b/demos/simpleBuildAgainstTrilinos/README.md
@@ -17,6 +17,8 @@ To run this example, do the following steps.
     -D CMAKE_INSTALL_PREFIX=<tril-install-prefix> \
     -D TPL_ENABLE_MPI=ON \
     -D Trilinos_ENABLE_Tpetra=ON \
+    -D CMAKE_C_COMPILER=<c-compiler> \
+    -D CMAKE_CXX_COMPILER=<cxx-compiler> \    
     [other options] \
     <trilinos-src>
 ```
@@ -42,8 +44,15 @@ This will put a file called `TrilinosConfig.cmake` under a subdirectory of
   $ cd <app-build-dir>/
   $ cmake \
     -D CMAKE_PREFIX_PATH=<tril-install-prefix> \
+    -D CMAKE_C_COMPILER=<c-compiler> \
+    -D CMAKE_CXX_COMPILER=<cxx-compiler> \    
     <trilinos-src>/demos/simpleBuildAgainstTrilinos
 ```
+
+NOTE: To configure `simpleBuildAgainstTrilinos` against the installed Trilinos
+one must pass in compatible compilers used to build Trilinos. For CUDA builds,
+this means using `nvcc_wrapper` (e.g. using OpenMPI with `-D CMAKE_CXX_COMPILER=mpicxx`
+and setting environment variable `export OMPI_CXX=<base-path>/nvcc_wrapper`.)
 
 NOTE: To use the alternative `CMakeLists.txt` file that calls
 `find_package(Tpetra)` and links to `Tpetra::all_libs` instead of


### PR DESCRIPTION
@ndellingwood

Fixes #11955

Added explicit mention of needing to pass in compatible compilers to CMake.  This example can't get compilers from `find_package(Trilinos)` for CUDA builds (see https://github.com/trilinos/Trilinos/issues/11955#issuecomment-1584933666).
