### PR TITLE
AztecOO: Don't use hardcoded `MPI_COMM_WORLD` in `AztecOO` code

### DIFF
--- a/packages/aztecoo/src/az_old_matvec_mult.c
+++ b/packages/aztecoo/src/az_old_matvec_mult.c
@@ -1,13 +1,13 @@
 /*
 //@HEADER
 // ***********************************************************************
-// 
-//        AztecOO: An Object-Oriented Aztec Linear Solver Package 
+//
+//        AztecOO: An Object-Oriented Aztec Linear Solver Package
 //                 Copyright (2002) Sandia Corporation
-// 
+//
 // Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
 // license for use of this work by or on behalf of the U.S. Government.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -35,8 +35,8 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov) 
-// 
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
 // ***********************************************************************
 //@HEADER
 */
@@ -119,9 +119,9 @@ void AZ_matvec_mult(double *val, int *indx, int *bindx, int *rpntr, int *cpntr,
    Amat.aux_matrix = NULL;
    Amat.matrix_type = data_org[AZ_matrix_type];
 #ifdef AZTEC_MPI
-   AZ_set_comm(proc_config, MPI_COMM_WORLD);
+   AZ_set_comm(proc_config, MPI_COMM_WORLD); // CHECK: ALLOW MPI_COMM_WORLD
    if (first_time == 1) {
-      AZ_set_proc_config(proc_config, MPI_COMM_WORLD);
+      AZ_set_proc_config(proc_config, MPI_COMM_WORLD); // CHECK: ALLOW MPI_COMM_WORLD
 #else
    if (first_time == 1) {
       AZ_set_proc_config(proc_config, AZ_NOT_MPI);

--- a/packages/aztecoo/src/md_wrap_mpi_c.c
+++ b/packages/aztecoo/src/md_wrap_mpi_c.c
@@ -1,13 +1,13 @@
 /*
 //@HEADER
 // ***********************************************************************
-// 
-//        AztecOO: An Object-Oriented Aztec Linear Solver Package 
+//
+//        AztecOO: An Object-Oriented Aztec Linear Solver Package
 //                 Copyright (2002) Sandia Corporation
-// 
+//
 // Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
 // license for use of this work by or on behalf of the U.S. Government.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -35,8 +35,8 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov) 
-// 
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
 // ***********************************************************************
 //@HEADER
 */
@@ -73,8 +73,8 @@ void get_parallel_info(int *proc, int *nprocs, int *dim)
 
   /* local variables */
 
-  MPI_Comm_size(MPI_COMM_WORLD, nprocs);
-  MPI_Comm_rank(MPI_COMM_WORLD, proc);
+  MPI_Comm_size(MPI_COMM_WORLD, nprocs); // CHECK: ALLOW MPI_COMM_WORLD
+  MPI_Comm_rank(MPI_COMM_WORLD, proc); // CHECK: ALLOW MPI_COMM_WORLD
   *dim = 0;
 the_proc_name = *proc;
 
@@ -99,11 +99,11 @@ int md_read(char *buf, int bytes, int *source, int *type, int *flag)
   if (*source == -1) *source = MPI_ANY_SOURCE;
 
   if (bytes == 0) {
-    err = MPI_Recv(&gl_rbuf, 1, MPI_BYTE, *source, *type, MPI_COMM_WORLD,
+    err = MPI_Recv(&gl_rbuf, 1, MPI_BYTE, *source, *type, MPI_COMM_WORLD, // CHECK: ALLOW MPI_COMM_WORLD
                    &status);
   }
   else {
-    err = MPI_Recv(buf, bytes, MPI_BYTE, *source, *type, MPI_COMM_WORLD,
+    err = MPI_Recv(buf, bytes, MPI_BYTE, *source, *type, MPI_COMM_WORLD, // CHECK: ALLOW MPI_COMM_WORLD
                    &status);
   }
 
@@ -129,10 +129,10 @@ int md_write(char *buf, int bytes, int dest, int type, int *flag)
   int err;
 
   if (bytes == 0) {
-    err = MPI_Send(&gl_sbuf, 1, MPI_BYTE, dest, type, MPI_COMM_WORLD);
+    err = MPI_Send(&gl_sbuf, 1, MPI_BYTE, dest, type, MPI_COMM_WORLD); // CHECK: ALLOW MPI_COMM_WORLD
   }
   else {
-    err = MPI_Send(buf, bytes, MPI_BYTE, dest, type, MPI_COMM_WORLD);
+    err = MPI_Send(buf, bytes, MPI_BYTE, dest, type, MPI_COMM_WORLD); // CHECK: ALLOW MPI_COMM_WORLD
   }
 
   if (err != 0) (void) fprintf(stderr, "MPI_Send error = %d\n", err);
@@ -182,11 +182,11 @@ int md_wrap_iread(void *buf, int bytes, int *source, int *type,
   if (*source == -1) *source = MPI_ANY_SOURCE;
 
   if (bytes == 0) {
-    err = MPI_Irecv(&gl_rbuf, 1, MPI_BYTE, *source, *type, MPI_COMM_WORLD,
+    err = MPI_Irecv(&gl_rbuf, 1, MPI_BYTE, *source, *type, MPI_COMM_WORLD, // CHECK: ALLOW MPI_COMM_WORLD
                     request);
   }
   else {
-    err = MPI_Irecv(buf, bytes, MPI_BYTE, *source, *type, MPI_COMM_WORLD,
+    err = MPI_Irecv(buf, bytes, MPI_BYTE, *source, *type, MPI_COMM_WORLD, // CHECK: ALLOW MPI_COMM_WORLD
                     request);
   }
 
@@ -231,10 +231,10 @@ int md_wrap_write(void *buf, int bytes, int dest, int type, int *flag)
   int err = 0;
 
   if (bytes == 0) {
-    err = MPI_Send(&gl_sbuf, 1, MPI_BYTE, dest, type, MPI_COMM_WORLD);
+    err = MPI_Send(&gl_sbuf, 1, MPI_BYTE, dest, type, MPI_COMM_WORLD); // CHECK: ALLOW MPI_COMM_WORLD
   }
   else {
-    err = MPI_Send(buf, bytes, MPI_BYTE, dest, type, MPI_COMM_WORLD);
+    err = MPI_Send(buf, bytes, MPI_BYTE, dest, type, MPI_COMM_WORLD); // CHECK: ALLOW MPI_COMM_WORLD
   }
 
   return err;
@@ -303,7 +303,7 @@ int md_wrap_iwrite(void *buf, int bytes, int dest, int type, int *flag,
 
 /*******************************************************************************
 
-  Machine dependent wrapped message-sending (nonblocking) communication 
+  Machine dependent wrapped message-sending (nonblocking) communication
   routine for MPI.
 
   Author:          Scott A. Hutchinson, SNL, 9221
@@ -332,11 +332,11 @@ int md_wrap_iwrite(void *buf, int bytes, int dest, int type, int *flag,
   int err = 0;
 
   if (bytes == 0) {
-    err = MPI_Isend(&gl_sbuf, 1, MPI_BYTE, dest, type, MPI_COMM_WORLD,
+    err = MPI_Isend(&gl_sbuf, 1, MPI_BYTE, dest, type, MPI_COMM_WORLD, // CHECK: ALLOW MPI_COMM_WORLD
                   request);
   }
   else {
-    err = MPI_Isend(buf, bytes, MPI_BYTE, dest, type, MPI_COMM_WORLD,
+    err = MPI_Isend(buf, bytes, MPI_BYTE, dest, type, MPI_COMM_WORLD, // CHECK: ALLOW MPI_COMM_WORLD
                   request);
   }
 


### PR DESCRIPTION
@trilinos/aztecoo

~~Introduce  `az_global_mpi_comm` global variable that defaults to `MPI_COMM_WORLD` and use it instead of hardcoded `MPI_COMM_WORLD`.~~

This PR is part of the initiative to phase out the use of `MPI_COMM_WORLD` in Trilinos.

EDIT: 
See https://github.com/trilinos/Trilinos/pull/12163#issuecomment-1737863375