### PR TITLE
STK: Don't use `MPI_COMM_WORLD`

### DIFF
--- a/packages/stk/stk_balance/stk_balance/setup/M2NParser.cpp
+++ b/packages/stk/stk_balance/stk_balance/setup/M2NParser.cpp
@@ -35,6 +35,7 @@
 #include "stk_util/command_line/CommandLineParserUtils.hpp"
 #include "stk_util/util/string_utils.hpp"
 #include "stk_balance/balanceUtils.hpp"
+#include "stk_util/parallel/GlobalComm.hpp"
 
 namespace stk {
 namespace balance {
@@ -131,9 +132,9 @@ void M2NParser::set_logfile(M2NBalanceSettings& settings) const
     settings.set_log_filename(m_commandLineParser.get_option_value<std::string>(m_optionNames.logfile));
   }
   else {
-    const int initialNumProcs = stk::parallel_machine_size(MPI_COMM_WORLD);
+    const int initialNumProcs = stk::parallel_machine_size(get_global_comm());
     const int finalNumProcs = settings.get_num_output_processors();
-    settings.set_log_filename(stk::basename(stk::tailname(settings.get_input_filename())) + "." + std::to_string(initialNumProcs) + "_to_" 
+    settings.set_log_filename(stk::basename(stk::tailname(settings.get_input_filename())) + "." + std::to_string(initialNumProcs) + "_to_"
                                                                                                 + std::to_string(finalNumProcs) + ".log");
   }
 
@@ -144,7 +145,7 @@ void M2NParser::set_use_nested_decomp(M2NBalanceSettings& settings) const
   const bool useNestedDecomp = m_commandLineParser.is_option_provided(m_optionNames.useNestedDecomp);
   settings.set_use_nested_decomp(useNestedDecomp);
   if (useNestedDecomp) {
-    const int initialNumProcs = stk::parallel_machine_size(MPI_COMM_WORLD);
+    const int initialNumProcs = stk::parallel_machine_size(get_global_comm());
     const int finalNumProcs = settings.get_num_output_processors();
     const bool isValidProcCount = (finalNumProcs % initialNumProcs) == 0;
     STK_ThrowRequireMsg(isValidProcCount, "Final number of processors (" << finalNumProcs << ") must be an integer "

--- a/packages/stk/stk_balance/stk_balance/setup/Parser.cpp
+++ b/packages/stk/stk_balance/stk_balance/setup/Parser.cpp
@@ -34,6 +34,7 @@
 #include "Parser.hpp"
 #include "stk_balance/search_tolerance_algs/SecondShortestEdgeFaceSearchTolerance.hpp"
 #include "stk_util/command_line/CommandLineParserUtils.hpp"
+#include "stk_util/parallel/GlobalComm.hpp"
 #include "stk_util/util/string_utils.hpp"
 
 namespace stk {
@@ -413,7 +414,7 @@ void Parser::set_use_nested_decomp(BalanceSettings& settings) const
   settings.set_use_nested_decomp(useNestedDecomp);
 
   if (useNestedDecomp) {
-    const int inputNumProcs = stk::parallel_machine_size(MPI_COMM_WORLD);
+    const int inputNumProcs = stk::parallel_machine_size(get_global_comm());
     const int outputNumProcs = settings.get_num_output_processors();
     const bool isValidProcCount = (outputNumProcs % inputNumProcs) == 0;
     STK_ThrowRequireMsg(isValidProcCount, "Output number of processors (" << outputNumProcs << ") must be an integer "

--- a/packages/stk/stk_mesh/stk_mesh/base/NgpFieldParallel.hpp
+++ b/packages/stk/stk_mesh/stk_mesh/base/NgpFieldParallel.hpp
@@ -38,6 +38,7 @@
 #include "stk_mesh/base/Ngp.hpp"
 #include "stk_mesh/base/NgpField.hpp"
 #include "stk_mesh/base/NgpParallelComm.hpp"
+#include "stk_util/parallel/GlobalComm.hpp"
 #include <vector>
 
 namespace stk {
@@ -297,7 +298,7 @@ void parallel_sum_device_mpi(const stk::mesh::NgpMesh& ngpMesh, const std::vecto
   }
 
   const bool deterministic = false;
-  stk::mesh::ngp_parallel_data_exchange_sym_pack_unpack<double>(MPI_COMM_WORLD,
+  stk::mesh::ngp_parallel_data_exchange_sym_pack_unpack<double>(get_global_comm(),
                                                                 comm_procs,
                                                                 exchangeHandler,
                                                                 deterministic);

--- a/packages/stk/stk_middle_mesh/stk_middle_mesh/parallel_search.hpp
+++ b/packages/stk/stk_middle_mesh/stk_middle_mesh/parallel_search.hpp
@@ -6,15 +6,15 @@
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-// 
+//
 //     * Redistributions of source code must retain the above copyright
 //       notice, this list of conditions and the following disclaimer.
-// 
+//
 //     * Redistributions in binary form must reproduce the above
 //       copyright notice, this list of conditions and the following
 //       disclaimer in the documentation and/or other materials provided
 //       with the distribution.
-// 
+//
 //     * Neither the name of NTESS nor the names of its contributors
 //       may be used to endorse or promote products derived from this
 //       software without specific prior written permission.
@@ -30,7 +30,7 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
+//
 
 #ifndef  STK_MIDDLE_MESH_PARALLEL_SEARCH_HPP
 #define  STK_MIDDLE_MESH_PARALLEL_SEARCH_HPP
@@ -98,7 +98,8 @@ class SearchMesh {
   void fill_bounding_boxes(std::vector<BoundingBox>& boundingBoxes) const
   {
     int proc;
-    MPI_Comm_rank(MPI_COMM_WORLD, &proc);
+    MPI_Comm_rank(m_mesh->get_comm(), &proc);
+
     auto entities = m_mesh->get_elements();
 
     stk::search::Point<double> minCorner, maxCorner;

--- a/packages/stk/stk_middle_mesh_util/stk_middle_mesh_util/stk_interface.hpp
+++ b/packages/stk/stk_middle_mesh_util/stk_middle_mesh_util/stk_interface.hpp
@@ -15,6 +15,7 @@
 #include "stk_mesh/base/MetaData.hpp"
 #include "stk_mesh/base/Selector.hpp"
 #include "stk_topology/topology.hpp"
+#include "stk_util/parallel/GlobalComm.hpp"
 
 #include "stk_middle_mesh/nonconformal_standard.hpp"
 #include "create_stk_mesh.hpp"
@@ -34,7 +35,7 @@ class StkInterface
     explicit StkInterface(const mesh::impl::MeshInput& input)
       : m_input(input)
       , m_stkMeshCreator(input.fnameIn)
-      , m_bulkDataOutPtr(stk::mesh::MeshBuilder(MPI_COMM_WORLD).set_spatial_dimension(3).create())
+      , m_bulkDataOutPtr(stk::mesh::MeshBuilder(get_global_comm()).set_spatial_dimension(3).create())
       , m_metaDataOutPtr(m_bulkDataOutPtr->mesh_meta_data_ptr())
     {
       m_metaDataOutPtr->use_simple_fields();

--- a/packages/stk/stk_tools/stk_tools/mesh_tools/DisconnectBlocks.cpp
+++ b/packages/stk/stk_tools/stk_tools/mesh_tools/DisconnectBlocks.cpp
@@ -39,7 +39,7 @@
 #include "stk_tools/mesh_tools/DetectHingesImpl.hpp"
 #include "stk_tools/mesh_tools/DisconnectBlocksImpl.hpp"
 #include "stk_util/environment/WallTime.hpp"
-
+#include "stk_util/parallel/GlobalComm.hpp"
 namespace stk
 {
 namespace tools
@@ -67,7 +67,7 @@ bool has_nodes_in_part(const stk::mesh::BulkData& bulk, const stk::mesh::Part* p
   unsigned localCount = stk::mesh::count_selected_entities(*part, bulk.buckets(stk::topology::NODE_RANK));
   unsigned globalCount;
 
-  MPI_Allreduce(&localCount, &globalCount, 1, MPI_UNSIGNED, MPI_SUM, MPI_COMM_WORLD);
+  MPI_Allreduce(&localCount, &globalCount, 1, MPI_UNSIGNED, MPI_SUM, get_global_comm());
 
   return (globalCount > 0);
 }

--- a/packages/stk/stk_tools/stk_tools/mesh_tools/DisconnectBlocksImpl.hpp
+++ b/packages/stk/stk_tools/stk_tools/mesh_tools/DisconnectBlocksImpl.hpp
@@ -44,6 +44,7 @@
 #include "stk_tools/mesh_tools/DisconnectTypes.hpp"
 #include "stk_tools/mesh_tools/DisconnectUtils.hpp"
 #include "stk_tools/mesh_tools/ConvexGroup.hpp"
+#include "stk_util/parallel/GlobalComm.hpp"
 #include "stk_util/parallel/ParallelComm.hpp"
 #include <map>
 #include <utility>
@@ -167,7 +168,7 @@ struct LinkInfo
   std::ostream& print_debug_msg(int userDebugLevel, bool prefixMsg = true) {
     if(userDebugLevel <= debugLevel) {
       if(prefixMsg) {
-        os << "P" << stk::parallel_machine_rank(MPI_COMM_WORLD) << ": ";
+        os << "P" << stk::parallel_machine_rank(get_global_comm()) << ": ";
       }
       return os;
     } else {
@@ -176,7 +177,7 @@ struct LinkInfo
   }
 
   std::ostream& print_debug_msg_p0(int userDebugLevel, bool prefixMsg = true) {
-    if(stk::parallel_machine_rank(MPI_COMM_WORLD) == 0) {
+    if(stk::parallel_machine_rank(get_global_comm()) == 0) {
       return print_debug_msg(userDebugLevel, prefixMsg);
     }
     return ns;

--- a/packages/stk/stk_tools/stk_tools/pmesh_lib/makeparfiles.cpp
+++ b/packages/stk/stk_tools/stk_tools/pmesh_lib/makeparfiles.cpp
@@ -9,10 +9,11 @@
 #include <stdlib.h>       // for exit
 #include <cstring>        // for strcpy
 #include <iostream>       // for operator<<, basic_ostream, char_traits, cerr
+#include "stk_util/parallel/GlobalComm.hpp"
 // clang-format on
 // #######################   End Clang Header Tool Managed Headers  ########################
 
-namespace stk_tools 
+namespace stk_tools
 {
 
 void SetFileName(char fn[], int total_subdomains, int i, const char* rootdir);
@@ -67,7 +68,7 @@ int getCubeId(int &x_c, int &y_c, int &z_c, const int& n_x, const int& n_y, cons
 
 // This function uses the following information to create a partitioned input file
 // cube.par.${num_procs}.${file_id}
-// 
+//
 // my_proc_id: This processor's id
 // num_procs:  Total number of processors being used to create files
 // ncuts_x:    Number of cuts to make in the x-direction of the cube
@@ -489,7 +490,7 @@ int GetNumDigits(int n)
 }
 
 
-void SetFileName(char dirloc[], int total_subdomains, int i, 
+void SetFileName(char dirloc[], int total_subdomains, int i,
                  const char* rootdir)
 // The following is some ugly code to arrive at the full path and name for
 // each subdomain cube. If root = /ufs/tmp and nsubdomains is 8, then
@@ -524,7 +525,7 @@ void SetFileName(char dirloc[], int total_subdomains, int i,
     break;
   default:
     std::cerr << "no more than 6 digits are supported " << std::endl;
-    MPI_Abort(MPI_COMM_WORLD, digit);
+    MPI_Abort(stk::get_global_comm(), digit);
     exit(-1);
   }
 
@@ -551,7 +552,7 @@ int OpenExoFile(char filename[300] )
   {
     int ierr=0;
     std::cerr << "\nCould not create file " << filename << "\n. Aborting.\n\n";
-    MPI_Abort(MPI_COMM_WORLD, ierr);
+    MPI_Abort(stk::get_global_comm(), ierr);
     exit(-1);
   }
   return exoid;
@@ -998,4 +999,4 @@ void WriteNodesets(int xc, int exoid, int num_nodes_in_set,
 }
 
 
-} // end namespace 
+} // end namespace

--- a/packages/stk/stk_util/stk_util/parallel/CouplingVersions.cpp
+++ b/packages/stk/stk_util/stk_util/parallel/CouplingVersions.cpp
@@ -1,6 +1,7 @@
 #include "stk_util/parallel/CouplingVersions.hpp"
 #include "stk_util/parallel/CouplingVersions_impl.hpp"
 
+#include "GlobalComm.hpp"
 #include "stk_util/stk_config.h"
 #include <stdexcept>
 #include <map>
@@ -27,7 +28,7 @@ void MPI_Op_MaxMinReduction(void* invec, void* inoutvec, int* len, MPI_Datatype*
 std::pair<int, int> allreduce_minmax(MPI_Comm comm, int localVersion)
 {
   // for compatibility with the ParallelReduce code, the buffer has to be
-  // large enough for 3 ints (empty struct + padding + 2 ints), even though 
+  // large enough for 3 ints (empty struct + padding + 2 ints), even though
   // only the ints are used
   constexpr int bufSize = 3;
   std::array<int, bufSize> inbuf{-1, localVersion, localVersion}, outbuf;
@@ -64,7 +65,7 @@ class StkCompatibleVersion
 
     void set_version_for_testing(unsigned int version)
     {
-      set_version_impl(MPI_COMM_WORLD, version);
+      set_version_impl(get_global_comm(), version);
     }
 
     void set_version(MPI_Comm comm)
@@ -108,7 +109,7 @@ class StkCompatibleVersion
       if (m_isVersionSet && (m_errorOnResetVersion && requestedVersion != oldVersion)) {
         int myRank;
         MPI_Comm_rank(comm, &myRank);
-        if (myRank) { 
+        if (myRank) {
           std::cerr << "STK version compatibility has already been set, and cannot be changed" << std::endl;
         }
 
@@ -128,7 +129,7 @@ class StkCompatibleVersion
 
     std::string get_version_error_string(int requestedVersion)
     {
-      return std::string("Requested version is not compatible with this version of STK.  Requested version: ") + 
+      return std::string("Requested version is not compatible with this version of STK.  Requested version: ") +
              std::to_string(requestedVersion) + ", minimum supported version " + std::to_string(STK_MIN_COUPLING_VERSION) +
              ", maximum supported version " + std::to_string(STK_MAX_COUPLING_VERSION);
     }
@@ -231,7 +232,7 @@ bool is_local_stk_coupling_deprecated()
 
 
 void print_unsupported_version_warning(int version, int line, const char* file)
-{                                                                                      
+{
   if ( STK_MIN_COUPLING_VERSION > version ) {
     std::cerr  << "The function at line " << line << " of file " << file
                << " can be simplified now that STK_MIN_COUPLING_VERSION is greater than "

--- a/packages/stk/stk_util/stk_util/parallel/GlobalComm.hpp
+++ b/packages/stk/stk_util/stk_util/parallel/GlobalComm.hpp
@@ -1,0 +1,34 @@
+#ifndef STK_UTIL_GLOBAL_COMM_hpp
+#define STK_UTIL_GLOBAL_COMM_hpp
+
+#include <mutex>
+
+#ifdef HAVE_MPI
+
+#include <mpi.h>
+
+#else  // HAVE_MPI
+#define MPI_Comm int
+#define MPI_COMM_WORLD 0
+#endif // HAVE_MPI
+
+namespace stk {
+
+static std::mutex mpi_mutex;
+static MPI_Comm Global_STK_Comm = MPI_COMM_WORLD;
+
+inline void initialize_global_comm(MPI_Comm comm)
+{
+  std::lock_guard<std::mutex> guard(mpi_mutex);
+  Global_STK_Comm = comm;
+}
+
+inline MPI_Comm get_global_comm()
+{
+  std::lock_guard<std::mutex> guard(mpi_mutex);
+  return Global_STK_Comm;
+}
+
+}  // namespace stk
+
+#endif  // STK_UTIL_GLOBAL_COMM_hpp

--- a/packages/stk/stk_util/stk_util/parallel/MPICommKey.cpp
+++ b/packages/stk/stk_util/stk_util/parallel/MPICommKey.cpp
@@ -3,6 +3,7 @@
 #include <limits>
 #include "stk_util/parallel/MPICommKey.hpp"
 #include "ParallelComm.hpp"
+#include "GlobalComm.hpp"
 
 namespace stk {
 
@@ -44,7 +45,7 @@ MPIKeyManager::MPIKeyManager() : m_destructor([this]() { destructor(); })
   MPI_Comm_create_keyval(MPI_COMM_NULL_COPY_FN, &impl::delete_mpi_comm_key, &m_mpiAttrKey, this);
 
   int myRank;
-  MPI_Comm_rank(MPI_COMM_WORLD, &myRank);
+  MPI_Comm_rank(get_global_comm(), &myRank);
   m_currentCommKey = myRank;
 }
 

--- a/packages/stk/stk_util/stk_util/parallel/Parallel.hpp
+++ b/packages/stk/stk_util/stk_util/parallel/Parallel.hpp
@@ -6,15 +6,15 @@
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-// 
+//
 //     * Redistributions of source code must retain the above copyright
 //       notice, this list of conditions and the following disclaimer.
-// 
+//
 //     * Redistributions in binary form must reproduce the above
 //       copyright notice, this list of conditions and the following
 //       disclaimer in the documentation and/or other materials provided
 //       with the distribution.
-// 
+//
 //     * Neither the name of NTESS nor the names of its contributors
 //       may be used to endorse or promote products derived from this
 //       software without specific prior written permission.
@@ -30,7 +30,7 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
+//
 
 #ifndef stk_util_parallel_Parallel_hpp
 #define stk_util_parallel_Parallel_hpp


### PR DESCRIPTION
@trilinos/stk

This PR is part of the initiative to phase out the use of `MPI_COMM_WORLD` in Trilinos.