### PR TITLE
Tpetra: fix #11959

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -2150,6 +2150,7 @@ public:
     row_ptrs_device_view_type rowPtrsPacked_dev_;
     mutable row_ptrs_host_view_type rowPtrsPacked_host_;
 
+    //! Whether the unpacked and packed row pointers hvae identical contents
     bool packedUnpackedRowPtrsMatch_ = false;
 
   protected:

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -2129,6 +2129,7 @@ public:
     global_size_t globalMaxNumRowEntries_ =
       Teuchos::OrdinalTraits<global_size_t>::invalid();
 
+  private:
     // Replacement for device view k_rowPtrs_
     // Device view rowPtrsUnpacked_dev_ takes place of k_rowPtrs_ 
     // Host view rowPtrsUnpacked_host_ takes place of copies and use of getEntryOnHost
@@ -2141,28 +2142,101 @@ public:
     // When OptimizedStorage, rowPtrsUnpacked_ = k_rowPtrsPacked_
 
     row_ptrs_device_view_type rowPtrsUnpacked_dev_;
-    row_ptrs_host_view_type rowPtrsUnpacked_host_;
+    mutable row_ptrs_host_view_type rowPtrsUnpacked_host_;
 
-    void setRowPtrsUnpacked(const row_ptrs_device_view_type &dview) {
-      rowPtrsUnpacked_dev_ = dview;
-      rowPtrsUnpacked_host_ = 
-           Kokkos::create_mirror_view_and_copy(
-                          typename row_ptrs_device_view_type::host_mirror_space(),
-                          dview);
-    }
-
-    // Row offsets into the actual graph local indices 
+    // Row offsets into the actual graph local indices
     // Device view rowPtrsUnpacked_dev_ takes place of lclGraph_.row_map
 
     row_ptrs_device_view_type rowPtrsPacked_dev_;
-    row_ptrs_host_view_type rowPtrsPacked_host_;
+    mutable row_ptrs_host_view_type rowPtrsPacked_host_;
+
+    bool packedUnpackedRowPtrsMatch_ = false;
+
+  protected:
+    void setRowPtrsUnpacked(const row_ptrs_device_view_type &dview) {
+      packedUnpackedRowPtrsMatch_ = false;
+      rowPtrsUnpacked_dev_ = dview;
+      //Make sure stale host rowptrs are not kept
+      rowPtrsUnpacked_host_ = row_ptrs_host_view_type();
+    }
+
+    //! Get the unpacked row pointers on device
+    const row_ptrs_device_view_type& getRowPtrsUnpackedDevice() const
+    {
+      return rowPtrsUnpacked_dev_;
+    }
+
+    //! Get the unpacked row pointers on host. Lazily make a copy from device.
+    const row_ptrs_host_view_type& getRowPtrsUnpackedHost() const
+    {
+      if(rowPtrsUnpacked_host_.extent(0) != rowPtrsUnpacked_dev_.extent(0))
+      {
+        //NOTE: not just using create_mirror_view here, because
+        //we do want host/device to be in different memory, even if we're using a SharedSpace.
+        //This is so that reads will never trigger a host-device transfer.
+        //The exception is when 'device' views are HostSpace, then don't make another copy.
+        if constexpr(std::is_same_v<typename Node::memory_space, Kokkos::HostSpace>)
+        {
+          rowPtrsUnpacked_host_ = rowPtrsUnpacked_dev_;
+        }
+        else
+        {
+          //Have to make this temporary because rowptrs are const-valued
+          typename row_ptrs_host_view_type::non_const_type rowPtrsTemp(
+              Kokkos::view_alloc(Kokkos::WithoutInitializing, "rowPtrsUnpacked_host_"), rowPtrsUnpacked_dev_.extent(0));
+          Kokkos::deep_copy(rowPtrsTemp, rowPtrsUnpacked_dev_);
+          rowPtrsUnpacked_host_= rowPtrsTemp;
+        }
+        //Also keep packed/unpacked views in sync, if they are known to have the same contents
+        if(packedUnpackedRowPtrsMatch_)
+        {
+          rowPtrsPacked_host_ = rowPtrsUnpacked_host_;
+        }
+      }
+      return rowPtrsUnpacked_host_;
+    }
 
     void setRowPtrsPacked(const row_ptrs_device_view_type &dview) {
+      packedUnpackedRowPtrsMatch_ = false;
       rowPtrsPacked_dev_ = dview;
-      rowPtrsPacked_host_ = 
-           Kokkos::create_mirror_view_and_copy(
-                       typename row_ptrs_device_view_type::host_mirror_space(),
-                       dview);
+      //Make sure stale host rowptrs are not kept
+      rowPtrsPacked_host_ = row_ptrs_host_view_type();
+    }
+
+    //! Get the packed row pointers on device
+    const row_ptrs_device_view_type& getRowPtrsPackedDevice() const
+    {
+      return rowPtrsPacked_dev_;
+    }
+
+    //! Get the packed row pointers on host. Lazily make a copy from device.
+    const row_ptrs_host_view_type& getRowPtrsPackedHost() const
+    {
+      if(rowPtrsPacked_host_.extent(0) != rowPtrsPacked_dev_.extent(0))
+      {
+        //NOTE: not just using create_mirror_view here, because
+        //we do want host/device to be in different memory, even if we're using a SharedSpace.
+        //This is so that reads will never trigger a host-device transfer.
+        //The exception is when 'device' views are HostSpace, then don't make another copy.
+        if constexpr(std::is_same_v<typename Node::memory_space, Kokkos::HostSpace>)
+        {
+          rowPtrsPacked_host_ = rowPtrsPacked_dev_;
+        }
+        else
+        {
+          //Have to make this temporary because rowptrs are const-valued
+          typename row_ptrs_host_view_type::non_const_type rowPtrsTemp(
+              Kokkos::view_alloc(Kokkos::WithoutInitializing, "rowPtrsPacked_host_"), rowPtrsPacked_dev_.extent(0));
+          Kokkos::deep_copy(rowPtrsTemp, rowPtrsPacked_dev_);
+          rowPtrsPacked_host_= rowPtrsTemp;
+        }
+        //Also keep packed/unpacked views in sync, if they are known to have the same contents
+        if(packedUnpackedRowPtrsMatch_)
+        {
+          rowPtrsUnpacked_host_ = rowPtrsPacked_host_;
+        }
+      }
+      return rowPtrsPacked_host_;
     }
 
     // There are common cases where both packed and unpacked views are set to the same array.
