### PR TITLE
Framework: Remove need for source_branch in all PR scripts

### DIFF
--- a/packages/framework/pr_tools/PullRequestLinuxDriver.sh
+++ b/packages/framework/pr_tools/PullRequestLinuxDriver.sh
@@ -172,7 +172,6 @@ print_banner "Launch the Test Driver"
 # Prepare the command for the TEST operation
 test_cmd_options=(
     --source-repo-url=${TRILINOS_SOURCE_REPO:?}
-    --source-branch-name=${TRILINOS_SOURCE_BRANCH:?}
     --target-repo-url=${TRILINOS_TARGET_REPO:?}
     --target-branch-name=${TRILINOS_TARGET_BRANCH:?}
     --pullrequest-build-name=${JOB_BASE_NAME:?}

--- a/packages/framework/pr_tools/PullRequestLinuxDriver.sh
+++ b/packages/framework/pr_tools/PullRequestLinuxDriver.sh
@@ -96,7 +96,6 @@ message_std "PRDriver> " "TRILINOS_SOURCE_SHA: ${TRILINOS_SOURCE_SHA:?}"
 # Prepare the command for the MERGE operation
 merge_cmd_options=(
     ${TRILINOS_SOURCE_REPO:?}
-    ${TRILINOS_SOURCE_BRANCH:?}
     ${TRILINOS_TARGET_REPO:?}
     ${TRILINOS_TARGET_BRANCH:?}
     ${TRILINOS_SOURCE_SHA:?}

--- a/packages/framework/pr_tools/PullRequestLinuxDriverMerge.py
+++ b/packages/framework/pr_tools/PullRequestLinuxDriverMerge.py
@@ -71,9 +71,6 @@ def parseArgs():
     parser.add_argument('sourceRepo',
                         help='Repo with the new changes',
                         action='store')
-    parser.add_argument('sourceBranch',
-                        help='Branch with the new changes',
-                        action='store')
     parser.add_argument('targetRepo',
                         help='Repo to merge into',
                         action='store')
@@ -130,12 +127,11 @@ def check_output_wrapper(args):
     return output
 
 
-def merge_branch(source_url, source_branch, target_branch, sourceSHA):
+def merge_branch(source_url, target_branch, sourceSHA):
     """
     TODO: add docstring.
     """
     source_url    = source_url.strip()
-    source_branch = source_branch.strip()
     target_branch = target_branch.strip()
     sourceSHA     = sourceSHA.strip()
 
@@ -153,7 +149,7 @@ def merge_branch(source_url, source_branch, target_branch, sourceSHA):
     fetch_succeeded = False
     for i in range(3):
         try:
-            check_call_wrapper(['git', 'fetch', 'source_remote', source_branch])
+            check_call_wrapper(['git', 'fetch', 'source_remote', sourceSHA])
             fetch_succeeded = True
             break
         except subprocess.CalledProcessError:
@@ -166,23 +162,7 @@ def merge_branch(source_url, source_branch, target_branch, sourceSHA):
     check_call_wrapper(['git', 'fetch', 'origin', target_branch])
     check_call_wrapper(['git', 'reset', '--hard', 'HEAD'])
     check_call_wrapper(['git', 'checkout', '-B', target_branch, 'origin/' + target_branch])
-    check_call_wrapper(['git', 'merge', '--no-edit', 'source_remote/' + source_branch]),
-
-    actual_source_SHA = check_output_wrapper(['git', 'rev-parse', 'source_remote/' + source_branch])
-
-    if isinstance(actual_source_SHA, bytes):
-        actual_source_SHA = actual_source_SHA.decode('utf-8')
-
-    if isinstance(actual_source_SHA, bytes):
-        actual_source_SHA = actual_source_SHA.decode('utf-8')
-
-    actual_source_SHA = actual_source_SHA.strip()
-
-    if actual_source_SHA != sourceSHA:
-        print_wrapper(f"The SHA ({actual_source_SHA}) for the last commit on branch {source_branch}")
-        print_wrapper(f"in repo {source_url} is different from the expected SHA,")
-        print_wrapper(f"which is: {sourceSHA}.")
-        raise SystemExit(-1)
+    check_call_wrapper(['git', 'merge', '--no-edit', 'source_remote/' + sourceSHA]),
 
     return 0
 
@@ -201,7 +181,6 @@ def run():
         echoJenkinsVars(arguments.workspaceDir)
         try:
             merge_branch(arguments.sourceRepo,
-                         arguments.sourceBranch,
                          arguments.targetBranch,
                          arguments.sourceSHA)
         except SystemExit:

--- a/packages/framework/pr_tools/PullRequestLinuxDriverMerge.py
+++ b/packages/framework/pr_tools/PullRequestLinuxDriverMerge.py
@@ -145,6 +145,10 @@ def merge_branch(source_url, target_branch, sourceSHA):
         check_call_wrapper(['git', 'remote', 'rm', 'source_remote'])
 
     check_call_wrapper(['git', 'remote', 'add', 'source_remote', source_url])
+    check_call_wrapper(['git', 'prune'])
+    if os.path.isfile(os.path.join('.git', 'gc.log')):
+        os.remove(os.path.join('.git', 'gc.log'))
+    check_call_wrapper(['git', 'gc'])
 
     fetch_succeeded = False
     for i in range(3):
@@ -162,7 +166,7 @@ def merge_branch(source_url, target_branch, sourceSHA):
     check_call_wrapper(['git', 'fetch', 'origin', target_branch])
     check_call_wrapper(['git', 'reset', '--hard', 'HEAD'])
     check_call_wrapper(['git', 'checkout', '-B', target_branch, 'origin/' + target_branch])
-    check_call_wrapper(['git', 'merge', '--no-edit', 'source_remote/' + sourceSHA]),
+    check_call_wrapper(['git', 'merge', '--no-edit', sourceSHA]),
 
     return 0
 

--- a/packages/framework/pr_tools/PullRequestLinuxDriverTest.py
+++ b/packages/framework/pr_tools/PullRequestLinuxDriverTest.py
@@ -73,12 +73,6 @@ def parse_args():
                           help='Repo with the new changes',
                           required=True)
 
-    required.add_argument('--source-branch-name',
-                          dest="source_branch_name",
-                          action='store',
-                          help='Branch with the new changes',
-                          required=True)
-
     required.add_argument('--target-repo-url',
                           dest="target_repo_url",
                           action='store',
@@ -250,7 +244,6 @@ def parse_args():
     print("| PullRequestLinuxDriverTest Parameters")
     print("+" + "="*78 + "+")
     print("| - [R] source-repo-url             : {source_repo_url}".format(**vars(arguments)))
-    print("| - [R] source-branch-name          : {source_branch_name}".format(**vars(arguments)))
     print("| - [R] target_repo_url             : {target_repo_url}".format(**vars(arguments)))
     print("| - [R] target_branch_name          : {target_branch_name}".format(**vars(arguments)))
     print("| - [R] pullrequest-build-name      : {pullrequest_build_name}".format(**vars(arguments)))

--- a/packages/framework/pr_tools/PullRequestLinuxDriverTest.py
+++ b/packages/framework/pr_tools/PullRequestLinuxDriverTest.py
@@ -42,7 +42,7 @@ import argparse
 import os
 import sys
 
-#import trilinosprhelpers
+import trilinosprhelpers
 
 
 

--- a/packages/framework/pr_tools/PullRequestLinuxDriverTest.py
+++ b/packages/framework/pr_tools/PullRequestLinuxDriverTest.py
@@ -42,7 +42,7 @@ import argparse
 import os
 import sys
 
-import trilinosprhelpers
+#import trilinosprhelpers
 
 
 

--- a/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
@@ -649,36 +649,6 @@ class TrilinosPRConfigurationBase(object):
         return 0
 
 
-    def validate_branch_constraints(self):
-        """
-        Verify that the source branch is allowed.
-
-        For the `master` branch, we only allow the source branch to be
-        a protected branch named with the scheme `master_merge_YYYYMMDD_HHMMSS`
-        """
-        print("")
-        print("Validate target branch constraints:")
-        print("--- Target branch is '{}'".format(self.args.target_branch_name))
-
-        re_master_merge_source = "master_merge_[0-9]{8}_[0-9]{6}"
-        if "master" == self.args.target_branch_name:
-            print("--- Target branch is 'master'. Checking source branch constraints...")
-            if not re.match(re_master_merge_source, self.args.source_branch_name):
-                message  = "+" + "="*78 + "+\n"
-                message += "ERROR: Source branch is NOT trilinos/Trilinos::master_merge_YYYYMMDD_HHMMSS\n"
-                message += "       This violates Trilinos policy for pull requests into the master\n"
-                message += "       branch.\n"
-                message += "       Source branch provided is {}\n".format(self.args.source_branch_name)
-                message += "       Perhaps you forgot to set `develop` as the target in your PR?\n"
-                message += "+" + "="*78 + "+\n"
-                #print(message)
-                sys.exit(message)
-
-        print("--- target branch constraints OK")
-        print("")
-        return 0
-
-
     def prepare_test(self):
         """
         Prepares a test environment for exeution.
@@ -686,9 +656,6 @@ class TrilinosPRConfigurationBase(object):
         This includes tasks like determining the # of cores to use, setting
         environment variables, loading environment modules, etc.
         """
-        # Validate the branch constraints (i.e., if target_branch_name is master, then
-        # source_branch_name must be master_merge_YYYYMMDD_HHMMSS)
-        self.validate_branch_constraints()
 
         self.message("+" + "-"*78 + "+")
         self.message("Configuration Parameters")

--- a/packages/framework/pr_tools/trilinosprhelpers/jenkinsenv/TrilinosJenkinsEnv.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/jenkinsenv/TrilinosJenkinsEnv.py
@@ -13,11 +13,6 @@ class TrilinosJenkinsEnv(JenkinsEnv):
 
 
     @property
-    def trilinos_source_branch(self):
-        return self.get_envvar_str("TRILINOS_SOURCE_BRANCH", error_if_missing=True)
-
-
-    @property
     def trilinos_source_repo(self):
         return self.get_envvar_str("TRILINOS_SOURCE_REPO", error_if_missing=True)
 

--- a/packages/framework/pr_tools/trilinosprhelpers/jenkinsenv/unittests/test_TrilinosJenkinsEnv.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/jenkinsenv/unittests/test_TrilinosJenkinsEnv.py
@@ -54,7 +54,6 @@ class TrilinosJenkinsEnvTest(TestCase):
     """
     def setUp(self):
 
-        os.environ["TRILINOS_SOURCE_BRANCH"]  = "trilinos_source_branch_value"
         os.environ["TRILINOS_SOURCE_REPO"]    = "trilinos_source_repo_value"
         os.environ["TRILINOS_SOURCE_SHA"]     = "trilinos_source_sha_value"
         os.environ["TRILINOS_TARGET_BRANCH"]  = "trilinos_target_branch_value"
@@ -78,11 +77,6 @@ class TrilinosJenkinsEnvTest(TestCase):
         del os.environ["PULLREQUEST_CDASH_TRACK"]
         del os.environ["FORCE_CLEAN"]
 
-
-
-    def test_trilinos_source_branch(self):
-        value = self._envvar_helper.trilinos_source_branch
-        self.assertEqual(value, "trilinos_source_branch_value")
 
 
     def test_trilinos_source_repo(self):

--- a/packages/framework/pr_tools/trilinosprhelpers/jenkinsenv/unittests/test_TrilinosJenkinsEnv.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/jenkinsenv/unittests/test_TrilinosJenkinsEnv.py
@@ -67,7 +67,6 @@ class TrilinosJenkinsEnvTest(TestCase):
 
 
     def tearDown(self):
-        del os.environ["TRILINOS_SOURCE_BRANCH"]
         del os.environ["TRILINOS_SOURCE_REPO"]
         del os.environ["TRILINOS_SOURCE_SHA"]
         del os.environ["TRILINOS_TARGET_BRANCH"]

--- a/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationBase.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationBase.py
@@ -165,7 +165,6 @@ class TrilinosPRConfigurationTest(unittest.TestCase):
     Test TrilinsoPRConfigurationBase class
     """
     def setUp(self):
-        #os.environ["TRILINOS_SOURCE_BRANCH"]  = "trilinos_source_branch_value"
         #os.environ["TRILINOS_SOURCE_REPO"]    = "trilinos_source_repo_value"
         #os.environ["TRILINOS_SOURCE_SHA"]     = "trilinos_source_sha_value"
         #os.environ["TRILINOS_TARGET_BRANCH"]  = "trilinos_target_branch_value"
@@ -209,7 +208,6 @@ class TrilinosPRConfigurationTest(unittest.TestCase):
         """
         output = argparse.Namespace(
             source_repo_url="https://github.com/trilinos/Trilinos",
-            source_branch_name="source_branch_name",
             target_repo_url="https://github.com/trilinos/Trilinos",
             target_branch_name="develop",
             pullrequest_build_name="Trilinos-pullrequest-gcc-7.2.0",
@@ -275,7 +273,6 @@ class TrilinosPRConfigurationTest(unittest.TestCase):
         """
         args = copy.deepcopy(self.dummy_args())
         args.target_branch_name = "master"
-        args.source_branch_name = "master_merge_20200101_000000"
         return args
 
 
@@ -286,7 +283,6 @@ class TrilinosPRConfigurationTest(unittest.TestCase):
         """
         args = copy.deepcopy(self.dummy_args())
         args.target_branch_name = "master"
-        args.source_branch_name = "invalid_source_branch_name"
         return args
 
 

--- a/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationBase.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationBase.py
@@ -322,28 +322,6 @@ class TrilinosPRConfigurationTest(unittest.TestCase):
         self.assertEqual(pr_config.concurrency_test, 3)
 
 
-    def test_TrilinosPRConfigurationValidateBranchNameDevelop(self):
-        args = self.dummy_args()
-        pr_config = trilinosprhelpers.TrilinosPRConfigurationBase(args)
-        pr_config.validate_branch_constraints()
-
-
-    def test_TrilinosPRConfigurationValidateBranchNameMasterPASS(self):
-        args = self.dummy_args_master_pass()
-        pr_config = trilinosprhelpers.TrilinosPRConfigurationBase(args)
-        pr_config.validate_branch_constraints()
-
-
-    def test_TrilinosPRConfigurationValidateBranchNameMasterFAIL(self):
-        args = self.dummy_args_master_fail()
-        pr_config = trilinosprhelpers.TrilinosPRConfigurationBase(args)
-        with patch('sys.stdout', new=StringIO()) as fake_out:
-            with patch('sys.exit', side_effect=mock_early_return) as m:
-                pr_config.validate_branch_constraints()
-                m.assert_called_once()
-                self.assertTrue( "ERROR:" in fake_out.getvalue())
-
-
     def test_TrilinosPRConfigurationCDashTrack(self):
         args = self.dummy_args_python3()
         pr_config = trilinosprhelpers.TrilinosPRConfigurationBase(args)

--- a/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationInstallation.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationInstallation.py
@@ -151,7 +151,6 @@ class TrilinosPRConfigurationInstallationTest(TestCase):
         """
         output = argparse.Namespace(
             source_repo_url="https://github.com/trilinos/Trilinos",
-            source_branch_name="source_branch_name",
             target_repo_url="https://github.com/trilinos/Trilinos",
             target_branch_name="develop",
             pullrequest_build_name="Trilinos-pullrequest-gcc-8.3.0-installation-testing",

--- a/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationStandard.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationStandard.py
@@ -148,7 +148,6 @@ class TrilinosPRConfigurationStandardTest(TestCase):
         """
         output = argparse.Namespace(
             source_repo_url="https://github.com/trilinos/Trilinos",
-            source_branch_name="source_branch_name",
             target_repo_url="https://github.com/trilinos/Trilinos",
             target_branch_name="develop",
             pullrequest_build_name="Trilinos-pullrequest-gcc-7.2.0",

--- a/packages/framework/pr_tools/unittests/test_PullRequestLinuxDriverMerge.py
+++ b/packages/framework/pr_tools/unittests/test_PullRequestLinuxDriverMerge.py
@@ -241,38 +241,6 @@ class Test_mergeBranch(unittest.TestCase):
         return
 
 
-    @patch('subprocess.check_output', side_effect=['origin /dev/null/target/Trilinos', 'df324ae'])
-    @patch('subprocess.check_call')
-    def test_mergeBranch_fails_on_SHA_mismatch(self, m_check_call, m_check_out):
-        """
-        Test that ``merge_branch`` will fail if a SHA mismatch detected.
-        """
-        with self.assertRaises(SystemExit):
-            with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
-                tmp_path = os.path.join(os.path.sep, 'dev', 'null', 'source', 'Trilinos.git')
-                PRMerge.merge_branch(tmp_path, 'neverland', 'fake_develop', 'foobar')
-
-        expected_calls = []
-        expected_calls.append( mock.call(['git', 'remote', '-v']) )
-        m_check_out.assert_has_calls(expected_calls)
-
-        expected_calls = []
-        expected_calls.append(mock.call(['git', 'remote', 'add', 'source_remote', '/dev/null/source/Trilinos.git']))
-        expected_calls.append(mock.call(['git', 'fetch', 'source_remote', 'neverland']))
-        m_check_call.assert_has_calls(expected_calls)
-
-        stdout_actual     = m_stdout.getvalue()
-        stdout_expected_1 = "The SHA (df324ae) for the last commit on branch neverland"
-        stdout_expected_2 = "is different from the expected SHA"
-        stdout_expected_3 = "which is: foobar"
-
-        self.assertIn(stdout_expected_1, stdout_actual)
-        self.assertIn(stdout_expected_2, stdout_actual)
-        self.assertIn(stdout_expected_3, stdout_actual)
-
-        return
-
-
 
 class Test_run(unittest.TestCase):
     '''This is the main function that ties everything together in order'''

--- a/packages/framework/pr_tools/unittests/test_PullRequestLinuxDriverMerge.py
+++ b/packages/framework/pr_tools/unittests/test_PullRequestLinuxDriverMerge.py
@@ -123,7 +123,8 @@ class Test_parsing(unittest.TestCase):
     def test_parseInsufficientArgs_fails(self):
         test_namespace = Namespace()
         setattr(test_namespace, 'sourceRepo', '/dev/null/source/Trilinos.git')
-        expected_output = '''usage: programName [-h] sourceRepo targetRepo targetBranch sourceSHA workspaceDir
+        expected_output = '''usage: programName [-h]
+                   sourceRepo targetRepo targetBranch sourceSHA workspaceDir
 programName: error: the following arguments are required: sourceRepo, \
 targetRepo, targetBranch, sourceSHA, workspaceDir
 '''

--- a/packages/framework/pr_tools/unittests/test_PullRequestLinuxDriverMerge.py
+++ b/packages/framework/pr_tools/unittests/test_PullRequestLinuxDriverMerge.py
@@ -92,7 +92,6 @@ class Test_parsing(unittest.TestCase):
     def test_parseArgs(self):
         test_namespace = Namespace()
         setattr(test_namespace, 'sourceRepo', '/dev/null/source/Trilinos.git')
-        setattr(test_namespace, 'sourceBranch', 'fake_test_branch_fixing_issue_neverland')
         setattr(test_namespace, 'targetRepo', '/dev/null/target/Trilinos.git')
         setattr(test_namespace, 'targetBranch', 'fake_develop')
         setattr(test_namespace, 'sourceSHA', '0123456789abcdef')
@@ -104,7 +103,6 @@ class Test_parsing(unittest.TestCase):
                                                           'null',
                                                           'source',
                                                           'Trilinos.git'),
-                                             'fake_test_branch_fixing_issue_neverland',
                                              os.path.join(os.path.sep,
                                                           'dev',
                                                           'null',
@@ -126,14 +124,14 @@ class Test_parsing(unittest.TestCase):
         test_namespace = Namespace()
         setattr(test_namespace, 'sourceRepo', '/dev/null/source/Trilinos.git')
         expected_output = '''usage: programName [-h]
-                   sourceRepo sourceBranch targetRepo targetBranch sourceSHA
+                   sourceRepo targetRepo targetBranch sourceSHA
                    workspaceDir
 programName: error: the following arguments are required: sourceRepo, \
 sourceBranch, targetRepo, targetBranch, sourceSHA, workspaceDir
 '''
         if sys.version_info.major != 3:
             expected_output = '''usage: programName [-h]
-                   sourceRepo sourceBranch targetRepo targetBranch sourceSHA
+                   sourceRepo targetRepo targetBranch sourceSHA
                    workspaceDir\nprogramName: error: too few arguments
 '''
         with mock.patch.object(sys, 'argv', ['programName']), \
@@ -161,28 +159,19 @@ class Test_mergeBranch(unittest.TestCase):
                                                                   'null',
                                                                   'source',
                                                                   'Trilinos.git'),
-                                                    'neverland',
                                                     'fake_develop',
                                                     'df324ae')
         m_check_out.assert_has_calls([mock.call(['git', 'remote', '-v']),
                                       mock.call(['git', 'rev-parse',
                                                  'source_remote/neverland'])])
 
-        m_check_call.assert_has_calls([mock.call(['git', 'remote', 'add',
-                                                 'source_remote',
-                                                 '/dev/null/source/Trilinos.git']),
-                                       mock.call(['git', 'fetch', 'source_remote',
-                                                  'neverland']),
-                                       mock.call(['git', 'fetch', 'origin',
-                                                  'fake_develop']),
-                                       mock.call(['git', 'reset', '--hard',
-                                                  'HEAD']),
-                                       mock.call(['git', 'checkout',
-                                                  '-B', 'fake_develop',
-                                                  'origin/fake_develop']),
-                                       mock.call(['git', 'merge',
-                                                  '--no-edit',
-                                                  'source_remote/neverland']),
+        m_check_call.assert_has_calls([mock.call(['git', 'remote', 'add', 'source_remote', '/dev/null/source/Trilinos.git']),
+                                       mock.call(['git', 'fetch', 'source_remote', 'df324ae']),
+                                       mock.call(['git', 'prune']),
+                                       mock.call(['git', 'gc']),
+                                       mock.call(['git', 'reset', '--hard', 'HEAD']),
+                                       mock.call(['git', 'checkout', '-B', 'fake_develop', 'origin/fake_develop']),
+                                       mock.call(['git', 'merge', '--no-edit', 'df324ae']),
                                        ])
         return
 
@@ -198,7 +187,7 @@ class Test_mergeBranch(unittest.TestCase):
 
         with mock.patch('subprocess.check_output', side_effect=side_effect_list) as m_check_out:
             with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
-                PRMerge.merge_branch(tmp_path, 'neverland', 'fake_develop', 'df324ae')
+                PRMerge.merge_branch(tmp_path, 'fake_develop', 'df324ae')
 
         expected_calls = []
         expected_calls.append( mock.call(['git', 'remote', '-v']) )
@@ -207,11 +196,13 @@ class Test_mergeBranch(unittest.TestCase):
 
         m_check_call.assert_has_calls([mock.call(['git', 'remote', 'rm', 'source_remote']),
                                        mock.call(['git', 'remote', 'add', 'source_remote', '/dev/null/source/Trilinos.git']),
-                                       mock.call(['git', 'fetch', 'source_remote', 'neverland']),
+                                       mock.call(['git', 'fetch', 'source_remote', 'df324ae']),
+                                       mock.call(['git', 'prune']),
+                                       mock.call(['git', 'gc']),
                                        mock.call(['git', 'fetch', 'origin', 'fake_develop']),
                                        mock.call(['git', 'reset', '--hard', 'HEAD']),
                                        mock.call(['git', 'checkout', '-B', 'fake_develop', 'origin/fake_develop']),
-                                       mock.call(['git', 'merge', '--no-edit', 'source_remote/neverland']),
+                                       mock.call(['git', 'merge', '--no-edit', 'df324ae']),
                                        ])
         self.assertIn("git remote exists, removing it", m_stdout.getvalue())
         return
@@ -234,7 +225,7 @@ class Test_mergeBranch(unittest.TestCase):
 
         with self.assertRaises(SystemExit):
             with mock.patch('subprocess.check_call', side_effect=side_effect_list) as m_check_call:
-                PRMerge.merge_branch(tmp_path, 'neverland', 'fake_develop', 'df324ae')
+                PRMerge.merge_branch(tmp_path, 'fake_develop', 'df324ae')
 
         expected_calls = []
         expected_calls.append(mock.call(['git', 'remote', '-v']))
@@ -242,9 +233,9 @@ class Test_mergeBranch(unittest.TestCase):
 
         expected_calls = []
         expected_calls.append(mock.call(['git', 'remote', 'add', 'source_remote', '/dev/null/source/Trilinos.git']))
-        expected_calls.append(mock.call(['git', 'fetch', 'source_remote', 'neverland']))
-        expected_calls.append(mock.call(['git', 'fetch', 'source_remote', 'neverland']))
-        expected_calls.append(mock.call(['git', 'fetch', 'source_remote', 'neverland']))
+        expected_calls.append(mock.call(['git', 'fetch', 'source_remote', 'df324ae']))
+        expected_calls.append(mock.call(['git', 'fetch', 'source_remote', 'df324ae']))
+        expected_calls.append(mock.call(['git', 'fetch', 'source_remote', 'df324ae']))
         m_check_call.assert_has_calls(expected_calls)
 
         return

--- a/packages/framework/pr_tools/unittests/test_PullRequestLinuxDriverTest.py
+++ b/packages/framework/pr_tools/unittests/test_PullRequestLinuxDriverTest.py
@@ -48,7 +48,6 @@ class Test_parse_args(unittest.TestCase):
                                                                    'dev',
                                                                    'null',
                                                                    'source_repo'),
-                                                      '--source-branch-name', 'foobar',
                                                       '--target-repo-url',
                                                       os.path.join(os.path.sep,
                                                                    'dev',
@@ -63,7 +62,6 @@ class Test_parse_args(unittest.TestCase):
                                                       '--jenkins-job-number', '2424'])
 
         self.default_options = Namespace(source_repo_url='/dev/null/source_repo',
-                                         source_branch_name='foobar',
                                          target_repo_url='/dev/null/target_repo',
                                          target_branch_name='real_trash',
                                          pullrequest_build_name='Some_odd_compiler',
@@ -89,7 +87,6 @@ class Test_parse_args(unittest.TestCase):
 
         self.default_stdout = dedent('''\
                 | - [R] source-repo-url             : /dev/null/source_repo
-                | - [R] source-branch-name          : foobar
                 | - [R] target_repo_url             : /dev/null/target_repo
                 | - [R] target_branch_name          : real_trash
                 | - [R] pullrequest-build-name      : Some_odd_compiler
@@ -115,8 +112,7 @@ class Test_parse_args(unittest.TestCase):
                 ''')
 
         self.help_output = dedent('''\
-                usage: programName [-h] --source-repo-url SOURCE_REPO_URL --source-branch-name
-                                   SOURCE_BRANCH_NAME --target-repo-url TARGET_REPO_URL
+                usage: programName [-h] --source-repo-url SOURCE_REPO_URL --target-repo-url TARGET_REPO_URL
                                    --target-branch-name TARGET_BRANCH_NAME
                                    --pullrequest-build-name PULLREQUEST_BUILD_NAME
                                    --genconfig-build-name GENCONFIG_BUILD_NAME
@@ -145,8 +141,6 @@ class Test_parse_args(unittest.TestCase):
                 Required Arguments:
                   --source-repo-url SOURCE_REPO_URL
                                         Repo with the new changes
-                  --source-branch-name SOURCE_BRANCH_NAME
-                                        Branch with the new changes
                   --target-repo-url TARGET_REPO_URL
                                         Repo to merge into
                   --target-branch-name TARGET_BRANCH_NAME
@@ -218,8 +212,7 @@ class Test_parse_args(unittest.TestCase):
                 ''')
 
         self.usage_output = dedent('''\
-                usage: programName [-h] --source-repo-url SOURCE_REPO_URL --source-branch-name
-                                   SOURCE_BRANCH_NAME --target-repo-url TARGET_REPO_URL
+                usage: programName [-h] --source-repo-url SOURCE_REPO_URL --target-repo-url TARGET_REPO_URL
                                    --target-branch-name TARGET_BRANCH_NAME
                                    --pullrequest-build-name PULLREQUEST_BUILD_NAME
                                    --genconfig-build-name GENCONFIG_BUILD_NAME
@@ -239,7 +232,7 @@ class Test_parse_args(unittest.TestCase):
                                    [--max-cores-allowed MAX_CORES_ALLOWED]
                                    [--num-concurrent-tests NUM_CONCURRENT_TESTS]
                                    [--enable-ccache] [--dry-run]
-                programName: error: the following arguments are required: --source-repo-url, --source-branch-name, --target-repo-url, --target-branch-name, --pullrequest-build-name, --genconfig-build-name, --pullrequest-number, --jenkins-job-number
+                programName: error: the following arguments are required: --source-repo-url, --target-repo-url, --target-branch-name, --pullrequest-build-name, --genconfig-build-name, --pullrequest-number, --jenkins-job-number
                 ''')
 
         self.m_cwd = mock.patch('PullRequestLinuxDriverTest.os.getcwd',

--- a/packages/framework/pr_tools/unittests/test_PullRequestLinuxDriverTest.py
+++ b/packages/framework/pr_tools/unittests/test_PullRequestLinuxDriverTest.py
@@ -24,6 +24,7 @@ try:
 except ImportError:  # pragma nocover
     import unittest.mock as mock
 
+import re
 
 from argparse import Namespace
 
@@ -301,7 +302,7 @@ class Test_parse_args(unittest.TestCase):
         with mock.patch.object(sys, 'argv', ['programName', '--usage']), self.assertRaises(SystemExit), self.stderrRedirect as m_stderr:
             PullRequestLinuxDriverTest.parse_args()
 
-        self.assertIn(self.usage_output, m_stderr.getvalue())
+        self.assertEqual(re.sub("\s+", " ", self.usage_output, flags=re.DOTALL), re.sub("\s+", " ", m_stderr.getvalue(), flags=re.DOTALL))
         return
 
 

--- a/packages/framework/pr_tools/unittests/test_PullRequestLinuxDriverTest.py
+++ b/packages/framework/pr_tools/unittests/test_PullRequestLinuxDriverTest.py
@@ -112,8 +112,8 @@ class Test_parse_args(unittest.TestCase):
                 ''')
 
         self.help_output = dedent('''\
-                usage: programName [-h] --source-repo-url SOURCE_REPO_URL --target-repo-url TARGET_REPO_URL
-                                   --target-branch-name TARGET_BRANCH_NAME
+                usage: programName [-h] --source-repo-url SOURCE_REPO_URL --target-repo-url
+                                   TARGET_REPO_URL --target-branch-name TARGET_BRANCH_NAME
                                    --pullrequest-build-name PULLREQUEST_BUILD_NAME
                                    --genconfig-build-name GENCONFIG_BUILD_NAME
                                    --pullrequest-number PULLREQUEST_NUMBER


### PR DESCRIPTION
Won't have access to source_branch any more.

Switch to sha-based merging (not a big deal probably) to do the testing.

Remove the checks around what branches can/cannot be merged to master branch (github rules should take care of this automatically by only allowing the automated system to merge into master branch).

Also removed check for branch tip != SHA1, because that's not possible if we only use the SHA1.  The thing that cancels PR runs and makes you run a new one if it finds changes on the branch after a run starts should handle this issue.

User Support Ticket(s) or Story Referenced: TRILFRAME-573

@trilinos/framework 

## Motivation
New autotester is changing its interface a bit, and want to be ready for when it rolls out.
