### PR TITLE
Tpetra/Teuchos: don't use deprecated Kokkos::Impl::ALL_t, View::Rank

### DIFF
--- a/packages/teuchos/kokkoscompat/src/KokkosCompat_View.hpp
+++ b/packages/teuchos/kokkoscompat/src/KokkosCompat_View.hpp
@@ -129,7 +129,7 @@ namespace Kokkos {
     ViewType
     create_view (const std::string& label, size_t size) {
       static_assert(Kokkos::is_view<ViewType>::value==true,"Kokkos::Compat::create_view() called with non-view argument.");
-      static_assert(ViewType::Rank==1,"Kokkos::Compat::create_view() called with non-rank-1 view argument.");
+      static_assert(ViewType::rank==1,"Kokkos::Compat::create_view() called with non-rank-1 view argument.");
       return ViewType (label, size);
     }
 
@@ -211,7 +211,7 @@ namespace Kokkos {
                    const Ordinal end)
     {
       static_assert(Kokkos::is_view<ViewType>::value==true,"Kokkos::Compat::subview_range() called with non-view argument.");
-      static_assert(ViewType::Rank==1,"Kokkos::Compat::subview_range() called with non-rank-1 view argument.");
+      static_assert(ViewType::rank==1,"Kokkos::Compat::subview_range() called with non-rank-1 view argument.");
       return Kokkos::subview (view, std::make_pair (begin, end));
     }
 
@@ -222,7 +222,7 @@ namespace Kokkos {
                     const Ordinal size)
     {
       static_assert(Kokkos::is_view<ViewType>::value==true,"Kokkos::Compat::subview_offset() called with non-view argument.");
-      static_assert(ViewType::Rank==1,"Kokkos::Compat::subview_offset() called with non-rank-1 view argument.");
+      static_assert(ViewType::rank==1,"Kokkos::Compat::subview_offset() called with non-rank-1 view argument.");
       return Kokkos::subview (view, std::make_pair (offset, offset+size));
     }
 
@@ -237,7 +237,7 @@ namespace Kokkos {
     {
       static_assert(Kokkos::is_view<DstViewType>::value==true,"Kokkos::Compat::deep_copy_range() called with non-view argument.");
       static_assert(Kokkos::is_view<SrcViewType>::value==true,"Kokkos::Compat::deep_copy_range() called with non-view argument.");
-      static_assert(DstViewType::Rank==1 && SrcViewType::Rank==1,"Kokkos::Compat::deep_copy_range() called with non-rank-1 view argument.");
+      static_assert(DstViewType::rank==1 && SrcViewType::rank==1,"Kokkos::Compat::deep_copy_range() called with non-rank-1 view argument.");
       const Ordinal size = src_end - src_begin;
       const Ordinal dst_end = dst_begin + size;
       DstViewType dst_sub = Kokkos::subview(
@@ -258,7 +258,7 @@ namespace Kokkos {
     {
       static_assert(Kokkos::is_view<DstViewType>::value==true,"Kokkos::Compat::deep_copy_offset() called with non-view argument.");
       static_assert(Kokkos::is_view<SrcViewType>::value==true,"Kokkos::Compat::deep_copy_offset() called with non-view argument.");
-      static_assert(DstViewType::Rank==1 && SrcViewType::Rank==1,"Kokkos::Compat::deep_copy_offset() called with non-rank-1 view argument.");
+      static_assert(DstViewType::rank==1 && SrcViewType::rank==1,"Kokkos::Compat::deep_copy_offset() called with non-rank-1 view argument.");
       const Ordinal dst_end = dst_offset + size;
       const Ordinal src_end = src_offset + size;
       DstViewType dst_sub = Kokkos::subview(

--- a/packages/tpetra/core/src/Tpetra_Details_Blas.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Blas.hpp
@@ -90,7 +90,7 @@ template<class ViewType,
 IndexType
 getStride2DView (const ViewType& A)
 {
-  static_assert (ViewType::Rank == 2, "A must be a rank-2 Kokkos::View.");
+  static_assert (ViewType::rank == 2, "A must be a rank-2 Kokkos::View.");
   static_assert (std::is_same<typename ViewType::array_layout, Kokkos::LayoutLeft>::value ||
                  std::is_same<typename ViewType::array_layout, Kokkos::LayoutRight>::value ||
                  std::is_same<typename ViewType::array_layout, Kokkos::LayoutStride>::value,
@@ -115,7 +115,7 @@ struct GetStride1DView {
 
   static IndexType getStride (const ViewType& x)
   {
-    static_assert (ViewType::Rank == 1, "x must be a rank-1 Kokkos::View.");
+    static_assert (ViewType::rank == 1, "x must be a rank-1 Kokkos::View.");
     static_assert (std::is_same<typename ViewType::array_layout, Kokkos::LayoutLeft>::value ||
                    std::is_same<typename ViewType::array_layout, Kokkos::LayoutRight>::value ||
                    std::is_same<typename ViewType::array_layout, Kokkos::LayoutStride>::value,
@@ -137,7 +137,7 @@ struct GetStride1DView<ViewType, Kokkos::LayoutLeft, IndexType> {
 
   static IndexType getStride (const ViewType&)
   {
-    static_assert (ViewType::Rank == 1, "x must be a rank-1 Kokkos::View.");
+    static_assert (ViewType::rank == 1, "x must be a rank-1 Kokkos::View.");
     static_assert (std::is_same<typename ViewType::array_layout, array_layout>::value,
                    "ViewType::array_layout must be the same as array_layout.");
     static_assert (std::is_integral<IndexType>::value,
@@ -153,7 +153,7 @@ struct GetStride1DView<ViewType, Kokkos::LayoutRight, IndexType> {
 
   static IndexType getStride (const ViewType&)
   {
-    static_assert (ViewType::Rank == 1, "x must be a rank-1 Kokkos::View.");
+    static_assert (ViewType::rank == 1, "x must be a rank-1 Kokkos::View.");
     static_assert (std::is_same<typename ViewType::array_layout, array_layout>::value,
                    "ViewType::array_layout must be the same as array_layout.");
     static_assert (std::is_integral<IndexType>::value,

--- a/packages/tpetra/core/src/Tpetra_Details_WrappedDualView.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_WrappedDualView.hpp
@@ -202,12 +202,12 @@ public:
 
 
   // 2D View Constructors
-  WrappedDualView(const WrappedDualView parent,const Kokkos::pair<size_t,size_t>& rowRng, const Kokkos::Impl::ALL_t& colRng) {
+  WrappedDualView(const WrappedDualView parent,const Kokkos::pair<size_t,size_t>& rowRng, const Kokkos::ALL_t& colRng) {
     originalDualView = parent.originalDualView;
     dualView = getSubview2D(parent.dualView,rowRng,colRng);
   }
 
-  WrappedDualView(const WrappedDualView parent,const Kokkos::Impl::ALL_t &rowRng, const Kokkos::pair<size_t,size_t>& colRng) {
+  WrappedDualView(const WrappedDualView parent,const Kokkos::ALL_t &rowRng, const Kokkos::pair<size_t,size_t>& colRng) {
     originalDualView = parent.originalDualView;
     dualView = getSubview2D(parent.dualView,rowRng,colRng);
   }
@@ -589,12 +589,12 @@ private:
   }
 
   template <typename ViewType,typename int_type>
-  ViewType getSubview2D(ViewType view, Kokkos::pair<int_type,int_type> offset0, const Kokkos::Impl::ALL_t&) const {
+  ViewType getSubview2D(ViewType view, Kokkos::pair<int_type,int_type> offset0, const Kokkos::ALL_t&) const {
     return Kokkos::subview(view,offset0,Kokkos::ALL());
   }
 
   template <typename ViewType,typename int_type>
-  ViewType getSubview2D(ViewType view, const Kokkos::Impl::ALL_t&, Kokkos::pair<int_type,int_type> offset1) const {
+  ViewType getSubview2D(ViewType view, const Kokkos::ALL_t&, Kokkos::pair<int_type,int_type> offset1) const {
     return Kokkos::subview(view,Kokkos::ALL(),offset1);
   }
 

--- a/packages/tpetra/core/src/Tpetra_Details_copyConvert.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_copyConvert.hpp
@@ -130,7 +130,7 @@ namespace { // (anonymous)
   /// \tparam InputViewType Type of the input Kokkos::View.
   template<class OutputViewType,
            class InputViewType,
-           const int rank = static_cast<int> (OutputViewType::Rank)>
+           const int rank = static_cast<int> (OutputViewType::rank)>
   class CopyConvertFunctor {};
 
   template<class OutputViewType,
@@ -138,8 +138,8 @@ namespace { // (anonymous)
   class CopyConvertFunctor<OutputViewType, InputViewType, 1> {
   private:
     static_assert
-    (static_cast<int> (OutputViewType::Rank) == 1 &&
-     static_cast<int> (InputViewType::Rank) == 1,
+    (static_cast<int> (OutputViewType::rank) == 1 &&
+     static_cast<int> (InputViewType::rank) == 1,
      "CopyConvertFunctor (implements Tpetra::Details::copyConvert): "
      "OutputViewType and InputViewType must both have rank 1.");
     OutputViewType dst_;
@@ -168,8 +168,8 @@ namespace { // (anonymous)
 
   private:
     static_assert
-    (static_cast<int> (OutputViewType::Rank) == 2 &&
-     static_cast<int> (InputViewType::Rank) == 2,
+    (static_cast<int> (OutputViewType::rank) == 2 &&
+     static_cast<int> (InputViewType::rank) == 2,
      "CopyConvertFunctor (implements Tpetra::Details::copyConvert): "
      "OutputViewType and InputViewType must both have rank 2.");
     OutputViewType dst_;
@@ -369,8 +369,8 @@ copyConvert (const OutputViewType& dst,
   static_assert (std::is_same<typename OutputViewType::value_type,
                    typename OutputViewType::non_const_value_type>::value,
                  "OutputViewType must be a nonconst Kokkos::View.");
-  static_assert (static_cast<int> (OutputViewType::Rank) ==
-                 static_cast<int> (InputViewType::Rank),
+  static_assert (static_cast<int> (OutputViewType::rank) ==
+                 static_cast<int> (InputViewType::rank),
                  "src and dst must have the same rank.");
 
   if (dst.extent (0) != src.extent (0)) {
@@ -381,7 +381,7 @@ copyConvert (const OutputViewType& dst,
        << ".";
     throw std::invalid_argument (os.str ());
   }
-  if (static_cast<int> (OutputViewType::Rank) > 1 &&
+  if (static_cast<int> (OutputViewType::rank) > 1 &&
       dst.extent (1) != src.extent (1)) {
     std::ostringstream os;
     os << "Tpetra::Details::copyConvert: "

--- a/packages/tpetra/core/src/Tpetra_Details_fill.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_fill.hpp
@@ -71,7 +71,7 @@ template<class ViewType,
          class ValueType,
          class ExecutionSpace,
          class IndexType,
-         const int rank = ViewType::Rank>
+         const int rank = ViewType::rank>
 class Fill {
 public:
   static void
@@ -98,7 +98,7 @@ public:
   Fill (const ViewType& X, const ValueType& alpha) :
     X_ (X), alpha_ (alpha)
   {
-    static_assert (ViewType::Rank == 1,
+    static_assert (ViewType::rank == 1,
                    "ViewType must be a rank-1 Kokkos::View.");
     static_assert (std::is_integral<IndexType>::value,
                    "IndexType must be a built-in integer type.");
@@ -139,7 +139,7 @@ public:
         const IndexType numCols) :
     X_ (X), alpha_ (alpha), numCols_ (numCols)
   {
-    static_assert (ViewType::Rank == 2,
+    static_assert (ViewType::rank == 2,
                    "ViewType must be a rank-2 Kokkos::View.");
     static_assert (std::is_integral<IndexType>::value,
                    "IndexType must be a built-in integer type.");
@@ -190,7 +190,7 @@ struct Fill<ViewType,
         const IndexType numRows,
         const IndexType /* numCols */ )
   {
-    static_assert (ViewType::Rank == 1,
+    static_assert (ViewType::rank == 1,
                    "ViewType must be a rank-1 Kokkos::View.");
     static_assert (std::is_integral<IndexType>::value,
                    "IndexType must be a built-in integer type.");
@@ -232,7 +232,7 @@ struct Fill<ViewType,
         const IndexType /* numRows */,
         const IndexType numCols)
   {
-    static_assert (ViewType::Rank == 2,
+    static_assert (ViewType::rank == 2,
                    "ViewType must be a rank-2 Kokkos::View.");
     static_assert (std::is_integral<IndexType>::value,
                    "IndexType must be a built-in integer type.");
@@ -297,7 +297,7 @@ fill (const ExecutionSpace& execSpace,
   static_assert (std::is_integral<IndexType>::value,
                  "IndexType must be a built-in integer type.");
   typedef Impl::Fill<ViewType, ValueType, ExecutionSpace,
-    IndexType, ViewType::Rank> impl_type;
+    IndexType, ViewType::rank> impl_type;
   impl_type::fill (execSpace, X, alpha, numRows, numCols);
 }
 
@@ -313,7 +313,7 @@ fill (const ExecutionSpace& execSpace,
       const IndexType numCols,
       const size_t whichVectors[])
 {
-  static_assert (ViewType::Rank == 2, "ViewType must be a rank-2 "
+  static_assert (ViewType::rank == 2, "ViewType must be a rank-2 "
                  "Kokkos::View in order to call the \"whichVectors\" "
                  "specialization of fill.");
   static_assert (std::is_integral<IndexType>::value,

--- a/packages/tpetra/core/src/Tpetra_Details_getEntryOnHost.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_getEntryOnHost.hpp
@@ -61,7 +61,7 @@ getEntryOnHost (const ViewType& x,
                 const IndexType ind)
 {
   using execution_space = typename ViewType::execution_space;
-  static_assert (ViewType::Rank == 1, "x must be a rank-1 Kokkos::View.");
+  static_assert (ViewType::rank == 1, "x must be a rank-1 Kokkos::View.");
   // Get a 0-D subview of the entry of the array, and copy to host scalar.
   typename ViewType::non_const_value_type val;
   // DEEP_COPY REVIEW - DEVICE-TO-VALUE
@@ -76,7 +76,7 @@ getEntriesOnHost (const ViewType& x,
                   const IndexType ind,
                   const int count)
 {
-  static_assert (ViewType::Rank == 1, "x must be a rank-1 Kokkos::View.");
+  static_assert (ViewType::rank == 1, "x must be a rank-1 Kokkos::View.");
   // Get a 1-D subview of the entry of the array, and copy to host.
   auto subview = Kokkos::subview(x, Kokkos::make_pair(ind, ind + count));
   return Kokkos::create_mirror_view_and_copy(typename ViewType::HostMirror::memory_space(), subview);

--- a/packages/tpetra/core/src/Tpetra_Details_leftScaleLocalCrsMatrix.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_leftScaleLocalCrsMatrix.hpp
@@ -73,7 +73,7 @@ public:
   using val_type =
     typename std::remove_const<typename LocalSparseMatrixType::value_type>::type;
   using mag_type = typename ScalingFactorsViewType::non_const_value_type;
-  static_assert (ScalingFactorsViewType::Rank == 1,
+  static_assert (ScalingFactorsViewType::rank == 1,
                  "scalingFactors must be a rank-1 Kokkos::View.");
   using device_type = typename LocalSparseMatrixType::device_type;
 

--- a/packages/tpetra/core/src/Tpetra_Details_normImpl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_normImpl.hpp
@@ -119,13 +119,13 @@ lclNormImpl (const RV& normsOut,
   using Kokkos::subview;
   using mag_type = typename RV::non_const_value_type;
 
-  static_assert (static_cast<int> (RV::Rank) == 1,
+  static_assert (static_cast<int> (RV::rank) == 1,
                  "Tpetra::MultiVector::lclNormImpl: "
                  "The first argument normsOut must have rank 1.");
   static_assert (Kokkos::is_view<XMV>::value,
                  "Tpetra::MultiVector::lclNormImpl: "
                  "The second argument X is not a Kokkos::View.");
-  static_assert (static_cast<int> (XMV::Rank) == 2,
+  static_assert (static_cast<int> (XMV::rank) == 2,
                  "Tpetra::MultiVector::lclNormImpl: "
                  "The second argument X must have rank 2.");
 

--- a/packages/tpetra/core/src/Tpetra_Details_rightScaleLocalCrsMatrix.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_rightScaleLocalCrsMatrix.hpp
@@ -73,7 +73,7 @@ public:
   using val_type =
     typename std::remove_const<typename LocalSparseMatrixType::value_type>::type;
   using mag_type = typename ScalingFactorsViewType::non_const_value_type;
-  static_assert (ScalingFactorsViewType::Rank == 1,
+  static_assert (ScalingFactorsViewType::rank == 1,
                  "scalingFactors must be a rank-1 Kokkos::View.");
   using device_type = typename LocalSparseMatrixType::device_type;
 

--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -262,7 +262,7 @@ namespace { // (anonymous)
   WrappedDualViewType
   takeSubview (const WrappedDualViewType& X,
                const std::pair<size_t, size_t>& rowRng,
-               const Kokkos::Impl::ALL_t& colRng)
+               const Kokkos::ALL_t& colRng)
 
   {
     // The bug we saw below should be harder to trigger here.
@@ -272,7 +272,7 @@ namespace { // (anonymous)
   template<class WrappedDualViewType>
   WrappedDualViewType
   takeSubview (const WrappedDualViewType& X,
-               const Kokkos::Impl::ALL_t& rowRng,
+               const Kokkos::ALL_t& rowRng,
                const std::pair<size_t, size_t>& colRng)
   {
     using DualViewType = typename WrappedDualViewType::DVT;

--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -318,7 +318,7 @@ namespace { // (anonymous)
     // method yet, but its Views do.
     // NOTE: dv.stride() returns a vector of length one
     // more than its rank
-    size_t strides[WrappedOrNotDualViewType::t_dev::Rank+1];
+    size_t strides[WrappedOrNotDualViewType::t_dev::rank+1];
     dv.stride(strides);
     const size_t LDA = strides[1];
     const size_t numRows = dv.extent (0);

--- a/packages/tpetra/core/src/Tpetra_computeRowAndColumnOneNorms_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_computeRowAndColumnOneNorms_def.hpp
@@ -780,7 +780,7 @@ copyMultiVectorColumnInto1DView (
 template<class OneDViewType, class IndexType>
 class FindZero {
 public:
-  static_assert (OneDViewType::Rank == 1,
+  static_assert (OneDViewType::rank == 1,
                  "OneDViewType must be a rank-1 Kokkos::View.");
   static_assert (std::is_integral<IndexType>::value,
                  "IndexType must be a built-in integer type.");

--- a/packages/tpetra/core/src/kokkos_refactor/Tpetra_KokkosRefactor_Details_MultiVectorDistObjectKernels.hpp
+++ b/packages/tpetra/core/src/kokkos_refactor/Tpetra_KokkosRefactor_Details_MultiVectorDistObjectKernels.hpp
@@ -1643,8 +1643,8 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
   };
 
 // clang-format on
-// To do:  Add enable_if<> restrictions on DstView::Rank == 1,
-// SrcView::Rank == 2
+// To do:  Add enable_if<> restrictions on DstView::rank == 1,
+// SrcView::rank == 2
 template <typename ExecutionSpace, typename DstView, typename SrcView,
           typename DstIdxView, typename SrcIdxView, typename Op>
 void permute_array_multi_column(const ExecutionSpace &space, const DstView &dst,
@@ -1657,8 +1657,8 @@ void permute_array_multi_column(const ExecutionSpace &space, const DstView &dst,
 }
 // clang-format off
 
-  // To do:  Add enable_if<> restrictions on DstView::Rank == 1,
-  // SrcView::Rank == 2
+  // To do:  Add enable_if<> restrictions on DstView::rank == 1,
+  // SrcView::rank == 2
   template <typename DstView, typename SrcView,
             typename DstIdxView, typename SrcIdxView, typename Op>
   void permute_array_multi_column(const DstView& dst,
@@ -1738,8 +1738,8 @@ void permute_array_multi_column(const ExecutionSpace &space, const DstView &dst,
   };
 
 // clang-format on
-// To do:  Add enable_if<> restrictions on DstView::Rank == 1,
-// SrcView::Rank == 2
+// To do:  Add enable_if<> restrictions on DstView::rank == 1,
+// SrcView::rank == 2
 template <typename ExecutionSpace, typename DstView, typename SrcView,
           typename DstIdxView, typename SrcIdxView, typename DstColView,
           typename SrcColView, typename Op>
@@ -1756,8 +1756,8 @@ void permute_array_multi_column_variable_stride(
 }
 // clang-format off
 
-  // To do:  Add enable_if<> restrictions on DstView::Rank == 1,
-  // SrcView::Rank == 2
+  // To do:  Add enable_if<> restrictions on DstView::rank == 1,
+  // SrcView::rank == 2
   template <typename DstView, typename SrcView,
             typename DstIdxView, typename SrcIdxView,
             typename DstColView, typename SrcColView, typename Op>

--- a/packages/tpetra/core/test/HashTable/FixedHashTableTest.cpp
+++ b/packages/tpetra/core/test/HashTable/FixedHashTableTest.cpp
@@ -188,12 +188,12 @@ namespace { // (anonymous)
           if (actualVal == Tpetra::Details::OrdinalTraits<ValueType>::invalid ()) {
             curBad = true;
             printf("get(key=%lld) = invalid, should have been %d\n",
-                    key, expectedVal);
+                    (long long) key, expectedVal);
           }
           else if (testValues && actualVal != expectedVal) {
             curBad = true;
             printf("get(key=%lld) = %d, should have been %d\n",
-                    key, actualVal, expectedVal);
+                    (long long) key, actualVal, expectedVal);
           }
   
           if (curBad) {


### PR DESCRIPTION
Use ``Kokkos::ALL_t`` instead of ``Kokkos::Impl::ALL_t``, and ``Kokkos::View::rank`` instead of ``Kokkos::View::Rank``.

Also fix a minor warning out of printf from using the wrong format specifier.
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 
@trilinos/teuchos 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Fix a bunch of ``-Wdeprecated-declarations`` warnings. Along with #12003 this fixes all the deprecated warnings in Tpetra after the Kokkos/KokkosKernels 4.1 release.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->