### PR TITLE
Intrepid2: Pass non const value type to mapToPhysicalFrame.

### DIFF
--- a/packages/intrepid2/src/Cell/Intrepid2_CellTools.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellTools.hpp
@@ -316,7 +316,8 @@ public:
                  const Kokkos::DynRankView<pointValueType,pointProperties...>       points,
                  const Kokkos::DynRankView<worksetCellValueType,worksetCellProperties...> worksetCell,
                  const shards::CellTopology cellTopo ) {
-    auto basis = createHGradBasis<pointValueType,pointValueType>(cellTopo);
+    using nonConstPointValueType = std::remove_const_t<pointValueType>;
+    auto basis = createHGradBasis<nonConstPointValueType,nonConstPointValueType>(cellTopo);
     setJacobian(jacobian, 
                 points, 
                 worksetCell, 
@@ -1083,7 +1084,8 @@ public:
                         const Kokkos::DynRankView<refPointValueType,refPointProperties...>       refPoints,
                         const Kokkos::DynRankView<worksetCellValueType,worksetCellProperties...> worksetCell,
                         const shards::CellTopology cellTopo ) {
-      auto basis = createHGradBasis<refPointValueType,refPointValueType>(cellTopo);
+    using nonConstRefPointValueType = std::remove_const_t<refPointValueType>;
+    auto basis = createHGradBasis<nonConstRefPointValueType,nonConstRefPointValueType>(cellTopo);
       mapToPhysicalFrame(physPoints, 
                          refPoints, 
                          worksetCell, 

--- a/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefRefToPhys.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefRefToPhys.hpp
@@ -163,27 +163,6 @@ namespace Intrepid2 {
     };
   }
 
-
-/*
-  template<typename DeviceType>
-  template<typename physPointValueType,   class ...physPointProperties,
-           typename refPointValueType,    class ...refPointProperties,
-           typename worksetCellValueType, class ...worksetCellProperties>
-  void
-  CellTools<DeviceType>::
-  mapToPhysicalFrame(       Kokkos::DynRankView<physPointValueType,physPointProperties...>     physPoints,
-                      const Kokkos::DynRankView<refPointValueType,refPointProperties...>       refPoints,
-                      const Kokkos::DynRankView<worksetCellValueType,worksetCellProperties...> worksetCell,
-                      const shards::CellTopology cellTopo ) {
-
-   auto basis = createHGradBasis<refPointValueType,refPointValueType>(cellTopo);
-   mapToPhysicalFrame(physPoints,
-                      refPoints,
-                      worksetCell,
-                      basis);
-  }
-*/
-
   template<typename DeviceType>
   template<typename physPointValueType,   class ...physPointProperties,
            typename refPointValueType,    class ...refPointProperties,


### PR DESCRIPTION
@trilinos/intrepid2 @mperego

## Motivation

The `Intrepid2` function `mapToPhysicalFrame` allows to map coordinates of points in the reference domain (input) to coordinates in the physical domain (output). We would like to be able to pass in the input coordinates with a const value type. However, this is not currently possible because the value type is passed to a basis factory which expects a non const value type.  

This PR solves this issue by using `std::remove_const_t`.

This change was discussed with @CamelliaDPG at EUTug 2023. 