### PR TITLE
KokkosKernels: patch in PR 1927

### DIFF
--- a/packages/kokkos-kernels/common/src/KokkosKernels_BlockHashmapAccumulator.hpp
+++ b/packages/kokkos-kernels/common/src/KokkosKernels_BlockHashmapAccumulator.hpp
@@ -250,9 +250,8 @@ struct BlockHashmapAccumulator {
       KokkosSparse::Impl::kk_block_set_mul(
           block_dim, values + my_write_index * block_size, valA, valB);
 
-#if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || \
-    defined(KOKKOS_ARCH_AMPERE)
-      // this is an issue on VOLTA and up because warps do not go in SIMD
+#ifdef KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS
+      // this is an issue on VOLTA+ and up because warps do not go in SIMD
       // fashion anymore. while some thread might insert my_write_index into
       // linked list, another thread in the warp might be reading keys in above
       // loop. before inserting the new value in liked list -- which is done
@@ -327,9 +326,8 @@ struct BlockHashmapAccumulator {
       KokkosSparse::Impl::kk_block_set_mul(
           block_dim, values + my_write_index * block_size, valA, valB);
 
-#if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || \
-    defined(KOKKOS_ARCH_AMPERE)
-      // this is an issue on VOLTA and up because warps do not go in SIMD
+#ifdef KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS
+      // this is an issue on VOLTA+ and up because warps do not go in SIMD
       // fashion anymore. while some thread might insert my_write_index into
       // linked list, another thread in the warp might be reading keys in above
       // loop. before inserting the new value in liked list -- which is done
@@ -407,9 +405,8 @@ struct BlockHashmapAccumulator {
     } else {
       keys[my_write_index] = key;
 
-#if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || \
-    defined(KOKKOS_ARCH_AMPERE)
-      // this is an issue on VOLTA and up because warps do not go in SIMD
+#ifdef KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS
+      // this is an issue on VOLTA+ and up because warps do not go in SIMD
       // fashion anymore. while some thread might insert my_write_index into
       // linked list, another thread in the warp might be reading keys in above
       // loop. before inserting the new value in liked list -- which is done
@@ -460,9 +457,8 @@ struct BlockHashmapAccumulator {
       keys[my_write_index]   = key;
       values[my_write_index] = value;
 
-#if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || \
-    defined(KOKKOS_ARCH_AMPERE)
-      // this is an issue on VOLTA and up because warps do not go in SIMD
+#ifdef KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS
+      // this is an issue on VOLTA+ and up because warps do not go in SIMD
       // fashion anymore. while some thread might insert my_write_index into
       // linked list, another thread in the warp might be reading keys in above
       // loop. before inserting the new value in liked list -- which is done
@@ -514,9 +510,8 @@ struct BlockHashmapAccumulator {
       keys[my_write_index]   = key;
       values[my_write_index] = value;
 
-#if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || \
-    defined(KOKKOS_ARCH_AMPERE)
-      // this is an issue on VOLTA and up because warps do not go in SIMD
+#ifdef KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS
+      // this is an issue on VOLTA+ and up because warps do not go in SIMD
       // fashion anymore. while some thread might insert my_write_index into
       // linked list, another thread in the warp might be reading keys in above
       // loop. before inserting the new value in liked list -- which is done
@@ -564,9 +559,8 @@ struct BlockHashmapAccumulator {
     } else {
       keys[my_write_index] = key;
 
-#if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || \
-    defined(KOKKOS_ARCH_AMPERE)
-      // this is an issue on VOLTA and up because warps do not go in SIMD
+#ifdef KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS
+      // this is an issue on VOLTA+ and up because warps do not go in SIMD
       // fashion anymore. while some thread might insert my_write_index into
       // linked list, another thread in the warp might be reading keys in above
       // loop. before inserting the new value in liked list -- which is done

--- a/packages/kokkos-kernels/common/src/KokkosKernels_HashmapAccumulator.hpp
+++ b/packages/kokkos-kernels/common/src/KokkosKernels_HashmapAccumulator.hpp
@@ -16,6 +16,7 @@
 #ifndef _KOKKOSKERNELS_HASHMAPACCUMULATOR_HPP
 #define _KOKKOSKERNELS_HASHMAPACCUMULATOR_HPP
 #include <Kokkos_Atomic.hpp>
+#include "KokkosKernels_Macros.hpp"
 #include <atomic>
 
 namespace KokkosKernels {
@@ -412,9 +413,8 @@ struct HashmapAccumulator {
       keys[my_write_index]   = key;
       values[my_write_index] = value;
 
-#if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || \
-    defined(KOKKOS_ARCH_AMPERE)
-      // this is an issue on VOLTA because warps do not go in SIMD fashion
+#ifdef KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS
+      // this is an issue on VOLTA+ because warps do not go in SIMD fashion
       // anymore. while some thread might insert my_write_index into linked
       // list, another thread in the warp might be reading keys in above loop.
       // before inserting the new value in liked list -- which is done with
@@ -483,9 +483,8 @@ struct HashmapAccumulator {
       keys[my_write_index]   = key;
       values[my_write_index] = value;
 
-#if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || \
-    defined(KOKKOS_ARCH_AMPERE)
-      // this is an issue on VOLTA and up because warps do not go in SIMD
+#ifdef KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS
+      // this is an issue on VOLTA+ and up because warps do not go in SIMD
       // fashion anymore. while some thread might insert my_write_index into
       // linked list, another thread in the warp might be reading keys in above
       // loop. before inserting the new value in liked list -- which is done
@@ -601,9 +600,8 @@ struct HashmapAccumulator {
       keys[my_write_index]   = key;
       values[my_write_index] = value;
 
-#if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || \
-    defined(KOKKOS_ARCH_AMPERE)
-      // this is an issue on VOLTA and up because warps do not go in SIMD
+#ifdef KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS
+      // this is an issue on VOLTA+ and up because warps do not go in SIMD
       // fashion anymore. while some thread might insert my_write_index into
       // linked list, another thread in the warp might be reading keys in above
       // loop. before inserting the new value in liked list -- which is done
@@ -679,9 +677,8 @@ struct HashmapAccumulator {
     } else {
       keys[my_write_index] = key;
 
-#if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || \
-    defined(KOKKOS_ARCH_AMPERE)
-      // this is an issue on VOLTA and up because warps do not go in SIMD
+#ifdef KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS
+      // this is an issue on VOLTA+ and up because warps do not go in SIMD
       // fashion anymore. while some thread might insert my_write_index into
       // linked list, another thread in the warp might be reading keys in above
       // loop. before inserting the new value in liked list -- which is done
@@ -732,9 +729,8 @@ struct HashmapAccumulator {
       keys[my_write_index]   = key;
       values[my_write_index] = value;
 
-#if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || \
-    defined(KOKKOS_ARCH_AMPERE)
-      // this is an issue on VOLTA and up because warps do not go in SIMD
+#ifdef KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS
+      // this is an issue on VOLTA+ and up because warps do not go in SIMD
       // fashion anymore. while some thread might insert my_write_index into
       // linked list, another thread in the warp might be reading keys in above
       // loop. before inserting the new value in liked list -- which is done
@@ -786,9 +782,8 @@ struct HashmapAccumulator {
       keys[my_write_index]   = key;
       values[my_write_index] = value;
 
-#if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || \
-    defined(KOKKOS_ARCH_AMPERE)
-      // this is an issue on VOLTA and up because warps do not go in SIMD
+#ifdef KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS
+      // this is an issue on VOLTA+ and up because warps do not go in SIMD
       // fashion anymore. while some thread might insert my_write_index into
       // linked list, another thread in the warp might be reading keys in above
       // loop. before inserting the new value in liked list -- which is done
@@ -836,9 +831,8 @@ struct HashmapAccumulator {
     } else {
       keys[my_write_index] = key;
 
-#if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || \
-    defined(KOKKOS_ARCH_AMPERE)
-      // this is an issue on VOLTA and up because warps do not go in SIMD
+#ifdef KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS
+      // this is an issue on VOLTA+ and up because warps do not go in SIMD
       // fashion anymore. while some thread might insert my_write_index into
       // linked list, another thread in the warp might be reading keys in above
       // loop. before inserting the new value in liked list -- which is done

--- a/packages/kokkos-kernels/common/src/KokkosKernels_Macros.hpp
+++ b/packages/kokkos-kernels/common/src/KokkosKernels_Macros.hpp
@@ -96,4 +96,13 @@
 #endif  // KOKKOS_COMPILER_GNU
 /******* END other helper macros *******/
 
+// define KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS if we are targeting a CUDA
+// architecture with "independent thread scheduling" (Volta70 and up). This
+// requires some extra logic in HashmapAccumulator to avoid data races.
+#if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || \
+    defined(KOKKOS_ARCH_AMPERE) || defined(KOKKOS_ARCH_ADA89) ||   \
+    defined(KOKKOS_ARCH_HOPPER)
+#define KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS
+#endif
+
 #endif  // KOKKOSKERNELS_MACROS_HPP_


### PR DESCRIPTION
To fix HashmapAccumulator (used in spgemm, graph coarsening) on Ada & Hopper architectures.
See https://github.com/kokkos/kokkos-kernels/pull/1927 for original PR and https://github.com/kokkos/kokkos-kernels/issues/1891 for the original issue.
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/kokkos-kernels 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
Spgemm and graph coarsening unit tests were failing on Hopper, but now they pass.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->