### PR TITLE
NOX: Fix font and formatting in screen output

### DIFF
--- a/packages/nox/src/NOX_Utils.C
+++ b/packages/nox/src/NOX_Utils.C
@@ -222,7 +222,7 @@ NOX::Utils::Sci NOX::Utils::sciformat(double dval, int p)
 
 std::ostream& NOX::operator<<(std::ostream& os, const NOX::Utils::Sci& s)
 {
-  os.setf(std::ios::scientific);
+  os.setf(std::ios::scientific, std::ios::floatfield);
   std::streamsize p = os.precision();
   os.precision(s.p);
   os << std::setw(s.p + 6) << s.d;


### PR DESCRIPTION
@trilinos/nox 

## Motivation

In our application code, we have found non-decimal-format print out of convergence history.

Example:
```
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    0  0x1.6f991b49cf45ep-6       0x0p+0       0x0p+0
    1  0x1.d567c9ebbe25p-31       0x1p+0  0x1.3e6aa2bad478cp-29
    2  0x1.458b21e21267ep-30       0x1p+0  0x1.eb966c999c6dcp-54 (Converged!)
************************************************************************
```

This PR fixes it.


<!--- 
## Stakeholder Feedback
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

<!---

## Testing
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->