### PR TITLE
MueLu: cleanup errors

### DIFF
--- a/packages/muelu/src/Graph/MatrixTransformation/MueLu_CoalesceDropFactory_def.hpp
+++ b/packages/muelu/src/Graph/MatrixTransformation/MueLu_CoalesceDropFactory_def.hpp
@@ -166,7 +166,7 @@ namespace MueLu {
         Input(currentLevel, "Coordinates");
       }
       if(algo == "signed classical sa")
-	;
+        ;
       else if (algo.find("block diagonal") != std::string::npos || algo.find("signed classical") != std::string::npos)  {
         Input(currentLevel, "BlockNumber");
       }
@@ -330,11 +330,11 @@ namespace MueLu {
       TEUCHOS_TEST_FOR_EXCEPTION(algo != "classical" && algo != "distance laplacian" && algo != "signed classical", Exceptions::RuntimeError, "\"algorithm\" must be one of (classical|distance laplacian|signed classical)");
 
       SC threshold;
-    // If we're doing the ML-style halving of the drop tol at each level, we do that here.
-    if (pL.get<bool>("aggregation: use ml scaling of drop tol"))
-      threshold = pL.get<double>("aggregation: drop tol") / pow(2.0,currentLevel.GetLevelID());
-    else
-      threshold =  as<SC>(pL.get<double>("aggregation: drop tol"));
+      // If we're doing the ML-style halving of the drop tol at each level, we do that here.
+      if (pL.get<bool>("aggregation: use ml scaling of drop tol"))
+        threshold = pL.get<double>("aggregation: drop tol") / pow(2.0,currentLevel.GetLevelID());
+      else
+        threshold =  as<SC>(pL.get<double>("aggregation: drop tol"));
 
 
       std::string distanceLaplacianAlgoStr = pL.get<std::string>("aggregation: distance laplacian algo");

--- a/packages/muelu/test/interface/CreateOperator.cpp
+++ b/packages/muelu/test/interface/CreateOperator.cpp
@@ -187,8 +187,9 @@ namespace MueLuExamples {
     sed_pref = sed_pref +  "\"\" ";
 #endif
 
-    system((sed_pref + pattern + " " + baseFile + ".gold_filtered").c_str());
-    system((sed_pref + pattern + " " + baseFile + ".out_filtered").c_str());
+    int ret_val = 0; (void) ret_val; // suppress fscanf return value and unused variable warnings
+    ret_val = system((sed_pref + pattern + " " + baseFile + ".gold_filtered").c_str());
+    ret_val = system((sed_pref + pattern + " " + baseFile + ".out_filtered").c_str());
   }
 
   bool compare_to_gold(int myRank, const std::string & baseFile) {
@@ -197,8 +198,9 @@ namespace MueLuExamples {
 
       // Create a copy of outputs
       std::string cmd = "cp -f ";
-      system((cmd + baseFile + ".gold " + baseFile + ".gold_filtered").c_str());
-      system((cmd + baseFile + ".out "  + baseFile + ".out_filtered").c_str());
+      int ret_val = 0; (void) ret_val; // suppress fscanf return value and unused variable warnings
+      ret_val = system((cmd + baseFile + ".gold " + baseFile + ".gold_filtered").c_str());
+      ret_val = system((cmd + baseFile + ".out "  + baseFile + ".out_filtered").c_str());
 
       // Tpetra produces different eigenvalues in Chebyshev due to using
       // std::rand() for generating random vectors, which may be initialized

--- a/packages/muelu/test/scaling/ComboPDriver.cpp
+++ b/packages/muelu/test/scaling/ComboPDriver.cpp
@@ -163,17 +163,22 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib lib, int arg
     }
 
     int ch;
-    while (  (ch = getc(fp) ) != '\n') ; fscanf(fp,"%d",&nElas);
+    int ret_val = 0; (void) ret_val; // suppress fscanf return value and unused variable warnings
+    while (  (ch = getc(fp) ) != '\n')
+      ;
+    ret_val = fscanf(fp,"%d",&nElas);
 
     fp = fopen(std::string("aux2" + suffix + ".mat").c_str(),"r");
     if (fp == NULL) {
       std::cout << "\nERROR:  File aux2"+suffix+".mat not found"  << std::endl;
       return EXIT_FAILURE;
     }
-    while (  (ch = getc(fp) ) != '\n') ; fscanf(fp,"%d",&nPois);
+    while (  (ch = getc(fp) ) != '\n')
+      ;
+    ret_val = fscanf(fp,"%d",&nPois);
     fclose(fp); 
 
-    // check that multiphysics problem and aux matrices are consstent with respect to sizes
+    // check that multiphysics problem and aux matrices are consistent with respect to sizes
 
     int itemp;
 
@@ -183,7 +188,9 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib lib, int arg
       std::cout << "\nERROR:  File multiPhys4x4"+suffix+".mat not found"  << std::endl;
       return EXIT_FAILURE;
     }
-    while (  (ch = getc(fp) ) != '\n') ; fscanf(fp,"%d",&itemp);
+    while (  (ch = getc(fp) ) != '\n')
+      ;
+    ret_val = fscanf(fp,"%d",&itemp);
     if (itemp != nElas+nPois+nElas+nPois) {
       std::cout << "\nERROR:  multiPhys4x4"+suffix+".mat dimension is" << itemp << "was expecting it to be " << 2*(nElas+nPois) << std::endl;
       return EXIT_FAILURE;
@@ -194,7 +201,9 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib lib, int arg
       std::cout << "\nERROR:  File multiPhys2x2"+suffix+".mat not found"  << std::endl;
       return EXIT_FAILURE;
     }
-    while (  (ch = getc(fp) ) != '\n') ; fscanf(fp,"%d",&itemp);
+    while (  (ch = getc(fp) ) != '\n')
+      ;
+    ret_val = fscanf(fp,"%d",&itemp);
     if (itemp != nElas+nPois) {
       std::cout << "\nERROR:  multiPhys2x2"+suffix+".mat dimension is" << itemp << "was expecting it to be " << (nElas+nPois) << std::endl;
       return EXIT_FAILURE;


### PR DESCRIPTION
@trilinos/muelu @cgcgcg 

Fixes irksome messages while compiling MueLu.

Introduced by #12006
```
In file included from /home/graham/Programming/cpp/Trilinos/Trilinos-build/packages/muelu/src/Utils/ExplicitInstantiation/ETI_MueLu_CoalesceDropFactory.cpp:55:
/home/graham/Programming/cpp/Trilinos/Trilinos-source/packages/muelu/src/Graph/MatrixTransformation/MueLu_CoalesceDropFactory_def.hpp: In member function ‘void MueLu::CoalesceDropFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(MueLu::CoalesceDropFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Level&) const’:
/home/graham/Programming/cpp/Trilinos/Trilinos-source/packages/muelu/src/Graph/MatrixTransformation/MueLu_CoalesceDropFactory_def.hpp:336:5: warning: this ‘else’ clause does not guard... [-Wmisleading-indentation]
  336 |     else
      |     ^~~~
/home/graham/Programming/cpp/Trilinos/Trilinos-source/packages/muelu/src/Graph/MatrixTransformation/MueLu_CoalesceDropFactory_def.hpp:340:7: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘else’
  340 |       std::string distanceLaplacianAlgoStr = pL.get<std::string>("aggregation: distance laplacian algo");
      |       ^~~
```

Introduced by #11951
```
/home/graham/Programming/cpp/Trilinos/Trilinos-source/packages/muelu/test/scaling/ComboPDriver.cpp: In function ‘int main_(Teuchos::CommandLineProcessor&, Xpetra::UnderlyingLib, int, char**)’:
/home/graham/Programming/cpp/Trilinos/Trilinos-source/packages/muelu/test/scaling/ComboPDriver.cpp:166:5: warning: this ‘while’ clause does not guard... [-Wmisleading-indentation]
  166 |     while (  (ch = getc(fp) ) != '\n') ; fscanf(fp,"%d",&nElas);
      |     ^~~~~
/home/graham/Programming/cpp/Trilinos/Trilinos-source/packages/muelu/test/scaling/ComboPDriver.cpp:166:42: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘while’
  166 |     while (  (ch = getc(fp) ) != '\n') ; fscanf(fp,"%d",&nElas);
      |                                          ^~~~~~
/home/graham/Programming/cpp/Trilinos/Trilinos-source/packages/muelu/test/scaling/ComboPDriver.cpp:173:5: warning: this ‘while’ clause does not guard... [-Wmisleading-indentation]
  173 |     while (  (ch = getc(fp) ) != '\n') ; fscanf(fp,"%d",&nPois);
      |     ^~~~~
/home/graham/Programming/cpp/Trilinos/Trilinos-source/packages/muelu/test/scaling/ComboPDriver.cpp:173:42: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘while’
  173 |     while (  (ch = getc(fp) ) != '\n') ; fscanf(fp,"%d",&nPois);
      |                                          ^~~~~~
/home/graham/Programming/cpp/Trilinos/Trilinos-source/packages/muelu/test/scaling/ComboPDriver.cpp:186:5: warning: this ‘while’ clause does not guard... [-Wmisleading-indentation]
  186 |     while (  (ch = getc(fp) ) != '\n') ; fscanf(fp,"%d",&itemp);
      |     ^~~~~
/home/graham/Programming/cpp/Trilinos/Trilinos-source/packages/muelu/test/scaling/ComboPDriver.cpp:186:42: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘while’
  186 |     while (  (ch = getc(fp) ) != '\n') ; fscanf(fp,"%d",&itemp);
      |                                          ^~~~~~
/home/graham/Programming/cpp/Trilinos/Trilinos-source/packages/muelu/test/scaling/ComboPDriver.cpp: In function ‘int main_(Teuchos::CommandLineProcessor&, Xpetra::UnderlyingLib, int, char**) [with Scalar = double; LocalOrdinal = int; GlobalOrdinal = long long int; Node = Tpetra::KokkosCompat::KokkosDeviceWrapperNode<Kokkos::Serial>]’:
/home/graham/Programming/cpp/Trilinos/Trilinos-source/packages/muelu/test/scaling/ComboPDriver.cpp:166:48: warning: ignoring return value of ‘int fscanf(FILE*, const char*, ...)’, declared with attribute warn_unused_result [-Wunused-result]
  166 |     while (  (ch = getc(fp) ) != '\n') ; fscanf(fp,"%d",&nElas);
      |                                          ~~~~~~^~~~~~~~~~~~~~~~
/home/graham/Programming/cpp/Trilinos/Trilinos-source/packages/muelu/test/scaling/ComboPDriver.cpp:173:48: warning: ignoring return value of ‘int fscanf(FILE*, const char*, ...)’, declared with attribute warn_unused_result [-Wunused-result]
  173 |     while (  (ch = getc(fp) ) != '\n') ; fscanf(fp,"%d",&nPois);
      |                                          ~~~~~~^~~~~~~~~~~~~~~~
/home/graham/Programming/cpp/Trilinos/Trilinos-source/packages/muelu/test/scaling/ComboPDriver.cpp:186:48: warning: ignoring return value of ‘int fscanf(FILE*, const char*, ...)’, declared with attribute warn_unused_result [-Wunused-result]
  186 |     while (  (ch = getc(fp) ) != '\n') ; fscanf(fp,"%d",&itemp);
      |                                          ~~~~~~^~~~~~~~~~~~~~~~
```

Old stuff:
```
/home/graham/Programming/cpp/Trilinos/Trilinos-source/packages/muelu/test/interface/CreateOperator.cpp: In function ‘void MueLuExamples::run_sed(const string&, const string&)’:
/home/graham/Programming/cpp/Trilinos/Trilinos-source/packages/muelu/test/interface/CreateOperator.cpp:190:11: warning: ignoring return value of ‘int system(const char*)’, declared with attribute warn_unused_result [-Wunused-result]
  190 |     system((sed_pref + pattern + " " + baseFile + ".gold_filtered").c_str());
      |     ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/graham/Programming/cpp/Trilinos/Trilinos-source/packages/muelu/test/interface/CreateOperator.cpp:191:11: warning: ignoring return value of ‘int system(const char*)’, declared with attribute warn_unused_result [-Wunused-result]
  191 |     system((sed_pref + pattern + " " + baseFile + ".out_filtered").c_str());
      |     ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/graham/Programming/cpp/Trilinos/Trilinos-source/packages/muelu/test/interface/CreateOperator.cpp: In function ‘bool MueLuExamples::compare_to_gold(int, const string&)’:
/home/graham/Programming/cpp/Trilinos/Trilinos-source/packages/muelu/test/interface/CreateOperator.cpp:200:13: warning: ignoring return value of ‘int system(const char*)’, declared with attribute warn_unused_result [-Wunused-result]
  200 |       system((cmd + baseFile + ".gold " + baseFile + ".gold_filtered").c_str());
      |       ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/graham/Programming/cpp/Trilinos/Trilinos-source/packages/muelu/test/interface/CreateOperator.cpp:201:13: warning: ignoring return value of ‘int system(const char*)’, declared with attribute warn_unused_result [-Wunused-result]
  201 |       system((cmd + baseFile + ".out "  + baseFile + ".out_filtered").c_str());
      |       ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```