### PR TITLE
Trilframe 378 complex float

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1824,8 +1824,7 @@ use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
 use COMMON
 
 opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                            STRING       : --bind-to;none
-opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                         BOOL FORCE   : ON
-opt-set-cmake-var Trilinos_ENABLE_FLOAT                                  BOOL FORCE   : ON
+opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                         BOOL         : ON
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D          BOOL         : ON
 opt-set-cmake-var KokkosKernels_blas_serial_MPI_1_DISABLE                BOOL         : ON
 opt-set-cmake-var ROL_example_PDE-OPT_helmholtz_example_02_MPI_1_DISABLE BOOL         : ON

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1824,7 +1824,8 @@ use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
 use COMMON
 
 opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                            STRING       : --bind-to;none
-opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                         BOOL         : ON
+opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                         BOOL FORCE   : ON
+opt-set-cmake-var Trilinos_ENABLE_FLOAT                                  BOOL FORCE   : ON
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D          BOOL         : ON
 opt-set-cmake-var KokkosKernels_blas_serial_MPI_1_DISABLE                BOOL         : ON
 opt-set-cmake-var ROL_example_PDE-OPT_helmholtz_example_02_MPI_1_DISABLE BOOL         : ON

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1853,6 +1853,14 @@ use rhel7_sems-gnu-8.3.0-openmpi-1.10.1-serial_debug_shared_no-kokkos-arch_no-as
 use BUILD-TYPE|DEBUG-COVERAGE-GNU
 use PACKAGE-ENABLES|ALL
 
+[rhel7_sems-gnu-8.3.0-openmpi-1.10.1-serial_debug_shared_no-kokkos-arch_no-asan_complex-float_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
+#uses sems-archive modules
+use rhel7_sems-gnu-8.3.0-openmpi-1.10.1-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
+opt-set-cmake-var Trilinos_ENABLE_DOUBLE                                 BOOL FORCE   : OFF
+opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                         BOOL FORCE   : OFF
+opt-set-cmake-var Trilinos_ENABLE_FLOAT                                  BOOL FORCE   : ON
+opt-set-cmake-var Trilinos_ENABLE_COMPLEX_FLOAT                          BOOL FORCE   : ON
+
 [rhel7_sems-gnu-8.3.0-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
 #uses sems-archive modules
 use RHEL7_SEMS_COMPILER|GNU

--- a/packages/framework/ini-files/supported-config-flags.ini
+++ b/packages/framework/ini-files/supported-config-flags.ini
@@ -209,6 +209,8 @@ use-asan:  SELECT_ONE
 use-complex:  SELECT_ONE
     no-complex
     complex
+    complex-float
+    complex-double
 
 # Whether or not to turn on position independent code.
 use-fpic:  SELECT_ONE


### PR DESCRIPTION
@trilinos/framework 

## Motivation
The ASC Sierra Code requires support for complex<double> and float with the configure arguments:
```
-D Trilinos_ENABLE_COMPLEX_DOUBLE=ON \
-D Trilinos_ENABLE_FLOAT=ON \
```
Yet there appear to be no PR or `master` promotion builds that enable either of these.

For details, see:

- https://github.com/trilinos/Trilinos/issues/10742