### PR TITLE
Remove guard that disables stk-balance if Tpetra Global-Ordinal=int

### DIFF
--- a/cmake/RepositoryDependenciesSetup.cmake
+++ b/cmake/RepositoryDependenciesSetup.cmake
@@ -12,11 +12,6 @@
 #   endif()
 # endif() 
 
-#########################################################################
-# STKBalance does not work with GO=INT or GO=UNSIGNED
-# Note and disable it if it was set as a dependence of STK
-# Error out if it was explicitly requested by user
-
 SET(KDD_INT_INT OFF)     # Current default
 SET(KDD_INT_UNSIGNED OFF)  # Current default
 SET(KDD_INT_LONG OFF)      # Current default
@@ -45,28 +40,6 @@ ENDIF()
 
 IF(NOT ("${Tpetra_INST_INT_LONG_LONG}" STREQUAL ""))
   SET(KDD_INT_LONG_LONG ${Tpetra_INST_INT_LONG_LONG})
-ENDIF()
-
-IF ((NOT ${KDD_INT_LONG}) AND (NOT ${KDD_INT_LONG_LONG}))
-  IF ("${${PROJECT_NAME}_ENABLE_STKBalance}" STREQUAL "")
-    # STKBalance may be enabled but only implicitly (as a dependence of STK);
-    # give a message but turn off STKBalance support
-    MESSAGE("NOTE:  int global indices are enabled in Trilinos. "
-            "Because STKBalance requires long or long long "
-            "global indices, STKBalance will be disabled.  "
-            "To make this warning go away, do not request "
-            "int global indices in Trilinos (that is,  do not "
-            "set Tpetra_INST_INT_INT=ON or "
-            "Tpetra_INST_INT_UNSIGNED=ON)." )
-    SET(${PROJECT_NAME}_ENABLE_STKBalance OFF)
-  ELSEIF (${PROJECT_NAME}_ENABLE_STKBalance)
-    # STKBalance was explicitly enabled by the user, so error out
-    MESSAGE(FATAL_ERROR 
-            "STKBalance requires long or long long global indices, "
-            "but Trilinos is using int indices "
-            "(likely via Tpetra_INST_INT_INT or Tpetra_INST_INT_UNSIGNED).  "
-            "Disable STKBalance or specify Tpetra_INST_INT_LONG_LONG.")
-  ENDIF()
 ENDIF()
 
 # Tpetra supports only one GO type at a time, and the default is long long.


### PR DESCRIPTION
I tested and confirmed that stk-balance builds and runs with Global-Ordinal = int.

Technically I didn't confirm that stk-balance is ok with Global-Ordinal = unsigned. I attempted to build that way, but Tpetra won't allow it. Tpetra has compile-time checks for signed-ness and won't compile.
There is no *known* reason why stk-balance
wouldn't work with unsigned, if it were allowed
through Zoltan2/Tpetra.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->