### PR TITLE
EpetraExt: Remove use of hardcoded MPI_COMM_WORLD

### DIFF
--- a/packages/epetraext/src/inout/EpetraExt_HDF5.cpp
+++ b/packages/epetraext/src/inout/EpetraExt_HDF5.cpp
@@ -379,7 +379,7 @@ void EpetraExt::HDF5::Open(const std::string FileName, int AccessType)
   const Epetra_MpiComm* MpiComm ( dynamic_cast<const Epetra_MpiComm*> (&Comm_) );
 
   if (MpiComm == 0)
-    H5Pset_fapl_mpio(plist_id_, MPI_COMM_WORLD, MPI_INFO_NULL);
+    H5Pset_fapl_mpio(plist_id_, MPI_COMM_WORLD, MPI_INFO_NULL); // CHECK: ALLOW MPI_COMM_WORLD
   else
     H5Pset_fapl_mpio(plist_id_, MpiComm->Comm(), MPI_INFO_NULL);
 #endif


### PR DESCRIPTION
@trilinos/epetraext

Introduce `Global_MPI_Comm` global variable that defaults to `MPI_COMM_WORLD` and use it instead of the hardcoded `MPI_COMM_WORLD`. This PR includes also method which allows for the change of the global communicator.

This PR is a part of the initiative to phase out the use of `MPI_COMM_WOLRD` in Trilinos.