### PR TITLE
Tpetra: fix #12148 - avoid CrsGraph rowptrs D->H

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -1206,47 +1206,47 @@ namespace Tpetra {
       }
       non_const_row_map_type k_rowPtrs ("Tpetra::CrsGraph::ptr", numRows + 1);
 
-      if (this->k_numAllocPerRow_.extent (0) != 0) {
-        // It's OK to throw std::invalid_argument here, because we
-        // haven't incurred any side effects yet.  Throwing that
-        // exception (and not, say, std::logic_error) implies that the
-        // instance can recover.
-        TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-          (this->k_numAllocPerRow_.extent (0) != numRows,
-           std::invalid_argument, "k_numAllocPerRow_ is allocated, that is, "
-           "has nonzero length " << this->k_numAllocPerRow_.extent (0)
-           << ", but its length != numRows = " << numRows << ".");
+    if (this->k_numAllocPerRow_.extent (0) != 0) {
+      // It's OK to throw std::invalid_argument here, because we
+      // haven't incurred any side effects yet.  Throwing that
+      // exception (and not, say, std::logic_error) implies that the
+      // instance can recover.
+      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+        (this->k_numAllocPerRow_.extent (0) != numRows,
+         std::invalid_argument, "k_numAllocPerRow_ is allocated, that is, "
+         "has nonzero length " << this->k_numAllocPerRow_.extent (0)
+         << ", but its length != numRows = " << numRows << ".");
 
-        // k_numAllocPerRow_ is a host View, but k_rowPtrs (the thing
-        // we want to compute here) lives on device.  That's OK;
-        // computeOffsetsFromCounts can handle this case.
-        using Details::computeOffsetsFromCounts;
+      // k_numAllocPerRow_ is a host View, but k_rowPtrs (the thing
+      // we want to compute here) lives on device.  That's OK;
+      // computeOffsetsFromCounts can handle this case.
+      using Details::computeOffsetsFromCounts;
 
-        // FIXME (mfh 27 Jun 2016) Currently, computeOffsetsFromCounts
-        // doesn't attempt to check its input for "invalid" flag
-        // values.  For now, we omit that feature of the sequential
-        // code disabled below.
-        numInds = computeOffsetsFromCounts (k_rowPtrs, k_numAllocPerRow_);
-      }
-      else {
-        // It's OK to throw std::invalid_argument here, because we
-        // haven't incurred any side effects yet.  Throwing that
-        // exception (and not, say, std::logic_error) implies that the
-        // instance can recover.
-        TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-          (this->numAllocForAllRows_ ==
-           Tpetra::Details::OrdinalTraits<size_t>::invalid (),
-           std::invalid_argument, "numAllocForAllRows_ has an invalid value, "
-           "namely Tpetra::Details::OrdinalTraits<size_t>::invalid() = " <<
-           Tpetra::Details::OrdinalTraits<size_t>::invalid () << ".");
-
-        using Details::computeOffsetsFromConstantCount;
-        numInds = computeOffsetsFromConstantCount (k_rowPtrs, this->numAllocForAllRows_);
-      }
-
-      // "Commit" the resulting row offsets.
-      setRowPtrsUnpacked(k_rowPtrs);
+      // FIXME (mfh 27 Jun 2016) Currently, computeOffsetsFromCounts
+      // doesn't attempt to check its input for "invalid" flag
+      // values.  For now, we omit that feature of the sequential
+      // code disabled below.
+      numInds = computeOffsetsFromCounts (k_rowPtrs, k_numAllocPerRow_);
     }
