### PR TITLE
Anasazi: Add global MPI communicator that can be used instead of hardcoded `MPI_COMM_WORLD`

### DIFF
--- a/packages/anasazi/epetra/src-rbgen/RBGenDriver_EpetraMV.cpp
+++ b/packages/anasazi/epetra/src-rbgen/RBGenDriver_EpetraMV.cpp
@@ -65,7 +65,7 @@
 #include "Teuchos_ParameterList.hpp"
 #include "Teuchos_CommandLineProcessor.hpp"
 #include "Teuchos_Assert.hpp"
-	
+
 int main( int argc, char* argv[] )
 {
 
@@ -111,13 +111,13 @@ int main( int argc, char* argv[] )
   // ---------------------------------------------------------------
   //
   Teuchos::RCP<Teuchos::ParameterList> BasisParams = RBGen::createParams( xml_file );
-  if (verbose && Comm.MyPID() == 0) 
+  if (verbose && Comm.MyPID() == 0)
   {
     std::cout<<"-------------------------------------------------------"<<std::endl;
     std::cout<<"Input Parameter List: "<<std::endl;
     std::cout<<"-------------------------------------------------------"<<std::endl;
     BasisParams->print();
-  } 
+  }
   //
   // ---------------------------------------------------------------
   //  CREATE THE FILE I/O HANDLER
@@ -134,17 +134,17 @@ int main( int argc, char* argv[] )
   //
   Teuchos::RCP< RBGen::FileIOHandler<Epetra_MultiVector> > mvFileIO;
   Teuchos::RCP< RBGen::FileIOHandler<Epetra_Operator> > opFileIO =
-    Teuchos::rcp( new RBGen::EpetraCrsMatrixFileIOHandler() ); 
+    Teuchos::rcp( new RBGen::EpetraCrsMatrixFileIOHandler() );
   {
     Teuchos::TimeMonitor lcltimer( *timerFileIO );
     mvFileIO = fio_factory.create( *BasisParams );
-    //					    
+    //
     // Initialize file IO handlers
     //
     mvFileIO->Initialize( BasisParams );
     opFileIO->Initialize( BasisParams );
-  }    
-  if (verbose && Comm.MyPID() == 0) 
+  }
+  if (verbose && Comm.MyPID() == 0)
   {
     std::cout<<"-------------------------------------------------------"<<std::endl;
     std::cout<<"File I/O Handlers Generated"<<std::endl;
@@ -164,7 +164,7 @@ int main( int argc, char* argv[] )
   {
     Teuchos::TimeMonitor lcltimer( *timerSnapshotIn );
     testMV = mvFileIO->Read( *filenames );
-  } 
+  }
 
   RBGen::EpetraMVPreprocessorFactory preprocess_factory;
 
@@ -180,14 +180,14 @@ int main( int argc, char* argv[] )
     prep->Initialize( BasisParams, mvFileIO );
   }
 
-  Teuchos::RCP<Teuchos::Time> timerPreprocess = Teuchos::rcp( new Teuchos::Time("Preprocess Snapshot Set") );  
+  Teuchos::RCP<Teuchos::Time> timerPreprocess = Teuchos::rcp( new Teuchos::Time("Preprocess Snapshot Set") );
   timersRBGen.push_back( timerPreprocess );
   {
     Teuchos::TimeMonitor lcltimer( *timerPreprocess );
     prep->Preprocess( testMV );
   }
 
