### PR TITLE
Intrepid2 add H(vol) hierarchical pyramids

### DIFF
--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasisFamily.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasisFamily.hpp
@@ -130,7 +130,6 @@ namespace Intrepid2
     using HDIV_WEDGE  = Basis_Derived_HDIV_WEDGE < HDIV_TRI, HVOL_TRI,  HGRAD_LINE, HVOL_LINE>;
     using HVOL_WEDGE  = Basis_Derived_HVOL_WEDGE < HVOL_TRI, HVOL_LINE>;
     
-    
     // pyramid bases
     using HGRAD_PYR = typename PyramidBasisFamily::HGRAD;
     using HCURL_PYR = typename PyramidBasisFamily::HCURL;
@@ -408,7 +407,7 @@ namespace Intrepid2
     using Teuchos::rcp;
     switch (fs)
     {
-//      case FUNCTION_SPACE_HVOL:  return rcp(new typename BasisFamily::HVOL_PYR (polyOrder, pointType));
+      case FUNCTION_SPACE_HVOL:  return rcp(new typename BasisFamily::HVOL_PYR (polyOrder, pointType));
 //      case FUNCTION_SPACE_HCURL: return rcp(new typename BasisFamily::HCURL_PYR(polyOrder, pointType));
 //      case FUNCTION_SPACE_HDIV:  return rcp(new typename BasisFamily::HDIV_PYR (polyOrder, pointType));
       case FUNCTION_SPACE_HGRAD: return rcp(new typename BasisFamily::HGRAD_PYR(polyOrder, pointType));

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HierarchicalBasisFamily.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HierarchicalBasisFamily.hpp
@@ -61,6 +61,7 @@
 #include "Intrepid2_LegendreBasis_HVOL_LINE.hpp"
 #include "Intrepid2_LegendreBasis_HVOL_TRI.hpp"
 #include "Intrepid2_LegendreBasis_HVOL_TET.hpp"
+#include "Intrepid2_LegendreBasis_HVOL_PYR.hpp"
 
 namespace Intrepid2 {
   
@@ -115,7 +116,7 @@ namespace Intrepid2 {
     using HGRAD = IntegratedLegendreBasis_HGRAD_PYR<DeviceType,OutputScalar,PointScalar,defineVertexFunctions>;
     using HCURL = void;
     using HDIV  = void;
-    using HVOL  = void;
+    using HVOL  = LegendreBasis_HGRAD_PYR<DeviceType,OutputScalar,PointScalar>;
   };
   
   /** \class Intrepid2::HierarchicalBasisFamily

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HierarchicalBasisFamily.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HierarchicalBasisFamily.hpp
@@ -116,7 +116,7 @@ namespace Intrepid2 {
     using HGRAD = IntegratedLegendreBasis_HGRAD_PYR<DeviceType,OutputScalar,PointScalar,defineVertexFunctions>;
     using HCURL = void;
     using HDIV  = void;
-    using HVOL  = LegendreBasis_HGRAD_PYR<DeviceType,OutputScalar,PointScalar>;
+    using HVOL  = LegendreBasis_HVOL_PYR<DeviceType,OutputScalar,PointScalar>;
   };
   
   /** \class Intrepid2::HierarchicalBasisFamily

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_IntegratedLegendreBasis_HGRAD_PYR.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_IntegratedLegendreBasis_HGRAD_PYR.hpp
@@ -63,134 +63,13 @@
 #include "Intrepid2_IntegratedLegendreBasis_HGRAD_LINE.hpp"
 #include "Intrepid2_IntegratedLegendreBasis_HGRAD_TRI.hpp"
 #include "Intrepid2_Polynomials.hpp"
+#include "Intrepid2_PyramidCoords.hpp"
 #include "Intrepid2_Utils.hpp"
 
 #include "Teuchos_RCP.hpp"
 
 namespace Intrepid2
 {
-  /// Compute various affine-like coordinates on the pyramid.  See Fuentes et al, Appendix E.9 for definitions.
-  template<class PointScalar>
-  KOKKOS_INLINE_FUNCTION
-  void affinePyramid(Kokkos::Array<PointScalar,5>                                   &lambda,
-                     Kokkos::Array<Kokkos::Array<PointScalar,3>,5>                  &lambdaGrad,
-                     Kokkos::Array<Kokkos::Array<PointScalar,3>,2>                  &mu,
-                     Kokkos::Array<Kokkos::Array<Kokkos::Array<PointScalar,3>,3>,2> &muGrad,
-                     Kokkos::Array<Kokkos::Array<PointScalar,2>,3>                  &nu,
-                     Kokkos::Array<Kokkos::Array<Kokkos::Array<PointScalar,3>,2>,3> &nuGrad,
-                     Kokkos::Array<PointScalar,3>  &coords)
-  {
-    const auto & x = coords[0];
-    const auto & y = coords[1];
-    const auto & z = coords[2];
-    nu[0][0]  = 1. - x - z; // nu_0^{\zeta,\xi_1}
-    nu[0][1]  = 1. - y - z; // nu_0^{\zeta,\xi_2}
-    nu[1][0]  =      x    ; // nu_1^{\zeta,\xi_1}
-    nu[1][1]  =      y    ; // nu_1^{\zeta,\xi_2}
-    nu[2][0]  =      z    ; // nu_2^{\zeta,\xi_1}
-    nu[2][1]  =      z    ; // nu_2^{\zeta,\xi_2}
-    
-    nuGrad[0][0][0]  = -1. ; // nu_0^{\zeta,\xi_1}_dxi_1
-    nuGrad[0][0][1]  =  0. ; // nu_0^{\zeta,\xi_1}_dxi_2
-    nuGrad[0][0][2]  = -1. ; // nu_0^{\zeta,\xi_1}_dzeta
-    
-    nuGrad[0][1][0]  =  0. ; // nu_0^{\zeta,\xi_2}_dxi_1
-    nuGrad[0][1][1]  = -1. ; // nu_0^{\zeta,\xi_2}_dxi_2
-    nuGrad[0][1][2]  = -1. ; // nu_0^{\zeta,\xi_2}_dzeta
-    
-    nuGrad[1][0][0]  =  1. ; // nu_1^{\zeta,\xi_1}_dxi_1
-    nuGrad[1][0][1]  =  0. ; // nu_1^{\zeta,\xi_1}_dxi_2
-    nuGrad[1][0][2]  =  0. ; // nu_1^{\zeta,\xi_1}_dzeta
-    
-    nuGrad[1][1][0]  =  0. ; // nu_1^{\zeta,\xi_2}_dxi_1
-    nuGrad[1][1][1]  =  1. ; // nu_1^{\zeta,\xi_2}_dxi_2
-    nuGrad[1][1][2]  =  0. ; // nu_1^{\zeta,\xi_2}_dzeta
-    
-    nuGrad[2][0][0]  =  0. ; // nu_2^{\zeta,\xi_1}_dxi_1
-    nuGrad[2][0][1]  =  0. ; // nu_2^{\zeta,\xi_1}_dxi_2
-    nuGrad[2][0][2]  =  1. ; // nu_2^{\zeta,\xi_1}_dzeta
-    
-    nuGrad[2][1][0]  =  0. ; // nu_2^{\zeta,\xi_2}_dxi_1
-    nuGrad[2][1][1]  =  0. ; // nu_2^{\zeta,\xi_2}_dxi_2
-    nuGrad[2][1][2]  =  1. ; // nu_2^{\zeta,\xi_2}_dzeta
-    
-    // (1 - z) goes in denominator -- so we check for 1-z=0
-    auto & muZ_0 = mu[0][2];
-    auto & muZ_1 = mu[1][2];
-    const double epsilon = 1e-12;
-    muZ_0 = (fabs(1.-z) > epsilon) ? 1. - z :      epsilon;
-    muZ_1 = (fabs(1.-z) > epsilon) ?      z : 1. - epsilon;
-    PointScalar scaling = 1. / muZ_0;
-    mu[0][0]  = 1. - x * scaling;
-    mu[0][1]  = 1. - y * scaling;
-    mu[1][0]  =      x * scaling;
-    mu[1][1]  =      y * scaling;
-    
-    PointScalar scaling2 = scaling * scaling;
-    muGrad[0][0][0]  =  -scaling     ;
-    muGrad[0][0][1]  =     0.        ;
-    muGrad[0][0][2]  = - x * scaling2;
-    
-    muGrad[0][1][0]  =     0.       ;
-    muGrad[0][1][1]  =  -scaling    ;
-    muGrad[0][1][2]  = -y * scaling2;
-    
-    muGrad[0][2][0]  =     0.   ;
-    muGrad[0][2][1]  =     0.   ;
-    muGrad[0][2][2]  =    -1.   ;
-    
-    muGrad[1][0][0]  =  scaling     ;
-    muGrad[1][0][1]  =     0.       ;
-    muGrad[1][0][2]  =  x * scaling2;
-    
-    muGrad[1][1][0]  =     0.       ;
-    muGrad[1][1][1]  =   scaling    ;
-    muGrad[1][1][2]  =  y * scaling2;
-    
-    muGrad[1][2][0]  =     0.   ;
-    muGrad[1][2][1]  =     0.   ;
-    muGrad[1][2][2]  =     1.   ;
-    
-    lambda[0] = nu[0][0] * mu[0][1];
-    lambda[1] = nu[0][1] * mu[1][0];
-    lambda[2] = nu[1][0] * mu[1][1];
-    lambda[3] = nu[1][1] * mu[0][0];
-    lambda[4] = z;
-    
-    for (int d=0; d<3; d++)
-    {
-      lambdaGrad[0][d] = nu[0][0] * muGrad[0][1][d] + nuGrad[0][0][d] * mu[0][1];
-      lambdaGrad[1][d] = nu[0][1] * muGrad[1][0][d] + nuGrad[0][1][d] * mu[1][0];
-      lambdaGrad[2][d] = nu[1][0] * muGrad[1][1][d] + nuGrad[1][0][d] * mu[1][1];
-      lambdaGrad[3][d] = nu[1][1] * muGrad[0][0][d] + nuGrad[1][1][d] * mu[0][0];
-    }
-    lambdaGrad[4][0] = 0;
-    lambdaGrad[4][1] = 0;
-    lambdaGrad[4][2] = 1;
-  }
-
-  /// Transforms from the Intrepid2 pyramid, centered at the origin with base [-1,1]^2 and height 1, to ESEAS pyramid, with base [0,1]^2, height 1, with its top vertex at (0,0,1).
-  template<class PointScalar>
-  KOKKOS_INLINE_FUNCTION
-  void transformToESEASPyramid(      PointScalar &x_eseas,       PointScalar &y_eseas,       PointScalar &z_eseas,
-                               const PointScalar &x_int2,  const PointScalar &y_int2,  const PointScalar &z_int2)
-  {
-    x_eseas = (x_int2 + 1. - z_int2) / 2.;
-    y_eseas = (y_int2 + 1. - z_int2) / 2.;
-    z_eseas = z_int2;
-  }
-
-  /// Transforms gradients computed on the ESEAS pyramid to gradients on the Intrepid2 pyramid.
-  template<class OutputScalar>
-  KOKKOS_INLINE_FUNCTION
-  void transformFromESEASPyramidGradient(      OutputScalar &dx_int2,        OutputScalar &dy_int2,        OutputScalar &dz_int2,
-                                         const OutputScalar &dx_eseas, const OutputScalar &dy_eseas, const OutputScalar &dz_eseas)
-  {
-    dx_int2 = dx_eseas / 2.;
-    dy_int2 = dy_eseas / 2.;
-    dz_int2 = dz_eseas - dx_int2 - dy_int2;
-  }
-
   /** \class  Intrepid2::Hierarchical_HGRAD_PYR_Functor
       \brief  Functor for computing values for the IntegratedLegendreBasis_HGRAD_PYR class.
    
@@ -842,11 +721,11 @@ namespace Intrepid2
     /** \brief  Constructor.
         \param [in] polyOrder - the polynomial order of the basis.
      
-     The basis will have polyOrder + 1 members.
+     The basis will have polyOrder^3 + 3 * polyOrder + 1 members.
      
-     If defineVertexFunctions is false, then all basis functions are identified with the interior of the line element, and the first four basis functions are 1, x, y, and z.
+     If defineVertexFunctions is false, then all basis functions are identified with the interior of the element, and the first basis function is 1.
      
-     If defineVertexFunctions is true, then the first two basis functions are 1-x-y-z, x, y, and z, and these are identified with the left and right vertices of the cell.
+     If defineVertexFunctions is true, then the first basis functions are nodal functions of the vertices of the cell.
      
      */
     IntegratedLegendreBasis_HGRAD_PYR(int polyOrder, const EPointType pointType=POINTTYPE_DEFAULT)
@@ -863,8 +742,8 @@ namespace Intrepid2
       this->functionSpace_     = FUNCTION_SPACE_HGRAD;
       
       const int degreeLength = 1;
-      this->fieldOrdinalPolynomialDegree_ = OrdinalTypeArray2DHost("Integrated Legendre H(grad) tetrahedron polynomial degree lookup", this->basisCardinality_, degreeLength);
-      this->fieldOrdinalH1PolynomialDegree_ = OrdinalTypeArray2DHost("Integrated Legendre H(grad) tetrahedron polynomial H^1 degree lookup", this->basisCardinality_, degreeLength);
+      this->fieldOrdinalPolynomialDegree_ = OrdinalTypeArray2DHost("Integrated Legendre H(grad) pyramid polynomial degree lookup", this->basisCardinality_, degreeLength);
+      this->fieldOrdinalH1PolynomialDegree_ = OrdinalTypeArray2DHost("Integrated Legendre H(grad) pyramid polynomial H^1 degree lookup", this->basisCardinality_, degreeLength);
       
       int fieldOrdinalOffset = 0;
       // **** vertex functions **** //

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_IntegratedLegendreBasis_HGRAD_PYR.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_IntegratedLegendreBasis_HGRAD_PYR.hpp
@@ -1028,7 +1028,7 @@ namespace Intrepid2
       }
       else if (subCellDim == 2)
       {
-        if (subCellOrd == 0) // quad basis
+        if (subCellOrd == 4) // quad basis
         {
           return Teuchos::rcp(new HGRAD_QUAD(p));
         }

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_LegendreBasis_HVOL_PYR.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_LegendreBasis_HVOL_PYR.hpp
@@ -123,9 +123,9 @@ namespace Intrepid2
       numFields_ = output.extent_int(0);
       numPoints_ = output.extent_int(1);
       const auto & p = polyOrder;
-      const auto p3  = p * p * p;
+      const auto p_plus_one_cubed = (p+1) * (p+1) * (p+1);
       INTREPID2_TEST_FOR_EXCEPTION(numPoints_ != inputPoints.extent_int(0), std::invalid_argument, "point counts need to match!");
-      INTREPID2_TEST_FOR_EXCEPTION(numFields_ != p3 + 3 * p + 1, std::invalid_argument, "output field size does not match basis cardinality");
+      INTREPID2_TEST_FOR_EXCEPTION(numFields_ != p_plus_one_cubed, std::invalid_argument, "output field size does not match basis cardinality");
     }
     
     KOKKOS_INLINE_FUNCTION
@@ -320,7 +320,7 @@ namespace Intrepid2
     pointType_(pointType)
     {
       INTREPID2_TEST_FOR_EXCEPTION(pointType!=POINTTYPE_DEFAULT,std::invalid_argument,"PointType not supported");
-      this->basisCardinality_  = polyOrder * polyOrder * polyOrder + 3 * polyOrder + 1;
+      this->basisCardinality_  = (polyOrder + 1) * (polyOrder + 1) * (polyOrder + 1);
       this->basisDegree_       = polyOrder;
       this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Pyramid<> >() );
       this->basisType_         = BASIS_FEM_HIERARCHICAL;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_LegendreBasis_HVOL_PYR.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_LegendreBasis_HVOL_PYR.hpp
@@ -1,0 +1,478 @@
+// @HEADER
+// ************************************************************************
+//
+//                           Intrepid2 Package
+//                 Copyright (2007) Sandia Corporation
+//
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Mauro Perego  (mperego@sandia.gov) or
+//                    Nate Roberts  (nvrober@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+
+/** \file   Intrepid2_LegendreBasis_HVOL_PYR.hpp
+    \brief  H(vol) basis on the pyramid based on Legendre polynomials.
+    \author Created by N.V. Roberts.
+ 
+ Note that although this basis is derived from Legendre polynomials, it is not itself a polynomial basis, but a set of rational functions.
+ 
+ The construction is also hierarchical, in the sense that the basis for p-1 is included in the basis for p.
+ 
+ Intrepid2 has a pre-existing lowest-order HGRAD basis defined on the pyramid, found in Intrepid2_HGRAD_PYR_C1_FEM.hpp; this agrees precisely with this basis when p=1.
+ */
+
+#ifndef Intrepid2_LegendreBasis_HVOL_PYR_h
+#define Intrepid2_LegendreBasis_HVOL_PYR_h
+
+#include <Kokkos_DynRankView.hpp>
+
+#include <Intrepid2_config.h>
+
+#include "Intrepid2_Basis.hpp"
+#include "Intrepid2_Polynomials.hpp"
+#include "Intrepid2_PyramidCoords.hpp"
+#include "Intrepid2_Utils.hpp"
+
+#include "Teuchos_RCP.hpp"
+
+namespace Intrepid2
+{
+  /** \class  Intrepid2::Hierarchical_HVOL_PYR_Functor
+      \brief  Functor for computing values for the LegendreBasis_HVOL_PYR class.
+   
+   This functor is not intended for use outside of LegendreBasis_HVOL_PYR.
+  */
+  template<class DeviceType, class OutputScalar, class PointScalar,
+           class OutputFieldType, class InputPointsType>
+  struct Hierarchical_HVOL_PYR_Functor
+  {
+    using ExecutionSpace     = typename DeviceType::execution_space;
+    using ScratchSpace        = typename ExecutionSpace::scratch_memory_space;
+    using OutputScratchView   = Kokkos::View<OutputScalar*,ScratchSpace,Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+    using OutputScratchView2D = Kokkos::View<OutputScalar**,ScratchSpace,Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+    using PointScratchView    = Kokkos::View<PointScalar*, ScratchSpace,Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+    
+    using TeamPolicy = Kokkos::TeamPolicy<ExecutionSpace>;
+    using TeamMember = typename TeamPolicy::member_type;
+    
+    EOperator opType_;
+    
+    OutputFieldType  output_;      // F,P
+    InputPointsType  inputPoints_; // P,D
+    
+    int polyOrder_;
+    int numFields_, numPoints_;
+    
+    size_t fad_size_output_;
+    
+    static const int numVertices   = 5;
+    static const int numMixedEdges = 4;
+    static const int numTriEdges   = 4;
+    static const int numEdges      = 8;
+    // the following ordering of the edges matches that used by ESEAS
+    // (it *looks* like this is what ESEAS uses; the basis comparison tests will clarify whether I've read their code correctly)
+    // see also PyramidEdgeNodeMap in Shards_BasicTopologies.hpp
+    const int edge_start_[numEdges] = {0,1,2,3,0,1,2,3}; // edge i is from edge_start_[i] to edge_end_[i]
+    const int edge_end_[numEdges]   = {1,2,3,0,4,4,4,4}; // edge i is from edge_start_[i] to edge_end_[i]
+    
+    // quadrilateral face comes first
+    static const int numQuadFaces = 1;
+    static const int numTriFaces  = 4;
+    
+    // face ordering matches ESEAS.  (See BlendProjectPyraTF in ESEAS.)
+    const int tri_face_vertex_0[numTriFaces] = {0,1,3,0}; // faces are abc where 0 ≤ a < b < c ≤ 3
+    const int tri_face_vertex_1[numTriFaces] = {1,2,2,3};
+    const int tri_face_vertex_2[numTriFaces] = {4,4,4,4};
+    
+    Hierarchical_HVOL_PYR_Functor(EOperator opType, OutputFieldType output, InputPointsType inputPoints,
+                                   int polyOrder)
+    : opType_(opType), output_(output), inputPoints_(inputPoints),
+      polyOrder_(polyOrder),
+      fad_size_output_(getScalarDimensionForView(output))
+    {
+      numFields_ = output.extent_int(0);
+      numPoints_ = output.extent_int(1);
+      const auto & p = polyOrder;
+      const auto p3  = p * p * p;
+      INTREPID2_TEST_FOR_EXCEPTION(numPoints_ != inputPoints.extent_int(0), std::invalid_argument, "point counts need to match!");
+      INTREPID2_TEST_FOR_EXCEPTION(numFields_ != p3 + 3 * p + 1, std::invalid_argument, "output field size does not match basis cardinality");
+    }
+    
+    KOKKOS_INLINE_FUNCTION
+    void operator()( const TeamMember & teamMember ) const
+    {
+      auto pointOrdinal = teamMember.league_rank();
+      OutputScratchView scratch1D_1, scratch1D_2, scratch1D_3;
+      OutputScratchView scratch1D_4, scratch1D_5, scratch1D_6;
+      OutputScratchView scratch1D_7, scratch1D_8, scratch1D_9;
+      OutputScratchView2D scratch2D_1, scratch2D_2, scratch2D_3;
+      const int numAlphaValues = (polyOrder_-1 > 1) ? (polyOrder_-1) : 1; // make numAlphaValues at least 1 so we can avoid zero-extent allocations…
+      if (fad_size_output_ > 0) {
+        scratch1D_1 = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1, fad_size_output_);
+        scratch1D_2 = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1, fad_size_output_);
+        scratch1D_3 = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1, fad_size_output_);
+        scratch1D_4 = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1, fad_size_output_);
+        scratch1D_5 = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1, fad_size_output_);
+        scratch1D_6 = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1, fad_size_output_);
+        scratch1D_7 = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1, fad_size_output_);
+        scratch1D_8 = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1, fad_size_output_);
+        scratch1D_9 = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1, fad_size_output_);
+        scratch2D_1 = OutputScratchView2D(teamMember.team_shmem(), numAlphaValues, polyOrder_ + 1, fad_size_output_);
+        scratch2D_2 = OutputScratchView2D(teamMember.team_shmem(), numAlphaValues, polyOrder_ + 1, fad_size_output_);
+        scratch2D_3 = OutputScratchView2D(teamMember.team_shmem(), numAlphaValues, polyOrder_ + 1, fad_size_output_);
+      }
+      else {
+        scratch1D_1 = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1);
+        scratch1D_2 = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1);
+        scratch1D_3 = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1);
+        scratch1D_4 = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1);
+        scratch1D_5 = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1);
+        scratch1D_6 = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1);
+        scratch1D_7 = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1);
+        scratch1D_8 = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1);
+        scratch1D_9 = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1);
+        scratch2D_1 = OutputScratchView2D(teamMember.team_shmem(), numAlphaValues, polyOrder_ + 1);
+        scratch2D_2 = OutputScratchView2D(teamMember.team_shmem(), numAlphaValues, polyOrder_ + 1);
+        scratch2D_3 = OutputScratchView2D(teamMember.team_shmem(), numAlphaValues, polyOrder_ + 1);
+      }
+      
+      const auto & x = inputPoints_(pointOrdinal,0);
+      const auto & y = inputPoints_(pointOrdinal,1);
+      const auto & z = inputPoints_(pointOrdinal,2);
+      
+      // Intrepid2 uses (-1,1)^2 for x,y
+      // ESEAS uses (0,1)^2
+      // (Can look at what we do on the HGRAD_LINE for reference; there's a similar difference for line topology.)
+      
+      Kokkos::Array<PointScalar,3> coords;
+      transformToESEASPyramid<>(coords[0], coords[1], coords[2], x, y, z); // map x,y coordinates from (-z,z)^2 to (0,z)^2
+      
+      // pyramid "affine" coordinates and gradients get stored in lambda, lambdaGrad:
+      using Kokkos::Array;
+      Array<PointScalar,5> lambda;
+      Array<Kokkos::Array<PointScalar,3>,5> lambdaGrad;
+      
+      Array<Array<PointScalar,3>,2> mu; // first index is subscript; second is superscript: 0 --> (\zeta, xi_1), 1 --> (\zeta, xi_2), 2 --> (\zeta)
+      Array<Array<Array<PointScalar,3>,3>,2> muGrad;
+      
+      Array<Array<PointScalar,2>,3> nu;
+      Array<Array<Array<PointScalar,3>,2>,3> nuGrad;
+      
+      affinePyramid(lambda, lambdaGrad, mu, muGrad, nu, nuGrad, coords);
+      
+      switch (opType_)
+      {
+        case OPERATOR_VALUE:
+        {
+          // interior functions
+          // rename scratch
+          ordinal_type fieldOrdinalOffset = 0;
+          auto & Pi = scratch1D_1;
+          auto & Pj = scratch1D_2;
+          auto & Pk = scratch1D_3;
+          // [P_i](mu_01^{\zeta,\xi_1})
+          Polynomials::shiftedScaledLegendreValues(Pi, polyOrder_, mu[1][0], mu[0][0] + mu[1][0]);
+          // [P_j](mu_01^{\zeta,\xi_2})
+          Polynomials::shiftedScaledLegendreValues(Pj, polyOrder_, mu[1][1], mu[0][1] + mu[1][1]);
+          // [P_k](mu_01^{\zeta})
+          Polynomials::shiftedScaledLegendreValues(Pk, polyOrder_, mu[1][2], mu[0][2] + mu[1][2]);
+          // (grad nu_1^{\zeta,\xi_1} x grad nu_1^{\zeta,\xi_2}) \cdot grad mu_1^zeta:
+          PointScalar grad_weight =
+            (nuGrad[1][0][1] * nuGrad[1][1][2] - nuGrad[1][0][2] * nuGrad[1][1][1]) * muGrad[1][2][0]
+          + (nuGrad[1][0][2] * nuGrad[1][1][0] - nuGrad[1][0][0] * nuGrad[1][1][2]) * muGrad[1][2][1]
+          + (nuGrad[1][0][0] * nuGrad[1][1][1] - nuGrad[1][0][1] * nuGrad[1][1][0]) * muGrad[1][2][2];
+          
+          // following the ESEAS ordering: k increments first
+          for (int k=0; k<=polyOrder_; k++)
+          {
+            for (int j=0; j<=polyOrder_; j++)
+            {
+              for (int i=0; i<=polyOrder_; i++)
+              {
+                output_(fieldOrdinalOffset,pointOrdinal) = Pk(k) * Pi(i) * Pj(j) * grad_weight;
+                fieldOrdinalOffset++;
+              }
+            }
+          }
+        } // end OPERATOR_VALUE
+          break;
+        case OPERATOR_GRAD:
+        case OPERATOR_D1:
+        case OPERATOR_D2:
+        case OPERATOR_D3:
+        case OPERATOR_D4:
+        case OPERATOR_D5:
+        case OPERATOR_D6:
+        case OPERATOR_D7:
+        case OPERATOR_D8:
+        case OPERATOR_D9:
+        case OPERATOR_D10:
+          INTREPID2_TEST_FOR_ABORT( true,
+                                   ">>> ERROR: (Intrepid2::Hierarchical_HVOL_PYR_Functor) Computing of derivatives is not supported");
+        default:
+          // unsupported operator type
+          device_assert(false);
+      }
+    }
+    
+    // Provide the shared memory capacity.
+    // This function takes the team_size as an argument,
+    // which allows team_size-dependent allocations.
+    size_t team_shmem_size (int team_size) const
+    {
+      // we use shared memory to create a fast buffer for basis computations
+      // for the (integrated) Legendre computations, we just need p+1 values stored.  For interior functions on the pyramid, we have up to 3 scratch arrays with (integrated) Legendre values stored, for each of the 3 directions (i,j,k indices): a total of 9.
+      // for the (integrated) Jacobi computations, though, we want (p+1)*(# alpha values)
+      // alpha is either 2i or 2(i+j), where i=2,…,p or i+j=3,…,p.  So there are at most (p-1) alpha values needed.
+      // We can have up to 3 of the (integrated) Jacobi values needed at once.
+      const int numAlphaValues = std::max(polyOrder_-1, 1); // make it at least 1 so we can avoid zero-extent ranks…
+      size_t shmem_size = 0;
+      if (fad_size_output_ > 0)
+      {
+        // Legendre:
+        shmem_size += 9 * OutputScratchView::shmem_size(polyOrder_ + 1, fad_size_output_);
+        // Jacobi:
+        shmem_size += 3 * OutputScratchView2D::shmem_size(numAlphaValues, polyOrder_ + 1, fad_size_output_);
+      }
+      else
+      {
+        // Legendre:
+        shmem_size += 9 * OutputScratchView::shmem_size(polyOrder_ + 1);
+        // Jacobi:
+        shmem_size += 3 * OutputScratchView2D::shmem_size(numAlphaValues, polyOrder_ + 1);
+      }
+      
+      return shmem_size;
+    }
+  };
+  
+  /** \class  Intrepid2::LegendreBasis_HVOL_PYR
+      \brief  Basis defining integrated Legendre basis on the line, a polynomial subspace of H(grad) on the line.
+
+              This is used in the construction of hierarchical bases on higher-dimensional topologies.  For
+              mathematical details of the construction, see:
+   
+               Federico Fuentes, Brendan Keith, Leszek Demkowicz, Sriram Nagaraj.
+               "Orientation embedded high order shape functions for the exact sequence elements of all shapes."
+               Computers & Mathematics with Applications, Volume 70, Issue 4, 2015, Pages 353-458, ISSN 0898-1221.
+               https://doi.org/10.1016/j.camwa.2015.04.027.
+  */
+  template<typename DeviceType,
+           typename OutputScalar = double,
+           typename PointScalar  = double>
+  class LegendreBasis_HVOL_PYR
+  : public Basis<DeviceType,OutputScalar,PointScalar>
+  {
+  public:
+    using BasisBase = Basis<DeviceType,OutputScalar,PointScalar>;
+
+    using typename BasisBase::OrdinalTypeArray1DHost;
+    using typename BasisBase::OrdinalTypeArray2DHost;
+
+    using typename BasisBase::OutputViewType;
+    using typename BasisBase::PointViewType;
+    using typename BasisBase::ScalarViewType;
+
+    using typename BasisBase::ExecutionSpace;
+
+  protected:
+    int polyOrder_; // the maximum order of the polynomial
+    EPointType pointType_;
+  public:
+    /** \brief  Constructor.
+        \param [in] polyOrder - the polynomial order of the basis.
+     
+     The basis will have polyOrder^3 + 3 * polyOrder + 1 members.
+     */
+    LegendreBasis_HVOL_PYR(int polyOrder, const EPointType pointType=POINTTYPE_DEFAULT)
+    :
+    polyOrder_(polyOrder),
+    pointType_(pointType)
+    {
+      INTREPID2_TEST_FOR_EXCEPTION(pointType!=POINTTYPE_DEFAULT,std::invalid_argument,"PointType not supported");
+      this->basisCardinality_  = polyOrder * polyOrder * polyOrder + 3 * polyOrder + 1;
+      this->basisDegree_       = polyOrder;
+      this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Pyramid<> >() );
+      this->basisType_         = BASIS_FEM_HIERARCHICAL;
+      this->basisCoordinates_  = COORDINATES_CARTESIAN;
+      this->functionSpace_     = FUNCTION_SPACE_HVOL;
+      
+      const int degreeLength = 1;
+      this->fieldOrdinalPolynomialDegree_ = OrdinalTypeArray2DHost("Legendre H(vol) pyramid polynomial degree lookup", this->basisCardinality_, degreeLength);
+      this->fieldOrdinalH1PolynomialDegree_ = OrdinalTypeArray2DHost("Legendre H(vol) pyramid polynomial H^1 degree lookup", this->basisCardinality_, degreeLength);
+      
+      int fieldOrdinalOffset = 0;
+      
+      // **** interior functions **** //
+      const int numFunctionsPerVolume = (polyOrder-1)*(polyOrder-1)*(polyOrder-1);
+      const int numVolumes = 1; // interior
+      for (int volumeOrdinal=0; volumeOrdinal<numVolumes; volumeOrdinal++)
+      {
+        // following the ESEAS ordering: k increments first
+        for (int k=0; k<=polyOrder_; k++)
+        {
+          for (int j=0; j<=polyOrder_; j++)
+          {
+            for (int i=0; i<=polyOrder_; i++)
+            {
+              const int max_ij  = std::max(i,j);
+              const int max_ijk = std::max(max_ij,k);
+              this->fieldOrdinalPolynomialDegree_  (fieldOrdinalOffset,0) = max_ijk;     // L^2 degree
+              this->fieldOrdinalH1PolynomialDegree_(fieldOrdinalOffset,0) = max_ijk + 1; // H^1 degree
+              fieldOrdinalOffset++;
+            }
+          }
+        }
+      }
+      
+      INTREPID2_TEST_FOR_EXCEPTION(fieldOrdinalOffset != this->basisCardinality_, std::invalid_argument, "Internal error: basis enumeration is incorrect");
+      
+      // initialize tags
+      {
+        const auto & cardinality = this->basisCardinality_;
+        
+        // Basis-dependent initializations
+        const ordinal_type tagSize  = 4; // size of DoF tag, i.e., number of fields in the tag
+        const ordinal_type posScDim = 0; // position in the tag, counting from 0, of the subcell dim
+        const ordinal_type posScOrd = 1; // position in the tag, counting from 0, of the subcell ordinal
+        const ordinal_type posDfOrd = 2; // position in the tag, counting from 0, of DoF ordinal relative to the subcell
+        
+        OrdinalTypeArray1DHost tagView("tag view", cardinality*tagSize);
+        const int vertexDim = 0, edgeDim = 1, faceDim = 2, volumeDim = 3;
+
+        for (ordinal_type i=0;i<cardinality;++i) {
+          tagView(i*tagSize+0) = volumeDim;   // volume dimension
+          tagView(i*tagSize+1) = 0;           // volume ordinal
+          tagView(i*tagSize+2) = i;           // local dof id
+          tagView(i*tagSize+3) = cardinality; // total number of dofs on this volume
+        }
+        
+        // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
+        // tags are constructed on host
+        this->setOrdinalTagData(this->tagToOrdinal_,
+                                this->ordinalToTag_,
+                                tagView,
+                                this->basisCardinality_,
+                                tagSize,
+                                posScDim,
+                                posScOrd,
+                                posDfOrd);
+      }
+    }
+    
+    /** \brief  Returns basis name
+     
+     \return the name of the basis
+     */
+    const char* getName() const override {
+      return "Intrepid2_LegendreBasis_HVOL_PYR";
+    }
+    
+    /** \brief True if orientation is required
+    */
+    virtual bool requireOrientation() const override {
+      return false;
+    }
+
+    // since the getValues() below only overrides the FEM variant, we specify that
+    // we use the base class's getValues(), which implements the FVD variant by throwing an exception.
+    // (It's an error to use the FVD variant on this basis.)
+    using BasisBase::getValues;
+    
+    /** \brief  Evaluation of a FEM basis on a <strong>reference cell</strong>.
+
+        Returns values of <var>operatorType</var> acting on FEM basis functions for a set of
+        points in the <strong>reference cell</strong> for which the basis is defined.
+
+        \param  outputValues      [out] - variable rank array with the basis values
+        \param  inputPoints       [in]  - rank-2 array (P,D) with the evaluation points
+        \param  operatorType      [in]  - the operator acting on the basis functions
+
+        \remark For rank and dimension specifications of the output array see Section
+        \ref basis_md_array_sec.  Dimensions of <var>ArrayScalar</var> arguments are checked
+        at runtime if HAVE_INTREPID2_DEBUG is defined.
+
+        \remark A FEM basis spans a COMPLETE or INCOMPLETE polynomial space on the reference cell
+        which is a smooth function space. Thus, all operator types that are meaningful for the
+        approximated function space are admissible. When the order of the operator exceeds the
+        degree of the basis, the output array is filled with the appropriate number of zeros.
+    */
+    virtual void getValues( OutputViewType outputValues, const PointViewType  inputPoints,
+                           const EOperator operatorType = OPERATOR_VALUE ) const override
+    {
+      auto numPoints = inputPoints.extent_int(0);
+      
+      using FunctorType = Hierarchical_HVOL_PYR_Functor<DeviceType, OutputScalar, PointScalar, OutputViewType, PointViewType>;
+      
+      FunctorType functor(operatorType, outputValues, inputPoints, polyOrder_);
+      
+      const int outputVectorSize = getVectorSizeForHierarchicalParallelism<OutputScalar>();
+      const int pointVectorSize  = getVectorSizeForHierarchicalParallelism<PointScalar>();
+      const int vectorSize = std::max(outputVectorSize,pointVectorSize);
+      const int teamSize = 1; // because of the way the basis functions are computed, we don't have a second level of parallelism...
+
+      auto policy = Kokkos::TeamPolicy<ExecutionSpace>(numPoints,teamSize,vectorSize);
+      Kokkos::parallel_for("Hierarchical_HVOL_PYR_Functor", policy, functor);
+    }
+
+    /** \brief returns the basis associated to a subCell.
+
+        The bases of the subCell are the restriction to the subCell
+        of the bases of the parent cell.
+        \param [in] subCellDim - dimension of subCell
+        \param [in] subCellOrd - position of the subCell among of the subCells having the same dimension
+        \return pointer to the subCell basis of dimension subCellDim and position subCellOrd
+     */
+    BasisPtr<DeviceType,OutputScalar,PointScalar>
+    getSubCellRefBasis(const ordinal_type subCellDim, const ordinal_type subCellOrd) const override{
+      // no subcell ref basis for HVOL
+      INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
+    }
+
+    /** \brief Creates and returns a Basis object whose DeviceType template argument is Kokkos::HostSpace::device_type, but is otherwise identical to this.
+     
+        \return Pointer to the new Basis object.
+     */
+    virtual BasisPtr<typename Kokkos::HostSpace::device_type, OutputScalar, PointScalar>
+    getHostBasis() const override {
+      using HostDeviceType = typename Kokkos::HostSpace::device_type;
+      using HostBasisType  = LegendreBasis_HVOL_PYR<HostDeviceType, OutputScalar, PointScalar>;
+      return Teuchos::rcp( new HostBasisType(polyOrder_, pointType_) );
+    }
+  };
+} // end namespace Intrepid2
+
+// do ETI with default (double) type
+extern template class Intrepid2::LegendreBasis_HVOL_PYR<Kokkos::DefaultExecutionSpace::device_type,double,double>;
+
+#endif /* Intrepid2_LegendreBasis_HVOL_PYR_h */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_LegendreBasis_HVOL_PYR.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_LegendreBasis_HVOL_PYR.hpp
@@ -334,7 +334,6 @@ namespace Intrepid2
       int fieldOrdinalOffset = 0;
       
       // **** interior functions **** //
