### PR TITLE
Ifpack: Remove use of hardcoded MPI_COMM_WORLD

### DIFF
--- a/packages/ifpack/src/euclid/guards_dh.h
+++ b/packages/ifpack/src/euclid/guards_dh.h
@@ -52,7 +52,7 @@
 
 #define  INITIALIZE_DH(argc, argv, help) \
             MPI_Init(&argc,&argv);  \
-            comm_dh = MPI_COMM_WORLD;    \
+            comm_dh = MPI_COMM_WORLD; /* CHECK: ALLOW MPI_COMM_WORLD */ \
             MPI_Errhandler_set(comm_dh, MPI_ERRORS_RETURN); \
             EuclidInitialize(argc, argv, help); \
             dh_StartFunc(__FUNC__, __FILE__, __LINE__, 1); \

--- a/packages/ifpack/src/euclid/mat_dh_private.c
+++ b/packages/ifpack/src/euclid/mat_dh_private.c
@@ -1166,7 +1166,7 @@ partition_and_distribute_metis_private (Mat_dh A, Mat_dh * Bout)
   /* broadcast number of rows to all processors */
   if (myid_dh == 0)
     m = A->m;
-  MPI_Bcast (&m, 1, MPI_INT, 0, MPI_COMM_WORLD);
+  MPI_Bcast (&m, 1, MPI_INT, 0, MPI_COMM_WORLD); // CHECK: ALLOW MPI_COMM_WORLD
 
   /* broadcast number of nonzeros in each row to all processors */
   rowLengths = (int *) MALLOC_DH (m * sizeof (int));
@@ -1359,7 +1359,7 @@ partition_and_distribute_private (Mat_dh A, Mat_dh * Bout)
   /* broadcast number of rows to all processors */
   if (myid_dh == 0)
     m = A->m;
-  MPI_Bcast (&m, 1, MPI_INT, 0, MPI_COMM_WORLD);
+  MPI_Bcast (&m, 1, MPI_INT, 0, MPI_COMM_WORLD); // CHECK: ALLOW MPI_COMM_WORLD
 
   /* broadcast number of nonzeros in each row to all processors */
   rowLengths = (int *) MALLOC_DH (m * sizeof (int));


### PR DESCRIPTION
@trilinos/ifpack

~~Introduce `Global_MPI_Comm` global variable that defaults to `MPI_COMM_WORLD` and use it instead of the hardcoded `MPI_COMM_WORLD`. This PR includes also method which allows for the change of the global communicator.~~

This PR is a part of the initiative to phase out the use of `MPI_COMM_WOLRD` in Trilinos.

See comments:
- https://github.com/trilinos/Trilinos/pull/12193#discussion_r1339098111
- https://github.com/trilinos/Trilinos/pull/12193#discussion_r1339162430