### PR TITLE
Stokhos:  Make integral conversion available to expressions, not just Vectors

### DIFF
--- a/packages/stokhos/src/kokkos/Stokhos_Multiply.hpp
+++ b/packages/stokhos/src/kokkos/Stokhos_Multiply.hpp
@@ -80,11 +80,11 @@ class DefaultMultiply {};
 template <unsigned> class IntegralRank {};
 
 template <typename T> struct ViewRank {
-  typedef IntegralRank< T::Rank > type;
+  typedef IntegralRank< T::rank > type;
 };
 
 template <typename T> struct ViewRank< std::vector<T> > {
-  typedef IntegralRank< T::Rank > type;
+  typedef IntegralRank< T::rank > type;
 };
 
 template <typename MatrixType,

--- a/packages/stokhos/src/sacado/kokkos/pce/KokkosExp_View_UQ_PCE_Contiguous.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/KokkosExp_View_UQ_PCE_Contiguous.hpp
@@ -587,7 +587,7 @@ void deep_copy( const ExecSpace &,
         src_dims[5] = src.extent(5);
         src_dims[6] = src.extent(6);
         src_dims[7] = src.extent(7);
-        src_dims[src_type::Rank] = dimension_scalar(src);
+        src_dims[src_type::rank] = dimension_scalar(src);
         tmp_src_type src_tmp(
           view_alloc("src_tmp" , WithoutInitializing, cijk(src) ) ,
           src_dims[0], src_dims[1], src_dims[2], src_dims[3],
@@ -612,7 +612,7 @@ void deep_copy( const ExecSpace &,
         dst_dims[5] = dst.extent(5);
         dst_dims[6] = dst.extent(6);
         dst_dims[7] = dst.extent(7);
-        dst_dims[dst_type::Rank] = dimension_scalar(dst);
+        dst_dims[dst_type::rank] = dimension_scalar(dst);
         tmp_dst_type dst_tmp(
           view_alloc("dst_tmp" , WithoutInitializing, cijk(dst) ) ,
           dst_dims[0], dst_dims[1], dst_dims[2], dst_dims[3],
@@ -636,7 +636,7 @@ void deep_copy( const ExecSpace &,
         src_dims[5] = src.extent(5);
         src_dims[6] = src.extent(6);
         src_dims[7] = src.extent(7);
-        src_dims[src_type::Rank] = dimension_scalar(src);
+        src_dims[src_type::rank] = dimension_scalar(src);
         tmp_src_type src_tmp(
           view_alloc("src_tmp" , WithoutInitializing, cijk(src) ) ,
           src_dims[0], src_dims[1], src_dims[2], src_dims[3],
@@ -652,7 +652,7 @@ void deep_copy( const ExecSpace &,
         dst_dims[5] = dst.extent(5);
         dst_dims[6] = dst.extent(6);
         dst_dims[7] = dst.extent(7);
-        dst_dims[dst_type::Rank] = dimension_scalar(dst);
+        dst_dims[dst_type::rank] = dimension_scalar(dst);
         tmp_dst_type dst_tmp(
           view_alloc("dst_tmp" , WithoutInitializing, cijk(dst) ) ,
           dst_dims[0], dst_dims[1], dst_dims[2], dst_dims[3],
@@ -689,7 +689,7 @@ namespace Impl {
 
 template <unsigned N, typename... Args>
 KOKKOS_FUNCTION std::enable_if_t<
-    N == View<Args...>::Rank &&
+    N == View<Args...>::rank &&
     std::is_same<typename ViewTraits<Args...>::specialize,
                  Kokkos::Experimental::Impl::ViewPCEContiguous>::value,
     View<Args...>>
@@ -701,7 +701,7 @@ as_view_of_rank_n(View<Args...> v) {
 // never be called
 template <unsigned N, typename T, typename... Args>
 std::enable_if_t<
-    N != View<T, Args...>::Rank &&
+    N != View<T, Args...>::rank &&
         std::is_same<typename ViewTraits<T, Args...>::specialize,
                      Kokkos::Experimental::Impl::ViewPCEContiguous>::value,
     View<typename RankDataType<typename View<T, Args...>::value_type, N>::type,

--- a/packages/stokhos/src/sacado/kokkos/pce/Kokkos_View_UQ_PCE_Fwd.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/Kokkos_View_UQ_PCE_Fwd.hpp
@@ -249,7 +249,7 @@ namespace Impl {
 
 template <unsigned N, typename... Args>
 KOKKOS_FUNCTION std::enable_if_t<
-    N == View<Args...>::Rank &&
+    N == View<Args...>::rank &&
     std::is_same<typename ViewTraits<Args...>::specialize,
                  Kokkos::Experimental::Impl::ViewPCEContiguous>::value,
     View<Args...>>
@@ -259,7 +259,7 @@ as_view_of_rank_n(View<Args...> v);
 // never be called
 template <unsigned N, typename T, typename... Args>
 std::enable_if_t<
-    N != View<T, Args...>::Rank &&
+    N != View<T, Args...>::rank &&
         std::is_same<typename ViewTraits<T, Args...>::specialize,
                      Kokkos::Experimental::Impl::ViewPCEContiguous>::value,
     View<typename RankDataType<typename View<T, Args...>::value_type, N>::type,

--- a/packages/stokhos/src/sacado/kokkos/pce/Kokkos_View_UQ_PCE_Utils.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/Kokkos_View_UQ_PCE_Utils.hpp
@@ -56,7 +56,7 @@ namespace Kokkos {
 // Type name for a local, unmanaged view with possibly a different static size
 template <typename ViewType,
           unsigned LocalSize,
-          unsigned Rank = ViewType::Rank,
+          unsigned Rank = ViewType::rank,
           bool isStatic = ViewType::is_static>
 struct LocalUQPCEView {};
 

--- a/packages/stokhos/src/sacado/kokkos/pce/tpetra/Tpetra_Details_fill_UQ_PCE.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/tpetra/Tpetra_Details_fill_UQ_PCE.hpp
@@ -80,7 +80,7 @@ fill (const ExecutionSpace& execSpace,
       const size_t whichVectors[])
 {
   typedef Kokkos::View<DT,DP...> ViewType;
-  static_assert (ViewType::Rank == 2, "ViewType must be a rank-2 "
+  static_assert (ViewType::rank == 2, "ViewType must be a rank-2 "
                  "Kokkos::View in order to call the \"whichVectors\" "
                  "specialization of fill.");
   static_assert (std::is_integral<IndexType>::value,

--- a/packages/stokhos/src/sacado/kokkos/vector/KokkosExp_View_MP_Vector_Contiguous.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/KokkosExp_View_MP_Vector_Contiguous.hpp
@@ -463,7 +463,7 @@ namespace Impl {
 
 template <unsigned N, typename... Args>
 KOKKOS_FUNCTION std::enable_if_t<
-    N == View<Args...>::Rank &&
+    N == View<Args...>::rank &&
     std::is_same<typename ViewTraits<Args...>::specialize,
                  Kokkos::Experimental::Impl::ViewMPVectorContiguous>::value,
     View<Args...>>
@@ -475,7 +475,7 @@ as_view_of_rank_n(View<Args...> v) {
 // never be called
 template <unsigned N, typename T, typename... Args>
 std::enable_if_t<
-    N != View<T, Args...>::Rank &&
+    N != View<T, Args...>::rank &&
         std::is_same<typename ViewTraits<T, Args...>::specialize,
                      Kokkos::Experimental::Impl::ViewMPVectorContiguous>::value,
     View<typename RankDataType<typename View<T, Args...>::value_type, N>::type,

--- a/packages/stokhos/src/sacado/kokkos/vector/Kokkos_View_MP_Vector_Fwd.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/Kokkos_View_MP_Vector_Fwd.hpp
@@ -251,7 +251,7 @@ namespace Impl {
 
 template <unsigned N, typename... Args>
 KOKKOS_FUNCTION std::enable_if_t<
-    N == View<Args...>::Rank &&
+    N == View<Args...>::rank &&
     std::is_same<typename ViewTraits<Args...>::specialize,
                  Kokkos::Experimental::Impl::ViewMPVectorContiguous>::value,
     View<Args...>>
@@ -261,7 +261,7 @@ as_view_of_rank_n(View<Args...> v);
 // never be called
 template <unsigned N, typename T, typename... Args>
 std::enable_if_t<
-    N != View<T, Args...>::Rank &&
+    N != View<T, Args...>::rank &&
         std::is_same<typename ViewTraits<T, Args...>::specialize,
                      Kokkos::Experimental::Impl::ViewMPVectorContiguous>::value,
     View<typename RankDataType<typename View<T, Args...>::value_type, N>::type,

--- a/packages/stokhos/src/sacado/kokkos/vector/Kokkos_View_MP_Vector_Interlaced.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/Kokkos_View_MP_Vector_Interlaced.hpp
@@ -982,8 +982,8 @@ struct ViewAssignment< ViewMPVectorInterlaced , ViewMPVectorInterlaced , void >
                              typename View<ST,SL,SD,SM,specialize>::array_layout >::value
                     &&
                     // Same rank
-                    ( unsigned(View<DT,DL,DD,DM,specialize>::Rank) ==
-                      unsigned(View<ST,SL,SD,SM,specialize>::Rank) )
+                    ( unsigned(View<DT,DL,DD,DM,specialize>::rank) ==
+                      unsigned(View<ST,SL,SD,SM,specialize>::rank) )
                     &&
                     // Destination is not managed
                     ! View<DT,DL,DD,DM,specialize>::is_managed
@@ -997,7 +997,7 @@ struct ViewAssignment< ViewMPVectorInterlaced , ViewMPVectorInterlaced , void >
     typedef typename dst_traits::value_type                   dst_sacado_mp_vector_type ;
     typedef typename dst_sacado_mp_vector_type::storage_type  dst_stokhos_storage_type ;
 
-    enum { DstRank         = dst_type::Rank };
+    enum { DstRank         = dst_type::rank };
     enum { DstStaticLength = dst_stokhos_storage_type::static_size };
 
     const int length = part.end - part.begin ;
@@ -1015,7 +1015,7 @@ struct ViewAssignment< ViewMPVectorInterlaced , ViewMPVectorInterlaced , void >
     dims[5] = src.m_array_shape.N5;
     dims[6] = src.m_array_shape.N6;
     dims[7] = src.m_array_shape.N7;
-    unsigned rank = dst_type::Rank;
+    unsigned rank = dst_type::rank;
 
     dst_shape_type::assign( dst.m_shape,
                             dims[0] , dims[1] , dims[2] , dims[3] ,

--- a/packages/stokhos/src/sacado/kokkos/vector/Sacado_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/Sacado_MP_Vector.hpp
@@ -113,6 +113,12 @@ namespace Sacado {
         return static_cast<const volatile derived_type&>(*this);
       }
 
+      // Allow explicit casting to integral types, since we don't have an
+      // integral ensemble type.
+      template <typename U, typename Enabled = typename std::enable_if<std::is_integral<U>::value>::type>
+      KOKKOS_INLINE_FUNCTION
+      explicit operator U() const { return static_cast<U>(derived().val()); }
+
     };
 
     //! Vectorized evaluation class
@@ -287,12 +293,6 @@ namespace Sacado {
       //! Destructor
       KOKKOS_DEFAULTED_FUNCTION
       ~Vector() = default;
-
-      // Allow explicit casting to integral types, since we don't have an
-      // integral ensemble type.
-      template <typename T, typename Enabled = typename std::enable_if<std::is_integral<T>::value>::type>
-      KOKKOS_INLINE_FUNCTION
-      explicit operator T() const { return static_cast<T>(val()); }
 
       //! Initialize coefficients to value
       KOKKOS_INLINE_FUNCTION

--- a/packages/stokhos/src/sacado/kokkos/vector/Sacado_MP_Vector_SFS.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/Sacado_MP_Vector_SFS.hpp
@@ -175,12 +175,6 @@ namespace Sacado {
       KOKKOS_INLINE_FUNCTION
       ~Vector() {}
 
-      // Allow explicit casting to integral types, since we don't have an
-      // integral ensemble type.
-      template <typename T, typename Enabled = typename std::enable_if<std::is_integral<T>::value>::type>
-      KOKKOS_INLINE_FUNCTION
-      explicit operator T() const { return static_cast<T>(val()); }
-
       //! Initialize coefficients to value
       KOKKOS_INLINE_FUNCTION
       void init(const value_type& v) { s.init(v); }

--- a/packages/stokhos/src/sacado/kokkos/vector/tpetra/Tpetra_Details_fill_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/tpetra/Tpetra_Details_fill_MP_Vector.hpp
@@ -80,7 +80,7 @@ fill (const ExecutionSpace& execSpace,
       const size_t whichVectors[])
 {
   typedef Kokkos::View<DT,DP...> ViewType;
-  static_assert (ViewType::Rank == 2, "ViewType must be a rank-2 "
+  static_assert (ViewType::rank == 2, "ViewType must be a rank-2 "
                  "Kokkos::View in order to call the \"whichVectors\" "
                  "specialization of fill.");
   static_assert (std::is_integral<IndexType>::value,


### PR DESCRIPTION
For PR #11840.

Also remove deprecated use of View::Rank.