### PR TITLE
Intrepid2: Removing Experimental namespace used for projections (part2)

### DIFF
--- a/packages/intrepid2/CMakeLists.txt
+++ b/packages/intrepid2/CMakeLists.txt
@@ -30,13 +30,6 @@ ELSE()
     OFF)
 ENDIF()   
 
-# temporary flag
-TRIBITS_ADD_OPTION_AND_DEFINE(${PACKAGE_NAME}_KEEP_EXPERIMENTAL_NAMESPACE
-  HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-  "Whether Intrepid2 keeps experimentatl namespace for projections."
-  ON
-)
-
 #
 # C) Add the libraries, tests, and examples
 #

--- a/packages/intrepid2/cmake/Intrepid2_config.h.in
+++ b/packages/intrepid2/cmake/Intrepid2_config.h.in
@@ -9,7 +9,3 @@
 
 /* Define if want to build with KokkosKernels enabled */
 #cmakedefine HAVE_INTREPID2_KOKKOSKERNELS
-
-/* Temporary flag */
-#cmakedefine HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-

--- a/packages/intrepid2/src/Cell/Intrepid2_ProjectedGeometry.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_ProjectedGeometry.hpp
@@ -93,13 +93,8 @@ namespace Intrepid2
       INTREPID2_TEST_FOR_EXCEPTION(projectedBasisNodes.extent_int(2) != spaceDim, std::invalid_argument, "projectedBasisNodes must have shape (C,F,D)");
       
       using ExecutionSpace = typename DeviceType::execution_space;
-#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-      using ProjectionTools  = Experimental::ProjectionTools<DeviceType>; 
-      using ProjectionStruct = Experimental::ProjectionStruct<DeviceType,PointScalar>;
-#else
       using ProjectionTools  = ProjectionTools<DeviceType>; 
       using ProjectionStruct = ProjectionStruct<DeviceType,PointScalar>;
-#endif
       
       ProjectionStruct projectionStruct;
       ordinal_type targetQuadratureDegree(targetHGradBasis->getDegree()), targetDerivativeQuadratureDegree(targetHGradBasis->getDegree());

--- a/packages/intrepid2/src/Discretization/FunctionSpaceTools/Intrepid2_FunctionSpaceToolsDef.hpp
+++ b/packages/intrepid2/src/Discretization/FunctionSpaceTools/Intrepid2_FunctionSpaceToolsDef.hpp
@@ -624,7 +624,7 @@ namespace Intrepid2 {
                                   ">>> ERROR (FunctionSpaceTools::computeFaceMeasure): Input Jacobian container must have rank 4.");
     INTREPID2_TEST_FOR_EXCEPTION( scratch.rank() != 1, std::invalid_argument,
                                   ">>> ERROR (FunctionSpaceTools::computeFaceMeasure): Scratch view imust have rank 1.");
-    INTREPID2_TEST_FOR_EXCEPTION( scratch.span() < inputJac.span(), std::invalid_argument,
+    INTREPID2_TEST_FOR_EXCEPTION( scratch.size() < inputJac.size(), std::invalid_argument,
                                   ">>> ERROR (FunctionSpaceTools::computeFaceMeasure): Scratch storage must be greater than or equal to inputJac's one.");
 #endif
 
@@ -671,7 +671,7 @@ namespace Intrepid2 {
                                   ">>> ERROR (FunctionSpaceTools::computeEdgeMeasure): Input Jacobian container must have rank 4.");
     INTREPID2_TEST_FOR_EXCEPTION( scratch.rank() != 1, std::invalid_argument,
                                   ">>> ERROR (FunctionSpaceTools::computeEdgeMeasure): Scratch view must have a rank 1.");
-    INTREPID2_TEST_FOR_EXCEPTION( scratch.span() < inputJac.span(), std::invalid_argument,
+    INTREPID2_TEST_FOR_EXCEPTION( scratch.size() < inputJac.size(), std::invalid_argument,
                                   ">>> ERROR (FunctionSpaceTools::computeEdgeMeasure): Scratch storage must be greater than or equal to inputJac'one.");
 #endif
 

--- a/packages/intrepid2/src/Projection/Intrepid2_LagrangianInterpolation.hpp
+++ b/packages/intrepid2/src/Projection/Intrepid2_LagrangianInterpolation.hpp
@@ -224,6 +224,13 @@ public:
       const Kokkos::DynRankView<ortValueType,   ortProperties...>  cellOrientations
   );
 };
+
+// temporary fix to allow applications keep using the Experimental namespace. It will be removed soon.
+namespace Experimental {
+template<typename DeviceType>
+class LagrangianInterpolation: public Intrepid2::LagrangianInterpolation<DeviceType>{};
+}
+
 }
 
 // include templated function definitions

--- a/packages/intrepid2/src/Projection/Intrepid2_LagrangianInterpolation.hpp
+++ b/packages/intrepid2/src/Projection/Intrepid2_LagrangianInterpolation.hpp
@@ -41,7 +41,7 @@
 // @HEADER
 
 /** \file   Intrepid2_LagrangianInterpolation.hpp
-    \brief  Header file for the Intrepid2::Experimental::LagrangianInterpolation class.
+    \brief  Header file for the Intrepid2::LagrangianInterpolation class.
     \author Created by Mauro Perego
  */
 #ifndef __INTREPID2_LAGRANGIANINTERPOLATION_HPP__
@@ -103,11 +103,7 @@
 
 namespace Intrepid2 {
 
-#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-namespace Experimental {
-#endif
-
-/** \class  Intrepid2::Experimental::LagrangianInterpolation
+/** \class  Intrepid2::LagrangianInterpolation and LagrangianTools classes
     \brief  A class providing static members to perform Lagrangian interpolation on a finite element.
 
 
@@ -133,64 +129,6 @@ namespace Experimental {
 template<typename DeviceType>
 class LagrangianInterpolation {
 public:
-
-#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-  /** \brief  Computes the points and coefficients associated with the basis DOFs for the reference oriented element
-   *          WARNING: this method will probably be removed when the class will be moved out of the Experimental namespace.
-
-      \code
-      C  - num. cells
-      F  - num. fields
-      D  - spatial dimension
-      \endcode
-
-      \param  dofCoords        [out] - rank-3 view (C,F,D), that will contain coordinates associated with the basis DOFs.
-      \param  dofCoeffs        [out] - variable rank view that will contain coefficients associated with the basis DOFs.
-      \param  cellBasis        [in]  - pointer to the basis for the interpolation
-      \param  cellOrientations [in]  - rank-1 view (C) containing the Orientation objects at each cell
-
-      \remark the output views need to be pre-allocated. <var><b>dofCoeffs</b></var> has rank 2, (C,F) for scalar basis and  3,
-              (C,F,D) for vector basis.
-   */
-  template<typename BasisType,
-  class ...coordsProperties, class ...coeffsProperties,
-  typename ortValueType, class ...ortProperties>
-  static void
-  getDofCoordsAndCoeffs(
-      Kokkos::DynRankView<typename BasisType::scalarType, coordsProperties...> dofCoords,
-      Kokkos::DynRankView<typename BasisType::scalarType, coeffsProperties...> dofCoeffs,
-      const BasisType* cellBasis,
-      const Kokkos::DynRankView<ortValueType,   ortProperties...>  cellOrientations
-  );
-
-  /** \brief  Computes the basis weights of the function interpolation
-   *          WARNING: this method will be removed when the class will be moved out of the Experimental namespace.
-
-      \code
-      C  - num. cells
-      F  - num. fields
-      D  - spatial dimension
-      \endcode
-
-      \param  basisCoeffs         [out] - rank-2 view (C,F) that will contain the basis coefficients of the interpolation.
-      \param  functionAtDofCoords [in]  - variable rank view that contains the function evaluated at DOF coordinates.
-      \param  dofCoeffs           [in]  - variable rank view that contains coefficients associated with the basis DOFs.
-
-      \remark The output views need to be pre-allocated. <var><b>dofCoeffs</b></var> and <var><b>functionAtDofCoords</b></var> have
-              rank 2, (C,F) for scalar basis and  3, (C,F,D) for vector basis.
-              <var><b>functValsAtDofCoords</b></var> contains the function evaluated at the dofCoords and contravariantly transformed
-              to the reference eleemnt.
-              <var><b>dofCoeffs</b></var> are as returned by <var><b>getDofCoordsAndCoeffs</b></var>.
-   */
-  template<typename basisCoeffsViewType,
-  typename funcViewType,
-  typename dofCoeffViewType>
-  static void
-  getBasisCoeffs(basisCoeffsViewType basisCoeffs,
-      const funcViewType functionAtDofCoords,
-      const dofCoeffViewType dofCoeffs);
-#endif
-
 
   /** \brief  Computes the basis weights of the function interpolation.
 
@@ -220,10 +158,6 @@ public:
       const BasisType* cellBasis,
       const ortViewType orts);
   };
-
-#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-}
-#endif
 
 /** \class  Intrepid2::LagrangianTools
   \brief  A class providing tools for Lagrangian elements as static members.

--- a/packages/intrepid2/src/Projection/Intrepid2_LagrangianInterpolationDef.hpp
+++ b/packages/intrepid2/src/Projection/Intrepid2_LagrangianInterpolationDef.hpp
@@ -41,7 +41,7 @@
 // @HEADER
 
 /** \file   Intrepid2_LagrangianInterpolationDef.hpp
-    \brief  Header file for the Intrepid2::Experimental::LagrangianInterpolation containing definitions.
+    \brief  Header file for the Intrepid2::LagrangianInterpolation containing definitions.
     \author Created by Mauro Perego
  */
 
@@ -333,40 +333,6 @@ LagrangianTools<DeviceType>::getOrientedDofCoeffs(
 }
 
 
-#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-namespace Experimental {
-#endif
-
-
-#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-template<typename DeviceType>
-template<typename BasisType,
-class ...coordsProperties, class ...coeffsProperties,
-typename ortValueType, class ...ortProperties>
-void
-LagrangianInterpolation<DeviceType>::getDofCoordsAndCoeffs(
-    Kokkos::DynRankView<typename BasisType::scalarType, coordsProperties...> dofCoords,
-    Kokkos::DynRankView<typename BasisType::scalarType, coeffsProperties...> dofCoeffs,
-    const BasisType* basis,
-    const Kokkos::DynRankView<ortValueType,   ortProperties...>  orts) {
-  LagrangianTools<DeviceType>::getOrientedDofCoords(dofCoords, basis, orts);
-  LagrangianTools<DeviceType>::getOrientedDofCoeffs(dofCoeffs, basis, orts);
-}
-
-
-template<typename DeviceType>
-template<typename basisCoeffsViewType,
-typename funcViewType,
-typename dofCoeffViewType>
-void
-LagrangianInterpolation<DeviceType>::getBasisCoeffs(basisCoeffsViewType basisCoeffs,
-    const funcViewType functionValsAtDofCoords,
-    const dofCoeffViewType dofCoeffs){
-  ArrayTools<DeviceType>::dotMultiplyDataData(basisCoeffs,functionValsAtDofCoords,dofCoeffs);
-}
-#endif
-
-
 template<typename DeviceType>
 template<typename basisCoeffsViewType,
 typename funcViewType,
@@ -390,9 +356,6 @@ LagrangianInterpolation<DeviceType>::getBasisCoeffs(basisCoeffsViewType basisCoe
   OrientationTools<DeviceType>::modifyBasisByOrientationInverse(basisCoeffs, basisCoeffsRef, orts, cellBasis, true);
 }
 
-#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-}
-#endif
 } // Intrepid2 namespace
 
 #endif

--- a/packages/intrepid2/src/Projection/Intrepid2_ProjectionStruct.hpp
+++ b/packages/intrepid2/src/Projection/Intrepid2_ProjectionStruct.hpp
@@ -42,7 +42,7 @@
 // @HEADER
 
 /** \file   Intrepid2_ProjectionStruct.hpp
-    \brief  Header file for the Intrepid2::Experimental::ProjectionStruct.
+    \brief  Header file for the Intrepid2::ProjectionStruct.
     \author Created by Mauro Perego
  */
 #ifndef __INTREPID2_PROJECTIONSTRUCT_HPP__
@@ -56,11 +56,8 @@
 #include <array>
 
 namespace Intrepid2 {
-#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-namespace Experimental {
-#endif
 
-/** \class  Intrepid2::Experimental::ProjectionStruct
+/** \class  Intrepid2::ProjectionStruct
     \brief  An helper class to compute the evaluation points and weights needed for performing projections
 
     In order to perform projections, the basis functions and the target function need to be evaluated
@@ -528,9 +525,7 @@ public:
   ordinal_type maxNumBasisDerivEvalPoints;
   ordinal_type maxNumTargetDerivEvalPoints;
 };
-#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-}
-#endif
+
 } // Intrepid2 namespace
 #include "Intrepid2_ProjectionStructDef.hpp"
 #endif

--- a/packages/intrepid2/src/Projection/Intrepid2_ProjectionStruct.hpp
+++ b/packages/intrepid2/src/Projection/Intrepid2_ProjectionStruct.hpp
@@ -526,6 +526,12 @@ public:
   ordinal_type maxNumTargetDerivEvalPoints;
 };
 
+//Temporary fix, to allow application keep using the Experimental namespace. It will be removed soon.
+namespace Experimental {
+template<typename DeviceType, typename ValueType>
+class ProjectionStruct: public Intrepid2::ProjectionStruct<DeviceType, ValueType>{};
+}
+
 } // Intrepid2 namespace
 #include "Intrepid2_ProjectionStructDef.hpp"
 #endif

--- a/packages/intrepid2/src/Projection/Intrepid2_ProjectionStructDef.hpp
+++ b/packages/intrepid2/src/Projection/Intrepid2_ProjectionStructDef.hpp
@@ -41,7 +41,7 @@
 // @HEADER
 
 /** \file   Intrepid2_ProjectionStructDef.hpp
-    \brief  Header file for the Intrepid2::Experimental::ProjectionStruct containing definitions.
+    \brief  Header file for the Intrepid2::ProjectionStruct containing definitions.
     \author Created by Mauro Perego
  */
 #ifndef __INTREPID2_PROJECTIONSTRUCTDEF_HPP__
@@ -60,10 +60,6 @@
 
 
 namespace Intrepid2 {
-
-#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-namespace Experimental {
-#endif
 
 template<typename DeviceType, typename ValueType>
 template<typename BasisPtrType>
@@ -767,9 +763,7 @@ void ProjectionStruct<DeviceType,ValueType>::createHVolProjectionStruct(const Ba
   allBasisDerivEPoints = view_type("allBasisDerivPoints", numBasisDerivEvalPoints, dim);
   allTargetDerivEPoints = view_type("allTargetDerivPoints", numTargetDerivEvalPoints, dim);
 }
-#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-}
-#endif
+
 }  // Intrepid2 namespace
 #endif
 

--- a/packages/intrepid2/src/Projection/Intrepid2_ProjectionTools.hpp
+++ b/packages/intrepid2/src/Projection/Intrepid2_ProjectionTools.hpp
@@ -369,7 +369,7 @@ public:
   static void
   getHVolBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueType,basisCoeffsProperties...> basisCoeffs,
       const Kokkos::DynRankView<funValsValueType,funValsProperties...> targetAtEvalPoints,
-      const Kokkos::DynRankView<ortValueType,   ortProperties...>  cellOrientations,
+      [[maybe_unused]] const Kokkos::DynRankView<ortValueType,   ortProperties...>  cellOrientations,
       const BasisType* cellBasis,
       ProjectionStruct<DeviceType, typename BasisType::scalarType> * projStruct);
 

--- a/packages/intrepid2/src/Projection/Intrepid2_ProjectionTools.hpp
+++ b/packages/intrepid2/src/Projection/Intrepid2_ProjectionTools.hpp
@@ -802,6 +802,12 @@ public:
   
 };
 
+//Temporary fix to allow application keep using the Experimental namespace. It will be removed soon.
+namespace Experimental {
+template<typename DeviceType>
+class ProjectionTools: public Intrepid2::ProjectionTools<DeviceType>{};
+}
+
 } //Intrepid2
 
 

--- a/packages/intrepid2/src/Projection/Intrepid2_ProjectionTools.hpp
+++ b/packages/intrepid2/src/Projection/Intrepid2_ProjectionTools.hpp
@@ -41,7 +41,7 @@
 // @HEADER
 
 /** \file   Intrepid2_ProjectionTools.hpp
-    \brief  Header file for the Intrepid2::Experimental::ProjectionTools.
+    \brief  Header file for the Intrepid2::ProjectionTools.
     \author Created by Mauro Perego
  */
 #ifndef __INTREPID2_PROJECTIONTOOLS_HPP__
@@ -88,13 +88,8 @@
 #endif
 
 namespace Intrepid2 {
-#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-namespace Experimental {
-#endif
 
-
-
-/** \class  Intrepid2::Experimental::ProjectionTools
+/** \class  Intrepid2::ProjectionTools
     \brief  A class providing static members to perform projection-based interpolations:
 
     This class provides tools to perform projection-based interpolations of a target function
@@ -153,66 +148,6 @@ public:
   using MemSpaceType = typename DeviceType::memory_space;
   using EvalPointsType = typename ProjectionStruct<DeviceType, double>::EvalPointsType;
 
-#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-  /** \brief  Computes evaluation points for L2 projection
-   *          WARNING: this function will be removed when the class will be moved out of the namespace Experimental
-
-      \code
-      C  - num. cells
-      P  - num. evaluation points
-      D  - spatial dimension
-      \endcode
-
-      \param  evaluationPoints [out] - rank-3 view (C,P,D) containing the coordinates of the evaluation
-                                       points for the projection at each cell
-      \param  cellOrientations [in]  - rank-1 view (C) containing the Orientation objects at each cell
-      \param  cellBasis        [in]  - pointer to the basis for the projection
-      \param  projStruct       [in]  - pointer to ProjectionStruct object
-      \param  evalPointType    [in]  - enum selecting whether the points should be computed for the basis
-                                       functions or for the target function
-   */
-  template<typename BasisType,
-  typename ortValueType,       class ...ortProperties>
-  static void
-  getL2EvaluationPoints(typename BasisType::ScalarViewType evaluationPoints,
-      const Kokkos::DynRankView<ortValueType,   ortProperties...>  cellOrientations,
-      const BasisType* cellBasis,
-      ProjectionStruct<DeviceType, typename BasisType::scalarType> * projStruct,
-      const EvalPointsType evalPointType = EvalPointsType::TARGET
-  );
-
-  /** \brief  Computes the basis coefficients of the L2 projection of the target function
-
-      \code
-      C  - num. cells
-      F  - num. fields
-      P  - num. evaluation points
-      D  - spatial dimension
-      \endcode
-
-      \param  basisCoeffs         [out] - rank-2 view (C,F) containing the basis coefficients
-      \param  targetAtEvalPoints  [in]  - variable rank view containing the values of the target function
-                                          evaluated at the evaluation points
-      \param  cellOrientations    [in]  - 1-rank view (C) containing the Orientation objects at each cell
-      \param  cellBasis           [in]  - pointer to the basis for the projection
-      \param  projStruct          [in]  - pointer to ProjectionStruct object
-
-      \remark targetAtEvalPoints has rank 2 (C,P) for HGRAD and HVOL elements, and rank 3 (C,P,D)
-              for HCURL and HDIV elements
-   */
-  template<typename basisCoeffsValueType, class ...basisCoeffsProperties,
-  typename funValsValueType, class ...funValsProperties,
-  typename BasisType,
-  typename ortValueType,       class ...ortProperties>
-  static void
-  getL2BasisCoeffs(Kokkos::DynRankView<basisCoeffsValueType,basisCoeffsProperties...> basisCoeffs,
-      const Kokkos::DynRankView<funValsValueType,funValsProperties...> targetAtEvalPoints,
-      const typename BasisType::ScalarViewType evaluationPoints,
-      const Kokkos::DynRankView<ortValueType,   ortProperties...>  cellOrientations,
-      const BasisType* cellBasis,
-      ProjectionStruct<DeviceType, typename BasisType::scalarType> * projStruct);
-
-#endif
 
   /** \brief  Computes the basis coefficients of the L2 projection of the target function
 
@@ -244,32 +179,6 @@ public:
       const BasisType* cellBasis,
       ProjectionStruct<DeviceType, typename BasisType::scalarType> * projStruct);
 
-#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-  /** \brief  Computes evaluation points for local L2 projection
-     for broken HGRAD HCURL HDIV and HVOL spaces
-     WARNING: this function will be removed when the class will be moved out of the namespace Experimental
-
-      \code
-      C  - num. cells
-      P  - num. evaluation points
-      D  - spatial dimension
-      \endcode
-
-      \param  evaluationPoints [out] - rank-3 view (C,P,D) containing the coordinates of the evaluation
-                                       points for the projection at each cell
-      \param  cellBasis        [in]  - pointer to the basis for the projection
-      \param  projStruct       [in]  - pointer to ProjectionStruct object
-      \param  evalPointType    [in]  - enum selecting whether the points should be computed for the basis
-                                       functions or for the target function
-   */
-  template<typename BasisType>
-  static void
-  getL2DGEvaluationPoints(typename BasisType::ScalarViewType evaluationPoints,
-      const BasisType* cellBasis,
-      ProjectionStruct<DeviceType, typename BasisType::scalarType> * projStruct,
-      const EvalPointsType evalPointType = EvalPointsType::TARGET
-  );
-#endif
 
   /** \brief  Computes evaluation points for local L2 projection
      for broken HGRAD HCURL HDIV and HVOL spaces
@@ -305,6 +214,7 @@ public:
       const BasisType* cellBasis,
       ProjectionStruct<DeviceType, typename BasisType::scalarType> * projStruct);
 
+
   /** \brief  Computes evaluation points for local L2 projection
      for broken HGRAD HCURL HDIV and HVOL spaces
 
@@ -333,73 +243,6 @@ public:
       const targetViewType targetAtTargetEPoints,
       const BasisType* cellBasis,
       ProjectionStruct<DeviceType, typename BasisType::scalarType> * projStruct);
-
-#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-  /** \brief  Computes evaluation points for HGrad projection
-   *          WARNING: this function will be removed when the class will be moved out of the namespace Experimental
-
-      \code
-      C  - num. cells
-      P1 - num. evaluation points
-      P2 - num. evaluation points for derivatives
-      D  - spatial dimension
-      \endcode
-
-      \param  evaluationPoints [out] - rank-3 view (C,P1,D) containing the coordinates of the evaluation
-                                       points, at each cell
-      \param  gradEvalPoints   [in]  - rank-3 view (C,P2,D) containing the coordinates of the points
-                                       where to evaluate the function gradients, at each cell
-      \param  cellOrientations [in]  - rank-1 container (C) containing the Orientation objects at each cell
-      \param  cellBasis        [in]  - pointer to the HGRAD basis for the projection
-      \param  projStruct       [in]  - pointer to ProjectionStruct object
-      \param  evalPointType    [in]  - enum selecting whether the points should be computed for the basis
-                                       functions or for the target function
-   */
-  template<typename BasisType, typename OrientationViewType >
-  static void
-  getHGradEvaluationPoints(typename BasisType::ScalarViewType evaluationPoints,
-      typename BasisType::ScalarViewType gradEvalPoints,
-      const OrientationViewType cellOrientations,
-      const BasisType* cellBasis,
-      ProjectionStruct<DeviceType, typename BasisType::scalarType> * projStruct,
-      const EvalPointsType evalPointType = EvalPointsType::TARGET
-  );
-
-  /** \brief  Computes the basis coefficients of the HGrad projection of the target function
-
-      \code
-      C  - num. cells
-      F  - num. fields
-      P1 - num. evaluation points
-      P2 - num. evaluation points for derivatives
-      D  - spatial dimension
-      \endcode
-
-      \param  basisCoeffs                [out] - rank-2 view (C,F) containing the basis coefficients
-      \param  targetAtEvalPoints         [in]  - rank-2 view (C,P1) containing the values of the target function
-                                                 evaluated at the evaluation points
-      \param  targetGradAtGradEvalPoints [in]  - rank-3 view (C,P2,D) view containing the values of the gradient
-                                                 of the target function evaluated at the evaluation points
-      \param  evaluationPoints           [in]  - rank-3 view (C,P1,D) containing the coordinates of the evaluation
-                                                 points, at each cell
-      \param  gradEvalPoints             [in]  - rank-3 view (C,P2,D) containing the coordinates of the points
-                                                 where to evaluate the function gradients, at each cell
-      \param  cellOrientations           [in]  - 1-rank view (C) containing the Orientation objects at each cell
-      \param  cellBasis                  [in]  - pointer to the HGRAD basis for the projection
-      \param  projStruct                 [in]  - pointer to ProjectionStruct object
-   */
-  template<class BasisCoeffsViewType, class TargetValueViewType, class TargetGradViewType,
-           class BasisType, class OrientationViewType>
-  static void
-  getHGradBasisCoeffs(BasisCoeffsViewType basisCoeffs,
-                      const TargetValueViewType targetAtEvalPoints,
-                      const TargetGradViewType targetGradAtGradEvalPoints,
-                      const typename BasisType::ScalarViewType evaluationPoints,
-                      const typename BasisType::ScalarViewType gradEvalPoints,
-                      const OrientationViewType cellOrientations,
-                      const BasisType* cellBasis,
-                      ProjectionStruct<DeviceType, typename BasisType::scalarType> * projStruct);
-#endif
 
   /** \brief  Computes the basis coefficients of the HGrad projection of the target function
 
@@ -432,79 +275,6 @@ public:
                       const BasisType* cellBasis,
                       ProjectionStruct<DeviceType, typename BasisType::scalarType> * projStruct);
 
-#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-  /** \brief  Computes evaluation points for HCurl projection
-   *          WARNING: this function will be removed when the class will be moved out of the namespace Experimental
-
-      \code
-      C  - num. cells
-      P1 - num. evaluation points
-      P2 - num. evaluation points for derivatives
-      D  - spatial dimension
-      \endcode
-
-      \param  evaluationPoints [out] - rank-3 view (C,P1,D) containing the coordinates of the evaluation
-                                       points for the projection at each cell
-      \param  curlEvalPoints   [in]  - rank-3 view (C,P2,D) containing the coordinates of the points
-                                       where to evaluate the function curls, at each cell
-      \param  cellOrientations [in]  - rank-1 view (C) containing the Orientation objects at each cell
-      \param  cellBasis        [in]  - pointer to the HCURL basis for the projection
-      \param  projStruct       [in]  - pointer to ProjectionStruct object
-      \param  evalPointType    [in]  - enum selecting whether the points should be computed for the basis
-                                       functions or for the target function
-   */
-  template<typename BasisType,
-  typename ortValueType,       class ...ortProperties>
-  static void
-  getHCurlEvaluationPoints(typename BasisType::ScalarViewType evaluationPoints,
-      typename BasisType::ScalarViewType curlEvalPoints,
-      const Kokkos::DynRankView<ortValueType,   ortProperties...>  cellOrientations,
-      const BasisType* cellBasis,
-      ProjectionStruct<DeviceType, typename BasisType::scalarType> * projStruct,
-      const EvalPointsType evalPointType = EvalPointsType::TARGET
-  );
-
-
-  /** \brief  Computes the basis coefficients of the HCurl projection of the target function
-
-      \code
-      C  - num. cells
-      F  - num. fields
-      P1 - num. evaluation points
-      P2 - num. evaluation points for derivatives
-      D  - spatial dimension
-      \endcode
-
-      \param  basisCoeffs                [out] - rank-2 view (C,F) containing the basis coefficients
-      \param  targetAtEvalPoints         [in]  - rank-3 view (C,P1,D) containing the values of the target function
-                                                 evaluated at the evaluation points
-      \param  targetcurlAtCurlEvalPoints [in]  - variable rank view containing the values of the curl of the target
-                                                 function evaluated at the evaluation points
-      \param  evaluationPoints           [in]  - rank-3 view (C,P1,D) containing the coordinates of the evaluation
-                                                 points for the projection at each cell
-      \param  curlEvalPoints             [in]  - rank-3 view (C,P2,D) containing the coordinates of the points
-                                                 where to evaluate the function curls, at each cell
-      \param  cellOrientations           [in]  - 1-rank view (C) containing the Orientation objects at each cell
-      \param  cellBasis                  [in]  - pointer to the HCURL basis for the projection
-      \param  projStruct                 [in]  - pointer to ProjectionStruct object
-
-      \remark targetAtCurlEvalPoints has rank 2 (C,P2) in 2D, and rank 3 (C,P2,D) in 3D
-   */
-  template<typename basisCoeffsValueType, class ...basisCoeffsProperties,
-  typename funValsValueType, class ...funValsProperties,
-  typename BasisType,
-  typename ortValueType,       class ...ortProperties>
-  static void
-  getHCurlBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueType,basisCoeffsProperties...> basisCoeffs,
-      const Kokkos::DynRankView<funValsValueType,funValsProperties...> targetAtEvalPoints,
-      const Kokkos::DynRankView<funValsValueType,funValsProperties...> targetCurlAtCurlEvalPoints,
-      const typename BasisType::ScalarViewType evaluationPoints,
-      const typename BasisType::ScalarViewType curlEvalPoints,
-      const Kokkos::DynRankView<ortValueType,   ortProperties...>  cellOrientations,
-      const BasisType* cellBasis,
-      ProjectionStruct<DeviceType, typename BasisType::scalarType> * projStruct);
-
-#endif
 
   /** \brief  Computes the basis coefficients of the HCurl projection of the target function
 
@@ -540,78 +310,6 @@ public:
       const Kokkos::DynRankView<ortValueType,   ortProperties...>  cellOrientations,
       const BasisType* cellBasis,
       ProjectionStruct<DeviceType, typename BasisType::scalarType> * projStruct);
-
-
-#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-  /** \brief  Computes evaluation points for HDiv projection
-   *          WARNING: this function will be removed when the class will be moved out of the namespace Experimental
-
-      \code
-      C  - num. cells
-      P1 - num. evaluation points
-      P2 - num. evaluation points for derivatives
-      D  - spatial dimension
-      \endcode
-
-      \param  evaluationPoints [out] - rank-3 view (C,P1,D) containing the coordinates of the evaluation
-                                       points for the projection at each cell
-      \param  divEvalPoints    [in]  - rank-3 view (C,P2,D) containing the coordinates of the points
-                                       where to evaluate the function divergence, at each cell
-      \param  cellOrientations [in]  - rank-1 view (C) containing the Orientation objects at each cell
-      \param  cellBasis        [in]  - pointer to the HDIV basis for the projection
-      \param  projStruct       [in]  - pointer to ProjectionStruct object
-      \param  evalPointType    [in]  - enum selecting whether the points should be computed for the basis
-                                       functions or for the target function
-   */
-  template<typename BasisType,
-  typename ortValueType,       class ...ortProperties>
-  static void
-  getHDivEvaluationPoints(typename BasisType::ScalarViewType evaluationPoints,
-      typename BasisType::ScalarViewType divEvalPoints,
-      const Kokkos::DynRankView<ortValueType,   ortProperties...>  cellOrientations,
-      const BasisType* cellBasis,
-      ProjectionStruct<DeviceType, typename BasisType::scalarType> * projStruct,
-      const EvalPointsType evalPointType = EvalPointsType::TARGET
-  );
-
-
-  /** \brief  Computes the basis coefficients of the HDiv projection of the target function
-
-      \code
-      C  - num. cells
-      F  - num. fields
-      P1 - num. evaluation points
-      P2 - num. evaluation points for derivatives
-      D  - spatial dimension
-      \endcode
-
-      \param  basisCoeffs              [out] - rank-2 view (C,F) containing the basis coefficients
-      \param  targetAtEvalPoints       [in]  - rank-3 view (C,P1,D) containing the values of the target function
-                                               evaluated at the evaluation points
-      \param  targetDivAtDivEvalPoints [in]  - rank-2 view (C,P2) view containing the values of the divergence
-                                               of the target function evaluated at the evaluation points
-      \param  evaluationPoints         [in]  - rank-3 view (C,P1,D) containing the coordinates of the evaluation
-                                               points, at each cell
-      \param  divEvalPoints            [in]  - rank-3 view (C,P2,D) containing the coordinates of the points
-                                               where to evaluate the function divergence, at each cell
-      \param  cellOrientations         [in]  - 1-rank view (C) containing the Orientation objects at each cell
-      \param  cellBasis                [in]  - pointer to the HDIV basis for the projection
-      \param  projStruct               [in]  - pointer to ProjectionStruct object
-   */
-  template<typename basisCoeffsValueType, class ...basisCoeffsProperties,
-  typename funValsValueType, class ...funValsProperties,
-  typename BasisType,
-  typename ortValueType,       class ...ortProperties>
-  static void
-  getHDivBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueType,basisCoeffsProperties...> basisCoeffs,
-      const Kokkos::DynRankView<funValsValueType,funValsProperties...> targetAtEvalPoints,
-      const Kokkos::DynRankView<funValsValueType,funValsProperties...> targetDivAtDivEvalPoints,
-      const typename BasisType::ScalarViewType evaluationPoints,
-      const typename BasisType::ScalarViewType divEvalPoints,
-      const Kokkos::DynRankView<ortValueType,   ortProperties...>  cellOrientations,
-      const BasisType* cellBasis,
-      ProjectionStruct<DeviceType, typename BasisType::scalarType> * projStruct);
-#endif
   
   /** \brief  Computes the basis coefficients of the HDiv projection of the target function
 
@@ -646,65 +344,6 @@ public:
       const BasisType* cellBasis,
       ProjectionStruct<DeviceType, typename BasisType::scalarType> * projStruct);
 
-#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-  /** \brief  Computes evaluation points for HVol projection
-   *          WARNING: this function will be removed when the class will be moved out of the namespace Experimental
-
-      \code
-      C  - num. cells
-      P  - num. evaluation points
-      D  - spatial dimension
-      \endcode
-
-      \param  evaluationPoints [out] - rank-3 view (C,P,D) containing the coordinates of the evaluation
-                                       points, at each cell
-      \param  cellOrientations [in]  - rank-1 view (C) containing the Orientation objects at each cell
-      \param  cellBasis        [in]  - pointer to the HVOL basis for the projection
-      \param  projStruct       [in]  - pointer to ProjectionStruct object
-      \param  evalPointType    [in]  - enum selecting whether the points should be computed for the basis
-                                       functions or for the target function
-   */
-  template<typename BasisType,
-  typename ortValueType,       class ...ortProperties>
-  static void
-  getHVolEvaluationPoints(typename BasisType::ScalarViewType evaluationPoints,
-      const Kokkos::DynRankView<ortValueType, ortProperties...>  cellOrientations,
-      const BasisType* cellBasis,
-      ProjectionStruct<DeviceType, typename BasisType::scalarType> * projStruct,
-      const EvalPointsType evalPointType = EvalPointsType::TARGET
-  );
-
-
-  /** \brief  Computes the basis coefficients of the HVol projection of the target function
-
-      \code
-      C  - num. cells
-      F  - num. fields
-      P  - num. evaluation points
-      D  - spatial dimension
-      \endcode
-
-      \param  basisCoeffs           [out] - rank-2 view (C,F) containing the basis coefficients
-      \param  targetAtEvalPoints    [in]  - rank-2 view (C,P) containing the values of the target function
-                                            evaluated at the evaluation points
-      \param  evaluationPoints      [in]  - rank-3 view (C,P,D) containing the coordinates of the evaluation
-                                            points, at each cell
-      \param  cellOrientations      [in]  - 1-rank view (C) containing the Orientation objects at each cell
-      \param  cellBasis             [in]  - pointer to the HGRAD basis for the projection
-      \param  projStruct            [in]  - pointer to ProjectionStruct object
-   */
-  template<typename basisCoeffsValueType, class ...basisCoeffsProperties,
-  typename funValsValueType, class ...funValsProperties,
-  typename BasisType,
-  typename ortValueType,       class ...ortProperties>
-  static void
-  getHVolBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueType,basisCoeffsProperties...> basisCoeffs,
-      const Kokkos::DynRankView<funValsValueType,funValsProperties...> targetAtEvalPoints,
-      const typename BasisType::ScalarViewType evaluationPoints,
-      const Kokkos::DynRankView<ortValueType,   ortProperties...>  cellOrientations,
-      const BasisType* cellBasis,
-      ProjectionStruct<DeviceType, typename BasisType::scalarType> * projStruct);
-#endif
 
   /** \brief  Computes the basis coefficients of the HVol projection of the target function
 
@@ -1162,9 +801,7 @@ public:
   };
   
 };
-#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-} //Experimental
-#endif
+
 } //Intrepid2
 
 

--- a/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefHCURL.hpp
+++ b/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefHCURL.hpp
@@ -41,7 +41,7 @@
 // @HEADER
 
 /** \file   Intrepid2_ProjectionToolsDefHCURL.hpp
-    \brief  Header file for the Intrepid2::Experimental::ProjectionTools
+    \brief  Header file for the Intrepid2::ProjectionTools
             containing definitions for HCURL projections.
     \author Created by Mauro Perego
  */
