### PR TITLE
Kokkos-Kernels: cherry pick of fixes needed for Ifpack2 MDF

### DIFF
--- a/packages/kokkos-kernels/sparse/impl/KokkosSparse_mdf_impl.hpp
+++ b/packages/kokkos-kernels/sparse/impl/KokkosSparse_mdf_impl.hpp
@@ -18,6 +18,9 @@
 #define KOKKOSSPARSE_MDF_IMPL_HPP_
 
 #include <Kokkos_Core.hpp>
+#include <Kokkos_UnorderedMap.hpp>
+#include "KokkosKernels_Sorting.hpp"
+#include "KokkosSparse_findRelOffset.hpp"
 #include <type_traits>
 #include "Kokkos_ArithTraits.hpp"
 
@@ -40,31 +43,45 @@ struct MDF_count_lower {
       entries_type::non_const_type;
   using size_type  = typename crs_matrix_type::ordinal_type;
   using value_type = typename crs_matrix_type::size_type;
+  using KAV        = typename Kokkos::ArithTraits<value_type>;
 
   crs_matrix_type A;
   col_ind_type permutation;
   col_ind_type permutation_inv;
+
+  using execution_space = typename crs_matrix_type::execution_space;
+  using team_policy_t   = Kokkos::TeamPolicy<execution_space>;
+  using team_member_t   = typename team_policy_t::member_type;
 
   MDF_count_lower(crs_matrix_type A_, col_ind_type permutation_,
                   col_ind_type permutation_inv_)
       : A(A_), permutation(permutation_), permutation_inv(permutation_inv_){};
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(const size_type rowIdx, value_type& update) const {
-    permutation(rowIdx)     = rowIdx;
-    permutation_inv(rowIdx) = rowIdx;
-    for (value_type entryIdx = A.graph.row_map(rowIdx);
-         entryIdx < A.graph.row_map(rowIdx + 1); ++entryIdx) {
-      if (A.graph.entries(entryIdx) <= rowIdx) {
-        update += 1;
-      }
-    }
-  }
+  void operator()(const team_member_t team, value_type& update) const {
+    const auto rowIdx  = team.league_rank();
+    const auto rowView = A.graph.rowConst(rowIdx);
 
+    value_type local_contrib = KAV::zero();
+    Kokkos::parallel_reduce(
+        Kokkos::TeamThreadRange(team, rowView.length),
+        [&](const size_type entryIdx, value_type& partial) {
+          if (rowView(entryIdx) <= rowIdx) partial += 1;
+        },
+        Kokkos::Sum<value_type, execution_space>(local_contrib));
+
+    Kokkos::single(Kokkos::PerTeam(team), [&] {
+      permutation(rowIdx)     = rowIdx;
+      permutation_inv(rowIdx) = rowIdx;
+      update += local_contrib;
+    });
+  }
 };  // MDF_count_lower
 
