### PR TITLE
Tpetra: mark `BlockMultiVector::checkSizes` as `override`

### DIFF
--- a/packages/tpetra/core/src/Tpetra_BlockMultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockMultiVector_decl.hpp
@@ -548,9 +548,9 @@ protected:
   /// Users don't have to worry about these methods.
   //@{
 
-  virtual bool checkSizes (const Tpetra::SrcDistObject& source);
-
   // clang-format on
+  virtual bool checkSizes(const Tpetra::SrcDistObject &source) override;
+
   using dist_object_type::
       copyAndPermute; ///< DistObject copyAndPermute has multiple overloads --
                       ///< use copyAndPermutes for anything we don't override


### PR DESCRIPTION
Fix for

```
.../Trilinos/packages/tpetra/core/src/Tpetra_BlockMultiVector_decl.hpp:551:16: warning: 'checkSizes' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  virtual bool checkSizes (const Tpetra::SrcDistObject& source);
```