-      const int numFunctionsPerVolume = (polyOrder-1)*(polyOrder-1)*(polyOrder-1);
       const int numVolumes = 1; // interior
       for (int volumeOrdinal=0; volumeOrdinal<numVolumes; volumeOrdinal++)
       {
@@ -368,7 +367,7 @@ namespace Intrepid2
         const ordinal_type posDfOrd = 2; // position in the tag, counting from 0, of DoF ordinal relative to the subcell
         
         OrdinalTypeArray1DHost tagView("tag view", cardinality*tagSize);
-        const int vertexDim = 0, edgeDim = 1, faceDim = 2, volumeDim = 3;
+        const ordinal_type volumeDim = 3;
 
         for (ordinal_type i=0;i<cardinality;++i) {
           tagView(i*tagSize+0) = volumeDim;   // volume dimension

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_LegendreBasis_HVOL_PYR_ETI.cpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_LegendreBasis_HVOL_PYR_ETI.cpp
@@ -1,0 +1,51 @@
+// @HEADER
+// ************************************************************************
+//
+//                           Intrepid2 Package
+//                 Copyright (2007) Sandia Corporation
+//
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Mauro Perego  (mperego@sandia.gov) or
+//                    Nate Roberts  (nvrober@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+
+/** \file   Intrepid2_LegendreBasis_HVOL_PYR.cpp
+    \brief  \brief ETI instantiation for Intrepid2 LegendreBasis_HVOL_PYR class.
+    \author Created by N.V. Roberts.
+ */
+
+#include "Intrepid2_LegendreBasis_HVOL_PYR.hpp"
+
+using DefaultDeviceType = Kokkos::DefaultExecutionSpace::device_type;
+template class Intrepid2::LegendreBasis_HVOL_PYR<Kokkos::DefaultExecutionSpace::device_type,double,double>;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_LegendreBasis_HVOL_TRI.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_LegendreBasis_HVOL_TRI.hpp
@@ -287,7 +287,7 @@ namespace Intrepid2
     /** \brief True if orientation is required
     */
     virtual bool requireOrientation() const override {
-      return (this->getDegree() > 2);
+      return false;
     }
 
     // since the getValues() below only overrides the FEM variant, we specify that
@@ -341,11 +341,7 @@ namespace Intrepid2
      */
     BasisPtr<DeviceType,OutputScalar,PointScalar>
       getSubCellRefBasis(const ordinal_type subCellDim, const ordinal_type subCellOrd) const override{
-      if(subCellDim == 1) {
-        return Teuchos::rcp(new
-            IntegratedLegendreBasis_HGRAD_LINE<DeviceType,OutputScalar,PointScalar>
-                    (this->basisDegree_));
-      }
+      // no subcell ref basis for HVOL
       INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
     }
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_PyramidCoords.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_PyramidCoords.hpp
@@ -1,0 +1,180 @@
+// @HEADER
+// ************************************************************************
+//
+//                           Intrepid2 Package
+//                 Copyright (2007) Sandia Corporation
+//
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Mauro Perego  (mperego@sandia.gov) or
+//                    Nate Roberts  (nvrober@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+
+/** \file   Intrepid2_PyramidCoords.hpp
+    \brief  Defines several coordinates and their gradients on the pyramid; maps from Intrepid2 (shards) pyramid to the ESEAS pyramid and back.
+    \author Created by N.V. Roberts.
+ */
+
+#ifndef Intrepid2_Intrepid2_PyramidCoords_h
+#define Intrepid2_Intrepid2_PyramidCoords_h
+
+#include <Kokkos_DynRankView.hpp>
+
+#include <Intrepid2_config.h>
+
+namespace Intrepid2
+{
+  /// Compute various affine-like coordinates on the pyramid.  See Fuentes et al, Appendix E.9 for definitions.
+  template<class PointScalar>
+  KOKKOS_INLINE_FUNCTION
+  void affinePyramid(Kokkos::Array<PointScalar,5>                                   &lambda,
+                     Kokkos::Array<Kokkos::Array<PointScalar,3>,5>                  &lambdaGrad,
+                     Kokkos::Array<Kokkos::Array<PointScalar,3>,2>                  &mu,
+                     Kokkos::Array<Kokkos::Array<Kokkos::Array<PointScalar,3>,3>,2> &muGrad,
+                     Kokkos::Array<Kokkos::Array<PointScalar,2>,3>                  &nu,
+                     Kokkos::Array<Kokkos::Array<Kokkos::Array<PointScalar,3>,2>,3> &nuGrad,
+                     Kokkos::Array<PointScalar,3>  &coords)
+  {
+    const auto & x = coords[0];
+    const auto & y = coords[1];
+    const auto & z = coords[2];
+    nu[0][0]  = 1. - x - z; // nu_0^{\zeta,\xi_1}
+    nu[0][1]  = 1. - y - z; // nu_0^{\zeta,\xi_2}
+    nu[1][0]  =      x    ; // nu_1^{\zeta,\xi_1}
+    nu[1][1]  =      y    ; // nu_1^{\zeta,\xi_2}
+    nu[2][0]  =      z    ; // nu_2^{\zeta,\xi_1}
+    nu[2][1]  =      z    ; // nu_2^{\zeta,\xi_2}
+    
+    nuGrad[0][0][0]  = -1. ; // nu_0^{\zeta,\xi_1}_dxi_1
+    nuGrad[0][0][1]  =  0. ; // nu_0^{\zeta,\xi_1}_dxi_2
+    nuGrad[0][0][2]  = -1. ; // nu_0^{\zeta,\xi_1}_dzeta
+    
+    nuGrad[0][1][0]  =  0. ; // nu_0^{\zeta,\xi_2}_dxi_1
+    nuGrad[0][1][1]  = -1. ; // nu_0^{\zeta,\xi_2}_dxi_2
+    nuGrad[0][1][2]  = -1. ; // nu_0^{\zeta,\xi_2}_dzeta
+    
+    nuGrad[1][0][0]  =  1. ; // nu_1^{\zeta,\xi_1}_dxi_1
+    nuGrad[1][0][1]  =  0. ; // nu_1^{\zeta,\xi_1}_dxi_2
+    nuGrad[1][0][2]  =  0. ; // nu_1^{\zeta,\xi_1}_dzeta
+    
+    nuGrad[1][1][0]  =  0. ; // nu_1^{\zeta,\xi_2}_dxi_1
+    nuGrad[1][1][1]  =  1. ; // nu_1^{\zeta,\xi_2}_dxi_2
+    nuGrad[1][1][2]  =  0. ; // nu_1^{\zeta,\xi_2}_dzeta
+    
+    nuGrad[2][0][0]  =  0. ; // nu_2^{\zeta,\xi_1}_dxi_1
+    nuGrad[2][0][1]  =  0. ; // nu_2^{\zeta,\xi_1}_dxi_2
+    nuGrad[2][0][2]  =  1. ; // nu_2^{\zeta,\xi_1}_dzeta
+    
+    nuGrad[2][1][0]  =  0. ; // nu_2^{\zeta,\xi_2}_dxi_1
+    nuGrad[2][1][1]  =  0. ; // nu_2^{\zeta,\xi_2}_dxi_2
+    nuGrad[2][1][2]  =  1. ; // nu_2^{\zeta,\xi_2}_dzeta
+    
+    // (1 - z) goes in denominator -- so we check for 1-z=0
+    auto & muZ_0 = mu[0][2];
+    auto & muZ_1 = mu[1][2];
+    const double epsilon = 1e-12;
+    muZ_0 = (fabs(1.-z) > epsilon) ? 1. - z :      epsilon;
+    muZ_1 = (fabs(1.-z) > epsilon) ?      z : 1. - epsilon;
+    PointScalar scaling = 1. / muZ_0;
+    mu[0][0]  = 1. - x * scaling;
+    mu[0][1]  = 1. - y * scaling;
+    mu[1][0]  =      x * scaling;
+    mu[1][1]  =      y * scaling;
+    
+    PointScalar scaling2 = scaling * scaling;
+    muGrad[0][0][0]  =  -scaling     ;
+    muGrad[0][0][1]  =     0.        ;
+    muGrad[0][0][2]  = - x * scaling2;
+    
+    muGrad[0][1][0]  =     0.       ;
+    muGrad[0][1][1]  =  -scaling    ;
+    muGrad[0][1][2]  = -y * scaling2;
+    
+    muGrad[0][2][0]  =     0.   ;
+    muGrad[0][2][1]  =     0.   ;
+    muGrad[0][2][2]  =    -1.   ;
+    
+    muGrad[1][0][0]  =  scaling     ;
+    muGrad[1][0][1]  =     0.       ;
+    muGrad[1][0][2]  =  x * scaling2;
+    
+    muGrad[1][1][0]  =     0.       ;
+    muGrad[1][1][1]  =   scaling    ;
+    muGrad[1][1][2]  =  y * scaling2;
+    
+    muGrad[1][2][0]  =     0.   ;
+    muGrad[1][2][1]  =     0.   ;
+    muGrad[1][2][2]  =     1.   ;
+    
+    lambda[0] = nu[0][0] * mu[0][1];
+    lambda[1] = nu[0][1] * mu[1][0];
+    lambda[2] = nu[1][0] * mu[1][1];
+    lambda[3] = nu[1][1] * mu[0][0];
+    lambda[4] = z;
+    
+    for (int d=0; d<3; d++)
+    {
+      lambdaGrad[0][d] = nu[0][0] * muGrad[0][1][d] + nuGrad[0][0][d] * mu[0][1];
+      lambdaGrad[1][d] = nu[0][1] * muGrad[1][0][d] + nuGrad[0][1][d] * mu[1][0];
+      lambdaGrad[2][d] = nu[1][0] * muGrad[1][1][d] + nuGrad[1][0][d] * mu[1][1];
+      lambdaGrad[3][d] = nu[1][1] * muGrad[0][0][d] + nuGrad[1][1][d] * mu[0][0];
+    }
+    lambdaGrad[4][0] = 0;
+    lambdaGrad[4][1] = 0;
+    lambdaGrad[4][2] = 1;
+  }
+
+  /// Transforms from the Intrepid2 pyramid, centered at the origin with base [-1,1]^2 and height 1, to ESEAS pyramid, with base [0,1]^2, height 1, with its top vertex at (0,0,1).
+  template<class PointScalar>
+  KOKKOS_INLINE_FUNCTION
+  void transformToESEASPyramid(      PointScalar &x_eseas,       PointScalar &y_eseas,       PointScalar &z_eseas,
+                               const PointScalar &x_int2,  const PointScalar &y_int2,  const PointScalar &z_int2)
+  {
+    x_eseas = (x_int2 + 1. - z_int2) / 2.;
+    y_eseas = (y_int2 + 1. - z_int2) / 2.;
+    z_eseas = z_int2;
+  }
+
+  /// Transforms gradients computed on the ESEAS pyramid to gradients on the Intrepid2 pyramid.
+  template<class OutputScalar>
+  KOKKOS_INLINE_FUNCTION
+  void transformFromESEASPyramidGradient(      OutputScalar &dx_int2,        OutputScalar &dy_int2,        OutputScalar &dz_int2,
+                                         const OutputScalar &dx_eseas, const OutputScalar &dy_eseas, const OutputScalar &dz_eseas)
+  {
+    dx_int2 = dx_eseas / 2.;
+    dy_int2 = dy_eseas / 2.;
+    dz_int2 = dz_eseas - dx_int2 - dy_int2;
+  }
+} // end namespace Intrepid2
+
+#endif /* Intrepid2_Intrepid2_PyramidCoords_h */

--- a/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefCoeffMatrix_HGRAD.hpp
+++ b/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefCoeffMatrix_HGRAD.hpp
@@ -170,7 +170,7 @@ getCoeffMatrix_HGRAD(OutputViewType &output, /// this is device view
   INTREPID2_TEST_FOR_EXCEPTION( latticeSize != ndofSubcell,
       std::logic_error,
       ">>> ERROR (Intrepid::OrientationTools::getCoeffMatrix_HGRAD): " \
-      "Lattice size should be equal to the onber of subcell internal DoFs");
+      "Lattice size should be equal to the number of subcell internal DoFs");
   PointTools::getLattice(refPtsSubcell, subcellTopo, subcellBasis.getDegree(), 1, POINTTYPE_WARPBLEND);
 
   // map the points into the parent, cell accounting for orientation

--- a/packages/intrepid2/unit-test/MonolithicExecutable/BasisCardinalityTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/BasisCardinalityTests.cpp
@@ -591,6 +591,21 @@ namespace
     }
   }
 
