### PR TITLE
Intrepid2: Removing Experimental namespace used for projections (part1)

### DIFF
--- a/packages/intrepid2/CMakeLists.txt
+++ b/packages/intrepid2/CMakeLists.txt
@@ -34,7 +34,7 @@ ENDIF()
 TRIBITS_ADD_OPTION_AND_DEFINE(${PACKAGE_NAME}_KEEP_EXPERIMENTAL_NAMESPACE
   HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
   "Whether Intrepid2 keeps experimentatl namespace for projections."
-  OFF
+  ON
 )
 
 #

--- a/packages/intrepid2/CMakeLists.txt
+++ b/packages/intrepid2/CMakeLists.txt
@@ -30,6 +30,13 @@ ELSE()
     OFF)
 ENDIF()   
 
+# temporary flag
+TRIBITS_ADD_OPTION_AND_DEFINE(${PACKAGE_NAME}_KEEP_EXPERIMENTAL_NAMESPACE
+  HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
+  "Whether Intrepid2 keeps experimentatl namespace for projections."
+  OFF
+)
+
 #
 # C) Add the libraries, tests, and examples
 #

--- a/packages/intrepid2/cmake/Intrepid2_config.h.in
+++ b/packages/intrepid2/cmake/Intrepid2_config.h.in
@@ -10,3 +10,6 @@
 /* Define if want to build with KokkosKernels enabled */
 #cmakedefine HAVE_INTREPID2_KOKKOSKERNELS
 
+/* Temporary flag */
+#cmakedefine HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
+

