### PR TITLE
Zoltan: Remove use of hardcoded MPI_COMM_WORLD

### DIFF
--- a/packages/zoltan/README.developer
+++ b/packages/zoltan/README.developer
@@ -69,7 +69,7 @@ printf("GID: " ZOLTAN_ID_SPEC ", LID %d\n", my_gid, my_lid);
 
 To send a ZOLTAN_ID_TYPE in an MPI message, use ZOLTAN_ID_MPI_TYPE:
 
-MPI_Bcast(&gid, 1, ZOLTAN_ID_MPI_TYPE, 0, MPI_COMM_WORLD);
+MPI_Bcast(&gid, 1, ZOLTAN_ID_MPI_TYPE, 0, zoltan_get_global_comm());
 
 To silence compiler warnings, you can properly specify a constant of type ZOLTAN_ID_TYPE using ZOLTAN_ID_CONSTANT:
 

--- a/packages/zoltan/src/CMakeLists.txt
+++ b/packages/zoltan/src/CMakeLists.txt
@@ -482,6 +482,7 @@ APPEND_SET(SOURCES
   Utilities/Communication/comm_do_reverse.c
   Utilities/Communication/comm_info.c
   Utilities/Communication/comm_create.c
+  Utilities/Communication/comm_default.c
   Utilities/Communication/comm_resize.c
   Utilities/Communication/comm_sort_ints.c
   Utilities/Communication/comm_destroy.c

--- a/packages/zoltan/src/Utilities/Communication/comm_default.c
+++ b/packages/zoltan/src/Utilities/Communication/comm_default.c
@@ -44,84 +44,30 @@
  * @HEADER
  */
 
-
-#include "dr_const.h"
-#include "dr_util_const.h"
-#include "dr_err_const.h"
-#include "dr_dd.h"
+#include "comm.h"
+#include <pthread.h>
 
 #ifdef __cplusplus
 /* if C++, define the rest of this header file as extern C */
 extern "C" {
 #endif
 
+static pthread_mutex_t zoltan_global_mpi_lock;
+static MPI_Comm Zoltan_Global_MPI_Comm = MPI_COMM_WORLD; // CHECK: ALLOW MPI_COMM_WORLD
 
-/****************************************************************************/
-int build_elem_dd(MESH_INFO_PTR mesh) 
-{
-/* Create a distributed directory of the elements so we can track their
- * processor assignment after migrations.
- */
-int maxelems;
-
-  MPI_Allreduce(&(mesh->num_elems), &maxelems, 1, MPI_INT, MPI_MAX,
-                zoltan_get_global_comm());
-  if (Zoltan_DD_Create(&(mesh->dd), zoltan_get_global_comm(), 1, 0, 0, maxelems, 0) != 0){
-    Gen_Error(0, "fatal:  NULL returned from Zoltan_DD_Create()\n");
-    return 0;
-  }
-
-  return update_elem_dd(mesh);
+/* Function to set the default communicator */
+inline void zoltan_initialize_global_comm(MPI_Comm comm) {
+  pthread_mutex_lock(&zoltan_global_mpi_lock);
+  Zoltan_Global_MPI_Comm = comm;
+  pthread_mutex_unlock(&zoltan_global_mpi_lock);
 }
 
-/****************************************************************************/
-int update_elem_dd(MESH_INFO_PTR mesh)
-{
-/*  Update a distributed directory of the elements with processor
- *  assignments initially and after migration.
- */
-ELEM_INFO_PTR current_elem;
-ZOLTAN_ID_PTR gids; 
-int *parts;
-int i, j;
-
-  gids = (ZOLTAN_ID_PTR) malloc(mesh->num_elems * sizeof(ZOLTAN_ID_TYPE));
-  parts = (int *) malloc(mesh->num_elems * sizeof(int));
-
-  for (j = 0, i = 0; i < mesh->elem_array_len; i++) {
-    current_elem = &(mesh->elements[i]);
-    if (current_elem->globalID != ZOLTAN_ID_INVALID) {
-      gids[j] = (ZOLTAN_ID_TYPE)current_elem->globalID;
-      parts[j] = current_elem->my_part;
-      j++;
-    }
-  }
-
-  if (Zoltan_DD_Update(mesh->dd, gids, NULL,NULL, parts, mesh->num_elems)!=0) {
-    Gen_Error(0, "fatal:  NULL returned from Zoltan_DD_Update()\n");
-    return 0;
-  }
-
-  safe_free((void **)(void *) &gids);
-  safe_free((void **)(void *) &parts);
-  return 1;
-}
-
-
-/****************************************************************************/
-int update_hvertex_proc(MESH_INFO_PTR mesh)
-{
-  int npins;
-
-  npins = mesh->hindex[mesh->nhedges];  
-
-  if (Zoltan_DD_Find(mesh->dd, mesh->hvertex, NULL, NULL, NULL, npins, mesh->hvertex_proc) != 0) {
-
-    Gen_Error(0, "fatal:  NULL returned from Zoltan_DD_Find()\n");
-    return 0;
-  }
-
-  return 1;
+/* Function to get the default communicator */
+inline MPI_Comm zoltan_get_global_comm() {
+  pthread_mutex_lock(&zoltan_global_mpi_lock);
+  MPI_Comm comm = Zoltan_Global_MPI_Comm;
+  pthread_mutex_unlock(&zoltan_global_mpi_lock);
+  return comm;
 }
 
 #ifdef __cplusplus

--- a/packages/zoltan/src/Utilities/Communication/comm_do.c
+++ b/packages/zoltan/src/Utilities/Communication/comm_do.c
@@ -145,7 +145,7 @@ char *recv_data)		/* array of data I'll own after comm */
 
     /* Check input parameters */
     if (!plan) {
-        MPI_Comm_rank(MPI_COMM_WORLD, &my_proc);
+        MPI_Comm_rank(zoltan_get_global_comm(), &my_proc);
 	ZOLTAN_COMM_ERROR("Communication plan = NULL", yo, my_proc);
 	return ZOLTAN_FATAL;
     }

--- a/packages/zoltan/src/Utilities/Communication/comm_info.c
+++ b/packages/zoltan/src/Utilities/Communication/comm_info.c
@@ -90,7 +90,7 @@ int i, j, k, my_proc;
 
   /* Check input parameters */
   if (!plan) {
-    MPI_Comm_rank(MPI_COMM_WORLD, &my_proc);
+    MPI_Comm_rank(zoltan_get_global_comm(), &my_proc);
     ZOLTAN_COMM_ERROR("Communication plan = NULL", yo, my_proc);
     return ZOLTAN_FATAL;
   }

--- a/packages/zoltan/src/Utilities/Memory/mem.c
+++ b/packages/zoltan/src/Utilities/Memory/mem.c
@@ -79,8 +79,8 @@ static int nfree = 0;           /* number of calls to free */
 #ifdef ZOLTAN_NO_MPI
 #define GET_RANK(a) *(a)=0
 #else
-#include <mpi.h>
-#define GET_RANK(a) MPI_Comm_rank(MPI_COMM_WORLD, (a))
+#include <zoltan_comm.h>
+#define GET_RANK(a) MPI_Comm_rank(zoltan_get_global_comm(), (a))
 #endif
 
 #define MAX_STRING_LEN 50

--- a/packages/zoltan/src/Utilities/Timer/zoltan_timer.c
+++ b/packages/zoltan/src/Utilities/Timer/zoltan_timer.c
@@ -49,6 +49,7 @@
 #include "zoltan_types.h"
 #include "zoltan_util.h"
 #include "zoltan_mem.h"
+#include "zoltan_comm.h"
 
 #ifdef VAMPIR
 #include <VT.h>
@@ -88,7 +89,7 @@ extern "C" {
 #define FATALERROR(yo, str) \
   { \
     int ppproc; \
-    MPI_Comm_rank(MPI_COMM_WORLD, &ppproc); \
+    MPI_Comm_rank(zoltan_get_global_comm(), &ppproc); \
     ZOLTAN_PRINT_ERROR(ppproc, yo, str); \
     return ZOLTAN_FATAL; \
   }

--- a/packages/zoltan/src/ch/ch_init_dist.c
+++ b/packages/zoltan/src/ch/ch_init_dist.c
@@ -133,7 +133,7 @@ int max_assignment, have_assignments;
   /* Broadcast initial assignments if they exist.  
    * Assignments can be used for partitions and/or processors.
    */
-  MPI_Comm_rank(MPI_COMM_WORLD, &proc);
+  MPI_Comm_rank(zoltan_get_global_comm(), &proc);
 
   /* First, tell other processors whether the assignments array is NULL. */
   if (proc == host_proc) 

--- a/packages/zoltan/src/driver/dr_chaco_io.c
+++ b/packages/zoltan/src/driver/dr_chaco_io.c
@@ -118,7 +118,7 @@ int read_chaco_file(int Proc,
     file_error = (fp == NULL);
   }
 
-  MPI_Bcast(&file_error, 1, MPI_INT, 0, MPI_COMM_WORLD);
+  MPI_Bcast(&file_error, 1, MPI_INT, 0, zoltan_get_global_comm());
 
   if (file_error) {
     sprintf(cmesg, "fatal:  Could not open Chaco graph file %s",
@@ -236,14 +236,14 @@ for (i=0; i<nvtxs; i++) { /* move 2/3 of points much closer to "a" */
 
   /* Distribute graph */
 
-  if (!chaco_dist_graph(MPI_COMM_WORLD, pio_info, 0, &gnvtxs, &nvtxs, 
+  if (!chaco_dist_graph(zoltan_get_global_comm(), pio_info, 0, &gnvtxs, &nvtxs, 
              &start, &adj, &vwgt_dim, &vwgts, &ewgt_dim, &ewgts, 
              &ndim, &x, &y, &z, &assignments)) {
     Gen_Error(0, "fatal: Error returned from chaco_dist_graph");
     return 0;
   }
 
-  MPI_Bcast(&base, 1, MPI_INT, 0, MPI_COMM_WORLD);
+  MPI_Bcast(&base, 1, MPI_INT, 0, zoltan_get_global_comm());
 
   if (!chaco_setup_mesh_struct(Proc, Num_Proc, prob, mesh, pio_info, gnvtxs, nvtxs,
                      start, adj, vwgt_dim, vwgts, ewgt_dim, ewgts, 
@@ -341,7 +341,7 @@ int i;
    * Each element has one set of coordinates (i.e., node) if a coords file
    * was provided; zero otherwise. 
    */
-  MPI_Bcast( &no_geom, 1, MPI_INT, 0, MPI_COMM_WORLD);
+  MPI_Bcast( &no_geom, 1, MPI_INT, 0, zoltan_get_global_comm());
   if (no_geom)
     mesh->eb_nnodes[0] = 0;
   else
@@ -551,7 +551,7 @@ void chaco_init_local_ids(
 int i;
 int Proc;
 
-  MPI_Comm_rank(MPI_COMM_WORLD, &Proc);
+  MPI_Comm_rank(zoltan_get_global_comm(), &Proc);
 
   *num_vtx = ch_dist_max_num_vtx(assignments);
   *vtx_list = (int *) malloc(((int)*num_vtx) * sizeof(int));

--- a/packages/zoltan/src/driver/dr_chaco_io.c.shockstem
+++ b/packages/zoltan/src/driver/dr_chaco_io.c.shockstem
@@ -118,7 +118,7 @@ int read_chaco_file(int Proc,
     file_error = (fp == NULL);
   }
 
-  MPI_Bcast(&file_error, 1, MPI_INT, 0, MPI_COMM_WORLD);
+  MPI_Bcast(&file_error, 1, MPI_INT, 0, zoltan_get_global_comm());
 
   if (file_error) {
     sprintf(cmesg, "fatal:  Could not open Chaco graph file %s",
@@ -218,7 +218,7 @@ printf("%d KDDKDD NEARESTSFILE %s\n", Proc, chaco_fname); fflush(stdout);
   }
 
   /* Distribute graph */
-  if (!chaco_dist_graph(MPI_COMM_WORLD, pio_info, 0, &gnvtxs, &nvtxs, 
+  if (!chaco_dist_graph(zoltan_get_global_comm(), pio_info, 0, &gnvtxs, &nvtxs, 
              &start, &adj, &vwgt_dim, &vwgts, &ewgt_dim, &ewgts, 
              &ndim, &x, &y, &z, &assignments) != 0) {
     Gen_Error(0, "fatal: Error returned from chaco_dist_graph");
@@ -315,7 +315,7 @@ int i;
    * Each element has one set of coordinates (i.e., node) if a coords file
    * was provided; zero otherwise. 
    */
-  MPI_Bcast( &no_geom, 1, MPI_INT, 0, MPI_COMM_WORLD);
+  MPI_Bcast( &no_geom, 1, MPI_INT, 0, zoltan_get_global_comm());
   if (no_geom)
     mesh->eb_nnodes[0] = 0;
   else
@@ -516,7 +516,7 @@ void chaco_init_local_ids(
 int i;
 int Proc;
 
-  MPI_Comm_rank(MPI_COMM_WORLD, &Proc);
+  MPI_Comm_rank(zoltan_get_global_comm(), &Proc);
 
   *num_vtx = ch_dist_max_num_vtx(assignments);
   *vtx_list = (int *) malloc(*num_vtx * sizeof(int));

--- a/packages/zoltan/src/driver/dr_ddCPP.cpp
+++ b/packages/zoltan/src/driver/dr_ddCPP.cpp
@@ -58,7 +58,7 @@ int build_elem_dd(MESH_INFO_PTR mesh)
 {
   destroy_elem_dd();
 
-  dd = new Zoltan_DD(MPI_COMM_WORLD, 1, 0, 0, 0, 0);
+  dd = new Zoltan_DD(zoltan_get_global_comm(), 1, 0, 0, 0, 0);
 
   return update_elem_dd(mesh);
 }

--- a/packages/zoltan/src/driver/dr_err.c
+++ b/packages/zoltan/src/driver/dr_err.c
@@ -171,7 +171,7 @@ void error_report(int Proc)
     }
   }
 
-  MPI_Abort(MPI_COMM_WORLD, -1);
+  MPI_Abort(zoltan_get_global_comm(), -1);
 }
 
 #ifdef __cplusplus

--- a/packages/zoltan/src/driver/dr_eval.c
+++ b/packages/zoltan/src/driver/dr_eval.c
@@ -78,7 +78,7 @@ ZOLTAN_ID_TYPE gsumcuts, gmaxcuts, gmincuts, elemcount;
 ZOLTAN_ID_TYPE gsumelems, gmaxelems, gminelems;
 double gsumload, gmaxload, gminload;
 
-  MPI_Comm_rank(MPI_COMM_WORLD, &proc);
+  MPI_Comm_rank(zoltan_get_global_comm(), &proc);
 
   for (i = 0; i < mesh->necmap; i++) {
     cuts += mesh->ecmap_cnt[i];
@@ -89,19 +89,19 @@ double gsumload, gmaxload, gminload;
     load += mesh->elements[i].cpu_wgt[0];
   }
 
-  MPI_Allreduce(&cuts, &gsumcuts, 1, ZOLTAN_ID_MPI_TYPE, MPI_SUM, MPI_COMM_WORLD);
-  MPI_Allreduce(&cuts, &gmaxcuts, 1, ZOLTAN_ID_MPI_TYPE, MPI_MAX, MPI_COMM_WORLD);
-  MPI_Allreduce(&cuts, &gmincuts, 1, ZOLTAN_ID_MPI_TYPE, MPI_MIN, MPI_COMM_WORLD);
+  MPI_Allreduce(&cuts, &gsumcuts, 1, ZOLTAN_ID_MPI_TYPE, MPI_SUM, zoltan_get_global_comm());
+  MPI_Allreduce(&cuts, &gmaxcuts, 1, ZOLTAN_ID_MPI_TYPE, MPI_MAX, zoltan_get_global_comm());
+  MPI_Allreduce(&cuts, &gmincuts, 1, ZOLTAN_ID_MPI_TYPE, MPI_MIN, zoltan_get_global_comm());
 
   elemcount = mesh->num_elems - mesh->blank_count;
 
-  MPI_Allreduce(&elemcount, &gsumelems, 1, ZOLTAN_ID_MPI_TYPE, MPI_SUM, MPI_COMM_WORLD);
-  MPI_Allreduce(&elemcount, &gmaxelems, 1, ZOLTAN_ID_MPI_TYPE, MPI_MAX, MPI_COMM_WORLD);
-  MPI_Allreduce(&elemcount, &gminelems, 1, ZOLTAN_ID_MPI_TYPE, MPI_MIN, MPI_COMM_WORLD);
+  MPI_Allreduce(&elemcount, &gsumelems, 1, ZOLTAN_ID_MPI_TYPE, MPI_SUM, zoltan_get_global_comm());
+  MPI_Allreduce(&elemcount, &gmaxelems, 1, ZOLTAN_ID_MPI_TYPE, MPI_MAX, zoltan_get_global_comm());
+  MPI_Allreduce(&elemcount, &gminelems, 1, ZOLTAN_ID_MPI_TYPE, MPI_MIN, zoltan_get_global_comm());
 
-  MPI_Allreduce(&load, &gsumload, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
-  MPI_Allreduce(&load, &gmaxload, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
-  MPI_Allreduce(&load, &gminload, 1, MPI_DOUBLE, MPI_MIN, MPI_COMM_WORLD);
+  MPI_Allreduce(&load, &gsumload, 1, MPI_DOUBLE, MPI_SUM, zoltan_get_global_comm());
+  MPI_Allreduce(&load, &gmaxload, 1, MPI_DOUBLE, MPI_MAX, zoltan_get_global_comm());
+  MPI_Allreduce(&load, &gminload, 1, MPI_DOUBLE, MPI_MIN, zoltan_get_global_comm());
 
   if (proc == 0) {
     printf("DRIVER EVAL:  load:  max %f  min %f  sum %f\n", 

--- a/packages/zoltan/src/driver/dr_exoII_io.c
+++ b/packages/zoltan/src/driver/dr_exoII_io.c
@@ -230,9 +230,9 @@ int read_exoII_file(int Proc,
 
   /* Perform reduction on necessary fields of element blocks.  kdd 2/2001 */
   MPI_Allreduce(nnodes, mesh->eb_nnodes, mesh->num_el_blks, MPI_INT, MPI_MAX, 
-                MPI_COMM_WORLD);
+                zoltan_get_global_comm());
   MPI_Allreduce(etypes, mesh->eb_etypes, mesh->num_el_blks, MPI_INT, MPI_MIN, 
-                MPI_COMM_WORLD);
+                zoltan_get_global_comm());
   for (i = 0; i < mesh->num_el_blks; i++) {
     strcpy(mesh->eb_names[i], get_elem_name(mesh->eb_etypes[i]));
   }
@@ -893,7 +893,7 @@ static int read_comm_map_info(int pexoid, int Proc, PROB_INFO_PTR prob,
    * for the adjacent elements in this communication map.
    */
 
-  ierr = Zoltan_Comm_Create(&comm_obj, max_len, proc_ids, MPI_COMM_WORLD, 
+  ierr = Zoltan_Comm_Create(&comm_obj, max_len, proc_ids, zoltan_get_global_comm(), 
                             msg, &nrecv);
   if (ierr != ZOLTAN_OK) {
     Gen_Error(0, "fatal: Error returned from Zoltan_Comm_Create");
@@ -1016,7 +1016,7 @@ char cmesg[256];
 char *str = "Proc";
 
   /* generate the parallel filename for this processor */
-  MPI_Comm_size(MPI_COMM_WORLD, &Num_Proc);
+  MPI_Comm_size(zoltan_get_global_comm(), &Num_Proc);
   gen_par_filename(pio_info->pexo_fname, tmp_nem_fname, pio_info, Proc,
                    Num_Proc);
   /* 

--- a/packages/zoltan/src/driver/dr_exoII_ioCPP.cpp
+++ b/packages/zoltan/src/driver/dr_exoII_ioCPP.cpp
@@ -226,9 +226,9 @@ int read_exoII_file(int Proc,
 
   /* Perform reduction on necessary fields of element blocks.  kdd 2/2001 */
   MPI_Allreduce(nnodes, mesh->eb_nnodes, mesh->num_el_blks, 
-                            MPI_INT, MPI_MAX, MPI_COMM_WORLD) ;
+                            MPI_INT, MPI_MAX, zoltan_get_global_comm()) ;
   MPI_Allreduce(etypes, mesh->eb_etypes, mesh->num_el_blks, 
-                            MPI_INT, MPI_MIN, MPI_COMM_WORLD);
+                            MPI_INT, MPI_MIN, zoltan_get_global_comm());
   for (i = 0; i < mesh->num_el_blks; i++) {
     strcpy(mesh->eb_names[i], get_elem_name(mesh->eb_etypes[i]));
   }
@@ -888,7 +888,7 @@ static int read_comm_map_info(int pexoid, int Proc, PROB_INFO_PTR prob,
    * for the adjacent elements in this communication map.
    */
 
-  comm_obj = new Zoltan_Comm(max_len, proc_ids, MPI_COMM_WORLD, msg, &nrecv);
+  comm_obj = new Zoltan_Comm(max_len, proc_ids, zoltan_get_global_comm(), msg, &nrecv);
   
   if (nrecv != max_len) {
     Gen_Error(0, "fatal: Error returned from Zoltan_Comm constructor");
@@ -990,7 +990,7 @@ char cmesg[256];
 
   /* generate the parallel filename for this processor */
   int Num_Proc = 0;
-  MPI_Comm_size(MPI_COMM_WORLD, &Num_Proc);
+  MPI_Comm_size(zoltan_get_global_comm(), &Num_Proc);
 
   gen_par_filename(pio_info->pexo_fname, tmp_nem_fname, pio_info, Proc,
                    Num_Proc);

--- a/packages/zoltan/src/driver/dr_gnuplot.c
+++ b/packages/zoltan/src/driver/dr_gnuplot.c
@@ -190,7 +190,7 @@ int output_gnu(const char *cmd_file,
     /* Sort by part numbers.  Assumes # parts >= # proc. */
     if (nelems > 0) 
       Zoltan_quicksort_pointer_inc_int_int(index, parts, NULL, 0, nelems-1);
-    MPI_Allreduce(&max_part, &gmax_part, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
+    MPI_Allreduce(&max_part, &gmax_part, 1, MPI_INT, MPI_MAX, zoltan_get_global_comm());
     gnum_part = gmax_part + 1;
   }
 
@@ -267,10 +267,10 @@ int output_gnu(const char *cmd_file,
       }
     }
 
-    MPI_Reduce(&locMinX,&globMinX,1,MPI_FLOAT,MPI_MIN,0,MPI_COMM_WORLD);
-    MPI_Reduce(&locMinY,&globMinY,1,MPI_FLOAT,MPI_MIN,0,MPI_COMM_WORLD);
-    MPI_Reduce(&locMaxX,&globMaxX,1,MPI_FLOAT,MPI_MAX,0,MPI_COMM_WORLD);
-    MPI_Reduce(&locMaxY,&globMaxY,1,MPI_FLOAT,MPI_MAX,0,MPI_COMM_WORLD);
+    MPI_Reduce(&locMinX,&globMinX,1,MPI_FLOAT,MPI_MIN,0,zoltan_get_global_comm());
+    MPI_Reduce(&locMinY,&globMinY,1,MPI_FLOAT,MPI_MIN,0,zoltan_get_global_comm());
+    MPI_Reduce(&locMaxX,&globMaxX,1,MPI_FLOAT,MPI_MAX,0,zoltan_get_global_comm());
+    MPI_Reduce(&locMaxY,&globMaxY,1,MPI_FLOAT,MPI_MAX,0,zoltan_get_global_comm());
 
   }
   else if (pio_info->file_type == NEMESIS_FILE) { /* Nemesis input file */

--- a/packages/zoltan/src/driver/dr_hg_io.c
+++ b/packages/zoltan/src/driver/dr_hg_io.c
@@ -214,7 +214,7 @@ int read_hypergraph_file(
 
 
 
-  MPI_Bcast(&file_error, 1, MPI_INT, 0, MPI_COMM_WORLD);
+  MPI_Bcast(&file_error, 1, MPI_INT, 0, zoltan_get_global_comm());
 
   if (file_error) {
     sprintf(cmesg,
@@ -354,7 +354,7 @@ int read_hypergraph_file(
    }
  }
 
-  MPI_Bcast(&base, 1, MPI_INT, 0, MPI_COMM_WORLD);
+  MPI_Bcast(&base, 1, MPI_INT, 0, zoltan_get_global_comm());
 
   if (distributed_pins){
     gnhedges = nhedges;
@@ -404,14 +404,14 @@ int read_hypergraph_file(
     /* Distribute hypergraph graph */
     /* Use hypergraph vertex information and chaco edge information. */
 
-    if (!chaco_dist_graph(MPI_COMM_WORLD, pio_info, 0, &gnvtxs, &nvtxs,
+    if (!chaco_dist_graph(zoltan_get_global_comm(), pio_info, 0, &gnvtxs, &nvtxs,
 	     &ch_start, &ch_adj, &vwgt_dim, &vwgts, &ch_ewgt_dim, &ch_ewgts,
 	     &ch_ndim, &ch_x, &ch_y, &ch_z, &ch_assignments)) {
       Gen_Error(0, "fatal: Error returned from chaco_dist_graph");
       return 0;
     }
 
-    if (!dist_hyperedges(MPI_COMM_WORLD, pio_info, 0, base, gnvtxs, &gnhedges,
+    if (!dist_hyperedges(zoltan_get_global_comm(), pio_info, 0, base, gnvtxs, &gnhedges,
 		       &nhedges, &hgid, &hindex, &hvertex, &hvertex_proc,
 		       &hewgt_dim, &hewgts, ch_assignments)) {
       Gen_Error(0, "fatal: Error returned from dist_hyperedges");
@@ -477,7 +477,7 @@ int read_hypergraph_file(
    * Each element has one set of coordinates (i.e., node) if a coords file
    * was provided; zero otherwise.
    */
-  MPI_Bcast( &ch_no_geom, 1, MPI_INT, 0, MPI_COMM_WORLD);
+  MPI_Bcast( &ch_no_geom, 1, MPI_INT, 0, zoltan_get_global_comm());
   if (ch_no_geom)
     mesh->eb_nnodes[0] = 0;
   else
@@ -630,7 +630,7 @@ int read_mtxplus_file(
       }
     }
   
-    MPI_Bcast(&fsize, 1, MPI_INT, 0, MPI_COMM_WORLD);
+    MPI_Bcast(&fsize, 1, MPI_INT, 0, zoltan_get_global_comm());
   
     if (fsize == 0) {
       sprintf(cmesg, "fatal:  Could not open/read hypergraph file %s", filename);
@@ -642,7 +642,7 @@ int read_mtxplus_file(
       filebuf = (char *)malloc(fsize);
     }
   
-    MPI_Bcast(filebuf, fsize, MPI_BYTE, 0, MPI_COMM_WORLD);
+    MPI_Bcast(filebuf, fsize, MPI_BYTE, 0, zoltan_get_global_comm());
   }
   else{
     /* ERROR - we don't handle the zdrive.inp file request */
@@ -658,7 +658,7 @@ int read_mtxplus_file(
 
   free(filebuf);
   
-  MPI_Allreduce(&rc, &status, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
+  MPI_Allreduce(&rc, &status, 1, MPI_INT, MPI_SUM, zoltan_get_global_comm());
   
   if (status != Num_Proc){
     Gen_Error(0, "fatal: invalid mtxp file");  /* TODO better message */
@@ -699,7 +699,7 @@ int read_mtxplus_file(
     mesh->format = ZOLTAN_COMPRESSED_VERTEX;
   }
 
-  MPI_Allreduce(&rc, &status, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
+  MPI_Allreduce(&rc, &status, 1, MPI_INT, MPI_SUM, zoltan_get_global_comm());
 
   if (status != Num_Proc){
     return 0;
@@ -2189,7 +2189,7 @@ static void debug_elements(int Proc, int Num_Proc, int num, ELEM_INFO_PTR el)
       printf("\n");
       fflush(stdout);
     }
-    MPI_Barrier(MPI_COMM_WORLD);
+    MPI_Barrier(zoltan_get_global_comm());
   }
 }
 static void debug_lists(int Proc, int Num_Proc, int nedge, int *index, ZOLTAN_ID_TYPE *vtx, int *vtx_proc, ZOLTAN_ID_TYPE *egid)
@@ -2209,7 +2209,7 @@ static void debug_lists(int Proc, int Num_Proc, int nedge, int *index, ZOLTAN_ID
       }
       fflush(stdout);
     }
-    MPI_Barrier(MPI_COMM_WORLD);
+    MPI_Barrier(zoltan_get_global_comm());
   }
 }
 static void debug_pins(int Proc, int Num_Proc,  
@@ -2221,7 +2221,7 @@ static void debug_pins(int Proc, int Num_Proc,
 {
 int p,i,j,k;
 
-  MPI_Barrier(MPI_COMM_WORLD);
+  MPI_Barrier(zoltan_get_global_comm());
   for (p=0; p < Num_Proc; p++){
     if (p == Proc){
       printf("Process: %d\n",p);
@@ -2252,8 +2252,8 @@ int p,i,j,k;
       printf("\n");
       fflush(stdout);
     } 
-    MPI_Barrier(MPI_COMM_WORLD);
+    MPI_Barrier(zoltan_get_global_comm());
   }
-  MPI_Barrier(MPI_COMM_WORLD);
+  MPI_Barrier(zoltan_get_global_comm());
 }
 #endif

--- a/packages/zoltan/src/driver/dr_input.c
+++ b/packages/zoltan/src/driver/dr_input.c
@@ -711,7 +711,7 @@ void brdcst_cmd_info (
   float_params[k++] = Test.Dynamic_Weights;
   float_params[k++] = Test.Dynamic_Graph;
 
-  MPI_Bcast (float_params, k, MPI_FLOAT, 0, MPI_COMM_WORLD);
+  MPI_Bcast (float_params, k, MPI_FLOAT, 0, zoltan_get_global_comm());
 
   k = 0;
   Test.Dynamic_Weights = float_params[k++];
@@ -739,7 +739,7 @@ void brdcst_cmd_info (
   int_params[j++] = Test.Gen_Files;
   int_params[j++] = Test.Vtx_Inc;
 
-  MPI_Bcast (int_params, j, MPI_INT, 0, MPI_COMM_WORLD);
+  MPI_Bcast (int_params, j, MPI_INT, 0, zoltan_get_global_comm());
 
   j = 0;
   Debug_Driver           = int_params[j++];
@@ -763,7 +763,7 @@ void brdcst_cmd_info (
   Test.Gen_Files         = int_params[j++];
   Test.Vtx_Inc           = int_params[j++];
 
-  MPI_Bcast (pio_info, sizeof(PARIO_INFO), MPI_BYTE, 0, MPI_COMM_WORLD);
+  MPI_Bcast (pio_info, sizeof(PARIO_INFO), MPI_BYTE, 0, zoltan_get_global_comm());
 
   switch (pio_info->file_type) {
   case CHACO_FILE:
@@ -785,16 +785,16 @@ void brdcst_cmd_info (
     if (Proc != 0)
       pio_info->dsk_list = (int*) malloc (pio_info->dsk_list_cnt*sizeof(int));
     MPI_Bcast (pio_info->dsk_list, pio_info->dsk_list_cnt, MPI_INT, 0,
-    MPI_COMM_WORLD);
+    zoltan_get_global_comm());
   }
 
   /* and broadcast the problem specifications */
-  MPI_Bcast (prob, sizeof(PROB_INFO), MPI_BYTE, 0, MPI_COMM_WORLD);
+  MPI_Bcast (prob, sizeof(PROB_INFO), MPI_BYTE, 0, zoltan_get_global_comm());
   if (prob->num_params > 0) {
     size = prob->num_params * sizeof(Parameter_Pair);
     if (Proc != 0)
       prob->params = (Parameter_Pair*) malloc(size);
-    MPI_Bcast (prob->params, size, MPI_CHAR, 0, MPI_COMM_WORLD);
+    MPI_Bcast (prob->params, size, MPI_CHAR, 0, zoltan_get_global_comm());
   }
 
   /* now calculate where the file for this processor is */

--- a/packages/zoltan/src/driver/dr_input.c.shockstem
+++ b/packages/zoltan/src/driver/dr_input.c.shockstem
@@ -656,7 +656,7 @@ void brdcst_cmd_info (
   float_params[k++] = Test.Dynamic_Weights;
   float_params[k++] = Test.Dynamic_Graph;
 
-  MPI_Bcast (float_params, k, MPI_FLOAT, 0, MPI_COMM_WORLD);
+  MPI_Bcast (float_params, k, MPI_FLOAT, 0, zoltan_get_global_comm());
 
   k = 0;
   Test.Dynamic_Weights = float_params[k++];
@@ -683,7 +683,7 @@ void brdcst_cmd_info (
   int_params[j++] = Test.RCB_Box;
   int_params[j++] = Test.Gen_Files;
 
-  MPI_Bcast (int_params, j, MPI_INT, 0, MPI_COMM_WORLD);
+  MPI_Bcast (int_params, j, MPI_INT, 0, zoltan_get_global_comm());
 
   j = 0;
   Debug_Driver           = int_params[j++];
@@ -706,22 +706,22 @@ void brdcst_cmd_info (
   Test.RCB_Box           = int_params[j++];
   Test.Gen_Files         = int_params[j++];
 
-  MPI_Bcast (pio_info, sizeof(PARIO_INFO), MPI_BYTE, 0, MPI_COMM_WORLD);
+  MPI_Bcast (pio_info, sizeof(PARIO_INFO), MPI_BYTE, 0, zoltan_get_global_comm());
 
   if (pio_info->dsk_list_cnt > 0) {
     if (Proc != 0)
       pio_info->dsk_list = (int*) malloc (pio_info->dsk_list_cnt*sizeof(int));
     MPI_Bcast (pio_info->dsk_list, pio_info->dsk_list_cnt, MPI_INT, 0,
-    MPI_COMM_WORLD);
+    zoltan_get_global_comm());
   }
 
   /* and broadcast the problem specifications */
-  MPI_Bcast (prob, sizeof(PROB_INFO), MPI_BYTE, 0, MPI_COMM_WORLD);
+  MPI_Bcast (prob, sizeof(PROB_INFO), MPI_BYTE, 0, zoltan_get_global_comm());
   if (prob->num_params > 0) {
     size = prob->num_params * sizeof(Parameter_Pair);
     if (Proc != 0)
       prob->params = (Parameter_Pair*) malloc(size);
-    MPI_Bcast (prob->params, size, MPI_CHAR, 0, MPI_COMM_WORLD);
+    MPI_Bcast (prob->params, size, MPI_CHAR, 0, zoltan_get_global_comm());
   }
 
   /* now calculate where the file for this processor is */

--- a/packages/zoltan/src/driver/dr_main.c
+++ b/packages/zoltan/src/driver/dr_main.c
@@ -160,8 +160,8 @@ int main(int argc, char *argv[])
 #endif
 
   /* get some machine information */
-  MPI_Comm_rank(MPI_COMM_WORLD, &Proc);
-  MPI_Comm_size(MPI_COMM_WORLD, &Num_Proc);
+  MPI_Comm_rank(zoltan_get_global_comm(), &Proc);
+  MPI_Comm_size(zoltan_get_global_comm(), &Num_Proc);
 
   my_rank = Proc;
 
@@ -276,7 +276,7 @@ int main(int argc, char *argv[])
     print_input_info(stdout, Num_Proc, &prob, &pio_info, version);
   }
 
-  MPI_Allreduce(&error, &gerror, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
+  MPI_Allreduce(&error, &gerror, 1, MPI_INT, MPI_MAX, zoltan_get_global_comm());
   if (gerror) goto End;
 
   /* broadcast the command info to all of the processor */
@@ -288,7 +288,7 @@ int main(int argc, char *argv[])
   /*
    *  Create a Zoltan structure.
    */
-  if ((zz = Zoltan_Create(MPI_COMM_WORLD)) == NULL) {
+  if ((zz = Zoltan_Create(zoltan_get_global_comm())) == NULL) {
     Gen_Error(0, "fatal:  NULL returned from Zoltan_Create()\n");
     return 0;
   }
@@ -376,7 +376,7 @@ int main(int argc, char *argv[])
           }
           fclose(fp);
         }
-        MPI_Bcast (CITESEER, 200, MPI_INT, 0, MPI_COMM_WORLD);
+        MPI_Bcast (CITESEER, 200, MPI_INT, 0, zoltan_get_global_comm());
       }
     }
 
@@ -624,11 +624,11 @@ static int read_mesh(
       printf("Process %d:\n",i);
       print_mesh(Proc, mesh, &pins, &he, &verts);
     }
-    MPI_Barrier(MPI_COMM_WORLD);
+    MPI_Barrier(zoltan_get_global_comm());
   }
-  MPI_Reduce(&pins, &tpins, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
-  MPI_Reduce(&he, &the, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
-  MPI_Reduce(&verts, &tverts, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
+  MPI_Reduce(&pins, &tpins, 1, MPI_INT, MPI_SUM, 0, zoltan_get_global_comm());
+  MPI_Reduce(&he, &the, 1, MPI_INT, MPI_SUM, 0, zoltan_get_global_comm());
+  MPI_Reduce(&verts, &tverts, 1, MPI_INT, MPI_SUM, 0, zoltan_get_global_comm());
   if (Proc == 0){
     if (mesh->format == ZOLTAN_COMPRESSED_EDGE){
       printf("Total pins %d, total vertices %d, total rows %d\n",
@@ -831,11 +831,11 @@ ELEM_INFO *elem;
     }
   }
 
-  MPI_Allreduce(&mesh->blank_count, &mesh->global_blank_count, 1, ZOLTAN_ID_MPI_TYPE, MPI_SUM, MPI_COMM_WORLD);
+  MPI_Allreduce(&mesh->blank_count, &mesh->global_blank_count, 1, ZOLTAN_ID_MPI_TYPE, MPI_SUM, zoltan_get_global_comm());
 
   tmp = (ZOLTAN_ID_TYPE)mesh->num_elems;
 
-  MPI_Reduce(&tmp, &total_vertices, 1, ZOLTAN_ID_MPI_TYPE, MPI_SUM, 0, MPI_COMM_WORLD);
+  MPI_Reduce(&tmp, &total_vertices, 1, ZOLTAN_ID_MPI_TYPE, MPI_SUM, 0, zoltan_get_global_comm());
 
   if (mesh->proc == 0){
     printf("Dynamic graph factor %0.4f, " ZOLTAN_ID_SPEC " vertices, " ZOLTAN_ID_SPEC " blanked (%0.2f%%)\n",
@@ -844,7 +844,7 @@ ELEM_INFO *elem;
   }
   fflush(stdout);
   if (Debug_Driver > 1) {
-    MPI_Barrier(MPI_COMM_WORLD);
+    MPI_Barrier(zoltan_get_global_comm());
     if (mesh->num_elems){
       printf("Proc %d: %d vertices, %d blanked (%0.2f%%)\n",
             mesh->proc, mesh->num_elems,  mesh->blank_count,
@@ -854,7 +854,7 @@ ELEM_INFO *elem;
       printf("Proc %d: 0 vertices\n", mesh->proc);
     }
     fflush(stdout);
-    MPI_Barrier(MPI_COMM_WORLD);
+    MPI_Barrier(zoltan_get_global_comm());
   }
 }
 

--- a/packages/zoltan/src/driver/dr_main.c.shockstem
+++ b/packages/zoltan/src/driver/dr_main.c.shockstem
@@ -148,8 +148,8 @@ int main(int argc, char *argv[])
 #endif
 
   /* get some machine information */
-  MPI_Comm_rank(MPI_COMM_WORLD, &Proc);
-  MPI_Comm_size(MPI_COMM_WORLD, &Num_Proc);
+  MPI_Comm_rank(zoltan_get_global_comm(), &Proc);
+  MPI_Comm_size(zoltan_get_global_comm(), &Num_Proc);
 
 #ifdef ZOLTAN_PURIFY
   printf("%d of %d ZDRIVE LAUNCH pid = %d file = %s\n", 
@@ -251,7 +251,7 @@ int main(int argc, char *argv[])
     print_input_info(stdout, Num_Proc, &prob, &pio_info, version);
   }
 
-  MPI_Allreduce(&error, &gerror, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
+  MPI_Allreduce(&error, &gerror, 1, MPI_INT, MPI_MAX, zoltan_get_global_comm());
   if (gerror) goto End;
 
   /* broadcast the command info to all of the processor */
@@ -263,7 +263,7 @@ int main(int argc, char *argv[])
   /*
    *  Create a Zoltan structure.
    */
-  if ((zz = Zoltan_Create(MPI_COMM_WORLD)) == NULL) {
+  if ((zz = Zoltan_Create(zoltan_get_global_comm())) == NULL) {
     Gen_Error(0, "fatal:  NULL returned from Zoltan_Create()\n");
     return 0;
   }
@@ -509,11 +509,11 @@ static int read_mesh(
       printf("Process %d:\n",i);
       print_mesh(Proc, mesh, &pins, &he, &verts);
     }
-    MPI_Barrier(MPI_COMM_WORLD);
+    MPI_Barrier(zoltan_get_global_comm());
   }
-  MPI_Reduce(&pins, &tpins, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
-  MPI_Reduce(&he, &the, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
-  MPI_Reduce(&verts, &tverts, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
+  MPI_Reduce(&pins, &tpins, 1, MPI_INT, MPI_SUM, 0, zoltan_get_global_comm());
+  MPI_Reduce(&he, &the, 1, MPI_INT, MPI_SUM, 0, zoltan_get_global_comm());
+  MPI_Reduce(&verts, &tverts, 1, MPI_INT, MPI_SUM, 0, zoltan_get_global_comm());
   if (Proc == 0){
     if (mesh->format == ZOLTAN_COMPRESSED_EDGE){
       printf("Total pins %d, total vertices %d, total rows %d\n",
@@ -710,10 +710,10 @@ ELEM_INFO *elem;
   }
 
   MPI_Allreduce(&mesh->blank_count, &mesh->global_blank_count, 
-             1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
+             1, MPI_INT, MPI_SUM, zoltan_get_global_comm());
 
   MPI_Reduce(&mesh->num_elems, &total_vertices, 
-             1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
+             1, MPI_INT, MPI_SUM, 0, zoltan_get_global_comm());
 
   if (mesh->proc == 0){
     printf("Dynamic graph factor %0.4f, %d vertices, %d blanked (%0.2f%%)\n",
@@ -722,7 +722,7 @@ ELEM_INFO *elem;
   }
   fflush(stdout);
   if (Debug_Driver > 1) {
-    MPI_Barrier(MPI_COMM_WORLD);
+    MPI_Barrier(zoltan_get_global_comm());
     if (mesh->num_elems){
       printf("Proc %d: %d vertices, %d blanked (%0.2f%%)\n",
             mesh->proc, mesh->num_elems,  mesh->blank_count,
@@ -732,7 +732,7 @@ ELEM_INFO *elem;
       printf("Proc %d: 0 vertices\n", mesh->proc);
     }
     fflush(stdout);
-    MPI_Barrier(MPI_COMM_WORLD);
+    MPI_Barrier(zoltan_get_global_comm());
   }
 }
 

--- a/packages/zoltan/src/driver/dr_mainCPP.cpp
+++ b/packages/zoltan/src/driver/dr_mainCPP.cpp
@@ -104,8 +104,8 @@ int main(int argc, char *argv[])
 
   /* get some machine information */
   int Proc = 0, Num_Proc = 0;
-  MPI_Comm_rank(MPI_COMM_WORLD, &Proc);
-  MPI_Comm_size(MPI_COMM_WORLD, &Num_Proc);
+  MPI_Comm_rank(zoltan_get_global_comm(), &Proc);
+  MPI_Comm_size(zoltan_get_global_comm(), &Num_Proc);
 
   /* Initialize flags */
   Test.DDirectory = 0;
@@ -222,7 +222,7 @@ int main(int argc, char *argv[])
     print_input_info(cout, Num_Proc, &prob, &pio_info, version);
   }
 
-  MPI_Allreduce(&error, &gerror, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
+  MPI_Allreduce(&error, &gerror, 1, MPI_INT, MPI_MAX, zoltan_get_global_comm());
 
   if (gerror) goto End;
 

--- a/packages/zoltan/src/driver/dr_maps.c
+++ b/packages/zoltan/src/driver/dr_maps.c
@@ -386,9 +386,9 @@ ZOLTAN_COMM_OBJ *comm, *comm_copy;
    * Create DDirectory and register all owned elements. 
    */
 
-  MPI_Allreduce(&num_elems, &max_nelems, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
+  MPI_Allreduce(&num_elems, &max_nelems, 1, MPI_INT, MPI_MAX, zoltan_get_global_comm());
 
-  ierr = Zoltan_DD_Create(&dd, MPI_COMM_WORLD, 1, 1, 0, max_nelems, 0);
+  ierr = Zoltan_DD_Create(&dd, zoltan_get_global_comm(), 1, 1, 0, max_nelems, 0);
   if (ierr) {
     Gen_Error(0, "Fatal:  Error returned by Zoltan_DD_Create");
     error = 1;
@@ -498,7 +498,7 @@ ZOLTAN_COMM_OBJ *comm, *comm_copy;
    * Check for errors 
    */
 
-  MPI_Allreduce(&error, &gerror, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
+  MPI_Allreduce(&error, &gerror, 1, MPI_INT, MPI_SUM, zoltan_get_global_comm());
   if (gerror) {
     Gen_Error(0, "Fatal:  Error returned by DDirectory Test");
     error_report(proc);
@@ -537,7 +537,7 @@ ZOLTAN_COMM_OBJ *comm, *comm_copy;
     i_want[j++] = my_gids[i];
   }
 
-  ierr = Zoltan_Comm_Create(&comm, num_nbor, ownerlist, MPI_COMM_WORLD, 747, 
+  ierr = Zoltan_Comm_Create(&comm, num_nbor, ownerlist, zoltan_get_global_comm(), 747, 
                         &num_others);
   if (ierr) {
     Gen_Error(0, "Fatal:  Error returned from Zoltan_Comm_Create");
@@ -683,7 +683,7 @@ ZOLTAN_COMM_OBJ *comm, *comm_copy;
      * output of generated map is serialized (and not junked up).
      */
     int nprocs;
-    MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
+    MPI_Comm_size(zoltan_get_global_comm(), &nprocs);
     print_sync_end(proc, nprocs, 1);
   }
 

--- a/packages/zoltan/src/driver/dr_mapsCPP.cpp
+++ b/packages/zoltan/src/driver/dr_mapsCPP.cpp
@@ -380,7 +380,7 @@ Zoltan_Comm *comm;
    * Create DDirectory and register all owned elements. 
    */
 
-  dd = new Zoltan_DD(MPI_COMM_WORLD, 1, 1, 0, 0, 0);
+  dd = new Zoltan_DD(zoltan_get_global_comm(), 1, 1, 0, 0, 0);
 
   ierr = dd->Update(gids, lids, NULL, NULL, num_elems);
 
@@ -453,7 +453,7 @@ Zoltan_Comm *comm;
    * Check for errors 
    */
 
-  MPI_Allreduce(&error, &gerror, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
+  MPI_Allreduce(&error, &gerror, 1, MPI_INT, MPI_SUM, zoltan_get_global_comm());
 
   if (gerror) {
     Gen_Error(0, "Fatal:  Error returned by DDirectory Test");
@@ -493,7 +493,7 @@ Zoltan_Comm *comm;
     i_want[j++] = my_gids[i];
   }
 
-  comm = new Zoltan_Comm(num_nbor, ownerlist, MPI_COMM_WORLD, 747, 
+  comm = new Zoltan_Comm(num_nbor, ownerlist, zoltan_get_global_comm(), 747, 
                         &num_others);
 
   /*
@@ -622,7 +622,7 @@ printf("Test comm copy functions\n");
      * output of generated map is serialized (and not junked up).
      */
     int nprocs = 0;
-    MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
+    MPI_Comm_size(zoltan_get_global_comm(), &nprocs);
     print_sync_end(proc, nprocs, 1);
   }
 

--- a/packages/zoltan/src/driver/dr_migrate.c
+++ b/packages/zoltan/src/driver/dr_migrate.c
@@ -392,7 +392,7 @@ char msg[256];
   else
     k = 0;
   /* Make sure all procs have the same value */
-  MPI_Allreduce(&k, &Use_Edge_Wgts, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
+  MPI_Allreduce(&k, &Use_Edge_Wgts, 1, MPI_INT, MPI_MAX, zoltan_get_global_comm());
 
   /* NOT IMPLEMENTED: blanking information is not sent along.  Subsequent
      lb_eval may be incorrect, since imported elements may have blanked
@@ -403,7 +403,7 @@ char msg[256];
   else
     k = 0;
  
-  MPI_Allreduce(&k, &Vertex_Blanking, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
+  MPI_Allreduce(&k, &Vertex_Blanking, 1, MPI_INT, MPI_MAX, zoltan_get_global_comm());
 
   */
 
@@ -413,7 +413,7 @@ char msg[256];
    *  information.  
    */
   
-  MPI_Comm_rank(MPI_COMM_WORLD, &proc);
+  MPI_Comm_rank(zoltan_get_global_comm(), &proc);
 
   /*
    *  Build New_Elem_Index array and list of processor assignments.
@@ -672,8 +672,8 @@ ZOLTAN_ID_TYPE adj_elem;
   elements = mesh->elements;
 
 
-  MPI_Comm_rank(MPI_COMM_WORLD, &proc);
-  MPI_Comm_size(MPI_COMM_WORLD, &num_proc);
+  MPI_Comm_rank(zoltan_get_global_comm(), &proc);
+  MPI_Comm_size(zoltan_get_global_comm(), &num_proc);
 
   /* compact elements array, as the application expects the array to be dense */
   for (i = 0; i < New_Elem_Index_Size; i++) {
@@ -875,7 +875,7 @@ void migrate_pack_elem(void *data, int num_gid_entries, int num_lid_entries,
   mesh = (MESH_INFO_PTR) data;
   elem = mesh->elements;
 
-  MPI_Comm_rank(MPI_COMM_WORLD, &proc);
+  MPI_Comm_rank(zoltan_get_global_comm(), &proc);
 
   current_elem = (num_lid_entries 
                    ? &(elem[elem_lid[lid]])
@@ -1008,7 +1008,7 @@ void migrate_unpack_elem(void *data, int num_gid_entries, ZOLTAN_ID_PTR elem_gid
   elem = mesh->elements;
   elem_mig = (ELEM_INFO *) buf;
 
-  MPI_Comm_rank(MPI_COMM_WORLD, &proc);
+  MPI_Comm_rank(zoltan_get_global_comm(), &proc);
 
   idx = find_in_hash((int)elem_gid[gid]);
   if (idx >= 0) 

--- a/packages/zoltan/src/driver/dr_migrate.c.shockstem
+++ b/packages/zoltan/src/driver/dr_migrate.c.shockstem
@@ -399,7 +399,7 @@ char msg[256];
   else
     k = 0;
   /* Make sure all procs have the same value */
-  MPI_Allreduce(&k, &Use_Edge_Wgts, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
+  MPI_Allreduce(&k, &Use_Edge_Wgts, 1, MPI_INT, MPI_MAX, zoltan_get_global_comm());
 
   /* NOT IMPLEMENTED: blanking information is not sent along.  Subsequent
      lb_eval may be incorrect, since imported elements may have blanked
@@ -410,7 +410,7 @@ char msg[256];
   else
     k = 0;
  
-  MPI_Allreduce(&k, &Vertex_Blanking, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
+  MPI_Allreduce(&k, &Vertex_Blanking, 1, MPI_INT, MPI_MAX, zoltan_get_global_comm());
 
   */
 
@@ -420,7 +420,7 @@ char msg[256];
    *  information.  
    */
   
-  MPI_Comm_rank(MPI_COMM_WORLD, &proc);
+  MPI_Comm_rank(zoltan_get_global_comm(), &proc);
 
   /*
    *  Build New_Elem_Index array and list of processor assignments.
@@ -677,8 +677,8 @@ int adj_elem;
   elements = mesh->elements;
 
 
-  MPI_Comm_rank(MPI_COMM_WORLD, &proc);
-  MPI_Comm_size(MPI_COMM_WORLD, &num_proc);
+  MPI_Comm_rank(zoltan_get_global_comm(), &proc);
+  MPI_Comm_size(zoltan_get_global_comm(), &num_proc);
 
   /* compact elements array, as the application expects the array to be dense */
   for (i = 0; i < New_Elem_Index_Size; i++) {
@@ -862,7 +862,7 @@ void migrate_pack_elem(void *data, int num_gid_entries, int num_lid_entries,
   mesh = (MESH_INFO_PTR) data;
   elem = mesh->elements;
 
-  MPI_Comm_rank(MPI_COMM_WORLD, &proc);
+  MPI_Comm_rank(zoltan_get_global_comm(), &proc);
 
   current_elem = (num_lid_entries 
                    ? &(elem[elem_lid[lid]])
@@ -989,7 +989,7 @@ void migrate_unpack_elem(void *data, int num_gid_entries, ZOLTAN_ID_PTR elem_gid
   elem = mesh->elements;
   elem_mig = (ELEM_INFO *) buf;
 
-  MPI_Comm_rank(MPI_COMM_WORLD, &proc);
+  MPI_Comm_rank(zoltan_get_global_comm(), &proc);
 
   idx = find_in_hash(elem_gid[gid]);
   if (idx >= 0) 

--- a/packages/zoltan/src/driver/dr_migrateCPP.cpp
+++ b/packages/zoltan/src/driver/dr_migrateCPP.cpp
@@ -260,7 +260,7 @@ char msg[256];
 
   /* Make sure all procs have the same value */
 
-  MPI_Allreduce(&k, &Use_Edge_Wgts, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
+  MPI_Allreduce(&k, &Use_Edge_Wgts, 1, MPI_INT, MPI_MAX, zoltan_get_global_comm());
 
   /*
    *  For all elements, update adjacent elements' processor information.
@@ -269,7 +269,7 @@ char msg[256];
    */
   
   int proc = 0;
-  MPI_Comm_rank(MPI_COMM_WORLD, &proc);
+  MPI_Comm_rank(zoltan_get_global_comm(), &proc);
 
   /*
    *  Build New_Elem_Index array and list of processor assignments.
@@ -525,8 +525,8 @@ void migrate_post_process(void *data, int num_gid_entries, int num_lid_entries,
   ELEM_INFO *elements = mesh->elements;
 
   int proc = 0, num_proc = 0;
-  MPI_Comm_rank(MPI_COMM_WORLD, &proc);
-  MPI_Comm_size(MPI_COMM_WORLD, &num_proc);
+  MPI_Comm_rank(zoltan_get_global_comm(), &proc);
+  MPI_Comm_size(zoltan_get_global_comm(), &num_proc);
 
   /* compact elements array, as the application expects the array to be dense */
   for (int i = 0; i < New_Elem_Index_Size; i++) {
@@ -699,7 +699,7 @@ void migrate_pack_elem(void *data, int num_gid_entries, int num_lid_entries,
   ELEM_INFO *elem = mesh->elements;
 
   int proc = 0;
-  MPI_Comm_rank(MPI_COMM_WORLD, &proc);
+  MPI_Comm_rank(zoltan_get_global_comm(), &proc);
 
   int idx;
 
@@ -830,7 +830,7 @@ void migrate_unpack_elem(void *data, int num_gid_entries, ZOLTAN_ID_PTR elem_gid
   ELEM_INFO *elem_mig = (ELEM_INFO *) buf;
 
   int proc = 0;
-  MPI_Comm_rank(MPI_COMM_WORLD, &proc);
+  MPI_Comm_rank(zoltan_get_global_comm(), &proc);
 
   int idx = 0;
   ZOLTAN_ID_TYPE egid = elem_gid[gid];

--- a/packages/zoltan/src/driver/dr_mm_readfile.c
+++ b/packages/zoltan/src/driver/dr_mm_readfile.c
@@ -158,9 +158,9 @@ int error = 0;  /* flag to indicate status */
         M=N=gnz=0;
       }
     }
-    MPI_Bcast(&gnz, 1, MPI_INT, 0, MPI_COMM_WORLD);
-    MPI_Bcast(&M, 1, MPI_INT, 0, MPI_COMM_WORLD);
-    MPI_Bcast(&N, 1, MPI_INT, 0, MPI_COMM_WORLD);
+    MPI_Bcast(&gnz, 1, MPI_INT, 0, zoltan_get_global_comm());
+    MPI_Bcast(&M, 1, MPI_INT, 0, zoltan_get_global_comm());
+    MPI_Bcast(&N, 1, MPI_INT, 0, zoltan_get_global_comm());
 
     if (pio_info->matrix_obj==COLUMNS){
       *nVtx = N;
@@ -205,7 +205,7 @@ int error = 0;  /* flag to indicate status */
       /* Initialize which process owns which vertex, and global
        * variables used by graph callbacks. */
 
-      ch_dist_init(Num_Proc, *nVtx, pio_info, &assignments, 0, MPI_COMM_WORLD);
+      ch_dist_init(Num_Proc, *nVtx, pio_info, &assignments, 0, zoltan_get_global_comm());
 
       if (Proc == 0){
         sendcount = (int *)malloc(Num_Proc * sizeof(int));
@@ -264,7 +264,7 @@ int error = 0;  /* flag to indicate status */
           start[0] = 0;
           for (j=0; j<Num_Proc; j++){
             if (j > 0){
-              MPI_Send(sendcount + j, 1, MPI_INT, j, 0x0101, MPI_COMM_WORLD);
+              MPI_Send(sendcount + j, 1, MPI_INT, j, 0x0101, zoltan_get_global_comm());
             }
             start[j+1] = start[j] + sendcount[j];
             sendcount[j] = 0;
@@ -285,7 +285,7 @@ int error = 0;  /* flag to indicate status */
           }
           for (j=1; j<Num_Proc; j++){
             MPI_Send(outVals + (2*start[j]), sendcount[j] * 2,
-                     MPI_INT, j, 0x0102, MPI_COMM_WORLD);
+                     MPI_INT, j, 0x0102, zoltan_get_global_comm());
           }
           rc = add_new_vals(outVals, myInCount, &myVals, &myCount, &myMaxCount);
           if (rc) {
@@ -297,8 +297,8 @@ int error = 0;  /* flag to indicate status */
         else{
           /* Await pins from process 0 and store them in a buffer
            */
-          MPI_Recv(&myInCount, 1, MPI_INT, 0, 0x0101, MPI_COMM_WORLD,&status);
-          MPI_Recv(inVals, myInCount*2, MPI_INT, 0, 0x0102, MPI_COMM_WORLD,&status);
+          MPI_Recv(&myInCount, 1, MPI_INT, 0, 0x0101, zoltan_get_global_comm(),&status);
+          MPI_Recv(inVals, myInCount*2, MPI_INT, 0, 0x0102, zoltan_get_global_comm(),&status);
           rc = add_new_vals(inVals, myInCount, &myVals, &myCount, &myMaxCount);
           if (rc) {
             fprintf(stderr,"Process %d out of memory\n",Proc);

--- a/packages/zoltan/src/driver/dr_par_util.c
+++ b/packages/zoltan/src/driver/dr_par_util.c
@@ -88,10 +88,10 @@ void print_sync_start(int proc, int do_print_line)
   int        from, flag;
   MPI_Status status;
 
-  MPI_Barrier(MPI_COMM_WORLD);
+  MPI_Barrier(zoltan_get_global_comm());
   if ( proc != 0) {
     from = proc - 1;
-    MPI_Recv((void *) &flag, 1, MPI_INT, from, 0, MPI_COMM_WORLD, &status);
+    MPI_Recv((void *) &flag, 1, MPI_INT, from, 0, zoltan_get_global_comm(), &status);
   }
   else {
     if (do_print_line) {
@@ -153,14 +153,14 @@ void print_sync_end(int proc, int nprocs, int do_print_line)
 
   if (proc == 0) {
     from = nprocs - 1;
-    MPI_Irecv((void *) &flag, 1, MPI_INT, from, 0, MPI_COMM_WORLD, &req);
+    MPI_Irecv((void *) &flag, 1, MPI_INT, from, 0, zoltan_get_global_comm(), &req);
 
 #ifdef DEBUG_PSYNC
     (void) printf("\t\t\t Proc 0 posted receive from %5d\n", from);
 #endif
   }
 
-  MPI_Send((void *) &flag, 1, MPI_INT, to, 0, MPI_COMM_WORLD);
+  MPI_Send((void *) &flag, 1, MPI_INT, to, 0, zoltan_get_global_comm());
 
   if (proc == 0) {
     MPI_Wait(&req, &status);
@@ -172,7 +172,7 @@ void print_sync_end(int proc, int nprocs, int do_print_line)
    * (Num_Proc-1)
    */
 
-  MPI_Barrier(MPI_COMM_WORLD);
+  MPI_Barrier(zoltan_get_global_comm());
 
 }
 
@@ -200,7 +200,7 @@ MPI_Request *req = NULL;
   offset = 0;
   for (i = 0; i < mesh->necmap; i++) {
     MPI_Irecv(&(recv_vec[offset]), mesh->ecmap_cnt[i]*vec_len, MPI_INT, 
-              mesh->ecmap_id[i], msg_type, MPI_COMM_WORLD, &(req[i]));
+              mesh->ecmap_id[i], msg_type, zoltan_get_global_comm(), &(req[i]));
     offset += mesh->ecmap_cnt[i]*vec_len;
   }
 
@@ -208,7 +208,7 @@ MPI_Request *req = NULL;
   offset = 0;
   for (i = 0; i < mesh->necmap; i++) {
     MPI_Send(&(send_vec[offset]), mesh->ecmap_cnt[i]*vec_len, MPI_INT, 
-             mesh->ecmap_id[i], msg_type, MPI_COMM_WORLD);
+             mesh->ecmap_id[i], msg_type, zoltan_get_global_comm());
     offset += mesh->ecmap_cnt[i]*vec_len;
   }
 

--- a/packages/zoltan/src/driver/dr_param_file.c
+++ b/packages/zoltan/src/driver/dr_param_file.c
@@ -81,7 +81,7 @@
        fflush(stdout); \
        fprintf(stderr,"in file %s, line %d, failed to allocate %ld bytes",\
                __FILE__,__LINE__,size); \
-       MPI_Abort(MPI_COMM_WORLD,1); \
+       MPI_Abort(zoltan_get_global_comm(),1); \
     } \
  }
 

--- a/packages/zoltan/src/driver/dr_param_fileCPP.cpp
+++ b/packages/zoltan/src/driver/dr_param_fileCPP.cpp
@@ -78,7 +78,7 @@
        fflush(stdout); \
        fprintf(stderr,"in file %s, line %d, failed to allocate %ld bytes",\
                __FILE__,__LINE__,size); \
-       MPI_Abort(MPI_COMM_WORLD,1); \
+       MPI_Abort(zoltan_get_global_comm(),1); \
     } \
  }
 

--- a/packages/zoltan/src/driver/dr_random_io.c
+++ b/packages/zoltan/src/driver/dr_random_io.c
@@ -262,7 +262,7 @@ int create_random_triangles(
 
   /* Distribute graph */
 
-  if (!chaco_dist_graph(MPI_COMM_WORLD, pio_info, 0, &gnvtxs, &nvtxs, 
+  if (!chaco_dist_graph(zoltan_get_global_comm(), pio_info, 0, &gnvtxs, &nvtxs, 
              &start, &adj, &vwgt_dim, &vwgts, &ewgt_dim, &ewgts, 
              &ndim, &x, &y, &z, &assignments)) {
     Gen_Error(0, "fatal: Error returned from chaco_dist_graph");
@@ -421,7 +421,7 @@ int create_random_input(
 
   /* Distribute graph */
 
-  if (!chaco_dist_graph(MPI_COMM_WORLD, pio_info, 0, &gnvtxs, &nvtxs, 
+  if (!chaco_dist_graph(zoltan_get_global_comm(), pio_info, 0, &gnvtxs, &nvtxs, 
              &start, &adj, &vwgt_dim, &vwgts, &ewgt_dim, &ewgts, 
              &ndim, &x, &y, &z, &assignments)) {
     Gen_Error(0, "fatal: Error returned from chaco_dist_graph");

--- a/packages/zoltan/src/driver/dr_setfixed.c
+++ b/packages/zoltan/src/driver/dr_setfixed.c
@@ -64,8 +64,8 @@ int i, part;
 int proc, nprocs;
 FILE *fp;
 
-  MPI_Comm_rank(MPI_COMM_WORLD, &proc);
-  MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
+  MPI_Comm_rank(zoltan_get_global_comm(), &proc);
+  MPI_Comm_size(zoltan_get_global_comm(), &nprocs);
 
   /* Initialize fixed elements in mesh */
   for (i = 0; i < mesh->num_elems; i++) mesh->elements[i].fixed_part = -1;

--- a/packages/zoltan/src/fdriver/fdr_chaco_io.f90
+++ b/packages/zoltan/src/fdriver/fdr_chaco_io.f90
@@ -139,7 +139,7 @@ type(ELEM_INFO), pointer :: elements(:)
   endif ! Proc == 0
 
 !   Distribute graph 
-  if (.not.chaco_dist_graph(MPI_COMM_WORLD, 0, nvtxs, vtxdist, start, adj, &
+  if (.not.chaco_dist_graph(zoltan_get_global_comm(), 0, nvtxs, vtxdist, start, adj, &
                             vwgts, ewgts, ndim, x, y, z)) then
       print *, "fatal: Error returned from chaco_dist_graph"
       read_chaco_mesh = .false.

--- a/packages/zoltan/src/fdriver/fdr_input.f90
+++ b/packages/zoltan/src/fdriver/fdr_input.f90
@@ -410,23 +410,23 @@ type(PARIO_INFO) :: pio_info
   integer(Zoltan_INT) :: ierr, i
 !**************************** BEGIN EXECUTION *****************************
 
-  call MPI_Bcast(Test_Multi_Callbacks, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
-  call MPI_Bcast(Test_Local_Partitions, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
-  call MPI_Bcast(Test_Drops, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
-  call MPI_Bcast(Test_Gen_Files, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
-  call MPI_Bcast(Driver_Action, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
-  call MPI_Bcast(pio_info%dsk_list_cnt, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
-  call MPI_Bcast(pio_info%rdisk, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
-  call MPI_Bcast(pio_info%num_dsk_ctrlrs, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
-  call MPI_Bcast(pio_info%pdsk_add_fact, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
-  call MPI_Bcast(pio_info%zeros, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
-  call MPI_Bcast(pio_info%file_type, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
+  call MPI_Bcast(Test_Multi_Callbacks, 1, MPI_INTEGER, 0, zoltan_get_global_comm(), ierr)
+  call MPI_Bcast(Test_Local_Partitions, 1, MPI_INTEGER, 0, zoltan_get_global_comm(), ierr)
+  call MPI_Bcast(Test_Drops, 1, MPI_INTEGER, 0, zoltan_get_global_comm(), ierr)
+  call MPI_Bcast(Test_Gen_Files, 1, MPI_INTEGER, 0, zoltan_get_global_comm(), ierr)
+  call MPI_Bcast(Driver_Action, 1, MPI_INTEGER, 0, zoltan_get_global_comm(), ierr)
+  call MPI_Bcast(pio_info%dsk_list_cnt, 1, MPI_INTEGER, 0, zoltan_get_global_comm(), ierr)
+  call MPI_Bcast(pio_info%rdisk, 1, MPI_INTEGER, 0, zoltan_get_global_comm(), ierr)
+  call MPI_Bcast(pio_info%num_dsk_ctrlrs, 1, MPI_INTEGER, 0, zoltan_get_global_comm(), ierr)
+  call MPI_Bcast(pio_info%pdsk_add_fact, 1, MPI_INTEGER, 0, zoltan_get_global_comm(), ierr)
+  call MPI_Bcast(pio_info%zeros, 1, MPI_INTEGER, 0, zoltan_get_global_comm(), ierr)
+  call MPI_Bcast(pio_info%file_type, 1, MPI_INTEGER, 0, zoltan_get_global_comm(), ierr)
   call MPI_Bcast(pio_info%pdsk_root, len(pio_info%pdsk_root), MPI_CHARACTER, &
-            0, MPI_COMM_WORLD, ierr)
+            0, zoltan_get_global_comm(), ierr)
   call MPI_Bcast(pio_info%pdsk_subdir, len(pio_info%pdsk_root), MPI_CHARACTER, &
-            0, MPI_COMM_WORLD, ierr)
+            0, zoltan_get_global_comm(), ierr)
   call MPI_Bcast(pio_info%pexo_fname, len(pio_info%pdsk_root), MPI_CHARACTER, &
-            0, MPI_COMM_WORLD, ierr)
+            0, zoltan_get_global_comm(), ierr)
 
   if(pio_info%dsk_list_cnt > 0) then
     if(Proc /= 0) then
@@ -434,16 +434,16 @@ type(PARIO_INFO) :: pio_info
     endif
 
     call MPI_Bcast(pio_info%dsk_list, pio_info%dsk_list_cnt, MPI_INTEGER, &
-                   0, MPI_COMM_WORLD, ierr)
+                   0, zoltan_get_global_comm(), ierr)
   endif
 
 !   broadcast the param file name 
   call MPI_Bcast(prob%ztnPrm_file, len(prob%ztnPrm_file), MPI_CHARACTER, &
-       0, MPI_COMM_WORLD, ierr)
+       0, zoltan_get_global_comm(), ierr)
 
 !   and broadcast the problem specifications 
-  call MPI_Bcast(prob%method, len(prob%method), MPI_CHARACTER, 0,MPI_COMM_WORLD,ierr)
-  call MPI_Bcast(prob%num_params, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
+  call MPI_Bcast(prob%method, len(prob%method), MPI_CHARACTER, 0,zoltan_get_global_comm(),ierr)
+  call MPI_Bcast(prob%num_params, 1, MPI_INTEGER, 0, zoltan_get_global_comm(), ierr)
   if (prob%num_params > 0) then
     size = len(prob%params(0)%str(0))
     if (Proc /= 0) then
@@ -451,9 +451,9 @@ type(PARIO_INFO) :: pio_info
     endif
     do i=0,prob%num_params-1
       call MPI_Bcast(prob%params(i)%str(0), size, MPI_CHARACTER, 0, &
-                     MPI_COMM_WORLD, ierr)
+                     zoltan_get_global_comm(), ierr)
       call MPI_Bcast(prob%params(i)%str(1), size, MPI_CHARACTER, 0, &
-                     MPI_COMM_WORLD, ierr)
+                     zoltan_get_global_comm(), ierr)
     end do
   endif
 

--- a/packages/zoltan/src/fdriver/fdr_loadbal.f90
+++ b/packages/zoltan/src/fdriver/fdr_loadbal.f90
@@ -135,7 +135,7 @@ type(PARIO_INFO) :: pio_info
 
 
 !  Allocate space for arrays. 
-  call MPI_Comm_size(MPI_COMM_WORLD, nprocs, ierr)
+  call MPI_Comm_size(zoltan_get_global_comm(), nprocs, ierr)
   allocate(psize(nprocs))
   allocate(partid(nprocs))
   allocate(idx(nprocs))
@@ -143,7 +143,7 @@ type(PARIO_INFO) :: pio_info
 !  
 !   *  Create a load-balancing object.
 !   
-  zz_obj => Zoltan_Create(MPI_COMM_WORLD)
+  zz_obj => Zoltan_Create(zoltan_get_global_comm())
   if (.not.associated(zz_obj)) then
     print *, "fatal:  NULL object returned from Zoltan_Create()"
     run_zoltan = .false.
@@ -168,7 +168,7 @@ type(PARIO_INFO) :: pio_info
 !     note: contents of this file may override the parameters set above 
   if (prob%ztnPrm_file /= "") then  
     call ztnPrm_read_file(zz_obj, prob%ztnPrm_file, &
-         MPI_COMM_WORLD)
+         zoltan_get_global_comm())
   endif
 
 !  
@@ -1027,7 +1027,7 @@ integer(Zoltan_INT), intent(out) :: ierr
   endif
 
 !   get the processor number 
-  call MPI_Comm_rank(MPI_COMM_WORLD, proc, mpierr)
+  call MPI_Comm_rank(zoltan_get_global_comm(), proc, mpierr)
 
   j = 1
   do i = 0, current_elem%adj_len-1
@@ -1239,7 +1239,7 @@ integer(Zoltan_INT) :: test_both
   mesh => Mesh
 
   ! Find maximum partition number across all processors. 
-  call MPI_Comm_size(MPI_COMM_WORLD, Num_Proc, ierr)
+  call MPI_Comm_size(zoltan_get_global_comm(), Num_Proc, ierr)
   max_part = -1
   gmax_part = -1
   do i = 0, mesh%num_elems-1
@@ -1248,7 +1248,7 @@ integer(Zoltan_INT) :: test_both
     endif
   end do
   call MPI_Allreduce(max_part, gmax_part, 1, MPI_INTEGER, MPI_MAX, &
-                     MPI_COMM_WORLD, ierr)
+                     zoltan_get_global_comm(), ierr)
   if ((gmax_part == (Num_Proc-1)) .and. (Test_Local_Partitions == 0)) then
     test_both = 1
   else

--- a/packages/zoltan/src/fdriver/fdr_main.f90
+++ b/packages/zoltan/src/fdriver/fdr_main.f90
@@ -138,8 +138,8 @@ end interface
   call MPI_Init(error)
 
 !   get some machine information 
-  call MPI_Comm_rank(MPI_COMM_WORLD, Proc, error)
-  call MPI_Comm_size(MPI_COMM_WORLD, Num_Proc, error)
+  call MPI_Comm_rank(zoltan_get_global_comm(), Proc, error)
+  call MPI_Comm_size(zoltan_get_global_comm(), Num_Proc, error)
 
   call MPI_Get_processor_name(procname, namelen, error)
   print *,"Processor ",Proc," of ",Num_Proc," on host ",procname(1:namelen)

--- a/packages/zoltan/src/fdriver/fdr_migrate.f90
+++ b/packages/zoltan/src/fdriver/fdr_migrate.f90
@@ -265,7 +265,7 @@ integer(Zoltan_INT) :: lid
   endif
 ! Make sure all procs have the same value.
   call MPI_Allreduce(flag, Use_Edge_Wgts, 1, MPI_LOGICAL, MPI_LOR, &
-                     MPI_COMM_WORLD, mpierr)
+                     zoltan_get_global_comm(), mpierr)
 
 
 !  
@@ -276,7 +276,7 @@ integer(Zoltan_INT) :: lid
   
   if (Mesh%num_elems == 0) return ! No elements to update 
 
-  call MPI_Comm_rank(MPI_COMM_WORLD, proc, mpierr)
+  call MPI_Comm_rank(zoltan_get_global_comm(), proc, mpierr)
 
 !  
 !   *  Build New_Elem_Index array and list of processor assignments.
@@ -515,8 +515,8 @@ integer(Zoltan_INT) :: i, j, k, last, mpierr
 integer(Zoltan_INT) :: adj_elem
 
 
-  call MPI_Comm_rank(MPI_COMM_WORLD, proc, mpierr)
-  call MPI_Comm_size(MPI_COMM_WORLD, num_proc, mpierr)
+  call MPI_Comm_rank(zoltan_get_global_comm(), proc, mpierr)
+  call MPI_Comm_size(zoltan_get_global_comm(), num_proc, mpierr)
 
 !  compact elements array, as the application expects the array to be dense 
   do i = 0, New_Elem_Index_Size-1
@@ -713,7 +713,7 @@ integer(Zoltan_INT), intent(out) :: ierr
   gid = num_gid_entries;
   lid = num_lid_entries;
 
-  call MPI_Comm_rank(MPI_COMM_WORLD, proc, mpierr)
+  call MPI_Comm_rank(zoltan_get_global_comm(), proc, mpierr)
 
 
   if (num_lid_entries.gt.0) then
@@ -862,7 +862,7 @@ integer(Zoltan_INT), intent(out) :: ierr
 
   gid = num_gid_entries;
 
-  call MPI_Comm_rank(MPI_COMM_WORLD, proc, mpierr)
+  call MPI_Comm_rank(zoltan_get_global_comm(), proc, mpierr)
 
 
   idx = in_list(elem_gid(gid), New_Elem_Index_Size, New_Elem_Index)
@@ -1014,7 +1014,7 @@ integer, allocatable :: status(:,:), req(:)
   do i = 0, Mesh%necmap-1
 ! RISKY old style assumption the address of recv_vec(offset) is passed
     call MPI_Irecv(recv_vec(offset), Mesh%ecmap_cnt(i), MPI_INTEGER, &
-                     Mesh%ecmap_id(i), msg_type, MPI_COMM_WORLD, req(i), ierr)
+                     Mesh%ecmap_id(i), msg_type, zoltan_get_global_comm(), req(i), ierr)
     offset = offset + Mesh%ecmap_cnt(i)
   end do
 
@@ -1023,7 +1023,7 @@ integer, allocatable :: status(:,:), req(:)
   do i = 0, Mesh%necmap-1
 ! RISKY old style assumption the address of send_vec(offset) is passed
     call MPI_Send(send_vec(offset), Mesh%ecmap_cnt(i), MPI_INTEGER, &
-                    Mesh%ecmap_id(i), msg_type, MPI_COMM_WORLD, ierr)
+                    Mesh%ecmap_id(i), msg_type, zoltan_get_global_comm(), ierr)
     offset = offset + Mesh%ecmap_cnt(i)
   end do
 

--- a/packages/zoltan/src/fdriver/fdr_mm_io.f90
+++ b/packages/zoltan/src/fdriver/fdr_mm_io.f90
@@ -210,9 +210,9 @@ type(PARIO_INFO) :: pio_info
   endif ! Proc == 0
 
 ! BCast pertinent info to all procs.
-  call MPI_Bcast(mm_ncol, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
-  call MPI_Bcast(mm_nrow, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
-  call MPI_Bcast(mm_nnz, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
+  call MPI_Bcast(mm_ncol, 1, MPI_INTEGER, 0, zoltan_get_global_comm(), ierr)
+  call MPI_Bcast(mm_nrow, 1, MPI_INTEGER, 0, zoltan_get_global_comm(), ierr)
+  call MPI_Bcast(mm_nnz, 1, MPI_INTEGER, 0, zoltan_get_global_comm(), ierr)
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !  Assume linear distribution of vertices.
@@ -318,7 +318,7 @@ type(PARIO_INFO) :: pio_info
   endif
 
 ! Allocate arrays to receive pins.
-  call MPI_Bcast(pindist, Num_Proc+1, MPI_INTEGER, 0, MPI_COMM_WORLD, ierr);
+  call MPI_Bcast(pindist, Num_Proc+1, MPI_INTEGER, 0, zoltan_get_global_comm(), ierr);
   npins = pindist(Proc+1) - pindist(Proc)
   allocate(iidx(0:npins-1),stat=allocstat)
   allocate(jidx(0:npins-1),stat=allocstat)
@@ -330,9 +330,9 @@ type(PARIO_INFO) :: pio_info
     do i = 1, Num_Proc-1
       sendsize = pindist(i+1)-pindist(i)
       call MPI_Send(mm_iidx(pindist(i)), sendsize, MPI_INTEGER, &
-                    i, 1, MPI_COMM_WORLD, ierr)
+                    i, 1, zoltan_get_global_comm(), ierr)
       call MPI_Send(mm_jidx(pindist(i)), sendsize, MPI_INTEGER, &
-                    i, 2, MPI_COMM_WORLD, ierr)
+                    i, 2, zoltan_get_global_comm(), ierr)
     enddo
 !   Copy Proc zero's pins.
     do i = 0, pindist(1)-1
@@ -340,9 +340,9 @@ type(PARIO_INFO) :: pio_info
       jidx(i) = mm_jidx(i)
     enddo
   else
-    call MPI_Recv(iidx, npins, MPI_INTEGER, 0, 1, MPI_COMM_WORLD, &
+    call MPI_Recv(iidx, npins, MPI_INTEGER, 0, 1, zoltan_get_global_comm(), &
                   status, ierr)
-    call MPI_Recv(jidx, npins, MPI_INTEGER, 0, 2, MPI_COMM_WORLD, &
+    call MPI_Recv(jidx, npins, MPI_INTEGER, 0, 2, zoltan_get_global_comm(), &
                   status, ierr)
   endif
      

--- a/packages/zoltan/src/hier/hier.c
+++ b/packages/zoltan/src/hier/hier.c
@@ -1115,14 +1115,14 @@ static int Zoltan_Hier_Initialize_Params(ZZ *zz, HierPartParams *hpp) {
   }
 
   if (hpp->output_level >= HIER_DEBUG_LIST){
-    MPI_Barrier(MPI_COMM_WORLD);
+    MPI_Barrier(zoltan_get_global_comm());
     for (i=0; i < zz->Num_Proc; i++){
       if (i == zz->Proc){
         view_hierarchy_specification(hpp->spec, i, (i==0));
       }
-      MPI_Barrier(MPI_COMM_WORLD);
+      MPI_Barrier(zoltan_get_global_comm());
     }
-    MPI_Barrier(MPI_COMM_WORLD);
+    MPI_Barrier(zoltan_get_global_comm());
   }
 
   return ZOLTAN_OK;

--- a/packages/zoltan/src/include/zoltan_comm.h
+++ b/packages/zoltan/src/include/zoltan_comm.h
@@ -64,6 +64,8 @@ typedef struct Zoltan_Comm_Obj ZOLTAN_COMM_OBJ;
 
 /* function prototypes */
 
+MPI_Comm zoltan_get_global_comm();
+
 int Zoltan_Comm_Create(ZOLTAN_COMM_OBJ**, int, int*, MPI_Comm, int, int*);
 
 int Zoltan_Comm_Copy_To(ZOLTAN_COMM_OBJ **toptr, ZOLTAN_COMM_OBJ *from);

--- a/packages/zoltan/src/include/zoltan_cpp.h
+++ b/packages/zoltan/src/include/zoltan_cpp.h
@@ -75,11 +75,11 @@ public:
 
   // Constructor
 
-  Zoltan (const MPI_Comm &communicator = MPI_COMM_WORLD) 
+  Zoltan (const MPI_Comm &communicator = zoltan_get_global_comm()) 
   {
-  this->ZZ_Ptr = Zoltan_Create(communicator);
+    this->ZZ_Ptr = Zoltan_Create(communicator);
 
-  // int fail = (this->ZZ_Ptr == NULL);  should catch this exception
+    // int fail = (this->ZZ_Ptr == NULL);  should catch this exception
   }
 
   // Copy constructor

--- a/packages/zoltan/src/lb/low_mem_lb_migrate.c
+++ b/packages/zoltan/src/lb/low_mem_lb_migrate.c
@@ -89,8 +89,8 @@ int i, j;
     fprintf(stderr,"\n");
     }
 
-    MPI_Barrier(MPI_COMM_WORLD);
-    MPI_Barrier(MPI_COMM_WORLD);
+    MPI_Barrier(zoltan_get_global_comm());
+    MPI_Barrier(zoltan_get_global_comm());
   }
 
 }

--- a/packages/zoltan/src/order/hsfcOrder.c
+++ b/packages/zoltan/src/order/hsfcOrder.c
@@ -98,7 +98,7 @@ int Zoltan_LocalHSFC_Order(
   ZOLTAN_ID_TYPE tmp, offset=0;
 
   int myrank;
-  MPI_Comm_rank(MPI_COMM_WORLD,&myrank);
+  MPI_Comm_rank(zoltan_get_global_comm(),&myrank);
 
   ZOLTAN_TRACE_ENTER(zz, yo);
 

--- a/packages/zoltan/src/phg/phg_build.c
+++ b/packages/zoltan/src/phg/phg_build.c
@@ -883,7 +883,7 @@ End:
       fflush(stdout);
     }
   
-    rc = MPI_Barrier(MPI_COMM_WORLD);
+    rc = MPI_Barrier(zoltan_get_global_comm());
   }
 #endif
 

--- a/packages/zoltan/src/phg/phg_build.c.improved_calculate_cuts
+++ b/packages/zoltan/src/phg/phg_build.c.improved_calculate_cuts
@@ -881,7 +881,7 @@ End:
       fflush(stdout);
     }
   
-    rc = MPI_Barrier(MPI_COMM_WORLD);
+    rc = MPI_Barrier(zoltan_get_global_comm());
   }
 #endif
 

--- a/packages/zoltan/src/tpls/third_library.c
+++ b/packages/zoltan/src/tpls/third_library.c
@@ -364,11 +364,11 @@ int nproc_y = m2d->comm->nProc_y;
   
       fflush(stderr);
     }
-    MPI_Barrier(MPI_COMM_WORLD);
-    MPI_Barrier(MPI_COMM_WORLD);
+    MPI_Barrier(zoltan_get_global_comm());
+    MPI_Barrier(zoltan_get_global_comm());
   }
-  MPI_Barrier(MPI_COMM_WORLD);
-  MPI_Barrier(MPI_COMM_WORLD);
+  MPI_Barrier(zoltan_get_global_comm());
+  MPI_Barrier(zoltan_get_global_comm());
   return ZOLTAN_OK;
 }
 int Zoltan_Third_Graph_Print(ZZ *zz, ZOLTAN_Third_Graph *gr, char *s)
@@ -416,11 +416,11 @@ me = zz->Proc;
   
       fflush(stderr);
     }
-    MPI_Barrier(MPI_COMM_WORLD);
-    MPI_Barrier(MPI_COMM_WORLD);
+    MPI_Barrier(zoltan_get_global_comm());
+    MPI_Barrier(zoltan_get_global_comm());
   }
-  MPI_Barrier(MPI_COMM_WORLD);
-  MPI_Barrier(MPI_COMM_WORLD);
+  MPI_Barrier(zoltan_get_global_comm());
+  MPI_Barrier(zoltan_get_global_comm());
   return ZOLTAN_OK;
 }
 

--- a/packages/zoltan/src/util/memory_usage/commdup.c
+++ b/packages/zoltan/src/util/memory_usage/commdup.c
@@ -60,21 +60,21 @@ size_t total_leak = 0;
 void test_function()
 {
 MPI_Comm local_comm;
-int myproc, nprocs;               // MPI info wrt MPI_COMM_WORLD.
+int myproc, nprocs;               // MPI info wrt comm from zoltan_get_global_comm().
 size_t oldheap, newheap;
 size_t used, freed;
 static int itercnt = 0;
 int ierr;
 
-  MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
-  MPI_Comm_rank(MPI_COMM_WORLD, &myproc);
+  MPI_Comm_size(zoltan_get_global_comm(), &nprocs);
+  MPI_Comm_rank(zoltan_get_global_comm(), &myproc);
 
-  //  Duplicate MPI_COMM_WORLD to local communicator.
+  //  Duplicate zoltan_get_global_comm() to local communicator.
   oldheap = get_heap_usage();
   std::cout << "KDD " << myproc 
             << " ITER " << itercnt
             << " BEFORE Comm_dup:  " << oldheap << std::endl;
-  ierr = MPI_Comm_dup(MPI_COMM_WORLD,&local_comm);
+  ierr = MPI_Comm_dup(zoltan_get_global_comm(),&local_comm);
   newheap = get_heap_usage();
   used = newheap - oldheap;
   if (ierr != MPI_SUCCESS) std::cout << " ERROR DUP " << ierr << std::endl;
@@ -120,11 +120,11 @@ main(int argc, char *argv[])
   size_t finalheap = get_heap_usage();
 
   int myproc;
-  MPI_Comm_rank(MPI_COMM_WORLD, &myproc);
+  MPI_Comm_rank(zoltan_get_global_comm(), &myproc);
 
   int localmax, globalmax;
   localmax = total_leak;
-  MPI_Allreduce(&localmax, &globalmax, 1, MPI_INTEGER, MPI_MAX, MPI_COMM_WORLD);
+  MPI_Allreduce(&localmax, &globalmax, 1, MPI_INTEGER, MPI_MAX, zoltan_get_global_comm());
 
   MPI_Finalize();
   size_t ending = get_heap_usage();

--- a/packages/zoltan/src/util/memory_usage/commsplit.c
+++ b/packages/zoltan/src/util/memory_usage/commsplit.c
@@ -61,17 +61,17 @@ size_t total_leak = 0;
 void test_function()
 {
 MPI_Comm local_comm;
-int myproc, nprocs;               // MPI info wrt MPI_COMM_WORLD.
+int myproc, nprocs;               // MPI info wrt comm from zoltan_get_global_comm().
 int set;
 size_t oldheap, newheap;
 size_t used, freed;
 static int itercnt = 0;
 int ierr;
 
-  MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
-  MPI_Comm_rank(MPI_COMM_WORLD, &myproc);
+  MPI_Comm_size(zoltan_get_global_comm(), &nprocs);
+  MPI_Comm_rank(zoltan_get_global_comm(), &myproc);
 
-  //  Split MPI_COMM_WORLD to half-sized local communicator.
+  //  Split zoltan_get_global_comm() to half-sized local communicator.
   if (myproc < nprocs/2) set = 0;      // set = LOWERHALF;
   else set = 1;                        // set = UPPERHALF;
 
@@ -79,7 +79,7 @@ int ierr;
   std::cout << "KDD " << myproc 
             << " ITER " << itercnt
             << " BEFORE Comm_split:  " << oldheap << std::endl;
-  ierr = MPI_Comm_split(MPI_COMM_WORLD, set, myproc, &local_comm);
+  ierr = MPI_Comm_split(zoltan_get_global_comm(), set, myproc, &local_comm);
   newheap = get_heap_usage();
   used = newheap - oldheap;
   if (ierr != MPI_SUCCESS) std::cout << " ERROR SPLIT " << ierr << std::endl;
@@ -125,11 +125,11 @@ main(int argc, char *argv[])
   size_t finalheap = get_heap_usage();
 
   int myproc;
-  MPI_Comm_rank(MPI_COMM_WORLD, &myproc);
+  MPI_Comm_rank(zoltan_get_global_comm(), &myproc);
 
   int localmax, globalmax;
   localmax = total_leak;
-  MPI_Allreduce(&localmax, &globalmax, 1, MPI_INTEGER, MPI_MAX, MPI_COMM_WORLD);
+  MPI_Allreduce(&localmax, &globalmax, 1, MPI_INTEGER, MPI_MAX, zoltan_get_global_comm());
 
   MPI_Finalize();
   size_t ending = get_heap_usage();

--- a/packages/zoltan/src/util/memory_usage/rcblike.c
+++ b/packages/zoltan/src/util/memory_usage/rcblike.c
@@ -57,22 +57,22 @@
 void test_function()
 {
 MPI_Comm local_comm, tmp_comm;
-int myproc, nprocs;               // MPI info wrt MPI_COMM_WORLD.
+int myproc, nprocs;               // MPI info wrt comm form zoltan_get_global_comm().
 int local_myproc, local_nprocs;   // MPI info wrt local_comm.
 int set, procmid;
 int commcnt = 0;
 size_t oldheap, newheap;
 static int itercnt = 0;
 
-  MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
-  MPI_Comm_rank(MPI_COMM_WORLD, &myproc);
+  MPI_Comm_size(zoltan_get_global_comm(), &nprocs);
+  MPI_Comm_rank(zoltan_get_global_comm(), &myproc);
 
-  //  Duplicate MPI_COMM_WORLD to local communicator.
+  //  Duplicate zoltan_get_global_comm() to local communicator.
   oldheap = get_heap_usage();
   std::cout << "KDD " << myproc 
             << " ITER " << itercnt
             << " BEFORE Comm_dup:  " << oldheap << std::endl;
-  MPI_Comm_dup(MPI_COMM_WORLD,&local_comm);
+  MPI_Comm_dup(zoltan_get_global_comm(),&local_comm);
   newheap = get_heap_usage();
   std::cout << "KDD " << myproc 
             << " ITER " << itercnt
@@ -148,7 +148,7 @@ main(int argc, char *argv[])
   size_t finalheap = get_heap_usage();
 
   int myproc;
-  MPI_Comm_rank(MPI_COMM_WORLD, &myproc);
+  MPI_Comm_rank(zoltan_get_global_comm(), &myproc);
   std::cout << "KDDEND " << myproc 
             << " Total leaked " << finalheap - initheap
             << " Avg per iteration " << (finalheap - initheap) / NUM_ITER

--- a/packages/zoltan/src/util/network_topology/MPI/test32.c
+++ b/packages/zoltan/src/util/network_topology/MPI/test32.c
@@ -77,9 +77,9 @@ comm_group level_info[NLEVELS];
       fprintf(stderr,"(%d) MPI_Comm_size %s : %s\n",me[0],commName[i],errorstr); 
     }
 #ifdef DEBUG_ME
-    MPI_Barrier(MPI_COMM_WORLD);
+    MPI_Barrier(zoltan_get_global_comm());
     printf("(%d) %s communicator, size %d, my rank %d\n",me[0],commName[i],nprocs[i],me[i]);
-    MPI_Barrier(MPI_COMM_WORLD);
+    MPI_Barrier(zoltan_get_global_comm());
 #endif
   }
 
@@ -104,7 +104,7 @@ comm_group level_info[NLEVELS];
   }
 
 #ifdef DEBUG_ME
-  MPI_Barrier(MPI_COMM_WORLD);
+  MPI_Barrier(zoltan_get_global_comm());
   for (i=0; i < nprocs[0]; i++){
     if (i == me[0]){
       printf("(%d) ranges: %s (%d %d iam %d) %s (%d %d iam %d) %s (%d %d iam %d) %s (%d %d iam %d) \n", 
@@ -114,9 +114,9 @@ comm_group level_info[NLEVELS];
         commName[2], level_part_range[2][0],  level_part_range[2][1], level_part_range[2][0] + me[2],
         commName[3], level_part_range[3][0],  level_part_range[3][1], level_part_range[3][0] + me[3]);
     }
-    MPI_Barrier(MPI_COMM_WORLD);
-    MPI_Barrier(MPI_COMM_WORLD);
-    MPI_Barrier(MPI_COMM_WORLD);
+    MPI_Barrier(zoltan_get_global_comm());
+    MPI_Barrier(zoltan_get_global_comm());
+    MPI_Barrier(zoltan_get_global_comm());
   }
 #endif
 
@@ -134,7 +134,7 @@ comm_group level_info[NLEVELS];
       lval=0;   /* meaningful level in hierarchy */
     }
 
-    MPI_Allreduce(&lval, &gval, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
+    MPI_Allreduce(&lval, &gval, 1, MPI_INT, MPI_SUM, zoltan_get_global_comm());
 
     if (gval < nprocs[0]){
       /* next level in hierarchy is significant for at least some processes */
@@ -143,10 +143,10 @@ comm_group level_info[NLEVELS];
   }
 
 #ifdef DEBUG_ME
-  MPI_Barrier(MPI_COMM_WORLD);
+  MPI_Barrier(zoltan_get_global_comm());
   printf("(%d) %d significant levels %d %d %d %d\n",me[0], num_significant_levels,
   level_number[0], level_number[1], level_number[2], level_number[3]);
-  MPI_Barrier(MPI_COMM_WORLD);
+  MPI_Barrier(zoltan_get_global_comm());
 #endif
 
   /* Save global info about topology */
@@ -155,13 +155,13 @@ comm_group level_info[NLEVELS];
 
   my_part_number = level_part_range[level][0] + me[level];
 
-  MPI_Allgather(&my_part_number, 1, MPI_INT, procToPart, 1, MPI_INT, MPI_COMM_WORLD);
+  MPI_Allgather(&my_part_number, 1, MPI_INT, procToPart, 1, MPI_INT, zoltan_get_global_comm());
 
   for (i=0; i < nprocs[0]; i++){
     partToProc[procToPart[i]] = i;
   }
 
-  level_info[0].comm = MPI_COMM_WORLD;
+  level_info[0].comm = zoltan_get_global_comm();
   level_info[0].name = commName[0];
   level_info[0].nGroups = 1;
   level_info[0].myGroup = 0;
@@ -177,7 +177,7 @@ comm_group level_info[NLEVELS];
     memset((void *)&level_info[i], 0, sizeof(comm_group));
     mine = 0;
 
-    MPI_Allgather(&(level_part_range[level][0]), 1, MPI_INT, buf, 1, MPI_INT, MPI_COMM_WORLD);
+    MPI_Allgather(&(level_part_range[level][0]), 1, MPI_INT, buf, 1, MPI_INT, zoltan_get_global_comm());
     memset(classes, 0, sizeof(int) * nprocs[0]);
     for (j=0; j < nprocs[0]; j++){
       classes[buf[j]]++;
@@ -234,7 +234,7 @@ comm_group level_info[NLEVELS];
                 level_info[i].name, 0, level_info[i].offsets[1]-1);
     }
 
-    ping_pong_test(MPI_COMM_WORLD, me[0], sender, receiver, 100);
+    ping_pong_test(zoltan_get_global_comm(), me[0], sender, receiver, 100);
 
     /* ping pong across an entity */
 
@@ -246,7 +246,7 @@ comm_group level_info[NLEVELS];
     sender = partToProc[0];
     receiver = partToProc[level_info[i].offsets[1]];
 
-    ping_pong_test(MPI_COMM_WORLD, me[0], sender, receiver, 100);
+    ping_pong_test(zoltan_get_global_comm(), me[0], sender, receiver, 100);
   }
 
   MPI_Finalize();
@@ -381,7 +381,7 @@ void ping_pong_test(MPI_Comm comm, int myproc, int senderRank, int receiverRank,
 
         if (myproc == senderRank) {
 
-           MPI_Recv(NULL, 0, MPI_CHAR, receiverRank, 99, MPI_COMM_WORLD, &status);   /* ok to start */
+           MPI_Recv(NULL, 0, MPI_CHAR, receiverRank, 99, zoltan_get_global_comm(), &status);   /* ok to start */
            MPI_Irecv(b, size/8, MPI_DOUBLE, other_proc, j, comm, &request);
   
            t0 = MPI_Wtime();
@@ -393,7 +393,7 @@ void ping_pong_test(MPI_Comm comm, int myproc, int senderRank, int receiverRank,
 
            MPI_Irecv(b, size/8, MPI_DOUBLE, other_proc, j, comm, &request);
 
-           MPI_Send(NULL, 0, MPI_CHAR, senderRank, 99, MPI_COMM_WORLD);    /* ok to start */
+           MPI_Send(NULL, 0, MPI_CHAR, senderRank, 99, zoltan_get_global_comm());    /* ok to start */
   
            MPI_Wait(&request, &status);
 

--- a/packages/zoltan/src/util/network_topology/MPI/topologyVis.c
+++ b/packages/zoltan/src/util/network_topology/MPI/topologyVis.c
@@ -53,7 +53,7 @@
 #define NUM_LEVELS 4
 
 MPI_Comm comm[NUM_LEVELS] = {
-MPI_COMM_WORLD,
+zoltan_get_global_comm(),
 MPI_COMM_NODE,
 MPI_COMM_SOCKET,
 MPI_COMM_CACHE
@@ -93,9 +93,9 @@ char *errorstr;
       fprintf(stderr,"(%d) MPI_Comm_size %s : %s\n",me[0],commName[i],errorstr); 
     }
 #ifdef DEBUG_ME
-    MPI_Barrier(MPI_COMM_WORLD);
+    MPI_Barrier(zoltan_get_global_comm());
     printf("(%d) %s communicator, size %d, my rank %d\n",me[0],commName[i],nprocs[i],me[i]);
-    MPI_Barrier(MPI_COMM_WORLD);
+    MPI_Barrier(zoltan_get_global_comm());
 #endif
   }
 
@@ -118,14 +118,14 @@ char *errorstr;
   }
 
 #ifdef DEBUG_ME
-  MPI_Barrier(MPI_COMM_WORLD);
+  MPI_Barrier(zoltan_get_global_comm());
   printf("(%d) ranges: %s (%d %d iam %d) %s (%d %d iam %d) %s (%d %d iam %d) %s (%d %d iam %d) \n",
   me[0],
   commName[0], level_part_range[0][0],  level_part_range[0][1], level_part_range[0][0] + me[0],
   commName[1], level_part_range[1][0],  level_part_range[1][1], level_part_range[1][0] + me[1],
   commName[2], level_part_range[2][0],  level_part_range[2][1], level_part_range[2][0] + me[2],
   commName[3], level_part_range[3][0],  level_part_range[3][1], level_part_range[3][0] + me[3]);
-  MPI_Barrier(MPI_COMM_WORLD);
+  MPI_Barrier(zoltan_get_global_comm());
 #endif
 
   /* Figure out which levels are significant */
@@ -143,7 +143,7 @@ char *errorstr;
       lval=0;   /* meaningful level in hierarchy */
     }
 
-    MPI_Allreduce(&lval, &gval, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
+    MPI_Allreduce(&lval, &gval, 1, MPI_INT, MPI_SUM, zoltan_get_global_comm());
 
     if (gval < nprocs[0]){
       /* next level in hierarchy is significant for at least some processes */
@@ -158,10 +158,10 @@ char *errorstr;
 #endif
 
 #ifdef DEBUG_ME
-  MPI_Barrier(MPI_COMM_WORLD);
+  MPI_Barrier(zoltan_get_global_comm());
   printf("(%d) %d significant levels %d %d %d %d \n",me[0], num_significant_levels,
   level_number[0], level_number[1], level_number[2], level_number[3]);
-  MPI_Barrier(MPI_COMM_WORLD);
+  MPI_Barrier(zoltan_get_global_comm());
 #endif
 
   last_level = level_number[num_significant_levels-1];
@@ -170,7 +170,7 @@ char *errorstr;
 
   /* Visualize hierarchy */
 
-  MPI_Gather(&my_part_number, 1, MPI_INT, buf, 1, MPI_INT, 0, MPI_COMM_WORLD);
+  MPI_Gather(&my_part_number, 1, MPI_INT, buf, 1, MPI_INT, 0, zoltan_get_global_comm());
 
   if (me[0] == 0){
 
@@ -185,7 +185,7 @@ char *errorstr;
 
     for (i=0; i < num_significant_levels; i++){
       printf("Level %s:\n", commName[level_number[i]]);
-      MPI_Gather(&(level_part_range[level_number[i]][0]), 1, MPI_INT, buf, 1, MPI_INT, 0, MPI_COMM_WORLD);
+      MPI_Gather(&(level_part_range[level_number[i]][0]), 1, MPI_INT, buf, 1, MPI_INT, 0, zoltan_get_global_comm());
       memset(classes, 0, sizeof(int) * nprocs[0]);
       for (j=0; j < nprocs[0]; j++){
         classes[buf[j]]++;
@@ -208,7 +208,7 @@ char *errorstr;
   }
   else{
     for (i=0; i < num_significant_levels; i++){
-      MPI_Gather(&(level_part_range[level_number[i]][0]), 1, MPI_INT, buf, 1, MPI_INT, 0, MPI_COMM_WORLD);
+      MPI_Gather(&(level_part_range[level_number[i]][0]), 1, MPI_INT, buf, 1, MPI_INT, 0, zoltan_get_global_comm());
     }
   }
 

--- a/packages/zoltan/src/util/network_topology/hwloc/node_topology.c
+++ b/packages/zoltan/src/util/network_topology/hwloc/node_topology.c
@@ -96,8 +96,8 @@ int i, j, p;
 int rc, num;
 
   MPI_Init(&argc, &argv);
-  MPI_Comm_size(MPI_COMM_WORLD, &size);
-  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(zoltan_get_global_comm(), &size);
+  MPI_Comm_rank(zoltan_get_global_comm(), &rank);
 
   /* allocate & initialize topology object */
 
@@ -145,7 +145,7 @@ int rc, num;
     }
   }
 
-  MPI_Barrier(MPI_COMM_WORLD);
+  MPI_Barrier(zoltan_get_global_comm());
 
   if (!have_my_cpu && (rank == 0)){
     printf("Warning: Unable to identify each MPI process with its CPU\n");
@@ -161,7 +161,7 @@ int rc, num;
   if (have_my_cpu){
 
     hwloc_cpuset_snprintf(mask, MAX_NAME_LEN-1, binding);
-    MPI_Gather(mask, MAX_NAME_LEN, MPI_CHAR, recvbuf, MAX_NAME_LEN, MPI_CHAR, 0, MPI_COMM_WORLD);
+    MPI_Gather(mask, MAX_NAME_LEN, MPI_CHAR, recvbuf, MAX_NAME_LEN, MPI_CHAR, 0, zoltan_get_global_comm());
  
     if (rank == 0){
       cpuset = (hwloc_cpuset_t*)malloc(sizeof(hwloc_cpuset_t) * size);

--- a/packages/zoltan/src/util/network_topology/hwloc/zoltan_get_topology.c
+++ b/packages/zoltan/src/util/network_topology/hwloc/zoltan_get_topology.c
@@ -114,8 +114,8 @@ hwloc_cpuset_t ancestor_cpuset[MAX_NUM_LEVELS];  /* mask representing cpus in th
 uint64_t lmem[MAX_NUM_LEVELS];           /* memory owned by this object */
 uint64_t tmem[MAX_NUM_LEVELS];           /* owned by this object and all its children */
 
-  MPI_Comm_size(MPI_COMM_WORLD, &size);
-  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(zoltan_get_global_comm(), &size);
+  MPI_Comm_rank(zoltan_get_global_comm(), &rank);
 
   /* allocate & initialize topology object */
 
@@ -309,11 +309,11 @@ uint64_t *local_memory=NULL, *total_memory=NULL;
 char **type_name=NULL;
 
   MPI_Init(&argc, &argv);
-  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_rank(zoltan_get_global_comm(), &rank);
 
   depth = Zoltan_Get_Topology(&branching_degree, &num_cpus, &type_name, &total_memory, &local_memory);
 
-  MPI_Barrier(MPI_COMM_WORLD);
+  MPI_Barrier(zoltan_get_global_comm());
 
   if (rank == 0){
 
@@ -355,7 +355,7 @@ char **type_name=NULL;
 
   /* Allocated cpusets can be freed with hwloc_cpuset_free() */
 
-  MPI_Barrier(MPI_COMM_WORLD);
+  MPI_Barrier(zoltan_get_global_comm());
   MPI_Finalize();
 
   return 0;

--- a/packages/zoltan/src/zz/zz_util.c
+++ b/packages/zoltan/src/zz/zz_util.c
@@ -360,7 +360,7 @@ MPI_Datatype Zoltan_mpi_gno_type()
   if (!zz_mpi_gno_name){
     /* should never happen */
     fprintf(stderr,"Zoltan_mpi_gno_type: It happened\n");
-    MPI_Abort(MPI_COMM_WORLD,99);
+    MPI_Abort(zoltan_get_global_comm(),99);
   }
 
   return zz_mpi_gno_type;
@@ -435,7 +435,7 @@ void Zoltan_write_linux_meminfo(int append, char *msg, int committedOnly)
   char *c=NULL, *next=NULL, *c_end;
   char fbuf[64],buf[2048],label[64],value[64],units[64];
 
-  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_rank(zoltan_get_global_comm(), &rank);
 
   f = open("/proc/meminfo", O_RDONLY);
   if (f == -1) return;


### PR DESCRIPTION
@trilinos/zoltan

Introduce `Global_MPI_Comm` global variable that defaults to `MPI_COMM_WORLD` and use it instead of the hardcoded `MPI_COMM_WORLD`. This PR includes also method which allows for the change of the global communicator.

This PR is a part of the initiative to phase out the use of `MPI_COMM_WOLRD` in Trilinos.