### PR TITLE
Tpetra: Fix #12118 (adding checks)

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_DistributorActor.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorActor.hpp
@@ -249,7 +249,13 @@ void DistributorActor::doPosts(const DistributorPlan& plan,
     size_t numBlocks = plan.getNumSends() + plan.hasSelfMessage();
     for (size_t p = 0; p < numBlocks; ++p) {
       sdispls[plan.getProcsTo()[p]]    = plan.getStartsTo()[p]  * numPackets;
-      sendcounts[plan.getProcsTo()[p]] = plan.getLengthsTo()[p] * numPackets;
+      size_t sendcount = plan.getLengthsTo()[p] * numPackets;
+      // sendcount is converted down to int, so make sure it can be represented
+      TEUCHOS_TEST_FOR_EXCEPTION(sendcount > size_t(INT_MAX),
+                                 std::logic_error, "Tpetra::Distributor::doPosts(3 args, Kokkos): "
+                                 "Send count for block " << p << " (" << sendcount << ") is too large "
+                                 "to be represented as int.");
+      sendcounts[plan.getProcsTo()[p]] = static_cast<int>(sendcount);
     }
 
     const size_type actualNumReceives = as<size_type> (plan.getNumReceives()) +
@@ -265,7 +271,12 @@ void DistributorActor::doPosts(const DistributorPlan& plan,
                                  "curBufferOffset(" << curBufferOffset << ") + curBufLen(" <<
                                  curBufLen << ").");
       rdispls   [plan.getProcsFrom()[i]] = curBufferOffset;
-      recvcounts[plan.getProcsFrom()[i]] = curBufLen;
+      // curBufLen is converted down to int, so make sure it can be represented
+      TEUCHOS_TEST_FOR_EXCEPTION(curBufLen > size_t(INT_MAX),
+                                 std::logic_error, "Tpetra::Distributor::doPosts(3 args, Kokkos): "
+                                 "Recv count for receive " << i << " (" << curBufLen << ") is too large "
+                                 "to be represented as int.");
+      recvcounts[plan.getProcsFrom()[i]] = static_cast<int>(curBufLen);
       curBufferOffset += curBufLen;
     }
 
@@ -580,7 +591,12 @@ void DistributorActor::doPosts(const DistributorPlan& plan,
       for (size_t j=plan.getStartsTo()[pp]; j<plan.getStartsTo()[pp]+plan.getLengthsTo()[pp]; ++j) {
         numPackets += numExportPacketsPerLID[j];
       }
-      sendcounts[plan.getProcsTo()[pp]] = numPackets;
+      // numPackets is converted down to int, so make sure it can be represented
+      TEUCHOS_TEST_FOR_EXCEPTION(numPackets > size_t(INT_MAX),
+                                 std::logic_error, "Tpetra::Distributor::doPosts(4 args, Kokkos): "
+                                 "Send count for send " << pp << " (" << numPackets << ") is too large "
+                                 "to be represented as int.");
+      sendcounts[plan.getProcsTo()[pp]] = static_cast<int>(numPackets);
       curPKToffset += numPackets;
     }
 
@@ -597,7 +613,12 @@ void DistributorActor::doPosts(const DistributorPlan& plan,
       curLIDoffset += plan.getLengthsFrom()[i];
 
       rdispls   [plan.getProcsFrom()[i]] = curBufferOffset;
-      recvcounts[plan.getProcsFrom()[i]] = totalPacketsFrom_i;
+      // totalPacketsFrom_i is converted down to int, so make sure it can be represented
+      TEUCHOS_TEST_FOR_EXCEPTION(totalPacketsFrom_i > size_t(INT_MAX),
+                                 std::logic_error, "Tpetra::Distributor::doPosts(3 args, Kokkos): "
+                                 "Recv count for receive " << i << " (" << totalPacketsFrom_i << ") is too large "
+                                 "to be represented as int.");
+      recvcounts[plan.getProcsFrom()[i]] = static_cast<int>(totalPacketsFrom_i);
       curBufferOffset += totalPacketsFrom_i;
     }
 