@@ -411,43 +411,6 @@ struct ComputeBasisCoeffsOnCell_HCurl {
 };
 
 } // FunctorsProjectionTools namespace
-
-#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-namespace Experimental {
-
-
-template<typename DeviceType>
-template<typename BasisType,
-typename ortValueType,       class ...ortProperties>
-void
-ProjectionTools<DeviceType>::getHCurlEvaluationPoints(typename BasisType::ScalarViewType ePoints,
-    typename BasisType::ScalarViewType curlEPoints,
-    const Kokkos::DynRankView<ortValueType,   ortProperties...>, //  orts,
-    const BasisType* cellBasis,
-    ProjectionStruct<DeviceType, typename BasisType::scalarType> * projStruct,
-    const EvalPointsType evalPointType) {    
-      RealSpaceTools<DeviceType>::clone(ePoints, projStruct->getAllEvalPoints(evalPointType));
-      RealSpaceTools<DeviceType>::clone(curlEPoints, projStruct->getAllDerivEvalPoints(evalPointType));
-}
-
-template<typename DeviceType>
-template<typename basisCoeffsValueType, class ...basisCoeffsProperties,
-typename funValsValueType, class ...funValsProperties,
-typename BasisType,
-typename ortValueType,class ...ortProperties>
-void
-ProjectionTools<DeviceType>::getHCurlBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueType,basisCoeffsProperties...> basisCoeffs,
-    const Kokkos::DynRankView<funValsValueType,funValsProperties...> targetAtTargetEPoints,
-    const Kokkos::DynRankView<funValsValueType,funValsProperties...> targetCurlAtTargetCurlEPoints,
-    const typename BasisType::ScalarViewType, // targetEPoints,
-    const typename BasisType::ScalarViewType, // targetCurlEPoints,
-    const Kokkos::DynRankView<ortValueType,   ortProperties...>  orts,
-    const BasisType* cellBasis,
-    ProjectionStruct<DeviceType, typename BasisType::scalarType> * projStruct){
-    
-    getHCurlBasisCoeffs(basisCoeffs, targetAtTargetEPoints, targetCurlAtTargetCurlEPoints, orts, cellBasis, projStruct);
-}
-#endif
 
 
 template<typename DeviceType>
@@ -820,9 +783,7 @@ ProjectionTools<DeviceType>::getHCurlBasisCoeffs(Kokkos::DynRankView<basisCoeffs
     delete hgradBasis;
   }
 }
-#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-}
-#endif
+
 }   // Intrepid2 namespace
 
 #endif