+    else {
+      // It's OK to throw std::invalid_argument here, because we
+      // haven't incurred any side effects yet.  Throwing that
+      // exception (and not, say, std::logic_error) implies that the
+      // instance can recover.
+      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+        (this->numAllocForAllRows_ ==
+         Tpetra::Details::OrdinalTraits<size_t>::invalid (),
+         std::invalid_argument, "numAllocForAllRows_ has an invalid value, "
+         "namely Tpetra::Details::OrdinalTraits<size_t>::invalid() = " <<
+         Tpetra::Details::OrdinalTraits<size_t>::invalid () << ".");
+
+      using Details::computeOffsetsFromConstantCount;
+      numInds = computeOffsetsFromConstantCount (k_rowPtrs, this->numAllocForAllRows_);
+    }
+
+    // "Commit" the resulting row offsets.
+    setRowPtrsUnpacked(k_rowPtrs);
+  }
 
     if (lg == LocalIndices) {
       if (verbose) {

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -1198,13 +1198,13 @@ namespace Tpetra {
     //  STATIC ALLOCATION PROFILE
     //
     size_type numInds = 0;
-    {
-      if (verbose) {
-        std::ostringstream os;
-        os << *prefix << "Allocate k_rowPtrs: " << (numRows+1) << endl;
-        std::cerr << os.str();
-      }
-      non_const_row_map_type k_rowPtrs ("Tpetra::CrsGraph::ptr", numRows + 1);
+  {
+    if (verbose) {
+      std::ostringstream os;
+      os << *prefix << "Allocate k_rowPtrs: " << (numRows+1) << endl;
+      std::cerr << os.str();
+    }
+    non_const_row_map_type k_rowPtrs ("Tpetra::CrsGraph::ptr", numRows + 1);
 
     if (this->k_numAllocPerRow_.extent (0) != 0) {
       // It's OK to throw std::invalid_argument here, because we

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -1072,7 +1072,10 @@ namespace Tpetra {
           return static_cast<size_t> (0);
         }
         else {
-          return this->getRowPtrsPackedHost()(lclNumRows);
+          if(this->isLocallyIndexed())
+            return lclIndsPacked_wdv.extent(0);
+          else
+            return gblInds_wdv.extent(0);
         }
       }
       else if (storageStatus_ == Details::STORAGE_1D_UNPACKED) {
@@ -1081,7 +1084,10 @@ namespace Tpetra {
           return static_cast<size_t> (0);
         }
         else {
-          return rowPtrsUnpacked_host(lclNumRows);
+          if(this->isLocallyIndexed())
+            return lclIndsUnpacked_wdv.extent(0);
+          else
+            return gblInds_wdv.extent(0);
         }
       }
       else {

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -939,6 +939,7 @@ namespace Tpetra {
   CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
   getLocalNumEntries () const
   {
+    const char tfecfFuncName[] = "getLocalNumEntries: ";
     typedef LocalOrdinal LO;
 
     if (this->indicesAreAllocated_) {
@@ -959,6 +960,11 @@ namespace Tpetra {
             // indices are allocated and k_numRowEntries_ is not allocated,
             // so we have packed storage and the length of lclIndsPacked_wdv
             // must be the number of local entries.
+            if(debug_) {
+              TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+                (this->getRowPtrsPackedHost()(lclNumRows) != lclIndsPacked_wdv.extent(0), std::logic_error,
+                 "Final entry of packed host rowptrs doesn't match the length of lclIndsPacked");
+            }
             return lclIndsPacked_wdv.extent(0);
           }
         }

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -956,7 +956,10 @@ namespace Tpetra {
             return static_cast<size_t> (0);
           }
           else {
-            return this->getRowPtrsPackedHost()(lclNumRows);
+            // indices are allocated and k_numRowEntries_ is not allocated,
+            // so we have packed storage and the length of lclIndsPacked_wdv
+            // must be the number of local entries.
+            return lclIndsPacked_wdv.extent(0);
           }
         }
         else { // k_numRowEntries_ is populated
@@ -1188,57 +1191,57 @@ namespace Tpetra {
     //
     //  STATIC ALLOCATION PROFILE
     //
-  {
-    if (verbose) {
-      std::ostringstream os;
-      os << *prefix << "Allocate k_rowPtrs: " << (numRows+1) << endl;
-      std::cerr << os.str();
+    size_type numInds = 0;
+    {
+      if (verbose) {
+        std::ostringstream os;
+        os << *prefix << "Allocate k_rowPtrs: " << (numRows+1) << endl;
+        std::cerr << os.str();
+      }
+      non_const_row_map_type k_rowPtrs ("Tpetra::CrsGraph::ptr", numRows + 1);
+
+      if (this->k_numAllocPerRow_.extent (0) != 0) {
+        // It's OK to throw std::invalid_argument here, because we
+        // haven't incurred any side effects yet.  Throwing that
+        // exception (and not, say, std::logic_error) implies that the
+        // instance can recover.
+        TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+          (this->k_numAllocPerRow_.extent (0) != numRows,
+           std::invalid_argument, "k_numAllocPerRow_ is allocated, that is, "
+           "has nonzero length " << this->k_numAllocPerRow_.extent (0)
+           << ", but its length != numRows = " << numRows << ".");
+
+        // k_numAllocPerRow_ is a host View, but k_rowPtrs (the thing
+        // we want to compute here) lives on device.  That's OK;
+        // computeOffsetsFromCounts can handle this case.
+        using Details::computeOffsetsFromCounts;
+
+        // FIXME (mfh 27 Jun 2016) Currently, computeOffsetsFromCounts
+        // doesn't attempt to check its input for "invalid" flag
+        // values.  For now, we omit that feature of the sequential
+        // code disabled below.
+        numInds = computeOffsetsFromCounts (k_rowPtrs, k_numAllocPerRow_);
+      }
+      else {
+        // It's OK to throw std::invalid_argument here, because we
+        // haven't incurred any side effects yet.  Throwing that
+        // exception (and not, say, std::logic_error) implies that the
+        // instance can recover.
+        TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+          (this->numAllocForAllRows_ ==
+           Tpetra::Details::OrdinalTraits<size_t>::invalid (),
+           std::invalid_argument, "numAllocForAllRows_ has an invalid value, "
+           "namely Tpetra::Details::OrdinalTraits<size_t>::invalid() = " <<
+           Tpetra::Details::OrdinalTraits<size_t>::invalid () << ".");
+
+        using Details::computeOffsetsFromConstantCount;
+        numInds = computeOffsetsFromConstantCount (k_rowPtrs, this->numAllocForAllRows_);
+      }
+
+      // "Commit" the resulting row offsets.
+      setRowPtrsUnpacked(k_rowPtrs);
     }
-    non_const_row_map_type k_rowPtrs ("Tpetra::CrsGraph::ptr", numRows + 1);
 
-    if (this->k_numAllocPerRow_.extent (0) != 0) {
-      // It's OK to throw std::invalid_argument here, because we
-      // haven't incurred any side effects yet.  Throwing that
-      // exception (and not, say, std::logic_error) implies that the
-      // instance can recover.
-      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (this->k_numAllocPerRow_.extent (0) != numRows,
-         std::invalid_argument, "k_numAllocPerRow_ is allocated, that is, "
-         "has nonzero length " << this->k_numAllocPerRow_.extent (0)
-         << ", but its length != numRows = " << numRows << ".");
-
-      // k_numAllocPerRow_ is a host View, but k_rowPtrs (the thing
-      // we want to compute here) lives on device.  That's OK;
-      // computeOffsetsFromCounts can handle this case.
-      using Details::computeOffsetsFromCounts;
-
-      // FIXME (mfh 27 Jun 2016) Currently, computeOffsetsFromCounts
-      // doesn't attempt to check its input for "invalid" flag
-      // values.  For now, we omit that feature of the sequential
-      // code disabled below.
-      computeOffsetsFromCounts (k_rowPtrs, k_numAllocPerRow_);
-    }
-    else {
-      // It's OK to throw std::invalid_argument here, because we
-      // haven't incurred any side effects yet.  Throwing that
-      // exception (and not, say, std::logic_error) implies that the
-      // instance can recover.
-      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (this->numAllocForAllRows_ ==
-         Tpetra::Details::OrdinalTraits<size_t>::invalid (),
-         std::invalid_argument, "numAllocForAllRows_ has an invalid value, "
-         "namely Tpetra::Details::OrdinalTraits<size_t>::invalid() = " <<
-         Tpetra::Details::OrdinalTraits<size_t>::invalid () << ".");
-
-      using Details::computeOffsetsFromConstantCount;
-      computeOffsetsFromConstantCount (k_rowPtrs, this->numAllocForAllRows_);
-    }
-
-    // "Commit" the resulting row offsets.
-    setRowPtrsUnpacked(k_rowPtrs);
-  }
-
-    const size_type numInds = this->getRowPtrsUnpackedHost()(numRows);
     if (lg == LocalIndices) {
       if (verbose) {
         std::ostringstream os;

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -71,8 +71,6 @@
 #include <utility>
 #include <vector>
 
-#include "KokkosKernels_Utils.hpp"
-
 namespace Tpetra {
   namespace Details {
     namespace Impl {
@@ -1235,7 +1233,6 @@ namespace Tpetra {
       // values.  For now, we omit that feature of the sequential
       // code disabled below.
       numInds = computeOffsetsFromCounts (k_rowPtrs, k_numAllocPerRow_);
-      std::cout << "Just computed numInds = " << numInds << " from computeOffsetsFromCounst\n";
     }
     else {
       // It's OK to throw std::invalid_argument here, because we
@@ -1251,19 +1248,11 @@ namespace Tpetra {
 
       using Details::computeOffsetsFromConstantCount;
       numInds = computeOffsetsFromConstantCount (k_rowPtrs, this->numAllocForAllRows_);
-      std::cout << "Just computed numInds = " << numInds << " from computeOffsetsFromConstantCount, with allocPerRow = " << numAllocForAllRows_ << '\n';
-      std::cout << "The rowptrs: ";
-      KokkosKernels::Impl::print_1Dview(k_rowPtrs);
-      std::cout << '\n';
     }
     // "Commit" the resulting row offsets.
     setRowPtrsUnpacked(k_rowPtrs);
   }
-    std::cout << "The host rowptrs, after setRowPtrsUnpacked: ";
-    KokkosKernels::Impl::print_1Dview(this->getRowPtrsUnpackedHost());
-    std::cout << '\n';
     if(debug_) {
-      std::cout << "These should match: " << numInds << ", " << this->getRowPtrsUnpackedHost()(numRows) << '\n';
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
         (numInds != size_type(this->getRowPtrsUnpackedHost()(numRows)), std::logic_error,
          ": Number of indices produced by computeOffsetsFrom[Constant]Counts "

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -71,6 +71,8 @@
 #include <utility>
 #include <vector>
 
+#include "KokkosKernels_Utils.hpp"
+
 namespace Tpetra {
   namespace Details {
     namespace Impl {
@@ -1227,6 +1229,7 @@ namespace Tpetra {
       // values.  For now, we omit that feature of the sequential
       // code disabled below.
       numInds = computeOffsetsFromCounts (k_rowPtrs, k_numAllocPerRow_);
+      std::cout << "Just computed numInds = " << numInds << " from computeOffsetsFromCounst\n";
     }
     else {
       // It's OK to throw std::invalid_argument here, because we
@@ -1242,11 +1245,25 @@ namespace Tpetra {
 
       using Details::computeOffsetsFromConstantCount;
       numInds = computeOffsetsFromConstantCount (k_rowPtrs, this->numAllocForAllRows_);
+      std::cout << "Just computed numInds = " << numInds << " from computeOffsetsFromConstantCount, with allocPerRow = " << numAllocForAllRows_ << '\n';
+      std::cout << "The rowptrs: ";
+      KokkosKernels::Impl::print_1Dview(k_rowPtrs);
+      std::cout << '\n';
     }
-
     // "Commit" the resulting row offsets.
     setRowPtrsUnpacked(k_rowPtrs);
   }
+    std::cout << "The host rowptrs, after setRowPtrsUnpacked: ";
+    KokkosKernels::Impl::print_1Dview(this->getRowPtrsUnpackedHost());
+    std::cout << '\n';
+    if(debug_) {
+      std::cout << "These should match: " << numInds << ", " << this->getRowPtrsUnpackedHost()(numRows) << '\n';
+      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+        (numInds != size_type(this->getRowPtrsUnpackedHost()(numRows)), std::logic_error,
+         ": Number of indices produced by computeOffsetsFrom[Constant]Counts "
+         "does not match final entry of rowptrs unpacked");
+    }
+
 
     if (lg == LocalIndices) {
       if (verbose) {

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -1178,7 +1178,7 @@ namespace Tpetra {
       const size_t lclNumRows = this->staticGraph_->getLocalNumRows ();
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
         (this->staticGraph_->rowPtrsUnpacked_host_(lclNumRows) != lclTotalNumEntries, std::logic_error,
-         "staticGraph_ is null." << suffix);
+         "length of staticGraph's lclIndsUnpacked does not match final entry of rowPtrsUnapcked_host." << suffix);
     }
 
     // Allocate array of (packed???) matrix values.

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -1173,12 +1173,13 @@ namespace Tpetra {
     }
 
     // Allocate matrix values.
-    const size_t lclNumRows = this->staticGraph_->getLocalNumRows ();
-    typename Graph::local_graph_device_type::row_map_type k_ptrs =
-                                      this->staticGraph_->rowPtrsUnpacked_dev_;
-
-    const size_t lclTotalNumEntries = 
-                 this->staticGraph_->rowPtrsUnpacked_host_(lclNumRows);
+    const size_t lclTotalNumEntries = this->staticGraph_->lclIndsUnpacked_wdv.extent(0);
+    if (debug) {
+      const size_t lclNumRows = this->staticGraph_->getLocalNumRows ();
+      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+        (this->staticGraph_->rowPtrsUnpacked_host_(lclNumRows) != lclTotalNumEntries, std::logic_error,
+         "staticGraph_ is null." << suffix);
+    }
 
     // Allocate array of (packed???) matrix values.
     using values_type = typename local_matrix_device_type::values_type;

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -1173,11 +1173,11 @@ namespace Tpetra {
     }
 
     // Allocate matrix values.
-    const size_t lclTotalNumEntries = this->staticGraph_->lclIndsUnpacked_wdv.extent(0);
+    const size_t lclTotalNumEntries = this->staticGraph_->getLocalAllocationSize();
     if (debug) {
       const size_t lclNumRows = this->staticGraph_->getLocalNumRows ();
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (this->staticGraph_->rowPtrsUnpacked_host_(lclNumRows) != lclTotalNumEntries, std::logic_error,
+        (this->staticGraph_->getRowPtrsUnpackedHost()(lclNumRows) != lclTotalNumEntries, std::logic_error,
          "length of staticGraph's lclIndsUnpacked does not match final entry of rowPtrsUnapcked_host." << suffix);
     }
 
@@ -1268,7 +1268,7 @@ namespace Tpetra {
          << curRowOffsets.extent (0) << " != lclNumRows + 1 = "
          << (lclNumRows + 1) << ".");
       const size_t numOffsets = curRowOffsets.extent (0);
-      const auto valToCheck = myGraph_->rowPtrsUnpacked_host_(numOffsets - 1);
+      const auto valToCheck = myGraph_->getRowPtrsUnpackedHost()(numOffsets - 1);
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
         (numOffsets != 0 &&
          myGraph_->lclIndsUnpacked_wdv.extent (0) != valToCheck,
@@ -1305,7 +1305,7 @@ namespace Tpetra {
       if (debug && curRowOffsets.extent (0) != 0) {
         const size_t numOffsets =
           static_cast<size_t> (curRowOffsets.extent (0));
-        const auto valToCheck = myGraph_->rowPtrsUnpacked_host_(numOffsets - 1);
+        const auto valToCheck = myGraph_->getRowPtrsUnpackedHost()(numOffsets - 1);
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
           (static_cast<size_t> (valToCheck) !=
            static_cast<size_t> (valuesUnpacked_wdv.extent (0)),
@@ -1458,13 +1458,14 @@ namespace Tpetra {
       // FIXME? This is already done in the graph fill call - need to avoid the memcpy to host
       myGraph_->rowPtrsPacked_dev_ = myGraph_->rowPtrsUnpacked_dev_;
       myGraph_->rowPtrsPacked_host_ = myGraph_->rowPtrsUnpacked_host_;
+      myGraph_->packedUnpackedRowPtrsMatch_ = true;
       myGraph_->lclIndsPacked_wdv = myGraph_->lclIndsUnpacked_wdv;
       valuesPacked_wdv = valuesUnpacked_wdv;
 
       if (verbose) {
         std::ostringstream os;
         os << *prefix << "Storage already packed: rowPtrsUnpacked_: "
-           << myGraph_->rowPtrsUnpacked_host_.extent(0) << ", lclIndsUnpacked_wdv: "
+           << myGraph_->getRowPtrsUnpackedHost().extent(0) << ", lclIndsUnpacked_wdv: "
            << myGraph_->lclIndsUnpacked_wdv.extent(0) << ", valuesUnpacked_wdv: "
            << valuesUnpacked_wdv.extent(0) << endl;
         std::cerr << os.str();
@@ -1473,13 +1474,14 @@ namespace Tpetra {
       if (debug) {
         const char myPrefix[] =
           "(\"Optimize Storage\"=false branch) ";
+        auto rowPtrsUnpackedHost = myGraph_->getRowPtrsUnpackedHost();
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
           (myGraph_->rowPtrsUnpacked_dev_.extent (0) == 0, std::logic_error, myPrefix
            << "myGraph->rowPtrsUnpacked_dev_.extent(0) = 0.  This probably means "
            "that rowPtrsUnpacked_ was never allocated.");
         if (myGraph_->rowPtrsUnpacked_dev_.extent (0) != 0) {
-          const size_t numOffsets (myGraph_->rowPtrsUnpacked_host_.extent (0));
-          const auto valToCheck = myGraph_->rowPtrsUnpacked_host_(numOffsets - 1);
+          const size_t numOffsets = rowPtrsUnpackedHost.extent (0);
+          const auto valToCheck = rowPtrsUnpackedHost(numOffsets - 1);
           TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
             (size_t (valToCheck) != valuesPacked_wdv.extent (0),
              std::logic_error, myPrefix <<
@@ -1498,14 +1500,15 @@ namespace Tpetra {
 
     if (debug) {
       const char myPrefix[] = "After packing, ";
+      auto rowPtrsPackedHost = myGraph_->getRowPtrsPackedHost();
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (size_t (myGraph_->rowPtrsPacked_host_.extent (0)) != size_t (lclNumRows + 1),
+        (size_t (rowPtrsPackedHost.extent (0)) != size_t (lclNumRows + 1),
          std::logic_error, myPrefix << "myGraph_->rowPtrsPacked_host_.extent(0) = "
-         << myGraph_->rowPtrsPacked_host_.extent (0) << " != lclNumRows+1 = " <<
+         << rowPtrsPackedHost.extent (0) << " != lclNumRows+1 = " <<
          (lclNumRows+1) << ".");
-      if (myGraph_->rowPtrsPacked_host_.extent (0) != 0) {
-        const size_t numOffsets (myGraph_->rowPtrsPacked_host_.extent (0));
-        const size_t valToCheck = myGraph_->rowPtrsPacked_host_(numOffsets-1);
+      if (rowPtrsPackedHost.extent (0) != 0) {
+        const size_t numOffsets (rowPtrsPackedHost.extent (0));
+        const size_t valToCheck = rowPtrsPackedHost(numOffsets-1);
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
           (valToCheck != size_t (valuesPacked_wdv.extent (0)),
            std::logic_error, myPrefix << "k_ptrs_const(" <<
@@ -1553,6 +1556,7 @@ namespace Tpetra {
       // We directly set the memory spaces to avoid a memcpy from device to host
       myGraph_->rowPtrsUnpacked_dev_ = myGraph_->rowPtrsPacked_dev_;
       myGraph_->rowPtrsUnpacked_host_ = myGraph_->rowPtrsPacked_host_;
+      myGraph_->packedUnpackedRowPtrsMatch_ = true;
       myGraph_->lclIndsUnpacked_wdv = myGraph_->lclIndsPacked_wdv;
       valuesUnpacked_wdv = valuesPacked_wdv;
 
@@ -3720,7 +3724,7 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     const LO myNumRows = static_cast<LO> (this->getLocalNumRows ());
     const size_t INV = Tpetra::Details::OrdinalTraits<size_t>::invalid ();
 
-    auto rowPtrsPackedHost = staticGraph_->rowPtrsPacked_host_;
+    auto rowPtrsPackedHost = staticGraph_->getRowPtrsPackedHost();
     auto valuesPackedHost = valuesPacked_wdv.getHostView(Access::ReadOnly);
     Kokkos::parallel_for
       ("Tpetra::CrsMatrix::getLocalDiagCopy",
@@ -4662,7 +4666,7 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       size_t totalNumDups = 0;
       {
         //Accessing host unpacked (4-array CRS) local matrix.
-        auto rowBegins_ = graph.rowPtrsUnpacked_host_;
+        auto rowBegins_ = graph.getRowPtrsUnpackedHost();
         auto rowLengths_ = graph.k_numRowEntries_;
         auto vals_ = this->valuesUnpacked_wdv.getHostView(Access::ReadWrite);
         auto cols_ = graph.lclIndsUnpacked_wdv.getHostView(Access::ReadWrite);
@@ -5523,7 +5527,7 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     if (verbose) {
       std::ostringstream os;
       os << *prefix << "Allocate row_ptrs_beg: "
-         << myGraph_->rowPtrsUnpacked_host_.extent(0) << endl;
+         << myGraph_->getRowPtrsUnpackedHost().extent(0) << endl;
       std::cerr << os.str();
     }
     using Kokkos::view_alloc;
@@ -5610,7 +5614,7 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
          << "old size: " << myGraph_->rowPtrsUnpacked_host_.extent(0)
          << ", new size: " << row_ptr_beg.extent(0) << endl;
       std::cerr << os.str();
-      TEUCHOS_ASSERT( myGraph_->rowPtrsUnpacked_host_.extent(0) ==
+      TEUCHOS_ASSERT( myGraph_->getRowPtrsUnpackedHost().extent(0) ==
                       row_ptr_beg.extent(0) );
     }
     myGraph_->setRowPtrsUnpacked(row_ptr_beg);

--- a/packages/tpetra/core/src/Tpetra_Details_computeOffsets.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_computeOffsets.hpp
@@ -385,7 +385,7 @@ computeOffsetsFromConstantCount (const OffsetsViewType& ptr,
     using functor_type =
       ComputeOffsetsFromConstantCount<offset_type, CT, SizeType>;
     execution_space execSpace;
-    functor_type::run (execSpace, ptr, count);
+    total = functor_type::run (execSpace, ptr, count);
   }
   return total;
 }

--- a/packages/tpetra/core/src/Tpetra_Details_computeOffsets.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_computeOffsets.hpp
@@ -189,12 +189,17 @@ public:
        const CountType count)
   {
     const SizeType numOffsets (offsets.extent (0));
+    if(numOffsets == SizeType(0))
+    {
+      // Special case that is possible with zero rows
+      return 0;
+    }
     using range_type = Kokkos::RangePolicy<ExecutionSpace, SizeType>;
     range_type range (execSpace, 0, numOffsets);
     using functor_type =
       ComputeOffsetsFromConstantCount<OffsetType, CountType, SizeType>;
     functor_type functor (offsets, count);
-    const OffsetType total = numOffsets*count;
+    const OffsetType total = (numOffsets - 1) * count;
     const char funcName[] =
       "Tpetra::Details::computeOffsetsFromConstantCount";
     Kokkos::parallel_for (funcName, range, functor);


### PR DESCRIPTION
- In packed storage, locally indexed case, just use the extent of lcl indices for ``getLocalNumEntries()``
- In ``allocateIndices()``, use the return value of ``computeOffsetsFromCounts`` functions instead of reading from rowptrs
- Fix bug in ``computeOffsetsFromConstantCount()`` where incorrect total was returned
- In ``CrsGraph::getLocalAllocationSize()``, use the lengths of indices views instead of reading from host rowptrs
- In ``CrsMatrix::allocateValues()`` use the graph's allocated size instead of reading from rowptrs

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Makes it possible to skip the device->host copy of packed rowptrs, in an ordinary ``CrsGraph::fillComplete``.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:
-->
## Related Issues

* Closes #12148
* Blocks 
* Is blocked by 
* Follows #12009
* Precedes
* Related to 
* Part of 
* Composed of 

## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->