+  TEUCHOS_UNIT_TEST( BasisCardinality, Pyramid_HVOL )
+  {
+    using HierarchicalBasis = HierarchicalBasisFamily<DefaultTestDeviceType>::HVOL_PYR;
+    
+    for (ordinal_type p=1; p<10; p++)
+    {
+      // expected cardinality is (p+1)^3
+      const ordinal_type expectedCardinality = (p+1) * (p+1) * (p+1);
+      
+      HierarchicalBasis hierarchicalBasis(p);
+      const ordinal_type actualCardinality = hierarchicalBasis.getCardinality();
+      TEST_EQUALITY(expectedCardinality, actualCardinality);
+    }
+  }
+
   TEUCHOS_UNIT_TEST( BasisCardinality, Serendipity_HDIV_HEX )
   {
     // TODO: finish this test.  (Can we do something templated on the BasisFamily??)

--- a/packages/intrepid2/unit-test/MonolithicExecutable/SubBasisInclusionTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/SubBasisInclusionTests.cpp
@@ -93,21 +93,19 @@ namespace
     bool isLine = cellTopo.getKey() == shards::Line<>::key;
     bool isQuad = cellTopo.getKey() == shards::Quadrilateral<>::key;
     bool isHex  = cellTopo.getKey() == shards::Hexahedron<>::key;
-    bool isTri  = cellTopo.getKey() == shards::Triangle<>::key;
-    bool isTet  = cellTopo.getKey() == shards::Tetrahedron<>::key;
     bool isWedge = cellTopo.getKey() == shards::Wedge<>::key;
     int polyOrderDim = -1; // the number of dimensions of p-anisotropy allowed
     if (isLine || isQuad || isHex)
     {
       polyOrderDim = spaceDim;
     }
-    else if (isTri || isTet)
-    {
-      polyOrderDim = 1;
-    }
     else if (isWedge)
     {
       polyOrderDim = 2; // line x tri
+    }
+    else
+    {
+      polyOrderDim = 1;
     }
     auto subBasisDegreeTestCases = getBasisTestCasesUpToDegree(polyOrderDim, minDegree, polyOrder_x, polyOrder_y, polyOrder_z);
     
@@ -358,15 +356,16 @@ namespace
     shards::CellTopology hexTopo = shards::CellTopology(shards::getCellTopologyData<shards::Hexahedron<> >() );
     runSubBasisTests(hexTopo, out, success);
   }
