### PR TITLE
Framework: Fix checkouts of branches

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1263,6 +1263,7 @@ opt-set-cmake-var FEI_multifield_vbr_az_MPI_2_DISABLE BOOL : ON
 opt-set-cmake-var FEI_multifield_vbr_az_MPI_3_DISABLE BOOL : ON
 opt-set-cmake-var ROL_example_PinT_parabolic-control_example_01_MPI_1_DISABLE BOOL : ON
 opt-set-cmake-var Rythmos_StepperBuilder_UnitTest_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var SEACASAprepro_lib_aprepro_lib_array_test_DISABLE BOOL : ON
 
 [WEAVER_TEST_DISABLES|CUDA]
 opt-set-cmake-var MueLu_ParameterListInterpreterTpetra_MPI_1_DISABLE BOOL : ON

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1135,6 +1135,7 @@ use ATS2-RUN-SERIAL-TESTS
 
 [RHEL7]
 use COMMON
+opt-set-cmake-var SEACASAprepro_lib_aprepro_lib_array_test_DISABLE BOOL : ON
 
 [RHEL8]
 use COMMON
@@ -1263,7 +1264,6 @@ opt-set-cmake-var FEI_multifield_vbr_az_MPI_2_DISABLE BOOL : ON
 opt-set-cmake-var FEI_multifield_vbr_az_MPI_3_DISABLE BOOL : ON
 opt-set-cmake-var ROL_example_PinT_parabolic-control_example_01_MPI_1_DISABLE BOOL : ON
 opt-set-cmake-var Rythmos_StepperBuilder_UnitTest_MPI_1_DISABLE BOOL : ON
-opt-set-cmake-var SEACASAprepro_lib_aprepro_lib_array_test_DISABLE BOOL : ON
 
 [WEAVER_TEST_DISABLES|CUDA]
 opt-set-cmake-var MueLu_ParameterListInterpreterTpetra_MPI_1_DISABLE BOOL : ON

--- a/packages/framework/pr_tools/PullRequestLinuxDriverMerge.py
+++ b/packages/framework/pr_tools/PullRequestLinuxDriverMerge.py
@@ -166,7 +166,14 @@ def merge_branch(source_url, target_branch, sourceSHA):
     check_call_wrapper(['git', 'fetch', 'origin', target_branch])
     check_call_wrapper(['git', 'reset', '--hard', 'HEAD'])
     check_call_wrapper(['git', 'checkout', '-B', target_branch, 'origin/' + target_branch])
-    check_call_wrapper(['git', 'merge', '--no-edit', sourceSHA]),
+
+    sha_exists_as_branch_on_remote = bool(subprocess.check_output('git rev-parse --verify --quiet source_remote/' + sourceSHA + ' || true', shell=True))
+
+    if sha_exists_as_branch_on_remote:
+        print_wrapper("REMARK: Detected ref as a remote branch, will merge as such")
+        check_call_wrapper(['git', 'merge', '--no-edit', "source_remote/" + sourceSHA])
+    else:
+        check_call_wrapper(['git', 'merge', '--no-edit', sourceSHA])
 
     return 0
 


### PR DESCRIPTION
If it exists as a ref on source_remote, check it out as such.  This allows passing a branch or a SHA as a ref.

User Support Ticket(s) or Story Referenced: TRILFRAME-567
@trilinos/framework 

## Motivation
Nightly/scheduled runs tend to use branch names as opposed to SHAs.
