### PR TITLE
Framework: Correct spec inheritance for CXX20 build

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -2535,8 +2535,7 @@ use rhel7_sems-gnu-8.3.0-openmpi-1.10.7-serial_debug_shared_no-kokkos-arch_no-as
 use PACKAGE-ENABLES|ALL
 
 [rhel7_cxx-20-sems-gnu-8.3.0-openmpi-1.10.1-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
-# uses sems-v2 modules
-use rhel7_sems-gnu-8.3.0-openmpi-1.10.7-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
+use rhel7_sems-gnu-8.3.0-openmpi-1.10.1-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 use PACKAGE-ENABLES|ALL
 opt-set-cmake-var CMAKE_CXX_STANDARD             STRING FORCE : 20
 


### PR DESCRIPTION
@trilinos/framework 

## Motivation
Spec was inheriting from another that was non-working.  Correct it to align with older MPI modules.