@@ -2170,9 +2244,12 @@ public:
     // removing a deep_copy from device to host.
 
     void setRowPtrs(const row_ptrs_device_view_type &dview) {
-      setRowPtrsUnpacked(dview);
-      rowPtrsPacked_dev_ = rowPtrsUnpacked_dev_;
-      rowPtrsPacked_host_ = rowPtrsUnpacked_host_;
+      packedUnpackedRowPtrsMatch_ = true;
+      rowPtrsUnpacked_dev_ = dview;
+      rowPtrsPacked_dev_ = dview;
+      //Make sure stale host rowptrs are not kept
+      rowPtrsUnpacked_host_ = row_ptrs_host_view_type();
+      rowPtrsPacked_host_ = row_ptrs_host_view_type();
     }
     
     //TODO:  Make private -- matrix shouldn't access directly the guts of graph

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -539,14 +539,12 @@ namespace Tpetra {
     staticAssertions();
 
     int numRows = rowMap->getLocalNumElements();
-    size_t numNonZeros = originalGraph.rowPtrsPacked_host_(numRows);
+    size_t numNonZeros = originalGraph.getRowPtrsPackedHost()(numRows);
     auto rowsToUse = Kokkos::pair<size_t, size_t>(0, numRows+1);
 
-    rowPtrsUnpacked_dev_ = Kokkos::subview(originalGraph.rowPtrsUnpacked_dev_, rowsToUse);
-    rowPtrsUnpacked_host_ = Kokkos::subview(originalGraph.rowPtrsUnpacked_host_, rowsToUse);
 
-    rowPtrsPacked_dev_ = Kokkos::subview(originalGraph.rowPtrsPacked_dev_, rowsToUse);
-    rowPtrsPacked_host_ = Kokkos::subview(originalGraph.rowPtrsPacked_host_, rowsToUse);
+    this->setRowPtrsUnpacked(Kokkos::subview(originalGraph.getRowPtrsUnpackedDevice(), rowsToUse));
+    this->setRowPtrsPacked(Kokkos::subview(originalGraph.getRowPtrsPackedDevice(), rowsToUse));
 
     if (indicesAreLocal_) {
       lclIndsUnpacked_wdv = local_inds_wdv_type(originalGraph.lclIndsUnpacked_wdv, 0, numNonZeros);
@@ -953,12 +951,12 @@ namespace Tpetra {
         auto numEntPerRow = this->k_numRowEntries_;
         const LO numNumEntPerRow = numEntPerRow.extent (0);
         if (numNumEntPerRow == 0) {
-          if (static_cast<LO> (this->rowPtrsPacked_dev_.extent (0)) <
+          if (static_cast<LO> (this->getRowPtrsPackedDevice().extent (0)) <
               static_cast<LO> (lclNumRows + 1)) {
             return static_cast<size_t> (0);
           }
           else {
-            return this->rowPtrsPacked_host_(lclNumRows);
+            return this->getRowPtrsPackedHost()(lclNumRows);
           }
         }
         else { // k_numRowEntries_ is populated
@@ -1058,20 +1056,21 @@ namespace Tpetra {
         return static_cast<size_t> (0);
       }
       else if (storageStatus_ == Details::STORAGE_1D_PACKED) {
-        if (static_cast<LO> (this->rowPtrsPacked_dev_.extent (0)) <
+        if (static_cast<LO> (this->getRowPtrsPackedDevice().extent (0)) <
             static_cast<LO> (lclNumRows + 1)) {
           return static_cast<size_t> (0);
         }
         else {
-          return this->rowPtrsPacked_host_(lclNumRows);
+          return this->getRowPtrsPackedHost()(lclNumRows);
         }
       }
       else if (storageStatus_ == Details::STORAGE_1D_UNPACKED) {
-        if (rowPtrsUnpacked_host_.extent (0) == 0) {
+        auto rowPtrsUnpacked_host = this->getRowPtrsUnpackedHost();
+        if (rowPtrsUnpacked_host.extent (0) == 0) {
           return static_cast<size_t> (0);
         }
         else {
-          return rowPtrsUnpacked_host_(lclNumRows);
+          return rowPtrsUnpacked_host(lclNumRows);
         }
       }
       else {
@@ -1239,7 +1238,7 @@ namespace Tpetra {
     setRowPtrsUnpacked(k_rowPtrs);
   }
 
-    const size_type numInds = rowPtrsUnpacked_host_(numRows);
+    const size_type numInds = this->getRowPtrsUnpackedHost()(numRows);
     if (lg == LocalIndices) {
       if (verbose) {
         std::ostringstream os;
@@ -1404,14 +1403,15 @@ namespace Tpetra {
 
     ret.localRow = static_cast<size_t> (myRow);
     if (this->indicesAreAllocated ()) {
+      auto rowPtrsUnpacked_host = this->getRowPtrsUnpackedHost();
       // Offsets tell us the allocation size in this case.
-      if (rowPtrsUnpacked_host_.extent (0) == 0) {
+      if (rowPtrsUnpacked_host.extent (0) == 0) {
         ret.offset1D  = 0;
         ret.allocSize = 0;
       }
       else {
-        ret.offset1D  = rowPtrsUnpacked_host_(myRow);
-        ret.allocSize = rowPtrsUnpacked_host_(myRow+1) - rowPtrsUnpacked_host_(myRow);
+        ret.offset1D  = rowPtrsUnpacked_host(myRow);
+        ret.allocSize = rowPtrsUnpacked_host(myRow+1) - rowPtrsUnpacked_host(myRow);
       }
 
       ret.numEntries = (this->k_numRowEntries_.extent (0) == 0) ?
@@ -1461,13 +1461,14 @@ namespace Tpetra {
       // graph data structures have the info that we need
       //
       // if static graph, offsets tell us the allocation size
-      if (rowPtrsUnpacked_host_.extent (0) == 0) {
+      auto rowPtrsUnpacked_host = this->getRowPtrsUnpackedHost();
+      if (rowPtrsUnpacked_host.extent (0) == 0) {
         ret.offset1D  = 0;
         ret.allocSize = 0;
       }
       else {
-        ret.offset1D  = rowPtrsUnpacked_host_(myRow);
-        ret.allocSize = rowPtrsUnpacked_host_(myRow+1) - rowPtrsUnpacked_host_(myRow);
+        ret.offset1D  = rowPtrsUnpacked_host(myRow);
+        ret.allocSize = rowPtrsUnpacked_host(myRow+1) - rowPtrsUnpacked_host(myRow);
       }
 
       ret.numEntries = (this->k_numRowEntries_.extent (0) == 0) ?
@@ -1674,7 +1675,7 @@ namespace Tpetra {
     size_t numInserted;
     {
       auto gblIndsHostView = this->gblInds_wdv.getHostView(Access::ReadWrite);
-      numInserted = Details::insertCrsIndices(lclRow, this->rowPtrsUnpacked_host_,
+      numInserted = Details::insertCrsIndices(lclRow, this->getRowPtrsUnpackedHost(),
                                               gblIndsHostView,
                                               numEntries, inputInds, fun);
     }
@@ -1742,7 +1743,7 @@ namespace Tpetra {
     size_t numInserted = 0;
     {
       auto lclInds = lclIndsUnpacked_wdv.getHostView(Access::ReadWrite);
-      numInserted = Details::insertCrsIndices(myRow, rowPtrsUnpacked_host_, lclInds,
+      numInserted = Details::insertCrsIndices(myRow, this->getRowPtrsUnpackedHost(), lclInds,
                                               numEntries, inputInds, fun);
     }
 
@@ -1802,13 +1803,13 @@ namespace Tpetra {
         return invalidCount;
       const auto& colMap = *(this->colMap_);
       auto map = [&](GO const gblInd){return colMap.getLocalElement(gblInd);};
-      numFound = Details::findCrsIndices(lclRow, rowPtrsUnpacked_host_,
+      numFound = Details::findCrsIndices(lclRow, this->getRowPtrsUnpackedHost(),
         rowInfo.numEntries,
         lclIndsUnpacked_wdv.getHostView(Access::ReadOnly), inputInds, map, fun);
     }
     else if (this->isGloballyIndexed())
     {
-      numFound = Details::findCrsIndices(lclRow, rowPtrsUnpacked_host_,
+      numFound = Details::findCrsIndices(lclRow, this->getRowPtrsUnpackedHost(),
         rowInfo.numEntries,
         gblInds_wdv.getHostView(Access::ReadOnly), inputInds, fun);
     }
@@ -1988,36 +1989,38 @@ namespace Tpetra {
          "nonzero, or k_numAllocPerRow_ has nonzero dimension.  In other words, "
          "the graph is supposed to release its \"allocation specifications\" "
          "when it allocates its indices." << suffix);
+      auto rowPtrsUnpacked_host = this->getRowPtrsUnpackedHost();
+      auto rowPtrsUnpacked_dev = this->getRowPtrsUnpackedDevice();
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (rowPtrsUnpacked_host_.extent(0) != rowPtrsUnpacked_dev_.extent(0),
+        (rowPtrsUnpacked_host.extent(0) != rowPtrsUnpacked_dev.extent(0),
          std::logic_error, "The host and device views of k_rowPtrs_ have "
          "different sizes; rowPtrsUnpacked_host_ has size  "
-         << rowPtrsUnpacked_host_.extent(0)
+         << rowPtrsUnpacked_host.extent(0)
          << ", but rowPtrsUnpacked_dev_ has size "
-         << rowPtrsUnpacked_dev_.extent(0)
+         << rowPtrsUnpacked_dev.extent(0)
          << "." << suffix);
-      if (isGloballyIndexed() && rowPtrsUnpacked_host_.extent(0) != 0) {
+      if (isGloballyIndexed() && rowPtrsUnpacked_host.extent(0) != 0) {
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-          (size_t(rowPtrsUnpacked_host_.extent(0)) != size_t(lclNumRows + 1),
+          (size_t(rowPtrsUnpacked_host.extent(0)) != size_t(lclNumRows + 1),
            std::logic_error, "The graph is globally indexed and "
-           "k_rowPtrs has nonzero size " << rowPtrsUnpacked_host_.extent(0)
+           "k_rowPtrs has nonzero size " << rowPtrsUnpacked_host.extent(0)
            << ", but that size does not equal lclNumRows+1 = "
            << (lclNumRows+1) << "." << suffix);
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-          (rowPtrsUnpacked_host_(lclNumRows) != size_t(gblInds_wdv.extent(0)),
+          (rowPtrsUnpacked_host(lclNumRows) != size_t(gblInds_wdv.extent(0)),
            std::logic_error, "The graph is globally indexed and "
-           "k_rowPtrs_ has nonzero size " << rowPtrsUnpacked_host_.extent(0)
+           "k_rowPtrs_ has nonzero size " << rowPtrsUnpacked_host.extent(0)
            << ", but k_rowPtrs_(lclNumRows=" << lclNumRows << ")="
-           << rowPtrsUnpacked_host_(lclNumRows) 
+           << rowPtrsUnpacked_host(lclNumRows) 
            << " != gblInds_wdv.extent(0)="
            << gblInds_wdv.extent(0) << "." << suffix);
       }
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
         (this->isLocallyIndexed () &&
-         this->rowPtrsUnpacked_host_.extent (0) != 0 &&
-         (static_cast<size_t> (rowPtrsUnpacked_host_.extent (0)) != 
+         rowPtrsUnpacked_host.extent (0) != 0 &&
+         (static_cast<size_t> (rowPtrsUnpacked_host.extent (0)) != 
               static_cast<size_t> (lclNumRows + 1) ||
-          this->rowPtrsUnpacked_host_(lclNumRows) != 
+          rowPtrsUnpacked_host(lclNumRows) != 
               static_cast<size_t> (this->lclIndsUnpacked_wdv.extent (0))),
          std::logic_error, "If k_rowPtrs_ has nonzero size and "
          "the graph is locally indexed, then "
@@ -2034,7 +2037,7 @@ namespace Tpetra {
 
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
         (! this->indicesAreAllocated () &&
-         ((this->rowPtrsUnpacked_host_.extent (0) != 0 ||
+         ((rowPtrsUnpacked_host.extent (0) != 0 ||
            this->k_numRowEntries_.extent (0) != 0) ||
           this->lclIndsUnpacked_wdv.extent (0) != 0 ||
           this->gblInds_wdv.extent (0) != 0),
@@ -2081,16 +2084,16 @@ namespace Tpetra {
          << getLocalNumRows () << " > 0." << suffix);
       // check the actual allocations
       if (this->indicesAreAllocated () &&
-          this->rowPtrsUnpacked_host_.extent (0) != 0) {
+          rowPtrsUnpacked_host.extent (0) != 0) {
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-          (static_cast<size_t> (this->rowPtrsUnpacked_host_.extent (0)) !=
+          (static_cast<size_t> (rowPtrsUnpacked_host.extent (0)) !=
            this->getLocalNumRows () + 1,
            std::logic_error, "Indices are allocated and "
            "k_rowPtrs_ has nonzero length, but rowPtrsUnpacked_host_.extent(0) = "
-           << this->rowPtrsUnpacked_host_.extent (0) << " != getLocalNumRows()+1 = "
+           << rowPtrsUnpacked_host.extent (0) << " != getLocalNumRows()+1 = "
            << (this->getLocalNumRows () + 1) << "." << suffix);
         const size_t actualNumAllocated = 
-              this->rowPtrsUnpacked_host_(this->getLocalNumRows());
+              rowPtrsUnpacked_host(this->getLocalNumRows());
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
           (this->isLocallyIndexed () &&
            static_cast<size_t> (this->lclIndsUnpacked_wdv.extent (0)) != actualNumAllocated,
@@ -2181,7 +2184,7 @@ namespace Tpetra {
   CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
   getLocalRowPtrsHost () const
   {
-    return rowPtrsPacked_host_;
+    return getRowPtrsPackedHost();
   }
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
@@ -2189,7 +2192,7 @@ namespace Tpetra {
   CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
   getLocalRowPtrsDevice () const
   {
-    return rowPtrsPacked_dev_;
+    return getRowPtrsPackedDevice();
   }
 
 
@@ -3353,15 +3356,16 @@ namespace Tpetra {
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
       isFillComplete () || ! hasColMap (), std::runtime_error, "You may not "
       "call this method unless the graph has a column Map.");
+    auto rowPtrsUnpackedLength = this->getRowPtrsUnpackedHost().extent (0);
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
-      getLocalNumRows () > 0 && rowPtrsUnpacked_host_.extent (0) == 0,
+      getLocalNumRows () > 0 && rowPtrsUnpackedLength == 0,
       std::runtime_error, "The calling process has getLocalNumRows() = "
       << getLocalNumRows () << " > 0 rows, but the row offsets array has not "
       "been set.");
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
-      static_cast<size_t> (rowPtrsUnpacked_host_.extent (0)) != getLocalNumRows () + 1,
+      static_cast<size_t> (rowPtrsUnpackedLength) != getLocalNumRows () + 1,
       std::runtime_error, "The row offsets array has length " <<
-      rowPtrsUnpacked_host_.extent (0) << " != getLocalNumRows()+1 = " <<
+      rowPtrsUnpackedLength << " != getLocalNumRows()+1 = " <<
       (getLocalNumRows () + 1) << ".");
 
     // Note: We don't need to do the following things which are normally done in fillComplete:
@@ -3496,23 +3500,24 @@ namespace Tpetra {
     // in k_lclInds1D_.
 
     if (debug_) {
+      auto rowPtrsUnpacked = this->getRowPtrsUnpackedHost();
       // The graph's array of row offsets must already be allocated.
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (rowPtrsUnpacked_host_.extent (0) == 0, std::logic_error,
-         "k_rowPtrs_ has size zero, but shouldn't");
+        (rowPtrsUnpacked.extent (0) == 0, std::logic_error,
+         "rowPtrsUnpacked_host_ has size zero, but shouldn't");
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (rowPtrsUnpacked_host_.extent (0) != lclNumRows + 1, std::logic_error,
+        (rowPtrsUnpacked.extent (0) != lclNumRows + 1, std::logic_error,
          "rowPtrsUnpacked_host_.extent(0) = "
-         << rowPtrsUnpacked_host_.extent (0) << " != (lclNumRows + 1) = "
+         << rowPtrsUnpacked.extent (0) << " != (lclNumRows + 1) = "
          << (lclNumRows + 1) << ".");
-      const size_t numOffsets = rowPtrsUnpacked_host_.extent (0);
-      const auto valToCheck = rowPtrsUnpacked_host_(numOffsets-1);
+      const size_t numOffsets = rowPtrsUnpacked.extent (0);
+      const auto valToCheck = rowPtrsUnpacked(numOffsets-1);
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
         (numOffsets != 0 &&
          lclIndsUnpacked_wdv.extent (0) != valToCheck,
          std::logic_error, "numOffsets=" << numOffsets << " != 0 "
          " and lclIndsUnpacked_wdv.extent(0)=" << lclIndsUnpacked_wdv.extent(0)
-         << " != k_rowPtrs_(" << numOffsets << ")=" << valToCheck
+         << " != rowPtrsUnpacked_host_(" << numOffsets << ")=" << valToCheck
          << ".");
     }
 
@@ -3554,10 +3559,11 @@ namespace Tpetra {
       // didn't fill all those entries.
 
       if (debug_) {
-        if (rowPtrsUnpacked_host_.extent (0) != 0) {
+        auto rowPtrsUnpacked = this->getRowPtrsUnpackedHost();
+        if (rowPtrsUnpacked.extent (0) != 0) {
           const size_t numOffsets =
-            static_cast<size_t> (rowPtrsUnpacked_host_.extent (0));
-          const auto valToCheck = rowPtrsUnpacked_host_(numOffsets - 1);
+            static_cast<size_t> (rowPtrsUnpacked.extent (0));
+          const auto valToCheck = rowPtrsUnpacked(numOffsets - 1);
           TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
             (valToCheck != size_t(lclIndsUnpacked_wdv.extent(0)),
              std::logic_error, "(Unpacked branch) Before allocating "
@@ -3632,7 +3638,7 @@ namespace Tpetra {
         typename local_graph_device_type::row_map_type> inds_packer_type;
       inds_packer_type f (ind_d, 
                           lclIndsUnpacked_wdv.getDeviceView(Access::ReadOnly),
-                          ptr_d, rowPtrsUnpacked_dev_);
+                          ptr_d, this->getRowPtrsUnpackedDevice());
       {
         typedef typename decltype (ind_d)::execution_space exec_space;
         typedef Kokkos::RangePolicy<exec_space, LocalOrdinal> range_type;
@@ -3643,8 +3649,7 @@ namespace Tpetra {
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
           (ptr_d.extent (0) == 0, std::logic_error,
            "(\"Optimize Storage\"=true branch) After packing, "
-           "ptr_d.extent(0)=0.  This probably means k_rowPtrs_ was "
-           "never allocated.");
+           "ptr_d.extent(0)=0.");
         if (ptr_d.extent (0) != 0) {
           const size_t numOffsets = static_cast<size_t> (ptr_d.extent (0));
           const auto valToCheck =
@@ -3665,23 +3670,22 @@ namespace Tpetra {
       lclIndsPacked_wdv = local_inds_wdv_type(ind_d);
     }
     else { // We don't have to pack, so just set the pointers.
-      // Note: The setRowPtrsPacked call has an aditional memcpy to host that we want to avoid
-      rowPtrsPacked_dev_ = rowPtrsUnpacked_dev_;
-      rowPtrsPacked_host_ = rowPtrsUnpacked_host_;
+      //Set both packed and unpacked rowptrs to this
+      this->setRowPtrs(rowPtrsUnpacked_dev_);
       lclIndsPacked_wdv = lclIndsUnpacked_wdv; 
 
       if (debug_) {
+        auto rowPtrsPacked_dev = this->getRowPtrsPackedDevice();
+        auto rowPtrsPacked_host = this->getRowPtrsPackedHost();
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-          (rowPtrsPacked_dev_.extent (0) == 0, std::logic_error,
+          (rowPtrsPacked_dev.extent (0) == 0, std::logic_error,
            "(\"Optimize Storage\"=false branch) "
-           "rowPtrsPacked_dev_.extent(0) = 0.  "
-           "This probably means that "
-           "k_rowPtrs_ was never allocated.");
-        if (rowPtrsPacked_dev_.extent (0) != 0) {
+           "rowPtrsPacked_dev_.extent(0) = 0.");
+        if (rowPtrsPacked_dev.extent (0) != 0) {
           const size_t numOffsets =
-            static_cast<size_t> (rowPtrsPacked_dev_.extent (0));
+            static_cast<size_t> (rowPtrsPacked_dev.extent (0));
           const size_t valToCheck =
-            rowPtrsPacked_host_(numOffsets - 1);
+            rowPtrsPacked_host(numOffsets - 1);
           TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
             (valToCheck != size_t(lclIndsPacked_wdv.extent (0)),
              std::logic_error, "(\"Optimize Storage\"=false branch) "
@@ -3694,14 +3698,16 @@ namespace Tpetra {
     }
 
     if (debug_) {
+      auto rowPtrsPacked_dev = this->getRowPtrsPackedDevice();
+      auto rowPtrsPacked_host = this->getRowPtrsPackedHost();
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (static_cast<size_t> (rowPtrsPacked_dev_.extent (0)) != lclNumRows + 1,
+        (static_cast<size_t> (rowPtrsPacked_dev.extent (0)) != lclNumRows + 1,
          std::logic_error, "After packing, rowPtrsPacked_dev_.extent(0) = " <<
-         rowPtrsPacked_dev_.extent (0) << " != lclNumRows+1 = " << (lclNumRows+1)
+         rowPtrsPacked_dev.extent (0) << " != lclNumRows+1 = " << (lclNumRows+1)
          << ".");
-      if (rowPtrsPacked_dev_.extent (0) != 0) {
-        const size_t numOffsets = static_cast<size_t> (rowPtrsPacked_dev_.extent (0));
-        const auto valToCheck = rowPtrsPacked_host_(numOffsets - 1);
+      if (rowPtrsPacked_dev.extent (0) != 0) {
+        const size_t numOffsets = static_cast<size_t> (rowPtrsPacked_dev.extent (0));
+        const auto valToCheck = rowPtrsPacked_host(numOffsets - 1);
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
           (static_cast<size_t> (valToCheck) != lclIndsPacked_wdv.extent (0),
            std::logic_error, "After packing, rowPtrsPacked_dev_(" << (numOffsets-1)
@@ -4108,7 +4114,7 @@ namespace Tpetra {
   {
     return local_graph_device_type(
                  lclIndsPacked_wdv.getDeviceView(Access::ReadWrite),
-                 rowPtrsPacked_dev_);
+                 this->getRowPtrsPackedDevice());
   }
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
@@ -4118,7 +4124,7 @@ namespace Tpetra {
   {
     return local_graph_host_type(
                  lclIndsPacked_wdv.getHostView(Access::ReadWrite),
-                 rowPtrsPacked_host_);
+                 this->getRowPtrsPackedHost());
   }
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
@@ -4185,7 +4191,7 @@ namespace Tpetra {
 
     using LO = local_ordinal_type;
 
-    auto ptr = this->rowPtrsPacked_dev_;
+    auto ptr = this->getRowPtrsPackedDevice();
     const LO lclNumRows = ptr.extent(0) == 0 ?
       static_cast<LO> (0) :
       (static_cast<LO> (ptr.extent(0)) - static_cast<LO> (1));
@@ -4250,16 +4256,18 @@ namespace Tpetra {
       typename row_entries_type::const_type h_numRowEnt =
         this->k_numRowEntries_;
 
+      auto rowPtrsUnpacked_host = this->getRowPtrsUnpackedHost();
+
       // Allocate space for local indices.
-      if (rowPtrsUnpacked_host_.extent (0) == 0) {
-        errStrm << "k_rowPtrs_.extent(0) == 0.  This should never "
+      if (rowPtrsUnpacked_host.extent(0) == 0) {
+        errStrm << "Unpacked row pointers (rowPtrsUnpacked_dev_) has length 0.  This should never "
         "happen here.  Please report this bug to the Tpetra developers."
         << endl;
         // Need to return early.
         return std::make_pair(Tpetra::Details::OrdinalTraits<size_t>::invalid (),
                               errStrm.str ());
       }
-      const auto numEnt = rowPtrsUnpacked_host_(lclNumRows);
+      const auto numEnt = rowPtrsUnpacked_host(lclNumRows);
 
       // mfh 17 Dec 2016: We don't need initial zero-fill of
       // lclIndsUnpacked_wdv, because we will fill it below anyway.
@@ -4314,7 +4322,7 @@ namespace Tpetra {
         convertColumnIndicesFromGlobalToLocal<LO, GO, DT, offset_type, num_ent_type> (
           lclIndsUnpacked_wdv.getDeviceView(Access::OverwriteAll),
           gblInds_wdv.getDeviceView(Access::ReadOnly),
-          rowPtrsUnpacked_dev_,
+          this->getRowPtrsUnpackedDevice(),
           lclColMap,
           k_numRowEnt);
       if (lclNumErrs != 0) {
@@ -4920,19 +4928,20 @@ namespace Tpetra {
     // Making copies here because k_rowPtrs_ has a const type. Otherwise, we
     // would use it directly.
 
+    auto rowPtrsUnpacked_dev = this->getRowPtrsUnpackedDevice();
     if (verbose) {
       std::ostringstream os;
       os << *prefix << "Allocate row_ptrs_beg: "
-         << rowPtrsUnpacked_dev_.extent(0) << endl;
+         << rowPtrsUnpacked_dev.extent(0) << endl;
       std::cerr << os.str();
     }
     using Kokkos::view_alloc;
     using Kokkos::WithoutInitializing;
     row_ptrs_type row_ptrs_beg(
       view_alloc("row_ptrs_beg", WithoutInitializing),
-      rowPtrsUnpacked_dev_.extent(0));
+      rowPtrsUnpacked_dev.extent(0));
     // DEEP_COPY REVIEW - DEVICE-TO-DEVICE
-    Kokkos::deep_copy(execution_space(),row_ptrs_beg, rowPtrsUnpacked_dev_);
+    Kokkos::deep_copy(execution_space(),row_ptrs_beg, rowPtrsUnpacked_dev);
 
     const size_t N = row_ptrs_beg.extent(0) == 0 ? size_t(0) :
       size_t(row_ptrs_beg.extent(0) - 1);
@@ -4992,15 +5001,13 @@ namespace Tpetra {
     if (verbose) {
       std::ostringstream os;
       os << *prefix << "Reassign k_rowPtrs_; old size: "
-         << rowPtrsUnpacked_dev_.extent(0) << ", new size: "
+         << rowPtrsUnpacked_dev.extent(0) << ", new size: "
          << row_ptrs_beg.extent(0) << endl;
       std::cerr << os.str();
-      TEUCHOS_ASSERT( rowPtrsUnpacked_dev_.extent(0) == row_ptrs_beg.extent(0) );
+      TEUCHOS_ASSERT( rowPtrsUnpacked_dev.extent(0) == row_ptrs_beg.extent(0) );
     }
 
     setRowPtrsUnpacked(row_ptrs_beg);
-
-    set_need_sync_host_uvm_access(); // need fence before host UVM access of k_rowPtrs_
   }
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
@@ -5507,7 +5514,7 @@ namespace Tpetra {
     }
     // packCrsGraphNew requires k_rowPtrsPacked_ to be set
     else if (! getColMap ().is_null () &&
-        (rowPtrsPacked_dev_.extent (0) != 0 ||
+        (this->getRowPtrsPackedDevice().extent (0) != 0 ||
          getRowMap ()->getLocalNumElements () == 0)) {
       if (verbose) {
         std::ostringstream os;
@@ -5546,7 +5553,7 @@ namespace Tpetra {
   {
     auto col_map = this->getColMap();
     // packCrsGraph requires k_rowPtrsPacked to be set
-    if( !col_map.is_null() && (rowPtrsPacked_dev_.extent(0) != 0  ||  getRowMap()->getLocalNumElements() ==0)) {
+    if( !col_map.is_null() && (this->getRowPtrsPackedDevice().extent(0) != 0  ||  getRowMap()->getLocalNumElements() ==0)) {
       using Tpetra::Details::packCrsGraph;
       packCrsGraph<LocalOrdinal,GlobalOrdinal,Node>(*this, exports, numPacketsPerLID,
                                                     exportLIDs, constantNumPackets);
@@ -7321,9 +7328,6 @@ namespace Tpetra {
     std::swap(graph.importer_, this->importer_);
     std::swap(graph.exporter_, this->exporter_);
 
-    std::swap(graph.rowPtrsPacked_dev_, this->rowPtrsPacked_dev_);
-    std::swap(graph.rowPtrsPacked_host_, this->rowPtrsPacked_host_);
-
     std::swap(graph.nodeMaxNumRowEntries_, this->nodeMaxNumRowEntries_);
 
     std::swap(graph.globalNumEntries_, this->globalNumEntries_);
@@ -7331,8 +7335,13 @@ namespace Tpetra {
 
     std::swap(graph.numAllocForAllRows_, this->numAllocForAllRows_);
 
+    std::swap(graph.rowPtrsPacked_dev_, this->rowPtrsPacked_dev_);
+    std::swap(graph.rowPtrsPacked_host_, this->rowPtrsPacked_host_);
+
     std::swap(graph.rowPtrsUnpacked_dev_, this->rowPtrsUnpacked_dev_);
     std::swap(graph.rowPtrsUnpacked_host_, this->rowPtrsUnpacked_host_);
+    std::swap(graph.packedUnpackedRowPtrsMatch_, this->packedUnpackedRowPtrsMatch_);
+
     std::swap(graph.k_offRankOffsets_, this->k_offRankOffsets_);
 
     std::swap(graph.lclIndsUnpacked_wdv, this->lclIndsUnpacked_wdv);
@@ -7438,12 +7447,11 @@ namespace Tpetra {
     }
 
     // Compare this->k_rowPtrs_ isa Kokkos::View<LocalOrdinal*, ...>
-    output = this->rowPtrsUnpacked_host_.extent(0) == graph.rowPtrsUnpacked_host_.extent(0) ? output : false;
-    if(output && this->rowPtrsUnpacked_host_.extent(0) > 0)
     {
-      auto rowPtrsThis = this->rowPtrsUnpacked_host_;
-      auto rowPtrsGraph = graph.rowPtrsUnpacked_host_;
-      for(size_t i=0; output && i<rowPtrsThis.extent(0); i++)
+      auto rowPtrsThis = this->getRowPtrsUnpackedHost();
+      auto rowPtrsGraph = graph.getRowPtrsUnpackedHost();
+      output = rowPtrsThis .extent(0) == rowPtrsGraph.extent(0) ? output : false;
+      for(size_t i=0; output && i< rowPtrsThis.extent(0); i++)
         output = rowPtrsThis(i) == rowPtrsGraph(i) ? output : false;
     }
 


### PR DESCRIPTION
Lazily copy row pointers from device to host, for both packed and unpacked.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
In CrsGraph, this can avoid an eager host allocation and/or device-to-host copy. It also improves performance on CudaUVMSpace (or any other Kokkos SharedSpace) by using separate allocations for the host and device rowptrs. Since the data is immutable, this is better than having the same memory pages get passed back and forth at each access.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:
-->
## Related Issues

* Closes #11959 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 

## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request