### PR TITLE
Tpetra: Making the MV random pool static

### DIFF
--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -2697,7 +2697,7 @@ void MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::copyAndPermute(
     uint64_t seed64 = static_cast<uint64_t> (std::rand ()) + myRank + 17311uLL;
     unsigned int seed = static_cast<unsigned int> (seed64&0xffffffff);
 
-    pool_type rand_pool (seed);
+    static pool_type rand_pool (seed);
     const IST max = static_cast<IST> (maxVal);
     const IST min = static_cast<IST> (minVal);
 


### PR DESCRIPTION
Issue: #12106 
Tests: Should already be exercised.
Stakeholder feedback: n/a

Every time MV::randomize() gets called, it initializes a Kokkos::Random_XorShift64_Pool object, which involves some pretty beefy H2D transfers.  We'll try to make that static so it only happens on the first call and subsequent calls just advance the state.

Right now, each Chebyshev setup (at each level) in MueLu triggers the pool initialization. 

