### PR TITLE
Converted Panzer to the new STK simple_fields workflow

### DIFF
--- a/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_GatherFields_impl.hpp
+++ b/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_GatherFields_impl.hpp
@@ -90,7 +90,7 @@ postRegistrationSetup(typename Traits::SetupData /* d */,
   for (std::size_t fd = 0; fd < gatherFields_.size(); ++fd) {
     std::string fieldName = gatherFields_[fd].fieldTag().name();
 
-    stkFields_[fd] = mesh_->getMetaData()->get_field<VariableField>(stk::topology::NODE_RANK, fieldName);
+    stkFields_[fd] = mesh_->getMetaData()->get_field<double>(stk::topology::NODE_RANK, fieldName);
 
     if(stkFields_[fd]==0) {
       std::stringstream ss; 

--- a/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterCellAvgQuantity_impl.hpp
+++ b/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterCellAvgQuantity_impl.hpp
@@ -106,7 +106,7 @@ postRegistrationSetup(
   for (std::size_t fd = 0; fd < scatterFields_.size(); ++fd) {
     std::string fieldName = scatterFields_[fd].fieldTag().name();
 
-    stkFields_[fd] = mesh_->getMetaData()->get_field<VariableField>(stk::topology::ELEMENT_RANK, fieldName);
+    stkFields_[fd] = mesh_->getMetaData()->get_field<double>(stk::topology::ELEMENT_RANK, fieldName);
   }
 }
 

--- a/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterCellAvgVector_impl.hpp
+++ b/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterCellAvgVector_impl.hpp
@@ -108,7 +108,7 @@ postRegistrationSetup(
   {
     std::string fieldName = scatterFields_[fd].fieldTag().name();
 
-    stkFields_[fd] = mesh_->getMetaData()->get_field<VariableField>(stk::topology::ELEMENT_RANK, fieldName);
+    stkFields_[fd] = mesh_->getMetaData()->get_field<double>(stk::topology::ELEMENT_RANK, fieldName);
   }
 }
 

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_ExodusReaderFactory.cpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_ExodusReaderFactory.cpp
@@ -74,6 +74,7 @@ int getMeshDimension(const std::string & meshStr,
                      const std::string & typeStr)
 {
   stk::io::StkMeshIoBroker meshData(parallelMach);
+  meshData.use_simple_fields();
   meshData.property_add(Ioss::Property("LOWER_CASE_VARIABLE_NAMES", false));
   meshData.add_mesh_database(meshStr, fileTypeToIOSSType(typeStr), stk::io::READ_MESH);
   meshData.create_input_mesh();
@@ -142,6 +143,7 @@ Teuchos::RCP<STK_Interface> STK_ExodusReaderFactory::buildUncommitedMesh(stk::Pa
 
    // read in meta data
    stk::io::StkMeshIoBroker* meshData = new stk::io::StkMeshIoBroker(parallelMach);
+   meshData->use_simple_fields();
    meshData->property_add(Ioss::Property("LOWER_CASE_VARIABLE_NAMES", false));
 
    // add in "FAMILY_TREE" entity for doing refinement
@@ -230,8 +232,7 @@ void STK_ExodusReaderFactory::completeMeshConstruction(STK_Interface & mesh,stk:
    // turned on from the input file.
    if (userMeshScaling_)
    {
-     stk::mesh::Field<double,stk::mesh::Cartesian>* coord_field =
-       metaData.get_field<stk::mesh::Field<double, stk::mesh::Cartesian> >(stk::topology::NODE_RANK, "coordinates");
+     stk::mesh::Field<double>* coord_field = metaData.get_field<double>(stk::topology::NODE_RANK, "coordinates");
 
      stk::mesh::Selector select_all_local = metaData.locally_owned_part() | metaData.globally_shared_part();
      stk::mesh::BucketVector const& my_node_buckets = bulkData.get_buckets(stk::topology::NODE_RANK, select_all_local);
@@ -279,8 +280,7 @@ void STK_ExodusReaderFactory::completeMeshConstruction(STK_Interface & mesh,stk:
    mesh.endModification();
 
    if (userMeshScaling_) {
-     stk::mesh::Field<double,stk::mesh::Cartesian>* coord_field =
-       metaData.get_field<stk::mesh::Field<double, stk::mesh::Cartesian> >(stk::topology::NODE_RANK, "coordinates");
+     stk::mesh::Field<double>* coord_field = metaData.get_field<double>(stk::topology::NODE_RANK, "coordinates");
      std::vector< const stk::mesh::FieldBase *> fields;
      fields.push_back(coord_field);
 

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.cpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.cpp
@@ -109,12 +109,14 @@ STK_Interface::STK_Interface()
    : dimension_(0), initialized_(false), currentLocalId_(0), initialStateTime_(0.0), currentStateTime_(0.0), useFieldCoordinates_(false)
 {
   metaData_ = rcp(new stk::mesh::MetaData());
+  metaData_->use_simple_fields();
 }
 
 STK_Interface::STK_Interface(Teuchos::RCP<stk::mesh::MetaData> metaData)
   : dimension_(0), initialized_(false), currentLocalId_(0), initialStateTime_(0.0), currentStateTime_(0.0), useFieldCoordinates_(false)
 {
   metaData_ = metaData;
+  metaData_->use_simple_fields();
 }
 
 STK_Interface::STK_Interface(unsigned dim)
@@ -124,6 +126,7 @@ STK_Interface::STK_Interface(unsigned dim)
    entity_rank_names.push_back("FAMILY_TREE");
 
    metaData_ = rcp(new stk::mesh::MetaData(dimension_,entity_rank_names));
+   metaData_->use_simple_fields();
 
    initializeFromMetaData();
 }
@@ -162,13 +165,12 @@ void STK_Interface::addSolutionField(const std::string & fieldName,const std::st
 
    // add & declare field if not already added...currently assuming linears
    if(fieldNameToSolution_.find(key)==fieldNameToSolution_.end()) {
-      SolutionFieldType * field = metaData_->get_field<SolutionFieldType>(stk::topology::NODE_RANK, fieldName);
+      SolutionFieldType * field = metaData_->get_field<double>(stk::topology::NODE_RANK, fieldName);
       if(field==0)
-         field = &metaData_->declare_field<SolutionFieldType>(stk::topology::NODE_RANK, fieldName);
+         field = &metaData_->declare_field<double>(stk::topology::NODE_RANK, fieldName);
       if ( initialized_ )  {
         metaData_->enable_late_fields();
-        stk::mesh::FieldTraits<SolutionFieldType>::data_type* init_sol = nullptr;
-        stk::mesh::put_field_on_mesh(*field, metaData_->universal_part(),init_sol );
+        stk::mesh::put_field_on_mesh(*field, metaData_->universal_part(), nullptr);
       }
       fieldNameToSolution_[key] = field;
    }
@@ -182,14 +184,13 @@ void STK_Interface::addCellField(const std::string & fieldName,const std::string
 
    // add & declare field if not already added...currently assuming linears
    if(fieldNameToCellField_.find(key)==fieldNameToCellField_.end()) {
-      SolutionFieldType * field = metaData_->get_field<SolutionFieldType>(stk::topology::ELEMENT_RANK, fieldName);
+      SolutionFieldType * field = metaData_->get_field<double>(stk::topology::ELEMENT_RANK, fieldName);
       if(field==0)
-         field = &metaData_->declare_field<SolutionFieldType>(stk::topology::ELEMENT_RANK, fieldName);
+         field = &metaData_->declare_field<double>(stk::topology::ELEMENT_RANK, fieldName);
 
       if ( initialized_ )  {
         metaData_->enable_late_fields();
-        stk::mesh::FieldTraits<SolutionFieldType>::data_type* init_sol = nullptr;
-        stk::mesh::put_field_on_mesh(*field, metaData_->universal_part(),init_sol );
+        stk::mesh::put_field_on_mesh(*field, metaData_->universal_part(), nullptr);
       }
       fieldNameToCellField_[key] = field;
    }
@@ -203,15 +204,14 @@ void STK_Interface::addEdgeField(const std::string & fieldName,const std::string
 
    // add & declare field if not already added...currently assuming linears
    if(fieldNameToEdgeField_.find(key)==fieldNameToEdgeField_.end()) {
-      SolutionFieldType * field = metaData_->get_field<SolutionFieldType>(stk::topology::EDGE_RANK, fieldName);
+      SolutionFieldType * field = metaData_->get_field<double>(stk::topology::EDGE_RANK, fieldName);
       if(field==0) {
-         field = &metaData_->declare_field<SolutionFieldType>(stk::topology::EDGE_RANK, fieldName);
+         field = &metaData_->declare_field<double>(stk::topology::EDGE_RANK, fieldName);
       }
 
       if ( initialized_ )  {
         metaData_->enable_late_fields();
-        stk::mesh::FieldTraits<SolutionFieldType>::data_type* init_sol = nullptr;
-        stk::mesh::put_field_on_mesh(*field, metaData_->universal_part(),init_sol );
+        stk::mesh::put_field_on_mesh(*field, metaData_->universal_part(), nullptr);
       }
       fieldNameToEdgeField_[key] = field;
    }
@@ -225,15 +225,14 @@ void STK_Interface::addFaceField(const std::string & fieldName,const std::string
 
    // add & declare field if not already added...currently assuming linears
    if(fieldNameToFaceField_.find(key)==fieldNameToFaceField_.end()) {
-      SolutionFieldType * field = metaData_->get_field<SolutionFieldType>(stk::topology::FACE_RANK, fieldName);
+      SolutionFieldType * field = metaData_->get_field<double>(stk::topology::FACE_RANK, fieldName);
       if(field==0) {
-         field = &metaData_->declare_field<SolutionFieldType>(stk::topology::FACE_RANK, fieldName);
+         field = &metaData_->declare_field<double>(stk::topology::FACE_RANK, fieldName);
       }
 
       if ( initialized_ )  {
         metaData_->enable_late_fields();
-        stk::mesh::FieldTraits<SolutionFieldType>::data_type* init_sol = nullptr;
-        stk::mesh::put_field_on_mesh(*field, metaData_->universal_part(),init_sol );
+        stk::mesh::put_field_on_mesh(*field, metaData_->universal_part(), nullptr);
       }
       fieldNameToFaceField_[key] = field;
    }
@@ -274,9 +273,9 @@ void STK_Interface::addMeshCoordFields(const std::string & blockId,
       // add & declare field if not already added...currently assuming linears
       if(fieldNameToSolution_.find(key)==fieldNameToSolution_.end()) {
 
-         SolutionFieldType * field = metaData_->get_field<SolutionFieldType>(stk::topology::NODE_RANK, dispName);
+         SolutionFieldType * field = metaData_->get_field<double>(stk::topology::NODE_RANK, dispName);
          if(field==0) {
-            field = &metaData_->declare_field<SolutionFieldType>(stk::topology::NODE_RANK, dispName);
+            field = &metaData_->declare_field<double>(stk::topology::NODE_RANK, dispName);
          }
          fieldNameToSolution_[key] = field;
       }
@@ -300,15 +299,12 @@ void STK_Interface::initialize(stk::ParallelMachine parallelMach,bool setupIO,
    procRank_ = stk::parallel_machine_rank(*mpiComm_->getRawMpiComm());
 
    // associating the field with a part: universal part!
-   stk::mesh::FieldTraits<VectorFieldType>::data_type* init_vf = nullptr; // gcc 4.8 hack
-   stk::mesh::FieldTraits<ProcIdFieldType>::data_type* init_pid = nullptr; // gcc 4.8 hack
-   stk::mesh::FieldTraits<SolutionFieldType>::data_type* init_sol = nullptr; // gcc 4.8 hack
-   stk::mesh::put_field_on_mesh( *coordinatesField_ , metaData_->universal_part(), getDimension(),init_vf);
-   stk::mesh::put_field_on_mesh( *edgesField_ , metaData_->universal_part(), getDimension(),init_vf);
+   stk::mesh::put_field_on_mesh( *coordinatesField_ , metaData_->universal_part(), getDimension(), nullptr);
+   stk::mesh::put_field_on_mesh( *edgesField_ , metaData_->universal_part(), getDimension(), nullptr);
    if (dimension_ > 2)
-     stk::mesh::put_field_on_mesh( *facesField_ , metaData_->universal_part(), getDimension(),init_vf);
-   stk::mesh::put_field_on_mesh( *processorIdField_ , metaData_->universal_part(),init_pid);
-   stk::mesh::put_field_on_mesh( *loadBalField_ , metaData_->universal_part(),init_sol);
+     stk::mesh::put_field_on_mesh( *facesField_ , metaData_->universal_part(), getDimension(), nullptr);
+   stk::mesh::put_field_on_mesh( *processorIdField_ , metaData_->universal_part(), nullptr);
+   stk::mesh::put_field_on_mesh( *loadBalField_ , metaData_->universal_part(), nullptr);
 
    initializeFieldsInSTK(fieldNameToSolution_, setupIO);
    initializeFieldsInSTK(fieldNameToCellField_, setupIO);
@@ -365,11 +361,16 @@ void STK_Interface::initialize(stk::ParallelMachine parallelMach,bool setupIO,
          stk::io::put_io_part_attribute(*nodesPart_);
 
       stk::io::set_field_role(*coordinatesField_, Ioss::Field::MESH);
+      stk::io::set_field_output_type(*coordinatesField_, stk::io::FieldOutputType::VECTOR_3D);
       stk::io::set_field_role(*edgesField_, Ioss::Field::MESH);
-      if (dimension_ > 2)
+      stk::io::set_field_output_type(*edgesField_, stk::io::FieldOutputType::VECTOR_3D);
+      if (dimension_ > 2) {
          stk::io::set_field_role(*facesField_, Ioss::Field::MESH);
+         stk::io::set_field_output_type(*facesField_, stk::io::FieldOutputType::VECTOR_3D);
+      }
       stk::io::set_field_role(*processorIdField_, Ioss::Field::TRANSIENT);
       // stk::io::set_field_role(*loadBalField_, Ioss::Field::TRANSIENT);
+
    }
 #endif
 
@@ -404,9 +405,8 @@ void STK_Interface::initializeFieldsInSTK(const std::map<std::pair<std::string,s
 
    {
       std::set<SolutionFieldType*>::const_iterator uniqueFieldIter;
-      stk::mesh::FieldTraits<SolutionFieldType>::data_type* init_sol = nullptr; // gcc 4.8 hack
       for(uniqueFieldIter=uniqueFields.begin();uniqueFieldIter!=uniqueFields.end();++uniqueFieldIter)
-        stk::mesh::put_field_on_mesh(*(*uniqueFieldIter),metaData_->universal_part(),init_sol);
+        stk::mesh::put_field_on_mesh(*(*uniqueFieldIter),metaData_->universal_part(),nullptr);
    }
 
 #ifdef PANZER_HAVE_IOSS
@@ -1722,12 +1722,12 @@ void STK_Interface::initializeFromMetaData()
    dimension_ = metaData_->spatial_dimension();
 
    // declare coordinates and node parts
-   coordinatesField_ = &metaData_->declare_field<VectorFieldType>(stk::topology::NODE_RANK, coordsString);
-   edgesField_       = &metaData_->declare_field<VectorFieldType>(stk::topology::EDGE_RANK, edgesString);
+   coordinatesField_ = &metaData_->declare_field<double>(stk::topology::NODE_RANK, coordsString);
+   edgesField_       = &metaData_->declare_field<double>(stk::topology::EDGE_RANK, edgesString);
    if (dimension_ > 2)
-     facesField_       = &metaData_->declare_field<VectorFieldType>(stk::topology::FACE_RANK, facesString);
-   processorIdField_ = &metaData_->declare_field<ProcIdFieldType>(stk::topology::ELEMENT_RANK, "PROC_ID");
-   loadBalField_     = &metaData_->declare_field<SolutionFieldType>(stk::topology::ELEMENT_RANK, "LOAD_BAL");
+     facesField_       = &metaData_->declare_field<double>(stk::topology::FACE_RANK, facesString);
+   processorIdField_ = &metaData_->declare_field<ProcIdData>(stk::topology::ELEMENT_RANK, "PROC_ID");
+   loadBalField_     = &metaData_->declare_field<double>(stk::topology::ELEMENT_RANK, "LOAD_BAL");
 
    // stk::mesh::put_field( *coordinatesField_ , getNodeRank() , metaData_->universal_part() );
 

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.hpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.hpp
@@ -51,8 +51,6 @@
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/Field.hpp>
 #include <stk_mesh/base/FieldBase.hpp>
-#include <stk_mesh/base/MetaData.hpp>
-#include <stk_mesh/base/CoordinateSystems.hpp>
 
 #include "Kokkos_Core.hpp"
 
@@ -105,7 +103,7 @@ class STK_Interface {
 public:
    typedef double ProcIdData; // ECC: Not sure why?
    typedef stk::mesh::Field<double> SolutionFieldType;
-   typedef stk::mesh::Field<double,stk::mesh::Cartesian> VectorFieldType;
+   typedef stk::mesh::Field<double> VectorFieldType;
    typedef stk::mesh::Field<ProcIdData> ProcIdFieldType;
 
    // some simple exception classes

--- a/packages/panzer/adapters-stk/test/gather_scatter_evaluators/gs_evaluators.cpp
+++ b/packages/panzer/adapters-stk/test/gather_scatter_evaluators/gs_evaluators.cpp
@@ -248,8 +248,8 @@ namespace panzer {
 
     factory.completeMeshConstruction(*mesh,MPI_COMM_WORLD);
 
-    VariableField * field = mesh->getMetaData()->get_field<VariableField>(stk::topology::NODE_RANK, "dog");
-    CoordinateField * cField = mesh->getMetaData()->get_field<CoordinateField>(stk::topology::NODE_RANK, "coordinates");
+    VariableField * field = mesh->getMetaData()->get_field<double>(stk::topology::NODE_RANK, "dog");
+    CoordinateField * cField = mesh->getMetaData()->get_field<double>(stk::topology::NODE_RANK, "coordinates");
     TEUCHOS_ASSERT(field!=0);
     TEUCHOS_ASSERT(cField!=0);
 

--- a/packages/panzer/adapters-stk/test/stk_interface_test/tPamgenMeshFactory.cpp
+++ b/packages/panzer/adapters-stk/test/stk_interface_test/tPamgenMeshFactory.cpp
@@ -89,6 +89,7 @@ TEUCHOS_UNIT_TEST(tPamgenFactory, acceptance)
   {
     out << "\nCreating pamgen mesh." << std::endl;
     RCP<stk::io::StkMeshIoBroker> broker = rcp(new stk::io::StkMeshIoBroker(MPI_COMM_WORLD));
+    broker->use_simple_fields();
     broker->add_mesh_database("pamgen_test.gen", "pamgen", stk::io::READ_MESH);
     broker->create_input_mesh();
     metaData = Teuchos::rcp(broker->meta_data_ptr());
@@ -172,6 +173,7 @@ TEUCHOS_UNIT_TEST(tPamgenFactory, acceptance)
   {
     out << "\nReading Exodus file." << std::endl;
     RCP<stk::io::StkMeshIoBroker> broker = rcp(new stk::io::StkMeshIoBroker(MPI_COMM_WORLD));
+    broker->use_simple_fields();
     broker->add_mesh_database(output_exodus_file_name, "exodus", stk::io::READ_MESH);
     broker->create_input_mesh();
     metaData = Teuchos::rcp(broker->meta_data_ptr());

--- a/packages/panzer/adapters-stk/test/stk_interface_test/tPointLocationSearch.cpp
+++ b/packages/panzer/adapters-stk/test/stk_interface_test/tPointLocationSearch.cpp
@@ -64,8 +64,6 @@
 #include <stk_search/BoundingBox.hpp>
 #include <stk_search_util/stk_mesh/CreateBoundingBox.hpp>
 
-typedef stk::mesh::Field<double, stk::mesh::Cartesian>  VectorField;
-
 namespace panzer_stk {
 
 TEUCHOS_UNIT_TEST(tPointLocationSearch, basic)
@@ -99,7 +97,7 @@ TEUCHOS_UNIT_TEST(tPointLocationSearch, basic)
    // Build (domain) bounding boxes for all cells in mesh
    RCP<stk::mesh::MetaData> meta_data = mesh->getMetaData();
    RCP<stk::mesh::BulkData> bulk_data = mesh->getBulkData(); 
-   const stk::mesh::Field<double, stk::mesh::Cartesian>* domain_coord_field = &(mesh->getCoordinatesField());
+   const stk::mesh::Field<double>* domain_coord_field = &(mesh->getCoordinatesField());
    stk::ParallelMachine comm = bulk_data->parallel();
    // NOTE: the create bounding boxes call has specific typedefs on data.  We need to rewrite for general case.
    std::vector<AxisAlignedBoundingBox3D> domain_vector;
@@ -136,7 +134,7 @@ TEUCHOS_UNIT_TEST(tPointLocationSearch, basic)
 
    stk::search_util::build_axis_aligned_bbox(*bulk_data,
 					     mesh->getElementRank(),
-					     const_cast<stk::mesh::Field<double, stk::mesh::Cartesian>* >(domain_coord_field),
+               const_cast<stk::mesh::Field<double>* >(domain_coord_field),
 					     domain_vector);
    
 

--- a/packages/panzer/adapters-stk/test/stk_interface_test/tSTKInterface.cpp
+++ b/packages/panzer/adapters-stk/test/stk_interface_test/tSTKInterface.cpp
@@ -497,6 +497,7 @@ TEUCHOS_UNIT_TEST(tSTKInterface, globalVariables)
 
   // Open the output file for reading.
   stk::io::StkMeshIoBroker stkIo(MPI_COMM_WORLD);
+  stkIo.use_simple_fields();
   stkIo.add_mesh_database(filename, stk::io::READ_RESTART);
   stkIo.create_input_mesh();
   stkIo.populate_bulk_data();


### PR DESCRIPTION
This essentially removes all usage of the template parameters beyond just the datatype in `stk::mesh::Field`s.  This makes setting the size of a `Field` a run-time configuration option through calls to `stk::mesh::put_field_on_mesh()` and keeps the datatype (double, int, etc.) a compile-time configuration option.  Functions like `stk::mesh::MetaData::declare_field()` and `stk::mesh::MetaData::get_field()` now just pass the datatype as a template parameter instead of the whole templated `Field` type itself.

The `stk::mesh::MetaData::use_simple_fields()` method is called early in `MetaData` construction to force the new behavior, to prevent any accidental regressions and to ensure that any auto-registered `Field`s (like coordinates) will be sized consistently by things like `stk::mesh::StkMeshIoBroker`.  Any calls to the legacy functions will trigger a run-time error.

There should be no user-visible behavior changes, and external applications that use `Panzer` should not need to make any changes as long as they consistently use `Panzer`'s typedefs to refer to higher-dimensional `Field`s like `panzer_stk::VectorFieldType`.  If external apps grab a `stk::mesh::MetaData` and register or manipulate their own `Field`s, there is a chance that they will encounter a new error.  The error message should guide them to the correct solution.
