### PR TITLE
NOX: Remove use of hardcoded MPI_COMM_WORLD from NOX package

### DIFF
--- a/packages/nox/src/CMakeLists.txt
+++ b/packages/nox/src/CMakeLists.txt
@@ -189,6 +189,7 @@ APPEND_SET(HEADERS
   NOX_Observer_Log.hpp
   NOX_Observer_Print.hpp
   NOX_Assert.H
+  NOX_GlobalComm.H
   )
 APPEND_SET(SOURCES
   NOX_Utils.C

--- a/packages/nox/src/NOX_Description.H
+++ b/packages/nox/src/NOX_Description.H
@@ -1984,7 +1984,7 @@ int main(int argc, char *argv[])
 
   // Create a communicator for Epetra objects
 #ifdef HAVE_MPI
-  Epetra_MpiComm Comm( MPI_COMM_WORLD );
+  Epetra_MpiComm Comm( NOX::get_global_comm() );
 #else
   Epetra_SerialComm Comm;
 #endif

--- a/packages/nox/src/NOX_GlobalComm.H
+++ b/packages/nox/src/NOX_GlobalComm.H
@@ -1,0 +1,77 @@
+// $Id$
+// $Source$
+
+//@HEADER
+// ************************************************************************
+//
+//            NOX: An Object-Oriented Nonlinear Solver Package
+//                 Copyright (2002) Sandia Corporation
+//
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Roger Pawlowski (rppawlo@sandia.gov) or
+// Eric Phipps (etphipp@sandia.gov), Sandia National Laboratories.
+// ************************************************************************
+//  CVS Information
+//  $Source$
+//  $Author$
+//  $Date$
+//  $Revision$
+// ************************************************************************
+//@HEADER
+
+#ifndef NOX_GLOBAL_COMM_H
+#define NOX_GLOBAL_COMM_H
+
+#ifdef HAVE_MPI
+
+#include <mpi.h>
+#include <mutex>
+
+namespace NOX {
+
+static std::mutex mpi_mutex;
+static MPI_Comm Global_MPI_Comm = MPI_COMM_WORLD;
+
+inline void initialize_global_comm(MPI_Comm comm) {
+    std::lock_guard<std::mutex> guard(mpi_mutex);
+    Global_MPI_Comm = comm;
+}
+
+inline MPI_Comm get_global_comm() {
+    std::lock_guard<std::mutex> guard(mpi_mutex);
+    return Global_MPI_Comm;
+}
+
+}
+
+#endif /* HAVE_MPI */
+#endif /* NOX_GLOBAL_COMM_H */

--- a/packages/nox/src/NOX_Utils.C
+++ b/packages/nox/src/NOX_Utils.C
@@ -54,6 +54,7 @@
 
 #ifdef HAVE_MPI
 #include <mpi.h>
+#include <NOX_GlobalComm.H>
 #endif
 
 NOX::Utils::Utils(int outputInformation, int MyPID, int outputProcess,
@@ -160,7 +161,7 @@ void NOX::Utils::reset(Teuchos::ParameterList& p)
     MPI_Initialized(&mpiIsRunning);
     if (mpiIsRunning)
       {
-        MPI_Comm_rank(MPI_COMM_WORLD, &myPID);
+        MPI_Comm_rank(NOX::get_global_comm(), &myPID);
       }
     else
       {


### PR DESCRIPTION
@trilinos/nox

Introduce `Global_MPI_Comm` global variable that defaults to `MPI_COMM_WORLD` and use it instead of the hardcoded `MPI_COMM_WORLD`. This PR includes also method which allows for the change of the global communicator. 

This PR is a part of the initiative to phase out the use of `MPI_COMM_WOLRD` in Trilinos.

