### PR TITLE
Zoltan: Remove `inline` specifier from `comm_default.c` functions to avoid warnings

### DIFF
--- a/packages/zoltan/src/Utilities/Communication/comm_default.c
+++ b/packages/zoltan/src/Utilities/Communication/comm_default.c
@@ -1,4 +1,4 @@
-/* 
+/*
  * @HEADER
  *
  * ***********************************************************************
@@ -51,19 +51,18 @@
 /* if C++, define the rest of this header file as extern C */
 extern "C" {
 #endif
-
 static pthread_mutex_t zoltan_global_mpi_lock;
 static MPI_Comm Zoltan_Global_MPI_Comm = MPI_COMM_WORLD; // CHECK: ALLOW MPI_COMM_WORLD
 
 /* Function to set the default communicator */
-inline void zoltan_initialize_global_comm(MPI_Comm comm) {
+void zoltan_initialize_global_comm(MPI_Comm comm) {
   pthread_mutex_lock(&zoltan_global_mpi_lock);
   Zoltan_Global_MPI_Comm = comm;
   pthread_mutex_unlock(&zoltan_global_mpi_lock);
 }
 
 /* Function to get the default communicator */
-inline MPI_Comm zoltan_get_global_comm() {
+MPI_Comm zoltan_get_global_comm() {
   pthread_mutex_lock(&zoltan_global_mpi_lock);
   MPI_Comm comm = Zoltan_Global_MPI_Comm;
   pthread_mutex_unlock(&zoltan_global_mpi_lock);


### PR DESCRIPTION
Fixes #12265

@trilinos/zoltan 