### PR TITLE
EXODUS: Need to check whether nc_def_var_fill is defined in netCDF

### DIFF
--- a/packages/seacas/libraries/exodus/include/exodusII.h
+++ b/packages/seacas/libraries/exodus/include/exodusII.h
@@ -52,12 +52,12 @@
 #endif
 
 /* EXODUS version number */
-#define EXODUS_VERSION       "8.22"
+#define EXODUS_VERSION       "8.23"
 #define EXODUS_VERSION_MAJOR 8
-#define EXODUS_VERSION_MINOR 22
-#define EXODUS_RELEASE_DATE  "June 5, 2023"
+#define EXODUS_VERSION_MINOR 23
+#define EXODUS_RELEASE_DATE  "July 13, 2023"
 
-#define EX_API_VERS       8.22f
+#define EX_API_VERS       8.23f
 #define EX_API_VERS_NODOT (100 * EXODUS_VERSION_MAJOR + EXODUS_VERSION_MINOR)
 #define EX_VERS           EX_API_VERS
 

--- a/packages/seacas/libraries/exodus/include/exodusII_int.h
+++ b/packages/seacas/libraries/exodus/include/exodusII_int.h
@@ -65,6 +65,10 @@
 extern "C" {
 #endif
 
+#if NC_VERSION_MAJOR > 4 || (NC_VERSION_MAJOR == 4 && NC_VERSION_MINOR >= 6) || NC_HAS_HDF5
+#define EX_CAN_USE_NC_DEF_VAR_FILL 1
+#endif
+
 /**
  * \defgroup Internal Internal Functions and Defines
  * \internal

--- a/packages/seacas/libraries/exodus/src/ex__put_homogenous_block_params.c
+++ b/packages/seacas/libraries/exodus/src/ex__put_homogenous_block_params.c
@@ -280,8 +280,10 @@ int ex__put_homogenous_block_params(int exoid, size_t block_count, const struct 
         ex_err_fn(exoid, __func__, errmsg, status);
         goto error_ret; /* exit define mode and return */
       }
+#if defined(EX_CAN_USE_NC_DEF_VAR_FILL)
       int fill = NC_FILL_CHAR;
       nc_def_var_fill(exoid, att_name_varid, 0, &fill);
+#endif
     }
 
     int conn_int_type = NC_INT;

--- a/packages/seacas/libraries/exodus/src/ex_put_all_var_param_ext.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_all_var_param_ext.c
@@ -382,8 +382,10 @@ static int define_variable_name_variable(int exoid, const char *VARIABLE, int di
     }
   }
   ex__set_compact_storage(exoid, variable);
+#if defined(EX_CAN_USE_NC_DEF_VAR_FILL)
   int fill = NC_FILL_CHAR;
   nc_def_var_fill(exoid, variable, 0, &fill);
+#endif
   return (status);
 }
 

--- a/packages/seacas/libraries/exodus/src/ex_put_attr_param.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_attr_param.c
@@ -193,8 +193,10 @@ int ex_put_attr_param(int exoid, ex_entity_type obj_type, ex_entity_id obj_id, i
     ex_err_fn(exoid, __func__, errmsg, status);
     goto error_ret; /* exit define mode and return */
   }
+#if defined(EX_CAN_USE_NC_DEF_VAR_FILL)
   int fill = NC_FILL_CHAR;
   nc_def_var_fill(exoid, varid, 0, &fill);
+#endif
 
   /* leave define mode  */
   if ((status = ex__leavedef(exoid, __func__)) != NC_NOERR) {

--- a/packages/seacas/libraries/exodus/src/ex_put_block_params.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_block_params.c
@@ -400,8 +400,10 @@ int ex_put_block_params(int exoid, size_t block_count, const struct ex_block *bl
         ex_err_fn(exoid, __func__, errmsg, status);
         goto error_ret; /* exit define mode and return */
       }
+#if defined(EX_CAN_USE_NC_DEF_VAR_FILL)
       int fill = NC_FILL_CHAR;
       nc_def_var_fill(exoid, att_name_varid, 0, &fill);
+#endif
     }
 
     conn_int_type = NC_INT;

