### PR TITLE
KokkosKernels: Patch to fix 11926

### DIFF
--- a/packages/kokkos-kernels/sparse/src/KokkosSparse_spmv.hpp
+++ b/packages/kokkos-kernels/sparse/src/KokkosSparse_spmv.hpp
@@ -161,6 +161,12 @@ void spmv(KokkosKernels::Experimental::Controls controls, const char mode[],
     useFallback = useFallback || (mode[0] == Conjugate[0]);
 #endif
   }
+  // cuSPARSE 12 requires that the output (y) vector is 16-byte aligned for all
+  // scalar types
+#if defined(CUSPARSE_VER_MAJOR) && (CUSPARSE_VER_MAJOR == 12)
+  uintptr_t yptr = uintptr_t((void*)y.data());
+  if (yptr % 16 != 0) useFallback = true;
+#endif
 #endif
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_ROCSPARSE


### PR DESCRIPTION
(Patch of https://github.com/kokkos/kokkos-kernels/pull/1889)

For cusparse 12 spmv, make sure y vector is aligned to 16 bytes. If not, call the native impl as a fallback.
@maartenarnst This should fix #11926.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/kokkos-kernels 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Fixes ``cudaErrorMisalignedAddress`` errors when calling ``KokkosSparse::spmv`` with an output vector aligned to < 16 bytes (for example, a column subview of a multivector with odd number of rows). See the issue linked above.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
Reported by @maartenarnst first, but everybody uses cusparse spmv and we want to support cusparse 12 correctly

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->