### PR TITLE
Geminga: Remove deprecated flag

### DIFF
--- a/cmake/ctest/drivers/geminga/TrilinosCTestDriverCore.geminga.gcc-cuda.cmake
+++ b/cmake/ctest/drivers/geminga/TrilinosCTestDriverCore.geminga.gcc-cuda.cmake
@@ -126,7 +126,6 @@ MACRO(TRILINOS_SYSTEM_SPECIFIC_CTEST_DRIVER)
 
       ### PACKAGE CONFIGURATION ###
           "-DKokkos_ENABLE_CUDA:BOOL=ON"
-          "-DKokkos_ENABLE_CUDA_UVM:BOOL=ON"
           "-DKokkos_ENABLE_CUDA_LAMBDA:BOOL=ON"
           "-DKokkos_ARCH_KEPLER35:BOOL=ON"
           "-DTrilinos_ENABLE_Epetra:BOOL=OFF"


### PR DESCRIPTION
@trilinos/muelu 

## Motivation
Remove the deprecated UVM flag, see
https://testing.sandia.gov/cdash/build/11578770/configure