--- a/packages/intrepid2/src/Cell/Intrepid2_CellTools.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellTools.hpp
@@ -1084,8 +1084,8 @@ public:
                         const Kokkos::DynRankView<refPointValueType,refPointProperties...>       refPoints,
                         const Kokkos::DynRankView<worksetCellValueType,worksetCellProperties...> worksetCell,
                         const shards::CellTopology cellTopo ) {
-    using nonConstRefPointValueType = std::remove_const_t<refPointValueType>;
-    auto basis = createHGradBasis<nonConstRefPointValueType,nonConstRefPointValueType>(cellTopo);
+      using nonConstRefPointValueType = std::remove_const_t<refPointValueType>;
+      auto basis = createHGradBasis<nonConstRefPointValueType,nonConstRefPointValueType>(cellTopo);
       mapToPhysicalFrame(physPoints, 
                          refPoints, 
                          worksetCell, 
@@ -1143,11 +1143,11 @@ public:
         \param  subcellOrd        [in]  - subcell ordinal
         \param  parentCell        [in]  - cell topology of the parent cell.
     */
-    template<typename refSubcellPointValueType, class ...refSubcellPointProperties,
-             typename paramPointValueType, class ...paramPointProperties>
+    template<typename refSubcellViewType,
+             typename paramPointViewType>
     static void
-    mapToReferenceSubcell(       Kokkos::DynRankView<refSubcellPointValueType,refSubcellPointProperties...> refSubcellPoints,
-                           const Kokkos::DynRankView<paramPointValueType,paramPointProperties...>           paramPoints,
+    mapToReferenceSubcell(       refSubcellViewType refSubcellPoints,
+                           const paramPointViewType paramPoints,
                            const ordinal_type subcellDim,
                            const ordinal_type subcellOrd,
                            const shards::CellTopology parentCell );
@@ -1157,19 +1157,26 @@ public:
 
         Overload of the previous function (see explanation above) where the subcell parametrization is used instead of 
         passing the parent cell topology.
-
-        \param  refSubcellPoints       [out] - rank-2 (P,D1) array with images of parameter space points
-        \param  paramPoints            [in]  - rank-2 (P,D2) array with points in 1D or 2D parameter domain
-        \param  subcellParametrization [in]  - parametrization map of a subcell in the cell
-        \param  subcellOrd             [in]  - subcell ordinal.
     */
-    template<typename refSubcellPointValueType, class ...refSubcellPointProperties,
-             typename paramPointValueType, class ...paramPointProperties>
+
+    template<typename refSubcellViewType, typename paramPointViewType>
     static void
-    mapToReferenceSubcell(       Kokkos::DynRankView<refSubcellPointValueType,refSubcellPointProperties...> refSubcellPoints,
-                         const Kokkos::DynRankView<paramPointValueType,paramPointProperties...>           paramPoints,
-                         const typename RefSubcellParametrization<DeviceType>::ConstViewType              subcellParametrization,
+    mapToReferenceSubcell(     refSubcellViewType                                             refSubcellPoints,
+                         const paramPointViewType                                             paramPoints,
+                         const typename RefSubcellParametrization<DeviceType>::ConstViewType  subcellParametrization,
                          const ordinal_type subcellOrd);
+
+    /** \brief  Computes parameterization maps of 1- and 2-subcells of reference cells.
+
+        Overload of the previous function (see explanation above) where the subcellOrd is a rank-1 array (P).
+    */
+
+    template<typename refSubcellViewType, typename paramPointViewType, typename ordViewType>
+    static void
+    mapToReferenceSubcell(     refSubcellViewType                                             refSubcellPoints,
+                         const paramPointViewType                                             paramPoints,
+                         const typename RefSubcellParametrization<DeviceType>::ConstViewType  subcellParametrization,
+                         const ordViewType                                                    subcellOrd);
 
 
     //============================================================================================//

--- a/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefRefToPhys.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefRefToPhys.hpp
@@ -108,53 +108,55 @@ namespace Intrepid2 {
     template<typename refSubcellViewType,
              typename paramPointsViewType,
              typename subcellMapViewType>
-    struct F_mapReferenceSubcell2 {
+    struct F_mapReferenceSubcell {
       refSubcellViewType refSubcellPoints_;
       const paramPointsViewType paramPoints_;
       const subcellMapViewType subcellMap_;
-      ordinal_type subcellOrd_;
+      const ordinal_type subcellOrd_;
+      const ordinal_type sideDim_;
 
       KOKKOS_INLINE_FUNCTION
-      F_mapReferenceSubcell2( refSubcellViewType  refSubcellPoints,
+      F_mapReferenceSubcell( refSubcellViewType  refSubcellPoints,
                              const paramPointsViewType paramPoints,
                              const subcellMapViewType  subcellMap,
                              ordinal_type subcellOrd)
         : refSubcellPoints_(refSubcellPoints), paramPoints_(paramPoints), subcellMap_(subcellMap),
-          subcellOrd_(subcellOrd){};
+          subcellOrd_(subcellOrd), sideDim_(paramPoints_.extent(1)){};
 
       KOKKOS_INLINE_FUNCTION
       void operator()(const size_type pt, const size_type d) const {
 
-        const auto u = paramPoints_(pt, 0);
-        const auto v = paramPoints_(pt, 1);
-
-        // map_dim(u,v) = c_0(dim) + c_1(dim)*u + c_2(dim)*v because both Quad and Tri ref faces are affine!
-        refSubcellPoints_(pt, d) = subcellMap_(subcellOrd_, d, 0) + ( subcellMap_(subcellOrd_, d, 1)*u +
-                                                                 subcellMap_(subcellOrd_, d, 2)*v );
+        refSubcellPoints_(pt, d) = subcellMap_(subcellOrd_, d, 0);
+        for(ordinal_type k=0; k<sideDim_; ++k)
+          refSubcellPoints_(pt, d) += subcellMap_(subcellOrd_, d, k+1)*paramPoints_(pt, k);
       }
     };
 
     template<typename refSubcellViewType,
-             typename paramPointsViewType,
-             typename subcellMapViewType>
-    struct F_mapReferenceSubcell1 {
+          typename paramPointsViewType,
+          typename subcellMapViewType,
+          typename ordViewType>
+    struct F_mapReferenceSubcellBatch {
       refSubcellViewType refSubcellPoints_;
       const paramPointsViewType paramPoints_;
       const subcellMapViewType subcellMap_;
-      ordinal_type subcellOrd_;
+      const ordViewType subcellOrd_;
+      const ordinal_type sideDim_;
 
       KOKKOS_INLINE_FUNCTION
-      F_mapReferenceSubcell1( refSubcellViewType  refSubcellPoints,
+      F_mapReferenceSubcellBatch( refSubcellViewType  refSubcellPoints,
                              const paramPointsViewType paramPoints,
                              const subcellMapViewType  subcellMap,
-                             ordinal_type subcellOrd)
+                             ordViewType subcellOrd)
         : refSubcellPoints_(refSubcellPoints), paramPoints_(paramPoints), subcellMap_(subcellMap),
-          subcellOrd_(subcellOrd){};
+          subcellOrd_(subcellOrd), sideDim_(paramPoints_.extent(1)){};
 
       KOKKOS_INLINE_FUNCTION
-      void operator()(const size_type pt, const size_type d) const {
-        const auto u = paramPoints_(pt, 0);
-        refSubcellPoints_(pt, d) = subcellMap_(subcellOrd_, d, 0) + ( subcellMap_(subcellOrd_, d, 1)*u );
+      void operator()(const size_type isc, const size_type pt, const size_type d) const {
+
+        refSubcellPoints_(isc, pt, d) = subcellMap_(subcellOrd_(isc), d, 0);
+        for(ordinal_type k=0; k<sideDim_; ++k)
+          refSubcellPoints_(isc, pt, d) += subcellMap_(subcellOrd_(isc), d, k+1)*paramPoints_(pt, k);
       }
     };
   }
@@ -224,12 +226,11 @@ namespace Intrepid2 {
   }
 
   template<typename DeviceType>
-  template<typename refSubcellPointValueType, class ...refSubcellPointProperties,
-           typename paramPointValueType, class ...paramPointProperties>
+  template<typename refSubcellViewType, typename paramViewType>
   void
   CellTools<DeviceType>::
-  mapToReferenceSubcell(       Kokkos::DynRankView<refSubcellPointValueType,refSubcellPointProperties...> refSubcellPoints,
-                         const Kokkos::DynRankView<paramPointValueType,paramPointProperties...>           paramPoints,
+  mapToReferenceSubcell(       refSubcellViewType refSubcellPoints,
+                         const paramViewType  paramPoints,
                          const ordinal_type subcellDim,
                          const ordinal_type subcellOrd,
                          const shards::CellTopology parentCell ) {
@@ -259,7 +260,7 @@ namespace Intrepid2 {
                                   ">>> ERROR (Intrepid2::CellTools::mapToReferenceSubcell): paramPoints dimension (1) does not match to subcell dimension.");
 
     // cross check: refSubcellPoints and paramPoints: dimension 0 must match
-    INTREPID2_TEST_FOR_EXCEPTION( refSubcellPoints.extent(0) < paramPoints.extent(0), std::invalid_argument,
+    INTREPID2_TEST_FOR_EXCEPTION( refSubcellPoints.extent(0) != paramPoints.extent(0), std::invalid_argument,
                                   ">>> ERROR (Intrepid2::CellTools::mapToReferenceSubcell): refSubcellPoints dimension (0) does not match to paramPoints dimension(0).");
 #endif
 
@@ -270,13 +271,12 @@ namespace Intrepid2 {
   }
 
   template<typename DeviceType>
-  template<typename refSubcellPointValueType, class ...refSubcellPointProperties,
-           typename paramPointValueType, class ...paramPointProperties>
+  template<typename refSubcellViewType, typename paramViewType>
   void
   CellTools<DeviceType>::
-  mapToReferenceSubcell(       Kokkos::DynRankView<refSubcellPointValueType,refSubcellPointProperties...> refSubcellPoints,
-                         const Kokkos::DynRankView<paramPointValueType,paramPointProperties...>           paramPoints,
-                         const typename RefSubcellParametrization<DeviceType>::ConstViewType              subcellParametrization,
+  mapToReferenceSubcell(       refSubcellViewType                                            refSubcellPoints,
+                         const paramViewType                                                 paramPoints,
+                         const typename RefSubcellParametrization<DeviceType>::ConstViewType subcellParametrization,
                          const ordinal_type subcellOrd) {
 
     constexpr bool are_accessible =
@@ -284,31 +284,71 @@ namespace Intrepid2 {
         typename decltype(refSubcellPoints)::memory_space>::accessible &&
         Kokkos::Impl::MemorySpaceAccess<MemSpaceType,
         typename decltype(paramPoints)::memory_space>::accessible;
-
     static_assert(are_accessible, "CellTools<DeviceType>::mapToReferenceSubcell(..): input/output views' memory spaces are not compatible with DeviceType");
+
+
+  #ifdef HAVE_INTREPID2_DEBUG
+    const bool ranks_and_dims_compatible = (refSubcellPoints.rank() == 2) && (paramPoints.rank() == 2) && (subcellParametrization.rank() == 3) && 
+                                           (refSubcellPoints.extent(0) == paramPoints.extent(0)) && 
+                                           (refSubcellPoints.extent(1) == subcellParametrization.extent(1)) && 
+                                           (paramPoints.extent(1) == subcellParametrization.extent(2)-1);
+    
+    INTREPID2_TEST_FOR_EXCEPTION(!ranks_and_dims_compatible, std::invalid_argument, "CellTools<DeviceType>::mapToReferenceSubcell(..): input/output views' ranks and dimensions are not compatible");
+  #endif
 
     const ordinal_type parentCellDim = subcellParametrization.extent(1);
     const ordinal_type numPts  = paramPoints.extent(0);
-    const ordinal_type subcellDim = paramPoints.extent(1);
     
     //Note: this function has several template parameters and the compiler gets confused if using a lambda function
-    using FunctorType1 = FunctorCellTools::F_mapReferenceSubcell1<decltype(refSubcellPoints), decltype(paramPoints), decltype(subcellParametrization)>;
-    using FunctorType2 = FunctorCellTools::F_mapReferenceSubcell2<decltype(refSubcellPoints), decltype(paramPoints), decltype(subcellParametrization)>;
-
+    using FunctorType = FunctorCellTools::F_mapReferenceSubcell<decltype(refSubcellPoints), decltype(paramPoints), decltype(subcellParametrization)>;
 
     Kokkos::MDRangePolicy<ExecSpaceType,Kokkos::Rank<2>> rangePolicy({0,0},{numPts,parentCellDim});
+    
     // Apply the parametrization map to every point in parameter domain
-    switch (subcellDim) {
-    case 2: {
-      Kokkos::parallel_for( rangePolicy, FunctorType2(refSubcellPoints, paramPoints, subcellParametrization, subcellOrd) );
-      break;
-    }
-    case 1: {
-      Kokkos::parallel_for( rangePolicy, FunctorType1(refSubcellPoints, paramPoints, subcellParametrization, subcellOrd) );
-      break;
-    }
-    default: {}
-    }
+    Kokkos::parallel_for( rangePolicy, FunctorType(refSubcellPoints, paramPoints, subcellParametrization, subcellOrd) );
+  }
+
+  template<typename DeviceType>
+  template<typename refSubcellViewType, typename paramViewType, typename ordViewType>
+  void
+  CellTools<DeviceType>::
+  mapToReferenceSubcell(       refSubcellViewType                                            refSubcellPoints,
+                         const paramViewType                                                 paramPoints,
+                         const typename RefSubcellParametrization<DeviceType>::ConstViewType subcellParametrization,
+                         const ordViewType                                                   subcellOrd) {
+
+    constexpr bool are_accessible =
+        Kokkos::Impl::MemorySpaceAccess<MemSpaceType,
+        typename decltype(refSubcellPoints)::memory_space>::accessible &&
+        Kokkos::Impl::MemorySpaceAccess<MemSpaceType,
+        typename decltype(paramPoints)::memory_space>::accessible && 
+        Kokkos::Impl::MemorySpaceAccess<MemSpaceType,
+        typename decltype(subcellOrd)::memory_space>::accessible;
+    static_assert(are_accessible, "CellTools<DeviceType>::mapToReferenceSubcell(..): input/output views' memory spaces are not compatible with DeviceType");
+    
+
+#ifdef HAVE_INTREPID2_DEBUG
+    const bool ranks_and_dims_compatible = (refSubcellPoints.rank() == 3) && (paramPoints.rank() == 2) && (subcellParametrization.rank() == 3) && 
+                                           (refSubcellPoints.extent(0) == subcellOrd.extent(0)) && 
+                                           (refSubcellPoints.extent(1) == paramPoints.extent(0)) && 
+                                           (refSubcellPoints.extent(2) == subcellParametrization.extent(1)) && 
+                                           (paramPoints.extent(1) == subcellParametrization.extent(2)-1);
+
+    INTREPID2_TEST_FOR_EXCEPTION(!ranks_and_dims_compatible, std::invalid_argument, "CellTools<DeviceType>::mapToReferenceSubcell(..): input/output views' ranks and dimensions are not compatible");
+#endif
+
+    const ordinal_type numSubCells = refSubcellPoints.extent(0);
+    const ordinal_type parentCellDim = subcellParametrization.extent(1);
+    const ordinal_type numPts  = paramPoints.extent(0);
+
+    
+    //Note: this function has several template parameters and the compiler gets confused if using a lambda function
+    using FunctorType = FunctorCellTools::F_mapReferenceSubcellBatch<decltype(refSubcellPoints), decltype(paramPoints), decltype(subcellParametrization), decltype(subcellOrd)>;
+
+    Kokkos::MDRangePolicy<ExecSpaceType,Kokkos::Rank<3>> rangePolicy({0,0,0},{numSubCells,numPts,parentCellDim});
+    
+    // Apply the parametrization map to every point in parameter domain
+    Kokkos::parallel_for( rangePolicy, FunctorType(refSubcellPoints, paramPoints, subcellParametrization, subcellOrd) );
   }
 
 }

--- a/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefValidateArguments.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefValidateArguments.hpp
@@ -225,15 +225,19 @@ namespace Intrepid2 {
                                     const worksetCellViewType  worksetCell,
                                     const shards::CellTopology cellTopo ) {
     // Validate worksetCell array
-    INTREPID2_TEST_FOR_EXCEPTION( worksetCell.rank() != 3, std::invalid_argument,
-                                  ">>> ERROR (Intrepid2::CellTools::mapToPhysicalFrame): rank = 3 required for worksetCell array." );
+    INTREPID2_TEST_FOR_EXCEPTION( (worksetCell.rank() != 3) || (physPoints.rank() != 3), std::invalid_argument,
+                                  ">>> ERROR (Intrepid2::CellTools::mapToPhysicalFrame): rank = 3 required for worksetCell and physPoints arrays." );
  
     //TODO: check this, not working for tria6 
     //INTREPID2_TEST_FOR_EXCEPTION( worksetCell.extent(1) != cellTopo.getSubcellCount(0), std::invalid_argument,
     //                              ">>> ERROR (Intrepid2::CellTools::mapToPhysicalFrame): dim 1 (number of cell nodes) of worksetCell array does not match cell topology." );
   
-    INTREPID2_TEST_FOR_EXCEPTION( worksetCell.extent(2) != cellTopo.getDimension(), std::invalid_argument,
-                                  ">>> ERROR (Intrepid2::CellTools::mapToPhysicalFrame): dim 2 (spatial dimension) of worksetCell array  does not match cell dimension." );
+    //we allow cells immersed in a higher-dimensional space  (e.g. 2d cell in a 3d space)
+    INTREPID2_TEST_FOR_EXCEPTION( worksetCell.extent(2) < cellTopo.getDimension(), std::invalid_argument,
+                                  ">>> ERROR (Intrepid2::CellTools::mapToPhysicalFrame): dim 2 (spatial dimension) of worksetCell array is smaller than the cell dimension." );
+
+    INTREPID2_TEST_FOR_EXCEPTION( physPoints.extent(2) !=  worksetCell.extent(2), std::invalid_argument,
+                                  ">>> ERROR (Intrepid2::CellTools::mapToPhysicalFrame): physPoints and worksetCell should have the same spatial dimension." );
 
 
     // Validate refPoints array: can be rank-2 (P,D) or rank-3 (C,P,D) array
@@ -259,8 +263,7 @@ namespace Intrepid2 {
       INTREPID2_TEST_FOR_EXCEPTION( physPoints.extent(1) != refPoints.extent(0), std::invalid_argument,
                                     ">>> ERROR (Intrepid2::CellTools::mapToPhysicalFrame): dim 1 (number of points) of physPoints array must equal dim 0 of refPoints array." ); 
       
-      INTREPID2_TEST_FOR_EXCEPTION( physPoints.extent(2) != cellTopo.getDimension(), std::invalid_argument,
-                                    ">>> ERROR (Intrepid2::CellTools::mapToPhysicalFrame): dim 2 (spatial dimension) does not match cell dimension." );  
+  
       break;
     }
     case 3: {
@@ -276,7 +279,7 @@ namespace Intrepid2 {
       INTREPID2_TEST_FOR_EXCEPTION( refPointRank != physPointRank, std::invalid_argument, 
                                     " >>> ERROR (Intrepid2::CellTools::mapToPhysicalFrame): refPoints rank does not match to physPoints rank." );
       
-      for (ordinal_type i=0;i<refPointRank;++i) {
+      for (ordinal_type i=0;i<refPointRank-1;++i) {
         INTREPID2_TEST_FOR_EXCEPTION( refPoints.extent(i) != physPoints.extent(i), std::invalid_argument, 
                                       " >>> ERROR (Intrepid2::CellTools::mapToPhysicalFrame): refPoints dimension(i) does not match to physPoints dimension(i)." );
       }

--- a/packages/intrepid2/src/Cell/Intrepid2_ProjectedGeometry.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_ProjectedGeometry.hpp
@@ -93,8 +93,13 @@ namespace Intrepid2
       INTREPID2_TEST_FOR_EXCEPTION(projectedBasisNodes.extent_int(2) != spaceDim, std::invalid_argument, "projectedBasisNodes must have shape (C,F,D)");
       
       using ExecutionSpace = typename DeviceType::execution_space;
+#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
       using ProjectionTools  = Experimental::ProjectionTools<DeviceType>; 
       using ProjectionStruct = Experimental::ProjectionStruct<DeviceType,PointScalar>;
+#else
+      using ProjectionTools  = ProjectionTools<DeviceType>; 
+      using ProjectionStruct = ProjectionStruct<DeviceType,PointScalar>;
+#endif
       
       ProjectionStruct projectionStruct;
       ordinal_type targetQuadratureDegree(targetHGradBasis->getDegree()), targetDerivativeQuadratureDegree(targetHGradBasis->getDegree());

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_IntegratedLegendreBasis_HGRAD_PYR.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_IntegratedLegendreBasis_HGRAD_PYR.hpp
@@ -629,9 +629,9 @@ namespace Intrepid2
             // compute integrated Jacobi values for each desired value of alpha
             // relabel storage:
             // 1D containers:
-            auto & P_i_minus_1 = scratch1D_1;
-            auto & L_i_dt      = scratch1D_2; // R_{i-1} = d/dt L_i
-            auto & L_i         = scratch1D_3;
+            P_i_minus_1 = scratch1D_1;
+            L_i_dt      = scratch1D_2; // R_{i-1} = d/dt L_i
+            L_i         = scratch1D_3;
             // 2D containers:
             auto & L_2i_j_dt      = scratch2D_1;
             auto & L_2i_j         = scratch2D_2;

--- a/packages/intrepid2/src/Projection/Intrepid2_LagrangianInterpolation.hpp
+++ b/packages/intrepid2/src/Projection/Intrepid2_LagrangianInterpolation.hpp
@@ -103,7 +103,9 @@
 
 namespace Intrepid2 {
 
+#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
 namespace Experimental {
+#endif
 
 /** \class  Intrepid2::Experimental::LagrangianInterpolation
     \brief  A class providing static members to perform Lagrangian interpolation on a finite element.
@@ -132,7 +134,7 @@ template<typename DeviceType>
 class LagrangianInterpolation {
 public:
 
-
+#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
   /** \brief  Computes the points and coefficients associated with the basis DOFs for the reference oriented element
    *          WARNING: this method will probably be removed when the class will be moved out of the Experimental namespace.
 
@@ -187,7 +189,7 @@ public:
   getBasisCoeffs(basisCoeffsViewType basisCoeffs,
       const funcViewType functionAtDofCoords,
       const dofCoeffViewType dofCoeffs);
-
+#endif
 
 
   /** \brief  Computes the basis weights of the function interpolation.
@@ -206,7 +208,7 @@ public:
       \remark The output views need to be pre-allocated. <var><b>dofCoeffs</b></var> and <var><b>functionAtDofCoords</b></var> have
               rank 2, (C,F) for scalar basis and  3, (C,F,D) for vector basis.
               <var><b>functValsAtDofCoords</b></var> contains the function evaluated at the reference <var><b>dofCoords</b></var> and contravariantly transformed
-              to the reference element. The reference <var><b>dofCoords</b></var> are obtained with the method cellBasis->getDofCoords(...)
+              to the reference element. The reference <var><b>dofCoords</b></var> are obtained with the method cellBasis->getDofCoords(...), NOT with the getOrientedDofCoords() method
    */
   template<typename basisCoeffsViewType,
   typename funcViewType,
@@ -217,11 +219,78 @@ public:
       const funcViewType functionAtDofCoords,
       const BasisType* cellBasis,
       const ortViewType orts);
+  };
+
+#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
+}
+#endif
+
+/** \class  Intrepid2::LagrangianTools
+  \brief  A class providing tools for Lagrangian elements as static members.
+
+  Lagrangian orthonormal DOFs are defined as
+  \f[
+  L_i(f) := f(\mathbf x_i) \cdot \beta_i, \quad L_i(\phi_j) = \delta_{ij},
+  \f]
+  where \f$\beta_i\f$ are referred to as <var><b>dofCoeffs</b></var>, and \f$\mathbf x_i\f$ as the <var><b>dofCoords</b></var>.
+
+  This class provides tools to compute <var><b>dofCoords</b></var> and <var><b>dofCoeffs</b></var> for the <b>oriented</b> reference element.
+*/
+
+template<typename DeviceType>
+class LagrangianTools {
+public:
+
+  /** \brief  Computes the coordinates associated with the basis DOFs for the reference oriented element
+
+      \code
+      C  - num. cells
+      F  - num. fields
+      D  - spatial dimension
+      \endcode
+
+      \param  dofCoords        [out] - rank-3 view (C,F,D), that will contain coordinates associated with the basis DOFs.
+      \param  cellBasis        [in]  - pointer to the basis for the interpolation
+      \param  cellOrientations [in]  - rank-1 view (C) containing the Orientation objects at each cell
+
+      \remark the output views need to be pre-allocated.
+   */
+  template<typename BasisType,
+  class ...coordsProperties,
+  typename ortValueType, class ...ortProperties>
+  static void
+  getOrientedDofCoords(
+      Kokkos::DynRankView<typename BasisType::scalarType, coordsProperties...> dofCoords,
+      const BasisType* cellBasis,
+      const Kokkos::DynRankView<ortValueType,   ortProperties...>  cellOrientations
+  );
+
+      /** \brief  Computes the coefficients associated with the basis DOFs for the reference oriented element
+
+      \code
+      C  - num. cells
+      F  - num. fields
+      D  - spatial dimension
+      \endcode
+
+      \param  dofCoeffs        [out] - variable rank view that will contain coefficients associated with the basis DOFs.
+      \param  cellBasis        [in]  - pointer to the basis for the interpolation
+      \param  cellOrientations [in]  - rank-1 view (C) containing the Orientation objects at each cell
+
+      \remark the output views need to be pre-allocated. <var><b>dofCoeffs</b></var> has rank 2, (C,F) for scalar basis and  3,
+              (C,F,D) for vector basis.
+   */
+  template<typename BasisType,
+  class ...coeffsProperties,
+  typename ortValueType, class ...ortProperties>
+  static void
+  getOrientedDofCoeffs(
+      Kokkos::DynRankView<typename BasisType::scalarType, coeffsProperties...> dofCoeffs,
+      const BasisType* cellBasis,
+      const Kokkos::DynRankView<ortValueType,   ortProperties...>  cellOrientations
+  );
 };
-
 }
-}
-
 
 // include templated function definitions
 #include "Intrepid2_LagrangianInterpolationDef.hpp"

--- a/packages/intrepid2/src/Projection/Intrepid2_ProjectionStruct.hpp
+++ b/packages/intrepid2/src/Projection/Intrepid2_ProjectionStruct.hpp
@@ -56,8 +56,9 @@
 #include <array>
 
 namespace Intrepid2 {
-
+#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
 namespace Experimental {
+#endif
 
 /** \class  Intrepid2::Experimental::ProjectionStruct
     \brief  An helper class to compute the evaluation points and weights needed for performing projections
@@ -527,9 +528,10 @@ public:
   ordinal_type maxNumBasisDerivEvalPoints;
   ordinal_type maxNumTargetDerivEvalPoints;
 };
-
+#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
 }
-}
+#endif
+} // Intrepid2 namespace
 #include "Intrepid2_ProjectionStructDef.hpp"
 #endif
 

--- a/packages/intrepid2/src/Projection/Intrepid2_ProjectionStructDef.hpp
+++ b/packages/intrepid2/src/Projection/Intrepid2_ProjectionStructDef.hpp
@@ -94,7 +94,6 @@ void ProjectionStruct<DeviceType,ValueType>::createL2ProjectionStruct(const Basi
 
   numBasisEvalPoints += numVertices;
   numTargetEvalPoints += numVertices;
-  host_view_type coord("vertex_coord", dim);
 
   basisPointsRange = range_tag("basisPointsRange", 4,maxSubCellsCount);
   targetPointsRange = range_tag("targetPointsRange", 4,maxSubCellsCount);
@@ -103,16 +102,14 @@ void ProjectionStruct<DeviceType,ValueType>::createL2ProjectionStruct(const Basi
   subCellTopologyKey = key_tag("subCellTopologyKey",numberSubCellDims,maxSubCellsCount);
 
   maxNumBasisEvalPoints = numVertices; maxNumTargetEvalPoints = numVertices;
+
+  // The set of the eval points on the reference vertex contains only point (0.0).
+  // Not very useful, updating these for completeness  
   for(ordinal_type iv=0; iv<numVertices; ++iv) {
     basisPointsRange(0,iv) = range_type(iv, iv+1);
-    basisCubPoints[0][iv] = host_view_type("basisCubPoints",1,dim);
+    basisCubPoints[0][iv] = host_view_type("basisCubPoints",1,1);
     targetPointsRange(0,iv) = range_type(iv, iv+1);
-    targetCubPoints[0][iv] = host_view_type("targetCubPoints",1,dim);
-    CellTools<HostDeviceType>::getReferenceVertex(coord, cellTopo, iv);
-    for(ordinal_type d=0; d<dim; d++) {
-      basisCubPoints[0][iv](0,d) = coord(d);
-      targetCubPoints[0][iv](0,d) = coord(d);
-    }
+    targetCubPoints[0][iv] = host_view_type("targetCubPoints",1,1);
   }
 
   if (cellBasis->getFunctionSpace() == FUNCTION_SPACE_HCURL) {
@@ -199,7 +196,6 @@ void ProjectionStruct<DeviceType,ValueType>::createL2ProjectionStruct(const Basi
   allTargetDerivEPoints = view_type("allTargetDerivPoints", numTargetDerivEvalPoints, dim);
 
   if(numVertices>0) {
-    host_view_type coord("vertex_coord", dim);
     for(ordinal_type iv=0; iv<numVertices; ++iv) {
       CellTools<DeviceType>::getReferenceVertex(Kokkos::subview(allBasisEPoints, iv, Kokkos::ALL()), cellTopo, iv);
       CellTools<DeviceType>::getReferenceVertex(Kokkos::subview(allTargetEPoints, iv, Kokkos::ALL()), cellTopo, iv);
@@ -277,17 +273,14 @@ void ProjectionStruct<DeviceType,ValueType>::createHGradProjectionStruct(const B
 
   numBasisEvalPoints += numVertices;
   numTargetEvalPoints += numVertices;
-  host_view_type coord("vertex_coord", dim);
+  
+  // The set of the eval points on the reference vertex contains only point (0.0).
+  // Not very useful, updating these for completeness  
   for(ordinal_type iv=0; iv<numVertices; ++iv) {
     basisPointsRange(0,iv) = range_type(iv, iv+1);
-    basisCubPoints[0][iv] = host_view_type("basisCubPoints",1,dim);
+    basisCubPoints[0][iv] = host_view_type("basisCubPoints",1,1);
     targetPointsRange(0,iv) = range_type(iv, iv+1);
-    targetCubPoints[0][iv] = host_view_type("targetCubPoints",1,dim);
-    CellTools<HostDeviceType>::getReferenceVertex(coord, cellTopo, iv);
-    for(ordinal_type d=0; d<dim; d++) {
-      basisCubPoints[0][iv](0,d) = coord(d);
-      targetCubPoints[0][iv](0,d) = coord(d);
-    }
+    targetCubPoints[0][iv] = host_view_type("targetCubPoints",1,1);
   }
 
   DefaultCubatureFactory cub_factory;
@@ -359,7 +352,6 @@ void ProjectionStruct<DeviceType,ValueType>::createHGradProjectionStruct(const B
   allTargetDerivEPoints = view_type("allTargetDerivPoints", numTargetDerivEvalPoints, dim);
 
   if(numVertices>0) {
-    host_view_type coord("vertex_coord", dim);
     for(ordinal_type iv=0; iv<numVertices; ++iv) {
       CellTools<DeviceType>::getReferenceVertex(Kokkos::subview(allBasisEPoints, iv, Kokkos::ALL()), cellTopo, iv);
       CellTools<DeviceType>::getReferenceVertex(Kokkos::subview(allTargetEPoints, iv, Kokkos::ALL()), cellTopo, iv);

--- a/packages/intrepid2/src/Projection/Intrepid2_ProjectionStructDef.hpp
+++ b/packages/intrepid2/src/Projection/Intrepid2_ProjectionStructDef.hpp
@@ -61,7 +61,10 @@
 
 namespace Intrepid2 {
 
+#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
 namespace Experimental {
+#endif
+
 template<typename DeviceType, typename ValueType>
 template<typename BasisPtrType>
 void ProjectionStruct<DeviceType,ValueType>::createL2ProjectionStruct(const BasisPtrType cellBasis,
@@ -769,9 +772,10 @@ void ProjectionStruct<DeviceType,ValueType>::createHVolProjectionStruct(const Ba
   allBasisDerivEPoints = view_type("allBasisDerivPoints", numBasisDerivEvalPoints, dim);
   allTargetDerivEPoints = view_type("allTargetDerivPoints", numTargetDerivEvalPoints, dim);
 }
-
+#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
 }
-}
+#endif
+}  // Intrepid2 namespace
 #endif
 
 

--- a/packages/intrepid2/src/Projection/Intrepid2_ProjectionTools.hpp
+++ b/packages/intrepid2/src/Projection/Intrepid2_ProjectionTools.hpp
@@ -88,8 +88,9 @@
 #endif
 
 namespace Intrepid2 {
-
+#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
 namespace Experimental {
+#endif
 
 
 
@@ -152,7 +153,7 @@ public:
   using MemSpaceType = typename DeviceType::memory_space;
   using EvalPointsType = typename ProjectionStruct<DeviceType, double>::EvalPointsType;
 
-
+#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
   /** \brief  Computes evaluation points for L2 projection
    *          WARNING: this function will be removed when the class will be moved out of the namespace Experimental
 
@@ -211,6 +212,7 @@ public:
       const BasisType* cellBasis,
       ProjectionStruct<DeviceType, typename BasisType::scalarType> * projStruct);
 
+#endif
 
   /** \brief  Computes the basis coefficients of the L2 projection of the target function
 
@@ -242,7 +244,7 @@ public:
       const BasisType* cellBasis,
       ProjectionStruct<DeviceType, typename BasisType::scalarType> * projStruct);
 
-
+#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
   /** \brief  Computes evaluation points for local L2 projection
      for broken HGRAD HCURL HDIV and HVOL spaces
      WARNING: this function will be removed when the class will be moved out of the namespace Experimental
@@ -267,6 +269,7 @@ public:
       ProjectionStruct<DeviceType, typename BasisType::scalarType> * projStruct,
       const EvalPointsType evalPointType = EvalPointsType::TARGET
   );
+#endif
 
   /** \brief  Computes evaluation points for local L2 projection
      for broken HGRAD HCURL HDIV and HVOL spaces
@@ -331,7 +334,7 @@ public:
       const BasisType* cellBasis,
       ProjectionStruct<DeviceType, typename BasisType::scalarType> * projStruct);
 
-
+#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
   /** \brief  Computes evaluation points for HGrad projection
    *          WARNING: this function will be removed when the class will be moved out of the namespace Experimental
 
@@ -396,7 +399,7 @@ public:
                       const OrientationViewType cellOrientations,
                       const BasisType* cellBasis,
                       ProjectionStruct<DeviceType, typename BasisType::scalarType> * projStruct);
-
+#endif
 
   /** \brief  Computes the basis coefficients of the HGrad projection of the target function
 
@@ -429,7 +432,7 @@ public:
                       const BasisType* cellBasis,
                       ProjectionStruct<DeviceType, typename BasisType::scalarType> * projStruct);
 
-
+#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
   /** \brief  Computes evaluation points for HCurl projection
    *          WARNING: this function will be removed when the class will be moved out of the namespace Experimental
 
@@ -501,6 +504,8 @@ public:
       const BasisType* cellBasis,
       ProjectionStruct<DeviceType, typename BasisType::scalarType> * projStruct);
 
+#endif
+
   /** \brief  Computes the basis coefficients of the HCurl projection of the target function
 
       \code
@@ -537,6 +542,7 @@ public:
       ProjectionStruct<DeviceType, typename BasisType::scalarType> * projStruct);
 
 
+#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
   /** \brief  Computes evaluation points for HDiv projection
    *          WARNING: this function will be removed when the class will be moved out of the namespace Experimental
 
@@ -605,7 +611,7 @@ public:
       const Kokkos::DynRankView<ortValueType,   ortProperties...>  cellOrientations,
       const BasisType* cellBasis,
       ProjectionStruct<DeviceType, typename BasisType::scalarType> * projStruct);
-
+#endif
   
   /** \brief  Computes the basis coefficients of the HDiv projection of the target function
 
@@ -640,6 +646,7 @@ public:
       const BasisType* cellBasis,
       ProjectionStruct<DeviceType, typename BasisType::scalarType> * projStruct);
 
+#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
   /** \brief  Computes evaluation points for HVol projection
    *          WARNING: this function will be removed when the class will be moved out of the namespace Experimental
 
@@ -697,7 +704,7 @@ public:
       const Kokkos::DynRankView<ortValueType,   ortProperties...>  cellOrientations,
       const BasisType* cellBasis,
       ProjectionStruct<DeviceType, typename BasisType::scalarType> * projStruct);
-
+#endif
 
   /** \brief  Computes the basis coefficients of the HVol projection of the target function
 
@@ -1155,8 +1162,9 @@ public:
   };
   
 };
-
+#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
 } //Experimental
+#endif
 } //Intrepid2
 
 

--- a/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefHCURL.hpp
+++ b/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefHCURL.hpp
@@ -56,7 +56,8 @@
 
 
 namespace Intrepid2 {
-namespace Experimental {
+
+namespace FunctorsProjectionTools {
 
 template<typename ViewType1, typename ViewType2, typename ViewType3, typename ViewType4>
 struct ComputeBasisCoeffsOnEdges_HCurl {
@@ -409,6 +410,11 @@ struct ComputeBasisCoeffsOnCell_HCurl {
   }
 };
 
+} // FunctorsProjectionTools namespace
+
+#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
+namespace Experimental {
+
 
 template<typename DeviceType>
 template<typename BasisType,
@@ -441,6 +447,7 @@ ProjectionTools<DeviceType>::getHCurlBasisCoeffs(Kokkos::DynRankView<basisCoeffs
     
     getHCurlBasisCoeffs(basisCoeffs, targetAtTargetEPoints, targetCurlAtTargetCurlEPoints, orts, cellBasis, projStruct);
 }
+#endif
 
 
 template<typename DeviceType>
@@ -564,7 +571,7 @@ ProjectionTools<DeviceType>::getHCurlBasisCoeffs(Kokkos::DynRankView<basisCoeffs
     ordinal_type offsetBasis = basisEPointsRange(edgeDim, ie).first;
     ordinal_type offsetTarget = targetEPointsRange(edgeDim, ie).first;
 
-    typedef ComputeBasisCoeffsOnEdges_HCurl<ScalarViewType,  decltype(basisEWeights), decltype(tagToOrdinal), decltype(targetAtTargetEPoints)> functorTypeEdge;
+    using functorTypeEdge = FunctorsProjectionTools::ComputeBasisCoeffsOnEdges_HCurl<ScalarViewType,  decltype(basisEWeights), decltype(tagToOrdinal), decltype(targetAtTargetEPoints)>;
     Kokkos::parallel_for(policy, functorTypeEdge(basisTanAtBasisEPoints,basisAtBasisEPoints,basisEWeights,
         weightedTanBasisAtBasisEPoints, targetEWeights,
         basisAtTargetEPoints, weightedTanBasisAtTargetEPoints, tagToOrdinal,
@@ -664,8 +671,8 @@ ProjectionTools<DeviceType>::getHCurlBasisCoeffs(Kokkos::DynRankView<basisCoeffs
     auto targetCurlEWeights = Kokkos::create_mirror_view_and_copy(MemSpaceType(),projStruct->getTargetDerivEvalWeights(faceDim,iface));
     auto basisCurlEWeights = Kokkos::create_mirror_view_and_copy(MemSpaceType(),projStruct->getBasisDerivEvalWeights(faceDim,iface));
     const auto topoKey = refTopologyKey(faceDim, iface);
-    typedef ComputeBasisCoeffsOnFaces_HCurl<decltype(basisCoeffs), decltype(orts), ScalarViewType,  decltype(targetAtTargetEPoints), decltype(basisEWeights),
-        decltype(tagToOrdinal), decltype(subcellParamFace), decltype(computedDofs)> functorTypeFaces;
+    using functorTypeFaces = FunctorsProjectionTools::ComputeBasisCoeffsOnFaces_HCurl<decltype(basisCoeffs), decltype(orts), ScalarViewType,  decltype(targetAtTargetEPoints), decltype(basisEWeights),
+        decltype(tagToOrdinal), decltype(subcellParamFace), decltype(computedDofs)>;
     Kokkos::parallel_for(policy, functorTypeFaces(basisCoeffs,
         orts, negPartialProjTan, negPartialProjCurlNormal,
         hgradBasisGradAtBasisEPoints, wHgradBasisGradAtBasisEPoints,
@@ -771,8 +778,8 @@ ProjectionTools<DeviceType>::getHCurlBasisCoeffs(Kokkos::DynRankView<basisCoeffs
 
     auto hGradTagToOrdinal = Kokkos::create_mirror_view_and_copy(MemSpaceType(), hgradBasis->getAllDofOrdinal());
 
-    typedef ComputeBasisCoeffsOnCell_HCurl<decltype(basisCoeffs), ScalarViewType,  decltype(basisEWeights),
-        decltype(computedDofs), decltype(tagToOrdinal)> functorTypeCell;
+    using functorTypeCell = FunctorsProjectionTools::ComputeBasisCoeffsOnCell_HCurl<decltype(basisCoeffs), ScalarViewType,  decltype(basisEWeights),
+        decltype(computedDofs), decltype(tagToOrdinal)>;
     Kokkos::parallel_for(policy, functorTypeCell(basisCoeffs, negPartialProj, negPartialProjCurl,
         cellBasisAtBasisEPoints, cellBasisCurlAtCurlEPoints,
         basisAtBasisEPoints, hgradBasisGradAtBasisEPoints, basisCurlAtBasisCurlEPoints,
@@ -813,8 +820,10 @@ ProjectionTools<DeviceType>::getHCurlBasisCoeffs(Kokkos::DynRankView<basisCoeffs
     delete hgradBasis;
   }
 }
+#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
 }
-}
+#endif
+}   // Intrepid2 namespace
 
 #endif
 

--- a/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefHDIV.hpp
+++ b/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefHDIV.hpp
@@ -55,8 +55,8 @@
 
 
 namespace Intrepid2 {
-namespace Experimental {
 
+namespace FunctorsProjectionTools {
 
 template<typename ViewType1, typename ViewType2, typename ViewType3, typename ViewType4>
 struct ComputeBasisCoeffsOnSides_HDiv {
@@ -240,6 +240,10 @@ struct ComputeHCurlBasisCoeffsOnCells_HDiv {
     }
   }
 };
+}  // FunctorsProjectionTools namespace
+
+#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
+namespace Experimental {
 
 
 template<typename DeviceType>
@@ -273,6 +277,8 @@ ProjectionTools<DeviceType>::getHDivBasisCoeffs(Kokkos::DynRankView<basisCoeffsV
     ProjectionStruct<DeviceType, typename BasisType::scalarType> * projStruct){
       getHDivBasisCoeffs(basisCoeffs, targetAtEPoints, targetDivAtDivEPoints, orts, cellBasis, projStruct);
 }
+
+#endif
 
 template<typename DeviceType>
 template<typename basisCoeffsValueType, class ...basisCoeffsProperties,
@@ -376,7 +382,7 @@ ProjectionTools<DeviceType>::getHDivBasisCoeffs(Kokkos::DynRankView<basisCoeffsV
     auto basisEWeights = Kokkos::create_mirror_view_and_copy(MemSpaceType(),projStruct->getBasisEvalWeights(sideDim,is));
 
 
-    typedef ComputeBasisCoeffsOnSides_HDiv<ScalarViewType,  decltype(basisEWeights), decltype(tagToOrdinal), decltype(targetAtEPoints)> functorTypeSide;
+    using functorTypeSide = FunctorsProjectionTools::ComputeBasisCoeffsOnSides_HDiv<ScalarViewType,  decltype(basisEWeights), decltype(tagToOrdinal), decltype(targetAtEPoints)>;
     Kokkos::parallel_for(policy, functorTypeSide(basisNormalAtBasisEPoints, basisAtBasisEPoints,
         basisEWeights,  wBasisNormalAtBasisEPoints, targetEWeights,
         basisAtTargetEPoints, wBasisNormalAtTargetEPoints, tagToOrdinal,
@@ -456,7 +462,7 @@ ProjectionTools<DeviceType>::getHDivBasisCoeffs(Kokkos::DynRankView<basisCoeffsV
   ScalarViewType targetSideDivAtBasisEPoints("targetSideDivAtBasisEPoints",numCells, numBasisDivEPoints);
 
   auto cellDofs = Kokkos::subview(tagToOrdinal, dim, 0, Kokkos::ALL());
-  typedef ComputeBasisCoeffsOnCells_HDiv<decltype(basisCoeffs), ScalarViewType,  decltype(divEWeights), decltype(computedDofs), decltype(cellDofs)> functorType;
+  using functorType = FunctorsProjectionTools::ComputeBasisCoeffsOnCells_HDiv<decltype(basisCoeffs), ScalarViewType,  decltype(divEWeights), decltype(computedDofs), decltype(cellDofs)>;
   Kokkos::parallel_for(policy, functorType( basisCoeffs, targetSideDivAtBasisEPoints,  basisDivAtBasisEPoints,
       basisDivAtBasisDivEPoints, divEWeights,  weightedBasisDivAtBasisEPoints, targetDivEWeights, basisDivAtTargetDivEPoints, weightedBasisDivAtTargetEPoints,
       computedDofs, cellDofs, numCellDofs, offsetBasisDiv, offsetTargetDiv, numSideDofs));
@@ -498,8 +504,8 @@ ProjectionTools<DeviceType>::getHDivBasisCoeffs(Kokkos::DynRankView<basisCoeffsV
     auto hCurlTagToOrdinal = Kokkos::create_mirror_view_and_copy(MemSpaceType(), hcurlBasis->getAllDofOrdinal());
     auto cellHCurlDof = Kokkos::subview(hCurlTagToOrdinal, dim, 0, range_type(0, numCurlInteriorDOFs));
 
-    typedef ComputeHCurlBasisCoeffsOnCells_HDiv<decltype(basisCoeffs), ScalarViewType,  decltype(divEWeights),
-        decltype(tagToOrdinal), decltype(computedDofs), decltype(cellDofs)> functorTypeHCurlCells;
+    using functorTypeHCurlCells = FunctorsProjectionTools::ComputeHCurlBasisCoeffsOnCells_HDiv<decltype(basisCoeffs), ScalarViewType,  decltype(divEWeights),
+        decltype(tagToOrdinal), decltype(computedDofs), decltype(cellDofs)>;
     Kokkos::parallel_for(policy, functorTypeHCurlCells(basisCoeffs, negPartialProjAtBasisEPoints,  nonWeightedBasisAtBasisEPoints,
         basisAtBasisEPoints, hcurlBasisCurlAtBasisEPoints, basisEWeights, wHcurlBasisCurlAtBasisEPoints, targetEWeights,
         hcurlBasisCurlAtTargetEPoints, wHcurlBasisCurlAtTargetEPoints, tagToOrdinal, computedDofs, cellHCurlDof,
@@ -519,10 +525,10 @@ ProjectionTools<DeviceType>::getHDivBasisCoeffs(Kokkos::DynRankView<basisCoeffsV
   cellSystem.solve(basisCoeffs, massMat_, rhsMatTrans, t_, w_, cellDofs, numCellDofs, numCurlInteriorDOFs);
 }
 
-
-
+#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
 }
-}
+#endif
+}  // Intrepid2 namespace
 
 #endif
 

--- a/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefHVOL.hpp
+++ b/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefHVOL.hpp
@@ -55,6 +55,8 @@
 
 
 namespace Intrepid2 {
+
+#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
 namespace Experimental {
 
 template<typename DeviceType>
@@ -83,6 +85,7 @@ ProjectionTools<DeviceType>::getHVolBasisCoeffs(Kokkos::DynRankView<basisCoeffsV
     ProjectionStruct<DeviceType, typename BasisType::scalarType> * projStruct){
       getHVolBasisCoeffs(basisCoeffs, targetAtTargetEPoints, orts, cellBasis, projStruct);
 }
+#endif
 
 template<typename DeviceType>
 template<typename basisCoeffsValueType, class ...basisCoeffsProperties,
@@ -163,9 +166,10 @@ ProjectionTools<DeviceType>::getHVolBasisCoeffs(Kokkos::DynRankView<basisCoeffsV
   ElemSystem cellSystem("cellSystem", true);
   cellSystem.solve(basisCoeffs, massMat, rhsMat, t_, w_, cellDofs, basisCardinality);
 }
-
+#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
 }
-}
+#endif
+} // Intrepid2 namespace
 
 #endif
 

--- a/packages/intrepid2/unit-test/Projection/test_DeRham_commutativity_HEX.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_DeRham_commutativity_HEX.hpp
@@ -270,12 +270,18 @@ int DeRhamCommutativityHex(const bool verbose) {
     degree() {return 4;}
   };
 
-  typedef std::array<ordinal_type,4> faceType;
-  typedef CellTools<DeviceType> ct;
-  typedef OrientationTools<DeviceType> ots;
-  typedef Experimental::ProjectionTools<DeviceType> pts;
-  typedef RealSpaceTools<DeviceType> rst;
-  typedef FunctionSpaceTools<DeviceType> fst;
+  using faceType = std::array<ordinal_type,4>;
+  using ct = CellTools<DeviceType>;
+  using ots = OrientationTools<DeviceType>;
+  #ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
+  using pts = Experimental::ProjectionTools<DeviceType>;
+  using ProjStruct = Experimental::ProjectionStruct<DeviceType,ValueType>;
+  #else
+  using pts = ProjectionTools<DeviceType>;
+  using ProjStruct = ProjectionStruct<DeviceType,ValueType>;
+  #endif
+  using rst = RealSpaceTools<DeviceType>;
+  using fst = FunctionSpaceTools<DeviceType>;
 
   constexpr ordinal_type dim = 3;
   constexpr ordinal_type numCells = 2;
@@ -386,7 +392,7 @@ int DeRhamCommutativityHex(const bool verbose) {
         {
           ordinal_type targetCubDegree(Fun::degree()),targetDerivCubDegree(GradFun::degree());
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createHGradProjectionStruct(&basis, targetCubDegree, targetDerivCubDegree);
           auto evaluationPoints = projStruct.getAllEvalPoints();
           auto evaluationGradPoints = projStruct.getAllDerivEvalPoints();
@@ -451,7 +457,7 @@ int DeRhamCommutativityHex(const bool verbose) {
         {
           ordinal_type targetCubDegree(GradFun::degree()),targetDerivCubDegree(0);
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createHCurlProjectionStruct(&basisHCurl, targetCubDegree, targetDerivCubDegree);
 
           auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -701,7 +707,7 @@ int DeRhamCommutativityHex(const bool verbose) {
           ordinal_type targetCubDegree(FunCurl::degree()),targetDerivCubDegree(CurlFunCurl::degree());
 
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createHCurlProjectionStruct(&basis, targetCubDegree, targetDerivCubDegree);
 
           auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -781,7 +787,7 @@ int DeRhamCommutativityHex(const bool verbose) {
         {
           ordinal_type targetCubDegree(CurlFunCurl::degree()),targetDerivCubDegree(0);
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createHDivProjectionStruct(&basisHDiv, targetCubDegree, targetDerivCubDegree);
 
           auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -1026,7 +1032,7 @@ int DeRhamCommutativityHex(const bool verbose) {
           ordinal_type targetCubDegree(FunDiv::degree()),targetDerivCubDegree(DivFunDiv::degree());
 
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createHDivProjectionStruct(&basis, targetCubDegree, targetDerivCubDegree);
 
           auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -1099,7 +1105,7 @@ int DeRhamCommutativityHex(const bool verbose) {
         {
           ordinal_type targetCubDegree(DivFunDiv::degree());
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createHVolProjectionStruct(&basisHVol, targetCubDegree);
 
           auto evaluationPoints = projStruct.getAllEvalPoints();

--- a/packages/intrepid2/unit-test/Projection/test_DeRham_commutativity_QUAD.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_DeRham_commutativity_QUAD.hpp
@@ -262,11 +262,17 @@ int DeRhamCommutativityQuad(const bool verbose) {
     degree() {return 4;}
   };
 
-  typedef CellTools<DeviceType> ct;
-  typedef OrientationTools<DeviceType> ots;
-  typedef Experimental::ProjectionTools<DeviceType> pts;
-  typedef RealSpaceTools<DeviceType> rst;
-  typedef FunctionSpaceTools<DeviceType> fst;
+  using ct = CellTools<DeviceType>;
+  using ots = OrientationTools<DeviceType>;
+  #ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
+  using pts = Experimental::ProjectionTools<DeviceType>;
+  using ProjStruct = Experimental::ProjectionStruct<DeviceType,ValueType>;
+  #else
+  using pts = ProjectionTools<DeviceType>;
+  using ProjStruct = ProjectionStruct<DeviceType,ValueType>;
+  #endif
+  using rst = RealSpaceTools<DeviceType>;
+  using fst = FunctionSpaceTools<DeviceType>;
 
   constexpr ordinal_type dim = 2;
   constexpr ordinal_type numCells = 2;
@@ -357,7 +363,7 @@ int DeRhamCommutativityQuad(const bool verbose) {
         {
           ordinal_type targetCubDegree(Fun::degree()),targetDerivCubDegree(GradFun::degree());
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createHGradProjectionStruct(&basis, targetCubDegree, targetDerivCubDegree);
           auto evaluationPoints = projStruct.getAllEvalPoints();
           auto evaluationGradPoints = projStruct.getAllDerivEvalPoints();
@@ -422,7 +428,7 @@ int DeRhamCommutativityQuad(const bool verbose) {
         {
           ordinal_type targetCubDegree(GradFun::degree()),targetDerivCubDegree(0);
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createHCurlProjectionStruct(&basisHCurl, targetCubDegree, targetDerivCubDegree);
 
           auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -569,7 +575,7 @@ int DeRhamCommutativityQuad(const bool verbose) {
         {
           ordinal_type targetCubDegree(GradFun::degree()),targetDerivCubDegree(0);
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createHDivProjectionStruct(&basisHDiv, targetCubDegree, targetDerivCubDegree);
 
           auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -805,7 +811,7 @@ int DeRhamCommutativityQuad(const bool verbose) {
           ordinal_type targetCubDegree(FunCurl::degree()),targetDerivCubDegree(CurlFunCurl::degree());
 
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createHCurlProjectionStruct(&basis, targetCubDegree, targetDerivCubDegree);
 
           auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -881,7 +887,7 @@ int DeRhamCommutativityQuad(const bool verbose) {
         {
           ordinal_type targetCubDegree(CurlFunCurl::degree());
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createHVolProjectionStruct(&basisHVol, targetCubDegree);
 
           auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -1107,7 +1113,7 @@ int DeRhamCommutativityQuad(const bool verbose) {
           ordinal_type targetCubDegree(FunDiv::degree()),targetDerivCubDegree(DivFunDiv::degree());
 
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createHDivProjectionStruct(&basis, targetCubDegree, targetDerivCubDegree);
 
           auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -1182,7 +1188,7 @@ int DeRhamCommutativityQuad(const bool verbose) {
         {
           ordinal_type targetCubDegree(DivFunDiv::degree());
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createHVolProjectionStruct(&basisHVol, targetCubDegree);
 
           auto evaluationPoints = projStruct.getAllEvalPoints();

--- a/packages/intrepid2/unit-test/Projection/test_DeRham_commutativity_TET.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_DeRham_commutativity_TET.hpp
@@ -270,11 +270,17 @@ int DeRhamCommutativityTet(const bool verbose) {
     degree() {return 4;}
   };
 
-  typedef CellTools<DeviceType> ct;
-  typedef OrientationTools<DeviceType> ots;
-  typedef Experimental::ProjectionTools<DeviceType> pts;
-  typedef RealSpaceTools<DeviceType> rst;
-  typedef FunctionSpaceTools<DeviceType> fst;
+  using ct = CellTools<DeviceType>;
+  using ots = OrientationTools<DeviceType>;
+  #ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
+  using pts = Experimental::ProjectionTools<DeviceType>;
+  using ProjStruct = Experimental::ProjectionStruct<DeviceType,ValueType>;
+  #else
+  using pts = ProjectionTools<DeviceType>;
+  using ProjStruct = ProjectionStruct<DeviceType,ValueType>;
+  #endif
+  using rst = RealSpaceTools<DeviceType>;
+  using fst = FunctionSpaceTools<DeviceType>;
 
   constexpr ordinal_type dim = 3;
   constexpr ordinal_type numCells = 2;
@@ -365,7 +371,7 @@ int DeRhamCommutativityTet(const bool verbose) {
         {
           ordinal_type targetCubDegree(Fun::degree()),targetDerivCubDegree(GradFun::degree());
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createHGradProjectionStruct(&basis, targetCubDegree, targetDerivCubDegree);
           auto evaluationPoints = projStruct.getAllEvalPoints();
           auto evaluationGradPoints = projStruct.getAllDerivEvalPoints();
@@ -430,7 +436,7 @@ int DeRhamCommutativityTet(const bool verbose) {
         {
           ordinal_type targetCubDegree(GradFun::degree()),targetDerivCubDegree(0);
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createHCurlProjectionStruct(&basisHCurl, targetCubDegree, targetDerivCubDegree);
 
           auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -665,7 +671,7 @@ int DeRhamCommutativityTet(const bool verbose) {
           ordinal_type targetCubDegree(FunCurl::degree()),targetDerivCubDegree(CurlFunCurl::degree());
 
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createHCurlProjectionStruct(&basis, targetCubDegree, targetDerivCubDegree);
 
           auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -745,7 +751,7 @@ int DeRhamCommutativityTet(const bool verbose) {
         {
           ordinal_type targetCubDegree(CurlFunCurl::degree()),targetDerivCubDegree(0);
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createHDivProjectionStruct(&basisHDiv, targetCubDegree, targetDerivCubDegree);
 
           auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -976,7 +982,7 @@ int DeRhamCommutativityTet(const bool verbose) {
           ordinal_type targetCubDegree(FunDiv::degree()),targetDerivCubDegree(DivFunDiv::degree());
 
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createHDivProjectionStruct(&basis, targetCubDegree, targetDerivCubDegree);
 
           auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -1049,7 +1055,7 @@ int DeRhamCommutativityTet(const bool verbose) {
         {
           ordinal_type targetCubDegree(DivFunDiv::degree());
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createHVolProjectionStruct(&basisHVol, targetCubDegree);
 
           auto evaluationPoints = projStruct.getAllEvalPoints();

--- a/packages/intrepid2/unit-test/Projection/test_DeRham_commutativity_TRI.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_DeRham_commutativity_TRI.hpp
@@ -262,11 +262,17 @@ int DeRhamCommutativityTri(const bool verbose) {
     degree() {return 5;}
   };
 
-  typedef CellTools<DeviceType> ct;
-  typedef OrientationTools<DeviceType> ots;
-  typedef Experimental::ProjectionTools<DeviceType> pts;
-  typedef RealSpaceTools<DeviceType> rst;
-  typedef FunctionSpaceTools<DeviceType> fst;
+  using ct = CellTools<DeviceType>;
+  using ots = OrientationTools<DeviceType>;
+  #ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
+  using pts = Experimental::ProjectionTools<DeviceType>;
+  using ProjStruct = Experimental::ProjectionStruct<DeviceType,ValueType>;
+  #else
+  using pts = ProjectionTools<DeviceType>;
+  using ProjStruct = ProjectionStruct<DeviceType,ValueType>;
+  #endif
+  using rst = RealSpaceTools<DeviceType>;
+  using fst = FunctionSpaceTools<DeviceType>;
 
   constexpr ordinal_type dim = 2;
   constexpr ordinal_type numCells = 2;
@@ -357,7 +363,7 @@ int DeRhamCommutativityTri(const bool verbose) {
         {
           ordinal_type targetCubDegree(Fun::degree()),targetDerivCubDegree(GradFun::degree());
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createHGradProjectionStruct(&basis, targetCubDegree, targetDerivCubDegree);
           auto evaluationPoints = projStruct.getAllEvalPoints();
           auto evaluationGradPoints = projStruct.getAllDerivEvalPoints();
@@ -422,7 +428,7 @@ int DeRhamCommutativityTri(const bool verbose) {
         {
           ordinal_type targetCubDegree(GradFun::degree()),targetDerivCubDegree(0);
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createHCurlProjectionStruct(&basisHCurl, targetCubDegree, targetDerivCubDegree);
 
           auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -569,7 +575,7 @@ int DeRhamCommutativityTri(const bool verbose) {
         {
           ordinal_type targetCubDegree(GradFun::degree()),targetDerivCubDegree(0);
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createHDivProjectionStruct(&basisHDiv, targetCubDegree, targetDerivCubDegree);
 
           auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -805,7 +811,7 @@ int DeRhamCommutativityTri(const bool verbose) {
           ordinal_type targetCubDegree(FunCurl::degree()),targetDerivCubDegree(CurlFunCurl::degree());
 
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createHCurlProjectionStruct(&basis, targetCubDegree, targetDerivCubDegree);
 
           auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -881,7 +887,7 @@ int DeRhamCommutativityTri(const bool verbose) {
         {
           ordinal_type targetCubDegree(CurlFunCurl::degree());
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createHVolProjectionStruct(&basisHVol, targetCubDegree);
 
           auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -1107,7 +1113,7 @@ int DeRhamCommutativityTri(const bool verbose) {
           ordinal_type targetCubDegree(FunDiv::degree()),targetDerivCubDegree(DivFunDiv::degree());
 
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createHDivProjectionStruct(&basis, targetCubDegree, targetDerivCubDegree);
 
           auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -1182,7 +1188,7 @@ int DeRhamCommutativityTri(const bool verbose) {
         {
           ordinal_type targetCubDegree(DivFunDiv::degree());
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createHVolProjectionStruct(&basisHVol, targetCubDegree);
 
           auto evaluationPoints = projStruct.getAllEvalPoints();

--- a/packages/intrepid2/unit-test/Projection/test_DeRham_commutativity_WEDGE.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_DeRham_commutativity_WEDGE.hpp
@@ -267,11 +267,17 @@ int DeRhamCommutativityWedge(const bool verbose) {
     degree() {return 4;}
   };
 
-  typedef CellTools<DeviceType> ct;
-  typedef OrientationTools<DeviceType> ots;
-  typedef Experimental::ProjectionTools<DeviceType> pts;
-  typedef RealSpaceTools<DeviceType> rst;
-  typedef FunctionSpaceTools<DeviceType> fst;
+  using ct = CellTools<DeviceType>;
+  using ots = OrientationTools<DeviceType>;
+  #ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
+  using pts = Experimental::ProjectionTools<DeviceType>;
+  using ProjStruct = Experimental::ProjectionStruct<DeviceType,ValueType>;
+  #else
+  using pts = ProjectionTools<DeviceType>;
+  using ProjStruct = ProjectionStruct<DeviceType,ValueType>;
+  #endif
+  using rst = RealSpaceTools<DeviceType>;
+  using fst = FunctionSpaceTools<DeviceType>;
 
   constexpr ordinal_type dim = 3;
   constexpr ordinal_type numCells = 2;
@@ -281,8 +287,8 @@ int DeRhamCommutativityWedge(const bool verbose) {
   ValueType  vertices_orig[numTotalVertexes][dim] = {{0,0,-1},{0,1,-1},{1,0,-1},{0,0,1},{0,1,1},{1,0,1},{1,1,-1},{1,1,1}};
   ordinal_type wedges_orig[numCells][numElemVertexes] = {{0,1,2,3,4,5},{1,6,2,4,7,5}};  //common face is {1,2,4,5}
 
-  typedef std::array<ordinal_type,3> baseFaceType;
-  typedef std::array<ordinal_type,4> latFaceType;
+  using baseFaceType = std::array<ordinal_type,3>;
+  using latFaceType = std::array<ordinal_type,4>;
   latFaceType common_face = {{1,2,5,4}};
   const baseFaceType bottomFace = {{0,2,1}};
   const baseFaceType topFace = {{3,4,5}};
@@ -385,7 +391,7 @@ int DeRhamCommutativityWedge(const bool verbose) {
         {
           ordinal_type targetCubDegree(Fun::degree()),targetDerivCubDegree(GradFun::degree());
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createHGradProjectionStruct(&basis, targetCubDegree, targetDerivCubDegree);
           auto evaluationPoints = projStruct.getAllEvalPoints();
           auto evaluationGradPoints = projStruct.getAllDerivEvalPoints();
@@ -450,7 +456,7 @@ int DeRhamCommutativityWedge(const bool verbose) {
         {
           ordinal_type targetCubDegree(GradFun::degree()),targetDerivCubDegree(0);
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createHCurlProjectionStruct(&basisHCurl, targetCubDegree, targetDerivCubDegree);
 
           auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -689,7 +695,7 @@ int DeRhamCommutativityWedge(const bool verbose) {
           ordinal_type targetCubDegree(FunCurl::degree()),targetDerivCubDegree(CurlFunCurl::degree());
 
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createHCurlProjectionStruct(&basis, targetCubDegree, targetDerivCubDegree);
 
           auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -769,7 +775,7 @@ int DeRhamCommutativityWedge(const bool verbose) {
         {
           ordinal_type targetCubDegree(CurlFunCurl::degree()),targetDerivCubDegree(0);
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createHDivProjectionStruct(&basisHDiv, targetCubDegree, targetDerivCubDegree);
 
           auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -1004,7 +1010,7 @@ int DeRhamCommutativityWedge(const bool verbose) {
           ordinal_type targetCubDegree(FunDiv::degree()),targetDerivCubDegree(DivFunDiv::degree());
 
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createHDivProjectionStruct(&basis, targetCubDegree, targetDerivCubDegree);
 
           auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -1077,7 +1083,7 @@ int DeRhamCommutativityWedge(const bool verbose) {
         {
           ordinal_type targetCubDegree(DivFunDiv::degree());
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createHVolProjectionStruct(&basisHVol, targetCubDegree);
 
           auto evaluationPoints = projStruct.getAllEvalPoints();

--- a/packages/intrepid2/unit-test/Projection/test_convergence_HEX.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_convergence_HEX.hpp
@@ -225,11 +225,17 @@ int ConvergenceHex(const bool verbose) {
     }
   };
 
-  typedef CellTools<DeviceType> ct;
-  typedef OrientationTools<DeviceType> ots;
-  typedef Experimental::ProjectionTools<DeviceType> pts;
-  typedef RealSpaceTools<DeviceType> rst;
-  typedef FunctionSpaceTools<DeviceType> fst;
+  using ct = CellTools<DeviceType>;
+  using ots = OrientationTools<DeviceType>;
+  #ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
+  using pts = Experimental::ProjectionTools<DeviceType>;
+  using ProjStruct = Experimental::ProjectionStruct<DeviceType,ValueType>;
+  #else
+  using pts = ProjectionTools<DeviceType>;
+  using ProjStruct = ProjectionStruct<DeviceType,ValueType>;
+  #endif
+  using rst = RealSpaceTools<DeviceType>;
+  using fst = FunctionSpaceTools<DeviceType>;
 
   constexpr ordinal_type dim = 3;
   const ordinal_type basisDegree = 3;
@@ -373,7 +379,7 @@ int ConvergenceHex(const bool verbose) {
         {
           ordinal_type targetCubDegree(basis.getDegree()),targetDerivCubDegree(basis.getDegree());
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           if(useL2Projection) {
             projStruct.createL2ProjectionStruct(&basis, targetCubDegree);
           } else {
@@ -606,7 +612,7 @@ int ConvergenceHex(const bool verbose) {
         {
           ordinal_type targetCubDegree(cub_degree),targetDerivCubDegree(cub_degree-1);
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           if(useL2Projection) {
             projStruct.createL2ProjectionStruct(&basis, targetCubDegree);
           } else {
@@ -854,7 +860,7 @@ int ConvergenceHex(const bool verbose) {
         {
           ordinal_type targetCubDegree(basis.getDegree()),targetDerivCubDegree(basis.getDegree()-1);
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           if(useL2Projection) {
             projStruct.createL2ProjectionStruct(&basis, targetCubDegree);
           } else {
@@ -1095,7 +1101,7 @@ int ConvergenceHex(const bool verbose) {
         {
           ordinal_type targetCubDegree(basis.getDegree());
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           if(useL2Projection) {
             projStruct.createL2ProjectionStruct(&basis, targetCubDegree);
           } else {

--- a/packages/intrepid2/unit-test/Projection/test_convergence_QUAD.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_convergence_QUAD.hpp
@@ -207,7 +207,13 @@ int ConvergenceQuad(const bool verbose) {
 
   using ct = CellTools<DeviceType>;
   using ots = OrientationTools<DeviceType>;
+  #ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
   using pts = Experimental::ProjectionTools<DeviceType>;
+  using ProjStruct = Experimental::ProjectionStruct<DeviceType,ValueType>;
+  #else
+  using pts = ProjectionTools<DeviceType>;
+  using ProjStruct = ProjectionStruct<DeviceType,ValueType>;
+  #endif
   using rst = RealSpaceTools<DeviceType>;
   using fst = FunctionSpaceTools<DeviceType>;
 
@@ -350,7 +356,7 @@ int ConvergenceQuad(const bool verbose) {
         {
           ordinal_type targetCubDegree(basis.getDegree()),targetDerivCubDegree(basis.getDegree());
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           if(useL2Projection) {
             projStruct.createL2ProjectionStruct(&basis, targetCubDegree);
           } else {
@@ -581,7 +587,7 @@ int ConvergenceQuad(const bool verbose) {
         {
           ordinal_type targetCubDegree(cub_degree),targetDerivCubDegree(cub_degree-1);
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           if(useL2Projection) {
             projStruct.createL2ProjectionStruct(&basis, targetCubDegree);
           } else {
@@ -824,7 +830,7 @@ int ConvergenceQuad(const bool verbose) {
         {
           ordinal_type targetCubDegree(basis.getDegree()),targetDerivCubDegree(basis.getDegree()-1);
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           if(useL2Projection) {
             projStruct.createL2ProjectionStruct(&basis, targetCubDegree);
           } else {
@@ -1064,7 +1070,7 @@ int ConvergenceQuad(const bool verbose) {
         {
           ordinal_type targetCubDegree(basis.getDegree());
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           if(useL2Projection) {
             projStruct.createL2ProjectionStruct(&basis, targetCubDegree);
           } else {
@@ -1186,7 +1192,7 @@ int ConvergenceQuad(const bool verbose) {
       errorFlag = -1000;
     }
   }
-//*
+/*
   *outStream << "\nHGRAD ERROR:";
   for(int iter = 0; iter<numRefinements; iter++)
     *outStream << " " << hgradNorm[iter];
@@ -1200,7 +1206,7 @@ int ConvergenceQuad(const bool verbose) {
   for(int iter = 0; iter<numRefinements; iter++)
     *outStream << " " << hvolNorm[iter];
   *outStream << std::endl;
- //*/
+ */
 
   if (errorFlag != 0)
     std::cout << "End Result: TEST FAILED = " << errorFlag << "\n";

--- a/packages/intrepid2/unit-test/Projection/test_convergence_TET.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_convergence_TET.hpp
@@ -226,11 +226,17 @@ int ConvergenceTet(const bool verbose) {
     }
   };
 
-  typedef CellTools<DeviceType> ct;
-  typedef OrientationTools<DeviceType> ots;
-  typedef Experimental::ProjectionTools<DeviceType> pts;
-  typedef RealSpaceTools<DeviceType> rst;
-  typedef FunctionSpaceTools<DeviceType> fst;
+  using ct = CellTools<DeviceType>;
+  using ots = OrientationTools<DeviceType>;
+  #ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
+  using pts = Experimental::ProjectionTools<DeviceType>;
+  using ProjStruct = Experimental::ProjectionStruct<DeviceType,ValueType>;
+  #else
+  using pts = ProjectionTools<DeviceType>;
+  using ProjStruct = ProjectionStruct<DeviceType,ValueType>;
+  #endif
+  using rst = RealSpaceTools<DeviceType>;
+  using fst = FunctionSpaceTools<DeviceType>;
 
   constexpr ordinal_type dim = 3;
   const ordinal_type basisDegree = 3;
@@ -373,7 +379,7 @@ int ConvergenceTet(const bool verbose) {
         {
           ordinal_type targetCubDegree(basis.getDegree()),targetDerivCubDegree(basis.getDegree());
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           if(useL2Projection) {
             projStruct.createL2ProjectionStruct(&basis, targetCubDegree);
           } else {
@@ -606,7 +612,7 @@ int ConvergenceTet(const bool verbose) {
         {
           ordinal_type targetCubDegree(cub_degree),targetDerivCubDegree(cub_degree-1);
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           if(useL2Projection) {
             projStruct.createL2ProjectionStruct(&basis, targetCubDegree);
           } else {
@@ -854,7 +860,7 @@ int ConvergenceTet(const bool verbose) {
         {
           ordinal_type targetCubDegree(basis.getDegree()),targetDerivCubDegree(basis.getDegree()-1);
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           if(useL2Projection) {
             projStruct.createL2ProjectionStruct(&basis, targetCubDegree);
           } else {
@@ -1095,7 +1101,7 @@ int ConvergenceTet(const bool verbose) {
         {
           ordinal_type targetCubDegree(basis.getDegree());
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           if(useL2Projection) {
             projStruct.createL2ProjectionStruct(&basis, targetCubDegree);
           } else {

--- a/packages/intrepid2/unit-test/Projection/test_convergence_TRI.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_convergence_TRI.hpp
@@ -208,7 +208,13 @@ int ConvergenceTri(const bool verbose) {
 
   using ct = CellTools<DeviceType>;
   using ots = OrientationTools<DeviceType>;
+  #ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
   using pts = Experimental::ProjectionTools<DeviceType>;
+  using ProjStruct = Experimental::ProjectionStruct<DeviceType,ValueType>;
+  #else
+  using pts = ProjectionTools<DeviceType>;
+  using ProjStruct = ProjectionStruct<DeviceType,ValueType>;
+  #endif
   using rst = RealSpaceTools<DeviceType>;
   using fst = FunctionSpaceTools<DeviceType>;
 
@@ -352,7 +358,7 @@ int ConvergenceTri(const bool verbose) {
         {
           ordinal_type targetCubDegree(basis.getDegree()),targetDerivCubDegree(basis.getDegree());
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           if(useL2Projection) {
             projStruct.createL2ProjectionStruct(&basis, targetCubDegree);
           } else {
@@ -584,7 +590,7 @@ int ConvergenceTri(const bool verbose) {
         {
           ordinal_type targetCubDegree(cub_degree),targetDerivCubDegree(cub_degree-1);
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           if(useL2Projection) {
             projStruct.createL2ProjectionStruct(&basis, targetCubDegree);
           } else {
@@ -828,7 +834,7 @@ int ConvergenceTri(const bool verbose) {
         {
           ordinal_type targetCubDegree(basis.getDegree()),targetDerivCubDegree(basis.getDegree()-1);
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           if(useL2Projection) {
             projStruct.createL2ProjectionStruct(&basis, targetCubDegree);
           } else {
@@ -1069,7 +1075,7 @@ int ConvergenceTri(const bool verbose) {
         {
           ordinal_type targetCubDegree(basis.getDegree());
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           if(useL2Projection) {
             projStruct.createL2ProjectionStruct(&basis, targetCubDegree);
           } else {

--- a/packages/intrepid2/unit-test/Projection/test_convergence_WEDGE.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_convergence_WEDGE.hpp
@@ -223,11 +223,17 @@ int ConvergenceWedge(const bool verbose) {
     }
   };
 
-  typedef CellTools<DeviceType> ct;
-  typedef OrientationTools<DeviceType> ots;
-  typedef Experimental::ProjectionTools<DeviceType> pts;
-  typedef RealSpaceTools<DeviceType> rst;
-  typedef FunctionSpaceTools<DeviceType> fst;
+  using ct = CellTools<DeviceType>;
+  using ots = OrientationTools<DeviceType>;
+  #ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
+  using pts = Experimental::ProjectionTools<DeviceType>;
+  using ProjStruct = Experimental::ProjectionStruct<DeviceType,ValueType>;
+  #else
+  using pts = ProjectionTools<DeviceType>;
+  using ProjStruct = ProjectionStruct<DeviceType,ValueType>;
+  #endif
+  using rst = RealSpaceTools<DeviceType>;
+  using fst = FunctionSpaceTools<DeviceType>;
 
   constexpr ordinal_type dim = 3;
   const ordinal_type basisDegree = 3;
@@ -369,7 +375,7 @@ int ConvergenceWedge(const bool verbose) {
         {
           ordinal_type targetCubDegree(basis.getDegree()),targetDerivCubDegree(basis.getDegree());
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           if(useL2Projection) {
             projStruct.createL2ProjectionStruct(&basis, targetCubDegree);
           } else {
@@ -601,7 +607,7 @@ int ConvergenceWedge(const bool verbose) {
         {
           ordinal_type targetCubDegree(cub_degree),targetDerivCubDegree(cub_degree-1);
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           if(useL2Projection) {
             projStruct.createL2ProjectionStruct(&basis, targetCubDegree);
           } else {
@@ -849,7 +855,7 @@ int ConvergenceWedge(const bool verbose) {
         {
           ordinal_type targetCubDegree(basis.getDegree()),targetDerivCubDegree(basis.getDegree()-1);
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           if(useL2Projection) {
             projStruct.createL2ProjectionStruct(&basis, targetCubDegree);
           } else {
@@ -1089,7 +1095,7 @@ int ConvergenceWedge(const bool verbose) {
         {
           ordinal_type targetCubDegree(basis.getDegree());
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           if(useL2Projection) {
             projStruct.createL2ProjectionStruct(&basis, targetCubDegree);
           } else {

--- a/packages/intrepid2/unit-test/Projection/test_interpolation_projection_HEX.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_interpolation_projection_HEX.hpp
@@ -213,13 +213,21 @@ int InterpolationProjectionHex(const bool verbose) {
     }
   };
 
-  typedef std::array<ordinal_type,2> edgeType;
-  typedef std::array<ordinal_type,4> faceType;
-  typedef CellTools<DeviceType> ct;
-  typedef OrientationTools<DeviceType> ots;
-  typedef Experimental::ProjectionTools<DeviceType> pts;
-  typedef FunctionSpaceTools<DeviceType> fst;
-  typedef Experimental::LagrangianInterpolation<DeviceType> li;
+  using edgeType = std::array<ordinal_type,2>;
+  using faceType = std::array<ordinal_type,4>;
+  using ct = CellTools<DeviceType>;
+  using ots = OrientationTools<DeviceType>;
+  using fst = FunctionSpaceTools<DeviceType>;
+  #ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
+  using pts = Experimental::ProjectionTools<DeviceType>;
+  using li = Experimental::LagrangianInterpolation<DeviceType>;
+  using ProjStruct = Experimental::ProjectionStruct<DeviceType,ValueType>;
+#else
+  using pts = ProjectionTools<DeviceType>;
+  using li = LagrangianInterpolation<DeviceType>;
+  using ProjStruct = ProjectionStruct<DeviceType,ValueType>;
+#endif
+  using lt = LagrangianTools<DeviceType>;
   using  basisType = Basis<DeviceType,ValueType,ValueType>;
 
   constexpr ordinal_type dim = 3;
@@ -416,7 +424,8 @@ int InterpolationProjectionHex(const bool verbose) {
             {
               DynRankView ConstructWithLabel(dofCoordsOriented, numCells, basisCardinality, dim);
               DynRankView ConstructWithLabel(dofCoeffsPhys, numCells, basisCardinality);
-              li::getDofCoordsAndCoeffs(dofCoordsOriented, dofCoeffsPhys, basisPtr, elemOrts);
+              lt::getOrientedDofCoords(dofCoordsOriented, basisPtr, elemOrts);
+              lt::getOrientedDofCoeffs(dofCoeffsPhys, basisPtr, elemOrts);
               DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality);
               DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
               for(ordinal_type i=0; i<numCells; ++i) {
@@ -555,7 +564,7 @@ int InterpolationProjectionHex(const bool verbose) {
             {
               ordinal_type targetCubDegree(basisPtr->getDegree()),targetDerivCubDegree(basisPtr->getDegree());
 
-              Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+              ProjStruct projStruct;
               projStruct.createHGradProjectionStruct(basisPtr, targetCubDegree, targetDerivCubDegree);
 
               auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -628,7 +637,7 @@ int InterpolationProjectionHex(const bool verbose) {
             {
               ordinal_type targetCubDegree(basisPtr->getDegree());
 
-              Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+              ProjStruct projStruct;
               projStruct.createL2ProjectionStruct(basisPtr, targetCubDegree);
 
               auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -682,7 +691,7 @@ int InterpolationProjectionHex(const bool verbose) {
             {
               ordinal_type targetCubDegree(basisPtr->getDegree());
 
-              Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+              ProjStruct projStruct;
               projStruct.createL2DGProjectionStruct(basisPtr, targetCubDegree);
 
               auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -921,7 +930,8 @@ int InterpolationProjectionHex(const bool verbose) {
             {
               DynRankView ConstructWithLabel(dofCoordsOriented, numCells, basisCardinality, dim);
               DynRankView ConstructWithLabel(dofCoeffs, numCells, basisCardinality, dim);
-              li::getDofCoordsAndCoeffs(dofCoordsOriented, dofCoeffs, basisPtr, elemOrts);
+              lt::getOrientedDofCoords(dofCoordsOriented, basisPtr, elemOrts);
+              lt::getOrientedDofCoeffs(dofCoeffs, basisPtr, elemOrts);
               DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality, dim);
               DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
               for(ordinal_type i=0; i<numCells; ++i) {
@@ -1068,7 +1078,7 @@ int InterpolationProjectionHex(const bool verbose) {
             {
               ordinal_type targetCubDegree(basisPtr->getDegree()),targetDerivCubDegree(basisPtr->getDegree()-1);
 
-              Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+              ProjStruct projStruct;
               projStruct.createHCurlProjectionStruct(basisPtr, targetCubDegree, targetDerivCubDegree);
 
               auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -1143,7 +1153,7 @@ int InterpolationProjectionHex(const bool verbose) {
             {
               ordinal_type targetCubDegree(basisPtr->getDegree());
 
-              Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+              ProjStruct projStruct;
               projStruct.createL2ProjectionStruct(basisPtr, targetCubDegree);
 
               auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -1198,7 +1208,7 @@ int InterpolationProjectionHex(const bool verbose) {
             {
               ordinal_type targetCubDegree(basisPtr->getDegree());
 
-              Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+              ProjStruct projStruct;
               projStruct.createL2DGProjectionStruct(basisPtr, targetCubDegree);
 
               auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -1428,7 +1438,8 @@ int InterpolationProjectionHex(const bool verbose) {
             {
               DynRankView ConstructWithLabel(dofCoordsOriented, numCells, basisCardinality, dim);
               DynRankView ConstructWithLabel(dofCoeffs, numCells, basisCardinality, dim);
-              li::getDofCoordsAndCoeffs(dofCoordsOriented,  dofCoeffs, basisPtr, elemOrts);
+              lt::getOrientedDofCoords(dofCoordsOriented, basisPtr, elemOrts);
+              lt::getOrientedDofCoeffs(dofCoeffs, basisPtr, elemOrts);
               DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality, dim);
               DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
               for(ordinal_type i=0; i<numCells; ++i) {
@@ -1556,7 +1567,7 @@ int InterpolationProjectionHex(const bool verbose) {
             {
               ordinal_type targetCubDegree(basisPtr->getDegree()),targetDerivCubDegree(basisPtr->getDegree()-1);
 
-              Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+              ProjStruct projStruct;
               projStruct.createHDivProjectionStruct(basisPtr, targetCubDegree, targetDerivCubDegree);
 
               auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -1628,7 +1639,7 @@ int InterpolationProjectionHex(const bool verbose) {
             {
               ordinal_type targetCubDegree(basisPtr->getDegree());
 
-              Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+              ProjStruct projStruct;
               projStruct.createL2ProjectionStruct(basisPtr, targetCubDegree);
 
               auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -1683,7 +1694,7 @@ int InterpolationProjectionHex(const bool verbose) {
             {
               ordinal_type targetCubDegree(basisPtr->getDegree());
 
-              Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+              ProjStruct projStruct;
               projStruct.createL2DGProjectionStruct(basisPtr, targetCubDegree);
 
               auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -1847,7 +1858,8 @@ int InterpolationProjectionHex(const bool verbose) {
         {
           DynRankView ConstructWithLabel(dofCoordsOriented, numCells, basisCardinality, dim);
           DynRankView ConstructWithLabel(dofCoeffsPhys, numCells, basisCardinality);
-          li::getDofCoordsAndCoeffs(dofCoordsOriented,  dofCoeffsPhys, basisPtr, elemOrts);
+          lt::getOrientedDofCoords(dofCoordsOriented, basisPtr, elemOrts);
+          lt::getOrientedDofCoeffs(dofCoeffsPhys, basisPtr, elemOrts);
           DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality);
           DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
           for(ordinal_type i=0; i<numCells; ++i) {
@@ -1941,7 +1953,7 @@ int InterpolationProjectionHex(const bool verbose) {
         {
           ordinal_type targetCubDegree(basisPtr->getDegree());
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createHVolProjectionStruct(basisPtr, targetCubDegree);
 
           auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -1996,7 +2008,7 @@ int InterpolationProjectionHex(const bool verbose) {
         {
           ordinal_type targetCubDegree(basisPtr->getDegree());
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createL2ProjectionStruct(basisPtr, targetCubDegree);
 
           auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -2050,7 +2062,7 @@ int InterpolationProjectionHex(const bool verbose) {
         {
           ordinal_type targetCubDegree(basisPtr->getDegree());
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createL2DGProjectionStruct(basisPtr, targetCubDegree);
 
           auto evaluationPoints = projStruct.getAllEvalPoints();

--- a/packages/intrepid2/unit-test/Projection/test_interpolation_projection_QUAD.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_interpolation_projection_QUAD.hpp
@@ -189,12 +189,20 @@ int InterpolationProjectionQuad(const bool verbose) {
     }
   };
 
-  typedef std::array<ordinal_type,2> edgeType;
-  typedef CellTools<DeviceType> ct;
-  typedef OrientationTools<DeviceType> ots;
-  typedef Experimental::ProjectionTools<DeviceType> pts;
-  typedef FunctionSpaceTools<DeviceType> fst;
-  typedef Experimental::LagrangianInterpolation<DeviceType> li;
+  using edgeType = std::array<ordinal_type,2>;
+  using ct = CellTools<DeviceType>;
+  using ots = OrientationTools<DeviceType>;
+  using fst = FunctionSpaceTools<DeviceType>;
+  #ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
+  using pts = Experimental::ProjectionTools<DeviceType>;
+  using li = Experimental::LagrangianInterpolation<DeviceType>;
+  using ProjStruct = Experimental::ProjectionStruct<DeviceType,ValueType>;
+#else
+  using pts = ProjectionTools<DeviceType>;
+  using li = LagrangianInterpolation<DeviceType>;
+  using ProjStruct = ProjectionStruct<DeviceType,ValueType>;
+#endif
+  using lt = LagrangianTools<DeviceType>;
   using  basisType = Basis<DeviceType,ValueType,ValueType>;
 
   constexpr ordinal_type dim = 2;
@@ -337,7 +345,8 @@ int InterpolationProjectionQuad(const bool verbose) {
             {
               DynRankView ConstructWithLabel(dofCoordsOriented, numCells, basisCardinality, dim);
               DynRankView ConstructWithLabel(dofCoeffsPhys, numCells, basisCardinality);
-              li::getDofCoordsAndCoeffs(dofCoordsOriented, dofCoeffsPhys, basisPtr, elemOrts);
+              lt::getOrientedDofCoords(dofCoordsOriented, basisPtr, elemOrts);
+              lt::getOrientedDofCoeffs(dofCoeffsPhys, basisPtr, elemOrts);
               DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality);
               DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
               for(ordinal_type i=0; i<numCells; ++i) {
@@ -450,7 +459,7 @@ int InterpolationProjectionQuad(const bool verbose) {
             {
               ordinal_type targetCubDegree(basisPtr->getDegree()),targetDerivCubDegree(basisPtr->getDegree());
 
-              Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+              ProjStruct projStruct;
               projStruct.createHGradProjectionStruct(basisPtr, targetCubDegree, targetDerivCubDegree);
 
               auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -522,7 +531,7 @@ int InterpolationProjectionQuad(const bool verbose) {
             {
               ordinal_type targetCubDegree(basisPtr->getDegree());
 
-              Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+              ProjStruct projStruct;
               projStruct.createL2ProjectionStruct(basisPtr, targetCubDegree);
 
               auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -576,7 +585,7 @@ int InterpolationProjectionQuad(const bool verbose) {
             {
               ordinal_type targetCubDegree(basisPtr->getDegree());
 
-              Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+              ProjStruct projStruct;
               projStruct.createL2DGProjectionStruct(basisPtr, targetCubDegree);
 
               auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -769,7 +778,8 @@ int InterpolationProjectionQuad(const bool verbose) {
             {
               DynRankView ConstructWithLabel(dofCoordsOriented, numCells, basisCardinality, dim);
               DynRankView ConstructWithLabel(dofCoeffs, numCells, basisCardinality, dim);
-              li::getDofCoordsAndCoeffs(dofCoordsOriented, dofCoeffs, basisPtr, elemOrts);
+              lt::getOrientedDofCoords(dofCoordsOriented, basisPtr, elemOrts);
+              lt::getOrientedDofCoeffs(dofCoeffs, basisPtr, elemOrts);
               DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality, dim);
               DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
               for(ordinal_type i=0; i<numCells; ++i) {
@@ -892,7 +902,7 @@ int InterpolationProjectionQuad(const bool verbose) {
             {
               ordinal_type targetCubDegree(basisPtr->getDegree()),targetDerivCubDegree(basisPtr->getDegree()-1);
 
-              Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+              ProjStruct projStruct;
               projStruct.createHCurlProjectionStruct(basisPtr, targetCubDegree, targetDerivCubDegree);
 
               auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -965,7 +975,7 @@ int InterpolationProjectionQuad(const bool verbose) {
             {
               ordinal_type targetCubDegree(basisPtr->getDegree());
 
-              Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+              ProjStruct projStruct;
               projStruct.createL2ProjectionStruct(basisPtr, targetCubDegree);
 
               auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -1020,7 +1030,7 @@ int InterpolationProjectionQuad(const bool verbose) {
             {
               ordinal_type targetCubDegree(basisPtr->getDegree());
 
-              Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+              ProjStruct projStruct;
               projStruct.createL2DGProjectionStruct(basisPtr, targetCubDegree);
 
               auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -1215,7 +1225,8 @@ int InterpolationProjectionQuad(const bool verbose) {
             {
               DynRankView ConstructWithLabel(dofCoordsOriented, numCells, basisCardinality, dim);
               DynRankView ConstructWithLabel(dofCoeffs, numCells, basisCardinality, dim);
-              li::getDofCoordsAndCoeffs(dofCoordsOriented,  dofCoeffs, basisPtr, elemOrts);
+              lt::getOrientedDofCoords(dofCoordsOriented, basisPtr, elemOrts);
+              lt::getOrientedDofCoeffs(dofCoeffs, basisPtr, elemOrts);
               DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality, dim);
               DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
               for(ordinal_type i=0; i<numCells; ++i) {
@@ -1343,7 +1354,7 @@ int InterpolationProjectionQuad(const bool verbose) {
             {
               ordinal_type targetCubDegree(basisPtr->getDegree()),targetDerivCubDegree(basisPtr->getDegree()-1);
 
-              Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+              ProjStruct projStruct;
               projStruct.createHDivProjectionStruct(basisPtr, targetCubDegree, targetDerivCubDegree);
 
               auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -1416,7 +1427,7 @@ int InterpolationProjectionQuad(const bool verbose) {
             {
               ordinal_type targetCubDegree(basisPtr->getDegree());
 
-              Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+              ProjStruct projStruct;
               projStruct.createL2ProjectionStruct(basisPtr, targetCubDegree);
 
               auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -1471,7 +1482,7 @@ int InterpolationProjectionQuad(const bool verbose) {
             {
               ordinal_type targetCubDegree(basisPtr->getDegree());
 
-              Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+              ProjStruct projStruct;
               projStruct.createL2DGProjectionStruct(basisPtr, targetCubDegree);
 
               auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -1635,7 +1646,8 @@ int InterpolationProjectionQuad(const bool verbose) {
         {
           DynRankView ConstructWithLabel(dofCoordsOriented, numCells, basisCardinality, dim);
           DynRankView ConstructWithLabel(dofCoeffsPhys, numCells, basisCardinality);
-          li::getDofCoordsAndCoeffs(dofCoordsOriented,  dofCoeffsPhys, basisPtr, elemOrts);
+          lt::getOrientedDofCoords(dofCoordsOriented, basisPtr, elemOrts);
+          lt::getOrientedDofCoeffs(dofCoeffsPhys, basisPtr, elemOrts);
           DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality);
           DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
           for(ordinal_type i=0; i<numCells; ++i) {
@@ -1729,7 +1741,7 @@ int InterpolationProjectionQuad(const bool verbose) {
         {
           ordinal_type targetCubDegree(basisPtr->getDegree());
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createHVolProjectionStruct(basisPtr, targetCubDegree);
 
           auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -1784,7 +1796,7 @@ int InterpolationProjectionQuad(const bool verbose) {
         {
           ordinal_type targetCubDegree(basisPtr->getDegree());
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createL2ProjectionStruct(basisPtr, targetCubDegree);
 
           auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -1838,7 +1850,7 @@ int InterpolationProjectionQuad(const bool verbose) {
         {
           ordinal_type targetCubDegree(basisPtr->getDegree());
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createL2DGProjectionStruct(basisPtr, targetCubDegree);
 
           auto evaluationPoints = projStruct.getAllEvalPoints();

--- a/packages/intrepid2/unit-test/Projection/test_interpolation_projection_TET.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_interpolation_projection_TET.hpp
@@ -207,13 +207,21 @@ int InterpolationProjectionTet(const bool verbose) {
     }
   };
 
-  typedef std::array<ordinal_type,2> edgeType;
-  typedef std::array<ordinal_type,3> faceType;
-  typedef CellTools<DeviceType> ct;
-  typedef OrientationTools<DeviceType> ots;
-  typedef Experimental::ProjectionTools<DeviceType> pts;
-  typedef FunctionSpaceTools<DeviceType> fst;
-  typedef Experimental::LagrangianInterpolation<DeviceType> li;
+  using edgeType = std::array<ordinal_type,2>;
+  using faceType = std::array<ordinal_type,3>;
+  using ct = CellTools<DeviceType>;
+  using ots = OrientationTools<DeviceType>;
+  using fst = FunctionSpaceTools<DeviceType>;
+  #ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
+  using pts = Experimental::ProjectionTools<DeviceType>;
+  using li = Experimental::LagrangianInterpolation<DeviceType>;
+  using ProjStruct = Experimental::ProjectionStruct<DeviceType,ValueType>;
+#else
+  using pts = ProjectionTools<DeviceType>;
+  using li = LagrangianInterpolation<DeviceType>;
+  using ProjStruct = ProjectionStruct<DeviceType,ValueType>;
+#endif
+  using lt = LagrangianTools<DeviceType>;
   using  basisType = Basis<DeviceType,ValueType,ValueType>;
 
   constexpr ordinal_type dim = 3;
@@ -378,7 +386,8 @@ int InterpolationProjectionTet(const bool verbose) {
             {
               DynRankView ConstructWithLabel(dofCoordsOriented, numCells, basisCardinality, dim);
               DynRankView ConstructWithLabel(dofCoeffsPhys, numCells, basisCardinality);
-              li::getDofCoordsAndCoeffs(dofCoordsOriented, dofCoeffsPhys, basisPtr, elemOrts);
+              lt::getOrientedDofCoords(dofCoordsOriented, basisPtr, elemOrts);
+              lt::getOrientedDofCoeffs(dofCoeffsPhys, basisPtr, elemOrts);
               DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality);
               DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
               for(ordinal_type i=0; i<numCells; ++i) {
@@ -517,7 +526,7 @@ int InterpolationProjectionTet(const bool verbose) {
             {
               ordinal_type targetCubDegree(basisPtr->getDegree()),targetDerivCubDegree(basisPtr->getDegree());
 
-              Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+              ProjStruct projStruct;
               projStruct.createHGradProjectionStruct(basisPtr, targetCubDegree, targetDerivCubDegree);
 
               auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -590,7 +599,7 @@ int InterpolationProjectionTet(const bool verbose) {
             {
               ordinal_type targetCubDegree(basisPtr->getDegree());
 
-              Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+              ProjStruct projStruct;
               projStruct.createL2ProjectionStruct(basisPtr, targetCubDegree);
 
               auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -644,7 +653,7 @@ int InterpolationProjectionTet(const bool verbose) {
             {
               ordinal_type targetCubDegree(basisPtr->getDegree());
 
-              Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+              ProjStruct projStruct;
               projStruct.createL2DGProjectionStruct(basisPtr, targetCubDegree);
 
               auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -865,7 +874,8 @@ int InterpolationProjectionTet(const bool verbose) {
             {
               DynRankView ConstructWithLabel(dofCoordsOriented, numCells, basisCardinality, dim);
               DynRankView ConstructWithLabel(dofCoeffs, numCells, basisCardinality, dim);
-              li::getDofCoordsAndCoeffs(dofCoordsOriented, dofCoeffs, basisPtr, elemOrts);
+              lt::getOrientedDofCoords(dofCoordsOriented, basisPtr, elemOrts);
+              lt::getOrientedDofCoeffs(dofCoeffs, basisPtr, elemOrts);
               DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality, dim);
               DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
               for(ordinal_type i=0; i<numCells; ++i) {
@@ -1012,7 +1022,7 @@ int InterpolationProjectionTet(const bool verbose) {
             {
               ordinal_type targetCubDegree(basisPtr->getDegree()),targetDerivCubDegree(basisPtr->getDegree()-1);
 
-              Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+              ProjStruct projStruct;
               projStruct.createHCurlProjectionStruct(basisPtr, targetCubDegree, targetDerivCubDegree);
 
               auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -1086,7 +1096,7 @@ int InterpolationProjectionTet(const bool verbose) {
             {
               ordinal_type targetCubDegree(basisPtr->getDegree());
 
-              Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+              ProjStruct projStruct;
               projStruct.createL2ProjectionStruct(basisPtr, targetCubDegree);
 
               auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -1141,7 +1151,7 @@ int InterpolationProjectionTet(const bool verbose) {
             {
               ordinal_type targetCubDegree(basisPtr->getDegree());
 
-              Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+              ProjStruct projStruct;
               projStruct.createL2DGProjectionStruct(basisPtr, targetCubDegree);
 
               auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -1347,7 +1357,8 @@ int InterpolationProjectionTet(const bool verbose) {
             {
               DynRankView ConstructWithLabel(dofCoordsOriented, numCells, basisCardinality, dim);
               DynRankView ConstructWithLabel(dofCoeffs, numCells, basisCardinality, dim);
-              li::getDofCoordsAndCoeffs(dofCoordsOriented,  dofCoeffs, basisPtr, elemOrts);
+              lt::getOrientedDofCoords(dofCoordsOriented, basisPtr, elemOrts);
+              lt::getOrientedDofCoeffs(dofCoeffs, basisPtr, elemOrts);
               DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality, dim);
               DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
               for(ordinal_type i=0; i<numCells; ++i) {
@@ -1475,7 +1486,7 @@ int InterpolationProjectionTet(const bool verbose) {
             {
               ordinal_type targetCubDegree(basisPtr->getDegree()),targetDerivCubDegree(basisPtr->getDegree()-1);
 
-              Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+              ProjStruct projStruct;
               projStruct.createHDivProjectionStruct(basisPtr, targetCubDegree, targetDerivCubDegree);
 
               auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -1547,7 +1558,7 @@ int InterpolationProjectionTet(const bool verbose) {
             {
               ordinal_type targetCubDegree(basisPtr->getDegree());
 
-              Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+              ProjStruct projStruct;
               projStruct.createL2ProjectionStruct(basisPtr, targetCubDegree);
 
               auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -1602,7 +1613,7 @@ int InterpolationProjectionTet(const bool verbose) {
             {
               ordinal_type targetCubDegree(basisPtr->getDegree());
 
-              Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+              ProjStruct projStruct;
               projStruct.createL2DGProjectionStruct(basisPtr, targetCubDegree);
 
               auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -1766,7 +1777,8 @@ int InterpolationProjectionTet(const bool verbose) {
         {
           DynRankView ConstructWithLabel(dofCoordsOriented, numCells, basisCardinality, dim);
           DynRankView ConstructWithLabel(dofCoeffsPhys, numCells, basisCardinality);
-          li::getDofCoordsAndCoeffs(dofCoordsOriented,  dofCoeffsPhys, basisPtr, elemOrts);
+          lt::getOrientedDofCoords(dofCoordsOriented, basisPtr, elemOrts);
+          lt::getOrientedDofCoeffs(dofCoeffsPhys, basisPtr, elemOrts);
           DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality);
           DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
           for(ordinal_type i=0; i<numCells; ++i) {
@@ -1860,7 +1872,7 @@ int InterpolationProjectionTet(const bool verbose) {
         {
           ordinal_type targetCubDegree(basisPtr->getDegree());
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createHVolProjectionStruct(basisPtr, targetCubDegree);
 
           auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -1915,7 +1927,7 @@ int InterpolationProjectionTet(const bool verbose) {
         {
           ordinal_type targetCubDegree(basisPtr->getDegree());
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createL2ProjectionStruct(basisPtr, targetCubDegree);
 
           auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -1969,7 +1981,7 @@ int InterpolationProjectionTet(const bool verbose) {
         {
           ordinal_type targetCubDegree(basisPtr->getDegree());
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createL2DGProjectionStruct(basisPtr, targetCubDegree);
 
           auto evaluationPoints = projStruct.getAllEvalPoints();

--- a/packages/intrepid2/unit-test/Projection/test_interpolation_projection_TRI.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_interpolation_projection_TRI.hpp
@@ -183,12 +183,20 @@ int InterpolationProjectionTri(const bool verbose) {
     }
   };
 
-  typedef std::array<ordinal_type,2> edgeType;
-  typedef CellTools<DeviceType> ct;
-  typedef OrientationTools<DeviceType> ots;
-  typedef Experimental::ProjectionTools<DeviceType> pts;
-  typedef FunctionSpaceTools<DeviceType> fst;
-  typedef Experimental::LagrangianInterpolation<DeviceType> li;
+  using edgeType = std::array<ordinal_type,2>;
+  using ct = CellTools<DeviceType>;
+  using ots = OrientationTools<DeviceType>;
+  using fst = FunctionSpaceTools<DeviceType>;
+  #ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
+  using pts = Experimental::ProjectionTools<DeviceType>;
+  using li = Experimental::LagrangianInterpolation<DeviceType>;
+  using ProjStruct = Experimental::ProjectionStruct<DeviceType,ValueType>;
+#else
+  using pts = ProjectionTools<DeviceType>;
+  using li = LagrangianInterpolation<DeviceType>;
+  using ProjStruct = ProjectionStruct<DeviceType,ValueType>;
+#endif
+  using lt = LagrangianTools<DeviceType>;
   using  basisType = Basis<DeviceType,ValueType,ValueType>;
 
   constexpr ordinal_type dim = 2;
@@ -330,7 +338,8 @@ int InterpolationProjectionTri(const bool verbose) {
             {
               DynRankView ConstructWithLabel(dofCoordsOriented, numCells, basisCardinality, dim);
               DynRankView ConstructWithLabel(dofCoeffsPhys, numCells, basisCardinality);
-              li::getDofCoordsAndCoeffs(dofCoordsOriented, dofCoeffsPhys, basisPtr, elemOrts);
+              lt::getOrientedDofCoords(dofCoordsOriented, basisPtr, elemOrts);
+              lt::getOrientedDofCoeffs(dofCoeffsPhys, basisPtr, elemOrts);
               DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality);
               DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
               for(ordinal_type i=0; i<numCells; ++i) {
@@ -443,7 +452,7 @@ int InterpolationProjectionTri(const bool verbose) {
             {
               ordinal_type targetCubDegree(basisPtr->getDegree()),targetDerivCubDegree(basisPtr->getDegree());
 
-              Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+              ProjStruct projStruct;
               projStruct.createHGradProjectionStruct(basisPtr, targetCubDegree, targetDerivCubDegree);
 
               auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -515,7 +524,7 @@ int InterpolationProjectionTri(const bool verbose) {
             {
               ordinal_type targetCubDegree(basisPtr->getDegree());
 
-              Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+              ProjStruct projStruct;
               projStruct.createL2ProjectionStruct(basisPtr, targetCubDegree);
 
               auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -569,7 +578,7 @@ int InterpolationProjectionTri(const bool verbose) {
             {
               ordinal_type targetCubDegree(basisPtr->getDegree());
 
-              Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+              ProjStruct projStruct;
               projStruct.createL2DGProjectionStruct(basisPtr, targetCubDegree);
 
               auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -761,7 +770,8 @@ int InterpolationProjectionTri(const bool verbose) {
             {
               DynRankView ConstructWithLabel(dofCoordsOriented, numCells, basisCardinality, dim);
               DynRankView ConstructWithLabel(dofCoeffs, numCells, basisCardinality, dim);
-              li::getDofCoordsAndCoeffs(dofCoordsOriented, dofCoeffs, basisPtr, elemOrts);
+              lt::getOrientedDofCoords(dofCoordsOriented, basisPtr, elemOrts);
+              lt::getOrientedDofCoeffs(dofCoeffs, basisPtr, elemOrts);
               DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality, dim);
               DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
               for(ordinal_type i=0; i<numCells; ++i) {
@@ -884,7 +894,7 @@ int InterpolationProjectionTri(const bool verbose) {
             {
               ordinal_type targetCubDegree(basisPtr->getDegree()),targetDerivCubDegree(basisPtr->getDegree()-1);
 
-              Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+              ProjStruct projStruct;
               projStruct.createHCurlProjectionStruct(basisPtr, targetCubDegree, targetDerivCubDegree);
 
               auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -957,7 +967,7 @@ int InterpolationProjectionTri(const bool verbose) {
             {
               ordinal_type targetCubDegree(basisPtr->getDegree());
 
-              Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+              ProjStruct projStruct;
               projStruct.createL2ProjectionStruct(basisPtr, targetCubDegree);
 
               auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -1012,7 +1022,7 @@ int InterpolationProjectionTri(const bool verbose) {
             {
               ordinal_type targetCubDegree(basisPtr->getDegree());
 
-              Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+              ProjStruct projStruct;
               projStruct.createL2DGProjectionStruct(basisPtr, targetCubDegree);
 
               auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -1207,7 +1217,8 @@ int InterpolationProjectionTri(const bool verbose) {
             {
               DynRankView ConstructWithLabel(dofCoordsOriented, numCells, basisCardinality, dim);
               DynRankView ConstructWithLabel(dofCoeffs, numCells, basisCardinality, dim);
-              li::getDofCoordsAndCoeffs(dofCoordsOriented,  dofCoeffs, basisPtr, elemOrts);
+              lt::getOrientedDofCoords(dofCoordsOriented, basisPtr, elemOrts);
+              lt::getOrientedDofCoeffs(dofCoeffs, basisPtr, elemOrts);
               DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality, dim);
               DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
               for(ordinal_type i=0; i<numCells; ++i) {
@@ -1335,7 +1346,7 @@ int InterpolationProjectionTri(const bool verbose) {
             {
               ordinal_type targetCubDegree(basisPtr->getDegree()),targetDerivCubDegree(basisPtr->getDegree()-1);
 
-              Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+              ProjStruct projStruct;
               projStruct.createHDivProjectionStruct(basisPtr, targetCubDegree, targetDerivCubDegree);
 
               auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -1408,7 +1419,7 @@ int InterpolationProjectionTri(const bool verbose) {
             {
               ordinal_type targetCubDegree(basisPtr->getDegree());
 
-              Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+              ProjStruct projStruct;
               projStruct.createL2ProjectionStruct(basisPtr, targetCubDegree);
 
               auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -1463,7 +1474,7 @@ int InterpolationProjectionTri(const bool verbose) {
             {
               ordinal_type targetCubDegree(basisPtr->getDegree());
 
-              Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+              ProjStruct projStruct;
               projStruct.createL2DGProjectionStruct(basisPtr, targetCubDegree);
 
               auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -1627,7 +1638,8 @@ int InterpolationProjectionTri(const bool verbose) {
         {
           DynRankView ConstructWithLabel(dofCoordsOriented, numCells, basisCardinality, dim);
           DynRankView ConstructWithLabel(dofCoeffsPhys, numCells, basisCardinality);
-          li::getDofCoordsAndCoeffs(dofCoordsOriented,  dofCoeffsPhys, basisPtr, elemOrts);
+          lt::getOrientedDofCoords(dofCoordsOriented, basisPtr, elemOrts);
+          lt::getOrientedDofCoeffs(dofCoeffsPhys, basisPtr, elemOrts);
           DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality);
           DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
           for(ordinal_type i=0; i<numCells; ++i) {
@@ -1721,7 +1733,7 @@ int InterpolationProjectionTri(const bool verbose) {
         {
           ordinal_type targetCubDegree(basisPtr->getDegree());
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createHVolProjectionStruct(basisPtr, targetCubDegree);
 
           auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -1776,7 +1788,7 @@ int InterpolationProjectionTri(const bool verbose) {
         {
           ordinal_type targetCubDegree(basisPtr->getDegree());
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createL2ProjectionStruct(basisPtr, targetCubDegree);
 
           auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -1830,7 +1842,7 @@ int InterpolationProjectionTri(const bool verbose) {
         {
           ordinal_type targetCubDegree(basisPtr->getDegree());
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createL2DGProjectionStruct(basisPtr, targetCubDegree);
 
           auto evaluationPoints = projStruct.getAllEvalPoints();

--- a/packages/intrepid2/unit-test/Projection/test_interpolation_projection_WEDGE.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_interpolation_projection_WEDGE.hpp
@@ -210,15 +210,24 @@ int InterpolationProjectionWedge(const bool verbose) {
     }
   };
 
-  typedef std::array<ordinal_type,2> edgeType;
-  typedef std::array<ordinal_type,3> baseFaceType;
-  typedef std::array<ordinal_type,4> latFaceType;
-  typedef CellTools<DeviceType> ct;
-  typedef OrientationTools<DeviceType> ots;
-  typedef Experimental::ProjectionTools<DeviceType> pts;
-  typedef FunctionSpaceTools<DeviceType> fst;
-  typedef Experimental::LagrangianInterpolation<DeviceType> li;
+  using edgeType = std::array<ordinal_type,2>;
+  using baseFaceType = std::array<ordinal_type,3>;
+  using latFaceType = std::array<ordinal_type,4>;
+  using ct = CellTools<DeviceType>;
+  using ots = OrientationTools<DeviceType>;
+  using fst = FunctionSpaceTools<DeviceType>;
+#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
+  using pts = Experimental::ProjectionTools<DeviceType>;
+  using li = Experimental::LagrangianInterpolation<DeviceType>;
+  using ProjStruct = Experimental::ProjectionStruct<DeviceType,ValueType>;
+#else
+  using pts = ProjectionTools<DeviceType>;
+  using li = LagrangianInterpolation<DeviceType>;
+  using ProjStruct = ProjectionStruct<DeviceType,ValueType>;
+#endif
+  using lt = LagrangianTools<DeviceType>;
   using  basisType = Basis<DeviceType,ValueType,ValueType>;
+
 
   constexpr ordinal_type dim = 3;
   constexpr ordinal_type numCells = 2;
@@ -410,7 +419,8 @@ int InterpolationProjectionWedge(const bool verbose) {
             {
               DynRankView ConstructWithLabel(dofCoordsOriented, numCells, basisCardinality, dim);
               DynRankView ConstructWithLabel(dofCoeffsPhys, numCells, basisCardinality);
-              li::getDofCoordsAndCoeffs(dofCoordsOriented, dofCoeffsPhys, basisPtr, elemOrts);
+              lt::getOrientedDofCoords(dofCoordsOriented, basisPtr, elemOrts);
+              lt::getOrientedDofCoeffs(dofCoeffsPhys, basisPtr, elemOrts);
               DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality);
               DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
               for(ordinal_type i=0; i<numCells; ++i) {
@@ -549,7 +559,7 @@ int InterpolationProjectionWedge(const bool verbose) {
             {
               ordinal_type targetCubDegree(basisPtr->getDegree()),targetDerivCubDegree(basisPtr->getDegree());
 
-              Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+              ProjStruct projStruct;
               projStruct.createHGradProjectionStruct(basisPtr, targetCubDegree, targetDerivCubDegree);
 
               auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -622,7 +632,7 @@ int InterpolationProjectionWedge(const bool verbose) {
             {
               ordinal_type targetCubDegree(basisPtr->getDegree());
 
-              Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+              ProjStruct projStruct;
               projStruct.createL2ProjectionStruct(basisPtr, targetCubDegree);
 
               auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -676,7 +686,7 @@ int InterpolationProjectionWedge(const bool verbose) {
             {
               ordinal_type targetCubDegree(basisPtr->getDegree());
 
-              Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+              ProjStruct projStruct;
               projStruct.createL2DGProjectionStruct(basisPtr, targetCubDegree);
 
               auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -909,7 +919,8 @@ int InterpolationProjectionWedge(const bool verbose) {
             {
               DynRankView ConstructWithLabel(dofCoordsOriented, numCells, basisCardinality, dim);
               DynRankView ConstructWithLabel(dofCoeffs, numCells, basisCardinality, dim);
-              li::getDofCoordsAndCoeffs(dofCoordsOriented, dofCoeffs, basisPtr, elemOrts);
+              lt::getOrientedDofCoords(dofCoordsOriented, basisPtr, elemOrts);
+              lt::getOrientedDofCoeffs(dofCoeffs, basisPtr, elemOrts);
               DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality, dim);
               DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
               for(ordinal_type i=0; i<numCells; ++i) {
@@ -1056,7 +1067,7 @@ int InterpolationProjectionWedge(const bool verbose) {
             {
               ordinal_type targetCubDegree(basisPtr->getDegree()),targetDerivCubDegree(basisPtr->getDegree()-1);
 
-              Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+              ProjStruct projStruct;
               projStruct.createHCurlProjectionStruct(basisPtr, targetCubDegree, targetDerivCubDegree);
 
               auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -1131,7 +1142,7 @@ int InterpolationProjectionWedge(const bool verbose) {
             {
               ordinal_type targetCubDegree(basisPtr->getDegree());
 
-              Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+              ProjStruct projStruct;
               projStruct.createL2ProjectionStruct(basisPtr, targetCubDegree);
 
               auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -1186,7 +1197,7 @@ int InterpolationProjectionWedge(const bool verbose) {
             {
               ordinal_type targetCubDegree(basisPtr->getDegree());
 
-              Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+              ProjStruct projStruct;
               projStruct.createL2DGProjectionStruct(basisPtr, targetCubDegree);
 
               auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -1410,7 +1421,8 @@ int InterpolationProjectionWedge(const bool verbose) {
             {
               DynRankView ConstructWithLabel(dofCoordsOriented, numCells, basisCardinality, dim);
               DynRankView ConstructWithLabel(dofCoeffs, numCells, basisCardinality, dim);
-              li::getDofCoordsAndCoeffs(dofCoordsOriented,  dofCoeffs, basisPtr, elemOrts);
+              lt::getOrientedDofCoords(dofCoordsOriented, basisPtr, elemOrts);
+              lt::getOrientedDofCoeffs(dofCoeffs, basisPtr, elemOrts);
               DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality, dim);
               DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
               for(ordinal_type i=0; i<numCells; ++i) {
@@ -1538,7 +1550,7 @@ int InterpolationProjectionWedge(const bool verbose) {
             {
               ordinal_type targetCubDegree(basisPtr->getDegree()),targetDerivCubDegree(basisPtr->getDegree()-1);
 
-              Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+              ProjStruct projStruct;
               projStruct.createHDivProjectionStruct(basisPtr, targetCubDegree, targetDerivCubDegree);
 
               auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -1610,7 +1622,7 @@ int InterpolationProjectionWedge(const bool verbose) {
             {
               ordinal_type targetCubDegree(basisPtr->getDegree());
 
-              Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+              ProjStruct projStruct;
               projStruct.createL2ProjectionStruct(basisPtr, targetCubDegree);
 
               auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -1665,7 +1677,7 @@ int InterpolationProjectionWedge(const bool verbose) {
             {
               ordinal_type targetCubDegree(basisPtr->getDegree());
 
-              Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+              ProjStruct projStruct;
               projStruct.createL2DGProjectionStruct(basisPtr, targetCubDegree);
 
               auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -1829,7 +1841,8 @@ int InterpolationProjectionWedge(const bool verbose) {
         {
           DynRankView ConstructWithLabel(dofCoordsOriented, numCells, basisCardinality, dim);
           DynRankView ConstructWithLabel(dofCoeffsPhys, numCells, basisCardinality);
-          li::getDofCoordsAndCoeffs(dofCoordsOriented,  dofCoeffsPhys, basisPtr, elemOrts);
+          lt::getOrientedDofCoords(dofCoordsOriented, basisPtr, elemOrts);
+          lt::getOrientedDofCoeffs(dofCoeffsPhys, basisPtr, elemOrts);
           DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality);
           DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
           for(ordinal_type i=0; i<numCells; ++i) {
@@ -1923,7 +1936,7 @@ int InterpolationProjectionWedge(const bool verbose) {
         {
           ordinal_type targetCubDegree(basisPtr->getDegree());
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createHVolProjectionStruct(basisPtr, targetCubDegree);
 
           auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -1978,7 +1991,7 @@ int InterpolationProjectionWedge(const bool verbose) {
         {
           ordinal_type targetCubDegree(basisPtr->getDegree());
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createL2ProjectionStruct(basisPtr, targetCubDegree);
 
           auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -2032,7 +2045,7 @@ int InterpolationProjectionWedge(const bool verbose) {
         {
           ordinal_type targetCubDegree(basisPtr->getDegree());
 
-          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          ProjStruct projStruct;
           projStruct.createL2DGProjectionStruct(basisPtr, targetCubDegree);
 
           auto evaluationPoints = projStruct.getAllEvalPoints();

--- a/packages/intrepid2/unit-test/Projection/test_project_fields.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_project_fields.hpp
@@ -160,9 +160,14 @@ int ProjectFields(const bool verbose) {
     }
   };
 
-  typedef OrientationTools<DeviceType> ots;
-  typedef Experimental::ProjectionTools<DeviceType> pts;
-
+  using ots = OrientationTools<DeviceType>;
+  #ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
+  using pts = Experimental::ProjectionTools<DeviceType>;
+  using ProjStruct = Experimental::ProjectionStruct<DeviceType,ValueType>;
+#else
+  using pts = ProjectionTools<DeviceType>;
+  using ProjStruct = ProjectionStruct<DeviceType,ValueType>;
+#endif
   using basisPtrType = BasisPtr<DeviceType,ValueType,ValueType>;
   using CG_NBasis = DerivedNodalBasisFamily<DeviceType,ValueType,ValueType>;
 
@@ -376,7 +381,7 @@ int ProjectFields(const bool verbose) {
       {
         ordinal_type srcCubDegree(srcBasisPtr->getDegree());
 
-        Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+        ProjStruct projStruct;
         projStruct.createL2ProjectionStruct(srcBasisPtr.get(), srcCubDegree);
         
         auto evaluationPoints = projStruct.getAllEvalPoints();

--- a/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ProjectField_impl.hpp
+++ b/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ProjectField_impl.hpp
@@ -108,8 +108,11 @@ evaluateFields(typename Traits::EvalData workset)
   if (workset.num_cells<=0) return;
 
   // Perform local L2 projection
-
-  typedef Intrepid2::Experimental::ProjectionTools<PHX::Device> pts;
+#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
+  using pts = Intrepid2::Experimental::ProjectionTools<PHX::Device>;
+#else
+  using pts = Intrepid2::ProjectionTools<PHX::Device>;
+#endif
 
   size_t numCells = workset.num_cells;
   const auto cell_range = std::pair<int,int>(0,numCells);

--- a/packages/panzer/adapters-stk/test/projection/projection.cpp
+++ b/packages/panzer/adapters-stk/test/projection/projection.cpp
@@ -457,11 +457,6 @@ TEUCHOS_UNIT_TEST(L2Projection, ToNodal)
         //Computing HDIV coefficients for B to interpolate the constant vector [1,1,1]
         DynRankView basisCoeffsB("basisCoeffsB", workset.numOwnedCells(), numBasisB);
         {
-          DynRankView dofCoordsB("dofCoordsB", workset.numOwnedCells(), numBasisB, dim);
-          DynRankView dofCoeffsB("dofCoeffsB", workset.numOwnedCells(), numBasisB, dim);
-          li::getDofCoordsAndCoeffs(dofCoordsB,  dofCoeffsB, divBasis.getRawPtr(), elemOrts);
-
-
           // Evaluate the function (in the physical frame) and map it back to the reference frame
           // In order to map an HDiv function back to the reference frame we need to multiply it
           // by det(J) J^(-1)   (J being the Jacobian of the map from reference to physical frame)
@@ -477,7 +472,7 @@ TEUCHOS_UNIT_TEST(L2Projection, ToNodal)
           });
 
           //compute basis coefficients
-          li::getBasisCoeffs(basisCoeffsB, functValuesAtDofCoordsB, dofCoeffsB);
+          li::getBasisCoeffs(basisCoeffsB, functValuesAtDofCoordsB, divBasis.getRawPtr(), elemOrts);
         }
 
 

--- a/packages/panzer/adapters-stk/test/projection/projection.cpp
+++ b/packages/panzer/adapters-stk/test/projection/projection.cpp
@@ -369,8 +369,11 @@ TEUCHOS_UNIT_TEST(L2Projection, ToNodal)
         const int numBasisPHI = static_cast<int>(offsetsPHI.extent(0));
         const int numBasisE = static_cast<int>(offsetsE.extent(0));
         const int numBasisB = static_cast<int>(offsetsB.extent(0));
-
+  #ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
         using li = Intrepid2::Experimental::LagrangianInterpolation<PHX::Device>;
+  #else
+        using li = Intrepid2::LagrangianInterpolation<PHX::Device>;
+  #endif
 
         //Computing HGRAD coefficients for PHI to interpolate function f(x,y,z) = 1+x+2y+3z
         DynRankView basisCoeffsPHI("basisCoeffsPHI", workset.numOwnedCells(), numBasisPHI);
@@ -425,11 +428,11 @@ TEUCHOS_UNIT_TEST(L2Projection, ToNodal)
    /*
         // Alternative way of computing HCurl coefficients with L2 projection
         #include "Intrepid2_ProjectionTools.hpp"
-        using pts = Intrepid2::Experimental::ProjectionTools<PHX::Device>;
+        using pts = Intrepid2::ProjectionTools<PHX::Device>;
         DynRankView basisCoeffsE("basisCoeffsE", workset.numOwnedCells(), numBasisE);
         {
           int targetCubDegree(0);
-          Intrepid2::Experimental::ProjectionStruct<PHX::Device,double> projStruct;
+          Intrepid2::ProjectionStruct<PHX::Device,double> projStruct;
           projStruct.createL2DGProjectionStruct(curlBasis, targetCubDegree);
           int numPoints = projStruct.getNumTargetEvalPoints();
           //DynRankView evalPoints("evalPoints", elemOrts, workset.numOwnedCells(), numPoints, dim);

--- a/packages/panzer/dof-mgr/test/fe_assembly/test_fe_assembly_HEX.hpp
+++ b/packages/panzer/dof-mgr/test/fe_assembly/test_fe_assembly_HEX.hpp
@@ -213,8 +213,6 @@ int feAssemblyHex(int argc, char *argv[]) {
           false,
       Kokkos::DefaultHostExecutionSpace, exec_space>;
 
-  using host_execution_space =
-      do_not_use_host_execution_space;
   using host_mirror_space = std::conditional_t<
       std::is_same<exec_space, do_not_use_host_execution_space>::value &&
           std::is_same<mem_space, do_not_use_host_memory_space>::value,
@@ -224,26 +222,30 @@ int feAssemblyHex(int argc, char *argv[]) {
 
   using HostSpaceType = typename host_mirror_space::execution_space;
 
-  typedef Kokkos::DynRankView<ValueType,DeviceSpaceType> DynRankView;
+  using DynRankView = Kokkos::DynRankView<ValueType,DeviceSpaceType>;
 
-  typedef Tpetra::Map<panzer::LocalOrdinal, panzer::GlobalOrdinal> map_t;
+  using map_t = Tpetra::Map<panzer::LocalOrdinal, panzer::GlobalOrdinal>;
 
-  typedef typename map_t::local_ordinal_type  local_ordinal_t;
-  typedef typename map_t::global_ordinal_type global_ordinal_t;
-  typedef typename map_t::node_type           node_t;
-  typedef Tpetra::FECrsGraph<local_ordinal_t,global_ordinal_t,node_t>      fe_graph_t;
-  typedef ValueType scalar_t;
-  typedef Tpetra::FECrsMatrix<scalar_t, local_ordinal_t, global_ordinal_t> fe_matrix_t;
-  typedef Tpetra::FEMultiVector<scalar_t, local_ordinal_t, global_ordinal_t> fe_multivector_t;
-  typedef Tpetra::Vector<scalar_t, local_ordinal_t, global_ordinal_t> vector_t;
+  using local_ordinal_t = typename map_t::local_ordinal_type;
+  using global_ordinal_t = typename map_t::global_ordinal_type;
+  using node_t = typename map_t::node_type;
+  using fe_graph_t = Tpetra::FECrsGraph<local_ordinal_t,global_ordinal_t,node_t>;
+  using scalar_t = ValueType;
+  using fe_matrix_t = Tpetra::FECrsMatrix<scalar_t, local_ordinal_t, global_ordinal_t>;
+  using fe_multivector_t = Tpetra::FEMultiVector<scalar_t, local_ordinal_t, global_ordinal_t>;
+  using vector_t = Tpetra::Vector<scalar_t, local_ordinal_t, global_ordinal_t>;
 
-  typedef Kokkos::DynRankView<global_ordinal_t,DeviceSpaceType> DynRankViewGId;
+  using DynRankViewGId = Kokkos::DynRankView<global_ordinal_t,DeviceSpaceType>;
 
-  typedef Intrepid2::CellTools<DeviceSpaceType> ct;
-  typedef Intrepid2::OrientationTools<DeviceSpaceType> ots;
-  typedef Intrepid2::RealSpaceTools<DeviceSpaceType> rst;
-  typedef Intrepid2::FunctionSpaceTools<DeviceSpaceType> fst;
-  typedef Intrepid2::Experimental::LagrangianInterpolation<DeviceSpaceType> li;
+  using ct = Intrepid2::CellTools<DeviceSpaceType>;
+  using ots = Intrepid2::OrientationTools<DeviceSpaceType>;
+  using rst = Intrepid2::RealSpaceTools<DeviceSpaceType>;
+  using fst = Intrepid2::FunctionSpaceTools<DeviceSpaceType>;
+#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
+  using li = Intrepid2::Experimental::LagrangianInterpolation<DeviceSpaceType>;
+#else
+  using li = Intrepid2::LagrangianInterpolation<DeviceSpaceType>;
+#endif
 
   int errorFlag = 0;
 

--- a/packages/panzer/dof-mgr/test/fe_assembly/test_fe_projection.hpp
+++ b/packages/panzer/dof-mgr/test/fe_assembly/test_fe_projection.hpp
@@ -154,26 +154,32 @@ enum ElemShape {HEX, TET, QUAD, TRI};
 template<typename ValueType, typename DeviceSpaceType>
 int feProjection(int argc, char *argv[]) {
 
-  typedef typename
-      Kokkos::Impl::HostMirror<DeviceSpaceType>::Space::execution_space HostSpaceType ;
-  typedef Kokkos::DynRankView<ValueType,DeviceSpaceType> DynRankView;
-  typedef Kokkos::DynRankView<ValueType,HostSpaceType> DynRankViewHost;
+  using HostSpaceType = typename
+      Kokkos::Impl::HostMirror<DeviceSpaceType>::Space::execution_space;
+  using DynRankView = Kokkos::DynRankView<ValueType,DeviceSpaceType>;
+  using DynRankViewHost = Kokkos::DynRankView<ValueType,HostSpaceType>;
 
-  typedef Tpetra::Map<panzer::LocalOrdinal, panzer::GlobalOrdinal> map_t;
+  using map_t = Tpetra::Map<panzer::LocalOrdinal, panzer::GlobalOrdinal>;
 
-  typedef typename map_t::local_ordinal_type  local_ordinal_t;
-  typedef typename map_t::global_ordinal_type global_ordinal_t;
-  typedef ValueType scalar_t;
+  using local_ordinal_t = typename map_t::local_ordinal_type;
+  using global_ordinal_t = typename map_t::global_ordinal_type;
+  using scalar_t = ValueType;
 
-  typedef Kokkos::DynRankView<global_ordinal_t,DeviceSpaceType> DynRankViewGId;
+  using DynRankViewGId = Kokkos::DynRankView<global_ordinal_t,DeviceSpaceType>;
 
-  typedef Intrepid2::CellTools<DeviceSpaceType> ct;
-  typedef Intrepid2::OrientationTools<DeviceSpaceType> ots;
-  typedef Intrepid2::Experimental::ProjectionTools<DeviceSpaceType> pts;
-  typedef Intrepid2::RealSpaceTools<DeviceSpaceType> rst;
-  typedef Intrepid2::FunctionSpaceTools<DeviceSpaceType> fst;
+  using ct = Intrepid2::CellTools<DeviceSpaceType>;
+  using ots = Intrepid2::OrientationTools<DeviceSpaceType>;
+#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
+  using pts = Intrepid2::Experimental::ProjectionTools<DeviceSpaceType>;
+  using ProjectionStruct = Intrepid2::Experimental::ProjectionStruct<DeviceSpaceType,scalar_t>;
+#else
+  using pts = Intrepid2::ProjectionTools<DeviceSpaceType>;
+  using ProjectionStruct = Intrepid2::ProjectionStruct<DeviceSpaceType,scalar_t>;
+#endif
+  using rst = Intrepid2::RealSpaceTools<DeviceSpaceType>;
+  using fst = Intrepid2::FunctionSpaceTools<DeviceSpaceType>;
 
-  typedef shards::CellTopology    CellTopology;
+  using CellTopology = shards::CellTopology;
 
   int errorFlag = 0;
 
@@ -520,7 +526,7 @@ int feProjection(int argc, char *argv[]) {
 
     DynRankView basisCoeffsL2Proj("basisCoeffsL2Proj", numOwnedElems, basisCardinality);
     {
-      Intrepid2::Experimental::ProjectionStruct<DeviceSpaceType,scalar_t> projStruct;
+      ProjectionStruct projStruct;
       projStruct.createL2ProjectionStruct(basis.get(), targetCubDegree);
 
       auto evaluationPoints = projStruct.getAllEvalPoints();
@@ -536,35 +542,7 @@ int feProjection(int argc, char *argv[]) {
       }
 
       DynRankView physEvalPoints("physEvalPoints", numOwnedElems, numPoints, dim);
-      {
-        DynRankView linearBasisValuesAtEvalPoint("linearBasisValuesAtEvalPoint", numOwnedElems, numNodesPerElem);
-
-        Kokkos::parallel_for(Kokkos::RangePolicy<typename DeviceSpaceType::execution_space>(0,numOwnedElems),
-            KOKKOS_LAMBDA (const int &i) {
-          auto basisValuesAtEvalPoint = Kokkos::subview(linearBasisValuesAtEvalPoint,i,Kokkos::ALL());
-          for(int j=0; j<numPoints; ++j){
-            auto evalPoint = Kokkos::subview(evaluationPoints,j,Kokkos::ALL());
-            switch (eShape) {
-            case HEX:
-              Intrepid2::Impl::Basis_HGRAD_HEX_C1_FEM::template Serial<Intrepid2::OPERATOR_VALUE>::getValues(basisValuesAtEvalPoint, evalPoint);
-              break;
-            case TET:
-              Intrepid2::Impl::Basis_HGRAD_TET_C1_FEM::template Serial<Intrepid2::OPERATOR_VALUE>::getValues(basisValuesAtEvalPoint, evalPoint);
-              break;
-            case QUAD:
-              Intrepid2::Impl::Basis_HGRAD_QUAD_C1_FEM::template Serial<Intrepid2::OPERATOR_VALUE>::getValues(basisValuesAtEvalPoint, evalPoint);
-              break;
-            case TRI:
-              Intrepid2::Impl::Basis_HGRAD_TRI_C1_FEM::template Serial<Intrepid2::OPERATOR_VALUE>::getValues(basisValuesAtEvalPoint, evalPoint);
-              break;
-            }
-            for(int k=0; k<numNodesPerElem; ++k)
-              for(int d=0; d<dim; ++d)
-                physEvalPoints(i,j,d) += physVertexes(i,k,d)*basisValuesAtEvalPoint(k);
-          }
-        });
-        Kokkos::fence();
-      }
+      ct::mapToPhysicalFrame(physEvalPoints,evaluationPoints,physVertexes,basis->getBaseCellTopology());
 
       //transform the target function and its derivative to the reference element (inverse of pullback operator)
       DynRankView jacobian("jacobian", numOwnedElems, numPoints, dim, dim);
@@ -670,12 +648,10 @@ int feProjection(int argc, char *argv[]) {
       DynRankView linearBasisValuesAtRefCoords("linearBasisValuesAtRefCoords", numNodesPerElem, numRefCoords);
       linearBasis->getValues(linearBasisValuesAtRefCoords, refPoints);
       Kokkos::fence();
-      Kokkos::parallel_for(Kokkos::RangePolicy<typename DeviceSpaceType::execution_space>(0,numOwnedElems),
-          KOKKOS_LAMBDA (const int &i) {
-        for(int d=0; d<dim; ++d)
-          for(int j=0; j<numRefCoords; ++j)
-            for(int k=0; k<numNodesPerElem; ++k)
-              physRefCoords(i,j,d) += physVertexes(i,k,d)*linearBasisValuesAtRefCoords(k,j);
+      Kokkos::MDRangePolicy<typename DeviceSpaceType::execution_space,Kokkos::Rank<3>> rangePolicy({0,0,0},{numOwnedElems, numRefCoords, dim});
+      Kokkos::parallel_for(rangePolicy, KOKKOS_LAMBDA (const int &i, const int &j, const int &d) {
+          for(int k=0; k<numNodesPerElem; ++k)
+            physRefCoords(i,j,d) += physVertexes(i,k,d)*linearBasisValuesAtRefCoords(k,j);
       });
       Kokkos::fence();
     }
@@ -835,7 +811,7 @@ int feProjection(int argc, char *argv[]) {
       auto sideBasisCardinality = sideBasisPtr->getCardinality();
       DynRankView sideBasisCoeffsL2Proj("sideBasisCoeffsL2Proj", numBoundarySides, sideBasisCardinality);
       {
-        Intrepid2::Experimental::ProjectionStruct<DeviceSpaceType,scalar_t> sideProjStruct;
+        ProjectionStruct sideProjStruct;
         sideProjStruct.createL2ProjectionStruct(sideBasisPtr.get(), targetCubDegree);
 
         auto sideEvaluationPoints = sideProjStruct.getAllEvalPoints();
@@ -853,63 +829,37 @@ int feProjection(int argc, char *argv[]) {
 
         // maps reference points into physical space
         DynRankView physSideEvalPoints("physSideEvalPoints", numBoundarySides, numSidePoints, dim);
-        DynRankView sidePhysVertices("sidePhysVertices", numBoundarySides, numNodesPerElem, dim);
+        DynRankView physVerticesOnSide("physVerticesOnSide", numBoundarySides, numNodesPerElem, dim);
         DynRankView sideEvaluationPoints3d("sideEvaluationPoints3d", numBoundarySides, numSidePoints, dim);
-        Kokkos::DynRankView<int,DeviceSpaceType> sideNodeMap("sideNodeMap", cellTopoPtr->getSideCount(), maxNumNodesPerSide);
-        auto sideNodeMapHost = Kokkos::create_mirror_view(sideNodeMap);
-        for (size_t is=0; is < sideNodeMapHost.extent(0); is++) {
-          for (size_t node=0; node < cellTopoPtr->getNodeCount(sideDim,is); node++)
-            sideNodeMapHost(is, node) = cellTopoPtr->getNodeMap(sideDim, is, node);
-        }
-        Kokkos::deep_copy(sideNodeMap,sideNodeMapHost);
-
-
-        auto sideTopoKey = sideBasisPtr->getBaseCellTopology().getBaseKey();
         {
-          DynRankView linearBasisValuesAtSideEvalPoint("linearBasisValuesAtSideEvalPoint", numBoundarySides, maxNumNodesPerSide);
-          const auto subcellParametrization =
-              Intrepid2::RefSubcellParametrization<DeviceSpaceType>::get(sideDim, cellTopoPtr->getKey());
-          Kokkos::parallel_for(Kokkos::RangePolicy<typename DeviceSpaceType::execution_space>(0,numBoundarySides),
-              KOKKOS_LAMBDA (const int &is) {
+          const auto subcellParametrization = Intrepid2::RefSubcellParametrization<DeviceSpaceType>::get(sideDim, cellTopoPtr->getKey());
+          ct::mapToReferenceSubcell(sideEvaluationPoints3d, sideEvaluationPoints, subcellParametrization, sideOrdinals);
+
+          Kokkos::DynRankView<int,DeviceSpaceType> sideNodeMap("sideNodeMap", cellTopoPtr->getSideCount(), maxNumNodesPerSide);
+          auto sideNodeMapHost = Kokkos::create_mirror_view(sideNodeMap);
+          for (size_t is=0; is < sideNodeMapHost.extent(0); is++) {
+            for (size_t node=0; node < cellTopoPtr->getNodeCount(sideDim,is); node++)
+              sideNodeMapHost(is, node) = cellTopoPtr->getNodeMap(sideDim, is, node);
+          }
+          Kokkos::deep_copy(sideNodeMap,sideNodeMapHost);
+
+          DynRankView sidePhysVertices("sidePhysVertices", numBoundarySides, numNodesPerSide, dim);
+          Kokkos::MDRangePolicy<typename DeviceSpaceType::execution_space,Kokkos::Rank<2>> rangePolicy({0,0},{numBoundarySides, dim});
+          Kokkos::parallel_for(rangePolicy, KOKKOS_LAMBDA (const int &is, const int &d) {
             auto elem = sideParentElem(is);
             auto elemSide = sideOrdinals(is);
-            auto basisValuesAtSideEvalPoint = Kokkos::subview(linearBasisValuesAtSideEvalPoint,is,Kokkos::ALL());
-
-            auto cellCoords = Kokkos::subview(sideEvaluationPoints3d,is,Kokkos::ALL(),Kokkos::ALL());
-            for(size_t i=0; i<sideEvaluationPoints.extent(0); ++i) {
-              for(int d=0; d<dim; ++d) {
-                cellCoords(i,d) = subcellParametrization(elemSide, d, 0);
-                for(int k=0; k<sideDim; ++k)
-                  cellCoords(i,d) += subcellParametrization(elemSide, d, k+1)*sideEvaluationPoints(i,k);
-              }
-            }
 
             for(int node=0; node < numNodesPerElem; ++node)
-              for(int d=0; d < dim; ++d)
-                sidePhysVertices(is, node, d) = physVertexes(elem, node, d);
+              physVerticesOnSide(is, node, d) = physVertexes(elem, node, d);
 
-            for(int j=0; j<numSidePoints; ++j){
-              auto sideEvalPoint = Kokkos::subview(sideEvaluationPoints,j,Kokkos::ALL());
-
-              switch (sideTopoKey) {
-              case shards::Quadrilateral<4>::key:
-              Intrepid2::Impl::Basis_HGRAD_QUAD_C1_FEM::template Serial<Intrepid2::OPERATOR_VALUE>::getValues(basisValuesAtSideEvalPoint, sideEvalPoint);
-              break;
-              case shards::Triangle<3>::key:
-              Intrepid2::Impl::Basis_HGRAD_TRI_C1_FEM::template Serial<Intrepid2::OPERATOR_VALUE>::getValues(basisValuesAtSideEvalPoint, sideEvalPoint);
-              break;
-              case shards::Line<2>::key:
-              Intrepid2::Impl::Basis_HGRAD_LINE_C1_FEM::template Serial<Intrepid2::OPERATOR_VALUE>::getValues(basisValuesAtSideEvalPoint, sideEvalPoint);
-              break;
-              }
-              for(int sideNode=0; sideNode < numNodesPerSide; ++sideNode) {
-                int node = sideNodeMap(elemSide, sideNode);
-                for(int d=0; d<dim; ++d)
-                  physSideEvalPoints(is,j,d) += physVertexes(elem,node,d)*basisValuesAtSideEvalPoint(sideNode);
-              }
+            for(int sideNode=0; sideNode < numNodesPerSide; ++sideNode) {
+              int node = sideNodeMap(elemSide, sideNode);
+              sidePhysVertices(is, sideNode, d) = physVertexes(elem, node, d);
             }
           });
           Kokkos::fence();
+
+          ct::mapToPhysicalFrame(physSideEvalPoints,sideEvaluationPoints,sidePhysVertices,sideBasisPtr->getBaseCellTopology());
         }
 
         //evaluate the boundary term in the physical space and map it back to the reference element
@@ -920,7 +870,7 @@ int feProjection(int argc, char *argv[]) {
           DynRankView metricTensor_inv("metricTensor_inv", numBoundarySides, numSidePoints, dim-1, dim-1);
           DynRankView metricTensor_det("metricTensor_det", numBoundarySides, numSidePoints);
 
-          ct::setJacobian(jacobian,sideEvaluationPoints3d,sidePhysVertices, *cellTopoPtr);
+          ct::setJacobian(jacobian, sideEvaluationPoints3d, physVerticesOnSide, *cellTopoPtr);
 
           //compute  metric information
           if ((sideFunctionSpace == Intrepid2::FUNCTION_SPACE_HCURL) || (sideFunctionSpace == Intrepid2::FUNCTION_SPACE_HVOL)) {

--- a/packages/panzer/mini-em/src/solvers/MiniEM_Interpolation.cpp
+++ b/packages/panzer/mini-em/src/solvers/MiniEM_Interpolation.cpp
@@ -26,7 +26,11 @@ Teko::LinearOp buildInterpolation(const Teuchos::RCP<const panzer::LinearObjFact
   typedef PHX::Device DeviceSpace;
   typedef Kokkos::HostSpace HostSpace;
   typedef Intrepid2::OrientationTools<DeviceSpace> ots;
+#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
   typedef Intrepid2::Experimental::LagrangianInterpolation<DeviceSpace> li;
+#else
+  typedef Intrepid2::LagrangianInterpolation<DeviceSpace> li;
+#endif
 
   typedef Kokkos::DynRankView<double,DeviceSpace> DynRankDeviceView;
 

--- a/packages/panzer/mini-em/src/solvers/MiniEM_MatrixFreeInterpolationOp.cpp
+++ b/packages/panzer/mini-em/src/solvers/MiniEM_MatrixFreeInterpolationOp.cpp
@@ -187,10 +187,13 @@ namespace mini_em {
     using Teuchos::rcp_dynamic_cast;
     using range_type = Kokkos::RangePolicy<LocalOrdinal, DeviceSpace>;
 
-    typedef Intrepid2::OrientationTools<DeviceSpace> ots;
-    typedef Intrepid2::Experimental::LagrangianInterpolation<DeviceSpace> li;
-    typedef Kokkos::DynRankView<Scalar,DeviceSpace> DynRankDeviceView;
-
+    using ots = Intrepid2::OrientationTools<DeviceSpace>;
+#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
+    using li = Intrepid2::Experimental::LagrangianInterpolation<DeviceSpace>;
+#else
+    using li = Intrepid2::LagrangianInterpolation<DeviceSpace>;
+#endif
+    using DynRankDeviceView = Kokkos::DynRankView<Scalar,DeviceSpace>;
     using view_t = typename Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>::dual_view_type::t_dev;
     using const_view_t = typename Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>::dual_view_type::t_dev::const_type;
 
@@ -396,9 +399,12 @@ namespace mini_em {
     using range_type = Kokkos::RangePolicy<LocalOrdinal, DeviceSpace>;
 
     typedef Intrepid2::OrientationTools<DeviceSpace> ots;
+  #ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
     typedef Intrepid2::Experimental::LagrangianInterpolation<DeviceSpace> li;
+  #else
+    typedef Intrepid2::LagrangianInterpolation<DeviceSpace> li;
+  #endif
     typedef Kokkos::DynRankView<Scalar,DeviceSpace> DynRankDeviceView;
-
     using TST = Teuchos::ScalarTraits<Scalar>;
     const Scalar ZERO = TST::zero();
     using view_t = typename Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>::dual_view_type::t_dev;


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/intrepid2 
@trilinos/panzer

## Motivation
The projection tools are mature enough and we want to remove the Experimental namespace. 
Added cmake option` Intrepid2_KEEP_EXPERIMENTAL_NAMESPACE`. When set,
we use the legacy namespace, otherwise the Experimental namespace is removed. The option is ON by default.
This will give time to applications (EMPIRE) to update their code before we remove the namespace completely.
Some of the legacy projection functions will be removed together with the Experimental namespace.

This PR also include some modifications to the cell tools to:
1. allow the map ref cells in a physical space that is higher dimensional  (e.g. quadrilateral in a 3d physical space)
2. call mapToReferenceSubcell on a batch of cells, where the subcell ordinal is an array changing from cell to cell.
This is useful when working on a batch of sides.


<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->