### PR TITLE
Tpetra: modify deep copy tracking

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_Behavior.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Behavior.cpp
@@ -594,9 +594,21 @@ bool Behavior::timeKokkosDeepCopy()
 
 }    
 
-bool Behavior::timeKokkosDeepCopyVerbose() 
+bool Behavior::timeKokkosDeepCopyVerbose1() 
 {
-  constexpr char envVarName[] = "TPETRA_TIME_KOKKOS_DEEP_COPY_VERBOSE";
+  constexpr char envVarName[] = "TPETRA_TIME_KOKKOS_DEEP_COPY_VERBOSE1";
+  constexpr bool defaultValue(false);
+
+  static bool value_ = defaultValue;
+  static bool initialized_ = false;
+  return idempotentlyGetEnvironmentVariableAsBool
+    (value_, initialized_, envVarName, defaultValue);
+
+}    
+
+bool Behavior::timeKokkosDeepCopyVerbose2() 
+{
+  constexpr char envVarName[] = "TPETRA_TIME_KOKKOS_DEEP_COPY_VERBOSE2";
   constexpr bool defaultValue(false);
 
   static bool value_ = defaultValue;

--- a/packages/tpetra/core/src/Tpetra_Details_Behavior.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Behavior.hpp
@@ -283,11 +283,21 @@ public:
   static bool timeKokkosDeepCopy();
   
   /// \brief Adds verbose output to Kokkos deep_copy timers
+  /// by appending source and destination.
   /// This is especially useful for identifying host/device data transfers
   ///
   /// This is disabled by default.  You may control this at run time via the
-  /// <tt>TPETRA_TIME_KOKKOS_DEEP_COPY_VERBOSE</tt> environment variable.
-  static bool timeKokkosDeepCopyVerbose();
+  /// <tt>TPETRA_TIME_KOKKOS_DEEP_COPY_VERBOSE1</tt> environment variable.
+  static bool timeKokkosDeepCopyVerbose1();
+
+  
+  /// \brief Adds verbose output to Kokkos deep_copy timers
+  /// by appending source, destination, and size.
+  /// This is especially useful for identifying host/device data transfers
+  ///
+  /// This is disabled by default.  You may control this at run time via the
+  /// <tt>TPETRA_TIME_KOKKOS_DEEP_COPY_VERBOSE2</tt> environment variable.
+  static bool timeKokkosDeepCopyVerbose2();
 
   /// \brief Add Teuchos timers for all host calls to Kokkos::fence().
   ///

--- a/packages/tpetra/core/src/Tpetra_Details_KokkosTeuchosTimerInjection.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_KokkosTeuchosTimerInjection.cpp
@@ -67,7 +67,9 @@ namespace Details {
                                  uint64_t size) {      
       // In verbose mode, we add the src/dst names as well
       std::string extra_label;
-      if(Tpetra::Details::Behavior::timeKokkosDeepCopyVerbose()) {
+      if(Tpetra::Details::Behavior::timeKokkosDeepCopyVerbose1()) {
+        extra_label = std::string(" {") + src_name + "=>" + dst_name + "}";
+      } else if(Tpetra::Details::Behavior::timeKokkosDeepCopyVerbose2()) {
         extra_label = std::string(" {") + src_name + "=>" + dst_name + "," + std::to_string(size)+"}";
       }    
 
@@ -122,7 +124,8 @@ namespace Details {
 
   void AddKokkosDeepCopyToTimeMonitor(bool force) {
     if (!DeepCopyTimerInjection::initialized_) {
-      if (force || Tpetra::Details::Behavior::timeKokkosDeepCopy() || Tpetra::Details::Behavior::timeKokkosDeepCopyVerbose()) {
+      if (force || Tpetra::Details::Behavior::timeKokkosDeepCopy() || Tpetra::Details::Behavior::timeKokkosDeepCopyVerbose1()
+                                                                   || Tpetra::Details::Behavior::timeKokkosDeepCopyVerbose2()) {
         Kokkos::Tools::Experimental::set_begin_deep_copy_callback(DeepCopyTimerInjection::kokkosp_begin_deep_copy);
         Kokkos::Tools::Experimental::set_end_deep_copy_callback(DeepCopyTimerInjection::kokkosp_end_deep_copy);
         DeepCopyTimerInjection::initialized_=true;


### PR DESCRIPTION
This adds a second level of verbosity. One level includes only source & destination, the second includes source, destination, and size.

Motivation: In parallel, sizes may differ per MPI process, thus leading to different timer labels.