### PR TITLE
Sacado: Fix subview() for LayoutContiguous<LayoutLeft> views

### DIFF
--- a/packages/sacado/src/KokkosExp_View_Fad_Contiguous.hpp
+++ b/packages/sacado/src/KokkosExp_View_Fad_Contiguous.hpp
@@ -1639,13 +1639,13 @@ private:
       ( /* Same array layout IF */
         ( rank == 0 ) /* output rank zero */
         ||
-        // OutputRank 1 or 2, InputLayout Left, Interval 0
-        // because single stride one or second index has a stride.
-        ( rank <= 2 && R0 && std::is_same< typename SrcTraits::array_layout , Kokkos::LayoutLeft >::value )
+        // OutputRank 1, InputLayout Left, Interval 0
+        // because single stride one
+        ( rank <= 1 && R0 && std::is_same< typename SrcTraits::array_layout , Kokkos::LayoutLeft >::value )
         ||
-        // OutputRank 1 or 2, InputLayout Right, Interval [InputRank-1]
-        // because single stride one or second index has a stride.
-        ( rank <= 2 && R0_rev && std::is_same< typename SrcTraits::array_layout , Kokkos::LayoutRight >::value )
+        // OutputRank 1, InputLayout Right, Interval [InputRank-1]
+        // because single stride one
+        ( rank <= 1 && R0_rev && std::is_same< typename SrcTraits::array_layout , Kokkos::LayoutRight >::value )
         ), typename SrcTraits::array_layout , Kokkos::LayoutContiguous<Kokkos::LayoutStride,SrcTraits::array_layout::scalar_stride>
       >::type array_layout ;
 
@@ -1699,8 +1699,35 @@ public:
                                    , array_extents.domain_offset(5)
                                    , array_extents.domain_offset(6)
                                    , array_extents.domain_offset(7) );
-        dst.m_array_offset = dst_array_offset_type( src.m_array_offset ,
-                                                    array_extents );
+        dst_array_offset_type dst_array_offset( src.m_array_offset ,
+                                                array_extents );
+        // For LayoutStride, we always use LayoutRight indexing (because we
+        // don't know whether the original array was Left or Right), so we
+        // need to swap the Fad dimension to the last and shift all of the
+        // other dimensions left by 1
+        if constexpr(std::is_same<typename traits_type::array_layout, LayoutStride>::value)
+        {
+          Kokkos::LayoutStride ls(
+            dst_array_offset.m_dim.N0, dst_array_offset.m_stride.S0,
+            dst_array_offset.m_dim.N1, dst_array_offset.m_stride.S1,
+            dst_array_offset.m_dim.N2, dst_array_offset.m_stride.S2,
+            dst_array_offset.m_dim.N3, dst_array_offset.m_stride.S3,
+            dst_array_offset.m_dim.N4, dst_array_offset.m_stride.S4,
+            dst_array_offset.m_dim.N5, dst_array_offset.m_stride.S5,
+            dst_array_offset.m_dim.N6, dst_array_offset.m_stride.S6,
+            dst_array_offset.m_dim.N7, dst_array_offset.m_stride.S7);
+          auto t1 = ls.dimension[0];
+          for (unsigned i=0; i<rank; ++i)
+            ls.dimension[i] = ls.dimension[i+1];
+          ls.dimension[rank] = t1;
+          auto t2 = ls.stride[0];
+          for (unsigned i=0; i<rank; ++i)
+            ls.stride[i] = ls.stride[i+1];
+          ls.stride[rank] = t2;
+          dst.m_array_offset = dst_array_offset_type(std::integral_constant<unsigned, 0>(), ls);
+        }
+        else
+          dst.m_array_offset = dst_array_offset;
       }
       else {
         const SubviewExtents< SrcTraits::rank + 1 , rank + 1 >

--- a/packages/sacado/src/Kokkos_DynRankView_Fad_Contiguous.hpp
+++ b/packages/sacado/src/Kokkos_DynRankView_Fad_Contiguous.hpp
@@ -751,7 +751,7 @@ public:
                         src.m_map.m_impl_offset.layout() );
 
       dst.m_map.m_impl_handle = src.m_map.m_impl_handle ;
