### PR TITLE
EXODUS: Fix for mpi-io with fixed-length path limit

### DIFF
--- a/packages/seacas/libraries/exodus/src/ex_create_par.c
+++ b/packages/seacas/libraries/exodus/src/ex_create_par.c
@@ -192,10 +192,10 @@ int ex_create_par_int(const char *path, int cmode, int *comp_ws, int *io_ws, MPI
   }
 #endif
 
-  /* There is an issue on some versions of mpi that limit the length of the path to <256 characters
-   * Check for that here and use `path` if `canon_path` is >=256 characters...
+  /* There is an issue on some versions of mpi that limit the length of the path to <250 characters
+   * Check for that here and use `path` if `canon_path` is >=250 characters...
    */
-  if (strlen(canon_path) >= 256) {
+  if (strlen(canon_path) >= 250) {
     status = nc_create_par(path, nc_mode, comm, info, &exoid);
   }
   else {

--- a/packages/seacas/libraries/exodus/src/ex_open_par.c
+++ b/packages/seacas/libraries/exodus/src/ex_open_par.c
@@ -180,10 +180,10 @@ int ex_open_par_int(const char *path, int mode, int *comp_ws, int *io_ws, float 
   else {
     nc_mode = (NC_NOWRITE | NC_SHARE | NC_MPIIO);
   }
-  /* There is an issue on some versions of mpi that limit the length of the path to <256 characters
-   * Check for that here and use `path` if `canon_path` is >=256 characters...
+  /* There is an issue on some versions of mpi that limit the length of the path to <250 characters
+   * Check for that here and use `path` if `canon_path` is >=250 characters...
    */
-  if (strlen(canon_path) >= 256) {
+  if (strlen(canon_path) >= 250) {
     status = nc_open_par(path, nc_mode, comm, info, &exoid);
   }
   else {


### PR DESCRIPTION

@trilinos/seacas 

## Motivation

Some mpi-io implementations have a fixed length maximum of ~256 characters for the filename + path.  They sometimes prepend some other information, so there are cases where the maximum available is ~250 characters.  We are hitting close to those limits on some jenkins or other runs with long paths...

<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->