### PR TITLE
Tpetra: Use Kokkos::Experimental::SYCLDeviceUSMSpace for KokkosSYCLWrapperNode

### DIFF
--- a/packages/tpetra/core/compat/Tpetra_KokkosCompat_ClassicNodeAPI_Wrapper.hpp
+++ b/packages/tpetra/core/compat/Tpetra_KokkosCompat_ClassicNodeAPI_Wrapper.hpp
@@ -51,7 +51,7 @@ public:
 };
 
 #ifdef KOKKOS_ENABLE_SYCL
-  typedef KokkosDeviceWrapperNode<::Kokkos::Experimental::SYCL, ::Kokkos::Experimental::SYCLSharedUSMSpace> KokkosSYCLWrapperNode;
+  typedef KokkosDeviceWrapperNode<::Kokkos::Experimental::SYCL, ::Kokkos::Experimental::SYCLDeviceUSMSpace> KokkosSYCLWrapperNode;
 #endif
 
 #ifdef KOKKOS_ENABLE_HIP


### PR DESCRIPTION
@trilinos/tpetra @csiefer2 

## Motivation
For all other GPU backends supported by `Tpetra`, i.e., `Cuda` and `HIP`, the memory space for the wrapper node is a device native space anymore, not a shared space. This discrepancy for `SYCL` causes issues in a lot of places that are not ready to use mixed memory spaces, also see https://github.com/trilinos/Trilinos/pull/12119.
This pull request makes sure that the `SYCL` implementation is conforming and also uses a device memory space for the wrapper node.

## Related Issues
* Related to #12119 

## Testing
Compiling `Trilinos` with `Belos` and all required dependencies.