-  if (verbose && Comm.MyPID() == 0) 
+  if (verbose && Comm.MyPID() == 0)
   {
     std::cout<<"-------------------------------------------------------"<<std::endl;
     std::cout<<"Snapshot Set Imported and Preprocessed"<<std::endl;
@@ -208,7 +208,7 @@ int main( int argc, char* argv[] )
   timersRBGen.push_back( timerCreateMethod );
   Teuchos::RCP<RBGen::Method<Epetra_MultiVector,Epetra_Operator> > method;
   {
-    Teuchos::TimeMonitor lcltimer( *timerCreateMethod );  
+    Teuchos::TimeMonitor lcltimer( *timerCreateMethod );
     method = mthd_factory.create( *BasisParams );
     //
     // Initialize reduced basis method.
@@ -221,7 +221,7 @@ int main( int argc, char* argv[] )
   Teuchos::RCP<Teuchos::Time> timerComputeBasis = Teuchos::rcp( new Teuchos::Time("Reduced Basis Computation") );
   timersRBGen.push_back( timerComputeBasis );
   {
-    Teuchos::TimeMonitor lcltimer( *timerComputeBasis );  
+    Teuchos::TimeMonitor lcltimer( *timerComputeBasis );
     method->computeBasis();
   }
   //
@@ -239,8 +239,8 @@ int main( int argc, char* argv[] )
     std::cout<<"Computed Singular Values : "<<std::endl;
     std::cout<<"-------------------------------------------------------"<<std::endl;
     for (unsigned int i=0; i<sv.size(); ++i) { std::cout << sv[i] << std::endl; }
-  }      
-  
+  }
+
   if (Comm.MyPID() == 0) {
     std::cout<<"-------------------------------------------------------"<<std::endl;
     std::cout<<"RBGen Computation Time Breakdown (seconds) : "<<std::endl;

--- a/packages/anasazi/epetra/src-rbgen/RBGen_AnasaziPOD.cpp
+++ b/packages/anasazi/epetra/src-rbgen/RBGen_AnasaziPOD.cpp
@@ -52,17 +52,18 @@
 
 #ifdef EPETRA_MPI
 #include "Epetra_MpiComm.h"
+#include "AnasaziGlobalComm.hpp"
 #else
 #include "Epetra_SerialComm.h"
 #endif
 
 namespace RBGen {
-  
+
   AnasaziPOD::AnasaziPOD() :
     isInitialized_( false ),
     isInner_( true ),
     basis_size_( 16 ),
-    comp_time_( 0.0 ) 
+    comp_time_( 0.0 )
   {
   }
 
@@ -76,8 +77,8 @@ namespace RBGen {
 
     if ( rbmethod_params.get("Basis Size", 16) < ss->NumVectors() ) {
       basis_size_ = rbmethod_params.get("Basis Size", 16);
-    } 
-    else { 
+    }
+    else {
       basis_size_ = ss->NumVectors();
     }
     // Get the inner / outer product form of the operator
@@ -97,20 +98,20 @@ namespace RBGen {
       inner_prod_op_ = fileio->Read( filename );
     }
 
-    // Resize the singular value vector 
-    sv_.resize( basis_size_ );    
+    // Resize the singular value vector
+    sv_.resize( basis_size_ );
 
     // Set the snapshot set
     ss_ = ss;
   }
 
   void AnasaziPOD::computeBasis()
-  {    
+  {
 #ifdef EPETRA_MPI
-    Epetra_MpiComm comm( MPI_COMM_WORLD );
+    Epetra_MpiComm comm( get_global_comm() );
 #else
     Epetra_SerialComm comm;
-#endif    
+#endif
 
     int MyPID = comm.MyPID();
     //
@@ -156,7 +157,7 @@ namespace RBGen {
     MyPL.set( "Block Size", blockSize );
     MyPL.set( "Num Blocks", maxBlocks );
     MyPL.set( "Maximum Restarts", maxRestarts );
-    MyPL.set( "Which", which );        
+    MyPL.set( "Which", which );
     MyPL.set( "Step Size", step );
     MyPL.set( "Convergence Tolerance", tol );
     //
@@ -203,13 +204,13 @@ namespace RBGen {
     // Create the eigenproblem
     Teuchos::RCP<Anasazi::BasicEigenproblem<double,MV,OP> > MyProblem =
       Teuchos::rcp( new Anasazi::BasicEigenproblem<double,MV,OP>(Amat, ivec) );
-  
+
     // Inform the eigenproblem that the operator A is symmetric
-    MyProblem->setHermitian( true ); 
-    
+    MyProblem->setHermitian( true );
+
     // Set the number of eigenvalues requested
     MyProblem->setNEV( nev );
-    
+
     // Inform the eigenproblem that you are finishing passing it information
     bool boolret = MyProblem->setProblem();
     if (boolret != true) {
@@ -217,10 +218,10 @@ namespace RBGen {
         std::cout << "Anasazi::BasicEigenproblem::setProblem() returned with error." << std::endl;
       }
     }
-    
+
     // Initialize the Block Arnoldi solver
     Anasazi::BlockKrylovSchurSolMgr<double,MV,OP> MySolverMgr(MyProblem, MyPL);
-    
+
     timer.ResetStartTime();
 
     // Solve the problem to the specified tolerances or length
@@ -239,25 +240,25 @@ namespace RBGen {
     if (numev < nev && MyPID==0) {
       std::cout << "RBGen::AnasaziPOD will return " << numev << " singular vectors." << std::endl;
     }
- 
+
     // Resize the singular value vector to the number of computed singular pairs.
-    sv_.resize( numev );    
+    sv_.resize( numev );
 
     if (numev > 0) {
       // Retrieve eigenvectors
       std::vector<int> index(numev);
       for (i=0; i<numev; i++) { index[i] = i; }
-      Teuchos::RCP<const Anasazi::EpetraMultiVec> evecs = Teuchos::rcp_dynamic_cast<const Anasazi::EpetraMultiVec>( 
+      Teuchos::RCP<const Anasazi::EpetraMultiVec> evecs = Teuchos::rcp_dynamic_cast<const Anasazi::EpetraMultiVec>(
         Anasazi::MultiVecTraits<double,MV>::CloneView(*sol.Evecs, index) );
-      // const Anasazi::EpetraMultiVec* evecs = dynamic_cast<const Anasazi::EpetraMultiVec *>(sol.Evecs->CloneView( index )); 
+      // const Anasazi::EpetraMultiVec* evecs = dynamic_cast<const Anasazi::EpetraMultiVec *>(sol.Evecs->CloneView( index ));
       //
       // Compute singular values which are the square root of the eigenvalues
       //
-      for (i=0; i<numev; i++) { 
-        sv_[i] = Teuchos::ScalarTraits<double>::squareroot( Teuchos::ScalarTraits<double>::magnitude(evals[i].realpart) ); 
+      for (i=0; i<numev; i++) {
+        sv_[i] = Teuchos::ScalarTraits<double>::squareroot( Teuchos::ScalarTraits<double>::magnitude(evals[i].realpart) );
       }
       //
-      // If we are using inner product formulation, 
+      // If we are using inner product formulation,
       // then we must compute left singular vectors:
       //             u = Av/sigma
       //
@@ -265,17 +266,17 @@ namespace RBGen {
       if (isInner_) {
         basis_ = Teuchos::rcp( new Epetra_MultiVector(ss_->Map(), numev) );
         Epetra_MultiVector AV( ss_->Map(), numev );
-        
-        /* A*V */   
+
+        /* A*V */
         AV.Multiply( 'N', 'N', 1.0, *ss_, *evecs, 0.0 );
         AV.Norm2( &tempnrm[0] );
-        
+
         /* U = A*V(i)/S(i) */
         Epetra_LocalMap localMap2( numev, 0, ss_->Map().Comm() );
         Epetra_MultiVector S( localMap2, numev );
         for( i=0; i<numev; i++ ) { S[i][i] = 1.0/tempnrm[i]; }
         basis_->Multiply( 'N', 'N', 1.0, AV, S, 0.0 );
-        
+
         /* Compute direct residuals : || Av - sigma*u ||
            for (i=0; i<nev; i++) { S[i][i] = sv_[i]; }
            info = AV.Multiply( 'N', 'N', -1.0, *basis_, S, 1.0 );
@@ -292,19 +293,19 @@ namespace RBGen {
       } else {
         basis_ = Teuchos::rcp( new Epetra_MultiVector( Copy, *evecs, 0, numev ) );
         Epetra_MultiVector ATU( localMap, numev );
-        Epetra_MultiVector V( localMap, numev );      
-        
-        /* A^T*U */   
+        Epetra_MultiVector V( localMap, numev );
+
+        /* A^T*U */
         ATU.Multiply( 'T', 'N', 1.0, *ss_, *evecs, 0.0 );
         ATU.Norm2( &tempnrm[0] );
-        
+
         /* V = A^T*U(i)/S(i) */
         Epetra_LocalMap localMap2( numev, 0, ss_->Map().Comm() );
         Epetra_MultiVector S( localMap2, numev );
         for( i=0; i<numev; i++ ) { S[i][i] = 1.0/tempnrm[i]; }
         V.Multiply( 'N', 'N', 1.0, ATU, S, 0.0 );
-        
-        /* Compute direct residuals : || (A^T)u - sigma*v ||     
+
+        /* Compute direct residuals : || (A^T)u - sigma*v ||
            for (i=0; i<nev; i++) { S[i][i] = sv_[i]; }
            info = ATU.Multiply( 'N', 'N', -1.0, V, S, 1.0 );
            ATU.Norm2( tempnrm );

--- a/packages/anasazi/epetra/src-rbgen/RBGen_BurkardtFileIOHandler.cpp
+++ b/packages/anasazi/epetra/src-rbgen/RBGen_BurkardtFileIOHandler.cpp
@@ -54,13 +54,14 @@
 
 #ifdef EPETRA_MPI
 #include "Epetra_MpiComm.h"
+#include "AnasaziGlobalComm.hpp"
 #else
 #include "Epetra_SerialComm.h"
 #endif
 
 
 namespace RBGen {
-  
+
   BurkardtFileIOHandler::BurkardtFileIOHandler()
     : num_nodes(0), isInit(false)
   {
@@ -70,27 +71,27 @@ namespace RBGen {
   {
 
 #ifdef EPETRA_MPI
-    Epetra_MpiComm comm( MPI_COMM_WORLD );
+    Epetra_MpiComm comm( get_global_comm() );
 #else
     Epetra_SerialComm comm;
 #endif
 
     // Get the "File I/O" sublist.
     Teuchos::ParameterList& fileio_params = params->sublist( "File IO" );
-    
-    if( fileio_params.isParameter("Burkardt Data Format File") ) 
-      {      
+
+    if( fileio_params.isParameter("Burkardt Data Format File") )
+      {
         std::string format_file = Teuchos::getParameter<std::string>( fileio_params, "Burkardt Data Format File" );
         //
         // The first processor get the number of nodes from the data format file and then broadcasts it.
         //
-        if ( comm.MyPID() == 0 ) 
+        if ( comm.MyPID() == 0 )
           num_nodes = data_size( format_file );
         comm.Broadcast( &num_nodes, 1, 0 );
         // if (!num_nodes) { TO DO:  THROW EXCEPTION! }
         isInit = true;
-      } 
-    else 
+      }
+    else
     {
       // Can't find the data size or data format file
       isInit = false;
@@ -99,7 +100,7 @@ namespace RBGen {
 
     // Get the input path.
     in_path = "";
-    if ( fileio_params.isParameter( "Data Input Path" ) ) {       
+    if ( fileio_params.isParameter( "Data Input Path" ) ) {
       in_path = Teuchos::getParameter<std::string>( fileio_params, "Data Input Path" );
     }
 
@@ -112,7 +113,7 @@ namespace RBGen {
     // This file i/o handler is not initialized.
     isInit = true;
   }
-  
+
   Teuchos::RCP<Epetra_MultiVector> BurkardtFileIOHandler::Read( const std::vector<std::string>& filenames )
   {
 
@@ -121,7 +122,7 @@ namespace RBGen {
     if (isInit) {
 
 #ifdef EPETRA_MPI
-      Epetra_MpiComm comm( MPI_COMM_WORLD );
+      Epetra_MpiComm comm( get_global_comm() );
 #else
       Epetra_SerialComm comm;
 #endif
@@ -195,17 +196,17 @@ namespace RBGen {
     }
     else {
       TEUCHOS_TEST_FOR_EXCEPTION(true, std::runtime_error, "File I/O handler is not initialized!");
-    }      
+    }
     // Return.
     return newMV;
   }
-  
+
   void BurkardtFileIOHandler::Write( const Teuchos::RCP<const Epetra_MultiVector>& MV, const std::string& filename )
   {
     if (isInit) {
 
 #ifdef EPETRA_MPI
-      Epetra_MpiComm comm( MPI_COMM_WORLD );
+      Epetra_MpiComm comm( get_global_comm() );
 #else
       Epetra_SerialComm comm;
 #endif
@@ -262,7 +263,7 @@ namespace RBGen {
           for (int j=curr_places; j<num_places; j++) {
             out_file += "0";
           }
- 
+
           // Add the file number.
           out_file += Teuchos::Utils::toString( i );
 
@@ -281,11 +282,11 @@ namespace RBGen {
     }
     else {
       TEUCHOS_TEST_FOR_EXCEPTION(true, std::runtime_error, "File I/O handler is not initialized!");
-    }      
+    }
   }
 
   /* -----------------------------------------------------------------------------
-     GET NUMBER OF NODES IN THE DATA FROM A FORMAT FILE 
+     GET NUMBER OF NODES IN THE DATA FROM A FORMAT FILE
      ----------------------------------------------------------------------------- */
   int BurkardtFileIOHandler::data_size( const std::string filename )
   {
@@ -299,11 +300,11 @@ namespace RBGen {
     }
     //
     // Count how many lines are in the file.
-    // 
+    //
     while( fgets( temp_str, 100, in_file ) != NULL ) { i++; }
 
     fclose(in_file);
-    return( i );  
+    return( i );
   }
 
   /* -----------------------------------------------------------------------------
@@ -333,7 +334,7 @@ namespace RBGen {
         fscanf(in_file, "%lf", x+i);
     }
     fclose(in_file);
-    return( 0 );  
+    return( 0 );
     /* end read_vec */
   }
 
@@ -365,7 +366,7 @@ namespace RBGen {
     }
 
     fclose(out_file);
-    return( 0 );  
+    return( 0 );
     /* end write_vec */
   }
 

--- a/packages/anasazi/epetra/src-rbgen/RBGen_EpetraCrsMatrixFileIOHandler.cpp
+++ b/packages/anasazi/epetra/src-rbgen/RBGen_EpetraCrsMatrixFileIOHandler.cpp
@@ -54,6 +54,7 @@
 
 #ifdef EPETRA_MPI
 #include "Epetra_MpiComm.h"
+#include "AnasaziGlobalComm.hpp"
 #else
 #include "Epetra_SerialComm.h"
 #endif
@@ -61,7 +62,7 @@
 #include "Teuchos_Assert.hpp"
 
 namespace RBGen {
-  
+
   EpetraCrsMatrixFileIOHandler::EpetraCrsMatrixFileIOHandler()
     : isInit(false)
   {
@@ -96,7 +97,7 @@ namespace RBGen {
     if (isInit) {
 
 #ifdef EPETRA_MPI
-      Epetra_MpiComm comm( MPI_COMM_WORLD );
+      Epetra_MpiComm comm( get_global_comm() );
 #else
       Epetra_SerialComm comm;
 #endif
@@ -114,12 +115,12 @@ namespace RBGen {
 
     }
     else {
-      TEUCHOS_TEST_FOR_EXCEPTION(true, std::runtime_error, "File I/O handler is not initialized!"); 
-    }      
+      TEUCHOS_TEST_FOR_EXCEPTION(true, std::runtime_error, "File I/O handler is not initialized!");
+    }
     // Return.
     return newMTX;
   }
-  
+
   void EpetraCrsMatrixFileIOHandler::Write( const Teuchos::RCP<const Epetra_Operator>& MTX, const std::string& filename )
   {
     if (isInit) {
@@ -129,10 +130,10 @@ namespace RBGen {
 
     }
     else {
-      TEUCHOS_TEST_FOR_EXCEPTION(true, std::runtime_error, "File I/O handler is not initialized!"); 
-    }      
+      TEUCHOS_TEST_FOR_EXCEPTION(true, std::runtime_error, "File I/O handler is not initialized!");
+    }
   }
-  
+
 } // namespace RBGen
 
 

--- a/packages/anasazi/epetra/src-rbgen/RBGen_LapackPOD.cpp
+++ b/packages/anasazi/epetra/src-rbgen/RBGen_LapackPOD.cpp
@@ -50,16 +50,17 @@
 
 #ifdef EPETRA_MPI
 #include "Epetra_MpiComm.h"
+#include "AnasaziGlobalComm.hpp"
 #else
 #include "Epetra_SerialComm.h"
 #endif
 
 namespace RBGen {
-  
+
   LapackPOD::LapackPOD() :
     isInitialized_( false ),
     basis_size_( 16 ),
-    comp_time_( 0.0 ) 
+    comp_time_( 0.0 )
   {
   }
 
@@ -84,12 +85,12 @@ namespace RBGen {
   }
 
   void LapackPOD::computeBasis()
-  {    
+  {
 #ifdef EPETRA_MPI
-    Epetra_MpiComm comm( MPI_COMM_WORLD );
+    Epetra_MpiComm comm( get_global_comm() );
 #else
     Epetra_SerialComm comm;
-#endif    
+#endif
     //
     // Variables for Epetra
     //
@@ -138,8 +139,8 @@ namespace RBGen {
 	//
 	timer.ResetStartTime();
 	lapack.GESVD( 'O', 'N', dim, num_vecs, Proc0MV.Values(), Proc0MV.Stride(), &sv_[0], U, 1, Vt, 1, &work[0], &lwork, &info );
-	comp_time_ = timer.ElapsedTime();      
-	if (info != 0) { 
+	comp_time_ = timer.ElapsedTime();
+	if (info != 0) {
 	  // THROW AN EXCEPTION HERE!
 	  std::cout<< "The return value of the SVD is not 0!"<< std::endl;
 	}
@@ -156,7 +157,7 @@ namespace RBGen {
       //
       // Each processor needs to import the information back.
       //
-      Epetra_Import importer( basis_->Map(), Proc0MV_front.Map() );     
+      Epetra_Import importer( basis_->Map(), Proc0MV_front.Map() );
       basis_->Import(Proc0MV_front, importer, Insert);
       //
       // Clean up
@@ -179,16 +180,16 @@ namespace RBGen {
       //
       timer.ResetStartTime();
       lapack.GESVD( 'O', 'N', dim, num_vecs, ss_->Values(), ss_->Stride(), &sv_[0], U, 1, Vt, 1, &work[0], &lwork, &info );
-      comp_time_ = timer.ElapsedTime();      
-      if (info != 0) { 
+      comp_time_ = timer.ElapsedTime();
+      if (info != 0) {
 	// THROW AN EXCEPTION HERE!
 	std::cout<< "The return value of the SVD is not 0!"<< std::endl;
       }
-      sv_.resize( basis_size_ );     
+      sv_.resize( basis_size_ );
       basis_ = Teuchos::rcp( new Epetra_MultiVector( Copy, *ss_, 0, basis_size_ ) );
       //
     }
   }
-  
+
 } // end of RBGen namespace
 

--- a/packages/anasazi/epetra/src-rbgen/RBGen_MatrixMarketFileIOHandler.cpp
+++ b/packages/anasazi/epetra/src-rbgen/RBGen_MatrixMarketFileIOHandler.cpp
@@ -57,13 +57,14 @@
 
 #ifdef EPETRA_MPI
 #include "Epetra_MpiComm.h"
+#include "AnasaziGlobalComm.hpp"
 #else
 #include "Epetra_SerialComm.h"
 #endif
 
 
 namespace RBGen {
-  
+
   MatrixMarketFileIOHandler::MatrixMarketFileIOHandler()
     : num_nodes(0), isInit(false)
     {
@@ -98,7 +99,7 @@ namespace RBGen {
     if (isInit) {
 
 #ifdef EPETRA_MPI
-      Epetra_MpiComm comm( MPI_COMM_WORLD );
+      Epetra_MpiComm comm( get_global_comm() );
 #else
       Epetra_SerialComm comm;
 #endif
@@ -126,7 +127,7 @@ namespace RBGen {
         else {
           // Check to make sure the number of rows is the same.
           TEUCHOS_TEST_FOR_EXCEPTION(rows_i!=rows, std::logic_error, "Error reading file '"+temp_filename+"', does not have same number of rows!");
-        } 
+        }
         // Add the number of columns up.
         num_vecs += cols[i];
 
@@ -138,7 +139,7 @@ namespace RBGen {
       Epetra_Map Map( rows, 0, comm );
       newMV = Teuchos::rcp( new Epetra_MultiVector( Map, num_vecs ) );
 
-      // Create a pointer to a multivector 
+      // Create a pointer to a multivector
       int col_ptr = 0;
       Epetra_MultiVector* fileMV = 0;
 
@@ -153,7 +154,7 @@ namespace RBGen {
         //  Get a view of the multivector columns.
         //
         Epetra_MultiVector subMV( View, *newMV, col_ptr, cols[i] );
-        // 
+        //
         //  Put the multivector read in from the file into this subview.
         //
         subMV.Update( 1.0, *fileMV, 0.0 );
@@ -170,7 +171,7 @@ namespace RBGen {
     }
     else {
       TEUCHOS_TEST_FOR_EXCEPTION(true, std::runtime_error, "File I/O handler is not initialized!");
-    }      
+    }
     // Return.
     return newMV;
   }
@@ -185,7 +186,7 @@ namespace RBGen {
     }
     else {
       TEUCHOS_TEST_FOR_EXCEPTION(true, std::runtime_error, "File I/O handler is not initialized!");
-    }      
+    }
   }
 
 } // namespace RBGen

--- a/packages/anasazi/epetra/src-rbgen/RBGen_NetCDFFileIOHandler.cpp
+++ b/packages/anasazi/epetra/src-rbgen/RBGen_NetCDFFileIOHandler.cpp
@@ -53,6 +53,7 @@
 
 #ifdef EPETRA_MPI
 #include "Epetra_MpiComm.h"
+#include "AnasaziGlobalComm.hpp"
 #else
 #include "Epetra_SerialComm.h"
 #endif
@@ -61,13 +62,13 @@
 #include "Teuchos_ParameterList.hpp"
 
 namespace RBGen {
-  
-  NetCDFFileIOHandler::NetCDFFileIOHandler() 
+
+  NetCDFFileIOHandler::NetCDFFileIOHandler()
     : isInit(false), num_nodes(0), num_nod_var(0), len_string(0), var_name(0)
   {
   }
 
-  NetCDFFileIOHandler::~NetCDFFileIOHandler() 
+  NetCDFFileIOHandler::~NetCDFFileIOHandler()
   {
     for (int i=0; i<num_nod_var; i++)
       delete [] var_name[i];
@@ -76,7 +77,7 @@ namespace RBGen {
 
   void NetCDFFileIOHandler::Initialize( const Teuchos::RCP< Teuchos::ParameterList >& params )
   {
-    
+
     // Save the parameter list.
     params_ = params;
 
@@ -102,7 +103,7 @@ namespace RBGen {
   Teuchos::RCP<Epetra_MultiVector> NetCDFFileIOHandler::Read( const std::vector<std::string>& filenames )
   {
 #ifdef EPETRA_MPI
-    Epetra_MpiComm comm( MPI_COMM_WORLD );
+    Epetra_MpiComm comm( get_global_comm() );
 #else
     Epetra_SerialComm comm;
 #endif
@@ -123,12 +124,12 @@ namespace RBGen {
     }
     catch (std::exception &e) {
       createSSIdx = true;
-    }    
+    }
     */
     //
     // Open all the files and check that the snapshots have the same dimensions.
     //
-    if ( comm.MyPID() == 0 ) {	
+    if ( comm.MyPID() == 0 ) {
       size_t rows0=0, cols0=0, cols_t=0, total_rows=0;
 
       std::string temp_filename = in_path + filenames[0];
@@ -136,14 +137,14 @@ namespace RBGen {
       if (status != NC_NOERR) handle_error(status);
       //
       // If the scaling index vector is needed we can create it here.
-      //	
+      //
       if (createSSIdx) {
 	idx_pair.first = total_rows;
       }
       //
       // Get information on the number of snapshots in the file.
       status = nc_inq_dimid(ncid,"row",&row_id);
-      if (status != NC_NOERR) handle_error(status); 
+      if (status != NC_NOERR) handle_error(status);
       status = nc_inq_dimlen(ncid,row_id, &rows0);
       if (status != NC_NOERR) handle_error(status);
       total_rows += rows0;
@@ -163,40 +164,40 @@ namespace RBGen {
 	if (status != NC_NOERR) handle_error(status);
 	status=nc_inq_dimlen(ncid,len_string_id,&len_string_t);
 	if (status != NC_NOERR) handle_error(status);
-	
+
 	// Get number of nodes.
 	status=nc_inq_dimid(ncid,"num_nodes",&num_nodes_id);
 	if (status != NC_NOERR) handle_error(status);
 	status=nc_inq_dimlen(ncid,num_nodes_id, &num_nodes_t);
 	if (status != NC_NOERR) handle_error(status);
-	
+
 	// Get number of nodal variables.
 	status=nc_inq_dimid(ncid,"num_nod_var",&num_nod_var_id);
 	if (status != NC_NOERR) handle_error(status);
 	status=nc_inq_dimlen(ncid,num_nod_var_id,&num_nod_var_t);
 	if (status != NC_NOERR) handle_error(status);
-	
+
 	len_string = len_string_t;
 	num_nodes = num_nodes_t;
 	num_nod_var = num_nod_var_t;
-	
+
 	// Read in names of nodal variables.
 	status=nc_inq_varid(ncid,"name_nod_var",&name_nod_var_id);
 	if (status != NC_NOERR) handle_error(status);
-	
+
 	var_name = new char*[ num_nod_var ];
 	for (i=0; i<num_nod_var; ++i)
 	  var_name[i] =  new char[ len_string ];
-	
+
 	for (i=0; i<num_nod_var; ++i) {
 	  start2[0]=i;
 	  start2[1]=0;
 	  count2[0]=1;
 	  count2[1]=len_string;
-	  
+
 	  status=nc_get_vara_text(ncid,name_nod_var_id,start2,count2,var_name[i]);
 	  if (status != NC_NOERR) handle_error(status);
-	}	
+	}
 	//
 	// If the scaling index vector is needed we can set the endpoint here.
 	//
@@ -207,7 +208,7 @@ namespace RBGen {
 
 	// Now we are initialized!
 	isInit = true;
-	
+
 	// Output information.
 	std::cout<<"len_string = "<<len_string<<std::endl;
 	std::cout<<"num_nodes = "<<num_nodes<<std::endl;
@@ -217,7 +218,7 @@ namespace RBGen {
 	  std::cout<<var_name[i]<<" ";
 	std::cout<<std::endl;
       }
-      
+
       // Close first file.
       status = nc_close(ncid);
       if (status != NC_NOERR) handle_error(status);
@@ -235,7 +236,7 @@ namespace RBGen {
 	//
 	// Get information on the number of snapshots in the file.
 	status = nc_inq_dimid(ncid,"row",&row_id);
-	if (status != NC_NOERR) handle_error(status); 
+	if (status != NC_NOERR) handle_error(status);
 	status = nc_inq_dimlen(ncid,row_id, &rows_t);
 	if (status != NC_NOERR) handle_error(status);
 	//
@@ -278,7 +279,7 @@ namespace RBGen {
     comm.Broadcast( &num_vars, 1, 0 );
     //
     // Sync all other processors on the scaling index vector if necessary
-    // 
+    //
     if (createSSIdx) {
       for (i=0; i<(int)filenames.size(); i++) {
 	if ( comm.MyPID() != 0 )
@@ -287,10 +288,10 @@ namespace RBGen {
 	comm.Broadcast( &scaling_idx[i].second, 1, 0 );
       }
       // Set the scaling index vector
-      //params_->set("Snapshot Scaling Indices", scaling_idx);   
+      //params_->set("Snapshot Scaling Indices", scaling_idx);
     }
     //
-    // Create maps for new Epetra_MultiVector to hold the snapshots and 
+    // Create maps for new Epetra_MultiVector to hold the snapshots and
     // temporary Epetra_Vector used by processor 0 to import the information.
     //
     Epetra_Map Map( num_vars, 0, comm );
@@ -319,7 +320,7 @@ namespace RBGen {
     // imported into the i-th column of the Epetra_MultiVector.
     //
     // Read starting with row "start2[0]" for "count2[0]" rows, as the columns vary from
-    // "start2[1]" to "count2[1]", i.e. specifically for this case, read starting with row i 
+    // "start2[1]" to "count2[1]", i.e. specifically for this case, read starting with row i
     // for 1 row, as the columns vary from first column to the last column
     //
     start2[1]=0;
@@ -337,19 +338,19 @@ namespace RBGen {
 	//
 	// Get information on the number of snapshots in the file.
 	status = nc_inq_dimid(ncid,"row",&row_id);
-	if (status != NC_NOERR) handle_error(status); 
+	if (status != NC_NOERR) handle_error(status);
 	status = nc_inq_dimlen(ncid,row_id, &rows_t);
-	
+
 	if (status != NC_NOERR) handle_error(status);
 	// Get the pointer for the snapshot matrix
 	status = nc_inq_varid(ncid,"snapshot",&ss_id);
-	if (status != NC_NOERR) handle_error(status); 
+	if (status != NC_NOERR) handle_error(status);
 	//
 	// Convert from size_t to int.
 	rows = rows_t;
       }
       comm.Broadcast( &rows, 1, 0 );
-      
+
       for (j=0; j<rows; j++) {
 	//
 	// Get column of Epetra_MultiVector in terms of Epetra_Vector.
@@ -394,15 +395,15 @@ namespace RBGen {
     if ( index ) delete [] index;
     if ( temp_vec_f ) delete [] temp_vec_f;
     if ( temp_vec_d ) delete [] temp_vec_d;
-    
+
     // Return.
     return newMV;
   }
-  
+
   void NetCDFFileIOHandler::Write( const Teuchos::RCP<const Epetra_MultiVector>& MV, const std::string& filename )
   {
 #ifdef EPETRA_MPI
-    Epetra_MpiComm comm( MPI_COMM_WORLD );
+    Epetra_MpiComm comm( get_global_comm() );
 #else
     Epetra_SerialComm comm;
 #endif
@@ -413,7 +414,7 @@ namespace RBGen {
     int ncid, len_string_id, num_nodes_id, num_nod_var_id, row_id, col_id, ss_id, name_nod_var_id;
     int i,j;
     int ss_dimids[2];
-    
+
     //size_t start[1],count[1];
     size_t start2[2],count2[2];
     //
@@ -438,26 +439,26 @@ namespace RBGen {
     //
     Epetra_Export exporter( MV->Map(), *Proc0Map );
     //
-    if ( comm.MyPID() == 0 ) {	
+    if ( comm.MyPID() == 0 ) {
       //
       // Open basis output file and define output variables going into the file.
       //
       std::string temp_filename = out_path + filename;
       status=nc_create(temp_filename.c_str(),NC_CLOBBER,&ncid);
       if (status != NC_NOERR) handle_error(status);
-      
+
       status=nc_def_dim(ncid,"len_string",(long)len_string,&len_string_id);
       if (status != NC_NOERR) handle_error(status);
-      
+
       status=nc_def_dim(ncid,"num_nodes",(long)num_nodes,&num_nodes_id);
       if (status != NC_NOERR) handle_error(status);
-      
+
       status=nc_def_dim(ncid,"num_nod_var",(long)num_nod_var,&num_nod_var_id);
       if (status != NC_NOERR) handle_error(status);
-      
+
       status=nc_def_dim(ncid,"row",NC_UNLIMITED,&row_id);
       if (status != NC_NOERR) handle_error(status);
-      
+
       status=nc_def_dim(ncid,"col",(long)dim,&col_id);
       if (status != NC_NOERR) handle_error(status);
 
@@ -465,12 +466,12 @@ namespace RBGen {
       ss_dimids[1]=col_id;
       status=nc_def_var(ncid,"snapshot",NC_FLOAT,2,ss_dimids,&ss_id);
       if (status != NC_NOERR) handle_error(status);
-      
+
       ss_dimids[0]=num_nod_var_id;
       ss_dimids[1]=len_string_id;
       status=nc_def_var(ncid,"name_nod_var",NC_CHAR,2,ss_dimids,&name_nod_var_id);
       if (status != NC_NOERR) handle_error(status);
-      
+
       status=nc_enddef(ncid);
       if (status != NC_NOERR) handle_error(status);
 
@@ -499,12 +500,12 @@ namespace RBGen {
 	//
 	for (j=0; j<dim; ++j)
 	  temp_vec[j] = Proc0Vector[j];
-	
+
 	status=nc_put_vara_float(ncid,ss_id,start2,count2,temp_vec);
 	if (status != NC_NOERR) handle_error(status);
       }
-    }     
-    
+    }
+
     // Write the list of names of the nodal variables to the Netcdf file */
     if ( comm.MyPID() == 0 ) {
       for(i=0; i<num_nod_var; ++i) {
@@ -514,11 +515,11 @@ namespace RBGen {
 	count2[1] = strlen(var_name[i]);
 	/*    printf("start2=%d %d\n",start2[0],start2[1]);
 	      printf("count2=%d %d\n",count2[0],count2[1]); */
-	
+
 	status=nc_put_vara_text(ncid,name_nod_var_id,start2,count2,var_name[i]);
 	if (status != NC_NOERR) handle_error(status);
-      } 
-      
+      }
+
       status=nc_close(ncid);
       if (status != NC_NOERR) handle_error(status);
     }
@@ -527,7 +528,7 @@ namespace RBGen {
     delete Proc0Map;
     if (temp_vec) delete [] temp_vec;
   }
-  
+
 } // namespace RBGen
 
 

--- a/packages/anasazi/src/AnasaziBasicOutputManager.hpp
+++ b/packages/anasazi/src/AnasaziBasicOutputManager.hpp
@@ -52,6 +52,7 @@
 
 #ifdef HAVE_MPI
 #include <mpi.h>
+#include "AnasaziGlobalComm.hpp"
 #endif
 
 /*!  \class Anasazi::BasicOutputManager
@@ -70,7 +71,7 @@ namespace Anasazi {
     public:
 
       //! @name Constructors/Destructor
-      //@{ 
+      //@{
 
       //! Default constructor
       BasicOutputManager(int vb = Anasazi::Errors, int rootRank = 0);
@@ -89,7 +90,7 @@ namespace Anasazi {
     private:
 
       //! @name Undefined methods
-      //@{ 
+      //@{
 
       //! Copy constructor.
       BasicOutputManager( const OutputManager<ScalarType>& OM );
@@ -114,8 +115,8 @@ namespace Anasazi {
     MPI_Initialized(&mpiStarted);
     if (mpiStarted)
     {
-      MPI_Comm_rank(MPI_COMM_WORLD, &myRank);
-      MPI_Comm_size(MPI_COMM_WORLD, &numProcs);
+      MPI_Comm_rank(get_global_comm(), &myRank);
+      MPI_Comm_size(get_global_comm(), &numProcs);
     }
     this->fos_->setProcRankAndSize(myRank, numProcs);
     this->fos_->setOutputToRootOnly(rootRank);

--- a/packages/anasazi/src/ModalAnalysisSolvers/AMGOperator.cpp
+++ b/packages/anasazi/src/ModalAnalysisSolvers/AMGOperator.cpp
@@ -99,7 +99,7 @@ AMGOperator::AMGOperator(const Epetra_Comm &_Comm, const Epetra_Operator *KK, in
     if (numDofs == 1)
       ML_Gen_Smoother_SymGaussSeidel(ml_handle, ML_ALL_LEVELS, ML_BOTH, param, ML_DEFAULT);
     else
-      ML_Gen_Smoother_BlockGaussSeidel(ml_handle, ML_ALL_LEVELS, ML_BOTH, param, ML_DEFAULT, 
+      ML_Gen_Smoother_BlockGaussSeidel(ml_handle, ML_ALL_LEVELS, ML_BOTH, param, ML_DEFAULT,
                                        numDofs);
   }
 
@@ -113,7 +113,7 @@ AMGOperator::AMGOperator(const Epetra_Comm &_Comm, const Epetra_Operator *KK, in
       int *blockIndices = new int[size];
       int j;
       for (j = 0; j < size; ++j)
-        blockIndices[j] = j/numDofs; 
+        blockIndices[j] = j/numDofs;
       for (j = 0; j < AMG_NLevels; ++j) {
         size = ml_handle->Amat[j].getrow->Nrows;
         ML_Gen_Smoother_VBlockJacobi(ml_handle, j, ML_BOTH, param, ML_DEFAULT,
@@ -199,7 +199,7 @@ AMGOperator::AMGOperator(const Epetra_Comm &_Comm, const Epetra_Operator *KK, in
       int *blockIndices = new int[size];
       int j;
       for (j = 0; j < size; ++j)
-        blockIndices[j] = j/numDofs; 
+        blockIndices[j] = j/numDofs;
       for (j = 0; j < AMG_NLevels; ++j) {
         size = ml_handle->Amat[j].getrow->Nrows;
         ML_Gen_Smoother_VBlockJacobi(ml_handle, j, ML_BOTH, (param) ? param[j] : 1,
@@ -304,7 +304,7 @@ void AMGOperator::setCoarseSolver_Cycle(int coarseSolver, int cycle) {
         if (verbose < 2)
           options[AZ_output] = AZ_none;
 #ifdef EPETRA_MPI
-        AZ_set_proc_config(proc_config, MPI_COMM_WORLD);
+        AZ_set_proc_config(proc_config, get_global_comm());
 #endif
         params[AZ_tol] = 1.0e-14;
         coarseLocalSize = ml_handle->Amat[AMG_NLevels-1].invec_leng;
@@ -313,7 +313,7 @@ void AMGOperator::setCoarseSolver_Cycle(int coarseSolver, int cycle) {
           cout << "\n --> Total number of coarse grid unknowns = " << coarseGlobalSize << endl;
         // Define the data for the projection
         if (Q) {
-          int zCol = ml_agg->nullspace_dim; 
+          int zCol = ml_agg->nullspace_dim;
           double *ZZ = ml_agg->nullspace_vect;
           ZcoarseTZcoarse = new double[zCol*zCol];
           double *tmp = new double[zCol*zCol];
@@ -329,7 +329,7 @@ void AMGOperator::setCoarseSolver_Cycle(int coarseSolver, int cycle) {
             cerr << endl;
           }
 #ifndef MACOSX
-          singularCoarse::setNullSpace(ml_agg->nullspace_vect, coarseLocalSize, 
+          singularCoarse::setNullSpace(ml_agg->nullspace_vect, coarseLocalSize,
                                        ml_agg->nullspace_dim, ZcoarseTZcoarse, &MyComm);
 #endif
           delete[] tmp;
@@ -340,10 +340,10 @@ void AMGOperator::setCoarseSolver_Cycle(int coarseSolver, int cycle) {
 //        options[AZ_keep_kvecs] = (Q) ? coarseGlobalSize - Q->NumVectors() : coarseGlobalSize;
 //        options[AZ_apply_kvecs] = AZ_APPLY;
 #ifdef MACOSX
-        ML_Gen_SmootherAztec(ml_handle, AMG_NLevels-1, options, params, proc_config, status, 
+        ML_Gen_SmootherAztec(ml_handle, AMG_NLevels-1, options, params, proc_config, status,
                              options[AZ_max_iter], ML_PRESMOOTHER, NULL);
 #else
-        ML_Gen_SmootherAztec(ml_handle, AMG_NLevels-1, options, params, proc_config, status, 
+        ML_Gen_SmootherAztec(ml_handle, AMG_NLevels-1, options, params, proc_config, status,
                              options[AZ_max_iter], ML_PRESMOOTHER,
                              (Q) ?  singularCoarse::projection : NULL);
 #endif
@@ -367,7 +367,7 @@ void AMGOperator::setCoarseSolver_Cycle(int coarseSolver, int cycle) {
 
   //------------------------------------
   // This definition of Prec calls the old class 'Epetra_ML_Operator'
-  //Prec = new Epetra_ML_Operator(ml_handle, MyComm, K->OperatorDomainMap(), 
+  //Prec = new Epetra_ML_Operator(ml_handle, MyComm, K->OperatorDomainMap(),
   //                              K->OperatorDomainMap());
   //------------------------------------
 
@@ -420,12 +420,12 @@ int AMGOperator::ApplyInverse(const Epetra_MultiVector& X, Epetra_MultiVector& Y
   if ((rightProjection == true) && (Q)) {
     int qcol = Q->NumVectors();
     double *work = new double[2*qcol*xcol];
-    memcpy(X2.Values(), X.Values(), xcol*X.MyLength()*sizeof(double)); 
+    memcpy(X2.Values(), X.Values(), xcol*X.MyLength()*sizeof(double));
     callBLAS.GEMM('T', 'N', qcol, xcol, Q->MyLength(), 1.0, Q->Values(), Q->MyLength(),
                   X2.Values(), X2.MyLength(), 0.0, work + qcol*xcol, qcol);
     MyComm.SumAll(work + qcol*xcol, work, qcol*xcol);
     int info = 0;
-    callLAPACK.POTRS('U', qcol, xcol, QtQ, qcol, work, qcol, &info); 
+    callLAPACK.POTRS('U', qcol, xcol, QtQ, qcol, work, qcol, &info);
     callBLAS.GEMM('N', 'N', X2.MyLength(), xcol, qcol, -1.0, Q->Values(), Q->MyLength(),
                   work, qcol, 1.0, X2.Values(), X2.MyLength());
     delete[] work;
@@ -443,7 +443,7 @@ int AMGOperator::ApplyInverse(const Epetra_MultiVector& X, Epetra_MultiVector& Y
                   Y.Values(), Y.MyLength(), 0.0, work + qcol*xcol, qcol);
     MyComm.SumAll(work + qcol*xcol, work, qcol*xcol);
     int info = 0;
-    callLAPACK.POTRS('U', qcol, xcol, QtQ, qcol, work, qcol, &info); 
+    callLAPACK.POTRS('U', qcol, xcol, QtQ, qcol, work, qcol, &info);
     callBLAS.GEMM('N', 'N', Y.MyLength(), xcol, qcol, -1.0, Q->Values(), Q->MyLength(),
                   work, qcol, 1.0, Y.Values(), Y.MyLength());
     delete[] work;


### PR DESCRIPTION
@trilinos/anasazi 

This PR is part of the initiative to phase out the use of `MPI_COMM_WORLD` in Trilinos.