### PR TITLE
ML: Adding sorting support for Maxwell1

### DIFF
--- a/packages/ml/src/Utils/ml_MultiLevelPreconditioner.cpp
+++ b/packages/ml/src/Utils/ml_MultiLevelPreconditioner.cpp
@@ -2242,8 +2242,10 @@ ComputePreconditioner(const bool CheckPreconditioner)
   if(AMGSolver_ != ML_CLASSICAL_FAMILY) 
     ML_CHK_ERR(SetupCoordinates());
 
-  if (List_.get("RAP: sort columns",0))                                     //
+  if (List_.get("RAP: sort columns",0)) {                                    
+    if (ml_nodes_) ml_nodes_->sortColumnsAfterRAP = 1;
     ml_->sortColumnsAfterRAP = 1;
+  }
   // ========================================================================//
   //               Setting Repartitioning                                    //
   // ========================================================================//


### PR DESCRIPTION
Part of the continuing ML/MueLu harmonization project.  Previously, you couldn't make the nodal aggregation hierarchy sort rows of the coarse A matrices.  This is problematic since Phase 2b aggregation is sensitive to row ordering.  This PR addresses that issue.

Issue: #11214 
Tests: n/a
Stakeholder feedback: n/a