### PR TITLE
APREPRO: Fix -I parsing; use include_path on input file

### DIFF
--- a/packages/seacas/applications/aprepro/aprepro.C
+++ b/packages/seacas/applications/aprepro/aprepro.C
@@ -93,9 +93,15 @@ int main(int argc, char *argv[])
   else {
     std::fstream infile(input_files[0], std::fstream::in);
     if (!infile.good()) {
-      std::cerr << "APREPRO: ERROR: Could not open file: " << input_files[0] << '\n'
-                << "                Error Code: " << strerror(errno) << '\n';
-      return EXIT_FAILURE;
+      if (!aprepro.ap_options.include_path.empty() && input_files[0][0] != '/') {
+	std::string filename = aprepro.ap_options.include_path + "/" + input_files[0];
+	infile.open(filename, std::fstream::in);
+      }
+      if (!infile.good()) {
+	std::cerr << "APREPRO: ERROR: Could not open file: " << input_files[0] << '\n'
+		  << "                Error Code: " << strerror(errno) << '\n';
+	return EXIT_FAILURE;
+      }
     }
 
     // Read and parse a file.  The entire file will be parsed and

--- a/packages/seacas/libraries/aprepro_lib/CMakeLists.txt
+++ b/packages/seacas/libraries/aprepro_lib/CMakeLists.txt
@@ -115,7 +115,7 @@ if (${PACKAGE_NAME}_ENABLE_TESTS)
 TRIBITS_ADD_ADVANCED_TEST(
  aprepro_lib_unit_test
  TEST_0 EXEC aprepro_lib_test
-        ARGS -o test.output ${CMAKE_CURRENT_SOURCE_DIR}/test.inp_app
+        ARGS -o test.output ${CMAKE_CURRENT_SOURCE_DIR}/test.inp_app 
   NOEXEPREFIX NOEXESUFFIX
   PASS_ANY
  TEST_1 CMND diff ARGS -w
@@ -130,8 +130,26 @@ TRIBITS_ADD_ADVANCED_TEST(
 TRIBITS_ADD_ADVANCED_TEST(
  aprepro_lib_array_test
  TEST_0 EXEC aprepro_lib_test
-	ARGS --info=test-array.dump --include=${CMAKE_CURRENT_SOURCE_DIR} -o test-array.out
-	     ${CMAKE_CURRENT_SOURCE_DIR}/test-array.i
+	ARGS --info=test-array.dump --include=${CMAKE_CURRENT_SOURCE_DIR} -o test-array.out test-array.i
+  NOEXEPREFIX NOEXESUFFIX
+  PASS_ANY
+ TEST_1 CMND diff ARGS -w
+		       ${CMAKE_CURRENT_SOURCE_DIR}/test-array.gold
+		       ${CMAKE_CURRENT_BINARY_DIR}/test-array.out
+ TEST_2 CMND diff ARGS -w
+		       ${CMAKE_CURRENT_SOURCE_DIR}/test-array.stderr.gold
+		       ${CMAKE_CURRENT_BINARY_DIR}/test-array.dump
+ COMM mpi serial
+ OVERALL_NUM_MPI_PROCS 1
+ FINAL_PASS_REGULAR_EXPRESSION
+ XHOSTTYPE Windows
+)
+
+TRIBITS_ADD_ADVANCED_TEST(
+ aprepro_lib_array_test_short_opt
+ TEST_0 EXEC aprepro_lib_test
+	ARGS --info=test-array.dump -I=${CMAKE_CURRENT_SOURCE_DIR} -o test-array.out
+	     test-array.i
   NOEXEPREFIX NOEXESUFFIX
   PASS_ANY
  TEST_1 CMND diff ARGS -w

--- a/packages/seacas/libraries/aprepro_lib/apr_aprepro.cc
+++ b/packages/seacas/libraries/aprepro_lib/apr_aprepro.cc
@@ -35,7 +35,7 @@
 #endif
 
 namespace {
-  const std::string version_string{"6.14 (2023/06/20)"};
+  const std::string version_string{"6.16 (2023/07/17)"};
 
   void output_copyright();
 
@@ -453,6 +453,9 @@ namespace SEAMS {
       auto equals = option.find('=');
       if (equals == std::string::npos) {
         equals = option.size();
+      }
+      else {
+	equals = equals - number_dash;
       }
 
       // NOTE: `option` contains two leading `--` or `-` and a single character...

--- a/packages/seacas/libraries/aprepro_lib/apr_test.cc
+++ b/packages/seacas/libraries/aprepro_lib/apr_test.cc
@@ -62,6 +62,12 @@ int main(int argc, char *argv[])
       // Aprepro::parsing_results()
       std::fstream infile(argv[ai]);
       if (!infile.good()) {
+	if (!aprepro.ap_options.include_path.empty() && argv[ai][0] != '/') {
+	  std::string filename = aprepro.ap_options.include_path + "/" + argv[ai];
+	  infile.open(filename, std::fstream::in);
+	}
+      }
+      if (!infile.good()) {
         std::cerr << "APREPRO: Could not open file: " << argv[ai] << '\n';
         return 0;
       }


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/seacas 

## Motivation

Recent changes to reduce duplicate parsing code and hopefully make parsing more robust broke the short-argument parsing of --include / -I.  This fixes that and adds a test to make sure it keeps working.  Also extend the use of the include path to apply to input file specified on the execution command line.
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->