--- a/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefHCURL.hpp
+++ b/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefHCURL.hpp
@@ -59,39 +59,63 @@ namespace Intrepid2 {
 
 namespace FunctorsProjectionTools {
 
-template<typename ViewType1, typename ViewType2, typename ViewType3, typename ViewType4>
-struct ComputeBasisCoeffsOnEdges_HCurl {
-  const ViewType1 basisTanAtBasisEPoints_;
+
+template<typename ViewType1, typename ViewType2, typename ViewType3>
+struct ComputeWBasisEdge_HCurl {
+  ViewType1 basisTanAtBasisEPoints_;
+  ViewType1 weightedTanBasisAtBasisEPoints_;
   const ViewType1 basisAtBasisEPoints_;
   const ViewType2 basisEWeights_;
-  const ViewType1 wTanBasisAtBasisEPoints_;
+  const ViewType1 refEdgeTangent_;
+  const ViewType3 tagToOrdinal_;
+  ordinal_type edgeDim_;
+  ordinal_type iedge_;
+  ordinal_type offsetBasis_;
+
+  ComputeWBasisEdge_HCurl(ViewType1 basisTanAtBasisEPoints, ViewType1 weightedTanBasisAtBasisEPoints,
+      ViewType1 basisAtBasisEPoints, ViewType2 basisEWeights,  ViewType1 refEdgeTangent, ViewType3 tagToOrdinal,  
+      ordinal_type edgeDim, ordinal_type iedge, ordinal_type offsetBasis) :
+        basisTanAtBasisEPoints_(basisTanAtBasisEPoints), weightedTanBasisAtBasisEPoints_(weightedTanBasisAtBasisEPoints), basisAtBasisEPoints_(basisAtBasisEPoints),
+        basisEWeights_(basisEWeights), refEdgeTangent_(refEdgeTangent), tagToOrdinal_(tagToOrdinal),
+        edgeDim_(edgeDim), iedge_(iedge), offsetBasis_(offsetBasis) {}
+
+  void
+  KOKKOS_INLINE_FUNCTION
+  operator()(const ordinal_type j, const ordinal_type iq) const {
+    ordinal_type jdof = tagToOrdinal_(edgeDim_, iedge_, j);
+    for(ordinal_type d=0; d <ordinal_type(refEdgeTangent_.extent(0)); ++d)
+      basisTanAtBasisEPoints_(0,j,iq) += refEdgeTangent_(d)*basisAtBasisEPoints_(jdof,offsetBasis_+iq,d);
+    weightedTanBasisAtBasisEPoints_(0,j,iq) = basisTanAtBasisEPoints_(0,j,iq)*basisEWeights_(iq);
+  }
+};
+
+template<typename ViewType1, typename ViewType2, typename ViewType3, typename ViewType4>
+struct ComputeBasisCoeffsOnEdges_HCurl {
   const ViewType2 targetEWeights_;
   const ViewType1 basisAtTargetEPoints_;
   const ViewType1 wTanBasisAtTargetEPoints_;
   const ViewType3 tagToOrdinal_;
   const ViewType4 targetAtTargetEPoints_;
   const ViewType1 targetTanAtTargetEPoints_;
-  const ViewType1 refEdgesTangent_;
+  const ViewType1 refEdgeTangent_;
   ordinal_type edgeCardinality_;
-  ordinal_type offsetBasis_;
   ordinal_type offsetTarget_;
   ordinal_type edgeDim_;
   ordinal_type dim_;
   ordinal_type iedge_;
 
-  ComputeBasisCoeffsOnEdges_HCurl(const ViewType1 basisTanAtBasisEPoints,
-      const ViewType1 basisAtBasisEPoints, const ViewType2 basisEWeights,  const ViewType1 wTanBasisAtBasisEPoints,   const ViewType2 targetEWeights,
+  ComputeBasisCoeffsOnEdges_HCurl(
+      const ViewType2 targetEWeights,
       const ViewType1 basisAtTargetEPoints, const ViewType1 wTanBasisAtTargetEPoints, const ViewType3 tagToOrdinal,
       const ViewType4 targetAtTargetEPoints, const ViewType1 targetTanAtTargetEPoints,
-      const ViewType1 refEdgesTangent, ordinal_type edgeCardinality, ordinal_type offsetBasis,
+      const ViewType1 refEdgeTangent, ordinal_type edgeCardinality,
       ordinal_type offsetTarget, ordinal_type edgeDim,
       ordinal_type dim, ordinal_type iedge) :
-        basisTanAtBasisEPoints_(basisTanAtBasisEPoints),
-        basisAtBasisEPoints_(basisAtBasisEPoints), basisEWeights_(basisEWeights), wTanBasisAtBasisEPoints_(wTanBasisAtBasisEPoints), targetEWeights_(targetEWeights),
+        targetEWeights_(targetEWeights),
         basisAtTargetEPoints_(basisAtTargetEPoints), wTanBasisAtTargetEPoints_(wTanBasisAtTargetEPoints),
         tagToOrdinal_(tagToOrdinal), targetAtTargetEPoints_(targetAtTargetEPoints),
         targetTanAtTargetEPoints_(targetTanAtTargetEPoints),
-        refEdgesTangent_(refEdgesTangent), edgeCardinality_(edgeCardinality), offsetBasis_(offsetBasis),
+        refEdgeTangent_(refEdgeTangent), edgeCardinality_(edgeCardinality),
         offsetTarget_(offsetTarget), edgeDim_(edgeDim), dim_(dim), iedge_(iedge)
   {}
 
@@ -99,61 +123,53 @@ struct ComputeBasisCoeffsOnEdges_HCurl {
   KOKKOS_INLINE_FUNCTION
   operator()(const ordinal_type ic) const {
 
-    ordinal_type numBasisEPoints = basisEWeights_.extent(0);
     ordinal_type numTargetEPoints = targetEWeights_.extent(0);
+    typename ViewType1::value_type  tmp = 0; 
     for(ordinal_type j=0; j <edgeCardinality_; ++j) {
       ordinal_type jdof = tagToOrdinal_(edgeDim_, iedge_, j);
-      for(ordinal_type iq=0; iq <numBasisEPoints; ++iq) {
-        for(ordinal_type d=0; d <dim_; ++d)
-          basisTanAtBasisEPoints_(ic,j,iq) += refEdgesTangent_(iedge_,d)*basisAtBasisEPoints_(ic,jdof,offsetBasis_+iq,d);
-        wTanBasisAtBasisEPoints_(ic,j,iq) = basisTanAtBasisEPoints_(ic,j,iq)*basisEWeights_(iq);
-      }
-
       for(ordinal_type iq=0; iq <numTargetEPoints; ++iq) {
-        typename ViewType2::value_type  tmp = 0;
+        tmp = 0;
         for(ordinal_type d=0; d <dim_; ++d)
-          tmp += refEdgesTangent_(iedge_,d)*basisAtTargetEPoints_(ic,jdof,offsetTarget_+iq,d);
+          tmp += refEdgeTangent_(d)*basisAtTargetEPoints_(jdof,offsetTarget_+iq,d);
         wTanBasisAtTargetEPoints_(ic,j,iq) = tmp*targetEWeights_(iq);
       }
     }
     for(ordinal_type iq=0; iq <numTargetEPoints; ++iq)
       for(ordinal_type d=0; d <dim_; ++d)
-        targetTanAtTargetEPoints_(ic,iq) += refEdgesTangent_(iedge_,d)*targetAtTargetEPoints_(ic,offsetTarget_+iq,d);
+        targetTanAtTargetEPoints_(ic,iq) += refEdgeTangent_(d)*targetAtTargetEPoints_(ic,offsetTarget_+iq,d);
   }
 };
 
 
 template<typename ViewType1, typename ViewType2, typename ViewType3, typename ViewType4,
-typename ViewType5, typename ViewType6, typename ViewType7, typename ViewType8>
+typename ViewType5>
 struct ComputeBasisCoeffsOnFaces_HCurl {
   const ViewType1 basisCoeffs_;
-  const ViewType2 orts_;
-  const ViewType3 negPartialProjTan_;
-  const ViewType3 negPartialProjCurlNormal_;
-  const ViewType3 hgradBasisGradAtBasisEPoints_;
-  const ViewType3 wHgradBasisGradAtBasisEPoints_;
-  const ViewType3 basisCurlAtBasisCurlEPoints_;
-  const ViewType3 basisCurlNormalAtBasisCurlEPoints_;
-  const ViewType3 basisAtBasisEPoints_;
-  const ViewType3 normalTargetCurlAtTargetEPoints_;
-  const ViewType3 basisTanAtBasisEPoints_;
-  const ViewType3 hgradBasisGradAtTargetEPoints_;
-  const ViewType3 wHgradBasisGradAtTargetEPoints_;
-  const ViewType3 wNormalBasisCurlAtBasisCurlEPoints_;
-  const ViewType3 basisCurlAtTargetCurlEPoints_;
-  const ViewType3 wNormalBasisCurlBasisAtTargetCurlEPoints_;
-  const ViewType4 targetAtTargetEPoints_;
-  const ViewType3 targetTanAtTargetEPoints_;
-  const ViewType4 targetCurlAtTargetCurlEPoints_;
-  const ViewType5 basisEWeights_;
-  const ViewType5 targetEWeights_;
-  const ViewType5 basisCurlEWeights_;
-  const ViewType5 targetCurlEWeights_;
-  const ViewType6 tagToOrdinal_;
-  const ViewType6 hGradTagToOrdinal_;
-  const ViewType7 faceParametrization_;
-  const ViewType8 computedDofs_;
-  unsigned refTopologyKey_;
+  const ViewType1 negPartialProjTan_;
+  const ViewType1 negPartialProjCurlNormal_;
+  const ViewType1 hgradBasisGradAtBasisEPoints_;
+  const ViewType1 wHgradBasisGradAtBasisEPoints_;
+  const ViewType1 basisCurlAtBasisCurlEPoints_;
+  const ViewType1 basisCurlNormalAtBasisCurlEPoints_;
+  const ViewType1 basisAtBasisEPoints_;
+  const ViewType1 normalTargetCurlAtTargetEPoints_;
+  const ViewType1 basisTanAtBasisEPoints_;
+  const ViewType1 hgradBasisGradAtTargetEPoints_;
+  const ViewType1 wHgradBasisGradAtTargetEPoints_;
+  const ViewType1 wNormalBasisCurlAtBasisCurlEPoints_;
+  const ViewType1 basisCurlAtTargetCurlEPoints_;
+  const ViewType1 wNormalBasisCurlBasisAtTargetCurlEPoints_;
+  const ViewType2 targetAtTargetEPoints_;
+  const ViewType1 targetTanAtTargetEPoints_;
+  const ViewType2 targetCurlAtTargetCurlEPoints_;
+  const ViewType3 basisEWeights_;
+  const ViewType3 targetEWeights_;
+  const ViewType3 basisCurlEWeights_;
+  const ViewType3 targetCurlEWeights_;
+  const ViewType4 tagToOrdinal_;
+  const ViewType4 hGradTagToOrdinal_;
+  const ViewType5 computedDofs_;
+  const ViewType1 refFaceNormal_;
   ordinal_type offsetBasis_;
   ordinal_type offsetBasisCurl_;
   ordinal_type offsetTarget_;
@@ -170,27 +186,27 @@ struct ComputeBasisCoeffsOnFaces_HCurl {
 
 
   ComputeBasisCoeffsOnFaces_HCurl(const ViewType1 basisCoeffs,
-      const ViewType2 orts, const ViewType3 negPartialProjTan, const ViewType3 negPartialProjCurlNormal,
-      const ViewType3 hgradBasisGradAtBasisEPoints, const ViewType3 wHgradBasisGradAtBasisEPoints,
-      const ViewType3 basisCurlAtBasisCurlEPoints, const ViewType3 basisCurlNormalAtBasisCurlEPoints,
-      const ViewType3 basisAtBasisEPoints,
-      const ViewType3 normalTargetCurlAtTargetEPoints,
-      const ViewType3 basisTanAtBasisEPoints,
-      const ViewType3 hgradBasisGradAtTargetEPoints, const ViewType3 wHgradBasisGradAtTargetEPoints,
-      const ViewType3 wNormalBasisCurlAtBasisCurlEPoints, const ViewType3 basisCurlAtTargetCurlEPoints,
-      const ViewType3 wNormalBasisCurlBasisAtTargetCurlEPoints, const ViewType4 targetAtTargetEPoints,
-      const ViewType3 targetTanAtTargetEPoints, const ViewType4 targetCurlAtTargetCurlEPoints,
-      const ViewType5 basisEWeights, const ViewType5 targetEWeights,
-      const ViewType5 basisCurlEWeights, const ViewType5 targetCurlEWeights, const ViewType6 tagToOrdinal,
-      const ViewType6 hGradTagToOrdinal, const ViewType7 faceParametrization,
-      const ViewType8 computedDofs, unsigned refTopologyKey, ordinal_type offsetBasis,
+      const ViewType1 negPartialProjTan, const ViewType1 negPartialProjCurlNormal,
+      const ViewType1 hgradBasisGradAtBasisEPoints, const ViewType1 wHgradBasisGradAtBasisEPoints,
+      const ViewType1 basisCurlAtBasisCurlEPoints, const ViewType1 basisCurlNormalAtBasisCurlEPoints,
+      const ViewType1 basisAtBasisEPoints,
+      const ViewType1 normalTargetCurlAtTargetEPoints,
+      const ViewType1 basisTanAtBasisEPoints,
+      const ViewType1 hgradBasisGradAtTargetEPoints, const ViewType1 wHgradBasisGradAtTargetEPoints,
+      const ViewType1 wNormalBasisCurlAtBasisCurlEPoints, const ViewType1 basisCurlAtTargetCurlEPoints,
+      const ViewType1 wNormalBasisCurlBasisAtTargetCurlEPoints, const ViewType2 targetAtTargetEPoints,
+      const ViewType1 targetTanAtTargetEPoints, const ViewType2 targetCurlAtTargetCurlEPoints,
+      const ViewType3 basisEWeights, const ViewType3 targetEWeights,
+      const ViewType3 basisCurlEWeights, const ViewType3 targetCurlEWeights, const ViewType4 tagToOrdinal,
+      const ViewType4 hGradTagToOrdinal, const ViewType5 computedDofs, 
+      const ViewType1 refFaceNormal , ordinal_type offsetBasis,
       ordinal_type offsetBasisCurl, ordinal_type offsetTarget,
       ordinal_type offsetTargetCurl, ordinal_type iface,
       ordinal_type hgradCardinality, ordinal_type numFaces,
       ordinal_type numFaceDofs, ordinal_type numEdgeDofs,
       ordinal_type faceDim, ordinal_type dim):
         basisCoeffs_(basisCoeffs),
-        orts_(orts),  negPartialProjTan_(negPartialProjTan),  negPartialProjCurlNormal_(negPartialProjCurlNormal),
+        negPartialProjTan_(negPartialProjTan),  negPartialProjCurlNormal_(negPartialProjCurlNormal),
         hgradBasisGradAtBasisEPoints_(hgradBasisGradAtBasisEPoints),  wHgradBasisGradAtBasisEPoints_(wHgradBasisGradAtBasisEPoints),
         basisCurlAtBasisCurlEPoints_(basisCurlAtBasisCurlEPoints),  basisCurlNormalAtBasisCurlEPoints_(basisCurlNormalAtBasisCurlEPoints),
         basisAtBasisEPoints_(basisAtBasisEPoints),
@@ -201,8 +217,8 @@ struct ComputeBasisCoeffsOnFaces_HCurl {
         targetTanAtTargetEPoints_(targetTanAtTargetEPoints),  targetCurlAtTargetCurlEPoints_(targetCurlAtTargetCurlEPoints),
         basisEWeights_(basisEWeights),  targetEWeights_(targetEWeights),
         basisCurlEWeights_(basisCurlEWeights), targetCurlEWeights_(targetCurlEWeights),  tagToOrdinal_(tagToOrdinal),
-        hGradTagToOrdinal_(hGradTagToOrdinal), faceParametrization_(faceParametrization),
-        computedDofs_(computedDofs), refTopologyKey_(refTopologyKey), offsetBasis_(offsetBasis),
+        hGradTagToOrdinal_(hGradTagToOrdinal), computedDofs_(computedDofs),
+        refFaceNormal_(refFaceNormal), offsetBasis_(offsetBasis),
         offsetBasisCurl_(offsetBasisCurl), offsetTarget_(offsetTarget),
         offsetTargetCurl_(offsetTargetCurl), iface_(iface),
         hgradCardinality_(hgradCardinality), numFaces_(numFaces),
@@ -213,15 +229,8 @@ struct ComputeBasisCoeffsOnFaces_HCurl {
   KOKKOS_INLINE_FUNCTION
   operator()(const ordinal_type ic) const {
 
-    ordinal_type fOrt[6];
-    orts_(ic).getFaceOrientation(fOrt, numFaces_);
-
-    ordinal_type ort = fOrt[iface_];
-
-    typename ViewType3::value_type data[3*3];
-    auto tangentsAndNormal = ViewType3(data, dim_, dim_);
-    Impl::OrientationTools::getRefSideTangentsAndNormal(tangentsAndNormal, faceParametrization_,refTopologyKey_, iface_, ort);
-    typename ViewType3::value_type n[3] = {tangentsAndNormal(2,0), tangentsAndNormal(2,1), tangentsAndNormal(2,2)};
+    typename ViewType1::value_type n[3] = {refFaceNormal_(0), refFaceNormal_(1), refFaceNormal_(2)};
+    typename ViewType1::value_type tmp=0;
 
     ordinal_type numBasisEPoints = basisEWeights_.extent(0);
     ordinal_type numTargetEPoints = targetEWeights_.extent(0);
@@ -253,22 +262,24 @@ struct ComputeBasisCoeffsOnFaces_HCurl {
           ordinal_type dp1 = (d+1) % dim_;
           ordinal_type dp2 = (d+2) % dim_;
           // basis \times n
-          basisTanAtBasisEPoints_(ic,j,iq,d) = basisAtBasisEPoints_(ic,jdof,offsetBasis_+iq,dp1)*n[dp2] - basisAtBasisEPoints_(ic,jdof,offsetBasis_+iq,dp2)*n[dp1];
+          basisTanAtBasisEPoints_(0,j,iq,d) = basisAtBasisEPoints_(jdof,offsetBasis_+iq,dp1)*n[dp2] - basisAtBasisEPoints_(jdof,offsetBasis_+iq,dp2)*n[dp1];
         }
       }
       //Note: we are not considering the jacobian of the orientation map for normals since it is simply a scalar term for the integrals and it does not affect the projection
       for(ordinal_type iq=0; iq <numBasisCurlEPoints; ++iq) {
+        tmp=0;
         for(ordinal_type d=0; d <dim_; ++d)
-          basisCurlNormalAtBasisCurlEPoints_(ic,j,iq) += n[d]*basisCurlAtBasisCurlEPoints_(ic,jdof,offsetBasisCurl_+iq,d);
-        wNormalBasisCurlAtBasisCurlEPoints_(ic,j,iq) = basisCurlNormalAtBasisCurlEPoints_(ic,j,iq) * basisCurlEWeights_(iq);
+          tmp += n[d]*basisCurlAtBasisCurlEPoints_(jdof,offsetBasisCurl_+iq,d);
+        basisCurlNormalAtBasisCurlEPoints_(0,j,iq) = tmp;
+        wNormalBasisCurlAtBasisCurlEPoints_(ic,j,iq) = tmp * basisCurlEWeights_(iq);
       }
 
       ordinal_type numTargetCurlEPoints = targetCurlEWeights_.extent(0);
       for(ordinal_type iq=0; iq <numTargetCurlEPoints; ++iq) {
-        typename ViewType3::value_type tmp=0;
-        // target \times n  
+        tmp=0;
+        // target \cdot n  
         for(ordinal_type d=0; d <dim_; ++d)
-          tmp += n[d]*basisCurlAtTargetCurlEPoints_(ic,jdof,offsetTargetCurl_+iq,d);
+          tmp += n[d]*basisCurlAtTargetCurlEPoints_(jdof,offsetTargetCurl_+iq,d);
         wNormalBasisCurlBasisAtTargetCurlEPoints_(ic,j,iq) = tmp*targetCurlEWeights_(iq);
       }
     }
@@ -279,9 +290,9 @@ struct ComputeBasisCoeffsOnFaces_HCurl {
         for(ordinal_type d=0; d <dim_; ++d) {
           ordinal_type dp1 = (d+1) % dim_;
           ordinal_type dp2 = (d+2) % dim_;
-          negPartialProjCurlNormal_(ic,iq) -=  n[d]*basisCoeffs_(ic,jdof)*basisCurlAtBasisCurlEPoints_(ic,jdof,offsetBasisCurl_+iq,d);
+          negPartialProjCurlNormal_(ic,iq) -=  n[d]*basisCoeffs_(ic,jdof)*basisCurlAtBasisCurlEPoints_(jdof,offsetBasisCurl_+iq,d);
           // basis \times n
-          negPartialProjTan_(ic,iq,d) -=  (basisAtBasisEPoints_(ic,jdof,offsetBasis_+iq,dp1)*n[dp2] - basisAtBasisEPoints_(ic,jdof,offsetBasis_+iq,dp2)*n[dp1])*basisCoeffs_(ic,jdof);
+          negPartialProjTan_(ic,iq,d) -=  (basisAtBasisEPoints_(jdof,offsetBasis_+iq,dp1)*n[dp2] - basisAtBasisEPoints_(jdof,offsetBasis_+iq,dp2)*n[dp1])*basisCoeffs_(ic,jdof);
         }
     }
 
@@ -304,29 +315,29 @@ struct ComputeBasisCoeffsOnFaces_HCurl {
 
 
 template<typename ViewType1, typename ViewType2, typename ViewType3,
-typename ViewType4, typename ViewType5>
+typename ViewType4>
 struct ComputeBasisCoeffsOnCell_HCurl {
   const ViewType1 basisCoeffs_;
-  const ViewType2 negPartialProj_;
-  const ViewType2 negPartialProjCurl_;
-  const ViewType2 cellBasisAtBasisEPoints_;
-  const ViewType2 cellBasisCurlAtBasisCurlEPoints_;
-  const ViewType2 basisAtBasisEPoints_;
-  const ViewType2 hgradBasisGradAtBasisEPoints_;
-  const ViewType2 basisCurlAtBasisCurlEPoints_;
-  const ViewType2 hgradBasisGradAtTargetEPoints_;
-  const ViewType2 basisCurlAtTargetCurlEPoints_;
-  const ViewType3 basisEWeights_;
-  const ViewType3 basisCurlEWeights_;
-  const ViewType2 wHgradBasisGradAtBasisEPoints_;
-  const ViewType2 wBasisCurlAtBasisCurlEPoints_;
-  const ViewType3 targetEWeights_;
-  const ViewType3 targetCurlEWeights_;
-  const ViewType2 wHgradBasisGradAtTargetEPoints_;
-  const ViewType2 wBasisCurlAtTargetCurlEPoints_;
-  const ViewType4 computedDofs_;
-  const ViewType5 tagToOrdinal_;
-  const ViewType5 hGradTagToOrdinal_;
+  const ViewType1 negPartialProj_;
+  const ViewType1 negPartialProjCurl_;
+  const ViewType1 cellBasisAtBasisEPoints_;
+  const ViewType1 cellBasisCurlAtBasisCurlEPoints_;
+  const ViewType1 basisAtBasisEPoints_;
+  const ViewType1 hgradBasisGradAtBasisEPoints_;
+  const ViewType1 basisCurlAtBasisCurlEPoints_;
+  const ViewType1 hgradBasisGradAtTargetEPoints_;
+  const ViewType1 basisCurlAtTargetCurlEPoints_;
+  const ViewType2 basisEWeights_;
+  const ViewType2 basisCurlEWeights_;
+  const ViewType1 wHgradBasisGradAtBasisEPoints_;
+  const ViewType1 wBasisCurlAtBasisCurlEPoints_;
+  const ViewType2 targetEWeights_;
+  const ViewType2 targetCurlEWeights_;
+  const ViewType1 wHgradBasisGradAtTargetEPoints_;
+  const ViewType1 wBasisCurlAtTargetCurlEPoints_;
+  const ViewType3 computedDofs_;
+  const ViewType4 tagToOrdinal_;
+  const ViewType4 hGradTagToOrdinal_;
   ordinal_type numCellDofs_;
   ordinal_type hgradCardinality_;
   ordinal_type offsetBasis_;
@@ -336,16 +347,16 @@ struct ComputeBasisCoeffsOnCell_HCurl {
   ordinal_type dim_;
   ordinal_type derDim_;
 
-  ComputeBasisCoeffsOnCell_HCurl(const ViewType1 basisCoeffs, ViewType2 negPartialProj,  ViewType2 negPartialProjCurl,
-      const ViewType2 cellBasisAtBasisEPoints, const ViewType2 cellBasisCurlAtBasisCurlEPoints,
-      const ViewType2 basisAtBasisEPoints, const ViewType2 hgradBasisGradAtBasisEPoints, const ViewType2 basisCurlAtBasisCurlEPoints,
-      const ViewType2 hgradBasisGradAtTargetEPoints,   const ViewType2 basisCurlAtTargetCurlEPoints,
-      const ViewType3 basisEWeights,  const ViewType3 basisCurlEWeights,
-      const ViewType2 wHgradBasisGradAtBasisEPoints, const ViewType2 wBasisCurlAtBasisCurlEPoints,
-      const ViewType3 targetEWeights, const ViewType3 targetCurlEWeights,
-      const ViewType2 wHgradBasisGradAtTargetEPoints,
-      const ViewType2 wBasisCurlAtTargetCurlEPoints, const ViewType4 computedDofs,
-      const ViewType5 tagToOrdinal, const ViewType5 hGradTagToOrdinal,
+  ComputeBasisCoeffsOnCell_HCurl(const ViewType1 basisCoeffs, ViewType1 negPartialProj,  ViewType1 negPartialProjCurl,
+      const ViewType1 cellBasisAtBasisEPoints, const ViewType1 cellBasisCurlAtBasisCurlEPoints,
+      const ViewType1 basisAtBasisEPoints, const ViewType1 hgradBasisGradAtBasisEPoints, const ViewType1 basisCurlAtBasisCurlEPoints,
+      const ViewType1 hgradBasisGradAtTargetEPoints,   const ViewType1 basisCurlAtTargetCurlEPoints,
+      const ViewType2 basisEWeights,  const ViewType2 basisCurlEWeights,
+      const ViewType1 wHgradBasisGradAtBasisEPoints, const ViewType1 wBasisCurlAtBasisCurlEPoints,
+      const ViewType2 targetEWeights, const ViewType2 targetCurlEWeights,
+      const ViewType1 wHgradBasisGradAtTargetEPoints,
+      const ViewType1 wBasisCurlAtTargetCurlEPoints, const ViewType3 computedDofs,
+      const ViewType4 tagToOrdinal, const ViewType4 hGradTagToOrdinal,
       ordinal_type numCellDofs, ordinal_type hgradCardinality,
       ordinal_type offsetBasis, ordinal_type offsetBasisCurl, ordinal_type offsetTargetCurl,
       ordinal_type numEdgeFaceDofs, ordinal_type dim, ordinal_type derDim) :
@@ -387,25 +398,25 @@ struct ComputeBasisCoeffsOnCell_HCurl {
       ordinal_type idof = tagToOrdinal_(dim_, 0, j);
       for(ordinal_type d=0; d <dim_; ++d)
         for(ordinal_type iq=0; iq <numBasisPoints; ++iq)
-          cellBasisAtBasisEPoints_(ic,j,iq,d)=basisAtBasisEPoints_(ic,idof,offsetBasis_+iq,d);
+          cellBasisAtBasisEPoints_(0,j,iq,d)=basisAtBasisEPoints_(idof,offsetBasis_+iq,d);
 
       for(ordinal_type d=0; d <derDim_; ++d) {
         for(ordinal_type iq=0; iq <numBasisCurlPoints; ++iq) {
-          cellBasisCurlAtBasisCurlEPoints_(ic,j,iq,d)=basisCurlAtBasisCurlEPoints_(ic,idof,offsetBasisCurl_+iq,d);
-          wBasisCurlAtBasisCurlEPoints_(ic,j,iq,d)=cellBasisCurlAtBasisCurlEPoints_(ic,j,iq,d)*basisCurlEWeights_(iq);
+          cellBasisCurlAtBasisCurlEPoints_(0,j,iq,d)=basisCurlAtBasisCurlEPoints_(idof,offsetBasisCurl_+iq,d);
+          wBasisCurlAtBasisCurlEPoints_(ic,j,iq,d)=cellBasisCurlAtBasisCurlEPoints_(0,j,iq,d)*basisCurlEWeights_(iq);
         }
         for(ordinal_type iq=0; iq <numTargetCurlPoints; ++iq)
-          wBasisCurlAtTargetCurlEPoints_(ic,j,iq,d) = basisCurlAtTargetCurlEPoints_(ic,idof,offsetTargetCurl_+iq,d)*targetCurlEWeights_(iq);
+          wBasisCurlAtTargetCurlEPoints_(ic,j,iq,d) = basisCurlAtTargetCurlEPoints_(idof,offsetTargetCurl_+iq,d)*targetCurlEWeights_(iq);
       }
     }
     for(ordinal_type j=0; j < numEdgeFaceDofs_; ++j) {
       ordinal_type jdof = computedDofs_(j);
       for(ordinal_type d=0; d <derDim_; ++d)
         for(ordinal_type iq=0; iq <numBasisCurlPoints; ++iq)
-          negPartialProjCurl_(ic,iq,d) -=  basisCoeffs_(ic,jdof)*basisCurlAtBasisCurlEPoints_(ic,jdof,offsetBasisCurl_+iq,d);
+          negPartialProjCurl_(ic,iq,d) -=  basisCoeffs_(ic,jdof)*basisCurlAtBasisCurlEPoints_(jdof,offsetBasisCurl_+iq,d);
       for(ordinal_type d=0; d <dim_; ++d)
         for(ordinal_type iq=0; iq <numBasisPoints; ++iq)
-          negPartialProj_(ic,iq,d) -=  basisCoeffs_(ic,jdof)*basisAtBasisEPoints_(ic,jdof,offsetBasis_+iq,d);
+          negPartialProj_(ic,iq,d) -=  basisCoeffs_(ic,jdof)*basisAtBasisEPoints_(jdof,offsetBasis_+iq,d);
     }
   }
 };
@@ -444,9 +455,8 @@ ProjectionTools<DeviceType>::getHCurlBasisCoeffs(Kokkos::DynRankView<basisCoeffs
   ordinal_type numEdges = (cellBasis->getDofCount(1, 0) > 0) ? cellTopo.getEdgeCount() : 0;
   ordinal_type numFaces = (cellBasis->getDofCount(2, 0) > 0) ? cellTopo.getFaceCount() : 0;
 
-  ScalarViewType refEdgesTangent("refEdgesTangent", numEdges, dim);
-  ScalarViewType refFacesTangents("refFaceTangents", numFaces, dim, 2);
-  ScalarViewType refFacesNormal("refFaceNormal", numFaces, dim);
+  ScalarViewType refEdgeTangent("refEdgeTangent", dim);
+  ScalarViewType refFaceNormal("refFaceNormal", dim);
 
   ordinal_type numEdgeDofs(0);
   for(ordinal_type ie=0; ie<numEdges; ++ie)
@@ -466,8 +476,6 @@ ProjectionTools<DeviceType>::getHCurlBasisCoeffs(Kokkos::DynRankView<basisCoeffs
   auto basisEPointsRange = projStruct->getBasisPointsRange();
   auto basisCurlEPointsRange = projStruct->getBasisDerivPointsRange();
 
-  auto refTopologyKey = projStruct->getTopologyKey();
-
   ordinal_type numTotalBasisEPoints = projStruct->getNumBasisEvalPoints(), numTotalBasisCurlEPoints = projStruct->getNumBasisDerivEvalPoints();
   auto basisEPoints = projStruct->getAllEvalPoints(EvalPointsType::BASIS);
   auto basisCurlEPoints = projStruct->getAllDerivEvalPoints(EvalPointsType::BASIS);
@@ -476,39 +484,28 @@ ProjectionTools<DeviceType>::getHCurlBasisCoeffs(Kokkos::DynRankView<basisCoeffs
   auto targetEPoints = projStruct->getAllEvalPoints(EvalPointsType::TARGET);
   auto targetCurlEPoints = projStruct->getAllDerivEvalPoints(EvalPointsType::TARGET);
 
-  ScalarViewType basisAtBasisEPoints("basisAtBasisEPoints",numCells,basisCardinality, numTotalBasisEPoints, dim);
-  ScalarViewType basisAtTargetEPoints("basisAtTargetEPoints",numCells,basisCardinality, numTotalTargetEPoints, dim);
-  {
-    ScalarViewType nonOrientedBasisAtBasisEPoints("nonOrientedBasisAtEPoints",basisCardinality, numTotalBasisEPoints, dim);
-    ScalarViewType nonOrientedBasisAtTargetEPoints("nonOrientedBasisAtTargetEPoints",basisCardinality, numTotalTargetEPoints, dim);
-    cellBasis->getValues(nonOrientedBasisAtTargetEPoints, targetEPoints);
-    cellBasis->getValues(nonOrientedBasisAtBasisEPoints, basisEPoints);
-
-    OrientationTools<DeviceType>::modifyBasisByOrientation(basisAtBasisEPoints, nonOrientedBasisAtBasisEPoints, orts, cellBasis);
-    OrientationTools<DeviceType>::modifyBasisByOrientation(basisAtTargetEPoints, nonOrientedBasisAtTargetEPoints, orts, cellBasis);
-  }
+  ScalarViewType basisAtBasisEPoints("basisAtBasisEPoints",basisCardinality, numTotalBasisEPoints, dim);
+  ScalarViewType basisAtTargetEPoints("basisAtTargetEPoints",basisCardinality, numTotalTargetEPoints, dim);
+  cellBasis->getValues(basisAtTargetEPoints, targetEPoints);
+  cellBasis->getValues(basisAtBasisEPoints, basisEPoints);
 
   ScalarViewType basisCurlAtBasisCurlEPoints;
   ScalarViewType basisCurlAtTargetCurlEPoints;
   if(numTotalBasisCurlEPoints>0) {
     ScalarViewType nonOrientedBasisCurlAtTargetCurlEPoints, nonOrientedBasisCurlAtBasisCurlEPoints;
     if (dim == 3) {
-      basisCurlAtBasisCurlEPoints = ScalarViewType ("basisCurlAtBasisCurlEPoints",numCells,basisCardinality, numTotalBasisCurlEPoints, dim);
-      nonOrientedBasisCurlAtBasisCurlEPoints = ScalarViewType ("nonOrientedBasisCurlAtBasisCurlEPoints", basisCardinality, numTotalBasisCurlEPoints, dim);
-      basisCurlAtTargetCurlEPoints = ScalarViewType("basisCurlAtTargetCurlEPoints",numCells,basisCardinality, numTotalTargetCurlEPoints, dim);
-      nonOrientedBasisCurlAtTargetCurlEPoints = ScalarViewType("nonOrientedBasisCurlAtTargetCurlEPoints",basisCardinality, numTotalTargetCurlEPoints, dim);
+      basisCurlAtBasisCurlEPoints = ScalarViewType ("basisCurlAtBasisCurlEPoints",basisCardinality, numTotalBasisCurlEPoints, dim);
+      basisCurlAtTargetCurlEPoints = ScalarViewType("basisCurlAtTargetCurlEPoints",basisCardinality, numTotalTargetCurlEPoints, dim);
     } else {
-      basisCurlAtBasisCurlEPoints = ScalarViewType ("basisCurlAtBasisCurlEPoints",numCells,basisCardinality, numTotalBasisCurlEPoints);
-      nonOrientedBasisCurlAtBasisCurlEPoints = ScalarViewType ("nonOrientedBasisCurlAtBasisCurlEPoints",basisCardinality, numTotalBasisCurlEPoints);
-      basisCurlAtTargetCurlEPoints = ScalarViewType("basisCurlAtTargetCurlEPoints",numCells,basisCardinality, numTotalTargetCurlEPoints);
-      nonOrientedBasisCurlAtTargetCurlEPoints = ScalarViewType("nonOrientedBasisCurlAtTargetCurlEPoints",basisCardinality, numTotalTargetCurlEPoints);
+      basisCurlAtBasisCurlEPoints = ScalarViewType ("basisCurlAtBasisCurlEPoints",basisCardinality, numTotalBasisCurlEPoints);
+      basisCurlAtTargetCurlEPoints = ScalarViewType("basisCurlAtTargetCurlEPoints",basisCardinality, numTotalTargetCurlEPoints);
     }
 
-    cellBasis->getValues(nonOrientedBasisCurlAtBasisCurlEPoints, basisCurlEPoints,OPERATOR_CURL);
-    cellBasis->getValues(nonOrientedBasisCurlAtTargetCurlEPoints, targetCurlEPoints,OPERATOR_CURL);
-    OrientationTools<DeviceType>::modifyBasisByOrientation(basisCurlAtBasisCurlEPoints, nonOrientedBasisCurlAtBasisCurlEPoints, orts, cellBasis);
-    OrientationTools<DeviceType>::modifyBasisByOrientation(basisCurlAtTargetCurlEPoints, nonOrientedBasisCurlAtTargetCurlEPoints, orts, cellBasis);
+    cellBasis->getValues(basisCurlAtBasisCurlEPoints, basisCurlEPoints,OPERATOR_CURL);
+    cellBasis->getValues(basisCurlAtTargetCurlEPoints, targetCurlEPoints,OPERATOR_CURL);
   }
+
+  ScalarViewType refBasisCoeffs("refBasisCoeffs", basisCoeffs.extent(0), basisCoeffs.extent(1));
 
   ordinal_type computedDofsCount = 0;
   for(ordinal_type ie=0; ie<numEdges; ++ie)  {
@@ -517,36 +514,35 @@ ProjectionTools<DeviceType>::getHCurlBasisCoeffs(Kokkos::DynRankView<basisCoeffs
     ordinal_type numBasisEPoints = range_size(basisEPointsRange(edgeDim, ie));
     ordinal_type numTargetEPoints = range_size(targetEPointsRange(edgeDim, ie));
 
-    {
-      auto refEdgeTan = Kokkos::subview(refEdgesTangent, ie, Kokkos::ALL());
-      CellTools<DeviceType>::getReferenceEdgeTangent(refEdgeTan, ie, cellTopo);
-    }
+    CellTools<DeviceType>::getReferenceEdgeTangent(refEdgeTangent, ie, cellTopo);
 
-    ScalarViewType basisTanAtBasisEPoints("basisTanAtBasisEPoints",numCells,edgeCardinality, numBasisEPoints);
-    ScalarViewType weightedTanBasisAtBasisEPoints("weightedTanBasisAtBasisEPoints",numCells,edgeCardinality, numBasisEPoints);
+    ScalarViewType basisTanAtBasisEPoints("basisTanAtBasisEPoints",1,edgeCardinality, numBasisEPoints);
+    ScalarViewType weightedTanBasisAtBasisEPoints("weightedTanBasisAtBasisEPoints",1,edgeCardinality, numBasisEPoints);
     ScalarViewType weightedTanBasisAtTargetEPoints("weightedTanBasisAtTargetEPoints",numCells,edgeCardinality, numTargetEPoints);
     ScalarViewType targetTanAtTargetEPoints("normalTargetAtTargetEPoints",numCells, numTargetEPoints);
 
     auto targetEWeights = Kokkos::create_mirror_view_and_copy(MemSpaceType(),projStruct->getTargetEvalWeights(edgeDim,ie));
     auto basisEWeights = Kokkos::create_mirror_view_and_copy(MemSpaceType(),projStruct->getBasisEvalWeights(edgeDim,ie));
 
-    //Note: we are not considering the jacobian of the orientation map since it is simply a scalar term for the integrals and it does not affect the projection
     ordinal_type offsetBasis = basisEPointsRange(edgeDim, ie).first;
     ordinal_type offsetTarget = targetEPointsRange(edgeDim, ie).first;
 
-    using functorTypeEdge = FunctorsProjectionTools::ComputeBasisCoeffsOnEdges_HCurl<ScalarViewType,  decltype(basisEWeights), decltype(tagToOrdinal), decltype(targetAtTargetEPoints)>;
-    Kokkos::parallel_for(policy, functorTypeEdge(basisTanAtBasisEPoints,basisAtBasisEPoints,basisEWeights,
-        weightedTanBasisAtBasisEPoints, targetEWeights,
+    using functorTypeWBasisEdge = FunctorsProjectionTools::ComputeWBasisEdge_HCurl<ScalarViewType,  decltype(basisEWeights), decltype(tagToOrdinal)>;
+    Kokkos::parallel_for(Kokkos::MDRangePolicy<ExecSpaceType, Kokkos::Rank<2> >({0,0}, {edgeCardinality,numBasisEPoints}), 
+      functorTypeWBasisEdge(basisTanAtBasisEPoints,weightedTanBasisAtBasisEPoints,basisAtBasisEPoints,basisEWeights,refEdgeTangent,tagToOrdinal,edgeDim,ie,offsetBasis));
+
+    using functorTypeEdge = FunctorsProjectionTools::ComputeBasisCoeffsOnEdges_HCurl<ScalarViewType,  decltype(targetEWeights), decltype(tagToOrdinal), decltype(targetAtTargetEPoints)>;
+    Kokkos::parallel_for(policy, functorTypeEdge(targetEWeights,
         basisAtTargetEPoints, weightedTanBasisAtTargetEPoints, tagToOrdinal,
         targetAtTargetEPoints, targetTanAtTargetEPoints,
-        refEdgesTangent, edgeCardinality, offsetBasis,
+        refEdgeTangent, edgeCardinality,
         offsetTarget, edgeDim,
         dim, ie));
 
-    ScalarViewType edgeMassMat_("edgeMassMat_", numCells, edgeCardinality+1, edgeCardinality+1),
+    ScalarViewType edgeMassMat_("edgeMassMat_", 1, edgeCardinality+1, edgeCardinality+1),
         edgeRhsMat_("rhsMat_", numCells, edgeCardinality+1);
 
-    ScalarViewType eWeights_("eWeights_", numCells, 1, basisEWeights.extent(0)), targetEWeights_("targetEWeights", numCells, 1, targetEWeights.extent(0));
+    ScalarViewType eWeights_("eWeights_", 1, 1, basisEWeights.extent(0)), targetEWeights_("targetEWeights", numCells, 1, targetEWeights.extent(0));
     RealSpaceTools<DeviceType>::clone(eWeights_, basisEWeights);
     RealSpaceTools<DeviceType>::clone(targetEWeights_, targetEWeights);
 
@@ -562,8 +558,8 @@ ProjectionTools<DeviceType>::getHCurlBasisCoeffs(Kokkos::DynRankView<basisCoeffs
     WorkArrayViewType w_("w",numCells, edgeCardinality+1);
 
     auto edgeDofs = Kokkos::subview(tagToOrdinal, edgeDim, ie, range_type(0,edgeCardinality));
-    ElemSystem edgeSystem("edgeSystem", false);
-    edgeSystem.solve(basisCoeffs, edgeMassMat_, edgeRhsMat_, t_, w_, edgeDofs, edgeCardinality, 1);
+    ElemSystem edgeSystem("edgeSystem", true);
+    edgeSystem.solve(refBasisCoeffs, edgeMassMat_, edgeRhsMat_, t_, w_, edgeDofs, edgeCardinality, 1);
 
     auto computedEdgeDofs = Kokkos::subview(computedDofs, range_type(computedDofsCount,computedDofsCount+edgeCardinality));
     deep_copy(computedEdgeDofs, edgeDofs);
@@ -610,8 +606,8 @@ ProjectionTools<DeviceType>::getHCurlBasisCoeffs(Kokkos::DynRankView<basisCoeffs
 
     auto hGradTagToOrdinal = Kokkos::create_mirror_view_and_copy(MemSpaceType(), hgradBasis->getAllDofOrdinal());
 
-    ScalarViewType basisTanAtBasisEPoints("basisTanAtBasisEPoints",numCells,numFaceDofs, numBasisEPoints,dim);
-    ScalarViewType basisCurlNormalAtBasisCurlEPoints("normaBasisCurlAtBasisEPoints",numCells,numFaceDofs, numBasisCurlEPoints);
+    ScalarViewType basisTanAtBasisEPoints("basisTanAtBasisEPoints",1,numFaceDofs, numBasisEPoints,dim);
+    ScalarViewType basisCurlNormalAtBasisCurlEPoints("normaBasisCurlAtBasisEPoints",1,numFaceDofs, numBasisCurlEPoints);
     ScalarViewType wNormalBasisCurlAtBasisCurlEPoints("weightedNormalBasisCurlAtBasisEPoints",numCells,numFaceDofs, numBasisCurlEPoints);
 
     ScalarViewType targetTanAtTargetEPoints("targetTanAtTargetEPoints",numCells, numTargetEPoints, dim);
@@ -633,11 +629,13 @@ ProjectionTools<DeviceType>::getHCurlBasisCoeffs(Kokkos::DynRankView<basisCoeffs
     auto targetEWeights = Kokkos::create_mirror_view_and_copy(MemSpaceType(),projStruct->getTargetEvalWeights(faceDim,iface));
     auto targetCurlEWeights = Kokkos::create_mirror_view_and_copy(MemSpaceType(),projStruct->getTargetDerivEvalWeights(faceDim,iface));
     auto basisCurlEWeights = Kokkos::create_mirror_view_and_copy(MemSpaceType(),projStruct->getBasisDerivEvalWeights(faceDim,iface));
-    const auto topoKey = refTopologyKey(faceDim, iface);
-    using functorTypeFaces = FunctorsProjectionTools::ComputeBasisCoeffsOnFaces_HCurl<decltype(basisCoeffs), decltype(orts), ScalarViewType,  decltype(targetAtTargetEPoints), decltype(basisEWeights),
-        decltype(tagToOrdinal), decltype(subcellParamFace), decltype(computedDofs)>;
-    Kokkos::parallel_for(policy, functorTypeFaces(basisCoeffs,
-        orts, negPartialProjTan, negPartialProjCurlNormal,
+
+    CellTools<DeviceType>::getReferenceFaceNormal(refFaceNormal, iface, cellTopo);
+
+    using functorTypeFaces = FunctorsProjectionTools::ComputeBasisCoeffsOnFaces_HCurl<ScalarViewType,  decltype(targetAtTargetEPoints), decltype(basisEWeights),
+        decltype(tagToOrdinal), decltype(computedDofs)>;
+    Kokkos::parallel_for(policy, functorTypeFaces(refBasisCoeffs,
+        negPartialProjTan, negPartialProjCurlNormal,
         hgradBasisGradAtBasisEPoints, wHgradBasisGradAtBasisEPoints,
         basisCurlAtBasisCurlEPoints, basisCurlNormalAtBasisCurlEPoints,
         basisAtBasisEPoints,
@@ -648,8 +646,8 @@ ProjectionTools<DeviceType>::getHCurlBasisCoeffs(Kokkos::DynRankView<basisCoeffs
         targetTanAtTargetEPoints, targetCurlAtTargetCurlEPoints,
         basisEWeights, targetEWeights,
         basisCurlEWeights, targetCurlEWeights, tagToOrdinal,
-        hGradTagToOrdinal, subcellParamFace,
-        computedDofs, topoKey, offsetBasis,
+        hGradTagToOrdinal,
+        computedDofs, refFaceNormal, offsetBasis,
         offsetBasisCurl, offsetTarget,
         offsetTargetCurl, iface,
         hgradCardinality, numFaces,
@@ -657,12 +655,12 @@ ProjectionTools<DeviceType>::getHCurlBasisCoeffs(Kokkos::DynRankView<basisCoeffs
         faceDim, dim));
 
 
-    ScalarViewType faceMassMat_("faceMassMat_", numCells, numFaceDofs+hgradCardinality, numFaceDofs+hgradCardinality),
+    ScalarViewType faceMassMat_("faceMassMat_", 1, numFaceDofs+hgradCardinality, numFaceDofs+hgradCardinality),
         faceRhsMat_("rhsMat_", numCells, numFaceDofs+hgradCardinality);
     range_type range_H(0, numFaceDofs);
     range_type range_B(numFaceDofs, numFaceDofs+hgradCardinality);
-    FunctionSpaceTools<DeviceType >::integrate(Kokkos::subview(faceMassMat_,Kokkos::ALL(),range_H,range_H), basisCurlNormalAtBasisCurlEPoints, wNormalBasisCurlAtBasisCurlEPoints);
-    FunctionSpaceTools<DeviceType >::integrate(Kokkos::subview(faceMassMat_,Kokkos::ALL(),range_H,range_B), basisTanAtBasisEPoints, wHgradBasisGradAtBasisEPoints);
+    FunctionSpaceTools<DeviceType >::integrate(Kokkos::subview(faceMassMat_,Kokkos::ALL(),range_H,range_H), basisCurlNormalAtBasisCurlEPoints, Kokkos::subview(wNormalBasisCurlAtBasisCurlEPoints, std::make_pair(0,1), Kokkos::ALL(), Kokkos::ALL()) );
+    FunctionSpaceTools<DeviceType >::integrate(Kokkos::subview(faceMassMat_,Kokkos::ALL(),range_H,range_B), basisTanAtBasisEPoints, Kokkos::subview(wHgradBasisGradAtBasisEPoints, std::make_pair(0,1), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()) );
 
     FunctionSpaceTools<DeviceType >::integrate(Kokkos::subview(faceRhsMat_,Kokkos::ALL(),range_H), normalTargetCurlAtTargetEPoints, wNormalBasisCurlBasisAtTargetCurlEPoints);
     FunctionSpaceTools<DeviceType >::integrate(Kokkos::subview(faceRhsMat_,Kokkos::ALL(),range_H), negPartialProjCurlNormal, wNormalBasisCurlAtBasisCurlEPoints,true);
@@ -676,8 +674,8 @@ ProjectionTools<DeviceType>::getHCurlBasisCoeffs(Kokkos::DynRankView<basisCoeffs
     WorkArrayViewType w_("w",numCells, numFaceDofs+hgradCardinality);
 
     auto faceDofs = Kokkos::subview(tagToOrdinal, faceDim, iface, range_type(0,numFaceDofs));
-    ElemSystem faceSystem( "faceSystem", false);
-    faceSystem.solve(basisCoeffs, faceMassMat_, faceRhsMat_, t_, w_, faceDofs, numFaceDofs, hgradCardinality);
+    ElemSystem faceSystem( "faceSystem", true);
+    faceSystem.solve(refBasisCoeffs, faceMassMat_, faceRhsMat_, t_, w_, faceDofs, numFaceDofs, hgradCardinality);
 
     auto computedFaceDofs = Kokkos::subview(computedDofs, range_type(computedDofsCount,computedDofsCount+numFaceDofs));
     deep_copy(computedFaceDofs, faceDofs);
@@ -723,8 +721,8 @@ ProjectionTools<DeviceType>::getHCurlBasisCoeffs(Kokkos::DynRankView<basisCoeffs
     hgradBasis->getValues(hgradBasisGradAtBasisEPoints,Kokkos::subview(basisEPoints, basisEPointsRange(dim, 0), Kokkos::ALL()), OPERATOR_GRAD);
     hgradBasis->getValues(hgradBasisGradAtTargetEPoints,Kokkos::subview(targetEPoints, targetEPointsRange(dim, 0), Kokkos::ALL()),OPERATOR_GRAD);
 
-    ScalarViewType cellBasisAtBasisEPoints("basisCellAtEPoints",numCells,numCellDofs, numBasisEPoints, dim);
-    ScalarViewType cellBasisCurlAtCurlEPoints("cellBasisCurlAtCurlEPoints",numCells,numCellDofs, numBasisCurlEPoints, derDim);
+    ScalarViewType cellBasisAtBasisEPoints("basisCellAtEPoints",1,numCellDofs, numBasisEPoints, dim);
+    ScalarViewType cellBasisCurlAtCurlEPoints("cellBasisCurlAtCurlEPoints",1,numCellDofs, numBasisCurlEPoints, derDim);
     ScalarViewType negPartialProjCurl("negPartialProjCurl", numCells, numBasisEPoints, derDim);
     ScalarViewType negPartialProj("negPartialProj", numCells, numBasisEPoints, dim);
     ScalarViewType wBasisCurlAtCurlEPoints("weightedBasisCurlAtBasisEPoints",numCells,numCellDofs, numBasisCurlEPoints,derDim);
@@ -741,9 +739,9 @@ ProjectionTools<DeviceType>::getHCurlBasisCoeffs(Kokkos::DynRankView<basisCoeffs
 
     auto hGradTagToOrdinal = Kokkos::create_mirror_view_and_copy(MemSpaceType(), hgradBasis->getAllDofOrdinal());
 
-    using functorTypeCell = FunctorsProjectionTools::ComputeBasisCoeffsOnCell_HCurl<decltype(basisCoeffs), ScalarViewType,  decltype(basisEWeights),
+    using functorTypeCell = FunctorsProjectionTools::ComputeBasisCoeffsOnCell_HCurl<ScalarViewType,  decltype(basisEWeights),
         decltype(computedDofs), decltype(tagToOrdinal)>;
-    Kokkos::parallel_for(policy, functorTypeCell(basisCoeffs, negPartialProj, negPartialProjCurl,
+    Kokkos::parallel_for(policy, functorTypeCell(refBasisCoeffs, negPartialProj, negPartialProjCurl,
         cellBasisAtBasisEPoints, cellBasisCurlAtCurlEPoints,
         basisAtBasisEPoints, hgradBasisGradAtBasisEPoints, basisCurlAtBasisCurlEPoints,
         hgradBasisGradAtTargetEPoints,  basisCurlAtTargetCurlEPoints,
@@ -756,13 +754,13 @@ ProjectionTools<DeviceType>::getHCurlBasisCoeffs(Kokkos::DynRankView<basisCoeffs
         offsetBasis, offsetBasisCurl,  offsetTargetCurl,
         numEdgeDofs+numTotalFaceDofs, dim, derDim));
 
-    ScalarViewType cellMassMat_("cellMassMat_", numCells, numCellDofs+hgradCardinality, numCellDofs+hgradCardinality),
+    ScalarViewType cellMassMat_("cellMassMat_", 1, numCellDofs+hgradCardinality, numCellDofs+hgradCardinality),
         cellRhsMat_("rhsMat_", numCells, numCellDofs+hgradCardinality);
 
     range_type range_H(0, numCellDofs);
     range_type range_B(numCellDofs, numCellDofs+hgradCardinality);
-    FunctionSpaceTools<DeviceType >::integrate(Kokkos::subview(cellMassMat_,Kokkos::ALL(),range_H,range_H), cellBasisCurlAtCurlEPoints, wBasisCurlAtCurlEPoints);
-    FunctionSpaceTools<DeviceType >::integrate(Kokkos::subview(cellMassMat_,Kokkos::ALL(),range_H,range_B), cellBasisAtBasisEPoints, wHgradBasisGradAtBasisEPoints);
+    FunctionSpaceTools<DeviceType >::integrate(Kokkos::subview(cellMassMat_,Kokkos::ALL(),range_H,range_H), cellBasisCurlAtCurlEPoints, Kokkos::subview(wBasisCurlAtCurlEPoints, std::make_pair(0,1), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()) );
+    FunctionSpaceTools<DeviceType >::integrate(Kokkos::subview(cellMassMat_,Kokkos::ALL(),range_H,range_B), cellBasisAtBasisEPoints, Kokkos::subview(wHgradBasisGradAtBasisEPoints, std::make_pair(0,1), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()) );
     if(dim==3)
       FunctionSpaceTools<DeviceType >::integrate(Kokkos::subview(cellRhsMat_,Kokkos::ALL(),range_H), Kokkos::subview(targetCurlAtTargetCurlEPoints,Kokkos::ALL(),cellCurlPointsRange,Kokkos::ALL()), wBasisCurlBasisAtTargetCurlEPoints);
     else
@@ -778,10 +776,12 @@ ProjectionTools<DeviceType>::getHCurlBasisCoeffs(Kokkos::DynRankView<basisCoeffs
 
     auto cellDofs = Kokkos::subview(tagToOrdinal, dim, 0, Kokkos::ALL());
     ElemSystem cellSystem( "cellSystem", true);
-    cellSystem.solve(basisCoeffs, cellMassMat_, cellRhsMat_, t_, w_, cellDofs, numCellDofs, hgradCardinality);
+    cellSystem.solve(refBasisCoeffs, cellMassMat_, cellRhsMat_, t_, w_, cellDofs, numCellDofs, hgradCardinality);
 
     delete hgradBasis;
   }
+
+  OrientationTools<DeviceType>::modifyBasisByOrientationInverse(basisCoeffs, refBasisCoeffs, orts, cellBasis, true);
 }
 
 }   // Intrepid2 namespace

--- a/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefHDIV.hpp
+++ b/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefHDIV.hpp
@@ -41,7 +41,7 @@
 // @HEADER
 
 /** \file   Intrepid2_ProjectionToolsDefHDIV.hpp
-    \brief  Header file for the Intrepid2::Experimental::ProjectionTools
+    \brief  Header file for the Intrepid2::ProjectionTools
             containing definitions for HDIV projections.
     \author Created by Mauro Perego
  */
@@ -242,43 +242,6 @@ struct ComputeHCurlBasisCoeffsOnCells_HDiv {
 };
 }  // FunctorsProjectionTools namespace
 
-#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-namespace Experimental {
-
-
-template<typename DeviceType>
-template<typename BasisType,
-typename ortValueType,       class ...ortProperties>
-void
-ProjectionTools<DeviceType>::getHDivEvaluationPoints(typename BasisType::ScalarViewType ePoints,
-    typename BasisType::ScalarViewType divEPoints,
-    const Kokkos::DynRankView<ortValueType,   ortProperties...>,//  orts,
-    const BasisType* cellBasis,
-    ProjectionStruct<DeviceType, typename BasisType::scalarType> * projStruct,
-    const EvalPointsType evalPointType){
-      RealSpaceTools<DeviceType>::clone(ePoints, projStruct->getAllEvalPoints(evalPointType));
-      RealSpaceTools<DeviceType>::clone(divEPoints, projStruct->getAllDerivEvalPoints(evalPointType));
-}
-
-
-template<typename DeviceType>
-template<typename basisCoeffsValueType, class ...basisCoeffsProperties,
-typename funValsValueType, class ...funValsProperties,
-typename BasisType,
-typename ortValueType,class ...ortProperties>
-void
-ProjectionTools<DeviceType>::getHDivBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueType,basisCoeffsProperties...> basisCoeffs,
-    const Kokkos::DynRankView<funValsValueType,funValsProperties...> targetAtEPoints,
-    const Kokkos::DynRankView<funValsValueType,funValsProperties...> targetDivAtDivEPoints,
-    const typename BasisType::ScalarViewType, // targetEPoints,
-    const typename BasisType::ScalarViewType,// divEPoints,
-    const Kokkos::DynRankView<ortValueType,   ortProperties...>  orts,
-    const BasisType* cellBasis,
-    ProjectionStruct<DeviceType, typename BasisType::scalarType> * projStruct){
-      getHDivBasisCoeffs(basisCoeffs, targetAtEPoints, targetDivAtDivEPoints, orts, cellBasis, projStruct);
-}
-
-#endif
 
 template<typename DeviceType>
 template<typename basisCoeffsValueType, class ...basisCoeffsProperties,
@@ -528,9 +491,6 @@ ProjectionTools<DeviceType>::getHDivBasisCoeffs(Kokkos::DynRankView<basisCoeffsV
   cellSystem.solve(basisCoeffs, massMat_, rhsMatTrans, t_, w_, cellDofs, numCellDofs, numCurlInteriorDOFs);
 }
 
-#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-}
-#endif
 }  // Intrepid2 namespace
 
 #endif

--- a/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefHDIV.hpp
+++ b/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefHDIV.hpp
@@ -58,39 +58,61 @@ namespace Intrepid2 {
 
 namespace FunctorsProjectionTools {
 
-template<typename ViewType1, typename ViewType2, typename ViewType3, typename ViewType4>
-struct ComputeBasisCoeffsOnSides_HDiv {
-  const ViewType1 sideBasisNormalAtBasisEPoints_;
+template<typename ViewType1, typename ViewType2, typename ViewType3>
+struct ComputeWBasisSide_HDiv {
+  ViewType1 basisNormalAtBasisEPoints_;
+  ViewType1 wBasisNormalAtBasisEPoints_;
   const ViewType1 basisAtBasisEPoints_;
   const ViewType2 basisEWeights_;
-  const ViewType1 wBasisDofAtBasisEPoints_;
+  const ViewType1 refSideNormal_;
+  const ViewType3 tagToOrdinal_;
+  ordinal_type sideDim_;
+  ordinal_type iside_;
+  ordinal_type offsetBasis_;
+
+  ComputeWBasisSide_HDiv(ViewType1 basisNormalAtBasisEPoints, ViewType1 wBasisNormalAtBasisEPoints,
+      ViewType1 basisAtBasisEPoints, ViewType2 basisEWeights,  ViewType1 refSideNormal, ViewType3 tagToOrdinal,  
+      ordinal_type sideDim, ordinal_type iside, ordinal_type offsetBasis) :
+        basisNormalAtBasisEPoints_(basisNormalAtBasisEPoints), wBasisNormalAtBasisEPoints_(wBasisNormalAtBasisEPoints), basisAtBasisEPoints_(basisAtBasisEPoints),
+        basisEWeights_(basisEWeights), refSideNormal_(refSideNormal), tagToOrdinal_(tagToOrdinal),
+        sideDim_(sideDim), iside_(iside), offsetBasis_(offsetBasis) {}
+
+  void
+  KOKKOS_INLINE_FUNCTION
+  operator()(const ordinal_type j, const ordinal_type iq) const {
+    ordinal_type jdof = tagToOrdinal_(sideDim_, iside_, j);
+    for(ordinal_type d=0; d <ordinal_type(refSideNormal_.extent(0)); ++d)
+      basisNormalAtBasisEPoints_(0,j,iq) += refSideNormal_(d)*basisAtBasisEPoints_(jdof,offsetBasis_+iq,d);
+    wBasisNormalAtBasisEPoints_(0,j,iq) = basisNormalAtBasisEPoints_(0,j,iq)*basisEWeights_(iq);
+  }
+};
+
+template<typename ViewType1, typename ViewType2, typename ViewType3, typename ViewType4>
+struct ComputeBasisCoeffsOnSides_HDiv {
   const ViewType2 targetEWeights_;
   const ViewType1 basisAtTargetEPoints_;
   const ViewType1 wBasisDofAtTargetEPoints_;
   const ViewType3 tagToOrdinal_;
   const ViewType4 targetAtEPoints_;
   const ViewType1 targetAtTargetEPoints_;
-  const ViewType1 refSidesNormal_;
+  const ViewType1 refSideNormal_;
   ordinal_type sideCardinality_;
-  ordinal_type offsetBasis_;
   ordinal_type offsetTarget_;
   ordinal_type sideDim_;
   ordinal_type dim_;
   ordinal_type iside_;
 
-  ComputeBasisCoeffsOnSides_HDiv(const ViewType1 sideBasisNormalAtBasisEPoints,
-      const ViewType1 basisAtBasisEPoints, const ViewType2 basisEWeights,  const ViewType1 wBasisDofAtBasisEPoints,   const ViewType2 targetEWeights,
+  ComputeBasisCoeffsOnSides_HDiv(const ViewType2 targetEWeights,
       const ViewType1 basisAtTargetEPoints, const ViewType1 wBasisDofAtTargetEvalPoint, const ViewType3 tagToOrdinal,
       const ViewType4 targetAtEPoints, const ViewType1 targetAtTargetEPoints,
-      const ViewType1 refSidesNormal, ordinal_type sideCardinality, ordinal_type offsetBasis,
+      const ViewType1 refSideNormal, ordinal_type sideCardinality,
       ordinal_type offsetTarget, ordinal_type sideDim,
       ordinal_type dim, ordinal_type iside) :
-        sideBasisNormalAtBasisEPoints_(sideBasisNormalAtBasisEPoints),
-        basisAtBasisEPoints_(basisAtBasisEPoints), basisEWeights_(basisEWeights), wBasisDofAtBasisEPoints_(wBasisDofAtBasisEPoints), targetEWeights_(targetEWeights),
+        targetEWeights_(targetEWeights),
         basisAtTargetEPoints_(basisAtTargetEPoints), wBasisDofAtTargetEPoints_(wBasisDofAtTargetEvalPoint),
         tagToOrdinal_(tagToOrdinal), targetAtEPoints_(targetAtEPoints),
         targetAtTargetEPoints_(targetAtTargetEPoints),
-        refSidesNormal_(refSidesNormal), sideCardinality_(sideCardinality), offsetBasis_(offsetBasis),
+        refSideNormal_(refSideNormal), sideCardinality_(sideCardinality),
         offsetTarget_(offsetTarget), sideDim_(sideDim), dim_(dim), iside_(iside)
   {}
 
@@ -98,52 +120,46 @@ struct ComputeBasisCoeffsOnSides_HDiv {
   KOKKOS_INLINE_FUNCTION
   operator()(const ordinal_type ic) const {
 
-    //Note: we are not considering the jacobian of the orientation map since it is simply a scalar term for the integrals and it does not affect the projection
+    typename ViewType1::value_type tmp =0;
     for(ordinal_type j=0; j <sideCardinality_; ++j) {
       ordinal_type jdof = tagToOrdinal_(sideDim_, iside_, j);
-
-    for(ordinal_type iq=0; iq <ordinal_type(basisEWeights_.extent(0)); ++iq) {
-      for(ordinal_type d=0; d <dim_; ++d)
-        sideBasisNormalAtBasisEPoints_(ic,j,iq) += refSidesNormal_(iside_,d)*basisAtBasisEPoints_(ic,jdof,offsetBasis_+iq,d);
-      wBasisDofAtBasisEPoints_(ic,j,iq) = sideBasisNormalAtBasisEPoints_(ic,j,iq) * basisEWeights_(iq);
+      for(ordinal_type iq=0; iq <ordinal_type(targetEWeights_.extent(0)); ++iq) {
+        tmp=0;
+        for(ordinal_type d=0; d <dim_; ++d)
+          tmp += refSideNormal_(d)*basisAtTargetEPoints_(jdof,offsetTarget_+iq,d);
+        wBasisDofAtTargetEPoints_(ic,j,iq) = tmp * targetEWeights_(iq);
+      }
     }
-    for(ordinal_type iq=0; iq <ordinal_type(targetEWeights_.extent(0)); ++iq) {
-      typename ViewType2::value_type sum=0;
-      for(ordinal_type d=0; d <dim_; ++d)
-        sum += refSidesNormal_(iside_,d)*basisAtTargetEPoints_(ic,jdof,offsetTarget_+iq,d);
-      wBasisDofAtTargetEPoints_(ic,j,iq) = sum * targetEWeights_(iq);
-    }
-  }
 
-  for(ordinal_type d=0; d <dim_; ++d)
+    for(ordinal_type d=0; d <dim_; ++d)
       for(ordinal_type iq=0; iq <ordinal_type(targetEWeights_.extent(0)); ++iq)
-        targetAtTargetEPoints_(ic,iq) += refSidesNormal_(iside_,d)*targetAtEPoints_(ic,offsetTarget_+iq,d);
+        targetAtTargetEPoints_(ic,iq) += refSideNormal_(d)*targetAtEPoints_(ic,offsetTarget_+iq,d);
   }
 };
 
 
 template<typename ViewType1, typename ViewType2, typename ViewType3,
-typename ViewType4, typename ViewType5>
+typename ViewType4>
 struct ComputeBasisCoeffsOnCells_HDiv {
   const ViewType1 basisCoeffs_;
-  const ViewType2 negPartialProjAtBasisEPoints_;
-  const ViewType2 nonWeightedBasisAtBasisEPoints_;
-  const ViewType2 basisAtBasisEPoints_;
-  const ViewType3 basisEWeights_;
-  const ViewType2 wBasisAtBasisEPoints_;
-  const ViewType3 targetEWeights_;
-  const ViewType2 basisAtTargetEPoints_;
-  const ViewType2 wBasisAtTargetEPoints_;
-  const ViewType4 computedDofs_;
-  const ViewType5 cellDof_;
+  const ViewType1 negPartialProjAtBasisEPoints_;
+  const ViewType1 nonWeightedBasisAtBasisEPoints_;
+  const ViewType1 basisAtBasisEPoints_;
+  const ViewType2 basisEWeights_;
+  const ViewType1 wBasisAtBasisEPoints_;
+  const ViewType2 targetEWeights_;
+  const ViewType1 basisAtTargetEPoints_;
+  const ViewType1 wBasisAtTargetEPoints_;
+  const ViewType3 computedDofs_;
+  const ViewType4 cellDof_;
   ordinal_type numCellDofs_;
   ordinal_type offsetBasis_;
   ordinal_type offsetTarget_;
   ordinal_type numSideDofs_;
 
-  ComputeBasisCoeffsOnCells_HDiv(const ViewType1 basisCoeffs, ViewType2 negPartialProjAtBasisEPoints,  const ViewType2 nonWeightedBasisAtBasisEPoints,
-      const ViewType2 basisAtBasisEPoints, const ViewType3 basisEWeights,  const ViewType2 wBasisAtBasisEPoints,   const ViewType3 targetEWeights,
-      const ViewType2 basisAtTargetEPoints, const ViewType2 wBasisAtTargetEPoints, const ViewType4 computedDofs, const ViewType5 cellDof,
+  ComputeBasisCoeffsOnCells_HDiv(const ViewType1 basisCoeffs, ViewType1 negPartialProjAtBasisEPoints,  const ViewType1 nonWeightedBasisAtBasisEPoints,
+      const ViewType1 basisAtBasisEPoints, const ViewType2 basisEWeights,  const ViewType1 wBasisAtBasisEPoints,   const ViewType2 targetEWeights,
+      const ViewType1 basisAtTargetEPoints, const ViewType1 wBasisAtTargetEPoints, const ViewType3 computedDofs, const ViewType4 cellDof,
       ordinal_type numCellDofs, ordinal_type offsetBasis, ordinal_type offsetTarget, ordinal_type numSideDofs) :
         basisCoeffs_(basisCoeffs), negPartialProjAtBasisEPoints_(negPartialProjAtBasisEPoints), nonWeightedBasisAtBasisEPoints_(nonWeightedBasisAtBasisEPoints),
         basisAtBasisEPoints_(basisAtBasisEPoints), basisEWeights_(basisEWeights), wBasisAtBasisEPoints_(wBasisAtBasisEPoints), targetEWeights_(targetEWeights),
@@ -158,46 +174,46 @@ struct ComputeBasisCoeffsOnCells_HDiv {
     for(ordinal_type j=0; j <numCellDofs_; ++j) {
       ordinal_type idof = cellDof_(j);
       for(ordinal_type iq=0; iq <ordinal_type(basisEWeights_.extent(0)); ++iq) {
-        nonWeightedBasisAtBasisEPoints_(ic,j,iq) = basisAtBasisEPoints_(ic,idof,offsetBasis_+iq);
-        wBasisAtBasisEPoints_(ic,j,iq) = nonWeightedBasisAtBasisEPoints_(ic,j,iq) * basisEWeights_(iq);
+        nonWeightedBasisAtBasisEPoints_(0,j,iq) = basisAtBasisEPoints_(idof,offsetBasis_+iq);
+        wBasisAtBasisEPoints_(ic,j,iq) = nonWeightedBasisAtBasisEPoints_(0,j,iq) * basisEWeights_(iq);
       }
       for(ordinal_type iq=0; iq <ordinal_type(targetEWeights_.extent(0)); ++iq) {
-        wBasisAtTargetEPoints_(ic,j,iq) = basisAtTargetEPoints_(ic,idof,offsetTarget_+iq)* targetEWeights_(iq);
+        wBasisAtTargetEPoints_(ic,j,iq) = basisAtTargetEPoints_(idof,offsetTarget_+iq)* targetEWeights_(iq);
       }
     }
     for(ordinal_type j=0; j < numSideDofs_; ++j) {
       ordinal_type jdof = computedDofs_(j);
       for(ordinal_type iq=0; iq <ordinal_type(basisEWeights_.extent(0)); ++iq)
-        negPartialProjAtBasisEPoints_(ic,iq) -=  basisCoeffs_(ic,jdof)*basisAtBasisEPoints_(ic,jdof,offsetBasis_+iq);
+        negPartialProjAtBasisEPoints_(ic,iq) -=  basisCoeffs_(ic,jdof)*basisAtBasisEPoints_(jdof,offsetBasis_+iq);
     }
   }
 };
 
 
 template<typename ViewType1, typename ViewType2, typename ViewType3,
-typename ViewType4, typename ViewType5, typename ViewType6>
+typename ViewType4, typename ViewType5>
 struct ComputeHCurlBasisCoeffsOnCells_HDiv {
   const ViewType1 basisCoeffs_;
-  const ViewType2 negPartialProjAtBasisEPoints_;
-  const ViewType2 nonWeightedBasisAtBasisEPoints_;
-  const ViewType2 basisAtBasisEPoints_;
-  const ViewType2 hcurlBasisCurlAtBasisEPoints_;
-  const ViewType3 basisEWeights_;
-  const ViewType2 wHCurlBasisAtBasisEPoints_;
-  const ViewType3 targetEWeights_;
-  const ViewType2 hcurlBasisCurlAtTargetEPoints_;
-  const ViewType2 wHCurlBasisAtTargetEPoints_;
-  const ViewType4 tagToOrdinal_;
-  const ViewType5 computedDofs_;
-  const ViewType6 hCurlDof_;
+  const ViewType1 negPartialProjAtBasisEPoints_;
+  const ViewType1 nonWeightedBasisAtBasisEPoints_;
+  const ViewType1 basisAtBasisEPoints_;
+  const ViewType1 hcurlBasisCurlAtBasisEPoints_;
+  const ViewType2 basisEWeights_;
+  const ViewType1 wHCurlBasisAtBasisEPoints_;
+  const ViewType2 targetEWeights_;
+  const ViewType1 hcurlBasisCurlAtTargetEPoints_;
+  const ViewType1 wHCurlBasisAtTargetEPoints_;
+  const ViewType3 tagToOrdinal_;
+  const ViewType4 computedDofs_;
+  const ViewType5 hCurlDof_;
   ordinal_type numCellDofs_;
   ordinal_type offsetBasis_;
   ordinal_type numSideDofs_;
   ordinal_type dim_;
 
-  ComputeHCurlBasisCoeffsOnCells_HDiv(const ViewType1 basisCoeffs, ViewType2 negPartialProjAtBasisEPoints,  const ViewType2 nonWeightedBasisAtBasisEPoints,
-      const ViewType2 basisAtBasisEPoints, const ViewType2 hcurlBasisCurlAtBasisEPoints, const ViewType3 basisEWeights,  const ViewType2 wHCurlBasisAtBasisEPoints,   const ViewType3 targetEWeights,
-      const ViewType2 hcurlBasisCurlAtTargetEPoints, const ViewType2 wHCurlBasisAtTargetEPoints, const ViewType4 tagToOrdinal, const ViewType5 computedDofs, const ViewType6 hCurlDof,
+  ComputeHCurlBasisCoeffsOnCells_HDiv(const ViewType1 basisCoeffs, ViewType1 negPartialProjAtBasisEPoints, const ViewType1 nonWeightedBasisAtBasisEPoints,
+      const ViewType1 basisAtBasisEPoints, const ViewType1 hcurlBasisCurlAtBasisEPoints, const ViewType2 basisEWeights,  const ViewType1 wHCurlBasisAtBasisEPoints,   const ViewType2 targetEWeights,
+      const ViewType1 hcurlBasisCurlAtTargetEPoints, const ViewType1 wHCurlBasisAtTargetEPoints, const ViewType3 tagToOrdinal, const ViewType4 computedDofs, const ViewType5 hCurlDof,
       ordinal_type numCellDofs, ordinal_type offsetBasis, ordinal_type numSideDofs, ordinal_type dim) :
         basisCoeffs_(basisCoeffs), negPartialProjAtBasisEPoints_(negPartialProjAtBasisEPoints), nonWeightedBasisAtBasisEPoints_(nonWeightedBasisAtBasisEPoints),
         basisAtBasisEPoints_(basisAtBasisEPoints), hcurlBasisCurlAtBasisEPoints_(hcurlBasisCurlAtBasisEPoints), basisEWeights_(basisEWeights), wHCurlBasisAtBasisEPoints_(wHCurlBasisAtBasisEPoints), targetEWeights_(targetEWeights),
@@ -215,7 +231,7 @@ struct ComputeHCurlBasisCoeffsOnCells_HDiv {
       ordinal_type idof = computedDofs_(i);
       for(ordinal_type iq=0; iq<numBasisEPoints; ++iq){
         for(ordinal_type d=0; d <dim_; ++d)
-          negPartialProjAtBasisEPoints_(ic,iq,d) -= basisCoeffs_(ic,idof)*basisAtBasisEPoints_(ic,idof,offsetBasis_+iq,d);
+          negPartialProjAtBasisEPoints_(ic,iq,d) -= basisCoeffs_(ic,idof)*basisAtBasisEPoints_(idof,offsetBasis_+iq,d);
       }
     }
 
@@ -223,7 +239,7 @@ struct ComputeHCurlBasisCoeffsOnCells_HDiv {
       ordinal_type idof = tagToOrdinal_(dim_, 0, i);
       for(ordinal_type iq=0; iq<numBasisEPoints; ++iq) {
         for(ordinal_type d=0; d<dim_; ++d)
-          nonWeightedBasisAtBasisEPoints_(ic,i,iq,d) = basisAtBasisEPoints_(ic,idof,offsetBasis_+iq,d);
+          nonWeightedBasisAtBasisEPoints_(0,i,iq,d) = basisAtBasisEPoints_(idof,offsetBasis_+iq,d);
       }
     }
 
@@ -267,7 +283,6 @@ ProjectionTools<DeviceType>::getHDivBasisCoeffs(Kokkos::DynRankView<basisCoeffsV
   const std::string& name = cellBasis->getName();
 
   ordinal_type numSides = cellBasis->getBaseCellTopology().getSideCount();
-  ScalarViewType refSideNormal("refSideNormal", dim);
 
   ordinal_type numSideDofs(0);
   for(ordinal_type is=0; is<numSides; ++is)
@@ -290,34 +305,22 @@ ProjectionTools<DeviceType>::getHDivBasisCoeffs(Kokkos::DynRankView<basisCoeffsV
   auto targetEPoints = projStruct->getAllEvalPoints(EvalPointsType::TARGET);
   auto targetDivEPoints = projStruct->getAllDerivEvalPoints(EvalPointsType::TARGET);
 
-  ScalarViewType basisAtBasisEPoints("basisAtBasisEPoints",numCells,basisCardinality, numTotalBasisEPoints, dim);
-  ScalarViewType basisAtTargetEPoints("basisAtTargetEPoints",numCells,basisCardinality, numTotalTargetEPoints, dim);
-  {
-    ScalarViewType nonOrientedBasisAtBasisEPoints("nonOrientedBasisAtBasisEPoints",basisCardinality, numTotalBasisEPoints, dim);
-    ScalarViewType nonOrientedBasisAtTargetEPoints("nonOrientedBasisAtTargetEPoints",basisCardinality, numTotalTargetEPoints, dim);
-    cellBasis->getValues(nonOrientedBasisAtTargetEPoints, targetEPoints);
-    cellBasis->getValues(nonOrientedBasisAtBasisEPoints, basisEPoints);
-
-    OrientationTools<DeviceType>::modifyBasisByOrientation(basisAtBasisEPoints, nonOrientedBasisAtBasisEPoints, orts, cellBasis);
-    OrientationTools<DeviceType>::modifyBasisByOrientation(basisAtTargetEPoints, nonOrientedBasisAtTargetEPoints, orts, cellBasis);
-  }
+  ScalarViewType basisAtBasisEPoints("basisAtBasisEPoints",basisCardinality, numTotalBasisEPoints, dim);
+  ScalarViewType basisAtTargetEPoints("basisAtTargetEPoints",basisCardinality, numTotalTargetEPoints, dim);
+  cellBasis->getValues(basisAtTargetEPoints, targetEPoints);
+  cellBasis->getValues(basisAtBasisEPoints, basisEPoints);
 
   ScalarViewType basisDivAtBasisDivEPoints;
   ScalarViewType basisDivAtTargetDivEPoints;
   if(numTotalTargetDivEPoints>0) {
-    ScalarViewType nonOrientedBasisDivAtTargetDivEPoints, nonOrientedBasisDivAtBasisDivEPoints;
-    basisDivAtBasisDivEPoints = ScalarViewType ("basisDivAtBasisDivEPoints",numCells,basisCardinality, numTotalBasisDivEPoints);
-    nonOrientedBasisDivAtBasisDivEPoints = ScalarViewType ("nonOrientedBasisDivAtBasisDivEPoints",basisCardinality, numTotalBasisDivEPoints);
-    basisDivAtTargetDivEPoints = ScalarViewType("basisDivAtTargetDivEPoints",numCells,basisCardinality, numTotalTargetDivEPoints);
-    nonOrientedBasisDivAtTargetDivEPoints = ScalarViewType("nonOrientedBasisDivAtTargetDivEPoints",basisCardinality, numTotalTargetDivEPoints);
-    cellBasis->getValues(nonOrientedBasisDivAtBasisDivEPoints, basisDivEPoints, OPERATOR_DIV);
-    cellBasis->getValues(nonOrientedBasisDivAtTargetDivEPoints, targetDivEPoints, OPERATOR_DIV);
-
-    OrientationTools<DeviceType>::modifyBasisByOrientation(basisDivAtBasisDivEPoints, nonOrientedBasisDivAtBasisDivEPoints, orts, cellBasis);
-    OrientationTools<DeviceType>::modifyBasisByOrientation(basisDivAtTargetDivEPoints, nonOrientedBasisDivAtTargetDivEPoints, orts, cellBasis);
+    basisDivAtBasisDivEPoints = ScalarViewType ("basisDivAtBasisDivEPoints",basisCardinality, numTotalBasisDivEPoints);
+    basisDivAtTargetDivEPoints = ScalarViewType("basisDivAtTargetDivEPoints",basisCardinality, numTotalTargetDivEPoints);
+    cellBasis->getValues(basisDivAtBasisDivEPoints, basisDivEPoints, OPERATOR_DIV);
+    cellBasis->getValues(basisDivAtTargetDivEPoints, targetDivEPoints, OPERATOR_DIV);
   }
 
-  ScalarViewType refSidesNormal("refSidesNormal", numSides, dim);
+  ScalarViewType refBasisCoeffs("refBasisCoeffs", basisCoeffs.extent(0), basisCoeffs.extent(1));
+  
   ordinal_type computedDofsCount = 0;
   for(ordinal_type is=0; is<numSides; ++is)  {
 
@@ -331,11 +334,11 @@ ProjectionTools<DeviceType>::getHDivBasisCoeffs(Kokkos::DynRankView<basisCoeffsV
     deep_copy(computedSideDofs, sideDofs);
     computedDofsCount += sideCardinality;
 
-    auto sideNormal = Kokkos::subview(refSidesNormal,is,Kokkos::ALL());
-    CellTools<DeviceType>::getReferenceSideNormal(sideNormal, is, cellTopo);
+    ScalarViewType refSideNormal("refSideNormal", dim);
+    CellTools<DeviceType>::getReferenceSideNormal(refSideNormal, is, cellTopo);
 
-    ScalarViewType basisNormalAtBasisEPoints("normalBasisAtBasisEPoints",numCells,sideCardinality, numBasisEPoints);
-    ScalarViewType wBasisNormalAtBasisEPoints("wBasisNormalAtBasisEPoints",numCells,sideCardinality, numBasisEPoints);
+    ScalarViewType basisNormalAtBasisEPoints("normalBasisAtBasisEPoints",1,sideCardinality, numBasisEPoints);
+    ScalarViewType wBasisNormalAtBasisEPoints("wBasisNormalAtBasisEPoints",1,sideCardinality, numBasisEPoints);
     ScalarViewType wBasisNormalAtTargetEPoints("wBasisNormalAtTargetEPoints",numCells,sideCardinality, numTargetEPoints);
     ScalarViewType targetNormalAtTargetEPoints("targetNormalAtTargetEPoints",numCells, numTargetEPoints);
 
@@ -344,17 +347,19 @@ ProjectionTools<DeviceType>::getHDivBasisCoeffs(Kokkos::DynRankView<basisCoeffsV
     auto targetEWeights = Kokkos::create_mirror_view_and_copy(MemSpaceType(),projStruct->getTargetEvalWeights(sideDim,is));
     auto basisEWeights = Kokkos::create_mirror_view_and_copy(MemSpaceType(),projStruct->getBasisEvalWeights(sideDim,is));
 
+    using functorTypeWBasisEdge = FunctorsProjectionTools::ComputeWBasisSide_HDiv<ScalarViewType,  decltype(basisEWeights), decltype(tagToOrdinal)>;
+    Kokkos::parallel_for(Kokkos::MDRangePolicy<ExecSpaceType, Kokkos::Rank<2> >({0,0}, {sideCardinality,numBasisEPoints}), 
+      functorTypeWBasisEdge(basisNormalAtBasisEPoints,wBasisNormalAtBasisEPoints,basisAtBasisEPoints,basisEWeights,refSideNormal,tagToOrdinal,sideDim,is,offsetBasis));
 
-    using functorTypeSide = FunctorsProjectionTools::ComputeBasisCoeffsOnSides_HDiv<ScalarViewType,  decltype(basisEWeights), decltype(tagToOrdinal), decltype(targetAtEPoints)>;
-    Kokkos::parallel_for(policy, functorTypeSide(basisNormalAtBasisEPoints, basisAtBasisEPoints,
-        basisEWeights,  wBasisNormalAtBasisEPoints, targetEWeights,
+    using functorTypeSide = FunctorsProjectionTools::ComputeBasisCoeffsOnSides_HDiv<ScalarViewType,  decltype(targetEWeights), decltype(tagToOrdinal), decltype(targetAtEPoints)>;
+    Kokkos::parallel_for(policy, functorTypeSide(targetEWeights,
         basisAtTargetEPoints, wBasisNormalAtTargetEPoints, tagToOrdinal,
         targetAtEPoints, targetNormalAtTargetEPoints,
-        refSidesNormal, sideCardinality, offsetBasis,
+        refSideNormal, sideCardinality,
         offsetTarget, sideDim,
         dim, is));
 
-    ScalarViewType sideMassMat_("sideMassMat_", numCells, sideCardinality+1, sideCardinality+1),
+    ScalarViewType sideMassMat_("sideMassMat_", 1, sideCardinality+1, sideCardinality+1),
         sideRhsMat_("rhsMat_", numCells, sideCardinality+1);
 
     ScalarViewType targetEWeights_("targetEWeights", numCells, 1, targetEWeights.extent(0));
@@ -362,7 +367,7 @@ ProjectionTools<DeviceType>::getHDivBasisCoeffs(Kokkos::DynRankView<basisCoeffsV
 
     range_type range_H(0, sideCardinality);
     range_type range_B(sideCardinality, sideCardinality+1);
-    ScalarViewType ones("ones",numCells,1,numBasisEPoints);
+    ScalarViewType ones("ones",1,1,numBasisEPoints);
     Kokkos::deep_copy(ones,1);
 
     FunctionSpaceTools<DeviceType >::integrate(Kokkos::subview(sideMassMat_, Kokkos::ALL(), range_H, range_H), basisNormalAtBasisEPoints, wBasisNormalAtBasisEPoints);
@@ -377,118 +382,120 @@ ProjectionTools<DeviceType>::getHDivBasisCoeffs(Kokkos::DynRankView<basisCoeffsV
 
     auto sideDof = Kokkos::subview(tagToOrdinal, sideDim, is, Kokkos::ALL());
 
-    ElemSystem sideSystem("sideSystem", false);
-    sideSystem.solve(basisCoeffs, sideMassMat_, sideRhsMat_, t_, w_, sideDof, sideCardinality, 1);
+    ElemSystem sideSystem("sideSystem", true);
+    sideSystem.solve(refBasisCoeffs, sideMassMat_, sideRhsMat_, t_, w_, sideDof, sideCardinality, 1);
   }
 
 
   //Cell
   ordinal_type numCellDofs = cellBasis->getDofCount(dim,0);
-  if(numCellDofs==0)
-    return;
+  if(numCellDofs!=0) {
+    Basis<DeviceType,scalarType,scalarType> *hcurlBasis = NULL;
+    if(cellTopo.getKey() == shards::getCellTopologyData<shards::Hexahedron<8> >()->key)
+      hcurlBasis = new Basis_HCURL_HEX_In_FEM<DeviceType,scalarType,scalarType>(cellBasis->getDegree());
+    else if(cellTopo.getKey() == shards::getCellTopologyData<shards::Tetrahedron<4> >()->key)
+      hcurlBasis = new Basis_HCURL_TET_In_FEM<DeviceType,scalarType,scalarType>(cellBasis->getDegree());
+    else if(cellTopo.getKey() == shards::getCellTopologyData<shards::Wedge<6> >()->key)
+      hcurlBasis = new typename DerivedNodalBasisFamily<DeviceType,scalarType,scalarType>::HCURL_WEDGE(cellBasis->getDegree());
+   // TODO: uncomment the next two lines once H(curl) pyramid implemented
+   //  else if(cellTopo.getKey() == shards::getCellTopologyData<shards::Pyramid<5> >()->key)
+   //    hcurlBasis = new typename DerivedNodalBasisFamily<DeviceType,scalarType,scalarType>::HCURL_PYR(cellBasis->getDegree());
+    else if(cellTopo.getKey() == shards::getCellTopologyData<shards::Quadrilateral<4> >()->key)
+      hcurlBasis = new Basis_HGRAD_QUAD_Cn_FEM<DeviceType,scalarType,scalarType>(cellBasis->getDegree());
+    else if(cellTopo.getKey() == shards::getCellTopologyData<shards::Triangle<3> >()->key)
+      hcurlBasis = new Basis_HGRAD_TRI_Cn_FEM<DeviceType,scalarType,scalarType>(cellBasis->getDegree());
+    else  {
+      std::stringstream ss;
+      ss << ">>> ERROR (Intrepid2::ProjectionTools::getHDivBasisCoeffs): "
+          << "Method not implemented for basis " << name;
+      INTREPID2_TEST_FOR_EXCEPTION( true, std::runtime_error, ss.str().c_str() );
+    }
+    if(hcurlBasis == NULL) return;
 
-  Basis<DeviceType,scalarType,scalarType> *hcurlBasis = NULL;
-  if(cellTopo.getKey() == shards::getCellTopologyData<shards::Hexahedron<8> >()->key)
-    hcurlBasis = new Basis_HCURL_HEX_In_FEM<DeviceType,scalarType,scalarType>(cellBasis->getDegree());
-  else if(cellTopo.getKey() == shards::getCellTopologyData<shards::Tetrahedron<4> >()->key)
-    hcurlBasis = new Basis_HCURL_TET_In_FEM<DeviceType,scalarType,scalarType>(cellBasis->getDegree());
-  else if(cellTopo.getKey() == shards::getCellTopologyData<shards::Wedge<6> >()->key)
-    hcurlBasis = new typename DerivedNodalBasisFamily<DeviceType,scalarType,scalarType>::HCURL_WEDGE(cellBasis->getDegree());
-// TODO: uncomment the next two lines once H(curl) pyramid implemented
-//  else if(cellTopo.getKey() == shards::getCellTopologyData<shards::Pyramid<5> >()->key)
-//    hcurlBasis = new typename DerivedNodalBasisFamily<DeviceType,scalarType,scalarType>::HCURL_PYR(cellBasis->getDegree());
-  else if(cellTopo.getKey() == shards::getCellTopologyData<shards::Quadrilateral<4> >()->key)
-    hcurlBasis = new Basis_HGRAD_QUAD_Cn_FEM<DeviceType,scalarType,scalarType>(cellBasis->getDegree());
-  else if(cellTopo.getKey() == shards::getCellTopologyData<shards::Triangle<3> >()->key)
-    hcurlBasis = new Basis_HGRAD_TRI_Cn_FEM<DeviceType,scalarType,scalarType>(cellBasis->getDegree());
-  else  {
-    std::stringstream ss;
-    ss << ">>> ERROR (Intrepid2::ProjectionTools::getHDivBasisCoeffs): "
-        << "Method not implemented for basis " << name;
-    INTREPID2_TEST_FOR_EXCEPTION( true, std::runtime_error, ss.str().c_str() );
+
+    auto targetDivEPointsRange = projStruct->getTargetDerivPointsRange();
+    auto basisDivEPointsRange = projStruct->getBasisDerivPointsRange();
+
+    ordinal_type numTargetDivEPoints = range_size(targetDivEPointsRange(dim,0));
+    ordinal_type numBasisDivEPoints = range_size(basisDivEPointsRange(dim,0));
+
+    auto targetDivEWeights = Kokkos::create_mirror_view_and_copy(MemSpaceType(),projStruct->getTargetDerivEvalWeights(dim,0));
+    auto divEWeights = Kokkos::create_mirror_view_and_copy(MemSpaceType(),projStruct->getBasisDerivEvalWeights(dim,0));
+
+    ordinal_type offsetBasisDiv = basisDivEPointsRange(dim,0).first;
+    ordinal_type offsetTargetDiv = targetDivEPointsRange(dim,0).first;
+
+    ScalarViewType weightedBasisDivAtBasisEPoints("weightedBasisDivAtBasisEPoints",numCells,numCellDofs, numBasisDivEPoints);
+    ScalarViewType weightedBasisDivAtTargetEPoints("weightedBasisDivAtTargetEPoints",numCells, numCellDofs, numTargetDivEPoints);
+    ScalarViewType basisDivAtBasisEPoints("basisDivAtBasisEPoints",1,numCellDofs, numBasisDivEPoints);
+    ScalarViewType targetSideDivAtBasisEPoints("targetSideDivAtBasisEPoints",numCells, numBasisDivEPoints);
+
+    auto cellDofs = Kokkos::subview(tagToOrdinal, dim, 0, Kokkos::ALL());
+    using functorType = FunctorsProjectionTools::ComputeBasisCoeffsOnCells_HDiv<ScalarViewType,  decltype(divEWeights), decltype(computedDofs), decltype(cellDofs)>;
+    Kokkos::parallel_for(policy, functorType( refBasisCoeffs, targetSideDivAtBasisEPoints,  basisDivAtBasisEPoints,
+        basisDivAtBasisDivEPoints, divEWeights,  weightedBasisDivAtBasisEPoints, targetDivEWeights, basisDivAtTargetDivEPoints, weightedBasisDivAtTargetEPoints,
+        computedDofs, cellDofs, numCellDofs, offsetBasisDiv, offsetTargetDiv, numSideDofs));
+
+
+    ordinal_type hcurlBasisCardinality = hcurlBasis->getCardinality();
+    ordinal_type numCurlInteriorDOFs = hcurlBasis->getDofCount(dim,0);
+
+    range_type range_H(0, numCellDofs);
+    range_type range_B(numCellDofs, numCellDofs+numCurlInteriorDOFs);
+
+
+    ScalarViewType massMat_("massMat_",1,numCellDofs+numCurlInteriorDOFs,numCellDofs+numCurlInteriorDOFs),
+                  rhsMatTrans("rhsMatTrans",numCells,numCellDofs+numCurlInteriorDOFs);
+
+    FunctionSpaceTools<DeviceType >::integrate(Kokkos::subview(massMat_, Kokkos::ALL(), range_H,range_H), basisDivAtBasisEPoints, Kokkos::subview(weightedBasisDivAtBasisEPoints, std::make_pair(0,1), Kokkos::ALL(), Kokkos::ALL()) );
+    FunctionSpaceTools<DeviceType >::integrate(Kokkos::subview(rhsMatTrans, Kokkos::ALL(), range_H), targetDivAtDivEPoints, weightedBasisDivAtTargetEPoints);
+    FunctionSpaceTools<DeviceType >::integrate(Kokkos::subview(rhsMatTrans, Kokkos::ALL(), range_H), targetSideDivAtBasisEPoints, weightedBasisDivAtBasisEPoints,true);
+
+    if(numCurlInteriorDOFs>0){
+      ordinal_type numTargetEPoints = range_size(targetEPointsRange(dim,0));
+      ordinal_type numBasisEPoints = range_size(basisEPointsRange(dim,0));
+
+      auto targetEWeights = Kokkos::create_mirror_view_and_copy(MemSpaceType(),projStruct->getTargetEvalWeights(dim,0));
+      auto basisEWeights = Kokkos::create_mirror_view_and_copy(MemSpaceType(),projStruct->getBasisEvalWeights(dim,0));
+
+      ordinal_type offsetBasis = basisEPointsRange(dim,0).first;
+
+      ScalarViewType negPartialProjAtBasisEPoints("targetSideAtBasisEPoints",numCells, numBasisEPoints, dim);
+      ScalarViewType nonWeightedBasisAtBasisEPoints("basisAtBasisEPoints",1,numCellDofs, numBasisEPoints, dim);
+      ScalarViewType hcurlBasisCurlAtBasisEPoints("hcurlBasisCurlAtBasisEPoints",hcurlBasisCardinality, numBasisEPoints,dim);
+      ScalarViewType hcurlBasisCurlAtTargetEPoints("hcurlBasisCurlAtTargetEPoints", hcurlBasisCardinality,numTargetEPoints, dim);
+      ScalarViewType wHcurlBasisCurlAtBasisEPoints("wHcurlBasisHcurlAtBasisEPoints", numCells, numCurlInteriorDOFs, numBasisEPoints,dim);
+      ScalarViewType wHcurlBasisCurlAtTargetEPoints("wHcurlBasisHcurlAtTargetEPoints",numCells, numCurlInteriorDOFs, numTargetEPoints,dim);
+
+      hcurlBasis->getValues(hcurlBasisCurlAtBasisEPoints, Kokkos::subview(basisEPoints, basisEPointsRange(dim,0), Kokkos::ALL()), OPERATOR_CURL);
+      hcurlBasis->getValues(hcurlBasisCurlAtTargetEPoints, Kokkos::subview(targetEPoints,targetEPointsRange(dim,0),Kokkos::ALL()), OPERATOR_CURL);
+
+      auto hCurlTagToOrdinal = Kokkos::create_mirror_view_and_copy(MemSpaceType(), hcurlBasis->getAllDofOrdinal());
+      auto cellHCurlDof = Kokkos::subview(hCurlTagToOrdinal, dim, 0, range_type(0, numCurlInteriorDOFs));
+
+      using functorTypeHCurlCells = FunctorsProjectionTools::ComputeHCurlBasisCoeffsOnCells_HDiv<ScalarViewType,  decltype(divEWeights),
+          decltype(tagToOrdinal), decltype(computedDofs), decltype(cellDofs)>;
+      Kokkos::parallel_for(policy, functorTypeHCurlCells(refBasisCoeffs, negPartialProjAtBasisEPoints,  nonWeightedBasisAtBasisEPoints,
+          basisAtBasisEPoints, hcurlBasisCurlAtBasisEPoints, basisEWeights, wHcurlBasisCurlAtBasisEPoints, targetEWeights,
+          hcurlBasisCurlAtTargetEPoints, wHcurlBasisCurlAtTargetEPoints, tagToOrdinal, computedDofs, cellHCurlDof,
+          numCellDofs, offsetBasis, numSideDofs, dim));
+
+      FunctionSpaceTools<DeviceType >::integrate(Kokkos::subview(massMat_, Kokkos::ALL(), range_H,range_B), nonWeightedBasisAtBasisEPoints, Kokkos::subview(wHcurlBasisCurlAtBasisEPoints, std::make_pair(0,1), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()) );
+      FunctionSpaceTools<DeviceType >::integrate(Kokkos::subview(rhsMatTrans, Kokkos::ALL(), range_B), Kokkos::subview(targetAtEPoints, Kokkos::ALL(), targetEPointsRange(dim,0), Kokkos::ALL()), wHcurlBasisCurlAtTargetEPoints);
+      FunctionSpaceTools<DeviceType >::integrate(Kokkos::subview(rhsMatTrans, Kokkos::ALL(), range_B), negPartialProjAtBasisEPoints, wHcurlBasisCurlAtBasisEPoints,true);
+    }
+    delete hcurlBasis;
+
+    typedef Kokkos::DynRankView<scalarType, Kokkos::LayoutRight, DeviceType> WorkArrayViewType;
+    ScalarViewType t_("t",numCells, numCellDofs+numCurlInteriorDOFs);
+    WorkArrayViewType w_("w",numCells, numCellDofs+numCurlInteriorDOFs);
+
+    ElemSystem cellSystem("cellSystem", true);
+    cellSystem.solve(refBasisCoeffs, massMat_, rhsMatTrans, t_, w_, cellDofs, numCellDofs, numCurlInteriorDOFs);
   }
-  if(hcurlBasis == NULL) return;
 
+  OrientationTools<DeviceType>::modifyBasisByOrientationInverse(basisCoeffs, refBasisCoeffs, orts, cellBasis, true);
 
-  auto targetDivEPointsRange = projStruct->getTargetDerivPointsRange();
-  auto basisDivEPointsRange = projStruct->getBasisDerivPointsRange();
-
-  ordinal_type numTargetDivEPoints = range_size(targetDivEPointsRange(dim,0));
-  ordinal_type numBasisDivEPoints = range_size(basisDivEPointsRange(dim,0));
-
-  auto targetDivEWeights = Kokkos::create_mirror_view_and_copy(MemSpaceType(),projStruct->getTargetDerivEvalWeights(dim,0));
-  auto divEWeights = Kokkos::create_mirror_view_and_copy(MemSpaceType(),projStruct->getBasisDerivEvalWeights(dim,0));
-
-  ordinal_type offsetBasisDiv = basisDivEPointsRange(dim,0).first;
-  ordinal_type offsetTargetDiv = targetDivEPointsRange(dim,0).first;
-
-  ScalarViewType weightedBasisDivAtBasisEPoints("weightedBasisDivAtBasisEPoints",numCells,numCellDofs, numBasisDivEPoints);
-  ScalarViewType weightedBasisDivAtTargetEPoints("weightedBasisDivAtTargetEPoints",numCells, numCellDofs, numTargetDivEPoints);
-  ScalarViewType basisDivAtBasisEPoints("basisDivAtBasisEPoints",numCells,numCellDofs, numBasisDivEPoints);
-  ScalarViewType targetSideDivAtBasisEPoints("targetSideDivAtBasisEPoints",numCells, numBasisDivEPoints);
-
-  auto cellDofs = Kokkos::subview(tagToOrdinal, dim, 0, Kokkos::ALL());
-  using functorType = FunctorsProjectionTools::ComputeBasisCoeffsOnCells_HDiv<decltype(basisCoeffs), ScalarViewType,  decltype(divEWeights), decltype(computedDofs), decltype(cellDofs)>;
-  Kokkos::parallel_for(policy, functorType( basisCoeffs, targetSideDivAtBasisEPoints,  basisDivAtBasisEPoints,
-      basisDivAtBasisDivEPoints, divEWeights,  weightedBasisDivAtBasisEPoints, targetDivEWeights, basisDivAtTargetDivEPoints, weightedBasisDivAtTargetEPoints,
-      computedDofs, cellDofs, numCellDofs, offsetBasisDiv, offsetTargetDiv, numSideDofs));
-
-
-  ordinal_type hcurlBasisCardinality = hcurlBasis->getCardinality();
-  ordinal_type numCurlInteriorDOFs = hcurlBasis->getDofCount(dim,0);
-
-  range_type range_H(0, numCellDofs);
-  range_type range_B(numCellDofs, numCellDofs+numCurlInteriorDOFs);
-
-
-  ScalarViewType massMat_("massMat_",numCells,numCellDofs+numCurlInteriorDOFs,numCellDofs+numCurlInteriorDOFs),
-                 rhsMatTrans("rhsMatTrans",numCells,numCellDofs+numCurlInteriorDOFs);
-
-  FunctionSpaceTools<DeviceType >::integrate(Kokkos::subview(massMat_, Kokkos::ALL(), range_H,range_H), basisDivAtBasisEPoints, weightedBasisDivAtBasisEPoints);
-  FunctionSpaceTools<DeviceType >::integrate(Kokkos::subview(rhsMatTrans, Kokkos::ALL(), range_H), targetDivAtDivEPoints, weightedBasisDivAtTargetEPoints);
-  FunctionSpaceTools<DeviceType >::integrate(Kokkos::subview(rhsMatTrans, Kokkos::ALL(), range_H), targetSideDivAtBasisEPoints, weightedBasisDivAtBasisEPoints,true);
-
-  if(numCurlInteriorDOFs>0){
-    ordinal_type numTargetEPoints = range_size(targetEPointsRange(dim,0));
-    ordinal_type numBasisEPoints = range_size(basisEPointsRange(dim,0));
-
-    auto targetEWeights = Kokkos::create_mirror_view_and_copy(MemSpaceType(),projStruct->getTargetEvalWeights(dim,0));
-    auto basisEWeights = Kokkos::create_mirror_view_and_copy(MemSpaceType(),projStruct->getBasisEvalWeights(dim,0));
-
-    ordinal_type offsetBasis = basisEPointsRange(dim,0).first;
-
-    ScalarViewType negPartialProjAtBasisEPoints("targetSideAtBasisEPoints",numCells, numBasisEPoints, dim);
-    ScalarViewType nonWeightedBasisAtBasisEPoints("basisAtBasisEPoints",numCells,numCellDofs, numBasisEPoints, dim);
-    ScalarViewType hcurlBasisCurlAtBasisEPoints("hcurlBasisCurlAtBasisEPoints",hcurlBasisCardinality, numBasisEPoints,dim);
-    ScalarViewType hcurlBasisCurlAtTargetEPoints("hcurlBasisCurlAtTargetEPoints", hcurlBasisCardinality,numTargetEPoints, dim);
-    ScalarViewType wHcurlBasisCurlAtBasisEPoints("wHcurlBasisHcurlAtBasisEPoints", numCells, numCurlInteriorDOFs, numBasisEPoints,dim);
-    ScalarViewType wHcurlBasisCurlAtTargetEPoints("wHcurlBasisHcurlAtTargetEPoints",numCells, numCurlInteriorDOFs, numTargetEPoints,dim);
-
-    hcurlBasis->getValues(hcurlBasisCurlAtBasisEPoints, Kokkos::subview(basisEPoints, basisEPointsRange(dim,0), Kokkos::ALL()), OPERATOR_CURL);
-    hcurlBasis->getValues(hcurlBasisCurlAtTargetEPoints, Kokkos::subview(targetEPoints,targetEPointsRange(dim,0),Kokkos::ALL()), OPERATOR_CURL);
-
-    auto hCurlTagToOrdinal = Kokkos::create_mirror_view_and_copy(MemSpaceType(), hcurlBasis->getAllDofOrdinal());
-    auto cellHCurlDof = Kokkos::subview(hCurlTagToOrdinal, dim, 0, range_type(0, numCurlInteriorDOFs));
-
-    using functorTypeHCurlCells = FunctorsProjectionTools::ComputeHCurlBasisCoeffsOnCells_HDiv<decltype(basisCoeffs), ScalarViewType,  decltype(divEWeights),
-        decltype(tagToOrdinal), decltype(computedDofs), decltype(cellDofs)>;
-    Kokkos::parallel_for(policy, functorTypeHCurlCells(basisCoeffs, negPartialProjAtBasisEPoints,  nonWeightedBasisAtBasisEPoints,
-        basisAtBasisEPoints, hcurlBasisCurlAtBasisEPoints, basisEWeights, wHcurlBasisCurlAtBasisEPoints, targetEWeights,
-        hcurlBasisCurlAtTargetEPoints, wHcurlBasisCurlAtTargetEPoints, tagToOrdinal, computedDofs, cellHCurlDof,
-        numCellDofs, offsetBasis, numSideDofs, dim));
-
-    FunctionSpaceTools<DeviceType >::integrate(Kokkos::subview(massMat_, Kokkos::ALL(), range_H,range_B), nonWeightedBasisAtBasisEPoints, wHcurlBasisCurlAtBasisEPoints);
-    FunctionSpaceTools<DeviceType >::integrate(Kokkos::subview(rhsMatTrans, Kokkos::ALL(), range_B), Kokkos::subview(targetAtEPoints, Kokkos::ALL(), targetEPointsRange(dim,0), Kokkos::ALL()), wHcurlBasisCurlAtTargetEPoints);
-    FunctionSpaceTools<DeviceType >::integrate(Kokkos::subview(rhsMatTrans, Kokkos::ALL(), range_B), negPartialProjAtBasisEPoints, wHcurlBasisCurlAtBasisEPoints,true);
-  }
-  delete hcurlBasis;
-
-  typedef Kokkos::DynRankView<scalarType, Kokkos::LayoutRight, DeviceType> WorkArrayViewType;
-  ScalarViewType t_("t",numCells, numCellDofs+numCurlInteriorDOFs);
-  WorkArrayViewType w_("w",numCells, numCellDofs+numCurlInteriorDOFs);
-
-  ElemSystem cellSystem("cellSystem", true);
-  cellSystem.solve(basisCoeffs, massMat_, rhsMatTrans, t_, w_, cellDofs, numCellDofs, numCurlInteriorDOFs);
 }
 
 }  // Intrepid2 namespace

--- a/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefHGRAD.hpp
+++ b/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefHGRAD.hpp
@@ -41,7 +41,7 @@
 // @HEADER
 
 /** \file   Intrepid2_ProjectionToolsDefHGRAD.hpp
-    \brief  Header file for the Intrepid2::Experimental::ProjectionTools
+    \brief  Header file for the Intrepid2::ProjectionTools
             containing definitions for HGRAD projections.
     \author Created by Mauro Perego
  */
@@ -321,36 +321,6 @@ struct ComputeBasisCoeffsOnCells_HGRAD {
 
 } // FunctorsProjectionTools namespace
 
-#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-namespace Experimental {
-
-template<typename DeviceType>
-template<typename BasisType, typename OrientationViewType>
-void
-ProjectionTools<DeviceType>::getHGradEvaluationPoints(typename BasisType::ScalarViewType ePoints,
-    typename BasisType::ScalarViewType gradEPoints,
-    const OrientationViewType,// orts,
-    const BasisType* cellBasis,
-    ProjectionStruct<DeviceType, typename BasisType::scalarType> * projStruct,
-    const EvalPointsType evalPointType) {
-      RealSpaceTools<DeviceType>::clone(ePoints, projStruct->getAllEvalPoints(evalPointType));
-      RealSpaceTools<DeviceType>::clone(gradEPoints, projStruct->getAllDerivEvalPoints(evalPointType));
-}
-
-template<typename DeviceType>
-template<class BasisCoeffsViewType, class TargetValueViewType, class TargetGradViewType, class BasisType, class OrientationViewType>
-void
-ProjectionTools<DeviceType>::getHGradBasisCoeffs(BasisCoeffsViewType basisCoeffs,
-                                          const TargetValueViewType targetAtTargetEPoints,
-                                          const TargetGradViewType targetGradAtTargetGradEPoints,
-                                          const typename BasisType::ScalarViewType,// targetEPoints,
-                                          const typename BasisType::ScalarViewType,// targetGradEPoints,
-                                          const OrientationViewType orts,
-                                          const BasisType* cellBasis,
-                                          ProjectionStruct<DeviceType, typename BasisType::scalarType> * projStruct) {
-                                            getHGradBasisCoeffs(basisCoeffs, targetAtTargetEPoints, targetGradAtTargetGradEPoints, orts, cellBasis, projStruct);
-                                          }
-#endif
 
 template<typename DeviceType>
 template<class BasisCoeffsViewType, class TargetValueViewType, class TargetGradViewType, class BasisType, class OrientationViewType>
@@ -405,9 +375,7 @@ ProjectionTools<DeviceType>::getHGradBasisCoeffs(BasisCoeffsViewType basisCoeffs
   ScalarViewType basisAtTargetEPoints("basisAtTargetEPoints",numCells,basisCardinality, numTotalTargetEPoints);
   {
     ScalarViewType nonOrientedBasisAtTargetEPoints("nonOrientedBasisAtTargetEPoints",basisCardinality, numTotalTargetEPoints);
-    for(ordinal_type ic=0; ic<numCells; ++ic) {
-      cellBasis->getValues(nonOrientedBasisAtTargetEPoints, targetEPoints);
-    }
+    cellBasis->getValues(nonOrientedBasisAtTargetEPoints, targetEPoints);
     OrientationTools<DeviceType>::modifyBasisByOrientation(basisAtTargetEPoints, nonOrientedBasisAtTargetEPoints, orts, cellBasis);
   }
 
@@ -421,11 +389,8 @@ ProjectionTools<DeviceType>::getHGradBasisCoeffs(BasisCoeffsViewType basisCoeffs
     basisGradAtTargetGradEPoints = ScalarViewType("basisGradAtTargetGradEPoints",numCells,basisCardinality, numTotalTargetGradEPoints, dim);
     nonOrientedBasisGradAtTargetGradEPoints = ScalarViewType("nonOrientedBasisGradAtTargetGradEPoints",basisCardinality, numTotalTargetGradEPoints, dim);
 
-    for(ordinal_type ic=0; ic<numCells; ++ic) {
-      cellBasis->getValues(nonOrientedBasisGradAtBasisGradEPoints, basisGradEPoints, OPERATOR_GRAD);
-      cellBasis->getValues(nonOrientedBasisGradAtTargetGradEPoints, targetGradEPoints, OPERATOR_GRAD);
-    }
-
+    cellBasis->getValues(nonOrientedBasisGradAtBasisGradEPoints, basisGradEPoints, OPERATOR_GRAD);
+    cellBasis->getValues(nonOrientedBasisGradAtTargetGradEPoints, targetGradEPoints, OPERATOR_GRAD);
     OrientationTools<DeviceType>::modifyBasisByOrientation(basisGradAtBasisGradEPoints, nonOrientedBasisGradAtBasisGradEPoints, orts, cellBasis);
     OrientationTools<DeviceType>::modifyBasisByOrientation(basisGradAtTargetGradEPoints, nonOrientedBasisGradAtTargetGradEPoints, orts, cellBasis);
   }
@@ -602,9 +567,7 @@ ProjectionTools<DeviceType>::getHGradBasisCoeffs(BasisCoeffsViewType basisCoeffs
     cellSystem.solve(basisCoeffs, cellMassMat_, cellRhsMat_, t_, w_, cellDofs, numElemDofs);
   }
 }
-#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-}
-#endif
+
 }  // Intrepid2 namespace
 
 #endif

--- a/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefHGRAD.hpp
+++ b/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefHGRAD.hpp
@@ -84,28 +84,28 @@ struct ComputeBasisCoeffsOnVertices_HGRAD {
       ordinal_type idof = tagToOrdinal_(0, iv, 0);
       ordinal_type pt = targetEPointsRange_(0,iv).first;
       //the value of the basis at the vertex might be different than 1; HGrad basis, so the function is scalar
-      basisCoeffs_(ic,idof) = targetAtTargetEPoints_(ic,pt)/basisAtTargetEPoints_(ic,idof,pt,0);
+      basisCoeffs_(ic,idof) = targetAtTargetEPoints_(ic,pt)/basisAtTargetEPoints_(idof,pt,0);
     }
   }
 };
 
 template<typename ViewType1, typename ViewType2, typename ViewType3,
-typename ViewType4, typename ViewType5, typename ViewType6>
+typename ViewType4, typename ViewType5>
 struct ComputeBasisCoeffsOnEdges_HGRAD {
   const ViewType1 basisCoeffs_;
-  const ViewType2 negPartialProjGrad_;
-  const ViewType2 basisTanAtEPoints_;
-  const ViewType2 basisGradAtBasisGradEPoints_;
-  const ViewType3 basisGradEWeights_;
-  const ViewType2 wBasisAtBasisGradEPoints_;
-  const ViewType3 targetGradEWeights_;
-  const ViewType2 basisGradAtTargetGradEPoints_;
-  const ViewType2 wBasisAtTargetGradEPoints_;
-  const ViewType4 computedDofs_;
-  const ViewType5 tagToOrdinal_;
-  const ViewType2 targetGradTanAtTargetGradEPoints_;
-  const ViewType6 targetGradAtTargetGradEPoints_;
-  const ViewType2 refEdgesTan_;
+  const ViewType1 negPartialProjGrad_;
+  const ViewType1 basisTanAtEPoints_;
+  const ViewType1 basisGradAtBasisGradEPoints_;
+  const ViewType2 basisGradEWeights_;
+  const ViewType1 wBasisAtBasisGradEPoints_;
+  const ViewType2 targetGradEWeights_;
+  const ViewType1 basisGradAtTargetGradEPoints_;
+  const ViewType1 wBasisAtTargetGradEPoints_;
+  const ViewType3 computedDofs_;
+  const ViewType4 tagToOrdinal_;
+  const ViewType1 targetGradTanAtTargetGradEPoints_;
+  const ViewType5 targetGradAtTargetGradEPoints_;
+  const ViewType1 refEdgeTan_;
   ordinal_type edgeCardinality_;
   ordinal_type offsetBasis_;
   ordinal_type offsetTarget_;
@@ -114,17 +114,17 @@ struct ComputeBasisCoeffsOnEdges_HGRAD {
   ordinal_type dim_;
   ordinal_type iedge_;
 
-  ComputeBasisCoeffsOnEdges_HGRAD(const ViewType1 basisCoeffs, ViewType2 negPartialProjGrad,  const ViewType2 basisTanAtEPoints,
-      const ViewType2 basisGradAtBasisGradEPoints, const ViewType3 basisGradEWeights,  const ViewType2 wBasisAtBasisGradEPoints,   const ViewType3 targetGradEWeights,
-      const ViewType2 basisGradAtTargetGradEPoints, const ViewType2 wBasisAtTargetGradEPoints, const ViewType4 computedDofs, const ViewType5 tagToOrdinal,
-      const ViewType2 targetGradTanAtTargetGradEPoints, const ViewType6 targetGradAtTargetGradEPoints, const ViewType2 refEdgesTan,
+  ComputeBasisCoeffsOnEdges_HGRAD(const ViewType1 basisCoeffs, ViewType1 negPartialProjGrad,  const ViewType1 basisTanAtEPoints,
+      const ViewType1 basisGradAtBasisGradEPoints, const ViewType2 basisGradEWeights,  const ViewType1 wBasisAtBasisGradEPoints,   const ViewType2 targetGradEWeights,
+      const ViewType1 basisGradAtTargetGradEPoints, const ViewType1 wBasisAtTargetGradEPoints, const ViewType3 computedDofs, const ViewType4 tagToOrdinal,
+      const ViewType1 targetGradTanAtTargetGradEPoints, const ViewType5 targetGradAtTargetGradEPoints, const ViewType1 refEdgeTan,
       ordinal_type edgeCardinality, ordinal_type offsetBasis,
       ordinal_type offsetTarget, ordinal_type numVertexDofs, ordinal_type edgeDim, ordinal_type dim, ordinal_type iedge) :
         basisCoeffs_(basisCoeffs), negPartialProjGrad_(negPartialProjGrad), basisTanAtEPoints_(basisTanAtEPoints),
         basisGradAtBasisGradEPoints_(basisGradAtBasisGradEPoints), basisGradEWeights_(basisGradEWeights), wBasisAtBasisGradEPoints_(wBasisAtBasisGradEPoints), targetGradEWeights_(targetGradEWeights),
         basisGradAtTargetGradEPoints_(basisGradAtTargetGradEPoints), wBasisAtTargetGradEPoints_(wBasisAtTargetGradEPoints),
         computedDofs_(computedDofs), tagToOrdinal_(tagToOrdinal), targetGradTanAtTargetGradEPoints_(targetGradTanAtTargetGradEPoints),
-        targetGradAtTargetGradEPoints_(targetGradAtTargetGradEPoints), refEdgesTan_(refEdgesTan),
+        targetGradAtTargetGradEPoints_(targetGradAtTargetGradEPoints), refEdgeTan_(refEdgeTan),
         edgeCardinality_(edgeCardinality), offsetBasis_(offsetBasis),
         offsetTarget_(offsetTarget), numVertexDofs_(numVertexDofs), edgeDim_(edgeDim), dim_(dim), iedge_(iedge)
   {}
@@ -135,53 +135,54 @@ struct ComputeBasisCoeffsOnEdges_HGRAD {
 
     ordinal_type numBasisGradEPoints = basisGradEWeights_.extent(0);
     ordinal_type numTargetGradEPoints = targetGradEWeights_.extent(0);
+
+    //this loop could be moved outside of cell loop
     for(ordinal_type j=0; j <edgeCardinality_; ++j) {
       ordinal_type jdof = tagToOrdinal_(edgeDim_, iedge_, j);
 
-      //Note: we are not considering the orientation map since it is simply results in a scalar term for the integrals and it does not affect the projection
       for(ordinal_type iq=0; iq <numBasisGradEPoints; ++iq) {
+        typename ViewType1::value_type tmp =0;
         for(ordinal_type d=0; d <dim_; ++d)
-          basisTanAtEPoints_(ic,j,iq) += basisGradAtBasisGradEPoints_(ic,jdof,offsetBasis_+iq,d)*refEdgesTan_(iedge_, d);
-        wBasisAtBasisGradEPoints_(ic,j,iq) = basisTanAtEPoints_(ic,j,iq)*basisGradEWeights_(iq);
+          tmp += basisGradAtBasisGradEPoints_(jdof,offsetBasis_+iq,d)*refEdgeTan_(d);
+        basisTanAtEPoints_(0,j,iq) = tmp;
+        wBasisAtBasisGradEPoints_(ic,j,iq) = tmp*basisGradEWeights_(iq);
       }
       for(ordinal_type iq=0; iq <numTargetGradEPoints; ++iq) {
         for(ordinal_type d=0; d <dim_; ++d)
-          wBasisAtTargetGradEPoints_(ic,j,iq) += basisGradAtTargetGradEPoints_(ic,jdof,offsetTarget_+iq,d)*refEdgesTan_(iedge_, d)*targetGradEWeights_(iq);
+          wBasisAtTargetGradEPoints_(ic,j,iq) += basisGradAtTargetGradEPoints_(jdof,offsetTarget_+iq,d)*refEdgeTan_(d)*targetGradEWeights_(iq);
       }
     }
 
     for(ordinal_type iq=0; iq <numTargetGradEPoints; ++iq)
       for(ordinal_type d=0; d <dim_; ++d)
-        targetGradTanAtTargetGradEPoints_(ic,iq) += targetGradAtTargetGradEPoints_(ic,offsetTarget_+iq,d)*refEdgesTan_(iedge_, d);
+        targetGradTanAtTargetGradEPoints_(ic,iq) += targetGradAtTargetGradEPoints_(ic,offsetTarget_+iq,d)*refEdgeTan_(d);
 
     for(ordinal_type j=0; j <numVertexDofs_; ++j) {
       ordinal_type jdof = computedDofs_(j);
       for(ordinal_type iq=0; iq <numBasisGradEPoints; ++iq)
         for(ordinal_type d=0; d <dim_; ++d)
-          negPartialProjGrad_(ic,iq) -=  basisCoeffs_(ic,jdof)*basisGradAtBasisGradEPoints_(ic,jdof,offsetBasis_+iq,d)*refEdgesTan_(iedge_, d);
+          negPartialProjGrad_(ic,iq) -=  basisCoeffs_(ic,jdof)*basisGradAtBasisGradEPoints_(jdof,offsetBasis_+iq,d)*refEdgeTan_(d);
     }
   }
 };
 
 template<typename ViewType1, typename ViewType2, typename ViewType3,
-typename ViewType4, typename ViewType5, typename ViewType6, typename ViewType7, typename ViewType8>
+typename ViewType4, typename ViewType5>
 struct ComputeBasisCoeffsOnFaces_HGRAD {
   const ViewType1 basisCoeffs_;
-  const ViewType2 negPartialProjGrad_;
-  const ViewType2 faceBasisGradAtGradEPoints_;
-  const ViewType2 basisGradAtBasisGradEPoints_;
-  const ViewType3 basisGradEWeights_;
-  const ViewType2 wBasisGradAtGradEPoints_;
-  const ViewType3 targetGradEWeights_;
-  const ViewType2 basisGradAtTargetGradEPoints_;
-  const ViewType2 wBasisGradBasisAtTargetGradEPoints_;
-  const ViewType4 computedDofs_;
-  const ViewType5 tagToOrdinal_;
-  const ViewType6 orts_;
-  const ViewType2 targetGradTanAtTargetGradEPoints_;
-  const ViewType7 targetGradAtTargetGradEPoints_;
-  const ViewType2 faceCoeff_;
-  const ViewType8 faceParametrization_;
+  const ViewType1 negPartialProjGrad_;
+  const ViewType1 faceBasisGradAtGradEPoints_;
+  const ViewType1 basisGradAtBasisGradEPoints_;
+  const ViewType2 basisGradEWeights_;
+  const ViewType1 wBasisGradAtGradEPoints_;
+  const ViewType2 targetGradEWeights_;
+  const ViewType1 basisGradAtTargetGradEPoints_;
+  const ViewType1 wBasisGradBasisAtTargetGradEPoints_;
+  const ViewType3 computedDofs_;
+  const ViewType4 tagToOrdinal_;
+  const ViewType1 targetGradTanAtTargetGradEPoints_;
+  const ViewType5 targetGradAtTargetGradEPoints_;
+  const ViewType1 refFaceNormal_;
   ordinal_type faceCardinality_;
   ordinal_type offsetBasisGrad_;
   ordinal_type offsetTargetGrad_;
@@ -190,42 +191,34 @@ struct ComputeBasisCoeffsOnFaces_HGRAD {
   ordinal_type faceDim_;
   ordinal_type dim_;
   ordinal_type iface_;
-  unsigned topoKey_;
 
-  ComputeBasisCoeffsOnFaces_HGRAD(const ViewType1 basisCoeffs, ViewType2 negPartialProjGrad,  const ViewType2 faceBasisGradAtGradEPoints,
-      const ViewType2 basisGradAtBasisGradEPoints, const ViewType3 basisGradEWeights,  const ViewType2 wBasisGradAtGradEPoints,   const ViewType3 targetGradEWeights,
-      const ViewType2 basisGradAtTargetGradEPoints, const ViewType2 wBasisGradBasisAtTargetGradEPoints, const ViewType4 computedDofs, const ViewType5 tagToOrdinal,
-      const ViewType6 orts, const ViewType2 targetGradTanAtTargetGradEPoints, const ViewType7 targetGradAtTargetGradEPoints,
-      const ViewType8 faceParametrization, ordinal_type faceCardinality, ordinal_type offsetBasisGrad,
+  ComputeBasisCoeffsOnFaces_HGRAD(const ViewType1 basisCoeffs, ViewType1 negPartialProjGrad,  const ViewType1 faceBasisGradAtGradEPoints,
+      const ViewType1 basisGradAtBasisGradEPoints, const ViewType2 basisGradEWeights,  const ViewType1 wBasisGradAtGradEPoints,   const ViewType2 targetGradEWeights,
+      const ViewType1 basisGradAtTargetGradEPoints, const ViewType1 wBasisGradBasisAtTargetGradEPoints, const ViewType3 computedDofs, const ViewType4 tagToOrdinal,
+      const ViewType1 targetGradTanAtTargetGradEPoints, const ViewType5 targetGradAtTargetGradEPoints,
+      const ViewType1 refFaceNormal, ordinal_type faceCardinality, ordinal_type offsetBasisGrad,
       ordinal_type offsetTargetGrad, ordinal_type numVertexEdgeDofs, ordinal_type numFaces, ordinal_type faceDim,
-      ordinal_type dim, ordinal_type iface, unsigned topoKey) :
+      ordinal_type dim, ordinal_type iface) :
         basisCoeffs_(basisCoeffs), negPartialProjGrad_(negPartialProjGrad), faceBasisGradAtGradEPoints_(faceBasisGradAtGradEPoints),
         basisGradAtBasisGradEPoints_(basisGradAtBasisGradEPoints), basisGradEWeights_(basisGradEWeights), wBasisGradAtGradEPoints_(wBasisGradAtGradEPoints),
         targetGradEWeights_(targetGradEWeights),
         basisGradAtTargetGradEPoints_(basisGradAtTargetGradEPoints), wBasisGradBasisAtTargetGradEPoints_(wBasisGradBasisAtTargetGradEPoints),
-        computedDofs_(computedDofs), tagToOrdinal_(tagToOrdinal), orts_(orts), targetGradTanAtTargetGradEPoints_(targetGradTanAtTargetGradEPoints),
-        targetGradAtTargetGradEPoints_(targetGradAtTargetGradEPoints), faceParametrization_(faceParametrization),
+        computedDofs_(computedDofs), tagToOrdinal_(tagToOrdinal), targetGradTanAtTargetGradEPoints_(targetGradTanAtTargetGradEPoints),
+        targetGradAtTargetGradEPoints_(targetGradAtTargetGradEPoints), refFaceNormal_(refFaceNormal),
         faceCardinality_(faceCardinality), offsetBasisGrad_(offsetBasisGrad),
         offsetTargetGrad_(offsetTargetGrad), numVertexEdgeDofs_(numVertexEdgeDofs), numFaces_(numFaces),
-        faceDim_(faceDim), dim_(dim), iface_(iface), topoKey_(topoKey)
+        faceDim_(faceDim), dim_(dim), iface_(iface)
   {}
 
   void
   KOKKOS_INLINE_FUNCTION
   operator()(const ordinal_type ic) const {
 
-    typename ViewType2::value_type data[3*3];
-    auto tangentsAndNormal = ViewType2(data, 3, 3);
-
-    ordinal_type fOrt[6];
-    orts_(ic).getFaceOrientation(fOrt, numFaces_);
-    ordinal_type ort = fOrt[iface_];
-
     ordinal_type numBasisGradEPoints = basisGradEWeights_.extent(0);
     ordinal_type numTargetGradEPoints = targetGradEWeights_.extent(0);
-    Impl::OrientationTools::getRefSideTangentsAndNormal(tangentsAndNormal, faceParametrization_,topoKey_, iface_, ort);
+
     //normal
-    typename ViewType2::value_type n[3] = {tangentsAndNormal(2,0), tangentsAndNormal(2,1), tangentsAndNormal(2,2)};
+    typename ViewType2::value_type n[3] = {refFaceNormal_(0), refFaceNormal_(1), refFaceNormal_(2)};
 
     for(ordinal_type j=0; j <faceCardinality_; ++j) {
       ordinal_type jdof = tagToOrdinal_(faceDim_, iface_, j);
@@ -233,11 +226,11 @@ struct ComputeBasisCoeffsOnFaces_HGRAD {
         ordinal_type dp1 = (d+1) % dim_;
         ordinal_type dp2 = (d+2) % dim_;
         for(ordinal_type iq=0; iq <numBasisGradEPoints; ++iq) {
-          faceBasisGradAtGradEPoints_(ic,j,iq,d) = basisGradAtBasisGradEPoints_(ic,jdof,offsetBasisGrad_+iq,dp1)*n[dp2] - basisGradAtBasisGradEPoints_(ic,jdof,offsetBasisGrad_+iq,dp2)*n[dp1];        
-          wBasisGradAtGradEPoints_(ic,j,iq,d) = faceBasisGradAtGradEPoints_(ic,j,iq,d) * basisGradEWeights_(iq);
+          faceBasisGradAtGradEPoints_(0,j,iq,d) = basisGradAtBasisGradEPoints_(jdof,offsetBasisGrad_+iq,dp1)*n[dp2] - basisGradAtBasisGradEPoints_(jdof,offsetBasisGrad_+iq,dp2)*n[dp1];        
+          wBasisGradAtGradEPoints_(ic,j,iq,d) = faceBasisGradAtGradEPoints_(0,j,iq,d) * basisGradEWeights_(iq);
         }
         for(ordinal_type iq=0; iq <numTargetGradEPoints; ++iq) {
-          wBasisGradBasisAtTargetGradEPoints_(ic,j,iq,d) = (basisGradAtTargetGradEPoints_(ic,jdof,offsetTargetGrad_+iq,dp1)*n[dp2] - basisGradAtTargetGradEPoints_(ic,jdof,offsetTargetGrad_+iq,dp2)*n[dp1]) * targetGradEWeights_(iq);
+          wBasisGradBasisAtTargetGradEPoints_(ic,j,iq,d) = (basisGradAtTargetGradEPoints_(jdof,offsetTargetGrad_+iq,dp1)*n[dp2] - basisGradAtTargetGradEPoints_(jdof,offsetTargetGrad_+iq,dp2)*n[dp1]) * targetGradEWeights_(iq);
         }
       }
     }
@@ -255,7 +248,7 @@ struct ComputeBasisCoeffsOnFaces_HGRAD {
         ordinal_type dp1 = (d+1) % dim_;
         ordinal_type dp2 = (d+2) % dim_;
         for(ordinal_type iq=0; iq <numBasisGradEPoints; ++iq)
-          negPartialProjGrad_(ic,iq,d) -= (basisGradAtBasisGradEPoints_(ic,jdof,offsetBasisGrad_+iq,dp1)*n[dp2] - basisGradAtBasisGradEPoints_(ic,jdof,offsetBasisGrad_+iq,dp2)*n[dp1]) * basisCoeffs_(ic,jdof);
+          negPartialProjGrad_(ic,iq,d) -= (basisGradAtBasisGradEPoints_(jdof,offsetBasisGrad_+iq,dp1)*n[dp2] - basisGradAtBasisGradEPoints_(jdof,offsetBasisGrad_+iq,dp2)*n[dp1]) * basisCoeffs_(ic,jdof);
       }
     }
   }
@@ -263,28 +256,28 @@ struct ComputeBasisCoeffsOnFaces_HGRAD {
 
 
 template<typename ViewType1, typename ViewType2, typename ViewType3,
-typename ViewType4, typename ViewType5>
+typename ViewType4>
 struct ComputeBasisCoeffsOnCells_HGRAD {
   const ViewType1 basisCoeffs_;
-  const ViewType2 negPartialProjGrad_;
-  const ViewType2 cellBasisGradAtGradEPoints_;
-  const ViewType2 basisGradAtBasisGradEPoints_;
-  const ViewType3 basisGradEWeights_;
-  const ViewType2 wBasisGradAtGradEPoints_;
-  const ViewType3 targetGradEWeights_;
-  const ViewType2 basisGradAtTargetGradEPoints_;
-  const ViewType2 wBasisGradBasisAtTargetGradEPoints_;
-  const ViewType4 computedDofs_;
-  const ViewType5 elemDof_;
+  const ViewType1 negPartialProjGrad_;
+  const ViewType1 cellBasisGradAtGradEPoints_;
+  const ViewType1 basisGradAtBasisGradEPoints_;
+  const ViewType2 basisGradEWeights_;
+  const ViewType1 wBasisGradAtGradEPoints_;
+  const ViewType2 targetGradEWeights_;
+  const ViewType1 basisGradAtTargetGradEPoints_;
+  const ViewType1 wBasisGradBasisAtTargetGradEPoints_;
+  const ViewType3 computedDofs_;
+  const ViewType4 elemDof_;
   ordinal_type dim_;
   ordinal_type numElemDofs_;
   ordinal_type offsetBasisGrad_;
   ordinal_type offsetTargetGrad_;
   ordinal_type numVertexEdgeFaceDofs_;
 
-  ComputeBasisCoeffsOnCells_HGRAD(const ViewType1 basisCoeffs, ViewType2 negPartialProjGrad,  const ViewType2 cellBasisGradAtGradEPoints,
-      const ViewType2 basisGradAtBasisGradEPoints, const ViewType3 basisGradEWeights,  const ViewType2 wBasisGradAtGradEPoints,   const ViewType3 targetGradEWeights,
-      const ViewType2 basisGradAtTargetGradEPoints, const ViewType2 wBasisGradBasisAtTargetGradEPoints, const ViewType4 computedDofs, const ViewType5 elemDof,
+  ComputeBasisCoeffsOnCells_HGRAD(const ViewType1 basisCoeffs, ViewType1 negPartialProjGrad,  const ViewType1 cellBasisGradAtGradEPoints,
+      const ViewType1 basisGradAtBasisGradEPoints, const ViewType2 basisGradEWeights,  const ViewType1 wBasisGradAtGradEPoints,   const ViewType2 targetGradEWeights,
+      const ViewType1 basisGradAtTargetGradEPoints, const ViewType1 wBasisGradBasisAtTargetGradEPoints, const ViewType3 computedDofs, const ViewType4 elemDof,
       ordinal_type dim, ordinal_type numElemDofs, ordinal_type offsetBasisGrad, ordinal_type offsetTargetGrad, ordinal_type numVertexEdgeFaceDofs) :
         basisCoeffs_(basisCoeffs), negPartialProjGrad_(negPartialProjGrad), cellBasisGradAtGradEPoints_(cellBasisGradAtGradEPoints),
         basisGradAtBasisGradEPoints_(basisGradAtBasisGradEPoints), basisGradEWeights_(basisGradEWeights), wBasisGradAtGradEPoints_(wBasisGradAtGradEPoints), targetGradEWeights_(targetGradEWeights),
@@ -301,11 +294,11 @@ struct ComputeBasisCoeffsOnCells_HGRAD {
       ordinal_type idof = elemDof_(j);
       for(ordinal_type d=0; d <dim_; ++d) {
         for(ordinal_type iq=0; iq <numBasisGradEPoints; ++iq) {
-          cellBasisGradAtGradEPoints_(ic,j,iq,d) = basisGradAtBasisGradEPoints_(ic,idof,offsetBasisGrad_+iq,d);
-          wBasisGradAtGradEPoints_(ic,j,iq,d) = cellBasisGradAtGradEPoints_(ic,j,iq,d) * basisGradEWeights_(iq);
+          cellBasisGradAtGradEPoints_(0,j,iq,d) = basisGradAtBasisGradEPoints_(idof,offsetBasisGrad_+iq,d);
+          wBasisGradAtGradEPoints_(ic,j,iq,d) = cellBasisGradAtGradEPoints_(0,j,iq,d) * basisGradEWeights_(iq);
         }
         for(ordinal_type iq=0; iq <numTargetGradEPoints; ++iq) {
-          wBasisGradBasisAtTargetGradEPoints_(ic,j,iq,d )= basisGradAtTargetGradEPoints_(ic,idof,offsetTargetGrad_+iq,d) * targetGradEWeights_(iq);
+          wBasisGradBasisAtTargetGradEPoints_(ic,j,iq,d )= basisGradAtTargetGradEPoints_(idof,offsetTargetGrad_+iq,d) * targetGradEWeights_(iq);
         }
       }
     }
@@ -313,7 +306,7 @@ struct ComputeBasisCoeffsOnCells_HGRAD {
       ordinal_type jdof = computedDofs_(j);
       for(ordinal_type iq=0; iq <numBasisGradEPoints; ++iq)
         for(ordinal_type d=0; d <dim_; ++d) {
-          negPartialProjGrad_(ic,iq,d) -=  basisCoeffs_(ic,jdof)*basisGradAtBasisGradEPoints_(ic,jdof,offsetBasisGrad_+iq,d);
+          negPartialProjGrad_(ic,iq,d) -=  basisCoeffs_(ic,jdof)*basisGradAtBasisGradEPoints_(jdof,offsetBasisGrad_+iq,d);
         }
     }
   }
@@ -350,7 +343,8 @@ ProjectionTools<DeviceType>::getHGradBasisCoeffs(BasisCoeffsViewType basisCoeffs
   ordinal_type numEdges = (cellBasis->getDofCount(1, 0) > 0) ? cellTopo.getEdgeCount() : 0;
   ordinal_type numFaces = (cellBasis->getDofCount(2, 0) > 0) ? cellTopo.getFaceCount() : 0;
 
-  ScalarViewType refEdgesTan("refEdgesTan",  numEdges, dim);
+  ScalarViewType refEdgeTan("refTan", dim);
+  ScalarViewType refFaceNormal("refNormal", dim);
 
   ordinal_type numVertexDofs = numVertices;
 
@@ -372,34 +366,22 @@ ProjectionTools<DeviceType>::getHGradBasisCoeffs(BasisCoeffsViewType basisCoeffs
   auto targetGradEPoints = projStruct->getAllDerivEvalPoints(EvalPointsType::TARGET);
 
 
-  ScalarViewType basisAtTargetEPoints("basisAtTargetEPoints",numCells,basisCardinality, numTotalTargetEPoints);
-  {
-    ScalarViewType nonOrientedBasisAtTargetEPoints("nonOrientedBasisAtTargetEPoints",basisCardinality, numTotalTargetEPoints);
-    cellBasis->getValues(nonOrientedBasisAtTargetEPoints, targetEPoints);
-    OrientationTools<DeviceType>::modifyBasisByOrientation(basisAtTargetEPoints, nonOrientedBasisAtTargetEPoints, orts, cellBasis);
-  }
+  ScalarViewType basisAtTargetEPoints("basisAtTargetEPoints",basisCardinality, numTotalTargetEPoints);
+  cellBasis->getValues(basisAtTargetEPoints, targetEPoints);
 
   ScalarViewType basisGradAtBasisGradEPoints;
   ScalarViewType basisGradAtTargetGradEPoints;
   if(numTotalBasisGradEPoints>0) {
-    ScalarViewType nonOrientedBasisGradAtTargetGradEPoints, nonOrientedBasisGradAtBasisGradEPoints;
+    basisGradAtBasisGradEPoints = ScalarViewType ("basisGradAtBasisGradEPoints",basisCardinality, numTotalBasisGradEPoints, dim);
+    basisGradAtTargetGradEPoints = ScalarViewType("basisGradAtTargetGradEPoints",basisCardinality, numTotalTargetGradEPoints, dim);
 
-    basisGradAtBasisGradEPoints = ScalarViewType ("basisGradAtBasisGradEPoints",numCells,basisCardinality, numTotalBasisGradEPoints, dim);
-    nonOrientedBasisGradAtBasisGradEPoints = ScalarViewType ("nonOrientedBasisGradAtBasisGradEPoints",basisCardinality, numTotalBasisGradEPoints, dim);
-    basisGradAtTargetGradEPoints = ScalarViewType("basisGradAtTargetGradEPoints",numCells,basisCardinality, numTotalTargetGradEPoints, dim);
-    nonOrientedBasisGradAtTargetGradEPoints = ScalarViewType("nonOrientedBasisGradAtTargetGradEPoints",basisCardinality, numTotalTargetGradEPoints, dim);
-
-    cellBasis->getValues(nonOrientedBasisGradAtBasisGradEPoints, basisGradEPoints, OPERATOR_GRAD);
-    cellBasis->getValues(nonOrientedBasisGradAtTargetGradEPoints, targetGradEPoints, OPERATOR_GRAD);
-    OrientationTools<DeviceType>::modifyBasisByOrientation(basisGradAtBasisGradEPoints, nonOrientedBasisGradAtBasisGradEPoints, orts, cellBasis);
-    OrientationTools<DeviceType>::modifyBasisByOrientation(basisGradAtTargetGradEPoints, nonOrientedBasisGradAtTargetGradEPoints, orts, cellBasis);
+    cellBasis->getValues(basisGradAtBasisGradEPoints, basisGradEPoints, OPERATOR_GRAD);
+    cellBasis->getValues(basisGradAtTargetGradEPoints, targetGradEPoints, OPERATOR_GRAD);
   }
 
   auto targetEPointsRange = Kokkos::create_mirror_view_and_copy(MemSpaceType(), projStruct->getTargetPointsRange());
   auto targetGradEPointsRange  = projStruct->getTargetDerivPointsRange();
   auto basisGradEPointsRange  = projStruct->getBasisDerivPointsRange();
-
-  auto refTopologyKey =  projStruct->getTopologyKey();
 
   auto tagToOrdinal = Kokkos::create_mirror_view_and_copy(MemSpaceType(), cellBasis->getAllDofOrdinal());
 
@@ -414,13 +396,13 @@ ProjectionTools<DeviceType>::getHGradBasisCoeffs(BasisCoeffsViewType basisCoeffs
   });
   ordinal_type computedDofsCount = numVertices;
 
-  const Kokkos::RangePolicy<ExecSpaceType> policy(0, numCells);
-  using functorType = FunctorsProjectionTools::ComputeBasisCoeffsOnVertices_HGRAD<decltype(basisCoeffs), decltype(tagToOrdinal), decltype(targetEPointsRange),
-      decltype(targetAtTargetEPoints), decltype(basisAtTargetEPoints)>;
-  Kokkos::parallel_for(policy, functorType(basisCoeffs, tagToOrdinal, targetEPointsRange,
-      targetAtTargetEPoints, basisAtTargetEPoints, numVertices));
+  ScalarViewType refBasisCoeffs("refBasisCoeffs", basisCoeffs.extent(0), basisCoeffs.extent(1));
 
-//  printView(basisCoeffs, std::cout, "after vertex evaluation, basisCoeffs");
+  const Kokkos::RangePolicy<ExecSpaceType> policy(0, numCells);
+  using functorType = FunctorsProjectionTools::ComputeBasisCoeffsOnVertices_HGRAD<ScalarViewType, decltype(tagToOrdinal), decltype(targetEPointsRange),
+      decltype(targetAtTargetEPoints), decltype(basisAtTargetEPoints)>;
+  Kokkos::parallel_for(policy, functorType(refBasisCoeffs, tagToOrdinal, targetEPointsRange,
+      targetAtTargetEPoints, basisAtTargetEPoints, numVertices));
   
   for(ordinal_type ie=0; ie<numEdges; ++ie)  {
 
@@ -432,29 +414,28 @@ ProjectionTools<DeviceType>::getHGradBasisCoeffs(BasisCoeffsViewType basisCoeffs
     auto basisGradEWeights = Kokkos::create_mirror_view_and_copy(MemSpaceType(),projStruct->getBasisDerivEvalWeights(edgeDim,ie));
     auto targetGradEWeights = Kokkos::create_mirror_view_and_copy(MemSpaceType(),projStruct->getTargetDerivEvalWeights(edgeDim,ie));
 
-    auto edgeTan = Kokkos::subview(refEdgesTan, ie, Kokkos::ALL());
-    CellTools<DeviceType>::getReferenceEdgeTangent(edgeTan, ie, cellTopo);
+    CellTools<DeviceType>::getReferenceEdgeTangent(refEdgeTan, ie, cellTopo);
 
-    ScalarViewType basisTanAtEPoints("basisTanAtEPoints",numCells,edgeCardinality, numBasisGradEPoints);
+    ScalarViewType basisTanAtEPoints("basisTanAtEPoints",1,edgeCardinality, numBasisGradEPoints);
     ScalarViewType targetGradTanAtTargetGradEPoints("tanBasisAtTargetGradEPoints",numCells, numTargetGradEPoints);
     ScalarViewType wBasisAtBasisGradEPoints("wTanBasisAtBasisGradEPoints",numCells,edgeCardinality, numBasisGradEPoints);
     ScalarViewType wBasisAtTargetGradEPoints("wTanBasisAtTargetGradEPoints",numCells,edgeCardinality, numTargetGradEPoints);
     ScalarViewType negPartialProjGrad("negPartialProjGrad", numCells, numBasisGradEPoints);
 
-    using functorTypeEdge = FunctorsProjectionTools::ComputeBasisCoeffsOnEdges_HGRAD<decltype(basisCoeffs), ScalarViewType,  decltype(basisGradEWeights),
+    using functorTypeEdge = FunctorsProjectionTools::ComputeBasisCoeffsOnEdges_HGRAD<ScalarViewType,  decltype(basisGradEWeights),
         decltype(computedDofs), decltype(tagToOrdinal), decltype(targetGradAtTargetGradEPoints)>;
 
-    Kokkos::parallel_for(policy, functorTypeEdge(basisCoeffs, negPartialProjGrad,  basisTanAtEPoints,
+    Kokkos::parallel_for(policy, functorTypeEdge(refBasisCoeffs, negPartialProjGrad,  basisTanAtEPoints,
         basisGradAtBasisGradEPoints, basisGradEWeights,  wBasisAtBasisGradEPoints,   targetGradEWeights,
         basisGradAtTargetGradEPoints, wBasisAtTargetGradEPoints, computedDofs, tagToOrdinal,
-        targetGradTanAtTargetGradEPoints, targetGradAtTargetGradEPoints, refEdgesTan,
+        targetGradTanAtTargetGradEPoints, targetGradAtTargetGradEPoints, refEdgeTan,
         edgeCardinality, offsetBasis,
         offsetTarget, numVertexDofs, edgeDim, dim, ie));
 
-    ScalarViewType edgeMassMat_("edgeMassMat_", numCells, edgeCardinality, edgeCardinality),
+    ScalarViewType edgeMassMat_("edgeMassMat_", 1, edgeCardinality, edgeCardinality),
         edgeRhsMat_("rhsMat_", numCells, edgeCardinality);
 
-    FunctionSpaceTools<DeviceType >::integrate(edgeMassMat_, basisTanAtEPoints, wBasisAtBasisGradEPoints);
+    FunctionSpaceTools<DeviceType >::integrate(edgeMassMat_, basisTanAtEPoints, Kokkos::subview(wBasisAtBasisGradEPoints, std::make_pair(0,1), Kokkos::ALL(), Kokkos::ALL()) );
     FunctionSpaceTools<DeviceType >::integrate(edgeRhsMat_, targetGradTanAtTargetGradEPoints, wBasisAtTargetGradEPoints);
     FunctionSpaceTools<DeviceType >::integrate(edgeRhsMat_, negPartialProjGrad, wBasisAtBasisGradEPoints,true);
 
@@ -464,8 +445,8 @@ ProjectionTools<DeviceType>::getHGradBasisCoeffs(BasisCoeffsViewType basisCoeffs
 
     auto edgeDofs = Kokkos::subview(tagToOrdinal, edgeDim, ie, Kokkos::ALL());
 
-    ElemSystem edgeSystem("edgeSystem", false);
-    edgeSystem.solve(basisCoeffs, edgeMassMat_, edgeRhsMat_, t_, w_, edgeDofs, edgeCardinality);
+    ElemSystem edgeSystem("edgeSystem", true);
+    edgeSystem.solve(refBasisCoeffs, edgeMassMat_, edgeRhsMat_, t_, w_, edgeDofs, edgeCardinality);
 
     Kokkos::parallel_for("Compute Dofs ", Kokkos::RangePolicy<ExecSpaceType, int> (0, edgeCardinality),
         KOKKOS_LAMBDA (const size_t i) {
@@ -477,8 +458,6 @@ ProjectionTools<DeviceType>::getHGradBasisCoeffs(BasisCoeffsViewType basisCoeffs
 
   for(ordinal_type iface=0; iface<numFaces; ++iface) {
 
-    const auto topoKey = refTopologyKey(faceDim,iface);
-
     ordinal_type faceCardinality = cellBasis->getDofCount(faceDim,iface);
 
     ordinal_type numGradEPoints = range_size(basisGradEPointsRange(faceDim, iface));
@@ -488,28 +467,29 @@ ProjectionTools<DeviceType>::getHGradBasisCoeffs(BasisCoeffsViewType basisCoeffs
     auto basisGradEWeights =  Kokkos::create_mirror_view_and_copy(MemSpaceType(),projStruct->getBasisDerivEvalWeights(faceDim,iface));
     auto targetGradEWeights = Kokkos::create_mirror_view_and_copy(MemSpaceType(),projStruct->getTargetDerivEvalWeights(faceDim,iface));
 
-    ScalarViewType faceBasisGradAtGradEPoints("faceBasisGradAtGradEPoints",numCells,faceCardinality, numGradEPoints,dim);
+    CellTools<DeviceType>::getReferenceFaceNormal(refFaceNormal, iface, cellTopo);
+
+    ScalarViewType faceBasisGradAtGradEPoints("faceBasisGradAtGradEPoints",1,faceCardinality, numGradEPoints,dim);
     ScalarViewType wBasisGradAtGradEPoints("wNormalBasisGradAtGradEPoints",numCells,faceCardinality, numGradEPoints,dim);
     ScalarViewType wBasisGradBasisAtTargetGradEPoints("wNormalBasisGradAtTargetGradEPoints",numCells,faceCardinality, numTargetGradEPoints,dim);
     ScalarViewType targetGradTanAtTargetGradEPoints("targetGradTanAtTargetGradEPoints",numCells, numTargetGradEPoints,dim);
     ScalarViewType negPartialProjGrad("mNormalComputedProjection", numCells,numGradEPoints,dim);
 
-    using functorTypeFace_HGRAD = FunctorsProjectionTools::ComputeBasisCoeffsOnFaces_HGRAD<decltype(basisCoeffs), ScalarViewType,  decltype(basisGradEWeights),
-        decltype(computedDofs), decltype(tagToOrdinal), decltype(orts), decltype(targetGradAtTargetGradEPoints), decltype(subcellParamFace)>;
+    using functorTypeFace_HGRAD = FunctorsProjectionTools::ComputeBasisCoeffsOnFaces_HGRAD<ScalarViewType,  decltype(basisGradEWeights),
+        decltype(computedDofs), decltype(tagToOrdinal), decltype(targetGradAtTargetGradEPoints)>;
 
-    Kokkos::parallel_for(policy, functorTypeFace_HGRAD(basisCoeffs, negPartialProjGrad, faceBasisGradAtGradEPoints,
+    Kokkos::parallel_for(policy, functorTypeFace_HGRAD(refBasisCoeffs, negPartialProjGrad, faceBasisGradAtGradEPoints,
         basisGradAtBasisGradEPoints, basisGradEWeights, wBasisGradAtGradEPoints, targetGradEWeights,
         basisGradAtTargetGradEPoints,wBasisGradBasisAtTargetGradEPoints, computedDofs, tagToOrdinal,
-        orts,targetGradTanAtTargetGradEPoints,targetGradAtTargetGradEPoints,
-        subcellParamFace, faceCardinality, offsetBasisGrad,
+        targetGradTanAtTargetGradEPoints,targetGradAtTargetGradEPoints,
+        refFaceNormal, faceCardinality, offsetBasisGrad,
         offsetTargetGrad, numVertexDofs+numEdgeDofs, numFaces, faceDim,
-        dim, iface, topoKey));
+        dim, iface));
 
-    ScalarViewType faceMassMat_("faceMassMat_", numCells, faceCardinality, faceCardinality),
+    ScalarViewType faceMassMat_("faceMassMat_", 1, faceCardinality, faceCardinality),
         faceRhsMat_("rhsMat_", numCells, faceCardinality);
 
-    FunctionSpaceTools<DeviceType >::integrate(faceMassMat_, faceBasisGradAtGradEPoints, wBasisGradAtGradEPoints);
-
+    FunctionSpaceTools<DeviceType >::integrate(faceMassMat_, faceBasisGradAtGradEPoints, Kokkos::subview(wBasisGradAtGradEPoints, std::make_pair(0,1), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()) );
     FunctionSpaceTools<DeviceType >::integrate(faceRhsMat_, targetGradTanAtTargetGradEPoints, wBasisGradBasisAtTargetGradEPoints);
     FunctionSpaceTools<DeviceType >::integrate(faceRhsMat_, negPartialProjGrad, wBasisGradAtGradEPoints,true);
 
@@ -519,8 +499,8 @@ ProjectionTools<DeviceType>::getHGradBasisCoeffs(BasisCoeffsViewType basisCoeffs
 
     auto faceDofs = Kokkos::subview(tagToOrdinal, faceDim, iface, Kokkos::ALL());
 
-    ElemSystem faceSystem("faceSystem", false);
-    faceSystem.solve(basisCoeffs, faceMassMat_, faceRhsMat_, t_, w_, faceDofs, faceCardinality);
+    ElemSystem faceSystem("faceSystem", true);
+    faceSystem.solve(refBasisCoeffs, faceMassMat_, faceRhsMat_, t_, w_, faceDofs, faceCardinality);
 
     Kokkos::parallel_for("Compute Face Dofs ", Kokkos::RangePolicy<ExecSpaceType, int> (0, faceCardinality),
         KOKKOS_LAMBDA (const size_t i) {
@@ -540,21 +520,21 @@ ProjectionTools<DeviceType>::getHGradBasisCoeffs(BasisCoeffsViewType basisCoeffs
     auto targetGradEWeights = Kokkos::create_mirror_view_and_copy(MemSpaceType(),projStruct->getTargetDerivEvalWeights(dim,0));
     auto basisGradEWeights = Kokkos::create_mirror_view_and_copy(MemSpaceType(),projStruct->getBasisDerivEvalWeights(dim,0));
 
-    ScalarViewType cellBasisGradAtGradEPoints("internalBasisGradAtEPoints",numCells,numElemDofs, numGradEPoints, dim);
+    ScalarViewType cellBasisGradAtGradEPoints("internalBasisGradAtEPoints",1,numElemDofs, numGradEPoints, dim);
     ScalarViewType negPartialProjGrad("negPartialProjGrad", numCells, numGradEPoints, dim);
     ScalarViewType wBasisGradAtGradEPoints("wBasisGradAtGradEPoints",numCells,numElemDofs, numGradEPoints,dim);
     ScalarViewType wBasisGradBasisAtTargetGradEPoints("wBasisGradAtTargetGradEPoints",numCells,numElemDofs, numTargetGradEPoints,dim);
 
     auto elemDof = Kokkos::subview(tagToOrdinal, dim, 0, Kokkos::ALL());
-    using functorTypeCell_HGRAD = FunctorsProjectionTools::ComputeBasisCoeffsOnCells_HGRAD<decltype(basisCoeffs), ScalarViewType,  decltype(basisGradEWeights), decltype(computedDofs), decltype(elemDof)>;
-    Kokkos::parallel_for(policy, functorTypeCell_HGRAD(basisCoeffs, negPartialProjGrad,  cellBasisGradAtGradEPoints,
+    using functorTypeCell_HGRAD = FunctorsProjectionTools::ComputeBasisCoeffsOnCells_HGRAD<ScalarViewType,  decltype(basisGradEWeights), decltype(computedDofs), decltype(elemDof)>;
+    Kokkos::parallel_for(policy, functorTypeCell_HGRAD(refBasisCoeffs, negPartialProjGrad,  cellBasisGradAtGradEPoints,
         basisGradAtBasisGradEPoints, basisGradEWeights,  wBasisGradAtGradEPoints,   targetGradEWeights,
         basisGradAtTargetGradEPoints, wBasisGradBasisAtTargetGradEPoints, computedDofs, elemDof,
         dim, numElemDofs, offsetBasisGrad, offsetTargetGrad, numVertexDofs+numEdgeDofs+numFaceDofs));
-    ScalarViewType cellMassMat_("cellMassMat_", numCells, numElemDofs, numElemDofs),
+    ScalarViewType cellMassMat_("cellMassMat_", 1, numElemDofs, numElemDofs),
         cellRhsMat_("rhsMat_", numCells, numElemDofs);
 
-    FunctionSpaceTools<DeviceType >::integrate(cellMassMat_, cellBasisGradAtGradEPoints, wBasisGradAtGradEPoints);
+    FunctionSpaceTools<DeviceType >::integrate(cellMassMat_, cellBasisGradAtGradEPoints, Kokkos::subview(wBasisGradAtGradEPoints, std::make_pair(0,1), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()) );
     FunctionSpaceTools<DeviceType >::integrate(cellRhsMat_, Kokkos::subview(targetGradAtTargetGradEPoints,Kokkos::ALL(),cellTargetGradEPointsRange,Kokkos::ALL()), wBasisGradBasisAtTargetGradEPoints);
     FunctionSpaceTools<DeviceType >::integrate(cellRhsMat_, negPartialProjGrad, wBasisGradAtGradEPoints, true);
 
@@ -564,8 +544,11 @@ ProjectionTools<DeviceType>::getHGradBasisCoeffs(BasisCoeffsViewType basisCoeffs
 
     auto cellDofs = Kokkos::subview(tagToOrdinal, dim, 0, Kokkos::ALL());
     ElemSystem cellSystem("cellSystem", true);
-    cellSystem.solve(basisCoeffs, cellMassMat_, cellRhsMat_, t_, w_, cellDofs, numElemDofs);
+    cellSystem.solve(refBasisCoeffs, cellMassMat_, cellRhsMat_, t_, w_, cellDofs, numElemDofs);
   }
+
+  OrientationTools<DeviceType>::modifyBasisByOrientationInverse(basisCoeffs, refBasisCoeffs, orts, cellBasis, true);
+
 }
 
 }  // Intrepid2 namespace

--- a/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefHVOL.hpp
+++ b/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefHVOL.hpp
@@ -41,7 +41,7 @@
 // @HEADER
 
 /** \file   Intrepid2_ProjectionToolsDefHVOL.hpp
-    \brief  Header file for the Intrepid2::Experimental::ProjectionTools
+    \brief  Header file for the Intrepid2::ProjectionTools
             containing definitions for HVOL projections.
     \author Created by Mauro Perego
  */
@@ -55,37 +55,6 @@
 
 
 namespace Intrepid2 {
-
-#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-namespace Experimental {
-
-template<typename DeviceType>
-template<typename BasisType,
-typename ortValueType,       class ...ortProperties>
-void
-ProjectionTools<DeviceType>::getHVolEvaluationPoints(typename BasisType::ScalarViewType ePoints,
-    const Kokkos::DynRankView<ortValueType,   ortProperties...>  /*orts*/,
-    const BasisType* cellBasis,
-    ProjectionStruct<DeviceType, typename BasisType::scalarType> * projStruct,
-    const EvalPointsType ePointType) {
-   RealSpaceTools<DeviceType>::clone(ePoints, projStruct->getAllEvalPoints(ePointType));
-}
-
-template<typename DeviceType>
-template<typename basisCoeffsValueType, class ...basisCoeffsProperties,
-typename funValsValueType, class ...funValsProperties,
-typename BasisType,
-typename ortValueType,class ...ortProperties>
-void
-ProjectionTools<DeviceType>::getHVolBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueType,basisCoeffsProperties...> basisCoeffs,
-    const Kokkos::DynRankView<funValsValueType,funValsProperties...> targetAtTargetEPoints,
-    const typename BasisType::ScalarViewType targetEPoints,
-    const Kokkos::DynRankView<ortValueType,   ortProperties...>  orts,
-    const BasisType* cellBasis,
-    ProjectionStruct<DeviceType, typename BasisType::scalarType> * projStruct){
-      getHVolBasisCoeffs(basisCoeffs, targetAtTargetEPoints, orts, cellBasis, projStruct);
-}
-#endif
 
 template<typename DeviceType>
 template<typename basisCoeffsValueType, class ...basisCoeffsProperties,
@@ -166,9 +135,7 @@ ProjectionTools<DeviceType>::getHVolBasisCoeffs(Kokkos::DynRankView<basisCoeffsV
   ElemSystem cellSystem("cellSystem", true);
   cellSystem.solve(basisCoeffs, massMat, rhsMat, t_, w_, cellDofs, basisCardinality);
 }
-#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-}
-#endif
+
 } // Intrepid2 namespace
 
 #endif

--- a/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefL2.hpp
+++ b/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefL2.hpp
@@ -59,18 +59,18 @@ namespace Intrepid2 {
 namespace FunctorsProjectionTools {
 
 template<typename ViewType1, typename ViewType2, typename ViewType3,
-typename ViewType4, typename ViewType5>
+typename ViewType4>
 struct ComputeBasisCoeffsOnVertices_L2 {
   ViewType1 basisCoeffs_;
   const ViewType2 tagToOrdinal_;
   const ViewType3 targetEPointsRange_;
   const ViewType4 targetAtTargetEPoints_;
-  const ViewType5 basisAtTargetEPoints_;
+  const ViewType1 basisAtTargetEPoints_;
   ordinal_type numVertices_;
 
 
   ComputeBasisCoeffsOnVertices_L2(ViewType1 basisCoeffs, ViewType2 tagToOrdinal, ViewType3 targetEPointsRange,
-      ViewType4  targetAtTargetEPoints, ViewType5 basisAtTargetEPoints, ordinal_type numVertices) :
+      ViewType4  targetAtTargetEPoints, ViewType1 basisAtTargetEPoints, ordinal_type numVertices) :
         basisCoeffs_(basisCoeffs), tagToOrdinal_(tagToOrdinal), targetEPointsRange_(targetEPointsRange),
         targetAtTargetEPoints_(targetAtTargetEPoints), basisAtTargetEPoints_(basisAtTargetEPoints), numVertices_(numVertices) {}
 
@@ -81,29 +81,29 @@ struct ComputeBasisCoeffsOnVertices_L2 {
       ordinal_type idof = tagToOrdinal_(0, iv, 0);
       ordinal_type pt = targetEPointsRange_(0,iv).first;
       //the value of the basis at the vertex might be different than 1; HGrad basis, so the function is scalar
-      basisCoeffs_(ic,idof) = targetAtTargetEPoints_(ic,pt)/basisAtTargetEPoints_(ic,idof,pt,0);
+      basisCoeffs_(ic,idof) = targetAtTargetEPoints_(ic,pt)/basisAtTargetEPoints_(idof,pt,0);
     }
   }
 };
 
 
 template<typename ViewType1, typename ViewType2, typename ViewType3,
-typename ViewType4, typename ViewType5, typename ViewType6>
+typename ViewType4, typename ViewType5>
 struct ComputeBasisCoeffsOnEdges_L2 {
   const ViewType1 basisCoeffs_;
-  const ViewType2 negPartialProj_;
-  const ViewType2 basisDofDofAtBasisEPoints_;
-  const ViewType2 basisAtBasisEPoints_;
-  const ViewType3 basisEWeights_;
-  const ViewType2 wBasisDofAtBasisEPoints_;
-  const ViewType3 targetEWeights_;
-  const ViewType2 basisAtTargetEPoints_;
-  const ViewType2 wBasisDofAtTargetEPoints_;
-  const ViewType4 computedDofs_;
-  const ViewType5 tagToOrdinal_;
-  const ViewType6 targetAtTargetEPoints_;
-  const ViewType2 targetTanAtTargetEPoints_;
-  const ViewType2 refEdgesVec_;
+  const ViewType1 negPartialProj_;
+  const ViewType1 basisDofDofAtBasisEPoints_;
+  const ViewType1 basisAtBasisEPoints_;
+  const ViewType2 basisEWeights_;
+  const ViewType1 wBasisDofAtBasisEPoints_;
+  const ViewType2 targetEWeights_;
+  const ViewType1 basisAtTargetEPoints_;
+  const ViewType1 wBasisDofAtTargetEPoints_;
+  const ViewType3 computedDofs_;
+  const ViewType4 tagToOrdinal_;
+  const ViewType5 targetAtTargetEPoints_;
+  const ViewType1 targetTanAtTargetEPoints_;
+  const ViewType1 refEdgesVec_;
   ordinal_type fieldDim_;
   ordinal_type edgeCardinality_;
   ordinal_type offsetBasis_;
@@ -112,10 +112,10 @@ struct ComputeBasisCoeffsOnEdges_L2 {
   ordinal_type edgeDim_;
   ordinal_type iedge_;
 
-  ComputeBasisCoeffsOnEdges_L2(const ViewType1 basisCoeffs, ViewType2 negPartialProj,  const ViewType2 basisDofDofAtBasisEPoints,
-      const ViewType2 basisAtBasisEPoints, const ViewType3 basisEWeights,  const ViewType2 wBasisDofAtBasisEPoints,   const ViewType3 targetEWeights,
-      const ViewType2 basisAtTargetEPoints, const ViewType2 wBasisDofAtTargetEPoints, const ViewType4 computedDofs, const ViewType5 tagToOrdinal,
-      const ViewType6 targetAtTargetEPoints, const ViewType2 targetTanAtTargetEPoints, const ViewType2 refEdgesVec,
+  ComputeBasisCoeffsOnEdges_L2(const ViewType1 basisCoeffs, ViewType1 negPartialProj,  const ViewType1 basisDofDofAtBasisEPoints,
+      const ViewType1 basisAtBasisEPoints, const ViewType2 basisEWeights,  const ViewType1 wBasisDofAtBasisEPoints,   const ViewType2 targetEWeights,
+      const ViewType1 basisAtTargetEPoints, const ViewType1 wBasisDofAtTargetEPoints, const ViewType3 computedDofs, const ViewType4 tagToOrdinal,
+      const ViewType5 targetAtTargetEPoints, const ViewType1 targetTanAtTargetEPoints, const ViewType1 refEdgesVec,
       ordinal_type fieldDim, ordinal_type edgeCardinality, ordinal_type offsetBasis,
       ordinal_type offsetTarget, ordinal_type numVertexDofs, ordinal_type edgeDim, ordinal_type iedge) :
         basisCoeffs_(basisCoeffs), negPartialProj_(negPartialProj), basisDofDofAtBasisEPoints_(basisDofDofAtBasisEPoints),
@@ -133,13 +133,15 @@ struct ComputeBasisCoeffsOnEdges_L2 {
     for(ordinal_type j=0; j <edgeCardinality_; ++j) {
       ordinal_type jdof =tagToOrdinal_(edgeDim_, iedge_, j);
       for(ordinal_type iq=0; iq <ordinal_type(basisEWeights_.extent(0)); ++iq) {
+        typename ViewType1::value_type tmp =0;
         for(ordinal_type d=0; d <fieldDim_; ++d)
-          basisDofDofAtBasisEPoints_(ic,j,iq) += basisAtBasisEPoints_(ic,jdof,offsetBasis_+iq,d)*refEdgesVec_(iedge_,d);
-        wBasisDofAtBasisEPoints_(ic,j,iq) = basisDofDofAtBasisEPoints_(ic,j,iq)*basisEWeights_(iq);
+          tmp += basisAtBasisEPoints_(jdof,offsetBasis_+iq,d)*refEdgesVec_(iedge_,d);
+        basisDofDofAtBasisEPoints_(0,j,iq) = tmp;
+        wBasisDofAtBasisEPoints_(ic,j,iq) = tmp*basisEWeights_(iq);
       }
       for(ordinal_type iq=0; iq <ordinal_type(targetEWeights_.extent(0)); ++iq) {
         for(ordinal_type d=0; d <fieldDim_; ++d)
-          wBasisDofAtTargetEPoints_(ic,j,iq) += basisAtTargetEPoints_(ic,jdof,offsetTarget_+iq,d)*refEdgesVec_(iedge_,d)*targetEWeights_(iq);
+          wBasisDofAtTargetEPoints_(ic,j,iq) += basisAtTargetEPoints_(jdof,offsetTarget_+iq,d)*refEdgesVec_(iedge_,d)*targetEWeights_(iq);
       }
     }
 
@@ -151,29 +153,28 @@ struct ComputeBasisCoeffsOnEdges_L2 {
       ordinal_type jdof = computedDofs_(j);
       for(ordinal_type iq=0; iq <ordinal_type(basisEWeights_.extent(0)); ++iq)
         for(ordinal_type d=0; d <fieldDim_; ++d)
-          negPartialProj_(ic,iq) -=  basisCoeffs_(ic,jdof)*basisAtBasisEPoints_(ic,jdof,offsetBasis_+iq,d)*refEdgesVec_(iedge_,d);
+          negPartialProj_(ic,iq) -=  basisCoeffs_(ic,jdof)*basisAtBasisEPoints_(jdof,offsetBasis_+iq,d)*refEdgesVec_(iedge_,d);
     }
   }
 };
 
 template<typename ViewType1, typename ViewType2, typename ViewType3,
-typename ViewType4, typename ViewType5, typename ViewType6, typename ViewType7, typename ViewType8>
+typename ViewType4, typename ViewType5>
 struct ComputeBasisCoeffsOnFaces_L2 {
   const ViewType1 basisCoeffs_;
-  const ViewType2 negPartialProj_;
-  const ViewType2 faceBasisDofAtBasisEPoints_;
-  const ViewType2 basisAtBasisEPoints_;
-  const ViewType3 basisEWeights_;
-  const ViewType2 wBasisDofAtBasisEPoints_;
-  const ViewType3 targetEWeights_;
-  const ViewType2 basisAtTargetEPoints_;
-  const ViewType2 wBasisDofAtTargetEPoints_;
-  const ViewType4 computedDofs_;
-  const ViewType5 tagToOrdinal_;
-  const ViewType6 orts_;
-  const ViewType7 targetAtTargetEPoints_;
-  const ViewType2 targetDofAtTargetEPoints_;
-  const ViewType8 faceParametrization_;
+  const ViewType1 negPartialProj_;
+  const ViewType1 faceBasisDofAtBasisEPoints_;
+  const ViewType1 basisAtBasisEPoints_;
+  const ViewType2 basisEWeights_;
+  const ViewType1 wBasisDofAtBasisEPoints_;
+  const ViewType2 targetEWeights_;
+  const ViewType1 basisAtTargetEPoints_;
+  const ViewType1 wBasisDofAtTargetEPoints_;
+  const ViewType3 computedDofs_;
+  const ViewType4 tagToOrdinal_;
+  const ViewType5 targetAtTargetEPoints_;
+  const ViewType1 targetDofAtTargetEPoints_;
+  const ViewType1 refSideNormal_;
   ordinal_type fieldDim_;
   ordinal_type faceCardinality_;
   ordinal_type offsetBasis_;
@@ -183,24 +184,23 @@ struct ComputeBasisCoeffsOnFaces_L2 {
   ordinal_type faceDim_;
   ordinal_type dim_;
   ordinal_type iface_;
-  unsigned topoKey_;
   bool isHCurlBasis_, isHDivBasis_;
 
-  ComputeBasisCoeffsOnFaces_L2(const ViewType1 basisCoeffs, ViewType2 negPartialProj,  const ViewType2 faceBasisDofAtBasisEPoints,
-      const ViewType2 basisAtBasisEPoints, const ViewType3 basisEWeights,  const ViewType2 wBasisDofAtBasisEPoints,   const ViewType3 targetEWeights,
-      const ViewType2 basisAtTargetEPoints, const ViewType2 wBasisDofAtTargetEPoints, const ViewType4 computedDofs, const ViewType5 tagToOrdinal,
-      const ViewType6 orts, const ViewType7 targetAtTargetEPoints, const ViewType2 targetDofAtTargetEPoints,
-      const ViewType8 faceParametrization, ordinal_type fieldDim, ordinal_type faceCardinality, ordinal_type offsetBasis,
+  ComputeBasisCoeffsOnFaces_L2(const ViewType1 basisCoeffs, ViewType1 negPartialProj,  const ViewType1 faceBasisDofAtBasisEPoints,
+      const ViewType1 basisAtBasisEPoints, const ViewType2 basisEWeights,  const ViewType1 wBasisDofAtBasisEPoints,   const ViewType2 targetEWeights,
+      const ViewType1 basisAtTargetEPoints, const ViewType1 wBasisDofAtTargetEPoints, const ViewType3 computedDofs, const ViewType4 tagToOrdinal,
+      const ViewType5 targetAtTargetEPoints, const ViewType1 targetDofAtTargetEPoints,
+      const ViewType1 refSideNormal, ordinal_type fieldDim, ordinal_type faceCardinality, ordinal_type offsetBasis,
       ordinal_type offsetTarget, ordinal_type numVertexEdgeDofs, ordinal_type numFaces, ordinal_type faceDim,
-      ordinal_type dim, ordinal_type iface, unsigned topoKey, bool isHCurlBasis, bool isHDivBasis) :
+      ordinal_type dim, ordinal_type iface, bool isHCurlBasis, bool isHDivBasis) :
         basisCoeffs_(basisCoeffs), negPartialProj_(negPartialProj), faceBasisDofAtBasisEPoints_(faceBasisDofAtBasisEPoints),
         basisAtBasisEPoints_(basisAtBasisEPoints), basisEWeights_(basisEWeights), wBasisDofAtBasisEPoints_(wBasisDofAtBasisEPoints), targetEWeights_(targetEWeights),
         basisAtTargetEPoints_(basisAtTargetEPoints), wBasisDofAtTargetEPoints_(wBasisDofAtTargetEPoints),
-        computedDofs_(computedDofs), tagToOrdinal_(tagToOrdinal), orts_(orts), targetAtTargetEPoints_(targetAtTargetEPoints),
-        targetDofAtTargetEPoints_(targetDofAtTargetEPoints), faceParametrization_(faceParametrization),
+        computedDofs_(computedDofs), tagToOrdinal_(tagToOrdinal), targetAtTargetEPoints_(targetAtTargetEPoints),
+        targetDofAtTargetEPoints_(targetDofAtTargetEPoints), refSideNormal_(refSideNormal),
         fieldDim_(fieldDim), faceCardinality_(faceCardinality), offsetBasis_(offsetBasis),
         offsetTarget_(offsetTarget), numVertexEdgeDofs_(numVertexEdgeDofs), numFaces_(numFaces),
-        faceDim_(faceDim), dim_(dim), iface_(iface), topoKey_(topoKey),
+        faceDim_(faceDim), dim_(dim), iface_(iface),
         isHCurlBasis_(isHCurlBasis), isHDivBasis_(isHDivBasis)
   {}
 
@@ -208,16 +208,9 @@ struct ComputeBasisCoeffsOnFaces_L2 {
   KOKKOS_INLINE_FUNCTION
   operator()(const ordinal_type ic) const {
 
-    ordinal_type fOrt[6];
-    orts_(ic).getFaceOrientation(fOrt, numFaces_);
-    ordinal_type ort = fOrt[iface_];
-
     if(isHCurlBasis_) {
-      typename ViewType3::value_type data[3*3];
-      auto tangentsAndNormal = ViewType3(data, dim_, dim_);
-      Impl::OrientationTools::getRefSideTangentsAndNormal(tangentsAndNormal, faceParametrization_,topoKey_, iface_, ort);
       //normal
-      typename ViewType2::value_type n[3] = {tangentsAndNormal(2,0), tangentsAndNormal(2,1), tangentsAndNormal(2,2)};
+      typename ViewType1::value_type n[3] = {refSideNormal_(0), refSideNormal_(1), refSideNormal_(2)};
 
       for(ordinal_type j=0; j <faceCardinality_; ++j) {
         ordinal_type jdof = tagToOrdinal_(faceDim_, iface_, j);
@@ -226,13 +219,13 @@ struct ComputeBasisCoeffsOnFaces_L2 {
           ordinal_type dp2 = (d+2) % dim_;
           for(ordinal_type iq=0; iq <ordinal_type(basisEWeights_.extent(0)); ++iq) {
 
-            faceBasisDofAtBasisEPoints_(ic,j,iq,d) = basisAtBasisEPoints_(ic,jdof,offsetBasis_+iq,dp1)*n[dp2] - basisAtBasisEPoints_(ic,jdof,offsetBasis_+iq,dp2)*n[dp1];
+            faceBasisDofAtBasisEPoints_(0,j,iq,d) = basisAtBasisEPoints_(jdof,offsetBasis_+iq,dp1)*n[dp2] - basisAtBasisEPoints_(jdof,offsetBasis_+iq,dp2)*n[dp1];
             // basis \times n
-            wBasisDofAtBasisEPoints_(ic,j,iq,d) = faceBasisDofAtBasisEPoints_(ic,j,iq,d) * basisEWeights_(iq);
+            wBasisDofAtBasisEPoints_(ic,j,iq,d) = faceBasisDofAtBasisEPoints_(0,j,iq,d) * basisEWeights_(iq);
           }
           for(ordinal_type iq=0; iq <ordinal_type(targetEWeights_.extent(0)); ++iq) {
             // basis \times n
-            wBasisDofAtTargetEPoints_(ic,j,iq,d) = (basisAtTargetEPoints_(ic,jdof,offsetTarget_+iq,dp1)*n[dp2] - basisAtTargetEPoints_(ic,jdof,offsetTarget_+iq,dp2)*n[dp1]) * targetEWeights_(iq);
+            wBasisDofAtTargetEPoints_(ic,j,iq,d) = (basisAtTargetEPoints_(jdof,offsetTarget_+iq,dp1)*n[dp2] - basisAtTargetEPoints_(jdof,offsetTarget_+iq,dp2)*n[dp1]) * targetEWeights_(iq);
           }
         }
       }
@@ -253,34 +246,30 @@ struct ComputeBasisCoeffsOnFaces_L2 {
           ordinal_type dp2 = (d+2) % dim_;
           for(ordinal_type iq=0; iq <ordinal_type(basisEWeights_.extent(0)); ++iq) {
             // basis \times n
-            negPartialProj_(ic,iq,d) -= (basisAtBasisEPoints_(ic,jdof,offsetBasis_+iq,dp1)*n[dp2] - basisAtBasisEPoints_(ic,jdof,offsetBasis_+iq,dp2)*n[dp1])*basisCoeffs_(ic,jdof);
+            negPartialProj_(ic,iq,d) -= (basisAtBasisEPoints_(jdof,offsetBasis_+iq,dp1)*n[dp2] - basisAtBasisEPoints_(jdof,offsetBasis_+iq,dp2)*n[dp1])*basisCoeffs_(ic,jdof);
           } 
         }
       }
-    } else {
-      typename ViewType3::value_type coeff[3];
+    } else { // isHDivBasis_ || isHGradBasis_
+      typename ViewType1::value_type coeff[3] = {1,0,0}; //only need first component for HGrad basis
       if (isHDivBasis_) {
-        typename ViewType3::value_type data[3*3];
-        auto tangentsAndNormal = ViewType3(data, dim_, dim_);
-        Impl::OrientationTools::getRefSideTangentsAndNormal(tangentsAndNormal, faceParametrization_,topoKey_, iface_, ort);
-        for(ordinal_type d=0; d <dim_; ++d)
-          coeff[d] = tangentsAndNormal(dim_-1,d);
+        for (ordinal_type d=0; d<3; d++)
+          coeff[d] =  refSideNormal_(d);
       }
-      else //isHGradBasis
-        coeff[0] = 1;
 
       for(ordinal_type j=0; j <faceCardinality_; ++j) {
         ordinal_type jdof = tagToOrdinal_(faceDim_, iface_, j);
         for(ordinal_type iq=0; iq <ordinal_type(basisEWeights_.extent(0)); ++iq) {
-          faceBasisDofAtBasisEPoints_(ic,j,iq,0) = 0;
+          typename ViewType1::value_type tmp =0;
           for(ordinal_type d=0; d <fieldDim_; ++d)
-            faceBasisDofAtBasisEPoints_(ic,j,iq,0) += coeff[d]*basisAtBasisEPoints_(ic,jdof,offsetBasis_+iq,d);
-          wBasisDofAtBasisEPoints_(ic,j,iq,0) = faceBasisDofAtBasisEPoints_(ic,j,iq,0) * basisEWeights_(iq);
+            tmp += coeff[d]*basisAtBasisEPoints_(jdof,offsetBasis_+iq,d);
+          faceBasisDofAtBasisEPoints_(0,j,iq,0) = tmp;
+          wBasisDofAtBasisEPoints_(ic,j,iq,0) = tmp * basisEWeights_(iq);
         }
         for(ordinal_type iq=0; iq <ordinal_type(targetEWeights_.extent(0)); ++iq) {
           typename ViewType2::value_type sum=0;
           for(ordinal_type d=0; d <fieldDim_; ++d)
-            sum += coeff[d]*basisAtTargetEPoints_(ic,jdof,offsetTarget_+iq,d);
+            sum += coeff[d]*basisAtTargetEPoints_(jdof,offsetTarget_+iq,d);
           wBasisDofAtTargetEPoints_(ic,j,iq,0) = sum * targetEWeights_(iq);
         }
       }
@@ -293,36 +282,35 @@ struct ComputeBasisCoeffsOnFaces_L2 {
         ordinal_type jdof = computedDofs_(j);
         for(ordinal_type iq=0; iq <ordinal_type(basisEWeights_.extent(0)); ++iq)
           for(ordinal_type d=0; d <fieldDim_; ++d)
-            negPartialProj_(ic,iq,0) -=  basisCoeffs_(ic,jdof)*coeff[d]*basisAtBasisEPoints_(ic,jdof,offsetBasis_+iq,d);
+            negPartialProj_(ic,iq,0) -=  basisCoeffs_(ic,jdof)*coeff[d]*basisAtBasisEPoints_(jdof,offsetBasis_+iq,d);
       }
     }
   }
 };
 
 
-template<typename ViewType1, typename ViewType2, typename ViewType3,
-typename ViewType4, typename ViewType5>
+template<typename ViewType1, typename ViewType2, typename ViewType3, typename ViewType4>
 struct ComputeBasisCoeffsOnCells_L2 {
   const ViewType1 basisCoeffs_;
-  const ViewType2 negPartialProj_;
-  const ViewType2 internalBasisAtBasisEPoints_;
-  const ViewType2 basisAtBasisEPoints_;
-  const ViewType3 basisEWeights_;
-  const ViewType2 wBasisAtBasisEPoints_;
-  const ViewType3 targetEWeights_;
-  const ViewType2 basisAtTargetEPoints_;
-  const ViewType2 wBasisDofAtTargetEPoints_;
-  const ViewType4 computedDofs_;
-  const ViewType5 elemDof_;
+  const ViewType1 negPartialProj_;
+  const ViewType1 internalBasisAtBasisEPoints_;
+  const ViewType1 basisAtBasisEPoints_;
+  const ViewType2 basisEWeights_;
+  const ViewType1 wBasisAtBasisEPoints_;
+  const ViewType2 targetEWeights_;
+  const ViewType1 basisAtTargetEPoints_;
+  const ViewType1 wBasisDofAtTargetEPoints_;
+  const ViewType3 computedDofs_;
+  const ViewType4 elemDof_;
   ordinal_type fieldDim_;
   ordinal_type numElemDofs_;
   ordinal_type offsetBasis_;
   ordinal_type offsetTarget_;
   ordinal_type numVertexEdgeFaceDofs_;
 
-  ComputeBasisCoeffsOnCells_L2(const ViewType1 basisCoeffs, ViewType2 negPartialProj,  const ViewType2 internalBasisAtBasisEPoints,
-      const ViewType2 basisAtBasisEPoints, const ViewType3 basisEWeights,  const ViewType2 wBasisAtBasisEPoints,   const ViewType3 targetEWeights,
-      const ViewType2 basisAtTargetEPoints, const ViewType2 wBasisDofAtTargetEPoints, const ViewType4 computedDofs, const ViewType5 elemDof,
+  ComputeBasisCoeffsOnCells_L2(const ViewType1 basisCoeffs, ViewType1 negPartialProj,  const ViewType1 internalBasisAtBasisEPoints,
+      const ViewType1 basisAtBasisEPoints, const ViewType2 basisEWeights,  const ViewType1 wBasisAtBasisEPoints,   const ViewType2 targetEWeights,
+      const ViewType1 basisAtTargetEPoints, const ViewType1 wBasisDofAtTargetEPoints, const ViewType3 computedDofs, const ViewType4 elemDof,
       ordinal_type fieldDim, ordinal_type numElemDofs, ordinal_type offsetBasis, ordinal_type offsetTarget, ordinal_type numVertexEdgeFaceDofs) :
         basisCoeffs_(basisCoeffs), negPartialProj_(negPartialProj), internalBasisAtBasisEPoints_(internalBasisAtBasisEPoints),
         basisAtBasisEPoints_(basisAtBasisEPoints), basisEWeights_(basisEWeights), wBasisAtBasisEPoints_(wBasisAtBasisEPoints), targetEWeights_(targetEWeights),
@@ -338,11 +326,11 @@ struct ComputeBasisCoeffsOnCells_L2 {
       ordinal_type idof = elemDof_(j);
       for(ordinal_type d=0; d <fieldDim_; ++d) {
         for(ordinal_type iq=0; iq <ordinal_type(basisEWeights_.extent(0)); ++iq) {
-          internalBasisAtBasisEPoints_(ic,j,iq,d) = basisAtBasisEPoints_(ic,idof,offsetBasis_+iq,d);
-          wBasisAtBasisEPoints_(ic,j,iq,d) = internalBasisAtBasisEPoints_(ic,j,iq,d) * basisEWeights_(iq);
+          internalBasisAtBasisEPoints_(0,j,iq,d) = basisAtBasisEPoints_(idof,offsetBasis_+iq,d);
+          wBasisAtBasisEPoints_(ic,j,iq,d) = internalBasisAtBasisEPoints_(0,j,iq,d) * basisEWeights_(iq);
         }
         for(ordinal_type iq=0; iq <ordinal_type(targetEWeights_.extent(0)); ++iq) {
-          wBasisDofAtTargetEPoints_(ic,j,iq,d) = basisAtTargetEPoints_(ic,idof,offsetTarget_+iq,d)* targetEWeights_(iq);
+          wBasisDofAtTargetEPoints_(ic,j,iq,d) = basisAtTargetEPoints_(idof,offsetTarget_+iq,d)* targetEWeights_(iq);
         }
       }
     }
@@ -350,7 +338,7 @@ struct ComputeBasisCoeffsOnCells_L2 {
       ordinal_type jdof = computedDofs_(j);
       for(ordinal_type iq=0; iq <ordinal_type(basisEWeights_.extent(0)); ++iq)
         for(ordinal_type d=0; d <fieldDim_; ++d) {
-          negPartialProj_(ic,iq,d) -=  basisCoeffs_(ic,jdof)*basisAtBasisEPoints_(ic,jdof,offsetBasis_+iq,d);
+          negPartialProj_(ic,iq,d) -=  basisCoeffs_(ic,jdof)*basisAtBasisEPoints_(jdof,offsetBasis_+iq,d);
         }
     }
   }
@@ -381,10 +369,10 @@ struct MultiplyBasisByWeights {
     for(ordinal_type j=0; j <numElemDofs_; ++j) {
       for(ordinal_type d=0; d <fieldDim_; ++d) {
         for(ordinal_type iq=0; iq <ordinal_type(basisEWeights_.extent(0)); ++iq) {
-          wBasisAtBasisEPoints_(ic,j,iq,d) = basisAtBasisEPoints_(ic,j,iq,d) * basisEWeights_(iq);
+          wBasisAtBasisEPoints_(ic,j,iq,d) = basisAtBasisEPoints_(j,iq,d) * basisEWeights_(iq);
         }
         for(ordinal_type iq=0; iq <ordinal_type(targetEWeights_.extent(0)); ++iq) {
-          wBasisDofAtTargetEPoints_(ic,j,iq,d) = basisAtTargetEPoints_(ic,j,iq,d)* targetEWeights_(iq);
+          wBasisDofAtTargetEPoints_(ic,j,iq,d) = basisAtTargetEPoints_(j,iq,d)* targetEWeights_(iq);
         }
       }
     }
@@ -439,8 +427,6 @@ ProjectionTools<DeviceType>::getL2BasisCoeffs(Kokkos::DynRankView<basisCoeffsVal
 
   auto basisEPointsRange = projStruct->getBasisPointsRange();
 
-  auto refTopologyKey = projStruct->getTopologyKey();
-
   ordinal_type numTotalBasisEPoints = projStruct->getNumBasisEvalPoints();
   auto basisEPoints = projStruct->getAllEvalPoints(EvalPointsType::BASIS);
 
@@ -449,26 +435,16 @@ ProjectionTools<DeviceType>::getL2BasisCoeffs(Kokkos::DynRankView<basisCoeffsVal
 
   auto tagToOrdinal = Kokkos::create_mirror_view_and_copy(MemSpaceType(), cellBasis->getAllDofOrdinal());
 
-  ScalarViewType basisAtBasisEPoints("basisAtBasisEPoints",numCells,basisCardinality, numTotalBasisEPoints, fieldDim);
-  ScalarViewType basisAtTargetEPoints("basisAtTargetEPoints",numCells,basisCardinality, numTotalTargetEPoints, fieldDim);
+  ScalarViewType basisAtBasisEPoints("basisAtBasisEPoints",basisCardinality, numTotalBasisEPoints, fieldDim);
+  ScalarViewType basisAtTargetEPoints("basisAtTargetEPoints",basisCardinality, numTotalTargetEPoints, fieldDim);
   {
     if(fieldDim == 1) {
-      ScalarViewType nonOrientedBasisAtBasisEPoints("nonOrientedBasisAtBasisEPoints",basisCardinality, numTotalBasisEPoints);
-      ScalarViewType nonOrientedBasisAtTargetEPoints("nonOrientedBasisAtTargetEPoints",basisCardinality, numTotalTargetEPoints);
-      cellBasis->getValues(nonOrientedBasisAtTargetEPoints, targetEPoints);
-      cellBasis->getValues(nonOrientedBasisAtBasisEPoints,basisEPoints);
-      OrientationTools<DeviceType>::modifyBasisByOrientation(Kokkos::subview(basisAtBasisEPoints, Kokkos::ALL(), Kokkos::ALL(),
-          Kokkos::ALL(),0), nonOrientedBasisAtBasisEPoints, orts, cellBasis);
-      OrientationTools<DeviceType>::modifyBasisByOrientation(Kokkos::subview(basisAtTargetEPoints, Kokkos::ALL(),
-          Kokkos::ALL(), Kokkos::ALL(),0), nonOrientedBasisAtTargetEPoints, orts, cellBasis);
+      cellBasis->getValues(Kokkos::subview(basisAtTargetEPoints, Kokkos::ALL(), Kokkos::ALL(), 0), targetEPoints);
+      cellBasis->getValues(Kokkos::subview(basisAtBasisEPoints, Kokkos::ALL(), Kokkos::ALL(), 0), basisEPoints);
     }
     else {
-      ScalarViewType nonOrientedBasisAtBasisEPoints("nonOrientedBasisAtBasisEPoints",basisCardinality, numTotalBasisEPoints,fieldDim);
-      ScalarViewType nonOrientedBasisAtTargetEPoints("nonOrientedBasisAtTargetEPoints",basisCardinality, numTotalTargetEPoints,fieldDim);
-      cellBasis->getValues(nonOrientedBasisAtTargetEPoints, targetEPoints);
-      cellBasis->getValues(nonOrientedBasisAtBasisEPoints, basisEPoints);
-      OrientationTools<DeviceType>::modifyBasisByOrientation(basisAtBasisEPoints, nonOrientedBasisAtBasisEPoints, orts, cellBasis);
-      OrientationTools<DeviceType>::modifyBasisByOrientation(basisAtTargetEPoints, nonOrientedBasisAtTargetEPoints, orts, cellBasis);
+      cellBasis->getValues(basisAtTargetEPoints, targetEPoints);
+      cellBasis->getValues(basisAtBasisEPoints, basisEPoints);
     }
   }
 
@@ -500,13 +476,14 @@ ProjectionTools<DeviceType>::getL2BasisCoeffs(Kokkos::DynRankView<basisCoeffsVal
 
 
   const Kokkos::RangePolicy<ExecSpaceType> policy(0, numCells);
+  ScalarViewType refBasisCoeffs("refBasisCoeffs", basisCoeffs.extent(0), basisCoeffs.extent(1));
 
   if(isHGradBasis) {
 
     auto targetEPointsRange = Kokkos::create_mirror_view_and_copy(MemSpaceType(), projStruct->getTargetPointsRange());
-    using functorType = FunctorsProjectionTools::ComputeBasisCoeffsOnVertices_L2<decltype(basisCoeffs), decltype(tagToOrdinal), decltype(targetEPointsRange),
-        decltype(targetAtTargetEPoints), decltype(basisAtTargetEPoints)>;
-    Kokkos::parallel_for(policy, functorType(basisCoeffs, tagToOrdinal, targetEPointsRange,
+    using functorType = FunctorsProjectionTools::ComputeBasisCoeffsOnVertices_L2<ScalarViewType, decltype(tagToOrdinal), decltype(targetEPointsRange),
+        decltype(targetAtTargetEPoints)>;
+    Kokkos::parallel_for(policy, functorType(refBasisCoeffs, tagToOrdinal, targetEPointsRange,
         targetAtTargetEPoints, basisAtTargetEPoints, numVertices));
   }
 
@@ -527,7 +504,7 @@ ProjectionTools<DeviceType>::getL2BasisCoeffs(Kokkos::DynRankView<basisCoeffsVal
     ordinal_type numBasisEPoints = range_size(basisEPointsRange(edgeDim, ie));
     ordinal_type numTargetEPoints = range_size(targetEPointsRange(edgeDim, ie));
 
-    ScalarViewType basisDofAtBasisEPoints("BasisDofAtBasisEPoints",numCells,edgeCardinality, numBasisEPoints);
+    ScalarViewType basisDofAtBasisEPoints("BasisDofAtBasisEPoints",1,edgeCardinality, numBasisEPoints);
     ScalarViewType tragetDofAtTargetEPoints("TargetDofAtTargetEPoints",numCells, numTargetEPoints);
     ScalarViewType weightedBasisAtBasisEPoints("weightedTanBasisAtBasisEPoints",numCells,edgeCardinality, numBasisEPoints);
     ScalarViewType weightedBasisAtTargetEPoints("weightedTanBasisAtTargetEPoints",numCells,edgeCardinality, numTargetEPoints);
@@ -541,20 +518,20 @@ ProjectionTools<DeviceType>::getL2BasisCoeffs(Kokkos::DynRankView<basisCoeffsVal
     ordinal_type offsetTarget = targetEPointsRange(edgeDim, ie).first;
 
 
-    using functorTypeEdge = FunctorsProjectionTools::ComputeBasisCoeffsOnEdges_L2<decltype(basisCoeffs), ScalarViewType,  decltype(basisEWeights),
+    using functorTypeEdge = FunctorsProjectionTools::ComputeBasisCoeffsOnEdges_L2<ScalarViewType,  decltype(basisEWeights),
         decltype(computedDofs), decltype(tagToOrdinal), decltype(targetAtTargetEPoints)>;
 
-    Kokkos::parallel_for(policy, functorTypeEdge(basisCoeffs, negPartialProj, basisDofAtBasisEPoints,
+    Kokkos::parallel_for(policy, functorTypeEdge(refBasisCoeffs, negPartialProj, basisDofAtBasisEPoints,
         basisAtBasisEPoints, basisEWeights, weightedBasisAtBasisEPoints, targetEWeights,
         basisAtTargetEPoints, weightedBasisAtTargetEPoints, computedDofs, tagToOrdinal,
         targetAtTargetEPoints,tragetDofAtTargetEPoints, refEdgesVec, fieldDim,
         edgeCardinality, offsetBasis, offsetTarget, numVertexDofs, edgeDim, ie));
 
 
-    ScalarViewType edgeMassMat_("edgeMassMat_", numCells, edgeCardinality, edgeCardinality),
+    ScalarViewType edgeMassMat_("edgeMassMat_", 1, edgeCardinality, edgeCardinality),
         edgeRhsMat_("rhsMat_", numCells, edgeCardinality);
 
-    FunctionSpaceTools<DeviceType >::integrate(edgeMassMat_, basisDofAtBasisEPoints, weightedBasisAtBasisEPoints);
+    FunctionSpaceTools<DeviceType >::integrate(edgeMassMat_, basisDofAtBasisEPoints, Kokkos::subview(weightedBasisAtBasisEPoints, std::make_pair(0,1), Kokkos::ALL(),Kokkos::ALL()) );
     FunctionSpaceTools<DeviceType >::integrate(edgeRhsMat_, tragetDofAtTargetEPoints, weightedBasisAtTargetEPoints);
     FunctionSpaceTools<DeviceType >::integrate(edgeRhsMat_, negPartialProj, weightedBasisAtBasisEPoints,true);
 
@@ -565,22 +542,17 @@ ProjectionTools<DeviceType>::getL2BasisCoeffs(Kokkos::DynRankView<basisCoeffsVal
 
     auto edgeDof = Kokkos::subview(tagToOrdinal, edgeDim, ie, Kokkos::ALL());
 
-    ElemSystem edgeSystem("edgeSystem", false);
-    edgeSystem.solve(basisCoeffs, edgeMassMat_, edgeRhsMat_, t_, w_, edgeDof, edgeCardinality);
+    ElemSystem edgeSystem("edgeSystem", true);
+    edgeSystem.solve(refBasisCoeffs, edgeMassMat_, edgeRhsMat_, t_, w_, edgeDof, edgeCardinality);
   }
 
-  typename RefSubcellParametrization<DeviceType>::ConstViewType  subcellParamFace;
-  if(numFaces>0)
-    subcellParamFace = RefSubcellParametrization<DeviceType>::get(faceDim, cellBasis->getBaseCellTopology().getKey());
-
   for(ordinal_type iface=0; iface<numFaces; ++iface) {
-    const auto topoKey = refTopologyKey(faceDim,iface);
     ordinal_type faceCardinality = cellBasis->getDofCount(faceDim,iface);
 
     ordinal_type numTargetEPoints = range_size(targetEPointsRange(faceDim, iface));
     ordinal_type numBasisEPoints = range_size(basisEPointsRange(faceDim, iface));
 
-    ScalarViewType faceBasisDofAtBasisEPoints("faceBasisDofAtBasisEPoints",numCells,faceCardinality, numBasisEPoints,faceDofDim);
+    ScalarViewType faceBasisDofAtBasisEPoints("faceBasisDofAtBasisEPoints",1,faceCardinality, numBasisEPoints,faceDofDim);
     ScalarViewType wBasisDofAtBasisEPoints("weightedBasisDofAtBasisEPoints",numCells,faceCardinality, numBasisEPoints,faceDofDim);
 
     ScalarViewType faceBasisAtTargetEPoints("faceBasisDofAtTargetEPoints",numCells,faceCardinality, numTargetEPoints,faceDofDim);
@@ -594,23 +566,25 @@ ProjectionTools<DeviceType>::getL2BasisCoeffs(Kokkos::DynRankView<basisCoeffsVal
     auto targetEWeights = Kokkos::create_mirror_view_and_copy(MemSpaceType(),projStruct->getTargetEvalWeights(faceDim,iface));
     auto basisEWeights = Kokkos::create_mirror_view_and_copy(MemSpaceType(),projStruct->getBasisEvalWeights(faceDim,iface));
 
+    ScalarViewType refSideNormal("refSideNormal", dim);
+    CellTools<DeviceType>::getReferenceSideNormal(refSideNormal, iface, cellTopo);
 
-    using functorTypeFace = FunctorsProjectionTools::ComputeBasisCoeffsOnFaces_L2<decltype(basisCoeffs), ScalarViewType,  decltype(basisEWeights),
-        decltype(computedDofs), decltype(tagToOrdinal), decltype(orts), decltype(targetAtTargetEPoints), decltype(subcellParamFace)>;
+    using functorTypeFace = FunctorsProjectionTools::ComputeBasisCoeffsOnFaces_L2<ScalarViewType,  decltype(basisEWeights),
+        decltype(computedDofs), decltype(tagToOrdinal), decltype(targetAtTargetEPoints)>;
 
-    Kokkos::parallel_for(policy, functorTypeFace(basisCoeffs, negPartialProj,faceBasisDofAtBasisEPoints,
+    Kokkos::parallel_for(policy, functorTypeFace(refBasisCoeffs, negPartialProj,faceBasisDofAtBasisEPoints,
         basisAtBasisEPoints, basisEWeights, wBasisDofAtBasisEPoints, targetEWeights,
         basisAtTargetEPoints, wBasisDofAtTargetEPoints, computedDofs, tagToOrdinal,
-        orts, targetAtTargetEPoints,targetDofAtTargetEPoints,
-        subcellParamFace, fieldDim, faceCardinality, offsetBasis,
+        targetAtTargetEPoints,targetDofAtTargetEPoints,
+        refSideNormal, fieldDim, faceCardinality, offsetBasis,
         offsetTarget, numVertexDofs+numEdgeDofs, numFaces, faceDim,
-        dim, iface, topoKey, isHCurlBasis, isHDivBasis));
+        dim, iface, isHCurlBasis, isHDivBasis));
 
     typedef Kokkos::DynRankView<scalarType, Kokkos::LayoutRight, DeviceType> WorkArrayViewType;
-    ScalarViewType faceMassMat_("faceMassMat_", numCells, faceCardinality, faceCardinality),
+    ScalarViewType faceMassMat_("faceMassMat_", 1, faceCardinality, faceCardinality),
         faceRhsMat_("rhsMat_", numCells, faceCardinality);
 
-    FunctionSpaceTools<DeviceType >::integrate(faceMassMat_, faceBasisDofAtBasisEPoints, wBasisDofAtBasisEPoints);
+    FunctionSpaceTools<DeviceType >::integrate(faceMassMat_, faceBasisDofAtBasisEPoints, Kokkos::subview(wBasisDofAtBasisEPoints, std::make_pair(0,1), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()) );
     FunctionSpaceTools<DeviceType >::integrate(faceRhsMat_, targetDofAtTargetEPoints, wBasisDofAtTargetEPoints);
     FunctionSpaceTools<DeviceType >::integrate(faceRhsMat_, negPartialProj, wBasisDofAtBasisEPoints,true);
 
@@ -619,8 +593,8 @@ ProjectionTools<DeviceType>::getL2BasisCoeffs(Kokkos::DynRankView<basisCoeffsVal
 
     auto faceDof = Kokkos::subview(tagToOrdinal, faceDim, iface, Kokkos::ALL());
 
-    ElemSystem faceSystem("faceSystem", false);
-    faceSystem.solve(basisCoeffs, faceMassMat_, faceRhsMat_, t_, w_, faceDof, faceCardinality);
+    ElemSystem faceSystem("faceSystem", true);
+    faceSystem.solve(refBasisCoeffs, faceMassMat_, faceRhsMat_, t_, w_, faceDof, faceCardinality);
   }
 
   ordinal_type numElemDofs = cellBasis->getDofCount(dim,0);
@@ -635,7 +609,7 @@ ProjectionTools<DeviceType>::getL2BasisCoeffs(Kokkos::DynRankView<basisCoeffsVal
     ordinal_type numTargetEPoints = range_size(targetEPointsRange(dim,0));
     ordinal_type numBasisEPoints = range_size(basisEPointsRange(dim,0));
 
-    ScalarViewType internalBasisAtBasisEPoints("internalBasisAtBasisEPoints",numCells,numElemDofs, numBasisEPoints, fieldDim);
+    ScalarViewType internalBasisAtBasisEPoints("internalBasisAtBasisEPoints",1,numElemDofs, numBasisEPoints, fieldDim);
     ScalarViewType negPartialProj("negPartialProj", numCells, numBasisEPoints, fieldDim);
 
     auto targetEWeights = Kokkos::create_mirror_view_and_copy(MemSpaceType(),projStruct->getTargetEvalWeights(dim,0));
@@ -643,20 +617,19 @@ ProjectionTools<DeviceType>::getL2BasisCoeffs(Kokkos::DynRankView<basisCoeffsVal
     ordinal_type offsetBasis = basisEPointsRange(dim, 0).first;
     ordinal_type offsetTarget = targetEPointsRange(dim, 0).first;
 
-
     ScalarViewType wBasisAtBasisEPoints("weightedBasisAtBasisEPoints",numCells,numElemDofs, numBasisEPoints,fieldDim);
     ScalarViewType wBasisDofAtTargetEPoints("weightedBasisAtTargetEPoints",numCells,numElemDofs, numTargetEPoints,fieldDim);
 
-    using functorType = FunctorsProjectionTools::ComputeBasisCoeffsOnCells_L2<decltype(basisCoeffs), ScalarViewType,  decltype(basisEWeights), decltype(computedDofs), decltype(cellDofs)>;
-    Kokkos::parallel_for(policy, functorType( basisCoeffs, negPartialProj,  internalBasisAtBasisEPoints,
+    using functorType = FunctorsProjectionTools::ComputeBasisCoeffsOnCells_L2<ScalarViewType,  decltype(basisEWeights), decltype(computedDofs), decltype(cellDofs)>;
+    Kokkos::parallel_for(policy, functorType( refBasisCoeffs, negPartialProj,  internalBasisAtBasisEPoints,
         basisAtBasisEPoints, basisEWeights,  wBasisAtBasisEPoints, targetEWeights, basisAtTargetEPoints, wBasisDofAtTargetEPoints,
         computedDofs, cellDofs, fieldDim, numElemDofs, offsetBasis, offsetTarget, numVertexDofs+numEdgeDofs+numFaceDofs));
 
     typedef Kokkos::DynRankView<scalarType, Kokkos::LayoutRight, DeviceType> WorkArrayViewType;
-    ScalarViewType cellMassMat_("cellMassMat_", numCells, numElemDofs, numElemDofs),
+    ScalarViewType cellMassMat_("cellMassMat_", 1, numElemDofs, numElemDofs),
         cellRhsMat_("rhsMat_", numCells, numElemDofs);
 
-    FunctionSpaceTools<DeviceType >::integrate(cellMassMat_, internalBasisAtBasisEPoints, wBasisAtBasisEPoints);
+    FunctionSpaceTools<DeviceType >::integrate(cellMassMat_, internalBasisAtBasisEPoints, Kokkos::subview(wBasisAtBasisEPoints, std::make_pair(0,1), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()) );
     if(fieldDim==1)
       FunctionSpaceTools<DeviceType >::integrate(cellRhsMat_, Kokkos::subview(targetAtTargetEPoints,Kokkos::ALL(),cellPointsRange,Kokkos::ALL()),
           Kokkos::subview(wBasisDofAtTargetEPoints,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL(),0));
@@ -666,9 +639,11 @@ ProjectionTools<DeviceType>::getL2BasisCoeffs(Kokkos::DynRankView<basisCoeffsVal
 
     ScalarViewType t_("t",numCells, numElemDofs);
     WorkArrayViewType w_("w",numCells,numElemDofs);
-    ElemSystem cellSystem("cellSystem", false);
-    cellSystem.solve(basisCoeffs, cellMassMat_, cellRhsMat_, t_, w_, cellDofs, numElemDofs);
+    ElemSystem cellSystem("cellSystem", true);
+    cellSystem.solve(refBasisCoeffs, cellMassMat_, cellRhsMat_, t_, w_, cellDofs, numElemDofs);
   }
+
+  OrientationTools<DeviceType>::modifyBasisByOrientationInverse(basisCoeffs, refBasisCoeffs, orts, cellBasis, true);
 }
 
 
@@ -683,83 +658,13 @@ ProjectionTools<DeviceType>::getL2DGBasisCoeffs(Kokkos::DynRankView<basisCoeffsV
     const Kokkos::DynRankView<ortValueType,   ortProperties...>  orts,
     const BasisType* cellBasis,
     ProjectionStruct<DeviceType, typename BasisType::scalarType> * projStruct){
+  
+  Kokkos::DynRankView<typename BasisType::scalarType,DeviceType>  refBasisCoeffs("refBasisCoeffs", basisCoeffs.extent(0), basisCoeffs.extent(1));
+  getL2DGBasisCoeffs(refBasisCoeffs, targetAtTargetEPoints, cellBasis, projStruct);
 
-  typedef typename BasisType::scalarType scalarType;
-  typedef Kokkos::DynRankView<scalarType,DeviceType> ScalarViewType;
-  const auto cellTopo = cellBasis->getBaseCellTopology();
-
-  ordinal_type dim = cellTopo.getDimension();
-
-  auto basisEPoints = Kokkos::create_mirror_view_and_copy(MemSpaceType(),
-      projStruct->getEvalPoints(dim,0,EvalPointsType::BASIS));
-  auto targetEPoints = Kokkos::create_mirror_view_and_copy(MemSpaceType(),
-      projStruct->getEvalPoints(dim,0,EvalPointsType::TARGET));
-
-
-  ordinal_type numTotalTargetEPoints(targetAtTargetEPoints.extent(1));
-  ordinal_type basisCardinality = cellBasis->getCardinality();
-  ordinal_type numCells = targetAtTargetEPoints.extent(0);
-  const ordinal_type fieldDim = (targetAtTargetEPoints.rank()==2) ? 1 : targetAtTargetEPoints.extent(2);
-
-  ordinal_type numTotalBasisEPoints = projStruct->getNumBasisEvalPoints();
-  ScalarViewType basisAtBasisEPoints("basisAtBasisEPoints",numCells,basisCardinality, numTotalBasisEPoints, fieldDim);
-  ScalarViewType basisAtTargetEPoints("basisAtTargetEPoints",numCells,basisCardinality, numTotalTargetEPoints, fieldDim);
-  {
-    if(fieldDim == 1) {
-      ScalarViewType nonOrientedBasisAtBasisEPoints("nonOrientedBasisAtBasisEPoints",basisCardinality, numTotalBasisEPoints);
-      ScalarViewType nonOrientedBasisAtTargetEPoints("nonOrientedBasisAtTargetEPoints",basisCardinality, numTotalTargetEPoints);
-      cellBasis->getValues(nonOrientedBasisAtTargetEPoints, targetEPoints);
-      cellBasis->getValues(nonOrientedBasisAtBasisEPoints, basisEPoints);
-
-      OrientationTools<DeviceType>::modifyBasisByOrientation(Kokkos::subview(basisAtBasisEPoints, Kokkos::ALL(), Kokkos::ALL(),
-          Kokkos::ALL(),0), nonOrientedBasisAtBasisEPoints, orts, cellBasis);
-      OrientationTools<DeviceType>::modifyBasisByOrientation(Kokkos::subview(basisAtTargetEPoints, Kokkos::ALL(),
-          Kokkos::ALL(), Kokkos::ALL(),0), nonOrientedBasisAtTargetEPoints, orts, cellBasis);
-    }
-    else {
-      ScalarViewType nonOrientedBasisAtBasisEPoints("nonOrientedBasisAtBasisEPoints",basisCardinality, numTotalBasisEPoints,fieldDim);
-      ScalarViewType nonOrientedBasisAtTargetEPoints("nonOrientedBasisAtTargetEPoints",basisCardinality, numTotalTargetEPoints,fieldDim);
-      cellBasis->getValues(nonOrientedBasisAtTargetEPoints, targetEPoints);
-      cellBasis->getValues(nonOrientedBasisAtBasisEPoints, basisEPoints);
-
-      OrientationTools<DeviceType>::modifyBasisByOrientation(basisAtBasisEPoints, nonOrientedBasisAtBasisEPoints, orts, cellBasis);
-      OrientationTools<DeviceType>::modifyBasisByOrientation(basisAtTargetEPoints, nonOrientedBasisAtTargetEPoints, orts, cellBasis);
-    }
-  }
-
-  const Kokkos::RangePolicy<ExecSpaceType> policy(0, numCells);
-  ordinal_type numElemDofs = cellBasis->getCardinality();
-
-  auto targetEWeights = Kokkos::create_mirror_view_and_copy(MemSpaceType(),projStruct->getTargetEvalWeights(dim,0));
-  auto basisEWeights = Kokkos::create_mirror_view_and_copy(MemSpaceType(),projStruct->getBasisEvalWeights(dim,0));
-
-  ScalarViewType wBasisAtBasisEPoints("weightedBasisAtBasisEPoints",numCells,numElemDofs, numTotalBasisEPoints,fieldDim);
-  ScalarViewType wBasisDofAtTargetEPoints("weightedBasisAtTargetEPoints",numCells,numElemDofs, numTotalTargetEPoints,fieldDim);
-
-  using functorType = FunctorsProjectionTools::MultiplyBasisByWeights<decltype(basisAtBasisEPoints), decltype(basisEWeights)>;
-  Kokkos::parallel_for( "Multiply basis by weights", policy, functorType(basisAtBasisEPoints, basisEWeights,
-      wBasisAtBasisEPoints, targetEWeights,  basisAtTargetEPoints, wBasisDofAtTargetEPoints, fieldDim, numElemDofs));// )){
-
-  typedef Kokkos::DynRankView<scalarType, Kokkos::LayoutRight, DeviceType> WorkArrayViewType;
-  ScalarViewType cellMassMat_("cellMassMat_", numCells, numElemDofs, numElemDofs),
-      cellRhsMat_("rhsMat_", numCells, numElemDofs);
-
-  FunctionSpaceTools<DeviceType >::integrate(cellMassMat_, basisAtBasisEPoints, wBasisAtBasisEPoints);
-  if(fieldDim==1)
-    FunctionSpaceTools<DeviceType >::integrate(cellRhsMat_, targetAtTargetEPoints,
-        Kokkos::subview(wBasisDofAtTargetEPoints,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL(),0));
-  else
-    FunctionSpaceTools<DeviceType >::integrate(cellRhsMat_, targetAtTargetEPoints, wBasisDofAtTargetEPoints);
-
-  Kokkos::DynRankView<ordinal_type,Kokkos::HostSpace> hCellDofs("cellDoFs", numElemDofs);
-  for(ordinal_type i=0; i<numElemDofs; ++i) hCellDofs(i) = i;
-  auto cellDofs = Kokkos::create_mirror_view_and_copy(MemSpaceType(),hCellDofs);
-
-  ScalarViewType t_("t",numCells, numElemDofs);
-  WorkArrayViewType w_("w",numCells,numElemDofs);
-  ElemSystem cellSystem("cellSystem", false);
-  cellSystem.solve(basisCoeffs, cellMassMat_, cellRhsMat_, t_, w_, cellDofs, numElemDofs);
+  OrientationTools<DeviceType>::modifyBasisByOrientationInverse(basisCoeffs, refBasisCoeffs, orts, cellBasis, true);
 }
+
 
 template<typename DeviceType>
 template<typename basisViewType, typename targetViewType, typename BasisType>

--- a/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefL2.hpp
+++ b/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefL2.hpp
@@ -41,7 +41,7 @@
 // @HEADER
 
 /** \file   Intrepid2_ProjectionToolsDefL2.hpp
-    \brief  Header file for the Intrepid2::Experimental::ProjectionTools
+    \brief  Header file for the Intrepid2::ProjectionTools
             containing definitions for L2 projections.
     \author Created by Mauro Perego
  */
@@ -393,38 +393,6 @@ struct MultiplyBasisByWeights {
 
 } // FunctorsProjectionTools namespace
 
-#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-namespace Experimental {
-
-template<typename DeviceType>
-template<typename BasisType,
-typename ortValueType,       class ...ortProperties>
-void
-ProjectionTools<DeviceType>::getL2EvaluationPoints(typename BasisType::ScalarViewType ePoints,
-    const Kokkos::DynRankView<ortValueType,   ortProperties...>, //  orts,
-    const BasisType* cellBasis,
-    ProjectionStruct<DeviceType, typename BasisType::scalarType> * projStruct,
-    const EvalPointsType ePointType) {
-      RealSpaceTools<DeviceType>::clone(ePoints, projStruct->getAllEvalPoints(ePointType));
-}
-
-template<typename DeviceType>
-template<typename basisCoeffsValueType, class ...basisCoeffsProperties,
-typename funValsValueType, class ...funValsProperties,
-typename BasisType,
-typename ortValueType,class ...ortProperties>
-void
-ProjectionTools<DeviceType>::getL2BasisCoeffs(Kokkos::DynRankView<basisCoeffsValueType,basisCoeffsProperties...> basisCoeffs,
-    const Kokkos::DynRankView<funValsValueType,funValsProperties...> targetAtTargetEPoints,
-    const typename BasisType::ScalarViewType, // targetEPoints,
-    const Kokkos::DynRankView<ortValueType,   ortProperties...>  orts,
-    const BasisType* cellBasis,
-    ProjectionStruct<DeviceType, typename BasisType::scalarType> * projStruct){
-
-  getL2BasisCoeffs(basisCoeffs, targetAtTargetEPoints, orts, cellBasis, projStruct);
-}
-#endif
-
 
 template<typename DeviceType>
 template<typename basisCoeffsValueType, class ...basisCoeffsProperties,
@@ -703,17 +671,6 @@ ProjectionTools<DeviceType>::getL2BasisCoeffs(Kokkos::DynRankView<basisCoeffsVal
   }
 }
 
-#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-template<typename DeviceType>
-template<typename BasisType>
-void
-ProjectionTools<DeviceType>::getL2DGEvaluationPoints(typename BasisType::ScalarViewType ePoints,
-    const BasisType* cellBasis,
-    ProjectionStruct<DeviceType, typename BasisType::scalarType> * projStruct,
-    const EvalPointsType ePointType) {
-  RealSpaceTools<DeviceType>::clone(ePoints, projStruct->getAllEvalPoints(ePointType));
-}
-#endif
 
 template<typename DeviceType>
 template<typename basisCoeffsValueType, class ...basisCoeffsProperties,
@@ -882,9 +839,6 @@ ProjectionTools<DeviceType>::getL2DGBasisCoeffs(basisViewType basisCoeffs,
   cellSystem.solve(basisCoeffs, cellMassMat_, cellRhsMat_, t_, w_, cellDofs, numElemDofs);
 }
 
-#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-}
-#endif
 } //Intrepid2 namespace
 
 #endif

--- a/packages/intrepid2/unit-test/Projection/test_DeRham_commutativity_HEX.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_DeRham_commutativity_HEX.hpp
@@ -80,8 +80,6 @@
 #include "Intrepid2_CellTools.hpp"
 #include "Intrepid2_FunctionSpaceTools.hpp"
 
-#define Intrepid2_Experimental
-
 
 #include "Teuchos_oblackholestream.hpp"
 #include "Teuchos_RCP.hpp"
@@ -273,13 +271,8 @@ int DeRhamCommutativityHex(const bool verbose) {
   using faceType = std::array<ordinal_type,4>;
   using ct = CellTools<DeviceType>;
   using ots = OrientationTools<DeviceType>;
-  #ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-  using pts = Experimental::ProjectionTools<DeviceType>;
-  using ProjStruct = Experimental::ProjectionStruct<DeviceType,ValueType>;
-  #else
   using pts = ProjectionTools<DeviceType>;
   using ProjStruct = ProjectionStruct<DeviceType,ValueType>;
-  #endif
   using rst = RealSpaceTools<DeviceType>;
   using fst = FunctionSpaceTools<DeviceType>;
 

--- a/packages/intrepid2/unit-test/Projection/test_DeRham_commutativity_QUAD.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_DeRham_commutativity_QUAD.hpp
@@ -83,8 +83,6 @@
 #include "Intrepid2_CellTools.hpp"
 #include "Intrepid2_FunctionSpaceTools.hpp"
 
-#define Intrepid2_Experimental
-
 
 #include "Teuchos_oblackholestream.hpp"
 #include "Teuchos_RCP.hpp"
@@ -264,13 +262,8 @@ int DeRhamCommutativityQuad(const bool verbose) {
 
   using ct = CellTools<DeviceType>;
   using ots = OrientationTools<DeviceType>;
-  #ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-  using pts = Experimental::ProjectionTools<DeviceType>;
-  using ProjStruct = Experimental::ProjectionStruct<DeviceType,ValueType>;
-  #else
   using pts = ProjectionTools<DeviceType>;
   using ProjStruct = ProjectionStruct<DeviceType,ValueType>;
-  #endif
   using rst = RealSpaceTools<DeviceType>;
   using fst = FunctionSpaceTools<DeviceType>;
 

--- a/packages/intrepid2/unit-test/Projection/test_DeRham_commutativity_TET.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_DeRham_commutativity_TET.hpp
@@ -80,8 +80,6 @@
 #include "Intrepid2_CellTools.hpp"
 #include "Intrepid2_FunctionSpaceTools.hpp"
 
-#define Intrepid2_Experimental
-
 
 #include "Teuchos_oblackholestream.hpp"
 #include "Teuchos_RCP.hpp"
@@ -272,13 +270,8 @@ int DeRhamCommutativityTet(const bool verbose) {
 
   using ct = CellTools<DeviceType>;
   using ots = OrientationTools<DeviceType>;
-  #ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-  using pts = Experimental::ProjectionTools<DeviceType>;
-  using ProjStruct = Experimental::ProjectionStruct<DeviceType,ValueType>;
-  #else
   using pts = ProjectionTools<DeviceType>;
   using ProjStruct = ProjectionStruct<DeviceType,ValueType>;
-  #endif
   using rst = RealSpaceTools<DeviceType>;
   using fst = FunctionSpaceTools<DeviceType>;
 

--- a/packages/intrepid2/unit-test/Projection/test_DeRham_commutativity_TRI.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_DeRham_commutativity_TRI.hpp
@@ -83,8 +83,6 @@
 #include "Intrepid2_CellTools.hpp"
 #include "Intrepid2_FunctionSpaceTools.hpp"
 
-#define Intrepid2_Experimental
-
 
 #include "Teuchos_oblackholestream.hpp"
 #include "Teuchos_RCP.hpp"
@@ -264,13 +262,8 @@ int DeRhamCommutativityTri(const bool verbose) {
 
   using ct = CellTools<DeviceType>;
   using ots = OrientationTools<DeviceType>;
-  #ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-  using pts = Experimental::ProjectionTools<DeviceType>;
-  using ProjStruct = Experimental::ProjectionStruct<DeviceType,ValueType>;
-  #else
   using pts = ProjectionTools<DeviceType>;
   using ProjStruct = ProjectionStruct<DeviceType,ValueType>;
-  #endif
   using rst = RealSpaceTools<DeviceType>;
   using fst = FunctionSpaceTools<DeviceType>;
 

--- a/packages/intrepid2/unit-test/Projection/test_DeRham_commutativity_WEDGE.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_DeRham_commutativity_WEDGE.hpp
@@ -77,9 +77,6 @@
 #include "Intrepid2_CellTools.hpp"
 #include "Intrepid2_FunctionSpaceTools.hpp"
 
-#define Intrepid2_Experimental
-
-
 #include "Teuchos_oblackholestream.hpp"
 #include "Teuchos_RCP.hpp"
 #include <array>
@@ -269,13 +266,8 @@ int DeRhamCommutativityWedge(const bool verbose) {
 
   using ct = CellTools<DeviceType>;
   using ots = OrientationTools<DeviceType>;
-  #ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-  using pts = Experimental::ProjectionTools<DeviceType>;
-  using ProjStruct = Experimental::ProjectionStruct<DeviceType,ValueType>;
-  #else
   using pts = ProjectionTools<DeviceType>;
   using ProjStruct = ProjectionStruct<DeviceType,ValueType>;
-  #endif
   using rst = RealSpaceTools<DeviceType>;
   using fst = FunctionSpaceTools<DeviceType>;
 

--- a/packages/intrepid2/unit-test/Projection/test_convergence_HEX.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_convergence_HEX.hpp
@@ -71,8 +71,6 @@
 #include "Intrepid2_FunctionSpaceTools.hpp"
 #include "struct_mesh_utils.hpp"
 
-#define Intrepid2_Experimental
-
 
 #include "Teuchos_oblackholestream.hpp"
 #include "Teuchos_RCP.hpp"
@@ -227,13 +225,8 @@ int ConvergenceHex(const bool verbose) {
 
   using ct = CellTools<DeviceType>;
   using ots = OrientationTools<DeviceType>;
-  #ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-  using pts = Experimental::ProjectionTools<DeviceType>;
-  using ProjStruct = Experimental::ProjectionStruct<DeviceType,ValueType>;
-  #else
   using pts = ProjectionTools<DeviceType>;
   using ProjStruct = ProjectionStruct<DeviceType,ValueType>;
-  #endif
   using rst = RealSpaceTools<DeviceType>;
   using fst = FunctionSpaceTools<DeviceType>;
 

--- a/packages/intrepid2/unit-test/Projection/test_convergence_PYR.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_convergence_PYR.hpp
@@ -71,9 +71,6 @@
 #include "Intrepid2_FunctionSpaceTools.hpp"
 #include "struct_mesh_utils.hpp"
 
-#define Intrepid2_Experimental
-
-
 #include "Teuchos_oblackholestream.hpp"
 #include "Teuchos_RCP.hpp"
 #include <array>
@@ -226,13 +223,8 @@ int ConvergencePyr(const bool verbose) {
 
   using ct = CellTools<DeviceType>;
   using ots = OrientationTools<DeviceType>;
-  #ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-  using pts = Experimental::ProjectionTools<DeviceType>;
-  using ProjStruct = Experimental::ProjectionStruct<DeviceType,ValueType>;
-  #else
   using pts = ProjectionTools<DeviceType>;
   using ProjStruct = ProjectionStruct<DeviceType,ValueType>;
-  #endif
   using rst = RealSpaceTools<DeviceType>;
   using fst = FunctionSpaceTools<DeviceType>;
 

--- a/packages/intrepid2/unit-test/Projection/test_convergence_QUAD.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_convergence_QUAD.hpp
@@ -72,8 +72,6 @@
 #include "Intrepid2_FunctionSpaceTools.hpp"
 #include "struct_mesh_utils.hpp"
 
-#define Intrepid2_Experimental
-
 
 #include "Teuchos_oblackholestream.hpp"
 #include "Teuchos_RCP.hpp"
@@ -207,13 +205,8 @@ int ConvergenceQuad(const bool verbose) {
 
   using ct = CellTools<DeviceType>;
   using ots = OrientationTools<DeviceType>;
-  #ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-  using pts = Experimental::ProjectionTools<DeviceType>;
-  using ProjStruct = Experimental::ProjectionStruct<DeviceType,ValueType>;
-  #else
   using pts = ProjectionTools<DeviceType>;
   using ProjStruct = ProjectionStruct<DeviceType,ValueType>;
-  #endif
   using rst = RealSpaceTools<DeviceType>;
   using fst = FunctionSpaceTools<DeviceType>;
 

--- a/packages/intrepid2/unit-test/Projection/test_convergence_TET.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_convergence_TET.hpp
@@ -72,8 +72,6 @@
 #include "Intrepid2_FunctionSpaceTools.hpp"
 #include "struct_mesh_utils.hpp"
 
-#define Intrepid2_Experimental
-
 
 #include "Teuchos_oblackholestream.hpp"
 #include "Teuchos_RCP.hpp"
@@ -228,13 +226,8 @@ int ConvergenceTet(const bool verbose) {
 
   using ct = CellTools<DeviceType>;
   using ots = OrientationTools<DeviceType>;
-  #ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-  using pts = Experimental::ProjectionTools<DeviceType>;
-  using ProjStruct = Experimental::ProjectionStruct<DeviceType,ValueType>;
-  #else
   using pts = ProjectionTools<DeviceType>;
   using ProjStruct = ProjectionStruct<DeviceType,ValueType>;
-  #endif
   using rst = RealSpaceTools<DeviceType>;
   using fst = FunctionSpaceTools<DeviceType>;
 

--- a/packages/intrepid2/unit-test/Projection/test_convergence_TRI.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_convergence_TRI.hpp
@@ -73,8 +73,6 @@
 #include "Intrepid2_FunctionSpaceTools.hpp"
 #include "struct_mesh_utils.hpp"
 
-#define Intrepid2_Experimental
-
 
 #include "Teuchos_oblackholestream.hpp"
 #include "Teuchos_RCP.hpp"
@@ -208,13 +206,8 @@ int ConvergenceTri(const bool verbose) {
 
   using ct = CellTools<DeviceType>;
   using ots = OrientationTools<DeviceType>;
-  #ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-  using pts = Experimental::ProjectionTools<DeviceType>;
-  using ProjStruct = Experimental::ProjectionStruct<DeviceType,ValueType>;
-  #else
   using pts = ProjectionTools<DeviceType>;
   using ProjStruct = ProjectionStruct<DeviceType,ValueType>;
-  #endif
   using rst = RealSpaceTools<DeviceType>;
   using fst = FunctionSpaceTools<DeviceType>;
 

--- a/packages/intrepid2/unit-test/Projection/test_convergence_WEDGE.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_convergence_WEDGE.hpp
@@ -69,8 +69,6 @@
 #include "Intrepid2_FunctionSpaceTools.hpp"
 #include "struct_mesh_utils.hpp"
 
-#define Intrepid2_Experimental
-
 
 #include "Teuchos_oblackholestream.hpp"
 #include "Teuchos_RCP.hpp"
@@ -225,13 +223,8 @@ int ConvergenceWedge(const bool verbose) {
 
   using ct = CellTools<DeviceType>;
   using ots = OrientationTools<DeviceType>;
-  #ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-  using pts = Experimental::ProjectionTools<DeviceType>;
-  using ProjStruct = Experimental::ProjectionStruct<DeviceType,ValueType>;
-  #else
   using pts = ProjectionTools<DeviceType>;
   using ProjStruct = ProjectionStruct<DeviceType,ValueType>;
-  #endif
   using rst = RealSpaceTools<DeviceType>;
   using fst = FunctionSpaceTools<DeviceType>;
 

--- a/packages/intrepid2/unit-test/Projection/test_interpolation_projection_HEX.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_interpolation_projection_HEX.hpp
@@ -83,8 +83,6 @@
 #include "Intrepid2_LagrangianInterpolation.hpp"
 
 
-#define Intrepid2_Experimental
-
 //this allows to reduce cost of the tests.
 //undefine when debugging/developing
 #define RANDOMLY_PICK_ELEM_PERMUTATION
@@ -218,15 +216,9 @@ int InterpolationProjectionHex(const bool verbose) {
   using ct = CellTools<DeviceType>;
   using ots = OrientationTools<DeviceType>;
   using fst = FunctionSpaceTools<DeviceType>;
-  #ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-  using pts = Experimental::ProjectionTools<DeviceType>;
-  using li = Experimental::LagrangianInterpolation<DeviceType>;
-  using ProjStruct = Experimental::ProjectionStruct<DeviceType,ValueType>;
-#else
   using pts = ProjectionTools<DeviceType>;
   using li = LagrangianInterpolation<DeviceType>;
   using ProjStruct = ProjectionStruct<DeviceType,ValueType>;
-#endif
   using lt = LagrangianTools<DeviceType>;
   using  basisType = Basis<DeviceType,ValueType,ValueType>;
 

--- a/packages/intrepid2/unit-test/Projection/test_interpolation_projection_QUAD.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_interpolation_projection_QUAD.hpp
@@ -83,9 +83,6 @@
 #include "Intrepid2_LagrangianInterpolation.hpp"
 
 
-#define Intrepid2_Experimental
-
-
 #include "Teuchos_oblackholestream.hpp"
 #include "Teuchos_RCP.hpp"
 #include <array>
@@ -193,15 +190,9 @@ int InterpolationProjectionQuad(const bool verbose) {
   using ct = CellTools<DeviceType>;
   using ots = OrientationTools<DeviceType>;
   using fst = FunctionSpaceTools<DeviceType>;
-  #ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-  using pts = Experimental::ProjectionTools<DeviceType>;
-  using li = Experimental::LagrangianInterpolation<DeviceType>;
-  using ProjStruct = Experimental::ProjectionStruct<DeviceType,ValueType>;
-#else
   using pts = ProjectionTools<DeviceType>;
   using li = LagrangianInterpolation<DeviceType>;
   using ProjStruct = ProjectionStruct<DeviceType,ValueType>;
-#endif
   using lt = LagrangianTools<DeviceType>;
   using  basisType = Basis<DeviceType,ValueType,ValueType>;
 

--- a/packages/intrepid2/unit-test/Projection/test_interpolation_projection_TET.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_interpolation_projection_TET.hpp
@@ -83,8 +83,6 @@
 #include "Intrepid2_LagrangianInterpolation.hpp"
 
 
-#define Intrepid2_Experimental
-
 //this allows to reduce cost of the tests.
 //undefine when debugging/developing
 #define RANDOMLY_PICK_ELEM_PERMUTATION
@@ -212,15 +210,9 @@ int InterpolationProjectionTet(const bool verbose) {
   using ct = CellTools<DeviceType>;
   using ots = OrientationTools<DeviceType>;
   using fst = FunctionSpaceTools<DeviceType>;
-  #ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-  using pts = Experimental::ProjectionTools<DeviceType>;
-  using li = Experimental::LagrangianInterpolation<DeviceType>;
-  using ProjStruct = Experimental::ProjectionStruct<DeviceType,ValueType>;
-#else
   using pts = ProjectionTools<DeviceType>;
   using li = LagrangianInterpolation<DeviceType>;
   using ProjStruct = ProjectionStruct<DeviceType,ValueType>;
-#endif
   using lt = LagrangianTools<DeviceType>;
   using  basisType = Basis<DeviceType,ValueType,ValueType>;
 

--- a/packages/intrepid2/unit-test/Projection/test_interpolation_projection_TRI.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_interpolation_projection_TRI.hpp
@@ -83,9 +83,6 @@
 #include "Intrepid2_LagrangianInterpolation.hpp"
 
 
-#define Intrepid2_Experimental
-
-
 #include "Teuchos_oblackholestream.hpp"
 #include "Teuchos_RCP.hpp"
 #include <array>
@@ -187,15 +184,9 @@ int InterpolationProjectionTri(const bool verbose) {
   using ct = CellTools<DeviceType>;
   using ots = OrientationTools<DeviceType>;
   using fst = FunctionSpaceTools<DeviceType>;
-  #ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-  using pts = Experimental::ProjectionTools<DeviceType>;
-  using li = Experimental::LagrangianInterpolation<DeviceType>;
-  using ProjStruct = Experimental::ProjectionStruct<DeviceType,ValueType>;
-#else
   using pts = ProjectionTools<DeviceType>;
   using li = LagrangianInterpolation<DeviceType>;
   using ProjStruct = ProjectionStruct<DeviceType,ValueType>;
-#endif
   using lt = LagrangianTools<DeviceType>;
   using  basisType = Basis<DeviceType,ValueType,ValueType>;
 

--- a/packages/intrepid2/unit-test/Projection/test_interpolation_projection_WEDGE.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_interpolation_projection_WEDGE.hpp
@@ -80,8 +80,6 @@
 #include "Intrepid2_LagrangianInterpolation.hpp"
 
 
-#define Intrepid2_Experimental
-
 //this allows to reduce cost of the tests.
 //undefine when debugging/developing
 #define RANDOMLY_PICK_ELEM_PERMUTATION
@@ -216,15 +214,9 @@ int InterpolationProjectionWedge(const bool verbose) {
   using ct = CellTools<DeviceType>;
   using ots = OrientationTools<DeviceType>;
   using fst = FunctionSpaceTools<DeviceType>;
-#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-  using pts = Experimental::ProjectionTools<DeviceType>;
-  using li = Experimental::LagrangianInterpolation<DeviceType>;
-  using ProjStruct = Experimental::ProjectionStruct<DeviceType,ValueType>;
-#else
   using pts = ProjectionTools<DeviceType>;
   using li = LagrangianInterpolation<DeviceType>;
   using ProjStruct = ProjectionStruct<DeviceType,ValueType>;
-#endif
   using lt = LagrangianTools<DeviceType>;
   using  basisType = Basis<DeviceType,ValueType,ValueType>;
 

--- a/packages/intrepid2/unit-test/Projection/test_project_fields.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_project_fields.hpp
@@ -86,8 +86,6 @@
 #include "Intrepid2_HVOL_C0_FEM.hpp"
 #include "struct_mesh_utils.hpp"
 
-#define Intrepid2_Experimental
-
 
 #include "Teuchos_oblackholestream.hpp"
 #include "Teuchos_RCP.hpp"
@@ -161,13 +159,8 @@ int ProjectFields(const bool verbose) {
   };
 
   using ots = OrientationTools<DeviceType>;
-  #ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-  using pts = Experimental::ProjectionTools<DeviceType>;
-  using ProjStruct = Experimental::ProjectionStruct<DeviceType,ValueType>;
-#else
   using pts = ProjectionTools<DeviceType>;
   using ProjStruct = ProjectionStruct<DeviceType,ValueType>;
-#endif
   using basisPtrType = BasisPtr<DeviceType,ValueType,ValueType>;
   using CG_NBasis = DerivedNodalBasisFamily<DeviceType,ValueType,ValueType>;
 

--- a/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ProjectField_impl.hpp
+++ b/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ProjectField_impl.hpp
@@ -108,11 +108,7 @@ evaluateFields(typename Traits::EvalData workset)
   if (workset.num_cells<=0) return;
 
   // Perform local L2 projection
-#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-  using pts = Intrepid2::Experimental::ProjectionTools<PHX::Device>;
-#else
   using pts = Intrepid2::ProjectionTools<PHX::Device>;
-#endif
 
   size_t numCells = workset.num_cells;
   const auto cell_range = std::pair<int,int>(0,numCells);

--- a/packages/panzer/adapters-stk/test/projection/project_field.cpp
+++ b/packages/panzer/adapters-stk/test/projection/project_field.cpp
@@ -121,11 +121,7 @@ class GetCoeffsEvaluator
     DynRankView local_physEvalPoints;
     DynRankView local_refTargetAtEvalPoints, local_physTargetAtEvalPoints;
     ElemShape elemShape;
-  #ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-    Intrepid2::Experimental::ProjectionStruct<PHX::Device,double> projStruct;
-  #else
     Intrepid2::ProjectionStruct<PHX::Device,double> projStruct;
-  #endif
     Teuchos::RCP<Intrepid2::Basis<PHX::Device::execution_space,double,double> > it2basis;
   
 }; // end of class
@@ -202,11 +198,7 @@ evaluateFields(
 {
   using ct = Intrepid2::CellTools<PHX::Device>;
   using fst = Intrepid2::FunctionSpaceTools<PHX::Device>;
-  #ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-  using pts = Intrepid2::Experimental::ProjectionTools<PHX::Device>;
-  #else
   using pts = Intrepid2::ProjectionTools<PHX::Device>;
-  #endif 
 
   // FYI, this all relies on a first-order mesh
   auto cellNodesAll = workset.getCellNodes();

--- a/packages/panzer/adapters-stk/test/projection/projection.cpp
+++ b/packages/panzer/adapters-stk/test/projection/projection.cpp
@@ -369,11 +369,7 @@ TEUCHOS_UNIT_TEST(L2Projection, ToNodal)
         const int numBasisPHI = static_cast<int>(offsetsPHI.extent(0));
         const int numBasisE = static_cast<int>(offsetsE.extent(0));
         const int numBasisB = static_cast<int>(offsetsB.extent(0));
-  #ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-        using li = Intrepid2::Experimental::LagrangianInterpolation<PHX::Device>;
-  #else
         using li = Intrepid2::LagrangianInterpolation<PHX::Device>;
-  #endif
 
         //Computing HGRAD coefficients for PHI to interpolate function f(x,y,z) = 1+x+2y+3z
         DynRankView basisCoeffsPHI("basisCoeffsPHI", workset.numOwnedCells(), numBasisPHI);

--- a/packages/panzer/dof-mgr/test/fe_assembly/test_fe_assembly_HEX.hpp
+++ b/packages/panzer/dof-mgr/test/fe_assembly/test_fe_assembly_HEX.hpp
@@ -100,7 +100,6 @@
 #include <random>
 #include <algorithm>
 
-#define Intrepid2_Experimental
 
 namespace Discretization {
 
@@ -241,11 +240,7 @@ int feAssemblyHex(int argc, char *argv[]) {
   using ots = Intrepid2::OrientationTools<DeviceSpaceType>;
   using rst = Intrepid2::RealSpaceTools<DeviceSpaceType>;
   using fst = Intrepid2::FunctionSpaceTools<DeviceSpaceType>;
-#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-  using li = Intrepid2::Experimental::LagrangianInterpolation<DeviceSpaceType>;
-#else
   using li = Intrepid2::LagrangianInterpolation<DeviceSpaceType>;
-#endif
 
   int errorFlag = 0;
 

--- a/packages/panzer/dof-mgr/test/fe_assembly/test_fe_projection.hpp
+++ b/packages/panzer/dof-mgr/test/fe_assembly/test_fe_projection.hpp
@@ -106,8 +106,6 @@
 #include <random>
 #include <algorithm>
 
-#define Intrepid2_Experimental
-
 namespace Discretization {
 
 namespace Example {
@@ -169,13 +167,8 @@ int feProjection(int argc, char *argv[]) {
 
   using ct = Intrepid2::CellTools<DeviceSpaceType>;
   using ots = Intrepid2::OrientationTools<DeviceSpaceType>;
-#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-  using pts = Intrepid2::Experimental::ProjectionTools<DeviceSpaceType>;
-  using ProjectionStruct = Intrepid2::Experimental::ProjectionStruct<DeviceSpaceType,scalar_t>;
-#else
   using pts = Intrepid2::ProjectionTools<DeviceSpaceType>;
   using ProjectionStruct = Intrepid2::ProjectionStruct<DeviceSpaceType,scalar_t>;
-#endif
   using rst = Intrepid2::RealSpaceTools<DeviceSpaceType>;
   using fst = Intrepid2::FunctionSpaceTools<DeviceSpaceType>;
 

--- a/packages/panzer/mini-em/src/solvers/MiniEM_Interpolation.cpp
+++ b/packages/panzer/mini-em/src/solvers/MiniEM_Interpolation.cpp
@@ -26,12 +26,7 @@ Teko::LinearOp buildInterpolation(const Teuchos::RCP<const panzer::LinearObjFact
   typedef PHX::Device DeviceSpace;
   typedef Kokkos::HostSpace HostSpace;
   typedef Intrepid2::OrientationTools<DeviceSpace> ots;
-#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-  typedef Intrepid2::Experimental::LagrangianInterpolation<DeviceSpace> li;
-#else
   typedef Intrepid2::LagrangianInterpolation<DeviceSpace> li;
-#endif
-
   typedef Kokkos::DynRankView<double,DeviceSpace> DynRankDeviceView;
 
   // must be able to cast to a block linear object factory

--- a/packages/panzer/mini-em/src/solvers/MiniEM_MatrixFreeInterpolationOp.cpp
+++ b/packages/panzer/mini-em/src/solvers/MiniEM_MatrixFreeInterpolationOp.cpp
@@ -188,11 +188,7 @@ namespace mini_em {
     using range_type = Kokkos::RangePolicy<LocalOrdinal, DeviceSpace>;
 
     using ots = Intrepid2::OrientationTools<DeviceSpace>;
-#ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-    using li = Intrepid2::Experimental::LagrangianInterpolation<DeviceSpace>;
-#else
     using li = Intrepid2::LagrangianInterpolation<DeviceSpace>;
-#endif
     using DynRankDeviceView = Kokkos::DynRankView<Scalar,DeviceSpace>;
     using view_t = typename Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>::dual_view_type::t_dev;
     using const_view_t = typename Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>::dual_view_type::t_dev::const_type;
@@ -399,11 +395,7 @@ namespace mini_em {
     using range_type = Kokkos::RangePolicy<LocalOrdinal, DeviceSpace>;
 
     typedef Intrepid2::OrientationTools<DeviceSpace> ots;
-  #ifdef HAVE_INTREPID2_EXPERIMENTAL_NAMESPACE
-    typedef Intrepid2::Experimental::LagrangianInterpolation<DeviceSpace> li;
-  #else
     typedef Intrepid2::LagrangianInterpolation<DeviceSpace> li;
-  #endif
     typedef Kokkos::DynRankView<Scalar,DeviceSpace> DynRankDeviceView;
     using TST = Teuchos::ScalarTraits<Scalar>;
     const Scalar ZERO = TST::zero();


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/intrepid2 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
In this PR we continue the work started in PR #12141 and remove legacy projection functions in the `Experimental` namespace.

We also further improve the performance of Projections by fully working at the level of the reference element and map the basis coefficient back to the oriented frame at the end of the projection computation.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->