### PR TITLE
Update zoltan table formatting

### DIFF
--- a/packages/zoltan2/core/src/util/Zoltan2_ImbalanceMetrics.hpp
+++ b/packages/zoltan2/core/src/util/Zoltan2_ImbalanceMetrics.hpp
@@ -153,7 +153,7 @@ template <typename scalar_t>
   void ImbalanceMetrics<scalar_t>::printHeader(std::ostream &os)
 {
   os << std::setw(20) << " ";
-  os << std::setw(11) << "min" << std::setw(11) << "max" << std::setw(11) << "avg";
+  os << std::setw(15) << "min" << std::setw(15) << "max" << std::setw(15) << "avg";
   os << std::setw(2) << " ";
   os << std::setw(10) << "imbalance";
   os << std::endl;
@@ -184,13 +184,17 @@ template <typename scalar_t>
     label = oss.str();
   }
 
+  auto min = this->getMetricValue("global minimum");
+  auto max = this->getMetricValue("global maximum");
+  auto avg = this->getMetricValue("global average");
+  int precision = 4;
+  if( min > 999 ) { precision = 0; }
+  else if( min > 99 ) { precision = 2; }
+
   os << std::setw(20) << label;
-  os << std::setw(11) << std::setprecision(4) 
-     << this->getMetricValue("global minimum");
-  os << std::setw(11) << std::setprecision(4) 
-     << this->getMetricValue("global maximum");
-  os << std::setw(11) << std::setprecision(4) 
-     << this->getMetricValue("global average");
+  os << std::setw(15) << std::setprecision(precision) << min;
+  os << std::setw(15) << std::setprecision(precision) << max;
+  os << std::setw(15) << std::setprecision(precision) << avg;
 
   os << std::setw(2) << " ";
   os << std::setw(10) << std::setprecision(4) 


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@egboman 

## Motivation
When using large weights, the current Zoltan table does not have room and prints all the numbers without spacing, making it difficult to read. This adds space and reduces precision for large numbers, changing the table from something like this:

    Imbalance Metrics: (8 existing parts)
                                min        max        avg   imbalance
        object count (2)142062.0000173118.0000158268.1250      1.0938
       normed weight (2)5747604.06736730017.01836214345.1864      1.0830
            weight 0 (2)     0.2493     0.3263     0.2891      1.1290
            weight 1 (2)     1.2349     1.5900     1.4277      1.1136
            weight 2 (2)3907548.64324589655.98794238875.5000      1.0828
            weight 3 (2)     5.3724     5.9525     5.5874      1.0654
            weight 4 (2)4210736.63914916853.77834540803.0623      1.0828

To this:

    Imbalance Metrics: (8 existing parts)
                                    min            max            avg   imbalance
        object count (2)         145466         165419         158268      1.0452
       normed weight (2)        3800334        4232395        4057523      1.0431
            weight 0 (2)        1551480        1727868        1656477      1.0431
            weight 1 (2)        1551480        1727868        1656477      1.0431
            weight 2 (2)        1551480        1727868        1656477      1.0431
            weight 3 (2)        1551480        1727868        1656477      1.0431
            weight 4 (2)        1551480        1727868        1656477      1.0431
            weight 5 (2)        1551480        1727868        1656477      1.0431