-      dst.m_rank = src.Rank ;
+      dst.m_rank = src.rank ;
 
       dst.m_map.m_fad_size = src.m_map.m_fad_size ;
       dst.m_map.m_original_fad_size = src.m_map.m_original_fad_size;
@@ -824,7 +824,7 @@ public:
       dst.m_map.m_impl_offset.m_stride = src.m_map.m_array_offset.m_stride ;
 
       dst.m_map.m_impl_handle = src.m_map.m_impl_handle ;
-      dst.m_rank = src.Rank ;
+      dst.m_rank = src.rank ;
     }
 };
 

--- a/packages/sacado/test/UnitTests/Fad_KokkosTests.hpp
+++ b/packages/sacado/test/UnitTests/Fad_KokkosTests.hpp
@@ -361,9 +361,9 @@ struct AssignRank2Rank1Kernel {
                          const OutputViewType v2,
                          const size_type col) :
     m_v1(v1), m_v2(v2), m_col(col) {
-    static_assert( unsigned(InputViewType::Rank) == 2 ,
+    static_assert( unsigned(InputViewType::rank) == 2 ,
                    "Require rank-2 input view" );
-    static_assert( unsigned(OutputViewType::Rank) == 1 ,
+    static_assert( unsigned(OutputViewType::rank) == 1 ,
                    "Require rank-1 output view" );
   };
 

--- a/packages/sacado/test/UnitTests/Fad_KokkosTests.hpp
+++ b/packages/sacado/test/UnitTests/Fad_KokkosTests.hpp
@@ -1693,6 +1693,119 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
   }
 }
 
+TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
+  Kokkos_View_Fad, Subview2, FadType, Layout, Device )
+{
+  typedef Kokkos::View<FadType***,Layout,Device> ViewType;
+  typedef typename ViewType::HostMirror host_view_type;
+
+  // Test various subview operations to check the resulting indexing is correct.
+  // We only need to run these tests on the host because the indexing does
+  // not depend on the device.
+
+  const int num_cell = 5;
+  const int num_qp = 4;
+  const int num_dim = 3;
+  const int num_deriv = 2;
+
+  // Create and fill view
+  host_view_type v;
+#if defined (SACADO_DISABLE_FAD_VIEW_SPEC)
+  v = host_view_type ("view", num_cell, num_qp, num_dim);
+#else
+  v = host_view_type ("view", num_cell, num_qp, num_dim, num_deriv+1);
+#endif
+  for (int cell=0; cell < num_cell; ++cell) {
+    for (int qp=0; qp < num_qp; ++qp) {
+      for (int dim = 0; dim < num_dim; ++dim) {
+        v(cell,qp,dim).val() = 100.*cell + 10.*qp + 1.*dim;
+        for (int deriv = 0; deriv < num_deriv; ++deriv) {
+          v(cell,qp,dim).fastAccessDx(deriv) = v(cell,qp,dim).val() + (1.0*deriv)/10.;
+        }
+      }
+    }
+  }
+
+  success = true;
+
+  out << "checking subview(v,ALL,*,*)..." << std::endl;
+  for (int qp=0; qp < num_qp; ++qp) {
+    for (int dim=0; dim < num_dim; ++dim) {
+      auto v_tmp = subview(v,Kokkos::ALL(),qp,dim);
+      for (int cell=0; cell < num_cell; ++cell) {
+        out << "\tChecking (" << cell << "," << qp << "," << dim << ")" << std::endl;
+        success = success && checkFads(v(cell,qp,dim), v_tmp(cell), out);
+      }
+    }
+  }
+
+  out << "checking subview(v,*,ALL,*)..." << std::endl;
+  for (int cell=0; cell < num_cell; ++cell) {
+    for (int dim=0; dim < num_dim; ++dim) {
+      auto v_tmp = subview(v,cell,Kokkos::ALL(),dim);
+      for (int qp=0; qp < num_qp; ++qp) {
+        out << "\tChecking (" << cell << "," << qp << "," << dim << ")" << std::endl;
+        success = success && checkFads(v(cell,qp,dim), v_tmp(qp), out);
+      }
+    }
+  }
+
+  out << "checking subview(v,*,*,ALL)..." << std::endl;
+  for (int cell=0; cell < num_cell; ++cell) {
+    for (int qp=0; qp < num_qp; ++qp) {
+      auto v_tmp = subview(v,cell,qp,Kokkos::ALL());
+      for (int dim=0; dim < num_dim; ++dim) {
+        out << "\tChecking (" << cell << "," << qp << "," << dim << ")" << std::endl;
+        success = success && checkFads(v(cell,qp,dim), v_tmp(dim), out);
+      }
+    }
+  }
+
+  out << "checking subview(v,ALL,ALL,*)..." << std::endl;
+  for (int dim=0; dim < num_dim; ++dim) {
+    auto v_tmp = subview(v,Kokkos::ALL(),Kokkos::ALL(),dim);
+    for (int cell=0; cell < num_cell; ++cell) {
+      for (int qp=0; qp < num_qp; ++qp) {
+        out << "\tChecking (" << cell << "," << qp << "," << dim << ")" << std::endl;
+        success = success && checkFads(v(cell,qp,dim), v_tmp(cell,qp), out);
+      }
+    }
+  }
+
+  out << "checking subview(v,*,ALL,ALL)..." << std::endl;
+  for (int cell=0; cell < num_cell; ++cell) {
+    auto v_tmp = subview(v,cell,Kokkos::ALL(),Kokkos::ALL());
+    for (int qp=0; qp < num_qp; ++qp) {
+      for (int dim=0; dim < num_dim; ++dim) {
+        out << "\tChecking (" << cell << "," << qp << "," << dim << ")" << std::endl;
+        success = success && checkFads(v(cell,qp,dim), v_tmp(qp,dim), out);
+      }
+    }
+  }
+
+  out << "checking subview(v,ALL,*,ALL)..." << std::endl;
+  for (int qp=0; qp < num_qp; ++qp) {
+    auto v_tmp = subview(v,Kokkos::ALL(),qp,Kokkos::ALL());
+    for (int cell=0; cell < num_cell; ++cell) {
+      for (int dim=0; dim < num_dim; ++dim) {
+        out << "\tChecking (" << cell << "," << qp << "," << dim << ")" << std::endl;
+        success = success && checkFads(v(cell,qp,dim), v_tmp(cell,dim), out);
+      }
+    }
+  }
+
+  out << "checking subview(v,range,range,range)..." << std::endl;
+  auto v_tmp = subview(v,std::make_pair(1,5),std::make_pair(1,4),std::make_pair(1,3));
+  for (int cell=1; cell < num_cell; ++cell) {
+    for (int qp=1; qp < num_qp; ++qp) {
+      for (int dim=1; dim < num_dim; ++dim) {
+        out << "\tChecking (" << cell << "," << qp << "," << dim << ")" << std::endl;
+        success = success && checkFads(v(cell,qp,dim), v_tmp(cell-1,qp-1,dim-1), out);
+      }
+    }
+  }
+}
+
 #ifdef SACADO_NEW_FAD_DESIGN_IS_DEFAULT
 TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
   Kokkos_View_Fad, ConstViewAssign, FadType, Layout, Device )
@@ -2376,6 +2489,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Kokkos_View_Fad, SubdynrankviewRow, F, L, D ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Kokkos_View_Fad, SubdynrankviewScalar, F, L, D ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Kokkos_View_Fad, Subview, F, L, D ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Kokkos_View_Fad, Subview2, F, L, D ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Kokkos_View_Fad, ShmemSize, F, L, D ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Kokkos_View_Fad, ConstViewAssign, F, L, D )
 


### PR DESCRIPTION
Calling subview() with LayoutContiguous<LayoutLeft> can result in  invalid indexing when the returned view is LayoutStride.  This is because the implementation assumes the right-most index is the fad dimension for all layouts except LayoutLeft, including LayoutStride.  However, if the original view was LayoutLeft, this isn't correct.  I fixed this by interchanging the dimensions in the LayoutStride case.  I also added a test to verify it is correct now by checking the indexing in numerous subview cases.

Also fixed a few uses of deprecated Rank.

Thanks to @rppawlo  for reporting this.