--- a/packages/seacas/libraries/exodus/src/ex_put_concat_all_blocks.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_concat_all_blocks.c
@@ -211,7 +211,7 @@ int ex_put_concat_all_blocks(int exoid, const ex_block_params *param)
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
-#if NC_HAS_HDF5
+#if defined(EX_CAN_USE_NC_DEF_VAR_FILL)
 #define EX_PREPARE_ATTRIB_ARRAY(TNAME, CURBLK, DNAME, DVAL, ID, VANAME, VADIM0, VADIM1, VANNAME)   \
   if (DVAL[iblk] > 0) {                                                                            \
     if ((status = nc_def_dim(exoid, DNAME(CURBLK + 1), DVAL[iblk], &VADIM1)) != NC_NOERR) {        \

--- a/packages/seacas/libraries/exodus/src/ex_put_concat_elem_block.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_concat_elem_block.c
@@ -271,8 +271,10 @@ int ex_put_concat_elem_block(int exoid, const void_int *elem_blk_id, char *const
         ex_err_fn(exoid, __func__, errmsg, status);
         goto error_ret; /* exit define mode and return */
       }
+#if defined(EX_CAN_USE_NC_DEF_VAR_FILL)
       int fill = NC_FILL_CHAR;
       nc_def_var_fill(exoid, temp, 0, &fill);
+#endif
       eb_array[iblk] = temp;
 
       dims[0] = numelbdim;

--- a/packages/seacas/libraries/exodus/src/ex_put_init_ext.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_init_ext.c
@@ -58,8 +58,10 @@ static int ex_write_object_names(int exoid, const char *type, const char *dimens
       return (status); /* exit define mode and return */
     }
     ex__set_compact_storage(exoid, varid);
+#if defined(EX_CAN_USE_NC_DEF_VAR_FILL)
     int fill = NC_FILL_CHAR;
     nc_def_var_fill(exoid, varid, 0, &fill);
+#endif
   }
   return (NC_NOERR);
 }

--- a/packages/seacas/libraries/exodus/src/ex_put_map_param.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_map_param.c
@@ -116,8 +116,10 @@ int ex_put_map_param(int exoid, int num_node_maps, int num_elem_maps)
         ex_err_fn(exoid, __func__, errmsg, status);
         goto error_ret; /* exit define mode and return */
       }
+#if defined(EX_CAN_USE_NC_DEF_VAR_FILL)
       int fill = NC_FILL_CHAR;
       nc_def_var_fill(exoid, varid, 0, &fill);
+#endif
 
       /* determine number of nodes */
       if ((status = nc_inq_dimid(exoid, DIM_NUM_NODES, &dimid)) != NC_NOERR) {
@@ -185,9 +187,10 @@ int ex_put_map_param(int exoid, int num_node_maps, int num_elem_maps)
         ex_err_fn(exoid, __func__, errmsg, status);
         goto error_ret; /* exit define mode and return */
       }
+#if defined(EX_CAN_USE_NC_DEF_VAR_FILL)
       int fill = NC_FILL_CHAR;
       nc_def_var_fill(exoid, varid, 0, &fill);
-
+#endif
       /* determine number of elements */
       if ((status = nc_inq_dimid(exoid, DIM_NUM_ELEM, &dimid)) != NC_NOERR) {
         snprintf(errmsg, MAX_ERR_LENGTH,

--- a/packages/seacas/libraries/exodus/src/ex_put_reduction_variable_param.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_reduction_variable_param.c
@@ -59,8 +59,10 @@ static int ex__prepare_result_var(int exoid, int num_vars, char *type_name, char
     }
     return (EX_FATAL); /* exit define mode and return */
   }
+#if defined(EX_CAN_USE_NC_DEF_VAR_FILL)
   int fill = NC_FILL_CHAR;
   nc_def_var_fill(exoid, varid, 0, &fill);
+#endif
   return (EX_NOERR);
 }
 /*! \endcond */

--- a/packages/seacas/libraries/exodus/src/ex_put_variable_param.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_variable_param.c
@@ -61,7 +61,9 @@ static int ex_prepare_result_var(int exoid, int num_vars, char *type_name, char 
     return (EX_FATAL); /* exit define mode and return */
   }
   ex__set_compact_storage(exoid, varid);
+#if defined(EX_CAN_USE_NC_DEF_VAR_FILL)
   nc_def_var_fill(exoid, varid, 0, &fill);
+#endif
   return (EX_NOERR);
 }
 /*! \endcond */


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/seacas

## Motivation
There are some older versions of netCDF that do not include the `nc_def_var_fill` call.  To avoid breaking the builds
of people using those versions, made the recent change that called that function only present if the netcdf library has the call enabled.

<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->