### PR TITLE
Add some constexpr traits to Tpetra Node types

### DIFF
--- a/packages/tpetra/core/compat/Tpetra_KokkosCompat_ClassicNodeAPI_Wrapper.hpp
+++ b/packages/tpetra/core/compat/Tpetra_KokkosCompat_ClassicNodeAPI_Wrapper.hpp
@@ -43,6 +43,18 @@ public:
   /// release.  This Node type is safe to use.
   static constexpr bool classic = false;
 
+  //! Whether the ExecutionSpace is Kokkos::Serial.
+#ifdef KOKKOS_ENABLE_SERIAL
+  static constexpr bool is_serial = std::is_same_v<ExecutionSpace, Kokkos::Serial>;
+#else
+  static constexpr bool is_serial = false;
+#endif
+
+  //! Whether the ExecutionSpace is CPU-like (its default memory space is HostSpace)
+  static constexpr bool is_cpu = std::is_same_v<typename ExecutionSpace::memory_space, Kokkos::HostSpace>;
+  //! Whether the ExecutionSpace is GPU-like (its default memory space is not HostSpace)
+  static constexpr bool is_gpu = !is_cpu;
+
   KokkosDeviceWrapperNode (Teuchos::ParameterList& /* params */) = delete;
   KokkosDeviceWrapperNode () = delete;
 


### PR DESCRIPTION
- ``Node::is_serial``: is it Kokkos::Serial?
- ``Node::is_cpu``: is it a CPU-like device? (default memspace is HostSpace)
- ``Node::is_gpu``: is it a GPU-like device? (default memspace is something other than HostSpace)

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Possible solution to issue discussed at Tpetra meeting. Instead of having to compare the node or execution space to every possible case (with ifdefs to check if types like ``Kokkos::Serial`` even exist), this lets users check the Node for common properties more easily.


@csiefer2 comments: Basically, I only want to see the words "HIP" "CUDA" and "SYCL" in Trilinos code where it is absolutely necessary for performance.  We have a lot of boilerplate where this stuff is littered through Trilinos right now, which makes adding new backends way harder then it needs to be.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->