-  
-  TEUCHOS_UNIT_TEST( SubBasisInclusion, Tetrahedron )
+
+  TEUCHOS_UNIT_TEST( SubBasisInclusion, Pyramid )
   {
-    shards::CellTopology tetTopo = shards::CellTopology(shards::getCellTopologyData<shards::Tetrahedron<> >() );
+    shards::CellTopology pyrTopo = shards::CellTopology(shards::getCellTopologyData<shards::Pyramid<> >() );
+//    runSubBasisTests(pyrTopo, out, success);
     
-    // so far, only HGRAD implemented for hierarchical tetrahedron.  Once we have full exact sequence, we can
+    // so far, only HGRAD, HVOL implemented for hierarchical pyramid.  Once we have full exact sequence, we can
     // switch to calling runSubBasisTests(tetTopo, out, success).
-    std::vector<Intrepid2::EFunctionSpace> functionSpaces = {FUNCTION_SPACE_HGRAD};
-    auto cellTopo = tetTopo;
+    std::vector<Intrepid2::EFunctionSpace> functionSpaces = {FUNCTION_SPACE_HGRAD, FUNCTION_SPACE_HVOL};
+    auto cellTopo = pyrTopo;
     
     const int maxDegree = 5;
     const double tol = TEST_TOLERANCE_TIGHT;
@@ -386,10 +385,16 @@ namespace
       {
         for (int degree=1; degree<=maxDegree; degree++)
         {
-          testSubBasis(cellTopo, fs, tol, out, success, degree, -1, -1,continuousBasis);
+          testSubBasis(cellTopo, fs, tol, out, success, degree, -1, -1, continuousBasis);
         }
       }
     }
+  }
+  
+  TEUCHOS_UNIT_TEST( SubBasisInclusion, Tetrahedron )
+  {
+    shards::CellTopology tetTopo = shards::CellTopology(shards::getCellTopologyData<shards::Tetrahedron<> >() );
+    runSubBasisTests(tetTopo, out, success);
   }
   
   TEUCHOS_UNIT_TEST( SubBasisInclusion, Triangle )