@@ -696,6 +717,11 @@ void DistributorActor::doPosts(const DistributorPlan& plan,
       for (size_t j = 0; j < plan.getLengthsFrom()[i]; ++j) {
         totalPacketsFrom_i += numImportPacketsPerLID[curLIDoffset+j];
       }
+      // totalPacketsFrom_i is converted down to int, so make sure it can be represented
+      TEUCHOS_TEST_FOR_EXCEPTION(totalPacketsFrom_i > size_t(INT_MAX),
+                                 std::logic_error, "Tpetra::Distributor::doPosts(3 args, Kokkos): "
+                                 "Recv count for receive " << i << " (" << totalPacketsFrom_i << ") is too large "
+                                 "to be represented as int.");
       curLIDoffset += plan.getLengthsFrom()[i];
       if (plan.getProcsFrom()[i] != myProcID && totalPacketsFrom_i) {
         // If my process is receiving these packet(s) from another
@@ -734,6 +760,11 @@ void DistributorActor::doPosts(const DistributorPlan& plan,
       numPackets += numExportPacketsPerLID[j];
     }
     if (numPackets > maxNumPackets) maxNumPackets = numPackets;
+    // numPackets will be used as a message length, so make sure it can be represented as int
+    TEUCHOS_TEST_FOR_EXCEPTION(numPackets > size_t(INT_MAX),
+                               std::logic_error, "Tpetra::Distributor::doPosts(4 args, Kokkos): "
+                               "packetsPerSend[" << pp << "] = " << numPackets << " is too large "
+                               "to be represented as int.");
     packetsPerSend[pp] = numPackets;
     curPKToffset += numPackets;
   }


### PR DESCRIPTION
In ``DistributorActor::doPosts``, make sure each message length in bytes (sendCount) can be represented in 32-bit int. This is needed because the Teuchos MPI wrappers and MPI itself represent send and recv counts as int.

In #12118 reproducer, this is the output now:
```
p=0 |   nnz_per_row = 20
p=0 |   rpt_size = 18808798
p=0 |   ent_size = 376175940
p=0 |   val_size = 376175940
p=1 |   num_rows = 18808797
p=1 |   nnz_per_row = 20
p=1 |   rpt_size = 18808798
p=1 |   ent_size = 376175940
p=1 |   val_size = 376175940
p=0 |   my_local_num_rows = 18808797  my_global_num_rows = 18808797
p=1 |   my_local_num_rows = 0  my_global_num_rows = 18808797
p=0 |   I make it here...
p=1 |   I make it here...

 
 p=0: *** Caught standard std::exception of type 'std::logic_error' :
 
  /ascldap/users/bmkelle/TrilinosWork/Trilinos/packages/tpetra/core/src/Tpetra_Details_DistributorActor.hpp:764:
  
  Throw number = 1
  
  Throw test that evaluated to true: numPackets > size_t(INT_MAX)
  
  Tpetra::Distributor::doPosts(4 args, Kokkos): packetsPerSend[0] = 2294673112 is too large to be represented as int.
```
so internal MPI errors are avoided, and the throw message gives some better info about what and where the issue is.

Before this check, the output was a lot less informative:
```
[kokkos-dev-2:261932] *** An error occurred in MPI_Send
[kokkos-dev-2:261932] *** reported by process [3031236609,0]
[kokkos-dev-2:261932] *** on communicator MPI_COMM_WORLD
[kokkos-dev-2:261932] *** MPI_ERR_COUNT: invalid count argument
[kokkos-dev-2:261932] *** MPI_ERRORS_ARE_FATAL (processes in this communicator will now abort,
[kokkos-dev-2:261932] ***    and potentially your MPI job)
```

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Resolve #12118. On that issue's discussion, we decided not to make large messages actually work since it would require some nontrivial changes in Teuchos. And this isn't a use case that has shown up in applications before.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:
-->
## Related Issues

* Closes #12118
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 



## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
Tested with the reproducer in #12118. Even though it's pretty minimal for triggering this issue, it still takes way too long to run for a permanent unit test.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->