### PR TITLE
Tpetra: mark `BlockMultiVector::{packAndPrepare, unpackAndCombine}` as override

### DIFF
--- a/packages/tpetra/core/src/Tpetra_BlockMultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockMultiVector_decl.hpp
@@ -566,7 +566,6 @@ protected:
      buffer_device_type>& permuteFromLIDs,
    const CombineMode CM) override;
 
-  // clang-format on
   using dist_object_type::packAndPrepare; ///< DistObject overloads
                                           ///< packAndPrepare. Explicitly use
                                           ///< DistObject's packAndPrepare for
@@ -582,9 +581,8 @@ protected:
      buffer_device_type>& exports,
    Kokkos::DualView<size_t*,
      buffer_device_type> numPacketsPerLID,
-   size_t& constantNumPackets);
+   size_t& constantNumPackets) override;
 
-  // clang-format on
   using dist_object_type::unpackAndCombine; ///< DistObject has overloaded
                                             ///< unpackAndCombine, use the
                                             ///< DistObject's implementation for
@@ -600,7 +598,8 @@ protected:
    Kokkos::DualView<size_t*,
      buffer_device_type> numPacketsPerLID,
    const size_t constantNumPackets,
-   const CombineMode combineMode);
+   const CombineMode combineMode) override;
+   // clang-format off
 
   //@}
 


### PR DESCRIPTION
Silences warnings like:

```
In file included from .../packages/tpetra/core/src/Tpetra_RowMatrixTransposer_LONG_LONG_INT_LONG_LONG_SERIAL.cpp:67:
In file included from ...packages/tpetra/core/src/Tpetra_RowMatrixTransposer_def.hpp:46:
In file included from .../build/packages/tpetra/core/src/Tpetra_BlockCrsMatrix.hpp:1:
In file included from .../packages/tpetra/core/src/Tpetra_BlockCrsMatrix_decl.hpp:49:
.../packages/tpetra/core/src/Tpetra_BlockMultiVector_decl.hpp:577:3: warning: 'packAndPrepare' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  packAndPrepare
```