### PR TITLE
Intrepid2: Avoid including `<Kokkos_Vector.hpp>` header

### DIFF
--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_Basis.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_Basis.hpp
@@ -57,9 +57,9 @@
 #include "Intrepid2_BasisValues.hpp"
 #include "Intrepid2_CellTopologyTags.hpp"
 #include "Intrepid2_TensorPoints.hpp"
-#include "Kokkos_Vector.hpp"
 #include "Shards_CellTopology.hpp"
 #include <Teuchos_RCPDecl.hpp>
+#include <Kokkos_Core.hpp>
 
 #include <vector>
 

--- a/packages/intrepid2/src/Shared/Intrepid2_TensorPoints.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_TensorPoints.hpp
@@ -50,7 +50,7 @@
 #ifndef Intrepid2_TensorPoints_h
 #define Intrepid2_TensorPoints_h
 
-#include <Kokkos_Vector.hpp>
+#include <Kokkos_Core.hpp>
 
 namespace Intrepid2 {
 /** \class Intrepid2::TensorPoints

--- a/packages/intrepid2/src/Shared/Intrepid2_TensorViewIterator.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_TensorViewIterator.hpp
@@ -52,7 +52,8 @@
 #include "Intrepid2_DeviceAssert.hpp"
 #include "Intrepid2_ViewIterator.hpp"
 
-#include "Kokkos_Vector.hpp"
+#include <Kokkos_Core.hpp>
+
 #include <vector>
 
 namespace Intrepid2


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@mperego
@ndellingwood 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Kokkos is looking at deprecating `Kokkos::vector` and may want to emit warnings when that header is included.

Moreover, these header includes are unnecessary since `Kokkos::vector` is currently not actually used in Intrepid2 (nor anywhere else in Trilinos as far as I can tell).


<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->
* Related to kokkos/kokkos#6252

## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
N/A

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->

