### PR TITLE
Framework: Remove LFS image objects

### DIFF
--- a/cmake/SimpleTesting/img/CMake-structure.graffle
+++ b/cmake/SimpleTesting/img/CMake-structure.graffle
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:df060b5017cd4f5e7daa1d83050684d1c5cd2633aa5d7511d328e95bb0628690
-size 205737

--- a/cmake/SimpleTesting/img/CMake-structure.pdf
+++ b/cmake/SimpleTesting/img/CMake-structure.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:74773b511497f713294c27d6355c64c27cdf0e03fc03740c2f9aed0477ee42fd
-size 25870

--- a/cmake/SimpleTesting/img/CMake-structure.png
+++ b/cmake/SimpleTesting/img/CMake-structure.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:da7f79b64d607b9552f9176401a3e516c76062707565e5ca1f4ba30746b5c1e3
-size 193664


### PR DESCRIPTION
Some LFS objects from SimpleTestingRefactor got added.

@trilinos/framework 
@vbrunini 

## Motivation
We don't want to get involved with git LFS at the moment.
