### PR TITLE
Framework: Add action to prevent LFS files from being added

### DIFF
--- a/.github/workflows/detect-git-lfs.yml
+++ b/.github/workflows/detect-git-lfs.yml
@@ -18,4 +18,4 @@ jobs:
         git diff -U0 --ignore-all-space $(git merge-base origin/${{ github.event.pull_request.base.ref }} ${{ github.event.pull_request.head.sha }}) \
         | grep "^oid sha236" \
         || { echo "No pointers found!" ; exit 0 } \
-        && { echo "Git LFS pointers found; not allowed to add LFS files to Trilinos!" ; exit 1 
+        && { echo "Git LFS pointers found; not allowed to add LFS files to Trilinos!" ; exit 1 }

--- a/.github/workflows/detect-git-lfs.yml
+++ b/.github/workflows/detect-git-lfs.yml
@@ -17,5 +17,5 @@ jobs:
       run: |
         git diff -U0 --ignore-all-space $(git merge-base origin/${{ github.event.pull_request.base.ref }} ${{ github.event.pull_request.head.sha }}) \
         | grep "^oid sha236" \
-        || ( echo "No pointers found!" ; exit 0 ) \
-        && ( echo "Git LFS pointers found; not allowed to add LFS files to Trilinos!" ; exit 1)
+        || { echo "No pointers found!" ; exit 0 } \
+        && { echo "Git LFS pointers found; not allowed to add LFS files to Trilinos!" ; exit 1 

--- a/.github/workflows/detect-git-lfs.yml
+++ b/.github/workflows/detect-git-lfs.yml
@@ -1,0 +1,21 @@
+name: Check for git LFS pointers
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Search for oids in modified lines
+      run: |
+        git diff -U0 --ignore-all-space $(git merge-base origin/${{ github.event.pull_request.base.ref }} ${{ github.event.pull_request.head.sha }}) \
+        | grep "^oid sha236" \
+        || ( echo "No pointers found!" ; exit 0 ) \
+        && ( echo "Git LFS pointers found; not allowed to add LFS files to Trilinos!" ; exit 1)

--- a/.github/workflows/detect-git-lfs.yml
+++ b/.github/workflows/detect-git-lfs.yml
@@ -15,7 +15,6 @@ jobs:
 
     - name: Search for oids in modified lines
       run: |
-        git diff -U0 --ignore-all-space $(git merge-base origin/${{ github.event.pull_request.base.ref }} ${{ github.event.pull_request.head.sha }}) \
-        | grep "^oid sha236" \
-        || { echo "No pointers found!" ; exit 0 } \
-        && { echo "Git LFS pointers found; not allowed to add LFS files to Trilinos!" ; exit 1 }
+        $GITHUB_WORKSPACE/commonTools/test/utilities/check-lfs-oids.sh \
+        origin/${{ github.event.pull_request.base.ref }} \
+        ${{ github.event.pull_request.head.sha }}

--- a/commonTools/test/utilities/check-lfs-oids.sh
+++ b/commonTools/test/utilities/check-lfs-oids.sh
@@ -4,11 +4,10 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
-claimed_start_of_branch=${1}
-end_of_branch=${2}
-start_of_branch=$(git merge-base ${claimed_start_of_branch} ${end_of_branch})
+target_branch=${1}
+source_branch=${2}
 
-for commit in $(git log --format=%H ${start_of_branch}..${end_of_branch})
+for commit in $(git log --format=%H ${target_branch} --not ${source_branch})
 do
     echo "Processing commit ${commit}"
     git diff -U0 --ignore-all-space ${commit}~1 ${commit} | grep "^\+oid sha256" \

--- a/commonTools/test/utilities/check-lfs-oids.sh
+++ b/commonTools/test/utilities/check-lfs-oids.sh
@@ -7,7 +7,7 @@ set -o pipefail
 target_branch=${1}
 source_branch=${2}
 
-for commit in $(git log --format=%H ${target_branch} --not ${source_branch})
+for commit in $(git log --format=%H ${source_branch} --not ${target_branch})
 do
     echo "Processing commit ${commit}"
     git diff -U0 --ignore-all-space ${commit}~1 ${commit} | grep "^\+oid sha256" \

--- a/commonTools/test/utilities/check-lfs-oids.sh
+++ b/commonTools/test/utilities/check-lfs-oids.sh
@@ -1,0 +1,18 @@
+#!/bin/bash    
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+claimed_start_of_branch=${1}
+end_of_branch=${2}
+start_of_branch=$(git merge-base ${claimed_start_of_branch} ${end_of_branch})
+
+for commit in $(git log --format=%H ${start_of_branch}..${end_of_branch})
+do
+    echo "Processing commit ${commit}"
+    git diff -U0 --ignore-all-space ${commit}~1 ${commit} | grep "^\+oid sha256" \
+    && { echo "Git LFS pointers found; not allowed to add LFS files to Trilinos!" ; exit 1 ; }
+done
+
+echo "No LFS pointers found!"

--- a/commonTools/test/utilities/check-mpi-comm-world-usage.py
+++ b/commonTools/test/utilities/check-mpi-comm-world-usage.py
@@ -108,6 +108,12 @@ if __name__ == "__main__":
     parser.add_argument(
         "--head", default="HEAD", help="HEAD commit (default: %(default)s)"
     )
+    parser.add_argument(
+        "REGEX", help="Regular expression representing forbidden strings."
+    )
+    parser.add_argument(
+        "--file-extensions"
+    )
 
     start_commit = parser.parse_args().base
     print(f"Start commit: {start_commit}")

--- a/commonTools/test/utilities/check-mpi-comm-world-usage.py
+++ b/commonTools/test/utilities/check-mpi-comm-world-usage.py
@@ -108,12 +108,6 @@ if __name__ == "__main__":
     parser.add_argument(
         "--head", default="HEAD", help="HEAD commit (default: %(default)s)"
     )
-    parser.add_argument(
-        "REGEX", help="Regular expression representing forbidden strings."
-    )
-    parser.add_argument(
-        "--file-extensions"
-    )
 
     start_commit = parser.parse_args().base
     print(f"Start commit: {start_commit}")


### PR DESCRIPTION
@trilinos/framework 

## Motivation
Adding LFS pointers causes headaches with GitHub quotas and some downstream customers doing mirroring.