### PR TITLE
Stratimikos: Enable Amesos2 example only when Klu2 is available

### DIFF
--- a/packages/stratimikos/example/tpetra/CMakeLists.txt
+++ b/packages/stratimikos/example/tpetra/CMakeLists.txt
@@ -1,8 +1,10 @@
 tribits_add_executable( simple_tpetra_stratimikos_example
   SOURCES simple_tpetra_stratimikos_example.cpp )
 
+
+ASSERT_DEFINED(Amesos2_ENABLE_KLU2)
 TRIBITS_ADD_TEST( simple_tpetra_stratimikos_example
-  EXCLUDE_IF_NOT_TRUE ${PACKAGE_NAME}_ENABLE_Amesos2
+  EXCLUDE_IF_NOT_TRUE ${PACKAGE_NAME}_ENABLE_Amesos2 Amesos2_ENABLE_KLU2
   POSTFIX_AND_ARGS_0 amesos2_klu2
     "--linear-solver-params-file=${CMAKE_CURRENT_SOURCE_DIR}/amesos2.klu2.xml"
     "--matrix-file=${CMAKE_CURRENT_SOURCE_DIR}/FourByFour.mtx" --tol=1e-13


### PR DESCRIPTION
Fixes #11983

@trilinos/stratimikos @trilinos/amesos2 

## Motivation
The example fails when Amesos2 was enabled, but not Klu2.