### PR TITLE
Tpetra: remove unnecessary copy to host in TAFC

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -8502,7 +8502,6 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       CSR_colind_LID.resize (CSR_colind_GID.size());
     }
     CSR_colind_LID.resize (CSR_colind_GID.size());
-    size_t mynnz = CSR_vals.size();
 
     // On return from unpackAndCombineIntoCrsArrays TargetPids[i] == -1 for locally
     // owned entries.  Convert them to the actual PID.

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -8598,9 +8598,9 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     typename nonconst_local_inds_host_view_type::non_const_type CSR_colind_LID_host(CSR_colind_LID.getRawPtr(), CSR_colind_LID.size());
     typename nonconst_values_host_view_type::non_const_type     CSR_vals_host(reinterpret_cast<impl_scalar_type*>(CSR_vals.getRawPtr()), CSR_vals.size());
 
-    typename row_ptrs_device_view_type::non_const_type   CSR_rowptr_dev("rowmap", CSR_rowptr.size());
-    typename local_inds_device_view_type::non_const_type CSR_colind_LID_dev("colind", CSR_colind_LID.size());
-    typename values_device_view_type::non_const_type     CSR_vals_dev("values", CSR_vals.size());
+    typename row_ptrs_device_view_type::non_const_type   CSR_rowptr_dev(Kokkos::ViewAllocateWithoutInitializing("rowmap"), CSR_rowptr.size());
+    typename local_inds_device_view_type::non_const_type CSR_colind_LID_dev(Kokkos::ViewAllocateWithoutInitializing("colind"), CSR_colind_LID.size());
+    typename values_device_view_type::non_const_type     CSR_vals_dev(Kokkos::ViewAllocateWithoutInitializing("values"), CSR_vals.size());
 
     Kokkos::deep_copy(CSR_rowptr_dev, CSR_rowptr_host);
     Kokkos::deep_copy(CSR_colind_LID_dev, CSR_colind_LID_host);


### PR DESCRIPTION
@trilinos/tpetra 

## Motivation
This provides further performance improvements on device for TAFC and simplifies the code.
It's also a step toward full device execution of TAFC where it constructs the CrsMatrix.
That's an important update as the data associated with the CrsMatrix is potentially quite large and moving it back and forth on host and device is really a performance issue.

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows #11751 
* Precedes 
* Related to 
* Part of #11689 
* Composed of 


## Stakeholder Feedback
N/A

## Testing
Tested on weaver with complex enabled.