### PR TITLE
Zoltan2: Update GraphAdapters to use Kokkos data structures and impro…

### DIFF
--- a/packages/zoltan2/core/src/input/Zoltan2_Adapter.hpp
+++ b/packages/zoltan2/core/src/input/Zoltan2_Adapter.hpp
@@ -50,12 +50,17 @@
 #ifndef _ZOLTAN2_ADAPTER_HPP_
 #define _ZOLTAN2_ADAPTER_HPP_
 
+#include "Kokkos_StaticCrsGraph.hpp"
 #include <Kokkos_Core.hpp>
 #include <Zoltan2_Standards.hpp>
 #include <Zoltan2_InputTraits.hpp>
 #include <Zoltan2_PartitioningSolution.hpp>
+#include <fstream>
 
 namespace Zoltan2 {
+
+//template<typename Adapter>
+//class PartitioningSolution;
 
 /*! \brief An enum to identify general types of adapters.
  *
@@ -80,7 +85,7 @@ enum BaseAdapterType {
 
 class BaseAdapterRoot {
 public:
-  virtual ~BaseAdapterRoot() {}; // required virtual declaration
+  virtual ~BaseAdapterRoot() = default; // required virtual declaration
 
   /*! \brief Returns the number of objects on this process
    *
@@ -101,22 +106,51 @@ template <typename User>
   class BaseAdapter : public BaseAdapterRoot {
 
 public:
-  typedef typename InputTraits<User>::lno_t lno_t;
-  typedef typename InputTraits<User>::gno_t gno_t;
-  typedef typename InputTraits<User>::scalar_t scalar_t;
-  typedef typename InputTraits<User>::node_t node_t;
-  typedef typename InputTraits<User>::part_t part_t;
-  typedef typename InputTraits<User>::offset_t offset_t;
+  using lno_t = typename InputTraits<User>::lno_t;
+  using gno_t = typename InputTraits<User>::gno_t;
+  using scalar_t = typename InputTraits<User>::scalar_t;
+  using node_t = typename InputTraits<User>::node_t;
+  using part_t = typename InputTraits<User>::part_t;
+  using offset_t = typename InputTraits<User>::offset_t;
+  using host_t = typename Kokkos::HostSpace::memory_space;
+  using device_t = typename node_t::device_type;
+
+  using ConstIdsDeviceView = Kokkos::View<const gno_t *, device_t>;
+  using ConstIdsHostView = typename ConstIdsDeviceView::HostMirror;
+
+  using IdsDeviceView = Kokkos::View<gno_t *, device_t>;
+  using IdsHostView = typename IdsDeviceView::HostMirror;
+
+  using ConstOffsetsDeviceView = Kokkos::View<const offset_t *, device_t>;
+  using ConstOffsetsHostView = typename ConstOffsetsDeviceView::HostMirror;
+
+  using offsetsDeviceView = Kokkos::View<offset_t *, device_t>;
+  using offsetsHostView = typename offsetsDeviceView::HostMirror;
+
+  using ConstScalarsDeviceView = Kokkos::View<const scalar_t *, device_t>;
+  using ConstScalarsHostView = typename ConstScalarsDeviceView::HostMirror;
+
+  using scalarsDeviceView = Kokkos::View<scalar_t *, device_t>;
+  using scalarsHostView = typename scalarsDeviceView::HostMirror;
+
+  using ConstWeightsDeviceView1D = Kokkos::View<const scalar_t *, device_t>;
+  using ConstWeightsHostView1D = typename ConstWeightsDeviceView1D::HostMirror;
+
+  using WeightsDeviceView1D = Kokkos::View<scalar_t *, device_t>;
+  using WeightsHostView1D = typename WeightsDeviceView1D::HostMirror;
+
+  using ConstWeightsDeviceView = Kokkos::View<const scalar_t **, device_t>;
+  using ConstWeightsHostView = typename ConstWeightsDeviceView::HostMirror;
+
+  using WeightsDeviceView = Kokkos::View<scalar_t **, device_t>;
+  using WeightsHostView = typename WeightsDeviceView::HostMirror;
 
   /*! \brief Returns the type of adapter.
    */
   virtual enum BaseAdapterType adapterType() const = 0;
 
-  /*! \brief Destructor
-   */
-  virtual ~BaseAdapter() {};
-
   /*! \brief Provide a pointer to this process' identifiers.
+      \deprecated Use \b getIDsHostView instead.
       \param ids will on return point to the list of the global Ids for
         this process.
    */
@@ -124,32 +158,47 @@ public:
     // If adapter does not define getIDsView, getIDsKokkosView is called.
     // If adapter does not define getIDsKokkosView, getIDsView is called.
     // Allows forward and backwards compatibility.
-    Kokkos::View<const gno_t *, typename node_t::device_type> kokkosIds;
+    ConstIdsDeviceView kokkosIds;
     getIDsKokkosView(kokkosIds);
+    //deep_copy(?)
     ids = kokkosIds.data();
   }
 
   /*! \brief Provide a Kokkos view to this process' identifiers.
+      \deprecated Use \b getIDsDeviceView instead.
       \param ids will on return point to the list of the global Ids for
         this process.
    */
-  virtual void getIDsKokkosView(Kokkos::View<const gno_t *,
-    typename node_t::device_type> &ids) const {
+  virtual void getIDsKokkosView(ConstIdsDeviceView &ids) const {
     // If adapter does not define getIDsView, getIDsKokkosView is called.
     // If adapter does not define getIDsKokkosView, getIDsView is called.
     // Allows forward and backwards compatibility.
     const gno_t * ptr_ids;
     getIDsView(ptr_ids);
 
-    typedef Kokkos::View<gno_t *, typename node_t::device_type> view_t;
-    view_t non_const_ids = view_t("ptr_ids", getLocalNumIDs());
-
+    auto non_const_ids = IdsDeviceView("ptr_ids", getLocalNumIDs());
     auto host_ids = Kokkos::create_mirror_view(non_const_ids);
     for(size_t i = 0; i < this->getLocalNumIDs(); ++i) {
        host_ids(i) = ptr_ids[i];
     }
     Kokkos::deep_copy(non_const_ids, host_ids);
     ids = non_const_ids;
+  }
+
+  /*! \brief Provide a Kokkos view (Host side) to this process' identifiers.
+      \param hostIds will on return point to the list of the global Ids for
+        this process.
+   */
+  virtual void getIDsHostView(ConstIdsHostView& hostIds) const {
+    Z2_THROW_NOT_IMPLEMENTED
+  }
+
+  /*! \brief Provide a Kokkos view (Device side) to this process' identifiers.
+      \param deviceIds will on return point to the list of the global Ids for
+        this process.
+   */
+  virtual void getIDsDeviceView(ConstIdsDeviceView &deviceIds) const {
+    Z2_THROW_NOT_IMPLEMENTED
   }
 
   ///*! \brief Provide pointer to a weight array with stride.
@@ -166,9 +215,9 @@ public:
     // If adapter does not define getWeightsView, getWeightsKokkosView is called.
     // If adapter does not define getWeightsKokkosView, getWeightsView is called.
     // Allows forward and backwards compatibility.
-    Kokkos::View<scalar_t **, typename node_t::device_type> kokkos_wgts_2d;
+    Kokkos::View<scalar_t **, device_t> kokkos_wgts_2d;
     getWeightsKokkosView(kokkos_wgts_2d);
-    Kokkos::View<scalar_t *, typename node_t::device_type> kokkos_wgts;
+    Kokkos::View<scalar_t *, device_t> kokkos_wgts;
     wgt = Kokkos::subview(kokkos_wgts_2d, Kokkos::ALL, idx).data();
     stride = 1;
   }