-template <class crs_matrix_type>
+template <class crs_matrix_type, bool is_initial_fill>
 struct MDF_discarded_fill_norm {
+  using device_type = typename crs_matrix_type::device_type;
+
   using static_crs_graph_type = typename crs_matrix_type::StaticCrsGraphType;
   using col_ind_type =
       typename static_crs_graph_type::entries_type::non_const_type;
@@ -76,10 +93,14 @@ struct MDF_discarded_fill_norm {
   using KAS             = typename Kokkos::ArithTraits<scalar_type>;
   using scalar_mag_type = typename KAS::mag_type;
   using KAM             = typename Kokkos::ArithTraits<scalar_mag_type>;
+  using permutation_set_type =
+      Kokkos::UnorderedMap<ordinal_type, void, device_type>;
 
   crs_matrix_type A, At;
   ordinal_type factorization_step;
   col_ind_type permutation;
+  permutation_set_type permutation_set;
+  col_ind_type update_list;
 
   values_mag_type discarded_fill;
   col_ind_type deficiency;
@@ -88,240 +109,146 @@ struct MDF_discarded_fill_norm {
   MDF_discarded_fill_norm(crs_matrix_type A_, crs_matrix_type At_,
                           ordinal_type factorization_step_,
                           col_ind_type permutation_,
+                          permutation_set_type permutation_set_,
                           values_mag_type discarded_fill_,
-                          col_ind_type deficiency_, int verbosity_)
+                          col_ind_type deficiency_, int verbosity_,
+                          col_ind_type update_list_ = col_ind_type{})
       : A(A_),
         At(At_),
         factorization_step(factorization_step_),
         permutation(permutation_),
-        discarded_fill(discarded_fill_),
-        deficiency(deficiency_),
-        verbosity(verbosity_){};
-
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const ordinal_type i) const {
-    ordinal_type rowIdx          = permutation(i);
-    scalar_mag_type discard_norm = KAM::zero();
-    scalar_type diag_val         = KAS::zero();
-    bool entryIsDiscarded        = true;
-    ordinal_type numFillEntries  = 0;
-    for (size_type alphaIdx = At.graph.row_map(rowIdx);
-         alphaIdx < At.graph.row_map(rowIdx + 1); ++alphaIdx) {
-      ordinal_type fillRowIdx = At.graph.entries(alphaIdx);
-      bool row_not_eliminated = true;
-      for (ordinal_type stepIdx = 0; stepIdx < factorization_step; ++stepIdx) {
-        if (fillRowIdx == permutation(stepIdx)) {
-          row_not_eliminated = false;
-        }
-      }
-
-      if (fillRowIdx != rowIdx && row_not_eliminated) {
-        for (size_type betaIdx = A.graph.row_map(rowIdx);
-             betaIdx < A.graph.row_map(rowIdx + 1); ++betaIdx) {
-          ordinal_type fillColIdx = A.graph.entries(betaIdx);
-          bool col_not_eliminated = true;
-          for (ordinal_type stepIdx = 0; stepIdx < factorization_step;
-               ++stepIdx) {
-            if (fillColIdx == permutation(stepIdx)) {
-              col_not_eliminated = false;
-            }
-          }
-
-          if (fillColIdx != rowIdx && col_not_eliminated) {
-            entryIsDiscarded = true;
-            for (size_type entryIdx = A.graph.row_map(fillRowIdx);
-                 entryIdx < A.graph.row_map(fillRowIdx + 1); ++entryIdx) {
-              if (A.graph.entries(entryIdx) == fillColIdx) {
-                entryIsDiscarded = false;
-              }
-            }
-            if (entryIsDiscarded) {
-              numFillEntries += 1;
-              discard_norm +=
-                  KAS::abs(At.values(alphaIdx) * A.values(betaIdx)) *
-                  KAS::abs(At.values(alphaIdx) * A.values(betaIdx));
-              if (verbosity > 1) {
-                if constexpr (std::is_arithmetic_v<scalar_mag_type>) {
-                  KOKKOS_IMPL_DO_NOT_USE_PRINTF(
-                      "Adding value A[%d,%d]=%f to discard norm of row %d\n",
-                      int(At.graph.entries(alphaIdx)),
-                      int(A.graph.entries(betaIdx)),
-                      KAS::abs(At.values(alphaIdx) * A.values(betaIdx)) *
-                          KAS::abs(At.values(alphaIdx) * A.values(betaIdx)),
-                      int(rowIdx));
-                }
-              }
-            }
-          }
-        }
-      } else if (fillRowIdx == rowIdx) {
-        diag_val = At.values(alphaIdx);
-        if (verbosity > 1) {
-          if constexpr (std::is_arithmetic_v<scalar_type>) {
-            KOKKOS_IMPL_DO_NOT_USE_PRINTF(
-                "Row %d diagonal value detected, values(%d)=%f\n", int(rowIdx),
-                int(alphaIdx), At.values(alphaIdx));
-          } else if constexpr (std::is_arithmetic_v<scalar_mag_type>) {
-            KOKKOS_IMPL_DO_NOT_USE_PRINTF(
-                "Row %d diagonal value detected, |values(%d)|=%f\n",
-                int(rowIdx), int(alphaIdx), KAS::abs(At.values(alphaIdx)));
-          }
-        }
-      }
-    }
-
-    // TODO add a check on `diag_val == zero`
-    discard_norm           = discard_norm / KAS::abs(diag_val * diag_val);
-    discarded_fill(rowIdx) = discard_norm;
-    deficiency(rowIdx)     = numFillEntries;
-
-    if constexpr (std::is_arithmetic_v<scalar_mag_type>) {
-      if (verbosity > 0) {
-        const ordinal_type degree = ordinal_type(A.graph.row_map(rowIdx + 1) -
-                                                 A.graph.row_map(rowIdx) - 1);
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF(
-            "Row %d has discarded fill of %f, deficiency of %d and degree %d\n",
-            static_cast<int>(rowIdx),
-            static_cast<double>(KAM::sqrt(discard_norm)),
-            static_cast<int>(deficiency(rowIdx)), static_cast<int>(degree));
-      }
-    }
-  }
-
-};  // MDF_discarded_fill_norm
-
-template <class crs_matrix_type>
-struct MDF_selective_discarded_fill_norm {
-  using static_crs_graph_type = typename crs_matrix_type::StaticCrsGraphType;
-  using col_ind_type =
-      typename static_crs_graph_type::entries_type::non_const_type;
-  using values_type     = typename crs_matrix_type::values_type::non_const_type;
-  using size_type       = typename crs_matrix_type::size_type;
-  using ordinal_type    = typename crs_matrix_type::ordinal_type;
-  using scalar_type     = typename crs_matrix_type::value_type;
-  using KAS             = typename Kokkos::ArithTraits<scalar_type>;
-  using scalar_mag_type = typename KAS::mag_type;
-  using KAM             = typename Kokkos::ArithTraits<scalar_mag_type>;
-  using values_mag_type = typename MDF_types<crs_matrix_type>::values_mag_type;
-
-  crs_matrix_type A, At;
-  ordinal_type factorization_step;
-  col_ind_type permutation;
-  col_ind_type update_list;
-
-  values_mag_type discarded_fill;
-  col_ind_type deficiency;
-  int verbosity;
-
-  MDF_selective_discarded_fill_norm(crs_matrix_type A_, crs_matrix_type At_,
-                                    ordinal_type factorization_step_,
-                                    col_ind_type permutation_,
-                                    col_ind_type update_list_,
-                                    values_mag_type discarded_fill_,
-                                    col_ind_type deficiency_, int verbosity_)
-      : A(A_),
-        At(At_),
-        factorization_step(factorization_step_),
-        permutation(permutation_),
+        permutation_set(permutation_set_),
         update_list(update_list_),
         discarded_fill(discarded_fill_),
         deficiency(deficiency_),
         verbosity(verbosity_){};
 
+  using execution_space = typename crs_matrix_type::execution_space;
+  using team_policy_t   = Kokkos::TeamPolicy<execution_space>;
+  using team_member_t   = typename team_policy_t::member_type;
+
+  struct DiscNormReducer {
+    using reducer = DiscNormReducer;
+    struct value_type {
+      scalar_mag_type discarded_norm;
+      ordinal_type numFillEntries;
+      scalar_type diag_val;
+    };
+    using result_view_type = Kokkos::View<value_type, execution_space>;
+
+   private:
+    result_view_type value;
+
+   public:
+    KOKKOS_INLINE_FUNCTION
+    DiscNormReducer(value_type& value_) : value(&value_) {}
+
+    KOKKOS_INLINE_FUNCTION
+    static void join(value_type& dest, const value_type& src) {
+      dest.discarded_norm += src.discarded_norm;
+      dest.numFillEntries += src.numFillEntries;
+      if (dest.diag_val == KAS::zero()) dest.diag_val = src.diag_val;
+    }
+
+    KOKKOS_INLINE_FUNCTION
+    static void init(value_type& val) {
+      val.discarded_norm = Kokkos::reduction_identity<scalar_mag_type>::sum();
+      val.numFillEntries = Kokkos::reduction_identity<ordinal_type>::sum();
+      val.diag_val       = KAS::zero();
+    }
+
+    KOKKOS_INLINE_FUNCTION
+    static value_type init() {
+      value_type out;
+      init(out);
+      return out;
+    }
+
+    KOKKOS_INLINE_FUNCTION
+    value_type& reference() const { return *value.data(); }
+
+    KOKKOS_INLINE_FUNCTION
+    result_view_type view() const { return value; }
+  };
+
   KOKKOS_INLINE_FUNCTION
-  void operator()(const ordinal_type i) const {
-    ordinal_type rowIdx          = permutation(update_list(i));
-    scalar_mag_type discard_norm = KAM::zero();
-    scalar_type diag_val         = KAS::zero();
-    bool entryIsDiscarded        = true;
-    ordinal_type numFillEntries  = 0;
-    for (size_type alphaIdx = At.graph.row_map(rowIdx);
-         alphaIdx < At.graph.row_map(rowIdx + 1); ++alphaIdx) {
-      ordinal_type fillRowIdx = At.graph.entries(alphaIdx);
-      bool row_not_eliminated = true;
-      for (ordinal_type stepIdx = 0; stepIdx < factorization_step; ++stepIdx) {
-        if (fillRowIdx == permutation(stepIdx)) {
-          row_not_eliminated = false;
-        }
-      }
+  void operator()(team_member_t team) const {
+    const ordinal_type rowIdx =
+        is_initial_fill ? permutation(team.league_rank())
+                        : permutation(update_list(team.league_rank()));
+    const auto colView = At.rowConst(rowIdx);
+    const auto rowView = A.rowConst(rowIdx);
 
-      if (fillRowIdx != rowIdx && row_not_eliminated) {
-        for (size_type betaIdx = A.graph.row_map(rowIdx);
-             betaIdx < A.graph.row_map(rowIdx + 1); ++betaIdx) {
-          ordinal_type fillColIdx = A.graph.entries(betaIdx);
-          bool col_not_eliminated = true;
-          for (ordinal_type stepIdx = 0; stepIdx < factorization_step;
-               ++stepIdx) {
-            if (fillColIdx == permutation(stepIdx)) {
-              col_not_eliminated = false;
-            }
+    using reduction_val_t         = typename DiscNormReducer::value_type;
+    reduction_val_t reduction_val = DiscNormReducer::init();
+    Kokkos::parallel_reduce(
+        Kokkos::TeamThreadRange(team, colView.length),
+        [&](const size_type alpha, reduction_val_t& running_disc_norm) {
+          const ordinal_type fillRowIdx = colView.colidx(alpha);
+
+          // Record diagonal term
+          if (fillRowIdx == rowIdx) {
+            Kokkos::single(Kokkos::PerThread(team), [&] {
+              running_disc_norm.diag_val = colView.value(alpha);
+            });
+            return;
           }
 
-          if (fillColIdx != rowIdx && col_not_eliminated) {
-            entryIsDiscarded = true;
-            for (size_type entryIdx = A.graph.row_map(fillRowIdx);
-                 entryIdx < A.graph.row_map(fillRowIdx + 1); ++entryIdx) {
-              if (A.graph.entries(entryIdx) == fillColIdx) {
-                entryIsDiscarded = false;
-              }
-            }
-            if (entryIsDiscarded) {
-              numFillEntries += 1;
-              discard_norm +=
-                  KAS::abs(At.values(alphaIdx) * A.values(betaIdx)) *
-                  KAS::abs(At.values(alphaIdx) * A.values(betaIdx));
-              if (verbosity > 1) {
-                if constexpr (std::is_arithmetic_v<scalar_mag_type>) {
-                  KOKKOS_IMPL_DO_NOT_USE_PRINTF(
-                      "Adding value A[%d,%d]=%f to discard norm of row %d\n",
-                      static_cast<int>(At.graph.entries(alphaIdx)),
-                      static_cast<int>(A.graph.entries(betaIdx)),
-                      static_cast<double>(
-                          KAS::abs(At.values(alphaIdx) * A.values(betaIdx)) *
-                          KAS::abs(At.values(alphaIdx) * A.values(betaIdx))),
-                      static_cast<int>(rowIdx));
+          // Check if row already eliminated
+          if constexpr (!is_initial_fill) {
+            if (permutation_set.exists(fillRowIdx)) return;
+          }
+
+          const auto fillRowView              = A.rowConst(fillRowIdx);
+          reduction_val_t local_reduction_val = DiscNormReducer::init();
+          Kokkos::parallel_reduce(
+              Kokkos::ThreadVectorRange(team, rowView.length),
+              [&](const ordinal_type beta,
+                  reduction_val_t& vect_running_disc_norm) {
+                const ordinal_type fillColIdx = rowView.colidx(beta);
+
+                if (fillColIdx == rowIdx) return;
+
+                if constexpr (!is_initial_fill) {
+                  if (permutation_set.exists(fillColIdx)) return;
                 }
-              }
-            }
-          }
-        }
-      } else if (fillRowIdx == rowIdx) {
-        diag_val = At.values(alphaIdx);
-        if (verbosity > 1) {
-          if constexpr (std::is_arithmetic_v<scalar_type>) {
-            KOKKOS_IMPL_DO_NOT_USE_PRINTF(
-                "Row %d diagonal value dected, values(%d)=%f\n",
-                static_cast<int>(rowIdx), static_cast<int>(alphaIdx),
-                static_cast<double>(At.values(alphaIdx)));
-          } else if constexpr (std::is_arithmetic_v<scalar_mag_type>) {
-            KOKKOS_IMPL_DO_NOT_USE_PRINTF(
-                "Row %d diagonal value dected, |values(%d)|=%f\n",
-                static_cast<int>(rowIdx), static_cast<int>(alphaIdx),
-                static_cast<double>(KAS::abs(At.values(alphaIdx))));
-          }
-        }
-      }
-    }
 
-    // TODO add a check on `diag_val == zero`
-    discard_norm           = discard_norm / KAS::abs(diag_val * diag_val);
-    discarded_fill(rowIdx) = discard_norm;
-    deficiency(rowIdx)     = numFillEntries;
+                bool entryIsDiscarded = true;
+                for (ordinal_type gamma = 0; gamma < fillRowView.length;
+                     ++gamma) {
+                  if (fillRowView.colidx(gamma) == fillColIdx) {
+                    entryIsDiscarded = false;
+                  }
+                }
+                if (entryIsDiscarded) {
+                  vect_running_disc_norm.numFillEntries += 1;
+                  vect_running_disc_norm.discarded_norm +=
+                      KAS::abs(colView.value(alpha) * rowView.value(beta)) *
+                      KAS::abs(colView.value(alpha) * rowView.value(beta));
+                }
+              },
+              DiscNormReducer(local_reduction_val));
 
-    if constexpr (std::is_arithmetic_v<scalar_mag_type>) {
-      if (verbosity > 0) {
-        const ordinal_type degree = ordinal_type(A.graph.row_map(rowIdx + 1) -
-                                                 A.graph.row_map(rowIdx) - 1);
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF(
-            "Row %d has discarded fill of %f, deficiency of %d and degree %d\n",
-            static_cast<int>(rowIdx),
-            static_cast<double>(KAM::sqrt(discard_norm)),
-            static_cast<int>(deficiency(rowIdx)), static_cast<int>(degree));
-      }
-    }
+          Kokkos::single(Kokkos::PerThread(team), [&] {
+            running_disc_norm.discarded_norm +=
+                local_reduction_val.discarded_norm;
+            running_disc_norm.numFillEntries +=
+                local_reduction_val.numFillEntries;
+          });
+        },
+        DiscNormReducer(reduction_val));
+
+    Kokkos::single(Kokkos::PerTeam(team), [&] {
+      const scalar_mag_type& discard_norm = reduction_val.discarded_norm;
+      const ordinal_type& numFillEntries  = reduction_val.numFillEntries;
+      const scalar_type& diag_val         = reduction_val.diag_val;
+
+      // TODO add a check on `diag_val == zero`
+      discarded_fill(rowIdx) = discard_norm / KAS::abs(diag_val * diag_val);
+      deficiency(rowIdx)     = numFillEntries;
+    });
   }
-
-};  // MDF_selective_discarded_fill_norm
+};  // MDF_discarded_fill_norm
 
 template <class crs_matrix_type>
 struct MDF_select_row {
@@ -429,14 +356,25 @@ struct MDF_select_row {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void init(value_type& dst) const {
-    dst = Kokkos::ArithTraits<ordinal_type>::zero();
-  }
+  void init(value_type& dst) const { dst = factorization_step; }
 
 };  // MDF_select_row
 
+template <class view_type, class ordinal_type>
+KOKKOS_INLINE_FUNCTION bool sorted_view_contains(
+    const view_type& values, const ordinal_type size,
+    typename view_type::const_value_type search_val) {
+  return KokkosSparse::findRelOffset(values, size, search_val, size, true) !=
+         size;
+}
+
 template <class crs_matrix_type>
 struct MDF_factorize_row {
+  using device_type     = typename crs_matrix_type::device_type;
+  using execution_space = typename crs_matrix_type::execution_space;
+  using team_policy_t   = Kokkos::TeamPolicy<execution_space>;
+  using team_member_t   = typename team_policy_t::member_type;
+
   using row_map_type = typename crs_matrix_type::StaticCrsGraphType::
       row_map_type::non_const_type;
   using col_ind_type = typename crs_matrix_type::StaticCrsGraphType::
@@ -447,6 +385,8 @@ struct MDF_factorize_row {
   using value_type      = typename crs_matrix_type::value_type;
   using values_mag_type = typename MDF_types<crs_matrix_type>::values_mag_type;
   using value_mag_type  = typename values_mag_type::value_type;
+  using permutation_set_type =
+      Kokkos::UnorderedMap<ordinal_type, void, device_type>;
 
   crs_matrix_type A, At;
 
@@ -459,9 +399,12 @@ struct MDF_factorize_row {
   values_type valuesU;
 
   col_ind_type permutation, permutation_inv;
+  permutation_set_type permutation_set;
   values_mag_type discarded_fill;
   col_ind_type factored;
   ordinal_type selected_row_idx, factorization_step;
+
+  col_ind_type update_list;
 
   int verbosity;
 
@@ -470,9 +413,11 @@ struct MDF_factorize_row {
                     values_type valuesL_, row_map_type row_mapU_,
                     col_ind_type entriesU_, values_type valuesU_,
                     col_ind_type permutation_, col_ind_type permutation_inv_,
+                    permutation_set_type permutation_set_,
                     values_mag_type discarded_fill_, col_ind_type factored_,
                     ordinal_type selected_row_idx_,
-                    ordinal_type factorization_step_, int verbosity_)
+                    ordinal_type factorization_step_,
+                    col_ind_type& update_list_, int verbosity_)
       : A(A_),
         At(At_),
         row_mapL(row_mapL_),
@@ -483,277 +428,306 @@ struct MDF_factorize_row {
         valuesU(valuesU_),
         permutation(permutation_),
         permutation_inv(permutation_inv_),
+        permutation_set(permutation_set_),
         discarded_fill(discarded_fill_),
         factored(factored_),
         selected_row_idx(selected_row_idx_),
         factorization_step(factorization_step_),
+        update_list(update_list_),
         verbosity(verbosity_){};
 
+  // Phase 2, do facrotization
   KOKKOS_INLINE_FUNCTION
-  void operator()(const ordinal_type /* idx */) const {
-    const ordinal_type selected_row = permutation(selected_row_idx);
-    discarded_fill(selected_row) = Kokkos::ArithTraits<value_mag_type>::max();
+  void operator()(team_member_t team) const {
+    const auto alpha                = team.league_rank();
+    const ordinal_type selected_row = permutation(factorization_step);
+    const auto colView              = At.rowConst(selected_row);
 
-    // Swap entries in permutation vectors
-    permutation(selected_row_idx)   = permutation(factorization_step);
-    permutation(factorization_step) = selected_row;
-    permutation_inv(permutation(factorization_step)) = factorization_step;
-    permutation_inv(permutation(selected_row_idx))   = selected_row_idx;
+    const auto rowInd = colView.colidx(alpha);
+    if (rowInd == selected_row) return;
 
-    if (verbosity > 0) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("Permutation vector: { ");
-      for (ordinal_type rowIdx = 0; rowIdx < A.numRows(); ++rowIdx) {
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF("%d ",
-                                      static_cast<int>(permutation(rowIdx)));
-      }
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("}\n");
-    }
+    if (permutation_set.exists(rowInd)) return;
 
-    // Insert the upper part of the selected row in U
-    // including the diagonal term.
-    value_type diag      = Kokkos::ArithTraits<value_type>::zero();
-    size_type U_entryIdx = row_mapU(factorization_step);
-    for (size_type entryIdx = A.graph.row_map(selected_row);
-         entryIdx < A.graph.row_map(selected_row + 1); ++entryIdx) {
-      if (permutation_inv(A.graph.entries(entryIdx)) >= factorization_step) {
-        entriesU(U_entryIdx) = A.graph.entries(entryIdx);
-        valuesU(U_entryIdx)  = A.values(entryIdx);
-        ++U_entryIdx;
-        if (A.graph.entries(entryIdx) == selected_row) {
-          diag = A.values(entryIdx);
-        }
-      }
-    }
-    row_mapU(factorization_step + 1) = U_entryIdx;
-    if constexpr (std::is_arithmetic_v<value_type>) {
-      if (verbosity > 0) {
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF("Diagonal values of row %d is %f\n",
-                                      static_cast<int>(selected_row),
-                                      static_cast<double>(diag));
-      }
-
-      if (verbosity > 2) {
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF("U, row_map={ ");
-        for (ordinal_type rowIdx = 0; rowIdx < factorization_step + 1;
-             ++rowIdx) {
-          KOKKOS_IMPL_DO_NOT_USE_PRINTF("%d ",
-                                        static_cast<int>(row_mapU(rowIdx)));
-        }
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF("}, entries={ ");
-        for (size_type entryIdx = row_mapU(0);
-             entryIdx < row_mapU(factorization_step + 1); ++entryIdx) {
-          KOKKOS_IMPL_DO_NOT_USE_PRINTF("%d ",
-                                        static_cast<int>(entriesU(entryIdx)));
-        }
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF("}, values={ ");
-        for (size_type entryIdx = row_mapU(0);
-             entryIdx < row_mapU(factorization_step + 1); ++entryIdx) {
-          KOKKOS_IMPL_DO_NOT_USE_PRINTF("%f ",
-                                        static_cast<double>(valuesU(entryIdx)));
-        }
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF("}\n");
-      }
-    }
-
-    // Insert the lower part of the selected column of A
-    // divided by its the diagonal value to obtain a unit
-    // diagonal value in L.
-    size_type L_entryIdx = row_mapL(factorization_step);
-    entriesL(L_entryIdx) = selected_row;
-    valuesL(L_entryIdx)  = Kokkos::ArithTraits<value_type>::one();
-    ++L_entryIdx;
-    for (size_type entryIdx = At.graph.row_map(selected_row);
-         entryIdx < At.graph.row_map(selected_row + 1); ++entryIdx) {
-      if (permutation_inv(At.graph.entries(entryIdx)) > factorization_step) {
-        entriesL(L_entryIdx) = At.graph.entries(entryIdx);
-        valuesL(L_entryIdx)  = At.values(entryIdx) / diag;
-        ++L_entryIdx;
-      }
-    }
-    row_mapL(factorization_step + 1) = L_entryIdx;
-
-    if constexpr (std::is_arithmetic_v<value_type>) {
-      if (verbosity > 2) {
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF(
-            "L(%d), [row_map(%d), row_map(%d)[ = [%d, %d[, entries={ ",
-            static_cast<int>(factorization_step),
-            static_cast<int>(factorization_step),
-            static_cast<int>(factorization_step + 1),
-            static_cast<int>(row_mapL(factorization_step)),
-            static_cast<int>(row_mapL(factorization_step + 1)));
-        for (size_type entryIdx = row_mapL(factorization_step);
-             entryIdx < row_mapL(factorization_step + 1); ++entryIdx) {
-          KOKKOS_IMPL_DO_NOT_USE_PRINTF("%d ",
-                                        static_cast<int>(entriesL(entryIdx)));
-        }
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF("}, values={ ");
-        for (size_type entryIdx = row_mapL(factorization_step);
-             entryIdx < row_mapL(factorization_step + 1); ++entryIdx) {
-          KOKKOS_IMPL_DO_NOT_USE_PRINTF("%f ",
-                                        static_cast<double>(valuesL(entryIdx)));
-        }
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF("}\n");
-      }
-    }
-
-    // If this was the last row no need to update A and At!
-    if (factorization_step == A.numRows() - 1) {
-      return;
-    }
-
-    // Finally we want to update A and At with the values
-    // that where not discarded during factorization.
-    // Note: this is almost the same operation as computing
-    // the norm of the discarded fill...
-
-    // First step: find the diagonal entry in selected_row
-    value_type diag_val = Kokkos::ArithTraits<value_type>::zero();
-    for (size_type entryIdx = A.graph.row_map(selected_row);
-         entryIdx < A.graph.row_map(selected_row + 1); ++entryIdx) {
-      ordinal_type colIdx = A.graph.entries(entryIdx);
-      if (selected_row == colIdx) {
-        diag_val = A.values(entryIdx);
-      }
-    }
+    // Only one of the values will match selected so can just sum all contribs
+    const auto rowView = A.rowConst(selected_row);
+    value_type diag    = Kokkos::ArithTraits<value_type>::zero();
+    Kokkos::parallel_reduce(
+        Kokkos::TeamVectorRange(team, rowView.length),
+        [&](const size_type ind, value_type& running_diag) {
+          if (rowView.colidx(ind) == selected_row)
+            running_diag = rowView.value(ind);
+        },
+        Kokkos::Sum<value_type, execution_space>(diag));
 
     // Extract alpha and beta vectors
     // Then insert alpha*beta/diag_val if the corresponding
     // entry in A is non-zero.
-    for (size_type alphaIdx = At.graph.row_map(selected_row);
-         alphaIdx < At.graph.row_map(selected_row + 1); ++alphaIdx) {
-      ordinal_type fillRowIdx = At.graph.entries(alphaIdx);
-      bool row_not_eliminated = true;
-      for (ordinal_type stepIdx = 0; stepIdx < factorization_step; ++stepIdx) {
-        if (fillRowIdx == permutation(stepIdx)) {
-          row_not_eliminated = false;
-        }
-      }
+    auto fillRowView = A.row(rowInd);
+    Kokkos::parallel_for(
+        Kokkos::TeamThreadRange(team, rowView.length),
+        [&](const ordinal_type beta) {
+          const auto colInd = rowView.colidx(beta);
 
-      if ((fillRowIdx != selected_row) && row_not_eliminated) {
-        for (size_type betaIdx = A.graph.row_map(selected_row);
-             betaIdx < A.graph.row_map(selected_row + 1); ++betaIdx) {
-          ordinal_type fillColIdx = A.graph.entries(betaIdx);
-          bool col_not_eliminated = true;
-          for (ordinal_type stepIdx = 0; stepIdx < factorization_step;
-               ++stepIdx) {
-            if (fillColIdx == permutation(stepIdx)) {
-              col_not_eliminated = false;
-            }
-          }
+          if (colInd == selected_row) return;
 
-          if ((fillColIdx != selected_row) && col_not_eliminated) {
-            for (size_type entryIdx = A.graph.row_map(fillRowIdx);
-                 entryIdx < A.graph.row_map(fillRowIdx + 1); ++entryIdx) {
-              if (A.graph.entries(entryIdx) == fillColIdx) {
-                A.values(entryIdx) -=
-                    At.values(alphaIdx) * A.values(betaIdx) / diag_val;
-                if constexpr (std::is_arithmetic_v<value_type>) {
-                  if (verbosity > 1) {
-                    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
-                        "A[%d, %d] -= %f\n", static_cast<int>(fillRowIdx),
-                        static_cast<int>(fillColIdx),
-                        static_cast<double>(At.values(alphaIdx) *
-                                            A.values(betaIdx) / diag_val));
-                  }
+          if (permutation_set.exists(colInd)) return;
+
+          const auto subVal = colView.value(alpha) * rowView.value(beta) / diag;
+
+          Kokkos::parallel_for(
+              Kokkos::ThreadVectorRange(team, fillRowView.length),
+              [&](const ordinal_type gamma) {
+                if (colInd == fillRowView.colidx(gamma)) {
+                  Kokkos::atomic_sub(&fillRowView.value(gamma), subVal);
                 }
-              }
-            }
+              });
 
-            for (size_type entryIdx = At.graph.row_map(fillColIdx);
-                 entryIdx < At.graph.row_map(fillColIdx + 1); ++entryIdx) {
-              if (At.graph.entries(entryIdx) == fillRowIdx) {
-                At.values(entryIdx) -=
-                    At.values(alphaIdx) * A.values(betaIdx) / diag_val;
-              }
-            }
-          }
-        }
-      }
-    }
-
-    factored(selected_row) = 1;
-
-    if constexpr (std::is_arithmetic_v<value_type>) {
-      if (verbosity > 0) {
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF("New values in A: { ");
-        for (size_type entryIdx = 0; entryIdx < A.nnz(); ++entryIdx) {
-          KOKKOS_IMPL_DO_NOT_USE_PRINTF(
-              "%f ", static_cast<double>(A.values(entryIdx)));
-        }
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF("}\n");
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF("New values in At: { ");
-        for (size_type entryIdx = 0; entryIdx < At.nnz(); ++entryIdx) {
-          KOKKOS_IMPL_DO_NOT_USE_PRINTF(
-              "%f ", static_cast<double>(At.values(entryIdx)));
-        }
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF("}\n");
-      }
-    }
-  }  // operator()
-
-};  // MDF_factorize_row
+          auto fillColView = At.row(colInd);
+          Kokkos::parallel_for(
+              Kokkos::ThreadVectorRange(team, fillColView.length),
+              [&](const ordinal_type delt) {
+                if (rowInd == fillColView.colidx(delt)) {
+                  Kokkos::atomic_sub(&fillColView.value(delt), subVal);
+                }
+              });
+        });
+  }
+};
 
 template <class crs_matrix_type>
 struct MDF_compute_list_length {
+  using device_type     = typename crs_matrix_type::device_type;
+  using execution_space = typename crs_matrix_type::execution_space;
+  using team_policy_t   = Kokkos::TeamPolicy<execution_space>;
+  using team_member_t   = typename team_policy_t::member_type;
+
+  using row_map_type = typename crs_matrix_type::StaticCrsGraphType::
+      row_map_type::non_const_type;
   using col_ind_type = typename crs_matrix_type::StaticCrsGraphType::
       entries_type::non_const_type;
-  using ordinal_type = typename crs_matrix_type::ordinal_type;
-  using size_type    = typename crs_matrix_type::size_type;
+  using values_type     = typename crs_matrix_type::values_type::non_const_type;
+  using ordinal_type    = typename crs_matrix_type::ordinal_type;
+  using size_type       = typename crs_matrix_type::size_type;
+  using value_type      = typename crs_matrix_type::value_type;
+  using values_mag_type = typename MDF_types<crs_matrix_type>::values_mag_type;
+  using value_mag_type  = typename values_mag_type::value_type;
 
-  ordinal_type selected_row_idx;
-  crs_matrix_type A;
-  crs_matrix_type At;
-  col_ind_type permutation;
+  using permutation_set_type =
+      Kokkos::UnorderedMap<ordinal_type, void, device_type>;
+
+  crs_matrix_type A, At;
+
+  row_map_type row_mapL;
+  col_ind_type entriesL;
+  values_type valuesL;
+
+  row_map_type row_mapU;
+  col_ind_type entriesU;
+  values_type valuesU;
+
+  col_ind_type permutation, permutation_inv;
+  permutation_set_type permutation_set;
+  values_mag_type discarded_fill;
   col_ind_type factored;
-  col_ind_type update_list_length;
+  ordinal_type selected_row_idx, factorization_step;
+
   col_ind_type update_list;
 
-  MDF_compute_list_length(const ordinal_type rowIdx_, const crs_matrix_type& A_,
-                          const crs_matrix_type& At_,
-                          const col_ind_type& permutation_,
-                          const col_ind_type factored_,
-                          col_ind_type& update_list_length_,
-                          col_ind_type& update_list_)
-      : selected_row_idx(rowIdx_),
-        A(A_),
+  int verbosity;
+
+  MDF_compute_list_length(
+      crs_matrix_type A_, crs_matrix_type At_, row_map_type row_mapL_,
+      col_ind_type entriesL_, values_type valuesL_, row_map_type row_mapU_,
+      col_ind_type entriesU_, values_type valuesU_, col_ind_type permutation_,
+      col_ind_type permutation_inv_, permutation_set_type permutation_set_,
+      values_mag_type discarded_fill_, col_ind_type factored_,
+      ordinal_type selected_row_idx_, ordinal_type factorization_step_,
+      col_ind_type& update_list_, int verbosity_)
+      : A(A_),
         At(At_),
+        row_mapL(row_mapL_),
+        entriesL(entriesL_),
+        valuesL(valuesL_),
+        row_mapU(row_mapU_),
+        entriesU(entriesU_),
+        valuesU(valuesU_),
         permutation(permutation_),
+        permutation_inv(permutation_inv_),
+        permutation_set(permutation_set_),
+        discarded_fill(discarded_fill_),
         factored(factored_),
-        update_list_length(update_list_length_),
-        update_list(update_list_) {}
+        selected_row_idx(selected_row_idx_),
+        factorization_step(factorization_step_),
+        update_list(update_list_),
+        verbosity(verbosity_){};
 
+  // Phase 1, update list length
   KOKKOS_INLINE_FUNCTION
-  void operator()(const size_type /*idx*/) const {
-    const ordinal_type selected_row = permutation(selected_row_idx);
+  void operator()(const team_member_t team, ordinal_type& update_list_len,
+                  ordinal_type& selected_row_len) const {
+    ordinal_type selected_row = 0;
 
-    size_type updateIdx = 0;
-    for (size_type entryIdx = A.graph.row_map(selected_row);
-         entryIdx < A.graph.row_map(selected_row + 1); ++entryIdx) {
-      if ((A.graph.entries(entryIdx) != selected_row) &&
-          (factored(A.graph.entries(entryIdx)) != 1)) {
-        update_list(updateIdx) = A.graph.entries(entryIdx);
-        ++updateIdx;
-      }
-    }
-    size_type update_rows = updateIdx;
-    for (size_type entryIdx = At.graph.row_map(selected_row);
-         entryIdx < At.graph.row_map(selected_row + 1); ++entryIdx) {
-      if ((At.graph.entries(entryIdx) != selected_row) &&
-          (factored(A.graph.entries(entryIdx)) != 1)) {
-        bool already_updated = false;
-        for (size_type checkIdx = 0; checkIdx < update_rows; ++checkIdx) {
-          if (At.graph.entries(entryIdx) == update_list(checkIdx)) {
-            already_updated = true;
-            break;
+    size_type U_entryIdx = row_mapU(factorization_step);
+    size_type L_entryIdx = row_mapL(factorization_step);
+
+    Kokkos::single(Kokkos::PerTeam(team), [&] {
+      selected_row                 = permutation(selected_row_idx);
+      discarded_fill(selected_row) = Kokkos::ArithTraits<value_mag_type>::max();
+
+      // Swap entries in permutation vectors
+      permutation(selected_row_idx)   = permutation(factorization_step);
+      permutation(factorization_step) = selected_row;
+      permutation_inv(permutation(factorization_step)) = factorization_step;
+      permutation_inv(permutation(selected_row_idx))   = selected_row_idx;
+
+      // Diagonal value of L
+      entriesL(L_entryIdx) = selected_row;
+      valuesL(L_entryIdx)  = Kokkos::ArithTraits<value_type>::one();
+
+      // Insert into permutation set for later
+      const auto res = permutation_set.insert(selected_row);
+      (void)res;  // avoid unused error
+      assert(res.success());
+    });
+    ++L_entryIdx;
+
+    // Only one thread has the selected row
+    team.team_reduce(Kokkos::Max<ordinal_type, execution_space>(selected_row));
+    const auto rowView = A.rowConst(selected_row);
+    const auto colView = At.rowConst(selected_row);
+
+    // Insert the upper part of the selected row in U
+    // including the diagonal term.
+    ordinal_type updateIdx = 0;
+    value_type diag        = Kokkos::ArithTraits<value_type>::zero();
+    {
+      Kokkos::parallel_scan(
+          Kokkos::TeamThreadRange(team, rowView.length),
+          [&](const size_type alpha, ordinal_type& running_update,
+              bool is_final) {
+            const auto colInd = rowView.colidx(alpha);
+            if ((colInd != selected_row) && (factored(colInd) != 1)) {
+              if (is_final) {
+                update_list(running_update) = colInd;
+                ++updateIdx;
+              }
+              ++running_update;
+            }
           }
-        }
-        if (already_updated == false) {
-          update_list(updateIdx) = At.graph.entries(entryIdx);
-          ++updateIdx;
-        }
-      }
+          // ,updateIdx
+      );
+
+      // Until https://github.com/kokkos/kokkos/issues/6259 is resolved, do
+      // reduction outside of parallel_scan
+      team.team_reduce(Kokkos::Sum<ordinal_type, execution_space>(updateIdx));
+
+      // Sort update list
+      KokkosKernels::TeamBitonicSort(&update_list(0), updateIdx, team);
     }
-    update_list_length(0) = updateIdx;
+    {
+      size_type numEntrU = 0;
+      Kokkos::parallel_scan(
+          Kokkos::TeamThreadRange(team, rowView.length),
+          [&](const size_type alpha, size_type& running_nEntr, bool is_final) {
+            const auto colInd = rowView.colidx(alpha);
+            if (permutation_inv(colInd) >= factorization_step) {
+              if (is_final) {
+                ++numEntrU;
+                entriesU(U_entryIdx + running_nEntr) = colInd;
+                valuesU(U_entryIdx + running_nEntr)  = rowView.value(alpha);
+                if (colInd == selected_row) diag = rowView.value(alpha);
+              }
+              ++running_nEntr;
+            }
+          }
+          // , numEntrU
+      );
+
+      // Until https://github.com/kokkos/kokkos/issues/6259 is resolved, do
+      // reduction outside of parallel_scan
+      team.team_reduce(Kokkos::Sum<size_type, execution_space>(numEntrU));
+
+      U_entryIdx += numEntrU;
+    }
+
+    // Only one thread found diagonal so just sum over all
+    team.team_reduce(Kokkos::Sum<value_type, execution_space>(diag));
+
+    // Insert the lower part of the selected column of A
+    // divided by its the diagonal value to obtain a unit
+    // diagonal value in L.
+    {
+      size_type numEntrL = 0;
+      Kokkos::parallel_scan(
+          Kokkos::TeamThreadRange(team, colView.length),
+          [&](const size_type alpha, size_type& running_nEntr, bool is_final) {
+            const auto rowInd = colView.colidx(alpha);
+            if (permutation_inv(rowInd) > factorization_step) {
+              if (is_final) {
+                ++numEntrL;
+                entriesL(L_entryIdx + running_nEntr) = rowInd;
+                valuesL(L_entryIdx + running_nEntr) =
+                    colView.value(alpha) / diag;
+              }
+              ++running_nEntr;
+            }
+          }
+          // , numEntrL
+      );
+
+      // Until https://github.com/kokkos/kokkos/issues/6259 is resolved, do
+      // reduction outside of parallel_scan
+      team.team_reduce(Kokkos::Sum<size_type, execution_space>(numEntrL));
+
+      L_entryIdx += numEntrL;
+    }
+    {
+      ordinal_type numUpdateL = 0;
+      Kokkos::parallel_scan(
+          Kokkos::TeamThreadRange(team, colView.length),
+          [&](const size_type alpha, ordinal_type& running_update,
+              bool is_final) {
+            const auto rowInd = colView.colidx(alpha);
+            if ((rowInd != selected_row) && (factored(rowInd) != 1)) {
+              // updateIdx currently holds the rows that were updated. don't add
+              // duplicates
+              const size_type& update_rows = updateIdx;
+
+              const bool already_updated =
+                  sorted_view_contains(update_list, update_rows, rowInd);
+
+              if (!already_updated) {
+                // Cannot make use of vector ranges until
+                // https://github.com/kokkos/kokkos/issues/6259 is resolved
+                // Kokkos::single(Kokkos::PerThread(team),[&]{
+                if (is_final) {
+                  update_list(updateIdx + running_update) = rowInd;
+                  ++numUpdateL;
+                }
+                ++running_update;
+                // });
+              }
+            }
+          }
+          // , numUpdateL
+      );
+
+      // Until https://github.com/kokkos/kokkos/issues/6259 is resolved, do
+      // reduction outside of parallel_scan
+      team.team_reduce(Kokkos::Sum<ordinal_type, execution_space>(numUpdateL));
+
+      updateIdx += numUpdateL;
+    }
+
+    Kokkos::single(Kokkos::PerTeam(team), [&] {
+      row_mapU(factorization_step + 1) = U_entryIdx;
+      row_mapL(factorization_step + 1) = L_entryIdx;
+
+      update_list_len  = updateIdx;
+      selected_row_len = rowView.length;
+
+      factored(selected_row) = 1;
+    });
   }
 };
 

--- a/packages/kokkos-kernels/sparse/src/KokkosSparse_mdf.hpp
+++ b/packages/kokkos-kernels/sparse/src/KokkosSparse_mdf.hpp
@@ -27,6 +27,7 @@
 #ifndef KOKKOSSPARSE_MDF_HPP_
 #define KOKKOSSPARSE_MDF_HPP_
 
+#include <Kokkos_UnorderedMap.hpp>
 #include "KokkosSparse_mdf_handle.hpp"
 #include "KokkosSparse_mdf_impl.hpp"
 
@@ -35,22 +36,20 @@ namespace Experimental {
 
 template <class crs_matrix_type, class MDF_handle>
 void mdf_symbolic(const crs_matrix_type& A, MDF_handle& handle) {
-  using size_type    = typename crs_matrix_type::size_type;
-  using ordinal_type = typename crs_matrix_type::ordinal_type;
+  using size_type = typename crs_matrix_type::size_type;
 
-  using execution_space   = typename crs_matrix_type::execution_space;
-  using range_policy_type = Kokkos::RangePolicy<ordinal_type, execution_space>;
+  using execution_space        = typename crs_matrix_type::execution_space;
+  using team_range_policy_type = Kokkos::TeamPolicy<execution_space>;
 
   // Symbolic phase:
   // compute transpose of A for easy access to columns of A
   // allocate temporaries
   // allocate L and U
   size_type nnzL = 0, nnzU = 0;
-  range_policy_type setupPolicy(0, A.numRows());
+  team_range_policy_type setupPolicy(A.numRows(), Kokkos::AUTO);
   KokkosSparse::Impl::MDF_count_lower<crs_matrix_type> compute_nnzL(
       A, handle.permutation, handle.permutation_inv);
-  Kokkos::parallel_reduce(range_policy_type(0, A.numRows()), compute_nnzL,
-                          nnzL);
+  Kokkos::parallel_reduce(setupPolicy, compute_nnzL, nnzL);
   nnzU = A.nnz() - nnzL + A.numRows();
   handle.allocate_data(nnzL, nnzU);
 
@@ -62,17 +61,40 @@ void mdf_symbolic(const crs_matrix_type& A, MDF_handle& handle) {
   return;
 }  // mdf_symbolic
 
+template <class view_t, class ordinal_t = size_t>
+void mdf_print_joined_view(
+    const view_t& dev_view, const char* sep,
+    ordinal_t max_count = Kokkos::ArithTraits<ordinal_t>::max()) {
+  const auto host_view =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), dev_view);
+
+  max_count = max_count > (ordinal_t)host_view.extent(0)
+                  ? (ordinal_t)host_view.extent(0)
+                  : max_count;
+  for (ordinal_t i = 0; i < max_count; ++i) {
+    if (i) printf("%s", sep);
+    printf("%g", static_cast<double>(host_view[i]));
+  }
+}
+
 template <class crs_matrix_type, class MDF_handle>
 void mdf_numeric(const crs_matrix_type& A, MDF_handle& handle) {
   using col_ind_type = typename crs_matrix_type::StaticCrsGraphType::
       entries_type::non_const_type;
+  using scalar_mag_type =
+      typename KokkosSparse::Impl::MDF_types<crs_matrix_type>::scalar_mag_type;
   using values_mag_type =
       typename KokkosSparse::Impl::MDF_types<crs_matrix_type>::values_mag_type;
   using ordinal_type   = typename crs_matrix_type::ordinal_type;
   using value_mag_type = typename values_mag_type::value_type;
 
+  using device_type       = typename crs_matrix_type::device_type;
   using execution_space   = typename crs_matrix_type::execution_space;
   using range_policy_type = Kokkos::RangePolicy<ordinal_type, execution_space>;
+  using team_range_policy_type = Kokkos::TeamPolicy<execution_space>;
+
+  using permutation_set_type =
+      Kokkos::UnorderedMap<ordinal_type, void, device_type>;
 
   // Numerical phase:
   // loop over rows
@@ -85,60 +107,104 @@ void mdf_numeric(const crs_matrix_type& A, MDF_handle& handle) {
   KokkosSparse::sort_crs_matrix<crs_matrix_type>(At);
   values_mag_type discarded_fill("discarded fill", A.numRows());
   col_ind_type deficiency("deficiency", A.numRows());
-  col_ind_type update_list_length("update list length", 1);
-  typename col_ind_type::HostMirror update_list_length_host =
-      Kokkos::create_mirror_view(update_list_length);
+  ordinal_type update_list_len = 0;
   col_ind_type update_list("update list", A.numRows());
   col_ind_type factored("factored rows", A.numRows());
   Kokkos::deep_copy(discarded_fill, Kokkos::ArithTraits<value_mag_type>::max());
   Kokkos::deep_copy(deficiency, Kokkos::ArithTraits<ordinal_type>::max());
+  permutation_set_type permutation_set(A.numRows());
 
-  KokkosSparse::Impl::MDF_discarded_fill_norm<crs_matrix_type> MDF_df_norm(
-      Atmp, At, 0, handle.permutation, discarded_fill, deficiency,
-      verbosity_level);
-  Kokkos::parallel_for("MDF: initial fill computation",
-                       range_policy_type(0, Atmp.numRows()), MDF_df_norm);
+  KokkosSparse::Impl::MDF_discarded_fill_norm<crs_matrix_type, true>
+      MDF_df_norm(Atmp, At, 0, handle.permutation, permutation_set,
+                  discarded_fill, deficiency, verbosity_level);
+  Kokkos::parallel_for(
+      "MDF: initial fill computation",
+      team_range_policy_type(Atmp.numRows(), Kokkos::AUTO, Kokkos::AUTO),
+      MDF_df_norm);
 
   for (ordinal_type factorization_step = 0; factorization_step < A.numRows();
        ++factorization_step) {
     if (verbosity_level > 0) {
-      printf("\n\nFactorization step %d\n\n",
+      printf("\n\nFactorization step %d\n",
              static_cast<int>(factorization_step));
     }
 
-    Kokkos::deep_copy(update_list_length_host, update_list_length);
-    range_policy_type updatePolicy(0, update_list_length_host(0));
-    KokkosSparse::Impl::MDF_selective_discarded_fill_norm<crs_matrix_type>
-        MDF_update_df_norm(Atmp, At, factorization_step, handle.permutation,
-                           update_list, discarded_fill, deficiency,
-                           verbosity_level);
-    Kokkos::parallel_for("MDF: updating fill norms", updatePolicy,
-                         MDF_update_df_norm);
+    if (update_list_len > 0) {
+      team_range_policy_type updatePolicy(update_list_len, Kokkos::AUTO,
+                                          Kokkos::AUTO);
+      KokkosSparse::Impl::MDF_discarded_fill_norm<crs_matrix_type, false>
+          MDF_update_df_norm(Atmp, At, factorization_step, handle.permutation,
+                             permutation_set, discarded_fill, deficiency,
+                             verbosity_level, update_list);
+      Kokkos::parallel_for("MDF: updating fill norms", updatePolicy,
+                           MDF_update_df_norm);
+    }
 
-    range_policy_type stepPolicy(factorization_step, Atmp.numRows());
+    if (verbosity_level > 1) {
+      if constexpr (std::is_arithmetic_v<scalar_mag_type>) {
+        printf("  discarded_fill = {");
+        mdf_print_joined_view(discarded_fill, ", ");
+        printf("}\n");
+      }
+      printf("  deficiency = {");
+      mdf_print_joined_view(deficiency, ", ");
+      printf("}\n");
+    }
+
     ordinal_type selected_row_idx = 0;
-    KokkosSparse::Impl::MDF_select_row<crs_matrix_type> MDF_row_selector(
-        factorization_step, discarded_fill, deficiency, Atmp.graph.row_map,
-        handle.permutation);
-    Kokkos::parallel_reduce("MDF: select pivot", stepPolicy, MDF_row_selector,
-                            selected_row_idx);
+    {
+      range_policy_type stepPolicy(factorization_step, Atmp.numRows());
+      KokkosSparse::Impl::MDF_select_row<crs_matrix_type> MDF_row_selector(
+          factorization_step, discarded_fill, deficiency, Atmp.graph.row_map,
+          handle.permutation);
+      Kokkos::parallel_reduce("MDF: select pivot", stepPolicy, MDF_row_selector,
+                              selected_row_idx);
+    }
 
-    KokkosSparse::Impl::MDF_compute_list_length<crs_matrix_type>
-        compute_list_length(selected_row_idx, Atmp, At, handle.permutation,
-                            factored, update_list_length, update_list);
-    Kokkos::parallel_for("MDF: compute update list", range_policy_type(0, 1),
-                         compute_list_length);
+    ordinal_type selected_row_len = 0;
+    {
+      // vector overloads required for scans to use vector parallel not yet
+      // provided by kokkos (https://github.com/kokkos/kokkos/issues/6259)
+      team_range_policy_type updateListPolicy(1, Kokkos::AUTO);
+      KokkosSparse::Impl::MDF_compute_list_length<crs_matrix_type> updateList(
+          Atmp, At, handle.row_mapL, handle.entriesL, handle.valuesL,
+          handle.row_mapU, handle.entriesU, handle.valuesU, handle.permutation,
+          handle.permutation_inv, permutation_set, discarded_fill, factored,
+          selected_row_idx, factorization_step, update_list, verbosity_level);
+      update_list_len = 0;
+      Kokkos::parallel_reduce("MDF: compute update list", updateListPolicy,
+                              updateList, update_list_len, selected_row_len);
+    }
 
-    KokkosSparse::Impl::MDF_factorize_row<crs_matrix_type> factorize_row(
-        Atmp, At, handle.row_mapL, handle.entriesL, handle.valuesL,
-        handle.row_mapU, handle.entriesU, handle.valuesU, handle.permutation,
-        handle.permutation_inv, discarded_fill, factored, selected_row_idx,
-        factorization_step, verbosity_level);
-    Kokkos::parallel_for("MDF: factorize row", range_policy_type(0, 1),
-                         factorize_row);
-
+    if (verbosity_level > 1) {
+      printf("  updateList = {");
+      mdf_print_joined_view(update_list, ", ", update_list_len);
+      printf("}\n  permutation = {");
+      mdf_print_joined_view(handle.permutation, ", ");
+      printf("}\n  permutation_inv = {");
+      mdf_print_joined_view(handle.permutation_inv, ", ");
+      printf("}\n");
+    }
     if (verbosity_level > 0) {
-      printf("\n");
+      printf(
+          "  Selected row idx %d with length %d. Requires update of %d fill "
+          "norms.\n",
+          static_cast<int>(selected_row_idx),
+          static_cast<int>(selected_row_len),
+          static_cast<int>(update_list_len));
+    }
+
+    // If this was the last row no need to update A and At!
+    if (factorization_step < A.numRows() - 1) {
+      team_range_policy_type factorizePolicy(selected_row_len, Kokkos::AUTO,
+                                             Kokkos::AUTO);
+      KokkosSparse::Impl::MDF_factorize_row<crs_matrix_type> factorize_row(
+          Atmp, At, handle.row_mapL, handle.entriesL, handle.valuesL,
+          handle.row_mapU, handle.entriesU, handle.valuesU, handle.permutation,
+          handle.permutation_inv, permutation_set, discarded_fill, factored,
+          selected_row_idx, factorization_step, update_list, verbosity_level);
+      Kokkos::parallel_for("MDF: factorize row", factorizePolicy,
+                           factorize_row);
     }
   }  // Loop over factorization steps
 


### PR DESCRIPTION
This updates Kokkos Kernels to include changes from PR #1916 in the kokkos/kokkos-kernels repo.

@trilinos/kokkos-kernels 

## Motivation
This cherry-pick is required by PR #12078 to achieve the fix in Ifpack2 MDF implementation

## Related Issues

* Closes 
* Blocks #12078 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 


## Stakeholder Feedback
@ndellingwood @tmranse 
Let me know if this looks good to unblock the PR to ifpack2?

## Testing
Tested locally and in Kokkos Kernels.
