### PR TITLE
Ifpack2: add option to use stream interfaces of KK SPILUK and KK SPTRSV in RILUK and local triangular solver

### DIFF
--- a/packages/ifpack2/doc/UsersGuide/options.tex
+++ b/packages/ifpack2/doc/UsersGuide/options.tex
@@ -478,6 +478,30 @@ The following parameters are used in the ILU($k$) method:
      (not including contribution specified by {\tt "fact: absolute
      threshold"}). Can be combined with {\tt "fact: absolute threshold"}.
      The matrix remains unchanged.}
+\ccc{fact: type}
+    {string}
+    {"Serial"}
+    {The RILUK factorization implementation type. Currently supports two types:
+     "Serial" (serial execution on the host) and "KSPILUK" (a Kokkos Kernels's
+     SpILUK on multi-core or GPU).}
+\ccc{trisolver: type}
+    {string}
+    {"Internal"}
+    {The triangular solver type. Currently supports three solver types:
+     "Internal" (serial execution on the host), "HTS" (a ShyLU's sparse
+     triangular solver that uses OpenMP on the host), and "KSPTRSV" (a Kokkos
+     Kernels's SpTRSV on multi-core or GPU).}
+\ccc{fact: kspiluk number-of-streams}
+    {int|global\_ordinal}
+    {0}
+    {Number of streams used by Kokkos Kernels's SpILUK and SpTRSV. When using
+     streams, the sub-domain on each MPI process is divided to diagonal blocks,
+     each of which is handled by SpILUK and SpTRSV on a stream. Because
+     information in off-diagonals of the sub-domain is ignored, it is expected
+     that iterative solvers take more interations to converge. However, since
+     these streams can run concurrently, the total time can be faster. When
+     this option is not set (i.e. not using stream), the entire sub-domain is
+     used instead.}
 % All overlap-related code was removed by M. Hoemmen in
 %
 % commit 162f64572fbf93e2cac73e3034d76a3db918a494

--- a/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_decl.hpp
@@ -340,6 +340,16 @@ public:
   /// then compute(), before you may call apply().
   virtual void setMatrix (const Teuchos::RCP<const row_matrix_type>& A);
 
+  /// \brief Set this triangular solver's stream information.
+  ///
+  void setStreamInfo (const bool& isKokkosKernelsStream, const int& num_streams, const std::vector<HandleExecSpace>& exec_space_instances);
+
+  /// \brief Set this preconditioner's matrices (used by stream interface of triangular solve).
+  ///
+  /// After calling this method, you must call first initialize(),
+  /// then compute(), before you may call apply().
+  void setMatrices (const std::vector< Teuchos::RCP<crs_matrix_type> >& A_crs_v);
+
   //@}
 
 private:
@@ -349,6 +359,7 @@ private:
   Teuchos::RCP<Teuchos::FancyOStream> out_;
   //! The original input matrix, as a Tpetra::CrsMatrix.
   Teuchos::RCP<const crs_matrix_type> A_crs_;
+  std::vector< Teuchos::RCP<crs_matrix_type> > A_crs_v_;
 
   typedef Tpetra::MultiVector<scalar_type, local_ordinal_type, global_ordinal_type, node_type> MV;
   mutable Teuchos::RCP<MV> X_colMap_;
@@ -383,6 +394,11 @@ private:
   //! Optional KokkosKernels implementation.
   bool isKokkosKernelsSptrsv_;
   Teuchos::RCP<k_handle> kh_;
+  std::vector< Teuchos::RCP<k_handle> > kh_v_;
+  int num_streams_;
+  bool isKokkosKernelsStream_;
+  bool kh_v_nonnull_;
+  std::vector<HandleExecSpace> exec_space_instances_;
 
   /// \brief "L" if the matrix is locally lower triangular, "U" if the
   ///   matrix is locally upper triangular, or "N" if unknown or

--- a/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
@@ -310,6 +310,8 @@ void LocalSparseTriangularSolver<MatrixType>::initializeState ()
   computeTime_ = 0.0;
   applyTime_ = 0.0;
   isKokkosKernelsSptrsv_ = false;
+  isKokkosKernelsStream_ = false;
+  num_streams_ = 0;
   uplo_ = "N";
   diag_ = "N";
 }
@@ -318,9 +320,17 @@ template<class MatrixType>
 LocalSparseTriangularSolver<MatrixType>::
 ~LocalSparseTriangularSolver ()
 {
-  if (Teuchos::nonnull (kh_))
-  {
-    kh_->destroy_sptrsv_handle();
+  if (!isKokkosKernelsStream_) {
+    if (Teuchos::nonnull (kh_)) {
+      kh_->destroy_sptrsv_handle();
+    }
+  }
+  else {
+    for (int i = 0; i < num_streams_; i++) {
+      if (Teuchos::nonnull (kh_v_[i])) {
+        kh_v_[i]->destroy_sptrsv_handle();
+      }
+    }
   }
 }
 
@@ -355,7 +365,10 @@ setParameters (const Teuchos::ParameterList& pl)
   }
 
   if (trisolverType == Details::TrisolverType::KSPTRSV) {
-    kh_ = Teuchos::rcp (new k_handle());
+    this->isKokkosKernelsSptrsv_ = true;
+  }
+  else {
+    this->isKokkosKernelsSptrsv_ = false;
   }
 
   if (pl.isParameter("trisolver: reverse U"))
@@ -383,125 +396,172 @@ initialize ()
     *out_ << ">>> DEBUG " << prefix << std::endl;
   }
 
-  TEUCHOS_TEST_FOR_EXCEPTION
-    (A_.is_null (), std::runtime_error, prefix << "You must call "
-     "setMatrix() with a nonnull input matrix before you may call "
-     "initialize() or compute().");
-  if (A_crs_.is_null ()) {
-    auto A_crs = Teuchos::rcp_dynamic_cast<const crs_matrix_type> (A_);
+  if (!isKokkosKernelsStream_) {
     TEUCHOS_TEST_FOR_EXCEPTION
-      (A_crs.get () == nullptr, std::invalid_argument,
-       prefix << "The input matrix A is not a Tpetra::CrsMatrix.");
-    A_crs_ = A_crs;
-  }
-  auto G = A_crs_->getGraph ();
-  TEUCHOS_TEST_FOR_EXCEPTION
-    (G.is_null (), std::logic_error, prefix << "A_ and A_crs_ are nonnull, "
-     "but A_crs_'s RowGraph G is null.  "
-     "Please report this bug to the Ifpack2 developers.");
-  // At this point, the graph MUST be fillComplete.  The "initialize"
-  // (symbolic) part of setup only depends on the graph structure, so
-  // the matrix itself need not be fill complete.
-  TEUCHOS_TEST_FOR_EXCEPTION
-    (! G->isFillComplete (), std::runtime_error, "If you call this method, "
-     "the matrix's graph must be fill complete.  It is not.");
+      (A_.is_null (), std::runtime_error, prefix << "You must call "
+       "setMatrix() with a nonnull input matrix before you may call "
+       "initialize() or compute().");
+    if (A_crs_.is_null ()) {
+      auto A_crs = Teuchos::rcp_dynamic_cast<const crs_matrix_type> (A_);
+      TEUCHOS_TEST_FOR_EXCEPTION
+        (A_crs.get () == nullptr, std::invalid_argument,
+         prefix << "The input matrix A is not a Tpetra::CrsMatrix.");
+      A_crs_ = A_crs;
+    }
+    auto G = A_crs_->getGraph ();
+    TEUCHOS_TEST_FOR_EXCEPTION
+      (G.is_null (), std::logic_error, prefix << "A_ and A_crs_ are nonnull, "
+       "but A_crs_'s RowGraph G is null.  "
+       "Please report this bug to the Ifpack2 developers.");
+    // At this point, the graph MUST be fillComplete.  The "initialize"
+    // (symbolic) part of setup only depends on the graph structure, so
+    // the matrix itself need not be fill complete.
+    TEUCHOS_TEST_FOR_EXCEPTION
+      (! G->isFillComplete (), std::runtime_error, "If you call this method, "
+       "the matrix's graph must be fill complete.  It is not.");
 
-  // mfh 30 Apr 2018: See GitHub Issue #2658.
-  constexpr bool ignoreMapsForTriStructure = true;
-  auto lclTriStructure = [&] {
-    auto lclMatrix = A_crs_->getLocalMatrixDevice ();
-    auto lclRowMap = A_crs_->getRowMap ()->getLocalMap ();
-    auto lclColMap = A_crs_->getColMap ()->getLocalMap ();
-    auto lclTriStruct =
-      determineLocalTriangularStructure (lclMatrix.graph,
-                                         lclRowMap,
-                                         lclColMap,
-                                         ignoreMapsForTriStructure);
-    const LO lclNumRows = lclRowMap.getLocalNumElements ();
-    this->diag_ = (lclTriStruct.diagCount < lclNumRows) ? "U" : "N";
-    this->uplo_ = lclTriStruct.couldBeLowerTriangular ? "L" :
-      (lclTriStruct.couldBeUpperTriangular ? "U" : "N");
-    return lclTriStruct;
-  } ();
-
-  if (reverseStorage_ && lclTriStructure.couldBeUpperTriangular &&
-      htsImpl_.is_null ()) {
-    // Reverse the storage for an upper triangular matrix
-    auto Alocal = A_crs_->getLocalMatrixDevice();
-    auto ptr    = Alocal.graph.row_map;
-    auto ind    = Alocal.graph.entries;
-    auto val    = Alocal.values;
-
-    auto numRows = Alocal.numRows();
-    auto numCols = Alocal.numCols();
-    auto numNnz = Alocal.nnz();
-
-    typename decltype(ptr)::non_const_type  newptr ("ptr", ptr.extent (0));
-    typename decltype(ind)::non_const_type  newind ("ind", ind.extent (0));
-    decltype(val)                           newval ("val", val.extent (0));
-
-    // FIXME: The code below assumes UVM
-    typename crs_matrix_type::execution_space().fence();
-    newptr(0) = 0;
-    for (local_ordinal_type row = 0, rowStart = 0; row < numRows; ++row) {
-      auto A_r = Alocal.row(numRows-1 - row);
-
-      auto numEnt = A_r.length;
-      for (local_ordinal_type k = 0; k < numEnt; ++k) {
-        newind(rowStart + k) = numCols-1 - A_r.colidx(numEnt-1 - k);
-        newval(rowStart + k) = A_r.value (numEnt-1 - k);
+    // mfh 30 Apr 2018: See GitHub Issue #2658.
+    constexpr bool ignoreMapsForTriStructure = true;
+    auto lclTriStructure = [&] {
+      auto lclMatrix = A_crs_->getLocalMatrixDevice ();
+      auto lclRowMap = A_crs_->getRowMap ()->getLocalMap ();
+      auto lclColMap = A_crs_->getColMap ()->getLocalMap ();
+      auto lclTriStruct =
+        determineLocalTriangularStructure (lclMatrix.graph,
+                                           lclRowMap,
+                                           lclColMap,
+                                           ignoreMapsForTriStructure);
+      const LO lclNumRows = lclRowMap.getLocalNumElements ();
+      this->diag_ = (lclTriStruct.diagCount < lclNumRows) ? "U" : "N";
+      this->uplo_ = lclTriStruct.couldBeLowerTriangular ? "L" :
+        (lclTriStruct.couldBeUpperTriangular ? "U" : "N");
+      return lclTriStruct;
+    } ();
+    
+    if (reverseStorage_ && lclTriStructure.couldBeUpperTriangular &&
+        htsImpl_.is_null ()) {
+      // Reverse the storage for an upper triangular matrix
+      auto Alocal = A_crs_->getLocalMatrixDevice();
+      auto ptr    = Alocal.graph.row_map;
+      auto ind    = Alocal.graph.entries;
+      auto val    = Alocal.values;
+    
+      auto numRows = Alocal.numRows();
+      auto numCols = Alocal.numCols();
+      auto numNnz = Alocal.nnz();
+    
+      typename decltype(ptr)::non_const_type  newptr ("ptr", ptr.extent (0));
+      typename decltype(ind)::non_const_type  newind ("ind", ind.extent (0));
+      decltype(val)                           newval ("val", val.extent (0));
+    
+      // FIXME: The code below assumes UVM
+      typename crs_matrix_type::execution_space().fence();
+      newptr(0) = 0;
+      for (local_ordinal_type row = 0, rowStart = 0; row < numRows; ++row) {
+        auto A_r = Alocal.row(numRows-1 - row);
+    
+        auto numEnt = A_r.length;
+        for (local_ordinal_type k = 0; k < numEnt; ++k) {
+          newind(rowStart + k) = numCols-1 - A_r.colidx(numEnt-1 - k);
+          newval(rowStart + k) = A_r.value (numEnt-1 - k);
+        }
+        rowStart += numEnt;
+        newptr(row+1) = rowStart;
       }
-      rowStart += numEnt;
-      newptr(row+1) = rowStart;
+      typename crs_matrix_type::execution_space().fence();
+    
+      // Reverse maps
+      Teuchos::RCP<map_type> newRowMap, newColMap;
+      {
+        // Reverse row map
+        auto rowMap = A_->getRowMap();
+        auto numElems = rowMap->getLocalNumElements();
+        auto rowElems = rowMap->getLocalElementList();
+    
+        Teuchos::Array<global_ordinal_type> newRowElems(rowElems.size());
+        for (size_t i = 0; i < numElems; i++)
+          newRowElems[i] = rowElems[numElems-1 - i];
+    
+        newRowMap = Teuchos::rcp(new map_type(rowMap->getGlobalNumElements(), newRowElems, rowMap->getIndexBase(), rowMap->getComm()));
+      }
+      {
+        // Reverse column map
+        auto colMap = A_->getColMap();
+        auto numElems = colMap->getLocalNumElements();
+        auto colElems = colMap->getLocalElementList();
+    
+        Teuchos::Array<global_ordinal_type> newColElems(colElems.size());
+        for (size_t i = 0; i < numElems; i++)
+          newColElems[i] = colElems[numElems-1 - i];
+    
+        newColMap = Teuchos::rcp(new map_type(colMap->getGlobalNumElements(), newColElems, colMap->getIndexBase(), colMap->getComm()));
+      }
+    
+      // Construct new matrix
+      local_matrix_type newLocalMatrix("Upermuted", numRows, numCols, numNnz, newval, newptr, newind);
+    
+      A_crs_ = Teuchos::rcp(new crs_matrix_type(newLocalMatrix, newRowMap, newColMap, A_crs_->getDomainMap(), A_crs_->getRangeMap()));
+    
+      isInternallyChanged_ = true;
+    
+      // FIXME (mfh 18 Apr 2019) Recomputing this is unnecessary, but I
+      // didn't want to break any invariants, especially considering
+      // that this branch is likely poorly tested.
+      auto newLclTriStructure =
+        determineLocalTriangularStructure (newLocalMatrix.graph,
+                                           newRowMap->getLocalMap (),
+                                           newColMap->getLocalMap (),
+                                           ignoreMapsForTriStructure);
+      const LO newLclNumRows = newRowMap->getLocalNumElements ();
+      this->diag_ = (newLclTriStructure.diagCount < newLclNumRows) ? "U" : "N";
+      this->uplo_ = newLclTriStructure.couldBeLowerTriangular ? "L" :
+        (newLclTriStructure.couldBeUpperTriangular ? "U" : "N");
     }
-    typename crs_matrix_type::execution_space().fence();
-
-    // Reverse maps
-    Teuchos::RCP<map_type> newRowMap, newColMap;
-    {
-      // Reverse row map
-      auto rowMap = A_->getRowMap();
-      auto numElems = rowMap->getLocalNumElements();
-      auto rowElems = rowMap->getLocalElementList();
-
-      Teuchos::Array<global_ordinal_type> newRowElems(rowElems.size());
-      for (size_t i = 0; i < numElems; i++)
-        newRowElems[i] = rowElems[numElems-1 - i];
-
-      newRowMap = Teuchos::rcp(new map_type(rowMap->getGlobalNumElements(), newRowElems, rowMap->getIndexBase(), rowMap->getComm()));
+  }
+  else {
+    for (int i = 0; i < num_streams_; i++) {
+      TEUCHOS_TEST_FOR_EXCEPTION
+        (A_crs_v_[i].is_null (), std::runtime_error, prefix << "You must call "
+         "setMatrix() with a nonnull input matrix before you may call "
+         "initialize() or compute().");
+      auto G = A_crs_v_[i]->getGraph ();
+      TEUCHOS_TEST_FOR_EXCEPTION
+        (G.is_null (), std::logic_error, prefix << "A_crs_ are nonnull, "
+         "but A_crs_'s RowGraph G is null.  "
+         "Please report this bug to the Ifpack2 developers.");
+      // At this point, the graph MUST be fillComplete.  The "initialize"
+      // (symbolic) part of setup only depends on the graph structure, so
+      // the matrix itself need not be fill complete.
+      TEUCHOS_TEST_FOR_EXCEPTION
+        (! G->isFillComplete (), std::runtime_error, "If you call this method, "
+         "the matrix's graph must be fill complete.  It is not.");
+	  
+      // mfh 30 Apr 2018: See GitHub Issue #2658.
+      constexpr bool ignoreMapsForTriStructure = true;
+      std::string prev_uplo_ = this->uplo_;
+      std::string prev_diag_ = this->diag_;
+      auto lclTriStructure = [&] {
+        auto lclMatrix = A_crs_v_[i]->getLocalMatrixDevice ();
+        auto lclRowMap = A_crs_v_[i]->getRowMap ()->getLocalMap ();
+        auto lclColMap = A_crs_v_[i]->getColMap ()->getLocalMap ();
+        auto lclTriStruct =
+          determineLocalTriangularStructure (lclMatrix.graph,
+                                             lclRowMap,
+                                             lclColMap,
+                                             ignoreMapsForTriStructure);
+        const LO lclNumRows = lclRowMap.getLocalNumElements ();
+        this->diag_ = (lclTriStruct.diagCount < lclNumRows) ? "U" : "N";
+        this->uplo_ = lclTriStruct.couldBeLowerTriangular ? "L" :
+          (lclTriStruct.couldBeUpperTriangular ? "U" : "N");
+        return lclTriStruct;
+      } ();
+      if (i > 0) {
+        TEUCHOS_TEST_FOR_EXCEPTION
+          ((this->diag_ != prev_diag_) || (this->uplo_ != prev_uplo_),
+           std::logic_error, prefix << "A_crs_'s structures in streams "
+           "are different. Please report this bug to the Ifpack2 developers.");
+      }
     }
-    {
-      // Reverse column map
-      auto colMap = A_->getColMap();
-      auto numElems = colMap->getLocalNumElements();
-      auto colElems = colMap->getLocalElementList();
-
-      Teuchos::Array<global_ordinal_type> newColElems(colElems.size());
-      for (size_t i = 0; i < numElems; i++)
-        newColElems[i] = colElems[numElems-1 - i];
-
-      newColMap = Teuchos::rcp(new map_type(colMap->getGlobalNumElements(), newColElems, colMap->getIndexBase(), colMap->getComm()));
-    }
-
-    // Construct new matrix
-    local_matrix_type newLocalMatrix("Upermuted", numRows, numCols, numNnz, newval, newptr, newind);
-
-    A_crs_ = Teuchos::rcp(new crs_matrix_type(newLocalMatrix, newRowMap, newColMap, A_crs_->getDomainMap(), A_crs_->getRangeMap()));
-
-    isInternallyChanged_ = true;
-
-    // FIXME (mfh 18 Apr 2019) Recomputing this is unnecessary, but I
-    // didn't want to break any invariants, especially considering
-    // that this branch is likely poorly tested.
-    auto newLclTriStructure =
-      determineLocalTriangularStructure (newLocalMatrix.graph,
-                                         newRowMap->getLocalMap (),
-                                         newColMap->getLocalMap (),
-                                         ignoreMapsForTriStructure);
-    const LO newLclNumRows = newRowMap->getLocalNumElements ();
-    this->diag_ = (newLclTriStructure.diagCount < newLclNumRows) ? "U" : "N";
-    this->uplo_ = newLclTriStructure.couldBeLowerTriangular ? "L" :
-      (newLclTriStructure.couldBeUpperTriangular ? "U" : "N");
   }
 
   if (Teuchos::nonnull (htsImpl_))
@@ -511,13 +571,19 @@ initialize ()
   }
 
   const bool ksptrsv_valid_uplo = (this->uplo_ != "N");
-  if (Teuchos::nonnull(kh_) && ksptrsv_valid_uplo && this->diag_ != "U")
+  kh_v_nonnull_ = false;
+  if (this->isKokkosKernelsSptrsv_ && ksptrsv_valid_uplo && this->diag_ != "U")
   {
-    this->isKokkosKernelsSptrsv_ = true;
-  }
-  else
-  {
-    this->isKokkosKernelsSptrsv_ = false;
+    if (!isKokkosKernelsStream_) {
+      kh_ = Teuchos::rcp (new k_handle());
+    }
+	else {
+      kh_v_ = std::vector< Teuchos::RCP<k_handle> >(num_streams_);
+      for (int i = 0; i < num_streams_; i++) {
+        kh_v_[i] = Teuchos::rcp (new k_handle ());
+      }
+      kh_v_nonnull_ = true;
+    }
   }
 
   isInitialized_ = true;
@@ -534,17 +600,31 @@ compute ()
     *out_ << ">>> DEBUG " << prefix << std::endl;
   }
 
-  TEUCHOS_TEST_FOR_EXCEPTION
-    (A_.is_null (), std::runtime_error, prefix << "You must call "
-     "setMatrix() with a nonnull input matrix before you may call "
-     "initialize() or compute().");
-  TEUCHOS_TEST_FOR_EXCEPTION
-    (A_crs_.is_null (), std::logic_error, prefix << "A_ is nonnull, but "
-     "A_crs_ is null.  Please report this bug to the Ifpack2 developers.");
-  // At this point, the matrix MUST be fillComplete.
-  TEUCHOS_TEST_FOR_EXCEPTION
-    (! A_crs_->isFillComplete (), std::runtime_error, "If you call this "
-     "method, the matrix must be fill complete.  It is not.");
+  if (!isKokkosKernelsStream_) {
+    TEUCHOS_TEST_FOR_EXCEPTION
+      (A_.is_null (), std::runtime_error, prefix << "You must call "
+       "setMatrix() with a nonnull input matrix before you may call "
+       "initialize() or compute().");
+    TEUCHOS_TEST_FOR_EXCEPTION
+      (A_crs_.is_null (), std::logic_error, prefix << "A_ is nonnull, but "
+       "A_crs_ is null.  Please report this bug to the Ifpack2 developers.");
+    // At this point, the matrix MUST be fillComplete.
+    TEUCHOS_TEST_FOR_EXCEPTION
+      (! A_crs_->isFillComplete (), std::runtime_error, "If you call this "
+       "method, the matrix must be fill complete.  It is not.");
+  }
+  else {
+    for(int i = 0; i < num_streams_; i++) {
+      TEUCHOS_TEST_FOR_EXCEPTION
+        (A_crs_v_[i].is_null (), std::runtime_error, prefix << "You must call "
+         "setMatrices() with a nonnull input matrix before you may call "
+         "initialize() or compute().");
+      // At this point, the matrix MUST be fillComplete.
+      TEUCHOS_TEST_FOR_EXCEPTION
+        (! A_crs_v_[i]->isFillComplete (), std::runtime_error, "If you call this "
+         "method, the matrix must be fill complete.  It is not.");
+    }
+  }
 
   if (! isInitialized_) {
     initialize ();
@@ -558,16 +638,16 @@ compute ()
   if (Teuchos::nonnull (htsImpl_))
     htsImpl_->compute (*A_crs_, out_);
 
-  if (Teuchos::nonnull(kh_) && this->isKokkosKernelsSptrsv_)
-  {
+  if (Teuchos::nonnull(kh_) && this->isKokkosKernelsSptrsv_) {
+    const bool is_lower_tri = (this->uplo_ == "L") ? true : false;
+  
     auto A_crs = Teuchos::rcp_dynamic_cast<const crs_matrix_type> (A_);
     auto Alocal = A_crs->getLocalMatrixDevice();
     auto ptr    = Alocal.graph.row_map;
     auto ind    = Alocal.graph.entries;
     auto val    = Alocal.values;
 
-    auto numRows = Alocal.numRows();
-    const bool is_lower_tri = (this->uplo_ == "L") ? true : false;
+    auto numRows = Alocal.numRows();    
 
     // Destroy existing handle and recreate in case new matrix provided - requires rerunning symbolic analysis
     kh_->destroy_sptrsv_handle();
@@ -589,6 +669,40 @@ compute ()
       kh_->create_sptrsv_handle(KokkosSparse::Experimental::SPTRSVAlgorithm::SEQLVLSCHD_TP1, numRows, is_lower_tri);
     }
     KokkosSparse::Experimental::sptrsv_symbolic(kh_.getRawPtr(), ptr, ind, val);
+  }
+  else if (kh_v_nonnull_ && this->isKokkosKernelsSptrsv_) {
+    const bool is_lower_tri = (this->uplo_ == "L") ? true : false;
+
+    for (int i = 0; i < num_streams_; i++) {
+      auto A_crs_i = Teuchos::rcp_dynamic_cast<const crs_matrix_type> (A_crs_v_[i]);
+      auto Alocal_i = A_crs_i->getLocalMatrixDevice();
+      auto ptr_i    = Alocal_i.graph.row_map;
+      auto ind_i    = Alocal_i.graph.entries;
+      auto val_i    = Alocal_i.values;
+   
+      auto numRows_i = Alocal_i.numRows();
+
+      // Destroy existing handle and recreate in case new matrix provided - requires rerunning symbolic analysis
+      kh_v_[i]->destroy_sptrsv_handle();
+#if defined(KOKKOSKERNELS_ENABLE_TPL_CUSPARSE) && defined(KOKKOS_ENABLE_CUDA)
+      // CuSparse only supports int type ordinals 
+      // and scalar types of float, double, float complex and double complex
+      if (std::is_same<Kokkos::Cuda, HandleExecSpace>::value &&
+          std::is_same<int, local_ordinal_type>::value &&
+         (std::is_same<scalar_type, float>::value ||
+          std::is_same<scalar_type, double>::value ||
+          std::is_same<scalar_type, Kokkos::complex<float>>::value ||
+          std::is_same<scalar_type, Kokkos::complex<double>>::value))
+      {
+        kh_v_[i]->create_sptrsv_handle(KokkosSparse::Experimental::SPTRSVAlgorithm::SPTRSV_CUSPARSE, numRows_i, is_lower_tri);
+      }
+      else
+#endif
+      {
+        kh_v_[i]->create_sptrsv_handle(KokkosSparse::Experimental::SPTRSVAlgorithm::SEQLVLSCHD_TP1, numRows_i, is_lower_tri);
+      }
+      KokkosSparse::Experimental::sptrsv_symbolic(kh_v_[i].getRawPtr(), ptr_i, ind_i, val_i);
+    }
   }
 
   isComputed_ = true;
@@ -612,21 +726,41 @@ apply (const Tpetra::MultiVector<scalar_type, local_ordinal_type,
   typedef scalar_type ST;
   typedef Teuchos::ScalarTraits<ST> STS;
   const char prefix[] = "Ifpack2::LocalSparseTriangularSolver::apply: ";
+
   if (! out_.is_null ()) {
     *out_ << ">>> DEBUG " << prefix;
-    if (A_crs_.is_null ()) {
-      *out_ << "A_crs_ is null!" << std::endl;
+    if (!isKokkosKernelsStream_) {
+      if (A_crs_.is_null ()) {
+        *out_ << "A_crs_ is null!" << std::endl;
+      }
+      else {
+        Teuchos::RCP<const crs_matrix_type> A_crs =
+            Teuchos::rcp_dynamic_cast<const crs_matrix_type> (A_);
+        const std::string uplo = this->uplo_;
+        const std::string trans = (mode == Teuchos::CONJ_TRANS) ? "C" :
+          (mode == Teuchos::TRANS ? "T" : "N");
+        const std::string diag = this->diag_;
+        *out_ << "uplo=\"" << uplo
+              << "\", trans=\"" << trans
+              << "\", diag=\"" << diag << "\"" << std::endl;
+      }
     }
     else {
-      Teuchos::RCP<const crs_matrix_type> A_crs =
-          Teuchos::rcp_dynamic_cast<const crs_matrix_type> (A_);
-      const std::string uplo = this->uplo_;
-      const std::string trans = (mode == Teuchos::CONJ_TRANS) ? "C" :
-        (mode == Teuchos::TRANS ? "T" : "N");
-      const std::string diag = this->diag_;
-      *out_ << "uplo=\"" << uplo
-            << "\", trans=\"" << trans
-            << "\", diag=\"" << diag << "\"" << std::endl;
+      for (int i = 0; i < num_streams_; i++) {
+        if (A_crs_v_[i].is_null ()) {
+          *out_ << "A_crs_v_[" << i << "]" << " is null!" << std::endl;
+        }
+        else {
+          const std::string uplo = this->uplo_;
+          const std::string trans = (mode == Teuchos::CONJ_TRANS) ? "C" :
+            (mode == Teuchos::TRANS ? "T" : "N");
+          const std::string diag = this->diag_;
+          *out_ << "A_crs_v_[" << i << "]: "
+                << "uplo=\"" << uplo
+                << "\", trans=\"" << trans
+                << "\", diag=\"" << diag << "\"" << std::endl;
+        }
+      }
     }
   }
 
@@ -636,66 +770,101 @@ apply (const Tpetra::MultiVector<scalar_type, local_ordinal_type,
      "call compute() before you may call this method.");
   // If isComputed() is true, it's impossible for the matrix to be
   // null, or for it not to be a Tpetra::CrsMatrix.
-  TEUCHOS_TEST_FOR_EXCEPTION
-    (A_.is_null (), std::logic_error, prefix << "A_ is null.  "
-     "Please report this bug to the Ifpack2 developers.");
-  TEUCHOS_TEST_FOR_EXCEPTION
-    (A_crs_.is_null (), std::logic_error, prefix << "A_crs_ is null.  "
-     "Please report this bug to the Ifpack2 developers.");
-  // However, it _is_ possible that the user called resumeFill() on
-  // the matrix, after calling compute().  This is NOT allowed.
-  TEUCHOS_TEST_FOR_EXCEPTION
-    (! A_crs_->isFillComplete (), std::runtime_error, "If you call this "
-     "method, the matrix must be fill complete.  It is not.  This means that "
-     " you must have called resumeFill() on the matrix before calling apply(). "
-     "This is NOT allowed.  Note that this class may use the matrix's data in "
-     "place without copying it.  Thus, you cannot change the matrix and expect "
-     "the solver to stay the same.  If you have changed the matrix, first call "
-     "fillComplete() on it, then call compute() on this object, before you call"
-     " apply().  You do NOT need to call setMatrix, as long as the matrix "
-     "itself (that is, its address in memory) is the same.");
-
-  auto G = A_crs_->getGraph ();
-  TEUCHOS_TEST_FOR_EXCEPTION
-    (G.is_null (), std::logic_error, prefix << "A_ and A_crs_ are nonnull, "
-     "but A_crs_'s RowGraph G is null.  "
-     "Please report this bug to the Ifpack2 developers.");
-  auto importer = G->getImporter ();
-  auto exporter = G->getExporter ();
-
-  if (! importer.is_null ()) {
-    if (X_colMap_.is_null () || X_colMap_->getNumVectors () != X.getNumVectors ()) {
-      X_colMap_ = rcp (new MV (importer->getTargetMap (), X.getNumVectors ()));
-    }
-    else {
-      X_colMap_->putScalar (STS::zero ());
-    }
-    // See discussion of Github Issue #672 for why the Import needs to
-    // use the ZERO CombineMode.  The case where the Export is
-    // nontrivial is likely never exercised.
-    X_colMap_->doImport (X, *importer, Tpetra::ZERO);
+  if (!isKokkosKernelsStream_) {
+    TEUCHOS_TEST_FOR_EXCEPTION
+      (A_.is_null (), std::logic_error, prefix << "A_ is null.  "
+       "Please report this bug to the Ifpack2 developers.");
+    TEUCHOS_TEST_FOR_EXCEPTION
+      (A_crs_.is_null (), std::logic_error, prefix << "A_crs_ is null.  "
+       "Please report this bug to the Ifpack2 developers.");
+    // However, it _is_ possible that the user called resumeFill() on
+    // the matrix, after calling compute().  This is NOT allowed.
+    TEUCHOS_TEST_FOR_EXCEPTION
+      (! A_crs_->isFillComplete (), std::runtime_error, "If you call this "
+       "method, the matrix must be fill complete.  It is not.  This means that "
+       " you must have called resumeFill() on the matrix before calling apply(). "
+       "This is NOT allowed.  Note that this class may use the matrix's data in "
+       "place without copying it.  Thus, you cannot change the matrix and expect "
+       "the solver to stay the same.  If you have changed the matrix, first call "
+       "fillComplete() on it, then call compute() on this object, before you call"
+       " apply().  You do NOT need to call setMatrix, as long as the matrix "
+       "itself (that is, its address in memory) is the same.");
   }
-  RCP<const MV> X_cur = importer.is_null () ? rcpFromRef (X) :
-    Teuchos::rcp_const_cast<const MV> (X_colMap_);
-
-  if (! exporter.is_null ()) {
-    if (Y_rowMap_.is_null () || Y_rowMap_->getNumVectors () != Y.getNumVectors ()) {
-      Y_rowMap_ = rcp (new MV (exporter->getSourceMap (), Y.getNumVectors ()));
+  else {
+    for (int i = 0; i < num_streams_; i++) {
+      TEUCHOS_TEST_FOR_EXCEPTION
+        (A_crs_v_[i].is_null (), std::logic_error, prefix << "A_crs_ is null.  "
+         "Please report this bug to the Ifpack2 developers.");
+      // However, it _is_ possible that the user called resumeFill() on
+      // the matrix, after calling compute().  This is NOT allowed.
+      TEUCHOS_TEST_FOR_EXCEPTION
+        (! A_crs_v_[i]->isFillComplete (), std::runtime_error, "If you call this "
+         "method, the matrix must be fill complete.  It is not.  This means that "
+         " you must have called resumeFill() on the matrix before calling apply(). "
+         "This is NOT allowed.  Note that this class may use the matrix's data in "
+         "place without copying it.  Thus, you cannot change the matrix and expect "
+         "the solver to stay the same.  If you have changed the matrix, first call "
+         "fillComplete() on it, then call compute() on this object, before you call"
+         " apply().  You do NOT need to call setMatrix, as long as the matrix "
+         "itself (that is, its address in memory) is the same.");
     }
-    else {
-      Y_rowMap_->putScalar (STS::zero ());
-    }
-    Y_rowMap_->doExport (Y, *importer, Tpetra::ADD);
   }
-  RCP<MV> Y_cur = exporter.is_null () ? rcpFromRef (Y) : Y_rowMap_;
+
+  RCP<const MV> X_cur;
+  RCP<MV> Y_cur;
+
+  if (!isKokkosKernelsStream_) {
+    auto G = A_crs_->getGraph ();
+    TEUCHOS_TEST_FOR_EXCEPTION
+      (G.is_null (), std::logic_error, prefix << "A_ and A_crs_ are nonnull, "
+       "but A_crs_'s RowGraph G is null.  "
+       "Please report this bug to the Ifpack2 developers.");
+    auto importer = G->getImporter ();
+    auto exporter = G->getExporter ();
+    
+    if (! importer.is_null ()) {
+      if (X_colMap_.is_null () || X_colMap_->getNumVectors () != X.getNumVectors ()) {
+        X_colMap_ = rcp (new MV (importer->getTargetMap (), X.getNumVectors ()));
+      }
+      else {
+        X_colMap_->putScalar (STS::zero ());
+      }
+      // See discussion of Github Issue #672 for why the Import needs to
+      // use the ZERO CombineMode.  The case where the Export is
+      // nontrivial is likely never exercised.
+      X_colMap_->doImport (X, *importer, Tpetra::ZERO);
+    }
+    X_cur = importer.is_null () ? rcpFromRef (X) :
+      Teuchos::rcp_const_cast<const MV> (X_colMap_);
+    
+    if (! exporter.is_null ()) {
+      if (Y_rowMap_.is_null () || Y_rowMap_->getNumVectors () != Y.getNumVectors ()) {
+        Y_rowMap_ = rcp (new MV (exporter->getSourceMap (), Y.getNumVectors ()));
+      }
+      else {
+        Y_rowMap_->putScalar (STS::zero ());
+      }
+      Y_rowMap_->doExport (Y, *importer, Tpetra::ADD);
+    }
+    Y_cur = exporter.is_null () ? rcpFromRef (Y) : Y_rowMap_;
+  }
+  else {
+    // Currently assume X and Y are local vectors (same sizes as A_crs_).
+    // Should do a better job here!!!
+    X_cur = rcpFromRef (X);
+    Y_cur = rcpFromRef (Y);
+  }
 
   localApply (*X_cur, *Y_cur, mode, alpha, beta);
 
-  if (! exporter.is_null ()) {
-    Y.putScalar (STS::zero ());
-    Y.doExport (*Y_cur, *exporter, Tpetra::ADD);
+  if (!isKokkosKernelsStream_) {
+    auto G = A_crs_->getGraph ();
+    auto exporter = G->getExporter ();
+    if (! exporter.is_null ()) {
+      Y.putScalar (STS::zero ());
+      Y.doExport (*Y_cur, *exporter, Tpetra::ADD);
+    }
   }
-
   ++numApply_;
 }
 
@@ -711,18 +880,35 @@ localTriangularSolve (const MV& Y,
   using Teuchos::TRANS;
   const char tfecfFuncName[] = "localTriangularSolve: ";
 
-  TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-    (! A_crs_->isFillComplete (), std::runtime_error,
-     "The matrix is not fill complete.");
+  if (!isKokkosKernelsStream_)
+  {
+    TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+      (! A_crs_->isFillComplete (), std::runtime_error,
+       "The matrix is not fill complete.");
+    TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+      ( A_crs_->getLocalNumRows() > 0 && this->uplo_ == "N", std::runtime_error,
+        "The matrix is neither upper triangular or lower triangular.  "
+        "You may only call this method if the matrix is triangular.  "
+        "Remember that this is a local (per MPI process) property, and that "
+        "Tpetra only knows how to do a local (per process) triangular solve.");
+  }
+  else
+  {
+    for (int i = 0; i < num_streams_; i++) {
+      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+        (! A_crs_v_[i]->isFillComplete (), std::runtime_error,
+         "The matrix is not fill complete.");
+      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+        ( A_crs_v_[i]->getLocalNumRows() > 0 && this->uplo_ == "N", std::runtime_error,
+          "The matrix is neither upper triangular or lower triangular.  "
+          "You may only call this method if the matrix is triangular.  "
+          "Remember that this is a local (per MPI process) property, and that "
+          "Tpetra only knows how to do a local (per process) triangular solve.");
+    }
+  }
   TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
     (! X.isConstantStride () || ! Y.isConstantStride (), std::invalid_argument,
      "X and Y must be constant stride.");
-  TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-    ( A_crs_->getLocalNumRows() > 0 && this->uplo_ == "N", std::runtime_error,
-      "The matrix is neither upper triangular or lower triangular.  "
-      "You may only call this method if the matrix is triangular.  "
-      "Remember that this is a local (per MPI process) property, and that "
-      "Tpetra only knows how to do a local (per process) triangular solve.");
   using STS = Teuchos::ScalarTraits<scalar_type>;
   TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
     (STS::isComplex && mode == TRANS, std::logic_error, "This method does "
@@ -732,6 +918,7 @@ localTriangularSolve (const MV& Y,
   const std::string uplo = this->uplo_;
   const std::string trans = (mode == Teuchos::CONJ_TRANS) ? "C" :
     (mode == Teuchos::TRANS ? "T" : "N");
+  const size_t numVecs = std::min (X.getNumVectors (), Y.getNumVectors ());
 
   if (Teuchos::nonnull(kh_) && this->isKokkosKernelsSptrsv_ && trans == "N")
   {
@@ -740,9 +927,7 @@ localTriangularSolve (const MV& Y,
     auto ptr    = A_lclk.graph.row_map;
     auto ind    = A_lclk.graph.entries;
     auto val    = A_lclk.values;
-
-    const size_t numVecs = std::min (X.getNumVectors (), Y.getNumVectors ());
-
+	
     for (size_t j = 0; j < numVecs; ++j) {
       auto X_j = X.getVectorNonConst (j);
       auto Y_j = Y.getVector (j);
@@ -754,7 +939,43 @@ localTriangularSolve (const MV& Y,
       // TODO is this fence needed...
       typename k_handle::HandleExecSpace().fence();
     }
-  }
+  } // End using regular interface of Kokkos Kernels Sptrsv
+  else if (kh_v_nonnull_ && this->isKokkosKernelsSptrsv_ && trans == "N")
+  {
+    std::vector<lno_row_view_t>        ptr_v(num_streams_);
+    std::vector<lno_nonzero_view_t>    ind_v(num_streams_);
+    std::vector<scalar_nonzero_view_t> val_v(num_streams_);
+    std::vector<k_handle *>            KernelHandle_rawptr_v_(num_streams_);
+    for (size_t j = 0; j < numVecs; ++j) {
+      auto X_j = X.getVectorNonConst (j);
+      auto Y_j = Y.getVector (j);
+      auto X_lcl = X_j->getLocalViewDevice (Tpetra::Access::ReadWrite);
+      auto Y_lcl = Y_j->getLocalViewDevice (Tpetra::Access::ReadOnly);
+      auto X_lcl_1d = Kokkos::subview (X_lcl, Kokkos::ALL (), 0);
+      auto Y_lcl_1d = Kokkos::subview (Y_lcl, Kokkos::ALL (), 0);
+      std::vector<decltype(X_lcl_1d)> x_v(num_streams_);
+      std::vector<decltype(Y_lcl_1d)> y_v(num_streams_);
+      local_ordinal_type stream_begin = 0;
+      local_ordinal_type stream_end;
+      for (int i = 0; i < num_streams_; i++) {
+        auto A_crs_i = Teuchos::rcp_dynamic_cast<const crs_matrix_type> (A_crs_v_[i]);
+        auto Alocal_i = A_crs_i->getLocalMatrixDevice();
+        ptr_v[i] = Alocal_i.graph.row_map;
+        ind_v[i] = Alocal_i.graph.entries;
+        val_v[i] = Alocal_i.values;
+        stream_end = stream_begin + Alocal_i.numRows();
+        x_v[i] = Kokkos::subview (X_lcl, Kokkos::make_pair(stream_begin, stream_end), 0);
+        y_v[i] = Kokkos::subview (Y_lcl, Kokkos::make_pair(stream_begin, stream_end), 0);;
+        KernelHandle_rawptr_v_[i] = kh_v_[i].getRawPtr();
+        stream_begin = stream_end;
+      }
+      KokkosSparse::Experimental::sptrsv_solve_streams( exec_space_instances_, KernelHandle_rawptr_v_,
+                                                        ptr_v, ind_v, val_v, y_v, x_v );
+      for (int i = 0; i < num_streams_; i++) {
+        exec_space_instances_[i].fence();
+      }
+    }
+  } // End using stream interface of Kokkos Kernels Sptrsv
   else
   {
     const std::string diag = this->diag_;
@@ -771,8 +992,6 @@ localTriangularSolve (const MV& Y,
           A_lcl, Y_lcl, X_lcl);
     }
     else {
-      const size_t numVecs =
-        std::min (X.getNumVectors (), Y.getNumVectors ());
       for (size_t j = 0; j < numVecs; ++j) {
         auto X_j = X.getVectorNonConst (j);
         auto Y_j = Y.getVector (j);
@@ -1009,6 +1228,68 @@ setMatrix (const Teuchos::RCP<const row_matrix_type>& A)
     if (Teuchos::nonnull (htsImpl_))
       htsImpl_->reset ();
   } // pointers are not the same
+
+  //NOTE (Nov-09-2022): 
+  //For Cuda >= 11.3 (using cusparseSpSV), always call compute before apply,
+  //even when matrix values are changed with the same sparsity pattern.
+  //So, force isComputed_ to FALSE here
+#if defined(KOKKOSKERNELS_ENABLE_TPL_CUSPARSE) && defined(KOKKOS_ENABLE_CUDA) && (CUDA_VERSION >= 11030)
+  isComputed_ = false;
+#endif
+}
+
+template<class MatrixType>
+void
+LocalSparseTriangularSolver<MatrixType>::
+setStreamInfo (const bool& isKokkosKernelsStream, const int& num_streams,
+               const std::vector<HandleExecSpace>& exec_space_instances)
+{
+  isKokkosKernelsStream_ = isKokkosKernelsStream;
+  num_streams_ = num_streams;
+  exec_space_instances_ = exec_space_instances;
+  A_crs_v_ = std::vector< Teuchos::RCP<crs_matrix_type> >(num_streams_);
+}
+
+template<class MatrixType>
+void LocalSparseTriangularSolver<MatrixType>::
+setMatrices (const std::vector< Teuchos::RCP<crs_matrix_type> >& A_crs_v)
+{
+  const char prefix[] = "Ifpack2::LocalSparseTriangularSolver::setMatrixWithStreams: ";
+
+  for(int i = 0; i < num_streams_; i++) {
+    // If the pointer didn't change, do nothing.  This is reasonable
+    // because users are supposed to call this method with the same
+    // object over all participating processes, and pointer identity
+    // implies object identity.
+    if (A_crs_v[i].getRawPtr () != A_crs_v_[i].getRawPtr () || isInternallyChanged_) {
+      // Check in serial or one-process mode if the matrix is square.
+      TEUCHOS_TEST_FOR_EXCEPTION
+        (! A_crs_v[i].is_null () && A_crs_v[i]->getComm ()->getSize () == 1 &&
+         A_crs_v[i]->getLocalNumRows () != A_crs_v[i]->getLocalNumCols (),
+         std::runtime_error, prefix << "If A's communicator only contains one "
+         "process, then A must be square.  Instead, you provided a matrix A with "
+         << A_crs_v[i]->getLocalNumRows () << " rows and " << A_crs_v[i]->getLocalNumCols ()
+         << " columns.");
+    
+      // It's legal for A to be null; in that case, you may not call
+      // initialize() until calling setMatrix() with a nonnull input.
+      // Regardless, setting the matrix invalidates the preconditioner.
+      isInitialized_ = false;
+      isComputed_ = false;
+    
+      if (A_crs_v[i].is_null ()) {
+        A_crs_v_[i] = Teuchos::null;
+      }
+      else { // A is not null
+        Teuchos::RCP<crs_matrix_type> A_crs =
+          Teuchos::rcp_dynamic_cast<crs_matrix_type> (A_crs_v[i]);
+        TEUCHOS_TEST_FOR_EXCEPTION
+          (A_crs.is_null (), std::invalid_argument, prefix <<
+           "The input matrix A is not a Tpetra::CrsMatrix.");
+        A_crs_v_[i] = A_crs;
+      }
+    } // pointers are not the same
+  }
 
   //NOTE (Nov-09-2022): 
   //For Cuda >= 11.3 (using cusparseSpSV), always call compute before apply,

--- a/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
@@ -540,21 +540,18 @@ initialize ()
       constexpr bool ignoreMapsForTriStructure = true;
       std::string prev_uplo_ = this->uplo_;
       std::string prev_diag_ = this->diag_;
-      auto lclTriStructure = [&] {
-        auto lclMatrix = A_crs_v_[i]->getLocalMatrixDevice ();
-        auto lclRowMap = A_crs_v_[i]->getRowMap ()->getLocalMap ();
-        auto lclColMap = A_crs_v_[i]->getColMap ()->getLocalMap ();
-        auto lclTriStruct =
-          determineLocalTriangularStructure (lclMatrix.graph,
-                                             lclRowMap,
-                                             lclColMap,
-                                             ignoreMapsForTriStructure);
-        const LO lclNumRows = lclRowMap.getLocalNumElements ();
-        this->diag_ = (lclTriStruct.diagCount < lclNumRows) ? "U" : "N";
-        this->uplo_ = lclTriStruct.couldBeLowerTriangular ? "L" :
-          (lclTriStruct.couldBeUpperTriangular ? "U" : "N");
-        return lclTriStruct;
-      } ();
+      auto lclMatrix = A_crs_v_[i]->getLocalMatrixDevice ();
+      auto lclRowMap = A_crs_v_[i]->getRowMap ()->getLocalMap ();
+      auto lclColMap = A_crs_v_[i]->getColMap ()->getLocalMap ();
+      auto lclTriStruct =
+        determineLocalTriangularStructure (lclMatrix.graph,
+                                           lclRowMap,
+                                           lclColMap,
+                                           ignoreMapsForTriStructure);
+      const LO lclNumRows = lclRowMap.getLocalNumElements ();
+      this->diag_ = (lclTriStruct.diagCount < lclNumRows) ? "U" : "N";
+      this->uplo_ = lclTriStruct.couldBeLowerTriangular ? "L" :
+        (lclTriStruct.couldBeUpperTriangular ? "U" : "N");
       if (i > 0) {
         TEUCHOS_TEST_FOR_EXCEPTION
           ((this->diag_ != prev_diag_) || (this->uplo_ != prev_uplo_),

--- a/packages/ifpack2/src/Ifpack2_RILUK_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_RILUK_decl.hpp
@@ -318,6 +318,7 @@ class RILUK:
   typedef typename KokkosKernels::Experimental::KokkosKernelsHandle
     <typename lno_row_view_t::const_value_type, typename lno_nonzero_view_t::const_value_type, typename scalar_nonzero_view_t::value_type,
     HandleExecSpace, TemporaryMemorySpace,PersistentMemorySpace > kk_handle_type;
+  typedef Ifpack2::IlukGraph<Tpetra::CrsGraph<local_ordinal_type, global_ordinal_type, node_type>, kk_handle_type> iluk_graph_type;
   
   /// \brief Constructor that takes a Tpetra::RowMatrix.
   ///
@@ -592,23 +593,28 @@ protected:
   Teuchos::RCP<const row_matrix_type> A_;
 
   //! The ILU(k) graph.
-  Teuchos::RCP<Ifpack2::IlukGraph<Tpetra::CrsGraph<local_ordinal_type,
-                                                   global_ordinal_type,
-                                                   node_type>, kk_handle_type> > Graph_;
+  Teuchos::RCP<iluk_graph_type> Graph_;
+  std::vector< Teuchos::RCP<iluk_graph_type> > Graph_v_;
   /// \brief The matrix whos numbers are used to to compute ILU(k). The graph
   /// may be computed using a crs_matrix_type that initialize() constructs
   /// temporarily.
   Teuchos::RCP<const row_matrix_type> A_local_;
   lno_row_view_t A_local_rowmap_; 
-  lno_nonzero_view_t A_local_entries_; 
+  lno_nonzero_view_t A_local_entries_;
   scalar_nonzero_view_t A_local_values_;
+  std::vector<local_matrix_device_type> A_local_diagblks;
+  std::vector< lno_row_view_t > A_local_diagblks_rowmap_v_;
+  std::vector< lno_nonzero_view_t > A_local_diagblks_entries_v_;
+  std::vector< scalar_nonzero_view_t > A_local_diagblks_values_v_;
 
   //! The L (lower triangular) factor of ILU(k).
   Teuchos::RCP<crs_matrix_type> L_;
+  std::vector< Teuchos::RCP<crs_matrix_type> > L_v_;
   //! Sparse triangular solver for L
   Teuchos::RCP<LocalSparseTriangularSolver<row_matrix_type> > L_solver_;
   //! The U (upper triangular) factor of ILU(k).
   Teuchos::RCP<crs_matrix_type> U_;
+  std::vector< Teuchos::RCP<crs_matrix_type> > U_v_;
   //! Sparse triangular solver for U
   Teuchos::RCP<LocalSparseTriangularSolver<row_matrix_type> > U_solver_;
 
@@ -637,6 +643,10 @@ protected:
   //! Optional KokkosKernels implementation.
   bool isKokkosKernelsSpiluk_;
   Teuchos::RCP<kk_handle_type> KernelHandle_;
+  std::vector< Teuchos::RCP<kk_handle_type> > KernelHandle_v_;
+  int num_streams_;
+  bool isKokkosKernelsStream_;
+  std::vector<execution_space> exec_space_instances_;
 };
 
 // NOTE (mfh 11 Feb 2015) This used to exist in order to deal with

--- a/packages/ifpack2/src/Ifpack2_RILUK_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_RILUK_decl.hpp
@@ -644,8 +644,8 @@ protected:
   bool isKokkosKernelsSpiluk_;
   Teuchos::RCP<kk_handle_type> KernelHandle_;
   std::vector< Teuchos::RCP<kk_handle_type> > KernelHandle_v_;
-  int num_streams_;
   bool isKokkosKernelsStream_;
+  int num_streams_;
   std::vector<execution_space> exec_space_instances_;
 };
 

--- a/packages/ifpack2/src/Ifpack2_RILUK_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_RILUK_def.hpp
@@ -50,6 +50,7 @@
 #include "Kokkos_Sort.hpp"
 #include "KokkosSparse_Utils.hpp"
 #include "KokkosKernels_Sorting.hpp"
+#include "KokkosSparse_IOUtils.hpp"
 
 namespace Ifpack2 {
 
@@ -88,7 +89,9 @@ RILUK<MatrixType>::RILUK (const Teuchos::RCP<const row_matrix_type>& Matrix_in)
     RelaxValue_ (Teuchos::ScalarTraits<magnitude_type>::zero ()),
     Athresh_ (Teuchos::ScalarTraits<magnitude_type>::zero ()),
     Rthresh_ (Teuchos::ScalarTraits<magnitude_type>::one ()),
-    isKokkosKernelsSpiluk_(false)
+    isKokkosKernelsSpiluk_(false),
+    isKokkosKernelsStream_(false),
+    num_streams_(0)
 {
   allocateSolvers();
 }
@@ -111,7 +114,9 @@ RILUK<MatrixType>::RILUK (const Teuchos::RCP<const crs_matrix_type>& Matrix_in)
     RelaxValue_ (Teuchos::ScalarTraits<magnitude_type>::zero ()),
     Athresh_ (Teuchos::ScalarTraits<magnitude_type>::zero ()),
     Rthresh_ (Teuchos::ScalarTraits<magnitude_type>::one ()),
-    isKokkosKernelsSpiluk_(false)
+    isKokkosKernelsSpiluk_(false),
+    isKokkosKernelsStream_(false),
+    num_streams_(0)
 {
   allocateSolvers();
 }
@@ -120,9 +125,17 @@ RILUK<MatrixType>::RILUK (const Teuchos::RCP<const crs_matrix_type>& Matrix_in)
 template<class MatrixType>
 RILUK<MatrixType>::~RILUK() 
 {
-  if (Teuchos::nonnull (KernelHandle_))
-  {
-    KernelHandle_->destroy_spiluk_handle();
+  if (!isKokkosKernelsStream_) {
+    if (Teuchos::nonnull (KernelHandle_)) {
+      KernelHandle_->destroy_spiluk_handle();
+    }
+  }
+  else {
+    for (int i = 0; i < num_streams_; i++) {
+      if (Teuchos::nonnull (KernelHandle_v_[i])) {
+        KernelHandle_v_[i]->destroy_spiluk_handle();
+      }
+    }
   }
 }
 
@@ -275,23 +288,41 @@ void RILUK<MatrixType>::allocate_L_and_U ()
   using Teuchos::rcp;
 
   if (! isAllocated_) {
-    // Deallocate any existing storage.  This avoids storing 2x
-    // memory, since RCP op= does not deallocate until after the
-    // assignment.
-    L_ = null;
-    U_ = null;
-    D_ = null;
+    if (!isKokkosKernelsStream_) {
+      // Deallocate any existing storage.  This avoids storing 2x
+      // memory, since RCP op= does not deallocate until after the
+      // assignment.
+      L_ = null;
+      U_ = null;
+      D_ = null;
 
-    // Allocate Matrix using ILUK graphs
-    L_ = rcp (new crs_matrix_type (Graph_->getL_Graph ()));
-    U_ = rcp (new crs_matrix_type (Graph_->getU_Graph ()));
-    L_->setAllToScalar (STS::zero ()); // Zero out L and U matrices
-    U_->setAllToScalar (STS::zero ());
+      // Allocate Matrix using ILUK graphs
+      L_ = rcp (new crs_matrix_type (Graph_->getL_Graph ()));
+      U_ = rcp (new crs_matrix_type (Graph_->getU_Graph ()));
+      L_->setAllToScalar (STS::zero ()); // Zero out L and U matrices
+      U_->setAllToScalar (STS::zero ());
 
-    // FIXME (mfh 24 Jan 2014) This assumes domain == range Map for L and U.
-    L_->fillComplete ();
-    U_->fillComplete ();
-    D_ = rcp (new vec_type (Graph_->getL_Graph ()->getRowMap ()));    
+      // FIXME (mfh 24 Jan 2014) This assumes domain == range Map for L and U.
+      L_->fillComplete ();
+      U_->fillComplete ();
+      D_ = rcp (new vec_type (Graph_->getL_Graph ()->getRowMap ()));
+    }
+    else {
+      L_v_ = std::vector< Teuchos::RCP<crs_matrix_type> >(num_streams_);
+      U_v_ = std::vector< Teuchos::RCP<crs_matrix_type> >(num_streams_);
+      for (int i = 0; i < num_streams_; i++) {
+        L_v_[i] = null;
+        U_v_[i] = null;
+	  
+        L_v_[i] = rcp (new crs_matrix_type (Graph_v_[i]->getL_Graph ()));
+        U_v_[i] = rcp (new crs_matrix_type (Graph_v_[i]->getU_Graph ()));
+        L_v_[i]->setAllToScalar (STS::zero ()); // Zero out L and U matrices
+        U_v_[i]->setAllToScalar (STS::zero ());
+	  
+        L_v_[i]->fillComplete ();
+        U_v_[i]->fillComplete ();
+      }
+    }
   }
   isAllocated_ = true;
 }
@@ -314,6 +345,7 @@ setParameters (const Teuchos::ParameterList& params)
   magnitude_type relThresh = STM::one ();
   magnitude_type relaxValue = STM::zero ();
   double overalloc = 2.;
+  int nstreams = 0;
 
   // "fact: iluk level-of-fill" parsing is more complicated, because
   // we want to allow as many types as make sense.  int is the native
@@ -374,6 +406,12 @@ setParameters (const Teuchos::ParameterList& params)
   else {
     this->isKokkosKernelsSpiluk_ = false;
   }
+
+  {
+    const std::string paramName ("fact: kspiluk number-of-streams");
+    getParamTryingTypes<int, int, global_ordinal_type, double, float>
+      (nstreams, params, paramName, prefix);
+  }
   
   // Forward to trisolvers.
   L_solver_->setParameters(params);
@@ -385,6 +423,14 @@ setParameters (const Teuchos::ParameterList& params)
 
   LevelOfFill_ = fillLevel;
   Overalloc_ = overalloc;
+  num_streams_ = nstreams;
+
+  if (num_streams_ >= 1) {
+    this->isKokkosKernelsStream_ = true;
+  }
+  else {
+    this->isKokkosKernelsStream_ = false;
+  }
 
   // mfh 28 Nov 2012: The previous code would not assign Athresh_,
   // Rthresh_, or RelaxValue_, if the read-in value was -1.  I don't
@@ -464,6 +510,9 @@ void RILUK<MatrixType>::initialize ()
   typedef Tpetra::CrsGraph<local_ordinal_type,
                            global_ordinal_type,
                            node_type> crs_graph_type;
+  typedef Tpetra::Map<local_ordinal_type,
+                      global_ordinal_type,
+                      node_type> crs_map_type;
   const char prefix[] = "Ifpack2::RILUK::initialize: ";
 
   TEUCHOS_TEST_FOR_EXCEPTION
@@ -493,7 +542,16 @@ void RILUK<MatrixType>::initialize ()
     isComputed_    = false;
     Graph_ = Teuchos::null;
 
+    if (isKokkosKernelsStream_) {
+      Graph_v_ = std::vector< Teuchos::RCP<iluk_graph_type> >(num_streams_);
+      A_local_diagblks = std::vector<local_matrix_device_type>(num_streams_);
+      for (int i = 0; i < num_streams_; i++) {
+        Graph_v_[i] = Teuchos::null;
+      }
+    }
+
     A_local_ = makeLocalFilter (A_);
+
     TEUCHOS_TEST_FOR_EXCEPTION(
       A_local_.is_null (), std::logic_error, "Ifpack2::RILUK::initialize: "
       "makeLocalFilter returned null; it failed to compute A_local.  "
@@ -504,14 +562,6 @@ void RILUK<MatrixType>::initialize ()
     // just CrsMatrix.  (That would require rewriting IlukGraph to
     // handle a Tpetra::RowGraph.)  However, to make it work for now,
     // we just copy the input matrix if it's not a CrsMatrix.
-
-    if (this->isKokkosKernelsSpiluk_) {
-      this->KernelHandle_ = Teuchos::rcp (new kk_handle_type ());
-      KernelHandle_->create_spiluk_handle( KokkosSparse::Experimental::SPILUKAlgorithm::SEQLVLSCHD_TP1, 
-                                           A_local_->getLocalNumRows(),
-                                           2*A_local_->getLocalNumEntries()*(LevelOfFill_+1), 
-                                           2*A_local_->getLocalNumEntries()*(LevelOfFill_+1) );
-    }
 
     {
       RCP<const crs_matrix_type> A_local_crs = Details::getCrsMatrix(A_local_);
@@ -536,17 +586,67 @@ void RILUK<MatrixType>::initialize ()
         A_local_crs_nc->fillComplete (A_local_->getDomainMap (), A_local_->getRangeMap ());
         A_local_crs = rcp_const_cast<const crs_matrix_type> (A_local_crs_nc);
       }
-      Graph_ = rcp (new Ifpack2::IlukGraph<crs_graph_type,kk_handle_type> (A_local_crs->getCrsGraph (),
-                                                                           LevelOfFill_, 0, Overalloc_));
+      if (!isKokkosKernelsStream_) {
+        Graph_ = rcp (new Ifpack2::IlukGraph<crs_graph_type,kk_handle_type> (A_local_crs->getCrsGraph (),
+                                                                             LevelOfFill_, 0, Overalloc_));
+      }
+      else {
+        auto lclMtx = A_local_crs->getLocalMatrixDevice();
+        KokkosSparse::Impl::kk_extract_diagonal_blocks_crsmatrix_sequential(lclMtx, A_local_diagblks);
+
+        for(int i = 0; i < num_streams_; i++) {
+          Teuchos::RCP<const crs_map_type> A_local_diagblks_RowMap = rcp (new crs_map_type(A_local_diagblks[i].numRows(),
+                                                                                           A_local_diagblks[i].numRows(),
+                                                                                           A_local_crs->getRowMap()->getComm()));
+          Teuchos::RCP<const crs_map_type> A_local_diagblks_ColMap = rcp (new crs_map_type(A_local_diagblks[i].numCols(),
+                                                                                           A_local_diagblks[i].numCols(),
+                                                                                           A_local_crs->getColMap()->getComm()));
+          Teuchos::RCP<crs_matrix_type> A_local_diagblks_ = rcp (new crs_matrix_type(A_local_diagblks_RowMap,
+                                                                                     A_local_diagblks_ColMap,
+                                                                                     A_local_diagblks[i]));
+          Graph_v_[i] = rcp (new Ifpack2::IlukGraph<crs_graph_type,kk_handle_type> (A_local_diagblks_->getCrsGraph(),
+                                                                                    LevelOfFill_, 0, Overalloc_));
+        }
+      }
     }
 
-    // This calls spiluk_symbolic
-    if (this->isKokkosKernelsSpiluk_) Graph_->initialize (KernelHandle_);
-    else Graph_->initialize ();
+    if (this->isKokkosKernelsSpiluk_) {
+      if (!isKokkosKernelsStream_) {
+        this->KernelHandle_ = Teuchos::rcp (new kk_handle_type ());
+        KernelHandle_->create_spiluk_handle( KokkosSparse::Experimental::SPILUKAlgorithm::SEQLVLSCHD_TP1, 
+                                             A_local_->getLocalNumRows(),
+                                             2*A_local_->getLocalNumEntries()*(LevelOfFill_+1), 
+                                             2*A_local_->getLocalNumEntries()*(LevelOfFill_+1) );
+        Graph_->initialize (KernelHandle_); // this calls spiluk_symbolic
+      }
+      else {
+        KernelHandle_v_ = std::vector< Teuchos::RCP<kk_handle_type> >(num_streams_);
+        for (int i = 0; i < num_streams_; i++) {
+          KernelHandle_v_[i] = Teuchos::rcp (new kk_handle_type ());
+          KernelHandle_v_[i]->create_spiluk_handle( KokkosSparse::Experimental::SPILUKAlgorithm::SEQLVLSCHD_TP1, 
+                                                    A_local_diagblks[i].numRows(),
+                                                    2*A_local_diagblks[i].nnz()*(LevelOfFill_+1), 
+                                                    2*A_local_diagblks[i].nnz()*(LevelOfFill_+1) );
+          Graph_v_[i]->initialize (KernelHandle_v_[i]); // this calls spiluk_symbolic
+        }
+        std::vector<int> weights(num_streams_);
+        std::fill(weights.begin(), weights.end(), 1);
+        exec_space_instances_ = Kokkos::Experimental::partition_space(execution_space(), weights);
+      }
+    }
+    else {
+      Graph_->initialize ();
+    }
 
     allocate_L_and_U ();
     checkOrderingConsistency (*A_local_);
-    L_solver_->setMatrix (L_);
+    if (!isKokkosKernelsStream_) {
+      L_solver_->setMatrix (L_);
+    }
+    else {
+      L_solver_->setStreamInfo (isKokkosKernelsStream_, num_streams_, exec_space_instances_);
+      L_solver_->setMatrices (L_v_);
+    }
     L_solver_->initialize ();
     //NOTE (Nov-09-2022): 
     //For Cuda >= 11.3 (using cusparseSpSV), skip trisolve computes here.
@@ -554,7 +654,13 @@ void RILUK<MatrixType>::initialize ()
 #if !defined(KOKKOSKERNELS_ENABLE_TPL_CUSPARSE) || !defined(KOKKOS_ENABLE_CUDA) || (CUDA_VERSION < 11030)
     L_solver_->compute ();//NOTE: It makes sense to do compute here because only the nonzero pattern is involved in trisolve compute
 #endif
-    U_solver_->setMatrix (U_);
+    if (!isKokkosKernelsStream_) {
+      U_solver_->setMatrix (U_);
+    }
+    else {
+      U_solver_->setStreamInfo (isKokkosKernelsStream_, num_streams_, exec_space_instances_);
+      U_solver_->setMatrices (U_v_);
+    }
     U_solver_->initialize ();
 #if !defined(KOKKOSKERNELS_ENABLE_TPL_CUSPARSE) || !defined(KOKKOS_ENABLE_CUDA) || (CUDA_VERSION < 11030)
     U_solver_->compute ();//NOTE: It makes sense to do compute here because only the nonzero pattern is involved in trisolve compute
@@ -938,22 +1044,48 @@ void RILUK<MatrixType>::compute ()
         A_local_crs = rcp_const_cast<const crs_matrix_type> (A_local_crs_nc);
       }
       auto lclMtx = A_local_crs->getLocalMatrixDevice();
-      A_local_rowmap_  = lclMtx.graph.row_map;
-      A_local_entries_ = lclMtx.graph.entries;
-      A_local_values_  = lclMtx.values;
+      if (!isKokkosKernelsStream_) {
+        A_local_rowmap_  = lclMtx.graph.row_map;
+        A_local_entries_ = lclMtx.graph.entries;
+        A_local_values_  = lclMtx.values;
+      }
+      else {
+        KokkosSparse::Impl::kk_extract_diagonal_blocks_crsmatrix_sequential(lclMtx, A_local_diagblks);
+        A_local_diagblks_rowmap_v_  = std::vector<lno_row_view_t>(num_streams_);
+        A_local_diagblks_entries_v_ = std::vector<lno_nonzero_view_t>(num_streams_);
+        A_local_diagblks_values_v_  = std::vector<scalar_nonzero_view_t>(num_streams_);
+        for(int i = 0; i < num_streams_; i++) {
+          A_local_diagblks_rowmap_v_[i]  = A_local_diagblks[i].graph.row_map;
+          A_local_diagblks_entries_v_[i] = A_local_diagblks[i].graph.entries;
+          A_local_diagblks_values_v_[i]  = A_local_diagblks[i].values;
+        }
+      }
     }
 
-    L_->resumeFill ();
-    U_->resumeFill ();
+    if (!isKokkosKernelsStream_) {
+      L_->resumeFill ();
+      U_->resumeFill ();
 
-    if (L_->isStaticGraph () || L_->isLocallyIndexed ()) {
-      L_->setAllToScalar (STS::zero ()); // Zero out L and U matrices
-      U_->setAllToScalar (STS::zero ());
+      if (L_->isStaticGraph () || L_->isLocallyIndexed ()) {
+        L_->setAllToScalar (STS::zero ()); // Zero out L and U matrices
+        U_->setAllToScalar (STS::zero ());
+      }
     }
-    
+    else {
+      for(int i = 0; i < num_streams_; i++) {
+        L_v_[i]->resumeFill ();
+        U_v_[i]->resumeFill ();
+	    
+        if (L_v_[i]->isStaticGraph () || L_v_[i]->isLocallyIndexed ()) {
+          L_v_[i]->setAllToScalar (STS::zero ()); // Zero out L and U matrices
+          U_v_[i]->setAllToScalar (STS::zero ());
+        }
+      }
+    }
+
     using row_map_type = typename crs_matrix_type::local_matrix_device_type::row_map_type;
 
-    {
+    if (!isKokkosKernelsStream_) {
       auto lclL = L_->getLocalMatrixDevice();
       row_map_type L_rowmap  = lclL.graph.row_map;
       auto L_entries = lclL.graph.entries;
@@ -967,14 +1099,47 @@ void RILUK<MatrixType>::compute ()
       KokkosSparse::Experimental::spiluk_numeric( KernelHandle_.getRawPtr(), LevelOfFill_, 
                                                   A_local_rowmap_, A_local_entries_, A_local_values_, 
                                                   L_rowmap, L_entries, L_values, U_rowmap, U_entries, U_values );
+
+      L_->fillComplete (L_->getColMap (), A_local_->getRangeMap ());
+      U_->fillComplete (A_local_->getDomainMap (), U_->getRowMap ());
+
+      L_solver_->setMatrix (L_);
+      U_solver_->setMatrix (U_);
+	}
+    else {
+      std::vector<lno_row_view_t>        L_rowmap_v(num_streams_);
+      std::vector<lno_nonzero_view_t>    L_entries_v(num_streams_);
+      std::vector<scalar_nonzero_view_t> L_values_v(num_streams_);
+      std::vector<lno_row_view_t>        U_rowmap_v(num_streams_);
+      std::vector<lno_nonzero_view_t>    U_entries_v(num_streams_);
+      std::vector<scalar_nonzero_view_t> U_values_v(num_streams_);
+      std::vector<kk_handle_type *>      KernelHandle_rawptr_v_(num_streams_);
+      for(int i = 0; i < num_streams_; i++) {
+        auto lclL = L_v_[i]->getLocalMatrixDevice();
+        L_rowmap_v[i]  = lclL.graph.row_map;
+        L_entries_v[i] = lclL.graph.entries;
+        L_values_v[i]  = lclL.values;
+	  
+        auto lclU = U_v_[i]->getLocalMatrixDevice();
+        U_rowmap_v[i]  = lclU.graph.row_map;
+        U_entries_v[i] = lclU.graph.entries;
+        U_values_v[i]  = lclU.values;
+        KernelHandle_rawptr_v_[i] = KernelHandle_v_[i].getRawPtr();
+      }
+      KokkosSparse::Experimental::spiluk_numeric_streams( exec_space_instances_, KernelHandle_rawptr_v_, LevelOfFill_,
+                                                          A_local_diagblks_rowmap_v_, A_local_diagblks_entries_v_, A_local_diagblks_values_v_,
+                                                          L_rowmap_v, L_entries_v, L_values_v,
+                                                          U_rowmap_v, U_entries_v, U_values_v );
+      for(int i = 0; i < num_streams_; i++) {
+        L_v_[i]->fillComplete ();
+        U_v_[i]->fillComplete ();
+      }
+
+      L_solver_->setMatrices (L_v_);
+      U_solver_->setMatrices (U_v_);
     }
-    
-    L_->fillComplete (L_->getColMap (), A_local_->getRangeMap ());
-    U_->fillComplete (A_local_->getDomainMap (), U_->getRowMap ());
-    
-    L_solver_->setMatrix (L_);
+
     L_solver_->compute ();//NOTE: Only do compute if the pointer changed. Otherwise, do nothing
-    U_solver_->setMatrix (U_);
     U_solver_->compute ();//NOTE: Only do compute if the pointer changed. Otherwise, do nothing
   }
 

--- a/packages/ifpack2/src/Ifpack2_RILUK_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_RILUK_def.hpp
@@ -409,7 +409,7 @@ setParameters (const Teuchos::ParameterList& params)
 
   {
     const std::string paramName ("fact: kspiluk number-of-streams");
-    getParamTryingTypes<int, int, global_ordinal_type, double, float>
+    getParamTryingTypes<int, int, global_ordinal_type>
       (nstreams, params, paramName, prefix);
   }
   

--- a/packages/ifpack2/test/belos/CMakeLists.txt
+++ b/packages/ifpack2/test/belos/CMakeLists.txt
@@ -68,9 +68,13 @@ TRIBITS_COPY_FILES_TO_BINARY_DIR(Ifpack2BelosCopyFiles
   test_2_ILUT_nos1_hb.xml 
   test_2_RILUK_nos1_hb.xml
   test_2_RILUK_HTS_nos1_hb.xml
+  test_2_RILUK_2streams_nos1_hb.xml
+  test_2_RILUK_4streams_nos1_hb.xml
   test_4_ILUT_nos1_hb.xml 
   test_4_RILUK_nos1_hb.xml
   test_4_RILUK_HTS_nos1_hb.xml
+  test_4_RILUK_2streams_nos1_hb.xml
+  test_4_RILUK_4streams_nos1_hb.xml
   test_SGS_calore1_mm.xml 
   test_MTSGS_calore1_mm.xml
   calore1.mtx 
@@ -345,6 +349,44 @@ TRIBITS_ADD_TEST(
   NUM_MPI_PROCS 4
   STANDARD_PASS_OUTPUT
 )
+
+IF(Kokkos_ENABLE_CUDA)
+  TRIBITS_ADD_TEST(
+    tif_belos
+    NAME RILUK_hb_belos
+    ARGS "--xml_file=test_2_RILUK_2streams_nos1_hb.xml"
+    COMM serial mpi
+    NUM_MPI_PROCS 2
+    STANDARD_PASS_OUTPUT
+  )
+
+  TRIBITS_ADD_TEST(
+    tif_belos
+    NAME RILUK_hb_belos
+    ARGS "--xml_file=test_2_RILUK_4streams_nos1_hb.xml"
+    COMM serial mpi
+    NUM_MPI_PROCS 2
+    STANDARD_PASS_OUTPUT
+  )
+
+  TRIBITS_ADD_TEST(
+    tif_belos
+    NAME RILUK_hb_belos
+    ARGS "--xml_file=test_4_RILUK_2streams_nos1_hb.xml"
+    COMM serial mpi
+    NUM_MPI_PROCS 4
+    STANDARD_PASS_OUTPUT
+  )
+
+  TRIBITS_ADD_TEST(
+    tif_belos
+    NAME RILUK_hb_belos
+    ARGS "--xml_file=test_4_RILUK_4streams_nos1_hb.xml"
+    COMM serial mpi
+    NUM_MPI_PROCS 4
+    STANDARD_PASS_OUTPUT
+  )
+ENDIF()
 ENDIF()
 
 

--- a/packages/ifpack2/test/belos/CMakeLists.txt
+++ b/packages/ifpack2/test/belos/CMakeLists.txt
@@ -353,7 +353,7 @@ TRIBITS_ADD_TEST(
 IF(Kokkos_ENABLE_CUDA)
   TRIBITS_ADD_TEST(
     tif_belos
-    NAME RILUK_hb_belos
+    NAME RILUK_2streams_hb_belos
     ARGS "--xml_file=test_2_RILUK_2streams_nos1_hb.xml"
     COMM serial mpi
     NUM_MPI_PROCS 2
@@ -362,7 +362,7 @@ IF(Kokkos_ENABLE_CUDA)
 
   TRIBITS_ADD_TEST(
     tif_belos
-    NAME RILUK_hb_belos
+    NAME RILUK_4streams_hb_belos
     ARGS "--xml_file=test_2_RILUK_4streams_nos1_hb.xml"
     COMM serial mpi
     NUM_MPI_PROCS 2
@@ -371,7 +371,7 @@ IF(Kokkos_ENABLE_CUDA)
 
   TRIBITS_ADD_TEST(
     tif_belos
-    NAME RILUK_hb_belos
+    NAME RILUK_2streams_hb_belos
     ARGS "--xml_file=test_4_RILUK_2streams_nos1_hb.xml"
     COMM serial mpi
     NUM_MPI_PROCS 4
@@ -380,7 +380,7 @@ IF(Kokkos_ENABLE_CUDA)
 
   TRIBITS_ADD_TEST(
     tif_belos
-    NAME RILUK_hb_belos
+    NAME RILUK_4streams_hb_belos
     ARGS "--xml_file=test_4_RILUK_4streams_nos1_hb.xml"
     COMM serial mpi
     NUM_MPI_PROCS 4

--- a/packages/ifpack2/test/belos/test_2_RILUK_2streams_nos1_hb.xml
+++ b/packages/ifpack2/test/belos/test_2_RILUK_2streams_nos1_hb.xml
@@ -1,0 +1,21 @@
+<ParameterList name="test_params">
+  <Parameter name="hb_file" type="string" value="nos1.rsa"/>
+
+  <Parameter name="solver_type" type="string" value="Block Gmres"/>
+  <ParameterList name="Belos">
+    <Parameter name="Num Blocks" type="int" value="300"/>
+    <Parameter name="Verbosity" type="int" value="33"/>
+    <Parameter name="Output Style" type="int" value="1"/>
+    <Parameter name="Output Frequency" type="int" value="1"/>
+  </ParameterList>
+
+  <Parameter name="Ifpack2::Preconditioner" type="string" value="RILUK"/>
+  <ParameterList name="Ifpack2">
+    <Parameter name="fact: iluk level-of-fill" type="int" value="2"/>
+    <Parameter name="fact: type" type="string" value="KSPILUK"/>
+    <Parameter name="fact: kspiluk number-of-streams" type="int" value="2"/>
+    <Parameter name="trisolver: type" type="string" value="KSPTRSV"/>
+  </ParameterList>
+
+  <Parameter name="expectNumIters" type="int" value="50"/>
+</ParameterList>

--- a/packages/ifpack2/test/belos/test_2_RILUK_4streams_nos1_hb.xml
+++ b/packages/ifpack2/test/belos/test_2_RILUK_4streams_nos1_hb.xml
@@ -1,0 +1,21 @@
+<ParameterList name="test_params">
+  <Parameter name="hb_file" type="string" value="nos1.rsa"/>
+
+  <Parameter name="solver_type" type="string" value="Block Gmres"/>
+  <ParameterList name="Belos">
+    <Parameter name="Num Blocks" type="int" value="300"/>
+    <Parameter name="Verbosity" type="int" value="33"/>
+    <Parameter name="Output Style" type="int" value="1"/>
+    <Parameter name="Output Frequency" type="int" value="1"/>
+  </ParameterList>
+
+  <Parameter name="Ifpack2::Preconditioner" type="string" value="RILUK"/>
+  <ParameterList name="Ifpack2">
+    <Parameter name="fact: iluk level-of-fill" type="int" value="2"/>
+    <Parameter name="fact: type" type="string" value="KSPILUK"/>
+    <Parameter name="fact: kspiluk number-of-streams" type="int" value="4"/>
+    <Parameter name="trisolver: type" type="string" value="KSPTRSV"/>
+  </ParameterList>
+
+  <Parameter name="expectNumIters" type="int" value="50"/>
+</ParameterList>

--- a/packages/ifpack2/test/belos/test_4_RILUK_2streams_nos1_hb.xml
+++ b/packages/ifpack2/test/belos/test_4_RILUK_2streams_nos1_hb.xml
@@ -1,0 +1,22 @@
+<ParameterList name="test_params">
+  <Parameter name="hb_file" type="string" value="nos1.rsa"/>
+
+  <Parameter name="solver_type" type="string" value="Block Gmres"/>
+  <ParameterList name="Belos">
+    <Parameter name="Num Blocks" type="int" value="300"/>
+    <Parameter name="Verbosity" type="int" value="33"/>
+    <Parameter name="Output Style" type="int" value="1"/>
+    <Parameter name="Output Frequency" type="int" value="1"/>
+  </ParameterList>
+
+  <Parameter name="Ifpack2::Preconditioner" type="string" value="RILUK"/>
+  <ParameterList name="Ifpack2">
+    <Parameter name="fact: iluk level-of-fill" type="int" value="2"/>
+    <Parameter name="fact: type" type="string" value="KSPILUK"/>
+    <Parameter name="fact: kspiluk number-of-streams" type="int" value="2"/>
+    <Parameter name="trisolver: type" type="string" value="KSPTRSV"/>
+  </ParameterList>
+
+  <Parameter name="expectNumIters" type="int" value="80"/>
+  <Parameter name="Reuse Pattern" type="bool" value="true"/>
+</ParameterList>

--- a/packages/ifpack2/test/belos/test_4_RILUK_4streams_nos1_hb.xml
+++ b/packages/ifpack2/test/belos/test_4_RILUK_4streams_nos1_hb.xml
@@ -1,0 +1,22 @@
+<ParameterList name="test_params">
+  <Parameter name="hb_file" type="string" value="nos1.rsa"/>
+
+  <Parameter name="solver_type" type="string" value="Block Gmres"/>
+  <ParameterList name="Belos">
+    <Parameter name="Num Blocks" type="int" value="300"/>
+    <Parameter name="Verbosity" type="int" value="33"/>
+    <Parameter name="Output Style" type="int" value="1"/>
+    <Parameter name="Output Frequency" type="int" value="1"/>
+  </ParameterList>
+
+  <Parameter name="Ifpack2::Preconditioner" type="string" value="RILUK"/>
+  <ParameterList name="Ifpack2">
+    <Parameter name="fact: iluk level-of-fill" type="int" value="2"/>
+    <Parameter name="fact: type" type="string" value="KSPILUK"/>
+    <Parameter name="fact: kspiluk number-of-streams" type="int" value="4"/>
+    <Parameter name="trisolver: type" type="string" value="KSPTRSV"/>
+  </ParameterList>
+
+  <Parameter name="expectNumIters" type="int" value="80"/>
+  <Parameter name="Reuse Pattern" type="bool" value="true"/>
+</ParameterList>


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/ifpack2 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
This PR is to add a code path of using stream interfaces of KK SPILUK and KK SPTRSV in Ifpack2 RILUK and local triangular solver, respectively. Basically, a domain on each MPI process is divided to some sub-domains, each of which is handled by SPILUK and SPTRSV on a stream. These streams run concurrently.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Tested with ```Ifpack2_tif_belos``` tester and Sierra T/F matrix ```abnormal_system_surrogate_with_gpu_rowmap-energy_fast_ilu_solver-np-16-time-292.78-solve_count-0``` on 16 MPI processes (4 MPI processes per node, V100 GPUs)
| Streams per MPI process | No stream | 2 | 4 | 9 |
| ------------- | ------------- | ------------- | ------------- | ------------- |
| Init preconditioner (seconds) | 6.35349 | 6.08481 | 5.39639 | 3.66621 |
| Compute preconditioner (seconds) | 14.9215 | 11.2069 | 8.51655 | 4.81502 |
| Belos solve (seconds) | 5.56272 | 2.35 | 2.23373 | 1.91015 |
| Total time (seconds) | 26.8475 | 19.6511 | 16.1841 | 10.4001 |
| Number of iterations | 30 | 37 | 53 | 66 |
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->