### PR TITLE
Stokhos: update for new KokkosSparse::spmv overloads

### DIFF
--- a/packages/stokhos/src/sacado/kokkos/pce/linalg/Kokkos_CrsMatrix_UQ_PCE.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/linalg/Kokkos_CrsMatrix_UQ_PCE.hpp
@@ -1619,6 +1619,53 @@ spmv(
   spmv(mode, a, A, x, b, y, RANK_TWO());
 }
 
+template <typename AlphaType,
+          typename BetaType,
+          typename MatrixType,
+          typename InputType,
+          typename ... InputP,
+          typename OutputType,
+          typename ... OutputP>
+std::enable_if_t<
+  Kokkos::is_view_uq_pce< Kokkos::View< InputType, InputP... > >::value &&
+  Kokkos::is_view_uq_pce< Kokkos::View< OutputType, OutputP... > >::value &&
+  KokkosSparse::is_crs_matrix<MatrixType>::value>
+spmv(
+  KokkosKernels::Experimental::Controls controls,
+  const char mode[],
+  const AlphaType& a,
+  const MatrixType& A,
+  const Kokkos::View< InputType, InputP... >& x,
+  const BetaType& b,
+  const Kokkos::View< OutputType, OutputP... >& y)
+{
+  using RANK_SPECIALISE = std::conditional_t<std::decay_t<decltype(x)>::rank == 2, RANK_TWO, RANK_ONE>;
+  spmv(controls, mode, a, A, x, b, y, RANK_SPECIALISE());
+}
+
+template <typename AlphaType,
+          typename BetaType,
+          typename MatrixType,
+          typename InputType,
+          typename ... InputP,
+          typename OutputType,
+          typename ... OutputP>
+std::enable_if_t<
+  Kokkos::is_view_uq_pce< Kokkos::View< InputType, InputP... > >::value &&
+  Kokkos::is_view_uq_pce< Kokkos::View< OutputType, OutputP... > >::value &&
+  KokkosSparse::is_crs_matrix<MatrixType>::value>
+spmv(
+  const char mode[],
+  const AlphaType& a,
+  const MatrixType& A,
+  const Kokkos::View< InputType, InputP... >& x,
+  const BetaType& b,
+  const Kokkos::View< OutputType, OutputP... >& y)
+{
+  using RANK_SPECIALISE = std::conditional_t<std::decay_t<decltype(x)>::rank == 2, RANK_TWO, RANK_ONE>;
+  spmv(mode, a, A, x, b, y, RANK_SPECIALISE());
+}
+
 }
 
 #endif /* #ifndef KOKKOS_CRSMATRIX_UQ_PCE_HPP */

--- a/packages/stokhos/src/sacado/kokkos/vector/linalg/Kokkos_CrsMatrix_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/linalg/Kokkos_CrsMatrix_MP_Vector.hpp
@@ -749,6 +749,53 @@ spmv(
   spmv(mode, a, A, x, b, y, RANK_TWO());
 }
 
+template <typename AlphaType,
+          typename BetaType,
+          typename MatrixType,
+          typename InputType,
+          typename ... InputP,
+          typename OutputType,
+          typename ... OutputP>
+std::enable_if_t<
+  Kokkos::is_view_mp_vector< Kokkos::View< InputType, InputP... > >::value &&
+  Kokkos::is_view_mp_vector< Kokkos::View< OutputType, OutputP... > >::value && 
+  KokkosSparse::is_crs_matrix<MatrixType>::value>
+spmv(
+  KokkosKernels::Experimental::Controls controls,
+  const char mode[],
+  const AlphaType& a,
+  const MatrixType& A,
+  const Kokkos::View< InputType, InputP... >& x,
+  const BetaType& b,
+  const Kokkos::View< OutputType, OutputP... >& y)
+{
+  using RANK_SPECIALISE = std::conditional_t<std::decay_t<decltype(x)>::rank == 2, RANK_TWO, RANK_ONE>;
+  spmv(controls, mode, a, A, x, b, y, RANK_SPECIALISE());
+}
+
+template <typename AlphaType,
+          typename BetaType,
+          typename MatrixType,
+          typename InputType,
+          typename ... InputP,
+          typename OutputType,
+          typename ... OutputP>
+std::enable_if_t<
+  Kokkos::is_view_mp_vector< Kokkos::View< InputType, InputP... > >::value &&
+  Kokkos::is_view_mp_vector< Kokkos::View< OutputType, OutputP... > >::value && 
+  KokkosSparse::is_crs_matrix<MatrixType>::value>
+spmv(
+  const char mode[],
+  const AlphaType& a,
+  const MatrixType& A,
+  const Kokkos::View< InputType, InputP... >& x,
+  const BetaType& b,
+  const Kokkos::View< OutputType, OutputP... >& y)
+{
+  using RANK_SPECIALISE = std::conditional_t<std::decay_t<decltype(x)>::rank == 2, RANK_TWO, RANK_ONE>;
+  spmv(mode, a, A, x, b, y, RANK_SPECIALISE());
+}
+
 }
 
 #endif /* #ifndef KOKKOS_CRSMATRIX_MP_VECTOR_HPP */


### PR DESCRIPTION
KokkosKernels 4.2 will add some new overloads for spmv that accept execution space instances. The Stokhos specializations for spmv, where Scalar is PCE or MPVector, won't have those yet. So make sure that the existing Stokhos specializations still work by calling a Stokhos implementation (and not a KokkosKernels implementation).

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/stokhos 
@trilinos/kokkos-kernels 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Prevent crashes and possible build errors when the future KokkosKernels 4.2 release is being tested.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:
-->
## Related Issues

* Closes https://github.com/kokkos/kokkos-kernels/issues/1959
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 

## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
The spmv specializations are tested in ``Stokhos_KokkosCrsMatrixUQPCEUnitTest`` and ``Stokhos_KokkosCrsMatrixMPVectorUnitTest``.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->