### PR TITLE
ROL: Resolve __host__ function called from __host__ __device__ when building with HIPCC

### DIFF
--- a/packages/rol/adapters/pebbl/src/algorithm/ROL_PEBBL_Interface.hpp
+++ b/packages/rol/adapters/pebbl/src/algorithm/ROL_PEBBL_Interface.hpp
@@ -78,7 +78,7 @@ private:
     const Real tol_;
   public:
     SnapInt(void) : tol_(1e-6) {}
-    Real apply(const Real &x) const {
+    KOKKOS_FUNCTION Real apply(const Real &x) const {
       Real fx = std::floor(x);
       Real cx = std::ceil(x);
       if (std::abs(fx - x) < tol_)      return fx;
@@ -348,7 +348,7 @@ protected:
 
   class round : public Elementwise::UnaryFunction<Real> {
   public:
-    Real apply(const Real &x) const { return std::round(x); }
+    KOKKOS_FUNCTION Real apply(const Real &x) const { return std::round(x); }
   } rnd;
 
   Ptr<Vector<Real>> getOptVector(const Ptr<Vector<Real>> &xs ) const {

--- a/packages/rol/src/algorithm/TypeG/interiorpoint/ROL_InteriorPointObjective.hpp
+++ b/packages/rol/src/algorithm/TypeG/interiorpoint/ROL_InteriorPointObjective.hpp
@@ -94,7 +94,7 @@ private:
   //             { -inf   if x <= 0
   class ModifiedLogarithm : public Elementwise::UnaryFunction<Real> {
   public:
-    Real apply( const Real &x ) const {
+    KOKKOS_FUNCTION Real apply( const Real &x ) const {
       const Real zero(0), NINF(ROL_NINF<Real>());
       return (x>zero) ? std::log(x) : NINF;
       //return std::log(x);
@@ -105,7 +105,7 @@ private:
   //             { 0    if  x <= 0
   class ModifiedReciprocal : public Elementwise::UnaryFunction<Real> {
   public:
-    Real apply( const Real &x ) const {
+    KOKKOS_FUNCTION Real apply( const Real &x ) const {
       const Real zero(0), one(1);
       return (x>zero) ? one/x : zero;
       //return one/x;
@@ -117,7 +117,7 @@ private:
   //               { 0    if  x <= 0
   class ModifiedDivide : public Elementwise::BinaryFunction<Real> {
   public:
-    Real apply( const Real &x, const Real &y ) const {
+    KOKKOS_FUNCTION Real apply( const Real &x, const Real &y ) const {
       const Real zero(0);
       return (x>zero) ? y/x : zero;
       //return y/x;
@@ -133,7 +133,7 @@ private:
     bool complement_;
   public:
     Mask( bool complement ) : complement_(complement) {}
-    Real apply( const Real &x, const Real &y ) const {
+    KOKKOS_FUNCTION Real apply( const Real &x, const Real &y ) const {
       const Real zero(0);
       return ( complement_ ^ (y != zero) ) ? zero : x;
     }

--- a/packages/rol/src/elementwise/ROL_BinaryFunctions.hpp
+++ b/packages/rol/src/elementwise/ROL_BinaryFunctions.hpp
@@ -55,7 +55,7 @@ class Multiply : public BinaryFunction<Real> {
 public:
   Multiply( ) { }
 
-  Real apply( const Real &x, const Real &y ) const {
+  KOKKOS_FUNCTION Real apply( const Real &x, const Real &y ) const {
     return x*y;
   }  
 }; // class Multiply
@@ -63,7 +63,7 @@ public:
 template<class Real>
 class Plus : public BinaryFunction<Real> {
 public:
-  Real apply( const Real &x, const Real &y ) const {
+  KOKKOS_FUNCTION Real apply( const Real &x, const Real &y ) const {
     return x+y;
   }
 };
@@ -75,7 +75,7 @@ class Divide : public BinaryFunction<Real> {
 public:
   Divide( ) { }
 
-  Real apply( const Real &x, const Real &y ) const {
+  KOKKOS_FUNCTION Real apply( const Real &x, const Real &y ) const {
     return x/y;
   }  
 }; // class Divide
@@ -85,7 +85,7 @@ class DivideAndInvert : public BinaryFunction<Real> {
 public:
   DivideAndInvert( ) { }
 
-  Real apply( const Real &x, const Real &y ) const {
+  KOKKOS_FUNCTION Real apply( const Real &x, const Real &y ) const {
     return y/x;
   }  
 }; // class DivideAndInvert
@@ -98,7 +98,7 @@ private:
   Real a_;
 public:
   Axpy(Real a) : a_(a) {}
-  Real apply( const Real &x, const Real &y ) const {
+  KOKKOS_FUNCTION Real apply( const Real &x, const Real &y ) const {
     return x+a_*y;
   }
 };
@@ -110,7 +110,7 @@ private:
   Real a_;
 public:
   Aypx(Real a) : a_(a) {}
-  Real apply( const Real &x, const Real &y ) const {
+  KOKKOS_FUNCTION Real apply( const Real &x, const Real &y ) const {
     return a_*x+y;
   }
 };
@@ -120,7 +120,7 @@ template<class Real>
 class Min : public BinaryFunction<Real> {
 public:
   Min() {}
-  Real apply(const Real &x, const Real &y) const {
+  KOKKOS_FUNCTION Real apply(const Real &x, const Real &y) const {
     return std::min(x,y);
   }
 };
@@ -130,7 +130,7 @@ template<class Real>
 class Max : public BinaryFunction<Real> {
 public:
   Max() {}
-  Real apply(const Real &x, const Real &y) const {
+  KOKKOS_FUNCTION Real apply(const Real &x, const Real &y) const {
     return std::max(x,y);
   }
 };
@@ -139,7 +139,7 @@ public:
 template<class Real> 
 class Set : public BinaryFunction<Real> {
 public:
-  Real apply( const Real &x, const Real &y ) const {
+  KOKKOS_FUNCTION Real apply( const Real &x, const Real &y ) const {
     return y;
   }
 };
@@ -147,7 +147,7 @@ public:
 template<class Real> 
 class Lesser : public BinaryFunction<Real> {
 public:
-  Real apply( const Real &x, const Real &y ) const {
+  KOKKOS_FUNCTION Real apply( const Real &x, const Real &y ) const {
     return (x<y) ? x : y;
   }
 };
@@ -155,7 +155,7 @@ public:
 template<class Real> 
 class Greater : public BinaryFunction<Real> {
 public:
-  Real apply( const Real &x, const Real &y ) const {
+  KOKKOS_FUNCTION Real apply( const Real &x, const Real &y ) const {
     return (x>y) ? x : y;
   }
 };
@@ -176,7 +176,7 @@ public:
   ValueSet( const Real& threshold, const int option, const Real &c1=Real(1), const Real &c2=Real(0) ) :
     threshold_(threshold), option_(option), c1_(c1), c2_(c2) {}
  
-  Real apply(const Real &x, const Real &y ) const {
+  KOKKOS_FUNCTION Real apply(const Real &x, const Real &y ) const {
     Real result(c2_);
     switch( option_ ) {
       case LESS_THAN:    { result = y <  threshold_ ? c1_ : c2_; break; }
@@ -201,7 +201,7 @@ public:
 
   BinaryComposition( ROL::Ptr<BinaryFunction<Real> > &f,
                      ROL::Ptr<UnaryFunction<Real> > &g ) : f_(f), g_(g) {}
-  Real apply( const Real &x, const Real &y ) const {
+  KOKKOS_FUNCTION Real apply( const Real &x, const Real &y ) const {
     return g_->apply(f_->apply(x,y));
   }
 

--- a/packages/rol/src/elementwise/ROL_Elementwise_Function.hpp
+++ b/packages/rol/src/elementwise/ROL_Elementwise_Function.hpp
@@ -56,7 +56,7 @@ template<class Real>
 class UnaryFunction {
 public:
   virtual ~UnaryFunction() {}
-  virtual Real apply( const Real &x ) const = 0;
+  virtual KOKKOS_FUNCTION Real apply( const Real &x ) const = 0;
 };
 
 // Wrap a generic function/functor of a single argument
@@ -65,7 +65,7 @@ class UnaryFunctionWrapper : public UnaryFunction<Real> {
 public:
   UnaryFunctionWrapper( const Func &f ) : f_(f) {}
   
-  Real apply( const Real &x ) const {
+  KOKKOS_FUNCTION Real apply( const Real &x ) const {
     return f_(x);
   }
 private:
@@ -92,7 +92,7 @@ template<class Real>
 class BinaryFunction {
 public:
   virtual ~BinaryFunction() {}
-  virtual Real apply( const Real &x, const Real &y ) const = 0;
+  virtual KOKKOS_FUNCTION Real apply( const Real &x, const Real &y ) const = 0;
 };
 
 
@@ -102,7 +102,7 @@ class BinaryFunctionWrapper : public BinaryFunction<Real> {
 public:
   BinaryFunctionWrapper( const Func &f ) : f_(f) {}
   
-  Real apply( const Real &x, const Real &y ) const {
+  KOKKOS_FUNCTION Real apply( const Real &x, const Real &y ) const {
     return f_(x,y); 
   }
 private:

--- a/packages/rol/src/elementwise/ROL_Elementwise_Function.hpp
+++ b/packages/rol/src/elementwise/ROL_Elementwise_Function.hpp
@@ -43,6 +43,7 @@
 
 #ifndef ROL_ELEMENTWISE_FUNCTION_H
 #define ROL_ELEMENTWISE_FUNCTION_H
+#include <Kokkos_Core.hpp>
 
 namespace ROL {
 

--- a/packages/rol/src/elementwise/ROL_Elementwise_Reduce.hpp
+++ b/packages/rol/src/elementwise/ROL_Elementwise_Reduce.hpp
@@ -47,6 +47,7 @@
 
 #include <ROL_Elementwise_Function.hpp>
 #include <ROL_Types.hpp>
+#include <Kokkos_Core.hpp>
 
 namespace ROL {
 namespace Elementwise {

--- a/packages/rol/src/elementwise/ROL_Elementwise_Reduce.hpp
+++ b/packages/rol/src/elementwise/ROL_Elementwise_Reduce.hpp
@@ -64,24 +64,24 @@ template<class Real>
 class ReductionOp {
 public:
   virtual ~ReductionOp() {}
-  virtual void reduce( const Real &input, Real &output ) const = 0;
-  virtual void reduce( const volatile Real &input, volatile Real &output ) const = 0; 
-  virtual Real initialValue() const = 0;
+  virtual KOKKOS_FUNCTION void reduce( const Real &input, Real &output ) const = 0;
+  virtual KOKKOS_FUNCTION void reduce( const volatile Real &input, volatile Real &output ) const = 0; 
+  virtual KOKKOS_FUNCTION Real initialValue() const = 0;
   virtual EReductionType reductionType() const = 0;
 };
 
 template<class Real> 
 class ReductionSum : public ReductionOp<Real> {
 public: 
-  void reduce( const Real &input, Real &output ) const {
+  KOKKOS_FUNCTION void reduce( const Real &input, Real &output ) const {
     output = output + input;
   }
 
-  void reduce( const volatile Real &input, volatile Real &output ) const {
+  KOKKOS_FUNCTION void reduce( const volatile Real &input, volatile Real &output ) const {
     output = output + input;
   }
 
-  Real initialValue() const {
+  KOKKOS_FUNCTION Real initialValue() const {
     return 0;
   }
 
@@ -94,15 +94,15 @@ public:
 template<class Real> 
 class ReductionAnd : public ReductionOp<Real> {
 public:
-  void reduce( const Real &input, Real &output ) const {
+  KOKKOS_FUNCTION void reduce( const Real &input, Real &output ) const {
     output = (input*output)==0 ? 0.0 : 1.0;
   }
 
-  void reduce( const volatile Real &input, volatile Real &output ) const {
+  KOKKOS_FUNCTION void reduce( const volatile Real &input, volatile Real &output ) const {
     output = (input*output)==0 ? 0.0 : 1.0;
   }
 
-  Real initialValue() const {
+  KOKKOS_FUNCTION Real initialValue() const {
     return 1.0;
   }
 
@@ -120,15 +120,15 @@ public:
         "be specialized on supplied template parameter.\n" ); 
   }
 
-  void reduce( const Real &input, Real &output ) const {
+  KOKKOS_FUNCTION void reduce( const Real &input, Real &output ) const {
     output = (input<output) ? input : output;
   }
 
-  void reduce( const volatile Real &input, Real volatile &output ) const {
+  KOKKOS_FUNCTION void reduce( const volatile Real &input, Real volatile &output ) const {
     output = (input<output) ? input : output;
   }
  
-  Real initialValue() const {
+  KOKKOS_FUNCTION Real initialValue() const {
     return std::numeric_limits<Real>::max();
   }
 
@@ -147,15 +147,15 @@ public:
         "be specialized on supplied template parameter.\n" ); 
   }
 
-  void reduce( const Real &input, Real &output ) const {
+  KOKKOS_FUNCTION void reduce( const Real &input, Real &output ) const {
     output = (input>output) ? input : output;
   }
 
-  void reduce( const volatile Real &input, volatile Real &output ) const {
+  KOKKOS_FUNCTION void reduce( const volatile Real &input, volatile Real &output ) const {
     output = (input>output) ? input : output;
   }
  
-  Real initialValue() const {
+  KOKKOS_FUNCTION Real initialValue() const {
     return std::numeric_limits<Real>::min();
   }
 
@@ -168,15 +168,15 @@ public:
 template<class Real> 
 class EuclideanNormSquared : public ReductionOp<Real> {
 public: 
-  void reduce( const Real &input, Real &output ) const {
+  KOKKOS_FUNCTION void reduce( const Real &input, Real &output ) const {
     output = output*output + input;
   }
 
-  void reduce( const volatile Real &input, volatile Real &output ) const {
+  KOKKOS_FUNCTION void reduce( const volatile Real &input, volatile Real &output ) const {
     output = output*output + input;
   }
 
-  Real initialValue() const {
+  KOKKOS_FUNCTION Real initialValue() const {
     return 0;
   }
 

--- a/packages/rol/src/elementwise/ROL_UnaryFunctions.hpp
+++ b/packages/rol/src/elementwise/ROL_UnaryFunctions.hpp
@@ -51,6 +51,7 @@
 #include <ctime>
 #include <random>
 #include <chrono>
+#include <Kokkos_Core.hpp>
 
 
 namespace ROL {

--- a/packages/rol/src/elementwise/ROL_UnaryFunctions.hpp
+++ b/packages/rol/src/elementwise/ROL_UnaryFunctions.hpp
@@ -61,7 +61,7 @@ template<class Real>
 class Fill : public UnaryFunction<Real> {
 public:
   Fill( const Real &value ) : value_(value) {}
-  Real apply( const Real &x ) const {
+  KOKKOS_FUNCTION Real apply( const Real &x ) const {
     return value_;
   }  
 private:  
@@ -75,7 +75,7 @@ private:
   Real value_;
 public:
   Shift( const Real &value ) : value_(value) {}
-  Real apply( const Real &x ) const {
+  KOKKOS_FUNCTION Real apply( const Real &x ) const {
     return x+value_;
   }
 }; // class Shift
@@ -85,7 +85,7 @@ public:
 template<class Real> 
 class Reciprocal : public UnaryFunction<Real> {
 public:
-  Real apply( const Real &x ) const {
+  KOKKOS_FUNCTION Real apply( const Real &x ) const {
     return static_cast<Real>(1)/x;
   }  
 }; // class Reciprocal
@@ -94,7 +94,7 @@ public:
 template<class Real>
 class AbsoluteValue : public UnaryFunction<Real> {
 public:
-  Real apply( const Real &x ) const {
+  KOKKOS_FUNCTION Real apply( const Real &x ) const {
     return std::abs(x); 
   }
 
@@ -107,7 +107,7 @@ private:
   Real one_;
 public:
   Sign() : zero_(0), one_(1) {}
-  Real apply(const Real &x) const {
+  KOKKOS_FUNCTION Real apply(const Real &x) const {
     if(x==zero_) {
       return zero_;
     }
@@ -126,7 +126,7 @@ private:
 public:
   Power( const Real &exponent ) : exponent_(exponent) {}
 
-  Real apply( const Real &x ) const {
+  KOKKOS_FUNCTION Real apply( const Real &x ) const {
     return std::pow(x,exponent_);
   } 
 }; // class Power
@@ -138,7 +138,7 @@ class SquareRoot : public UnaryFunction<Real> {
 public:
   SquareRoot( void ) {}
 
-  Real apply( const Real &x ) const {
+  KOKKOS_FUNCTION Real apply( const Real &x ) const {
     return std::sqrt(x);
   } 
 }; // class Power
@@ -163,7 +163,7 @@ public:
     dist_ = makePtr<std::normal_distribution<Real>>(mu,sigma);
   }
 
-  Real apply( const Real &x ) const {
+  KOKKOS_FUNCTION Real apply( const Real &x ) const {
     return (*dist_)(*gen_);
   }
 }; // class NormalRandom
@@ -182,7 +182,7 @@ public:
     lower_(lower), upper_(upper) {
   }
 
-  Real apply( const Real &x ) const {
+  KOKKOS_FUNCTION Real apply( const Real &x ) const {
     return (static_cast<Real>(rand()) / static_cast<Real>(RAND_MAX)) * (upper_-lower_) + lower_;
   }
 }; // class UniformlyRandom
@@ -200,7 +200,7 @@ public:
     lower_(lower), upper_(upper) {
   }
 
-  Real apply( const Real &x ) const {
+  KOKKOS_FUNCTION Real apply( const Real &x ) const {
     return x*((static_cast<Real>(rand()) / static_cast<Real>(RAND_MAX)) * (upper_-lower_) + lower_);
   }
 }; // class UniformlyRandom
@@ -218,7 +218,7 @@ public:
   ThresholdUpper( const Real threshold ) : 
     threshold_(threshold) {}
 
-  Real apply( const Real &x ) const {
+  KOKKOS_FUNCTION Real apply( const Real &x ) const {
     return std::max(threshold_,x);
   }
 }; 
@@ -234,7 +234,7 @@ public:
   ThresholdLower( const Real threshold ) : 
     threshold_(threshold) {}
 
-  Real apply( const Real &x ) const {
+  KOKKOS_FUNCTION Real apply( const Real &x ) const {
     return std::min(threshold_,x);
   }
 }; 
@@ -246,7 +246,7 @@ private:
   Real value_;
 public:
   Scale( const Real value ) : value_(value) {}
-  Real apply( const Real &x ) const {
+  KOKKOS_FUNCTION Real apply( const Real &x ) const {
     return value_*x;
   }
 };
@@ -258,7 +258,7 @@ template<class Real>
 class Logarithm : public UnaryFunction<Real> {
 public:
 
-  Real apply( const Real &x ) const {
+  KOKKOS_FUNCTION Real apply( const Real &x ) const {
     // To avoid circular dependency
     Real NINF = -0.1*std::abs(ROL::ScalarTraits<Real>::rmax()); 
     return (x>0) ? std::log(x) : NINF;
@@ -272,7 +272,7 @@ template<class Real>
 class Heaviside : public UnaryFunction<Real> {
 public:
  
-  Real apply( const Real &x ) const {
+  KOKKOS_FUNCTION Real apply( const Real &x ) const {
     Real value = 0;
     if( x>0 ) {
       value = 1.0;
@@ -290,7 +290,7 @@ template<class Real>
 class Round : public UnaryFunction<Real> {
 public:
   Round(void) {}
-  Real apply(const Real &x) const {
+  KOKKOS_FUNCTION Real apply(const Real &x) const {
     const Real half(0.5), fx = std::floor(x), cx = std::ceil(x);
     return (x-fx < half ? fx : cx); 
   }
@@ -308,7 +308,7 @@ private:
 public:
   UnaryComposition( ROL::Ptr<UnaryFunction<Real> > &f,
                     ROL::Ptr<UnaryFunction<Real> > &g ) : f_(f), g_(g) {}
-  Real apply( const Real &x ) const {
+  KOKKOS_FUNCTION Real apply( const Real &x ) const {
     return g_->apply(f_->apply(x));
   }
 

--- a/packages/rol/src/function/boundconstraint/ROL_Bounds.hpp
+++ b/packages/rol/src/function/boundconstraint/ROL_Bounds.hpp
@@ -73,7 +73,7 @@ private:
   class Active : public Elementwise::BinaryFunction<Real> {
     public:
     Active(Real offset) : offset_(offset) {}
-    Real apply( const Real &x, const Real &y ) const {
+    KOKKOS_FUNCTION Real apply( const Real &x, const Real &y ) const {
       return ((y <= offset_) ? 0 : x);
     }
     private:
@@ -83,7 +83,7 @@ private:
   class UpperBinding : public Elementwise::BinaryFunction<Real> {
     public:
     UpperBinding(Real xeps, Real geps) : xeps_(xeps), geps_(geps) {}
-    Real apply( const Real &x, const Real &y ) const {
+    KOKKOS_FUNCTION Real apply( const Real &x, const Real &y ) const {
       return ((y < -geps_ && x <= xeps_) ? 0 : 1);
     }
     private:
@@ -93,7 +93,7 @@ private:
   class LowerBinding : public Elementwise::BinaryFunction<Real> {
     public:
     LowerBinding(Real xeps, Real geps) : xeps_(xeps), geps_(geps) {}
-    Real apply( const Real &x, const Real &y ) const {
+    KOKKOS_FUNCTION Real apply( const Real &x, const Real &y ) const {
       return ((y > geps_ && x <= xeps_) ? 0 : 1);
     }
     private:
@@ -102,14 +102,14 @@ private:
 
   class PruneBinding : public Elementwise::BinaryFunction<Real> {
     public:
-      Real apply( const Real &x, const Real &y ) const {
+      KOKKOS_FUNCTION Real apply( const Real &x, const Real &y ) const {
         return ((y == 1) ? x : 0);
       }
   } prune_;
 
   class BuildC : public Elementwise::UnaryFunction<Real> {
     public:
-      Real apply( const Real &x ) const {
+      KOKKOS_FUNCTION Real apply( const Real &x ) const {
         const Real zeta(0.5), kappa(1);
         return std::min(zeta * x, kappa);
       }
@@ -117,7 +117,7 @@ private:
 
   class SetZeroEntry : public Elementwise::BinaryFunction<Real> {
     public:
-      Real apply(const Real &x, const Real &y) const {
+      KOKKOS_FUNCTION Real apply(const Real &x, const Real &y) const {
         const Real zero(0);
         return (x==zero ? y : x);
       }

--- a/packages/rol/src/function/boundconstraint/ROL_Bounds_Def.hpp
+++ b/packages/rol/src/function/boundconstraint/ROL_Bounds_Def.hpp
@@ -90,11 +90,11 @@ Bounds<Real>::Bounds(const Ptr<Vector<Real>> &x_lo, const Ptr<Vector<Real>> &x_u
 template<typename Real>
 void Bounds<Real>::project( Vector<Real> &x ) {
   struct Lesser : public Elementwise::BinaryFunction<Real> {
-    Real apply(const Real &xc, const Real &yc) const { return xc<yc ? xc : yc; }
+    KOKKOS_FUNCTION Real apply(const Real &xc, const Real &yc) const { return xc<yc ? xc : yc; }
   } lesser;
 
   struct Greater : public Elementwise::BinaryFunction<Real> {
-    Real apply(const Real &xc, const Real &yc) const { return xc>yc ? xc : yc; }
+    KOKKOS_FUNCTION Real apply(const Real &xc, const Real &yc) const { return xc>yc ? xc : yc; }
   } greater;
 
   if (BoundConstraint<Real>::isUpperActivated()) {
@@ -117,7 +117,7 @@ void Bounds<Real>::projectInterior( Vector<Real> &x ) {
     public:
       LowerFeasible(const Real eps, const Real diff)
         : eps_(eps), diff_(diff) {}
-      Real apply( const Real &x, const Real &y ) const {
+      KOKKOS_FUNCTION Real apply( const Real &x, const Real &y ) const {
         const Real tol = static_cast<Real>(100)*ROL_EPSILON<Real>();
         const Real one(1);
         Real val = ((y <-tol) ? y*(one-eps_)
@@ -138,7 +138,7 @@ void Bounds<Real>::projectInterior( Vector<Real> &x ) {
     public:
       UpperFeasible(const Real eps, const Real diff)
         : eps_(eps), diff_(diff) {}
-      Real apply( const Real &x, const Real &y ) const {
+      KOKKOS_FUNCTION Real apply( const Real &x, const Real &y ) const {
         const Real tol = static_cast<Real>(100)*ROL_EPSILON<Real>();
         const Real one(1);
         Real val = ((y <-tol) ? y*(one+eps_)

--- a/packages/rol/src/function/constraint/ROL_BinaryConstraint.hpp
+++ b/packages/rol/src/function/constraint/ROL_BinaryConstraint.hpp
@@ -72,7 +72,7 @@ private:
   public:
     BoundsCheck( int option ) : opt_(option) {}
 
-    Real apply( const Real &dl, const Real &du ) const {
+    KOKKOS_FUNCTION Real apply( const Real &dl, const Real &du ) const {
       const Real zero(0), one(1), two(2);
       if( dl < ROL_INF<Real>() ) {
         if( du < ROL_INF<Real>() ) {

--- a/packages/rol/src/function/objective/ROL_l1Objective.hpp
+++ b/packages/rol/src/function/objective/ROL_l1Objective.hpp
@@ -63,7 +63,7 @@ private:
   Ptr<Vector<Real>> tmp_;
 
   struct ProjSymBnd : public Elementwise::BinaryFunction<Real> {
-       Real apply(const Real &xc, const Real &yc) const { return std::min(yc, std::max(-yc, xc)); }
+       KOKKOS_FUNCTION Real apply(const Real &xc, const Real &yc) const { return std::min(yc, std::max(-yc, xc)); }
   } psb_;
  
 public:

--- a/packages/rol/src/step/ROL_PrimalDualInteriorPointStep.hpp
+++ b/packages/rol/src/step/ROL_PrimalDualInteriorPointStep.hpp
@@ -370,7 +370,7 @@ public:
 
     class Max1X : public Elementwise::UnaryFunction<Real> {
     public:
-      Real apply( const Real &x ) const {
+      KOKKOS_FUNCTION Real apply( const Real &x ) const {
         return std::max(1.0,x);
       }
     };

--- a/packages/rol/src/step/fletcher/ROL_BoundFletcher.hpp
+++ b/packages/rol/src/step/fletcher/ROL_BoundFletcher.hpp
@@ -152,7 +152,7 @@ private:
   class DiffLower : public Elementwise::BinaryFunction<Real> {
   public:
     DiffLower(void) {}
-    Real apply(const Real& x, const Real& y) const {
+    KOKKOS_FUNCTION Real apply(const Real& x, const Real& y) const {
       const Real NINF(ROL_NINF<Real>());
       return (y <= NINF ? static_cast<Real>(-1.) : x - y);
     }
@@ -161,7 +161,7 @@ private:
   class DiffUpper : public Elementwise::BinaryFunction<Real> {
   public:
     DiffUpper(void) {}
-    Real apply(const Real& x, const Real& y) const {
+    KOKKOS_FUNCTION Real apply(const Real& x, const Real& y) const {
       const Real INF(ROL_INF<Real>());
       return (y >= INF ? static_cast<Real>(-1.) : y - x);
     }
@@ -170,7 +170,7 @@ private:
   class FormQ : public Elementwise::BinaryFunction<Real> {
   public:
     FormQ(void) {}
-    Real apply(const Real& x, const Real& y) const {
+    KOKKOS_FUNCTION Real apply(const Real& x, const Real& y) const {
       Real zero(0.);
       if( x < zero  && y < zero) {
         return static_cast<Real>(1);
@@ -188,7 +188,7 @@ private:
   class FormDQ : public Elementwise::BinaryFunction<Real> {
   public:
     FormDQ(void) {}
-    Real apply(const Real& x, const Real& y) const {
+    KOKKOS_FUNCTION Real apply(const Real& x, const Real& y) const {
       Real zero(0.), one(1.), mone(-1.);
       if( x < zero  && y < zero) {
         return zero;

--- a/packages/rol/src/step/interiorpoint/ROL_InteriorPointPenalty.hpp
+++ b/packages/rol/src/step/interiorpoint/ROL_InteriorPointPenalty.hpp
@@ -101,7 +101,7 @@ private:
   //             { 0      if x <= 0
   class ModifiedLogarithm : public Elementwise::UnaryFunction<Real> {
   public:
-    Real apply( const Real &x ) const {
+    KOKKOS_FUNCTION Real apply( const Real &x ) const {
       return (x>0) ? std::log(x) : Real(0.0);
     }
   }; // class ModifiedLogarithm
@@ -110,7 +110,7 @@ private:
   //             { 0    if  x <= 0
   class ModifiedReciprocal : public Elementwise::UnaryFunction<Real> {
   public:
-    Real apply( const Real &x ) const {
+    KOKKOS_FUNCTION Real apply( const Real &x ) const {
       return (x>0) ? 1.0/x : Real(0.0);
     }
 
@@ -120,7 +120,7 @@ private:
   //               { 0    if  x <= 0
   class ModifiedDivide : public Elementwise::BinaryFunction<Real> {
   public:
-    Real apply( const Real &x, const Real &y ) const {
+    KOKKOS_FUNCTION Real apply( const Real &x, const Real &y ) const {
       return (x>0) ? y/x : Real(0.0);
     }
   }; // class ModifiedDivide
@@ -134,7 +134,7 @@ private:
     bool complement_;
   public:
     Mask( bool complement ) : complement_(complement) {}
-    Real apply( const Real &x, const Real &y ) const {
+    KOKKOS_FUNCTION Real apply( const Real &x, const Real &y ) const {
       return ( complement_ ^ (y !=0) ) ? 0 : x;
     }
   }; // class Mask

--- a/packages/rol/src/step/interiorpoint/ROL_LogBarrierObjective.hpp
+++ b/packages/rol/src/step/interiorpoint/ROL_LogBarrierObjective.hpp
@@ -84,7 +84,7 @@ public:
     dbyx->set(x);
 
     struct Division : public Elementwise::BinaryFunction<Real> {
-      Real apply( const Real &xc, const Real &dc ) const {
+      KOKKOS_FUNCTION Real apply( const Real &xc, const Real &dc ) const {
         return dc/xc;    
       }
     } division;
@@ -100,7 +100,7 @@ public:
     hv.set(v);
     
     struct HessianApply : public Elementwise::BinaryFunction<Real> {
-      Real apply( const Real &vc, const Real &xc ) const { 
+      KOKKOS_FUNCTION Real apply( const Real &vc, const Real &xc ) const { 
         return vc/(xc*xc);   
       }
     } hessian;

--- a/packages/rol/src/step/trustregion/ROL_ColemanLiModel.hpp
+++ b/packages/rol/src/step/trustregion/ROL_ColemanLiModel.hpp
@@ -105,7 +105,7 @@ private:
     class NegGradInfU : public Elementwise::BinaryFunction<Real> {
     public:
       NegGradInfU(void) {}
-      Real apply(const Real &x, const Real &y) const {
+      KOKKOS_FUNCTION Real apply(const Real &x, const Real &y) const {
         const Real zero(0), one(1), INF(ROL_INF<Real>());
         return (x < zero && y == INF) ? zero : one;
       }
@@ -117,7 +117,7 @@ private:
     class PosGradNinfL : public Elementwise::BinaryFunction<Real> {
     public:
       PosGradNinfL(void) {}
-      Real apply(const Real &x, const Real &y) const {
+      KOKKOS_FUNCTION Real apply(const Real &x, const Real &y) const {
         const Real zero(0), one(1), NINF(ROL_NINF<Real>());
         return (x >= zero && y == NINF) ? zero : one;
       }
@@ -395,7 +395,7 @@ private:
       const Real val_;
     public:
       PruneNegative( const Real val ) : val_(val) {}
-      Real apply(const Real &x, const Real &y) const {
+      KOKKOS_FUNCTION Real apply(const Real &x, const Real &y) const {
         return (y < static_cast<Real>(0)) ? x/y : val_;
       }
     };
@@ -404,7 +404,7 @@ private:
       const Real val_;
     public:
       PrunePositive( const Real val ) : val_(val) {}
-      Real apply(const Real &x, const Real &y) const {
+      KOKKOS_FUNCTION Real apply(const Real &x, const Real &y) const {
         return (y > static_cast<Real>(0)) ? x/y : val_;
       }
     };
@@ -489,7 +489,7 @@ private:
 
     class LowerBound : public Elementwise::BinaryFunction<Real> {
     public:
-      Real apply( const Real &x, const Real &y ) const {
+      KOKKOS_FUNCTION Real apply( const Real &x, const Real &y ) const {
         return (x == y) ? static_cast<Real>(-1) : static_cast<Real>(1);
       }
     };
@@ -499,7 +499,7 @@ private:
 
     class UpperBound : public Elementwise::BinaryFunction<Real> {
     public:
-      Real apply( const Real &x, const Real &y ) const {
+      KOKKOS_FUNCTION Real apply( const Real &x, const Real &y ) const {
         return (x == y) ? static_cast<Real>(-1) : static_cast<Real>(1);
       }
     };
@@ -514,7 +514,7 @@ private:
 
     class LowerBound : public Elementwise::BinaryFunction<Real> {
     public:
-      Real apply( const Real &x, const Real &y ) const {
+      KOKKOS_FUNCTION Real apply( const Real &x, const Real &y ) const {
         return (x < y) ? static_cast<Real>(-1) : static_cast<Real>(1);
       }
     };
@@ -524,7 +524,7 @@ private:
 
     class UpperBound : public Elementwise::BinaryFunction<Real> {
     public:
-      Real apply( const Real &x, const Real &y ) const {
+      KOKKOS_FUNCTION Real apply( const Real &x, const Real &y ) const {
         return (x > y) ? static_cast<Real>(-1) : static_cast<Real>(1);
       }
     };
@@ -543,7 +543,7 @@ private:
       const Real val_;
     public:
       SafeDivide( const Real val ) : val_(val) {}
-      Real apply(const Real &x, const Real &y) const {
+      KOKKOS_FUNCTION Real apply(const Real &x, const Real &y) const {
         const Real zero(0);
         return (y == zero) ? val_ : x/y;
       }
@@ -572,7 +572,7 @@ private:
     class Greater : public Elementwise::BinaryFunction<Real> {
     public:
       Greater() {}
-      Real apply(const Real &x, const Real &y) const {
+      KOKKOS_FUNCTION Real apply(const Real &x, const Real &y) const {
         return (x > y) ? static_cast<Real>(1) : static_cast<Real>(0);
       }
     };
@@ -583,7 +583,7 @@ private:
     class Lesser : public Elementwise::BinaryFunction<Real> {
     public:
       Lesser() {}
-      Real apply(const Real &x, const Real &y) const {
+      KOKKOS_FUNCTION Real apply(const Real &x, const Real &y) const {
         return (x < y) ? static_cast<Real>(1) : static_cast<Real>(0);
       }
     };

--- a/packages/rol/src/step/trustregion/ROL_KelleySachsModel.hpp
+++ b/packages/rol/src/step/trustregion/ROL_KelleySachsModel.hpp
@@ -66,7 +66,7 @@ private:
   class UpperBinding : public Elementwise::BinaryFunction<Real> {
     public:
     UpperBinding(Real offset) : offset_(offset) {}
-    Real apply( const Real &x, const Real &y ) const {
+    KOKKOS_FUNCTION Real apply( const Real &x, const Real &y ) const {
       const Real one(1), tol(1e2*ROL_EPSILON<Real>());
       return ((y <= -offset_ && x <= tol) ? -one : one);
     }
@@ -77,7 +77,7 @@ private:
   class LowerBinding : public Elementwise::BinaryFunction<Real> {
     public:
     LowerBinding(Real offset) : offset_(offset) {}
-    Real apply( const Real &x, const Real &y ) const {
+    KOKKOS_FUNCTION Real apply( const Real &x, const Real &y ) const {
       const Real one(1), tol(1e2*ROL_EPSILON<Real>());
       return ((y >= offset_ && x <= tol) ? -one : one);
     }
@@ -87,7 +87,7 @@ private:
 
   class PruneBinding : public Elementwise::BinaryFunction<Real> {
     public:
-    Real apply( const Real &x, const Real &y ) const {
+    KOKKOS_FUNCTION Real apply( const Real &x, const Real &y ) const {
       const Real zero(0), one(1);
       return ((y == one) ? x : zero);
     }
@@ -95,7 +95,7 @@ private:
 
   class PruneNonbinding : public Elementwise::BinaryFunction<Real> {
     public:
-    Real apply( const Real &x, const Real &y ) const {
+    KOKKOS_FUNCTION Real apply( const Real &x, const Real &y ) const {
       const Real zero(0), one(1);
       return ((y == -one) ? x : zero);
     }

--- a/packages/rol/src/step/trustregion/ROL_LinMore.hpp
+++ b/packages/rol/src/step/trustregion/ROL_LinMore.hpp
@@ -69,7 +69,7 @@ private:
 
   class LowerBreakPoint : public Elementwise::BinaryFunction<Real> {
     public:
-    Real apply( const Real &x, const Real &y) const {
+    KOKKOS_FUNCTION Real apply( const Real &x, const Real &y) const {
       const Real zero(0), one(1);
       return (x > zero && y < zero) ? -x/y : -one;
     }
@@ -77,7 +77,7 @@ private:
 
   class UpperBreakPoint : public Elementwise::BinaryFunction<Real> {
     public:
-    Real apply( const Real &x, const Real &y) const {
+    KOKKOS_FUNCTION Real apply( const Real &x, const Real &y) const {
       const Real zero(0), one(1);
       return (x > zero && y > zero) ? x/y : -one;
     }


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/rol
@dridzal

## Motivation
When compiling with HIPCC, errors are reported that ROL ElementWise operations are attempting to invoke __host__ functions from __host__ __device__ functions. This is not allowed and the compilation does not complete.

This issue was initially brought up in and closes #11401 .

## Stakeholder Feedback
N/A

## Testing
Modifications are to ROL::ElementWise::[UnaryFunction|BinaryFunction|ReductionOp] and their derived class implementations.

The changes made to UnaryFunction, BinaryFunction, and ReductionOp are tested by elementwise.test_01.cpp.