### PR TITLE
Add option to test against develop for kokkos and kokkos-kernels packages

### DIFF
--- a/packages/framework/pr_tools/LaunchDriver.py
+++ b/packages/framework/pr_tools/LaunchDriver.py
@@ -83,6 +83,8 @@ def main(argv):
                       help='The INI file containing supported systems')
   parser.add_argument('--in-container', default=False, action="store_true",
                       help="Build is happening in a container")
+  parser.add_argument("--kokkos-develop", default=False, action="store_true",
+                       help="Build is requiring to pull the current develop of kokkos and kokkos-kernels packages")
   args = parser.parse_args(argv)
 
   if os.getenv("TRILINOS_DIR") == None:
@@ -107,6 +109,9 @@ def main(argv):
 
   if args.in_container:
      cmd += " --no-bootstrap"
+
+  if args.kokkos_develop:
+     cmd += " --kokkos-develop"
 
   print("LaunchDriver> EXEC: " + cmd, flush=True)
 

--- a/packages/framework/pr_tools/PullRequestLinuxDriver.sh
+++ b/packages/framework/pr_tools/PullRequestLinuxDriver.sh
@@ -93,67 +93,67 @@ sig_merge_old=$(get_md5sum ${REPO_ROOT:?}/packages/framework/pr_tools/PullReques
 if [[ ${kokkos_develop} == "1" ]]; then
     message_std "PRDriver> --kokkos-develop is set - setting kokkos and kokkos-kernels packages to current develop"
     ./$SCRIPTPATH/SetKokkosDevelop.sh
-fi
+else
+    print_banner "Merge Source into Target"
+    message_std "PRDriver> " "TRILINOS_SOURCE_SHA: ${TRILINOS_SOURCE_SHA:?}"
 
-print_banner "Merge Source into Target"
-message_std "PRDriver> " "TRILINOS_SOURCE_SHA: ${TRILINOS_SOURCE_SHA:?}"
-
-# Prepare the command for the MERGE operation
-merge_cmd_options=(
-    ${TRILINOS_SOURCE_REPO:?}
-    ${TRILINOS_TARGET_REPO:?}
-    ${TRILINOS_TARGET_BRANCH:?}
-    ${TRILINOS_SOURCE_SHA:?}
-    ${WORKSPACE:?}
-    )
-merge_cmd="${PYTHON_EXE:?} ${REPO_ROOT:?}/packages/framework/pr_tools/PullRequestLinuxDriverMerge.py ${merge_cmd_options[@]}"
-
-
-# Call the script to handle merging the incoming branch into
-# the current trilinos/develop branch for testing.
-message_std "PRDriver> " ""
-message_std "PRDriver> " "Execute Merge Command: ${merge_cmd:?}"
-message_std "PRDriver> " ""
-execute_command_checked "${merge_cmd:?}"
-#err=$?
-#if [ $err != 0 ]; then
-#    print_banner "An error occurred during merge"
-#    exit $err
-#fi
-print_banner "Merge completed"
+    # Prepare the command for the MERGE operation
+    merge_cmd_options=(
+        ${TRILINOS_SOURCE_REPO:?}
+        ${TRILINOS_TARGET_REPO:?}
+        ${TRILINOS_TARGET_BRANCH:?}
+        ${TRILINOS_SOURCE_SHA:?}
+        ${WORKSPACE:?}
+        )
+    merge_cmd="${PYTHON_EXE:?} ${REPO_ROOT:?}/packages/framework/pr_tools/PullRequestLinuxDriverMerge.py ${merge_cmd_options[@]}"
 
 
-print_banner "Check for PR Driver Script Modifications"
-
-# Get the md5 checksum of this script:
-#sig_script_new=$(get_md5sum ${REPO_ROOT:?}/packages/framework/pr_tools/PullRequestLinuxDriver.sh)
-sig_script_new=$(get_md5sum ${SCRIPTFILE:?})
-message_std "PRDriver> " ""
-message_std "PRDriver> " "Script File: ${SCRIPTFILE:?}"
-message_std "PRDriver> " "Old md5sum : ${sig_script_old:?}"
-message_std "PRDriver> " "New md5sum : ${sig_script_new:?}"
-
-# Get the md5 checksum of the Merge script
-#sig_merge_new=$(get_md5sum ${REPO_ROOT:?}/packages/framework/pr_tools/PullRequestLinuxDriverMerge.py)
-export MERGE_SCRIPT=${SCRIPTPATH:?}/PullRequestLinuxDriverMerge.py
-sig_merge_new=$(get_md5sum ${MERGE_SCRIPT:?})
-message_std "PRDriver> " ""
-message_std "PRDriver> " "Script File: ${MERGE_SCRIPT:?}"
-message_std "PRDriver> " "Old md5sum : ${sig_merge_old:?}"
-message_std "PRDriver> " "New md5sum : ${sig_merge_new:?}"
-
-if [ "${sig_script_old:?}" != "${sig_script_new:?}" ] || [ "${sig_merge_old:?}" != "${sig_merge_new:?}"  ]
-then
+    # Call the script to handle merging the incoming branch into
+    # the current trilinos/develop branch for testing.
     message_std "PRDriver> " ""
-    message_std "PRDriver> " "Driver or Merge script change detected. Re-launching PR Driver"
+    message_std "PRDriver> " "Execute Merge Command: ${merge_cmd:?}"
     message_std "PRDriver> " ""
-    ${REPO_ROOT:?}/packages/framework/pr_tools/PullRequestLinuxDriver.sh
-    exit $?
-fi
+    execute_command_checked "${merge_cmd:?}"
+    #err=$?
+    #if [ $err != 0 ]; then
+    #    print_banner "An error occurred during merge"
+    #    exit $err
+    #fi
+    print_banner "Merge completed"
 
-message_std "PRDriver> " ""
-message_std "PRDriver> " "Driver and Merge scripts unchanged, proceeding to TEST phase"
-message_std "PRDriver> " ""
+
+    print_banner "Check for PR Driver Script Modifications"
+
+    # Get the md5 checksum of this script:
+    #sig_script_new=$(get_md5sum ${REPO_ROOT:?}/packages/framework/pr_tools/PullRequestLinuxDriver.sh)
+    sig_script_new=$(get_md5sum ${SCRIPTFILE:?})
+    message_std "PRDriver> " ""
+    message_std "PRDriver> " "Script File: ${SCRIPTFILE:?}"
+    message_std "PRDriver> " "Old md5sum : ${sig_script_old:?}"
+    message_std "PRDriver> " "New md5sum : ${sig_script_new:?}"
+
+    # Get the md5 checksum of the Merge script
+    #sig_merge_new=$(get_md5sum ${REPO_ROOT:?}/packages/framework/pr_tools/PullRequestLinuxDriverMerge.py)
+    export MERGE_SCRIPT=${SCRIPTPATH:?}/PullRequestLinuxDriverMerge.py
+    sig_merge_new=$(get_md5sum ${MERGE_SCRIPT:?})
+    message_std "PRDriver> " ""
+    message_std "PRDriver> " "Script File: ${MERGE_SCRIPT:?}"
+    message_std "PRDriver> " "Old md5sum : ${sig_merge_old:?}"
+    message_std "PRDriver> " "New md5sum : ${sig_merge_new:?}"
+
+    if [ "${sig_script_old:?}" != "${sig_script_new:?}" ] || [ "${sig_merge_old:?}" != "${sig_merge_new:?}"  ]
+    then
+        message_std "PRDriver> " ""
+        message_std "PRDriver> " "Driver or Merge script change detected. Re-launching PR Driver"
+        message_std "PRDriver> " ""
+        ${REPO_ROOT:?}/packages/framework/pr_tools/PullRequestLinuxDriver.sh
+        exit $?
+    fi
+
+    message_std "PRDriver> " ""
+    message_std "PRDriver> " "Driver and Merge scripts unchanged, proceeding to TEST phase"
+    message_std "PRDriver> " ""
+fi
 
 # determine what MODE we are using
 mode="standard"

--- a/packages/framework/pr_tools/PullRequestLinuxDriver.sh
+++ b/packages/framework/pr_tools/PullRequestLinuxDriver.sh
@@ -7,8 +7,9 @@ source ${SCRIPTPATH:?}/common.bash
 # Fetch arguments
 on_weaver=$(echo "$@" | grep '\-\-on_weaver' &> /dev/null && echo "1")
 on_ats2=$(echo "$@" | grep '\-\-on_ats2' &> /dev/null && echo "1")
+on_kokkos_develop=$(echo "$@" | grep '\-\-kokkos\-develop' &> /dev/null && echo "1")
+
 bootstrap=$(echo "$@" | grep '\-\-\no\-bootstrap' &> /dev/null && echo "0" || echo "1")
-kokkos_develop=$(echo "$@" | grep '\-\-kokkos\-develop' &> /dev/null && echo "0" || echo "1")
 
 # Configure ccache via environment variables
 function configure_ccache() {
@@ -90,7 +91,7 @@ sig_script_old=$(get_md5sum ${REPO_ROOT:?}/packages/framework/pr_tools/PullReque
 # Get the md5 checksum of the Merge script
 sig_merge_old=$(get_md5sum ${REPO_ROOT:?}/packages/framework/pr_tools/PullRequestLinuxDriverMerge.py)
 
-if [[ ${kokkos_develop} == "1" ]]; then
+if [[ ${on_kokkos_develop} == "1" ]]; then
     message_std "PRDriver> --kokkos-develop is set - setting kokkos and kokkos-kernels packages to current develop"
     ./$SCRIPTPATH/SetKokkosDevelop.sh
 else

--- a/packages/framework/pr_tools/PullRequestLinuxDriver.sh
+++ b/packages/framework/pr_tools/PullRequestLinuxDriver.sh
@@ -8,6 +8,7 @@ source ${SCRIPTPATH:?}/common.bash
 on_weaver=$(echo "$@" | grep '\-\-on_weaver' &> /dev/null && echo "1")
 on_ats2=$(echo "$@" | grep '\-\-on_ats2' &> /dev/null && echo "1")
 bootstrap=$(echo "$@" | grep '\-\-\no\-bootstrap' &> /dev/null && echo "0" || echo "1")
+kokkos_develop=$(echo "$@" | grep '\-\-kokkos\-develop' &> /dev/null && echo "0" || echo "1")
 
 # Configure ccache via environment variables
 function configure_ccache() {
@@ -89,6 +90,10 @@ sig_script_old=$(get_md5sum ${REPO_ROOT:?}/packages/framework/pr_tools/PullReque
 # Get the md5 checksum of the Merge script
 sig_merge_old=$(get_md5sum ${REPO_ROOT:?}/packages/framework/pr_tools/PullRequestLinuxDriverMerge.py)
 
+if [[ ${kokkos_develop} == "1" ]]; then
+    message_std "PRDriver> --kokkos-develop is set - setting kokkos and kokkos-kernels packages to current develop"
+    ./$SCRIPTPATH/SetKokkosDevelop.sh
+fi
 
 print_banner "Merge Source into Target"
 message_std "PRDriver> " "TRILINOS_SOURCE_SHA: ${TRILINOS_SOURCE_SHA:?}"

--- a/packages/framework/pr_tools/SetKokkosDevelop.sh
+++ b/packages/framework/pr_tools/SetKokkosDevelop.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+SCRIPTFILE=$(realpath ${WORKSPACE:?}/Trilinos/packages/framework/pr_tools/SetKokkosDevelop.sh)
+SCRIPTPATH=$(dirname $SCRIPTFILE)
+source ${SCRIPTPATH:?}/common.bash
+PACKAGESPATH=$(realpath ${WORKSPACE:?}/Trilinos/packages)
+
+# Ensures git is loaded properly
+if ! command -v git &> /dev/null; then
+    message_std "SetKokkosDevelop> ERROR: git is not available"
+    exit 1
+fi
+
+cd $PACKAGESPATH
+rm -rf kokkos kokkos-kernels
+git clone --depth=1 --single-branch --branch=develop --shallow-submodules https://github.com/kokkos/kokkos.git
+git clone --depth=1 --single-branch --branch=develop --shallow-submodules https://github.com/kokkos/kokkos-kernels.git
+message_std "SetKokkosDevelop> INFO: updated kokkos and kokkos-kernels packages with current develop"
+
+# Returns to previous path from before running this script
+cd -


### PR DESCRIPTION
@trilinos/framework 

## Motivation
As a Kokkos/KokkosKernels developer, I want Trilinos developers to know about issues with integrating a newer version of these core packages as early as possible, to decrease the effort of a single person overseeing the integration.

As a Trilinos developer, I want the most current Kokkos/KokkosKernels as is feasible to enable new capability.

As a Trilinos customer, I want the most current version of all packages as soon as possible, particularly for use on advanced new platforms.

See TRILFRAME-571 for more details.