@@ -180,14 +229,13 @@ public:
   // *   This function should not be called if getNumWeightsPerID is zero.
   // */
   virtual void getWeightsKokkosView(Kokkos::View<scalar_t **,
-    typename node_t::device_type> & wgt) const {
+    device_t> & wgt) const {
     // If adapter does not define getWeightsKokkosView, getWeightsView is called.
     // If adapter does not define getWeightsView, getWeightsKokkosView is called.
     // Allows forward and backwards compatibility.
-    wgt = Kokkos::View<scalar_t **, typename node_t::device_type>(
+    wgt = Kokkos::View<scalar_t **, device_t>(
       "wgts", getLocalNumIDs(), getNumWeightsPerID());
-    typename Kokkos::View<scalar_t **, typename node_t::device_type>::HostMirror
-      host_wgt = Kokkos::create_mirror_view(wgt);
+    auto host_wgt = Kokkos::create_mirror_view(wgt);
     for(int j = 0; j < this->getNumWeightsPerID(); ++j) {
       const scalar_t * ptr_wgts;
       int stride;
@@ -200,6 +248,36 @@ public:
     Kokkos::deep_copy(wgt, host_wgt);
   }
 
+  /*! \brief Provide a Kokkos view (Host side) of the weights.
+      \param hostWgts on return a Kokkos view of the weights for this idx
+      \param idx  the weight index, zero or greater
+   */
+  virtual void getWeightsHostView(WeightsHostView1D& hostWgts, int idx = 0) const {
+    Z2_THROW_NOT_IMPLEMENTED
+  }
+
+  /*! \brief Provide a Kokkos view (Host side) of the weights.
+      \param hostWgts on return a Kokkos view of all the weights
+   */
+  virtual void getWeightsHostView(WeightsHostView& hostWgts) const {
+    Z2_THROW_NOT_IMPLEMENTED
+  }
+
+  /*! \brief Provide a Kokkos view (Device side) of the weights.
+      \param deviceWgts on return a Kokkos view of the weights for this idx
+      \param idx  the weight index, zero or greater
+   */
+  virtual void getWeightsDeviceView(WeightsDeviceView1D& deviceWgts, int idx = 0) const {
+    Z2_THROW_NOT_IMPLEMENTED
+  }
+
+  /*! \brief Provide a Kokkos view (Device side) of the weights.
+      \param deviceWgts on return a Kokkos view of all the weights
+   */
+  virtual void getWeightsDeviceView(WeightsDeviceView& deviceWgts) const {
+    Z2_THROW_NOT_IMPLEMENTED
+  }
+
   /*! \brief Provide pointer to an array containing the input part
    *         assignment for each ID.
    *         The input part information may be used for re-partitioning
@@ -209,10 +287,18 @@ public:
    *         the rank
    *    \param inputPart on return a pointer to input part numbers
    */
-  void getPartsView(const part_t *&inputPart) const {
+  virtual void getPartsView(const part_t *&inputPart) const {
     // Default behavior:  return NULL for inputPart array;
     // assume input part == rank
     inputPart = NULL;
+  }
+
+  virtual void getPartsHostView(Kokkos::View<part_t*, host_t> &inputPart) const {
+    Z2_THROW_NOT_IMPLEMENTED
+  }
+
+  virtual void getPartsDeviceView(Kokkos::View<part_t*, device_t> &inputPart) const {
+    Z2_THROW_NOT_IMPLEMENTED
   }
 
   /*! \brief Apply a PartitioningSolution to an input.
@@ -250,13 +336,25 @@ protected:
 
 };
 
-template <typename User>
-class AdapterWithCoords : public BaseAdapter<User>
+template <typename User> class AdapterWithCoords : public BaseAdapter<User>
 {
+  using scalar_t = typename BaseAdapter<User>::scalar_t;
+  using device_t = typename BaseAdapter<User>::node_t::device_type;
+  using host_t = typename Kokkos::HostSpace::memory_space;
+  template <typename space>
+  using coords_t = Kokkos::View<scalar_t **, Kokkos::LayoutLeft, space>;
+
 public:
-  virtual void getCoordinatesView(const typename BaseAdapter<User>::scalar_t *&coords, int &stride, int coordDim) const = 0;
-  virtual void getCoordinatesKokkosView(
-    Kokkos::View<typename BaseAdapter<User>::scalar_t **, Kokkos::LayoutLeft, typename BaseAdapter<User>::node_t::device_type> &elements) const = 0;
+  virtual void getCoordinatesView(const scalar_t *&coords, int &stride,
+                                  int coordDim) const = 0;
+  virtual void getCoordinatesKokkosView(coords_t<device_t> &elements) const = 0;
+
+  virtual void getCoordinatesHostView(coords_t<host_t> &) const {
+    Z2_THROW_NOT_IMPLEMENTED
+  }
+  virtual void getCoordinatesDeviceView(coords_t<device_t> &elements) const {
+    Z2_THROW_NOT_IMPLEMENTED
+  }
 };
 
 // Forward declare

--- a/packages/zoltan2/core/src/input/Zoltan2_GraphAdapter.hpp
+++ b/packages/zoltan2/core/src/input/Zoltan2_GraphAdapter.hpp
@@ -47,7 +47,6 @@
     \brief Defines the GraphAdapter interface.
 */
 
-
 #ifndef _ZOLTAN2_GRAPHADAPTER_HPP_
 #define _ZOLTAN2_GRAPHADAPTER_HPP_
 
@@ -58,10 +57,7 @@ namespace Zoltan2 {
 
 /*!  \brief Enumerated entity type for graphs:  Vertices or Edges
  */
-enum GraphEntityType {
-  GRAPH_VERTEX,
-  GRAPH_EDGE
-};
+enum GraphEntityType { GRAPH_VERTEX, GRAPH_EDGE };
 
 /*!  \brief GraphAdapter defines the interface for graph-based user data.
 
@@ -95,47 +91,44 @@ enum GraphEntityType {
 
 */
 
-template <typename User, typename UserCoord=User>
-  class GraphAdapter : public AdapterWithCoordsWrapper<User, UserCoord> {
+template <typename User, typename UserCoord = User>
+class GraphAdapter : public AdapterWithCoordsWrapper<User, UserCoord> {
 private:
-  enum GraphEntityType primaryEntityType; // Entity (vertex or edge) to
-                                          // be partitioned, ordered,
-                                          // colored, matched, etc.
-  enum GraphEntityType adjacencyEntityType; // Entity (edge or vertex)
-                                            // describing adjacencies;
-                                            // typically opposite of
-                                            // primaryEntityType.
-  VectorAdapter<UserCoord> *coordinateInput_;  // A VectorAdapter containing
-                                               // coordinates of the objects
-                                               // with primaryEntityType;
-                                               // optional.
-  bool haveCoordinateInput_;                   // Flag indicating whether
-                                               // coordinateInput_ is provided.
+  /// Enum to represent the primary entity type in the graph (vertex or edge).
+  /// This is the entity that will be partitioned, ordered, colored, matched,
+  /// etc.
+  enum GraphEntityType primaryEntityType_ = GRAPH_VERTEX;
+
+  /// Enum to represent the adjacency entity type in the graph (edge or vertex).
+  /// This typically refers to an entity type opposite to the
+  /// primaryEntityType_.
+  enum GraphEntityType adjacencyEntityType_ = GRAPH_EDGE;
+
+  /// Pointer to a VectorAdapter containing coordinates of objects of type
+  /// primaryEntityType_. This is an optional attribute. \sa
+  /// haveCoordinateInput_
+  VectorAdapter<UserCoord> *coordinateInput_ = nullptr;
+
+  /// Flag indicating whether the coordinate input is provided.
+  /// When this flag is set to true, coordinateInput_ should not be null.
+  bool haveCoordinateInput_ = false;
 
 public:
-
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
-  typedef typename InputTraits<User>::scalar_t scalar_t;
-  typedef typename InputTraits<User>::lno_t    lno_t;
-  typedef typename InputTraits<User>::gno_t    gno_t;
-  typedef typename InputTraits<User>::node_t   node_t;
-  typedef typename InputTraits<User>::offset_t offset_t;
-  typedef User user_t;
-  typedef UserCoord userCoord_t;
-  typedef GraphAdapter<User, UserCoord> base_adapter_t;
+  using scalar_t = typename InputTraits<User>::scalar_t;
+  using lno_t = typename InputTraits<User>::lno_t;
+  using gno_t = typename InputTraits<User>::gno_t;
+  using node_t = typename InputTraits<User>::node_t;
+  using offset_t = typename InputTraits<User>::offset_t;
+  using user_t = User;
+  using userCoord_t = UserCoord;
+  using base_adapter_t = GraphAdapter<User, UserCoord>;
+  using Base = AdapterWithCoordsWrapper<User, UserCoord>;
+  using VtxDegreeHostView = Kokkos::View<bool *, Kokkos::HostSpace>;
+  using device_t = typename node_t::device_type;
 #endif
 
-  enum BaseAdapterType adapterType() const override {return GraphAdapterType;}
-
-  /*! \brief Destructor
-   */
-  virtual ~GraphAdapter() {};
-
-  // Default GraphEntityType is GRAPH_VERTEX.
-  GraphAdapter() : primaryEntityType(GRAPH_VERTEX),
-                   adjacencyEntityType(GRAPH_EDGE),
-                   coordinateInput_(),
-                   haveCoordinateInput_(false) {}
+  enum BaseAdapterType adapterType() const override { return GraphAdapterType; }
 
   ////////////////////////////////////////////////////////////////////////////
   // Methods to be defined in derived classes.
@@ -153,6 +146,23 @@ public:
    */
   virtual void getVertexIDsView(const gno_t *&vertexIds) const = 0;
 
+  /*! \brief Sets pointers to this process' graph entries.
+      \param vertexIds will on return a device Kokkos::View with vertex global
+     Ids
+   */
+  virtual void
+  getVertexIDsDeviceView(typename Base::ConstIdsDeviceView &vertexIds) const {
+    Z2_THROW_NOT_IMPLEMENTED
+  }
+
+  /*! \brief Sets pointers to this process' graph entries.
+      \param vertexIds will on return a host Kokkos::View with vertex global Ids
+   */
+  virtual void
+  getVertexIDsHostView(typename Base::ConstIdsHostView &vertexIds) const {
+    Z2_THROW_NOT_IMPLEMENTED
+  }
+
   /*! \brief Gets adjacency lists for all vertices in a compressed
              sparse row (CSR) format.
       \param offsets is an array of size getLocalNumVertices() + 1.
@@ -165,6 +175,34 @@ public:
   virtual void getEdgesView(const offset_t *&offsets,
                             const gno_t *&adjIds) const = 0;
 
+  /*! \brief Gets adjacency lists for all vertices in a compressed
+             sparse row (CSR) format.
+      \param offsets is device Kokkos::View of size getLocalNumVertices() + 1.
+         The neighboring vertices for vertexId[i]
+         begin at adjIds[offsets[i]].
+         The last element of offsets is the size of the adjIds array.
+      \param adjIds Device Kokkos::View of adjacent vertices for for each
+     vertex.
+   */
+  virtual void
+  getEdgesDeviceView(typename Base::ConstOffsetsDeviceView &offsets,
+                     typename Base::ConstIdsDeviceView &adjIds) const {
+    Z2_THROW_NOT_IMPLEMENTED
+  }
+
+  /*! \brief Gets adjacency lists for all vertices in a compressed
+             sparse row (CSR) format.
+      \param offsets is host Kokkos::View of size getLocalNumVertices() + 1.
+         The neighboring vertices for vertexId[i]
+         begin at adjIds[offsets[i]].
+         The last element of offsets is the size of the adjIds array.
+      \param adjIds Host Kokkos::View of adjacent vertices for for each vertex.
+   */
+  virtual void getEdgesHostView(typename Base::ConstOffsetsHostView &offsets,
+                                typename Base::ConstIdsHostView &adjIds) const {
+    Z2_THROW_NOT_IMPLEMENTED
+  }
+
   /*! \brief Returns the number (0 or greater) of weights per vertex
    */
   virtual int getNumWeightsPerVertex() const { return 0; }
@@ -176,21 +214,54 @@ public:
       \param idx ranges from zero to one less than getNumWeightsPerVertex().
    */
   virtual void getVertexWeightsView(const scalar_t *&weights, int &stride,
-                                    int /* idx */ = 0) const
-  {
+                                    int /* idx */ = 0) const {
     weights = NULL;
     stride = 0;
     Z2_THROW_NOT_IMPLEMENTED
   }
 
+  /*! \brief  Provide a device view of the vertex weights, if any.
+      \param weights is the list of weights of the given index for
+           the vertices returned in getVertexIDsView().
+      \param idx ranges from zero to one less than getNumWeightsPerVertex().
+   */
+  virtual void
+  getVertexWeightsDeviceView(typename Base::WeightsDeviceView1D &weights,
+                             int /* idx */ = 0) const {
+    Z2_THROW_NOT_IMPLEMENTED
+  }
+
+  /*! \brief  Provide a device view of the vertex weights, if any.
+      \param weights is the view of all the weights for the vertices returned in getVertexIDsView().
+   */
+  virtual void
+  getVertexWeightsDeviceView(typename Base::WeightsDeviceView &weights) const {
+    Z2_THROW_NOT_IMPLEMENTED
+  }
+
+  /*! \brief  Provide a host view of the vertex weights, if any.
+      \param weights is the list of weights of the given index for
+           the vertices returned in getVertexIDsView().
+      \param idx ranges from zero to one less than getNumWeightsPerVertex().
+   */
+  virtual void
+  getVertexWeightsHostView(typename Base::WeightsHostView1D &weights,
+                           int /* idx */ = 0) const {
+    Z2_THROW_NOT_IMPLEMENTED
+  }
+
+  /*! \brief  Provide a host view of the vertex weights, if any.
+      \param weights is the list of all the weights for the vertices returned in getVertexIDsView()
+   */
+  virtual void
+  getVertexWeightsHostView(typename Base::WeightsHostView &weights) const {
+    Z2_THROW_NOT_IMPLEMENTED
+  }
 
   /*! \brief Indicate whether vertex weight with index idx should be the
    *         global degree of the vertex
    */
-  virtual bool useDegreeAsVertexWeight(int /* idx */) const
-  {
-    return false;
-  }
+  virtual bool useDegreeAsVertexWeight(int /* idx */) const { return false; }
 
   /*! \brief Returns the number (0 or greater) of edge weights.
    */
@@ -203,24 +274,59 @@ public:
       \param idx ranges from zero to one less than getNumWeightsPerEdge().
    */
   virtual void getEdgeWeightsView(const scalar_t *&weights, int &stride,
-                                  int /* idx */ = 0) const
-  {
+                                  int /* idx */ = 0) const {
     weights = NULL;
     stride = 0;
     Z2_THROW_NOT_IMPLEMENTED
   }
 
+  /*! \brief  Provide a device view of the edge weights, if any.
+      \param weights is the list of weights of the given index for
+           the edges returned in getEdgeView().
+      \param idx ranges from zero to one less than getNumWeightsPerEdge().
+   */
+  virtual void
+  getEdgeWeightsDeviceView(typename Base::WeightsDeviceView1D &weights,
+                           int /* idx */ = 0) const {
+    Z2_THROW_NOT_IMPLEMENTED
+  }
+
+  /*! \brief  Provide a device view of the edge weights, if any.
+      \param weights is the list of weights for the edges returned in getEdgeView().
+   */
+  virtual void
+  getEdgeWeightsDeviceView(typename Base::WeightsDeviceView &weights) const {
+    Z2_THROW_NOT_IMPLEMENTED
+  }
+
+  /*! \brief  Provide a host view of the edge weights, if any.
+      \param weights is the list of weights of the given index for
+           the edges returned in getEdgeView().
+      \param idx ranges from zero to one less than getNumWeightsPerEdge().
+   */
+  virtual void
+  getEdgeWeightsHostView(typename Base::WeightsHostView1D &weights,
+                         int /* idx */ = 0) const {
+    Z2_THROW_NOT_IMPLEMENTED
+  }
+
+  /*! \brief  Provide a host view of the edge weights, if any.
+      \param weights is the list of weights for the edges returned in getEdgeView().
+   */
+  virtual void
+  getEdgeWeightsHostView(typename Base::WeightsHostView &weights) const {
+    Z2_THROW_NOT_IMPLEMENTED
+  }
 
   /*! \brief Allow user to provide additional data that contains coordinate
-   *         info associated with the MatrixAdapter's primaryEntityType.
+   *         info associated with the MatrixAdapter's primaryEntityType_.
    *         Associated data must have the same parallel distribution and
-   *         ordering of entries as the primaryEntityType.
+   *         ordering of entries as the primaryEntityType_.
    *
    *  \param coordData is a pointer to a VectorAdapter with the user's
    *         coordinate data.
    */
-  void setCoordinateInput(VectorAdapter<UserCoord> *coordData) override
-  {
+  void setCoordinateInput(VectorAdapter<UserCoord> *coordData) override {
     coordinateInput_ = coordData;
     haveCoordinateInput_ = true;
   }
@@ -233,8 +339,7 @@ public:
   /*! \brief Obtain the coordinate data registered by the user.
    *  \return pointer a VectorAdapter with the user's coordinate data.
    */
-  VectorAdapter<UserCoord> *getCoordinateInput() const override
-  {
+  VectorAdapter<UserCoord> *getCoordinateInput() const override {
     return coordinateInput_;
   }
 
@@ -245,29 +350,24 @@ public:
    *  Valid values are GRAPH_VERTEX or GRAPH_EDGE.
    */
   inline enum GraphEntityType getPrimaryEntityType() const {
-    return this->primaryEntityType;
+    return this->primaryEntityType_;
   }
 
   /*! \brief Sets the primary entity type.  Called by algorithm based on
    *  parameter value in parameter list from application.
-   *  Also sets to adjacencyEntityType to something reasonable:  opposite of
-   *  primaryEntityType.
+   *  Also sets to adjacencyEntityType_ to something reasonable:  opposite of
+   *  primaryEntityType_.
    */
-  void setPrimaryEntityType(std::string typestr) {
+  void setPrimaryEntityType(const std::string &typestr) {
     if (typestr == "vertex") {
-      this->primaryEntityType = GRAPH_VERTEX;
-      this->adjacencyEntityType = GRAPH_EDGE;
-    }
-    else if (typestr == "edge") {
-      this->primaryEntityType = GRAPH_EDGE;
-      this->adjacencyEntityType = GRAPH_VERTEX;
-    }
-    else {
-      std::ostringstream emsg;
-      emsg << __FILE__ << "," << __LINE__
-           << " error:  Invalid GraphEntityType " << typestr << std::endl;
-      emsg << "Valid values are 'vertex' and 'edge'" << std::endl;
-      throw std::runtime_error(emsg.str());
+      this->primaryEntityType_ = GRAPH_VERTEX;
+      this->adjacencyEntityType_ = GRAPH_EDGE;
+    } else if (typestr == "edge") {
+      this->primaryEntityType_ = GRAPH_EDGE;
+      this->adjacencyEntityType_ = GRAPH_VERTEX;
+    } else {
+      AssertCondition(true, "Invalid GraphEntityType (" + typestr +
+                                "). Valid values are 'vertex' and 'edge'");
     }
   }
 
@@ -276,29 +376,24 @@ public:
    *  Valid values are GRAPH_VERTEX or GRAPH_EDGE.
    */
   inline enum GraphEntityType getAdjacencyEntityType() const {
-    return this->adjacencyEntityType;
+    return this->adjacencyEntityType_;
   }
 
   /*! \brief Sets the adjacency entity type.  Called by algorithm based on
    *  parameter value in parameter list from application.
-   *  Also sets to primaryEntityType to something reasonable:  opposite of
-   *  adjacencyEntityType.
+   *  Also sets to primaryEntityType_ to something reasonable:  opposite of
+   *  adjacencyEntityType_.
    */
-  void setAdjacencyEntityType(std::string typestr) {
+  void setAdjacencyEntityType(const std::string &typestr) {
     if (typestr == "vertex") {
-      this->adjacencyEntityType = GRAPH_VERTEX;
-      this->primaryEntityType = GRAPH_EDGE;
-    }
-    else if (typestr == "edge") {
-      this->adjacencyEntityType = GRAPH_EDGE;
-      this->primaryEntityType = GRAPH_VERTEX;
-    }
-    else {
-      std::ostringstream emsg;
-      emsg << __FILE__ << "," << __LINE__
-           << " error:  Invalid GraphEntityType " << typestr << std::endl;
-      emsg << "Valid values are 'vertex' and 'edge'" << std::endl;
-      throw std::runtime_error(emsg.str());
+      this->adjacencyEntityType_ = GRAPH_VERTEX;
+      this->primaryEntityType_ = GRAPH_EDGE;
+    } else if (typestr == "edge") {
+      this->adjacencyEntityType_ = GRAPH_EDGE;
+      this->primaryEntityType_ = GRAPH_VERTEX;
+    } else {
+      AssertCondition(true, "Invalid GraphEntityType (" + typestr +
+                                "). Valid values are 'vertex' and 'edge'");
     }
   }
 
@@ -308,20 +403,27 @@ public:
       return getLocalNumVertices();
     else
       return getLocalNumEdges();
-   }
+  }
 
   void getIDsView(const gno_t *&Ids) const override {
-    if (getPrimaryEntityType() == GRAPH_VERTEX)
-      getVertexIDsView(Ids);
-    else {
-      // TODO:  Need getEdgeIDsView?  What is an Edge ID?
-      // TODO:  std::pair<gno_t, gno_t>?
-      std::ostringstream emsg;
-      emsg << __FILE__ << "," << __LINE__
-           << " error:  getIDsView not yet supported for graph edges."
-           << std::endl;
-      throw std::runtime_error(emsg.str());
-    }
+    AssertCondition(getPrimaryEntityType() == GRAPH_VERTEX,
+                    "getIDsView not yet supported for graph edges.");
+
+    getVertexIDsView(Ids);
+  }
+
+  void getIDsDeviceView(typename Base::ConstIdsDeviceView &Ids) const override {
+    AssertCondition(getPrimaryEntityType() == GRAPH_VERTEX,
+                    "getIDsDeviceView not yet supported for graph edges.");
+
+    getVertexIDsDeviceView(Ids);
+  }
+
+  void getIDsHostView(typename Base::ConstIdsHostView &Ids) const override {
+    AssertCondition(getPrimaryEntityType() == GRAPH_VERTEX,
+                    "getIDsHostView not yet supported for graph edges.");
+
+    getVertexIDsHostView(Ids);
   }
 
   int getNumWeightsPerID() const override {
@@ -331,34 +433,53 @@ public:
       return getNumWeightsPerEdge();
   }
 
-  void getWeightsView(const scalar_t *&wgt, int &stride, int idx = 0) const override {
-    if (getPrimaryEntityType() == GRAPH_VERTEX)
-      getVertexWeightsView(wgt, stride, idx);
-    else {
-      // TODO:  Need getEdgeWeightsView that lets Edges be primary object?
-      // TODO:  That is, get edge weights based on some Edge ID.
-      std::ostringstream emsg;
-      emsg << __FILE__ << "," << __LINE__
-           << " error:  getWeightsView not yet supported for graph edges."
-           << std::endl;
-      throw std::runtime_error(emsg.str());
-    }
+  void getWeightsView(const scalar_t *&wgt, int &stride,
+                      int idx = 0) const override {
+
+    AssertCondition(getPrimaryEntityType() == GRAPH_VERTEX,
+                    "getWeightsView not yet supported for graph edges.");
+
+    getVertexWeightsView(wgt, stride, idx);
   }
 
-  bool useDegreeAsWeight(int idx) const
-  {
-    if (this->getPrimaryEntityType() == GRAPH_VERTEX)
-      return useDegreeAsVertexWeight(idx);
-    else {
-      std::ostringstream emsg;
-      emsg << __FILE__ << "," << __LINE__
-           << " error:  useDegreeAsWeight is supported only for vertices"
-           << std::endl;
-      throw std::runtime_error(emsg.str());
-    }
+  void getWeightsHostView(typename Base::WeightsHostView1D &hostWgts,
+                          int idx = 0) const override {
+    AssertCondition(getPrimaryEntityType() == GRAPH_VERTEX,
+                    "getWeightsHostView not yet supported for graph edges.");
+
+    getVertexWeightsHostView(hostWgts, idx);
+  }
+
+  void getWeightsHostView(typename Base::WeightsHostView &hostWgts) const override {
+    AssertCondition(getPrimaryEntityType() == GRAPH_VERTEX,
+                    "getWeightsHostView not yet supported for graph edges.");
+
+    getVertexWeightsHostView(hostWgts);
+  }
+
+  void getWeightsDeviceView(typename Base::WeightsDeviceView1D &deviceWgts,
+                            int idx = 0) const override {
+    AssertCondition(getPrimaryEntityType() == GRAPH_VERTEX,
+                    "getWeightsDeviceView not yet supported for graph edges.");
+
+    getVertexWeightsDeviceView(deviceWgts, idx);
+  }
+
+  void getWeightsDeviceView(typename Base::WeightsDeviceView &deviceWgts) const override {
+    AssertCondition(getPrimaryEntityType() == GRAPH_VERTEX,
+                    "getWeightsDeviceView not yet supported for graph edges.");
+
+    getVertexWeightsDeviceView(deviceWgts);
+  }
+
+  bool useDegreeAsWeight(int idx) const {
+    AssertCondition(this->getPrimaryEntityType() == GRAPH_VERTEX,
+                    "useDegreeAsWeight not yet supported for graph edges.");
+
+    return useDegreeAsVertexWeight(idx);
   }
 };
 
-}  //namespace Zoltan2
+} // namespace Zoltan2
 
 #endif

--- a/packages/zoltan2/core/src/input/Zoltan2_IdentifierAdapter.hpp
+++ b/packages/zoltan2/core/src/input/Zoltan2_IdentifierAdapter.hpp
@@ -108,10 +108,6 @@ public:
   typedef IdentifierAdapter<User> base_adapter_t;
 #endif
 
-  /*! \brief Destructor
-   */
-  virtual ~IdentifierAdapter() {};
-
   enum BaseAdapterType adapterType() const {return IdentifierAdapterType;}
 };
 

--- a/packages/zoltan2/core/src/input/Zoltan2_MatrixAdapter.hpp
+++ b/packages/zoltan2/core/src/input/Zoltan2_MatrixAdapter.hpp
@@ -112,15 +112,15 @@ private:
 public:
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
-  typedef typename InputTraits<User>::scalar_t scalar_t;
-  typedef typename InputTraits<User>::lno_t    lno_t;
-  typedef typename InputTraits<User>::gno_t    gno_t;
-  typedef typename InputTraits<User>::part_t   part_t;
-  typedef typename InputTraits<User>::node_t   node_t;
-  typedef typename InputTraits<User>::offset_t offset_t;
-  typedef User user_t;
-  typedef UserCoord userCoord_t;
-  typedef MatrixAdapter<User,UserCoord> base_adapter_t;
+  using scalar_t = typename InputTraits<User>::scalar_t;
+  using lno_t = typename InputTraits<User>::lno_t;
+  using gno_t = typename InputTraits<User>::gno_t;
+  using part_t = typename InputTraits<User>::part_t;
+  using node_t = typename InputTraits<User>::node_t;
+  using offset_t = typename InputTraits<User>::offset_t;
+  using user_t = User;
+  using userCoord_t = UserCoord;
+  using base_adapter_t = MatrixAdapter<User,UserCoord>;
 #endif
 
   enum BaseAdapterType adapterType() const override {return MatrixAdapterType;}
@@ -129,10 +129,6 @@ public:
   MatrixAdapter() : primaryEntityType_(MATRIX_ROW),
                     coordinateInput_(),
                     haveCoordinateInput_(false) {}
-
-  /*! \brief Destructor
-   */
-  virtual ~MatrixAdapter(){}
 
   /*! \brief Returns the number of rows on this process.
    */
@@ -164,6 +160,16 @@ public:
     Z2_THROW_NOT_IMPLEMENTED
   }
 
+  virtual void getRowIDsHostView(typename BaseAdapter<User>::ConstIdsHostView& rowIds) const
+  {
+    Z2_THROW_NOT_IMPLEMENTED
+  }
+
+  virtual void getRowIDsDeviceView(typename BaseAdapter<User>::ConstIdsDeviceView& rowIds) const
+  {
+    Z2_THROW_NOT_IMPLEMENTED
+  }
+
   /*! \brief Sets pointers to this process' matrix entries using
              compressed sparse row (CRS) format.
              All matrix adapters must implement either getCRSView or
@@ -182,6 +188,19 @@ public:
     colIds = ArrayRCP<const gno_t>();
     Z2_THROW_NOT_IMPLEMENTED
   }
+
+  virtual void getCRSHostView(typename BaseAdapter<User>::ConstOffsetsHostView& offsets,
+                              typename BaseAdapter<User>::ConstIdsHostView& colIds) const
+  {
+      Z2_THROW_NOT_IMPLEMENTED
+  }
+
+  virtual void getCRSDeviceView(typename BaseAdapter<User>::ConstOffsetsDeviceView& offsets,
+                                typename BaseAdapter<User>::ConstIdsDeviceView& colIds) const
+  {
+      Z2_THROW_NOT_IMPLEMENTED
+  }
+
 
   /*! \brief Sets pointers to this process' matrix entries
              and their values using
@@ -208,6 +227,21 @@ public:
     Z2_THROW_NOT_IMPLEMENTED
   }
 
+  virtual void getCRSHostView(typename BaseAdapter<User>::ConstOffsetsHostView& offsets,
+                              typename BaseAdapter<User>::ConstIdsHostView& colIds,
+                              typename BaseAdapter<User>::ConstScalarsHostView& values) const
+  {
+      Z2_THROW_NOT_IMPLEMENTED
+  }
+
+  virtual void getCRSDeviceView(typename BaseAdapter<User>::ConstOffsetsDeviceView& offsets,
+                                typename BaseAdapter<User>::ConstIdsDeviceView& colIds,
+                                typename BaseAdapter<User>::ConstScalarsDeviceView& values) const
+  {
+      Z2_THROW_NOT_IMPLEMENTED
+  }
+
+
   /*! \brief Returns the number of weights per row (0 or greater).
       Row weights may be used when partitioning matrix rows.
    */
@@ -226,6 +260,16 @@ public:
     weights = NULL;
     stride = 0;
     Z2_THROW_NOT_IMPLEMENTED
+  }
+
+  virtual void getRowWeightsHostView(typename BaseAdapter<User>::WeightsHostView& weights) const
+  {
+      Z2_THROW_NOT_IMPLEMENTED
+  }
+
+  virtual void getRowWeightsDeviceView(typename BaseAdapter<User>::WeightsDeviceView& weights) const
+  {
+      Z2_THROW_NOT_IMPLEMENTED
   }
 
   /*! \brief Indicate whether row weight with index idx should be the
@@ -249,6 +293,16 @@ public:
   virtual void getColumnIDsView(const gno_t *&colIds) const
   {
     colIds = NULL;
+    Z2_THROW_NOT_IMPLEMENTED
+  }
+
+  virtual void getColumnIDsHostView(typename BaseAdapter<User>::ConstIdsHostView& colIds) const
+  {
+    Z2_THROW_NOT_IMPLEMENTED
+  }
+
+  virtual void getColumnIDsDeviceView(typename BaseAdapter<User>::ConstIdsDeviceView& colIds) const
+  {
     Z2_THROW_NOT_IMPLEMENTED
   }
 
@@ -315,6 +369,16 @@ public:
     weights = NULL;
     stride = 0;
     Z2_THROW_NOT_IMPLEMENTED
+  }
+
+  virtual void getColumnWeightsHostView(typename BaseAdapter<User>::WeightsHostView& weights) const
+  {
+      Z2_THROW_NOT_IMPLEMENTED
+  }
+
+  virtual void getColumnWeightsDeviceView(typename BaseAdapter<User>::WeightsDeviceView& weights) const
+  {
+      Z2_THROW_NOT_IMPLEMENTED
   }
 
   /*! \brief Indicate whether column weight with index idx should be the
@@ -431,6 +495,50 @@ public:
     }
   }
 
+  void getIDsHostView(typename BaseAdapter<User>::ConstIdsHostView& ids) const override {
+    switch (getPrimaryEntityType()) {
+    case MATRIX_ROW:
+      getRowIDsHostView(ids);
+      break;
+    case MATRIX_COLUMN:
+      getColumnIDsHostView(ids);
+      break;
+    case MATRIX_NONZERO: {
+      // TODO:  Need getNonzeroIDsHostView?  What is a Nonzero ID?
+      // TODO:  std::pair<gno_t, gno_t>?
+      std::ostringstream emsg;
+      emsg << __FILE__ << "," << __LINE__
+           << " error:  getIDsView not yet supported for matrix nonzeros."
+           << std::endl;
+      throw std::runtime_error(emsg.str());
+      }
+    default:   // Shouldn't reach default; just making compiler happy
+      break;
+    }
+  }
+
+  void getIDsDeviceView(typename BaseAdapter<User>::ConstIdsDeviceView& ids) const override {
+    switch (getPrimaryEntityType()) {
+    case MATRIX_ROW:
+      getRowIDsDeviceView(ids);
+      break;
+    case MATRIX_COLUMN:
+      getColumnIDsDeviceView(ids);
+      break;
+    case MATRIX_NONZERO: {
+      // TODO:  Need getNonzeroIDsDeviceView?  What is a Nonzero ID?
+      // TODO:  std::pair<gno_t, gno_t>?
+      std::ostringstream emsg;
+      emsg << __FILE__ << "," << __LINE__
+           << " error:  getIDsView not yet supported for matrix nonzeros."
+           << std::endl;
+      throw std::runtime_error(emsg.str());
+      }
+    default:   // Shouldn't reach default; just making compiler happy
+      break;
+    }
+  }
+
   int getNumWeightsPerID() const override
   {
     switch (getPrimaryEntityType()) {
@@ -468,6 +576,50 @@ public:
       break;
     }
   }
+
+  virtual void getWeightsHostView(typename BaseAdapter<User>::WeightsHostView& hostWgts) const {
+      switch (getPrimaryEntityType()) {
+      case MATRIX_ROW:
+        getRowWeightsHostView(hostWgts);
+        break;
+      case MATRIX_COLUMN:
+        getColumnWeightsHostView(hostWgts);
+        break;
+      case MATRIX_NONZERO:
+        {
+        // TODO:  Need getNonzeroWeightsView with Nonzeros as primary object?
+        // TODO:  That is, get Nonzeros' weights based on some nonzero ID?
+        std::ostringstream emsg;
+        emsg << __FILE__ << "," << __LINE__
+             << " error:  getWeightsView not yet supported for matrix nonzeros."
+             << std::endl;
+        throw std::runtime_error(emsg.str());
+        }
+      default:   // Shouldn't reach default; just making compiler happy
+        break;
+      }  }
+
+  virtual void getWeightsDeviceView(typename BaseAdapter<User>::WeightsDeviceView& deviceWgts) const {
+      switch (getPrimaryEntityType()) {
+      case MATRIX_ROW:
+        getRowWeightsDeviceView(deviceWgts);
+        break;
+      case MATRIX_COLUMN:
+        getColumnWeightsDeviceView(deviceWgts);
+        break;
+      case MATRIX_NONZERO:
+        {
+        // TODO:  Need getNonzeroWeightsView with Nonzeros as primary object?
+        // TODO:  That is, get Nonzeros' weights based on some nonzero ID?
+        std::ostringstream emsg;
+        emsg << __FILE__ << "," << __LINE__
+             << " error:  getWeightsView not yet supported for matrix nonzeros."
+             << std::endl;
+        throw std::runtime_error(emsg.str());
+        }
+      default:   // Shouldn't reach default; just making compiler happy
+        break;
+      }  }
 
   bool useDegreeAsWeight(int idx) const
   {

--- a/packages/zoltan2/core/src/input/Zoltan2_MeshAdapter.hpp
+++ b/packages/zoltan2/core/src/input/Zoltan2_MeshAdapter.hpp
@@ -138,10 +138,6 @@ public:
 
   enum BaseAdapterType adapterType() const override {return MeshAdapterType;}
 
-  /*! \brief Destructor
-   */
-  virtual ~MeshAdapter() {};
-
   // Default MeshEntityType is MESH_REGION with MESH_FACE-based adjacencies and
   // second adjacencies and coordinates
   MeshAdapter() : primaryEntityType(MESH_REGION),

--- a/packages/zoltan2/core/src/input/Zoltan2_TpetraCrsGraphAdapter.hpp
+++ b/packages/zoltan2/core/src/input/Zoltan2_TpetraCrsGraphAdapter.hpp
@@ -1,0 +1,184 @@
+// @HEADER
+//
+// ***********************************************************************
+//
+//   Zoltan2: A package of combinatorial algorithms for scientific computing
+//                  Copyright 2012 Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Karen Devine      (kddevin@sandia.gov)
+//                    Erik Boman        (egboman@sandia.gov)
+//                    Siva Rajamanickam (srajama@sandia.gov)
+//
+// ***********************************************************************
+//
+// @HEADER
+
+/*! \file Zoltan2_TpetraCrsGraphAdapter.hpp
+    \brief Defines TpetraCrsGraphAdapter class.
+*/
+
+#ifndef _ZOLTAN2_TPETRACRSGRAPHADAPTER_HPP_
+#define _ZOLTAN2_TPETRACRSGRAPHADAPTER_HPP_
+
+#include <Zoltan2_PartitioningHelpers.hpp>
+#include <Zoltan2_StridedData.hpp>
+#include <Zoltan2_TpetraRowGraphAdapter.hpp>
+#include <Zoltan2_XpetraTraits.hpp>
+#include <string>
+
+namespace Zoltan2 {
+
+/*!  \brief Provides access for Zoltan2 to Tpetra::CrsGraph data.
+
+    \todo test for memory alloc failure when we resize a vector
+    \todo we assume FillComplete has been called.  Should we support
+                objects that are not FillCompleted.
+*/
+
+template <typename User, typename UserCoord = User>
+class TpetraCrsGraphAdapter : public TpetraRowGraphAdapter<User, UserCoord> {
+
+public:
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+  using scalar_t = typename InputTraits<User>::scalar_t;
+  using offset_t = typename InputTraits<User>::offset_t;
+  using lno_t = typename InputTraits<User>::lno_t;
+  using gno_t = typename InputTraits<User>::gno_t;
+  using part_t = typename InputTraits<User>::part_t;
+  using node_t = typename InputTraits<User>::node_t;
+  using user_t = User;
+  using userCoord_t = UserCoord;
+
+  using Base = GraphAdapter<User, UserCoord>;
+  using RowGraph = TpetraRowGraphAdapter<User, UserCoord>;
+#endif
+
+  /*! \brief Constructor for graph with no weights or coordinates.
+   *  \param ingraph the Tpetra::CrsGraph
+   *  \param numVtxWeights  the number of weights per vertex (default = 0)
+   *  \param numEdgeWeights the number of weights per edge  (default = 0)
+   *
+   * Most adapters do not have RCPs in their interface.  This
+   * one does because the user is obviously a Trilinos user.
+   */
+
+  TpetraCrsGraphAdapter(const RCP<const User> &graph, int nVtxWeights = 0,
+                        int nEdgeWeights = 0);
+
+  /*! \brief Access to user's graph
+   */
+  RCP<const User> getUserGraph() const { return this->graph_; }
+
+  template <typename Adapter>
+  void applyPartitioningSolution(
+      const User &in, User *&out,
+      const PartitioningSolution<Adapter> &solution) const;
+
+  template <typename Adapter>
+  void applyPartitioningSolution(
+      const User &in, RCP<User> &out,
+      const PartitioningSolution<Adapter> &solution) const;
+};
+
+/////////////////////////////////////////////////////////////////
+// Definitions
+/////////////////////////////////////////////////////////////////
+
+template <typename User, typename UserCoord>
+TpetraCrsGraphAdapter<User, UserCoord>::TpetraCrsGraphAdapter(
+    const RCP<const User> &graph, int nVtxWgts, int nEdgeWgts)
+    : TpetraRowGraphAdapter<User>(nVtxWgts, nEdgeWgts, graph) {
+  auto adjIdsHost = graph->getLocalIndicesHost();
+
+  auto adjIdsGlobalHost =
+      typename Base::IdsHostView("adjIdsGlobalHost", adjIdsHost.extent(0));
+  auto colMap = graph->getColMap();
+
+  // Convert to global IDs using Tpetra::Map
+  Kokkos::parallel_for("adjIdsGlobalHost",
+                       Kokkos::RangePolicy<Kokkos::HostSpace::execution_space>(
+                           0, adjIdsGlobalHost.extent(0)),
+                       [=](const int i) {
+                         adjIdsGlobalHost(i) =
+                             colMap->getGlobalElement(adjIdsHost(i));
+                       });
+
+  auto adjIdsDevice = Kokkos::create_mirror_view_and_copy(
+      typename Base::device_t(), adjIdsGlobalHost);
+
+  this->adjIdsDevice_ = adjIdsDevice;
+  this->offsDevice_ = graph->getLocalRowPtrsDevice();
+
+  if (this->nWeightsPerVertex_ > 0) {
+
+    this->vertexWeightsDevice_ = typename Base::WeightsDeviceView(
+        "vertexWeightsDevice_", graph->getLocalNumRows(),
+        this->nWeightsPerVertex_);
+
+    this->vertexDegreeWeightsHost_ = typename Base::VtxDegreeHostView(
+        "vertexDegreeWeightsHost_", this->nWeightsPerVertex_);
+
+    for (int i = 0; i < this->nWeightsPerVertex_; ++i) {
+      this->vertexDegreeWeightsHost_(i) = false;
+    }
+  }
+
+  if (this->nWeightsPerEdge_) {
+    this->edgeWeightsDevice_ = typename Base::WeightsDeviceView(
+        "nWeightsPerEdge_", graph->getLocalNumRows(), this->nWeightsPerEdge_);
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////
+template <typename User, typename UserCoord>
+template <typename Adapter>
+void TpetraCrsGraphAdapter<User, UserCoord>::applyPartitioningSolution(
+    const User &in, User *&out,
+    const PartitioningSolution<Adapter> &solution) const {
+  TpetraRowGraphAdapter<User, UserCoord>::applyPartitioningSolution(in, out,
+                                                                    solution);
+}
+
+////////////////////////////////////////////////////////////////////////////
+template <typename User, typename UserCoord>
+template <typename Adapter>
+void TpetraCrsGraphAdapter<User, UserCoord>::applyPartitioningSolution(
+    const User &in, RCP<User> &out,
+    const PartitioningSolution<Adapter> &solution) const {
+  TpetraRowGraphAdapter<User, UserCoord>::applyPartitioningSolution(in, out,
+                                                                    solution);
+}
+
+} // namespace Zoltan2
+
+#endif

--- a/packages/zoltan2/core/src/input/Zoltan2_VectorAdapter.hpp
+++ b/packages/zoltan2/core/src/input/Zoltan2_VectorAdapter.hpp
@@ -110,10 +110,6 @@ public:
   typedef VectorAdapter<User> base_adapter_t;
 #endif
 
-  /*! \brief Destructor
-   */
-  virtual ~VectorAdapter() {};
-
   ////////////////////////////////////////////////////
   // The Adapter interface.
   ////////////////////////////////////////////////////

--- a/packages/zoltan2/core/src/input/Zoltan2_XpetraCrsMatrixAdapter.hpp
+++ b/packages/zoltan2/core/src/input/Zoltan2_XpetraCrsMatrixAdapter.hpp
@@ -98,12 +98,8 @@ public:
   typedef UserCoord userCoord_t;
 #endif
 
-  /*! \brief Destructor
-   */
-  ~XpetraCrsMatrixAdapter() { }
-
-  /*! \brief Constructor   
-   *    \param inmatrix The users Epetra, Tpetra, or Xpetra CrsMatrix object 
+  /*! \brief Constructor
+   *    \param inmatrix The users Epetra, Tpetra, or Xpetra CrsMatrix object
    *    \param nWeightsPerRow If row weights will be provided in setRowWeights(),
    *        the set \c nWeightsPerRow to the number of weights per row.
    */
@@ -115,10 +111,10 @@ public:
    *    \stride          A stride to be used in reading the values.  The
    *        index \c idx weight for entity \k should be found at
    *        <tt>weightVal[k*stride]</tt>.
-   *    \param idx  A value between zero and one less that the \c nWeightsPerRow 
+   *    \param idx  A value between zero and one less that the \c nWeightsPerRow
    *                  argument to the constructor.
    *
-   * The order of weights should correspond to the order of the primary 
+   * The order of weights should correspond to the order of the primary
    * entity type; see, e.g.,  setRowWeights below.
    */
 
@@ -129,7 +125,7 @@ public:
    *    \stride          A stride to be used in reading the values.  The
    *        index \c idx weight for row \k should be found at
    *        <tt>weightVal[k*stride]</tt>.
-   *    \param idx  A value between zero and one less that the \c nWeightsPerRow 
+   *    \param idx  A value between zero and one less that the \c nWeightsPerRow
    *                  argument to the constructor.
    *
    * The order of weights should correspond to the order of rows
@@ -143,7 +139,7 @@ public:
 
   /*! \brief Specify an index for which the weight should be
               the degree of the entity
-   *    \param idx Zoltan2 will use the entity's 
+   *    \param idx Zoltan2 will use the entity's
    *         degree as the entity weight for index \c idx.
    */
   void setWeightIsDegree(int idx);
@@ -159,11 +155,11 @@ public:
   // The MatrixAdapter interface.
   ////////////////////////////////////////////////////
 
-  size_t getLocalNumRows() const { 
+  size_t getLocalNumRows() const {
     return matrix_->getLocalNumRows();
   }
 
-  size_t getLocalNumColumns() const { 
+  size_t getLocalNumColumns() const {
     return matrix_->getLocalNumCols();
   }
 
@@ -173,7 +169,7 @@ public:
 
   bool CRSViewAvailable() const { return true; }
 
-  void getRowIDsView(const gno_t *&rowIds) const 
+  void getRowIDsView(const gno_t *&rowIds) const
   {
     ArrayView<const gno_t> rowView = rowMap_->getLocalElementList();
     rowIds = rowView.getRawPtr();
@@ -208,7 +204,7 @@ public:
       std::ostringstream emsg;
       emsg << __FILE__ << ":" << __LINE__
            << "  Invalid row weight index " << idx << std::endl;
-      throw std::runtime_error(emsg.str()); 
+      throw std::runtime_error(emsg.str());
     }
 
     size_t length;
@@ -314,7 +310,7 @@ template <typename User, typename UserCoord>
       std::ostringstream emsg;
       emsg << __FILE__ << ":" << __LINE__
            << "  Invalid row weight index " << idx << std::endl;
-      throw std::runtime_error(emsg.str()); 
+      throw std::runtime_error(emsg.str());
   }
 
   size_t nvtx = getLocalNumRows();
@@ -349,7 +345,7 @@ template <typename User, typename UserCoord>
       std::ostringstream emsg;
       emsg << __FILE__ << ":" << __LINE__
            << "  Invalid row weight index " << idx << std::endl;
-      throw std::runtime_error(emsg.str()); 
+      throw std::runtime_error(emsg.str());
   }
 
 
@@ -360,9 +356,9 @@ template <typename User, typename UserCoord>
 template <typename User, typename UserCoord>
   template <typename Adapter>
     void XpetraCrsMatrixAdapter<User,UserCoord>::applyPartitioningSolution(
-      const User &in, User *&out, 
+      const User &in, User *&out,
       const PartitioningSolution<Adapter> &solution) const
-{ 
+{
   // Get an import list (rows to be received)
   size_t numNewRows;
   ArrayRCP<gno_t> importList;
@@ -384,9 +380,9 @@ template <typename User, typename UserCoord>
 template <typename User, typename UserCoord>
   template <typename Adapter>
     void XpetraCrsMatrixAdapter<User,UserCoord>::applyPartitioningSolution(
-      const User &in, RCP<User> &out, 
+      const User &in, RCP<User> &out,
       const PartitioningSolution<Adapter> &solution) const
-{ 
+{
   // Get an import list (rows to be received)
   size_t numNewRows;
   ArrayRCP<gno_t> importList;
@@ -403,5 +399,5 @@ template <typename User, typename UserCoord>
 }
 
 }  //namespace Zoltan2
-  
+
 #endif

--- a/packages/zoltan2/core/src/input/Zoltan2_XpetraMultiVectorAdapter.hpp
+++ b/packages/zoltan2/core/src/input/Zoltan2_XpetraMultiVectorAdapter.hpp
@@ -97,10 +97,6 @@ public:
     scalar_t, lno_t, gno_t, node_t> xt_mvector_t;
 #endif
 
-  /*! \brief Destructor
-   */
-  ~XpetraMultiVectorAdapter() { }
-
   /*! \brief Constructor
    *
    *  \param invector  the user's Xpetra, Tpetra or Epetra MultiVector object
@@ -177,7 +173,7 @@ public:
         std::ostringstream emsg;
         emsg << __FILE__ << ":" << __LINE__
              << "  Invalid weight index " << idx << std::endl;
-        throw std::runtime_error(emsg.str()); 
+        throw std::runtime_error(emsg.str());
     }
 
     size_t length;

--- a/packages/zoltan2/core/src/util/Zoltan2_Util.hpp
+++ b/packages/zoltan2/core/src/util/Zoltan2_Util.hpp
@@ -54,6 +54,7 @@
 
 #include <Zoltan2_Standards.hpp>
 #include <Teuchos_DefaultComm.hpp>
+#include <stdexcept>
 
 namespace Zoltan2{
 
@@ -64,6 +65,16 @@ template <typename scalar_t>
     return ((val < mark-epsilon) || (val > mark+epsilon));
 }
 
+static inline void
+AssertCondition(bool condition, const std::string &message,
+                const char *file = __FILE__, int line = __LINE__) {
+    if (!condition) {
+      std::ostringstream eMsg;
+      eMsg << "Error: " << file << ", " << line << ": " << message
+                << std::endl;
+      throw std::runtime_error(eMsg.str());
+    }
+}
 
 } // namespace Zoltan2
 

--- a/packages/zoltan2/test/core/scaling/rcbPerformanceZ1.cpp
+++ b/packages/zoltan2/test/core/scaling/rcbPerformanceZ1.cpp
@@ -53,15 +53,6 @@
 #include <zoltan.h>
 
 #include <Zoltan2_Util.hpp>
-#define MEMORY_CHECK(iPrint, msg) \
-  if (iPrint){ \
-    long kb = Zoltan2::getProcessKilobytes(); \
-    std::cout.width(10); \
-    std::cout.fill('*'); \
-    std::cout << kb << " KB, " << msg << std::endl; \
-    std::cout.width(0); \
-    std::cout.fill(' '); \
-  }
 
 #include <Teuchos_RCP.hpp>
 #include <Teuchos_ArrayView.hpp>

--- a/packages/zoltan2/test/core/unit/CMakeLists.txt
+++ b/packages/zoltan2/test/core/unit/CMakeLists.txt
@@ -98,7 +98,7 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   PASS_REGULAR_EXPRESSION "PASS"
   FAIL_REGULAR_EXPRESSION "FAIL"
   )
- 
+
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   BasicIdentifierInput
   SOURCES input/BasicIdentifierInput.cpp
@@ -157,10 +157,10 @@ TRIBITS_COPY_FILES_TO_BINARY_DIR(copy_files_for_scorec_unit_tests
 )
 
 ENDIF()
- 
+
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   TpetraRowMatrixInput
-  SOURCES input/TpetraRowMatrixInput.cpp 
+  SOURCES input/TpetraRowMatrixInput.cpp
   NUM_MPI_PROCS 4
   COMM serial mpi
   PASS_REGULAR_EXPRESSION "PASS"
@@ -177,26 +177,35 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   )
 
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
-  XpetraTraits
-  SOURCES input/XpetraTraits.cpp 
+  TpetraRowGraphInputKokkos
+  SOURCES input/TpetraRowGraphInputKokkos.cpp
   NUM_MPI_PROCS 4
   COMM serial mpi
   PASS_REGULAR_EXPRESSION "PASS"
   FAIL_REGULAR_EXPRESSION "FAIL"
   )
- 
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  XpetraTraits
+  SOURCES input/XpetraTraits.cpp
+  NUM_MPI_PROCS 4
+  COMM serial mpi
+  PASS_REGULAR_EXPRESSION "PASS"
+  FAIL_REGULAR_EXPRESSION "FAIL"
+  )
+
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   XpetraCrsMatrixInput
-  SOURCES input/XpetraCrsMatrixInput.cpp 
+  SOURCES input/XpetraCrsMatrixInput.cpp
   NUM_MPI_PROCS 4
   COMM serial mpi
   PASS_REGULAR_EXPRESSION "PASS"
   FAIL_REGULAR_EXPRESSION "FAIL"
   )
- 
+
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   XpetraCrsGraphInput
-  SOURCES input/XpetraCrsGraphInput.cpp 
+  SOURCES input/XpetraCrsGraphInput.cpp
   NUM_MPI_PROCS 4
   COMM serial mpi
   PASS_REGULAR_EXPRESSION "PASS"
@@ -205,7 +214,7 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
 
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   XpetraVectorInput
-  SOURCES input/XpetraVectorInput.cpp 
+  SOURCES input/XpetraVectorInput.cpp
   NUM_MPI_PROCS 4
   COMM serial mpi
   PASS_REGULAR_EXPRESSION "PASS"
@@ -214,7 +223,7 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
 
 TRIBITS_ADD_EXECUTABLE(
   XpetraMultiVectorInput
-  SOURCES input/XpetraMultiVectorInput.cpp 
+  SOURCES input/XpetraMultiVectorInput.cpp
   COMM serial mpi
   )
 
@@ -251,7 +260,7 @@ TRIBITS_ADD_TEST(
 #
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   GraphModel
-  SOURCES models/GraphModel.cpp 
+  SOURCES models/GraphModel.cpp
   NUM_MPI_PROCS 4
   COMM serial mpi
   PASS_REGULAR_EXPRESSION "PASS"
@@ -274,7 +283,7 @@ ENDIF()
 IF (${PROJECT_NAME}_ENABLE_Pamgen)
   TRIBITS_ADD_EXECUTABLE_AND_TEST(
     GraphModel2ndAdjsFromAdjs
-    SOURCES models/GraphModel2ndAdjsFromAdjs.cpp 
+    SOURCES models/GraphModel2ndAdjsFromAdjs.cpp
     NUM_MPI_PROCS 4
     COMM serial mpi
     PASS_REGULAR_EXPRESSION "PASS"
@@ -294,6 +303,15 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   CoordinateModel
   SOURCES models/CoordinateModel.cpp
+  NUM_MPI_PROCS 4
+  COMM serial mpi
+  PASS_REGULAR_EXPRESSION "PASS"
+  FAIL_REGULAR_EXPRESSION "FAIL"
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  MatrixAdapter
+  SOURCES input/MatrixAdapter.cpp
   NUM_MPI_PROCS 4
   COMM serial mpi
   PASS_REGULAR_EXPRESSION "PASS"
@@ -339,7 +357,7 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
 
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   Metric
-  SOURCES util/Metric.cpp 
+  SOURCES util/Metric.cpp
   NUM_MPI_PROCS 4
   COMM serial mpi
   PASS_REGULAR_EXPRESSION "PASS"
@@ -348,7 +366,7 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
 
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   TPLTraits
-  SOURCES util/TPLTraits.cpp 
+  SOURCES util/TPLTraits.cpp
   NUM_MPI_PROCS 4
   COMM serial mpi
   PASS_REGULAR_EXPRESSION "PASS"

--- a/packages/zoltan2/test/core/unit/input/MatrixAdapter.cpp
+++ b/packages/zoltan2/test/core/unit/input/MatrixAdapter.cpp
@@ -1,0 +1,332 @@
+// @HEADER
+//
+// ***********************************************************************
+//
+//   Zoltan2: A package of combinatorial algorithms for scientific computing
+//                  Copyright 2012 Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Karen Devine      (kddevin@sandia.gov)
+//                    Erik Boman        (egboman@sandia.gov)
+//                    Siva Rajamanickam (srajama@sandia.gov)
+//
+// ***********************************************************************
+//
+// @HEADER
+//
+// Testing of GraphAdapter built from Xpetra matrix input adapters.
+//
+
+/*! \brief Test of GraphAdapter interface.
+ *
+ */
+
+#include "Kokkos_StaticCrsGraph.hpp"
+#include "Kokkos_UnorderedMap.hpp"
+#include <Zoltan2_BasicVectorAdapter.hpp>
+#include <Zoltan2_InputTraits.hpp>
+#include <Zoltan2_TestHelpers.hpp>
+#include <Zoltan2_TpetraRowMatrixAdapter.hpp>
+#include <Zoltan2_XpetraCrsMatrixAdapter.hpp>
+
+#include <bitset>
+#include <iostream>
+#include <string>
+
+#include <Teuchos_ArrayView.hpp>
+#include <Teuchos_Comm.hpp>
+#include <Teuchos_DefaultComm.hpp>
+#include <Teuchos_TestingHelpers.hpp>
+
+using Teuchos::ArrayView;
+using Teuchos::Comm;
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+
+using simpleUser_t = Zoltan2::BasicUserTypes<zscalar_t, zlno_t, zgno_t>;
+
+using tcrsMatrix_t = Tpetra::CrsMatrix<zscalar_t, zlno_t, zgno_t, znode_t>;
+using trowMatrix_t = Tpetra::RowMatrix<zscalar_t, zlno_t, zgno_t, znode_t>;
+using tmap_t = Tpetra::Map<zlno_t, zgno_t, znode_t>;
+
+using simpleVAdapter_t = Zoltan2::BasicVectorAdapter<simpleUser_t>;
+using baseMAdapter_t = Zoltan2::MatrixAdapter<tcrsMatrix_t, simpleUser_t>;
+using tRowMAdapter_t = typename Zoltan2::TpetraRowMatrixAdapter<trowMatrix_t, simpleUser_t>;
+using zoffset_t = typename baseMAdapter_t::offset_t;
+
+/////////////////////////////////////////////////////////////////////////////
+int main(int narg, char *arg[]) {
+  Tpetra::ScopeGuard tscope(&narg, &arg);
+  Teuchos::RCP<const Teuchos::Comm<int>> comm = Tpetra::getDefaultComm();
+
+  int rank = comm->getRank();
+
+  int nVtxWeights = 5;
+  int nnzWgtIdx = -1;
+  std::string fname("simple");
+
+  if (rank == 0)
+    std::cout << "TESTING base case (global)" << std::endl;
+
+  // Input generator
+  UserInputForTests *uinput;
+
+  uinput = new UserInputForTests(testDataFilePath, fname, comm, true);
+
+  RCP<tcrsMatrix_t> M = uinput->getUITpetraCrsMatrix();
+  RCP<trowMatrix_t> trM = rcp_dynamic_cast<trowMatrix_t>(M);
+  RCP<const trowMatrix_t> ctrM = rcp_const_cast<const trowMatrix_t>(trM);
+  zlno_t nLocalRows = M->getLocalNumRows();
+
+  // Weights:
+  zscalar_t **rowWeights = NULL;
+  Zoltan2::BaseAdapter<trowMatrix_t>::WeightsDeviceView kRowWeights(
+      Kokkos::ViewAllocateWithoutInitializing("kRowWeights"), nVtxWeights,
+      nLocalRows);
+
+  auto kRowWeightsHost = Kokkos::create_mirror_view(kRowWeights);
+
+  if (nVtxWeights > 0) {
+    rowWeights = new zscalar_t *[nVtxWeights];
+    for (int i = 0; i < nVtxWeights; i++) {
+      if (nnzWgtIdx == i) {
+        rowWeights[i] = NULL;
+        kRowWeightsHost(i, 0) = 0;
+      } else {
+        rowWeights[i] = new zscalar_t[nLocalRows];
+        for (zlno_t j = 0; j < nLocalRows; j++) {
+          rowWeights[i][j] = 200000 * i + j;
+          kRowWeightsHost(i, j) = 200000 * i + j;
+        }
+      }
+    }
+  }
+
+  Kokkos::deep_copy(kRowWeights, kRowWeightsHost);
+
+  tRowMAdapter_t tmi(ctrM, nVtxWeights);
+  for (int i = 0; i < nVtxWeights; i++) {
+    tmi.setWeights(rowWeights[i], 1, i);
+  }
+  tmi.setRowWeights(kRowWeights);
+
+  simpleVAdapter_t *via = NULL;
+
+  // Set up some fake input
+  zscalar_t **coords = NULL;
+  int coordDim = 3;
+
+  if (coordDim > 0) {
+    coords = new zscalar_t *[coordDim];
+    for (int i = 0; i < coordDim; i++) {
+      coords[i] = new zscalar_t[nLocalRows];
+      for (zlno_t j = 0; j < nLocalRows; j++) {
+        coords[i][j] = 100000 * i + j;
+      }
+    }
+  }
+
+  zgno_t *gids = NULL;
+  if (coordDim > 0) {
+    gids = new zgno_t[nLocalRows];
+    for (zlno_t i = 0; i < nLocalRows; i++)
+      gids[i] = M->getRowMap()->getGlobalElement(i);
+    via = new simpleVAdapter_t(nLocalRows, gids, coords[0],
+                               (coordDim > 1 ? coords[1] : NULL),
+                               (coordDim > 2 ? coords[2] : NULL), 1, 1, 1);
+    tmi.setCoordinateInput(via);
+  }
+
+  // TEST of getIDsView, getIDsKokkosView, getRowIDsView, getRowIDsHostView and
+  // getRowIDsDeviceView
+
+  const zgno_t *ids;
+  const zgno_t *rowIds;
+  Zoltan2::BaseAdapter<simpleUser_t>::ConstIdsDeviceView kIds;
+  Zoltan2::BaseAdapter<simpleUser_t>::ConstIdsHostView kHostIds;
+  Zoltan2::BaseAdapter<simpleUser_t>::ConstIdsDeviceView kDeviceIds;
+
+  tmi.getIDsView(ids);
+  tmi.getRowIDsView(rowIds);
+  tmi.getIDsKokkosView(kIds);
+  auto kIdsHost = Kokkos::create_mirror_view(kIds);
+  Kokkos::deep_copy(kIdsHost, kIds);
+
+  tmi.getRowIDsHostView(kHostIds);
+  tmi.getRowIDsDeviceView(kDeviceIds);
+
+  auto kDeviceIdsHost = Kokkos::create_mirror_view(kDeviceIds);
+  Kokkos::deep_copy(kDeviceIdsHost, kDeviceIds);
+
+  bool success = true;
+  for (size_t i = 0; i < tmi.getLocalNumIDs(); ++i) {
+    TEUCHOS_TEST_EQUALITY(ids[i], kIdsHost(i), std::cout, success);
+    TEUCHOS_TEST_EQUALITY(ids[i], rowIds[i], std::cout, success);
+    TEUCHOS_TEST_EQUALITY(kIdsHost(i), kHostIds(i), std::cout, success);
+    TEUCHOS_TEST_EQUALITY(kIdsHost(i), kDeviceIdsHost(i), std::cout, success);
+  }
+  TEST_FAIL_AND_EXIT(*comm, success, "ids != vertexIds != kIds", 1)
+
+  // TEST of getCRSView, getCRSHostView and getCRSDeviceView
+  //  const zoffset_t *offsets;
+  ArrayRCP<const zoffset_t> offsets;
+  ArrayRCP<const zgno_t> colIds;
+  Zoltan2::BaseAdapter<trowMatrix_t>::ConstOffsetsHostView kHostOffsets;
+  Zoltan2::BaseAdapter<trowMatrix_t>::ConstIdsHostView kHostColIds;
+  Zoltan2::BaseAdapter<trowMatrix_t>::ConstOffsetsDeviceView kDeviceOffsets;
+  Zoltan2::BaseAdapter<trowMatrix_t>::ConstIdsDeviceView kDeviceColIds;
+  tmi.getCRSView(offsets, colIds);
+  tmi.getCRSHostView(kHostOffsets, kHostColIds);
+  tmi.getCRSDeviceView(kDeviceOffsets, kDeviceColIds);
+
+  auto kDeviceColIdsHost = Kokkos::create_mirror_view(kDeviceColIds);
+  Kokkos::deep_copy(kDeviceColIdsHost, kDeviceColIds);
+
+  auto kDeviceOffsetsHost = Kokkos::create_mirror_view(kDeviceOffsets);
+  Kokkos::deep_copy(kDeviceOffsetsHost, kDeviceOffsets);
+
+  for (int i = 0; success && i < colIds.size(); i++) {
+    TEUCHOS_TEST_EQUALITY(colIds[i], kHostColIds(i), std::cout, success);
+    TEUCHOS_TEST_EQUALITY(colIds[i], kDeviceColIdsHost(i), std::cout, success);
+  }
+  TEST_FAIL_AND_EXIT(*comm, success, "colIds != kHostColIds != kDeviceColIds",
+                     1)
+
+  for (int i = 0; success && i < offsets.size(); i++) {
+    TEUCHOS_TEST_EQUALITY(offsets[i], kHostOffsets(i), std::cout, success);
+    TEUCHOS_TEST_EQUALITY(offsets[i], kDeviceOffsetsHost(i), std::cout,
+                          success);
+  }
+  TEST_FAIL_AND_EXIT(*comm, success,
+                     "offsets != kHostOffsets != kDeviceOffsets", 1)
+
+  ArrayRCP<const zscalar_t> values;
+  Zoltan2::BaseAdapter<trowMatrix_t>::ConstScalarsHostView kHostValues;
+  Zoltan2::BaseAdapter<trowMatrix_t>::ConstScalarsDeviceView kDeviceValues;
+
+  tmi.getCRSView(offsets, colIds, values);
+  tmi.getCRSHostView(kHostOffsets, kHostColIds, kHostValues);
+  tmi.getCRSDeviceView(kDeviceOffsets, kDeviceColIds, kDeviceValues);
+  auto kDeviceValuesHost = Kokkos::create_mirror_view(kDeviceValues);
+  Kokkos::deep_copy(kDeviceValuesHost, kDeviceValues);
+
+  for (int i = 0; success && i < colIds.size(); i++) {
+    TEUCHOS_TEST_EQUALITY(colIds[i], kHostColIds(i), std::cout, success);
+    TEUCHOS_TEST_EQUALITY(colIds[i], kDeviceColIdsHost(i), std::cout, success);
+  }
+  TEST_FAIL_AND_EXIT(*comm, success, "colIds != kHostColIds != kDeviceColIds",
+                     1)
+
+  for (int i = 0; success && i < offsets.size(); i++) {
+    TEUCHOS_TEST_EQUALITY(offsets[i], kHostOffsets(i), std::cout, success);
+    TEUCHOS_TEST_EQUALITY(offsets[i], kDeviceOffsetsHost(i), std::cout,
+                          success);
+  }
+  TEST_FAIL_AND_EXIT(*comm, success,
+                     "offsets != kHostOffsets != kDeviceOffsets", 1)
+
+  for (int i = 0; success && i < values.size(); i++) {
+    TEUCHOS_TEST_EQUALITY(values[i], kHostValues(i), std::cout, success);
+    TEUCHOS_TEST_EQUALITY(values[i], kDeviceValuesHost(i), std::cout, success);
+  }
+  TEST_FAIL_AND_EXIT(*comm, success, "values != kHostValues != kDeviceValues",
+                     1)
+
+  // TEST of getRowWeightsView, getRowWeightsHostView and
+  // getRowWeightsDeviceView
+  for (int w = 0; success && w < nVtxWeights; w++) {
+    const zscalar_t *wgts;
+    Zoltan2::BaseAdapter<trowMatrix_t>::WeightsHostView kHostWgts;
+    Zoltan2::BaseAdapter<trowMatrix_t>::WeightsDeviceView kDeviceWgts;
+
+    Kokkos::View<zscalar_t **, typename znode_t::device_type> wkgts;
+    int stride;
+    tmi.getRowWeightsView(wgts, stride, w);
+    tmi.getRowWeightsHostView(kHostWgts);
+    tmi.getRowWeightsDeviceView(kDeviceWgts);
+
+    auto kDeviceWgtsHost = Kokkos::create_mirror_view(kDeviceWgts);
+    Kokkos::deep_copy(kDeviceWgtsHost, kDeviceWgts);
+
+    for (zlno_t i = 0; success && i < nLocalRows; ++i) {
+      TEUCHOS_TEST_EQUALITY(wgts[stride * i], kHostWgts(w, i), std::cout,
+                            success);
+      TEUCHOS_TEST_EQUALITY(wgts[stride * i], kDeviceWgtsHost(w, i), std::cout,
+                            success);
+    }
+  }
+  TEST_FAIL_AND_EXIT(*comm, success, "wgts != vwgts != wkgts", 1)
+
+  // TEST of useNumNonzerosAsRowWeight, useNumNonzerosAsRowWeightHost and
+  // useNumNonzerosAsRowWeightDevice
+  // for (int w = 0; success && w < nVtxWeights; w++) {
+  //   TEUCHOS_TEST_EQUALITY(tmi.useNumNonzerosAsRowWeight(w),
+  //                         tmi.useNumNonzerosAsRowWeightHost(w), std::cout,
+  //                         success);
+  //   TEUCHOS_TEST_EQUALITY(tmi.useNumNonzerosAsRowWeight(w),
+  //                         tmi.useNumNonzerosAsRowWeightDevice(w), std::cout,
+  //                         success);
+  // }
+  // TEST_FAIL_AND_EXIT(
+  //     *comm, success,
+  //     "useNumNonzerosAsRowWeight != useNumNonzerosAsRowWeightHost != "
+  //     "useNumNonzerosAsRowWeightDevice",
+  //     1)
+
+  // clean
+  if (nVtxWeights > 0) {
+    for (int i = 0; i < nVtxWeights; i++) {
+      if (rowWeights[i])
+        delete[] rowWeights[i];
+    }
+    delete[] rowWeights;
+  }
+
+  if (coordDim > 0) {
+    delete via;
+    delete[] gids;
+    for (int i = 0; i < coordDim; i++) {
+      if (coords[i])
+        delete[] coords[i];
+    }
+    delete[] coords;
+  }
+
+  delete uinput;
+
+  if (rank == 0)
+    std::cout << "PASS" << std::endl;
+
+  return 0;
+}

--- a/packages/zoltan2/test/core/unit/input/TpetraRowGraphInput.cpp
+++ b/packages/zoltan2/test/core/unit/input/TpetraRowGraphInput.cpp
@@ -99,7 +99,7 @@ int verifyInputAdapter(
 {
   typedef typename Zoltan2::InputTraits<User>::offset_t offset_t;
 
-  RCP<const Comm<int> > comm = graph.getComm();
+  auto comm = graph.getComm();
   int fail = 0, gfail=0;
 
   if (!fail &&
@@ -163,8 +163,8 @@ int main(int narg, char *arg[])
   TEST_FAIL_AND_EXIT(*comm, aok, "input ", 1);
 
   // Input crs graph and row graph cast from it.
-  RCP<ztcrsgraph_t> tG = uinput->getUITpetraCrsGraph();
-  RCP<ztrowgraph_t> trG = rcp_dynamic_cast<ztrowgraph_t>(tG);
+  auto tG = uinput->getUITpetraCrsGraph();
+  auto trG = rcp_dynamic_cast<ztrowgraph_t>(tG);
 
   RCP<ztrowgraph_t> newG;   // migrated graph
 
@@ -172,7 +172,7 @@ int main(int narg, char *arg[])
 
   // To test migration in the input adapter we need a Solution object.
 
-  RCP<const Zoltan2::Environment> env = rcp(new Zoltan2::Environment(comm));
+  const auto env = rcp(new Zoltan2::Environment(comm));
 
   int nWeights = 1;
 
@@ -224,8 +224,7 @@ int main(int narg, char *arg[])
       gfail = globalFail(*comm, fail);
 
       if (!gfail){
-        RCP<const ztrowgraph_t> cnewG =
-                                rcp_const_cast<const ztrowgraph_t>(newG);
+        auto cnewG = rcp_const_cast<const ztrowgraph_t>(newG);
         RCP<adapter_t> newInput;
         try{
           newInput = rcp(new adapter_t(cnewG));

--- a/packages/zoltan2/test/core/unit/input/TpetraRowGraphInputKokkos.cpp
+++ b/packages/zoltan2/test/core/unit/input/TpetraRowGraphInputKokkos.cpp
@@ -1,0 +1,337 @@
+// @HEADER
+//
+// ***********************************************************************
+//
+//   Zoltan2: A package of combinatorial algorithms for scientific computing
+//                  Copyright 2012 Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Karen Devine      (kddevin@sandia.gov)
+//                    Erik Boman        (egboman@sandia.gov)
+//                    Siva Rajamanickam (srajama@sandia.gov)
+//
+// ***********************************************************************
+//
+// @HEADER
+//
+// Basic testing of Zoltan2::TpetraRowGraphAdapter
+/*!  \file TpetraRowGraphAdapter.cpp
+ *   \brief Test of Zoltan2::TpetraRowGraphAdapter class.
+ *  \todo add weights and coordinates
+ */
+
+#include <Zoltan2_InputTraits.hpp>
+#include <Zoltan2_TestHelpers.hpp>
+#include <Zoltan2_TpetraCrsGraphAdapter.hpp>
+#include <Zoltan2_TpetraRowGraphAdapter.hpp>
+
+#include <Teuchos_Comm.hpp>
+#include <Teuchos_CommHelpers.hpp>
+#include <Teuchos_DefaultComm.hpp>
+#include <Teuchos_RCP.hpp>
+#include <cstdlib>
+#include <stdexcept>
+
+using Teuchos::Comm;
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+
+using ztcrsgraph_t = Tpetra::CrsGraph<zlno_t, zgno_t, znode_t>;
+using ztrowgraph_t = Tpetra::RowGraph<zlno_t, zgno_t, znode_t>;
+using node_t = typename Zoltan2::InputTraits<ztrowgraph_t>::node_t;
+using device_t = typename node_t::device_type;
+using rowAdapter_t = Zoltan2::TpetraRowGraphAdapter<ztrowgraph_t>;
+using crsAdapter_t = Zoltan2::TpetraCrsGraphAdapter<ztcrsgraph_t>;
+using execspace_t =
+    typename rowAdapter_t::ConstWeightsHostView1D::execution_space;
+
+template <typename offset_t>
+void printGraph(RCP<const Comm<int>> &comm, zlno_t nvtx, const zgno_t *vtxIds,
+                const offset_t *offsets, const zgno_t *edgeIds) {
+  int rank = comm->getRank();
+  int nprocs = comm->getSize();
+  comm->barrier();
+  for (int p = 0; p < nprocs; p++) {
+    if (p == rank) {
+      std::cout << rank << ":" << std::endl;
+      for (zlno_t i = 0; i < nvtx; i++) {
+        std::cout << " vertex " << vtxIds[i] << ": ";
+        for (offset_t j = offsets[i]; j < offsets[i + 1]; j++) {
+          std::cout << edgeIds[j] << " ";
+        }
+        std::cout << std::endl;
+      }
+      std::cout.flush();
+    }
+    comm->barrier();
+  }
+  comm->barrier();
+}
+
+template <typename adapter_t, typename graph_t>
+void TestGraphIds(adapter_t &ia, graph_t &graph) {
+
+  using idsHost_t = typename adapter_t::ConstIdsHostView;
+  using offsetsHost_t = typename adapter_t::ConstOffsetsHostView;
+  using localInds_t =
+      typename adapter_t::user_t::nonconst_local_inds_host_view_type;
+
+  const auto nvtx = graph.getLocalNumRows();
+  const auto nedges = graph.getLocalNumEntries();
+  const auto maxNumEntries = graph.getLocalMaxNumRowEntries();
+
+  typename adapter_t::Base::ConstIdsHostView adjIdsHost_("adjIdsHost_", nedges);
+  typename adapter_t::Base::ConstOffsetsHostView offsHost_("offsHost_",
+                                                           nvtx + 1);
+
+  localInds_t nbors("nbors", maxNumEntries);
+
+  for (size_t v = 0; v < nvtx; v++) {
+    size_t numColInds = 0;
+    graph.getLocalRowCopy(v, nbors, numColInds);
+
+    offsHost_(v + 1) = offsHost_(v) + numColInds;
+    for (size_t e = offsHost_(v), i = 0; e < offsHost_(v + 1); e++) {
+      adjIdsHost_(e) = graph.getColMap()->getGlobalElement(nbors(i++));
+    }
+  }
+
+  idsHost_t vtxIdsHost;
+  ia.getVertexIDsHostView(vtxIdsHost);
+
+  const auto graphIDS = graph.getRowMap()->getLocalElementList();
+
+  Z2_TEST_COMPARE_ARRAYS(graphIDS, vtxIdsHost);
+
+  idsHost_t adjIdsHost;
+  offsetsHost_t offsetsHost;
+  ia.getEdgesHostView(offsetsHost, adjIdsHost);
+
+  Z2_TEST_COMPARE_ARRAYS(adjIdsHost_, adjIdsHost);
+  Z2_TEST_COMPARE_ARRAYS(offsHost_, offsetsHost);
+}
+
+template <typename adapter_t, typename graph_t>
+void verifyInputAdapter(adapter_t &ia, graph_t &graph) {
+  using idsDevice_t = typename adapter_t::ConstIdsDeviceView;
+  using idsHost_t = typename adapter_t::ConstIdsHostView;
+  using offsetsDevice_t = typename adapter_t::ConstOffsetsDeviceView;
+  using offsetsHost_t = typename adapter_t::ConstOffsetsHostView;
+  using weightsDevice_t = typename adapter_t::WeightsDeviceView1D;
+  using weightsHost_t = typename adapter_t::WeightsHostView1D;
+
+  const auto nVtx = ia.getLocalNumIDs();
+
+  Z2_TEST_EQUALITY(ia.getLocalNumVertices(), graph.getLocalNumRows());
+  Z2_TEST_EQUALITY(ia.getLocalNumEdges(), graph.getLocalNumEntries());
+
+  /////////////////////////////////
+  //// getVertexIdsView
+  /////////////////////////////////
+
+  idsDevice_t vtxIdsDevice;
+  ia.getVertexIDsDeviceView(vtxIdsDevice);
+  idsHost_t vtxIdsHost;
+  ia.getVertexIDsHostView(vtxIdsHost);
+
+  Z2_TEST_DEVICE_HOST_VIEWS(vtxIdsDevice, vtxIdsHost);
+
+  /////////////////////////////////
+  //// getEdgesView
+  /////////////////////////////////
+
+  idsDevice_t adjIdsDevice;
+  offsetsDevice_t offsetsDevice;
+
+  ia.getEdgesDeviceView(offsetsDevice, adjIdsDevice);
+
+  idsHost_t adjIdsHost;
+  offsetsHost_t offsetsHost;
+  ia.getEdgesHostView(offsetsHost, adjIdsHost);
+
+  Z2_TEST_DEVICE_HOST_VIEWS(adjIdsDevice, adjIdsHost);
+  Z2_TEST_DEVICE_HOST_VIEWS(offsetsDevice, offsetsHost);
+
+  /////////////////////////////////
+  //// setVertexWeightsDevice
+  /////////////////////////////////
+  Z2_TEST_THROW(ia.setVertexWeightsDevice(
+                    typename adapter_t::ConstWeightsDeviceView1D{}, 50),
+                std::runtime_error);
+
+  weightsDevice_t wgts0("wgts0", nVtx);
+  Kokkos::parallel_for(
+      nVtx, KOKKOS_LAMBDA(const int idx) { wgts0(idx) = idx * 2; });
+  Kokkos::fence();
+
+  Z2_TEST_NOTHROW(ia.setVertexWeightsDevice(wgts0, 0));
+
+  // Don't reuse the same View, since we don't copy the values,
+  // we just assign the View (increase use count)
+  weightsDevice_t wgts1("wgts1", nVtx);
+  Kokkos::parallel_for(
+      nVtx, KOKKOS_LAMBDA(const int idx) { wgts1(idx) = idx * 3; });
+
+  Z2_TEST_NOTHROW(ia.setVertexWeightsDevice(wgts1, 1));
+
+  /////////////////////////////////
+  //// getVertexWeightsDevice
+  /////////////////////////////////
+  {
+    weightsDevice_t weightsDevice;
+    Z2_TEST_NOTHROW(ia.getVertexWeightsDeviceView(weightsDevice, 0));
+
+    weightsHost_t weightsHost;
+    Z2_TEST_NOTHROW(ia.getVertexWeightsHostView(weightsHost, 0));
+
+    Z2_TEST_DEVICE_HOST_VIEWS(weightsDevice, weightsHost);
+
+    Z2_TEST_DEVICE_HOST_VIEWS(wgts0, weightsHost);
+  }
+  {
+    weightsDevice_t weightsDevice;
+    Z2_TEST_NOTHROW(ia.getVertexWeightsDeviceView(weightsDevice, 1));
+
+    weightsHost_t weightsHost;
+    Z2_TEST_NOTHROW(ia.getVertexWeightsHostView(weightsHost, 1));
+
+    Z2_TEST_DEVICE_HOST_VIEWS(weightsDevice, weightsHost);
+
+    Z2_TEST_DEVICE_HOST_VIEWS(wgts1, weightsHost);
+  }
+  {
+    weightsDevice_t wgtsDevice;
+    Z2_TEST_THROW(ia.getVertexWeightsDeviceView(wgtsDevice, 2),
+                  std::runtime_error);
+
+    weightsHost_t wgtsHost;
+    Z2_TEST_THROW(ia.getVertexWeightsHostView(wgtsHost, 2), std::runtime_error);
+  }
+
+  TestGraphIds(ia, graph);
+}
+
+int main(int narg, char *arg[]) {
+  using rowSoln_t = Zoltan2::PartitioningSolution<rowAdapter_t>;
+  using rowPart_t = rowAdapter_t::part_t;
+
+  using crsSoln_t = Zoltan2::PartitioningSolution<crsAdapter_t>;
+  using crsPart_t = crsAdapter_t::part_t;
+
+  Tpetra::ScopeGuard tscope(&narg, &arg);
+  const auto comm = Tpetra::getDefaultComm();
+
+  try {
+    Teuchos::ParameterList params;
+    params.set("input file", "simple");
+    params.set("file type", "Chaco");
+
+    auto uinput = rcp(new UserInputForTests(params, comm));
+
+    // Input crs graph and row graph cast from it.
+    const auto crsGraph = uinput->getUITpetraCrsGraph();
+    const auto rowGraph = rcp_dynamic_cast<ztrowgraph_t>(crsGraph);
+
+    const auto nvtx = rowGraph->getLocalNumRows();
+
+    // To test migration in the input adapter we need a Solution object.
+    const auto env = rcp(new Zoltan2::Environment(comm));
+
+    const int nWeights = 2;
+
+    /////////////////////////////////////////////////////////////
+    // User object is Tpetra::CrsGraph
+    /////////////////////////////////////////////////////////////
+    {
+      PrintFromRoot("Input adapter for Tpetra::CrsGraph");
+
+      auto tpetraCrsGraphInput = rcp(new crsAdapter_t(crsGraph, nWeights));
+
+      verifyInputAdapter(*tpetraCrsGraphInput, *crsGraph);
+
+      ztcrsgraph_t *mMigrate = NULL;
+      crsPart_t *p = new crsPart_t[nvtx];
+      memset(p, 0, sizeof(crsPart_t) * nvtx);
+      ArrayRCP<crsPart_t> solnParts(p, 0, nvtx, true);
+
+      crsSoln_t solution(env, comm, nWeights);
+      solution.setParts(solnParts);
+      tpetraCrsGraphInput->applyPartitioningSolution(*crsGraph, mMigrate,
+                                                     solution);
+      const auto newG = rcp(mMigrate);
+
+      auto cnewG = rcp_const_cast<const ztcrsgraph_t>(newG);
+      auto newInput = rcp(new crsAdapter_t(cnewG, nWeights));
+
+      PrintFromRoot("Input adapter for Tpetra::RowGraph migrated to proc 0");
+
+      verifyInputAdapter(*newInput, *newG);
+    }
+
+    /////////////////////////////////////////////////////////////
+    // User object is Tpetra::RowGraph
+    /////////////////////////////////////////////////////////////
+    {
+      PrintFromRoot("Input adapter for Tpetra::RowGraph");
+
+      auto tpetraRowGraphInput = rcp(new rowAdapter_t(rowGraph, nWeights));
+
+      verifyInputAdapter(*tpetraRowGraphInput, *crsGraph);
+
+      rowPart_t *p = new rowPart_t[nvtx];
+      memset(p, 0, sizeof(rowPart_t) * nvtx);
+      ArrayRCP<rowPart_t> solnParts(p, 0, nvtx, true);
+
+      rowSoln_t solution(env, comm, nWeights);
+      solution.setParts(solnParts);
+
+      ztrowgraph_t *mMigrate = NULL;
+      tpetraRowGraphInput->applyPartitioningSolution(*crsGraph, mMigrate,
+                                                     solution);
+      const auto newG = rcp(mMigrate);
+
+      auto cnewG = rcp_const_cast<const ztrowgraph_t>(newG);
+      auto newInput = rcp(new rowAdapter_t(cnewG, nWeights));
+
+      PrintFromRoot("Input adapter for Tpetra::RowGraph migrated to proc 0");
+
+      verifyInputAdapter(*newInput, *newG);
+    }
+  } catch (std::exception &e) {
+    std::cout << e.what() << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  PrintFromRoot("PASS");
+}

--- a/packages/zoltan2/test/core/unit/input/TpetraRowMatrixInput.cpp
+++ b/packages/zoltan2/test/core/unit/input/TpetraRowMatrixInput.cpp
@@ -43,7 +43,7 @@
 //
 // @HEADER
 //
-// Basic testing of Zoltan2::TpetraRowMatrixAdapter 
+// Basic testing of Zoltan2::TpetraRowMatrixAdapter
 
 /*! \file TpetraRowMatrixInput.cpp
  *  \brief Test of Zoltan2::TpetraRowMatrixAdapter class.
@@ -177,7 +177,7 @@ int main(int narg, char *arg[])
 
   size_t nrows = trM->getLocalNumRows();
 
-  // To test migration in the input adapter we need a Solution object. 
+  // To test migration in the input adapter we need a Solution object.
 
   RCP<const Zoltan2::Environment> env = rcp(new Zoltan2::Environment(comm));
 
@@ -196,14 +196,14 @@ int main(int narg, char *arg[])
 
   /////////////////////////////////////////////////////////////
   // User object is Tpetra::RowMatrix
-  if (!gfail){ 
+  if (!gfail){
     if (rank==0)
       std::cout << "Input adapter for Tpetra::RowMatrix" << std::endl;
-    
+
     RCP<const ztrowmatrix_t> ctrM = rcp_const_cast<const ztrowmatrix_t>(
                                    rcp_dynamic_cast<ztrowmatrix_t>(tM));
     RCP<adapter_t> trMInput;
-  
+
     try {
       trMInput = rcp(new adapter_t(ctrM));
     }
@@ -212,11 +212,11 @@ int main(int narg, char *arg[])
       std::cout << e.what() << std::endl;
     }
     TEST_FAIL_AND_EXIT(*comm, aok, "TpetraRowMatrixAdapter ", 1);
-  
+
     fail = verifyInputAdapter<ztrowmatrix_t>(*trMInput, *trM);
-  
+
     gfail = globalFail(*comm, fail);
-  
+
     if (!gfail){
       ztrowmatrix_t *mMigrate = NULL;
       try{
@@ -229,9 +229,9 @@ int main(int narg, char *arg[])
       }
 
       gfail = globalFail(*comm, fail);
-  
+
       if (!gfail){
-        RCP<const ztrowmatrix_t> cnewM = 
+        RCP<const ztrowmatrix_t> cnewM =
                                  rcp_const_cast<const ztrowmatrix_t>(newM);
         RCP<adapter_t> newInput;
         try{
@@ -242,10 +242,10 @@ int main(int narg, char *arg[])
           std::cout << e.what() << std::endl;
         }
         TEST_FAIL_AND_EXIT(*comm, aok, "TpetraRowMatrixAdapter 2 ", 1);
-  
+
         if (rank==0){
-          std::cout << 
-           "Input adapter for Tpetra::RowMatrix migrated to proc 0" << 
+          std::cout <<
+           "Input adapter for Tpetra::RowMatrix migrated to proc 0" <<
            std::endl;
         }
         fail = verifyInputAdapter<ztrowmatrix_t>(*newInput, *newM);


### PR DESCRIPTION
@trilinos/zoltan2
@egboman 

This PR introduces new API to Zoltan2's Graph Adapters (`Zoltan2_TpetraRowGraphAdapter` and new `Zoltan2_TpetraCrsGraphAdapter`) 
This PR shares common changes with https://github.com/trilinos/Trilinos/pull/12082. 