--- a/packages/intrepid2/unit-test/Orientation/CMakeLists.txt
+++ b/packages/intrepid2/unit-test/Orientation/CMakeLists.txt
@@ -17,6 +17,8 @@ LIST(APPEND Intrepid2_TEST_ETI_FILE
   "test_orientation_encoding"
   "test_orientation_HEX"
   "test_orientation_HEX_newBasis"
+  "test_orientation_PYR_QuadFace_newBasis"
+  "test_orientation_PYR_TriFace_newBasis"
   "test_orientation_QUAD"
   "test_orientation_QUAD_newBasis"
   "test_orientation_TET"

--- a/packages/intrepid2/unit-test/Orientation/eti/test_orientation_PYR_QuadFace_newBasis_ETI.in
+++ b/packages/intrepid2/unit-test/Orientation/eti/test_orientation_PYR_QuadFace_newBasis_ETI.in
@@ -1,0 +1,62 @@
+// @HEADER
+// ************************************************************************
+//
+//                           Intrepid2 Package
+//                 Copyright (2007) Sandia Corporation
+//
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Mauro Perego  (mperego@sandia.gov), or
+//                    Nate Roberts  (nvrober@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+
+/** \file test_01.cpp
+    \brief  Test for checking orientation tools for pyramid elements with a shared quadrilateral face.
+    \author Created by Nate Roberts, based on hex tests by Mauro Perego
+*/
+
+#include "Kokkos_Core.hpp"
+
+#include "test_orientation_PYR_QuadFace_newBasis.hpp"
+
+int main(int argc, char *argv[]) {
+
+  const bool verbose = (argc-1) > 0;
+  Kokkos::initialize();
+  
+  const int r_val = Intrepid2::Test::OrientationPyrQuadFaceNewBasis<@ETI_VALUETYPE@,@ETI_DEVICE@>(verbose);
+
+  Kokkos::finalize();
+  return r_val;
+}
+

--- a/packages/intrepid2/unit-test/Orientation/eti/test_orientation_PYR_TriFace_newBasis_ETI.in
+++ b/packages/intrepid2/unit-test/Orientation/eti/test_orientation_PYR_TriFace_newBasis_ETI.in
@@ -1,0 +1,62 @@
+// @HEADER
+// ************************************************************************
+//
+//                           Intrepid2 Package
+//                 Copyright (2007) Sandia Corporation
+//
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Mauro Perego  (mperego@sandia.gov), or
+//                    Nate Roberts  (nvrober@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+
+/** \file test_01.cpp
+    \brief  Test for checking orientation tools for pyramid elements with a shared triangular face.
+    \author Created by Nate Roberts, based on hex tests by Mauro Perego
+*/
+
+#include "Kokkos_Core.hpp"
+
+#include "test_orientation_PYR_TriFace_newBasis.hpp"
+
+int main(int argc, char *argv[]) {
+
+  const bool verbose = (argc-1) > 0;
+  Kokkos::initialize();
+  
+  const int r_val = Intrepid2::Test::OrientationPyrTriFaceNewBasis<@ETI_VALUETYPE@,@ETI_DEVICE@>(verbose);
+
+  Kokkos::finalize();
+  return r_val;
+}
+

--- a/packages/intrepid2/unit-test/Orientation/test_orientation_HEX_newBasis.hpp
+++ b/packages/intrepid2/unit-test/Orientation/test_orientation_HEX_newBasis.hpp
@@ -34,8 +34,8 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Kyungjoo Kim  (kyukim@sandia.gov), or
-//                    Mauro Perego  (mperego@sandia.gov)
+// Questions? Contact Mauro Perego  (mperego@sandia.gov), or
+//                    Nate Roberts  (nvrober@sandia.gov)
 //
 // ************************************************************************
 // @HEADER

--- a/packages/intrepid2/unit-test/Orientation/test_orientation_PYR_QuadFace_newBasis.hpp
+++ b/packages/intrepid2/unit-test/Orientation/test_orientation_PYR_QuadFace_newBasis.hpp
@@ -1,0 +1,778 @@
+// @HEADER
+// ************************************************************************
+//
+//                           Intrepid2 Package
+//                 Copyright (2007) Sandia Corporation
+//
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Mauro Perego  (mperego@sandia.gov), or
+//                    Nate Roberts  (nvrober@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+
+
+/** \file test_orientation_PYR_QuadFace_newBasis.hpp
+    \brief  Test for checking orientation tools for the Hierarchical basis on Pyramids
+
+    The test considers two pyramids in physical space sharing a common quadrilateral face.
+    We permute the global ids of the vertices of the common face.
+    This gives a total of 12 combinations.
+
+    The test considers HGRAD, HCURL and HDIV Hierarchical basis functions, and for each:
+    1. Computes the oriented basis.
+    2. Computes the basis coefficients, separately for each pyramid, for functions belonging to the H-space spanned by the basis.
+    3. Checks that the dofs shared between the two pyramids are equivalent (this ensures that the orientation works correctly)
+    4. Checks that the functions are indeed exactly reproduced
+
+    \author Created by Nate Roberts, based on HEX tests by Mauro Perego.
+ */
+
+#include "Intrepid2_config.h"
+
+#ifdef HAVE_INTREPID2_DEBUG
+#define INTREPID2_TEST_FOR_DEBUG_ABORT_OVERRIDE_TO_CONTINUE
+#endif
+
+#include "Intrepid2_Orientation.hpp"
+#include "Intrepid2_OrientationTools.hpp"
+#include "Intrepid2_PointTools.hpp"
+#include "Intrepid2_CellTools.hpp"
+#include "Intrepid2_FunctionSpaceTools.hpp"
+#include "Intrepid2_TestUtils.hpp"
+
+#include "Intrepid2_HGRAD_PYR_C1_FEM.hpp"
+#include "Intrepid2_HierarchicalBasisFamily.hpp"
+
+#include "Teuchos_oblackholestream.hpp"
+#include "Teuchos_RCP.hpp"
+#include <array>
+#include <set>
+#include <random>
+#include <algorithm>
+
+namespace Intrepid2 {
+
+namespace Test {
+
+#define INTREPID2_TEST_ERROR_EXPECTED( S )              \
+    try {                                                               \
+      ++nthrow;                                                         \
+      S ;                                                               \
+    }                                                                   \
+    catch (std::exception &err) {                                        \
+      ++ncatch;                                                         \
+      *outStream << "Expected Error ----------------------------------------------------------------\n"; \
+      *outStream << err.what() << '\n';                                 \
+      *outStream << "-------------------------------------------------------------------------------" << "\n\n"; \
+    }
+
+template<typename ValueType, typename DeviceType>
+int OrientationPyrQuadFaceNewBasis(const bool verbose) {
+
+  typedef Kokkos::DynRankView<ValueType,DeviceType> DynRankView;
+  typedef Kokkos::DynRankView<ordinal_type,DeviceType> DynRankViewInt;
+#define ConstructWithLabel(obj, ...) obj(#obj, __VA_ARGS__)
+
+  static Teuchos::RCP<std::ostream> outStream;
+  Teuchos::oblackholestream bhs; // outputs nothing
+
+  if (verbose)
+    outStream = Teuchos::rcp(&std::cout, false);
+  else
+    outStream = Teuchos::rcp(&bhs,       false);
+
+  Teuchos::oblackholestream oldFormatState;
+  oldFormatState.copyfmt(std::cout);
+
+  int errorFlag = 0;
+  const ValueType tol = tolerence();
+
+  struct Fun {
+    ValueType
+    KOKKOS_INLINE_FUNCTION
+    operator()(const ValueType& x, const ValueType& y, const ValueType& z) {
+      return (x+1)*(y-2);//*(z+3)*(x + 2*y +5*z+ 1.0/3.0);
+    }
+  };
+
+  struct FunDiv {
+    ValueType
+    KOKKOS_INLINE_FUNCTION
+    operator()(const ValueType& x, const ValueType& y, const ValueType& z, const int comp=0) {
+      ValueType a = 2*x*y+x*x;
+      ValueType f0 = 5+y+x*x+z*z;
+      ValueType f1 = -7-2*z+x+y*y+z*z;
+      ValueType f2 = 0.5+z*z+x*x;
+      //fun = f + a x
+      switch (comp) {
+      case 0:
+        return f0 + a*x;
+      case 1:
+        return f1 + a*y;
+      case 2:
+        return f2 + a*z;
+      default:
+        return 0;
+      }
+    }
+  };
+
+  struct FunCurl {
+    ValueType
+    KOKKOS_INLINE_FUNCTION
+    operator()(const ValueType& x, const ValueType& y, const ValueType& z, const int comp=0) {
+      ValueType a0 = y-7+z*z;
+      ValueType a1 = 2*z-1+z*x;
+      ValueType a2 = z-2+x*x;
+      ValueType f0 = 2+x+z+x*y;
+      ValueType f1 = 3-3*z;
+      ValueType f2 = -5+x;
+      //fun = f + a \times x
+      switch (comp) {
+      case 0:
+        return f0 + (a1*z-a2*y);//2*x+y-z + (x+2*(y+z);
+      case 1:
+        return f1 + (a2*x-a0*z);//y+2*(z+x);
+      case 2:
+        return f2 + (a0*y-a1*x);//z+2*(x+y);
+      default:
+        return 0;
+      }
+    }
+  };
+
+
+  class BasisFunctionsSystem{
+  public:
+    BasisFunctionsSystem(const ordinal_type basisCardinality_, const ordinal_type numRefCoords_, const ordinal_type  dim_) :
+      basisCardinality(basisCardinality_),
+      numRefCoords(numRefCoords_),
+      dim(dim_),
+      work("lapack_work", basisCardinality+dim*numRefCoords, 1) ,
+      cellMassMat("basisMat", dim*numRefCoords,basisCardinality),
+      cellRhsMat("rhsMat",dim*numRefCoords, 1) {
+    };
+
+    std::vector<int> computeBasisCoeffs(DynRankView basisCoeffs, ordinal_type& errorFlag, const DynRankView transformedBasisValuesAtRefCoordsOriented, const DynRankView funAtPhysRefCoords) {
+
+      ordinal_type numCells = basisCoeffs.extent(0);
+      std::vector<int> info(numCells);
+      for(ordinal_type ic=0; ic<numCells; ++ic) {
+        for(ordinal_type i=0; i<numRefCoords; ++i) {
+          if (dim==1) {
+            for(ordinal_type j=0; j<basisCardinality; ++j) {
+              cellMassMat(i,j) = transformedBasisValuesAtRefCoordsOriented(ic,j,i);
+            }
+            cellRhsMat(i,0) = funAtPhysRefCoords(ic,i);
+          } else
+            for (ordinal_type id=0; id<dim; ++id) {
+              for(ordinal_type j=0; j<basisCardinality; ++j) {
+                cellMassMat(i+id*numRefCoords,j) = transformedBasisValuesAtRefCoordsOriented(ic,j,i,id);
+              }
+              cellRhsMat(i+id*numRefCoords,0) = funAtPhysRefCoords(ic,i,id);
+            }
+        }
+
+        lapack.GELS('N', dim*numRefCoords, basisCardinality,1,
+            cellMassMat.data(),
+            cellMassMat.stride_1(),
+            cellRhsMat.data(),
+            cellRhsMat.stride_1(),
+            work.data(),
+            basisCardinality+dim*numRefCoords,
+            &info[ic]);
+
+        for(ordinal_type i=0; i<basisCardinality; ++i){
+          basisCoeffs(ic,i) = cellRhsMat(i,0);
+        }
+      }
+      return info;
+    }
+  private:
+    Teuchos::LAPACK<ordinal_type,ValueType> lapack;
+    ordinal_type basisCardinality, numRefCoords, dim;
+    Kokkos::View<ValueType**,Kokkos::LayoutLeft,Kokkos::HostSpace> work;
+    Kokkos::View<ValueType**,Kokkos::LayoutLeft,Kokkos::HostSpace> cellMassMat;
+    Kokkos::View<ValueType**,Kokkos::LayoutLeft,Kokkos::HostSpace> cellRhsMat;
+  };
+
+
+  typedef std::array<ordinal_type,2> edgeType;
+  typedef std::array<ordinal_type,4> faceType;
+  typedef CellTools<DeviceType> ct;
+  typedef OrientationTools<DeviceType> ots;
+  typedef RealSpaceTools<DeviceType> rst;
+  typedef FunctionSpaceTools<DeviceType> fst;
+
+  using  basisType = Basis<DeviceType,ValueType,ValueType>;
+
+  constexpr ordinal_type dim = 3;
+  constexpr ordinal_type numCells = 2;
+  constexpr ordinal_type numElemVertices = 5;
+  constexpr ordinal_type numTotalVertices = 6;
+  constexpr ordinal_type numSharedVertices = 4;
+  constexpr ordinal_type numSharedEdges = 4;
+
+  ValueType  vertices_orig[numTotalVertices][dim] = {{0,0,0},{0,1,0},{1,1,0},{0,1,0},{0,0,1},{0,0,-1}};
+  ordinal_type pyrs_orig[numCells][numElemVertices] = {{0,1,2,3,4},{0,1,2,3,5}};  //common face is {0,1,2,3}
+  faceType common_face = {{0,1,2,3}};
+  ordinal_type pyrs_rotated[numCells][numElemVertices];
+
+  static std::set<edgeType> common_edges { {{0,1}}, {{0,4}}, {{1,2}}, {{2,3}} };
+  
+  static ordinal_type shared_vertices[numCells][numSharedVertices];
+  static ordinal_type edgeIndices[numCells][numSharedEdges];
+  static ordinal_type faceIndex[numCells];
+
+  class TestResults
+  {
+  private:
+    const DynRankView basisCoeffs, transformedBasisValuesAtRefCoords, transformedBasisValuesAtRefCoordsOriented, funAtPhysRefCoords;
+    const Kokkos::DynRankView<Orientation,DeviceType> elemOrts;
+    const basisType* basis;
+
+
+  public:
+
+    TestResults(const DynRankView basisCoeffs_,
+                const DynRankView transformedBasisValuesAtRefCoords_,
+                const DynRankView transformedBasisValuesAtRefCoordsOriented_,
+                const DynRankView funAtPhysRefCoords_,
+                const Kokkos::DynRankView<Orientation,DeviceType> elemOrts_,
+                const basisType* basis_) :
+          basisCoeffs(basisCoeffs_),
+          transformedBasisValuesAtRefCoords(transformedBasisValuesAtRefCoords_),
+          transformedBasisValuesAtRefCoordsOriented(transformedBasisValuesAtRefCoordsOriented_),
+          funAtPhysRefCoords(funAtPhysRefCoords_),
+          elemOrts(elemOrts_),
+          basis(basis_){}
+
+    //check that fun values are consistent at the common vertices
+    void test(ordinal_type& errorFlag, ValueType tol){
+
+      auto numVertexDOFs = basis->getDofCount(0,0);
+      if(numVertexDOFs >0) {
+        bool areDifferent(false);
+
+
+        for(ordinal_type j=0;j<numSharedVertices && !areDifferent;j++)
+          areDifferent = std::abs(basisCoeffs(0,basis->getDofOrdinal(0,shared_vertices[0][j],0))
+              - basisCoeffs(1,basis->getDofOrdinal(0,shared_vertices[1][j],0))) > 10*tol;
+
+        if(areDifferent) {
+          errorFlag++;
+          *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+          *outStream << "Function  DOFs on shared vertices computed using Cell 0 basis functions are not consistent with those computed using Cell 1 bssis functions\n";
+          *outStream << "Function DOFs for Cell 0 are:";
+          for(ordinal_type j=0;j<numSharedVertices;j++)
+            *outStream << " " << basisCoeffs(0,basis->getDofOrdinal(0,shared_vertices[0][j],0));
+          *outStream << "\nFunction DOFs for Cell 1 are:";
+          for(ordinal_type j=0;j<numSharedVertices;j++)
+            *outStream << " " << basisCoeffs(1,basis->getDofOrdinal(0,shared_vertices[1][j],0));
+          *outStream << std::endl;
+        }
+
+      }
+
+
+      //check that fun values are consistent on shared edges dofs
+      auto numEdgeDOFs = basis->getDofCount(1,0);
+      if(numEdgeDOFs>0)
+      {
+
+        bool areDifferent(false);
+        for(std::size_t iEdge=0;iEdge<numSharedEdges;iEdge++) {
+        for(ordinal_type j=0;j<numEdgeDOFs && !areDifferent;j++) {
+          areDifferent = std::abs(basisCoeffs(0,basis->getDofOrdinal(1,edgeIndices[0][iEdge],j))
+              - basisCoeffs(1,basis->getDofOrdinal(1,edgeIndices[1][iEdge],j))) > 10*tol;
+        }
+        if(areDifferent) {
+          errorFlag++;
+          *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+          *outStream << "Function DOFs on shared edge " << iEdge << " computed using Cell 0 basis functions are not consistent with those computed using Cell 1 basis functions\n";
+          *outStream << "Function DOFs for Cell 0 are:";
+          for(ordinal_type j=0;j<numEdgeDOFs;j++)
+            *outStream << " " << basisCoeffs(0,basis->getDofOrdinal(1,edgeIndices[0][iEdge],j));
+          *outStream << "\nFunction DOFs for Cell 1 are:";
+          for(ordinal_type j=0;j<numEdgeDOFs;j++)
+            *outStream << " " << basisCoeffs(1,basis->getDofOrdinal(1,edgeIndices[1][iEdge],j));
+          *outStream << std::endl;
+        }
+        }
+      }
+
+
+      //check that fun values are consistent on common face dofs
+      auto numFaceDOFs = basis->getDofCount(2,0);
+      if(numFaceDOFs > 0 && dim>2)
+      {
+        bool areDifferent(false);
+        for(ordinal_type j=0;j<numFaceDOFs && !areDifferent;j++) {
+          areDifferent = std::abs(basisCoeffs(0,basis->getDofOrdinal(2,faceIndex[0],j))
+              - basisCoeffs(1,basis->getDofOrdinal(2,faceIndex[1],j))) > 100*tol;
+        }
+
+        if(areDifferent) {
+          errorFlag++;
+          *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+          *outStream << "Function DOFs on common face computed using Hex 0 basis functions are not consistent with those computed using Hex 1\n";
+          *outStream << "Function DOFs for Hex 0 are:";
+          for(ordinal_type j=0;j<numFaceDOFs;j++)
+            *outStream << " " << basisCoeffs(0,basis->getDofOrdinal(2,faceIndex[0],j));
+          *outStream << "\nFunction DOFs for Hex 1 are:";
+          for(ordinal_type j=0;j<numFaceDOFs;j++)
+            *outStream << " " << basisCoeffs(1,basis->getDofOrdinal(2,faceIndex[1],j));
+          *outStream << std::endl;
+        }
+      }
+
+      ordinal_type numRefCoords = funAtPhysRefCoords.extent(1);
+      ordinal_type basisCardinality = basisCoeffs.extent(1);
+      INTREPID2_TEST_FOR_EXCEPTION(numRefCoords < basisCardinality, std::invalid_argument, "numRefCoords must be at least as large as basisCardinality");
+      ordinal_type basis_dim = (transformedBasisValuesAtRefCoordsOriented.rank()==3) ? 1 : dim;
+
+      DynRankView ConstructWithLabel(funAtRefCoordsOriented, numCells, numRefCoords, basis_dim);
+      for(ordinal_type ic=0; ic<numCells; ++ic) {
+        ValueType error=0;
+        for(ordinal_type j=0; j<numRefCoords; ++j) {
+          if (basis_dim==1) {
+            for(ordinal_type k=0; k<basisCardinality; ++k)
+              funAtRefCoordsOriented(ic,j,0) += basisCoeffs(ic,k)*transformedBasisValuesAtRefCoordsOriented(ic,k,j);
+            error = std::max(std::abs( funAtPhysRefCoords(ic,j) - funAtRefCoordsOriented(ic,j,0)), error);
+          } else {
+            for(ordinal_type d=0; d<basis_dim; ++d) {
+              for(ordinal_type k=0; k<basisCardinality; ++k)
+                funAtRefCoordsOriented(ic,j,d) += basisCoeffs(ic,k)*transformedBasisValuesAtRefCoordsOriented(ic,k,j,d);
+              error = std::max(std::abs( funAtPhysRefCoords(ic,j,d) - funAtRefCoordsOriented(ic,j,d)), error);
+            }
+          }
+        }
+
+        if(error>100*tol) {
+          errorFlag++;
+          *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+          *outStream << "Function values at reference points differ from those computed using basis functions on Cell " << ic << "\n";
+          *outStream << "Function values at reference points are:\n";
+          for(ordinal_type j=0; j<numRefCoords; ++j) {
+            if(basis_dim==1)
+              *outStream << " (" << funAtPhysRefCoords(ic,j);
+            else
+              *outStream << " (" << funAtPhysRefCoords(ic,j,0);
+            for(ordinal_type d=1; d<basis_dim; d++)
+              *outStream <<  ", " << funAtPhysRefCoords(ic,j,d);
+            *outStream  << ")";
+          }
+          *outStream << "\nFunction values at reference points computed using basis functions are\n";
+          for(ordinal_type j=0; j<numRefCoords; ++j) {
+            *outStream << " (" << funAtRefCoordsOriented(ic,j,0);
+            for(ordinal_type d=1; d<basis_dim; d++)
+              *outStream <<  ", " << funAtRefCoordsOriented(ic,j,d);
+            *outStream  << ")";
+          }
+          *outStream << std::endl;
+        }
+      }
+      
+      // check that global (oriented) basis coefficients contracted with the transformed oriented basis values agrees with the transpose-oriented basis coefficients contracted with the unoriented transformed basis values
+      DynRankView ConstructWithLabel(localBasisCoeffs, numCells, basisCardinality);
+      OrientationTools<DeviceType>::modifyBasisByOrientationTranspose(localBasisCoeffs,
+                                                                      basisCoeffs,
+                                                                      elemOrts,
+                                                                      basis);
+      
+      DynRankView ConstructWithLabel(basisCoeffsModified, numCells, basisCardinality);
+      OrientationTools<DeviceType>::modifyBasisByOrientation(basisCoeffsModified,
+                                                             basisCoeffs,
+                                                             elemOrts,
+                                                             basis);
+      
+      
+      for(ordinal_type ic=0; ic<numCells; ++ic) {
+        ValueType error=0;
+        for(ordinal_type j=0; j<numRefCoords; ++j) {
+          for (int d=0; d<transformedBasisValuesAtRefCoords.extent_int(3); d++)
+          {
+            ValueType globalValue_d = 0; // oriented/global
+            ValueType localValue_d  = 0; // unoriented/local
+            for(ordinal_type k=0; k<basisCardinality; ++k)
+            {
+              auto orientedBasisValue = transformedBasisValuesAtRefCoordsOriented(ic,k,j,d);
+              auto basisValue         = transformedBasisValuesAtRefCoords        (ic,k,j,d);
+              
+              globalValue_d += basisCoeffs(ic,k)      * orientedBasisValue;
+              localValue_d  += localBasisCoeffs(ic,k) * basisValue;
+            }
+            error = std::max(std::abs( globalValue_d - localValue_d), error);
+          }
+        }
+
+        if(error>100*tol) {
+          errorFlag++;
+          *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+          *outStream << "global values do not agree with local on cell " << ic << "\n";
+        }
+      }
+    }
+  };
+
+
+  try {
+
+    const ordinal_type order = 3;
+    ordinal_type reorder[numTotalVertices] = {0,1,2,3,4,5};
+
+    do {
+      ordinal_type orderback[numTotalVertices];
+      for(ordinal_type i=0;i<numTotalVertices;++i) {
+        orderback[reorder[i]]=i;
+      }
+      ValueType vertices[numTotalVertices][dim];
+      ordinal_type pyrs[numCells][numElemVertices];
+      std::copy(&pyrs_orig[0][0], &pyrs_orig[0][0]+numCells*numElemVertices, &pyrs_rotated[0][0]);
+      for (ordinal_type rotationOrdinal=0; rotationOrdinal<1; ++rotationOrdinal) {
+        // for this test (as opposed to the shared-triangle-face test), there is only one possible quad-face-to-quad-face configuration, so the only "rotation" we consider is the trivial one.  In the outer ("do") loop, we permute the global vertices, which gives us the full set of orientations of the quadrilateral.
+        for (int vertexOrdinal=0; vertexOrdinal<4; vertexOrdinal++)
+        {
+          pyrs_rotated[0][vertexOrdinal] = pyrs_orig[0][(vertexOrdinal + rotationOrdinal) % 4];
+        }
+
+        for(ordinal_type i=0; i<numCells;++i)
+          for(ordinal_type j=0; j<numElemVertices;++j)
+            pyrs[i][j] = reorder[pyrs_rotated[i][j]];
+
+        for(ordinal_type i=0; i<numTotalVertices;++i)
+          for(ordinal_type d=0; d<dim;++d)
+            vertices[i][d] = vertices_orig[orderback[i]][d];
+
+        *outStream <<  "Considering Pyr 0: [ ";
+        for(ordinal_type j=0; j<numElemVertices;++j)
+          *outStream << pyrs[0][j] << " ";
+        *outStream << "] and Pyr 1: [ ";
+        for(ordinal_type j=0; j<numElemVertices;++j)
+          *outStream << pyrs[1][j] << " ";
+        *outStream << "]\n";
+
+        shards::CellTopology pyramid(shards::getCellTopologyData<shards::Pyramid<5> >());
+
+        //computing vertices coords
+        DynRankView ConstructWithLabel(physVertices, numCells, pyramid.getNodeCount(), dim);
+        for(ordinal_type i=0; i<numCells; ++i)
+          for(std::size_t j=0; j<pyramid.getNodeCount(); ++j)
+            for(ordinal_type k=0; k<dim; ++k)
+              physVertices(i,j,k) = vertices[pyrs[i][j]][k];
+
+
+
+        //computing common face and edges
+        {
+          faceType face={};
+          edgeType edge={};
+          //bool faceOrientation[numCells][4];
+          for(ordinal_type i=0; i<numCells; ++i) {
+            for (std::size_t iv=0; iv<pyramid.getNodeCount(); ++iv) {
+              auto vertex = pyrs_rotated[i][pyramid.getNodeMap(0,iv,0)];
+              for (std::size_t isv=0; isv<common_face.size(); ++isv)
+                if(common_face[isv] == vertex)
+                  shared_vertices[i][isv] = iv;
+            }
+            //compute faces' tangents
+            for (std::size_t is=0; is<pyramid.getSideCount(); ++is) {
+              for (std::size_t k=0; k<pyramid.getNodeCount(2,is); ++k)
+                face[k]= pyrs_rotated[i][pyramid.getNodeMap(2,is,k)];
+
+              //rotate and flip
+              auto minElPtr= std::min_element(face.begin(), face.end());
+              std::rotate(face.begin(),minElPtr,face.end());
+              if(face[3]<face[1]) {auto tmp=face[1]; face[1]=face[3]; face[3]=tmp;}
+
+              if(face == common_face) faceIndex[i]=is;
+            }
+            //compute edges' tangents
+            for (std::size_t ie=0; ie<pyramid.getEdgeCount(); ++ie) {
+              for (std::size_t k=0; k<pyramid.getNodeCount(1,ie); ++k)
+                edge[k]= pyrs_rotated[i][pyramid.getNodeMap(1,ie,k)];
+              std::sort(edge.begin(),edge.end());
+              auto it=common_edges.find(edge);
+              if(it !=common_edges.end()){
+                auto edge_lid = std::distance(common_edges.begin(),it);
+                edgeIndices[i][edge_lid]=ie;
+              }
+            }
+          }
+        }
+
+        using CG_HBasis = HierarchicalBasisFamily<DeviceType,ValueType,ValueType>;
+        std::vector<basisType*> basis_set;
+
+        //compute reference points: use a lattice
+        auto refPoints = getInputPointsView<double,DeviceType>(pyramid, order*3);
+        ordinal_type numRefCoords = refPoints.extent_int(0);
+        
+        // compute orientations for cells (one time computation)
+        DynRankViewInt elemNodes(&pyrs[0][0], numCells, numElemVertices);
+        Kokkos::DynRankView<Orientation,DeviceType> elemOrts("elemOrts", numCells);
+        ots::getOrientation(elemOrts, elemNodes, pyramid);
+
+        //Compute physical Dof Coordinates and Reference coordinates
+        DynRankView ConstructWithLabel(physRefCoords, numCells, numRefCoords, dim);
+        {
+          Basis_HGRAD_PYR_C1_FEM<DeviceType,ValueType,ValueType> pyramidLinearBasis; //used for computing physical coordinates
+          DynRankView ConstructWithLabel(pyramidLinearBasisValuesAtRefCoords, pyramid.getNodeCount(), numRefCoords);
+          pyramidLinearBasis.getValues(pyramidLinearBasisValuesAtRefCoords, refPoints);
+          for(ordinal_type i=0; i<numCells; ++i)
+            for(ordinal_type d=0; d<dim; ++d) {
+              for(ordinal_type j=0; j<numRefCoords; ++j)
+                for(std::size_t k=0; k<pyramid.getNodeCount(); ++k)
+                  physRefCoords(i,j,d) += vertices[pyrs[i][k]][d]*pyramidLinearBasisValuesAtRefCoords(k,j);
+            }
+        }
+
+
+        //HGRAD BASIS
+        {
+          Fun fun;
+          DynRankView ConstructWithLabel(funAtPhysRefCoords, numCells, numRefCoords);
+          for(ordinal_type i=0; i<numCells; ++i) {
+            for(ordinal_type j=0; j<numRefCoords; ++j)
+              funAtPhysRefCoords(i,j) = fun(physRefCoords(i,j,0), physRefCoords(i,j,1), physRefCoords(i,j,2));
+          }
+
+          basis_set.push_back(new typename  CG_HBasis::HGRAD_PYR(order));
+
+          for (auto basisPtr:basis_set) {
+            auto& basis = *basisPtr;
+            auto name = basis.getName();
+            *outStream << " " << name << std::endl;
+            ordinal_type basisCardinality = basis.getCardinality();
+
+            //check that fun values at reference points coincide with those computed using basis functions
+            DynRankView ConstructWithLabel(basisValuesAtRefCoordsOriented, numCells, basisCardinality, numRefCoords);
+            DynRankView ConstructWithLabel(transformedBasisValuesAtRefCoordsOriented, numCells, basisCardinality, numRefCoords);
+            DynRankView ConstructWithLabel(transformedBasisValuesAtRefCoords, numCells, basisCardinality, numRefCoords);
+
+            DynRankView ConstructWithLabel(basisValuesAtRefCoords, basisCardinality, numRefCoords);
+            basis.getValues(basisValuesAtRefCoords, refPoints);
+
+            // modify basis values to account for orientations
+            ots::modifyBasisByOrientation(basisValuesAtRefCoordsOriented,
+                basisValuesAtRefCoords,
+                elemOrts,
+                &basis);
+            
+            // transform basis values
+            fst::HGRADtransformVALUE(transformedBasisValuesAtRefCoords, basisValuesAtRefCoords);
+            deep_copy(transformedBasisValuesAtRefCoordsOriented,
+                basisValuesAtRefCoordsOriented);
+
+            DynRankView ConstructWithLabel(basisCoeffs, numCells, basisCardinality);
+
+            BasisFunctionsSystem  basisFunctionsSystem(basisCardinality, numRefCoords, 1);
+            auto info = basisFunctionsSystem.computeBasisCoeffs(basisCoeffs, errorFlag, transformedBasisValuesAtRefCoordsOriented, funAtPhysRefCoords);
+
+            for (int ic =0; ic < numCells; ++ic) {
+              if(info[ic] != 0) {
+                errorFlag++;
+                *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                *outStream << "LAPACK error flag for cell " << ic << " is: " << info[ic] << std::endl;
+              }
+            }
+
+            TestResults testResults(basisCoeffs, transformedBasisValuesAtRefCoords, transformedBasisValuesAtRefCoordsOriented, funAtPhysRefCoords, elemOrts, basisPtr);
+            testResults.test(errorFlag,tol);
+            delete basisPtr;
+          }
+        }
+
+
+        //HCURL Case
+        //TODO: uncomment after we implement H(curl) basis for pyramids
+        /*{
+          FunCurl fun;
+          DynRankView ConstructWithLabel(funAtPhysRefCoords, numCells, numRefCoords, dim);
+          for(ordinal_type i=0; i<numCells; ++i) {
+            for(ordinal_type j=0; j<numRefCoords; ++j) {
+              for(ordinal_type k=0; k<dim; ++k)
+                funAtPhysRefCoords(i,j,k) = fun(physRefCoords(i,j,0), physRefCoords(i,j,1), physRefCoords(i,j,2), k);
+            }
+          }
+
+          basis_set.clear();
+          basis_set.push_back(new typename  CG_HBasis::HCURL_PYR(order));
+
+          for (auto basisPtr:basis_set) {
+            auto& basis = *basisPtr;
+            auto name = basis.getName();
+            *outStream << " " << name << std::endl;
+
+            ordinal_type basisCardinality = basis.getCardinality();
+            DynRankView ConstructWithLabel(basisCoeffs, numCells, basisCardinality);
+
+            //check that fun values at reference points coincide with those computed using basis functions
+            DynRankView ConstructWithLabel(basisValuesAtRefCoordsOriented, numCells, basisCardinality, numRefCoords, dim);
+            DynRankView ConstructWithLabel(transformedBasisValuesAtRefCoordsOriented, numCells, basisCardinality, numRefCoords, dim);
+            DynRankView ConstructWithLabel(transformedBasisValuesAtRefCoords, numCells, basisCardinality, numRefCoords, dim);
+            DynRankView basisValuesAtRefCoordsCells("inValues", numCells, basisCardinality, numRefCoords, dim);
+
+
+            DynRankView ConstructWithLabel(basisValuesAtRefCoords, basisCardinality, numRefCoords, dim);
+            basis.getValues(basisValuesAtRefCoords, refPoints);
+            rst::clone(basisValuesAtRefCoordsCells,basisValuesAtRefCoords);
+
+            // modify basis values to account for orientations
+            ots::modifyBasisByOrientation(basisValuesAtRefCoordsOriented,
+                basisValuesAtRefCoordsCells,
+                elemOrts,
+                &basis);
+
+            // transform basis values
+            DynRankView ConstructWithLabel(jacobianAtRefCoords, numCells, numRefCoords, dim, dim);
+            DynRankView ConstructWithLabel(jacobianAtRefCoords_inv, numCells, numRefCoords, dim, dim);
+            ct::setJacobian(jacobianAtRefCoords, refPoints, physVertices, pyramid);
+            ct::setJacobianInv (jacobianAtRefCoords_inv, jacobianAtRefCoords);
+            fst::HCURLtransformVALUE(transformedBasisValuesAtRefCoordsOriented,
+                jacobianAtRefCoords_inv,
+                basisValuesAtRefCoordsOriented);
+            fst::HCURLtransformVALUE(transformedBasisValuesAtRefCoords,
+                jacobianAtRefCoords_inv,
+                basisValuesAtRefCoords);
+
+            BasisFunctionsSystem  basisFunctionsSystem(basisCardinality, numRefCoords, dim);
+            auto info = basisFunctionsSystem.computeBasisCoeffs(basisCoeffs, errorFlag, transformedBasisValuesAtRefCoordsOriented, funAtPhysRefCoords);
+
+            for (int ic =0; ic < numCells; ++ic) {
+              if(info[ic] != 0) {
+                errorFlag++;
+                *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                *outStream << "LAPACK error flag for cell " << ic << " is: " << info[ic] << std::endl;
+              }
+            }
+
+            TestResults testResults(basisCoeffs, transformedBasisValuesAtRefCoords, transformedBasisValuesAtRefCoordsOriented, funAtPhysRefCoords, elemOrts, basisPtr);
+            testResults.test(errorFlag,tol);
+            delete basisPtr;
+          }
+        }*/
+
+
+        //HDIV Case
+        //TODO: uncomment after we implement H(div) basis for pyramids
+        /*{
+          FunDiv fun;
+          DynRankView ConstructWithLabel(funAtPhysRefCoords, numCells, numRefCoords, dim);
+          for(ordinal_type i=0; i<numCells; ++i) {
+            for(ordinal_type j=0; j<numRefCoords; ++j) {
+              for(ordinal_type k=0; k<dim; ++k)
+                funAtPhysRefCoords(i,j,k) = fun(physRefCoords(i,j,0), physRefCoords(i,j,1), physRefCoords(i,j,2), k);
+            }
+          }
+          basis_set.clear();
+          basis_set.push_back(new typename  CG_HBasis::HDIV_PYR(order));
+
+          for (auto basisPtr:basis_set) {
+            auto& basis = *basisPtr;
+            auto name = basis.getName();
+            *outStream << " " << name << std::endl;
+            ordinal_type basisCardinality = basis.getCardinality();
+
+            //check that fun values at reference points coincide with those computed using basis functions
+            DynRankView ConstructWithLabel(basisValuesAtRefCoordsOriented, numCells, basisCardinality, numRefCoords, dim);
+            DynRankView ConstructWithLabel(transformedBasisValuesAtRefCoordsOriented, numCells, basisCardinality, numRefCoords, dim);
+            DynRankView ConstructWithLabel(transformedBasisValuesAtRefCoords, numCells, basisCardinality, numRefCoords, dim);
+            DynRankView basisValuesAtRefCoordsCells("inValues", numCells, basisCardinality, numRefCoords, dim);
+
+            DynRankView ConstructWithLabel(basisValuesAtRefCoords, basisCardinality, numRefCoords, dim);
+            basis.getValues(basisValuesAtRefCoords, refPoints);
+            rst::clone(basisValuesAtRefCoordsCells,basisValuesAtRefCoords);
+
+            // modify basis values to account for orientations
+            ots::modifyBasisByOrientation(basisValuesAtRefCoordsOriented,
+                basisValuesAtRefCoordsCells,
+                elemOrts,
+                &basis);
+
+            // transform basis values
+            DynRankView ConstructWithLabel(jacobianAtRefCoords, numCells, numRefCoords, dim, dim);
+            DynRankView ConstructWithLabel(jacobianAtRefCoords_det, numCells, numRefCoords);
+            ct::setJacobian(jacobianAtRefCoords, refPoints, physVertices, pyramid);
+            ct::setJacobianDet (jacobianAtRefCoords_det, jacobianAtRefCoords);
+            fst::HDIVtransformVALUE(transformedBasisValuesAtRefCoordsOriented,
+                jacobianAtRefCoords,
+                jacobianAtRefCoords_det,
+                basisValuesAtRefCoordsOriented);
+            fst::HDIVtransformVALUE(transformedBasisValuesAtRefCoords,
+                jacobianAtRefCoords,
+                jacobianAtRefCoords_det,
+                basisValuesAtRefCoords);
+
+            DynRankView ConstructWithLabel(basisCoeffs, numCells, basisCardinality);
+
+
+            BasisFunctionsSystem  basisFunctionsSystem(basisCardinality, numRefCoords, dim);
+            auto info = basisFunctionsSystem.computeBasisCoeffs(basisCoeffs, errorFlag, transformedBasisValuesAtRefCoordsOriented, funAtPhysRefCoords);
+
+            for (int ic =0; ic < numCells; ++ic) {
+              if(info[ic] != 0) {
+                errorFlag++;
+                *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                *outStream << "LAPACK error flag for cell " << ic << " is: " << info[ic] << std::endl;
+              }
+            }
+
+            TestResults testResults(basisCoeffs, transformedBasisValuesAtRefCoords, transformedBasisValuesAtRefCoordsOriented, funAtPhysRefCoords, elemOrts, basisPtr);
+            testResults.test(errorFlag,tol);
+            delete basisPtr;
+          }
+        }*/
+      } //rotation of first cell vertices
+    } while(std::next_permutation(&reorder[0]+2, &reorder[0]+5)); //reorder vertices of common face
+
+  } catch (std::exception &err) {
+    std::cout << " Exeption\n";
+    *outStream << err.what() << "\n\n";
+    errorFlag = -1000;
+  }
+
+
+  if (errorFlag != 0)
+    std::cout << "End Result: TEST FAILED = " << errorFlag << "\n";
+  else
+    std::cout << "End Result: TEST PASSED\n";
+
+  // reset format state of std::cout
+  std::cout.copyfmt(oldFormatState);
+
+  return errorFlag;
+}
+}
+}
+

--- a/packages/intrepid2/unit-test/Orientation/test_orientation_PYR_TriFace_newBasis.hpp
+++ b/packages/intrepid2/unit-test/Orientation/test_orientation_PYR_TriFace_newBasis.hpp
@@ -1,0 +1,782 @@
+// @HEADER
+// ************************************************************************
+//
+//                           Intrepid2 Package
+//                 Copyright (2007) Sandia Corporation
+//
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Mauro Perego  (mperego@sandia.gov), or
+//                    Nate Roberts  (nvrober@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+
+
+/** \file test_orientation_PYR_newBasis.hpp
+    \brief  Test for checking orientation tools for the Hierarchical basis on Pyramids
+
+    The test considers two pyramids in physical space sharing a common triangular face.
+    In order to test significant configurations, we consider 4 mappings of the reference pyramid
+    to the first (physical) pyramid, so that the common face is mapped from all 4 triangular faces
+    of the reference pyramid.
+    Then, for each of the mappings, the global ids of the vertices of the common face are permuted.
+    This gives a total of 24 combinations.
+
+    The test considers HGRAD, HCURL and HDIV Hierarchical basis functions, and for each:
+    1. Computes the oriented basis.
+    2. Computes the basis coefficients, separately for each pyramid, for functions belonging to the H-space spanned by the basis.
+    3. Checks that the dofs shared between the two pyramids are equivalent (this ensures that the orientation works correctly)
+    4. Checks that the functions are indeed exactly reproduced
+
+    \author Created by Nate Roberts, based on HEX tests by Mauro Perego.
+ */
+
+#include "Intrepid2_config.h"
+
+#ifdef HAVE_INTREPID2_DEBUG
+#define INTREPID2_TEST_FOR_DEBUG_ABORT_OVERRIDE_TO_CONTINUE
+#endif
+
+#include "Intrepid2_Orientation.hpp"
+#include "Intrepid2_OrientationTools.hpp"
+#include "Intrepid2_PointTools.hpp"
+#include "Intrepid2_CellTools.hpp"
+#include "Intrepid2_FunctionSpaceTools.hpp"
+#include "Intrepid2_TestUtils.hpp"
+
+#include "Intrepid2_HGRAD_PYR_C1_FEM.hpp"
+#include "Intrepid2_HierarchicalBasisFamily.hpp"
+
+#include "Teuchos_oblackholestream.hpp"
+#include "Teuchos_RCP.hpp"
+#include <array>
+#include <set>
+#include <random>
+#include <algorithm>
+
+namespace Intrepid2 {
+
+namespace Test {
+
+#define INTREPID2_TEST_ERROR_EXPECTED( S )              \
+    try {                                                               \
+      ++nthrow;                                                         \
+      S ;                                                               \
+    }                                                                   \
+    catch (std::exception &err) {                                        \
+      ++ncatch;                                                         \
+      *outStream << "Expected Error ----------------------------------------------------------------\n"; \
+      *outStream << err.what() << '\n';                                 \
+      *outStream << "-------------------------------------------------------------------------------" << "\n\n"; \
+    }
+
+template<typename ValueType, typename DeviceType>
+int OrientationPyrTriFaceNewBasis(const bool verbose) {
+
+  typedef Kokkos::DynRankView<ValueType,DeviceType> DynRankView;
+  typedef Kokkos::DynRankView<ordinal_type,DeviceType> DynRankViewInt;
+#define ConstructWithLabel(obj, ...) obj(#obj, __VA_ARGS__)
+
+  static Teuchos::RCP<std::ostream> outStream;
+  Teuchos::oblackholestream bhs; // outputs nothing
+
+  if (verbose)
+    outStream = Teuchos::rcp(&std::cout, false);
+  else
+    outStream = Teuchos::rcp(&bhs,       false);
+
+  Teuchos::oblackholestream oldFormatState;
+  oldFormatState.copyfmt(std::cout);
+
+  int errorFlag = 0;
+  const ValueType tol = tolerence();
+
+  struct Fun {
+    ValueType
+    KOKKOS_INLINE_FUNCTION
+    operator()(const ValueType& x, const ValueType& y, const ValueType& z) {
+      return (x+1)*(y-2);//*(z+3)*(x + 2*y +5*z+ 1.0/3.0);
+    }
+  };
+
+  struct FunDiv {
+    ValueType
+    KOKKOS_INLINE_FUNCTION
+    operator()(const ValueType& x, const ValueType& y, const ValueType& z, const int comp=0) {
+      ValueType a = 2*x*y+x*x;
+      ValueType f0 = 5+y+x*x+z*z;
+      ValueType f1 = -7-2*z+x+y*y+z*z;
+      ValueType f2 = 0.5+z*z+x*x;
+      //fun = f + a x
+      switch (comp) {
+      case 0:
+        return f0 + a*x;
+      case 1:
+        return f1 + a*y;
+      case 2:
+        return f2 + a*z;
+      default:
+        return 0;
+      }
+    }
+  };
+
+  struct FunCurl {
+    ValueType
+    KOKKOS_INLINE_FUNCTION
+    operator()(const ValueType& x, const ValueType& y, const ValueType& z, const int comp=0) {
+      ValueType a0 = y-7+z*z;
+      ValueType a1 = 2*z-1+z*x;
+      ValueType a2 = z-2+x*x;
+      ValueType f0 = 2+x+z+x*y;
+      ValueType f1 = 3-3*z;
+      ValueType f2 = -5+x;
+      //fun = f + a \times x
+      switch (comp) {
+      case 0:
+        return f0 + (a1*z-a2*y);//2*x+y-z + (x+2*(y+z);
+      case 1:
+        return f1 + (a2*x-a0*z);//y+2*(z+x);
+      case 2:
+        return f2 + (a0*y-a1*x);//z+2*(x+y);
+      default:
+        return 0;
+      }
+    }
+  };
+
+
+  class BasisFunctionsSystem{
+  public:
+    BasisFunctionsSystem(const ordinal_type basisCardinality_, const ordinal_type numRefCoords_, const ordinal_type  dim_) :
+      basisCardinality(basisCardinality_),
+      numRefCoords(numRefCoords_),
+      dim(dim_),
+      work("lapack_work", basisCardinality+dim*numRefCoords, 1) ,
+      cellMassMat("basisMat", dim*numRefCoords,basisCardinality),
+      cellRhsMat("rhsMat",dim*numRefCoords, 1) {
+    };
+
+    std::vector<int> computeBasisCoeffs(DynRankView basisCoeffs, ordinal_type& errorFlag, const DynRankView transformedBasisValuesAtRefCoordsOriented, const DynRankView funAtPhysRefCoords) {
+
+      ordinal_type numCells = basisCoeffs.extent(0);
+      std::vector<int> info(numCells);
+      for(ordinal_type ic=0; ic<numCells; ++ic) {
+        for(ordinal_type i=0; i<numRefCoords; ++i) {
+          if (dim==1) {
+            for(ordinal_type j=0; j<basisCardinality; ++j) {
+              cellMassMat(i,j) = transformedBasisValuesAtRefCoordsOriented(ic,j,i);
+            }
+            cellRhsMat(i,0) = funAtPhysRefCoords(ic,i);
+          } else
+            for (ordinal_type id=0; id<dim; ++id) {
+              for(ordinal_type j=0; j<basisCardinality; ++j) {
+                cellMassMat(i+id*numRefCoords,j) = transformedBasisValuesAtRefCoordsOriented(ic,j,i,id);
+              }
+              cellRhsMat(i+id*numRefCoords,0) = funAtPhysRefCoords(ic,i,id);
+            }
+        }
+
+        lapack.GELS('N', dim*numRefCoords, basisCardinality,1,
+            cellMassMat.data(),
+            cellMassMat.stride_1(),
+            cellRhsMat.data(),
+            cellRhsMat.stride_1(),
+            work.data(),
+            basisCardinality+dim*numRefCoords,
+            &info[ic]);
+
+        for(ordinal_type i=0; i<basisCardinality; ++i){
+          basisCoeffs(ic,i) = cellRhsMat(i,0);
+        }
+      }
+      return info;
+    }
+  private:
+    Teuchos::LAPACK<ordinal_type,ValueType> lapack;
+    ordinal_type basisCardinality, numRefCoords, dim;
+    Kokkos::View<ValueType**,Kokkos::LayoutLeft,Kokkos::HostSpace> work;
+    Kokkos::View<ValueType**,Kokkos::LayoutLeft,Kokkos::HostSpace> cellMassMat;
+    Kokkos::View<ValueType**,Kokkos::LayoutLeft,Kokkos::HostSpace> cellRhsMat;
+  };
+
+
+  typedef std::array<ordinal_type,2> edgeType;
+  typedef std::array<ordinal_type,3> faceType;
+  typedef CellTools<DeviceType> ct;
+  typedef OrientationTools<DeviceType> ots;
+  typedef RealSpaceTools<DeviceType> rst;
+  typedef FunctionSpaceTools<DeviceType> fst;
+
+  using  basisType = Basis<DeviceType,ValueType,ValueType>;
+
+  constexpr ordinal_type dim = 3;
+  constexpr ordinal_type numCells = 2;
+  constexpr ordinal_type numElemVertices = 5;
+  constexpr ordinal_type numTotalVertices = 7;
+  constexpr ordinal_type numSharedVertices = 3;
+  constexpr ordinal_type numSharedEdges = 3;
+
+  ValueType  vertices_orig[numTotalVertices][dim] = {{1,1,0},{0,1,0},{0,0,0},{0,1,0},{0,0,1},{0,-1,0},{1,-1,0}};
+  ordinal_type pyrs_orig[numCells][numElemVertices] = {{2,3,0,1,4},{5,6,3,2,4}};  //common face is {2,3,4}
+  faceType common_face = {{2,3,4}};
+  ordinal_type pyrs_rotated[numCells][numElemVertices];
+
+  static std::set<edgeType> common_edges { {{2,3}}, {{2,4}}, {{3,4}} };
+  
+  static ordinal_type shared_vertices[numCells][numSharedVertices];
+  static ordinal_type edgeIndices[numCells][numSharedEdges];
+  static ordinal_type faceIndex[numCells];
+
+  class TestResults
+  {
+  private:
+    const DynRankView basisCoeffs, transformedBasisValuesAtRefCoords, transformedBasisValuesAtRefCoordsOriented, funAtPhysRefCoords;
+    const Kokkos::DynRankView<Orientation,DeviceType> elemOrts;
+    const basisType* basis;
+
+
+  public:
+
+    TestResults(const DynRankView basisCoeffs_,
+                const DynRankView transformedBasisValuesAtRefCoords_,
+                const DynRankView transformedBasisValuesAtRefCoordsOriented_,
+                const DynRankView funAtPhysRefCoords_,
+                const Kokkos::DynRankView<Orientation,DeviceType> elemOrts_,
+                const basisType* basis_) :
+          basisCoeffs(basisCoeffs_),
+          transformedBasisValuesAtRefCoords(transformedBasisValuesAtRefCoords_),
+          transformedBasisValuesAtRefCoordsOriented(transformedBasisValuesAtRefCoordsOriented_),
+          funAtPhysRefCoords(funAtPhysRefCoords_),
+          elemOrts(elemOrts_),
+          basis(basis_){}
+
+    //check that fun values are consistent at the common vertices
+    void test(ordinal_type& errorFlag, ValueType tol){
+
+      auto numVertexDOFs = basis->getDofCount(0,0);
+      if(numVertexDOFs >0) {
+        bool areDifferent(false);
+
+
+        for(ordinal_type j=0;j<numSharedVertices && !areDifferent;j++)
+          areDifferent = std::abs(basisCoeffs(0,basis->getDofOrdinal(0,shared_vertices[0][j],0))
+              - basisCoeffs(1,basis->getDofOrdinal(0,shared_vertices[1][j],0))) > 10*tol;
+
+        if(areDifferent) {
+          errorFlag++;
+          *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+          *outStream << "Function  DOFs on shared vertices computed using Cell 0 basis functions are not consistent with those computed using Cell 1 bssis functions\n";
+          *outStream << "Function DOFs for Cell 0 are:";
+          for(ordinal_type j=0;j<numSharedVertices;j++)
+            *outStream << " " << basisCoeffs(0,basis->getDofOrdinal(0,shared_vertices[0][j],0));
+          *outStream << "\nFunction DOFs for Cell 1 are:";
+          for(ordinal_type j=0;j<numSharedVertices;j++)
+            *outStream << " " << basisCoeffs(1,basis->getDofOrdinal(0,shared_vertices[1][j],0));
+          *outStream << std::endl;
+        }
+
+      }
+
+
+      //check that fun values are consistent on shared edges dofs
+      auto numEdgeDOFs = basis->getDofCount(1,0);
+      if(numEdgeDOFs>0)
+      {
+
+        bool areDifferent(false);
+        for(std::size_t iEdge=0;iEdge<numSharedEdges;iEdge++) {
+        for(ordinal_type j=0;j<numEdgeDOFs && !areDifferent;j++) {
+          areDifferent = std::abs(basisCoeffs(0,basis->getDofOrdinal(1,edgeIndices[0][iEdge],j))
+              - basisCoeffs(1,basis->getDofOrdinal(1,edgeIndices[1][iEdge],j))) > 10*tol;
+        }
+        if(areDifferent) {
+          errorFlag++;
+          *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+          *outStream << "Function DOFs on shared edge " << iEdge << " computed using Cell 0 basis functions are not consistent with those computed using Cell 1 basis functions\n";
+          *outStream << "Function DOFs for Cell 0 are:";
+          for(ordinal_type j=0;j<numEdgeDOFs;j++)
+            *outStream << " " << basisCoeffs(0,basis->getDofOrdinal(1,edgeIndices[0][iEdge],j));
+          *outStream << "\nFunction DOFs for Cell 1 are:";
+          for(ordinal_type j=0;j<numEdgeDOFs;j++)
+            *outStream << " " << basisCoeffs(1,basis->getDofOrdinal(1,edgeIndices[1][iEdge],j));
+          *outStream << std::endl;
+        }
+        }
+      }
+
+
+      //check that fun values are consistent on common face dofs
+      auto numFaceDOFs = basis->getDofCount(2,0);
+      if(numFaceDOFs > 0 && dim>2)
+      {
+        bool areDifferent(false);
+        for(ordinal_type j=0;j<numFaceDOFs && !areDifferent;j++) {
+          areDifferent = std::abs(basisCoeffs(0,basis->getDofOrdinal(2,faceIndex[0],j))
+              - basisCoeffs(1,basis->getDofOrdinal(2,faceIndex[1],j))) > 100*tol;
+        }
+
+        if(areDifferent) {
+          errorFlag++;
+          *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+          *outStream << "Function DOFs on common face computed using Hex 0 basis functions are not consistent with those computed using Hex 1\n";
+          *outStream << "Function DOFs for Hex 0 are:";
+          for(ordinal_type j=0;j<numFaceDOFs;j++)
+            *outStream << " " << basisCoeffs(0,basis->getDofOrdinal(2,faceIndex[0],j));
+          *outStream << "\nFunction DOFs for Hex 1 are:";
+          for(ordinal_type j=0;j<numFaceDOFs;j++)
+            *outStream << " " << basisCoeffs(1,basis->getDofOrdinal(2,faceIndex[1],j));
+          *outStream << std::endl;
+        }
+      }
+
+      ordinal_type numRefCoords = funAtPhysRefCoords.extent(1);
+      ordinal_type basisCardinality = basisCoeffs.extent(1);
+      INTREPID2_TEST_FOR_EXCEPTION(numRefCoords < basisCardinality, std::invalid_argument, "numRefCoords must be at least as large as basisCardinality");
+      ordinal_type basis_dim = (transformedBasisValuesAtRefCoordsOriented.rank()==3) ? 1 : dim;
+
+      DynRankView ConstructWithLabel(funAtRefCoordsOriented, numCells, numRefCoords, basis_dim);
+      for(ordinal_type ic=0; ic<numCells; ++ic) {
+        ValueType error=0;
+        for(ordinal_type j=0; j<numRefCoords; ++j) {
+          if (basis_dim==1) {
+            for(ordinal_type k=0; k<basisCardinality; ++k)
+              funAtRefCoordsOriented(ic,j,0) += basisCoeffs(ic,k)*transformedBasisValuesAtRefCoordsOriented(ic,k,j);
+            error = std::max(std::abs( funAtPhysRefCoords(ic,j) - funAtRefCoordsOriented(ic,j,0)), error);
+          } else {
+            for(ordinal_type d=0; d<basis_dim; ++d) {
+              for(ordinal_type k=0; k<basisCardinality; ++k)
+                funAtRefCoordsOriented(ic,j,d) += basisCoeffs(ic,k)*transformedBasisValuesAtRefCoordsOriented(ic,k,j,d);
+              error = std::max(std::abs( funAtPhysRefCoords(ic,j,d) - funAtRefCoordsOriented(ic,j,d)), error);
+            }
+          }
+        }
+
+        if(error>100*tol) {
+          errorFlag++;
+          *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+          *outStream << "Function values at reference points differ from those computed using basis functions on Cell " << ic << "\n";
+          *outStream << "Function values at reference points are:\n";
+          for(ordinal_type j=0; j<numRefCoords; ++j) {
+            if(basis_dim==1)
+              *outStream << " (" << funAtPhysRefCoords(ic,j);
+            else
+              *outStream << " (" << funAtPhysRefCoords(ic,j,0);
+            for(ordinal_type d=1; d<basis_dim; d++)
+              *outStream <<  ", " << funAtPhysRefCoords(ic,j,d);
+            *outStream  << ")";
+          }
+          *outStream << "\nFunction values at reference points computed using basis functions are\n";
+          for(ordinal_type j=0; j<numRefCoords; ++j) {
+            *outStream << " (" << funAtRefCoordsOriented(ic,j,0);
+            for(ordinal_type d=1; d<basis_dim; d++)
+              *outStream <<  ", " << funAtRefCoordsOriented(ic,j,d);
+            *outStream  << ")";
+          }
+          *outStream << std::endl;
+        }
+      }
+      
+      // check that global (oriented) basis coefficients contracted with the transformed oriented basis values agrees with the transpose-oriented basis coefficients contracted with the unoriented transformed basis values
+      DynRankView ConstructWithLabel(localBasisCoeffs, numCells, basisCardinality);
+      OrientationTools<DeviceType>::modifyBasisByOrientationTranspose(localBasisCoeffs,
+                                                                      basisCoeffs,
+                                                                      elemOrts,
+                                                                      basis);
+      
+      DynRankView ConstructWithLabel(basisCoeffsModified, numCells, basisCardinality);
+      OrientationTools<DeviceType>::modifyBasisByOrientation(basisCoeffsModified,
+                                                             basisCoeffs,
+                                                             elemOrts,
+                                                             basis);
+      
+      
+      for(ordinal_type ic=0; ic<numCells; ++ic) {
+        ValueType error=0;
+        for(ordinal_type j=0; j<numRefCoords; ++j) {
+          for (int d=0; d<transformedBasisValuesAtRefCoords.extent_int(3); d++)
+          {
+            ValueType globalValue_d = 0; // oriented/global
+            ValueType localValue_d  = 0; // unoriented/local
+            for(ordinal_type k=0; k<basisCardinality; ++k)
+            {
+              auto orientedBasisValue = transformedBasisValuesAtRefCoordsOriented(ic,k,j,d);
+              auto basisValue         = transformedBasisValuesAtRefCoords        (ic,k,j,d);
+              
+              globalValue_d += basisCoeffs(ic,k)      * orientedBasisValue;
+              localValue_d  += localBasisCoeffs(ic,k) * basisValue;
+            }
+            error = std::max(std::abs( globalValue_d - localValue_d), error);
+          }
+        }
+
+        if(error>100*tol) {
+          errorFlag++;
+          *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+          *outStream << "global values do not agree with local on cell " << ic << "\n";
+        }
+      }
+    }
+  };
+
+
+  try {
+
+    const ordinal_type order = 3;
+    ordinal_type reorder[numTotalVertices] = {0,1,2,3,4,5,6};
+
+    do {
+      ordinal_type orderback[numTotalVertices];
+      for(ordinal_type i=0;i<numTotalVertices;++i) {
+        orderback[reorder[i]]=i;
+      }
+      ValueType vertices[numTotalVertices][dim];
+      ordinal_type pyrs[numCells][numElemVertices];
+      std::copy(&pyrs_orig[0][0], &pyrs_orig[0][0]+numCells*numElemVertices, &pyrs_rotated[0][0]);
+      for (ordinal_type rotationOrdinal=0; rotationOrdinal<4; ++rotationOrdinal) {
+        // rotations of the pyramid correspond to rotations of the bottom quadrilateral
+        // for now, we do not consider reflection symmetries
+        for (int vertexOrdinal=0; vertexOrdinal<4; vertexOrdinal++)
+        {
+          pyrs_rotated[0][vertexOrdinal] = pyrs_orig[0][(vertexOrdinal + rotationOrdinal) % 4];
+        }
+
+        for(ordinal_type i=0; i<numCells;++i)
+          for(ordinal_type j=0; j<numElemVertices;++j)
+            pyrs[i][j] = reorder[pyrs_rotated[i][j]];
+
+        for(ordinal_type i=0; i<numTotalVertices;++i)
+          for(ordinal_type d=0; d<dim;++d)
+            vertices[i][d] = vertices_orig[orderback[i]][d];
+
+        *outStream <<  "Considering Pyr 0: [ ";
+        for(ordinal_type j=0; j<numElemVertices;++j)
+          *outStream << pyrs[0][j] << " ";
+        *outStream << "] and Pyr 1: [ ";
+        for(ordinal_type j=0; j<numElemVertices;++j)
+          *outStream << pyrs[1][j] << " ";
+        *outStream << "]\n";
+
+        shards::CellTopology pyramid(shards::getCellTopologyData<shards::Pyramid<5> >());
+
+        //computing vertices coords
+        DynRankView ConstructWithLabel(physVertices, numCells, pyramid.getNodeCount(), dim);
+        for(ordinal_type i=0; i<numCells; ++i)
+          for(std::size_t j=0; j<pyramid.getNodeCount(); ++j)
+            for(ordinal_type k=0; k<dim; ++k)
+              physVertices(i,j,k) = vertices[pyrs[i][j]][k];
+
+
+
+        //computing common face and edges
+        {
+          faceType face={};
+          edgeType edge={};
+          //bool faceOrientation[numCells][4];
+          for(ordinal_type i=0; i<numCells; ++i) {
+            for (std::size_t iv=0; iv<pyramid.getNodeCount(); ++iv) {
+              auto vertex = pyrs_rotated[i][pyramid.getNodeMap(0,iv,0)];
+              for (std::size_t isv=0; isv<common_face.size(); ++isv)
+                if(common_face[isv] == vertex)
+                  shared_vertices[i][isv] = iv;
+            }
+            //compute faces' tangents
+            for (std::size_t is=0; is<pyramid.getSideCount(); ++is) {
+              for (std::size_t k=0; k<pyramid.getNodeCount(2,is); ++k)
+                face[k]= pyrs_rotated[i][pyramid.getNodeMap(2,is,k)];
+
+              //rotate and flip
+              auto minElPtr= std::min_element(face.begin(), face.end());
+              std::rotate(face.begin(),minElPtr,face.end());
+              if(face[3]<face[1]) {auto tmp=face[1]; face[1]=face[3]; face[3]=tmp;}
+
+              if(face == common_face) faceIndex[i]=is;
+            }
+            //compute edges' tangents
+            for (std::size_t ie=0; ie<pyramid.getEdgeCount(); ++ie) {
+              for (std::size_t k=0; k<pyramid.getNodeCount(1,ie); ++k)
+                edge[k]= pyrs_rotated[i][pyramid.getNodeMap(1,ie,k)];
+              std::sort(edge.begin(),edge.end());
+              auto it=common_edges.find(edge);
+              if(it !=common_edges.end()){
+                auto edge_lid = std::distance(common_edges.begin(),it);
+                edgeIndices[i][edge_lid]=ie;
+              }
+            }
+          }
+        }
+
+        using CG_HBasis = HierarchicalBasisFamily<DeviceType,ValueType,ValueType>;
+        std::vector<basisType*> basis_set;
+
+        //compute reference points: use a lattice
+        auto refPoints = getInputPointsView<double,DeviceType>(pyramid, order*3);
+        ordinal_type numRefCoords = refPoints.extent_int(0);
+        
+        // compute orientations for cells (one time computation)
+        DynRankViewInt elemNodes(&pyrs[0][0], numCells, numElemVertices);
+        Kokkos::DynRankView<Orientation,DeviceType> elemOrts("elemOrts", numCells);
+        ots::getOrientation(elemOrts, elemNodes, pyramid);
+
+        //Compute physical Dof Coordinates and Reference coordinates
+        DynRankView ConstructWithLabel(physRefCoords, numCells, numRefCoords, dim);
+        {
+          Basis_HGRAD_PYR_C1_FEM<DeviceType,ValueType,ValueType> pyramidLinearBasis; //used for computing physical coordinates
+          DynRankView ConstructWithLabel(pyramidLinearBasisValuesAtRefCoords, pyramid.getNodeCount(), numRefCoords);
+          pyramidLinearBasis.getValues(pyramidLinearBasisValuesAtRefCoords, refPoints);
+          for(ordinal_type i=0; i<numCells; ++i)
+            for(ordinal_type d=0; d<dim; ++d) {
+              for(ordinal_type j=0; j<numRefCoords; ++j)
+                for(std::size_t k=0; k<pyramid.getNodeCount(); ++k)
+                  physRefCoords(i,j,d) += vertices[pyrs[i][k]][d]*pyramidLinearBasisValuesAtRefCoords(k,j);
+            }
+        }
+
+
+        //HGRAD BASIS
+        {
+          Fun fun;
+          DynRankView ConstructWithLabel(funAtPhysRefCoords, numCells, numRefCoords);
+          for(ordinal_type i=0; i<numCells; ++i) {
+            for(ordinal_type j=0; j<numRefCoords; ++j)
+              funAtPhysRefCoords(i,j) = fun(physRefCoords(i,j,0), physRefCoords(i,j,1), physRefCoords(i,j,2));
+          }
+
+          basis_set.push_back(new typename  CG_HBasis::HGRAD_PYR(order));
+
+          for (auto basisPtr:basis_set) {
+            auto& basis = *basisPtr;
+            auto name = basis.getName();
+            *outStream << " " << name << std::endl;
+            ordinal_type basisCardinality = basis.getCardinality();
+
+            //check that fun values at reference points coincide with those computed using basis functions
+            DynRankView ConstructWithLabel(basisValuesAtRefCoordsOriented, numCells, basisCardinality, numRefCoords);
+            DynRankView ConstructWithLabel(transformedBasisValuesAtRefCoordsOriented, numCells, basisCardinality, numRefCoords);
+            DynRankView ConstructWithLabel(transformedBasisValuesAtRefCoords, numCells, basisCardinality, numRefCoords);
+
+            DynRankView ConstructWithLabel(basisValuesAtRefCoords, basisCardinality, numRefCoords);
+            basis.getValues(basisValuesAtRefCoords, refPoints);
+
+            // modify basis values to account for orientations
+            ots::modifyBasisByOrientation(basisValuesAtRefCoordsOriented,
+                basisValuesAtRefCoords,
+                elemOrts,
+                &basis);
+            
+            // transform basis values
+            fst::HGRADtransformVALUE(transformedBasisValuesAtRefCoords, basisValuesAtRefCoords);
+            deep_copy(transformedBasisValuesAtRefCoordsOriented,
+                basisValuesAtRefCoordsOriented);
+
+            DynRankView ConstructWithLabel(basisCoeffs, numCells, basisCardinality);
+
+            BasisFunctionsSystem  basisFunctionsSystem(basisCardinality, numRefCoords, 1);
+            auto info = basisFunctionsSystem.computeBasisCoeffs(basisCoeffs, errorFlag, transformedBasisValuesAtRefCoordsOriented, funAtPhysRefCoords);
+
+            for (int ic =0; ic < numCells; ++ic) {
+              if(info[ic] != 0) {
+                errorFlag++;
+                *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                *outStream << "LAPACK error flag for cell " << ic << " is: " << info[ic] << std::endl;
+              }
+            }
+
+            TestResults testResults(basisCoeffs, transformedBasisValuesAtRefCoords, transformedBasisValuesAtRefCoordsOriented, funAtPhysRefCoords, elemOrts, basisPtr);
+            testResults.test(errorFlag,tol);
+            delete basisPtr;
+          }
+        }
+
+
+        //HCURL Case
+        //TODO: uncomment after we implement H(curl) basis for pyramids
+        /*{
+          FunCurl fun;
+          DynRankView ConstructWithLabel(funAtPhysRefCoords, numCells, numRefCoords, dim);
+          for(ordinal_type i=0; i<numCells; ++i) {
+            for(ordinal_type j=0; j<numRefCoords; ++j) {
+              for(ordinal_type k=0; k<dim; ++k)
+                funAtPhysRefCoords(i,j,k) = fun(physRefCoords(i,j,0), physRefCoords(i,j,1), physRefCoords(i,j,2), k);
+            }
+          }
+
+          basis_set.clear();
+          basis_set.push_back(new typename  CG_HBasis::HCURL_PYR(order));
+
+          for (auto basisPtr:basis_set) {
+            auto& basis = *basisPtr;
+            auto name = basis.getName();
+            *outStream << " " << name << std::endl;
+
+            ordinal_type basisCardinality = basis.getCardinality();
+            DynRankView ConstructWithLabel(basisCoeffs, numCells, basisCardinality);
+
+            //check that fun values at reference points coincide with those computed using basis functions
+            DynRankView ConstructWithLabel(basisValuesAtRefCoordsOriented, numCells, basisCardinality, numRefCoords, dim);
+            DynRankView ConstructWithLabel(transformedBasisValuesAtRefCoordsOriented, numCells, basisCardinality, numRefCoords, dim);
+            DynRankView ConstructWithLabel(transformedBasisValuesAtRefCoords, numCells, basisCardinality, numRefCoords, dim);
+            DynRankView basisValuesAtRefCoordsCells("inValues", numCells, basisCardinality, numRefCoords, dim);
+
+
+            DynRankView ConstructWithLabel(basisValuesAtRefCoords, basisCardinality, numRefCoords, dim);
+            basis.getValues(basisValuesAtRefCoords, refPoints);
+            rst::clone(basisValuesAtRefCoordsCells,basisValuesAtRefCoords);
+
+            // modify basis values to account for orientations
+            ots::modifyBasisByOrientation(basisValuesAtRefCoordsOriented,
+                basisValuesAtRefCoordsCells,
+                elemOrts,
+                &basis);
+
+            // transform basis values
+            DynRankView ConstructWithLabel(jacobianAtRefCoords, numCells, numRefCoords, dim, dim);
+            DynRankView ConstructWithLabel(jacobianAtRefCoords_inv, numCells, numRefCoords, dim, dim);
+            ct::setJacobian(jacobianAtRefCoords, refPoints, physVertices, pyramid);
+            ct::setJacobianInv (jacobianAtRefCoords_inv, jacobianAtRefCoords);
+            fst::HCURLtransformVALUE(transformedBasisValuesAtRefCoordsOriented,
+                jacobianAtRefCoords_inv,
+                basisValuesAtRefCoordsOriented);
+            fst::HCURLtransformVALUE(transformedBasisValuesAtRefCoords,
+                jacobianAtRefCoords_inv,
+                basisValuesAtRefCoords);
+
+            BasisFunctionsSystem  basisFunctionsSystem(basisCardinality, numRefCoords, dim);
+            auto info = basisFunctionsSystem.computeBasisCoeffs(basisCoeffs, errorFlag, transformedBasisValuesAtRefCoordsOriented, funAtPhysRefCoords);
+
+            for (int ic =0; ic < numCells; ++ic) {
+              if(info[ic] != 0) {
+                errorFlag++;
+                *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                *outStream << "LAPACK error flag for cell " << ic << " is: " << info[ic] << std::endl;
+              }
+            }
+
+            TestResults testResults(basisCoeffs, transformedBasisValuesAtRefCoords, transformedBasisValuesAtRefCoordsOriented, funAtPhysRefCoords, elemOrts, basisPtr);
+            testResults.test(errorFlag,tol);
+            delete basisPtr;
+          }
+        }*/
+
+
+        //HDIV Case
+        //TODO: uncomment after we implement H(div) basis for pyramids
+        /*{
+          FunDiv fun;
+          DynRankView ConstructWithLabel(funAtPhysRefCoords, numCells, numRefCoords, dim);
+          for(ordinal_type i=0; i<numCells; ++i) {
+            for(ordinal_type j=0; j<numRefCoords; ++j) {
+              for(ordinal_type k=0; k<dim; ++k)
+                funAtPhysRefCoords(i,j,k) = fun(physRefCoords(i,j,0), physRefCoords(i,j,1), physRefCoords(i,j,2), k);
+            }
+          }
+          basis_set.clear();
+          basis_set.push_back(new typename  CG_HBasis::HDIV_PYR(order));
+
+          for (auto basisPtr:basis_set) {
+            auto& basis = *basisPtr;
+            auto name = basis.getName();
+            *outStream << " " << name << std::endl;
+            ordinal_type basisCardinality = basis.getCardinality();
+
+            //check that fun values at reference points coincide with those computed using basis functions
+            DynRankView ConstructWithLabel(basisValuesAtRefCoordsOriented, numCells, basisCardinality, numRefCoords, dim);
+            DynRankView ConstructWithLabel(transformedBasisValuesAtRefCoordsOriented, numCells, basisCardinality, numRefCoords, dim);
+            DynRankView ConstructWithLabel(transformedBasisValuesAtRefCoords, numCells, basisCardinality, numRefCoords, dim);
+            DynRankView basisValuesAtRefCoordsCells("inValues", numCells, basisCardinality, numRefCoords, dim);
+
+            DynRankView ConstructWithLabel(basisValuesAtRefCoords, basisCardinality, numRefCoords, dim);
+            basis.getValues(basisValuesAtRefCoords, refPoints);
+            rst::clone(basisValuesAtRefCoordsCells,basisValuesAtRefCoords);
+
+            // modify basis values to account for orientations
+            ots::modifyBasisByOrientation(basisValuesAtRefCoordsOriented,
+                basisValuesAtRefCoordsCells,
+                elemOrts,
+                &basis);
+
+            // transform basis values
+            DynRankView ConstructWithLabel(jacobianAtRefCoords, numCells, numRefCoords, dim, dim);
+            DynRankView ConstructWithLabel(jacobianAtRefCoords_det, numCells, numRefCoords);
+            ct::setJacobian(jacobianAtRefCoords, refPoints, physVertices, pyramid);
+            ct::setJacobianDet (jacobianAtRefCoords_det, jacobianAtRefCoords);
+            fst::HDIVtransformVALUE(transformedBasisValuesAtRefCoordsOriented,
+                jacobianAtRefCoords,
+                jacobianAtRefCoords_det,
+                basisValuesAtRefCoordsOriented);
+            fst::HDIVtransformVALUE(transformedBasisValuesAtRefCoords,
+                jacobianAtRefCoords,
+                jacobianAtRefCoords_det,
+                basisValuesAtRefCoords);
+
+            DynRankView ConstructWithLabel(basisCoeffs, numCells, basisCardinality);
+
+
+            BasisFunctionsSystem  basisFunctionsSystem(basisCardinality, numRefCoords, dim);
+            auto info = basisFunctionsSystem.computeBasisCoeffs(basisCoeffs, errorFlag, transformedBasisValuesAtRefCoordsOriented, funAtPhysRefCoords);
+
+            for (int ic =0; ic < numCells; ++ic) {
+              if(info[ic] != 0) {
+                errorFlag++;
+                *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                *outStream << "LAPACK error flag for cell " << ic << " is: " << info[ic] << std::endl;
+              }
+            }
+
+            TestResults testResults(basisCoeffs, transformedBasisValuesAtRefCoords, transformedBasisValuesAtRefCoordsOriented, funAtPhysRefCoords, elemOrts, basisPtr);
+            testResults.test(errorFlag,tol);
+            delete basisPtr;
+          }
+        }*/
+      } //rotation of first cell vertices
+    } while(std::next_permutation(&reorder[0]+2, &reorder[0]+5)); //reorder vertices of common face
+
+  } catch (std::exception &err) {
+    std::cout << " Exeption\n";
+    *outStream << err.what() << "\n\n";
+    errorFlag = -1000;
+  }
+
+
+  if (errorFlag != 0)
+    std::cout << "End Result: TEST FAILED = " << errorFlag << "\n";
+  else
+    std::cout << "End Result: TEST PASSED\n";
+
+  // reset format state of std::cout
+  std::cout.copyfmt(oldFormatState);
+
+  return errorFlag;
+}
+}
+}
+


### PR DESCRIPTION
@trilinos/intrepid2 

## Motivation
This PR adds an arbitrary-order, hierarchical basis for H(vol) on the pyramid.  This follows #12079, which added hierarchical bases for H(grad) on the pyramid.

Additionally, this PR adds "sub-basis inclusion" tests for both H(vol) and H(grad) on the pyramid, and orientation tests against H(grad) on the pyramid.

## Testing
This PR includes "sub-basis inclusion" tests for both H(vol) and H(grad) on the pyramid, and orientation tests against H(grad) on the pyramid.  It also adds a simple basis cardinality test for the new H(vol) basis.

Additionally, I have done offline comparison with the ESEAS implementation of this basis, testing up to 10th order, with excellent agreement.  I hope to include these tests with Intrepid2 soon; this has been prevented previously by the license for ESEAS, but they are changing the license to one that will allow inclusion.